### PR TITLE
feat(cmp): value-correct mixed-numeric comparisons

### DIFF
--- a/.github/tests/mixedcmp/app/mach.toml
+++ b/.github/tests/mixedcmp/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "mixedcmpapp"
+name = "Mixed-numeric comparison test — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/mixedcmpapp"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/mixedcmp/app/src/main.mach
+++ b/.github/tests/mixedcmp/app/src/main.mach
@@ -1,0 +1,252 @@
+use std.runtime.linux.x86_64;
+
+# mixed-numeric comparison regression coverage (issues #1248 / #1251). Comparing
+# two numeric primitives is legal and compares MATHEMATICAL VALUES, so the result
+# is identical in either operand order — the original bug was an LHS-signedness
+# miscompile that flipped with operand order. Each `chk_*` asserts all six
+# operators in BOTH orders against the expected (lt, eq, gt) outcome and returns a
+# nonzero check id on any disagreement. Every operand is offset by a runtime,
+# non-foldable zero (`n = argc - 1`) so the comparison is genuinely lowered rather
+# than constant-folded.
+
+# asserts the six comparisons of a signed i64 against a u64 (the irreducible pair),
+# forward and reversed. lt/eq/gt are the expected a<b / a==b / a>b as 0/1.
+fun chk_i64_u64(a: i64, b: u64, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)           { ret base + 0; }
+    if ((a <= b) != (lt | eq))    { ret base + 1; }
+    if ((a >  b) != gt)           { ret base + 2; }
+    if ((a >= b) != (gt | eq))    { ret base + 3; }
+    if ((a == b) != eq)           { ret base + 4; }
+    if ((a != b) != (1 - eq))     { ret base + 5; }
+    if ((b <  a) != gt)           { ret base + 6; }
+    if ((b <= a) != (gt | eq))    { ret base + 7; }
+    if ((b >  a) != lt)           { ret base + 8; }
+    if ((b >= a) != (lt | eq))    { ret base + 9; }
+    if ((b == a) != eq)           { ret base + 10; }
+    if ((b != a) != (1 - eq))     { ret base + 11; }
+    ret 0;
+}
+
+# asserts the six comparisons of a signed i32 against a u32 (a reducible pair that
+# widens to i64), forward and reversed.
+fun chk_i32_u32(a: i32, b: u32, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)           { ret base + 0; }
+    if ((a <= b) != (lt | eq))    { ret base + 1; }
+    if ((a >  b) != gt)           { ret base + 2; }
+    if ((a >= b) != (gt | eq))    { ret base + 3; }
+    if ((a == b) != eq)           { ret base + 4; }
+    if ((a != b) != (1 - eq))     { ret base + 5; }
+    if ((b <  a) != gt)           { ret base + 6; }
+    if ((b <= a) != (gt | eq))    { ret base + 7; }
+    if ((b >  a) != lt)           { ret base + 8; }
+    if ((b >= a) != (lt | eq))    { ret base + 9; }
+    if ((b == a) != eq)           { ret base + 10; }
+    if ((b != a) != (1 - eq))     { ret base + 11; }
+    ret 0;
+}
+
+# asserts the six comparisons of a signed i8 against a u8 (a reducible pair whose
+# common type is wider than either operand), forward and reversed.
+fun chk_i8_u8(a: i8, b: u8, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)           { ret base + 0; }
+    if ((a <= b) != (lt | eq))    { ret base + 1; }
+    if ((a >  b) != gt)           { ret base + 2; }
+    if ((a >= b) != (gt | eq))    { ret base + 3; }
+    if ((a == b) != eq)           { ret base + 4; }
+    if ((a != b) != (1 - eq))     { ret base + 5; }
+    if ((b <  a) != gt)           { ret base + 6; }
+    if ((b <= a) != (gt | eq))    { ret base + 7; }
+    if ((b >  a) != lt)           { ret base + 8; }
+    if ((b >= a) != (lt | eq))    { ret base + 9; }
+    if ((b == a) != eq)           { ret base + 10; }
+    if ((b != a) != (1 - eq))     { ret base + 11; }
+    ret 0;
+}
+
+# asserts the six comparisons of a signed i8 against a u16 (mixed sign and width),
+# forward and reversed.
+fun chk_i8_u16(a: i8, b: u16, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)           { ret base + 0; }
+    if ((a <= b) != (lt | eq))    { ret base + 1; }
+    if ((a >  b) != gt)           { ret base + 2; }
+    if ((a >= b) != (gt | eq))    { ret base + 3; }
+    if ((a == b) != eq)           { ret base + 4; }
+    if ((a != b) != (1 - eq))     { ret base + 5; }
+    if ((b <  a) != gt)           { ret base + 6; }
+    if ((b <= a) != (gt | eq))    { ret base + 7; }
+    if ((b >  a) != lt)           { ret base + 8; }
+    if ((b >= a) != (lt | eq))    { ret base + 9; }
+    if ((b == a) != eq)           { ret base + 10; }
+    if ((b != a) != (1 - eq))     { ret base + 11; }
+    ret 0;
+}
+
+# asserts the six comparisons of a signed i64 against a u32 (signed operand wider),
+# forward and reversed.
+fun chk_i64_u32(a: i64, b: u32, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)           { ret base + 0; }
+    if ((a <= b) != (lt | eq))    { ret base + 1; }
+    if ((a >  b) != gt)           { ret base + 2; }
+    if ((a >= b) != (gt | eq))    { ret base + 3; }
+    if ((a == b) != eq)           { ret base + 4; }
+    if ((a != b) != (1 - eq))     { ret base + 5; }
+    if ((b <  a) != gt)           { ret base + 6; }
+    if ((b <= a) != (gt | eq))    { ret base + 7; }
+    if ((b >  a) != lt)           { ret base + 8; }
+    if ((b >= a) != (lt | eq))    { ret base + 9; }
+    if ((b == a) != eq)           { ret base + 10; }
+    if ((b != a) != (1 - eq))     { ret base + 11; }
+    ret 0;
+}
+
+# asserts the six comparisons of two same-signedness unsigned operands of mixed
+# width (u8 vs u64), forward and reversed.
+fun chk_u8_u64(a: u8, b: u64, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)           { ret base + 0; }
+    if ((a <= b) != (lt | eq))    { ret base + 1; }
+    if ((a >  b) != gt)           { ret base + 2; }
+    if ((a >= b) != (gt | eq))    { ret base + 3; }
+    if ((a == b) != eq)           { ret base + 4; }
+    if ((a != b) != (1 - eq))     { ret base + 5; }
+    if ((b <  a) != gt)           { ret base + 6; }
+    if ((b <= a) != (gt | eq))    { ret base + 7; }
+    if ((b >  a) != lt)           { ret base + 8; }
+    if ((b >= a) != (lt | eq))    { ret base + 9; }
+    if ((b == a) != eq)           { ret base + 10; }
+    if ((b != a) != (1 - eq))     { ret base + 11; }
+    ret 0;
+}
+
+# asserts the six comparisons of two same-signedness signed operands of mixed
+# width (i8 vs i64), forward and reversed.
+fun chk_i8_i64(a: i8, b: i64, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)           { ret base + 0; }
+    if ((a <= b) != (lt | eq))    { ret base + 1; }
+    if ((a >  b) != gt)           { ret base + 2; }
+    if ((a >= b) != (gt | eq))    { ret base + 3; }
+    if ((a == b) != eq)           { ret base + 4; }
+    if ((a != b) != (1 - eq))     { ret base + 5; }
+    if ((b <  a) != gt)           { ret base + 6; }
+    if ((b <= a) != (gt | eq))    { ret base + 7; }
+    if ((b >  a) != lt)           { ret base + 8; }
+    if ((b >= a) != (lt | eq))    { ret base + 9; }
+    if ((b == a) != eq)           { ret base + 10; }
+    if ((b != a) != (1 - eq))     { ret base + 11; }
+    ret 0;
+}
+
+# asserts the six comparisons of an f32 against an f64 (exact widening), forward
+# and reversed.
+fun chk_f32_f64(a: f32, b: f64, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)           { ret base + 0; }
+    if ((a <= b) != (lt | eq))    { ret base + 1; }
+    if ((a >  b) != gt)           { ret base + 2; }
+    if ((a >= b) != (gt | eq))    { ret base + 3; }
+    if ((a == b) != eq)           { ret base + 4; }
+    if ((a != b) != (1 - eq))     { ret base + 5; }
+    if ((b <  a) != gt)           { ret base + 6; }
+    if ((b <= a) != (gt | eq))    { ret base + 7; }
+    if ((b >  a) != lt)           { ret base + 8; }
+    if ((b >= a) != (lt | eq))    { ret base + 9; }
+    if ((b == a) != eq)           { ret base + 10; }
+    if ((b != a) != (1 - eq))     { ret base + 11; }
+    ret 0;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    val n:  u64 = argc::u64 - 1;
+    val zi: i64 = n::i64;
+    val zf32: f32 = n::f32;
+    val zf64: f64 = n::f64;
+
+    var r: i64 = 0;
+
+    # i64 vs u64 — the irreducible pair (sign-test + unsigned compare).
+    r = chk_i64_u64(zi - 1, 18446744073709551615::u64 + n, 1, 0, 0, 100);
+    if (r != 0) { ret r; }
+    r = chk_i64_u64((9223372036854775808::u64 + n)::i64, n, 1, 0, 0, 120);
+    if (r != 0) { ret r; }
+    r = chk_i64_u64(zi + 9223372036854775807, 9223372036854775807::u64 + n, 0, 1, 0, 140);
+    if (r != 0) { ret r; }
+    r = chk_i64_u64(zi + 9223372036854775807, 18446744073709551615::u64 + n, 1, 0, 0, 160);
+    if (r != 0) { ret r; }
+    r = chk_i64_u64(zi + 9223372036854775807, 9223372036854775808::u64 + n, 1, 0, 0, 180);
+    if (r != 0) { ret r; }
+    r = chk_i64_u64(zi + 5, 5::u64 + n, 0, 1, 0, 200);
+    if (r != 0) { ret r; }
+    r = chk_i64_u64(zi - 1, n, 1, 0, 0, 220);
+    if (r != 0) { ret r; }
+    r = chk_i64_u64(zi + 1, n, 0, 0, 1, 240);
+    if (r != 0) { ret r; }
+    r = chk_i64_u64(zi + 9223372036854775807, n, 0, 0, 1, 260);
+    if (r != 0) { ret r; }
+
+    # i32 vs u32 — reducible mixed sign, widen to i64.
+    r = chk_i32_u32((zi - 1)::i32, (n + 2147483648)::u32, 1, 0, 0, 300);
+    if (r != 0) { ret r; }
+    r = chk_i32_u32((zi - 1)::i32, (n)::u32, 1, 0, 0, 320);
+    if (r != 0) { ret r; }
+    r = chk_i32_u32((zi + 2147483647)::i32, (n + 2147483647)::u32, 0, 1, 0, 340);
+    if (r != 0) { ret r; }
+    r = chk_i32_u32((zi + 2147483647)::i32, (n + 2147483648)::u32, 1, 0, 0, 360);
+    if (r != 0) { ret r; }
+    r = chk_i32_u32((zi - 2147483648)::i32, (n)::u32, 1, 0, 0, 380);
+    if (r != 0) { ret r; }
+    r = chk_i32_u32((zi + 5)::i32, (n + 5)::u32, 0, 1, 0, 400);
+    if (r != 0) { ret r; }
+
+    # i8 vs u8 — reducible mixed sign, common type wider than either operand.
+    r = chk_i8_u8((zi - 1)::i8, (n + 255)::u8, 1, 0, 0, 500);
+    if (r != 0) { ret r; }
+    r = chk_i8_u8((zi - 1)::i8, (n)::u8, 1, 0, 0, 520);
+    if (r != 0) { ret r; }
+    r = chk_i8_u8((zi + 127)::i8, (n + 127)::u8, 0, 1, 0, 540);
+    if (r != 0) { ret r; }
+    r = chk_i8_u8((zi + 127)::i8, (n + 128)::u8, 1, 0, 0, 560);
+    if (r != 0) { ret r; }
+    r = chk_i8_u8((zi - 128)::i8, (n)::u8, 1, 0, 0, 580);
+    if (r != 0) { ret r; }
+
+    # i8 vs u16 — mixed sign and width.
+    r = chk_i8_u16((zi - 1)::i8, (n + 65535)::u16, 1, 0, 0, 700);
+    if (r != 0) { ret r; }
+    r = chk_i8_u16((zi + 127)::i8, (n + 200)::u16, 1, 0, 0, 720);
+    if (r != 0) { ret r; }
+    r = chk_i8_u16((zi + 100)::i8, (n + 50)::u16, 0, 0, 1, 740);
+    if (r != 0) { ret r; }
+    r = chk_i8_u16((zi + 100)::i8, (n + 100)::u16, 0, 1, 0, 760);
+    if (r != 0) { ret r; }
+
+    # i64 vs u32 — reducible mixed sign, signed operand already 64-bit.
+    r = chk_i64_u32(zi - 1, (n + 4294967295)::u32, 1, 0, 0, 900);
+    if (r != 0) { ret r; }
+    r = chk_i64_u32(zi + 5000000000, (n + 4294967295)::u32, 0, 0, 1, 920);
+    if (r != 0) { ret r; }
+    r = chk_i64_u32(zi + 4294967295, (n + 4294967295)::u32, 0, 1, 0, 940);
+    if (r != 0) { ret r; }
+
+    # u8 vs u64 — same signedness, mixed width.
+    r = chk_u8_u64((n + 255)::u8, 255::u64 + n, 0, 1, 0, 1100);
+    if (r != 0) { ret r; }
+    r = chk_u8_u64((n)::u8, 18446744073709551615::u64 + n, 1, 0, 0, 1120);
+    if (r != 0) { ret r; }
+
+    # i8 vs i64 — same signedness, mixed width (sign extension both sides).
+    r = chk_i8_i64((zi - 1)::i8, zi - 1, 0, 1, 0, 1300);
+    if (r != 0) { ret r; }
+    r = chk_i8_i64((zi - 128)::i8, zi, 1, 0, 0, 1320);
+    if (r != 0) { ret r; }
+    r = chk_i8_i64((zi + 127)::i8, zi + 1000, 1, 0, 0, 1340);
+    if (r != 0) { ret r; }
+
+    # f32 vs f64 — exact widening of the narrower operand.
+    r = chk_f32_f64(1.5::f32 + zf32, 1.5 + zf64, 0, 1, 0, 1500);
+    if (r != 0) { ret r; }
+    r = chk_f32_f64(1.5::f32 + zf32, 2.5 + zf64, 1, 0, 0, 1520);
+    if (r != 0) { ret r; }
+    r = chk_f32_f64(3.5::f32 + zf32, 2.5 + zf64, 0, 0, 1, 1540);
+    if (r != 0) { ret r; }
+
+    ret 0;
+}

