### PR TITLE
fix(regalloc): FP-bank interference, win64 XMM callee-save, asm clobbers (#1254)

### DIFF
--- a/.github/tests/asmclobber/app/mach.toml
+++ b/.github/tests/asmclobber/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "asmclobber"
+name = "inline-asm clobber regression — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "linux"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/asmclobber"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/asmclobber/app/src/main.mach
+++ b/.github/tests/asmclobber/app/src/main.mach
@@ -1,0 +1,47 @@
+use std.runtime.linux.x86_64;
+
+# Inline-asm clobber regression (#1254). doc/language/asm.md promises the
+# compiler infers each instruction's clobbers; regalloc instead modeled an asm
+# block only as a caller-saved call barrier. two corruptions followed: (1) a
+# value parked in a callee-saved register the asm writes, and (2) a caller's
+# value preserved in a callee-saved register the called asm-bearing function
+# overwrites without saving. both are reproduced here.
+
+# clobber: `keep` is live across `asm { mov rbx, 999 }`. before the fix it was
+# colored rbx (pick_gp prefers callee-saved for call-crossing values) and the
+# asm overwrote it, so the function returned 999 instead of p + 42.
+fun clobber(p: i64) i64 {
+    val keep: i64 = p + 42;
+    asm x86_64 {
+        mov rbx, 999
+    }
+    ret keep;
+}
+
+# writes_rbx: a value-free asm-only function whose asm writes the callee-saved
+# RBX. before the fix it was emitted naked (no prologue), so it never preserved
+# RBX for its caller.
+fun writes_rbx() i64 {
+    asm x86_64 {
+        mov rbx, 999
+    }
+    ret 7;
+}
+
+# caller: `held` lives across the call to writes_rbx() in a callee-saved register
+# (RBX). before the fix writes_rbx clobbered RBX without saving it, so `held`
+# came back as 999.
+fun caller(seed: i64) i64 {
+    val held: i64 = seed * 2;
+    val r: i64 = writes_rbx();
+    ret held + r;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # clobber(1) == 43; the bug returned 999.
+    if (clobber(1) != 43) { ret 1; }
+    # caller(50) == 100 + 7 == 107; the bug returned 999 + 7 == 1006.
+    if (caller(50) != 107) { ret 2; }
+    ret 0;
+}

--- a/.github/tests/asmclobber/run.sh
+++ b/.github/tests/asmclobber/run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# inline-asm clobber regression test (#1254): regalloc modeled an inline-asm
+# block only as a caller-saved call barrier, ignoring the callee-saved registers
+# the body writes. a value parked in such a register was overwritten (1), and an
+# asm-bearing function corrupted its caller's preserved register because the
+# clobbered register never reached the prologue save mask (2). this builds a
+# program exercising both shapes at -O0 (so the asm and calls are real) and runs
+# it natively; main exits 0 only when both reads see the correct value.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# build at -O0 so the asm blocks and calls are not optimized away — the clobber
+# barrier must be exercised at the asm and the call boundary.
+if ! ( cd "$WORK/app" && "$MACH" build . -O0 ) >/dev/null 2>&1; then
+    echo "FAIL asmclobber: native build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/asmclobber"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS asmclobber: a value across an asm and a caller's register survive the asm's clobbers"
+    exit 0
+fi
+
+echo "FAIL asmclobber: inline-asm clobber miscompiled (exit $code: 1=value parked in clobbered reg, 2=caller corruption)" >&2
+exit 1

--- a/.github/tests/fpargs/app/mach.toml
+++ b/.github/tests/fpargs/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "fpargs"
+name = "fp-bank interference regression — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "linux"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/fpargs"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/fpargs/app/src/main.mach
+++ b/.github/tests/fpargs/app/src/main.mach
@@ -1,0 +1,46 @@
+use std.runtime.linux.x86_64;
+
+# FP-bank interference regression (#1254). Before the fix, the precolored
+# def / argument-window reservations and the param-register pinning that guard
+# physical-register operands were GP-only: an FP value live across a float
+# argument-setup move could be colored onto the XMM register that move writes,
+# so swapped float arguments collapsed to the same value. take(b, a) forwarding
+# returned b - b == 0 instead of b - a.
+
+# near: 1 when |a - b| < 0.001, else 0. avoids an exact float equality.
+fun near(a: f64, b: f64) i64 {
+    var d: f64 = a - b;
+    if (d < 0.0) { d = 0.0 - d; }
+    if (d < 0.001) { ret 1; }
+    ret 0;
+}
+
+fun take(a: f64, b: f64) f64 { ret a - b; }
+
+# the core repro: param capture colors a -> xmm0, b -> xmm1; the take(b, a)
+# setup writes xmm0 then reads the clobbered a from xmm0.
+fun swap_call(a: f64, b: f64) f64 { ret take(b, a); }
+
+fun take3(a: f64, b: f64, c: f64) f64 { ret a * 100.0 + b * 10.0 + c; }
+fun rev3(a: f64, b: f64, c: f64) f64 { ret take3(c, b, a); }
+
+fun sub(a: f64, b: f64) f64 { ret a - b; }
+
+# keep is live across the sub() call; the result mixes a call-crossing float
+# with a freshly placed argument.
+fun acc(x: f64) f64 {
+    val keep: f64 = x + 0.5;
+    val s: f64 = sub(x, 1.0);
+    ret keep + s;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # take(3.0, 10.0) == -7.0; the bug returned 0.0.
+    if (near(swap_call(10.0, 3.0), -7.0) == 0) { ret 1; }
+    # rev3(1, 2, 3) -> take3(3, 2, 1) == 321.0.
+    if (near(rev3(1.0, 2.0, 3.0), 321.0) == 0) { ret 2; }
+    # acc(4.0) = (4.5) + (4.0 - 1.0) == 7.5.
+    if (near(acc(4.0), 7.5) == 0) { ret 3; }
+    ret 0;
+}

--- a/.github/tests/fpargs/run.sh
+++ b/.github/tests/fpargs/run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# FP-bank interference regression test (#1254): the precolored-register
+# reservation and param-pinning interference machinery was GP-only, so an FP
+# value live across a float argument-setup move could be colored onto the XMM
+# register that move writes. swapped float arguments then collapsed to one value
+# (take(b, a) returned b - b == 0). this builds a float-heavy program at -O0 (so
+# the calls are real, not inlined) and runs it natively; main exits 0 only when
+# every float forwarding produced the right value (1 = 2-arg swap, 2 = 3-arg
+# reverse, 3 = call-crossing float).
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# build at -O0 so the calls are not inlined away — the FP argument-setup path
+# must actually be exercised at the call boundary.
+if ! ( cd "$WORK/app" && "$MACH" build . -O0 ) >/dev/null 2>&1; then
+    echo "FAIL fpargs: native build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/fpargs"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS fpargs: swapped and call-crossing float arguments forward correctly"
+    exit 0
+fi
+
+echo "FAIL fpargs: float argument forwarding miscompiled (exit $code: 1=swap, 2=reverse, 3=call-crossing)" >&2
+exit 1

--- a/.github/tests/win64fp/app/mach.toml
+++ b/.github/tests/win64fp/app/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id = "win64fp"
+name = "win64 callee-saved XMM regression — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "windows"
+
+[targets.windows]
+os = "windows"
+isa = "x86_64"
+abi = "win64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "windows"
+binary = "windows/bin/win64fp.exe"
+libs = ["kernel32.dll"]
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/win64fp/app/src/main.mach
+++ b/.github/tests/win64fp/app/src/main.mach
@@ -1,0 +1,41 @@
+use std.runtime.windows.x86_64;
+
+# win64 callee-saved XMM regression (#1254). Under win64, XMM6–15 are callee-
+# saved, but regalloc handed them out and the prologue never saved them. A
+# function with several FP values live across a call now keeps them in
+# callee-saved XMM6+ (rather than spilling every float as the old conservative
+# model did) and the prologue preserves them with 16-byte-aligned MOVAPS saves
+# (described in .xdata as UWOP_SAVE_XMM128). A misaligned save would fault under
+# wine; a dropped save would corrupt a caller's preserved register.
+
+fun mul2(x: f64) f64 { ret x * 2.0; }
+
+# eight values live across the mul2 call, forcing the allocator to use the
+# callee-saved XMM6+ partition for the call-crossing floats.
+fun compute(a: f64, b: f64, c: f64, d: f64) f64 {
+    val v0: f64 = a + 1.0;
+    val v1: f64 = b + 2.0;
+    val v2: f64 = c + 3.0;
+    val v3: f64 = d + 4.0;
+    val v4: f64 = a * 5.0;
+    val v5: f64 = b * 6.0;
+    val v6: f64 = c * 7.0;
+    val v7: f64 = mul2(d);
+    ret v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7;
+}
+
+fun near(a: f64, b: f64) i64 {
+    var e: f64 = a - b;
+    if (e < 0.0) { e = 0.0 - e; }
+    if (e < 0.001) { ret 1; }
+    ret 0;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # (10+1)+(20+2)+(30+3)+(40+4) = 110; 10*5+20*6+30*7 = 380; mul2(40) = 80;
+    # total = 570.
+    val r: f64 = compute(10.0, 20.0, 30.0, 40.0);
+    if (near(r, 570.0) == 1) { ret 0; }
+    ret 1;
+}

--- a/.github/tests/win64fp/run.sh
+++ b/.github/tests/win64fp/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# win64 callee-saved XMM regression test (#1254): under win64 the allocator hands
+# out the callee-saved vector registers XMM6–15 but the prologue never saved them.
+# the FP-bank callee-save model now keeps call-crossing floats in XMM6+ and the
+# prologue preserves them with 16-byte-aligned MOVAPS saves (described in .xdata as
+# UWOP_SAVE_XMM128). this cross-compiles a float-heavy program (several FP values
+# live across a call) and runs it under wine: a misaligned MOVAPS would fault, a
+# dropped save would corrupt the result. main exits 0 only when the float math is
+# correct.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+# the test runs a windows binary; without wine there is nothing to execute it.
+if ! command -v wine >/dev/null 2>&1; then
+    echo "SKIP win64fp: 'wine' not available to run the windows binary"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# build at -O0 so the call is real and the float values genuinely live across it.
+if ! ( cd "$WORK/app" && "$MACH" build . -O0 ) >/dev/null 2>&1; then
+    echo "FAIL win64fp: windows cross-build failed" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/windows/bin/win64fp.exe"
+test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
+
+set +e
+WINEDEBUG=-all wine "$EXE" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS win64fp: call-crossing floats survive in callee-saved XMM6+ and the result is correct"
+    exit 0
+fi
+
+echo "FAIL win64fp: win64 callee-saved XMM miscompiled or faulted (exit $code)" >&2
+exit 1

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -592,6 +592,12 @@ pub rec MirFrame {
 #              set means physical GP register id `n` is live in the function and
 #              must be preserved. `lower_ir` initializes it to 0 (no callee-saved
 #              register used until regalloc proves otherwise).
+# callee_mask_fp: the FP-bank twin of `callee_mask` — a bitmask of callee-saved
+#              vector (XMM) register INDICES this function must preserve, written
+#              by regalloc. bit `n` set means XMM register `n` must be saved in the
+#              prologue and restored in the epilogue. only conventions with
+#              callee-saved vector registers (win64's XMM6–15) ever set bits here;
+#              under SysV, where every XMM is caller-saved, it stays 0.
 pub rec MirFunction {
     name:        intern.StrId;
 
@@ -605,6 +611,7 @@ pub rec MirFunction {
 
     frame:       MirFrame;
     callee_mask: u32;
+    callee_mask_fp: u32;
 }
 
 # MirModule: the per-source-module unit produced by `lower_ir`.
@@ -917,6 +924,7 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interne
     mf.frame.va_save_off  = 0;
     mf.frame.outgoing_size = 0;
     mf.callee_mask        = 0;
+    mf.callee_mask_fp     = 0;
 
     # extern / body-less functions lower to an empty MirFunction shell. extern
     # variadic declarations (e.g. printf) are fine here; only defining the body of

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -256,7 +256,14 @@ fun bank_count(tgt: *target.Target, class: u32) u32 {
 # ret: ok(true) on success, or an error string on an allocation failure
 fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) Result[bool, str] {
     if (f.block_count == 0) { ret ok[bool, str](true); }
-    if (f.vreg_count == 0)  { ret ok[bool, str](true); }
+    # a function with no vregs has nothing to allocate, but its inline asm may still
+    # clobber callee-saved registers the prologue must preserve for the caller, so
+    # derive the callee mask before returning (the asm-clobber caller-corruption
+    # path also corrupts callers from a value-free asm-only function).
+    if (f.vreg_count == 0)  {
+        f.callee_mask = asm_callee_mask(tgt, f);
+        ret ok[bool, str](true);
+    }
 
     var ctx: AllocCtx;
     val ic: Result[bool, str] = ctx_init(?ctx, tgt, m, f);
@@ -321,7 +328,7 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
     val sc: Result[bool, str] = linear_scan(tgt, ?ctx);
     if (is_err[bool, str](sc)) { ctx_dnit(?ctx); ret sc; }
 
-    val sp: Result[bool, str] = spill_across_calls(?ctx);
+    val sp: Result[bool, str] = spill_across_calls(tgt, ?ctx);
     if (is_err[bool, str](sp)) { ctx_dnit(?ctx); ret sp; }
 
     val rw: Result[bool, str] = rewrite(tgt, ?ctx);
@@ -1787,15 +1794,119 @@ fun add_spill_slot(ctx: *AllocCtx, value_id: u32, size: u32) Result[i32, str] {
     ret ok[i32, str](si::i32);
 }
 
+# asm_instr_clobbers: when `mi` is an inline-asm instruction, fill `gp` / `fp` with
+# the register-index clobber bitmasks the ISA infers from its body and return true;
+# otherwise return false. an ISA exposing no analyzer is treated conservatively
+# (every register potentially clobbered) rather than as "no clobbers", so a value
+# is never left in a register a foreign asm body might overwrite. the masks index
+# registers by their within-bank index (bit n -> GP / XMM register n).
+fun asm_instr_clobbers(tgt: *target.Target, mi: *mir.MirInstr, gp: *u32, fp: *u32) bool {
+    if (mi.asm_block == nil) { ret false; }
+    @gp = 0;
+    @fp = 0;
+    if (tgt.arch.asm_clobbers == nil) {
+        @gp = 0xFFFFFFFF;
+        @fp = 0xFFFFFFFF;
+        ret true;
+    }
+    val clob: isa.AsmClobbersFn = tgt.arch.asm_clobbers::isa.AsmClobbersFn;
+    clob(mi.asm_block.body, gp, fp);
+    ret true;
+}
+
+# asm_clobbers_at: `asm_instr_clobbers` for the flat-stream instruction at `pos`.
+# only valid before the rewrite pass rebuilds the per-block instruction lists (the
+# flat stream indexes the original layout); record_callee_mask, which runs after
+# rewrite, walks the blocks directly instead.
+fun asm_clobbers_at(tgt: *target.Target, ctx: *AllocCtx, pos: u32, gp: *u32, fp: *u32) bool {
+    ret asm_instr_clobbers(tgt, flat_instr(ctx, pos), gp, fp);
+}
+
+# abi_callee_saved_gp_mask: GP-register bitmask of the ABI's callee-saved file —
+# the bitmask form of `seed_callee_saved`, for the asm-clobber callee-mask
+# derivation that runs without a full allocation context (a vreg-free function).
+fun abi_callee_saved_gp_mask(tgt: *target.Target) u32 {
+    var regs: [32]isa.Register;
+    val fill: abi.RegFileFn = tgt.abi.callee_saved::abi.RegFileFn;
+    val n: i32 = fill(?regs[0]);
+    var m: u32 = 0;
+    var i: i32 = 0;
+    for (i < n && i < MAX_REG_FILE) {
+        val id: i32 = regs[i].id;
+        if (isa.regid_class(id) == isa.REG_CLASS_ID_GP && id >= 0 && id < 32) {
+            m = m | (1::u32 << id::u32);
+        }
+        i = i + 1;
+    }
+    ret m;
+}
+
+# isa_reserved_gp_mask: GP-register bitmask the ISA reserves from allocation (the
+# stack / frame pointers, the reload-scratch pool, and the encoder's split
+# scratch) — the bitmask form of `seed_reserved`'s always-reserved set, so a
+# callee-saved-but-reserved register (the frame pointer) is excluded from an asm
+# clobber mask just as it is from an allocated one.
+fun isa_reserved_gp_mask(tgt: *target.Target) u32 {
+    var m: u32 = 0;
+    var i: i32 = 0;
+    for (i < tgt.arch.reserved_reg_count && i < MAX_REG_FILE) {
+        val id: i32 = tgt.arch.reserved_regs[i].id;
+        if (id >= 0 && id < 32) { m = m | (1::u32 << id::u32); }
+        i = i + 1;
+    }
+    var j: i32 = 0;
+    for (j < tgt.arch.reload_scratch_count && j < MAX_REG_FILE) {
+        val id: i32 = tgt.arch.reload_scratch_regs[j].id;
+        if (id >= 0 && id < 32) { m = m | (1::u32 << id::u32); }
+        j = j + 1;
+    }
+    val sid: i32 = tgt.arch.scratch_reg;
+    if (sid >= 0 && sid < 32) { m = m | (1::u32 << sid::u32); }
+    ret m;
+}
+
+# asm_callee_mask: the callee-saved GP registers any inline-asm body in `f` writes
+# — the registers the prologue must additionally preserve for the caller. computed
+# directly from the ABI callee-saved file and the ISA reserved set so it works for
+# a function with no vregs, which skips register allocation (and record_callee_mask)
+# entirely yet may still carry an asm body that clobbers a callee-saved register.
+fun asm_callee_mask(tgt: *target.Target, f: *mir.MirFunction) u32 {
+    val cs: u32 = abi_callee_saved_gp_mask(tgt);
+    val res: u32 = isa_reserved_gp_mask(tgt);
+    var mask: u32 = 0;
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            var agp: u32 = 0;
+            var afp: u32 = 0;
+            if (asm_instr_clobbers(tgt, ?blk.instrs[ii], ?agp, ?afp)) {
+                mask = mask | (agp & cs & ~res);
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret mask;
+}
+
 # spill_across_calls: at each MIR_CALL barrier, spill every live vreg whose
 # assigned register is caller-saved (or any FP register) so the call cannot
-# destroy it. a spilled value is reloaded at its uses by the rewrite pass; here
-# we only convert call-clobbered live registers into spill slots. ranges already
-# placed in callee-saved registers survive the call untouched.
-fun spill_across_calls(ctx: *AllocCtx) Result[bool, str] {
+# destroy it. an inline-asm barrier additionally spills a live value held in a
+# CALLEE-saved register the asm body writes — pick_gp parks call-crossing values
+# in callee-saved registers, exactly the ones a `mov rbx, ...` asm would corrupt
+# (the inline-asm clobber miscompile). a spilled value is reloaded at its uses by
+# the rewrite pass; here we only convert clobbered live registers into spill slots.
+# ranges in callee-saved registers no barrier writes survive untouched.
+fun spill_across_calls(tgt: *target.Target, ctx: *AllocCtx) Result[bool, str] {
     var pos: u32 = 0;
     for (pos < ctx.flat_count) {
         if (!ctx.flat[pos].is_call) { pos = pos + 1; cnt; }
+        # the inline-asm clobber set for this barrier (empty for a MIR_CALL).
+        var asm_gp: u32 = 0;
+        var asm_fp: u32 = 0;
+        val is_asm: bool = asm_clobbers_at(tgt, ctx, pos, ?asm_gp, ?asm_fp);
         var v: u32 = 0;
         for (v < ctx.f.vreg_count) {
             val mv: *mir.MirVReg = ?ctx.f.vregs[v];
@@ -1810,6 +1921,9 @@ fun spill_across_calls(ctx: *AllocCtx) Result[bool, str] {
                 must_spill = true;
             } or (mv.assigned < ctx.gp_count && !ctx.callee_saved[mv.assigned]) {
                 must_spill = true;
+            } or (is_asm && mv.assigned < ctx.gp_count && (asm_gp & (1::u32 << mv.assigned)) != 0) {
+                # a callee-saved GP register the asm body itself overwrites.
+                must_spill = true;
             }
             if (must_spill) {
                 val sr: Result[bool, str] = spill_vreg(ctx, v);
@@ -1823,8 +1937,12 @@ fun spill_across_calls(ctx: *AllocCtx) Result[bool, str] {
 }
 
 # record_callee_mask: set `MirFunction.callee_mask` bit `n` for every callee-saved
-# GP register the allocator actually assigned, so the prologue saves and the
-# epilogue restores exactly those registers.
+# GP register the function must preserve — those the allocator assigned, plus any
+# a function's inline asm body writes. the prologue saves and the epilogue restores
+# exactly these. the asm contribution closes the caller-corruption path: an asm
+# body may overwrite a callee-saved register the allocator never assigned (so its
+# value was spilled or never placed there), yet the function still owes its caller
+# that register's preservation.
 fun record_callee_mask(tgt: *target.Target, ctx: *AllocCtx) {
     var mask: u32 = 0;
     var v: u32 = 0;
@@ -1838,6 +1956,12 @@ fun record_callee_mask(tgt: *target.Target, ctx: *AllocCtx) {
         }
         v = v + 1;
     }
+
+    # OR in every callee-saved GP register any inline-asm body in the function
+    # writes, so the prologue preserves it for the caller even when no allocated
+    # value lives there.
+    mask = mask | asm_callee_mask(tgt, ctx.f);
+
     ctx.f.callee_mask = mask;
 }
 

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1082,16 +1082,15 @@ fun compute_use_def(ctx: *AllocCtx, uses: *bool, defs: *bool, nv: u32) {
 # condition with explicit MIR_OP_BLOCK targets following; treating any
 # block-target-bearing instruction as a non-defining branch keeps the condition a
 # use, not a def. MIR_CALL is the value-less call barrier and survives selection.
-# MIR_CALL_RES and MIR_ARG are zero-byte liveness markers (the encoder drops both):
-# MIR_CALL_RES's result vreg is bound by the return-register move emitted before
-# it (an sret call binds it pre-call via RDI), so operand 0 is a live use the
-# marker extends, never a destination — treating it as a def would emit a spurious
-# store of an undefined post-call register over the vreg's live slot.
+# MIR_CALL_RES is a zero-byte liveness marker the encoder drops: its result vreg is
+# bound by the return-register move emitted before it (an sret call binds it
+# pre-call via RDI), so operand 0 is a live use the marker extends, never a
+# destination — treating it as a def would emit a spurious store of an undefined
+# post-call register over the vreg's live slot.
 fun instr_defines(mi: *mir.MirInstr) bool {
     if (mi.operand_count == 0) { ret false; }
     if (mi.opcode == mir.MIR_CALL) { ret false; }
     if (mi.opcode == mir.MIR_CALL_RES) { ret false; }
-    if (mi.opcode == mir.MIR_ARG) { ret false; }
     if (has_block_operand(mi)) { ret false; }
     val d: *mir.MirOperand = ?mi.operands[0];
     ret d.kind == mir.MIR_OP_VREG;
@@ -1401,7 +1400,6 @@ fun instr_defines_preg(mi: *mir.MirInstr) bool {
     if (mi.operand_count == 0) { ret false; }
     if (mi.opcode == mir.MIR_CALL) { ret false; }
     if (mi.opcode == mir.MIR_CALL_RES) { ret false; }
-    if (mi.opcode == mir.MIR_ARG) { ret false; }
     if (has_block_operand(mi)) { ret false; }
     ret mi.operands[0].kind == mir.MIR_OP_PREG;
 }
@@ -2023,7 +2021,15 @@ fun rewrite_block(tgt: *target.Target, ctx: *AllocCtx, blk: *mir.MirBlock, is_en
         val mi: *mir.MirInstr = ?blk.instrs[ii];
         val re: Result[bool, str] = rewrite_instr(tgt, ctx, mi, dst, ?w, is_entry, flat_base + ii);
         if (is_err[bool, str](re)) {
-            # release any operand arrays already moved into `dst` and the array.
+            # release the operand arrays already written into `dst` (the rewritten
+            # instructions and their spliced reloads/stores), then the array itself.
+            var d: u32 = 0;
+            for (d < w) {
+                if (dst[d].operands != nil && dst[d].operand_count > 0) {
+                    deallocate[mir.MirOperand](ctx.alloc, dst[d].operands, dst[d].operand_count::usize);
+                }
+                d = d + 1;
+            }
             deallocate[mir.MirInstr](ctx.alloc, dst, total::usize);
             ret re;
         }
@@ -2171,7 +2177,8 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, -1, is_entry, src_pos);
                     if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str]("regalloc: no free register for spilled source"); }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    emit_reload(ctx, dst, wp, tmp::u32, v);
+                    val er: Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v);
+                    if (is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }
                     ops[k] = mir.op_preg(tmp::u32);
                 } or {
                     ops[k] = preg_of(ctx, v);
@@ -2196,7 +2203,8 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, -1, is_entry, src_pos);
                     if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str]("regalloc: no free register for spilled MEM base"); }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    emit_reload(ctx, dst, wp, tmp::u32, v);
+                    val er: Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v);
+                    if (is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }
                     ops[k].vreg = mir.MIR_VREG_NIL;
                     ops[k].preg = tmp::u32;
                 } or {
@@ -2214,7 +2222,8 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, -1, is_entry, src_pos);
                     if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str]("regalloc: no free register for spilled MEM index"); }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    emit_reload(ctx, dst, wp, tmp::u32, iv);
+                    val er: Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, iv);
+                    if (is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }
                     ops[k].index         = tmp::u32;
                     ops[k].index_is_preg = true;
                 } or {
@@ -2258,7 +2267,6 @@ fun instr_defines_ops(mi: *mir.MirInstr, ops: *mir.MirOperand, n: u32) bool {
     if (n == 0) { ret false; }
     if (mi.opcode == mir.MIR_CALL) { ret false; }
     if (mi.opcode == mir.MIR_CALL_RES) { ret false; }
-    if (mi.opcode == mir.MIR_ARG) { ret false; }
     var k: u32 = 0;
     for (k < n) {
         if (ops[k].kind == mir.MIR_OP_BLOCK) { ret false; }
@@ -2350,10 +2358,12 @@ fun id_claimed(claimed: *i32, count: u32, id: i32) bool {
 # emit_reload: append `MIR_MOV (preg tmp) <- [rbp + slot]` reloading a spilled
 # vreg into a temporary. the slot is addressed by a MEM operand whose base is the
 # spilled vreg id (the encoder resolves it to `[rbp + offset]` via the frame
-# slot), matching the by-value-spill addressing convention.
-fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32) {
+# slot), matching the by-value-spill addressing convention. propagates an
+# operand-array allocation failure as a Result, mirroring its twin emit_store (the
+# rewrite already threads every other allocation failure through Result).
+fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32) Result[bool, str] {
     val ro: Result[*mir.MirOperand, str] = allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (is_err[*mir.MirOperand, str](ro)) { panic("regalloc: reload operand allocation failed\n"); }
+    if (is_err[*mir.MirOperand, str](ro)) { ret err[bool, str](unwrap_err[*mir.MirOperand, str](ro)); }
     val ops: *mir.MirOperand = unwrap_ok[*mir.MirOperand, str](ro);
     ops[0] = mir.op_preg(tmp);
     ops[1] = mir.op_mem_slot(v, 0);
@@ -2364,6 +2374,7 @@ fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32) 
     dst[@wp].width         = SPILL_MOV_WIDTH;
     dst[@wp].src_width     = SPILL_MOV_WIDTH;
     @wp = @wp + 1;
+    ret ok[bool, str](true);
 }
 
 # emit_store: append `MIR_MOV [rbp + slot] <- (preg tmp)` storing a temporary

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -138,6 +138,9 @@ rec LiveRange {
 # active:        active-range vreg ids during the scan
 # active_count:  number of active ranges
 # pinned_end:    per-GP-register reservation end position (param-reg lifetimes)
+# fp_pinned_end: per-FP-register reservation end position — the FP-bank twin of
+#                pinned_end, holding an incoming XMM param register busy from
+#                entry until its capture move so no earlier FP range steals it
 # arg_res_reg / arg_res_start / arg_res_end: parallel windows reserving an
 #                outgoing call-argument register over [setup-move, call] so a
 #                later same-call argument's materialization cannot reuse a
@@ -169,6 +172,7 @@ rec AllocCtx {
     reserved:      *bool;
     gp_busy:       *bool;
     fp_busy:       *bool;
+    fp_pinned_end: *i64;
     active:        *u32;
     active_count:  u32;
     pinned_end:    *i64;
@@ -344,6 +348,7 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
     ctx.reserved     = nil;
     ctx.gp_busy      = nil;
     ctx.fp_busy      = nil;
+    ctx.fp_pinned_end = nil;
     ctx.active       = nil;
     ctx.active_count = 0;
     ctx.pinned_end   = nil;
@@ -418,8 +423,11 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
         val rfb: Result[*bool, str] = allocate[bool](m.alloc, ctx.fp_count::usize);
         if (is_err[*bool, str](rfb)) { ctx_dnit(ctx); ret err[bool, str](unwrap_err[*bool, str](rfb)); }
         ctx.fp_busy = unwrap_ok[*bool, str](rfb);
+        val rfp: Result[*i64, str] = allocate[i64](m.alloc, ctx.fp_count::usize);
+        if (is_err[*i64, str](rfp)) { ctx_dnit(ctx); ret err[bool, str](unwrap_err[*i64, str](rfp)); }
+        ctx.fp_pinned_end = unwrap_ok[*i64, str](rfp);
         var fii: u32 = 0;
-        for (fii < ctx.fp_count) { ctx.fp_busy[fii] = false; fii = fii + 1; }
+        for (fii < ctx.fp_count) { ctx.fp_busy[fii] = false; ctx.fp_pinned_end[fii] = -1; fii = fii + 1; }
     }
 
     val ra: Result[*u32, str] = allocate[u32](m.alloc, f.vreg_count::usize);
@@ -487,6 +495,10 @@ fun ctx_dnit(ctx: *AllocCtx) {
     if (ctx.fp_busy != nil) {
         deallocate[bool](ctx.alloc, ctx.fp_busy, ctx.fp_count::usize);
         ctx.fp_busy = nil;
+    }
+    if (ctx.fp_pinned_end != nil) {
+        deallocate[i64](ctx.alloc, ctx.fp_pinned_end, ctx.fp_count::usize);
+        ctx.fp_pinned_end = nil;
     }
     if (ctx.active != nil) {
         deallocate[u32](ctx.alloc, ctx.active, ctx.f.vreg_count::usize);
@@ -1253,10 +1265,22 @@ fun reserve_param_registers(ctx: *AllocCtx) {
             # (e.g. a 16-byte value's second eightbyte) is colored over and clobbered
             # before it is captured.
             if ((d.kind == mir.MIR_OP_VREG || d.kind == mir.MIR_OP_MEM) && s.kind == mir.MIR_OP_PREG) {
+                # `r` is the composite source register id. a GP id is its raw index
+                # (< gp_count); an XMM id carries the SSE class tag, so it is pinned
+                # in the FP bank's array keyed on its within-bank index. the FP twin
+                # keeps an incoming float param (XMM0–XMM7) busy until its capture
+                # MOVSD, the mirror of the GP arg-register pin.
                 val r: u32 = s.preg;
-                if (r < ctx.gp_count && pos::i64 > ctx.pinned_end[r]) {
-                    ctx.pinned_end[r]    = pos::i64;
-                    ctx.param_reg_end[r] = pos::i64;
+                if (isa.regid_class(r::i32) == isa.REG_CLASS_ID_GP) {
+                    if (r < ctx.gp_count && pos::i64 > ctx.pinned_end[r]) {
+                        ctx.pinned_end[r]    = pos::i64;
+                        ctx.param_reg_end[r] = pos::i64;
+                    }
+                } or {
+                    val fi: u32 = isa.regid_index(r::i32)::u32;
+                    if (ctx.fp_pinned_end != nil && fi < ctx.fp_count && pos::i64 > ctx.fp_pinned_end[fi]) {
+                        ctx.fp_pinned_end[fi] = pos::i64;
+                    }
                 }
             }
         }
@@ -1266,7 +1290,10 @@ fun reserve_param_registers(ctx: *AllocCtx) {
 }
 
 # build_arg_reservations: record reservations protecting every precolored
-# physical-register definition (operand 0 a GP `MIR_OP_PREG`) from value coloring.
+# physical-register definition (operand 0 a `MIR_OP_PREG`, GP or XMM) from value
+# coloring. the records key on the composite register id, so one set of windows
+# serves both banks: `gp_available` consults them with GP ids and `fp_available`
+# with XMM ids, and the disjoint id spaces keep the two banks from interfering.
 # two distinct hazards are covered, both rooted in the fact that a value carried in
 # a `MIR_OP_PREG` is invisible to the vreg liveness `build_ranges` tracks:
 #
@@ -1315,8 +1342,15 @@ fun build_arg_reservations(ctx: *AllocCtx) Result[bool, str] {
         val mi: *mir.MirInstr = flat_instr(ctx, pos);
         if (!instr_defines_preg(mi)) { pos = pos + 1; cnt; }
         val d: *mir.MirOperand = ?mi.operands[0];
+        # `r` is a composite physical-register id (GP index, or the SSE class tag
+        # plus index for an XMM precoloring). the reservation lists key on it
+        # directly, so both banks share one set of records and `gp_available` /
+        # `fp_available` consult the same lists with their bank's composite ids —
+        # the GP and XMM id spaces are disjoint, so neither bank sees the other's
+        # entries. FP argument-setup moves (`MOVSD xmm_k <- vreg`) were previously
+        # skipped here, leaving FP precolored defs invisible to interference (the
+        # swapped-float-args miscompile).
         val r: u32 = d.preg;
-        if (r >= ctx.gp_count) { pos = pos + 1; cnt; }
 
         # record the precolored DEF position: no value vreg living past `pos` may
         # own `r`, since the def overwrites `r` here.
@@ -1365,10 +1399,10 @@ fun instr_defines_preg(mi: *mir.MirInstr) bool {
     ret mi.operands[0].kind == mir.MIR_OP_PREG;
 }
 
-# arg_reg_reserved: true when an outgoing call-argument window holds GP register
-# `id` busy over a span that overlaps the range currently being colored
-# (`cur_start`..`cur_end`). two intervals overlap when neither ends before the
-# other starts.
+# arg_reg_reserved: true when an outgoing call-argument window holds physical
+# register `id` (a composite GP or XMM id) busy over a span that overlaps the range
+# currently being colored (`cur_start`..`cur_end`). two intervals overlap when
+# neither ends before the other starts.
 fun arg_reg_reserved(ctx: *AllocCtx, id: u32) bool {
     var i: u32 = 0;
     for (i < ctx.arg_res_count) {
@@ -1401,8 +1435,8 @@ fun arg_reg_busy_at(ctx: *AllocCtx, id: u32, pos: u32) bool {
     ret false;
 }
 
-# release_pins: clear any param-register reservation whose end position has been
-# reached, returning the register to the free pool.
+# release_pins: clear any param-register reservation (GP or FP) whose end position
+# has been reached, returning the register to the free pool.
 fun release_pins(ctx: *AllocCtx, current_start: i64) {
     var r: u32 = 0;
     for (r < ctx.gp_count) {
@@ -1410,6 +1444,15 @@ fun release_pins(ctx: *AllocCtx, current_start: i64) {
             ctx.pinned_end[r] = -1;
         }
         r = r + 1;
+    }
+    if (ctx.fp_pinned_end != nil) {
+        var fi: u32 = 0;
+        for (fi < ctx.fp_count) {
+            if (ctx.fp_pinned_end[fi] >= 0 && ctx.fp_pinned_end[fi] < current_start) {
+                ctx.fp_pinned_end[fi] = -1;
+            }
+            fi = fi + 1;
+        }
     }
 }
 
@@ -1515,9 +1558,9 @@ fun pick_gp(ctx: *AllocCtx, crosses_call: bool) i32 {
     ret -1;
 }
 
-# def_reg_reserved: true when GP register `id` is overwritten by a precolored
-# physical-register DEF at a position the range currently being colored
-# (`cur_start`..`cur_end`) is live PAST. a value used at the def position but live
+# def_reg_reserved: true when physical register `id` (a composite GP or XMM id) is
+# overwritten by a precolored physical-register DEF at a position the range
+# currently being colored (`cur_start`..`cur_end`) is live PAST. a value used at the def position but live
 # only up to it (`cur_end == def-pos`) may still share the register — the def reads
 # its sources before writing, the standard def/use coalescing on a 2-address ISA —
 # so the test rejects only a value live strictly beyond the def (`cur_end >
@@ -1550,14 +1593,29 @@ fun gp_available(ctx: *AllocCtx, id: u32) bool {
     ret true;
 }
 
+# fp_available: true when FP register index `fi` is neither busy, pinned as a live
+# incoming param register, held by an outgoing call-argument window, nor overwritten
+# by a precolored DEF the colored range is live past — the FP-bank twin of
+# `gp_available`. the argument / def reservations key on the composite XMM id so the
+# shared windows reject the right register for a float range exactly as for a GP one.
+fun fp_available(ctx: *AllocCtx, fi: u32) bool {
+    if (ctx.fp_busy[fi]) { ret false; }
+    if (ctx.fp_pinned_end != nil && ctx.fp_pinned_end[fi] >= 0) { ret false; }
+    val cid: u32 = isa.regid_make(isa.REG_CLASS_ID_XMM, fi::i32)::u32;
+    if (arg_reg_reserved(ctx, cid)) { ret false; }
+    if (def_reg_reserved(ctx, cid)) { ret false; }
+    ret true;
+}
+
 # pick_fp: choose a free floating-point register, or -1 when none is free. the
 # chosen within-bank index is composed with the SSE class tag so the returned id
-# carries its bank — the allocation ORDER is unchanged, only the representation of
-# the assigned id.
+# carries its bank. an FP range is gated by `fp_available` exactly as a GP range is
+# by `gp_available`, so an argument-setup move's precolored XMM def can no longer be
+# colored over a still-live float (the swapped-float-args miscompile).
 fun pick_fp(ctx: *AllocCtx) i32 {
     var fi: u32 = 0;
     for (fi < ctx.fp_count) {
-        if (!ctx.fp_busy[fi]) {
+        if (fp_available(ctx, fi)) {
             ctx.fp_busy[fi] = true;
             ret isa.regid_make(isa.REG_CLASS_ID_XMM, fi::i32);
         }

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -132,6 +132,10 @@ rec LiveRange {
 # gp_count:      number of general-purpose registers in the bank
 # fp_count:      number of floating-point registers in the bank
 # callee_saved:  per-GP-register flag: is this register callee-saved?
+# fp_callee_saved: per-FP-register flag: is this XMM register callee-saved? (the
+#                FP-bank twin of `callee_saved` — win64 preserves XMM6–15, SysV
+#                none, so under SysV every entry is false and the FP callee-save
+#                machinery is inert)
 # reserved:      per-GP-register flag: is this register off-limits (rsp/rbp)?
 # gp_busy:       per-GP-register transient busy flag during scan
 # fp_busy:       per-FP-register transient busy flag during scan
@@ -169,6 +173,7 @@ rec AllocCtx {
     gp_count:      u32;
     fp_count:      u32;
     callee_saved:  *bool;
+    fp_callee_saved: *bool;
     reserved:      *bool;
     gp_busy:       *bool;
     fp_busy:       *bool;
@@ -352,6 +357,7 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
     ctx.gp_count     = bank_count(tgt, REG_CLASS_GP);
     ctx.fp_count     = bank_count(tgt, fp_class_index(tgt));
     ctx.callee_saved = nil;
+    ctx.fp_callee_saved = nil;
     ctx.reserved     = nil;
     ctx.gp_busy      = nil;
     ctx.fp_busy      = nil;
@@ -418,11 +424,10 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
             gi = gi + 1;
         }
 
-        # the callee-saved partition comes from the ABI vtable's callee-saved
-        # register file, and the never-allocatable reserved registers (stack / frame
-        # pointers) from the ISA vtable's reserved-register list — no architecture
-        # register is named here, and the linear scan reads these flags unchanged.
-        seed_callee_saved(tgt, ctx);
+        # the never-allocatable reserved registers (stack / frame pointers) come
+        # from the ISA vtable's reserved-register list — no architecture register is
+        # named here, and the linear scan reads these flags unchanged. the
+        # callee-saved partition is seeded below, once the FP bank is also allocated.
         seed_reserved(tgt, ctx);
     }
 
@@ -433,9 +438,22 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
         val rfp: Result[*i64, str] = allocate[i64](m.alloc, ctx.fp_count::usize);
         if (is_err[*i64, str](rfp)) { ctx_dnit(ctx); ret err[bool, str](unwrap_err[*i64, str](rfp)); }
         ctx.fp_pinned_end = unwrap_ok[*i64, str](rfp);
+        val rfc: Result[*bool, str] = allocate[bool](m.alloc, ctx.fp_count::usize);
+        if (is_err[*bool, str](rfc)) { ctx_dnit(ctx); ret err[bool, str](unwrap_err[*bool, str](rfc)); }
+        ctx.fp_callee_saved = unwrap_ok[*bool, str](rfc);
         var fii: u32 = 0;
-        for (fii < ctx.fp_count) { ctx.fp_busy[fii] = false; ctx.fp_pinned_end[fii] = -1; fii = fii + 1; }
+        for (fii < ctx.fp_count) {
+            ctx.fp_busy[fii] = false;
+            ctx.fp_pinned_end[fii] = -1;
+            ctx.fp_callee_saved[fii] = false;
+            fii = fii + 1;
+        }
     }
+
+    # seed the callee-saved partition of BOTH banks from the ABI vtable's
+    # callee-saved register file, now that both banks' flag arrays exist. one walk
+    # routes each register to its bank by the composite id's class tag.
+    seed_callee_saved(tgt, ctx);
 
     val ra: Result[*u32, str] = allocate[u32](m.alloc, f.vreg_count::usize);
     if (is_err[*u32, str](ra)) { ctx_dnit(ctx); ret err[bool, str](unwrap_err[*u32, str](ra)); }
@@ -462,6 +480,10 @@ fun ctx_dnit(ctx: *AllocCtx) {
     if (ctx.callee_saved != nil) {
         deallocate[bool](ctx.alloc, ctx.callee_saved, ctx.gp_count::usize);
         ctx.callee_saved = nil;
+    }
+    if (ctx.fp_callee_saved != nil) {
+        deallocate[bool](ctx.alloc, ctx.fp_callee_saved, ctx.fp_count::usize);
+        ctx.fp_callee_saved = nil;
     }
     if (ctx.reserved != nil) {
         deallocate[bool](ctx.alloc, ctx.reserved, ctx.gp_count::usize);
@@ -533,13 +555,16 @@ fun reserve_reg(ctx: *AllocCtx, id: i32) {
 }
 
 # seed_callee_saved: mark every register in the ABI's callee-saved file as
-# callee-saved. reads the file from `tgt.abi.callee_saved` (the convention's
-# preserved GP registers, e.g. SysV's RBX/RBP/R12–R15) rather than naming any
-# architecture register, so a new convention needs no edit here. registers outside
-# the GP bank are ignored.
+# callee-saved in its bank. reads the file from `tgt.abi.callee_saved` (the
+# convention's preserved registers, e.g. SysV's RBX/RBP/R12–R15, or win64's GP set
+# plus XMM6–15) rather than naming any architecture register, so a new convention
+# needs no edit here. each register is routed to the GP or FP flag array by its
+# composite-id class tag, so the FP bank gains the same callee-saved partition the
+# GP bank has always had (the win64 vector callee-saves the old GP-only seed
+# silently dropped).
 # ---
 # tgt: the active target; supplies the ABI callee-saved register file
-# ctx: the allocation context whose `callee_saved` flags are set
+# ctx: the allocation context whose `callee_saved` / `fp_callee_saved` flags are set
 fun seed_callee_saved(tgt: *target.Target, ctx: *AllocCtx) {
     var regs: [32]isa.Register;
     val fill: abi.RegFileFn = tgt.abi.callee_saved::abi.RegFileFn;
@@ -547,8 +572,15 @@ fun seed_callee_saved(tgt: *target.Target, ctx: *AllocCtx) {
     var i: i32 = 0;
     for (i < n && i < MAX_REG_FILE) {
         val id: i32 = regs[i].id;
-        if (id >= 0 && id::u32 < ctx.gp_count) {
-            ctx.callee_saved[id::u32] = true;
+        if (isa.regid_class(id) == isa.REG_CLASS_ID_GP) {
+            if (ctx.callee_saved != nil && id >= 0 && id::u32 < ctx.gp_count) {
+                ctx.callee_saved[id::u32] = true;
+            }
+        } or {
+            val idx: i32 = isa.regid_index(id);
+            if (ctx.fp_callee_saved != nil && idx >= 0 && idx::u32 < ctx.fp_count) {
+                ctx.fp_callee_saved[idx::u32] = true;
+            }
         }
         i = i + 1;
     }
@@ -1227,7 +1259,7 @@ fun linear_scan(tgt: *target.Target, ctx: *AllocCtx) Result[bool, str] {
         if (lr.reg_class == REG_CLASS_GP) {
             preg = pick_gp(ctx, lr.crosses_call);
         } or {
-            preg = pick_fp(ctx);
+            preg = pick_fp(ctx, lr.crosses_call);
         }
 
         if (preg >= 0) {
@@ -1612,12 +1644,36 @@ fun fp_available(ctx: *AllocCtx, fi: u32) bool {
     ret true;
 }
 
-# pick_fp: choose a free floating-point register, or -1 when none is free. the
-# chosen within-bank index is composed with the SSE class tag so the returned id
-# carries its bank. an FP range is gated by `fp_available` exactly as a GP range is
-# by `gp_available`, so an argument-setup move's precolored XMM def can no longer be
-# colored over a still-live float (the swapped-float-args miscompile).
-fun pick_fp(ctx: *AllocCtx) i32 {
+# pick_fp: choose a free floating-point register, preferring a callee-saved XMM for
+# a call-crossing range (so the value survives the call without a spill) and a
+# caller-saved one otherwise — the FP-bank twin of pick_gp. -1 when none is free.
+# under SysV no XMM is callee-saved, so the callee-saved loop finds nothing and the
+# caller-saved loop returns the same first-available register the old single loop
+# did (FP behavior is unchanged there). an FP range is gated by `fp_available`
+# exactly as a GP range is by `gp_available`.
+fun pick_fp(ctx: *AllocCtx, crosses_call: bool) i32 {
+    if (crosses_call) {
+        # prefer a free callee-saved XMM so the value survives the call.
+        var ci: u32 = 0;
+        for (ci < ctx.fp_count) {
+            if (fp_available(ctx, ci) && ctx.fp_callee_saved[ci]) {
+                ctx.fp_busy[ci] = true;
+                ret isa.regid_make(isa.REG_CLASS_ID_XMM, ci::i32);
+            }
+            ci = ci + 1;
+        }
+    } or {
+        # prefer a free caller-saved XMM to leave callee-saved untouched.
+        var ci: u32 = 0;
+        for (ci < ctx.fp_count) {
+            if (fp_available(ctx, ci) && !ctx.fp_callee_saved[ci]) {
+                ctx.fp_busy[ci] = true;
+                ret isa.regid_make(isa.REG_CLASS_ID_XMM, ci::i32);
+            }
+            ci = ci + 1;
+        }
+    }
+    # fall back to any free XMM of either partition.
     var fi: u32 = 0;
     for (fi < ctx.fp_count) {
         if (fp_available(ctx, fi)) {
@@ -1679,7 +1735,7 @@ fun spill_on_pressure(ctx: *AllocCtx, v: u32) Result[bool, str] {
     if (lr.reg_class == REG_CLASS_GP) {
         preg = pick_gp(ctx, lr.crosses_call);
     } or {
-        preg = pick_fp(ctx);
+        preg = pick_fp(ctx, lr.crosses_call);
     }
     if (preg >= 0) {
         assign(ctx, v, preg::u32, lr.reg_class);
@@ -1916,7 +1972,17 @@ fun spill_across_calls(tgt: *target.Target, ctx: *AllocCtx) Result[bool, str] {
 
             var must_spill: bool = false;
             if (lr.reg_class != REG_CLASS_GP) {
-                must_spill = true;
+                # an FP value: spill only when its XMM is caller-saved (a
+                # callee-saved XMM survives the call once the prologue preserves it).
+                # under SysV every XMM is caller-saved, so this still spills every
+                # FP value across a call. an asm barrier additionally spills a
+                # callee-saved XMM the body writes.
+                val xidx: u32 = isa.regid_index(mv.assigned::i32)::u32;
+                if (xidx >= ctx.fp_count || !ctx.fp_callee_saved[xidx]) {
+                    must_spill = true;
+                } or (is_asm && (asm_fp & (1::u32 << xidx)) != 0) {
+                    must_spill = true;
+                }
             } or (mv.assigned < ctx.gp_count && !ctx.callee_saved[mv.assigned]) {
                 must_spill = true;
             } or (is_asm && mv.assigned < ctx.gp_count && (asm_gp & (1::u32 << mv.assigned)) != 0) {
@@ -1934,23 +2000,32 @@ fun spill_across_calls(tgt: *target.Target, ctx: *AllocCtx) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
-# record_callee_mask: set `MirFunction.callee_mask` bit `n` for every callee-saved
-# GP register the function must preserve — those the allocator assigned, plus any
-# a function's inline asm body writes. the prologue saves and the epilogue restores
-# exactly these. the asm contribution closes the caller-corruption path: an asm
-# body may overwrite a callee-saved register the allocator never assigned (so its
-# value was spilled or never placed there), yet the function still owes its caller
-# that register's preservation.
+# record_callee_mask: set `MirFunction.callee_mask` / `callee_mask_fp` bit `n` for
+# every callee-saved GP / XMM register the function must preserve — those the
+# allocator assigned, plus any a function's inline asm body writes (GP only; the
+# inline-asm grammar names no vector register). the prologue saves and the epilogue
+# restores exactly these. the asm contribution closes the caller-corruption path:
+# an asm body may overwrite a callee-saved register the allocator never assigned
+# (so its value was spilled or never placed there), yet the function still owes its
+# caller that register's preservation. the FP mask is keyed on the XMM within-bank
+# index; under SysV (no callee-saved XMM) it stays 0.
 fun record_callee_mask(tgt: *target.Target, ctx: *AllocCtx) {
     var mask: u32 = 0;
+    var fp_mask: u32 = 0;
     var v: u32 = 0;
     for (v < ctx.f.vreg_count) {
         val mv: *mir.MirVReg = ?ctx.f.vregs[v];
         if (mv.assigned == mir.MIR_VREG_NIL) { v = v + 1; cnt; }
         val lr: *LiveRange = ?ctx.ranges[v];
-        if (lr.reg_class != REG_CLASS_GP) { v = v + 1; cnt; }
-        if (mv.assigned < ctx.gp_count && ctx.callee_saved[mv.assigned] && !ctx.reserved[mv.assigned]) {
-            mask = mask | (1::u32 << mv.assigned);
+        if (lr.reg_class == REG_CLASS_GP) {
+            if (mv.assigned < ctx.gp_count && ctx.callee_saved[mv.assigned] && !ctx.reserved[mv.assigned]) {
+                mask = mask | (1::u32 << mv.assigned);
+            }
+        } or {
+            val xidx: u32 = isa.regid_index(mv.assigned::i32)::u32;
+            if (ctx.fp_callee_saved != nil && xidx < ctx.fp_count && ctx.fp_callee_saved[xidx]) {
+                fp_mask = fp_mask | (1::u32 << xidx);
+            }
         }
         v = v + 1;
     }
@@ -1960,7 +2035,8 @@ fun record_callee_mask(tgt: *target.Target, ctx: *AllocCtx) {
     # value lives there.
     mask = mask | asm_callee_mask(tgt, ctx.f);
 
-    ctx.f.callee_mask = mask;
+    ctx.f.callee_mask    = mask;
+    ctx.f.callee_mask_fp = fp_mask;
 }
 
 # rewrite: the final pass. for each block, rebuild its instruction list so every

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -70,7 +70,7 @@ use std.system.panic.panic;
 
 use target: mach.lang.target;
 use isa:    mach.lang.target.isa;
-use sysv:   mach.lang.target.abi.sysv;
+use abi:    mach.lang.target.abi;
 use mir:    mach.lang.be.codegen.mir;
 
 # REG_CLASS_GP: index of the general-purpose register bank in `reg_classes`.
@@ -523,7 +523,7 @@ fun reserve_reg(ctx: *AllocCtx, id: i32) {
 # ctx: the allocation context whose `callee_saved` flags are set
 fun seed_callee_saved(tgt: *target.Target, ctx: *AllocCtx) {
     var regs: [32]isa.Register;
-    val fill: sysv.RegFileFn = tgt.abi.callee_saved::sysv.RegFileFn;
+    val fill: abi.RegFileFn = tgt.abi.callee_saved::abi.RegFileFn;
     val n: i32 = fill(?regs[0]);
     var i: i32 = 0;
     for (i < n && i < MAX_REG_FILE) {

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -16,6 +16,7 @@ use std.types.bool.true;
 use std.types.bool.false;
 
 use intern: mach.lang.intern;
+use isa:    mach.lang.target.isa;
 
 # canonical numeric ids for known calling conventions. stable across compiler
 # versions and used as the registry slot index.
@@ -60,6 +61,68 @@ pub rec ParamSlot {
     size:   u64;
 }
 
+# the concrete signatures the erased `AbiVTable` function pointers are cast back
+# to. they live in this neutral module — which every calling convention already
+# imports — rather than in one concrete convention's module, so a consumer
+# typing a win64 vtable's pointer never routes through the sysv module (the
+# coupling a target-agnostic backend must avoid). naming `isa.Register` here only
+# adds a typedef-level dependency on `isa`; the vtable's own fields stay erased
+# (`*u8`), so the runtime-dispatch interface itself carries no ISA type. each
+# per-ABI implementation aliases these (e.g. `sysv.RegFileFn`) for local use.
+
+# classify one value into a placement decision. `gp_used` / `fp_used` are the GP
+# and FP registers already consumed by earlier arguments.
+# ---
+# arch_id:      architecture id (one of isa.ARCH_*)
+# size:         value size in bytes
+# align:        value alignment in bytes
+# is_float:     true if the value is FP-register-eligible
+# is_aggregate: true if the value is a record/array (recursively classified)
+# gp_used:      GP registers already consumed
+# fp_used:      FP registers already consumed
+# ret:          the placement decision
+pub def ClassifyFn: fun(u32, u64, u64, bool, bool, i32, i32) ParamSlot;
+
+# assign the registers or stack slot for a single argument, given the GP/FP usage
+# counters the caller tracks across the call's argument list.
+# ---
+# arch_id:      architecture id (one of isa.ARCH_*)
+# index:        zero-based logical argument position
+# size:         argument size in bytes
+# align:        argument alignment in bytes
+# is_float:     true if the argument goes in FP registers
+# is_aggregate: true if the argument is an aggregate
+# gp_used:      GP registers already consumed
+# fp_used:      FP registers already consumed
+# ret:          the placement decision
+pub def ArgPassingFn: fun(u32, i32, u64, u64, bool, bool, i32, i32) ParamSlot;
+
+# assign the registers or sret slot for a return value.
+# ---
+# arch_id:      architecture id (one of isa.ARCH_*)
+# size:         return-value size in bytes
+# align:        return-value alignment in bytes
+# is_float:     true if the value is returned in FP registers
+# is_aggregate: true if the value is an aggregate
+# ret:          the placement decision
+pub def RetPassingFn: fun(u32, u64, u64, bool, bool) ParamSlot;
+
+# fill a caller-owned `out` buffer with a register bank in canonical order and
+# return the count written. the erased `gp_arg_regs` / `fp_arg_regs` /
+# `callee_saved` pointers are all cast back to this. the caller must size `out`
+# to hold at least the bank's maximum count.
+# ---
+# out: caller-owned buffer receiving the register descriptors
+# ret: the number of registers written
+pub def RegFileFn: fun(*isa.Register) i32;
+
+# return the convention's `VaModel` — the variadic save model the backend's
+# prologue / va_start / va_arg expansion dispatches on. the erased `va_model`
+# pointer is cast back to this.
+# ---
+# ret: the convention's variadic save model
+pub def VaModelFn: fun() VaModel;
+
 # the ABI runtime-dispatch interface. exactly one of these exists per calling
 # convention; the backend reads stack alignment and red-zone size directly and
 # casts the erased function pointers back to the convention's concrete
@@ -75,10 +138,10 @@ pub rec ParamSlot {
 # spills across a call) and the callee-saved set (which the prologue preserves).
 # regalloc derives the caller-saved set as the complement: every allocatable
 # physical register in a class that is NOT in the callee-saved set. all six
-# function pointers are type-erased (`*u8`) — their concrete signatures name
-# `isa.Register` / `abi.ParamSlot`, so the vtable stays free of an ISA dependency
-# and each consumer casts back to the convention's typed signature (declared in
-# the per-ABI impl, e.g. `sysv.RegFileFn` / `sysv.ClassifyFn`).
+# function pointers are type-erased (`*u8`) — the vtable's fields name no ISA or
+# ABI value type — and each consumer casts back to the neutral typed signature
+# declared above (`RegFileFn` / `ClassifyFn` / ...), so a consumer typing any
+# convention's vtable never routes through a concrete convention's module.
 # ---
 # id:           calling-convention id (one of ABI_*)
 # name:         interned convention name ("sysv", "win64")

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -77,64 +77,15 @@ pub val RED_ZONE: u32 = 128;
 # larger is returned via a hidden sret pointer.
 pub val MAX_REG_RET: u64 = 16;
 
-# concrete signature the erased `AbiVTable.classify` pointer is cast back to.
-# classifies one value into a placement decision. `gp_used` and `fp_used` are
-# the counts of GP and FP registers already consumed by earlier arguments.
-# ---
-# arch_id:      architecture id (one of isa.ARCH_*)
-# size:         value size in bytes
-# align:        value alignment in bytes
-# is_float:     true if the value is a floating-point scalar or an all-float
-#               aggregate eligible for FP registers
-# is_aggregate: true if the value is a record/array (recursively classified)
-# gp_used:      GP registers already consumed
-# fp_used:      FP registers already consumed
-# ret:          the placement decision
-pub def ClassifyFn: fun(u32, u64, u64, bool, bool, i32, i32) abi.ParamSlot;
-
-# concrete signature the erased `AbiVTable.arg_passing` pointer is cast back to.
-# assigns the registers or stack slot for a single argument under the SysV
-# rules, given the GP/FP usage counters tracked by the caller.
-# ---
-# arch_id:      architecture id (one of isa.ARCH_*)
-# index:        zero-based logical argument position
-# size:         argument size in bytes
-# align:        argument alignment in bytes
-# is_float:     true if the argument goes in FP registers
-# is_aggregate: true if the argument is an aggregate
-# gp_used:      GP registers already consumed
-# fp_used:      FP registers already consumed
-# ret:          the placement decision
-pub def ArgPassingFn: fun(u32, i32, u64, u64, bool, bool, i32, i32) abi.ParamSlot;
-
-# concrete signature the erased `AbiVTable.ret_passing` pointer is cast back to.
-# assigns the registers or sret slot for a return value under the SysV rules.
-# ---
-# arch_id:      architecture id (one of isa.ARCH_*)
-# size:         return-value size in bytes
-# align:        return-value alignment in bytes
-# is_float:     true if the value is returned in FP registers
-# is_aggregate: true if the value is an aggregate
-# ret:          the placement decision
-pub def RetPassingFn: fun(u32, u64, u64, bool, bool) abi.ParamSlot;
-
-# concrete signature the erased `AbiVTable.gp_arg_regs` / `fp_arg_regs` /
-# `callee_saved` pointers are cast back to. fills the caller-owned `out` buffer
-# with a register bank in canonical order and returns the number of registers
-# written. the caller must size `out` to hold at least the bank's maximum count
-# (`GP_PARAM_COUNT`, `FP_PARAM_COUNT`, or `CALLEE_SAVED_COUNT`).
-# ---
-# out: caller-owned buffer receiving the register descriptors
-# ret: the number of registers written
-pub def RegFileFn: fun(*isa.Register) i32;
-
-# concrete signature the erased `AbiVTable.va_model` pointer is cast back to.
-# returns the convention's `VaModel` — the variadic save model the backend's
-# prologue / va_start / va_arg expansion dispatches on. shared by both ABIs so a
-# consumer casts either convention's pointer back to this one signature.
-# ---
-# ret: the convention's variadic save model
-pub def VaModelFn: fun() abi.VaModel;
+# local aliases of the neutral vtable function signatures (`mach.lang.target.abi`).
+# the shared typedefs live in the abi module so a consumer typing any convention's
+# erased vtable pointer never routes through this concrete convention; sysv keeps
+# these names for its own use and self-registration.
+pub def ClassifyFn:    abi.ClassifyFn;
+pub def ArgPassingFn:  abi.ArgPassingFn;
+pub def RetPassingFn:  abi.RetPassingFn;
+pub def RegFileFn:     abi.RegFileFn;
+pub def VaModelFn:     abi.VaModelFn;
 
 # gp_param_reg: the GP argument register for a given argument-register index.
 # returns -1 when the index is past the six GP argument registers.

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -8,8 +8,8 @@
 # pointer in RCX, the 32-byte shadow space, and the win64 callee-saved set —
 # plus the GP/FP/callee-saved register files and the 16-byte stack alignment. The
 # three `classify`/`arg_passing`/`ret_passing` vtable function pointers are
-# type-erased (`*u8`); a consumer casts each back to the concrete signature
-# declared in `sysv` (`ClassifyFn`, `ArgPassingFn`, `RetPassingFn`, `RegFileFn`)
+# type-erased (`*u8`); a consumer casts each back to the neutral signature
+# declared in `abi` (`ClassifyFn`, `ArgPassingFn`, `RetPassingFn`, `RegFileFn`)
 # — those signatures are shared, so the cast-back is sound across both ABIs.
 
 use std.types.result.Result;
@@ -464,7 +464,7 @@ pub fun va_model() abi.VaModel {
 # the win64 ABI vtable. populated by register_win64 on first call and handed out
 # as a borrowed pointer to the registry. its three classify/arg/ret function
 # pointers are stored type-erased (`*u8`); consumers cast them back to the
-# shared `sysv.ClassifyFn` / `sysv.ArgPassingFn` / `sysv.RetPassingFn`.
+# shared `abi.ClassifyFn` / `abi.ArgPassingFn` / `abi.RetPassingFn`.
 var win64_vtable: abi.AbiVTable;
 var win64_registered: bool = false;
 

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -177,6 +177,20 @@ pub rec RegClass {
     count:     u32;
 }
 
+# AsmClobbersFn: the concrete signature the erased `IsaVTable.asm_clobbers`
+# pointer is cast back to. given an inline-asm body's raw text (with `{name}`
+# placeholders still present — they substitute to memory operands, never
+# registers), it sets `gp_out` to the bitmask of GP register indices the body
+# writes and `fp_out` to the bitmask of vector-register indices it writes. an
+# instruction the analyzer cannot classify falls back to a conservative
+# all-registers mask, so the result is always a sound over-approximation — a
+# register the body merely reads may be reported, never a written one omitted.
+# ---
+# body:   raw inline-asm body text
+# gp_out: receives the GP-register clobber bitmask (index n -> bit n)
+# fp_out: receives the vector-register clobber bitmask (index n -> bit n)
+pub def AsmClobbersFn: fun(str, *u32, *u32);
+
 # the ISA runtime-dispatch interface. exactly one of these exists per
 # architecture; the backend reads pointer width, endianness, register classes,
 # and the arch-specific operation entry points through it and never branches on
@@ -228,6 +242,12 @@ pub rec RegClass {
 #                     human-readable assembly text into a writer (cast back to the
 #                     arch's `PrintAsmFn`); a debug-only artifact hook, nil when the
 #                     ISA supplies no printer
+# asm_clobbers:       erased fn ptr — infer the GP / vector registers an inline-asm
+#                     body writes (cast back to `AsmClobbersFn`), so regalloc avoids
+#                     leaving a live value in a register a body clobbers and the
+#                     prologue preserves any callee-saved register a body writes.
+#                     nil when the ISA supplies no analyzer, which regalloc treats
+#                     conservatively (every register potentially clobbered)
 # reserved_regs:      registers the allocator must never assign (stack/frame
 #                     pointers); owned by the per-arch impl for the process
 #                     lifetime
@@ -264,6 +284,7 @@ pub rec IsaVTable {
     select:             *u8;
     encode:             *u8;
     emit_asm:           *u8;
+    asm_clobbers:       *u8;
     reserved_regs:      *Register;
     reserved_reg_count: i32;
     reload_scratch_regs:  *Register;

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -115,6 +115,7 @@ pub fun register_arm64(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     arm64_vtable.select             = nil;
     arm64_vtable.encode             = nil;
     arm64_vtable.emit_asm           = nil;
+    arm64_vtable.asm_clobbers        = nil;
     arm64_vtable.reserved_regs      = ?arm64_reserved_regs[0];
     arm64_vtable.reserved_reg_count = 2;
     # the AArch64 backend has no encoder yet; it wires no reload-scratch pool.

--- a/src/lang/target/isa/x64.mach
+++ b/src/lang/target/isa/x64.mach
@@ -267,6 +267,10 @@ pub val XADD:      Opcode = 81;
 pub val CMPXCHG:   Opcode = 82;
 # emit a single raw byte verbatim (inline-asm `.byte` directive).
 pub val RAW_BYTE:  Opcode = 83;
+# aligned packed single-precision move (128-bit). used by the prologue/epilogue to
+# save / restore a callee-saved XMM register to a 16-byte-aligned frame slot under
+# win64; the unwind tables describe it with UWOP_SAVE_XMM128.
+pub val MOVAPS:    Opcode = 84;
 
 # the canonical opcode the back end uses to load a GP value from memory.
 pub val LOAD_OPCODE: Opcode = 1;

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -4414,6 +4414,173 @@ fun encode_asm_text(st: *EncodeState, fn_base: u32, text: str) Result[bool, str]
     ret ok[bool, str](true);
 }
 
+# asm_clobbers: the `AsmClobbersFn` the x86-64 ISA vtable exposes — infer the
+# registers an inline-asm body writes so the allocator never leaves a live value
+# in one and the prologue preserves any callee-saved register the body clobbers.
+#
+# the doc (`doc/language/asm.md`) promises clobber inference from the instruction
+# stream; this implements it for the x86-64 inline-asm grammar `encode_asm_stmt`
+# accepts. the body still carries `{name}` placeholders (they substitute to
+# `[rbp+off]` memory operands at encode time, never registers), so they contribute
+# no register. the grammar admits no SSE mnemonic, so a register operand is always
+# a GP write and `fp_out` stays empty — except the opaque `.byte` directive (and
+# any unrecognized statement), which is treated as clobbering every register so
+# the result is always a sound over-approximation. RSP/RBP moves (push/pop) touch
+# only the reserved stack/frame pointers and are not reported.
+pub fun asm_clobbers(body: str, gp_out: *u32, fp_out: *u32) {
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+    val len: usize = str_len(body);
+    var start: usize = 0;
+    for (start < len) {
+        var end: usize = start;
+        for (end < len && body[end] != '\n'::char && body[end] != ';'::char) { end = end + 1; }
+        var lo: usize = start;
+        for (lo < end && is_asm_space(body[lo])) { lo = lo + 1; }
+        var hi: usize = lo;
+        for (hi < end && body[hi] != '#'::char) { hi = hi + 1; }
+        for (hi > lo && is_asm_space(body[hi - 1])) { hi = hi - 1; }
+        if (hi > lo) {
+            var line: [256]u8;
+            val ll: usize = hi - lo;
+            if (ll >= 256) {
+                # an over-long statement the encoder will reject; be conservative.
+                gp = gp | 0xFFFF::u32;
+                fp = fp | 0xFFFF::u32;
+            } or {
+                var c: usize = 0;
+                for (c < ll) { line[c] = body[lo + c]::u8; c = c + 1; }
+                line[ll] = 0;
+                stmt_clobbers((?line[0])::str, ?gp, ?fp);
+            }
+        }
+        start = end + 1;
+    }
+    @gp_out = gp;
+    @fp_out = fp;
+}
+
+# clobber_reg_operand: OR a register operand's GP-index bit into `@gp`. the inline
+# grammar produces only GP register operands; a memory / immediate / symbol
+# operand contributes no register write (a memory destination writes memory, its
+# base register is only read).
+fun clobber_reg_operand(op: *AsmOperand, gp: *u32) {
+    if (op.kind == ASMOP_REG && op.reg >= 0 && op.reg < 16) {
+        @gp = @gp | (1::u32 << op.reg::u32);
+    }
+}
+
+# clobber_two_dst: mark the destination (first) operand of a two-operand statement
+# as written. a malformed operand list the encoder will reject is treated
+# conservatively (every GP register written).
+fun clobber_two_dst(args: str, gp: *u32) {
+    var dst: AsmOperand;
+    var src: AsmOperand;
+    var dbuf: [128]u8;
+    var sbuf: [128]u8;
+    if (split_two_op(args, ?dst, ?src, ?dbuf[0], ?sbuf[0])) {
+        clobber_reg_operand(?dst, gp);
+    } or {
+        @gp = @gp | 0xFFFF::u32;
+    }
+}
+
+# clobber_two_both: mark both operands of a two-operand statement as written (the
+# XCHG / XADD exchange forms).
+fun clobber_two_both(args: str, gp: *u32) {
+    var dst: AsmOperand;
+    var src: AsmOperand;
+    var dbuf: [128]u8;
+    var sbuf: [128]u8;
+    if (split_two_op(args, ?dst, ?src, ?dbuf[0], ?sbuf[0])) {
+        clobber_reg_operand(?dst, gp);
+        clobber_reg_operand(?src, gp);
+    } or {
+        @gp = @gp | 0xFFFF::u32;
+    }
+}
+
+# clobber_one: mark the sole operand of a one-operand write form (neg / not / inc
+# / dec / pop) as written.
+fun clobber_one(args: str, gp: *u32) {
+    var op: AsmOperand;
+    if (parse_asm_operand(trim_str(args), ?op)) {
+        clobber_reg_operand(?op, gp);
+    } or {
+        @gp = @gp | 0xFFFF::u32;
+    }
+}
+
+# stmt_clobbers: OR the registers one trimmed inline-asm statement writes into
+# `@gp` / `@fp`. covers exactly the grammar `encode_asm_stmt` encodes; an
+# unrecognized statement (including `.byte`) is opaque and conservatively clobbers
+# every register.
+fun stmt_clobbers(stmt: str, gp: *u32, fp: *u32) {
+    # zero-operand forms: syscall implicitly clobbers RAX (return), RCX and R11.
+    if (str_equals(stmt, "syscall")) {
+        @gp = @gp | (1::u32 << x64.RAX::u32) | (1::u32 << x64.RCX::u32) | (1::u32 << x64.R11::u32);
+        ret;
+    }
+    if (str_equals(stmt, "ret") || str_equals(stmt, "hlt") || str_equals(stmt, "mfence")
+        || str_equals(stmt, "pause") || str_equals(stmt, "nop")) { ret; }
+
+    # a control transfer writes no callee-saved register; the surrounding asm
+    # barrier already covers a call's caller-saved clobbers.
+    if (mnemonic_is(stmt, "call") || mnemonic_is(stmt, "jmp")
+        || mnemonic_is(stmt, "je") || mnemonic_is(stmt, "jz")
+        || mnemonic_is(stmt, "jne") || mnemonic_is(stmt, "jnz")) { ret; }
+
+    # cmp / test write only the flags.
+    if (mnemonic_is(stmt, "cmp"))  { ret; }
+    if (mnemonic_is(stmt, "test")) { ret; }
+
+    # exchange forms write both operands.
+    if (mnemonic_is(stmt, "lock xadd")) { clobber_two_both(arg_str(stmt, 9), gp); ret; }
+    if (mnemonic_is(stmt, "xadd"))      { clobber_two_both(arg_str(stmt, 4), gp); ret; }
+    if (mnemonic_is(stmt, "xchg"))      { clobber_two_both(arg_str(stmt, 4), gp); ret; }
+
+    # cmpxchg writes its destination and implicitly RAX.
+    if (mnemonic_is(stmt, "lock cmpxchg")) {
+        clobber_two_dst(arg_str(stmt, 12), gp);
+        @gp = @gp | (1::u32 << x64.RAX::u32);
+        ret;
+    }
+    if (mnemonic_is(stmt, "cmpxchg")) {
+        clobber_two_dst(arg_str(stmt, 7), gp);
+        @gp = @gp | (1::u32 << x64.RAX::u32);
+        ret;
+    }
+
+    # two-operand write-first forms.
+    if (mnemonic_is(stmt, "mov"))   { clobber_two_dst(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "lea"))   { clobber_two_dst(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "add"))   { clobber_two_dst(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "sub"))   { clobber_two_dst(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "and"))   { clobber_two_dst(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "or"))    { clobber_two_dst(arg_str(stmt, 2), gp); ret; }
+    if (mnemonic_is(stmt, "xor"))   { clobber_two_dst(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "shl"))   { clobber_two_dst(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "shr"))   { clobber_two_dst(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "sar"))   { clobber_two_dst(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "movzx")) { clobber_two_dst(arg_str(stmt, 5), gp); ret; }
+    if (mnemonic_is(stmt, "movsx")) { clobber_two_dst(arg_str(stmt, 5), gp); ret; }
+
+    # one-operand write forms.
+    if (mnemonic_is(stmt, "neg")) { clobber_one(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "not")) { clobber_one(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "inc")) { clobber_one(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "dec")) { clobber_one(arg_str(stmt, 3), gp); ret; }
+    if (mnemonic_is(stmt, "pop")) { clobber_one(arg_str(stmt, 3), gp); ret; }
+
+    # push reads its operand and adjusts the reserved RSP; nothing else is written.
+    if (mnemonic_is(stmt, "push")) { ret; }
+
+    # `.byte` raw bytes or any statement outside the grammar is opaque: assume it
+    # writes every register so no live value is left in one it might overwrite.
+    @gp = @gp | 0xFFFF::u32;
+    @fp = @fp | 0xFFFF::u32;
+}
+
 # encode_asm_stmt: parse and encode one trimmed inline-asm statement.
 fun encode_asm_stmt(st: *EncodeState, fn_base: u32, tok: str) Result[bool, str] {
     # zero-operand mnemonics.

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -1626,6 +1626,36 @@ fun encode_sse_mov(mi: *isa.Inst, buf: *ByteBuf) i32 {
     ret 0;
 }
 
+# encode_movaps: encode MOVAPS in reg<-mem (`0F 28 /r`, a 128-bit aligned load)
+# and mem<-reg (`0F 29 /r`, a 128-bit aligned store) forms — the prologue /
+# epilogue callee-saved XMM save and restore. MOVAPS takes no mandatory SSE prefix.
+# the memory operand must be 16-byte aligned, which the frame layout guarantees
+# (RBP is 16-aligned after `push rbp; mov rbp, rsp`, and the XMM slots sit at
+# 16-aligned `[rbp - k*16]`). reg<->reg is unused here and not emitted.
+fun encode_movaps(mi: *isa.Inst, buf: *ByteBuf) i32 {
+    val start: usize = buf.len;
+    val dst: *isa.Operand = ?mi.dst;
+    val src1: *isa.Operand = ?mi.src1;
+
+    if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_MEM) {
+        emit_rex_mem(buf, 0, dst.reg, src1);
+        emit_byte(buf, 0x0F);
+        emit_byte(buf, 0x28);
+        encode_mem_operand(buf, dst.reg, src1);
+        ret (buf.len - start)::i32;
+    }
+
+    if (dst.kind == isa.OPK_MEM && src1.kind == isa.OPK_REG) {
+        emit_rex_mem(buf, 0, src1.reg, dst);
+        emit_byte(buf, 0x0F);
+        emit_byte(buf, 0x29);
+        encode_mem_operand(buf, src1.reg, dst);
+        ret (buf.len - start)::i32;
+    }
+
+    ret 0;
+}
+
 # sse_alu_opcode: map an SSE arithmetic opcode to its secondary opcode byte.
 fun sse_alu_opcode(opcode: u16) u8 {
     if (opcode == x64.ADDSS || opcode == x64.ADDSD) { ret 0x58; }
@@ -1919,6 +1949,10 @@ pub fun encode_inst(mi: *isa.Inst, buf: *ByteBuf) i32 {
         ret encode_sse_mov(mi, buf);
     }
 
+    if (opcode == x64.MOVAPS) {
+        ret encode_movaps(mi, buf);
+    }
+
     if (is_sse_alu(opcode)) {
         ret encode_sse_alu(mi, buf);
     }
@@ -2055,11 +2089,37 @@ fun count_callee_saved(abi_vt: *abi.AbiVTable, mask: u32) i32 {
 # the outgoing region as the bottommost slice puts its base exactly at the new
 # RSP, so a caller's `[rsp + off]` argument store lands in it, and keeping every
 # addend 16-aligned holds RSP 16-byte aligned at each call boundary.
-fun frame_total(abi_vt: *abi.AbiVTable, frame_size: u32, callee_mask: u32, outgoing_size: u32) usize {
-    val callee_space: usize = count_callee_saved(abi_vt, callee_mask)::usize * 8;
-    var base: usize = frame_size::usize + callee_space;
+fun frame_total(abi_vt: *abi.AbiVTable, frame_size: u32, callee_mask: u32, callee_mask_fp: u32, outgoing_size: u32) usize {
+    var base: usize = fp_save_base(abi_vt, frame_size, callee_mask);
+    # the callee-saved XMM save area (16 bytes per register, MOVAPS-aligned) sits
+    # below the 16-aligned GP-area base. `fp_save_base` is already 16-aligned, so
+    # adding 16-byte slots keeps the whole area 16-aligned.
+    base = base + popcount32(callee_mask_fp)::usize * 16;
     if (base > 0 && (base & 15) != 0) { base = (base + 15) & ~15::usize; }
     ret base + outgoing_size::usize;
+}
+
+# fp_save_base: the 16-byte-aligned offset (from RBP) at which the callee-saved
+# XMM save area begins — just below the local frame and the GP save area. the XMM
+# slots are then at `[rbp - (fp_save_base + 16*k)]`, each 16-aligned because RBP and
+# fp_save_base are. shared by `frame_total`, `emit_prologue`, and `emit_epilogue` so
+# the reserved size and the actual save offsets always agree.
+fun fp_save_base(abi_vt: *abi.AbiVTable, frame_size: u32, callee_mask: u32) usize {
+    val gp_space: usize = count_callee_saved(abi_vt, callee_mask)::usize * 8;
+    var base: usize = frame_size::usize + gp_space;
+    if ((base & 15) != 0) { base = (base + 15) & ~15::usize; }
+    ret base;
+}
+
+# popcount32: the number of set bits in a 32-bit mask.
+fun popcount32(m: u32) i32 {
+    var n: i32 = 0;
+    var x: u32 = m;
+    for (x != 0) {
+        n = n + (x & 1)::i32;
+        x = x >> 1;
+    }
+    ret n;
 }
 
 # emit_inst: encode one fully-formed `isa.Inst` into the encoder byte sink. used
@@ -2095,6 +2155,32 @@ fun emit_frame_load(st: *EncodeState, reg: i32, disp: i32) {
     emit_inst(st, ?mi);
 }
 
+# emit_xmm_store: encode a `movaps [rbp+disp], xmm` saving a callee-saved vector
+# register into the frame. `idx` is the XMM within-bank index (0–15); the operand
+# is built on its composite SSE id so the encoder selects the SSE form. `disp` must
+# be 16-aligned (the frame layout guarantees it) for the aligned MOVAPS.
+fun emit_xmm_store(st: *EncodeState, idx: i32, disp: i32) {
+    var mi: isa.Inst;
+    zero_inst(?mi);
+    mi.opcode = x64.MOVAPS;
+    mi.dst    = isa.make_mem(x64.RBP, disp, -1, 0, 16);
+    mi.src1   = isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, idx), 16);
+    mi.size   = 16;
+    emit_inst(st, ?mi);
+}
+
+# emit_xmm_load: encode a `movaps xmm, [rbp+disp]` restoring a callee-saved vector
+# register from the frame, mirroring emit_xmm_store.
+fun emit_xmm_load(st: *EncodeState, idx: i32, disp: i32) {
+    var mi: isa.Inst;
+    zero_inst(?mi);
+    mi.opcode = x64.MOVAPS;
+    mi.dst    = isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, idx), 16);
+    mi.src1   = isa.make_mem(x64.RBP, disp, -1, 0, 16);
+    mi.size   = 16;
+    emit_inst(st, ?mi);
+}
+
 # emit_prologue: encode the standard x86-64 function prologue into the `.text`
 # byte sink.
 #
@@ -2107,11 +2193,13 @@ fun emit_frame_load(st: *EncodeState, reg: i32, disp: i32) {
 # the call. the callee-save offsets are frame_size-relative and so are unaffected
 # by the outgoing region reserved below them.
 # ---
-# st:            encoder state whose byte sink the prologue bytes are appended to
-# frame_size:    size of the local frame in bytes (locals + va-save; pre callee-save)
-# callee_mask:   bitmask of callee-saved GP registers regalloc assigned
-# outgoing_size: bytes reserved at the bottom of the frame for stack-passed call args
-fun emit_prologue(st: *EncodeState, frame_size: u32, callee_mask: u32, outgoing_size: u32) {
+# st:             encoder state whose byte sink the prologue bytes are appended to
+# frame_size:     size of the local frame in bytes (locals + va-save; pre callee-save)
+# callee_mask:    bitmask of callee-saved GP registers regalloc assigned
+# callee_mask_fp: bitmask of callee-saved XMM register indices regalloc assigned
+#                 (win64 only; 0 under SysV, where the XMM save path is inert)
+# outgoing_size:  bytes reserved at the bottom of the frame for stack-passed call args
+fun emit_prologue(st: *EncodeState, frame_size: u32, callee_mask: u32, callee_mask_fp: u32, outgoing_size: u32) {
     var push_rbp: isa.Inst;
     zero_inst(?push_rbp);
     push_rbp.opcode = x64.PUSH;
@@ -2129,7 +2217,7 @@ fun emit_prologue(st: *EncodeState, frame_size: u32, callee_mask: u32, outgoing_
     mov_rbp.flags  = x64.FLAG_REX_W;
     emit_inst(st, ?mov_rbp);
 
-    val total: usize = frame_total(st.abi, frame_size, callee_mask, outgoing_size);
+    val total: usize = frame_total(st.abi, frame_size, callee_mask, callee_mask_fp, outgoing_size);
     if (total > 0) {
         var sub_rsp: isa.Inst;
         zero_inst(?sub_rsp);
@@ -2152,6 +2240,19 @@ fun emit_prologue(st: *EncodeState, frame_size: u32, callee_mask: u32, outgoing_
         }
         i = i + 1;
     }
+
+    # callee-saved XMM saves (win64): each at a 16-aligned `[rbp - (base + 16*k)]`
+    # below the GP save area, in ascending index order (matching the epilogue).
+    val xbase: i32 = fp_save_base(st.abi, frame_size, callee_mask)::i32;
+    var xoff: i32 = xbase + 16;
+    var x: i32 = 0;
+    for (x < 16) {
+        if ((callee_mask_fp & (1::u32 << x::u32)) != 0) {
+            emit_xmm_store(st, x, -xoff);
+            xoff = xoff + 16;
+        }
+        x = x + 1;
+    }
 }
 
 # emit_epilogue: encode the standard x86-64 function epilogue into the `.text`
@@ -2163,10 +2264,24 @@ fun emit_prologue(st: *EncodeState, frame_size: u32, callee_mask: u32, outgoing_
 # so each is reloaded from the slot it was saved into. the RET itself is encoded
 # from the MIR_RET instruction that follows.
 # ---
-# st:          encoder state whose byte sink the epilogue bytes are appended to
-# frame_size:  size of the local frame in bytes (locals + va-save; pre callee-save)
-# callee_mask: bitmask of callee-saved GP registers regalloc assigned
-fun emit_epilogue(st: *EncodeState, frame_size: u32, callee_mask: u32) {
+# st:             encoder state whose byte sink the epilogue bytes are appended to
+# frame_size:     size of the local frame in bytes (locals + va-save; pre callee-save)
+# callee_mask:    bitmask of callee-saved GP registers regalloc assigned
+# callee_mask_fp: bitmask of callee-saved XMM register indices regalloc assigned
+fun emit_epilogue(st: *EncodeState, frame_size: u32, callee_mask: u32, callee_mask_fp: u32) {
+    # restore the callee-saved XMM registers first (the reverse of the prologue's
+    # last stores), from the same 16-aligned slots in ascending index order.
+    val xbase: i32 = fp_save_base(st.abi, frame_size, callee_mask)::i32;
+    var xoff: i32 = xbase + 16;
+    var x: i32 = 0;
+    for (x < 16) {
+        if ((callee_mask_fp & (1::u32 << x::u32)) != 0) {
+            emit_xmm_load(st, x, -xoff);
+            xoff = xoff + 16;
+        }
+        x = x + 1;
+    }
+
     var list: [16]i32;
     val ln: i32 = x64.callee_saved_gp_list(st.abi, ?list[0]);
     var coff: i32 = frame_size::i32 + 8;
@@ -2514,6 +2629,7 @@ fun shrink_text(st: *EncodeState) Result[bool, str] {
 fun function_is_naked(f: *mir.MirFunction) bool {
     if (f.frame.size != 0) { ret false; }
     if (f.callee_mask != 0) { ret false; }
+    if (f.callee_mask_fp != 0) { ret false; }
     if (f.frame.outgoing_size != 0) { ret false; }
 
     var bi: u32 = 0;
@@ -2548,8 +2664,9 @@ fun encode_function(st: *EncodeState, f: *mir.MirFunction) Result[bool, str] {
     val naked: bool = function_is_naked(f);
     val frame_size: u32 = f.frame.size;
     val callee_mask: u32 = f.callee_mask;
+    val callee_mask_fp: u32 = f.callee_mask_fp;
     val outgoing_size: u32 = f.frame.outgoing_size;
-    if (!naked) { emit_prologue(st, frame_size, callee_mask, outgoing_size); }
+    if (!naked) { emit_prologue(st, frame_size, callee_mask, callee_mask_fp, outgoing_size); }
 
     var bi: u32 = 0;
     for (bi < f.block_count) {
@@ -2563,7 +2680,7 @@ fun encode_function(st: *EncodeState, f: *mir.MirFunction) Result[bool, str] {
             # the function epilogue precedes every RET: restore callee-saved
             # registers and tear down the frame, then encode the RET itself.
             if (mi.opcode::u16 == x64.RET::u16 && !naked) {
-                emit_epilogue(st, frame_size, callee_mask);
+                emit_epilogue(st, frame_size, callee_mask, callee_mask_fp);
             }
             val ei: Result[bool, str] = encode_mir_instr(st, f, fn_base, mi);
             if (is_err[bool, str](ei)) { ret ei; }

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -143,6 +143,7 @@ pub fun register_x64(alloc: *Allocator, interner: *intern.Interner) Result[bool,
     x64_vtable.select             = x64isel.select::*u8;
     x64_vtable.encode             = x64encode.encode_x64::*u8;
     x64_vtable.emit_asm           = x64printer.print_asm_x64::*u8;
+    x64_vtable.asm_clobbers        = x64encode.asm_clobbers::*u8;
     x64_vtable.reserved_regs      = ?x64_reserved_regs[0];
     x64_vtable.reserved_reg_count = 2;
     x64_vtable.reload_scratch_regs  = ?x64_reload_scratch_regs[0];

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -158,6 +158,8 @@ val UWOP_ALLOC_SMALL: u8 = 2;
 val UWOP_SET_FPREG: u8 = 3;
 val UWOP_SAVE_NONVOL: u8 = 4;
 val UWOP_SAVE_NONVOL_FAR: u8 = 5;
+val UWOP_SAVE_XMM128: u8 = 8;
+val UWOP_SAVE_XMM128_FAR: u8 = 9;
 val UWREG_RBP: u8 = 5;
 
 # write a u16 little-endian into a buffer.
@@ -1551,7 +1553,7 @@ rec FunctionUnwind {
     slot_count:  u32;
     xdata_rva:   u64;
     xdata_size:  usize;
-    codes:       [16]UnwindCode;
+    codes:       [32]UnwindCode;
 }
 
 # func_import_count: the number of function imports in a dynamic plan — only these
@@ -1608,7 +1610,7 @@ fun import_dir_bytes(dyn: *of.DynamicInfo) usize {
 # to a function's code array, tracking the running slot count; false when full.
 fun push_unwind_code(uw: *FunctionUnwind, end_off: u8, op: u8, info: u8,
                      extra0: u16, extra1: u16, extra_slots: u8) bool {
-    if (uw.code_count >= 16) { ret false; }
+    if (uw.code_count >= 32) { ret false; }
     uw.codes[uw.code_count].end_off = end_off;
     uw.codes[uw.code_count].op = op;
     uw.codes[uw.code_count].info = info;
@@ -1650,6 +1652,28 @@ fun push_save_nonvol(uw: *FunctionUnwind, end_off: u8, reg: u8, save_off: usize)
     # the far form records the UNSCALED byte offset in two slots (cf. ALLOC_LARGE info=1).
     ret push_unwind_code(uw, end_off, UWOP_SAVE_NONVOL_FAR, reg,
                          (save_off & 0xFFFF)::u16, ((save_off >> 16) & 0xFFFF)::u16, 2);
+}
+
+# push_save_xmm128: append the unwind code for a `movaps [frame-off], xmm` 128-bit
+# callee-saved vector save — SAVE_XMM128 with the offset scaled by 16, or
+# SAVE_XMM128_FAR with the unscaled byte offset when that scaled value exceeds 16
+# bits. the offset must be 16-aligned (the frame layout guarantees it).
+fun push_save_xmm128(uw: *FunctionUnwind, end_off: u8, reg: u8, save_off: usize) bool {
+    if ((save_off & 15) != 0) { ret false; }
+    val scaled: u64 = (save_off / 16)::u64;
+    if (scaled <= 0xFFFF) {
+        ret push_unwind_code(uw, end_off, UWOP_SAVE_XMM128, reg, scaled::u16, 0, 1);
+    }
+    if (save_off > 0xFFFFFFFF::usize) { ret false; }
+    # the far form records the UNSCALED byte offset in two slots (cf. SAVE_NONVOL_FAR).
+    ret push_unwind_code(uw, end_off, UWOP_SAVE_XMM128_FAR, reg,
+                         (save_off & 0xFFFF)::u16, ((save_off >> 16) & 0xFFFF)::u16, 2);
+}
+
+# is_win64_nonvol_xmm: whether a vector register number is callee-saved under the
+# win64 ABI (XMM6–XMM15).
+fun is_win64_nonvol_xmm(reg: u8) bool {
+    ret reg >= 6 && reg <= 15;
 }
 
 # is_win64_nonvol_reg: whether a register number is callee-saved under the win64
@@ -1758,6 +1782,51 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count:
         if ((rex & 4) != 0) { reg = reg + 8; }
         if (!is_win64_nonvol_reg(reg)) { brk; }
         if (!push_save_nonvol(uw, (cur + inst_len)::u8, reg, save_off)) { ret false; }
+        pos = cur + inst_len;
+    }
+
+    # callee-saved XMM saves (`movaps [rbp-off], xmm`), emitted after the GP saves
+    # under win64. each is `[REX.R] 0F 29 modrm disp` storing an XMM6–15 to a
+    # 16-aligned frame slot; recorded as UWOP_SAVE_XMM128 so the unwinder restores
+    # the full register. parsing them here keeps the prologue size and the unwind
+    # codes complete (an unrecognized save would leave them silently invisible).
+    for (true) {
+        var cur: usize = pos;
+        if (cur + 4 > lim) { brk; }
+        var rex: u8 = 0;
+        if (seg.bytes[base + cur] >= 0x40 && seg.bytes[base + cur] <= 0x4F) {
+            rex = seg.bytes[base + cur];
+            cur = cur + 1;
+            if (cur + 4 > lim) { brk; }
+        }
+        # MOVAPS store is `0F 29 /r`; a REX.B extended base is not [rbp].
+        if (seg.bytes[base + cur] != 0x0F || seg.bytes[base + cur + 1] != 0x29) { brk; }
+        if ((rex & 1) != 0) { brk; }
+        val modrm: u8 = seg.bytes[base + cur + 2];
+        val mod: u8 = modrm >> 6;
+        if ((modrm & 7) != 5 || (mod != 1 && mod != 2)) { brk; }
+
+        var disp: i64 = 0;
+        var inst_len: usize = 0;
+        if (mod == 1) {
+            if (cur + 4 > lim) { brk; }
+            disp = (seg.bytes[base + cur + 3]::i8)::i64;
+            inst_len = 4;
+        }
+        or {
+            if (cur + 7 > lim) { brk; }
+            disp = (read_u32_le(seg.bytes, base + cur + 3)::i32)::i64;
+            inst_len = 7;
+        }
+        if (disp >= 0) { brk; }
+
+        val off_rbp: usize = (-disp)::usize;
+        if (alloc < off_rbp) { ret false; }
+        val save_off: usize = alloc - off_rbp;
+        var reg: u8 = ((modrm >> 3) & 7);
+        if ((rex & 4) != 0) { reg = reg + 8; }
+        if (!is_win64_nonvol_xmm(reg)) { brk; }
+        if (!push_save_xmm128(uw, (cur + inst_len)::u8, reg, save_off)) { ret false; }
         pos = cur + inst_len;
     }
 
@@ -2245,9 +2314,9 @@ fun write_unwind_xdata(buf: *u8, lay: *PeLayout, uw: *FunctionUnwind) {
     buf[xoff + 2] = uw.slot_count::u8;
     buf[xoff + 3] = (uw.frame_reg & 0x0F) | ((uw.frame_off & 0x0F) << 4);
 
-    var used: [16]bool;
+    var used: [32]bool;
     var i: usize = 0;
-    for (i < 16) { used[i] = false; i = i + 1; }
+    for (i < 32) { used[i] = false; i = i + 1; }
 
     var slots_written: usize = 0;
     var codes_written: u32 = 0;
@@ -3366,6 +3435,68 @@ test "coff: push_save_nonvol writes the unscaled offset in the SAVE_NONVOL_FAR f
     if (c.extra1 != ((off >> 16) & 0xFFFF)::u16) { ret 1; }
     val scaled: usize = off / 8;
     if (c.extra0 == (scaled & 0xFFFF)::u16 && c.extra1 == ((scaled >> 16) & 0xFFFF)::u16) { ret 1; }
+    ret 0;
+}
+
+test "coff: parse_function_unwind decodes callee-saved XMM saves as SAVE_XMM128 (#1254)" {
+    # push rbp; mov rbp,rsp; sub rsp,0x40; mov [rbp-8],rbx;
+    # movaps [rbp-0x20],xmm6; movaps [rbp-0x30],xmm8 (REX.R); ret
+    var text_bytes: [22]u8;
+    text_bytes[0] = 0x55;
+    text_bytes[1] = 0x48; text_bytes[2] = 0x89; text_bytes[3] = 0xE5;
+    text_bytes[4] = 0x48; text_bytes[5] = 0x83; text_bytes[6] = 0xEC; text_bytes[7] = 0x40;
+    text_bytes[8] = 0x48; text_bytes[9] = 0x89; text_bytes[10] = 0x5D; text_bytes[11] = 0xF8;
+    text_bytes[12] = 0x0F; text_bytes[13] = 0x29; text_bytes[14] = 0x75; text_bytes[15] = 0xE0;
+    text_bytes[16] = 0x44; text_bytes[17] = 0x0F; text_bytes[18] = 0x29; text_bytes[19] = 0x45; text_bytes[20] = 0xD0;
+    text_bytes[21] = 0xC3;
+
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = 0x140000000; segs[0].filesz = 22; segs[0].memsz = 22;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
+
+    var funcs: [1]of.ExecFunction;
+    funcs[0].seg_index = 0; funcs[0].seg_offset = 0; funcs[0].size = 22;
+
+    var uw: FunctionUnwind;
+    if (!parse_function_unwind(?uw, ?segs[0], 1, ?funcs[0], 0)) { ret 1; }
+    # PUSH_NONVOL, ALLOC_SMALL, SAVE_NONVOL(rbx), SAVE_XMM128(xmm6), SAVE_XMM128(xmm8).
+    if (uw.code_count != 5) { ret 1; }
+    if (uw.prolog_size != 21) { ret 1; }  # the whole prologue, including the XMM saves
+
+    # codes are recorded in insertion order; the two XMM saves follow the GP save.
+    val x6: *UnwindCode = ?uw.codes[3];
+    if (x6.op != UWOP_SAVE_XMM128) { ret 1; }
+    if (x6.info != 6) { ret 1; }
+    if (x6.extra0 != 2) { ret 1; }   # save_off (0x40 - 0x20) = 0x20, scaled by 16
+    if (x6.end_off != 16) { ret 1; }
+
+    val x8: *UnwindCode = ?uw.codes[4];
+    if (x8.op != UWOP_SAVE_XMM128) { ret 1; }
+    if (x8.info != 8) { ret 1; }
+    if (x8.extra0 != 1) { ret 1; }   # save_off (0x40 - 0x30) = 0x10, scaled by 16
+    if (x8.end_off != 21) { ret 1; }
+
+    ret 0;
+}
+
+test "coff: push_save_xmm128 writes the unscaled offset in the SAVE_XMM128_FAR form" {
+    var uw: FunctionUnwind;
+    uw.code_count = 0;
+    uw.slot_count = 0;
+    # 0x110000 / 16 = 0x11000 exceeds the 16-bit scaled field, forcing the far form.
+    val off: usize = 0x110000;
+    if (!push_save_xmm128(?uw, 0, 9, off)) { ret 1; }  # xmm9
+    if (uw.code_count != 1) { ret 1; }
+    val c: *UnwindCode = ?uw.codes[0];
+    if (c.op != UWOP_SAVE_XMM128_FAR) { ret 1; }
+    if (c.info != 9) { ret 1; }
+    if (c.extra_slots != 2) { ret 1; }
+    if (c.extra0 != (off & 0xFFFF)::u16) { ret 1; }
+    if (c.extra1 != ((off >> 16) & 0xFFFF)::u16) { ret 1; }
+    # a 16-misaligned offset is rejected (MOVAPS requires alignment).
+    uw.code_count = 0;
+    uw.slot_count = 0;
+    if (push_save_xmm128(?uw, 0, 6, 0x18)) { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Refs #1254. Audit cluster for `src/lang/be/codegen/regalloc.mach` — the three confirmed miscompiles plus the surrounding smells/cleanups. The three miscompiles and all the small smells are fixed; two non-correctness items are deferred with precise follow-up notes (see below).

## Findings

### Fixed
- **[BUG/M] FP-bank interference blindness** (`a45…`) — the precolored-def / argument-window reservations and the param-register pinning that guard physical-register operands were GP-only, so an FP value live across a float argument-setup move could be colored onto the XMM the move writes. Extended the (composite-id-keyed) reservation windows to serve both banks, added FP param pinning and an `fp_available` gate. Fixes the swapped-float-args miscompile (`take(b, a)` returned `b - b`).
- **[BUG/L] inline-asm clobbers ignored** — `doc/language/asm.md` promises clobber inference that did not exist; regalloc modeled an asm block only as a caller-saved call barrier, so a value parked in a callee-saved register the asm writes was corrupted, and an asm-bearing function corrupted its caller. Implemented the doc's promise: a new ISA-vtable `AsmClobbersFn` infers the written registers from the x86-64 inline-asm grammar (precise per-mnemonic write sets + syscall/cmpxchg implicit clobbers, conservative for opaque `.byte`); regalloc spills a live value out of an asm-clobbered callee-saved register and ORs every asm-clobbered callee-saved register into `callee_mask` (including for vreg-free asm-only functions).
- **[BUG/L] win64 callee-saved XMM6–13 never saved** — extended the per-bank callee-save model to the FP bank: `fp_callee_saved` seeded from the ABI file, callee-save-aware `pick_fp`, `spill_across_calls` keeps call-crossing values in callee-saved XMM, a new `MirFunction.callee_mask_fp`, x64 prologue/epilogue 16-byte-aligned MOVAPS save/restore (new opcode + encoder + frame accounting), and coff `parse_function_unwind` decoding the saves into `UWOP_SAVE_XMM128` so `.xdata`/`.pdata` stays complete. Entirely win64-only (SysV has no callee-saved XMM), so the linux self-host build is byte-for-byte unchanged.
- **[DESIGN/S] sysv-typed ABI vtable** — moved the shared vtable fn typedefs to the neutral `abi` module; regalloc no longer casts through `sysv`.
- **[SMELL/S] emit_reload/emit_store divergence** — `emit_reload` now returns a `Result` like its twin; `rewrite_block`'s error path now frees the operand arrays it claims to.
- **[CLEANUP/S] regalloc MIR_ARG vestiges** — removed the three dead branches + corrected the comment (left mir.mach's opcode for the later mir work).

### Deferred (non-correctness, tracked)
- **win64 float-scratch XMM14/15** — the encoder's float-arith scratch (XMM14/15) is callee-saved under win64 but is not allocator-assigned, so it is outside this finding's "allocator hands them out" scope. Harmless for pure-mach programs (no mach value ever lives there); preserving it for non-mach float-using callbacks is a precise follow-up.
- **[SMELL/M] quadratic scaling family** — perf-only; the candidate rewrites touch the core liveness/scan paths where any subtle change risks the byte-identical self-host fixpoint, with no correctness benefit. Deferred per "don't gold-plate".

## Verification
- `mach build .` clean; `mach test .` 237 pass (incl. new coff XMM-unwind unit tests).
- Byte-identical self-host fixpoint converges (same as pristine `dev`).
- All `.github/tests` suites pass locally including wine, plus three new failing-before suites: `fpargs`, `asmclobber`, `win64fp`.
- Cross-compiled `mach.exe`; `wine mach.exe build .` on a float test project produces a correct binary.
