### PR TITLE
fix(global): emit aggregate global initializers as initialized data

### DIFF
--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -23,12 +23,16 @@ use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 use std.types.size.usize;
+use std.types.option.Option;
+use std.types.option.is_none;
+use std.types.option.unwrap;
 use std.allocator.allocate;
 
 use writer: std.io.writer;
 
 use sess:   mach.lang.session;
 use intern: mach.lang.intern;
+use float:  mach.lang.float;
 use target: mach.lang.target;
 use of:     mach.lang.target.of;
 
@@ -423,6 +427,14 @@ fun pack_relocs(image: *of.ObjectImage, enc: *encode.EncoderOutput,
 # image: object image being built
 # irmod: IR module whose globals are packed
 # ret:   true on success, or an error string
+# true when IR type `id` is a 32-bit float.
+fun is_f32_type(types: *ir_type.IrTypeTable, id: ir_type.IrTypeId) bool {
+    val t_opt: Option[*ir_type.IrType] = ir_type.get(types, id);
+    if (is_none[*ir_type.IrType](t_opt)) { ret false; }
+    val t: *ir_type.IrType = unwrap[*ir_type.IrType](t_opt);
+    ret t.kind == ir_type.IRT_FLOAT && t.data.bits == 32;
+}
+
 fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
                  irmod: *ir.Module) Result[bool, str] {
     var i: u32 = 0;
@@ -475,7 +487,13 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
                 val br: Result[*u8, str] = allocate[u8](s.alloc, gsz::usize);
                 if (is_err[*u8, str](br)) { ret err[bool, str](unwrap_err[*u8, str](br)); }
                 bytes = unwrap_ok[*u8, str](br);
-                val bits: u64 = g.init.data.int_lit;
+                # a comptime float is always an f64 bit pattern; a 32-bit float
+                # global must carry the IEEE-754 single pattern of its own width,
+                # not the low 4 bytes of the f64 (which would corrupt the value).
+                var bits: u64 = g.init.data.int_lit;
+                if (g.init.kind == value.VAL_CONST_FLOAT && is_f32_type(?irmod.types, g.ty)) {
+                    bits = float.f64_to_f32_bits(bits)::u64;
+                }
                 var bi: u32 = 0;
                 for (bi < gsz) {
                     bytes[bi] = (bits >> (bi::u64 * 8::u64))::u8;
@@ -595,6 +613,24 @@ fun pack_agg_relocs(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImag
 
         val r: Result[bool, str] = obj.add_relocation(image, rel);
         if (is_err[bool, str](r)) { ret err[bool, str](unwrap_err[bool, str](r)); }
+
+        # a function-pointer leaf targeting a symbol this object has not defined is
+        # a cross-module reference: declare a STT_FUNC extern stub now. every local
+        # function is already defined (pack_symbols ran before pack_globals), so an
+        # undefined fn-target is genuinely external. object (global) targets are
+        # left to pack_data_reloc_externs, which a later-packed global may still
+        # define.
+        if (ar.is_fn && ar.symbol != intern.STR_NIL && !image_has_symbol(image, ar.symbol)) {
+            var xsym: of.Symbol;
+            xsym.name    = ar.symbol;
+            xsym.section = of.SECTION_EXTERNAL;
+            xsym.offset  = 0;
+            xsym.size    = 0;
+            xsym.flags   = of.SYM_OBJ_FLAG_FUNCTION | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_GLOBAL;
+
+            val rx: Result[u32, str] = obj.add_symbol(image, xsym);
+            if (is_err[u32, str](rx)) { ret err[bool, str](unwrap_err[u32, str](rx)); }
+        }
         i = i + 1;
     }
     ret ok[bool, str](true);

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -418,6 +418,14 @@ fun pack_relocs(image: *of.ObjectImage, enc: *encode.EncoderOutput,
     ret ok[bool, str](true);
 }
 
+# true when IR type `id` is a 32-bit float.
+fun is_f32_type(types: *ir_type.IrTypeTable, id: ir_type.IrTypeId) bool {
+    val t_opt: Option[*ir_type.IrType] = ir_type.get(types, id);
+    if (is_none[*ir_type.IrType](t_opt)) { ret false; }
+    val t: *ir_type.IrType = unwrap[*ir_type.IrType](t_opt);
+    ret t.kind == ir_type.IRT_FLOAT && t.data.bits == 32;
+}
+
 # materialise every module global into the image. a global with an initializer
 # becomes a `.rodata` (immutable) or `.data` (mutable) section; one with no
 # initializer becomes a zero-filled `.bss` entry sized from its type. each global
@@ -427,14 +435,6 @@ fun pack_relocs(image: *of.ObjectImage, enc: *encode.EncoderOutput,
 # image: object image being built
 # irmod: IR module whose globals are packed
 # ret:   true on success, or an error string
-# true when IR type `id` is a 32-bit float.
-fun is_f32_type(types: *ir_type.IrTypeTable, id: ir_type.IrTypeId) bool {
-    val t_opt: Option[*ir_type.IrType] = ir_type.get(types, id);
-    if (is_none[*ir_type.IrType](t_opt)) { ret false; }
-    val t: *ir_type.IrType = unwrap[*ir_type.IrType](t_opt);
-    ret t.kind == ir_type.IRT_FLOAT && t.data.bits == 32;
-}
-
 fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
                  irmod: *ir.Module) Result[bool, str] {
     var i: u32 = 0;

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -187,7 +187,45 @@ fun pack_image(s: *sess.Session, tgt: *target.Target, irmod: *ir.Module,
         ret err[of.ObjectImage, str](unwrap_err[bool, str](rxr));
     }
 
+    # an aggregate constant's `&G` / function-pointer leaf may target a symbol
+    # defined in another module (cross-object reference). every such data-section
+    # relocation target that this object has not defined is declared undefined so
+    # the linker binds it — the data analog of pack_reloc_externs.
+    val rdx: Result[bool, str] = pack_data_reloc_externs(?image);
+    if (is_err[bool, str](rdx)) {
+        obj.dnit(?image);
+        ret err[of.ObjectImage, str](unwrap_err[bool, str](rdx));
+    }
+
     ret ok[of.ObjectImage, str](image);
+}
+
+# declare an undefined (external) symbol for every relocation target the image
+# references but has not defined. covers aggregate-constant data relocations
+# whose `&G` / function-pointer leaf names a symbol defined in another module;
+# a target already defined or declared here is left alone (no double declaration).
+# ---
+# image: object image being built (its symbol table holds every defined symbol)
+# ret:   true on success, or an error string
+fun pack_data_reloc_externs(image: *of.ObjectImage) Result[bool, str] {
+    var i: u32 = 0;
+    for (i < image.reloc_count) {
+        val name: intern.StrId = image.relocations[i].symbol;
+        if (name == intern.STR_NIL) { i = i + 1; cnt; }
+        if (image_has_symbol(image, name)) { i = i + 1; cnt; }
+
+        var xsym: of.Symbol;
+        xsym.name    = name;
+        xsym.section = of.SECTION_EXTERNAL;
+        xsym.offset  = 0;
+        xsym.size    = 0;
+        xsym.flags   = of.SYM_OBJ_FLAG_OBJECT | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_GLOBAL;
+
+        val rx: Result[u32, str] = obj.add_symbol(image, xsym);
+        if (is_err[u32, str](rx)) { ret err[bool, str](unwrap_err[u32, str](rx)); }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
 }
 
 # emit an undefined (external) symbol for every relocation target the module

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -417,6 +417,14 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
             bytes = g.init.data.bytes.ptr;
             len   = g.init.data.bytes.len;
         }
+        or (g.init.kind == value.VAL_CONST_AGG) {
+            # a pre-serialized aggregate constant carries its laid-out blob and a
+            # relocation side-table for its pointer leaves. the blob lands in
+            # .data/.rodata like any byte image; the relocations are attached to
+            # the new section below.
+            bytes = g.init.data.agg.bytes;
+            len   = g.init.data.agg.len;
+        }
         or (g.init.kind == value.VAL_CONST_INT || g.init.kind == value.VAL_CONST_FLOAT) {
             # a scalar constant initializer is materialized into its type-sized
             # little-endian byte image so it lands in .data/.rodata. without this
@@ -504,6 +512,51 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
         if (is_err[u32, str](rsym)) {
             ret err[bool, str](unwrap_err[u32, str](rsym));
         }
+
+        # an aggregate constant's pointer leaves (a `str` / address-of-global)
+        # are patched at link time: each side-table entry becomes an abs64
+        # relocation against this global's section, naming the target symbol
+        # (an anonymous rodata global already packed in this same loop). the
+        # ELF writer emits a `.rela.<section>` for any section carrying these.
+        if (g.init.kind == value.VAL_CONST_AGG) {
+            val rr: Result[bool, str] = pack_agg_relocs(s, tgt, image, ?g.init, sec_idx);
+            if (is_err[bool, str](rr)) { ret err[bool, str](unwrap_err[bool, str](rr)); }
+        }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# attach the relocation side-table of an aggregate constant initializer to its
+# packed section: one abs64 relocation per pointer leaf, patching the leaf's
+# byte offset with the address of its target symbol plus the recorded addend.
+# ---
+# s:       session, for the interner
+# tgt:     resolved target, supplying the object format's abs64 kind name
+# image:   object image being built
+# init:    the VAL_CONST_AGG initializer carrying the side-table
+# sec_idx: index of the section the relocations patch
+# ret:     true on success, or an error string
+fun pack_agg_relocs(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
+                    init: *value.Value, sec_idx: u32) Result[bool, str] {
+    val kind: intern.StrId = of.reloc_kind_name(tgt.of, of.RK_ABS64);
+    if (kind == intern.STR_NIL) {
+        ret err[bool, str]("codegen: target object format does not map the abs64 relocation kind");
+    }
+
+    var i: u32 = 0;
+    for (i < init.data.agg.reloc_count) {
+        val ar: *value.AggReloc = ?init.data.agg.relocs[i];
+
+        var rel: of.Relocation;
+        rel.section = sec_idx;
+        rel.offset  = ar.offset;
+        rel.kind    = kind;
+        rel.symbol  = ar.symbol;
+        rel.addend  = ar.addend;
+
+        val r: Result[bool, str] = obj.add_relocation(image, rel);
+        if (is_err[bool, str](r)) { ret err[bool, str](unwrap_err[bool, str](r)); }
         i = i + 1;
     }
     ret ok[bool, str](true);

--- a/src/lang/float.mach
+++ b/src/lang/float.mach
@@ -1,0 +1,76 @@
+# mach.lang.float: IEEE-754 bit-level float utilities shared across phases.
+#
+# A leaf module (no compiler-internal dependencies) so both the middle end
+# (constant-aggregate folding) and the back end (scalar-global emission) can
+# narrow a comptime f64 to its emitted width without duplicating the conversion
+# or depending on each other. Integer-only arithmetic keeps the result
+# deterministic across hosts, independent of any backend float-cast support.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+
+# reinterprets an f64 as its raw 64-bit IEEE-754 pattern.
+# ---
+# f:   the value
+# ret: the 64-bit bit pattern
+pub fun f64_bits(f: f64) u64 {
+    var u: uni { f: f64; i: u64; };
+    u.f = f;
+    ret u.i;
+}
+
+# converts an IEEE-754 double bit pattern to the IEEE-754 single pattern with
+# round-to-nearest-even. handles zero, subnormal, normal, overflow-to-infinity,
+# and NaN/infinity inputs. matches a hardware `(float)(double)` narrowing.
+# ---
+# d:   the 64-bit double bit pattern (e.g. from f64_bits)
+# ret: the 32-bit single bit pattern
+pub fun f64_to_f32_bits(d: u64) u32 {
+    val sign: u32 = ((d >> 63) & 0x1)::u32;
+    val exp:  u32 = ((d >> 52) & 0x7FF)::u32;
+    val mant: u64 = d & 0xFFFFFFFFFFFFF;
+
+    # NaN / infinity: exponent all ones. preserve infinity; map any NaN to a
+    # canonical quiet NaN so the result is deterministic.
+    if (exp == 0x7FF) {
+        if (mant != 0) { ret (sign << 31) | 0x7FC00000; }
+        ret (sign << 31) | 0x7F800000;
+    }
+
+    # rebias the exponent from double (1023) to single (127).
+    val e: i32 = exp::i32 - 1023 + 127;
+
+    # overflow: too large for single -> signed infinity.
+    if (e >= 0xFF) { ret (sign << 31) | 0x7F800000; }
+
+    if (e <= 0) {
+        # subnormal or underflow in single. shift the full significand (with the
+        # implicit leading 1) right by (1 - e) plus the 29-bit mantissa-width
+        # difference, and round to nearest even. e < -23 underflows to zero.
+        if (e < -23) { ret sign << 31; }
+        val full:  u64 = mant | 0x10000000000000;
+        val shift: u32 = (1 - e)::u32 + 29;
+        var frac:  u32 = (full >> shift::u64)::u32;
+        val rem:   u64 = full & ((1::u64 << shift::u64) - 1);
+        val half:  u64 = 1::u64 << (shift - 1)::u64;
+        if (rem > half || (rem == half && (frac & 0x1) != 0)) { frac = frac + 1; }
+        ret (sign << 31) | frac;
+    }
+
+    # normal: take the top 23 bits of the 52-bit mantissa and round to nearest
+    # even, carrying a mantissa overflow into the exponent.
+    var frac: u32 = (mant >> 29)::u32;
+    val rem:  u64 = mant & 0x1FFFFFFF;
+    val half: u64 = 0x10000000;
+    var em: u32 = e::u32;
+    if (rem > half || (rem == half && (frac & 0x1) != 0)) {
+        frac = frac + 1;
+        if (frac == 0x800000) {
+            frac = 0;
+            em = em + 1;
+            if (em >= 0xFF) { ret (sign << 31) | 0x7F800000; }
+        }
+    }
+    ret (sign << 31) | (em << 23) | frac;
+}

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -376,6 +376,13 @@ pub fun print_value(out: *writer.Writer, m: *ir.Module, v: *value.Value, interne
         }
         ret wu(out, v.data.fn_ix::u64);
     }
+    if (v.kind == value.VAL_CONST_AGG) {
+        val ra: Result[bool, str] = ws(out, "agg[");
+        if (is_err[bool, str](ra)) { ret ra; }
+        val ru: Result[bool, str] = wu(out, v.data.agg.len::u64);
+        if (is_err[bool, str](ru)) { ret ru; }
+        ret ws(out, "]");
+    }
     ret ws(out, "<?value>");
 }
 

--- a/src/lang/me/ir/value.mach
+++ b/src/lang/me/ir/value.mach
@@ -17,6 +17,7 @@ use std.types.bool.false;
 
 use ir_type: mach.lang.me.ir.type;
 use id:      mach.lang.me.ir.id;
+use intern:  mach.lang.intern;
 
 # discriminator for Value.data.
 pub def ValueKind: u8;
@@ -37,6 +38,10 @@ pub val VAL_CONST_BYTES: ValueKind = 5;
 pub val VAL_GLOBAL:      ValueKind = 6;
 # a reference to a function symbol; `data.fn_ix` indexes Module.functions.
 pub val VAL_FN:          ValueKind = 7;
+# a pre-serialized aggregate constant (struct/array/str initializer);
+# `data.agg` holds the laid-out blob plus a relocation side-table naming the
+# pointer leaves (string / address-of-global) the linker must patch.
+pub val VAL_CONST_AGG:   ValueKind = 8;
 
 # a borrowed byte blob for VAL_CONST_BYTES constants.
 # ---
@@ -45,6 +50,36 @@ pub val VAL_FN:          ValueKind = 7;
 pub rec ValueBytes {
     ptr: *u8;
     len: u32;
+}
+
+# one pointer leaf in an aggregate constant that the linker must patch: the
+# blob byte `offset` holds a pointer slot to be filled with the address of
+# `symbol` plus `addend`. used for `str` / address-of-global leaves whose value
+# is a symbol address not known until link time.
+# ---
+# offset: byte offset of the pointer slot within the aggregate blob
+# symbol: interned name of the target symbol (e.g. an anonymous rodata global)
+# addend: constant added to the resolved symbol address
+pub rec AggReloc {
+    offset: u32;
+    symbol: intern.StrId;
+    addend: i64;
+}
+
+# a pre-serialized aggregate constant for VAL_CONST_AGG: the laid-out little-
+# endian blob plus a relocation side-table for its pointer leaves. the blob and
+# side-table are owned by the IR module's allocator (materialised once during
+# lowering, never copied), so the Value carries borrowing pointers to them.
+# ---
+# bytes:       the laid-out aggregate blob (sized to the aggregate's IR type)
+# len:         number of bytes in the blob
+# relocs:      side-table of pointer leaves to patch (nil when reloc_count is 0)
+# reloc_count: number of side-table entries
+pub rec ValueAgg {
+    bytes:       *u8;
+    len:         u32;
+    relocs:      *AggReloc;
+    reloc_count: u32;
 }
 
 # an SSA value: a typed, tagged operand reference.
@@ -63,6 +98,7 @@ pub rec Value {
         bytes:     ValueBytes;
         global_ix: u32;
         fn_ix:     u32;
+        agg:       ValueAgg;
     };
 }
 
@@ -185,9 +221,29 @@ pub fun fn_value(index: u32, ty: ir_type.IrTypeId) Value {
     ret v;
 }
 
+# constructs a pre-serialized aggregate constant. the blob and relocation
+# side-table are borrowed (owned by the module allocator), not copied.
+# ---
+# bytes:       the laid-out aggregate blob
+# len:         number of bytes in the blob
+# relocs:      pointer-leaf side-table (nil when reloc_count is 0)
+# reloc_count: number of side-table entries
+# ty:          IR type of the aggregate
+# ret:         a VAL_CONST_AGG value
+pub fun const_agg(bytes: *u8, len: u32, relocs: *AggReloc, reloc_count: u32, ty: ir_type.IrTypeId) Value {
+    var v: Value;
+    v.kind = VAL_CONST_AGG;
+    v.ty   = ty;
+    v.data.agg.bytes       = bytes;
+    v.data.agg.len         = len;
+    v.data.agg.relocs      = relocs;
+    v.data.agg.reloc_count = reloc_count;
+    ret v;
+}
+
 # true when the value carries a compile-time constant inline (integer,
-# float, null, or byte blob); false for instruction/parameter/global/fn
-# references.
+# float, null, byte blob, or aggregate); false for instruction/parameter/
+# global/fn references.
 # ---
 # v:   the value to test
 # ret: true for the VAL_CONST_* kinds
@@ -196,5 +252,6 @@ pub fun is_constant(v: Value) bool {
     if (v.kind == VAL_CONST_FLOAT) { ret true; }
     if (v.kind == VAL_CONST_NULL)  { ret true; }
     if (v.kind == VAL_CONST_BYTES) { ret true; }
+    if (v.kind == VAL_CONST_AGG)   { ret true; }
     ret false;
 }

--- a/src/lang/me/ir/value.mach
+++ b/src/lang/me/ir/value.mach
@@ -54,16 +54,19 @@ pub rec ValueBytes {
 
 # one pointer leaf in an aggregate constant that the linker must patch: the
 # blob byte `offset` holds a pointer slot to be filled with the address of
-# `symbol` plus `addend`. used for `str` / address-of-global leaves whose value
-# is a symbol address not known until link time.
+# `symbol` plus `addend`. used for `str` / address-of-global / function-pointer
+# leaves whose value is a symbol address not known until link time.
 # ---
 # offset: byte offset of the pointer slot within the aggregate blob
 # symbol: interned name of the target symbol (e.g. an anonymous rodata global)
 # addend: constant added to the resolved symbol address
+# is_fn:  true when `symbol` names a function (so a cross-module extern stub for
+#         it is typed STT_FUNC, not STT_OBJECT)
 pub rec AggReloc {
     offset: u32;
     symbol: intern.StrId;
     addend: i64;
+    is_fn:  bool;
 }
 
 # a pre-serialized aggregate constant for VAL_CONST_AGG: the laid-out little-

--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -1,19 +1,26 @@
 # mach.lang.me.lower.constagg: compile-time folding of aggregate global
 # initializers into initialized data.
 #
-# A module-level `val`/`var` whose initializer is a struct / array / `str`
-# literal is a compile-time constant: its bytes are known at compile time and
-# must be emitted into `.data`/`.rodata`, not left as a zeroed `.bss` slot.
-# `comptime.eval` only folds scalars, so this module folds the aggregate shapes
-# it rejects.
+# A module-level `val`/`var` whose initializer is a struct / array / union /
+# `str` literal is, when every leaf is a compile-time constant, known at compile
+# time and must be emitted into `.data`/`.rodata` rather than left as a zeroed
+# `.bss` slot. `comptime.eval` only folds scalars, so this module folds the
+# aggregate shapes it rejects.
 #
-# The folder lays the initializer out into a blob sized to the aggregate's IR
-# type, placing each leaf at its IR field offset / array stride, and records a
-# relocation for every pointer leaf (a `str` literal, whose value is the address
-# of an anonymous `.rodata` global the linker must patch in). The result is a
-# `VAL_CONST_AGG` value the back end serializes directly. Record layout is
-# backend-owned, so this mirrors the `$size_of` handling path in `lower_global`:
-# it folds here, where the IR type table answers layout questions.
+# The folder is BEST-EFFORT: it fully folds every constant leaf, and on a
+# genuinely non-constant leaf (a runtime value / runtime call) it abandons the
+# fold and signals the caller to fall back to the zero-placeholder path — it
+# never turns a valid program into a compile error. An `err` is reserved for a
+# real malformed-input or internal-invariant violation.
+#
+# It lays the initializer out into a blob sized to the aggregate's IR type,
+# placing each leaf at its IR field offset / array stride, and records a
+# relocation for every pointer / function leaf (a `str` literal, an address-of-
+# global, a function pointer) whose value is a symbol address the linker patches
+# in. The result is a `VAL_CONST_AGG` value the back end serializes directly.
+# Record layout is backend-owned, so this mirrors the `$size_of` handling path
+# in `lower_global`: it folds here, where the IR type table answers layout
+# questions.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -34,10 +41,11 @@ use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 
 use std.allocator.allocate;
+use std.allocator.zallocate;
 use std.allocator.reallocate;
 
-use src:      mach.lang.source;
 use ty:       mach.lang.type;
+use intern:   mach.lang.intern;
 
 use ast:      mach.lang.fe.ast;
 use aid:      mach.lang.fe.ast.id;
@@ -50,6 +58,15 @@ use value:    mach.lang.me.ir.value;
 
 use lower:    mach.lang.me.lower.context;
 use expr:     mach.lang.me.lower.expr;
+
+# the outcome of laying out one leaf. distinguishes a successful fold from a
+# best-effort bail-out (a genuinely non-constant leaf -> the caller falls back
+# to the zero placeholder) so a valid program never becomes a compile error.
+def FoldResult: u8;
+# the leaf (and every leaf below it) folded into the blob.
+val FOLD_OK:       FoldResult = 0;
+# a leaf is genuinely non-constant; abandon the fold and fall back.
+val FOLD_FALLBACK: FoldResult = 1;
 
 # a growing collection of pointer-leaf relocations accumulated while laying out
 # an aggregate. backed by the module allocator so the side-table outlives the
@@ -86,11 +103,12 @@ fun reloc_push(ctx: *lower.LowerContext, rb: *RelocBuf, r: value.AggReloc) Resul
 }
 
 # attempts to fold an aggregate (or `str`) global initializer into a
-# VAL_CONST_AGG value. returns some(value) when `eid` is a struct / array
-# literal, or a `str` literal initializing a pointer global, whose leaves are
-# all compile-time constants; none when `eid` is not such an initializer (the
-# caller falls back to its scalar path); an error when a leaf is not a
-# compile-time constant.
+# VAL_CONST_AGG value. returns some(value) when `eid` is a struct / array /
+# union literal, or a `str` literal initializing a pointer global, whose leaves
+# are all compile-time constants; none when `eid` is not such an initializer, or
+# is one but has a genuinely non-constant leaf (the caller falls back to the
+# zero-placeholder path); an error only on a real malformed-input / internal
+# failure.
 # ---
 # ctx:    the lowering context
 # eid:    the initializer expression
@@ -111,47 +129,64 @@ pub fun try_const_aggregate(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_t
         ret ok[Option[value.Value], str](none[value.Value]());
     }
 
+    # a zero-size aggregate (e.g. an empty record) carries no data; there is
+    # nothing to emit, so fall back to the existing path rather than allocate a
+    # zero-length blob.
     val size: u32 = ir_type.byte_size(?ctx.m.types, gty, ctx.tgt);
-    if (size == 0) { ret err[Option[value.Value], str]("constagg: aggregate global has zero size"); }
+    if (size == 0) { ret ok[Option[value.Value], str](none[value.Value]()); }
 
-    val br: Result[*u8, str] = allocate[u8](ctx.m.alloc, size::usize);
+    # the blob is zero-initialized so inter-field padding, trailing alignment
+    # pad, a union's inactive bytes, and any unwritten slot are deterministically
+    # zero — required for the byte-identical fixpoint.
+    val br: Result[*u8, str] = zallocate[u8](ctx.m.alloc, size::usize);
     if (is_err[*u8, str](br)) { ret err[Option[value.Value], str](unwrap_err[*u8, str](br)); }
     val blob: *u8 = unwrap_ok[*u8, str](br);
-    zero_fill(blob, size);
 
     var rb: RelocBuf;
     rb.relocs = nil;
     rb.len    = 0;
     rb.cap    = 0;
 
-    val pr: Result[bool, str] = place(ctx, eid, gty, blob, 0, ?rb);
+    var fold: FoldResult = FOLD_OK;
+    val pr: Result[bool, str] = place(ctx, eid, gty, blob, 0, ?rb, ?fold);
     if (is_err[bool, str](pr)) { ret err[Option[value.Value], str](unwrap_err[bool, str](pr)); }
+    if (fold == FOLD_FALLBACK) { ret ok[Option[value.Value], str](none[value.Value]()); }
 
     ret ok[Option[value.Value], str](some[value.Value](value.const_agg(blob, size, rb.relocs, rb.len, gty)));
 }
 
 # lays the initializer `eid` out at byte offset `base` within `blob`, dispatching
