### PR TITLE
fix: x86_64 ISel: `div` instruction uses same register for dividend...

### DIFF
--- a/src/compiler/isa/x86_64/isel.mach
+++ b/src/compiler/isa/x86_64/isel.mach
@@ -182,51 +182,50 @@ pub fun select(inst: *ir.Inst, out: *isa.MachInstBuf) bool {
         ret emit2(out, op.IMUL, inst.dst, inst.src1, sz);
     }
 
-    # signed division: dst = src1 / src2
-    # x86_64 IDIV divides rdx:rax by operand; quotient in rax, remainder in rdx.
-    if (o == ir.OP_DIV) {
-        val rax: ir.Operand = ir.make_reg(op.RAX, sz);
-        val rdx: ir.Operand = ir.make_reg(op.RDX, sz);
-        emit2(out, op.OP_MOV, rax, inst.src1, sz);
-        emit2(out, op.OP_MOV, rdx, rax, sz);
-        var shift: u8 = 31;
-        if (sz == 8) { shift = 63; }
-        emit2(out, op.SAR, rdx, ir.make_imm(shift::i64, 1), sz);
-        emit1(out, op.IDIV, inst.src2, sz);
-        ret emit2(out, op.OP_MOV, inst.dst, rax, sz);
-    }
+    # --- integer division / modulo ---
+    # x86_64 DIV/IDIV: divides rdx:rax by r/m operand.
+    #   quotient in rax, remainder in rdx.
+    # IR form: dst = src1 OP src2  (src1=dividend, src2=divisor)
+    #
+    # DIV/IDIV only accept register or memory operands as the divisor.
+    # if the divisor (src2) is an immediate, materialize it into R11.
 
