### PR TITLE
fix(codegen): flip the IEEE-754 sign bit for a runtime float negate

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -314,6 +314,12 @@ pub val MIR_FCMP:      MirOpcode = 0x1118;
 # memory directly) and the encoder materializes the SSE move. the width (4 for
 # f32, 8 for f64) selects MOVSS vs MOVSD.
 pub val MIR_FMOV:      MirOpcode = 0x1119;
+# MIR_FNEG: scalar float negation, operands [dst, src]. a float negate flips the
+# IEEE-754 sign bit, which an integer MIR_NEG (two's-complement of the whole bit
+# pattern) would not produce; this dedicated opcode survives selection and the
+# encoder materializes the sign-bit XOR on the XMM value (XORPS with a sign mask).
+# the width (4 for f32, 8 for f64) selects the f32 vs f64 sign-bit mask.
+pub val MIR_FNEG:      MirOpcode = 0x111B;
 # MIR_VA_FP_SAVE: the AL-guarded variadic FP-register spill pseudo. operand 0 is
 # the save-area MEM operand at `va_fp_save_offset` (a frame-slot key the encoder
 # resolves to `[rbp + off]`); operand 1 is an immediate count of FP argument
@@ -1683,6 +1689,13 @@ fun lower_instr(ctx: *LowerCtx, fn: *ir.Function, mb: *MirBlock, iid: id.Instruc
     if (is_float_op(ctx, inst)) {
         ret lower_float_op(ctx, mb, inst, iid);
     }
+    # a scalar float negate shares the IR integer OP_NEG opcode; routing it to the
+    # integer path would emit a GP MIR_NEG (two's-complement of the float bit
+    # pattern) instead of flipping the IEEE-754 sign bit. dispatch a float-typed
+    # negate to its dedicated SSE lowering before the generic path.
+    if (inst.kind == instr.OP_NEG && value_is_float(ctx, inst.ty)) {
+        ret lower_float_neg(ctx, mb, inst, iid);
+    }
     # integer division / remainder needs the dividend / remainder register wiring
     # the active ISA's division form mandates (x86-64 IDIV/DIV reads the dividend
     # in RAX and yields the quotient in RAX / remainder in RDX). the accumulator
@@ -2267,6 +2280,39 @@ fun lower_float_op(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid:
         mi.opcode = MIR_FDIV;
     }
 
+    ret push_instr(ctx, mb, mi);
+}
+
+# lower_float_neg: lower a scalar floating-point negation (a float-typed OP_NEG) to
+# the dedicated MIR_FNEG opcode. the opcode survives instruction selection and the
+# encoder flips the IEEE-754 sign bit on the XMM value (XORPS with a width-selected
+# sign mask) rather than the integer MIR_NEG, which would two's-complement the whole
+# bit pattern and produce garbage. operand layout is `[dst, src]` like MIR_FMOV; the
+# operation width (4 for f32, 8 for f64) rides on `mi.width` so the encoder selects
+# the f32 vs f64 sign-bit mask.
+fun lower_float_neg(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.InstructionId) Result[bool, str] {
+    if (inst.operand_count < 1) {
+        ret err[bool, str]("mir.lower_ir: float negate missing operand");
+    }
+    val dst: u32 = result_vreg(ctx, iid);
+    if (dst == MIR_VREG_NIL) {
+        ret err[bool, str]("mir.lower_ir: float negate defines no result vreg");
+    }
+
+    val rop: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
+    if (is_err[*MirOperand, str](rop)) { ret err[bool, str](unwrap_err[*MirOperand, str](rop)); }
+    val ops: *MirOperand = unwrap_ok[*MirOperand, str](rop);
+    ops[0] = op_vreg(dst);
+    ops[1] = lower_value(ctx, inst.operands[0]);
+
+    val w: u8 = op_width_of(ctx, inst.ty);
+
+    var mi: MirInstr;
+    mi.opcode        = MIR_FNEG;
+    mi.operands      = ops;
+    mi.operand_count = 2;
+    mi.width         = w;
+    mi.src_width     = w;
     ret push_instr(ctx, mb, mi);
 }
 

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1828,13 +1828,14 @@ fun is_spilled(ctx: *AllocCtx, v: u32) bool {
     ret ctx.f.vregs[v].spill_slot >= 0;
 }
 
