### PR TITLE
fix(passes): address #1252 audit — constfold SIGFPE, dead phis, ghost-pool, --verify-ir, inline recursion

### DIFF
--- a/.github/tests/relverify/app/mach.toml
+++ b/.github/tests/relverify/app/mach.toml
@@ -1,0 +1,17 @@
+[project]
+id = "relverify"
+name = "release --verify-ir regression — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "linux"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "library"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/lib/relverify.o"

--- a/.github/tests/relverify/app/src/main.mach
+++ b/.github/tests/relverify/app/src/main.mach
@@ -1,0 +1,37 @@
+# release-pipeline --verify-ir regression for #1252. The release pipeline
+# (inline + late constfold/algebraic/cse/constfold/dce) once produced IR the
+# aggregate-representation verifier rejected on virtually any program: inline
+# built a result phi even for a single returning predecessor, and an
+# aggregate-returning callee's phi is not address-producing. This library
+# exercises that path — a scalar single-return inline whose constant must
+# propagate, a single-return aggregate inline, and an ignored argument whose
+# computation becomes dead — and is built with `--release --verify-ir`, which
+# must pass.
+
+# a 16-byte aggregate, returned by address.
+rec Pair { a: i64; b: i64; }
+
+# scalar single-return: inlined; its constant 5 must propagate to the caller so
+# `five() - 5` folds across the inline boundary (single-incoming result phi
+# collapse).
+pub fun five() i64 { ret 5; }
+
+# aggregate single-return: inlined; the inliner must wire the result directly
+# instead of building an aggregate result phi the verifier rejects.
+pub fun mk(x: i64) Pair {
+    var p: Pair;
+    p.a = x;
+    p.b = x;
+    ret p;
+}
+
+# ignores its argument: after inlining, the caller's argument computation is
+# dead and must not be pinned by the unlinked call ghost.
+pub fun ignore(x: i64) i64 { ret 0; }
+
+pub fun driver(n: i64) i64 {
+    val s: i64 = five() - 5;
+    val p: Pair = mk(n);
+    val z: i64 = ignore(n * 999 + 3);
+    ret s + p.a + p.b + z;
+}

--- a/.github/tests/relverify/run.sh
+++ b/.github/tests/relverify/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# release-pipeline IR-verification regression (issue #1252): build the `app`
+# library with `--release --verify-ir`. The release pipeline used to emit IR the
+# aggregate-representation verifier rejected on almost any program (inline's
+# single-return result phi over an aggregate, plus a too-strict post-inline
+# reachability gate), so `mach build . --release --verify-ir` failed on a
+# hello-world. The app exercises scalar and aggregate single-return inlining,
+# constant propagation across an inline boundary, and a dead inlined-argument
+# computation; the build must pass at both -O0 and --release under --verify-ir.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cp -r "$HERE/app" "$WORK/"
+
+if ! ( cd "$WORK/app" && "$MACH" build . --verify-ir ) >/dev/null 2>&1; then
+    echo "FAIL relverify: -O0 --verify-ir build failed" >&2
+    exit 1
+fi
+
+if ! ( cd "$WORK/app" && "$MACH" build . --release --verify-ir ) >/dev/null 2>&1; then
+    echo "FAIL relverify: --release --verify-ir build failed (inline aggregate phi / post-inline gate)" >&2
+    exit 1
+fi
+
+echo "PASS relverify: release pipeline passes --verify-ir on inlined aggregate/constant-propagation paths"
+exit 0

--- a/src/lang/me/pass/constfold.mach
+++ b/src/lang/me/pass/constfold.mach
@@ -21,13 +21,20 @@
 # compute at runtime. Integer results are evaluated in u64 and masked to the
 # result type's bit width (two's-complement wrap), matching the back end, which
 # masks every narrow ALU write to its operand width. Signed operations
-# sign-extend their masked operands first. Shift counts are masked modulo the
-# *operation* width — the back end clamps a sub-word shift to a 32-bit ALU op
-# (`clamp_alu_width`), so an `i8`/`i16` shift masks its count modulo 32, not the
-# narrow type width. Float folding is restricted to f64: the IR stores every
-# float constant as an f64 bit pattern, so an f32 fold would not match the f32
-# rounding the back end performs in hardware. Division/remainder by zero is
-# never folded (it traps at runtime).
+# sign-extend their masked operands first. Float folding is restricted to f64:
+# the IR stores every float constant as an f64 bit pattern, so an f32 fold would
+# not match the f32 rounding the back end performs in hardware.
+#
+# Operations that TRAP at runtime are never folded — folding one would convert a
+# trapping program into a non-trapping one (or, when evaluated natively, fault
+# the compiler itself). This covers division/remainder by zero and signed
+# division/remainder overflow (INT_MIN / -1, which overflows the native IDIV).
+#
+# Shifts are folded ONLY when the result is target-independent: a count in the
+# range [0, type_width) shifts by exactly that amount on every backend. An
+# out-of-range count is target-defined (x86 masks the count modulo the operation
+# width, other ISAs may mask to the type width or trap), so such a shift is left
+# to the back end rather than folded here.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -53,6 +60,11 @@ use instr:   mach.lang.me.ir.instruction;
 use value:   mach.lang.me.ir.value;
 use ir_type: mach.lang.me.ir.type;
 use id:      mach.lang.me.ir.id;
+use float:   mach.lang.float;
+
+use std.allocator.Allocator;
+use page:    std.allocator.page;
+use intern:  mach.lang.intern;
 
 # Pass entry. Folds, propagates, and simplifies branches on every function in
 # the module, iterating to a local fixpoint within each function.
