### PR TITLE
fix(lower): audit findings from #1251 (comptime-string panic, generic $if context, label handling, scans)

### DIFF
--- a/.github/tests/lower-testrunner/duplabel/mach.toml
+++ b/.github/tests/lower-testrunner/duplabel/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "duplabel"
+name = "Lower Testrunner Regression — duplabel"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/duplabel"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/lower-testrunner/duplabel/src/main.mach
+++ b/.github/tests/lower-testrunner/duplabel/src/main.mach
@@ -1,0 +1,10 @@
+use std.runtime.linux.x86_64;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 { ret 0; }
+
+# two tests with the same label in one module. before issue #1251 the clash
+# surfaced only at link time as "multiple definition" of an internal mangled
+# symbol; lowering now reports a source-located "duplicate test label" diagnostic.
+test "same label" { ret 0; }
+test "same label" { ret 0; }

--- a/.github/tests/lower-testrunner/nlabel/mach.toml
+++ b/.github/tests/lower-testrunner/nlabel/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "nlabel"
+name = "Lower Testrunner Regression — nlabel"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/nlabel"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/lower-testrunner/nlabel/src/main.mach
+++ b/.github/tests/lower-testrunner/nlabel/src/main.mach
@@ -1,0 +1,12 @@
+use std.runtime.linux.x86_64;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 { ret 0; }
+
+# a label whose text itself contains `N<digit>`. before issue #1251 the runner
+# recovered the printable label by inverse-parsing the mangled linkage name and
+# locked onto the in-label `N3`, printing "foo" instead of the real label. the
+# label is now carried on the IR function, so the full text is reported.
+test "check N3foo parsing" {
+    ret 0;
+}

--- a/.github/tests/lower-testrunner/run.sh
+++ b/.github/tests/lower-testrunner/run.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# test-runner regression suite: each app exercises a `mach test` lowering bug
+# from the 2026-06 audit (issue #1251) in the synthesized test runner.
+#
+#   nlabel:   a test whose label text contains `N<digit>`. the runner used to
+#             recover the printable label by inverse-parsing the mangled linkage
+#             name and locked onto the in-label `N3`, listing "foo" instead of
+#             the real label. the label is now carried on the IR function, so
+#             `--list` prints the full text.
+#   duplabel: two tests sharing one label in a module. the clash used to surface
+#             only at link time as "multiple definition" of an internal mangled
+#             symbol; lowering now reports a source-located "duplicate test
+#             label" diagnostic and the build fails cleanly.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# stage <app-dir-name>: copy the app into a temp dir and vendor std into it,
+# echoing the staged path.
+stage() {
+    local app="$1"; local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    echo "$dst"
+}
+
+# nlabel: `--list` must print the full label, not the inverse-mangled fragment.
+dst="$(stage nlabel)"
+out="$( ( cd "$dst" && "$MACH" test . --list ) 2>&1 )" || true
+if echo "$out" | grep -qF 'check N3foo parsing'; then
+    echo "PASS lower-testrunner/nlabel"
+else
+    echo "FAIL lower-testrunner/nlabel: --list did not print the full label" >&2
+    echo "$out" >&2
+    fail=1
+fi
+
+# duplabel: the build must fail with a source-located duplicate-label diagnostic
+# rather than succeeding or emitting a mangled link error.
+dst="$(stage duplabel)"
+set +e
+out="$( ( cd "$dst" && "$MACH" build . ) 2>&1 )"
+code=$?
+set -e
+if [ "$code" -eq 0 ]; then
+    echo "FAIL lower-testrunner/duplabel: build succeeded, expected a duplicate-label error" >&2
+    fail=1
+elif echo "$out" | grep -qF 'duplicate test label'; then
+    echo "PASS lower-testrunner/duplabel"
+else
+    echo "FAIL lower-testrunner/duplabel: build failed without the duplicate-label diagnostic" >&2
+    echo "$out" >&2
+    fail=1
+fi
+
+exit "$fail"

--- a/.github/tests/lower/comptime-str/mach.toml
+++ b/.github/tests/lower/comptime-str/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "comptimestr"
+name = "Lower Regression — comptime string in expression position"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/comptimestr"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/lower/comptime-str/src/main.mach
+++ b/.github/tests/lower/comptime-str/src/main.mach
@@ -1,0 +1,17 @@
+use std.runtime.linux.x86_64;
+
+fun first_byte(p: *u8) i64 { ret p[0]::i64; }
+
+# a comptime `*u8` value parameter referenced in the instance body folds to a
+# string constant in EXPRESSION position. before issue #1251 the folded blob
+# reached the back end as a raw VAL_CONST_BYTES operand and panicked codegen
+# ("unexpected IR value kind in lower_value"); the fix routes it through an
+# anonymous `.rodata` global and a pointer, exactly like a string literal.
+fun greet($name: *u8) i64 { ret first_byte(name); }
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # "hello"[0] == 'h' == 104; main returns 0 only when the fold produced a
+    # valid pointer to the rodata bytes.
+    ret greet("hello") - 104;
+}

--- a/.github/tests/lower/run.sh
+++ b/.github/tests/lower/run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# lowering regression suite: each app exercises a lowering bug from the 2026-06
+# audit (issue #1251) that produced a compiler crash, a link-time failure, or a
+# silently wrong instance body. every app must build cleanly and run to exit 0.
+#
+#   comptime-str: a comptime `*u8`/str value parameter referenced in the body
+#                 folds to a string constant in expression position — used to
+#                 panic codegen with "unexpected IR value kind in lower_value".
+#   xmod-generic: a generic body whose `$if` gates on the defining module's
+#                 `pub val`, instantiated from another module — used to fail with
+#                 "identifier is not a comptime constant in scope".
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# build_and_run <app-dir-name> <expected-exit>: copy the app into a temp dir,
+# vendor std, build it, run the binary, and check its exit code.
+build_and_run() {
+    local app="$1"; local want="$2"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    if ! ( cd "$dst" && "$MACH" build . ) >/dev/null 2>&1; then
+        echo "FAIL lower/$app: build failed" >&2; fail=1; return
+    fi
+    local bin
+    bin="$(find "$dst/out" -type f -path '*/bin/*' | head -n1)"
+    if [ -z "$bin" ]; then
+        echo "FAIL lower/$app: no binary produced" >&2; fail=1; return
+    fi
+    set +e
+    "$bin"
+    local code=$?
+    set -e
+    if [ "$code" -ne "$want" ]; then
+        echo "FAIL lower/$app: ran with exit $code, expected $want" >&2; fail=1; return
+    fi
+    echo "PASS lower/$app"
+}
+
+build_and_run comptime-str 0
+build_and_run xmod-generic 0
+
+exit "$fail"

--- a/.github/tests/lower/xmod-generic/mach.toml
+++ b/.github/tests/lower/xmod-generic/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "xmodgen"
+name = "Lower Regression — cross-module generic $if context"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/xmodgen"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/lower/xmod-generic/src/main.mach
+++ b/.github/tests/lower/xmod-generic/src/main.mach
@@ -1,0 +1,9 @@
+use std.runtime.linux.x86_64;
+use util: xmodgen.util;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # FLAG == 1, so pick selects its first argument (7); main returns 0 only when
+    # the cross-module instance folded the right $if arm.
+    ret util.pick[i64](7, 99) - 7;
+}

