### PR TITLE
fix(sysv): reserve true size of >16B by-value aggregate stack arg

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -3135,11 +3135,10 @@ fun lower_call(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
 
         val aag2: bool = value_is_aggregate(ctx, av.ty);
         # the operand's true byte size is the copy length for a by-value aggregate
-        # spilled to the stack: a >16-byte aggregate's ABI slot carries a sizing-only
-        # size of 8 (it is otherwise passed by reference), so reading slot.size would
-        # truncate the copy. for a fixed param this equals the declared param size
-        # (same interned type); for every register / by-ref / <=16B-stack slot it
-        # equals slot.size, so only the >16B-on-stack copy length is affected.
+        # spilled to the stack. every classifier slot — register, by-ref, and the
+        # >16B MEMORY-class stack slot alike — now carries the true aggregate size,
+        # so this equals slot.size; it is read from the operand type to stay robust
+        # to a variadic tail argument whose slot is classified from its own type.
         val asz2: u64 = ir_type.byte_size(ctx.types, av.ty, ctx.tgt)::u64;
         # a global / function symbol argument is its address; LEA-materialize it
         # so the register / stack move passes the address, not the symbol's bytes.

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -196,9 +196,11 @@ pub fun classify(arch_id: u32, size: u64, align: u64, is_float: bool,
 
 # classify_arg: assign registers or a stack slot for one argument (SysV).
 #
-# aggregates larger than 16 bytes are passed by hidden reference (CLASS_BYREF):
-# the pointer occupies the next GP argument register, or the stack if none
-# remain. aggregates of 9–16 bytes take TWO consecutive GP registers
+# aggregates larger than 16 bytes are passed by hidden reference (CLASS_BYREF)
+# when a GP argument register remains — the pointer occupies that register; once
+# the GP registers are exhausted such an aggregate is MEMORY-class, passed BY
+# VALUE on the stack (its full byte size, CLASS_STACK), not by reference.
+# aggregates of 9–16 bytes take TWO consecutive GP registers
 # (RDI:RSI, RSI:RDX, ...); aggregates of ≤8 bytes take one GP register, or one
 # FP register when all-float. scalars take one GP or FP register until that set
 # is exhausted, then spill to the stack. this classifier is AMD64-only: a
@@ -226,7 +228,11 @@ pub fun classify_arg(arch_id: u32, index: i32, size: u64, align: u64,
         if (gp_used < GP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
         }
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, 8);
+        # no GP register remains: the aggregate is MEMORY-class, passed BY VALUE on
+        # the stack (its full byte size), not by reference. the slot size is the true
+        # aggregate size so the caller's by-value copy, the outgoing-region cursor /
+        # reservation, and the callee's in-place read all agree on its footprint.
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
     }
 
     if (is_aggregate) {


### PR DESCRIPTION
Fixes the first remaining `smach -> mach` bootstrap crash: a >16-byte by-value aggregate stack argument was copied at full size but its outgoing-region was reserved at only 8 bytes, overflowing into the caller's callee-save slots and corrupting a saved register (faulting a later post-call aggregate copy).

`classify_arg` (SysV) now returns the true aggregate size for a MEMORY-class stack aggregate so the by-value copy, the outgoing reservation/cursor, and the callee's in-place read agree. The ABI rule stays in the target-specific `sysv.mach`.

Verified with `make clean && make`: the original crash (rip `0x4677d2`, r14=`0xffffffff`) is cleared and the bootstrap advances past it. A separate later crash (rip `0x4bccd5`) remains and is being root-caused next.

Closes #1026