### PR TITLE
fix(abi): complete the ABI abstraction boundary (arch-aware selection, SysV SSE aggregates, variadic model)

### DIFF
--- a/.github/tests/cffi/app/mach.toml
+++ b/.github/tests/cffi/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "cffiapp"
+name = "SysV float-aggregate C-FFI — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "linux"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/cffiapp"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/cffi/app/src/main.mach
+++ b/.github/tests/cffi/app/src/main.mach
@@ -1,0 +1,48 @@
+use std.runtime.linux.x86_64;
+
+# SysV float-aggregate C-FFI (#1257 BUG/L). by-value structs containing floats are
+# classified per eightbyte: an SSE eightbyte (all-float) rides an XMM register, so
+# {f64,f64} passes/returns in XMM0:XMM1, {f32,f32} in one XMM, and {i64,f64} in
+# RDI:XMM0. before the fix these went in GP registers and the C functions read
+# garbage. each `near` check returns non-zero on mismatch, exiting with the failing
+# case's code.
+
+rec Vec2  { x: f64; y: f64; }
+rec F2    { a: f32; b: f32; }
+rec Mixed { i: i64; d: f64; }
+
+# the C library's float-struct functions, bound at link time against cffi.o.
+ext fun vec2_sum(v: Vec2) f64;
+ext fun vec2_scale(v: Vec2, s: f64) Vec2;
+ext fun f2_sum(f: F2) f32;
+ext fun mixed_sum(m: Mixed) f64;
+
+# near: 1 when |a - b| < 0.001, else 0. avoids an exact float equality.
+fun near(a: f64, b: f64) i64 {
+    var d: f64 = a - b;
+    if (d < 0.0) { d = 0.0 - d; }
+    if (d < 0.001) { ret 1; }
+    ret 0;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # {f64,f64} argument in XMM0:XMM1.
+    val v: Vec2 = Vec2{ x: 3.0, y: 4.0 };
+    if (near(vec2_sum(v), 7.0) == 0) { ret 1; }
+
+    # {f64,f64} return in XMM0:XMM1 (plus a scalar f64 in XMM2).
+    val sc: Vec2 = vec2_scale(v, 2.0);
+    if (near(sc.x, 6.0) == 0) { ret 2; }
+    if (near(sc.y, 8.0) == 0) { ret 3; }
+
+    # one all-float eightbyte ({f32,f32}, 8 bytes) in XMM0, returned in XMM0.
+    val f: F2 = F2{ a: 1.5, b: 2.5 };
+    if (near(f2_sum(f)::f64, 4.0) == 0) { ret 4; }
+
+    # mixed INTEGER:SSE aggregate ({i64,f64}) in RDI:XMM0.
+    val m: Mixed = Mixed{ i: 10, d: 2.5 };
+    if (near(mixed_sum(m), 12.5) == 0) { ret 5; }
+
+    ret 0;
+}

--- a/.github/tests/cffi/cffi.c
+++ b/.github/tests/cffi/cffi.c
@@ -1,0 +1,15 @@
+/* C side of the SysV float-aggregate C-FFI test. compiled with the system `cc`
+ * to a loose object, then linked into the Mach consumer. these functions exchange
+ * by-value structs containing floats, which the System V AMD64 psABI passes and
+ * returns in SSE registers (XMM0/XMM1) per eightbyte. before the Mach compiler
+ * classified float-bearing aggregate eightbytes as SSE, it passed/returned them in
+ * GP registers, so every call below saw garbage and the consumer exited non-zero. */
+
+typedef struct { double x; double y; } Vec2;   /* SSE,SSE  -> XMM0:XMM1        */
+typedef struct { float  a; float  b; } F2;      /* one SSE eightbyte -> XMM0    */
+typedef struct { long   i; double d; } Mixed;   /* INTEGER,SSE -> RDI:XMM0      */
+
+double vec2_sum(Vec2 v)             { return v.x + v.y; }
+Vec2   vec2_scale(Vec2 v, double s) { Vec2 r; r.x = v.x * s; r.y = v.y * s; return r; }
+float  f2_sum(F2 f)                 { return f.a + f.b; }
+double mixed_sum(Mixed m)           { return (double)m.i + m.d; }

