### PR TITLE
fix: ISel silently drops MEM-to-MEM store instructions

### DIFF
--- a/src/compiler/isa/x86_64/isel.mach
+++ b/src/compiler/isa/x86_64/isel.mach
@@ -128,6 +128,17 @@ pub fun select(inst: *ir.Inst, out: *isa.MachInstBuf) bool {
         var ssz: u8 = inst.size;
         if (ssz == 0) { ssz = inst.src1.size; }
         if (ssz == 0) { ssz = inst.dst.size; }
+
+        # x86_64 cannot encode MEM-to-MEM MOV; route through R11
+        if (inst.src1.kind == ir.OPK_MEM) {
+            var tmp: ir.Operand;
+            tmp.kind = ir.OPK_REG;
+            tmp.reg = op.R11;
+            tmp.size = ssz;
+            emit2(out, op.OP_MOV, tmp, inst.src1, ssz);
+            ret emit2(out, op.OP_MOV, inst.dst, tmp, ssz);
+        }
+
         ret emit2(out, op.OP_MOV, inst.dst, inst.src1, ssz);
     }
 

--- a/src/compiler/isa/x86_64/isel.mach
+++ b/src/compiler/isa/x86_64/isel.mach
@@ -128,17 +128,6 @@ pub fun select(inst: *ir.Inst, out: *isa.MachInstBuf) bool {
         var ssz: u8 = inst.size;
         if (ssz == 0) { ssz = inst.src1.size; }
         if (ssz == 0) { ssz = inst.dst.size; }
-
-        # x86_64 cannot encode MEM-to-MEM MOV; route through R11
-        if (inst.src1.kind == ir.OPK_MEM) {
-            var tmp: ir.Operand;
-            tmp.kind = ir.OPK_REG;
-            tmp.reg = op.R11;
-            tmp.size = ssz;
-            emit2(out, op.OP_MOV, tmp, inst.src1, ssz);
-            ret emit2(out, op.OP_MOV, inst.dst, tmp, ssz);
-        }
-
         ret emit2(out, op.OP_MOV, inst.dst, inst.src1, ssz);
     }
 

--- a/src/compiler/isa/x86_64/isel.mach
+++ b/src/compiler/isa/x86_64/isel.mach
@@ -128,6 +128,14 @@ pub fun select(inst: *ir.Inst, out: *isa.MachInstBuf) bool {
         var ssz: u8 = inst.size;
         if (ssz == 0) { ssz = inst.src1.size; }
         if (ssz == 0) { ssz = inst.dst.size; }
+
+        # x86_64 cannot encode MEM-to-MEM MOV; materialize through R11.
+        if (inst.src1.kind == ir.OPK_MEM) {
+            val tmp: ir.Operand = ir.make_reg(op.R11, ssz);
+            emit2(out, op.OP_MOV, tmp, inst.src1, ssz);
+            ret emit2(out, op.OP_MOV, inst.dst, tmp, ssz);
+        }
+
         ret emit2(out, op.OP_MOV, inst.dst, inst.src1, ssz);
     }
 

--- a/src/compiler/lower.mach
+++ b/src/compiler/lower.mach
@@ -235,7 +235,15 @@ pub fun emit_mov(ctx: *LowerContext, dst: ir.Operand, src: ir.Operand) {
 }
 
 # emit_store: emit a STORE instruction.
+# when the source is a MEM operand, splits into LOAD + STORE through a
+# vreg so downstream ISel never sees an illegal MEM-to-MEM encoding.
 pub fun emit_store(ctx: *LowerContext, dst: ir.Operand, src: ir.Operand) {
+    if (src.kind == ir.OPK_MEM) {
+        val tmp: ir.Operand = new_vreg(ctx, src.size);
+        emit(ctx, ir.OP_LOAD, tmp, src, ir.make_none(), ir.CC_NONE);
+        emit(ctx, ir.OP_STORE, dst, tmp, ir.make_none(), ir.CC_NONE);
+        ret;
+    }
     emit(ctx, ir.OP_STORE, dst, src, ir.make_none(), ir.CC_NONE);
 }
 

--- a/src/compiler/lower.mach
+++ b/src/compiler/lower.mach
@@ -235,15 +235,7 @@ pub fun emit_mov(ctx: *LowerContext, dst: ir.Operand, src: ir.Operand) {
 }
 
 # emit_store: emit a STORE instruction.
-# when the source is a MEM operand, splits into LOAD + STORE through a
-# vreg so downstream ISel never sees an illegal MEM-to-MEM encoding.
 pub fun emit_store(ctx: *LowerContext, dst: ir.Operand, src: ir.Operand) {
-    if (src.kind == ir.OPK_MEM) {
-        val tmp: ir.Operand = new_vreg(ctx, src.size);
-        emit(ctx, ir.OP_LOAD, tmp, src, ir.make_none(), ir.CC_NONE);
-        emit(ctx, ir.OP_STORE, dst, tmp, ir.make_none(), ir.CC_NONE);
-        ret;
-    }
     emit(ctx, ir.OP_STORE, dst, src, ir.make_none(), ir.CC_NONE);
 }
 


### PR DESCRIPTION
Closes #438