### PR TITLE
fix(win64): recover startup imports and unwind SAVE_NONVOL guard

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -598,9 +598,20 @@ fun emit_executable(s: *sess.Session, tgt: *target.Target, out_img: *of.ObjectIm
     if (is_err[*of.LoadSegment, str](sr)) { ret err[bool, str](unwrap_err[*of.LoadSegment, str](sr)); }
     val segs: *of.LoadSegment = unwrap_ok[*of.LoadSegment, str](sr);
 
-    val emit_r: Result[bool, str] =
-        tgt.of.emit_exec(alloc, tgt.arch, segs, seg_count, entry, out_path);
+    var func_count: u32 = 0;
+    val fr: Result[*of.ExecFunction, str] = build_exec_functions(alloc, out_img, segs, seg_count, ?func_count);
+    if (is_err[*of.ExecFunction, str](fr)) {
+        deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
+        ret err[bool, str](unwrap_err[*of.ExecFunction, str](fr));
+    }
+    val funcs: *of.ExecFunction = unwrap_ok[*of.ExecFunction, str](fr);
 
+    val emit_r: Result[bool, str] =
+        tgt.of.emit_exec(alloc, tgt.arch, segs, seg_count, entry, funcs, func_count, out_path);
+
+    if (funcs != nil && func_count > 0) {
+        deallocate[of.ExecFunction](alloc, funcs, func_count::usize);
+    }
     deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
 
     if (is_err[bool, str](emit_r)) {
@@ -646,10 +657,21 @@ fun emit_dynamic_executable(s: *sess.Session, tgt: *target.Target, out_img: *of.
     if (is_err[*of.LoadSegment, str](sr)) { ret err[bool, str](unwrap_err[*of.LoadSegment, str](sr)); }
     val segs: *of.LoadSegment = unwrap_ok[*of.LoadSegment, str](sr);
 
+    var func_count: u32 = 0;
+    val fr: Result[*of.ExecFunction, str] = build_exec_functions(alloc, out_img, segs, seg_count, ?func_count);
+    if (is_err[*of.ExecFunction, str](fr)) {
+        deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
+        ret err[bool, str](unwrap_err[*of.ExecFunction, str](fr));
+    }
+    val funcs: *of.ExecFunction = unwrap_ok[*of.ExecFunction, str](fr);
+
     val emit_r: Result[bool, str] =
         tgt.of.emit_dyn_exec(alloc, tgt.arch, segs, seg_count, entry,
-                             ?dyn.info, dyn.fixups, dyn.fixup_count, out_path);
+                             funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, out_path);
 
+    if (funcs != nil && func_count > 0) {
+        deallocate[of.ExecFunction](alloc, funcs, func_count::usize);
+    }
     deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
 
     if (is_err[bool, str](emit_r)) {
@@ -720,6 +742,99 @@ fun build_load_segments(alloc: *Allocator, out_img: *of.ObjectImage, merged: *Me
 
     @seg_count = count;
     ret ok[*of.LoadSegment, str](segs);
+}
+
+# build_exec_functions: collect defined function symbols into executable-segment
+# ranges for executable writers that need per-function metadata (for example PE
+# unwind tables). each entry carries segment index + offset + byte size; zero-sized
+# and out-of-range symbols are dropped.
+fun build_exec_functions(alloc: *Allocator, out_img: *of.ObjectImage,
+                         segs: *of.LoadSegment, seg_count: u32,
+                         func_count: *u32) Result[*of.ExecFunction, str] {
+    @func_count = 0;
+    if (out_img.symbol_count == 0) { ret ok[*of.ExecFunction, str](nil); }
+
+    val ar: Result[*of.ExecFunction, str] = allocate[of.ExecFunction](alloc, out_img.symbol_count::usize);
+    if (is_err[*of.ExecFunction, str](ar)) {
+        ret err[*of.ExecFunction, str](unwrap_err[*of.ExecFunction, str](ar));
+    }
+    var funcs: *of.ExecFunction = unwrap_ok[*of.ExecFunction, str](ar);
+    var n: u32 = 0;
+
+    var si: u32 = 0;
+    for (si < out_img.symbol_count) {
+        val sym: *of.Symbol = ?out_img.symbols[si];
+        if ((sym.flags & of.SYM_OBJ_FLAG_FUNCTION) == 0) { si = si + 1; cnt; }
+        if (sym.section == of.SECTION_EXTERNAL || sym.section >= out_img.section_count) { si = si + 1; cnt; }
+        if (out_img.sections[sym.section].kind != of.SK_TEXT) { si = si + 1; cnt; }
+
+        val seg: u32 = segment_index_for(out_img, sym.section);
+        if (seg >= seg_count) { si = si + 1; cnt; }
+        if (sym.offset::usize >= segs[seg].filesz) { si = si + 1; cnt; }
+
+        funcs[n].seg_index = seg;
+        funcs[n].seg_offset = sym.offset;
+        funcs[n].size = 0;
+        n = n + 1;
+        si = si + 1;
+    }
+
+    if (n == 0) {
+        deallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize);
+        ret ok[*of.ExecFunction, str](nil);
+    }
+
+    # stable insertion sort by segment then offset.
+    var i: u32 = 1;
+    for (i < n) {
+        var cur: of.ExecFunction = funcs[i];
+        var j: i32 = i::i32 - 1;
+        for (j >= 0
+             && (funcs[j::u32].seg_index > cur.seg_index
+                 || (funcs[j::u32].seg_index == cur.seg_index
+                     && funcs[j::u32].seg_offset > cur.seg_offset))) {
+            funcs[(j + 1)::u32] = funcs[j::u32];
+            j = j - 1;
+        }
+        funcs[(j + 1)::u32] = cur;
+        i = i + 1;
+    }
+
+    # fill sizes from the next function in the same segment (or segment end), and
+    # compact away zero/non-forward ranges.
+    var w: u32 = 0;
+    i = 0;
+    for (i < n) {
+        val seg: u32 = funcs[i].seg_index;
+        val cur_off: u32 = funcs[i].seg_offset;
+        var next_off: u32 = segs[seg].filesz::u32;
+        if (i + 1 < n && funcs[i + 1].seg_index == seg) {
+            next_off = funcs[i + 1].seg_offset;
+        }
+        if (next_off > cur_off) {
+            funcs[w] = funcs[i];
+            funcs[w].size = next_off - cur_off;
+            w = w + 1;
+        }
+        i = i + 1;
+    }
+
+    if (w == 0) {
+        deallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize);
+        ret ok[*of.ExecFunction, str](nil);
+    }
+    if (w < out_img.symbol_count) {
+        val rr: Result[*of.ExecFunction, str] =
+            reallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize, w::usize);
+        if (is_err[*of.ExecFunction, str](rr)) {
+            deallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize);
+            ret err[*of.ExecFunction, str](unwrap_err[*of.ExecFunction, str](rr));
+        }
+        funcs = unwrap_ok[*of.ExecFunction, str](rr);
+    }
+
+    @func_count = w;
+    ret ok[*of.ExecFunction, str](funcs);
 }
 
 # is_loadable_kind: whether a merged section kind becomes a loadable executable

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -254,6 +254,20 @@ pub rec LoadSegment {
     bytes:  *u8;
 }
 
