### PR TITLE
fix(of): objfmt audit — reloc-kind safety, count narrowing, parser bounds, shared bin layer; linker weak/strong + bounds (#1256, #1257)

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -56,6 +56,7 @@ use sess:   mach.lang.session;
 use intern: mach.lang.intern;
 use target: mach.lang.target;
 use of:     mach.lang.target.of;
+use bin:    mach.lang.target.of.bin;
 use ar:     mach.lang.target.of.ar;
 use obj:    mach.lang.be.obj;
 
@@ -937,7 +938,7 @@ fun assign_section_vaddrs(tgt: *target.Target, merged: *MergedSection) {
         if (merged[i].used) {
             var seg_align: u64 = merged[i].align::u64;
             if (seg_align < page) { seg_align = page; }
-            va = align_up_u64(va, seg_align);
+            va = bin.align_up_u64(va, seg_align);
             merged[i].vaddr = va;
             va = va + merged[i].len::u64;
         }
@@ -1440,7 +1441,7 @@ fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
             ret err[bool, str](overflow_message(s, kind, module, rel_off));
         }
         val value: u64 = sym_va + (addend::u64);
-        write_u64_le(dst, patch_off, value);
+        bin.write_u64_le(dst, patch_off::usize, value);
         ret ok[bool, str](true);
     }
 
@@ -1452,7 +1453,7 @@ fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
         if (disp > 2147483647 || disp < -2147483648) {
             ret err[bool, str](overflow_message(s, kind, module, rel_off));
         }
-        write_u32_le(dst, patch_off, (disp::u64) & 0xFFFFFFFF);
+        bin.write_u32_le(dst, patch_off::usize, ((disp::u64) & 0xFFFFFFFF)::u32);
         ret ok[bool, str](true);
     }
 
@@ -1465,7 +1466,7 @@ fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
         if (v > 2147483647 || v < -2147483648) {
             ret err[bool, str](overflow_message(s, kind, module, rel_off));
         }
-        write_u32_le(dst, patch_off, (v::u64) & 0xFFFFFFFF);
+        bin.write_u32_le(dst, patch_off::usize, ((v::u64) & 0xFFFFFFFF)::u32);
         ret ok[bool, str](true);
     }
 
