### PR TITLE
feat: fix: `val` keyword used as parameter name in emit_brcond brea...

### DIFF
--- a/src/compiler/masm/lower/lower.mach
+++ b/src/compiler/masm/lower/lower.mach
@@ -1706,18 +1706,18 @@ pub fun emit_br(ctx: *LowerContext, label: str) {
     lower_emit_instr(ctx, instr.op, instr.dst, instr.src1, instr.src2, 0);
 }
 
-# emit_brcond: emit a conditional branch (branch if val is nonzero).
+# emit_brcond: emit a conditional branch (branch if cond_val is nonzero).
 # ---
-# ctx:   lowering context
-# val:   value to test (branches if nonzero)
-# label: target label
-# ret:   none
-pub fun emit_brcond(ctx: *LowerContext, val: ir.IRValue, label: str) {
+# ctx:       lowering context
+# cond_val:  value to test (branches if nonzero)
+# label:     target label
+# ret:       none
+pub fun emit_brcond(ctx: *LowerContext, cond_val: ir.IRValue, label: str) {
     if (ctx == nil) {
         ret;
     }
 
-    lower_emit_instr(ctx, ir.IROp{ir_brcond: ir.OP_BRCOND}, ir.make_label(label), val, ir.make_none(), 0);
+    lower_emit_instr(ctx, ir.IROp{ir_brcond: ir.OP_BRCOND}, ir.make_label(label), cond_val, ir.make_none(), 0);
 }
 
 # emit_alu: emit an ALU (arithmetic/logic) instruction.


### PR DESCRIPTION
Closes #349