+# one function's executable-range descriptor in the linker's load-segment view.
+# used by executable writers that need per-function metadata (for example, PE
+# unwind tables): each entry points at the owning segment and the function's byte
+# range within it.
+# ---
+# seg_index: index into the executable writer's `LoadSegment` array
+# seg_offset: byte offset of the function start within that segment
+# size:      byte length of the function body
+pub rec ExecFunction {
+    seg_index:  u32;
+    seg_offset: u32;
+    size:       u32;
+}
+
 # one entry in a format's relocation-kind table: the format's mapping of an
 # abstract relocation kind to its machine type and encoding properties.
 # ---
@@ -306,9 +320,12 @@ pub def ParserFn: fun(*Allocator, *u8, usize, *ObjectImage) Result[bool, str];
 # arg 2: the loadable segments, in ascending virtual-address order
 # arg 3: number of load segments
 # arg 4: program entry-point virtual address
-# arg 5: null-terminated output file path
+# arg 5: per-function descriptors (may be nil when count is 0)
+# arg 6: number of per-function descriptors
+# arg 7: null-terminated output file path
 # ret:   true on success, or an error string
-pub def ExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64, *u8) Result[bool, str];
+pub def ExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64,
+                    *ExecFunction, u32, *u8) Result[bool, str];
 
 # a dynamically-linked-executable writer: serializes the linker's laid-out load
 # segments into a dynamically-linked executable, framing the format's
@@ -326,13 +343,15 @@ pub def ExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64, *u8) Res
 # arg 2: the loadable segments, in ascending virtual-address order
 # arg 3: number of load segments
 # arg 4: program entry-point virtual address
-# arg 5: the dynamic-link plan (dependencies, imports, interpreter)
-# arg 6: the import call-site fixups to redirect to call-thunks
-# arg 7: number of fixups
-# arg 8: null-terminated output file path
+# arg 5: per-function descriptors (may be nil when count is 0)
+# arg 6: number of per-function descriptors
+# arg 7: the dynamic-link plan (dependencies, imports, interpreter)
+# arg 8: the import call-site fixups to redirect to call-thunks
+# arg 9: number of fixups
+# arg 10: null-terminated output file path
 # ret:   true on success, or an error string
 pub def DynExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64,
-                       *DynamicInfo, *PltFixup, u32, *u8) Result[bool, str];
+                       *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *u8) Result[bool, str];
 
 # the object-format runtime-dispatch interface. exactly one of these exists
 # per format; the back end serializes through `emit_object`, the linker reads

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1350,6 +1350,7 @@ fun infer_extern_function_flags_from_calls(out: *of.ObjectImage) {
             if (sym.name == r.symbol && sym.section == of.SECTION_EXTERNAL
                 && (sym.flags & of.SYM_OBJ_FLAG_EXTERN) != 0) {
                 sym.flags = sym.flags | of.SYM_OBJ_FLAG_FUNCTION | of.SYM_OBJ_FLAG_GLOBAL;
+                brk;
             }
             si = si + 1;
         }
@@ -1590,6 +1591,7 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment,
             if (cur + 2 > lim) { brk; }
         }
         if (seg.bytes[base + cur] != 0x89) { brk; }
+        if ((rex & 8) == 0) { brk; }
         val modrm: u8 = seg.bytes[base + cur + 1];
         val mod: u8 = modrm >> 6;
         if ((modrm & 7) != 5 || (mod != 1 && mod != 2)) { brk; }
@@ -1613,7 +1615,7 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment,
         val save_off: usize = alloc - off_rbp;
         var reg: u8 = ((modrm >> 3) & 7);
         if ((rex & 4) != 0) { reg = reg + 8; }
-        if (!is_win64_nonvol_reg(reg)) { ret false; }
+        if (!is_win64_nonvol_reg(reg)) { brk; }
         if (!push_save_nonvol(uw, (cur + inst_len)::u8, reg, save_off)) { ret false; }
         pos = cur + inst_len;
     }
@@ -1786,13 +1788,15 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
 # imports) is the dynamic write with an empty plan, so this delegates to the
 # shared PE writer with a nil DynamicInfo and no fixups.
 # ---
