### PR TITLE
fix(x64): #1255 audit — int→float miscompile, byte-reg REX, imm-width, loud failures, encoder consolidation

### DIFF
--- a/.github/tests/fconv/app/mach.toml
+++ b/.github/tests/fconv/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "fconvapp"
+name = "Integer-to-float conversion test — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/fconvapp"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/fconv/app/src/main.mach
+++ b/.github/tests/fconv/app/src/main.mach
@@ -1,0 +1,72 @@
+use std.runtime.linux.x86_64;
+
+# integer-to-float conversion regression coverage (issue #1255): u32/u16/u8 ->
+# f32/f64 must convert UNSIGNED (not as a signed i32) and off a clean register
+# (no stale upper bits from a narrow source); signed narrow sources must
+# sign-extend; u64 >= 2^63 must convert positive through the range-fixup path.
+# every source is offset by a runtime, non-foldable zero so the cast exercises the
+# codegen conversion rather than being constant-folded. references for the huge u64
+# magnitudes are built by exact doubling, not by parsing huge decimal float literals.
+
+# pow2: 2^k built by exact repeated doubling from 1.0 in f64.
+fun pow2(k: i32) f64 {
+    var r: f64 = 1.0;
+    var i: i32 = 0;
+    for (i < k) { r = r * 2.0; i = i + 1; }
+    ret r;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    val n: u64 = argc::u64 - 1;
+
+    # u32 -> f64 (sign bug: >= 2^31 must stay positive and exact).
+    val u32a: u32 = (4294967295::u64 + n)::u32;
+    if (u32a::f64 != 4294967295.0) { ret 1; }
+    val u32b: u32 = (2147483648::u64 + n)::u32;
+    if (u32b::f64 != 2147483648.0) { ret 2; }
+    val u32c: u32 = (2147483647::u64 + n)::u32;
+    if (u32c::f64 != 2147483647.0) { ret 3; }
+    val u32d: u32 = (2147483648::u64 + n)::u32;
+    if (u32d::f32 != 2147483648.0::f32) { ret 4; }
+
+    # u16 -> f64 / f32 (stale-upper-bits guard).
+    val u16a: u16 = (65535::u64 + n)::u16;
+    if (u16a::f64 != 65535.0) { ret 5; }
+    if (u16a::f32 != 65535.0::f32) { ret 6; }
+    val u16b: u16 = (32768::u64 + n)::u16;
+    if (u16b::f64 != 32768.0) { ret 7; }
+
+    # u8 -> f64 / f32 (stale-upper-bits guard).
+    val u8a: u8 = (255::u64 + n)::u8;
+    if (u8a::f64 != 255.0) { ret 8; }
+    if (u8a::f32 != 255.0::f32) { ret 9; }
+    val u8b: u8 = (128::u64 + n)::u8;
+    if (u8b::f64 != 128.0) { ret 10; }
+
+    # signed narrow -> f64 (must sign-extend, not zero-extend).
+    val i8a: i8 = (0::u64 + n)::i8 - 1;
+    if (i8a::f64 != -1.0) { ret 11; }
+    val i8b: i8 = (0::u64 + n)::i8 - 128;
+    if (i8b::f64 != -128.0) { ret 12; }
+    val i16a: i16 = (0::u64 + n)::i16 - 32768;
+    if (i16a::f64 != -32768.0) { ret 13; }
+    val i32a: i32 = (0::u64 + n)::i32 - 2147483648;
+    if (i32a::f64 != -2147483648.0) { ret 14; }
+
+    # u64 -> f64 / f32 (>= 2^63 range-fixup path; doubling-built references).
+    val u64a: u64 = 9223372036854775808::u64 + n;
+    if (u64a::f64 < 0.0) { ret 15; }
+    if (u64a::f64 != pow2(63)) { ret 16; }
+    val u64b: u64 = 18446744073709551615::u64 + n;
+    if (u64b::f64 != pow2(64)) { ret 17; }
+    val u64c: u64 = 9223372036854777856::u64 + n;
+    if (u64c::f64 != pow2(63) + pow2(11)) { ret 18; }
+    if (u64a::f32::f64 != pow2(63)) { ret 19; }
+
+    # exact path: small u64 < 2^63 stays exact.
+    val u64s: u64 = 1000000::u64 + n;
+    if (u64s::f64 != 1000000.0) { ret 20; }
+
+    ret 0;
+}

--- a/.github/tests/fconv/run.sh
+++ b/.github/tests/fconv/run.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# integer-to-float conversion regression test (issue #1255): build the `app`
+# project with the freshly-built compiler and run it. the app self-checks u32 /
+# u16 / u8 / i8 / i16 / i32 / u64 -> f32 / f64 conversions across boundary values
+# (0xFFFFFFFF, 0x80000000, 2^63, 2^64-1, ...) and exits 0 only when every result is
+# correct; any miscompiled conversion exits with a non-zero check id.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL fconv: build failed" >&2
+    exit 1
+fi
+
+set +e
+"$WORK/app/out/linux/bin/fconvapp"
+code=$?
+set -e
+
+if [ "$code" -ne 0 ]; then
+    echo "FAIL fconv: conversion check $code produced a wrong result" >&2
+    exit 1
+fi
+
+echo "PASS fconv: integer-to-float conversions correct across boundary values"
+exit 0

--- a/src/lang/target/isa/x64.mach
+++ b/src/lang/target/isa/x64.mach
@@ -1,36 +1,23 @@
 # mach.lang.target.isa.x64: x86-64 instruction set implementation.
 #
 # Owns the concrete register numbering, machine opcode space, and encoding flags
-# for the architecture, plus the register-file construction, register-name
-# lookup, and the frame-shape helpers (prologue / epilogue emission, return /
-# call recognition, relocation-patch offset) that the encoder calls by name.
-# Builds and self-registers an `isa.IsaVTable` (gpr / xmm / flags register
-# classes) into the process-global ISA registry so `target.select` can compose
-# an x86-64 target. Only the isel and encode tables are target-specific;
-# everything the back end consumes that is x86-64-shaped lives here.
-
-use std.types.result.Result;
-use std.types.result.ok;
-use std.types.result.err;
-use std.types.result.is_err;
-use std.types.result.unwrap_ok;
-use std.types.result.unwrap_err;
+# for the architecture, plus the register-name lookup, FP-opcode classification,
+# and the ABI-driven callee-saved GP list the encoder's frame emission reads. The
+# register files and the `isa.IsaVTable` are constructed and registered by the
+# sibling `register` module; the live prologue / epilogue, return / call
+# recognition, and relocation-patch offset live in the `encode` module. Only the
+# isel and encode tables are target-specific; everything the back end consumes
+# that is x86-64-shaped lives here.
 
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 
-use std.types.size.usize;
-
 use std.types.string.str;
 
-use std.allocator.Allocator;
-use std.allocator.allocate;
-
-use intern: mach.lang.intern;
-use isa:    mach.lang.target.isa;
-use abi:    mach.lang.target.abi;
-use sysv:   mach.lang.target.abi.sysv;
+use isa:  mach.lang.target.isa;
+use abi:  mach.lang.target.abi;
+use sysv: mach.lang.target.abi.sysv;
 
 # general-purpose register ids. these are the canonical x86-64 GP register
 # numbers (matching the ModRM/REX encoding), used directly as `Operand.reg`
@@ -90,9 +77,6 @@ pub val FRAME_REG: i32 = 5;
 pub val SCRATCH_REG:    i32 = 11;
 pub val SCRATCH_REG2:   i32 = 10;
 pub val FP_SCRATCH_REG: i32 = (1 << 8) | 15;
-
-# code alignment for function entry points, in bytes.
-pub val CODE_ALIGN: u32 = 16;
 
 # the x86-64 machine opcode space. each value names a logical instruction form;
 # the encoder maps it to concrete bytes and the isel table emits it. pseudo
@@ -268,17 +252,6 @@ pub val CMPXCHG:   Opcode = 82;
 # emit a single raw byte verbatim (inline-asm `.byte` directive).
 pub val RAW_BYTE:  Opcode = 83;
 
-# the canonical opcode the back end uses to load a GP value from memory.
-pub val LOAD_OPCODE: Opcode = 1;
-# the canonical opcode the back end uses to store a GP value to memory.
-pub val STORE_OPCODE: Opcode = 1;
-# the canonical opcode the back end uses to zero-extend a narrow GP value.
-pub val ZEXT_OPCODE: Opcode = 58;
-# the canonical opcode the back end uses to load a scalar FP value.
-pub val FP_LOAD_OPCODE: Opcode = 42;
-# the canonical opcode the back end uses to store a scalar FP value.
-pub val FP_STORE_OPCODE: Opcode = 42;
-
 # encoding flags carried on `isa.Inst.flags`. they steer prefix and width
 # selection in the encoder independently of the opcode.
 pub def EncFlag: u16;
@@ -292,99 +265,6 @@ pub val FLAG_LOCK:     EncFlag = 4;
 pub val FLAG_REP:      EncFlag = 8;
 # the memory operand is an indirect access through the named register.
 pub val FLAG_INDIRECT: EncFlag = 16;
