### PR TITLE
ci(release): refuse a tag that does not match the mach.toml version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,14 @@ jobs:
         with:
           submodules: true
 
+      - name: Verify the tag matches the source version
+        run: |
+          ver="$(sed -n 's/^version = "\(.*\)"$/\1/p' mach.toml | head -1)"
+          if [ "v$ver" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match mach.toml version $ver — tagged the wrong commit?"
+            exit 1
+          fi
+
       - name: Fetch seed compiler (most recent release)
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Closes #1233 (remediation already applied; this is the prevention half).

The v1.1.0 release was tagged at main's stale tip `d5799e1c` (v1.0.0 content) because the dev→main merge was skipped, and release.yml — which checks out the tag — built and published a byte-identical copy of the v1.0.0 binary under the v1.1.0 name, with the wrong source tree behind the tag. Remediation already done directly on the release: the tag now points at `6d3271bd` (dev's tip at publish, the only commit with pure v1.1.0 content) and the retriggered workflow replaced the binary (verified: differs from both v1.0.0 and v1.1.1, fixpoint check passed).

This PR adds the guard that turns a repeat into a hard failure: before fetching the seed compiler, assert `v<mach.toml version> == $GITHUB_REF_NAME`. The v1.1.0 mistake would have failed immediately (`tag v1.1.0 does not match mach.toml version 1.0.0`).