### PR TITLE
fix: always recompute size/align for records and unions

### DIFF
--- a/src/compiler/mir/lower/ctx.mach
+++ b/src/compiler/mir/lower/ctx.mach
@@ -168,6 +168,9 @@ pub fun type_size(ctx: *LowerCtx, tid: type.TypeId) u32 {
     if (tid::u32 == type.TYPE_NIL::u32) { ret 0; }
     val t: *type.Type = type.get(ctx.sema.types, tid);
     if (t == nil) { ret 0; }
+    if (t.kind == type.TK_RECORD || t.kind == type.TK_UNION) {
+        ret compute_type_size(ctx.sema.types, t);
+    }
     if (t.size > 0) { ret t.size; }
     ret compute_type_size(ctx.sema.types, t);
 }
@@ -177,6 +180,9 @@ pub fun type_align(ctx: *LowerCtx, tid: type.TypeId) u32 {
     if (tid::u32 == type.TYPE_NIL::u32) { ret 1; }
     val t: *type.Type = type.get(ctx.sema.types, tid);
     if (t == nil) { ret 1; }
+    if (t.kind == type.TK_RECORD || t.kind == type.TK_UNION) {
+        ret compute_type_align(ctx.sema.types, t);
+    }
     if (t.align > 0) { ret t.align; }
     ret compute_type_align(ctx.sema.types, t);
 }


### PR DESCRIPTION
Forces recompute from fields instead of trusting cached t.size for aggregate types