-# alloc:     allocator for the output buffer and layout scratch
-# isa_vt:    the instruction-set vtable describing the machine (must be x86-64)
-# segs:      the loadable segments, in ascending virtual-address order
-# seg_count: number of load segments
-# entry:     program entry-point virtual address
-# path:      null-terminated output file path
-# ret:       ok(true) on success, or an error string
+# alloc:      allocator for the output buffer and layout scratch
+# isa_vt:     the instruction-set vtable describing the machine (must be x86-64)
+# segs:       the loadable segments, in ascending virtual-address order
+# seg_count:  number of load segments
+# entry:      program entry-point virtual address
+# funcs:      per-function metadata for unwind-table emission
+# func_count: number of entries in funcs
+# path:       null-terminated output file path
+# ret:        ok(true) on success, or an error string
 fun coff_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                    seg_count: u32, entry: u64, funcs: *of.ExecFunction,
                    func_count: u32, path: *u8) Result[bool, str] {
@@ -1812,6 +1816,8 @@ fun coff_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegm
 # segs:        the loadable segments, in ascending virtual-address order
 # seg_count:   number of load segments
 # entry:       program entry-point virtual address
+# funcs:       per-function metadata for unwind-table emission
+# func_count:  number of entries in funcs
 # dyn:         the dynamic-link plan (dependencies, imports)
 # fixups:      the import call-site fixups to redirect to import stubs
 # fixup_count: number of fixups

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -27,9 +27,9 @@
 # `.idata` import directory + IAT built from the `of.DynamicInfo` plan (one
 # IMAGE_IMPORT_DESCRIPTOR per DynLib, an ILT/IAT thunk per DynImport, a hint/name
 # table). Each `PltFixup` call site is redirected to an import stub that jumps
-# through the IAT slot the loader fills. Exception/unwind tables (`.pdata`/
-# `.xdata`) are not emitted yet: correct unwind needs per-function prologue codes
-# the back end does not produce, and wrong unwind metadata is worse than none.
+# through the IAT slot the loader fills. Per-function exception/unwind tables are
+# emitted for functions whose x86-64 prologue matches the encoder's canonical
+# frame shape.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -123,6 +123,7 @@ val IMAGE_DLLCHARACTERISTICS_NX_COMPAT: u16 = 0x0100;
 
 # data-directory indices in the PE32+ optional header.
 val IMAGE_DIRECTORY_ENTRY_IMPORT:    u32 = 1;
+val IMAGE_DIRECTORY_ENTRY_EXCEPTION: u32 = 3;
 val IMAGE_DIRECTORY_ENTRY_IAT:       u32 = 12;
 val IMAGE_NUMBEROF_DIRECTORY_ENTRIES: u32 = 16;
 
@@ -143,6 +144,17 @@ val IMPORT_DESCRIPTOR_SIZE: usize = 20;
 val THUNK_SIZE:             usize = 8;
 # the per-function import stub: `jmp qword [rip+disp32]` through the IAT slot.
 val IMPORT_STUB_SIZE:       usize = 6;
+# one RUNTIME_FUNCTION table row (`BeginAddress`, `EndAddress`, `UnwindInfoAddress`).
+val RUNTIME_FUNCTION_SIZE:  usize = 12;
+
+# x64 unwind opcodes / register ids (PE/COFF).
+val UNWIND_VERSION: u8 = 1;
+val UWOP_PUSH_NONVOL: u8 = 0;
+val UWOP_ALLOC_LARGE: u8 = 1;
+val UWOP_ALLOC_SMALL: u8 = 2;
+val UWOP_SAVE_NONVOL: u8 = 4;
+val UWOP_SAVE_NONVOL_FAR: u8 = 5;
+val UWREG_RBP: u8 = 5;
 
 # write a u16 little-endian into a buffer.
 fun write_u16_le(buf: *u8, offset: usize, value: u16) {
@@ -1311,8 +1323,38 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
         s = s + 1;
     }
 
+    # some external COFF producers leave an undefined import's Type field as 0
+    # (no DT_FUNCTION) even when every reference is a call relocation. recover the
+    # function bit from the reloc stream so dynamic-import discovery can still bind
+    # those call targets through import stubs.
+    infer_extern_function_flags_from_calls(out);
+
     deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
     ret ok[bool, str](true);
+}
+
+# infer_extern_function_flags_from_calls: mark an undefined external symbol as a
+# function import when some relocation calls it (`pc32`/`plt32`) but the symbol
+# record itself lacks the function type bit. this preserves dynamic import binding
+# for COFF inputs emitted by toolchains that encode undefined import type as 0.
+fun infer_extern_function_flags_from_calls(out: *of.ObjectImage) {
+    if (out == nil || out.reloc_count == 0 || out.symbol_count == 0) { ret; }
+    var ri: u32 = 0;
+    for (ri < out.reloc_count) {
+        val r: *of.Relocation = ?out.relocations[ri];
+        if (r.symbol == intern.STR_NIL) { ri = ri + 1; cnt; }
+        if (r.kind != rk_pc32 && r.kind != rk_plt32) { ri = ri + 1; cnt; }
+        var si: u32 = 0;
+        for (si < out.symbol_count) {
+            val sym: *of.Symbol = ?out.symbols[si];
+            if (sym.name == r.symbol && sym.section == of.SECTION_EXTERNAL
+                && (sym.flags & of.SYM_OBJ_FLAG_EXTERN) != 0) {
+                sym.flags = sym.flags | of.SYM_OBJ_FLAG_FUNCTION | of.SYM_OBJ_FLAG_GLOBAL;
+            }
+            si = si + 1;
+        }
+        ri = ri + 1;
+    }
 }
 
 # the resolved layout of one PE section: its in-memory RVA (relative to ImageBase)
