### PR TITLE
fix(sema): emit one diagnostic for an invalid :~ cast (completes #1146)

### DIFF
--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -826,8 +826,12 @@ fun infer_cast(sc: *sema.SemaContext, c: *expr.ExprCast, span: token.Span) type.
     val tt: type.TypeId = sema.resolved_type_of(sc, c.ty);
     if (ft == type.TYPE_ERROR || tt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
-    var r: Option[type.TypeId] = check.check_cast(sc, ft, tt, span);
-    if (c.reinterpret) { r = check.check_reinterpret(sc, ft, tt, span); }
+    var r: Option[type.TypeId] = none[type.TypeId]();
+    if (c.reinterpret) {
+        r = check.check_reinterpret(sc, ft, tt, span);
+    } or {
+        r = check.check_cast(sc, ft, tt, span);
+    }
     if (is_none[type.TypeId](r)) { ret type.TYPE_ERROR; }
     ret unwrap[type.TypeId](r);
 }


### PR DESCRIPTION
Completes item 1 of #1146 — the infer.mach duplicate-diagnostic fix that didn't make it into #1147 (it was left uncommitted in the worker's worktree; items 2/3, the doc comment + typo, did land in #1147).

`infer_cast` now selects exactly one check by the `reinterpret` flag (`:~` -> check_reinterpret only; `::` -> check_cast only), so an invalid `:~` that check_cast also rejects no longer emits both `cast: conversion is invalid` and `bit reinterpret requires equal-size types`.

Verified: an invalid `*i32 :~ u32` now emits only the bit-reinterpret diagnostic; fixpoint byte-identical (diagnostic-only change, no codegen impact); corpus 200, differential both arms.

Closes #1146