### PR TITLE
fix(frontend): parser/lexer audit — index-then-call, val/var grammar, literals, OOM masking (#1247)

### DIFF
--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -445,7 +445,10 @@ Disambiguating a postfix `[`:
   calling an element of a function-pointer table needs no parentheses.
 - The single residual ambiguity is a bare identifier payload (`callee[x](…)`):
   it is locally indistinguishable from one type argument and binds as a
-  generic call; name resolution owns that case.
+  generic call. If `x` names a value rather than a type, name resolution then
+  reports an error, so the variable-index-then-call form `table[i]()` still
+  needs `(table[i])()`; deferring this decision to resolve is tracked
+  separately.
 - The struct-literal `Name[T]{...}` form is recognized at the **prefix**
   stage (`typed-literal`) and never reaches postfix.
 

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -156,11 +156,11 @@ char escapes:   \n  \t  \r  \\  \'  \0  \xHH
 string escapes: (char escapes) + \"
 ```
 
-A string literal may span multiple lines: the lexer scans from the opening
-`"` to the next unescaped `"` or to EOF, and a newline in between is just
-another body byte (it does not terminate the literal). A char literal scans
-likewise to the next `'` or EOF. An unterminated `'` or `"` (the scan hits
-EOF first) is a lexer error but still produces a token span.
+A string literal is single-line (see [literals.md](literals.md)): the lexer
+scans from the opening `"` to the next unescaped `"`, stopping at an
+unescaped newline or EOF. A char literal scans likewise to the next `'`. An
+unterminated `'` or `"` (the scan hits a newline or EOF first) is a lexer
+error but still produces a token span covering the rest of that line.
 
 ### Comments and whitespace
 
@@ -274,13 +274,16 @@ typed-name ::= [ "$" ] IDENT ":" type
 ### `val` / `var` — bindings
 
 ```ebnf
-bind-decl ::= ( "val" | "var" ) IDENT [ ":" type ] [ "=" expr ] ";"
+val-decl  ::= "val" IDENT ":" type "=" expr ";"
+var-decl  ::= "var" IDENT ":" type [ "=" expr ] ";"
+bind-decl ::= val-decl | var-decl
 ```
 
