### PR TITLE
fix(coff): correct per-function win64 unwind .xdata and drop merge artifacts

### DIFF
--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1423,6 +1423,8 @@ rec PeLayout {
     sec_total:   u32;
 }
 
+# UnwindCode: one decoded x64 unwind operation — its prologue end offset, the
+# opcode and operation-info nibble, and up to two extra u16 operand slots.
 rec UnwindCode {
     end_off:     u8;
     op:          u8;
@@ -1432,6 +1434,9 @@ rec UnwindCode {
     extra_slots: u8;
 }
 
+# FunctionUnwind: the parsed unwind description of one function — its location,
+# prologue size, frame declaration, and the unwind-code array that drives the
+# .xdata/.pdata emission.
 rec FunctionUnwind {
     seg_index:   u32;
     seg_offset:  u32;
@@ -1496,6 +1501,8 @@ fun import_dir_bytes(dyn: *of.DynamicInfo) usize {
     ret (dyn.lib_count + 1)::usize * IMPORT_DESCRIPTOR_SIZE;
 }
 
+# push_unwind_code: append one unwind code (with up to two extra operand slots)
+# to a function's code array, tracking the running slot count; false when full.
 fun push_unwind_code(uw: *FunctionUnwind, end_off: u8, op: u8, info: u8,
                      extra0: u16, extra1: u16, extra_slots: u8) bool {
     if (uw.code_count >= 16) { ret false; }
@@ -1510,6 +1517,9 @@ fun push_unwind_code(uw: *FunctionUnwind, end_off: u8, op: u8, info: u8,
     ret true;
 }
 
+# push_alloc_code: append the unwind code(s) for a prologue stack allocation of
+# `alloc` bytes — ALLOC_SMALL, or ALLOC_LARGE with a scaled (info 0) or unscaled
+# (info 1) size.
 fun push_alloc_code(uw: *FunctionUnwind, end_off: u8, alloc: usize) bool {
     if (alloc == 0) { ret true; }
     if ((alloc & 7) != 0) { ret false; }
@@ -1524,23 +1534,32 @@ fun push_alloc_code(uw: *FunctionUnwind, end_off: u8, alloc: usize) bool {
                          (alloc & 0xFFFF)::u16, ((alloc >> 16) & 0xFFFF)::u16, 2);
 }
 
+# push_save_nonvol: append the unwind code for a `mov [frame-off], reg` nonvolatile
+# save — SAVE_NONVOL with the scaled-by-8 offset, or SAVE_NONVOL_FAR with the
+# unscaled byte offset when that scaled value exceeds 16 bits.
 fun push_save_nonvol(uw: *FunctionUnwind, end_off: u8, reg: u8, save_off: usize) bool {
     if ((save_off & 7) != 0) { ret false; }
     val scaled: u64 = (save_off / 8)::u64;
     if (scaled <= 0xFFFF) {
         ret push_unwind_code(uw, end_off, UWOP_SAVE_NONVOL, reg, scaled::u16, 0, 1);
     }
-    if (scaled > 0xFFFFFFFF::u64) { ret false; }
+    if (save_off > 0xFFFFFFFF::usize) { ret false; }
+    # the far form records the UNSCALED byte offset in two slots (cf. ALLOC_LARGE info=1).
     ret push_unwind_code(uw, end_off, UWOP_SAVE_NONVOL_FAR, reg,
-                         (scaled & 0xFFFF)::u16, ((scaled >> 16) & 0xFFFF)::u16, 2);
+                         (save_off & 0xFFFF)::u16, ((save_off >> 16) & 0xFFFF)::u16, 2);
 }
 
+# is_win64_nonvol_reg: whether a register number is callee-saved under the win64
+# ABI (RBX, RBP, RSI, RDI, R12–R15).
 fun is_win64_nonvol_reg(reg: u8) bool {
     if (reg == 3 || reg == 5 || reg == 6 || reg == 7) { ret true; }  # RBX/RBP/RSI/RDI
     if (reg >= 12 && reg <= 15) { ret true; }  # R12-R15
     ret false;
 }
 
+# parse_function_unwind: decode one emitted function's canonical prologue
+# (push rbp; mov rbp,rsp; sub rsp,N; nonvolatile saves) into x64 unwind codes;
+# false when the bytes are not the recognized fixed-frame shape.
 fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count: u32,
                           funcs: *of.ExecFunction, idx: u32) bool {
     uw.seg_index = funcs[idx].seg_index;
@@ -1575,9 +1594,10 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count:
         ret false;
     }
     pos = pos + 3;
-    if (!push_unwind_code(uw, pos::u8, UWOP_SET_FPREG, 0, 0, 0, 0)) { ret false; }
-    uw.frame_reg = UWREG_RBP;
-    uw.frame_off = 0;
+    # no frame register is declared: this prologue leaves RSP fixed for the whole
+    # body, so RtlVirtualUnwind takes RSP as the offset base and the RSP-relative
+    # save offsets below stay valid. `mov rbp,rsp` needs no unwind code — RBP is
+    # restored by the UWOP_PUSH_NONVOL above. frame_reg/frame_off stay 0.
 
     var alloc: usize = 0;
     if (pos + 4 <= lim
@@ -1610,7 +1630,9 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count:
         if ((rex & 8) == 0) { brk; }
         val modrm: u8 = seg.bytes[base + cur + 1];
         val mod: u8 = modrm >> 6;
-        if ((modrm & 7) != 5 || (mod != 1 && mod != 2)) { brk; }
+        # rm==5 with mod 1|2 is [rbp+disp] only when REX.B is clear; with REX.B set
+        # it addresses [r13+disp], so a body `mov [r13+disp], r64` is not a save.
+        if ((modrm & 7) != 5 || (mod != 1 && mod != 2) || (rex & 1) != 0) { brk; }
 
         var disp: i64 = 0;
         var inst_len: usize = 0;
@@ -1643,6 +1665,8 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count:
     ret true;
 }
 
+# collect_function_unwind: parse every emitted function into `out`, returning the
+# count whose prologue matched and that carry unwind data.
 fun collect_function_unwind(segs: *of.LoadSegment, seg_count: u32, funcs: *of.ExecFunction,
                             func_count: u32, out: *FunctionUnwind) u32 {
     var n: u32 = 0;
@@ -2109,6 +2133,9 @@ fun write_pe_stubs(buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo) {
     }
 }
 
+# write_unwind_xdata: write one function's UNWIND_INFO record into .xdata — the
+# header (version/flags, prolog size, slot count, frame nibble) followed by its
+# unwind codes in descending prologue-offset order.
 fun write_unwind_xdata(buf: *u8, lay: *PeLayout, uw: *FunctionUnwind) {
     val xoff: usize = lay.xdata_sec.file_off + (uw.xdata_rva - lay.xdata_sec.rva)::usize;
     buf[xoff] = UNWIND_VERSION;
@@ -3056,18 +3083,73 @@ test "coff: emit_exec emits .xdata/.pdata for a canonical x64 prologue" {
     if (begin_rva == 0 || end_rva <= begin_rva) { ret 1; }
     if (unwind_rva < xdata_rva) { ret 1; }
     val uw_ptr: usize = xdata_ptr::usize + (unwind_rva - xdata_rva)::usize;
-    if ((buf.data[uw_ptr] & 0x7) != UNWIND_VERSION) { ret 1; }
-    if ((buf.data[uw_ptr + 3] & 0x0F) != UWREG_RBP) { ret 1; }
 
-    var saw_set_fpreg: bool = false;
-    val slot_count: usize = buf.data[uw_ptr + 2]::usize;
-    var slot_i: usize = 0;
-    for (slot_i < slot_count) {
-        val op: u8 = buf.data[uw_ptr + 4 + slot_i * 2 + 1] & 0x0F;
-        if (op == UWOP_SET_FPREG) { saw_set_fpreg = true; }
-        slot_i = slot_i + 1;
+    # the full UNWIND_INFO image for `push rbp; mov rbp,rsp; sub rsp,0x20; mov [rbp-8],rbx`.
+    # this is a fixed-RSP frame: no frame register is declared (byte 3 == 0), so the
+    # SAVE_NONVOL offset is RSP-relative — (0x20 - 8) / 8 = 3. wine ignores .xdata, so
+    # these byte assertions are the only verification of unwind correctness.
+    if (buf.data[uw_ptr + 0] != 0x01) { ret 1; }  # version 1, flags 0
+    if (buf.data[uw_ptr + 1] != 0x0C) { ret 1; }  # size of prolog = 12
+    if (buf.data[uw_ptr + 2] != 0x04) { ret 1; }  # 4 unwind slots
+    if (buf.data[uw_ptr + 3] != 0x00) { ret 1; }  # frame_reg = 0, frame_off = 0
+    # codes are written in descending prologue-offset order. each op byte is
+    # op | (info << 4): SAVE_NONVOL(4)|rbx(3)=0x34, ALLOC_SMALL(2)|3=0x32, PUSH(0)|rbp(5)=0x50.
+    if (buf.data[uw_ptr + 4] != 0x0C) { ret 1; }             # SAVE_NONVOL end_off = 12
+    if (buf.data[uw_ptr + 5] != 0x34) { ret 1; }             # op 4 (SAVE_NONVOL), info 3 (rbx)
+    if (read_u16_le(buf.data, uw_ptr + 6) != 3) { ret 1; }   # scaled offset (0x18 / 8)
+    if (buf.data[uw_ptr + 8] != 0x08) { ret 1; }             # ALLOC_SMALL end_off = 8
+    if (buf.data[uw_ptr + 9] != 0x32) { ret 1; }             # op 2 (ALLOC_SMALL), info 3 ((0x20-8)/8)
+    if (buf.data[uw_ptr + 10] != 0x01) { ret 1; }            # PUSH_NONVOL end_off = 1
+    if (buf.data[uw_ptr + 11] != 0x50) { ret 1; }            # op 0 (PUSH_NONVOL), info 5 (rbp)
+
+    ret 0;
+}
+
+test "coff: push_save_nonvol writes the unscaled offset in the SAVE_NONVOL_FAR form" {
+    var uw: FunctionUnwind;
+    uw.code_count = 0;
+    uw.slot_count = 0;
+    # 0x88888 / 8 = 0x11111 exceeds the 16-bit scaled field, forcing the far form.
+    val off: usize = 0x88888;
+    if (!push_save_nonvol(?uw, 0, 12, off)) { ret 1; }  # r12
+    if (uw.code_count != 1) { ret 1; }
+    val c: *UnwindCode = ?uw.codes[0];
+    if (c.op != UWOP_SAVE_NONVOL_FAR) { ret 1; }
+    if (c.info != 12) { ret 1; }
+    if (c.extra_slots != 2) { ret 1; }
+    # the two slots carry the UNSCALED byte offset (0x8888, 0x0008), never the scaled 0x11111.
+    if (c.extra0 != (off & 0xFFFF)::u16) { ret 1; }
+    if (c.extra1 != ((off >> 16) & 0xFFFF)::u16) { ret 1; }
+    val scaled: usize = off / 8;
+    if (c.extra0 == (scaled & 0xFFFF)::u16 && c.extra1 == ((scaled >> 16) & 0xFFFF)::u16) { ret 1; }
+    ret 0;
+}
+
+test "coff: parse_function_unwind rejects an [r13+disp] store as a save (REX.B)" {
+    # push rbp; mov rbp,rsp; sub rsp,0x20; mov [r13-8],r12; ret
+    var text_bytes: [13]u8;
+    text_bytes[0] = 0x55;
+    text_bytes[1] = 0x48; text_bytes[2] = 0x89; text_bytes[3] = 0xE5;
+    text_bytes[4] = 0x48; text_bytes[5] = 0x83; text_bytes[6] = 0xEC; text_bytes[7] = 0x20;
+    text_bytes[8] = 0x4D; text_bytes[9] = 0x89; text_bytes[10] = 0x65; text_bytes[11] = 0xF8;
+    text_bytes[12] = 0xC3;
+
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = 0x140000000; segs[0].filesz = 13; segs[0].memsz = 13;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
+
+    var funcs: [1]of.ExecFunction;
+    funcs[0].seg_index = 0; funcs[0].seg_offset = 0; funcs[0].size = 13;
+
+    var uw: FunctionUnwind;
+    if (!parse_function_unwind(?uw, ?segs[0], 1, ?funcs[0], 0)) { ret 1; }
+    # only PUSH_NONVOL + ALLOC_SMALL — the [r13-8] store must not become a save.
+    if (uw.code_count != 2) { ret 1; }
+    var k: u32 = 0;
+    for (k < uw.code_count) {
+        if (uw.codes[k].op == UWOP_SAVE_NONVOL || uw.codes[k].op == UWOP_SAVE_NONVOL_FAR) { ret 1; }
+        k = k + 1;
     }
-    if (!saw_set_fpreg) { ret 1; }
-
+    if (uw.prolog_size != 8) { ret 1; }  # prologue ends at the sub rsp; the r13 store is body
     ret 0;
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1937,8 +1937,7 @@ fun write_pe(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
     # jump through the IAT slots the import section owns.
     if (lay.have_idata) { write_pe_imports(buf, ?lay, dyn); }
     if (lay.have_stub)  { write_pe_stubs(buf, ?lay, dyn); }
-    if (lay.have_xdata || lay.have_pdata) { write_pe_unwind(buf, ?lay, uw_all, uw_count, seg_count); }
-    if (lay.have_xdata || lay.have_pdata) { write_pe_unwind(buf, ?lay, uw_all, uw_count, seg_count); }
+    if (lay.have_xdata || lay.have_pdata) { write_pe_unwind(buf, ?lay, uw_all, uw_count); }
 
     # redirect each import call site to its stub (a non-import call site never
     # reaches here — the linker only records fixups for function imports).
@@ -2180,7 +2179,10 @@ fun write_unwind_xdata(buf: *u8, lay: *PeLayout, uw: *FunctionUnwind) {
     }
 }
 
-fun write_pe_unwind(buf: *u8, lay: *PeLayout, uws: *FunctionUnwind, uw_count: u32, seg_count: u32) {
+# write_pe_unwind: emit the .xdata UNWIND_INFO records and the .pdata
+# RUNTIME_FUNCTION table for every collected function. parse_function_unwind has
+# already rejected any out-of-range seg_index, so every entry maps to a segment.
+fun write_pe_unwind(buf: *u8, lay: *PeLayout, uws: *FunctionUnwind, uw_count: u32) {
     if (uw_count == 0 || uws == nil) { ret; }
     if (!lay.have_xdata || !lay.have_pdata) { ret; }
 
@@ -2195,7 +2197,6 @@ fun write_pe_unwind(buf: *u8, lay: *PeLayout, uws: *FunctionUnwind, uw_count: u3
 
     i = 0;
     for (i < uw_count) {
-        if (uws[i].seg_index >= seg_count) { i = i + 1; cnt; }
         val poff: usize = lay.pdata_sec.file_off + i::usize * RUNTIME_FUNCTION_SIZE;
         val seg_rva: u64 = lay.seg_secs[uws[i].seg_index].rva;
         val begin_rva: u32 = (seg_rva + uws[i].seg_offset::u64)::u32;
@@ -3074,7 +3075,6 @@ test "coff: emit_exec emits .xdata/.pdata for a canonical x64 prologue" {
         sh = sh + SECTION_HEADER_SIZE;
         si = si + 1;
     }
-    if (xdata_rva == 0 || xdata_ptr == 0 || pdata_ptr == 0) { ret 1; }
     if (xdata_rva == 0 || xdata_ptr == 0 || pdata_ptr == 0) { ret 1; }
 
     val begin_rva: u32 = read_u32_le(buf.data, pdata_ptr::usize);


### PR DESCRIPTION
Fixes the per-function win64 unwind metadata in \`src/lang/target/of/coff.mach\` (PR #1226 / #1227 audit).

## #1229 — .xdata correctness

1. **SET_FPREG base mismatch.** Replaced \`UWOP_SET_FPREG\` (frame_off=0) with no frame register. mach's prologue (\`push rbp; mov rbp,rsp; sub rsp,N\`) leaves RSP fixed for the whole body — outgoing call args are pre-reserved in the prologue \`sub rsp,N\` (see \`frame_total\`/\`emit_prologue\`), and RSP is written nowhere else in the body. Per the MS x64 unwind spec, with no frame register \`RtlVirtualUnwind\` uses RSP as the offset base, so the existing RSP-relative offsets (\`save_off = alloc - off_rbp\`) are exactly correct. The prior frame_off=0 declaration rebased every \`UWOP_SAVE_NONVOL\` read to \`RBP - 16*0 = RBP\`, leaving each nonvolatile restore off by \`alloc\` bytes. Dropping the frame register is correct for any alloc size — no \`alloc <= 240\` constraint or fallback.
2. **SAVE_NONVOL_FAR offset.** The far form now stores the **unscaled** byte offset in its two slots (the spec stores unscaled here; cf. \`push_alloc_code\`'s ALLOC_LARGE info=1). Bot commit 1bdef8c8 had regressed this to the scaled value.
3. **REX.B prologue scan.** The save scan now requires REX.B clear, so a body \`mov [r13+disp], r64\` (rm==5 with REX.B set) is no longer misrecorded as an \`[rbp+disp]\` save.

## #1230 — cleanup

- Removed the duplicated \`write_pe_unwind\` call (merge artifact).
- Removed the duplicated test guard.
- Removed the unreachable \`seg_index >= seg_count\` skip in the .pdata loop (\`parse_function_unwind\` already rejects that case) and its now-unused \`seg_count\` parameter.

## Convention

Added the missing leading doc comments to the unwind helpers/records from PR #1226.

## Tests

- Strengthened the emit test to assert the **full UNWIND_INFO byte image** for the canonical prologue (header, frame nibble = 0, and each unwind code's op/info/offset).
- Added a SAVE_NONVOL_FAR unit test asserting the unscaled offset.
- Added a REX.B \`[r13+disp]\` negative case.

\`mach build .\` clean, \`mach test .\` 234 pass / 0 fail.

**Bonus cross-check:** cross-compiled the compiler to \`mach.exe\` with the fixed build and dumped it with \`llvm-readobj --unwind\`: all 5626 functions parse with no frame register, zero SET_FPREG, no errors; offsets reconcile against the disassembled prologues (e.g. \`sub $0x210\` + \`mov %rbx,-0x1d8(%rbp)\` → SAVE_NONVOL RBX offset 0x38).

Closes #1229
Closes #1230