@@ -1334,11 +1376,8 @@ rec PeSection {
 # load segments, and the synthesized sections (import stubs, .idata). every RVA is
 # relative to ImageBase and every file offset is absolute. computed once from the
 # segment and import counts, then consumed by the write pass. `sec_total` counts
-# the section-table entries (linker segments + stubs + idata, the synthesized ones
-# present only when used). exception/unwind tables (.pdata/.xdata) are not emitted:
-# the back end does not yet produce per-function prologue unwind codes, and
-# structurally-valid-but-wrong unwind metadata is worse than none — see the
-# follow-up issue for proper per-function .pdata/.xdata.
+# the section-table entries (linker segments + synthesized stubs/import/unwind
+# sections, present only when used).
 # ---
 # image_base:    PE ImageBase (64 KiB-aligned, one reserve region below seg[0])
 # header_size:   SizeOfHeaders (file-aligned span of DOS+PE+section headers)
@@ -1349,6 +1388,7 @@ rec PeSection {
 # iat_rva/size:  the IAT span within .idata (the IAT data directory)
 # import_dir_*:  the import directory span within .idata (the IMPORT directory)
 # nimp:          number of function imports (IAT/stub/hint-name entries)
+# exception_*:   the .pdata span (EXCEPTION data directory target)
 # sec_total:     number of section-table entries
 rec PeLayout {
     image_base:  u64;
@@ -1357,14 +1397,41 @@ rec PeLayout {
     seg_secs:    *PeSection;
     stub_sec:    PeSection;
     idata_sec:   PeSection;
+    xdata_sec:   PeSection;
+    pdata_sec:   PeSection;
     iat_rva:     u64;
     iat_size:    u64;
     import_dir_rva:  u64;
     import_dir_size: u64;
+    exception_rva:   u64;
+    exception_size:  u64;
     nimp:        u32;
     have_stub:   bool;
     have_idata:  bool;
+    have_xdata:  bool;
+    have_pdata:  bool;
     sec_total:   u32;
+}
+
+rec UnwindCode {
+    end_off:     u8;
+    op:          u8;
+    info:        u8;
+    extra0:      u16;
+    extra1:      u16;
+    extra_slots: u8;
+}
+
+rec FunctionUnwind {
+    seg_index:   u32;
+    seg_offset:  u32;
+    size:        u32;
+    prolog_size: u8;
+    code_count:  u32;
+    slot_count:  u32;
+    xdata_rva:   u64;
+    xdata_size:  usize;
+    codes:       [16]UnwindCode;
 }
 
 # func_import_count: the number of function imports in a dynamic plan — only these
@@ -1417,6 +1484,151 @@ fun import_dir_bytes(dyn: *of.DynamicInfo) usize {
     ret (dyn.lib_count + 1)::usize * IMPORT_DESCRIPTOR_SIZE;
 }
 
+fun push_unwind_code(uw: *FunctionUnwind, end_off: u8, op: u8, info: u8,
+                     extra0: u16, extra1: u16, extra_slots: u8) bool {
+    if (uw.code_count >= 16) { ret false; }
+    uw.codes[uw.code_count].end_off = end_off;
+    uw.codes[uw.code_count].op = op;
+    uw.codes[uw.code_count].info = info;
+    uw.codes[uw.code_count].extra0 = extra0;
+    uw.codes[uw.code_count].extra1 = extra1;
+    uw.codes[uw.code_count].extra_slots = extra_slots;
+    uw.code_count = uw.code_count + 1;
+    uw.slot_count = uw.slot_count + 1 + extra_slots::u32;
+    ret true;
+}
+
+fun push_alloc_code(uw: *FunctionUnwind, end_off: u8, alloc: usize) bool {
+    if (alloc == 0) { ret true; }
+    if ((alloc & 7) != 0) { ret false; }
+    if (alloc <= 128) {
+        ret push_unwind_code(uw, end_off, UWOP_ALLOC_SMALL, ((alloc - 8) / 8)::u8, 0, 0, 0);
+    }
+    val scaled: u32 = (alloc / 8)::u32;
+    if (scaled <= 0xFFFF) {
+        ret push_unwind_code(uw, end_off, UWOP_ALLOC_LARGE, 0, scaled::u16, 0, 1);
+    }
+    ret push_unwind_code(uw, end_off, UWOP_ALLOC_LARGE, 1,
+                         (alloc & 0xFFFF)::u16, ((alloc >> 16) & 0xFFFF)::u16, 2);
+}
+
+fun push_save_nonvol(uw: *FunctionUnwind, end_off: u8, reg: u8, save_off: usize) bool {
+    if ((save_off & 7) != 0) { ret false; }
+    val scaled: u32 = (save_off / 8)::u32;
+    if (scaled <= 0xFFFF) {
+        ret push_unwind_code(uw, end_off, UWOP_SAVE_NONVOL, reg, scaled::u16, 0, 1);
+    }
+    if (save_off > 0xFFFFFFFF::usize) { ret false; }
+    ret push_unwind_code(uw, end_off, UWOP_SAVE_NONVOL_FAR, reg,
+                         (save_off & 0xFFFF)::u16, ((save_off >> 16) & 0xFFFF)::u16, 2);
+}
+
+fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment,
+                          funcs: *of.ExecFunction, idx: u32) bool {
+    uw.seg_index = funcs[idx].seg_index;
+    uw.seg_offset = funcs[idx].seg_offset;
+    uw.size = funcs[idx].size;
+    uw.prolog_size = 0;
+    uw.code_count = 0;
+    uw.slot_count = 0;
+    uw.xdata_rva = 0;
+    uw.xdata_size = 0;
+
+    if (uw.seg_index >= 0xFFFFFFFF || uw.size == 0) { ret false; }
+    val seg: *of.LoadSegment = ?segs[uw.seg_index];
+    if (seg.bytes == nil) { ret false; }
+    if (uw.seg_offset::usize >= seg.filesz) { ret false; }
+    val lim_all: usize = seg.filesz - uw.seg_offset::usize;
+    var lim: usize = uw.size::usize;
+    if (lim > lim_all) { lim = lim_all; }
+    if (lim < 4) { ret false; }
+
+    val base: usize = uw.seg_offset::usize;
+    var pos: usize = 0;
+
+    if (seg.bytes[base] != 0x55) { ret false; }
+    if (!push_unwind_code(uw, 1, UWOP_PUSH_NONVOL, UWREG_RBP, 0, 0, 0)) { ret false; }
+    pos = 1;
+
+    if (pos + 3 > lim) { ret false; }
+    if (seg.bytes[base + pos] != 0x48 || seg.bytes[base + pos + 1] != 0x89 || seg.bytes[base + pos + 2] != 0xE5) {
+        ret false;
+    }
+    pos = pos + 3;
+
+    var alloc: usize = 0;
+    if (pos + 4 <= lim
+        && seg.bytes[base + pos] == 0x48
+        && seg.bytes[base + pos + 1] == 0x83
+        && seg.bytes[base + pos + 2] == 0xEC) {
+        alloc = seg.bytes[base + pos + 3]::usize;
+        if (!push_alloc_code(uw, (pos + 4)::u8, alloc)) { ret false; }
+        pos = pos + 4;
+    }
+    or (pos + 7 <= lim
+         && seg.bytes[base + pos] == 0x48
+         && seg.bytes[base + pos + 1] == 0x81
+         && seg.bytes[base + pos + 2] == 0xEC) {
+        alloc = read_u32_le(seg.bytes, base + pos + 3)::usize;
+        if (!push_alloc_code(uw, (pos + 7)::u8, alloc)) { ret false; }
+        pos = pos + 7;
+    }
+
+    for (true) {
+        var cur: usize = pos;
+        if (cur + 3 > lim) { brk; }
+        var rex: u8 = 0;
+        if (seg.bytes[base + cur] >= 0x40 && seg.bytes[base + cur] <= 0x4F) {
+            rex = seg.bytes[base + cur];
+            cur = cur + 1;
+            if (cur + 2 > lim) { brk; }
+        }
+        if (seg.bytes[base + cur] != 0x89) { brk; }
+        val modrm: u8 = seg.bytes[base + cur + 1];
+        val mod: u8 = modrm >> 6;
+        if ((modrm & 7) != 5 || (mod != 1 && mod != 2)) { brk; }
+
+        var disp: i64 = 0;
+        var inst_len: usize = 0;
+        if (mod == 1) {
+            if (cur + 3 > lim) { brk; }
+            disp = (seg.bytes[base + cur + 2]::i8)::i64;
+            inst_len = 3;
+        }
+        or {
+            if (cur + 6 > lim) { brk; }
+            disp = (read_u32_le(seg.bytes, base + cur + 2)::i32)::i64;
+            inst_len = 6;
+        }
+        if (disp >= 0) { brk; }
+
+        val off_rbp: usize = (-disp)::usize;
+        if (alloc < off_rbp) { ret false; }
+        val save_off: usize = alloc - off_rbp;
+        var reg: u8 = ((modrm >> 3) & 7);
+        if ((rex & 4) != 0) { reg = reg + 8; }
+        if (!push_save_nonvol(uw, (cur + inst_len)::u8, reg, save_off)) { ret false; }
+        pos = cur + inst_len;
+    }
+
+    if (uw.code_count == 0) { ret false; }
+    if (pos > 255) { ret false; }
+    uw.prolog_size = pos::u8;
+    uw.xdata_size = align_up(4 + uw.slot_count::usize * 2, 4);
+    ret true;
+}
+
+fun collect_function_unwind(segs: *of.LoadSegment, funcs: *of.ExecFunction,
+                            func_count: u32, out: *FunctionUnwind) u32 {
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < func_count) {
+        if (parse_function_unwind(?out[n], segs, funcs, i)) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
 # compute_pe_layout: place every PE section at an RVA and file offset, given the
 # linker's load segments and the dynamic-import plan. the headers occupy file
 # offset 0 (mapped at ImageBase, RVA 0); each linker segment maps at its assigned
@@ -1425,11 +1637,14 @@ fun import_dir_bytes(dyn: *of.DynamicInfo) usize {
 # RVAs advance under their own alignments (FileAlignment on disk, SectionAlignment
 # in memory). returns the total file size.
 fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
-                      dyn: *of.DynamicInfo, seg_secs: *PeSection) usize {
+                      dyn: *of.DynamicInfo, seg_secs: *PeSection,
+                      xdata_vsize: usize, pdata_vsize: usize) usize {
     lay.nimp      = func_import_count(dyn);
     lay.seg_secs  = seg_secs;
     lay.have_stub = lay.nimp > 0;
     lay.have_idata = dyn != nil && (dyn.lib_count > 0 || dyn.import_count > 0);
+    lay.have_xdata = xdata_vsize > 0;
+    lay.have_pdata = pdata_vsize > 0;
 
     # ImageBase: 64 KiB-aligned, one reserve region below the first segment's page
     # so the PE headers map at RVA 0 and segment[0] sits at RVA >= the reserve.
@@ -1442,6 +1657,8 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
     var nsec: u32 = seg_count;
     if (lay.have_stub)  { nsec = nsec + 1; }
     if (lay.have_idata) { nsec = nsec + 1; }
+    if (lay.have_xdata) { nsec = nsec + 1; }
+    if (lay.have_pdata) { nsec = nsec + 1; }
     lay.sec_total = nsec;
 
     # headers: DOS header + PE signature + COFF header + optional header + the
@@ -1531,6 +1748,28 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
         rva = rva + align_up_u64(ioff::u64, PE_SECTION_ALIGN);
     }
 
+    if (lay.have_xdata) {
+        rva = align_up_u64(rva, PE_SECTION_ALIGN);
+        lay.xdata_sec.rva       = rva;
+        lay.xdata_sec.vsize     = xdata_vsize::u64;
+        lay.xdata_sec.file_off  = file_off;
+        lay.xdata_sec.file_size = align_up(xdata_vsize, PE_FILE_ALIGN::usize);
+        file_off = file_off + lay.xdata_sec.file_size;
+        rva = rva + align_up_u64(lay.xdata_sec.vsize, PE_SECTION_ALIGN);
+    }
+
+    if (lay.have_pdata) {
+        rva = align_up_u64(rva, PE_SECTION_ALIGN);
+        lay.pdata_sec.rva       = rva;
+        lay.pdata_sec.vsize     = pdata_vsize::u64;
+        lay.pdata_sec.file_off  = file_off;
+        lay.pdata_sec.file_size = align_up(pdata_vsize, PE_FILE_ALIGN::usize);
+        lay.exception_rva       = rva;
+        lay.exception_size      = pdata_vsize::u64;
+        file_off = file_off + lay.pdata_sec.file_size;
+        rva = rva + align_up_u64(lay.pdata_sec.vsize, PE_SECTION_ALIGN);
+    }
+
     lay.image_size = align_up_u64(rva, PE_SECTION_ALIGN);
     ret file_off;
 }
@@ -1548,8 +1787,9 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
 # path:      null-terminated output file path
 # ret:       ok(true) on success, or an error string
 fun coff_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
-                   seg_count: u32, entry: u64, path: *u8) Result[bool, str] {
-    ret write_pe(alloc, isa_vt, segs, seg_count, entry, nil, nil, 0, path);
+                   seg_count: u32, entry: u64, funcs: *of.ExecFunction,
+                   func_count: u32, path: *u8) Result[bool, str] {
+    ret write_pe(alloc, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, path);
 }
 
 # coff_emit_dyn_exec: serialize laid-out load segments into a dynamically-linked
@@ -1571,9 +1811,10 @@ fun coff_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegm
 # path:        null-terminated output file path
 # ret:         ok(true) on success, or an error string
 fun coff_emit_dyn_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
-                       seg_count: u32, entry: u64, dyn: *of.DynamicInfo,
+                       seg_count: u32, entry: u64, funcs: *of.ExecFunction,
+                       func_count: u32, dyn: *of.DynamicInfo,
                        fixups: *of.PltFixup, fixup_count: u32, path: *u8) Result[bool, str] {
-    ret write_pe(alloc, isa_vt, segs, seg_count, entry, dyn, fixups, fixup_count, path);
+    ret write_pe(alloc, isa_vt, segs, seg_count, entry, funcs, func_count, dyn, fixups, fixup_count, path);
 }
 
 # write_pe: the shared PE32+ executable writer behind `coff_emit_exec` (static)