--- a/.github/tests/cffi/run.sh
+++ b/.github/tests/cffi/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SysV float-aggregate C-FFI test (#1257 BUG/L): link a Mach program against a
+# C-compiled object that exchanges by-value structs containing floats, and confirm
+# the values cross the boundary correctly.
+#
+# the System V AMD64 psABI classifies an aggregate per eightbyte: an all-float
+# eightbyte is SSE class and travels in an XMM register, so `{f64,f64}` passes and
+# returns in XMM0:XMM1, `{f32,f32}` in one XMM, and `{i64,f64}` in RDI:XMM0. before
+# the Mach compiler implemented SSE-eightbyte classification it passed/returned
+# float-bearing aggregates in GP registers, so a C function reading XMM saw garbage.
+# this compiles `cffi.c` with the system `cc` (skipped when absent), links the Mach
+# consumer against the object, and runs it — `main` exits 0 only when every
+# float-struct call produced the right value (1=vec2_sum arg, 2/3=vec2_scale return,
+# 4=f2_sum one-eightbyte, 5=mixed INTEGER:SSE).
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+if ! command -v cc >/dev/null 2>&1; then
+    echo "SKIP cffi: no system 'cc' to compile the C boundary object"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# compile the C boundary object exporting the float-struct functions.
+OBJ="$WORK/cffi.o"
+if ! cc -c "$HERE/cffi.c" -o "$OBJ"; then
+    echo "FAIL cffi: could not compile cffi.c with cc" >&2
+    exit 1
+fi
+
+# build the Mach consumer, linking the C object.
+if ! ( cd "$WORK/app" && "$MACH" build . "$OBJ" ) >/dev/null 2>&1; then
+    echo "FAIL cffi: build linking the C object failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/cffiapp"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS cffi: by-value float structs cross the C boundary in SSE registers"
+    exit 0
+fi
+
+echo "FAIL cffi: float-struct C-FFI miscompiled (exit $code: 1=vec2_sum, 2/3=vec2_scale, 4=f2_sum, 5=mixed)" >&2
+exit 1

--- a/.github/tests/win64va/app/mach.toml
+++ b/.github/tests/win64va/app/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id = "win64va"
+name = "win64 variadic regression — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "windows"
+
+[targets.windows]
+os = "windows"
+isa = "x86_64"
+abi = "win64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "windows"
+binary = "windows/bin/win64va.exe"
+libs = ["kernel32.dll"]
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/win64va/app/src/main.mach
+++ b/.github/tests/win64va/app/src/main.mach
@@ -1,0 +1,79 @@
+use std.runtime.windows.x86_64;
+
+# win64 variadic regression (#1253). two confirmed miscompiles plus the va_list
+# type, all on the home-area variadic model:
+#   * a variadic float argument must be duplicated into the matching INTEGER
+#     argument register, because the callee reads varargs through the home/stack
+#     slots (which only mirror the integer registers). before the fix the float
+#     went only to its XMM register, so the home slot held garbage and va_arg[f64]
+#     read it.
+#   * va_start must seed the cursor past EVERY named positional slot, including
+#     stack-passed named parameters (the 5th+). before the fix it saturated at the
+#     four register slots, so a function with more than four named params returned
+#     a named argument from the first va_arg.
+#   * va_list is a single pointer under the home model (8 bytes), not the 24-byte
+#     SysV __va_list_tag.
+
+# fsum: n floating-point varargs. exercises the variadic float duplication — each
+# float vararg must reach the home slot through its integer register.
+fun fsum(n: i64, ...) f64 {
+    var ap: va_list;
+    va_start(?ap);
+    var acc: f64 = 0.0;
+    var i: i64 = 0;
+    for (i < n) {
+        acc = acc + va_arg[f64](?ap);
+        i = i + 1;
+    }
+    va_end(?ap);
+    ret acc;
+}
+
+# tail_after_six: six named integer params (the 5th and 6th are stack-passed under
+# win64) precede the varargs, so va_start must seed at positional slot 6. before
+# the fix it seeded at slot 4 and the first va_arg returned a named parameter.
+fun tail_after_six(a: i64, b: i64, c: i64, d: i64, e: i64, f: i64, ...) i64 {
+    var ap: va_list;
+    va_start(?ap);
+    val x: i64 = va_arg[i64](?ap);
+    val y: i64 = va_arg[i64](?ap);
+    va_end(?ap);
+    ret x + y;
+}
+
+# mixed: an integer then a float vararg. the float must be duplicated into its
+# integer slot for va_arg[f64] to read it after the leading integer.
+fun mixed(n: i64, ...) i64 {
+    var ap: va_list;
+    va_start(?ap);
+    val a: i64 = va_arg[i64](?ap);
+    val b: f64 = va_arg[f64](?ap);
+    va_end(?ap);
+    ret a + b::i64;
+}
+
+# near: 1 when |a - b| < 0.001, else 0.
+fun near(a: f64, b: f64) i64 {
+    var d: f64 = a - b;
+    if (d < 0.0) { d = 0.0 - d; }
+    if (d < 0.001) { ret 1; }
+    ret 0;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # three float varargs summed: requires the float-into-integer-register dup.
+    if (near(fsum(3, 1.5, 2.5, 4.0), 8.0) == 0) { ret 1; }
+
+    # the va_list is a single pointer under the home model.
+    if ($size_of(va_list) != 8) { ret 2; }
+
+    # six named params (two stack-passed) before the varargs: va_start must skip
+    # all six, so the first two varargs are 100 and 200.
+    if (tail_after_six(1, 2, 3, 4, 5, 6, 100, 200) != 300) { ret 3; }
+
+    # an integer vararg followed by a float vararg.
+    if (mixed(2, 10, 5.0) != 15) { ret 4; }
+
+    ret 0;
+}

--- a/.github/tests/win64va/run.sh
+++ b/.github/tests/win64va/run.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# win64 variadic regression test (#1253): the home-area variadic model had two
+# confirmed miscompiles — a variadic float was never duplicated into the matching
+# integer register (so va_arg[f64] read garbage from the home slot), and va_start
+# seeded the cursor past only the four register slots, so a function with more than
+# four named parameters returned a named argument from its first va_arg. va_list is
+# also a single pointer (8 bytes) under this model, not the 24-byte SysV tag. this
+# cross-compiles a win64 program exercising all three and runs it under wine; main
+# exits 0 only when every variadic read is correct (1=float dup, 2=va_list size,
+# 3=va_start past stack-passed named params, 4=mixed int/float).
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+# the test runs a windows binary; without wine there is nothing to execute it.
+if ! command -v wine >/dev/null 2>&1; then
+    echo "SKIP win64va: 'wine' not available to run the windows binary"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# build at -O0 so the variadic calls are real, not folded.
+if ! ( cd "$WORK/app" && "$MACH" build . -O0 ) >/dev/null 2>&1; then
+    echo "FAIL win64va: windows cross-build failed" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/windows/bin/win64va.exe"
+test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
+
+set +e
+WINEDEBUG=-all wine "$EXE" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS win64va: variadic float dup, va_start slot seeding, and va_list pointer are correct"
+    exit 0
+fi
+
+echo "FAIL win64va: win64 variadic miscompiled (exit $code: 1=float dup, 2=va_list size, 3=va_start slots, 4=mixed)" >&2
+exit 1

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -579,7 +579,7 @@ fun build_test_runner(p: *driver.Project, level: u8, verify_ir: bool,
                       irs: *ir.Module,
                       runner_ir: *ir.Module, runner_ir_ok: *bool,
                       runner_img: *of.ObjectImage, runner_img_ok: *bool) i64 {
-    val syn_r: Result[Option[ir.Module], str] = testrunner.synthesize(p.s, irs, p.module_len);
+    val syn_r: Result[Option[ir.Module], str] = testrunner.synthesize(p.s, ?p.target, irs, p.module_len);
     if (is_err[Option[ir.Module], str](syn_r)) {
         util.emit("error: ");
         util.emit(unwrap_err[Option[ir.Module], str](syn_r));

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -3041,7 +3041,7 @@ fun require_abi(tgt: *target.Target) Result[bool, str] {
 # ret:   ok(true) on success, or a loud error
 fun abi_gp_arg_reg(tgt: *target.Target, index: i32, out: *i32) Result[bool, str] {
     var regs: [16]isa.Register;
-    val fill: sysv.RegFileFn = tgt.abi.gp_arg_regs::sysv.RegFileFn;
+    val fill: abi.RegFileFn = tgt.abi.gp_arg_regs::abi.RegFileFn;
     val n: i32 = fill(?regs[0]);
     if (index < 0 || index >= n || index >= MAX_GP_ARG_REGS) {
         ret err[bool, str]("mir.lower_ir: GP argument register index out of range");
@@ -3062,8 +3062,8 @@ fun abi_gp_arg_reg(tgt: *target.Target, index: i32, out: *i32) Result[bool, str]
 # out: receives the physical register id on success
 # ret: ok(true) on success, or a loud error
 fun abi_gp_ret_reg(tgt: *target.Target, out: *i32) Result[bool, str] {
-    val classify_ret: sysv.RetPassingFn = tgt.abi.ret_passing::sysv.RetPassingFn;
-    val slot: abi.ParamSlot = classify_ret(tgt.arch_id, 8, 8, false, false);
+    val classify_ret: abi.RetPassingFn = tgt.abi.ret_passing::abi.RetPassingFn;
+    val slot: abi.ParamSlot = classify_ret(8, 8, false, false);
     if (slot.class != abi.CLASS_GP || slot.reg < 0) {
         ret err[bool, str]("mir.lower_ir: ABI vtable has no GP return register");
     }
@@ -3084,7 +3084,7 @@ fun abi_va_model(tgt: *target.Target, out: *abi.VaModel) Result[bool, str] {
     if (tgt.abi.va_model == nil) {
         ret err[bool, str]("mir.lower_ir: ABI vtable exposes no variadic save model");
     }
-    val model: sysv.VaModelFn = tgt.abi.va_model::sysv.VaModelFn;
+    val model: abi.VaModelFn = tgt.abi.va_model::abi.VaModelFn;
     @out = model();
     ret ok[bool, str](true);
 }
@@ -3229,9 +3229,8 @@ fun classify_signature(ctx: *LowerCtx, sig: ir_type.IrTypeId, ret_ty: ir_type.Ir
     val rok: Result[bool, str] = require_abi(ctx.tgt);
     if (is_err[bool, str](rok)) { ret rok; }
 
-    val arch: u32 = ctx.tgt.arch_id;
-    val classify_arg: sysv.ArgPassingFn = ctx.tgt.abi.arg_passing::sysv.ArgPassingFn;
-    val classify_ret: sysv.RetPassingFn = ctx.tgt.abi.ret_passing::sysv.RetPassingFn;
+    val classify_arg: abi.ArgPassingFn = ctx.tgt.abi.arg_passing::abi.ArgPassingFn;
+    val classify_ret: abi.RetPassingFn = ctx.tgt.abi.ret_passing::abi.RetPassingFn;
 
     out.params      = nil;
     out.param_count = 0;
@@ -3242,7 +3241,7 @@ fun classify_signature(ctx: *LowerCtx, sig: ir_type.IrTypeId, ret_ty: ir_type.Ir
     val ret_size:  u64  = ir_type.byte_size(ctx.types, ret_ty, ctx.tgt)::u64;
     val ret_float: bool = value_is_float(ctx, ret_ty);
     val ret_aggr:  bool = value_is_aggregate(ctx, ret_ty);
-    out.ret_slot = classify_ret(arch, ret_size, 0, ret_float, ret_aggr);
+    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_aggr);
 
     var gp_used:   i32 = 0;
     var fp_used:   i32 = 0;
@@ -3289,7 +3288,7 @@ fun classify_signature(ctx: *LowerCtx, sig: ir_type.IrTypeId, ret_ty: ir_type.Ir
         val psz:  u64  = ir_type.byte_size(ctx.types, pty, ctx.tgt)::u64;
         val pfl:  bool = value_is_float(ctx, pty);
         val pag:  bool = value_is_aggregate(ctx, pty);
-        var slot: abi.ParamSlot = classify_arg(arch, pi::i32, psz, 0, pfl, pag, gp_used, fp_used);
+        var slot: abi.ParamSlot = classify_arg(pi::i32, psz, 0, pfl, pag, gp_used, fp_used);
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering
@@ -3351,8 +3350,7 @@ fun lower_call(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
     val rok: Result[bool, str] = require_abi(ctx.tgt);
     if (is_err[bool, str](rok)) { ret rok; }
 
-    val arch: u32 = ctx.tgt.arch_id;
-    val classify_arg: sysv.ArgPassingFn = ctx.tgt.abi.arg_passing::sysv.ArgPassingFn;
+    val classify_arg: abi.ArgPassingFn = ctx.tgt.abi.arg_passing::abi.ArgPassingFn;
 
     # classify the WHOLE declared signature once (the callee's IRT_FN rides on
     # `inst.aux_ty`, the call's result type on `inst.ty`); the return and every
@@ -3432,7 +3430,7 @@ fun lower_call(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
             val asz:  u64  = ir_type.byte_size(ctx.types, av.ty, ctx.tgt)::u64;
             val afl:  bool = value_is_float(ctx, av.ty);
             val aag:  bool = value_is_aggregate(ctx, av.ty);
-            slot = classify_arg(arch, pidx::i32, asz, 0, afl, aag, gp_used, fp_used);
+            slot = classify_arg(pidx::i32, asz, 0, afl, aag, gp_used, fp_used);
             soff = stack_off;
         }
 
@@ -4482,9 +4480,9 @@ fun lower_va_arg_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instructi
     # hidden pointer, one GP eightbyte) for a >16B aggregate, two GP eightbytes for a
     # 9-16B aggregate, one for a <=8B aggregate. the runtime gp_offset cursor — not
     # gp_used — decides registers vs overflow below.
-    val classify_arg: sysv.ArgPassingFn = ctx.tgt.abi.arg_passing::sysv.ArgPassingFn;
+    val classify_arg: abi.ArgPassingFn = ctx.tgt.abi.arg_passing::abi.ArgPassingFn;
     val align: u64 = ir_type.byte_align(ctx.types, inst.ty, ctx.tgt)::u64;
-    val slot:  abi.ParamSlot = classify_arg(ctx.tgt.arch_id, 0, size, align, false, true, 0, 0);
+    val slot:  abi.ParamSlot = classify_arg(0, size, align, false, true, 0, 0);
     val byref: bool = slot.class == abi.CLASS_BYREF;
     var gp_bytes: i64 = 8;
     if (!byref && slot.reg2 >= 0) { gp_bytes = 16; }
@@ -4633,8 +4631,8 @@ fun lower_va_arg_home(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, d
 
         # classify the aggregate to learn whether the slot holds it by value or a
         # hidden pointer to it.
-        val classify_arg: sysv.ArgPassingFn = ctx.tgt.abi.arg_passing::sysv.ArgPassingFn;
-        val slot: abi.ParamSlot = classify_arg(ctx.tgt.arch_id, 0, size, align, false, true, 0, 0);
+        val classify_arg: abi.ArgPassingFn = ctx.tgt.abi.arg_passing::abi.ArgPassingFn;
+        val slot: abi.ParamSlot = classify_arg(0, size, align, false, true, 0, 0);
         val byref: bool = slot.class == abi.CLASS_BYREF;
 
         # back the result vreg with caller-owned storage so downstream copies / stores

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -65,7 +65,6 @@ use float:   mach.lang.float;
 use intern:  mach.lang.intern;
 use target:  mach.lang.target.resolved;
 use abi:     mach.lang.target.abi;
-use sysv:    mach.lang.target.abi.sysv;
 use isa:     mach.lang.target.isa;
 use ir:      mach.lang.me.ir;
 use ir_type: mach.lang.me.ir.type;
@@ -894,6 +893,13 @@ rec LowerCtx {
     # past them. captured from the signature layout in the entry prologue.
     va_named_gp: i32;
     va_named_fp: i32;
+    # va_named_slots: the number of POSITIONAL argument slots the named parameters
+    # (plus a hidden sret pointer) consume under the home-area model — `va_start`
+    # seeds the single va_list pointer just past them. unlike `va_named_gp +
+    # va_named_fp` (register-passed named count, which saturates at the register
+    # file size), this counts every named slot including stack-passed ones, so a
+    # variadic function with more than four named params seeds the cursor correctly.
+    va_named_slots: i32;
     # va_overflow_off: the `[rbp + off]` displacement of the first stack-passed
     # argument (the overflow area `va_start` points overflow_arg_area at). it is the
     # base of the incoming stack-argument region, 16 plus the fixed params' stack
@@ -3050,27 +3056,6 @@ fun abi_gp_arg_reg(tgt: *target.Target, index: i32, out: *i32) Result[bool, str]
     ret ok[bool, str](true);
 }
 
-# abi_gp_ret_reg: the physical register id of the active ABI's general-purpose
-# scalar-return register, obtained by classifying an 8-byte integer return through
-# `tgt.abi.ret_passing`. SysV's varargs convention requires the count of vector
-# registers a variadic call uses in this register (AL, the low byte of RAX) before
-# every call; sourcing it from the return classifier keeps that placement
-# vtable-driven rather than naming RAX directly. errors loudly when the classifier
-# returns no register (an unsupported convention).
-# ---
-# tgt: the active target
-# out: receives the physical register id on success
-# ret: ok(true) on success, or a loud error
-fun abi_gp_ret_reg(tgt: *target.Target, out: *i32) Result[bool, str] {
-    val classify_ret: abi.RetPassingFn = tgt.abi.ret_passing::abi.RetPassingFn;
-    val slot: abi.ParamSlot = classify_ret(8, 8, false, false);
-    if (slot.class != abi.CLASS_GP || slot.reg < 0) {
-        ret err[bool, str]("mir.lower_ir: ABI vtable has no GP return register");
-    }
-    @out = slot.reg;
-    ret ok[bool, str](true);
-}
-
 # abi_va_model: the active ABI's variadic save model, read from `tgt.abi.va_model`.
 # the variadic prologue / va_start / va_arg expansion dispatch on `VaModel.kind`
 # (the register-save vs home-area model) so the mechanism stays ABI-agnostic and
@@ -3352,6 +3337,13 @@ fun lower_call(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
 
     val classify_arg: abi.ArgPassingFn = ctx.tgt.abi.arg_passing::abi.ArgPassingFn;
 
+    # the convention's variadic save model drives the pre-call vector-count move and
+    # the win64 variadic-float duplication — both ABI facts the call lowering reads
+    # from the model rather than naming a register or convention directly.
+    var vamodel: abi.VaModel;
+    val vmr: Result[bool, str] = abi_va_model(ctx.tgt, ?vamodel);
+    if (is_err[bool, str](vmr)) { ret vmr; }
+
     # classify the WHOLE declared signature once (the callee's IRT_FN rides on
     # `inst.aux_ty`, the call's result type on `inst.ty`); the return and every
     # fixed argument read their placement from this single layout so the call and
@@ -3456,6 +3448,27 @@ fun lower_call(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
             ret er;
         }
 
+        # win64 variadic float: an unnamed (tail) float argument rides BOTH its XMM
+        # register and the integer argument register of the same positional slot, so
+        # a callee reading it through `va_arg` (which only walks the integer/home
+        # slots) sees it. duplicate the float's bits into the slot's GP argument
+        # register (the positional slot is `gp_used + fp_used`, before the advance);
+        # the move is cross-bank (MOVQ), gated on the model's `float_dup_gp` so SysV —
+        # whose FP save area captures floats directly — never emits it.
+        if (pidx >= layout.param_count && vamodel.float_dup_gp && slot.class == abi.CLASS_FP) {
+            var dup_reg: i32 = 0;
+            val dr: Result[bool, str] = abi_gp_arg_reg(ctx.tgt, gp_used + fp_used, ?dup_reg);
+            if (is_err[bool, str](dr)) {
+                sig_layout_free(ctx, ?layout);
+                ret dr;
+            }
+            val dm: Result[bool, str] = emit_mov(ctx, mb, op_preg(dup_reg::u32), argop);
+            if (is_err[bool, str](dm)) {
+                sig_layout_free(ctx, ?layout);
+                ret dm;
+            }
+        }
+
         # advance the running cursors only for the variadic tail; the fixed-param
         # cursors were already consumed by `classify_signature`.
         if (pidx >= layout.param_count) {
@@ -3482,17 +3495,17 @@ fun lower_call(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
     # call-site RSP stays sixteen-byte aligned.
     record_outgoing_size(ctx, stack_off);
 
-    # SysV requires the GP return register (AL, the low byte of RAX) to hold the
-    # number of vector registers used by variadic arguments before every call (a
-    # conservative upper bound is the FP count). the register is the ABI's GP
-    # scalar-return register, obtained by classifying an integer return through the
-    # ret classifier rather than naming RAX directly.
-    var al_reg: i32 = 0;
-    val alr: Result[bool, str] = abi_gp_ret_reg(ctx.tgt, ?al_reg);
-    if (is_err[bool, str](alr)) { ret alr; }
-    val al: Result[bool, str] = emit_mov(ctx, mb,
-        op_preg(al_reg::u32), op_imm(fp_used::i64));
-    if (is_err[bool, str](al)) { ret al; }
+    # the pre-call vector-count move: a convention that encodes the number of vector
+    # registers a variadic call uses (SysV's AL, the low byte of RAX) sets it before
+    # every call (a conservative upper bound is the FP count). the register rides on
+    # the variadic save model — a convention that encodes no count (win64) reports -1
+    # and the move is skipped, so the instruction is an ABI-driven hook rather than an
+    # unconditional emission on every target.
+    if (vamodel.vector_count_reg >= 0) {
+        val al: Result[bool, str] = emit_mov(ctx, mb,
+            op_preg(vamodel.vector_count_reg::u32), op_imm(fp_used::i64));
+        if (is_err[bool, str](al)) { ret al; }
+    }
 
     # the call itself: the caller-saved clobber barrier (see MIR_CALL docs).
     val rcall: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 1::usize);
@@ -4017,6 +4030,13 @@ fun emit_va_save_prologue(ctx: *LowerCtx, mb: *MirBlock) Result[bool, str] {
     if (is_err[bool, str](cls)) { ret cls; }
     ctx.va_named_gp     = layout.gp_used;
     ctx.va_named_fp     = layout.fp_used;
+    # the home model is strictly one positional slot per argument, so the named
+    # slots are the fixed params plus a hidden sret pointer (a CLASS_SRET return
+    # consumes positional slot 0). counts stack-passed named params that the
+    # register cursors do not, so `va_start` seeds past every named argument.
+    var named_slots: i32 = layout.param_count::i32;
+    if (layout.ret_slot.class == abi.CLASS_SRET) { named_slots = named_slots + 1; }
+    ctx.va_named_slots  = named_slots;
     ctx.va_overflow_off = ctx.tgt.arch.incoming_arg_base + layout.stack_off;
     sig_layout_free(ctx, ?layout);
     ctx.va_active = true;
@@ -4032,15 +4052,16 @@ fun emit_va_save_prologue(ctx: *LowerCtx, mb: *MirBlock) Result[bool, str] {
 # SLOT_ALLOCA frame slot keyed on a fresh slot-key vreg (`va_save_vreg`), sized by
 # the active ABI's `va_save_size`. the GP argument registers are stored at offsets
 # 0,8,..,40 and the FP argument registers at `va_fp_save_offset()` + i*16 —
-# matching the AMD64 `__va_list_tag` register-save layout the `va_arg` field
-# offsets index. all SysV register-file / layout facts are read through `sysv` (its
-# erased vtable casts and layout helpers), keeping the mechanism generic.
+# matching the register-save layout the `va_arg` field offsets index. every layout
+# fact — the save-area size, the FP dump offset, the argument-register files — is
+# read from the `VaModel` and the ABI vtable's register-file accessors, so the
+# mechanism names no convention module.
 fun emit_va_save_regsave(ctx: *LowerCtx, mb: *MirBlock, model: *abi.VaModel) Result[bool, str] {
     # the register-save area: one addressed alloca slot keyed on a slot-key vreg.
     val skr: Result[u32, str] = new_vreg(ctx, REG_CLASS_GP);
     if (is_err[u32, str](skr)) { ret err[bool, str](unwrap_err[u32, str](skr)); }
     val sk: u32 = unwrap_ok[u32, str](skr);
-    val ar: Result[bool, str] = add_alloca_slot(ctx, sk, sysv.va_save_size(), 8);
+    val ar: Result[bool, str] = add_alloca_slot(ctx, sk, model.save_size, 8);
     if (is_err[bool, str](ar)) { ret ar; }
     ctx.va_save_vreg = sk;
 
@@ -4063,34 +4084,38 @@ fun emit_va_save_regsave(ctx: *LowerCtx, mb: *MirBlock, model: *abi.VaModel) Res
     # [save+i*16], xmm_i` in the encoder, keeping the conditional spill in one block
     # (no entry-block CFG split). its base is the save-area slot at the FP region's
     # start; its count is the convention's FP argument-register file size.
-    val sp: Result[bool, str] = emit_va_fp_save(ctx, mb, sk);
+    val sp: Result[bool, str] = emit_va_fp_save(ctx, mb, sk, model);
     if (is_err[bool, str](sp)) { ret sp; }
     ret ok[bool, str](true);
 }
 
 # emit_va_save_home: spill the integer argument registers that hold UNNAMED
 # arguments into the caller's home/shadow space (win64). the home area sits just
-# above the saved frame pointer and return address (`model.home_base_off`,
+# above the saved frame pointer and return address (the ISA's `incoming_arg_base`,
 # `[rbp+16]`), one 8-byte slot per positional argument register (RCX/RDX/R8/R9);
 # the caller always reserves it. the named parameters already occupy the first
-# `va_named_gp + va_named_fp` positional slots (`lower_params` pre-colored them
-# from their registers), so this stores `slot_gp_reg(i)` into `[rbp + base + i*8]`
-# for each remaining positional slot, making the named and unnamed arguments one
-# contiguous stack array; `va_start` then seeds the va_list pointer just past the
-# named arguments. there is NO frame-local save area, so `va_save_vreg` stays
-# NIL and the frame reserves no va-save slot — the home spill targets the caller's
-# frame. a variadic float rides both its XMM register and the matching integer
-# register, so spilling the integer registers alone captures every unnamed
-# argument (`fp_save_count` is 0 for this model).
+# `va_named_gp + va_named_fp` REGISTER positional slots (`lower_params` pre-colored
+# them from their registers), so this stores `slot_gp_reg(i)` into
+# `[rbp + base + i*8]` for each remaining register slot, making the named and
+# unnamed arguments one contiguous stack array; `va_start` then seeds the va_list
+# pointer just past the named arguments. there is NO frame-local save area, so
+# `va_save_vreg` stays NIL and the frame reserves no va-save slot — the home spill
+# targets the caller's frame. a variadic float rides both its XMM register and the
+# matching integer register, so spilling the integer registers alone captures every
+# unnamed argument (`fp_save_count` is 0 for this model).
 fun emit_va_save_home(ctx: *LowerCtx, mb: *MirBlock, model: *abi.VaModel) Result[bool, str] {
-    val named: i32 = ctx.va_named_gp + ctx.va_named_fp;
+    # the number of register-passed named arguments is the start of the unnamed
+    # register slots; a named param spilled to the stack consumed no register, so
+    # this is the right (register-count) quantity, not the full positional count.
+    val named_regs: i32 = ctx.va_named_gp + ctx.va_named_fp;
+    val base: i64 = ctx.tgt.arch.incoming_arg_base;
     val fp: u32 = ctx.tgt.arch.frame_ptr_reg::u32;
-    var si: i32 = named;
+    var si: i32 = named_regs;
     for (si < model.gp_save_count) {
         var greg: i32 = 0;
         val gr: Result[bool, str] = abi_gp_arg_reg(ctx.tgt, si, ?greg);
         if (is_err[bool, str](gr)) { ret gr; }
-        val off: i64 = model.home_base_off + si::i64 * 8;
+        val off: i64 = base + si::i64 * 8;
         val st: Result[bool, str] = emit_store_to(ctx, mb, op_mem_preg(fp, off), op_preg(greg::u32));
         if (is_err[bool, str](st)) { ret st; }
         si = si + 1;
@@ -4100,18 +4125,19 @@ fun emit_va_save_home(ctx: *LowerCtx, mb: *MirBlock, model: *abi.VaModel) Result
 
 # emit_va_fp_save: append the AL-guarded FP-register spill pseudo to the prologue.
 # `save_vreg` is the register-save area's slot-key vreg; operand 0 addresses the FP
-# region at `va_fp_save_offset` within it, operand 1 carries the FP argument-register
-# count, operand 2 is a MIR_OP_PREG use of the vector-count register (AL/RAX) the
-# guard reads. the encoder expands operands 0-1 into the conditional XMM dump (see
-# MIR_VA_FP_SAVE); operand 2 is invisible to the encoder but makes the AL read
-# visible to regalloc so no value vreg is colored to that register before the guard.
-fun emit_va_fp_save(ctx: *LowerCtx, mb: *MirBlock, save_vreg: u32) Result[bool, str] {
+# region at the model's `fp_save_offset` within it, operand 1 carries the FP
+# argument-register count (`fp_save_count`), operand 2 is a MIR_OP_PREG use of the
+# model's vector-count register (AL/RAX) the guard reads. the encoder expands
+# operands 0-1 into the conditional XMM dump (see MIR_VA_FP_SAVE); operand 2 is
+# invisible to the encoder but makes the AL read visible to regalloc so no value
+# vreg is colored to that register before the guard.
+fun emit_va_fp_save(ctx: *LowerCtx, mb: *MirBlock, save_vreg: u32, model: *abi.VaModel) Result[bool, str] {
     val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 3::usize);
     if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
     val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
-    ops[0] = op_mem_slot(save_vreg, sysv.va_fp_save_offset()::i64);
-    ops[1] = op_imm(sysv.FP_PARAM_COUNT::i64);
-    ops[2] = op_preg(sysv.VA_VECTOR_COUNT_REG::u32);
+    ops[0] = op_mem_slot(save_vreg, model.fp_save_offset::i64);
+    ops[1] = op_imm(model.fp_save_count::i64);
+    ops[2] = op_preg(model.vector_count_reg::u32);
     var mi: MirInstr;
     mi.opcode        = MIR_VA_FP_SAVE;
     mi.operands      = ops;
@@ -4139,7 +4165,7 @@ fun lower_va_start(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction) Resu
     if (model.kind == abi.VA_MODEL_HOME) {
         ret lower_va_start_home(ctx, mb, inst, ?model);
     }
-    ret lower_va_start_regsave(ctx, mb, inst);
+    ret lower_va_start_regsave(ctx, mb, inst, ?model);
 }
 
 # lower_va_start_regsave: initialize the SysV `__va_list_tag`. with `ap` the
@@ -4148,26 +4174,27 @@ fun lower_va_start(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction) Resu
 #   fp_offset         = GP area size + named FP regs * 16
 #   reg_save_area     = &register-save slot
 #   overflow_arg_area = &first incoming stack argument (`[rbp + overflow_off]`)
-# all four fields at the SysV `VA_*` offsets the lowering and `va_arg` share.
-fun lower_va_start_regsave(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction) Result[bool, str] {
+# all four fields at the model's `__va_list_tag` offsets the lowering and `va_arg`
+# share.
+fun lower_va_start_regsave(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, model: *abi.VaModel) Result[bool, str] {
     # base address of the va_list struct (the `ap` pointer operand).
     val apbase: MirOperand = mem_operand_of(ctx, inst.operands[0]);
 
     # gp_offset = named GP regs * 8.
     val gp_init: i64 = ctx.va_named_gp::i64 * 8;
-    val sg: Result[bool, str] = emit_store_imm(ctx, mb, va_field_mem(apbase, sysv.VA_GP_OFFSET), gp_init, 4);
+    val sg: Result[bool, str] = emit_store_imm(ctx, mb, va_field_mem(apbase, model.gp_offset_field), gp_init, 4);
     if (is_err[bool, str](sg)) { ret sg; }
 
-    # fp_offset = GP area size + named FP regs * 16.
-    val fp_init: i64 = sysv.va_fp_save_offset()::i64 + ctx.va_named_fp::i64 * 16;
-    val sf: Result[bool, str] = emit_store_imm(ctx, mb, va_field_mem(apbase, sysv.VA_FP_OFFSET), fp_init, 4);
+    # fp_offset = FP region offset + named FP regs * per-XMM stride.
+    val fp_init: i64 = model.fp_save_offset::i64 + ctx.va_named_fp::i64 * model.fp_save_stride::i64;
+    val sf: Result[bool, str] = emit_store_imm(ctx, mb, va_field_mem(apbase, model.fp_offset_field), fp_init, 4);
     if (is_err[bool, str](sf)) { ret sf; }
 
     # reg_save_area = &register-save slot.
     var rsa: u32 = MIR_VREG_NIL;
     val lr: Result[bool, str] = emit_lea_slot(ctx, mb, op_mem_slot(ctx.va_save_vreg, 0), ?rsa);
     if (is_err[bool, str](lr)) { ret lr; }
-    val sr: Result[bool, str] = emit_store_to(ctx, mb, va_field_mem(apbase, sysv.VA_REG_SAVE_AREA), op_vreg(rsa));
+    val sr: Result[bool, str] = emit_store_to(ctx, mb, va_field_mem(apbase, model.reg_save_field), op_vreg(rsa));
     if (is_err[bool, str](sr)) { ret sr; }
 
     # overflow_arg_area = &first incoming stack argument (`[rbp + overflow_off]`).
@@ -4175,20 +4202,22 @@ fun lower_va_start_regsave(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instructi
     var ovf: u32 = MIR_VREG_NIL;
     val lo: Result[bool, str] = emit_lea_slot(ctx, mb, op_mem_preg(fp, ctx.va_overflow_off), ?ovf);
     if (is_err[bool, str](lo)) { ret lo; }
-    ret emit_store_to(ctx, mb, va_field_mem(apbase, sysv.VA_OVERFLOW_ARG_AREA), op_vreg(ovf));
+    ret emit_store_to(ctx, mb, va_field_mem(apbase, model.overflow_field), op_vreg(ovf));
 }
 
 # lower_va_start_home: seed the win64 single-pointer va_list. the named and unnamed
 # arguments form one contiguous stack array starting at the caller's first home slot
-# (`[rbp + home_base_off]`, where `emit_va_save_home` spilled the integer argument
-# registers); the named parameters occupy the first `va_named_gp + va_named_fp`
-# positional slots, so the first unnamed argument is at `[rbp + home_base_off +
-# named*8]`. store that address into the va_list pointer (field offset 0); `va_arg`
-# then reads `arg_stride` bytes and advances the pointer.
+# (`[rbp + incoming_arg_base]`, where `emit_va_save_home` spilled the integer
+# argument registers); the named parameters occupy the first `va_named_slots`
+# positional slots (every named argument, register- AND stack-passed, plus a hidden
+# sret pointer), so the first unnamed argument is at `[rbp + incoming_arg_base +
+# named_slots*8]`. store that address into the va_list pointer (field offset 0);
+# `va_arg` then reads `arg_stride` bytes and advances the pointer. using the full
+# positional slot count (not the register-passed count) keeps the cursor correct
+# when more than four named parameters precede the varargs.
 fun lower_va_start_home(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, model: *abi.VaModel) Result[bool, str] {
     val apbase: MirOperand = mem_operand_of(ctx, inst.operands[0]);
-    val named: i32 = ctx.va_named_gp + ctx.va_named_fp;
-    val first_off: i64 = model.home_base_off + named::i64 * 8;
+    val first_off: i64 = ctx.tgt.arch.incoming_arg_base + ctx.va_named_slots::i64 * 8;
     val fp: u32 = ctx.tgt.arch.frame_ptr_reg::u32;
     var ap0: u32 = MIR_VREG_NIL;
     val la: Result[bool, str] = emit_lea_slot(ctx, mb, op_mem_preg(fp, first_off), ?ap0);
@@ -4258,23 +4287,23 @@ fun lower_va_arg(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: i
         ret lower_va_arg_home(ctx, mb, inst, dst, ?vmodel);
     }
     if (value_is_float(ctx, inst.ty)) {
-        ret lower_va_arg_fp(ctx, mb, inst, dst);
+        ret lower_va_arg_fp(ctx, mb, inst, dst, ?vmodel);
     }
     if (value_is_aggregate(ctx, inst.ty)) {
-        ret lower_va_arg_aggregate(ctx, mb, inst, dst);
+        ret lower_va_arg_aggregate(ctx, mb, inst, dst, ?vmodel);
     }
 
     val apbase: MirOperand = mem_operand_of(ctx, inst.operands[0]);
 
     # gp = load.i32 [ap + gp_offset]; gp64 = zext gp.
     var gp: u32 = MIR_VREG_NIL;
-    val lg: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_GP_OFFSET), 4, ?gp);
+    val lg: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, vmodel.gp_offset_field), 4, ?gp);
     if (is_err[bool, str](lg)) { ret lg; }
 
     # in_reg = gp < gp_offset_max  (u32 compare -> i8 boolean).
     var in_reg: u32 = MIR_VREG_NIL;
     val cr: Result[bool, str] = emit_alu3(ctx, mb, MIR_CMP_LT_U, op_vreg(gp),
-        op_imm(sysv.va_gp_offset_max()::i64), 4, ?in_reg);
+        op_imm(vmodel.gp_offset_max::i64), 4, ?in_reg);
     if (is_err[bool, str](cr)) { ret cr; }
 
     # mask = 0 - zext(in_reg)  -> 0 or 0xFFFFFFFFFFFFFFFF (64-bit).
@@ -4290,7 +4319,7 @@ fun lower_va_arg(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: i
 
     # reg_addr = reg_save_area + zext(gp).
     var rsa: u32 = MIR_VREG_NIL;
-    val lr: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_REG_SAVE_AREA), 8, ?rsa);
+    val lr: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, vmodel.reg_save_field), 8, ?rsa);
     if (is_err[bool, str](lr)) { ret lr; }
     var gp64: u32 = MIR_VREG_NIL;
     val gzr: Result[bool, str] = emit_zext_to(ctx, mb, op_vreg(gp), 4, ?gp64);
@@ -4301,7 +4330,7 @@ fun lower_va_arg(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: i
 
     # ovf = overflow_arg_area.
     var ovf: u32 = MIR_VREG_NIL;
-    val lo: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_OVERFLOW_ARG_AREA), 8, ?ovf);
+    val lo: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, vmodel.overflow_field), 8, ?ovf);
     if (is_err[bool, str](lo)) { ret lo; }
 
     # addr = (reg_addr & mask) | (ovf & ~mask).
@@ -4322,7 +4351,7 @@ fun lower_va_arg(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: i
     var new_gp: u32 = MIR_VREG_NIL;
     val ng: Result[bool, str] = emit_alu3(ctx, mb, MIR_ADD, op_vreg(gp), op_vreg(step_gp), 4, ?new_gp);
     if (is_err[bool, str](ng)) { ret ng; }
-    val wg: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, sysv.VA_GP_OFFSET), op_vreg(new_gp), 4);
+    val wg: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, vmodel.gp_offset_field), op_vreg(new_gp), 4);
     if (is_err[bool, str](wg)) { ret wg; }
 
     # overflow_arg_area += (8 & ~mask): advance only when the overflow area was used.
@@ -4332,7 +4361,7 @@ fun lower_va_arg(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: i
     var new_ov: u32 = MIR_VREG_NIL;
     val no: Result[bool, str] = emit_alu3(ctx, mb, MIR_ADD, op_vreg(ovf), op_vreg(step_ov), 8, ?new_ov);
     if (is_err[bool, str](no)) { ret no; }
-    val wo: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, sysv.VA_OVERFLOW_ARG_AREA), op_vreg(new_ov), 8);
+    val wo: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, vmodel.overflow_field), op_vreg(new_ov), 8);
     if (is_err[bool, str](wo)) { ret wo; }
 
     # result = load.T [addr], at the result type's width.
@@ -4368,18 +4397,19 @@ fun lower_va_arg(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: i
 #   result = fmov.T [addr]                    (MOVSS / MOVSD into the FP-class dst)
 # the address arithmetic / select runs in GP vregs; only the final load is a float
 # move so the value lands in the XMM-classed result vreg.
-fun lower_va_arg_fp(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, dst: u32) Result[bool, str] {
+fun lower_va_arg_fp(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, dst: u32,
+                    model: *abi.VaModel) Result[bool, str] {
     val apbase: MirOperand = mem_operand_of(ctx, inst.operands[0]);
 
     # fp = load.i32 [ap + fp_offset].
     var fp: u32 = MIR_VREG_NIL;
-    val lf: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_FP_OFFSET), 4, ?fp);
+    val lf: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, model.fp_offset_field), 4, ?fp);
     if (is_err[bool, str](lf)) { ret lf; }
 
     # in_reg = fp < fp_offset_max  (u32 compare -> i8 boolean).
     var in_reg: u32 = MIR_VREG_NIL;
     val cr: Result[bool, str] = emit_alu3(ctx, mb, MIR_CMP_LT_U, op_vreg(fp),
-        op_imm(sysv.va_fp_offset_max()::i64), 4, ?in_reg);
+        op_imm(model.fp_offset_max::i64), 4, ?in_reg);
     if (is_err[bool, str](cr)) { ret cr; }
 
     # mask = 0 - zext(in_reg)  -> 0 or 0xFFFFFFFFFFFFFFFF (64-bit).
@@ -4395,7 +4425,7 @@ fun lower_va_arg_fp(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, dst
 
     # reg_addr = reg_save_area + zext(fp).
     var rsa: u32 = MIR_VREG_NIL;
-    val lr: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_REG_SAVE_AREA), 8, ?rsa);
+    val lr: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, model.reg_save_field), 8, ?rsa);
     if (is_err[bool, str](lr)) { ret lr; }
     var fp64: u32 = MIR_VREG_NIL;
     val fzr: Result[bool, str] = emit_zext_to(ctx, mb, op_vreg(fp), 4, ?fp64);
