### PR TITLE
docs: refresh README + CONTRIBUTING for self-host state

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -20,9 +20,8 @@ reminders and points back to writing-mach for the full rules.
 
 ## Authoritative references
 
-The skills are the fast path, not the contract. For exhaustive detail:
-
-- [`doc/language/*.md`](../../doc/language/) — the complete per-feature reference.
-  Each skill links the relevant files in its own Reference section.
-- [`SPEC.md`](../../SPEC.md) — locked-decision source of truth. When a skill and
-  SPEC.md disagree, SPEC.md wins, and the skill is the bug.
+The skills are the fast path, not the contract. For exhaustive detail, see
+[`doc/language/`](../../doc/language/README.md) — the complete per-feature
+reference and source of truth. Each skill links the relevant files in its own
+Reference section. When a skill and the reference disagree, the reference wins,
+and the skill is the bug.

--- a/.github/skills/mach-comptime/SKILL.md
+++ b/.github/skills/mach-comptime/SKILL.md
@@ -229,4 +229,4 @@ brackets and are a separate mechanism.
 - [doc/language/comptime-attrs.md](../../../doc/language/comptime-attrs.md) — symbol attributes
 - [doc/language/comptime-intrinsics.md](../../../doc/language/comptime-intrinsics.md) — intrinsics
 - [doc/language/comptime-control.md](../../../doc/language/comptime-control.md) — `$if` / `$or`
-- [SPEC.md](../../../SPEC.md) — locked decisions, source of truth
+- [doc/language/](../../../doc/language/README.md) — full language reference index

--- a/.github/skills/mach-lowlevel/SKILL.md
+++ b/.github/skills/mach-lowlevel/SKILL.md
@@ -137,4 +137,4 @@ Vector types follow `<u|i|f><width>x<count>`: `f32x4`, `i32x8`, `u8x16`. Higher 
 - [doc/language/policy.md](../../../doc/language/policy.md) — the compiler-vs-stdlib boundary in full.
 - [doc/language/comptime-control.md](../../../doc/language/comptime-control.md) — `$if`/`$or` over `$mach.target.arch`.
 - [doc/language/comptime-intrinsics.md](../../../doc/language/comptime-intrinsics.md) — what is a compiler intrinsic vs deferred to stdlib.
-- [SPEC.md](../../../SPEC.md) — locked decisions, source of truth.
+- [doc/language/](../../../doc/language/README.md) — full language reference index.

--- a/.github/skills/writing-mach/SKILL.md
+++ b/.github/skills/writing-mach/SKILL.md
@@ -295,7 +295,8 @@ attribute (write-once, before the decl, same module). Closed attribute set:
 `$if (C) {} $or (C) {} $or {}` — only the taken branch compiles. Value
 intrinsics `$size_of(T) $align_of(T) $offset_of(T, f)` yield comptime unsigned
 integers; `$error("msg")` / `$assert(C, "msg")` are diagnostics. The full
-comptime/asm grammar is out of scope here — see `SPEC.md`.
+comptime/asm grammar is out of scope here — see the comptime docs under
+[doc/language/](../../../doc/language/README.md).
 
 ## Reference
 
@@ -316,4 +317,4 @@ comptime/asm grammar is out of scope here — see `SPEC.md`.
 - [doc/language/statements.md](../../../doc/language/statements.md) — statement forms
 - [doc/language/expressions.md](../../../doc/language/expressions.md) — expression forms
 - [doc/language/documentation.md](../../../doc/language/documentation.md) — docstring conventions
-- [SPEC.md](../../../SPEC.md) — locked decisions, comptime channel, inline asm
+- [doc/language/](../../../doc/language/README.md) — full language reference index

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,9 @@ Be respectful, constructive, and professional. Treat Mach like a passion project
 
 ### Building
 
