### PR TITLE
chore(release): version bump to v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-06-09
+
+Patch release for project scaffolding correctness.
+
+### Fixed
+
+- `mach init` now scaffolds fully buildable projects with all required manifest
+  entries and `mach-std` dependency wiring.
+
 ## [1.1.0] - 2026-06-08
 
 Tooling and cross-compilation release. Mach can now emit Windows executables,

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "1.1.0"
+version = "1.1.1"
 dir_src = "src"
 dir_dep = "dep"
 dir_out = "out"

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -949,7 +949,7 @@ fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     if (is_err[intern.StrId, str](rcn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rcn)); }
     p.compiler_name = unwrap_ok[intern.StrId, str](rcn);
 
-    val rcv: Result[intern.StrId, str] = intern.intern(?p.s.interner, "1.1.0");
+    val rcv: Result[intern.StrId, str] = intern.intern(?p.s.interner, "1.1.1");
     if (is_err[intern.StrId, str](rcv)) { ret err[bool, str](unwrap_err[intern.StrId, str](rcv)); }
     p.compiler_ver = unwrap_ok[intern.StrId, str](rcv);
 


### PR DESCRIPTION
Closes #1219\n\n## Summary\n- bump project version in `mach.toml` to `1.1.1`\n- bump compiler version string in `src/lang/driver.mach` to `1.1.1`\n- add `[1.1.1] - 2026-06-09` changelog section for the `mach init` scaffolding fix