### PR TITLE
fix: Linker drops relocations for unmapped FLAG_ALLOC sections

### DIFF
--- a/src/compiler/linker.mach
+++ b/src/compiler/linker.mach
@@ -602,6 +602,9 @@ pub fun link_objects(obj_paths: *str, obj_count: i32, tgt: *target.Target,
                 msecs[mi].capacity = 0;
                 msecs[mi].align = osec.align;
                 msec_count = msec_count + 1;
+            } or (mi < 0) {
+                print.eprintlnf("linker: too many unique sections (max %d)", MAX_MERGED_SECS::i64);
+                ret 3;
             }
 
             if (mi >= 0) {
@@ -663,7 +666,9 @@ pub fun link_objects(obj_paths: *str, obj_count: i32, tgt: *target.Target,
                     moff = obj_sec_base[osym.section] + osym.offset;
                 }
                 if (ms < 0 && osym.binding == sym.BIND_GLOBAL) {
-                    print.eprintlnf("linker: warning: symbol '%s' in unmapped section", osym.name);
+                    print.eprintlnf("linker: symbol '%s' in non-loadable section %d of %s",
+                        osym.name, osym.section::i64, obj_paths[fi]);
+                    ret 4;
                 }
 
                 # check for duplicate global definitions
@@ -771,6 +776,11 @@ pub fun link_objects(obj_paths: *str, obj_count: i32, tgt: *target.Target,
                     }
 
                     # cross-section local: defer with pre-resolved target
+                    if (sym_ms < 0) {
+                        print.eprintlnf("linker: local symbol '%s' in non-loadable section",
+                            orel.symbol_name);
+                        ret 4;
+                    }
                     if (mrel_count >= mrel_cap) {
                         val new_cap: i32 = mrel_cap * 2;
                         val gr: Result[*MergedReloc, allocator.AllocError] =
@@ -974,9 +984,9 @@ pub fun link_objects(obj_paths: *str, obj_count: i32, tgt: *target.Target,
             # pre-resolved local: use stored target section/offset
             val sym_esec: i32 = msec_map[rel.target_sec];
             if (sym_esec < 0) {
-                print.eprintlnf("linker: warning: pre-resolved relocation targets unmapped section %d", rel.target_sec);
-                rli = rli + 1;
-                cnt;
+                print.eprintlnf("linker: pre-resolved relocation targets unmapped section %d",
+                    rel.target_sec);
+                ret 6;
             }
             sym_vaddr = esecs[sym_esec].vaddr + rel.target_off::u64;
         } or {
@@ -1000,9 +1010,8 @@ pub fun link_objects(obj_paths: *str, obj_count: i32, tgt: *target.Target,
 
         val rel_esec: i32 = msec_map[rel.section];
         if (rel_esec < 0) {
-            print.eprintlnf("linker: warning: relocation in unmapped source section %d", rel.section);
-            rli = rli + 1;
-            cnt;
+            print.eprintlnf("linker: relocation in unmapped source section %d", rel.section);
+            ret 8;
         }
         val rel_vaddr: u64 = esecs[rel_esec].vaddr + rel.offset::u64;
 


### PR DESCRIPTION
Closes #610