--- a/.github/tests/mixedcmp/run.sh
+++ b/.github/tests/mixedcmp/run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# mixed-numeric comparison regression test (issues #1248 / #1251): build the
+# `app` project with the freshly-built compiler and run it. the app self-checks
+# integer comparisons across every signedness/width class and float-width
+# comparisons, asserting each boundary case in BOTH operand orders (the original
+# bug was an order-dependent miscompile), and exits 0 only when every result is
+# value-correct; any wrong comparison exits with a non-zero check id.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL mixedcmp: build failed" >&2
+    exit 1
+fi
+
+set +e
+"$WORK/app/out/linux/bin/mixedcmpapp"
+code=$?
+set -e
+
+if [ "$code" -ne 0 ]; then
+    echo "FAIL mixedcmp: comparison check $code produced a wrong result" >&2
+    exit 1
+fi
+
+echo "PASS mixedcmp: mixed-numeric comparisons value-correct and order-independent"
+exit 0

--- a/doc/language/operators.md
+++ b/doc/language/operators.md
@@ -28,7 +28,17 @@ val z: i32x4  = (m & n) ^ k;     # vectors not yet implemented
 ## Comparison
 
 `==` `!=` `<` `>` `<=` `>=` — produce `u8` (`1` or `0`). Mach has no compiler
