### PR TITLE
feat(build): x86_64-windows cross-compile target (native mach.exe leg)

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -16,6 +16,16 @@ entrypoint = "main.mach"
 artifacts = "linux"
 binary = "linux/bin/mach"
 
+[targets.x86_64-windows]
+os = "windows"
+isa = "x86_64"
+abi = "win64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "x86_64-windows"
+binary = "x86_64-windows/bin/mach.exe"
+libs = ["kernel32.dll"]
+
 [deps.mach-std]
 type = "remote"
 path = "https://github.com/octalide/mach-std"

--- a/mach.toml
+++ b/mach.toml
@@ -16,14 +16,14 @@ entrypoint = "main.mach"
 artifacts = "linux"
 binary = "linux/bin/mach"
 
-[targets.x86_64-windows]
+[targets.windows]
 os = "windows"
 isa = "x86_64"
 abi = "win64"
 mode = "executable"
 entrypoint = "main.mach"
-artifacts = "x86_64-windows"
-binary = "x86_64-windows/bin/mach.exe"
+artifacts = "windows"
+binary = "windows/bin/mach.exe"
 libs = ["kernel32.dll"]
 
 [deps.mach-std]


### PR DESCRIPTION
Final integration leg of the v1.1.0 Windows target (epic #1160): cross-compile `mach.exe` and run a project natively on Windows.

## What's here
- **Milestone 1 (done):** `[targets.x86_64-windows]` in `mach.toml` (os windows, isa x86_64, abi win64, executable, `libs = ["kernel32.dll"]`), matching the foundation's shape.

## Blocked: two compiler bugs surfaced, both escalated with minimal repros
Cross-compiling `mach.exe` (and even a hello-world) through the win64/COFF/PE path surfaced two genuine **compiler-codegen** bugs (not Windows-layer gaps), both reproducible on Linux and outside this port's scope. Per the escalation discipline they are filed as issues rather than papered over:

- **#1207 — COFF: defined weak symbols don't round-trip** → spurious `multiple definition of '…okI3u64P2u8E'` on the Windows link. Monomorphized generics are emitted weak so the whole-program linker dedups them; ELF round-trips weak via `STB_WEAK`, but the COFF writer drops it (emits a defined weak as a plain external), so re-read copies collide. Blocks any non-trivial Windows link.
- **#1206 — global `val` of unsigned type initialized from a cast silently becomes 0.** `comptime.eval` rejects casts and `lower_global` has no runtime init, so `val X: u32 = (-11)::i32::u32` falls through to a zero placeholder — no diagnostic. This zeroes the std's `STD_OUTPUT_HANDLE`/`STD_INPUT_HANDLE`/`STD_ERROR_HANDLE`, so `GetStdHandle(0)` returns INVALID and all Windows std I/O returns EBADF. Also a silent miscompile on every target.

## The rest of the Windows pipeline is proven to work
With both blockers temporarily sidestepped in a throwaway probe (relaxed the linker's strong-dup check; not committed), a Windows hello-world:
- cross-compiles and links to a valid PE32+ `.exe`;
- loads under wine, resolves its kernel32 imports (`GetStdHandle`/`WriteFile`/`GetCommandLineA`/`ExitProcess`), parses args via the runtime entry, reads/writes the data section, and runs.

So once #1206 and #1207 land, the port completes: cross-build `mach.exe`, run `mach.exe build .` under wine on a hello project, run the produced `.exe`.

## CI gate (milestone 4) — ready, held until the blockers clear
A two-job `Native Windows` workflow is designed and verified locally but **not committed** here (it would run red on every PR while #1206/#1207 are open): an ubuntu job builds the dev compiler from the release seed (the seed has no Windows target), cross-compiles `mach.exe`, and uploads it + a hello project as an artifact; a `runs-on: windows-latest` job downloads them, runs `mach.exe build .` natively, runs the produced `.exe`, and asserts exit code 0 + stdout. It will be added in the follow-up that closes the blockers.

## Gates
- **Linux self-host fixpoint holds:** seed→a→b→c, `cmp b c` byte-identical, with this change applied.
- **Corpus:** `mach test .` → 226 PASS / 0 FAIL.
- The compiler's own source uses no global-`val`-cast and is unaffected by either bug's fix, so the fixpoint is structurally safe once they land.

Part of epic #1160. Blocked by #1206, #1207.