-    # signed modulo: dst = src1 % src2
-    if (o == ir.OP_MOD) {
+    if (o == ir.OP_DIV || o == ir.OP_MOD) {
         val rax: ir.Operand = ir.make_reg(op.RAX, sz);
         val rdx: ir.Operand = ir.make_reg(op.RDX, sz);
+        var divisor: ir.Operand = inst.src2;
+        if (divisor.kind == ir.OPK_IMM) {
+            val scratch: ir.Operand = ir.make_reg(op.R11, sz);
+            emit2(out, op.OP_MOV, scratch, divisor, sz);
+            divisor = scratch;
+        }
         emit2(out, op.OP_MOV, rax, inst.src1, sz);
         emit2(out, op.OP_MOV, rdx, rax, sz);
         var shift: u8 = 31;
         if (sz == 8) { shift = 63; }
         emit2(out, op.SAR, rdx, ir.make_imm(shift::i64, 1), sz);
-        emit1(out, op.IDIV, inst.src2, sz);
+        emit1(out, op.IDIV, divisor, sz);
+        if (o == ir.OP_DIV) {
+            ret emit2(out, op.OP_MOV, inst.dst, rax, sz);
+        }
         ret emit2(out, op.OP_MOV, inst.dst, rdx, sz);
     }
 
-    # unsigned division: dst = src1 / src2
-    # x86_64 DIV divides rdx:rax by operand; quotient in rax, remainder in rdx.
-    if (o == ir.OP_DIVU) {
+    if (o == ir.OP_DIVU || o == ir.OP_MODU) {
         val rax: ir.Operand = ir.make_reg(op.RAX, sz);
         val rdx: ir.Operand = ir.make_reg(op.RDX, sz);
+        var divisor: ir.Operand = inst.src2;
+        if (divisor.kind == ir.OPK_IMM) {
+            val scratch: ir.Operand = ir.make_reg(op.R11, sz);
+            emit2(out, op.OP_MOV, scratch, divisor, sz);
+            divisor = scratch;
+        }
         emit2(out, op.OP_MOV, rax, inst.src1, sz);
         emit2(out, op.XOR, rdx, rdx, sz);
-        emit1(out, op.DIV, inst.src2, sz);
-        ret emit2(out, op.OP_MOV, inst.dst, rax, sz);
-    }
-
-    # unsigned modulo: dst = src1 % src2
-    if (o == ir.OP_MODU) {
-        val rax: ir.Operand = ir.make_reg(op.RAX, sz);
-        val rdx: ir.Operand = ir.make_reg(op.RDX, sz);
-        emit2(out, op.OP_MOV, rax, inst.src1, sz);
-        emit2(out, op.XOR, rdx, rdx, sz);
-        emit1(out, op.DIV, inst.src2, sz);
+        emit1(out, op.DIV, divisor, sz);
+        if (o == ir.OP_DIVU) {
+            ret emit2(out, op.OP_MOV, inst.dst, rax, sz);
+        }
         ret emit2(out, op.OP_MOV, inst.dst, rdx, sz);
     }
 

--- a/src/compiler/isa/x86_64/isel.mach
+++ b/src/compiler/isa/x86_64/isel.mach
@@ -182,46 +182,52 @@ pub fun select(inst: *ir.Inst, out: *isa.MachInstBuf) bool {
         ret emit2(out, op.IMUL, inst.dst, inst.src1, sz);
     }
 
-    # signed division: CDQ/CQO + IDIV
+    # signed division: dst = src1 / src2
+    # x86_64 IDIV divides rdx:rax by operand; quotient in rax, remainder in rdx.
     if (o == ir.OP_DIV) {
-        if (sz == 8) { emit0(out, op.CQO); }
-        or            { emit0(out, op.CDQ); }
-        ret emit1(out, op.IDIV, inst.src1, sz);
+        val rax: ir.Operand = ir.make_reg(op.RAX, sz);
+        val rdx: ir.Operand = ir.make_reg(op.RDX, sz);
+        emit2(out, op.OP_MOV, rax, inst.src1, sz);
+        emit2(out, op.OP_MOV, rdx, rax, sz);
+        var shift: u8 = 31;
+        if (sz == 8) { shift = 63; }
+        emit2(out, op.SAR, rdx, ir.make_imm(shift::i64, 1), sz);
+        emit1(out, op.IDIV, inst.src2, sz);
+        ret emit2(out, op.OP_MOV, inst.dst, rax, sz);
     }
 
-    # signed modulo: same sequence, result in RDX
+    # signed modulo: dst = src1 % src2
     if (o == ir.OP_MOD) {
-        if (sz == 8) { emit0(out, op.CQO); }
-        or            { emit0(out, op.CDQ); }
-        ret emit1(out, op.IDIV, inst.src1, sz);
+        val rax: ir.Operand = ir.make_reg(op.RAX, sz);
+        val rdx: ir.Operand = ir.make_reg(op.RDX, sz);
+        emit2(out, op.OP_MOV, rax, inst.src1, sz);
+        emit2(out, op.OP_MOV, rdx, rax, sz);
+        var shift: u8 = 31;
+        if (sz == 8) { shift = 63; }
+        emit2(out, op.SAR, rdx, ir.make_imm(shift::i64, 1), sz);
+        emit1(out, op.IDIV, inst.src2, sz);
+        ret emit2(out, op.OP_MOV, inst.dst, rdx, sz);
     }
 
-    # unsigned division: zero RDX + DIV
+    # unsigned division: dst = src1 / src2
+    # x86_64 DIV divides rdx:rax by operand; quotient in rax, remainder in rdx.
     if (o == ir.OP_DIVU) {
-        var rdx: ir.Operand;
-        rdx.kind = ir.OPK_REG;
-        rdx.reg = op.RDX;
-        rdx.size = sz;
-        var zero: ir.Operand;
-        zero.kind = ir.OPK_REG;
-        zero.reg = op.RDX;
-        zero.size = sz;
-        emit2(out, op.XOR, rdx, zero, sz);
-        ret emit1(out, op.DIV, inst.src1, sz);
+        val rax: ir.Operand = ir.make_reg(op.RAX, sz);
+        val rdx: ir.Operand = ir.make_reg(op.RDX, sz);
+        emit2(out, op.OP_MOV, rax, inst.src1, sz);
+        emit2(out, op.XOR, rdx, rdx, sz);
+        emit1(out, op.DIV, inst.src2, sz);
+        ret emit2(out, op.OP_MOV, inst.dst, rax, sz);
     }
 
-    # unsigned modulo: same as DIVU
+    # unsigned modulo: dst = src1 % src2
     if (o == ir.OP_MODU) {
-        var rdx: ir.Operand;
-        rdx.kind = ir.OPK_REG;
-        rdx.reg = op.RDX;
-        rdx.size = sz;
-        var zero: ir.Operand;
-        zero.kind = ir.OPK_REG;
-        zero.reg = op.RDX;
-        zero.size = sz;
-        emit2(out, op.XOR, rdx, zero, sz);
-        ret emit1(out, op.DIV, inst.src1, sz);
+        val rax: ir.Operand = ir.make_reg(op.RAX, sz);
+        val rdx: ir.Operand = ir.make_reg(op.RDX, sz);
+        emit2(out, op.OP_MOV, rax, inst.src1, sz);
+        emit2(out, op.XOR, rdx, rdx, sz);
+        emit1(out, op.DIV, inst.src2, sz);
+        ret emit2(out, op.OP_MOV, inst.dst, rdx, sz);
     }
 
     # --- bitwise ---

--- a/src/compiler/sema/expr.mach
+++ b/src/compiler/sema/expr.mach
@@ -3020,6 +3020,13 @@ fun resolve_comptime_size_align(sema: *Sema, node: *ast.Node, name: str) *type.T
         arg_type = resolve_expr_type(sema, arg);
     }
 
+    # fall back to already-resolved type (set by substitute_types_in_body
+    # during generic instantiation — the identifier "T" won't resolve by
+    # name, but its .type field was already substituted to the concrete type)
+    if (arg_type == nil) {
+        arg_type = arg.type;
+    }
+
     if (arg_type == nil) { ret nil; }
 
     # don't fold when arg is a generic parameter — will be folded during instantiation

--- a/src/compiler/sema/expr.mach
+++ b/src/compiler/sema/expr.mach
@@ -3020,13 +3020,6 @@ fun resolve_comptime_size_align(sema: *Sema, node: *ast.Node, name: str) *type.T
         arg_type = resolve_expr_type(sema, arg);
     }
 
