### PR TITLE
docs: accuracy pass — skills cast operator + aarch64 backend status (#1152)

### DIFF
--- a/.github/skills/mach-comptime/SKILL.md
+++ b/.github/skills/mach-comptime/SKILL.md
@@ -55,7 +55,10 @@ $mach.arch.x86_64 $mach.arch.aarch64
 > `$mach.target.{os,arch,pointer_width}`, `$mach.os.*`, `$mach.arch.*`, and
 > `$mach.compiler.{name,version}`. The `$mach.target.abi`, `$mach.build.*`,
 > `$mach.project.*`, and `$mach.source.*` paths are reserved stubs — reading one
-> is a compile error. Prefer the live reads in real code.
+> is a compile error. Prefer the live reads in real code. Note `$mach.arch.aarch64`
+> resolves as a value, but only `$mach.arch.x86_64` is a working backend target
+> today ([#1045](https://github.com/octalide/mach/issues/1045)) — aarch64 dispatch
+> branches below illustrate the pattern but are comptime-discarded on an x86_64 build.
 
 Tag comparison is path-value — no `.id` suffix, no unwrapping:
 

--- a/.github/skills/mach-lowlevel/SKILL.md
+++ b/.github/skills/mach-lowlevel/SKILL.md
@@ -23,7 +23,7 @@ asm <isa> {
 Locked rules:
 
 - The ISA tag is **mandatory**. Bare `asm { ... }` does not exist.
-- ISA tags are a closed set tracking backend support: `x86_64`, `aarch64`, … A tag exists because the compiler can target it.
+- ISA tags are a closed set: `x86_64`, `aarch64`. **Only `x86_64` has a working backend today**; `aarch64` is a recognized tag for portable target-conditional source but has no code generator yet ([#1045](https://github.com/octalide/mach/issues/1045)). An `asm aarch64` block is therefore valid only inside a branch that gets comptime-discarded on an `x86_64` build.
 - Body is **unquoted raw lines**, one instruction per line, in the ISA's native syntax. No surrounding quotes, no string concatenation. (Mach has no multi-line string; the `asm` body is not a string.)
 - `#` introduces a line comment.
 

--- a/.github/skills/writing-mach/SKILL.md
+++ b/.github/skills/writing-mach/SKILL.md
@@ -279,7 +279,7 @@ newline inside the quotes is part of the literal.
   true) → `u8`.
 - Unary: `-` negate, `~` bitwise NOT, `!` logical NOT.
 - Pointer: `?expr` address-of, `@ptr` dereference (also `@p = x;` to write).
-- Cast: `expr::Type` — explicit width/sign/pointer conversion.
+- Cast: `expr::Type` value conversion (width/sign/pointer, int↔float by value) and `expr:~Type` bit reinterpret (read the exact bits as an equal-size type).
 
 Precedence follows C-family conventions. There is no compound assignment
 (`+=`, `-=`, … do not exist).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,8 @@ All work happens on feature branches off `dev`. When `dev` reaches a stable mile
 - Target `dev` branch (not `main`)
 - Provide clear description of changes
 - Link related issues
-- Ensure code builds with `make`
+- Ensure code builds with `make` and reaches the byte-identical fixpoint
+- Run the tests: `mach test --cwd .` (unit corpus), and for codegen changes `tools/test/differential.sh` (optimization-level / cross-compiler agreement)
 - Follow coding standards
 
 ## Versioning

--- a/doc/language/asm.md
+++ b/doc/language/asm.md
@@ -16,7 +16,7 @@ asm <isa> {
 ```
 
 - The ISA tag is mandatory. Bare `asm { ... }` does not exist.
-- Supported tags come from a closed set: `x86_64`, `aarch64`, …
+- The tag comes from a closed set: `x86_64`, `aarch64`. Only `x86_64` has a working code generator today; `aarch64` is recognized for portable target-conditional source but is not yet a buildable target (see issue #1045).
 - Each line is an instruction in the ISA's native syntax.
 - `#` introduces a line comment.
 


### PR DESCRIPTION
Fixes the inaccuracies a full doc-accuracy audit surfaced (README and core language docs came back clean):

- **writing-mach skill**: cast section documented only `::`; now also documents `:~` (bit reinterpret, #1142).
- **mach-lowlevel skill**: corrected the false claim that every ISA tag is targetable — only x86_64 has a working backend; aarch64 is a recognized tag with no code generator yet (#1045).
- **mach-comptime skill**: noted `$mach.arch.aarch64` resolves as a value but isn't a working target; the multi-arch dispatch examples are kept (they teach the pattern and compile on x64 — the aarch64 branch is comptime-discarded).
- **asm.md**: x86_64-only backend caveat on the closed ISA-tag set.
- **CONTRIBUTING**: added test-running guidance (`mach test`, `differential.sh`) to the PR checklist.

Closes #1152