### PR TITLE
fix: ISel emits 32-bit MOV for STORE when dst is a large record slot

### DIFF
--- a/src/compiler/isa/x86_64/isel.mach
+++ b/src/compiler/isa/x86_64/isel.mach
@@ -123,7 +123,12 @@ pub fun select(inst: *ir.Inst, out: *isa.MachInstBuf) bool {
     }
 
     if (o == ir.OP_STORE) {
-        ret emit2(out, op.OP_MOV, inst.dst, inst.src1, sz);
+        # for STORE: size comes from the value being stored (src1),
+        # not the memory destination (dst), which may be a larger slot.
+        var ssz: u8 = inst.size;
+        if (ssz == 0) { ssz = inst.src1.size; }
+        if (ssz == 0) { ssz = inst.dst.size; }
+        ret emit2(out, op.OP_MOV, inst.dst, inst.src1, ssz);
     }
 
     if (o == ir.OP_ADDR) {


### PR DESCRIPTION
Closes #428