### PR TITLE
fix(codegen): clamp sub-word integer ALU result width to 4 bytes

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -334,6 +334,17 @@ val FP_CLASS_MIN_BITS: u32 = 128;
 # the encoder also treats a `width` of 0 as this width.
 val WORD_WIDTH: u8 = 8;
 
+# the minimum byte width an integer ALU / shift result is computed at. a register
+# that holds a value narrower than this is still saved and reloaded at the full
+# machine-word `SPILL_MOV_WIDTH`, so a sub-word ALU op (which leaves the upper
+# register bits undefined) would persist garbage into the spill slot and corrupt
+# any later full-width use (an index in a LEA address, a word-width move). running
+# the op at >= 4 bytes keeps the live portion of the register defined up through
+# the width an ISA's narrow-write clears (the 32-bit GP write that zero-extends to
+# 64 on x86-64), so the spilled word is clean. logical sub-word truncation is
+# unaffected: every consumer that needs the narrow value re-narrows it.
+val ALU_MIN_WIDTH: u8 = 4;
+
 # MirOperand: a single MIR operand whose live fields depend on `kind`.
 # ---
 # kind:         operand discriminant (one of MIR_OP_*)
@@ -1767,7 +1778,10 @@ fun lower_shift(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id
     if (dst == MIR_VREG_NIL) {
         ret err[bool, str]("mir.lower_ir: shift defines no result vreg");
     }
-    val w: u8 = op_width_of(ctx, inst.ty);
+    # a sub-word shift result, like any narrow GP ALU write, leaves the upper
+    # register bits undefined; clamp the operation width so the spilled word stays
+    # clean (mirrors `set_generic_widths` and the byte-divide promotion).
+    val w: u8 = clamp_alu_width(op_width_of(ctx, inst.ty));
 
     var op: MirOpcode = MIR_SHR_U;
     if (inst.kind == instr.OP_SHL)   { op = MIR_SHL; }
@@ -2022,12 +2036,37 @@ fun set_generic_widths(ctx: *LowerCtx, inst: *instr.Instruction, mi: *MirInstr) 
     }
     var dw: u8 = WORD_WIDTH;
     if (!instr.is_terminator(inst.kind)) { dw = op_width_of(ctx, inst.ty); }
+    # a register-writing integer ALU result must be defined across the full width
+    # it is later spilled / reloaded at, or a sub-word op's undefined upper bits
+    # leak through the word-width spill into a downstream full-width use. the
+    # conversions are excluded: their destination width selects the MOVZX / MOVSX
+    # narrow form and is load-bearing, not a clamp candidate.
+    if (is_int_alu_kind(inst.kind)) { dw = clamp_alu_width(dw); }
     var sw: u8 = dw;
     if (is_int_conversion_kind(inst.kind) && inst.operand_count >= 1) {
         sw = op_width_of(ctx, inst.operands[0].ty);
     }
     mi.width     = dw;
     mi.src_width = sw;
+}
+
+# is_int_alu_kind: true for the integer arithmetic / bitwise opcodes whose result
+# is materialized by a width-sized GP ALU write (ADD / SUB / MUL / NEG / AND / OR /
+# XOR / NOT, and the shifts). a sub-word write of one of these leaves the upper
+# register bits undefined, so its result width is clamped to `ALU_MIN_WIDTH`. the
+# divisions are excluded — `lower_div` already promotes a byte divide to 32 bits.
+fun is_int_alu_kind(k: instr.InstrKind) bool {
+    ret k == instr.OP_ADD || k == instr.OP_SUB || k == instr.OP_MUL ||
+        k == instr.OP_NEG || k == instr.OP_AND || k == instr.OP_OR ||
+        k == instr.OP_XOR || k == instr.OP_NOT ||
+        k == instr.OP_SHL || k == instr.OP_SHR_S || k == instr.OP_SHR_U;
+}
+
+# clamp_alu_width: raise a sub-`ALU_MIN_WIDTH` integer ALU operation width up to
+# `ALU_MIN_WIDTH` so the result fully defines the register it spills through.
+fun clamp_alu_width(w: u8) u8 {
+    if (w < ALU_MIN_WIDTH) { ret ALU_MIN_WIDTH; }
+    ret w;
 }
 
 # is_compare_kind: true for the IR comparison opcodes whose CMP operates at the


### PR DESCRIPTION
Fixes the `smach -> mach` SIGSEGV at `0x4bccd5`: a u16 ALU result (a loop counter's `sh+1`) was emitted as a true 16-bit op, leaving the upper register bits undefined; regalloc spilled it at the fixed 8-byte width, persisting garbage, and a later full-width reload used it as a `lea` index -> wild address.

`set_generic_widths` / `lower_shift` now clamp the integer ALU/shift result width to a 4-byte minimum (mirrors the existing byte-divide promotion at `mir.mach:1863`), so the op runs >= 32-bit and the GP write's implicit zero-extension keeps the spilled word clean. Generic backend, names no register; compares (operand-width by design) and conversions (MOVZX/MOVSX width is load-bearing) are untouched.

Verified `make clean && make`: smach now codegens **all 114 mach objects** (matching imach) and advances **past** the fault to the final link, which fails on a separate `relocation 'pc32' overflows` (next bug, tracked separately).

Closes #1029