-# on the leaf's IR type. struct and array leaves recurse; pointer leaves record a
-# relocation; scalar leaves are comptime-folded and written little-endian.
-fun place(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf) Result[bool, str] {
+# on the leaf's IR type. struct / union / array leaves recurse; pointer and
+# function leaves record a relocation; scalar leaves are comptime-folded and
+# written little-endian. sets `*fold` to FOLD_FALLBACK on a genuinely non-
+# constant leaf (and stops); `err` is reserved for a real failure.
+fun place(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf, fold: *FoldResult) Result[bool, str] {
     val t_opt: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ity);
     if (is_none[*ir_type.IrType](t_opt)) { ret err[bool, str]("constagg: leaf has unknown IR type"); }
     val t: *ir_type.IrType = unwrap[*ir_type.IrType](t_opt);
 
-    if (t.kind == ir_type.IRT_STRUCT) { ret place_struct(ctx, eid, ity, blob, base, rb); }
-    if (t.kind == ir_type.IRT_ARRAY)  { ret place_array(ctx, eid, ity, blob, base, rb); }
-    if (t.kind == ir_type.IRT_PTR)    { ret place_ptr(ctx, eid, ity, blob, base, rb); }
-    ret place_scalar(ctx, eid, ity, blob, base);
+    # a union shares the struct payload and lays its single active member at
+    # offset 0 (byte_offset returns 0 for every union member), so it folds
+    # through the struct-literal path unchanged.
+    if (t.kind == ir_type.IRT_STRUCT) { ret place_struct(ctx, eid, ity, blob, base, rb, fold); }
+    if (t.kind == ir_type.IRT_UNION)  { ret place_struct(ctx, eid, ity, blob, base, rb, fold); }
+    if (t.kind == ir_type.IRT_ARRAY)  { ret place_array(ctx, eid, ity, blob, base, rb, fold); }
+    if (t.kind == ir_type.IRT_PTR)    { ret place_ptr(ctx, eid, blob, base, rb, fold); }
+    if (t.kind == ir_type.IRT_FN)     { ret place_fn(ctx, eid, blob, base, rb, fold); }
+    ret place_scalar(ctx, eid, ity, blob, base, fold);
 }
 