@@ -4406,7 +4436,7 @@ fun lower_va_arg_fp(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, dst
 
     # ovf = overflow_arg_area.
     var ovf: u32 = MIR_VREG_NIL;
-    val lo: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_OVERFLOW_ARG_AREA), 8, ?ovf);
+    val lo: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, model.overflow_field), 8, ?ovf);
     if (is_err[bool, str](lo)) { ret lo; }
 
     # addr = (reg_addr & mask) | (ovf & ~mask).
@@ -4420,14 +4450,14 @@ fun lower_va_arg_fp(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, dst
     val r3: Result[bool, str] = emit_alu3(ctx, mb, MIR_OR, op_vreg(ra_m), op_vreg(ov_m), 8, ?addr);
     if (is_err[bool, str](r3)) { ret r3; }
 
-    # fp_offset += (16 & mask32): advance by an XMM save stride when a register was used.
+    # fp_offset += (stride & mask32): advance by the per-XMM save stride when a register was used.
     var step_fp: u32 = MIR_VREG_NIL;
-    val sf: Result[bool, str] = emit_alu3(ctx, mb, MIR_AND, op_imm(16), op_vreg(mask), 4, ?step_fp);
+    val sf: Result[bool, str] = emit_alu3(ctx, mb, MIR_AND, op_imm(model.fp_save_stride::i64), op_vreg(mask), 4, ?step_fp);
     if (is_err[bool, str](sf)) { ret sf; }
     var new_fp: u32 = MIR_VREG_NIL;
     val nf: Result[bool, str] = emit_alu3(ctx, mb, MIR_ADD, op_vreg(fp), op_vreg(step_fp), 4, ?new_fp);
     if (is_err[bool, str](nf)) { ret nf; }
-    val wf: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, sysv.VA_FP_OFFSET), op_vreg(new_fp), 4);
+    val wf: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, model.fp_offset_field), op_vreg(new_fp), 4);
     if (is_err[bool, str](wf)) { ret wf; }
 
     # overflow_arg_area += (8 & ~mask): advance by one eightbyte when the overflow area was used.
@@ -4437,7 +4467,7 @@ fun lower_va_arg_fp(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, dst
     var new_ov: u32 = MIR_VREG_NIL;
     val no: Result[bool, str] = emit_alu3(ctx, mb, MIR_ADD, op_vreg(ovf), op_vreg(step_ov), 8, ?new_ov);
     if (is_err[bool, str](no)) { ret no; }
-    val wo: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, sysv.VA_OVERFLOW_ARG_AREA), op_vreg(new_ov), 8);
+    val wo: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, model.overflow_field), op_vreg(new_ov), 8);
     if (is_err[bool, str](wo)) { ret wo; }
 
     # result = fmov.T [addr]: a float move so the value lands in the XMM-classed dst.
@@ -4470,7 +4500,8 @@ fun lower_va_arg_fp(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, dst
 #   gp_offset         += (gp_bytes      & mask32)
 #   overflow_arg_area  = (overflow & mask) | ((ovf_al + stack_slot_bytes(size)) & ~mask)
 #   copy size bytes from [src] into the result storage
-fun lower_va_arg_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, dst: u32) Result[bool, str] {
+fun lower_va_arg_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, dst: u32,
+                           model: *abi.VaModel) Result[bool, str] {
     val rok: Result[bool, str] = require_abi(ctx.tgt);
     if (is_err[bool, str](rok)) { ret rok; }
 
@@ -4496,11 +4527,11 @@ fun lower_va_arg_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instructi
 
     # gp = load.i32 [ap + gp_offset].
     var gp: u32 = MIR_VREG_NIL;
-    val lg: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_GP_OFFSET), 4, ?gp);
+    val lg: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, model.gp_offset_field), 4, ?gp);
     if (is_err[bool, str](lg)) { ret lg; }
 
     # in_reg = gp < (gp_offset_max - gp_bytes + 1): the operand's eightbytes all fit.
-    val thr: i64 = sysv.va_gp_offset_max()::i64 - gp_bytes + 1;
+    val thr: i64 = model.gp_offset_max::i64 - gp_bytes + 1;
     var in_reg: u32 = MIR_VREG_NIL;
     val cr: Result[bool, str] = emit_alu3(ctx, mb, MIR_CMP_LT_U, op_vreg(gp), op_imm(thr), 4, ?in_reg);
     if (is_err[bool, str](cr)) { ret cr; }
@@ -4518,7 +4549,7 @@ fun lower_va_arg_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instructi
 
     # reg_base = reg_save_area + zext(gp).
     var rsa: u32 = MIR_VREG_NIL;
-    val lr: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_REG_SAVE_AREA), 8, ?rsa);
+    val lr: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, model.reg_save_field), 8, ?rsa);
     if (is_err[bool, str](lr)) { ret lr; }
     var gp64: u32 = MIR_VREG_NIL;
     val gzr: Result[bool, str] = emit_zext_to(ctx, mb, op_vreg(gp), 4, ?gp64);
@@ -4540,7 +4571,7 @@ fun lower_va_arg_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instructi
 
     # ovf = overflow_arg_area; ovf_al = (ovf + 7) & ~7 (eight-byte granular overflow).
     var ovf: u32 = MIR_VREG_NIL;
-    val lo: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_OVERFLOW_ARG_AREA), 8, ?ovf);
+    val lo: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, model.overflow_field), 8, ?ovf);
     if (is_err[bool, str](lo)) { ret lo; }
     var ovf_up: u32 = MIR_VREG_NIL;
     val au: Result[bool, str] = emit_alu3(ctx, mb, MIR_ADD, op_vreg(ovf), op_imm(7), 8, ?ovf_up);
@@ -4567,7 +4598,7 @@ fun lower_va_arg_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instructi
     var new_gp: u32 = MIR_VREG_NIL;
     val ng: Result[bool, str] = emit_alu3(ctx, mb, MIR_ADD, op_vreg(gp), op_vreg(step_gp), 4, ?new_gp);
     if (is_err[bool, str](ng)) { ret ng; }
-    val wg: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, sysv.VA_GP_OFFSET), op_vreg(new_gp), 4);
+    val wg: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, model.gp_offset_field), op_vreg(new_gp), 4);
     if (is_err[bool, str](wg)) { ret wg; }
 
     # overflow_arg_area = (ovf & mask) | ((ovf_al + stack_slot_bytes(size)) & ~mask):
@@ -4587,7 +4618,7 @@ fun lower_va_arg_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instructi
     var new_ovf: u32 = MIR_VREG_NIL;
     val ok3: Result[bool, str] = emit_alu3(ctx, mb, MIR_OR, op_vreg(ovf_keep), op_vreg(ovf_take), 8, ?new_ovf);
     if (is_err[bool, str](ok3)) { ret ok3; }