-# is_float_op_mir: true for a surviving scalar float arithmetic / comparison op
-# (MIR_FADD / FSUB / FMUL / FDIV / FCMP). the encoder expands these through a fixed
-# XMM scratch pair, so a spilled float operand / result is left as a frame-slot MEM
-# operand for it rather than reloaded into a GP temp.
+# is_float_op_mir: true for a surviving scalar float arithmetic / comparison / move
+# / negate op (MIR_FADD / FSUB / FMUL / FDIV / FCMP / FMOV / FNEG). the encoder
+# expands these through a fixed XMM scratch pair, so a spilled float operand / result
+# is left as a frame-slot MEM operand for it rather than reloaded into a GP temp.
 fun is_float_op_mir(op: mir.MirOpcode) bool {
     ret op == mir.MIR_FADD || op == mir.MIR_FSUB || op == mir.MIR_FMUL ||
-        op == mir.MIR_FDIV || op == mir.MIR_FCMP || op == mir.MIR_FMOV;
+        op == mir.MIR_FDIV || op == mir.MIR_FCMP || op == mir.MIR_FMOV ||
+        op == mir.MIR_FNEG;
 }
 
 # is_fp_vreg: true when a vreg belongs to the float / vector register class, so a

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2472,6 +2472,13 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     if (mi.opcode == mir.MIR_FMOV) {
         ret encode_float_mov(f, mi, ?st.buf);
     }
+    # a float negate survives selection keeping its MIR_FNEG opcode; the encoder
+    # materializes the sign-bit XOR byte sequence here (the float value loaded into
+    # the XMM scratch, XORPS against a width-selected sign mask, the result stored
+    # back), flipping the IEEE-754 sign bit. it references no relocatable symbol.
+    if (mi.opcode == mir.MIR_FNEG) {
+        ret encode_float_neg(f, mi, ?st.buf);
+    }
 
     # a float conversion survives selection keeping its dedicated MIR_FP_* opcode;
     # the encoder materializes the SSE conversion byte sequence here, routing the
