### PR TITLE
fix: float comparisons return incorrect results for NaN

### DIFF
--- a/src/compiler/target/isa/x86_64/isel.mach
+++ b/src/compiler/target/isa/x86_64/isel.mach
@@ -809,15 +809,20 @@ fun sel_fcmp(func: *ir.Function, inst: *ir.Inst, out: *isa.InstBuf, sz: u8, line
     val lhs_sz: u8 = op_size(func, ir.inst_arg(func, inst, 0));
     var ucom_opc: u16 = x86.UCOMISS;
     if (lhs_sz == 8) { ucom_opc = x86.UCOMISD; }
-    emit_rr(out, ucom_opc, lhs, rhs, lhs_sz, line, file);
+    val cc: u16 = inst.flags;
+    val swap: bool = cc == op.CC_SLT::u16 || cc == op.CC_SLE::u16;
+    if (swap) {
+        emit_rr(out, ucom_opc, rhs, lhs, lhs_sz, line, file);
+    } else {
+        emit_rr(out, ucom_opc, lhs, rhs, lhs_sz, line, file);
+    }
     out.insts[out.count - 1].flags = out.insts[out.count - 1].flags | isa.ISA_FLAG_DST_READ;
 
-    val cc: u16 = inst.flags;
     var setcc: u16 = x86.SETE;
     if (cc == op.CC_EQ::u16)  { setcc = x86.SETE; }
     if (cc == op.CC_NE::u16)  { setcc = x86.SETNE; }
-    if (cc == op.CC_SLT::u16) { setcc = x86.SETB; }
-    if (cc == op.CC_SLE::u16) { setcc = x86.SETBE; }
+    if (cc == op.CC_SLT::u16) { setcc = x86.SETA; }
+    if (cc == op.CC_SLE::u16) { setcc = x86.SETAE; }
     if (cc == op.CC_SGT::u16) { setcc = x86.SETA; }
     if (cc == op.CC_SGE::u16) { setcc = x86.SETAE; }
 


### PR DESCRIPTION
## Summary
- Swap UCOMISS/UCOMISD operands for CC_SLT and CC_SLE, then use SETA/SETAE instead of SETB/SETBE
- This matches the LLVM/GCC approach: ordered less-than/less-or-equal now correctly return false when either operand is NaN

Closes #908

## Test plan
- [ ] Verify `f32`/`f64` less-than returns false when either operand is NaN
- [ ] Verify `f32`/`f64` less-or-equal returns false when either operand is NaN
- [ ] Verify greater-than/greater-or-equal and equality comparisons are unaffected