### PR TITLE
fix: type size recomputation, symbol mangling, PCOPY spill handling

### DIFF
--- a/src/compiler/mir/compile.mach
+++ b/src/compiler/mir/compile.mach
@@ -368,17 +368,28 @@ fun resolve_pcopy_group(insts: *isa.InstBuf, out: *isa.InstBuf,
     var done: [16]bool;
     var n: i32 = 0;
 
+    var mem_pcs: [16]isa.Inst;
+    var mem_count: i32 = 0;
+
     var j: i32 = fence_pos - 1;
     for (j >= 0 && n < 16) {
         if (insts.insts[j].opcode != isa.ISA_PCOPY) { brk; }
         val pc: isa.Inst = insts.insts[j];
+        if (pc.src1.kind == isa.OPK_MEM) {
+            if (mem_count < 16) {
+                mem_pcs[mem_count] = pc;
+                mem_count = mem_count + 1;
+            }
+            j = j - 1;
+            cnt;
+        }
         dsts[n] = pc.dst.reg;
         srcs[n] = pc.src1.reg;
         done[n] = dsts[n] == srcs[n];
         n = n + 1;
         j = j - 1;
     }
-    if (n == 0) { ret; }
+    if (n == 0 && mem_count == 0) { ret; }
 
     val template: isa.Inst = insts.insts[fence_pos];
 
@@ -406,7 +417,24 @@ fun resolve_pcopy_group(insts: *isa.InstBuf, out: *isa.InstBuf,
     var remaining: i32 = 0;
     var ri: i32 = 0;
     for (ri < n) { if (!done[ri]) { remaining = remaining + 1; } ri = ri + 1; }
-    if (remaining == 0) { ret; }
+    if (remaining == 0) {
+        var mi: i32 = 0;
+        for (mi < mem_count) {
+            var ld: isa.Inst;
+            ld.clobbers = 0;
+            ld.opcode   = tgt.isa.load_opcode;
+            ld.dst      = mem_pcs[mi].dst;
+            ld.src1     = mem_pcs[mi].src1;
+            ld.src2     = isa.make_reg(-1, 0);
+            ld.size     = 8;
+            ld.flags    = tgt.isa.rex_w_flag;
+            ld.src_line = mem_pcs[mi].src_line;
+            ld.src_file = mem_pcs[mi].src_file;
+            isa.buf_append(out, ld);
+            mi = mi + 1;
+        }
+        ret;
+    }
 
     val temp_reg: i32 = tgt.isa.scratch_reg;
     ri = 0;
@@ -441,6 +469,22 @@ fun resolve_pcopy_group(insts: *isa.InstBuf, out: *isa.InstBuf,
             }
         }
         ri = ri + 1;
+    }
+
+    var mi: i32 = 0;
+    for (mi < mem_count) {
+        var ld: isa.Inst;
+        ld.clobbers = 0;
+        ld.opcode   = tgt.isa.load_opcode;
+        ld.dst      = mem_pcs[mi].dst;
+        ld.src1     = mem_pcs[mi].src1;
+        ld.src2     = isa.make_reg(-1, 0);
+        ld.size     = 8;
+        ld.flags    = tgt.isa.rex_w_flag;
+        ld.src_line = mem_pcs[mi].src_line;
+        ld.src_file = mem_pcs[mi].src_file;
+        isa.buf_append(out, ld);
+        mi = mi + 1;
     }
 }
 

