### PR TITLE
fix: build hotfix — pub helpers, val→var cfg, ComptimeKind discriminant

### DIFF
--- a/src/commands/run.mach
+++ b/src/commands/run.mach
@@ -121,7 +121,7 @@ pub fun handle(argc: i64, argv: &&u8) i64 {
         ret 1;
     }
 
-    val cfg: config.Config = result_unwrap_ok[config.Config, str](cfg_res);
+    var cfg: config.Config = result_unwrap_ok[config.Config, str](cfg_res);
 
     # determine target
     var target_name: str = opts.target_name;

--- a/src/compiler/comptime.mach
+++ b/src/compiler/comptime.mach
@@ -32,18 +32,13 @@ pub rec ComptimeValue {
 
 # ComptimeKind: the type of a compile-time value.
 # ---
-# ct_int:    integer value
-# ct_bool:   boolean value
-# ct_string: string value
-# ct_nil:    nil/void
-# ct_error:  evaluation error
-pub uni ComptimeKind {
-    ct_int:    u8;
-    ct_bool:   u8;
-    ct_string: u8;
-    ct_nil:    u8;
-    ct_error:  u8;
-}
+# each variant uses a distinct value to serve as a discriminant.
+pub def ComptimeKind: u8;
+pub val CT_INT:    ComptimeKind = 1;
+pub val CT_BOOL:   ComptimeKind = 2;
+pub val CT_STRING: ComptimeKind = 3;
+pub val CT_NIL:    ComptimeKind = 4;
+pub val CT_ERROR:  ComptimeKind = 5;
 
 # ComptimeContext: context for compile-time evaluation.
 # ---
@@ -65,18 +60,19 @@ pub rec ComptimeContext {
     eval_depth: i32;
 }
 
-# init: create a new compile-time evaluation context.
+# init: initialize a compile-time evaluation context in place.
 # ---
+# ctx:     pointer to context to initialize
 # alloc:   allocator to use
 # symbols: symbol table for lookups
 # types:   type context for type queries
-# ret:     initialized ComptimeContext
-pub fun init(alloc: *allocator.Allocator, symbols: *symbol.Table, types: *type.TypeCache, tgt: target.Target) ComptimeContext {
-    var ctx: ComptimeContext;
+# tgt:     target configuration
+pub fun init(ctx: *ComptimeContext, alloc: *allocator.Allocator, symbols: *symbol.Table, types: *type.TypeCache, tgt: *target.Target) {
     ctx.alloc = alloc;
     ctx.symbols = symbols;
     ctx.types = types;
-    ctx.tgt = tgt;
+    ctx.eval_depth = 0;
+    ctx.tgt = @tgt;
 
     # extract target strings from the Target record
     if (tgt.os_name != nil) { ctx.target_os = tgt.os_name; }
@@ -91,7 +87,6 @@ pub fun init(alloc: *allocator.Allocator, symbols: *symbol.Table, types: *type.T
     } or (str_equals(ctx.target_isa, "x86_64") && str_equals(ctx.target_os, "windows")) {
         ctx.target_abi = "win64";
     } or { ctx.target_abi = "unknown"; }
-    ret ctx;
 }
 
 # set_target: set target platform information.
@@ -106,9 +101,14 @@ pub fun set_target(ctx: *ComptimeContext, os: str, isa: str, abi: str) {
         ret;
     }
 
-    ctx.target_os = os;
-    ctx.target_isa = isa;
-    ctx.target_abi = abi;
+    if (os != nil) { ctx.target_os = os; }
+    or { ctx.target_os = "unknown"; }
+
+    if (isa != nil) { ctx.target_isa = isa; }
+    or { ctx.target_isa = "unknown"; }
+
+    if (abi != nil) { ctx.target_abi = abi; }
+    or { ctx.target_abi = "unknown"; }
 }
 
 # eval: evaluate a compile-time expression.
@@ -282,13 +282,13 @@ fun eval_binary(ctx: *ComptimeContext, expr: *ast.Node) Result[ComptimeValue, st
 
     # comparison operators
     if (op == token.TAG_EQ_EQ) {
-        if (lhs.kind == ComptimeKind { ct_string: 0 } && rhs.kind == ComptimeKind { ct_string: 0 }) {
+        if (lhs.kind == CT_STRING && rhs.kind == CT_STRING) {
             ret ok[ComptimeValue, str](make_bool(str_equals(lhs.str_val, rhs.str_val)));
         }
         ret ok[ComptimeValue, str](make_bool(lhs.int_val == rhs.int_val));
     }
     if (op == token.TAG_BANG_EQ) {
-        if (lhs.kind == ComptimeKind { ct_string: 0 } && rhs.kind == ComptimeKind { ct_string: 0 }) {
+        if (lhs.kind == CT_STRING && rhs.kind == CT_STRING) {
             ret ok[ComptimeValue, str](make_bool(!str_equals(lhs.str_val, rhs.str_val)));
         }
         ret ok[ComptimeValue, str](make_bool(lhs.int_val != rhs.int_val));
@@ -562,13 +562,13 @@ pub fun eval_condition(ctx: *ComptimeContext, cond: *ast.Node) Result[bool, str]
     val value: ComptimeValue = result_unwrap_ok[ComptimeValue, str](res);
 
     # return truthiness based on value kind
-    if (value.kind == ComptimeKind { ct_bool: 0 }) {
+    if (value.kind == CT_BOOL) {
         ret ok[bool, str](value.bool_val);
     }
-    if (value.kind == ComptimeKind { ct_int: 0 }) {
+    if (value.kind == CT_INT) {
         ret ok[bool, str](value.int_val != 0);
     }
-    if (value.kind == ComptimeKind { ct_string: 0 }) {
+    if (value.kind == CT_STRING) {
         ret ok[bool, str](value.str_val != nil);
     }
     ret ok[bool, str](value.bool_val);
@@ -759,7 +759,7 @@ pub fun is_target_isa(ctx: *ComptimeContext, isa: str) bool {
 # ret: ComptimeValue with integer kind
 pub fun make_int(value: i64) ComptimeValue {
     var v: ComptimeValue;
-    v.kind = ComptimeKind { ct_int: 0 };
+    v.kind = CT_INT;
     v.int_val = value;
     v.bool_val = false;
     v.str_val = nil;
@@ -772,7 +772,7 @@ pub fun make_int(value: i64) ComptimeValue {
 # ret: ComptimeValue with boolean kind
 pub fun make_bool(value: bool) ComptimeValue {
     var v: ComptimeValue;
-    v.kind = ComptimeKind { ct_bool: 0 };
+    v.kind = CT_BOOL;
     v.int_val = 0;
     v.bool_val = value;
     v.str_val = nil;
@@ -785,7 +785,7 @@ pub fun make_bool(value: bool) ComptimeValue {
 # ret: ComptimeValue with string kind
 pub fun make_string(value: str) ComptimeValue {
     var v: ComptimeValue;
-    v.kind = ComptimeKind { ct_string: 0 };
+    v.kind = CT_STRING;
     v.int_val = 0;
     v.bool_val = false;
     v.str_val = value;
@@ -797,7 +797,7 @@ pub fun make_string(value: str) ComptimeValue {
 # ret: ComptimeValue with nil kind
 pub fun make_nil() ComptimeValue {
     var v: ComptimeValue;
-    v.kind = ComptimeKind { ct_nil: 0 };
+    v.kind = CT_NIL;
     v.int_val = 0;
     v.bool_val = false;
     v.str_val = nil;

--- a/src/compiler/pipeline.mach
+++ b/src/compiler/pipeline.mach
@@ -163,7 +163,6 @@ pub fun analyze(root: *ast.Node, file_path: str, source: str,
     # optionally create comptime context
     var cctx_ptr: *comptime.ComptimeContext = nil;
     if (opts.enable_comptime) {
-        val cctx_init: comptime.ComptimeContext = comptime.init(opts.alloc, sem.symbols, sem.types, opts.target);
         val cctx_alloc_res: Result[*comptime.ComptimeContext, allocator.AllocError] =
             allocator.allocator_alloc[comptime.ComptimeContext](opts.alloc, 1);
         if (result_is_err[*comptime.ComptimeContext, allocator.AllocError](cctx_alloc_res)) {
@@ -171,7 +170,7 @@ pub fun analyze(root: *ast.Node, file_path: str, source: str,
             ret result;
         }
         cctx_ptr = result_unwrap_ok[*comptime.ComptimeContext, allocator.AllocError](cctx_alloc_res);
-        @cctx_ptr = cctx_init;
+        comptime.init(cctx_ptr, opts.alloc, sem.symbols, sem.types, ?opts.target);
     }
 
     val analyze_res: Result[bool, str] = sema_a.analyze(?sem, root, file_path, source, cctx_ptr);

--- a/src/compiler/sema/expr.mach
+++ b/src/compiler/sema/expr.mach
@@ -412,7 +412,7 @@ fun lookup_function_symbol(sema: *Sema, name: str) *symbol.Symbol {
 # t:           record type to update (size and align are set)
 # fields:      field array (offsets will be set in-place)
 # field_count: number of fields
-fun compute_record_layout(t: *type.Type, fields: *type.Field, field_count: i32) {
+pub fun compute_record_layout(t: *type.Type, fields: *type.Field, field_count: i32) {
     var offset: usize = 0;
     var max_align: usize = 1;
 
@@ -446,7 +446,7 @@ fun compute_record_layout(t: *type.Type, fields: *type.Field, field_count: i32) 
 # t:           union type to update (size and align are set)
 # fields:      field array (all offsets will be set to 0)
 # field_count: number of fields
-fun compute_union_layout(t: *type.Type, fields: *type.Field, field_count: i32) {
+pub fun compute_union_layout(t: *type.Type, fields: *type.Field, field_count: i32) {
     var max_size: usize = 0;
     var max_align: usize = 1;
 


### PR DESCRIPTION
Closes #504

## Summary
- Added `pub` to `compute_record_layout` and `compute_union_layout` in `sema/expr.mach`
- Changed `val cfg` to `var cfg` in `run.mach` for mutable pointer compatibility
- Replaced broken `ComptimeKind` union (all variants = 0) with `def`/`val` constants with distinct values
- Refactored `comptime.init()` to accept `*target.Target` and write in-place

## Test plan
- [x] Stage 1 (cmach → imach) builds successfully
- [x] Stage 2 (imach → smach) no longer segfaults — comptime conditions evaluate correctly