### PR TITLE
fix(parser,resolve): variable-index function-pointer-table dispatch table[i]() (#1270)

### DIFF
--- a/.github/tests/lower/fnptr-table/mach.toml
+++ b/.github/tests/lower/fnptr-table/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "fnptrtable"
+name = "Lower Regression — variable-index function-pointer-table dispatch (#1270)"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/fnptrtable"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/lower/fnptr-table/src/main.mach
+++ b/.github/tests/lower/fnptr-table/src/main.mach
@@ -1,0 +1,49 @@
+use std.runtime.linux.x86_64;
+
+fun add(a: i64, b: i64) i64 { ret a + b; }
+fun sub(a: i64, b: i64) i64 { ret a - b; }
+
+fun make_adder() fun(i64, i64) i64 { ret add; }
+fun id_of(x: i64) i64 { ret x; }
+
+# a genuine call-site generic must still bind its type argument
+fun first[T](a: T, b: T) T { ret a; }
+
+# variable-index function-pointer-table dispatch must work without parentheses.
+# before #1270 `table[i](..)` misparsed as a generic call and failed in resolve;
+# this exercises the bare-identifier index, a complex index expression, a nested
+# matrix index, a chained call, and a real generic call — main exits 0 only when
+# every dispatch lands on the right function.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    var table: [2]fun(i64, i64) i64;
+    table[0] = add;
+    table[1] = sub;
+
+    var i: i64 = 0;
+
+    # bare-identifier index then call -> sub(10, 3) = 7
+    if (table[i + 1](10, 3) != 7) { ret 1; }
+
+    # complex index expression (call-result subscript) -> add(2, 3) = 5
+    if (table[id_of(0)](2, 3) != 5) { ret 2; }
+
+    # nested matrix-style index then call -> sub(9, 4) = 5
+    var grid: [1][2]fun(i64, i64) i64;
+    grid[0][0] = add;
+    grid[0][1] = sub;
+    var a: i64 = 0;
+    var b: i64 = 1;
+    if (grid[a][b](9, 4) != 5) { ret 3; }
+
+    # index-then-call whose result is itself called -> add(6, 1) = 7
+    var makers: [1]fun() fun(i64, i64) i64;
+    makers[0] = make_adder;
+    var k: i64 = 0;
+    if (makers[k]()(6, 1) != 7) { ret 4; }
+
+    # a real generic call still selects its first argument
+    if (first[i64](42, 0) != 42) { ret 5; }
+
+    ret 0;
+}

--- a/.github/tests/lower/run.sh
+++ b/.github/tests/lower/run.sh
@@ -9,6 +9,8 @@
 #   xmod-generic: a generic body whose `$if` gates on the defining module's
 #                 `pub val`, instantiated from another module — used to fail with
 #                 "identifier is not a comptime constant in scope".
+#   fnptr-table:  variable-index function-pointer-table dispatch `table[i](..)`
+#                 — used to misparse as a generic call and fail in resolve (#1270).
 #
 # usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -59,5 +61,6 @@ build_and_run() {
 
 build_and_run comptime-str 0
 build_and_run xmod-generic 0