--- a/src/compiler/mir/lower/ctx.mach
+++ b/src/compiler/mir/lower/ctx.mach
@@ -324,26 +324,51 @@ pub fun mangle_symbol(ctx: *LowerCtx, mod_path: str, name: str) str {
     if (mod_path == nil) { ret name; }
     if (name == nil) { ret mod_path; }
 
-    val path_len: usize = str_len(mod_path);
-    val name_len: usize = str_len(name);
-    val total: usize = path_len + 2 + name_len + 1;
-
-    val res: Result[*u8, str] = allocator.allocate[u8](ctx.alloc, total);
+    val buf_cap: usize = 2048;
+    val res: Result[*u8, str] = allocator.allocate[u8](ctx.alloc, buf_cap);
     if (is_err[*u8, str](res)) { ret name; }
     val buf: *u8 = unwrap_ok[*u8, str](res);
+    var off: usize = 0;
 
-    mem.raw_copy(buf::ptr, mod_path, path_len);
+    buf[off] = '_'; off = off + 1;
+    buf[off] = 'M'; off = off + 1;
 
-    var i: usize = 0;
-    for (i < path_len) {
-        if (buf[i] == 46) { buf[i] = 95; }
-        i = i + 1;
+    val mp_len: usize = str_len(mod_path);
+    var seg_start: usize = 0;
+    var pi: usize = 0;
+    for (pi <= mp_len && off < buf_cap - 112) {
+        if (pi == mp_len || mod_path[pi] == '.') {
+            val seg_len: usize = pi - seg_start;
+            if (seg_len > 0) {
+                if (seg_len >= 100) { buf[off] = ('0' + (seg_len / 100)::u8); off = off + 1; }
+                if (seg_len >= 10) { buf[off] = ('0' + ((seg_len / 10) % 10)::u8); off = off + 1; }
+                buf[off] = ('0' + (seg_len % 10)::u8); off = off + 1;
+                var j: usize = 0;
+                for (j < seg_len) {
+                    buf[off] = mod_path[seg_start + j];
+                    off = off + 1;
+                    j = j + 1;
+                }
+            }
+            seg_start = pi + 1;
+        }
+        pi = pi + 1;
     }
 
-    buf[path_len] = 95;
-    buf[path_len + 1] = 95;
-    mem.raw_copy((buf::usize + path_len + 2)::ptr, name, name_len);
-    buf[total - 1] = 0;
+    buf[off] = 'N'; off = off + 1;
+
+    val nm_len: usize = str_len(name);
+    if (nm_len >= 100) { buf[off] = ('0' + (nm_len / 100)::u8); off = off + 1; }
+    if (nm_len >= 10) { buf[off] = ('0' + ((nm_len / 10) % 10)::u8); off = off + 1; }
+    buf[off] = ('0' + (nm_len % 10)::u8); off = off + 1;
+    var ni: usize = 0;
+    for (ni < nm_len && off < buf_cap - 2) {
+        buf[off] = name[ni];
+        off = off + 1;
+        ni = ni + 1;
+    }
+
+    buf[off] = 0;
     ret buf::str;
 }
 

--- a/src/compiler/mir/lower/ctx.mach
+++ b/src/compiler/mir/lower/ctx.mach
@@ -168,7 +168,8 @@ pub fun type_size(ctx: *LowerCtx, tid: type.TypeId) u32 {
     if (tid::u32 == type.TYPE_NIL::u32) { ret 0; }
     val t: *type.Type = type.get(ctx.sema.types, tid);
     if (t == nil) { ret 0; }
-    ret t.size;
+    if (t.size > 0) { ret t.size; }
+    ret compute_type_size(ctx.sema.types, t);
 }
 
 # type alignment in bytes
@@ -176,8 +177,95 @@ pub fun type_align(ctx: *LowerCtx, tid: type.TypeId) u32 {
     if (tid::u32 == type.TYPE_NIL::u32) { ret 1; }
     val t: *type.Type = type.get(ctx.sema.types, tid);
     if (t == nil) { ret 1; }
-    if (t.align == 0) { ret 1; }
-    ret t.align;
+    if (t.align > 0) { ret t.align; }
+    ret compute_type_align(ctx.sema.types, t);
+}
+
+fun compute_type_size(types: *type.TypeTable, t: *type.Type) u32 {
+    if (t.kind == type.TK_POINTER || t.kind == type.TK_OPAQUE_PTR) { ret types.ptr_size; }
+    if (t.kind == type.TK_FUN) { ret types.ptr_size; }
+
+    if (t.kind == type.TK_RECORD) {
+        var offset: u32 = 0;
+        var max_al: u32 = 1;
+        var i: u16 = 0;
+        for (i < t.field_count) {
+            val ft: *type.Type = type.get(types, t.fields[i].type_id);
+            if (ft == nil) { i = i + 1; cnt; }
+            var fa: u32 = ft.align;
+            if (fa == 0) { fa = compute_type_align(types, ft); }
+            if (fa > max_al) { max_al = fa; }
+            if (fa > 0) { offset = (offset + fa - 1) & ~(fa - 1); }
+            var fs: u32 = ft.size;
+            if (fs == 0) { fs = compute_type_size(types, ft); }
+            offset = offset + fs;
+            i = i + 1;
+        }
+        if (max_al > 0) { offset = (offset + max_al - 1) & ~(max_al - 1); }
+        t.size = offset;
+        t.align = max_al;
+        ret offset;
+    }
+
+    if (t.kind == type.TK_UNION) {
+        var max_sz: u32 = 0;
+        var max_al: u32 = 1;
+        var i: u16 = 0;
+        for (i < t.field_count) {
+            val ft: *type.Type = type.get(types, t.fields[i].type_id);
+            if (ft == nil) { i = i + 1; cnt; }
+            var fs: u32 = ft.size;
+            if (fs == 0) { fs = compute_type_size(types, ft); }
+            if (fs > max_sz) { max_sz = fs; }
+            var fa: u32 = ft.align;
+            if (fa == 0) { fa = compute_type_align(types, ft); }
+            if (fa > max_al) { max_al = fa; }
+            i = i + 1;
+        }
+        if (max_al > 0) { max_sz = (max_sz + max_al - 1) & ~(max_al - 1); }
+        t.size = max_sz;
+        t.align = max_al;
+        ret max_sz;
+    }
+
+    if (t.kind == type.TK_ARRAY) {
+        val et: *type.Type = type.get(types, t.elem);
+        if (et != nil) {
+            var es: u32 = et.size;
+            if (es == 0) { es = compute_type_size(types, et); }
+            ret es * t.array_len;
+        }
+    }
+
+    ret 0;
+}
+
+fun compute_type_align(types: *type.TypeTable, t: *type.Type) u32 {
+    if (t.kind == type.TK_POINTER || t.kind == type.TK_OPAQUE_PTR || t.kind == type.TK_FUN) {
+        ret types.ptr_align;
+    }
+    if (t.kind == type.TK_RECORD || t.kind == type.TK_UNION) {
+        var max_al: u32 = 1;
+        var i: u16 = 0;
+        for (i < t.field_count) {
+            val ft: *type.Type = type.get(types, t.fields[i].type_id);
+            if (ft != nil) {
+                var fa: u32 = ft.align;
+                if (fa == 0) { fa = compute_type_align(types, ft); }
+                if (fa > max_al) { max_al = fa; }
+            }
+            i = i + 1;
+        }
+        ret max_al;
+    }
+    if (t.kind == type.TK_ARRAY) {
+        val et: *type.Type = type.get(types, t.elem);
+        if (et != nil) {
+            if (et.align > 0) { ret et.align; }
+            ret compute_type_align(types, et);
+        }
+    }
+    ret 1;
 }
 
 # returns true if a type is a floating point type

--- a/src/compiler/regalloc.mach
+++ b/src/compiler/regalloc.mach
@@ -704,6 +704,7 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
         var inst: isa.Inst = insts.insts[pi];
 
         if (inst.opcode == isa.ISA_PCOPY) {
+            var pcopy_handled: bool = false;
             if (inst.src1.kind == isa.OPK_REG && is_vreg(inst.src1.reg)) {
                 var si: i32 = 0;
                 for (si < range_count) {
@@ -711,7 +712,7 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
                         var reload: isa.Inst;
                         reload.clobbers = 0;
                         reload.opcode = i.load_opcode;
-                        reload.dst = isa.make_reg(i.scratch_reg2, 8);
+                        reload.dst = inst.dst;
                         reload.src1 = isa.make_mem(i.frame_reg, (-(ranges[si].spill_off::i32))::i32, -1, 0, 8);
                         reload.src2 = isa.make_reg(-1, 0);
                         reload.size = 8;
@@ -719,14 +720,16 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
                         reload.src_line = inst.src_line;
                         reload.src_file = inst.src_file;
                         isa.buf_append(?out, reload);
-                        inst.src1 = isa.make_reg(i.scratch_reg2, 8);
+                        pcopy_handled = true;
                         si = range_count;
                     }
                     si = si + 1;
                 }
             }
-            rewrite_operand(i, ?inst.src1, ranges, range_count);
-            isa.buf_append(?out, inst);
+            if (!pcopy_handled) {
+                rewrite_operand(i, ?inst.src1, ranges, range_count);
+                isa.buf_append(?out, inst);
+            }
             pi = pi + 1;
             cnt;
         }

