### PR TITLE
fix(ir): exact teardown ownership (operand cap + agg blobs) and aggregate phi in verifier

### DIFF
--- a/.github/tests/relverify/app/src/main.mach
+++ b/.github/tests/relverify/app/src/main.mach
@@ -1,12 +1,13 @@
-# release-pipeline --verify-ir regression for #1252. The release pipeline
+# release-pipeline --verify-ir regression for #1252 / #1280. The release pipeline
 # (inline + late constfold/algebraic/cse/constfold/dce) once produced IR the
 # aggregate-representation verifier rejected on virtually any program: inline
 # built a result phi even for a single returning predecessor, and an
 # aggregate-returning callee's phi is not address-producing. This library
 # exercises that path — a scalar single-return inline whose constant must
-# propagate, a single-return aggregate inline, and an ignored argument whose
-# computation becomes dead — and is built with `--release --verify-ir`, which
-# must pass.
+# propagate, a single-return aggregate inline, a MULTI-return aggregate inline
+# (whose two return sites legitimately merge into an aggregate result phi — the
+# #1280 case the verifier must accept), and an ignored argument whose computation
+# becomes dead — and is built with `--release --verify-ir`, which must pass.
 
 # a 16-byte aggregate, returned by address.
 rec Pair { a: i64; b: i64; }
@@ -25,6 +26,23 @@ pub fun mk(x: i64) Pair {
     ret p;
 }
 
+# aggregate MULTI-return: returns the aggregate from two distinct sites. when
+# inlined, the two `ret` sites merge into a result OP_PHI over the return-storage
+# pointers — an aggregate-typed phi. the verifier must treat that phi as
+# address-producing (#1280); before the fix it flunked VC_AGG_ADDRESS and the
+# --release --verify-ir build failed here.
+pub fun pick(c: i64) Pair {
+    var p: Pair;
+    if (c != 0) {
+        p.a = 1;
+        p.b = 2;
+        ret p;
+    }
+    p.a = 3;
+    p.b = 4;
+    ret p;
+}
+
 # ignores its argument: after inlining, the caller's argument computation is
 # dead and must not be pinned by the unlinked call ghost.
 pub fun ignore(x: i64) i64 { ret 0; }
@@ -32,6 +50,7 @@ pub fun ignore(x: i64) i64 { ret 0; }
 pub fun driver(n: i64) i64 {
     val s: i64 = five() - 5;
     val p: Pair = mk(n);
+    val q: Pair = pick(n);
     val z: i64 = ignore(n * 999 + 3);
-    ret s + p.a + p.b + z;
+    ret s + p.a + p.b + q.a + q.b + z;
 }

--- a/.github/tests/relverify/run.sh
+++ b/.github/tests/relverify/run.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
-# release-pipeline IR-verification regression (issue #1252): build the `app`
-# library with `--release --verify-ir`. The release pipeline used to emit IR the
-# aggregate-representation verifier rejected on almost any program (inline's
+# release-pipeline IR-verification regression (issues #1252 / #1280): build the
+# `app` library with `--release --verify-ir`. The release pipeline used to emit IR
+# the aggregate-representation verifier rejected on almost any program (inline's
 # single-return result phi over an aggregate, plus a too-strict post-inline
-# reachability gate), so `mach build . --release --verify-ir` failed on a
-# hello-world. The app exercises scalar and aggregate single-return inlining,
-# constant propagation across an inline boundary, and a dead inlined-argument
-# computation; the build must pass at both -O0 and --release under --verify-ir.
+# reachability gate), and an aggregate callee returning from two or more sites
+# merges into an aggregate result phi the verifier rejected (#1280), so
+# `mach build . --release --verify-ir` failed on a hello-world. The app exercises
+# scalar and aggregate single-return inlining, a multi-return aggregate inline
+# (the result-phi case), constant propagation across an inline boundary, and a
+# dead inlined-argument computation; the build must pass at both -O0 and --release
+# under --verify-ir.
 #
 # usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -27,9 +30,9 @@ if ! ( cd "$WORK/app" && "$MACH" build . --verify-ir ) >/dev/null 2>&1; then
 fi
 
 if ! ( cd "$WORK/app" && "$MACH" build . --release --verify-ir ) >/dev/null 2>&1; then