@@ -1584,7 +1825,8 @@ fun coff_emit_dyn_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.Load
 # data directories), the section table, and every section's bytes. each `PltFixup`
 # call site is redirected to its import stub.
 fun write_pe(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
-             seg_count: u32, entry: u64, dyn: *of.DynamicInfo,
+             seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
+             dyn: *of.DynamicInfo,
              fixups: *of.PltFixup, fixup_count: u32, path: *u8) Result[bool, str] {
     if (isa_vt == nil) { ret err[bool, str]("coff: nil exec isa"); }
     if (path == nil)   { ret err[bool, str]("coff: nil exec path"); }
@@ -1598,8 +1840,28 @@ fun write_pe(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
     if (is_err[*PeSection, str](ssr)) { ret err[bool, str]("coff: segment layout alloc failed"); }
     seg_secs = unwrap_ok[*PeSection, str](ssr);
 
+    var uw_all: *FunctionUnwind = nil;
+    var uw_count: u32 = 0;
+    var xdata_vsize: usize = 0;
+    var pdata_vsize: usize = 0;
+    if (func_count > 0 && funcs != nil) {
+        val ur: Result[*FunctionUnwind, str] = zallocate[FunctionUnwind](alloc, func_count::usize);
+        if (is_err[*FunctionUnwind, str](ur)) {
+            deallocate[PeSection](alloc, seg_secs, seg_count::usize);
+            ret err[bool, str]("coff: unwind table alloc failed");
+        }
+        uw_all = unwrap_ok[*FunctionUnwind, str](ur);
+        uw_count = collect_function_unwind(segs, funcs, func_count, uw_all);
+        var ui: u32 = 0;
+        for (ui < uw_count) {
+            xdata_vsize = xdata_vsize + uw_all[ui].xdata_size;
+            ui = ui + 1;
+        }
+        pdata_vsize = uw_count::usize * RUNTIME_FUNCTION_SIZE;
+    }
+
     var lay: PeLayout;
-    val total_size: usize = compute_pe_layout(?lay, segs, seg_count, dyn, seg_secs);
+    val total_size: usize = compute_pe_layout(?lay, segs, seg_count, dyn, seg_secs, xdata_vsize, pdata_vsize);
 
     val res_buf: Result[*u8, str] = zallocate[u8](alloc, total_size);
     if (is_err[*u8, str](res_buf)) {
@@ -1621,6 +1883,7 @@ fun write_pe(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
     # jump through the IAT slots the import section owns.
     if (lay.have_idata) { write_pe_imports(buf, ?lay, dyn); }
     if (lay.have_stub)  { write_pe_stubs(buf, ?lay, dyn); }
+    if (lay.have_xdata || lay.have_pdata) { write_pe_unwind(buf, ?lay, uw_all, uw_count); }
 
     # redirect each import call site to its stub (a non-import call site never
     # reaches here — the linker only records fixups for function imports).
@@ -1628,6 +1891,7 @@ fun write_pe(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
     if (is_err[bool, str](fx_r)) {
         deallocate[u8](alloc, buf, total_size);
         deallocate[PeSection](alloc, seg_secs, seg_count::usize);
+        if (uw_all != nil && func_count > 0) { deallocate[FunctionUnwind](alloc, uw_all, func_count::usize); }
         ret err[bool, str](unwrap_err[bool, str](fx_r));
     }
 
@@ -1635,6 +1899,7 @@ fun write_pe(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
     write_pe_headers(buf, ?lay, segs, seg_count, entry);
 
     deallocate[PeSection](alloc, seg_secs, seg_count::usize);
+    if (uw_all != nil && func_count > 0) { deallocate[FunctionUnwind](alloc, uw_all, func_count::usize); }
 
     val res_file: Result[fs.File, str] = fs.create(path, 0o755);
     if (is_err[fs.File, str](res_file)) {
@@ -1813,6 +2078,76 @@ fun write_pe_stubs(buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo) {
     }
 }
 
+fun write_unwind_xdata(buf: *u8, lay: *PeLayout, uw: *FunctionUnwind) {
+    val xoff: usize = lay.xdata_sec.file_off + (uw.xdata_rva - lay.xdata_sec.rva)::usize;
+    buf[xoff] = UNWIND_VERSION;
+    buf[xoff + 1] = uw.prolog_size;
+    buf[xoff + 2] = uw.slot_count::u8;
+    buf[xoff + 3] = 0;  # no frame reg, no exception handler chain
+
+    var used: [16]bool;
+    var i: usize = 0;
+    for (i < 16) { used[i] = false; i = i + 1; }
+
+    var slots_written: usize = 0;
+    var codes_written: u32 = 0;
+    for (codes_written < uw.code_count) {
+        var best: i32 = -1;
+        var best_off: u8 = 0;
+        var ci: u32 = 0;
+        for (ci < uw.code_count) {
+            if (!used[ci::usize]
+                && (best < 0 || uw.codes[ci].end_off > best_off)) {
+                best = ci::i32;
+                best_off = uw.codes[ci].end_off;
+            }
+            ci = ci + 1;
+        }
+        if (best < 0) { brk; }
+        val c: *UnwindCode = ?uw.codes[best::u32];
+        val slot_off: usize = xoff + 4 + slots_written * 2;
+        buf[slot_off] = c.end_off;
+        buf[slot_off + 1] = c.op | (c.info << 4);
+        slots_written = slots_written + 1;
+        if (c.extra_slots >= 1) {
+            write_u16_le(buf, xoff + 4 + slots_written * 2, c.extra0);
+            slots_written = slots_written + 1;
+        }
+        if (c.extra_slots >= 2) {
+            write_u16_le(buf, xoff + 4 + slots_written * 2, c.extra1);
+            slots_written = slots_written + 1;
+        }
+        used[best::usize] = true;
+        codes_written = codes_written + 1;
+    }
+}
+
+fun write_pe_unwind(buf: *u8, lay: *PeLayout, uws: *FunctionUnwind, uw_count: u32) {
+    if (uw_count == 0 || uws == nil) { ret; }
+    if (!lay.have_xdata || !lay.have_pdata) { ret; }
+
+    var xcur: usize = 0;
+    var i: u32 = 0;
+    for (i < uw_count) {
+        uws[i].xdata_rva = lay.xdata_sec.rva + xcur::u64;
+        write_unwind_xdata(buf, lay, ?uws[i]);
+        xcur = xcur + uws[i].xdata_size;
+        i = i + 1;
+    }
+
+    i = 0;
+    for (i < uw_count) {
+        val poff: usize = lay.pdata_sec.file_off + i::usize * RUNTIME_FUNCTION_SIZE;
+        val seg_rva: u64 = lay.seg_secs[uws[i].seg_index].rva;
+        val begin_rva: u32 = (seg_rva + uws[i].seg_offset::u64)::u32;
+        val end_rva: u32 = begin_rva + uws[i].size;
+        write_u32_le(buf, poff, begin_rva);
+        write_u32_le(buf, poff + 4, end_rva);
+        write_u32_le(buf, poff + 8, uws[i].xdata_rva::u32);
+        i = i + 1;
+    }
+}
+
 # patch_pe_fixups: rewrite each import call site (a `PltFixup` the linker could not
 # resolve) to a pc-relative call to the import's stub. the fixup records the
 # segment + offset of the 4-byte displacement field and the patch-site vaddr; the
@@ -1957,10 +2292,11 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
         write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IAT::usize * DATA_DIR_SIZE, lay.iat_rva::u32);
         write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IAT::usize * DATA_DIR_SIZE + 4, lay.iat_size::u32);
     }
-    # no EXCEPTION directory: the .pdata/.xdata unwind tables are not emitted (the
-    # back end does not yet produce per-function prologue unwind codes), so real
-    # Windows treats these frames as leaf functions rather than unwinding with
-    # wrong metadata. see the follow-up issue for proper per-function unwind.
+    # EXCEPTION directory (index 3) — the RUNTIME_FUNCTION table in .pdata.
+    if (lay.have_pdata) {
+        write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE, lay.exception_rva::u32);
+        write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE + 4, lay.exception_size::u32);
+    }
 
     # the section table follows the optional header.
     var pos: usize = oh + OPTIONAL_HEADER_SIZE;
@@ -1981,6 +2317,16 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
     if (lay.have_idata) {
         write_pe_section_header(buf, pos, ".idata", ?lay.idata_sec,
             IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE);
+        pos = pos + SECTION_HEADER_SIZE;
+    }
+    if (lay.have_xdata) {
+        write_pe_section_header(buf, pos, ".xdata", ?lay.xdata_sec,
+            IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ);
+        pos = pos + SECTION_HEADER_SIZE;
+    }
+    if (lay.have_pdata) {
+        write_pe_section_header(buf, pos, ".pdata", ?lay.pdata_sec,
+            IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ);
         pos = pos + SECTION_HEADER_SIZE;
     }
 }