-# force a bare REX prefix (needed for SPL/BPL/SIL/DIL byte operands).
-pub val FLAG_REX_BYTE: EncFlag = 32;
-
-# per-process register-file backing for the x86-64 ISA. the register descriptor
-# arrays are allocated once and referenced by the register files; they live for
-# the lifetime of the process.
-# ---
-# alloc:   backing allocator
-# gp:      general-purpose register descriptors
-# fp:      SSE register descriptors
-# gp_file: register file over `gp`
-# fp_file: register file over `fp`
-pub rec X86Context {
-    alloc:   *Allocator;
-    gp:      *isa.Register;
-    fp:      *isa.Register;
-    gp_file: isa.RegisterFile;
-    fp_file: isa.RegisterFile;
-}
-
-# init_context: build the x86-64 register files.
-#
-# allocates the 16 GP and 16 SSE register descriptors, sizes them (8 bytes for
-# GP, 16 for SSE), and wires up the two register files. returns nil on any
-# allocation failure so the caller can surface a clean target-selection error.
-# ---
-# alloc: backing allocator
-# ret:   a fully constructed X86Context, or nil on allocation failure
-pub fun init_context(alloc: *Allocator) *X86Context {
-    val res_ctx: Result[*X86Context, str] = allocate[X86Context](alloc, 1);
-    if (is_err[*X86Context, str](res_ctx)) { ret nil; }
-    val xctx: *X86Context = unwrap_ok[*X86Context, str](res_ctx);
-    xctx.alloc = alloc;
-
-    val res_gp: Result[*isa.Register, str] = allocate[isa.Register](alloc, GP_COUNT::usize);
-    if (is_err[*isa.Register, str](res_gp)) { ret nil; }
-    xctx.gp = unwrap_ok[*isa.Register, str](res_gp);
-    var i: i32 = 0;
-    for (i < GP_COUNT) {
-        xctx.gp[i].id   = i;
-        xctx.gp[i].size = 8;
-        i = i + 1;
-    }
-
-    val res_fp: Result[*isa.Register, str] = allocate[isa.Register](alloc, FP_COUNT::usize);
-    if (is_err[*isa.Register, str](res_fp)) { ret nil; }
-    xctx.fp = unwrap_ok[*isa.Register, str](res_fp);
-    i = 0;
-    for (i < FP_COUNT) {
-        xctx.fp[i].id   = i;
-        xctx.fp[i].size = 16;
-        i = i + 1;
-    }
-
-    xctx.gp_file.regs  = xctx.gp;
-    xctx.gp_file.count = GP_COUNT;
-    xctx.fp_file.regs  = xctx.fp;
-    xctx.fp_file.count = FP_COUNT;
-
-    ret xctx;
-}
-
-# gp_registers: the general-purpose register file.
-# ---
-# ctx: an X86Context cast to ptr (nil yields an empty-pointer file with the
-#      correct count)
-# ret: the GP register file
-pub fun gp_registers(ctx: ptr) isa.RegisterFile {
-    if (ctx != nil) {
-        val xctx: *X86Context = ctx::*X86Context;
-        ret xctx.gp_file;
-    }
-    var rf: isa.RegisterFile;
-    rf.regs  = nil;
-    rf.count = GP_COUNT;
-    ret rf;
-}
-
-# fp_registers: the SSE register file.
-# ---
-# ctx: an X86Context cast to ptr (nil yields an empty-pointer file with the
-#      correct count)
-# ret: the SSE register file
-pub fun fp_registers(ctx: ptr) isa.RegisterFile {
-    if (ctx != nil) {
-        val xctx: *X86Context = ctx::*X86Context;
-        ret xctx.fp_file;
-    }
-    var rf: isa.RegisterFile;
-    rf.regs  = nil;
-    rf.count = FP_COUNT;
-    ret rf;
-}
 
 # is_fp_opcode: report whether an opcode operates on the SSE register file.
 #
@@ -553,207 +433,4 @@ pub fun callee_saved_gp_list(abi_vt: *abi.AbiVTable, out: *i32) i32 {
         i = i + 1;
     }
     ret n;
