### PR TITLE
fix: Redundant identity moves not eliminated by peephole

### DIFF
--- a/src/compiler/isa/x86_64/peephole.mach
+++ b/src/compiler/isa/x86_64/peephole.mach
@@ -36,7 +36,7 @@ fun rule_self_move(buf: *isa.MachInstBuf) bool {
         val inst: *isa.MachInst = isa.buf_get(buf, i);
         if (inst != nil && inst.opcode == op.OP_MOV &&
             inst.dst.kind == ir.OPK_REG && inst.src1.kind == ir.OPK_REG &&
-            inst.dst.reg == inst.src1.reg) {
+            inst.dst.reg == inst.src1.reg && inst.dst.size == inst.src1.size) {
             isa.buf_mark_nop(buf, i);
             changed = true;
         }

--- a/src/compiler/pipeline.mach
+++ b/src/compiler/pipeline.mach
@@ -476,6 +476,9 @@ fun codegen(mctx: *masm.Context, tgt: *target.Target,
             }
         }
 
+        # post-regalloc peephole: eliminate identity moves introduced by regalloc
+        i.peephole(i.ctx, ?ra.out);
+
         # === Phase D: Encode regalloc output ===
         var encode_fails: i32 = 0;
         var encode_ok: i32 = 0;


### PR DESCRIPTION
Closes #523