-# lays out a struct literal: each field-init is placed at its field's IR byte
-# offset. fields with no initializer stay zero (the blob is pre-zeroed).
-fun place_struct(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf) Result[bool, str] {
+# lays out a struct / union literal: each field-init is placed at its field's IR
+# byte offset (0 for every union member). a non-struct-literal initializer for an
+# aggregate-typed leaf is a genuinely non-constant value (e.g. a runtime call
+# returning the aggregate) -> fall back. fields with no initializer stay zero.
+fun place_struct(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf, fold: *FoldResult) Result[bool, str] {
     val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
     if (is_none[*aexpr.Expr](e_opt)) { ret err[bool, str]("constagg: struct leaf expr out of range"); }
     val e: *aexpr.Expr = unwrap[*aexpr.Expr](e_opt);
     if (e.kind != aexpr.EXPR_KIND_STRUCT_LIT) {
-        ret err[bool, str]("constagg: struct-typed aggregate field has a non-struct-literal initializer");
+        @fold = FOLD_FALLBACK;
+        ret ok[bool, str](true);
     }
 
     val rec_ty: ty.TypeId = lower.expr_type_of(ctx, eid);
@@ -168,21 +203,26 @@ fun place_struct(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeI
         if (field_ix >= t.data.struct_.field_count) { ret err[bool, str]("constagg: struct field index exceeds IR field count"); }
         val fty: ir_type.IrTypeId = t.data.struct_.fields[field_ix];
         val foff: u32 = ir_type.byte_offset(?ctx.m.types, ity, field_ix, ctx.tgt);
-        val r: Result[bool, str] = place(ctx, fi.value, fty, blob, base + foff, rb);
+        val r: Result[bool, str] = place(ctx, fi.value, fty, blob, base + foff, rb, fold);
         if (is_err[bool, str](r)) { ret r; }
+        if (@fold == FOLD_FALLBACK) { ret ok[bool, str](true); }
         i = i + 1;
     }
     ret ok[bool, str](true);
 }
 
-# lays out an array literal: each element is placed at `i * element-size`.
-# elements past the literal's length stay zero.
-fun place_array(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf) Result[bool, str] {
+# lays out an array literal: each element is placed at `i * element-size`. the
+# write is bounded by the array TYPE's declared element count, never the literal
+# length, so a too-long literal that slips past sema cannot write past the blob
+# (the real fix for the length mismatch is upstream in sema, issue #1113). a
+# too-short literal leaves the remaining elements zero.
+fun place_array(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf, fold: *FoldResult) Result[bool, str] {
     val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
     if (is_none[*aexpr.Expr](e_opt)) { ret err[bool, str]("constagg: array leaf expr out of range"); }
     val e: *aexpr.Expr = unwrap[*aexpr.Expr](e_opt);
     if (e.kind != aexpr.EXPR_KIND_ARRAY_LIT) {
-        ret err[bool, str]("constagg: array-typed aggregate field has a non-array-literal initializer");
+        @fold = FOLD_FALLBACK;
+        ret ok[bool, str](true);
     }
 
     val t_opt: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ity);
@@ -190,23 +230,31 @@ fun place_array(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId
     val t: *ir_type.IrType = unwrap[*ir_type.IrType](t_opt);
     val ety: ir_type.IrTypeId = t.data.element;
     val stride: u32 = ir_type.byte_size(?ctx.m.types, ety, ctx.tgt);
+    val cap: u32 = ir_type.array_count(?ctx.m.types, ity);
 
     var i: u32 = 0;
     for (i < e.data.array_lit.elems_len) {
+        # never write past the declared array length: a literal longer than the
+        # type is malformed input (rejected upstream) but must not corrupt the
+        # heap blob here. extra elements are dropped.
+        if (i >= cap) { ret ok[bool, str](true); }
         val pool_ix: u32 = e.data.array_lit.elems_start + i;
         if (pool_ix::usize >= ctx.a.expr_id_len) { ret err[bool, str]("constagg: array element index out of range"); }
         val elem_eid: aid.ExprId = ctx.a.expr_ids[pool_ix];
-        val r: Result[bool, str] = place(ctx, elem_eid, ety, blob, base + i * stride, rb);
+        val r: Result[bool, str] = place(ctx, elem_eid, ety, blob, base + i * stride, rb, fold);
         if (is_err[bool, str](r)) { ret r; }
+        if (@fold == FOLD_FALLBACK) { ret ok[bool, str](true); }
         i = i + 1;
     }
     ret ok[bool, str](true);
 }
 
-# lays out a pointer leaf. a `str` literal materializes an anonymous `.rodata`
-# global and records a relocation patching this slot with its address; `nil`
-# stays zero. any other pointer initializer is not a compile-time constant.
-fun place_ptr(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf) Result[bool, str] {
+# lays out a pointer leaf. records a relocation patching this slot with a symbol
+# address: a `str` literal materializes an anonymous `.rodata` global; `&G` (or
+# `&G.field`) takes the address of a module global with a field-offset addend.
+# `nil` stays zero. any other pointer initializer (a runtime pointer) -> fall
+# back.
+fun place_ptr(ctx: *lower.LowerContext, eid: aid.ExprId, blob: *u8, base: u32, rb: *RelocBuf, fold: *FoldResult) Result[bool, str] {
     val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
     if (is_none[*aexpr.Expr](e_opt)) { ret err[bool, str]("constagg: pointer leaf expr out of range"); }
     val e: *aexpr.Expr = unwrap[*aexpr.Expr](e_opt);
@@ -220,40 +268,135 @@ fun place_ptr(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, 
         if (gv.kind != value.VAL_GLOBAL || gv.data.global_ix >= ctx.m.global_len) {
             ret err[bool, str]("constagg: string leaf did not lower to a global");
         }
-        var r: value.AggReloc;
-        r.offset = base;
-        r.symbol = ctx.m.globals[gv.data.global_ix].name;
-        r.addend = 0;
-        ret reloc_push(ctx, rb, r);
+        ret push_sym_reloc(ctx, rb, base, ctx.m.globals[gv.data.global_ix].name, 0);
     }
 
-    ret err[bool, str]("constagg: non-constant pointer in aggregate global initializer");
+    # `&G` / `&G.field`: the address of a module global. resolve the base global's
+    # linkage symbol and sum the member-chain field offsets into the addend,
+    # without emitting any IR (no active builder block at global scope).
+    if (e.kind == aexpr.EXPR_KIND_UNARY && e.data.unary.op == aexpr.UN_ADDR) {
+        ret place_addr_of(ctx, e.data.unary.operand, blob, base, rb, fold);
+    }
+
+    @fold = FOLD_FALLBACK;
+    ret ok[bool, str](true);
 }
 
-# lays out a scalar leaf: comptime-folds the expression and writes its bits
-# little-endian into the leaf's type-sized slot.
-fun place_scalar(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32) Result[bool, str] {
-    val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, module_source(ctx), eid, ?ctx.s.interner);
-    if (is_err[comptime.CTValue, str](ev)) {
-        ret err[bool, str]("constagg: aggregate global initializer has a non-constant leaf");
+# lays out a function-pointer leaf: an identifier naming a function records a
+# relocation to that function's symbol. anything else (a runtime callback) ->
+# fall back.
+fun place_fn(ctx: *lower.LowerContext, eid: aid.ExprId, blob: *u8, base: u32, rb: *RelocBuf, fold: *FoldResult) Result[bool, str] {
+    val name_opt: Option[intern.StrId] = expr.symbol_linkage_name(ctx, eid);
+    if (is_some[intern.StrId](name_opt)) {
+        ret push_sym_reloc(ctx, rb, base, unwrap[intern.StrId](name_opt), 0);
     }
-    val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
+    @fold = FOLD_FALLBACK;
+    ret ok[bool, str](true);
+}
 
+# resolves `&operand` to a symbol-plus-offset relocation. the operand is an
+# identifier naming a module global (offset 0) or a member chain `G.f.g` rooting
+# at one (offset = summed field offsets). anything else -> fall back.
+fun place_addr_of(ctx: *lower.LowerContext, operand: aid.ExprId, blob: *u8, base: u32, rb: *RelocBuf, fold: *FoldResult) Result[bool, str] {
+    var cur: aid.ExprId = operand;
+    var addend: i64 = 0;
+
+    # walk an outer-to-inner member chain, accumulating each field's byte offset,
+    # until the base identifier is reached.
+    for (true) {
+        val ce_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, cur);
+        if (is_none[*aexpr.Expr](ce_opt)) { @fold = FOLD_FALLBACK; ret ok[bool, str](true); }
+        val ce: *aexpr.Expr = unwrap[*aexpr.Expr](ce_opt);
+        if (ce.kind != aexpr.EXPR_KIND_MEMBER) { brk; }
+
+        val obj_ty: ty.TypeId = lower.expr_type_of(ctx, ce.data.member.object);
+        val obj_ir_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, obj_ty);
+        if (is_err[ir_type.IrTypeId, str](obj_ir_r)) { @fold = FOLD_FALLBACK; ret ok[bool, str](true); }
+        val obj_ir: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](obj_ir_r);
+        val field_ix: u32 = expr.field_index_in_type(ctx, obj_ty, ce.data.member.name);
+        addend = addend + ir_type.byte_offset(?ctx.m.types, obj_ir, field_ix, ctx.tgt)::i64;
+        cur = ce.data.member.object;
+    }
+
+    val name_opt: Option[intern.StrId] = expr.symbol_linkage_name(ctx, cur);
+    if (is_none[intern.StrId](name_opt)) { @fold = FOLD_FALLBACK; ret ok[bool, str](true); }
+    ret push_sym_reloc(ctx, rb, base, unwrap[intern.StrId](name_opt), addend);
+}
+
+# records an abs64 relocation at blob offset `off` to `symbol` plus `addend`.
+fun push_sym_reloc(ctx: *lower.LowerContext, rb: *RelocBuf, off: u32, symbol: intern.StrId, addend: i64) Result[bool, str] {
+    var r: value.AggReloc;
+    r.offset = off;
+    r.symbol = symbol;
+    r.addend = addend;
+    ret reloc_push(ctx, rb, r);
+}
+
+# lays out a scalar leaf: folds the expression to a compile-time constant and
+# writes its bits little-endian into the leaf's type-sized slot. an `$size_of` /
+# `$align_of` / `$offset_of` intrinsic call folds through the same path the
+# scalar global initializer uses; everything else folds through `comptime.eval`.
+# a non-constant leaf -> fall back. a float leaf narrower than f64 is re-encoded
+# to its IEEE-754 width.
+fun place_scalar(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, fold: *FoldResult) Result[bool, str] {
     val size: u32 = ir_type.byte_size(?ctx.m.types, ity, ctx.tgt);
     if (size == 0 || size > 8) { ret err[bool, str]("constagg: scalar leaf has unsupported size"); }
+
+    # an `$size_of(T)`-style intrinsic is a comptime constant `comptime.eval`
+    # cannot fold (it rejects CALL exprs); fold it through the same layout-aware
+    # path the scalar global path uses.
+    val ie_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
+    if (is_some[*aexpr.Expr](ie_opt)) {
+        val ie: *aexpr.Expr = unwrap[*aexpr.Expr](ie_opt);
+        if (ie.kind == aexpr.EXPR_KIND_CALL) {
+            val intr: Option[Result[value.Value, str]] = expr.try_lower_comptime_intrinsic(ctx, eid, ie);
+            if (is_some[Result[value.Value, str]](intr)) {
+                val ir2: Result[value.Value, str] = unwrap[Result[value.Value, str]](intr);
+                if (is_err[value.Value, str](ir2)) { ret err[bool, str](unwrap_err[value.Value, str](ir2)); }
+                write_bits(blob, base, unwrap_ok[value.Value, str](ir2).data.int_lit, size);
+                ret ok[bool, str](true);
+            }
+            # a non-intrinsic call is a runtime value: fall back.
+            @fold = FOLD_FALLBACK;
+            ret ok[bool, str](true);
+        }
+    }
+
+    val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner);
+    if (is_err[comptime.CTValue, str](ev)) {
+        @fold = FOLD_FALLBACK;
+        ret ok[bool, str](true);
+    }
+    val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
 
     var bits: u64 = 0;
     if (v.kind == comptime.CT_KIND_INT)   { bits = v.data.i::u64; }
     or (v.kind == comptime.CT_KIND_BOOL)  { if (v.data.b) { bits = 1; } }
-    or (v.kind == comptime.CT_KIND_FLOAT) { bits = f64_bits(v.data.f); }
-    or { ret err[bool, str]("constagg: unsupported scalar leaf kind"); }
+    or (v.kind == comptime.CT_KIND_FLOAT) {
+        # comptime floats are always f64; a narrower float leaf must carry the
+        # IEEE-754 pattern of its own width, not the low bytes of the f64.
+        if (size == 8)      { bits = f64_bits(v.data.f); }
+        or (size == 4)      { bits = f64_to_f32_bits(f64_bits(v.data.f))::u64; }
+        or { ret err[bool, str]("constagg: unsupported float leaf width"); }
+    }
+    or {
+        # a comptime string scalar leaf at a non-pointer type is not representable
+        # as inline bits; fall back rather than emit wrong data.
+        @fold = FOLD_FALLBACK;
+        ret ok[bool, str](true);
+    }
 
+    write_bits(blob, base, bits, size);
+    ret ok[bool, str](true);
+}
+
+# writes the low `size` bytes of `bits` little-endian at `blob[base..]`.
+fun write_bits(blob: *u8, base: u32, bits: u64, size: u32) {
     var i: u32 = 0;
     for (i < size) {
         blob[base + i] = (bits >> (i::u64 * 8::u64))::u8;
         i = i + 1;
     }
-    ret ok[bool, str](true);
 }
 
 # reinterprets an f64 as its raw 64-bit pattern via a one-element union.
