### PR TITLE
fix: sema: embedded record field offsets are zero when layout not y...

### DIFF
--- a/src/compiler/frontend/sema/resolve.mach
+++ b/src/compiler/frontend/sema/resolve.mach
@@ -342,7 +342,12 @@ fun ensure_layout(sema: *Sema, mod: *SemaModule, ft_node: *ast.Node, ft: *type.T
         if (ft_node != nil) {
             val ft_sym: *symbol.Symbol = ft_node.symbol::*symbol.Symbol;
             if (ft_sym != nil && ft_sym.decl_node != nil) {
-                resolve_fields(sema, mod, ft_sym.decl_node);
+                var owner: *SemaModule = mod;
+                if (ft_sym.module_path != nil) {
+                    val found: *SemaModule = find_module(sema, ft_sym.module_path);
+                    if (found != nil) { owner = found; }
+                }
+                resolve_fields(sema, owner, ft_sym.decl_node);
             }
         }
         ret;
@@ -351,12 +356,10 @@ fun ensure_layout(sema: *Sema, mod: *SemaModule, ft_node: *ast.Node, ft: *type.T
     if (ft.kind == type.TYPE_ARRAY && ft.size == 0 && ft.inner != nil) {
         val elem: *type.Type = ft.inner;
         if ((elem.kind == type.TYPE_RECORD || elem.kind == type.TYPE_UNION) && elem.size == 0) {
-            # resolve the element type's layout first
             if (ft_node != nil && ft_node.kind == ast.NODE_TYPE_ARRAY) {
                 val elem_node: *ast.Node = ft_node.info.type_array.elem_type;
                 ensure_layout(sema, mod, elem_node, elem);
             }
-            # recompute array size from now-resolved element
             ft.size = elem.size * ft.array_len;
             ft.align = elem.align;
         }

--- a/src/compiler/frontend/sema/resolve.mach
+++ b/src/compiler/frontend/sema/resolve.mach
@@ -331,6 +331,38 @@ fun resolve_aggregate_decl(sema: *Sema, mod: *SemaModule, node: *ast.Node) {
     }
 }
 
+# ensure a value-type's layout (size/align) is computed before embedding.
+# for named records/unions whose fields haven't been resolved yet, this
+# recursively triggers resolve_fields via the type's declaration node.
+# for arrays of such types, ensures the element layout then recomputes.
+fun ensure_layout(sema: *Sema, mod: *SemaModule, ft_node: *ast.Node, ft: *type.Type) {
+    if (ft == nil) { ret; }
+
+    if ((ft.kind == type.TYPE_RECORD || ft.kind == type.TYPE_UNION) && ft.size == 0) {
+        if (ft_node != nil) {
+            val ft_sym: *symbol.Symbol = ft_node.symbol::*symbol.Symbol;
+            if (ft_sym != nil && ft_sym.decl_node != nil) {
+                resolve_fields(sema, mod, ft_sym.decl_node);
+            }
+        }
+        ret;
+    }
+
+    if (ft.kind == type.TYPE_ARRAY && ft.size == 0 && ft.inner != nil) {
+        val elem: *type.Type = ft.inner;
+        if ((elem.kind == type.TYPE_RECORD || elem.kind == type.TYPE_UNION) && elem.size == 0) {
+            # resolve the element type's layout first
+            if (ft_node != nil && ft_node.kind == ast.NODE_TYPE_ARRAY) {
+                val elem_node: *ast.Node = ft_node.info.type_array.elem_type;
+                ensure_layout(sema, mod, elem_node, elem);
+            }
+            # recompute array size from now-resolved element
+            ft.size = elem.size * ft.array_len;
+            ft.align = elem.align;
+        }
+    }
+}
+
 # resolve fields for a record or union declaration and compute its layout
 pub fun resolve_fields(sema: *Sema, mod: *SemaModule, node: *ast.Node) {
     if (node == nil) { ret; }
@@ -361,6 +393,7 @@ pub fun resolve_fields(sema: *Sema, mod: *SemaModule, node: *ast.Node) {
             val ft_node: *ast.Node = field_node.info.field_decl.type_node;
             if (ft_node != nil) {
                 fields[fi].type = resolve_type_expr(sema, mod, ft_node);
+                ensure_layout(sema, mod, ft_node, fields[fi].type);
             }
         }
         fi = fi + 1;
@@ -399,6 +432,7 @@ fun resolve_inline_fields(sema: *Sema, mod: *SemaModule, type_node: *ast.Node, t
             val ft_node: *ast.Node = field_node.info.field_decl.type_node;
             if (ft_node != nil) {
                 fields[fi].type = resolve_type_expr(sema, mod, ft_node);
+                ensure_layout(sema, mod, ft_node, fields[fi].type);
             }
         }
         fi = fi + 1;


### PR DESCRIPTION
Closes #602