### PR TITLE
fix: va_arg stack path missing JMP to done label

### DIFF
--- a/src/compiler/lower/expr.mach
+++ b/src/compiler/lower/expr.mach
@@ -576,8 +576,8 @@ fun lower_va_arg(ctx: *lower.LowerContext, node_id: ast.NodeId,
     val new_overflow: u16 = lower.alloc_vreg(ctx);
     lower.emit(ctx, inst.make_alu(op.OP_ADD, new_overflow, overflow, eight_vreg, ps));
     lower.emit(ctx, inst.make_store(new_overflow, ap, oa_disp, ps));
+    lower.emit(ctx, inst.make_jmp(done_lbl));
 
-    # done
     lower.new_block(ctx, done_lbl);
 
     ret result;


### PR DESCRIPTION
Closes #777