### PR TITLE
docs(build): mach.toml manifest + CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ mach <command> [options]
 | `run`   | build and execute the current project (`-- args...` forward to the program) |
 | `test`  | build and run the project's tests |
 | `dep`   | manage vendored dependencies (`list`, `add`, `remove`, `sync`, `vendor`) |
-| `init`  | scaffold a new project (`--bin`, `--lib`, `--name`) |
+| `init`  | scaffold a new project (`--lib`, `--name`, `--force`) |
+| `doc`   | generate Markdown reference docs from source doc-comments |
 | `help`  | show usage; `mach help <command>` for detail |
 
-Run `mach help <command>` for more information about a specific subcommand.
+Run `mach help <command>` for more information about a specific subcommand, or
+see the full [CLI reference](doc/cli.md).
 
 
 # Examples
@@ -135,7 +137,11 @@ fun main(argc: i64, argv: **u8) i64 {
 
 # Documentation
 
-The full language reference is in [`doc/language/`](doc/language/README.md).
+The full language reference is in [`doc/language/`](doc/language/README.md). The
+build system is documented in:
+
+- [`doc/manifest.md`](doc/manifest.md) — the `mach.toml` manifest reference
+- [`doc/cli.md`](doc/cli.md) — the `mach` command-line reference
 
 
 # Credit

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -66,14 +66,40 @@ objects are the deliverable and nothing is linked.
 | `-O1`          | —              | select the release pipeline |
 | `-O2`          | —              | select the release pipeline |
 | `--emit <kind>`| `obj`\|`exe`   | `obj` stops at the relocatable objects; `exe` (default) links a binary |
+| `-L <dir>`     | dir            | add a search directory for `-l`-resolved objects; repeatable |
+| `-l <name>`    | name           | link a named loose object, resolved through the `-L` dirs (see below); repeatable |
+| *(positional)* | object path    | a bare argument that contains `/` or ends in `.o` is linked verbatim |
 
 Plus the global flags above. The `-O<n>` flags override `--release` when both
 are present; absent any optimisation flag the build uses the debug pipeline
 (the bootstrap-stable default). `-O1` and `-O2` currently select the same
 release pipeline.
 
+### External link inputs
+
+`ext fun` declarations are forward references whose definitions are supplied at
+link time by external precompiled objects. Those objects come from the
+command line and from the target's `[targets.*].libs` manifest field (see
+[manifest.md](manifest.md)); both sets are linked. An input that resolves to no
+existing file is a hard error, so a typo never silently drops a dependency.
+
+- **Explicit object path** — a bare (non-flag) argument that contains a `/` or
+  ends in `.o` is treated as an object path. The first non-flag positional after
+  `build` is the project root and is skipped; remaining object-path positionals
+  are link inputs. A relative path is tried verbatim against the working
+  directory first, then rooted at the project root.
+- **`-l <name>`** — resolves to a loose object. Each `-L <dir>` is searched for
+  `<dir>/lib<name>.o`, then `<dir>/<name>.o`; if none hit, `lib<name>.o` then
+  `<name>.o` relative to the working directory are tried.
+- **`-L <dir>`** — adds a search directory for the `-l` resolution above. Both
+  `-L` and `-l` may be repeated.
+
+Only loose `.o` relocatable objects are supported — static archives (`.a`) and
+shared libraries (`.so`) are not. Manifest `libs` are resolved before the CLI
+inputs, giving a stable, deterministic link order.
+
 Exit codes: `0` ok, `1` user error (no `mach.toml`, unknown target, compile
-errors), `2` internal error.
+errors, an unresolvable link input), `2` internal error.
 
 ## `mach run`
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1,0 +1,201 @@
+# `mach` — the command-line interface
+
+```
+mach <command> [options]
+```
+
+The compiler dispatches on `argv[1]`. With no command, or an unknown one, it
+prints usage and exits non-zero. Every command except `init` runs from inside a
+project tree: it walks up from the working directory until a `mach.toml` is
+found.
+
+This page documents the flags the current binary actually parses. Flags are
+matched exactly: `--flag value` (a value follows in the next argument) or a bare
+`--flag` toggle. The combined `--flag=value` form and bundled short flags are
+**not** recognized.
+
+## Commands
+
+| Command | Summary |
+|---------|---------|
+| `build` | compile the project to objects and (in executable mode) a linked binary |
+| `run`   | build, then execute the produced binary |
+| `test`  | build the test binary and run the collected tests |
+| `dep`   | inspect and (when supported) manage vendored dependencies |
+| `init`  | scaffold a new project |
+| `doc`   | generate Markdown reference docs from source doc-comments |
+| `help`  | print usage; `mach help <command>` for detail |
+
+## Global flags
+
+Read by `build`, `run`, `test`, and `doc` (they share one config parser).
+`--verbose` and `--quiet` together is a parse error.
+
+| Flag             | Value            | Effect |
+|------------------|------------------|--------|
+| `--verbose`, `-v`| —                | write extra detail (per-stage compile progress) to stderr |
+| `--quiet`, `-q`  | —                | suppress non-error output |
+| `--color <mode>` | `auto`\|`always`\|`never` | color preference for terminal output (default `auto`); an unknown mode is a parse error |
+| `--cwd <path>`   | path             | run as if started in `<path>` (project-root search begins there) |
+| `--target <name>`| target name      | select a `[targets.<name>]` entry; absent, defers to `[project].target` |
+| `-o <path>`      | path             | override the linked-binary path, rooted at the project root (build/run/test) |
+| `--artifacts <dir>` | dir           | override the per-target object directory, rooted at `<dir_out>` (build/run/test) |
+| `--emit-asm`     | —                | emit per-module assembly text (`.s`) beside each object |
+| `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`) beside each object |
+| `--verify-ir`    | —                | run the IR verifier after each optimisation pass |
+
+> `mach dep` and `mach init` do not use the shared config parser; they read only
+> their own flags listed below.
+
+## `mach build`
+
+```
+mach build [options]
+```
+
+Compiles the current project. Every reachable module is driven through
+sema → lower → optimise → codegen to one relocatable object, written to
+`<dir_out>/<artifacts>/obj/<fqn-as-path>.o`. In executable mode the objects are
+linked into `<dir_out>/<binary>`; in library mode (or with `--emit obj`) the
+objects are the deliverable and nothing is linked.
+
+| Flag           | Value          | Effect |
+|----------------|----------------|--------|
+| `--release`    | —              | select the release optimisation pipeline |
+| `-O0`          | —              | force the debug pipeline (overrides `--release`) |
+| `-O1`          | —              | select the release pipeline |
+| `-O2`          | —              | select the release pipeline |
+| `--emit <kind>`| `obj`\|`exe`   | `obj` stops at the relocatable objects; `exe` (default) links a binary |
+
+Plus the global flags above. The `-O<n>` flags override `--release` when both
+are present; absent any optimisation flag the build uses the debug pipeline
+(the bootstrap-stable default). `-O1` and `-O2` currently select the same
+release pipeline.
+
+Exit codes: `0` ok, `1` user error (no `mach.toml`, unknown target, compile
+errors), `2` internal error.
+
+## `mach run`
+
+```
+mach run [options] [-- args...]
+```
+
+Builds the project exactly like `mach build`, then executes the produced binary.
+Arguments after a `--` separator are forwarded to the child as its `argv`. The
+child's exit code becomes this command's exit code.
+
+`--emit` is rejected — running a relocatable object is not meaningful. All other
+`build` and global flags apply.
+
+Exit codes: the child's exit code, `1` on a build/user error, `2` on internal
+error.
+
+## `mach test`
+
+```
+mach test [options]
+```
+
+Builds a test binary — a synthesized runner over every `test` declaration the
+resolver collected, replacing the project's own entry point — then runs it.
+A test build always links an executable, even for a library target.
+
+| Flag                | Value   | Effect |
+|---------------------|---------|--------|
+| `--filter <pattern>`| pattern | forwarded to the runner: run only tests whose name matches `<pattern>` |
+| `--list`            | —       | forwarded to the runner: list the collected tests and exit |
+
+Plus the `build` and global flags. `--filter`/`--list` are passed through to the
+test runner as its argv; the runner itself selects or enumerates the tests.
+
+Exit codes: `0` all passed, `1` any failed, `2` build/internal error.
+
+## `mach dep`
+
+```
+mach dep <action> [args]
+```
+
+Manages vendored dependencies under `<dir_dep>`. Dispatches on `argv[2]`.
+
+| Action   | Status | Effect |
+|----------|--------|--------|
+| `list`   | implemented | print each `[deps.<alias>]` entry from `mach.toml`, with its `path=` (or `source=`) field |
+| `add`    | stub        | not supported in this build |
+| `remove` | stub        | not supported in this build |
+| `sync`   | stub        | not supported in this build |
+| `vendor` | stub        | not supported in this build |
+
+The mutating actions (`add`, `remove`, `sync`, `vendor`) require on-disk
+fetch/copy and in-place manifest editing that the current runtime does not
+expose. Each fails loudly with `'mach dep <action>' is not supported in this
+build` rather than pretending to succeed.
+
+| Flag        | Effect |
+|-------------|--------|
+| `--dry-run` | for a mutating action, describe the intended action and exit `0` instead of failing |
+
+`mach dep list` reads `mach.toml` from the current directory directly (it does
+not walk up to find a project root). Exit codes: `0` ok, `1` user error, `2`
+internal error.
+
+## `mach init`
+
+```
+mach init [dir] [options]
+```
+
+Scaffolds a new project in `[dir]` (default: the current directory). Writes a
+minimal `mach.toml` with a `[project]` block and a `[targets.host]` entry
+matching the running compiler, a starter source file, and an empty `dep/`
+directory. Refuses to overwrite an existing `mach.toml` unless `--force`.
+
+| Flag           | Value | Effect |
+|----------------|-------|--------|
+| `--name <name>`| name  | project id (default: the directory base name) |
+| `--force`      | —     | scaffold even when a `mach.toml` already exists |
+| `--lib`        | —     | library layout: write `src/lib.mach` instead of `src/main.mach`, and omit `entrypoint` from the manifest |
+
+The first non-flag argument after `init` is the target directory.
+
+> The scaffolded manifest omits the `binary` key (and, with `--lib`, the
+> `entrypoint` key too) — both of which a build requires. A scaffolded project
+> therefore needs its `[targets.host]` entry completed before `mach build`
+> succeeds. See [manifest.md](manifest.md) for the required keys.
+
+Exit codes: `0` ok, `1` user error, `2` internal error.
+
+## `mach doc`
+
+```
+mach doc [options]
+```
+
+Loads the project's module graph and generates Markdown reference docs from
+source doc-comments — one page per module plus an index. Each `pub` declaration
+is paired with the run of `#` comment lines immediately preceding it. The
+hand-written `doc/language/` material is never touched.
+
+| Flag             | Value | Effect |
+|------------------|-------|--------|
+| `--out <dir>`    | dir   | output directory, rooted at the project (default `doc/api`) |
+| `--target <name>`| name  | select a `[targets.<name>]` entry for module discovery |
+
+Plus the global flags. Exit codes: `0` ok, `1` user error, `2` internal error.
+
+## `mach help`
+
+```
+mach help [command]
+```
+
+Prints the top-level usage summary, or — with a known `[command]` — that
+command's detail page. An unknown command prints the top-level usage and exits
+non-zero.
+
+## See also
+
+- [manifest.md](manifest.md) — the `mach.toml` reference
+- [language/test.md](language/test.md) — the `test` declaration and `mach test`
+- [language/files.md](language/files.md) — project file layout

