### PR TITLE
fix: Add MOVSB opcode constant to x86_64 defs

### DIFF
--- a/src/compiler/target/isa/x86_64/defs.mach
+++ b/src/compiler/target/isa/x86_64/defs.mach
@@ -119,7 +119,8 @@ pub val CVTTSS2SI: Opcode = 64;
 pub val CVTTSD2SI: Opcode = 65;
 pub val UCOMISS:   Opcode = 66;
 pub val UCOMISD:       Opcode = 67;
-pub val ISA_ASM_BLOCK: Opcode = 68;
+pub val MOVSB:         Opcode = 68;
+pub val ISA_ASM_BLOCK: Opcode = 69;
 
 pub def EncFlag: u16;
 pub val FLAG_REX_W:    EncFlag = 1;


### PR DESCRIPTION
Closes #753