@@ -2484,7 +2830,7 @@ test "coff: emit_exec writes a well-formed PE32+ header" {
     if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
     var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
 
-    val em: Result[bool, str] = coff_emit_exec(?alloc, ?isa_vt, ?segs[0], 2, entry, fs.temp_path(?tf)::*u8);
+    val em: Result[bool, str] = coff_emit_exec(?alloc, ?isa_vt, ?segs[0], 2, entry, nil, 0, fs.temp_path(?tf)::*u8);
     if (is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: Result[fs.Buffer, str] = fs.read_all_sized(?alloc, fs.temp_path(?tf));
@@ -2514,6 +2860,166 @@ test "coff: emit_exec writes a well-formed PE32+ header" {
     val image_base: u64 = read_u64_le(buf.data, oh + 24);
     val entry_rva:  u32 = read_u32_le(buf.data, oh + 16);
     if (image_base + entry_rva::u64 != entry) { ret 1; }
+
+    ret 0;
+}
+
+test "coff: parse infers function imports from call relocations" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
+    if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
+    val vt: *of.OfVTable = unwrap[*of.OfVTable](vt_o);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    # a tiny text body with one call-site relocation targeting an undefined extern.
+    var text_bytes: [8]u8;
+    text_bytes[0] = 0xE8;  # call rel32
+    text_bytes[1] = 0; text_bytes[2] = 0; text_bytes[3] = 0; text_bytes[4] = 0;
+    text_bytes[5] = 0x90; text_bytes[6] = 0x90; text_bytes[7] = 0xC3;
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 8; secs[0].align = 16;
+
+    var syms: [2]of.Symbol;
+    syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 8; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    syms[1].name = t_intern(?i, "GetCommandLineA"); syms[1].section = of.SECTION_EXTERNAL;
+    syms[1].offset = 0; syms[1].size = 0;
+    # intentionally omit FUNCTION to emulate toolchains that encode undefined
+    # import type as 0; parser must recover function intent from the call reloc.
+    syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN;
+
+    val k_pc32: intern.StrId = of.reloc_kind_name(vt, of.RK_PC32);
+    var relocs: [1]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = k_pc32;
+    relocs[0].symbol = syms[1].name; relocs[0].addend = -4;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 2;
+    img.relocations = ?relocs[0]; img.reloc_count = 1;
+
+    val tf_r: Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_ifn");
+    if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
+
+    val em: Result[bool, str] = coff_emit_object(?isa_vt, ?img, fs.temp_path(?tf)::*u8);
+    if (is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: Result[fs.Buffer, str] = fs.read_all_sized(?alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (is_err[fs.Buffer, str](rb)) { ret 1; }
+    val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
+
+    var out: of.ObjectImage;
+    val pr: Result[bool, str] = coff_parse_object(?alloc, buf.data, buf.len, ?out);
+    if (is_err[bool, str](pr)) { ret 1; }
+
+    var saw: bool = false;
+    var si: u32 = 0;
+    for (si < out.symbol_count) {
+        if (out.symbols[si].name == syms[1].name) {
+            saw = true;
+            if ((out.symbols[si].flags & of.SYM_OBJ_FLAG_EXTERN) == 0) { ret 1; }
+            if ((out.symbols[si].flags & of.SYM_OBJ_FLAG_FUNCTION) == 0) { ret 1; }
+        }
+        si = si + 1;
+    }
+    if (!saw) { ret 1; }
+
+    ret 0;
+}
+
+test "coff: emit_exec emits .xdata/.pdata for a canonical x64 prologue" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    # push rbp; mov rbp,rsp; sub rsp,0x20; mov [rbp-8],rbx; nop; ret
+    var text_bytes: [14]u8;
+    text_bytes[0] = 0x55;
+    text_bytes[1] = 0x48; text_bytes[2] = 0x89; text_bytes[3] = 0xE5;
+    text_bytes[4] = 0x48; text_bytes[5] = 0x83; text_bytes[6] = 0xEC; text_bytes[7] = 0x20;
+    text_bytes[8] = 0x48; text_bytes[9] = 0x89; text_bytes[10] = 0x5D; text_bytes[11] = 0xF8;
+    text_bytes[12] = 0x90;
+    text_bytes[13] = 0xC3;
+
+    val base:  u64 = 0x140000000;
+    val entry: u64 = base;
+
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = base; segs[0].filesz = 14; segs[0].memsz = 14;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
+
+    var funcs: [1]of.ExecFunction;
+    funcs[0].seg_index = 0;
+    funcs[0].seg_offset = 0;
+    funcs[0].size = 14;
+
+    val tf_r: Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_unw");
+    if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
+
+    val em: Result[bool, str] = coff_emit_exec(?alloc, ?isa_vt, ?segs[0], 1, entry, ?funcs[0], 1, fs.temp_path(?tf)::*u8);
+    if (is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: Result[fs.Buffer, str] = fs.read_all_sized(?alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (is_err[fs.Buffer, str](rb)) { ret 1; }
+    val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
+
+    val pe_off: usize = read_u32_le(buf.data, 0x3C)::usize;
+    val ch: usize = pe_off + PE_SIGNATURE_SIZE;
+    if (read_u16_le(buf.data, ch + 2) != 3) { ret 1; }  # .text + .xdata + .pdata
+
+    val oh: usize = ch + COFF_HEADER_SIZE;
+    val dd: usize = oh + 112;
+    val exc_rva: u32 = read_u32_le(buf.data, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE);
+    val exc_size: u32 = read_u32_le(buf.data, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE + 4);
+    if (exc_rva == 0 || exc_size != RUNTIME_FUNCTION_SIZE::u32) { ret 1; }
+
+    var xdata_rva: u32 = 0;
+    var pdata_ptr: u32 = 0;
+    var si: u32 = 0;
+    var sh: usize = oh + OPTIONAL_HEADER_SIZE;
+    for (si < 3) {
+        if (buf.data[sh] == '.' && buf.data[sh + 1] == 'x'
+            && buf.data[sh + 2] == 'd' && buf.data[sh + 3] == 'a'
+            && buf.data[sh + 4] == 't' && buf.data[sh + 5] == 'a') {
+            xdata_rva = read_u32_le(buf.data, sh + 12);
+        }
+        if (buf.data[sh] == '.' && buf.data[sh + 1] == 'p'
+            && buf.data[sh + 2] == 'd' && buf.data[sh + 3] == 'a'
+            && buf.data[sh + 4] == 't' && buf.data[sh + 5] == 'a') {
+            pdata_ptr = read_u32_le(buf.data, sh + 20);
+        }
+        sh = sh + SECTION_HEADER_SIZE;
+        si = si + 1;
+    }
+    if (xdata_rva == 0 || pdata_ptr == 0) { ret 1; }
+
+    val begin_rva: u32 = read_u32_le(buf.data, pdata_ptr::usize);
+    val end_rva: u32 = read_u32_le(buf.data, pdata_ptr::usize + 4);
+    val unwind_rva: u32 = read_u32_le(buf.data, pdata_ptr::usize + 8);
+    if (begin_rva == 0 || end_rva <= begin_rva) { ret 1; }
+    if (unwind_rva < xdata_rva) { ret 1; }
 
     ret 0;
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1523,6 +1523,12 @@ fun push_save_nonvol(uw: *FunctionUnwind, end_off: u8, reg: u8, save_off: usize)
                          (save_off & 0xFFFF)::u16, ((save_off >> 16) & 0xFFFF)::u16, 2);
 }
 
+fun is_win64_nonvol_reg(reg: u8) bool {
+    if (reg == 3 || reg == 5 || reg == 6 || reg == 7) { ret true; }  # RBX/RBP/RSI/RDI
+    if (reg >= 12 && reg <= 15) { ret true; }  # R12-R15
+    ret false;
+}
+
 fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment,
                           funcs: *of.ExecFunction, idx: u32) bool {
     uw.seg_index = funcs[idx].seg_index;
@@ -1607,6 +1613,7 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment,
         val save_off: usize = alloc - off_rbp;
         var reg: u8 = ((modrm >> 3) & 7);
         if ((rex & 4) != 0) { reg = reg + 8; }
+        if (!is_win64_nonvol_reg(reg)) { ret false; }
         if (!push_save_nonvol(uw, (cur + inst_len)::u8, reg, save_off)) { ret false; }
         pos = cur + inst_len;
     }
@@ -1866,6 +1873,7 @@ fun write_pe(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
     val res_buf: Result[*u8, str] = zallocate[u8](alloc, total_size);
     if (is_err[*u8, str](res_buf)) {
         deallocate[PeSection](alloc, seg_secs, seg_count::usize);
+        if (uw_all != nil && func_count > 0) { deallocate[FunctionUnwind](alloc, uw_all, func_count::usize); }
         ret err[bool, str]("coff: PE buffer alloc failed");
     }
     var buf: *u8 = unwrap_ok[*u8, str](res_buf);

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1515,13 +1515,13 @@ fun push_alloc_code(uw: *FunctionUnwind, end_off: u8, alloc: usize) bool {
 
 fun push_save_nonvol(uw: *FunctionUnwind, end_off: u8, reg: u8, save_off: usize) bool {
     if ((save_off & 7) != 0) { ret false; }
-    val scaled: u32 = (save_off / 8)::u32;
+    val scaled: u64 = (save_off / 8)::u64;
     if (scaled <= 0xFFFF) {
         ret push_unwind_code(uw, end_off, UWOP_SAVE_NONVOL, reg, scaled::u16, 0, 1);
     }
-    if (save_off > 0xFFFFFFFF::usize) { ret false; }
+    if (scaled > 0xFFFFFFFF::u64) { ret false; }
     ret push_unwind_code(uw, end_off, UWOP_SAVE_NONVOL_FAR, reg,
-                         (save_off & 0xFFFF)::u16, ((save_off >> 16) & 0xFFFF)::u16, 2);
+                         (scaled & 0xFFFF)::u16, ((scaled >> 16) & 0xFFFF)::u16, 2);
 }
 
 fun is_win64_nonvol_reg(reg: u8) bool {

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1344,6 +1344,13 @@ fun infer_extern_function_flags_from_calls(out: *of.ObjectImage) {
         val r: *of.Relocation = ?out.relocations[ri];
         if (r.symbol == intern.STR_NIL) { ri = ri + 1; cnt; }
         if (r.kind != rk_pc32 && r.kind != rk_plt32) { ri = ri + 1; cnt; }
+        if (r.section >= out.section_count) { ri = ri + 1; cnt; }
+        val sec: *of.Section = ?out.sections[r.section];
+        if (sec.bytes == nil || r.offset == 0) { ri = ri + 1; cnt; }
+        if (r.offset::usize + 4 > sec.len::usize) { ri = ri + 1; cnt; }
+        val op: u8 = sec.bytes[r.offset::usize - 1];
+        if (op != 0xE8 && op != 0xE9) { ri = ri + 1; cnt; }
+
         var si: u32 = 0;
         for (si < out.symbol_count) {
             val sym: *of.Symbol = ?out.symbols[si];

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -827,7 +827,8 @@ fun pf_flags_for(flags: u32) u32 {
 # path:      null-terminated output file path
 # ret:       ok(true) on success, or an error string
 fun emit_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
-              seg_count: u32, entry: u64, path: *u8) Result[bool, str] {
+              seg_count: u32, entry: u64, funcs: *of.ExecFunction,
+              func_count: u32, path: *u8) Result[bool, str] {
     if (tgt_isa == nil) { ret err[bool, str]("elf: nil exec isa"); }
     if (path == nil) { ret err[bool, str]("elf: nil exec path"); }
 
@@ -1012,8 +1013,9 @@ fun dynstr_name_len(id: intern.StrId) usize {
 # path:        null-terminated output file path
 # ret:         ok(true) on success, or an error string
 fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
-                  seg_count: u32, entry: u64, dyn: *of.DynamicInfo,
-                  fixups: *of.PltFixup, fixup_count: u32, path: *u8) Result[bool, str] {
+                  seg_count: u32, entry: u64, funcs: *of.ExecFunction,
+                  func_count: u32, dyn: *of.DynamicInfo, fixups: *of.PltFixup,
+                  fixup_count: u32, path: *u8) Result[bool, str] {
     if (tgt_isa == nil) { ret err[bool, str]("elf: nil dyn-exec isa"); }
     if (path == nil)    { ret err[bool, str]("elf: nil dyn-exec path"); }
     if (dyn == nil)     { ret err[bool, str]("elf: nil dynamic plan"); }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -819,13 +819,15 @@ fun pf_flags_for(flags: u32) u32 {
 # address before calling this. each segment's file offset is page-aligned so
 # `offset % page == vaddr % page` holds for the loader.
 # ---
-# alloc:     allocator for the output buffer and the segment-offset scratch
-# tgt_isa:   the instruction-set vtable selecting the ELF machine type
-# segs:      loadable segments, in ascending virtual-address order
-# seg_count: number of segments
-# entry:     program entry-point virtual address
-# path:      null-terminated output file path
-# ret:       ok(true) on success, or an error string
+# alloc:      allocator for the output buffer and the segment-offset scratch
+# tgt_isa:    the instruction-set vtable selecting the ELF machine type
+# segs:       loadable segments, in ascending virtual-address order
+# seg_count:  number of segments
+# entry:      program entry-point virtual address
+# funcs:      per-function metadata for unwind-table emission
+# func_count: number of entries in funcs
+# path:       null-terminated output file path
+# ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, entry: u64, funcs: *of.ExecFunction,
               func_count: u32, path: *u8) Result[bool, str] {
@@ -1007,6 +1009,8 @@ fun dynstr_name_len(id: intern.StrId) usize {
 # segs:        the linker's loadable segments, ascending virtual-address order
 # seg_count:   number of segments
 # entry:       program entry-point virtual address
+# funcs:       per-function metadata for unwind-table emission
+# func_count:  number of entries in funcs
 # dyn:         the dynamic-link plan (dependencies, imports, interpreter path)
 # fixups:      import call-site fixups to redirect to PLT stubs
 # fixup_count: number of fixups

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -68,13 +68,15 @@ fun macho_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Ob
 # unsupported-target error so no malformed executable is written. matches the
 # of.ExecFn signature exactly.
 # ---
-# alloc:     allocator for the output buffer
-# isa_vt:    the instruction-set vtable describing the machine
-# segs:      the loadable segments
-# seg_count: number of load segments
-# entry:     program entry-point virtual address
-# path:      null-terminated output file path
-# ret:       the unsupported-target error
+# alloc:      allocator for the output buffer
+# isa_vt:     the instruction-set vtable describing the machine
+# segs:       the loadable segments
+# seg_count:  number of load segments
+# entry:      program entry-point virtual address
+# funcs:      per-function metadata for unwind-table emission
+# func_count: number of entries in funcs
+# path:       null-terminated output file path
+# ret:        the unsupported-target error
 fun macho_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                     seg_count: u32, entry: u64, funcs: *of.ExecFunction,
                     func_count: u32, path: *u8) Result[bool, str] {

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -76,7 +76,8 @@ fun macho_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Ob
 # path:      null-terminated output file path
 # ret:       the unsupported-target error
 fun macho_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
-                    seg_count: u32, entry: u64, path: *u8) Result[bool, str] {
+                    seg_count: u32, entry: u64, funcs: *of.ExecFunction,
+                    func_count: u32, path: *u8) Result[bool, str] {
     ret err[bool, str](MACHO_UNSUPPORTED);
 }
 


### PR DESCRIPTION
## Summary
- recover COFF imported function flags for undefined externs referenced by call relocations
- add regression coverage for import discovery from call relocations
- guard UWOP_SAVE_NONVOL emission to non-volatile Win64 registers only

## Validation
- mach build .
- mach build . --target windows
- mach test .

Refs #1211