--- a/src/compiler/regalloc.mach
+++ b/src/compiler/regalloc.mach
@@ -704,32 +704,22 @@ pub fun alloc_function(alloc: *allocator.Allocator, i: *isa.ISA, a: *abi.ABI,
         var inst: isa.Inst = insts.insts[pi];
 
         if (inst.opcode == isa.ISA_PCOPY) {
-            var pcopy_handled: bool = false;
+            var is_spilled_src: bool = false;
             if (inst.src1.kind == isa.OPK_REG && is_vreg(inst.src1.reg)) {
                 var si: i32 = 0;
                 for (si < range_count) {
                     if (ranges[si].vreg == inst.src1.reg && ranges[si].spilled) {
-                        var reload: isa.Inst;
-                        reload.clobbers = 0;
-                        reload.opcode = i.load_opcode;
-                        reload.dst = inst.dst;
-                        reload.src1 = isa.make_mem(i.frame_reg, (-(ranges[si].spill_off::i32))::i32, -1, 0, 8);
-                        reload.src2 = isa.make_reg(-1, 0);
-                        reload.size = 8;
-                        reload.flags = 0;
-                        reload.src_line = inst.src_line;
-                        reload.src_file = inst.src_file;
-                        isa.buf_append(?out, reload);
-                        pcopy_handled = true;
+                        is_spilled_src = true;
+                        inst.src1 = isa.make_mem(i.frame_reg, (-(ranges[si].spill_off::i32))::i32, -1, 0, 8);
                         si = range_count;
                     }
                     si = si + 1;
                 }
             }
-            if (!pcopy_handled) {
+            if (!is_spilled_src) {
                 rewrite_operand(i, ?inst.src1, ranges, range_count);
-                isa.buf_append(?out, inst);
             }
+            isa.buf_append(?out, inst);
             pi = pi + 1;
             cnt;
         }


### PR DESCRIPTION
## Summary
- type_size/type_align recompute from fields when pre-cached size is 0
- mangle_symbol uses itanium-style _M prefix format  
- PCOPY spill reload uses memory operands resolved after register copies
- Fixes sret pointer corruption from shared scratch register in PCOPY groups

## Status
- sret pointers now correctly point to stack allocas
- TOML parse crashes with null pointer at offset 0x28 (table navigation)
- This may be a genuine logic bug now exposed by correct control flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)