### PR TITLE
feat: ABI: wire LowerContext init from Target/ABI instead of hardcodes

### DIFF
--- a/src/compiler/masm/lower/lower.mach
+++ b/src/compiler/masm/lower/lower.mach
@@ -466,8 +466,6 @@ pub fun init_lower_ctx(alloc: *allocator.Allocator, symbols: *symbol.Table, type
     ctx.symbols       = symbols;
     ctx.types         = types;
     ctx.tgt           = tgt;
-    ctx.ptr_size      = 8;  # assume 64-bit
-    ctx.stack_align   = 16; # sysv64
     ctx.current_fn    = nil;
     ctx.current_block = nil;
     ctx.local_vars    = nil;
@@ -499,8 +497,10 @@ pub fun init_lower_ctx(alloc: *allocator.Allocator, symbols: *symbol.Table, type
     ctx.ir_func_count = 0;
     ctx.ir_func_cap   = 0;
 
-    # initialize ABI
+    # initialize ABI before reading ptr_size/stack_align from it
     ctx.abi = abi_dispatch.for_target(?ctx.tgt);
+    ctx.ptr_size      = tgt.ptr_size;
+    ctx.stack_align   = ctx.abi.stack_align;
 
     # imported modules (set later by lower_all_modules)
     ctx.loaded_mods = nil;


### PR DESCRIPTION
Closes #340