### PR TITLE
fix: preserve win64 callee-saved r14 across calls

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -3576,6 +3576,15 @@ fun lower_value_addr(ctx: *LowerCtx, mb: *MirBlock, v: value.Value) Result[MirOp
     ret ok[MirOperand, str](op_vreg(addr));
 }
 
+# stack_aggr_spills_pointer: true when a CLASS_STACK aggregate slot carries only
+# a hidden pointer (not by-value bytes). this is the win64 by-reference overflow
+# case: an aggregate larger than the by-value threshold whose first four register
+# slots are exhausted. the classifier reports CLASS_STACK with pointer size (8),
+# while the IR operand type still reports the aggregate's full byte size.
+fun stack_aggr_spills_pointer(slot: abi.ParamSlot, is_aggr: bool, value_size: u64) bool {
+    ret slot.class == abi.CLASS_STACK && is_aggr && slot.size < value_size;
+}
+
 # emit_arg_slot: emit the pre-coloring move(s) placing one classified argument.
 # GP/FP register args move the value into the argument register (a 9–16 byte
 # aggregate in two GP registers moves each half from `[base+0]` / `[base+8]` of
@@ -3585,10 +3594,11 @@ fun lower_value_addr(ctx: *LowerCtx, mb: *MirBlock, v: value.Value) Result[MirOp
 # region (the ABI classifier returns a sizing-only slot with no offset of its
 # own, so the running cursor is the caller's responsibility — see `lower_call`).
 # an aggregate argop is a pointer to the aggregate's storage (aggregates flow by
-# address); the register / stack forms load or copy the aggregate's bytes from
-# that storage, and `addr_to_vreg` normalizes a global's symbol address into a
-# value vreg so the two-register / by-reference forms index a register pointer
-# base. a scalar argop is the value itself, placed directly.
+# address). a by-value stack aggregate copies its bytes to the outgoing slot, but
+# a by-reference stack spill stores only that pointer value (win64 exhausted-slot
+# byref case). `addr_to_vreg` normalizes a global's symbol address into a value
+# vreg so the two-register / by-reference forms index a register pointer base.
+# a scalar argop is the value itself, placed directly.
 fun emit_arg_slot(ctx: *LowerCtx, mb: *MirBlock, slot: abi.ParamSlot, argop: MirOperand,
                   stack_off: i64, is_aggr: bool, size: u64) Result[bool, str] {
     if (slot.class == abi.CLASS_STACK) {
@@ -3596,6 +3606,11 @@ fun emit_arg_slot(ctx: *LowerCtx, mb: *MirBlock, slot: abi.ParamSlot, argop: Mir
         # (x86-64 RSP), named through `tgt.arch.stack_ptr_reg` rather than a literal.
         val sp: u32 = ctx.tgt.arch.stack_ptr_reg::u32;
         if (is_aggr) {
+            if (stack_aggr_spills_pointer(slot, is_aggr, size)) {
+                # win64 by-reference overflow: the stack slot holds the hidden
+                # aggregate pointer, not a by-value copy of the aggregate bytes.
+                ret emit_store_to(ctx, mb, op_mem_preg(sp, stack_off), argop);
+            }
             # the by-value aggregate is copied into the outgoing stack slot from its
             # storage; argop is a pointer to that storage.
             ret copy_aggregate(ctx, mb, op_mem_preg(sp, stack_off), argop, size);
@@ -3716,6 +3731,21 @@ fun stack_slot_bytes(size: u64) i64 {
     if (n == 0) { n = 8; }
     n = (n + 7) & ~7::u64;
     ret n::i64;
+}
+
+test "mir: stack aggregate pointer-spill detection catches win64 byref overflow" {
+    var slot: abi.ParamSlot = abi.make_slot(abi.CLASS_STACK, -1, -1, 32, 8);
+    if (!stack_aggr_spills_pointer(slot, true, 40)) { ret 1; }
+    ret 0;
+}
+
+test "mir: stack aggregate by-value slots do not take pointer-spill path" {
+    var by_value: abi.ParamSlot = abi.make_slot(abi.CLASS_STACK, -1, -1, 32, 24);
+    if (stack_aggr_spills_pointer(by_value, true, 24)) { ret 1; }
+
+    var scalar: abi.ParamSlot = abi.make_slot(abi.CLASS_STACK, -1, -1, 32, 8);
+    if (stack_aggr_spills_pointer(scalar, false, 8)) { ret 1; }
+    ret 0;
 }
 
 # record_outgoing_size: grow the function's reserved outgoing-argument region to


### PR DESCRIPTION
Fix win64 call lowering for exhausted by-reference aggregate stack args so we spill the hidden pointer instead of copying aggregate bytes.

This resolves the r14 clobber crash in #1212.

Follow-up crash investigation is tracked separately in #1224.

Closes #1212