### PR TITLE
fix(lower): report a diagnostic for an unknown field instead of folding to 0

### DIFF
--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -59,6 +59,7 @@ use lower:    mach.lang.me.lower.context;
 use mangle:   mach.lang.me.lower.mangle;
 use generics: mach.lang.fe.sema.generics;
 use sess:     mach.lang.session;
+use diag:     mach.lang.diagnostic;
 
 # lowers an expression to its rvalue: the loaded value the expression
 # denotes. dispatches on the expression's `ExprKind`.
@@ -1283,8 +1284,11 @@ fun is_aggregate_ir(ctx: *lower.LowerContext, ity: ir_type.IrTypeId) bool {
 # matching the interned member name against each field's interned name in the
 # session-global field store (keyed by TypeId). using the store rather than an
 # AST declaration resolves anonymous records (structural identity) and cross-
-# module records uniformly. returns 0 when the layout is not recoverable (an
-# upstream sema error already reported it).
+# module records uniformly. an unmatched name records a `no such field`
+# diagnostic at `name` (which gates the build before any artifact links) and
+# returns 0, instead of silently folding to field 0. for `.field` access and
+# struct literals sema guarantees the field exists, so the miss is unreachable
+# there; `$offset_of`'s bare field argument is only validated here.
 fun field_index_in_type(ctx: *lower.LowerContext, rec_ty: ty.TypeId, name: token.Span) u32 {
     val src_text: str = module_source(ctx);
     val want_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, src_text, name);
@@ -1300,6 +1304,8 @@ fun field_index_in_type(ctx: *lower.LowerContext, rec_ty: ty.TypeId, name: token
         }
         i = i + 1;
     }
+
+    diag.error(?ctx.s.diags, ctx.a.file_id, name, "no such field: type has no field with that name");
     ret 0;
 }
 


### PR DESCRIPTION
## Summary

`field_index_in_type` (`src/lang/me/lower/expr.mach`) silently returned index **0** when a field name was not found in the record type. A typo'd `$offset_of(T, bogus)` therefore folded to offset 0 — a silent miscompile.

The lowering now records a `no such field` diagnostic at the offending field's span and still returns 0; the recorded error gates the build (via `diag.has_errors`) before any artifact links, exactly as sema does for `.field` typos. This produces a single, clean, underlined diagnostic.

### Callers of `field_index_in_type`
- **member/field access** (`lower_member_lvalue`) — sema's `check_member` already reports `no such field`, so the miss is unreachable here.
- **struct literal** (`lower_struct_lit`) — sema's struct-literal check already reports it, so unreachable here too.
- **`$offset_of`** (`try_lower_comptime_intrinsic`) — sema only types the result `u64` and explicitly defers the bare field name to lowering, so this was the one reachable path that silently produced offset 0. Now it errors.

### Before / after on `$offset_of(R, nonexistent)`
Before: built successfully, folded to offset 0 (binary returned 0).
After:
```
error: main.mach:11:34: no such field: type has no field with that name
    val off: u64 = $offset_of(R, nonexistent);
                                 ^~~~~~~~~~~
```

### Verification
- `make clean && make` full bootstrap: exit 0
- valid `.field` access + `$offset_of(R, a)/(R, b)`: builds, runs correctly
- artifact determinism (`--artifacts da` vs `db`): 0 obj diffs
- self-rebuild (`mach` builds `mach2`): binaries identical

Closes #1076