@@ -118,7 +130,7 @@ fun fold_to_fixpoint(m: *ir.Module, fn: *ir.Function,
             if (has_sub[k] == false) {
                 val inst: *instr.Instruction = ?fn.instrs[k];
                 var out: value.Value;
-                if (try_fold(m, inst, subst, has_sub, ilen, ?out)) {
+                if (try_fold(m, inst, k, subst, has_sub, ilen, ?out)) {
                     subst[k]   = out;
                     has_sub[k] = true;
                     changed    = true;
@@ -129,25 +141,38 @@ fun fold_to_fixpoint(m: *ir.Module, fn: *ir.Function,
     }
 }
 
-# resolves an operand through the substitution table: a VAL_INSTR naming a folded
-# instruction becomes that instruction's constant value, carrying the operand's
-# own carried type (so a fold feeding a differently-typed slot keeps the slot's
-# type — e.g. a branch-target encoding). Non-instruction operands pass through.
+# resolves an operand through the substitution table, following chains: a
+# VAL_INSTR naming a folded instruction becomes that instruction's folded value,
+# followed again when that value itself names a folded instruction (so a
+# phi-of-a-folded-value collapses to the underlying constant in one resolve). The
+# operand's own carried type is preserved (so a fold feeding a differently-typed
+# slot keeps the slot's type — e.g. a branch-target encoding). The hop count is
+# bounded by `ilen` as a guard; the table is acyclic in practice.
 fun resolve(v: value.Value, subst: *value.Value, has_sub: *bool, ilen: u32) value.Value {
-    if (v.kind != value.VAL_INSTR) { ret v; }
-    val iid: u32 = v.data.instr::u32;
-    if (iid < ilen && has_sub[iid]) {
-        ret value.retype(subst[iid], v.ty);
+    var cur: value.Value = v;
+    var hops: u32 = 0;
+    for (cur.kind == value.VAL_INSTR && hops <= ilen) {
+        val iid: u32 = cur.data.instr::u32;
+        if (iid >= ilen || has_sub[iid] == false) { ret value.retype(cur, v.ty); }
+        cur  = subst[iid];
+        hops = hops + 1;
     }
-    ret v;
+    ret value.retype(cur, v.ty);
 }
 
-# attempts to fold one instruction to a constant. Writes the constant into `out`
-# and returns true on a successful fold. Only pure, value-producing opcodes whose
-# (resolved) operands are all constants of a foldable kind are considered.
-fun try_fold(m: *ir.Module, inst: *instr.Instruction,
+# attempts to fold one instruction to a constant value. Writes the result into
+# `out` and returns true on a successful fold. Most opcodes fold only when their
+# (resolved) operands are all constants of a foldable kind; OP_PHI collapses when
+# its incomings all resolve to one value (which need not be a constant). `self_id`
+# is the instruction's own id, used to ignore a phi's self-references.
+fun try_fold(m: *ir.Module, inst: *instr.Instruction, self_id: u32,
              subst: *value.Value, has_sub: *bool, ilen: u32, out: *value.Value) bool {
     val k: instr.InstrKind = inst.kind;
+
+    # phi: collapse to the single value all its incomings resolve to.
+    if (k == instr.OP_PHI) {
+        ret fold_phi(inst, self_id, subst, has_sub, ilen, out);
+    }
 
     # binary ops: [lhs, rhs]. the integer and float arithmetic / comparison
     # opcodes overlap (a compare opcode rides both an int and a float compare), so
@@ -199,6 +224,54 @@ fun try_fold(m: *ir.Module, inst: *instr.Instruction,
         ret true;
     }
 
+    ret false;
+}
+
+# collapses a phi whose incoming values — resolved through the substitution
+# table and ignoring self-references — are all one value, writing that value into
+# `out`. A single-incoming phi always collapses; an all-identical multi-incoming
+# phi collapses too. Because every predecessor supplies the same value, that value
+# dominates the phi's block, so replacing the phi with it preserves SSA. This lets
+# a constant returned through an inline result phi (or a phi pruned to one
+# incoming by branch simplification) propagate to its uses. A phi with no
+# incomings, or with two distinct incomings, is left untouched.
+fun fold_phi(inst: *instr.Instruction, self_id: u32,
+             subst: *value.Value, has_sub: *bool, ilen: u32, out: *value.Value) bool {
+    var have: bool = false;
+    var common: value.Value;
+    var o: u32 = 1;                         # odd slots carry the incoming values
+    for (o < inst.operand_count) {
+        val v: value.Value = resolve(inst.operands[o], subst, has_sub, ilen);
+        val is_self: bool = v.kind == value.VAL_INSTR && v.data.instr::u32 == self_id;
+        if (is_self == false) {
+            if (have == false) {
+                common = v;
+                have   = true;
+            } or {
+                if (values_equal(common, v) == false) { ret false; }
+            }
+        }
+        o = o + 2;
+    }
+    if (have == false) { ret false; }
+    @out = common;
+    ret true;
+}
+
+# true when two operand values denote the same SSA value or identical constant.
+# Float constants compare by raw bit pattern (so +0.0 and -0.0 stay distinct);
+# byte-blob and aggregate constants are conservatively treated as unequal. The
+# carried IR type is not compared — two operands naming the same value through
+# differently-typed slots still denote it.
+fun values_equal(a: value.Value, b: value.Value) bool {
+    if (a.kind != b.kind) { ret false; }
+    if (a.kind == value.VAL_INSTR)      { ret a.data.instr == b.data.instr; }
+    if (a.kind == value.VAL_PARAM)      { ret a.data.param_ix == b.data.param_ix; }
+    if (a.kind == value.VAL_CONST_INT)  { ret a.data.int_lit == b.data.int_lit; }
+    if (a.kind == value.VAL_CONST_NULL) { ret true; }
+    if (a.kind == value.VAL_CONST_FLOAT){ ret float.f64_bits(a.data.float_lit) == float.f64_bits(b.data.float_lit); }
+    if (a.kind == value.VAL_GLOBAL)     { ret a.data.global_ix == b.data.global_ix; }
+    if (a.kind == value.VAL_FN)         { ret a.data.fn_ix == b.data.fn_ix; }
     ret false;
 }
 
@@ -269,16 +342,21 @@ fun fold_int_binary(m: *ir.Module, k: instr.InstrKind, a: value.Value, b: value.
         if (y == 0) { ret false; }
         val sa: i64 = sext(x, bits)::i64;
         val sb: i64 = sext(y, bits)::i64;
+        if (div_overflows(sa, sb, bits)) { ret false; }
         r = mask((sa / sb)::u64, bits);
     }
     or (k == instr.OP_REM_S) {
         if (y == 0) { ret false; }
         val sa: i64 = sext(x, bits)::i64;
         val sb: i64 = sext(y, bits)::i64;
+        if (div_overflows(sa, sb, bits)) { ret false; }
         r = mask((sa % sb)::u64, bits);
     }
     or (k == instr.OP_SHL || k == instr.OP_SHR_S || k == instr.OP_SHR_U) {
-        r = fold_shift(k, x, b.data.int_lit, bits);
+        # only an in-range count folds to a target-independent result.
+        val cnt: u64 = b.data.int_lit;
+        if (cnt >= bits::u64) { ret false; }
+        r = fold_shift(k, x, cnt, bits);
     }
     or { ret false; }
 
@@ -286,34 +364,44 @@ fun fold_int_binary(m: *ir.Module, k: instr.InstrKind, a: value.Value, b: value.
     ret true;
 }
 
-# evaluates an integer shift. The back end clamps a sub-word shift to a 32-bit
-# ALU op, so the count is masked modulo the *operation* width (>= 32 bits), not
-# the narrow result type — an `i8 << 40` shifts by 40 % 32 == 8, yielding 0. The
-# shifted value is masked to the result width; an arithmetic right shift first
+# evaluates an in-range integer shift (the caller has already verified
+# `count < bits`, the only range whose result is target-independent). The shifted
+# value is masked to the result width; an arithmetic right shift first
 # sign-extends to the result width so the sign bit fills from the left.
 # ---
 # k:     OP_SHL / OP_SHR_S / OP_SHR_U
 # v:     the value being shifted (already masked to `bits`)
-# count: the raw shift count (unmasked)
+# count: the shift count, guaranteed in [0, bits)
 # bits:  result type bit width
 # ret:   the shift result masked to `bits`
 fun fold_shift(k: instr.InstrKind, v: u64, count: u64, bits: u32) u64 {
-    var opbits: u32 = bits;
-    if (opbits < 32) { opbits = 32; }
-    val masked_count: u64 = mask(count, opbits);
-    val sh: u64 = masked_count % opbits::u64;
     if (k == instr.OP_SHL) {
-        val shifted: u64 = v << sh;
+        val shifted: u64 = v << count;
         ret mask(shifted, bits);
     }
     if (k == instr.OP_SHR_U) {
         val low: u64 = mask(v, bits);
-        ret low >> sh;
+        ret low >> count;
     }
     # arithmetic right shift: sign-extend to the result width, shift, re-mask.
     val se: i64 = sext(v, bits)::i64;
-    val sr: u64 = (se >> sh)::u64;
+    val sr: u64 = (se >> count)::u64;
     ret mask(sr, bits);
+}
+
+# true when a signed division or remainder of `sa` by `sb` would overflow the
+# native IDIV at its operation width, i.e. INT_MIN / -1. The back end widens a
+# sub-32-bit division to a 32-bit IDIV, so the trapping dividend is the most
+# negative value of max(32, bits) — an `i8`/`i16` operand can never reach it, so
+# those widths never overflow and fold normally. Such a division traps at
+# runtime; folding it would drop the trap (and evaluating it natively faults the
+# compiler at i64), so the fold is declined and the trap left to the backend.
+fun div_overflows(sa: i64, sb: i64, bits: u32) bool {
+    if (sb != 0 - 1) { ret false; }
+    var opbits: u32 = bits;
+    if (opbits < 32) { opbits = 32; }
+    val opmin: i64 = sext(1::u64 << (opbits - 1)::u64, opbits)::i64;
+    ret sa == opmin;
 }
 
 # evaluates an integer comparison of two `bits`-wide operands. Equality and
@@ -522,4 +610,141 @@ fun block_is_pred(blk: *ir.Block, pred: id.BlockId) bool {
         k = k + 1;
     }
     ret false;
+}
+
+# fills `phi` (a stack Instruction) with an OP_PHI over `n` constant incomings
+# in the IR's [block, value, …] operand layout, pointing at the caller-owned
+# `ops` array (sized 2*n). the block slots are placeholders — fold_phi reads only
+# the value slots — so the test supplies the values in `vals[0..n)`.
+fun build_const_phi(phi: *instr.Instruction, ops: *value.Value, vals: *value.Value,
+                    n: u32, ty: ir_type.IrTypeId) {
+    var i: u32 = 0;
+    for (i < n) {
+        ops[i * 2]     = value.const_int(0, ty);
+        ops[i * 2 + 1] = vals[i];
+        i = i + 1;
+    }
+    phi.kind          = instr.OP_PHI;
+    phi.ty            = ty;
+    phi.operands      = ops;
+    phi.operand_count = n * 2;
+    phi.block         = 0::id.BlockId;
+    phi.flags         = 0;
+    phi.aux_ty        = ir_type.IRT_NIL;
+}
+
+test "constfold: i64 INT_MIN / -1 is not folded (no compiler SIGFPE; trap left to runtime)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val tr: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret 1; }
+    val ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+
+    val a: value.Value = value.const_int(0x8000000000000000, ty);
+    val b: value.Value = value.const_int(0xFFFFFFFFFFFFFFFF, ty);
+    var out: value.Value;
+    # before the fix this runs a native idiv on INT_MIN/-1 and faults the compiler.
+    if (fold_int_binary(?m, instr.OP_DIV_S, a, b, ty, ?out)) { ret 1; }
+    if (fold_int_binary(?m, instr.OP_REM_S, a, b, ty, ?out)) { ret 1; }
+    ret 0;
+}
+
+test "constfold: i32 INT_MIN / -1 is not folded (no silent trap removal)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val tr: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 32);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret 1; }
+    val ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+
+    val a: value.Value = value.const_int(0x80000000, ty);
+    val b: value.Value = value.const_int(0xFFFFFFFF, ty);
+    var out: value.Value;
+    # sext makes -2^31/-1 fit in i64, so the old code folds it — but the runtime
+    # 32-bit IDIV traps, so the fold must be declined.
+    if (fold_int_binary(?m, instr.OP_DIV_S, a, b, ty, ?out)) { ret 1; }
+    ret 0;
+}
+
+test "constfold: division by zero and a normal signed division" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val tr: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret 1; }
+    val ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+
+    var out: value.Value;
+    # division by zero is never folded (trap left to runtime).
+    if (fold_int_binary(?m, instr.OP_DIV_S, value.const_int(7, ty), value.const_int(0, ty), ty, ?out)) { ret 1; }
+    # a normal division folds to the exact value.
+    if (fold_int_binary(?m, instr.OP_DIV_S, value.const_int(20, ty), value.const_int(4, ty), ty, ?out) == false) { ret 1; }
+    if (out.kind != value.VAL_CONST_INT || out.data.int_lit != 5) { ret 1; }
+    ret 0;
+}
+
+test "constfold: an in-range shift folds, an out-of-range shift does not" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val tr: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 32);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret 1; }
+    val ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+
+    var out: value.Value;
+    # 8 << 2 == 32 is target-independent and folds.
+    if (fold_int_binary(?m, instr.OP_SHL, value.const_int(8, ty), value.const_int(2, ty), ty, ?out) == false) { ret 1; }
+    if (out.data.int_lit != 32) { ret 1; }
+    # 8 << 40: count >= width is target-defined, so it must not fold here.
+    if (fold_int_binary(?m, instr.OP_SHL, value.const_int(8, ty), value.const_int(40, ty), ty, ?out)) { ret 1; }
+    ret 0;
+}
+
+test "constfold: phi collapses single-incoming and all-same, keeps distinct" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val tr: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret 1; }
+    val ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+
+    var subst: value.Value;        # never dereferenced: no VAL_INSTR incomings
+    var has_sub: bool = false;
+    var out: value.Value;
+
+    # single incoming 7 -> collapses to 7.
+    var v1: [1]value.Value;
+    v1[0] = value.const_int(7, ty);
+    var ops1: [2]value.Value;
+    var phi1: instr.Instruction;
+    build_const_phi(?phi1, ?ops1[0], ?v1[0], 1, ty);
+    if (fold_phi(?phi1, 0xFFFFFFFF, ?subst, ?has_sub, 1, ?out) == false) { ret 1; }
+    if (out.kind != value.VAL_CONST_INT || out.data.int_lit != 7) { ret 1; }
+
+    # two identical incomings (9, 9) -> collapses to 9.
+    var v2: [2]value.Value;
+    v2[0] = value.const_int(9, ty);
+    v2[1] = value.const_int(9, ty);
+    var ops2: [4]value.Value;
+    var phi2: instr.Instruction;
+    build_const_phi(?phi2, ?ops2[0], ?v2[0], 2, ty);
+    if (fold_phi(?phi2, 0xFFFFFFFF, ?subst, ?has_sub, 1, ?out) == false) { ret 1; }
+    if (out.data.int_lit != 9) { ret 1; }
+
+    # distinct incomings (9, 5) -> not folded.
+    v2[1] = value.const_int(5, ty);
+    build_const_phi(?phi2, ?ops2[0], ?v2[0], 2, ty);
+    if (fold_phi(?phi2, 0xFFFFFFFF, ?subst, ?has_sub, 1, ?out)) { ret 1; }
+    ret 0;
 }