+build_and_run fnptr-table 0
 
 exit "$fail"

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -435,20 +435,25 @@ cast         ::= ( "::" | ":~" ) type
 `::` is a value conversion and `:~` a same-size bit reinterpret; see
 [operators.md](operators.md#cast). Both bind as postfix.
 
-Disambiguating a postfix `[`:
-- `callee[T, U](args)` — a generic call: the bracketed list is committed as
-  type arguments only when its first token can begin a type (`*`, `[`, or an
-  identifier) **and** the token after the matching `]` is `(`.
-- `obj[idx]` — an index expression otherwise. In particular a bracket whose
-  payload starts with a token that cannot begin a type (a literal, `-`, `@`,
-  `$`, …) is always an index, so `table[0]()` parses as index-then-call —
-  calling an element of a function-pointer table needs no parentheses.
-- The single residual ambiguity is a bare identifier payload (`callee[x](…)`):
-  it is locally indistinguishable from one type argument and binds as a
-  generic call. If `x` names a value rather than a type, name resolution then
-  reports an error, so the variable-index-then-call form `table[i]()` still
-  needs `(table[i])()`; deferring this decision to resolve is tracked
-  separately.
+Disambiguating a postfix `[`: a bracket whose matching `]` is **not** followed
+by `(` is always an index `obj[idx]`. When it **is** followed by `(`, the
+bracket may open a generic call `callee[T, U](args)` or be the index of an
+index-then-call `callee[idx](args)`. The two grammars overlap — a bare name is
+both a type and a value — so the parser cannot decide locally. It probes the
+payload against both grammars:
+- reads cleanly **only** as a type list (`*T`, `[N]T`, a comma list, or a
+  nested generic like `Result[bool, str]`) → a generic call;
+- reads cleanly **only** as an expression (`i + 1`, `f(x)`, a literal) → an
+  index, so `table[0]()` and `table[i + 1]()` are index-then-call;
+- reads cleanly as **both** (a bare identifier, a dotted path, a generic
+  application like `v[k]`) → the decision is deferred to name resolution, which
+  picks by the callee's resolved kind: a value (or any non-name callee, e.g. an
+  index/call result) makes `[x]` an index, while a function, type, or imported
+  name takes `[x]` as a type argument. So `table[i]()` calls the indexed
+  function pointer and `make[T]()` instantiates the generic — neither needs
+  parentheses;
+- reads cleanly as **neither** → the committing index parse reports the error
+  (never a silent wrong parse).
 - The struct-literal `Name[T]{...}` form is recognized at the **prefix**
   stage (`typed-literal`) and never reaches postfix.
 