-}
-
-# count_callee_saved: number of callee-saved GP registers the `mask` selects from
-# the active ABI's saveable set (`callee_saved_gp_list`). used to size the
-# callee-save home area in the prologue. driven by the ABI, never a hard-coded set.
-# ---
-# abi_vt: the active calling-convention vtable
-# mask:   bitmask of physical registers (bit N = register N)
-# ret:    count of callee-saved registers present in the mask
-fun count_callee_saved(abi_vt: *abi.AbiVTable, mask: u32) i32 {
-    var list: [16]i32;
-    val ln: i32 = callee_saved_gp_list(abi_vt, ?list[0]);
-    var n: i32 = 0;
-    var i: i32 = 0;
-    for (i < ln) {
-        if ((mask & (1::u32 << list[i]::u32)) != 0) { n = n + 1; }
-        i = i + 1;
-    }
-    ret n;
-}
-
-# emit a `mov [base+disp], reg` storing a callee-saved register into its frame
-# home slot.
-# ---
-# buf:  instruction buffer to append into
-# reg:  source register id
-# base: base register id for the memory operand
-# disp: frame-pointer-relative displacement
-fun emit_frame_store(buf: *isa.InstBuf, reg: i32, base: i32, disp: i32) {
-    var mi: isa.Inst;
-    zero_inst(?mi);
-    mi.opcode = MOV;
-    mi.dst    = isa.make_mem(base, disp, -1, 0, 8);
-    mi.src1   = isa.make_reg(reg, 8);
-    mi.size   = 8;
-    mi.flags  = FLAG_REX_W;
-    isa.buf_append(buf, mi);
-}
-
-# emit a `mov reg, [base+disp]` reloading a callee-saved register from its frame
-# home slot.
-# ---
-# buf:  instruction buffer to append into
-# reg:  destination register id
-# base: base register id for the memory operand
-# disp: frame-pointer-relative displacement
-fun emit_frame_load(buf: *isa.InstBuf, reg: i32, base: i32, disp: i32) {
-    var mi: isa.Inst;
-    zero_inst(?mi);
-    mi.opcode = MOV;
-    mi.dst    = isa.make_reg(reg, 8);
-    mi.src1   = isa.make_mem(base, disp, -1, 0, 8);
-    mi.size   = 8;
-    mi.flags  = FLAG_REX_W;
-    isa.buf_append(buf, mi);
-}
-
-# emit_prologue: emit the standard x86-64 function prologue.
-#
-# pushes RBP, establishes the frame pointer (`mov rbp, rsp`), reserves the
-# frame and callee-saved spill space rounded up to 16-byte alignment, then
-# stores each preserved callee-saved register (the ABI's saveable GP set —
-# `callee_saved_gp_list`) into a frame-pointer-relative home slot below the locals.
-# ---
-# ctx:         ISA backend context (unused; accepted for call-site uniformity)
-# abi_vt:      active calling-convention vtable; supplies the callee-saved set
-# buf:         instruction buffer to append the prologue into
-# frame_size:  size of the local frame in bytes
-# callee_mask: bitmask of callee-saved registers to preserve
-pub fun emit_prologue(ctx: ptr, abi_vt: *abi.AbiVTable, buf: *isa.InstBuf, frame_size: usize, callee_mask: u32) {
-    var push_rbp: isa.Inst;
-    zero_inst(?push_rbp);
-    push_rbp.opcode = PUSH;
-    push_rbp.dst    = isa.make_reg(FRAME_REG, 8);
-    push_rbp.flags  = FLAG_REX_W;
-    isa.buf_append(buf, push_rbp);
-
-    var mov_rbp: isa.Inst;
-    zero_inst(?mov_rbp);
-    mov_rbp.opcode = MOV;
-    mov_rbp.dst    = isa.make_reg(FRAME_REG, 8);
-    mov_rbp.src1   = isa.make_reg(STACK_REG, 8);
-    mov_rbp.size   = 8;
-    mov_rbp.flags  = FLAG_REX_W;
-    isa.buf_append(buf, mov_rbp);
-
-    val callee_space: usize = count_callee_saved(abi_vt, callee_mask)::usize * 8;
-    var total: usize = frame_size + callee_space;
-    if (total > 0 && (total & 15) != 0) { total = (total + 15) & ~15::usize; }
-    if (total > 0) {
-        var sub_rsp: isa.Inst;
-        zero_inst(?sub_rsp);
-        sub_rsp.opcode = SUB;
-        sub_rsp.dst    = isa.make_reg(STACK_REG, 8);
-        sub_rsp.src1   = isa.make_imm(total::i64, 8);
-        sub_rsp.size   = 8;
-        sub_rsp.flags  = FLAG_REX_W;
-        isa.buf_append(buf, sub_rsp);
-    }
-
-    var list: [16]i32;
-    val ln: i32 = callee_saved_gp_list(abi_vt, ?list[0]);
-    var coff: i32 = frame_size::i32 + 8;
-    var i: i32 = 0;
-    for (i < ln) {
-        if ((callee_mask & (1::u32 << list[i]::u32)) != 0) {
-            emit_frame_store(buf, list[i], FRAME_REG, -coff);
-            coff = coff + 8;
-        }
-        i = i + 1;
-    }
-}
-
-# emit_epilogue: emit the standard x86-64 function epilogue.
-#
-# reloads each preserved callee-saved register from its frame home slot, then
-# tears down the frame (`mov rsp, rbp` ; `pop rbp`). the caller appends the
-# `ret` after this sequence.
-# ---
-# ctx:         ISA backend context (unused; accepted for call-site uniformity)
-# abi_vt:      active calling-convention vtable; supplies the callee-saved set
-# buf:         instruction buffer to append the epilogue into
-# frame_size:  size of the local frame in bytes (matching the prologue)
-# callee_mask: bitmask of callee-saved registers that were preserved
-pub fun emit_epilogue(ctx: ptr, abi_vt: *abi.AbiVTable, buf: *isa.InstBuf, frame_size: usize, callee_mask: u32) {
-    var list: [16]i32;
-    val ln: i32 = callee_saved_gp_list(abi_vt, ?list[0]);
-    var coff: i32 = frame_size::i32 + 8;
-    var i: i32 = 0;
-    for (i < ln) {
-        if ((callee_mask & (1::u32 << list[i]::u32)) != 0) {
-            emit_frame_load(buf, list[i], FRAME_REG, -coff);
-            coff = coff + 8;
-        }
-        i = i + 1;
-    }
-
-    var mov_rsp: isa.Inst;
-    zero_inst(?mov_rsp);
-    mov_rsp.opcode = MOV;
-    mov_rsp.dst    = isa.make_reg(STACK_REG, 8);
-    mov_rsp.src1   = isa.make_reg(FRAME_REG, 8);
-    mov_rsp.size   = 8;
-    mov_rsp.flags  = FLAG_REX_W;
-    isa.buf_append(buf, mov_rsp);
-
-    var pop_rbp: isa.Inst;
-    zero_inst(?pop_rbp);
-    pop_rbp.opcode = POP;
-    pop_rbp.dst    = isa.make_reg(FRAME_REG, 8);
-    pop_rbp.flags  = FLAG_REX_W;
-    isa.buf_append(buf, pop_rbp);
-}
-
-# is_ret: report whether an instruction is a return.
-# ---
-# ctx: ISA backend context (unused; accepted for call-site uniformity)
-# mi:  instruction to classify
-# ret: true if the instruction is a RET
-pub fun is_ret(ctx: ptr, mi: *isa.Inst) bool {
-    ret mi.opcode == RET;
-}
-
-# is_call: report whether an instruction is a call.
-# ---
-# ctx: ISA backend context (unused; accepted for call-site uniformity)
-# mi:  instruction to classify
-# ret: true if the instruction is a CALL
-pub fun is_call(ctx: ptr, mi: *isa.Inst) bool {
-    ret mi.opcode == CALL;
-}
-
-# clear an instruction to a known-empty state before its fields are filled. all
-# operand kinds default to OPK_NONE (0) with no register and the base/index
-# fields set to -1 (no register).
-# ---
-# inst: instruction to zero in place
-fun zero_inst(inst: *isa.Inst) {
-    inst.opcode   = 0;
-    inst.size     = 0;
-    inst.flags    = 0;
-    inst.clobbers = 0;
-    inst.src_line = 0;
-    inst.src_file = nil;
-    zero_operand(?inst.dst);
-    zero_operand(?inst.src1);
-    zero_operand(?inst.src2);
-}
-
-# clear an operand to OPK_NONE with no register references.
-# ---
-# op: operand to zero in place
-fun zero_operand(op: *isa.Operand) {
-    op.kind   = isa.OPK_NONE;
-    op.size   = 0;
-    op.reg    = 0;
-    op.imm    = 0;
-    op.base   = -1;
-    op.index  = -1;
-    op.scale  = 0;
-    op.disp   = 0;
-    op.sym_id = 0;
-    op.label  = nil;
 }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -986,21 +986,33 @@ fun encode_xchg(mi: *isa.Inst, buf: *ByteBuf) i32 {
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG) {
         if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        emit_rex_if_needed(buf, size_to_w(size, flags), src1.reg, dst.reg);
+        if (size == 1 && (needs_rex_for_byte_reg(src1.reg) || needs_rex_for_byte_reg(dst.reg))) {
+            emit_byte(buf, encode_rex(0, src1.reg, dst.reg));
+        } or {
+            emit_rex_if_needed(buf, size_to_w(size, flags), src1.reg, dst.reg);
+        }
         emit_byte(buf, opc);
         emit_byte(buf, encode_modrm(3, reg_bits(src1.reg), reg_bits(dst.reg)));
         ret (buf.len - start)::i32;
     }
     if (dst.kind == isa.OPK_MEM && src1.kind == isa.OPK_REG) {
         if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        emit_rex_mem(buf, size_to_w(size, flags), src1.reg, dst);
+        if (size == 1 && needs_rex_for_byte_reg(src1.reg)) {
+            emit_rex_byte_mem(buf, src1.reg, dst);
+        } or {
+            emit_rex_mem(buf, size_to_w(size, flags), src1.reg, dst);
+        }
         emit_byte(buf, opc);
         encode_mem_operand(buf, src1.reg, dst);
         ret (buf.len - start)::i32;
     }
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_MEM) {
         if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        emit_rex_mem(buf, size_to_w(size, flags), dst.reg, src1);
+        if (size == 1 && needs_rex_for_byte_reg(dst.reg)) {
+            emit_rex_byte_mem(buf, dst.reg, src1);
+        } or {
+            emit_rex_mem(buf, size_to_w(size, flags), dst.reg, src1);
+        }
         emit_byte(buf, opc);
         encode_mem_operand(buf, dst.reg, src1);
         ret (buf.len - start)::i32;
@@ -1028,14 +1040,22 @@ fun encode_xadd_cmpxchg(mi: *isa.Inst, buf: *ByteBuf) i32 {
     if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
 
     if (dst.kind == isa.OPK_REG) {
-        emit_rex_if_needed(buf, size_to_w(size, flags), src1.reg, dst.reg);
+        if (size == 1 && (needs_rex_for_byte_reg(src1.reg) || needs_rex_for_byte_reg(dst.reg))) {
+            emit_byte(buf, encode_rex(0, src1.reg, dst.reg));
+        } or {
+            emit_rex_if_needed(buf, size_to_w(size, flags), src1.reg, dst.reg);
+        }
         emit_byte(buf, 0x0F);
         emit_byte(buf, opc2);
         emit_byte(buf, encode_modrm(3, reg_bits(src1.reg), reg_bits(dst.reg)));
         ret (buf.len - start)::i32;
     }
     if (dst.kind == isa.OPK_MEM) {
-        emit_rex_mem(buf, size_to_w(size, flags), src1.reg, dst);
+        if (size == 1 && needs_rex_for_byte_reg(src1.reg)) {
+            emit_rex_byte_mem(buf, src1.reg, dst);
+        } or {
+            emit_rex_mem(buf, size_to_w(size, flags), src1.reg, dst);
+        }
         emit_byte(buf, 0x0F);
         emit_byte(buf, opc2);
         encode_mem_operand(buf, src1.reg, dst);

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -388,28 +388,58 @@ fun emit_rex_mem(buf: *ByteBuf, w: u8, reg: i32, mem: *isa.Operand) {
     }
 }
 
+# emit_prefix_reg: emit the operand-size (0x66) and REX prefixes for an instruction
+# whose r/m operand is a register — the single place the byte-register REX rule lives
+# for register-register and /digit forms. a size-1 operand naming SPL/BPL/SIL/DIL
+# (regs 4-7) forces a bare REX so it is not encoded as AH/CH/DH/BH; a 16-bit operand
+# takes the 0x66 prefix. `reg` is the ModR/M reg-field register (an opcode-extension
+# digit for /digit forms, where the fixed digit 0 never trips the byte rule), `rm`
+# the r/m-field register. centralizing this is what makes the byte-reg REX gap (the
+# XCHG/XADD class) structurally unable to recur per-opcode.
+fun emit_prefix_reg(buf: *ByteBuf, size: u8, flags: u16, reg: i32, rm: i32) {
+    if (size == 2 || (flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
+    if (size == 1 && (needs_rex_for_byte_reg(reg) || needs_rex_for_byte_reg(rm))) {
+        emit_byte(buf, encode_rex(0, reg, rm));
+    } or {
+        emit_rex_if_needed(buf, size_to_w(size, flags), reg, rm);
+    }
+}
+
+# emit_prefix_mem: emit the operand-size (0x66) and REX prefixes for an instruction
+# whose r/m operand is a memory reference, threading the SIB index into REX.X — the
+# memory counterpart of emit_prefix_reg under the same single byte-register REX rule
+# (a size-1 reg-field register in 4-7 forces a bare REX). `reg` is the ModR/M
+# reg-field register (an opcode-extension digit for /digit forms).
+fun emit_prefix_mem(buf: *ByteBuf, size: u8, flags: u16, reg: i32, mem: *isa.Operand) {
+    if (size == 2 || (flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
+    if (size == 1 && needs_rex_for_byte_reg(reg)) {
+        emit_rex_byte_mem(buf, reg, mem);
+    } or {
+        emit_rex_mem(buf, size_to_w(size, flags), reg, mem);
+    }
+}
+
+# emit_imm_sized: emit a trailing immediate at the operand width — imm8 for size 1,
+# imm16 for size 2, imm32 otherwise (a 64-bit operand still takes a sign-extended
+# imm32). the single place the trailing-immediate width is decided, so no per-opcode
+# encoder can desync the immediate from the operand-size prefix (the bug class behind
+# the pre-1.0 encode_alu_imm fault, #1198, and the encode_imul imm16 fault).
+fun emit_imm_sized(buf: *ByteBuf, imm: i64, size: u8) {
+    if (size == 1) { emit_byte(buf, imm::u8); }
+    or (size == 2) { emit_u16(buf, imm::u16); }
+    or { emit_u32(buf, imm::u32); }
+}
+
 # encode_alu_rr: encode a two-register ALU op (opcode reg,reg).
 fun encode_alu_rr(buf: *ByteBuf, opcode: u8, dst: i32, src: i32, size: u8, flags: u16) {
-    val w: u8 = size_to_w(size, flags);
-    if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-    if (size == 1 && (needs_rex_for_byte_reg(dst) || needs_rex_for_byte_reg(src))) {
-        emit_byte(buf, encode_rex(0, src, dst));
-    } or {
-        emit_rex_if_needed(buf, w, src, dst);
-    }
+    emit_prefix_reg(buf, size, flags, src, dst);
     emit_byte(buf, opcode);
     emit_byte(buf, encode_modrm(3, reg_bits(src), reg_bits(dst)));
 }
 
 # encode_alu_rm: encode an ALU op with a memory operand.
 fun encode_alu_rm(buf: *ByteBuf, opcode: u8, reg: i32, mem: *isa.Operand, size: u8, flags: u16) {
-    val w: u8 = size_to_w(size, flags);
-    if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-    if (size == 1 && needs_rex_for_byte_reg(reg)) {
-        emit_rex_byte_mem(buf, reg, mem);
-    } or {
-        emit_rex_mem(buf, w, reg, mem);
-    }
+    emit_prefix_mem(buf, size, flags, reg, mem);
     emit_byte(buf, opcode);
     encode_mem_operand(buf, reg, mem);
 }
@@ -439,30 +469,20 @@ fun encode_alu_imm(buf: *ByteBuf, opcode: u16, reg: i32, imm: i64, size: u8, fla
     }
 
     val group: u8 = alu_group(opcode);
-    val w: u8 = size_to_w(size, flags);
-    if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-    if (size == 1 && needs_rex_for_byte_reg(reg)) {
-        emit_byte(buf, encode_rex(0, 0, reg));
-    } or {
-        emit_rex_if_needed(buf, w, 0, reg);
-    }
+    emit_prefix_reg(buf, size, flags, 0, reg);
 
+    # the imm8 short form (0x83) sign-extends to the operand width for size > 1; the
+    # full form (0x80 byte / 0x81 wider) takes an operand-width immediate.
     if (imm >= -128 && imm <= 127 && size > 1) {
         emit_byte(buf, 0x83);
         emit_byte(buf, encode_modrm(3, group, reg_bits(reg)));
         emit_byte(buf, imm::u8);
-    } or (size == 1) {
-        emit_byte(buf, 0x80);
-        emit_byte(buf, encode_modrm(3, group, reg_bits(reg)));
-        emit_byte(buf, imm::u8);
-    } or (size == 2) {
-        emit_byte(buf, 0x81);
-        emit_byte(buf, encode_modrm(3, group, reg_bits(reg)));
-        emit_u16(buf, imm::u16);
     } or {
-        emit_byte(buf, 0x81);
+        var opc: u8 = 0x81;
+        if (size == 1) { opc = 0x80; }
+        emit_byte(buf, opc);
         emit_byte(buf, encode_modrm(3, group, reg_bits(reg)));
-        emit_u32(buf, imm::u32);
+        emit_imm_sized(buf, imm, size);
     }
 }
 
@@ -605,13 +625,7 @@ fun encode_mov(mi: *isa.Inst, buf: *ByteBuf) i32 {
     }
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG) {
-        val w: u8 = size_to_w(size, flags);
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && (needs_rex_for_byte_reg(dst.reg) || needs_rex_for_byte_reg(src1.reg))) {
-            emit_byte(buf, encode_rex(0, src1.reg, dst.reg));
-        } or {
-            emit_rex_if_needed(buf, w, src1.reg, dst.reg);
-        }
+        emit_prefix_reg(buf, size, flags, src1.reg, dst.reg);
         if (size == 1) {
             emit_byte(buf, 0x88);
         } or {
@@ -624,7 +638,11 @@ fun encode_mov(mi: *isa.Inst, buf: *ByteBuf) i32 {
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_IMM) {
         val w: u8 = size_to_w(size, flags);
         val imm: i64 = src1.imm;
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
+        # the immediate-to-register forms (B0+rb / B8+rd) carry the operand-width
+        # immediate in the opcode itself, so the 0x66 must track the operand size, not
+        # just the flag — a size-2 MOV without FLAG_16BIT would otherwise emit B8+imm16
+        # with no prefix and desync the stream.
+        if (size == 2 || (flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
         if (size == 1) {
             if (needs_rex_byte(dst.reg)) {
                 emit_byte(buf, encode_rex(0, 0, dst.reg));
@@ -655,13 +673,7 @@ fun encode_mov(mi: *isa.Inst, buf: *ByteBuf) i32 {
     }
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_MEM) {
-        val w: u8 = size_to_w(size, flags);
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && needs_rex_for_byte_reg(dst.reg)) {
-            emit_rex_byte_mem(buf, dst.reg, src1);
-        } or {
-            emit_rex_mem(buf, w, dst.reg, src1);
-        }
+        emit_prefix_mem(buf, size, flags, dst.reg, src1);
         if (size == 1) {
             emit_byte(buf, 0x8A);
         } or {
@@ -672,13 +684,7 @@ fun encode_mov(mi: *isa.Inst, buf: *ByteBuf) i32 {
     }
 
     if (dst.kind == isa.OPK_MEM && src1.kind == isa.OPK_REG) {
-        val w: u8 = size_to_w(size, flags);
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && needs_rex_for_byte_reg(src1.reg)) {
-            emit_rex_byte_mem(buf, src1.reg, dst);
-        } or {
-            emit_rex_mem(buf, w, src1.reg, dst);
-        }
+        emit_prefix_mem(buf, size, flags, src1.reg, dst);
         if (size == 1) {
             emit_byte(buf, 0x88);
         } or {
@@ -748,22 +754,14 @@ fun encode_mov(mi: *isa.Inst, buf: *ByteBuf) i32 {
             val st_sz: i32 = encode_mov(?st, buf);
             ret ld_sz + st_sz;
         }
-        val w: u8 = size_to_w(size, flags);
-        if (size == 2 || (flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        emit_rex_mem(buf, w, 0, dst);
+        emit_prefix_mem(buf, size, flags, 0, dst);
         if (size == 1) {
             emit_byte(buf, 0xC6);
         } or {
             emit_byte(buf, 0xC7);
         }
         encode_mem_operand(buf, 0, dst);
-        if (size == 1) {
-            emit_byte(buf, src1.imm::u8);
-        } or (size == 2) {
-            emit_u16(buf, src1.imm::u16);
-        } or {
-            emit_u32(buf, src1.imm::u32);
-        }
+        emit_imm_sized(buf, src1.imm, size);
         ret (buf.len - start)::i32;
     }
 
@@ -935,19 +933,13 @@ fun encode_unary_grp3(mi: *isa.Inst, buf: *ByteBuf) i32 {
     if (size == 1) { opc = 0xF6; }
 
     if (dst.kind == isa.OPK_REG) {
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && needs_rex_for_byte_reg(dst.reg)) {
-            emit_byte(buf, encode_rex(0, 0, dst.reg));
-        } or {
-            emit_rex_if_needed(buf, size_to_w(size, flags), 0, dst.reg);
-        }
+        emit_prefix_reg(buf, size, flags, 0, dst.reg);
         emit_byte(buf, opc);
         emit_byte(buf, encode_modrm(3, modrm_ext, reg_bits(dst.reg)));
         ret (buf.len - start)::i32;
     }
     if (dst.kind == isa.OPK_MEM) {
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        emit_rex_mem(buf, size_to_w(size, flags), modrm_ext::i32, dst);
+        emit_prefix_mem(buf, size, flags, 0, dst);
         emit_byte(buf, opc);
         encode_mem_operand(buf, modrm_ext::i32, dst);
         ret (buf.len - start)::i32;
@@ -969,19 +961,13 @@ fun encode_unary_grp5(mi: *isa.Inst, buf: *ByteBuf) i32 {
     if (size == 1) { opc = 0xFE; }
 
     if (dst.kind == isa.OPK_REG) {
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && needs_rex_for_byte_reg(dst.reg)) {
-            emit_byte(buf, encode_rex(0, 0, dst.reg));
-        } or {
-            emit_rex_if_needed(buf, size_to_w(size, flags), 0, dst.reg);
-        }
+        emit_prefix_reg(buf, size, flags, 0, dst.reg);
         emit_byte(buf, opc);
         emit_byte(buf, encode_modrm(3, modrm_ext, reg_bits(dst.reg)));
         ret (buf.len - start)::i32;
     }
     if (dst.kind == isa.OPK_MEM) {
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        emit_rex_mem(buf, size_to_w(size, flags), modrm_ext::i32, dst);
+        emit_prefix_mem(buf, size, flags, 0, dst);
         emit_byte(buf, opc);
         encode_mem_operand(buf, modrm_ext::i32, dst);
         ret (buf.len - start)::i32;
@@ -1003,34 +989,19 @@ fun encode_xchg(mi: *isa.Inst, buf: *ByteBuf) i32 {
     if (size == 1) { opc = 0x86; }
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG) {
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && (needs_rex_for_byte_reg(src1.reg) || needs_rex_for_byte_reg(dst.reg))) {
-            emit_byte(buf, encode_rex(0, src1.reg, dst.reg));
-        } or {
-            emit_rex_if_needed(buf, size_to_w(size, flags), src1.reg, dst.reg);
-        }
+        emit_prefix_reg(buf, size, flags, src1.reg, dst.reg);
         emit_byte(buf, opc);
         emit_byte(buf, encode_modrm(3, reg_bits(src1.reg), reg_bits(dst.reg)));
         ret (buf.len - start)::i32;
     }
     if (dst.kind == isa.OPK_MEM && src1.kind == isa.OPK_REG) {
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && needs_rex_for_byte_reg(src1.reg)) {
-            emit_rex_byte_mem(buf, src1.reg, dst);
-        } or {
-            emit_rex_mem(buf, size_to_w(size, flags), src1.reg, dst);
-        }
+        emit_prefix_mem(buf, size, flags, src1.reg, dst);
         emit_byte(buf, opc);
         encode_mem_operand(buf, src1.reg, dst);
         ret (buf.len - start)::i32;
     }
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_MEM) {
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && needs_rex_for_byte_reg(dst.reg)) {
-            emit_rex_byte_mem(buf, dst.reg, src1);
-        } or {
-            emit_rex_mem(buf, size_to_w(size, flags), dst.reg, src1);
-        }
+        emit_prefix_mem(buf, size, flags, dst.reg, src1);
         emit_byte(buf, opc);
         encode_mem_operand(buf, dst.reg, src1);
         ret (buf.len - start)::i32;
@@ -1055,25 +1026,16 @@ fun encode_xadd_cmpxchg(mi: *isa.Inst, buf: *ByteBuf) i32 {
     if (size == 1) { opc2 = opc2 - 1; }
 
     maybe_emit_lock(buf, flags);
-    if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
 
     if (dst.kind == isa.OPK_REG) {
-        if (size == 1 && (needs_rex_for_byte_reg(src1.reg) || needs_rex_for_byte_reg(dst.reg))) {
-            emit_byte(buf, encode_rex(0, src1.reg, dst.reg));
-        } or {
-            emit_rex_if_needed(buf, size_to_w(size, flags), src1.reg, dst.reg);
-        }
+        emit_prefix_reg(buf, size, flags, src1.reg, dst.reg);
         emit_byte(buf, 0x0F);
         emit_byte(buf, opc2);
         emit_byte(buf, encode_modrm(3, reg_bits(src1.reg), reg_bits(dst.reg)));
         ret (buf.len - start)::i32;
     }
     if (dst.kind == isa.OPK_MEM) {
-        if (size == 1 && needs_rex_for_byte_reg(src1.reg)) {
-            emit_rex_byte_mem(buf, src1.reg, dst);
-        } or {
-            emit_rex_mem(buf, size_to_w(size, flags), src1.reg, dst);
-        }
+        emit_prefix_mem(buf, size, flags, src1.reg, dst);
         emit_byte(buf, 0x0F);
         emit_byte(buf, opc2);
         encode_mem_operand(buf, src1.reg, dst);
@@ -1091,13 +1053,7 @@ fun encode_test(mi: *isa.Inst, buf: *ByteBuf) i32 {
     val flags: u16 = mi.flags;
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG) {
-        val w: u8 = size_to_w(size, flags);
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && (needs_rex_for_byte_reg(dst.reg) || needs_rex_for_byte_reg(src1.reg))) {
-            emit_byte(buf, encode_rex(0, src1.reg, dst.reg));
-        } or {
-            emit_rex_if_needed(buf, w, src1.reg, dst.reg);
-        }
+        emit_prefix_reg(buf, size, flags, src1.reg, dst.reg);
         if (size == 1) {
             emit_byte(buf, 0x84);
         } or {
@@ -1108,57 +1064,27 @@ fun encode_test(mi: *isa.Inst, buf: *ByteBuf) i32 {
     }
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_IMM) {
-        val w: u8 = size_to_w(size, flags);
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && needs_rex_for_byte_reg(dst.reg)) {
-            emit_byte(buf, encode_rex(0, 0, dst.reg));
-        } or {
-            emit_rex_if_needed(buf, w, 0, dst.reg);
-        }
-        if (size == 1) {
-            emit_byte(buf, 0xF6);
-            emit_byte(buf, encode_modrm(3, 0, reg_bits(dst.reg)));
-            emit_byte(buf, src1.imm::u8);
-        } or (size == 2) {
-            emit_byte(buf, 0xF7);
-            emit_byte(buf, encode_modrm(3, 0, reg_bits(dst.reg)));
-            emit_u16(buf, src1.imm::u16);
-        } or {
-            emit_byte(buf, 0xF7);
-            emit_byte(buf, encode_modrm(3, 0, reg_bits(dst.reg)));
-            emit_u32(buf, src1.imm::u32);
-        }
+        emit_prefix_reg(buf, size, flags, 0, dst.reg);
+        var opc: u8 = 0xF7;
+        if (size == 1) { opc = 0xF6; }
+        emit_byte(buf, opc);
+        emit_byte(buf, encode_modrm(3, 0, reg_bits(dst.reg)));
+        emit_imm_sized(buf, src1.imm, size);
         ret (buf.len - start)::i32;
     }
 
     if (dst.kind == isa.OPK_MEM && src1.kind == isa.OPK_IMM) {
-        val w: u8 = size_to_w(size, flags);
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        emit_rex_mem(buf, w, 0, dst);
-        if (size == 1) {
-            emit_byte(buf, 0xF6);
-            encode_mem_operand(buf, 0, dst);
-            emit_byte(buf, src1.imm::u8);
-        } or (size == 2) {
-            emit_byte(buf, 0xF7);
-            encode_mem_operand(buf, 0, dst);
-            emit_u16(buf, src1.imm::u16);
-        } or {
-            emit_byte(buf, 0xF7);
-            encode_mem_operand(buf, 0, dst);
-            emit_u32(buf, src1.imm::u32);
-        }
+        emit_prefix_mem(buf, size, flags, 0, dst);
+        var opc: u8 = 0xF7;
+        if (size == 1) { opc = 0xF6; }
+        emit_byte(buf, opc);
+        encode_mem_operand(buf, 0, dst);
+        emit_imm_sized(buf, src1.imm, size);
         ret (buf.len - start)::i32;
     }
 
     if (dst.kind == isa.OPK_MEM && src1.kind == isa.OPK_REG) {
-        val w: u8 = size_to_w(size, flags);
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && needs_rex_for_byte_reg(src1.reg)) {
-            emit_rex_byte_mem(buf, src1.reg, dst);
-        } or {
-            emit_rex_mem(buf, w, src1.reg, dst);
-        }
+        emit_prefix_mem(buf, size, flags, src1.reg, dst);
         if (size == 1) {
             emit_byte(buf, 0x84);
         } or {
@@ -1178,11 +1104,9 @@ fun encode_imul(mi: *isa.Inst, buf: *ByteBuf) i32 {
     val src1: *isa.Operand = ?mi.src1;
     val size: u8 = mi.size;
     val flags: u16 = mi.flags;
-    val w: u8 = size_to_w(size, flags);
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG) {
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        emit_rex_if_needed(buf, w, dst.reg, src1.reg);
+        emit_prefix_reg(buf, size, flags, dst.reg, src1.reg);
         emit_byte(buf, 0x0F);
         emit_byte(buf, 0xAF);
         emit_byte(buf, encode_modrm(3, reg_bits(dst.reg), reg_bits(src1.reg)));
@@ -1190,8 +1114,7 @@ fun encode_imul(mi: *isa.Inst, buf: *ByteBuf) i32 {
     }
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_MEM) {
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        emit_rex_mem(buf, w, dst.reg, src1);
+        emit_prefix_mem(buf, size, flags, dst.reg, src1);
         emit_byte(buf, 0x0F);
         emit_byte(buf, 0xAF);
         encode_mem_operand(buf, dst.reg, src1);
@@ -1231,23 +1154,17 @@ fun encode_imul(mi: *isa.Inst, buf: *ByteBuf) i32 {
             encode_imul(?rr, buf);
             ret (buf.len - start)::i32;
         }
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        emit_rex_if_needed(buf, w, dst.reg, dst.reg);
+        emit_prefix_reg(buf, size, flags, dst.reg, dst.reg);
         if (imm >= -128 && imm <= 127) {
             emit_byte(buf, 0x6B);
             emit_byte(buf, encode_modrm(3, reg_bits(dst.reg), reg_bits(dst.reg)));
             emit_byte(buf, imm::u8);
-        } or (size == 2) {
-            # under the 0x66 prefix opcode 0x69 takes an imm16; emitting imm32 would
-            # desync the instruction stream (the recurring imm-width class shared with
-            # encode_alu_imm / encode_test, which size the trailing immediate the same way).
-            emit_byte(buf, 0x69);
-            emit_byte(buf, encode_modrm(3, reg_bits(dst.reg), reg_bits(dst.reg)));
-            emit_u16(buf, imm::u16);
         } or {
+            # the 0x69 form takes an operand-width immediate -- imm16 under the 0x66
+            # prefix (size 2), imm32 otherwise; emit_imm_sized keeps it from desyncing.
             emit_byte(buf, 0x69);
             emit_byte(buf, encode_modrm(3, reg_bits(dst.reg), reg_bits(dst.reg)));
-            emit_u32(buf, imm::u32);
+            emit_imm_sized(buf, imm, size);
         }
         ret (buf.len - start)::i32;
     }
@@ -1261,17 +1178,11 @@ fun encode_div(mi: *isa.Inst, buf: *ByteBuf, is_signed: bool) i32 {
     val src: *isa.Operand = ?mi.src1;
     val size: u8 = mi.size;
     val flags: u16 = mi.flags;
-    val w: u8 = size_to_w(size, flags);
     var modrm_ext: u8 = 6;
     if (is_signed) { modrm_ext = 7; }
 
     if (src.kind == isa.OPK_REG) {
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        if (size == 1 && needs_rex_for_byte_reg(src.reg)) {
-            emit_byte(buf, encode_rex(0, 0, src.reg));
-        } or {
-            emit_rex_if_needed(buf, w, 0, src.reg);
-        }
+        emit_prefix_reg(buf, size, flags, 0, src.reg);
         if (size == 1) {
             emit_byte(buf, 0xF6);
         } or {
@@ -1282,8 +1193,7 @@ fun encode_div(mi: *isa.Inst, buf: *ByteBuf, is_signed: bool) i32 {
     }
 
     if (src.kind == isa.OPK_MEM) {
-        if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-        emit_rex_mem(buf, w, modrm_ext::i32, src);
+        emit_prefix_mem(buf, size, flags, 0, src);
         if (size == 1) {
             emit_byte(buf, 0xF6);
         } or {
@@ -1303,20 +1213,13 @@ fun encode_shift(mi: *isa.Inst, buf: *ByteBuf) i32 {
     val src1: *isa.Operand = ?mi.src1;
     val size: u8 = mi.size;
     val flags: u16 = mi.flags;
-    val w: u8 = size_to_w(size, flags);
     val opcode: u16 = mi.opcode;
     var modrm_ext: u8 = 4;
     if (opcode == x64.SHR) { modrm_ext = 5; }
     if (opcode == x64.SAR) { modrm_ext = 7; }
 
-    if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
-
     if (src1.kind == isa.OPK_REG) {
-        if (size == 1 && needs_rex_for_byte_reg(dst.reg)) {
-            emit_byte(buf, encode_rex(0, 0, dst.reg));
-        } or {
-            emit_rex_if_needed(buf, w, 0, dst.reg);
-        }
+        emit_prefix_reg(buf, size, flags, 0, dst.reg);
         if (size == 1) {
             emit_byte(buf, 0xD2);
         } or {
@@ -1325,11 +1228,7 @@ fun encode_shift(mi: *isa.Inst, buf: *ByteBuf) i32 {
         emit_byte(buf, encode_modrm(3, modrm_ext, reg_bits(dst.reg)));
     } or (src1.kind == isa.OPK_IMM) {
         val imm: i64 = src1.imm;
-        if (size == 1 && needs_rex_for_byte_reg(dst.reg)) {
-            emit_byte(buf, encode_rex(0, 0, dst.reg));
-        } or {
-            emit_rex_if_needed(buf, w, 0, dst.reg);
-        }
+        emit_prefix_reg(buf, size, flags, 0, dst.reg);
         if (imm == 1) {
             if (size == 1) {
                 emit_byte(buf, 0xD0);
@@ -1431,9 +1330,10 @@ fun encode_setcc(mi: *isa.Inst, buf: *ByteBuf) i32 {
     val cc: u8 = cc_to_x86(mi.opcode);
 
     if (dst.kind == isa.OPK_REG) {
-        if (needs_rex(dst.reg) || dst.reg == 4 || dst.reg == 5 || dst.reg == 6 || dst.reg == 7) {
-            emit_byte(buf, encode_rex(0, 0, dst.reg));
-        }
+        # SETcc writes a byte: route through the byte-operand prefix (size 1, no
+        # operand-size prefix) so SPL/BPL/SIL/DIL force a bare REX in the one place
+        # that rule lives, rather than the open-coded `dst.reg == 4 || ...` it used.
+        emit_prefix_reg(buf, 1, 0, 0, dst.reg);
         emit_byte(buf, 0x0F);
         emit_byte(buf, 0x90 + cc);
         emit_byte(buf, encode_modrm(3, 0, reg_bits(dst.reg)));
@@ -4984,6 +4884,25 @@ test "x64.encode: imul r16, imm16 emits a 16-bit immediate (not imm32)" {
     mi8.src1   = isa.make_imm(5, 1);
     mi8.size   = 1;
     if (encode_imul(?mi8, ?buf) != 0) { bad = 1; }
+
+    buf_dnit(?buf);
+    ret bad;
+}
+
+test "x64.encode: byte ALU on SIL/DIL forces a bare REX (shared prefix core)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var buf: ByteBuf = buf_init(?alloc);
+
+    # and sil, dil -> 40 20 FE: the byte-register rule (a single place now) must emit
+    # a bare REX so SIL/DIL are not misencoded as DH/BH.
+    encode_alu_rr(?buf, alu_opcode_rr(x64.AND, 1), x64.RSI, x64.RDI, 1, 0);
+
+    var bad: i32 = 0;
+    if (buf.len != 3) { bad = 1; }
+    or (buf.data[0] != 0x40) { bad = 1; }
+    or (buf.data[1] != 0x20) { bad = 1; }
+    or (buf.data[2] != 0xFE) { bad = 1; }
 
     buf_dnit(?buf);
     ret bad;

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2105,7 +2105,7 @@ fun count_callee_saved(abi_vt: *abi.AbiVTable, mask: u32) i32 {
 # the outgoing region as the bottommost slice puts its base exactly at the new
 # RSP, so a caller's `[rsp + off]` argument store lands in it, and keeping every
 # addend 16-aligned holds RSP 16-byte aligned at each call boundary.
-fun frame_total(abi_vt: *abi.AbiVTable, frame_size: u32, callee_mask: u32, outgoing_size: u32) usize {
+pub fun frame_total(abi_vt: *abi.AbiVTable, frame_size: u32, callee_mask: u32, outgoing_size: u32) usize {
     val callee_space: usize = count_callee_saved(abi_vt, callee_mask)::usize * 8;
     var base: usize = frame_size::usize + callee_space;
     if (base > 0 && (base & 15) != 0) { base = (base + 15) & ~15::usize; }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -285,7 +285,14 @@ fun encode_mem_operand(buf: *ByteBuf, reg: i32, op: *isa.Operand) {
         if (op.scale <= 1) { scale_bits = 0; }
         or (op.scale == 2) { scale_bits = 1; }
         or (op.scale == 4) { scale_bits = 2; }
-        or { scale_bits = 3; }
+        or (op.scale == 8) { scale_bits = 3; }
+        or {
+            # the x86 SIB scale field encodes 1/2/4/8 only; lowering produces only
+            # those and parse_asm_mem rejects any other inline-asm scale, so a
+            # non-power-of-two scale here is a backend bug -- rejected loudly rather
+            # than silently encoded as *8.
+            panic("encode: invalid SIB scale (must be 1, 2, 4, or 8)\n");
+        }
     }
 
     if (base == -1 && has_index) {
@@ -570,11 +577,15 @@ fun encode_fp_mov(mi: *isa.Inst, buf: *ByteBuf) i32 {
     }
 
     # a same-bank float move: load the source into the float scratch and store it to
-    # the destination, so every register / frame-slot / immediate shape encodes.
+    # the destination, so every register / frame-slot / immediate shape encodes. a
+    # load/store error means an operand reached here in a bank the move cannot model
+    # (a regalloc / lowering bug); surface its specific message loudly rather than
+    # returning zero bytes the driver would report as the generic "produced no bytes",
+    # matching encode_mem_operand's handling of the same class of backend bug.
     val ld: Result[bool, str] = emit_float_load(@src1, FLOAT_SCRATCH0, w, buf);
-    if (is_err[bool, str](ld)) { ret 0; }
+    if (is_err[bool, str](ld)) { panic(unwrap_err[bool, str](ld)::*u8); }
     val st: Result[bool, str] = emit_float_store(@dst, FLOAT_SCRATCH0, w, buf);
-    if (is_err[bool, str](st)) { ret 0; }
+    if (is_err[bool, str](st)) { panic(unwrap_err[bool, str](st)::*u8); }
     ret (buf.len - start)::i32;
 }
 
@@ -2480,7 +2491,11 @@ pub fun encode_x64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Re
         fi = fi + 1;
     }
 
-    patch_branches(?st);
+    val pb: Result[bool, str] = patch_branches(?st);
+    if (is_err[bool, str](pb)) {
+        free_state(?st);
+        ret err[enc.EncoderOutput, str](unwrap_err[bool, str](pb));
+    }
 
     # right-size the text buffer so its allocation length equals `text_len`: the
     # object builder owns these bytes and frees them by `len`, so the backing
@@ -2760,15 +2775,27 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     }
 
     if (has_block) {
+        # a block-referencing branch must have a rel32 patch site; a missing one means
+        # a branch shape reached the encoder without a relocation field (a backend
+        # bug), rejected loudly rather than guessed at `inst_size - 4` -- the symbol
+        # path below rejects the identical condition.
         val reloc_off: i32 = x86_reloc_offset(nil, ?inst, inst_size);
-        var patch_off: i32 = reloc_off;
-        if (patch_off < 0) { patch_off = inst_size - 4; }
-        val patch_pos: u32 = (inst_start + patch_off::usize)::u32;
+        if (reloc_off < 0) {
+            ret err[bool, str]("encode: block-referencing instruction has no relocation patch site");
+        }
+        val patch_pos: u32 = (inst_start + reloc_off::usize)::u32;
         val next_ip: u32 = (inst_start + inst_size::usize)::u32;
         ret push_fixup(st, patch_pos, next_ip, target_block, fn_base);
     }
 
-    if (has_sym && sym != intern.STR_NIL) {
+    if (has_sym) {
+        # has_sym means classify_refs found a MIR_OP_SYM operand, so it must carry a
+        # resolved interned name; a nil name means a symbol operand reached the encoder
+        # unresolved (a backend bug), rejected loudly rather than emitted as
+        # unrelocated bytes the linker would leave pointing at the wrong address.
+        if (sym == intern.STR_NIL) {
+            ret err[bool, str]("encode: symbol-referencing instruction has no resolved symbol name");
+        }
         # the instruction names a relocatable symbol, so it must have a patch site;
         # a missing one means an instruction shape reached the encoder without a
         # reloc field (a backend bug), rejected loudly rather than emitted as
@@ -4488,7 +4515,11 @@ fun parse_asm_mem(tok: str, len: usize, op: *AsmOperand) bool {
         if (!copy_trimmed(tok, star + 1, bi_hi, ?buf[0], 32)) { ret false; }
         val scr: Result[i64, str] = parse.parse_i64_exact((?buf[0])::str, 0);
         if (is_err[i64, str](scr)) { ret false; }
-        op.scale = unwrap_ok[i64, str](scr)::u8;
+        val scale_val: i64 = unwrap_ok[i64, str](scr);
+        # the x86 SIB scale field encodes 1/2/4/8 only; reject any other scale here so
+        # it surfaces as an inline-asm parse failure rather than silently encoding *8.
+        if (scale_val != 1 && scale_val != 2 && scale_val != 4 && scale_val != 8) { ret false; }
+        op.scale = scale_val::u8;
     } or {
         # `[ base ]` or `[ symbol ]` (no index term).
         if (!copy_trimmed(tok, inner_lo, bi_hi, ?buf[0], 32)) { ret false; }
@@ -4990,33 +5021,43 @@ fun classify_refs(mi: *mir.MirInstr, target_block: *u32, has_block: *bool,
 
 # pass 2: patch each recorded intra-module branch fixup with the rel32
 # displacement from the end of the branch to the start of its target block.
-fun patch_branches(st: *EncodeState) {
-    if (st.buf.data == nil) { ret; }
+fun patch_branches(st: *EncodeState) Result[bool, str] {
+    if (st.buf.data == nil) { ret ok[bool, str](true); }
     var i: u32 = 0;
     for (i < st.fixup_count) {
         val fx: *BranchFixup = ?st.fixups[i];
-        val target_off: u32 = block_offset(st, fx.fn_text_base, fx.target_block);
+        val tr: Result[u32, str] = block_offset(st, fx.fn_text_base, fx.target_block);
+        if (is_err[u32, str](tr)) { ret err[bool, str](unwrap_err[u32, str](tr)); }
+        val target_off: u32 = unwrap_ok[u32, str](tr);
         val disp: i32 = target_off::i32 - fx.next_ip::i32;
-        if (fx.patch_pos::usize + 4 <= st.buf.len) {
-            st.buf.data[fx.patch_pos]     = (disp & 0xFF)::u8;
-            st.buf.data[fx.patch_pos + 1] = ((disp >> 8) & 0xFF)::u8;
-            st.buf.data[fx.patch_pos + 2] = ((disp >> 16) & 0xFF)::u8;
-            st.buf.data[fx.patch_pos + 3] = ((disp >> 24) & 0xFF)::u8;
+        # the fixup site was recorded when its branch was emitted, so it must lie
+        # within the text buffer; an out-of-range site is a backend bug, rejected
+        # loudly rather than skipped (which would leave a zero rel32 branching into
+        # the first function).
+        if (fx.patch_pos::usize + 4 > st.buf.len) {
+            ret err[bool, str]("encode: branch fixup site is outside the text buffer");
         }
+        st.buf.data[fx.patch_pos]     = (disp & 0xFF)::u8;
+        st.buf.data[fx.patch_pos + 1] = ((disp >> 8) & 0xFF)::u8;
+        st.buf.data[fx.patch_pos + 2] = ((disp >> 16) & 0xFF)::u8;
+        st.buf.data[fx.patch_pos + 3] = ((disp >> 24) & 0xFF)::u8;
         i = i + 1;
     }
+    ret ok[bool, str](true);
 }
 
-# resolve a function-local block id to its `.text` offset (0 if unrecorded).
-fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) u32 {
+# resolve a function-local block id to its `.text` offset. an unrecorded target is
+# a backend bug (a branch to a block the encoder never emitted), rejected loudly
+# rather than resolved to offset 0 (a branch into the first function's middle).
+fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) Result[u32, str] {
     var i: u32 = 0;
     for (i < st.block_count) {
         if (st.blocks[i].fn_text_base == fn_base && st.blocks[i].block_id == block_id) {
-            ret st.blocks[i].offset;
+            ret ok[u32, str](st.blocks[i].offset);
         }
         i = i + 1;
     }
-    ret 0;
+    ret err[u32, str]("encode: branch target block was never recorded");
 }
 
 # build an inactive (OPK_NONE) operand with no register references.

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -49,6 +49,7 @@ use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.reallocate;
 use std.allocator.deallocate;
+use page: std.allocator.page;
 
 use std.system.panic.panic;
 use os: std.system.os;
@@ -797,9 +798,15 @@ fun encode_push(mi: *isa.Inst, buf: *ByteBuf) i32 {
         if (imm >= -128 && imm <= 127) {
             emit_byte(buf, 0x6A);
             emit_byte(buf, imm::u8);
-        } or {
+        } or (imm >= -2147483648 && imm <= 2147483647) {
             emit_byte(buf, 0x68);
             emit_u32(buf, imm::u32);
+        } or {
+            # PUSH imm has no 64-bit form and 0x68 sign-extends its imm32, so a value
+            # outside signed-imm32 range cannot be encoded without silently corrupting
+            # it. reject loudly (no bytes) rather than truncate -- materialize it into a
+            # register and push that instead.
+            ret 0;
         }
     }
     ret (buf.len - start)::i32;
@@ -1182,6 +1189,11 @@ fun encode_imul(mi: *isa.Inst, buf: *ByteBuf) i32 {
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_IMM) {
         val imm: i64 = src1.imm;
+        # IMUL's immediate forms (6B imm8, 69 imm16/imm32) exist only for 16/32/64-bit
+        # operands -- there is no `imul r/m8, imm8`. lowering clamps integer ALU widths
+        # to >= 4, so size 1 never reaches here; reject it loudly (no bytes) rather than
+        # emit a malformed encoding.
+        if (size < 2) { ret 0; }
         # the imm forms here -- `imul r64, r/m64, imm8` (6B) and `imul r64, r/m64,
         # imm32` (69) -- carry at most a 32-bit field that the CPU sign-extends to
         # the operand width; x86-64 has no `imul r64, imm64`. a 64-bit immediate
@@ -1214,6 +1226,13 @@ fun encode_imul(mi: *isa.Inst, buf: *ByteBuf) i32 {
             emit_byte(buf, 0x6B);
             emit_byte(buf, encode_modrm(3, reg_bits(dst.reg), reg_bits(dst.reg)));
             emit_byte(buf, imm::u8);
+        } or (size == 2) {
+            # under the 0x66 prefix opcode 0x69 takes an imm16; emitting imm32 would
+            # desync the instruction stream (the recurring imm-width class shared with
+            # encode_alu_imm / encode_test, which size the trailing immediate the same way).
+            emit_byte(buf, 0x69);
+            emit_byte(buf, encode_modrm(3, reg_bits(dst.reg), reg_bits(dst.reg)));
+            emit_u16(buf, imm::u16);
         } or {
             emit_byte(buf, 0x69);
             emit_byte(buf, encode_modrm(3, reg_bits(dst.reg), reg_bits(dst.reg)));
@@ -4901,6 +4920,42 @@ test "x64.encode: inline-asm stack-slot used as memory base gets actionable diag
     if (!str_contains(msg, "load it into a register first")) { ret 1; }
     if (str_contains(msg, "malformed inline-asm two-operand instruction")) { ret 1; }
     ret 0;
+}
+
+test "x64.encode: imul r16, imm16 emits a 16-bit immediate (not imm32)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var buf: ByteBuf = buf_init(?alloc);
+
+    # imul ax, ax, 0x1234 -> 66 69 C0 34 12 (the 0x66 prefix makes 0x69 take an imm16).
+    var mi: isa.Inst;
+    zero_inst(?mi);
+    mi.opcode = x64.IMUL;
+    mi.dst    = isa.make_reg(x64.RAX, 2);
+    mi.src1   = isa.make_imm(0x1234, 2);
+    mi.size   = 2;
+    mi.flags  = x64.FLAG_16BIT;
+    val n: i32 = encode_imul(?mi, ?buf);
+
+    var bad: i32 = 0;
+    if (n != 5) { bad = 1; }
+    or (buf.data[0] != 0x66) { bad = 1; }
+    or (buf.data[1] != 0x69) { bad = 1; }
+    or (buf.data[2] != 0xC0) { bad = 1; }
+    or (buf.data[3] != 0x34) { bad = 1; }
+    or (buf.data[4] != 0x12) { bad = 1; }
+
+    # a size-1 immediate IMUL has no encoding -- it must emit nothing (loud failure).
+    var mi8: isa.Inst;
+    zero_inst(?mi8);
+    mi8.opcode = x64.IMUL;
+    mi8.dst    = isa.make_reg(x64.RAX, 1);
+    mi8.src1   = isa.make_imm(5, 1);
+    mi8.size   = 1;
+    if (encode_imul(?mi8, ?buf) != 0) { bad = 1; }
+
+    buf_dnit(?buf);
+    ret bad;
 }
 
 # determine whether an instruction names an intra-module branch target (a

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -3101,27 +3101,6 @@ fun is_mir_float_conv(op: mir.MirOpcode) bool {
         op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP;
 }
 
-# emit_gp_load: load a GP integer operand into the GP scratch register `gp` at byte
-# width `w`. the operand resolves after register allocation to a physical register
-# (a plain MOV), a frame slot (a `MOV reg, [rbp + off]` reload), or an immediate (a
-# `MOV reg, imm`). a float-bank operand would mean the allocator placed an integer
-# value in the wrong bank — rejected loudly. mirrors `emit_float_load` for the GP
-# side of a conversion.
-fun emit_gp_load(op: isa.Operand, gp: i32, w: u8, buf: *ByteBuf) Result[bool, str] {
-    if (op.kind == isa.OPK_REG || op.kind == isa.OPK_MEM || op.kind == isa.OPK_IMM) {
-        var ld: isa.Inst;
-        zero_inst(?ld);
-        ld.opcode = x64.MOV;
-        ld.dst    = isa.make_reg(gp, w);
-        ld.src1   = op;
-        ld.size   = w;
-        ld.flags  = width_flags(w);
-        encode_inst(?ld, buf);
-        ret ok[bool, str](true);
-    }
-    ret err[bool, str]("encode: conversion integer operand is not a register, frame slot, or immediate");
-}
-
 # emit_gp_store: store the GP scratch register `gp` to a conversion's integer
 # destination at byte width `w` — a physical register (a plain MOV) or a frame slot
 # (a `MOV [rbp + off], reg` spill). a float-bank destination is a backend bug,
@@ -3155,6 +3134,159 @@ fun emit_cvt_reg(cvt_op: u16, dst_reg: i32, src_reg: i32, int_w: u8, buf: *ByteB
     encode_inst(?cvt, buf);
 }
 
+# patch_rel32: overwrite the 4-byte little-endian rel32 placeholder at `pos` with
+# `disp`. fills an intra-instruction forward jump once its target offset is known —
+# the self-contained sequences that branch within a single MIR instruction.
+fun patch_rel32(buf: *ByteBuf, pos: usize, disp: i32) {
+    buf.data[pos]     = (disp & 0xFF)::u8;
+    buf.data[pos + 1] = ((disp >> 8) & 0xFF)::u8;
+    buf.data[pos + 2] = ((disp >> 16) & 0xFF)::u8;
+    buf.data[pos + 3] = ((disp >> 24) & 0xFF)::u8;
+}
+
+# emit_gp_rr8: emit a 64-bit register-register GP op (`opcode dst_reg, src_reg`).
+fun emit_gp_rr8(opcode: u16, dst_reg: i32, src_reg: i32, buf: *ByteBuf) {
+    var mi: isa.Inst;
+    zero_inst(?mi);
+    mi.opcode = opcode;
+    mi.dst    = isa.make_reg(dst_reg, 8);
+    mi.src1   = isa.make_reg(src_reg, 8);
+    mi.size   = 8;
+    mi.flags  = width_flags(8);
+    encode_inst(?mi, buf);
+}
+
+# emit_gp_ri8: emit a 64-bit register-immediate GP op (`opcode dst_reg, imm`).
+fun emit_gp_ri8(opcode: u16, dst_reg: i32, imm: i64, buf: *ByteBuf) {
+    var mi: isa.Inst;
+    zero_inst(?mi);
+    mi.opcode = opcode;
+    mi.dst    = isa.make_reg(dst_reg, 8);
+    mi.src1   = isa.make_imm(imm, 8);
+    mi.size   = 8;
+    mi.flags  = width_flags(8);
+    encode_inst(?mi, buf);
+}
+
+# emit_fp_rr: emit a register-register SSE op (`opcode dst_reg, src_reg`) at float
+# width `w` (4 -> single, 8 -> double).
+fun emit_fp_rr(opcode: u16, dst_reg: i32, src_reg: i32, w: u8, buf: *ByteBuf) {
+    var mi: isa.Inst;
+    zero_inst(?mi);
+    mi.opcode = opcode;
+    mi.dst    = isa.make_reg(dst_reg, 16);
+    mi.src1   = isa.make_reg(src_reg, 16);
+    mi.size   = w;
+    encode_inst(?mi, buf);
+}
+
+# normalize_int_imm: reduce an integer constant to the value its `width`-byte source
+# represents, zero- or sign-extended (by `signed`) to 64 bits, so a constant
+# conversion source converts the same value a runtime register of that width would.
+fun normalize_int_imm(imm: i64, width: u8, signed: bool) i64 {
+    if (width >= 8) { ret imm; }
+    val bits: u64 = width::u64 * 8;
+    val mask: u64 = (1::u64 << bits) - 1;
+    var v: u64 = imm::u64 & mask;
+    if (signed) {
+        val sign: u64 = 1::u64 << (bits - 1);
+        if ((v & sign) != 0) { v = v | ~mask; }
+    }
+    ret v::i64;
+}
+
+# emit_gp_load_ext: load an integer conversion source into the full 64-bit GP scratch
+# `gp`, extending a sub-64-bit value by signedness so the CVTSI2SS/SD that follows
+# reads a clean register rather than stale upper bits. a u32 source rides a 4-byte MOV
+# (which already zero-extends into the 64-bit register); a u8/u16 source uses MOVZX
+# (unsigned) / MOVSX (signed); a 32-bit signed source uses MOVSXD; a 64-bit source
+# loads as-is; an immediate is re-normalized to its source width and materialized.
+# accepts the same operand shapes regalloc can produce (register, frame slot,
+# immediate); a float-bank operand is a regalloc bug, rejected loudly.
+fun emit_gp_load_ext(op: isa.Operand, gp: i32, src_w: u8, signed: bool, buf: *ByteBuf) Result[bool, str] {
+    if (op.kind == isa.OPK_IMM) {
+        emit_gp_ri8(x64.MOV, gp, normalize_int_imm(op.imm, src_w, signed), buf);
+        ret ok[bool, str](true);
+    }
+    if (op.kind != isa.OPK_REG && op.kind != isa.OPK_MEM) {
+        ret err[bool, str]("encode: conversion integer operand is not a register, frame slot, or immediate");
+    }
+
+    var ld: isa.Inst;
+    zero_inst(?ld);
+    ld.dst       = isa.make_reg(gp, 8);
+    ld.src1      = op;
+    ld.src1.size = src_w;
+    ld.size      = 8;
+    ld.flags     = width_flags(8);
+    if (src_w >= 8) {
+        ld.opcode = x64.MOV;
+    } or (signed && src_w >= 4) {
+        ld.opcode = x64.MOVSXD;
+    } or (signed) {
+        ld.opcode = x64.MOVSX;
+    } or {
+        # MOVZX with a >= 4-byte source emits a plain 32-bit MOV whose write clears the
+        # upper 32 bits; a sub-word source emits the true MOVZX.
+        ld.opcode = x64.MOVZX;
+    }
+    encode_inst(?ld, buf);
+    ret ok[bool, str](true);
+}
+
+# emit_u64_to_fp: convert the unsigned 64-bit value in SCRATCH_REG to the float in
+# FLOAT_SCRATCH0 and store it to `dst`. the signed CVTSI2SS/SD treats bit 63 as a
+# sign, so a value >= 2^63 would convert negative; branch on the sign (`test`; with OF
+# cleared, JL is "jump if sign") — a value < 2^63 converts exactly, a value >= 2^63 is
+# halved with a low-bit-preserving round-to-odd, converted, then doubled. SCRATCH_REG2
+# is the halving temp. the two forward rel32 jumps are intra-instruction, patched here
+# from the measured branch lengths.
+fun emit_u64_to_fp(dst: isa.Operand, dst_w: u8, cvt_op: u16, buf: *ByteBuf) Result[bool, str] {
+    var test_inst: isa.Inst;
+    zero_inst(?test_inst);
+    test_inst.opcode = x64.TEST;
+    test_inst.dst    = isa.make_reg(x64.SCRATCH_REG, 8);
+    test_inst.src1   = isa.make_reg(x64.SCRATCH_REG, 8);
+    test_inst.size   = 8;
+    test_inst.flags  = width_flags(8);
+    encode_inst(?test_inst, buf);
+
+    var jl: isa.Inst;
+    zero_inst(?jl);
+    jl.opcode = x64.JL;
+    jl.dst    = isa.make_label(nil);
+    jl.size   = DEFAULT_OPERAND_SIZE;
+    encode_inst(?jl, buf);
+    val jl_patch: usize = buf.len - 4;
+    val after_jl: usize = buf.len;
+
+    # value < 2^63: the signed conversion is exact.
+    emit_cvt_reg(cvt_op, FLOAT_SCRATCH0, x64.SCRATCH_REG, 8, buf);
+
+    var jmp: isa.Inst;
+    zero_inst(?jmp);
+    jmp.opcode = x64.JMP;
+    jmp.dst    = isa.make_label(nil);
+    jmp.size   = DEFAULT_OPERAND_SIZE;
+    encode_inst(?jmp, buf);
+    val jmp_patch: usize = buf.len - 4;
+    val after_jmp: usize = buf.len;
+
+    # value >= 2^63: r11 = (r11 >> 1) | (r11 & 1); convert; double.
+    patch_rel32(buf, jl_patch, (buf.len - after_jl)::i32);
+    emit_gp_rr8(x64.MOV, x64.SCRATCH_REG2, x64.SCRATCH_REG, buf);
+    emit_gp_ri8(x64.SHR, x64.SCRATCH_REG2, 1, buf);
+    emit_gp_ri8(x64.AND, x64.SCRATCH_REG, 1, buf);
+    emit_gp_rr8(x64.OR, x64.SCRATCH_REG, x64.SCRATCH_REG2, buf);
+    emit_cvt_reg(cvt_op, FLOAT_SCRATCH0, x64.SCRATCH_REG, 8, buf);
+    var add_op: u16 = x64.ADDSD;
+    if (dst_w == 4) { add_op = x64.ADDSS; }
+    emit_fp_rr(add_op, FLOAT_SCRATCH0, FLOAT_SCRATCH0, dst_w, buf);
+
+    patch_rel32(buf, jmp_patch, (buf.len - after_jmp)::i32);
+    ret emit_float_store(dst, FLOAT_SCRATCH0, dst_w, buf);
+}
+
 # encode_float_conv: materialize a fully-resolved float conversion into its SSE byte
 # sequence, routing operands through the fixed scratch registers (XMM FLOAT_SCRATCH0
 # for the float side, the GP SCRATCH_REG for the integer side) exactly as
@@ -3162,8 +3294,14 @@ fun emit_cvt_reg(cvt_op: u16, dst_reg: i32, src_reg: i32, int_w: u8, buf: *ByteB
 # register, a spilled `[rbp + off]` frame slot, or an immediate) encodes without the
 # reg-reg-only `encode_cvt` path. the carried widths (`mi.width` = result type,
 # `mi.src_width` = operand-0 type, both from `set_conv_widths`) select the
-# single-precision SS vs double SD form on the float side and size the GP integer
-# side for REX.W. operand layout is `[dst, src]`.
+# single-precision SS vs double SD form on the float side; the integer side is always
+# extended to a clean 64-bit value and converted with the REX.W CVT. operand layout is
+# `[dst, src]`.
+#
+# SI_TO_FP / UI_TO_FP extend the integer source to 64 bits by signedness (so a u32 is
+# not converted as a signed i32 and a sub-word source carries no stale upper bits); an
+# unsigned 64-bit value >= 2^63 takes a range-fixup path (`emit_u64_to_fp`) since the
+# signed CVTSI2SS/SD has no direct unsigned-64 form.
 #
 # FP_TO_SI / FP_TO_UI map to the signed CVTTSS2SI / CVTTSD2SI: a full unsigned
 # 64-bit conversion needs a range-fixup sequence x86-64 lacks a single instruction
@@ -3194,8 +3332,11 @@ fun encode_float_conv(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Res
         ret emit_float_store(dst, FLOAT_SCRATCH0, dst_w, buf);
     }
 
-    # SI_TO_FP / UI_TO_FP (int -> float): dst is float (dst_w picks SS / SD), src is
-    # an integer (src_w sizes the GP load + REX.W of the CVTSI2SS/SD).
+    # SI_TO_FP / UI_TO_FP (int -> float): dst is float (dst_w picks SS / SD), src is an
+    # integer. the source is extended to a clean 64-bit value by signedness (so a u32
+    # is not converted as a signed i32 and a u8/u16 is not read off stale upper bits),
+    # then the REX.W signed CVTSI2SS/SD converts it. an unsigned 64-bit source whose
+    # top bit is set has no signed CVT form, so it takes the range-fixup path.
     if (op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP) {
         val rd: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], 16);
         if (is_err[isa.Operand, str](rd)) { ret err[bool, str](unwrap_err[isa.Operand, str](rd)); }
@@ -3204,11 +3345,15 @@ fun encode_float_conv(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Res
         if (is_err[isa.Operand, str](rs)) { ret err[bool, str](unwrap_err[isa.Operand, str](rs)); }
         val src: isa.Operand = unwrap_ok[isa.Operand, str](rs);
 
-        val ld: Result[bool, str] = emit_gp_load(src, x64.SCRATCH_REG, src_w, buf);
+        val signed: bool = op == mir.MIR_SI_TO_FP;
+        val ld: Result[bool, str] = emit_gp_load_ext(src, x64.SCRATCH_REG, src_w, signed, buf);
         if (is_err[bool, str](ld)) { ret ld; }
         var cvt_op: u16 = x64.CVTSI2SD;
         if (dst_w == 4) { cvt_op = x64.CVTSI2SS; }
-        emit_cvt_reg(cvt_op, FLOAT_SCRATCH0, x64.SCRATCH_REG, src_w, buf);
+        if (!signed && src_w >= 8) {
+            ret emit_u64_to_fp(dst, dst_w, cvt_op, buf);
+        }
+        emit_cvt_reg(cvt_op, FLOAT_SCRATCH0, x64.SCRATCH_REG, 8, buf);
         ret emit_float_store(dst, FLOAT_SCRATCH0, dst_w, buf);
     }
 

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -41,7 +41,8 @@ use fmt:    std.format;
 
 use intern:  mach.lang.intern;
 use isa:     mach.lang.target.isa;
-use x64:     mach.lang.target.isa.x64;
+use x64:       mach.lang.target.isa.x64;
+use x64encode: mach.lang.target.isa.x64.encode;
 use target:  mach.lang.target.resolved;
 use abi:     mach.lang.target.abi;
 use mir:     mach.lang.be.codegen.mir;
@@ -127,9 +128,9 @@ fun print_function(abi_vt: *abi.AbiVTable, out: *writer.Writer, m: *mir.MirModul
 }
 
 # print_prologue: render the standard x86-64 prologue as comment-flagged lines so
-# the frame shape is visible without re-deriving it. mirrors `x64.emit_prologue`:
-# the frame-pointer setup, the rounded stack reservation, and each preserved
-# callee-saved register's home store.
+# the frame shape is visible without re-deriving it. mirrors the encoder's live
+# `encode.emit_prologue`: the frame-pointer setup, the rounded stack reservation,
+# and each preserved callee-saved register's home store.
 fun print_prologue(abi_vt: *abi.AbiVTable, out: *writer.Writer, f: *mir.MirFunction) Result[bool, str] {
     val r1: Result[bool, str] = ws(out, "  push  rbp                  # prologue\n");
     if (is_err[bool, str](r1)) { ret r1; }
@@ -149,35 +150,20 @@ fun print_prologue(abi_vt: *abi.AbiVTable, out: *writer.Writer, f: *mir.MirFunct
 }
 
 # print_epilogue: render the standard x86-64 epilogue as a comment-flagged line.
-# mirrors `x64.emit_epilogue` (callee-saved restores then frame teardown), rendered
-# compactly as `leave` since this artifact need not be byte-exact.
+# mirrors the encoder's live `encode.emit_epilogue` (callee-saved restores then
+# frame teardown), rendered compactly as `leave` since this artifact need not be
+# byte-exact.
 fun print_epilogue(out: *writer.Writer, f: *mir.MirFunction) Result[bool, str] {
     ret ws(out, "  leave                       # epilogue\n");
 }
 
 # prologue_reserve: the rounded stack-reservation byte count the prologue subtracts
-# from RSP — the local frame plus the callee-saved home area, rounded up to the
-# 16-byte ABI alignment. mirrors the size `x64.emit_prologue` computes.
+# from RSP — the local frame, the callee-saved home area, and the outgoing-argument
+# region. shares the encoder's `encode.frame_total` so the debug `.s` reports the
+# exact reservation the encoder emits; the earlier local copy omitted the outgoing
+# region and under-reported it for any function with stack-passed call arguments.
 fun prologue_reserve(abi_vt: *abi.AbiVTable, f: *mir.MirFunction) usize {
-    val callee_space: usize = count_callee_saved(abi_vt, f.callee_mask)::usize * 8;
-    var total: usize = f.frame.size::usize + callee_space;
-    if (total > 0 && (total & 15) != 0) { total = (total + 15) & ~15::usize; }
-    ret total;
-}
-
-# count_callee_saved: number of callee-saved GP registers the `mask` selects from
-# the active ABI's saveable set (`x64.callee_saved_gp_list`). ABI-driven, so it
-# matches the encoder's win64 set (RDI/RSI), not just the SysV {RBX, R12–R15}.
-fun count_callee_saved(abi_vt: *abi.AbiVTable, mask: u32) i32 {
-    var list: [16]i32;
-    val ln: i32 = x64.callee_saved_gp_list(abi_vt, ?list[0]);
-    var n: i32 = 0;
-    var i: i32 = 0;
-    for (i < ln) {
-        if ((mask & (1::u32 << list[i]::u32)) != 0) { n = n + 1; }
-        i = i + 1;
-    }
-    ret n;
+    ret x64encode.frame_total(abi_vt, f.frame.size, f.callee_mask, f.frame.outgoing_size);
 }
 
 # function_is_naked: true when an asm-carrying function needs no frame (no locals,


### PR DESCRIPTION
Addresses the 2026-06 x64-encoder audit findings in #1255 (parent epic #1259), in two stages.

## Stage 1 — the bugs (minimal fixes against the current structure)

- **[BUG/M] int→float miscompile** — `encode_float_conv` converted a u32 through the 32-bit *signed* CVT (values ≥ 2³¹ went negative) and read sub-word sources off stale upper bits. Now sign/zero-extends the source to a clean 64-bit register (MOVSX/MOVZX/MOVSXD/zero-extending MOV) and converts with the REX.W CVT; u64 ≥ 2⁶³ takes a round-to-odd range-fixup path. New `.github/tests/fconv` suite checks u8/u16/u32/u64/i8/i16/i32 → f32/f64 across boundary values (0xFFFFFFFF, 0x80000000, 2⁶³, 2⁶⁴−1).
- **[BUG/S] byte-register REX gap** — `encode_xchg` / `encode_xadd_cmpxchg` lacked the SPL/BPL/SIL/DIL bare-REX special case; added.
- **[BUG/S] imm-width desync** — `encode_imul` reg,imm emitted imm32 under the 0x66 prefix (the 16-bit form would desync the stream); now sizes the immediate by operand width and rejects a size-1 immediate IMUL loudly. `encode_push` immediate is bound-checked.
- **[DESIGN/M] silent fallbacks → loud failures** — branch-patch/reloc paths (`block_offset`, `patch_branches`, the block patch-offset fallback, the nil-symbol drop), `encode_fp_mov`'s discarded error, and `encode_mem_operand`'s invalid-SIB-scale → ×8 mapping now fail loudly; `parse_asm_mem` rejects a non-1/2/4/8 inline-asm scale.
- **[CLEANUP/M] dead frame surface** — removed x64.mach's diverged second prologue/epilogue + register-file surface (~320 dead lines) and pointed `printer.mach`'s prologue mirror at the live `encode.frame_total` so the debug `.s` reports the real reservation (it had under-reported the outgoing-argument region).

## Stage 2 — the structural fix (DESIGN/L)

Extracted one shared core — `emit_prefix_reg` / `emit_prefix_mem` (the 0x66 + REX + byte-register rule in one place each) and `emit_imm_sized` (the trailing-immediate width in one place) — and routed the ALU / MOV / TEST / IMUL / DIV / SHIFT / SETcc / NEG-NOT / INC-DEC / XCHG / XADD-CMPXCHG encoders through them. The imm-width and byte-reg bug classes are now structurally unable to recur per-opcode; the three divergent byte-reg idioms (incl. SETcc's raw `dst.reg == 4 || …`) are gone. The mixed-width MOVZX/MOVSX keep their own prefix (the byte-reg check rides the source width). Encoding-preserving.

## Verification

`mach build .` clean · `mach test .` 237/237 (incl. two new direct encoder tests: IMUL imm16 + byte-ALU REX) · byte-identical self-host fixpoint (stage2 == stage3) · all `.github/tests` suites pass (dynlink, extlink, fconv, opt, win64byref, win64fnptr — wine-backed) · windows cross-compile + `wine mach.exe build .` smoke builds and runs a Windows project (exit 0).

Closes #1255