### PR TITLE
Centralize aggregate layout + ABI, add IR verifier (#1002)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -245,7 +245,7 @@ fun free_sema_deps(alloc: *Allocator, deps: *sema.SemaDeps) {
 # codegen passes off a semantically broken AST. `images` (caller-owned, sized
 # to p.module_len) is filled in topo order. on failure the partial images and
 # IR modules are torn down by the caller via `free_modules`.
-fun compile_modules(p: *driver.Project, level: u8,
+fun compile_modules(p: *driver.Project, level: u8, verify_ir: bool,
                     results: *sema.SemaResult, ready: *bool,
                     irs: *ir.Module, ir_ready: *bool,
                     images: *of.ObjectImage, image_ready: *bool) Result[bool, str] {
@@ -288,7 +288,7 @@ fun compile_modules(p: *driver.Project, level: u8,
         irs[mid::u32]     = unwrap_ok[ir.Module, str](lower_r);
         ir_ready[mid::u32] = true;
 
-        val opt_r: Result[bool, str] = pipeline.run(?irs[mid::u32], ?p.target, level);
+        val opt_r: Result[bool, str] = pipeline.run(?irs[mid::u32], ?p.target, level, verify_ir);
         if (is_err[bool, str](opt_r)) { ret err[bool, str](unwrap_err[bool, str](opt_r)); }
 
         val cg_r: Result[of.ObjectImage, str] = codegen.codegen_module(p.s, ?p.target, ?irs[mid::u32]);
@@ -392,7 +392,7 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool) BuildR
     }
     var p: driver.Project = unwrap_ok[driver.Project, str](proj_r);
 
-    br.code = compile_and_link(?p, level, emit_obj, ?root[0], config.output, config.artifacts, ?br.output_path);
+    br.code = compile_and_link(?p, level, emit_obj, config.verify_ir, ?root[0], config.output, config.artifacts, ?br.output_path);
 
     flush_diagnostics(?s, ?s.diags);
     driver.dnit_project(?p);
@@ -405,7 +405,7 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool) BuildR
 # sets `*out_path` to the produced artifact path on success. `out_override`
 # (-o) and `art_override` (--artifacts), when non-nil, replace the target's
 # configured binary and artifacts paths.
-fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool,
+fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, verify_ir: bool,
                      root: *u8, out_override: *u8, art_override: *u8, out_path: **u8) i64 {
     val n: usize = p.module_len::usize;
     if (n == 0) {
@@ -446,7 +446,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool,
     }
 
     var code: i64 = 0;
-    val comp_r: Result[bool, str] = compile_modules(p, level, results, ready, irs, ir_ready, images, image_ready);
+    val comp_r: Result[bool, str] = compile_modules(p, level, verify_ir, results, ready, irs, ir_ready, images, image_ready);
     if (is_err[bool, str](comp_r)) {
         emit("error: ");
         emit(unwrap_err[bool, str](comp_r));

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -45,6 +45,7 @@ pub rec Config {
     color:     ColorMode;
     verbose:   bool;
     quiet:     bool;
+    verify_ir: bool;
     cwd:       *u8;
     target:    *u8;
     output:    *u8;
@@ -80,6 +81,7 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
     c.color     = COLOR_AUTO;
     c.verbose   = false;
     c.quiet     = false;
+    c.verify_ir = false;
     c.cwd       = nil;
     c.target    = nil;
     c.output    = nil;
@@ -92,6 +94,7 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
     }
     c.verbose = verbose;
     c.quiet   = quiet;
+    c.verify_ir = args.has_flag(argc, argv, "--verify-ir");
 
     val color_opt: Option[*u8] = args.get_value(argc, argv, "--color");
     if (is_some[*u8](color_opt)) {

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -2829,6 +2829,145 @@ fun emit_store_to(ctx: *LowerCtx, mb: *MirBlock, mem: MirOperand, src: MirOperan
     ret push_instr(ctx, mb, mi);
 }
 
+# classify_signature: classify a whole function ABI in ONE left-to-right walk and
+# fill `out` with the resulting `SigLayout`. this is the single ABI-lowering oracle
+# the param / return / call lowering all read, so they can never disagree on a
+# value's placement: every fact (size / float / aggregate) is taken from a DECLARED
+# type via the IR layout oracle, never from a per-operand value type that diverges
+# when an aggregate flows by address (its operand is an 8-byte pointer).
+#
+# the walk:
+#   - classifies the return through `tgt.abi.ret_passing` from `ret_ty` (the
+#     function's declared return type — the call passes its result type, the
+#     callee its signature's return); a CLASS_SRET return reserves the first GP
+#     argument register (seeds `gp_used = 1`) just as the hidden pointer consumes a
+#     GP slot in the call / params lowering;
+#   - when `sig` resolves to an IRT_FN, classifies each fixed parameter through
+#     `tgt.abi.arg_passing` against the running GP/FP counters, then assigns the
+#     real outgoing stack offset into the slot's `offset` (an eight-byte-granular
+#     cursor) and advances the matching cursor — register slots advance `gp_used` /
+#     `fp_used` (a 9–16 byte two-GP aggregate advances by two), a stack slot
+#     advances `stack_off`. when `sig` is not an IRT_FN (an indirect call through
+#     an untyped function pointer, whose declared parameter types the IR does not
+#     carry), `param_count` is 0 and the caller classifies every argument from its
+#     operand type against the returned running cursors — the same fallback the
+#     variadic tail uses.
+#
+# `out.params` is a fresh allocation (sized to the signature's own param_count, so
+# never over/under-run regardless of the caller's parameter count) the caller
+# releases with `sig_layout_free` once the lowering of this signature is done. the
+# 9–16 byte two-register and >16 byte by-reference / sret behavior is whatever
+# `classify_arg` / `classify_return` return, unchanged — this oracle only walks
+# them in order and records offsets.
+# ---
+# ctx:    the active lowering context (supplies the IR type oracle and target)
+# sig:    the function signature (an IRT_FN id; non-IRT_FN yields zero fixed params)
+# ret_ty: the declared return type to classify the return / sret reservation from
+# out:    receives the assembled SigLayout (`params` is owned — free it with
+#         `sig_layout_free`)
+# ret:    ok(true) on success, or a loud error from the ABI vtable surface
+fun classify_signature(ctx: *LowerCtx, sig: ir_type.IrTypeId, ret_ty: ir_type.IrTypeId,
+                       out: *abi.SigLayout) Result[bool, str] {
+    val rok: Result[bool, str] = require_abi(ctx.tgt);
+    if (is_err[bool, str](rok)) { ret rok; }
+
+    val arch: u32 = ctx.tgt.arch_id;
+    val classify_arg: sysv.ArgPassingFn = ctx.tgt.abi.arg_passing::sysv.ArgPassingFn;
+    val classify_ret: sysv.RetPassingFn = ctx.tgt.abi.ret_passing::sysv.RetPassingFn;
+
+    out.params      = nil;
+    out.param_count = 0;
+
+    # the return value's placement decides whether the first GP argument register
+    # is reserved for a hidden sret pointer; classify it from the declared return
+    # type so its size / shape match what the params / ret lowering both reserve.
+    val ret_size:  u64  = ir_type.byte_size(ctx.types, ret_ty, ctx.tgt)::u64;
+    val ret_float: bool = value_is_float(ctx, ret_ty);
+    val ret_aggr:  bool = value_is_aggregate(ctx, ret_ty);
+    out.ret_slot = classify_ret(arch, ret_size, 0, ret_float, ret_aggr);
+
+    var gp_used:   i32 = 0;
+    var fp_used:   i32 = 0;
+    var stack_off: i64 = 0;
+
+    # a CLASS_SRET return reserves the first GP argument register for the hidden
+    # result-storage pointer, so the parameters classify against that reservation.
+    if (out.ret_slot.class == abi.CLASS_SRET) {
+        gp_used = 1;
+    }
+
+    # an indirect call through an untyped function pointer carries no declared
+    # parameter types (the signature is not an IRT_FN); leave the fixed-param list
+    # empty so the caller classifies every argument from its operand type.
+    val it: Option[*ir_type.IrType] = ir_type.get(ctx.types, sig);
+    if (!is_some[*ir_type.IrType](it)) {
+        out.gp_used   = gp_used;
+        out.fp_used   = fp_used;
+        out.stack_off = stack_off;
+        ret ok[bool, str](true);
+    }
+    val t: *ir_type.IrType = unwrap[*ir_type.IrType](it);
+    if (t.kind != ir_type.IRT_FN) {
+        out.gp_used   = gp_used;
+        out.fp_used   = fp_used;
+        out.stack_off = stack_off;
+        ret ok[bool, str](true);
+    }
+
+    val pc: u32 = t.data.fn.param_count;
+    var slots: *abi.ParamSlot = nil;
+    if (pc > 0) {
+        val sb: Result[*abi.ParamSlot, str] = allocate[abi.ParamSlot](ctx.alloc, pc::usize);
+        if (is_err[*abi.ParamSlot, str](sb)) { ret err[bool, str](unwrap_err[*abi.ParamSlot, str](sb)); }
+        slots = unwrap_ok[*abi.ParamSlot, str](sb);
+    }
+
+    var pi: u32 = 0;
+    for (pi < pc) {
+        val pty:  ir_type.IrTypeId = t.data.fn.params[pi];
+        val psz:  u64  = ir_type.byte_size(ctx.types, pty, ctx.tgt)::u64;
+        val pfl:  bool = value_is_float(ctx, pty);
+        val pag:  bool = value_is_aggregate(ctx, pty);
+        var slot: abi.ParamSlot = classify_arg(arch, pi::i32, psz, 0, pfl, pag, gp_used, fp_used);
+
+        # record the real outgoing stack offset on the slot (the ABI classifier
+        # returns a sizing-only slot with offset 0); the param / call lowering
+        # read this instead of re-deriving a parallel cursor.
+        if (slot.class == abi.CLASS_STACK) {
+            slot.offset = stack_off;
+            stack_off   = stack_off + stack_slot_bytes(slot.size);
+        } or (slot.class == abi.CLASS_FP) {
+            fp_used = fp_used + 1;
+        } or (slot.class == abi.CLASS_GP) {
+            gp_used = gp_used + 1;
+            if (slot.reg2 >= 0) { gp_used = gp_used + 1; }
+        } or (slot.class == abi.CLASS_BYREF) {
+            gp_used = gp_used + 1;
+        }
+
+        slots[pi] = slot;
+        pi = pi + 1;
+    }
+
+    out.params      = slots;
+    out.param_count = pc;
+    out.gp_used     = gp_used;
+    out.fp_used     = fp_used;
+    out.stack_off   = stack_off;
+    ret ok[bool, str](true);
+}
+
+# sig_layout_free: release the owned `params` array of a `SigLayout` produced by
+# `classify_signature`. safe on an empty (nil-params) layout. every site that
+# classifies a signature calls this once the layout's slots are consumed.
+fun sig_layout_free(ctx: *LowerCtx, layout: *abi.SigLayout) {
+    if (layout.params != nil && layout.param_count > 0) {
+        deallocate[abi.ParamSlot](ctx.alloc, layout.params, layout.param_count::usize);
+        layout.params      = nil;
+        layout.param_count = 0;
+    }
+}
+
 # expands an OP_CALL under SysV AMD64. classifies the callee's return value and
 # each argument through the ABI vtable, then emits, in order:
 #   - the SRET hidden-pointer move into RDI when the return is >16 bytes;
@@ -2851,18 +2990,32 @@ fun lower_call(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
 
     val arch: u32 = ctx.tgt.arch_id;
     val classify_arg: sysv.ArgPassingFn = ctx.tgt.abi.arg_passing::sysv.ArgPassingFn;
-    val classify_ret: sysv.RetPassingFn = ctx.tgt.abi.ret_passing::sysv.RetPassingFn;
 
-    # return classification decides whether the call needs an sret pointer in the
-    # first GP argument register, which also consumes one GP slot for the args.
-    val ret_ty:    ir_type.IrTypeId = inst.ty;
+    # classify the WHOLE declared signature once (the callee's IRT_FN rides on
+    # `inst.aux_ty`, the call's result type on `inst.ty`); the return and every
+    # fixed argument read their placement from this single layout so the call and
+    # the callee's `lower_params` can never disagree — in particular a by-value
+    # aggregate argument is classified from its DECLARED parameter type, not from
+    # the 8-byte pointer its operand carries. an indirect call through an untyped
+    # function pointer yields zero fixed params, so every argument falls back to
+    # per-operand classification below.
+    val sig: ir_type.IrTypeId = inst.aux_ty;
+    val ret_ty: ir_type.IrTypeId = inst.ty;
+    var layout: abi.SigLayout;
+    val cls: Result[bool, str] = classify_signature(ctx, sig, ret_ty, ?layout);
+    if (is_err[bool, str](cls)) { ret cls; }
+
+    val rslot: abi.ParamSlot = layout.ret_slot;
+
+    # the call's result type sizes the caller-owned aggregate result storage.
     val ret_size:  u64 = ir_type.byte_size(ctx.types, ret_ty, ctx.tgt)::u64;
-    val ret_float: bool = value_is_float(ctx, ret_ty);
     val ret_aggr:  bool = value_is_aggregate(ctx, ret_ty);
-    val rslot: abi.ParamSlot = classify_ret(arch, ret_size, 0, ret_float, ret_aggr);
 
-    var gp_used: i32 = 0;
-    var fp_used: i32 = 0;
+    # the running register / stack cursors resume from the fixed-parameter walk so
+    # a variadic call's tail arguments continue against the same counters.
+    var gp_used:   i32 = layout.gp_used;
+    var fp_used:   i32 = layout.fp_used;
+    var stack_off: i64 = layout.stack_off;
 
     # an aggregate return arrives by address: the caller owns the result storage
     # and the result vreg points at it. allocate that storage and LEA its address
@@ -2872,66 +3025,96 @@ fun lower_call(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
     val res_dst: u32 = result_vreg(ctx, iid);
     if (ret_aggr && res_dst != MIR_VREG_NIL) {
         val ra: Result[bool, str] = alloc_result_storage(ctx, mb, res_dst, ret_size, ret_align(ctx, ret_ty));
-        if (is_err[bool, str](ra)) { ret ra; }
+        if (is_err[bool, str](ra)) {
+            sig_layout_free(ctx, ?layout);
+            ret ra;
+        }
     }
-
-    # running offset into this call's outgoing stack-argument region. each
-    # stack-passed argument is stored at `[rsp + stack_off]`, eight-byte aligned
-    # per the SysV stack-slot rule, and `stack_off` advances by the slot's size so
-    # the next stack argument lands in the next slot rather than overwriting it.
-    var stack_off: i64 = 0;
 
     if (rslot.class == abi.CLASS_SRET) {
         # the caller allocates the return storage (above) and passes its address in
         # the first GP argument register (the ABI's GP argument file, RDI under
-        # SysV); the result vreg names that storage.
+        # SysV); the result vreg names that storage. the layout already reserved the
+        # GP slot in `gp_used`, so emit the pre-coloring move into the first register.
         if (res_dst != MIR_VREG_NIL) {
             var sret_reg: i32 = 0;
-            val sr: Result[bool, str] = abi_gp_arg_reg(ctx.tgt, gp_used, ?sret_reg);
-            if (is_err[bool, str](sr)) { ret sr; }
+            val sr: Result[bool, str] = abi_gp_arg_reg(ctx.tgt, 0, ?sret_reg);
+            if (is_err[bool, str](sr)) {
+                sig_layout_free(ctx, ?layout);
+                ret sr;
+            }
             val pre: Result[bool, str] = emit_mov(ctx, mb,
                 op_preg(sret_reg::u32), op_vreg(res_dst));
-            if (is_err[bool, str](pre)) { ret pre; }
+            if (is_err[bool, str](pre)) {
+                sig_layout_free(ctx, ?layout);
+                ret pre;
+            }
         }
-        gp_used = gp_used + 1;
     }
 
-    # arguments, in source order. each consumes GP/FP slots per its placement so
-    # the next argument classifies against the running usage counters.
+    # arguments, in source order. a fixed argument reads its placement (and real
+    # stack offset) from the precomputed layout; a variadic tail argument (past the
+    # declared param count) classifies from its operand type against the running
+    # counters — the one place an operand's own type is consulted.
     var ai:  u32 = 1;
-    var idx: i32 = 0;
     for (ai < inst.operand_count) {
         val av:   value.Value = inst.operands[ai];
-        val asz:  u64  = ir_type.byte_size(ctx.types, av.ty, ctx.tgt)::u64;
-        val afl:  bool = value_is_float(ctx, av.ty);
-        val aag:  bool = value_is_aggregate(ctx, av.ty);
-        val slot: abi.ParamSlot = classify_arg(arch, idx, asz, 0, afl, aag, gp_used, fp_used);
+        val pidx: u32 = ai - 1;
+        var slot: abi.ParamSlot;
+        var soff: i64 = 0;
+        if (pidx < layout.param_count) {
+            slot = layout.params[pidx];
+            soff = slot.offset;
+        } or {
+            val asz:  u64  = ir_type.byte_size(ctx.types, av.ty, ctx.tgt)::u64;
+            val afl:  bool = value_is_float(ctx, av.ty);
+            val aag:  bool = value_is_aggregate(ctx, av.ty);
+            slot = classify_arg(arch, pidx::i32, asz, 0, afl, aag, gp_used, fp_used);
+            soff = stack_off;
+        }
+
+        val aag2: bool = value_is_aggregate(ctx, av.ty);
+        # the operand's true byte size is the copy length for a by-value aggregate
+        # spilled to the stack: a >16-byte aggregate's ABI slot carries a sizing-only
+        # size of 8 (it is otherwise passed by reference), so reading slot.size would
+        # truncate the copy. for a fixed param this equals the declared param size
+        # (same interned type); for every register / by-ref / <=16B-stack slot it
+        # equals slot.size, so only the >16B-on-stack copy length is affected.
+        val asz2: u64 = ir_type.byte_size(ctx.types, av.ty, ctx.tgt)::u64;
         # a global / function symbol argument is its address; LEA-materialize it
         # so the register / stack move passes the address, not the symbol's bytes.
         val aor: Result[MirOperand, str] = lower_value_addr(ctx, mb, av);
-        if (is_err[MirOperand, str](aor)) { ret err[bool, str](unwrap_err[MirOperand, str](aor)); }
+        if (is_err[MirOperand, str](aor)) {
+            sig_layout_free(ctx, ?layout);
+            ret err[bool, str](unwrap_err[MirOperand, str](aor));
+        }
         val argop: MirOperand = unwrap_ok[MirOperand, str](aor);
 
-        val er: Result[bool, str] = emit_arg_slot(ctx, mb, slot, argop, stack_off, aag, asz);
-        if (is_err[bool, str](er)) { ret er; }
-
-        # advance the usage counters by what this argument consumed. a stack
-        # argument advances the outgoing-region cursor instead of a register file;
-        # each slot is rounded up to the eight-byte stack-slot granularity.
-        if (slot.class == abi.CLASS_FP) {
-            fp_used = fp_used + 1;
-        } or (slot.class == abi.CLASS_GP) {
-            gp_used = gp_used + 1;
-            if (slot.reg2 >= 0) { gp_used = gp_used + 1; }
-        } or (slot.class == abi.CLASS_BYREF) {
-            gp_used = gp_used + 1;
-        } or (slot.class == abi.CLASS_STACK) {
-            stack_off = stack_off + stack_slot_bytes(slot.size);
+        val er: Result[bool, str] = emit_arg_slot(ctx, mb, slot, argop, soff, aag2, asz2);
+        if (is_err[bool, str](er)) {
+            sig_layout_free(ctx, ?layout);
+            ret er;
         }
 
-        ai  = ai + 1;
-        idx = idx + 1;
+        # advance the running cursors only for the variadic tail; the fixed-param
+        # cursors were already consumed by `classify_signature`.
+        if (pidx >= layout.param_count) {
+            if (slot.class == abi.CLASS_FP) {
+                fp_used = fp_used + 1;
+            } or (slot.class == abi.CLASS_GP) {
+                gp_used = gp_used + 1;
+                if (slot.reg2 >= 0) { gp_used = gp_used + 1; }
+            } or (slot.class == abi.CLASS_BYREF) {
+                gp_used = gp_used + 1;
+            } or (slot.class == abi.CLASS_STACK) {
+                stack_off = stack_off + stack_slot_bytes(slot.size);
+            }
+        }
+
+        ai = ai + 1;
     }
+
+    sig_layout_free(ctx, ?layout);
 
     # record this call's outgoing stack-argument footprint. frame.run reserves the
     # maximum over all calls, sixteen-byte aligned, as the lowest region of the
@@ -3209,77 +3392,61 @@ fun emit_ret_slot_to_vreg(ctx: *LowerCtx, mb: *MirBlock, slot: abi.ParamSlot, ds
 # loads from the caller frame at `[fp + 16 + offset]`. driven purely through the
 # ABI vtable: an absent / unsupported ABI vtable is a loud error.
 fun lower_params(ctx: *LowerCtx, mb: *MirBlock) Result[bool, str] {
-    val rok: Result[bool, str] = require_abi(ctx.tgt);
-    if (is_err[bool, str](rok)) { ret rok; }
+    # classify the whole function signature once: the same layout the caller's
+    # `lower_call` derives, so a parameter is placed exactly where the call passed
+    # it. an sret return reserves the first GP register (in the layout); the per-
+    # parameter slots carry their real `[rbp + 16 + offset]` stack offsets.
+    val ret_ty: ir_type.IrTypeId = fn_return_type(ctx);
+    var layout: abi.SigLayout;
+    val cls: Result[bool, str] = classify_signature(ctx, ctx.fn.sig, ret_ty, ?layout);
+    if (is_err[bool, str](cls)) { ret cls; }
 
-    val arch: u32 = ctx.tgt.arch_id;
-
-    # an sret return consumes the first GP register for the hidden pointer; the
-    # callee's parameters classify against that reservation.
-    var gp_used: i32 = 0;
-    var fp_used: i32 = 0;
-    val ret_ty:    ir_type.IrTypeId = fn_return_type(ctx);
-    if (ret_ty != ir_type.IRT_NIL) {
-        val rsz:  u64  = ir_type.byte_size(ctx.types, ret_ty, ctx.tgt)::u64;
-        val rfl:  bool = value_is_float(ctx, ret_ty);
-        val rag:  bool = value_is_aggregate(ctx, ret_ty);
-        val classify_ret: sysv.RetPassingFn = ctx.tgt.abi.ret_passing::sysv.RetPassingFn;
-        val rslot: abi.ParamSlot = classify_ret(arch, rsz, 0, rfl, rag);
-        if (rslot.class == abi.CLASS_SRET) {
-            # the caller passes the hidden result-storage pointer in the first GP
-            # argument register; capture it into a vreg so `lower_ret` copies the
-            # returned aggregate into that storage and returns the pointer in RAX.
-            var sret_reg: i32 = 0;
-            val sr: Result[bool, str] = abi_gp_arg_reg(ctx.tgt, gp_used, ?sret_reg);
-            if (is_err[bool, str](sr)) { ret sr; }
-            val svr: Result[u32, str] = new_vreg(ctx, REG_CLASS_GP);
-            if (is_err[u32, str](svr)) { ret err[bool, str](unwrap_err[u32, str](svr)); }
-            val sv: u32 = unwrap_ok[u32, str](svr);
-            val mv: Result[bool, str] = emit_mov(ctx, mb, op_vreg(sv), op_preg(sret_reg::u32));
-            if (is_err[bool, str](mv)) { ret mv; }
-            ctx.sret_vreg = sv;
-            gp_used = gp_used + 1;
+    # an sret return: the caller passes the hidden result-storage pointer in the
+    # first GP argument register; capture it into a vreg so `lower_ret` copies the
+    # returned aggregate into that storage and returns the pointer in RAX.
+    if (layout.ret_slot.class == abi.CLASS_SRET) {
+        var sret_reg: i32 = 0;
+        val sr: Result[bool, str] = abi_gp_arg_reg(ctx.tgt, 0, ?sret_reg);
+        if (is_err[bool, str](sr)) {
+            sig_layout_free(ctx, ?layout);
+            ret sr;
         }
+        val svr: Result[u32, str] = new_vreg(ctx, REG_CLASS_GP);
+        if (is_err[u32, str](svr)) {
+            sig_layout_free(ctx, ?layout);
+            ret err[bool, str](unwrap_err[u32, str](svr));
+        }
+        val sv: u32 = unwrap_ok[u32, str](svr);
+        val mv: Result[bool, str] = emit_mov(ctx, mb, op_vreg(sv), op_preg(sret_reg::u32));
+        if (is_err[bool, str](mv)) {
+            sig_layout_free(ctx, ?layout);
+            ret mv;
+        }
+        ctx.sret_vreg = sv;
     }
 
-    # a zero-parameter function still needs the sret-pointer capture above (a
-    # niladic aggregate-returning function receives the hidden pointer); only the
-    # per-parameter classification below is skipped.
-    if (ctx.param_count == 0) { ret ok[bool, str](true); }
-
-    val classify_arg: sysv.ArgPassingFn = ctx.tgt.abi.arg_passing::sysv.ArgPassingFn;
-
-    # running offset into the caller's outgoing-argument area for stack-passed
-    # parameters, read at `[rbp + 16 + stack_off]`. it advances by each stack
-    # parameter's eight-byte-granular slot size, mirroring the offsets the caller
-    # used in `lower_call`; the ABI classifier returns a sizing-only slot, so this
-    # cursor is the callee's responsibility.
-    var stack_off: i64 = 0;
-
+    # the signature's declared param count and the function's param count are the
+    # same list (both lowered from the same semantic parameter types); iterate the
+    # smaller as a hard bound so neither the layout slots nor the param vregs are
+    # indexed out of range.
+    var bound: u32 = ctx.param_count;
+    if (layout.param_count < bound) { bound = layout.param_count; }
     var pi: u32 = 0;
-    for (pi < ctx.param_count) {
+    for (pi < bound) {
         val pv:   u32 = ctx.param_vregs[pi];
         val pty:  ir_type.IrTypeId = ctx.fn.params[pi].ty;
-        val psz:  u64  = ir_type.byte_size(ctx.types, pty, ctx.tgt)::u64;
-        val pfl:  bool = value_is_float(ctx, pty);
         val pag:  bool = value_is_aggregate(ctx, pty);
-        val slot: abi.ParamSlot = classify_arg(arch, pi::i32, psz, 0, pfl, pag, gp_used, fp_used);
+        val slot: abi.ParamSlot = layout.params[pi];
 
-        val er: Result[bool, str] = emit_param_slot(ctx, mb, slot, pv, psz, stack_off, pag);
-        if (is_err[bool, str](er)) { ret er; }
-
-        if (slot.class == abi.CLASS_FP) {
-            fp_used = fp_used + 1;
-        } or (slot.class == abi.CLASS_GP) {
-            gp_used = gp_used + 1;
-            if (slot.reg2 >= 0) { gp_used = gp_used + 1; }
-        } or (slot.class == abi.CLASS_BYREF) {
-            gp_used = gp_used + 1;
-        } or (slot.class == abi.CLASS_STACK) {
-            stack_off = stack_off + stack_slot_bytes(slot.size);
+        val er: Result[bool, str] = emit_param_slot(ctx, mb, slot, pv, slot.size, slot.offset, pag);
+        if (is_err[bool, str](er)) {
+            sig_layout_free(ctx, ?layout);
+            ret er;
         }
         pi = pi + 1;
     }
+
+    sig_layout_free(ctx, ?layout);
     ret ok[bool, str](true);
 }
 
@@ -3361,23 +3528,21 @@ fun lower_ret(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction) Result[bo
     if (inst.operand_count == 0) {
         ret emit_bare_ret(ctx, mb);
     }
-    val rok: Result[bool, str] = require_abi(ctx.tgt);
-    if (is_err[bool, str](rok)) { ret rok; }
-
-    val arch: u32 = ctx.tgt.arch_id;
     val rv:   value.Value = inst.operands[0];
     # classify the return ABI from the function's declared return type, not the
     # value operand's IR type: an aggregate flows by address, so `rv.ty` is a
     # pointer (8 bytes) and would misclassify a >16-byte aggregate as a scalar
     # RAX return (returning a pointer to a dead local). the declared return type
-    # carries the true size/shape, matching the hidden-pointer reservation
-    # `lower_params` already classifies from `fn_return_type`.
+    # carries the true size/shape. the same whole-signature oracle the caller and
+    # `lower_params` use returns the slot, so the return placement is identical.
     val rt:   ir_type.IrTypeId = fn_return_type(ctx);
     val rsz:  u64  = ir_type.byte_size(ctx.types, rt, ctx.tgt)::u64;
-    val rfl:  bool = value_is_float(ctx, rt);
     val rag:  bool = value_is_aggregate(ctx, rt);
-    val classify_ret: sysv.RetPassingFn = ctx.tgt.abi.ret_passing::sysv.RetPassingFn;
-    val slot: abi.ParamSlot = classify_ret(arch, rsz, 0, rfl, rag);
+    var layout: abi.SigLayout;
+    val cls: Result[bool, str] = classify_signature(ctx, ctx.fn.sig, rt, ?layout);
+    if (is_err[bool, str](cls)) { ret cls; }
+    val slot: abi.ParamSlot = layout.ret_slot;
+    sig_layout_free(ctx, ?layout);
     # a returned global / function symbol is its address; LEA-materialize it so
     # the scalar-register return carries the address, not the symbol's bytes. the
     # SRET / two-register branches re-`addr_to_vreg` the resulting vreg harmlessly.

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -2759,18 +2759,13 @@ fun abi_gp_ret_reg(tgt: *target.Target, out: *i32) Result[bool, str] {
 # value_is_float: true when an IR type is a floating-point scalar, so the ABI
 # classifier routes it through the FP register file.
 fun value_is_float(ctx: *LowerCtx, ty: ir_type.IrTypeId) bool {
-    val it: Option[*ir_type.IrType] = ir_type.get(ctx.types, ty);
-    if (!is_some[*ir_type.IrType](it)) { ret false; }
-    ret unwrap[*ir_type.IrType](it).kind == ir_type.IRT_FLOAT;
+    ret ir_type.is_float_scalar(ctx.types, ty);
 }
 
 # value_is_aggregate: true when an IR type is a record or array, so the ABI
 # classifier applies the aggregate (one/two-register or by-reference) rules.
 fun value_is_aggregate(ctx: *LowerCtx, ty: ir_type.IrTypeId) bool {
-    val it: Option[*ir_type.IrType] = ir_type.get(ctx.types, ty);
-    if (!is_some[*ir_type.IrType](it)) { ret false; }
-    val k: ir_type.IrTypeKind = unwrap[*ir_type.IrType](it).kind;
-    ret k == ir_type.IRT_STRUCT || k == ir_type.IRT_UNION || k == ir_type.IRT_ARRAY;
+    ret ir_type.is_aggregate(ctx.types, ty);
 }
 
 # emit_mov: append a `MIR_MOV (dst) <- (src)` to a block. used for every ABI

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -632,6 +632,17 @@ pub fun emit_call(b: *Builder, callee: value.Value, args: *value.Value, arg_coun
     val r: Result[id.InstructionId, str] = emit_raw_owned(b, instr.OP_CALL, ret_ty, ops, total);
     if (is_err[id.InstructionId, str](r)) { ret err[value.Value, str](unwrap_err[id.InstructionId, str](r)); }
     val iid: id.InstructionId = unwrap_ok[id.InstructionId, str](r);
+
+    # stamp the callee's declared IRT_FN signature onto the call (aux_ty) so the
+    # back end classifies the ABI from the declared signature, not from per-arg
+    # operand types that can diverge. a direct call reads the callee function's
+    # `sig`; an indirect (function-pointer) call's callee value already carries
+    # the IRT_FN as its type.
+    var sig: ir_type.IrTypeId = callee.ty;
+    if (callee.kind == value.VAL_FN && callee.data.fn_ix < b.m.function_len) {
+        sig = b.m.functions[callee.data.fn_ix].sig;
+    }
+    b.fn.instrs[iid].aux_ty = sig;
     ret ok[value.Value, str](value.instr_value(iid, ret_ty));
 }
 

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -29,6 +29,8 @@ use std.types.string.str;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
+use std.types.option.is_none;
+use std.types.option.unwrap;
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
@@ -485,6 +487,8 @@ pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
 pub fun byte_offset(t: *IrTypeTable, id: IrTypeId, field_ix: u32, tgt: *target.Target) u32 {
     if (id >= t.len) { ret 0; }
     val ir: *IrType = ?t.types[id];
+    # a union's members all overlap at offset 0.
+    if (ir.kind == IRT_UNION) { ret 0; }
     if (ir.kind != IRT_STRUCT) { ret 0; }
     var off: u32 = 0;
     var i:   u32 = 0;
@@ -565,11 +569,32 @@ fun id_seq_equals(a: *IrTypeId, b: *IrTypeId, n: u32) bool {
     ret true;
 }
 
-fun round_up(value: u32, align: u32) u32 {
+pub fun round_up(value: u32, align: u32) u32 {
     if (align <= 1) { ret value; }
     val rem: u32 = value % align;
     if (rem == 0) { ret value; }
     ret value + (align - rem);
+}
+
+# is_aggregate: true when a type is a record, union, or array — i.e. a value that
+# flows by address and is copied/passed/returned by value, not in a single
+# register. THE single classifier the lowerer (`is_aggregate_ir`) and the back end
+# (`value_is_aggregate`) both consult, so they cannot disagree. an unresolvable id
+# is not aggregate (the verifier flags a stale id separately).
+pub fun is_aggregate(t: *IrTypeTable, id: IrTypeId) bool {
+    val o: Option[*IrType] = get(t, id);
+    if (is_none[*IrType](o)) { ret false; }
+    val k: IrTypeKind = unwrap[*IrType](o).kind;
+    ret k == IRT_STRUCT || k == IRT_UNION || k == IRT_ARRAY;
+}
+
+# is_float_scalar: true when a type is a scalar floating-point value (one SSE
+# register). deliberately scalar-only — an all-float aggregate's per-eightbyte SSE
+# classification is the ABI layer's concern, not this predicate's.
+pub fun is_float_scalar(t: *IrTypeTable, id: IrTypeId) bool {
+    val o: Option[*IrType] = get(t, id);
+    if (is_none[*IrType](o)) { ret false; }
+    ret unwrap[*IrType](o).kind == IRT_FLOAT;
 }
 
 fun bits_to_bytes(bits: u32) u32 {

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -63,6 +63,20 @@ pub val VC_DOMINANCE:       VerifyCheck = 8;
 # a non-entry block is unreachable (empty preds, referenced nowhere).
 pub val VC_REACHABILITY:    VerifyCheck = 9;
 
+# an operand whose type is an aggregate (record/union/array) does not name its
+# storage by address: an aggregate value flows by address, so it must be a global,
+# a parameter, or the result of an address-producing instruction
+# (alloca/gep/load/call/bitcast). a VAL_CONST_* tagged aggregate, or an aggregate
+# value produced by a non-address op, is a dropped retype that miscompiles into an
+# 8-byte move instead of a sized copy.
+pub val VC_AGG_ADDRESS:     VerifyCheck = 10;
+
+# an operand carries a type id that does not resolve in the module's type table
+# (and is not the IRT_NIL sentinel), or a GEP's source-pointee aux_ty is
+# unresolvable. a stale id silently classifies as scalar/size-8 downstream,
+# turning a sized memcpy into a truncated move.
+pub val VC_TYPE_RESOLVE:    VerifyCheck = 11;
+
 # one invariant failure, located as precisely as the failing check allows.
 # ---
 # function: index into Module.functions
@@ -100,7 +114,7 @@ val INITIAL_VIOLATION_CAP: u32 = 8;
 # alloc: allocator for the report's violations array
 # ret:   a VerifyReport, or an allocation error
 pub fun verify_module(m: *ir.Module, alloc: *Allocator) Result[VerifyReport, str] {
-    ret verify_module_ext(m, alloc, true);
+    ret verify_module_ext(m, alloc, true, false);
 }
 
 # verify_module_ext: as verify_module, but `full` selects whether the CFG-shape
@@ -115,7 +129,7 @@ pub fun verify_module(m: *ir.Module, alloc: *Allocator) Result[VerifyReport, str
 # alloc: allocator for the report's violations array
 # full:  enforce reachability / dominance (post-DCE invariants)
 # ret:   a VerifyReport, or an allocation error
-pub fun verify_module_ext(m: *ir.Module, alloc: *Allocator, full: bool) Result[VerifyReport, str] {
+pub fun verify_module_ext(m: *ir.Module, alloc: *Allocator, full: bool, repr: bool) Result[VerifyReport, str] {
     var r: VerifyReport;
     r.alloc      = alloc;
     r.violations = nil;
@@ -126,7 +140,7 @@ pub fun verify_module_ext(m: *ir.Module, alloc: *Allocator, full: bool) Result[V
 
     var fi: u32 = 0;
     for (fi < m.function_len) {
-        val vr: Result[bool, str] = verify_function(m, ?m.functions[fi], fi, ?r, full);
+        val vr: Result[bool, str] = verify_function(m, ?m.functions[fi], fi, ?r, full, repr);
         if (is_err[bool, str](vr)) {
             dnit_report(?r);
             ret err[VerifyReport, str](unwrap_err[bool, str](vr));
@@ -165,12 +179,14 @@ pub fun describe(check: VerifyCheck) str {
     if (check == VC_CONST_TYPE)      { ret "constant typing: constant carries an incompatible type"; }
     if (check == VC_DOMINANCE)       { ret "dominance: operand definition does not dominate its use"; }
     if (check == VC_REACHABILITY)    { ret "reachability: block is unreachable"; }
+    if (check == VC_AGG_ADDRESS)     { ret "aggregate representation: aggregate-typed operand is not address-producing"; }
+    if (check == VC_TYPE_RESOLVE)    { ret "type resolution: operand or gep aux type does not resolve"; }
     ret "unknown verification check";
 }
 
 # validates one function, recording violations into the report. extern
 # functions (no body) are skipped. returns err only on allocation failure.
-fun verify_function(m: *ir.Module, fn: *ir.Function, fi: u32, r: *VerifyReport, full: bool) Result[bool, str] {
+fun verify_function(m: *ir.Module, fn: *ir.Function, fi: u32, r: *VerifyReport, full: bool, repr: bool) Result[bool, str] {
     if ((fn.flags & ir.FN_FLAG_EXTERN) != 0) { ret ok[bool, str](true); }
     if (fn.block_count == 0) { ret ok[bool, str](true); }
 
@@ -187,7 +203,7 @@ fun verify_function(m: *ir.Module, fn: *ir.Function, fi: u32, r: *VerifyReport, 
         if (is_err[bool, str](tu)) { ret tu; }
         val se: Result[bool, str] = check_successors(fn, blk, fi, r);
         if (is_err[bool, str](se)) { ret se; }
-        val ar: Result[bool, str] = check_arity_and_consts(m, fn, blk, fi, r);
+        val ar: Result[bool, str] = check_arity_and_consts(m, fn, blk, fi, r, repr);
         if (is_err[bool, str](ar)) { ret ar; }
         bi = bi + 1;
     }
@@ -321,28 +337,28 @@ fun check_successors(fn: *ir.Function, blk: *ir.Block, fi: u32, r: *VerifyReport
 
 # VC_OPERAND_TYPE (arity) + VC_CONST_TYPE: per-instruction operand-count and
 # constant-typing checks over a block's phis, body, and terminator.
-fun check_arity_and_consts(m: *ir.Module, fn: *ir.Function, blk: *ir.Block, fi: u32, r: *VerifyReport) Result[bool, str] {
+fun check_arity_and_consts(m: *ir.Module, fn: *ir.Function, blk: *ir.Block, fi: u32, r: *VerifyReport, repr: bool) Result[bool, str] {
     var p: u32 = 0;
     for (p < blk.phi_count) {
-        val rr: Result[bool, str] = check_one_instr(m, fn, blk.phis[p], fi, blk.id, r);
+        val rr: Result[bool, str] = check_one_instr(m, fn, blk.phis[p], fi, blk.id, r, repr);
         if (is_err[bool, str](rr)) { ret rr; }
         p = p + 1;
     }
     var ix: u32 = 0;
     for (ix < blk.instr_count) {
-        val rr: Result[bool, str] = check_one_instr(m, fn, blk.instructions[ix], fi, blk.id, r);
+        val rr: Result[bool, str] = check_one_instr(m, fn, blk.instructions[ix], fi, blk.id, r, repr);
         if (is_err[bool, str](rr)) { ret rr; }
         ix = ix + 1;
     }
     if (blk.terminator != id.INSTR_NIL) {
-        val rr: Result[bool, str] = check_one_instr(m, fn, blk.terminator, fi, blk.id, r);
+        val rr: Result[bool, str] = check_one_instr(m, fn, blk.terminator, fi, blk.id, r, repr);
         if (is_err[bool, str](rr)) { ret rr; }
     }
     ret ok[bool, str](true);
 }
 
 # arity + constant-type checks for a single instruction.
-fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: u32, bid: id.BlockId, r: *VerifyReport) Result[bool, str] {
+fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: u32, bid: id.BlockId, r: *VerifyReport, repr: bool) Result[bool, str] {
     if (iid >= fn.instr_len) { ret ok[bool, str](true); }
     val ins: *instr.Instruction = ?fn.instrs[iid];
 
@@ -358,9 +374,55 @@ fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: 
             val rr: Result[bool, str] = push(r, fi, bid, iid, VC_CONST_TYPE);
             if (is_err[bool, str](rr)) { ret rr; }
         }
+        # the aggregate-representation invariants are opt-in until a clean
+        # self-host promotes them to always-on (see pipeline `verify_ir`).
+        if (repr) {
+            # VC_TYPE_RESOLVE: a non-sentinel operand type must resolve.
+            if (op.ty != ir_type.IRT_NIL) {
+                val ot: Option[*ir_type.IrType] = ir_type.get(?m.types, op.ty);
+                if (!is_some[*ir_type.IrType](ot)) {
+                    val rr: Result[bool, str] = push(r, fi, bid, iid, VC_TYPE_RESOLVE);
+                    if (is_err[bool, str](rr)) { ret rr; }
+                }
+            }
+            # VC_AGG_ADDRESS: an aggregate-typed operand must name storage by address.
+            if (ir_type.is_aggregate(?m.types, op.ty) && !agg_value_is_address_producing(fn, op)) {
+                val rr: Result[bool, str] = push(r, fi, bid, iid, VC_AGG_ADDRESS);
+                if (is_err[bool, str](rr)) { ret rr; }
+            }
+        }
         oi = oi + 1;
     }
+    # VC_TYPE_RESOLVE: a GEP with indices descends from its source-pointee aux_ty;
+    # it must resolve (an aggregate kind is NOT required — a single-index pointer
+    # stride legitimately walks a scalar element type).
+    if (repr && ins.kind == instr.OP_GEP && ins.operand_count > 1) {
+        val at: Option[*ir_type.IrType] = ir_type.get(?m.types, ins.aux_ty);
+        if (!is_some[*ir_type.IrType](at)) {
+            val rr: Result[bool, str] = push(r, fi, bid, iid, VC_TYPE_RESOLVE);
+            if (is_err[bool, str](rr)) { ret rr; }
+        }
+    }
     ret ok[bool, str](true);
+}
+
+# agg_value_is_address_producing: an aggregate value flows by address, so a valid
+# aggregate-typed operand must be a global (its symbol IS the address), a parameter
+# (lower_params establishes its storage), or the result of an address-producing
+# instruction. alloca/gep yield addresses directly; load/call/bitcast pass an
+# aggregate's storage pointer through (the back end reads it by reference). a
+# constant cannot be an aggregate's storage address.
+fun agg_value_is_address_producing(fn: *ir.Function, op: *value.Value) bool {
+    if (op.kind == value.VAL_GLOBAL) { ret true; }
+    if (op.kind == value.VAL_PARAM)  { ret true; }
+    if (op.kind == value.VAL_INSTR) {
+        val did: id.InstructionId = op.data.instr;
+        if (did >= fn.instr_len) { ret false; }
+        val k: instr.InstrKind = (?fn.instrs[did]).kind;
+        ret k == instr.OP_ALLOCA || k == instr.OP_GEP || k == instr.OP_LOAD
+            || k == instr.OP_CALL || k == instr.OP_BITCAST;
+    }
+    ret false;
 }
 
 # VC_PRED_CONSISTENT: a block's recorded preds must equal the multiset of

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1200,10 +1200,7 @@ fun is_pointer_type(ctx: *lower.LowerContext, tid: ty.TypeId) bool {
 # reference argument passing and aggregate returns. classifies on the IR type
 # so the test matches the back end's `mir.value_is_aggregate` exactly.
 fun is_aggregate_ir(ctx: *lower.LowerContext, ity: ir_type.IrTypeId) bool {
-    val it: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ity);
-    if (is_none[*ir_type.IrType](it)) { ret false; }
-    val k: ir_type.IrTypeKind = unwrap[*ir_type.IrType](it).kind;
-    ret k == ir_type.IRT_STRUCT || k == ir_type.IRT_UNION || k == ir_type.IRT_ARRAY;
+    ret ir_type.is_aggregate(?ctx.m.types, ity);
 }
 
 # resolves a member name to a field index within a nominal semantic type by

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -45,43 +45,63 @@ pub val OPT_RELEASE: OptLevel = 1;
 # tgt:   target — passed to the passes that consult a cost model (inline)
 # level: selects the stage sequence (debug vs release)
 # ret:   ok(true) on a clean pipeline, or an internal-compiler-error message
-pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel) Result[bool, str] {
+pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool) Result[bool, str] {
     # entry verification: sanity-check the lowered input. reachability and
     # dominance are not enforced here — freshly-lowered IR carries the
     # unreachable blocks the lowerer parks after terminators, which `dce`
-    # removes below.
-    val rv_in: Result[bool, str] = run_verify(m, false);
+    # removes below. the aggregate-representation checks (`repr`) are opt-in via
+    # --verify-ir per-pass below; the always-on entry/exit runs keep `repr=false`
+    # until a clean self-host promotes them.
+    val rv_in: Result[bool, str] = run_verify(m, false, false);
     if (is_err[bool, str](rv_in)) { ret rv_in; }
 
     # mem2reg always runs — code generation expects mostly-SSA input.
     val rm: Result[bool, str] = mem2reg.run(m);
     if (is_err[bool, str](rm)) { ret rm; }
+    if (verify_ir) {
+        val rvm: Result[bool, str] = run_verify(m, false, true);
+        if (is_err[bool, str](rvm)) { ret rvm; }
+    }
 
     # dce always runs: beyond cleaning dead values, its reachability sweep
     # removes the unreachable blocks lowering left behind, so the back end
     # receives a connected CFG at every optimisation level.
     val rd0: Result[bool, str] = dce.run(m);
     if (is_err[bool, str](rd0)) { ret rd0; }
+    # after dce the CFG is connected: reachability/dominance hold (full=true).
+    if (verify_ir) {
+        val rvd: Result[bool, str] = run_verify(m, true, true);
+        if (is_err[bool, str](rvd)) { ret rvd; }
+    }
 
     if (level == OPT_RELEASE) {
         # inline: single-use and small functions.
         val ri: Result[bool, str] = inline.run(m, tgt);
         if (is_err[bool, str](ri)) { ret ri; }
+        if (verify_ir) {
+            val rvi: Result[bool, str] = run_verify(m, true, true);
+            if (is_err[bool, str](rvi)) { ret rvi; }
+        }
 
         # late dce: sweep up now-dead calls and branches from inlining.
         val rd1: Result[bool, str] = dce.run(m);
         if (is_err[bool, str](rd1)) { ret rd1; }
+        if (verify_ir) {
+            val rvl: Result[bool, str] = run_verify(m, true, true);
+            if (is_err[bool, str](rvl)) { ret rvl; }
+        }
     }
 
     # exit verification: full invariant check before the backend takes over.
-    ret run_verify(m, true);
+    ret run_verify(m, true, false);
 }
 
 # runs the verifier over `m` and maps a non-empty report into an err carrying
 # the description of the first failed check. A clean module yields ok(true).
-# `full` enforces the post-DCE reachability / dominance invariants.
-fun run_verify(m: *ir.Module, full: bool) Result[bool, str] {
-    val rr: Result[verify.VerifyReport, str] = verify.verify_module_ext(m, m.alloc, full);
+# `full` enforces the post-DCE reachability / dominance invariants; `repr`
+# enables the opt-in aggregate-representation checks.
+fun run_verify(m: *ir.Module, full: bool, repr: bool) Result[bool, str] {
+    val rr: Result[verify.VerifyReport, str] = verify.verify_module_ext(m, m.alloc, full, repr);
     if (is_err[verify.VerifyReport, str](rr)) {
         ret err[bool, str](unwrap_err[verify.VerifyReport, str](rr));
     }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -144,6 +144,36 @@ pub fun lookup(abi_id: u32) Option[*AbiVTable] {
     ret some[*AbiVTable](abi_registry[abi_id]);
 }
 
+# whole-signature ABI layout: the placement of a function's return value and
+# each of its fixed parameters, classified together in one left-to-right walk so
+# the running GP/FP register and stack cursors stay coherent across the return's
+# sret reservation and every parameter. computed once from the declared `IRT_FN`
+# by the backend's `classify_signature` and shared by the param / return / call
+# lowering so the three can never disagree.
+#
+# `params` is a borrowed pointer into a caller-owned `ParamSlot` buffer (the
+# backend allocates and frees it around the lowering of one signature — see
+# `classify_signature`); each fixed parameter's slot carries the real outgoing
+# stack offset in `ParamSlot.offset` (an eight-byte-granular cursor), unlike the
+# sizing-only slots `classify_arg` returns. `gp_used` / `fp_used` / `stack_off`
+# are the running cursors AFTER the fixed parameters, so a variadic call's tail
+# arguments (positions beyond `param_count`) continue classifying from them.
+# ---
+# ret_slot:    the return value's placement (CLASS_SRET reserves the first GP reg)
+# params:      borrowed array of per-fixed-parameter slots (len param_count)
+# param_count: number of fixed parameters classified
+# gp_used:     GP argument registers consumed by sret + fixed params
+# fp_used:     FP argument registers consumed by fixed params
+# stack_off:   outgoing stack bytes consumed by fixed params (eight-byte-granular)
+pub rec SigLayout {
+    ret_slot:    ParamSlot;
+    params:      *ParamSlot;
+    param_count: u32;
+    gp_used:     i32;
+    fp_used:     i32;
+    stack_off:   i64;
+}
+
 # make_slot: build a ParamSlot. convenience for ABI implementations.
 # ---
 # class:  classification


### PR DESCRIPTION
Implements the structural cure for the recurring aggregate-handling bug class
(see #1002): two parts of the compiler disagreeing about how an aggregate value
is laid out or crosses a boundary, surfacing far downstream as a corrupted pointer.

## Pillars

- **#1004 layout oracle** ✅ — `ir_type.is_aggregate` / `is_float_scalar` are now THE
  shared classifiers; `value_is_aggregate` (mir), `is_aggregate_ir` (lower), and
  `value_is_float` collapse to thin wrappers so the lowerer and back end cannot
  disagree. `round_up` is pub; the union member offset is explicit. Behavior-neutral.
- **#1003 IR verifier** ✅ — `VC_AGG_ADDRESS` (an aggregate-typed operand must name
  storage by address) and `VC_TYPE_RESOLVE` (operand/GEP-aux types must resolve),
  gated behind `--verify-ir`, run after every me/pass. Clean across all 114 compiler
  modules (no false positives). Localizes the class to a precise pass + instruction.
- **#1005 ABI legalize** 🚧 — one `classify_signature` keyed on the declared `IRT_FN`,
  consumed by `lower_call`/`lower_params`/`lower_ret`, replacing the three
  convention-synced classification sites. (in progress on this branch)

Deferred follow-ups: per-eightbyte SSE classification for mixed/all-float 9–16B
aggregates (kept two-GP, internally consistent — only C FFI on `{double,double}`
differs); collapsing sema's frontend-layer `byte_size` stub (different layer, only
gates a cast optimization, not codegen layout).

NOTE: CI is red until the self-hosted compiler reaches its fixpoint — expected.

Closes #1003, #1004. Advances #1005, #1002.