-    echo "FAIL relverify: --release --verify-ir build failed (inline aggregate phi / post-inline gate)" >&2
+    echo "FAIL relverify: --release --verify-ir build failed (inline aggregate result phi / post-inline gate)" >&2
     exit 1
 fi
 
-echo "PASS relverify: release pipeline passes --verify-ir on inlined aggregate/constant-propagation paths"
+echo "PASS relverify: release pipeline passes --verify-ir on inlined aggregate (incl. multi-return phi) / constant-propagation paths"
 exit 0

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -13,6 +13,7 @@
 
 use std.types.bool.bool;
 use std.types.bool.true;
+use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.option.Option;
@@ -34,6 +35,9 @@ use std.allocator.deallocate;
 use std.allocator.reallocate;
 
 use map: std.collections.map;
+
+use page: std.allocator.page;
+use pmem: std.system.os;
 
 use intern:  mach.lang.intern;
 use ir_type: mach.lang.me.ir.type;
@@ -333,7 +337,8 @@ pub fun init_module(alloc: *Allocator, name: intern.StrId) Result[Module, str] {
 }
 
 # releases every owned array in the module: each function's blocks and asm
-# map, the function and global arrays, and the IR type table. safe on nil.
+# map, each VAL_CONST_AGG global initializer's blob and relocation table, the
+# function and global arrays, and the IR type table. safe on nil.
 # ---
 # m: the module to tear down; all owned storage is freed
 pub fun dnit_module(m: *Module) {
@@ -343,6 +348,15 @@ pub fun dnit_module(m: *Module) {
     for (f < m.function_len) {
         dnit_function(m, ?m.functions[f]);
         f = f + 1;
+    }
+
+    # a VAL_CONST_AGG initializer's blob and reloc table are owned by the module
+    # allocator (materialised once during lowering, see me.lower.constagg) and
+    # appear only as global initializers, so a single walk frees each exactly once.
+    var g: u32 = 0;
+    for (g < m.global_len) {
+        dnit_agg_value(m, ?m.globals[g].init);
+        g = g + 1;
     }
 
     if (m.functions != nil && m.function_cap > 0) {
@@ -407,10 +421,25 @@ fun dnit_function(m: *Module, fn: *Function) {
     map.dnit[id.InstructionId, IrAsm](?fn.asm_blocks);
 }
 
-# frees one instruction's owned operand array. safe on a zero-operand instruction.
+# frees one instruction's owned operand array, sized by `operand_cap` (the
+# allocation size) rather than `operand_count` (a live prefix a pass may have
+# shrunk). safe on a zero-operand instruction.
 fun dnit_instruction(m: *Module, inst: *instr.Instruction) {
-    if (inst.operands != nil && inst.operand_count > 0) {
-        deallocate[value.Value](m.alloc, inst.operands, inst.operand_count::usize);
+    if (inst.operands != nil && inst.operand_cap > 0) {
+        deallocate[value.Value](m.alloc, inst.operands, inst.operand_cap::usize);
+    }
+}
+
+# frees a VAL_CONST_AGG value's owned blob and relocation table; the relocs are
+# sized by `reloc_cap` (the allocation size), not `reloc_count` (the live prefix).
+# a no-op for any other value kind, so it is safe to call on every global's init.
+fun dnit_agg_value(m: *Module, v: *value.Value) {
+    if (v.kind != value.VAL_CONST_AGG) { ret; }
+    if (v.data.agg.bytes != nil && v.data.agg.len > 0) {
+        deallocate[u8](m.alloc, v.data.agg.bytes, v.data.agg.len::usize);
+    }
+    if (v.data.agg.relocs != nil && v.data.agg.reloc_cap > 0) {
+        deallocate[value.AggReloc](m.alloc, v.data.agg.relocs, v.data.agg.reloc_cap::usize);
     }
 }
 
@@ -499,6 +528,10 @@ pub fun get_instruction(fn: *Function, i: id.InstructionId) Option[*instr.Instru
 # appends an instruction to a function's pool, growing it as needed, and
 # returns its freshly assigned InstructionId. the instruction's `block` field
 # is the caller's responsibility; this only manages pool storage and identity.
+# the operand array a caller hands in is freshly allocated to exactly
+# `operand_count`, so `operand_cap` is normalized to match here; a caller that
+# later grows the operands in place (e.g. appending phi incomings) must keep
+# `operand_cap` in step so teardown frees the true allocation size.
 # ---
 # m:    module owning the allocator
 # fn:   the function whose pool receives the instruction
@@ -516,8 +549,10 @@ pub fun add_instruction(m: *Module, fn: *Function, inst: instr.Instruction) Resu
         fn.instrs    = unwrap_ok[*instr.Instruction, str](r);
         fn.instr_cap = new_cap;
     }
+    var stored: instr.Instruction = inst;
+    stored.operand_cap = stored.operand_count;
     val iid: id.InstructionId = fn.instr_len::id.InstructionId;
-    fn.instrs[fn.instr_len] = inst;
+    fn.instrs[fn.instr_len] = stored;
     fn.instr_len = fn.instr_len + 1;
     ret ok[id.InstructionId, str](iid);
 }
@@ -707,4 +742,210 @@ pub fun rebuild_preds(m: *Module, fn: *Function) Result[bool, str] {
         s = s + 1;
     }
     ret ok[bool, str](true);
+}
+
+# test scaffolding: a size-checking allocator over raw pages. it records every
+# live allocation's exact byte size and, on free/realloc, asserts the size the
+# caller supplies matches the size the pointer was allocated with — so a teardown
+# that frees an operand array by a shrunk `operand_count` (rather than its
+# `operand_cap`) is caught as a size mismatch, and a never-freed agg blob is caught
+# as a residual live entry. lets the page-allocator teardown contract be tested
+# without relying on the arena masking every `deallocate`.
+rec TrackEntry {
+    p:    ptr;
+    size: usize;
+    live: bool;
+}
+
+# size-checking allocator state; `ctx` of the test Allocator points at one.
+# ---
+# entries:  recorded allocations (page-backed, outside the tracked set)
+# cap:      capacity of `entries`
+# count:    number of recorded entries
+# live:     number of entries still allocated (not yet freed)
+# mismatch: set when a free/realloc supplied the wrong size for a pointer
+# overflow: set when `entries` filled — the test result is then invalid
+rec Tracker {
+    entries:  *TrackEntry;
+    cap:      u32;
+    count:    u32;
+    live:     u32;
+    mismatch: bool;
+    overflow: bool;
+}
+
+# records a fresh (p, size) allocation, flagging overflow if the table is full.
+fun track_record(t: *Tracker, p: ptr, size: usize) {
+    if (t.count >= t.cap) { t.overflow = true; ret; }
+    t.entries[t.count].p    = p;
+    t.entries[t.count].size = size;
+    t.entries[t.count].live = true;
+    t.count = t.count + 1;
+    t.live  = t.live + 1;
+}
+
+# index of the live entry for `p`, or -1 if none is live.
+fun track_find(t: *Tracker, p: ptr) i64 {
+    var i: u32 = 0;
+    for (i < t.count) {
+        if (t.entries[i].live && t.entries[i].p == p) { ret i::i64; }
+        i = i + 1;
+    }
+    ret 0 - 1;
+}
+
+# true when `p` was allocated and has since been freed with a matching size.
+fun track_is_freed(t: *Tracker, p: ptr) bool {
+    var i: u32 = 0;
+    for (i < t.count) {
+        if (t.entries[i].p == p && t.entries[i].live == false) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+fun track_allocate(ctx: ptr, size: usize, align: usize) Option[ptr] {
+    if (size == 0) { ret some[ptr](nil); }
+    val t: *Tracker = ctx::*Tracker;
+    val p: ptr = pmem.allocate(size);
+    if (p == nil) { ret none[ptr](); }
+    track_record(t, p, size);
+    ret some[ptr](p);
+}
+
+fun track_deallocate(ctx: ptr, p: ptr, size: usize, align: usize) i64 {
+    if (p == nil || size == 0) { ret 0; }
+    val t: *Tracker = ctx::*Tracker;
+    val idx: i64 = track_find(t, p);
+    if (idx < 0) { t.mismatch = true; ret 0; }
+    if (t.entries[idx::u32].size != size) { t.mismatch = true; }
+    t.entries[idx::u32].live = false;
+    t.live = t.live - 1;
+    ret pmem.deallocate(p, size);
+}
+
+fun track_reallocate(ctx: ptr, p: ptr, old_size: usize, new_size: usize, align: usize) Option[ptr] {
+    if (p == nil) { ret track_allocate(ctx, new_size, align); }
+    if (new_size == 0) {
+        track_deallocate(ctx, p, old_size, align);
+        ret some[ptr](nil);
+    }
+    val t: *Tracker = ctx::*Tracker;
+    val idx: i64 = track_find(t, p);
+    if (idx < 0) { t.mismatch = true; }
+    or { if (t.entries[idx::u32].size != old_size) { t.mismatch = true; } }
+    val np: ptr = pmem.reallocate(p, old_size, new_size);
+    if (np == nil) { ret none[ptr](); }
+    if (idx < 0) { track_record(t, np, new_size); }
+    or {
+        t.entries[idx::u32].p    = np;
+        t.entries[idx::u32].size = new_size;
+    }
+    ret some[ptr](np);
+}
+
+test "ir: module teardown frees operands by capacity and agg blobs under a freeing allocator" {
+    var page_alloc: Allocator;
+    page.make(?page_alloc);
+
+    var tracker: Tracker;
+    val er: Result[*TrackEntry, str] = allocate[TrackEntry](?page_alloc, 8192::usize);
+    if (is_err[*TrackEntry, str](er)) { ret 1; }
+    tracker.entries  = unwrap_ok[*TrackEntry, str](er);
+    tracker.cap      = 8192;
+    tracker.count    = 0;
+    tracker.live     = 0;
+    tracker.mismatch = false;
+    tracker.overflow = false;
+
+    var tp: *Tracker = ?tracker;
+    var alloc: Allocator;
+    alloc.ctx           = tp::ptr;
+    alloc.fn_allocate   = track_allocate;
+    alloc.fn_reallocate = track_reallocate;
+    alloc.fn_deallocate = track_deallocate;
+
+    val mr: Result[Module, str] = init_module(?alloc, intern.STR_NIL);
+    if (is_err[Module, str](mr)) { ret 1; }
+    var m: Module = unwrap_ok[Module, str](mr);
+
+    val tr: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret 1; }
+    val i64t: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+
+    val fr: Result[u32, str] = add_function(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (is_err[u32, str](fr)) { ret 1; }
+    val fn: *Function = ?m.functions[unwrap_ok[u32, str](fr)];
+
+    # a 3-operand terminator whose live count is shrunk to 1 (a CBR folded to a
+    # BR): operand_cap stays 3, so teardown must free 3 values, not 1.
+    val o3r: Result[*value.Value, str] = allocate[value.Value](?alloc, 3::usize);
+    if (is_err[*value.Value, str](o3r)) { ret 1; }
+    val o3: *value.Value = unwrap_ok[*value.Value, str](o3r);
+    o3[0] = value.const_int(0, i64t);
+    o3[1] = value.const_int(0, i64t);
+    o3[2] = value.const_int(0, i64t);
+    var cbr: instr.Instruction;
+    cbr.kind = instr.OP_CBR;
+    cbr.ty = i64t;
+    cbr.operands = o3;
+    cbr.operand_count = 3;
+    cbr.block = 0::id.BlockId;
+    cbr.flags = 0;
+    cbr.aux_ty = ir_type.IRT_NIL;
+    val cr: Result[id.InstructionId, str] = add_instruction(?m, fn, cbr);
+    if (is_err[id.InstructionId, str](cr)) { ret 1; }
+    fn.instrs[unwrap_ok[id.InstructionId, str](cr)::u32].operand_count = 1;
+
+    # a 4-operand phi (two incomings) pruned to one incoming (count 2).
+    val o4r: Result[*value.Value, str] = allocate[value.Value](?alloc, 4::usize);
+    if (is_err[*value.Value, str](o4r)) { ret 1; }
+    val o4: *value.Value = unwrap_ok[*value.Value, str](o4r);
+    var k: u32 = 0;
+    for (k < 4) { o4[k] = value.const_int(0, i64t); k = k + 1; }
+    var phi: instr.Instruction;
+    phi.kind = instr.OP_PHI;
+    phi.ty = i64t;
+    phi.operands = o4;
+    phi.operand_count = 4;
+    phi.block = 0::id.BlockId;
+    phi.flags = 0;
+    phi.aux_ty = ir_type.IRT_NIL;
+    val pr2: Result[id.InstructionId, str] = add_instruction(?m, fn, phi);
+    if (is_err[id.InstructionId, str](pr2)) { ret 1; }
+    fn.instrs[unwrap_ok[id.InstructionId, str](pr2)::u32].operand_count = 2;
+
+    # a VAL_CONST_AGG global initializer whose blob and over-allocated reloc table
+    # the module owns: reloc_cap (4) exceeds reloc_count (1), so teardown must free
+    # 4 reloc entries. before the fix the blob and relocs were never freed at all.
+    val bb: Result[*u8, str] = allocate[u8](?alloc, 16::usize);
+    if (is_err[*u8, str](bb)) { ret 1; }
+    val blob: *u8 = unwrap_ok[*u8, str](bb);
+    val rr2: Result[*value.AggReloc, str] = allocate[value.AggReloc](?alloc, 4::usize);
+    if (is_err[*value.AggReloc, str](rr2)) { ret 1; }
+    val relocs: *value.AggReloc = unwrap_ok[*value.AggReloc, str](rr2);
+    val blob_p:  ptr = blob::ptr;
+    val reloc_p: ptr = relocs::ptr;
+
+    var gl: Global;
+    gl.name      = intern.STR_NIL;
+    gl.ty        = i64t;
+    gl.init      = value.const_agg(blob, 16, relocs, 1, 4, i64t);
+    gl.is_mut    = false;
+    gl.is_pub    = false;
+    gl.is_extern = false;
+    gl.is_local  = true;
+    m.globals[0] = gl;
+    m.global_len = 1;
+
+    dnit_module(?m);
+
+    if (tracker.overflow) { ret 1; }                  # entry table too small; test invalid
+    if (tracker.mismatch) { ret 1; }                  # a free used the wrong size (finding 1)
+    if (!track_is_freed(?tracker, blob_p))  { ret 1; } # agg blob leaked (finding 2)
+    if (!track_is_freed(?tracker, reloc_p)) { ret 1; } # agg reloc table leaked
+    if (tracker.live != 0) { ret 1; }                 # any residual live allocation is a leak
+
+    deallocate[TrackEntry](?page_alloc, tracker.entries, 8192::usize);
+    ret 0;
 }

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -679,6 +679,7 @@ pub fun phi_add_incoming(b: *Builder, phi: value.Value, source: id.BlockId, valu
     ops[ins.operand_count + 1] = value_arg;
     ins.operands      = ops;
     ins.operand_count = new_count;
+    ins.operand_cap   = new_count;  # grow reallocated `operands` to new_count
     ret ok[bool, str](true);
 }
 
@@ -980,6 +981,7 @@ fun pool_append(b: *Builder, k: instr.InstrKind, ty: ir_type.IrTypeId, operands:
     ins.ty            = ty;
     ins.operands      = operands;
     ins.operand_count = n;
+    ins.operand_cap   = n;          # `operands` is allocated to exactly n here
     ins.block         = b.block;
     ins.flags         = 0;
     ins.aux_ty        = ir_type.IRT_NIL;

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -162,7 +162,15 @@ pub val INSTR_FLAG_VOLATILE: u16 = 0x08;
 # kind:          the opcode
 # ty:            result IR type (IRT_VOID for terminators and stores)
 # operands:      pointer to a contiguous array of operand Values (owned)
-# operand_count: number of operands
+# operand_count: number of live operands; the prefix of `operands` in use. a pass
+#                may shrink this in place (a CBR folded to a BR, a phi compacted to
+#                its surviving incomings) without reallocating, so it is NOT the
+#                allocation size — see `operand_cap`.
+# operand_cap:   allocated element capacity of `operands` (the true allocation
+#                size). teardown frees `operand_cap` values, so the free size never
+#                depends on a count a pass may have shrunk. any code that allocates
+#                or grows `operands` must set this to the allocation size; a pass
+#                that only shrinks `operand_count` leaves it untouched.
 # block:         the block this instruction belongs to
 # flags:         bitwise-or of INSTR_FLAG_* modifiers
 # aux_ty:        opcode-specific auxiliary type, used by the opcodes whose base
@@ -181,6 +189,7 @@ pub rec Instruction {
     ty:            ir_type.IrTypeId;
     operands:      *value.Value;
     operand_count: u32;
+    operand_cap:   u32;
     block:         id.BlockId;
     flags:         u16;
     aux_ty:        ir_type.IrTypeId;

--- a/src/lang/me/ir/value.mach
+++ b/src/lang/me/ir/value.mach
@@ -72,17 +72,23 @@ pub rec AggReloc {
 # a pre-serialized aggregate constant for VAL_CONST_AGG: the laid-out little-
 # endian blob plus a relocation side-table for its pointer leaves. the blob and
 # side-table are owned by the IR module's allocator (materialised once during
-# lowering, never copied), so the Value carries borrowing pointers to them.
+# lowering, never copied) and freed by `ir.dnit_module`; a VAL_CONST_AGG appears
+# only as a global's initializer (never as an instruction operand), so the module
+# teardown frees each blob exactly once via a global walk.
 # ---
 # bytes:       the laid-out aggregate blob (sized to the aggregate's IR type)
-# len:         number of bytes in the blob
-# relocs:      side-table of pointer leaves to patch (nil when reloc_count is 0)
-# reloc_count: number of side-table entries
+# len:         number of bytes in the blob (also its allocation size)
+# relocs:      side-table of pointer leaves to patch (nil when reloc_cap is 0)
+# reloc_count: number of live side-table entries
+# reloc_cap:   allocated entry capacity of `relocs` (the true allocation size,
+#              which the layout pass grows past `reloc_count`); teardown frees
+#              `reloc_cap` entries
 pub rec ValueAgg {
     bytes:       *u8;
     len:         u32;
     relocs:      *AggReloc;
     reloc_count: u32;
+    reloc_cap:   u32;
 }
 
 # an SSA value: a typed, tagged operand reference.
@@ -229,11 +235,12 @@ pub fun fn_value(index: u32, ty: ir_type.IrTypeId) Value {
 # ---
 # bytes:       the laid-out aggregate blob
 # len:         number of bytes in the blob
-# relocs:      pointer-leaf side-table (nil when reloc_count is 0)
-# reloc_count: number of side-table entries
+# relocs:      pointer-leaf side-table (nil when reloc_cap is 0)
+# reloc_count: number of live side-table entries
+# reloc_cap:   allocated entry capacity of `relocs` (its allocation size)
 # ty:          IR type of the aggregate
 # ret:         a VAL_CONST_AGG value
-pub fun const_agg(bytes: *u8, len: u32, relocs: *AggReloc, reloc_count: u32, ty: ir_type.IrTypeId) Value {
+pub fun const_agg(bytes: *u8, len: u32, relocs: *AggReloc, reloc_count: u32, reloc_cap: u32, ty: ir_type.IrTypeId) Value {
     var v: Value;
     v.kind = VAL_CONST_AGG;
     v.ty   = ty;
@@ -241,6 +248,7 @@ pub fun const_agg(bytes: *u8, len: u32, relocs: *AggReloc, reloc_count: u32, ty:
     v.data.agg.len         = len;
     v.data.agg.relocs      = relocs;
     v.data.agg.reloc_count = reloc_count;
+    v.data.agg.reloc_cap   = reloc_cap;
     ret v;
 }
 

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -583,8 +583,11 @@ fun is_pointerish(m: *ir.Module, ty: ir_type.IrTypeId) bool {
 # aggregate-typed operand must be a global (its symbol IS the address), a parameter
 # (lower_params establishes its storage), or the result of an address-producing
 # instruction. alloca/gep yield addresses directly; load/call/va_arg/bitcast pass
-# an aggregate's storage pointer through (the back end reads it by reference). a
-# constant cannot be an aggregate's storage address.
+# an aggregate's storage pointer through (the back end reads it by reference); a phi
+# merges its incoming addresses into one (each incoming is itself address-producing,
+# so the merged value is too — inline builds such a phi over the return-storage
+# pointers when an aggregate callee returns from two or more sites). a constant
+# cannot be an aggregate's storage address.
 fun agg_value_is_address_producing(fn: *ir.Function, op: *value.Value) bool {
     if (op.kind == value.VAL_GLOBAL) { ret true; }
     if (op.kind == value.VAL_PARAM)  { ret true; }
@@ -593,7 +596,8 @@ fun agg_value_is_address_producing(fn: *ir.Function, op: *value.Value) bool {
         if (did >= fn.instr_len) { ret false; }
         val k: instr.InstrKind = (?fn.instrs[did]).kind;
         ret k == instr.OP_ALLOCA || k == instr.OP_GEP || k == instr.OP_LOAD
-            || k == instr.OP_CALL || k == instr.OP_BITCAST || k == instr.OP_VA_ARG;
+            || k == instr.OP_CALL || k == instr.OP_BITCAST || k == instr.OP_VA_ARG
+            || k == instr.OP_PHI;
     }
     ret false;
 }
@@ -1569,5 +1573,55 @@ test "ir.verify: type resolution (repr) flags an unresolvable alloca element typ
     val aid: id.InstructionId = av.data.instr;
     env.m.functions[0].instrs[aid].ty = 0xFFFF::ir_type.IrTypeId;
     if (t_count(?env, false, true, VC_TYPE_RESOLVE) < 1) { ret 1; }
+    ret 0;
+}
+
+test "ir.verify: aggregate representation (repr) accepts a multi-return result phi" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+    val agr: Result[ir_type.IrTypeId, str] = ir_type.intern_array(?env.m.types, env.i64ty, 4);
+    if (is_err[ir_type.IrTypeId, str](agr)) { ret 1; }
+    val aggty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](agr);
+
+    val b0: id.BlockId = t_block(?env);
+    val b1: id.BlockId = t_block(?env);
+    val b2: id.BlockId = t_block(?env);
+    val b3: id.BlockId = t_block(?env);
+    if (b0 != 0 || b1 != 1 || b2 != 2 || b3 != 3) { ret 1; }
+
+    # entry: a slot to store into, then a two-way branch into the diamond arms.
+    builder.set_block(?env.bld, b0);
+    val a0r: Result[value.Value, str] = builder.emit_alloca(?env.bld, aggty, t_ci(?env, 1));
+    if (is_err[value.Value, str](a0r)) { ret 1; }
+    val a0: value.Value = unwrap_ok[value.Value, str](a0r);
+    if (is_err[bool, str](builder.emit_cbr(?env.bld, t_ci(?env, 1), b1, b2))) { ret 1; }
+
+    # each arm allocates aggregate return storage and branches to the join.
+    builder.set_block(?env.bld, b1);
+    val a1r: Result[value.Value, str] = builder.emit_alloca(?env.bld, aggty, t_ci(?env, 1));
+    if (is_err[value.Value, str](a1r)) { ret 1; }
+    val a1: value.Value = unwrap_ok[value.Value, str](a1r);
+    if (is_err[bool, str](builder.emit_br(?env.bld, b3))) { ret 1; }
+
+    builder.set_block(?env.bld, b2);
+    val a2r: Result[value.Value, str] = builder.emit_alloca(?env.bld, aggty, t_ci(?env, 1));
+    if (is_err[value.Value, str](a2r)) { ret 1; }
+    val a2: value.Value = unwrap_ok[value.Value, str](a2r);
+    if (is_err[bool, str](builder.emit_br(?env.bld, b3))) { ret 1; }
+
+    # join: an aggregate-typed phi merges the two arms' storage pointers, then it
+    # is consumed as an aggregate operand. before OP_PHI joined the address-
+    # producing set, that use flunked VC_AGG_ADDRESS.
+    builder.set_block(?env.bld, b3);
+    val pr: Result[value.Value, str] = builder.emit_phi(?env.bld, aggty);
+    if (is_err[value.Value, str](pr)) { ret 1; }
+    val phi: value.Value = unwrap_ok[value.Value, str](pr);
+    if (is_err[bool, str](builder.phi_add_incoming(?env.bld, phi, b1, value.retype(a1, aggty)))) { ret 1; }
+    if (is_err[bool, str](builder.phi_add_incoming(?env.bld, phi, b2, value.retype(a2, aggty)))) { ret 1; }
+    if (is_err[bool, str](builder.emit_store(?env.bld, value.retype(phi, aggty), a0))) { ret 1; }
+    if (is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
+
+    # with the fix the aggregate phi is address-producing, so the repr run is clean.
+    if (t_count(?env, false, true, VC_AGG_ADDRESS) != 0) { ret 1; }
     ret 0;
 }

--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -172,7 +172,7 @@ pub fun try_const_aggregate(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_t
         ret ok[Option[value.Value], str](none[value.Value]());
     }
 
-    ret ok[Option[value.Value], str](some[value.Value](value.const_agg(blob, size, rb.relocs, rb.len, gty)));
+    ret ok[Option[value.Value], str](some[value.Value](value.const_agg(blob, size, rb.relocs, rb.len, rb.cap, gty)));
 }
 
 # lays the initializer `eid` out at byte offset `base` within `blob`, dispatching

--- a/src/lang/me/pass/constfold.mach
+++ b/src/lang/me/pass/constfold.mach
@@ -628,6 +628,7 @@ fun build_const_phi(phi: *instr.Instruction, ops: *value.Value, vals: *value.Val
     phi.ty            = ty;
     phi.operands      = ops;
     phi.operand_count = n * 2;
+    phi.operand_cap   = n * 2;
     phi.block         = 0::id.BlockId;
     phi.flags         = 0;
     phi.aux_ty        = ir_type.IRT_NIL;


### PR DESCRIPTION
Fixes two related IR issues split from the #1250/#1252 audit line.

## #1277 — IR teardown ownership held only under the arena
The IR module's teardown contracts were correct only because the driver backs it with an arena (where `deallocate` is a no-op). Under std's page allocator — or any size-class allocator — two ownership lies surfaced:

1. **Operand arrays freed with a shrunken count.** `dnit_instruction` freed `operands` by `operand_count`, but passes shrink that count in place over an array allocated at the original width (constfold's CBR→BR rewrite, phi-incoming compaction in constfold and dce). The free size disagreed with the allocation size.
2. **Agg blobs never freed.** `VAL_CONST_AGG` initializer blobs and their relocation tables — documented as owned by the module allocator — had no deallocation site at all.

**Contract chosen: exact, allocator-agnostic ownership via a capacity field**, matching the count/cap split every other owned IR array already uses (`instr_cap`, `phi_cap`, `pred_cap`, `block_cap`, …). Operands were the lone owned array lacking one — that omission *was* the bug; arena-only would have been a documented hazard rather than a real contract, and could not be tested under the page allocator.

- `Instruction.operand_cap`: `dnit_instruction` frees `operand_cap`, so the free size never depends on a count a pass may have shrunk. The builder maintains it at every operand (re)allocation; `add_instruction` normalizes it for externally-built instructions whose operands are freshly sized to the count.
- `ValueAgg.reloc_cap`: the layout pass grows `relocs` past `reloc_count`, so the table is freed by its true capacity. `dnit_module` frees each `VAL_CONST_AGG` global initializer's blob and reloc table in a single-owner global walk (an agg constant appears only as a global initializer, so each blob is freed exactly once).

Test: a size-checking allocator over raw pages asserts every free matches its allocation size, and that the agg blob + over-allocated reloc table are reclaimed. Fails before the fix (operand free size mismatch + leaked blob), passes after.

## #1280 — verifier rejected inline's multi-return aggregate result phi
`agg_value_is_address_producing` accepted ALLOCA/GEP/LOAD/CALL/BITCAST/VA_ARG but not OP_PHI, so an aggregate-typed phi — which inline legitimately builds over the return-storage pointers when a callee returns from two or more sites — flunked `VC_AGG_ADDRESS`, the last blocker for full-std `--release --verify-ir`. A phi merges address-producing incomings into one address, so it is itself address-producing; add OP_PHI to the set.

Tests: a verifier unit test (aggregate result phi consumed as an aggregate operand) and a relverify-suite extension (`pick`, a two-return-site aggregate inlined into `driver`). Both fail before the fix and pass after; the headline `mach build . --release --verify-ir` on the compiler's own source is now clean.

## Verification
- `mach build .` clean; `mach test .` all 296 pass (2 new).
- Byte-identical self-host fixpoint at **-O0** and **--release**.
- `mach build . --release --verify-ir` on the full compiler: exit 0.
- Both new unit tests and the relverify multi-return case verified failing-before / passing-after.

## Scope note for #1252 (passes audit)
`inline.mach`/`mem2reg.mach` grow phi operand arrays in place with their own duplicated grow code rather than a shared `ir` primitive, and so do not yet set `operand_cap`. Under the production arena this is harmless (deallocate is a no-op). Routing those grows through a capacity-maintaining primitive belongs to the passes-owned files (out of this PR's territory) — flagged, not papered over.

Closes #1277
Closes #1280