### PR TITLE
Zero-initialize uninitialized val/var locals (#1007)

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -1572,6 +1572,9 @@ fun lower_instr(ctx: *LowerCtx, fn: *ir.Function, mb: *MirBlock, iid: id.Instruc
     if (inst.kind == instr.OP_STORE) {
         ret lower_store(ctx, mb, inst);
     }
+    if (inst.kind == instr.OP_MEMZERO) {
+        ret lower_memzero(ctx, mb, inst);
+    }
     if (inst.kind == instr.OP_GEP) {
         ret lower_gep(ctx, mb, inst, iid);
     }
@@ -2320,6 +2323,45 @@ fun lower_store_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instructio
         if (is_err[bool, str](pl)) { ret pl; }
 
         val st: Result[bool, str] = push_store_chunk(ctx, mb, dst, op_vreg(tmp), chunk);
+        if (is_err[bool, str](st)) { ret st; }
+
+        off = off + chunk::i64;
+    }
+    ret ok[bool, str](true);
+}
+
+
+# lower_memzero: expand an OP_MEMZERO into a sized zero-fill of the destination
+# aggregate's storage. operand 0 is the destination pointer and `aux_ty` is the
+# pointee aggregate type whose `byte_size` is the byte count to clear (operand 0
+# is an untyped IRT_PTR, so the size cannot come from its `.ty` — it must come
+# from `aux_ty`). mirrors `lower_store_aggregate`, but each chunk stores an
+# immediate 0 (`MOV [mem], 0`) rather than a value loaded from a source — no
+# scratch register and no source read. the fill walks 8/4/2/1-byte chunks so a
+# 4/2/1-byte tail clears exactly its bytes without writing past the aggregate.
+# a zero-sized aggregate clears nothing.
+fun lower_memzero(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction) Result[bool, str] {
+    if (inst.operand_count < 1) {
+        ret err[bool, str]("mir.lower_ir: memzero missing destination pointer operand");
+    }
+    if (inst.aux_ty == ir_type.IRT_NIL) {
+        ret err[bool, str]("mir.lower_ir: memzero is missing its pointee type");
+    }
+    val size: u32 = ir_type.byte_size(ctx.types, inst.aux_ty, ctx.tgt);
+    var off: i64 = 0;
+    for (off::u32 < size) {
+        val remaining: u32 = size - off::u32;
+        var chunk: u8 = 1;
+        if (remaining >= 8) {
+            chunk = 8;
+        } or (remaining >= 4) {
+            chunk = 4;
+        } or (remaining >= 2) {
+            chunk = 2;
+        }
+
+        val dst: MirOperand = agg_pointer_mem(ctx, inst.operands[0], off);
+        val st: Result[bool, str] = push_store_chunk(ctx, mb, dst, op_imm(0), chunk);
         if (is_err[bool, str](st)) { ret st; }
 
         off = off + chunk::i64;

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -482,6 +482,33 @@ pub fun emit_store(b: *Builder, value_arg: value.Value, ptr: value.Value) Result
     ret ok[bool, str](true);
 }
 
+
+# emits a zero-fill of the aggregate at `ptr`. produces no value (void
+# instruction). `pointee_ty` is the aggregate type whose `byte_size` the back
+# end zeroes, recorded on the instruction (`aux_ty`) since the pointer operand
+# is untyped (IRT_PTR). `aux_ty` is not verified, so the caller must pass a
+# resolvable aggregate type; lower_decl_stmt passes the slot type. used to
+# zero-initialize an aggregate local that has no initializer — a scalar local
+# uses a plain typed zero store instead so mem2reg can still promote it.
+# ---
+# b:          the builder
+# ptr:        destination pointer (the aggregate's storage address)
+# pointee_ty: the aggregate type to zero (sizes the fill)
+# ret:        ok(true) on success, or an error
+pub fun emit_memzero(b: *Builder, ptr: value.Value, pointee_ty: ir_type.IrTypeId) Result[bool, str] {
+    val vr: Result[ir_type.IrTypeId, str] = void_type(b);
+    if (is_err[ir_type.IrTypeId, str](vr)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](vr)); }
+    val vty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](vr);
+
+    var ops: [1]value.Value;
+    ops[0] = ptr;
+    val r: Result[id.InstructionId, str] = emit_raw(b, instr.OP_MEMZERO, vty, ?ops[0], 1);
+    if (is_err[id.InstructionId, str](r)) { ret err[bool, str](unwrap_err[id.InstructionId, str](r)); }
+    val iid: id.InstructionId = unwrap_ok[id.InstructionId, str](r);
+    b.fn.instrs[iid].aux_ty = pointee_ty;
+    ret ok[bool, str](true);
+}
+
 # emits an address computation: `base` adjusted by the given indices. the
 # result is a pointer. operand order is [base, idx0, idx1, ...]. the index walk
 # follows the standard getelementptr model: index 0 strides over the source

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -129,6 +129,13 @@ pub val OP_UNREACHABLE: InstrKind = 42;
 # inline assembly; the body and operands live in Function.asm keyed by id.
 pub val OP_ASM:         InstrKind = 43;
 
