### PR TITLE
fix(sema): address #1248 audit — generics holes, fwd re-export, truncation, type-universe scaling

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1690,30 +1690,100 @@ fun run_resolve_one(p: *Project, mid: sess.ModuleId) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
+# build_resolve_deps: the dependency surface resolve sees for module `m` — its
+# direct deps plus the transitive closure of the modules those deps re-export as
+# a `fwd` module alias. a re-exported module is nameable from `m` (as
+# `dep.alias`), so its exports must be present in the dep set or the re-export
+# resolves to nothing downstream. all closure members are earlier in topo order
+# and thus already resolved.
 fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps, str] {
     var deps: resolve.ResolveDeps;
     deps.entries = nil;
     deps.count   = 0;
     if (m.dep_count == 0) { ret ok[resolve.ResolveDeps, str](deps); }
 
-    val r: Result[*resolve.ModuleExports, str] = allocate[resolve.ModuleExports](p.s.alloc, m.dep_count::usize);
-    if (is_err[*resolve.ModuleExports, str](r)) { ret err[resolve.ResolveDeps, str](unwrap_err[*resolve.ModuleExports, str](r)); }
-    deps.entries = unwrap_ok[*resolve.ModuleExports, str](r);
-    deps.count   = m.dep_count;
+    val vr: Result[*bool, str] = allocate[bool](p.s.alloc, p.module_len::usize);
+    if (is_err[*bool, str](vr)) { ret err[resolve.ResolveDeps, str](unwrap_err[*bool, str](vr)); }
+    val visited: *bool = unwrap_ok[*bool, str](vr);
+    var vi: u32 = 0;
+    for (vi < p.module_len) { visited[vi] = false; vi = vi + 1; }
+
+    val lr: Result[*sess.ModuleId, str] = allocate[sess.ModuleId](p.s.alloc, p.module_len::usize);
+    if (is_err[*sess.ModuleId, str](lr)) {
+        deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+        ret err[resolve.ResolveDeps, str](unwrap_err[*sess.ModuleId, str](lr));
+    }
+    val list: *sess.ModuleId = unwrap_ok[*sess.ModuleId, str](lr);
+    var list_len: u32 = 0;
 
     var i: u32 = 0;
     for (i < m.dep_count) {
-        val dep_id: sess.ModuleId = m.deps[i];
+        val d: sess.ModuleId = m.deps[i];
+        if (d::u32 < p.module_len && !visited[d::u32]) {
+            visited[d::u32] = true;
+            list[list_len] = d;
+            list_len = list_len + 1;
+        }
+        i = i + 1;
+    }
+
+    var head: u32 = 0;
+    for (head < list_len) {
+        add_reexport_targets(p, list[head], visited, list, ?list_len);
+        head = head + 1;
+    }
+
+    val r: Result[*resolve.ModuleExports, str] = allocate[resolve.ModuleExports](p.s.alloc, list_len::usize);
+    if (is_err[*resolve.ModuleExports, str](r)) {
+        deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
+        deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+        ret err[resolve.ResolveDeps, str](unwrap_err[*resolve.ModuleExports, str](r));
+    }
+    deps.entries = unwrap_ok[*resolve.ModuleExports, str](r);
+    deps.count   = list_len;
+
+    var k: u32 = 0;
+    for (k < list_len) {
+        val dep_id: sess.ModuleId = list[k];
         val dep:    *ModuleEntry = ?p.modules[dep_id::u32];
         val mx_r: Result[resolve.ModuleExports, str] = build_module_exports(p, dep_id, dep);
         if (is_err[resolve.ModuleExports, str](mx_r)) {
             free_resolve_deps(p.s.alloc, ?deps);
+            deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
+            deallocate[bool](p.s.alloc, visited, p.module_len::usize);
             ret err[resolve.ResolveDeps, str](unwrap_err[resolve.ModuleExports, str](mx_r));
         }
-        deps.entries[i] = unwrap_ok[resolve.ModuleExports, str](mx_r);
+        deps.entries[k] = unwrap_ok[resolve.ModuleExports, str](mx_r);
+        k = k + 1;
+    }
+
+    deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
+    deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+    ret ok[resolve.ResolveDeps, str](deps);
+}
+
+# add_reexport_targets: append every module that `mid` re-exports as a `fwd`
+# module alias — a pub SYM_USE among its resolved symbols, whose slot names the
+# target module — to `list`, marking each in `visited` so the closure never
+# revisits a module.
+fun add_reexport_targets(p: *Project, mid: sess.ModuleId, visited: *bool, list: *sess.ModuleId, list_len: *u32) {
+    val dep: *ModuleEntry = ?p.modules[mid::u32];
+    if (!dep.resolved) { ret; }
+    val rr: *resolve.ResolveResult = ?dep.resolve_result;
+    if (rr.symbols == nil) { ret; }
+    var i: u32 = 0;
+    for (i < rr.pub_count) {
+        val s: *resolve.Symbol = ?rr.symbols[i];
+        if (s.kind == resolve.SYM_USE) {
+            val tgt: sess.ModuleId = s.slot::sess.ModuleId;
+            if (tgt::u32 < p.module_len && !visited[tgt::u32]) {
+                visited[tgt::u32] = true;
+                list[@list_len] = tgt;
+                @list_len = @list_len + 1;
+            }
+        }
         i = i + 1;
     }
-    ret ok[resolve.ResolveDeps, str](deps);
 }
 
 fun build_module_exports(p: *Project, dep_id: sess.ModuleId, dep: *ModuleEntry) Result[resolve.ModuleExports, str] {
@@ -1737,6 +1807,7 @@ fun build_module_exports(p: *Project, dep_id: sess.ModuleId, dep: *ModuleEntry) 
         ps.kind   = sym.kind;
         ps.name   = sym.name;
         ps.decl   = sym.decl;
+        ps.slot   = sym.slot;
         ps.origin = sym.origin;
         syms[i] = ps;
         i = i + 1;

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -698,3 +698,30 @@ test "diagnostics: unresolved type name names the type and suggests a near match
     sess.dnit(?s);
     ret 0;
 }
+
+test "sema: pointer reinterpret legality follows the target pointer width (#1248)" {
+    var alloc: Allocator;
+    val srr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](srr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](srr);
+    var es: EditorSession = init(?s);
+
+    # a `*u8` reinterpreted to u32 is legal exactly when a pointer is 4 bytes;
+    # byte_size must read the width from the target, not a hardcoded 8.
+    val fr: Result[src.FileId, str] = open(?es, "pw.mach",
+        "fun main() i64 { var p: *u8; var x: u32; x = p:~u32; ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val d4: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 4);
+    if (is_err[*diag.DiagList, str](d4)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag_has(unwrap_ok[*diag.DiagList, str](d4), "bit reinterpret")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    val d8: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](d8)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](d8), "bit reinterpret")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -579,6 +579,138 @@ fun t_run_sema(es: *EditorSession, fid: src.FileId, pw: u32) Result[*diag.DiagLi
     ret ok[*diag.DiagList, str](?es.s.diags);
 }
 