@@ -263,26 +406,64 @@ fun f64_bits(f: f64) u64 {
     ret u.i;
 }
 
+# converts an IEEE-754 double bit pattern to the IEEE-754 single pattern with
+# round-to-nearest-even, using only integer arithmetic (the f32 narrowing cast
+# is not yet encodable on every backend, and this keeps the result deterministic
+# across hosts). handles zero, subnormal, normal, overflow-to-infinity, and
+# NaN/infinity inputs.
+fun f64_to_f32_bits(d: u64) u32 {
+    val sign: u32 = ((d >> 63) & 0x1)::u32;
+    val exp:  u32 = ((d >> 52) & 0x7FF)::u32;
+    val mant: u64 = d & 0xFFFFFFFFFFFFF;
+
+    # NaN / infinity: exponent all ones. preserve infinity; map any NaN to a
+    # canonical quiet NaN so the result is deterministic.
+    if (exp == 0x7FF) {
+        if (mant != 0) { ret (sign << 31) | 0x7FC00000; }
+        ret (sign << 31) | 0x7F800000;
+    }
+
+    # rebias the exponent from double (1023) to single (127).
+    val e: i32 = exp::i32 - 1023 + 127;
+
+    # overflow: too large for single -> signed infinity.
+    if (e >= 0xFF) { ret (sign << 31) | 0x7F800000; }
+
+    # the 23-bit single mantissa with round-to-nearest-even, taken from the top
+    # 23 bits of the 52-bit double mantissa plus the implicit leading 1.
+    if (e <= 0) {
+        # subnormal or underflow in single. shift the full significand (with the
+        # implicit 1) right by (1 - e) and round to nearest even.
+        if (e < -23) { ret sign << 31; }
+        val full: u64 = mant | 0x10000000000000;
+        val shift: u32 = (1 - e)::u32 + 29;
+        if (shift >= 64) { ret sign << 31; }
+        var frac: u32 = (full >> shift::u64)::u32;
+        val rem:  u64 = full & ((1::u64 << shift::u64) - 1);
+        val half: u64 = 1::u64 << (shift - 1)::u64;
+        if (rem > half || (rem == half && (frac & 0x1) != 0)) { frac = frac + 1; }
+        ret (sign << 31) | frac;
+    }
+
+    var frac: u32 = (mant >> 29)::u32;
+    val rem:  u64 = mant & 0x1FFFFFFF;
+    val half: u64 = 0x10000000;
+    var em: u32 = e::u32;
+    if (rem > half || (rem == half && (frac & 0x1) != 0)) {
+        frac = frac + 1;
+        # rounding overflowed the 23-bit mantissa: carry into the exponent.
+        if (frac == 0x800000) {
+            frac = 0;
+            em = em + 1;
+            if (em >= 0xFF) { ret (sign << 31) | 0x7F800000; }
+        }
+    }
+    ret (sign << 31) | (em << 23) | frac;
+}
+
 # true when IR type `ity` is a pointer.
 fun ir_is_ptr(ctx: *lower.LowerContext, ity: ir_type.IrTypeId) bool {
     val t_opt: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ity);
     if (is_none[*ir_type.IrType](t_opt)) { ret false; }
     ret unwrap[*ir_type.IrType](t_opt).kind == ir_type.IRT_PTR;
-}
-
-# zero-fills `len` bytes at `p`.
-fun zero_fill(p: *u8, len: u32) {
-    var i: u32 = 0;
-    for (i < len) {
-        p[i] = 0;
-        i = i + 1;
-    }
-}
-
-# the module's source text from the session source map (empty for an
-# unregistered file id, which a well-formed pipeline never produces).
-fun module_source(ctx: *lower.LowerContext) str {
-    val sf: Option[*src.SourceFile] = src.get(?ctx.s.sources, ctx.a.file_id);
-    if (is_none[*src.SourceFile](sf)) { ret nil::str; }
-    ret unwrap[*src.SourceFile](sf).text;
 }

--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -46,6 +46,7 @@ use std.allocator.reallocate;
 
 use ty:       mach.lang.type;
 use intern:   mach.lang.intern;
+use float:    mach.lang.float;
 
 use ast:      mach.lang.fe.ast;
 use aid:      mach.lang.fe.ast.id;
