### PR TITLE
ci: guard the self-host fixpoint (determinism + mach == mach2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,22 @@ jobs:
 
       - name: Build
         run: make
+
+      - name: Self-host fixpoint guard
+        run: |
+          set -euo pipefail
+          # determinism: two builds of the same source by the same compiler
+          # must be byte-identical (no leaked addresses / iteration order).
+          out/bin/mach build . --artifacts det_a
+          out/bin/mach build . --artifacts det_b
+          if ! diff -rq out/det_a/obj out/det_b/obj; then
+            echo "::error::non-deterministic build — two builds of the same source differ"
+            exit 1
+          fi
+          # self-reproduction: mach must rebuild itself byte-for-byte.
+          out/bin/mach build . -o out/bin/mach2 --artifacts m2
+          if ! cmp -s out/bin/mach out/bin/mach2; then
+            echo "::error::mach does not reproduce itself byte-for-byte (mach != mach2)"
+            exit 1
+          fi
+          echo "fixpoint guard ok: deterministic build + mach == mach2"


### PR DESCRIPTION
Adds a CI step after `make`: builds the source twice and asserts byte-identical objects (determinism), and asserts `mach` rebuilds itself byte-for-byte (`mach == mach2`). Protects the byte-identical self-host fixpoint (#1053) against regressions.

Refs #1043 — the `mach test` corpus step lands together with the corpus itself (#1039).