### PR TITLE
ci: run the test corpus (mach test) as a correctness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,10 @@ jobs:
 
       - name: Differential test (-O0 vs -O2, smach vs mach)
         run: bash tools/test/differential.sh
+
+      - name: Test corpus
+        run: |
+          set -euo pipefail
+          # run the project's test corpus (the compiler's own `test` blocks plus
+          # the std tests reachable through its build graph). 0 = pass.
+          out/bin/mach test --cwd .


### PR DESCRIPTION
Adds a `mach test --cwd .` step to CI. Unblocked by #1106/#1108 (the `File{fd}` aggregate-global fix that resolved the #1109 runner halt) — the corpus now completes cleanly (PASS=194, FAIL=0, exit 0) on merged dev.

Closes #1043