### PR TITLE
fix(lower): function-pointer cast truncation breaking native win64 mach.exe

### DIFF
--- a/.github/tests/win64fnptr/app/mach.toml
+++ b/.github/tests/win64fnptr/app/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id = "win64fnptr"
+name = "win64 erased function-pointer cast regression — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "windows"
+
+[targets.windows]
+os = "windows"
+isa = "x86_64"
+abi = "win64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "windows"
+binary = "windows/bin/win64fnptr.exe"
+libs = ["kernel32.dll"]
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/win64fnptr/app/src/main.mach
+++ b/.github/tests/win64fnptr/app/src/main.mach
@@ -1,0 +1,31 @@
+use std.runtime.windows.x86_64;
+
+# the type-erased operation a vtable stores. mach's ABI / ISA / object-format
+# vtables hold their entry points as `*u8` and register them with `fn::*u8`
+# casts, recalling them with `*u8::Fn` casts at the call site.
+def Fn: fun(i64) i64;
+
+# a vtable whose operation is stored type-erased, exactly as `abi.AbiVTable` /
+# `isa.IsaVTable` store theirs.
+rec VT {
+    op: *u8;
+}
+
+fun inc(x: i64) i64 { ret x + 1; }
+
+var vt: VT;
+
+# main: register `inc` into the erased slot via `inc::*u8`, recall it via
+# `vt.op::Fn`, and call through it. before #1224's fix `scalar_bits` reported a
+# function type as 0 bits, so `inc::*u8` lowered to a zero-extension that on
+# x86-64 encodes as a 32-bit `mov ecx, eax` — truncating the high 32 bits of the
+# code address. harmless on linux (addresses < 2GB) but on win64 (ImageBase
+# 0x140000000) the stored pointer becomes unmapped and `f(41)` faults. exits 0
+# only when the round-tripped pointer calls correctly (41 -> 42).
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    vt.op = inc::*u8;
+    val f: Fn = vt.op::Fn;
+    if (f(41) != 42) { ret 1; }
+    ret 0;
+}

--- a/.github/tests/win64fnptr/run.sh
+++ b/.github/tests/win64fnptr/run.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# win64 erased function-pointer cast regression test (#1224): a function value
+# cast to a type-erased `*u8` slot and recalled with a `*u8::Fn` cast must keep
+# its full 64-bit code address. `scalar_bits` omitted the function type, so
+# `lower_cast` treated `fn::*u8` as a zero-extension instead of a same-size
+# bitcast; on x86-64 that encodes as a 32-bit `mov ecx, eax`, zeroing the high
+# 32 bits of the address. harmless on linux (addresses < 2GB) but on win64
+# (ImageBase 0x140000000) the stored vtable pointer faults the first time it is
+# called through — the deterministic execute-access fault that blocked a native
+# windows mach.exe.
+#
+# cross-compiles a tiny windows program that round-trips `inc` through an erased
+# `*u8` slot and calls it under wine. main returns 0 only when the recalled
+# pointer is intact (1 = the truncated pointer miscomputed; a hard fault is a
+# nonzero exit either way).
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+# the test runs a windows binary; without wine there is nothing to execute it.
+if ! command -v wine >/dev/null 2>&1; then
+    echo "SKIP win64fnptr: 'wine' not available to run the windows binary"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# build at -O0 so the cast is not folded away — the `fn::*u8` lowering must
+# actually be exercised.
+if ! ( cd "$WORK/app" && "$MACH" build . -O0 ) >/dev/null 2>&1; then
+    echo "FAIL win64fnptr: windows cross-build failed" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/windows/bin/win64fnptr.exe"
+test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
+
+set +e
+WINEDEBUG=-all wine "$EXE" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS win64fnptr: erased function pointer round-trips its full 64-bit address"
+    exit 0
+fi
+
+echo "FAIL win64fnptr: recalled function pointer faulted or miscomputed (exit $code)" >&2
+exit 1

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1743,8 +1743,9 @@ fun index_type(ctx: *lower.LowerContext) Result[ir_type.IrTypeId, str] {
 }
 
 
-# the bit width of a scalar semantic type (int/float/pointer), or 0 for
-# non-scalars.
+# the bit width of a scalar semantic type (int/float/pointer/function), or 0
+# for non-scalars. a function value is its code address, so it is pointer-width
+# — a `fn::*ptr` cast is then a same-size bitcast, not a truncate/extend.
 fun scalar_bits(ctx: *lower.LowerContext, tid: ty.TypeId) u32 {
     val t_opt: Option[*ty.Type] = ty.get(?ctx.s.types, tid);
     if (is_none[*ty.Type](t_opt)) { ret 0; }
@@ -1753,7 +1754,7 @@ fun scalar_bits(ctx: *lower.LowerContext, tid: ty.TypeId) u32 {
     if (k == ty.TYPE_U16 || k == ty.TYPE_I16) { ret 16; }
     if (k == ty.TYPE_U32 || k == ty.TYPE_I32 || k == ty.TYPE_F32) { ret 32; }
     if (k == ty.TYPE_U64 || k == ty.TYPE_I64 || k == ty.TYPE_F64) { ret 64; }
-    if (k == ty.TYPE_PTR || k == ty.TYPE_POINTER) { ret ctx.tgt.arch.pointer_width * 8; }
+    if (k == ty.TYPE_PTR || k == ty.TYPE_POINTER || k == ty.TYPE_FUN) { ret ctx.tgt.arch.pointer_width * 8; }
     ret 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes the deterministic execute-access fault (`rip = r12 = 0x400DD73B`) that blocked a working native windows `mach.exe`. Root cause is a single missing type case in `scalar_bits`.

## Root cause

`scalar_bits` (`src/lang/me/lower/expr.mach`) reports the bit width of a scalar semantic type for `lower_cast`'s trunc/extend/bitcast decision. It handled int/float/pointer but **not `TYPE_FUN`**, falling through to `ret 0`.

The ABI/ISA vtables store their operations as type-erased `*u8` fields and register them with casts like `classify::*u8` (win64), `select::*u8` (x64 isel). For such a cast `lower_cast` computed `from_bits = 0` (function), `to_bits = 64` (pointer), saw `to_bits > from_bits`, and emitted a **zero-extension** instead of a same-size bitcast. On x86-64 a zext of a pointer-width value encodes as a 32-bit `mov ecx, eax`, which **zeroes the high 32 bits of the code address**.

This is harmless on linux (non-PIE executables load below 2 GB, so the high bits are already zero) but on win64 the PE ImageBase is `0x140000000`: every type-erased vtable function pointer was stored as `0x00000000_400dd73b`. The first indirect call through one (`call r12`) jumped to the truncated, unmapped address and faulted.

## Fix

Treat `TYPE_FUN` as pointer-width in `scalar_bits`, so a function↔pointer cast takes the same-size bitcast path (matching sema's `byte_size`, which already sizes a function as a pointer). The cast now lowers to a full 64-bit move.

## Verification

- Truncation sites in cross-compiled `mach.exe` (`lea rax,fn; mov ecx,eax`): **17 → 0**.
- `wine mach.exe build .` on a hello-world project: completes, produced exe returns its expected code.
- `wine mach.exe build . --target windows` building **mach itself**: completes (exit 0) and produces a `mach.exe` **byte-identical** (sha256) to the linux-cross-compiled artifact — a native self-build fixpoint.
- Adds a wine-run regression test under `.github/tests/win64fnptr/`.

Closes #1224