@@ -2885,6 +2892,74 @@ fun encode_float_mov(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Resu
 
     val ld: Result[bool, str] = emit_float_load(src, FLOAT_SCRATCH0, w, buf);
     if (is_err[bool, str](ld)) { ret ld; }
+    ret emit_float_store(dst, FLOAT_SCRATCH0, w, buf);
+}
+
+# float_sign_mask: the IEEE-754 sign-bit mask for a float of byte width `w` — the
+# single high bit (0x8000_0000 for an f32, 0x8000_0000_0000_0000 for an f64). XORing
+# the value against it flips the sign, which is exactly a float negation; a wider
+# f64 mask must NOT be applied to an f32 (it would touch bits outside the value).
+fun float_sign_mask(w: u8) i64 {
+    if (w == 4) { ret 0x80000000::i64; }
+    ret 0x8000000000000000::i64;
+}
+
+# encode_float_neg: materialize a fully-resolved float negation `MIR_FNEG [dst, src]`
+# into its SSE byte sequence, flipping the IEEE-754 sign bit rather than two's-
+# complementing the bit pattern (which the integer MIR_NEG would do). routes the
+# value through the fixed FLOAT_SCRATCH0 register exactly as `encode_float_mov` does,
+# loads the width-selected sign mask into FLOAT_SCRATCH1 (the mask bits go through the
+# R11 GP scratch then MOVQ, mirroring the immediate operand path of `emit_float_load`,
+# so no float value ever aliases a GP register in the emitted bytes), XORs the two,
+# and stores the result back. the width (`mi.width`: 4 for f32, 8 for f64) selects the
+# f32 vs f64 sign mask. XORPS (a 128-bit bitwise XOR) is correct for both widths: the
+# mask only sets the value's sign bit in the low lane and the XOR is purely bitwise.
+fun encode_float_neg(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Result[bool, str] {
+    if (mi.operand_count < 2) {
+        ret err[bool, str]("encode: float negate missing operands");
+    }
+    val w: u8 = mi.width;
+    if (w != 4 && w != 8) {
+        ret err[bool, str]("encode: float negate has a non-float operand width");
+    }
+
+    val rd: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], 16);
+    if (is_err[isa.Operand, str](rd)) { ret err[bool, str](unwrap_err[isa.Operand, str](rd)); }
+    val dst: isa.Operand = unwrap_ok[isa.Operand, str](rd);
+    val rs: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[1], w);
+    if (is_err[isa.Operand, str](rs)) { ret err[bool, str](unwrap_err[isa.Operand, str](rs)); }
+    val src: isa.Operand = unwrap_ok[isa.Operand, str](rs);
+
+    # load the value into FLOAT_SCRATCH0.
+    val ld: Result[bool, str] = emit_float_load(src, FLOAT_SCRATCH0, w, buf);
+    if (is_err[bool, str](ld)) { ret ld; }
+
+    # materialize the sign-bit mask into FLOAT_SCRATCH1 via the R11 GP scratch.
+    var mov_imm: isa.Inst;
+    zero_inst(?mov_imm);
+    mov_imm.opcode = x64.MOVABS;
+    mov_imm.dst    = isa.make_reg(x64.R11, 8);
+    mov_imm.src1   = isa.make_imm(float_sign_mask(w), 8);
+    mov_imm.size   = 8;
+    encode_inst(?mov_imm, buf);
+
+    var movq: isa.Inst;
+    zero_inst(?movq);
+    movq.opcode = x64.MOVQ;
+    movq.dst    = isa.make_reg(FLOAT_SCRATCH1, 16);
+    movq.src1   = isa.make_reg(x64.R11, 8);
+    movq.size   = 8;
+    encode_inst(?movq, buf);
+
+    # FLOAT_SCRATCH0 ^= FLOAT_SCRATCH1 (flip the sign bit), then store back.
+    var xorp: isa.Inst;
+    zero_inst(?xorp);
+    xorp.opcode = x64.XORPS;
+    xorp.dst    = isa.make_reg(FLOAT_SCRATCH0, 16);
+    xorp.src1   = isa.make_reg(FLOAT_SCRATCH1, 16);
+    xorp.size   = w;
+    encode_inst(?xorp, buf);
+
     ret emit_float_store(dst, FLOAT_SCRATCH0, w, buf);
 }
 

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -320,6 +320,9 @@ fun is_simple(o: mir.MirOpcode) bool {
     # its frame slot from the surviving opcode, and the encoder materializes the
     # MOVSS / MOVSD byte form.
     if (o == mir.MIR_FMOV) { ret true; }
+    # a float negate survives selection keeping its dedicated MIR_FNEG opcode (like
+    # the float arith ops): the encoder materializes the sign-bit XOR byte sequence.
+    if (o == mir.MIR_FNEG) { ret true; }
     if (o == mir.MIR_ALLOCA || o == mir.MIR_LOAD || o == mir.MIR_STORE ||
         o == mir.MIR_GEP) { ret true; }
     if (o == mir.MIR_EXTRACT || o == mir.MIR_INSERT) { ret true; }
@@ -482,6 +485,10 @@ fun rewrite_simple(mi: *mir.MirInstr) Result[bool, str] {
     # the encoder materializes its MOVSS / MOVSD byte form. `retag_float_moves` set
     # the opcode before this pass from the function's vreg classes.
     if (o == mir.MIR_FMOV) { ret ok[bool, str](true); }
+
+    # a float negate survives selection unchanged; the encoder materializes its
+    # sign-bit XOR byte sequence (XORPS with a width-selected sign mask).
+    if (o == mir.MIR_FNEG) { ret ok[bool, str](true); }
 
     # the AL-guarded variadic FP-register spill survives selection unchanged; the
     # encoder materializes its self-contained TEST ; JZ ; MOVSD sequence.

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -395,7 +395,8 @@ fun size_prefix(width: u8) str {
 # (`x64.is_fp_opcode`) and the surviving MIR scalar-float family.
 fun is_fp_instr(op: mir.MirOpcode) bool {
     if (op == mir.MIR_FADD || op == mir.MIR_FSUB ||
-        op == mir.MIR_FMUL || op == mir.MIR_FDIV || op == mir.MIR_FCMP) { ret true; }
+        op == mir.MIR_FMUL || op == mir.MIR_FDIV || op == mir.MIR_FCMP ||
+        op == mir.MIR_FNEG) { ret true; }
     if (op >= mir.MIR_SEL_ADD) { ret false; }
     ret x64.is_fp_opcode(op::u16);
 }
@@ -437,6 +438,7 @@ fun mnemonic(op: mir.MirOpcode) str {
     if (op == mir.MIR_FMUL) { ret "fmul"; }
     if (op == mir.MIR_FDIV) { ret "fdiv"; }
     if (op == mir.MIR_FCMP) { ret "fcmp"; }
+    if (op == mir.MIR_FNEG) { ret "fneg"; }
 
     if (op == mir.MIR_VA_FP_SAVE) { ret "va.fp_save"; }
 


### PR DESCRIPTION
## Problem

A runtime float negation `-x` (where `x` is an `f32`/`f64` value, not a constfolded literal) lowered the IR `OP_NEG` to the integer `MIR_NEG`, which negates the bit pattern as a two's-complement integer rather than flipping the IEEE-754 sign bit — producing garbage for both f32 and f64. The bug was masked for literals because a negative float literal is constfolded at compile time.

Root cause: `is_float_op` (which routes shared int/float IR opcodes to the SSE lowering) did not claim `OP_NEG`, so a float-typed negate fell through to `lower_generic`, which emitted `mi.opcode = OP_NEG` == `MIR_NEG` (the GP integer negate).

## Fix

- New `MIR_FNEG` opcode (`mir.mach`), lowered from a float-typed `OP_NEG` via `lower_float_neg` (layout `[dst, src]`, width 4/8 on `mi.width`).
- Survives instruction selection unchanged (`isel.mach`, both `is_simple` and `rewrite_simple`), like the float arith / move ops.
- `encode_float_neg` (`encode.mach`) materializes the sign-bit flip: load the value into `FLOAT_SCRATCH0`, materialize the width-selected sign mask (`0x8000_0000` for f32, `0x8000_0000_0000_0000` for f64) into `FLOAT_SCRATCH1` via the R11 GP scratch + MOVQ (the same path the float-constant immediate load uses), `XORPS SCRATCH0, SCRATCH1`, store back. No float value ever aliases a GP register in the emitted bytes, so determinism (#1053) is preserved.
- `is_float_op_mir` in `regalloc.mach` includes `MIR_FNEG` so a spilled float operand/result stays a frame-slot MEM (read/written directly by the encoder, not reloaded through a GP temp).
- Printer mnemonic `fneg` added for completeness.

Integer `MIR_NEG` is unchanged.

## Verification

- Runtime `-x` now correct for f64 and f32 across positive, negative, large, fractional, `0.0`/`-0.0` values; double-negate `-(-x) == x`; integer negate still correct. The `-0.0` case is verified by reciprocal sign (`1.0/-0.0 = -inf < 1.0/+0.0 = +inf`), proving the sign bit is genuinely flipped.
- `make clean && make` exits 0.
- Byte-identical fixpoint: `mach build . -o mach2` then `cmp -s mach mach2` — identical.
- `mach test --cwd .` passes (194 tests, 0 fail).
- `differential.sh`: the smach-vs-mach arm passes all 10 inputs. Its `-O2` arm is `BUILD-FAIL` due to the separate, unrelated `mir.lower_ir: gep base is neither a memory nor a symbol reference` `-O2` bug (#1125) — not touched by this change.

Closes #1127