### PR TITLE
refactor: replace allocator.default() with page.make()

### DIFF
--- a/src/commands/build.mach
+++ b/src/commands/build.mach
@@ -6,6 +6,7 @@ use std.types.result;
 
 use allocator: std.allocator;
 use arena:     std.allocator.arena;
+use page:      std.allocator.page;
 use fs:        std.filesystem;
 use print:     std.print;
 
@@ -172,7 +173,8 @@ fun parse_options(a: args.Args) BuildOptions {
 
                 if (eq_pos > 0 && eq_pos < map_len - 1) {
                     # copy prefix into a separate allocation to avoid mutating argv
-                    var tmp_alloc: allocator.Allocator               = allocator.default();
+                    var tmp_alloc: allocator.Allocator;
+                    page.make(?tmp_alloc);
                     val pfx_res:   Result[*u8, allocator.AllocError] = allocator.allocator_alloc[u8](?tmp_alloc, eq_pos + 1);
 
                     if (result_is_ok[*u8, allocator.AllocError](pfx_res)) {
@@ -387,7 +389,8 @@ pub fun handle(argc: i64, argv: &&u8) i64 {
     }
 
     # create arena-backed allocator for bulk allocation/deallocation
-    var backing:   allocator.Allocator                       = allocator.default();
+    var backing: allocator.Allocator;
+    page.make(?backing);
     # TODO: magic number is 256 MiB... could be cleaned up
     val arena_res: Result[arena.Arena, allocator.AllocError] = arena.init(backing, 268435456);
     if (result_is_err[arena.Arena, allocator.AllocError](arena_res)) {

--- a/src/commands/dep.mach
+++ b/src/commands/dep.mach
@@ -9,6 +9,7 @@ use std.types.option;
 use std.types.result;
 
 use allocator: std.allocator;
+use page:      std.allocator.page;
 use print:     std.print;
 use cmd_help: mach.commands.help;
 use config:   mach.config.config;
@@ -122,7 +123,8 @@ pub fun handle(argc: i64, argv: &&u8) i64 {
 # argv: argument vector
 # ret:  exit code
 fun handle_list(argc: i64, argv: &&u8) i64 {
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
 
     # find project root
     val root: str = find_project_root(".", ?alloc);
@@ -224,7 +226,8 @@ fun handle_info(argc: i64, argv: &&u8) i64 {
     }
 
     val dep_name: str = argv[3];
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
 
     # find project root
     val root: str = find_project_root(".", ?alloc);
@@ -281,7 +284,8 @@ fun handle_info(argc: i64, argv: &&u8) i64 {
 # argv: argument vector
 # ret:  exit code
 fun handle_tidy(argc: i64, argv: &&u8) i64 {
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
 
     # find project root
     val root: str = find_project_root(".", ?alloc);
@@ -425,7 +429,8 @@ fun handle_add(argc: i64, argv: &&u8) i64 {
         ret 1;
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
 
     # find project root
     val root: str = find_project_root(".", ?alloc);
@@ -592,7 +597,8 @@ fun handle_del(argc: i64, argv: &&u8) i64 {
     }
 
     val dep_name: str = argv[3];
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
 
     # find project root
     val root: str = find_project_root(".", ?alloc);
@@ -718,7 +724,8 @@ fun handle_pull(argc: i64, argv: &&u8) i64 {
         specific_dep = argv[3];
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
 
     # find project root
     val root: str = find_project_root(".", ?alloc);
@@ -796,7 +803,8 @@ fun handle_pull(argc: i64, argv: &&u8) i64 {
 # dep_path: path to the dependency directory
 # ret: 0 on success, non-zero on failure
 fun pull_git_dep(dep_path: str) i64 {
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git_path: str = proc.resolve_binary("git", ?alloc);
     if (git_path == nil) {
         print.eprintln("error: git not found in PATH");

--- a/src/commands/init.mach
+++ b/src/commands/init.mach
@@ -9,6 +9,7 @@ use std.types.option;
 use std.types.result;
 
 use allocator: std.allocator;
+use page:      std.allocator.page;
 use fs:        std.filesystem;
 use print:     std.print;
 
@@ -269,7 +270,8 @@ pub fun handle(argc: i64, argv: &&u8) i64 {
     }
 
     # create allocator
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
 
     print.print("creating project: ");
     print.println(project_id);

--- a/src/commands/run.mach
+++ b/src/commands/run.mach
@@ -9,6 +9,7 @@ use std.types.option;
 use std.types.result;
 
 use allocator: std.allocator;
+use page:      std.allocator.page;
 use print:     std.print;
 use os:        std.system.os;
 
@@ -105,7 +106,8 @@ pub fun handle(argc: i64, argv: &&u8) i64 {
     val opts: RunOptions = parse_options(argc, argv);
 
     # create allocator
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
 
     # check for mach.toml in project directory
     val config_path: str = utilfs.path_join(opts.project_path, "mach.toml", ?alloc);

--- a/src/commands/testing.mach
+++ b/src/commands/testing.mach
@@ -10,6 +10,7 @@ use std.types.result;
 
 use allocator: std.allocator;
 use arena:     std.allocator.arena;
+use page:      std.allocator.page;
 use print:     std.print;
 use args:     mach.cli.args;
 use cmd_help: mach.commands.help;
@@ -1156,7 +1157,8 @@ fun module_matches_filter(module_path: str, filter: str) bool {
 pub fun handle(argc: i64, argv: &&u8) i64 {
     val opts: TestOptions = parse_options(argc, argv);
 
-    var backing: allocator.Allocator = allocator.default();
+    var backing: allocator.Allocator;
+    page.make(?backing);
     val arena_res: Result[arena.Arena, allocator.AllocError] = arena.init(backing, 268435456);
     if (result_is_err[arena.Arena, allocator.AllocError](arena_res)) {
         print.eprintln("error: failed to create arena allocator");

--- a/src/git.mach
+++ b/src/git.mach
@@ -11,6 +11,7 @@ use std.types.string;
 use std.types.result;
 
 use allocator: std.allocator;
+use page:      std.allocator.page;
 
 use proc: mach.util.process;
 
@@ -45,7 +46,8 @@ pub fun exec(args: &&u8, argc: i64) Result[i32, str] {
         ret err[i32, str]("too many arguments");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[i32, str]("git not found in PATH");
@@ -74,7 +76,8 @@ pub fun exec(args: &&u8, argc: i64) Result[i32, str] {
 # dir: directory to initialize (or nil for current directory)
 # ret: Ok(true) on success, Err(str) on failure
 pub fun init(dir: str) Result[bool, str] {
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -113,7 +116,8 @@ pub fun submodule_add(url: str, path: str) Result[bool, str] {
         ret err[bool, str]("submodule path is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -140,7 +144,8 @@ pub fun submodule_add(url: str, path: str) Result[bool, str] {
 # path: path to a specific submodule (or nil for all submodules)
 # ret:  Ok(true) on success, Err(str) on failure
 pub fun submodule_update(path: str) Result[bool, str] {
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -176,7 +181,8 @@ pub fun submodule_deinit(path: str) Result[bool, str] {
         ret err[bool, str]("submodule path is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -210,7 +216,8 @@ pub fun submodule_remove(path: str) Result[bool, str] {
     val deinit_res: Result[bool, str] = submodule_deinit(path);
     # continue even if deinit fails
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -241,7 +248,8 @@ pub fun checkout(ref: str) Result[bool, str] {
         ret err[bool, str]("ref is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -275,7 +283,8 @@ pub fun checkout_in_dir(dir: str, ref: str) Result[bool, str] {
         ret err[bool, str]("ref is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -302,7 +311,8 @@ pub fun checkout_in_dir(dir: str, ref: str) Result[bool, str] {
 # dir: directory containing the git repository (or nil for current)
 # ret: Ok(true) on success, Err(str) on failure
 pub fun fetch(dir: str) Result[bool, str] {
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -334,7 +344,8 @@ pub fun fetch(dir: str) Result[bool, str] {
 # dir: directory containing the git repository (or nil for current)
 # ret: Ok(true) on success, Err(str) on failure
 pub fun pull(dir: str) Result[bool, str] {
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -375,7 +386,8 @@ pub fun clone(url: str, path: str) Result[bool, str] {
         ret err[bool, str]("path is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -410,7 +422,8 @@ pub fun clone_shallow(url: str, path: str) Result[bool, str] {
         ret err[bool, str]("path is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");

--- a/src/util/git.mach
+++ b/src/util/git.mach
@@ -11,6 +11,7 @@ use std.types.string;
 use std.types.result;
 
 use allocator: std.allocator;
+use page:      std.allocator.page;
 
 use proc: mach.util.process;
 
@@ -45,7 +46,8 @@ pub fun exec(args: &&u8, argc: i64) Result[i32, str] {
         ret err[i32, str]("too many arguments");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[i32, str]("git not found in PATH");
@@ -74,7 +76,8 @@ pub fun exec(args: &&u8, argc: i64) Result[i32, str] {
 # dir: directory to initialize (or nil for current directory)
 # ret: Ok(true) on success, Err(str) on failure
 pub fun init(dir: str) Result[bool, str] {
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -113,7 +116,8 @@ pub fun submodule_add(url: str, path: str) Result[bool, str] {
         ret err[bool, str]("submodule path is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -140,7 +144,8 @@ pub fun submodule_add(url: str, path: str) Result[bool, str] {
 # path: path to a specific submodule (or nil for all submodules)
 # ret:  Ok(true) on success, Err(str) on failure
 pub fun submodule_update(path: str) Result[bool, str] {
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -176,7 +181,8 @@ pub fun submodule_deinit(path: str) Result[bool, str] {
         ret err[bool, str]("submodule path is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -210,7 +216,8 @@ pub fun submodule_remove(path: str) Result[bool, str] {
     val deinit_res: Result[bool, str] = submodule_deinit(path);
     # continue even if deinit fails
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -241,7 +248,8 @@ pub fun checkout(ref: str) Result[bool, str] {
         ret err[bool, str]("ref is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -275,7 +283,8 @@ pub fun checkout_in_dir(dir: str, ref: str) Result[bool, str] {
         ret err[bool, str]("ref is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -302,7 +311,8 @@ pub fun checkout_in_dir(dir: str, ref: str) Result[bool, str] {
 # dir: directory containing the git repository (or nil for current)
 # ret: Ok(true) on success, Err(str) on failure
 pub fun fetch(dir: str) Result[bool, str] {
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -334,7 +344,8 @@ pub fun fetch(dir: str) Result[bool, str] {
 # dir: directory containing the git repository (or nil for current)
 # ret: Ok(true) on success, Err(str) on failure
 pub fun pull(dir: str) Result[bool, str] {
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -375,7 +386,8 @@ pub fun clone(url: str, path: str) Result[bool, str] {
         ret err[bool, str]("path is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");
@@ -410,7 +422,8 @@ pub fun clone_shallow(url: str, path: str) Result[bool, str] {
         ret err[bool, str]("path is nil");
     }
 
-    var alloc: allocator.Allocator = allocator.default();
+    var alloc: allocator.Allocator;
+    page.make(?alloc);
     val git: str = resolve_git(?alloc);
     if (git == nil) {
         ret err[bool, str]("git not found in PATH");


### PR DESCRIPTION
## Summary
- Replace all 36 `allocator.default()` calls with explicit `page.make()` construction
- Add `use page: std.allocator.page;` import to 7 affected files
- No stdlib changes — compiler-only

Closes #675