### PR TITLE
fix: Float codegen missing: literals, arithmetic, and SSE instructions

### DIFF
--- a/src/compiler/masm/ir.mach
+++ b/src/compiler/masm/ir.mach
@@ -75,6 +75,13 @@ pub uni IROp {
     ir_fext:     u8;  # float extend (f32 -> f64)
     ir_ftrunc:   u8;  # float truncate (f64 -> f32)
 
+    # float arithmetic
+    ir_fadd:     u8;  # float add
+    ir_fsub:     u8;  # float sub
+    ir_fmul:     u8;  # float mul
+    ir_fdiv:     u8;  # float div
+    ir_fcmp:     u8;  # float compare (ucomisd)
+
     # special
     ir_nop:      u8;
     ir_label:    u8;
@@ -135,6 +142,11 @@ pub val OP_SYSCALL: u8 = 47;
 pub val OP_DIVU:    u8 = 48;  # unsigned division
 pub val OP_MODU:    u8 = 49;  # unsigned modulo
 pub val OP_MEMSET:  u8 = 50;  # memset via rep stosb
+pub val OP_FADD:    u8 = 51;  # float add
+pub val OP_FSUB:    u8 = 52;  # float sub
+pub val OP_FMUL:    u8 = 53;  # float mul
+pub val OP_FDIV:    u8 = 54;  # float div
+pub val OP_FCMP:    u8 = 55;  # float compare
 
 # x86_64 physical register numbers (for isel layer)
 # matches sysv64 abi: 0-15 for rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi, r8-r15

--- a/src/compiler/masm/isa/x86_64/isel.mach
+++ b/src/compiler/masm/isa/x86_64/isel.mach
@@ -2356,6 +2356,119 @@ pub fun select_cmp(ctx: *ISelContext, instr: *ir.Instr) {
     }
 }
 
