### PR TITLE
fix(diagnostics): clarity pass — named identifiers/types/fields, counted arity, safe note attach

### DIFF
--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -33,6 +33,7 @@ use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_contains;
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
@@ -505,6 +506,78 @@ test "editor: update drops cached analysis and reparses against new text" {
     val p2: Result[*ast.Ast, str] = parse(?es, fid);
     if (is_err[*ast.Ast, str](p2)) { dnit(?es); sess.dnit(?s); ret 1; }
     if (unwrap_ok[*ast.Ast, str](p2).decl_len <= n1) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+# diag_has: true when any diagnostic on `list` has a message containing `sub`.
+fun diag_has(list: *diag.DiagList, sub: str) bool {
+    var i: usize = 0;
+    for (i < list.len) {
+        if (str_contains(list.items[i].message, sub)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# diag_note_has: true when any diagnostic on `list` carries a note containing `sub`.
+fun diag_note_has(list: *diag.DiagList, sub: str) bool {
+    var i: usize = 0;
+    for (i < list.len) {
+        if (list.items[i].note != nil && str_contains(list.items[i].note, sub)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+test "diagnostics: unresolved identifier names the symbol and suggests a near match" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `helpr` is one edit from the in-scope `helper`, so the message embeds the
+    # unresolved name and a `did you mean` note points at the near match.
+    val fr: Result[src.FileId, str] = open(?es, "ident.mach",
+        "fun helper() i64 { ret 0; }\nfun main() i64 { ret helpr(); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val rr: Result[*res.ResolveResult, str] = resolve(?es, fid);
+    if (is_err[*res.ResolveResult, str](rr)) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    val list: *diag.DiagList = ?es.s.diags;
+    if (!diag_has(list, "unresolved identifier `helpr`")) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_note_has(list, "did you mean `helper`?")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "diagnostics: unresolved type name names the type and suggests a near match" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `Widgt` is one edit from the in-scope record `Widget`, so the type-name
+    # error embeds the misspelling and suggests the near match.
+    val fr: Result[src.FileId, str] = open(?es, "type.mach",
+        "rec Widget { x: i64; }\nfun main(w: Widgt) i64 { ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val rr: Result[*res.ResolveResult, str] = resolve(?es, fid);
+    if (is_err[*res.ResolveResult, str](rr)) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    val list: *diag.DiagList = ?es.s.diags;
+    if (!diag_has(list, "unresolved type name `Widgt`")) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_note_has(list, "did you mean `Widget`?")) { dnit(?es); sess.dnit(?s); ret 1; }
 
     dnit(?es);
     sess.dnit(?s);

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -28,6 +28,7 @@ use std.types.option.is_none;
 use std.types.option.is_some;
 use std.types.option.unwrap;
 use std.types.size.usize;
+use std.types.char.char;
 use std.types.string.str;
 use std.types.string.str_len;
 use std.text.string.str_free;
@@ -545,8 +546,10 @@ fun declare(
 
     val existing: SymbolId = scope_lookup_local(rc, scope, name_id);
     if (existing != SYMBOL_NIL) {
-        diag.error(?rc.s.diags, rc.a.file_id, name, "duplicate definition in this scope");
-        diag.attach_note(?rc.s.diags, "a name with this spelling is already bound here");
+        val de: Result[bool, str] = report_named(rc, name, "duplicate definition: `", name_id, "` is already bound in this scope");
+        if (is_ok[bool, str](de)) {
+            diag.attach_note(?rc.s.diags, "a name with this spelling is already bound here");
+        }
         ret ok[SymbolId, str](SYMBOL_NIL);
     }
 
@@ -1590,8 +1593,8 @@ fun bind_ident(rc: *ResolveContext, eid: id.ExprId, span: token.Span) Result[boo
     val name: intern.StrId = unwrap_ok[intern.StrId, str](r);
     val sid: SymbolId = scope_lookup_chain(rc, rc.current_scope, name);
     if (sid == SYMBOL_NIL) {
-        diag.error(?rc.s.diags, rc.a.file_id, span, "unresolved identifier");
-        attach_suggestion(rc, name);
+        val re: Result[bool, str] = report_named(rc, span, "unresolved identifier `", name, "`");
+        if (is_ok[bool, str](re)) { attach_suggestion(rc, name); }
     }
     or {
         if (rc.expr_resolved != nil) { rc.expr_resolved[eid] = sid; }
@@ -1648,6 +1651,43 @@ fun attach_suggestion(rc: *ResolveContext, target: intern.StrId) {
     if (note == nil) { ret; }
     diag.attach_note(?rc.s.diags, note);
     str_free(rc.s.alloc, note);
+}
+
+# report_named: emit an error at `span` whose message embeds the interned name
+# `name_id` between `prefix` and `suffix`, e.g. `unresolved identifier `<name>``.
+# returns the sink's append result so a caller can gate an attached note on the
+# error actually landing. on any allocation failure the message degrades to the
+# static `prefix` text alone so the diagnostic is always reported.
+fun report_named(rc: *ResolveContext, span: token.Span, prefix: str, name_id: intern.StrId, suffix: str) Result[bool, str] {
+    val no: Option[str] = intern.lookup(?rc.s.interner, name_id);
+    if (is_none[str](no)) {
+        ret diag.error(?rc.s.diags, rc.a.file_id, span, prefix);
+    }
+    val name: str = unwrap[str](no);
+
+    val pn: usize = str_len(prefix);
+    val nn: usize = str_len(name);
+    val sn: usize = str_len(suffix);
+    val total: usize = pn + nn + sn;
+
+    val r: Result[*char, str] = allocate[char](rc.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        ret diag.error(?rc.s.diags, rc.a.file_id, span, prefix);
+    }
+    val buf: str = unwrap_ok[*char, str](r);
+
+    var w: usize = 0;
+    var i: usize = 0;
+    for (i < pn) { buf[w] = prefix[i]; w = w + 1; i = i + 1; }
+    i = 0;
+    for (i < nn) { buf[w] = name[i]; w = w + 1; i = i + 1; }
+    i = 0;
+    for (i < sn) { buf[w] = suffix[i]; w = w + 1; i = i + 1; }
+    buf[w] = 0;
+
+    val emit: Result[bool, str] = diag.error(?rc.s.diags, rc.a.file_id, span, buf);
+    deallocate[char](rc.s.alloc, buf, total + 1);
+    ret emit;
 }
 
 # MAX_SUGGEST_DISTANCE: largest edit distance a "did you mean" candidate may
@@ -1761,7 +1801,8 @@ fun bind_intrinsic_type_arg(rc: *ResolveContext, eid: id.ExprId) Result[bool, st
         var sid: SymbolId = prim_symbol_for(rc, name);
         if (sid == SYMBOL_NIL) { sid = scope_lookup_chain(rc, rc.current_scope, name); }
         if (sid == SYMBOL_NIL) {
-            diag.error(?rc.s.diags, rc.a.file_id, e.span, "unresolved type name");
+            val re: Result[bool, str] = report_named(rc, e.span, "unresolved type name `", name, "`");
+            if (is_ok[bool, str](re)) { attach_suggestion(rc, name); }
         }
         or {
             if (rc.expr_resolved != nil) { rc.expr_resolved[eid] = sid; }
@@ -1911,8 +1952,16 @@ fun resolve_type_path(rc: *ResolveContext, named: *atype.TypeNamed, full: token.
         }
 
         if (current_sym == SYMBOL_NIL) {
-            diag.error(?rc.s.diags, rc.a.file_id, full, "unresolved type name");
-            if (seg_start == path.offset && seg_end >= end) { attach_suggestion(rc, seg_name); }
+            # a single-segment path names the type directly, so embed the name and
+            # offer a suggestion; a qualified `mod.Type` miss reports on the whole
+            # path without a (cross-module) suggestion.
+            if (seg_start == path.offset && seg_end >= end) {
+                val re: Result[bool, str] = report_named(rc, full, "unresolved type name `", seg_name, "`");
+                if (is_ok[bool, str](re)) { attach_suggestion(rc, seg_name); }
+            }
+            or {
+                diag.error(?rc.s.diags, rc.a.file_id, full, "unresolved type name");
+            }
             ret SYMBOL_NIL;
         }
 

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -105,12 +105,12 @@ pub fun check_call(sc: *sema.SemaContext, callee_sig: ty.TypeId, args_start: u32
     val variadic:    bool = ft.data.fn.variadic;
     if (variadic) {
         if (args_len < param_count) {
-            report(sc, span, "arity mismatch: too few call arguments");
+            report_arity(sc, span, param_count, args_len, true);
             ret false;
         }
     }
     or (args_len != param_count) {
-        report(sc, span, "arity mismatch: wrong number of call arguments");
+        report_arity(sc, span, param_count, args_len, false);
         ret false;
     }
 
@@ -158,12 +158,12 @@ pub fun check_comptime_call(sc: *sema.SemaContext, callee_sig: ty.TypeId, callee
     val total: u32 = f.params_len;
     if (f.variadic) {
         if (args_len < total) {
-            report(sc, span, "arity mismatch: too few call arguments");
+            report_arity(sc, span, total, args_len, true);
             ret false;
         }
     }
     or (args_len != total) {
-        report(sc, span, "arity mismatch: wrong number of call arguments");
+        report_arity(sc, span, total, args_len, false);
         ret false;
     }
 
@@ -325,7 +325,7 @@ pub fun check_member(sc: *sema.SemaContext, object: ty.TypeId, name: intern.StrI
     val f: Option[ty.TypeId] = sema.field_lookup(sc, record, name);
     if (is_some[ty.TypeId](f)) { ret f; }
 
-    report(sc, span, "no such field: type has no field with that name");
+    report_no_field(sc, span, name, record);
     ret none[ty.TypeId]();
 }
 
@@ -890,9 +890,12 @@ fun report(sc: *sema.SemaContext, span: token.Span, message: str) {
     diag.error(?sc.s.diags, sc.a.file_id, span, message);
 }
 
-# report_note: report plus a static clarifying `note:` line on the same diagnostic.
+# report_note: report plus a static clarifying `note:` line on the same
+# diagnostic. the note attaches only when the error itself landed, so a failed
+# error emit never misattaches the note to the previous diagnostic.
 fun report_note(sc: *sema.SemaContext, span: token.Span, message: str, note: str) {
-    diag.error(?sc.s.diags, sc.a.file_id, span, message);
+    val r: Result[bool, str] = diag.error(?sc.s.diags, sc.a.file_id, span, message);
+    if (is_err[bool, str](r)) { ret; }
     diag.attach_note(?sc.s.diags, note);
 }
 
@@ -937,4 +940,73 @@ fun report_mismatch(sc: *sema.SemaContext, span: token.Span, expected: ty.TypeId
     deallocate[char](sc.s.alloc, msg, total + 1);
     type_str_free(sc, ex);
     type_str_free(sc, ac);
+}
+
+# report_arity: report an `arity mismatch: expected <E>, found <A>` diagnostic,
+# rendering both counts as decimals. `min` distinguishes a variadic callee
+# (`expected at least <E>`) from a fixed one (`expected <E>`). any allocation
+# failure degrades to a static, count-free message so the error is always
+# reported.
+fun report_arity(sc: *sema.SemaContext, span: token.Span, expected: u32, actual: u32, min: bool) {
+    val prefix: str = "arity mismatch: expected ";
+    val atleast: str = "at least ";
+    val mid:    str = ", found ";
+    var total:  usize = str_len(prefix) + decimal_len(expected::usize)
+        + str_len(mid) + decimal_len(actual::usize);
+    if (min) { total = total + str_len(atleast); }
+
+    val r: Result[*char, str] = allocate[char](sc.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        report(sc, span, "arity mismatch: wrong number of call arguments");
+        ret;
+    }
+    val msg: str = unwrap_ok[*char, str](r);
+    var w: usize = write_kw(msg, 0, prefix);
+    if (min) { w = write_kw(msg, w, atleast); }
+    w = write_decimal(msg, w, expected::usize);
+    w = write_kw(msg, w, mid);
+    w = write_decimal(msg, w, actual::usize);
+    msg[w] = 0;
+
+    report(sc, span, msg);
+    deallocate[char](sc.s.alloc, msg, total + 1);
+}
+
+# report_no_field: report a `no such field `<name>` on type <T>` diagnostic,
+# naming the missing field and the record type it was looked up on. any
+# allocation failure degrades to a static, name-free message so the error is
+# always reported.
+# ---
+# sc:     the active sema context
+# span:   source range to pin the diagnostic to
+# name:   interned identifier of the missing field
+# record: the record/union type the field was looked up on
+pub fun report_no_field(sc: *sema.SemaContext, span: token.Span, name: intern.StrId, record: ty.TypeId) {
+    val tr: Result[str, str] = type_to_str(sc, record);
+    if (is_err[str, str](tr)) {
+        report(sc, span, "no such field: type has no field with that name");
+        ret;
+    }
+    val ts: str = unwrap_ok[str, str](tr);
+
+    val prefix: str = "no such field `";
+    val mid:    str = "` on type ";
+    val total:  usize = str_len(prefix) + name_str_len(sc, name) + str_len(mid) + str_len(ts);
+
+    val r: Result[*char, str] = allocate[char](sc.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        report(sc, span, "no such field: type has no field with that name");
+        type_str_free(sc, ts);
+        ret;
+    }
+    val msg: str = unwrap_ok[*char, str](r);
+    var w: usize = write_kw(msg, 0, prefix);
+    w = write_name(sc, msg, w, name);
+    w = write_kw(msg, w, mid);
+    w = write_kw(msg, w, ts);
+    msg[w] = 0;
+
+    report(sc, span, msg);
+    deallocate[char](sc.s.alloc, msg, total + 1);
+    type_str_free(sc, ts);
 }

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -259,14 +259,17 @@ pub fun report(sc: *SemaContext, span: token.Span, message: str) {
 }
 
 # report_note: like report, but also attaches a static secondary `note:` line
-# clarifying the error; allocation failures in the sink are swallowed.
+# clarifying the error; allocation failures in the sink are swallowed. the note
+# is attached only when the error diagnostic itself landed, so a failed error
+# emit never misattaches the note to the previous diagnostic.
 # ---
 # sc:      sema context
 # span:    source span the diagnostic refers to
 # message: human-readable error text
 # note:    secondary clarifying message rendered on a `note:` line
 pub fun report_note(sc: *SemaContext, span: token.Span, message: str, note: str) {
-    diag.error(?sc.s.diags, sc.a.file_id, span, message);
+    val r: Result[bool, str] = diag.error(?sc.s.diags, sc.a.file_id, span, message);
+    if (is_err[bool, str](r)) { ret; }
     diag.attach_note(?sc.s.diags, note);
 }
 

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -23,6 +23,8 @@ use std.types.option.is_none;
 use std.types.option.is_some;
 use std.types.option.unwrap;
 use std.types.string.str;
+use std.types.string.str_len;
+use std.types.char.char;
 use std.types.size.usize;
 use std.types.result.Result;
 use std.types.result.ok;
@@ -80,7 +82,7 @@ pub fun instantiate(
     var i: u32 = 0;
     for (i < arg_count) {
         if (args[i] == ty.TYPE_NIL || args[i] == ty.TYPE_ERROR) {
-            report(sc, span, "generic arg N: invalid type");
+            report(sc, span, "generic argument is not a valid type");
             ret ok[ty.TypeId, str](ty.TYPE_ERROR);
         }
         i = i + 1;
@@ -289,7 +291,7 @@ pub fun check_arity(
     }
     val want: u32 = unwrap[u32](want_opt);
     if (arg_count != want) {
-        report(sc, span, "generic arg count: wrong number of type arguments");
+        report_type_arg_count(sc, span, "wrong number of type arguments", want, arg_count);
         ret false;
     }
     ret true;
@@ -533,4 +535,62 @@ fun unwrap_or_error(r: Result[ty.TypeId, str]) ty.TypeId {
 # append cannot itself be reported and sema never halts on it.
 fun report(sc: *sema.SemaContext, span: token.Span, message: str) {
     diag.error(?sc.s.diags, sc.a.file_id, span, message);
+}
+
+# report_type_arg_count: report a `<prefix>: expected <E>, found <A>` diagnostic
+# naming the declared and supplied type-argument counts. any allocation failure
+# degrades to the static `prefix` text so the error is always reported.
+fun report_type_arg_count(sc: *sema.SemaContext, span: token.Span, prefix: str, expected: u32, actual: u32) {
+    val mid:   str = ": expected ";
+    val found: str = ", found ";
+    val total: usize = str_len(prefix) + str_len(mid) + decimal_len(expected::usize)
+        + str_len(found) + decimal_len(actual::usize);
+
+    val r: Result[*char, str] = allocate[char](sc.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        report(sc, span, prefix);
+        ret;
+    }
+    val msg: str = unwrap_ok[*char, str](r);
+    var w: usize = write_kw(msg, 0, prefix);
+    w = write_kw(msg, w, mid);
+    w = write_decimal(msg, w, expected::usize);
+    w = write_kw(msg, w, found);
+    w = write_decimal(msg, w, actual::usize);
+    msg[w] = 0;
+
+    report(sc, span, msg);
+    deallocate[char](sc.s.alloc, msg, total + 1);
+}
+
+# write_kw: copy a string's bytes into `buf` at offset `k`, returning the new offset.
+fun write_kw(buf: str, k: usize, s: str) usize {
+    val n: usize = str_len(s);
+    var w: usize = k;
+    var i: usize = 0;
+    for (i < n) { buf[w] = s[i]; w = w + 1; i = i + 1; }
+    ret w;
+}
+
+# decimal_len: number of base-10 digits in `n` (1 for 0).
+fun decimal_len(n: usize) usize {
+    if (n == 0) { ret 1; }
+    var len: usize = 0;
+    var v: usize = n;
+    for (v > 0) { len = len + 1; v = v / 10; }
+    ret len;
+}
+
+# write_decimal: write the base-10 digits of `n` into `buf` at offset `k`,
+# returning the new offset.
+fun write_decimal(buf: str, k: usize, n: usize) usize {
+    if (n == 0) { buf[k] = '0'; ret k + 1; }
+    var tmp: [24]char;
+    var t: usize = 0;
+    var v: usize = n;
+    for (v > 0) { tmp[t] = (v % 10)::char + '0'; v = v / 10; t = t + 1; }
+    var w: usize = k;
+    var ri: usize = 0;
+    for (ri < t) { buf[w] = tmp[t - 1 - ri]; w = w + 1; ri = ri + 1; }
+    ret w;
 }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -893,7 +893,7 @@ fun infer_struct_lit(sc: *sema.SemaContext, sl: *expr.ExprStructLit, span: token
             val fname: intern.StrId = intern_span_or_nil(sc, fi.name);
             val ft_opt: Option[type.TypeId] = sema.field_lookup(sc, rec_ty, fname);
             if (is_none[type.TypeId](ft_opt)) {
-                sema.report(sc, fi.name, "no such field: in struct literal");
+                check.report_no_field(sc, fi.name, fname, rec_ty);
             }
             or {
                 val ft: type.TypeId = unwrap[type.TypeId](ft_opt);


### PR DESCRIPTION
First, bounded pass over the diagnostics quality work tracked in #1046. Builds on #1188 (which already landed the `DiagList` model, note/suggestion plumbing, and the `did you mean` edit-distance machinery for unresolved names). Wording changes only — no codegen impact.

## Audit findings + fixes (before → after)

Front-end `report()` / emission sites were audited across parser, resolve, and sema. The parser messages were already specific and consistent; the worst offenders were in resolve/sema where messages were vague or carried placeholders.

| site | before | after |
|---|---|---|
| resolve: unresolved ident | `unresolved identifier` | `unresolved identifier \`helpr\`` (+ `note: did you mean \`helper\`?`) |
| resolve: unresolved type | `unresolved type name` | `unresolved type name \`Widgt\`` (+ suggestion for an unqualified miss) |
| resolve: duplicate def | `duplicate definition in this scope` | `duplicate definition: \`x\` is already bound in this scope` |
| sema: call arity | `arity mismatch: wrong number of call arguments` | `arity mismatch: expected 2, found 1` (and `expected at least N` for a variadic callee) |
| sema: missing field | `no such field: type has no field with that name` | `no such field \`q\` on type Point` (member + struct-literal paths) |
| generics: arg count | `generic arg count: wrong number of type arguments` | `wrong number of type arguments: expected 1, found 2` |
| generics: bad arg | `generic arg N: invalid type` (literal `N`) | `generic argument is not a valid type` |

## note / help + suggestions

- `did you mean` already existed for unresolved identifiers; this pass extends the suggestion to the single-segment unresolved **type-name** path and makes both message families name the offending symbol so the message is self-contained.
- Fixed the note-attach OOM race flagged on the issue (folded in from #1138): `report_note` and the resolve suggestion/duplicate-def notes attached unconditionally after `diag.error`, so a failed (OOM) error emit would misattach the note to the *previous* diagnostic. Each attach is now gated on the error emit landing.

## Confirmed already-resolved on dev (no action needed)

- **Double-reporting** (#1146 comment): expression diagnostics no longer fire twice — the cast-pass duplication is gone on current `dev` (post-#1142/#1188). Verified with a cast-error repro: fires once.

## Deferred (to track under #1046 or a follow-up)

- **Multi-error recovery in sema** (don't stop at the first error within a body) — structurally larger; the parser already recovers and resolve is best-effort, but sema halts some sub-checks early. Out of scope for a bounded pass.
- **Sema-level message assertions in the corpus** — the editor query surface runs tokenize→parse→resolve but not sema, so the new arity/no-field messages can't be asserted through it without a sema-driving test harness. They're verified manually via full builds; a sema test harness is a separate task.
- **`note: previously defined here`** with the original definition's span on a duplicate — `Symbol` carries `decl: DeclId` but no resolved span; plumbing a decl→span lookup is deferred.
- Cross-module (`mod.Type`) unresolved-type suggestions — only the local/unqualified case suggests.

## Gates

- **Byte-identical self-host fixpoint**: clean rebuild from the v1.0.0 seed → `a` → rebuild with `a` → `cmp` converges (held across 3 iterations). Wording changes do not touch codegen.
- **`mach test .` → 209**, exit 0, zero failures (207 baseline + 2 new resolve-diagnostic tests). No corpus test asserted on the old message text.

Refs #1046