### PR TITLE
fix: fix: struct literal >8 bytes not zero-initialized before field...

### DIFF
--- a/src/compiler/lower/expr.mach
+++ b/src/compiler/lower/expr.mach
@@ -887,9 +887,18 @@ fun lower_struct_lit(ctx: *LowerContext, node: *ast.Node) ir.Operand {
     if (lv == nil) { ret ir.make_none(); }
     val base: ir.Operand = local_operand(lv, psz);
 
-    # zero-initialize
-    if (ssize > 0 && ssize <= 8) {
-        emit_store(ctx, base, ir.make_imm(0, ssize::u8));
+    # zero-initialize (word-by-word to handle structs of any size)
+    if (ssize > 0) {
+        val word: usize = psz::usize;
+        var off: usize = 0;
+        for (off < ssize) {
+            var chunk: u8 = psz;
+            if (off + word > ssize) { chunk = (ssize - off)::u8; }
+            val d: ir.Operand = ir.make_mem(base.base, base.index, base.scale,
+                                            base.disp + off::i64, chunk);
+            emit_store(ctx, d, ir.make_imm(0, chunk));
+            off = off + word;
+        }
     }
 
     # lower field initializers


### PR DESCRIPTION
Closes #452