### PR TITLE
fix: actionable inline-asm diagnostic for [{name}] slot-base misuse

### DIFF
--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -4536,7 +4536,7 @@ fun emit_two_op(st: *EncodeState, opcode: u16, args: str, extra_flags: u16) Resu
     var sbuf: [128]u8;
     if (!split_two_op(args, ?dst, ?src, ?dbuf[0], ?sbuf[0])) {
         if (has_stack_slot_base_misuse(args)) {
-            ret err[bool, str]("encode: inline-asm '{name}' is a stack-slot binding and cannot be used as a memory base '[{name}]'; load it into a register first");
+            ret err[bool, str]("encode: inline-asm stack-slot address cannot be used as a memory base (nested [[rbp+disp]]/[[rbp-disp]]); load it into a register first");
         }
         ret err[bool, str]("encode: malformed inline-asm two-operand instruction");
     }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -4536,7 +4536,7 @@ fun emit_two_op(st: *EncodeState, opcode: u16, args: str, extra_flags: u16) Resu
     var sbuf: [128]u8;
     if (!split_two_op(args, ?dst, ?src, ?dbuf[0], ?sbuf[0])) {
         if (has_stack_slot_base_misuse(args)) {
-            ret err[bool, str]("encode: inline-asm stack-slot address cannot be used as a memory base (nested [[rbp+disp]]/[[rbp-disp]]); load it into a register first");
+            ret err[bool, str]("encode: inline-asm stack-slot binding cannot be used as a memory base (nested [[rbp+disp]]/[[rbp-disp]]); load it into a register first");
         }
         ret err[bool, str]("encode: malformed inline-asm two-operand instruction");
     }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -4642,21 +4642,7 @@ fun split_two_op(args: str, dst: *AsmOperand, src: *AsmOperand, dbuf: *u8, sbuf:
 # `[[rbp-` (the shape produced by using a stack-slot `{name}` binding as a
 # memory base, e.g. `[{name}]` -> `[[rbp+disp]]`).
 fun has_stack_slot_base_misuse(args: str) bool {
-    var i: usize = 0;
-    for (args[i] != 0) {
-        if (
-            args[i] == '['::char
-            && args[i + 1] == '['::char
-            && args[i + 2] == 'r'::char
-            && args[i + 3] == 'b'::char
-            && args[i + 4] == 'p'::char
-            && (args[i + 5] == '+'::char || args[i + 5] == '-'::char)
-        ) {
-            ret true;
-        }
-        i = i + 1;
-    }
-    ret false;
+    ret str_contains(args, "[[rbp+") || str_contains(args, "[[rbp-");
 }
 
 # trim_str: return a pointer past leading whitespace in `s` (trailing whitespace

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -4642,7 +4642,23 @@ fun split_two_op(args: str, dst: *AsmOperand, src: *AsmOperand, dbuf: *u8, sbuf:
 # `[[rbp-` (the shape produced by using a stack-slot `{name}` binding as a
 # memory base, e.g. `[{name}]` -> `[[rbp+disp]]`).
 fun has_stack_slot_base_misuse(args: str) bool {
-    ret str_contains(args, "[[rbp+") || str_contains(args, "[[rbp-");
+    val len: usize = str_len(args);
+    var i: usize = 0;
+    for (i + 1 < len) {
+        if (args[i] != '['::char) { i = i + 1; cnt; }
+        var j: usize = i + 1;
+        for (j < len && is_asm_space(args[j])) { j = j + 1; }
+        if (j >= len || args[j] != '['::char) { i = i + 1; cnt; }
+        j = j + 1;
+        for (j < len && is_asm_space(args[j])) { j = j + 1; }
+        if (j + 2 < len && args[j] == 'r'::char && args[j + 1] == 'b'::char && args[j + 2] == 'p'::char) {
+            var k: usize = j + 3;
+            for (k < len && is_asm_space(args[k])) { k = k + 1; }
+            if (k < len && (args[k] == '+'::char || args[k] == '-'::char)) { ret true; }
+        }
+        i = i + 1;
+    }
+    ret false;
 }
 
 # trim_str: return a pointer past leading whitespace in `s` (trailing whitespace

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -27,6 +27,7 @@ use std.types.size.usize;
 use std.types.char.char;
 use std.types.string.str;
 use std.types.string.str_equals;
+use std.types.string.str_contains;
 use std.types.string.str_len;
 use std.types.result.Result;
 use std.types.result.ok;
@@ -4534,6 +4535,9 @@ fun emit_two_op(st: *EncodeState, opcode: u16, args: str, extra_flags: u16) Resu
     var dbuf: [128]u8;
     var sbuf: [128]u8;
     if (!split_two_op(args, ?dst, ?src, ?dbuf[0], ?sbuf[0])) {
+        if (has_stack_slot_base_misuse(args)) {
+            ret err[bool, str]("encode: inline-asm '{name}' is a stack-slot binding and cannot be used as a memory base '[{name}]'; load it into a register first");
+        }
         ret err[bool, str]("encode: malformed inline-asm two-operand instruction");
     }
 
@@ -4634,6 +4638,27 @@ fun split_two_op(args: str, dst: *AsmOperand, src: *AsmOperand, dbuf: *u8, sbuf:
     ret true;
 }
 
+# has_stack_slot_base_misuse: true when an asm arg string contains `[[rbp+` or
+# `[[rbp-` (the shape produced by using a stack-slot `{name}` binding as a
+# memory base, e.g. `[{name}]` -> `[[rbp+disp]]`).
+fun has_stack_slot_base_misuse(args: str) bool {
+    var i: usize = 0;
+    for (args[i] != 0) {
+        if (
+            args[i] == '['::char
+            && args[i + 1] == '['::char
+            && args[i + 2] == 'r'::char
+            && args[i + 3] == 'b'::char
+            && args[i + 4] == 'p'::char
+            && (args[i + 5] == '+'::char || args[i + 5] == '-'::char)
+        ) {
+            ret true;
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
 # trim_str: return a pointer past leading whitespace in `s` (trailing whitespace
 # was already stripped by the statement tokenizer).
 fun trim_str(s: str) str {
@@ -4681,6 +4706,17 @@ fun free_bytebuf(b: *ByteBuf) {
         b.cap  = 0;
         b.len  = 0;
     }
+}
+
+test "x64.encode: inline-asm stack-slot used as memory base gets actionable diagnostic" {
+    var st: EncodeState;
+    val r: Result[bool, str] = emit_two_op(?st, x64.MOV, "[[rbp-8]], rax", 0);
+    if (!is_err[bool, str](r)) { ret 1; }
+    val msg: str = unwrap_err[bool, str](r);
+    if (!str_contains(msg, "stack-slot binding")) { ret 1; }
+    if (!str_contains(msg, "load it into a register first")) { ret 1; }
+    if (str_contains(msg, "malformed inline-asm two-operand instruction")) { ret 1; }
+    ret 0;
 }
 
 # determine whether an instruction names an intra-module branch target (a

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -4535,6 +4535,23 @@ fun emit_two_op(st: *EncodeState, opcode: u16, args: str, extra_flags: u16) Resu
     var dbuf: [128]u8;
     var sbuf: [128]u8;
     if (!split_two_op(args, ?dst, ?src, ?dbuf[0], ?sbuf[0])) {
+        # if we can locate the comma, try to attribute the nested-slot misuse to a side.
+        val len: usize = str_len(args);
+        var comma: usize = len;
+        var found: bool = false;
+        var i: usize = 0;
+        for (i < len && !found) {
+            if (args[i] == ','::char) { comma = i; found = true; }
+            i = i + 1;
+        }
+        if (found) {
+            if (copy_trimmed(args, 0, comma, ?dbuf[0], 128) && has_stack_slot_base_misuse((?dbuf[0])::str)) {
+                ret err[bool, str]("encode: inline-asm destination operand uses a stack-slot binding as a memory base (nested [[rbp+disp]]/[[rbp-disp]]); load it into a register first");
+            }
+            if (copy_trimmed(args, comma + 1, len, ?sbuf[0], 128) && has_stack_slot_base_misuse((?sbuf[0])::str)) {
+                ret err[bool, str]("encode: inline-asm source operand uses a stack-slot binding as a memory base (nested [[rbp+disp]]/[[rbp-disp]]); load it into a register first");
+            }
+        }
         if (has_stack_slot_base_misuse(args)) {
             ret err[bool, str]("encode: inline-asm stack-slot binding cannot be used as a memory base (nested [[rbp+disp]]/[[rbp-disp]]); load it into a register first");
         }


### PR DESCRIPTION
Fixes #1197

## Summary
- detect nested stack-slot memory-base operand shapes produced by using a stack-slot {name} binding as a memory base ([{name}])
- emit a targeted inline-asm diagnostic that explains cause and remediation
- add a regression test asserting the targeted diagnostic is emitted and the generic malformed-two-operand message is not
