### PR TITLE
fix: Add MOVSB/REP prefix to x86_64 assembly printer

### DIFF
--- a/src/compiler/target/isa/x86_64/printer.mach
+++ b/src/compiler/target/isa/x86_64/printer.mach
@@ -41,6 +41,15 @@ pub fun x86_print_inst(ctx: ptr, mi: *isa.Inst, buf: *iobuf.WriteBuf) {
         ret;
     }
 
+    if (opcode == defs.MOVSB) {
+        if ((mi.flags & defs.FLAG_REP::u16) != 0) {
+            ws(buf, "  rep movsb\n");
+        } or {
+            ws(buf, "  movsb\n");
+        }
+        ret;
+    }
+
     ws(buf, "  ");
     ws(buf, opcode_name(opcode));
 
@@ -229,6 +238,7 @@ fun opcode_name(op: u16) str {
     if (op == defs.CVTTSD2SI) { ret "cvttsd2si"; }
     if (op == defs.UCOMISS)   { ret "ucomiss"; }
     if (op == defs.UCOMISD)   { ret "ucomisd"; }
+    if (op == defs.MOVSB)     { ret "movsb"; }
     ret "???";
 }
 


### PR DESCRIPTION
Closes #739