### PR TITLE
fix: Bootstrap broken: LowerContext uses keyword field names `ret` ...

### DIFF
--- a/src/compiler/codegen/lower.mach
+++ b/src/compiler/codegen/lower.mach
@@ -90,13 +90,13 @@ pub rec LowerContext {
     stack_offset:   i64;
 
     # function return state
-    ret: ReturnState;
+    rs: ReturnState;
 
     # loop state
-    loop: LoopState;
+    ls: LoopState;
 
     # deferred statements
-    defer: DeferState;
+    ds: DeferState;
 
     # debug info
     current_file:   u16;
@@ -129,17 +129,17 @@ pub fun create(alloc: *allocator.Allocator, tgt: *target.Target,
     ctx.label_counter = 0;
     ctx.str_counter = 0;
     ctx.stack_offset = 0;
-    ctx.ret.type = nil;
-    ctx.ret.has_sret = false;
-    ctx.ret.is_variadic = false;
-    ctx.ret.va_reg_save_off = 0;
-    ctx.ret.va_named_gp = 0;
-    ctx.ret.va_named_fp = 0;
-    ctx.ret.va_named_stack = 0;
-    ctx.loop.start = nil;
-    ctx.loop.end = nil;
-    ctx.defer.count = 0;
-    ctx.defer.mark = 0;
+    ctx.rs.type = nil;
+    ctx.rs.has_sret = false;
+    ctx.rs.is_variadic = false;
+    ctx.rs.va_reg_save_off = 0;
+    ctx.rs.va_named_gp = 0;
+    ctx.rs.va_named_fp = 0;
+    ctx.rs.va_named_stack = 0;
+    ctx.ls.start = nil;
+    ctx.ls.end = nil;
+    ctx.ds.count = 0;
+    ctx.ds.mark = 0;
     ctx.current_file = 0;
     ctx.current_line = 0;
     ctx.debug_file_path = file_path;
@@ -167,8 +167,8 @@ pub fun create(alloc: *allocator.Allocator, tgt: *target.Target,
     if (result_is_err[**ast.Node, allocator.AllocError](df_r)) {
         ret err[LowerContext, str]("out of memory");
     }
-    ctx.defer.stmts = result_unwrap_ok[**ast.Node, allocator.AllocError](df_r);
-    ctx.defer.cap = INITIAL_DEFER_CAP;
+    ctx.ds.stmts = result_unwrap_ok[**ast.Node, allocator.AllocError](df_r);
+    ctx.ds.cap = INITIAL_DEFER_CAP;
 
     ret ok[LowerContext, str](ctx);
 }
@@ -760,17 +760,17 @@ pub fun reset_function_state(ctx: *LowerContext) {
     ctx.vreg_next = ir.VREG_START;
     ctx.local_count = 0;
     ctx.stack_offset = 0;
-    ctx.ret.type = nil;
-    ctx.ret.has_sret = false;
-    ctx.ret.is_variadic = false;
-    ctx.ret.va_reg_save_off = 0;
-    ctx.ret.va_named_gp = 0;
-    ctx.ret.va_named_fp = 0;
-    ctx.ret.va_named_stack = 0;
-    ctx.loop.start = nil;
-    ctx.loop.end = nil;
-    ctx.defer.count = 0;
-    ctx.defer.mark = 0;
+    ctx.rs.type = nil;
+    ctx.rs.has_sret = false;
+    ctx.rs.is_variadic = false;
+    ctx.rs.va_reg_save_off = 0;
+    ctx.rs.va_named_gp = 0;
+    ctx.rs.va_named_fp = 0;
+    ctx.rs.va_named_stack = 0;
+    ctx.ls.start = nil;
+    ctx.ls.end = nil;
+    ctx.ds.count = 0;
+    ctx.ds.mark = 0;
 }
 
 # --- deferred statement management ---
@@ -778,22 +778,22 @@ pub fun reset_function_state(ctx: *LowerContext) {
 pub fun defer_push(ctx: *LowerContext, node: *ast.Node) {
     if (ctx == nil) { ret; }
 
-    if (ctx.defer.count >= ctx.defer.cap) {
-        val new_cap: i32 = ctx.defer.cap * 2;
+    if (ctx.ds.count >= ctx.ds.cap) {
+        val new_cap: i32 = ctx.ds.cap * 2;
         val r: Result[**ast.Node, allocator.AllocError] =
-            allocator.allocator_resize[*ast.Node](ctx.alloc, ctx.defer.stmts,
-                ctx.defer.cap::usize, new_cap::usize);
+            allocator.allocator_resize[*ast.Node](ctx.alloc, ctx.ds.stmts,
+                ctx.ds.cap::usize, new_cap::usize);
         if (result_is_err[**ast.Node, allocator.AllocError](r)) { ret; }
-        ctx.defer.stmts = result_unwrap_ok[**ast.Node, allocator.AllocError](r);
-        ctx.defer.cap = new_cap;
+        ctx.ds.stmts = result_unwrap_ok[**ast.Node, allocator.AllocError](r);
+        ctx.ds.cap = new_cap;
     }
 
-    ctx.defer.stmts[ctx.defer.count] = node;
-    ctx.defer.count = ctx.defer.count + 1;
+    ctx.ds.stmts[ctx.ds.count] = node;
+    ctx.ds.count = ctx.ds.count + 1;
 }
 
 pub fun defer_get_mark(ctx: *LowerContext) i32 {
-    ret ctx.defer.count;
+    ret ctx.ds.count;
 }
 
 # --- type size helpers ---

--- a/src/compiler/codegen/lower/decl.mach
+++ b/src/compiler/codegen/lower/decl.mach
@@ -126,21 +126,21 @@ fun lower_function_core(ctx: *LowerContext, node: *ast.Node,
     if (result_is_err[*fn.Function, str](fn_r)) { ret; }
     ctx.current_fn = result_unwrap_ok[*fn.Function, str](fn_r);
 
-    ctx.ret.type = fn_type.ret_type;
-    ctx.ret.is_variadic = node.info.fun_decl.is_variadic;
+    ctx.rs.type = fn_type.ret_type;
+    ctx.rs.is_variadic = node.info.fun_decl.is_variadic;
 
-    if (ctx.ret.type != nil && !type.type_is_void(ctx.ret.type)) {
-        val ret_size: usize = type_size(ctx, ctx.ret.type);
-        val ret_align: usize = type.type_align(ctx.ret.type);
-        val is_float: bool = is_float_type(ctx.ret.type);
-        val is_agg: bool = type.type_is_record(ctx.ret.type) ||
-                           type.type_is_union(ctx.ret.type);
+    if (ctx.rs.type != nil && !type.type_is_void(ctx.rs.type)) {
+        val ret_size: usize = type_size(ctx, ctx.rs.type);
+        val ret_align: usize = type.type_align(ctx.rs.type);
+        val is_float: bool = is_float_type(ctx.rs.type);
+        val is_agg: bool = type.type_is_record(ctx.rs.type) ||
+                           type.type_is_union(ctx.rs.type);
 
         val a: *abi.ABI = ?ctx.target.abi;
         val ret_slot: abi.ParamSlot = a.classify_return(a.ctx, ret_size, ret_align,
                                                          is_float, is_agg);
         if (ret_slot.class == abi.CLASS_SRET) {
-            ctx.ret.has_sret = true;
+            ctx.rs.has_sret = true;
         }
     }
 
@@ -152,7 +152,7 @@ fun lower_function_core(ctx: *LowerContext, node: *ast.Node,
         lstmt.lower_stmt(ctx, body);
     }
 
-    if (ctx.ret.type == nil || type.type_is_void(ctx.ret.type)) {
+    if (ctx.rs.type == nil || type.type_is_void(ctx.rs.type)) {
         emit_ret(ctx);
     }
 
@@ -181,7 +181,7 @@ fun lower_params(ctx: *LowerContext, node: *ast.Node) {
     val psz: u8 = ctx.ptr_size;
 
     # if sret, emit OP_PARAM(index=-1) for the hidden pointer
-    if (ctx.ret.has_sret) {
+    if (ctx.rs.has_sret) {
         val lv: *LocalVar = local_add(ctx, ".sret_ptr", nil, psz::usize);
         if (lv != nil) {
             lv.is_param = true;
@@ -190,24 +190,24 @@ fun lower_params(ctx: *LowerContext, node: *ast.Node) {
                  operand.make_imm(psz::i64, psz),
                  operand.make_imm(-1, 0),
                  sret_local, ir.CC_NONE);
-            ctx.ret.sret_slot = sret_local;
+            ctx.rs.sret_slot = sret_local;
         }
     }
 
     # variadic prologue: allocate register save area
-    if (ctx.ret.is_variadic) {
+    if (ctx.rs.is_variadic) {
         val layout: abi.VarargLayout = a.vararg_layout(a.ctx);
 
         # allocate save area on stack
         val align_mask: i64 = layout.save_area_align::i64 - 1;
         ctx.stack_offset = (ctx.stack_offset + layout.save_area_size::i64
                             + align_mask) & ~align_mask;
-        ctx.ret.va_reg_save_off = -ctx.stack_offset;
+        ctx.rs.va_reg_save_off = -ctx.stack_offset;
 
         # emit OP_PARAM(index=-2) for variadic register save
         # the ABI pass expands this to stores of all GP arg registers
         val save_base: ir.Operand = operand.make_mem(ir.VREG_FP, -1, 1,
-                                                  ctx.ret.va_reg_save_off, psz);
+                                                  ctx.rs.va_reg_save_off, psz);
         emit(ctx, ir.OP_PARAM,
              operand.make_imm(layout.save_area_size::i64, layout.save_area_align::u8),
              operand.make_imm(-2, 0),
@@ -219,7 +219,7 @@ fun lower_params(ctx: *LowerContext, node: *ast.Node) {
     var gp_used: i32 = 0;
     var fp_used: i32 = 0;
     var stack_count: i32 = 0;
-    if (ctx.ret.has_sret) { gp_used = 1; }
+    if (ctx.rs.has_sret) { gp_used = 1; }
 
     var i: i32 = 0;
     for (i < params.count) {
@@ -274,10 +274,10 @@ fun lower_params(ctx: *LowerContext, node: *ast.Node) {
     }
 
     # record variadic param counts for va_start
-    if (ctx.ret.is_variadic) {
-        ctx.ret.va_named_gp = gp_used;
-        ctx.ret.va_named_fp = fp_used;
-        ctx.ret.va_named_stack = stack_count;
+    if (ctx.rs.is_variadic) {
+        ctx.rs.va_named_gp = gp_used;
+        ctx.rs.va_named_fp = fp_used;
+        ctx.rs.va_named_stack = stack_count;
     }
 }
 

--- a/src/compiler/codegen/lower/expr.mach
+++ b/src/compiler/codegen/lower/expr.mach
@@ -1083,7 +1083,7 @@ fun lower_va_start(ctx: *LowerContext, arg_list: *ast.List) ir.Operand {
     }
 
     # gp_offset = va_named_gp * gp_slot_size
-    val gp_off_val: i64 = ctx.ret.va_named_gp::i64 * layout.gp_slot_size;
+    val gp_off_val: i64 = ctx.rs.va_named_gp::i64 * layout.gp_slot_size;
     val gp_off_mem: ir.Operand = operand.make_mem(ap.reg, -1, 1,
                                               layout.gp_offset_off,
                                               layout.gp_offset_size);
@@ -1091,7 +1091,7 @@ fun lower_va_start(ctx: *LowerContext, arg_list: *ast.List) ir.Operand {
 
     # fp_offset = fp_area_base + va_named_fp * fp_slot_size
     val fp_off_val: i64 = layout.fp_area_base
-                          + ctx.ret.va_named_fp::i64 * layout.fp_slot_size;
+                          + ctx.rs.va_named_fp::i64 * layout.fp_slot_size;
     val fp_off_mem: ir.Operand = operand.make_mem(ap.reg, -1, 1,
                                               layout.fp_offset_off,
                                               layout.fp_offset_size);
@@ -1099,7 +1099,7 @@ fun lower_va_start(ctx: *LowerContext, arg_list: *ast.List) ir.Operand {
 
     # overflow_arg_area = FP + stack_args_base + va_named_stack * stack_slot_size
     val overflow_off: i64 = layout.stack_args_base
-                            + ctx.ret.va_named_stack::i64 * layout.stack_slot_size;
+                            + ctx.rs.va_named_stack::i64 * layout.stack_slot_size;
     val overflow_src: ir.Operand = operand.make_mem(ir.VREG_FP, -1, 1,
                                                overflow_off, psz);
     val overflow_ptr: ir.Operand = new_vreg(ctx, psz);
@@ -1110,7 +1110,7 @@ fun lower_va_start(ctx: *LowerContext, arg_list: *ast.List) ir.Operand {
 
     # reg_save_area = FP + va_reg_save_off
     val regsave_src: ir.Operand = operand.make_mem(ir.VREG_FP, -1, 1,
-                                               ctx.ret.va_reg_save_off, psz);
+                                               ctx.rs.va_reg_save_off, psz);
     val regsave_ptr: ir.Operand = new_vreg(ctx, psz);
     emit(ctx, ir.OP_ADDR, regsave_ptr, regsave_src, operand.make_none(), ir.CC_NONE);
     val regsave_dst: ir.Operand = operand.make_mem(ap.reg, -1, 1,

--- a/src/compiler/codegen/lower/stmt.mach
+++ b/src/compiler/codegen/lower/stmt.mach
@@ -140,13 +140,13 @@ fun lower_return(ctx: *LowerContext, node: *ast.Node) {
     emit_deferred(ctx, 0);
 
     val expr: *ast.Node = node.info.wrapper.inner;
-    if (expr != nil && ctx.ret.type != nil && !type.type_is_void(ctx.ret.type)) {
-        if (ctx.ret.has_sret) {
+    if (expr != nil && ctx.rs.type != nil && !type.type_is_void(ctx.rs.type)) {
+        if (ctx.rs.has_sret) {
             # load the sret pointer from its local and dereference it
-            val ret_size: usize = type_size(ctx, ctx.ret.type);
+            val ret_size: usize = type_size(ctx, ctx.rs.type);
             val psz: u8 = ctx.ptr_size;
             val sret_ptr: ir.Operand = new_vreg(ctx, psz);
-            emit_load(ctx, sret_ptr, ctx.ret.sret_slot);
+            emit_load(ctx, sret_ptr, ctx.rs.sret_slot);
             val sret_dst: ir.Operand = operand.make_mem(sret_ptr.reg, -1, 1, 0,
                                                      ret_size::u8);
             if (ret_size > psz::usize) {
@@ -165,11 +165,11 @@ fun lower_return(ctx: *LowerContext, node: *ast.Node) {
             }
         } or {
             # emit OP_RETVAL — ABI pass places into return register(s)
-            val ret_size: usize = type_size(ctx, ctx.ret.type);
-            val ret_align: usize = type.type_align(ctx.ret.type);
-            val is_float: bool = is_float_type(ctx.ret.type);
-            val is_agg: bool = type.type_is_record(ctx.ret.type) ||
-                               type.type_is_union(ctx.ret.type);
+            val ret_size: usize = type_size(ctx, ctx.rs.type);
+            val ret_align: usize = type.type_align(ctx.rs.type);
+            val is_float: bool = is_float_type(ctx.rs.type);
+            val is_agg: bool = type.type_is_record(ctx.rs.type) ||
+                               type.type_is_union(ctx.rs.type);
 
             var flags: u8 = 0;
             if (is_float) { flags = flags | ir.ABI_FLAG_FLOAT; }
@@ -302,12 +302,12 @@ fun lower_for(ctx: *LowerContext, node: *ast.Node) {
     val loop_end: str = new_label(ctx, ".L_loop_end");
 
     # save loop state
-    val saved_start: str = ctx.loop.start;
-    val saved_end: str = ctx.loop.end;
-    val saved_defer_mark: i32 = ctx.defer.mark;
-    ctx.loop.start = loop_start;
-    ctx.loop.end = loop_end;
-    ctx.defer.mark = ctx.defer.count;
+    val saved_start: str = ctx.ls.start;
+    val saved_end: str = ctx.ls.end;
+    val saved_defer_mark: i32 = ctx.ds.mark;
+    ctx.ls.start = loop_start;
+    ctx.ls.end = loop_end;
+    ctx.ds.mark = ctx.ds.count;
 
     # loop header
     emit_label(ctx, loop_start);
@@ -326,24 +326,24 @@ fun lower_for(ctx: *LowerContext, node: *ast.Node) {
     emit_label(ctx, loop_end);
 
     # restore loop state
-    ctx.loop.start = saved_start;
-    ctx.loop.end = saved_end;
-    ctx.defer.mark = saved_defer_mark;
+    ctx.ls.start = saved_start;
+    ctx.ls.end = saved_end;
+    ctx.ds.mark = saved_defer_mark;
 }
 
 # lower_break: emit a jump to the loop end.
 fun lower_break(ctx: *LowerContext) {
-    if (ctx.loop.end != nil) {
-        emit_deferred(ctx, ctx.defer.mark);
-        emit_jmp(ctx, ctx.loop.end);
+    if (ctx.ls.end != nil) {
+        emit_deferred(ctx, ctx.ds.mark);
+        emit_jmp(ctx, ctx.ls.end);
     }
 }
 
 # lower_continue: emit a jump to the loop start.
 fun lower_continue(ctx: *LowerContext) {
-    if (ctx.loop.start != nil) {
-        emit_deferred(ctx, ctx.defer.mark);
-        emit_jmp(ctx, ctx.loop.start);
+    if (ctx.ls.start != nil) {
+        emit_deferred(ctx, ctx.ds.mark);
+        emit_jmp(ctx, ctx.ls.start);
     }
 }
 
@@ -357,12 +357,12 @@ fun lower_defer(ctx: *LowerContext, node: *ast.Node) {
 
 # emit_deferred: emit deferred statements in reverse order from mark.
 fun emit_deferred(ctx: *LowerContext, mark: i32) {
-    var i: i32 = ctx.defer.count - 1;
+    var i: i32 = ctx.ds.count - 1;
     for (i >= mark) {
-        if (ctx.defer.stmts[i] != nil) {
-            lower_stmt(ctx, ctx.defer.stmts[i]);
+        if (ctx.ds.stmts[i] != nil) {
+            lower_stmt(ctx, ctx.ds.stmts[i]);
         }
         i = i - 1;
     }
-    ctx.defer.count = mark;
+    ctx.ds.count = mark;
 }

--- a/src/compiler/pipeline.mach
+++ b/src/compiler/pipeline.mach
@@ -602,7 +602,7 @@ fun compile_module(root: *ast.Node, symbols: *symbol.Table,
         for (ai < mod_ptr.func_count) {
             val func: *fn.Function = mod_ptr.functions[ai];
             if (func != nil) {
-                abi_low.lower_function(alloc, func, ?tgt.abi, ?tgt.isa, tgt.isa.ptr_size::u8);
+                abi_low.lower_function(alloc, func, ?tgt.abi, ?tgt.isa, ?tgt.os, tgt.isa.ptr_size::u8);
             }
             ai = ai + 1;
         }


### PR DESCRIPTION
Closes #646