@@ -119,12 +120,15 @@ pub fun try_const_aggregate(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_t
     if (is_none[*aexpr.Expr](e_opt)) { ret ok[Option[value.Value], str](none[value.Value]()); }
     val e: *aexpr.Expr = unwrap[*aexpr.Expr](e_opt);
 
-    # a struct / array literal always routes here. a `str` literal routes here
-    # only when its global is a pointer: the global holds the *address* of a
-    # separate rodata blob (a relocation), never the bytes inline. any other
-    # initializer is a scalar the caller folds through its own path.
+    # a struct / array literal always routes here. a pointer-typed global routes
+    # here when its initializer is a constant address the linker must patch in:
+    # a `str` literal (a rodata blob), an address-of `?G` / `?G.field`, or a bare
+    # function / global name. the global holds that *address* (a relocation),
+    # never bytes inline — and there is no init-synthesis pass, so an unfolded
+    # pointer global would stay a NULL placeholder. any other initializer is a
+    # scalar the caller folds through its own path.
     var is_agg: bool = e.kind == aexpr.EXPR_KIND_STRUCT_LIT || e.kind == aexpr.EXPR_KIND_ARRAY_LIT;
-    if (e.kind == aexpr.EXPR_KIND_LIT_STR && ir_is_ptr(ctx, gty)) { is_agg = true; }
+    if (ir_is_ptr_or_fn(ctx, gty) && is_const_addr_init(ctx, e)) { is_agg = true; }
     if (!is_agg) {
         ret ok[Option[value.Value], str](none[value.Value]());
     }
@@ -135,11 +139,21 @@ pub fun try_const_aggregate(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_t
     val size: u32 = ir_type.byte_size(?ctx.m.types, gty, ctx.tgt);
     if (size == 0) { ret ok[Option[value.Value], str](none[value.Value]()); }
 
+    # a `str` / address-of leaf commits anonymous `.rodata` globals to the module
+    # as it folds (lower_lit_str -> add_rodata_bytes). a fold that later bails out
+    # must leave no trace: snapshot the global count and truncate back on every
+    # fallback / error exit, so a discarded fold leaks no dead `.Lc.<n>` global and
+    # does not shift the anon-global index of any later string.
+    val saved_globals: u32 = ctx.m.global_len;
+
     # the blob is zero-initialized so inter-field padding, trailing alignment
     # pad, a union's inactive bytes, and any unwritten slot are deterministically
     # zero — required for the byte-identical fixpoint.
     val br: Result[*u8, str] = zallocate[u8](ctx.m.alloc, size::usize);
-    if (is_err[*u8, str](br)) { ret err[Option[value.Value], str](unwrap_err[*u8, str](br)); }
+    if (is_err[*u8, str](br)) {
+        ctx.m.global_len = saved_globals;
+        ret err[Option[value.Value], str](unwrap_err[*u8, str](br));
+    }
     val blob: *u8 = unwrap_ok[*u8, str](br);
 
     var rb: RelocBuf;
@@ -149,8 +163,14 @@ pub fun try_const_aggregate(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_t
 
     var fold: FoldResult = FOLD_OK;
     val pr: Result[bool, str] = place(ctx, eid, gty, blob, 0, ?rb, ?fold);
-    if (is_err[bool, str](pr)) { ret err[Option[value.Value], str](unwrap_err[bool, str](pr)); }
-    if (fold == FOLD_FALLBACK) { ret ok[Option[value.Value], str](none[value.Value]()); }
+    if (is_err[bool, str](pr)) {
+        ctx.m.global_len = saved_globals;
+        ret err[Option[value.Value], str](unwrap_err[bool, str](pr));
+    }
+    if (fold == FOLD_FALLBACK) {
+        ctx.m.global_len = saved_globals;
+        ret ok[Option[value.Value], str](none[value.Value]());
+    }
 
     ret ok[Option[value.Value], str](some[value.Value](value.const_agg(blob, size, rb.relocs, rb.len, gty)));
 }
@@ -268,14 +288,24 @@ fun place_ptr(ctx: *lower.LowerContext, eid: aid.ExprId, blob: *u8, base: u32, r
         if (gv.kind != value.VAL_GLOBAL || gv.data.global_ix >= ctx.m.global_len) {
             ret err[bool, str]("constagg: string leaf did not lower to a global");
         }
-        ret push_sym_reloc(ctx, rb, base, ctx.m.globals[gv.data.global_ix].name, 0);
+        ret push_sym_reloc(ctx, rb, base, ctx.m.globals[gv.data.global_ix].name, 0, false);
     }
 
-    # `&G` / `&G.field`: the address of a module global. resolve the base global's
+    # `?G` / `?G.field`: the address of a module global. resolve the base global's
     # linkage symbol and sum the member-chain field offsets into the addend,
     # without emitting any IR (no active builder block at global scope).
     if (e.kind == aexpr.EXPR_KIND_UNARY && e.data.unary.op == aexpr.UN_ADDR) {
         ret place_addr_of(ctx, e.data.unary.operand, blob, base, rb, fold);
+    }
+
+    # a bare function name stored in a pointer slot is a constant (a function is
+    # an address); record a reloc to it. a bare *data* global name is the runtime
+    # contents of that global, not its address, so it is not a compile-time
+    # constant -> fall back.
+    if (e.kind == aexpr.EXPR_KIND_IDENT || e.kind == aexpr.EXPR_KIND_MEMBER) {
+        if (expr.references_function(ctx, eid)) {
+            ret place_fn(ctx, eid, blob, base, rb, fold);
+        }
     }
 
     @fold = FOLD_FALLBACK;
@@ -288,26 +318,36 @@ fun place_ptr(ctx: *lower.LowerContext, eid: aid.ExprId, blob: *u8, base: u32, r
 fun place_fn(ctx: *lower.LowerContext, eid: aid.ExprId, blob: *u8, base: u32, rb: *RelocBuf, fold: *FoldResult) Result[bool, str] {
     val name_opt: Option[intern.StrId] = expr.symbol_linkage_name(ctx, eid);
     if (is_some[intern.StrId](name_opt)) {
-        ret push_sym_reloc(ctx, rb, base, unwrap[intern.StrId](name_opt), 0);
+        ret push_sym_reloc(ctx, rb, base, unwrap[intern.StrId](name_opt), 0, true);
     }
     @fold = FOLD_FALLBACK;
     ret ok[bool, str](true);
 }
 
-# resolves `&operand` to a symbol-plus-offset relocation. the operand is an
-# identifier naming a module global (offset 0) or a member chain `G.f.g` rooting
-# at one (offset = summed field offsets). anything else -> fall back.
+# resolves `?operand` to a symbol-plus-offset relocation. the operand names a
+# module global (offset 0), a member chain `G.f.g` rooting at one (offset =
+# summed field offsets), or a module-qualified global `mod.G`. anything else ->
+# fall back.
 fun place_addr_of(ctx: *lower.LowerContext, operand: aid.ExprId, blob: *u8, base: u32, rb: *RelocBuf, fold: *FoldResult) Result[bool, str] {
     var cur: aid.ExprId = operand;
     var addend: i64 = 0;
 
     # walk an outer-to-inner member chain, accumulating each field's byte offset,
-    # until the base identifier is reached.
+    # until the base symbol is reached. a node that resolve already bound to a
+    # symbol (a bare ident, or a module-qualified `mod.G` whose symbol sits on the
+    # member node itself) is the base — never a field access — mirroring
+    # lower_member_rvalue/lvalue, so a cross-module `?mod.G` does not get walked as
+    # a struct object (which would emit a spurious "no such field" diagnostic).
     for (true) {
+        val name_opt: Option[intern.StrId] = expr.symbol_linkage_name(ctx, cur);
+        if (is_some[intern.StrId](name_opt)) {
+            ret push_sym_reloc(ctx, rb, base, unwrap[intern.StrId](name_opt), addend, false);
+        }
+
         val ce_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, cur);
         if (is_none[*aexpr.Expr](ce_opt)) { @fold = FOLD_FALLBACK; ret ok[bool, str](true); }
         val ce: *aexpr.Expr = unwrap[*aexpr.Expr](ce_opt);
-        if (ce.kind != aexpr.EXPR_KIND_MEMBER) { brk; }
+        if (ce.kind != aexpr.EXPR_KIND_MEMBER) { @fold = FOLD_FALLBACK; ret ok[bool, str](true); }
 
         val obj_ty: ty.TypeId = lower.expr_type_of(ctx, ce.data.member.object);
         val obj_ir_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, obj_ty);
@@ -317,18 +357,20 @@ fun place_addr_of(ctx: *lower.LowerContext, operand: aid.ExprId, blob: *u8, base
         addend = addend + ir_type.byte_offset(?ctx.m.types, obj_ir, field_ix, ctx.tgt)::i64;
         cur = ce.data.member.object;
     }
-
-    val name_opt: Option[intern.StrId] = expr.symbol_linkage_name(ctx, cur);
-    if (is_none[intern.StrId](name_opt)) { @fold = FOLD_FALLBACK; ret ok[bool, str](true); }
-    ret push_sym_reloc(ctx, rb, base, unwrap[intern.StrId](name_opt), addend);
+    # the loop returns on every path; this satisfies totality.
+    @fold = FOLD_FALLBACK;
+    ret ok[bool, str](true);
 }
 
 # records an abs64 relocation at blob offset `off` to `symbol` plus `addend`.
-fun push_sym_reloc(ctx: *lower.LowerContext, rb: *RelocBuf, off: u32, symbol: intern.StrId, addend: i64) Result[bool, str] {
+# `is_fn` marks a function-symbol target so a cross-module extern stub for it is
+# typed STT_FUNC rather than STT_OBJECT.
+fun push_sym_reloc(ctx: *lower.LowerContext, rb: *RelocBuf, off: u32, symbol: intern.StrId, addend: i64, is_fn: bool) Result[bool, str] {
     var r: value.AggReloc;
     r.offset = off;
     r.symbol = symbol;
     r.addend = addend;
+    r.is_fn  = is_fn;
     ret reloc_push(ctx, rb, r);
 }
 
@@ -353,7 +395,12 @@ fun place_scalar(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeI
             if (is_some[Result[value.Value, str]](intr)) {
                 val ir2: Result[value.Value, str] = unwrap[Result[value.Value, str]](intr);
                 if (is_err[value.Value, str](ir2)) { ret err[bool, str](unwrap_err[value.Value, str](ir2)); }
-                write_bits(blob, base, unwrap_ok[value.Value, str](ir2).data.int_lit, size);
+                val iv: value.Value = unwrap_ok[value.Value, str](ir2);
+                # the layout intrinsics ($size_of/$align_of/$offset_of) all yield an
+                # integer constant. guard the kind so a future intrinsic returning
+                # another shape (e.g. a float) cannot silently emit raw union bits.
+                if (iv.kind != value.VAL_CONST_INT) { @fold = FOLD_FALLBACK; ret ok[bool, str](true); }
+                write_bits(blob, base, iv.data.int_lit, size);
                 ret ok[bool, str](true);
             }
             # a non-intrinsic call is a runtime value: fall back.
@@ -375,8 +422,8 @@ fun place_scalar(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeI
     or (v.kind == comptime.CT_KIND_FLOAT) {
         # comptime floats are always f64; a narrower float leaf must carry the
         # IEEE-754 pattern of its own width, not the low bytes of the f64.
-        if (size == 8)      { bits = f64_bits(v.data.f); }
-        or (size == 4)      { bits = f64_to_f32_bits(f64_bits(v.data.f))::u64; }
+        if (size == 8)      { bits = float.f64_bits(v.data.f); }
+        or (size == 4)      { bits = float.f64_to_f32_bits(float.f64_bits(v.data.f))::u64; }
         or { ret err[bool, str]("constagg: unsupported float leaf width"); }
     }
     or {
@@ -399,71 +446,25 @@ fun write_bits(blob: *u8, base: u32, bits: u64, size: u32) {
     }
 }
 
-# reinterprets an f64 as its raw 64-bit pattern via a one-element union.
-fun f64_bits(f: f64) u64 {
-    var u: uni { f: f64; i: u64; };
-    u.f = f;
-    ret u.i;
-}
-
-# converts an IEEE-754 double bit pattern to the IEEE-754 single pattern with
-# round-to-nearest-even, using only integer arithmetic (the f32 narrowing cast
-# is not yet encodable on every backend, and this keeps the result deterministic
-# across hosts). handles zero, subnormal, normal, overflow-to-infinity, and
-# NaN/infinity inputs.
-fun f64_to_f32_bits(d: u64) u32 {
-    val sign: u32 = ((d >> 63) & 0x1)::u32;
-    val exp:  u32 = ((d >> 52) & 0x7FF)::u32;
-    val mant: u64 = d & 0xFFFFFFFFFFFFF;
-
-    # NaN / infinity: exponent all ones. preserve infinity; map any NaN to a
-    # canonical quiet NaN so the result is deterministic.
-    if (exp == 0x7FF) {
-        if (mant != 0) { ret (sign << 31) | 0x7FC00000; }
-        ret (sign << 31) | 0x7F800000;
-    }
-
-    # rebias the exponent from double (1023) to single (127).
-    val e: i32 = exp::i32 - 1023 + 127;
-
-    # overflow: too large for single -> signed infinity.
-    if (e >= 0xFF) { ret (sign << 31) | 0x7F800000; }
-
-    # the 23-bit single mantissa with round-to-nearest-even, taken from the top
-    # 23 bits of the 52-bit double mantissa plus the implicit leading 1.
-    if (e <= 0) {
-        # subnormal or underflow in single. shift the full significand (with the
-        # implicit 1) right by (1 - e) and round to nearest even.
-        if (e < -23) { ret sign << 31; }
-        val full: u64 = mant | 0x10000000000000;
-        val shift: u32 = (1 - e)::u32 + 29;
-        if (shift >= 64) { ret sign << 31; }
-        var frac: u32 = (full >> shift::u64)::u32;
-        val rem:  u64 = full & ((1::u64 << shift::u64) - 1);
-        val half: u64 = 1::u64 << (shift - 1)::u64;
-        if (rem > half || (rem == half && (frac & 0x1) != 0)) { frac = frac + 1; }
-        ret (sign << 31) | frac;
-    }
-
-    var frac: u32 = (mant >> 29)::u32;
-    val rem:  u64 = mant & 0x1FFFFFFF;
-    val half: u64 = 0x10000000;
-    var em: u32 = e::u32;
-    if (rem > half || (rem == half && (frac & 0x1) != 0)) {
-        frac = frac + 1;
-        # rounding overflowed the 23-bit mantissa: carry into the exponent.
-        if (frac == 0x800000) {
-            frac = 0;
-            em = em + 1;
-            if (em >= 0xFF) { ret (sign << 31) | 0x7F800000; }
-        }
-    }
-    ret (sign << 31) | (em << 23) | frac;
-}
-
-# true when IR type `ity` is a pointer.
-fun ir_is_ptr(ctx: *lower.LowerContext, ity: ir_type.IrTypeId) bool {
+# true when IR type `ity` is a pointer or a (first-class) function type — both
+# occupy one pointer slot and take a symbol-address relocation as a constant.
+fun ir_is_ptr_or_fn(ctx: *lower.LowerContext, ity: ir_type.IrTypeId) bool {
     val t_opt: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ity);
     if (is_none[*ir_type.IrType](t_opt)) { ret false; }
-    ret unwrap[*ir_type.IrType](t_opt).kind == ir_type.IRT_PTR;
+    val k: ir_type.IrTypeKind = unwrap[*ir_type.IrType](t_opt).kind;
+    ret k == ir_type.IRT_PTR || k == ir_type.IRT_FN;
+}
+
+# true when `e` initializes a pointer global with a compile-time-constant address
+# the back end emits as a relocation: a string literal, an address-of (`?G` /
+# `?mod.G`), or a bare name resolving to a module function. routing these through
+# the folder keeps a top-level pointer global from staying a NULL placeholder
+# (there is no init-synthesis pass to fill it later). a `nil` initializer is
+# already a correct zero placeholder on the scalar path, so it is left there; a
+# genuinely non-constant pointer initializer falls back inside place_ptr.
+fun is_const_addr_init(ctx: *lower.LowerContext, e: *aexpr.Expr) bool {
+    if (e.kind == aexpr.EXPR_KIND_LIT_STR) { ret true; }
+    if (e.kind == aexpr.EXPR_KIND_UNARY && e.data.unary.op == aexpr.UN_ADDR) { ret true; }
+    if (e.kind == aexpr.EXPR_KIND_IDENT || e.kind == aexpr.EXPR_KIND_MEMBER) { ret true; }
+    ret false;
 }

--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -29,7 +29,6 @@ use std.types.option.unwrap;
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
-use std.types.result.is_ok;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
@@ -39,7 +38,6 @@ use std.allocator.reallocate;
 
 use src:      mach.lang.source;
 use ty:       mach.lang.type;
-use intern:   mach.lang.intern;
 
 use ast:      mach.lang.fe.ast;
 use aid:      mach.lang.fe.ast.id;

--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -1,0 +1,290 @@
+# mach.lang.me.lower.constagg: compile-time folding of aggregate global
+# initializers into initialized data.
+#
+# A module-level `val`/`var` whose initializer is a struct / array / `str`
+# literal is a compile-time constant: its bytes are known at compile time and
+# must be emitted into `.data`/`.rodata`, not left as a zeroed `.bss` slot.
+# `comptime.eval` only folds scalars, so this module folds the aggregate shapes
+# it rejects.
+#
+# The folder lays the initializer out into a blob sized to the aggregate's IR
+# type, placing each leaf at its IR field offset / array stride, and records a
+# relocation for every pointer leaf (a `str` literal, whose value is the address
+# of an anonymous `.rodata` global the linker must patch in). The result is a
+# `VAL_CONST_AGG` value the back end serializes directly. Record layout is
+# backend-owned, so this mirrors the `$size_of` handling path in `lower_global`:
+# it folds here, where the IR type table answers layout questions.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_some;
+use std.types.option.is_none;
+use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_ok;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
+
+use std.allocator.allocate;
+use std.allocator.reallocate;
+
+use src:      mach.lang.source;
+use ty:       mach.lang.type;
+use intern:   mach.lang.intern;
+
+use ast:      mach.lang.fe.ast;
+use aid:      mach.lang.fe.ast.id;
+use aexpr:    mach.lang.fe.ast.expr;
+use comptime: mach.lang.fe.comptime;
+
+use ir:       mach.lang.me.ir;
+use ir_type:  mach.lang.me.ir.type;
+use value:    mach.lang.me.ir.value;
+
+use lower:    mach.lang.me.lower.context;
+use expr:     mach.lang.me.lower.expr;
+
+# a growing collection of pointer-leaf relocations accumulated while laying out
+# an aggregate. backed by the module allocator so the side-table outlives the
+# fold and is borrowed by the resulting Value.
+# ---
+# relocs: the side-table array (nil until the first push)
+# len:    number of entries
+# cap:    allocated slots
+rec RelocBuf {
+    relocs: *value.AggReloc;
+    len:    u32;
+    cap:    u32;
+}
+
+# appends one relocation to `rb`, growing the backing array on overflow.
+fun reloc_push(ctx: *lower.LowerContext, rb: *RelocBuf, r: value.AggReloc) Result[bool, str] {
+    if (rb.len == rb.cap) {
+        var new_cap: u32 = 4;
+        if (rb.cap > 0) { new_cap = rb.cap * 2; }
+        if (rb.relocs == nil) {
+            val ar: Result[*value.AggReloc, str] = allocate[value.AggReloc](ctx.m.alloc, new_cap::usize);
+            if (is_err[*value.AggReloc, str](ar)) { ret err[bool, str](unwrap_err[*value.AggReloc, str](ar)); }
+            rb.relocs = unwrap_ok[*value.AggReloc, str](ar);
+        } or {
+            val ar: Result[*value.AggReloc, str] = reallocate[value.AggReloc](ctx.m.alloc, rb.relocs, rb.cap::usize, new_cap::usize);
+            if (is_err[*value.AggReloc, str](ar)) { ret err[bool, str](unwrap_err[*value.AggReloc, str](ar)); }
+            rb.relocs = unwrap_ok[*value.AggReloc, str](ar);
+        }
+        rb.cap = new_cap;
+    }
+    rb.relocs[rb.len] = r;
+    rb.len = rb.len + 1;
+    ret ok[bool, str](true);
+}
+
+# attempts to fold an aggregate (or `str`) global initializer into a
+# VAL_CONST_AGG value. returns some(value) when `eid` is a struct / array
+# literal, or a `str` literal initializing a pointer global, whose leaves are
+# all compile-time constants; none when `eid` is not such an initializer (the
+# caller falls back to its scalar path); an error when a leaf is not a
+# compile-time constant.
+# ---
+# ctx:    the lowering context
+# eid:    the initializer expression
+# gty:    the global's IR type
+# ret:    some(VAL_CONST_AGG) | none | error
+pub fun try_const_aggregate(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_type.IrTypeId) Result[Option[value.Value], str] {
+    val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
+    if (is_none[*aexpr.Expr](e_opt)) { ret ok[Option[value.Value], str](none[value.Value]()); }
+    val e: *aexpr.Expr = unwrap[*aexpr.Expr](e_opt);
+
+    # a struct / array literal always routes here. a `str` literal routes here
+    # only when its global is a pointer: the global holds the *address* of a
+    # separate rodata blob (a relocation), never the bytes inline. any other
+    # initializer is a scalar the caller folds through its own path.
+    var is_agg: bool = e.kind == aexpr.EXPR_KIND_STRUCT_LIT || e.kind == aexpr.EXPR_KIND_ARRAY_LIT;
+    if (e.kind == aexpr.EXPR_KIND_LIT_STR && ir_is_ptr(ctx, gty)) { is_agg = true; }
+    if (!is_agg) {
+        ret ok[Option[value.Value], str](none[value.Value]());
+    }
+
+    val size: u32 = ir_type.byte_size(?ctx.m.types, gty, ctx.tgt);
+    if (size == 0) { ret err[Option[value.Value], str]("constagg: aggregate global has zero size"); }
+
+    val br: Result[*u8, str] = allocate[u8](ctx.m.alloc, size::usize);
+    if (is_err[*u8, str](br)) { ret err[Option[value.Value], str](unwrap_err[*u8, str](br)); }
+    val blob: *u8 = unwrap_ok[*u8, str](br);
+    zero_fill(blob, size);
+
+    var rb: RelocBuf;
+    rb.relocs = nil;
+    rb.len    = 0;
+    rb.cap    = 0;
+
+    val pr: Result[bool, str] = place(ctx, eid, gty, blob, 0, ?rb);
+    if (is_err[bool, str](pr)) { ret err[Option[value.Value], str](unwrap_err[bool, str](pr)); }
+
+    ret ok[Option[value.Value], str](some[value.Value](value.const_agg(blob, size, rb.relocs, rb.len, gty)));
+}
+
+# lays the initializer `eid` out at byte offset `base` within `blob`, dispatching
+# on the leaf's IR type. struct and array leaves recurse; pointer leaves record a
+# relocation; scalar leaves are comptime-folded and written little-endian.
+fun place(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf) Result[bool, str] {
+    val t_opt: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ity);
+    if (is_none[*ir_type.IrType](t_opt)) { ret err[bool, str]("constagg: leaf has unknown IR type"); }
+    val t: *ir_type.IrType = unwrap[*ir_type.IrType](t_opt);
+
+    if (t.kind == ir_type.IRT_STRUCT) { ret place_struct(ctx, eid, ity, blob, base, rb); }
+    if (t.kind == ir_type.IRT_ARRAY)  { ret place_array(ctx, eid, ity, blob, base, rb); }
+    if (t.kind == ir_type.IRT_PTR)    { ret place_ptr(ctx, eid, ity, blob, base, rb); }
+    ret place_scalar(ctx, eid, ity, blob, base);
+}
+
+# lays out a struct literal: each field-init is placed at its field's IR byte
+# offset. fields with no initializer stay zero (the blob is pre-zeroed).
+fun place_struct(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf) Result[bool, str] {
+    val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
+    if (is_none[*aexpr.Expr](e_opt)) { ret err[bool, str]("constagg: struct leaf expr out of range"); }
+    val e: *aexpr.Expr = unwrap[*aexpr.Expr](e_opt);
+    if (e.kind != aexpr.EXPR_KIND_STRUCT_LIT) {
+        ret err[bool, str]("constagg: struct-typed aggregate field has a non-struct-literal initializer");
+    }
+
+    val rec_ty: ty.TypeId = lower.expr_type_of(ctx, eid);
+    val t_opt: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ity);
+    if (is_none[*ir_type.IrType](t_opt)) { ret err[bool, str]("constagg: struct leaf has unknown IR type"); }
+    val t: *ir_type.IrType = unwrap[*ir_type.IrType](t_opt);
+
+    var i: u32 = 0;
+    for (i < e.data.struct_lit.fields_len) {
+        val pool_ix: u32 = e.data.struct_lit.fields_start + i;
+        if (pool_ix::usize >= ctx.a.field_init_len) { ret err[bool, str]("constagg: struct field index out of range"); }
+        val fi: *aexpr.FieldInit = ?ctx.a.field_inits[pool_ix];
+        val field_ix: u32 = expr.field_index_in_type(ctx, rec_ty, fi.name);
+        if (field_ix >= t.data.struct_.field_count) { ret err[bool, str]("constagg: struct field index exceeds IR field count"); }
+        val fty: ir_type.IrTypeId = t.data.struct_.fields[field_ix];
+        val foff: u32 = ir_type.byte_offset(?ctx.m.types, ity, field_ix, ctx.tgt);
+        val r: Result[bool, str] = place(ctx, fi.value, fty, blob, base + foff, rb);
+        if (is_err[bool, str](r)) { ret r; }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# lays out an array literal: each element is placed at `i * element-size`.
+# elements past the literal's length stay zero.
+fun place_array(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf) Result[bool, str] {
+    val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
+    if (is_none[*aexpr.Expr](e_opt)) { ret err[bool, str]("constagg: array leaf expr out of range"); }
+    val e: *aexpr.Expr = unwrap[*aexpr.Expr](e_opt);
+    if (e.kind != aexpr.EXPR_KIND_ARRAY_LIT) {
+        ret err[bool, str]("constagg: array-typed aggregate field has a non-array-literal initializer");
+    }
+
+    val t_opt: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ity);
+    if (is_none[*ir_type.IrType](t_opt)) { ret err[bool, str]("constagg: array leaf has unknown IR type"); }
+    val t: *ir_type.IrType = unwrap[*ir_type.IrType](t_opt);
+    val ety: ir_type.IrTypeId = t.data.element;
+    val stride: u32 = ir_type.byte_size(?ctx.m.types, ety, ctx.tgt);
+
+    var i: u32 = 0;
+    for (i < e.data.array_lit.elems_len) {
+        val pool_ix: u32 = e.data.array_lit.elems_start + i;
+        if (pool_ix::usize >= ctx.a.expr_id_len) { ret err[bool, str]("constagg: array element index out of range"); }
+        val elem_eid: aid.ExprId = ctx.a.expr_ids[pool_ix];
+        val r: Result[bool, str] = place(ctx, elem_eid, ety, blob, base + i * stride, rb);
+        if (is_err[bool, str](r)) { ret r; }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# lays out a pointer leaf. a `str` literal materializes an anonymous `.rodata`
+# global and records a relocation patching this slot with its address; `nil`
+# stays zero. any other pointer initializer is not a compile-time constant.
+fun place_ptr(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf) Result[bool, str] {
+    val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
+    if (is_none[*aexpr.Expr](e_opt)) { ret err[bool, str]("constagg: pointer leaf expr out of range"); }
+    val e: *aexpr.Expr = unwrap[*aexpr.Expr](e_opt);
+
+    if (e.kind == aexpr.EXPR_KIND_LIT_NIL) { ret ok[bool, str](true); }
+
+    if (e.kind == aexpr.EXPR_KIND_LIT_STR) {
+        val gv_r: Result[value.Value, str] = expr.lower_lit_str(ctx, e);
+        if (is_err[value.Value, str](gv_r)) { ret err[bool, str](unwrap_err[value.Value, str](gv_r)); }
+        val gv: value.Value = unwrap_ok[value.Value, str](gv_r);
+        if (gv.kind != value.VAL_GLOBAL || gv.data.global_ix >= ctx.m.global_len) {
+            ret err[bool, str]("constagg: string leaf did not lower to a global");
+        }
+        var r: value.AggReloc;
+        r.offset = base;
+        r.symbol = ctx.m.globals[gv.data.global_ix].name;
+        r.addend = 0;
+        ret reloc_push(ctx, rb, r);
+    }
+
+    ret err[bool, str]("constagg: non-constant pointer in aggregate global initializer");
+}
+
+# lays out a scalar leaf: comptime-folds the expression and writes its bits
+# little-endian into the leaf's type-sized slot.
+fun place_scalar(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32) Result[bool, str] {
+    val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, module_source(ctx), eid, ?ctx.s.interner);
+    if (is_err[comptime.CTValue, str](ev)) {
+        ret err[bool, str]("constagg: aggregate global initializer has a non-constant leaf");
+    }
+    val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
+
+    val size: u32 = ir_type.byte_size(?ctx.m.types, ity, ctx.tgt);
+    if (size == 0 || size > 8) { ret err[bool, str]("constagg: scalar leaf has unsupported size"); }
+
+    var bits: u64 = 0;
+    if (v.kind == comptime.CT_KIND_INT)   { bits = v.data.i::u64; }
+    or (v.kind == comptime.CT_KIND_BOOL)  { if (v.data.b) { bits = 1; } }
+    or (v.kind == comptime.CT_KIND_FLOAT) { bits = f64_bits(v.data.f); }
+    or { ret err[bool, str]("constagg: unsupported scalar leaf kind"); }
+
+    var i: u32 = 0;
+    for (i < size) {
+        blob[base + i] = (bits >> (i::u64 * 8::u64))::u8;
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# reinterprets an f64 as its raw 64-bit pattern via a one-element union.
+fun f64_bits(f: f64) u64 {
+    var u: uni { f: f64; i: u64; };
+    u.f = f;
+    ret u.i;
+}
+
+# true when IR type `ity` is a pointer.
+fun ir_is_ptr(ctx: *lower.LowerContext, ity: ir_type.IrTypeId) bool {
+    val t_opt: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ity);
+    if (is_none[*ir_type.IrType](t_opt)) { ret false; }
+    ret unwrap[*ir_type.IrType](t_opt).kind == ir_type.IRT_PTR;
+}
+
+# zero-fills `len` bytes at `p`.
+fun zero_fill(p: *u8, len: u32) {
+    var i: u32 = 0;
+    for (i < len) {
+        p[i] = 0;
+        i = i + 1;
+    }
+}
+
+# the module's source text from the session source map (empty for an
+# unregistered file id, which a well-formed pipeline never produces).
+fun module_source(ctx: *lower.LowerContext) str {
+    val sf: Option[*src.SourceFile] = src.get(?ctx.s.sources, ctx.a.file_id);
+    if (is_none[*src.SourceFile](sf)) { ret nil::str; }
+    ret unwrap[*src.SourceFile](sf).text;
+}

--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -123,12 +123,12 @@ pub fun try_const_aggregate(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_t
     # a struct / array literal always routes here. a pointer-typed global routes
     # here when its initializer is a constant address the linker must patch in:
     # a `str` literal (a rodata blob), an address-of `?G` / `?G.field`, or a bare
-    # function / global name. the global holds that *address* (a relocation),
-    # never bytes inline — and there is no init-synthesis pass, so an unfolded
-    # pointer global would stay a NULL placeholder. any other initializer is a
-    # scalar the caller folds through its own path.
+    # function name. the global holds that *address* (a relocation), never bytes
+    # inline — and there is no init-synthesis pass, so an unfolded pointer global
+    # would stay a NULL placeholder. any other initializer is a scalar the caller
+    # folds through its own path.
     var is_agg: bool = e.kind == aexpr.EXPR_KIND_STRUCT_LIT || e.kind == aexpr.EXPR_KIND_ARRAY_LIT;
-    if (ir_is_ptr_or_fn(ctx, gty) && is_const_addr_init(ctx, e)) { is_agg = true; }
+    if (ir_is_ptr_or_fn(ctx, gty) && is_const_addr_init(ctx, eid, e)) { is_agg = true; }
     if (!is_agg) {
         ret ok[Option[value.Value], str](none[value.Value]());
     }
@@ -341,7 +341,9 @@ fun place_addr_of(ctx: *lower.LowerContext, operand: aid.ExprId, blob: *u8, base
     for (true) {
         val name_opt: Option[intern.StrId] = expr.symbol_linkage_name(ctx, cur);
         if (is_some[intern.StrId](name_opt)) {
-            ret push_sym_reloc(ctx, rb, base, unwrap[intern.StrId](name_opt), addend, false);
+            # `?fn` takes the address of a function; mark the reloc so a cross-
+            # module extern stub for it is typed STT_FUNC, mirroring place_fn.
+            ret push_sym_reloc(ctx, rb, base, unwrap[intern.StrId](name_opt), addend, expr.references_function(ctx, cur));
         }
 
         val ce_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, cur);
@@ -460,11 +462,14 @@ fun ir_is_ptr_or_fn(ctx: *lower.LowerContext, ity: ir_type.IrTypeId) bool {
 # `?mod.G`), or a bare name resolving to a module function. routing these through
 # the folder keeps a top-level pointer global from staying a NULL placeholder
 # (there is no init-synthesis pass to fill it later). a `nil` initializer is
-# already a correct zero placeholder on the scalar path, so it is left there; a
-# genuinely non-constant pointer initializer falls back inside place_ptr.
-fun is_const_addr_init(ctx: *lower.LowerContext, e: *aexpr.Expr) bool {
+# already a correct zero placeholder on the scalar path, so it is left there. a
+# bare *data* global name is the runtime contents of that global, not a constant
+# address, so it is excluded here (it would only zalloc a blob and fall back).
+fun is_const_addr_init(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) bool {
     if (e.kind == aexpr.EXPR_KIND_LIT_STR) { ret true; }
     if (e.kind == aexpr.EXPR_KIND_UNARY && e.data.unary.op == aexpr.UN_ADDR) { ret true; }
-    if (e.kind == aexpr.EXPR_KIND_IDENT || e.kind == aexpr.EXPR_KIND_MEMBER) { ret true; }
+    if (e.kind == aexpr.EXPR_KIND_IDENT || e.kind == aexpr.EXPR_KIND_MEMBER) {
+        ret expr.references_function(ctx, eid);
+    }
     ret false;
 }

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -34,6 +34,7 @@ use map: std.collections.map;
 use maphash: std.collections.map;
 
 use sess:     mach.lang.session;
+use src:      mach.lang.source;
 use target:   mach.lang.target.resolved;
 use ty:       mach.lang.type;
 use intern:   mach.lang.intern;
@@ -711,6 +712,18 @@ pub fun expr_symbol_of(lc: *LowerContext, eid: aid.ExprId) resolve.SymbolId {
     if (eid == aid.EXPR_NIL) { ret resolve.SYMBOL_NIL; }
     if (eid::usize >= lc.rr.expr_count) { ret resolve.SYMBOL_NIL; }
     ret lc.rr.expr_resolved[eid];
+}
+
+# returns the module's source text from the session source map. an unregistered
+# file id yields the empty string — never reached for a well-formed pipeline,
+# since resolve already required the file to be registered.
+# ---
+# lc:  the context
+# ret: the module's source text, or the empty string
+pub fun module_source(lc: *LowerContext) str {
+    val sf: Option[*src.SourceFile] = src.get(?lc.s.sources, lc.a.file_id);
+    if (is_none[*src.SourceFile](sf)) { ret nil::str; }
+    ret unwrap[*src.SourceFile](sf).text;
 }
 
 # returns a pointer to a resolved Symbol by id, or none when out of range.

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -55,10 +55,11 @@ use ir_type:  mach.lang.me.ir.type;
 use value:    mach.lang.me.ir.value;
 use builder:  mach.lang.me.ir.builder;
 
-use lower:  mach.lang.me.lower.context;
-use mangle: mach.lang.me.lower.mangle;
-use stmt:   mach.lang.me.lower.stmt;
-use expr:   mach.lang.me.lower.expr;
+use lower:    mach.lang.me.lower.context;
+use mangle:   mach.lang.me.lower.mangle;
+use stmt:     mach.lang.me.lower.stmt;
+use expr:     mach.lang.me.lower.expr;
+use constagg: mach.lang.me.lower.constagg;
 
 # lowers one top-level declaration, dispatching on its `DeclKind`.
 # erased forms (rec, uni, def, use, comptime-attr) lower to nothing; a
@@ -381,8 +382,21 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
 
     var init_val: value.Value = value.const_int(0, gty);
     if (d.data.bind.init != aid.EXPR_NIL) {
+        # a struct / array / `str`-into-pointer initializer is a compile-time
+        # constant aggregate the frontend `comptime.eval` cannot fold to a
+        # scalar: its bytes (and the relocations for its pointer leaves) are laid
+        # out here and emitted as initialized data, never a zeroed .bss slot.
+        # tried before the scalar path so a `val X: str = "..."` becomes a real
+        # pointer-with-relocation instead of the bytes inline.
+        val agg: Result[Option[value.Value], str] = constagg.try_const_aggregate(ctx, d.data.bind.init, gty);
+        if (is_err[Option[value.Value], str](agg)) { ret err[bool, str](unwrap_err[Option[value.Value], str](agg)); }
+        val agg_opt: Option[value.Value] = unwrap_ok[Option[value.Value], str](agg);
+
         val cv: Option[comptime.CTValue] = try_comptime(ctx, d.data.bind.init);
-        if (is_some[comptime.CTValue](cv)) {
+        if (is_some[value.Value](agg_opt)) {
+            init_val = unwrap[value.Value](agg_opt);
+        }
+        or (is_some[comptime.CTValue](cv)) {
             val vr: Result[value.Value, str] = expr.const_value_of(ctx, d.data.bind.init, unwrap[comptime.CTValue](cv));
             if (is_err[value.Value, str](vr)) { ret err[bool, str](unwrap_err[value.Value, str](vr)); }
             init_val = unwrap_ok[value.Value, str](vr);

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -42,7 +42,6 @@ use intern:   mach.lang.intern;
 use ty:       mach.lang.type;
 use sess:     mach.lang.session;
 
-use src:      mach.lang.source;
 use ast:      mach.lang.fe.ast;
 use aid:      mach.lang.fe.ast.id;
 use adecl:    mach.lang.fe.ast.decl;
@@ -107,7 +106,7 @@ pub fun lower_fun(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, is_
     if (is_err[ir_type.IrTypeId, str](sig_r)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](sig_r)); }
     val sig: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](sig_r);
 
-    val bare_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, module_source(ctx), d.data.fun_.name);
+    val bare_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), d.data.fun_.name);
     if (is_err[intern.StrId, str](bare_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](bare_r)); }
     val bare: intern.StrId = unwrap_ok[intern.StrId, str](bare_r);
 
@@ -213,7 +212,7 @@ fun lower_test(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl) Result
     if (is_err[ir_type.IrTypeId, str](sig_r)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](sig_r)); }
     val sig: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](sig_r);
 
-    val bare_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, module_source(ctx), d.data.test_.label);
+    val bare_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), d.data.test_.label);
     if (is_err[intern.StrId, str](bare_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](bare_r)); }
     val bare: intern.StrId = unwrap_ok[intern.StrId, str](bare_r);
 
