### PR TITLE
fix: codegen: signed right shift always emits OP_SHR instead of OP_SAR

### DIFF
--- a/src/compiler/masm/lower/expr.mach
+++ b/src/compiler/masm/lower/expr.mach
@@ -971,7 +971,11 @@ fun lower_binary(ctx: *LowerContext, node: *ast.Node) ir.IRValue {
         ir_op = ir.IROp{ir_shl: ir.OP_SHL};
     }
     if (op == token.TAG_GT_GT) {
-        ir_op = ir.IROp{ir_shr: ir.OP_SHR};
+        if (node.ty != nil && ty.type_is_unsigned(node.ty)) {
+            ir_op = ir.IROp{ir_shr: ir.OP_SHR};
+        } or {
+            ir_op = ir.IROp{ir_sar: ir.OP_SAR};
+        }
     }
 
     # comparison (set result to 0 or 1 based on condition)


### PR DESCRIPTION
Closes #298