### PR TITLE
fix(regalloc): make MirInstr.asm_block deterministic at all construction sites

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -1456,6 +1456,10 @@ fun insert_mov_before_terminator(ctx: *LowerCtx, mb: *MirBlock, dst: MirOperand,
     mi.operand_count = 2;
     mi.width         = WORD_WIDTH;
     mi.src_width     = WORD_WIDTH;
+    # this splice bypasses push_instr, so enforce the asm_block invariant here:
+    # struct locals are not zero-initialized, and regalloc.flatten reads a non-nil
+    # asm_block as an inline-asm clobber barrier.
+    mi.asm_block     = nil;
 
     # grow by one, shift the terminator right, and drop the move into its place.
     val gr: Result[bool, str] = grow_instr(ctx, mb);
@@ -1549,6 +1553,10 @@ fun split_critical_edge(ctx: *LowerCtx, pred: *MirBlock, succ_id: u32) Result[*M
     br.operand_count = 1;
     br.width         = WORD_WIDTH;
     br.src_width     = WORD_WIDTH;
+    # this splice bypasses push_instr, so enforce the asm_block invariant here:
+    # struct locals are not zero-initialized, and regalloc.flatten reads a non-nil
+    # asm_block as an inline-asm clobber barrier.
+    br.asm_block     = nil;
 
     val ri: Result[*MirInstr, str] = allocate[MirInstr](ctx.alloc, 1::usize);
     if (is_err[*MirInstr, str](ri)) { deallocate[MirOperand](ctx.alloc, bops, 1::usize); ret err[*MirBlock, str](unwrap_err[*MirInstr, str](ri)); }

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -62,6 +62,7 @@ use std.types.result.unwrap_err;
 
 use std.allocator.Allocator;
 use std.allocator.allocate;
+use std.allocator.zallocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
@@ -1759,7 +1760,12 @@ fun rewrite_block(tgt: *target.Target, ctx: *AllocCtx, blk: *mir.MirBlock, is_en
         ii = ii + 1;
     }
 
-    val rn: Result[*mir.MirInstr, str] = allocate[mir.MirInstr](ctx.alloc, total::usize);
+    # zero the buffer so spliced reload/store MOVs (emit_reload/emit_store set
+    # opcode/operands/width but not asm_block) default to asm_block=nil rather than
+    # bump-arena residue; the rewritten real instruction still copies its own
+    # asm_block from `mi` explicitly. keeps every MirInstr reaching encode with a
+    # well-defined asm_block.
+    val rn: Result[*mir.MirInstr, str] = zallocate[mir.MirInstr](ctx.alloc, total::usize);
     if (is_err[*mir.MirInstr, str](rn)) { ret err[bool, str](unwrap_err[*mir.MirInstr, str](rn)); }
     val dst: *mir.MirInstr = unwrap_ok[*mir.MirInstr, str](rn);
     var w: u32 = 0;

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -82,6 +82,7 @@ use std.types.result.unwrap_err;
 
 use std.allocator.Allocator;
 use std.allocator.allocate;
+use std.allocator.zallocate;
 use std.allocator.deallocate;
 
 use target: mach.lang.target.resolved;
@@ -222,7 +223,13 @@ fun select_block(alloc: *Allocator, b: *mir.MirBlock) Result[bool, str] {
         ret ok[bool, str](true);
     }
 
-    val rnew: Result[*mir.MirInstr, str] = allocate[mir.MirInstr](alloc, total::usize);
+    # zero the buffer so every field of an emit()-built piece defaults to nil:
+    # the NEG/NOT expansion writes opcode/operands/width but not asm_block, and a
+    # MirInstr reaching the back end must carry asm_block=nil unless it is MIR_ASM
+    # (regalloc.flatten reads asm_block!=nil as the inline-asm clobber-barrier
+    # discriminant). leaving it as bump-arena residue would make that read
+    # generation-dependent and break the byte-identical self-host fixpoint.
+    val rnew: Result[*mir.MirInstr, str] = zallocate[mir.MirInstr](alloc, total::usize);
     if (is_err[*mir.MirInstr, str](rnew)) {
         ret err[bool, str](unwrap_err[*mir.MirInstr, str](rnew));
     }


### PR DESCRIPTION
## Root cause
`regalloc.flatten` reads `MirInstr.asm_block != nil` as the inline-asm clobber-barrier discriminant. Several MIR construction paths build `MirInstr` field-by-field without setting `asm_block`, and neither stack `var x: MirInstr;` locals nor `allocate[]` buffers are zero-initialized — so the field reads back **bump-arena / stack residue**. When non-nil it spuriously fences a plain ALU/terminator op, changing register/spill decisions and the frame layout for high-pressure functions.

Because the **heap** residue depends on the whole allocation history of the compiler binary, two builds of the same source by different bootstrap generations (`smach` vs `mach`) can diverge — breaking the byte-identical self-host fixpoint. Root-caused via the #1082 audit and objdump-proven in `constfold.o` `try_fold` (clean `sub $0x2c0,%rsp` vs poisoned `sub $0x2d0,%rsp`, same IR).

## Fix — cover every construction path so the field is a pure function of the IR
`push_instr` already nils `asm_block` at the append chokepoint. This closes the paths that bypass it:
- **isel `select_block`** — `zallocate` the rebuilt instruction buffer (`emit` writes fields directly into `dst[w]`, so the zeroed `asm_block` stays nil). *(fixpoint-breaker: feeds `flatten`)*
- **regalloc `rewrite_block`** — `zallocate` the spliced buffer (reload/store MOVs omit `asm_block`; real instructions still copy theirs explicitly).
- **`split_critical_edge` + the phi-predecessor move splice** — nil `asm_block` on the stack-built `MIR_BR` / `MIR_MOV` they insert positionally (latent: stack residue read nil by luck across the compiler's own generations, but still UB).

The first two are the workflow's fix; the latter two were found by auditing **all** `MirInstr` construction sites (not just the generation-dependent one) to close the whole class rather than the single triggering instance.

A future cleanup could route all `MirInstr` construction through one zeroing constructor (tracked under diagnostics/quality #1046-style polish); this PR enforces the invariant at every current site.

## Verification
- `make clean && make` → 0
- fixpoint: `mach build . -o mach2` + `cmp` → byte-identical
- `tools/test/differential.sh` → pass

Closes #1082