@@ -372,7 +371,7 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
     if (is_err[ir_type.IrTypeId, str](gty_r)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](gty_r)); }
     val gty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](gty_r);
 
-    val bare_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, module_source(ctx), d.data.bind.name);
+    val bare_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), d.data.bind.name);
     if (is_err[intern.StrId, str](bare_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](bare_r)); }
     val bare: intern.StrId = unwrap_ok[intern.StrId, str](bare_r);
 
@@ -443,7 +442,7 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
 # lowers a decl-scope `$if` chain: evaluates each arm's condition and
 # recurses into the active arm's decl list only.
 fun lower_comptime_if(ctx: *lower.LowerContext, d: *adecl.Decl) Result[bool, str] {
-    val txt: str = module_source(ctx);
+    val txt: str = lower.module_source(ctx);
     var bi: u32 = 0;
     for (bi < d.data.comptime_if.branches_len) {
         val branch_ix: u32 = d.data.comptime_if.branches_start + bi;
@@ -559,7 +558,7 @@ fun param_symbol(ctx: *lower.LowerContext, fun_did: aid.DeclId, index: u32) reso
 # none when the initialiser is not comptime-evaluable (its runtime logic
 # belongs in the module init function instead).
 fun try_comptime(ctx: *lower.LowerContext, eid: aid.ExprId) Option[comptime.CTValue] {
-    val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, module_source(ctx), eid, ?ctx.s.interner);
+    val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner);
     if (is_ok[comptime.CTValue, str](ev)) {
         ret some[comptime.CTValue](unwrap_ok[comptime.CTValue, str](ev));
     }
@@ -587,15 +586,6 @@ fun is_void_ir(ctx: *lower.LowerContext, tid: ir_type.IrTypeId) bool {
     val t_opt: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, tid);
     if (is_none[*ir_type.IrType](t_opt)) { ret true; }
     ret unwrap[*ir_type.IrType](t_opt).kind == ir_type.IRT_VOID;
-}
-
-# the module's source text from the session source map.
-fun module_source(ctx: *lower.LowerContext) str {
-    val sf: Option[*src.SourceFile] = src.get(?ctx.s.sources, ctx.a.file_id);
-    if (is_none[*src.SourceFile](sf)) {
-        ret nil::str;
-    }
-    ret unwrap[*src.SourceFile](sf).text;
 }
 
 # fun_export_of: the link-name override that exempts a function declaration from

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -423,10 +423,13 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
                 }
             }
         }