-    val wo: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, sysv.VA_OVERFLOW_ARG_AREA), op_vreg(new_ovf), 8);
+    val wo: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, model.overflow_field), op_vreg(new_ovf), 8);
     if (is_err[bool, str](wo)) { ret wo; }
 
     # copy the aggregate's bytes from the selected source into the result storage.

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -3851,25 +3851,27 @@ fun lower_params(ctx: *LowerCtx, mb: *MirBlock) Result[bool, str] {
 # — see `lower_params`).
 fun emit_param_slot(ctx: *LowerCtx, mb: *MirBlock, slot: abi.ParamSlot, pv: u32, size: u64,
                     stack_off: i64, is_aggr: bool) Result[bool, str] {
+    # incoming stack parameters are addressed off the ISA's frame pointer at the
+    # arch's incoming-argument base (`[fp + incoming_arg_base + off]`), both named
+    # through the ISA vtable rather than bare literals.
+    val arg_base: i64 = ctx.tgt.arch.incoming_arg_base;
     if (slot.class == abi.CLASS_STACK_BYREF) {
         # win64 by-reference overflow: the caller stored the hidden aggregate
         # pointer into this stack slot; load it so `pv` is the aggregate's address,
         # matching the register BYREF parameter form.
         val fp: u32 = ctx.tgt.arch.frame_ptr_reg::u32;
-        ret emit_mov(ctx, mb, op_vreg(pv), op_mem_preg(fp, 16 + stack_off));
+        ret emit_mov(ctx, mb, op_vreg(pv), op_mem_preg(fp, arg_base + stack_off));
     }
     if (slot.class == abi.CLASS_STACK) {
-        # incoming stack parameters are addressed off the ISA's frame pointer
-        # (x86-64 RBP), named through `tgt.arch.frame_ptr_reg` rather than a literal.
         val fp: u32 = ctx.tgt.arch.frame_ptr_reg::u32;
         if (is_aggr) {
             # the aggregate's bytes already sit in the caller's by-value stack copy;
             # `pv` is its address so reads / the local copy index it directly.
-            ret emit_lea_preg(ctx, mb, pv, fp, 16 + stack_off);
+            ret emit_lea_preg(ctx, mb, pv, fp, arg_base + stack_off);
         }
         # a scalar stack argument lives above the return address and saved frame
         # pointer, addressed through the physical frame pointer at the running offset.
-        ret emit_mov(ctx, mb, op_vreg(pv), op_mem_preg(fp, 16 + stack_off));
+        ret emit_mov(ctx, mb, op_vreg(pv), op_mem_preg(fp, arg_base + stack_off));
     }
     if (slot.class == abi.CLASS_BYREF) {
         ret emit_mov(ctx, mb, op_vreg(pv), op_preg(slot.reg::u32));
@@ -4015,7 +4017,7 @@ fun emit_va_save_prologue(ctx: *LowerCtx, mb: *MirBlock) Result[bool, str] {
     if (is_err[bool, str](cls)) { ret cls; }
     ctx.va_named_gp     = layout.gp_used;
     ctx.va_named_fp     = layout.fp_used;
-    ctx.va_overflow_off = 16 + layout.stack_off;
+    ctx.va_overflow_off = ctx.tgt.arch.incoming_arg_base + layout.stack_off;
     sig_layout_free(ctx, ?layout);
     ctx.va_active = true;
 

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -3086,6 +3086,118 @@ fun value_is_aggregate(ctx: *LowerCtx, ty: ir_type.IrTypeId) bool {
     ret ir_type.is_aggregate(ctx.types, ty);
 }
 
+# per-eightbyte SysV class tags used while classifying an aggregate's eightbytes.
+# the merge keeps the higher tag, so INTEGER dominates SSE dominates NO_CLASS: an
+# eightbyte is SSE only when every field that overlaps it is floating-point.
+val EB_NO_CLASS: u8 = 0;
+val EB_SSE:      u8 = 1;
+val EB_INTEGER:  u8 = 2;
+
+# mark_eightbyte_range: merge class `cls` into every eightbyte the byte range
+# `[off, off+size)` overlaps (only eightbytes 0 and 1 are tracked — a ≤16 byte
+# aggregate has at most two). the merge keeps the dominant tag.
+fun mark_eightbyte_range(classes: *u8, off: u64, size: u64, cls: u8) {
+    if (size == 0) { ret; }
+    var e: u64 = off / 8;
+    val last: u64 = (off + size - 1) / 8;
+    for (e <= last) {
+        if (e < 2) {
+            if (cls > classes[e]) { classes[e] = cls; }
+        }
+        e = e + 1;
+    }
+}
+
+# mark_eightbyte_classes: recursively classify each leaf scalar of an aggregate
+# type into the eightbyte(s) it occupies, starting at absolute byte offset
+# `base_off`. a float leaf marks its eightbytes SSE; an integer / pointer / function
+# leaf marks them INTEGER; structs recurse at each field offset, unions at offset 0
+# (members overlap), arrays at each element offset. `classes[0..1]` accumulate the
+# merged per-eightbyte class for the SysV SSE-aggregate classification.
+fun mark_eightbyte_classes(ctx: *LowerCtx, ty: ir_type.IrTypeId, base_off: u64, classes: *u8) {
+    val it: Option[*ir_type.IrType] = ir_type.get(ctx.types, ty);
+    if (!is_some[*ir_type.IrType](it)) { ret; }
+    val t: *ir_type.IrType = unwrap[*ir_type.IrType](it);
+
+    if (t.kind == ir_type.IRT_FLOAT) {
+        mark_eightbyte_range(classes, base_off, ir_type.byte_size(ctx.types, ty, ctx.tgt)::u64, EB_SSE);
+        ret;
+    }
+    if (t.kind == ir_type.IRT_STRUCT) {
+        var i: u32 = 0;
+        for (i < t.data.struct_.field_count) {
+            val fid: ir_type.IrTypeId = t.data.struct_.fields[i];
+            val fo:  u64 = ir_type.byte_offset(ctx.types, ty, i, ctx.tgt)::u64;
+            mark_eightbyte_classes(ctx, fid, base_off + fo, classes);
+            i = i + 1;
+        }
+        ret;
+    }
+    if (t.kind == ir_type.IRT_UNION) {
+        # union members all overlap at offset 0; merge each member's classes.
+        var i: u32 = 0;
+        for (i < t.data.struct_.field_count) {
+            mark_eightbyte_classes(ctx, t.data.struct_.fields[i], base_off, classes);
+            i = i + 1;
+        }
+        ret;
+    }
+    if (t.kind == ir_type.IRT_ARRAY) {
+        val elem: ir_type.IrTypeId = t.data.element;
+        val es:   u64 = ir_type.byte_size(ctx.types, elem, ctx.tgt)::u64;
+        val n:    u32 = ir_type.array_count(ctx.types, ty);
+        var i: u32 = 0;
+        for (i < n) {
+            mark_eightbyte_classes(ctx, elem, base_off + i::u64 * es, classes);
+            i = i + 1;
+        }
+        ret;
+    }
+    # integer / pointer / function leaf: an INTEGER-class eightbyte.
+    mark_eightbyte_range(classes, base_off, ir_type.byte_size(ctx.types, ty, ctx.tgt)::u64, EB_INTEGER);
+}
+
+# aggregate_sse_mask: the per-eightbyte SSE mask for a ≤16 byte aggregate type — bit
+# `e` set when eightbyte `e` is SSE class (every overlapping field floating-point),
+# which the SysV classifier uses to place that eightbyte in a vector register. 0 for
+# a non-aggregate or a >16 byte aggregate (which is byref/sret, so the mask is
+# unused).
+fun aggregate_sse_mask(ctx: *LowerCtx, ty: ir_type.IrTypeId) u8 {
+    if (!value_is_aggregate(ctx, ty)) { ret 0; }
+    val size: u64 = ir_type.byte_size(ctx.types, ty, ctx.tgt)::u64;
+    if (size == 0 || size > 16) { ret 0; }
+    var classes: [2]u8;
+    classes[0] = EB_NO_CLASS;
+    classes[1] = EB_NO_CLASS;
+    mark_eightbyte_classes(ctx, ty, 0, ?classes[0]);
+    var mask: u8 = 0;
+    if (classes[0] == EB_SSE) { mask = mask | 1; }
+    if (classes[1] == EB_SSE) { mask = mask | 2; }
+    ret mask;
+}
+
+# advance_one_cursor: advance the GP or FP argument-register cursor for one assigned
+# register, dispatching on the register's bank (the composite id encodes it). a
+# negative id (no register) advances neither. so a register aggregate's GP and SSE
+# eightbytes each consume from the right file.
+fun advance_one_cursor(reg: i32, gp_used: *i32, fp_used: *i32) {
+    if (reg < 0) { ret; }
+    if (isa.regid_class(reg) == isa.REG_CLASS_ID_XMM) {
+        @fp_used = @fp_used + 1;
+    } or {
+        @gp_used = @gp_used + 1;
+    }
+}
+
+# advance_arg_cursors: advance the GP / FP cursors for a register-passed slot by the
+# bank of each register it occupies (`reg` and, for a two-register aggregate, `reg2`),
+# so a scalar, a by-reference pointer, and a mixed GP/SSE aggregate each consume the
+# correct registers. stack slots carry no register and advance neither.
+fun advance_arg_cursors(slot: *abi.ParamSlot, gp_used: *i32, fp_used: *i32) {
+    advance_one_cursor(slot.reg, gp_used, fp_used);
+    advance_one_cursor(slot.reg2, gp_used, fp_used);
+}
+
 # emit_mov: append a `MIR_MOV (dst) <- (src)` to a block. used for every ABI
 # pre-coloring move (vreg<->preg, imm->preg) as well as plain vreg copies. driven
 # at the machine-word width: a scalar argument / return / hidden-pointer value
@@ -3226,7 +3338,8 @@ fun classify_signature(ctx: *LowerCtx, sig: ir_type.IrTypeId, ret_ty: ir_type.Ir
     val ret_size:  u64  = ir_type.byte_size(ctx.types, ret_ty, ctx.tgt)::u64;
     val ret_float: bool = value_is_float(ctx, ret_ty);
     val ret_aggr:  bool = value_is_aggregate(ctx, ret_ty);
-    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_aggr);
+    val ret_eb:    u8   = aggregate_sse_mask(ctx, ret_ty);
+    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr);
 
     var gp_used:   i32 = 0;
     var fp_used:   i32 = 0;
@@ -3273,23 +3386,21 @@ fun classify_signature(ctx: *LowerCtx, sig: ir_type.IrTypeId, ret_ty: ir_type.Ir
         val psz:  u64  = ir_type.byte_size(ctx.types, pty, ctx.tgt)::u64;
         val pfl:  bool = value_is_float(ctx, pty);
         val pag:  bool = value_is_aggregate(ctx, pty);
-        var slot: abi.ParamSlot = classify_arg(pi::i32, psz, 0, pfl, pag, gp_used, fp_used);
+        val peb:  u8   = aggregate_sse_mask(ctx, pty);
+        var slot: abi.ParamSlot = classify_arg(pi::i32, psz, 0, pfl, peb, pag, gp_used, fp_used);
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering
         # read this instead of re-deriving a parallel cursor. a byref stack spill
         # occupies the same eight-byte slot as a by-value one — only its contents
-        # (a hidden pointer) differ — so it advances the cursor identically.
+        # (a hidden pointer) differ — so it advances the cursor identically. a
+        # register slot advances each assigned register's bank cursor (a mixed
+        # GP/SSE aggregate consumes one of each).
         if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
             slot.offset = stack_off;
             stack_off   = stack_off + stack_slot_bytes(slot.size);
-        } or (slot.class == abi.CLASS_FP) {
-            fp_used = fp_used + 1;
-        } or (slot.class == abi.CLASS_GP) {
-            gp_used = gp_used + 1;
-            if (slot.reg2 >= 0) { gp_used = gp_used + 1; }
-        } or (slot.class == abi.CLASS_BYREF) {
-            gp_used = gp_used + 1;
+        } or {
+            advance_arg_cursors(?slot, ?gp_used, ?fp_used);
         }
 
         slots[pi] = slot;
@@ -3422,7 +3533,11 @@ fun lower_call(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
             val asz:  u64  = ir_type.byte_size(ctx.types, av.ty, ctx.tgt)::u64;
             val afl:  bool = value_is_float(ctx, av.ty);
             val aag:  bool = value_is_aggregate(ctx, av.ty);
-            slot = classify_arg(pidx::i32, asz, 0, afl, aag, gp_used, fp_used);
+            # a variadic tail aggregate is classified as integer eightbytes (mask 0):
+            # the va_arg read path walks the GP register-save / overflow areas, so the
+            # caller and callee stay consistent. SSE-eightbyte aggregate passing is for
+            # fixed parameters and returns (the C-FFI boundary), not the varargs tail.
+            slot = classify_arg(pidx::i32, asz, 0, afl, 0, aag, gp_used, fp_used);
             soff = stack_off;
         }
 
@@ -3470,17 +3585,13 @@ fun lower_call(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
         }
 
         # advance the running cursors only for the variadic tail; the fixed-param
-        # cursors were already consumed by `classify_signature`.
+        # cursors were already consumed by `classify_signature`. a register slot
+        # advances each assigned register's bank; a stack slot advances the offset.
         if (pidx >= layout.param_count) {
-            if (slot.class == abi.CLASS_FP) {
-                fp_used = fp_used + 1;
-            } or (slot.class == abi.CLASS_GP) {
-                gp_used = gp_used + 1;
-                if (slot.reg2 >= 0) { gp_used = gp_used + 1; }
-            } or (slot.class == abi.CLASS_BYREF) {
-                gp_used = gp_used + 1;
-            } or (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
+            if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
                 stack_off = stack_off + stack_slot_bytes(slot.size);
+            } or {
+                advance_arg_cursors(?slot, ?gp_used, ?fp_used);
             }
         }
 
@@ -4515,7 +4626,7 @@ fun lower_va_arg_aggregate(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instructi
     # gp_used — decides registers vs overflow below.
     val classify_arg: abi.ArgPassingFn = ctx.tgt.abi.arg_passing::abi.ArgPassingFn;
     val align: u64 = ir_type.byte_align(ctx.types, inst.ty, ctx.tgt)::u64;
-    val slot:  abi.ParamSlot = classify_arg(0, size, align, false, true, 0, 0);
+    val slot:  abi.ParamSlot = classify_arg(0, size, align, false, 0, true, 0, 0);
     val byref: bool = slot.class == abi.CLASS_BYREF;
     var gp_bytes: i64 = 8;
     if (!byref && slot.reg2 >= 0) { gp_bytes = 16; }
@@ -4665,7 +4776,7 @@ fun lower_va_arg_home(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, d
         # classify the aggregate to learn whether the slot holds it by value or a
         # hidden pointer to it.
         val classify_arg: abi.ArgPassingFn = ctx.tgt.abi.arg_passing::abi.ArgPassingFn;
-        val slot: abi.ParamSlot = classify_arg(0, size, align, false, true, 0, 0);
+        val slot: abi.ParamSlot = classify_arg(0, size, align, false, 0, true, 0, 0);
         val byref: bool = slot.class == abi.CLASS_BYREF;
 
         # back the result vreg with caller-owned storage so downstream copies / stores

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -36,6 +36,7 @@ use maphash: std.collections.map;
 use sess:     mach.lang.session;
 use src:      mach.lang.source;
 use target:   mach.lang.target.resolved;
+use abi:      mach.lang.target.abi;
 use ty:       mach.lang.type;
 use intern:   mach.lang.intern;
 
@@ -660,10 +661,10 @@ pub fun lower_type(lc: *LowerContext, tid: ty.TypeId) Result[ir_type.IrTypeId, s
     if (k == ty.TYPE_PTR)                     { ret ir_type.intern_ptr(?lc.m.types); }
     if (k == ty.TYPE_POINTER)                 { ret ir_type.intern_ptr(?lc.m.types); }
 
-    # `va_list` is the AMD64 `__va_list_tag` register-save struct:
-    # { gp_offset: u32, fp_offset: u32, overflow_arg_area: ptr, reg_save_area: ptr }
-    # (size 24, align 8). it lowers to that concrete IR struct so storage sizing,
-    # field addressing, and by-address flow reuse the ordinary aggregate path.
+    # `va_list` lowers per the target ABI's variadic save model: the register-save
+    # model (SysV) uses the four-field `__va_list_tag` struct, the home-area model
+    # (win64) a single pointer. dispatching here keeps `$size_of(va_list)`, C-interop
+    # struct layouts, and the scalar-vs-aggregate value path correct on every target.
     if (k == ty.TYPE_VA_LIST) {
         ret lower_va_list(lc);
     }
@@ -746,11 +747,20 @@ fun lower_nominal(lc: *LowerContext, tid: ty.TypeId, is_union: bool) Result[ir_t
     ret sr;
 }
 
-# lowers the builtin `va_list` type to the AMD64 `__va_list_tag` IR struct:
-# { i32 gp_offset, i32 fp_offset, ptr overflow_arg_area, ptr reg_save_area }.
-# the field order and types match `target.abi.sysv`'s VA_* offset constants, so
-# the backend's `va_start` / `va_arg` expansion GEPs the right field offsets.
+# lowers the builtin `va_list` type per the target ABI's variadic save model. the
+# register-save model (SysV) lowers it to the AMD64 `__va_list_tag` IR struct
+# { i32 gp_offset, i32 fp_offset, ptr overflow_arg_area, ptr reg_save_area }, whose
+# field order and types match the model's VA_* field offsets so the backend's
+# va_start / va_arg expansion GEPs the right offsets. the home-area model (win64)
+# lowers it to a single pointer — the cursor `va_start` seeds and `va_arg` walks —
+# so `$size_of(va_list)` is 8 (not 24) and a C-interop struct embedding it lays out
+# correctly. the model is read from the selected target's ABI vtable.
 fun lower_va_list(lc: *LowerContext) Result[ir_type.IrTypeId, str] {
+    val model: abi.VaModelFn = lc.tgt.abi.va_model::abi.VaModelFn;
+    val m: abi.VaModel = model();
+    if (m.kind == abi.VA_MODEL_HOME) {
+        ret ir_type.intern_ptr(?lc.m.types);
+    }
     var buf: [4]ir_type.IrTypeId;
     val i32r: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?lc.m.types, 32);
     if (is_err[ir_type.IrTypeId, str](i32r)) { ret i32r; }

--- a/src/lang/me/lower/testrunner.mach
+++ b/src/lang/me/lower/testrunner.mach
@@ -45,6 +45,8 @@ use maphash: std.collections.map;
 
 use intern: mach.lang.intern;
 use sess:   mach.lang.session;
+use rtgt:   mach.lang.target.resolved;
+use os:     mach.lang.target.os;
 
 use ir:      mach.lang.me.ir;
 use ir_type: mach.lang.me.ir.type;
@@ -63,6 +65,7 @@ rec Test {
 rec Ctx {
     s:    *sess.Session;
     m:    *ir.Module;
+    tgt:  *rtgt.Target;
     b:    builder.Builder;
     i32:  ir_type.IrTypeId;
     i64:  ir_type.IrTypeId;
@@ -78,8 +81,11 @@ rec Ctx {
 # synthesize: build the test-runner IR module from the test functions spread
 # across `modules[0..count)`. returns none when the build has no tests (the
 # caller keeps the project's own `main`); otherwise a fresh unoptimised IR
-# module whose `main` is the runner.
-pub fun synthesize(s: *sess.Session, modules: *ir.Module, count: u32) Result[Option[ir.Module], str] {
+# module whose `main` is the runner. `tgt` is the selected target — the runner's
+# output write primitive is sourced from its OS vtable so the runner is not
+# structurally single-platform; a target with no freestanding runner write fails
+# loudly.
+pub fun synthesize(s: *sess.Session, tgt: *rtgt.Target, modules: *ir.Module, count: u32) Result[Option[ir.Module], str] {
     var tests:    *Test = nil;
     var test_len: u32   = 0;
     var test_cap: u32   = 0;
@@ -108,7 +114,7 @@ pub fun synthesize(s: *sess.Session, modules: *ir.Module, count: u32) Result[Opt
     }
     var m: ir.Module = unwrap_ok[ir.Module, str](mod_r);
 
-    val br: Result[bool, str] = build_runner(s, ?m, tests, test_len);
+    val br: Result[bool, str] = build_runner(s, tgt, ?m, tests, test_len);
     free_tests(s, tests, test_cap);
     if (is_err[bool, str](br)) {
         ir.dnit_module(?m);
@@ -198,10 +204,11 @@ fun push_test(s: *sess.Session, tests: **Test, test_len: *u32, test_cap: *u32, t
 }
 
 # build_runner: emit the inline-asm write helper, then `main`.
-fun build_runner(s: *sess.Session, m: *ir.Module, tests: *Test, test_len: u32) Result[bool, str] {
+fun build_runner(s: *sess.Session, tgt: *rtgt.Target, m: *ir.Module, tests: *Test, test_len: u32) Result[bool, str] {
     var c: Ctx;
     c.s = s;
     c.m = m;
+    c.tgt = tgt;
     c.b = builder.init(m);
 
     val r32: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 32);
@@ -377,9 +384,19 @@ fun anon_name(c: *Ctx, idx: u32) Result[intern.StrId, str] {
 }
 
 # emit_write_helper: a `void __mach_test_write(buf: *u8, len: i64)` whose body is
-# a single inline-asm `write(1, buf, len)` syscall. all the runner's output flows
-# through here so no other function touches the OS.
+# the target's freestanding write primitive (`write(1, buf, len)` on Linux). all
+# the runner's output flows through here so no other function touches the OS. the
+# primitive — body text and OP_ASM arch tag — is read from the selected target's OS
+# vtable for the resolved architecture; a target with no freestanding runner write
+# (Darwin, Windows) is a loud error rather than a wrong-OS output sequence.
 fun emit_write_helper(c: *Ctx) Result[bool, str] {
+    val wfn: os.RunnerWriteFn = c.tgt.os.runner_write::os.RunnerWriteFn;
+    val spec_o: Option[os.RunnerWrite] = wfn(c.tgt.arch_id);
+    if (is_none[os.RunnerWrite](spec_o)) {
+        ret err[bool, str]("mach test: the selected target has no freestanding test-runner write primitive (only linux/x86_64 is supported; the windows/darwin runner is tracked by #1292)");
+    }
+    val spec: os.RunnerWrite = unwrap[os.RunnerWrite](spec_o);
+
     val nm_r: Result[intern.StrId, str] = intern.intern(?c.s.interner, "__mach_test_write");
     if (is_err[intern.StrId, str](nm_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](nm_r)); }
 
@@ -391,19 +408,17 @@ fun emit_write_helper(c: *Ctx) Result[bool, str] {
     if (is_err[u32, str](idx_r)) { ret err[bool, str](unwrap_err[u32, str](idx_r)); }
     c.write_fn = unwrap_ok[u32, str](idx_r);
 
-    val asm_r: Result[bool, str] = emit_asm_block(c,
-        "mov rax, 1\nmov rdi, 1\nmov rsi, {buf}\nmov rdx, {len}\nsyscall\n",
-        ?slots[0], 2);
+    val asm_r: Result[bool, str] = emit_asm_block(c, spec.isa_tag, spec.body, ?slots[0], 2);
     if (is_err[bool, str](asm_r)) { ret err[bool, str](unwrap_err[bool, str](asm_r)); }
 
     ret builder.emit_ret_void(?c.b);
 }
 
-# emit_asm_block: append an OP_ASM instruction with isa tag `x86_64` and the
+# emit_asm_block: append an OP_ASM instruction with the target's `isa_tag` and the
 # given body, binding the `{name}` references in declaration order (`buf`, then
 # `len`) to the supplied param alloca slots.
-fun emit_asm_block(c: *Ctx, body: str, slots: *value.Value, slot_count: u32) Result[bool, str] {
-    val isa_r: Result[intern.StrId, str] = intern.intern(?c.s.interner, "x86_64");
+fun emit_asm_block(c: *Ctx, isa_tag: str, body: str, slots: *value.Value, slot_count: u32) Result[bool, str] {
+    val isa_r: Result[intern.StrId, str] = intern.intern(?c.s.interner, isa_tag);
     if (is_err[intern.StrId, str](isa_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](isa_r)); }
     val body_r: Result[intern.StrId, str] = intern.intern(?c.s.interner, body);
     if (is_err[intern.StrId, str](body_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](body_r)); }

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -77,15 +77,30 @@ pub fun host_pointer_width() u32 {
     ret ($mach.target.pointer_width)::u32;
 }
 
-# canonical_abi: the ABI id paired with an operating system. SysV is the
-# convention on Linux and Darwin; Win64 on Windows. independent of arch.
+# canonical_abi: the ABI id paired with an (operating system, architecture) pair.
+# the convention depends on BOTH dimensions: x86-64 uses SysV on Linux/Darwin and
+# Win64 on Windows, while AArch64 uses AAPCS64 everywhere (the Apple/MS variants
+# reduce to AAPCS64 for selection). a pair with no canonical mapping yields
+# `abi.ABI_UNKNOWN`, which makes `select` fail loudly rather than composing the
+# wrong convention — so `select(OS_LINUX, ARCH_AARCH64)` never silently builds the
+# x86-64 SysV vtable.
 # ---
-# os_id: operating-system id
-# ret:   the canonical abi id (abi.ABI_UNKNOWN if the os is unknown)
-fun canonical_abi(os_id: u32) u32 {
-    if (os_id == os.OS_LINUX)   { ret abi.ABI_SYSV; }
-    if (os_id == os.OS_DARWIN)  { ret abi.ABI_SYSV; }
-    if (os_id == os.OS_WINDOWS) { ret abi.ABI_WIN64; }
+# os_id:   operating-system id
+# arch_id: architecture id (one of isa.ARCH_*)
+# ret:     the canonical abi id (abi.ABI_UNKNOWN if the pair is unsupported)
+fun canonical_abi(os_id: u32, arch_id: u32) u32 {
+    if (arch_id == isa.ARCH_X86_64) {
+        if (os_id == os.OS_LINUX)   { ret abi.ABI_SYSV; }
+        if (os_id == os.OS_DARWIN)  { ret abi.ABI_SYSV; }
+        if (os_id == os.OS_WINDOWS) { ret abi.ABI_WIN64; }
+        ret abi.ABI_UNKNOWN;
+    }
+    if (arch_id == isa.ARCH_AARCH64) {
+        if (os_id == os.OS_LINUX)   { ret abi.ABI_AAPCS64; }
+        if (os_id == os.OS_DARWIN)  { ret abi.ABI_AAPCS64; }
+        if (os_id == os.OS_WINDOWS) { ret abi.ABI_AAPCS64; }
+        ret abi.ABI_UNKNOWN;
+    }
     ret abi.ABI_UNKNOWN;
 }
 
@@ -152,19 +167,19 @@ pub fun register_all(i: *intern.Interner) Result[bool, str] {
 
 # select: compose a Target for an (os, arch) pair.
 #
-# resolves the canonical ABI and object format for the operating system, then
-# looks up all four vtables from the process-global registries that the
-# implementations self-register into. allocates nothing — every vtable pointer
-# is borrowed. fails if the pair has no canonical mapping or if any required
-# implementation is not registered.
+# resolves the canonical ABI for the (os, arch) pair and the object format for the
+# operating system, then looks up all four vtables from the process-global
+# registries that the implementations self-register into. allocates nothing —
+# every vtable pointer is borrowed. fails if the pair has no canonical mapping or
+# if any required implementation is not registered.
 # ---
 # os_id:   operating-system id (one of os.OS_*)
 # arch_id: architecture id (one of isa.ARCH_*)
 # ret:     the composed Target, or an error describing the missing piece
 pub fun select(os_id: u32, arch_id: u32) Result[tdef.Target, str] {
-    val abi_id: u32 = canonical_abi(os_id);
+    val abi_id: u32 = canonical_abi(os_id, arch_id);
     if (abi_id == abi.ABI_UNKNOWN) {
-        ret err[tdef.Target, str]("unsupported operating system");
+        ret err[tdef.Target, str]("unsupported (operating system, architecture) pair");
     }
     val of_id: u32 = canonical_of(os_id);
     if (of_id == of.OF_UNKNOWN) {

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -23,6 +23,10 @@ use isa:    mach.lang.target.isa;
 pub val ABI_UNKNOWN: u32 = 0;
 pub val ABI_SYSV:    u32 = 1;
 pub val ABI_WIN64:   u32 = 2;
+# AArch64 AAPCS64. reserved now so `target.select` resolves an (os, aarch64) pair
+# to it and fails loudly at `abi.lookup` until the AAPCS64 implementation (#1045)
+# registers — never silently composing the x86-64 SysV vtable for an arm64 target.
+pub val ABI_AAPCS64: u32 = 3;
 
 # how a single parameter or return value is classified for passing.
 pub def ParamClass: u8;
@@ -71,9 +75,10 @@ pub rec ParamSlot {
 # per-ABI implementation aliases these (e.g. `sysv.RegFileFn`) for local use.
 
 # classify one value into a placement decision. `gp_used` / `fp_used` are the GP
-# and FP registers already consumed by earlier arguments.
+# and FP registers already consumed by earlier arguments. the implementation is
+# arch-specific by selection (`target.select` composes an (os, arch)-keyed vtable),
+# so the classifier carries no `arch_id`.
 # ---
-# arch_id:      architecture id (one of isa.ARCH_*)
 # size:         value size in bytes
 # align:        value alignment in bytes
 # is_float:     true if the value is FP-register-eligible
@@ -81,12 +86,12 @@ pub rec ParamSlot {
 # gp_used:      GP registers already consumed
 # fp_used:      FP registers already consumed
 # ret:          the placement decision
-pub def ClassifyFn: fun(u32, u64, u64, bool, bool, i32, i32) ParamSlot;
+pub def ClassifyFn: fun(u64, u64, bool, bool, i32, i32) ParamSlot;
 
 # assign the registers or stack slot for a single argument, given the GP/FP usage
-# counters the caller tracks across the call's argument list.
+# counters the caller tracks across the call's argument list. arch-specific by
+# selection, so no `arch_id` is threaded.
 # ---
-# arch_id:      architecture id (one of isa.ARCH_*)
 # index:        zero-based logical argument position
 # size:         argument size in bytes
 # align:        argument alignment in bytes
@@ -95,17 +100,17 @@ pub def ClassifyFn: fun(u32, u64, u64, bool, bool, i32, i32) ParamSlot;
 # gp_used:      GP registers already consumed
 # fp_used:      FP registers already consumed
 # ret:          the placement decision
-pub def ArgPassingFn: fun(u32, i32, u64, u64, bool, bool, i32, i32) ParamSlot;
+pub def ArgPassingFn: fun(i32, u64, u64, bool, bool, i32, i32) ParamSlot;
 
-# assign the registers or sret slot for a return value.
+# assign the registers or sret slot for a return value. arch-specific by
+# selection, so no `arch_id` is threaded.
 # ---
-# arch_id:      architecture id (one of isa.ARCH_*)
 # size:         return-value size in bytes
 # align:        return-value alignment in bytes
 # is_float:     true if the value is returned in FP registers
 # is_aggregate: true if the value is an aggregate
 # ret:          the placement decision
-pub def RetPassingFn: fun(u32, u64, u64, bool, bool) ParamSlot;
+pub def RetPassingFn: fun(u64, u64, bool, bool) ParamSlot;
 
 # fill a caller-owned `out` buffer with a register bank in canonical order and
 # return the count written. the erased `gp_arg_regs` / `fp_arg_regs` /

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -77,40 +77,50 @@ pub rec ParamSlot {
 # classify one value into a placement decision. `gp_used` / `fp_used` are the GP
 # and FP registers already consumed by earlier arguments. the implementation is
 # arch-specific by selection (`target.select` composes an (os, arch)-keyed vtable),
-# so the classifier carries no `arch_id`.
+# so the classifier carries no `arch_id`. `fp_eightbytes` is the per-eightbyte SSE
+# mask the caller computes from the aggregate's field layout — bit `e` set means
+# eightbyte `e` is SSE class (every field overlapping it is floating-point) — so the
+# SysV classifier can place a float-bearing aggregate's SSE eightbytes in vector
+# registers. it is meaningful only for a ≤16 byte aggregate; 0 for scalars and
+# integer-only aggregates.
 # ---
-# size:         value size in bytes
-# align:        value alignment in bytes
-# is_float:     true if the value is FP-register-eligible
-# is_aggregate: true if the value is a record/array (recursively classified)
-# gp_used:      GP registers already consumed
-# fp_used:      FP registers already consumed
-# ret:          the placement decision
-pub def ClassifyFn: fun(u64, u64, bool, bool, i32, i32) ParamSlot;
+# size:          value size in bytes
+# align:         value alignment in bytes
+# is_float:      true if the value is FP-register-eligible
+# fp_eightbytes: per-eightbyte SSE mask (bit e -> eightbyte e is SSE class)
+# is_aggregate:  true if the value is a record/array (recursively classified)
+# gp_used:       GP registers already consumed
+# fp_used:       FP registers already consumed
+# ret:           the placement decision
+pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32) ParamSlot;
 
 # assign the registers or stack slot for a single argument, given the GP/FP usage
 # counters the caller tracks across the call's argument list. arch-specific by
-# selection, so no `arch_id` is threaded.
+# selection, so no `arch_id` is threaded. `fp_eightbytes` is the per-eightbyte SSE
+# mask (see `ClassifyFn`).
 # ---
-# index:        zero-based logical argument position
-# size:         argument size in bytes
-# align:        argument alignment in bytes
-# is_float:     true if the argument goes in FP registers
-# is_aggregate: true if the argument is an aggregate
-# gp_used:      GP registers already consumed
-# fp_used:      FP registers already consumed
-# ret:          the placement decision
-pub def ArgPassingFn: fun(i32, u64, u64, bool, bool, i32, i32) ParamSlot;
+# index:         zero-based logical argument position
+# size:          argument size in bytes
+# align:         argument alignment in bytes
+# is_float:      true if the argument goes in FP registers
+# fp_eightbytes: per-eightbyte SSE mask (bit e -> eightbyte e is SSE class)
+# is_aggregate:  true if the argument is an aggregate
+# gp_used:       GP registers already consumed
+# fp_used:       FP registers already consumed
+# ret:           the placement decision
+pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, i32, i32) ParamSlot;
 
 # assign the registers or sret slot for a return value. arch-specific by
-# selection, so no `arch_id` is threaded.
+# selection, so no `arch_id` is threaded. `fp_eightbytes` is the per-eightbyte SSE
+# mask (see `ClassifyFn`).
 # ---
-# size:         return-value size in bytes
-# align:        return-value alignment in bytes
-# is_float:     true if the value is returned in FP registers
-# is_aggregate: true if the value is an aggregate
-# ret:          the placement decision
-pub def RetPassingFn: fun(u64, u64, bool, bool) ParamSlot;
+# size:          return-value size in bytes
+# align:         return-value alignment in bytes
+# is_float:      true if the value is returned in FP registers
+# fp_eightbytes: per-eightbyte SSE mask (bit e -> eightbyte e is SSE class)
+# is_aggregate:  true if the value is an aggregate
+# ret:           the placement decision
+pub def RetPassingFn: fun(u64, u64, bool, u8, bool) ParamSlot;
 
 # fill a caller-owned `out` buffer with a register bank in canonical order and
 # return the count written. the erased `gp_arg_regs` / `fp_arg_regs` /

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -268,39 +268,71 @@ pub rec SigLayout {
 # VA_MODEL_REG_SAVE (SysV): the prologue spills the GP and FP argument registers
 # into a frame-local register-save area, and `va_list` is the four-field
 # `__va_list_tag` (gp_offset / fp_offset / overflow_arg_area / reg_save_area) the
-# `va_arg` cursors index.
+# `va_arg` cursors index. all the register-save geometry the backend needs — the
+# save-area size, the FP region offset and per-XMM stride, the exhaustion
+# thresholds, and the four `__va_list_tag` field offsets — rides on the model so
+# the backend reads no convention-specific constant from the SysV module.
 #
 # VA_MODEL_HOME (win64): the caller's 32-byte home/shadow space (just above the
-# return address) holds the register arguments; the variadic prologue spills the
-# integer argument registers at/after the last named parameter into their home
-# slots so the named and unnamed arguments form one contiguous stack array, and
-# `va_list` is a single pointer that `va_start` seeds just past the named
-# arguments and `va_arg` walks up by `arg_stride` bytes per argument. win64 has
-# no separate FP save area — a variadic float is passed in both the XMM register
-# and the matching integer register, and `va_arg` reads the integer/stack slot —
-# so `fp_save_count` is 0.
+# return address, at the ISA's `incoming_arg_base`) holds the register arguments;
+# the variadic prologue spills the integer argument registers at/after the last
+# named parameter into their home slots so the named and unnamed arguments form
+# one contiguous stack array, and `va_list` is a single pointer that `va_start`
+# seeds just past the named arguments and `va_arg` walks up by `arg_stride` bytes
+# per argument. win64 has no separate FP save area — a variadic float is passed in
+# both the XMM register and the matching integer register (`float_dup_gp`), and
+# `va_arg` reads the integer/stack slot — so `fp_save_count` is 0.
 pub val VA_MODEL_REG_SAVE: u8 = 0;
 pub val VA_MODEL_HOME:     u8 = 1;
 
 # the variadic-argument save model a calling convention uses. produced by the ABI
 # vtable's `va_model` accessor; the backend dispatches its prologue / va_start /
-# va_arg expansion on `kind` and reads the home-model layout facts from the rest.
+# va_arg expansion on `kind` and reads every convention-specific layout fact from
+# the rest of the model — never from a concrete convention module.
 # ---
-# kind:          one of VA_MODEL_*
-# gp_save_count: GP argument registers the variadic prologue spills (the full file
-#                for REG_SAVE; the home-slot count for HOME)
-# fp_save_count: FP argument registers the prologue spills (REG_SAVE only; 0 for HOME)
-# home_base_off: `[rbp + off]` of the first home/save slot for the HOME model — the
-#                first caller-home slot above the saved frame pointer and return
-#                address (unused by REG_SAVE)
-# arg_stride:    bytes `va_arg` advances the single-pointer cursor per argument for
-#                the HOME model (unused by REG_SAVE)
+# kind:             one of VA_MODEL_*
+# gp_save_count:    GP argument registers the variadic prologue spills (the full
+#                   file for REG_SAVE; the home-slot count for HOME)
+# fp_save_count:    FP argument registers the prologue spills (REG_SAVE only; 0 for
+#                   HOME). also the XMM dump count the AL-guarded spill writes.
+# arg_stride:       bytes `va_arg` advances the single-pointer cursor per argument
+#                   for the HOME model (unused by REG_SAVE)
+# float_dup_gp:     HOME model — a variadic float argument is duplicated into the
+#                   matching integer argument register (the GP register of its
+#                   positional slot) in addition to its XMM register, so a `va_arg`
+#                   reader that only knows the integer/home slots sees it. false for
+#                   REG_SAVE (the FP save area captures floats directly).
+# vector_count_reg: the register a variadic caller sets to the number of vector
+#                   registers the call uses (SysV's AL/RAX, read by the AL-guarded
+#                   FP spill), or -1 when the convention encodes no vector count
+#                   (win64). the pre-call vector-count move is emitted only when
+#                   this is non-negative.
+# save_size:        REG_SAVE — frame-local register-save area size in bytes
+# fp_save_offset:   REG_SAVE — byte offset of the FP dump within the save area
+#                   (after the GP registers)
+# fp_save_stride:   REG_SAVE — per-XMM save/advance stride in bytes (16)
+# gp_offset_max:    REG_SAVE — gp_offset value at which the GP save area is exhausted
+# fp_offset_max:    REG_SAVE — fp_offset value at which the FP save area is exhausted
+# gp_offset_field:  REG_SAVE — `__va_list_tag` byte offset of gp_offset
+# fp_offset_field:  REG_SAVE — `__va_list_tag` byte offset of fp_offset
+# overflow_field:   REG_SAVE — `__va_list_tag` byte offset of overflow_arg_area
+# reg_save_field:   REG_SAVE — `__va_list_tag` byte offset of reg_save_area
 pub rec VaModel {
-    kind:          u8;
-    gp_save_count: i32;
-    fp_save_count: i32;
-    home_base_off: i64;
-    arg_stride:    i64;
+    kind:             u8;
+    gp_save_count:    i32;
+    fp_save_count:    i32;
+    arg_stride:       i64;
+    float_dup_gp:     bool;
+    vector_count_reg: i32;
+    save_size:        u64;
+    fp_save_offset:   u64;
+    fp_save_stride:   u64;
+    gp_offset_max:    u32;
+    fp_offset_max:    u32;
+    gp_offset_field:  u32;
+    fp_offset_field:  u32;
+    overflow_field:   u32;
+    reg_save_field:   u32;
 }
 
 # make_slot: build a ParamSlot. convenience for ABI implementations.

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -128,9 +128,21 @@ pub fun fp_param_reg(index: i32) i32 {
 # gp_used:      GP registers already consumed
 # fp_used:      FP registers already consumed
 # ret:          the placement decision
-pub fun classify(size: u64, align: u64, is_float: bool,
+pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, is_aggregate, gp_used, fp_used);
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used);
+}
+
+# ret_int_reg: the SysV integer return register for eightbyte index 0 / 1 (RAX, RDX).
+fun ret_int_reg(index: i32) i32 {
+    if (index == 0) { ret REG_RAX; }
+    ret REG_RDX;
+}
+
+# ret_sse_reg: the SysV vector return register for eightbyte index 0 / 1 (XMM0, XMM1).
+fun ret_sse_reg(index: i32) i32 {
+    if (index == 0) { ret REG_XMM0; }
+    ret REG_XMM1;
 }
 
 # classify_arg: assign registers or a stack slot for one argument (SysV).
@@ -139,23 +151,30 @@ pub fun classify(size: u64, align: u64, is_float: bool,
 # when a GP argument register remains — the pointer occupies that register; once
 # the GP registers are exhausted such an aggregate is MEMORY-class, passed BY
 # VALUE on the stack (its full byte size, CLASS_STACK), not by reference.
-# aggregates of 9–16 bytes take TWO consecutive GP registers
-# (RDI:RSI, RSI:RDX, ...); aggregates of ≤8 bytes take one GP register, or one
-# FP register when all-float. scalars take one GP or FP register until that set
-# is exhausted, then spill to the stack. this classifier is AMD64-specific by
-# selection: `target.select` only composes the SysV vtable for an x86-64 (os,
-# arch) pair, so it never receives a non-x86_64 value to classify.
+# aggregates of 9–16 bytes are classified PER EIGHTBYTE: each eightbyte takes a GP
+# argument register, or an SSE eightbyte (all its fields floating-point, per
+# `fp_eightbytes`) takes an XMM register, so `{f64; f64}` rides XMM0:XMM1 and
+# `{i64; f64}` rides RDI:XMM0 — the System V psABI placement a C library expects.
+# aggregates of ≤8 bytes take one GP register, or one XMM register when their single
+# eightbyte is SSE class. if either register bank lacks the needed registers the
+# whole aggregate spills to the stack by value. a register aggregate is reported as
+# CLASS_GP with the per-eightbyte register in `reg` / `reg2` (the composite id
+# encodes its bank); the backend dispatches the load/store of each half on that
+# bank. scalars take one GP or FP register until that set is exhausted, then spill.
+# this classifier is AMD64-specific by selection: `target.select` only composes the
+# SysV vtable for an x86-64 (os, arch) pair, so it never receives a non-x86_64 value.
 # ---
-# index:        zero-based logical argument position
-# size:         argument size in bytes
-# align:        argument alignment in bytes
-# is_float:     true if the argument goes in FP registers
-# is_aggregate: true if the argument is an aggregate
-# gp_used:      GP registers already consumed
-# fp_used:      FP registers already consumed
-# ret:          the placement decision
+# index:         zero-based logical argument position
+# size:          argument size in bytes
+# align:         argument alignment in bytes
+# is_float:      true if the argument goes in FP registers (scalar floats)
+# fp_eightbytes: per-eightbyte SSE mask for an aggregate (bit e -> eightbyte e SSE)
+# is_aggregate:  true if the argument is an aggregate
+# gp_used:       GP registers already consumed
+# fp_used:       FP registers already consumed
+# ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
-                     is_float: bool, is_aggregate: bool,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
                      gp_used: i32, fp_used: i32) abi.ParamSlot {
     if (is_aggregate && size > MAX_REG_RET) {
         if (gp_used < GP_PARAM_COUNT) {
@@ -169,15 +188,35 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
     }
 
     if (is_aggregate) {
-        if (size <= 8 && is_float && fp_used < FP_PARAM_COUNT) {
-            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), -1, 0, size);
+        val eb0_sse: bool = (fp_eightbytes & 1) != 0;
+        if (size <= 8) {
+            # one eightbyte: an SSE eightbyte rides an XMM argument register, else a GP.
+            if (eb0_sse) {
+                if (fp_used < FP_PARAM_COUNT) {
+                    ret abi.make_slot(abi.CLASS_GP, fp_param_reg(fp_used), -1, 0, size);
+                }
+                ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+            }
+            if (gp_used < GP_PARAM_COUNT) {
+                ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+            }
+            ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
         }
-        if (size <= 8 && gp_used < GP_PARAM_COUNT) {
-            ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
-        }
-        if (size <= MAX_REG_RET && gp_used + 1 < GP_PARAM_COUNT) {
-            ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used),
-                              gp_param_reg(gp_used + 1), 0, size);
+        # two eightbytes: assign each to its bank's next register; spill the whole
+        # aggregate by value if either bank lacks the registers it needs.
+        val eb1_sse: bool = (fp_eightbytes & 2) != 0;
+        var gp_need: i32 = 0;
+        var fp_need: i32 = 0;
+        if (eb0_sse) { fp_need = fp_need + 1; } or { gp_need = gp_need + 1; }
+        if (eb1_sse) { fp_need = fp_need + 1; } or { gp_need = gp_need + 1; }
+        if (gp_used + gp_need <= GP_PARAM_COUNT && fp_used + fp_need <= FP_PARAM_COUNT) {
+            var gi: i32 = gp_used;
+            var fi: i32 = fp_used;
+            var r0: i32 = 0;
+            if (eb0_sse) { r0 = fp_param_reg(fi); fi = fi + 1; } or { r0 = gp_param_reg(gi); gi = gi + 1; }
+            var r1: i32 = 0;
+            if (eb1_sse) { r1 = fp_param_reg(fi); fi = fi + 1; } or { r1 = gp_param_reg(gi); gi = gi + 1; }
+            ret abi.make_slot(abi.CLASS_GP, r0, r1, 0, size);
         }
         ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
     }
@@ -200,19 +239,21 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # a zero-size (void) return yields CLASS_GP with reg=-1. aggregates larger than
 # 16 bytes are returned through a hidden struct-return pointer: the caller
 # passes the storage address in RDI and the callee returns it in RAX
-# (CLASS_SRET, reg=RAX). aggregates of 9–16 bytes return in RAX:RDX; ≤8-byte
-# aggregates return in RAX (or XMM0 when all-float). scalars return in RAX, or
-# XMM0 for floats. this classifier is AMD64-specific by selection — the SysV
-# vtable is only composed for an x86-64 target — so it never receives a
-# non-x86_64 return to classify.
+# (CLASS_SRET, reg=RAX). aggregates of 1–16 bytes are returned PER EIGHTBYTE: each
+# INTEGER eightbyte in RAX then RDX, each SSE eightbyte (per `fp_eightbytes`) in XMM0
+# then XMM1 — so `{f64; f64}` returns in XMM0:XMM1 and `{i64; f64}` in RAX:XMM0, the
+# psABI placement a C library produces. scalars return in RAX, or XMM0 for floats.
+# this classifier is AMD64-specific by selection — the SysV vtable is only composed
+# for an x86-64 target — so it never receives a non-x86_64 return to classify.
 # ---
-# size:         return-value size in bytes
-# align:        return-value alignment in bytes
-# is_float:     true if the value is returned in FP registers
-# is_aggregate: true if the value is an aggregate
-# ret:          the placement decision
+# size:          return-value size in bytes
+# align:         return-value alignment in bytes
+# is_float:      true if the value is returned in FP registers (scalar floats)
+# fp_eightbytes: per-eightbyte SSE mask for an aggregate (bit e -> eightbyte e SSE)
+# is_aggregate:  true if the value is an aggregate
+# ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, is_aggregate: bool) abi.ParamSlot {
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }
@@ -222,13 +263,21 @@ pub fun classify_return(size: u64, align: u64,
     }
 
     if (is_aggregate) {
-        if (size <= 8 && is_float) {
-            ret abi.make_slot(abi.CLASS_FP, REG_XMM0, -1, 0, size);
-        }
+        val eb0_sse: bool = (fp_eightbytes & 1) != 0;
         if (size <= 8) {
+            if (eb0_sse) { ret abi.make_slot(abi.CLASS_GP, REG_XMM0, -1, 0, size); }
             ret abi.make_slot(abi.CLASS_GP, REG_RAX, -1, 0, size);
         }
-        ret abi.make_slot(abi.CLASS_GP, REG_RAX, REG_RDX, 0, size);
+        # two eightbytes: INTEGER halves fill RAX then RDX, SSE halves XMM0 then XMM1,
+        # each bank advancing independently in eightbyte order.
+        val eb1_sse: bool = (fp_eightbytes & 2) != 0;
+        var ni: i32 = 0;
+        var ns: i32 = 0;
+        var r0: i32 = 0;
+        if (eb0_sse) { r0 = ret_sse_reg(ns); ns = ns + 1; } or { r0 = ret_int_reg(ni); ni = ni + 1; }
+        var r1: i32 = 0;
+        if (eb1_sse) { r1 = ret_sse_reg(ns); ns = ns + 1; } or { r1 = ret_int_reg(ni); ni = ni + 1; }
+        ret abi.make_slot(abi.CLASS_GP, r0, r1, 0, size);
     }
 
     if (is_float) {
@@ -443,4 +492,83 @@ pub fun register(i: *intern.Interner) Result[bool, str] {
     abi.register(?sysv_vtable);
     sysv_registered = true;
     ret ok[bool, str](true);
+}
+
+test "sysv: an all-float 16-byte aggregate rides XMM0:XMM1" {
+    # {f64; f64} -> both eightbytes SSE -> the two vector argument registers.
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 0);
+    if (s.class != abi.CLASS_GP) { ret 1; }
+    if (s.reg  != fp_param_reg(0)) { ret 1; }
+    if (s.reg2 != fp_param_reg(1)) { ret 1; }
+    ret 0;
+}
+
+test "sysv: an 8-byte all-float aggregate rides one XMM register" {
+    # {f32; f32} (8 bytes) -> one SSE eightbyte -> XMM0.
+    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, 0, 0);
+    if (s.class != abi.CLASS_GP) { ret 1; }
+    if (s.reg  != fp_param_reg(0)) { ret 1; }
+    if (s.reg2 != -1) { ret 1; }
+    ret 0;
+}
+
+test "sysv: a mixed INTEGER:SSE aggregate rides RDI:XMM0" {
+    # {i64; f64} -> eightbyte 0 INTEGER (RDI), eightbyte 1 SSE (XMM0).
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, 0, 0);
+    if (s.reg  != REG_RDI)        { ret 1; }
+    if (s.reg2 != fp_param_reg(0)) { ret 1; }
+    # the reverse {f64; i64} -> XMM0:RDI: the GP and SSE banks fill independently, so
+    # the integer eightbyte takes the FIRST GP register (RDI), not the second.
+    val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, 0, 0);
+    if (r.reg  != fp_param_reg(0)) { ret 1; }
+    if (r.reg2 != REG_RDI)        { ret 1; }
+    ret 0;
+}
+
+test "sysv: an all-integer aggregate still rides the GP pair (unchanged)" {
+    # {i64; i64} (mask 0) -> RDI:RSI, exactly as before SSE classification.
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0);
+    if (s.reg  != REG_RDI) { ret 1; }
+    if (s.reg2 != REG_RSI) { ret 1; }
+    ret 0;
+}
+
+test "sysv: SSE eightbytes consume the FP bank; exhaustion spills by value" {
+    # with seven XMM registers already used, a two-SSE aggregate needs two but only
+    # one remains, so the whole aggregate spills to the stack by value.
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 7);
+    if (s.class != abi.CLASS_STACK) { ret 1; }
+    if (s.size != 16)               { ret 1; }
+    ret 0;
+}
+
+test "sysv: an all-float aggregate returns in XMM0:XMM1" {
+    val s: abi.ParamSlot = classify_return(16, 8, false, 3, true);
+    if (s.reg  != REG_XMM0) { ret 1; }
+    if (s.reg2 != REG_XMM1) { ret 1; }
+    # one all-float eightbyte returns in XMM0.
+    val o: abi.ParamSlot = classify_return(8, 4, false, 1, true);
+    if (o.reg  != REG_XMM0) { ret 1; }
+    if (o.reg2 != -1)       { ret 1; }
+    ret 0;
+}
+
+test "sysv: aggregate returns place each bank's eightbytes in order" {
+    # {i64; i64} -> RAX:RDX (unchanged).
+    val gp: abi.ParamSlot = classify_return(16, 8, false, 0, true);
+    if (gp.reg != REG_RAX || gp.reg2 != REG_RDX) { ret 1; }
+    # {i64; f64} -> RAX:XMM0.
+    val mix: abi.ParamSlot = classify_return(16, 8, false, 2, true);
+    if (mix.reg != REG_RAX || mix.reg2 != REG_XMM0) { ret 1; }
+    ret 0;
+}
+
+test "sysv: a scalar float still takes an XMM register, an integer a GP" {
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
+    if (f.class != abi.CLASS_FP)   { ret 1; }
+    if (f.reg != fp_param_reg(0))  { ret 1; }
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
+    if (i.class != abi.CLASS_GP) { ret 1; }
+    if (i.reg != REG_RDI)        { ret 1; }
+    ret 0;
 }

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -375,17 +375,31 @@ pub fun va_fp_offset_max() u32 {
 
 # va_model: the SysV variadic save model — VA_MODEL_REG_SAVE. the prologue spills
 # all six GP and eight FP argument registers into a frame-local register-save area
-# and `va_list` is the four-field `__va_list_tag`, so the home-only fields
-# (`home_base_off` / `arg_stride`) are unused and reported as zero.
+# and `va_list` is the four-field `__va_list_tag`. the model carries every fact the
+# backend's prologue / va_start / va_arg expansion needs: the save-area size, the
+# FP dump offset and 16-byte per-XMM stride, the gp/fp exhaustion thresholds, the
+# four `__va_list_tag` field offsets, and the AL vector-count register. the
+# home-only `arg_stride` / `float_dup_gp` are unused and reported as zero/false.
 # ---
 # ret: the SysV variadic save model
 pub fun va_model() abi.VaModel {
     var m: abi.VaModel;
-    m.kind          = abi.VA_MODEL_REG_SAVE;
-    m.gp_save_count = GP_PARAM_COUNT;
-    m.fp_save_count = FP_PARAM_COUNT;
-    m.home_base_off = 0;
-    m.arg_stride    = 0;
+    m.kind             = abi.VA_MODEL_REG_SAVE;
+    m.gp_save_count    = GP_PARAM_COUNT;
+    m.fp_save_count    = FP_PARAM_COUNT;
+    m.arg_stride       = 0;
+    m.float_dup_gp     = false;
+    m.vector_count_reg = VA_VECTOR_COUNT_REG;
+    m.save_size        = va_save_size();
+    m.fp_save_offset   = va_fp_save_offset();
+    # each XMM argument register is dumped as a 16-byte save slot.
+    m.fp_save_stride   = 16;
+    m.gp_offset_max    = va_gp_offset_max();
+    m.fp_offset_max    = va_fp_offset_max();
+    m.gp_offset_field  = VA_GP_OFFSET;
+    m.fp_offset_field  = VA_FP_OFFSET;
+    m.overflow_field   = VA_OVERFLOW_ARG_AREA;
+    m.reg_save_field   = VA_REG_SAVE_AREA;
     ret m;
 }
 

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -115,42 +115,12 @@ pub fun fp_param_reg(index: i32) i32 {
     ret isa.regid_make(isa.REG_CLASS_ID_XMM, index);
 }
 
-# unsupported_slot: the honest "unsupported architecture" sentinel returned by
-# this AMD64-only classifier when handed a non-x86_64 arch_id.
-#
-# the vtable classify/arg/ret signatures return a plain `ParamSlot` (not a
-# `Result`), so an out-of-scope architecture cannot surface a `str` error here.
-# instead this returns a structurally impossible placement — CLASS_STACK with
-# offset = -1 and size = 0 — that no real SysV AMD64 placement ever produces (a
-# genuine stack slot always carries its true byte size and offset 0). a consumer
-# can reject it with `is_unsupported_slot`; it must never be treated as a valid
-# aarch64 (or any other) register/stack placement. aarch64 AAPCS64 classification
-# is intentionally out of scope for this file and belongs in a separate impl.
-# ---
-# ret: the unsupported-architecture sentinel slot
-pub fun unsupported_slot() abi.ParamSlot {
-    ret abi.make_slot(abi.CLASS_STACK, -1, -1, -1, 0);
-}
-
-# is_unsupported_slot: report whether a ParamSlot is the unsupported sentinel.
-#
-# consumers casting these classify/arg/ret pointers back to their concrete
-# signatures must call this before trusting a placement, so the AMD64-only
-# fallback is rejected rather than mistaken for a real stack slot.
-# ---
-# slot: the placement decision to test
-# ret:  true if `slot` is the `unsupported_slot` sentinel
-pub fun is_unsupported_slot(slot: abi.ParamSlot) bool {
-    ret slot.class == abi.CLASS_STACK && slot.offset == -1 && slot.size == 0;
-}
-
 # classify: classify one value into a SysV placement decision.
 #
 # this is the body behind the erased `AbiVTable.classify` pointer; it treats
 # the value as the first argument and routes through `classify_arg`. returns
 # are routed separately through `classify_return`.
 # ---
-# arch_id:      architecture id (one of isa.ARCH_*)
 # size:         value size in bytes
 # align:        value alignment in bytes
 # is_float:     true if the value is FP-eligible
@@ -158,9 +128,9 @@ pub fun is_unsupported_slot(slot: abi.ParamSlot) bool {
 # gp_used:      GP registers already consumed
 # fp_used:      FP registers already consumed
 # ret:          the placement decision
-pub fun classify(arch_id: u32, size: u64, align: u64, is_float: bool,
+pub fun classify(size: u64, align: u64, is_float: bool,
                  is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
-    ret classify_arg(arch_id, 0, size, align, is_float, is_aggregate, gp_used, fp_used);
+    ret classify_arg(0, size, align, is_float, is_aggregate, gp_used, fp_used);
 }
 
 # classify_arg: assign registers or a stack slot for one argument (SysV).
@@ -172,12 +142,10 @@ pub fun classify(arch_id: u32, size: u64, align: u64, is_float: bool,
 # aggregates of 9–16 bytes take TWO consecutive GP registers
 # (RDI:RSI, RSI:RDX, ...); aggregates of ≤8 bytes take one GP register, or one
 # FP register when all-float. scalars take one GP or FP register until that set
-# is exhausted, then spill to the stack. this classifier is AMD64-only: a
-# non-x86_64 arch_id (e.g. aarch64, whose AAPCS64 placement differs) yields the
-# `unsupported_slot` sentinel, which callers must reject -- it is never a valid
-# placement on the requested architecture.
+# is exhausted, then spill to the stack. this classifier is AMD64-specific by
+# selection: `target.select` only composes the SysV vtable for an x86-64 (os,
+# arch) pair, so it never receives a non-x86_64 value to classify.
 # ---
-# arch_id:      architecture id (one of isa.ARCH_*)
 # index:        zero-based logical argument position
 # size:         argument size in bytes
 # align:        argument alignment in bytes
@@ -186,13 +154,9 @@ pub fun classify(arch_id: u32, size: u64, align: u64, is_float: bool,
 # gp_used:      GP registers already consumed
 # fp_used:      FP registers already consumed
 # ret:          the placement decision
-pub fun classify_arg(arch_id: u32, index: i32, size: u64, align: u64,
+pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, is_aggregate: bool,
                      gp_used: i32, fp_used: i32) abi.ParamSlot {
-    if (arch_id != isa.ARCH_X86_64) {
-        ret unsupported_slot();
-    }
-
     if (is_aggregate && size > MAX_REG_RET) {
         if (gp_used < GP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
@@ -238,22 +202,17 @@ pub fun classify_arg(arch_id: u32, index: i32, size: u64, align: u64,
 # passes the storage address in RDI and the callee returns it in RAX
 # (CLASS_SRET, reg=RAX). aggregates of 9–16 bytes return in RAX:RDX; ≤8-byte
 # aggregates return in RAX (or XMM0 when all-float). scalars return in RAX, or
-# XMM0 for floats. this classifier is AMD64-only: a non-x86_64 arch_id (e.g.
-# aarch64, which returns sret in X8) yields the `unsupported_slot` sentinel,
-# which callers must reject rather than treat as a valid placement.
+# XMM0 for floats. this classifier is AMD64-specific by selection — the SysV
+# vtable is only composed for an x86-64 target — so it never receives a
+# non-x86_64 return to classify.
 # ---
-# arch_id:      architecture id (one of isa.ARCH_*)
 # size:         return-value size in bytes
 # align:        return-value alignment in bytes
 # is_float:     true if the value is returned in FP registers
 # is_aggregate: true if the value is an aggregate
 # ret:          the placement decision
-pub fun classify_return(arch_id: u32, size: u64, align: u64,
+pub fun classify_return(size: u64, align: u64,
                         is_float: bool, is_aggregate: bool) abi.ParamSlot {
-    if (arch_id != isa.ARCH_X86_64) {
-        ret unsupported_slot();
-    }
-
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -185,16 +185,17 @@ fun slot_index(gp_used: i32, fp_used: i32) i32 {
 # value as the first argument and routes through `classify_arg`. returns are
 # routed separately through `classify_return`.
 # ---
-# size:         value size in bytes
-# align:        value alignment in bytes
-# is_float:     true if the value is FP-eligible
-# is_aggregate: true if the value is an aggregate
-# gp_used:      GP registers already consumed
-# fp_used:      FP registers already consumed
-# ret:          the placement decision
-pub fun classify(size: u64, align: u64, is_float: bool,
+# size:          value size in bytes
+# align:         value alignment in bytes
+# is_float:      true if the value is FP-eligible
+# fp_eightbytes: per-eightbyte SSE mask (unused — win64 passes aggregates in GP)
+# is_aggregate:  true if the value is an aggregate
+# gp_used:       GP registers already consumed
+# fp_used:       FP registers already consumed
+# ret:           the placement decision
+pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, is_aggregate, gp_used, fp_used);
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used);
 }
 
 # classify_arg: assign a register or stack slot for one argument (win64).
@@ -212,16 +213,21 @@ pub fun classify(size: u64, align: u64, is_float: bool,
 # vtable is only composed for an x86-64 Windows target, so it never receives a
 # non-x86_64 argument to classify.
 # ---
-# index:        zero-based logical argument position
-# size:         argument size in bytes
-# align:        argument alignment in bytes
-# is_float:     true if the argument goes in FP registers
-# is_aggregate: true if the argument is an aggregate
-# gp_used:      GP registers already consumed
-# fp_used:      FP registers already consumed
-# ret:          the placement decision
+# win64 passes every aggregate in a single integer register (or by reference), so
+# `fp_eightbytes` is unused — a float-bearing 1/2/4/8-byte struct still rides a GP
+# register, unlike SysV.
+# ---
+# index:         zero-based logical argument position
+# size:          argument size in bytes
+# align:         argument alignment in bytes
+# is_float:      true if the argument goes in FP registers (scalar floats)
+# fp_eightbytes: per-eightbyte SSE mask (unused — win64 aggregates ride GP)
+# is_aggregate:  true if the argument is an aggregate
+# gp_used:       GP registers already consumed
+# fp_used:       FP registers already consumed
+# ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
-                     is_float: bool, is_aggregate: bool,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
                      gp_used: i32, fp_used: i32) abi.ParamSlot {
     val slot: i32 = slot_index(gp_used, fp_used);
 
@@ -259,30 +265,31 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # classify_return: assign a register or sret pointer for a return value (win64).
 #
 # a zero-size (void) return yields CLASS_GP with reg=-1. an aggregate of
-# 1/2/4/8 bytes returns in RAX (or XMM0 when all-float); any other aggregate is
-# returned through a hidden struct-return pointer that the caller passes in RCX
-# (consuming the first positional argument slot, shifting the real arguments) and
-# the callee returns in RAX (CLASS_SRET, reg=RAX). scalars return in RAX, or XMM0
-# for floats. this classifier is AMD64-specific by selection — the win64 vtable is
-# only composed for an x86-64 Windows target — so it never receives a non-x86_64
-# return to classify.
+# 1/2/4/8 bytes returns in RAX — Microsoft x64 returns EVERY 1/2/4/8-byte UDT in
+# the integer register, even an all-float one (unlike SysV, which uses XMM0); any
+# other aggregate is returned through a hidden struct-return pointer that the caller
+# passes in RCX (consuming the first positional argument slot, shifting the real
+# arguments) and the callee returns in RAX (CLASS_SRET, reg=RAX). scalars return in
+# RAX, or XMM0 for floats. this classifier is AMD64-specific by selection — the
+# win64 vtable is only composed for an x86-64 Windows target — so it never receives
+# a non-x86_64 return to classify.
 # ---
-# size:         return-value size in bytes
-# align:        return-value alignment in bytes
-# is_float:     true if the value is returned in FP registers
-# is_aggregate: true if the value is an aggregate
-# ret:          the placement decision
+# size:          return-value size in bytes
+# align:         return-value alignment in bytes
+# is_float:      true if the value is returned in FP registers (scalar floats)
+# fp_eightbytes: per-eightbyte SSE mask (unused — win64 returns aggregates in RAX)
+# is_aggregate:  true if the value is an aggregate
+# ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, is_aggregate: bool) abi.ParamSlot {
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }
 
     if (is_aggregate) {
+        # a 1/2/4/8-byte UDT returns in RAX regardless of its field types; everything
+        # else goes through an sret pointer.
         if (is_by_value_size(size)) {
-            if (is_float) {
-                ret abi.make_slot(abi.CLASS_FP, REG_XMM0, -1, 0, size);
-            }
             ret abi.make_slot(abi.CLASS_GP, REG_RAX, -1, 0, size);
         }
         # the hidden result-storage pointer rides RCX in and is returned in RAX.
@@ -473,19 +480,19 @@ pub fun register_win64(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
 }
 
 test "win64: scalar integer args take RCX, RDX, R8, R9 then spill" {
-    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, false, 0, 0);
+    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
     if (s0.class != abi.CLASS_GP) { ret 1; }
     if (s0.reg != REG_RCX)        { ret 1; }
 
-    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, false, 1, 0);
+    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 1, 0);
     if (s1.reg != REG_RDX) { ret 1; }
-    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, false, 2, 0);
+    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, 2, 0);
     if (s2.reg != REG_R8) { ret 1; }
-    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, false, 3, 0);
+    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, 3, 0);
     if (s3.reg != REG_R9) { ret 1; }
 
     # the fifth argument has no register slot and spills to the stack by value.
-    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, false, 4, 0);
+    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, 4, 0);
     if (s4.class != abi.CLASS_STACK) { ret 1; }
     if (s4.reg != -1)                { ret 1; }
     if (s4.size != 8)                { ret 1; }
@@ -493,16 +500,16 @@ test "win64: scalar integer args take RCX, RDX, R8, R9 then spill" {
 }
 
 test "win64: float args take XMM0–XMM3 then spill" {
-    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, false, 0, 0);
+    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
     if (f0.class != abi.CLASS_FP)                          { ret 1; }
     if (f0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
 
-    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, false, 0, 3);
+    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, 0, 3);
     if (f3.class != abi.CLASS_FP)                          { ret 1; }
     if (f3.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
 
     # the fifth positional argument (slot 4) spills regardless of bank.
-    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, false, 0, 4);
+    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, 0, 4);
     if (f4.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -511,16 +518,16 @@ test "win64: int and float share one positional slot per argument" {
     # argument 0 is an integer (slot 0 -> RCX). argument 1 is a float; under
     # win64 it takes the SECOND positional slot -> XMM1, not XMM0, because the
     # integer already consumed slot 0.
-    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, false, 0, 0);
+    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
     if (i0.reg != REG_RCX) { ret 1; }
-    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, false, 1, 0);
+    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, 1, 0);
     if (f1.class != abi.CLASS_FP)                          { ret 1; }
     if (f1.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 1)) { ret 1; }
 
     # the reverse: a float (slot 0 -> XMM0) followed by an integer (slot 1 -> RDX).
-    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, false, 0, 0);
+    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
     if (g0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
-    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, false, 0, 1);
+    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 0, 1);
     if (g1.class != abi.CLASS_GP) { ret 1; }
     if (g1.reg != REG_RDX)        { ret 1; }
     ret 0;
@@ -538,24 +545,24 @@ test "win64: a variadic float duplicates into the matching integer register" {
 
 test "win64: 1/2/4/8-byte aggregates ride one register, others go by reference" {
     # an 8-byte aggregate rides RCX by value.
-    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, true, 0, 0);
+    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0);
     if (by_val.class != abi.CLASS_GP) { ret 1; }
     if (by_val.reg != REG_RCX)        { ret 1; }
     if (by_val.size != 8)             { ret 1; }
 
     # a 4-byte aggregate also rides by value.
-    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, true, 0, 0);
+    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, 0, 0);
     if (four.class != abi.CLASS_GP) { ret 1; }
 
     # a 3-byte aggregate is not a by-value size: passed by hidden reference, the
     # pointer (8 bytes) in RCX.
-    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, true, 0, 0);
+    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, 0, 0);
     if (by_ref3.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref3.reg != REG_RCX)           { ret 1; }
     if (by_ref3.size != 8)                { ret 1; }
 
     # a 16-byte aggregate is also by reference.
-    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, true, 0, 0);
+    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0);
     if (by_ref16.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref16.reg != REG_RCX)           { ret 1; }
     ret 0;
@@ -565,7 +572,7 @@ test "win64: an exhausted by-reference aggregate spills its pointer to the stack
     # all four positional slots are taken; a 16-byte by-ref aggregate spills the
     # 8-byte hidden pointer to the stack as CLASS_STACK_BYREF (not the full
     # aggregate, and distinct from a by-value CLASS_STACK spill).
-    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, true, 4, 0);
+    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, 4, 0);
     if (s.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s.reg != -1)                      { ret 1; }
     if (s.size != 8)                      { ret 1; }
@@ -573,28 +580,28 @@ test "win64: an exhausted by-reference aggregate spills its pointer to the stack
     # a sub-pointer (3-byte) aggregate is also by reference: win64 treats every
     # non-1/2/4/8-byte aggregate as byref, so an exhausted 3-byte aggregate spills
     # its 8-byte pointer too — the size-mismatch heuristic missed this case.
-    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, true, 4, 0);
+    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, 4, 0);
     if (s3.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s3.size != 8)                      { ret 1; }
 
     # an exhausted by-value-size aggregate (8 bytes) spills its own bytes by value,
     # so it stays CLASS_STACK — the byref class must not capture the by-value path.
