### PR TITLE
fix: ELF object writer emits BSS section with zero sh_size

### DIFF
--- a/src/compiler/target/of/elf.mach
+++ b/src/compiler/target/of/elf.mach
@@ -770,10 +770,10 @@ fun elf_finalize(ctx: ptr, out: *buf.OutputBuffer) {
         val sh_offset: usize = sec_offsets[si];
         var sh_size: usize = sec.size;
 
-        # BSS: sh_type = NOBITS, offset in file but no data
+        # BSS: sh_type = NOBITS, no file data but preserve sh_size
         if (sec.kind == 3) {
             write_shdr(out, sec.name_off, SHT_NOBITS, sh_flags,
-                       0, sh_offset, 0, sec.align, 0, 0, 0);
+                       0, sh_offset, sh_size, sec.align, 0, 0, 0);
         } or {
             write_shdr(out, sec.name_off, sh_type, sh_flags,
                        0, sh_offset, sh_size, sec.align, 0, 0, 0);


### PR DESCRIPTION
Closes #655