-        # a non-comptime initialiser stays a zero placeholder; the runtime
-        # init logic is materialised into the module init function by the
-        # driver's init-synthesis step. lowering records the global so the
-        # initialiser slot exists.
+        # an initialiser that none of the paths above could fold stays a zero
+        # placeholder and lands in `.bss`. there is no runtime init-synthesis pass
+        # to fill it later (`ir.Module.init_fn` is never populated), so any
+        # initialiser that must carry data — a struct / array / `str` aggregate,
+        # or a const-address pointer (`?G`, a function name) — is deliberately
+        # routed through `constagg.try_const_aggregate` above to be emitted as
+        # initialised data instead of reaching this fall-through.
     }
 
     var g: ir.Global;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -391,30 +391,34 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
         if (is_err[Option[value.Value], str](agg)) { ret err[bool, str](unwrap_err[Option[value.Value], str](agg)); }
         val agg_opt: Option[value.Value] = unwrap_ok[Option[value.Value], str](agg);
 
-        val cv: Option[comptime.CTValue] = try_comptime(ctx, d.data.bind.init);
         if (is_some[value.Value](agg_opt)) {
             init_val = unwrap[value.Value](agg_opt);
-        }
-        or (is_some[comptime.CTValue](cv)) {
-            val vr: Result[value.Value, str] = expr.const_value_of(ctx, d.data.bind.init, unwrap[comptime.CTValue](cv));
-            if (is_err[value.Value, str](vr)) { ret err[bool, str](unwrap_err[value.Value, str](vr)); }
-            init_val = unwrap_ok[value.Value, str](vr);
         } or {
-            # a type-introspection intrinsic ($size_of/$align_of/$offset_of) is a
-            # comptime constant the frontend `comptime.eval` cannot fold — record
-            # layout is backend-owned. fold it here via the same path function
-            # bodies use, so `val X = $size_of(T)` becomes a real .rodata constant
-            # instead of a zero placeholder the read-only global can never receive.
-            val ie_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, d.data.bind.init);
-            if (is_some[*aexpr.Expr](ie_opt)) {
-                val ie: *aexpr.Expr = unwrap[*aexpr.Expr](ie_opt);
-                if (ie.kind == aexpr.EXPR_KIND_CALL) {
-                    val intr: Option[Result[value.Value, str]] =
-                        expr.try_lower_comptime_intrinsic(ctx, d.data.bind.init, ie);
-                    if (is_some[Result[value.Value, str]](intr)) {
-                        val ir2: Result[value.Value, str] = unwrap[Result[value.Value, str]](intr);
-                        if (is_err[value.Value, str](ir2)) { ret err[bool, str](unwrap_err[value.Value, str](ir2)); }
-                        init_val = unwrap_ok[value.Value, str](ir2);
+            # the aggregate folder did not apply; try the scalar comptime fold.
+            # only evaluated here (not unconditionally above) so a folded aggregate
+            # never pays for a wasted comptime.eval pass.
+            val cv: Option[comptime.CTValue] = try_comptime(ctx, d.data.bind.init);
+            if (is_some[comptime.CTValue](cv)) {
+                val vr: Result[value.Value, str] = expr.const_value_of(ctx, d.data.bind.init, unwrap[comptime.CTValue](cv));
+                if (is_err[value.Value, str](vr)) { ret err[bool, str](unwrap_err[value.Value, str](vr)); }
+                init_val = unwrap_ok[value.Value, str](vr);
+            } or {
+                # a type-introspection intrinsic ($size_of/$align_of/$offset_of) is a
+                # comptime constant the frontend `comptime.eval` cannot fold — record
+                # layout is backend-owned. fold it here via the same path function
+                # bodies use, so `val X = $size_of(T)` becomes a real .rodata constant
+                # instead of a zero placeholder the read-only global can never receive.
+                val ie_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, d.data.bind.init);
+                if (is_some[*aexpr.Expr](ie_opt)) {
+                    val ie: *aexpr.Expr = unwrap[*aexpr.Expr](ie_opt);
+                    if (ie.kind == aexpr.EXPR_KIND_CALL) {
+                        val intr: Option[Result[value.Value, str]] =
+                            expr.try_lower_comptime_intrinsic(ctx, d.data.bind.init, ie);
+                        if (is_some[Result[value.Value, str]](intr)) {
+                            val ir2: Result[value.Value, str] = unwrap[Result[value.Value, str]](intr);
+                            if (is_err[value.Value, str](ir2)) { ret err[bool, str](unwrap_err[value.Value, str](ir2)); }
+                            init_val = unwrap_ok[value.Value, str](ir2);
+                        }
                     }
                 }
             }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -38,7 +38,6 @@ use std.types.result.unwrap_err;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 
-use src:      mach.lang.source;
 use ty:       mach.lang.type;
 use intern:   mach.lang.intern;
 
@@ -165,7 +164,7 @@ pub fun lower_lit_str(ctx: *lower.LowerContext, e: *aexpr.Expr) Result[value.Val
     val pty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](pr);
 
     # the literal's inner content view, with the surrounding quotes stripped.
-    val txt: str = module_source(ctx);
+    val txt: str = lower.module_source(ctx);
     var inner: StrView = view(nil, 0);
     if (e.span.len >= 2::usize) {
         inner = view(?txt[e.span.offset + 1::usize], e.span.len - 2::usize);
@@ -317,6 +316,33 @@ fun reference_linkage_name(ctx: *lower.LowerContext, sym: *resolve.Symbol) Resul
         export = sess.export_name(ctx.s, sym.origin, sym.decl::u32);
     }
     ret mangle.linkage_name(ctx.s, fqn, sym.name, export);
+}
+
+# symbol_linkage_name: the back-end symbol name an identifier (or module-
+# qualified member) expression resolves to, when it names a module-level
+# function or `val`/`var` binding — the symbol whose address a constant
+# aggregate initializer's `&G` / function-pointer leaf relocates against. returns
+# none for a local, parameter, type, or otherwise non-addressable reference, so
+# the constant-aggregate folder falls back rather than emitting a bad relocation.
+# ---
+# ctx: the lowering context
+# eid: the AST expression naming the symbol
+# ret: some(linkage StrId) for a module-level fn/binding, else none
+pub fun symbol_linkage_name(ctx: *lower.LowerContext, eid: aid.ExprId) Option[intern.StrId] {
+    val sid: resolve.SymbolId = lower.expr_symbol_of(ctx, eid);
+    val sym_opt: Option[*resolve.Symbol] = lower.symbol_of(ctx, sid);
+    if (is_none[*resolve.Symbol](sym_opt)) { ret none[intern.StrId](); }
+    val sym: *resolve.Symbol = unwrap[*resolve.Symbol](sym_opt);
+
+    val ok_kind: bool = sym.kind == resolve.SYM_FUN
+        || sym.kind == resolve.SYM_VAL
+        || sym.kind == resolve.SYM_VAR
+        || sym.kind == resolve.SYM_IMPORTED;
+    if (!ok_kind) { ret none[intern.StrId](); }
+
+    val ln_r: Result[intern.StrId, str] = reference_linkage_name(ctx, sym);
+    if (is_err[intern.StrId, str](ln_r)) { ret none[intern.StrId](); }
+    ret some[intern.StrId](unwrap_ok[intern.StrId, str](ln_r));
 }
 
 # forms an rvalue for an identifier that names a module-level symbol: a
@@ -631,7 +657,7 @@ pub fun try_lower_comptime_intrinsic(ctx: *lower.LowerContext, eid: aid.ExprId, 
     var ns: token.Span = ce.span;
     ns.offset = ns.offset + 1;
     ns.len    = ns.len - 1;
-    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, module_source(ctx), ns);
+    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), ns);
     if (is_err[intern.StrId, str](name_r)) {
         ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[intern.StrId, str](name_r)));
     }