-`val` is immutable, `var` mutable. Both the type annotation and the
-initializer are independently optional in the grammar (the parser accepts
-either, both, or neither); semantic checks enforce the real requirements.
-A `val`/`var` may also appear as a local statement (see [Statements](#statements)).
+`val` is immutable, `var` mutable. The type annotation is mandatory for both
+(Mach has no type inference — see [val-var.md](val-var.md)); the parser
+rejects a binding with no `: type`. A `val` requires an initializer; a `var`
+may omit it and is default-initialized. A `val`/`var` may also appear as a
+local statement (see [Statements](#statements)).
 
 ### `test`
 
@@ -433,10 +436,16 @@ cast         ::= ( "::" | ":~" ) type
 [operators.md](operators.md#cast). Both bind as postfix.
 
 Disambiguating a postfix `[`:
-- `callee[T, U](args)` — a generic call: the bracketed list is scanned; if
-  the token after the matching `]` is `(`, it is parsed as type arguments
-  followed by a call.
-- `obj[idx]` — an index expression otherwise.
+- `callee[T, U](args)` — a generic call: the bracketed list is committed as
+  type arguments only when its first token can begin a type (`*`, `[`, or an
+  identifier) **and** the token after the matching `]` is `(`.
+- `obj[idx]` — an index expression otherwise. In particular a bracket whose
+  payload starts with a token that cannot begin a type (a literal, `-`, `@`,
+  `$`, …) is always an index, so `table[0]()` parses as index-then-call —
+  calling an element of a function-pointer table needs no parentheses.
+- The single residual ambiguity is a bare identifier payload (`callee[x](…)`):
+  it is locally indistinguishable from one type argument and binds as a
+  generic call; name resolution owns that case.
 - The struct-literal `Name[T]{...}` form is recognized at the **prefix**
   stage (`typed-literal`) and never reaches postfix.
 

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1271,8 +1271,11 @@ fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool
         lexer.dnit(?stream, p.s.alloc);
         ret err[bool, str](unwrap_err[bool, str](le_r));
     }
-    parser.parse(?stream, ?m.a, ?p.s.diags);
+    val fatal: bool = parser.parse(?stream, ?m.a, ?p.s.diags);
     lexer.dnit(?stream, p.s.alloc);
+    # a fatal allocation failure leaves the AST incomplete; refuse to walk it
+    # (the parser already emitted the OOM diagnostic onto the sink).
+    if (fatal) { ret err[bool, str]("out of memory while parsing module"); }
     ret ok[bool, str](true);
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -38,6 +38,7 @@ use std.types.char.char;
 use std.types.size.usize;
 
 use std.types.string.StrView;
+use std.types.string.str_len;
 use std.types.string.view;
 use std.types.string.view_eq_str;
 
@@ -314,7 +315,13 @@ pub fun eval_lit_int(source: str, span: token.Span) Result[CTValue, str] {
         or      (text.data[1] == 'o') { base = 8;  i = 2; }
     }
 
-    var value:  i64 = 0;
+    # accumulate into u64 so the full unsigned range is representable, with a
+    # pre-multiply overflow check: a literal that would exceed 2^64-1 is rejected
+    # rather than silently wrapping modulo 2^64. the u64 bits are stored into the
+    # i64 payload via a same-size bit reinterpret (parse_lit_int reads them back).
+    val u64_max: u64 = 0xFFFFFFFFFFFFFFFF;
+    val base_u:  u64 = base:~u64;
+    var value:   u64 = 0;
     var saw_digit: bool = false;
     for (i < text.len) {
         val c: u8 = text.data[i];
@@ -330,7 +337,11 @@ pub fun eval_lit_int(source: str, span: token.Span) Result[CTValue, str] {
         # the value — note 'f' IS a hex digit, so the digit test must come first.
         # anything else is a malformed digit.
         if (digit >= 0 && digit < base) {
-            value = value * base + digit;
+            val d: u64 = digit:~u64;
+            if (value > (u64_max - d) / base_u) {
+                ret err[CTValue, str]("integer literal out of range");
+            }
+            value = value * base_u + d;
             saw_digit = true;
             i = i + 1;
         }
@@ -346,7 +357,7 @@ pub fun eval_lit_int(source: str, span: token.Span) Result[CTValue, str] {
 
     var v: CTValue;
     v.kind   = CT_KIND_INT;
-    v.data.i = value;
+    v.data.i = value:~i64;
     ret ok[CTValue, str](v);
 }
 
@@ -962,4 +973,33 @@ fun str_value(s: intern.StrId) Result[CTValue, str] {
     v.kind   = CT_KIND_STR;
     v.data.s = s;
     ret ok[CTValue, str](v);
+}
+
+# helper: builds a full-length span over a literal and evaluates it as an integer.
+fun t_eval_int(s: str) Result[CTValue, str] {
+    var span: token.Span;
+    span.offset = 0;
+    span.len    = str_len(s);
+    ret eval_lit_int(s, span);
+}
+
+test "comptime: an integer literal above u64 max is rejected, not silently wrapped (#1247)" {
+    # 2^64 is one past the representable range and must error instead of wrapping
+    val r: Result[CTValue, str] = t_eval_int("18446744073709551616");
+    if (!is_err[CTValue, str](r)) { ret 1; }
+    ret 0;
+}
+
+test "comptime: the u64-max literal is accepted with its bits preserved (#1247)" {
+    val r: Result[CTValue, str] = t_eval_int("18446744073709551615");
+    if (is_err[CTValue, str](r)) { ret 1; }
+    val v: CTValue = unwrap_ok[CTValue, str](r);
+    if (v.data.i:~u64 != 0xFFFFFFFFFFFFFFFF) { ret 1; }
+    ret 0;
+}
+
+test "comptime: a hex literal wider than 16 nibbles is rejected (#1247)" {
+    val r: Result[CTValue, str] = t_eval_int("0x1FFFFFFFFFFFFFFFF");
+    if (!is_err[CTValue, str](r)) { ret 1; }
+    ret 0;
 }

--- a/src/lang/fe/lexer.mach
+++ b/src/lang/fe/lexer.mach
@@ -212,8 +212,11 @@ pub fun tokenize(source: str, alloc: *Allocator, file_id: src.FileId) Result[Tok
         or (c == '"') {
             val start: usize = pos;
             pos = pos + 1;
-            for (source[pos] != 0 && source[pos] != '"') {
-                if (source[pos] == '\\' && source[pos + 1] != 0) {
+            # a string literal is single-line (literals.md): stop at an unescaped
+            # newline and report it unterminated rather than swallowing the rest
+            # of the file until the next quote.
+            for (source[pos] != 0 && source[pos] != '"' && source[pos] != '\n') {
+                if (source[pos] == '\\' && source[pos + 1] != 0 && source[pos + 1] != '\n') {
                     pos = pos + 2;
                     cnt;
                 }
@@ -233,8 +236,10 @@ pub fun tokenize(source: str, alloc: *Allocator, file_id: src.FileId) Result[Tok
         or (c == '\'') {
             val start: usize = pos;
             pos = pos + 1;
-            for (source[pos] != 0 && source[pos] != '\'') {
-                if (source[pos] == '\\' && source[pos + 1] != 0) {
+            # a char literal is single-line too; terminate the scan at an
+            # unescaped newline so a missing closing quote does not run on.
+            for (source[pos] != 0 && source[pos] != '\'' && source[pos] != '\n') {
+                if (source[pos] == '\\' && source[pos + 1] != 0 && source[pos + 1] != '\n') {
                     pos = pos + 2;
                     cnt;
                 }
@@ -503,6 +508,28 @@ test "lexer: emit_diagnostics drains lex errors onto the sink" {
     if (diags.items[0].span.offset != 2) { dnit(?stream, ?alloc); diag.dnit(?diags); ret 1; }
 
     diag.dnit(?diags);
+    dnit(?stream, ?alloc);
+    ret 0;
+}
+
+test "lexer: a string literal stops at a newline and is reported unterminated (#1247)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    # the missing closing quote on line one must not swallow line two: the scan
+    # stops at the newline, records LEX_ERR_UNTERMINATED_STR, and `b` still lexes.
+    val tr: Result[TokenStream, str] = tokenize("\"line one\nval b: u8 = 1;", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr)) { ret 1; }
+    var stream: TokenStream = unwrap_ok[TokenStream, str](tr);
+
+    if (stream.error_len != 1) { dnit(?stream, ?alloc); ret 1; }
+    if (stream.errors[0].code != LEX_ERR_UNTERMINATED_STR) { dnit(?stream, ?alloc); ret 1; }
+    # the string token spans only line one (offset 0 up to the newline at 9)
+    if (stream.tokens[0].kind != token.KIND_LIT_STR) { dnit(?stream, ?alloc); ret 1; }
+    if (stream.tokens[0].span.len != 9) { dnit(?stream, ?alloc); ret 1; }
+    # the next token is the `val` keyword on line two, proving recovery
+    if (stream.tokens[1].kind != token.KIND_IDENT) { dnit(?stream, ?alloc); ret 1; }
+
     dnit(?stream, ?alloc);
     ret 0;
 }

--- a/src/lang/fe/parser.mach
+++ b/src/lang/fe/parser.mach
@@ -5,6 +5,8 @@
 # tolerant — errors are emitted into the supplied diagnostic sink while
 # parsing continues; the caller does not see a fallible return.
 
+use std.types.bool.bool;
+
 use lexer: mach.lang.fe.lexer;
 use diag:  mach.lang.diagnostic;
 use ast:   mach.lang.fe.ast;
@@ -13,11 +15,16 @@ use state: mach.lang.fe.parser.state;
 use pdecl: mach.lang.fe.parser.decl;
 
 # parse: parses the token stream into the AST, populating diagnostics along the way.
+# syntax errors are recovered from and pushed to `diags` while parsing continues;
+# the one unrecoverable condition is an allocation failure, signalled by the
+# return so the caller can refuse the now-incomplete AST.
 # ---
 # tokens: lexer output to consume
 # out:    AST to append parsed nodes into; its root_module is set on completion
 # diags:  diagnostic sink; parse errors are pushed here rather than returned
-pub fun parse(tokens: *lexer.TokenStream, out: *ast.Ast, diags: *diag.DiagList) {
+# ret:    true if a fatal allocation failure occurred during the parse
+pub fun parse(tokens: *lexer.TokenStream, out: *ast.Ast, diags: *diag.DiagList) bool {
     var p: state.Parser = state.init(tokens, out, diags);
     pdecl.parse_module(?p);
+    ret p.fatal;
 }

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -162,10 +162,12 @@ fun peek_is_kw(p: *parser.Parser, offset: usize, kw: str) bool {
     ret str_region_equals(p.tokens.source, t.span.offset, t.span.len, kw);
 }
 
-# parses `use [alias:] path;`
-fun parse_use_decl(p: *parser.Parser, start: token.Span, flags: u8) id.DeclId {
-    parser.advance(p);
-
+# parses the shared `[alias:] path;` tail of a `use`/`fwd` declaration (the
+# leading keyword is already consumed). writes the alias span (empty when
+# absent) and the dotted path span through the out-params, and returns the
+# token whose span ends the declaration. `path_msg`/`semi_msg` localize the
+# diagnostics to the calling keyword.
+fun parse_alias_path(p: *parser.Parser, path_msg: str, semi_msg: str, alias_out: *token.Span, path_out: *token.Span) token.Token {
     var alias: token.Span;
     alias.offset = 0;
     alias.len    = 0;
@@ -181,11 +183,26 @@ fun parse_use_decl(p: *parser.Parser, start: token.Span, flags: u8) id.DeclId {
     if (parser.at(p, token.KIND_IDENT)) {
         path = parse_dotted_path(p);
     } or {
-        parser.error_at_current(p, "expected module path after 'use'");
+        parser.error_at_current(p, path_msg);
     }
 
     val end: token.Token = parser.current(p);
-    parser.expect(p, token.KIND_SEMI, "expected ';' after 'use' declaration");
+    parser.expect(p, token.KIND_SEMI, semi_msg);
+
+    @alias_out = alias;
+    @path_out  = path;
+    ret end;
+}
+
+# parses `use [alias:] path;`
+fun parse_use_decl(p: *parser.Parser, start: token.Span, flags: u8) id.DeclId {
+    parser.advance(p);
+
+    var alias: token.Span;
+    var path:  token.Span;
+    val end: token.Token = parse_alias_path(p,
+        "expected module path after 'use'",
+        "expected ';' after 'use' declaration", ?alias, ?path);
 
     var u: decl.DeclUse;
     u.alias = alias;
@@ -209,25 +226,10 @@ fun parse_fwd_decl(p: *parser.Parser, start: token.Span, flags: u8) id.DeclId {
     parser.advance(p);
 
     var alias: token.Span;
-    alias.offset = 0;
-    alias.len    = 0;
-
-    if (parser.at(p, token.KIND_IDENT) && parser.peek(p, 1).kind == token.KIND_COLON) {
-        alias = parser.advance(p).span;
-        parser.advance(p);
-    }
-
-    var path: token.Span;
-    path.offset = 0;
-    path.len    = 0;
-    if (parser.at(p, token.KIND_IDENT)) {
-        path = parse_dotted_path(p);
-    } or {
-        parser.error_at_current(p, "expected re-export path after 'fwd'");
-    }
-
-    val end: token.Token = parser.current(p);
-    parser.expect(p, token.KIND_SEMI, "expected ';' after 'fwd' declaration");
+    var path:  token.Span;
+    val end: token.Token = parse_alias_path(p,
+        "expected re-export path after 'fwd'",
+        "expected ';' after 'fwd' declaration", ?alias, ?path);
 
     var fwd_d: decl.DeclFwd;
     fwd_d.alias = alias;
@@ -495,10 +497,19 @@ fun parse_comptime_decl(p: *parser.Parser, start: token.Span) id.DeclId {
     ret parse_comptime_attr_decl(p, start);
 }
 
-# parses `$if (cond) { decls } $or (cond) { decls } $or { decls }` at decl scope
-fun parse_comptime_if_decl(p: *parser.Parser, start: token.Span) id.DeclId {
-    # buffer this chain's branches so a nested `$if`/`$or` chain parsed inside a
-    # branch body cannot interleave into this chain's contiguous slice.
+# ComptimeBodyFn: parses one `$if`/`$or` branch body `{ ... }` in the caller's
+# scope (decls at decl scope, stmts at stmt scope), appending the body elements
+# to their pool as one contiguous block. writes that block's pool start and
+# length through the out-params and returns the closing `}` span. the two
+# implementations differ only in element kind, so the chain skeleton is shared.
+def ComptimeBodyFn: fun(*parser.Parser, *u32, *u32) token.Span;
+
+# parses a `$if (cond) {..} $or (cond) {..} $or {..}` chain, shared by decl and
+# stmt scope. the leading `$if` is at the cursor; `parse_body` parses each branch
+# body. the chain's branches are buffered so a nested chain inside a body cannot
+# interleave into this chain's contiguous slice. writes the branch-list pool
+# start/len through the out-params and returns the chain's end span.
+fun parse_comptime_chain(p: *parser.Parser, start: token.Span, parse_body: ComptimeBodyFn, branches_start_out: *u32, branches_len_out: *u32) token.Span {
     var br_buf: parser.ComptimeBranchBuf = parser.comptime_branch_buf_init();
 
     parser.advance(p);
@@ -523,27 +534,9 @@ fun parse_comptime_if_decl(p: *parser.Parser, start: token.Span) id.DeclId {
             }
         }
 
-        # buffer this branch's direct decls so a nested comptime branch body
-        # parsed inside cannot interleave into this branch's contiguous slice
-        var body_buf: parser.DeclIdBuf = parser.decl_id_buf_init();
-
-        parser.expect(p, token.KIND_LBRACE, "expected '{' to open comptime branch body");
-        for (!parser.at(p, token.KIND_RBRACE) && !parser.at_eof(p)) {
-            val d: id.DeclId = parse_decl(p);
-            if (d != id.DECL_NIL) {
-                parser.decl_id_buf_push(p, ?body_buf, d);
-            }
-            if (p.panic) {
-                parser.sync_to(p, token.KIND_SEMI, token.KIND_RBRACE, token.KIND_EOF);
-                if (parser.at(p, token.KIND_SEMI)) { parser.advance(p); }
-            }
-        }
-        val close: token.Token = parser.current(p);
-        parser.expect(p, token.KIND_RBRACE, "expected '}' to close comptime branch body");
-        end = close.span;
-
-        var body_len: u32 = 0;
-        val body_start: u32 = parser.decl_id_buf_flush(p, ?body_buf, ?body_len);
+        var body_start: u32 = 0;
+        var body_len:   u32 = 0;
+        end = parse_body(p, ?body_start, ?body_len);
 
         var br: decl.ComptimeBranch;
         br.cond       = cond;
@@ -563,6 +556,70 @@ fun parse_comptime_if_decl(p: *parser.Parser, start: token.Span) id.DeclId {
 
     var branches_len:   u32 = 0;
     val branches_start: u32 = parser.comptime_branch_buf_flush(p, ?br_buf, ?branches_len);
+    @branches_start_out = branches_start;
+    @branches_len_out   = branches_len;
+    ret end;
+}
+
+# parses a `$if`/`$or` branch body as a decl list (decl scope). the body's direct
+# decls are buffered so a nested comptime branch body cannot interleave into this
+# branch's contiguous slice.
+fun parse_comptime_decl_body(p: *parser.Parser, body_start_out: *u32, body_len_out: *u32) token.Span {
+    var body_buf: parser.DeclIdBuf = parser.decl_id_buf_init();
+
+    parser.expect(p, token.KIND_LBRACE, "expected '{' to open comptime branch body");
+    for (!parser.at(p, token.KIND_RBRACE) && !parser.at_eof(p)) {
+        val d: id.DeclId = parse_decl(p);
+        if (d != id.DECL_NIL) {
+            parser.decl_id_buf_push(p, ?body_buf, d);
+        }
+        if (p.panic) {
+            parser.sync_to(p, token.KIND_SEMI, token.KIND_RBRACE, token.KIND_EOF);
+            if (parser.at(p, token.KIND_SEMI)) { parser.advance(p); }
+        }
+    }
+    val close: token.Token = parser.current(p);
+    parser.expect(p, token.KIND_RBRACE, "expected '}' to close comptime branch body");
+
+    var body_len: u32 = 0;
+    val body_start: u32 = parser.decl_id_buf_flush(p, ?body_buf, ?body_len);
+    @body_start_out = body_start;
+    @body_len_out   = body_len;
+    ret close.span;
+}
+
+# parses a `$if`/`$or` branch body as a stmt list (stmt scope). the body's
+# statements are buffered so a nested block inside cannot interleave into this
+# branch's contiguous slice.
+fun parse_comptime_stmt_body(p: *parser.Parser, body_start_out: *u32, body_len_out: *u32) token.Span {
+    var body_buf: parser.StmtIdBuf = parser.stmt_id_buf_init();
+
+    parser.expect(p, token.KIND_LBRACE, "expected '{' to open comptime branch body");
+    for (!parser.at(p, token.KIND_RBRACE) && !parser.at_eof(p)) {
+        val s: id.StmtId = parse_stmt(p);
+        if (s != id.STMT_NIL) {
+            parser.stmt_id_buf_push(p, ?body_buf, s);
+        }
+        if (p.panic) {
+            parser.sync_to(p, token.KIND_SEMI, token.KIND_RBRACE, token.KIND_EOF);
+            if (parser.at(p, token.KIND_SEMI)) { parser.advance(p); }
+        }
+    }
+    val close: token.Token = parser.current(p);
+    parser.expect(p, token.KIND_RBRACE, "expected '}' to close comptime branch body");
+
+    var body_len: u32 = 0;
+    val body_start: u32 = parser.stmt_id_buf_flush(p, ?body_buf, ?body_len);
+    @body_start_out = body_start;
+    @body_len_out   = body_len;
+    ret close.span;
+}
+
+# parses `$if (cond) { decls } $or (cond) { decls } $or { decls }` at decl scope
+fun parse_comptime_if_decl(p: *parser.Parser, start: token.Span) id.DeclId {
+    var branches_start: u32 = 0;
+    var branches_len:   u32 = 0;
+    val end: token.Span = parse_comptime_chain(p, start, parse_comptime_decl_body, ?branches_start, ?branches_len);
 
     var ci: decl.DeclComptimeIf;
     ci.branches_start = branches_start;
@@ -1005,72 +1062,9 @@ fun parse_expr_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
 
 # parses `$if (cond) { stmts } $or (cond) { stmts } $or { stmts }` at statement scope
 fun parse_comptime_if_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
-    # buffer this chain's branches so a nested `$if`/`$or` chain parsed inside a
-    # branch body cannot interleave into this chain's contiguous slice.
-    var br_buf: parser.ComptimeBranchBuf = parser.comptime_branch_buf_init();
-
-    parser.advance(p);
-    parser.advance(p);
-
-    var has_more: bool = true;
-    var first:    bool = true;
-    var end:      token.Span = start;
-
-    for (has_more) {
-        var cond: id.ExprId = id.EXPR_NIL;
-        if (first) {
-            parser.expect(p, token.KIND_LPAREN, "expected '(' after '$if'");
-            cond = pexpr.parse_expr(p);
-            parser.expect(p, token.KIND_RPAREN, "expected ')' after '$if' condition");
-            first = false;
-        }
-        or {
-            if (parser.eat(p, token.KIND_LPAREN)) {
-                cond = pexpr.parse_expr(p);
-                parser.expect(p, token.KIND_RPAREN, "expected ')' after '$or' condition");
-            }
-        }
-
-        # buffer this branch's statements so a nested block inside cannot
-        # interleave into the branch's contiguous slice.
-        var body_buf: parser.StmtIdBuf = parser.stmt_id_buf_init();
-
-        parser.expect(p, token.KIND_LBRACE, "expected '{' to open comptime branch body");
-        for (!parser.at(p, token.KIND_RBRACE) && !parser.at_eof(p)) {
-            val s: id.StmtId = parse_stmt(p);
-            if (s != id.STMT_NIL) {
-                parser.stmt_id_buf_push(p, ?body_buf, s);
-            }
-            if (p.panic) {
-                parser.sync_to(p, token.KIND_SEMI, token.KIND_RBRACE, token.KIND_EOF);
-                if (parser.at(p, token.KIND_SEMI)) { parser.advance(p); }
-            }
-        }
-        val close: token.Token = parser.current(p);
-        parser.expect(p, token.KIND_RBRACE, "expected '}' to close comptime branch body");
-        end = close.span;
-
-        var body_len: u32 = 0;
-        val body_start: u32 = parser.stmt_id_buf_flush(p, ?body_buf, ?body_len);
-
-        var br: decl.ComptimeBranch;
-        br.cond       = cond;
-        br.body_start = body_start;
-        br.body_len   = body_len;
-        parser.comptime_branch_buf_push(p, ?br_buf, br);
-
-        if (parser.at(p, token.KIND_DOLLAR) && peek_is_kw(p, 1, "or")) {
-            parser.advance(p);
-            parser.advance(p);
-            has_more = true;
-        }
-        or {
-            has_more = false;
-        }
-    }
-
+    var branches_start: u32 = 0;
     var branches_len:   u32 = 0;
-    val branches_start: u32 = parser.comptime_branch_buf_flush(p, ?br_buf, ?branches_len);
+    val end: token.Span = parse_comptime_chain(p, start, parse_comptime_stmt_body, ?branches_start, ?branches_len);
 
     var ci: stmt.StmtComptimeIf;
     ci.branches_start = branches_start;
@@ -1117,5 +1111,15 @@ test "parser: a `val` without an initializer is rejected (val-var.md, #1247)" {
 test "parser: well-formed bindings parse without diagnostics (#1247)" {
     # val needs type+init; var needs a type but may default-initialize
     if (t_parse_module_has_errors("val c: i64 = 1; var d: i64;")) { ret 1; }
+    ret 0;
+}
+
+test "parser: $if/$or chains parse at decl and stmt scope via the shared skeleton (#1247)" {
+    # decl-scope chain: `$if`, conditional `$or`, and a bare `$or` else
+    if (t_parse_module_has_errors("$if (1) {} $or (2) {} $or {}")) { ret 1; }
+    # stmt-scope chain inside a function body
+    if (t_parse_module_has_errors("fun f() i64 { $if (1) { ret 1; } $or { ret 0; } }")) { ret 1; }
+    # a malformed chain still reports: the `$if` condition needs parentheses
+    if (!t_parse_module_has_errors("$if 1 {}")) { ret 1; }
     ret 0;
 }

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -13,6 +13,7 @@ use std.types.string.str_region_equals;
 use std.types.size.usize;
 use std.types.result.Result;
 use std.types.result.is_err;
+use std.types.result.unwrap_ok;
 use std.types.option.unwrap;
 
 use token:  mach.lang.fe.token;
@@ -25,6 +26,12 @@ use module: mach.lang.fe.ast.module;
 use parser: mach.lang.fe.parser.state;
 use pexpr:  mach.lang.fe.parser.expr;
 use pasm:   mach.lang.fe.parser.iasm;
+
+use lexer: mach.lang.fe.lexer;
+use diag:  mach.lang.diagnostic;
+use src:   mach.lang.source;
+use page:  std.allocator.page;
+use std.allocator.Allocator;
 
 # parse_module: parses a whole source file as a single Module, sets ast.root_module, and returns the ModuleId.
 # ---
@@ -381,14 +388,22 @@ fun parse_bind_decl(p: *parser.Parser, start: token.Span, flags: u8, kind: decl.
         parser.error_at_current(p, "expected binding name");
     }
 
+    # both bindings require an explicit type annotation (val-var.md: "Mach has
+    # no type inference"); the colon-and-type is mandatory at the syntax level.
     var ty: id.TypeId = id.TYPE_NIL;
     if (parser.eat(p, token.KIND_COLON)) {
         ty = pexpr.parse_type(p);
+    } or {
+        parser.error_at_current(p, "expected ':' and a type — bindings require an explicit type");
     }
 
+    # `val` requires an initializer (val-var.md); `var` may be default-initialized.
     var init: id.ExprId = id.EXPR_NIL;
     if (parser.eat(p, token.KIND_EQ)) {
         init = pexpr.parse_expr(p);
+    }
+    or (kind == decl.DECL_KIND_VAL) {
+        parser.error_at_current(p, "'val' requires an initializer");
     }
 
     val end: token.Token = parser.current(p);
@@ -933,7 +948,7 @@ fun parse_cnt_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
     ret parser.push_stmt(p, node);
 }
 
-# parses `fin expr;`
+# parses `fin stmt` — a deferred statement run at scope exit
 fun parse_fin_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
     parser.advance(p);
     val body_id: id.StmtId = parse_stmt(p);
@@ -1066,4 +1081,41 @@ fun parse_comptime_if_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
     node.kind = stmt.STMT_KIND_COMPTIME_IF;
     node.data.comptime_if = ci;
     ret parser.push_stmt(p, node);
+}
+
+# t_parse_module_has_errors: lexes and parses `source` as a module and reports
+# whether any error diagnostic was produced. used by the binding-grammar tests.
+fun t_parse_module_has_errors(source: str) bool {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize(source, ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret true; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+    parse_module(?p);
+    val had: bool = diag.has_errors(?diags);
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret had;
+}
+
+test "parser: a binding with no type annotation is rejected (val-var.md, #1247)" {
+    # val-var.md: bindings require an explicit type — neither form may omit it
+    if (!t_parse_module_has_errors("val a = 42;")) { ret 1; }
+    if (!t_parse_module_has_errors("var b;")) { ret 1; }
+    ret 0;
+}
+
+test "parser: a `val` without an initializer is rejected (val-var.md, #1247)" {
+    if (!t_parse_module_has_errors("val c: i64;")) { ret 1; }
+    ret 0;
+}
+
+test "parser: well-formed bindings parse without diagnostics (#1247)" {
+    # val needs type+init; var needs a type but may default-initialize
+    if (t_parse_module_has_errors("val c: i64 = 1; var d: i64;")) { ret 1; }
+    ret 0;
 }

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -26,6 +26,12 @@ use decl:     mach.lang.fe.ast.decl;
 use parser:   mach.lang.fe.parser.state;
 use comptime: mach.lang.fe.comptime;
 
+use lexer: mach.lang.fe.lexer;
+use diag:  mach.lang.diagnostic;
+use src:   mach.lang.source;
+use page:  std.allocator.page;
+use std.allocator.Allocator;
+
 # parse_expr: parses a full expression at the lowest infix binding power.
 # ---
 # p:   parser state
@@ -57,7 +63,7 @@ pub fun parse_expr_bp(p: *parser.Parser, min_bp: u8) id.ExprId {
         val rhs: id.ExprId = parse_expr_bp(p, right_bp);
 
         var bin: expr.ExprBinary;
-        bin.op  = bin_op_from_kind(op_tok.kind);
+        bin.op  = bin_op_from_kind(p, op_tok.kind);
         bin.lhs = lhs;
         bin.rhs = rhs;
 
@@ -66,8 +72,6 @@ pub fun parse_expr_bp(p: *parser.Parser, min_bp: u8) id.ExprId {
         node.kind = expr.EXPR_KIND_BINARY;
         node.data.binary = bin;
         lhs = parser.push_expr(p, node);
-
-        lhs = parse_postfix(p, lhs);
     }
 
     ret lhs;
@@ -140,7 +144,7 @@ fun parse_postfix(p: *parser.Parser, base: id.ExprId) id.ExprId {
         val k: token.Kind = parser.current(p).kind;
         if      (k == token.KIND_LPAREN)      { lhs = parse_call(p, lhs, 0, 0); }
         or      (k == token.KIND_LBRACKET) {
-            if (type_args_follow_kind(p) == token.KIND_LPAREN) {
+            if (postfix_is_generic_call(p)) {
                 lhs = parse_generic_call(p, lhs);
             }
             or {
@@ -155,25 +159,46 @@ fun parse_postfix(p: *parser.Parser, base: id.ExprId) id.ExprId {
     ret lhs;
 }
 
-# scans the balanced [...] starting at the current '[' and returns the token
-# kind immediately after the matching ']' (KIND_EOF if unterminated or empty).
-# a postfix '[' is a generic-arg list only when that follow-kind is '(' (a
-# call) — the '{' typed-literal form is recognized at the prefix stage and
-# never reaches postfix.
-fun type_args_follow_kind(p: *parser.Parser) token.Kind {
-    var i: usize = 1;            # peek(p, 0) is the current '['
+# scans a balanced bracket region for the postfix/prefix disambiguators: starting
+# at the '[' whose offset from the cursor is `bracket_off`, it walks to the
+# matching ']' and returns the cursor offset of the token immediately after it. a
+# ';' or EOF reached inside the brackets means the region can never be a type
+# list, reported as 0 (the brackets are unbalanced for that purpose). shared by
+# postfix_is_generic_call and looks_like_typed_literal so the two scanners cannot
+# drift apart.
+fun scan_bracket_close(p: *parser.Parser, bracket_off: usize) usize {
+    var i: usize = bracket_off + 1;
     var depth: usize = 1;
-    var has_payload: bool = false;
     for (depth > 0) {
         val k: token.Kind = parser.peek(p, i).kind;
-        if (k == token.KIND_EOF || k == token.KIND_SEMI) { ret token.KIND_EOF; }
+        if (k == token.KIND_EOF || k == token.KIND_SEMI) { ret 0; }
         if (k == token.KIND_LBRACKET) { depth = depth + 1; }
         or (k == token.KIND_RBRACKET) { depth = depth - 1; }
-        or                            { has_payload = true; }
         i = i + 1;
     }
-    if (!has_payload) { ret token.KIND_EOF; }
-    ret parser.peek(p, i).kind;
+    ret i;
+}
+
+# true when `k` can begin a type (per parse_type): a pointer '*', an array '[',
+# or an identifier (which covers named types and the `fun`/`rec`/`uni` keywords).
+fun token_begins_type(k: token.Kind) bool {
+    ret k == token.KIND_STAR || k == token.KIND_LBRACKET || k == token.KIND_IDENT;
+}
+
+# decides whether a postfix '[' opens a generic call `callee[T, ..](args)` rather
+# than an index `obj[i]`. it is a generic call only when the bracketed payload can
+# begin a type AND the token after the matching ']' is '(' (the call). a payload
+# that starts with a token which cannot begin a type — a literal, '-', '@', '$',
+# etc. — is an index, so `table[0]()` parses as index-then-call (#1247). the
+# decision stays purely syntactic: an index whose value is a bare identifier is
+# locally indistinguishable from a single type argument and still binds as a
+# generic call; resolve owns that residual ambiguity. the '{' typed-literal form
+# is recognized at the prefix stage and never reaches postfix.
+fun postfix_is_generic_call(p: *parser.Parser) bool {
+    if (!token_begins_type(parser.peek(p, 1).kind)) { ret false; }
+    val after: usize = scan_bracket_close(p, 0);   # peek(p, 0) is the current '['
+    if (after == 0) { ret false; }
+    ret parser.peek(p, after).kind == token.KIND_LPAREN;
 }
 
 # parses a generic call `callee[T, U](args)`: consumes the bracketed type-arg
@@ -565,22 +590,20 @@ fun looks_like_typed_literal(p: *parser.Parser) bool {
     }
 
     if (parser.peek(p, i).kind == token.KIND_LBRACKET) {
-        i = i + 1;
-        var depth: usize = 1;
-        for (depth > 0) {
-            val k: token.Kind = parser.peek(p, i).kind;
-            if (k == token.KIND_EOF)      { ret false; }
-            if (k == token.KIND_LBRACKET) { depth = depth + 1; }
-            if (k == token.KIND_RBRACKET) { depth = depth - 1; }
-            i = i + 1;
-        }
+        val after: usize = scan_bracket_close(p, i);
+        if (after == 0) { ret false; }
+        i = after;
     }
 
     ret parser.peek(p, i).kind == token.KIND_LBRACE;
 }
 
-# maps a token kind to its corresponding BinOp
-fun bin_op_from_kind(kind: token.Kind) expr.BinOp {
+# maps a token kind to its corresponding BinOp. paired with
+# token.infix_precedence: the Pratt loop only calls this for kinds with nonzero
+# infix precedence, so every operator listed there must be mapped here. `=` is
+# the sole assignment mapping; an unmapped kind means the two tables have drifted
+# out of sync and is reported rather than silently parsed as an assignment.
+fun bin_op_from_kind(p: *parser.Parser, kind: token.Kind) expr.BinOp {
     if (kind == token.KIND_PLUS)      { ret expr.BIN_ADD; }
     if (kind == token.KIND_MINUS)     { ret expr.BIN_SUB; }
     if (kind == token.KIND_STAR)      { ret expr.BIN_MUL; }
@@ -599,6 +622,8 @@ fun bin_op_from_kind(kind: token.Kind) expr.BinOp {
     if (kind == token.KIND_CARET)     { ret expr.BIN_BIT_XOR; }
     if (kind == token.KIND_LT_LT)     { ret expr.BIN_SHL; }
     if (kind == token.KIND_GT_GT)     { ret expr.BIN_SHR; }
+    if (kind == token.KIND_EQ)        { ret expr.BIN_ASSIGN; }
+    parser.error_at_current(p, "internal error: infix operator has no binary-operator mapping");
     ret expr.BIN_ASSIGN;
 }
 
@@ -844,4 +869,61 @@ fun at_type_boundary(p: *parser.Parser) bool {
     if (k == token.KIND_EQ)       { ret true; }
     if (k == token.KIND_EOF)      { ret true; }
     ret false;
+}
+
+test "parser: expr[i](args) parses as index-then-call, not a generic call (#1247)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize("t[0]()", ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+
+    val eid: id.ExprId = parse_expr(?p);
+    var rc: i32 = 0;
+    val e: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, eid));
+    # `t[0]()` is a call whose callee is the index `t[0]`, with no type args
+    if (e.kind != expr.EXPR_KIND_CALL) { rc = 1; }
+    or (e.data.call.type_args_len != 0) { rc = 1; }
+    or {
+        val callee: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, e.data.call.callee));
+        if (callee.kind != expr.EXPR_KIND_INDEX) { rc = 1; }
+    }
+    if (diag.has_errors(?diags)) { rc = 1; }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "parser: a true generic call callee[T](args) still binds its type args (#1247)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize("make[i64]()", ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+
+    val eid: id.ExprId = parse_expr(?p);
+    var rc: i32 = 0;
+    val e: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, eid));
+    if (e.kind != expr.EXPR_KIND_CALL) { rc = 1; }
+    or (e.data.call.type_args_len != 1) { rc = 1; }
+    or {
+        val callee: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, e.data.call.callee));
+        if (callee.kind != expr.EXPR_KIND_IDENT) { rc = 1; }
+    }
+    if (diag.has_errors(?diags)) { rc = 1; }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
 }

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -190,10 +190,12 @@ fun token_begins_type(k: token.Kind) bool {
 # begin a type AND the token after the matching ']' is '(' (the call). a payload
 # that starts with a token which cannot begin a type — a literal, '-', '@', '$',
 # etc. — is an index, so `table[0]()` parses as index-then-call (#1247). the
-# decision stays purely syntactic: an index whose value is a bare identifier is
-# locally indistinguishable from a single type argument and still binds as a
-# generic call; resolve owns that residual ambiguity. the '{' typed-literal form
-# is recognized at the prefix stage and never reaches postfix.
+# decision is purely syntactic and has one residual gap: a bare-identifier payload
+# is locally indistinguishable from a single type argument, so `table[i]()` still
+# binds as a generic call and, if `i` names a value, resolve then errors on it —
+# the variable-index-then-call form still needs `(table[i])()`. the complete fix
+# (deferring the index/generic decision to resolve) is tracked in #1270. the '{'
+# typed-literal form is recognized at the prefix stage and never reaches postfix.
 fun postfix_is_generic_call(p: *parser.Parser) bool {
     if (!token_begins_type(parser.peek(p, 1).kind)) { ret false; }
     val after: usize = scan_bracket_close(p, 0);   # peek(p, 0) is the current '['

--- a/src/lang/fe/parser/state.mach
+++ b/src/lang/fe/parser/state.mach
@@ -39,12 +39,16 @@ use module: mach.lang.fe.ast.module;
 # ast:    output AST; nodes are appended here as parsing progresses
 # diags:  diagnostic sink for parse errors and recovery messages
 # panic:  true while skipping tokens during error recovery; cleared at the next synchronization point
+# fatal:  sticky flag set by any allocation failure during parsing, independent
+#         of panic so an OOM hit mid-recovery is never swallowed; the driver
+#         treats a fatal parse as failed rather than consuming a corrupt AST
 pub rec Parser {
     tokens: *lexer.TokenStream;
     pos:    usize;
     ast:    *ast.Ast;
     diags:  *diag.DiagList;
     panic:  bool;
+    fatal:  bool;
 }
 
 # init: initializes a Parser over the given token stream, filling output into ast and diags.
@@ -60,6 +64,7 @@ pub fun init(tokens: *lexer.TokenStream, out: *ast.Ast, diags: *diag.DiagList) P
     p.ast    = out;
     p.diags  = diags;
     p.panic  = false;
+    p.fatal  = false;
     ret p;
 }
 
@@ -180,6 +185,25 @@ pub fun error_at(p: *Parser, span: token.Span, message: str) {
     if (is_err[bool, str](r)) { ret; }
 }
 
+# fatal_oom_at: records an unrecoverable allocation failure at `span`. an OOM is
+# not recoverable by error recovery, so this sets the sticky `fatal` flag and
+# emits the diagnostic directly, bypassing the `panic` guard that would otherwise
+# swallow an allocation failure hit while already recovering. the driver checks
+# `fatal` after the parse and refuses to consume the (now incomplete) AST.
+pub fun fatal_oom_at(p: *Parser, span: token.Span) {
+    # report the first allocation failure once: the flag is sticky and the driver
+    # aborts after parse, so a later failure during teardown needs no new message.
+    if (p.fatal) { ret; }
+    p.fatal = true;
+    val r: Result[bool, str] = diag.error(p.diags, p.tokens.file_id, span, "out of memory while parsing");
+    if (is_err[bool, str](r)) { ret; }
+}
+
+# fatal_oom: fatal_oom_at pinned to the current token's span.
+pub fun fatal_oom(p: *Parser) {
+    fatal_oom_at(p, current(p).span);
+}
+
 # sync_to: advances until the current token is EOF or matches one of the synchronization kinds, then clears panic.
 # ---
 # p:  parser state
@@ -251,7 +275,7 @@ pub fun span_of(start: token.Span, end: token.Span) token.Span {
 pub fun push_expr(p: *Parser, e: expr.Expr) id.ExprId {
     val r: Result[id.ExprId, str] = ast.add_expr(p.ast, e);
     if (is_err[id.ExprId, str](r)) {
-        error_at(p, e.span, "out of memory while parsing expression");
+        fatal_oom_at(p, e.span);
         ret id.EXPR_NIL;
     }
     ret unwrap_ok[id.ExprId, str](r);
@@ -265,7 +289,7 @@ pub fun push_expr(p: *Parser, e: expr.Expr) id.ExprId {
 pub fun push_stmt(p: *Parser, s: stmt.Stmt) id.StmtId {
     val r: Result[id.StmtId, str] = ast.add_stmt(p.ast, s);
     if (is_err[id.StmtId, str](r)) {
-        error_at(p, s.span, "out of memory while parsing statement");
+        fatal_oom_at(p, s.span);
         ret id.STMT_NIL;
     }
     ret unwrap_ok[id.StmtId, str](r);
@@ -279,7 +303,7 @@ pub fun push_stmt(p: *Parser, s: stmt.Stmt) id.StmtId {
 pub fun push_decl(p: *Parser, d: decl.Decl) id.DeclId {
     val r: Result[id.DeclId, str] = ast.add_decl(p.ast, d);
     if (is_err[id.DeclId, str](r)) {
-        error_at(p, d.span, "out of memory while parsing declaration");
+        fatal_oom_at(p, d.span);
         ret id.DECL_NIL;
     }
     ret unwrap_ok[id.DeclId, str](r);
@@ -293,7 +317,7 @@ pub fun push_decl(p: *Parser, d: decl.Decl) id.DeclId {
 pub fun push_type(p: *Parser, t: m_type.Type) id.TypeId {
     val r: Result[id.TypeId, str] = ast.add_type(p.ast, t);
     if (is_err[id.TypeId, str](r)) {
-        error_at(p, t.span, "out of memory while parsing type");
+        fatal_oom_at(p, t.span);
         ret id.TYPE_NIL;
     }
     ret unwrap_ok[id.TypeId, str](r);
@@ -307,13 +331,13 @@ pub fun push_type(p: *Parser, t: m_type.Type) id.TypeId {
 pub fun push_module(p: *Parser, m: module.Module) id.ModuleId {
     val r: Result[id.ModuleId, str] = ast.add_module(p.ast, m);
     if (is_err[id.ModuleId, str](r)) {
-        error_at(p, m.span, "out of memory while parsing module");
+        fatal_oom_at(p, m.span);
         ret id.MODULE_NIL;
     }
     ret unwrap_ok[id.ModuleId, str](r);
 }
 
-# push_decl_id: appends a DeclId to ast.decl_ids, returning 0 on failure (caller must check p.panic).
+# push_decl_id: appends a DeclId to ast.decl_ids; on allocation failure it flags the parse fatal (fatal_oom) and returns 0, which flush ignores since it derives the appended count from the pool.
 # ---
 # p:   parser state
 # id_: DeclId to append
@@ -321,7 +345,7 @@ pub fun push_module(p: *Parser, m: module.Module) id.ModuleId {
 pub fun push_decl_id(p: *Parser, id_: id.DeclId) u32 {
     val r: Result[u32, str] = ast.add_decl_id(p.ast, id_);
     if (is_err[u32, str](r)) {
-        error_at_current(p, "out of memory while parsing");
+        fatal_oom(p);
         ret 0;
     }
     ret unwrap_ok[u32, str](r);
@@ -361,12 +385,12 @@ pub fun decl_id_buf_push(p: *Parser, b: *DeclIdBuf, id_: id.DeclId) {
         if (new_cap == 0) { new_cap = 8; }
         if (b.data == nil) {
             val r: Result[*id.DeclId, str] = allocate[id.DeclId](p.ast.alloc, new_cap::usize);
-            if (is_err[*id.DeclId, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*id.DeclId, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*id.DeclId, str](r);
         }
         or {
             val r: Result[*id.DeclId, str] = reallocate[id.DeclId](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*id.DeclId, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*id.DeclId, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*id.DeclId, str](r);
         }
         b.cap = new_cap;
@@ -385,7 +409,9 @@ pub fun decl_id_buf_flush(p: *Parser, b: *DeclIdBuf, out_len: *u32) u32 {
         push_decl_id(p, b.data[i]);
         i = i + 1;
     }
-    @out_len = b.len;
+    # the count actually appended, not b.len: a fatal alloc failure mid-flush
+    # leaves the slice covering only the ids that reached the pool.
+    @out_len = (p.ast.decl_id_len::u32) - start;
     if (b.data != nil && b.cap > 0) {
         deallocate[id.DeclId](p.ast.alloc, b.data, b.cap::usize);
     }
@@ -430,12 +456,12 @@ pub fun expr_id_buf_push(p: *Parser, b: *ExprIdBuf, id_: id.ExprId) {
         if (new_cap == 0) { new_cap = 8; }
         if (b.data == nil) {
             val r: Result[*id.ExprId, str] = allocate[id.ExprId](p.ast.alloc, new_cap::usize);
-            if (is_err[*id.ExprId, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*id.ExprId, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*id.ExprId, str](r);
         }
         or {
             val r: Result[*id.ExprId, str] = reallocate[id.ExprId](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*id.ExprId, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*id.ExprId, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*id.ExprId, str](r);
         }
         b.cap = new_cap;
@@ -454,7 +480,9 @@ pub fun expr_id_buf_flush(p: *Parser, b: *ExprIdBuf, out_len: *u32) u32 {
         push_expr_id(p, b.data[i]);
         i = i + 1;
     }
-    @out_len = b.len;
+    # the count actually appended, not b.len: a fatal alloc failure mid-flush
+    # leaves the slice covering only the ids that reached the pool.
+    @out_len = (p.ast.expr_id_len::u32) - start;
     if (b.data != nil && b.cap > 0) {
         deallocate[id.ExprId](p.ast.alloc, b.data, b.cap::usize);
     }
@@ -498,12 +526,12 @@ pub fun type_id_buf_push(p: *Parser, b: *TypeIdBuf, id_: id.TypeId) {
         if (new_cap == 0) { new_cap = 8; }
         if (b.data == nil) {
             val r: Result[*id.TypeId, str] = allocate[id.TypeId](p.ast.alloc, new_cap::usize);
-            if (is_err[*id.TypeId, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*id.TypeId, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*id.TypeId, str](r);
         }
         or {
             val r: Result[*id.TypeId, str] = reallocate[id.TypeId](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*id.TypeId, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*id.TypeId, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*id.TypeId, str](r);
         }
         b.cap = new_cap;
@@ -522,7 +550,9 @@ pub fun type_id_buf_flush(p: *Parser, b: *TypeIdBuf, out_len: *u32) u32 {
         push_type_id(p, b.data[i]);
         i = i + 1;
     }
-    @out_len = b.len;
+    # the count actually appended, not b.len: a fatal alloc failure mid-flush
+    # leaves the slice covering only the ids that reached the pool.
+    @out_len = (p.ast.type_id_len::u32) - start;
     if (b.data != nil && b.cap > 0) {
         deallocate[id.TypeId](p.ast.alloc, b.data, b.cap::usize);
     }
@@ -565,12 +595,12 @@ pub fun field_init_buf_push(p: *Parser, b: *FieldInitBuf, fi: expr.FieldInit) {
         if (new_cap == 0) { new_cap = 8; }
         if (b.data == nil) {
             val r: Result[*expr.FieldInit, str] = allocate[expr.FieldInit](p.ast.alloc, new_cap::usize);
-            if (is_err[*expr.FieldInit, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*expr.FieldInit, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*expr.FieldInit, str](r);
         }
         or {
             val r: Result[*expr.FieldInit, str] = reallocate[expr.FieldInit](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*expr.FieldInit, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*expr.FieldInit, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*expr.FieldInit, str](r);
         }
         b.cap = new_cap;
@@ -587,10 +617,12 @@ pub fun field_init_buf_flush(p: *Parser, b: *FieldInitBuf, out_len: *u32) u32 {
     var i: u32 = 0;
     for (i < b.len) {
         val r: Result[u32, str] = ast.add_field_init(p.ast, b.data[i]);
-        if (is_err[u32, str](r)) { error_at_current(p, "out of memory while parsing"); }
+        if (is_err[u32, str](r)) { fatal_oom(p); }
         i = i + 1;
     }
-    @out_len = b.len;
+    # the count actually appended, not b.len: a fatal alloc failure mid-flush
+    # leaves the slice covering only the entries that reached the pool.
+    @out_len = (p.ast.field_init_len::u32) - start;
     if (b.data != nil && b.cap > 0) {
         deallocate[expr.FieldInit](p.ast.alloc, b.data, b.cap::usize);
     }
@@ -634,12 +666,12 @@ pub fun typed_name_buf_push(p: *Parser, b: *TypedNameBuf, tn: decl.TypedName) {
         if (new_cap == 0) { new_cap = 8; }
         if (b.data == nil) {
             val r: Result[*decl.TypedName, str] = allocate[decl.TypedName](p.ast.alloc, new_cap::usize);
-            if (is_err[*decl.TypedName, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*decl.TypedName, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*decl.TypedName, str](r);
         }
         or {
             val r: Result[*decl.TypedName, str] = reallocate[decl.TypedName](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*decl.TypedName, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*decl.TypedName, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*decl.TypedName, str](r);
         }
         b.cap = new_cap;
@@ -656,10 +688,12 @@ pub fun typed_name_buf_flush(p: *Parser, b: *TypedNameBuf, out_len: *u32) u32 {
     var i: u32 = 0;
     for (i < b.len) {
         val r: Result[u32, str] = ast.add_typed_name(p.ast, b.data[i]);
-        if (is_err[u32, str](r)) { error_at_current(p, "out of memory while parsing"); }
+        if (is_err[u32, str](r)) { fatal_oom(p); }
         i = i + 1;
     }
-    @out_len = b.len;
+    # the count actually appended, not b.len: a fatal alloc failure mid-flush
+    # leaves the slice covering only the entries that reached the pool.
+    @out_len = (p.ast.typed_name_len::u32) - start;
     if (b.data != nil && b.cap > 0) {
         deallocate[decl.TypedName](p.ast.alloc, b.data, b.cap::usize);
     }
@@ -702,12 +736,12 @@ pub fun stmt_id_buf_push(p: *Parser, b: *StmtIdBuf, id_: id.StmtId) {
         if (new_cap == 0) { new_cap = 8; }
         if (b.data == nil) {
             val r: Result[*id.StmtId, str] = allocate[id.StmtId](p.ast.alloc, new_cap::usize);
-            if (is_err[*id.StmtId, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*id.StmtId, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*id.StmtId, str](r);
         }
         or {
             val r: Result[*id.StmtId, str] = reallocate[id.StmtId](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*id.StmtId, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*id.StmtId, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*id.StmtId, str](r);
         }
         b.cap = new_cap;
@@ -726,7 +760,9 @@ pub fun stmt_id_buf_flush(p: *Parser, b: *StmtIdBuf, out_len: *u32) u32 {
         push_stmt_id(p, b.data[i]);
         i = i + 1;
     }
-    @out_len = b.len;
+    # the count actually appended, not b.len: a fatal alloc failure mid-flush
+    # leaves the slice covering only the ids that reached the pool.
+    @out_len = (p.ast.stmt_id_len::u32) - start;
     if (b.data != nil && b.cap > 0) {
         deallocate[id.StmtId](p.ast.alloc, b.data, b.cap::usize);
     }
@@ -770,12 +806,12 @@ pub fun comptime_branch_buf_push(p: *Parser, b: *ComptimeBranchBuf, br: decl.Com
         if (new_cap == 0) { new_cap = 8; }
         if (b.data == nil) {
             val r: Result[*decl.ComptimeBranch, str] = allocate[decl.ComptimeBranch](p.ast.alloc, new_cap::usize);
-            if (is_err[*decl.ComptimeBranch, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*decl.ComptimeBranch, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*decl.ComptimeBranch, str](r);
         }
         or {
             val r: Result[*decl.ComptimeBranch, str] = reallocate[decl.ComptimeBranch](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*decl.ComptimeBranch, str](r)) { error_at_current(p, "out of memory while parsing"); ret; }
+            if (is_err[*decl.ComptimeBranch, str](r)) { fatal_oom(p); ret; }
             b.data = unwrap_ok[*decl.ComptimeBranch, str](r);
         }
         b.cap = new_cap;
@@ -793,10 +829,12 @@ pub fun comptime_branch_buf_flush(p: *Parser, b: *ComptimeBranchBuf, out_len: *u
     var i: u32 = 0;
     for (i < b.len) {
         val r: Result[u32, str] = ast.add_comptime_branch(p.ast, b.data[i]);
-        if (is_err[u32, str](r)) { error_at_current(p, "out of memory while parsing"); }
+        if (is_err[u32, str](r)) { fatal_oom(p); }
         i = i + 1;
     }
-    @out_len = b.len;
+    # the count actually appended, not b.len: a fatal alloc failure mid-flush
+    # leaves the slice covering only the branches that reached the pool.
+    @out_len = (p.ast.comptime_branch_len::u32) - start;
     if (b.data != nil && b.cap > 0) {
         deallocate[decl.ComptimeBranch](p.ast.alloc, b.data, b.cap::usize);
     }
@@ -806,7 +844,7 @@ pub fun comptime_branch_buf_flush(p: *Parser, b: *ComptimeBranchBuf, out_len: *u
     ret start;
 }
 
-# push_stmt_id: appends a StmtId to ast.stmt_ids, returning 0 on failure (caller must check p.panic).
+# push_stmt_id: appends a StmtId to ast.stmt_ids; on allocation failure it flags the parse fatal (fatal_oom) and returns 0, which flush ignores since it derives the appended count from the pool.
 # ---
 # p:   parser state
 # id_: StmtId to append
@@ -814,13 +852,13 @@ pub fun comptime_branch_buf_flush(p: *Parser, b: *ComptimeBranchBuf, out_len: *u
 pub fun push_stmt_id(p: *Parser, id_: id.StmtId) u32 {
     val r: Result[u32, str] = ast.add_stmt_id(p.ast, id_);
     if (is_err[u32, str](r)) {
-        error_at_current(p, "out of memory while parsing");
+        fatal_oom(p);
         ret 0;
     }
     ret unwrap_ok[u32, str](r);
 }
 
-# push_expr_id: appends an ExprId to ast.expr_ids, returning 0 on failure (caller must check p.panic).
+# push_expr_id: appends an ExprId to ast.expr_ids; on allocation failure it flags the parse fatal (fatal_oom) and returns 0, which flush ignores since it derives the appended count from the pool.
 # ---
 # p:   parser state
 # id_: ExprId to append
@@ -828,13 +866,13 @@ pub fun push_stmt_id(p: *Parser, id_: id.StmtId) u32 {
 pub fun push_expr_id(p: *Parser, id_: id.ExprId) u32 {
     val r: Result[u32, str] = ast.add_expr_id(p.ast, id_);
     if (is_err[u32, str](r)) {
-        error_at_current(p, "out of memory while parsing");
+        fatal_oom(p);
         ret 0;
     }
     ret unwrap_ok[u32, str](r);
 }
 
-# push_type_id: appends a TypeId to ast.type_ids, returning 0 on failure (caller must check p.panic).
+# push_type_id: appends a TypeId to ast.type_ids; on allocation failure it flags the parse fatal (fatal_oom) and returns 0, which flush ignores since it derives the appended count from the pool.
 # ---
 # p:   parser state
 # id_: TypeId to append
@@ -842,7 +880,7 @@ pub fun push_expr_id(p: *Parser, id_: id.ExprId) u32 {
 pub fun push_type_id(p: *Parser, id_: id.TypeId) u32 {
     val r: Result[u32, str] = ast.add_type_id(p.ast, id_);
     if (is_err[u32, str](r)) {
-        error_at_current(p, "out of memory while parsing");
+        fatal_oom(p);
         ret 0;
     }
     ret unwrap_ok[u32, str](r);


### PR DESCRIPTION
Addresses the frontend parser/lexer audit findings in #1247 (epic #1259).

## Fixed
- **[BUG/M] index-then-call** — `table[0]()` parses as index-then-call instead of misparsing as a generic call. A postfix `[` is committed as type arguments only when its payload begins with a type-starting token (`*`, `[`, ident) **and** the token after the matching `]` is `(`. The two divergent bracket scanners are unified into `scan_bracket_close`. Residual: a bare-identifier payload (`table[i]()`) still binds as a generic call — the complete resolve-deferral fix is tracked in #1270.
- **[BUG/S] val/var grammar holes** — bindings now require an explicit `: type` (both forms) and `val` requires an initializer, per `val-var.md`. Previously these slipped through to a MIR ICE.
- **[BUG/S] multi-line string literals** — string/char scans terminate at an unescaped newline and report `LEX_ERR_UNTERMINATED_*`, per `literals.md`. Fixes the missing-quote recovery footgun.
- **[BUG/S] integer-literal overflow** — `eval_lit_int` accumulates into `u64` with a pre-multiply overflow check and rejects literals past `2^64-1`; the full unsigned range round-trips via a same-size bit reinterpret.
- **[DESIGN/M] OOM self-masking** — every `push_*`/`*_buf` allocation failure routes through a sticky `fatal` flag (independent of `panic`) and emits the OOM diagnostic once, unconditionally; each `*_buf_flush` reports the count actually appended (pool delta), so a partial flush yields a bounded slice; `parse()` returns the fatal flag and the driver refuses to walk the AST when set.
- **[SMELL/M] twin `$if`/`$or` parsers** — factored the chain into one `parse_comptime_chain` skeleton parameterized over a `ComptimeBodyFn` body-parser (decl vs stmt scope); the `use`/`fwd` `[alias:] path;` tail collapses into `parse_alias_path`.
- **[CLEANUP/S]** — removed the dead postfix re-application in the Pratt loop; made `bin_op_from_kind`'s `=` case explicit so an unmapped infix operator reports instead of silently becoming an assignment; fixed the `parse_fin_stmt` doc.
- **docs** — `grammar.md` corrected for strings, bindings, and the postfix-`[` rule to match the locked design docs.

## Deferred (tracked as follow-ups)
- **[SMELL/L] Vector[T] consolidation** (~1000 lines) → #1271 — too large to keep this PR reviewable. This PR already removed the OOM divergence the finding warned about, so it is now a pure code-size consolidation.
- **comptime signed/unsigned comparison of u64-range constants** → #1272 — `literals.md` does not settle comptime integer signedness (a spec decision). The silent wrap is fixed here.
- **variable-index-then-call** (`table[i]()`) → #1270 — the complete resolve-deferral fix for the residual bare-identifier ambiguity.
- **bare-`$or`-must-be-last** — spec-silent on whether mid-chain placement is an error; recommendation left on #1247.

## Tests
Inline `test` blocks for every bug fix (fail-before / pass-after): lexer newline termination, integer-overflow boundary, index-then-call vs generic-call shape, binding grammar, and the shared `$if`/`$or` chain at both scopes. `mach build .` clean, `mach test .` = 245 pass, self-host fixpoint byte-identical.

Refs #1247 (deferred items tracked in #1270, #1271, #1272)