--- a/.github/tests/lower/xmod-generic/src/util.mach
+++ b/.github/tests/lower/xmod-generic/src/util.mach
@@ -1,0 +1,12 @@
+val FLAG: u8 = 1;
+
+# a generic body whose `$if` gates on the DEFINING module's `pub val`. when this
+# is instantiated from another module, lowering must fold the `$if` against
+# util's comptime context (where FLAG is registered), not the instantiating
+# module's. before issue #1251 the type-instance drain folded against the
+# instantiating module and failed with "identifier is not a comptime constant in
+# scope" (or silently picked the wrong arm).
+pub fun pick[T](a: T, b: T) T {
+    $if (FLAG == 1) { ret a; }
+    ret b;
+}

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -220,6 +220,9 @@ val PRIM_COUNT: u32 = 12;
 # expr_count:    length of expr_resolved (= ast.expr_len), for teardown
 # type_count:    length of type_resolved (= ast.type_len), for teardown
 # decl_count:    length of decl_symbol (= ast.decl_len), for teardown
+# param_index:   (decl::u64 << 32 | slot) -> SymbolId for every SYM_PARAM, so a
+#                consumer resolves a function parameter by (owning decl, ordinal)
+#                in O(1) instead of scanning the whole symbol universe per param
 pub rec ResolveResult {
     alloc:         *Allocator;
     symbols:       *Symbol;
@@ -231,6 +234,23 @@ pub rec ResolveResult {
     expr_count:    u32;
     type_count:    u32;
     decl_count:    u32;
+
+    param_index:   map.Map[u64, SymbolId];
+}
+
+# param_symbol: the SymbolId of function `decl`'s parameter at ordinal `slot`,
+# or SYMBOL_NIL when no such parameter exists. resolves through `param_index`
+# in O(1).
+# ---
+# r:    the resolve result
+# decl: the function declaration owning the parameter
+# slot: the parameter ordinal
+# ret:  the parameter's SymbolId, or SYMBOL_NIL
+pub fun param_symbol(r: *ResolveResult, decl: id.DeclId, slot: u32) SymbolId {
+    var key: u64 = (decl::u64 << 32) | slot::u64;
+    val g: Result[*SymbolId, str] = map.get[u64, SymbolId](?r.param_index, ?key);
+    if (is_ok[*SymbolId, str](g)) { ret @unwrap_ok[*SymbolId, str](g); }
+    ret SYMBOL_NIL;
 }
 
 # dnit_result: releases every array owned by the result and zeroes its fields.
@@ -250,6 +270,7 @@ pub fun dnit_result(r: *ResolveResult) {
     if (r.decl_symbol != nil) {
         deallocate[SymbolId](r.alloc, r.decl_symbol, r.decl_count::usize);
     }
+    map.dnit[u64, SymbolId](?r.param_index);
     r.symbols       = nil;
     r.symbol_count  = 0;
     r.pub_count     = 0;
@@ -2071,6 +2092,25 @@ fun build_result(rc: *ResolveContext) Result[ResolveResult, str] {
 
     if (remap != nil) { deallocate[u32](rc.s.alloc, remap, rc.sym_len::usize); }
 
+    # index every parameter by (owning decl, ordinal) over the final symbol
+    # array, so lowering resolves a parameter symbol in O(1) rather than scanning
+    # the whole universe per parameter.
+    var param_index: map.Map[u64, SymbolId] = map.init[u64, SymbolId](rc.s.alloc, map.hash_u64, map.eq_u64);
+    var pk: u32 = 0;
+    for (pk < rc.sym_len) {
+        if (out_syms[pk].kind == SYM_PARAM) {
+            val key: u64 = (out_syms[pk].decl::u64 << 32) | out_syms[pk].slot::u64;
+            val ins: Result[bool, str] = map.insert[u64, SymbolId](?param_index, key, pk);
+            if (is_err[bool, str](ins)) {
+                map.dnit[u64, SymbolId](?param_index);
+                deallocate[Symbol](rc.s.alloc, out_syms, rc.sym_len::usize);
+                dnit_context(rc);
+                ret err[ResolveResult, str](unwrap_err[bool, str](ins));
+            }
+        }
+        pk = pk + 1;
+    }
+
     var out: ResolveResult;
     out.alloc         = rc.s.alloc;
     out.symbols       = out_syms;
@@ -2082,6 +2122,7 @@ fun build_result(rc: *ResolveContext) Result[ResolveResult, str] {
     out.expr_count    = rc.a.expr_len::u32;
     out.type_count    = rc.a.type_len::u32;
     out.decl_count    = rc.a.decl_len::u32;
+    out.param_index   = param_index;
 
     rc.expr_resolved = nil;
     rc.type_resolved = nil;

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -144,6 +144,9 @@ pub rec Block {
 # instr_len:   number of instructions in the pool
 # instr_cap:   allocated capacity for the instruction pool
 # flags:       bitwise-or of FN_FLAG_* bits
+# label:       printable source label, carried for an FN_FLAG_TEST function so
+#              the test runner reports it directly instead of inverse-parsing the
+#              mangled linkage name; STR_NIL for every non-test function
 # asm_blocks:  OP_ASM instruction id -> IrAsm payload map
 pub rec Function {
     name:        intern.StrId;
@@ -161,6 +164,7 @@ pub rec Function {
     instr_cap:   u32;
 
     flags:       u32;
+    label:       intern.StrId;
 
     asm_blocks:  map.Map[id.InstructionId, IrAsm];
 }
@@ -205,6 +209,11 @@ pub rec Global {
 # types:        the module's IR type universe
 # init_fn:      some(index into functions) for the synthesized global-init
 #               function, or none when the module needs no runtime init
+# fn_by_name:   linkage name -> index into `functions`, kept in step with every
+#               append so a reference resolves in O(1) instead of a linear scan
+# global_by_name: linkage name -> index into `globals` for user / extern globals
+#               (anonymous data globals are never resolved by name, so they are
+#               not indexed)
 pub rec Module {
     alloc: *Allocator;
     name:  intern.StrId;
@@ -220,6 +229,57 @@ pub rec Module {
     types: ir_type.IrTypeTable;
 
     init_fn: Option[u32];
+
+    fn_by_name:     map.Map[intern.StrId, u32];
+    global_by_name: map.Map[intern.StrId, u32];
+}
+
+# register_function: record `name -> idx` in the module's function index. callers
+# append to `functions` first, then register, so the index mirrors the array.
+# ---
+# m:    the module
+# name: the function's linkage name
+# idx:  its index in `functions`
+# ret:  true on success, or an allocation error
+pub fun register_function(m: *Module, name: intern.StrId, idx: u32) Result[bool, str] {
+    ret map.insert[intern.StrId, u32](?m.fn_by_name, name, idx);
+}
+
+# lookup_function: the index of the function with linkage name `name`, or none.
+# ---
+# m:    the module
+# name: the linkage name to resolve
+# ret:  some(index) when a function of that name exists, none otherwise
+pub fun lookup_function(m: *Module, name: intern.StrId) Option[u32] {
+    var key: intern.StrId = name;
+    val r: Result[*u32, str] = map.get[intern.StrId, u32](?m.fn_by_name, ?key);
+    if (is_ok[*u32, str](r)) { ret some[u32](@unwrap_ok[*u32, str](r)); }
+    ret none[u32]();
+}
+
+# register_global: record `name -> idx` in the module's global index. only user
+# and extern globals are indexed (anonymous data globals are never resolved by
+# name). callers append to `globals` first, then register.
+# ---
+# m:    the module
+# name: the global's linkage name
+# idx:  its index in `globals`
+# ret:  true on success, or an allocation error
+pub fun register_global(m: *Module, name: intern.StrId, idx: u32) Result[bool, str] {
+    ret map.insert[intern.StrId, u32](?m.global_by_name, name, idx);
+}
+
+# lookup_global: the index of the user / extern global with linkage name `name`,
+# or none.
+# ---
+# m:    the module
+# name: the linkage name to resolve
+# ret:  some(index) when an indexed global of that name exists, none otherwise
+pub fun lookup_global(m: *Module, name: intern.StrId) Option[u32] {
+    var key: intern.StrId = name;
+    val r: Result[*u32, str] = map.get[intern.StrId, u32](?m.global_by_name, ?key);
+    if (is_ok[*u32, str](r)) { ret some[u32](@unwrap_ok[*u32, str](r)); }
+    ret none[u32]();
 }
 
 val INITIAL_FN_CAP:     u32 = 8;
@@ -243,6 +303,8 @@ pub fun init_module(alloc: *Allocator, name: intern.StrId) Result[Module, str] {
     m.global_len   = 0;
     m.global_cap   = 0;
     m.init_fn      = none[u32]();
+    m.fn_by_name     = map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
+    m.global_by_name = map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
 
     val rt: Result[ir_type.IrTypeTable, str] = ir_type.init(alloc);
     if (is_err[ir_type.IrTypeTable, str](rt)) {
@@ -289,6 +351,8 @@ pub fun dnit_module(m: *Module) {
     if (m.globals != nil && m.global_cap > 0) {
         deallocate[Global](m.alloc, m.globals, m.global_cap::usize);
     }
+    map.dnit[intern.StrId, u32](?m.fn_by_name);
+    map.dnit[intern.StrId, u32](?m.global_by_name);
     ir_type.dnit(?m.types);
 
     m.functions    = nil;

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -247,11 +247,13 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
     if (d.kind != adecl.DECL_KIND_FUN) { ret err[bool, str]("lower: value-instance origin declaration is not a function"); }
 
     val home_ctx: *comptime.ComptimeCtx = lc.ctx;
+    val home_own: sess.ModuleId         = lc.own_module;
     lc.a           = oa;
     lc.sema_result = osema;
     lc.rr          = orr;
     lc.fqn         = sess.module_fqn(s, origin);
     lc.ctx         = octx;
+    lc.own_module  = origin;
     lc.subst       = nil;
     lc.subst_len   = 0;
 
@@ -266,7 +268,8 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
         val rr: Result[bool, str] = comptime.bind(octx, names[bi], vals[bi]);
         if (is_err[bool, str](rr)) {
             comptime.frame_close(octx, mark);
-            lc.ctx = home_ctx;
+            lc.ctx        = home_ctx;
+            lc.own_module = home_own;
             ret err[bool, str](unwrap_err[bool, str](rr));
         }
         bi = bi + 1;
@@ -274,7 +277,8 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
 
     val lr: Result[bool, str] = decl.lower_value_instance(lc, decl_id, d, name);
     comptime.frame_close(octx, mark);
-    lc.ctx = home_ctx;
+    lc.ctx        = home_ctx;
+    lc.own_module = home_own;
     ret lr;
 }
 
@@ -327,11 +331,16 @@ fun drain_instances(lc: *lctx.LowerContext, s: *sess.Session,
 }
 
 # emits one instance body: binds the context to the instance's origin module
-# (AST, typing, name-resolution, FQN) and substitution env, lowers the template
-# function under the instance name, then leaves the context bound (the caller
-# restores the home inputs once the worklist is drained). a missing origin AST /
-# typing / decl is skipped rather than aborting — the instance then resolves to
-# an undefined symbol the linker reports, never a silently wrong body.
+# (AST, typing, name-resolution, FQN, comptime context, own_module) and
+# substitution env, lowers the template function under the instance name, then
+# restores the comptime context and own_module (the caller restores the other
+# home inputs once the worklist is drained). swapping lc.ctx lets the body fold
+# `$if` gates referencing the defining module's own `pub val`s, mirroring
+# emit_one_value_instance; swapping lc.own_module keeps the origin-comparison
+# helpers in expr.mach coherent while ctx.a is the origin AST. a missing origin
+# AST / typing / comptime context / decl is skipped rather than aborting — the
+# instance then resolves to an undefined symbol the linker reports, never a
+# silently wrong body.
 fun emit_one_instance(lc: *lctx.LowerContext, s: *sess.Session,
                       decl_id: aid.DeclId, origin: sess.ModuleId,
                       args: *ty.TypeId, arg_len: u32, name: intern.StrId) Result[bool, str] {
@@ -341,18 +350,27 @@ fun emit_one_instance(lc: *lctx.LowerContext, s: *sess.Session,
     if (osema == nil) { ret ok[bool, str](true); }
     val orr: *resolve.ResolveResult = (sess.module_resolve_ptr(s, origin))::*resolve.ResolveResult;
     if (orr == nil) { ret ok[bool, str](true); }
+    val octx: *comptime.ComptimeCtx = (sess.module_comptime_ptr(s, origin))::*comptime.ComptimeCtx;
+    if (octx == nil) { ret ok[bool, str](true); }
 
     val d_opt: Option[*adecl.Decl] = ast.get_decl(oa, decl_id);
     if (is_none[*adecl.Decl](d_opt)) { ret ok[bool, str](true); }
     val d: *adecl.Decl = unwrap[*adecl.Decl](d_opt);
     if (d.kind != adecl.DECL_KIND_FUN) { ret ok[bool, str](true); }
 
+    val home_ctx: *comptime.ComptimeCtx = lc.ctx;
+    val home_own: sess.ModuleId         = lc.own_module;
     lc.a           = oa;
     lc.sema_result = osema;
     lc.rr          = orr;
     lc.fqn         = sess.module_fqn(s, origin);
+    lc.ctx         = octx;
+    lc.own_module  = origin;
     lc.subst       = args;
     lc.subst_len   = arg_len;
 
-    ret decl.lower_instance(lc, decl_id, d, name);
+    val lr: Result[bool, str] = decl.lower_instance(lc, decl_id, d, name);
+    lc.ctx        = home_ctx;
+    lc.own_module = home_own;
+    ret lr;
 }

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -859,7 +859,7 @@ pub fun expr_symbol_of(lc: *LowerContext, eid: aid.ExprId) resolve.SymbolId {
 # ret: the module's source text, or the empty string
 pub fun module_source(lc: *LowerContext) str {
     val sf: Option[*src.SourceFile] = src.get(?lc.s.sources, lc.a.file_id);
-    if (is_none[*src.SourceFile](sf)) { ret nil::str; }
+    if (is_none[*src.SourceFile](sf)) { ret ""; }
     ret unwrap[*src.SourceFile](sf).text;
 }
 
@@ -886,11 +886,8 @@ pub fun symbol_of(lc: *LowerContext, sid: resolve.SymbolId) Option[*resolve.Symb
 # ret:  the function index, or an allocation error
 pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_type.IrTypeId) Result[u32, str] {
     val m: *ir.Module = lc.m;
-    var i: u32 = 0;
-    for (i < m.function_len) {
-        if (m.functions[i].name == name) { ret ok[u32, str](i); }
-        i = i + 1;
-    }
+    val existing: Option[u32] = ir.lookup_function(m, name);
+    if (is_some[u32](existing)) { ret ok[u32, str](unwrap[u32](existing)); }
 
     if (m.function_len == m.function_cap) {
         val new_cap: u32 = grow_cap(m.function_cap);
@@ -913,10 +910,13 @@ pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_ty
     f.instr_len   = 0;
     f.instr_cap   = 0;
     f.flags       = ir.FN_FLAG_EXTERN;
+    f.label       = intern.STR_NIL;
     f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, maphash.hash_u32, maphash.eq_u32);
 
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;
+    val reg: Result[bool, str] = ir.register_function(m, name, idx);
+    if (is_err[bool, str](reg)) { ret err[u32, str](unwrap_err[bool, str](reg)); }
 
     # appending may have reallocated `m.functions`, invalidating the builder's
     # raw pointer to the function currently being lowered. re-point it at the
@@ -944,11 +944,8 @@ fun grow_cap(cap: u32) u32 {
 # ret:  the global index, or an allocation error
 pub fun ensure_extern_global(lc: *LowerContext, name: intern.StrId, ty: ir_type.IrTypeId) Result[u32, str] {
     val m: *ir.Module = lc.m;
-    var i: u32 = 0;
-    for (i < m.global_len) {
-        if (m.globals[i].name == name) { ret ok[u32, str](i); }
-        i = i + 1;
-    }
+    val existing: Option[u32] = ir.lookup_global(m, name);
+    if (is_some[u32](existing)) { ret ok[u32, str](unwrap[u32](existing)); }
 
     if (m.global_len == m.global_cap) {
         val new_cap: u32 = grow_cap(m.global_cap);
@@ -969,6 +966,8 @@ pub fun ensure_extern_global(lc: *LowerContext, name: intern.StrId, ty: ir_type.
     g.is_local  = false;
     m.globals[idx] = g;
     m.global_len   = m.global_len + 1;
+    val reg: Result[bool, str] = ir.register_global(m, name, idx);
+    if (is_err[bool, str](reg)) { ret err[u32, str](unwrap_err[bool, str](reg)); }
     ret ok[u32, str](idx);
 }
 

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -517,7 +517,7 @@ fun fold_global_init(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_type.IrT
     # for a wasted comptime.eval pass.
     val cv: Option[comptime.CTValue] = try_comptime(ctx, eid);
     if (is_some[comptime.CTValue](cv)) {
-        ret expr.const_value_of(ctx, eid, unwrap[comptime.CTValue](cv));
+        ret expr.const_value_of_init(ctx, eid, unwrap[comptime.CTValue](cv));
     }
 
     val ie_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -41,6 +41,8 @@ use maphash: std.collections.map;
 use intern:   mach.lang.intern;
 use ty:       mach.lang.type;
 use sess:     mach.lang.session;
+use token:    mach.lang.fe.token;
+use diag:     mach.lang.diagnostic;
 
 use ast:      mach.lang.fe.ast;
 use aid:      mach.lang.fe.ast.id;
@@ -286,9 +288,32 @@ fun lower_test(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl) Result
     if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
     val name: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
 
+    # two `test "label"` blocks in one module mangle (quotes included) to the same
+    # linkage name; appending both emits two same-named definitions and the clash
+    # surfaces only at link time as an internal "multiple definition" of a mangled
+    # symbol with no file / line. catch it here with a source-located diagnostic on
+    # the label and skip the duplicate (the accumulated diagnostic gates the build).
+    if (is_some[u32](ir.lookup_function(ctx.m, name))) {
+        diag.error(?ctx.s.diags, ctx.a.file_id, d.data.test_.label, "duplicate test label in this module");
+        ret ok[bool, str](true);
+    }
+
     val idx_r: Result[u32, str] = append_function(ctx, name, sig, ir.FN_FLAG_TEST, 0);
     if (is_err[u32, str](idx_r)) { ret err[bool, str](unwrap_err[u32, str](idx_r)); }
     val fn_index: u32 = unwrap_ok[u32, str](idx_r);
+
+    # carry the printable label (the literal's inner text, quotes stripped) on the
+    # function so the test runner reports it directly. the mangled linkage name
+    # keeps the quotes, so a label can never collide with a function / global of
+    # the same bare name.
+    var label_span: token.Span = d.data.test_.label;
+    if (label_span.len >= 2::usize) {
+        label_span.offset = label_span.offset + 1::usize;
+        label_span.len    = label_span.len - 2::usize;
+    }
+    val disp_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), label_span);
+    if (is_err[intern.StrId, str](disp_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](disp_r)); }
+    ctx.m.functions[fn_index].label = unwrap_ok[intern.StrId, str](disp_r);
 
     lower.begin_function(ctx, fn_index, ret_ty);
     builder.set_function(?ctx.builder, ?ctx.m.functions[fn_index]);
@@ -416,6 +441,9 @@ fun close_function(ctx: *lower.LowerContext, ret_ir: ir_type.IrTypeId) Result[bo
 # `unreachable` for a noreturn function, a void return for a void function,
 # otherwise a zero return of the declared type.
 fun emit_default_terminator(ctx: *lower.LowerContext, ret_ir: ir_type.IrTypeId) Result[bool, str] {
+    # nothing sets FN_FLAG_NORETURN today — the `.noreturn` comptime attr is not
+    # yet honored (doc/language/comptime-attrs.md) — so this branch is scaffolding
+    # kept ready for when the attr is wired up, not live behaviour.
     if ((ctx.m.functions[ctx.fn_index].flags & ir.FN_FLAG_NORETURN) != 0) {
         ret builder.emit_unreachable(?ctx.builder);
     }
@@ -605,10 +633,13 @@ fun append_function(ctx: *lower.LowerContext, name: intern.StrId, sig: ir_type.I
     f.instr_len   = 0;
     f.instr_cap   = 0;
     f.flags       = flags;
+    f.label       = intern.STR_NIL;
     f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, maphash.hash_u32, maphash.eq_u32);
 
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;
+    val reg: Result[bool, str] = ir.register_function(m, name, idx);
+    if (is_err[bool, str](reg)) { ret err[u32, str](unwrap_err[bool, str](reg)); }
     ret ok[u32, str](idx);
 }
 
@@ -626,6 +657,8 @@ fun append_global(ctx: *lower.LowerContext, g: ir.Global) Result[u32, str] {
     val idx: u32 = m.global_len;
     m.globals[idx] = g;
     m.global_len   = m.global_len + 1;
+    val reg: Result[bool, str] = ir.register_global(m, g.name, idx);
+    if (is_err[bool, str](reg)) { ret err[u32, str](unwrap_err[bool, str](reg)); }
     ret ok[u32, str](idx);
 }
 
@@ -642,17 +675,10 @@ fun function_return_ir(ctx: *lower.LowerContext, did: aid.DeclId) Result[ir_type
 
 # finds the SymbolId of a function parameter by its index: the SYM_PARAM
 # symbol owned by this module whose decl is the function and whose slot is
-# the parameter ordinal.
+# the parameter ordinal. resolves through the resolve result's param index in
+# O(1) rather than scanning the whole symbol universe per parameter.
 fun param_symbol(ctx: *lower.LowerContext, fun_did: aid.DeclId, index: u32) resolve.SymbolId {
-    var i: u32 = 0;
-    for (i < ctx.rr.symbol_count) {
-        val sym: *resolve.Symbol = ?ctx.rr.symbols[i];
-        if (sym.kind == resolve.SYM_PARAM && sym.decl == fun_did && sym.slot == index) {
-            ret i;
-        }
-        i = i + 1;
-    }
-    ret resolve.SYMBOL_NIL;
+    ret resolve.param_symbol(ctx.rr, fun_did, index);
 }
 
 # attempts to fold a global initialiser to a comptime constant, returning

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -731,7 +731,15 @@ pub fun try_lower_comptime_intrinsic(ctx: *lower.LowerContext, eid: aid.ExprId, 
     val is_offset: bool = name == interned_literal(ctx, "offset_of");
     if (!is_size && !is_align && !is_offset) { ret none[Result[value.Value, str]](); }
 
-    if (e.data.call.args_len::usize > ctx.a.expr_id_len) {
+    # bound the argument pool slice this call reads: arg0 (and, for offset_of,
+    # arg1) must lie within the expr-id pool. sema validates intrinsic arities, so
+    # this only guards the indexing — `args_start + args_len <= pool` makes every
+    # ordinal in [args_start, args_start + args_len) addressable, and the per-
+    # intrinsic arity requires the ordinals actually read to be present.
+    var arity: u32 = 1;
+    if (is_offset) { arity = 2; }
+    if (e.data.call.args_len < arity ||
+        e.data.call.args_start::usize + e.data.call.args_len::usize > ctx.a.expr_id_len) {
         ret some[Result[value.Value, str]](err[value.Value, str]("lower: comptime intrinsic argument index out of range"));
     }
     val arg0_eid: aid.ExprId = ctx.a.expr_ids[e.data.call.args_start];
@@ -1851,21 +1859,14 @@ pub fun field_index_in_type(ctx: *lower.LowerContext, rec_ty: ty.TypeId, name: t
 }
 
 # finds the module function index whose interned name matches `name`, or none.
+# the module keeps a name -> index map updated on every append, so this is an
+# O(1) lookup rather than a linear scan over every emitted function.
 fun find_function(ctx: *lower.LowerContext, name: intern.StrId) Option[u32] {
-    var i: u32 = 0;
-    for (i < ctx.m.function_len) {
-        if (ctx.m.functions[i].name == name) { ret some[u32](i); }
-        i = i + 1;
-    }
-    ret none[u32]();
+    ret ir.lookup_function(ctx.m, name);
 }
 
 # finds the module global index whose interned name matches `name`, or none.
+# resolves through the module's name -> index map (user / extern globals).
 fun find_global(ctx: *lower.LowerContext, name: intern.StrId) Option[u32] {
-    var i: u32 = 0;
-    for (i < ctx.m.global_len) {
-        if (ctx.m.globals[i].name == name) { ret some[u32](i); }
-        i = i + 1;
-    }
-    ret none[u32]();
+    ret ir.lookup_global(ctx.m, name);
 }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1702,14 +1702,39 @@ fun lower_struct_lit(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) 
 }
 
 # materialises a comptime CTValue as an IR constant Value at the expression's
-# IR type. used by COMPTIME_IDENT lowering and by the decl lowerer for
-# comptime-evaluable global initialisers.
+# IR type, in EXPRESSION position: a folded CT_KIND_STR is committed to an
+# anonymous `.rodata` global and the Value is a pointer to it, exactly as
+# `lower_lit_str` routes a string literal — a raw byte blob must never reach the
+# back end as an operand. used by COMPTIME_IDENT / comptime-path lowering, the
+# imported-const fallback, and comptime value-parameter references.
 # ---
 # ctx: the context
 # eid: the expression whose IR type the constant takes
 # v:   the folded comptime value
 # ret: the corresponding constant Value, or an error
 pub fun const_value_of(ctx: *lower.LowerContext, eid: aid.ExprId, v: comptime.CTValue) Result[value.Value, str] {
+    ret materialize_const_value(ctx, eid, v, true);
+}
+
+# the global-initialiser counterpart of `const_value_of`: a folded CT_KIND_STR is
+# returned as the raw VAL_CONST_BYTES blob the global-init emission lays out as
+# initialised data in place, rather than committed to a separate rodata global
+# and referenced by pointer. every other value kind is identical.
+# ---
+# ctx: the context
+# eid: the initialiser expression whose IR type the constant takes
+# v:   the folded comptime value
+# ret: the corresponding constant Value, or an error
+pub fun const_value_of_init(ctx: *lower.LowerContext, eid: aid.ExprId, v: comptime.CTValue) Result[value.Value, str] {
+    ret materialize_const_value(ctx, eid, v, false);
+}
+
+# materialises a comptime CTValue as an IR constant Value at the expression's IR
+# type. `expr_pos` selects how a CT_KIND_STR is realised: an expression-position
+# string constant becomes a rodata global plus a pointer to it (a raw blob must
+# never become an operand), while a global initialiser keeps the raw blob for
+# in-place data emission. the int / bool / float kinds are position-independent.
+fun materialize_const_value(ctx: *lower.LowerContext, eid: aid.ExprId, v: comptime.CTValue, expr_pos: bool) Result[value.Value, str] {
     val tr: Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
     if (is_err[ir_type.IrTypeId, str](tr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](tr)); }
     val ty_id: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
@@ -1727,7 +1752,9 @@ pub fun const_value_of(ctx: *lower.LowerContext, eid: aid.ExprId, v: comptime.CT
         val s: str = unwrap[str](txt);
         # include the trailing '\0' so the emitted blob is a valid null-terminated
         # `str` rather than relying on section padding (see lower_lit_str).
-        ret ok[value.Value, str](value.const_bytes(s::*u8, (str_len(s) + 1::usize)::u32, ty_id));
+        val blob: value.Value = value.const_bytes(s::*u8, (str_len(s) + 1::usize)::u32, ty_id);
+        if (expr_pos) { ret lower.add_rodata_bytes(ctx, blob, ty_id); }
+        ret ok[value.Value, str](blob);
     }
     ret err[value.Value, str]("lower: unsupported comptime value kind");
 }

--- a/src/lang/me/lower/testrunner.mach
+++ b/src/lang/me/lower/testrunner.mach
@@ -10,7 +10,7 @@
 # test's linkage name so the runner can `call` it across object boundaries, plus
 # a private `.rodata` global holding the test's label text. the runner's `main`
 # invokes each test in turn, interprets the returned `i32` as a process status
-# (`0` = pass, non-zero = fail), prints a line per test plus a summary, and
+# (`0` = pass, non-zero = fail), prints a `PASS`/`FAIL` line per test, and
 # returns `0` when every test passed and `1` otherwise.
 #
 # the only OS interaction is a `write` syscall, emitted as a small inline-asm
@@ -162,7 +162,10 @@ fun collect_tests(s: *sess.Session, modules: *ir.Module, count: u32,
             if ((fn.flags & ir.FN_FLAG_TEST) != 0) {
                 var t: Test;
                 t.linkage = fn.name;
-                t.label   = label_of(s, fn.name);
+                # the printable label is carried on the function by lower_test, so
+                # the runner reports it directly rather than inverse-parsing the
+                # mangled linkage name.
+                t.label   = fn.label;
                 val ar: Result[bool, str] = push_test(s, tests, test_len, test_cap, t);
                 if (is_err[bool, str](ar)) { ret ar; }
             }
@@ -171,55 +174,6 @@ fun collect_tests(s: *sess.Session, modules: *ir.Module, count: u32,
         mi = mi + 1;
     }
     ret ok[bool, str](true);
-}
-
-# label_of: recover the source label from a test function's mangled linkage
-# name. the mangler emits `_M<path>N<len><name>`, and a test's `<name>` is its
-# label, so the label is the `<len>`-byte run after the final `N<len>`. falls
-# back to the whole linkage name when the shape is unexpected.
-fun label_of(s: *sess.Session, linkage: intern.StrId) intern.StrId {
-    val o: Option[str] = intern.lookup(?s.interner, linkage);
-    if (is_none[str](o)) { ret linkage; }
-    val name: str = unwrap[str](o);
-    val n: usize = str_len(name);
-
-    var i: usize = 0;
-    var best_start: usize = 0;
-    var best_len: usize = 0;
-    var found: bool = false;
-    for (i < n) {
-        if (name[i] == 'N') {
-            var j: usize = i + 1;
-            var num: usize = 0;
-            var digits: usize = 0;
-            for (j < n && name[j] >= '0' && name[j] <= '9') {
-                num = num * 10 + (name[j] - '0')::usize;
-                j = j + 1;
-                digits = digits + 1;
-            }
-            if (digits > 0 && j + num <= n) {
-                best_start = j;
-                best_len   = num;
-                found      = true;
-            }
-        }
-        i = i + 1;
-    }
-    if (!found || best_len == 0) { ret linkage; }
-
-    # a test label is parsed from a string-literal token, so its mangled `<name>`
-    # still carries the surrounding quotes; strip a matching pair so the printed
-    # label is the bare text.
-    var off: usize = best_start;
-    var len: usize = best_len;
-    if (len >= 2 && name[off] == '"' && name[off + len - 1] == '"') {
-        off = off + 1;
-        len = len - 2;
-    }
-
-    val r: Result[intern.StrId, str] = intern.intern_bytes(?s.interner, (name::usize + off)::str, len);
-    if (is_err[intern.StrId, str](r)) { ret linkage; }
-    ret unwrap_ok[intern.StrId, str](r);
 }
 
 fun push_test(s: *sess.Session, tests: **Test, test_len: *u32, test_cap: *u32, t: Test) Result[bool, str] {
@@ -301,9 +255,12 @@ fun append_function(c: *Ctx, name: intern.StrId, sig: ir_type.IrTypeId, flags: u
     f.instr_len   = 0;
     f.instr_cap   = 0;
     f.flags       = flags;
+    f.label       = intern.STR_NIL;
     f.asm_blocks  = map.init[irid.InstructionId, ir.IrAsm](m.alloc, maphash.hash_u32, maphash.eq_u32);
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;
+    val reg: Result[bool, str] = ir.register_function(m, name, idx);
+    if (is_err[bool, str](reg)) { ret err[u32, str](unwrap_err[bool, str](reg)); }
     ret ok[u32, str](idx);
 }
 
@@ -351,12 +308,10 @@ fun begin_fn(c: *Ctx, name: intern.StrId, ret_ty: ir_type.IrTypeId,
 # extern_fn: declare a signature-only `i32()` extern under `linkage` and return a
 # VAL_FN reference to it, reusing an existing declaration when present.
 fun extern_fn(c: *Ctx, linkage: intern.StrId) Result[value.Value, str] {
-    var fi: u32 = 0;
-    for (fi < c.m.function_len) {
-        if (c.m.functions[fi].name == linkage) {
-            ret ok[value.Value, str](value.fn_value(fi, c.m.functions[fi].sig));
-        }
-        fi = fi + 1;
+    val existing: Option[u32] = ir.lookup_function(c.m, linkage);
+    if (is_some[u32](existing)) {
+        val ei: u32 = unwrap[u32](existing);
+        ret ok[value.Value, str](value.fn_value(ei, c.m.functions[ei].sig));
     }
     val sig_r: Result[ir_type.IrTypeId, str] = ir_type.intern_fn(?c.m.types, c.i32, nil, 0, false);
     if (is_err[ir_type.IrTypeId, str](sig_r)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](sig_r)); }
@@ -589,10 +544,18 @@ fun emit_streq_helper(c: *Ctx) Result[bool, str] {
 
     # header: load a[i], b[i]; continue iff both non-zero and equal.
     builder.set_block(?c.b, hdr);
-    val abyte_r: Result[value.Value, str] = byte_at(c, ld(c, slots[0]), ld_i64(c, islot));
+    val ap_r: Result[value.Value, str] = ld(c, slots[0]);
+    if (is_err[value.Value, str](ap_r)) { ret err[bool, str](unwrap_err[value.Value, str](ap_r)); }
+    val ai_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](ai_r)) { ret err[bool, str](unwrap_err[value.Value, str](ai_r)); }
+    val abyte_r: Result[value.Value, str] = byte_at(c, unwrap_ok[value.Value, str](ap_r), unwrap_ok[value.Value, str](ai_r));
     if (is_err[value.Value, str](abyte_r)) { ret err[bool, str](unwrap_err[value.Value, str](abyte_r)); }
     val abyte: value.Value = unwrap_ok[value.Value, str](abyte_r);
-    val bbyte_r: Result[value.Value, str] = byte_at(c, ld(c, slots[1]), ld_i64(c, islot));
+    val bp_r: Result[value.Value, str] = ld(c, slots[1]);
+    if (is_err[value.Value, str](bp_r)) { ret err[bool, str](unwrap_err[value.Value, str](bp_r)); }
+    val bi_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](bi_r)) { ret err[bool, str](unwrap_err[value.Value, str](bi_r)); }
+    val bbyte_r: Result[value.Value, str] = byte_at(c, unwrap_ok[value.Value, str](bp_r), unwrap_ok[value.Value, str](bi_r));
     if (is_err[value.Value, str](bbyte_r)) { ret err[bool, str](unwrap_err[value.Value, str](bbyte_r)); }
     val bbyte: value.Value = unwrap_ok[value.Value, str](bbyte_r);
 
@@ -608,7 +571,9 @@ fun emit_streq_helper(c: *Ctx) Result[bool, str] {
 
     # body: i = i + 1; back to header.
     builder.set_block(?c.b, body);
-    val inc_r: Result[value.Value, str] = builder.emit_add(?c.b, ld_i64(c, islot), value.const_int(1, c.i64));
+    val bi2_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](bi2_r)) { ret err[bool, str](unwrap_err[value.Value, str](bi2_r)); }
+    val inc_r: Result[value.Value, str] = builder.emit_add(?c.b, unwrap_ok[value.Value, str](bi2_r), value.const_int(1, c.i64));
     if (is_err[value.Value, str](inc_r)) { ret err[bool, str](unwrap_err[value.Value, str](inc_r)); }
     val st_r: Result[bool, str] = builder.emit_store(?c.b, unwrap_ok[value.Value, str](inc_r), islot);
     if (is_err[bool, str](st_r)) { ret st_r; }
@@ -617,9 +582,17 @@ fun emit_streq_helper(c: *Ctx) Result[bool, str] {
 
     # exit: equal iff a[i]==b[i] (both at terminator).
     builder.set_block(?c.b, exit_b);
-    val fa_r: Result[value.Value, str] = byte_at(c, ld(c, slots[0]), ld_i64(c, islot));
+    val fap_r: Result[value.Value, str] = ld(c, slots[0]);
+    if (is_err[value.Value, str](fap_r)) { ret err[bool, str](unwrap_err[value.Value, str](fap_r)); }
+    val fai_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](fai_r)) { ret err[bool, str](unwrap_err[value.Value, str](fai_r)); }
+    val fa_r: Result[value.Value, str] = byte_at(c, unwrap_ok[value.Value, str](fap_r), unwrap_ok[value.Value, str](fai_r));
     if (is_err[value.Value, str](fa_r)) { ret err[bool, str](unwrap_err[value.Value, str](fa_r)); }
-    val fb_r: Result[value.Value, str] = byte_at(c, ld(c, slots[1]), ld_i64(c, islot));
+    val fbp_r: Result[value.Value, str] = ld(c, slots[1]);
+    if (is_err[value.Value, str](fbp_r)) { ret err[bool, str](unwrap_err[value.Value, str](fbp_r)); }
+    val fbi_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](fbi_r)) { ret err[bool, str](unwrap_err[value.Value, str](fbi_r)); }
+    val fb_r: Result[value.Value, str] = byte_at(c, unwrap_ok[value.Value, str](fbp_r), unwrap_ok[value.Value, str](fbi_r));
     if (is_err[value.Value, str](fb_r)) { ret err[bool, str](unwrap_err[value.Value, str](fb_r)); }
     val feq_r: Result[value.Value, str] = builder.emit_cmp_eq(?c.b, unwrap_ok[value.Value, str](fa_r), unwrap_ok[value.Value, str](fb_r));
     if (is_err[value.Value, str](feq_r)) { ret err[bool, str](unwrap_err[value.Value, str](feq_r)); }
@@ -657,7 +630,9 @@ fun emit_contains_helper(c: *Ctx) Result[bool, str] {
     val jslot: value.Value = unwrap_ok[value.Value, str](jslot_r);
 
     # empty needle (needle[0] == 0) matches: return 1 immediately.
-    val n0_r: Result[value.Value, str] = byte_at(c, ld(c, slots[1]), value.const_int(0, c.i64));
+    val np0_r: Result[value.Value, str] = ld(c, slots[1]);
+    if (is_err[value.Value, str](np0_r)) { ret err[bool, str](unwrap_err[value.Value, str](np0_r)); }
+    val n0_r: Result[value.Value, str] = byte_at(c, unwrap_ok[value.Value, str](np0_r), value.const_int(0, c.i64));
     if (is_err[value.Value, str](n0_r)) { ret err[bool, str](unwrap_err[value.Value, str](n0_r)); }
     val nempty_r: Result[value.Value, str] = builder.emit_cmp_eq(?c.b, unwrap_ok[value.Value, str](n0_r), zero8);
     if (is_err[value.Value, str](nempty_r)) { ret err[bool, str](unwrap_err[value.Value, str](nempty_r)); }
@@ -698,7 +673,11 @@ fun emit_contains_helper(c: *Ctx) Result[bool, str] {
 
     builder.set_block(?c.b, outer);
     # outer header: stop (no match) when hay[i] == 0.
-    val hi_r: Result[value.Value, str] = byte_at(c, ld(c, slots[0]), ld_i64(c, islot));
+    val hp_r: Result[value.Value, str] = ld(c, slots[0]);
+    if (is_err[value.Value, str](hp_r)) { ret err[bool, str](unwrap_err[value.Value, str](hp_r)); }
+    val hpi_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](hpi_r)) { ret err[bool, str](unwrap_err[value.Value, str](hpi_r)); }
+    val hi_r: Result[value.Value, str] = byte_at(c, unwrap_ok[value.Value, str](hp_r), unwrap_ok[value.Value, str](hpi_r));
     if (is_err[value.Value, str](hi_r)) { ret err[bool, str](unwrap_err[value.Value, str](hi_r)); }
     val hay_nz_r: Result[value.Value, str] = builder.emit_cmp_ne(?c.b, unwrap_ok[value.Value, str](hi_r), zero8);
     if (is_err[value.Value, str](hay_nz_r)) { ret err[bool, str](unwrap_err[value.Value, str](hay_nz_r)); }
@@ -713,7 +692,11 @@ fun emit_contains_helper(c: *Ctx) Result[bool, str] {
 
     builder.set_block(?c.b, inner);
     # inner header: needle[j]==0 => full match. else hay[i+j]==needle[j] => advance.
-    val nj_r: Result[value.Value, str] = byte_at(c, ld(c, slots[1]), ld_i64(c, jslot));
+    val njp_r: Result[value.Value, str] = ld(c, slots[1]);
+    if (is_err[value.Value, str](njp_r)) { ret err[bool, str](unwrap_err[value.Value, str](njp_r)); }
+    val njj_r: Result[value.Value, str] = ld_i64(c, jslot);
+    if (is_err[value.Value, str](njj_r)) { ret err[bool, str](unwrap_err[value.Value, str](njj_r)); }
+    val nj_r: Result[value.Value, str] = byte_at(c, unwrap_ok[value.Value, str](njp_r), unwrap_ok[value.Value, str](njj_r));
     if (is_err[value.Value, str](nj_r)) { ret err[bool, str](unwrap_err[value.Value, str](nj_r)); }
     val nj: value.Value = unwrap_ok[value.Value, str](nj_r);
     val nj_zero_r: Result[value.Value, str] = builder.emit_cmp_eq(?c.b, nj, zero8);
@@ -723,9 +706,15 @@ fun emit_contains_helper(c: *Ctx) Result[bool, str] {
 
     builder.set_block(?c.b, inner_adv);
     # compare hay[i+j] to needle[j]; on mismatch advance the outer index.
-    val ij_r: Result[value.Value, str] = builder.emit_add(?c.b, ld_i64(c, islot), ld_i64(c, jslot));
+    val iji_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](iji_r)) { ret err[bool, str](unwrap_err[value.Value, str](iji_r)); }
+    val ijj_r: Result[value.Value, str] = ld_i64(c, jslot);
+    if (is_err[value.Value, str](ijj_r)) { ret err[bool, str](unwrap_err[value.Value, str](ijj_r)); }
+    val ij_r: Result[value.Value, str] = builder.emit_add(?c.b, unwrap_ok[value.Value, str](iji_r), unwrap_ok[value.Value, str](ijj_r));
     if (is_err[value.Value, str](ij_r)) { ret err[bool, str](unwrap_err[value.Value, str](ij_r)); }
-    val hij_r: Result[value.Value, str] = byte_at(c, ld(c, slots[0]), unwrap_ok[value.Value, str](ij_r));
+    val hijp_r: Result[value.Value, str] = ld(c, slots[0]);
+    if (is_err[value.Value, str](hijp_r)) { ret err[bool, str](unwrap_err[value.Value, str](hijp_r)); }
+    val hij_r: Result[value.Value, str] = byte_at(c, unwrap_ok[value.Value, str](hijp_r), unwrap_ok[value.Value, str](ij_r));
     if (is_err[value.Value, str](hij_r)) { ret err[bool, str](unwrap_err[value.Value, str](hij_r)); }
     val same_r: Result[value.Value, str] = builder.emit_cmp_eq(?c.b, unwrap_ok[value.Value, str](hij_r), nj);
     if (is_err[value.Value, str](same_r)) { ret err[bool, str](unwrap_err[value.Value, str](same_r)); }
@@ -736,7 +725,9 @@ fun emit_contains_helper(c: *Ctx) Result[bool, str] {
     if (is_err[bool, str](cbr_s)) { ret cbr_s; }
 
     builder.set_block(?c.b, jadv);
-    val jinc_r: Result[value.Value, str] = builder.emit_add(?c.b, ld_i64(c, jslot), value.const_int(1, c.i64));
+    val jcur_r: Result[value.Value, str] = ld_i64(c, jslot);
+    if (is_err[value.Value, str](jcur_r)) { ret err[bool, str](unwrap_err[value.Value, str](jcur_r)); }
+    val jinc_r: Result[value.Value, str] = builder.emit_add(?c.b, unwrap_ok[value.Value, str](jcur_r), value.const_int(1, c.i64));
     if (is_err[value.Value, str](jinc_r)) { ret err[bool, str](unwrap_err[value.Value, str](jinc_r)); }
     val jst: Result[bool, str] = builder.emit_store(?c.b, unwrap_ok[value.Value, str](jinc_r), jslot);
     if (is_err[bool, str](jst)) { ret jst; }
@@ -744,7 +735,9 @@ fun emit_contains_helper(c: *Ctx) Result[bool, str] {
     if (is_err[bool, str](jloop)) { ret jloop; }
 
     builder.set_block(?c.b, outer_adv);
-    val iinc_r: Result[value.Value, str] = builder.emit_add(?c.b, ld_i64(c, islot), value.const_int(1, c.i64));
+    val icur_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](icur_r)) { ret err[bool, str](unwrap_err[value.Value, str](icur_r)); }
+    val iinc_r: Result[value.Value, str] = builder.emit_add(?c.b, unwrap_ok[value.Value, str](icur_r), value.const_int(1, c.i64));
     if (is_err[value.Value, str](iinc_r)) { ret err[bool, str](unwrap_err[value.Value, str](iinc_r)); }
     val ist: Result[bool, str] = builder.emit_store(?c.b, unwrap_ok[value.Value, str](iinc_r), islot);
     if (is_err[bool, str](ist)) { ret ist; }
@@ -770,18 +763,15 @@ fun alloc_i64_slot(c: *Ctx, init: value.Value) Result[value.Value, str] {
     ret ok[value.Value, str](slot);
 }
 
-# ld / ld_i64: convenience loads that abort the synthesis on error by returning a
-# null value the subsequent emit rejects; used only where a slot is known-valid
-# (a parameter or freshly-allocated local), so the load cannot actually fail.
-fun ld(c: *Ctx, slot: value.Value) value.Value {
-    val r: Result[value.Value, str] = builder.emit_load(?c.b, slot, c.ptr);
-    if (is_err[value.Value, str](r)) { ret value.const_null(c.ptr); }
-    ret unwrap_ok[value.Value, str](r);
+# ld / ld_i64: convenience loads from a known-valid slot (a parameter or a
+# freshly-allocated local). emit_load can still fail on an allocation error when
+# it grows the instruction pool, so the error is propagated like every other emit
+# in this file rather than swallowed behind a placeholder constant.
+fun ld(c: *Ctx, slot: value.Value) Result[value.Value, str] {
+    ret builder.emit_load(?c.b, slot, c.ptr);
 }
-fun ld_i64(c: *Ctx, slot: value.Value) value.Value {
-    val r: Result[value.Value, str] = builder.emit_load(?c.b, slot, c.i64);
-    if (is_err[value.Value, str](r)) { ret value.const_int(0, c.i64); }
-    ret unwrap_ok[value.Value, str](r);
+fun ld_i64(c: *Ctx, slot: value.Value) Result[value.Value, str] {
+    ret builder.emit_load(?c.b, slot, c.i64);
 }
 
 # emit_main: the `main(argc: i64, argv: **u8) i32` runner. it reads `--list` and
@@ -938,13 +928,17 @@ fun emit_argv_scan(c: *Ctx, argc_slot: value.Value, argv_slot: value.Value,
     builder.set_block(?c.b, hdr);
     val argc_v_r: Result[value.Value, str] = builder.emit_load(?c.b, argc_slot, c.i64);
     if (is_err[value.Value, str](argc_v_r)) { ret err[bool, str](unwrap_err[value.Value, str](argc_v_r)); }
-    val lt_r: Result[value.Value, str] = builder.emit_cmp_lt_s(?c.b, ld_i64(c, islot), unwrap_ok[value.Value, str](argc_v_r));
+    val hi2_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](hi2_r)) { ret err[bool, str](unwrap_err[value.Value, str](hi2_r)); }
+    val lt_r: Result[value.Value, str] = builder.emit_cmp_lt_s(?c.b, unwrap_ok[value.Value, str](hi2_r), unwrap_ok[value.Value, str](argc_v_r));
     if (is_err[value.Value, str](lt_r)) { ret err[bool, str](unwrap_err[value.Value, str](lt_r)); }
     val hcbr: Result[bool, str] = builder.emit_cbr(?c.b, unwrap_ok[value.Value, str](lt_r), body, done);
     if (is_err[bool, str](hcbr)) { ret hcbr; }
 
     builder.set_block(?c.b, body);
-    val arg_r: Result[value.Value, str] = argv_at(c, argv_slot, ld_i64(c, islot));
+    val bidx_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](bidx_r)) { ret err[bool, str](unwrap_err[value.Value, str](bidx_r)); }
+    val arg_r: Result[value.Value, str] = argv_at(c, argv_slot, unwrap_ok[value.Value, str](bidx_r));
     if (is_err[value.Value, str](arg_r)) { ret err[bool, str](unwrap_err[value.Value, str](arg_r)); }
     val arg: value.Value = unwrap_ok[value.Value, str](arg_r);
 
@@ -973,7 +967,9 @@ fun emit_argv_scan(c: *Ctx, argc_slot: value.Value, argv_slot: value.Value,
     if (is_err[bool, str](fcbr)) { ret fcbr; }
 
     builder.set_block(?c.b, set_filt_b);
-    val next_i_r: Result[value.Value, str] = builder.emit_add(?c.b, ld_i64(c, islot), value.const_int(1, c.i64));
+    val fcur_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](fcur_r)) { ret err[bool, str](unwrap_err[value.Value, str](fcur_r)); }
+    val next_i_r: Result[value.Value, str] = builder.emit_add(?c.b, unwrap_ok[value.Value, str](fcur_r), value.const_int(1, c.i64));
     if (is_err[value.Value, str](next_i_r)) { ret err[bool, str](unwrap_err[value.Value, str](next_i_r)); }
     val argc_v2_r: Result[value.Value, str] = builder.emit_load(?c.b, argc_slot, c.i64);
     if (is_err[value.Value, str](argc_v2_r)) { ret err[bool, str](unwrap_err[value.Value, str](argc_v2_r)); }
@@ -994,7 +990,9 @@ fun emit_argv_scan(c: *Ctx, argc_slot: value.Value, argv_slot: value.Value,
     if (is_err[bool, str](svbr)) { ret svbr; }
 
     builder.set_block(?c.b, latch);
-    val iinc_r: Result[value.Value, str] = builder.emit_add(?c.b, ld_i64(c, islot), value.const_int(1, c.i64));
+    val lcur_r: Result[value.Value, str] = ld_i64(c, islot);
+    if (is_err[value.Value, str](lcur_r)) { ret err[bool, str](unwrap_err[value.Value, str](lcur_r)); }
+    val iinc_r: Result[value.Value, str] = builder.emit_add(?c.b, unwrap_ok[value.Value, str](lcur_r), value.const_int(1, c.i64));
     if (is_err[value.Value, str](iinc_r)) { ret err[bool, str](unwrap_err[value.Value, str](iinc_r)); }
     val ist: Result[bool, str] = builder.emit_store(?c.b, unwrap_ok[value.Value, str](iinc_r), islot);
     if (is_err[bool, str](ist)) { ret ist; }


### PR DESCRIPTION
Addresses the actionable findings from the 2026-06 lowering audit (#1251). Each bug fix ships with a failing-before regression test under `.github/tests/lower/` and `.github/tests/lower-testrunner/`.

- [x] **[BUG/M]** comptime string in expression position → codegen panic. `const_value_of` routes a folded `CT_KIND_STR` through `add_rodata_bytes` (pointer to anon `.rodata`); `const_value_of_init` keeps the raw blob for global-init data. (`lower/comptime-str`)
- [x] **[BUG/S]** generic type-instance drain now swaps the origin module's comptime context and `own_module`, mirroring the value-instance drain. (`lower/xmod-generic`)
- [—] **[BUG/M]** mixed-signedness integer comparisons. Dispositioned, **no lowering change**: `operators.md` ("compare values of matching types") is the arbiter, so the fix is sema rejection — see the [joint recommendation](https://github.com/octalide/mach/issues/1251#issuecomment-4672578503) on #1251 and #1248. Lowering's LHS-derived signedness is correct for matching-type operands; implementing mixed-sign semantics here would paper over a sema permissiveness hole.
- [x] **[DESIGN/M]** `label_of` inverse-mangling deleted; the printable label is carried on `ir.Function` and read directly by the runner. (`lower-testrunner/nlabel`)
- [x] **[SMELL/S]** comptime-intrinsic arg-pool guard corrected (`args_start + args_len <= pool` + per-intrinsic arity; `$offset_of` arg1 now bounded).
- [x] **[SMELL/S]** duplicate test labels → source-located "duplicate test label" diagnostic at lowering instead of a mangled link error. (`lower-testrunner/duplabel`)
- [x] **[SMELL/M]** quadratic scans: `fn_by_name`/`global_by_name` indices on `ir.Module` (O(1) find_function/find_global/ensure_extern_*); `(decl, slot) → SymbolId` param index on `ResolveResult` (O(1) `param_symbol`).
- [x] **[CLEANUP/S]** `module_source` returns `""` not nil-str; `ld`/`ld_i64` thread Results instead of swallowing errors; runner header summary line corrected; `FN_FLAG_NORETURN` branch annotated as pending the `.noreturn` attr.

Deliberately deferred to the ABI-boundary work ([commented on #1251](https://github.com/octalide/mach/issues/1251#issuecomment-4672579421)):
- **[DESIGN/M]** testrunner hardcoded Linux/x86_64 `write` syscall (no target input).
- **[DESIGN/S]** `lower_va_list` hardcoded SysV `__va_list_tag` layout.

Verified: `mach build .` clean, `mach test .` 235/235, all `.github/tests/*` integration suites pass (incl. win64 under wine), windows cross-compile of the compiler builds, and the build reaches the byte-identical self-host fixpoint.

`Refs #1251` (not `Closes`, since two findings are deferred and the mixed-signedness fix lands in #1248).