-Mach uses a 4-stage bootstrap build chain. The bootstrap compiler (`cmach`) is automatically downloaded from [mach-boot](https://github.com/octalide/mach-boot) releases.
+Mach is self-hosting — the compiler is written in Mach and compiles its own source. `make` runs a 4-stage bootstrap build chain; the seed compiler (`cmach`) is automatically downloaded from [mach-boot](https://github.com/octalide/mach-boot) releases.
 
-1. **cmach** — Bootstrap compiler (pre-built, auto-downloaded)
+1. **cmach** — Seed compiler (pre-built, auto-downloaded)
 2. **imach** — Intermediate compiler: Mach source compiled by cmach
 3. **smach** — Self-hosted compiler: Mach source compiled by imach
 4. **mach** — Final compiler: Mach source compiled by smach
@@ -31,6 +31,8 @@ git clone --recurse-submodules https://github.com/octalide/mach.git
 cd mach
 make    # downloads cmach and builds all stages
 ```
+
+The four binaries are written to `out/bin/`; the final compiler is `out/bin/mach`. The bootstrap reaches a byte-identical fixpoint — recompiling the source with `mach` reproduces `mach` exactly. `make clean` wipes `out/`.
 
 To use a custom cmach build:
 
@@ -123,7 +125,7 @@ dev (ongoing work)
 
 ### Mach Code (in `src/` and `dep/mach-std/`)
 
-Mach coding standards are in flux while syntax stabilizes and the userbase grows. Follow existing patterns and refer to the [language specification](doc/language-spec.md) for language features.
+Mach coding standards are in flux while syntax stabilizes and the userbase grows. Follow existing patterns and refer to the [language reference](doc/language/README.md) for language features.
 
 ---
 
@@ -134,7 +136,9 @@ mach/
 ├── dep/
 │   └── mach-std/      # standard library (git submodule)
 ├── doc/               # documentation
+├── examples/          # example projects and syntax fixtures
 ├── src/               # self-hosting mach compiler
+├── out/               # build output (git-ignored); final compiler at out/bin/mach
 ├── Makefile           # build system (auto-downloads cmach)
 └── mach.toml          # project configuration
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MACH
 ![Last Commit](https://img.shields.io/github/last-commit/octalide/mach)
 ![Issues](https://img.shields.io/github/issues/octalide/mach)
 
-Mach is a statically-typed, compiled programming language designed to be simple, fast, verbose, and intuitive.
+Mach is a statically-typed, compiled systems language designed to be simple, fast, verbose, and intuitive. The compiler is written in Mach and is **self-hosting**: it compiles its own source and reproduces itself bit-for-bit.
 
 > Mach is still alpha quality. Expect breaking changes as the compiler and standard library iterate.
 
@@ -17,6 +17,7 @@ We have an official [Discord](https://discord.com/invite/dfWG9NhGj7)!
 
 - [Core Philosophy](#core-philosophy)
 - [Getting Started](#getting-started)
+- [Usage](#usage)
 - [Examples](#examples)
 - [Documentation](#documentation)
 - [Credit](#credit)
@@ -39,12 +40,12 @@ Mach is NOT designed to prioritize:
 
 # Getting Started
 
-Read the [language documentation](doc/README.md) before installing. The docs are written more like a pamphlet than a bible and assume familiarity with basic programming concepts from other languages.
+Read the [language reference](doc/language/README.md) before installing. The docs are written more like a pamphlet than a bible and assume familiarity with basic programming concepts from other languages.
 
 
 ## Building Mach
 
-Prerequisites: git, make, curl. See [getting started](doc/getting-started.md) for details.
+Prerequisites: git, make, curl.
 
 ```bash
 git clone https://github.com/octalide/mach
@@ -52,18 +53,39 @@ cd mach
 make
 ```
 
-This runs the 4-stage bootstrap:
-1. **cmach** -- bootstrap compiler (auto-downloaded from [mach-boot](https://github.com/octalide/mach-boot))
-2. **imach** -- intermediate compiler (cmach compiles the Mach source)
-3. **smach** -- self-hosted compiler (imach compiles the Mach source)
-4. **mach** -- final compiler (smach compiles the Mach source)
+`make` runs the 4-stage bootstrap, each stage compiling the same Mach source with the previous compiler:
 
-The final binary is at `out/linux/bin/mach`. To use a custom cmach build: `CMACH=/path/to/cmach make`.
+1. **cmach** — seed compiler (the pinned version is auto-downloaded from [mach-boot](https://github.com/octalide/mach-boot))
+2. **imach** — intermediate compiler (`cmach` compiles the source)
+3. **smach** — self-hosted compiler (`imach` compiles the source)
+4. **mach** — final compiler (`smach` compiles the source)
+
+The four binaries land in `out/bin/`; the final compiler is `out/bin/mach`. Because the language is self-hosting, the bootstrap reaches a byte-identical fixpoint — recompiling the source with `mach` reproduces `mach` exactly.
+
+`make clean` wipes `out/`. To bootstrap from a custom seed: `CMACH=/path/to/cmach make`.
+
+
+# Usage
+
+```
+mach <command> [options]
+```
+
+| Command | Description |
+|---|---|
+| `build` | compile the current project to an executable or object |
+| `run`   | build and execute the current project (`-- args...` forward to the program) |
+| `test`  | build and run the project's tests |
+| `dep`   | manage vendored dependencies (`list`, `add`, `remove`, `sync`, `vendor`) |
+| `init`  | scaffold a new project (`--bin`, `--lib`, `--name`) |
+| `help`  | show usage; `mach help <command>` for detail |
+
+Common flags: `--target <name>` selects a `[targets.<name>]` entry, `--release` enables the optimisation pipeline, `--emit obj` stops at object files, `-o <path>` sets the output, and `--verbose`/`--quiet` adjust output. Run `mach help <command>` for the full set.
 
 
 # Examples
 
-The following examples require the standard library as a dependency. For a standalone project, see the [getting started guide](doc/getting-started.md) or the [Mach Sieve](https://github.com/octalide/mach-sieve) project.
+The following examples require the standard library as a dependency. For a standalone starting point, see the [Mach Sieve](https://github.com/octalide/mach-sieve) project, or run `mach init` to scaffold one.
 
 
 ## Hello World
@@ -124,7 +146,7 @@ fun main(argc: i64, argv: &&u8) i64 {
 
 # Documentation
 
-The full language and tooling documentation is in [`doc/`](doc/README.md).
+The full language reference is in [`doc/language/`](doc/language/README.md).
 
 
 # Credit


### PR DESCRIPTION
Refreshes repository decoration that lagged the self-host rebuild.

## README.md
- Describe Mach as self-hosting; note the byte-identical bootstrap fixpoint.
- Fix the final-binary path to `out/bin/mach` (was `out/linux/bin/mach`).
- Replace dead `doc/README.md` / `doc/getting-started.md` links with `doc/language/README.md`.
- Add a **Usage** section matching the present CLI (`build`/`run`/`test`/`dep`/`init`/`help`) and common flags.
- Keep the language examples and Core Philosophy as-is.

## CONTRIBUTING.md
- Light refresh: note self-hosting status and the `out/bin/mach` output location.
- Fix the dead `doc/language-spec.md` link to `doc/language/README.md`.
- Add `examples/` and `out/` to the project structure.
- Branch model, semver, and submodule notes verified correct — left unchanged.

## .github/skills/
- Drop dead `SPEC.md` references across the README and three SKILL.md files; point to `doc/language/` as the reference (skill content otherwise accurate, left as-is).

Docs only — no source touched, no build needed. All link targets verified to exist.

Note: `doc/language/README.md` also references a root `SPEC.md`; that lives under the `doc/language/` docs (#1048) and was left untouched here.

Closes #1042