### PR TITLE
fix(x64): route float moves through SSE — byte-identical self-host fixpoint

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -302,6 +302,17 @@ pub val MIR_FDIV:      MirOpcode = 0x1117;
 # the condition code (one of CC_*) rides on `mi.src_width`'s companion field via a
 # dedicated `fcc` carrier set by lowering.
 pub val MIR_FCMP:      MirOpcode = 0x1118;
+# MIR_FMOV: a scalar float register copy (MOVSS / MOVSD), operands [dst, src]. it
+# is the float-domain analogue of MIR_MOV: a plain MIR_MOV between XMM-classed
+# operands would mis-select to a general-purpose MOV, which — because the GP and
+# XMM register id spaces overlap (XMM0 == RAX, XMM1 == RCX, ...) — would silently
+# move the aliased GP register's bytes instead of the float value. isel retags a
+# float MIR_MOV (an operand is an FP-class vreg) to MIR_FMOV using the function's
+# vreg classes; like the float arith ops it then survives selection so regalloc
+# routes a spilled float operand to its frame slot (MOVSS / MOVSD read and write
+# memory directly) and the encoder materializes the SSE move. the width (4 for
+# f32, 8 for f64) selects MOVSS vs MOVSD.
+pub val MIR_FMOV:      MirOpcode = 0x1119;
 
 # float-comparison condition codes carried on a MIR_FCMP. a UCOMISD sets CF/ZF/PF
 # (an UNORDERED result sets all three), so the float compare maps to UNSIGNED
@@ -326,6 +337,19 @@ pub val MIR_VREG_NIL: u32 = 0xFFFFFFFF;
 # general-purpose bank is the first declared class and the float/vector bank is
 # selected by its wide bit width, so no arch-specific class name is hardcoded.
 val REG_CLASS_GP:  u32 = 0;
+
+# true when a vreg id names a float/vector-bank value (a non-GP register class).
+# exposed so instruction selection can identify a float register copy from the
+# function's recorded vreg classes without hardcoding the GP class convention. an
+# out-of-range vreg id is not an FP value.
+# ---
+# fn:   the MIR function owning the vreg table
+# vreg: the vreg id to test
+# ret:  true when the vreg's class is the float/vector bank
+pub fun vreg_is_fp(fn: *MirFunction, vreg: u32) bool {
+    if (vreg >= fn.vreg_count) { ret false; }
+    ret fn.vregs[vreg].class != REG_CLASS_GP;
+}
 # minimum register width in bits that identifies the float/vector bank.
 val FP_CLASS_MIN_BITS: u32 = 128;
 
@@ -2894,6 +2918,31 @@ fun emit_mov(ctx: *LowerCtx, mb: *MirBlock, dst: MirOperand, src: MirOperand) Re
     ret push_instr(ctx, mb, mi);
 }
 
+# emit_fmov: append a scalar floating-point register copy `MIR_FMOV (dst) <- (src)`
+# at the given float width (4 for f32, 8 for f64). used for the CLASS_FP ABI
+# pre-coloring moves — a float argument / return / parameter that pairs an XMM
+# physical register with a value vreg or a float-constant immediate. emitting the
+# dedicated MIR_FMOV (rather than MIR_MOV) is mandatory when EITHER side is a bare
+# XMM physical register or a float-constant immediate, because neither carries an
+# FP register class for isel to recover: a plain MIR_MOV would select to a
+# general-purpose MOV and move the GP register that aliases the XMM id (XMM0 ==
+# RAX), placing the float in the wrong register file. the encoder materializes the
+# MOVSS / MOVSD (or, for an immediate, MOVABS + MOVQ) byte form from MIR_FMOV.
+fun emit_fmov(ctx: *LowerCtx, mb: *MirBlock, dst: MirOperand, src: MirOperand, w: u8) Result[bool, str] {
+    val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
+    if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
+    val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
+    ops[0] = dst;
+    ops[1] = src;
+    var mi: MirInstr;
+    mi.opcode        = MIR_FMOV;
+    mi.operands      = ops;
+    mi.operand_count = 2;
+    mi.width         = w;
+    mi.src_width     = w;
+    ret push_instr(ctx, mb, mi);
+}
+
 # emit_mov_w: append a `MIR_MOV (dst) <- (src)` driven at an explicit operation
 # width rather than the machine word. used for the division dividend / result
 # pre-coloring moves, where the move must be exactly the divide's width so a
