### PR TITLE
fix(driver): resolve host os/arch id via comptime helpers, not a global val

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -218,33 +218,6 @@ val INITIAL_MODULE_CAP: u32 = 16;
 val INITIAL_PUB_CAP:    u32 = 4;
 val INITIAL_DEP_CAP:    u32 = 4;
 
-# HOST_OS_ID / HOST_ARCH_ID: the os/arch this compiler binary was built
-# for, which is the host it runs on. resolved at comptime from the active
-# build target so a "native"/"host" selector picks the matching
-# [targets.<name>] entry by host os/arch.
-$if ($mach.target.os == $mach.os.linux) {
-    val HOST_OS_ID: u32 = os.OS_LINUX;
-}
-$or ($mach.target.os == $mach.os.darwin) {
-    val HOST_OS_ID: u32 = os.OS_DARWIN;
-}
-$or ($mach.target.os == $mach.os.windows) {
-    val HOST_OS_ID: u32 = os.OS_WINDOWS;
-}
-$or {
-    val HOST_OS_ID: u32 = os.OS_UNKNOWN;
-}
-
-$if ($mach.target.arch == $mach.arch.x86_64) {
-    val HOST_ARCH_ID: u32 = isa.ARCH_X86_64;
-}
-$or ($mach.target.arch == $mach.arch.aarch64) {
-    val HOST_ARCH_ID: u32 = isa.ARCH_AARCH64;
-}
-$or {
-    val HOST_ARCH_ID: u32 = isa.ARCH_UNKNOWN;
-}
-
 # build_project: load `project_root/mach.toml`, select `target_name`, and
 # build the full module graph plus per-module ResolveResults.
 # ---
@@ -781,7 +754,7 @@ fun intern_or(i: *intern.Interner, text: str, default: str) Result[intern.StrId,
 # find_target: resolve a target selector against the config's [targets.*]
 # entries. an empty selector defers to [project].target. the selectors
 # "native" and "host" resolve to the entry whose os/isa match the build
-# host (HOST_OS_ID/HOST_ARCH_ID); any other selector matches an entry by
+# host (host_os_id()/host_arch_id()); any other selector matches an entry by
 # name. returns nil when nothing matches.
 fun find_target(c: *ProjectConfig, name: str, i: *intern.Interner) *TargetEntry {
     var sel: str = name;
@@ -806,9 +779,30 @@ fun find_target(c: *ProjectConfig, name: str, i: *intern.Interner) *TargetEntry 
     ret nil;
 }
 
+# host_os_id / host_arch_id: the os/arch id this compiler binary was built for,
+# which is the host it runs on. the `$mach.target.{os,arch}` predicate folds at
+# comptime to the active build target, and each branch returns the matching
+# os.OS_* / isa.ARCH_* id — the same numeric space `os_id_for`/`arch_id_for`
+# produce. resolving the host inside a function body (not a read-only global
+# initializer) keeps the const reference an ordinary runtime load, sidestepping
+# the comptime-only fold path globals take.
+fun host_os_id() u32 {
+    $if ($mach.target.os == $mach.os.linux)   { ret os.OS_LINUX; }
+    $or ($mach.target.os == $mach.os.darwin)  { ret os.OS_DARWIN; }
+    $or ($mach.target.os == $mach.os.windows) { ret os.OS_WINDOWS; }
+    $or                                        { ret os.OS_UNKNOWN; }
+}
+fun host_arch_id() u32 {
+    $if ($mach.target.arch == $mach.arch.x86_64)  { ret isa.ARCH_X86_64; }
+    $or ($mach.target.arch == $mach.arch.aarch64) { ret isa.ARCH_AARCH64; }
+    $or                                            { ret isa.ARCH_UNKNOWN; }
+}
+
 # find_host_target: pick the [targets.<name>] entry whose os/isa map to the
 # build host's os/arch ids. returns nil when no entry matches the host.
 fun find_host_target(c: *ProjectConfig, i: *intern.Interner) *TargetEntry {
+    val h_os:   u32 = host_os_id();
+    val h_arch: u32 = host_arch_id();
     var k: u32 = 0;
     for (k < c.target_count) {
         val os_opt: Option[str] = intern.lookup(i, c.targets[k].os_name);
@@ -816,7 +810,7 @@ fun find_host_target(c: *ProjectConfig, i: *intern.Interner) *TargetEntry {
         if (is_some[str](os_opt) && is_some[str](isa_opt)) {
             val os_id:   u32 = os_id_for(unwrap[str](os_opt));
             val arch_id: u32 = arch_id_for(unwrap[str](isa_opt));
-            if (os_id == HOST_OS_ID && arch_id == HOST_ARCH_ID) { ret ?c.targets[k]; }
+            if (os_id == h_os && arch_id == h_arch) { ret ?c.targets[k]; }
         }
         k = k + 1;
     }


### PR DESCRIPTION
## Summary
smach→mach failed target resolution ("target not found in mach.toml") because `driver.mach` resolved the build host with module-level `val HOST_OS_ID: u32 = os.OS_LINUX;` inside a `$if` chain. The self-hosted compiler can't comptime-fold the **alias-qualified cross-module const** `os.OS_LINUX` in a **read-only global initializer** (`comptime.eval`'s `eval_path` only handles `$mach.*` paths), so it left a 0 placeholder — `HOST_OS_ID = OS_UNKNOWN` — and `find_host_target` never matched `[targets.linux]`.

## Fix
Replace the `HOST_OS_ID`/`HOST_ARCH_ID` module vals with `host_os_id()`/`host_arch_id()` functions whose body is a `$if ($mach.target.os == $mach.os.*)` chain returning the matching `os.OS_*`/`isa.ARCH_*` id. The predicate folds at comptime; the branch's const reference is an ordinary **runtime load in function context**, not the comptime-only global-init fold path. Mirrors the existing `host_os()`/`host_isa()` in `cli/cmd/init.mach`.

No casts, no module-level indirection — the host id is injected at the use site.

## Why this shape (cmach constraint)
The pinned bootstrap compiler cmach v0.10.2 rejects `$mach.target.os` in a *value* position (`val x = $mach.target.os` → "type mismatch"), because a `$mach.*` path in value context is typed `TYPE_ERROR` and only literals coerce. The function-body `$if` shape is already in-tree (`init.mach`) and compiles under the full toolchain. The proper language fix (make value-context `$mach.*` paths coerce like literals) is filed as #1015, deferred post-fixpoint.

## Verification
- cmach→imach→smach builds clean (no sema error).
- smach now **resolves the host target** and advances past resolution to a new, later error — confirming `host_os_id()` folds/loads to the correct id (linux=1).

Closes #1014

> CI red until the self-host fixpoint lands (expected).