### PR TITLE
fix: codegen: defer/fin scope not saved/restored in lower_block

### DIFF
--- a/src/compiler/masm/lower/stmt.mach
+++ b/src/compiler/masm/lower/stmt.mach
@@ -39,6 +39,9 @@ pub fun emit_deferred_from(ctx: *LowerContext, from_index: i32) {
         }
         i = i - 1;
     }
+
+    # truncate deferred stack back to scope entry point
+    ctx.deferred_count = from_index;
 }
 
 # --- statement lowering ---
@@ -454,11 +457,17 @@ fun lower_block(ctx: *LowerContext, node: *ast.Node) {
         ret;
     }
 
+    # save deferred scope so fin statements in this block don't leak out
+    val saved_deferred: i32 = ctx.deferred_count;
+
     var i: i32 = 0;
     for (i < stmts.count) {
         lower_stmt(ctx, stmts.nodes[i]);
         i = i + 1;
     }
+
+    # emit block-scoped deferred statements and restore scope
+    emit_deferred_from(ctx, saved_deferred);
 }
 
 


### PR DESCRIPTION
Closes #296