### PR TITLE
fix(codegen): zero-extend a sub-word scalar load into the full register

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -2287,9 +2287,16 @@ fun lower_load(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
     mi.opcode        = MIR_LOAD;
     mi.operands      = ops;
     mi.operand_count = 2;
-    # the load accesses memory at the loaded result type's width.
-    mi.width         = op_width_of(ctx, inst.ty);
-    mi.src_width     = mi.width;
+    # the load accesses memory at the loaded result type's width (`src_width`) but
+    # must DEFINE the full register it lands in (`width`): a sub-word load of a
+    # scalar leaves the upper register bits undefined, and a downstream wider use
+    # (e.g. a mixed-width integer compare reading the value at the other operand's
+    # width) would read that garbage. clamping the destination width to
+    # `ALU_MIN_WIDTH` — the same full-register-definition invariant `clamp_alu_width`
+    # gives a sub-word ALU result — makes the backend zero-extend the load into a
+    # clean register (a wider load keeps its own width, so width == src_width there).
+    mi.src_width     = op_width_of(ctx, inst.ty);
+    mi.width         = clamp_alu_width(mi.src_width);
     ret push_instr(ctx, mb, mi);
 }
 

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -338,7 +338,16 @@ fun rewrite_simple(mi: *mir.MirInstr) Result[bool, str] {
 
     # memory.
     if (o == mir.MIR_ALLOCA) { mi.opcode = x64.LEA::u32; ret ok[bool, str](true); }
-    if (o == mir.MIR_LOAD)   { mi.opcode = x64.MOV::u32; ret ok[bool, str](true); }
+    # a load whose destination register width exceeds its memory-access width
+    # (`width > src_width`, set by `mir.lower_load` for a sub-word scalar) must
+    # zero-extend the narrow value into the full register rather than leave the
+    # upper bits undefined — select MOVZX, whose encoder reads the narrow source
+    # size (`src_width`) and the full destination size (`width`). a same-width load
+    # stays a plain MOV.
+    if (o == mir.MIR_LOAD) {
+        if (mi.width > mi.src_width) { mi.opcode = x64.MOVZX::u32; ret ok[bool, str](true); }
+        mi.opcode = x64.MOV::u32; ret ok[bool, str](true);
+    }
     if (o == mir.MIR_STORE)  { mi.opcode = x64.MOV::u32; ret ok[bool, str](true); }
     if (o == mir.MIR_GEP)    { mi.opcode = x64.LEA::u32; ret ok[bool, str](true); }
 


### PR DESCRIPTION
**Makes mach self-reproducing.** A sub-word scalar load left its destination register's upper bits undefined; a mixed-width integer compare (e.g. `is_integer`'s u32 TypeId == u8 TYPE_* globals) then read that garbage, so mach (depending on register allocation) rejected every `bool` if-condition and could not rebuild itself.

`lower_load` now keeps the access width on `src_width` and clamps the register-define `width` to `ALU_MIN_WIDTH` (the load analog of #1029's `clamp_alu_width`); x64 isel selects `MOVZX` when `width > src_width`. Generic invariant in the backend; MOVZX choice in target/isa/x64.

Verified `make clean && make` (full chain exit 0); `mach build .` rebuilds the compiler with **zero** errors; **mach→mach2→mach3→mach4 all build clean — mach is self-reproducing.**

A signed sub-word mixed-width compare (i8/i16) would want sign-extension; that pre-existing gap is tracked separately.

Closes #1033