### PR TITLE
fix(codegen): variadic codegen bugs (empty-aggregate overflow cursor, VA_FP_SAVE AL use)

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -323,15 +323,18 @@ pub val MIR_FNEG:      MirOpcode = 0x111B;
 # MIR_VA_FP_SAVE: the AL-guarded variadic FP-register spill pseudo. operand 0 is
 # the save-area MEM operand at `va_fp_save_offset` (a frame-slot key the encoder
 # resolves to `[rbp + off]`); operand 1 is an immediate count of FP argument
-# registers to dump (the convention's `FP_PARAM_COUNT`). it survives selection and
-# the encoder materializes a self-contained `test al,al ; jz over ; movsd
+# registers to dump (the convention's `FP_PARAM_COUNT`); operand 2 is a MIR_OP_PREG
+# use of the vector-count register (AL/RAX) the guard reads. it survives selection
+# and the encoder materializes a self-contained `test al,al ; jz over ; movsd
 # [save+i*16], xmm_i (i in 0..count)` sequence, AL-guarding the spill exactly as
 # the SysV variadic prologue requires (AL carries the caller's vector-register
 # count; zero means no FP varargs, so the dump is skipped). the low 8 bytes of each
 # XMM hold the passed f32/f64, so a MOVSD per register suffices and needs no 16-byte
-# alignment. it reads AL and XMM0..7 as fixed incoming argument registers — like the
-# GP spill's RDI..R9 reads, they are invisible to vreg liveness and the pseudo runs
-# in the prologue before any allocatable value is live, so no clobber conflict.
+# alignment. the XMM0..7 reads are invisible to vreg liveness and never allocated,
+# but AL IS allocatable, so operand 2 carries it as an explicit use: regalloc reads
+# that preg and holds the register off-limits to value coloring across the guard, or
+# a prologue param-capture vreg colored to RAX would clobber the count before the
+# read (the entry `mov %rdi,%rax` regression). the encoder ignores operand 2.
 pub val MIR_VA_FP_SAVE: MirOpcode = 0x111A;
 
 # float-comparison condition codes carried on a MIR_FCMP. a UCOMISD sets CF/ZF/PF
@@ -3987,17 +3990,21 @@ fun emit_va_save_prologue(ctx: *LowerCtx, mb: *MirBlock) Result[bool, str] {
 # emit_va_fp_save: append the AL-guarded FP-register spill pseudo to the prologue.
 # `save_vreg` is the register-save area's slot-key vreg; operand 0 addresses the FP
 # region at `va_fp_save_offset` within it, operand 1 carries the FP argument-register
-# count. the encoder expands it (see MIR_VA_FP_SAVE) into the conditional XMM dump.
+# count, operand 2 is a MIR_OP_PREG use of the vector-count register (AL/RAX) the
+# guard reads. the encoder expands operands 0-1 into the conditional XMM dump (see
+# MIR_VA_FP_SAVE); operand 2 is invisible to the encoder but makes the AL read
+# visible to regalloc so no value vreg is colored to that register before the guard.
 fun emit_va_fp_save(ctx: *LowerCtx, mb: *MirBlock, save_vreg: u32) Result[bool, str] {
-    val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
+    val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 3::usize);
     if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
     val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
     ops[0] = op_mem_slot(save_vreg, sysv.va_fp_save_offset()::i64);
     ops[1] = op_imm(sysv.FP_PARAM_COUNT::i64);
+    ops[2] = op_preg(sysv.VA_VECTOR_COUNT_REG::u32);
     var mi: MirInstr;
     mi.opcode        = MIR_VA_FP_SAVE;
     mi.operands      = ops;
-    mi.operand_count = 2;
+    mi.operand_count = 3;
     mi.width         = 8;
     mi.src_width     = 8;
     ret push_instr(ctx, mb, mi);

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -4305,7 +4305,7 @@ fun lower_va_arg_fp(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, dst
 #   ovf_al   = (overflow_arg_area + 7) & ~7      (overflow is eight-byte granular)
 #   src      = (reg_src & mask) | (ovf_al & ~mask)
 #   gp_offset         += (gp_bytes      & mask32)
-#   overflow_arg_area  = (overflow & mask) | ((ovf_al + roundup8(size)) & ~mask)
+#   overflow_arg_area  = (overflow & mask) | ((ovf_al + stack_slot_bytes(size)) & ~mask)
 #   copy size bytes from [src] into the result storage
 fun lower_va_arg_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, dst: u32) Result[bool, str] {
     val rok: Result[bool, str] = require_abi(ctx.tgt);
@@ -4407,9 +4407,11 @@ fun lower_va_arg_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instructi
     val wg: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, sysv.VA_GP_OFFSET), op_vreg(new_gp), 4);
     if (is_err[bool, str](wg)) { ret wg; }
 