+# --- float (SSE) helpers ---
+
+# emit_fmov_xmm_mem: emit MOVSD xmm, [base+disp].
+fun emit_fmov_xmm_mem(ctx: *ISelContext, xmm_reg: i32, base: i32, disp: i64) {
+    val dst: operand.Operand = operand.reg(xmm_reg, 16);
+    val src: operand.Operand = operand.mem(base, disp, 8);
+    val instr: spec.Instruction = make_instruction(x86.MOVSD, dst, src, operand.none(), 8);
+    emit_instr(ctx, instr);
+}
+
+# emit_fmov_mem_xmm: emit MOVSD [base+disp], xmm.
+fun emit_fmov_mem_xmm(ctx: *ISelContext, base: i32, disp: i64, xmm_reg: i32) {
+    val dst: operand.Operand = operand.mem(base, disp, 8);
+    val src: operand.Operand = operand.reg(xmm_reg, 16);
+    val instr: spec.Instruction = make_instruction(x86.MOVSD, dst, src, operand.none(), 8);
+    emit_instr(ctx, instr);
+}
+
+# emit_fmov_xmm_xmm: emit MOVSD xmm_dst, xmm_src.
+fun emit_fmov_xmm_xmm(ctx: *ISelContext, dst_xmm: i32, src_xmm: i32) {
+    val dst: operand.Operand = operand.reg(dst_xmm, 16);
+    val src: operand.Operand = operand.reg(src_xmm, 16);
+    val instr: spec.Instruction = make_instruction(x86.MOVSD, dst, src, operand.none(), 8);
+    emit_instr(ctx, instr);
+}
+
+# emit_farith: emit float arithmetic instruction (ADDSD/SUBSD/MULSD/DIVSD).
+fun emit_farith(ctx: *ISelContext, opcode: i32, dst_xmm: i32, src_xmm: i32) {
+    val dst: operand.Operand = operand.reg(dst_xmm, 16);
+    val src: operand.Operand = operand.reg(src_xmm, 16);
+    val instr: spec.Instruction = make_instruction(opcode, dst, src, operand.none(), 8);
+    emit_instr(ctx, instr);
+}
+
+# emit_fcmp: emit UCOMISD xmm, xmm.
+fun emit_fcmp(ctx: *ISelContext, lhs_xmm: i32, rhs_xmm: i32) {
+    val dst: operand.Operand = operand.reg(lhs_xmm, 16);
+    val src: operand.Operand = operand.reg(rhs_xmm, 16);
+    val instr: spec.Instruction = make_instruction(x86.UCOMISD, dst, src, operand.none(), 8);
+    emit_instr(ctx, instr);
+}
+
+# load_float_operand_to_xmm: load a float IR operand into an XMM register.
+fun load_float_operand_to_xmm(ctx: *ISelContext, v: ir.IRValue, xmm_reg: i32) {
+    if (v.kind == ir.VAL_REG && v.reg >= VREG_START) {
+        # vreg: MOVSD xmm, [rbp-offset]
+        val off: i32 = get_vreg_offset(ctx, v.reg, 8);
+        emit_fmov_xmm_mem(ctx, xmm_reg, x86.RBP, -off::i64);
+    } or (v.kind == ir.VAL_IMM) {
+        # immediate (float bits): MOV RAX, imm; MOV [rbp-temp], RAX; MOVSD xmm, [rbp-temp]
+        # use RAX to materialize the bits to the stack, then load via MOVSD
+        emit_mov_reg_imm(ctx, x86.RAX, v.imm, 8);
+        emit_push_reg(ctx, x86.RAX);
+        emit_fmov_xmm_mem(ctx, xmm_reg, x86.RSP, 0);
+        emit_alu_reg_imm(ctx, x86.ADD, x86.RSP, 8, 8);
+    } or (v.kind == ir.VAL_REG && v.reg < VREG_START) {
+        # physical register: push to stack, MOVSD from stack, pop
+        emit_push_reg(ctx, v.reg);
+        emit_fmov_xmm_mem(ctx, xmm_reg, x86.RSP, 0);
+        emit_alu_reg_imm(ctx, x86.ADD, x86.RSP, 8, 8);
+    }
+}
+
+# store_xmm_to_vreg: store XMM value to a virtual register's stack slot.
+fun store_xmm_to_vreg(ctx: *ISelContext, xmm_reg: i32, vreg_id: i32) {
+    val off: i32 = get_vreg_offset(ctx, vreg_id, 8);
+    emit_fmov_mem_xmm(ctx, x86.RBP, -off::i64, xmm_reg);
+}
+
+# select_float_arith: common handler for FADD/FSUB/FMUL/FDIV.
+fun select_float_arith(ctx: *ISelContext, instr: *ir.Instr, x86_opcode: i32) {
+    if (ctx == nil || instr == nil) {
+        ret;
+    }
+
+    val dst: ir.IRValue = instr.dst;
+    val lhs: ir.IRValue = instr.src1;
+    val rhs: ir.IRValue = instr.src2;
+
+    # load lhs into XMM0
+    load_float_operand_to_xmm(ctx, lhs, x86.XMM0);
+
+    # load rhs into XMM1
+    load_float_operand_to_xmm(ctx, rhs, x86.XMM1);
+
+    # perform float arithmetic: xmm0 = xmm0 op xmm1
+    emit_farith(ctx, x86_opcode, x86.XMM0, x86.XMM1);
+
+    # store result
+    if (dst.kind == ir.VAL_REG && dst.reg >= VREG_START) {
+        store_xmm_to_vreg(ctx, x86.XMM0, dst.reg);
+    }
+}
+
+# select_float_cmp: handle FCMP instruction (UCOMISD).
+fun select_float_cmp(ctx: *ISelContext, instr: *ir.Instr) {
+    if (ctx == nil || instr == nil) {
+        ret;
+    }
+
+    val lhs: ir.IRValue = instr.src1;
+    val rhs: ir.IRValue = instr.src2;
+
+    # load lhs into XMM0
+    load_float_operand_to_xmm(ctx, lhs, x86.XMM0);
+
+    # load rhs into XMM1
+    load_float_operand_to_xmm(ctx, rhs, x86.XMM1);
+
+    # UCOMISD XMM0, XMM1 — sets ZF and CF like unsigned integer cmp
+    emit_fcmp(ctx, x86.XMM0, x86.XMM1);
+}
+
 # select_instr: convert a single IR instruction to machine code.
 # ---
 # ctx:   isel context
