### PR TITLE
fix: Sret parameter stored at [rbp+0], overwriting saved frame pointer

### DIFF
--- a/src/compiler/codegen/lower/call.mach
+++ b/src/compiler/codegen/lower/call.mach
@@ -80,10 +80,19 @@ pub fun emit_call(ctx: *LowerContext, callee: ir.Operand,
         if (af) { flags = flags | ir.ABI_FLAG_FLOAT; }
         if (aa) { flags = flags | ir.ABI_FLAG_AGG; }
 
+        # for aggregate args that are memory operands, materialize the
+        # address into a vreg so ABI lowering gets the actual address
+        var arg_op: ir.Operand = args[i];
+        if (aa && arg_op.kind == ir.OPK_MEM) {
+            val arg_ptr: ir.Operand = new_vreg(ctx, ctx.ptr_size);
+            emit(ctx, ir.OP_ADDR, arg_ptr, arg_op, ir.make_none(), ir.CC_NONE);
+            arg_op = arg_ptr;
+        }
+
         emit(ctx, ir.OP_ARG,
              ir.make_imm(arg_size::i64, arg_align::u8),
              ir.make_imm(i::i64, flags),
-             args[i], ir.CC_NONE);
+             arg_op, ir.CC_NONE);
 
         i = i + 1;
     }
@@ -109,7 +118,11 @@ pub fun emit_call(ctx: *LowerContext, callee: ir.Operand,
         val lv: *LocalVar = local_add(ctx, ".agg_ret", ret_type, ret_size);
         if (lv == nil) { ret ir.make_none(); }
         val dst_mem: ir.Operand = local_operand(lv, psz);
-        emit(ctx, ir.OP_CALL, callee, ret_info, dst_mem, call_flags);
+        # materialize address into vreg so ABI lowering stores through
+        # the actual local address, not just the base register (VREG_FP)
+        val dst_ptr: ir.Operand = new_vreg(ctx, psz);
+        emit(ctx, ir.OP_ADDR, dst_ptr, dst_mem, ir.make_none(), ir.CC_NONE);
+        emit(ctx, ir.OP_CALL, callee, ret_info, dst_ptr, call_flags);
         ret dst_mem;
     }
 

--- a/src/compiler/codegen/lower/decl.mach
+++ b/src/compiler/codegen/lower/decl.mach
@@ -238,12 +238,16 @@ fun lower_params(ctx: *LowerContext, node: *ast.Node) {
 
     # if sret, emit OP_PARAM(index=-1) for the hidden pointer
     if (ctx.fn_has_sret) {
-        val sret_vreg: ir.Operand = new_vreg(ctx, psz);
-        emit(ctx, ir.OP_PARAM,
-             ir.make_imm(psz::i64, psz),
-             ir.make_imm(-1, 0),
-             sret_vreg, ir.CC_NONE);
-        ctx.sret_slot = ir.make_mem(sret_vreg.reg, -1, 1, 0, psz);
+        val lv: *LocalVar = local_add(ctx, ".sret_ptr", nil, psz::usize);
+        if (lv != nil) {
+            lv.is_param = true;
+            val sret_local: ir.Operand = local_operand(lv, psz);
+            emit(ctx, ir.OP_PARAM,
+                 ir.make_imm(psz::i64, psz),
+                 ir.make_imm(-1, 0),
+                 sret_local, ir.CC_NONE);
+            ctx.sret_slot = sret_local;
+        }
     }
 
     # variadic prologue: allocate register save area

--- a/src/compiler/codegen/lower/stmt.mach
+++ b/src/compiler/codegen/lower/stmt.mach
@@ -173,23 +173,26 @@ fun lower_return(ctx: *LowerContext, node: *ast.Node) {
     val expr: *ast.Node = node.info.wrapper.inner;
     if (expr != nil && ctx.fn_ret_type != nil && !type.type_is_void(ctx.fn_ret_type)) {
         if (ctx.fn_has_sret) {
-            # copy return value to sret buffer (no physical registers needed)
+            # load the sret pointer from its local and dereference it
             val ret_size: usize = type_size(ctx, ctx.fn_ret_type);
             val psz: u8 = ctx.ptr_size;
+            val sret_ptr: ir.Operand = new_vreg(ctx, psz);
+            emit_load(ctx, sret_ptr, ctx.sret_slot);
+            val sret_dst: ir.Operand = ir.make_mem(sret_ptr.reg, -1, 1, 0,
+                                                     ret_size::u8);
             if (ret_size > psz::usize) {
-                # large aggregate: try lvalue first for direct memory operand
                 var mem: ir.Operand = lexpr.lower_lvalue(ctx, expr);
                 if (mem.kind != ir.OPK_MEM) {
                     mem = lexpr.lower_expr(ctx, expr);
                 }
                 if (mem.kind == ir.OPK_MEM) {
-                    emit_memcpy(ctx, ctx.sret_slot, mem, ret_size);
+                    emit_memcpy(ctx, sret_dst, mem, ret_size);
                 } or {
-                    emit_store(ctx, ctx.sret_slot, mem);
+                    emit_store(ctx, sret_dst, mem);
                 }
             } or {
                 val value: ir.Operand = lexpr.lower_expr(ctx, expr);
-                emit_store(ctx, ctx.sret_slot, value);
+                emit_store(ctx, sret_dst, value);
             }
         } or {
             # emit OP_RETVAL — ABI pass places into return register(s)
@@ -208,6 +211,13 @@ fun lower_return(ctx: *LowerContext, node: *ast.Node) {
                 var agg_val: ir.Operand = lexpr.lower_lvalue(ctx, expr);
                 if (agg_val.kind != ir.OPK_MEM) {
                     agg_val = lexpr.lower_expr(ctx, expr);
+                }
+                # materialize address into vreg so ABI lowering loads
+                # through the actual aggregate address, not just base reg
+                if (agg_val.kind == ir.OPK_MEM) {
+                    val agg_ptr: ir.Operand = new_vreg(ctx, ctx.ptr_size);
+                    emit(ctx, ir.OP_ADDR, agg_ptr, agg_val, ir.make_none(), ir.CC_NONE);
+                    agg_val = agg_ptr;
                 }
                 emit(ctx, ir.OP_RETVAL,
                      ir.make_imm(ret_size::i64, ret_align::u8),


### PR DESCRIPTION
Closes #600