### PR TITLE
fix: fully recursive type size computation

### DIFF
--- a/src/compiler/mir/lower/ctx.mach
+++ b/src/compiler/mir/lower/ctx.mach
@@ -190,6 +190,9 @@ pub fun type_align(ctx: *LowerCtx, tid: type.TypeId) u32 {
 fun compute_type_size(types: *type.TypeTable, t: *type.Type) u32 {
     if (t.kind == type.TK_POINTER || t.kind == type.TK_OPAQUE_PTR) { ret types.ptr_size; }
     if (t.kind == type.TK_FUN) { ret types.ptr_size; }
+    if (t.size > 0 && t.kind != type.TK_RECORD && t.kind != type.TK_UNION && t.kind != type.TK_ARRAY) {
+        ret t.size;
+    }
 
     if (t.kind == type.TK_RECORD) {
         var offset: u32 = 0;
@@ -198,12 +201,10 @@ fun compute_type_size(types: *type.TypeTable, t: *type.Type) u32 {
         for (i < t.field_count) {
             val ft: *type.Type = type.get(types, t.fields[i].type_id);
             if (ft == nil) { i = i + 1; cnt; }
-            var fa: u32 = ft.align;
-            if (fa == 0) { fa = compute_type_align(types, ft); }
+            var fa: u32 = compute_type_align(types, ft);
             if (fa > max_al) { max_al = fa; }
             if (fa > 0) { offset = (offset + fa - 1) & ~(fa - 1); }
-            var fs: u32 = ft.size;
-            if (fs == 0) { fs = compute_type_size(types, ft); }
+            val fs: u32 = compute_type_size(types, ft);
             offset = offset + fs;
             i = i + 1;
         }
@@ -220,11 +221,9 @@ fun compute_type_size(types: *type.TypeTable, t: *type.Type) u32 {
         for (i < t.field_count) {
             val ft: *type.Type = type.get(types, t.fields[i].type_id);
             if (ft == nil) { i = i + 1; cnt; }
-            var fs: u32 = ft.size;
-            if (fs == 0) { fs = compute_type_size(types, ft); }
+            val fs: u32 = compute_type_size(types, ft);
             if (fs > max_sz) { max_sz = fs; }
-            var fa: u32 = ft.align;
-            if (fa == 0) { fa = compute_type_align(types, ft); }
+            var fa: u32 = compute_type_align(types, ft);
             if (fa > max_al) { max_al = fa; }
             i = i + 1;
         }


### PR DESCRIPTION
compute_type_size never trusts cached sizes for aggregate types