### PR TITLE
fix: op_size type table lookup, sret RAX return, func.types wiring

### DIFF
--- a/src/compiler/mir/lower/lower.mach
+++ b/src/compiler/mir/lower/lower.mach
@@ -154,6 +154,7 @@ fun lower_function(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSto
     }
 
     ctx.fb = builder.func_init(ctx.alloc, name, ret_tid, ctx.src_path);
+    ctx.fb.func.types  = ctx.sema.types;
     ctx.local_count    = 0;
     ctx.ds.count       = 0;
     ctx.ds.mark        = 0;
@@ -287,6 +288,7 @@ fun lower_instantiation(ctx: *lctx.LowerCtx, fi: *mono.FnInst, store: *ast.NodeS
     ctx.inst_scope = fi.scope_id;
 
     ctx.fb = builder.func_init(ctx.alloc, fi.mangled_name, ret_tid, ctx.src_path);
+    ctx.fb.func.types  = ctx.sema.types;
     ctx.local_count    = 0;
     ctx.ds.count       = 0;
     ctx.ds.mark        = 0;

--- a/src/compiler/target/abi/sysv64.mach
+++ b/src/compiler/target/abi/sysv64.mach
@@ -210,7 +210,7 @@ fun sysv_classify_return(ctx: ptr, size: usize, align: usize,
 
     if (is_aggregate && size > MAX_GP_CLASS_SIZE) {
         slot.class = abi.CLASS_SRET;
-        slot.reg   = defs.RDI;
+        slot.reg   = defs.RAX;
         slot.size  = 8;
         ret slot;
     }

--- a/src/compiler/target/isa/x86_64/isel.mach
+++ b/src/compiler/target/isa/x86_64/isel.mach
@@ -32,10 +32,19 @@ fun vreg(v: ir.ValueId) i32 {
 fun op_size(func: *ir.Function, v: ir.ValueId) u8 {
     if (v::u32 == ir.VALUE_NONE::u32 || v::u32 >= func.value_count) { ret 8; }
     val t: *ir.Value = ?func.values[v::u32];
-    val tk: u32 = t.type_id::u32;
+    val tid: type.TypeId = t.type_id;
+    val tk: u32 = tid::u32;
     if (tk == type.TK_U8::u32 || tk == type.TK_I8::u32 || tk == type.TK_BOOL::u32) { ret 1; }
     if (tk == type.TK_U16::u32 || tk == type.TK_I16::u32) { ret 2; }
     if (tk == type.TK_U32::u32 || tk == type.TK_I32::u32 || tk == type.TK_F32::u32) { ret 4; }
+    if (tk == type.TK_U64::u32 || tk == type.TK_I64::u32 || tk == type.TK_F64::u32) { ret 8; }
+    if (tk == type.TK_POINTER::u32 || tk == type.TK_OPAQUE_PTR::u32) { ret 8; }
+    if (func.types != nil) {
+        val ty: *type.Type = type.get(func.types, tid);
+        if (ty != nil && ty.size > 0 && ty.size <= 8) {
+            ret ty.size::u8;
+        }
+    }
     ret 8;
 }
 


### PR DESCRIPTION
## Summary
- op_size uses type table for non-primitive type sizes (was always 8)
- classify_return uses RAX for sret (was RDI, which is clobbered)  
- func.types wired from sema in lower_function and lower_instantiation

## Test plan
- [x] No crashes
- [x] Help output correct
- [x] mach.toml reads successfully
- [ ] TOML parse still returns error (separate issue — parse logic affected by cumulative codegen fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)