### PR TITLE
fix(cse): compare float-constant operands by raw bits, not numeric ==

### DIFF
--- a/src/lang/me/pass/cse.mach
+++ b/src/lang/me/pass/cse.mach
@@ -49,6 +49,7 @@ use ir:    mach.lang.me.ir;
 use instr: mach.lang.me.ir.instruction;
 use value: mach.lang.me.ir.value;
 use id:    mach.lang.me.ir.id;
+use float: mach.lang.float;
 
 # Pass entry. Runs local CSE on every non-extern function in the module.
 # ---
@@ -193,7 +194,11 @@ fun instrs_equal(a: *instr.Instruction, b: *instr.Instruction,
 
 # true when two operand values are the exact same SSA value or the same constant
 # literal. Instruction results match by id; parameters by index; integer / null
-# / float constants by payload; globals / functions by index. Byte-blob
+# constants by payload; globals / functions by index. Float constants match by
+# their raw 64-bit IEEE-754 pattern, NOT numeric `==`: `+0.0` and `-0.0` are
+# numerically equal but bit-distinct, so `x + 0.0` and `x + (-0.0)` (which differ
+# in the sign of zero they produce for `x = -0.0`) must not be value-numbered
+# alike; comparing bits also keeps distinct NaN payloads distinct. Byte-blob
 # constants are conservatively treated as unequal (a pointer-identity match on a
 # borrowed blob is not worth the risk). The carried IR type need not match — two
 # operands naming the same value through differently-typed slots still denote it.
@@ -203,7 +208,9 @@ fun values_equal(a: value.Value, b: value.Value) bool {
     if (a.kind == value.VAL_PARAM)       { ret a.data.param_ix == b.data.param_ix; }
     if (a.kind == value.VAL_CONST_INT)   { ret a.data.int_lit == b.data.int_lit; }
     if (a.kind == value.VAL_CONST_NULL)  { ret true; }
-    if (a.kind == value.VAL_CONST_FLOAT) { ret a.data.float_lit == b.data.float_lit; }
+    if (a.kind == value.VAL_CONST_FLOAT) {
+        ret float.f64_bits(a.data.float_lit) == float.f64_bits(b.data.float_lit);
+    }
     if (a.kind == value.VAL_GLOBAL)      { ret a.data.global_ix == b.data.global_ix; }
     if (a.kind == value.VAL_FN)          { ret a.data.fn_ix == b.data.fn_ix; }
     ret false;


### PR DESCRIPTION
## Summary

CSE established value-numbering identity for a float-constant operand with numeric `==` (`src/lang/me/pass/cse.mach`, `values_equal`), which treats `+0.0 == -0.0`. Because CSE merges all pure ops including float `OP_ADD` / `OP_MUL`, `x + 0.0` and `x + (-0.0)` were value-numbered alike and merged, corrupting the IEEE-754 sign of zero — for `x = -0.0`, `-0.0 + 0.0 = +0.0` but `-0.0 + -0.0 = -0.0`. Numeric `==` also conflates distinct NaN payloads.

## Root cause

`values_equal` compared `VAL_CONST_FLOAT` operands with `a.data.float_lit == b.data.float_lit`. `+0.0` and `-0.0` are numerically equal but bit-distinct, so two adds differing only in the sign of their zero constant got merged. This pass uses a linear scan (no separate hash/key), so this single comparison site is the entire identity test.

## Fix

Compare float constants by their raw 64-bit IEEE-754 pattern via `float.f64_bits`, so `+0.0` and `-0.0` are distinct and distinct NaN payloads are not conflated. Integer / null / other constants are unchanged; genuinely bit-identical float ops still merge.

## Verification

- Signed-zero repro (`x = -0.0`, encode `signbit(x+0.0)*2 + signbit(x+(-0.0))` in exit code): unfixed `-O2` exits `0` (wrongly merged); fixed `-O2` exits `1`, matching `-O0`. The `-O0` vs `-O2` divergence is exactly what `differential.sh` guards.
- Positive CSE preserved: two identical `a*b` collapse to one `fmul` at `-O2` (vs two at `-O0`) — not over-disabled.
- `make clean && make` exits 0; byte-identical fixpoint; `mach test --cwd .` (194); `differential.sh` both arms clean.

Closes #1134