-    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, true, 4, 0);
+    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, true, 4, 0);
     if (sv.class != abi.CLASS_STACK) { ret 1; }
     if (sv.size != 8)                { ret 1; }
     ret 0;
 }
 
 test "win64: scalar returns use RAX / XMM0, void returns reg=-1" {
-    val voidr: abi.ParamSlot = classify_return(0, 0, false, false);
+    val voidr: abi.ParamSlot = classify_return(0, 0, false, 0, false);
     if (voidr.class != abi.CLASS_GP) { ret 1; }
     if (voidr.reg != -1)             { ret 1; }
 
-    val ir: abi.ParamSlot = classify_return(8, 8, false, false);
+    val ir: abi.ParamSlot = classify_return(8, 8, false, 0, false);
     if (ir.class != abi.CLASS_GP) { ret 1; }
     if (ir.reg != REG_RAX)        { ret 1; }
 
-    val fr: abi.ParamSlot = classify_return(8, 8, true, false);
+    val fr: abi.ParamSlot = classify_return(8, 8, true, 0, false);
     if (fr.class != abi.CLASS_FP) { ret 1; }
     if (fr.reg != REG_XMM0)       { ret 1; }
     ret 0;
@@ -602,18 +609,19 @@ test "win64: scalar returns use RAX / XMM0, void returns reg=-1" {
 
 test "win64: aggregate returns are RAX by value or an sret pointer" {
     # an 8-byte aggregate returns in RAX.
-    val small: abi.ParamSlot = classify_return(8, 8, false, true);
+    val small: abi.ParamSlot = classify_return(8, 8, false, 0, true);
     if (small.class != abi.CLASS_GP) { ret 1; }
     if (small.reg != REG_RAX)        { ret 1; }
 
-    # a small all-float aggregate returns in XMM0.
-    val fsmall: abi.ParamSlot = classify_return(8, 8, true, true);
-    if (fsmall.class != abi.CLASS_FP) { ret 1; }
-    if (fsmall.reg != REG_XMM0)       { ret 1; }
+    # a small all-float UDT still returns in RAX under MS x64 (unlike SysV's XMM0):
+    # the fp_eightbytes mask is ignored, every 1/2/4/8-byte aggregate uses RAX.
+    val fsmall: abi.ParamSlot = classify_return(8, 8, true, 1, true);
+    if (fsmall.class != abi.CLASS_GP) { ret 1; }
+    if (fsmall.reg != REG_RAX)        { ret 1; }
 
     # a 12-byte aggregate is not a by-value size: returned via an sret pointer,
     # which the callee yields in RAX.
-    val big: abi.ParamSlot = classify_return(12, 4, false, true);
+    val big: abi.ParamSlot = classify_return(12, 4, false, 0, true);
     if (big.class != abi.CLASS_SRET) { ret 1; }
     if (big.reg != REG_RAX)          { ret 1; }
     ret 0;
@@ -622,9 +630,9 @@ test "win64: aggregate returns are RAX by value or an sret pointer" {
 test "win64: an sret return reserves the first positional slot, shifting args" {
     # a 24-byte aggregate return is sret. classify_signature seeds gp_used=1 for
     # the hidden RCX pointer, so the first real integer argument lands in RDX.
-    val ret_slot: abi.ParamSlot = classify_return(24, 8, false, true);
+    val ret_slot: abi.ParamSlot = classify_return(24, 8, false, 0, true);
     if (ret_slot.class != abi.CLASS_SRET) { ret 1; }
-    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, false, 1, 0);
+    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 1, 0);
     if (first_arg.class != abi.CLASS_GP) { ret 1; }
     if (first_arg.reg != REG_RDX)        { ret 1; }
     ret 0;

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -98,13 +98,6 @@ pub val RED_ZONE: u32 = 0;
 # four register arguments. it sits below the first stack argument and is always
 # reserved, even for a call that passes no arguments in registers.
 pub val SHADOW_SPACE: u64 = 32;
-# `[rbp + off]` of the caller's first home slot inside a standard RBP-based frame
-# (`push rbp; mov rbp, rsp`). the home/shadow space sits just above the saved
-# frame pointer (`[rbp+0]`) and the return address (`[rbp+8]`), so the first home
-# slot — holding the first integer argument register, RCX — is at `[rbp+16]`. the
-# variadic home-area model spills its register args into these slots and seeds the
-# `va_list` pointer relative to this base.
-pub val VA_HOME_BASE_OFF: i64 = 16;
 # bytes `va_arg` advances its single-pointer cursor per argument under the home
 # model — one 8-byte stack slot, matching the contiguous home + overflow array.
 pub val VA_ARG_STRIDE: i64 = 8;
@@ -407,17 +400,30 @@ pub fun max_reg_agg() u64 {
 # contiguous stack array. `va_list` is a single pointer the backend seeds just
 # past the named arguments and walks up `VA_ARG_STRIDE` (8) bytes per `va_arg`.
 # win64 passes a variadic float in both its XMM register and the matching integer
-# register, so `va_arg` reads the integer/stack slot and no separate FP save area
-# is needed (`fp_save_count` is 0).
+# register (`float_dup_gp`), so `va_arg` reads the integer/stack slot and no
+# separate FP save area is needed (`fp_save_count` is 0). win64 encodes no vector
+# count, so `vector_count_reg` is -1 (no pre-call AL move) and the register-save
+# geometry fields are unused. the home base is the ISA's `incoming_arg_base`, read
+# by the backend from the frame layer rather than carried here.
 # ---
 # ret: the win64 variadic save model
 pub fun va_model() abi.VaModel {
     var m: abi.VaModel;
-    m.kind          = abi.VA_MODEL_HOME;
-    m.gp_save_count = GP_PARAM_COUNT;
-    m.fp_save_count = 0;
-    m.home_base_off = VA_HOME_BASE_OFF;
-    m.arg_stride    = VA_ARG_STRIDE;
+    m.kind             = abi.VA_MODEL_HOME;
+    m.gp_save_count    = GP_PARAM_COUNT;
+    m.fp_save_count    = 0;
+    m.arg_stride       = VA_ARG_STRIDE;
+    m.float_dup_gp     = true;
+    m.vector_count_reg = -1;
+    m.save_size        = 0;
+    m.fp_save_offset   = 0;
+    m.fp_save_stride   = 0;
+    m.gp_offset_max    = 0;
+    m.fp_offset_max    = 0;
+    m.gp_offset_field  = 0;
+    m.fp_offset_field  = 0;
+    m.overflow_field   = 0;
+    m.reg_save_field   = 0;
     ret m;
 }
 
@@ -637,8 +643,10 @@ test "win64: the variadic save model is the home-area model" {
     if (m.gp_save_count != GP_PARAM_COUNT)  { ret 1; }
     # win64 has no FP save area: a variadic float duplicates into its integer slot.
     if (m.fp_save_count != 0)               { ret 1; }
-    # the first home slot sits above the saved RBP and return address.
-    if (m.home_base_off != VA_HOME_BASE_OFF) { ret 1; }
+    # a variadic float duplicates into the matching integer register.
+    if (!m.float_dup_gp)                     { ret 1; }
+    # win64 encodes no vector count, so there is no pre-call AL move.
+    if (m.vector_count_reg != -1)            { ret 1; }
     if (m.arg_stride != VA_ARG_STRIDE)       { ret 1; }
     ret 0;
 }

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -169,35 +169,6 @@ pub fun float_dup_gp_reg(index: i32) i32 {
     ret slot_gp_reg(index);
 }
 
-# unsupported_slot: the honest "unsupported architecture" sentinel returned by
-# this AMD64-only classifier when handed a non-x86_64 arch_id.
-#
-# the vtable classify/arg/ret signatures return a plain `ParamSlot` (not a
-# `Result`), so an out-of-scope architecture cannot surface a `str` error here.
-# instead this returns a structurally impossible placement — CLASS_STACK with
-# offset = -1 and size = 0 — that no real win64 placement ever produces (a genuine
-# stack slot always carries its true byte size and offset 0). a consumer can
-# reject it with `is_unsupported_slot`; it must never be treated as a valid
-# placement on another architecture. it shares the exact shape of the SysV
-# sentinel so a consumer can test either ABI's slots with one predicate.
-# ---
-# ret: the unsupported-architecture sentinel slot
-pub fun unsupported_slot() abi.ParamSlot {
-    ret abi.make_slot(abi.CLASS_STACK, -1, -1, -1, 0);
-}
-
-# is_unsupported_slot: report whether a ParamSlot is the unsupported sentinel.
-#
-# consumers casting the classify/arg/ret pointers back to their concrete
-# signatures must call this before trusting a placement, so the AMD64-only
-# fallback is rejected rather than mistaken for a real stack slot.
-# ---
-# slot: the placement decision to test
-# ret:  true if `slot` is the `unsupported_slot` sentinel
-pub fun is_unsupported_slot(slot: abi.ParamSlot) bool {
-    ret slot.class == abi.CLASS_STACK && slot.offset == -1 && slot.size == 0;
-}
-
 # slot_index: the positional argument slot from the running GP/FP usage counters.
 #
 # win64 shares one positional slot per argument across both register banks, so
@@ -221,7 +192,6 @@ fun slot_index(gp_used: i32, fp_used: i32) i32 {
 # value as the first argument and routes through `classify_arg`. returns are
 # routed separately through `classify_return`.
 # ---
-# arch_id:      architecture id (one of isa.ARCH_*)
 # size:         value size in bytes
 # align:        value alignment in bytes
 # is_float:     true if the value is FP-eligible
@@ -229,9 +199,9 @@ fun slot_index(gp_used: i32, fp_used: i32) i32 {
 # gp_used:      GP registers already consumed
 # fp_used:      FP registers already consumed
 # ret:          the placement decision
-pub fun classify(arch_id: u32, size: u64, align: u64, is_float: bool,
+pub fun classify(size: u64, align: u64, is_float: bool,
                  is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
-    ret classify_arg(arch_id, 0, size, align, is_float, is_aggregate, gp_used, fp_used);
+    ret classify_arg(0, size, align, is_float, is_aggregate, gp_used, fp_used);
 }
 
 # classify_arg: assign a register or stack slot for one argument (win64).
@@ -245,11 +215,10 @@ pub fun classify(arch_id: u32, size: u64, align: u64, is_float: bool,
 # register; an integer or pointer takes the slot's integer register. once the
 # four slots are exhausted the argument spills to the stack by value (CLASS_STACK)
 # — except a by-ref aggregate, which spills its 8-byte hidden pointer
-# (CLASS_STACK_BYREF). this classifier is AMD64-only: a
-# non-x86_64 arch_id yields the `unsupported_slot` sentinel, which callers must
-# reject -- it is never a valid placement on the requested architecture.
+# (CLASS_STACK_BYREF). this classifier is AMD64-specific by selection: the win64
+# vtable is only composed for an x86-64 Windows target, so it never receives a
+# non-x86_64 argument to classify.
 # ---
-# arch_id:      architecture id (one of isa.ARCH_*)
 # index:        zero-based logical argument position
 # size:         argument size in bytes
 # align:        argument alignment in bytes
@@ -258,13 +227,9 @@ pub fun classify(arch_id: u32, size: u64, align: u64, is_float: bool,
 # gp_used:      GP registers already consumed
 # fp_used:      FP registers already consumed
 # ret:          the placement decision
-pub fun classify_arg(arch_id: u32, index: i32, size: u64, align: u64,
+pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, is_aggregate: bool,
                      gp_used: i32, fp_used: i32) abi.ParamSlot {
-    if (arch_id != isa.ARCH_X86_64) {
-        ret unsupported_slot();
-    }
-
     val slot: i32 = slot_index(gp_used, fp_used);
 
     if (is_aggregate) {
@@ -305,22 +270,17 @@ pub fun classify_arg(arch_id: u32, index: i32, size: u64, align: u64,
 # returned through a hidden struct-return pointer that the caller passes in RCX
 # (consuming the first positional argument slot, shifting the real arguments) and
 # the callee returns in RAX (CLASS_SRET, reg=RAX). scalars return in RAX, or XMM0
-# for floats. this classifier is AMD64-only: a non-x86_64 arch_id yields the
-# `unsupported_slot` sentinel, which callers must reject rather than treat as a
-# valid placement.
+# for floats. this classifier is AMD64-specific by selection — the win64 vtable is
+# only composed for an x86-64 Windows target — so it never receives a non-x86_64
+# return to classify.
 # ---
-# arch_id:      architecture id (one of isa.ARCH_*)
 # size:         return-value size in bytes
 # align:        return-value alignment in bytes
 # is_float:     true if the value is returned in FP registers
 # is_aggregate: true if the value is an aggregate
 # ret:          the placement decision
-pub fun classify_return(arch_id: u32, size: u64, align: u64,
+pub fun classify_return(size: u64, align: u64,
                         is_float: bool, is_aggregate: bool) abi.ParamSlot {
-    if (arch_id != isa.ARCH_X86_64) {
-        ret unsupported_slot();
-    }
-
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }
@@ -507,20 +467,19 @@ pub fun register_win64(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
 }
 
 test "win64: scalar integer args take RCX, RDX, R8, R9 then spill" {
-    val a: u32 = isa.ARCH_X86_64;
-    val s0: abi.ParamSlot = classify_arg(a, 0, 8, 8, false, false, 0, 0);
+    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, false, 0, 0);
     if (s0.class != abi.CLASS_GP) { ret 1; }
     if (s0.reg != REG_RCX)        { ret 1; }
 
-    val s1: abi.ParamSlot = classify_arg(a, 1, 8, 8, false, false, 1, 0);
+    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, false, 1, 0);
     if (s1.reg != REG_RDX) { ret 1; }
-    val s2: abi.ParamSlot = classify_arg(a, 2, 8, 8, false, false, 2, 0);
+    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, false, 2, 0);
     if (s2.reg != REG_R8) { ret 1; }
-    val s3: abi.ParamSlot = classify_arg(a, 3, 8, 8, false, false, 3, 0);
+    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, false, 3, 0);
     if (s3.reg != REG_R9) { ret 1; }
 
     # the fifth argument has no register slot and spills to the stack by value.
-    val s4: abi.ParamSlot = classify_arg(a, 4, 8, 8, false, false, 4, 0);
+    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, false, 4, 0);
     if (s4.class != abi.CLASS_STACK) { ret 1; }
     if (s4.reg != -1)                { ret 1; }
     if (s4.size != 8)                { ret 1; }
@@ -528,36 +487,34 @@ test "win64: scalar integer args take RCX, RDX, R8, R9 then spill" {
 }
 
 test "win64: float args take XMM0–XMM3 then spill" {
-    val a: u32 = isa.ARCH_X86_64;
-    val f0: abi.ParamSlot = classify_arg(a, 0, 8, 8, true, false, 0, 0);
+    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, false, 0, 0);
     if (f0.class != abi.CLASS_FP)                          { ret 1; }
     if (f0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
 
-    val f3: abi.ParamSlot = classify_arg(a, 3, 4, 4, true, false, 0, 3);
+    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, false, 0, 3);
     if (f3.class != abi.CLASS_FP)                          { ret 1; }
     if (f3.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
 
     # the fifth positional argument (slot 4) spills regardless of bank.
-    val f4: abi.ParamSlot = classify_arg(a, 4, 8, 8, true, false, 0, 4);
+    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, false, 0, 4);
     if (f4.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
 
 test "win64: int and float share one positional slot per argument" {
-    val a: u32 = isa.ARCH_X86_64;
     # argument 0 is an integer (slot 0 -> RCX). argument 1 is a float; under
     # win64 it takes the SECOND positional slot -> XMM1, not XMM0, because the
     # integer already consumed slot 0.
-    val i0: abi.ParamSlot = classify_arg(a, 0, 8, 8, false, false, 0, 0);
+    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, false, 0, 0);
     if (i0.reg != REG_RCX) { ret 1; }
-    val f1: abi.ParamSlot = classify_arg(a, 1, 8, 8, true, false, 1, 0);
+    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, false, 1, 0);
     if (f1.class != abi.CLASS_FP)                          { ret 1; }
     if (f1.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 1)) { ret 1; }
 
     # the reverse: a float (slot 0 -> XMM0) followed by an integer (slot 1 -> RDX).
-    val g0: abi.ParamSlot = classify_arg(a, 0, 8, 8, true, false, 0, 0);
+    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, false, 0, 0);
     if (g0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
-    val g1: abi.ParamSlot = classify_arg(a, 1, 8, 8, false, false, 0, 1);
+    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, false, 0, 1);
     if (g1.class != abi.CLASS_GP) { ret 1; }
     if (g1.reg != REG_RDX)        { ret 1; }
     ret 0;
@@ -574,37 +531,35 @@ test "win64: a variadic float duplicates into the matching integer register" {
 }
 
 test "win64: 1/2/4/8-byte aggregates ride one register, others go by reference" {
-    val a: u32 = isa.ARCH_X86_64;
     # an 8-byte aggregate rides RCX by value.
-    val by_val: abi.ParamSlot = classify_arg(a, 0, 8, 8, false, true, 0, 0);
+    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, true, 0, 0);
     if (by_val.class != abi.CLASS_GP) { ret 1; }
     if (by_val.reg != REG_RCX)        { ret 1; }
     if (by_val.size != 8)             { ret 1; }
 
     # a 4-byte aggregate also rides by value.
-    val four: abi.ParamSlot = classify_arg(a, 0, 4, 4, false, true, 0, 0);
+    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, true, 0, 0);
     if (four.class != abi.CLASS_GP) { ret 1; }
 
     # a 3-byte aggregate is not a by-value size: passed by hidden reference, the
     # pointer (8 bytes) in RCX.
-    val by_ref3: abi.ParamSlot = classify_arg(a, 0, 3, 1, false, true, 0, 0);
+    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, true, 0, 0);
     if (by_ref3.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref3.reg != REG_RCX)           { ret 1; }
     if (by_ref3.size != 8)                { ret 1; }
 
     # a 16-byte aggregate is also by reference.
-    val by_ref16: abi.ParamSlot = classify_arg(a, 0, 16, 8, false, true, 0, 0);
+    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, true, 0, 0);
     if (by_ref16.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref16.reg != REG_RCX)           { ret 1; }
     ret 0;
 }
 
 test "win64: an exhausted by-reference aggregate spills its pointer to the stack" {
-    val a: u32 = isa.ARCH_X86_64;
     # all four positional slots are taken; a 16-byte by-ref aggregate spills the
     # 8-byte hidden pointer to the stack as CLASS_STACK_BYREF (not the full
     # aggregate, and distinct from a by-value CLASS_STACK spill).
-    val s: abi.ParamSlot = classify_arg(a, 4, 16, 8, false, true, 4, 0);
+    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, true, 4, 0);
     if (s.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s.reg != -1)                      { ret 1; }
     if (s.size != 8)                      { ret 1; }
@@ -612,61 +567,58 @@ test "win64: an exhausted by-reference aggregate spills its pointer to the stack
     # a sub-pointer (3-byte) aggregate is also by reference: win64 treats every
     # non-1/2/4/8-byte aggregate as byref, so an exhausted 3-byte aggregate spills
     # its 8-byte pointer too — the size-mismatch heuristic missed this case.
-    val s3: abi.ParamSlot = classify_arg(a, 4, 3, 1, false, true, 4, 0);
+    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, true, 4, 0);
     if (s3.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s3.size != 8)                      { ret 1; }
 
     # an exhausted by-value-size aggregate (8 bytes) spills its own bytes by value,
     # so it stays CLASS_STACK — the byref class must not capture the by-value path.
-    val sv: abi.ParamSlot = classify_arg(a, 4, 8, 8, false, true, 4, 0);
+    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, true, 4, 0);
     if (sv.class != abi.CLASS_STACK) { ret 1; }
     if (sv.size != 8)                { ret 1; }
     ret 0;
 }
 
 test "win64: scalar returns use RAX / XMM0, void returns reg=-1" {
-    val a: u32 = isa.ARCH_X86_64;
-    val voidr: abi.ParamSlot = classify_return(a, 0, 0, false, false);
+    val voidr: abi.ParamSlot = classify_return(0, 0, false, false);
     if (voidr.class != abi.CLASS_GP) { ret 1; }
     if (voidr.reg != -1)             { ret 1; }
 
-    val ir: abi.ParamSlot = classify_return(a, 8, 8, false, false);
+    val ir: abi.ParamSlot = classify_return(8, 8, false, false);
     if (ir.class != abi.CLASS_GP) { ret 1; }
     if (ir.reg != REG_RAX)        { ret 1; }
 
-    val fr: abi.ParamSlot = classify_return(a, 8, 8, true, false);
+    val fr: abi.ParamSlot = classify_return(8, 8, true, false);
     if (fr.class != abi.CLASS_FP) { ret 1; }
     if (fr.reg != REG_XMM0)       { ret 1; }
     ret 0;
 }
 
 test "win64: aggregate returns are RAX by value or an sret pointer" {
-    val a: u32 = isa.ARCH_X86_64;
     # an 8-byte aggregate returns in RAX.
-    val small: abi.ParamSlot = classify_return(a, 8, 8, false, true);
+    val small: abi.ParamSlot = classify_return(8, 8, false, true);
     if (small.class != abi.CLASS_GP) { ret 1; }
     if (small.reg != REG_RAX)        { ret 1; }
 
     # a small all-float aggregate returns in XMM0.
-    val fsmall: abi.ParamSlot = classify_return(a, 8, 8, true, true);
+    val fsmall: abi.ParamSlot = classify_return(8, 8, true, true);
     if (fsmall.class != abi.CLASS_FP) { ret 1; }
     if (fsmall.reg != REG_XMM0)       { ret 1; }
 
     # a 12-byte aggregate is not a by-value size: returned via an sret pointer,
     # which the callee yields in RAX.
-    val big: abi.ParamSlot = classify_return(a, 12, 4, false, true);
+    val big: abi.ParamSlot = classify_return(12, 4, false, true);
     if (big.class != abi.CLASS_SRET) { ret 1; }
     if (big.reg != REG_RAX)          { ret 1; }
     ret 0;
 }
 
 test "win64: an sret return reserves the first positional slot, shifting args" {
-    val a: u32 = isa.ARCH_X86_64;
     # a 24-byte aggregate return is sret. classify_signature seeds gp_used=1 for
     # the hidden RCX pointer, so the first real integer argument lands in RDX.
-    val ret_slot: abi.ParamSlot = classify_return(a, 24, 8, false, true);
+    val ret_slot: abi.ParamSlot = classify_return(24, 8, false, true);
     if (ret_slot.class != abi.CLASS_SRET) { ret 1; }
-    val first_arg: abi.ParamSlot = classify_arg(a, 0, 8, 8, false, false, 1, 0);
+    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, false, 1, 0);
     if (first_arg.class != abi.CLASS_GP) { ret 1; }
     if (first_arg.reg != REG_RDX)        { ret 1; }
     ret 0;
