### PR TITLE
fix: bootstrap codegen fixes (post-#854)

### DIFF
--- a/src/compiler/mir/builder.mach
+++ b/src/compiler/mir/builder.mach
@@ -168,6 +168,7 @@ pub fun func_init(alloc: *allocator.Allocator, name: str, ret_type: type.TypeId,
     fb.func.arg_count   = 0;
     fb.func.arg_cap     = 0;
     fb.func.src_path    = src_path;
+    fb.func.types       = nil;
 
     ret fb;
 }
@@ -317,6 +318,30 @@ pub fun emit(fb: *FuncBuilder, o: op.Op, flags: u16, tid: type.TypeId, args: *ir
     ret ok[ir.ValueId, str](result);
 }
 
+fun make_block_name(alloc: *allocator.Allocator, prefix: str, id: u32) str {
+    if (prefix == nil) { ret nil; }
+    var plen: usize = 0;
+    for (prefix[plen] != 0) { plen = plen + 1; }
+    val res: Result[*u8, str] = allocator.allocate[u8](alloc, plen + 12);
+    if (is_err[*u8, str](res)) { ret prefix; }
+    val buf: *u8 = unwrap_ok[*u8, str](res);
+    var i: usize = 0;
+    for (i < plen) { buf[i] = prefix[i]; i = i + 1; }
+    buf[i] = '_';
+    i = i + 1;
+    var n: u32 = id;
+    if (n == 0) { buf[i] = '0'; i = i + 1; }
+    or {
+        var digits: [10]u8;
+        var dc: i32 = 0;
+        for (n > 0 && dc < 10) { digits[dc] = (n % 10)::u8 + '0'; n = n / 10; dc = dc + 1; }
+        var di: i32 = dc - 1;
+        for (di >= 0) { buf[i] = digits[di]; i = i + 1; di = di - 1; }
+    }
+    buf[i] = 0;
+    ret buf::str;
+}
+
 # create a new basic block, returns its ID
 pub fun create_block(fb: *FuncBuilder, name: str) Result[ir.BlockId, str] {
     if (fb.func.block_count >= fb.func.block_cap) {
@@ -332,7 +357,7 @@ pub fun create_block(fb: *FuncBuilder, name: str) Result[ir.BlockId, str] {
     val idx: u32 = fb.func.block_count;
     val block: *ir.Block = ?fb.func.blocks[idx];
     block.id          = idx::ir.BlockId;
-    block.name        = name;
+    block.name        = make_block_name(fb.alloc, name, idx);
     block.params      = nil;
     block.param_count = 0;
     block.param_cap   = 0;
@@ -475,11 +500,11 @@ pub fun build_field_ptr(fb: *FuncBuilder, tid: type.TypeId, base: ir.ValueId, fi
 }
 
 # build an array element pointer (result is pointer to the element)
-pub fun build_index_ptr(fb: *FuncBuilder, tid: type.TypeId, base: ir.ValueId, index: ir.ValueId, loc: ir.SrcRef) Result[ir.ValueId, str] {
+pub fun build_index_ptr(fb: *FuncBuilder, tid: type.TypeId, base: ir.ValueId, index: ir.ValueId, elem_size: u64, loc: ir.SrcRef) Result[ir.ValueId, str] {
     var args: [2]ir.ValueId;
     args[0] = base;
     args[1] = index;
-    ret emit(fb, op.OP_INDEX_PTR, 0, tid, ?args[0], 2, ir.BLOCK_NONE, ir.BLOCK_NONE, 0, loc);
+    ret emit(fb, op.OP_INDEX_PTR, 0, tid, ?args[0], 2, ir.BLOCK_NONE, ir.BLOCK_NONE, elem_size, loc);
 }
 
 # build a memcpy (no result value)
@@ -527,6 +552,10 @@ pub fun build_call(fb: *FuncBuilder, ret_type: type.TypeId, sym: ir.SymId, call_
     ret emit(fb, op.OP_CALL, 0, ret_type, call_args, arg_count, ir.BLOCK_NONE, ir.BLOCK_NONE, sym::u64, loc);
 }
 
+pub fun build_call_agg(fb: *FuncBuilder, ret_type: type.TypeId, sym: ir.SymId, call_args: *ir.ValueId, arg_count: u16, ret_size: u16, loc: ir.SrcRef) Result[ir.ValueId, str] {
+    ret emit(fb, op.OP_CALL, ret_size, ret_type, call_args, arg_count, ir.BLOCK_NONE, ir.BLOCK_NONE, sym::u64, loc);
+}
+
 # build an indirect function call (callee is first arg)
 pub fun build_call_indirect(fb: *FuncBuilder, ret_type: type.TypeId, callee: ir.ValueId, call_args: *ir.ValueId, arg_count: u16, loc: ir.SrcRef) Result[ir.ValueId, str] {
     val total: u16 = 1 + arg_count;
@@ -540,7 +569,28 @@ pub fun build_call_indirect(fb: *FuncBuilder, ret_type: type.TypeId, callee: ir.
     ret emit(fb, op.OP_CALL_INDIRECT, 0, ret_type, ?buf[0], total, ir.BLOCK_NONE, ir.BLOCK_NONE, 0, loc);
 }
 
+pub fun build_call_indirect_agg(fb: *FuncBuilder, ret_type: type.TypeId, callee: ir.ValueId, call_args: *ir.ValueId, arg_count: u16, ret_size: u16, loc: ir.SrcRef) Result[ir.ValueId, str] {
+    val total: u16 = 1 + arg_count;
+    var buf: [64]ir.ValueId;
+    buf[0] = callee;
+    var i: u16 = 0;
+    for (i < arg_count) {
+        buf[1 + i] = call_args[i];
+        i = i + 1;
+    }
+    ret emit(fb, op.OP_CALL_INDIRECT, ret_size, ret_type, ?buf[0], total, ir.BLOCK_NONE, ir.BLOCK_NONE, 0, loc);
+}
+
 # build a return instruction
+pub fun build_ret_agg(fb: *FuncBuilder, value: ir.ValueId, ret_size: u16, loc: ir.SrcRef) Result[ir.ValueId, str] {
+    if (value::u32 == ir.VALUE_NONE::u32) {
+        ret emit(fb, op.OP_RET, 0, type.TK_VOID::type.TypeId, nil, 0, ir.BLOCK_NONE, ir.BLOCK_NONE, 0, loc);
+    }
+    var args: [1]ir.ValueId;
+    args[0] = value;
+    ret emit(fb, op.OP_RET, ret_size, type.TK_VOID::type.TypeId, ?args[0], 1, ir.BLOCK_NONE, ir.BLOCK_NONE, 0, loc);
+}
+
 pub fun build_ret(fb: *FuncBuilder, value: ir.ValueId, loc: ir.SrcRef) Result[ir.ValueId, str] {
     if (value::u32 == ir.VALUE_NONE::u32) {
         ret emit(fb, op.OP_RET, 0, type.TK_VOID::type.TypeId, nil, 0, ir.BLOCK_NONE, ir.BLOCK_NONE, 0, loc);

--- a/src/compiler/mir/builder.mach
+++ b/src/compiler/mir/builder.mach
@@ -607,7 +607,11 @@ pub fun build_unreachable(fb: *FuncBuilder, loc: ir.SrcRef) Result[ir.ValueId, s
 
 # build a function parameter reference (emitted in entry block)
 pub fun build_param(fb: *FuncBuilder, tid: type.TypeId, param_idx: u32, loc: ir.SrcRef) Result[ir.ValueId, str] {
-    ret emit(fb, op.OP_PARAM, 0, tid, nil, 0, ir.BLOCK_NONE, ir.BLOCK_NONE, param_idx::u64, loc);
+    val res: Result[ir.ValueId, str] = emit(fb, op.OP_PARAM, 0, tid, nil, 0, ir.BLOCK_NONE, ir.BLOCK_NONE, param_idx::u64, loc);
+    if (is_ok[ir.ValueId, str](res)) {
+        fb.func.param_count = fb.func.param_count + 1;
+    }
+    ret res;
 }
 
 # build a syscall

--- a/src/compiler/mir/compile.mach
+++ b/src/compiler/mir/compile.mach
@@ -78,7 +78,8 @@ fun compile_function(func: *ir.Function, module: *ir.Module, tgt: *target.Target
 
     var layout: frame.FrameLayout = frame.compute(alloc, func);
 
-    if (func.is_variadic) {
+    val needs_va_save: bool = func.is_variadic || has_va_start(func);
+    if (needs_va_save) {
         val va_sz: usize = tgt.abi.va_save_size(tgt.abi.ctx);
         if (va_sz > 0) {
             val base: i64 = -(layout.frame_size::i64);
@@ -141,6 +142,21 @@ fun compile_function(func: *ir.Function, module: *ir.Module, tgt: *target.Target
     isa.buf_dnit(?final_buf);
 
     ret emit_ok;
+}
+
+fun has_va_start(func: *ir.Function) bool {
+    var bi: u32 = 0;
+    for (bi < func.block_count) {
+        val block: *ir.Block = ?func.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < block.inst_count) {
+            val inst: *ir.Inst = ?func.insts[block.insts[ii]::u32];
+            if (inst.op == op.OP_VA_START) { ret true; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret false;
 }
 
 fun is_asm_only(func: *ir.Function) bool {
@@ -454,7 +470,7 @@ fun insert_prologue_epilogue(tgt: *target.Target, alloc: *allocator.Allocator,
         tgt.isa.emit_prologue(tgt.isa.ctx, ?buf, frame_size, callee_mask);
     }
 
-    if (func.is_variadic && tgt.abi.emit_va_save != nil && layout.va_save_off != 0) {
+    if (layout.va_save_off != 0 && tgt.abi.emit_va_save != nil) {
         val fp_reg: i32 = tgt.isa.frame_reg;
         tgt.abi.emit_va_save(tgt.abi.ctx, ?buf, fp_reg, layout.va_save_off);
     }

--- a/src/compiler/mir/compile.mach
+++ b/src/compiler/mir/compile.mach
@@ -78,6 +78,16 @@ fun compile_function(func: *ir.Function, module: *ir.Module, tgt: *target.Target
 
     var layout: frame.FrameLayout = frame.compute(alloc, func);
 
+    if (func.is_variadic) {
+        val va_sz: usize = tgt.abi.va_save_size(tgt.abi.ctx);
+        if (va_sz > 0) {
+            val base: i64 = -(layout.frame_size::i64);
+            val va_off: i64 = base - va_sz::i64;
+            layout.va_save_off = va_off;
+            layout.frame_size = layout.frame_size + ((va_sz + 15) & ~15::usize);
+        }
+    }
+
     var isel_buf: isa.InstBuf = isa.buf_init(alloc);
 
     val isel_ok: bool = dispatch_isel(tgt, module, func, ?layout, ?isel_buf, alloc);
@@ -123,7 +133,7 @@ fun compile_function(func: *ir.Function, module: *ir.Module, tgt: *target.Target
     var final_buf: isa.InstBuf = resolved_buf;
     if (!is_asm_only(func)) {
         final_buf = insert_prologue_epilogue(tgt, alloc, ?resolved_buf, total_frame,
-                                              ra_result.callee_mask);
+                                              ra_result.callee_mask, func, ?layout);
         isa.buf_dnit(?resolved_buf);
     }
 
@@ -436,11 +446,17 @@ fun emit_pcopy_mov(out: *isa.InstBuf, dst: i32, src: i32, template: isa.Inst,
 
 fun insert_prologue_epilogue(tgt: *target.Target, alloc: *allocator.Allocator,
                              ra_out: *isa.InstBuf, frame_size: usize,
-                             callee_mask: u32) isa.InstBuf {
+                             callee_mask: u32, func: *ir.Function,
+                             layout: *frame.FrameLayout) isa.InstBuf {
     var buf: isa.InstBuf = isa.buf_init(alloc);
 
     if (tgt.isa.emit_prologue != nil) {
         tgt.isa.emit_prologue(tgt.isa.ctx, ?buf, frame_size, callee_mask);
+    }
+
+    if (func.is_variadic && tgt.abi.emit_va_save != nil && layout.va_save_off != 0) {
+        val fp_reg: i32 = tgt.isa.frame_reg;
+        tgt.abi.emit_va_save(tgt.abi.ctx, ?buf, fp_reg, layout.va_save_off);
     }
 
     var i: i32 = 0;

--- a/src/compiler/mir/frame.mach
+++ b/src/compiler/mir/frame.mach
@@ -28,14 +28,16 @@ pub rec FrameLayout {
     slots:      *AllocaSlot;
     slot_count: u32;
     frame_size: usize;    # total bytes of stack space (positive)
+    va_save_off: i64;     # offset for variadic argument save area
 }
 
 # scan a MIR function and assign stack offsets to all allocas
 pub fun compute(alloc: *allocator.Allocator, func: *ir.Function) FrameLayout {
     var layout: FrameLayout;
-    layout.slots      = nil;
-    layout.slot_count = 0;
-    layout.frame_size = 0;
+    layout.slots       = nil;
+    layout.slot_count  = 0;
+    layout.frame_size  = 0;
+    layout.va_save_off = 0;
 
     val res: Result[*AllocaSlot, str] = allocator.allocate[AllocaSlot](alloc, MAX_ALLOCAS::usize);
     if (is_err[*AllocaSlot, str](res)) { ret layout; }
@@ -69,6 +71,23 @@ pub fun compute(alloc: *allocator.Allocator, func: *ir.Function) FrameLayout {
                 layout.slots[idx].offset = offset;
                 layout.slots[idx].size   = size;
                 layout.slots[idx].align  = align;
+                layout.slot_count = idx + 1;
+            }
+
+            if ((inst.op == op.OP_CALL || inst.op == op.OP_CALL_INDIRECT) &&
+                inst.flags > 8 && inst.flags < 0x8000 &&
+                inst.result::u32 != ir.VALUE_NONE::u32 &&
+                layout.slot_count < MAX_ALLOCAS) {
+                val agg_sz: u64 = inst.flags::u64;
+                offset = offset - agg_sz::i64;
+                val mask8: i64 = 7;
+                offset = (offset - mask8) & ~mask8;
+
+                val idx: u32 = layout.slot_count;
+                layout.slots[idx].value  = inst.result;
+                layout.slots[idx].offset = offset;
+                layout.slots[idx].size   = agg_sz;
+                layout.slots[idx].align  = 8;
                 layout.slot_count = idx + 1;
             }
 

--- a/src/compiler/mir/ir.mach
+++ b/src/compiler/mir/ir.mach
@@ -178,6 +178,7 @@ pub rec Function {
     arg_cap:     u32;
 
     src_path:    str;
+    types:       *type.TypeTable;
 }
 
 # a MIR module — self-contained unit of compilation

--- a/src/compiler/mir/lower/ctx.mach
+++ b/src/compiler/mir/lower/ctx.mach
@@ -76,9 +76,15 @@ pub rec LowerCtx {
     ds:           DeferState;
     rs:           ReturnState;
 
-    ptr_size:     u8;
-    str_counter:  u32;
-    fn_is_variadic: bool;
+    ptr_size:        u8;
+    str_counter:     u32;
+    fn_is_variadic:  bool;
+    max_reg_ret:     u32;
+    last_field_tid:  type.TypeId;
+    inst_param_count: i32;
+    inst_scope:      u32;
+    const_map:       ptr;
+    inst_etm:        ptr;
 }
 
 # initialize a lowering context
@@ -103,7 +109,13 @@ pub fun init(alloc: *allocator.Allocator, sa: *sema_mod.Sema,
     ctx.rs.ret_type = type.TYPE_NIL;
     ctx.ptr_size    = 8;
     ctx.str_counter = 0;
-    ctx.fn_is_variadic = false;
+    ctx.fn_is_variadic  = false;
+    ctx.max_reg_ret     = 16;
+    ctx.last_field_tid  = type.TYPE_NIL;
+    ctx.inst_param_count = -1;
+    ctx.inst_scope      = 0;
+    ctx.const_map       = nil;
+    ctx.inst_etm        = nil;
 
     val res: Result[*Local, str] = allocator.allocate[Local](alloc, MAX_LOCALS::usize);
     if (is_ok[*Local, str](res)) {
@@ -117,6 +129,10 @@ pub fun init(alloc: *allocator.Allocator, sa: *sema_mod.Sema,
 
 # get resolved type for an AST node from sema side tables
 pub fun node_type(ctx: *LowerCtx, node_id: ast.NodeId) type.TypeId {
+    if (ctx.inst_etm != nil) {
+        val inst_tid: type.TypeId = st.get_type(ctx.inst_etm::*st.ExprTypeMap, node_id);
+        if (inst_tid::u32 != type.TYPE_NIL::u32) { ret inst_tid; }
+    }
     val m: *smod.Module = smod.get(ctx.sema.modules, ctx.current_mod);
     ret st.get_type(?m.expr_types, node_id);
 }

--- a/src/compiler/mir/lower/ctx.mach
+++ b/src/compiler/mir/lower/ctx.mach
@@ -246,6 +246,16 @@ pub fun push_local(ctx: *LowerCtx, name: str, tid: type.TypeId, loc: ir.SrcRef) 
     ret ok[ir.ValueId, str](ptr_val);
 }
 
+pub fun push_local_with_ptr(ctx: *LowerCtx, name: str, tid: type.TypeId, ptr_val: ir.ValueId) {
+    if (ctx.local_count < MAX_LOCALS && ctx.locals != nil) {
+        val idx: i32 = ctx.local_count;
+        ctx.locals[idx].name    = name;
+        ctx.locals[idx].type_id = tid;
+        ctx.locals[idx].ptr     = ptr_val;
+        ctx.local_count = idx + 1;
+    }
+}
+
 # find a local variable by name, returns its alloca pointer (VALUE_NONE if not found)
 pub fun find_local(ctx: *LowerCtx, name: str) ir.ValueId {
     if (name == nil || ctx.locals == nil) { ret ir.VALUE_NONE; }

--- a/src/compiler/mir/lower/data.mach
+++ b/src/compiler/mir/lower/data.mach
@@ -16,10 +16,11 @@ use scope:     mach.compiler.sema.scope;
 use smod:      mach.compiler.sema.module;
 use ast:       mach.compiler.parse.ast;
 
-use ir:      mach.compiler.mir.ir;
-use builder: mach.compiler.mir.builder;
-use lctx:    mach.compiler.mir.lower.ctx;
-use smod_m:  mach.compiler.sema.module;
+use ir:       mach.compiler.mir.ir;
+use builder:  mach.compiler.mir.builder;
+use lctx:     mach.compiler.mir.lower.ctx;
+use smod_m:   mach.compiler.sema.module;
+use consteval: mach.compiler.sema.consteval;
 
 # lower a global val or var declaration
 pub fun lower_global_var(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore) {
@@ -68,6 +69,15 @@ pub fun lower_global_var(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.N
     glob.data     = nil;
     glob.data_len = 0;
     glob.is_const = is_const;
+
+    if (ctx.const_map != nil) {
+        val cm: *consteval.ConstMap = ctx.const_map::*consteval.ConstMap;
+        val cv: *consteval.ConstVal = consteval.get_val(cm, node_id);
+        if (cv != nil && cv.data != nil && cv.size > 0) {
+            glob.data     = cv.data;
+            glob.data_len = cv.size;
+        }
+    }
 
     val add_res: Result[u32, str] = builder.module_add_global(ctx.mb, glob);
     if (is_err[u32, str](add_res)) {

--- a/src/compiler/mir/lower/expr.mach
+++ b/src/compiler/mir/lower/expr.mach
@@ -934,8 +934,13 @@ fun lower_index_ptr(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSt
     val index_val: ir.ValueId = lower_expr(ctx, idx_id, store);
     if (base_ptr::u32 == ir.VALUE_NONE::u32 || index_val::u32 == ir.VALUE_NONE::u32) { ret ir.VALUE_NONE; }
 
+    val elem_tid: type.TypeId = lctx.node_type(ctx, node_id);
+    val elem_sz: u32 = lctx.type_size(ctx, elem_tid);
+    var esz: u64 = elem_sz::u64;
+    if (esz == 0) { esz = 1; }
+
     val ptr_tid: type.TypeId = type.TK_POINTER::type.TypeId;
-    val res: Result[ir.ValueId, str] = builder.build_index_ptr(?ctx.fb, ptr_tid, base_ptr, index_val, 0, loc);
+    val res: Result[ir.ValueId, str] = builder.build_index_ptr(?ctx.fb, ptr_tid, base_ptr, index_val, esz, loc);
     ret lctx.unwrap_build(ctx, res, loc);
 }
 
@@ -1068,7 +1073,10 @@ fun lower_array_lit(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSt
                 val idx_res: Result[ir.ValueId, str] = builder.build_iconst(?ctx.fb, type.TK_U64::type.TypeId, ei::u64, loc);
                 if (is_ok[ir.ValueId, str](idx_res)) {
                     val idx_val: ir.ValueId = unwrap_ok[ir.ValueId, str](idx_res);
-                    val eptr_res: Result[ir.ValueId, str] = builder.build_index_ptr(?ctx.fb, ptr_tid, ptr, idx_val, 0, loc);
+                    val elem_tid_for_sz: type.TypeId = lctx.node_type(ctx, elem_id);
+                    var elem_esz: u64 = lctx.type_size(ctx, elem_tid_for_sz)::u64;
+                    if (elem_esz == 0) { elem_esz = 1; }
+                    val eptr_res: Result[ir.ValueId, str] = builder.build_index_ptr(?ctx.fb, ptr_tid, ptr, idx_val, elem_esz, loc);
                     if (is_ok[ir.ValueId, str](eptr_res)) {
                         val eptr: ir.ValueId = unwrap_ok[ir.ValueId, str](eptr_res);
                         val elem_tid: type.TypeId = lctx.node_type(ctx, elem_id);

--- a/src/compiler/mir/lower/expr.mach
+++ b/src/compiler/mir/lower/expr.mach
@@ -279,6 +279,7 @@ fun lower_ident(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore,
                 if (is_ok[ir.ValueId, str](addr_res)) {
                     val addr: ir.ValueId = unwrap_ok[ir.ValueId, str](addr_res);
                     if (lctx.is_aggregate(ctx, tid)) { ret addr; }
+                    if (sym.kind == scope.SK_FUN) { ret addr; }
                     val ld_res: Result[ir.ValueId, str] = builder.build_load(?ctx.fb, tid, addr, loc);
                     if (is_ok[ir.ValueId, str](ld_res)) { ret unwrap_ok[ir.ValueId, str](ld_res); }
                 }
@@ -313,6 +314,7 @@ fun lower_ident_sym(ctx: *lctx.LowerCtx, sym: *scope.Symbol, tid: type.TypeId, n
         if (is_ok[ir.ValueId, str](addr_res)) {
             val addr: ir.ValueId = unwrap_ok[ir.ValueId, str](addr_res);
             if (lctx.is_aggregate(ctx, tid)) { ret addr; }
+            if (sym.kind == scope.SK_FUN) { ret addr; }
             val ld_res: Result[ir.ValueId, str] = builder.build_load(?ctx.fb, tid, addr, loc);
             if (is_ok[ir.ValueId, str](ld_res)) { ret unwrap_ok[ir.ValueId, str](ld_res); }
         }
@@ -933,9 +935,17 @@ fun lower_index_ptr(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSt
     val base_id: ast.NodeId = ast.get_extra(store, node.payload)::ast.NodeId;
     val idx_id: ast.NodeId = ast.get_extra(store, node.payload + 1)::ast.NodeId;
 
-    val base_ptr: ir.ValueId = lower_lvalue(ctx, base_id, store);
+    val base_lv: ir.ValueId = lower_lvalue(ctx, base_id, store);
     val index_val: ir.ValueId = lower_expr(ctx, idx_id, store);
-    if (base_ptr::u32 == ir.VALUE_NONE::u32 || index_val::u32 == ir.VALUE_NONE::u32) { ret ir.VALUE_NONE; }
+    if (base_lv::u32 == ir.VALUE_NONE::u32 || index_val::u32 == ir.VALUE_NONE::u32) { ret ir.VALUE_NONE; }
+
+    val base_tid: type.TypeId = lctx.node_type(ctx, base_id);
+    var base_ptr: ir.ValueId = base_lv;
+    if (!lctx.is_aggregate(ctx, base_tid)) {
+        val ld_res: Result[ir.ValueId, str] = builder.build_load(?ctx.fb, base_tid, base_lv, loc);
+        base_ptr = lctx.unwrap_build(ctx, ld_res, loc);
+        if (base_ptr::u32 == ir.VALUE_NONE::u32) { ret ir.VALUE_NONE; }
+    }
 
     val elem_tid: type.TypeId = lctx.node_type(ctx, node_id);
     val elem_sz: u32 = lctx.type_size(ctx, elem_tid);

--- a/src/compiler/mir/lower/expr.mach
+++ b/src/compiler/mir/lower/expr.mach
@@ -818,11 +818,13 @@ fun lower_va_start(ctx: *lctx.LowerCtx, args_span: ast.NodeSpan, store: *ast.Nod
     val va_ptr: ir.ValueId = lower_expr(ctx, arg_nid, store);
     if (va_ptr::u32 == ir.VALUE_NONE::u32) { ret ir.VALUE_NONE; }
 
+    val named_count: u64 = ctx.fb.func.param_count::u64;
+
     var args: [1]ir.ValueId;
     args[0] = va_ptr;
     val void_tid: type.TypeId = type.TK_VOID::type.TypeId;
     builder.emit(?ctx.fb, op.OP_VA_START, 0, void_tid, ?args[0], 1,
-                 ir.BLOCK_NONE, ir.BLOCK_NONE, 0, loc);
+                 ir.BLOCK_NONE, ir.BLOCK_NONE, named_count, loc);
     ret ir.VALUE_NONE;
 }
 
@@ -910,8 +912,9 @@ fun lower_field_ptr(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSt
         ret ir.VALUE_NONE;
     }
 
+    val field_offset: u32 = actual_t.fields[field_idx].offset;
     val ptr_tid: type.TypeId = type.TK_POINTER::type.TypeId;
-    val res: Result[ir.ValueId, str] = builder.build_field_ptr(?ctx.fb, ptr_tid, actual_base, field_idx, loc);
+    val res: Result[ir.ValueId, str] = builder.build_field_ptr(?ctx.fb, ptr_tid, actual_base, field_offset, loc);
     ret lctx.unwrap_build(ctx, res, loc);
 }
 
@@ -1031,7 +1034,12 @@ fun lower_struct_lit(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeS
             val val_id: ast.NodeId = ast.get_extra(store, init_node.payload + 1)::ast.NodeId;
             val field_val: ir.ValueId = lower_expr(ctx, val_id, store);
             if (field_val::u32 != ir.VALUE_NONE::u32) {
-                val fptr_res: Result[ir.ValueId, str] = builder.build_field_ptr(?ctx.fb, ptr_tid, ptr, fi, loc);
+                val st: *type.Type = lctx.get_type(ctx, tid);
+                var f_off: u32 = fi;
+                if (st != nil && fi::u16 < st.field_count) {
+                    f_off = st.fields[fi].offset;
+                }
+                val fptr_res: Result[ir.ValueId, str] = builder.build_field_ptr(?ctx.fb, ptr_tid, ptr, f_off, loc);
                 if (is_ok[ir.ValueId, str](fptr_res)) {
                     val fptr: ir.ValueId = unwrap_ok[ir.ValueId, str](fptr_res);
                     val field_tid: type.TypeId = lctx.node_type(ctx, val_id);

--- a/src/compiler/mir/lower/expr.mach
+++ b/src/compiler/mir/lower/expr.mach
@@ -229,7 +229,11 @@ fun lower_char_lit(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSto
     val str_id: ast.StrId = ast.get_extra(store, node.payload)::ast.StrId;
     val text: str = ast.get_str(store, str_id);
     var value: u64 = 0;
-    if (text != nil) { value = text[0]::u64; }
+    if (text != nil) {
+        val pc_res: Result[u8, str] = lit.parse_char(text);
+        if (is_ok[u8, str](pc_res)) { value = unwrap_ok[u8, str](pc_res)::u64; }
+        or { value = text[0]::u64; }
+    }
     val res: Result[ir.ValueId, str] = builder.build_iconst(?ctx.fb, tid, value, loc);
     ret lctx.unwrap_build(ctx, res, loc);
 }
@@ -243,7 +247,8 @@ fun lower_ident(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore,
     val local_ptr: ir.ValueId = lctx.find_local(ctx, name);
     if (local_ptr::u32 != ir.VALUE_NONE::u32) {
         if (lctx.is_aggregate(ctx, tid)) {
-            ret local_ptr;
+            val agg_sz: u32 = lctx.type_size(ctx, tid);
+            if (agg_sz > 8) { ret local_ptr; }
         }
         val res: Result[ir.ValueId, str] = builder.build_load(?ctx.fb, tid, local_ptr, loc);
         if (is_ok[ir.ValueId, str](res)) { ret unwrap_ok[ir.ValueId, str](res); }
@@ -488,8 +493,8 @@ fun lower_assign(ctx: *lctx.LowerCtx, lhs_id: ast.NodeId, rhs_id: ast.NodeId,
     }
 
     val tid: type.TypeId = lctx.node_type(ctx, rhs_id);
-    if (lctx.is_aggregate(ctx, tid)) {
-        val sz: u32 = lctx.type_size(ctx, tid);
+    val sz: u32 = lctx.type_size(ctx, tid);
+    if (lctx.is_aggregate(ctx, tid) && sz > 8) {
         builder.build_copy(?ctx.fb, ptr, value, sz::u64, loc);
     } or {
         builder.build_store(?ctx.fb, ptr, value, loc);
@@ -1085,7 +1090,9 @@ fun lower_array_lit(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSt
 
 fun lower_comptime(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore, loc: ir.SrcRef) ir.ValueId {
     val m: *smod.Module = smod.get(ctx.sema.modules, ctx.current_mod);
-    val cv: ct.CValue = ct.eval(ctx.sema, ctx.current_mod, m.scope, node_id);
+    var eval_scope: scope.ScopeId = m.scope;
+    if (ctx.inst_scope != 0) { eval_scope = ctx.inst_scope::scope.ScopeId; }
+    val cv: ct.CValue = ct.eval(ctx.sema, ctx.current_mod, eval_scope, node_id);
 
     val tid: type.TypeId = lctx.node_type(ctx, node_id);
 

--- a/src/compiler/mir/lower/expr.mach
+++ b/src/compiler/mir/lower/expr.mach
@@ -555,6 +555,74 @@ fun lower_unary(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore,
     ret ir.VALUE_NONE;
 }
 
+val SRET_FLAG: u16 = 0x8000;
+
+fun emit_call(ctx: *lctx.LowerCtx, ret_tid: type.TypeId, sid: ir.SymId,
+              args: *ir.ValueId, arg_count: u16, loc: ir.SrcRef) Result[ir.ValueId, str] {
+    val ret_sz: u32 = lctx.type_size(ctx, ret_tid);
+    if (lctx.is_aggregate(ctx, ret_tid) && ret_sz > 0) {
+        if (ret_sz > ctx.max_reg_ret) {
+            ret emit_sret_call(ctx, ret_tid, sid, args, arg_count, ret_sz, loc);
+        }
+        ret builder.build_call_agg(?ctx.fb, ret_tid, sid, args, arg_count, ret_sz::u16, loc);
+    }
+    ret builder.build_call(?ctx.fb, ret_tid, sid, args, arg_count, loc);
+}
+
+fun emit_call_indirect(ctx: *lctx.LowerCtx, ret_tid: type.TypeId, callee: ir.ValueId,
+                       args: *ir.ValueId, arg_count: u16, loc: ir.SrcRef) Result[ir.ValueId, str] {
+    val ret_sz: u32 = lctx.type_size(ctx, ret_tid);
+    if (lctx.is_aggregate(ctx, ret_tid) && ret_sz > 0) {
+        if (ret_sz > ctx.max_reg_ret) {
+            ret emit_sret_call_indirect(ctx, ret_tid, callee, args, arg_count, ret_sz, loc);
+        }
+        ret builder.build_call_indirect_agg(?ctx.fb, ret_tid, callee, args, arg_count, ret_sz::u16, loc);
+    }
+    ret builder.build_call_indirect(?ctx.fb, ret_tid, callee, args, arg_count, loc);
+}
+
+fun emit_sret_call(ctx: *lctx.LowerCtx, ret_tid: type.TypeId, sid: ir.SymId,
+                   args: *ir.ValueId, arg_count: u16, ret_sz: u32, loc: ir.SrcRef) Result[ir.ValueId, str] {
+    val ptr_tid: type.TypeId = type.make_pointer(ctx.sema.types, ret_tid);
+    val al: u32 = lctx.type_align(ctx, ret_tid);
+    val alloca_res: Result[ir.ValueId, str] = builder.build_alloca(?ctx.fb, ptr_tid, ret_sz::u64, al::u16, loc);
+    if (is_err[ir.ValueId, str](alloca_res)) { ret alloca_res; }
+    val sret_ptr: ir.ValueId = unwrap_ok[ir.ValueId, str](alloca_res);
+
+    var sret_args: [64]ir.ValueId;
+    sret_args[0] = sret_ptr;
+    var i: u16 = 0;
+    for (i < arg_count && i < 63) {
+        sret_args[1 + i] = args[i];
+        i = i + 1;
+    }
+    val total: u16 = 1 + arg_count;
+    val flags: u16 = SRET_FLAG | ret_sz::u16;
+    builder.build_call_agg(?ctx.fb, type.TK_VOID::type.TypeId, sid, ?sret_args[0], total, flags, loc);
+    ret ok[ir.ValueId, str](sret_ptr);
+}
+
+fun emit_sret_call_indirect(ctx: *lctx.LowerCtx, ret_tid: type.TypeId, callee: ir.ValueId,
+                            args: *ir.ValueId, arg_count: u16, ret_sz: u32, loc: ir.SrcRef) Result[ir.ValueId, str] {
+    val ptr_tid: type.TypeId = type.make_pointer(ctx.sema.types, ret_tid);
+    val al: u32 = lctx.type_align(ctx, ret_tid);
+    val alloca_res: Result[ir.ValueId, str] = builder.build_alloca(?ctx.fb, ptr_tid, ret_sz::u64, al::u16, loc);
+    if (is_err[ir.ValueId, str](alloca_res)) { ret alloca_res; }
+    val sret_ptr: ir.ValueId = unwrap_ok[ir.ValueId, str](alloca_res);
+
+    var sret_args: [64]ir.ValueId;
+    sret_args[0] = sret_ptr;
+    var i: u16 = 0;
+    for (i < arg_count && i < 63) {
+        sret_args[1 + i] = args[i];
+        i = i + 1;
+    }
+    val total: u16 = 1 + arg_count;
+    val flags: u16 = SRET_FLAG | ret_sz::u16;
+    builder.build_call_indirect_agg(?ctx.fb, type.TK_VOID::type.TypeId, callee, ?sret_args[0], total, flags, loc);
+    ret ok[ir.ValueId, str](sret_ptr);
+}
+
 fun lower_call(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore, loc: ir.SrcRef) ir.ValueId {
     val callee_id: ast.NodeId = ast.call_callee(store, node_id);
     val args_span: ast.NodeSpan = ast.call_args(store, node_id);
@@ -599,7 +667,7 @@ fun lower_call(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore, 
             val ld_res: Result[ir.ValueId, str] = builder.build_load(?ctx.fb, callee_tid, local_ptr, loc);
             val callee_val: ir.ValueId = lctx.unwrap_build(ctx, ld_res, loc);
             if (callee_val::u32 != ir.VALUE_NONE::u32) {
-                val res: Result[ir.ValueId, str] = builder.build_call_indirect(?ctx.fb, ret_tid, callee_val, ?arg_vals[0], arg_count, loc);
+                val res: Result[ir.ValueId, str] = emit_call_indirect(ctx, ret_tid, callee_val, ?arg_vals[0], arg_count, loc);
                 ret lctx.unwrap_build(ctx, res, loc);
             }
             ret ir.VALUE_NONE;
@@ -611,7 +679,7 @@ fun lower_call(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore, 
             if (sym != nil && (sym.kind == scope.SK_VAL || sym.kind == scope.SK_VAR || sym.kind == scope.SK_PARAM)) {
                 val callee_val: ir.ValueId = lower_ident(ctx, callee_id, store, loc);
                 if (callee_val::u32 != ir.VALUE_NONE::u32) {
-                    val res: Result[ir.ValueId, str] = builder.build_call_indirect(?ctx.fb, ret_tid, callee_val, ?arg_vals[0], arg_count, loc);
+                    val res: Result[ir.ValueId, str] = emit_call_indirect(ctx, ret_tid, callee_val, ?arg_vals[0], arg_count, loc);
                     ret lctx.unwrap_build(ctx, res, loc);
                 }
                 ret ir.VALUE_NONE;
@@ -630,7 +698,7 @@ fun lower_call(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore, 
         val sym_res: Result[ir.SymId, str] = builder.module_add_symbol(ctx.mb, name, false);
         if (is_ok[ir.SymId, str](sym_res)) {
             val sid: ir.SymId = unwrap_ok[ir.SymId, str](sym_res);
-            val res: Result[ir.ValueId, str] = builder.build_call(?ctx.fb, ret_tid, sid, ?arg_vals[0], arg_count, loc);
+            val res: Result[ir.ValueId, str] = emit_call(ctx, ret_tid, sid, ?arg_vals[0], arg_count, loc);
             if (is_ok[ir.ValueId, str](res)) { ret unwrap_ok[ir.ValueId, str](res); }
         }
     } or {
@@ -648,7 +716,7 @@ fun lower_call(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore, 
                 val sym_res: Result[ir.SymId, str] = builder.module_add_symbol(ctx.mb, fname, false);
                 if (is_ok[ir.SymId, str](sym_res)) {
                     val sid: ir.SymId = unwrap_ok[ir.SymId, str](sym_res);
-                    val res: Result[ir.ValueId, str] = builder.build_call(?ctx.fb, ret_tid, sid, ?arg_vals[0], arg_count, loc);
+                    val res: Result[ir.ValueId, str] = emit_call(ctx, ret_tid, sid, ?arg_vals[0], arg_count, loc);
                     if (is_ok[ir.ValueId, str](res)) { ret unwrap_ok[ir.ValueId, str](res); }
                 }
                 ret ir.VALUE_NONE;
@@ -694,7 +762,7 @@ fun lower_call(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore, 
                                 val sym_res: Result[ir.SymId, str] = builder.module_add_symbol(ctx.mb, fname, false);
                                 if (is_ok[ir.SymId, str](sym_res)) {
                                     val sid: ir.SymId = unwrap_ok[ir.SymId, str](sym_res);
-                                    val res: Result[ir.ValueId, str] = builder.build_call(?ctx.fb, ret_tid, sid, ?arg_vals[0], arg_count, loc);
+                                    val res: Result[ir.ValueId, str] = emit_call(ctx, ret_tid, sid, ?arg_vals[0], arg_count, loc);
                                     if (is_ok[ir.ValueId, str](res)) { ret unwrap_ok[ir.ValueId, str](res); }
                                 }
                             }
@@ -706,7 +774,7 @@ fun lower_call(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore, 
 
         val callee_val: ir.ValueId = lower_expr(ctx, callee_id, store);
         if (callee_val::u32 != ir.VALUE_NONE::u32) {
-            val res: Result[ir.ValueId, str] = builder.build_call_indirect(?ctx.fb, ret_tid, callee_val, ?arg_vals[0], arg_count, loc);
+            val res: Result[ir.ValueId, str] = emit_call_indirect(ctx, ret_tid, callee_val, ?arg_vals[0], arg_count, loc);
             if (is_ok[ir.ValueId, str](res)) { ret unwrap_ok[ir.ValueId, str](res); }
         }
     }

--- a/src/compiler/mir/lower/expr.mach
+++ b/src/compiler/mir/lower/expr.mach
@@ -862,7 +862,7 @@ fun lower_index_ptr(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSt
     if (base_ptr::u32 == ir.VALUE_NONE::u32 || index_val::u32 == ir.VALUE_NONE::u32) { ret ir.VALUE_NONE; }
 
     val ptr_tid: type.TypeId = type.TK_POINTER::type.TypeId;
-    val res: Result[ir.ValueId, str] = builder.build_index_ptr(?ctx.fb, ptr_tid, base_ptr, index_val, loc);
+    val res: Result[ir.ValueId, str] = builder.build_index_ptr(?ctx.fb, ptr_tid, base_ptr, index_val, 0, loc);
     ret lctx.unwrap_build(ctx, res, loc);
 }
 
@@ -995,7 +995,7 @@ fun lower_array_lit(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSt
                 val idx_res: Result[ir.ValueId, str] = builder.build_iconst(?ctx.fb, type.TK_U64::type.TypeId, ei::u64, loc);
                 if (is_ok[ir.ValueId, str](idx_res)) {
                     val idx_val: ir.ValueId = unwrap_ok[ir.ValueId, str](idx_res);
-                    val eptr_res: Result[ir.ValueId, str] = builder.build_index_ptr(?ctx.fb, ptr_tid, ptr, idx_val, loc);
+                    val eptr_res: Result[ir.ValueId, str] = builder.build_index_ptr(?ctx.fb, ptr_tid, ptr, idx_val, 0, loc);
                     if (is_ok[ir.ValueId, str](eptr_res)) {
                         val eptr: ir.ValueId = unwrap_ok[ir.ValueId, str](eptr_res);
                         val elem_tid: type.TypeId = lctx.node_type(ctx, elem_id);

--- a/src/compiler/mir/lower/lower.mach
+++ b/src/compiler/mir/lower/lower.mach
@@ -168,12 +168,31 @@ fun lower_function(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSto
     val entry_block: ir.BlockId = unwrap_ok[ir.BlockId, str](entry_res);
     builder.switch_to_block(?ctx.fb, entry_block);
 
+    val ret_sz: u32 = lctx.type_size(ctx, ret_tid);
+    val needs_sret: bool = lctx.is_aggregate(ctx, ret_tid) && ret_sz > ctx.max_reg_ret;
+    var param_offset: u32 = 0;
+    if (needs_sret) {
+        val ptr_tid: type.TypeId = type.make_pointer(ctx.sema.types, ret_tid);
+        val loc: ir.SrcRef = lctx.make_loc(ctx, store, node_id);
+        val sret_res: Result[ir.ValueId, str] = builder.build_param(?ctx.fb, ptr_tid, 0, loc);
+        if (is_ok[ir.ValueId, str](sret_res)) {
+            val sret_val: ir.ValueId = unwrap_ok[ir.ValueId, str](sret_res);
+            val al_res: Result[ir.ValueId, str] = builder.build_alloca(?ctx.fb, ptr_tid, 8, 8, loc);
+            if (is_ok[ir.ValueId, str](al_res)) {
+                val al: ir.ValueId = unwrap_ok[ir.ValueId, str](al_res);
+                builder.build_store(?ctx.fb, al, sret_val, loc);
+                lctx.push_local_with_ptr(ctx, "$sret", ptr_tid, al);
+            }
+        }
+        param_offset = 1;
+    }
+
     val params: ast.NodeSpan = ast.fun_params(store, node_id);
     var pi: u32 = 0;
     for (pi < params.len) {
         val param_nid: ast.NodeId = ast.get_extra(store, params.start + pi)::ast.NodeId;
         if (param_nid::u32 != ast.NODE_NIL::u32) {
-            lower_param(ctx, param_nid, pi, store);
+            lower_param(ctx, param_nid, pi + param_offset, store);
         }
         pi = pi + 1;
     }

--- a/src/compiler/mir/lower/lower.mach
+++ b/src/compiler/mir/lower/lower.mach
@@ -202,6 +202,13 @@ fun lower_function(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSto
     for (pi < params.len) {
         val param_nid: ast.NodeId = ast.get_extra(store, params.start + pi)::ast.NodeId;
         if (param_nid::u32 != ast.NODE_NIL::u32) {
+            val pn: *ast.Node = ast.get(store, param_nid);
+            val pn_name_sid: ast.StrId = ast.get_extra(store, pn.payload)::ast.StrId;
+            val pn_name: str = ast.get_str(store, pn_name_sid);
+            if (pn_name != nil && str_equals(pn_name, "...")) {
+                pi = pi + 1;
+                cnt;
+            }
             lower_param(ctx, param_nid, pi + param_offset, store);
         }
         pi = pi + 1;

--- a/src/compiler/mir/lower/lower.mach
+++ b/src/compiler/mir/lower/lower.mach
@@ -159,6 +159,16 @@ fun lower_function(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSto
     ctx.ls.cnt_block   = ir.BLOCK_NONE;
     ctx.rs.ret_type    = ret_tid;
 
+    var fn_variadic: bool = false;
+    if (fn_tid::u32 != type.TYPE_NIL::u32) {
+        val ft2: *type.Type = type.get(ctx.sema.types, fn_tid);
+        if (ft2.kind == type.TK_FUN && ft2.is_variadic) {
+            fn_variadic = true;
+            builder.func_set_variadic(?ctx.fb);
+            ctx.fn_is_variadic = true;
+        }
+    }
+
     val entry_res: Result[ir.BlockId, str] = builder.create_block(?ctx.fb, "entry");
     if (is_err[ir.BlockId, str](entry_res)) {
         val eloc: ir.SrcRef = lctx.make_loc(ctx, store, node_id);

--- a/src/compiler/mir/lower/lower.mach
+++ b/src/compiler/mir/lower/lower.mach
@@ -261,6 +261,11 @@ fun lower_instantiation(ctx: *lctx.LowerCtx, fi: *mono.FnInst, store: *ast.NodeS
         ret_tid = fn_t.ret_type;
     }
 
+    val saved_etm: ptr = ctx.inst_etm;
+    val saved_scope: u32 = ctx.inst_scope;
+    ctx.inst_etm   = (?fi.inst_etm)::ptr;
+    ctx.inst_scope = fi.scope_id;
+
     ctx.fb = builder.func_init(ctx.alloc, fi.mangled_name, ret_tid, ctx.src_path);
     ctx.local_count    = 0;
     ctx.ds.count       = 0;
@@ -273,9 +278,30 @@ fun lower_instantiation(ctx: *lctx.LowerCtx, fi: *mono.FnInst, store: *ast.NodeS
     if (is_err[ir.BlockId, str](entry_res)) {
         val eloc: ir.SrcRef = lctx.make_loc(ctx, store, node_id);
         lctx.emit_error(ctx, eloc, "failed to create entry block");
+        ctx.inst_etm   = saved_etm;
+        ctx.inst_scope = saved_scope;
         ret;
     }
     builder.switch_to_block(?ctx.fb, unwrap_ok[ir.BlockId, str](entry_res));
+
+    val ret_sz: u32 = lctx.type_size(ctx, ret_tid);
+    val needs_sret: bool = lctx.is_aggregate(ctx, ret_tid) && ret_sz > ctx.max_reg_ret;
+    var param_offset: u32 = 0;
+    if (needs_sret) {
+        val ptr_tid: type.TypeId = type.make_pointer(ctx.sema.types, ret_tid);
+        val loc: ir.SrcRef = lctx.make_loc(ctx, store, node_id);
+        val sret_res: Result[ir.ValueId, str] = builder.build_param(?ctx.fb, ptr_tid, 0, loc);
+        if (is_ok[ir.ValueId, str](sret_res)) {
+            val sret_val: ir.ValueId = unwrap_ok[ir.ValueId, str](sret_res);
+            val al_res: Result[ir.ValueId, str] = builder.build_alloca(?ctx.fb, ptr_tid, 8, 8, loc);
+            if (is_ok[ir.ValueId, str](al_res)) {
+                val al: ir.ValueId = unwrap_ok[ir.ValueId, str](al_res);
+                builder.build_store(?ctx.fb, al, sret_val, loc);
+                lctx.push_local_with_ptr(ctx, "$sret", ptr_tid, al);
+            }
+        }
+        param_offset = 1;
+    }
 
     val params: ast.NodeSpan = ast.fun_params(store, node_id);
     var pi: u32 = 0;
@@ -292,7 +318,7 @@ fun lower_instantiation(ctx: *lctx.LowerCtx, fi: *mono.FnInst, store: *ast.NodeS
             }
             val loc: ir.SrcRef = lctx.make_loc(ctx, store, param_nid);
 
-            val param_res: Result[ir.ValueId, str] = builder.build_param(?ctx.fb, param_tid, pi, loc);
+            val param_res: Result[ir.ValueId, str] = builder.build_param(?ctx.fb, param_tid, pi + param_offset, loc);
             if (is_err[ir.ValueId, str](param_res)) { pi = pi + 1; cnt; }
             val param_val: ir.ValueId = unwrap_ok[ir.ValueId, str](param_res);
 
@@ -330,4 +356,7 @@ fun lower_instantiation(ctx: *lctx.LowerCtx, fi: *mono.FnInst, store: *ast.NodeS
         val eloc: ir.SrcRef = lctx.make_loc(ctx, store, node_id);
         lctx.emit_error(ctx, eloc, "failed to add instantiation to module");
     }
+
+    ctx.inst_etm   = saved_etm;
+    ctx.inst_scope = saved_scope;
 }

--- a/src/compiler/mir/lower/lower.mach
+++ b/src/compiler/mir/lower/lower.mach
@@ -142,8 +142,10 @@ fun lower_function(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSto
 
     val ret_type_node: ast.NodeId = ast.fun_ret_type(store, node_id);
     var ret_tid: type.TypeId = type.primitive(ctx.sema.types, type.TK_VOID);
-    val fn_sym2: scope.SymbolId = lctx.node_sym(ctx, node_id);
-    val fn_tid: type.TypeId = lctx.sym_type(ctx, fn_sym2);
+    var fn_tid: type.TypeId = type.TYPE_NIL;
+    if (is_some[scope.SymbolId](opt_fn_sym)) {
+        fn_tid = lctx.sym_type(ctx, unwrap[scope.SymbolId](opt_fn_sym));
+    }
     if (fn_tid::u32 != type.TYPE_NIL::u32) {
         val ft: *type.Type = type.get(ctx.sema.types, fn_tid);
         if (ft.kind == type.TK_FUN) {

--- a/src/compiler/mir/lower/stmt.mach
+++ b/src/compiler/mir/lower/stmt.mach
@@ -90,8 +90,8 @@ fun lower_var_decl(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSto
     if (init_id::u32 != ast.NODE_NIL::u32) {
         val init_val: ir.ValueId = expr_mod.lower_expr(ctx, init_id, store);
         if (init_val::u32 != ir.VALUE_NONE::u32) {
-            if (lctx.is_aggregate(ctx, tid)) {
-                val sz: u32 = lctx.type_size(ctx, tid);
+            val sz: u32 = lctx.type_size(ctx, tid);
+            if (lctx.is_aggregate(ctx, tid) && sz > 8) {
                 builder.build_copy(?ctx.fb, ptr, init_val, sz::u64, loc);
             } or {
                 builder.build_store(?ctx.fb, ptr, init_val, loc);

--- a/src/compiler/mir/lower/stmt.mach
+++ b/src/compiler/mir/lower/stmt.mach
@@ -225,7 +225,26 @@ fun lower_ret(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore) {
         if (value::u32 == ir.VALUE_NONE::u32) {
             lctx.emit_error(ctx, loc, "failed to lower return value");
         }
-        builder.build_ret(?ctx.fb, value, loc);
+
+        val ret_tid: type.TypeId = ctx.rs.ret_type;
+        val ret_sz: u32 = lctx.type_size(ctx, ret_tid);
+        if (lctx.is_aggregate(ctx, ret_tid) && ret_sz > ctx.max_reg_ret) {
+            val sret_ptr: ir.ValueId = lctx.find_local(ctx, "$sret");
+            if (sret_ptr::u32 != ir.VALUE_NONE::u32) {
+                val sret_ld: Result[ir.ValueId, str] = builder.build_load(?ctx.fb, type.TK_POINTER::type.TypeId, sret_ptr, loc);
+                if (is_ok[ir.ValueId, str](sret_ld)) {
+                    val dst: ir.ValueId = unwrap_ok[ir.ValueId, str](sret_ld);
+                    builder.build_copy(?ctx.fb, dst, value, ret_sz::u64, loc);
+                    builder.build_ret(?ctx.fb, dst, loc);
+                    ret;
+                }
+            }
+        }
+        if (lctx.is_aggregate(ctx, ret_tid) && ret_sz > 0 && ret_sz <= ctx.max_reg_ret) {
+            builder.build_ret_agg(?ctx.fb, value, ret_sz::u16, loc);
+        } or {
+            builder.build_ret(?ctx.fb, value, loc);
+        }
     } or {
         builder.build_ret(?ctx.fb, ir.VALUE_NONE, loc);
     }

--- a/src/compiler/mir/lower/stmt.mach
+++ b/src/compiler/mir/lower/stmt.mach
@@ -226,7 +226,11 @@ fun lower_ret(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore) {
             lctx.emit_error(ctx, loc, "failed to lower return value");
         }
 
-        val ret_tid: type.TypeId = ctx.rs.ret_type;
+        var ret_tid: type.TypeId = ctx.rs.ret_type;
+        val val_tid: type.TypeId = lctx.node_type(ctx, value_id);
+        if (val_tid::u32 != type.TYPE_NIL::u32 && lctx.is_aggregate(ctx, val_tid)) {
+            ret_tid = val_tid;
+        }
         val ret_sz: u32 = lctx.type_size(ctx, ret_tid);
         if (lctx.is_aggregate(ctx, ret_tid) && ret_sz > ctx.max_reg_ret) {
             val sret_ptr: ir.ValueId = lctx.find_local(ctx, "$sret");

--- a/src/compiler/mir/lower/stmt.mach
+++ b/src/compiler/mir/lower/stmt.mach
@@ -377,26 +377,78 @@ fun lower_asm_syscall(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.Node
 
     var args: [8]ir.ValueId;
     var arg_count: u16 = 0;
+    var out_name: str = nil;
 
-    var si: u32 = 0;
-    for (si < specs_count && arg_count < 8) {
-        val spec_id: ast.NodeId = ast.get_extra(store, specs_start + si)::ast.NodeId;
-        if (spec_id::u32 != ast.NODE_NIL::u32) {
-            val spec_node: *ast.Node = ast.get(store, spec_id);
-            val kind: u32 = ast.get_extra(store, spec_node.payload);
-            if (kind == 1) {
-                val expr_id: ast.NodeId = ast.get_extra(store, spec_node.payload + 2)::ast.NodeId;
-                if (expr_id::u32 != ast.NODE_NIL::u32) {
-                    args[arg_count] = expr_mod.lower_expr(ctx, expr_id, store);
-                    arg_count = arg_count + 1;
+    if (specs_count > 0) {
+        var si: u32 = 0;
+        for (si < specs_count && arg_count < 8) {
+            val spec_id: ast.NodeId = ast.get_extra(store, specs_start + si)::ast.NodeId;
+            if (spec_id::u32 != ast.NODE_NIL::u32) {
+                val spec_node: *ast.Node = ast.get(store, spec_id);
+                val kind: u32 = ast.get_extra(store, spec_node.payload);
+                if (kind == 1) {
+                    val expr_id: ast.NodeId = ast.get_extra(store, spec_node.payload + 2)::ast.NodeId;
+                    if (expr_id::u32 != ast.NODE_NIL::u32) {
+                        args[arg_count] = expr_mod.lower_expr(ctx, expr_id, store);
+                        arg_count = arg_count + 1;
+                    }
                 }
             }
+            si = si + 1;
         }
-        si = si + 1;
+    } or {
+        val asm_sid: ast.StrId = ast.get_extra(store, node.payload)::ast.StrId;
+        val text: str = ast.get_str(store, asm_sid);
+        if (text != nil) {
+            var names: [8]str;
+            var name_count: i32 = 0;
+            var i: usize = 0;
+            val len: usize = str_len(text);
+            for (i < len) {
+                val c: u8 = text[i];
+                if (c == '{' && i + 1 < len) {
+                    val start: usize = i + 1;
+                    var end: usize = start;
+                    for (end < len && text[end] != '}') { end = end + 1; }
+                    if (end > start && end < len && name_count < 8) {
+                        names[name_count] = (text::usize + start)::str;
+                        val nlen: usize = end - start;
+                        val interned: ast.StrId = ast.intern(store, names[name_count], nlen::u32);
+                        names[name_count] = ast.get_str(store, interned);
+                        name_count = name_count + 1;
+                    }
+                    i = end + 1;
+                } or {
+                    i = i + 1;
+                }
+            }
+            if (name_count > 0) { out_name = names[0]; }
+            var ni: i32 = 1;
+            for (ni < name_count && arg_count < 8) {
+                val lp: ir.ValueId = lctx.find_local(ctx, names[ni]);
+                if (lp::u32 != ir.VALUE_NONE::u32) {
+                    val tid: type.TypeId = type.TK_U64::type.TypeId;
+                    val ld_res: Result[ir.ValueId, str] = builder.build_load(?ctx.fb, tid, lp, loc);
+                    if (is_ok[ir.ValueId, str](ld_res)) {
+                        args[arg_count] = unwrap_ok[ir.ValueId, str](ld_res);
+                        arg_count = arg_count + 1;
+                    }
+                }
+                ni = ni + 1;
+            }
+        }
     }
 
     val ret_tid: type.TypeId = type.TK_I64::type.TypeId;
-    builder.build_syscall(?ctx.fb, ret_tid, ?args[0], arg_count, loc);
+    val sc_res: Result[ir.ValueId, str] = builder.build_syscall(?ctx.fb, ret_tid, ?args[0], arg_count, loc);
+
+    if (out_name != nil && is_ok[ir.ValueId, str](sc_res)) {
+        val sc_val: ir.ValueId = unwrap_ok[ir.ValueId, str](sc_res);
+        val out_ptr: ir.ValueId = lctx.find_local(ctx, out_name);
+        if (out_ptr::u32 != ir.VALUE_NONE::u32) {
+            builder.build_store(?ctx.fb, out_ptr, sc_val, loc);
+        }
+    }
 }
 
 fun lower_asm_atomic(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore,

--- a/src/compiler/parse/parser.mach
+++ b/src/compiler/parse/parser.mach
@@ -1418,7 +1418,16 @@ fun parse_prefix(p: *Parser) ast.NodeId {
     }
 
     if (tag == token.TAG_LIT_STRING) {
-        val text: ast.StrId = intern_token_text(p);
+        val tok: token.Token = current(p);
+        val raw: str = lexer.text(p.stream, tok);
+        val raw_len: u32 = tok.span.len::u32;
+        var text: ast.StrId = ast.STR_NIL;
+        if (raw != nil && raw_len >= 2 && raw[0] == '"') {
+            val inner: str = (raw::usize + 1)::str;
+            text = ast.intern(p.store, inner, raw_len - 2);
+        } or {
+            text = ast.intern(p.store, raw, raw_len);
+        }
         advance(p);
         val payload: u32 = ast.add_extra(p.store, text::u32);
         ret ast.add_node(p.store, ast.NK_EXPR_LIT_STR, start_tok, p.pos, payload);

--- a/src/compiler/regalloc.mach
+++ b/src/compiler/regalloc.mach
@@ -625,7 +625,7 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
     gp_free[i.frame_reg] = false;
 
     var callee_mask: u32 = 0;
-    var spill_offset: usize = 0;
+    var spill_offset: usize = local_size;
 
     var ri: i32 = 0;
     for (ri < range_count) {
@@ -841,7 +841,8 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
     allocator.deallocate[LiveRange](alloc, ranges, MAX_RANGES::usize);
 
     result.out         = out;
-    result.spill_size  = align_up(spill_offset, 16);
+    val pure_spill: usize = spill_offset - local_size;
+    result.spill_size  = align_up(pure_spill, 16);
     result.callee_mask = callee_mask;
     result.ok          = true;
     ret result;

--- a/src/compiler/sema/check.mach
+++ b/src/compiler/sema/check.mach
@@ -81,9 +81,11 @@ pub fun resolve_instantiation_bodies(s: *sema.Sema) {
                 if (m.node_syms.syms == nil) {
                     m.node_syms = st.init_node_syms(s.alloc, m.store.node_count);
                 }
-                resolve_inst_body(s, inst, ?m.store, ?m.expr_types, ?m.node_syms);
+                var inst_etm: st.ExprTypeMap = st.init_expr_types(s.alloc, m.store.node_count);
+                resolve_inst_body(s, inst, ?m.store, ?inst_etm, ?m.node_syms);
                 val inst_mut: *mono.FnInst = ?s.mono.fn_insts[i];
                 inst_mut.body_resolved = true;
+                inst_mut.inst_etm = inst_etm;
             }
             i = i + 1;
         }
@@ -311,6 +313,7 @@ fun resolve_inst_body_inner(s: *sema.Sema, inst: *mono.FnInst,
     val mod_id: module.ModuleId = inst.origin_module;
     val m: *module.Module = module.get(s.modules, mod_id);
     val fn_scope: scope.ScopeId = scope.create_scope(s.symbols, m.scope);
+    inst.scope_id = fn_scope::u32;
 
     val generics: ast.NodeId = ast.fun_generics(store, node_id);
     if (generics::u32 != ast.NODE_NIL::u32 && inst.type_arg_count > 0) {

--- a/src/compiler/sema/mono.mach
+++ b/src/compiler/sema/mono.mach
@@ -16,6 +16,7 @@ use mem:       std.memory;
 use ast:       mach.compiler.parse.ast;
 use type:      mach.compiler.sema.type;
 use module:    mach.compiler.sema.module;
+use st:        mach.compiler.sema.sidetable;
 
 val MAX_DEPTH:      u32 = 64;
 val INITIAL_FN_CAP: u32 = 16;
@@ -43,6 +44,8 @@ pub rec FnInst {
     type_arg_count: u32;
     origin_module:  module.ModuleId;
     body_resolved:  bool;
+    scope_id:       u32;
+    inst_etm:       st.ExprTypeMap;
 }
 
 # cache of monomorphized types and functions
@@ -163,6 +166,9 @@ pub fun register_fn(cache: *MonoCache, mangled: str,
     inst.type_arg_count = 0;
     inst.origin_module  = origin_module;
     inst.body_resolved  = false;
+    inst.scope_id       = 0;
+    inst.inst_etm.types = nil;
+    inst.inst_etm.count = 0;
 
     if (type_args != nil && type_arg_count > 0) {
         val res: Result[*type.TypeId, str] = allocator.allocate[type.TypeId](cache.alloc, type_arg_count::usize);

--- a/src/compiler/session.mach
+++ b/src/compiler/session.mach
@@ -309,6 +309,10 @@ pub fun compile_all(s: *Session, pr: *ParseResult, sr: *SemaResult, artifacts_di
 
         var mb: mir_builder.ModuleBuilder = mir_builder.module_init(s.alloc, ?sr.types);
         var mir_ctx: mir_lctx.LowerCtx = mir_lctx.init(s.alloc, ?sa, ?s.diag, ?mb);
+        mir_ctx.max_reg_ret = s.target.abi.max_reg_ret::u32;
+        if (i < sr.const_cap) {
+            mir_ctx.const_map = (?sr.const_maps[i])::ptr;
+        }
 
         mir_lower.lower_module(?mir_ctx, mod_id);
 

--- a/src/compiler/target/abi.mach
+++ b/src/compiler/target/abi.mach
@@ -26,6 +26,7 @@ pub val CLASS_BYREF: ParamClass = 4;
 pub rec ParamSlot {
     class:  ParamClass;
     reg:    i32;
+    reg2:   i32;
     offset: i64;
     size:   usize;
 }
@@ -55,4 +56,7 @@ pub rec ABI {
     stack_align:     fun(ptr) usize;
     red_zone:        fun(ptr) usize;
     init_va_list:    fun(ptr, ptr);
+    va_save_size:    fun(ptr) usize;
+    emit_va_save:    fun(ptr, *isa.InstBuf, i32, i64);
+    max_reg_ret:     usize;
 }

--- a/src/compiler/target/abi/sysv64.mach
+++ b/src/compiler/target/abi/sysv64.mach
@@ -66,6 +66,9 @@ pub fun init(alloc: *allocator.Allocator) abi.ABI {
     a.stack_align     = sysv_stack_align;
     a.red_zone        = sysv_red_zone;
     a.init_va_list    = sysv_init_va_list;
+    a.va_save_size    = sysv_va_save_size;
+    a.emit_va_save    = sysv_emit_va_save;
+    a.max_reg_ret     = MAX_GP_CLASS_SIZE;
     ret a;
 }
 
@@ -136,6 +139,7 @@ fun sysv_classify_param(ctx: ptr, index: i32, size: usize, align: usize,
     var slot: abi.ParamSlot;
     slot.offset = 0;
     slot.size   = size;
+    slot.reg2   = -1;
 
     if (is_aggregate && size > MAX_GP_CLASS_SIZE) {
         slot.class = abi.CLASS_BYREF;
@@ -196,6 +200,7 @@ fun sysv_classify_return(ctx: ptr, size: usize, align: usize,
     var slot: abi.ParamSlot;
     slot.offset = 0;
     slot.size   = size;
+    slot.reg2   = -1;
 
     if (size == 0) {
         slot.class = abi.CLASS_GP;
@@ -218,6 +223,7 @@ fun sysv_classify_return(ctx: ptr, size: usize, align: usize,
         }
         slot.class = abi.CLASS_GP;
         slot.reg   = defs.RAX;
+        slot.reg2  = defs.RDX;
         ret slot;
     }
 
@@ -313,4 +319,11 @@ fun sysv_init_va_list(ctx: ptr, type_table: ptr) {
     fields[3].offset  = 16;
 
     type.register_va_list(table, fields, 4, 24, 8);
+}
+
+fun sysv_va_save_size(ctx: ptr) usize {
+    ret GP_PARAM_COUNT::usize * 8;
+}
+
+fun sysv_emit_va_save(ctx: ptr, buf: *isa.InstBuf, frame_reg: i32, save_off: i64) {
 }

--- a/src/compiler/target/abi/sysv64.mach
+++ b/src/compiler/target/abi/sysv64.mach
@@ -326,4 +326,27 @@ fun sysv_va_save_size(ctx: ptr) usize {
 }
 
 fun sysv_emit_va_save(ctx: ptr, buf: *isa.InstBuf, frame_reg: i32, save_off: i64) {
+    var gp_regs: [6]i32;
+    gp_regs[0] = defs.RDI;
+    gp_regs[1] = defs.RSI;
+    gp_regs[2] = defs.RDX;
+    gp_regs[3] = defs.RCX;
+    gp_regs[4] = defs.R8;
+    gp_regs[5] = defs.R9;
+
+    var i: i32 = 0;
+    for (i < GP_PARAM_COUNT) {
+        var mi: isa.Inst;
+        mi.clobbers = 0;
+        mi.opcode   = defs.MOV;
+        mi.dst      = isa.make_mem(frame_reg, (save_off + i::i64 * 8)::i32, -1, 0, 8);
+        mi.src1     = isa.make_reg(gp_regs[i], 8);
+        mi.src2.kind = 0;
+        mi.size     = 8;
+        mi.flags    = defs.FLAG_REX_W;
+        mi.src_line = 0;
+        mi.src_file = nil;
+        isa.buf_append(buf, mi);
+        i = i + 1;
+    }
 }

--- a/src/compiler/target/isa/x86_64/defs.mach
+++ b/src/compiler/target/isa/x86_64/defs.mach
@@ -131,6 +131,7 @@ pub val FLAG_16BIT:    EncFlag = 2;
 pub val FLAG_LOCK:     EncFlag = 4;
 pub val FLAG_REP:      EncFlag = 8;
 pub val FLAG_INDIRECT: EncFlag = 16;
+pub val FLAG_REX_BYTE: EncFlag = 32;
 
 pub rec X86Context {
     alloc:   *allocator.Allocator;

--- a/src/compiler/target/isa/x86_64/encode.mach
+++ b/src/compiler/target/isa/x86_64/encode.mach
@@ -61,6 +61,17 @@ fun needs_rex(id: i32) bool {
     ret id >= 8 && id <= 15;
 }
 
+fun needs_rex_byte(id: i32) bool {
+    ret id >= 4 && id <= 15;
+}
+
+fun emit_rex_for_byte(sec: *of.Section, alloc: *allocator.Allocator,
+                      reg: i32, rm: i32) {
+    if (needs_rex_byte(reg) || needs_rex_byte(rm)) {
+        emit_byte(sec, alloc, encode_rex(0, reg, rm));
+    }
+}
+
 # encode_rex: build a REX prefix byte
 # ---
 # w:   1 for 64-bit operand size
@@ -222,7 +233,11 @@ fun encode_alu_rr(sec: *of.Section, alloc: *allocator.Allocator,
                   opcode: u8, dst: i32, src: i32, size: u8, flags: u16) {
     val w: u8 = size_to_w(size, flags);
     if ((flags & defs.FLAG_16BIT::u16) != 0) { emit_byte(sec, alloc, 0x66); }
-    emit_rex_if_needed(sec, alloc, w, src, dst);
+    if ((flags & defs.FLAG_REX_BYTE::u16) != 0) {
+        emit_byte(sec, alloc, encode_rex(0, src, dst));
+    } or {
+        emit_rex_if_needed(sec, alloc, w, src, dst);
+    }
     emit_byte(sec, alloc, opcode);
     emit_byte(sec, alloc, encode_modrm(3, reg_bits(src), reg_bits(dst)));
 }
@@ -242,7 +257,11 @@ fun encode_alu_imm(sec: *of.Section, alloc: *allocator.Allocator,
                    group: u8, reg: i32, imm: i64, size: u8, flags: u16) {
     val w: u8 = size_to_w(size, flags);
     if ((flags & defs.FLAG_16BIT::u16) != 0) { emit_byte(sec, alloc, 0x66); }
-    emit_rex_if_needed(sec, alloc, w, 0, reg);
+    if ((flags & defs.FLAG_REX_BYTE::u16) != 0) {
+        emit_byte(sec, alloc, encode_rex(0, 0, reg));
+    } or {
+        emit_rex_if_needed(sec, alloc, w, 0, reg);
+    }
 
     if (imm >= -128 && imm <= 127 && size > 1) {
         emit_byte(sec, alloc, 0x83);
@@ -341,7 +360,11 @@ fun encode_mov(mi: *isa.Inst, sec: *of.Section, alloc: *allocator.Allocator) i32
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG) {
         val w: u8 = size_to_w(size, flags);
         if ((flags & defs.FLAG_16BIT::u16) != 0) { emit_byte(sec, alloc, 0x66); }
-        emit_rex_if_needed(sec, alloc, w, src1.reg, dst.reg);
+        if ((flags & defs.FLAG_REX_BYTE::u16) != 0) {
+            emit_byte(sec, alloc, encode_rex(0, src1.reg, dst.reg));
+        } or {
+            emit_rex_if_needed(sec, alloc, w, src1.reg, dst.reg);
+        }
         if (size == 1) {
             emit_byte(sec, alloc, 0x88);
         } or {
@@ -356,7 +379,7 @@ fun encode_mov(mi: *isa.Inst, sec: *of.Section, alloc: *allocator.Allocator) i32
         val imm: i64 = src1.imm;
         if ((flags & defs.FLAG_16BIT::u16) != 0) { emit_byte(sec, alloc, 0x66); }
         if (size == 1) {
-            if (needs_rex(dst.reg)) {
+            if (needs_rex_byte(dst.reg)) {
                 emit_byte(sec, alloc, encode_rex(0, 0, dst.reg));
             }
             emit_byte(sec, alloc, 0xB0 + reg_bits(dst.reg));
@@ -387,7 +410,11 @@ fun encode_mov(mi: *isa.Inst, sec: *of.Section, alloc: *allocator.Allocator) i32
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_MEM) {
         val w: u8 = size_to_w(size, flags);
         if ((flags & defs.FLAG_16BIT::u16) != 0) { emit_byte(sec, alloc, 0x66); }
-        emit_rex_mem(sec, alloc, w, dst.reg, src1);
+        if ((flags & defs.FLAG_REX_BYTE::u16) != 0) {
+            emit_rex_mem(sec, alloc, 0, dst.reg, src1);
+        } or {
+            emit_rex_mem(sec, alloc, w, dst.reg, src1);
+        }
         if (size == 1) {
             emit_byte(sec, alloc, 0x8A);
         } or {
@@ -400,7 +427,11 @@ fun encode_mov(mi: *isa.Inst, sec: *of.Section, alloc: *allocator.Allocator) i32
     if (dst.kind == isa.OPK_MEM && src1.kind == isa.OPK_REG) {
         val w: u8 = size_to_w(size, flags);
         if ((flags & defs.FLAG_16BIT::u16) != 0) { emit_byte(sec, alloc, 0x66); }
-        emit_rex_mem(sec, alloc, w, src1.reg, dst);
+        if ((flags & defs.FLAG_REX_BYTE::u16) != 0) {
+            emit_rex_mem(sec, alloc, 0, src1.reg, dst);
+        } or {
+            emit_rex_mem(sec, alloc, w, src1.reg, dst);
+        }
         if (size == 1) {
             emit_byte(sec, alloc, 0x88);
         } or {
@@ -560,7 +591,11 @@ fun encode_test(mi: *isa.Inst, sec: *of.Section, alloc: *allocator.Allocator) i3
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG) {
         val w: u8 = size_to_w(size, flags);
         if ((flags & defs.FLAG_16BIT::u16) != 0) { emit_byte(sec, alloc, 0x66); }
-        emit_rex_if_needed(sec, alloc, w, src1.reg, dst.reg);
+        if ((flags & defs.FLAG_REX_BYTE::u16) != 0) {
+            emit_byte(sec, alloc, encode_rex(0, src1.reg, dst.reg));
+        } or {
+            emit_rex_if_needed(sec, alloc, w, src1.reg, dst.reg);
+        }
         if (size == 1) {
             emit_byte(sec, alloc, 0x84);
         } or {
@@ -573,7 +608,11 @@ fun encode_test(mi: *isa.Inst, sec: *of.Section, alloc: *allocator.Allocator) i3
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_IMM) {
         val w: u8 = size_to_w(size, flags);
         if ((flags & defs.FLAG_16BIT::u16) != 0) { emit_byte(sec, alloc, 0x66); }
-        emit_rex_if_needed(sec, alloc, w, 0, dst.reg);
+        if ((flags & defs.FLAG_REX_BYTE::u16) != 0) {
+            emit_byte(sec, alloc, encode_rex(0, 0, dst.reg));
+        } or {
+            emit_rex_if_needed(sec, alloc, w, 0, dst.reg);
+        }
         if (size == 1) {
             emit_byte(sec, alloc, 0xF6);
             emit_byte(sec, alloc, encode_modrm(3, 0, reg_bits(dst.reg)));

--- a/src/compiler/target/isa/x86_64/encode.mach
+++ b/src/compiler/target/isa/x86_64/encode.mach
@@ -411,7 +411,7 @@ fun encode_mov(mi: *isa.Inst, sec: *of.Section, alloc: *allocator.Allocator) i32
         val w: u8 = size_to_w(size, flags);
         if ((flags & defs.FLAG_16BIT::u16) != 0) { emit_byte(sec, alloc, 0x66); }
         if ((flags & defs.FLAG_REX_BYTE::u16) != 0) {
-            emit_rex_mem(sec, alloc, 0, dst.reg, src1);
+            emit_byte(sec, alloc, encode_rex(0, dst.reg, src1.base));
         } or {
             emit_rex_mem(sec, alloc, w, dst.reg, src1);
         }
@@ -428,7 +428,7 @@ fun encode_mov(mi: *isa.Inst, sec: *of.Section, alloc: *allocator.Allocator) i32
         val w: u8 = size_to_w(size, flags);
         if ((flags & defs.FLAG_16BIT::u16) != 0) { emit_byte(sec, alloc, 0x66); }
         if ((flags & defs.FLAG_REX_BYTE::u16) != 0) {
-            emit_rex_mem(sec, alloc, 0, src1.reg, dst);
+            emit_byte(sec, alloc, encode_rex(0, src1.reg, dst.base));
         } or {
             emit_rex_mem(sec, alloc, w, src1.reg, dst);
         }

--- a/src/compiler/target/isa/x86_64/encode.mach
+++ b/src/compiler/target/isa/x86_64/encode.mach
@@ -1424,6 +1424,9 @@ pub fun x86_reloc_offset(ctx: ptr, mi: *isa.Inst, inst_size: i32) i32 {
     if (mi.dst.kind == isa.OPK_LABEL) {
         ret inst_size - 4;
     }
+    if (mi.src1.kind == isa.OPK_LABEL) {
+        ret inst_size - 4;
+    }
     ret -1;
 }
 

--- a/src/compiler/target/isa/x86_64/isel.mach
+++ b/src/compiler/target/isa/x86_64/isel.mach
@@ -451,9 +451,39 @@ fun sel_copy(func: *ir.Function, inst: *ir.Inst, out: *isa.InstBuf, line: u32, f
     val src_ptr: ir.ValueId = ir.inst_arg(func, inst, 1);
     val byte_count: u64 = inst.imm;
 
-    emit_rr(out, x86.MOV, x86.RDI, vreg(dst_ptr), 8, line, file);
-    emit_rr(out, x86.MOV, x86.RSI, vreg(src_ptr), 8, line, file);
     emit_ri(out, x86.MOV, x86.RCX, byte_count::i64, 8, line, file);
+
+    var pc1: isa.Inst;
+    pc1.clobbers  = 0;
+    pc1.opcode    = isa.ISA_PCOPY;
+    pc1.dst       = isa.make_reg(x86.RDI, 8);
+    pc1.src1      = isa.make_reg(vreg(dst_ptr), 8);
+    pc1.src2.kind = 0;
+    pc1.size      = 8;
+    pc1.flags     = 0;
+    pc1.src_line  = line;
+    pc1.src_file  = file;
+    isa.buf_append(out, pc1);
+
+    var pc2: isa.Inst;
+    pc2.clobbers  = 0;
+    pc2.opcode    = isa.ISA_PCOPY;
+    pc2.dst       = isa.make_reg(x86.RSI, 8);
+    pc2.src1      = isa.make_reg(vreg(src_ptr), 8);
+    pc2.src2.kind = 0;
+    pc2.size      = 8;
+    pc2.flags     = 0;
+    pc2.src_line  = line;
+    pc2.src_file  = file;
+    isa.buf_append(out, pc2);
+
+    var fence: isa.Inst;
+    fence.clobbers = 0;
+    fence.opcode = isa.ISA_PCOPY_FENCE;
+    fence.dst.kind = 0; fence.src1.kind = 0; fence.src2.kind = 0;
+    fence.size = 0; fence.flags = 0;
+    fence.src_line = line; fence.src_file = file;
+    isa.buf_append(out, fence);
 
     var mi: isa.Inst;
     mi.clobbers = (1::u32 << x86.RCX::u32) | (1::u32 << x86.RSI::u32) | (1::u32 << x86.RDI::u32);

--- a/src/compiler/target/isa/x86_64/isel.mach
+++ b/src/compiler/target/isa/x86_64/isel.mach
@@ -278,8 +278,13 @@ fun select_inst(func: *ir.Function, module: *ir.Module, tgt: *target.Target,
         ret;
     }
 
-    if (o == op.OP_VA_START || o == op.OP_VA_ARG) {
-        emit_ri(out, x86.UD2, 0, 0, 1, line, file);
+    if (o == op.OP_VA_START) {
+        sel_va_start(func, inst, layout, tgt, out, line, file);
+        ret;
+    }
+
+    if (o == op.OP_VA_ARG) {
+        sel_va_arg(func, inst, tgt, out, sz, line, file);
         ret;
     }
 
@@ -864,6 +869,51 @@ fun sel_itof(func: *ir.Function, inst: *ir.Inst, out: *isa.InstBuf, sz: u8, line
     var opc: u16 = x86.CVTSI2SS;
     if (is_d) { opc = x86.CVTSI2SD; }
     emit_rr(out, opc, dst, src, sz, line, file);
+}
+
+fun sel_va_start(func: *ir.Function, inst: *ir.Inst, layout: *frame.FrameLayout,
+                 tgt: *target.Target, out: *isa.InstBuf, line: u32, file: str) {
+    val va_ptr: i32 = vreg(ir.inst_arg(func, inst, 0));
+    val named_count: u64 = inst.imm;
+    val gp_offset: i32 = named_count::i32 * 8;
+
+    emit_ri(out, x86.MOV, tgt.isa.scratch_reg, gp_offset::i64, 4, line, file);
+    emit_store(out, va_ptr, 0, tgt.isa.scratch_reg, 4, line, file);
+
+    emit_ri(out, x86.MOV, tgt.isa.scratch_reg, 48, 4, line, file);
+    emit_store(out, va_ptr, 4, tgt.isa.scratch_reg, 4, line, file);
+
+    emit_lea(out, tgt.isa.scratch_reg, FP_REG, 16, line, file);
+    emit_store(out, va_ptr, 8, tgt.isa.scratch_reg, 8, line, file);
+
+    emit_lea(out, tgt.isa.scratch_reg, FP_REG, layout.va_save_off::i32, line, file);
+    emit_store(out, va_ptr, 16, tgt.isa.scratch_reg, 8, line, file);
+}
+
+fun sel_va_arg(func: *ir.Function, inst: *ir.Inst, tgt: *target.Target,
+               out: *isa.InstBuf, sz: u8, line: u32, file: str) {
+    val dst: i32 = vreg(inst.result);
+    val va_ptr: i32 = vreg(ir.inst_arg(func, inst, 0));
+
+    emit_load(out, tgt.isa.scratch_reg, va_ptr, 0, 4, line, file);
+    emit_load(out, dst, va_ptr, 16, 8, line, file);
+
+    var mi: isa.Inst;
+    mi.clobbers = 0;
+    mi.opcode   = x86.LEA;
+    mi.dst      = isa.make_reg(dst, 8);
+    mi.src1     = isa.make_mem(dst, 0, tgt.isa.scratch_reg, 1, 8);
+    mi.src2.kind = 0;
+    mi.size     = 8;
+    mi.flags    = x86.FLAG_REX_W;
+    mi.src_line = line;
+    mi.src_file = file;
+    isa.buf_append(out, mi);
+
+    emit_load(out, dst, dst, 0, sz, line, file);
+
+    emit_ri(out, x86.ADD, tgt.isa.scratch_reg, 8, 4, line, file);
+    emit_store(out, va_ptr, 0, tgt.isa.scratch_reg, 4, line, file);
 }
 
 fun sel_ftoi(func: *ir.Function, inst: *ir.Inst, out: *isa.InstBuf, sz: u8, line: u32, file: str) {

--- a/src/compiler/target/isa/x86_64/isel.mach
+++ b/src/compiler/target/isa/x86_64/isel.mach
@@ -72,6 +72,7 @@ fun emit_rr_ext(out: *isa.InstBuf, opc: u16, dst: i32, src: i32, dst_sz: u8, src
     mi.size     = dst_sz;
     mi.flags    = 0;
     if (dst_sz == 8) { mi.flags = x86.FLAG_REX_W; }
+    if (dst_sz == 1 && (dst >= 4 || src >= 4)) { mi.flags = mi.flags | x86.FLAG_REX_BYTE; }
     mi.src_line = line;
     mi.src_file = file;
     isa.buf_append(out, mi);
@@ -87,6 +88,7 @@ fun emit_rr(out: *isa.InstBuf, opc: u16, dst: i32, src: i32, sz: u8, line: u32, 
     mi.size     = sz;
     mi.flags    = 0;
     if (sz == 8) { mi.flags = x86.FLAG_REX_W; }
+    if (sz == 1 && (dst >= 4 || src >= 4)) { mi.flags = mi.flags | x86.FLAG_REX_BYTE; }
     mi.src_line = line;
     mi.src_file = file;
     isa.buf_append(out, mi);
@@ -103,6 +105,7 @@ fun emit_ri(out: *isa.InstBuf, opc: u16, dst: i32, imm: i64, sz: u8, line: u32, 
     mi.size     = sz;
     mi.flags    = 0;
     if (sz == 8) { mi.flags = x86.FLAG_REX_W; }
+    if (sz == 1 && dst >= 4) { mi.flags = mi.flags | x86.FLAG_REX_BYTE; }
     mi.src_line = line;
     mi.src_file = file;
     isa.buf_append(out, mi);
@@ -119,6 +122,7 @@ fun emit_load(out: *isa.InstBuf, dst: i32, base: i32, disp: i32, sz: u8, line: u
     mi.size     = sz;
     mi.flags    = 0;
     if (sz == 8) { mi.flags = x86.FLAG_REX_W; }
+    if (sz == 1 && dst >= 4) { mi.flags = mi.flags | x86.FLAG_REX_BYTE; }
     mi.src_line = line;
     mi.src_file = file;
     isa.buf_append(out, mi);
@@ -135,12 +139,27 @@ fun emit_store(out: *isa.InstBuf, base: i32, disp: i32, src: i32, sz: u8, line: 
     mi.size     = sz;
     mi.flags    = 0;
     if (sz == 8) { mi.flags = x86.FLAG_REX_W; }
+    if (sz == 1 && src >= 4) { mi.flags = mi.flags | x86.FLAG_REX_BYTE; }
     mi.src_line = line;
     mi.src_file = file;
     isa.buf_append(out, mi);
 }
 
 # emit a register-register-register ALU instruction (dst = src1 op src2)
+fun emit_lea(out: *isa.InstBuf, dst: i32, base: i32, disp: i32, line: u32, file: str) {
+    var mi: isa.Inst;
+    mi.clobbers = 0;
+    mi.opcode   = x86.LEA;
+    mi.dst      = isa.make_reg(dst, 8);
+    mi.src1     = isa.make_mem(base, disp, -1, 0, 8);
+    mi.src2.kind = 0;
+    mi.size     = 8;
+    mi.flags    = x86.FLAG_REX_W;
+    mi.src_line = line;
+    mi.src_file = file;
+    isa.buf_append(out, mi);
+}
+
 fun emit_alu(out: *isa.InstBuf, opc: u16, dst: i32, src1: i32, src2: i32, sz: u8, line: u32, file: str) {
     if (dst != src1) { emit_rr(out, x86.MOV, dst, src1, sz, line, file); }
     emit_rr(out, opc, dst, src2, sz, line, file);
@@ -225,8 +244,8 @@ fun select_inst(func: *ir.Function, module: *ir.Module, tgt: *target.Target,
 
     if (o == op.OP_BR)         { sel_br(func, inst, out, line, file); ret; }
     if (o == op.OP_COND_BR)    { sel_cond_br(func, inst, out, line, file); ret; }
-    if (o == op.OP_CALL)       { sel_call(func, inst, tgt, out, line, file); ret; }
-    if (o == op.OP_RET)        { sel_ret(func, inst, tgt, out, sz, line, file); ret; }
+    if (o == op.OP_CALL)       { sel_call(func, inst, tgt, layout, out, line, file); ret; }
+    if (o == op.OP_RET)        { sel_ret(func, inst, tgt, layout, out, sz, line, file); ret; }
     if (o == op.OP_UNREACHABLE) { emit_ri(out, x86.UD2, 0, 0, 1, line, file); ret; }
 
     if (o == op.OP_ZEXT || o == op.OP_SEXT || o == op.OP_TRUNC ||
@@ -242,7 +261,7 @@ fun select_inst(func: *ir.Function, module: *ir.Module, tgt: *target.Target,
     if (o == op.OP_FEXT)    { sel_fext(func, inst, out, sz, line, file); ret; }
     if (o == op.OP_FTRUNC)  { sel_ftrunc(func, inst, out, sz, line, file); ret; }
 
-    if (o == op.OP_CALL_INDIRECT) { sel_call_indirect(func, inst, tgt, out, line, file); ret; }
+    if (o == op.OP_CALL_INDIRECT) { sel_call_indirect(func, inst, tgt, layout, out, line, file); ret; }
 
     if (o == op.OP_ATOMIC_LOAD || o == op.OP_ATOMIC_STORE ||
         o == op.OP_ATOMIC_CAS || o == op.OP_ATOMIC_RMW) {
@@ -398,18 +417,28 @@ fun sel_index_ptr(func: *ir.Function, inst: *ir.Inst, out: *isa.InstBuf, line: u
     val idx_val: ir.ValueId = ir.inst_arg(func, inst, 1);
     val base: i32 = vreg(base_val);
     val index: i32 = vreg(idx_val);
+    val elem_sz: u64 = inst.imm;
 
-    var mi: isa.Inst;
-    mi.clobbers = 0;
-    mi.opcode   = x86.LEA;
-    mi.dst      = isa.make_reg(dst, 8);
-    mi.src1     = isa.make_mem(base, 0, index, 1, 8);
-    mi.src2.kind = 0;
-    mi.size     = 8;
-    mi.flags    = x86.FLAG_REX_W;
-    mi.src_line = line;
-    mi.src_file = file;
-    isa.buf_append(out, mi);
+    var scale: i32 = elem_sz::i32;
+    if (scale == 0) { scale = 1; }
+
+    if (scale == 1 || scale == 2 || scale == 4 || scale == 8) {
+        var mi: isa.Inst;
+        mi.clobbers = 0;
+        mi.opcode   = x86.LEA;
+        mi.dst      = isa.make_reg(dst, 8);
+        mi.src1     = isa.make_mem(base, 0, index, scale::u8, 8);
+        mi.src2.kind = 0;
+        mi.size     = 8;
+        mi.flags    = x86.FLAG_REX_W;
+        mi.src_line = line;
+        mi.src_file = file;
+        isa.buf_append(out, mi);
+    } or {
+        emit_rr(out, x86.MOV, dst, index, 8, line, file);
+        emit_ri(out, x86.IMUL, dst, scale::i64, 8, line, file);
+        emit_rr(out, x86.ADD, dst, base, 8, line, file);
+    }
 }
 
 fun sel_copy(func: *ir.Function, inst: *ir.Inst, out: *isa.InstBuf, line: u32, file: str) {
@@ -688,7 +717,7 @@ fun sel_cond_br(func: *ir.Function, inst: *ir.Inst, out: *isa.InstBuf, line: u32
     }
 }
 
-fun sel_call(func: *ir.Function, inst: *ir.Inst, tgt: *target.Target, out: *isa.InstBuf, line: u32, file: str) {
+fun sel_call(func: *ir.Function, inst: *ir.Inst, tgt: *target.Target, layout: *frame.FrameLayout, out: *isa.InstBuf, line: u32, file: str) {
     val gp_regs: isa.RegisterFile = tgt.abi.gp_param_regs(tgt.abi.ctx);
 
     var stack_args: i32 = inst.arg_count::i32 - gp_regs.count;
@@ -768,17 +797,50 @@ fun sel_call(func: *ir.Function, inst: *ir.Inst, tgt: *target.Target, out: *isa.
     }
 
     if (inst.result::u32 != ir.VALUE_NONE::u32) {
-        val ret_slot: abi.ParamSlot = tgt.abi.classify_return(tgt.abi.ctx, 8, 8, false, false);
-        emit_rr(out, x86.MOV, vreg(inst.result), ret_slot.reg, 8, line, file);
+        val agg_sz: u16 = inst.flags;
+        val is_agg: bool = agg_sz > 0;
+        var ret_size: usize = agg_sz::usize;
+        if (!is_agg) { ret_size = 8; }
+        val ret_slot: abi.ParamSlot = tgt.abi.classify_return(
+            tgt.abi.ctx, ret_size, 8, false, is_agg
+        );
+        if (ret_slot.class == abi.CLASS_SRET) {
+            emit_rr(out, x86.MOV, vreg(inst.result), ret_slot.reg, 8, line, file);
+        } or (ret_slot.reg2 >= 0) {
+            val off: i64 = frame.slot_offset(layout, inst.result);
+            emit_store(out, FP_REG, off::i32, ret_slot.reg, 8, line, file);
+            emit_store(out, FP_REG, (off + 8)::i32, ret_slot.reg2, 8, line, file);
+            emit_lea(out, vreg(inst.result), FP_REG, off::i32, line, file);
+        } or {
+            emit_rr(out, x86.MOV, vreg(inst.result), ret_slot.reg, 8, line, file);
+        }
     }
 }
 
-fun sel_ret(func: *ir.Function, inst: *ir.Inst, tgt: *target.Target, out: *isa.InstBuf, sz: u8, line: u32, file: str) {
+fun sel_ret(func: *ir.Function, inst: *ir.Inst, tgt: *target.Target, layout: *frame.FrameLayout, out: *isa.InstBuf, sz: u8, line: u32, file: str) {
+    val ret_agg_sz: u16 = inst.flags;
     if (inst.arg_count > 0) {
         val ret_val: ir.ValueId = ir.inst_arg(func, inst, 0);
         if (ret_val::u32 != ir.VALUE_NONE::u32) {
-            val ret_slot: abi.ParamSlot = tgt.abi.classify_return(tgt.abi.ctx, 8, 8, false, false);
-            emit_rr(out, x86.MOV, ret_slot.reg, vreg(ret_val), 8, line, file);
+            var real_sz: usize = sz::usize;
+            val is_agg: bool = ret_agg_sz > 0;
+            if (is_agg && ret_agg_sz::usize > real_sz) { real_sz = ret_agg_sz::usize; }
+            val ret_slot: abi.ParamSlot = tgt.abi.classify_return(
+                tgt.abi.ctx, real_sz, 8, false, is_agg
+            );
+            if (ret_slot.reg2 >= 0) {
+                if (frame.is_alloca(layout, ret_val)) {
+                    val off: i64 = frame.slot_offset(layout, ret_val);
+                    emit_load(out, ret_slot.reg, FP_REG, off::i32, 8, line, file);
+                    emit_load(out, ret_slot.reg2, FP_REG, (off + 8)::i32, 8, line, file);
+                } or {
+                    emit_rr(out, x86.MOV, tgt.isa.scratch_reg, vreg(ret_val), 8, line, file);
+                    emit_load(out, ret_slot.reg, tgt.isa.scratch_reg, 0, 8, line, file);
+                    emit_load(out, ret_slot.reg2, tgt.isa.scratch_reg, 8, 8, line, file);
+                }
+            } or {
+                emit_rr(out, x86.MOV, ret_slot.reg, vreg(ret_val), sz, line, file);
+            }
         }
     }
 
@@ -825,7 +887,7 @@ fun sel_ftrunc(func: *ir.Function, inst: *ir.Inst, out: *isa.InstBuf, sz: u8, li
     emit_rr(out, x86.CVTSD2SS, dst, src, sz, line, file);
 }
 
-fun sel_call_indirect(func: *ir.Function, inst: *ir.Inst, tgt: *target.Target, out: *isa.InstBuf, line: u32, file: str) {
+fun sel_call_indirect(func: *ir.Function, inst: *ir.Inst, tgt: *target.Target, layout: *frame.FrameLayout, out: *isa.InstBuf, line: u32, file: str) {
     val callee: i32 = vreg(ir.inst_arg(func, inst, 0));
     val gp_regs: isa.RegisterFile = tgt.abi.gp_param_regs(tgt.abi.ctx);
 
@@ -903,8 +965,23 @@ fun sel_call_indirect(func: *ir.Function, inst: *ir.Inst, tgt: *target.Target, o
     }
 
     if (inst.result::u32 != ir.VALUE_NONE::u32) {
-        val ret_slot: abi.ParamSlot = tgt.abi.classify_return(tgt.abi.ctx, 8, 8, false, false);
-        emit_rr(out, x86.MOV, vreg(inst.result), ret_slot.reg, 8, line, file);
+        val agg_sz: u16 = inst.flags;
+        val is_agg: bool = agg_sz > 0;
+        var ret_size: usize = agg_sz::usize;
+        if (!is_agg) { ret_size = 8; }
+        val ret_slot: abi.ParamSlot = tgt.abi.classify_return(
+            tgt.abi.ctx, ret_size, 8, false, is_agg
+        );
+        if (ret_slot.class == abi.CLASS_SRET) {
+            emit_rr(out, x86.MOV, vreg(inst.result), ret_slot.reg, 8, line, file);
+        } or (ret_slot.reg2 >= 0) {
+            val off: i64 = frame.slot_offset(layout, inst.result);
+            emit_store(out, FP_REG, off::i32, ret_slot.reg, 8, line, file);
+            emit_store(out, FP_REG, (off + 8)::i32, ret_slot.reg2, 8, line, file);
+            emit_lea(out, vreg(inst.result), FP_REG, off::i32, line, file);
+        } or {
+            emit_rr(out, x86.MOV, vreg(inst.result), ret_slot.reg, 8, line, file);
+        }
     }
 }
 

--- a/src/compiler/target/isa/x86_64/isel.mach
+++ b/src/compiler/target/isa/x86_64/isel.mach
@@ -873,6 +873,13 @@ fun sel_ret(func: *ir.Function, inst: *ir.Inst, tgt: *target.Target, layout: *fr
                     emit_load(out, ret_slot.reg, tgt.isa.scratch_reg, 0, 8, line, file);
                     emit_load(out, ret_slot.reg2, tgt.isa.scratch_reg, 8, 8, line, file);
                 }
+            } or (is_agg) {
+                if (frame.is_alloca(layout, ret_val)) {
+                    val off: i64 = frame.slot_offset(layout, ret_val);
+                    emit_load(out, ret_slot.reg, FP_REG, off::i32, ret_agg_sz::u8, line, file);
+                } or {
+                    emit_load(out, ret_slot.reg, vreg(ret_val), 0, ret_agg_sz::u8, line, file);
+                }
             } or {
                 emit_rr(out, x86.MOV, ret_slot.reg, vreg(ret_val), sz, line, file);
             }


### PR DESCRIPTION
## Summary
- 17 commits of codegen fixes building on the merged #854 work
- Compiler now boots, runs commands, reads mach.toml
- Remaining issues tracked in #855

## Changes
- Index scaling, field byte offsets, function refs as values
- VA_START/VA_ARG implementation, syscall inline arg parsing
- REX byte prefix for mem operands, global consteval data wiring
- sel_copy PCOPY for rep movsb, two-register return fixes
- fn_tid resolution via scope lookup, variadic detection via has_va_start
- Small aggregate return loads, param_count tracking

## Test plan
- [x] cmach→imach→smach builds successfully
- [x] smach boots, dispatches commands, prints formatted help text
- [x] mach.toml opens, fstats, and reads correctly
- [ ] Full bootstrap (blocked by #855)

🤖 Generated with [Claude Code](https://claude.com/claude-code)