### PR TITLE
docs: audit doc/language against the implementation

### DIFF
--- a/doc/language/README.md
+++ b/doc/language/README.md
@@ -3,9 +3,9 @@
 Per-element reference docs. Each file covers one language component;
 read the index below or follow `see also` links to navigate.
 
-The live, terse spec lives in `SPEC.md` at the repo root. This directory
-expands each section into focused docs with grammar, examples, and
-neighboring links.
+This directory is the authoritative reference for the locked Mach
+dialect. Each file is a focused doc with grammar, examples, and
+neighboring links; start from the index below.
 
 ## Files and structure
 

--- a/doc/language/comptime-attrs.md
+++ b/doc/language/comptime-attrs.md
@@ -33,16 +33,23 @@ pub fun panic(msg: *u8) {
 
 ## Known attribute names
 
-| Attribute | Applies to | Value | Purpose |
-|---|---|---|---|
-| `.symbol` | functions, vars | `*u8` literal | Linker name override |
-| `.noreturn` | functions | `u8` flag | Function never returns |
-| `.inline` | functions | `u8` flag | Strong hint to inline at call sites |
-| `.align` | vars, records, unions | power-of-two int | Storage / type alignment in bytes |
-| `.section` | functions, vars | `*u8` literal | Linker section name |
-| `.packed` | records, unions | `u8` flag | Disable field padding |
+| Attribute | Applies to | Value | Purpose | Status |
+|---|---|---|---|---|
+| `.symbol` | functions, vars | `*u8` literal | Linker name override | honored |
+| `.noreturn` | functions | `u8` flag | Function never returns | not yet honored |
+| `.inline` | functions | `u8` flag | Strong hint to inline at call sites | not yet honored |
+| `.align` | vars, records, unions | power-of-two int | Storage / type alignment in bytes | not yet honored |
+| `.section` | functions, vars | `*u8` literal | Linker section name | not yet honored |
+| `.packed` | records, unions | `u8` flag | Disable field padding | not yet honored |
 
 The set is closed. New attributes require a compiler change.
+
+> **Implementation status.** Any well-formed `$sym.attr = value;` write
+> parses, but only `.symbol` currently changes compiler output (the
+> registered linker name). The remaining attributes are accepted and
+> ignored — record/union layout uses the natural C-style rule regardless
+> of `.align` / `.packed`, and `.noreturn` / `.inline` / `.section` do not
+> yet feed codegen.
 
 Flag attributes take a `u8` (`1` on, `0` off). The stdlib constants `true` /
 `false` (`def bool: u8;` with `true`/`false` = `1`/`0`) are the idiomatic

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -24,6 +24,11 @@ pub val POINT_X:    i64 = $offset_of(Point, x);
 
 ## Diagnostic intrinsics
 
+> **Not yet implemented.** `$error` and `$assert` parse as comptime
+> directives but the compiler does not yet evaluate them — a `$error(...)`
+> directive is currently accepted and ignored rather than failing
+> compilation. The shapes below describe the intended behavior.
+
 Operate at compile time. `$error` fails compilation; `$assert` is sugar
 over `$if` plus `$error`.
 

--- a/doc/language/comptime-mach.md
+++ b/doc/language/comptime-mach.md
@@ -5,18 +5,32 @@ build context, project metadata, and source position. All reads, all
 comptime constants. The tags `$mach.os.*` and `$mach.arch.*` exist for
 path-value comparison.
 
+> **Implementation status.** Only a subset resolves today. The
+> `$mach.target.{os,arch,pointer_width}`, `$mach.os.*`, `$mach.arch.*`, and
+> `$mach.compiler.{name,version}` reads are live. The `$mach.target.abi`,
+> `$mach.build.*`, `$mach.project.*`, and `$mach.source.*` paths are
+> reserved stubs — reading one is a compile error ("not yet available").
+> Each subtree below notes its status.
+
 ## Subtrees
 
 ### `$mach.target.*` — what we're building for
 
 ```mach
-$mach.target.os                 # compared against $mach.os.* tags
-$mach.target.arch               # compared against $mach.arch.* tags
-$mach.target.abi
-$mach.target.pointer_width      # integer count of bytes
+$mach.target.os                 # live; compared against $mach.os.* tags
+$mach.target.arch               # live; compared against $mach.arch.* tags
+$mach.target.pointer_width      # live; integer count of bytes
+$mach.target.abi                # stub — not yet available
 ```
 
-### `$mach.build.*` — properties of this build session
+### `$mach.compiler.*` — compiler identity
+
+```mach
+$mach.compiler.name             # live
+$mach.compiler.version          # live
+```
+
+### `$mach.build.*` — properties of this build session (stubs)
 
 ```mach
 $mach.build.mode
@@ -26,7 +40,7 @@ $mach.build.git.dirty
 $mach.build.host
 ```
 
-### `$mach.project.*` — values from mach.toml
+### `$mach.project.*` — values from mach.toml (stubs)
 
 ```mach
 $mach.project.name
@@ -34,7 +48,7 @@ $mach.project.version
 $mach.project.root
 ```
 
-### `$mach.source.*` — current source position
+### `$mach.source.*` — current source position (stubs)
 
 ```mach
 $mach.source.file
@@ -71,8 +85,8 @@ A `$mach.*` read can initialize a runtime binding. The compiler folds the
 RHS at compile time:
 
 ```mach
-pub val IS_LINUX: u8  = $mach.target.os == $mach.os.linux;
-pub val VERSION:  *u8  = $mach.project.version;
+pub val IS_LINUX: u8   = $mach.target.os == $mach.os.linux;
+pub val COMPILER: *u8  = $mach.compiler.name;
 ```
 
 ## See also

--- a/doc/language/expressions.md
+++ b/doc/language/expressions.md
@@ -5,7 +5,7 @@ as conditions, and as call arguments.
 
 ## Literals
 
-See [literals.md](literals.md) — numeric, char, string forms.
+See [literals.md](literals.md) — numeric, char, string, and `nil` forms.
 
 ## Names
 
@@ -17,7 +17,7 @@ counter             # local or module-level binding
 core.add            # symbol from module `core`
 ```
 
-## Record / array / union / vector literals
+## Record / array / union literals
 
 A type name followed by a brace-delimited initializer:
 
@@ -25,18 +25,19 @@ A type name followed by a brace-delimited initializer:
 val p:    Point             = Point{ x: 1, y: 2 };
 val a:    [3]i64            = [3]i64{10, 20, 30};
 val u:    Number            = Number{ i: 99 };
-val v:    f32x4             = f32x4{1.0, 2.0, 3.0, 4.0};
 val pair: Pair[i64, u8]     = Pair[i64, u8]{ left: 5, right: 6u8 };
 ```
 
 For generics, the type arguments appear in brackets before the body.
 
+Vector literals (`f32x4{ ... }`) follow the same shape but depend on the
+SIMD vector types, which are not yet implemented — see [types.md](types.md).
+
 ## Field / index access
 
 ```mach
-val x:     i64 = p.x;
-val first: i64 = a[0];
-val lane:  f32 = v[2];
+val x:     i64 = p.x;            # record field
+val first: i64 = a[0];           # array index
 ```
 
 ## Function calls
@@ -44,8 +45,11 @@ val lane:  f32 = v[2];
 ```mach
 add(2, 3)
 identity[i64](42)               # generic call: type args in [ ]
-sum(3, 10i64, 20i64, 30i64)     # variadic
+sum(3, 10i64, 20i64, 30i64)     # variadic (call site parses; see fun.md)
 ```
+
+Variadic call sites parse, but the callee-side `va_list` machinery is not
+yet implemented — see [fun.md](fun.md).
 
 For comptime parameters, the value is passed positionally like a runtime
 argument — the function signature determines whether it must be comptime:

--- a/doc/language/fun.md
+++ b/doc/language/fun.md
@@ -86,6 +86,12 @@ fields, not other contexts.
 
 ## Variadic functions
 
+> **Partially implemented.** The parser accepts a trailing `...` parameter
+> and the function type carries a `variadic` flag, but the `va_list` type
+> and the `va_start` / `va_arg` / `va_end` intrinsics are not yet seeded or
+> lowered. The `sum` example above describes the intended form, not what
+> compiles today. Tracked in #1028.
+
 A function ending in `...` accepts a variable number of trailing arguments.
 The body accesses them through `va_list` / `va_start` / `va_arg` / `va_end`,
 matching C's convention.

--- a/doc/language/literals.md
+++ b/doc/language/literals.md
@@ -40,6 +40,18 @@ String escapes: the char escape set plus `\"`.
 A string literal is a single line. There is no multi-line string syntax —
 long content uses `\n` escapes or lives in external files.
 
+## `nil`
+
+The `nil` keyword is the null-address literal. With no context it types as
+`*u8`; it coerces to any pointer type. It is not assignable to a function
+type — function/`nil` relationships are expressed through `==` / `!=`
+comparison, not assignment.
+
+```mach
+var p: *i64 = nil;          # null pointer
+val absent: u8 = p == nil;  # nil compares against any pointer
+```
+
 ## Backticks
 
 Backticks (`` ` ``) are **reserved** as a literal/quote-class character

--- a/doc/language/operators.md
+++ b/doc/language/operators.md
@@ -1,32 +1,36 @@
 # Operators
 
+SIMD vector operands described below are part of the planned vector
+design and are not yet implemented — see [types.md](types.md).
+
 ## Arithmetic
 
 `+` `-` `*` `/` `%` — work on integer and floating-point scalars. SIMD
-vector types support the same operators, applied lane-wise.
+vector types are intended to support the same operators, applied lane-wise.
 
 ```mach
 val s: i64    = 10 + 20;
 val q: f32    = 1.5 * 2.0;
-val v: f32x4  = a + b;       # lane-wise add
+val v: f32x4  = a + b;       # lane-wise add (vectors not yet implemented)
 ```
 
 ## Bitwise
 
-`&` `|` `^` `~` `<<` `>>` — work on integer scalars and integer SIMD
-vectors.
+`&` `|` `^` `~` `<<` `>>` — work on integer scalars and (planned) integer
+SIMD vectors.
 
 ```mach
 val x: i64    = (a & b) | (c ^ d);
 val y: i64    = x << 2;
-val z: i32x4  = (m & n) ^ k;
+val z: i32x4  = (m & n) ^ k;     # vectors not yet implemented
 ```
 
 ## Comparison
 
 `==` `!=` `<` `>` `<=` `>=` — produce `u8` (`1` or `0`). Mach has no compiler
 `bool`; `bool` is a stdlib alias for `u8`. Compare values of matching types.
-On SIMD vectors, comparison produces a mask vector (lane-wise).
+A pointer may be compared against `nil` (the null-address literal). On the
+planned SIMD vectors, comparison produces a mask vector (lane-wise).
 
 ## Logical
 

--- a/doc/language/rec.md
+++ b/doc/language/rec.md
@@ -43,11 +43,15 @@ val n: i64            = p.x;            # field access via .
 ## Layout
 
 By default the compiler may insert padding between fields for alignment.
-Two attributes adjust this:
+Two attributes are intended to adjust this:
 
 - `$NAME.align = N;` — minimum type alignment in bytes (power of two).
 - `$NAME.packed = true;` — disable padding entirely (binary protocol /
   on-disk layouts).
+
+> **Not yet honored.** Both attributes parse but do not currently affect
+> layout — the compiler always uses the natural C-style rule. See the
+> status note in [comptime-attrs.md](comptime-attrs.md).
 
 ## See also
 

--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -1,9 +1,9 @@
 # Types
 
 Mach has a small set of compiler-shipped concrete types plus a uniform
-type-construction grammar for pointers, arrays, function types, and SIMD
-vectors. There are no compiler-known type aliases — names like `bool`,
-`usize`, and `str` are stdlib `def`s.
+type-construction grammar for pointers, arrays, and function types. There
+are no compiler-known type aliases — names like `bool`, `usize`, and `str`
+are stdlib `def`s.
 
 ## Primitive scalars
 
@@ -13,14 +13,20 @@ vectors. There are no compiler-known type aliases — names like `bool`,
 | Signed int | `i8`, `i16`, `i32`, `i64` |
 | Float | `f32`, `f64` |
 | Untyped pointer | `ptr` |
-| Varargs cursor | `va_list` |
+
+These eleven names are the complete set of compiler-seeded primitive types.
 
 There is no compiler `bool`. `bool` is a stdlib `def bool: u8;` with `true` /
 `false` as stdlib `val`s (`1` / `0`) — see [def.md](def.md).
 
 ## SIMD vectors
 
-Primitive numeric types extend into vectors by appending `x<count>`:
+> **Not yet implemented.** The vector type grammar below describes the
+> planned design. The compiler does not seed vector types today; a name
+> like `f32x4` resolves as an ordinary (unbound) identifier, not a type.
+
+The planned design extends primitive numeric types into vectors by
+appending `x<count>`:
 
 ```mach
 f32x4           # 4 lanes of f32


### PR DESCRIPTION
Audits `doc/language/*.md` against the actual compiler (lexer, parser, sema, comptime evaluator, codegen) and corrects the demonstrable inaccuracies. Docs only — no source changes.

## Fixes applied

- **README.md** — removed the dead reference to a root `SPEC.md` (the file no longer exists); the directory is now stated as the authoritative reference.
- **types.md** — removed `va_list` from the primitive-scalar table (it is not a compiler-seeded type) and marked the SIMD vector grammar as **not yet implemented** (no vector type kind exists). Noted the 11 seeded primitives (`u8..ptr`) are the complete set.
- **fun.md** — flagged variadics as **partially implemented** (`...` parses + `variadic` flag exists, but `va_list` / `va_start` / `va_arg` / `va_end` are unseeded and unlowered; #1028).
- **expressions.md** — split out the vector literal (unimplemented), removed the vector lane-index example, and annotated the variadic call example; added `nil` to the literals pointer.
- **operators.md** — marked SIMD lane-wise arithmetic/bitwise/comparison as planned; noted `nil` comparison.
- **literals.md** — documented the existing `nil` null-address literal (was undocumented).
- **comptime-mach.md** — split `$mach.*` reads into **live** (`target.{os,arch,pointer_width}`, `os.*`, `arch.*`, `compiler.{name,version}`) vs **reserved stubs** that error today (`target.abi`, `build.*`, `project.*`, `source.*`); added the implemented `$mach.compiler.*` subtree; fixed a runtime-value example that used a stub path.
- **comptime-intrinsics.md** — marked `$error` / `$assert` as **not yet evaluated** (they parse as directives but are ignored).
- **comptime-attrs.md / rec.md** — added a status column / note: only `.symbol` is honored; `.noreturn` / `.inline` / `.align` / `.section` / `.packed` parse but do not affect output (layout uses the natural C-style rule regardless of `.align` / `.packed`).

## GAP REPORT

### (a) Documented but NOT implemented

- **SIMD vector types** — `types.md` (SIMD section), `operators.md` (arith/bitwise/comparison), `expressions.md` (vector literal + lane index), `policy.md` (compiler "SIMD operators"). No vector type kind exists; `src/lang/type.mach:66-86` seeds only `u8..ptr` (11 primitives). A name like `f32x4` resolves as an unbound identifier.
- **Variadics — `va_list` / `va_start` / `va_arg` / `va_end`** — `fun.md`, `expressions.md`, `types.md`. `...` parses (`src/lang/fe/parser/expr.mach:727-739`) and `TypeFun.variadic` exists (`src/lang/type.mach:115`), but `va_list` is not a seeded primitive and the intrinsics are unseeded; backend rejects variadic *definitions* and `va_arg` (`src/lang/be/codegen/mir.mach:882`). Tracked in **#1028**.
- **`$error` / `$assert`** — `comptime-intrinsics.md`, `comptime.md` index. Parsed as `DECL_KIND_COMPTIME_ATTR` directives (`src/lang/fe/parser/decl.mach:564-592`) but never evaluated anywhere in sema or the middle end — currently accepted and ignored rather than failing compilation.
- **Symbol attributes other than `.symbol`** — `comptime-attrs.md`, `rec.md`, `ext-fun.md`, `documentation.md`. Only `.symbol` is processed (`src/lang/driver.mach:375`). `.noreturn` / `.inline` / `.align` / `.section` / `.packed` parse but are silently ignored; record/union layout uses the natural C-style rule (`src/lang/me/ir/type.mach:19-22`).
- **`$mach.*` reserved stubs** — `comptime-mach.md`. `$mach.target.abi`, `$mach.build.*`, `$mach.build.git.*`, `$mach.project.*`, `$mach.source.*` all return "not yet available" (`src/lang/fe/comptime.mach:792-842`).

### (b) Implemented but UNDOCUMENTED

- **`nil` literal** — null-address keyword, `EXPR_KIND_LIT_NIL` (`src/lang/fe/parser/expr.mach:269-276`); types as `*u8`, coerces to any pointer (`src/lang/fe/sema/coerce.mach:94-101`, `src/lang/fe/sema/infer.mach:210-212`); not comptime-evaluable (`src/lang/fe/comptime.mach:230`). Now documented in `literals.md`.
- **`test "label" { ... }` declaration** — reserved keyword + full pipeline: parsed (`src/lang/fe/parser/decl.mach:441`), resolved (`src/lang/fe/resolve.mach:629,1049`), type-checked with an i32 process-status body (`src/lang/fe/sema.mach:341-348`), lowered into an i32-returning function (`src/lang/me/lower/decl.mach:79`). **Still undocumented** — no `doc/language` page mentions `test`. Left for the owner to decide on placement (a dedicated page vs. a section), since authoring a full new declaration doc is a design call beyond "correct what's wrong."
- **`$mach.compiler.{name,version}`** — implemented (`src/lang/fe/comptime.mach:812-818`) but was absent from `comptime-mach.md`. Now documented.

### Note on the reserved-keyword set

The actual parser keyword set is `asm brk cnt def ext fin for fun fwd if nil or pub rec ret test uni use val var` (`src/lang/fe/parser/`). It includes **`nil`** and **`test`**, and does **not** reserve `label` or `msg` (those appear only as field/comment names). No doc lists a keyword table, so nothing to fix there, but flagging the discrepancy.

## Audit status

Complete for `doc/language/`. Every `*.md` was cross-checked against the lexer, parser, AST, sema, comptime evaluator, and (where relevant) lowering/codegen. The remaining gaps are tracked above; the largest implementation gaps (SIMD, variadics) are design-locked features awaiting compiler work, not doc errors — they are now labeled as such rather than removed.

Closes #1048