@@ -713,14 +665,6 @@ test "win64: register files report the win64 banks" {
     # the vector set begins right after the nine integer registers, at XMM6.
     if (cs[CALLEE_SAVED_GP_COUNT].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 6)) { ret 1; }
     if (cs[CALLEE_SAVED_COUNT - 1].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 15)) { ret 1; }
-    ret 0;
-}
-
-test "win64: a non-x86_64 arch yields the unsupported sentinel" {
-    val s: abi.ParamSlot = classify_arg(isa.ARCH_AARCH64, 0, 8, 8, false, false, 0, 0);
-    if (!is_unsupported_slot(s)) { ret 1; }
-    val r: abi.ParamSlot = classify_return(isa.ARCH_AARCH64, 8, 8, false, false);
-    if (!is_unsupported_slot(r)) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -268,6 +268,14 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 #                     stack-parameter memory operands (`[fp + ...]`)
 # stack_ptr_reg:      stack-pointer register id; the base of outgoing
 #                     stack-argument memory operands (`[sp + ...]`)
+# incoming_arg_base:  byte offset from the frame pointer to the first incoming
+#                     stack argument — the frame fact the prologue establishes
+#                     (x86-64 `push rbp; mov rbp, rsp` puts the saved frame
+#                     pointer at `[fp+0]` and the return address at `[fp+8]`, so
+#                     incoming stack args start at `[fp+16]`). the generic
+#                     parameter / variadic lowering reads it instead of a bare
+#                     literal so an arch with a different frame record does not
+#                     require hunting magic offsets
 # div_reg:            register the integer division form hard-wires as the
 #                     dividend / quotient accumulator (x86-64 RAX), or -1
 # div_hi_reg:         register the integer division form hard-wires for the
@@ -294,6 +302,7 @@ pub rec IsaVTable {
     fp_scratch_reg:     i32;
     frame_ptr_reg:      i32;
     stack_ptr_reg:      i32;
+    incoming_arg_base:  i64;
     div_reg:            i32;
     div_hi_reg:         i32;
     shift_count_reg:    i32;

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -126,6 +126,9 @@ pub fun register_arm64(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     arm64_vtable.fp_scratch_reg     = ARM64_V31;
     arm64_vtable.frame_ptr_reg      = ARM64_FP;
     arm64_vtable.stack_ptr_reg      = ARM64_SP;
+    # the AAPCS64 frame record stores the saved FP at [fp+0] and the saved LR at
+    # [fp+8], so incoming stack arguments start at [fp+16] — same base as x86-64.
+    arm64_vtable.incoming_arg_base  = 16;
     # AArch64 SDIV/UDIV write a normal destination register and a register shift
     # count rides any register, so the ISA wires no fixed division / shift
     # register: report -1 for all three.

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -153,6 +153,9 @@ pub fun register_x64(alloc: *Allocator, interner: *intern.Interner) Result[bool,
     x64_vtable.fp_scratch_reg     = x64.FP_SCRATCH_REG;
     x64_vtable.frame_ptr_reg      = x64.FRAME_REG;
     x64_vtable.stack_ptr_reg      = x64.STACK_REG;
+    # saved RBP at [rbp+0] and the return address at [rbp+8], so the first
+    # incoming stack argument sits at [rbp+16].
+    x64_vtable.incoming_arg_base  = 16;
     x64_vtable.div_reg            = x64.RAX;
     x64_vtable.div_hi_reg         = x64.RDX;
     x64_vtable.shift_count_reg    = x64.RCX;

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -12,6 +12,7 @@ use std.types.option.none;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
+use std.types.string.str;
 
 use intern: mach.lang.intern;
 
@@ -25,6 +26,28 @@ pub val OS_LINUX:        u32 = 1;
 pub val OS_DARWIN:       u32 = 2;
 pub val OS_WINDOWS:      u32 = 3;
 pub val OS_FREESTANDING: u32 = 4;
+
+# the freestanding inline-asm write primitive the synthesized `mach test` runner
+# uses to emit its output on a given (os, arch). `body` is the OP_ASM body — with
+# `{buf}` / `{len}` placeholders the runner binds to its buffer and length
+# arguments — and `isa_tag` is the OP_ASM architecture tag. produced by the
+# OsVTable's `runner_write` accessor for the resolved architecture; an OS / arch
+# pair with no freestanding write returns none and the runner is unavailable.
+# ---
+# body:    the OP_ASM body text (with {buf} / {len} placeholders)
+# isa_tag: the OP_ASM architecture tag for the resolved arch
+pub rec RunnerWrite {
+    body:    str;
+    isa_tag: str;
+}
+
+# RunnerWriteFn: the concrete signature the erased `OsVTable.runner_write` pointer
+# casts back to. given the resolved architecture id (one of isa.ARCH_*), returns
+# the runner's write primitive for this (os, arch), or none when the OS exposes no
+# freestanding inline-asm write for that architecture (e.g. Windows, which needs
+# imported kernel32 calls rather than a syscall). the test-runner synthesizer reads
+# it through the selected target's OS vtable so the runner stays target-agnostic.
+pub def RunnerWriteFn: fun(u32) Option[RunnerWrite];
 
 # the operating-system runtime-dispatch interface. exactly one of these exists
 # per OS; the driver and linker read the entry symbol, library directory, and
@@ -45,6 +68,11 @@ pub val OS_FREESTANDING: u32 = 4;
 #                  linker assigns section vaddrs upward from it
 # page_size:       virtual-memory page size in bytes the linker page-aligns
 #                  segment virtual addresses to
+# runner_write:    erased fn ptr — the synthesized `mach test` runner's freestanding
+#                  write primitive for a resolved architecture (cast back to
+#                  `RunnerWriteFn`); none when the OS has no inline-asm write for
+#                  that arch, which makes `mach test` fail loudly rather than emit a
+#                  wrong-OS output sequence
 pub rec OsVTable {
     id:             u32;
     name:           intern.StrId;
@@ -54,6 +82,7 @@ pub rec OsVTable {
     dynamic_linker: intern.StrId;
     base_addr:      u64;
     page_size:      u64;
+    runner_write:   *u8;
 }
 
 val OS_REGISTRY_CAP: u32 = 8;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -20,11 +20,23 @@ use std.types.bool.true;
 use std.types.bool.false;
 
 use std.types.string.str;
+use std.types.option.Option;
+use std.types.option.none;
 
 use std.allocator.Allocator;
 
 use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
+
+# runner_write: Darwin has no freestanding inline-asm `mach test` write yet (its
+# write syscall number differs from Linux's), so every architecture returns none
+# and `mach test --target darwin` fails loudly — tracked by #1292.
+# ---
+# arch_id: resolved architecture id (one of isa.ARCH_*)
+# ret:     none (no Darwin runner write implemented)
+fun runner_write(arch_id: u32) Option[os.RunnerWrite] {
+    ret none[os.RunnerWrite]();
+}
 
 # default base virtual address for Darwin executables (4 GiB).
 pub val DARWIN_BASE_ADDR: u64 = 0x100000000;
@@ -73,6 +85,7 @@ pub fun register_darwin(alloc: *Allocator, i: *intern.Interner) Result[bool, str
     darwin_vtable.dynamic_linker = intern.STR_NIL;
     darwin_vtable.base_addr      = DARWIN_BASE_ADDR;
     darwin_vtable.page_size      = DARWIN_PAGE_SIZE;
+    darwin_vtable.runner_write   = runner_write::*u8;
 
     os.register(?darwin_vtable);
     darwin_registered = true;

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -19,10 +19,14 @@ use std.types.bool.true;
 use std.types.bool.false;
 
 use std.types.string.str;
+use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
 
 use std.allocator.Allocator;
 
 use intern: mach.lang.intern;
+use isa:    mach.lang.target.isa;
 use os:     mach.lang.target.os;
 
 # default base virtual address for Linux executables. the first PT_LOAD
@@ -40,6 +44,24 @@ pub val LINUX_PAGE_SIZE: u64 = 4096;
 # target/sysroot-configurable setting to avoid emitting an ELF whose interpreter
 # is absent at exec time.
 pub val LINUX_DYNAMIC_LINKER: str = "/lib64/ld-linux-x86-64.so.2";
+
+# runner_write: the synthesized `mach test` runner's freestanding write primitive
+# on Linux. for x86-64 it is the `write(1, buf, len)` syscall (rax=1) tagged for the
+# x86_64 OP_ASM encoder; other architectures have no inline-asm write here yet and
+# return none so `mach test` fails loudly rather than emitting a wrong sequence (the
+# aarch64 runner lands with #1045's freestanding write).
+# ---
+# arch_id: resolved architecture id (one of isa.ARCH_*)
+# ret:     the write primitive for this arch, or none if unsupported
+fun runner_write(arch_id: u32) Option[os.RunnerWrite] {
+    if (arch_id == isa.ARCH_X86_64) {
+        var w: os.RunnerWrite;
+        w.body    = "mov rax, 1\nmov rdi, 1\nmov rsi, {buf}\nmov rdx, {len}\nsyscall\n";
+        w.isa_tag = "x86_64";
+        ret some[os.RunnerWrite](w);
+    }
+    ret none[os.RunnerWrite]();
+}
 
 # the Linux OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry; remains valid for the process lifetime.
@@ -83,6 +105,7 @@ pub fun register_linux(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     linux_vtable.dynamic_linker = unwrap_ok[intern.StrId, str](rd);
     linux_vtable.base_addr      = LINUX_BASE_ADDR;
     linux_vtable.page_size      = LINUX_PAGE_SIZE;
+    linux_vtable.runner_write   = runner_write::*u8;
 
     os.register(?linux_vtable);
     linux_registered = true;

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -20,11 +20,24 @@ use std.types.bool.true;
 use std.types.bool.false;
 
 use std.types.string.str;
+use std.types.option.Option;
+use std.types.option.none;
 
 use std.allocator.Allocator;
 
 use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
+
+# runner_write: Windows writes to standard output through kernel32 (GetStdHandle +
+# WriteFile imports), not a freestanding syscall, so the synthesized inline-asm
+# runner cannot express it; every architecture returns none and `mach test --target
+# windows` fails loudly — the import-based runner is tracked by #1292.
+# ---
+# arch_id: resolved architecture id (one of isa.ARCH_*)
+# ret:     none (no Windows runner write implemented)
+fun runner_write(arch_id: u32) Option[os.RunnerWrite] {
+    ret none[os.RunnerWrite]();
+}
 
 # default base virtual address for Windows x86_64 executables.
 pub val WINDOWS_BASE_ADDR: u64 = 0x140000000;
@@ -72,6 +85,7 @@ pub fun register_windows(alloc: *Allocator, i: *intern.Interner) Result[bool, st
     windows_vtable.dynamic_linker = intern.STR_NIL;
     windows_vtable.base_addr      = WINDOWS_BASE_ADDR;
     windows_vtable.page_size      = WINDOWS_PAGE_SIZE;
+    windows_vtable.runner_write   = runner_write::*u8;
 
     os.register(?windows_vtable);
     windows_registered = true;


### PR DESCRIPTION
## Summary

Completes the **ABI abstraction boundary** slice of the 2026-06 audits: SysV/win64 ABI behaviour is now selected and driven entirely through the ABI/ISA/OS vtables, the SysV classifier places float-bearing aggregates in SSE registers per the psABI, and variadic lowering is dispatched on the ABI's `VaModel` instead of reading SysV layout facts directly. A new C-FFI integration suite (`cffi`, gcc-compiled object) and a wine `win64va` regression prove the boundary against real toolchains.

This PR touches a subset of items across three audit issues (each spans many findings); it does not empty any of them, so it `Refs` rather than `Closes`.

## What changed (per inherited commit)

- `51af3003` — key ABI selection on `(os, arch)`; drop the unsupported-arch sentinel that had zero consumers. **#1257 [DESIGN/L]**
- `167f409d` — name the incoming-argument frame base on the ISA vtable (removes the repeated x86-prologue magic `16`). **#1253 [SMELL/S]**
- `f2cf2c45` — complete `VaModel`; ABI-driven vector-count hook (drops the AL-count return-classifier indirection); win64 variadic float-dup + `va_start` slot fixes. **#1253 [BUG/M], [BUG/S], [DESIGN/M], [DESIGN/S]**
- `2f84651d` — dispatch `va_list` lowering on the target ABI's variadic model (no more hardcoded SysV `__va_list_tag`). **#1251 [DESIGN/S], #1253 [DESIGN/M]**
- `d8aa614a` — source the test-runner write primitive from the target OS vtable (test runner no longer hardcodes Linux/x86_64 syscall asm). **#1251 [DESIGN/M]**
- `5a121ee2` — classify SysV float-bearing aggregates per eightbyte into SSE registers (`{f64,f64}`→XMM0:XMM1, `{f32,f32}`→XMM0, `{i64,f64}`→RDI:XMM0); adds `sysv.mach` classification unit tests + the `cffi` suite. **#1257 [BUG/L], #1253 [DESIGN/L]**
- `78d87722` — wine `win64va` regression for the variadic fixes.
- `610c9fef` — bump vendored `mach-std` to the `_start` stack-align fix (see Dependency).

## The cffi CI blocker — root cause

The `cffi` suite was SIGSEGV-ing in CI (exit 139), not returning a wrong value. The cause was **not** in the SSE classification (values cross correctly) but a latent stack-misalignment in `mach-std`'s `_start`:

```
and rsp, -16      # kernel already enters _start 16-aligned -> rsp%16==0 (call-ready)
sub rsp, 8        # over-corrects -> rsp%16==8, so every callee enters at rsp%16==0
```

SysV requires RSP 16-aligned **at the CALL site** so the callee is entered with `rsp%16==8`. The stray `sub rsp, 8` left every callee — including external C — entered 8-misaligned. This is invisible to pure-Mach programs (Mach never emits RBP-relative aligned SSE operands under SysV) but any C function that emits an aligned SSE access (`movaps`/`movapd`) against a 16-aligned stack slot `#GP`-faults. CI's gcc emitted such an access for the float-struct callees; the local gcc (newer, `-O0`) happened not to, which is why it passed locally and crashed in CI.

Evidence: a naked probe returning `rsp & 15` at entry read **0** before / **8** after; a deterministic `movaps`-to-stack C callee SIGSEGV'd (139) before / exited 0 after; `cffi` PASSes after (including with `-O2` callees). Fix: drop the `sub rsp, 8` (win64 was already correct — `sub rsp, 32` shadow space is a multiple of 16).

## Dependency

The root-cause fix lives in **octalide/mach-std#201** (Closes octalide/mach-std#200). This PR bumps the vendored submodule to that fix commit (`657d909`). Follow-up for the maintainer: merge mach-std#201, cut a mach-std patch release, and re-bump this submodule to the released main SHA per the usual pin convention.

## Verification

- `mach build .` clean; 3-stage self-host fixpoint byte-identical (stage2 == stage3).
- `mach test .` — 318 pass, 0 fail.
- All 16 `.github/tests/*/run.sh` integration suites pass, including `cffi`, `win64va`, and the wine win64 suites.
- Windows cross-compile + `wine mach.exe build .` smoke; the wine-built `mach.exe` is byte-identical to the cross-compiled one.

Refs #1257 #1253 #1251
