### PR TITLE
fix: add hlt instruction encoding to x86_64 backend

### DIFF
--- a/src/compiler/masm/isa/x86_64/encode.mach
+++ b/src/compiler/masm/isa/x86_64/encode.mach
@@ -1679,6 +1679,11 @@ pub fun encode_int(alloc: *allocator.Allocator, sec: *section.Section, vector: u
     ret ok[usize, str](sz);
 }
 
+# encode_hlt: encode hlt (halt) instruction.
+pub fun encode_hlt(alloc: *allocator.Allocator, sec: *section.Section) Result[usize, str] {
+    ret section.emit_byte(alloc, sec, 0xF4);
+}
+
 # ============================================================================
 # FLOATING POINT ENCODING (SSE2)
 # ============================================================================
@@ -2487,7 +2492,11 @@ fun encode_opcode_instruction(alloc: *allocator.Allocator, sec: *section.Section
         if (count < 1) { ret err[usize, str]("int requires 1 operand"); }
         ret encode_int(alloc, sec, ops[0].imm::u8);
     }
-    
+
+    if (opcode == opcode.HLT) {
+        ret encode_hlt(alloc, sec);
+    }
+
     # floating point
     if (opcode == opcode.MOVSD) {
         if (count < 2) { ret err[usize, str]("movsd requires 2 operands"); }


### PR DESCRIPTION
## Summary

- Add `encode_hlt()` function emitting `0xF4` to the x86_64 encoder
- Add dispatch case for `OP_HLT` in `encode_opcode_instruction()`

Used by `dep/mach-std/src/system/platform/linux/process.mach:terminate()` as a safety net after the exit syscall.

Closes #71

## Test plan

- [x] `make test` — 493/493 pass
- [ ] `make cmach imach && out/bin/imach build .` — verify hlt no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)