--- a/src/lang/me/pass/dce.mach
+++ b/src/lang/me/pass/dce.mach
@@ -2,11 +2,15 @@
 #
 # Two cooperating sweeps over each function:
 #
-#   1. value DCE — an instruction whose result Value is unused and whose opcode
-#      is pure (`is_pure`) is dead. A use-count map drives a worklist: removing
-#      one instruction decrements its operands' counts, which may expose more
-#      dead instructions. Volatile loads/stores and every call survive even when
-#      unused, since they may carry side effects.
+#   1. value DCE — an instruction whose result Value is unused and which is
+#      removable-when-unused (a pure value op, or an OP_PHI — a phi is not
+#      `is_pure`, but it has no side effects) is dead. A use-count map drives a
+#      worklist: removing one instruction decrements its operands' counts, which
+#      may expose more dead instructions. Volatile loads and every store/call
+#      survive even when unused, since they may carry side effects. Block lists
+#      (not the instruction pool) are the source of truth for liveness: a pool
+#      entry no longer named by any block — a ghost left by a pass that unlinked
+#      it — contributes no uses and is never seeded, so it cannot pin live values.
 #   2. reachability DCE — blocks not reachable from the entry block (BlockId 0)
 #      along terminator edges are removed. The block array compacts, every
 #      BlockId reference (terminator targets, predecessor lists, phi incomings)
