### PR TITLE
fix: remove duplicate 0x66 prefix in MOV reg,imm16 encoding

### DIFF
--- a/src/compiler/target/isa/x86_64/encode.mach
+++ b/src/compiler/target/isa/x86_64/encode.mach
@@ -392,7 +392,6 @@ fun encode_mov(mi: *isa.Inst, sec: *of.Section, alloc: *allocator.Allocator) i32
             emit_byte(sec, alloc, 0xB0 + reg_bits(dst.reg));
             emit_byte(sec, alloc, imm::u8);
         } or (size == 2) {
-            emit_byte(sec, alloc, 0x66);
             emit_rex_if_needed(sec, alloc, 0, 0, dst.reg);
             emit_byte(sec, alloc, 0xB8 + reg_bits(dst.reg));
             emit_u16(sec, alloc, imm::u16);


### PR DESCRIPTION
## Summary
- Removes duplicate `0x66` operand-size prefix emission in `encode_mov` for `MOV reg, imm16`
- The `FLAG_16BIT` check on line 387 already emits `0x66`, but the `size == 2` branch unconditionally emitted it again, producing two prefix bytes instead of one

Closes #890