### PR TITLE
fix: classify float aggregates <= 8 bytes as CLASS_FP in SysV64 ABI

### DIFF
--- a/src/compiler/target/abi/sysv64.mach
+++ b/src/compiler/target/abi/sysv64.mach
@@ -153,7 +153,17 @@ fun sysv_classify_param(ctx: ptr, index: i32, size: usize, align: usize,
         ret slot;
     }
 
+    # aggregate classification: SysV64 classifies each eightbyte independently,
+    # but we only have a single is_float flag (no per-field type info from the
+    # caller). for aggregates <= 8 bytes we can honor is_float directly. for
+    # 9-16 byte aggregates, full eightbyte classification would require
+    # field-level type info, so we conservatively use GP registers.
     if (is_aggregate) {
+        if (size <= 8 && is_float && fp_used < FP_PARAM_COUNT) {
+            slot.class = abi.CLASS_FP;
+            slot.reg   = fp_used;
+            ret slot;
+        }
         if (size <= 8 && gp_used < GP_PARAM_COUNT) {
             slot.class = abi.CLASS_GP;
             slot.reg   = gp_param_reg_id(gp_used);
@@ -216,7 +226,15 @@ fun sysv_classify_return(ctx: ptr, size: usize, align: usize,
         ret slot;
     }
 
+    # see comment in sysv_classify_param for why 9-16 byte float aggregates
+    # conservatively use GP: full eightbyte classification needs field-level
+    # type info that the caller does not yet provide.
     if (is_aggregate) {
+        if (size <= 8 && is_float) {
+            slot.class = abi.CLASS_FP;
+            slot.reg   = defs.XMM0;
+            ret slot;
+        }
         if (size <= 8) {
             slot.class = abi.CLASS_GP;
             slot.reg   = defs.RAX;


### PR DESCRIPTION
## Summary
- In `sysv_classify_param`, float aggregates <= 8 bytes now use CLASS_FP (XMM register) instead of always falling through to CLASS_GP
- In `sysv_classify_return`, float aggregates <= 8 bytes now return in XMM0 instead of RAX
- 9-16 byte float aggregates conservatively remain GP — full eightbyte classification requires field-level type info the caller does not yet provide

Closes #897