### PR TITLE
fix(regalloc): reserve a precolored-register DEF against value vregs live past it

### DIFF
--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -142,6 +142,13 @@ rec LiveRange {
 #                later same-call argument's materialization cannot reuse a
 #                register already holding a placed argument
 # arg_res_count: number of outgoing-argument reservation windows
+# def_res_reg / def_res_pos: parallel records of every precolored physical
+#                register DEF (operand 0 a MIR_OP_PREG, e.g. the RAX/RDX of a
+#                two-register aggregate return's `MOV preg <- [base+n]`). a value
+#                vreg live PAST the defining position must not be colored to that
+#                register, or the def clobbers the still-live value at that
+#                instruction (the two-register-return `mov (%rax),%rax` regression)
+# def_res_count: number of precolored-DEF reservation records
 # cur_start / cur_end: the interval of the range currently being colored, so
 #                `gp_available` can test it against each outgoing-arg window
 # reload_scratch: the ISA's reload-scratch GP register ids, reserved from value
@@ -173,6 +180,9 @@ rec AllocCtx {
     arg_res_start: *i64;
     arg_res_end:   *i64;
     arg_res_count: u32;
+    def_res_reg:   *u32;
+    def_res_pos:   *i64;
+    def_res_count: u32;
     cur_start:     i64;
     cur_end:       i64;
     reload_scratch:       *isa.Register;
@@ -327,6 +337,9 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
     ctx.arg_res_start = nil;
     ctx.arg_res_end   = nil;
     ctx.arg_res_count = 0;
+    ctx.def_res_reg   = nil;
+    ctx.def_res_pos   = nil;
+    ctx.def_res_count = 0;
     ctx.cur_start     = 0;
     ctx.cur_end       = 0;
     ctx.reload_scratch       = tgt.arch.reload_scratch_regs;
@@ -447,6 +460,14 @@ fun ctx_dnit(ctx: *AllocCtx) {
     if (ctx.arg_res_end != nil && ctx.flat_count > 0) {
         deallocate[i64](ctx.alloc, ctx.arg_res_end, ctx.flat_count::usize);
         ctx.arg_res_end = nil;
+    }
+    if (ctx.def_res_reg != nil && ctx.flat_count > 0) {
+        deallocate[u32](ctx.alloc, ctx.def_res_reg, ctx.flat_count::usize);
+        ctx.def_res_reg = nil;
+    }
+    if (ctx.def_res_pos != nil && ctx.flat_count > 0) {
+        deallocate[i64](ctx.alloc, ctx.def_res_pos, ctx.flat_count::usize);
+        ctx.def_res_pos = nil;
     }
     if (ctx.fp_busy != nil) {
         deallocate[bool](ctx.alloc, ctx.fp_busy, ctx.fp_count::usize);
@@ -1199,20 +1220,33 @@ fun reserve_param_registers(ctx: *AllocCtx) {
     }
 }
 
-# build_arg_reservations: record one window per outgoing call-argument register.
-# the per-argument setup `MOV preg <- value` / `LEA preg <- [rip+sym]` that
-# `lower_call`/`emit_arg_slot` emit leaves the argument's value live in a physical
-# register from that move until the `MIR_CALL` that consumes it — but the value
-# rides a `MIR_OP_PREG`, invisible to the vreg liveness `build_ranges` tracks. so
-# a later argument of the SAME call (e.g. a string-literal address LEA'd into a
-# fresh vreg) can be colored onto a register still holding an already-placed
-# argument, clobbering it before the call. for every instruction whose operand 0
-# is a GP `MIR_OP_PREG` definition, find the next `MIR_CALL` reached without that
-# same register being redefined, and reserve [def-pos, call-pos] so `gp_available`
-# rejects the register for any value range overlapping that span. an asm clobber
-# barrier ends the search just like a call (its window is honored identically).
+# build_arg_reservations: record reservations protecting every precolored
+# physical-register definition (operand 0 a GP `MIR_OP_PREG`) from value coloring.
+# two distinct hazards are covered, both rooted in the fact that a value carried in
+# a `MIR_OP_PREG` is invisible to the vreg liveness `build_ranges` tracks:
+#
+#   - outgoing call argument: the per-argument setup `MOV preg <- value` /
+#     `LEA preg <- [rip+sym]` that `lower_call`/`emit_arg_slot` emit leaves the
+#     argument live in a physical register from that move until the `MIR_CALL`
+#     that consumes it, so a later argument of the SAME call can be colored onto a
+#     register still holding an already-placed argument and clobber it. for every
+#     precolored DEF, the next `MIR_CALL` reached without that register being
+#     redefined opens a `[def-pos+1, call-pos]` window (an asm clobber barrier ends
+#     the search like a call); `arg_reg_reserved` rejects the register for any
+#     value range overlapping that span. the window opens at pos+1 so a value the
+#     setup move consumes (its range ending at `pos`) may have lived there up to
+#     the move.
+#   - precolored DEF clobber: the DEF itself overwrites its register at `pos`, so a
+#     value vreg merely USED at `pos` (a `MIR_OP_MEM` base) yet LIVE PAST it must
+#     not own that register, or the def clobbers the value before its later use —
+#     exactly the two-register aggregate return `MOV RAX <- [base+0]; MOV RDX <-
+#     [base+8]` where coloring `base` to RAX yields `mov (%rax),%rax`, destroying
+#     the pointer the second load needs. every precolored DEF records its position
+#     so `def_reg_reserved` rejects that register for any value range living past
+#     it (a value dying exactly at `pos` may still share the register).
 fun build_arg_reservations(ctx: *AllocCtx) Result[bool, str] {
     ctx.arg_res_count = 0;
+    ctx.def_res_count = 0;
     if (ctx.flat_count == 0) { ret ok[bool, str](true); }
 
     val rr: Result[*u32, str] = allocate[u32](ctx.alloc, ctx.flat_count::usize);
@@ -1224,6 +1258,12 @@ fun build_arg_reservations(ctx: *AllocCtx) Result[bool, str] {
     val re: Result[*i64, str] = allocate[i64](ctx.alloc, ctx.flat_count::usize);
     if (is_err[*i64, str](re)) { ret err[bool, str](unwrap_err[*i64, str](re)); }
     ctx.arg_res_end = unwrap_ok[*i64, str](re);
+    val dr: Result[*u32, str] = allocate[u32](ctx.alloc, ctx.flat_count::usize);
+    if (is_err[*u32, str](dr)) { ret err[bool, str](unwrap_err[*u32, str](dr)); }
+    ctx.def_res_reg = unwrap_ok[*u32, str](dr);
+    val dp: Result[*i64, str] = allocate[i64](ctx.alloc, ctx.flat_count::usize);
+    if (is_err[*i64, str](dp)) { ret err[bool, str](unwrap_err[*i64, str](dp)); }
+    ctx.def_res_pos = unwrap_ok[*i64, str](dp);
 
     var pos: u32 = 0;
     for (pos < ctx.flat_count) {
@@ -1232,6 +1272,12 @@ fun build_arg_reservations(ctx: *AllocCtx) Result[bool, str] {
         val d: *mir.MirOperand = ?mi.operands[0];
         val r: u32 = d.preg;
         if (r >= ctx.gp_count) { pos = pos + 1; cnt; }
+
+        # record the precolored DEF position: no value vreg living past `pos` may
+        # own `r`, since the def overwrites `r` here.
+        ctx.def_res_reg[ctx.def_res_count] = r;
+        ctx.def_res_pos[ctx.def_res_count] = pos::i64;
+        ctx.def_res_count = ctx.def_res_count + 1;
 
         # walk forward to the first call/barrier; abandon the window if this same
         # register is redefined first (it then holds a different live value whose
@@ -1421,13 +1467,38 @@ fun pick_gp(ctx: *AllocCtx, crosses_call: bool) i32 {
     ret -1;
 }
 
+# def_reg_reserved: true when GP register `id` is overwritten by a precolored
+# physical-register DEF at a position the range currently being colored
+# (`cur_start`..`cur_end`) is live PAST. a value used at the def position but live
+# only up to it (`cur_end == def-pos`) may still share the register — the def reads
+# its sources before writing, the standard def/use coalescing on a 2-address ISA —
+# so the test rejects only a value live strictly beyond the def (`cur_end >
+# def-pos`) that the def would clobber. this is the return-register / fixed-DEF
+# counterpart of `arg_reg_reserved`, closing the interference gap that colored a
+# two-register aggregate return's `base` pointer onto the RAX its first load
+# defines.
+fun def_reg_reserved(ctx: *AllocCtx, id: u32) bool {
+    var i: u32 = 0;
+    for (i < ctx.def_res_count) {
+        if (ctx.def_res_reg[i] == id
+            && ctx.cur_start <= ctx.def_res_pos[i]
+            && ctx.cur_end > ctx.def_res_pos[i]) {
+            ret true;
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
 # gp_available: true when GP register `id` is neither busy, pinned as a live
-# incoming param register, nor held by an outgoing call-argument window that
-# overlaps the range currently being colored.
+# incoming param register, held by an outgoing call-argument window, nor
+# overwritten by a precolored DEF the colored range is live past — each tested
+# against the range currently being colored.
 fun gp_available(ctx: *AllocCtx, id: u32) bool {
     if (ctx.gp_busy[id]) { ret false; }
     if (ctx.pinned_end[id] >= 0) { ret false; }
     if (arg_reg_reserved(ctx, id)) { ret false; }
+    if (def_reg_reserved(ctx, id)) { ret false; }
     ret true;
 }
 


### PR DESCRIPTION
## Summary
The linear-scan allocator's `gp_available` modeled only `gp_busy`, pinned incoming param registers, and outgoing call-argument windows. It never modeled that an instruction whose operand 0 is a `MIR_OP_PREG` (a precolored DEF — e.g. the RAX/RDX of a two-register aggregate return) **overwrites that register at its own position**. So a value vreg merely *used* there (a MEM base) yet *live past* it could be colored to the def register.

`lower_ret`'s two-register return `MOV RAX <- [base+0]; MOV RDX <- [base+8]` colored `base` to RAX → `mov (%rax),%rax` clobbered the pointer before the second load dereferenced it → SIGSEGV in std `Option` constructors. Latent until #1019 removed the spurious clobber barriers (from uninitialized `asm_block`) that had been forcing `base` onto a callee-saved register.

## Fix (target-agnostic, in the generic allocator)
Record every precolored GP DEF position in `build_arg_reservations` (reusing `instr_defines_preg`), and add `def_reg_reserved(ctx, id)` — true when `id` is defined at a position the range currently being colored is live **strictly past** (`cur_end > def-pos`; a value dying exactly at the def may still share the register, the standard def/use coalescing). Wire it as a fourth `gp_available` check. Names no architecture register.

## Verification
- cmach→imach→smach builds clean; `imach build .` compiles all of mach (exit 0 — no over-spill regression).
- `option none` now keeps `base` in RCX: `lea -0x18(%rbp),%rcx; mov (%rcx),%rax; mov 0x8(%rcx),%rdx` (was `mov (%rax),%rax; mov 0x8(%rax),%rdx`).
- smach→mach advances past this crash to a separate, deeper pre-existing bug (`regalloc: no free register for spilled destination`).

Root-caused by a read-only ultracode workflow (object-level verified).

Closes #1022

> CI red until the self-host fixpoint lands (expected).