### PR TITLE
fix(codegen): win64 byref stack-spill is caller-only — fix the callee side

### DIFF
--- a/.github/tests/win64byref/app/mach.toml
+++ b/.github/tests/win64byref/app/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id = "win64byref"
+name = "win64 byref 5th-arg regression — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "windows"
+
+[targets.windows]
+os = "windows"
+isa = "x86_64"
+abi = "win64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "windows"
+binary = "windows/bin/win64byref.exe"
+libs = ["kernel32.dll"]
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/win64byref/app/src/main.mach
+++ b/.github/tests/win64byref/app/src/main.mach
@@ -1,0 +1,50 @@
+use std.runtime.windows.x86_64;
+
+# Three: a 3-byte aggregate. win64 passes every non-1/2/4/8-byte aggregate by
+# reference, so as a 5th+ argument (its register slot exhausted) the hidden
+# pointer spills to the stack (CLASS_STACK_BYREF), not the aggregate's bytes.
+rec Three {
+    a: u8;
+    b: u8;
+    c: u8;
+}
+
+# Big: a 12-byte aggregate, also by reference under win64.
+rec Big {
+    x: i32;
+    y: i32;
+    z: i32;
+}
+
+# sum5_three: the 5th parameter `t` is a sub-pointer byref aggregate. the callee
+# must LOAD the spilled hidden pointer from the stack slot, not read the slot's
+# bytes as the aggregate (the #1228 callee-side defect).
+fun sum5_three(p0: i64, p1: i64, p2: i64, p3: i64, t: Three) i64 {
+    ret p0 + p1 + p2 + p3 + t.a::i64 + t.b::i64 + t.c::i64;
+}
+
+# sum5_big: the 5th parameter `b` is a >8-byte byref aggregate spilled to the
+# stack as a hidden pointer.
+fun sum5_big(p0: i64, p1: i64, p2: i64, p3: i64, b: Big) i64 {
+    ret p0 + p1 + p2 + p3 + b.x::i64 + b.y::i64 + b.z::i64;
+}
+
+# main: pass each byref aggregate as the 5th argument and verify the callee read
+# it correctly. exits 0 on success, 1 if the 3-byte case is misread, 2 if the
+# 12-byte case is misread.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    var t: Three;
+    t.a = 10;
+    t.b = 20;
+    t.c = 30;
+    if (sum5_three(1, 2, 3, 4, t) != 70) { ret 1; }
+
+    var b: Big;
+    b.x = 100;
+    b.y = 200;
+    b.z = 300;
+    if (sum5_big(1, 2, 3, 4, b) != 610) { ret 2; }
+
+    ret 0;
+}

