### PR TITLE
fix(codegen): nil MirInstr.asm_block for non-asm instructions at the store chokepoint

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -3850,9 +3850,19 @@ fun param_vreg(ctx: *LowerCtx, ix: u32) u32 {
 
 # appends a MIR instruction to a block, growing its instruction list on demand.
 fun push_instr(ctx: *LowerCtx, mb: *MirBlock, mi: MirInstr) Result[bool, str] {
+    # enforce the asm_block invariant: a MirInstr carries an inline-asm payload only
+    # for a MIR_ASM instruction, and is nil otherwise. instructions are built
+    # field-by-field and only the MIR_ASM emitter ever sets asm_block; since struct
+    # locals are not guaranteed zero-initialized, an otherwise-indeterminate
+    # asm_block would reach the back end — `regalloc.flatten` reads `asm_block != nil`
+    # as the inline-asm clobber-barrier discriminant and would wrongly fence almost
+    # every instruction, collapsing the argument-register reservation windows. nil it
+    # here, at the single store chokepoint, so the field's documented contract holds.
+    var ni: MirInstr = mi;
+    if (ni.opcode != MIR_ASM) { ni.asm_block = nil; }
     val gr: Result[bool, str] = grow_instr(ctx, mb);
     if (is_err[bool, str](gr)) { ret gr; }
-    mb.instrs[mb.instr_count] = mi;
+    mb.instrs[mb.instr_count] = ni;
     mb.instr_count = mb.instr_count + 1;
     ret ok[bool, str](true);
 }


### PR DESCRIPTION
## Summary
`MirInstr` is built field-by-field; only the MIR_ASM emitter sets `asm_block` (contract: *"inline-asm payload for a MIR_ASM instruction, else nil"*). Struct locals aren't guaranteed zero-initialized (cmach v0.10.2, which builds imach, doesn't zero them), so `asm_block` was indeterminate (non-nil) on nearly every non-asm instruction.

`regalloc.flatten` reads `asm_block != nil` as the inline-asm clobber-barrier discriminant, so it **fenced almost every instruction**. `build_arg_reservations` then collapsed every outgoing-argument reservation window to a single position, defeating #1017's `arg_reg_busy_at`: a placed register argument (`deps` in r8) got clobbered by the reload staging a spilled **stack** argument for the same call — `init_context` wrote `rc.deps = own_module` → SIGSEGV in the resolve pass. It also broadly corrupted `crosses_call` / barrier-driven spilling.

## Fix
Enforce the invariant at the single store chokepoint `push_instr`: nil `asm_block` for any non-`MIR_ASM` instruction. One place, covers every construction site (present and future), enforces the documented contract for all consumers.

## Verification
- cmach→imach→smach builds clean.
- The `resolve`→`init_context` call now stages its stack argument via **R10**, leaving the `deps` register argument intact (was `mov -0x520(%rbp),%r8` clobbering deps).
- smach progresses past the resolve crash (now fails much deeper).

Root-caused with a read-only ultracode workflow that reproduced the bug standalone and instrumented `build_arg_reservations` (all windows were `start==end`).

Closes #1019

> CI red until the self-host fixpoint lands (expected).