### PR TITLE
ci: multi-target release artifacts + integration suites on PRs

### DIFF
--- a/.github/tests/dynlink/run.sh
+++ b/.github/tests/dynlink/run.sh
@@ -15,6 +15,9 @@
 set -euo pipefail
 
 MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"

--- a/.github/tests/extlink/run.sh
+++ b/.github/tests/extlink/run.sh
@@ -16,6 +16,9 @@
 set -euo pipefail
 
 MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"

--- a/.github/tests/opt/run.sh
+++ b/.github/tests/opt/run.sh
@@ -13,6 +13,9 @@
 set -euo pipefail
 
 MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"

--- a/.github/tests/win64byref/run.sh
+++ b/.github/tests/win64byref/run.sh
@@ -15,6 +15,9 @@
 set -euo pipefail
 
 MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,44 @@ jobs:
 
       - name: Test corpus
         run: mach test .
+
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Fetch released mach (build seed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download -R ${{ github.repository }} -p mach -D /usr/local/bin
+          chmod +x /usr/local/bin/mach
+
+      - name: Install wine
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq wine64
+          command -v wine >/dev/null || sudo ln -s "$(command -v wine64)" /usr/local/bin/wine
+
+      - name: Build the compiler
+        run: mach build .
+
+      - name: Cross-compile the windows target
+        run: out/linux/bin/mach build . --target windows
+
+      - name: Run the integration suites
+        run: |
+          set -euo pipefail
+          fail=0
+          for t in .github/tests/*/run.sh; do
+            echo "::group::$t"
+            if ! bash "$t" "$GITHUB_WORKSPACE/out/linux/bin/mach"; then
+              echo "::error::integration suite failed: $t"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$fail"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,42 @@ jobs:
             exit 1
           fi
 
-      - name: Upload release binary
+      - name: Cross-compile the windows target
+        run: out/linux/bin/mach build . --target windows
+
+      - name: Smoke-test the windows binary under wine
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq wine64 zip
+          command -v wine >/dev/null || sudo ln -s "$(command -v wine64)" /usr/local/bin/wine
+          # emitted-code smoke: the win64 integration app must build and run.
+          bash .github/tests/win64byref/run.sh out/linux/bin/mach
+          # compiler smoke: mach.exe itself must build a real project under wine
+          # before it ships — a release artifact that cannot compile is not a release.
+          work="$(mktemp -d)"
+          cp -r .github/tests/win64byref/app "$work/app"
+          mkdir -p "$work/app/dep"
+          cp -r dep/mach-std "$work/app/dep/mach-std"
+          ( cd "$work/app" && WINEDEBUG=-all wine "$GITHUB_WORKSPACE/out/windows/bin/mach.exe" build . )
+          WINEDEBUG=-all wine "$work/app/out/windows/bin/win64byref.exe"
+
+      - name: Package artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          # `mach` is the bootstrap-seed alias (ci.yml / release.yml fetch `-p mach`
+          # from the most recent release); the per-target names are the public ones.
+          cp out/linux/bin/mach dist/mach
+          cp out/linux/bin/mach dist/mach-x86_64-linux
+          ( cd out/windows/bin && zip -q "$GITHUB_WORKSPACE/dist/mach-x86_64-windows.zip" mach.exe )
+          ( cd dist && sha256sum mach-x86_64-linux mach-x86_64-windows.zip > SHA256SUMS )
+
+      - name: Upload release artifacts
         uses: softprops/action-gh-release@v2
         with:
-          files: out/linux/bin/mach
+          files: |
+            dist/mach
+            dist/mach-x86_64-linux
+            dist/mach-x86_64-windows.zip
+            dist/SHA256SUMS

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -124,7 +124,7 @@ system libraries like libc). Manifest `libs` are resolved before the CLI inputs,
 giving a stable, deterministic link order.
 
 > Dynamic linking is implemented for the ELF (Linux) and PE (Windows) targets;
-> the Mach-O (Darwin) import path is not yet implemented (#1244).
+> the Mach-O (Darwin) import path is not yet implemented (#1176).
 
 Exit codes: `0` ok, `1` user error (no `mach.toml`, unknown target, compile
 errors, an unresolvable link input), `2` internal error.

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -123,8 +123,8 @@ fallback only applies when no static candidate exists (the common case for
 system libraries like libc). Manifest `libs` are resolved before the CLI inputs,
 giving a stable, deterministic link order.
 
-> Dynamic linking is currently implemented for the ELF (Linux) target; the PE
-> (Windows) and Mach-O (Darwin) import paths are in progress.
+> Dynamic linking is implemented for the ELF (Linux) and PE (Windows) targets;
+> the Mach-O (Darwin) import path is not yet implemented (#1244).
 
 Exit codes: `0` ok, `1` user error (no `mach.toml`, unknown target, compile
 errors, an unresolvable link input), `2` internal error.


### PR DESCRIPTION
Closes #1243

- **Releases ship per-target artifacts**: `mach-x86_64-linux`, `mach-x86_64-windows.zip` (containing `mach.exe`), and `SHA256SUMS`, alongside the bare `mach` asset which remains the bootstrap-seed alias (`-p mach` fetches in ci.yml/release.yml keep working, including for already-published releases). The naming uses mach's own target ids so it scales to the coming targets (darwin #1244, aarch64 #1045).
- **The windows artifact is gated before publishing**: the win64 integration app must build and run under wine, and `mach.exe` itself must build a real project under wine. Until #1224 lands this gate fails by design — a `mach.exe` that cannot compile is not released.
- **CI now runs the `.github/tests/` integration suites** (dynlink, extlink, opt, win64byref) on every PR, with wine installed so the windows suites execute rather than skip, plus a windows cross-build of the compiler. These suites were previously never invoked by CI — the #1228 byref bug shipped through exactly that hole.
- The suite scripts now absolutize a relative compiler path (they cd into temp dirs, which silently broke relative invocation).
- doc/cli.md: the "PE import path in progress" note was stale — PE dynamic linking landed in #1199/#1226.

All four suites pass locally against this branch's build; this PR's own CI exercises the new Integration Tests job.