### PR TITLE
fix: handle VAL_LABEL addresses in select_store()

### DIFF
--- a/src/compiler/masm/isa/x86_64/isel.mach
+++ b/src/compiler/masm/isa/x86_64/isel.mach
@@ -1406,6 +1406,9 @@ pub fun select_store(ctx: *ISelContext, instr: *ir.Instr) {
         emit_mov_reg_reg(ctx, x86.RCX, addr.reg, 8);
     } or (addr.kind == ir.VAL_MEM) {
         compute_addr_rcx(ctx, addr);
+    } or (addr.kind == ir.VAL_LABEL) {
+        # global variable: load label address into RCX
+        emit_mov_reg_label(ctx, x86.RCX, addr.label, 8);
     }
 
     if (needs_chunked_move(value.size)) {


### PR DESCRIPTION
## Summary
- Fixes segfault when storing to global variables (#76)
- Added missing VAL_LABEL case in select_store()
- Self-hosted mach now runs without segfaulting

## Problem
The self-hosted `mach` binary was segfaulting on startup when trying to initialize heap allocator globals:

```
Program received signal SIGSEGV, Segmentation fault.
heap.mach:66: heap_base = aligned;
=> mov %rax,(%rcx)
rcx: 0x6b6000  (garbage, should be 0x6b5030)
```

Root cause: `select_store()` was missing a case for `VAL_LABEL` addresses (globals), so RCX was never initialized.

## Fix
Added VAL_LABEL handler that loads the global's address into RCX:
```mach
} or (addr.kind == ir.VAL_LABEL) {
    # global variable: load label address into RCX
    emit_mov_reg_label(ctx, x86.RCX, addr.label, 8);
}
```

## Test plan
- [x] `make clean && make imach mach` builds successfully
- [x] `./out/linux/bin/mach build .` no longer segfaults
- [x] Now encounters semantic errors (different bug), which is progress!

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)