### PR TITLE
fix: isel: ZEXT 4→8 bytes incorrectly uses MOVZX

### DIFF
--- a/src/compiler/target/isa/x86_64/isel.mach
+++ b/src/compiler/target/isa/x86_64/isel.mach
@@ -1417,7 +1417,11 @@ fun sel_conv(func: *ir.Function, inst: *ir.Inst, out: *isa.InstBuf, sz: u8, line
     val src_sz: u8 = op_size(func, ir.inst_arg(func, inst, 0));
 
     if (o == op.OP_ZEXT) {
-        emit_rr_ext(out, x86.MOVZX, dst, src, sz, src_sz, line, file);
+        if (src_sz == 4 && sz == 8) {
+            emit_rr(out, x86.MOV, dst, src, 4, line, file);
+        } or {
+            emit_rr_ext(out, x86.MOVZX, dst, src, sz, src_sz, line, file);
+        }
     } or (o == op.OP_SEXT) {
         if (src_sz == 4 && sz == 8) {
             emit_rr_ext(out, x86.MOVSXD, dst, src, sz, src_sz, line, file);


### PR DESCRIPTION
Closes #892