@@ -3385,8 +3434,23 @@ fun emit_arg_slot(ctx: *LowerCtx, mb: *MirBlock, slot: abi.ParamSlot, argop: Mir
         if (is_err[bool, str](ar)) { ret ar; }
         ret emit_mov(ctx, mb, op_preg(slot.reg::u32), op_mem_value(base, 0));
     }
-    # single GP or FP register scalar argument.
+    # single FP register scalar argument: a float copy into the XMM argument
+    # register. emitted as MIR_FMOV so a float-constant immediate or the bare XMM
+    # preg (neither of which carries an FP register class) still selects to the SSE
+    # move rather than a general-purpose MOV of the GP register aliasing the XMM id.
+    if (slot.class == abi.CLASS_FP) {
+        ret emit_fmov(ctx, mb, op_preg(slot.reg::u32), argop, fp_move_width(size));
+    }
+    # single GP register scalar argument.
     ret emit_mov(ctx, mb, op_preg(slot.reg::u32), argop);
+}
+
+# fp_move_width: the SSE move width (4 for f32, 8 for f64) for a CLASS_FP scalar of
+# `size` bytes. a CLASS_FP slot is always a 4- or 8-byte scalar float; any other
+# size is an ABI-classification bug, defaulted to the f64 form.
+fun fp_move_width(size: u64) u8 {
+    if (size == 4) { ret 4; }
+    ret 8;
 }
 
 # copy_aggregate: memcpy `size` bytes from the source aggregate storage (`src`, a
