### PR TITLE
fix(x64): legalize an ALU immediate outside signed-imm32 range

### DIFF
--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -376,8 +376,31 @@ fun encode_alu_rm(buf: *ByteBuf, opcode: u8, reg: i32, mem: *isa.Operand, size: 
     encode_mem_operand(buf, reg, mem);
 }
 
-# encode_alu_imm: encode ALU reg,imm using the /digit group opcode.
-fun encode_alu_imm(buf: *ByteBuf, group: u8, reg: i32, imm: i64, size: u8, flags: u16) {
+# encode_alu_imm: encode ALU reg,imm using the /digit group opcode. the x86 ALU
+# group has no imm64 form -- `op r/m64, imm32` sign-extends its imm32 -- so a
+# 64-bit immediate outside signed-imm32 range cannot be encoded directly without
+# corrupting its value. such an immediate is materialized into the reserved R11
+# scratch and re-encoded as `op reg, r11`, mirroring the mem-mem split in
+# encode_mov and the MOV-immediate encoder's own movabs fallback.
+fun encode_alu_imm(buf: *ByteBuf, opcode: u16, reg: i32, imm: i64, size: u8, flags: u16) {
+    if (size == 8 && (imm < -2147483648 || imm > 2147483647)) {
+        val scratch: i32 = x64.R11;
+        var ld: isa.Inst;
+        ld.opcode   = x64.MOV;
+        ld.dst      = isa.make_reg(scratch, 8);
+        ld.src1     = isa.make_imm(imm, 8);
+        ld.src2.kind = 0;
+        ld.size     = 8;
+        ld.flags    = 0;
+        ld.clobbers = 0;
+        ld.src_line = 0;
+        ld.src_file = nil;
+        encode_mov(?ld, buf);
+        encode_alu_rr(buf, alu_opcode_rr(opcode, 8), reg, scratch, 8, flags);
+        ret;
+    }
+
+    val group: u8 = alu_group(opcode);
     val w: u8 = size_to_w(size, flags);
     if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
     if (size == 1 && needs_rex_for_byte_reg(reg)) {
@@ -693,8 +716,7 @@ fun encode_alu(mi: *isa.Inst, buf: *ByteBuf) i32 {
     }
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_IMM) {
-        val grp: u8 = alu_group(opcode);
-        encode_alu_imm(buf, grp, dst.reg, src1.imm, size, flags);
+        encode_alu_imm(buf, opcode, dst.reg, src1.imm, size, flags);
         ret (buf.len - start)::i32;
     }
 
@@ -711,11 +733,30 @@ fun encode_alu(mi: *isa.Inst, buf: *ByteBuf) i32 {
     }
 
     if (dst.kind == isa.OPK_MEM && src1.kind == isa.OPK_IMM) {
+        val imm: i64 = src1.imm;
+        # same imm64 legalization as the reg,imm form: a 64-bit ALU immediate
+        # outside signed-imm32 range is materialized into R11 and applied as
+        # `op [mem], r11`.
+        if (size == 8 && (imm < -2147483648 || imm > 2147483647)) {
+            val scratch: i32 = x64.R11;
+            var ld: isa.Inst;
+            ld.opcode   = x64.MOV;
+            ld.dst      = isa.make_reg(scratch, 8);
+            ld.src1     = isa.make_imm(imm, 8);
+            ld.src2.kind = 0;
+            ld.size     = 8;
+            ld.flags    = 0;
+            ld.clobbers = 0;
+            ld.src_line = 0;
+            ld.src_file = nil;
+            encode_mov(?ld, buf);
+            encode_alu_rm(buf, alu_opcode_rr(opcode, 8), scratch, dst, 8, flags);
+            ret (buf.len - start)::i32;
+        }
         val grp: u8 = alu_group(opcode);
         val w: u8 = size_to_w(size, flags);
         if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
         emit_rex_mem(buf, w, grp::i32, dst);
-        val imm: i64 = src1.imm;
         if (imm >= -128 && imm <= 127 && size > 1) {
             emit_byte(buf, 0x83);
             encode_mem_operand(buf, grp::i32, dst);


### PR DESCRIPTION
Clears the final bootstrap blocker — the spurious `relocation 'pc32' overflows` at link. The check's bound `-2147483648` (= `NEG 2147483648`) was miscompiled to `+2147483648` because `encode_alu_imm` emitted `sub r/m64, imm32` of `0x80000000` with no signed-imm32 guard, and the CPU sign-extends imm32.

Both ALU-immediate encoders (reg,imm and mem,imm) now materialize an out-of-range size-8 immediate into the reserved R11 scratch and re-encode as `op …, r11`, mirroring the existing mem-mem split / MOV-imm movabs fallback. Closes the whole imm32-truncation class (both sites).

**Verified `make clean && make`: the full chain cmach→imach→smach→mach now completes (exit 0) — smach codegens all 114 objects and links mach.** Byte-identical smach==mach convergence is tracked separately.

Closes #1031