--- a/src/lang/fe/ast/expr.mach
+++ b/src/lang/fe/ast/expr.mach
@@ -87,12 +87,19 @@ pub rec ExprUnary {
 # args_len:        number of argument expressions
 # type_args_start: start index into ast.type_ids for call-site type arguments
 # type_args_len:   number of call-site type arguments; 0 for a non-generic call
+# index_callee:    EXPR_NIL for an ordinary call. otherwise this is a provisional
+#                  bracket-call `callee[x](args)` whose `[x]` reads cleanly as
+#                  both a type-argument list and an index expression; the field
+#                  holds the pre-built `INDEX(callee, x)` node to use when resolve
+#                  decides — by the callee's kind — that the bracket was an index
+#                  and the call is index-then-call rather than generic
 pub rec ExprCall {
     callee:   id.ExprId;
     args_start: u32;
     args_len: u32;
     type_args_start: u32;
     type_args_len:   u32;
+    index_callee: id.ExprId;
 }
 
 # ExprIndex: an index expression `obj[idx]`.

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -142,10 +142,11 @@ fun parse_postfix(p: *parser.Parser, base: id.ExprId) id.ExprId {
     var lhs: id.ExprId = base;
     for (true) {
         val k: token.Kind = parser.current(p).kind;
-        if      (k == token.KIND_LPAREN)      { lhs = parse_call(p, lhs, 0, 0); }
+        if      (k == token.KIND_LPAREN)      { lhs = parse_call(p, lhs, 0, 0, id.EXPR_NIL); }
         or      (k == token.KIND_LBRACKET) {
-            if (postfix_is_generic_call(p)) {
-                lhs = parse_generic_call(p, lhs);
+            val after: usize = scan_bracket_close(p, 0);
+            if (after != 0 && parser.peek(p, after).kind == token.KIND_LPAREN) {
+                lhs = parse_bracket_call(p, lhs);
             }
             or {
                 lhs = parse_index(p, lhs);
@@ -164,7 +165,7 @@ fun parse_postfix(p: *parser.Parser, base: id.ExprId) id.ExprId {
 # matching ']' and returns the cursor offset of the token immediately after it. a
 # ';' or EOF reached inside the brackets means the region can never be a type
 # list, reported as 0 (the brackets are unbalanced for that purpose). shared by
-# postfix_is_generic_call and looks_like_typed_literal so the two scanners cannot
+# parse_bracket_call and looks_like_typed_literal so the two scanners cannot
 # drift apart.
 fun scan_bracket_close(p: *parser.Parser, bracket_off: usize) usize {
     var i: usize = bracket_off + 1;
@@ -179,35 +180,98 @@ fun scan_bracket_close(p: *parser.Parser, bracket_off: usize) usize {
     ret i;
 }
 
-# true when `k` can begin a type (per parse_type): a pointer '*', an array '[',
-# or an identifier (which covers named types and the `fun`/`rec`/`uni` keywords).
-fun token_begins_type(k: token.Kind) bool {
-    ret k == token.KIND_STAR || k == token.KIND_LBRACKET || k == token.KIND_IDENT;
+# true when `k` can begin an expression (per parse_prefix). used to gate the
+# index-reading probe: a payload that cannot start an expression (a bare '*',
+# for instance) is never an index, so it is left to the type reading.
+fun token_begins_expr(k: token.Kind) bool {
+    ret k == token.KIND_LIT_INT   || k == token.KIND_LIT_FLOAT
+     || k == token.KIND_LIT_CHAR  || k == token.KIND_LIT_STR
+     || k == token.KIND_IDENT     || k == token.KIND_DOLLAR
+     || k == token.KIND_MINUS     || k == token.KIND_BANG
+     || k == token.KIND_TILDE     || k == token.KIND_QUESTION
+     || k == token.KIND_AT        || k == token.KIND_LPAREN
+     || k == token.KIND_LBRACKET;
 }
 
-# decides whether a postfix '[' opens a generic call `callee[T, ..](args)` rather
-# than an index `obj[i]`. it is a generic call only when the bracketed payload can
-# begin a type AND the token after the matching ']' is '(' (the call). a payload
-# that starts with a token which cannot begin a type — a literal, '-', '@', '$',
-# etc. — is an index, so `table[0]()` parses as index-then-call (#1247). the
-# decision is purely syntactic and has one residual gap: a bare-identifier payload
-# is locally indistinguishable from a single type argument, so `table[i]()` still
-# binds as a generic call and, if `i` names a value, resolve then errors on it —
-# the variable-index-then-call form still needs `(table[i])()`. the complete fix
-# (deferring the index/generic decision to resolve) is tracked in #1270. the '{'
-# typed-literal form is recognized at the prefix stage and never reaches postfix.
-fun postfix_is_generic_call(p: *parser.Parser) bool {
-    if (!token_begins_type(parser.peek(p, 1).kind)) { ret false; }
-    val after: usize = scan_bracket_close(p, 0);   # peek(p, 0) is the current '['
-    if (after == 0) { ret false; }
-    ret parser.peek(p, after).kind == token.KIND_LPAREN;
+# parses a postfix '[' whose matching ']' is followed by '(' — a bracket that
+# may open a generic call `callee[T, ..](args)` OR be the index of an
+# index-then-call `callee[expr](args)`. the type and expression grammars overlap
+# (a bare name is both a type and a value reference), so the parser cannot decide
+# locally; it probes the payload against both grammars and:
+#   - parses cleanly only as a type list   -> a generic call;
+#   - parses cleanly only as an expression -> an index (the trailing '(' is read
+#     as a separate call by the postfix loop);
+#   - parses cleanly as both               -> a provisional call carrying both
+#     readings, deferred to resolve, which picks by the callee's resolved kind
+#     (a value indexes; a function/type takes type arguments);
+#   - parses cleanly as neither            -> falls to parse_index, whose real
+#     parse surfaces the diagnostic.
+# the '{' typed-literal form is recognized at the prefix stage and never reaches
+# here.
+fun parse_bracket_call(p: *parser.Parser, callee: id.ExprId) id.ExprId {
+    val idx_probe: id.ExprId = probe_index_payload(p);
+    val ty_ok:     bool       = probe_type_payload(p);
+
+    if (ty_ok && idx_probe != id.EXPR_NIL) {
+        ret parse_provisional_call(p, callee, idx_probe);
+    }
+    if (ty_ok) {
+        ret parse_generic_call(p, callee);
+    }
+    ret parse_index(p, callee);
 }
 
-# parses a generic call `callee[T, U](args)`: consumes the bracketed type-arg
-# list, then delegates to parse_call to read the parenthesized arguments,
-# threading the type args onto the produced ExprCall.
-fun parse_generic_call(p: *parser.Parser, callee: id.ExprId) id.ExprId {
-    parser.advance(p);
+# speculatively reads the current '[...]' payload as a single index expression,
+# returning its ExprId when the payload parses cleanly up to the closing ']' and
+# EXPR_NIL otherwise. the cursor is restored and diagnostics are suppressed (via
+# panic) so the probe is side-effect free except for the orphaned AST nodes it
+# appends, which a clean result intentionally reuses.
+fun probe_index_payload(p: *parser.Parser) id.ExprId {
+    if (!token_begins_expr(parser.peek(p, 1).kind)) { ret id.EXPR_NIL; }
+    val save_pos:   usize = p.pos;
+    val save_panic: bool  = p.panic;
+    p.panic = true;
+    parser.advance(p);                       # consume '['
+    val before: usize = p.pos;
+    val e: id.ExprId = parse_expr(p);
+    val clean: bool = p.pos > before && !p.fatal && parser.at(p, token.KIND_RBRACKET);
+    p.pos   = save_pos;
+    p.panic = save_panic;
+    if (clean) { ret e; }
+    ret id.EXPR_NIL;
+}
+
+# speculatively reads the current '[...]' payload as a generic type-argument
+# list, returning whether it parses cleanly up to the closing ']'. like
+# probe_index_payload it restores the cursor and suppresses diagnostics; the
+# orphaned type nodes it appends are discarded (the committing parse re-reads
+# the list).
+fun probe_type_payload(p: *parser.Parser) bool {
+    val save_pos:   usize = p.pos;
+    val save_panic: bool  = p.panic;
+    p.panic = true;
+    parser.advance(p);                       # consume '['
+    var ok: bool = false;
+    if (!parser.at(p, token.KIND_RBRACKET)) {
+        val before: usize = p.pos;
+        parse_type(p);
+        for (parser.eat(p, token.KIND_COMMA)) {
+            if (parser.at(p, token.KIND_RBRACKET)) { brk; }
+            parse_type(p);
+        }
+        ok = p.pos > before && !p.fatal && parser.at(p, token.KIND_RBRACKET);
+    }
+    p.pos   = save_pos;
+    p.panic = save_panic;
+    ret ok;
+}
+
+# consumes a '[T, U, ..]' type-argument list (the cursor is on the '[') and
+# flushes it into the shared type_id pool, returning the slice start through
+# `out_len`. factored out of the generic-call parses so both readings build the
+# list identically.
+fun parse_type_args(p: *parser.Parser, out_len: *u32) u32 {
+    parser.advance(p);                       # consume '['
 
     # buffer the type arguments: a nested generic type argument appends its own
     # child type ids to the shared type_id pool mid-parse, so flush the parent's
@@ -223,10 +287,52 @@ fun parse_generic_call(p: *parser.Parser, callee: id.ExprId) id.ExprId {
     }
     parser.expect(p, token.KIND_RBRACKET, "expected ']' to close generic arguments");
 
-    var type_args_len: u32 = 0;
-    val type_args_start: u32 = parser.type_id_buf_flush(p, ?buf, ?type_args_len);
+    ret parser.type_id_buf_flush(p, ?buf, out_len);
+}
 
-    ret parse_call(p, callee, type_args_start, type_args_len);
+# parses a generic call `callee[T, U](args)`: consumes the bracketed type-arg
+# list, then delegates to parse_call to read the parenthesized arguments,
+# threading the type args onto the produced ExprCall.
+fun parse_generic_call(p: *parser.Parser, callee: id.ExprId) id.ExprId {
+    var type_args_len: u32 = 0;
+    val type_args_start: u32 = parse_type_args(p, ?type_args_len);
+    ret parse_call(p, callee, type_args_start, type_args_len, id.EXPR_NIL);
+}
+
+# parses a provisional bracket call `callee[x](args)` whose payload read cleanly
+# as both a type list and the index expression `idx`. it commits the type-arg
+# reading and, alongside it, wraps `callee[idx]` as the alternative index reading
+# (index_callee) so resolve can choose between them by the callee's kind. `idx`
+# is the expression the index probe already built from the same tokens.
+fun parse_provisional_call(p: *parser.Parser, callee: id.ExprId, idx: id.ExprId) id.ExprId {
+    var type_args_len: u32 = 0;
+    val type_args_start: u32 = parse_type_args(p, ?type_args_len);
+    val index_callee: id.ExprId = make_index(p, callee, idx);
+    ret parse_call(p, callee, type_args_start, type_args_len, index_callee);
+}
+
+# builds an INDEX node `object[index]` without consuming tokens, used to record
+# the index-then-call reading of a provisional bracket call. its span runs from
+# the object to the index expression.
+fun make_index(p: *parser.Parser, object: id.ExprId, index: id.ExprId) id.ExprId {
+    var node_index: expr.ExprIndex;
+    node_index.object = object;
+    node_index.index  = index;
+
+    var start_span: token.Span = parser.current(p).span;
+    if (object != id.EXPR_NIL) {
+        start_span = unwrap[*expr.Expr](ast.get_expr(p.ast, object)).span;
+    }
+    var end_span: token.Span = start_span;
+    if (index != id.EXPR_NIL) {
+        end_span = unwrap[*expr.Expr](ast.get_expr(p.ast, index)).span;
+    }
+
+    var node: expr.Expr;
+    node.span = parser.span_of(start_span, end_span);
+    node.kind = expr.EXPR_KIND_INDEX;
+    node.data.index = node_index;
+    ret parser.push_expr(p, node);
 }
 
 # parses an integer literal, decoding its value from the source span (the token
@@ -359,8 +465,10 @@ fun parse_paren(p: *parser.Parser) id.ExprId {
 
 # parses a call expression `callee(args)`. type_args_start/type_args_len carry
 # any call-site generic arguments parsed by parse_generic_call; both are 0 for
-# a plain call.
-fun parse_call(p: *parser.Parser, callee: id.ExprId, type_args_start: u32, type_args_len: u32) id.ExprId {
+# a plain call. index_callee is EXPR_NIL except for a provisional bracket call,
+# where it carries the index-then-call reading for resolve to choose (see
+# ExprCall.index_callee).
+fun parse_call(p: *parser.Parser, callee: id.ExprId, type_args_start: u32, type_args_len: u32, index_callee: id.ExprId) id.ExprId {
     parser.advance(p);
 
     # buffer the arguments rather than pushing them to the shared expr_id pool
@@ -390,6 +498,7 @@ fun parse_call(p: *parser.Parser, callee: id.ExprId, type_args_start: u32, type_
     call.args_len        = args_len;
     call.type_args_start = type_args_start;
     call.type_args_len   = type_args_len;
+    call.index_callee    = index_callee;
 
     var start_span: token.Span = close.span;
     if (callee != id.EXPR_NIL) {
@@ -923,6 +1032,126 @@ test "parser: a true generic call callee[T](args) still binds its type args (#12
         if (callee.kind != expr.EXPR_KIND_IDENT) { rc = 1; }
     }
     if (diag.has_errors(?diags)) { rc = 1; }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "parser: bare-identifier bracket call tbl[i](args) is provisional (#1270)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize("tbl[i]()", ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+
+    val eid: id.ExprId = parse_expr(?p);
+    var rc: i32 = 0;
+    val e: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, eid));
+    # `tbl[i]()`: payload `i` reads as both a type arg and an index expression, so
+    # the parser records both readings (type_args plus a pre-built index callee)
+    # and defers the choice to resolve.
+    if (e.kind != expr.EXPR_KIND_CALL) { rc = 1; }
+    or (e.data.call.type_args_len != 1) { rc = 1; }
+    or (e.data.call.index_callee == id.EXPR_NIL) { rc = 1; }
+    or {
+        val callee: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, e.data.call.callee));
+        if (callee.kind != expr.EXPR_KIND_IDENT) { rc = 1; }
+        or {
+            val idx: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, e.data.call.index_callee));
+            if (idx.kind != expr.EXPR_KIND_INDEX) { rc = 1; }
+            or (idx.data.index.object != e.data.call.callee) { rc = 1; }
+        }
+    }
+    if (diag.has_errors(?diags)) { rc = 1; }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "parser: nested index-then-call m[i][j](args) keeps an index callee (#1270)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize("m[i][j]()", ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+
+    val eid: id.ExprId = parse_expr(?p);
+    var rc: i32 = 0;
+    val e: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, eid));
+    # `m[i]` is a plain index (no trailing call), so the provisional `[j](` sits
+    # on an index callee; the bracket call still records its index reading.
+    if (e.kind != expr.EXPR_KIND_CALL) { rc = 1; }
+    or (e.data.call.index_callee == id.EXPR_NIL) { rc = 1; }
+    or {
+        val callee: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, e.data.call.callee));
+        if (callee.kind != expr.EXPR_KIND_INDEX) { rc = 1; }
+    }
+    if (diag.has_errors(?diags)) { rc = 1; }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "parser: chained call f[i]()() nests a provisional inner call (#1270)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize("f[i]()()", ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+
+    val eid: id.ExprId = parse_expr(?p);
+    var rc: i32 = 0;
+    val e: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, eid));
+    # outer call applies to the inner provisional bracket call `f[i]()`.
+    if (e.kind != expr.EXPR_KIND_CALL) { rc = 1; }
+    or (e.data.call.index_callee != id.EXPR_NIL) { rc = 1; }
+    or {
+        val inner: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, e.data.call.callee));
+        if (inner.kind != expr.EXPR_KIND_CALL) { rc = 1; }
+        or (inner.data.call.index_callee == id.EXPR_NIL) { rc = 1; }
+    }
+    if (diag.has_errors(?diags)) { rc = 1; }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "parser: a malformed bracket payload t[a b](x) is rejected (#1270)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize("t[a b]()", ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+
+    parse_expr(?p);
+    var rc: i32 = 0;
+    # a payload that reads cleanly as neither a type list nor an expression is
+    # not silently accepted: the committing index parse surfaces a diagnostic.
+    if (!diag.has_errors(?diags)) { rc = 1; }
 
     diag.dnit(?diags);
     ast.dnit(?a);

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1624,6 +1624,14 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
         ret bind_expr(rc, e.data.unary.operand);
     }
     if (e.kind == expr.EXPR_KIND_CALL) {
+        # a provisional bracket call `callee[x](args)` whose payload read as both
+        # a type list and an index expression: choose the reading now from the
+        # callee's resolved kind and canonicalize the node before ordinary call
+        # binding sees it.
+        if (e.data.call.index_callee != id.EXPR_NIL) {
+            ret resolve_bracket_call(rc, eid);
+        }
+
         # a comptime value intrinsic (`$size_of`/`$align_of`/`$offset_of`) takes
         # a type-naming first argument (and, for `$offset_of`, a bare field name)
         # rather than value expressions, so it binds its arguments specially.
@@ -1639,14 +1647,7 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
             val rc_e: Result[bool, str] = bind_expr(rc, e.data.call.callee);
             if (is_err[bool, str](rc_e)) { ret rc_e; }
         }
