### PR TITLE
ci: run the differential harness (-O0 vs -O2, smach vs mach)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,6 @@ jobs:
             exit 1
           fi
           echo "fixpoint guard ok: deterministic build + mach == mach2"
+
+      - name: Differential test (-O0 vs -O2, smach vs mach)
+        run: bash tools/test/differential.sh


### PR DESCRIPTION
Adds a CI step running `tools/test/differential.sh` after the fixpoint guard — builds+runs the examples at `-O0`/`-O2` and asserts identical results, plus a smach-vs-mach check. Catches optimization miscompiles like the inliner phi bugs (#1085).

Refs #1043 (the `mach test` corpus step awaits #1079).