-    # overflow_arg_area = (ovf & mask) | ((ovf_al + roundup8(size)) & ~mask): when the
-    # overflow area was used, advance past the aligned by-value bytes; else leave it.
-    val ovf_step: i64 = ((size + 7) & ~7::u64)::i64;
+    # overflow_arg_area = (ovf & mask) | ((ovf_al + stack_slot_bytes(size)) & ~mask):
+    # when the overflow area was used, advance past the aligned by-value bytes; else
+    # leave it. uses stack_slot_bytes (size==0 -> 8) to stay in lockstep with the
+    # caller's slot footprint, so an empty-struct vararg still consumes one eightbyte.
+    val ovf_step: i64 = stack_slot_bytes(size);
     var ovf_next: u32 = MIR_VREG_NIL;
     val on: Result[bool, str] = emit_alu3(ctx, mb, MIR_ADD, op_vreg(ovf_al), op_imm(ovf_step), 8, ?ovf_next);
     if (is_err[bool, str](on)) { ret on; }

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -284,13 +284,15 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
         reserve_reg(?ctx, tgt.arch.shift_count_reg);
     }
 
-    # a variadic function with an FP-register-save pseudo reads the caller's vector
-    # count in a fixed register (AL/RAX) at the AL-guarded prologue spill. that
-    # register is filled by the calling convention and read by the pseudo, never by
-    # allocation, so reserving it keeps a prologue param-capture vreg from being
-    # colored onto it and clobbering the count before the guard. the register is
-    # carried in the pseudo's preg-use operand (so the ISA register choice stays out
-    # of the generic allocator); it is caller-saved, so the reservation is free.
+    # a variadic function that takes FP args has an FP-register-save pseudo reading
+    # the caller's vector count in a fixed register (AL/RAX) at the AL-guarded
+    # prologue spill. that register is filled by the calling convention and read by
+    # the pseudo, never by allocation, so reserving it keeps a prologue param-capture
+    # vreg from being colored onto it and clobbering the count before the guard. the
+    # register is carried in the pseudo's preg-use operand (so the ISA register choice
+    # stays out of the generic allocator). only such functions pay the cost, and it is
+    # not free: the register stays caller-saved (no callee-save spill), but removing it
+    # from the allocatable pool adds register pressure for that function's body.
     val va_fp_reg: i32 = function_va_fp_save_reg(?ctx);
     if (va_fp_reg >= 0) {
         reserve_reg(?ctx, va_fp_reg);
@@ -616,9 +618,11 @@ fun function_has_reg_shift(ctx: *AllocCtx) bool {
 # vector-register count in this register; like the division accumulator it is filled
 # by the calling convention, not by allocation, so reserving it from the value pool
 # guarantees no prologue param-capture vreg is colored onto it and clobbers the count
-# before the guard reads it. it is caller-saved, so the reservation is free in the
-# prologue/epilogue. the register rides in the pseudo (a shared selection-output
-# opcode, never a concrete encoder opcode), keeping this detection target-agnostic.
+# before the guard reads it. the register stays caller-saved (no callee-save spill),
+# but reserving it does cost the function's body one fewer allocatable GP register —
+# only variadic functions taking FP args pay it. the register rides in the pseudo (a
+# shared selection-output opcode, never a concrete encoder opcode), keeping this
+# detection target-agnostic.
 fun function_va_fp_save_reg(ctx: *AllocCtx) i32 {
     val f: *mir.MirFunction = ctx.f;
     var bi: u32 = 0;

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -284,6 +284,18 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
         reserve_reg(?ctx, tgt.arch.shift_count_reg);
     }
 
+    # a variadic function with an FP-register-save pseudo reads the caller's vector
+    # count in a fixed register (AL/RAX) at the AL-guarded prologue spill. that
+    # register is filled by the calling convention and read by the pseudo, never by
+    # allocation, so reserving it keeps a prologue param-capture vreg from being
+    # colored onto it and clobbering the count before the guard. the register is
+    # carried in the pseudo's preg-use operand (so the ISA register choice stays out
+    # of the generic allocator); it is caller-saved, so the reservation is free.
+    val va_fp_reg: i32 = function_va_fp_save_reg(?ctx);
+    if (va_fp_reg >= 0) {
+        reserve_reg(?ctx, va_fp_reg);
+    }
+
     val bo: Result[bool, str] = build_order(?ctx);
     if (is_err[bool, str](bo)) { ctx_dnit(?ctx); ret bo; }
 
@@ -596,6 +608,34 @@ fun function_has_reg_shift(ctx: *AllocCtx) bool {
         bi = bi + 1;
     }
     ret false;
+}
+
+# function_va_fp_save_reg: the GP register a variadic FP-register-save pseudo reads
+# (its MIR_OP_PREG vector-count operand), or -1 when the function has no such pseudo.
+# the AL-guarded MIR_VA_FP_SAVE runs in the variadic prologue and reads the caller's
+# vector-register count in this register; like the division accumulator it is filled
+# by the calling convention, not by allocation, so reserving it from the value pool
+# guarantees no prologue param-capture vreg is colored onto it and clobbers the count
+# before the guard reads it. it is caller-saved, so the reservation is free in the
+# prologue/epilogue. the register rides in the pseudo (a shared selection-output
+# opcode, never a concrete encoder opcode), keeping this detection target-agnostic.
+fun function_va_fp_save_reg(ctx: *AllocCtx) i32 {
+    val f: *mir.MirFunction = ctx.f;
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            if (mi.opcode == mir.MIR_VA_FP_SAVE && mi.operand_count >= 3
+                && mi.operands[2].kind == mir.MIR_OP_PREG) {
+                ret mi.operands[2].preg::i32;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret -1;
 }
 
 # build_order: compute a reverse-postorder block visitation order into `ctx.order`

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -58,6 +58,11 @@ pub val GP_PARAM_COUNT: i32 = 6;
 # number of floating-point registers available for argument passing
 # (XMM0–XMM7).
 pub val FP_PARAM_COUNT: i32 = 8;
+# the register whose low byte (AL) a variadic caller sets to the number of vector
+# registers used, read by the AL-guarded FP-register spill in a variadic callee's
+# prologue. named here so the spill pseudo can carry it as a use the allocator
+# keeps off-limits to value coloring across the guard.
+pub val VA_VECTOR_COUNT_REG: i32 = REG_RAX;
 # number of callee-saved general-purpose registers (RBX, RBP, R12–R15).
 pub val CALLEE_SAVED_COUNT: i32 = 6;
 


### PR DESCRIPTION
Fixes two variadic-codegen bugs in `src/lang/be/codegen/mir.mach` surfaced by Copilot review, plus committed regression coverage.

## #1136 — empty-aggregate overflow cursor

`lower_va_arg_aggregate` advanced `overflow_arg_area` by `roundup8(size)` (0 for a size-0 aggregate), while the caller spills every stack-passed arg into an eight-byte-granular slot (`stack_slot_bytes` treats size==0 as 8). An empty-struct vararg in the overflow area therefore left the cursor unmoved and the next `va_arg` re-read the same slot. Now advances by `stack_slot_bytes(size)`, in lockstep with the caller.

## #1135 — MIR_VA_FP_SAVE AL/RAX use (verified reachable + fixed)

`MIR_VA_FP_SAVE` is AL-guarded (AL = the caller's vector-register count) but modeled no operand for that read. Confirmed reachable: a variadic `fun one(p0: i64, ...)` compiles its prologue param capture as `mov %rdi,%rax` BEFORE the `test al,al`, clobbering AL — and `one(256, 3.0)` (low byte of p0 == 0) miscompiles, skipping the FP spill so `va_arg[f64]` reads garbage. Fix: the pseudo now carries the vector-count register as a `MIR_OP_PREG` use operand (named via `sysv.VA_VECTOR_COUNT_REG`), and regalloc reserves it from value allocation for any function containing the pseudo — mirroring the division-accumulator reservation. After the fix the capture is `mov %rdi,%rbx` and AL is preserved.

## Regression coverage (review follow-up)

There was no committed variadic test coverage. Added in **octalide/mach-std#183** (collected by `mach test` through the compiler's build graph) and pulled in here via the `dep/mach-std` submodule bump:

- empty-aggregate overflow cursor (#1136) + a mixed empty/small/big-by-ref/scalar overflow case
- FP-save AL guard (#1135): `va_arg[f64]` after a named GP param with a zero low byte (`256`)
- baseline `va_arg` smoke cases for `i64`, `str`, `f64`

Also corrected the regalloc reservation-cost comment (it isn't literally "free" — it removes one GP register from the body's allocatable pool; only variadic functions taking FP args pay it).

> Merge order: the submodule currently points at the mach-std test branch tip; retarget it to the mach-std dev merge commit once #183 lands.

## Verification

- #1136 / #1135 repros: FAIL on baseline -> OK fixed; #1135 prologue no longer writes RAX before the guard
- `make clean && make`: exit 0
- FIXPOINT byte-identical (smach == mach, same sha256)
- `mach test --cwd .`: **194 -> 200**, 0 fail (six new variadic tests)
- `tools/test/differential.sh`: both arms consistent

Closes #1135
Closes #1136