-    # fall back to already-resolved type (set by substitute_types_in_body
-    # during generic instantiation — the identifier "T" won't resolve by
-    # name, but its .type field was already substituted to the concrete type)
-    if (arg_type == nil) {
-        arg_type = arg.type;
-    }
-
     if (arg_type == nil) { ret nil; }
 
     # don't fold when arg is a generic parameter — will be folded during instantiation

--- a/src/compiler/sema/expr.mach
+++ b/src/compiler/sema/expr.mach
@@ -3029,12 +3029,8 @@ fun resolve_comptime_size_align(sema: *Sema, node: *ast.Node, name: str) *type.T
 
     if (arg_type == nil) { ret nil; }
 
-    # don't fold when arg is a generic parameter — will be folded during instantiation.
-    # persist the type on the arg node so substitute_types_in_body can substitute it.
-    if (arg_type.kind == type.TYPE_GENERIC_PARAM) {
-        arg.type = arg_type;
-        ret nil;
-    }
+    # don't fold when arg is a generic parameter — will be folded during instantiation
+    if (arg_type.kind == type.TYPE_GENERIC_PARAM) { ret nil; }
 
     # compute the value
     var value: usize = 0;

--- a/src/compiler/sema/expr.mach
+++ b/src/compiler/sema/expr.mach
@@ -3029,8 +3029,12 @@ fun resolve_comptime_size_align(sema: *Sema, node: *ast.Node, name: str) *type.T
 
     if (arg_type == nil) { ret nil; }
 
-    # don't fold when arg is a generic parameter — will be folded during instantiation
-    if (arg_type.kind == type.TYPE_GENERIC_PARAM) { ret nil; }
+    # don't fold when arg is a generic parameter — will be folded during instantiation.
+    # persist the type on the arg node so substitute_types_in_body can substitute it.
+    if (arg_type.kind == type.TYPE_GENERIC_PARAM) {
+        arg.type = arg_type;
+        ret nil;
+    }
 
     # compute the value
     var value: usize = 0;


### PR DESCRIPTION
Closes #554