-`bool`; `bool` is a stdlib alias for `u8`. Compare values of matching types.
+`bool`; `bool` is a stdlib alias for `u8`. Comparisons relate **mathematical
+values**, so the result is identical in either operand order:
+
+- **integer vs integer** — any signedness and width mix is legal and compares
+  the true values (e.g. a negative `i64` is never equal to, and always less
+  than, any `u64`). Width aliases (`usize`, `isize`) follow their backing type.
+- **float vs float** — any width mix is legal; the narrower operand widens
+  exactly (`f32` -> `f64`).
+- **integer vs float** — a compile error; cast one operand explicitly with
+  `::`. An implicit widening would hide `f64` rounding above `2^53`.
+
 A pointer may be compared against `nil` (the null-address literal). On the
 planned SIMD vectors, comparison produces a mask vector (lane-wise).
 

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -822,6 +822,74 @@ test "sema: a module-scope unannotated val reports an initializer error once (#1
     ret 0;
 }
 
+test "sema: mixed-signedness integer comparison is accepted (#1248)" {
+    var alloc: Allocator;
+    val srr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](srr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](srr);
+    var es: EditorSession = init(?s);
+
+    # i32 vs u64 compares mathematical values; sema must accept it without a
+    # type-mismatch, the lowering handles the value-correct sequence.
+    val fr: Result[src.FileId, str] = open(?es, "mix.mach",
+        "fun main() i64 { var a: i32 = 0; var b: u64 = 0; val c: u8 = a < b; ret c::i64; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag_has(unwrap_ok[*diag.DiagList, str](dr), "type mismatch")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: mixed-width float comparison is accepted (#1248)" {
+    var alloc: Allocator;
+    val srr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](srr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](srr);
+    var es: EditorSession = init(?s);
+
+    # f32 vs f64 widens exactly; sema must accept the comparison.
+    val fr: Result[src.FileId, str] = open(?es, "fmix.mach",
+        "fun main() i64 { var a: f32 = 0.0; var b: f64 = 0.0; val c: u8 = a < b; ret c::i64; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag_has(unwrap_ok[*diag.DiagList, str](dr), "type mismatch")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: integer-vs-float comparison is rejected and asks for an explicit cast (#1248)" {
+    var alloc: Allocator;
+    val srr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](srr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](srr);
+    var es: EditorSession = init(?s);
+
+    # an int vs float comparison is an error: a silent widening would hide f64
+    # rounding above 2^53. the diagnostic must tell the author to cast.
+    val fr: Result[src.FileId, str] = open(?es, "if.mach",
+        "fun main() i64 { var a: i32 = 0; var f: f64 = 0.0; val c: u8 = a < f; ret c::i64; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "cast one operand explicitly")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "diagnostics: unresolved identifier names the symbol and suggests a near match" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -523,6 +523,16 @@ pub fun is_integer(sc: *sema.SemaContext, t: ty.TypeId) bool {
     ret ty.is_integer(?sc.s.types, t);
 }
 
+# reports whether `t` is a float primitive (f32 or f64). delegates to the shared
+# kind-based predicate in the type layer.
+# ---
+# sc:  the active sema context
+# t:   a TypeId
+# ret: true for f32 or f64
+pub fun is_float(sc: *sema.SemaContext, t: ty.TypeId) bool {
+    ret ty.is_float(?sc.s.types, t);
+}
+
 # reports whether `t` is a primitive numeric type eligible for a numeric
 # cast. identical to `is_numeric`; named separately to mirror the cast-rule
 # vocabulary in the sema design.

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -352,18 +352,27 @@ fun infer_binary(sc: *sema.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, spa
     val both_int:  bool = is_integer(sc, lt) && is_integer(sc, rt);
     val operands_ok: bool = lt == rt || both_int;
 
+    # comparisons relate mathematical values, so any integer signedness/width mix
+    # and any float-width mix are legal — the lowering yields order-independent,
+    # value-correct results. a mixed integer/float pair is rejected: f64 rounding
+    # above 2^53 makes a silent widening hidden behavior, so the cast is explicit.
+    val both_float: bool = is_float(sc, lt) && is_float(sc, rt);
+    val int_float_mix: bool = (is_integer(sc, lt) && is_float(sc, rt)) ||
+                              (is_float(sc, lt) && is_integer(sc, rt));
+
     if (b.op == expr.BIN_EQ || b.op == expr.BIN_NEQ) {
         # equality also relates two address-shaped operands (pointers and
         # functions, both runtime code/data addresses). this covers `fn == nil`
         # / `fn != nil`, where `nil` types as `*u8`, without permitting nil to
-        # be assignable to a function type. cmach performs no operand-type
-        # check on comparisons at all.
+        # be assignable to a function type.
+        if (int_float_mix) { report_int_float_cmp(sc, span); ret type.TYPE_ERROR; }
         val addr_ok: bool = is_pointer_like(sc, lt) && is_pointer_like(sc, rt);
-        if (!operands_ok && !addr_ok) { type_mismatch(sc, span); ret type.TYPE_ERROR; }
+        if (!operands_ok && !both_float && !addr_ok) { type_mismatch(sc, span); ret type.TYPE_ERROR; }
         ret u8t;
     }
     if (b.op == expr.BIN_LT || b.op == expr.BIN_LEQ || b.op == expr.BIN_GT || b.op == expr.BIN_GEQ) {
-        if (!operands_ok || !is_numeric(sc, lt)) { type_mismatch(sc, span); ret type.TYPE_ERROR; }
+        if (int_float_mix) { report_int_float_cmp(sc, span); ret type.TYPE_ERROR; }
+        if (!both_int && !both_float) { type_mismatch(sc, span); ret type.TYPE_ERROR; }
         ret u8t;
     }
     if (b.op == expr.BIN_AND || b.op == expr.BIN_OR) {
@@ -1215,6 +1224,11 @@ fun is_integer(sc: *sema.SemaContext, ty: type.TypeId) bool {
     ret type.is_integer(?sc.s.types, ty);
 }
 
+# is the TypeId one of the float primitives f32 / f64?
+fun is_float(sc: *sema.SemaContext, ty: type.TypeId) bool {
+    ret type.is_float(?sc.s.types, ty);
+}
+
 # is the TypeId address-shaped — a raw `ptr`, a typed `*T`, or a function
 # (`TYPE_FUN`, a code address)? used by equality to relate `nil` against
 # pointer and function operands.
@@ -1238,6 +1252,12 @@ fun unify_literals(sc: *sema.SemaContext, lhs: id.ExprId, lt: type.TypeId, rhs: 
 # emits a `type mismatch:` diagnostic for a binary operand-type clash.
 fun type_mismatch(sc: *sema.SemaContext, span: token.Span) {
     sema.report(sc, span, "type mismatch: incompatible operand types");
+}
+
+# reports an integer-versus-float comparison, which is rejected because a silent
+# widening would hide f64 rounding above 2^53; the operand must be cast first.
+fun report_int_float_cmp(sc: *sema.SemaContext, span: token.Span) {
+    sema.report(sc, span, "type mismatch: cannot compare an integer and a float; cast one operand explicitly (`::`)");
 }
 
 # interns the identifier text covered by `span`, or STR_NIL for an empty span.

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1346,17 +1346,13 @@ fun lower_binary(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Resu
     val rty: ty.TypeId = lower.expr_type_of(ctx, e.data.binary.rhs);
     val signed: bool = is_signed_type(ctx, lty);
 
-    # a mixed-width integer comparison reads both operands at one width (the
-    # back end sizes the CMP from operand 0), so a narrower operand must be
-    # extended to the wider operand's width here, where signedness is known:
-    # sign-extension for a signed narrower operand (i8/i16), zero-extension for
-    # an unsigned one. the IR type carries no signedness, so the back end could
-    # not make this choice. non-comparison integer ops share the operand type
-    # via sema, so they need no unification.
-    if (is_compare_binop(op)) {
-        val ur: Result[bool, str] = unify_int_compare_widths(ctx, ?lhs, lty, ?rhs, rty);
-        if (is_err[bool, str](ur)) { ret err[value.Value, str](unwrap_err[bool, str](ur)); }
-    }
+    # comparisons compare mathematical values across any integer signedness /
+    # width mix and across float widths. lower_cmp owns the value-correct
+    # widening and the irreducible i64/u64 sign-test sequence; the back end's
+    # single-width CMP and the IR's signedness-free types make this the only
+    # layer that can choose extension and compare signedness from the semantic
+    # types. non-comparison integer ops share the operand type via sema.
+    if (is_compare_binop(op)) { ret lower_cmp(ctx, op, lhs, lty, rhs, rty); }
 
     if (op == aexpr.BIN_ADD) { ret builder.emit_add(?ctx.builder, lhs, rhs); }
     if (op == aexpr.BIN_SUB) { ret builder.emit_sub(?ctx.builder, lhs, rhs); }
@@ -1378,27 +1374,6 @@ fun lower_binary(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Resu
         ret builder.emit_shr_u(?ctx.builder, lhs, rhs);
     }
 
-    if (op == aexpr.BIN_EQ)  { ret builder.emit_cmp_eq(?ctx.builder, lhs, rhs); }
-    if (op == aexpr.BIN_NEQ) { ret builder.emit_cmp_ne(?ctx.builder, lhs, rhs); }
-    if (op == aexpr.BIN_LT) {
-        if (signed) { ret builder.emit_cmp_lt_s(?ctx.builder, lhs, rhs); }
-        ret builder.emit_cmp_lt_u(?ctx.builder, lhs, rhs);
-    }
-    if (op == aexpr.BIN_LEQ) {
-        if (signed) { ret builder.emit_cmp_le_s(?ctx.builder, lhs, rhs); }
-        ret builder.emit_cmp_le_u(?ctx.builder, lhs, rhs);
-    }
-    if (op == aexpr.BIN_GT) {
-        # a > b  ==  b < a
-        if (signed) { ret builder.emit_cmp_lt_s(?ctx.builder, rhs, lhs); }
-        ret builder.emit_cmp_lt_u(?ctx.builder, rhs, lhs);
-    }
-    if (op == aexpr.BIN_GEQ) {
-        # a >= b  ==  b <= a
-        if (signed) { ret builder.emit_cmp_le_s(?ctx.builder, rhs, lhs); }
-        ret builder.emit_cmp_le_u(?ctx.builder, rhs, lhs);
-    }
-
     ret err[value.Value, str]("lower: unsupported binary operator");
 }
 
@@ -1410,15 +1385,198 @@ fun is_compare_binop(op: aexpr.BinOp) bool {
         op == aexpr.BIN_GT  || op == aexpr.BIN_GEQ;
 }
 
-# extends the narrower operand of a mixed-width integer comparison up to the
+# lowers a comparison to its value-correct u8 result. comparisons relate the
+# mathematical values of the operands, so the result is identical in both
+# operand orders regardless of signedness or width:
+#   - float vs float: widen the narrower side (exact) and compare as floats;
+#     sema rejects int vs float, so a float operand implies both are floats.
+#   - same signedness: widen the narrower side per that signedness, compare as
+#     it (pointers fall here: unsigned, equal width).
+#   - mixed signedness with the unsigned operand narrower than 64 bits: it fits
+#     positive in i64, so widen each per its own signedness to 64 bits and
+#     compare signed.
+#   - the irreducible i64/u64 pair: no common wider integer, so emit a sign-test
+#     on the signed operand plus an unsigned compare (a negative signed value is
+#     less than every u64 and equal to none).
+fun lower_cmp(ctx: *lower.LowerContext, op: aexpr.BinOp, lhs: value.Value, lty: ty.TypeId, rhs: value.Value, rty: ty.TypeId) Result[value.Value, str] {
+    if (is_float_type(ctx, lty) || is_float_type(ctx, rty)) {
+        var fl: value.Value = lhs;
+        var fr: value.Value = rhs;
+        val ur: Result[bool, str] = unify_float_compare_widths(ctx, ?fl, lty, ?fr, rty);
+        if (is_err[bool, str](ur)) { ret err[value.Value, str](unwrap_err[bool, str](ur)); }
+        ret emit_cmp_int(ctx, op, false, fl, fr);
+    }
+
+    val ls: bool = is_signed_type(ctx, lty);
+    val rs: bool = is_signed_type(ctx, rty);
+
+    if (ls == rs) {
+        var sl: value.Value = lhs;
+        var sr: value.Value = rhs;
+        val ur: Result[bool, str] = unify_int_compare_widths(ctx, ?sl, lty, ?sr, rty);
+        if (is_err[bool, str](ur)) { ret err[value.Value, str](unwrap_err[bool, str](ur)); }
+        ret emit_cmp_int(ctx, op, ls, sl, sr);
+    }
+
+    # mixed signedness: name the signed and unsigned operand, keeping track of
+    # which one was the left-hand side so the operator stays oriented.
+    var s_val: value.Value = lhs;
+    var s_ty:  ty.TypeId   = lty;
+    var u_val: value.Value = rhs;
+    var u_ty:  ty.TypeId   = rty;
+    var s_is_lhs: bool     = true;
+    if (!ls) {
+        s_val = rhs; s_ty = rty; u_val = lhs; u_ty = lty; s_is_lhs = false;
+    }
+
+    val ty64r: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](ty64r)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](ty64r)); }
+    val ty64: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](ty64r);
+
+    val s64r: Result[value.Value, str] = widen_signed_to_i64(ctx, s_val, s_ty, ty64);
+    if (is_err[value.Value, str](s64r)) { ret s64r; }
+    val s64: value.Value = unwrap_ok[value.Value, str](s64r);
+
+    if (scalar_bits(ctx, u_ty) < 64) {
+        # reducible: the unsigned operand zero-extends to a positive i64, so a
+        # signed 64-bit compare in the original operand order is value-correct.
+        val u64r: Result[value.Value, str] = builder.emit_zext(?ctx.builder, u_val, ty64);
+        if (is_err[value.Value, str](u64r)) { ret u64r; }
+        val u64v: value.Value = unwrap_ok[value.Value, str](u64r);
+        if (s_is_lhs) { ret emit_cmp_int(ctx, op, true, s64, u64v); }
+        ret emit_cmp_int(ctx, op, true, u64v, s64);
+    }
+
+    ret lower_cmp_signed_u64(ctx, op, s64, u_val, s_is_lhs, ty64);
+}
+
+# emits an integer (or, with `signed` false, a float-or-unsigned) comparison for
+# `op` over operands already unified to a single width. `>` and `>=` reuse `<` /
+# `<=` with the operands swapped.
+fun emit_cmp_int(ctx: *lower.LowerContext, op: aexpr.BinOp, signed: bool, lhs: value.Value, rhs: value.Value) Result[value.Value, str] {
+    if (op == aexpr.BIN_EQ)  { ret builder.emit_cmp_eq(?ctx.builder, lhs, rhs); }
+    if (op == aexpr.BIN_NEQ) { ret builder.emit_cmp_ne(?ctx.builder, lhs, rhs); }
+    if (op == aexpr.BIN_LT) {
+        if (signed) { ret builder.emit_cmp_lt_s(?ctx.builder, lhs, rhs); }
+        ret builder.emit_cmp_lt_u(?ctx.builder, lhs, rhs);
+    }
+    if (op == aexpr.BIN_LEQ) {
+        if (signed) { ret builder.emit_cmp_le_s(?ctx.builder, lhs, rhs); }
+        ret builder.emit_cmp_le_u(?ctx.builder, lhs, rhs);
+    }
+    if (op == aexpr.BIN_GT) {
+        if (signed) { ret builder.emit_cmp_lt_s(?ctx.builder, rhs, lhs); }
+        ret builder.emit_cmp_lt_u(?ctx.builder, rhs, lhs);
+    }
+    if (op == aexpr.BIN_GEQ) {
+        if (signed) { ret builder.emit_cmp_le_s(?ctx.builder, rhs, lhs); }
+        ret builder.emit_cmp_le_u(?ctx.builder, rhs, lhs);
+    }
+    ret err[value.Value, str]("lower: unsupported comparison operator");
+}
+
+# sign-extends a signed integer value to 64 bits, or returns it unchanged when
+# it is already 64-bit wide.
+fun widen_signed_to_i64(ctx: *lower.LowerContext, v: value.Value, vty: ty.TypeId, ty64: ir_type.IrTypeId) Result[value.Value, str] {
+    if (scalar_bits(ctx, vty) >= 64) { ret ok[value.Value, str](v); }
+    ret builder.emit_sext(?ctx.builder, v, ty64);
+}
+
+# lowers the irreducible i64/u64 comparison. `s64` is the signed operand widened
+# to 64 bits, `u` the u64 operand, and `s_is_lhs` records whether the signed
+# operand was the left-hand side (so the operator can be re-oriented to `s op u`
+# form). a negative signed value is below every u64; a non-negative one compares
+# bit-identically as unsigned. composition is branch-free: every input is a 0/1
+# setcc result, so `||` is a bitwise OR and `&&` a bitwise AND.
+fun lower_cmp_signed_u64(ctx: *lower.LowerContext, op: aexpr.BinOp, s64: value.Value, u: value.Value, s_is_lhs: bool, ty64: ir_type.IrTypeId) Result[value.Value, str] {
+    var nop: aexpr.BinOp = op;
+    if (!s_is_lhs) { nop = swap_cmp_op(op); }
+    val zero: value.Value = value.const_int(0, ty64);
+
+    if (nop == aexpr.BIN_LT) {
+        # s < u  ==  s < 0 || s::u64 < u
+        ret cmp_or(ctx, builder.emit_cmp_lt_s(?ctx.builder, s64, zero),
+                        builder.emit_cmp_lt_u(?ctx.builder, s64, u));
+    }
+    if (nop == aexpr.BIN_LEQ) {
+        # s <= u  ==  s < 0 || s::u64 <= u
+        ret cmp_or(ctx, builder.emit_cmp_lt_s(?ctx.builder, s64, zero),
+                        builder.emit_cmp_le_u(?ctx.builder, s64, u));
+    }
+    if (nop == aexpr.BIN_GT) {
+        # s > u  ==  s >= 0 && u < s::u64
+        ret cmp_and(ctx, builder.emit_cmp_le_s(?ctx.builder, zero, s64),
+                         builder.emit_cmp_lt_u(?ctx.builder, u, s64));
+    }
+    if (nop == aexpr.BIN_GEQ) {
+        # s >= u  ==  s >= 0 && u <= s::u64
+        ret cmp_and(ctx, builder.emit_cmp_le_s(?ctx.builder, zero, s64),
+                         builder.emit_cmp_le_u(?ctx.builder, u, s64));
+    }
+    if (nop == aexpr.BIN_EQ) {
+        # s == u  ==  s >= 0 && s::u64 == u
+        ret cmp_and(ctx, builder.emit_cmp_le_s(?ctx.builder, zero, s64),
+                         builder.emit_cmp_eq(?ctx.builder, s64, u));
+    }
+    if (nop == aexpr.BIN_NEQ) {
+        # s != u  ==  s < 0 || s::u64 != u
+        ret cmp_or(ctx, builder.emit_cmp_lt_s(?ctx.builder, s64, zero),
+                        builder.emit_cmp_ne(?ctx.builder, s64, u));
+    }
+    ret err[value.Value, str]("lower: unsupported comparison operator");
+}
+
+# returns the operator that compares the same pair with the operands swapped:
+# `<`<->`>`, `<=`<->`>=`; equality and inequality are symmetric.
+fun swap_cmp_op(op: aexpr.BinOp) aexpr.BinOp {
+    if (op == aexpr.BIN_LT)  { ret aexpr.BIN_GT; }
+    if (op == aexpr.BIN_LEQ) { ret aexpr.BIN_GEQ; }
+    if (op == aexpr.BIN_GT)  { ret aexpr.BIN_LT; }
+    if (op == aexpr.BIN_GEQ) { ret aexpr.BIN_LEQ; }
+    ret op;
+}
+
+# bitwise-ORs two 0/1 comparison results, short-circuiting on either error.
+fun cmp_or(ctx: *lower.LowerContext, a: Result[value.Value, str], b: Result[value.Value, str]) Result[value.Value, str] {
+    if (is_err[value.Value, str](a)) { ret a; }
+    if (is_err[value.Value, str](b)) { ret b; }
+    ret builder.emit_or(?ctx.builder, unwrap_ok[value.Value, str](a), unwrap_ok[value.Value, str](b));
+}
+
+# bitwise-ANDs two 0/1 comparison results, short-circuiting on either error.
+fun cmp_and(ctx: *lower.LowerContext, a: Result[value.Value, str], b: Result[value.Value, str]) Result[value.Value, str] {
+    if (is_err[value.Value, str](a)) { ret a; }
+    if (is_err[value.Value, str](b)) { ret b; }
+    ret builder.emit_and(?ctx.builder, unwrap_ok[value.Value, str](a), unwrap_ok[value.Value, str](b));
+}
+
+# widens the narrower operand of a mixed-width float comparison up to the wider
+# operand's precision, in place, via an exact float extension. equal-width pairs
+# are left untouched.
+fun unify_float_compare_widths(ctx: *lower.LowerContext, lhs: *value.Value, lty: ty.TypeId, rhs: *value.Value, rty: ty.TypeId) Result[bool, str] {
+    val lw: u32 = scalar_bits(ctx, lty);
+    val rw: u32 = scalar_bits(ctx, rty);
+    if (lw == rw) { ret ok[bool, str](true); }
+    if (lw < rw) {
+        val xr: Result[value.Value, str] = builder.emit_fp_ext(?ctx.builder, @lhs, rhs.ty);
+        if (is_err[value.Value, str](xr)) { ret err[bool, str](unwrap_err[value.Value, str](xr)); }
+        @lhs = unwrap_ok[value.Value, str](xr);
+        ret ok[bool, str](true);
+    }
+    val xr: Result[value.Value, str] = builder.emit_fp_ext(?ctx.builder, @rhs, lhs.ty);
+    if (is_err[value.Value, str](xr)) { ret err[bool, str](unwrap_err[value.Value, str](xr)); }
+    @rhs = unwrap_ok[value.Value, str](xr);
+    ret ok[bool, str](true);
+}
+
+# extends the narrower operand of a same-signedness integer comparison up to the
 # wider operand's bit width, in place, so the back end's single-width CMP reads
 # two correctly-extended values. a signed narrower operand is sign-extended, an
 # unsigned one zero-extended (the IR type carries no signedness, so this choice
