### PR TITLE
fix: spilled destination register rewrite + workaround cleanup

### DIFF
--- a/src/compiler/regalloc.mach
+++ b/src/compiler/regalloc.mach
@@ -289,7 +289,6 @@ fun is_callee_saved(a: *abi.ABI, preg: i32) bool {
 
 # is_reserved: check if a register should not be allocated (stack/frame pointer)
 fun is_reserved(i: *isa.ISA, preg: i32) bool {
-    if (preg == 4 || preg == 5) { ret true; }
     if (preg == i.stack_reg) { ret true; }
     if (preg == i.frame_reg) { ret true; }
     if (preg == i.scratch_reg) { ret true; }
@@ -624,8 +623,6 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
         fp_free[fi] = true;
         fi = fi + 1;
     }
-    gp_free[4] = false;
-    gp_free[5] = false;
     gp_free[i.stack_reg] = false;
     gp_free[i.frame_reg] = false;
     gp_free[i.scratch_reg] = false;
@@ -819,6 +816,10 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
             inst.src2 = isa.make_reg(s2_preg, spill_s2_size);
         }
 
+        if (has_spill_dst) {
+            inst.dst = isa.make_reg(i.scratch_reg, spill_dst_size);
+        }
+
         rewrite_operand(i, ?inst.dst, ranges, range_count);
         rewrite_operand(i, ?inst.src1, ranges, range_count);
         rewrite_operand(i, ?inst.src2, ranges, range_count);
@@ -829,7 +830,7 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
             spill.clobbers = 0;
             spill.opcode = i.store_opcode;
             spill.dst = isa.make_mem(i.frame_reg, (-(spill_dst_off::i32))::i32, -1, 0, spill_dst_size);
-            spill.src1 = inst.dst;
+            spill.src1 = isa.make_reg(i.scratch_reg, spill_dst_size);
             spill.src2 = isa.make_reg(-1, 0);
             spill.size = spill_dst_size;
             spill.flags = 0;