--- a/doc/language/README.md
+++ b/doc/language/README.md
@@ -58,3 +58,8 @@ neighboring links; start from the index below.
 
 - [documentation.md](documentation.md) — docstring style for functions,
   types, modules, and values
+
+## Build system
+
+- [../manifest.md](../manifest.md) — the `mach.toml` manifest reference
+- [../cli.md](../cli.md) — the `mach` command-line reference

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -1,0 +1,147 @@
+# `mach.toml` — the project manifest
+
+Every Mach project has a `mach.toml` at its root. It declares the project's
+identity, one or more build targets, and its dependencies. The compiler finds
+it by walking up from the working directory until a `mach.toml` is seen, so any
+subcommand run inside a project tree resolves the same manifest.
+
+This page is the authoritative reference for the manifest schema as the current
+compiler reads it. Keys the parser does not consume are noted as **informational**
+— they are accepted (TOML still parses) but have no effect on the build today.
+
+## Tables
+
+A manifest has three tables:
+
+- `[project]` — identity and directory layout (required).
+- `[targets.<name>]` — one entry per build target (at least one required).
+- `[deps.<alias>]` — one entry per dependency (optional).
+
+## `[project]`
+
+| Key       | Type   | Required | Default    | Meaning |
+|-----------|--------|----------|------------|---------|
+| `id`      | string | yes      | —          | Root segment of every module path the project exposes. A file at `<dir_src>/foo/bar.mach` is reachable as `<id>.foo.bar`. |
+| `dir_src` | string | no       | `"src"`    | Source root, relative to the project root. Module paths resolve under it. |
+| `dir_dep` | string | no       | `"dep"`    | Vendored-dependency root, relative to the project root. Each dep lives at `<dir_dep>/<alias>/`. |
+| `dir_out` | string | no       | `"out"`    | Build-output root, relative to the project root. Objects and binaries are written under it. The legacy key `out` is accepted as a fallback when `dir_out` is absent. |
+| `target`  | string | no       | `"native"` | Default target selector when `--target` is not passed. `"native"` / `"host"` resolve to the `[targets.<name>]` entry whose `os`/`isa` match the build host. |
+
+Informational (parsed by TOML, not read by the build): `name`, `version`. They
+document the project but do not affect compilation.
+
+## `[targets.<name>]`
+
+Each `<name>` is a selector you pass to `--target <name>` (or set as
+`[project].target`). At least one target must be present, or the build fails
+with `mach.toml has no [targets.<name>] entries`.
+
+| Key          | Type   | Required | Default  | Meaning |
+|--------------|--------|----------|----------|---------|
+| `os`         | string | yes      | —        | Target operating system. See the accepted set below. |
+| `isa`        | string | yes      | —        | Target instruction-set architecture. See the accepted set below. |
+| `entrypoint` | string | yes      | —        | Entry source file, relative to `<dir_src>` (e.g. `"main.mach"`). The entry module's FQN is `<id>.<entrypoint without .mach>`, with `/` turned into `.`. Required for **every** target, including library targets. |
+| `binary`     | string | yes      | —        | Output path of the linked binary, relative to `<dir_out>` (e.g. `"linux/bin/mach"`). Required for **every** target, even in library mode where no binary is linked. |
+| `artifacts`  | string | no       | `<name>` | Subdirectory under `<dir_out>` holding the per-module object tree (`obj/`) and any `--emit-asm` / `--emit-ir` output. Defaults to the target name; may be nested (e.g. `"smach/linux"`). |
+| `mode`       | string | no       | `"executable"` | `"executable"` links the per-module objects into a static binary; `"library"` stops at the objects (no link). Any value other than `"library"` is treated as `"executable"`. |
+
+Informational (parsed by TOML, not read by the build): `abi`. The ABI is derived
+from `os` (Linux/macOS → SysV, Windows → Win64), so the key documents intent but
+does not change the build. There is no `libs` or `link` key in the current
+compiler — declaring external libraries to link is not yet supported in the
+manifest.
+
+### Accepted `os` values
+
+| Value     | Status |
+|-----------|--------|
+| `linux`   | supported — the only fully working host/target today |
+| `darwin`  | recognized; ABI/object-format vtables exist, but the toolchain is not yet validated end-to-end |
+| `windows` | recognized; ABI/object-format vtables exist, but the toolchain is not yet validated end-to-end |
+
+Any other value resolves to "unknown" and fails the build with
+`unsupported operating system`.
+
+### Accepted `isa` values
+
+| Value     | Status |
+|-----------|--------|
+| `x86_64`  | supported — the only fully working ISA today |
+| `aarch64` | recognized; an ISA vtable exists, but codegen is not yet validated end-to-end |
+
+Any other value resolves to "unknown" and fails target selection.
+
+### Accepted `mode` values
+
+| Value        | Effect |
+|--------------|--------|
+| `executable` | default; link the objects into a static binary at `<dir_out>/<binary>` |
+| `library`    | leave the per-module objects as the deliverable; no binary is linked |
+
+The single fully-supported triple today is `os = "linux"`, `isa = "x86_64"`
+(SysV ABI, ELF objects). The other recognized values pass manifest parsing and
+target composition but are not exercised by the working bootstrap.
+
+## `[deps.<alias>]`
+
+Each `<alias>` names a vendored dependency under `<dir_dep>/<alias>/`. The
+compiler resolves a dependency by reading that directory's own `mach.toml`
+(its `[project].id` becomes the head segment of the dep's module paths, and its
+`[project].dir_src` locates the dep's sources). A module path whose head matches
+a dep's `id` resolves into that dep's tree.
+
+The keys written under `[deps.<alias>]` are **not** consumed by the build's
+dependency resolution — resolution is purely by vendor layout. They are read
+only by `mach dep list`, which prints `path=<…>` if present, else `source=<…>`:
+
+| Key      | Type   | Read by                 | Meaning |
+|----------|--------|-------------------------|---------|
+| `path`   | string | `mach dep list` display | Local or remote location of the dependency. Preferred over `source` when both are present. |
+| `source` | string | `mach dep list` display | Alternate location field, shown when `path` is absent. |
+
+Other keys seen in practice — `type`, `version` — are informational: parsed by
+TOML, displayed by nothing, and not read by the build. They record provenance
+for the (not-yet-implemented) `mach dep add`/`sync`/`vendor` actions.
+
+The dependency at `<dir_dep>/<alias>/` must itself be a valid project (have its
+own `mach.toml` with a `[project].id`), or the build fails resolving the dep.
+
+## Annotated example
+
+```toml
+[project]
+id      = "mach"          # module-path root: this project's code is `mach.*`
+name    = "Mach Compiler" # informational
+version = "1.0.0"         # informational
+dir_src = "src"           # sources under ./src
+dir_dep = "dep"           # vendored deps under ./dep
+dir_out = "out"           # build output under ./out
+target  = "native"        # default target: the host-matching entry below
+
+[targets.linux]
+os         = "linux"          # target OS (linux | darwin | windows)
+isa        = "x86_64"         # target ISA (x86_64 | aarch64)
+abi        = "sysv64"         # informational; derived from os
+mode       = "executable"     # executable (default) | library
+entrypoint = "main.mach"      # entry module: mach.main, under src/
+artifacts  = "linux"          # objects under out/linux/obj/...
+binary     = "linux/bin/mach" # linked binary at out/linux/bin/mach
+
+[deps.mach-std]
+type    = "remote"                                # informational
+path    = "https://github.com/octalide/mach-std"  # shown by `mach dep list`
+version = "branch/dev"                            # informational
+```
+
+With this manifest, `mach build` (no `--target`) selects `linux` because
+`[project].target = "native"` resolves to the host-matching entry, compiles
+`src/main.mach` and its transitive imports — including modules from `mach-std`
+vendored at `dep/mach-std/` — into objects under `out/linux/obj/`, and links
+`out/linux/bin/mach`.
+
+## See also
+
+- [cli.md](cli.md) — the `mach` command-line reference
+- [language/files.md](language/files.md) — file layout and `lib.mach` / `main.mach`
+- [language/modules.md](language/modules.md) — how files map to module paths
+- [language/ext-fun.md](language/ext-fun.md) — linking against external symbols

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -44,12 +44,17 @@ with `mach.toml has no [targets.<name>] entries`.
 | `binary`     | string | yes      | —        | Output path of the linked binary, relative to `<dir_out>` (e.g. `"linux/bin/mach"`). Required for **every** target, even in library mode where no binary is linked. |
 | `artifacts`  | string | no       | `<name>` | Subdirectory under `<dir_out>` holding the per-module object tree (`obj/`) and any `--emit-asm` / `--emit-ir` output. Defaults to the target name; may be nested (e.g. `"smach/linux"`). |
 | `mode`       | string | no       | `"executable"` | `"executable"` links the per-module objects into a static binary; `"library"` stops at the objects (no link). Any value other than `"library"` is treated as `"executable"`. |
+| `libs`       | array of strings | no | `[]` | Project-level external link inputs. Each entry is either an explicit object-file path (project-root-relative or absolute) or a bare `-l`-style name resolved to a loose `lib<name>.o` / `<name>.o` at link time. These join every `mach build`/`run`/`test` link in addition to any CLI `-L`/`-l`/object arguments. A non-array value, or a non-string element, is a manifest error. The alias `link` is accepted when `libs` is absent. |
 
 Informational (parsed by TOML, not read by the build): `abi`. The ABI is derived
 from `os` (Linux/macOS → SysV, Windows → Win64), so the key documents intent but
-does not change the build. There is no `libs` or `link` key in the current
-compiler — declaring external libraries to link is not yet supported in the
-manifest.
+does not change the build.
+
+Only loose `.o` relocatable objects are linked — static archives (`.a`) and
+shared libraries (`.so`) are not yet supported. See
+[language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
+`ext fun` workflow that consumes these inputs, and [cli.md](cli.md#external-link-inputs)
+for the equivalent command-line flags.
 
 ### Accepted `os` values
 
@@ -126,6 +131,7 @@ mode       = "executable"     # executable (default) | library
 entrypoint = "main.mach"      # entry module: mach.main, under src/
 artifacts  = "linux"          # objects under out/linux/obj/...
 binary     = "linux/bin/mach" # linked binary at out/linux/bin/mach
+# libs     = ["build/libfoo.o", "bar"]  # optional external link inputs
 
 [deps.mach-std]
 type    = "remote"                                # informational


### PR DESCRIPTION
Adds the build-system reference docs requested in #1170.

## What

- **`doc/manifest.md`** — the authoritative `mach.toml` reference. Every `[project]`, `[targets.<name>]`, and `[deps.<alias>]` key, with type, required/optional, default, and accepted values, enumerated straight from the driver parser (`src/lang/driver.mach`). Closed `os`/`isa`/`mode` sets documented, with the linux/x86_64/sysv64 triple flagged as the only fully working path. Includes a complete annotated example.
- **`doc/cli.md`** — the `mach` CLI reference. Every subcommand (`build`, `run`, `test`, `dep`, `init`, `doc`, `help`) and only the flags the binary actually parses (`src/cli/cmd.mach`, `src/cli/config.mach`, `src/cli/cmd/*`). `mach dep` mutating actions noted as stubbed.
- Cross-linked from `README.md` and `doc/language/README.md`.

## Grounded in code, with deliberate omissions

Every documented field/flag was verified against the parser/CLI source. Surface that does **not** exist in the current binary was left out and flagged in the docs as informational or unsupported:

- `-L` / `-l` / explicit-object link flags — **do not exist** in the CLI; not documented.
- `[targets.*].libs` / `link` manifest keys — **not read** by the parser; documented as absent.
- `[targets.*].abi` — informational only; the ABI is derived from `os` via `canonical_abi`.
- `[project].name` / `version` and `[deps.*].type` / `version` — informational; parsed by TOML but not read by the build.
- `[deps.*]` keys (`path`/`source`) are read only by `mach dep list`, not by dependency resolution (which is purely vendor-layout). Documented as such.
- `mach init` (and `--lib`) scaffold a manifest missing the build-required `binary` (and `entrypoint`) keys — flagged in `doc/cli.md`.

Closes #1170