+# zero-fill a memory region; operand [ptr]; produces no value. `aux_ty` carries
+# the pointee type whose `byte_size` is the number of bytes zeroed (used to
+# zero-initialize an aggregate local that has no initializer). a scalar local
+# is zeroed with an ordinary typed OP_STORE of a zero constant instead, so this
+# opcode is reserved for record / union / array slots.
+pub val OP_MEMZERO:     InstrKind = 44;
+
 # no-signed-wrap: the result is poison if signed overflow occurs.
 pub val INSTR_FLAG_NSW:      u16 = 0x01;
 # no-unsigned-wrap: the result is poison if unsigned overflow occurs.
@@ -150,7 +157,9 @@ pub val INSTR_FLAG_VOLATILE: u16 = 0x08;
 #                pointee type the index walk starts from (an aggregate / element
 #                type), since the base pointer is untyped (IRT_PTR) and so cannot
 #                supply the element/field sizes the backend needs to turn each
-#                index into a byte offset. IRT_NIL for every other opcode.
+#                index into a byte offset. for OP_MEMZERO it is the aggregate
+#                pointee type whose `byte_size` is the number of bytes zeroed.
+#                IRT_NIL for every other opcode.
 pub rec Instruction {
     kind:          InstrKind;
     ty:            ir_type.IrTypeId;
@@ -185,6 +194,7 @@ pub fun is_terminator(k: InstrKind) bool {
 pub fun is_pure(k: InstrKind) bool {
     if (is_terminator(k)) { ret false; }
     if (k == OP_STORE)    { ret false; }
+    if (k == OP_MEMZERO)  { ret false; }
     if (k == OP_LOAD)     { ret false; }
     if (k == OP_CALL)     { ret false; }
     if (k == OP_ALLOCA)   { ret false; }

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -497,6 +497,7 @@ fun print_flag_suffixes(out: *writer.Writer, flags: u16) Result[bool, str] {
 fun produces_value(k: instr.InstrKind) bool {
     if (instr.is_terminator(k)) { ret false; }
     if (k == instr.OP_STORE) { ret false; }
+    if (k == instr.OP_MEMZERO) { ret false; }
     if (k == instr.OP_ASM)   { ret false; }
     ret true;
 }
@@ -537,6 +538,7 @@ fun opcode_name(k: instr.InstrKind) str {
     if (k == instr.OP_ALLOCA)      { ret "alloca"; }
     if (k == instr.OP_LOAD)        { ret "load"; }
     if (k == instr.OP_STORE)       { ret "store"; }
+    if (k == instr.OP_MEMZERO)     { ret "memzero"; }
     if (k == instr.OP_GEP)         { ret "gep"; }
     if (k == instr.OP_EXTRACT)     { ret "extract"; }
     if (k == instr.OP_INSERT)      { ret "insert"; }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -751,6 +751,8 @@ fun arity_ok(k: instr.InstrKind, count: u32) bool {
     }
     # store: [value, ptr].
     if (k == instr.OP_STORE) { ret count == 2; }
+    # memzero: [ptr].
+    if (k == instr.OP_MEMZERO) { ret count == 1; }
     # extract: [agg, index]; insert: [agg, index, element].
     if (k == instr.OP_EXTRACT) { ret count == 2; }
     if (k == instr.OP_INSERT)  { ret count == 3; }

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -291,6 +291,21 @@ pub fun run_pending_fins(ctx: *lower.LowerContext) Result[bool, str] {
     ret run_fins(ctx);
 }
 
+# builds the typed zero constant for a scalar / pointer / float slot type, so a
+# zero store passes the verifier's constant-typing rule (a float constant must
+# carry an IRT_FLOAT type; an integer / pointer constant an IRT_INT or IRT_PTR
+# type). the bit pattern is 0 in every case: 0.0 has an all-zero f64 encoding
+# and a null pointer is the zero address.
+fun zero_const(ctx: *lower.LowerContext, ty: ir_type.IrTypeId) value.Value {
+    val o: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ty);
+    if (is_some[*ir_type.IrType](o)) {
+        if (unwrap[*ir_type.IrType](o).kind == ir_type.IRT_FLOAT) {
+            ret value.const_float(0.0, ty);
+        }
+    }
+    ret value.const_int(0, ty);
+}
+
 # lowers a local `val` / `var`: allocate a stack slot, store the initial
 # value if present, and bind the source SymbolId to the slot pointer so
 # later reads / writes lower to load / store. mem2reg promotes the slot.
@@ -326,6 +341,19 @@ fun lower_decl_stmt(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] 
         if (is_err[value.Value, str](vr)) { ret err[bool, str](unwrap_err[value.Value, str](vr)); }
         val sr: Result[bool, str] = builder.emit_store(?ctx.builder, unwrap_ok[value.Value, str](vr), slot);
         if (is_err[bool, str](sr)) { ret sr; }
+    } or {
+        # an uninitialized `val` / `var` is zero-initialized (the language
+        # guarantees zeroed locals). an aggregate slot is cleared with a sized
+        # OP_MEMZERO; a scalar / pointer / float slot takes a typed zero store
+        # that mem2reg promotes and dce drops when the local is never read, so
+        # zeroing never pessimizes a scalar local.
+        if (ir_type.is_aggregate(?ctx.m.types, slot_ty)) {
+            val zr: Result[bool, str] = builder.emit_memzero(?ctx.builder, slot, slot_ty);
+            if (is_err[bool, str](zr)) { ret zr; }
+        } or {
+            val zr: Result[bool, str] = builder.emit_store(?ctx.builder, zero_const(ctx, slot_ty), slot);
+            if (is_err[bool, str](zr)) { ret zr; }
+        }
     }
 
     ret ok[bool, str](true);


### PR DESCRIPTION
Closes #1007.

The language guarantees an uninitialized `val`/`var` is zero-initialized, but
`lower_decl_stmt` only stored when an initializer was present — leaving the
alloca as stack garbage. Surfaced during #1005's adversarial review.

Fix (authored + 3-lens adversarially verified via ultracode):
- **scalar/ptr/float** slot → a typed zero store (`zero_const`); mem2reg keeps it
  promotable and DCE drops it when the local is never read, so scalars aren't pessimized.
- **aggregate** slot → new first-class void op `OP_MEMZERO` whose backend lowering
  mirrors `copy_aggregate` with immediate-0 in 8/4/2/1 chunks, sized from
  `byte_size(aux_ty)` so all inter-field/trailing padding is cleared.

Op wired into `is_pure`/arity/printer/dispatch; `--verify-ir`-clean across all 114
modules; `cmach→imach→smach` self-builds clean; only the uninitialized path changes.

CI red until the self-host fixpoint — expected.