### PR TITLE
fix(comptime/query/editor): audit findings — gate shadowing, eval traps, query poison, editor host ctx (#1249)

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -860,7 +860,7 @@ fun intern_required(i: *intern.Interner, text: str, missing: str) Result[intern.
 # find_target: resolve a target selector against the config's [targets.*]
 # entries. an empty selector defers to [project].target. the selectors
 # "native" and "host" resolve to the entry whose os/isa match the build
-# host (host_os_id()/host_arch_id()); any other selector matches an entry by
+# host (tgt.host_os_id()/host_arch_id()); any other selector matches an entry by
 # name. returns nil when nothing matches.
 fun find_target(c: *ProjectConfig, name: str, i: *intern.Interner) *TargetEntry {
     var sel: str = name;
@@ -885,30 +885,12 @@ fun find_target(c: *ProjectConfig, name: str, i: *intern.Interner) *TargetEntry 
     ret nil;
 }
 
-# host_os_id / host_arch_id: the os/arch id this compiler binary was built for,
-# which is the host it runs on. the `$mach.target.{os,arch}` predicate folds at
-# comptime to the active build target, and each branch returns the matching
-# os.OS_* / isa.ARCH_* id — the same numeric space `os_id_for`/`arch_id_for`
-# produce. resolving the host inside a function body (not a read-only global
-# initializer) keeps the const reference an ordinary runtime load, sidestepping
-# the comptime-only fold path globals take.
-fun host_os_id() u32 {
-    $if ($mach.target.os == $mach.os.linux)   { ret os.OS_LINUX; }
-    $or ($mach.target.os == $mach.os.darwin)  { ret os.OS_DARWIN; }
-    $or ($mach.target.os == $mach.os.windows) { ret os.OS_WINDOWS; }
-    $or                                        { ret os.OS_UNKNOWN; }
-}
-fun host_arch_id() u32 {
-    $if ($mach.target.arch == $mach.arch.x86_64)  { ret isa.ARCH_X86_64; }
-    $or ($mach.target.arch == $mach.arch.aarch64) { ret isa.ARCH_AARCH64; }
-    $or                                            { ret isa.ARCH_UNKNOWN; }
-}
-
 # find_host_target: pick the [targets.<name>] entry whose os/isa map to the
-# build host's os/arch ids. returns nil when no entry matches the host.
+# build host's os/arch ids (tgt.host_os_id()/host_arch_id()). returns nil when
+# no entry matches the host.
 fun find_host_target(c: *ProjectConfig, i: *intern.Interner) *TargetEntry {
-    val h_os:   u32 = host_os_id();
-    val h_arch: u32 = host_arch_id();
+    val h_os:   u32 = tgt.host_os_id();
+    val h_arch: u32 = tgt.host_arch_id();
     var k: u32 = 0;
     for (k < c.target_count) {
         val os_opt: Option[str] = intern.lookup(i, c.targets[k].os_name);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -23,10 +23,10 @@
 # this surface deliberately drives the front-end phases directly rather than
 # routing through `query.QueryDb.get(Q_PARSE / Q_RESOLVE)`: the derived query
 # shards are not registered until the query DB is wired into the build
-# (issue #1164). the buffer is still registered as a real source input whose
-# revision the `Q_FILE_TEXT` metadata source reads, so the incremental story
-# is preserved; the `get`-routed form of these entries lands with #1164
-# without changing this module's signatures.
+# (issue #1164). the buffer text lives in the session's SourceMap but is not
+# yet registered as a `Q_FILE_TEXT` query input — that metadata source and the
+# `get`-routed form of these entries land with #1164 without changing this
+# module's signatures.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -67,6 +67,7 @@ use comptime: mach.lang.fe.comptime;
 use ast:     mach.lang.fe.ast;
 use id:      mach.lang.fe.ast.id;
 use intern:  mach.lang.intern;
+use target:  mach.lang.target;
 
 # Buffer: the per-file analysis state the editor session owns for one
 # registered buffer.
@@ -75,7 +76,7 @@ use intern:  mach.lang.intern;
 # in_use:   whether this slot holds a live buffer (slots are indexed by FileId)
 # a:        owned parsed Ast, or nil before the first `parse`
 # rr:       owned ResolveResult side tables, or nil before the first `resolve`
-# ctx:      comptime context resolve mutates; seeded with neutral host defaults
+# ctx:      comptime context resolve mutates; seeded from the host target
 pub rec Buffer {
     file_id: src.FileId;
     in_use:  bool;
@@ -173,14 +174,33 @@ pub fun update(es: *EditorSession, fid: src.FileId, text: str) Result[bool, str]
     ret ok[bool, str](true);
 }
 
+# reset_diags: replace the borrowed session DiagList with a fresh empty one so a
+# public analysis entry reflects only its own current run. the single owner of
+# the editor's diagnostic-reset policy: every public entry point resets on the
+# way in, and the internal `*_inner` workers never touch the lifecycle, so
+# repeated calls cannot accumulate duplicates and analyses of different buffers
+# never mix on the list.
+fun reset_diags(es: *EditorSession) {
+    diag.dnit(?es.s.diags);
+    es.s.diags = diag.init(es.alloc);
+}
+
 # tokenize: lex the buffer and surface any lex errors as diagnostics on the
 # session's DiagList. returns the owning TokenStream; the caller frees it
-# with `lexer.dnit`. malformed input is recorded, never aborted.
+# with `lexer.dnit`. malformed input is recorded, never aborted. resets the
+# session DiagList so the result reflects only this buffer's lex pass.
 # ---
 # es:  the editor session
 # fid: FileId of an open buffer
 # ret: the owning TokenStream, or an error when fid is unknown / on allocation failure
 pub fun tokenize(es: *EditorSession, fid: src.FileId) Result[lexer.TokenStream, str] {
+    reset_diags(es);
+    ret tokenize_inner(es, fid);
+}
+
+# tokenize_inner: the lex pass without the diagnostic reset, so callers that
+# already reset (parse / diagnostics) do not wipe accumulated diagnostics.
+fun tokenize_inner(es: *EditorSession, fid: src.FileId) Result[lexer.TokenStream, str] {
     val fopt: Option[*src.SourceFile] = src.get(?es.s.sources, fid);
     if (is_none[*src.SourceFile](fopt)) {
         ret err[lexer.TokenStream, str]("editor: buffer not open");
@@ -209,10 +229,18 @@ pub fun tokenize(es: *EditorSession, fid: src.FileId) Result[lexer.TokenStream, 
 # fid: FileId of an open buffer
 # ret: a borrowed pointer to the buffer's parsed Ast, or an error when fid is unknown / on allocation failure
 pub fun parse(es: *EditorSession, fid: src.FileId) Result[*ast.Ast, str] {
+    reset_diags(es);
+    ret parse_inner(es, fid);
+}
+
+# parse_inner: the tokenize + parse pass without the diagnostic reset, shared by
+# the public `parse`, `resolve`, and `diagnostics` entries (each of which resets
+# once on the way in).
+fun parse_inner(es: *EditorSession, fid: src.FileId) Result[*ast.Ast, str] {
     val b: *Buffer = slot(es, fid);
     if (b == nil || !b.in_use) { ret err[*ast.Ast, str]("editor: buffer not open"); }
 
-    val tr: Result[lexer.TokenStream, str] = tokenize(es, fid);
+    val tr: Result[lexer.TokenStream, str] = tokenize_inner(es, fid);
     if (is_err[lexer.TokenStream, str](tr)) { ret err[*ast.Ast, str](unwrap_err[lexer.TokenStream, str](tr)); }
     var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
 
@@ -244,11 +272,13 @@ pub fun parse(es: *EditorSession, fid: src.FileId) Result[*ast.Ast, str] {
 # fid: FileId of an open buffer
 # ret: a borrowed pointer to the buffer's ResolveResult, or an error when fid is unknown / on allocation failure
 pub fun resolve(es: *EditorSession, fid: src.FileId) Result[*res.ResolveResult, str] {
+    reset_diags(es);
+
     val b: *Buffer = slot(es, fid);
     if (b == nil || !b.in_use) { ret err[*res.ResolveResult, str]("editor: buffer not open"); }
 
     if (b.a == nil) {
-        val pr: Result[*ast.Ast, str] = parse(es, fid);
+        val pr: Result[*ast.Ast, str] = parse_inner(es, fid);
         if (is_err[*ast.Ast, str](pr)) { ret err[*res.ResolveResult, str](unwrap_err[*ast.Ast, str](pr)); }
     }
 
@@ -291,10 +321,9 @@ pub fun resolve(es: *EditorSession, fid: src.FileId) Result[*res.ResolveResult, 
 # fid: FileId of an open buffer
 # ret: a borrowed pointer to the session DiagList, or an error when fid is unknown / on allocation failure
 pub fun diagnostics(es: *EditorSession, fid: src.FileId) Result[*diag.DiagList, str] {
-    diag.dnit(?es.s.diags);
-    es.s.diags = diag.init(es.alloc);
+    reset_diags(es);
 
-    val pr: Result[*ast.Ast, str] = parse(es, fid);
+    val pr: Result[*ast.Ast, str] = parse_inner(es, fid);
     if (is_err[*ast.Ast, str](pr)) { ret err[*diag.DiagList, str](unwrap_err[*ast.Ast, str](pr)); }
 
     ret ok[*diag.DiagList, str](?es.s.diags);
@@ -357,7 +386,7 @@ fun ensure_slot(es: *EditorSession, fid: src.FileId) Result[*Buffer, str] {
             nb.in_use  = false;
             nb.a       = nil;
             nb.rr      = nil;
-            nb.ctx     = comptime.init(es.alloc, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
+            nb.ctx     = host_ctx(es);
             z = z + 1;
         }
         es.buf_len = new_len;
@@ -382,13 +411,27 @@ fun alloc_ast(es: *EditorSession, fid: src.FileId) Result[*ast.Ast, str] {
     ret ok[*ast.Ast, str](a);
 }
 
-# seed_ctx: (re)initialize the buffer's comptime context with neutral host
-# defaults. the editor resolves a buffer in isolation, so no target params or
-# imported constants are bound; `$if` predicates evaluate against the host
-# os / arch only. resets any prior context first.
+# host_ctx: a fresh comptime context seeded from the host target — the os, arch,
+# and pointer width this compiler binary was built for. the editor resolves a
+# buffer in isolation with no project-selected target, so `$if` predicates
+# evaluate against the running compiler's own target rather than an unknown
+# placeholder. the single definition of the editor's neutral-target policy.
+fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
+    ret comptime.init(
+        es.alloc,
+        target.host_os_id(),
+        target.host_arch_id(),
+        target.host_pointer_width(),
+        intern.STR_NIL,
+        intern.STR_NIL
+    );
+}
+
+# seed_ctx: (re)initialize the buffer's comptime context from the host target,
+# resetting any prior context first.
 fun seed_ctx(es: *EditorSession, b: *Buffer) {
     comptime.dnit(?b.ctx);
-    b.ctx = comptime.init(es.alloc, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
+    b.ctx = host_ctx(es);
 }
 
 # drop_analysis: free a buffer's cached Ast, ResolveResult, and comptime
@@ -852,6 +895,109 @@ test "sema: pointer reinterpret legality follows the target pointer width (#1248
     val d8: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
     if (is_err[*diag.DiagList, str](d8)) { dnit(?es); sess.dnit(?s); ret 1; }
     if (!diag_has(unwrap_ok[*diag.DiagList, str](d8), "bit reinterpret")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "editor: a buffer's comptime ctx is seeded from the host target, not a placeholder (#1249)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    val fr: Result[src.FileId, str] = open(?es, "buf.mach", "fun f() {}\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val b: *Buffer = slot(?es, fid);
+    if (b == nil) { dnit(?es); sess.dnit(?s); ret 1; }
+    # the ctx target params reflect the running compiler's host, not the old
+    # os=0 / arch=0 / ptr=8 placeholder that made the LSP read target-gated code
+    # as a freestanding/unknown target.
+    if (b.ctx.target_os_id != target.host_os_id()) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (b.ctx.target_arch_id != target.host_arch_id()) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (b.ctx.pointer_width != target.host_pointer_width()) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "editor: repeated resolve resets diagnostics instead of accumulating them (#1249)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # an unbound `undef` makes every resolve emit a diagnostic; the count must
+    # stay stable across repeated calls rather than doubling.
+    val fr: Result[src.FileId, str] = open(?es, "buf.mach", "fun f() i64 { ret undef; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val r1: Result[*res.ResolveResult, str] = resolve(?es, fid);
+    if (is_err[*res.ResolveResult, str](r1)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val n1: usize = es.s.diags.len;
+    if (n1 == 0) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    val r2: Result[*res.ResolveResult, str] = resolve(?es, fid);
+    if (is_err[*res.ResolveResult, str](r2)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val n2: usize = es.s.diags.len;
+
+    # without the reset-on-entry, the second resolve appends a duplicate set.
+    if (n2 != n1) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "resolve: a runtime local shadowing a module const is rejected in a $if gate, not folded to the const (#1249)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `N` is a module comptime const; the runtime local `N` shadows it. the
+    # comptime env is name-keyed, so the gate fold silently succeeds against the
+    # module const 4 while the resolver bound the ident to the local — resolve
+    # must reject the gate on resolution identity instead of miscompiling it.
+    val fr: Result[src.FileId, str] = open(?es, "shadow.mach",
+        "pub val N: i64 = 4;\nfun g(x: i64) i64 {\n    val N: i64 = x;\n    $if (N > 2) { ret 1; }\n    ret 0;\n}\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val rr: Result[*res.ResolveResult, str] = resolve(?es, fid);
+    if (is_err[*res.ResolveResult, str](rr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(?es.s.diags, "shadows a comptime constant")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "resolve: a runtime parameter shadowing a module const is rejected in a $if gate (#1249)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # same miscompile through a runtime (non-`$`) parameter named after the
+    # module const: the fold would silently use the const, not the parameter.
+    val fr: Result[src.FileId, str] = open(?es, "pshadow.mach",
+        "pub val N: i64 = 4;\nfun g(N: i64) i64 {\n    $if (N > 2) { ret 1; }\n    ret 0;\n}\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val rr: Result[*res.ResolveResult, str] = resolve(?es, fid);
+    if (is_err[*res.ResolveResult, str](rr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(?es.s.diags, "shadows a comptime constant")) { dnit(?es); sess.dnit(?s); ret 1; }
 
     dnit(?es);
     sess.dnit(?s);

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -8,11 +8,13 @@
 # / logical / bitwise / shift operators over them. out of scope: function calls,
 # loops, type-introspection intrinsics, casts.
 #
-# `$mach.target.{os,arch,abi}` resolve to the numeric tag of the active
-# target; the matching `$mach.os.*` / `$mach.arch.*` tags resolve to the
-# same numeric space, so `$if ($mach.target.os == $mach.os.linux)` is a
+# `$mach.target.{os,arch,pointer_width}` resolve to the active target's
+# numeric parameters; the matching `$mach.os.*` / `$mach.arch.*` tags resolve
+# to the same numeric space, so `$if ($mach.target.os == $mach.os.linux)` is a
 # plain integer comparison. Tag comparisons are path-value: there is no
-# `.id` suffix and no `$mach.build.target` chain.
+# `.id` suffix and no `$mach.build.target` chain. `$mach.target.abi`,
+# `$mach.project.*`, `$mach.build.*`, and `$mach.source.*` are reserved stubs:
+# reading one is a compile error until the value is populated.
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -128,6 +130,10 @@ pub rec ComptimeCtx {
 
 val INITIAL_CONST_CAP: u32 = 8;
 
+# the i64 minimum, as a bit pattern since the literal `9223372036854775808` is
+# itself out of i64 range. used to trap the `INT64_MIN / -1` idiv overflow.
+val CT_I64_MIN: i64 = 0x8000000000000000::i64;
+
 # init: constructs a ComptimeCtx with the given target parameters and an empty
 # environment.
 # ---
@@ -218,12 +224,20 @@ pub fun frame_open(c: *ComptimeCtx) FrameMark {
 
 # frame_close: pops the entries array back to `mark`, removing every binding
 # made since the matching `frame_open`. used to scope a value-instance body's
-# `$param` bindings to that body's lowering, restoring exactly on every path.
+# `$param` bindings to that body's lowering, restoring exactly on every path. a
+# `mark` beyond the current depth means frames were closed out of order or
+# twice — a caller-side discipline bug — and is surfaced as an error rather than
+# silently ignored, so the open/close invariant the scoped model rests on is loud.
 # ---
 # c:    the context
 # mark: a depth previously returned by `frame_open`
-pub fun frame_close(c: *ComptimeCtx, mark: FrameMark) {
-    if (mark <= c.entries_len) { c.entries_len = mark; }
+# ret:  true on success, or an error when `mark` exceeds the current depth
+pub fun frame_close(c: *ComptimeCtx, mark: FrameMark) Result[bool, str] {
+    if (mark > c.entries_len) {
+        ret err[bool, str]("comptime: frame_close mark exceeds current frame depth");
+    }
+    c.entries_len = mark;
+    ret ok[bool, str](true);
 }
 
 # lookup: looks up a comptime constant by interned name with a single reverse
@@ -714,10 +728,16 @@ fun apply_arith(op: expr.BinOp, lhs: CTValue, rhs: CTValue) Result[CTValue, str]
         if (op == expr.BIN_MUL) { ret int_value(lhs.data.i * rhs.data.i); }
         if (op == expr.BIN_DIV) {
             if (rhs.data.i == 0) { ret err[CTValue, str]("integer division by zero"); }
+            if (lhs.data.i == CT_I64_MIN && rhs.data.i == (0 - 1)) {
+                ret err[CTValue, str]("integer division overflow (INT64_MIN / -1)");
+            }
             ret int_value(lhs.data.i / rhs.data.i);
         }
         if (op == expr.BIN_MOD) {
             if (rhs.data.i == 0) { ret err[CTValue, str]("integer modulo by zero"); }
+            if (lhs.data.i == CT_I64_MIN && rhs.data.i == (0 - 1)) {
+                ret err[CTValue, str]("integer modulo overflow (INT64_MIN % -1)");
+            }
             ret int_value(lhs.data.i % rhs.data.i);
         }
         if (op == expr.BIN_BIT_AND) { ret int_value(lhs.data.i & rhs.data.i); }
@@ -827,9 +847,15 @@ fun eval_path(
     ret resolve_mach_path(c, source, ?stack[0], depth);
 }
 
-# returns the span of the identifier portion of a `$ident` token (skips the
-# leading `$`)
-fun comptime_ident_name(full: token.Span) token.Span {
+# comptime_ident_name: the span of the identifier portion of a `$ident` token,
+# with the leading `$` skipped. the single owner of this offset+1 / len-1 span
+# surgery — sema, resolve, and lower all call it rather than hand-rolling it,
+# so the zero-length guard lives in exactly one place. a `$`-only span (len <= 1)
+# yields a zero-length span the caller can detect.
+# ---
+# full: the full span of a `$ident` token, including the leading `$`
+# ret:  the span covering just the identifier text
+pub fun comptime_ident_name(full: token.Span) token.Span {
     var s: token.Span;
     s.offset = full.offset + 1;
     if (full.len > 0) { s.len = full.len - 1; } or { s.len = 0; }
@@ -878,15 +904,21 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
         ret int_value(c.pointer_width::i64);
     }
 
-    # $mach.os.<name> — os tag value
+    # $mach.os.<name> — os tag value. an unrecognized name is an error, never a
+    # silent fold to OS_UNKNOWN (a typo'd tag must not quietly compare against a
+    # real target).
     if (depth == 3 && seg_is(source, stack, 1, "os")) {
         val name: StrView = span_text(source, stack[0]);
-        ret int_value(os_tag_for(name)::i64);
+        val r: Result[u32, str] = os_tag_for(name);
+        if (is_err[u32, str](r)) { ret err[CTValue, str](unwrap_err[u32, str](r)); }
+        ret int_value(unwrap_ok[u32, str](r)::i64);
     }
-    # $mach.arch.<name> — arch tag value
+    # $mach.arch.<name> — arch tag value; unrecognized names error likewise.
     if (depth == 3 && seg_is(source, stack, 1, "arch")) {
         val name: StrView = span_text(source, stack[0]);
-        ret int_value(arch_tag_for(name)::i64);
+        val r: Result[u32, str] = arch_tag_for(name);
+        if (is_err[u32, str](r)) { ret err[CTValue, str](unwrap_err[u32, str](r)); }
+        ret int_value(unwrap_ok[u32, str](r)::i64);
     }
 
     # $mach.compiler.{name,version}
@@ -931,20 +963,23 @@ fun seg_is(source: str, stack: *token.Span, idx: u32, expected: str) bool {
     ret view_eq_str(text, expected);
 }
 
-# maps an `$mach.os.<name>` tag to its numeric os id (os.OS_*)
-fun os_tag_for(name: StrView) u32 {
-    if (view_eq_str(name, "linux"))        { ret os.OS_LINUX; }
-    if (view_eq_str(name, "darwin"))       { ret os.OS_DARWIN; }
-    if (view_eq_str(name, "windows"))      { ret os.OS_WINDOWS; }
-    if (view_eq_str(name, "freestanding")) { ret os.OS_UNKNOWN; }
-    ret os.OS_UNKNOWN;
+# maps an `$mach.os.<name>` tag to its numeric os id (os.OS_*). the tag list is
+# closed: `freestanding` has its own id distinct from the unknown sentinel, and
+# an unrecognized name is an error rather than a fold to OS_UNKNOWN.
+fun os_tag_for(name: StrView) Result[u32, str] {
+    if (view_eq_str(name, "linux"))        { ret ok[u32, str](os.OS_LINUX); }
+    if (view_eq_str(name, "darwin"))       { ret ok[u32, str](os.OS_DARWIN); }
+    if (view_eq_str(name, "windows"))      { ret ok[u32, str](os.OS_WINDOWS); }
+    if (view_eq_str(name, "freestanding")) { ret ok[u32, str](os.OS_FREESTANDING); }
+    ret err[u32, str]("unknown `$mach.os.*` tag");
 }
 
-# maps an `$mach.arch.<name>` tag to its numeric arch id (isa.ARCH_*)
-fun arch_tag_for(name: StrView) u32 {
-    if (view_eq_str(name, "x86_64"))  { ret isa.ARCH_X86_64; }
-    if (view_eq_str(name, "aarch64")) { ret isa.ARCH_AARCH64; }
-    ret isa.ARCH_UNKNOWN;
+# maps an `$mach.arch.<name>` tag to its numeric arch id (isa.ARCH_*). closed
+# list; an unrecognized name is an error rather than a fold to ARCH_UNKNOWN.
+fun arch_tag_for(name: StrView) Result[u32, str] {
+    if (view_eq_str(name, "x86_64"))  { ret ok[u32, str](isa.ARCH_X86_64); }
+    if (view_eq_str(name, "aarch64")) { ret ok[u32, str](isa.ARCH_AARCH64); }
+    ret err[u32, str]("unknown `$mach.arch.*` tag");
 }
 
 fun int_value(i: i64) Result[CTValue, str] {
@@ -1001,5 +1036,52 @@ test "comptime: the u64-max literal is accepted with its bits preserved (#1247)"
 test "comptime: a hex literal wider than 16 nibbles is rejected (#1247)" {
     val r: Result[CTValue, str] = t_eval_int("0x1FFFFFFFFFFFFFFFF");
     if (!is_err[CTValue, str](r)) { ret 1; }
+    ret 0;
+}
+
+# helper: a full-length StrView over a literal, for the tag-name lookups.
+fun t_view(s: str) StrView {
+    ret view(?s[0], str_len(s));
+}
+
+test "comptime: INT64_MIN / -1 and % -1 trap as errors instead of SIGFPE (#1249)" {
+    val lhs: CTValue = unwrap_ok[CTValue, str](int_value(CT_I64_MIN));
+    val rhs: CTValue = unwrap_ok[CTValue, str](int_value(0 - 1));
+    # the idiv overflow that would SIGFPE the compiler must be a comptime error.
+    if (!is_err[CTValue, str](apply_arith(expr.BIN_DIV, lhs, rhs))) { ret 1; }
+    if (!is_err[CTValue, str](apply_arith(expr.BIN_MOD, lhs, rhs))) { ret 1; }
+    # an ordinary division still folds.
+    val ten: CTValue = unwrap_ok[CTValue, str](int_value(10));
+    val two: CTValue = unwrap_ok[CTValue, str](int_value(2));
+    val okd: Result[CTValue, str] = apply_arith(expr.BIN_DIV, ten, two);
+    if (is_err[CTValue, str](okd)) { ret 1; }
+    if (unwrap_ok[CTValue, str](okd).data.i != 5) { ret 1; }
+    ret 0;
+}
+
+test "comptime: an unknown $mach.os/arch tag errors; freestanding is distinct from unknown (#1249)" {
+    # a typo'd tag name must error, never fold to the unknown sentinel.
+    if (!is_err[u32, str](os_tag_for(t_view("linxu")))) { ret 1; }
+    if (!is_err[u32, str](arch_tag_for(t_view("x84_64")))) { ret 1; }
+    # freestanding resolves to its own id, distinct from OS_UNKNOWN.
+    val fr: Result[u32, str] = os_tag_for(t_view("freestanding"));
+    if (is_err[u32, str](fr)) { ret 1; }
+    if (unwrap_ok[u32, str](fr) == os.OS_UNKNOWN) { ret 1; }
+    ret 0;
+}
+
+test "comptime: frame_close rejects a mark beyond the current frame depth (#1249)" {
+    var c: ComptimeCtx;
+    c.entries     = nil;
+    c.entries_len = 2;
+    c.entries_cap = 0;
+    # a mark past the current depth is a caller-discipline bug, surfaced loud.
+    val bad: Result[bool, str] = frame_close(?c, 5);
+    if (!is_err[bool, str](bad)) { ret 1; }
+    if (c.entries_len != 2) { ret 1; }
+    # a valid mark still pops to that depth.
+    val good: Result[bool, str] = frame_close(?c, 1);
+    if (is_err[bool, str](good)) { ret 1; }
+    if (c.entries_len != 1) { ret 1; }
     ret 0;
 }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -92,6 +92,13 @@ pub val SYM_FLAG_PUB: u8 = 1;
 # SYM_FLAG_COMPTIME: comptime-flag bit, set on a SYM_PARAM declared with a leading `$` (comptime value parameter).
 pub val SYM_FLAG_COMPTIME: u8 = 2;
 
+# SYM_FLAG_MODULE: module-scope bit, set on every symbol declared at module
+# scope. distinguishes a module-level `val` (a comptime-foldable constant whose
+# name is unique in its module) from a block-local `val` that merely shares a
+# name with one, so the comptime-gate check folds on resolution identity rather
+# than on name text a shadowing local would spuriously satisfy.
+pub val SYM_FLAG_MODULE: u8 = 4;
+
 # Symbol: a resolved symbol.
 # ---
 # kind:   one of SYM_*
@@ -719,10 +726,10 @@ fun declare_decl(rc: *ResolveContext, kind: SymKind, flags: u8, name_span: token
 }
 
 fun symbol_flags_from(decl_flags: u8, at_module_scope: bool) u8 {
-    if (at_module_scope && (decl_flags & decl.DECL_FLAG_PUB) != 0) {
-        ret SYM_FLAG_PUB;
-    }
-    ret 0;
+    if (!at_module_scope) { ret 0; }
+    var f: u8 = SYM_FLAG_MODULE;
+    if ((decl_flags & decl.DECL_FLAG_PUB) != 0) { f = f | SYM_FLAG_PUB; }
+    ret f;
 }
 
 # binds a module-level comptime-evaluable val into the module frame. idempotent:
@@ -1257,6 +1264,18 @@ fun bind_comptime_if(rc: *ResolveContext, branches_start: u32, branches_len: u32
     var bi: u32 = 0;
     for (bi < branches_len) {
         val br: *decl.ComptimeBranch = ?rc.a.comptime_branches[branches_start + bi];
+        # resolve the gate's identifiers before folding it, recording each leaf's
+        # resolution identity, then reject any leaf whose binding the name-keyed
+        # fold would silently misread (a runtime local/param shadowing a comptime
+        # constant). eval failures themselves are reported by
+        # comptime_branch_active; this check covers exactly the case where the
+        # fold SUCCEEDS against the wrong binding.
+        if (br.cond != id.EXPR_NIL) {
+            val rce: Result[bool, str] = bind_expr(rc, br.cond);
+            if (is_err[bool, str](rce)) { ret rce; }
+            val rcs: Result[bool, str] = check_gate_shadowing(rc, br.cond);
+            if (is_err[bool, str](rcs)) { ret rcs; }
+        }
         val take_r: Result[bool, str] = comptime_branch_active(rc, br);
         if (is_err[bool, str](take_r)) { ret take_r; }
         if (unwrap_ok[bool, str](take_r)) {
@@ -1268,6 +1287,55 @@ fun bind_comptime_if(rc: *ResolveContext, branches_start: u32, branches_len: u32
         bi = bi + 1;
     }
     ret ok[bool, str](true);
+}
+
+# check_gate_shadowing: walks a folded (non-param) `$if` gate and rejects any
+# leaf identifier that resolves to a runtime binding whose NAME also names a
+# comptime constant in the env. the comptime fold is name-keyed, so such a gate
+# folds against the constant while the resolver bound the ident to the runtime
+# local / parameter — a silent wrong-arm miscompile. a runtime ident whose name
+# is not in the env is left alone: the fold fails on it and
+# comptime_branch_active reports that failure, so reporting here would
+# duplicate it. reports at the offending leaf's span.
+fun check_gate_shadowing(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
+    if (eid == id.EXPR_NIL) { ret ok[bool, str](true); }
+    val e_opt: Option[*expr.Expr] = ast.get_expr(rc.a, eid);
+    if (is_none[*expr.Expr](e_opt)) { ret ok[bool, str](true); }
+    val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
+
+    if (e.kind == expr.EXPR_KIND_BINARY) {
+        val rl: Result[bool, str] = check_gate_shadowing(rc, e.data.binary.lhs);
+        if (is_err[bool, str](rl)) { ret rl; }
+        ret check_gate_shadowing(rc, e.data.binary.rhs);
+    }
+    if (e.kind == expr.EXPR_KIND_UNARY) {
+        ret check_gate_shadowing(rc, e.data.unary.operand);
+    }
+    if (e.kind != expr.EXPR_KIND_IDENT) { ret ok[bool, str](true); }
+
+    if (rc.expr_resolved == nil) { ret ok[bool, str](true); }
+    val sid: SymbolId = rc.expr_resolved[eid];
+    if (sid == SYMBOL_NIL || sid >= rc.sym_len) { ret ok[bool, str](true); }
+    val sym: *Symbol = ?rc.symbols[sid];
+
+    # runtime by resolution identity: a block-local val/var, or a non-`$`
+    # parameter. module-scope vals, imports, and comptime params are foldable.
+    var runtime: bool = false;
+    if (sym.kind == SYM_VAL || sym.kind == SYM_VAR) {
+        runtime = (sym.flags & SYM_FLAG_MODULE) == 0;
+    }
+    if (sym.kind == SYM_PARAM) {
+        runtime = (sym.flags & SYM_FLAG_COMPTIME) == 0;
+    }
+    if (!runtime) { ret ok[bool, str](true); }
+
+    val id_r: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, e.span);
+    if (is_err[intern.StrId, str](id_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](id_r)); }
+    val nc: Option[*comptime.NamedConst] = comptime.lookup(rc.ctx, unwrap_ok[intern.StrId, str](id_r));
+    if (is_none[*comptime.NamedConst](nc)) { ret ok[bool, str](true); }
+
+    ret diag.error(?rc.s.diags, rc.a.file_id, e.span,
+        "comptime branch condition references a runtime binding that shadows a comptime constant");
 }
 
 # reports whether any arm gate of a `$if` chain references a comptime value
@@ -1793,11 +1861,9 @@ fun comptime_intrinsic_kind(rc: *ResolveContext, callee: id.ExprId) u8 {
     if (is_none[*expr.Expr](ce_opt)) { ret 0; }
     val ce: *expr.Expr = unwrap[*expr.Expr](ce_opt);
     if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret 0; }
-    if (ce.span.len <= 1) { ret 0; }
 
-    var ns: token.Span = ce.span;
-    ns.offset = ns.offset + 1;
-    ns.len    = ns.len - 1;
+    val ns: token.Span = comptime.comptime_ident_name(ce.span);
+    if (ns.len == 0) { ret 0; }
     val r: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, ns);
     if (is_err[intern.StrId, str](r)) { ret 0; }
     val name: intern.StrId = unwrap_ok[intern.StrId, str](r);

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -566,10 +566,24 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
         ret;
     }
 
-    # literals and `$mach.*` comptime paths fold directly.
+    # literals fold directly.
     if (k == expr.EXPR_KIND_LIT_INT || k == expr.EXPR_KIND_LIT_FLOAT
-     || k == expr.EXPR_KIND_LIT_CHAR || k == expr.EXPR_KIND_LIT_STR
-     || k == expr.EXPR_KIND_COMPTIME_IDENT) {
+     || k == expr.EXPR_KIND_LIT_CHAR || k == expr.EXPR_KIND_LIT_STR) {
+        ret;
+    }
+
+    # a bare `$ident` is only comptime-foldable when the evaluator accepts it
+    # (today: a `$mach.*` path; a single-segment `$mach` or a `$param` reference
+    # is not). fold-test it so an unfoldable one is reported here with a span
+    # rather than aborting lowering with a span-less `comptime path root must be
+    # $mach` error. a standalone bare `$ident` is not one of the four comptime
+    # channel shapes; its semantics remain the open `$ident` design question
+    # tracked in #1249.
+    if (k == expr.EXPR_KIND_COMPTIME_IDENT) {
+        val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
+        if (is_err[comptime.CTValue, str](ev)) {
+            ctxm.report(sc, e.span, "comptime `$if` gate is not a compile-time constant");
+        }
         ret;
     }
 
@@ -586,9 +600,19 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
             ret;
         }
         # a `val` / imported binding is foldable ONLY if it actually resolves to a
-        # comptime constant — a runtime block-local `val n = f();` is SYM_VAL but
-        # not foldable. test by folding it through the comptime evaluator.
+        # comptime constant. a runtime block-local `val n = f();` is SYM_VAL but
+        # not foldable — and the comptime env is name-keyed, so folding it would
+        # spuriously succeed against a same-named MODULE const it shadows (a real
+        # miscompile of the gate). decide on resolution identity first: only a
+        # module-scope val (or an import) reaches the fold test; a block-local val
+        # is rejected outright regardless of any name collision.
         if (sym.kind == resolve.SYM_VAL || sym.kind == resolve.SYM_IMPORTED) {
+            val is_module: bool = sym.kind == resolve.SYM_IMPORTED
+                                || (sym.flags & resolve.SYM_FLAG_MODULE) != 0;
+            if (!is_module) {
+                ctxm.report(sc, e.span, "comptime `$if` gate cannot reference a runtime value");
+                ret;
+            }
             val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
             if (is_err[comptime.CTValue, str](ev) && !check.imported_module_const_sym(sc, sym)) {
                 ctxm.report(sc, e.span, "comptime `$if` gate cannot reference a runtime value");

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -675,12 +675,11 @@ fun set_expr_type(sc: *sema.SemaContext, eid: id.ExprId, ty: type.TypeId) {
 }
 
 # interns the identifier text of a `$ident` comptime ident, with the leading
-# `$` stripped, returning its StrId (STR_NIL on failure or an empty name).
+# `$` stripped, returning its StrId (STR_NIL on failure or an empty name). the
+# span surgery is owned by `comptime.comptime_ident_name`.
 fun comptime_ident_name(sc: *sema.SemaContext, full: token.Span) intern.StrId {
-    if (full.len <= 1) { ret intern.STR_NIL; }
-    var s: token.Span;
-    s.offset = full.offset + 1;
-    s.len    = full.len - 1;
+    val s: token.Span = comptime.comptime_ident_name(full);
+    if (s.len == 0) { ret intern.STR_NIL; }
     ret intern_span_or_nil(sc, s);
 }
 

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -267,18 +267,20 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
     for (bi < val_len) {
         val rr: Result[bool, str] = comptime.bind(octx, names[bi], vals[bi]);
         if (is_err[bool, str](rr)) {
-            comptime.frame_close(octx, mark);
+            val cr: Result[bool, str] = comptime.frame_close(octx, mark);
             lc.ctx        = home_ctx;
             lc.own_module = home_own;
+            if (is_err[bool, str](cr)) { ret err[bool, str](unwrap_err[bool, str](cr)); }
             ret err[bool, str](unwrap_err[bool, str](rr));
         }
         bi = bi + 1;
     }
 
     val lr: Result[bool, str] = decl.lower_value_instance(lc, decl_id, d, name);
-    comptime.frame_close(octx, mark);
+    val cr: Result[bool, str] = comptime.frame_close(octx, mark);
     lc.ctx        = home_ctx;
     lc.own_module = home_own;
+    if (is_err[bool, str](cr)) { ret err[bool, str](unwrap_err[bool, str](cr)); }
     ret lr;
 }
 

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -716,11 +716,9 @@ pub fun try_lower_comptime_intrinsic(ctx: *lower.LowerContext, eid: aid.ExprId, 
     if (is_none[*aexpr.Expr](ce_opt)) { ret none[Result[value.Value, str]](); }
     val ce: *aexpr.Expr = unwrap[*aexpr.Expr](ce_opt);
     if (ce.kind != aexpr.EXPR_KIND_COMPTIME_IDENT) { ret none[Result[value.Value, str]](); }
-    if (ce.span.len <= 1) { ret none[Result[value.Value, str]](); }
 
-    var ns: token.Span = ce.span;
-    ns.offset = ns.offset + 1;
-    ns.len    = ns.len - 1;
+    val ns: token.Span = comptime.comptime_ident_name(ce.span);
+    if (ns.len == 0) { ret none[Result[value.Value, str]](); }
     val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), ns);
     if (is_err[intern.StrId, str](name_r)) {
         ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[intern.StrId, str](name_r)));
@@ -1602,9 +1600,7 @@ fun lower_cast(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result
 # comptime context. the `$ident` span carries the leading `$`; constants are
 # registered under the bare name, so strip it before interning the lookup key.
 fun lower_comptime_ident(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
-    var name_span: token.Span = e.span;
-    name_span.offset = name_span.offset + 1;
-    name_span.len    = name_span.len - 1;
+    val name_span: token.Span = comptime.comptime_ident_name(e.span);
     val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), name_span);
     if (is_err[intern.StrId, str](name_r)) { ret err[value.Value, str](unwrap_err[intern.StrId, str](name_r)); }
     val nc: Option[*comptime.NamedConst] = comptime.lookup(ctx.ctx, unwrap_ok[intern.StrId, str](name_r));

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -12,8 +12,9 @@
 # an external revision source). Validation is revision-based: an entry is
 # valid iff every recorded dependency's current `last_changed` still
 # equals the value captured when the entry was computed. Recomputes that
-# reproduce identical bytes leave `last_changed` untouched (early
-# cutoff), which is what keeps `last_changed` distinct from `computed_at`.
+# reproduce identical bytes leave `last_changed` untouched (early cutoff), so
+# `last_changed` tracks when an entry's bytes actually changed, not when it was
+# last revalidated.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -33,6 +34,7 @@ use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
+use page: std.allocator.page;
 use mem: std.memory;
 
 # QueryKind: discriminator identifying a particular query function. one
@@ -128,7 +130,6 @@ pub rec Dep {
 # key:          hashed key; the kind-key-type -> u64 mapping is the registrar's responsibility
 # value:        owned opaque value buffer (layout is the registered query's responsibility)
 # value_len:    length of value in bytes
-# computed_at:  revision at which value was last recomputed
 # last_changed: revision at which value's bytes last actually changed
 # deps:         queries read while computing value
 # dep_count:    number of entries in deps
@@ -137,7 +138,6 @@ pub rec QueryEntry {
     key:          u64;
     value:        *u8;
     value_len:    u32;
-    computed_at:  Revision;
     last_changed: Revision;
     deps:         *Dep;
     dep_count:    u32;
@@ -286,7 +286,6 @@ pub fun set_input(db: *QueryDb, kind: QueryKind, key: u64, value: *u8, value_len
         }
         existing.value     = unwrap_ok[*u8, str](rcopy);
         existing.value_len = value_len;
-        existing.computed_at = db.revision;
         if (!same) {
             existing.last_changed = db.revision;
         }
@@ -305,7 +304,6 @@ pub fun set_input(db: *QueryDb, kind: QueryKind, key: u64, value: *u8, value_len
     val entry: *QueryEntry = unwrap_ok[*QueryEntry, str](rentry);
     entry.value        = unwrap_ok[*u8, str](rcopy);
     entry.value_len    = value_len;
-    entry.computed_at  = db.revision;
     entry.last_changed = db.revision;
     ret ok[bool, str](true);
 }
@@ -323,6 +321,14 @@ pub fun invalidate(db: *QueryDb, kind: QueryKind, key: u64) Result[bool, str] {
     if (is_err[*QueryShard, str](rsh)) { ret err[bool, str](unwrap_err[*QueryShard, str](rsh)); }
     val sh: *QueryShard = unwrap_ok[*QueryShard, str](rsh);
 
+    remove_entry(db, sh, key);
+    ret ok[bool, str](true);
+}
+
+# remove_entry: free and swap-remove the entry keyed by `key` from `sh`, if
+# present. a no-op when absent. swap-remove leaves entry order unspecified, so
+# callers must not hold entry pointers across it.
+fun remove_entry(db: *QueryDb, sh: *QueryShard, key: u64) {
     var i: u32 = 0;
     for (i < sh.len) {
         val e: *QueryEntry = ?sh.entries[i];
@@ -331,11 +337,10 @@ pub fun invalidate(db: *QueryDb, kind: QueryKind, key: u64) Result[bool, str] {
             val last: u32 = sh.len - 1;
             if (i != last) { sh.entries[i] = sh.entries[last]; }
             sh.len = last;
-            ret ok[bool, str](true);
+            ret;
         }
         i = i + 1;
     }
-    ret ok[bool, str](true);
 }
 
 # get: the single public lookup. returns the cached entry for `(kind,
@@ -366,7 +371,6 @@ pub fun get(db: *QueryDb, kind: QueryKind, key: u64) Result[*QueryEntry, str] {
     val existing: *QueryEntry = find_entry(sh, key);
     if (existing != nil) {
         if (entry_valid(db, existing)) {
-            existing.computed_at = db.revision;
             ret ok[*QueryEntry, str](existing);
         }
         ret recompute(db, sh, existing, key);
@@ -480,7 +484,6 @@ fun append_entry(db: *QueryDb, sh: *QueryShard, key: u64) Result[*QueryEntry, st
     e.key          = key;
     e.value        = nil;
     e.value_len    = 0;
-    e.computed_at  = 0;
     e.last_changed = 0;
     e.deps         = nil;
     e.dep_count    = 0;
@@ -535,11 +538,14 @@ fun recompute(db: *QueryDb, sh: *QueryShard, e: *QueryEntry, key: u64) Result[*Q
 
     val rout: Result[QueryOutput, str] = sh.compute(db, key, db.alloc);
     if (is_err[QueryOutput, str](rout)) {
+        # a failed compute must not leave a poisoned entry behind: it now has
+        # zero deps, which entry_valid reads as vacuously valid, so the next get
+        # would return its stale (or never-computed nil) bytes as a success.
+        # drop it so the next get re-runs compute. `e` may dangle after this.
+        remove_entry(db, sh, key);
         ret err[*QueryEntry, str](unwrap_err[QueryOutput, str](rout));
     }
     val out: QueryOutput = unwrap_ok[QueryOutput, str](rout);
-
-    e.computed_at = db.revision;
 
     val same: bool = bytes_equal(e.value, e.value_len, out.bytes, out.len);
     if (same) {
@@ -666,4 +672,30 @@ fun bytes_equal(a: *u8, a_len: u32, b: *u8, b_len: u32) bool {
         i = i + 1;
     }
     ret true;
+}
+
+# a derived compute that always fails, to exercise the failed-recompute path.
+fun t_always_fail(db: *QueryDb, key: u64, alloc: *Allocator) Result[QueryOutput, str] {
+    ret err[QueryOutput, str]("compute always fails");
+}
+
+test "query: a failed recompute is not laundered into a cached success (#1249)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val dr: Result[QueryDb, str] = init(?alloc);
+    if (is_err[QueryDb, str](dr)) { ret 1; }
+    var db: QueryDb = unwrap_ok[QueryDb, str](dr);
+
+    val rr: Result[bool, str] = register_derived(?db, Q_TOKENIZE, t_always_fail);
+    if (is_err[bool, str](rr)) { dnit(?db); ret 1; }
+
+    # first get: compute fails, so get errs.
+    if (!is_err[*QueryEntry, str](get(?db, Q_TOKENIZE, 42))) { dnit(?db); ret 1; }
+    # second get: the failed entry must not be cached as a vacuously-valid (zero-
+    # dep) success; get must re-run compute and err again rather than return the
+    # poisoned nil value.
+    if (!is_err[*QueryEntry, str](get(?db, Q_TOKENIZE, 42))) { dnit(?db); ret 1; }
+
+    dnit(?db);
+    ret 0;
 }

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -50,6 +50,33 @@ fwd isa.ENDIAN_BIG;
 # root, which would close an import cycle.
 fwd tdef.Target;
 
+# host_os_id / host_arch_id / host_pointer_width: the os, arch, and pointer
+# width of the target this compiler binary was built for, which is the host it
+# runs on. each folds the `$mach.target.*` comptime read at compile time and
+# returns the matching numeric id — the same space `os.OS_*` / `isa.ARCH_*`
+# occupy. consumers that analyze code in isolation (the editor / LSP, which has
+# no project-selected target) seed a neutral comptime context from these so
+# `$if ($mach.target.os == $mach.os.linux)` evaluates against the running
+# compiler's target rather than an unknown placeholder. resolving inside a
+# function body (not a global initializer) keeps the read an ordinary runtime
+# load, sidestepping the comptime-only fold path globals take.
+pub fun host_os_id() u32 {
+    $if ($mach.target.os == $mach.os.linux)   { ret os.OS_LINUX; }
+    $or ($mach.target.os == $mach.os.darwin)  { ret os.OS_DARWIN; }
+    $or ($mach.target.os == $mach.os.windows) { ret os.OS_WINDOWS; }
+    $or                                        { ret os.OS_UNKNOWN; }
+}
+
+pub fun host_arch_id() u32 {
+    $if ($mach.target.arch == $mach.arch.x86_64)  { ret isa.ARCH_X86_64; }
+    $or ($mach.target.arch == $mach.arch.aarch64) { ret isa.ARCH_AARCH64; }
+    $or                                            { ret isa.ARCH_UNKNOWN; }
+}
+
+pub fun host_pointer_width() u32 {
+    ret ($mach.target.pointer_width)::u32;
+}
+
 # canonical_abi: the ABI id paired with an operating system. SysV is the
 # convention on Linux and Darwin; Win64 on Windows. independent of arch.
 # ---

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -17,11 +17,14 @@ use intern: mach.lang.intern;
 
 # canonical numeric ids for known operating systems. stable across compiler
 # versions; user code dispatches on them through `$mach.os.<name>` and
-# `$mach.target.os`.
-pub val OS_UNKNOWN: u32 = 0;
-pub val OS_LINUX:   u32 = 1;
-pub val OS_DARWIN:  u32 = 2;
-pub val OS_WINDOWS: u32 = 3;
+# `$mach.target.os`. `OS_UNKNOWN` is the absence of a known os (an
+# unrecognized selector); `OS_FREESTANDING` is the deliberate no-os / bare-metal
+# target and is distinct from `OS_UNKNOWN` so the two never compare equal.
+pub val OS_UNKNOWN:      u32 = 0;
+pub val OS_LINUX:        u32 = 1;
+pub val OS_DARWIN:       u32 = 2;
+pub val OS_WINDOWS:      u32 = 3;
+pub val OS_FREESTANDING: u32 = 4;
 
 # the operating-system runtime-dispatch interface. exactly one of these exists
 # per OS; the driver and linker read the entry symbol, library directory, and


### PR DESCRIPTION
Addresses the fixable comptime + query.mach + editor.mach findings from the 2026-06 audit (#1249, epic #1259). Builds on #1268 (literal-overflow rejection already merged), respects #1272 (comptime u64 signedness deferred as a spec decision), and is rebased onto #1269's sema-audit layering (resolve owns non-param `$if` gate diagnostics).

## Fixed

- **[BUG/M] gate name-text shadowing** — a runtime local `val N` (or a non-`$` parameter `N`) shadowing a same-named module comptime const no longer silently folds the `$if` gate to the module const. The resolver now binds non-param gate idents (recording each leaf's resolution identity), tags module-scope symbols `SYM_FLAG_MODULE`, and rejects any gate leaf that resolves to a runtime binding whose name also names a comptime constant in the env — exactly the case where the name-keyed fold succeeds against the wrong binding. Eval failures stay reported by `comptime_branch_active` alone (per #1269's layering), so nothing is double-reported. sema's `check_comptime_gate` (the param-gated path resolve cannot fold) gets the same identity narrowing.
- **[BUG/M] divergent bare `$ident`** — a standalone `$ident` gate in a param-gated chain is fold-tested in sema and reported with a span instead of crashing lowering with a span-less `comptime path root must be $mach`. The full `$ident` semantics stay an open design question (see the issue comment).
- **[BUG/S] integer trap/wrap** — `apply_arith` traps `INT64_MIN / -1` and `% -1` as comptime errors (no more compiler SIGFPE). Literal overflow was already fixed by #1268.
- **[BUG/S] unknown os/arch tags** — `$mach.os.*` / `$mach.arch.*` reject unrecognized names; `freestanding` gets its own `OS_FREESTANDING` id distinct from `OS_UNKNOWN`.
- **[BUG/S] query failed-recompute poison** — a failed compute drops its entry instead of leaving a zero-dep (vacuously-valid) stale/nil cache.
- **[SMELL/S] frame_close** — surfaces a mark beyond the current depth as an error instead of silently ignoring it.
- **[SMELL/S] computed_at** — removed the dead, inconsistently-maintained field.
- **[DESIGN/S] editor host defaults** — buffers seed their comptime ctx from the real host target (`mach.lang.target.host_*`) instead of os=0/arch=0/ptr=8; the host helpers moved out of the driver into `target.mach`.
- **[SMELL/S] editor diagnostic lifecycle** — one reset-on-entry policy (`reset_diags`) shared by every public analysis entry; repeated `resolve`/`parse` no longer accumulate duplicate diagnostics.
- **[CLEANUP/S] `$`-stripping** — `comptime.comptime_ident_name` is the single owner; the four hand-rolled copies call it.
- **[CLEANUP/S] stale docs** — corrected the comptime `$mach.target.abi` claim and the editor `Q_FILE_TEXT` claim.

## Remaining (design items, kept on #1249)

- query.mach transitive (shallow) validation and the manual-dep-recording / in-progress-stack model are rewrites, not localized bug fixes — recommendation left on #1249 (gates #1164).
- the full bare-`$ident` resolution model (one shared resolution rule across sema/eval/lowering) — recommendation left on #1249 (gates the `$project.*`/`$target.*` namespace from #1217).

## Tests

Inline fail-before tests for the idiv trap, unknown/freestanding tags, frame_close overflow, query failed-recompute, editor host-ctx seeding, editor diagnostic reset, and editor-driven checks that a gate referencing a runtime local or parameter shadowing a module const is rejected at resolve (not folded to the const). `mach build .` clean, `mach test .` = 294 pass, byte-identical self-host fixpoint.

Refs #1249