### PR TITLE
fix: Parser doesn't process \xNN hex escapes in char literals

### DIFF
--- a/src/compiler/frontend/parser.mach
+++ b/src/compiler/frontend/parser.mach
@@ -2823,6 +2823,11 @@ fun parser_eval_char_literal(this: *Parser) str {
         or (esc == '\\')      { buf[0] = 92; }
         or (esc == '\'')      { buf[0] = 39; }
         or (esc == '"')       { buf[0] = 34; }
+        or (esc == 'x') {
+            val hi: u8 = hex_digit_value(src[start + 2]);
+            val lo: u8 = hex_digit_value(src[start + 3]);
+            buf[0] = (hi << 4) | lo;
+        }
         or { buf[0] = esc; }
     } or {
         buf[0] = src[start];
@@ -2830,6 +2835,13 @@ fun parser_eval_char_literal(this: *Parser) str {
 
     buf[1] = 0;
     ret buf::&u8;
+}
+
+fun hex_digit_value(c: u8) u8 {
+    if (c >= '0' && c <= '9') { ret c - '0'; }
+    if (c >= 'A' && c <= 'F') { ret c - 'A' + 10; }
+    if (c >= 'a' && c <= 'f') { ret c - 'a' + 10; }
+    ret 0;
 }
 
 # parse_literal_nil: parse the nil literal.


### PR DESCRIPTION
Closes #644