@@ -2508,6 +2621,21 @@ pub fun select_instr(ctx: *ISelContext, instr: *ir.Instr) Result[bool, str] {
     }
     or (op_tag == ir.OP_MEMSET) {
         select_memset(ctx, instr);
+    }
+    or (op_tag == ir.OP_FADD) {
+        select_float_arith(ctx, instr, x86.ADDSD);
+    }
+    or (op_tag == ir.OP_FSUB) {
+        select_float_arith(ctx, instr, x86.SUBSD);
+    }
+    or (op_tag == ir.OP_FMUL) {
+        select_float_arith(ctx, instr, x86.MULSD);
+    }
+    or (op_tag == ir.OP_FDIV) {
+        select_float_arith(ctx, instr, x86.DIVSD);
+    }
+    or (op_tag == ir.OP_FCMP) {
+        select_float_cmp(ctx, instr);
     }
     or {
         ret err[bool, str]("unknown IR opcode in instruction selection");

--- a/src/compiler/masm/lower/expr.mach
+++ b/src/compiler/masm/lower/expr.mach
@@ -235,6 +235,14 @@ pub fun lower_expr(ctx: *LowerContext, node: *ast.Node) ir.IRValue {
         ret ir.make_imm(char_val, 8);
     }
 
+    if (node.kind == ast.NODE_EXPR_LIT_FLOAT) {
+        var float_val: f64 = parse_float(node.info.lit_expr.text);
+        val float_ptr: *f64 = ?float_val;
+        val bits_ptr: *u64 = float_ptr::*u64;
+        val bits: i64 = (@bits_ptr)::i64;
+        ret ir.make_imm(bits, 8);
+    }
+
     if (node.kind == ast.NODE_EXPR_LIT_STR) {
         ret lower_string_lit(ctx, node);
     }
@@ -900,21 +908,43 @@ fun lower_binary(ctx: *LowerContext, node: *ast.Node) ir.IRValue {
     # map token kind to IR opcode
     var ir_op: ir.IROp = ir.IROp{ir_mov: ir.OP_MOV};
 
+    # check if this is a float operation
+    var is_float: bool = false;
+    if (node.ty != nil && ty.type_is_float(node.ty)) {
+        is_float = true;
+    }
+
     # arithmetic
     if (op == token.TAG_PLUS) {
-        ir_op = ir.IROp{ir_add: ir.OP_ADD};
+        if (is_float) {
+            ir_op = ir.IROp{ir_fadd: ir.OP_FADD};
+        } or {
+            ir_op = ir.IROp{ir_add: ir.OP_ADD};
+        }
     }
     if (op == token.TAG_MINUS) {
-        ir_op = ir.IROp{ir_sub: ir.OP_SUB};
+        if (is_float) {
+            ir_op = ir.IROp{ir_fsub: ir.OP_FSUB};
+        } or {
+            ir_op = ir.IROp{ir_sub: ir.OP_SUB};
+        }
     }
     if (op == token.TAG_STAR) {
-        ir_op = ir.IROp{ir_mul: ir.OP_MUL};
+        if (is_float) {
+            ir_op = ir.IROp{ir_fmul: ir.OP_FMUL};
+        } or {
+            ir_op = ir.IROp{ir_mul: ir.OP_MUL};
+        }
     }
     if (op == token.TAG_SLASH) {
-        if (node.ty != nil && ty.type_is_unsigned(node.ty)) {
-            ir_op = ir.IROp{ir_div: ir.OP_DIVU};
+        if (is_float) {
+            ir_op = ir.IROp{ir_fdiv: ir.OP_FDIV};
         } or {
-            ir_op = ir.IROp{ir_div: ir.OP_DIV};
+            if (node.ty != nil && ty.type_is_unsigned(node.ty)) {
+                ir_op = ir.IROp{ir_div: ir.OP_DIVU};
+            } or {
+                ir_op = ir.IROp{ir_div: ir.OP_DIV};
+            }
         }
     }
     if (op == token.TAG_PERCENT) {
@@ -943,55 +973,87 @@ fun lower_binary(ctx: *LowerContext, node: *ast.Node) ir.IRValue {
     }
 
     # comparison (set result to 0 or 1 based on condition)
-    # check if operand type is unsigned to select correct comparison opcodes
+    # check if operand type is unsigned or float to select correct comparison opcodes
     var cmp_unsigned: bool = false;
+    var cmp_float: bool = false;
     if (lhs != nil && lhs.ty != nil && ty.type_is_unsigned(lhs.ty)) {
         cmp_unsigned = true;
     }
+    if (lhs != nil && lhs.ty != nil && ty.type_is_float(lhs.ty)) {
+        cmp_float = true;
+    }
 
     if (op == token.TAG_EQ_EQ) {
-        emit_cmp(ctx, left_value, right_value, size);
+        if (cmp_float) {
+            lower_emit_instr(ctx, ir.IROp{ir_fcmp: ir.OP_FCMP}, ir.make_none(), left_value, right_value, 0);
+        } or {
+            emit_cmp(ctx, left_value, right_value, size);
+        }
         lower_emit_instr(ctx, ir.IROp{ir_sete: ir.OP_SETE}, dst, ir.make_none(), ir.make_none(), 0);
         ret dst;
     }
     if (op == token.TAG_BANG_EQ) {
-        emit_cmp(ctx, left_value, right_value, size);
+        if (cmp_float) {
+            lower_emit_instr(ctx, ir.IROp{ir_fcmp: ir.OP_FCMP}, ir.make_none(), left_value, right_value, 0);
+        } or {
+            emit_cmp(ctx, left_value, right_value, size);
+        }
         lower_emit_instr(ctx, ir.IROp{ir_setne: ir.OP_SETNE}, dst, ir.make_none(), ir.make_none(), 0);
         ret dst;
     }
     if (op == token.TAG_LT) {
-        emit_cmp(ctx, left_value, right_value, size);
-        if (cmp_unsigned) {
+        if (cmp_float) {
+            lower_emit_instr(ctx, ir.IROp{ir_fcmp: ir.OP_FCMP}, ir.make_none(), left_value, right_value, 0);
             lower_emit_instr(ctx, ir.IROp{ir_setb: ir.OP_SETB}, dst, ir.make_none(), ir.make_none(), 0);
         } or {
-            lower_emit_instr(ctx, ir.IROp{ir_setl: ir.OP_SETL}, dst, ir.make_none(), ir.make_none(), 0);
+            emit_cmp(ctx, left_value, right_value, size);
+            if (cmp_unsigned) {
+                lower_emit_instr(ctx, ir.IROp{ir_setb: ir.OP_SETB}, dst, ir.make_none(), ir.make_none(), 0);
+            } or {
+                lower_emit_instr(ctx, ir.IROp{ir_setl: ir.OP_SETL}, dst, ir.make_none(), ir.make_none(), 0);
+            }
         }
         ret dst;
     }
     if (op == token.TAG_GT) {
-        emit_cmp(ctx, left_value, right_value, size);
-        if (cmp_unsigned) {
+        if (cmp_float) {
+            lower_emit_instr(ctx, ir.IROp{ir_fcmp: ir.OP_FCMP}, ir.make_none(), left_value, right_value, 0);
             lower_emit_instr(ctx, ir.IROp{ir_seta: ir.OP_SETA}, dst, ir.make_none(), ir.make_none(), 0);
         } or {
-            lower_emit_instr(ctx, ir.IROp{ir_setg: ir.OP_SETG}, dst, ir.make_none(), ir.make_none(), 0);
+            emit_cmp(ctx, left_value, right_value, size);
+            if (cmp_unsigned) {
+                lower_emit_instr(ctx, ir.IROp{ir_seta: ir.OP_SETA}, dst, ir.make_none(), ir.make_none(), 0);
+            } or {
+                lower_emit_instr(ctx, ir.IROp{ir_setg: ir.OP_SETG}, dst, ir.make_none(), ir.make_none(), 0);
+            }
         }
         ret dst;
     }
     if (op == token.TAG_LT_EQ) {
-        emit_cmp(ctx, left_value, right_value, size);
-        if (cmp_unsigned) {
+        if (cmp_float) {
+            lower_emit_instr(ctx, ir.IROp{ir_fcmp: ir.OP_FCMP}, ir.make_none(), left_value, right_value, 0);
             lower_emit_instr(ctx, ir.IROp{ir_setbe: ir.OP_SETBE}, dst, ir.make_none(), ir.make_none(), 0);
         } or {
-            lower_emit_instr(ctx, ir.IROp{ir_setle: ir.OP_SETLE}, dst, ir.make_none(), ir.make_none(), 0);
+            emit_cmp(ctx, left_value, right_value, size);
+            if (cmp_unsigned) {
+                lower_emit_instr(ctx, ir.IROp{ir_setbe: ir.OP_SETBE}, dst, ir.make_none(), ir.make_none(), 0);
+            } or {
+                lower_emit_instr(ctx, ir.IROp{ir_setle: ir.OP_SETLE}, dst, ir.make_none(), ir.make_none(), 0);
+            }
         }
         ret dst;
     }
     if (op == token.TAG_GT_EQ) {
-        emit_cmp(ctx, left_value, right_value, size);
-        if (cmp_unsigned) {
+        if (cmp_float) {
+            lower_emit_instr(ctx, ir.IROp{ir_fcmp: ir.OP_FCMP}, ir.make_none(), left_value, right_value, 0);
             lower_emit_instr(ctx, ir.IROp{ir_setae: ir.OP_SETAE}, dst, ir.make_none(), ir.make_none(), 0);
         } or {
-            lower_emit_instr(ctx, ir.IROp{ir_setge: ir.OP_SETGE}, dst, ir.make_none(), ir.make_none(), 0);
+            emit_cmp(ctx, left_value, right_value, size);
+            if (cmp_unsigned) {
+                lower_emit_instr(ctx, ir.IROp{ir_setae: ir.OP_SETAE}, dst, ir.make_none(), ir.make_none(), 0);
+            } or {
+                lower_emit_instr(ctx, ir.IROp{ir_setge: ir.OP_SETGE}, dst, ir.make_none(), ir.make_none(), 0);
+            }
         }
         ret dst;
     }


### PR DESCRIPTION
Closes #233