### PR TITLE
fix(regalloc): a spilled source aliasing the spilled dest reuses the dest's scratch

### DIFF
--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1913,6 +1913,15 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                 if (is_float && is_fp_vreg(ctx, v) && is_spilled(ctx, v)) {
                     # the float operand is loaded from its slot by the encoder.
                     ops[k] = mir.op_mem_slot(v, 0);
+                } or (store_dst_tmp >= 0 && v == store_dst_vreg) {
+                    # this spilled source names the SAME vreg as the (also-spilled)
+                    # destination — e.g. the `XOR dst, dst` zeroing idiom the x64 NEG
+                    # expansion emits, which is only valid when both operands are the
+                    # identical physical register. reuse the destination's reload
+                    # scratch (claimed at operand 0) rather than reloading the same
+                    # value into a second register, which would split the two
+                    # occurrences across registers and break the idiom.
+                    ops[k] = mir.op_preg(store_dst_tmp::u32);
                 } or (is_spilled(ctx, v)) {
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, -1, is_entry, src_pos);
                     if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str]("regalloc: no free register for spilled source"); }


### PR DESCRIPTION
## Summary
The rewrite reloaded each spilled operand occurrence into a fresh scratch with no dedup by vreg, so a two-address instruction naming the **same spilled vreg** in both its destination (operand 0) and a source got **two different scratch registers**. The x64 NEG expansion emits `XOR dst,dst` (zero) then `SUB dst,src`; `XOR dst,dst` only zeroes when both operands are the identical register. With a spilled `dst` it became `xor %r9,%r8` and didn't zero, so `-x` — and the literal `-1` (lowered as `NEG(1)`) — computed garbage.

That corrupted `ctx_init`'s `param_reg_end[gi] = -1` sentinels; `reload_temp`'s entry-block param check then read those garbage values as live param registers and **falsely excluded the entire reload-scratch pool**, so the next spilled-destination reload returned -1 → `regalloc: no free register for spilled destination`. imach was fine only because it didn't spill those XOR destinations (it did when building smach — **25 broken self-XORs in smach objects vs 0 in imach**).

## Fix
A spilled source naming the same vreg as the spilled destination reuses the destination's scratch register (claimed at operand 0) instead of reloading into a second register — restoring the register identity the two-address zeroing idiom requires. Names no architecture register.

## Verification
- `cmach→imach→smach` builds clean; **broken self-XOR count 25 → 0**; the `no free register` exhaustion is gone.
- smach now compiles *further* into building mach (the regalloc spill chain is fixed); it advances to a new, deeper SIGSEGV.

Root-caused by a read-only ultracode workflow (25-vs-0 objdump proof).

Closes #1024

> CI red until the self-host fixpoint lands (expected).