### PR TITLE
fix: skip zero-sized aggregate operations in MIR lowering

### DIFF
--- a/src/compiler/mir/lower/expr.mach
+++ b/src/compiler/mir/lower/expr.mach
@@ -518,6 +518,9 @@ fun lower_assign(ctx: *lctx.LowerCtx, lhs_id: ast.NodeId, rhs_id: ast.NodeId,
 
     val tid: type.TypeId = lctx.node_type(ctx, rhs_id);
     val sz: u32 = lctx.type_size(ctx, tid);
+    if (lctx.is_aggregate(ctx, tid) && sz == 0) {
+        ret value;
+    }
     if (lctx.is_aggregate(ctx, tid) && sz > 0 && sz <= 8) {
         builder.build_agg_store(?ctx.fb, ptr, value, sz, loc);
     } or (lctx.is_aggregate(ctx, tid) && sz > 8) {

--- a/src/compiler/mir/lower/lower.mach
+++ b/src/compiler/mir/lower/lower.mach
@@ -263,7 +263,8 @@ fun lower_param(ctx: *lctx.LowerCtx, param_nid: ast.NodeId, idx: u32, store: *as
 
         if (lctx.is_aggregate(ctx, param_tid)) {
             val sz: u32 = lctx.type_size(ctx, param_tid);
-            if (sz > 0 && sz <= 8) {
+            if (sz == 0) {
+            } or (sz > 0 && sz <= 8) {
                 builder.build_agg_store(?ctx.fb, ptr, param_val, sz, loc);
             } or {
                 builder.build_copy(?ctx.fb, ptr, param_val, sz::u64, loc);

--- a/src/compiler/mir/lower/stmt.mach
+++ b/src/compiler/mir/lower/stmt.mach
@@ -91,7 +91,8 @@ fun lower_var_decl(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeSto
         val init_val: ir.ValueId = expr_mod.lower_expr(ctx, init_id, store);
         if (init_val::u32 != ir.VALUE_NONE::u32) {
             val sz: u32 = lctx.type_size(ctx, tid);
-            if (lctx.is_aggregate(ctx, tid) && sz > 0 && sz <= 8) {
+            if (lctx.is_aggregate(ctx, tid) && sz == 0) {
+            } or (lctx.is_aggregate(ctx, tid) && sz > 0 && sz <= 8) {
                 builder.build_agg_store(?ctx.fb, ptr, init_val, sz, loc);
             } or (lctx.is_aggregate(ctx, tid) && sz > 8) {
                 builder.build_copy(?ctx.fb, ptr, init_val, sz::u64, loc);
@@ -246,7 +247,9 @@ fun lower_ret(ctx: *lctx.LowerCtx, node_id: ast.NodeId, store: *ast.NodeStore) {
                 }
             }
         }
-        if (lctx.is_aggregate(ctx, ret_tid) && ret_sz > 0 && ret_sz <= ctx.max_reg_ret) {
+        if (lctx.is_aggregate(ctx, ret_tid) && ret_sz == 0) {
+            builder.build_ret(?ctx.fb, ir.VALUE_NONE, loc);
+        } or (lctx.is_aggregate(ctx, ret_tid) && ret_sz > 0 && ret_sz <= ctx.max_reg_ret) {
             builder.build_ret_agg(?ctx.fb, value, ret_sz::u16, loc);
         } or {
             builder.build_ret(?ctx.fb, value, loc);


### PR DESCRIPTION
## Summary

Fixes #898.

- Added early `sz == 0` checks for aggregate types in four MIR lowering locations (`lower_assign`, `lower_var_decl`, `lower_ret`, `lower_param`) so zero-sized aggregates are treated as no-ops instead of falling through to the scalar `store` branch.

## Test plan

- [ ] Verify zero-sized aggregate types (e.g. empty structs) no longer emit spurious store/copy instructions
- [ ] Confirm non-zero aggregates still lower correctly (small agg_store, large copy, scalar store)