### PR TITLE
feat(cli): --verbose/-v per-stage build progress

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -108,6 +108,47 @@ fun emit(s: *u8) {
     os.write(os.STDERR_FD, s, slen(s));
 }
 
+# emit_id: resolve an interned StrId against the project interner and write
+# it to stderr; a miss writes "<?>".
+# ---
+# p:  the project (for its session interner)
+# id: the interned string to render
+fun emit_id(p: *driver.Project, id: intern.StrId) {
+    val o: Option[str] = intern.lookup(?p.s.interner, id);
+    if (is_some[str](o)) {
+        val v: str = unwrap[str](o);
+        os.write(os.STDERR_FD, v::*u8, slen(v::*u8));
+    }
+    or {
+        emit("<?>");
+    }
+}
+
+# emit_target: write the resolved target name and module count to stderr.
+# the leading line of verbose output, emitted once after graph discovery.
+# ---
+# p: the project carrying the selected target and module graph
+fun emit_target(p: *driver.Project) {
+    emit("target ");
+    if (p.target_entry != nil) { emit_id(p, p.target_entry.name); }
+    or                         { emit("<none>"); }
+    emit(" (");
+    emit_num(p.topo_len::usize);
+    emit(" module(s))\n");
+}
+
+# emit_stage: write a `<stage> <fqn>` progress line to stderr for one module.
+# ---
+# p:     the project (for its interner)
+# stage: a short stage label (e.g. "sema", "lower/codegen")
+# fqn:   the module's interned fully-qualified name
+fun emit_stage(p: *driver.Project, stage: *u8, fqn: intern.StrId) {
+    emit(stage);
+    emit(" ");
+    emit_id(p, fqn);
+    emit("\n");
+}
+
 # cstr_str: view a null-terminated `*u8` path as a length-counted `str` for the
 # filesystem layer, whose API is fat-string based. the returned `str` borrows
 # the same bytes — it must not outlive `s`.
