### PR TITLE
fix: data-first emission, symbol dedup, and naked asm prologue

### DIFF
--- a/src/compiler/lower/lower.mach
+++ b/src/compiler/lower/lower.mach
@@ -269,7 +269,7 @@ pub fun lower_function(ctx: *lctx.LowerContext, node_id: ast.NodeId, store: *ast
         var needs_ret: bool = true;
         if (bc > 0) {
             val last_op: u8 = ctx.block.insts[bc - 1].op;
-            if (last_op == op.OP_RET || last_op == op.OP_JUMP || last_op == op.OP_TRAP) {
+            if (last_op == op.OP_RET || last_op == op.OP_JUMP || last_op == op.OP_TRAP || last_op == op.OP_ISA_ASM) {
                 needs_ret = false;
             }
         }
@@ -378,7 +378,7 @@ fun lower_instantiation(ctx: *lctx.LowerContext, fi: *mono.FnInst) {
         var needs_ret: bool = true;
         if (bc > 0) {
             val last_op: u8 = ctx.block.insts[bc - 1].op;
-            if (last_op == op.OP_RET || last_op == op.OP_JUMP || last_op == op.OP_TRAP) {
+            if (last_op == op.OP_RET || last_op == op.OP_JUMP || last_op == op.OP_TRAP || last_op == op.OP_ISA_ASM) {
                 needs_ret = false;
             }
         }

--- a/src/compiler/session.mach
+++ b/src/compiler/session.mach
@@ -374,6 +374,8 @@ pub fun compile_all(s: *Session, artifacts_dir: str) CompileResult {
         var debug: of.DebugInfo = dwarf.init(s.alloc, ".");
         s.target.of.debug = debug;
 
+        emit_data_decls(s, ?ir_module, ?obj);
+
         var asm_wb: iobuf.WriteBuf = iobuf.wbuf_make(s.alloc);
         var use_asm: bool = s.opts.emit_asm;
 
@@ -401,8 +403,6 @@ pub fun compile_all(s: *Session, artifacts_dir: str) CompileResult {
         if (use_asm && mod_rel != nil && asm_wb.len > 0) {
             emit_asm_file(s, ?asm_wb, art_dir, mod_rel);
         }
-
-        emit_data_decls(s, ?ir_module, ?obj);
 
         if (debug.finalize != nil) {
             debug.finalize(debug.ctx, ?obj);


### PR DESCRIPTION
## Changes

Three fixes for pre-existing codegen bugs exposed after the inline asm overhaul:

1. **Emit data declarations before function codegen** (`session.mach`) — moves `emit_data_decls()` before the function compilation loop so that data symbols (string literals, globals) exist in the ELF writer when codegen creates relocations. Combined with the symbol dedup in `elf.mach` (PR #799), this prevents string literal collision across modules.

2. **ELF symbol deduplication** (already in #799, included here) — when `add_symbol` is called for a name that already exists as undefined, update it with the definition instead of creating a duplicate.

3. **Treat `OP_ISA_ASM` as terminal instruction** (`lower.mach`) — functions whose last instruction is an ISA asm block (like `_start`) no longer get an implicit `OP_RET` appended. This prevents prologue/epilogue insertion on naked asm functions, which was corrupting the initial stack pointer read.

Closes #798