### PR TITLE
fix: sel_copy RCX byte count after PCOPY fence

### DIFF
--- a/src/compiler/target/isa/x86_64/isel.mach
+++ b/src/compiler/target/isa/x86_64/isel.mach
@@ -463,8 +463,6 @@ fun sel_copy(func: *ir.Function, inst: *ir.Inst, out: *isa.InstBuf, line: u32, f
     val src_ptr: ir.ValueId = ir.inst_arg(func, inst, 1);
     val byte_count: u64 = inst.imm;
 
-    emit_ri(out, x86.MOV, x86.RCX, byte_count::i64, 8, line, file);
-
     var pc1: isa.Inst;
     pc1.clobbers  = 0;
     pc1.opcode    = isa.ISA_PCOPY;
@@ -496,6 +494,8 @@ fun sel_copy(func: *ir.Function, inst: *ir.Inst, out: *isa.InstBuf, line: u32, f
     fence.size = 0; fence.flags = 0;
     fence.src_line = line; fence.src_file = file;
     isa.buf_append(out, fence);
+
+    emit_ri(out, x86.MOV, x86.RCX, byte_count::i64, 8, line, file);
 
     var mi: isa.Inst;
     mi.clobbers = (1::u32 << x86.RCX::u32) | (1::u32 << x86.RSI::u32) | (1::u32 << x86.RDI::u32);


### PR DESCRIPTION
## Summary
sel_copy's MOV RCX, byte_count was before the PCOPY group. If regalloc
assigned a PCOPY source to RCX, the byte count clobbered the source.
Now emitted after the PCOPY fence, right before REP MOVSB.

## Status
Fixes rep movsb crash (source=40 instead of pointer). New crash is a
null+16 dereference in str_equals — a string value is corrupted somewhere
in the TOML parsing chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)