@@ -244,8 +285,9 @@ fun free_sema_deps(alloc: *Allocator, deps: *sema.SemaDeps) {
 # codegen each module to an ObjectImage. this ordering keeps the lowering and
 # codegen passes off a semantically broken AST. `images` (caller-owned, sized
 # to p.module_len) is filled in topo order. on failure the partial images and
-# IR modules are torn down by the caller via `free_modules`.
-fun compile_modules(p: *driver.Project, level: u8, verify_ir: bool,
+# IR modules are torn down by the caller via `free_modules`. when `verbose`
+# is set, each module's stage transitions are written to stderr.
+fun compile_modules(p: *driver.Project, level: u8, verify_ir: bool, verbose: bool,
                     results: *sema.SemaResult, ready: *bool,
                     irs: *ir.Module, ir_ready: *bool,
                     images: *of.ObjectImage, image_ready: *bool) Result[bool, str] {
@@ -253,6 +295,8 @@ fun compile_modules(p: *driver.Project, level: u8, verify_ir: bool,
     for (ti < p.topo_len) {
         val mid: sess.ModuleId = p.topo[ti];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
+
+        if (verbose) { emit_stage(p, "sema", m.fqn); }
 
         val deps_r: Result[sema.SemaDeps, str] = build_sema_deps(p, m, results, ready);
         if (is_err[sema.SemaDeps, str](deps_r)) { ret err[bool, str](unwrap_err[sema.SemaDeps, str](deps_r)); }
@@ -282,6 +326,8 @@ fun compile_modules(p: *driver.Project, level: u8, verify_ir: bool,
     for (ti < p.topo_len) {
         val mid: sess.ModuleId = p.topo[ti];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
+
+        if (verbose) { emit_stage(p, "lower/codegen", m.fqn); }
 
         val lower_r: Result[ir.Module, str] = lower.lower_module(p.s, ?p.target, ?m.a, m.fqn, mid, ?results[mid::u32], ?m.resolve_result, ?m.ctx);
         if (is_err[ir.Module, str](lower_r)) { ret err[bool, str](unwrap_err[ir.Module, str](lower_r)); }
@@ -392,7 +438,7 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool) BuildR
     }
     var p: driver.Project = unwrap_ok[driver.Project, str](proj_r);
 
-    br.code = compile_and_link(?p, level, emit_obj, config.verify_ir, ?root[0], config.output, config.artifacts, ?br.output_path);
+    br.code = compile_and_link(?p, level, emit_obj, config.verify_ir, config.verbose, ?root[0], config.output, config.artifacts, ?br.output_path);
 
     flush_diagnostics(?s, ?s.diags);
     driver.dnit_project(?p);
@@ -404,14 +450,17 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool) BuildR
 # and freeing the parallel module-state arrays. returns the exit code and
 # sets `*out_path` to the produced artifact path on success. `out_override`
 # (-o) and `art_override` (--artifacts), when non-nil, replace the target's
-# configured binary and artifacts paths.
-fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, verify_ir: bool,
+# configured binary and artifacts paths. when `verbose` is set, per-stage
+# progress is written to stderr.
+fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, verify_ir: bool, verbose: bool,
                      root: *u8, out_override: *u8, art_override: *u8, out_path: **u8) i64 {
     val n: usize = p.module_len::usize;
     if (n == 0) {
         emit("error: project graph is empty\n");
         ret 1;
     }
+
+    if (verbose) { emit_target(p); }
 
     val rr: Result[*sema.SemaResult, str] = allocate[sema.SemaResult](p.s.alloc, n);
     if (is_err[*sema.SemaResult, str](rr)) { emit("error: out of memory\n"); ret 2; }
@@ -446,7 +495,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, verify_ir: b
     }
 
     var code: i64 = 0;
-    val comp_r: Result[bool, str] = compile_modules(p, level, verify_ir, results, ready, irs, ir_ready, images, image_ready);
+    val comp_r: Result[bool, str] = compile_modules(p, level, verify_ir, verbose, results, ready, irs, ir_ready, images, image_ready);
     if (is_err[bool, str](comp_r)) {
         emit("error: ");
         emit(unwrap_err[bool, str](comp_r));
@@ -457,7 +506,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, verify_ir: b
         code = 1;
     }
     or {
-        code = link_artifact(p, emit_obj, root, out_override, art_override, images, out_path);
+        code = link_artifact(p, emit_obj, verbose, root, out_override, art_override, images, out_path);
     }
 
     free_modules(p, results, ready, irs, ir_ready, images, image_ready);
@@ -482,8 +531,9 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, verify_ir: b
 # deliverable. returns the exit code and sets `*out_path` on success — the
 # binary in executable mode, the object tree root in library mode. the linker
 # reads its inputs from disk, so the per-module objects are materialised
-# before linking.
-fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
+# before linking. when `verbose` is set, the object count and output path are
+# written to stderr.
+fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
                   out_override: *u8, art_override: *u8,
                   images: *of.ObjectImage, out_path: **u8) i64 {
     val te: *driver.TargetEntry = p.target_entry;
@@ -511,9 +561,20 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
     if (obj_code != 0) { ret obj_code; }
     val count: u32 = p.topo_len;
 
+    if (verbose) {
+        emit("link ");
+        emit_num(count::usize);
+        emit(" object(s)\n");
+    }
+
     # library mode (or `--emit obj`): the per-module objects are the
     # deliverable; do not link an executable.
     if (te.mode == driver.MODE_LIBRARY || emit_obj) {
+        if (verbose) {
+            emit("output ");
+            emit(?obj_base[0]);
+            emit("\n");
+        }
         free_paths(p.s.alloc, paths, count, count);
         @out_path = dup_cstr(p.s.alloc, ?obj_base[0]);
         ret 0;
@@ -548,6 +609,12 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
         emit(unwrap_err[bool, str](link_r));
         emit("\n");
         ret 1;
+    }
+
+    if (verbose) {
+        emit("output ");
+        emit(?artifact[0]);
+        emit("\n");
     }
 
     @out_path = dup_cstr(p.s.alloc, ?artifact[0]);

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -79,6 +79,7 @@ fun help_build() {
     out("  --target <name>  select a [targets.<name>] entry\n");
     out("  --release        enable the release optimisation pipeline\n");
     out("  --emit <kind>    obj | exe\n");
+    out("  --verbose, -v    write per-stage compilation progress to stderr\n");
     out("\n");
     out("exit: 0 ok, 1 user error, 2 internal error\n");
 }


### PR DESCRIPTION
Consumes the existing `config.verbose` flag and threads it through the build driver (mirroring `verify_ir`), writing per-stage progress to stderr via the existing `emit()` helper: resolved target + module count, `sema <fqn>` per module, `lower/codegen <fqn>`, and the link object count + output path. Quiet by default.

Verified `make clean && make` (exit 0); `mach build -v .` → 231 progress lines, `mach build .` → 0 (diff-confirmed). No std.format/std.print (compiler-code safe).

Closes #1038