@@ -31,10 +35,16 @@ use std.types.result.unwrap_err;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 
-use ir:    mach.lang.me.ir;
-use instr: mach.lang.me.ir.instruction;
-use value: mach.lang.me.ir.value;
-use id:    mach.lang.me.ir.id;
+use ir:      mach.lang.me.ir;
+use instr:   mach.lang.me.ir.instruction;
+use value:   mach.lang.me.ir.value;
+use id:      mach.lang.me.ir.id;
+
+use std.allocator.Allocator;
+use page:    std.allocator.page;
+use intern:  mach.lang.intern;
+use ir_type: mach.lang.me.ir.type;
+use builder: mach.lang.me.ir.builder;
 
 # sentinel for a removed/absent block in the compaction remap.
 val BLOCK_GONE: u32 = 0xFFFFFFFF;
@@ -58,13 +68,17 @@ pub fun run(m: *ir.Module) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
-# true when an instruction must be kept regardless of whether its result is
-# used: any non-pure opcode (call, store, control flow, asm, alloca) and any
-# volatile load. Pure instructions are removable when unused.
-fun must_keep(inst: *instr.Instruction) bool {
-    if (instr.is_pure(inst.kind) == false) { ret true; }
-    if ((inst.flags & instr.INSTR_FLAG_VOLATILE) != 0) { ret true; }
-    ret false;
+# true when an instruction may be deleted once its result is unused. Pure
+# value-producing opcodes qualify. OP_PHI also qualifies: it is not `is_pure`
+# (a phi is position-dependent, so CSE must never merge phis) but it has no side
+# effects, so an unused phi is dead. Every side-effecting opcode (store, call,
+# memzero, alloca, asm, va_*, terminators) and any volatile load is kept
+# regardless of use.
+fun removable_when_unused(inst: *instr.Instruction) bool {
+    if (inst.kind == instr.OP_PHI) { ret true; }
+    if (instr.is_pure(inst.kind) == false) { ret false; }
+    if ((inst.flags & instr.INSTR_FLAG_VOLATILE) != 0) { ret false; }
+    ret true;
 }
 
 # Value DCE: builds a per-instruction use count, seeds a worklist with the
@@ -97,20 +111,32 @@ fun value_dce(m: *ir.Module, fn: *ir.Function) Result[bool, str] {
     var i: u32 = 0;
     for (i < ilen) { use_count[i] = 0; dead[i] = false; i = i + 1; }
 
-    # count uses across every operand of every live instruction.
+    # count uses across the operands of every block-listed instruction. Block
+    # lists are the source of truth for liveness: a pool entry no longer named by
+    # any block (a ghost left by mem2reg's stripped stores or inline's unlinked
+    # calls) is not live, so its operands must not count as uses — counting them
+    # would pin otherwise-dead computations forever.
     count_uses(fn, use_count);
 
-    # seed: unused, pure, non-kept instructions that are actually in a block.
+    # seed: block-listed instructions that are removable-when-unused and unused.
     var wlen: u32 = 0;
-    var s: u32 = 0;
-    for (s < ilen) {
-        val inst: *instr.Instruction = ?fn.instrs[s];
-        if (must_keep(inst) == false && use_count[s] == 0) {
-            dead[s] = true;
-            work[wlen] = s::id.InstructionId;
-            wlen = wlen + 1;
+    var b0: u32 = 0;
+    for (b0 < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[b0];
+        var pi: u32 = 0;
+        for (pi < blk.phi_count) {
+            seed_if_dead(fn, blk.phis[pi], use_count, dead, work, ?wlen, ilen);
+            pi = pi + 1;
         }
-        s = s + 1;
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            seed_if_dead(fn, blk.instructions[ii], use_count, dead, work, ?wlen, ilen);
+            ii = ii + 1;
+        }
+        if (blk.terminator != id.INSTR_NIL) {
+            seed_if_dead(fn, blk.terminator, use_count, dead, work, ?wlen, ilen);
+        }
+        b0 = b0 + 1;
     }
 
     # drain: each removal decrements the use counts of its operands.
@@ -128,7 +154,7 @@ fun value_dce(m: *ir.Module, fn: *ir.Function) Result[bool, str] {
                         use_count[u] = use_count[u] - 1;
                         if (use_count[u] == 0 && dead[u] == false) {
                             val target: *instr.Instruction = ?fn.instrs[u];
-                            if (must_keep(target) == false) {
+                            if (removable_when_unused(target)) {
                                 dead[u] = true;
                                 work[wlen] = u::id.InstructionId;
                                 wlen = wlen + 1;
@@ -156,25 +182,56 @@ fun value_dce(m: *ir.Module, fn: *ir.Function) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
-# increments use_count for each VAL_INSTR operand. Operands naming a block
-# target (BR/CBR slots, phi incoming block slots) are NOT uses of an
-# instruction result, so they are skipped via the opcode's operand layout.
+# increments use_count for each VAL_INSTR operand of every instruction listed in
+# a block (its phis, body, and terminator). Pool entries not named by any block
+# are skipped — they are ghosts, not live uses. Operands naming a block target
+# (BR/CBR slots, phi incoming block slots) are NOT uses of an instruction result,
+# so they are skipped via the opcode's operand layout.
 fun count_uses(fn: *ir.Function, use_count: *u32) {
-    var i: u32 = 0;
-    for (i < fn.instr_len) {
-        val inst: *instr.Instruction = ?fn.instrs[i];
-        var o: u32 = 0;
-        for (o < inst.operand_count) {
-            if (operand_is_value_use(inst, o)) {
-                val op: value.Value = inst.operands[o];
-                if (op.kind == value.VAL_INSTR) {
-                    val u: u32 = op.data.instr::u32;
-                    if (u < fn.instr_len) { use_count[u] = use_count[u] + 1; }
-                }
+    var b: u32 = 0;
+    for (b < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[b];
+        var pi: u32 = 0;
+        for (pi < blk.phi_count) { count_instr_uses(fn, blk.phis[pi], use_count); pi = pi + 1; }
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) { count_instr_uses(fn, blk.instructions[ii], use_count); ii = ii + 1; }
+        if (blk.terminator != id.INSTR_NIL) { count_instr_uses(fn, blk.terminator, use_count); }
+        b = b + 1;
+    }
+}
+
+# increments use_count for each value-use operand of the instruction `iid`.
+fun count_instr_uses(fn: *ir.Function, iid: id.InstructionId, use_count: *u32) {
+    val opt: Option[*instr.Instruction] = ir.get_instruction(fn, iid);
+    if (is_none[*instr.Instruction](opt)) { ret; }
+    val inst: *instr.Instruction = unwrap[*instr.Instruction](opt);
+    var o: u32 = 0;
+    for (o < inst.operand_count) {
+        if (operand_is_value_use(inst, o)) {
+            val op: value.Value = inst.operands[o];
+            if (op.kind == value.VAL_INSTR) {
+                val u: u32 = op.data.instr::u32;
+                if (u < fn.instr_len) { use_count[u] = use_count[u] + 1; }
             }
-            o = o + 1;
         }
-        i = i + 1;
+        o = o + 1;
+    }
+}
+
+# seeds the dead worklist with instruction `iid` when it is removable-when-unused
+# and currently unused. `wlen` is the live worklist length, advanced on a seed.
+fun seed_if_dead(fn: *ir.Function, iid: id.InstructionId, use_count: *u32,
+                 dead: *bool, work: *id.InstructionId, wlen: *u32, ilen: u32) {
+    val s: u32 = iid::u32;
+    if (s >= ilen) { ret; }
+    if (dead[s]) { ret; }
+    val opt: Option[*instr.Instruction] = ir.get_instruction(fn, iid);
+    if (is_none[*instr.Instruction](opt)) { ret; }
+    val inst: *instr.Instruction = unwrap[*instr.Instruction](opt);
+    if (removable_when_unused(inst) && use_count[s] == 0) {
+        dead[s] = true;
+        work[@wlen] = iid;
+        @wlen = @wlen + 1;
     }
 }
 
@@ -405,4 +462,61 @@ fun prune_phis(fn: *ir.Function, blk: *ir.Block, remap: *u32) {
         }
         pi = pi + 1;
     }
+}
+
+# appends a fresh, empty non-extern function to `m` and returns its index. Fields
+# the dead-phi test does not exercise are left at their `var` zero default (the
+# builder grows blocks/instrs; asm_blocks stays an inert empty map).
+fun new_fn(m: *ir.Module) u32 {
+    val idx: u32 = m.function_len;
+    var f: ir.Function;
+    f.name  = intern.STR_NIL;
+    f.sig   = ir_type.IRT_NIL;
+    f.flags = 0;
+    m.functions[idx] = f;
+    m.function_len   = m.function_len + 1;
+    ret idx;
+}
+
+test "dce: an unused phi is removed (must be removable, not just is_pure-kept)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val tr: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret 1; }
+    val i64t: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+
+    val fi: u32 = new_fn(?m);
+    val fn: *ir.Function = ?m.functions[fi];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    val e0: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](e0)) { ret 1; }
+    val entry: id.BlockId = unwrap_ok[id.BlockId, str](e0);
+    val e1: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](e1)) { ret 1; }
+    val join: id.BlockId = unwrap_ok[id.BlockId, str](e1);
+
+    builder.set_block(?bld, entry);
+    val rbr: Result[bool, str] = builder.emit_br(?bld, join);
+    if (is_err[bool, str](rbr)) { ret 1; }
+
+    builder.set_block(?bld, join);
+    val rp: Result[value.Value, str] = builder.emit_phi(?bld, i64t);   # unused phi
+    if (is_err[value.Value, str](rp)) { ret 1; }
+    val phi: value.Value = unwrap_ok[value.Value, str](rp);
+    val ra: Result[bool, str] = builder.phi_add_incoming(?bld, phi, entry, value.const_int(5, i64t));
+    if (is_err[bool, str](ra)) { ret 1; }
+    val rr: Result[bool, str] = builder.emit_ret(?bld, value.const_int(9, i64t));
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    val dr: Result[bool, str] = run(?m);
+    if (is_err[bool, str](dr)) { ret 1; }
+
+    # before the fix the phi (non-pure, so must_keep) survives unconditionally.
+    if ((?fn.blocks[join::u32]).phi_count != 0) { ret 1; }
+    ret 0;
 }

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -11,8 +11,11 @@
 # an incoming predecessor is re-keyed to the continuation block.
 #
 # The inliner deliberately produces mechanical, un-cleaned output — the release
-# pipeline re-runs mem2reg and dce afterward to tidy it. Recursive functions and
-# calls reaching through inline asm are never inlined.
+# pipeline runs a late constfold / algebraic / cse / constfold / dce sweep
+# afterward to tidy it. mem2reg runs ONCE, before inline, and is not re-run, so a
+# caller alloca whose address only stops escaping after a callee is inlined is not
+# re-promoted (tracked as a known gap). Recursive functions and calls reaching
+# through inline asm are never inlined.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -45,8 +48,10 @@ use target:  mach.lang.target;
 # target.
 val INLINE_INSTR_THRESHOLD: u32 = 25;
 
-# global ceiling on inlines per pass invocation, guarding against runaway
-# expansion (mutually small functions calling each other).
+# global ceiling on inlines per pass invocation. With the call-graph recursion
+# guard below, inlining only contracts the graph along a DAG and terminates on
+# its own; the budget is kept solely as an ICE-grade backstop against an
+# unforeseen runaway, not as the termination mechanism.
 val INLINE_BUDGET: u32 = 1024;
 
 # Pass entry. Repeatedly inlines the first eligible call site found anywhere in
@@ -56,21 +61,42 @@ val INLINE_BUDGET: u32 = 1024;
 # tgt: target — reserved for target-derived cost-model parameters
 # ret: ok(true) after a full pass, or the first allocation error
 pub fun run(m: *ir.Module, tgt: *target.Target) Result[bool, str] {
+    # mark the recursion-cycle members once on the original call graph; they are
+    # never inlined (see should_inline). function_len does not change during the
+    # pass — inlining never adds functions — so this marking stays valid.
+    var recursive: *bool = nil;
+    if (m.function_len > 0) {
+        val rr: Result[*bool, str] = allocate[bool](m.alloc, m.function_len::usize);
+        if (is_err[*bool, str](rr)) { ret err[bool, str](unwrap_err[*bool, str](rr)); }
+        recursive = unwrap_ok[*bool, str](rr);
+        val rm: Result[bool, str] = mark_recursive(m, recursive);
+        if (is_err[bool, str](rm)) {
+            deallocate[bool](m.alloc, recursive, m.function_len::usize);
+            ret rm;
+        }
+    }
+
     var budget: u32 = INLINE_BUDGET;
     var progress: bool = true;
     for (progress && budget > 0) {
         progress = false;
-        val r: Result[bool, str] = inline_one(m, ?progress);
-        if (is_err[bool, str](r)) { ret r; }
+        val r: Result[bool, str] = inline_one(m, recursive, ?progress);
+        if (is_err[bool, str](r)) {
+            if (recursive != nil) { deallocate[bool](m.alloc, recursive, m.function_len::usize); }
+            ret r;
+        }
         if (progress) { budget = budget - 1; }
     }
+
+    if (recursive != nil) { deallocate[bool](m.alloc, recursive, m.function_len::usize); }
     ret ok[bool, str](true);
 }
 
 # scans the module for the first eligible call site and inlines it. sets
 # `did` to true when an inline happened. returns ok(false-in-did) when no
-# eligible site remains.
-fun inline_one(m: *ir.Module, did: *bool) Result[bool, str] {
+# eligible site remains. `recursive` flags the call-graph cycle members that
+# must never be inlined.
+fun inline_one(m: *ir.Module, recursive: *bool, did: *bool) Result[bool, str] {
     @did = false;
     var fi: u32 = 0;
     for (fi < m.function_len) {
@@ -89,7 +115,7 @@ fun inline_one(m: *ir.Module, did: *bool) Result[bool, str] {
                             val callee_ix: u32 = callee_index(inst);
                             if (callee_ix != 0xFFFFFFFF && callee_ix < m.function_len) {
                                 val callee: *ir.Function = ?m.functions[callee_ix];
-                                if (should_inline(m, fi, callee_ix, caller, callee)) {
+                                if (should_inline(m, recursive, fi, callee_ix, caller, callee)) {
                                     val r: Result[bool, str] =
                                         do_inline(m, caller, bi, ii, iid, callee_ix, callee);
                                     if (is_err[bool, str](r)) { ret r; }
@@ -123,9 +149,12 @@ fun callee_index(call: *instr.Instruction) u32 {
 # inline asm is never inlined: its OP_ASM payload lives in the callee's
 # Function.asm map keyed by the callee-side InstructionId, which the clone does
 # not carry over, so inlining it would silently drop the asm body/ISA/operands.
-fun should_inline(m: *ir.Module, caller_ix: u32, callee_ix: u32, caller: *ir.Function, callee: *ir.Function) bool {
+# A recursion-cycle member (`recursive[callee_ix]`) is never inlined — direct or
+# mutual; inlining one re-introduces a call into the cycle every iteration, so
+# the budget would be the only thing stopping the loop.
+fun should_inline(m: *ir.Module, recursive: *bool, caller_ix: u32, callee_ix: u32, caller: *ir.Function, callee: *ir.Function) bool {
     if ((callee.flags & ir.FN_FLAG_EXTERN) != 0) { ret false; }
-    if (callee_ix == caller_ix) { ret false; }      # direct self-recursion
+    if (recursive[callee_ix]) { ret false; }         # direct or mutual recursion
     if (callee.block_count == 0) { ret false; }      # no body to inline
     if (callee_has_asm(callee)) { ret false; }       # inline asm is never inlined
     if (callee_is_variadic(m, callee)) { ret false; } # variadic body is not inlinable
@@ -202,6 +231,86 @@ fun call_count(m: *ir.Module, callee_ix: u32) u32 {
         fi = fi + 1;
     }
     ret total;
+}
+
+# marks every function that lies on a recursion cycle (it can transitively reach
+# itself through direct calls). `recursive` is caller-owned of length
+# function_len. Allocates the BFS scratch once and reuses it across the
+# per-function reachability walks.
+fun mark_recursive(m: *ir.Module, recursive: *bool) Result[bool, str] {
+    val n: u32 = m.function_len;
+    val rv: Result[*bool, str] = allocate[bool](m.alloc, n::usize);
+    if (is_err[*bool, str](rv)) { ret err[bool, str](unwrap_err[*bool, str](rv)); }
+    val visited: *bool = unwrap_ok[*bool, str](rv);
+    val rq: Result[*u32, str] = allocate[u32](m.alloc, n::usize);
+    if (is_err[*u32, str](rq)) {
+        deallocate[bool](m.alloc, visited, n::usize);
+        ret err[bool, str](unwrap_err[*u32, str](rq));
+    }
+    val queue: *u32 = unwrap_ok[*u32, str](rq);
+
+    var f: u32 = 0;
+    for (f < n) {
+        recursive[f] = reaches_self(m, f, visited, queue, n);
+        f = f + 1;
+    }
+
+    deallocate[bool](m.alloc, visited, n::usize);
+    deallocate[u32](m.alloc, queue, n::usize);
+    ret ok[bool, str](true);
+}
+
+# true when function `start` can transitively reach itself through direct
+# (VAL_FN) calls — i.e. it is part of a recursion cycle. BFS over the call graph
+# from start's callees; reaching `start` again closes a cycle. `visited`/`queue`
+# are caller-owned scratch of length n, reset on entry. Each function is enqueued
+# at most once, so the queue never overflows n.
+fun reaches_self(m: *ir.Module, start: u32, visited: *bool, queue: *u32, n: u32) bool {
+    var i: u32 = 0;
+    for (i < n) { visited[i] = false; i = i + 1; }
+
+    var qt: u32 = 0;
+    if (scan_callees(m, start, start, visited, queue, ?qt)) { ret true; }
+    var qh: u32 = 0;
+    for (qh < qt) {
+        val g: u32 = queue[qh];
+        qh = qh + 1;
+        if (scan_callees(m, g, start, visited, queue, ?qt)) { ret true; }
+    }
+    ret false;
+}
+
+# scans function `fn_ix`'s live call sites; for each direct callee c, returns
+# true when c == target (the cycle is closed) and otherwise enqueues c the first
+# time it is seen. Mirrors call_count's live-only view — pool entries orphaned by
+# a prior inline are not edges.
+fun scan_callees(m: *ir.Module, fn_ix: u32, target: u32, visited: *bool, queue: *u32, qt: *u32) bool {
+    val fn: *ir.Function = ?m.functions[fn_ix];
+    var b: u32 = 0;
+    for (b < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[b];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val opt: Option[*instr.Instruction] = ir.get_instruction(fn, blk.instructions[ii]);
+            if (is_some[*instr.Instruction](opt)) {
+                val inst: *instr.Instruction = unwrap[*instr.Instruction](opt);
+                if (inst.kind == instr.OP_CALL && inst.operand_count >= 1) {
+                    val c: u32 = callee_index(inst);
+                    if (c != 0xFFFFFFFF && c < m.function_len) {
+                        if (c == target) { ret true; }
+                        if (visited[c] == false) {
+                            visited[c] = true;
+                            queue[@qt] = c;
+                            @qt = @qt + 1;
+                        }
+                    }
+                }
+            }
+            ii = ii + 1;
+        }
+        b = b + 1;
+    }
+    ret false;
 }
 
 # clone bookkeeping for one inline: maps from callee block/instruction ids to
@@ -587,10 +696,14 @@ fun emit_br(cx: *InlineCtx, in_blk: id.BlockId, target: id.BlockId) Result[id.In
     ret rid;
 }
 
-# rewrites every cloned `ret` into a branch to the continuation, collecting the
-# returned values; builds a result phi in the continuation when the callee
-# returns a value; then replaces the original call's result Value across the
-# whole caller with the phi (or the single return value).
+# rewrites every cloned `ret` into a branch to the continuation and wires the
+# call's result. With a single returning predecessor (the common case) the call
+# result is replaced directly by that return value — no phi is built, matching
+# the header; this also avoids a single-aggregate-return phi the verifier would
+# reject (an aggregate flows by address, and a phi is not address-producing). With
+# two or more returning predecessors a result phi over the return values is built
+# in the continuation. A non-returning callee leaves the result unwired (its
+# continuation is unreachable and the later dce removes it).
 fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) Result[bool, str] {
     val m: *ir.Module = cx.m;
     val caller: *ir.Function = cx.caller;
@@ -599,13 +712,10 @@ fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) Result[bool, str] 
     if (is_err[ir_type.IrTypeId, str](rvt)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](rvt)); }
     val returns_value: bool = cx.ret_ty != unwrap_ok[ir_type.IrTypeId, str](rvt);
 
-    # gather (clone-block, return-value) for each cloned ret, converting it to a
-    # branch to the continuation in place.
+    # count the cloned blocks that return a value, choosing the wiring strategy.
+    val value_rets: u32 = count_value_returns(cx, returns_value);
     var phi_id: id.InstructionId = id.INSTR_NIL;
-    var phi_incomings: u32 = 0;
-
-    # pre-create the phi (empty) so we can append incomings as we walk rets.
-    if (returns_value) {
+    if (returns_value && value_rets >= 2) {
         var phi: instr.Instruction;
         phi.kind          = instr.OP_PHI;
         phi.ty            = cx.ret_ty;
@@ -619,6 +729,10 @@ fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) Result[bool, str] 
         phi_id = unwrap_ok[id.InstructionId, str](rp);
     }
 
+    # walk the cloned returns, capturing the single value (or filling the phi) and
+    # converting each ret into a branch to the continuation in place.
+    var single_val: value.Value;
+    var have_single: bool = false;
     var cb: u32 = 0;
     for (cb < callee.block_count) {
         val clone_bid: id.BlockId = cx.block_map[cb]::id.BlockId;
@@ -629,12 +743,14 @@ fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) Result[bool, str] 
                 val term: *instr.Instruction = unwrap[*instr.Instruction](topt);
                 if (term.kind == instr.OP_RET) {
                     if (returns_value && term.operand_count >= 1) {
-                        # append (clone_bid, ret_value) to the phi.
-                        val pa: Result[bool, str] = phi_append(cx, phi_id, clone_bid, term.operands[0]);
-                        if (is_err[bool, str](pa)) { ret pa; }
-                        phi_incomings = phi_incomings + 1;
+                        if (value_rets == 1) {
+                            single_val  = term.operands[0];
+                            have_single = true;
+                        } or {
+                            val pa: Result[bool, str] = phi_append(cx, phi_id, clone_bid, term.operands[0]);
+                            if (is_err[bool, str](pa)) { ret pa; }
+                        }
                     }
-                    # rewrite this ret into a branch to the continuation.
                     val rconv: Result[bool, str] = convert_ret_to_br(cx, term);
                     if (is_err[bool, str](rconv)) { ret rconv; }
                 }
@@ -643,11 +759,10 @@ fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) Result[bool, str] 
         cb = cb + 1;
     }
 
-    # register the result phi in the continuation and replace the call's result
-    # with it. The phi carries exactly one incoming per returning predecessor, so
-    # it covers every predecessor of the continuation; it must live in the block's
-    # phi list for the back end (and verifier) to see it.
-    if (returns_value && phi_incomings >= 1) {
+    # wire the call's result to the single return value or the result phi.
+    if (returns_value && value_rets == 1 && have_single) {
+        replace_value_uses(caller, call_id, single_val);
+    } or (returns_value && value_rets >= 2) {
         val cont: *ir.Block = ?caller.blocks[cx.cont_blk::u32];
         val ap: Result[bool, str] = ir.block_append_phi(m, cont, phi_id);
         if (is_err[bool, str](ap)) { ret ap; }
@@ -659,6 +774,30 @@ fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) Result[bool, str] 
     # split_call_block truncated the call block to call_ii, so it is no longer
     # listed in any block. nothing more to do.
     ret ok[bool, str](true);
+}
+
+# counts the cloned callee blocks whose terminator is a value-carrying `ret`.
+# Zero when the callee returns void or never returns; the result selects the
+# direct-value vs result-phi wiring in finish_returns.
+fun count_value_returns(cx: *InlineCtx, returns_value: bool) u32 {
+    if (returns_value == false) { ret 0; }
+    val caller: *ir.Function = cx.caller;
+    val callee: *ir.Function = cx.callee;
+    var n: u32 = 0;
+    var cb: u32 = 0;
+    for (cb < callee.block_count) {
+        val clone_bid: id.BlockId = cx.block_map[cb]::id.BlockId;
+        val blk: *ir.Block = ?caller.blocks[clone_bid::u32];
+        if (blk.terminator != id.INSTR_NIL) {
+            val topt: Option[*instr.Instruction] = ir.get_instruction(caller, blk.terminator);
+            if (is_some[*instr.Instruction](topt)) {
+                val term: *instr.Instruction = unwrap[*instr.Instruction](topt);
+                if (term.kind == instr.OP_RET && term.operand_count >= 1) { n = n + 1; }
+            }
+        }
+        cb = cb + 1;
+    }
+    ret n;
 }
 
 # converts a cloned OP_RET into an OP_BR to the continuation block. The ret's

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -1026,7 +1026,11 @@ fun rename_enter_block(rc: *RenameCtx, bid: id.BlockId) Result[bool, str] {
         val ra: Result[bool, str] = add_phi_incomings(rc, bid, succ0);
         if (is_err[bool, str](ra)) { ret ra; }
     }
-    if (sn >= 2) {
+    # an equal-target CBR (succ1 == succ0) contributes a single predecessor edge
+    # (block_append_pred dedups), so its phis take one incoming — guarding succ1
+    # against succ0 keeps phi operand counts consistent with the pred list, the
+    # same invariant inline's rekey_successor_phis enforces.
+    if (sn >= 2 && succ1 != succ0) {
         val rb: Result[bool, str] = add_phi_incomings(rc, bid, succ1);
         if (is_err[bool, str](rb)) { ret rb; }
     }

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -95,8 +95,12 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         # inline: single-use and small functions.
         val ri: Result[bool, str] = inline.run(m, tgt);
         if (is_err[bool, str](ri)) { ret ri; }
+        # inlining a non-returning callee leaves the continuation block with no
+        # predecessors until the late dce sweeps it, so reachability/dominance are
+        # not yet enforced here (full=false) — they are re-checked after the late
+        # dce below, mirroring the constfold gates.
         if (verify_ir) {
-            val rvi: Result[bool, str] = run_verify(m, true, true);
+            val rvi: Result[bool, str] = run_verify(m, false, true);
             if (is_err[bool, str](rvi)) { ret rvi; }
         }
 


### PR DESCRIPTION
Addresses the optimization-passes audit in #1252 (parent epic #1259).

Most findings are fixed here; the two that land in verifier territory or are pure-perf are split into tracked follow-ups (`Refs #1252` rather than `Closes`, since the headline `--release --verify-ir` is only fully green once #1280 lands).

## Per-finding disposition

| # | Finding | Disposition |
|---|---------|-------------|
| BUG/S | constfold SIGFPE on INT_MIN/-1 (i64), silent trap-removal (i32) | **Fixed** — `div_overflows` declines the fold, matching the div-by-zero policy; trap left to the back end. Direct fold tests. |
| BUG/M | dce can never delete a dead phi | **Fixed** — `removable_when_unused` makes an unused OP_PHI dead (is_pure unchanged for CSE). End-to-end test. |
| DESIGN/M | ghost pool entries pin operands against DCE | **Fixed (structural)** — `count_uses` + the dead-seed loop walk block lists, not the pool, so unlinked ghosts contribute no uses. |
| BUG/S | `--release --verify-ir` always fails (pair) | **Partly fixed** — inline wires a single return directly (no aggregate phi) and the post-inline gate is `full=false`. The **multi-return** aggregate phi needs `OP_PHI` in the verifier's address-producing set → **#1280** (me/ir, deferred per the no-touch rule). |
| DESIGN/M | no phi simplification | **Fixed** — `fold_phi` collapses single-incoming / all-same phis; `resolve` follows substitution chains. Test. |
| CLEANUP/S | stale inline header (mem2reg re-run) | **Fixed doc** + gap filed as **#1281** (post-inline promotable allocas are never promoted today). |
| SMELL/S | mem2reg/inline diverged twin-CBR handling | **Fixed** — mem2reg adds the `succ1 != succ0` guard, matching inline. |
| SMELL/M | compiler-scale quadratic scans | **Deferred → #1282** (perf, not correctness). |
| DESIGN/S | x86 shift-count semantics hardcoded | **Fixed (conservative choice)** — fold shifts only for target-independent in-range counts; out-of-range left to the back end. Rationale on #1252. |
| DESIGN/M | inliner has no call-graph awareness | **Implemented** — `should_inline` refuses any callee on a call-graph cycle (transitive recursion, marked once); the budget is now a backstop, not the termination mechanism. |

## Coordination
- Rebased onto current dev (post #1273 verifier rewrite). The verifier's aggregate check still lacks `OP_PHI` (it gained `OP_VA_ARG`) and the post-inline gate was `full=true`; both re-baselined empirically. No `me/ir/` files touched — the residual verifier gap is **#1280**.

## Verification
- `mach build .` clean; `mach test .` 269 pass / 0 fail (6 new constfold/dce tests).
- New integration suite `relverify`: `--release --verify-ir` passes on the fixed paths (fails on seed). Picked up by the integration job automatically.
- SIGFPE repro: compiler builds at -O0 and --release (no crash); the program traps at runtime (exit 136) — fold did not remove the trap.
- Byte-identical self-host fixpoint at **-O0** (gen2 == gen3) and **--release** (relB == relC).

Refs #1252