-# must be made here from the semantic types). float and equal-width / non-scalar
-# pairs are left untouched. the narrower operand takes on the wider operand's
-# own IR type, the width the back end already sizes the CMP from.
+# must be made here from the semantic types). equal-width / non-scalar pairs are
+# left untouched. the narrower operand takes on the wider operand's own IR type,
+# the width the back end already sizes the CMP from.
 fun unify_int_compare_widths(ctx: *lower.LowerContext, lhs: *value.Value, lty: ty.TypeId, rhs: *value.Value, rty: ty.TypeId) Result[bool, str] {
-    if (is_float_type(ctx, lty) || is_float_type(ctx, rty)) { ret ok[bool, str](true); }
     val lw: u32 = scalar_bits(ctx, lty);
     val rw: u32 = scalar_bits(ctx, rty);
     if (lw == 0 || rw == 0 || lw == rw) { ret ok[bool, str](true); }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -1455,12 +1455,15 @@ fun encode_movzx(mi: *isa.Inst, buf: *ByteBuf) i32 {
     ret 0;
 }
 
-# encode_movsx: encode a sign-extending move from an 8- or 16-bit source.
+# encode_movsx: encode a sign-extending move. an 8- or 16-bit source uses the
+# 0F BE / 0F BF forms; a 32-bit source must use MOVSXD (0x63), since those forms
+# read only one or two bytes and would truncate a 32-bit operand.
 fun encode_movsx(mi: *isa.Inst, buf: *ByteBuf) i32 {
     val start: usize = buf.len;
     val dst: *isa.Operand = ?mi.dst;
     val src1: *isa.Operand = ?mi.src1;
     val src_size: u8 = src1.size;
+    if (src_size == 4) { ret encode_movsxd(mi, buf); }
     val w: u8 = size_to_w(mi.size, mi.flags);
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG) {

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -413,6 +413,18 @@ pub fun is_numeric(ti: *TypeInterner, tid: TypeId) bool {
     ret unwrap[*Type](t_opt).kind::u32 <= TYPE_F64::u32;
 }
 
+# is_float: whether `tid` is a float primitive (f32 or f64).
+# ---
+# ti:  the interner
+# tid: the TypeId to classify
+# ret: true for f32 or f64
+pub fun is_float(ti: *TypeInterner, tid: TypeId) bool {
+    val t_opt: Option[*Type] = get(ti, tid);
+    if (is_none[*Type](t_opt)) { ret false; }
+    val k: u32 = unwrap[*Type](t_opt).kind::u32;
+    ret k == TYPE_F32::u32 || k == TYPE_F64::u32;
+}
+
 # is_pointer_like: whether `tid` is address-shaped — a raw `ptr`, a typed `*T`,
 # or a function (a code address). used to relate `nil` and reinterpret casts
 # against pointer and function operands.


### PR DESCRIPTION
Implements the maintainer ruling on #1248: comparing two numeric primitives is **legal** and compares **mathematical values**, with results identical in either operand order — no cast ceremony for an `i32`-vs-`u64` GTE. Refs #1248 #1251.

## Semantics (per pair-class)

- **integer vs integer, same signedness** — widen the narrower operand per that signedness, compare as it (pointers fall here: unsigned, equal width).
- **integer vs integer, mixed signedness, unsigned operand < 64 bits** — it fits positive in `i64`, so widen each per its own signedness to `i64` and compare **signed** (e.g. `i32` vs `u32`, `i8` vs `u16`, `i64` vs `u32`).
- **the irreducible `i64`/`u64` pair** — no common wider integer, so emit a sign-test plus an unsigned compare: a negative signed value is below every `u64` and equal to none. All six operators derived consistently, branch-free (each input is a 0/1 setcc, so `||`/`&&` are bitwise OR/AND).
- **float vs float** — widen the narrower exactly (`f32` -> `f64`), compare as floats.
- **integer vs float** — rejected at sema with a cast-explicitly diagnostic (an `f64` widening above `2^53` would hide rounding; pending a separate maintainer call).

Sema acceptance is now explicit and typed (no pass-through hole). `operators.md` documents the rule.

## Prerequisite backend fix (flagged)

Verification surfaced a **pre-existing** backend miscompile (present in the released seed): `encode_movsx` emitted the 16-bit `0F BF` form for a 32-bit source, so every **register `i32 -> i64` sign-extension read only the low 16 bits** — silently corrupting positive `i32::i64` casts and mixed-width signed compares. Fixed by routing a 32-bit source through `MOVSXD` (REX.W + 0x63). This lives in `src/lang/target/isa/x64/encode.mach`, which overlaps the concurrent ABI-boundary work in `target/`; the hunk is tight and the branch is rebased on current `dev`.

## Tests

- Inline sema tests: mixed-signedness int and mixed-width float comparisons accepted; int-vs-float rejected with the cast diagnostic.
- Runtime suite `.github/tests/mixedcmp`: every comparison class across boundary values (`-1 i64` vs `u64` max, `i64` min vs `0u64`, `0x80000000 u32` vs `-1 i32`, equal cross-sign pairs, float widths), each asserted in **both operand orders** (the headline regression was order dependence).

## Verification

`mach build .` clean; `mach test .` all pass (297 inline); self-host **fixpoint converges** (stage2 == stage3 byte-identical); full `.github/tests` battery green incl. wine suites; windows cross-compile + `wine mach.exe build .` smoke green.