+# t_resolve_deps: name-resolve an open buffer against an explicit dependency set
+# (the editor's own `resolve` always uses an empty one), caching and returning
+# the ResolveResult. test-only, for cross-module scenarios.
+fun t_resolve_deps(es: *EditorSession, fid: src.FileId, deps: *res.ResolveDeps) Result[*res.ResolveResult, str] {
+    val b: *Buffer = slot(es, fid);
+    if (b == nil || !b.in_use) { ret err[*res.ResolveResult, str]("editor: buffer not open"); }
+    if (b.a == nil) {
+        val pr: Result[*ast.Ast, str] = parse(es, fid);
+        if (is_err[*ast.Ast, str](pr)) { ret err[*res.ResolveResult, str](unwrap_err[*ast.Ast, str](pr)); }
+    }
+    if (b.rr != nil) {
+        res.dnit_result(b.rr);
+        deallocate[res.ResolveResult](es.alloc, b.rr, 1);
+        b.rr = nil;
+    }
+    seed_ctx(es, b);
+
+    val rr_r: Result[res.ResolveResult, str] = res.resolve(es.s, b.a, deps, ?b.ctx, fid::sess.ModuleId);
+    if (is_err[res.ResolveResult, str](rr_r)) { ret err[*res.ResolveResult, str](unwrap_err[res.ResolveResult, str](rr_r)); }
+
+    val sr: Result[*res.ResolveResult, str] = allocate[res.ResolveResult](es.alloc, 1);
+    if (is_err[*res.ResolveResult, str](sr)) {
+        var local: res.ResolveResult = unwrap_ok[res.ResolveResult, str](rr_r);
+        res.dnit_result(?local);
+        ret sr;
+    }
+    val slot_rr: *res.ResolveResult = unwrap_ok[*res.ResolveResult, str](sr);
+    @slot_rr = unwrap_ok[res.ResolveResult, str](rr_r);
+    b.rr = slot_rr;
+    ret ok[*res.ResolveResult, str](slot_rr);
+}
+
+# t_exports: snapshot an already-resolved buffer's pub surface as a
+# ModuleExports keyed by `fqn`, mirroring the driver's build_module_exports
+# (slot included) so a dependent buffer can resolve against it. test-only; the
+# returned `symbols` array is owned by the caller.
+fun t_exports(es: *EditorSession, fid: src.FileId, fqn: str) Result[res.ModuleExports, str] {
+    val b: *Buffer = slot(es, fid);
+    if (b == nil || b.rr == nil) { ret err[res.ModuleExports, str]("editor: buffer not resolved"); }
+    val fqn_r: Result[intern.StrId, str] = intern.intern(?es.s.interner, fqn);
+    if (is_err[intern.StrId, str](fqn_r)) { ret err[res.ModuleExports, str](unwrap_err[intern.StrId, str](fqn_r)); }
+
+    var mx: res.ModuleExports;
+    mx.path    = unwrap_ok[intern.StrId, str](fqn_r);
+    mx.module  = fid::sess.ModuleId;
+    mx.symbols = nil;
+    mx.count   = 0;
+    val pcount: u32 = b.rr.pub_count;
+    if (pcount == 0) { ret ok[res.ModuleExports, str](mx); }
+
+    val r: Result[*res.PublicSymbol, str] = allocate[res.PublicSymbol](es.alloc, pcount::usize);
+    if (is_err[*res.PublicSymbol, str](r)) { ret err[res.ModuleExports, str](unwrap_err[*res.PublicSymbol, str](r)); }
+    val syms: *res.PublicSymbol = unwrap_ok[*res.PublicSymbol, str](r);
+    var i: u32 = 0;
+    for (i < pcount) {
+        val sym: *res.Symbol = ?b.rr.symbols[i];
+        var ps: res.PublicSymbol;
+        ps.kind   = sym.kind;
+        ps.name   = sym.name;
+        ps.decl   = sym.decl;
+        ps.slot   = sym.slot;
+        ps.origin = sym.origin;
+        syms[i] = ps;
+        i = i + 1;
+    }
+    mx.symbols = syms;
+    mx.count   = pcount;
+    ret ok[res.ModuleExports, str](mx);
+}
+
+test "resolve: a re-exported module alias resolves through downstream (#1248)" {
+    var alloc: Allocator;
+    val srr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](srr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](srr);
+    var es: EditorSession = init(?s);
+
+    # inner exports a type `Thing`; surface re-exports the inner module as alias
+    # `al`; consumer imports `t.surface.al` and names `al.Thing` in type
+    # position. before the fix the surface's SYM_USE slot was dropped through the
+    # export pipeline, so the consumer imported `al` as a plain symbol and the
+    # type path reported `expected a module alias before .`.
+    val ir: Result[src.FileId, str] = open(?es, "inner.mach", "pub rec Thing { x: i64; }\n");
+    if (is_err[src.FileId, str](ir)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val inner: src.FileId = unwrap_ok[src.FileId, str](ir);
+
+    var empty: res.ResolveDeps;
+    empty.entries = nil;
+    empty.count   = 0;
+    if (is_err[*res.ResolveResult, str](t_resolve_deps(?es, inner, ?empty))) { dnit(?es); sess.dnit(?s); ret 1; }
+    val ex_inner_r: Result[res.ModuleExports, str] = t_exports(?es, inner, "t.inner");
+    if (is_err[res.ModuleExports, str](ex_inner_r)) { dnit(?es); sess.dnit(?s); ret 1; }
+    var ex_inner: res.ModuleExports = unwrap_ok[res.ModuleExports, str](ex_inner_r);
+
+    val fr: Result[src.FileId, str] = open(?es, "surface.mach", "fwd al: t.inner;\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val surface: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    var sdeps: res.ResolveDeps;
+    sdeps.entries = ?ex_inner;
+    sdeps.count   = 1;
+    if (is_err[*res.ResolveResult, str](t_resolve_deps(?es, surface, ?sdeps))) { dnit(?es); sess.dnit(?s); ret 1; }
+    val ex_surface_r: Result[res.ModuleExports, str] = t_exports(?es, surface, "t.surface");
+    if (is_err[res.ModuleExports, str](ex_surface_r)) { dnit(?es); sess.dnit(?s); ret 1; }
+    var ex_surface: res.ModuleExports = unwrap_ok[res.ModuleExports, str](ex_surface_r);
+
+    val cr: Result[src.FileId, str] = open(?es, "consumer.mach",
+        "use al: t.surface.al;\nfun take(p: al.Thing) i64 { ret p.x; }\n");
+    if (is_err[src.FileId, str](cr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val consumer: src.FileId = unwrap_ok[src.FileId, str](cr);
+
+    var cdeps_arr: [2]res.ModuleExports;
+    cdeps_arr[0] = ex_surface;
+    cdeps_arr[1] = ex_inner;
+    var cdeps: res.ResolveDeps;
+    cdeps.entries = ?cdeps_arr[0];
+    cdeps.count   = 2;
+
+    diag.dnit(?es.s.diags);
+    es.s.diags = diag.init(es.alloc);
+    if (is_err[*res.ResolveResult, str](t_resolve_deps(?es, consumer, ?cdeps))) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    val ok_clean: bool = !diag.has_errors(?es.s.diags);
+    deallocate[res.PublicSymbol](es.alloc, ex_inner.symbols, ex_inner.count::usize);
+    deallocate[res.PublicSymbol](es.alloc, ex_surface.symbols, ex_surface.count::usize);
+    if (!ok_clean) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "sema: a generic parameter nested two anonymous-aggregate levels deep is substituted (#1248)" {
     var alloc: Allocator;
     val srr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -61,6 +61,8 @@ use diag:    mach.lang.diagnostic;
 use lexer:   mach.lang.fe.lexer;
 use parser:  mach.lang.fe.parser;
 use res:     mach.lang.fe.resolve;
+use sema:    mach.lang.fe.sema;
+use ctxm:    mach.lang.fe.sema.context;
 use comptime: mach.lang.fe.comptime;
 use ast:     mach.lang.fe.ast;
 use id:      mach.lang.fe.ast.id;
@@ -530,6 +532,119 @@ fun diag_note_has(list: *diag.DiagList, sub: str) bool {
         i = i + 1;
     }
     ret false;
+}
+
+# diag_count: the number of diagnostics on `list` whose message contains `sub`.
+fun diag_count(list: *diag.DiagList, sub: str) u32 {
+    var n: u32 = 0;
+    var i: usize = 0;
+    for (i < list.len) {
+        if (str_contains(list.items[i].message, sub)) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# t_run_sema: parse, resolve, and run full semantic analysis over one open
+# buffer in isolation (empty dependency set), with the comptime context's
+# pointer width forced to `pw`. every diagnostic lands on the session DiagList,
+# which is reset on entry and returned. test-only: drives the front-end the way
+# the build does for a single self-contained module.
+fun t_run_sema(es: *EditorSession, fid: src.FileId, pw: u32) Result[*diag.DiagList, str] {
+    val rr_r: Result[*res.ResolveResult, str] = resolve(es, fid);
+    if (is_err[*res.ResolveResult, str](rr_r)) { ret err[*diag.DiagList, str](unwrap_err[*res.ResolveResult, str](rr_r)); }
+    val rr: *res.ResolveResult = unwrap_ok[*res.ResolveResult, str](rr_r);
+
+    val b: *Buffer = slot(es, fid);
+    if (b == nil) { ret err[*diag.DiagList, str]("editor: buffer not open"); }
+    b.ctx.pointer_width = pw;
+
+    # sema's generic machinery reads a declaration's origin AST through the
+    # session registry, so the buffer's own module must be registered first.
+    val reg: Result[bool, str] = sess.register_module_ast(es.s, fid::sess.ModuleId, b.a);
+    if (is_err[bool, str](reg)) { ret err[*diag.DiagList, str](unwrap_err[bool, str](reg)); }
+
+    diag.dnit(?es.s.diags);
+    es.s.diags = diag.init(es.alloc);
+
+    var deps: ctxm.SemaDeps;
+    deps.entries = nil;
+    deps.count   = 0;
+
+    val sres: Result[ctxm.SemaResult, str] = sema.sema(es.s, b.a, rr, ?deps, ?b.ctx, fid::sess.ModuleId);
+    if (is_err[ctxm.SemaResult, str](sres)) { ret err[*diag.DiagList, str](unwrap_err[ctxm.SemaResult, str](sres)); }
+    var sr: ctxm.SemaResult = unwrap_ok[ctxm.SemaResult, str](sres);
+    sema.dnit_result(?sr);
+
+    ret ok[*diag.DiagList, str](?es.s.diags);
+}
+
+test "sema: a generic parameter nested two anonymous-aggregate levels deep is substituted (#1248)" {
+    var alloc: Allocator;
+    val srr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](srr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](srr);
+    var es: EditorSession = init(?s);
+
+    val fr: Result[src.FileId, str] = open(?es, "box.mach",
+        "rec Box[T] { outer: rec { inner: rec { v: T; }; }; }\nfun main() i64 { var b: Box[u32]; b.outer.inner.v = 5; ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    # before the fix the placeholder T leaked into Box[u32], so the concrete
+    # assignment reported `expected T, found i64`. it must now type clean.
+    if (diag.has_errors(unwrap_ok[*diag.DiagList, str](dr))) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: an array length above the u32 range is rejected, not truncated (#1248)" {
+    var alloc: Allocator;
+    val srr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](srr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](srr);
+    var es: EditorSession = init(?s);
+
+    # 0x100000001 truncates to 1 in u32; before the fix the array silently
+    # interned as [1]u8 with no diagnostic. it must now be rejected outright.
+    val fr: Result[src.FileId, str] = open(?es, "arr.mach",
+        "fun main() i64 { var a: [0x100000001]u8; ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "array length exceeds")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: a module-scope unannotated val reports an initializer error once (#1248)" {
+    var alloc: Allocator;
+    val srr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](srr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](srr);
+    var es: EditorSession = init(?s);
+
+    # the decl-type pass and the body pass both walked an unannotated
+    # initializer, so the operand-type error was reported verbatim twice.
+    val fr: Result[src.FileId, str] = open(?es, "dbl.mach", "val bad = 1 + nil;\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag_count(unwrap_ok[*diag.DiagList, str](dr), "incompatible operand types") != 1) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
 }
 
 test "diagnostics: unresolved identifier names the symbol and suggests a near match" {

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -367,8 +367,13 @@ fun init_context(
 
     rc.imported_cache = map.init[u64, SymbolId](s.alloc, map.hash_u64, map.eq_u64);
 
+    # every allocation past this point is owned by the context; on a failure
+    # dnit_context tears down whatever has been allocated so far (the array
+    # handles are nil and the cache is initialised), leaving no partial state
+    # leaked on the OOM path.
     val sa: Result[*Symbol, str] = allocate[Symbol](s.alloc, INITIAL_SYMBOLS_CAP::usize);
     if (is_err[*Symbol, str](sa)) {
+        dnit_context(rc);
         ret err[bool, str](unwrap_err[*Symbol, str](sa));
     }
     rc.symbols = unwrap_ok[*Symbol, str](sa);
@@ -376,9 +381,7 @@ fun init_context(
 
     val sca: Result[*Scope, str] = allocate[Scope](s.alloc, INITIAL_SCOPES_CAP::usize);
     if (is_err[*Scope, str](sca)) {
-        deallocate[Symbol](s.alloc, rc.symbols, rc.sym_cap::usize);
-        rc.symbols = nil;
-        rc.sym_cap = 0;
+        dnit_context(rc);
         ret err[bool, str](unwrap_err[*Scope, str](sca));
     }
     rc.scopes    = unwrap_ok[*Scope, str](sca);
@@ -386,19 +389,19 @@ fun init_context(
 
     if (a.expr_len > 0) {
         val r: Result[*SymbolId, str] = allocate[SymbolId](s.alloc, a.expr_len);
-        if (is_err[*SymbolId, str](r)) { ret err[bool, str](unwrap_err[*SymbolId, str](r)); }
+        if (is_err[*SymbolId, str](r)) { dnit_context(rc); ret err[bool, str](unwrap_err[*SymbolId, str](r)); }
         rc.expr_resolved = unwrap_ok[*SymbolId, str](r);
         fill_nil(rc.expr_resolved, a.expr_len::u32);
     }
     if (a.type_len > 0) {
         val r: Result[*SymbolId, str] = allocate[SymbolId](s.alloc, a.type_len);
-        if (is_err[*SymbolId, str](r)) { ret err[bool, str](unwrap_err[*SymbolId, str](r)); }
+        if (is_err[*SymbolId, str](r)) { dnit_context(rc); ret err[bool, str](unwrap_err[*SymbolId, str](r)); }
         rc.type_resolved = unwrap_ok[*SymbolId, str](r);
         fill_nil(rc.type_resolved, a.type_len::u32);
     }
     if (a.decl_len > 0) {
         val r: Result[*SymbolId, str] = allocate[SymbolId](s.alloc, a.decl_len);
-        if (is_err[*SymbolId, str](r)) { ret err[bool, str](unwrap_err[*SymbolId, str](r)); }
+        if (is_err[*SymbolId, str](r)) { dnit_context(rc); ret err[bool, str](unwrap_err[*SymbolId, str](r)); }
         rc.decl_symbol = unwrap_ok[*SymbolId, str](r);
         fill_nil(rc.decl_symbol, a.decl_len::u32);
     }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -117,11 +117,15 @@ pub rec Symbol {
 # kind:   one of SYM_*
 # name:   interned identifier
 # decl:   DeclId in the owning module's Ast
+# slot:   kind-dependent payload, mirrored from the source Symbol; for a
+#         re-exported module alias (SYM_USE) it carries the target ModuleId so a
+#         downstream consumer can resolve through the `fwd`
 # origin: ModuleId of the owning module (= the dep this entry came from)
 pub rec PublicSymbol {
     kind:   SymKind;
     name:   intern.StrId;
     decl:   id.DeclId;
+    slot:   u32;
     origin: sess.ModuleId;
 }
 
@@ -850,15 +854,24 @@ fun bind_imported_symbol(rc: *ResolveContext, decl_id: id.DeclId, bind_span: tok
     ret ok[bool, str](true);
 }
 
-# returns a SYM_IMPORTED SymbolId for `ps`, reusing the cached one when an
-# earlier use-site already imported the same (origin, decl) pair.
+# returns a Symbol for `ps`, reusing the cached one when an earlier use-site
+# already imported the same (origin, decl) pair. an ordinary export degrades to
+# a plain SYM_IMPORTED reference; a re-exported module alias (SYM_USE) keeps its
+# kind and target-module slot so a downstream consumer can resolve through the
+# `fwd` (the slot is a project-wide ModuleId, shared across the one build).
 fun imported_symbol_for(rc: *ResolveContext, ps: *PublicSymbol) Result[SymbolId, str] {
     val key: u64 = (ps.origin::u64 << 32) | ps.decl::u64;
     val cached: Result[*SymbolId, str] = map.get[u64, SymbolId](?rc.imported_cache, ?key);
     if (is_ok[*SymbolId, str](cached)) {
         ret ok[SymbolId, str](@unwrap_ok[*SymbolId, str](cached));
     }
-    val r: Result[SymbolId, str] = add_symbol(rc, SYM_IMPORTED, 0, ps.name, ps.decl, 0, ps.origin);
+    var kind: SymKind = SYM_IMPORTED;
+    var slot: u32     = 0;
+    if (ps.kind == SYM_USE) {
+        kind = SYM_USE;
+        slot = ps.slot;
+    }
+    val r: Result[SymbolId, str] = add_symbol(rc, kind, 0, ps.name, ps.decl, slot, ps.origin);
     if (is_err[SymbolId, str](r)) { ret r; }
     val sid: SymbolId = unwrap_ok[SymbolId, str](r);
     val ins: Result[bool, str] = map.insert[u64, SymbolId](?rc.imported_cache, key, sid);
@@ -976,7 +989,11 @@ fun bind_member_qualified(rc: *ResolveContext, eid: id.ExprId, member: *expr.Exp
         ret ok[bool, str](true);
     }
 
-    val r_sym: Result[SymbolId, str] = add_symbol(rc, SYM_IMPORTED, 0, leaf_id, ps.decl, 0, ps.origin);
+    # reuse the imported-symbol cache instead of minting a fresh Symbol per
+    # qualified reference, the exact use-case the cache documents; this also
+    # preserves a re-exported module alias as SYM_USE so `alias.member` chains
+    # through a `fwd`.
+    val r_sym: Result[SymbolId, str] = imported_symbol_for(rc, ps);
     if (is_err[SymbolId, str](r_sym)) { ret err[bool, str](unwrap_err[SymbolId, str](r_sym)); }
     rc.expr_resolved[eid] = unwrap_ok[SymbolId, str](r_sym);
     ret ok[bool, str](true);

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -677,9 +677,10 @@ fun check_return_stmt(sc: *ctxm.SemaContext, ret_ty: type.TypeId, value: id.Expr
 }
 
 # evaluates a comptime-branch condition through the shared comptime
-# evaluator. an empty cond (`$or { }`) is the unconditional final arm;
-# evaluation failures and non-bool results report a diagnostic and yield
-# false (the arm is treated as inactive).
+# evaluator. an empty cond (`$or { }`) is the unconditional final arm; an
+# evaluation failure or a non-bool result yields false (the arm is treated as
+# inactive) without a diagnostic — resolve's matching check runs first and
+# already reported it, so reporting again here would duplicate it.
 fun comptime_branch_active(sc: *ctxm.SemaContext, br: *decl.ComptimeBranch) Result[bool, str] {
     if (br.cond == id.EXPR_NIL) { ret ok[bool, str](true); }
     val r: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, br.cond, ?sc.s.interner);
@@ -702,7 +703,9 @@ fun build_result(sc: *ctxm.SemaContext) Result[ctxm.SemaResult, str] {
     out.decl_count       = sc.a.decl_len::u32;
 
     # ownership of the three parallel arrays passes to the result; clear the
-    # context handles so dnit_context releases only the field-table storage.
+    # context handles so they are not double-freed (dnit_context frees exactly
+    # these arrays — the field tables it once owned now live in the
+    # session-global type interner and outlive the context).
     sc.expr_type        = nil;
     sc.type_resolved_ty = nil;
     sc.decl_type        = nil;

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -88,7 +88,6 @@ fwd ctxm.field_table_begin;
 fwd ctxm.field_table_push;
 fwd ctxm.field_table_for;
 fwd ctxm.field_lookup;
-fwd ctxm.next_anon_ordinal;
 
 # sema: runs semantic analysis on one module, allocating the three parallel TypeId arrays, resolving every syntactic type, computing every decl's declared type, then walking every decl body inferring and checking expressions; diagnostics are pushed into the session and sema does not halt on errors.
 # ---
@@ -177,7 +176,6 @@ fun init_context(
     sc.type_resolved_ty = nil;
     sc.decl_type        = nil;
 
-    sc.anon_counter = 0;
     sc.callee_eid   = id.EXPR_NIL;
 
     if (a.expr_len > 0) {

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -590,7 +590,7 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
         # not foldable. test by folding it through the comptime evaluator.
         if (sym.kind == resolve.SYM_VAL || sym.kind == resolve.SYM_IMPORTED) {
             val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
-            if (is_err[comptime.CTValue, str](ev) && !arg_names_module_const_sym(sym)) {
+            if (is_err[comptime.CTValue, str](ev) && !check.imported_module_const_sym(sc, sym)) {
                 ctxm.report(sc, e.span, "comptime `$if` gate cannot reference a runtime value");
             }
             ret;
@@ -605,7 +605,7 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
         val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
         if (is_err[comptime.CTValue, str](ev)) {
             val so: Option[*resolve.Symbol] = ctxm.symbol_for_expr(sc, eid);
-            if (is_none[*resolve.Symbol](so) || !arg_names_module_const_sym(unwrap[*resolve.Symbol](so))) {
+            if (is_none[*resolve.Symbol](so) || !check.imported_module_const_sym(sc, unwrap[*resolve.Symbol](so))) {
                 ctxm.report(sc, e.span, "comptime `$if` gate is not a compile-time constant");
             }
         }
@@ -616,13 +616,6 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
     # gate. report against the whole subexpression.
     ctxm.report(sc, e.span, "comptime `$if` gate is not a compile-time constant");
     ret;
-}
-
-# reports whether a symbol names a module-origin constant (an import, or a
-# module-level `val`) whose value lives in the defining module's comptime context
-# — foldable at lowering even when sema cannot fold it here.
-fun arg_names_module_const_sym(sym: *resolve.Symbol) bool {
-    ret sym.kind == resolve.SYM_IMPORTED;
 }
 
 # types a local val/var: records its declared (or inferred) type in

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -373,10 +373,15 @@ fun test_return_type(sc: *ctxm.SemaContext) type.TypeId {
 # declared (or inferred) type recorded in decl_type by the decl-type pass.
 fun infer_binding_init(sc: *ctxm.SemaContext, did: id.DeclId, d: *decl.Decl) Result[bool, str] {
     if (d.data.bind.init == id.EXPR_NIL) { ret ok[bool, str](true); }
+    # an unannotated binding's initializer was already inferred — and any error
+    # in it already reported — by the decl-type pass, which records its type in
+    # decl_type and expr_type. re-inferring here would duplicate every
+    # diagnostic verbatim, so only an annotated binding (whose decl pass never
+    # walked the initializer) needs the body-pass infer-and-check.
+    if (d.data.bind.ty == id.TYPE_NIL) { ret ok[bool, str](true); }
     val actual: type.TypeId = infer.infer_expr(sc, d.data.bind.init);
     val expected: type.TypeId = sc.decl_type[did];
-    if (expected != type.TYPE_NIL && expected != type.TYPE_ERROR
-        && actual != type.TYPE_ERROR && d.data.bind.ty != id.TYPE_NIL) {
+    if (expected != type.TYPE_NIL && expected != type.TYPE_ERROR && actual != type.TYPE_ERROR) {
         check_binding(sc, expected, d.data.bind.init, actual, d.span);
     }
     ret ok[bool, str](true);

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -218,17 +218,32 @@ pub fun check_comptime_call(sc: *sema.SemaContext, callee_sig: ty.TypeId, callee
     ret ok_all;
 }
 
-# reports whether `eid` names a constant IMPORTED from another module (a bare
-# import or a module-qualified member `alias.CONST`, both SYM_IMPORTED). such a
-# value lives only in the defining module's comptime context, which sema does not
-# hold, so its constness fold is deferred to lowering. a local or module-level
-# SYM_VAL is NOT deferred: a comptime one folds in the eager check here, and a
-# non-foldable (runtime) one is reported eagerly rather than slipping through an
-# uninstantiated template whose body never lowers.
+# reports whether `eid` names a constant IMPORTED from another module — an
+# imported binding that resolves to a module-level `val` in its origin module.
+# such a value lives only in the defining module's comptime context, which sema
+# does not hold, so its constness fold is deferred to lowering. a local or
+# module-level SYM_VAL is NOT deferred: a comptime one folds in the eager check
+# here, and a non-foldable (runtime) one is reported eagerly rather than slipping
+# through an uninstantiated template whose body never lowers.
 fun arg_names_module_constant(sc: *sema.SemaContext, eid: id.ExprId) bool {
     val so: Option[*resolve.Symbol] = sema.symbol_for_expr(sc, eid);
     if (is_none[*resolve.Symbol](so)) { ret false; }
-    ret unwrap[*resolve.Symbol](so).kind == resolve.SYM_IMPORTED;
+    ret imported_module_const_sym(sc, unwrap[*resolve.Symbol](so));
+}
+
+# reports whether `sym` is an import that resolves to a module-level `val` in its
+# origin module — the only imports whose constness fold can be deferred to
+# lowering. SYM_IMPORTED alone is too broad: it covers every imported symbol
+# (functions, records, runtime bindings included), so an imported non-constant
+# used as a `$if` gate or `$`-argument would otherwise pass sema and then fail
+# span-less at lowering. reads the origin AST through the session registry.
+pub fun imported_module_const_sym(sc: *sema.SemaContext, sym: *resolve.Symbol) bool {
+    if (sym.kind != resolve.SYM_IMPORTED) { ret false; }
+    val a: *ast.Ast = sess.module_ast(sc.s, sym.origin);
+    if (a == nil) { ret false; }
+    val d_opt: Option[*adecl.Decl] = ast.get_decl(a, sym.decl);
+    if (is_none[*adecl.Decl](d_opt)) { ret false; }
+    ret unwrap[*adecl.Decl](d_opt).kind == adecl.DECL_KIND_VAL;
 }
 
 # walks `eid` reporting whether any leaf identifier resolves to a comptime value

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -515,11 +515,19 @@ pub fun is_primitive_numeric(t: ty.TypeId) bool {
     ret is_numeric(t);
 }
 
+# the target's pointer width in bytes, read from the comptime context the
+# driver seeds with the active target's parameters. cast/reinterpret legality
+# is a target-dependent type rule, so the width must come from the target layer
+# rather than a hardcoded constant.
+fun ptr_width(sc: *sema.SemaContext) u32 {
+    ret sc.ctx.pointer_width;
+}
+
 # returns the byte size of a type, resolving pointers/arrays/records via the
-# interner. pointer width is fixed at 8 (the only currently supported
-# targets are 64-bit); records and unions report 0 because their layout is
-# not computed in sema (the backend owns layout). a 0 result signals
-# "size unknown" and disables same-size cast reinterpretation.
+# interner. pointer/function values are pointer-sized, read from the target's
+# pointer width; records and unions report 0 because their layout is not
+# computed in sema (the backend owns layout). a 0 result signals "size unknown"
+# and disables same-size cast reinterpretation.
 # ---
 # sc: the active sema context
 # t:  a TypeId
@@ -529,15 +537,15 @@ pub fun byte_size(sc: *sema.SemaContext, t: ty.TypeId) u32 {
     if (t == ty.TYPE_U16 || t == ty.TYPE_I16) { ret 2; }
     if (t == ty.TYPE_U32 || t == ty.TYPE_I32 || t == ty.TYPE_F32) { ret 4; }
     if (t == ty.TYPE_U64 || t == ty.TYPE_I64 || t == ty.TYPE_F64) { ret 8; }
-    if (t == ty.TYPE_PTR) { ret 8; }
+    if (t == ty.TYPE_PTR) { ret ptr_width(sc); }
 
     val t_opt: Option[*ty.Type] = ty.get(?sc.s.types, t);
     if (is_none[*ty.Type](t_opt)) { ret 0; }
     val tp: *ty.Type = unwrap[*ty.Type](t_opt);
-    if (tp.kind == ty.TYPE_POINTER) { ret 8; }
+    if (tp.kind == ty.TYPE_POINTER) { ret ptr_width(sc); }
     # a function value is its code address, so it is pointer-sized and may be
     # bit-reinterpreted to/from a pointer (e.g. an erased `*u8` vtable slot).
-    if (tp.kind == ty.TYPE_FUN) { ret 8; }
+    if (tp.kind == ty.TYPE_FUN) { ret ptr_width(sc); }
     if (tp.kind == ty.TYPE_ARRAY) {
         # widen the multiply: a >4GiB array would wrap a u32 product and report a
         # wrong size to cast legality, so saturate to the 0 "unknown" sentinel.

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -299,7 +299,7 @@ pub fun check_index(sc: *sema.SemaContext, object: ty.TypeId, index: ty.TypeId, 
         ret none[ty.TypeId]();
     }
 
-    if (index != ty.TYPE_ERROR && !is_integer(index)) {
+    if (index != ty.TYPE_ERROR && !is_integer(sc, index)) {
         report(sc, span, "type mismatch: index must be an integer");
     }
     ret some[ty.TypeId](elem);
@@ -355,7 +355,7 @@ pub fun check_cast(sc: *sema.SemaContext, from: ty.TypeId, to: ty.TypeId, span: 
     if (from == to) { ret some[ty.TypeId](to); }
 
     # primitive numeric <-> primitive numeric conversion
-    if (is_primitive_numeric(from) && is_primitive_numeric(to)) {
+    if (is_primitive_numeric(sc, from) && is_primitive_numeric(sc, to)) {
         ret some[ty.TypeId](to);
     }
 
@@ -482,37 +482,41 @@ pub fun check_return(sc: *sema.SemaContext, fn_ret: ty.TypeId, value: ty.TypeId,
 # ret:  true when the condition is an integer primitive, false otherwise
 pub fun check_condition(sc: *sema.SemaContext, cond: ty.TypeId, span: token.Span) bool {
     if (cond == ty.TYPE_ERROR) { ret true; }
-    if (is_integer(cond)) { ret true; }
+    if (is_integer(sc, cond)) { ret true; }
     report_note(sc, span, "type mismatch: condition must be an integer",
         "mach has no `bool` type; comparisons yield an integer truth value");
     ret false;
 }
 
-# reports whether `t` is any numeric primitive (integer or float).
+# reports whether `t` is any numeric primitive (integer or float). delegates to
+# the shared kind-based predicate in the type layer.
 # ---
+# sc:  the active sema context
 # t:   a TypeId
 # ret: true for u8..u64, i8..i64, f32, f64
-pub fun is_numeric(t: ty.TypeId) bool {
-    ret is_integer(t) || t == ty.TYPE_F32 || t == ty.TYPE_F64;
+pub fun is_numeric(sc: *sema.SemaContext, t: ty.TypeId) bool {
+    ret ty.is_numeric(?sc.s.types, t);
 }
 
 # reports whether `t` is an integer primitive (any signed or unsigned width).
+# delegates to the shared kind-based predicate in the type layer.
 # ---
+# sc:  the active sema context
 # t:   a TypeId
 # ret: true for u8..u64 and i8..i64
-pub fun is_integer(t: ty.TypeId) bool {
-    ret t == ty.TYPE_U8  || t == ty.TYPE_U16 || t == ty.TYPE_U32 || t == ty.TYPE_U64
-     || t == ty.TYPE_I8  || t == ty.TYPE_I16 || t == ty.TYPE_I32 || t == ty.TYPE_I64;
+pub fun is_integer(sc: *sema.SemaContext, t: ty.TypeId) bool {
+    ret ty.is_integer(?sc.s.types, t);
 }
 
 # reports whether `t` is a primitive numeric type eligible for a numeric
 # cast. identical to `is_numeric`; named separately to mirror the cast-rule
 # vocabulary in the sema design.
 # ---
+# sc:  the active sema context
 # t:   a TypeId
 # ret: true for any integer or float primitive
-pub fun is_primitive_numeric(t: ty.TypeId) bool {
-    ret is_numeric(t);
+pub fun is_primitive_numeric(sc: *sema.SemaContext, t: ty.TypeId) bool {
+    ret is_numeric(sc, t);
 }
 
 # the target's pointer width in bytes, read from the comptime context the
@@ -533,20 +537,18 @@ fun ptr_width(sc: *sema.SemaContext) u32 {
 # t:  a TypeId
 # ret: the size in bytes, or 0 when the size is not known at this layer
 pub fun byte_size(sc: *sema.SemaContext, t: ty.TypeId) u32 {
-    if (t == ty.TYPE_U8  || t == ty.TYPE_I8)  { ret 1; }
-    if (t == ty.TYPE_U16 || t == ty.TYPE_I16) { ret 2; }
-    if (t == ty.TYPE_U32 || t == ty.TYPE_I32 || t == ty.TYPE_F32) { ret 4; }
-    if (t == ty.TYPE_U64 || t == ty.TYPE_I64 || t == ty.TYPE_F64) { ret 8; }
-    if (t == ty.TYPE_PTR) { ret ptr_width(sc); }
-
     val t_opt: Option[*ty.Type] = ty.get(?sc.s.types, t);
     if (is_none[*ty.Type](t_opt)) { ret 0; }
     val tp: *ty.Type = unwrap[*ty.Type](t_opt);
-    if (tp.kind == ty.TYPE_POINTER) { ret ptr_width(sc); }
-    # a function value is its code address, so it is pointer-sized and may be
-    # bit-reinterpreted to/from a pointer (e.g. an erased `*u8` vtable slot).
-    if (tp.kind == ty.TYPE_FUN) { ret ptr_width(sc); }
-    if (tp.kind == ty.TYPE_ARRAY) {
+    val k: ty.TypeKind = tp.kind;
+    if (k == ty.TYPE_U8  || k == ty.TYPE_I8)  { ret 1; }
+    if (k == ty.TYPE_U16 || k == ty.TYPE_I16) { ret 2; }
+    if (k == ty.TYPE_U32 || k == ty.TYPE_I32 || k == ty.TYPE_F32) { ret 4; }
+    if (k == ty.TYPE_U64 || k == ty.TYPE_I64 || k == ty.TYPE_F64) { ret 8; }
+    # a raw `ptr`, a typed `*T`, and a function value (a code address) are all
+    # pointer-sized, read from the target's pointer width.
+    if (k == ty.TYPE_PTR || k == ty.TYPE_POINTER || k == ty.TYPE_FUN) { ret ptr_width(sc); }
+    if (k == ty.TYPE_ARRAY) {
         # widen the multiply: a >4GiB array would wrap a u32 product and report a
         # wrong size to cast legality, so saturate to the 0 "unknown" sentinel.
         val total: u64 = byte_size(sc, tp.data.array.base)::u64 * tp.data.array.count::u64;
@@ -565,29 +567,28 @@ pub fun byte_size(sc: *sema.SemaContext, t: ty.TypeId) u32 {
 # t:  the type to describe
 # ret: a static, non-owning name for the type
 pub fun format_type(sc: *sema.SemaContext, t: ty.TypeId) str {
-    if (t == ty.TYPE_U8)  { ret "u8"; }
-    if (t == ty.TYPE_U16) { ret "u16"; }
-    if (t == ty.TYPE_U32) { ret "u32"; }
-    if (t == ty.TYPE_U64) { ret "u64"; }
-    if (t == ty.TYPE_I8)  { ret "i8"; }
-    if (t == ty.TYPE_I16) { ret "i16"; }
-    if (t == ty.TYPE_I32) { ret "i32"; }
-    if (t == ty.TYPE_I64) { ret "i64"; }
-    if (t == ty.TYPE_F32) { ret "f32"; }
-    if (t == ty.TYPE_F64) { ret "f64"; }
-    if (t == ty.TYPE_PTR) { ret "ptr"; }
     if (t == ty.TYPE_ERROR) { ret "<error>"; }
-
     val t_opt: Option[*ty.Type] = ty.get(?sc.s.types, t);
     if (is_none[*ty.Type](t_opt)) { ret "<type>"; }
-    val tp: *ty.Type = unwrap[*ty.Type](t_opt);
-    if (tp.kind == ty.TYPE_POINTER)       { ret "pointer"; }
-    if (tp.kind == ty.TYPE_ARRAY)         { ret "array"; }
-    if (tp.kind == ty.TYPE_FUN)           { ret "function"; }
-    if (tp.kind == ty.TYPE_REC)           { ret "record"; }
-    if (tp.kind == ty.TYPE_UNI)           { ret "union"; }
-    if (tp.kind == ty.TYPE_GENERIC_PARAM) { ret "generic"; }
-    if (tp.kind == ty.TYPE_INSTANCE)      { ret "instance"; }
+    val k: ty.TypeKind = unwrap[*ty.Type](t_opt).kind;
+    if (k == ty.TYPE_U8)  { ret "u8"; }
+    if (k == ty.TYPE_U16) { ret "u16"; }
+    if (k == ty.TYPE_U32) { ret "u32"; }
+    if (k == ty.TYPE_U64) { ret "u64"; }
+    if (k == ty.TYPE_I8)  { ret "i8"; }
+    if (k == ty.TYPE_I16) { ret "i16"; }
+    if (k == ty.TYPE_I32) { ret "i32"; }
+    if (k == ty.TYPE_I64) { ret "i64"; }
+    if (k == ty.TYPE_F32) { ret "f32"; }
+    if (k == ty.TYPE_F64) { ret "f64"; }
+    if (k == ty.TYPE_PTR)           { ret "ptr"; }
+    if (k == ty.TYPE_POINTER)       { ret "pointer"; }
+    if (k == ty.TYPE_ARRAY)         { ret "array"; }
+    if (k == ty.TYPE_FUN)           { ret "function"; }
+    if (k == ty.TYPE_REC)           { ret "record"; }
+    if (k == ty.TYPE_UNI)           { ret "union"; }
+    if (k == ty.TYPE_GENERIC_PARAM) { ret "generic"; }
+    if (k == ty.TYPE_INSTANCE)      { ret "instance"; }
     ret "<type>";
 }
 

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -539,7 +539,11 @@ pub fun byte_size(sc: *sema.SemaContext, t: ty.TypeId) u32 {
     # bit-reinterpreted to/from a pointer (e.g. an erased `*u8` vtable slot).
     if (tp.kind == ty.TYPE_FUN) { ret 8; }
     if (tp.kind == ty.TYPE_ARRAY) {
-        ret byte_size(sc, tp.data.array.base) * tp.data.array.count;
+        # widen the multiply: a >4GiB array would wrap a u32 product and report a
+        # wrong size to cast legality, so saturate to the 0 "unknown" sentinel.
+        val total: u64 = byte_size(sc, tp.data.array.base)::u64 * tp.data.array.count::u64;
+        if (total > 4294967295) { ret 0; }
+        ret total::u32;
     }
     ret 0;
 }

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -85,11 +85,11 @@ fun coerce_to(sc: *sema.SemaContext, eid: id.ExprId, to: ty.TypeId, negated: boo
     val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
 
     if (e.kind == expr.EXPR_KIND_LIT_INT) {
-        if (!int_literal_fits(e.data.lit_int, to, negated)) { ret none[ty.TypeId](); }
+        if (!int_literal_fits(sc, e.data.lit_int, to, negated)) { ret none[ty.TypeId](); }
         ret commit(sc, eid, to);
     }
     if (e.kind == expr.EXPR_KIND_LIT_CHAR) {
-        if (!int_literal_fits(e.data.lit_char::u64, to, negated)) { ret none[ty.TypeId](); }
+        if (!int_literal_fits(sc, e.data.lit_char::u64, to, negated)) { ret none[ty.TypeId](); }
         ret commit(sc, eid, to);
     }
     if (e.kind == expr.EXPR_KIND_LIT_FLOAT) {
@@ -129,7 +129,7 @@ fun coerce_comptime_int_path(sc: *sema.SemaContext, eid: id.ExprId, to: ty.TypeI
     if (is_err[comptime.CTValue, str](ev)) { ret none[ty.TypeId](); }
     val cv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
     if (cv.kind != comptime.CT_KIND_INT) { ret none[ty.TypeId](); }
-    if (!int_literal_fits(cv.data.i::u64, to, negated)) { ret none[ty.TypeId](); }
+    if (!int_literal_fits(sc, cv.data.i::u64, to, negated)) { ret none[ty.TypeId](); }
     ret commit(sc, eid, to);
 }
 
@@ -230,30 +230,34 @@ fun commit(sc: *sema.SemaContext, eid: id.ExprId, to: ty.TypeId) Option[ty.TypeI
 # literal never targets an unsigned destination. unsigned destinations are
 # checked against their unsigned maximum, non-negated signed destinations
 # against their signed maximum. non-integer destinations never fit.
-fun int_literal_fits(v: u64, to: ty.TypeId, negated: bool) bool {
+fun int_literal_fits(sc: *sema.SemaContext, v: u64, to: ty.TypeId, negated: bool) bool {
+    val to_opt: Option[*ty.Type] = ty.get(?sc.s.types, to);
+    if (is_none[*ty.Type](to_opt)) { ret false; }
+    val k: ty.TypeKind = unwrap[*ty.Type](to_opt).kind;
     if (negated) {
-        if (to == ty.TYPE_I8)  { ret v <= 0x80; }
-        if (to == ty.TYPE_I16) { ret v <= 0x8000; }
-        if (to == ty.TYPE_I32) { ret v <= 0x80000000; }
-        if (to == ty.TYPE_I64) { ret v <= 0x8000000000000000; }
+        if (k == ty.TYPE_I8)  { ret v <= 0x80; }
+        if (k == ty.TYPE_I16) { ret v <= 0x8000; }
+        if (k == ty.TYPE_I32) { ret v <= 0x80000000; }
+        if (k == ty.TYPE_I64) { ret v <= 0x8000000000000000; }
         ret false;
     }
-    if (to == ty.TYPE_U8)  { ret v <= 0xFF; }
-    if (to == ty.TYPE_U16) { ret v <= 0xFFFF; }
-    if (to == ty.TYPE_U32) { ret v <= 0xFFFFFFFF; }
-    if (to == ty.TYPE_U64) { ret true; }
-    if (to == ty.TYPE_I8)  { ret v <= 0x7F; }
-    if (to == ty.TYPE_I16) { ret v <= 0x7FFF; }
-    if (to == ty.TYPE_I32) { ret v <= 0x7FFFFFFF; }
-    if (to == ty.TYPE_I64) { ret v <= 0x7FFFFFFFFFFFFFFF; }
+    if (k == ty.TYPE_U8)  { ret v <= 0xFF; }
+    if (k == ty.TYPE_U16) { ret v <= 0xFFFF; }
+    if (k == ty.TYPE_U32) { ret v <= 0xFFFFFFFF; }
+    if (k == ty.TYPE_U64) { ret true; }
+    if (k == ty.TYPE_I8)  { ret v <= 0x7F; }
+    if (k == ty.TYPE_I16) { ret v <= 0x7FFF; }
+    if (k == ty.TYPE_I32) { ret v <= 0x7FFFFFFF; }
+    if (k == ty.TYPE_I64) { ret v <= 0x7FFFFFFFFFFFFFFF; }
     ret false;
 }
 
 # reports whether `t` is a pointer type — either the raw `ptr` primitive or
-# an interned `*T` pointer.
+# an interned `*T` pointer. reads the kind, so it does not depend on a
+# primitive's TypeId equaling its kind ordinal.
 fun is_pointer(sc: *sema.SemaContext, t: ty.TypeId) bool {
-    if (t == ty.TYPE_PTR) { ret true; }
     val to_opt: Option[*ty.Type] = ty.get(?sc.s.types, t);
     if (is_none[*ty.Type](to_opt)) { ret false; }
-    ret unwrap[*ty.Type](to_opt).kind == ty.TYPE_POINTER;
+    val k: ty.TypeKind = unwrap[*ty.Type](to_opt).kind;
+    ret k == ty.TYPE_PTR || k == ty.TYPE_POINTER;
 }

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -310,9 +310,9 @@ pub fun field_lookup(sc: *SemaContext, ty: type.TypeId, name: intern.StrId) Opti
     val ft: *FieldTable = unwrap[*FieldTable](ft_opt);
     var i: u32 = 0;
     for (i < ft.fields_len) {
-        val fe_opt: Option[*type.FieldEntry] = type.field_at(?sc.s.types, ty, i);
-        if (is_none[*type.FieldEntry](fe_opt)) { ret none[type.TypeId](); }
-        val fe: *type.FieldEntry = unwrap[*type.FieldEntry](fe_opt);
+        # read each field straight from the held table; field_at would re-resolve
+        # the table from scratch on every iteration.
+        val fe: *type.FieldEntry = type.field_entry_at(?sc.s.types, ft, i);
         if (fe.name == name) { ret some[type.TypeId](fe.ty); }
         i = i + 1;
     }

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -28,8 +28,7 @@ use std.types.result.unwrap_err;
 
 use std.allocator.Allocator;
 
-use sess:     mach.lang.module;
-use session:  mach.lang.session;
+use sess:     mach.lang.session;
 use diag:     mach.lang.diagnostic;
 use intern:   mach.lang.intern;
 use type:     mach.lang.type;
@@ -102,7 +101,7 @@ fwd type.FieldTable;
 # type_resolved_ty: parallel to ast.types; written by resolve_type_ref
 # decl_type:        parallel to ast.decls; written by infer_decl
 pub rec SemaContext {
-    s:          *session.Session;
+    s:          *sess.Session;
     a:          *ast.Ast;
     rr:         *resolve.ResolveResult;
     deps:       *SemaDeps;

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -101,7 +101,6 @@ fwd type.FieldTable;
 # expr_type:        parallel to ast.exprs; written by infer_expr
 # type_resolved_ty: parallel to ast.types; written by resolve_type_ref
 # decl_type:        parallel to ast.decls; written by infer_decl
-# anon_counter:     next ordinal for synthetic anonymous rec/uni names
 pub rec SemaContext {
     s:          *session.Session;
     a:          *ast.Ast;
@@ -114,8 +113,6 @@ pub rec SemaContext {
     expr_type:        *type.TypeId;
     type_resolved_ty: *type.TypeId;
     decl_type:        *type.TypeId;
-
-    anon_counter: u32;
 
     # the call-callee expression currently being inferred, or EXPR_NIL. set
     # transiently by infer_call so infer_ident permits a comptime-parameter
@@ -323,12 +320,3 @@ pub fun field_lookup(sc: *SemaContext, ty: type.TypeId, name: intern.StrId) Opti
     ret none[type.TypeId]();
 }
 
-# next_anon_ordinal: mints the next synthetic ordinal for an anonymous record/union nominal, so two textually-identical inline records in different positions intern to distinct (nominal) TypeIds.
-# ---
-# sc:  sema context
-# ret: a fresh ordinal, monotonically increasing per pass
-pub fun next_anon_ordinal(sc: *SemaContext) u32 {
-    val n: u32 = sc.anon_counter;
-    sc.anon_counter = sc.anon_counter + 1;
-    ret n;
-}

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -34,6 +34,7 @@ use std.types.result.unwrap_ok;
 
 use std.allocator.allocate;
 use std.allocator.deallocate;
+use std.allocator.reallocate;
 
 use ty:     mach.lang.type;
 use sess:   mach.lang.session;
@@ -47,13 +48,13 @@ use decl:   mach.lang.fe.ast.decl;
 use sema:   mach.lang.fe.sema.context;
 
 # instantiates a generic declaration with concrete type arguments,
-# producing an interned `TYPE_INSTANCE`. when the generic is declared in
-# this module its generic-parameter count is read directly from the AST and
-# the argument count is checked against it (a non-generic declaration, or a
-# count mismatch, is reported); a generic declared in a dependency was
-# already validated at its declaration site, so the supplied `arg_count` is
-# accepted. every argument must be a real, non-error type. on success the
-# interned instance TypeId is returned.
+# producing an interned `TYPE_INSTANCE`. the supplied argument count is
+# checked against the declaration's generic-parameter count — read from the
+# declaring module's AST, whether that is this module or a dependency (a use
+# site's arity cannot be validated at the declaration site, so a cross-module
+# instantiation is checked here too); a non-generic declaration, or a count
+# mismatch, is reported. every argument must be a real, non-error type. on
+# success the interned instance TypeId is returned.
 # ---
 # sc:             the active sema context
 # generic_decl:   DeclId of the generic declaration in `generic_origin`
@@ -265,10 +266,13 @@ fun intern_name_in(s: *sess.Session, ga: *ast.Ast, span: token.Span) intern.StrI
 }
 
 # validates the supplied argument count against a generic declaration's
-# parameter count. only declarations in this module are checked: a generic
-# declared in a dependency was already validated at its declaration site, so
-# its supplied `arg_count` is accepted. a non-generic declaration, or a count
-# mismatch, is reported and returns false; a valid arity returns true.
+# parameter count, read from the declaring module's AST (this module for a
+# local generic, or the origin dependency's AST reached through the session
+# registry for a cross-module one — a use site's arity is its own to validate,
+# never the declaration site's). a non-generic declaration, or a count
+# mismatch, is reported and returns false; a valid arity returns true. an
+# origin AST that cannot be reached is accepted (the reference will fail
+# elsewhere), so a missing dependency never masquerades as an arity error.
 # ---
 # sc:             the active sema context
 # generic_decl:   DeclId of the generic declaration
@@ -283,8 +287,12 @@ pub fun check_arity(
     arg_count:      u32,
     span:           token.Span
 ) bool {
-    if (generic_origin != sc.own_module) { ret true; }
-    val want_opt: Option[u32] = local_generic_count(sc, generic_decl);
+    var a: *ast.Ast = sc.a;
+    if (generic_origin != sc.own_module) {
+        a = sess.module_ast(sc.s, generic_origin);
+        if (a == nil) { ret true; }
+    }
+    val want_opt: Option[u32] = generic_count_in(a, generic_decl);
     if (is_none[u32](want_opt)) {
         report(sc, span, "not a generic: declaration takes no type parameters");
         ret false;
@@ -378,11 +386,46 @@ fun substitute_aggregate(s: *sess.Session, t: *ty.Type, args: *ty.TypeId, arg_co
     ret inst;
 }
 
+# GParamScan: the set of nominal TypeIds already entered during a single
+# generic-parameter search, so a recursive nominal (`rec Node { next: *Node; }`)
+# breaks its own cycle instead of recursing forever.
+# ---
+# visited: dynamic array of entered nominal TypeIds
+# len:     number of ids stored
+# cap:     allocated slots
+rec GParamScan {
+    visited: *ty.TypeId;
+    len:     u32;
+    cap:     u32;
+}
+
 # reports whether the field table registered for nominal TypeId `tid`
 # contains any `TYPE_GENERIC_PARAM` (directly, or nested under a pointer,
-# array, or instance). such a nominal is part of an unspecialized generic
-# body and must be substituted per instance; a fully concrete one need not be.
+# array, instance, or a further nominal). such a nominal is part of an
+# unspecialized generic body and must be substituted per instance; a fully
+# concrete one need not be. a fresh cycle-guard scan bounds the search against
+# recursive nominals.
 fun nominal_has_gparam(s: *sess.Session, tid: ty.TypeId) bool {
+    var scan: GParamScan;
+    scan.visited = nil;
+    scan.len     = 0;
+    scan.cap     = 0;
+    val r: bool = nominal_fields_mention(s, tid, ?scan);
+    if (scan.visited != nil && scan.cap > 0) {
+        deallocate[ty.TypeId](s.alloc, scan.visited, scan.cap::usize);
+    }
+    ret r;
+}
+
+# reports whether any field of nominal `tid` mentions a generic parameter.
+# guards against recursive nominals via `scan`: a TypeId already on the search
+# stack yields false here (its own frame examines every field), so a cycle
+# cannot recurse forever. an allocation failure recording the visit degrades to
+# true (forcing a harmless substitution attempt) rather than risking a leak.
+fun nominal_fields_mention(s: *sess.Session, tid: ty.TypeId, scan: *GParamScan) bool {
+    if (scan_contains(scan, tid)) { ret false; }
+    if (!scan_push(s, scan, tid)) { ret true; }
+
     val ft_opt: Option[*ty.FieldTable] = ty.field_table_for(?s.types, tid);
     if (is_none[*ty.FieldTable](ft_opt)) { ret false; }
     val flen: u32 = unwrap[*ty.FieldTable](ft_opt).fields_len;
@@ -390,7 +433,7 @@ fun nominal_has_gparam(s: *sess.Session, tid: ty.TypeId) bool {
     for (i < flen) {
         val fe_opt: Option[*ty.FieldEntry] = ty.field_at(?s.types, tid, i);
         if (is_some[*ty.FieldEntry](fe_opt)) {
-            if (mentions_gparam(s, unwrap[*ty.FieldEntry](fe_opt).ty)) { ret true; }
+            if (mentions_gparam(s, unwrap[*ty.FieldEntry](fe_opt).ty, scan)) { ret true; }
         }
         i = i + 1;
     }
@@ -399,15 +442,20 @@ fun nominal_has_gparam(s: *sess.Session, tid: ty.TypeId) bool {
 
 # reports whether `tid` is, or structurally contains, a generic parameter.
 # descends pointers, arrays, and instance arguments; a nested nominal is
-# checked through its own field table. bounded by the finite type graph.
-fun mentions_gparam(s: *sess.Session, tid: ty.TypeId) bool {
+# checked through its own field table (`nominal_fields_mention`), which carries
+# the cycle guard so two-plus levels of nested anonymous aggregate are reached
+# without unbounded recursion on a recursive nominal.
+fun mentions_gparam(s: *sess.Session, tid: ty.TypeId, scan: *GParamScan) bool {
     if (tid == ty.TYPE_NIL || tid == ty.TYPE_ERROR) { ret false; }
     val t_opt: Option[*ty.Type] = ty.get(?s.types, tid);
     if (is_none[*ty.Type](t_opt)) { ret false; }
     val t: *ty.Type = unwrap[*ty.Type](t_opt);
     if (t.kind == ty.TYPE_GENERIC_PARAM) { ret true; }
-    if (t.kind == ty.TYPE_POINTER)       { ret mentions_gparam(s, t.data.pointer.base); }
-    if (t.kind == ty.TYPE_ARRAY)         { ret mentions_gparam(s, t.data.array.base); }
+    if (t.kind == ty.TYPE_POINTER)       { ret mentions_gparam(s, t.data.pointer.base, scan); }
+    if (t.kind == ty.TYPE_ARRAY)         { ret mentions_gparam(s, t.data.array.base, scan); }
+    if (t.kind == ty.TYPE_REC || t.kind == ty.TYPE_UNI) {
+        ret nominal_fields_mention(s, tid, scan);
+    }
     if (t.kind == ty.TYPE_INSTANCE) {
         val astart: u32 = t.data.instance.args_start;
         val alen:   u32 = t.data.instance.args_len;
@@ -415,12 +463,44 @@ fun mentions_gparam(s: *sess.Session, tid: ty.TypeId) bool {
         for (i < alen) {
             val a_opt: Option[ty.TypeId] = ty.get_param(?s.types, astart + i);
             if (is_some[ty.TypeId](a_opt)) {
-                if (mentions_gparam(s, unwrap[ty.TypeId](a_opt))) { ret true; }
+                if (mentions_gparam(s, unwrap[ty.TypeId](a_opt), scan)) { ret true; }
             }
             i = i + 1;
         }
     }
     ret false;
+}
+
+# scan_contains: whether nominal TypeId `tid` is already recorded in `scan`.
+fun scan_contains(scan: *GParamScan, tid: ty.TypeId) bool {
+    var i: u32 = 0;
+    for (i < scan.len) {
+        if (scan.visited[i] == tid) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# scan_push: record nominal TypeId `tid` in `scan`, growing the backing array
+# as needed. returns false only on an allocation failure.
+fun scan_push(s: *sess.Session, scan: *GParamScan, tid: ty.TypeId) bool {
+    if (scan.len == scan.cap) {
+        var new_cap: u32 = scan.cap * 2;
+        if (new_cap == 0) { new_cap = 8; }
+        if (scan.visited == nil) {
+            val ar: Result[*ty.TypeId, str] = allocate[ty.TypeId](s.alloc, new_cap::usize);
+            if (is_err[*ty.TypeId, str](ar)) { ret false; }
+            scan.visited = unwrap_ok[*ty.TypeId, str](ar);
+        } or {
+            val rr: Result[*ty.TypeId, str] = reallocate[ty.TypeId](s.alloc, scan.visited, scan.cap::usize, new_cap::usize);
+            if (is_err[*ty.TypeId, str](rr)) { ret false; }
+            scan.visited = unwrap_ok[*ty.TypeId, str](rr);
+        }
+        scan.cap = new_cap;
+    }
+    scan.visited[scan.len] = tid;
+    scan.len = scan.len + 1;
+    ret true;
 }
 
 # rebuilds a function type with each parameter and the return type
@@ -508,14 +588,15 @@ fun substitute_instance(s: *sess.Session, t: *ty.Type, args: *ty.TypeId, arg_cou
     ret unwrap_or_error(r);
 }
 
-# returns the generic-parameter count of a declaration in this module, or
-# none when the declaration is not a kind that can carry generic parameters
-# (only `fun`, `rec`, and `uni` declarations are generic-capable). a zero
-# count is a valid `some(0)` — it means the named decl exists but is not
-# parameterized, which `instantiate` reports as a mismatch when args were
-# supplied.
-fun local_generic_count(sc: *sema.SemaContext, decl_id: id.DeclId) Option[u32] {
-    val d_opt: Option[*decl.Decl] = ast.get_decl(sc.a, decl_id);
+# returns the generic-parameter count of a declaration in AST `a`, or none
+# when the declaration is not a kind that can carry generic parameters (only
+# `fun`, `rec`, and `uni` declarations are generic-capable). a zero count is a
+# valid `some(0)` — it means the named decl exists but is not parameterized,
+# which `check_arity` reports as a mismatch when args were supplied. `a` is the
+# declaring module's AST, so the same check applies to a local or a
+# cross-module generic.
+fun generic_count_in(a: *ast.Ast, decl_id: id.DeclId) Option[u32] {
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, decl_id);
     if (is_none[*decl.Decl](d_opt)) { ret none[u32](); }
     val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
     if (d.kind == decl.DECL_KIND_FUN) { ret some[u32](d.data.fun_.generics_len); }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1095,9 +1095,6 @@ fun resolve_type_fun(sc: *sema.SemaContext, fn: *atype.TypeFun) type.TypeId {
 fun resolve_type_anon(sc: *sema.SemaContext, tid: id.TypeId, fields_start: u32, fields_len: u32, kind: type.TypeKind) type.TypeId {
     val name_id: intern.StrId = synth_anon_name(sc, kind);
 
-    # consume an anon ordinal so the per-pass counter stays meaningful for
-    # diagnostics, then derive the structural identity key.
-    sema.next_anon_ordinal(sc);
     val key: intern.StrId = anon_struct_key(sc, fields_start, fields_len, kind);
     if (key == intern.STR_NIL) { ret type.TYPE_ERROR; }
 
@@ -1112,24 +1109,32 @@ fun resolve_type_anon(sc: *sema.SemaContext, tid: id.TypeId, fields_start: u32, 
 # builds a canonical structural-identity key for an anonymous rec/uni: a hex
 # signature of the kind, the field count, and each field's interned name and
 # resolved type, interned to a StrId. equal shapes intern to the same StrId,
-# distinct shapes to distinct StrIds. STR_NIL signals an allocation failure.
+# distinct shapes to distinct StrIds. the buffer is sized to the exact shape —
+# one 8-hex-digit chunk for the kind and count, two per field — so the key never
+# truncates and the collision-free guarantee actually holds at any field count.
+# STR_NIL signals an allocation failure.
 fun anon_struct_key(sc: *sema.SemaContext, fields_start: u32, fields_len: u32, kind: type.TypeKind) intern.StrId {
-    var buf: [1024]u8;
+    val cap: usize = (2 + fields_len::usize * 2) * 8;
+    val br: Result[*u8, str] = allocate[u8](sc.s.alloc, cap);
+    if (is_err[*u8, str](br)) { ret intern.STR_NIL; }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+
     var n: usize = 0;
-    n = put_hex_u32(?buf[0], n, 1024, kind::u32);
-    n = put_hex_u32(?buf[0], n, 1024, fields_len);
+    n = put_hex_u32(buf, n, cap, kind::u32);
+    n = put_hex_u32(buf, n, cap, fields_len);
 
     var i: u32 = 0;
     for (i < fields_len) {
         val tn: *decl.TypedName = ?sc.a.typed_names[fields_start + i];
         val fname: intern.StrId = intern_span_or_nil(sc, tn.name);
         val fty: type.TypeId = sema.resolved_type_of(sc, tn.ty);
-        n = put_hex_u32(?buf[0], n, 1024, fname::u32);
-        n = put_hex_u32(?buf[0], n, 1024, fty::u32);
+        n = put_hex_u32(buf, n, cap, fname::u32);
+        n = put_hex_u32(buf, n, cap, fty::u32);
         i = i + 1;
     }
 
-    val r: Result[intern.StrId, str] = intern.intern_bytes(?sc.s.interner, (?buf[0])::str, n);
+    val r: Result[intern.StrId, str] = intern.intern_bytes(?sc.s.interner, buf::str, n);
+    deallocate[u8](sc.s.alloc, buf, cap);
     if (is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
     ret unwrap_ok[intern.StrId, str](r);
 }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -43,8 +43,7 @@ use std.allocator.deallocate;
 
 use intern:   mach.lang.intern;
 use type:     mach.lang.type;
-use sess:     mach.lang.module;
-use session:  mach.lang.session;
+use sess:     mach.lang.session;
 
 use ast:      mach.lang.fe.ast;
 use id:       mach.lang.fe.ast.id;
@@ -299,7 +298,7 @@ fun ident_is_comptime_param_fn(sc: *sema.SemaContext, sym: *resolve.Symbol) bool
     if (sym.decl == id.DECL_NIL) { ret false; }
     var a: *ast.Ast = sc.a;
     if (sym.origin != sc.own_module) {
-        a = session.module_ast(sc.s, sym.origin);
+        a = sess.module_ast(sc.s, sym.origin);
         if (a == nil) { ret false; }
     }
     val d_opt: Option[*decl.Decl] = ast.get_decl(a, sym.decl);
@@ -532,7 +531,7 @@ fun callee_fun_decl(sc: *sema.SemaContext, callee: id.ExprId) Option[*decl.DeclF
 
     var a: *ast.Ast = sc.a;
     if (sym.origin != sc.own_module) {
-        a = session.module_ast(sc.s, sym.origin);
+        a = sess.module_ast(sc.s, sym.origin);
         if (a == nil) { ret none[*decl.DeclFun](); }
     }
     val d_opt: Option[*decl.Decl] = ast.get_decl(a, sym.decl);
@@ -552,7 +551,7 @@ fun decl_has_comptime_param(sc: *sema.SemaContext, callee: id.ExprId, f: *decl.D
 
     var a: *ast.Ast = sc.a;
     if (sym.origin != sc.own_module) {
-        a = session.module_ast(sc.s, sym.origin);
+        a = sess.module_ast(sc.s, sym.origin);
         if (a == nil) { ret false; }
     }
     var i: u32 = 0;

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1045,6 +1045,12 @@ fun resolve_type_array(sc: *sema.SemaContext, ar: *atype.TypeArray, span: token.
         sema.report(sc, span, "type mismatch: array length must be non-negative");
         ret type.TYPE_ERROR;
     }
+    # the array count is interned as a u32; a larger comptime length would wrap
+    # silently, so reject it rather than truncating to a wrong element count.
+    if (cv.data.i > 4294967295) {
+        sema.report(sc, span, "type mismatch: array length exceeds the maximum of 4294967295 elements");
+        ret type.TYPE_ERROR;
+    }
 
     val r: Result[type.TypeId, str] = type.intern_array(?sc.s.types, elem, cv.data.i::u32);
     if (is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1204,28 +1204,19 @@ fun prim_or_error(sc: *sema.SemaContext, kind: type.TypeKind) type.TypeId {
 
 # is the TypeId one of the numeric primitives u8..f64?
 fun is_numeric(sc: *sema.SemaContext, ty: type.TypeId) bool {
-    val t_opt: Option[*type.Type] = type.get(?sc.s.types, ty);
-    if (is_none[*type.Type](t_opt)) { ret false; }
-    val k: type.TypeKind = unwrap[*type.Type](t_opt).kind;
-    ret k::u32 <= type.TYPE_F64::u32;
+    ret type.is_numeric(?sc.s.types, ty);
 }
 
 # is the TypeId one of the integer primitives u8..i64?
 fun is_integer(sc: *sema.SemaContext, ty: type.TypeId) bool {
-    val t_opt: Option[*type.Type] = type.get(?sc.s.types, ty);
-    if (is_none[*type.Type](t_opt)) { ret false; }
-    val k: type.TypeKind = unwrap[*type.Type](t_opt).kind;
-    ret k::u32 <= type.TYPE_I64::u32;
+    ret type.is_integer(?sc.s.types, ty);
 }
 
 # is the TypeId address-shaped — a raw `ptr`, a typed `*T`, or a function
 # (`TYPE_FUN`, a code address)? used by equality to relate `nil` against
 # pointer and function operands.
 fun is_pointer_like(sc: *sema.SemaContext, ty: type.TypeId) bool {
-    val t_opt: Option[*type.Type] = type.get(?sc.s.types, ty);
-    if (is_none[*type.Type](t_opt)) { ret false; }
-    val k: type.TypeKind = unwrap[*type.Type](t_opt).kind;
-    ret k == type.TYPE_PTR || k == type.TYPE_POINTER || k == type.TYPE_FUN;
+    ret type.is_pointer_like(?sc.s.types, ty);
 }
 
 # attempts to make a binary operation's two operands share a type when one

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -223,11 +223,22 @@ pub rec TypeInterner {
 
     dedup: map.Map[Type, TypeId];
 
+    # TYPE_INSTANCE bypasses `dedup` (its args live in the side pool, which the
+    # context-free dedup hash cannot read), so instance TypeIds are tracked in
+    # their own list and deduped by scanning it — O(instances), not O(type_len).
+    instances:     *TypeId;
+    instances_len: u32;
+    instances_cap: u32;
+
     prims: [11]TypeId;
 
     field_tables:    *FieldTable;
     field_table_len: u32;
     field_table_cap: u32;
+
+    # nominal / instance TypeId -> its index in field_tables, so a field-table
+    # lookup is O(1) rather than a linear scan of every registered table.
+    field_index: map.Map[TypeId, u32];
 
     field_pool:     *FieldEntry;
     field_pool_len: u32;
@@ -251,15 +262,20 @@ pub fun init(alloc: *Allocator) Result[TypeInterner, str] {
     ti.params_len = 0;
     ti.params_cap = 0;
     ti.dedup      = map.init[Type, TypeId](alloc, hash_type, eq_type);
+    ti.instances     = nil;
+    ti.instances_len = 0;
+    ti.instances_cap = 0;
     ti.field_tables    = nil;
     ti.field_table_len = 0;
     ti.field_table_cap = 0;
+    ti.field_index     = map.init[TypeId, u32](alloc, map.hash_u32, map.eq_u32);
     ti.field_pool      = nil;
     ti.field_pool_len  = 0;
     ti.field_pool_cap  = 0;
 
     val ra: Result[*Type, str] = allocate[Type](alloc, INITIAL_TYPE_CAP::usize);
     if (is_err[*Type, str](ra)) {
+        map.dnit[TypeId, u32](?ti.field_index);
         map.dnit[Type, TypeId](?ti.dedup);
         ret err[TypeInterner, str](unwrap_err[*Type, str](ra));
     }
@@ -269,6 +285,7 @@ pub fun init(alloc: *Allocator) Result[TypeInterner, str] {
     val rp: Result[*TypeId, str] = allocate[TypeId](alloc, INITIAL_PARAMS_CAP::usize);
     if (is_err[*TypeId, str](rp)) {
         deallocate[Type](alloc, ti.types, ti.type_cap::usize);
+        map.dnit[TypeId, u32](?ti.field_index);
         map.dnit[Type, TypeId](?ti.dedup);
         ret err[TypeInterner, str](unwrap_err[*TypeId, str](rp));
     }
@@ -287,6 +304,7 @@ pub fun init(alloc: *Allocator) Result[TypeInterner, str] {
         if (is_err[TypeId, str](pr)) {
             deallocate[TypeId](alloc, ti.params, ti.params_cap::usize);
             deallocate[Type](alloc, ti.types, ti.type_cap::usize);
+            map.dnit[TypeId, u32](?ti.field_index);
             map.dnit[Type, TypeId](?ti.dedup);
             ret err[TypeInterner, str](unwrap_err[TypeId, str](pr));
         }
@@ -296,6 +314,7 @@ pub fun init(alloc: *Allocator) Result[TypeInterner, str] {
         if (is_err[bool, str](ins)) {
             deallocate[TypeId](alloc, ti.params, ti.params_cap::usize);
             deallocate[Type](alloc, ti.types, ti.type_cap::usize);
+            map.dnit[TypeId, u32](?ti.field_index);
             map.dnit[Type, TypeId](?ti.dedup);
             ret err[TypeInterner, str](unwrap_err[bool, str](ins));
         }
@@ -316,12 +335,16 @@ pub fun dnit(ti: *TypeInterner) {
     if (ti.params != nil && ti.params_cap > 0) {
         deallocate[TypeId](ti.alloc, ti.params, ti.params_cap::usize);
     }
+    if (ti.instances != nil && ti.instances_cap > 0) {
+        deallocate[TypeId](ti.alloc, ti.instances, ti.instances_cap::usize);
+    }
     if (ti.field_tables != nil && ti.field_table_cap > 0) {
         deallocate[FieldTable](ti.alloc, ti.field_tables, ti.field_table_cap::usize);
     }
     if (ti.field_pool != nil && ti.field_pool_cap > 0) {
         deallocate[FieldEntry](ti.alloc, ti.field_pool, ti.field_pool_cap::usize);
     }
+    map.dnit[TypeId, u32](?ti.field_index);
     map.dnit[Type, TypeId](?ti.dedup);
     ti.types      = nil;
     ti.type_len   = 0;
@@ -329,6 +352,9 @@ pub fun dnit(ti: *TypeInterner) {
     ti.params     = nil;
     ti.params_len = 0;
     ti.params_cap = 0;
+    ti.instances     = nil;
+    ti.instances_len = 0;
+    ti.instances_cap = 0;
     ti.field_tables    = nil;
     ti.field_table_len = 0;
     ti.field_table_cap = 0;
@@ -392,12 +418,9 @@ pub fun is_pointer_like(ti: *TypeInterner, tid: TypeId) bool {
 # ty: the TypeId to look up
 # ret: some(*FieldTable) when present, none otherwise
 pub fun field_table_for(ti: *TypeInterner, ty: TypeId) Option[*FieldTable] {
-    var i: u32 = 0;
-    for (i < ti.field_table_len) {
-        if (ti.field_tables[i].ty == ty) { ret some[*FieldTable](?ti.field_tables[i]); }
-        i = i + 1;
-    }
-    ret none[*FieldTable]();
+    val idx: Result[*u32, str] = map.get[TypeId, u32](?ti.field_index, ?ty);
+    if (is_err[*u32, str](idx)) { ret none[*FieldTable](); }
+    ret some[*FieldTable](?ti.field_tables[@unwrap_ok[*u32, str](idx)]);
 }
 
 # field_table_begin: begin a new field table for TypeId `ty`, returning its index; fields are appended with field_table_push. each TypeId interns to a stable id, so a table is built once and shared session-wide.
@@ -420,11 +443,13 @@ pub fun field_table_begin(ti: *TypeInterner, ty: TypeId) Result[u32, str] {
         }
         ti.field_table_cap = new_cap;
     }
+    val idx: u32 = ti.field_table_len;
+    val ins: Result[bool, str] = map.insert[TypeId, u32](?ti.field_index, ty, idx);
+    if (is_err[bool, str](ins)) { ret err[u32, str](unwrap_err[bool, str](ins)); }
     var ft: FieldTable;
     ft.ty           = ty;
     ft.fields_start = ti.field_pool_len;
     ft.fields_len   = 0;
-    val idx: u32 = ti.field_table_len;
     ti.field_tables[idx] = ft;
     ti.field_table_len = ti.field_table_len + 1;
     ret ok[u32, str](idx);
@@ -484,6 +509,18 @@ pub fun field_at(ti: *TypeInterner, ty: TypeId, ix: u32) Option[*FieldEntry] {
     val ft: *FieldTable = unwrap[*FieldTable](ft_opt);
     if (ix >= ft.fields_len) { ret none[*FieldEntry](); }
     ret some[*FieldEntry](?ti.field_pool[ft.fields_start + ix]);
+}
+
+# field_entry_at: the FieldEntry at ordinal `ix` of an already-fetched table,
+# read straight from the field pool — O(1) with no table re-resolution. the
+# caller holds `ft` and guarantees `ix < ft.fields_len`.
+# ---
+# ti: the interner
+# ft: a field table previously returned by field_table_for / field_table_begin
+# ix: the field ordinal, in range [0, ft.fields_len)
+# ret: a borrowed pointer to the field entry
+pub fun field_entry_at(ti: *TypeInterner, ft: *FieldTable, ix: u32) *FieldEntry {
+    ret ?ti.field_pool[ft.fields_start + ix];
 }
 
 # intern_pointer: intern a pointer-to type. returns an existing TypeId
@@ -594,11 +631,11 @@ pub fun intern_function(ti: *TypeInterner, ret_ty: TypeId, params: *TypeId, coun
 }
 
 # intern_instance: intern a generic instantiation `(target_origin,
-# target_decl)<args>`. linear-scans existing TYPE_INSTANCE entries for a
-# match before appending; on miss, copies args into the params pool and
-# appends a fresh TypeInstance record. TYPE_INSTANCE bypasses the dedup
-# map (hash is awkward with args living in a side pool); instance counts
-# are small enough that linear scan is acceptable.
+# target_decl)<args>`. scans the instance list for a match before appending;
+# on miss, copies args into the params pool, appends a fresh TypeInstance
+# record, and records it in the instance list. TYPE_INSTANCE bypasses the dedup
+# map (its args live in the side pool, which the context-free dedup hash cannot
+# read), so dedup walks the instance list — O(instances), not O(type_len).
 # ---
 # ti:            the interner
 # target_origin: module that declared the generic
@@ -608,10 +645,10 @@ pub fun intern_function(ti: *TypeInterner, ret_ty: TypeId, params: *TypeId, coun
 # ret:           the (deduped) TypeId for the instance, or an allocation error
 pub fun intern_instance(ti: *TypeInterner, target_origin: sess.ModuleId, target_decl: id.DeclId, args: *TypeId, count: u32) Result[TypeId, str] {
     var i: u32 = 0;
-    for (i < ti.type_len) {
-        val ex: *Type = ?ti.types[i];
-        if (ex.kind == TYPE_INSTANCE
-            && ex.data.instance.target_origin == target_origin
+    for (i < ti.instances_len) {
+        val tid: TypeId = ti.instances[i];
+        val ex: *Type = ?ti.types[tid];
+        if (ex.data.instance.target_origin == target_origin
             && ex.data.instance.target_decl   == target_decl
             && ex.data.instance.args_len      == count) {
             var match: bool = true;
@@ -623,7 +660,7 @@ pub fun intern_instance(ti: *TypeInterner, target_origin: sess.ModuleId, target_
                 }
                 j = j + 1;
             }
-            if (match) { ret ok[TypeId, str](i); }
+            if (match) { ret ok[TypeId, str](tid); }
         }
         i = i + 1;
     }
@@ -644,7 +681,33 @@ pub fun intern_instance(ti: *TypeInterner, target_origin: sess.ModuleId, target_
     t.data.instance.target_decl   = target_decl;
     t.data.instance.args_start    = start;
     t.data.instance.args_len      = count;
-    ret append_type(ti, t);
+    val ap: Result[TypeId, str] = append_type(ti, t);
+    if (is_err[TypeId, str](ap)) { ret ap; }
+    val tid: TypeId = unwrap_ok[TypeId, str](ap);
+    val tr: Result[bool, str] = track_instance(ti, tid);
+    if (is_err[bool, str](tr)) { ret err[TypeId, str](unwrap_err[bool, str](tr)); }
+    ret ok[TypeId, str](tid);
+}
+
+# track_instance: append `tid` to the instance list, growing it as needed.
+fun track_instance(ti: *TypeInterner, tid: TypeId) Result[bool, str] {
+    if (ti.instances_len == ti.instances_cap) {
+        var new_cap: u32 = ti.instances_cap * 2;
+        if (new_cap == 0) { new_cap = 16; }
+        if (ti.instances == nil) {
+            val ar: Result[*TypeId, str] = allocate[TypeId](ti.alloc, new_cap::usize);
+            if (is_err[*TypeId, str](ar)) { ret err[bool, str](unwrap_err[*TypeId, str](ar)); }
+            ti.instances = unwrap_ok[*TypeId, str](ar);
+        } or {
+            val rr: Result[*TypeId, str] = reallocate[TypeId](ti.alloc, ti.instances, ti.instances_cap::usize, new_cap::usize);
+            if (is_err[*TypeId, str](rr)) { ret err[bool, str](unwrap_err[*TypeId, str](rr)); }
+            ti.instances = unwrap_ok[*TypeId, str](rr);
+        }
+        ti.instances_cap = new_cap;
+    }
+    ti.instances[ti.instances_len] = tid;
+    ti.instances_len = ti.instances_len + 1;
+    ret ok[bool, str](true);
 }
 
 # get: return a pointer to the Type for a given TypeId, or none when tid

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -275,6 +275,10 @@ pub fun init(alloc: *Allocator) Result[TypeInterner, str] {
     ti.params     = unwrap_ok[*TypeId, str](rp);
     ti.params_cap = INITIAL_PARAMS_CAP;
 
+    # seed the primitives in kind order; `prim(kind)` indexes the resulting
+    # `prims[]` table to recover a primitive's TypeId. sema classifies a type by
+    # reading its interned kind (is_integer / is_numeric / byte_size / ...), so
+    # nothing depends on a primitive's TypeId happening to equal its ordinal.
     var k: u32 = 0;
     for (k < PRIM_COUNT) {
         var prim: Type;
@@ -341,6 +345,45 @@ pub fun dnit(ti: *TypeInterner) {
 pub fun prim(ti: *TypeInterner, kind: TypeKind) Option[TypeId] {
     if (kind::u32 >= PRIM_COUNT) { ret none[TypeId](); }
     ret some[TypeId](ti.prims[kind::u32]);
+}
+
+# is_integer: whether `tid` is an integer primitive (u8..i64). reads the kind
+# through the interner, so — unlike a bare `tid == TYPE_U8` ordinal test — it
+# never depends on a primitive's TypeId equaling its kind ordinal. the single
+# shared predicate for sema's infer / check / coerce passes.
+# ---
+# ti:  the interner
+# tid: the TypeId to classify
+# ret: true for u8..u64 and i8..i64
+pub fun is_integer(ti: *TypeInterner, tid: TypeId) bool {
+    val t_opt: Option[*Type] = get(ti, tid);
+    if (is_none[*Type](t_opt)) { ret false; }
+    ret unwrap[*Type](t_opt).kind::u32 <= TYPE_I64::u32;
+}
+
+# is_numeric: whether `tid` is an integer or float primitive (u8..f64).
+# ---
+# ti:  the interner
+# tid: the TypeId to classify
+# ret: true for any integer or float primitive
+pub fun is_numeric(ti: *TypeInterner, tid: TypeId) bool {
+    val t_opt: Option[*Type] = get(ti, tid);
+    if (is_none[*Type](t_opt)) { ret false; }
+    ret unwrap[*Type](t_opt).kind::u32 <= TYPE_F64::u32;
+}
+
+# is_pointer_like: whether `tid` is address-shaped — a raw `ptr`, a typed `*T`,
+# or a function (a code address). used to relate `nil` and reinterpret casts
+# against pointer and function operands.
+# ---
+# ti:  the interner
+# tid: the TypeId to classify
+# ret: true for TYPE_PTR / TYPE_POINTER / TYPE_FUN
+pub fun is_pointer_like(ti: *TypeInterner, tid: TypeId) bool {
+    val t_opt: Option[*Type] = get(ti, tid);
+    if (is_none[*Type](t_opt)) { ret false; }
+    val k: TypeKind = unwrap[*Type](t_opt).kind;
+    ret k == TYPE_PTR || k == TYPE_POINTER || k == TYPE_FUN;
 }
 
 # field_table_for: the field table describing nominal or instance TypeId `ty`, or none when none has been registered yet.

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -10,8 +10,9 @@
 # as a primitive here. Compound types are interned by their canonical
 # form: pointer types by base, array types by `(base, count)`, nominal
 # types (`rec`/`uni`) by `(origin, decl)`, generic parameters by
-# `(owner, index)`. Function types are not deduplicated; structural
-# equality of function types is available via `type_equals_signatures`.
+# `(owner, index)`, function types by a content hash of their signature, and
+# instances by `(origin, decl, args)`. Structural equality of function types is
+# also available via `type_equals_signatures`.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -223,6 +224,14 @@ pub rec TypeInterner {
 
     dedup: map.Map[Type, TypeId];
 
+    # TYPE_FUN also bypasses `dedup` (its params live in the side pool); a
+    # content hash of (ret, params, variadic) -> TypeId deduplicates structurally
+    # equal function types, collapsing the per-generic-call TYPE_FUN explosion. a
+    # hash collision degrades to a fresh append (the prior non-deduped default),
+    # never to a wrong identity, since the candidate is verified against the
+    # mapped type before reuse.
+    fun_index: map.Map[u64, TypeId];
+
     # TYPE_INSTANCE bypasses `dedup` (its args live in the side pool, which the
     # context-free dedup hash cannot read), so instance TypeIds are tracked in
     # their own list and deduped by scanning it — O(instances), not O(type_len).
@@ -262,6 +271,7 @@ pub fun init(alloc: *Allocator) Result[TypeInterner, str] {
     ti.params_len = 0;
     ti.params_cap = 0;
     ti.dedup      = map.init[Type, TypeId](alloc, hash_type, eq_type);
+    ti.fun_index     = map.init[u64, TypeId](alloc, map.hash_u64, map.eq_u64);
     ti.instances     = nil;
     ti.instances_len = 0;
     ti.instances_cap = 0;
@@ -275,6 +285,7 @@ pub fun init(alloc: *Allocator) Result[TypeInterner, str] {
 
     val ra: Result[*Type, str] = allocate[Type](alloc, INITIAL_TYPE_CAP::usize);
     if (is_err[*Type, str](ra)) {
+        map.dnit[u64, TypeId](?ti.fun_index);
         map.dnit[TypeId, u32](?ti.field_index);
         map.dnit[Type, TypeId](?ti.dedup);
         ret err[TypeInterner, str](unwrap_err[*Type, str](ra));
@@ -285,6 +296,7 @@ pub fun init(alloc: *Allocator) Result[TypeInterner, str] {
     val rp: Result[*TypeId, str] = allocate[TypeId](alloc, INITIAL_PARAMS_CAP::usize);
     if (is_err[*TypeId, str](rp)) {
         deallocate[Type](alloc, ti.types, ti.type_cap::usize);
+        map.dnit[u64, TypeId](?ti.fun_index);
         map.dnit[TypeId, u32](?ti.field_index);
         map.dnit[Type, TypeId](?ti.dedup);
         ret err[TypeInterner, str](unwrap_err[*TypeId, str](rp));
@@ -304,6 +316,7 @@ pub fun init(alloc: *Allocator) Result[TypeInterner, str] {
         if (is_err[TypeId, str](pr)) {
             deallocate[TypeId](alloc, ti.params, ti.params_cap::usize);
             deallocate[Type](alloc, ti.types, ti.type_cap::usize);
+            map.dnit[u64, TypeId](?ti.fun_index);
             map.dnit[TypeId, u32](?ti.field_index);
             map.dnit[Type, TypeId](?ti.dedup);
             ret err[TypeInterner, str](unwrap_err[TypeId, str](pr));
@@ -314,6 +327,7 @@ pub fun init(alloc: *Allocator) Result[TypeInterner, str] {
         if (is_err[bool, str](ins)) {
             deallocate[TypeId](alloc, ti.params, ti.params_cap::usize);
             deallocate[Type](alloc, ti.types, ti.type_cap::usize);
+            map.dnit[u64, TypeId](?ti.fun_index);
             map.dnit[TypeId, u32](?ti.field_index);
             map.dnit[Type, TypeId](?ti.dedup);
             ret err[TypeInterner, str](unwrap_err[bool, str](ins));
@@ -344,6 +358,7 @@ pub fun dnit(ti: *TypeInterner) {
     if (ti.field_pool != nil && ti.field_pool_cap > 0) {
         deallocate[FieldEntry](ti.alloc, ti.field_pool, ti.field_pool_cap::usize);
     }
+    map.dnit[u64, TypeId](?ti.fun_index);
     map.dnit[TypeId, u32](?ti.field_index);
     map.dnit[Type, TypeId](?ti.dedup);
     ti.types      = nil;
@@ -598,19 +613,28 @@ pub fun intern_generic_param(ti: *TypeInterner, name: intern.StrId, owner: id.De
     ret intern_dedup(ti, t);
 }
 
-# intern_function: append a function type. parameter list is copied into
-# the side pool. function types are not currently deduplicated; structural
-# equivalence is available via `type_equals_signatures`. callers that need
-# pointer-equal function types (e.g. cached vtable slots) should
-# canonicalize at a higher layer.
+# intern_function: intern a function type, deduplicating structurally equal
+# signatures through a content-hash index so a generic call's repeated
+# substitute_fun does not grow the universe without bound. on a hash hit the
+# candidate is verified against the mapped type before reuse, so a collision
+# degrades to a fresh append (the historical non-deduped default), never to a
+# wrong identity. structural equivalence is also available via
+# `type_equals_signatures`.
 # ---
 # ti:       the interner
 # ret_ty:   return type
 # params:   pointer to a contiguous array of fixed parameter TypeIds
 # count:    number of fixed parameter types
 # variadic: true when the function accepts trailing variadic arguments
-# ret:      a fresh TypeId for the function, or an allocation error
+# ret:      the (deduped) TypeId for the function, or an allocation error
 pub fun intern_function(ti: *TypeInterner, ret_ty: TypeId, params: *TypeId, count: u32, variadic: bool) Result[TypeId, str] {
+    val h: u64 = hash_fun(ret_ty, params, count, variadic);
+    val cached: Result[*TypeId, str] = map.get[u64, TypeId](?ti.fun_index, ?h);
+    if (is_ok[*TypeId, str](cached)) {
+        val ex: TypeId = @unwrap_ok[*TypeId, str](cached);
+        if (fun_matches(ti, ex, ret_ty, params, count, variadic)) { ret ok[TypeId, str](ex); }
+    }
+
     val start: u32 = ti.params_len;
     val rp: Result[bool, str] = reserve_params(ti, count);
     if (is_err[bool, str](rp)) { ret err[TypeId, str](unwrap_err[bool, str](rp)); }
@@ -623,11 +647,51 @@ pub fun intern_function(ti: *TypeInterner, ret_ty: TypeId, params: *TypeId, coun
 
     var t: Type;
     t.kind = TYPE_FUN;
-    t.data.fn.ret_ty          = ret_ty;
+    t.data.fn.ret_ty       = ret_ty;
     t.data.fn.params_start = start;
     t.data.fn.params_len   = count;
     t.data.fn.variadic     = variadic;
-    ret append_type(ti, t);
+    val ap: Result[TypeId, str] = append_type(ti, t);
+    if (is_err[TypeId, str](ap)) { ret ap; }
+    val tid: TypeId = unwrap_ok[TypeId, str](ap);
+    # last-writer-wins on a hash collision: the most recently interned signature
+    # for this hash is the one reused next, so equal signatures still collapse.
+    val ins: Result[bool, str] = map.insert[u64, TypeId](?ti.fun_index, h, tid);
+    if (is_err[bool, str](ins)) { ret err[TypeId, str](unwrap_err[bool, str](ins)); }
+    ret ok[TypeId, str](tid);
+}
+
+# hash_fun: FNV-1a content hash over a function signature (ret, params, variadic),
+# matching the identity `fun_matches` verifies.
+fun hash_fun(ret_ty: TypeId, params: *TypeId, count: u32, variadic: bool) u64 {
+    var h: u64 = fnv1a.init();
+    h = fnv1a.step_u8(h, TYPE_FUN::u8);
+    h = fnv1a.step_u32(h, ret_ty::u32);
+    if (variadic) { h = fnv1a.step_u8(h, 1); } or { h = fnv1a.step_u8(h, 0); }
+    h = fnv1a.step_u32(h, count);
+    var i: u32 = 0;
+    for (i < count) {
+        h = fnv1a.step_u32(h, params[i]::u32);
+        i = i + 1;
+    }
+    ret h;
+}
+
+# fun_matches: whether the interned TYPE_FUN at `tid` has exactly the given
+# signature (ret, params slice, variadic).
+fun fun_matches(ti: *TypeInterner, tid: TypeId, ret_ty: TypeId, params: *TypeId, count: u32, variadic: bool) bool {
+    if (tid >= ti.type_len) { ret false; }
+    val t: *Type = ?ti.types[tid];
+    if (t.kind != TYPE_FUN) { ret false; }
+    if (t.data.fn.ret_ty != ret_ty) { ret false; }
+    if (t.data.fn.variadic != variadic) { ret false; }
+    if (t.data.fn.params_len != count) { ret false; }
+    var i: u32 = 0;
+    for (i < count) {
+        if (ti.params[t.data.fn.params_start + i] != params[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # intern_instance: intern a generic instantiation `(target_origin,


### PR DESCRIPTION
Addresses the 2026-06 sema audit findings in #1248 (resolve / infer / check / generics + type.mach).

Per-finding disposition (all the audit's listed findings):

- [x] **BUG/S** cross-module generic arity unchecked — `check_arity` reads the declaring module's generics_len from its AST (local or cross-module).
- [x] **BUG/M** deep-nested anonymous-aggregate generic-param substitution — `mentions_gparam` recurses through nested nominals with a visited-set cycle guard.
- [x] **BUG/S** array-length i64→u32 truncation — rejected with a diagnostic; the array byte_size multiply is widened to u64.
- [x] **BUG/M** fwd module re-export drops SYM_USE slot — `PublicSymbol` carries the slot, `imported_symbol_for` preserves SYM_USE, and the resolve dep set closes over re-exported modules.
- [x] **BUG/S** module-level unannotated val double-inference — the body pass no longer re-infers an unannotated initializer.
- [x] **DESIGN/M** type-universe quadratic scaling — field-table index map, instance list, function-type content-hash dedup.
- [x] **SMELL/S** bind_member_qualified bypasses imported_cache — routed through `imported_symbol_for`.
- [x] **SMELL/S** check.mach TypeId==TypeKind ordinal shortcut — shared kind-based predicates in the type layer; byte_size / format_type / int_literal_fits read the kind.
- [x] **DESIGN/S** pointer width hardcoded to 8 — `byte_size` reads the target's pointer width from the comptime context.
- [x] **SMELL/M** SYM_IMPORTED comptime-gate defensive fallback — narrowed to imports that resolve to a module-level `val`.
- [x] **CLEANUP/S** anon-aggregate key truncation past 63 fields — exact-size key buffer; dead anon-ordinal removed.
- [x] **CLEANUP/S** stale docs + two-meaning `sess` alias — unified alias, corrected comments, OOM-path resolve cleanup.

### Deferred (needs coordination)
- **BUG/M mixed-signedness comparisons** (joint #1248 / #1251 disposition): the sema rule is correct per `operators.md`, but enforcing it rejects existing mixed-sign comparisons in **mach-std** (`filesystem.mach` S_IF* checks), which breaks the build/fixpoint. Implementing it cleanly requires a coordinated mach + mach-std change (mach-std `branch/dev` + submodule bump), so it is left out of this PR and tracked for a follow-up. See the disposition comment on #1248.

Verification: `mach build .` clean, `mach test .` 240 pass, windows cross-compile + all integration suites pass, self-host fixpoint byte-identical.

Closes #1248
