### PR TITLE
fix: abi: SRET return classification uses RAX instead of RDI

### DIFF
--- a/src/compiler/target/abi/sysv64.mach
+++ b/src/compiler/target/abi/sysv64.mach
@@ -211,7 +211,7 @@ fun sysv_classify_return(ctx: ptr, size: usize, align: usize,
 
     if (is_aggregate && size > MAX_GP_CLASS_SIZE) {
         slot.class = abi.CLASS_SRET;
-        slot.reg   = defs.RAX;
+        slot.reg   = defs.RDI;
         slot.size  = 8;
         ret slot;
     }


### PR DESCRIPTION
Closes #891