### PR TITLE
fix(codegen): symbol-value addressing + string-literal blob emission

### DIFF
--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -360,10 +360,10 @@ fun pack_relocs(image: *of.ObjectImage, enc: *encode.EncoderOutput,
     ret ok[bool, str](true);
 }
 
-# materialise every module global into the image. a global with constant byte
-# content becomes a `.rodata` (immutable) or `.data` (mutable) section; one with
-# no initial bytes becomes a zero-filled `.bss` entry. each global gets a
-# defining symbol pointing at its section.
+# materialise every module global into the image. a global with an initializer
+# becomes a `.rodata` (immutable) or `.data` (mutable) section; one with no
+# initializer becomes a zero-filled `.bss` entry sized from its type. each global
+# gets a defining symbol pointing at its section.
 # ---
 # s:     session, for interning section names
 # image: object image being built
@@ -423,9 +423,15 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
             }
         }
 
+        # a global with an initializer (a non-nil byte image) is initialized data
+        # and belongs in .data/.rodata; only a global with no initializer at all
+        # (bytes == nil) is a zero-filled .bss reservation. routing on `len > 0`
+        # instead would misclassify an empty-but-present initializer (e.g. the
+        # "" string literal, a single '\0' byte) as bss, emitting a malformed
+        # section (kind bss yet bytes non-nil) whose symbol resolves to null.
         var kind: of.SectionKind = of.SK_BSS;
         var sname: str = ".bss";
-        if (bytes != nil && len > 0) {
+        if (bytes != nil) {
             if (g.is_mut) {
                 kind  = of.SK_DATA;
                 sname = ".data";

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -1371,11 +1371,17 @@ fun insert_mov_before_terminator(ctx: *LowerCtx, mb: *MirBlock, dst: MirOperand,
     ops[0] = dst;
     ops[1] = src;
     var mi: MirInstr;
+    # a phi merge copy is normally a register-to-register / immediate move; the
+    # full-width move copies the value's low bits intact regardless of its logical
+    # width. but a global / function symbol incoming value is its ADDRESS as an
+    # rvalue: a MIR_MOV of a symbol selects to `mov dst, [sym]` (loading the
+    # symbol's contents), so it is emitted as the address-computing MIR_GEP
+    # (`lea dst, [sym]`) instead — the same LEA-materialization the store /
+    # call-arg / return symbol paths use.
     mi.opcode        = MIR_MOV;
+    if (src.kind == MIR_OP_SYM) { mi.opcode = MIR_GEP; }
     mi.operands      = ops;
     mi.operand_count = 2;
-    # a phi merge copy is a register-to-register / immediate move; the full-width
-    # move copies the value's low bits intact regardless of its logical width.
     mi.width         = WORD_WIDTH;
     mi.src_width     = WORD_WIDTH;
 
@@ -1964,7 +1970,19 @@ fun lower_generic(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: 
 
     var k: u32 = 0;
     for (k < inst.operand_count) {
-        ops[base + k] = lower_operand(ctx, inst, k);
+        var op: MirOperand = lower_operand(ctx, inst, k);
+        # a global / function symbol operand is its ADDRESS as an rvalue; left as a
+        # bare MIR_OP_SYM the encoder would load `[sym]` into this ALU / compare /
+        # bitcast slot (the symbol's contents) instead of its address. LEA-
+        # materialize it into a vreg first, mirroring the store / call-arg / return
+        # symbol paths.
+        if (op.kind == MIR_OP_SYM) {
+            var av: u32 = MIR_VREG_NIL;
+            val ar: Result[bool, str] = addr_to_vreg(ctx, mb, op, ?av);
+            if (is_err[bool, str](ar)) { ret ar; }
+            op = op_vreg(av);
+        }
+        ops[base + k] = op;
         k = k + 1;
     }
 

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -178,7 +178,12 @@ fun lower_lit_str(ctx: *lower.LowerContext, e: *aexpr.Expr) Result[value.Value, 
 
     # materialise the literal as an anonymous `.rodata` global and yield a
     # pointer to it; a raw byte blob must not reach the back end as an operand.
-    val blob: value.Value = value.const_bytes(bytes::*u8, str_len(bytes)::u32, pty);
+    # the blob length includes the trailing '\0' (the interned bytes are
+    # null-terminated): a `str` is a thin `*char` walked to its terminator, so the
+    # terminator must be part of the emitted data rather than left to depend on a
+    # section's alignment padding — which an empty literal (0 content bytes) has
+    # none of, and a literal whose length is a multiple of the alignment loses.
+    val blob: value.Value = value.const_bytes(bytes::*u8, (str_len(bytes) + 1::usize)::u32, pty);
     ret lower.add_rodata_bytes(ctx, blob, pty);
 }
 
@@ -1126,7 +1131,9 @@ pub fun const_value_of(ctx: *lower.LowerContext, eid: aid.ExprId, v: comptime.CT
         val txt: Option[str] = intern.lookup(?ctx.s.interner, v.data.s);
         if (is_none[str](txt)) { ret err[value.Value, str]("lower: comptime string lookup failed"); }
         val s: str = unwrap[str](txt);
-        ret ok[value.Value, str](value.const_bytes(s::*u8, str_len(s)::u32, ty_id));
+        # include the trailing '\0' so the emitted blob is a valid null-terminated
+        # `str` rather than relying on section padding (see lower_lit_str).
+        ret ok[value.Value, str](value.const_bytes(s::*u8, (str_len(s) + 1::usize)::u32, ty_id));
     }
     ret err[value.Value, str]("lower: unsupported comptime value kind");
 }


### PR DESCRIPTION
Two codegen correctness fixes found while chasing the smach→mach SIGSEGV in `find_target`.

### #1011 — symbol value loaded instead of addressed
A `VAL_GLOBAL`/`VAL_FN` value (`MIR_OP_SYM`) is the symbol's *address* as an rvalue, but in a phi merge copy or an integer ALU/compare/bitcast operand the encoder emitted `mov/op dst, [sym]` (loading its contents). The store/call-arg/return paths already LEA-materialize symbols; the phi-copy and `lower_generic` paths now do too. This was the actual crash: `target_name = ""` (a phi copy) loaded NULL → `str_len(NULL)`.

### #1012 — empty string literal mis-emitted
String-literal blobs lacked an explicit `\0` (relied on section padding), and an empty `const_bytes` fell through to a malformed `.bss` section. Blobs are now null-terminated; any `const_bytes` initializer routes to `.rodata`/`.data`.

### Verification
- cmach→imach→smach builds clean.
- `target_name = ""` now emits `lea` (address), not `mov` (load).
- smach→mach no longer SIGSEGVs in `find_target` — it now reaches a graceful target-resolution path (a separate, non-crashing bug remains).

Closes #1011
Closes #1012

> CI red until the self-host fixpoint lands (expected).