### PR TITLE
fix(init): scaffold mach-std ref against branch/main

### DIFF
--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -27,7 +27,7 @@ use util: mach.cli.util;
 use dep:  mach.cli.cmd.dep;
 
 val MACH_STD_URL: *u8 = "https://github.com/octalide/mach-std";
-val MACH_STD_REF: *u8 = "branch/dev";
+val MACH_STD_REF: *u8 = "branch/main";
 
 # host_os: the running compiler's host os name, resolved at comptime.
 fun host_os() *u8 {


### PR DESCRIPTION
Flips `mach init`'s scaffolded `[deps.mach-std]` ref (`MACH_STD_REF` in `src/cli/cmd/init.mach`) from `branch/dev` to `branch/main`.

## Why

#1239 was blocked because mach-std `main` was ~270 commits / months stale (v0.2.5), so a `branch/main` scaffold failed at its own `use std.runtime; use std.print`. That blocker is now cleared: the mach-std `dev → main` sync shipped **v0.4.1** (main `c49d4f0`), so `main` carries the current std.

## Scope

Scaffold default ref only. This repo's own `[deps.mach-std]` and the vendored submodule are intentionally left untouched.

## Verification

Built this branch's compiler and ran a full end-to-end scaffold against `main`:

```
$ mach init . --name myapp          # scaffolds ref = "branch/main", syncs mach-std @ c49d4f0 (v0.4.1)
$ mach build .                      # exit 0
$ mach run .                        # exit 0
Hello, World!
```

The #1239 evidence failure mode (`use std.runtime; use std.print` failing to resolve) is gone — the scaffold builds and runs cleanly.

Closes #1239