--- a/src/compiler/regalloc.mach
+++ b/src/compiler/regalloc.mach
@@ -289,6 +289,7 @@ fun is_callee_saved(a: *abi.ABI, preg: i32) bool {
 
 # is_reserved: check if a register should not be allocated (stack/frame pointer)
 fun is_reserved(i: *isa.ISA, preg: i32) bool {
+    if (preg == 4 || preg == 5) { ret true; }
     if (preg == i.stack_reg) { ret true; }
     if (preg == i.frame_reg) { ret true; }
     if (preg == i.scratch_reg) { ret true; }
@@ -623,6 +624,8 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
         fp_free[fi] = true;
         fi = fi + 1;
     }
+    gp_free[4] = false;
+    gp_free[5] = false;
     gp_free[i.stack_reg] = false;
     gp_free[i.frame_reg] = false;
     gp_free[i.scratch_reg] = false;

--- a/src/compiler/regalloc.mach
+++ b/src/compiler/regalloc.mach
@@ -298,9 +298,9 @@ fun is_reserved(i: *isa.ISA, preg: i32) bool {
 
 # expire_old: remove ranges from active list whose end_pos < current start
 fun expire_old(active: *ActiveEntry, active_count: *i32,
-               gp_free: *u8, fp_free: *u8,
+               gp_free: *bool, fp_free: *bool,
                gp_count: i32, fp_count: i32,
-               current_start: i32, i: *isa.ISA) {
+               current_start: i32) {
     var write: i32 = 0;
     var read: i32 = 0;
     for (read < @active_count) {
@@ -311,12 +311,10 @@ fun expire_old(active: *ActiveEntry, active_count: *i32,
             write = write + 1;
         } or {
             val freed: i32 = active[read].preg;
-            if (active[read].reg_class == REG_CLASS_GP && freed >= 0 && freed < gp_count
-                && freed != 4 && freed != 5 && freed != 10 && freed != 11
-                && !is_reserved(i, freed)) {
-                gp_free[freed] = 1;
+            if (active[read].reg_class == REG_CLASS_GP && freed >= 0 && freed < gp_count) {
+                gp_free[freed] = true;
             } or (active[read].reg_class == REG_CLASS_FP && freed >= 0 && freed < fp_count) {
-                fp_free[freed] = 1;
+                fp_free[freed] = true;
             }
         }
         read = read + 1;
@@ -325,17 +323,17 @@ fun expire_old(active: *ActiveEntry, active_count: *i32,
 }
 
 # try_alloc_reg: try to allocate a free register, preferring caller-saved
-fun try_alloc_reg(gp_free: *u8, fp_free: *u8, reg_class: u8,
+fun try_alloc_reg(gp_free: *bool, fp_free: *bool, reg_class: u8,
                   i: *isa.ISA, a: *abi.ABI, hint: i32) i32 {
     if (reg_class == REG_CLASS_FP) {
-        if (hint >= 0 && hint < i.fp_count && fp_free[hint] != 0) {
-            fp_free[hint] = 0;
+        if (hint >= 0 && hint < i.fp_count && fp_free[hint]) {
+            fp_free[hint] = false;
             ret hint;
         }
         var fi: i32 = 0;
         for (fi < i.fp_count) {
-            if (fp_free[fi] != 0) {
-                fp_free[fi] = 0;
+            if (fp_free[fi]) {
+                fp_free[fi] = false;
                 ret fi;
             }
             fi = fi + 1;
@@ -343,23 +341,23 @@ fun try_alloc_reg(gp_free: *u8, fp_free: *u8, reg_class: u8,
         ret -1;
     }
 
-    if (hint >= 0 && hint < i.gp_count && gp_free[hint] != 0 && !is_reserved(i, hint)) {
-        gp_free[hint] = 0;
+    if (hint >= 0 && hint < i.gp_count && gp_free[hint] && !is_reserved(i, hint)) {
+        gp_free[hint] = false;
         ret hint;
     }
 
     var ci: i32 = 0;
     for (ci < i.gp_count) {
-        if (gp_free[ci] != 0 && !is_reserved(i, ci) && !is_callee_saved(a, ci)) {
-            gp_free[ci] = 0;
+        if (gp_free[ci] && !is_reserved(i, ci) && !is_callee_saved(a, ci)) {
+            gp_free[ci] = false;
             ret ci;
         }
         ci = ci + 1;
     }
     ci = 0;
     for (ci < i.gp_count) {
-        if (gp_free[ci] != 0 && !is_reserved(i, ci)) {
-            gp_free[ci] = 0;
+        if (gp_free[ci] && !is_reserved(i, ci)) {
+            gp_free[ci] = false;
             ret ci;
         }
         ci = ci + 1;
@@ -368,17 +366,17 @@ fun try_alloc_reg(gp_free: *u8, fp_free: *u8, reg_class: u8,
 }
 
 # try_alloc_reg_callee: allocate a register, preferring callee-saved
-fun try_alloc_reg_callee(gp_free: *u8, fp_free: *u8, reg_class: u8,
+fun try_alloc_reg_callee(gp_free: *bool, fp_free: *bool, reg_class: u8,
                          i: *isa.ISA, a: *abi.ABI, hint: i32) i32 {
     if (reg_class == REG_CLASS_FP) {
-        if (hint >= 0 && hint < i.fp_count && fp_free[hint] != 0) {
-            fp_free[hint] = 0;
+        if (hint >= 0 && hint < i.fp_count && fp_free[hint]) {
+            fp_free[hint] = false;
             ret hint;
         }
         var fi: i32 = 0;
         for (fi < i.fp_count) {
-            if (fp_free[fi] != 0) {
-                fp_free[fi] = 0;
+            if (fp_free[fi]) {
+                fp_free[fi] = false;
                 ret fi;
             }
             fi = fi + 1;
@@ -386,15 +384,15 @@ fun try_alloc_reg_callee(gp_free: *u8, fp_free: *u8, reg_class: u8,
         ret -1;
     }
 
-    if (hint >= 0 && hint < i.gp_count && gp_free[hint] != 0 && !is_reserved(i, hint) && is_callee_saved(a, hint)) {
-        gp_free[hint] = 0;
+    if (hint >= 0 && hint < i.gp_count && gp_free[hint] && !is_reserved(i, hint) && is_callee_saved(a, hint)) {
+        gp_free[hint] = false;
         ret hint;
     }
 
     var ci: i32 = 0;
     for (ci < i.gp_count) {
-        if (gp_free[ci] != 0 && !is_reserved(i, ci) && is_callee_saved(a, ci)) {
-            gp_free[ci] = 0;
+        if (gp_free[ci] && !is_reserved(i, ci) && is_callee_saved(a, ci)) {
+            gp_free[ci] = false;
             ret ci;
         }
         ci = ci + 1;
@@ -600,46 +598,42 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
     var active: *ActiveEntry = unwrap_ok[*ActiveEntry, str](res_active);
     var active_count: i32 = 0;
 
-    var gp_free: *u8 = nil;
-    var fp_free: *u8 = nil;
+    var gp_free: *bool = nil;
+    var fp_free: *bool = nil;
     val gp_reg_count: i32 = i.gp_count;
     val fp_reg_count: i32 = i.fp_count;
-    val res_gp: Result[*u8, str] = allocator.allocate[u8](alloc, gp_reg_count::usize);
-    val res_fp: Result[*u8, str] = allocator.allocate[u8](alloc, fp_reg_count::usize);
-    if (is_err[*u8, str](res_gp) || is_err[*u8, str](res_fp)) {
+    val res_gp: Result[*bool, str] = allocator.allocate[bool](alloc, gp_reg_count::usize);
+    val res_fp: Result[*bool, str] = allocator.allocate[bool](alloc, fp_reg_count::usize);
+    if (is_err[*bool, str](res_gp) || is_err[*bool, str](res_fp)) {
         allocator.deallocate[ActiveEntry](alloc, active, MAX_ACTIVE::usize);
         allocator.deallocate[LiveRange](alloc, ranges, MAX_RANGES::usize);
         result.out = isa.buf_init(alloc);
         ret result;
     }
-    gp_free = unwrap_ok[*u8, str](res_gp);
-    fp_free = unwrap_ok[*u8, str](res_fp);
+    gp_free = unwrap_ok[*bool, str](res_gp);
+    fp_free = unwrap_ok[*bool, str](res_fp);
 
     var gi: i32 = 0;
     for (gi < gp_reg_count) {
-        gp_free[gi] = 1;
+        gp_free[gi] = true;
         gi = gi + 1;
     }
     var fi: i32 = 0;
     for (fi < fp_reg_count) {
-        fp_free[fi] = 1;
+        fp_free[fi] = true;
         fi = fi + 1;
     }
-    gp_free[i.stack_reg] = 0;
-    gp_free[i.frame_reg] = 0;
-    gp_free[i.scratch_reg] = 0;
-    gp_free[i.scratch_reg2] = 0;
-    if (4 < gp_reg_count) { gp_free[4] = 0; }
-    if (5 < gp_reg_count) { gp_free[5] = 0; }
-    if (10 < gp_reg_count) { gp_free[10] = 0; }
-    if (11 < gp_reg_count) { gp_free[11] = 0; }
+    gp_free[i.stack_reg] = false;
+    gp_free[i.frame_reg] = false;
+    gp_free[i.scratch_reg] = false;
+    gp_free[i.scratch_reg2] = false;
 
     var callee_mask: u32 = 0;
     var spill_offset: usize = local_size;
 
     var ri: i32 = 0;
     for (ri < range_count) {
-        expire_old(active, ?active_count, gp_free, fp_free, gp_reg_count, fp_reg_count, ranges[ri].start, i);
+        expire_old(active, ?active_count, gp_free, fp_free, gp_reg_count, fp_reg_count, ranges[ri].start);
 
         var preg: i32 = -1;
         if (ranges[ri].crosses_call) {
@@ -666,12 +660,10 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
                 ranges[spilled_ri].spill_off = spill_offset::i64;
                 ranges[spilled_ri].preg = -1;
 
-                if (ranges[spilled_ri].reg_class == REG_CLASS_GP
-                    && freed_preg != 4 && freed_preg != 5 && freed_preg != 10 && freed_preg != 11
-                    && !is_reserved(i, freed_preg)) {
-                    gp_free[freed_preg] = 1;
+                if (ranges[spilled_ri].reg_class == REG_CLASS_GP) {
+                    gp_free[freed_preg] = true;
                 } or (ranges[spilled_ri].reg_class == REG_CLASS_FP) {
-                    fp_free[freed_preg] = 1;
+                    fp_free[freed_preg] = true;
                 }
                 remove_active(active, ?active_count, spill_idx);
 
@@ -846,8 +838,8 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
         pi = pi + 1;
     }
 
-    allocator.deallocate[u8](alloc, fp_free, fp_reg_count::usize);
-    allocator.deallocate[u8](alloc, gp_free, gp_reg_count::usize);
+    allocator.deallocate[bool](alloc, fp_free, fp_reg_count::usize);
+    allocator.deallocate[bool](alloc, gp_free, gp_reg_count::usize);
     allocator.deallocate[ActiveEntry](alloc, active, MAX_ACTIVE::usize);
     allocator.deallocate[i32](alloc, call_positions, MAX_CALLS::usize);
     allocator.deallocate[LiveRange](alloc, ranges, MAX_RANGES::usize);


### PR DESCRIPTION
## Summary
- Root cause of RBP=0 frame corruption identified and fixed
- Spilled destination vregs were passing through to encoder unrewritten
- `reg_bits(vreg) = vreg & 7` produced garbage register IDs (RSP when vreg%8==4)
- Fix: rewrite spilled dst to scratch_reg before emit, store from scratch to spill slot

## Test plan
- [x] Zero LEA RSP patterns in smach binary (was 2+)
- [x] RBP valid at all crash points (was 0x0)
- [x] Help command works with formatted output
- [x] mach.toml opens, fstats, reads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)