@@ -1599,32 +1600,6 @@ fun clamp_kind(kind: of.SectionKind) u32 {
 fun align_up_u32(value: u32, align: u32) u32 {
     if (align <= 1) { ret value; }
     ret (value + align - 1) & ~(align - 1);
-}
-
-# align_up_u64: round `value` up to the next multiple of `align` (a power of
-# two, or 1 for no alignment).
-fun align_up_u64(value: u64, align: u64) u64 {
-    if (align <= 1) { ret value; }
-    ret (value + align - 1) & ~(align - 1);
-}
-
-# write_u64_le: store a 64-bit value little-endian at `dst[off..off+8]`.
-fun write_u64_le(dst: *u8, off: u32, value: u64) {
-    var i: u32 = 0;
-    for (i < 8) {
-        dst[off + i] = ((value >> (i * 8)) & 0xFF)::u8;
-        i = i + 1;
-    }
-}
-
-# write_u32_le: store the low 32 bits of `value` little-endian at
-# `dst[off..off+4]`.
-fun write_u32_le(dst: *u8, off: u32, value: u64) {
-    var i: u32 = 0;
-    for (i < 4) {
-        dst[off + i] = ((value >> (i * 8)) & 0xFF)::u8;
-        i = i + 1;
-    }
 }
 
 # dup_message: build the "multiple definition of '<name>'" diagnostic string.

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1170,86 +1170,138 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
                      dyn: *DynState) Result[bool, str] {
     # intern the abstract relocation-kind names once for fast comparison.
     val kinds: RelocKindIds = intern_reloc_kinds(s);
+    val alloc: *Allocator = s.alloc;
 
     var m: u32 = 0;
     for (m < module_count) {
-        var ri: u32 = 0;
-        for (ri < modules[m].reloc_count) {
-            val r: *of.Relocation = ?modules[m].relocations[ri];
-            # a corrupt object can name an out-of-range section, or an offset past
-            # the end of its own section (which would wrap the u32 patch cursor and
-            # scribble outside the merged buffer). reject both loudly instead of
-            # silently dropping the relocation, which would ship an executable with
-            # an unpatched site.
-            if (r.section >= modules[m].section_count) {
-                ret err[bool, str]("linker: relocation names an out-of-range section");
-            }
-            if (r.offset > modules[m].sections[r.section].len) {
-                ret err[bool, str]("linker: relocation offset is past the end of its section");
-            }
+        # build module m's local-name -> vaddr index once, replacing the per-
+        # relocation linear symbol-table scan (an O(relocations x symbols) hot path
+        # on a self-host link). the index holds only LOCALs; GLOBAL targets resolve
+        # through the cross-object sym_locs table. the map is always freed after the
+        # module's relocations are patched, regardless of outcome.
+        var local_map: map.Map[intern.StrId, u64] =
+            map.init[intern.StrId, u64](alloc, maphash.hash_u32, maphash.eq_u32);
+        val br: Result[bool, str] = build_local_index(modules, m, placements, sec_base, ?local_map);
+        if (is_err[bool, str](br)) {
+            map.dnit[intern.StrId, u64](?local_map);
+            ret err[bool, str](unwrap_err[bool, str](br));
+        }
 
-            # the patch site's location in the merged image. the placement's
-            # merged_index is a section *kind*; map it to the output-section index.
-            val flat: u32 = sec_base[m] + r.section;
-            val pl: *Placement = ?placements[flat];
-            val patch_va: u64 = pl.vaddr + r.offset::u64;
-            val out_ix: u32 = out_section_for_merged(out_img, pl.merged_index);
-            # a relocation in a section with no merged output, or one whose patch
-            # site lands in a (byteless) BSS section, cannot be applied — that is a
-            # contract violation from a buggy parser/codegen, not a relocation to
-            # quietly skip.
-            if (out_ix == 0xFFFFFFFF) {
-                ret err[bool, str]("linker: relocation targets a section with no merged output");
-            }
-            val dst: *u8 = out_img.sections[out_ix].bytes;
-            if (dst == nil) {
-                ret err[bool, str]("linker: relocation patch site lands in a BSS section");
-            }
-            val patch_off: u32 = pl.offset + r.offset;
+        val pr: Result[bool, str] = patch_module_relocations(s, out_img, modules, m,
+            placements, sec_base, sym_locs, dyn, ?kinds, ?local_map);
+        map.dnit[intern.StrId, u64](?local_map);
+        if (is_err[bool, str](pr)) { ret err[bool, str](unwrap_err[bool, str](pr)); }
 
-            # locate the target symbol's final virtual address. a LOCAL target is
-            # private to module `m`; resolve it against `m`'s own definition.
-            # GLOBAL targets (and undefined externs) resolve by name via sym_locs.
-            var sym_va: u64 = 0;
-            val lv: Result[u64, str] =
-                local_symbol_vaddr(modules, module_count, m, r.symbol, placements, sec_base);
-            if (is_ok[u64, str](lv)) {
-                sym_va = unwrap_ok[u64, str](lv);
+        m = m + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# build_local_index: fill `out` with module `m`'s LOCAL (object-private) symbol
+# definitions, name -> final virtual address. the first definition of a name wins,
+# mirroring the linear scan it replaces. EXTERNAL, out-of-range, and GLOBAL symbols
+# are excluded — globals live in the cross-object table.
+fun build_local_index(modules: *of.ObjectImage, m: u32, placements: *Placement, sec_base: *u32,
+                      out: *map.Map[intern.StrId, u64]) Result[bool, str] {
+    var sy: u32 = 0;
+    for (sy < modules[m].symbol_count) {
+        val sym: *of.Symbol = ?modules[m].symbols[sy];
+        if (sym.section == of.SECTION_EXTERNAL) { sy = sy + 1; cnt; }
+        if (sym.section >= modules[m].section_count) { sy = sy + 1; cnt; }
+        if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0) { sy = sy + 1; cnt; }
+
+        if (is_err[*u64, str](map.get[intern.StrId, u64](out, ?sym.name))) {
+            val flat: u32 = sec_base[m] + sym.section;
+            val va: u64 = placements[flat].vaddr + sym.offset::u64;
+            val ins: Result[bool, str] = map.insert[intern.StrId, u64](out, sym.name, va);
+            if (is_err[bool, str](ins)) { ret err[bool, str](unwrap_err[bool, str](ins)); }
+        }
+        sy = sy + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# patch_module_relocations: apply every relocation in module `m` into the merged
+# bytes. a LOCAL target resolves through `local_map` (module `m`'s private index);
+# a GLOBAL target (or an undefined extern) resolves by name through `sym_locs`, and
+# an unresolved pc-relative call to a function import is deferred as a PltFixup.
+fun patch_module_relocations(s: *sess.Session, out_img: *of.ObjectImage,
+                             modules: *of.ObjectImage, m: u32,
+                             placements: *Placement, sec_base: *u32,
+                             sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
+                             kinds: *RelocKindIds, local_map: *map.Map[intern.StrId, u64]) Result[bool, str] {
+    var ri: u32 = 0;
+    for (ri < modules[m].reloc_count) {
+        val r: *of.Relocation = ?modules[m].relocations[ri];
+        # a corrupt object can name an out-of-range section, or an offset past the
+        # end of its own section (which would wrap the u32 patch cursor and scribble
+        # outside the merged buffer). reject both loudly instead of silently dropping
+        # the relocation, which would ship an executable with an unpatched site.
+        if (r.section >= modules[m].section_count) {
+            ret err[bool, str]("linker: relocation names an out-of-range section");
+        }
+        if (r.offset > modules[m].sections[r.section].len) {
+            ret err[bool, str]("linker: relocation offset is past the end of its section");
+        }
+
+        # the patch site's location in the merged image. the placement's
+        # merged_index is a section *kind*; map it to the output-section index.
+        val flat: u32 = sec_base[m] + r.section;
+        val pl: *Placement = ?placements[flat];
+        val patch_va: u64 = pl.vaddr + r.offset::u64;
+        val out_ix: u32 = out_section_for_merged(out_img, pl.merged_index);
+        # a relocation in a section with no merged output, or one whose patch site
+        # lands in a (byteless) BSS section, cannot be applied — that is a contract
+        # violation from a buggy parser/codegen, not a relocation to quietly skip.
+        if (out_ix == 0xFFFFFFFF) {
+            ret err[bool, str]("linker: relocation targets a section with no merged output");
+        }
+        val dst: *u8 = out_img.sections[out_ix].bytes;
+        if (dst == nil) {
+            ret err[bool, str]("linker: relocation patch site lands in a BSS section");
+        }
+        val patch_off: u32 = pl.offset + r.offset;
+
+        # locate the target symbol's final virtual address. a LOCAL target is
+        # private to module `m`; resolve it through `m`'s local index. GLOBAL targets
+        # (and undefined externs) resolve by name via sym_locs.
+        var sym_va: u64 = 0;
+        val lvm: Result[*u64, str] = map.get[intern.StrId, u64](local_map, ?r.symbol);
+        if (is_ok[*u64, str](lvm)) {
+            sym_va = @unwrap_ok[*u64, str](lvm);
+        }
+        or {
+            val sl: Result[*SymbolLoc, str] =
+                map.get[intern.StrId, SymbolLoc](sym_locs, ?r.symbol);
+            if (is_ok[*SymbolLoc, str](sl)) {
+                sym_va = unwrap_ok[*SymbolLoc, str](sl).vaddr;
             }
             or {
-                val sl: Result[*SymbolLoc, str] =
-                    map.get[intern.StrId, SymbolLoc](sym_locs, ?r.symbol);
-                if (is_ok[*SymbolLoc, str](sl)) {
-                    sym_va = unwrap_ok[*SymbolLoc, str](sl).vaddr;
+                # not defined anywhere: a dynamic import, or a hard error. a
+                # pc-relative call to a FUNCTION import is deferred to the writer
+                # (only function imports get a PLT stub); any other unresolved
+                # reference — including a call kind against a data import (deferred)
+                # — is rejected as undefined.
+                val imp: Result[u32, str] = dynstate_import_index(dyn, r.symbol);
+                if (is_ok[u32, str](imp) && is_call_kind(kinds, r.kind)
+                    && dynstate_import_is_func(dyn, unwrap_ok[u32, str](imp))) {
+                    val rec_r: Result[bool, str] = dynstate_add_fixup(s, dyn,
+                        segment_index_for(out_img, out_ix), patch_off,
+                        unwrap_ok[u32, str](imp), patch_va, r.addend);
+                    if (is_err[bool, str](rec_r)) { ret err[bool, str](unwrap_err[bool, str](rec_r)); }
+                    ri = ri + 1; cnt;
                 }
-                or {
-                    # not defined anywhere: a dynamic import, or a hard error. a
-                    # pc-relative call to a FUNCTION import is deferred to the
-                    # writer (only function imports get a PLT stub); any other
-                    # unresolved reference — including a call kind against a data
-                    # import (deferred) — is rejected as undefined.
-                    val imp: Result[u32, str] = dynstate_import_index(dyn, r.symbol);
-                    if (is_ok[u32, str](imp) && is_call_kind(?kinds, r.kind)
-                        && dynstate_import_is_func(dyn, unwrap_ok[u32, str](imp))) {
-                        val rec_r: Result[bool, str] = dynstate_add_fixup(s, dyn,
-                            segment_index_for(out_img, out_ix), patch_off,
-                            unwrap_ok[u32, str](imp), patch_va, r.addend);
-                        if (is_err[bool, str](rec_r)) { ret err[bool, str](unwrap_err[bool, str](rec_r)); }
-                        ri = ri + 1; cnt;
-                    }
-                    ret err[bool, str](undef_message(s, r.symbol));
-                }
+                ret err[bool, str](undef_message(s, r.symbol));
             }
-
-            val pr: Result[bool, str] =
-                apply_one(s, ?kinds, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va, m, r.offset);
-            if (is_err[bool, str](pr)) {
-                ret err[bool, str](unwrap_err[bool, str](pr));
-            }
-
-            ri = ri + 1;
         }
-        m = m + 1;
+
+        val pr: Result[bool, str] =
+            apply_one(s, kinds, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va, m, r.offset);
+        if (is_err[bool, str](pr)) {
+            ret err[bool, str](unwrap_err[bool, str](pr));
+        }
+
+        ri = ri + 1;
     }
     ret ok[bool, str](true);
 }
@@ -1449,40 +1501,6 @@ fun dynstate_add_fixup(s: *sess.Session, dyn: *DynState, seg_index: u32, seg_off
     dyn.fixups[ix].addend       = addend;
     dyn.fixup_count = ix + 1;
     ret ok[bool, str](true);
-}
-
-# local_symbol_vaddr: resolve a relocation target that names a LOCAL (object-
-# private) symbol of module `m` to its final virtual address.
-#
-# scans module `m`'s symbols for a defined (non-external) symbol named `name`
-# that is LOCAL (no GLOBAL flag) and computes its final virtual address the same
-# way collect_symbols rebases a definition: the vaddr of the placement of the
-# symbol's section plus the symbol's offset. returns err when module `m` has no
-# such local symbol, so the caller resolves the name through the cross-object
-# global table instead. mirrors how a real linker keeps locals per-object.
-# ---
-# modules:      parsed input images
-# module_count: number of images
-# m:            index of the module owning the relocation
-# name:         interned name of the referenced symbol
-# placements:   per-input-section placements (carry final vaddrs)
-# sec_base:     per-module base into the flat placement array
-# ret:          the local symbol's final virtual address, or err if none
-fun local_symbol_vaddr(modules: *of.ObjectImage, module_count: u32, m: u32,
-                       name: intern.StrId, placements: *Placement, sec_base: *u32) Result[u64, str] {
-    if (m >= module_count) { ret err[u64, str]("no local"); }
-    var sy: u32 = 0;
-    for (sy < modules[m].symbol_count) {
-        val sym: *of.Symbol = ?modules[m].symbols[sy];
-        if (sym.name != name) { sy = sy + 1; cnt; }
-        if (sym.section == of.SECTION_EXTERNAL) { sy = sy + 1; cnt; }
-        if (sym.section >= modules[m].section_count) { sy = sy + 1; cnt; }
-        if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0) { sy = sy + 1; cnt; }
-
-        val flat: u32 = sec_base[m] + sym.section;
-        ret ok[u64, str](placements[flat].vaddr + sym.offset::u64);
-    }
-    ret err[u64, str]("no local");
 }
 
 # apply_one: write a single resolved relocation into the merged bytes. `abs64`

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -238,7 +238,13 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     }
     sec_base = unwrap_ok[*u32, str](br);
 
-    accumulate_sections(modules, module_count, ?merged[0], placements, sec_base);
+    val acc_r: Result[bool, str] =
+        accumulate_sections(modules, module_count, ?merged[0], placements, sec_base);
+    if (is_err[bool, str](acc_r)) {
+        free_scratch(alloc, placements, sec_total, sec_base, module_count);
+        free_modules(alloc, modules, module_count);
+        ret err[bool, str](unwrap_err[bool, str](acc_r));
+    }
 
     # assign each merged section a virtual address (executables only). sections
     # are placed in canonical order from the OS base, each kind page-aligned.
@@ -902,7 +908,7 @@ fun total_sections(modules: *of.ObjectImage, module_count: u32) u32 {
 # merged section). also fills `sec_base` with the per-module prefix offset into
 # the flat placement array.
 fun accumulate_sections(modules: *of.ObjectImage, module_count: u32,
-                        merged: *MergedSection, placements: *Placement, sec_base: *u32) {
+                        merged: *MergedSection, placements: *Placement, sec_base: *u32) Result[bool, str] {
     var flat: u32 = 0;
     var m: u32 = 0;
     for (m < module_count) {
@@ -910,19 +916,33 @@ fun accumulate_sections(modules: *of.ObjectImage, module_count: u32,
         var sc: u32 = 0;
         for (sc < modules[m].section_count) {
             val sec: *of.Section = ?modules[m].sections[sc];
-            val ki: u32 = clamp_kind(sec.kind);
+            # the parser must hand the linker one of the known section kinds; an
+            # out-of-range kind is a contract violation, not a section to silently
+            # fold into .debug.
+            if (sec.kind::u32 >= MERGED_KIND_COUNT) {
+                ret err[bool, str]("linker: input section has an unknown section kind");
+            }
+            val ki: u32 = sec.kind::u32;
 
             var a: u32 = sec.align;
             if (a == 0) { a = 1; }
             if (a > merged[ki].align) { merged[ki].align = a; }
 
-            # align the running offset to this section's alignment.
-            val off: u32 = align_up_u32(merged[ki].len, a);
+            # align the running offset to this section's alignment and add this
+            # section's bytes, computed in u64 so a >4GiB merged section group is
+            # rejected rather than wrapping the u32 length into a tiny value that
+            # later truncates the output.
+            val off64: u64 = bin.align_up_u64(merged[ki].len::u64, a::u64);
+            val newlen: u64 = off64 + sec.len::u64;
+            if (newlen > 0xFFFFFFFF) {
+                ret err[bool, str]("linker: merged section size exceeds the 4 GiB u32 limit");
+            }
+
             placements[flat].merged_index = ki;
-            placements[flat].offset       = off;
+            placements[flat].offset       = off64::u32;
             placements[flat].vaddr        = 0;
 
-            merged[ki].len  = off + sec.len;
+            merged[ki].len  = newlen::u32;
             merged[ki].used = true;
 
             flat = flat + 1;
@@ -930,6 +950,7 @@ fun accumulate_sections(modules: *of.ObjectImage, module_count: u32,
         }
         m = m + 1;
     }
+    ret ok[bool, str](true);
 }
 
 # assign_section_vaddrs: give each used merged section a base virtual address,
@@ -979,7 +1000,12 @@ fun collect_symbols(s: *sess.Session, modules: *of.ObjectImage, module_count: u3
         for (sy < modules[m].symbol_count) {
             val sym: *of.Symbol = ?modules[m].symbols[sy];
             if (sym.section == of.SECTION_EXTERNAL) { sy = sy + 1; cnt; }
-            if (sym.section >= modules[m].section_count) { sy = sy + 1; cnt; }
+            # a defined symbol whose section index is out of range is a corrupt
+            # object: erroring here surfaces it directly instead of letting the
+            # definition vanish and resurface later as a baffling undefined symbol.
+            if (sym.section >= modules[m].section_count) {
+                ret err[bool, str]("linker: symbol names an out-of-range section");
+            }
             if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0) { sy = sy + 1; cnt; }
 
             val flat: u32 = sec_base[m] + sym.section;
@@ -1150,7 +1176,17 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
         var ri: u32 = 0;
         for (ri < modules[m].reloc_count) {
             val r: *of.Relocation = ?modules[m].relocations[ri];
-            if (r.section >= modules[m].section_count) { ri = ri + 1; cnt; }
+            # a corrupt object can name an out-of-range section, or an offset past
+            # the end of its own section (which would wrap the u32 patch cursor and
+            # scribble outside the merged buffer). reject both loudly instead of
+            # silently dropping the relocation, which would ship an executable with
+            # an unpatched site.
+            if (r.section >= modules[m].section_count) {
+                ret err[bool, str]("linker: relocation names an out-of-range section");
+            }
+            if (r.offset > modules[m].sections[r.section].len) {
+                ret err[bool, str]("linker: relocation offset is past the end of its section");
+            }
 
             # the patch site's location in the merged image. the placement's
             # merged_index is a section *kind*; map it to the output-section index.
@@ -1158,9 +1194,17 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
             val pl: *Placement = ?placements[flat];
             val patch_va: u64 = pl.vaddr + r.offset::u64;
             val out_ix: u32 = out_section_for_merged(out_img, pl.merged_index);
-            if (out_ix == 0xFFFFFFFF) { ri = ri + 1; cnt; }
+            # a relocation in a section with no merged output, or one whose patch
+            # site lands in a (byteless) BSS section, cannot be applied — that is a
+            # contract violation from a buggy parser/codegen, not a relocation to
+            # quietly skip.
+            if (out_ix == 0xFFFFFFFF) {
+                ret err[bool, str]("linker: relocation targets a section with no merged output");
+            }
             val dst: *u8 = out_img.sections[out_ix].bytes;
-            if (dst == nil) { ri = ri + 1; cnt; }
+            if (dst == nil) {
+                ret err[bool, str]("linker: relocation patch site lands in a BSS section");
+            }
             val patch_off: u32 = pl.offset + r.offset;
 
             # locate the target symbol's final virtual address. a LOCAL target is
@@ -1448,7 +1492,10 @@ fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
              dst: *u8, patch_off: u32, sec_len: u32,
              sym_va: u64, addend: i64, patch_va: u64, module: u32, rel_off: u32) Result[bool, str] {
     if (kind == kinds.abs64) {
-        if (patch_off + 8 > sec_len) {
+        # bound the patch site in u64: patch_off + width can wrap a u32 for an
+        # offset near 0xFFFFFFFF, which would pass a u32 check and then scribble
+        # outside the merged buffer.
+        if (patch_off::u64 + 8 > sec_len::u64) {
             ret err[bool, str](overflow_message(s, kind, module, rel_off));
         }
         val value: u64 = sym_va + (addend::u64);
@@ -1457,7 +1504,7 @@ fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
     }
 
     if (kind == kinds.pc32 || kind == kinds.plt32) {
-        if (patch_off + 4 > sec_len) {
+        if (patch_off::u64 + 4 > sec_len::u64) {
             ret err[bool, str](overflow_message(s, kind, module, rel_off));
         }
         val disp: i64 = (sym_va::i64) + addend - (patch_va::i64);
@@ -1470,7 +1517,7 @@ fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
 
     # abs32s: 32-bit signed absolute.
     if (kind == kinds.abs32s) {
-        if (patch_off + 4 > sec_len) {
+        if (patch_off::u64 + 4 > sec_len::u64) {
             ret err[bool, str](overflow_message(s, kind, module, rel_off));
         }
         val v: i64 = (sym_va::i64) + addend;
@@ -1494,7 +1541,14 @@ fun carry_relocations(out_img: *of.ObjectImage, modules: *of.ObjectImage, module
         var ri: u32 = 0;
         for (ri < modules[m].reloc_count) {
             val r: *of.Relocation = ?modules[m].relocations[ri];
-            if (r.section >= modules[m].section_count) { ri = ri + 1; cnt; }
+            # reject the same corrupt-input conditions the patch path does, rather
+            # than silently dropping a relocation from the carried-forward object.
+            if (r.section >= modules[m].section_count) {
+                ret err[bool, str]("linker: relocation names an out-of-range section");
+            }
+            if (r.offset > modules[m].sections[r.section].len) {
+                ret err[bool, str]("linker: relocation offset is past the end of its section");
+            }
 
             val flat: u32 = sec_base[m] + r.section;
             val pl: *Placement = ?placements[flat];
@@ -1502,7 +1556,9 @@ fun carry_relocations(out_img: *of.ObjectImage, modules: *of.ObjectImage, module
             # find the output-section index for this kind by matching merged
             # index against the already-added output sections.
             val out_ix: u32 = out_section_for_merged(out_img, pl.merged_index);
-            if (out_ix == 0xFFFFFFFF) { ri = ri + 1; cnt; }
+            if (out_ix == 0xFFFFFFFF) {
+                ret err[bool, str]("linker: relocation targets a section with no merged output");
+            }
 
             var orel: of.Relocation;
             orel.section = out_ix;
@@ -1596,21 +1652,6 @@ fun os_base_addr(tgt: *target.Target) u64 {
 # read from the OS vtable (`tgt.os.page_size`).
 fun os_page_size(tgt: *target.Target) u64 {
     ret tgt.os.page_size;
-}
-
-# clamp_kind: map a section kind to a valid merged-accumulator index, treating
-# any out-of-range kind as DEBUG so unknown sections are merged but never
-# loaded.
-fun clamp_kind(kind: of.SectionKind) u32 {
-    if (kind::u32 >= MERGED_KIND_COUNT) { ret of.SK_DEBUG::u32; }
-    ret kind::u32;
-}
-
-# align_up_u32: round `value` up to the next multiple of `align` (a power of
-# two, or 1 for no alignment).
-fun align_up_u32(value: u32, align: u32) u32 {
-    if (align <= 1) { ret value; }
-    ret (value + align - 1) & ~(align - 1);
 }
 
 # dup_message: build the "multiple definition of '<name>'" diagnostic string.

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -51,6 +51,7 @@ use mem: std.memory;
 use fs:  std.filesystem;
 use map: std.collections.map;
 use maphash: std.collections.map;
+use page: std.allocator.page;
 
 use sess:   mach.lang.session;
 use intern: mach.lang.intern;
@@ -105,12 +106,17 @@ rec MergedSection {
     used:  bool;
 }
 
-# resolved location of a defined symbol: its final virtual address (the only
-# datum relocation patching needs). undefined symbols never enter this table.
+# resolved location of a defined symbol: its final virtual address (what
+# relocation patching needs) and whether the winning definition is weak, so a
+# later strong definition can override it rather than collide. undefined symbols
+# never enter this table.
 # ---
 # vaddr: final virtual address of the symbol (its section's vaddr + offset)
+# weak:  true while the current winner is a weak definition (overridable by a
+#        later strong definition; a strong winner errors on a second strong)
 rec SymbolLoc {
     vaddr: u64;
+    weak:  bool;
 }
 
 # the linker's mutable dynamic-link state: the format-neutral plan (`of.DynamicInfo`)
@@ -979,24 +985,29 @@ fun collect_symbols(s: *sess.Session, modules: *of.ObjectImage, module_count: u3
             val flat: u32 = sec_base[m] + sym.section;
             val pl: *Placement = ?placements[flat];
 
+            val is_weak: bool = (sym.flags & of.SYM_OBJ_FLAG_WEAK) != 0;
+            var vaddr: u64 = 0;
+            if (have_vaddrs) { vaddr = pl.vaddr + sym.offset::u64; }
+
             val existing: Result[*SymbolLoc, str] =
                 map.get[intern.StrId, SymbolLoc](sym_locs, ?sym.name);
             if (is_ok[*SymbolLoc, str](existing)) {
-                val is_weak: bool = (sym.flags & of.SYM_OBJ_FLAG_WEAK) != 0;
-                if (!is_weak) {
-                    ret err[bool, str](dup_message(s, sym.name));
-                }
+                # standard weak/strong resolution, independent of input order: a weak
+                # definition never displaces an existing one; a strong definition
+                # overrides an existing weak winner (taking its address) but collides
+                # with an existing strong one.
+                val cur: *SymbolLoc = unwrap_ok[*SymbolLoc, str](existing);
+                if (is_weak) { sy = sy + 1; cnt; }
+                if (!cur.weak) { ret err[bool, str](dup_message(s, sym.name)); }
+                cur.vaddr = vaddr;
+                cur.weak = false;
                 sy = sy + 1;
                 cnt;
             }
 
             var loc: SymbolLoc;
-            if (have_vaddrs) {
-                loc.vaddr = pl.vaddr + sym.offset::u64;
-            }
-            or {
-                loc.vaddr = 0;
-            }
+            loc.vaddr = vaddr;
+            loc.weak = is_weak;
 
             val ins: Result[bool, str] =
                 map.insert[intern.StrId, SymbolLoc](sym_locs, sym.name, loc);
@@ -1757,4 +1768,76 @@ fun cstr_len(p: *u8) usize {
     var n: usize = 0;
     for (p[n] != 0) { n = n + 1; }
     ret n;
+}
+
+# lt_link: collect two single-symbol modules into a fresh symbol table and return
+# the winning definition's resolved virtual address (or the collect error). a test
+# helper for the weak/strong resolution rules; module 0 is placed at 0x1000 and
+# module 1 at 0x2000 so the winner is identifiable by address.
+fun lt_link(s: *sess.Session, name: intern.StrId, a: *of.Symbol, b: *of.Symbol) Result[u64, str] {
+    var placements: [2]Placement;
+    placements[0].vaddr = 0x1000; placements[0].offset = 0; placements[0].merged_index = 0;
+    placements[1].vaddr = 0x2000; placements[1].offset = 0; placements[1].merged_index = 0;
+    var sec_base: [2]u32;
+    sec_base[0] = 0; sec_base[1] = 1;
+
+    var mods: [2]of.ObjectImage;
+    mods[0].alloc = s.alloc; mods[0].symbols = a; mods[0].symbol_count = 1;
+    mods[0].sections = nil; mods[0].section_count = 1; mods[0].relocations = nil; mods[0].reloc_count = 0;
+    mods[1].alloc = s.alloc; mods[1].symbols = b; mods[1].symbol_count = 1;
+    mods[1].sections = nil; mods[1].section_count = 1; mods[1].relocations = nil; mods[1].reloc_count = 0;
+
+    var locs: map.Map[intern.StrId, SymbolLoc] =
+        map.init[intern.StrId, SymbolLoc](s.alloc, maphash.hash_u32, maphash.eq_u32);
+    val cr: Result[bool, str] = collect_symbols(s, ?mods[0], 2, ?placements[0], ?sec_base[0], ?locs, true);
+    if (is_err[bool, str](cr)) {
+        map.dnit[intern.StrId, SymbolLoc](?locs);
+        ret err[u64, str](unwrap_err[bool, str](cr));
+    }
+    val g: Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](?locs, ?name);
+    if (is_err[*SymbolLoc, str](g)) {
+        map.dnit[intern.StrId, SymbolLoc](?locs);
+        ret err[u64, str]("missing");
+    }
+    val v: u64 = unwrap_ok[*SymbolLoc, str](g).vaddr;
+    map.dnit[intern.StrId, SymbolLoc](?locs);
+    ret ok[u64, str](v);
+}
+
+test "linker: weak/strong symbol resolution is order-independent (#1257)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    val ri: Result[intern.StrId, str] = intern.intern(?s.interner, "dup");
+    if (is_err[intern.StrId, str](ri)) { ret 1; }
+    val nm: intern.StrId = unwrap_ok[intern.StrId, str](ri);
+
+    var weak: of.Symbol;
+    weak.name = nm; weak.section = 0; weak.offset = 0; weak.size = 0;
+    weak.flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK;
+    var strong: of.Symbol;
+    strong.name = nm; strong.section = 0; strong.offset = 0; strong.size = 0;
+    strong.flags = of.SYM_OBJ_FLAG_GLOBAL;
+    var strong2: of.Symbol;
+    strong2.name = nm; strong2.section = 0; strong2.offset = 0; strong2.size = 0;
+    strong2.flags = of.SYM_OBJ_FLAG_GLOBAL;
+
+    # weak-then-strong: the strong definition must override the weak one (before
+    # #1257 this was a hard "multiple definition" error), and its address wins.
+    val r1: Result[u64, str] = lt_link(?s, nm, ?weak, ?strong);
+    if (is_err[u64, str](r1)) { ret 1; }
+    if (unwrap_ok[u64, str](r1) != 0x2000) { ret 1; }
+
+    # strong-then-weak: the later weak definition is skipped; the strong wins.
+    val r2: Result[u64, str] = lt_link(?s, nm, ?strong, ?weak);
+    if (is_err[u64, str](r2)) { ret 1; }
+    if (unwrap_ok[u64, str](r2) != 0x1000) { ret 1; }
+
+    # strong-then-strong: still a multiple-definition error.
+    val r3: Result[u64, str] = lt_link(?s, nm, ?strong, ?strong2);
+    if (!is_err[u64, str](r3)) { ret 1; }
+    ret 0;
 }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -50,7 +50,6 @@ use std.allocator.deallocate;
 use mem: std.memory;
 use fs:  std.filesystem;
 use map: std.collections.map;
-use maphash: std.collections.map;
 use page: std.allocator.page;
 
 use sess:   mach.lang.session;
@@ -177,7 +176,7 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     if (tgt.of == nil) { ret err[bool, str]("link: target has no object-format vtable"); }
     if (tgt.os == nil) { ret err[bool, str]("link: target has no OS vtable"); }
     if (mode == LINK_SHARED) {
-        ret err[bool, str]("relocation 'shared' not supported by linker");
+        ret err[bool, str]("link: shared-object output (LINK_SHARED) is not supported");
     }
     if (obj_paths == nil || obj_count == 0) {
         ret err[bool, str]("link: no input objects");
@@ -257,7 +256,7 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     # collect the global symbol table: every defined symbol keyed by name, with
     # its resolved location. duplicate strong definitions are rejected.
     var sym_locs: map.Map[intern.StrId, SymbolLoc] =
-        map.init[intern.StrId, SymbolLoc](alloc, maphash.hash_u32, maphash.eq_u32);
+        map.init[intern.StrId, SymbolLoc](alloc, map.hash_u32, map.eq_u32);
 
     val collect_r: Result[bool, str] =
         collect_symbols(s, modules, module_count, placements, sec_base, ?sym_locs, assign_vaddrs);
@@ -1180,7 +1179,7 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
         # through the cross-object sym_locs table. the map is always freed after the
         # module's relocations are patched, regardless of outcome.
         var local_map: map.Map[intern.StrId, u64] =
-            map.init[intern.StrId, u64](alloc, maphash.hash_u32, maphash.eq_u32);
+            map.init[intern.StrId, u64](alloc, map.hash_u32, map.eq_u32);
         val br: Result[bool, str] = build_local_index(modules, m, placements, sec_base, ?local_map);
         if (is_err[bool, str](br)) {
             map.dnit[intern.StrId, u64](?local_map);
@@ -1296,7 +1295,7 @@ fun patch_module_relocations(s: *sess.Session, out_img: *of.ObjectImage,
         }
 
         val pr: Result[bool, str] =
-            apply_one(s, kinds, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va, m, r.offset);
+            apply_one(s, kinds, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va);
         if (is_err[bool, str](pr)) {
             ret err[bool, str](unwrap_err[bool, str](pr));
         }
@@ -1373,12 +1372,12 @@ fun build_dynamic_info(s: *sess.Session, tgt: *target.Target, dyn: *DynState,
         dyn.info.lib_count = soname_count;
     }
 
-    dyn.import_map = map.init[intern.StrId, u32](alloc, maphash.hash_u32, maphash.eq_u32);
+    dyn.import_map = map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
     dyn.active = true;
 
     # count distinct undefined externs first so the import array is sized exactly.
     var seen: map.Map[intern.StrId, u32] =
-        map.init[intern.StrId, u32](alloc, maphash.hash_u32, maphash.eq_u32);
+        map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
     var n_imports: u32 = 0;
     var m: u32 = 0;
     for (m < module_count) {
@@ -1508,13 +1507,13 @@ fun dynstate_add_fixup(s: *sess.Session, dyn: *DynState, seg_index: u32, seg_off
 # little-endian pc-relative displacement. bounds and 32-bit range are checked.
 fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
              dst: *u8, patch_off: u32, sec_len: u32,
-             sym_va: u64, addend: i64, patch_va: u64, module: u32, rel_off: u32) Result[bool, str] {
+             sym_va: u64, addend: i64, patch_va: u64) Result[bool, str] {
     if (kind == kinds.abs64) {
         # bound the patch site in u64: patch_off + width can wrap a u32 for an
         # offset near 0xFFFFFFFF, which would pass a u32 check and then scribble
         # outside the merged buffer.
         if (patch_off::u64 + 8 > sec_len::u64) {
-            ret err[bool, str](overflow_message(s, kind, module, rel_off));
+            ret err[bool, str](overflow_message(s, kind));
         }
         val value: u64 = sym_va + (addend::u64);
         bin.write_u64_le(dst, patch_off::usize, value);
@@ -1523,11 +1522,11 @@ fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
 
     if (kind == kinds.pc32 || kind == kinds.plt32) {
         if (patch_off::u64 + 4 > sec_len::u64) {
-            ret err[bool, str](overflow_message(s, kind, module, rel_off));
+            ret err[bool, str](overflow_message(s, kind));
         }
         val disp: i64 = (sym_va::i64) + addend - (patch_va::i64);
         if (disp > 2147483647 || disp < -2147483648) {
-            ret err[bool, str](overflow_message(s, kind, module, rel_off));
+            ret err[bool, str](overflow_message(s, kind));
         }
         bin.write_u32_le(dst, patch_off::usize, ((disp::u64) & 0xFFFFFFFF)::u32);
         ret ok[bool, str](true);
@@ -1536,11 +1535,11 @@ fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
     # abs32s: 32-bit signed absolute.
     if (kind == kinds.abs32s) {
         if (patch_off::u64 + 4 > sec_len::u64) {
-            ret err[bool, str](overflow_message(s, kind, module, rel_off));
+            ret err[bool, str](overflow_message(s, kind));
         }
         val v: i64 = (sym_va::i64) + addend;
         if (v > 2147483647 || v < -2147483648) {
-            ret err[bool, str](overflow_message(s, kind, module, rel_off));
+            ret err[bool, str](overflow_message(s, kind));
         }
         bin.write_u32_le(dst, patch_off::usize, ((v::u64) & 0xFFFFFFFF)::u32);
         ret ok[bool, str](true);
@@ -1687,7 +1686,7 @@ fun undef_message(s: *sess.Session, name: intern.StrId) str {
 }
 
 # overflow_message: build the "relocation '<kind>' overflows" diagnostic string.
-fun overflow_message(s: *sess.Session, kind: intern.StrId, module: u32, rel_off: u32) str {
+fun overflow_message(s: *sess.Session, kind: intern.StrId) str {
     val km: Option[str] = intern.lookup(?s.interner, kind);
     if (is_some[str](km)) { ret join3(s, "relocation '", unwrap[str](km), "' overflows", "relocation overflows"); }
     ret "relocation overflows";
@@ -1821,14 +1820,6 @@ fun free_modules_to(alloc: *Allocator, modules: *of.ObjectImage, n: u32, cap: u3
     }
 }
 
-# cstr_len: length of a null-terminated byte string, excluding the terminator.
-fun cstr_len(p: *u8) usize {
-    if (p == nil) { ret 0; }
-    var n: usize = 0;
-    for (p[n] != 0) { n = n + 1; }
-    ret n;
-}
-
 # lt_link: collect two single-symbol modules into a fresh symbol table and return
 # the winning definition's resolved virtual address (or the collect error). a test
 # helper for the weak/strong resolution rules; module 0 is placed at 0x1000 and
@@ -1847,7 +1838,7 @@ fun lt_link(s: *sess.Session, name: intern.StrId, a: *of.Symbol, b: *of.Symbol) 
     mods[1].sections = nil; mods[1].section_count = 1; mods[1].relocations = nil; mods[1].reloc_count = 0;
 
     var locs: map.Map[intern.StrId, SymbolLoc] =
-        map.init[intern.StrId, SymbolLoc](s.alloc, maphash.hash_u32, maphash.eq_u32);
+        map.init[intern.StrId, SymbolLoc](s.alloc, map.hash_u32, map.eq_u32);
     val cr: Result[bool, str] = collect_symbols(s, ?mods[0], 2, ?placements[0], ?sec_base[0], ?locs, true);
     if (is_err[bool, str](cr)) {
         map.dnit[intern.StrId, SymbolLoc](?locs);

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -105,10 +105,10 @@ pub fun register_all(i: *intern.Interner) Result[bool, str] {
     val r_elf: Result[bool, str] = elf.register(i);
     if (is_err[bool, str](r_elf)) { ret err[bool, str](unwrap_err[bool, str](r_elf)); }
 
-    val r_coff: Result[bool, str] = coff.register_coff(i.alloc, i);
+    val r_coff: Result[bool, str] = coff.register_coff(i);
     if (is_err[bool, str](r_coff)) { ret err[bool, str](unwrap_err[bool, str](r_coff)); }
 
-    val r_macho: Result[bool, str] = macho.register_macho(i.alloc, i);
+    val r_macho: Result[bool, str] = macho.register_macho(i);
     if (is_err[bool, str](r_macho)) { ret err[bool, str](unwrap_err[bool, str](r_macho)); }
 
     val r_linux: Result[bool, str] = linux.register_linux(i.alloc, i);

--- a/src/lang/target/of/bin.mach
+++ b/src/lang/target/of/bin.mach
@@ -1,0 +1,161 @@
+# mach.lang.target.of.bin: shared binary-IO support for the object formats.
+#
+# The ELF, COFF, and Mach-O writers — and the linker's executable patcher — all
+# serialize and parse the same little-endian integer fields, write the same
+# null-terminated names, and align the same file/virtual cursors. This module
+# owns that mechanical layer so the format files carry only format knowledge and
+# the three copies of these helpers cannot drift apart.
+#
+# It also owns the bounds-checked side every parser needs: `region_ok` /
+# `require_region` validate a header-derived `offset + len` against the input
+# size before any dereference, and `cstr_at` reads a name only when it is
+# terminated inside the buffer — so a truncated or hostile `.o`/`.a` errors
+# loudly instead of walking off the end of the mapped bytes.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+
+use std.allocator.Allocator;
+use std.allocator.zallocate;
+
+use of: mach.lang.target.of;
+
+# write a u16 little-endian into a buffer at `offset`.
+pub fun write_u16_le(buf: *u8, offset: usize, value: u16) {
+    buf[offset]     = (value & 0xFF)::u8;
+    buf[offset + 1] = ((value >> 8) & 0xFF)::u8;
+}
+
+# write a u32 little-endian into a buffer at `offset`.
+pub fun write_u32_le(buf: *u8, offset: usize, value: u32) {
+    buf[offset]     = (value & 0xFF)::u8;
+    buf[offset + 1] = ((value >> 8) & 0xFF)::u8;
+    buf[offset + 2] = ((value >> 16) & 0xFF)::u8;
+    buf[offset + 3] = ((value >> 24) & 0xFF)::u8;
+}
+
+# write a u64 little-endian into a buffer at `offset`.
+pub fun write_u64_le(buf: *u8, offset: usize, value: u64) {
+    write_u32_le(buf, offset, (value & 0xFFFFFFFF)::u32);
+    write_u32_le(buf, offset + 4, ((value >> 32) & 0xFFFFFFFF)::u32);
+}
+
+# read a u16 little-endian from a buffer at `offset`.
+pub fun read_u16_le(buf: *u8, offset: usize) u16 {
+    ret buf[offset]::u16 | (buf[offset + 1]::u16 << 8);
+}
+
+# read a u32 little-endian from a buffer at `offset`.
+pub fun read_u32_le(buf: *u8, offset: usize) u32 {
+    ret buf[offset]::u32 | (buf[offset + 1]::u32 << 8)
+      | (buf[offset + 2]::u32 << 16) | (buf[offset + 3]::u32 << 24);
+}
+
+# read a u64 little-endian from a buffer at `offset`.
+pub fun read_u64_le(buf: *u8, offset: usize) u64 {
+    ret read_u32_le(buf, offset)::u64 | (read_u32_le(buf, offset + 4)::u64 << 32);
+}
+
+# write a null-terminated string into a buffer at `offset`, returning the bytes
+# written (name length plus the terminator). a nil name writes a lone terminator.
+pub fun write_str(buf: *u8, offset: usize, s: str) usize {
+    if (s == nil) {
+        buf[offset] = 0;
+        ret 1;
+    }
+    val len: usize = str_len(s);
+    var i: usize = 0;
+    for (i < len) {
+        buf[offset + i] = s[i];
+        i = i + 1;
+    }
+    buf[offset + len] = 0;
+    ret len + 1;
+}
+
+# align a usize up to the given power-of-two alignment (0 leaves it unchanged).
+pub fun align_up(value: usize, alignment: usize) usize {
+    if (alignment == 0) { ret value; }
+    ret (value + alignment - 1) & ~(alignment - 1);
+}
+
+# align a u64 up to the given power-of-two alignment (0 leaves it unchanged).
+pub fun align_up_u64(value: u64, alignment: u64) u64 {
+    if (alignment == 0) { ret value; }
+    ret (value + alignment - 1) & ~(alignment - 1);
+}
+
+# whether the byte range `[offset, offset + len)` lies fully within a buffer of
+# `buf_size` bytes. computed without overflow (`len <= buf_size - offset`) so a
+# wrapped `offset + len` from a hostile file field can never spuriously pass.
+pub fun region_ok(buf_size: usize, offset: usize, len: usize) bool {
+    if (offset > buf_size) { ret false; }
+    if (len > buf_size - offset) { ret false; }
+    ret true;
+}
+
+# require that `[offset, offset + len)` lies within a `buf_size`-byte buffer,
+# failing with `msg` otherwise. the up-front guard every parser table walk uses
+# before dereferencing a header-derived offset.
+# ---
+# buf_size: length of the input buffer
+# offset:   start of the range to validate
+# len:      length of the range to validate
+# msg:      diagnostic returned when the range escapes the buffer
+# ret:      ok(true) when in bounds, or err(msg)
+pub fun require_region(buf_size: usize, offset: usize, len: usize, msg: str) Result[bool, str] {
+    if (!region_ok(buf_size, offset, len)) { ret err[bool, str](msg); }
+    ret ok[bool, str](true);
+}
+
+# read a null-terminated name at `offset` only when it is terminated inside the
+# buffer, returning a borrowed str into `buf`. an offset at or past the end, or a
+# run with no terminator before `buf_size`, is an error rather than an off-the-end
+# read. the returned pointer is valid only while `buf` lives; callers intern it.
+# ---
+# buf:      the input buffer
+# buf_size: length of `buf`
+# offset:   byte offset of the name's first character
+# ret:      the borrowed name, or an error string
+pub fun cstr_at(buf: *u8, buf_size: usize, offset: usize) Result[str, str] {
+    if (offset >= buf_size) { ret err[str, str]("bin: string offset out of bounds"); }
+    var i: usize = offset;
+    for (i < buf_size) {
+        if (buf[i] == 0) { ret ok[str, str]((buf::usize + offset)::str); }
+        i = i + 1;
+    }
+    ret err[str, str]("bin: unterminated string in object");
+}
+
+# count the relocations targeting each section of `img` in one pass, returning a
+# `section_count`-long array (`counts[s]` = relocations patching section `s`).
+# replaces the per-section linear scan both writers ran in four separate layout
+# passes — O(sections x relocations) — with one O(relocations) tally. a
+# relocation whose section index is out of range is ignored here; the writers
+# validate ranges separately. the caller owns and frees the returned array.
+# ---
+# alloc: allocator backing the returned array
+# img:   the object image whose relocations are tallied
+# ret:   the per-section reloc-count array, or an allocation error
+pub fun reloc_counts(alloc: *Allocator, img: *of.ObjectImage) Result[*u32, str] {
+    val n: usize = img.section_count::usize;
+    val r: Result[*u32, str] = zallocate[u32](alloc, n);
+    if (is_err[*u32, str](r)) { ret err[*u32, str]("bin: reloc-count table alloc failed"); }
+    val counts: *u32 = unwrap_ok[*u32, str](r);
+    var i: u32 = 0;
+    for (i < img.reloc_count) {
+        val sec: u32 = img.relocations[i].section;
+        if (sec < img.section_count) { counts[sec] = counts[sec] + 1; }
+        i = i + 1;
+    }
+    ret ok[*u32, str](counts);
+}

--- a/src/lang/target/of/bin.mach
+++ b/src/lang/target/of/bin.mach
@@ -23,11 +23,17 @@ use std.types.result.ok;
 use std.types.result.err;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
+use std.types.option.Option;
+use std.types.option.is_some;
+use std.types.option.unwrap;
 
 use std.allocator.Allocator;
+use std.allocator.allocate;
 use std.allocator.zallocate;
+use std.allocator.deallocate;
 
-use of: mach.lang.target.of;
+use intern: mach.lang.intern;
+use of:     mach.lang.target.of;
 
 # write a u16 little-endian into a buffer at `offset`.
 pub fun write_u16_le(buf: *u8, offset: usize, value: u16) {
@@ -134,6 +140,81 @@ pub fun cstr_at(buf: *u8, buf_size: usize, offset: usize) Result[str, str] {
         i = i + 1;
     }
     ret err[str, str]("bin: unterminated string in object");
+}
+
+# build the interned diagnostic "<prefix><name>", interned through `itn` so it
+# outlives this call. degrades to `generic` when the name is nil, no interner is
+# available, or interning fails under memory pressure — the caller still fails
+# loudly, just without the offending name. consolidates the per-format
+# unresolved-symbol / unsupported-kind message builders onto one implementation.
+# ---
+# itn:     interner the diagnostic is interned through (nil -> generic)
+# alloc:   allocator for the scratch concatenation buffer
+# prefix:  the fixed message prefix (e.g. "elf: unsupported relocation kind: ")
+# name:    the variable suffix to append (nil -> generic)
+# generic: the fallback used when the named form cannot be built
+# ret:     the interned named diagnostic, or `generic`
+pub fun name_message(itn: *intern.Interner, alloc: *Allocator, prefix: str, name: str, generic: str) str {
+    if (name == nil || itn == nil) { ret generic; }
+    val lpre:  usize = str_len(prefix);
+    val lnam:  usize = str_len(name);
+    val total: usize = lpre + lnam;
+
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret generic; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    for (k < lpre) { buf[k] = prefix[k]; k = k + 1; }
+    var n: usize = 0;
+    for (n < lnam) { buf[lpre + n] = name[n]; n = n + 1; }
+    buf[total] = 0;
+
+    val ir: Result[intern.StrId, str] = intern.intern(itn, buf::str);
+    deallocate[u8](alloc, buf, total + 1);
+    if (is_err[intern.StrId, str](ir)) { ret generic; }
+    val nm: Option[str] = intern.lookup(itn, unwrap_ok[intern.StrId, str](ir));
+    if (is_some[str](nm)) { ret unwrap[str](nm); }
+    ret generic;
+}
+
+# build the interned diagnostic "<prefix><value>" with `value` in decimal,
+# interned through `itn`. degrades to `generic` like `name_message`. used to name
+# an unknown machine relocation type a parser cannot map to an abstract kind.
+# ---
+# itn:     interner the diagnostic is interned through (nil -> generic)
+# alloc:   allocator for the scratch buffer
+# prefix:  the fixed message prefix (e.g. "elf: unsupported relocation type ")
+# value:   the numeric suffix, formatted in decimal
+# generic: the fallback used when the formatted form cannot be built
+# ret:     the interned diagnostic, or `generic`
+pub fun number_message(itn: *intern.Interner, alloc: *Allocator, prefix: str, value: u64, generic: str) str {
+    if (itn == nil) { ret generic; }
+    # decimal digits of `value` (at least one for zero), most-significant first.
+    var digits: [20]u8;
+    var ndig: usize = 0;
+    var v: u64 = value;
+    if (v == 0) { digits[0] = '0'; ndig = 1; }
+    or {
+        for (v > 0) { digits[ndig] = ('0'::u64 + (v % 10))::u8; v = v / 10; ndig = ndig + 1; }
+    }
+
+    val lpre:  usize = str_len(prefix);
+    val total: usize = lpre + ndig;
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret generic; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    for (k < lpre) { buf[k] = prefix[k]; k = k + 1; }
+    var d: usize = 0;
+    for (d < ndig) { buf[lpre + d] = digits[ndig - 1 - d]; d = d + 1; }
+    buf[total] = 0;
+
+    val ir: Result[intern.StrId, str] = intern.intern(itn, buf::str);
+    deallocate[u8](alloc, buf, total + 1);
+    if (is_err[intern.StrId, str](ir)) { ret generic; }
+    val nm: Option[str] = intern.lookup(itn, unwrap_ok[intern.StrId, str](ir));
+    if (is_some[str](nm)) { ret unwrap[str](nm); }
+    ret generic;
 }
 
 # count the relocations targeting each section of `img` in one pass, returning a

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1848,7 +1848,7 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count:
         }
         or {
             if (cur + 7 > lim) { brk; }
-            disp = (read_u32_le(seg.bytes, base + cur + 3)::i32)::i64;
+            disp = (bin.read_u32_le(seg.bytes, base + cur + 3)::i32)::i64;
             inst_len = 7;
         }
         if (disp >= 0) { brk; }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -64,8 +64,8 @@ use fs:   std.filesystem;
 use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 use of:     mach.lang.target.of;
-use map:     std.collections.map;
-use maphash: std.collections.map;
+use bin:    mach.lang.target.of.bin;
+use map:    std.collections.map;
 
 # COFF machine type for x86-64.
 val IMAGE_FILE_MACHINE_AMD64: u16 = 0x8664;
@@ -162,59 +162,6 @@ val UWOP_SAVE_XMM128: u8 = 8;
 val UWOP_SAVE_XMM128_FAR: u8 = 9;
 val UWREG_RBP: u8 = 5;
 
-# write a u16 little-endian into a buffer.
-fun write_u16_le(buf: *u8, offset: usize, value: u16) {
-    buf[offset]     = (value & 0xFF)::u8;
-    buf[offset + 1] = ((value >> 8) & 0xFF)::u8;
-}
-
-# write a u32 little-endian into a buffer.
-fun write_u32_le(buf: *u8, offset: usize, value: u32) {
-    buf[offset]     = (value & 0xFF)::u8;
-    buf[offset + 1] = ((value >> 8) & 0xFF)::u8;
-    buf[offset + 2] = ((value >> 16) & 0xFF)::u8;
-    buf[offset + 3] = ((value >> 24) & 0xFF)::u8;
-}
-
-# write a u64 little-endian into a buffer.
-fun write_u64_le(buf: *u8, offset: usize, value: u64) {
-    write_u32_le(buf, offset, (value & 0xFFFFFFFF)::u32);
-    write_u32_le(buf, offset + 4, ((value >> 32) & 0xFFFFFFFF)::u32);
-}
-
-# read a u16 little-endian from a buffer.
-fun read_u16_le(buf: *u8, offset: usize) u16 {
-    ret buf[offset]::u16 | (buf[offset + 1]::u16 << 8);
-}
-
-# read a u32 little-endian from a buffer.
-fun read_u32_le(buf: *u8, offset: usize) u32 {
-    ret buf[offset]::u32 | (buf[offset + 1]::u32 << 8)
-      | (buf[offset + 2]::u32 << 16) | (buf[offset + 3]::u32 << 24);
-}
-
-# read a u64 little-endian from a buffer.
-fun read_u64_le(buf: *u8, offset: usize) u64 {
-    ret read_u32_le(buf, offset)::u64 | (read_u32_le(buf, offset + 4)::u64 << 32);
-}
-
-# write a null-terminated string into a buffer, returning the bytes written
-# (name length plus the terminator). a nil name writes a lone terminator.
-fun write_str(buf: *u8, offset: usize, s: str) usize {
-    if (s == nil) {
-        buf[offset] = 0;
-        ret 1;
-    }
-    val len: usize = str_len(s);
-    var i: usize = 0;
-    for (i < len) {
-        buf[offset + i] = s[i];
-        i = i + 1;
-    }
-    buf[offset + len] = 0;
-    ret len + 1;
-}
-
 # session interner captured at registration so the reader/writer can resolve the
 # `intern.StrId` names carried by `of.ObjectImage`. set by `register_coff`.
 var coff_interner: *intern.Interner = nil;
@@ -256,10 +203,10 @@ fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
     if (sec.bytes == nil) { ret 0; }
     if (r_type == IMAGE_REL_AMD64_ADDR64) {
         if (offset::usize + 8 > sec.len::usize) { ret 0; }
-        ret read_u64_le(sec.bytes, offset::usize)::i64;
+        ret bin.read_u64_le(sec.bytes, offset::usize)::i64;
     }
     if (offset::usize + 4 > sec.len::usize) { ret 0; }
-    ret (read_u32_le(sec.bytes, offset::usize)::i32)::i64;
+    ret (bin.read_u32_le(sec.bytes, offset::usize)::i32)::i64;
 }
 
 # map a COFF x86-64 machine relocation type back to its abstract RK_* kind name.
@@ -325,18 +272,6 @@ fun align_from_characteristics(chars: u32) u32 {
 fun section_has_data(kind: of.SectionKind) bool {
     if (kind == of.SK_BSS) { ret false; }
     ret true;
-}
-
-# align a usize up to the given power-of-two alignment.
-fun align_up(value: usize, alignment: usize) usize {
-    if (alignment == 0) { ret value; }
-    ret (value + alignment - 1) & ~(alignment - 1);
-}
-
-# align a u64 up to the given power-of-two alignment.
-fun align_up_u64(value: u64, alignment: u64) u64 {
-    if (alignment == 0) { ret value; }
-    ret (value + alignment - 1) & ~(alignment - 1);
 }
 
 # COFF symbol Type word for an abstract section kind: a symbol in text gets the
@@ -884,13 +819,13 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     var buf: *u8 = unwrap_ok[*u8, str](res_buf);
 
     # file header.
-    write_u16_le(buf, 0, IMAGE_FILE_MACHINE_AMD64);
-    write_u16_le(buf, 2, num_secs::u16);
-    write_u32_le(buf, 4, 0);
-    write_u32_le(buf, 8, symtab_offset::u32);
-    write_u32_le(buf, 12, total_sym_records);
-    write_u16_le(buf, 16, 0);
-    write_u16_le(buf, 18, 0);
+    bin.write_u16_le(buf, 0, IMAGE_FILE_MACHINE_AMD64);
+    bin.write_u16_le(buf, 2, num_secs::u16);
+    bin.write_u32_le(buf, 4, 0);
+    bin.write_u32_le(buf, 8, symtab_offset::u32);
+    bin.write_u32_le(buf, 12, total_sym_records);
+    bin.write_u16_le(buf, 16, 0);
+    bin.write_u16_le(buf, 18, 0);
 
     # the string-table cursor starts past its own 4-byte length field; the
     # length is written last. long names (section + symbol) append here.
@@ -905,37 +840,37 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
             sec_name_offsets[s] = str_pos::u32;
             buf[sh] = '/';
             write_decimal(buf, sh + 1, 7, str_pos::u32);
-            str_pos = str_pos + write_str(buf, strtab_offset + str_pos, sn);
+            str_pos = str_pos + bin.write_str(buf, strtab_offset + str_pos, sn);
         } or {
             sec_name_offsets[s] = 0;
             write_inline_name(buf, sh, sn);
         }
 
         val seclen: u32 = img.sections[s].len;
-        write_u32_le(buf, sh + 8, 0);
-        write_u32_le(buf, sh + 12, 0);
-        write_u32_le(buf, sh + 16, seclen);
+        bin.write_u32_le(buf, sh + 8, 0);
+        bin.write_u32_le(buf, sh + 12, 0);
+        bin.write_u32_le(buf, sh + 16, seclen);
         if (section_has_data(img.sections[s].kind) && seclen > 0) {
-            write_u32_le(buf, sh + 20, data_offsets[s]::u32);
+            bin.write_u32_le(buf, sh + 20, data_offsets[s]::u32);
         } or {
-            write_u32_le(buf, sh + 20, 0);
+            bin.write_u32_le(buf, sh + 20, 0);
         }
         val rc: u32 = count_relocs_for_section(img, s);
         if (rc > 0) {
-            write_u32_le(buf, sh + 24, reloc_offsets[s]::u32);
+            bin.write_u32_le(buf, sh + 24, reloc_offsets[s]::u32);
         } or {
-            write_u32_le(buf, sh + 24, 0);
+            bin.write_u32_le(buf, sh + 24, 0);
         }
-        write_u32_le(buf, sh + 28, 0);
-        write_u16_le(buf, sh + 32, rc::u16);
-        write_u16_le(buf, sh + 34, 0);
+        bin.write_u32_le(buf, sh + 28, 0);
+        bin.write_u16_le(buf, sh + 32, rc::u16);
+        bin.write_u16_le(buf, sh + 34, 0);
         var chars: u32 = section_characteristics_for(img.sections[s].kind)
                        | align_characteristic(img.sections[s].align);
         # a COMDAT carrier section (one defined weak symbol) is flagged so the
         # reader recovers the weak/dedup attribute; its section symbol's aux record
         # carries SELECT_ANY below.
         if (comdat != nil && comdat[s]) { chars = chars | IMAGE_SCN_LNK_COMDAT; }
-        write_u32_le(buf, sh + 36, chars);
+        bin.write_u32_le(buf, sh + 36, chars);
         s = s + 1;
     }
 
@@ -962,9 +897,9 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
         if (img.relocations[ridx].addend != 0) {
             val fld: usize = data_offsets[rsec] + img.relocations[ridx].offset::usize;
             if (reloc_field_width(img.relocations[ridx].kind) == 8) {
-                write_u64_le(buf, fld, read_u64_le(buf, fld) + img.relocations[ridx].addend::u64);
+                bin.write_u64_le(buf, fld, bin.read_u64_le(buf, fld) + img.relocations[ridx].addend::u64);
             } or {
-                write_u32_le(buf, fld, read_u32_le(buf, fld) + (img.relocations[ridx].addend::u64)::u32);
+                bin.write_u32_le(buf, fld, bin.read_u32_le(buf, fld) + (img.relocations[ridx].addend::u64)::u32);
             }
         }
         ridx = ridx + 1;
@@ -979,14 +914,14 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
             var ri: u32 = 0;
             for (ri < img.reloc_count) {
                 if (img.relocations[ri].section == s) {
-                    write_u32_le(buf, ro, img.relocations[ri].offset);
+                    bin.write_u32_le(buf, ro, img.relocations[ri].offset);
                     # validate_reloc_symbols proved every reloc resolves, and a
                     # relocated section implies symbols, so sym_remap is non-nil
                     # and the lookup cannot miss; the first section symbol is
                     # never silently aliased.
                     val rsi: u32 = unwrap_ok[u32, str](reloc_sym_index(img, img.relocations[ri].symbol));
-                    write_u32_le(buf, ro + 4, sym_remap[rsi]);
-                    write_u16_le(buf, ro + 8, reloc_type_for(img.relocations[ri].kind));
+                    bin.write_u32_le(buf, ro + 4, sym_remap[rsi]);
+                    bin.write_u16_le(buf, ro + 8, reloc_type_for(img.relocations[ri].kind));
                     ro = ro + RELOCATION_SIZE;
                 }
                 ri = ri + 1;
@@ -1003,14 +938,14 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     for (s < num_secs) {
         val sn: str = resolve(img.sections[s].name);
         if (name_in_strtab(sn)) {
-            write_u32_le(buf, sym_off, 0);
-            write_u32_le(buf, sym_off + 4, sec_name_offsets[s]);
+            bin.write_u32_le(buf, sym_off, 0);
+            bin.write_u32_le(buf, sym_off + 4, sec_name_offsets[s]);
         } or {
             write_inline_name(buf, sym_off, sn);
         }
-        write_u32_le(buf, sym_off + 8, 0);
-        write_u16_le(buf, sym_off + 12, (s + 1)::u16);
-        write_u16_le(buf, sym_off + 14, 0);
+        bin.write_u32_le(buf, sym_off + 8, 0);
+        bin.write_u16_le(buf, sym_off + 12, (s + 1)::u16);
+        bin.write_u16_le(buf, sym_off + 14, 0);
         buf[sym_off + 16] = IMAGE_SYM_CLASS_STATIC;
         buf[sym_off + 17] = 1;
         sym_off = sym_off + SYMBOL_SIZE;
@@ -1021,8 +956,8 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
         # SELECT_ANY — the encoding the reader maps to a defined weak symbol. the
         # `number` field stays 0: it names the associated section only for an
         # associative COMDAT, which SELECT_ANY is not.
-        write_u32_le(buf, sym_off, img.sections[s].len);
-        write_u16_le(buf, sym_off + 4, count_relocs_for_section(img, s)::u16);
+        bin.write_u32_le(buf, sym_off, img.sections[s].len);
+        bin.write_u16_le(buf, sym_off + 4, count_relocs_for_section(img, s)::u16);
         if (comdat != nil && comdat[s]) {
             buf[sym_off + 14] = IMAGE_COMDAT_SELECT_ANY;
         }
@@ -1034,13 +969,13 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     for (symi < num_syms) {
         val name: str = resolve(img.symbols[symi].name);
         if (name_in_strtab(name)) {
-            write_u32_le(buf, sym_off, 0);
-            write_u32_le(buf, sym_off + 4, str_pos::u32);
-            str_pos = str_pos + write_str(buf, strtab_offset + str_pos, name);
+            bin.write_u32_le(buf, sym_off, 0);
+            bin.write_u32_le(buf, sym_off + 4, str_pos::u32);
+            str_pos = str_pos + bin.write_str(buf, strtab_offset + str_pos, name);
         } or {
             write_inline_name(buf, sym_off, name);
         }
-        write_u32_le(buf, sym_off + 8, img.symbols[symi].offset);
+        bin.write_u32_le(buf, sym_off + 8, img.symbols[symi].offset);
 
         var sec_num: i16 = IMAGE_SYM_UNDEFINED;
         var sym_ty: u16 = 0;
@@ -1052,8 +987,8 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
         if ((img.symbols[symi].flags & of.SYM_OBJ_FLAG_FUNCTION) != 0) {
             sym_ty = IMAGE_SYM_DTYPE_FUNCTION;
         }
-        write_u16_le(buf, sym_off + 12, sec_num::u16);
-        write_u16_le(buf, sym_off + 14, sym_ty);
+        bin.write_u16_le(buf, sym_off + 12, sec_num::u16);
+        bin.write_u16_le(buf, sym_off + 14, sym_ty);
 
         # global, weak, and external-undefined symbols are class EXTERNAL; a
         # local definition is class STATIC. a defined weak symbol is class
@@ -1073,7 +1008,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     }
 
     # the string-table length field counts itself and every appended name.
-    write_u32_le(buf, strtab_offset, str_pos::u32);
+    bin.write_u32_le(buf, strtab_offset, str_pos::u32);
 
     if (sym_remap != nil) { deallocate[u32](alloc, sym_remap, num_syms::usize); }
     deallocate[usize](alloc, data_offsets, (num_secs + 1)::usize);
@@ -1132,8 +1067,8 @@ fun read_section_name(buf: *u8, sh: usize, strtab_base: usize) str {
 # read a symbol-record name: inline when the first four name bytes are non-zero,
 # otherwise a 4-byte string-table offset stored in the second name word.
 fun read_symbol_name(buf: *u8, so: usize, strtab_base: usize) str {
-    if (read_u32_le(buf, so) == 0) {
-        val off: u32 = read_u32_le(buf, so + 4);
+    if (bin.read_u32_le(buf, so) == 0) {
+        val off: u32 = bin.read_u32_le(buf, so + 4);
         ret (buf::usize + strtab_base + off::usize)::str;
     }
     ret framed_name(buf, so);
@@ -1153,7 +1088,7 @@ fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32,
         val so: usize = symtab_off + ri::usize * SYMBOL_SIZE;
         val aux: u8 = buf[so + 17];
         if (buf[so + 16] == IMAGE_SYM_CLASS_STATIC && aux >= 1
-            && read_u16_le(buf, so + 12)::u32 == sec_num && read_u32_le(buf, so + 8) == 0) {
+            && bin.read_u16_le(buf, so + 12)::u32 == sec_num && bin.read_u32_le(buf, so + 8) == 0) {
             val ax: usize = so + SYMBOL_SIZE;
             ret buf[ax + 14] == IMAGE_COMDAT_SELECT_ANY;
         }
@@ -1180,15 +1115,15 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
     if (buf == nil || out == nil || buf_size < COFF_HEADER_SIZE) {
         ret err[bool, str]("coff: object too small");
     }
-    if (read_u16_le(buf, 0) != IMAGE_FILE_MACHINE_AMD64) {
+    if (bin.read_u16_le(buf, 0) != IMAGE_FILE_MACHINE_AMD64) {
         ret err[bool, str]("coff: not an x86-64 object");
     }
     if (coff_interner == nil) { ret err[bool, str]("coff: no interner registered"); }
 
-    val num_secs:     u32   = read_u16_le(buf, 2)::u32;
-    val symtab_off:   usize = read_u32_le(buf, 8)::usize;
-    val num_records:  u32   = read_u32_le(buf, 12);
-    val opt_size:     u16   = read_u16_le(buf, 16);
+    val num_secs:     u32   = bin.read_u16_le(buf, 2)::u32;
+    val symtab_off:   usize = bin.read_u32_le(buf, 8)::usize;
+    val num_records:  u32   = bin.read_u32_le(buf, 12);
+    val opt_size:     u16   = bin.read_u16_le(buf, 16);
     val secthdr_base: usize = COFF_HEADER_SIZE + opt_size::usize;
     val strtab_base:  usize = symtab_off + num_records::usize * SYMBOL_SIZE;
 
@@ -1205,7 +1140,7 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
     var s: u32 = 0;
     for (s < num_secs) {
         val sh: usize = secthdr_base + s::usize * SECTION_HEADER_SIZE;
-        rel_n = rel_n + read_u16_le(buf, sh + 32)::u32;
+        rel_n = rel_n + bin.read_u16_le(buf, sh + 32)::u32;
         s = s + 1;
     }
     var sym_n: u32 = 0;
@@ -1250,7 +1185,7 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
             ret err[bool, str](unwrap_err[intern.StrId, str](rin));
         }
 
-        val chars: u32 = read_u32_le(buf, sh + 36);
+        val chars: u32 = bin.read_u32_le(buf, sh + 36);
         var kind: of.SectionKind = of.SK_DATA;
         if ((chars & IMAGE_SCN_CNT_CODE) != 0) { kind = of.SK_TEXT; }
         or ((chars & IMAGE_SCN_CNT_UNINITIALIZED_DATA) != 0) { kind = of.SK_BSS; }
@@ -1259,11 +1194,11 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
 
         out.sections[s].name  = unwrap_ok[intern.StrId, str](rin);
         out.sections[s].kind  = kind;
-        out.sections[s].len   = read_u32_le(buf, sh + 16);
+        out.sections[s].len   = bin.read_u32_le(buf, sh + 16);
         out.sections[s].align = align_from_characteristics(chars);
         out.sections[s].bytes = nil;
 
-        val raw_ptr: u32 = read_u32_le(buf, sh + 20);
+        val raw_ptr: u32 = bin.read_u32_le(buf, sh + 20);
         if ((chars & IMAGE_SCN_CNT_UNINITIALIZED_DATA) == 0 && raw_ptr != 0
             && out.sections[s].len > 0) {
             val sz: usize = out.sections[s].len::usize;
@@ -1296,11 +1231,11 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
         val idx: u32 = out.symbol_count;
         rec_map[ri] = idx::i32;
         out.symbols[idx].name = unwrap_ok[intern.StrId, str](rin);
-        out.symbols[idx].offset = read_u32_le(buf, so + 8);
+        out.symbols[idx].offset = bin.read_u32_le(buf, so + 8);
         out.symbols[idx].size = 0;
 
-        val sec_num: i16 = read_u16_le(buf, so + 12)::i16;
-        val sym_ty:  u16 = read_u16_le(buf, so + 14);
+        val sec_num: i16 = bin.read_u16_le(buf, so + 12)::i16;
+        val sym_ty:  u16 = bin.read_u16_le(buf, so + 14);
         val scl:     u8  = buf[so + 16];
 
         var flags: u32 = 0;
@@ -1331,7 +1266,7 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
         if ((flags & of.SYM_OBJ_FLAG_GLOBAL) != 0
             && out.symbols[idx].section != of.SECTION_EXTERNAL) {
             val dsh: usize = secthdr_base + out.symbols[idx].section::usize * SECTION_HEADER_SIZE;
-            if ((read_u32_le(buf, dsh + 36) & IMAGE_SCN_LNK_COMDAT) != 0
+            if ((bin.read_u32_le(buf, dsh + 36) & IMAGE_SCN_LNK_COMDAT) != 0
                 && comdat_select_any_for_section(buf, symtab_off, num_records,
                                                  out.symbols[idx].section + 1)) {
                 flags = flags | of.SYM_OBJ_FLAG_WEAK;
@@ -1354,14 +1289,14 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
     s = 0;
     for (s < num_secs) {
         val sh: usize = secthdr_base + s::usize * SECTION_HEADER_SIZE;
-        val rptr: usize = read_u32_le(buf, sh + 24)::usize;
-        val rcount: u32 = read_u16_le(buf, sh + 32)::u32;
+        val rptr: usize = bin.read_u32_le(buf, sh + 24)::usize;
+        val rcount: u32 = bin.read_u16_le(buf, sh + 32)::u32;
         var k: u32 = 0;
         for (k < rcount) {
             val ro: usize = rptr + k::usize * RELOCATION_SIZE;
             val idx: u32 = out.reloc_count;
-            val r_type: u16 = read_u16_le(buf, ro + 8);
-            val r_off:  u32 = read_u32_le(buf, ro);
+            val r_type: u16 = bin.read_u16_le(buf, ro + 8);
+            val r_off:  u32 = bin.read_u32_le(buf, ro);
             out.relocations[idx].section = s;
             out.relocations[idx].offset = r_off;
             out.relocations[idx].kind = reloc_kind_for(r_type);
@@ -1372,7 +1307,7 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
             # preserves the codegen's addend (e.g. a call's pc32 -4 correction).
             out.relocations[idx].addend = read_inplace_addend(?out.sections[s], r_type, r_off);
 
-            val rec: u32 = read_u32_le(buf, ro + 4);
+            val rec: u32 = bin.read_u32_le(buf, ro + 4);
             if (rec < num_records && rec_map[rec] >= 0) {
                 out.relocations[idx].symbol = out.symbols[rec_map[rec]::u32].name;
             } or {
@@ -1434,7 +1369,7 @@ fun infer_extern_function_flags_from_calls(out: *of.ObjectImage) Result[bool, st
     # index those candidates by name so each call reloc is an O(1) lookup rather
     # than a full symbol-table scan.
     var idx: map.Map[intern.StrId, u32] =
-        map.init[intern.StrId, u32](out.alloc, maphash.hash_u32, maphash.eq_u32);
+        map.init[intern.StrId, u32](out.alloc, map.hash_u32, map.eq_u32);
     si = 0;
     for (si < out.symbol_count) {
         if (is_flagless_extern(?out.symbols[si])) {
@@ -1739,7 +1674,7 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count:
          && seg.bytes[base + pos] == 0x48
          && seg.bytes[base + pos + 1] == 0x81
          && seg.bytes[base + pos + 2] == 0xEC) {
-        alloc = read_u32_le(seg.bytes, base + pos + 3)::usize;
+        alloc = bin.read_u32_le(seg.bytes, base + pos + 3)::usize;
         if (!push_alloc_code(uw, (pos + 7)::u8, alloc)) { ret false; }
         pos = pos + 7;
     }
@@ -1770,7 +1705,7 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count:
         }
         or {
             if (cur + 6 > lim) { brk; }
-            disp = (read_u32_le(seg.bytes, base + cur + 2)::i32)::i64;
+            disp = (bin.read_u32_le(seg.bytes, base + cur + 2)::i32)::i64;
             inst_len = 6;
         }
         if (disp >= 0) { brk; }
@@ -1833,7 +1768,7 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count:
     if (uw.code_count == 0) { ret false; }
     if (pos > 255) { ret false; }
     uw.prolog_size = pos::u8;
-    uw.xdata_size = align_up(4 + uw.slot_count::usize * 2, 4);
+    uw.xdata_size = bin.align_up(4 + uw.slot_count::usize * 2, 4);
     ret true;
 }
 
@@ -1887,10 +1822,10 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
     # the same value is SizeOfHeaders.
     val headers_raw: usize = DOS_HEADER_SIZE + PE_SIGNATURE_SIZE + COFF_HEADER_SIZE
         + OPTIONAL_HEADER_SIZE + nsec::usize * SECTION_HEADER_SIZE;
-    lay.header_size = align_up(headers_raw, PE_FILE_ALIGN::usize);
+    lay.header_size = bin.align_up(headers_raw, PE_FILE_ALIGN::usize);
 
     var file_off: usize = lay.header_size;
-    var rva: u64 = align_up_u64(lay.header_size::u64, PE_SECTION_ALIGN);
+    var rva: u64 = bin.align_up_u64(lay.header_size::u64, PE_SECTION_ALIGN);
 
     # the linker segments map at their assigned vaddrs; the writer copies their
     # bytes to file offsets that advance under FileAlignment. RVA = vaddr - base.
@@ -1900,10 +1835,10 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
         seg_secs[li].rva       = seg_rva;
         seg_secs[li].vsize      = segs[li].memsz::u64;
         seg_secs[li].file_off   = file_off;
-        seg_secs[li].file_size  = align_up(segs[li].filesz, PE_FILE_ALIGN::usize);
+        seg_secs[li].file_size  = bin.align_up(segs[li].filesz, PE_FILE_ALIGN::usize);
         file_off = file_off + seg_secs[li].file_size;
         # the next synthesized section starts above this segment's mapped span.
-        val seg_end: u64 = align_up_u64(seg_rva + segs[li].memsz::u64, PE_SECTION_ALIGN);
+        val seg_end: u64 = bin.align_up_u64(seg_rva + segs[li].memsz::u64, PE_SECTION_ALIGN);
         if (seg_end > rva) { rva = seg_end; }
         li = li + 1;
     }
@@ -1911,19 +1846,19 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
     # the import-stub section (read+execute): one `jmp [rip+IAT]` per function
     # import (6 bytes each).
     if (lay.have_stub) {
-        rva = align_up_u64(rva, PE_SECTION_ALIGN);
+        rva = bin.align_up_u64(rva, PE_SECTION_ALIGN);
         lay.stub_sec.rva       = rva;
         lay.stub_sec.vsize     = (lay.nimp::usize * IMPORT_STUB_SIZE)::u64;
         lay.stub_sec.file_off  = file_off;
-        lay.stub_sec.file_size = align_up(lay.nimp::usize * IMPORT_STUB_SIZE, PE_FILE_ALIGN::usize);
+        lay.stub_sec.file_size = bin.align_up(lay.nimp::usize * IMPORT_STUB_SIZE, PE_FILE_ALIGN::usize);
         file_off = file_off + lay.stub_sec.file_size;
-        rva = rva + align_up_u64(lay.stub_sec.vsize, PE_SECTION_ALIGN);
+        rva = rva + bin.align_up_u64(lay.stub_sec.vsize, PE_SECTION_ALIGN);
     }
 
     # the .idata section (read+write — the loader writes resolved addresses into
     # the IAT): import directory, ILT, IAT, hint/name table, dll-name strings.
     if (lay.have_idata) {
-        rva = align_up_u64(rva, PE_SECTION_ALIGN);
+        rva = bin.align_up_u64(rva, PE_SECTION_ALIGN);
         var ioff: usize = 0;
 
         # import directory table.
@@ -1933,22 +1868,22 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
 
         # ILT (import lookup / import name table): one thunk per function import +
         # a null terminator per dependency.
-        ioff = align_up(ioff, 8);
+        ioff = bin.align_up(ioff, 8);
         ioff = ioff + (lay.nimp + dyn.lib_count)::usize * THUNK_SIZE;
 
         # IAT: identical shape to the ILT; the IAT data directory points here.
-        ioff = align_up(ioff, 8);
+        ioff = bin.align_up(ioff, 8);
         lay.iat_rva  = rva + ioff::u64;
         lay.iat_size = (lay.nimp + dyn.lib_count)::usize * THUNK_SIZE::u64;
         ioff = ioff + (lay.nimp + dyn.lib_count)::usize * THUNK_SIZE;
 
         # hint/name table: one (hint:u16 + name + NUL, 2-byte aligned) per import.
-        ioff = align_up(ioff, 2);
+        ioff = bin.align_up(ioff, 2);
         var i: u32 = 0;
         for (i < dyn.import_count) {
             if (dyn.imports[i].is_func) {
                 ioff = ioff + 2 + name_len_z(dyn.imports[i].symbol);
-                ioff = align_up(ioff, 2);
+                ioff = bin.align_up(ioff, 2);
             }
             i = i + 1;
         }
@@ -1957,41 +1892,41 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
         i = 0;
         for (i < dyn.lib_count) {
             ioff = ioff + name_len_z(dyn.libs[i].soname);
-            ioff = align_up(ioff, 2);
+            ioff = bin.align_up(ioff, 2);
             i = i + 1;
         }
 
         lay.idata_sec.rva       = rva;
         lay.idata_sec.vsize     = ioff::u64;
         lay.idata_sec.file_off  = file_off;
-        lay.idata_sec.file_size = align_up(ioff, PE_FILE_ALIGN::usize);
+        lay.idata_sec.file_size = bin.align_up(ioff, PE_FILE_ALIGN::usize);
         file_off = file_off + lay.idata_sec.file_size;
-        rva = rva + align_up_u64(ioff::u64, PE_SECTION_ALIGN);
+        rva = rva + bin.align_up_u64(ioff::u64, PE_SECTION_ALIGN);
     }
 
     if (lay.have_xdata) {
-        rva = align_up_u64(rva, PE_SECTION_ALIGN);
+        rva = bin.align_up_u64(rva, PE_SECTION_ALIGN);
         lay.xdata_sec.rva       = rva;
         lay.xdata_sec.vsize     = xdata_vsize::u64;
         lay.xdata_sec.file_off  = file_off;
-        lay.xdata_sec.file_size = align_up(xdata_vsize, PE_FILE_ALIGN::usize);
+        lay.xdata_sec.file_size = bin.align_up(xdata_vsize, PE_FILE_ALIGN::usize);
         file_off = file_off + lay.xdata_sec.file_size;
-        rva = rva + align_up_u64(lay.xdata_sec.vsize, PE_SECTION_ALIGN);
+        rva = rva + bin.align_up_u64(lay.xdata_sec.vsize, PE_SECTION_ALIGN);
     }
 
     if (lay.have_pdata) {
-        rva = align_up_u64(rva, PE_SECTION_ALIGN);
+        rva = bin.align_up_u64(rva, PE_SECTION_ALIGN);
         lay.pdata_sec.rva       = rva;
         lay.pdata_sec.vsize     = pdata_vsize::u64;
         lay.pdata_sec.file_off  = file_off;
-        lay.pdata_sec.file_size = align_up(pdata_vsize, PE_FILE_ALIGN::usize);
+        lay.pdata_sec.file_size = bin.align_up(pdata_vsize, PE_FILE_ALIGN::usize);
         lay.exception_rva       = rva;
         lay.exception_size      = pdata_vsize::u64;
         file_off = file_off + lay.pdata_sec.file_size;
-        rva = rva + align_up_u64(lay.pdata_sec.vsize, PE_SECTION_ALIGN);
+        rva = rva + bin.align_up_u64(lay.pdata_sec.vsize, PE_SECTION_ALIGN);
     }
 
-    lay.image_size = align_up_u64(rva, PE_SECTION_ALIGN);
+    lay.image_size = bin.align_up_u64(rva, PE_SECTION_ALIGN);
     ret file_off;
 }
 
@@ -2160,15 +2095,15 @@ fun write_pe_imports(buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo) {
     val dir_off: usize = ioff;
     ioff = ioff + import_dir_bytes(dyn);
 
-    ioff = align_up(ioff, 8);
+    ioff = bin.align_up(ioff, 8);
     val ilt_off: usize = ioff;
     ioff = ioff + (lay.nimp + dyn.lib_count)::usize * THUNK_SIZE;
 
-    ioff = align_up(ioff, 8);
+    ioff = bin.align_up(ioff, 8);
     val iat_off: usize = ioff;
     ioff = ioff + (lay.nimp + dyn.lib_count)::usize * THUNK_SIZE;
 
-    ioff = align_up(ioff, 2);
+    ioff = bin.align_up(ioff, 2);
     val hint_off: usize = ioff;
 
     # the hint/name entry RVA of each function import, recorded so the ILT/IAT
@@ -2186,36 +2121,36 @@ fun write_pe_imports(buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo) {
             if (dyn.imports[imp].is_func && import_lib_of(dyn, imp) == lib) {
                 val hint_rva: u64 = sec_rva + hcur::u64;
                 # hint = 0; the loader falls back to a binary search by name.
-                write_u16_le(buf, sec_off + hcur, 0);
+                bin.write_u16_le(buf, sec_off + hcur, 0);
                 hcur = hcur + 2;
-                hcur = hcur + write_str(buf, sec_off + hcur, resolve(dyn.imports[imp].symbol));
-                hcur = align_up(hcur, 2);
+                hcur = hcur + bin.write_str(buf, sec_off + hcur, resolve(dyn.imports[imp].symbol));
+                hcur = bin.align_up(hcur, 2);
 
                 # ILT[thunk_ix] and IAT[thunk_ix] = RVA of the hint/name entry.
-                write_u64_le(buf, sec_off + ilt_off + thunk_ix::usize * THUNK_SIZE, hint_rva);
-                write_u64_le(buf, sec_off + iat_off + thunk_ix::usize * THUNK_SIZE, hint_rva);
+                bin.write_u64_le(buf, sec_off + ilt_off + thunk_ix::usize * THUNK_SIZE, hint_rva);
+                bin.write_u64_le(buf, sec_off + iat_off + thunk_ix::usize * THUNK_SIZE, hint_rva);
                 thunk_ix = thunk_ix + 1;
             }
             imp = imp + 1;
         }
         # a null thunk terminates this dependency's ILT and IAT.
-        write_u64_le(buf, sec_off + ilt_off + thunk_ix::usize * THUNK_SIZE, 0);
-        write_u64_le(buf, sec_off + iat_off + thunk_ix::usize * THUNK_SIZE, 0);
+        bin.write_u64_le(buf, sec_off + ilt_off + thunk_ix::usize * THUNK_SIZE, 0);
+        bin.write_u64_le(buf, sec_off + iat_off + thunk_ix::usize * THUNK_SIZE, 0);
         thunk_ix = thunk_ix + 1;
 
         # the dll-name string for this dependency.
         val name_rva: u64 = sec_rva + hcur::u64;
-        hcur = hcur + write_str(buf, sec_off + hcur, resolve(dyn.libs[lib].soname));
-        hcur = align_up(hcur, 2);
+        hcur = hcur + bin.write_str(buf, sec_off + hcur, resolve(dyn.libs[lib].soname));
+        hcur = bin.align_up(hcur, 2);
 
         # IMAGE_IMPORT_DESCRIPTOR: OriginalFirstThunk(ILT), TimeDateStamp,
         # ForwarderChain, Name, FirstThunk(IAT).
         val d: usize = sec_off + dir_off + lib::usize * IMPORT_DESCRIPTOR_SIZE;
-        write_u32_le(buf, d, (sec_rva + ilt_off::u64 + first_thunk::u64 * THUNK_SIZE::u64)::u32);
-        write_u32_le(buf, d + 4, 0);
-        write_u32_le(buf, d + 8, 0);
-        write_u32_le(buf, d + 12, name_rva::u32);
-        write_u32_le(buf, d + 16, (sec_rva + iat_off::u64 + first_thunk::u64 * THUNK_SIZE::u64)::u32);
+        bin.write_u32_le(buf, d, (sec_rva + ilt_off::u64 + first_thunk::u64 * THUNK_SIZE::u64)::u32);
+        bin.write_u32_le(buf, d + 4, 0);
+        bin.write_u32_le(buf, d + 8, 0);
+        bin.write_u32_le(buf, d + 12, name_rva::u32);
+        bin.write_u32_le(buf, d + 16, (sec_rva + iat_off::u64 + first_thunk::u64 * THUNK_SIZE::u64)::u32);
         lib = lib + 1;
     }
     # the null import descriptor terminates the directory (zeroed by alloc).
@@ -2238,9 +2173,9 @@ fun pe_iat_slot_rva(lay: *PeLayout, dyn: *of.DynamicInfo, ord: u32) u64 {
     # mirror write_pe_imports' thunk indexing: function imports per dependency in
     # import order, with one null terminator slot after each dependency.
     var ioff: usize = import_dir_bytes(dyn);
-    ioff = align_up(ioff, 8);
+    ioff = bin.align_up(ioff, 8);
     ioff = ioff + (lay.nimp + dyn.lib_count)::usize * THUNK_SIZE;
-    ioff = align_up(ioff, 8);
+    ioff = bin.align_up(ioff, 8);
     val iat_off: usize = ioff;
 
     var thunk_ix: u32 = 0;
@@ -2299,7 +2234,7 @@ fun write_pe_stubs(buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo) {
         # FF 25 <disp32>: the disp is from the end of this 6-byte instruction.
         buf[stub_off] = 0xFF; buf[stub_off + 1] = 0x25;
         val next: u64 = stub_rva + IMPORT_STUB_SIZE::u64;
-        write_u32_le(buf, stub_off + 2, (iat_rva - next)::u32);
+        bin.write_u32_le(buf, stub_off + 2, (iat_rva - next)::u32);
         ord = ord + 1;
     }
 }
@@ -2339,11 +2274,11 @@ fun write_unwind_xdata(buf: *u8, lay: *PeLayout, uw: *FunctionUnwind) {
         buf[slot_off + 1] = c.op | (c.info << 4);
         slots_written = slots_written + 1;
         if (c.extra_slots >= 1) {
-            write_u16_le(buf, xoff + 4 + slots_written * 2, c.extra0);
+            bin.write_u16_le(buf, xoff + 4 + slots_written * 2, c.extra0);
             slots_written = slots_written + 1;
         }
         if (c.extra_slots >= 2) {
-            write_u16_le(buf, xoff + 4 + slots_written * 2, c.extra1);
+            bin.write_u16_le(buf, xoff + 4 + slots_written * 2, c.extra1);
             slots_written = slots_written + 1;
         }
         used[best::usize] = true;
@@ -2373,9 +2308,9 @@ fun write_pe_unwind(buf: *u8, lay: *PeLayout, uws: *FunctionUnwind, uw_count: u3
         val seg_rva: u64 = lay.seg_secs[uws[i].seg_index].rva;
         val begin_rva: u32 = (seg_rva + uws[i].seg_offset::u64)::u32;
         val end_rva: u32 = begin_rva + uws[i].size;
-        write_u32_le(buf, poff, begin_rva);
-        write_u32_le(buf, poff + 4, end_rva);
-        write_u32_le(buf, poff + 8, uws[i].xdata_rva::u32);
+        bin.write_u32_le(buf, poff, begin_rva);
+        bin.write_u32_le(buf, poff + 4, end_rva);
+        bin.write_u32_le(buf, poff + 8, uws[i].xdata_rva::u32);
         i = i + 1;
     }
 }
@@ -2412,7 +2347,7 @@ fun patch_pe_fixups(buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo, fixups: *of.
         }
 
         val file_off: usize = lay.seg_secs[fx.seg_index].file_off + fx.seg_offset::usize;
-        write_u32_le(buf, file_off, (disp::u64)::u32);
+        bin.write_u32_le(buf, file_off, (disp::u64)::u32);
         i = i + 1;
     }
     ret ok[bool, str](true);
@@ -2425,16 +2360,16 @@ fun patch_pe_fixups(buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo, fixups: *of.
 # a zero-size section is malformed and some loaders reject it.
 fun write_pe_section_header(buf: *u8, pos: usize, name: str, sec: *PeSection, chars: u32) {
     write_inline_name(buf, pos, name);
-    write_u32_le(buf, pos + 8, sec.vsize::u32);
-    write_u32_le(buf, pos + 12, sec.rva::u32);
-    write_u32_le(buf, pos + 16, sec.file_size::u32);
-    if (sec.file_size > 0) { write_u32_le(buf, pos + 20, sec.file_off::u32); }
-    or { write_u32_le(buf, pos + 20, 0); }
-    write_u32_le(buf, pos + 24, 0);
-    write_u32_le(buf, pos + 28, 0);
-    write_u16_le(buf, pos + 32, 0);
-    write_u16_le(buf, pos + 34, 0);
-    write_u32_le(buf, pos + 36, chars);
+    bin.write_u32_le(buf, pos + 8, sec.vsize::u32);
+    bin.write_u32_le(buf, pos + 12, sec.rva::u32);
+    bin.write_u32_le(buf, pos + 16, sec.file_size::u32);
+    if (sec.file_size > 0) { bin.write_u32_le(buf, pos + 20, sec.file_off::u32); }
+    or { bin.write_u32_le(buf, pos + 20, 0); }
+    bin.write_u32_le(buf, pos + 24, 0);
+    bin.write_u32_le(buf, pos + 28, 0);
+    bin.write_u16_le(buf, pos + 32, 0);
+    bin.write_u16_le(buf, pos + 34, 0);
+    bin.write_u32_le(buf, pos + 36, chars);
 }
 
 # write_pe_headers: write the DOS header + stub, the PE signature, the COFF file
@@ -2447,25 +2382,25 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
     # the DOS stub is left zero — Windows reads only the magic and e_lfanew.
     buf[0] = 'M'; buf[1] = 'Z';
     val pe_off: usize = DOS_HEADER_SIZE;
-    write_u32_le(buf, 0x3C, pe_off::u32);
+    bin.write_u32_le(buf, 0x3C, pe_off::u32);
 
     # PE signature 'PE\0\0'.
     buf[pe_off] = 'P'; buf[pe_off + 1] = 'E'; buf[pe_off + 2] = 0; buf[pe_off + 3] = 0;
 
     # COFF file header.
     val ch: usize = pe_off + PE_SIGNATURE_SIZE;
-    write_u16_le(buf, ch, IMAGE_FILE_MACHINE_AMD64);
-    write_u16_le(buf, ch + 2, lay.sec_total::u16);
-    write_u32_le(buf, ch + 4, 0);
-    write_u32_le(buf, ch + 8, 0);
-    write_u32_le(buf, ch + 12, 0);
-    write_u16_le(buf, ch + 16, OPTIONAL_HEADER_SIZE::u16);
-    write_u16_le(buf, ch + 18, IMAGE_FILE_EXECUTABLE_IMAGE | IMAGE_FILE_LARGE_ADDRESS_AWARE
+    bin.write_u16_le(buf, ch, IMAGE_FILE_MACHINE_AMD64);
+    bin.write_u16_le(buf, ch + 2, lay.sec_total::u16);
+    bin.write_u32_le(buf, ch + 4, 0);
+    bin.write_u32_le(buf, ch + 8, 0);
+    bin.write_u32_le(buf, ch + 12, 0);
+    bin.write_u16_le(buf, ch + 16, OPTIONAL_HEADER_SIZE::u16);
+    bin.write_u16_le(buf, ch + 18, IMAGE_FILE_EXECUTABLE_IMAGE | IMAGE_FILE_LARGE_ADDRESS_AWARE
         | IMAGE_FILE_LINE_NUMS_STRIPPED | IMAGE_FILE_LOCAL_SYMS_STRIPPED | IMAGE_FILE_RELOCS_STRIPPED);
 
     # PE32+ optional header.
     val oh: usize = ch + COFF_HEADER_SIZE;
-    write_u16_le(buf, oh, PE32PLUS_MAGIC);
+    bin.write_u16_le(buf, oh, PE32PLUS_MAGIC);
     buf[oh + 2] = 14; buf[oh + 3] = 0;            # linker version (cosmetic)
 
     # SizeOfCode / SizeOfInitializedData / SizeOfUninitializedData (cosmetic sums).
@@ -2479,55 +2414,55 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
         if (segs[li].bytes == nil) { udata_size = udata_size + segs[li].memsz::u64; }
         li = li + 1;
     }
-    write_u32_le(buf, oh + 4, code_size::u32);
-    write_u32_le(buf, oh + 8, idata_size::u32);
-    write_u32_le(buf, oh + 12, udata_size::u32);
+    bin.write_u32_le(buf, oh + 4, code_size::u32);
+    bin.write_u32_le(buf, oh + 8, idata_size::u32);
+    bin.write_u32_le(buf, oh + 12, udata_size::u32);
 
     # AddressOfEntryPoint (RVA), BaseOfCode (RVA of the first segment).
-    write_u32_le(buf, oh + 16, (entry - lay.image_base)::u32);
-    write_u32_le(buf, oh + 20, lay.seg_secs[0].rva::u32);
+    bin.write_u32_le(buf, oh + 16, (entry - lay.image_base)::u32);
+    bin.write_u32_le(buf, oh + 20, lay.seg_secs[0].rva::u32);
 
     # ImageBase (8 bytes), SectionAlignment, FileAlignment.
-    write_u64_le(buf, oh + 24, lay.image_base);
-    write_u32_le(buf, oh + 32, PE_SECTION_ALIGN::u32);
-    write_u32_le(buf, oh + 36, PE_FILE_ALIGN::u32);
+    bin.write_u64_le(buf, oh + 24, lay.image_base);
+    bin.write_u32_le(buf, oh + 32, PE_SECTION_ALIGN::u32);
+    bin.write_u32_le(buf, oh + 36, PE_FILE_ALIGN::u32);
 
     # OS/image/subsystem versions (6.0 satisfies modern loaders).
-    write_u16_le(buf, oh + 40, 6); write_u16_le(buf, oh + 42, 0);
-    write_u16_le(buf, oh + 44, 0); write_u16_le(buf, oh + 46, 0);
-    write_u16_le(buf, oh + 48, 6); write_u16_le(buf, oh + 50, 0);
-    write_u32_le(buf, oh + 52, 0);
+    bin.write_u16_le(buf, oh + 40, 6); bin.write_u16_le(buf, oh + 42, 0);
+    bin.write_u16_le(buf, oh + 44, 0); bin.write_u16_le(buf, oh + 46, 0);
+    bin.write_u16_le(buf, oh + 48, 6); bin.write_u16_le(buf, oh + 50, 0);
+    bin.write_u32_le(buf, oh + 52, 0);
 
     # SizeOfImage, SizeOfHeaders, CheckSum (0 — not required for an exe).
-    write_u32_le(buf, oh + 56, lay.image_size::u32);
-    write_u32_le(buf, oh + 60, lay.header_size::u32);
-    write_u32_le(buf, oh + 64, 0);
+    bin.write_u32_le(buf, oh + 56, lay.image_size::u32);
+    bin.write_u32_le(buf, oh + 60, lay.header_size::u32);
+    bin.write_u32_le(buf, oh + 64, 0);
 
     # Subsystem (console), DllCharacteristics (NX-compatible).
-    write_u16_le(buf, oh + 68, IMAGE_SUBSYSTEM_WINDOWS_CUI);
-    write_u16_le(buf, oh + 70, IMAGE_DLLCHARACTERISTICS_NX_COMPAT);
+    bin.write_u16_le(buf, oh + 68, IMAGE_SUBSYSTEM_WINDOWS_CUI);
+    bin.write_u16_le(buf, oh + 70, IMAGE_DLLCHARACTERISTICS_NX_COMPAT);
 
     # stack/heap reserve+commit (PE32+ are 8 bytes each): 1 MiB reserve / 4 KiB
     # commit for both, the conventional console defaults.
-    write_u64_le(buf, oh + 72, 0x100000); write_u64_le(buf, oh + 80, 0x1000);
-    write_u64_le(buf, oh + 88, 0x100000); write_u64_le(buf, oh + 96, 0x1000);
-    write_u32_le(buf, oh + 104, 0);                # LoaderFlags
-    write_u32_le(buf, oh + 108, IMAGE_NUMBEROF_DIRECTORY_ENTRIES);
+    bin.write_u64_le(buf, oh + 72, 0x100000); bin.write_u64_le(buf, oh + 80, 0x1000);
+    bin.write_u64_le(buf, oh + 88, 0x100000); bin.write_u64_le(buf, oh + 96, 0x1000);
+    bin.write_u32_le(buf, oh + 104, 0);                # LoaderFlags
+    bin.write_u32_le(buf, oh + 108, IMAGE_NUMBEROF_DIRECTORY_ENTRIES);
 
     # the 16 data directories (RVA, size) begin at optional-header offset 112.
     val dd: usize = oh + 112;
     # IMPORT directory (index 1).
     if (lay.have_idata) {
-        write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IMPORT::usize * DATA_DIR_SIZE, lay.import_dir_rva::u32);
-        write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IMPORT::usize * DATA_DIR_SIZE + 4, lay.import_dir_size::u32);
+        bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IMPORT::usize * DATA_DIR_SIZE, lay.import_dir_rva::u32);
+        bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IMPORT::usize * DATA_DIR_SIZE + 4, lay.import_dir_size::u32);
         # IAT directory (index 12) — the loader-writable IAT span.
-        write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IAT::usize * DATA_DIR_SIZE, lay.iat_rva::u32);
-        write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IAT::usize * DATA_DIR_SIZE + 4, lay.iat_size::u32);
+        bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IAT::usize * DATA_DIR_SIZE, lay.iat_rva::u32);
+        bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IAT::usize * DATA_DIR_SIZE + 4, lay.iat_size::u32);
     }
     # EXCEPTION directory (index 3) — the RUNTIME_FUNCTION table in .pdata.
     if (lay.have_pdata) {
-        write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE, lay.exception_rva::u32);
-        write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE + 4, lay.exception_size::u32);
+        bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE, lay.exception_rva::u32);
+        bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE + 4, lay.exception_size::u32);
     }
 
     # the section table follows the optional header.
@@ -2747,17 +2682,17 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
     # structural checks against the COFF spec: machine, section count, the
     # symbol-table offset's record count (2 section symbols/aux pairs each = 6,
     # plus 3 image symbols = 9), and a zero optional-header size.
-    if (read_u16_le(buf.data, 0) != IMAGE_FILE_MACHINE_AMD64) { ret 1; }
-    if (read_u16_le(buf.data, 2) != 3) { ret 1; }
-    if (read_u16_le(buf.data, 16) != 0) { ret 1; }
-    if (read_u32_le(buf.data, 12) != 9) { ret 1; }
+    if (bin.read_u16_le(buf.data, 0) != IMAGE_FILE_MACHINE_AMD64) { ret 1; }
+    if (bin.read_u16_le(buf.data, 2) != 3) { ret 1; }
+    if (bin.read_u16_le(buf.data, 16) != 0) { ret 1; }
+    if (bin.read_u32_le(buf.data, 12) != 9) { ret 1; }
 
     # .text section header: code+exec+read characteristics and 16-byte align.
     val sh0: usize = COFF_HEADER_SIZE;
-    val chars0: u32 = read_u32_le(buf.data, sh0 + 36);
+    val chars0: u32 = bin.read_u32_le(buf.data, sh0 + 36);
     if ((chars0 & IMAGE_SCN_CNT_CODE) == 0) { ret 1; }
     if ((chars0 & IMAGE_SCN_MEM_EXECUTE) == 0) { ret 1; }
-    if (read_u16_le(buf.data, sh0 + 32) != 2) { ret 1; }
+    if (bin.read_u16_le(buf.data, sh0 + 32) != 2) { ret 1; }
 
     # parse the bytes back into a fresh image and verify the round-trip.
     var out: of.ObjectImage;
@@ -2946,14 +2881,14 @@ test "coff: a defined weak symbol round-trips its weak flag through a COMDAT sec
 
     # the file carries the original .text plus one COMDAT carrier section for the
     # single weak symbol: two sections in total.
-    if (read_u16_le(buf.data, 2) != 2) { ret 1; }
+    if (bin.read_u16_le(buf.data, 2) != 2) { ret 1; }
 
     # exactly one section header carries the LNK_COMDAT characteristic.
     var comdat_secs: u32 = 0;
     var sh_i: u32 = 0;
     for (sh_i < 2) {
         val sh: usize = COFF_HEADER_SIZE + sh_i::usize * SECTION_HEADER_SIZE;
-        if ((read_u32_le(buf.data, sh + 36) & IMAGE_SCN_LNK_COMDAT) != 0) {
+        if ((bin.read_u32_le(buf.data, sh + 36) & IMAGE_SCN_LNK_COMDAT) != 0) {
             comdat_secs = comdat_secs + 1;
         }
         sh_i = sh_i + 1;
@@ -3130,25 +3065,25 @@ test "coff: emit_exec writes a well-formed PE32+ header" {
 
     # the DOS header: 'MZ' magic, e_lfanew (offset 0x3C) -> the PE signature.
     if (buf.data[0] != 'M' || buf.data[1] != 'Z') { ret 1; }
-    val pe_off: usize = read_u32_le(buf.data, 0x3C)::usize;
+    val pe_off: usize = bin.read_u32_le(buf.data, 0x3C)::usize;
     # the PE signature 'PE\0\0'.
     if (buf.data[pe_off] != 'P' || buf.data[pe_off + 1] != 'E'
         || buf.data[pe_off + 2] != 0 || buf.data[pe_off + 3] != 0) { ret 1; }
 
     # the COFF file header: Machine = AMD64, two sections (no imports / unwind).
     val ch: usize = pe_off + PE_SIGNATURE_SIZE;
-    if (read_u16_le(buf.data, ch) != IMAGE_FILE_MACHINE_AMD64) { ret 1; }
-    if (read_u16_le(buf.data, ch + 2) != 2) { ret 1; }
+    if (bin.read_u16_le(buf.data, ch) != IMAGE_FILE_MACHINE_AMD64) { ret 1; }
+    if (bin.read_u16_le(buf.data, ch + 2) != 2) { ret 1; }
 
     # the PE32+ optional header: Magic = 0x20B, subsystem = console.
     val oh: usize = ch + COFF_HEADER_SIZE;
-    if (read_u16_le(buf.data, oh) != PE32PLUS_MAGIC) { ret 1; }
-    if (read_u16_le(buf.data, oh + 68) != IMAGE_SUBSYSTEM_WINDOWS_CUI) { ret 1; }
+    if (bin.read_u16_le(buf.data, oh) != PE32PLUS_MAGIC) { ret 1; }
+    if (bin.read_u16_le(buf.data, oh + 68) != IMAGE_SUBSYSTEM_WINDOWS_CUI) { ret 1; }
 
     # AddressOfEntryPoint is the entry vaddr relative to ImageBase, and ImageBase
     # is the 64 KiB-reserved base — so entry maps back to the provided address.
-    val image_base: u64 = read_u64_le(buf.data, oh + 24);
-    val entry_rva:  u32 = read_u32_le(buf.data, oh + 16);
+    val image_base: u64 = bin.read_u64_le(buf.data, oh + 24);
+    val entry_rva:  u32 = bin.read_u32_le(buf.data, oh + 16);
     if (image_base + entry_rva::u64 != entry) { ret 1; }
 
     ret 0;
@@ -3358,14 +3293,14 @@ test "coff: emit_exec emits .xdata/.pdata for a canonical x64 prologue" {
     if (is_err[fs.Buffer, str](rb)) { ret 1; }
     val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
 
-    val pe_off: usize = read_u32_le(buf.data, 0x3C)::usize;
+    val pe_off: usize = bin.read_u32_le(buf.data, 0x3C)::usize;
     val ch: usize = pe_off + PE_SIGNATURE_SIZE;
-    if (read_u16_le(buf.data, ch + 2) != 3) { ret 1; }  # .text + .xdata + .pdata
+    if (bin.read_u16_le(buf.data, ch + 2) != 3) { ret 1; }  # .text + .xdata + .pdata
 
     val oh: usize = ch + COFF_HEADER_SIZE;
     val dd: usize = oh + 112;
-    val exc_rva: u32 = read_u32_le(buf.data, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE);
-    val exc_size: u32 = read_u32_le(buf.data, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE + 4);
+    val exc_rva: u32 = bin.read_u32_le(buf.data, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE);
+    val exc_size: u32 = bin.read_u32_le(buf.data, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE + 4);
     if (exc_rva == 0 || exc_size != RUNTIME_FUNCTION_SIZE::u32) { ret 1; }
 
     var xdata_rva: u32 = 0;
@@ -3377,22 +3312,22 @@ test "coff: emit_exec emits .xdata/.pdata for a canonical x64 prologue" {
         if (buf.data[sh] == '.' && buf.data[sh + 1] == 'x'
             && buf.data[sh + 2] == 'd' && buf.data[sh + 3] == 'a'
             && buf.data[sh + 4] == 't' && buf.data[sh + 5] == 'a') {
-            xdata_rva = read_u32_le(buf.data, sh + 12);
-            xdata_ptr = read_u32_le(buf.data, sh + 20);
+            xdata_rva = bin.read_u32_le(buf.data, sh + 12);
+            xdata_ptr = bin.read_u32_le(buf.data, sh + 20);
         }
         if (buf.data[sh] == '.' && buf.data[sh + 1] == 'p'
             && buf.data[sh + 2] == 'd' && buf.data[sh + 3] == 'a'
             && buf.data[sh + 4] == 't' && buf.data[sh + 5] == 'a') {
-            pdata_ptr = read_u32_le(buf.data, sh + 20);
+            pdata_ptr = bin.read_u32_le(buf.data, sh + 20);
         }
         sh = sh + SECTION_HEADER_SIZE;
         si = si + 1;
     }
     if (xdata_rva == 0 || xdata_ptr == 0 || pdata_ptr == 0) { ret 1; }
 
-    val begin_rva: u32 = read_u32_le(buf.data, pdata_ptr::usize);
-    val end_rva: u32 = read_u32_le(buf.data, pdata_ptr::usize + 4);
-    val unwind_rva: u32 = read_u32_le(buf.data, pdata_ptr::usize + 8);
+    val begin_rva: u32 = bin.read_u32_le(buf.data, pdata_ptr::usize);
+    val end_rva: u32 = bin.read_u32_le(buf.data, pdata_ptr::usize + 4);
+    val unwind_rva: u32 = bin.read_u32_le(buf.data, pdata_ptr::usize + 8);
     if (begin_rva == 0 || end_rva <= begin_rva) { ret 1; }
     if (unwind_rva < xdata_rva) { ret 1; }
     val uw_ptr: usize = xdata_ptr::usize + (unwind_rva - xdata_rva)::usize;
@@ -3409,7 +3344,7 @@ test "coff: emit_exec emits .xdata/.pdata for a canonical x64 prologue" {
     # op | (info << 4): SAVE_NONVOL(4)|rbx(3)=0x34, ALLOC_SMALL(2)|3=0x32, PUSH(0)|rbp(5)=0x50.
     if (buf.data[uw_ptr + 4] != 0x0C) { ret 1; }             # SAVE_NONVOL end_off = 12
     if (buf.data[uw_ptr + 5] != 0x34) { ret 1; }             # op 4 (SAVE_NONVOL), info 3 (rbx)
-    if (read_u16_le(buf.data, uw_ptr + 6) != 3) { ret 1; }   # scaled offset (0x18 / 8)
+    if (bin.read_u16_le(buf.data, uw_ptr + 6) != 3) { ret 1; }   # scaled offset (0x18 / 8)
     if (buf.data[uw_ptr + 8] != 0x08) { ret 1; }             # ALLOC_SMALL end_off = 8
     if (buf.data[uw_ptr + 9] != 0x32) { ret 1; }             # op 2 (ALLOC_SMALL), info 3 ((0x20-8)/8)
     if (buf.data[uw_ptr + 10] != 0x01) { ret 1; }            # PUSH_NONVOL end_off = 1

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -313,17 +313,6 @@ fun symbol_type_for(kind: of.SectionKind) u16 {
     ret 0;
 }
 
-# count the relocations in an image that patch a given section.
-fun count_relocs_for_section(img: *of.ObjectImage, sec_idx: u32) u32 {
-    var count: u32 = 0;
-    var i: u32 = 0;
-    for (i < img.reloc_count) {
-        if (img.relocations[i].section == sec_idx) { count = count + 1; }
-        i = i + 1;
-    }
-    ret count;
-}
-
 # whether a name needs the string table (longer than the eight inline bytes).
 fun name_in_strtab(name: str) bool {
     if (name == nil) { ret false; }
@@ -770,17 +759,41 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     val vrs: Result[bool, str] = validate_reloc_symbols(img);
     if (is_err[bool, str](vrs)) { ret err[bool, str](unwrap_err[bool, str](vrs)); }
 
+    # per-section relocation counts in one O(relocations) tally, reused by every
+    # layout pass below instead of rescanning the whole relocation table per
+    # section. this also pins the COFF u16 narrowing: NumberOfSections and each
+    # section's relocation count are stored as u16, so a count above 0xFFFF would
+    # silently truncate into a well-formed-looking object with dropped sections or
+    # relocations. reject it (COFF's IMAGE_SCN_LNK_NRELOC_OVFL escape is not
+    # implemented) rather than corrupt the output. `counts` is freed on every exit.
+    if (num_secs > 0xFFFF) { ret err[bool, str]("coff: section count exceeds the COFF 0xFFFF limit"); }
+    val res_counts: Result[*u32, str] = bin.reloc_counts(alloc, img);
+    if (is_err[*u32, str](res_counts)) { ret err[bool, str](unwrap_err[*u32, str](res_counts)); }
+    val counts: *u32 = unwrap_ok[*u32, str](res_counts);
+    var cs: u32 = 0;
+    for (cs < num_secs) {
+        if (counts[cs] > 0xFFFF) {
+            deallocate[u32](alloc, counts, num_secs::usize);
+            ret err[bool, str]("coff: section relocation count exceeds the COFF 0xFFFF limit");
+        }
+        cs = cs + 1;
+    }
+
     # file layout: header, section headers, per-section raw data, per-section
     # relocation arrays, symbol table, string table. compute each region's file
     # offset up front so section headers can point at their data and relocs.
     val secdata_base: usize = COFF_HEADER_SIZE + num_secs::usize * SECTION_HEADER_SIZE;
 
     val res_doff: Result[*usize, str] = zallocate[usize](alloc, (num_secs + 1)::usize);
-    if (is_err[*usize, str](res_doff)) { ret err[bool, str]("coff: data offset table alloc failed"); }
+    if (is_err[*usize, str](res_doff)) {
+        deallocate[u32](alloc, counts, num_secs::usize);
+        ret err[bool, str]("coff: data offset table alloc failed");
+    }
     var data_offsets: *usize = unwrap_ok[*usize, str](res_doff);
 
     val res_roff: Result[*usize, str] = zallocate[usize](alloc, (num_secs + 1)::usize);
     if (is_err[*usize, str](res_roff)) {
+        deallocate[u32](alloc, counts, num_secs::usize);
         deallocate[usize](alloc, data_offsets, (num_secs + 1)::usize);
         ret err[bool, str]("coff: reloc offset table alloc failed");
     }
@@ -790,6 +803,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     # 0 for an inline (<= 8 byte) name. filled while writing section headers.
     val res_snoff: Result[*u32, str] = zallocate[u32](alloc, (num_secs + 1)::usize);
     if (is_err[*u32, str](res_snoff)) {
+        deallocate[u32](alloc, counts, num_secs::usize);
         deallocate[usize](alloc, data_offsets, (num_secs + 1)::usize);
         deallocate[usize](alloc, reloc_offsets, (num_secs + 1)::usize);
         ret err[bool, str]("coff: section name offset table alloc failed");
@@ -809,7 +823,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     }
     s = 0;
     for (s < num_secs) {
-        val rc: u32 = count_relocs_for_section(img, s);
+        val rc: u32 = counts[s];
         if (rc > 0) {
             reloc_offsets[s] = cursor;
             cursor = cursor + rc::usize * RELOCATION_SIZE;
@@ -834,6 +848,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     if (num_syms > 0) {
         val res_remap: Result[*u32, str] = zallocate[u32](alloc, num_syms::usize);
         if (is_err[*u32, str](res_remap)) {
+            deallocate[u32](alloc, counts, num_secs::usize);
             deallocate[usize](alloc, data_offsets, (num_secs + 1)::usize);
             deallocate[usize](alloc, reloc_offsets, (num_secs + 1)::usize);
             deallocate[u32](alloc, sec_name_offsets, (num_secs + 1)::usize);
@@ -849,6 +864,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
 
     val res_buf: Result[*u8, str] = zallocate[u8](alloc, total_file_size);
     if (is_err[*u8, str](res_buf)) {
+        deallocate[u32](alloc, counts, num_secs::usize);
         deallocate[usize](alloc, data_offsets, (num_secs + 1)::usize);
         deallocate[usize](alloc, reloc_offsets, (num_secs + 1)::usize);
         deallocate[u32](alloc, sec_name_offsets, (num_secs + 1)::usize);
@@ -894,7 +910,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
         } or {
             bin.write_u32_le(buf, sh + 20, 0);
         }
-        val rc: u32 = count_relocs_for_section(img, s);
+        val rc: u32 = counts[s];
         if (rc > 0) {
             bin.write_u32_le(buf, sh + 24, reloc_offsets[s]::u32);
         } or {
@@ -944,31 +960,26 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
         ridx = ridx + 1;
     }
 
-    # per-section relocation arrays.
-    s = 0;
-    for (s < num_secs) {
-        val rc: u32 = count_relocs_for_section(img, s);
-        if (rc > 0) {
-            var ro: usize = reloc_offsets[s];
-            var ri: u32 = 0;
-            for (ri < img.reloc_count) {
-                if (img.relocations[ri].section == s) {
-                    bin.write_u32_le(buf, ro, img.relocations[ri].offset);
-                    # validate_reloc_symbols proved every reloc resolves, and a
-                    # relocated section implies symbols, so sym_remap is non-nil
-                    # and the lookup cannot miss; the first section symbol is
-                    # never silently aliased.
-                    val rsi: u32 = unwrap_ok[u32, str](reloc_sym_index(img, img.relocations[ri].symbol));
-                    bin.write_u32_le(buf, ro + 4, sym_remap[rsi]);
-                    # validate_reloc_kinds proved every kind maps, so this lookup
-                    # cannot miss; ADDR64 is never silently substituted.
-                    bin.write_u16_le(buf, ro + 8, unwrap_ok[u16, str](reloc_type_for(alloc, img.relocations[ri].kind)));
-                    ro = ro + RELOCATION_SIZE;
-                }
-                ri = ri + 1;
-            }
-        }
-        s = s + 1;
+    # per-section relocation arrays, written in one O(relocations) pass: each
+    # relocation lands in its owning section's slot, advancing that section's reloc
+    # cursor. `reloc_offsets` is no longer read after the section-header pass, so it
+    # doubles as the per-section write cursor (each starts at the section's reloc
+    # base from the layout pass and ends one past its last record).
+    var ri: u32 = 0;
+    for (ri < img.reloc_count) {
+        val rsec: u32 = img.relocations[ri].section;
+        val ro: usize = reloc_offsets[rsec];
+        bin.write_u32_le(buf, ro, img.relocations[ri].offset);
+        # validate_reloc_symbols proved every reloc resolves, and a relocated
+        # section implies symbols, so sym_remap is non-nil and the lookup cannot
+        # miss; the first section symbol is never silently aliased.
+        val rsi: u32 = unwrap_ok[u32, str](reloc_sym_index(img, img.relocations[ri].symbol));
+        bin.write_u32_le(buf, ro + 4, sym_remap[rsi]);
+        # validate_reloc_kinds proved every kind maps, so this lookup cannot miss;
+        # ADDR64 is never silently substituted.
+        bin.write_u16_le(buf, ro + 8, unwrap_ok[u16, str](reloc_type_for(alloc, img.relocations[ri].kind)));
+        reloc_offsets[rsec] = ro + RELOCATION_SIZE;
+        ri = ri + 1;
     }
 
     # symbol table: a section symbol (+ aux record) per section, then the image
@@ -998,7 +1009,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
         # `number` field stays 0: it names the associated section only for an
         # associative COMDAT, which SELECT_ANY is not.
         bin.write_u32_le(buf, sym_off, img.sections[s].len);
-        bin.write_u16_le(buf, sym_off + 4, count_relocs_for_section(img, s)::u16);
+        bin.write_u16_le(buf, sym_off + 4, counts[s]::u16);
         if (comdat != nil && comdat[s]) {
             buf[sym_off + 14] = IMAGE_COMDAT_SELECT_ANY;
         }
@@ -1052,6 +1063,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     bin.write_u32_le(buf, strtab_offset, str_pos::u32);
 
     if (sym_remap != nil) { deallocate[u32](alloc, sym_remap, num_syms::usize); }
+    deallocate[u32](alloc, counts, num_secs::usize);
     deallocate[usize](alloc, data_offsets, (num_secs + 1)::usize);
     deallocate[usize](alloc, reloc_offsets, (num_secs + 1)::usize);
     deallocate[u32](alloc, sec_name_offsets, (num_secs + 1)::usize);
@@ -3624,5 +3636,68 @@ test "coff: parse rejects a foreign ADDR32 relocation type (#1256)" {
     val pr: Result[bool, str] = coff_parse_object(?alloc, buf.data, buf.len, ?out);
     if (!is_err[bool, str](pr)) { ret 1; }
     if (!str_contains(unwrap_err[bool, str](pr), "relocation type")) { ret 1; }
+    ret 0;
+}
+
+test "coff: emit rejects a section reloc count above the u16 limit (#1256)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
+    if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
+    val k_pc32: intern.StrId = of.reloc_kind_name(unwrap[*of.OfVTable](vt_o), of.RK_PC32);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    var syms: [1]of.Symbol;
+    syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    # 65536 relocations into one section: the per-section count is written as u16,
+    # so before #1256 it truncated to 0 — a well-formed object that silently
+    # dropped every relocation. it must now fail loudly instead. heap-allocated to
+    # keep the count off the stack.
+    val nrel: u32 = 65536;
+    val rrl: Result[*of.Relocation, str] = zallocate[of.Relocation](?alloc, nrel::usize);
+    if (is_err[*of.Relocation, str](rrl)) { ret 1; }
+    val relocs: *of.Relocation = unwrap_ok[*of.Relocation, str](rrl);
+    var r: u32 = 0;
+    for (r < nrel) {
+        relocs[r].section = 0; relocs[r].offset = 0; relocs[r].kind = k_pc32;
+        relocs[r].symbol = syms[0].name; relocs[r].addend = 0;
+        r = r + 1;
+    }
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 1;
+    img.relocations = relocs; img.reloc_count = nrel;
+
+    val tf_r: Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_novfl");
+    if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: Result[bool, str] = coff_emit_object(?isa_vt, ?img, tpath::*u8);
+    fs.temp_close_and_remove(?tf);
+    deallocate[of.Relocation](?alloc, relocs, nrel::usize);
+
+    if (!is_err[bool, str](em)) { ret 1; }
+    if (!str_contains(unwrap_err[bool, str](em), "exceeds")) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2626,11 +2626,10 @@ var coff_vtable: of.OfVTable;
 # the first registration; `of.register` itself is idempotent. must be invoked at
 # compiler startup before target.select requests a Windows target.
 # ---
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields and captured
-#        for the reader/writer
-# ret:   true on success, or an error string if name interning fails
-pub fun register_coff(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# i:   string interner used to intern the vtable's string fields and captured for
+#      the reader/writer
+# ret: true on success, or an error string if name interning fails
+pub fun register_coff(i: *intern.Interner) Result[bool, str] {
     coff_interner = i;
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "coff");
@@ -2711,7 +2710,7 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
     # register_coff captures `i` as the reader/writer interner and interns the
     # relocation-kind names into it; the kind StrIds resolve against this same
     # interner below.
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
@@ -2862,7 +2861,7 @@ test "coff: emit rejects a relocation naming an unresolved symbol (#1196)" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
@@ -2920,7 +2919,7 @@ test "coff: a defined weak symbol round-trips its weak flag through a COMDAT sec
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
@@ -3056,7 +3055,7 @@ test "coff: long section and symbol names round-trip through the string table" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3125,7 +3124,7 @@ test "coff: emit_exec writes a well-formed PE32+ header" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3197,7 +3196,7 @@ test "coff: a function-flagged call-target import round-trips DT_FUNCTION" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
@@ -3274,7 +3273,7 @@ test "coff: parse infers function imports from a foreign object's call relocatio
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
@@ -3352,7 +3351,7 @@ test "coff: emit_exec emits .xdata/.pdata for a canonical x64 prologue" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3567,7 +3566,7 @@ test "coff: emit rejects a relocation whose kind has no COFF machine type (#1256
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3618,7 +3617,7 @@ test "coff: parse rejects a foreign ADDR32 relocation type (#1256)" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
@@ -3684,7 +3683,7 @@ test "coff: emit rejects a section reloc count above the u16 limit (#1256)" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
@@ -3747,7 +3746,7 @@ test "coff: parse rejects a truncated object instead of reading out of bounds (#
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    val rr: Result[bool, str] = register_coff(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1101,9 +1101,11 @@ fun framed_name(buf: *u8, off: usize) str {
 
 # read a section-header name: an inline 8-byte name, or a "/offset" reference
 # into the string table (decimal offset after the leading slash). the long form
-# returns a pointer into the string table; the short form is framed and
-# null-terminated through the scratch buffer.
-fun read_section_name(buf: *u8, sh: usize, strtab_base: usize) str {
+# is validated through `bin.cstr_at` — its offset must land inside the buffer and
+# the name must be terminated before the end — so a hostile offset errors rather
+# than interning off the end. the short form is framed (within the already-bounded
+# section-header region) and null-terminated through the scratch buffer.
+fun read_section_name(buf: *u8, buf_size: usize, sh: usize, strtab_base: usize) Result[str, str] {
     if (buf[sh] == '/') {
         var off: u32 = 0;
         var i: usize = 1;
@@ -1112,19 +1114,21 @@ fun read_section_name(buf: *u8, sh: usize, strtab_base: usize) str {
             if (c >= '0' && c <= '9') { off = off * 10 + (c - '0')::u32; }
             i = i + 1;
         }
-        ret (buf::usize + strtab_base + off::usize)::str;
+        ret bin.cstr_at(buf, buf_size, strtab_base + off::usize);
     }
-    ret framed_name(buf, sh);
+    ret ok[str, str](framed_name(buf, sh));
 }
 
 # read a symbol-record name: inline when the first four name bytes are non-zero,
-# otherwise a 4-byte string-table offset stored in the second name word.
-fun read_symbol_name(buf: *u8, so: usize, strtab_base: usize) str {
+# otherwise a 4-byte string-table offset stored in the second name word. the long
+# form is bounds-checked through `bin.cstr_at`; the inline form is framed within
+# the already-bounded symbol-table region.
+fun read_symbol_name(buf: *u8, buf_size: usize, so: usize, strtab_base: usize) Result[str, str] {
     if (bin.read_u32_le(buf, so) == 0) {
         val off: u32 = bin.read_u32_le(buf, so + 4);
-        ret (buf::usize + strtab_base + off::usize)::str;
+        ret bin.cstr_at(buf, buf_size, strtab_base + off::usize);
     }
-    ret framed_name(buf, so);
+    ret ok[str, str](framed_name(buf, so));
 }
 
 # whether the COMDAT for 1-based section `sec_num` selects SELECT_ANY — the
@@ -1140,7 +1144,10 @@ fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32,
     for (ri < num_records) {
         val so: usize = symtab_off + ri::usize * SYMBOL_SIZE;
         val aux: u8 = buf[so + 17];
-        if (buf[so + 16] == IMAGE_SYM_CLASS_STATIC && aux >= 1
+        # the aux read is bounded by the symbol-table validation only when the aux
+        # record is itself a counted record; a last record falsely claiming an aux
+        # would read past the table, so require the aux index to be in range.
+        if (buf[so + 16] == IMAGE_SYM_CLASS_STATIC && aux >= 1 && (ri + 1) < num_records
             && bin.read_u16_le(buf, so + 12)::u32 == sec_num && bin.read_u32_le(buf, so + 8) == 0) {
             val ax: usize = so + SYMBOL_SIZE;
             ret buf[ax + 14] == IMAGE_COMDAT_SELECT_ANY;
@@ -1178,6 +1185,19 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
     val num_records:  u32   = bin.read_u32_le(buf, 12);
     val opt_size:     u16   = bin.read_u16_le(buf, 16);
     val secthdr_base: usize = COFF_HEADER_SIZE + opt_size::usize;
+
+    # validate the header-derived table extents against the input size before any
+    # field is dereferenced: the section-header array and the symbol table (each a
+    # fixed-stride run) must lie fully within the buffer, so a truncated or hostile
+    # object errors here instead of walking off the end of the mapped bytes. the
+    # string table follows the symbol table; bounding the symbol table bounds its
+    # base, and individual names are checked as they are read.
+    val vsh: Result[bool, str] = bin.require_region(buf_size, secthdr_base,
+        num_secs::usize * SECTION_HEADER_SIZE, "coff: section header table out of bounds");
+    if (is_err[bool, str](vsh)) { ret err[bool, str](unwrap_err[bool, str](vsh)); }
+    val vsy: Result[bool, str] = bin.require_region(buf_size, symtab_off,
+        num_records::usize * SYMBOL_SIZE, "coff: symbol table out of bounds");
+    if (is_err[bool, str](vsy)) { ret err[bool, str](unwrap_err[bool, str](vsy)); }
     val strtab_base:  usize = symtab_off + num_records::usize * SYMBOL_SIZE;
 
     out.alloc = alloc;
@@ -1231,8 +1251,12 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
     s = 0;
     for (s < num_secs) {
         val sh: usize = secthdr_base + s::usize * SECTION_HEADER_SIZE;
-        val sec_name: str = read_section_name(buf, sh, strtab_base);
-        val rin: Result[intern.StrId, str] = intern.intern(coff_interner, sec_name);
+        val rsn: Result[str, str] = read_section_name(buf, buf_size, sh, strtab_base);
+        if (is_err[str, str](rsn)) {
+            deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
+            ret err[bool, str](unwrap_err[str, str](rsn));
+        }
+        val rin: Result[intern.StrId, str] = intern.intern(coff_interner, unwrap_ok[str, str](rsn));
         if (is_err[intern.StrId, str](rin)) {
             deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
             ret err[bool, str](unwrap_err[intern.StrId, str](rin));
@@ -1255,6 +1279,12 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
         if ((chars & IMAGE_SCN_CNT_UNINITIALIZED_DATA) == 0 && raw_ptr != 0
             && out.sections[s].len > 0) {
             val sz: usize = out.sections[s].len::usize;
+            # the section's PointerToRawData + SizeOfRawData must lie within the
+            # input before the bytes are copied out of it.
+            if (!bin.region_ok(buf_size, raw_ptr::usize, sz)) {
+                deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
+                ret err[bool, str]("coff: section raw data out of bounds");
+            }
             val rb: Result[*u8, str] = allocate[u8](alloc, sz);
             if (is_err[*u8, str](rb)) {
                 deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
@@ -1274,8 +1304,12 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
         val so: usize = symtab_off + ri::usize * SYMBOL_SIZE;
         val aux: u8 = buf[so + 17];
 
-        val name: str = read_symbol_name(buf, so, strtab_base);
-        val rin: Result[intern.StrId, str] = intern.intern(coff_interner, name);
+        val rsyn: Result[str, str] = read_symbol_name(buf, buf_size, so, strtab_base);
+        if (is_err[str, str](rsyn)) {
+            deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
+            ret err[bool, str](unwrap_err[str, str](rsyn));
+        }
+        val rin: Result[intern.StrId, str] = intern.intern(coff_interner, unwrap_ok[str, str](rsyn));
         if (is_err[intern.StrId, str](rin)) {
             deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
             ret err[bool, str](unwrap_err[intern.StrId, str](rin));
@@ -1344,6 +1378,12 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
         val sh: usize = secthdr_base + s::usize * SECTION_HEADER_SIZE;
         val rptr: usize = bin.read_u32_le(buf, sh + 24)::usize;
         val rcount: u32 = bin.read_u16_le(buf, sh + 32)::u32;
+        # the section's relocation array (PointerToRelocations + count records)
+        # must lie within the input before any record is read.
+        if (rcount > 0 && !bin.region_ok(buf_size, rptr, rcount::usize * RELOCATION_SIZE)) {
+            deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
+            ret err[bool, str]("coff: relocation array out of bounds");
+        }
         var k: u32 = 0;
         for (k < rcount) {
             val ro: usize = rptr + k::usize * RELOCATION_SIZE;
@@ -3699,5 +3739,61 @@ test "coff: emit rejects a section reloc count above the u16 limit (#1256)" {
 
     if (!is_err[bool, str](em)) { ret 1; }
     if (!str_contains(unwrap_err[bool, str](em), "exceeds")) { ret 1; }
+    ret 0;
+}
+
+test "coff: parse rejects a truncated object instead of reading out of bounds (#1256)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    var syms: [1]of.Symbol;
+    syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 1;
+    img.relocations = nil; img.reloc_count = 0;
+
+    val tf_r: Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_trunc");
+    if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: Result[bool, str] = coff_emit_object(?isa_vt, ?img, tpath::*u8);
+    if (is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: Result[fs.Buffer, str] = fs.read_all_sized(?alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (is_err[fs.Buffer, str](rb)) { ret 1; }
+    val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
+
+    # the full object parses cleanly; a buffer truncated past the header (the
+    # symbol table and relocation arrays now lie beyond the end) must error rather
+    # than walk off the mapped bytes.
+    var ok_out: of.ObjectImage;
+    if (is_err[bool, str](coff_parse_object(?alloc, buf.data, buf.len, ?ok_out))) { ret 1; }
+
+    var out: of.ObjectImage;
+    val pr: Result[bool, str] = coff_parse_object(?alloc, buf.data, COFF_HEADER_SIZE + 8, ?out);
+    if (!is_err[bool, str](pr)) { ret 1; }
+    if (!str_contains(unwrap_err[bool, str](pr), "out of bounds")) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -184,14 +184,43 @@ fun resolve(id: intern.StrId) str {
 }
 
 # map an abstract relocation-kind StrId to the COFF x86-64 machine relocation
-# type. defaults to ADDR64 for an unknown kind. pc32/plt32 both encode a 32-bit
-# pc-relative reference (REL32); addr32nb is the image-relative ADDR32NB.
-fun reloc_type_for(kind: intern.StrId) u16 {
-    if (kind == rk_abs64)    { ret IMAGE_REL_AMD64_ADDR64; }
-    if (kind == rk_pc32)     { ret IMAGE_REL_AMD64_REL32; }
-    if (kind == rk_plt32)    { ret IMAGE_REL_AMD64_REL32; }
-    if (kind == rk_addr32nb) { ret IMAGE_REL_AMD64_ADDR32NB; }
-    ret IMAGE_REL_AMD64_ADDR64;
+# type. an unmapped kind is an error naming the kind, never silently serialized
+# as ADDR64 (an 8-byte write over what codegen sized as a 4-byte field).
+# pc32/plt32 both encode a 32-bit pc-relative reference (REL32); addr32nb is the
+# image-relative ADDR32NB. `alloc` backs the error string.
+fun reloc_type_for(alloc: *Allocator, kind: intern.StrId) Result[u16, str] {
+    if (kind == rk_abs64)    { ret ok[u16, str](IMAGE_REL_AMD64_ADDR64); }
+    if (kind == rk_pc32)     { ret ok[u16, str](IMAGE_REL_AMD64_REL32); }
+    if (kind == rk_plt32)    { ret ok[u16, str](IMAGE_REL_AMD64_REL32); }
+    if (kind == rk_addr32nb) { ret ok[u16, str](IMAGE_REL_AMD64_ADDR32NB); }
+    ret err[u16, str](unsupported_kind_message(alloc, kind));
+}
+
+# "coff: unsupported relocation kind: <name>" for an abstract kind the writer has
+# no width-correct COFF machine type for.
+fun unsupported_kind_message(alloc: *Allocator, kind: intern.StrId) str {
+    ret bin.name_message(coff_interner, alloc, "coff: unsupported relocation kind: ",
+                         resolve(kind), "coff: unsupported relocation kind");
+}
+
+# "coff: unsupported relocation type <n>" for a machine type the parser cannot
+# map to an abstract kind (e.g. a foreign ADDR32 — a 32-bit field that must not
+# be linked as a 64-bit absolute).
+fun unsupported_type_message(alloc: *Allocator, r_type: u64) str {
+    ret bin.number_message(coff_interner, alloc, "coff: unsupported relocation type ",
+                           r_type, "coff: unsupported relocation type");
+}
+
+# verify every relocation's abstract kind maps to a COFF machine type, up front
+# before any output is allocated. an unmapped kind fails the emit naming the kind.
+fun validate_reloc_kinds(img: *of.ObjectImage) Result[bool, str] {
+    var i: u32 = 0;
+    for (i < img.reloc_count) {
+        val r: Result[u16, str] = reloc_type_for(img.alloc, img.relocations[i].kind);
+        if (is_err[u16, str](r)) { ret err[bool, str](unwrap_err[u16, str](r)); }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
 }
 
 # read_inplace_addend: recover a COFF relocation's in-place addend from the
@@ -210,12 +239,15 @@ fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
 }
 
 # map a COFF x86-64 machine relocation type back to its abstract RK_* kind name.
-fun reloc_kind_for(r_type: u16) intern.StrId {
-    if (r_type == IMAGE_REL_AMD64_ADDR64)   { ret rk_abs64; }
-    if (r_type == IMAGE_REL_AMD64_REL32)    { ret rk_pc32; }
-    if (r_type == IMAGE_REL_AMD64_ADDR32NB) { ret rk_addr32nb; }
-    if (r_type == IMAGE_REL_AMD64_ADDR32)   { ret rk_abs64; }
-    ret rk_abs64;
+# an unrecognized type is an error naming the type rather than a silent
+# fall-through to abs64. ADDR32 (a 32-bit absolute) is rejected too: there is no
+# width-correct abstract kind for it, and aliasing it to abs64 would link a
+# foreign object's 4-byte field with an 8-byte write.
+fun reloc_kind_for(alloc: *Allocator, r_type: u16) Result[intern.StrId, str] {
+    if (r_type == IMAGE_REL_AMD64_ADDR64)   { ret ok[intern.StrId, str](rk_abs64); }
+    if (r_type == IMAGE_REL_AMD64_REL32)    { ret ok[intern.StrId, str](rk_pc32); }
+    if (r_type == IMAGE_REL_AMD64_ADDR32NB) { ret ok[intern.StrId, str](rk_addr32nb); }
+    ret err[intern.StrId, str](unsupported_type_message(alloc, r_type::u64));
 }
 
 # COFF section characteristics for an abstract section kind (the alignment bits
@@ -409,11 +441,12 @@ fun validate_reloc_symbols(img: *of.ObjectImage) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
-# reloc_field_width: the byte width of a relocation's patched field for the COFF
-# x86-64 machine type the abstract kind maps to — 8 for ADDR64, 4 for every other
-# (REL32 / ADDR32 / ADDR32NB).
+# reloc_field_width: the byte width of a relocation's patched field — 8 for the
+# 64-bit absolute kind, 4 for every other supported kind (pc32 / plt32 / addr32nb,
+# all 4-byte). derived from the abstract kind directly; `validate_reloc_kinds`
+# rejects any kind the writer cannot map before this is consulted.
 fun reloc_field_width(kind: intern.StrId) usize {
-    if (reloc_type_for(kind) == IMAGE_REL_AMD64_ADDR64) { ret 8; }
+    if (kind == rk_abs64) { ret 8; }
     ret 4;
 }
 
@@ -717,6 +750,12 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     val num_secs: u32 = img.section_count;
     val num_syms: u32 = img.symbol_count;
 
+    # map every relocation kind to a machine type first, so an unmapped kind fails
+    # the emit naming the kind (never silently serialized as ADDR64) and the range
+    # check below sees only known, width-correct kinds.
+    val vrk: Result[bool, str] = validate_reloc_kinds(img);
+    if (is_err[bool, str](vrk)) { ret err[bool, str](unwrap_err[bool, str](vrk)); }
+
     # validate every relocation's patch field lies within its section before any
     # output is built — the addend fold writes the in-place value here (COFF has no
     # RELA addend), so a malformed offset must fail the link, not write out of
@@ -921,7 +960,9 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
                     # never silently aliased.
                     val rsi: u32 = unwrap_ok[u32, str](reloc_sym_index(img, img.relocations[ri].symbol));
                     bin.write_u32_le(buf, ro + 4, sym_remap[rsi]);
-                    bin.write_u16_le(buf, ro + 8, reloc_type_for(img.relocations[ri].kind));
+                    # validate_reloc_kinds proved every kind maps, so this lookup
+                    # cannot miss; ADDR64 is never silently substituted.
+                    bin.write_u16_le(buf, ro + 8, unwrap_ok[u16, str](reloc_type_for(alloc, img.relocations[ri].kind)));
                     ro = ro + RELOCATION_SIZE;
                 }
                 ri = ri + 1;
@@ -1299,7 +1340,12 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
             val r_off:  u32 = bin.read_u32_le(buf, ro);
             out.relocations[idx].section = s;
             out.relocations[idx].offset = r_off;
-            out.relocations[idx].kind = reloc_kind_for(r_type);
+            val rk: Result[intern.StrId, str] = reloc_kind_for(alloc, r_type);
+            if (is_err[intern.StrId, str](rk)) {
+                deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
+                ret err[bool, str](unwrap_err[intern.StrId, str](rk));
+            }
+            out.relocations[idx].kind = unwrap_ok[intern.StrId, str](rk);
             # COFF carries the addend in-place in the patched field, not in the
             # relocation record (no RELA addend). recover it as a signed value the
             # abstract `S + A - P` / `S + A` applier expects — a 64-bit field for
@@ -2515,7 +2561,6 @@ var coff_reloc_kinds: [4]of.RelocationKind;
 # the COFF OF vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry.
 var coff_vtable: of.OfVTable;
-var coff_registered: bool = false;
 
 # register_coff: build and install the COFF OfVTable.
 #
@@ -2523,8 +2568,11 @@ var coff_registered: bool = false;
 # interns the format name ("coff"), file extension ("obj"), and relocation-kind
 # names, fills the relocation-kind table and vtable, wires the writer/reader, and
 # self-registers it into the process-global OF registry under of.OF_COFF.
-# write-once: a second call only refreshes the captured interner. must be invoked
-# at compiler startup before target.select requests a Windows target.
+# reentrant: every call re-interns all names and refreshes the captured interner
+# and the `rk_*` / vtable kind handles against `i`, so a second session (or test)
+# with a different interner is fully consistent rather than leaving stale ids from
+# the first registration; `of.register` itself is idempotent. must be invoked at
+# compiler startup before target.select requests a Windows target.
 # ---
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields and captured
@@ -2532,7 +2580,6 @@ var coff_registered: bool = false;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_coff(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
     coff_interner = i;
-    if (coff_registered) { ret ok[bool, str](true); }
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "coff");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -2593,7 +2640,6 @@ pub fun register_coff(alloc: *Allocator, i: *intern.Interner) Result[bool, str] 
     coff_vtable.relocation_count = 4;
 
     of.register(?coff_vtable);
-    coff_registered = true;
     ret ok[bool, str](true);
 }
 
@@ -3461,5 +3507,122 @@ test "coff: parse_function_unwind rejects an [r13+disp] store as a save (REX.B)"
         k = k + 1;
     }
     if (uw.prolog_size != 8) { ret 1; }  # prologue ends at the sub rsp; the r13 store is body
+    ret 0;
+}
+
+test "coff: emit rejects a relocation whose kind has no COFF machine type (#1256)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    var syms: [1]of.Symbol;
+    syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    # a defined symbol but a kind COFF has no machine type for (gotpcrel is ELF-only)
+    # — before #1256 it was silently serialized as ADDR64 (an 8-byte write over the
+    # 4-byte field); it must now fail naming the kind.
+    val bogus: intern.StrId = t_intern(?i, "gotpcrel");
+    var relocs: [1]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = bogus;
+    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 1;
+    img.relocations = ?relocs[0]; img.reloc_count = 1;
+
+    val tf_r: Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_kind");
+    if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: Result[bool, str] = coff_emit_object(?isa_vt, ?img, tpath::*u8);
+    fs.temp_close_and_remove(?tf);
+
+    if (!is_err[bool, str](em)) { ret 1; }
+    if (!str_contains(unwrap_err[bool, str](em), "gotpcrel")) { ret 1; }
+    ret 0;
+}
+
+test "coff: parse rejects a foreign ADDR32 relocation type (#1256)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val rr: Result[bool, str] = register_coff(?alloc, ?i);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
+    if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
+    val vt: *of.OfVTable = unwrap[*of.OfVTable](vt_o);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    var syms: [1]of.Symbol;
+    syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    val k_pc32: intern.StrId = of.reloc_kind_name(vt, of.RK_PC32);
+    var relocs: [1]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = k_pc32;
+    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 1;
+    img.relocations = ?relocs[0]; img.reloc_count = 1;
+
+    val tf_r: Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_ptype");
+    if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: Result[bool, str] = coff_emit_object(?isa_vt, ?img, tpath::*u8);
+    if (is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: Result[fs.Buffer, str] = fs.read_all_sized(?alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (is_err[fs.Buffer, str](rb)) { ret 1; }
+    val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
+
+    # overwrite the lone relocation record's Type with ADDR32 (a 32-bit absolute
+    # the writer never emits). before #1256 the parser aliased ADDR32 to abs64 —
+    # an 8-byte relocation over the 4-byte field.
+    val rptr: usize = bin.read_u32_le(buf.data, COFF_HEADER_SIZE + 24)::usize;
+    if (rptr == 0) { ret 1; }
+    bin.write_u16_le(buf.data, rptr + 8, IMAGE_REL_AMD64_ADDR32);
+
+    var out: of.ObjectImage;
+    val pr: Result[bool, str] = coff_parse_object(?alloc, buf.data, buf.len, ?out);
+    if (!is_err[bool, str](pr)) { ret 1; }
+    if (!str_contains(unwrap_err[bool, str](pr), "relocation type")) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -391,6 +391,12 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
 
     # 1 null + sections + .symtab + .strtab + .shstrtab + per-rela sections
     val total_shdr: u32 = 1 + num_secs + 3 + num_rela_secs;
+    # e_shnum is a u16 and 0xFF00 (SHN_LORESERVE) up are reserved indices, so the
+    # real section-header count must stay below 0xFF00. real ELF escapes a larger
+    # count through section[0].sh_size; that is not implemented here, so reject a
+    # count that would otherwise truncate into a corrupt e_shnum rather than emit a
+    # well-formed-looking object with a wrong section count.
+    if (total_shdr > 0xFEFF) { ret err[bool, str]("elf: section-header count exceeds the ELF e_shnum limit"); }
     val shdr_table_size: usize = total_shdr::usize * SHDR_SIZE;
 
     # section-name string table: leading nul, section names, the three fixed

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1923,39 +1923,6 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
     ret ok[bool, str](true);
 }
 
-# apply_reloc: patch a relocation into a section's bytes.
-#
-# resolves one abstract relocation in place. `sym_addr` is the final virtual
-# address of the referenced symbol and `patch_addr` is the virtual address of
-# the patch site (the section base plus the relocation offset). ABS64 writes an
-# 8-byte absolute; PC32/PLT32/GOTPCREL write a 4-byte pc-relative displacement
-# (`sym + addend - patch`); ABS32S writes a 4-byte signed absolute.
-# ---
-# bytes:      the section bytes being patched
-# offset:     byte offset of the patch site within the section
-# kind:       the abstract relocation-kind name (one of the interned RK_* names)
-# addend:     constant added to the resolved symbol address
-# sym_addr:   final virtual address of the referenced symbol
-# patch_addr: virtual address of the patch site
-# ret:        ok(true) on success, or an error string for an unknown kind
-pub fun apply_reloc(bytes: *u8, offset: u32, kind: intern.StrId, addend: i64,
-                    sym_addr: u64, patch_addr: u64) Result[bool, str] {
-    val off: usize = offset::usize;
-    if (kind == rk_abs64) {
-        bin.write_u64_le(bytes, off, sym_addr + addend::u64);
-        ret ok[bool, str](true);
-    }
-    if (kind == rk_pc32 || kind == rk_plt32 || kind == rk_gotpcrel) {
-        bin.write_u32_le(bytes, off, (sym_addr::i64 + addend - patch_addr::i64)::u32);
-        ret ok[bool, str](true);
-    }
-    if (kind == rk_abs32s) {
-        bin.write_u32_le(bytes, off, (sym_addr::i64 + addend)::u32);
-        ret ok[bool, str](true);
-    }
-    ret err[bool, str]("elf: relocation kind not supported");
-}
-
 # intern `s` for a test, yielding STR_NIL on the (test-only) allocation failure.
 fun t_intern(i: *intern.Interner, s: str) intern.StrId {
     val r: Result[intern.StrId, str] = intern.intern(i, s);

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -29,7 +29,6 @@ use std.types.size.usize;
 
 use std.types.string.str;
 use std.types.string.str_len;
-use std.types.string.str_equals;
 use std.types.string.str_contains;
 
 use std.types.result.Result;
@@ -168,31 +167,63 @@ fun resolve(id: intern.StrId) str {
 }
 
 # map an abstract relocation-kind StrId to the ELF machine relocation type for
-# the given ISA. defaults to the 64-bit absolute type for unknown kinds.
-fun reloc_type_for(kind: intern.StrId, arch_id: u32) u32 {
+# the given ISA. an unmapped kind is an error naming the kind, never silently
+# serialized as the 64-bit absolute type (an 8-byte write over a 4-byte field) —
+# a kind the format has no width-correct machine type for must fail the emit, not
+# corrupt the object. `alloc` backs the error string.
+fun reloc_type_for(alloc: *Allocator, kind: intern.StrId, arch_id: u32) Result[u32, str] {
     if (arch_id == isa.ARCH_AARCH64) {
-        if (kind == rk_abs64)  { ret R_AARCH64_ABS64; }
-        if (kind == rk_pc32)   { ret R_AARCH64_PREL32; }
-        if (kind == rk_plt32)  { ret R_AARCH64_CALL26; }
-        if (kind == rk_abs32s) { ret R_AARCH64_ABS64; }
-        ret R_AARCH64_ABS64;
+        if (kind == rk_abs64) { ret ok[u32, str](R_AARCH64_ABS64); }
+        if (kind == rk_pc32)  { ret ok[u32, str](R_AARCH64_PREL32); }
+        if (kind == rk_plt32) { ret ok[u32, str](R_AARCH64_CALL26); }
+        ret err[u32, str](unsupported_kind_message(alloc, kind));
     }
-    if (kind == rk_abs64)    { ret R_X86_64_64; }
-    if (kind == rk_pc32)     { ret R_X86_64_PC32; }
-    if (kind == rk_plt32)    { ret R_X86_64_PLT32; }
-    if (kind == rk_gotpcrel) { ret R_X86_64_GOTPCREL; }
-    if (kind == rk_abs32s)   { ret R_X86_64_32S; }
-    ret R_X86_64_64;
+    if (kind == rk_abs64)    { ret ok[u32, str](R_X86_64_64); }
+    if (kind == rk_pc32)     { ret ok[u32, str](R_X86_64_PC32); }
+    if (kind == rk_plt32)    { ret ok[u32, str](R_X86_64_PLT32); }
+    if (kind == rk_gotpcrel) { ret ok[u32, str](R_X86_64_GOTPCREL); }
+    if (kind == rk_abs32s)   { ret ok[u32, str](R_X86_64_32S); }
+    ret err[u32, str](unsupported_kind_message(alloc, kind));
 }
 
-# map an ELF machine relocation type back to its abstract RK_* kind name.
-fun reloc_kind_for(r_type: u32) intern.StrId {
-    if (r_type == R_X86_64_64 || r_type == R_AARCH64_ABS64) { ret rk_abs64; }
-    if (r_type == R_X86_64_PC32 || r_type == R_AARCH64_PREL32) { ret rk_pc32; }
-    if (r_type == R_X86_64_PLT32 || r_type == R_AARCH64_CALL26) { ret rk_plt32; }
-    if (r_type == R_X86_64_GOTPCREL) { ret rk_gotpcrel; }
-    if (r_type == R_X86_64_32S) { ret rk_abs32s; }
-    ret rk_abs64;
+# map an ELF machine relocation type back to its abstract RK_* kind name. an
+# unrecognized type is an error naming the type rather than a silent fall-through
+# to abs64 — a foreign object's 4-byte type (e.g. R_X86_64_32) must not be linked
+# as a 64-bit absolute, which would write 8 bytes over the 4-byte field.
+fun reloc_kind_for(alloc: *Allocator, r_type: u32) Result[intern.StrId, str] {
+    if (r_type == R_X86_64_64 || r_type == R_AARCH64_ABS64) { ret ok[intern.StrId, str](rk_abs64); }
+    if (r_type == R_X86_64_PC32 || r_type == R_AARCH64_PREL32) { ret ok[intern.StrId, str](rk_pc32); }
+    if (r_type == R_X86_64_PLT32 || r_type == R_AARCH64_CALL26) { ret ok[intern.StrId, str](rk_plt32); }
+    if (r_type == R_X86_64_GOTPCREL) { ret ok[intern.StrId, str](rk_gotpcrel); }
+    if (r_type == R_X86_64_32S) { ret ok[intern.StrId, str](rk_abs32s); }
+    ret err[intern.StrId, str](unsupported_type_message(alloc, r_type::u64));
+}
+
+# "elf: unsupported relocation kind: <name>" for an abstract kind the writer has
+# no width-correct ELF machine type for.
+fun unsupported_kind_message(alloc: *Allocator, kind: intern.StrId) str {
+    ret bin.name_message(elf_interner, alloc, "elf: unsupported relocation kind: ",
+                         resolve(kind), "elf: unsupported relocation kind");
+}
+
+# "elf: unsupported relocation type <n>" for a machine type the parser cannot map
+# to an abstract kind.
+fun unsupported_type_message(alloc: *Allocator, r_type: u64) str {
+    ret bin.number_message(elf_interner, alloc, "elf: unsupported relocation type ",
+                           r_type, "elf: unsupported relocation type");
+}
+
+# verify every relocation's abstract kind maps to a width-correct ELF machine
+# type, up front before any output is allocated so the error path needs no
+# cleanup. an unmapped kind fails the emit naming the kind.
+fun validate_reloc_kinds(img: *of.ObjectImage, arch_id: u32) Result[bool, str] {
+    var i: u32 = 0;
+    for (i < img.reloc_count) {
+        val r: Result[u32, str] = reloc_type_for(img.alloc, img.relocations[i].kind, arch_id);
+        if (is_err[u32, str](r)) { ret err[bool, str](unwrap_err[u32, str](r)); }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
 }
 
 # ELF machine type for an ISA id.
@@ -265,46 +296,25 @@ fun strtab_size(img: *of.ObjectImage) usize {
 # as an error naming the symbol rather than silently aliased to index 0 (the
 # reserved undefined entry), which would corrupt the link.
 fun reloc_sym_index(img: *of.ObjectImage, sym: intern.StrId) Result[u32, str] {
-    val name: str = resolve(sym);
-    if (name != nil) {
+    if (sym != intern.STR_NIL) {
         var i: u32 = 0;
         for (i < img.symbol_count) {
-            val sn: str = resolve(img.symbols[i].name);
-            if (sn != nil && str_equals(sn, name)) { ret ok[u32, str](i); }
+            # both ids live in the same session interner, so a direct integer
+            # compare is correct — matching the COFF writer (no per-symbol resolve
+            # + str_equals, which was an O(relocs x symbols x len) hot path).
+            if (img.symbols[i].name == sym) { ret ok[u32, str](i); }
             i = i + 1;
         }
     }
     ret err[u32, str](unresolved_reloc_message(img.alloc, sym));
 }
 
-# build the "elf: unresolved relocation symbol: <name>" diagnostic, interned so
-# it outlives this call. an unnamed (STR_NIL) target, or interning failure under
-# memory pressure, degrades to the generic static form; the emit still fails.
+# build the "elf: unresolved relocation symbol: <name>" diagnostic. an unnamed
+# (STR_NIL) target, or interning failure under memory pressure, degrades to the
+# generic static form; the emit still fails.
 fun unresolved_reloc_message(alloc: *Allocator, sym: intern.StrId) str {
-    val generic: str = "elf: relocation references an unresolved symbol";
-    val name: str = resolve(sym);
-    if (name == nil || elf_interner == nil) { ret generic; }
-
-    val pre:  str = "elf: unresolved relocation symbol: ";
-    val lpre: usize = str_len(pre);
-    val lnam: usize = str_len(name);
-    val total: usize = lpre + lnam;
-
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { ret generic; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    var k: usize = 0;
-    for (k < lpre) { buf[k] = pre[k]; k = k + 1; }
-    var n: usize = 0;
-    for (n < lnam) { buf[lpre + n] = name[n]; n = n + 1; }
-    buf[total] = 0;
-
-    val ir: Result[intern.StrId, str] = intern.intern(elf_interner, buf::str);
-    deallocate[u8](alloc, buf, total + 1);
-    if (is_err[intern.StrId, str](ir)) { ret generic; }
-    val nm: Option[str] = intern.lookup(elf_interner, unwrap_ok[intern.StrId, str](ir));
-    if (is_some[str](nm)) { ret unwrap[str](nm); }
-    ret generic;
+    ret bin.name_message(elf_interner, alloc, "elf: unresolved relocation symbol: ",
+                         resolve(sym), "elf: relocation references an unresolved symbol");
 }
 
 # verify every relocation's target symbol resolves to an image symbol, up front
@@ -368,6 +378,12 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     # an unresolved target fails the emit (naming the symbol) with no cleanup.
     val vrs: Result[bool, str] = validate_reloc_symbols(img);
     if (is_err[bool, str](vrs)) { ret err[bool, str](unwrap_err[bool, str](vrs)); }
+
+    # map every relocation kind to a machine type up front too, so an unmapped
+    # kind fails the emit naming the kind instead of being silently serialized as
+    # a 64-bit absolute over a 4-byte field.
+    val vrk: Result[bool, str] = validate_reloc_kinds(img, tgt_isa.id);
+    if (is_err[bool, str](vrk)) { ret err[bool, str](unwrap_err[bool, str](vrk)); }
 
     val num_secs:      u32 = img.section_count;
     val num_syms:      u32 = img.symbol_count;
@@ -607,7 +623,9 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
                     # and the lookup cannot miss; index 0 is never silently used.
                     val rsi: u32 = unwrap_ok[u32, str](reloc_sym_index(img, img.relocations[ri].symbol));
                     val elf_sym: u64 = sym_remap[rsi]::u64;
-                    val elf_type: u32 = reloc_type_for(img.relocations[ri].kind, tgt_isa.id);
+                    # validate_reloc_kinds proved every kind maps, so the lookup
+                    # cannot miss; index 0 / abs64 is never silently substituted.
+                    val elf_type: u32 = unwrap_ok[u32, str](reloc_type_for(alloc, img.relocations[ri].kind, tgt_isa.id));
                     val r_info: u64 = (elf_sym << 32) | elf_type::u64;
                     bin.write_u64_le(buf, ro + 8, r_info);
                     bin.write_u64_le(buf, ro + 16, img.relocations[ri].addend::u64);
@@ -740,21 +758,22 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
 # register and handed out as borrowed pointers for the process lifetime.
 var elf_vtable: of.OfVTable;
 var elf_reloc_kinds: [5]of.RelocationKind;
-var elf_registered: bool = false;
 
 # register: build the ELF OfVTable and install it into the format registry.
 #
 # captures the interner so the writer can resolve `intern.StrId` names, interns
 # the format name ("elf"), extension ("o"), and the five abstract relocation
 # kind names, fills the relocation-kind table and the module-level vtable, and
-# registers it under `of.OF_ELF`. idempotent: a second call returns ok without
-# re-interning.
+# registers it under `of.OF_ELF`. reentrant: every call re-interns all names and
+# refreshes the captured interner and the `rk_*` / vtable kind handles against
+# `i`, so a second session (or test) with a different interner is consistent
+# rather than left with stale ids from the first registration; `of.register` is
+# itself idempotent.
 # ---
 # i:   interner used to intern the vtable's string fields and capture for the writer
 # ret: ok(true) on success, or an allocation error from interning
 pub fun register(i: *intern.Interner) Result[bool, str] {
     elf_interner = i;
-    if (elf_registered) { ret ok[bool, str](true); }
 
     val rname: Result[intern.StrId, str] = intern.intern(i, "elf");
     if (is_err[intern.StrId, str](rname)) { ret err[bool, str](unwrap_err[intern.StrId, str](rname)); }
@@ -795,7 +814,6 @@ pub fun register(i: *intern.Interner) Result[bool, str] {
     elf_vtable.relocation_count = 5;
 
     of.register(?elf_vtable);
-    elf_registered = true;
     ret ok[bool, str](true);
 }
 
@@ -1813,7 +1831,12 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
                 or { out.relocations[idx].section = of.SECTION_EXTERNAL; }
                 out.relocations[idx].offset = bin.read_u64_le(buf, ro)::u32;
                 out.relocations[idx].addend = bin.read_u64_le(buf, ro + 16)::i64;
-                out.relocations[idx].kind = reloc_kind_for(r_type);
+                val rk: Result[intern.StrId, str] = reloc_kind_for(alloc, r_type);
+                if (is_err[intern.StrId, str](rk)) {
+                    deallocate[i32](alloc, sec_map, e_shnum::usize);
+                    ret err[bool, str](unwrap_err[intern.StrId, str](rk));
+                }
+                out.relocations[idx].kind = unwrap_ok[intern.StrId, str](rk);
                 # r_sym indexes the on-disk symtab (1-based, index 0 reserved),
                 # so the ObjectImage symbol is r_sym - 1.
                 if (r_sym > 0 && (r_sym - 1) < out.symbol_count) {
@@ -1926,5 +1949,130 @@ test "elf: emit rejects a relocation naming an unresolved symbol (#1196)" {
 
     if (!is_err[bool, str](em)) { ret 1; }
     if (!str_contains(unwrap_err[bool, str](em), "ghost_symbol")) { ret 1; }
+    ret 0;
+}
+
+test "elf: emit rejects a relocation whose kind has no ELF machine type (#1256)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val rr: Result[bool, str] = register(?i);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    var syms: [1]of.Symbol;
+    syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    # the relocation names a defined symbol but carries a kind the ELF writer has
+    # no machine type for — before #1256 it was silently serialized as R_X86_64_64
+    # (an 8-byte write over the 4-byte field); it must now fail naming the kind.
+    val bogus: intern.StrId = t_intern(?i, "bogus_kind");
+    var relocs: [1]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = bogus;
+    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 1;
+    img.relocations = ?relocs[0]; img.reloc_count = 1;
+
+    val tf_r: Result[fs.TempFile, str] = fs.temp_create(?alloc, "elf_kind");
+    if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: Result[bool, str] = emit_object(?isa_vt, ?img, tpath::*u8);
+    fs.temp_close_and_remove(?tf);
+
+    if (!is_err[bool, str](em)) { ret 1; }
+    if (!str_contains(unwrap_err[bool, str](em), "bogus_kind")) { ret 1; }
+    ret 0;
+}
+
+test "elf: parse rejects an unknown machine relocation type (#1256)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val rr: Result[bool, str] = register(?i);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    var syms: [1]of.Symbol;
+    syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_ELF);
+    if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
+    val k_pc32: intern.StrId = of.reloc_kind_name(unwrap[*of.OfVTable](vt_o), of.RK_PC32);
+
+    var relocs: [1]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = k_pc32;
+    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 1;
+    img.relocations = ?relocs[0]; img.reloc_count = 1;
+
+    val tf_r: Result[fs.TempFile, str] = fs.temp_create(?alloc, "elf_ptype");
+    if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: Result[bool, str] = emit_object(?isa_vt, ?img, tpath::*u8);
+    if (is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: Result[fs.Buffer, str] = fs.read_all_sized(?alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (is_err[fs.Buffer, str](rb)) { ret 1; }
+    val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
+
+    # overwrite the lone rela entry's r_type (the low 32 bits of r_info) with a
+    # type the parser does not map (R_X86_64_32 = 10). before #1256 this was
+    # silently read back as abs64 — an 8-byte relocation over a 4-byte field.
+    val e_shoff:     usize = bin.read_u64_le(buf.data, 40)::usize;
+    val e_shentsize: usize = bin.read_u16_le(buf.data, 58)::usize;
+    val e_shnum:     usize = bin.read_u16_le(buf.data, 60)::usize;
+    var rela_off: usize = 0;
+    var sh: usize = 0;
+    for (sh < e_shnum) {
+        val so: usize = e_shoff + sh * e_shentsize;
+        if (bin.read_u32_le(buf.data, so + 4) == SHT_RELA) { rela_off = bin.read_u64_le(buf.data, so + 24)::usize; }
+        sh = sh + 1;
+    }
+    if (rela_off == 0) { ret 1; }
+    bin.write_u32_le(buf.data, rela_off + 8, 10);
+
+    var out: of.ObjectImage;
+    val pr: Result[bool, str] = parse_object(?alloc, buf.data, buf.len, ?out);
+    if (!is_err[bool, str](pr)) { ret 1; }
+    if (!str_contains(unwrap_err[bool, str](pr), "relocation type")) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1664,27 +1664,58 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
     val e_shstrndx:  u16   = bin.read_u16_le(buf, 62);
     if (e_shoff == 0 || e_shnum == 0) { ret err[bool, str]("elf: no section headers"); }
 
-    var shstrtab: *u8 = nil;
+    # the section-header table is a run of e_shnum entries of e_shentsize bytes;
+    # each header is read up to offset 56 (sh_entsize), so the stride must cover a
+    # full SHDR_SIZE header and the whole table must lie within the input before any
+    # header field is dereferenced — a truncated or hostile object errors here.
+    if (e_shentsize::usize < SHDR_SIZE) { ret err[bool, str]("elf: section header entry too small"); }
+    val vsht: Result[bool, str] = bin.require_region(buf_size, e_shoff,
+        e_shnum::usize * e_shentsize::usize, "elf: section header table out of bounds");
+    if (is_err[bool, str](vsht)) { ret err[bool, str](unwrap_err[bool, str](vsht)); }
+
+    # the section-name string table (offset, size); names are read against this
+    # window through bin.cstr_at. validated to lie within the input when present.
+    var shstr_off:  usize = 0;
+    var have_shstr: bool = false;
     if (e_shstrndx < e_shnum) {
         val so: usize = e_shoff + e_shstrndx::usize * e_shentsize::usize;
-        shstrtab = (buf::usize + bin.read_u64_le(buf, so + 24)::usize)::*u8;
+        shstr_off = bin.read_u64_le(buf, so + 24)::usize;
+        val shstr_size: usize = bin.read_u64_le(buf, so + 32)::usize;
+        val vss: Result[bool, str] = bin.require_region(buf_size, shstr_off, shstr_size,
+            "elf: section-name string table out of bounds");
+        if (is_err[bool, str](vss)) { ret err[bool, str](unwrap_err[bool, str](vss)); }
+        have_shstr = true;
     }
 
-    var strtab: *u8 = nil;
+    # the symbol-name string table (offset, size) linked from the symtab.
+    var strtab_off:  usize = 0;
+    var strtab_size: usize = 0;
+    var have_strtab: bool = false;
     var symtab: *u8 = nil;
     var symtab_count: u32 = 0;
     var sh: u16 = 0;
     for (sh < e_shnum) {
         val so: usize = e_shoff + sh::usize * e_shentsize::usize;
         if (bin.read_u32_le(buf, so + 4) == SHT_SYMTAB) {
-            symtab = (buf::usize + bin.read_u64_le(buf, so + 24)::usize)::*u8;
+            val symtab_off: usize = bin.read_u64_le(buf, so + 24)::usize;
             val sz: usize = bin.read_u64_le(buf, so + 32)::usize;
             val ent: usize = bin.read_u64_le(buf, so + 56)::usize;
             if (ent > 0) { symtab_count = (sz / ent)::u32; }
+            # the symtab entries actually walked (symtab_count of SYM_SIZE each)
+            # must lie within the input before they are read.
+            val vsy: Result[bool, str] = bin.require_region(buf_size, symtab_off,
+                symtab_count::usize * SYM_SIZE, "elf: symbol table out of bounds");
+            if (is_err[bool, str](vsy)) { ret err[bool, str](unwrap_err[bool, str](vsy)); }
+            symtab = (buf::usize + symtab_off)::*u8;
             val link: u32 = bin.read_u32_le(buf, so + 40);
             if (link < e_shnum::u32) {
                 val lo: usize = e_shoff + link::usize * e_shentsize::usize;
-                strtab = (buf::usize + bin.read_u64_le(buf, lo + 24)::usize)::*u8;
+                strtab_off = bin.read_u64_le(buf, lo + 24)::usize;
+                strtab_size = bin.read_u64_le(buf, lo + 32)::usize;
+                val vst: Result[bool, str] = bin.require_region(buf_size, strtab_off, strtab_size,
+                    "elf: symbol string table out of bounds");
+                if (is_err[bool, str](vst)) { ret err[bool, str](unwrap_err[bool, str](vst)); }
+                have_strtab = true;
             }
         }
         sh = sh + 1;
@@ -1746,11 +1777,19 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
             or ((flags & SHF_WRITE) == 0) { kind = of.SK_RODATA; }
 
             var sec_name: str = "";
-            if (shstrtab != nil) {
-                sec_name = (shstrtab::usize + bin.read_u32_le(buf, so)::usize)::str;
+            if (have_shstr) {
+                val rnm: Result[str, str] = bin.cstr_at(buf, buf_size, shstr_off + bin.read_u32_le(buf, so)::usize);
+                if (is_err[str, str](rnm)) {
+                    deallocate[i32](alloc, sec_map, e_shnum::usize);
+                    ret err[bool, str](unwrap_err[str, str](rnm));
+                }
+                sec_name = unwrap_ok[str, str](rnm);
             }
             val rin: Result[intern.StrId, str] = intern.intern(elf_interner, sec_name);
-            if (is_err[intern.StrId, str](rin)) { ret err[bool, str](unwrap_err[intern.StrId, str](rin)); }
+            if (is_err[intern.StrId, str](rin)) {
+                deallocate[i32](alloc, sec_map, e_shnum::usize);
+                ret err[bool, str](unwrap_err[intern.StrId, str](rin));
+            }
 
             val idx: u32 = out.section_count;
             out.sections[idx].name  = unwrap_ok[intern.StrId, str](rin);
@@ -1760,10 +1799,20 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
             out.sections[idx].bytes = nil;
             if (ty != SHT_NOBITS && out.sections[idx].len > 0) {
                 val sz: usize = out.sections[idx].len::usize;
+                val src_off: usize = bin.read_u64_le(buf, so + 24)::usize;
+                # the section's sh_offset + sh_size must lie within the input before
+                # its bytes are copied out.
+                if (!bin.region_ok(buf_size, src_off, sz)) {
+                    deallocate[i32](alloc, sec_map, e_shnum::usize);
+                    ret err[bool, str]("elf: section data out of bounds");
+                }
                 val rb: Result[*u8, str] = allocate[u8](alloc, sz);
-                if (is_err[*u8, str](rb)) { ret err[bool, str]("elf: section bytes alloc failed"); }
+                if (is_err[*u8, str](rb)) {
+                    deallocate[i32](alloc, sec_map, e_shnum::usize);
+                    ret err[bool, str]("elf: section bytes alloc failed");
+                }
                 out.sections[idx].bytes = unwrap_ok[*u8, str](rb);
-                val src: *u8 = (buf::usize + bin.read_u64_le(buf, so + 24)::usize)::*u8;
+                val src: *u8 = (buf::usize + src_off)::*u8;
                 mem.raw_copy(out.sections[idx].bytes::ptr, src::ptr, sz);
             }
             sec_map[sh] = idx::i32;
@@ -1773,7 +1822,7 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
     }
 
     # symbols (skip the reserved index-0 entry).
-    if (symtab != nil && strtab != nil) {
+    if (symtab != nil && have_strtab) {
         var si: u32 = 1;
         for (si < sym_n) {
             val so: usize = si::usize * SYM_SIZE;
@@ -1783,9 +1832,16 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
             val st_value: u64 = bin.read_u64_le(symtab, so + 8);
             val st_size:  u64 = bin.read_u64_le(symtab, so + 16);
 
-            val name: str = (strtab::usize + st_name::usize)::str;
-            val rin: Result[intern.StrId, str] = intern.intern(elf_interner, name);
-            if (is_err[intern.StrId, str](rin)) { ret err[bool, str](unwrap_err[intern.StrId, str](rin)); }
+            val rnm: Result[str, str] = bin.cstr_at(buf, buf_size, strtab_off + st_name::usize);
+            if (is_err[str, str](rnm)) {
+                deallocate[i32](alloc, sec_map, e_shnum::usize);
+                ret err[bool, str](unwrap_err[str, str](rnm));
+            }
+            val rin: Result[intern.StrId, str] = intern.intern(elf_interner, unwrap_ok[str, str](rnm));
+            if (is_err[intern.StrId, str](rin)) {
+                deallocate[i32](alloc, sec_map, e_shnum::usize);
+                ret err[bool, str](unwrap_err[intern.StrId, str](rin));
+            }
 
             val idx: u32 = out.symbol_count;
             out.symbols[idx].name = unwrap_ok[intern.StrId, str](rin);
@@ -1822,6 +1878,12 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
             val r_size: usize = bin.read_u64_le(buf, so + 32)::usize;
             val sh_info: u32 = bin.read_u32_le(buf, so + 44);
             val count: u32 = (r_size / RELA_SIZE)::u32;
+            # the rela array (count entries of RELA_SIZE) must lie within the input
+            # before any entry is read.
+            if (!bin.region_ok(buf_size, r_base, count::usize * RELA_SIZE)) {
+                deallocate[i32](alloc, sec_map, e_shnum::usize);
+                ret err[bool, str]("elf: relocation array out of bounds");
+            }
             var target_sec: i32 = -1;
             if (sh_info < e_shnum::u32) { target_sec = sec_map[sh_info]; }
 
@@ -2080,5 +2142,60 @@ test "elf: parse rejects an unknown machine relocation type (#1256)" {
     val pr: Result[bool, str] = parse_object(?alloc, buf.data, buf.len, ?out);
     if (!is_err[bool, str](pr)) { ret 1; }
     if (!str_contains(unwrap_err[bool, str](pr), "relocation type")) { ret 1; }
+    ret 0;
+}
+
+test "elf: parse rejects a truncated object instead of reading out of bounds (#1256)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val rr: Result[bool, str] = register(?i);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    var syms: [1]of.Symbol;
+    syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 1;
+    img.relocations = nil; img.reloc_count = 0;
+
+    val tf_r: Result[fs.TempFile, str] = fs.temp_create(?alloc, "elf_trunc");
+    if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: Result[bool, str] = emit_object(?isa_vt, ?img, tpath::*u8);
+    if (is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: Result[fs.Buffer, str] = fs.read_all_sized(?alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (is_err[fs.Buffer, str](rb)) { ret 1; }
+    val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
+
+    # the full object parses cleanly; a buffer truncated so e_shoff's section-header
+    # table lies past the end must error rather than dereference off the buffer.
+    var ok_out: of.ObjectImage;
+    if (is_err[bool, str](parse_object(?alloc, buf.data, buf.len, ?ok_out))) { ret 1; }
+
+    var out: of.ObjectImage;
+    val pr: Result[bool, str] = parse_object(?alloc, buf.data, ELF_HEADER_SIZE, ?out);
+    if (!is_err[bool, str](pr)) { ret 1; }
+    if (!str_contains(unwrap_err[bool, str](pr), "out of bounds")) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -55,6 +55,7 @@ use page: std.allocator.page;
 use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 use of:     mach.lang.target.of;
+use bin:    mach.lang.target.of.bin;
 
 # ELF identification bytes.
 val ELFCLASS64:    u8 = 2;
@@ -143,70 +144,6 @@ val RELA_SIZE:       usize = 24;
 
 # default page size for static executables; segment vaddrs are page-aligned.
 val EXEC_PAGE_SIZE: u64 = 4096;
-
-# write a u16 little-endian into a buffer.
-fun write_u16_le(buf: *u8, offset: usize, value: u16) {
-    buf[offset]     = (value & 0xFF)::u8;
-    buf[offset + 1] = ((value >> 8) & 0xFF)::u8;
-}
-
-# write a u32 little-endian into a buffer.
-fun write_u32_le(buf: *u8, offset: usize, value: u32) {
-    buf[offset]     = (value & 0xFF)::u8;
-    buf[offset + 1] = ((value >> 8) & 0xFF)::u8;
-    buf[offset + 2] = ((value >> 16) & 0xFF)::u8;
-    buf[offset + 3] = ((value >> 24) & 0xFF)::u8;
-}
-
-# write a u64 little-endian into a buffer.
-fun write_u64_le(buf: *u8, offset: usize, value: u64) {
-    write_u32_le(buf, offset, (value & 0xFFFFFFFF)::u32);
-    write_u32_le(buf, offset + 4, ((value >> 32) & 0xFFFFFFFF)::u32);
-}
-
-# read a u16 little-endian from a buffer.
-fun read_u16_le(buf: *u8, offset: usize) u16 {
-    ret buf[offset]::u16 | (buf[offset + 1]::u16 << 8);
-}
-
-# read a u32 little-endian from a buffer.
-fun read_u32_le(buf: *u8, offset: usize) u32 {
-    ret buf[offset]::u32 | (buf[offset + 1]::u32 << 8)
-      | (buf[offset + 2]::u32 << 16) | (buf[offset + 3]::u32 << 24);
-}
-
-# read a u64 little-endian from a buffer.
-fun read_u64_le(buf: *u8, offset: usize) u64 {
-    ret read_u32_le(buf, offset)::u64 | (read_u32_le(buf, offset + 4)::u64 << 32);
-}
-
-# write a null-terminated string into a buffer, returning the bytes written.
-fun write_str(buf: *u8, offset: usize, s: str) usize {
-    if (s == nil) {
-        buf[offset] = 0;
-        ret 1;
-    }
-    val len: usize = str_len(s);
-    var i: usize = 0;
-    for (i < len) {
-        buf[offset + i] = s[i];
-        i = i + 1;
-    }
-    buf[offset + len] = 0;
-    ret len + 1;
-}
-
-# align a usize up to the given power-of-two alignment.
-fun align_up(value: usize, alignment: usize) usize {
-    if (alignment == 0) { ret value; }
-    ret (value + alignment - 1) & ~(alignment - 1);
-}
-
-# align a u64 virtual address up to the given power-of-two alignment.
-fun align_up_u64(value: u64, alignment: u64) u64 {
-    if (alignment == 0) { ret value; }
-    ret (value + alignment - 1) & ~(alignment - 1);
-}
 
 # session interner captured at registration so the writer can resolve the
 # `intern.StrId` names carried by `of.ObjectImage`. set by `register`.
@@ -388,8 +325,8 @@ fun validate_reloc_symbols(img: *of.ObjectImage) Result[bool, str] {
 fun write_symbol(buf: *u8, sym_off: usize, str_off: usize, str_pos: *usize,
                  img: *of.ObjectImage, idx: u32, binding: u8) {
     val name_pos: usize = @str_pos;
-    @str_pos = @str_pos + write_str(buf, str_off + @str_pos, resolve(img.symbols[idx].name));
-    write_u32_le(buf, sym_off, name_pos::u32);
+    @str_pos = @str_pos + bin.write_str(buf, str_off + @str_pos, resolve(img.symbols[idx].name));
+    bin.write_u32_le(buf, sym_off, name_pos::u32);
 
     var sym_type: u8 = STT_NOTYPE;
     var sec_idx: u16 = 0;
@@ -403,9 +340,9 @@ fun write_symbol(buf: *u8, sym_off: usize, str_off: usize, str_pos: *usize,
     val info: u8 = (binding << 4) | (sym_type & 0xF);
     buf[sym_off + 4] = info;
     buf[sym_off + 5] = 0;
-    write_u16_le(buf, sym_off + 6, sec_idx);
-    write_u64_le(buf, sym_off + 8, img.symbols[idx].offset::u64);
-    write_u64_le(buf, sym_off + 16, img.symbols[idx].size::u64);
+    bin.write_u16_le(buf, sym_off + 6, sec_idx);
+    bin.write_u64_le(buf, sym_off + 8, img.symbols[idx].offset::u64);
+    bin.write_u64_le(buf, sym_off + 16, img.symbols[idx].size::u64);
 }
 
 # emit_object: serialize an ObjectImage to a relocatable ELF64 .o file.
@@ -482,15 +419,15 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     s = 0;
     for (s < num_secs) {
         name_offsets[s] = shstrtab_off::u32;
-        shstrtab_off = shstrtab_off + write_str(shstrtab, shstrtab_off, resolve(img.sections[s].name));
+        shstrtab_off = shstrtab_off + bin.write_str(shstrtab, shstrtab_off, resolve(img.sections[s].name));
         s = s + 1;
     }
     val symtab_name_off: u32 = shstrtab_off::u32;
-    shstrtab_off = shstrtab_off + write_str(shstrtab, shstrtab_off, ".symtab");
+    shstrtab_off = shstrtab_off + bin.write_str(shstrtab, shstrtab_off, ".symtab");
     val strtab_name_off: u32 = shstrtab_off::u32;
-    shstrtab_off = shstrtab_off + write_str(shstrtab, shstrtab_off, ".strtab");
+    shstrtab_off = shstrtab_off + bin.write_str(shstrtab, shstrtab_off, ".strtab");
     val shstrtab_name_off: u32 = shstrtab_off::u32;
-    shstrtab_off = shstrtab_off + write_str(shstrtab, shstrtab_off, ".shstrtab");
+    shstrtab_off = shstrtab_off + bin.write_str(shstrtab, shstrtab_off, ".shstrtab");
 
     s = 0;
     for (s < num_secs) {
@@ -525,13 +462,13 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     s = 0;
     for (s < num_secs) {
         if (img.sections[s].kind != of.SK_BSS) {
-            data_offset = align_up(data_offset, img.sections[s].align::usize);
+            data_offset = bin.align_up(data_offset, img.sections[s].align::usize);
             data_offset = data_offset + img.sections[s].len::usize;
         }
         s = s + 1;
     }
 
-    val symtab_offset: usize = align_up(data_offset, 8);
+    val symtab_offset: usize = bin.align_up(data_offset, 8);
     val symtab_size: usize = (num_syms + 1)::usize * SYM_SIZE;
     val strtab_offset: usize = symtab_offset + symtab_size;
     val strtab_sz: usize = strtab_size(img);
@@ -551,14 +488,14 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     for (s < num_secs) {
         val rc: u32 = count_relocs_for_section(img, s);
         if (rc > 0) {
-            rela_offset = align_up(rela_offset, 8);
+            rela_offset = bin.align_up(rela_offset, 8);
             rela_offsets[s] = rela_offset;
             rela_offset = rela_offset + rc::usize * RELA_SIZE;
         }
         s = s + 1;
     }
 
-    val shdr_offset: usize = align_up(rela_offset, 8);
+    val shdr_offset: usize = bin.align_up(rela_offset, 8);
     val total_file_size: usize = shdr_offset + shdr_table_size;
 
     val res_buf: Result[*u8, str] = zallocate[u8](alloc, total_file_size);
@@ -577,27 +514,27 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     buf[6] = EV_CURRENT;
     buf[7] = ELFOSABI_NONE;
 
-    write_u16_le(buf, 16, ET_REL);
-    write_u16_le(buf, 18, machine_for(tgt_isa.id));
-    write_u32_le(buf, 20, 1);
-    write_u64_le(buf, 24, 0);
-    write_u64_le(buf, 32, 0);
-    write_u64_le(buf, 40, shdr_offset::u64);
-    write_u32_le(buf, 48, 0);
-    write_u16_le(buf, 52, ELF_HEADER_SIZE::u16);
-    write_u16_le(buf, 54, 0);
-    write_u16_le(buf, 56, 0);
-    write_u16_le(buf, 58, SHDR_SIZE::u16);
-    write_u16_le(buf, 60, total_shdr::u16);
+    bin.write_u16_le(buf, 16, ET_REL);
+    bin.write_u16_le(buf, 18, machine_for(tgt_isa.id));
+    bin.write_u32_le(buf, 20, 1);
+    bin.write_u64_le(buf, 24, 0);
+    bin.write_u64_le(buf, 32, 0);
+    bin.write_u64_le(buf, 40, shdr_offset::u64);
+    bin.write_u32_le(buf, 48, 0);
+    bin.write_u16_le(buf, 52, ELF_HEADER_SIZE::u16);
+    bin.write_u16_le(buf, 54, 0);
+    bin.write_u16_le(buf, 56, 0);
+    bin.write_u16_le(buf, 58, SHDR_SIZE::u16);
+    bin.write_u16_le(buf, 60, total_shdr::u16);
     val shstrtab_idx: u16 = (1 + num_secs + 2)::u16;
-    write_u16_le(buf, 62, shstrtab_idx);
+    bin.write_u16_le(buf, 62, shstrtab_idx);
 
     # section data
     var sec_offset: usize = ELF_HEADER_SIZE;
     s = 0;
     for (s < num_secs) {
         if (img.sections[s].kind != of.SK_BSS) {
-            sec_offset = align_up(sec_offset, img.sections[s].align::usize);
+            sec_offset = bin.align_up(sec_offset, img.sections[s].align::usize);
             if (img.sections[s].bytes != nil && img.sections[s].len > 0) {
                 mem.raw_copy((buf::usize + sec_offset)::ptr, img.sections[s].bytes::ptr, img.sections[s].len::usize);
             }
@@ -664,7 +601,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
             var ri: u32 = 0;
             for (ri < img.reloc_count) {
                 if (img.relocations[ri].section == s) {
-                    write_u64_le(buf, ro, img.relocations[ri].offset::u64);
+                    bin.write_u64_le(buf, ro, img.relocations[ri].offset::u64);
                     # validate_reloc_symbols proved every reloc resolves, and a
                     # relocated section implies symbols, so sym_remap is non-nil
                     # and the lookup cannot miss; index 0 is never silently used.
@@ -672,8 +609,8 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
                     val elf_sym: u64 = sym_remap[rsi]::u64;
                     val elf_type: u32 = reloc_type_for(img.relocations[ri].kind, tgt_isa.id);
                     val r_info: u64 = (elf_sym << 32) | elf_type::u64;
-                    write_u64_le(buf, ro + 8, r_info);
-                    write_u64_le(buf, ro + 16, img.relocations[ri].addend::u64);
+                    bin.write_u64_le(buf, ro + 8, r_info);
+                    bin.write_u64_le(buf, ro + 16, img.relocations[ri].addend::u64);
                     ro = ro + RELA_SIZE;
                 }
                 ri = ri + 1;
@@ -692,25 +629,25 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     for (s < num_secs) {
         var this_off: usize = 0;
         if (img.sections[s].kind != of.SK_BSS) {
-            sec_offset = align_up(sec_offset, img.sections[s].align::usize);
+            sec_offset = bin.align_up(sec_offset, img.sections[s].align::usize);
             this_off = sec_offset;
         }
-        write_u32_le(buf, shdr_pos, name_offsets[s]);
-        write_u32_le(buf, shdr_pos + 4, section_type_for(img.sections[s].kind));
-        write_u64_le(buf, shdr_pos + 8, section_flags_for(img.sections[s].kind));
-        write_u64_le(buf, shdr_pos + 16, 0);
+        bin.write_u32_le(buf, shdr_pos, name_offsets[s]);
+        bin.write_u32_le(buf, shdr_pos + 4, section_type_for(img.sections[s].kind));
+        bin.write_u64_le(buf, shdr_pos + 8, section_flags_for(img.sections[s].kind));
+        bin.write_u64_le(buf, shdr_pos + 16, 0);
         if (img.sections[s].kind == of.SK_BSS) {
-            write_u64_le(buf, shdr_pos + 24, 0);
+            bin.write_u64_le(buf, shdr_pos + 24, 0);
         } or {
-            write_u64_le(buf, shdr_pos + 24, this_off::u64);
+            bin.write_u64_le(buf, shdr_pos + 24, this_off::u64);
         }
-        write_u64_le(buf, shdr_pos + 32, img.sections[s].len::u64);
-        write_u32_le(buf, shdr_pos + 40, 0);
-        write_u32_le(buf, shdr_pos + 44, 0);
+        bin.write_u64_le(buf, shdr_pos + 32, img.sections[s].len::u64);
+        bin.write_u32_le(buf, shdr_pos + 40, 0);
+        bin.write_u32_le(buf, shdr_pos + 44, 0);
         var sec_align: usize = img.sections[s].align::usize;
         if (sec_align == 0) { sec_align = 1; }
-        write_u64_le(buf, shdr_pos + 48, sec_align::u64);
-        write_u64_le(buf, shdr_pos + 56, 0);
+        bin.write_u64_le(buf, shdr_pos + 48, sec_align::u64);
+        bin.write_u64_le(buf, shdr_pos + 56, 0);
         shdr_pos = shdr_pos + SHDR_SIZE;
         if (img.sections[s].kind != of.SK_BSS) {
             sec_offset = sec_offset + img.sections[s].len::usize;
@@ -719,56 +656,56 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     }
 
     val symtab_shidx: u32 = 1 + num_secs;
-    write_u32_le(buf, shdr_pos, symtab_name_off);
-    write_u32_le(buf, shdr_pos + 4, SHT_SYMTAB);
-    write_u64_le(buf, shdr_pos + 8, 0);
-    write_u64_le(buf, shdr_pos + 16, 0);
-    write_u64_le(buf, shdr_pos + 24, symtab_offset::u64);
-    write_u64_le(buf, shdr_pos + 32, symtab_size::u64);
-    write_u32_le(buf, shdr_pos + 40, (symtab_shidx + 1)::u32);
-    write_u32_le(buf, shdr_pos + 44, first_global::u32);
-    write_u64_le(buf, shdr_pos + 48, 8);
-    write_u64_le(buf, shdr_pos + 56, SYM_SIZE::u64);
+    bin.write_u32_le(buf, shdr_pos, symtab_name_off);
+    bin.write_u32_le(buf, shdr_pos + 4, SHT_SYMTAB);
+    bin.write_u64_le(buf, shdr_pos + 8, 0);
+    bin.write_u64_le(buf, shdr_pos + 16, 0);
+    bin.write_u64_le(buf, shdr_pos + 24, symtab_offset::u64);
+    bin.write_u64_le(buf, shdr_pos + 32, symtab_size::u64);
+    bin.write_u32_le(buf, shdr_pos + 40, (symtab_shidx + 1)::u32);
+    bin.write_u32_le(buf, shdr_pos + 44, first_global::u32);
+    bin.write_u64_le(buf, shdr_pos + 48, 8);
+    bin.write_u64_le(buf, shdr_pos + 56, SYM_SIZE::u64);
     shdr_pos = shdr_pos + SHDR_SIZE;
 
-    write_u32_le(buf, shdr_pos, strtab_name_off);
-    write_u32_le(buf, shdr_pos + 4, SHT_STRTAB);
-    write_u64_le(buf, shdr_pos + 8, 0);
-    write_u64_le(buf, shdr_pos + 16, 0);
-    write_u64_le(buf, shdr_pos + 24, strtab_offset::u64);
-    write_u64_le(buf, shdr_pos + 32, strtab_sz::u64);
-    write_u32_le(buf, shdr_pos + 40, 0);
-    write_u32_le(buf, shdr_pos + 44, 0);
-    write_u64_le(buf, shdr_pos + 48, 1);
-    write_u64_le(buf, shdr_pos + 56, 0);
+    bin.write_u32_le(buf, shdr_pos, strtab_name_off);
+    bin.write_u32_le(buf, shdr_pos + 4, SHT_STRTAB);
+    bin.write_u64_le(buf, shdr_pos + 8, 0);
+    bin.write_u64_le(buf, shdr_pos + 16, 0);
+    bin.write_u64_le(buf, shdr_pos + 24, strtab_offset::u64);
+    bin.write_u64_le(buf, shdr_pos + 32, strtab_sz::u64);
+    bin.write_u32_le(buf, shdr_pos + 40, 0);
+    bin.write_u32_le(buf, shdr_pos + 44, 0);
+    bin.write_u64_le(buf, shdr_pos + 48, 1);
+    bin.write_u64_le(buf, shdr_pos + 56, 0);
     shdr_pos = shdr_pos + SHDR_SIZE;
 
-    write_u32_le(buf, shdr_pos, shstrtab_name_off);
-    write_u32_le(buf, shdr_pos + 4, SHT_STRTAB);
-    write_u64_le(buf, shdr_pos + 8, 0);
-    write_u64_le(buf, shdr_pos + 16, 0);
-    write_u64_le(buf, shdr_pos + 24, shstrtab_offset::u64);
-    write_u64_le(buf, shdr_pos + 32, shstrtab_len::u64);
-    write_u32_le(buf, shdr_pos + 40, 0);
-    write_u32_le(buf, shdr_pos + 44, 0);
-    write_u64_le(buf, shdr_pos + 48, 1);
-    write_u64_le(buf, shdr_pos + 56, 0);
+    bin.write_u32_le(buf, shdr_pos, shstrtab_name_off);
+    bin.write_u32_le(buf, shdr_pos + 4, SHT_STRTAB);
+    bin.write_u64_le(buf, shdr_pos + 8, 0);
+    bin.write_u64_le(buf, shdr_pos + 16, 0);
+    bin.write_u64_le(buf, shdr_pos + 24, shstrtab_offset::u64);
+    bin.write_u64_le(buf, shdr_pos + 32, shstrtab_len::u64);
+    bin.write_u32_le(buf, shdr_pos + 40, 0);
+    bin.write_u32_le(buf, shdr_pos + 44, 0);
+    bin.write_u64_le(buf, shdr_pos + 48, 1);
+    bin.write_u64_le(buf, shdr_pos + 56, 0);
     shdr_pos = shdr_pos + SHDR_SIZE;
 
     s = 0;
     for (s < num_secs) {
         val rc: u32 = count_relocs_for_section(img, s);
         if (rc > 0) {
-            write_u32_le(buf, shdr_pos, rela_name_offsets[s]);
-            write_u32_le(buf, shdr_pos + 4, SHT_RELA);
-            write_u64_le(buf, shdr_pos + 8, 0);
-            write_u64_le(buf, shdr_pos + 16, 0);
-            write_u64_le(buf, shdr_pos + 24, rela_offsets[s]::u64);
-            write_u64_le(buf, shdr_pos + 32, (rc::usize * RELA_SIZE)::u64);
-            write_u32_le(buf, shdr_pos + 40, symtab_shidx::u32);
-            write_u32_le(buf, shdr_pos + 44, (s + 1)::u32);
-            write_u64_le(buf, shdr_pos + 48, 8);
-            write_u64_le(buf, shdr_pos + 56, RELA_SIZE::u64);
+            bin.write_u32_le(buf, shdr_pos, rela_name_offsets[s]);
+            bin.write_u32_le(buf, shdr_pos + 4, SHT_RELA);
+            bin.write_u64_le(buf, shdr_pos + 8, 0);
+            bin.write_u64_le(buf, shdr_pos + 16, 0);
+            bin.write_u64_le(buf, shdr_pos + 24, rela_offsets[s]::u64);
+            bin.write_u64_le(buf, shdr_pos + 32, (rc::usize * RELA_SIZE)::u64);
+            bin.write_u32_le(buf, shdr_pos + 40, symtab_shidx::u32);
+            bin.write_u32_le(buf, shdr_pos + 44, (s + 1)::u32);
+            bin.write_u64_le(buf, shdr_pos + 48, 8);
+            bin.write_u64_le(buf, shdr_pos + 56, RELA_SIZE::u64);
             shdr_pos = shdr_pos + SHDR_SIZE;
         }
         s = s + 1;
@@ -912,10 +849,10 @@ fun emit_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
         seg_offsets = unwrap_ok[*usize, str](ro);
     }
 
-    var total_size: usize = align_up(phdr_offset + phdr_table_size, EXEC_PAGE_SIZE::usize);
+    var total_size: usize = bin.align_up(phdr_offset + phdr_table_size, EXEC_PAGE_SIZE::usize);
     var li: u32 = 0;
     for (li < seg_count) {
-        total_size = align_up(total_size, EXEC_PAGE_SIZE::usize);
+        total_size = bin.align_up(total_size, EXEC_PAGE_SIZE::usize);
         seg_offsets[li] = total_size;
         total_size = total_size + segs[li].filesz;
         li = li + 1;
@@ -934,19 +871,19 @@ fun emit_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
     buf[6] = EV_CURRENT;
     buf[7] = ELFOSABI_NONE;
 
-    write_u16_le(buf, 16, ET_EXEC);
-    write_u16_le(buf, 18, machine_for(tgt_isa.id));
-    write_u32_le(buf, 20, 1);
-    write_u64_le(buf, 24, entry);
-    write_u64_le(buf, 32, phdr_offset::u64);
-    write_u64_le(buf, 40, 0);
-    write_u32_le(buf, 48, 0);
-    write_u16_le(buf, 52, ELF_HEADER_SIZE::u16);
-    write_u16_le(buf, 54, PHDR_SIZE::u16);
-    write_u16_le(buf, 56, phdr_count::u16);
-    write_u16_le(buf, 58, SHDR_SIZE::u16);
-    write_u16_le(buf, 60, 0);
-    write_u16_le(buf, 62, 0);
+    bin.write_u16_le(buf, 16, ET_EXEC);
+    bin.write_u16_le(buf, 18, machine_for(tgt_isa.id));
+    bin.write_u32_le(buf, 20, 1);
+    bin.write_u64_le(buf, 24, entry);
+    bin.write_u64_le(buf, 32, phdr_offset::u64);
+    bin.write_u64_le(buf, 40, 0);
+    bin.write_u32_le(buf, 48, 0);
+    bin.write_u16_le(buf, 52, ELF_HEADER_SIZE::u16);
+    bin.write_u16_le(buf, 54, PHDR_SIZE::u16);
+    bin.write_u16_le(buf, 56, phdr_count::u16);
+    bin.write_u16_le(buf, 58, SHDR_SIZE::u16);
+    bin.write_u16_le(buf, 60, 0);
+    bin.write_u16_le(buf, 62, 0);
 
     var phdr_pos: usize = phdr_offset;
 
@@ -954,26 +891,26 @@ fun emit_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
     var hdr_vaddr: u64 = entry & ~(EXEC_PAGE_SIZE - 1);
     if (seg_count > 0) { hdr_vaddr = segs[0].vaddr & ~(EXEC_PAGE_SIZE - 1); }
     val hdr_filesz: usize = phdr_offset + phdr_table_size;
-    write_u32_le(buf, phdr_pos, PT_LOAD);
-    write_u32_le(buf, phdr_pos + 4, PF_R);
-    write_u64_le(buf, phdr_pos + 8, 0);
-    write_u64_le(buf, phdr_pos + 16, hdr_vaddr);
-    write_u64_le(buf, phdr_pos + 24, hdr_vaddr);
-    write_u64_le(buf, phdr_pos + 32, hdr_filesz::u64);
-    write_u64_le(buf, phdr_pos + 40, hdr_filesz::u64);
-    write_u64_le(buf, phdr_pos + 48, EXEC_PAGE_SIZE);
+    bin.write_u32_le(buf, phdr_pos, PT_LOAD);
+    bin.write_u32_le(buf, phdr_pos + 4, PF_R);
+    bin.write_u64_le(buf, phdr_pos + 8, 0);
+    bin.write_u64_le(buf, phdr_pos + 16, hdr_vaddr);
+    bin.write_u64_le(buf, phdr_pos + 24, hdr_vaddr);
+    bin.write_u64_le(buf, phdr_pos + 32, hdr_filesz::u64);
+    bin.write_u64_le(buf, phdr_pos + 40, hdr_filesz::u64);
+    bin.write_u64_le(buf, phdr_pos + 48, EXEC_PAGE_SIZE);
     phdr_pos = phdr_pos + PHDR_SIZE;
 
     li = 0;
     for (li < seg_count) {
-        write_u32_le(buf, phdr_pos, PT_LOAD);
-        write_u32_le(buf, phdr_pos + 4, pf_flags_for(segs[li].flags));
-        write_u64_le(buf, phdr_pos + 8, seg_offsets[li]::u64);
-        write_u64_le(buf, phdr_pos + 16, segs[li].vaddr);
-        write_u64_le(buf, phdr_pos + 24, segs[li].vaddr);
-        write_u64_le(buf, phdr_pos + 32, segs[li].filesz::u64);
-        write_u64_le(buf, phdr_pos + 40, segs[li].memsz::u64);
-        write_u64_le(buf, phdr_pos + 48, EXEC_PAGE_SIZE);
+        bin.write_u32_le(buf, phdr_pos, PT_LOAD);
+        bin.write_u32_le(buf, phdr_pos + 4, pf_flags_for(segs[li].flags));
+        bin.write_u64_le(buf, phdr_pos + 8, seg_offsets[li]::u64);
+        bin.write_u64_le(buf, phdr_pos + 16, segs[li].vaddr);
+        bin.write_u64_le(buf, phdr_pos + 24, segs[li].vaddr);
+        bin.write_u64_le(buf, phdr_pos + 32, segs[li].filesz::u64);
+        bin.write_u64_le(buf, phdr_pos + 40, segs[li].memsz::u64);
+        bin.write_u64_le(buf, phdr_pos + 48, EXEC_PAGE_SIZE);
         phdr_pos = phdr_pos + PHDR_SIZE;
 
         if (segs[li].bytes != nil && segs[li].filesz > 0) {
@@ -1122,7 +1059,7 @@ fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegm
     # the file offset where the synthesized structures begin: after the linker's
     # segment file bytes, page-aligned. the linker segments are written at file
     # offsets matching their vaddr page (`offset % page == vaddr % page`).
-    var struct_file: usize = align_up(phdr_offset + phdr_table_size, EXEC_PAGE_SIZE::usize);
+    var struct_file: usize = bin.align_up(phdr_offset + phdr_table_size, EXEC_PAGE_SIZE::usize);
     var seg_offsets: *usize = nil;
     if (seg_count > 0) {
         val ro: Result[*usize, str] = zallocate[usize](alloc, seg_count::usize);
@@ -1130,7 +1067,7 @@ fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegm
         seg_offsets = unwrap_ok[*usize, str](ro);
         li = 0;
         for (li < seg_count) {
-            struct_file = align_up(struct_file, EXEC_PAGE_SIZE::usize);
+            struct_file = bin.align_up(struct_file, EXEC_PAGE_SIZE::usize);
             seg_offsets[li] = struct_file;
             struct_file = struct_file + segs[li].filesz;
             li = li + 1;
@@ -1138,8 +1075,8 @@ fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegm
     }
 
     var lay: DynLayout;
-    compute_dyn_layout(?lay, dyn, nimp, align_up(struct_file, EXEC_PAGE_SIZE::usize),
-                       align_up_u64(hi_va, EXEC_PAGE_SIZE));
+    compute_dyn_layout(?lay, dyn, nimp, bin.align_up(struct_file, EXEC_PAGE_SIZE::usize),
+                       bin.align_up_u64(hi_va, EXEC_PAGE_SIZE));
 
     val total_size: usize = lay.rw_off + lay.rw_size;
 
@@ -1158,19 +1095,19 @@ fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegm
     # binary and still resolves the PLT.
     buf[0] = 0x7F; buf[1] = 0x45; buf[2] = 0x4C; buf[3] = 0x46;
     buf[4] = ELFCLASS64; buf[5] = ELFDATA2LSB; buf[6] = EV_CURRENT; buf[7] = ELFOSABI_NONE;
-    write_u16_le(buf, 16, ET_EXEC);
-    write_u16_le(buf, 18, machine_for(tgt_isa.id));
-    write_u32_le(buf, 20, 1);
-    write_u64_le(buf, 24, entry);
-    write_u64_le(buf, 32, phdr_offset::u64);
-    write_u64_le(buf, 40, 0);
-    write_u32_le(buf, 48, 0);
-    write_u16_le(buf, 52, ELF_HEADER_SIZE::u16);
-    write_u16_le(buf, 54, PHDR_SIZE::u16);
-    write_u16_le(buf, 56, phdr_count::u16);
-    write_u16_le(buf, 58, SHDR_SIZE::u16);
-    write_u16_le(buf, 60, 0);
-    write_u16_le(buf, 62, 0);
+    bin.write_u16_le(buf, 16, ET_EXEC);
+    bin.write_u16_le(buf, 18, machine_for(tgt_isa.id));
+    bin.write_u32_le(buf, 20, 1);
+    bin.write_u64_le(buf, 24, entry);
+    bin.write_u64_le(buf, 32, phdr_offset::u64);
+    bin.write_u64_le(buf, 40, 0);
+    bin.write_u32_le(buf, 48, 0);
+    bin.write_u16_le(buf, 52, ELF_HEADER_SIZE::u16);
+    bin.write_u16_le(buf, 54, PHDR_SIZE::u16);
+    bin.write_u16_le(buf, 56, phdr_count::u16);
+    bin.write_u16_le(buf, 58, SHDR_SIZE::u16);
+    bin.write_u16_le(buf, 60, 0);
+    bin.write_u16_le(buf, 62, 0);
 
     # copy the linker's segment bytes into their file offsets.
     li = 0;
@@ -1265,8 +1202,8 @@ fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
     va  = va  + lay.interp_size::u64;
 
     # .dynsym: index 0 reserved-null, then one entry per function import.
-    off = align_up(off, 8);
-    va  = align_up_u64(va, 8);
+    off = bin.align_up(off, 8);
+    va  = bin.align_up_u64(va, 8);
     lay.dynsym_off = off;
     lay.dynsym_va  = va;
     val dynsym_size: usize = (nimp + 1)::usize * SYM_SIZE;
@@ -1291,8 +1228,8 @@ fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
 
     # .hash: SysV hash (nbucket, nchain, buckets[nbucket], chain[nchain]). a
     # single bucket keeps the table valid with a trivial (linear-chain) layout.
-    off = align_up(off, 8);
-    va  = align_up_u64(va, 8);
+    off = bin.align_up(off, 8);
+    va  = bin.align_up_u64(va, 8);
     lay.hash_off = off;
     lay.hash_va  = va;
     val nchain: usize = (nimp + 1)::usize;
@@ -1301,8 +1238,8 @@ fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
     va  = va  + lay.hash_size::u64;
 
     # .rela.plt: one JUMP_SLOT relocation per function import.
-    off = align_up(off, 8);
-    va  = align_up_u64(va, 8);
+    off = bin.align_up(off, 8);
+    va  = bin.align_up_u64(va, 8);
     lay.relaplt_off  = off;
     lay.relaplt_va   = va;
     lay.relaplt_size = nimp::usize * RELA_SIZE;
@@ -1313,8 +1250,8 @@ fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
 
     # .plt: read+execute, its own page-aligned segment. header stub + one per
     # import. empty (size 0) when there are no function imports.
-    off = align_up(off, page);
-    va  = align_up_u64(va, page::u64);
+    off = bin.align_up(off, page);
+    va  = bin.align_up_u64(va, page::u64);
     lay.plt_off = off;
     lay.plt_va  = va;
     if (nimp > 0) { lay.plt_size = PLT_ENTRY_SIZE * (nimp + 1)::usize; } or { lay.plt_size = 0; }
@@ -1322,8 +1259,8 @@ fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
     va  = va  + lay.plt_size::u64;
 
     # .got.plt + .dynamic: read+write, its own page-aligned segment.
-    off = align_up(off, page);
-    va  = align_up_u64(va, page::u64);
+    off = bin.align_up(off, page);
+    va  = bin.align_up_u64(va, page::u64);
     lay.rw_off = off;
     lay.rw_va  = va;
 
@@ -1333,8 +1270,8 @@ fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
     off = off + lay.gotplt_size;
     va  = va  + lay.gotplt_size::u64;
 
-    off = align_up(off, 8);
-    va  = align_up_u64(va, 8);
+    off = bin.align_up(off, 8);
+    va  = bin.align_up_u64(va, 8);
     lay.dynamic_off = off;
     lay.dynamic_va  = va;
     # DT_NEEDED per lib + HASH,STRTAB,SYMTAB,STRSZ,SYMENT + (PLT tags when imports)
@@ -1357,19 +1294,19 @@ fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
 fun write_dyn_structures(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
                          arch_id: u32, imp_str: *usize, lib_str: *usize) {
     # .interp: the loader path.
-    write_str(buf, lay.interp_off, resolve(dyn.interp));
+    bin.write_str(buf, lay.interp_off, resolve(dyn.interp));
 
     # .dynstr and the offset of every name within it, recorded for .dynsym /
     # .dynamic. the interp path is included so the table is self-contained.
     buf[lay.dynstr_off] = 0;
     var str_pos: usize = 1;
-    str_pos = str_pos + write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.interp));
+    str_pos = str_pos + bin.write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.interp));
 
     var i: u32 = 0;
     for (i < dyn.import_count) {
         if (dyn.imports[i].is_func) {
             imp_str[i] = str_pos;
-            str_pos = str_pos + write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.imports[i].symbol));
+            str_pos = str_pos + bin.write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.imports[i].symbol));
         } or {
             imp_str[i] = 0;
         }
@@ -1378,7 +1315,7 @@ fun write_dyn_structures(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo, nimp: 
     i = 0;
     for (i < dyn.lib_count) {
         lib_str[i] = str_pos;
-        str_pos = str_pos + write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.libs[i].soname));
+        str_pos = str_pos + bin.write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.libs[i].soname));
         i = i + 1;
     }
 
@@ -1389,12 +1326,12 @@ fun write_dyn_structures(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo, nimp: 
     i = 0;
     for (i < dyn.import_count) {
         if (dyn.imports[i].is_func) {
-            write_u32_le(buf, sym_off, imp_str[i]::u32);
+            bin.write_u32_le(buf, sym_off, imp_str[i]::u32);
             buf[sym_off + 4] = (STB_GLOBAL << 4) | (STT_FUNC & 0xF);
             buf[sym_off + 5] = 0;
-            write_u16_le(buf, sym_off + 6, 0);
-            write_u64_le(buf, sym_off + 8, 0);
-            write_u64_le(buf, sym_off + 16, 0);
+            bin.write_u16_le(buf, sym_off + 6, 0);
+            bin.write_u64_le(buf, sym_off + 8, 0);
+            bin.write_u64_le(buf, sym_off + 16, 0);
             sym_off = sym_off + SYM_SIZE;
         }
         i = i + 1;
@@ -1404,23 +1341,23 @@ fun write_dyn_structures(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo, nimp: 
     # the chain links 1->2->...->n->0. with one bucket the loader walks the whole
     # chain, which is correct (if not fast) for the small import sets here.
     val nchain: u32 = nimp + 1;
-    write_u32_le(buf, lay.hash_off, 1);
-    write_u32_le(buf, lay.hash_off + 4, nchain);
-    if (nimp > 0) { write_u32_le(buf, lay.hash_off + 8, 1); } or { write_u32_le(buf, lay.hash_off + 8, 0); }
+    bin.write_u32_le(buf, lay.hash_off, 1);
+    bin.write_u32_le(buf, lay.hash_off + 4, nchain);
+    if (nimp > 0) { bin.write_u32_le(buf, lay.hash_off + 8, 1); } or { bin.write_u32_le(buf, lay.hash_off + 8, 0); }
     var c: u32 = 0;
     for (c < nchain) {
         var next: u32 = c + 1;
         if (next >= nchain) { next = 0; }
-        write_u32_le(buf, lay.hash_off + 12 + c::usize * 4, next);
+        bin.write_u32_le(buf, lay.hash_off + 12 + c::usize * 4, next);
         c = c + 1;
     }
 
     # GOT.PLT: GOT[0] = &.dynamic, GOT[1]/GOT[2] = 0 (filled by the loader with
     # the link_map and the lazy-resolver). GOT[3+n] points at the push in PLT[n]
     # so the first call triggers lazy resolution.
-    write_u64_le(buf, lay.gotplt_off, lay.dynamic_va);
-    write_u64_le(buf, lay.gotplt_off + 8, 0);
-    write_u64_le(buf, lay.gotplt_off + 16, 0);
+    bin.write_u64_le(buf, lay.gotplt_off, lay.dynamic_va);
+    bin.write_u64_le(buf, lay.gotplt_off + 8, 0);
+    bin.write_u64_le(buf, lay.gotplt_off + 16, 0);
 
     # .plt and .rela.plt, per function import.
     if (nimp > 0) {
@@ -1436,14 +1373,14 @@ fun write_dyn_structures(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo, nimp: 
                 # GOT[3+n] -> PLT[n] + 6 (the `push` after the indirect jump).
                 val got_slot_off: usize = lay.gotplt_off + (3 + n)::usize * GOT_ENTRY_SIZE;
                 val plt_stub_va: u64 = lay.plt_va + (n + 1)::u64 * PLT_ENTRY_SIZE::u64;
-                write_u64_le(buf, got_slot_off, plt_stub_va + 6);
+                bin.write_u64_le(buf, got_slot_off, plt_stub_va + 6);
 
                 # .rela.plt JUMP_SLOT: r_offset = &GOT[3+n], r_sym = dynsym slot.
                 val got_slot_va: u64 = lay.gotplt_va + (3 + n)::u64 * GOT_ENTRY_SIZE::u64;
-                write_u64_le(buf, rela_off, got_slot_va);
+                bin.write_u64_le(buf, rela_off, got_slot_va);
                 val r_info: u64 = (sym_index::u64 << 32) | jump_slot_for(arch_id)::u64;
-                write_u64_le(buf, rela_off + 8, r_info);
-                write_u64_le(buf, rela_off + 16, 0);
+                bin.write_u64_le(buf, rela_off + 8, r_info);
+                bin.write_u64_le(buf, rela_off + 16, 0);
                 rela_off = rela_off + RELA_SIZE;
 
                 n = n + 1;
@@ -1482,8 +1419,8 @@ val DT_RELA_TAG: u64 = 7;
 # write_dyn_entry: write one Elf64_Dyn (d_tag, d_un) at `off`, returning the next
 # offset.
 fun write_dyn_entry(buf: *u8, off: usize, tag: u64, value: u64) usize {
-    write_u64_le(buf, off, tag);
-    write_u64_le(buf, off + 8, value);
+    bin.write_u64_le(buf, off, tag);
+    bin.write_u64_le(buf, off + 8, value);
     ret off + DYN_SIZE;
 }
 
@@ -1497,12 +1434,12 @@ fun write_plt_header(buf: *u8, lay: *DynLayout) {
     buf[p] = 0xFF; buf[p + 1] = 0x35;
     val next1: u64 = lay.plt_va + 6;
     val got1:  u64 = lay.gotplt_va + 8;
-    write_u32_le(buf, p + 2, (got1 - next1)::u32);
+    bin.write_u32_le(buf, p + 2, (got1 - next1)::u32);
     # jmp qword [rip + d2]   (FF 25 d2) -> GOT[2]
     buf[p + 6] = 0xFF; buf[p + 7] = 0x25;
     val next2: u64 = lay.plt_va + 12;
     val got2:  u64 = lay.gotplt_va + 16;
-    write_u32_le(buf, p + 8, (got2 - next2)::u32);
+    bin.write_u32_le(buf, p + 8, (got2 - next2)::u32);
     # padding nop (0F 1F 40 00).
     buf[p + 12] = 0x0F; buf[p + 13] = 0x1F; buf[p + 14] = 0x40; buf[p + 15] = 0x00;
 }
@@ -1517,15 +1454,15 @@ fun write_plt_stub(buf: *u8, lay: *DynLayout, n: u32) {
     buf[stub_off] = 0xFF; buf[stub_off + 1] = 0x25;
     val next: u64 = stub_va + 6;
     val got:  u64 = lay.gotplt_va + (3 + n)::u64 * GOT_ENTRY_SIZE::u64;
-    write_u32_le(buf, stub_off + 2, (got - next)::u32);
+    bin.write_u32_le(buf, stub_off + 2, (got - next)::u32);
     # push <reloc index n>  (68 imm32)
     buf[stub_off + 6] = 0x68;
-    write_u32_le(buf, stub_off + 7, n);
+    bin.write_u32_le(buf, stub_off + 7, n);
     # jmp PLT[0]  (E9 rel32)
     buf[stub_off + 11] = 0xE9;
     val plt0: u64 = lay.plt_va;
     val after: u64 = stub_va + 16;
-    write_u32_le(buf, stub_off + 12, (plt0 - after)::u32);
+    bin.write_u32_le(buf, stub_off + 12, (plt0 - after)::u32);
 }
 
 # patch_plt_fixups: rewrite each import call site (a `PltFixup` the linker could
@@ -1574,7 +1511,7 @@ fun patch_plt_fixups(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo,
         }
 
         val file_off: usize = seg_offsets[fx.seg_index] + fx.seg_offset::usize;
-        write_u32_le(buf, file_off, (disp::u64)::u32);
+        bin.write_u32_le(buf, file_off, (disp::u64)::u32);
         i = i + 1;
     }
     ret ok[bool, str](true);
@@ -1663,14 +1600,14 @@ fun phdr_count_bytes(seg_count: u32) usize {
 # write_phdr: write one Elf64_Phdr at `pos`, returning the next phdr offset.
 fun write_phdr(buf: *u8, pos: usize, p_type: u32, flags: u32, off: usize, vaddr: u64,
                filesz: usize, memsz: usize, align: u64) usize {
-    write_u32_le(buf, pos, p_type);
-    write_u32_le(buf, pos + 4, flags);
-    write_u64_le(buf, pos + 8, off::u64);
-    write_u64_le(buf, pos + 16, vaddr);
-    write_u64_le(buf, pos + 24, vaddr);
-    write_u64_le(buf, pos + 32, filesz::u64);
-    write_u64_le(buf, pos + 40, memsz::u64);
-    write_u64_le(buf, pos + 48, align);
+    bin.write_u32_le(buf, pos, p_type);
+    bin.write_u32_le(buf, pos + 4, flags);
+    bin.write_u64_le(buf, pos + 8, off::u64);
+    bin.write_u64_le(buf, pos + 16, vaddr);
+    bin.write_u64_le(buf, pos + 24, vaddr);
+    bin.write_u64_le(buf, pos + 32, filesz::u64);
+    bin.write_u64_le(buf, pos + 40, memsz::u64);
+    bin.write_u64_le(buf, pos + 48, align);
     ret pos + PHDR_SIZE;
 }
 
@@ -1697,16 +1634,16 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
     }
     if (elf_interner == nil) { ret err[bool, str]("elf: no interner registered"); }
 
-    val e_shoff:     usize = read_u64_le(buf, 40)::usize;
-    val e_shentsize: u16   = read_u16_le(buf, 58);
-    val e_shnum:     u16   = read_u16_le(buf, 60);
-    val e_shstrndx:  u16   = read_u16_le(buf, 62);
+    val e_shoff:     usize = bin.read_u64_le(buf, 40)::usize;
+    val e_shentsize: u16   = bin.read_u16_le(buf, 58);
+    val e_shnum:     u16   = bin.read_u16_le(buf, 60);
+    val e_shstrndx:  u16   = bin.read_u16_le(buf, 62);
     if (e_shoff == 0 || e_shnum == 0) { ret err[bool, str]("elf: no section headers"); }
 
     var shstrtab: *u8 = nil;
     if (e_shstrndx < e_shnum) {
         val so: usize = e_shoff + e_shstrndx::usize * e_shentsize::usize;
-        shstrtab = (buf::usize + read_u64_le(buf, so + 24)::usize)::*u8;
+        shstrtab = (buf::usize + bin.read_u64_le(buf, so + 24)::usize)::*u8;
     }
 
     var strtab: *u8 = nil;
@@ -1715,15 +1652,15 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
     var sh: u16 = 0;
     for (sh < e_shnum) {
         val so: usize = e_shoff + sh::usize * e_shentsize::usize;
-        if (read_u32_le(buf, so + 4) == SHT_SYMTAB) {
-            symtab = (buf::usize + read_u64_le(buf, so + 24)::usize)::*u8;
-            val sz: usize = read_u64_le(buf, so + 32)::usize;
-            val ent: usize = read_u64_le(buf, so + 56)::usize;
+        if (bin.read_u32_le(buf, so + 4) == SHT_SYMTAB) {
+            symtab = (buf::usize + bin.read_u64_le(buf, so + 24)::usize)::*u8;
+            val sz: usize = bin.read_u64_le(buf, so + 32)::usize;
+            val ent: usize = bin.read_u64_le(buf, so + 56)::usize;
             if (ent > 0) { symtab_count = (sz / ent)::u32; }
-            val link: u32 = read_u32_le(buf, so + 40);
+            val link: u32 = bin.read_u32_le(buf, so + 40);
             if (link < e_shnum::u32) {
                 val lo: usize = e_shoff + link::usize * e_shentsize::usize;
-                strtab = (buf::usize + read_u64_le(buf, lo + 24)::usize)::*u8;
+                strtab = (buf::usize + bin.read_u64_le(buf, lo + 24)::usize)::*u8;
             }
         }
         sh = sh + 1;
@@ -1735,9 +1672,9 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
     sh = 0;
     for (sh < e_shnum) {
         val so: usize = e_shoff + sh::usize * e_shentsize::usize;
-        val ty: u32 = read_u32_le(buf, so + 4);
+        val ty: u32 = bin.read_u32_le(buf, so + 4);
         if (ty == SHT_PROGBITS || ty == SHT_NOBITS) { sec_n = sec_n + 1; }
-        if (ty == SHT_RELA) { rel_n = rel_n + (read_u64_le(buf, so + 32)::usize / RELA_SIZE)::u32; }
+        if (ty == SHT_RELA) { rel_n = rel_n + (bin.read_u64_le(buf, so + 32)::usize / RELA_SIZE)::u32; }
         sh = sh + 1;
     }
     val sym_n: u32 = symtab_count;
@@ -1775,9 +1712,9 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
     for (sh < e_shnum) {
         sec_map[sh] = -1;
         val so: usize = e_shoff + sh::usize * e_shentsize::usize;
-        val ty: u32 = read_u32_le(buf, so + 4);
+        val ty: u32 = bin.read_u32_le(buf, so + 4);
         if (ty == SHT_PROGBITS || ty == SHT_NOBITS) {
-            val flags: u64 = read_u64_le(buf, so + 8);
+            val flags: u64 = bin.read_u64_le(buf, so + 8);
             var kind: of.SectionKind = of.SK_DATA;
             if ((flags & SHF_ALLOC) == 0) { kind = of.SK_DEBUG; }
             or ((flags & SHF_EXECINSTR) != 0) { kind = of.SK_TEXT; }
@@ -1786,7 +1723,7 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
 
             var sec_name: str = "";
             if (shstrtab != nil) {
-                sec_name = (shstrtab::usize + read_u32_le(buf, so)::usize)::str;
+                sec_name = (shstrtab::usize + bin.read_u32_le(buf, so)::usize)::str;
             }
             val rin: Result[intern.StrId, str] = intern.intern(elf_interner, sec_name);
             if (is_err[intern.StrId, str](rin)) { ret err[bool, str](unwrap_err[intern.StrId, str](rin)); }
@@ -1794,15 +1731,15 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
             val idx: u32 = out.section_count;
             out.sections[idx].name  = unwrap_ok[intern.StrId, str](rin);
             out.sections[idx].kind  = kind;
-            out.sections[idx].align = read_u64_le(buf, so + 48)::u32;
-            out.sections[idx].len   = read_u64_le(buf, so + 32)::u32;
+            out.sections[idx].align = bin.read_u64_le(buf, so + 48)::u32;
+            out.sections[idx].len   = bin.read_u64_le(buf, so + 32)::u32;
             out.sections[idx].bytes = nil;
             if (ty != SHT_NOBITS && out.sections[idx].len > 0) {
                 val sz: usize = out.sections[idx].len::usize;
                 val rb: Result[*u8, str] = allocate[u8](alloc, sz);
                 if (is_err[*u8, str](rb)) { ret err[bool, str]("elf: section bytes alloc failed"); }
                 out.sections[idx].bytes = unwrap_ok[*u8, str](rb);
-                val src: *u8 = (buf::usize + read_u64_le(buf, so + 24)::usize)::*u8;
+                val src: *u8 = (buf::usize + bin.read_u64_le(buf, so + 24)::usize)::*u8;
                 mem.raw_copy(out.sections[idx].bytes::ptr, src::ptr, sz);
             }
             sec_map[sh] = idx::i32;
@@ -1816,11 +1753,11 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
         var si: u32 = 1;
         for (si < sym_n) {
             val so: usize = si::usize * SYM_SIZE;
-            val st_name:  u32 = read_u32_le(symtab, so);
+            val st_name:  u32 = bin.read_u32_le(symtab, so);
             val st_info:  u8  = symtab[so + 4];
-            val st_shndx: u16 = read_u16_le(symtab, so + 6);
-            val st_value: u64 = read_u64_le(symtab, so + 8);
-            val st_size:  u64 = read_u64_le(symtab, so + 16);
+            val st_shndx: u16 = bin.read_u16_le(symtab, so + 6);
+            val st_value: u64 = bin.read_u64_le(symtab, so + 8);
+            val st_size:  u64 = bin.read_u64_le(symtab, so + 16);
 
             val name: str = (strtab::usize + st_name::usize)::str;
             val rin: Result[intern.StrId, str] = intern.intern(elf_interner, name);
@@ -1856,10 +1793,10 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
     sh = 0;
     for (sh < e_shnum) {
         val so: usize = e_shoff + sh::usize * e_shentsize::usize;
-        if (read_u32_le(buf, so + 4) == SHT_RELA) {
-            val r_base: usize = read_u64_le(buf, so + 24)::usize;
-            val r_size: usize = read_u64_le(buf, so + 32)::usize;
-            val sh_info: u32 = read_u32_le(buf, so + 44);
+        if (bin.read_u32_le(buf, so + 4) == SHT_RELA) {
+            val r_base: usize = bin.read_u64_le(buf, so + 24)::usize;
+            val r_size: usize = bin.read_u64_le(buf, so + 32)::usize;
+            val sh_info: u32 = bin.read_u32_le(buf, so + 44);
             val count: u32 = (r_size / RELA_SIZE)::u32;
             var target_sec: i32 = -1;
             if (sh_info < e_shnum::u32) { target_sec = sec_map[sh_info]; }
@@ -1867,15 +1804,15 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
             var ri: u32 = 0;
             for (ri < count) {
                 val ro: usize = r_base + ri::usize * RELA_SIZE;
-                val r_info: u64 = read_u64_le(buf, ro + 8);
+                val r_info: u64 = bin.read_u64_le(buf, ro + 8);
                 val r_type: u32 = (r_info & 0xFFFFFFFF)::u32;
                 val r_sym:  u32 = (r_info >> 32)::u32;
 
                 val idx: u32 = out.reloc_count;
                 if (target_sec >= 0) { out.relocations[idx].section = target_sec::u32; }
                 or { out.relocations[idx].section = of.SECTION_EXTERNAL; }
-                out.relocations[idx].offset = read_u64_le(buf, ro)::u32;
-                out.relocations[idx].addend = read_u64_le(buf, ro + 16)::i64;
+                out.relocations[idx].offset = bin.read_u64_le(buf, ro)::u32;
+                out.relocations[idx].addend = bin.read_u64_le(buf, ro + 16)::i64;
                 out.relocations[idx].kind = reloc_kind_for(r_type);
                 # r_sym indexes the on-disk symtab (1-based, index 0 reserved),
                 # so the ObjectImage symbol is r_sym - 1.
@@ -1914,15 +1851,15 @@ pub fun apply_reloc(bytes: *u8, offset: u32, kind: intern.StrId, addend: i64,
                     sym_addr: u64, patch_addr: u64) Result[bool, str] {
     val off: usize = offset::usize;
     if (kind == rk_abs64) {
-        write_u64_le(bytes, off, sym_addr + addend::u64);
+        bin.write_u64_le(bytes, off, sym_addr + addend::u64);
         ret ok[bool, str](true);
     }
     if (kind == rk_pc32 || kind == rk_plt32 || kind == rk_gotpcrel) {
-        write_u32_le(bytes, off, (sym_addr::i64 + addend - patch_addr::i64)::u32);
+        bin.write_u32_le(bytes, off, (sym_addr::i64 + addend - patch_addr::i64)::u32);
         ret ok[bool, str](true);
     }
     if (kind == rk_abs32s) {
-        write_u32_le(bytes, off, (sym_addr::i64 + addend)::u32);
+        bin.write_u32_le(bytes, off, (sym_addr::i64 + addend)::u32);
         ret ok[bool, str](true);
     }
     ret err[bool, str]("elf: relocation kind not supported");

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -100,10 +100,9 @@ var macho_vtable: of.OfVTable;
 # `of.register` is itself idempotent. must be invoked at compiler startup before
 # target.select requests a Darwin target.
 # ---
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields
-# ret:   true on success, or an error string if name interning fails
-pub fun register_macho(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# i:   string interner used to intern the vtable's string fields
+# ret: true on success, or an error string if name interning fails
+pub fun register_macho(i: *intern.Interner) Result[bool, str] {
     val rn: Result[intern.StrId, str] = intern.intern(i, "macho");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
 

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -89,22 +89,21 @@ var macho_reloc_kinds: [4]of.RelocationKind;
 # the Mach-O OF vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry.
 var macho_vtable: of.OfVTable;
-var macho_registered: bool = false;
 
 # register_macho: build and install the Mach-O OfVTable.
 #
 # interns the format name ("macho"), file extension ("o"), and relocation-kind
 # names, fills the relocation-kind table and vtable, wires the (stub) writer,
 # and self-registers it into the process-global OF registry under of.OF_MACHO.
-# write-once: a second call is a no-op. must be invoked at compiler startup
-# before target.select requests a Darwin target.
+# reentrant: every call re-interns all names against `i` so a second session (or
+# test) with a different interner is consistent rather than left with stale ids;
+# `of.register` is itself idempotent. must be invoked at compiler startup before
+# target.select requests a Darwin target.
 # ---
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields
 # ret:   true on success, or an error string if name interning fails
 pub fun register_macho(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
-    if (macho_registered) { ret ok[bool, str](true); }
-
     val rn: Result[intern.StrId, str] = intern.intern(i, "macho");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
 
@@ -162,6 +161,5 @@ pub fun register_macho(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     macho_vtable.relocation_count = 4;
 
     of.register(?macho_vtable);
-    macho_registered = true;
     ret ok[bool, str](true);
 }


### PR DESCRIPTION
Resolves the object-formats audit (#1256) and the **linker** findings of the linker/ABI audit (#1257). The ABI findings of #1257 (SysV float-aggregate classification, `AbiVTable`/`VaModel`, arch-keyed ABI selection) are out of scope here and left for a later worker.

## #1256 — object formats
- **Shared `mach.lang.target.of.bin` layer** under the three format writers and the linker: LE read/write, `write_str`, align helpers, bounds primitives (`region_ok`/`require_region`/`cstr_at`), interned diagnostic builders, and a one-pass per-section reloc tally. Removes ~250 lines of copy-paste and the linker's third divergent copy of the byte writers.
- **Reloc kind/type mapping no longer silently defaults to 64-bit absolute** on emit or parse — an unmapped abstract kind, or a foreign machine type (e.g. `ADDR32`/`R_X86_64_32`), fails loudly naming the offending kind/type instead of an 8-byte write over a 4-byte field.
- **u16 count-narrowing validated**: COFF `NumberOfSections`/per-section reloc counts and ELF `e_shnum` are rejected when they would truncate, instead of shipping a well-formed-looking object with dropped sections/relocs.
- **Parser header offsets bounds-checked** against `buf_size` before every dereference (section/symbol/reloc tables, raw data, string tables) — a truncated/hostile `.o` errors rather than reading off the end.
- **COFF serialization de-quadratified**: per-section reloc counts tallied once and the per-section reloc arrays written in one O(relocations) pass.
- **Format registration made reentrant** (no stale interner ids across sessions/tests).
- Dead `elf.apply_reloc` and the unused registrar parity param removed.

## #1257 — linker only
- **Weak/strong resolution is order-independent**: a strong definition overrides an earlier weak one (taking its address); strong-over-strong still errors. Unit test pins all three orderings.
- **`apply_one` patch-site bounds computed in u64** + `r.offset` validated against the input section, so a corrupt offset can no longer wrap the u32 cursor and write OOB; `accumulate_sections` rejects a >4GiB merged group.
- **Malformed-input silent skips are now loud errors** (out-of-range section/reloc, missing merged output, BSS patch site, unknown section kind).
- **O(R×S) per-reloc symbol scan replaced** by a per-module local-name index.
- Dead `cstr_len`, dead overflow-message params, wrong `LINK_SHARED` text, and the duplicate map alias cleaned up.

## Design recommendations (left as issue comments, no code change)
- #1256: `Relocation.kind` StrId→`RelocKind` id + `WriterFn`/`ParserFn` interner threading (removes the module-global interner capture and the reentrancy band-aid) — one coherent v1.4 pass.
- #1257: armap-driven archive member selection (the pull-every-member policy).

## Verification
- `mach build .` clean; `mach test .` 282 pass / 0 fail; byte-identical self-host fixpoint.
- All `.github/tests` suites pass (extlink, dynlink, fconv, lower, lower-testrunner, opt, win64byref, win64fnptr).
- Windows cross-compile + `wine mach.exe build .` smoke (builds and runs a win64 exe).
- Rebased onto current `dev` (integrates #1266's win64 unwind work; its bare `read_u32_le` routed through the shared `bin` layer).

Closes #1256
Refs #1257