@@ -3686,6 +3750,12 @@ fun lower_ret(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction) Result[bo
         val ar: Result[bool, str] = addr_to_vreg(ctx, mb, rvop, ?base);
         if (is_err[bool, str](ar)) { ret ar; }
         val mr: Result[bool, str] = emit_mov(ctx, mb, op_preg(slot.reg::u32), op_mem_value(base, 0));
+        if (is_err[bool, str](mr)) { ret mr; }
+    } or (slot.class == abi.CLASS_FP) {
+        # scalar float return: a float copy into XMM0. emitted as MIR_FMOV so a
+        # float-constant immediate or the bare XMM0 preg still selects to the SSE
+        # move rather than a general-purpose MOV of RAX (which aliases XMM0's id).
+        val mr: Result[bool, str] = emit_fmov(ctx, mb, op_preg(slot.reg::u32), rvop, fp_move_width(rsz));
         if (is_err[bool, str](mr)) { ret mr; }
     } or (slot.reg >= 0) {
         val mr: Result[bool, str] = emit_mov(ctx, mb, op_preg(slot.reg::u32), rvop);

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1828,7 +1828,7 @@ fun is_spilled(ctx: *AllocCtx, v: u32) bool {
 # operand for it rather than reloaded into a GP temp.
 fun is_float_op_mir(op: mir.MirOpcode) bool {
     ret op == mir.MIR_FADD || op == mir.MIR_FSUB || op == mir.MIR_FMUL ||
-        op == mir.MIR_FDIV || op == mir.MIR_FCMP;
+        op == mir.MIR_FDIV || op == mir.MIR_FCMP || op == mir.MIR_FMOV;
 }
 
 # is_fp_vreg: true when a vreg belongs to the float / vector register class, so a

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -619,6 +619,38 @@ fun encode_mov(mi: *isa.Inst, buf: *ByteBuf) i32 {
     }
 
     if (dst.kind == isa.OPK_MEM && src1.kind == isa.OPK_IMM) {
+        # an 8-byte store of an immediate outside signed-imm32 range cannot use the
+        # `MOV r/m64, imm32` (C7) form — it carries only a 32-bit field that the CPU
+        # sign-extends, silently truncating the high 32 bits (e.g. an f64 constant
+        # bit pattern stored straight to its slot). materialize the full 64-bit
+        # immediate into the reserved R11 scratch and store the register, mirroring
+        # the mem-mem split and the ALU-imm64 legalization in this encoder.
+        if (size == 8 && (src1.imm < -2147483648 || src1.imm > 2147483647)) {
+            val scratch: i32 = x64.R11;
+            var ld: isa.Inst;
+            ld.opcode = x64.MOVABS;
+            ld.dst    = isa.make_reg(scratch, 8);
+            ld.src1   = isa.make_imm(src1.imm, 8);
+            ld.src2.kind = 0;
+            ld.size   = 8;
+            ld.flags  = 0;
+            ld.clobbers = 0;
+            ld.src_line = 0;
+            ld.src_file = nil;
+            val ld_sz: i32 = encode_movabs(?ld, buf);
+            var st: isa.Inst;
+            st.opcode = mi.opcode;
+            st.dst    = mi.dst;
+            st.src1   = isa.make_reg(scratch, 8);
+            st.src2.kind = 0;
+            st.size   = 8;
+            st.flags  = flags;
+            st.clobbers = 0;
+            st.src_line = 0;
+            st.src_file = nil;
+            val st_sz: i32 = encode_mov(?st, buf);
+            ret ld_sz + st_sz;
+        }
         val w: u8 = size_to_w(size, flags);
         if (size == 2 || (flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
         emit_rex_mem(buf, w, 0, dst);
@@ -2434,6 +2466,12 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     if (mi.opcode == mir.MIR_FCMP) {
         ret encode_float_cmp(f, mi, ?st.buf);
     }
+    # a float register copy survives selection keeping its MIR_FMOV opcode; the
+    # encoder materializes its MOVSS / MOVSD byte form here, routing the value
+    # through the float scratch so any spilled-operand shape encodes correctly.
+    if (mi.opcode == mir.MIR_FMOV) {
+        ret encode_float_mov(f, mi, ?st.buf);
+    }
 
     # division / remainder survive selection as a single `[RAX, divisor]`
     # instruction keeping their generic MIR_DIV_*/MIR_REM_* opcode; the encoder
@@ -2802,6 +2840,34 @@ fun encode_float_arith(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Re
     alu.size   = w;
     encode_inst(?alu, buf);
 
+    ret emit_float_store(dst, FLOAT_SCRATCH0, w, buf);
+}
+
+# encode_float_mov: materialize a fully-resolved float register copy
+# `MIR_FMOV [dst, src]` into its SSE byte sequence. routes the value through the
+# fixed FLOAT_SCRATCH0 register exactly as `encode_float_arith` does, so every
+# operand shape regalloc can produce — an XMM register, a spilled `[rbp + off]`
+# frame slot on either side, or a float-constant immediate source — is handled
+# uniformly without a mem-to-mem SSE form (which x86-64 has no encoding for). the
+# width (`mi.width`: 4 for f32, 8 for f64) selects MOVSS vs MOVSD throughout.
+fun encode_float_mov(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Result[bool, str] {
+    if (mi.operand_count < 2) {
+        ret err[bool, str]("encode: float move missing operands");
+    }
+    val w: u8 = mi.width;
+    if (w != 4 && w != 8) {
+        ret err[bool, str]("encode: float move has a non-float operand width");
+    }
+
+    val rd: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], 16);
+    if (is_err[isa.Operand, str](rd)) { ret err[bool, str](unwrap_err[isa.Operand, str](rd)); }
+    val dst: isa.Operand = unwrap_ok[isa.Operand, str](rd);
+    val rs: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[1], w);
+    if (is_err[isa.Operand, str](rs)) { ret err[bool, str](unwrap_err[isa.Operand, str](rs)); }
+    val src: isa.Operand = unwrap_ok[isa.Operand, str](rs);
+
+    val ld: Result[bool, str] = emit_float_load(src, FLOAT_SCRATCH0, w, buf);
+    if (is_err[bool, str](ld)) { ret ld; }
     ret emit_float_store(dst, FLOAT_SCRATCH0, w, buf);
 }
 

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -127,6 +127,15 @@ pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Res
     if (tgt == nil)   { ret err[bool, str]("isel: nil target"); }
     if (fn == nil)    { ret err[bool, str]("isel: nil mir function"); }
 
+    # retag every float register copy / scalar load / scalar store to MIR_FMOV
+    # before selection, while the operands are still vregs whose register class the
+    # function records. a plain MIR_MOV / MIR_LOAD / MIR_STORE on an XMM-classed
+    # value would otherwise select to a general-purpose MOV and move the aliased GP
+    # register (XMM register ids overlap GP ids — XMM0 == RAX) instead of the float,
+    # and the GP register allocator would then reuse that "free" GP register for an
+    # unrelated value, clobbering the float.
+    retag_float_moves(fn);
+
     var bi: u32 = 0;
     for (bi < fn.block_count) {
         val r: Result[bool, str] = select_block(alloc, ?fn.blocks[bi]);
@@ -135,6 +144,48 @@ pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Res
     }
 
     ret ok[bool, str](true);
+}
+
+# retags every float register copy / scalar load / scalar store to MIR_FMOV. the
+# operation moves a floating-point value when an operand names an FP-class vreg —
+# a MIR_MOV's value vreg (the ABI pre-coloring and phi copies pair an XMM physical
+# register with an FP-class value vreg), a MIR_LOAD's result vreg, or a MIR_STORE's
+# stored value vreg. retagging to the dedicated MIR_FMOV opcode (which survives
+# selection like the float arith ops) makes regalloc route a spilled float operand
+# to its frame slot and the encoder emit MOVSS / MOVSD; the alias-free SSE form
+# also keeps the GP allocator from reusing the float's (GP-id-aliased) register.
+# run before selection so isel's integer MIR_MOV / MIR_LOAD / MIR_STORE arms only
+# ever see integer/pointer operations.
+fun retag_float_moves(fn: *mir.MirFunction) {
+    var bi: u32 = 0;
+    for (bi < fn.block_count) {
+        val b: *mir.MirBlock = ?fn.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < b.instr_count) {
+            val mi: *mir.MirInstr = ?b.instrs[ii];
+            if ((mi.opcode == mir.MIR_MOV || mi.opcode == mir.MIR_LOAD ||
+                 mi.opcode == mir.MIR_STORE) && move_is_float(fn, mi)) {
+                mi.opcode = mir.MIR_FMOV;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+}
+
+# true when an operation moves a floating-point value: an operand is a
+# MIR_OP_VREG whose function-recorded register class is the FP/vector bank. a
+# memory operand's pointer base vreg is general-purpose, so a MIR_LOAD's result
+# (operand 0) and a MIR_STORE's stored value (operand 1) identify the float
+# domain without the address operand interfering.
+fun move_is_float(fn: *mir.MirFunction, mi: *mir.MirInstr) bool {
+    var k: u32 = 0;
+    for (k < mi.operand_count) {
+        val op: *mir.MirOperand = ?mi.operands[k];
+        if (op.kind == mir.MIR_OP_VREG && mir.vreg_is_fp(fn, op.vreg)) { ret true; }
+        k = k + 1;
+    }
+    ret false;
 }
 
 # select concrete instructions for one block. instructions that map 1:1 to a
@@ -257,6 +308,11 @@ fun is_simple(o: mir.MirOpcode) bool {
     # the surviving opcode.
     if (o == mir.MIR_FADD || o == mir.MIR_FSUB || o == mir.MIR_FMUL ||
         o == mir.MIR_FDIV || o == mir.MIR_FCMP) { ret true; }
+    # a float register copy survives selection keeping its dedicated MIR_FMOV
+    # opcode (like the float arith ops): regalloc routes a spilled float operand to
+    # its frame slot from the surviving opcode, and the encoder materializes the
+    # MOVSS / MOVSD byte form.
+    if (o == mir.MIR_FMOV) { ret true; }
     if (o == mir.MIR_ALLOCA || o == mir.MIR_LOAD || o == mir.MIR_STORE ||
         o == mir.MIR_GEP) { ret true; }
     if (o == mir.MIR_EXTRACT || o == mir.MIR_INSERT) { ret true; }
@@ -407,6 +463,11 @@ fun rewrite_simple(mi: *mir.MirInstr) Result[bool, str] {
     # to disambiguate), and the encoder materializes their SSE byte sequence from it.
     if (o == mir.MIR_FADD || o == mir.MIR_FSUB || o == mir.MIR_FMUL ||
         o == mir.MIR_FDIV || o == mir.MIR_FCMP) { ret ok[bool, str](true); }
+
+    # a float register copy survives selection unchanged, like the float arith ops;
+    # the encoder materializes its MOVSS / MOVSD byte form. `retag_float_moves` set
+    # the opcode before this pass from the function's vreg classes.
+    if (o == mir.MIR_FMOV) { ret ok[bool, str](true); }
 
     ret err[bool, str]("isel: unhandled MIR opcode");
 }


### PR DESCRIPTION
**The compiler now reproduces itself bit-for-bit (`mach == mach2 == mach3`).**

Non-determinism root cause: f64 values routed through GP registers that alias XMM ids (XMM0==RAX, …), so float reg-copies / scalar load-stores / 64-bit const-stores mis-selected to GP MOVs, leaking ASLR stack addresses into `.text` as float bit patterns. Fixed with a dedicated generic `MIR_FMOV` (retagged in isel from vreg classes, spilled by regalloc, encoded as MOVSS/MOVSD in x64) plus a 64-bit MEM←IMM legalization. Generic backend names no register; SSE/R11 stay in target/isa/x64.

Verified `make clean && make`: **0/114 objects differ across builds** (was 5); **`mach == mach2 == mach3`** byte-identical; 0 leaked stack-address immediates; bootstrap exit 0; float tests pass.

`smach != mach` remains (cmach seed miscompiles imach → over-emits into smach); full chain convergence follows from self-seeding off mach (#1044).

Closes #1053