-        var ti: u32 = 0;
-        for (ti < e.data.call.type_args_len) {
-            val arg_id: id.TypeId = rc.a.type_ids[e.data.call.type_args_start + ti];
-            val rt: Result[bool, str] = bind_type(rc, arg_id);
-            if (is_err[bool, str](rt)) { ret rt; }
-            ti = ti + 1;
-        }
-        ret bind_expr_list(rc, e.data.call.args_start, e.data.call.args_len);
+        ret bind_generic_call(rc, e.data.call.type_args_start, e.data.call.type_args_len, e.data.call.args_start, e.data.call.args_len);
     }
     if (e.kind == expr.EXPR_KIND_INDEX) {
         val ro: Result[bool, str] = bind_expr(rc, e.data.index.object);
@@ -1692,6 +1693,98 @@ fun bind_expr_list(rc: *ResolveContext, start: u32, len: u32) Result[bool, str] 
         i = i + 1;
     }
     ret ok[bool, str](true);
+}
+
+# resolves a provisional bracket call `callee[x](args)` (ExprCall.index_callee
+# set) that the parser could not classify: `[x]` read as both a type-argument
+# list and an index expression. the choice is the callee's resolved kind — a
+# function, type, or imported name takes the type arguments (a generic call); a
+# value, or any non-name callee, makes `[x]` an index (index-then-call). the
+# node is canonicalized to the chosen shape (index_callee cleared) and its parts
+# bound exactly once, so sema sees an ordinary generic call or index-then-call.
+fun resolve_bracket_call(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
+    val e_opt: Option[*expr.Expr] = ast.get_expr(rc.a, eid);
+    if (is_none[*expr.Expr](e_opt)) { ret err[bool, str]("ExprId out of range"); }
+    val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
+
+    val callee:          id.ExprId = e.data.call.callee;
+    val index_callee:    id.ExprId = e.data.call.index_callee;
+    val type_args_start: u32       = e.data.call.type_args_start;
+    val type_args_len:   u32       = e.data.call.type_args_len;
+    val args_start:      u32       = e.data.call.args_start;
+    val args_len:        u32       = e.data.call.args_len;
+
+    # a provisional node always carries at least one type argument (the type
+    # reading) alongside its index reading, so the type-argument reading wins for
+    # the variadic intrinsics (`va_arg[T](ap)`), whose callee is a builtin name
+    # rather than a bindable symbol and is left unbound, exactly as in an
+    # ordinary va call.
+    if (is_va_intrinsic_callee(rc, callee)) {
+        e.data.call.index_callee = id.EXPR_NIL;
+        ret bind_generic_call(rc, type_args_start, type_args_len, args_start, args_len);
+    }
+
+    # bind the callee once and read its kind: a function, type, or imported name
+    # takes the type arguments; anything else (a value, an index/call result, or
+    # an unresolved name) makes the bracket an index.
+    val rc_e: Result[bool, str] = bind_expr(rc, callee);
+    if (is_err[bool, str](rc_e)) { ret rc_e; }
+
+    if (callee_accepts_type_args(rc, callee)) {
+        # generic call: drop the index reading and bind the type arguments.
+        # `e` stays valid — resolve binding never appends to ast.exprs.
+        e.data.call.index_callee = id.EXPR_NIL;
+        ret bind_generic_call(rc, type_args_start, type_args_len, args_start, args_len);
+    }
+
+    # index-then-call: the effective callee is the pre-built `INDEX(callee, x)`,
+    # whose object (the now-bound callee) needs no rebinding. bind the subscript,
+    # then canonicalize the call onto the index.
+    val idx_opt: Option[*expr.Expr] = ast.get_expr(rc.a, index_callee);
+    if (is_none[*expr.Expr](idx_opt)) { ret err[bool, str]("ExprId out of range"); }
+    val idxn: *expr.Expr = unwrap[*expr.Expr](idx_opt);
+    val rs: Result[bool, str] = bind_expr(rc, idxn.data.index.index);
+    if (is_err[bool, str](rs)) { ret rs; }
+
+    e.data.call.callee          = index_callee;
+    e.data.call.index_callee    = id.EXPR_NIL;
+    e.data.call.type_args_start = 0;
+    e.data.call.type_args_len   = 0;
+    ret bind_expr_list(rc, args_start, args_len);
+}
+
+# binds a generic call's type arguments and value arguments — the tail shared by
+# the ordinary call path and a provisional bracket call resolved to a generic
+# call.
+fun bind_generic_call(rc: *ResolveContext, type_args_start: u32, type_args_len: u32, args_start: u32, args_len: u32) Result[bool, str] {
+    var ti: u32 = 0;
+    for (ti < type_args_len) {
+        val arg_id: id.TypeId = rc.a.type_ids[type_args_start + ti];
+        val rt: Result[bool, str] = bind_type(rc, arg_id);
+        if (is_err[bool, str](rt)) { ret rt; }
+        ti = ti + 1;
+    }
+    ret bind_expr_list(rc, args_start, args_len);
+}
+
+# true when a provisional bracket call's callee resolves to a name that can take
+# generic type arguments (a function, type, or imported symbol). a value callee
+# — or a non-name callee such as an index or call result — means the bracket was
+# an index. an unresolved name returns false so the index reading is taken and
+# the single unresolved diagnostic from binding the callee is not compounded by
+# spurious type-argument errors.
+fun callee_accepts_type_args(rc: *ResolveContext, callee: id.ExprId) bool {
+    val e_opt: Option[*expr.Expr] = ast.get_expr(rc.a, callee);
+    if (is_none[*expr.Expr](e_opt)) { ret false; }
+    val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
+    if (e.kind != expr.EXPR_KIND_IDENT && e.kind != expr.EXPR_KIND_MEMBER) { ret false; }
+    if (rc.expr_resolved == nil) { ret false; }
+    val sid: SymbolId = rc.expr_resolved[callee];
+    if (sid == SYMBOL_NIL || sid >= rc.sym_len) { ret false; }
+    val sym: *Symbol = ?rc.symbols[sid];
+    ret sym.kind == SYM_FUN || sym.kind == SYM_REC || sym.kind == SYM_UNI
+     || sym.kind == SYM_DEF || sym.kind == SYM_GENERIC || sym.kind == SYM_PRIM
+     || sym.kind == SYM_IMPORTED;
 }
 
 fun bind_ident(rc: *ResolveContext, eid: id.ExprId, span: token.Span) Result[bool, str] {


### PR DESCRIPTION
Closes #1270 (follow-up to #1247, epic #1259).

## Problem
`table[i](args)` — indexing a function-pointer table with a bare-identifier
index and calling the result — misparsed as a generic call. A bare identifier is
locally indistinguishable from a single type argument, so the parser committed
to the generic-call reading and name resolution then errored in `bind_type`
("not a generic" / "name does not denote a type"). PR #1268's syntactic fallback
only covered payloads that *cannot* begin a type (literals, `-`, `@`, …); a value
index still required `(table[i])()`.

## Fix — defer the decision to resolve
The parser cannot decide locally, so `parse_bracket_call` probes the bracketed
payload against **both** grammars (cursor-restoring, diagnostic-suppressed
probes) and classifies precisely:

| payload reads cleanly as | result |
|---|---|
| only a type list (`*T`, `[N]T`, a comma list, `Result[bool, str]`) | generic call |
| only an expression (`i + 1`, `f(x)`, a literal) | index-then-call |
| **both** (a bare name, dotted path, generic application `v[k]`) | **provisional** — deferred to resolve |
| neither | `parse_index` surfaces the diagnostic (never a silent wrong parse) |

A provisional call carries both readings: the parsed type args plus a pre-built
`INDEX(callee, x)` in the new `ExprCall.index_callee`. `resolve_bracket_call`
picks by the callee's resolved kind — a function/type/imported name takes the
type arguments; a value, or any non-name callee (an index/call result), makes
the bracket an index — and canonicalizes the node so sema/lower see an ordinary
generic call or index-then-call (no sema/lower changes needed).

This also fixes complex index payloads #1268 left as parse errors:
`table[i + 1]()`, `table[f(x)]()` now read as index-then-call.

## Behavior, per case
- `table[i](10, 3)` (value `table`) → index-then-call ✓
- `make[T](x)` / `err[bool, str](…)` / `is_none[Result[bool, str]](…)` (generic callee) → generic call, unchanged ✓
- `m[i][j]()`, `f[i]()()` → index-then-call (non-name callee) ✓
- `util.pick[i64](…)` (module-qualified generic) → generic; `self.field[i]()` (field access) → index ✓
- `va_arg[T](ap)` → type-argument reading, callee left unbound, unchanged ✓
- malformed `t[a b]()` → clean diagnostic ✓

## Tests
- Inline parser tests: provisional `tbl[i]()` shape, nested `m[i][j]()`, chained `f[i]()()`, malformed rejection (existing `t[0]()` / `make[i64]()` retained).
- New end-to-end lower app `fnptr-table` (bare/complex/nested/chained dispatch + a real generic call), wired into the lower suite.
- `mach build .` clean; `mach test .` = 301 pass / 0 fail; full `.github/tests` battery green; self-host fixpoint byte-identical.
