### PR TITLE
fix: Parser: void function types in record fields cause parse failure

### DIFF
--- a/src/compiler/parser.mach
+++ b/src/compiler/parser.mach
@@ -3534,14 +3534,16 @@ fun parser_parse_fun_type(this: *Parser) Result[*ast.Node, str] {
         ret err[*ast.Node, str]("expected ')'");
     }
 
-    # return type
-    val ret_res: Result[*ast.Node, str] = parser_parse_type(this);
-    if (result_is_err[*ast.Node, str](ret_res)) {
-        ret ret_res;
-    }
-
+    # return type (optional — void if followed by terminator)
     node.info.type_fun.params = params;
-    node.info.type_fun.ret_type = result_unwrap_ok[*ast.Node, str](ret_res);
+    if (!parser_check(this, token.TAG_SEMI) && !parser_check(this, token.TAG_COMMA)
+        && !parser_check(this, token.TAG_RPAREN)) {
+        val ret_res: Result[*ast.Node, str] = parser_parse_type(this);
+        if (result_is_err[*ast.Node, str](ret_res)) {
+            ret ret_res;
+        }
+        node.info.type_fun.ret_type = result_unwrap_ok[*ast.Node, str](ret_res);
+    }
 
     ret ok[*ast.Node, str](node);
 }


### PR DESCRIPTION
Closes #402