@@ -686,7 +712,7 @@ pub fun try_lower_va_intrinsic(ctx: *lower.LowerContext, eid: aid.ExprId, e: *ae
     val ce: *aexpr.Expr = unwrap[*aexpr.Expr](ce_opt);
     if (ce.kind != aexpr.EXPR_KIND_IDENT) { ret none[Result[value.Value, str]](); }
 
-    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, module_source(ctx), ce.span);
+    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), ce.span);
     if (is_err[intern.StrId, str](name_r)) {
         ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[intern.StrId, str](name_r)));
     }
@@ -1130,7 +1156,7 @@ fun lower_comptime_ident(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Ex
     var name_span: token.Span = e.span;
     name_span.offset = name_span.offset + 1;
     name_span.len    = name_span.len - 1;
-    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, module_source(ctx), name_span);
+    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), name_span);
     if (is_err[intern.StrId, str](name_r)) { ret err[value.Value, str](unwrap_err[intern.StrId, str](name_r)); }
     val nc: Option[*comptime.NamedConst] = comptime.lookup(ctx.ctx, unwrap_ok[intern.StrId, str](name_r));
     if (is_none[*comptime.NamedConst](nc)) {
@@ -1144,7 +1170,7 @@ fun lower_comptime_ident(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Ex
 # expression's IR type. used for `$mach.*` member chains in rvalue position,
 # whose semantic type was set to the usage-site type during coercion.
 fun lower_comptime_path(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.Value, str] {
-    val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, module_source(ctx), eid, ?ctx.s.interner);
+    val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner);
     if (is_err[comptime.CTValue, str](ev)) { ret err[value.Value, str](unwrap_err[comptime.CTValue, str](ev)); }
     ret const_value_of(ctx, eid, unwrap_ok[comptime.CTValue, str](ev));
 }
@@ -1275,17 +1301,6 @@ fun index_type(ctx: *lower.LowerContext) Result[ir_type.IrTypeId, str] {
     ret ir_type.intern_int(?ctx.m.types, 64);
 }
 
-# the module's source text, read from the session source map by the AST's
-# file id. an unregistered file id yields the empty string (a defensive
-# null, never reached for a well-formed pipeline since resolve already
-# required the file to be registered).
-fun module_source(ctx: *lower.LowerContext) str {
-    val sf: Option[*src.SourceFile] = src.get(?ctx.s.sources, ctx.a.file_id);
-    if (is_none[*src.SourceFile](sf)) {
-        ret nil::str;
-    }
-    ret unwrap[*src.SourceFile](sf).text;
-}
 
 # the bit width of a scalar semantic type (int/float/pointer), or 0 for
 # non-scalars.
@@ -1347,7 +1362,7 @@ fun is_aggregate_ir(ctx: *lower.LowerContext, ity: ir_type.IrTypeId) bool {
 # struct literals sema guarantees the field exists, so the miss is unreachable
 # there; `$offset_of`'s bare field argument is only validated here.
 pub fun field_index_in_type(ctx: *lower.LowerContext, rec_ty: ty.TypeId, name: token.Span) u32 {
-    val src_text: str = module_source(ctx);
+    val src_text: str = lower.module_source(ctx);
     val want_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, src_text, name);
     if (is_err[intern.StrId, str](want_r)) { ret 0; }
     val want: intern.StrId = unwrap_ok[intern.StrId, str](want_r);

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -159,7 +159,7 @@ fun lower_lit_char(ctx: *lower.LowerContext, e: *aexpr.Expr) Result[value.Value,
 # documented string-literal semantics and comptime.eval's eval_lit_str. the
 # decoded content is interned (giving a stable byte sequence) and the Value
 # borrows the interned bytes.
-fun lower_lit_str(ctx: *lower.LowerContext, e: *aexpr.Expr) Result[value.Value, str] {
+pub fun lower_lit_str(ctx: *lower.LowerContext, e: *aexpr.Expr) Result[value.Value, str] {
     val pr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);
     if (is_err[ir_type.IrTypeId, str](pr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](pr)); }
     val pty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](pr);
@@ -1346,7 +1346,7 @@ fun is_aggregate_ir(ctx: *lower.LowerContext, ity: ir_type.IrTypeId) bool {
 # returns 0, instead of silently folding to field 0. for `.field` access and
 # struct literals sema guarantees the field exists, so the miss is unreachable
 # there; `$offset_of`'s bare field argument is only validated here.
-fun field_index_in_type(ctx: *lower.LowerContext, rec_ty: ty.TypeId, name: token.Span) u32 {
+pub fun field_index_in_type(ctx: *lower.LowerContext, rec_ty: ty.TypeId, name: token.Span) u32 {
     val src_text: str = module_source(ctx);
     val want_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, src_text, name);
     if (is_err[intern.StrId, str](want_r)) { ret 0; }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -319,15 +319,19 @@ fun reference_linkage_name(ctx: *lower.LowerContext, sym: *resolve.Symbol) Resul
 }
 
 # symbol_linkage_name: the back-end symbol name an identifier (or module-
-# qualified member) expression resolves to, when it names a module-level
-# function or `val`/`var` binding — the symbol whose address a constant
-# aggregate initializer's `&G` / function-pointer leaf relocates against. returns
-# none for a local, parameter, type, or otherwise non-addressable reference, so
-# the constant-aggregate folder falls back rather than emitting a bad relocation.
+# qualified member) expression resolves to, when it names a function or a
+# `val`/`var` binding (kinds SYM_FUN / SYM_VAL / SYM_VAR / SYM_IMPORTED) — the
+# symbol whose address a constant aggregate initializer's `?G` / function-pointer
+# leaf relocates against. returns none for a parameter, type, or otherwise non-
+# addressable reference, so the folder falls back rather than emitting a bad
+# relocation. it does not by itself distinguish a module-level binding from a
+# block-local `val`/`var` of the same kind; the sole caller folds global-scope
+# initializers, where no local is in scope, so a returned name always denotes a
+# module-level symbol.
 # ---
 # ctx: the lowering context
 # eid: the AST expression naming the symbol
-# ret: some(linkage StrId) for a module-level fn/binding, else none
+# ret: some(linkage StrId) for a fn/binding symbol, else none
 pub fun symbol_linkage_name(ctx: *lower.LowerContext, eid: aid.ExprId) Option[intern.StrId] {
     val sid: resolve.SymbolId = lower.expr_symbol_of(ctx, eid);
     val sym_opt: Option[*resolve.Symbol] = lower.symbol_of(ctx, sid);
@@ -417,7 +421,7 @@ fun symbol_reference(ctx: *lower.LowerContext, eid: aid.ExprId, sid: resolve.Sym
 # true when the identifier expression's semantic type is a function type, so a
 # reference to it is a function-pointer reference (resolved to a local or extern
 # function rather than a global load).
-fun references_function(ctx: *lower.LowerContext, eid: aid.ExprId) bool {
+pub fun references_function(ctx: *lower.LowerContext, eid: aid.ExprId) bool {
     val tid: ty.TypeId = lower.expr_type_of(ctx, eid);
     val t_opt: Option[*ty.Type] = ty.get(?ctx.s.types, tid);
     if (is_none[*ty.Type](t_opt)) { ret false; }

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -33,7 +33,6 @@ use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
-use src:      mach.lang.source;
 use intern:   mach.lang.intern;
 
 use ast:      mach.lang.fe.ast;
@@ -370,7 +369,7 @@ fun lower_decl_stmt(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] 
 # a hard error: a mis-typed local would otherwise silently encode a bad
 # address.
 fun lower_asm(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] {
-    val txt: str = module_source(ctx);
+    val txt: str = lower.module_source(ctx);
 
     val isa_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, txt, s.data.asm_.isa);
     if (is_err[intern.StrId, str](isa_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](isa_r)); }
@@ -494,7 +493,7 @@ fun grow_bind_cap(cap: u32) u32 {
 # the comptime evaluator and lowers only the first arm whose condition is
 # true (or the final unconditional `$or` arm). inactive arms emit nothing.
 fun lower_comptime_if(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] {
-    val txt: str = module_source(ctx);
+    val txt: str = lower.module_source(ctx);
     var bi: u32 = 0;
     for (bi < s.data.comptime_if.branches_len) {
         val branch_ix: u32 = s.data.comptime_if.branches_start + bi;
@@ -552,11 +551,3 @@ fun decl_symbol_of(ctx: *lower.LowerContext, did: aid.DeclId) resolve.SymbolId {
     ret ctx.rr.decl_symbol[did];
 }
 
-# the module's source text from the session source map.
-fun module_source(ctx: *lower.LowerContext) str {
-    val sf: Option[*src.SourceFile] = src.get(?ctx.s.sources, ctx.a.file_id);
-    if (is_none[*src.SourceFile](sf)) {
-        ret nil::str;
-    }
-    ret unwrap[*src.SourceFile](sf).text;
-}

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -297,3 +297,23 @@ pub fun lookup(of_id: u32) Option[*OfVTable] {
     if (of_registry[of_id] == nil) { ret none[*OfVTable](); }
     ret some[*OfVTable](of_registry[of_id]);
 }
+
+# reloc_kind_name: the interned abstract relocation-kind name an `RK_*` id maps
+# to in a format vtable's `relocation_kinds` table — the StrId a `Relocation.kind`
+# must carry so the format writer matches it. returns intern.STR_NIL for a nil
+# vtable or an unmapped kind.
+# ---
+# vt:   the object-format vtable (nil yields STR_NIL)
+# kind: the abstract relocation kind (one of RK_*)
+# ret:  the interned kind name, or intern.STR_NIL
+pub fun reloc_kind_name(vt: *OfVTable, kind: RelocKind) intern.StrId {
+    if (vt == nil) { ret intern.STR_NIL; }
+    var i: u32 = 0;
+    for (i < vt.relocation_count) {
+        if (vt.relocation_kinds[i].id == kind::u32) {
+            ret vt.relocation_kinds[i].name;
+        }
+        i = i + 1;
+    }
+    ret intern.STR_NIL;
+}


### PR DESCRIPTION
Module-level aggregate global initializers (struct literals, array literals, `str` constants) were dropped to a zeroed `.bss` slot instead of carrying their data. This breaks all of `std.print` (`fs.stdout = File{fd:1}` reads `fd==0`) and segfaults on `str` globals (null pointer).

## Design

Global initializers are compile-time constants emitted as **initialized data** in `.data`/`.rodata`, with relocations for pointer/`str` leaves — no runtime constructor.

- New `VAL_CONST_AGG` value kind: a pre-serialized blob + a relocation side-table (`AggReloc`: offset -> symbol + addend) for pointer leaves.
- A const-aggregate folder in lowering walks struct/array/str literals whose leaves are all comptime constants, placing each leaf at its IR-type field offset and recording a relocation for `str`/address-of-global leaves (reusing the existing anonymous-rodata-global mechanism).
- `pack_globals` serializes the blob into `.data`/`.rodata` and attaches one `of.Relocation` per side-table entry — generalizing the existing section-agnostic relocation infra the `.text` path already uses.

Closes #1106