--- a/.github/tests/win64byref/run.sh
+++ b/.github/tests/win64byref/run.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# win64 byref 5th-argument regression test (#1228): a >8-byte or sub-pointer
+# aggregate passed as the 5th+ win64 argument is passed by hidden reference, so
+# its register slot being exhausted spills the 8-byte pointer to the stack
+# (CLASS_STACK_BYREF). the caller must STORE that pointer and the callee must
+# LOAD it; before #1228's fix the callee LEA'd the slot as if it held the
+# aggregate's bytes, handing itself garbage.
+#
+# cross-compiles a tiny windows program that calls two such functions — one
+# taking a 3-byte aggregate, one a 12-byte aggregate, each as the 5th argument —
+# and runs it under wine. main returns 0 only when both callees read the spilled
+# pointer correctly (1 = 3-byte misread, 2 = 12-byte misread).
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+# the test runs a windows binary; without wine there is nothing to execute it.
+if ! command -v wine >/dev/null 2>&1; then
+    echo "SKIP win64byref: 'wine' not available to run the windows binary"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# build at -O0 so the calls are not inlined away — the ABI byref-spill path must
+# actually be exercised at the call boundary.
+if ! ( cd "$WORK/app" && "$MACH" build . -O0 ) >/dev/null 2>&1; then
+    echo "FAIL win64byref: windows cross-build failed" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/windows/bin/win64byref.exe"
+test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
+
+set +e
+WINEDEBUG=-all wine "$EXE" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS win64byref: 3-byte and 12-byte byref aggregates read correctly as the 5th argument"
+    exit 0
+fi
+
+echo "FAIL win64byref: callee misread the byref-spilled 5th argument (exit $code: 1=3-byte, 2=12-byte)" >&2
+exit 1

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -3285,8 +3285,10 @@ fun classify_signature(ctx: *LowerCtx, sig: ir_type.IrTypeId, ret_ty: ir_type.Ir
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering
-        # read this instead of re-deriving a parallel cursor.
-        if (slot.class == abi.CLASS_STACK) {
+        # read this instead of re-deriving a parallel cursor. a byref stack spill
+        # occupies the same eight-byte slot as a by-value one — only its contents
+        # (a hidden pointer) differ — so it advances the cursor identically.
+        if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
             slot.offset = stack_off;
             stack_off   = stack_off + stack_slot_bytes(slot.size);
         } or (slot.class == abi.CLASS_FP) {
@@ -3458,7 +3460,7 @@ fun lower_call(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
                 if (slot.reg2 >= 0) { gp_used = gp_used + 1; }
             } or (slot.class == abi.CLASS_BYREF) {
                 gp_used = gp_used + 1;
-            } or (slot.class == abi.CLASS_STACK) {
+            } or (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
                 stack_off = stack_off + stack_slot_bytes(slot.size);
             }
         }
@@ -3576,15 +3578,6 @@ fun lower_value_addr(ctx: *LowerCtx, mb: *MirBlock, v: value.Value) Result[MirOp
     ret ok[MirOperand, str](op_vreg(addr));
 }
 
-# stack_aggr_spills_pointer: true when a CLASS_STACK aggregate slot carries only
-# a hidden pointer (not by-value bytes). this is the win64 by-reference overflow
-# case: an aggregate larger than the by-value threshold whose first four register
-# slots are exhausted. the classifier reports CLASS_STACK with pointer size (8),
-# while the IR operand type still reports the aggregate's full byte size.
-fun stack_aggr_spills_pointer(slot: abi.ParamSlot, is_aggr: bool, value_size: u64) bool {
-    ret slot.class == abi.CLASS_STACK && is_aggr && slot.size < value_size;
-}
-
 # emit_arg_slot: emit the pre-coloring move(s) placing one classified argument.
 # GP/FP register args move the value into the argument register (a 9–16 byte
 # aggregate in two GP registers moves each half from `[base+0]` / `[base+8]` of
@@ -3594,23 +3587,28 @@ fun stack_aggr_spills_pointer(slot: abi.ParamSlot, is_aggr: bool, value_size: u6
 # region (the ABI classifier returns a sizing-only slot with no offset of its
 # own, so the running cursor is the caller's responsibility — see `lower_call`).
 # an aggregate argop is a pointer to the aggregate's storage (aggregates flow by
-# address). a by-value stack aggregate copies its bytes to the outgoing slot, but
-# a by-reference stack spill stores only that pointer value (win64 exhausted-slot
-# byref case). `addr_to_vreg` normalizes a global's symbol address into a value
-# vreg so the two-register / by-reference forms index a register pointer base.
-# a scalar argop is the value itself, placed directly.
+# address). a by-value stack aggregate (CLASS_STACK) copies its bytes to the
+# outgoing slot; a by-reference stack spill (CLASS_STACK_BYREF, the win64
+# exhausted-slot case) stores only that pointer value, the stack analog of BYREF.
+# `addr_to_vreg` normalizes a global's symbol address into a value vreg so the
+# two-register / by-reference forms index a register pointer base. a scalar argop
+# is the value itself, placed directly.
 fun emit_arg_slot(ctx: *LowerCtx, mb: *MirBlock, slot: abi.ParamSlot, argop: MirOperand,
                   stack_off: i64, is_aggr: bool, size: u64) Result[bool, str] {
+    if (slot.class == abi.CLASS_STACK_BYREF) {
+        # win64 by-reference overflow: store the hidden aggregate pointer into the
+        # outgoing stack slot, not a by-value copy of the aggregate bytes.
+        val sp: u32 = ctx.tgt.arch.stack_ptr_reg::u32;
+        var base: u32 = MIR_VREG_NIL;
+        val ar: Result[bool, str] = addr_to_vreg(ctx, mb, argop, ?base);
+        if (is_err[bool, str](ar)) { ret ar; }
+        ret emit_store_to(ctx, mb, op_mem_preg(sp, stack_off), op_vreg(base));
+    }
     if (slot.class == abi.CLASS_STACK) {
         # outgoing stack arguments are addressed off the ISA's stack pointer
         # (x86-64 RSP), named through `tgt.arch.stack_ptr_reg` rather than a literal.
         val sp: u32 = ctx.tgt.arch.stack_ptr_reg::u32;
         if (is_aggr) {
-            if (stack_aggr_spills_pointer(slot, is_aggr, size)) {
-                # win64 by-reference overflow: the stack slot holds the hidden
-                # aggregate pointer, not a by-value copy of the aggregate bytes.
-                ret emit_store_to(ctx, mb, op_mem_preg(sp, stack_off), argop);
-            }
             # the by-value aggregate is copied into the outgoing stack slot from its
             # storage; argop is a pointer to that storage.
             ret copy_aggregate(ctx, mb, op_mem_preg(sp, stack_off), argop, size);
@@ -3733,21 +3731,6 @@ fun stack_slot_bytes(size: u64) i64 {
     ret n::i64;
 }
 
-test "mir: stack aggregate pointer-spill detection catches win64 byref overflow" {
-    var slot: abi.ParamSlot = abi.make_slot(abi.CLASS_STACK, -1, -1, 32, 8);
-    if (!stack_aggr_spills_pointer(slot, true, 40)) { ret 1; }
-    ret 0;
-}
-
-test "mir: stack aggregate by-value slots do not take pointer-spill path" {
-    var by_value: abi.ParamSlot = abi.make_slot(abi.CLASS_STACK, -1, -1, 32, 24);
-    if (stack_aggr_spills_pointer(by_value, true, 24)) { ret 1; }
-
-    var scalar: abi.ParamSlot = abi.make_slot(abi.CLASS_STACK, -1, -1, 32, 8);
-    if (stack_aggr_spills_pointer(scalar, false, 8)) { ret 1; }
-    ret 0;
-}
-
 # record_outgoing_size: grow the function's reserved outgoing-argument region to
 # cover one call's stack-argument footprint. frame.run reserves the running
 # maximum (sixteen-byte aligned) as the lowest region of the frame; recording the
@@ -3855,11 +3838,20 @@ fun lower_params(ctx: *LowerCtx, mb: *MirBlock) Result[bool, str] {
 # keyed on `pv` so the encoder resolves it to `[rbp + offset]` and `pv` names that
 # storage; a BYREF aggregate takes the hidden pointer directly; a STACK aggregate
 # is the caller's by-value copy at `[rbp + 16 + stack_off]`, whose address is LEA'd
-# into `pv`. a scalar parameter moves its single register / stack word into the
-# parameter value vreg `pv`. `stack_off` is the callee-tracked running offset (the
-# ABI classifier returns a sizing-only slot — see `lower_params`).
+# into `pv`; a STACK_BYREF aggregate is the caller's spilled hidden pointer at that
+# slot, LOADED into `pv` (the stack analog of BYREF). a scalar parameter moves its
+# single register / stack word into the parameter value vreg `pv`. `stack_off` is
+# the callee-tracked running offset (the ABI classifier returns a sizing-only slot
+# — see `lower_params`).
 fun emit_param_slot(ctx: *LowerCtx, mb: *MirBlock, slot: abi.ParamSlot, pv: u32, size: u64,
                     stack_off: i64, is_aggr: bool) Result[bool, str] {
+    if (slot.class == abi.CLASS_STACK_BYREF) {
+        # win64 by-reference overflow: the caller stored the hidden aggregate
+        # pointer into this stack slot; load it so `pv` is the aggregate's address,
+        # matching the register BYREF parameter form.
+        val fp: u32 = ctx.tgt.arch.frame_ptr_reg::u32;
+        ret emit_mov(ctx, mb, op_vreg(pv), op_mem_preg(fp, 16 + stack_off));
+    }
     if (slot.class == abi.CLASS_STACK) {
         # incoming stack parameters are addressed off the ISA's frame pointer
         # (x86-64 RBP), named through `tgt.arch.frame_ptr_reg` rather than a literal.

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -34,8 +34,14 @@ pub val CLASS_FP:    ParamClass = 1;
 pub val CLASS_STACK: ParamClass = 2;
 # returned via a hidden pointer to caller-allocated storage.
 pub val CLASS_SRET:  ParamClass = 3;
-# passed by hidden pointer (large by-value aggregate).
+# passed by hidden pointer in a register (a by-reference aggregate whose pointer
+# rides a GP argument register).
 pub val CLASS_BYREF: ParamClass = 4;
+# passed by hidden pointer on the stack (a by-reference aggregate whose register
+# slot was exhausted; the stack slot holds the 8-byte pointer, not the
+# aggregate's by-value bytes). distinct from CLASS_STACK, whose stack slot holds
+# the value's own bytes.
+pub val CLASS_STACK_BYREF: ParamClass = 5;
 
 # placement decision for one parameter or return value. `reg2` carries the
 # second register of a 9–16 byte aggregate split across two registers; it is

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -243,8 +243,9 @@ pub fun classify(arch_id: u32, size: u64, align: u64, is_float: bool,
 # passed by hidden reference (CLASS_BYREF) — a caller-allocated copy whose
 # pointer occupies the slot's integer register. a float takes the slot's XMM
 # register; an integer or pointer takes the slot's integer register. once the
-# four slots are exhausted the argument spills to the stack by value (a by-ref
-# aggregate spills its 8-byte pointer). this classifier is AMD64-only: a
+# four slots are exhausted the argument spills to the stack by value (CLASS_STACK)
+# — except a by-ref aggregate, which spills its 8-byte hidden pointer
+# (CLASS_STACK_BYREF). this classifier is AMD64-only: a
 # non-x86_64 arch_id yields the `unsupported_slot` sentinel, which callers must
 # reject -- it is never a valid placement on the requested architecture.
 # ---
@@ -279,7 +280,9 @@ pub fun classify_arg(arch_id: u32, index: i32, size: u64, align: u64,
             ret abi.make_slot(abi.CLASS_BYREF, slot_gp_reg(slot), -1, 0, 8);
         }
         # no register slot remains: spill the hidden pointer (8 bytes) to the stack.
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, 8);
+        # CLASS_STACK_BYREF keeps the by-reference fact explicit — the slot holds the
+        # pointer, not the aggregate's bytes — so caller and callee lowering agree.
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, 8);
     }
 
     if (is_float) {
@@ -599,10 +602,25 @@ test "win64: 1/2/4/8-byte aggregates ride one register, others go by reference" 
 test "win64: an exhausted by-reference aggregate spills its pointer to the stack" {
     val a: u32 = isa.ARCH_X86_64;
     # all four positional slots are taken; a 16-byte by-ref aggregate spills the
-    # 8-byte hidden pointer to the stack, not the full aggregate.
+    # 8-byte hidden pointer to the stack as CLASS_STACK_BYREF (not the full
+    # aggregate, and distinct from a by-value CLASS_STACK spill).
     val s: abi.ParamSlot = classify_arg(a, 4, 16, 8, false, true, 4, 0);
-    if (s.class != abi.CLASS_STACK) { ret 1; }
-    if (s.size != 8)                { ret 1; }
+    if (s.class != abi.CLASS_STACK_BYREF) { ret 1; }
+    if (s.reg != -1)                      { ret 1; }
+    if (s.size != 8)                      { ret 1; }
+
+    # a sub-pointer (3-byte) aggregate is also by reference: win64 treats every
+    # non-1/2/4/8-byte aggregate as byref, so an exhausted 3-byte aggregate spills
+    # its 8-byte pointer too — the size-mismatch heuristic missed this case.
+    val s3: abi.ParamSlot = classify_arg(a, 4, 3, 1, false, true, 4, 0);
+    if (s3.class != abi.CLASS_STACK_BYREF) { ret 1; }
+    if (s3.size != 8)                      { ret 1; }
+
+    # an exhausted by-value-size aggregate (8 bytes) spills its own bytes by value,
+    # so it stays CLASS_STACK — the byref class must not capture the by-value path.
+    val sv: abi.ParamSlot = classify_arg(a, 4, 8, 8, false, true, 4, 0);
+    if (sv.class != abi.CLASS_STACK) { ret 1; }
+    if (sv.size != 8)                { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
## Summary

PR #1225's fix for the win64 exhausted-slot byref aggregate spill was **caller-only**. `emit_arg_slot` stores the hidden aggregate pointer into the outgoing stack slot, but `emit_param_slot` still LEA'd that slot as if it held the aggregate's by-value bytes — so a mach-to-mach win64 call passing a `>8`-byte aggregate as a 5th+ argument handed the callee garbage.

Two defects, both fixed structurally rather than by patching the heuristic:

1. **Callee side never updated.** The classifier collapsed the byref stack spill to a bare `CLASS_STACK` size 8, discarding the by-reference fact; the caller reverse-engineered it from a size mismatch, and the callee couldn't (it sees only `slot.size`). Now the win64 classifier emits a distinct **`CLASS_STACK_BYREF`** class, and **both** `emit_arg_slot` (store the pointer) and `emit_param_slot` (load the pointer) dispatch on it. The `stack_aggr_spills_pointer` size-inference helper is removed.
2. **Sub-pointer byref aggregates missed.** The old predicate `slot.size < value_size` was false for 3/5/6/7-byte aggregates (`8 < 3` is false), even though win64 passes every non-1/2/4/8-byte aggregate by reference. The explicit class covers them.

## Tests

- `src/lang/target/abi/win64.mach`: the exhausted-byref classifier test now asserts `CLASS_STACK_BYREF` and adds a sub-pointer (3-byte) case plus a by-value (8-byte) case to keep the two paths distinct.
- `.github/tests/win64byref/`: a runtime regression (the gap that let this ship — the prior test only checked a classifier-level predicate). Cross-compiles a windows program passing a 3-byte and a 12-byte aggregate as the 5th argument and runs it under wine; exits 0 only when both callees read the spilled pointer correctly. Verified: **passes** with this fix, **fails** (`exit 2`) when built with a pre-fix compiler.

Full build (`mach build .`) and `mach test .` are green (230 tests).

## #1224

Cross-compiling `mach.exe` with a pre-fix compiler reproduces #1224 exactly (read fault at `0xffffffffffffffff`, `movzbl (%rax),%r12d` at `mach+0x13e8b`). With this fix the compiler-built `mach.exe` no longer faults there — it progresses past that site and hits a **distinct, later** deterministic fault (execute access at `0x400DD73B`). So this resolves the specific #1224 crash site, but native win64 `mach.exe` self-build has at least one further defect that should stay tracked.

Closes #1228.
Refs #1212, #1224, PR #1225.