### PR TITLE
refactor(lang): replace reimplemented std string/memory helpers (#1302)

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1768,12 +1768,7 @@ fun join3(s: *sess.Session, a: str, b: str, c: str, prefix: str) str {
 
 # copy_bytes: copy `len` bytes from a str's data into `dst` starting at `at`.
 fun copy_bytes(dst: *u8, at: usize, src: str, len: usize) {
-    if (len == 0 || src == nil) { ret; }
-    var i: usize = 0;
-    for (i < len) {
-        dst[at + i] = src[i];
-        i = i + 1;
-    }
+    mem.raw_copy((dst::usize + at)::ptr, src::ptr, len);
 }
 
 # free_placements: release the flat placement array.

--- a/src/lang/diagnostic.mach
+++ b/src/lang/diagnostic.mach
@@ -25,6 +25,8 @@ use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
+use mem: std.memory;
+
 use token: mach.lang.fe.token;
 use src:   mach.lang.source;
 
@@ -240,13 +242,9 @@ pub fun build_suggestion(alloc: *Allocator, name: str) str {
     if (is_err[*char, str](r)) { ret nil; }
     val buf: str = unwrap_ok[*char, str](r);
 
-    var w: usize = 0;
-    var i: usize = 0;
-    for (i < pn) { buf[w] = prefix[i]; w = w + 1; i = i + 1; }
-    i = 0;
-    for (i < nn) { buf[w] = name[i]; w = w + 1; i = i + 1; }
-    i = 0;
-    for (i < sn) { buf[w] = suffix[i]; w = w + 1; i = i + 1; }
-    buf[w] = 0;
+    mem.raw_copy(buf::ptr, prefix::ptr, pn);
+    mem.raw_copy((buf::usize + pn)::ptr, name::ptr, nn);
+    mem.raw_copy((buf::usize + pn + nn)::ptr, suffix::ptr, sn);
+    buf[total] = 0;
     ret buf;
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -21,6 +21,7 @@ use std.types.char.char;
 use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_empty;
+use std.types.string.str_ends_with;
 use std.text.string.str_dup;
 use std.text.string.str_free;
 use std.types.string.StrView;
@@ -993,15 +994,9 @@ fun entry_module_fqn(p: *Project, t: *TargetEntry) Result[intern.StrId, str] {
 
 fun strip_mach_suffix(s: str) StrView {
     val suffix: str = ".mach";
-    val s_len:   usize = str_len(s);
-    val suf_len: usize = str_len(suffix);
-    if (s_len < suf_len) { ret view(s::*char, s_len); }
-    var i: usize = 0;
-    for (i < suf_len) {
-        if (s[s_len - suf_len + i] != suffix[i]) { ret view(s::*char, s_len); }
-        i = i + 1;
-    }
-    ret view(s::*char, s_len - suf_len);
+    val s_len: usize = str_len(s);
+    if (!str_ends_with(s, suffix)) { ret view(s::*char, s_len); }
+    ret view(s::*char, s_len - str_len(suffix));
 }
 
 # fqn_to_file_path: resolve an FQN like "std.types.bool" against the

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -603,6 +603,8 @@ fun hex_digit(c: u8) i64 {
     ret 0 - 1;
 }
 
+# true when byte `b` occurs in view `s`.
+# TODO(#1302): kept local; std.types.string StrView has no view_index_char/contains.
 fun contains_byte(s: StrView, b: u8) bool {
     var i: usize = 0;
     for (i < s.len) {

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -45,6 +45,8 @@ use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
+use mem: std.memory;
+
 use src:    mach.lang.source;
 use diag:   mach.lang.diagnostic;
 use intern: mach.lang.intern;
@@ -1878,14 +1880,10 @@ fun report_named(rc: *ResolveContext, span: token.Span, prefix: str, name_id: in
     }
     val buf: str = unwrap_ok[*char, str](r);
 
-    var w: usize = 0;
-    var i: usize = 0;
-    for (i < pn) { buf[w] = prefix[i]; w = w + 1; i = i + 1; }
-    i = 0;
-    for (i < nn) { buf[w] = name[i]; w = w + 1; i = i + 1; }
-    i = 0;
-    for (i < sn) { buf[w] = suffix[i]; w = w + 1; i = i + 1; }
-    buf[w] = 0;
+    mem.raw_copy(buf::ptr, prefix::ptr, pn);
+    mem.raw_copy((buf::usize + pn)::ptr, name::ptr, nn);
+    mem.raw_copy((buf::usize + pn + nn)::ptr, suffix::ptr, sn);
+    buf[total] = 0;
 
     val emit: Result[bool, str] = diag.error(?rc.s.diags, rc.a.file_id, span, buf);
     deallocate[char](rc.s.alloc, buf, total + 1);

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -39,6 +39,8 @@ use std.types.result.unwrap_err;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 
+use mem: std.memory;
+
 use ty:    mach.lang.type;
 use diag:  mach.lang.diagnostic;
 use intern: mach.lang.intern;
@@ -876,10 +878,8 @@ fun write_name(sc: *sema.SemaContext, buf: str, k: usize, name: intern.StrId) us
 # offset.
 fun write_kw(buf: str, k: usize, s: str) usize {
     val n: usize = str_len(s);
-    var w: usize = k;
-    var i: usize = 0;
-    for (i < n) { buf[w] = s[i]; w = w + 1; i = i + 1; }
-    ret w;
+    mem.raw_copy((buf::usize + k)::ptr, s::ptr, n);
+    ret k + n;
 }
 
 # decimal_len: number of base-10 digits in `n` (1 for 0).

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -36,6 +36,8 @@ use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
+use mem: std.memory;
+
 use ty:     mach.lang.type;
 use sess:   mach.lang.session;
 use diag:   mach.lang.diagnostic;
@@ -647,10 +649,8 @@ fun report_type_arg_count(sc: *sema.SemaContext, span: token.Span, prefix: str, 
 # write_kw: copy a string's bytes into `buf` at offset `k`, returning the new offset.
 fun write_kw(buf: str, k: usize, s: str) usize {
     val n: usize = str_len(s);
-    var w: usize = k;
-    var i: usize = 0;
-    for (i < n) { buf[w] = s[i]; w = w + 1; i = i + 1; }
-    ret w;
+    mem.raw_copy((buf::usize + k)::ptr, s::ptr, n);
+    ret k + n;
 }
 
 # decimal_len: number of base-10 digits in `n` (1 for 0).

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -44,6 +44,7 @@ use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
+use mem:   std.memory;
 use map:   std.collections.map;
 use fnv1a: std.crypto.hash.fnv1a;
 
@@ -529,11 +530,7 @@ fun dup_ids(alloc: *Allocator, src: *IrTypeId, count: u32) Result[*IrTypeId, str
     val r: Result[*IrTypeId, str] = allocate[IrTypeId](alloc, count::usize);
     if (is_err[*IrTypeId, str](r)) { ret r; }
     val buf: *IrTypeId = unwrap_ok[*IrTypeId, str](r);
-    var i: u32 = 0;
-    for (i < count) {
-        buf[i] = src[i];
-        i = i + 1;
-    }
+    mem.copy[IrTypeId](buf, src, count::usize);
     ret ok[*IrTypeId, str](buf);
 }
 
@@ -548,6 +545,7 @@ fun free_payload(t: *IrTypeTable, ir: *IrType) {
 }
 
 # true when two IrTypeId sequences of length `n` are element-wise equal.
+# TODO(#1302): kept local; std.memory has no generic equal[T] yet.
 fun id_seq_equals(a: *IrTypeId, b: *IrTypeId, n: u32) bool {
     var i: u32 = 0;
     for (i < n) {

--- a/src/lang/me/lower/mangle.mach
+++ b/src/lang/me/lower/mangle.mach
@@ -40,6 +40,8 @@ use std.types.result.unwrap_err;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 
+use mem: std.memory;
+
 use sess:   mach.lang.session;
 use intern: mach.lang.intern;
 use ty:     mach.lang.type;
@@ -565,10 +567,8 @@ fun write_kw(buf: *u8, k: usize, kw: str) usize {
 # write_str: copy a str's bytes into `buf` at offset `k`, returning the new offset.
 fun write_str(buf: *u8, k: usize, s: str) usize {
     val n: usize = str_len(s);
-    var w: usize = k;
-    var i: usize = 0;
-    for (i < n) { buf[w] = s[i]; w = w + 1; i = i + 1; }
-    ret w;
+    mem.raw_copy((buf::usize + k)::ptr, s::ptr, n);
+    ret k + n;
 }
 
 # decimal_len: number of base-10 digits in `n` (1 for 0).

--- a/src/lang/me/lower/testrunner.mach
+++ b/src/lang/me/lower/testrunner.mach
@@ -40,6 +40,8 @@ use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
+use mem:     std.memory;
+
 use map:     std.collections.map;
 use maphash: std.collections.map;
 
@@ -367,10 +369,10 @@ fun rodata_cstr(c: *Ctx, sid: intern.StrId, len_out: *usize) Result[value.Value,
 # anon_name: a unique object-private global name for the runner's string blobs.
 fun anon_name(c: *Ctx, idx: u32) Result[intern.StrId, str] {
     var buf: [32]u8;
-    var k: usize = 0;
     val prefix: str = ".Ltest";
-    var pi: usize = 0;
-    for (pi < str_len(prefix)) { buf[k] = prefix[pi]::u8; k = k + 1; pi = pi + 1; }
+    val plen: usize = str_len(prefix);
+    mem.raw_copy((?buf[0])::ptr, prefix::ptr, plen);
+    var k: usize = plen;
     if (idx == 0) { buf[k] = '0'; k = k + 1; }
     or {
         var tmp: [16]u8;

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -663,6 +663,7 @@ fun dup_bytes(alloc: *Allocator, src: *u8, len: u32) Result[*u8, str] {
 }
 
 # bytes_equal: byte-wise equality of two buffers. nil buffers compare as length-0.
+# TODO(#1302): kept local; std.memory has no raw_equal/equal[T] yet.
 fun bytes_equal(a: *u8, a_len: u32, b: *u8, b_len: u32) bool {
     if (a_len != b_len) { ret false; }
     if (a_len == 0) { ret true; }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -29,6 +29,8 @@ use std.types.string.str;
 use std.types.string.str_equals;
 use std.types.string.str_contains;
 use std.types.string.str_len;
+use std.types.string.str_starts_with;
+use std.types.string.str_region_equals;
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
@@ -4277,14 +4279,7 @@ fun substitute_asm_locals(alloc: *Allocator, interner: *intern.Interner, f: *mir
 fun bind_name_eq(interner: *intern.Interner, name: intern.StrId, body: str, start: usize, name_len: usize) bool {
     val nopt: Option[str] = intern.lookup(interner, name);
     if (!is_some[str](nopt)) { ret false; }
-    val nm: str = unwrap[str](nopt);
-    if (str_len(nm) != name_len) { ret false; }
-    var k: usize = 0;
-    for (k < name_len) {
-        if (nm[k] != body[start + k]) { ret false; }
-        k = k + 1;
-    }
-    ret true;
+    ret str_region_equals(body, start, name_len, unwrap[str](nopt));
 }
 
 # is_asm_space: true for ASCII whitespace the asm tokenizer trims.
@@ -4592,13 +4587,8 @@ fun asm_to_isa(op: *AsmOperand, size: u8) isa.Operand {
 # mnemonic_is: true when `tok` starts with `m` followed by a space (an operand
 # follows) — the operand-bearing mnemonic test cmach spells with `strncmp`.
 fun mnemonic_is(tok: str, m: str) bool {
-    val ml: usize = str_len(m);
-    var k: usize = 0;
-    for (k < ml) {
-        if (tok[k] != m[k]) { ret false; }
-        k = k + 1;
-    }
-    ret tok[ml] == ' '::char;
+    if (!str_starts_with(tok, m)) { ret false; }
+    ret tok[str_len(m)] == ' '::char;
 }
 
 # arg_str: the trimmed operand text of `tok` after a leading mnemonic of length

--- a/src/lang/target/of/ar.mach
+++ b/src/lang/target/of/ar.mach
@@ -22,6 +22,8 @@ use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_starts_with;
 
 # the 8-byte archive magic that opens every `ar` file.
 val MAGIC_LEN: usize = 8;
@@ -195,12 +197,7 @@ pub fun is_special(buf: *u8, pos: usize) bool {
 # `pre`. the name occupies the first 16 header bytes; this compares only `pre`'s
 # bytes, so a longer name sharing the prefix (e.g. `__.SYMDEF SORTED`) matches.
 fun name_has_prefix(buf: *u8, pos: usize, pre: *u8) bool {
-    var i: usize = 0;
-    for (pre[i] != 0) {
-        if (buf[pos + i] != pre[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
+    ret str_starts_with((buf::usize + pos)::str, pre::str);
 }
 
 # parse_size: decode the space-padded decimal-ASCII size field at `at`.

--- a/src/lang/target/of/bin.mach
+++ b/src/lang/target/of/bin.mach
@@ -32,6 +32,8 @@ use std.allocator.allocate;
 use std.allocator.zallocate;
 use std.allocator.deallocate;
 
+use mem: std.memory;
+
 use intern: mach.lang.intern;
 use of:     mach.lang.target.of;
 
@@ -79,11 +81,7 @@ pub fun write_str(buf: *u8, offset: usize, s: str) usize {
         ret 1;
     }
     val len: usize = str_len(s);
-    var i: usize = 0;
-    for (i < len) {
-        buf[offset + i] = s[i];
-        i = i + 1;
-    }
+    mem.raw_copy((buf::usize + offset)::ptr, s::ptr, len);
     buf[offset + len] = 0;
     ret len + 1;
 }
@@ -163,10 +161,8 @@ pub fun name_message(itn: *intern.Interner, alloc: *Allocator, prefix: str, name
     val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
     if (is_err[*u8, str](r)) { ret generic; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
-    var k: usize = 0;
-    for (k < lpre) { buf[k] = prefix[k]; k = k + 1; }
-    var n: usize = 0;
-    for (n < lnam) { buf[lpre + n] = name[n]; n = n + 1; }
+    mem.raw_copy(buf::ptr, prefix::ptr, lpre);
+    mem.raw_copy((buf::usize + lpre)::ptr, name::ptr, lnam);
     buf[total] = 0;
 
     val ir: Result[intern.StrId, str] = intern.intern(itn, buf::str);
@@ -203,8 +199,7 @@ pub fun number_message(itn: *intern.Interner, alloc: *Allocator, prefix: str, va
     val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
     if (is_err[*u8, str](r)) { ret generic; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
-    var k: usize = 0;
-    for (k < lpre) { buf[k] = prefix[k]; k = k + 1; }
+    mem.raw_copy(buf::ptr, prefix::ptr, lpre);
     var d: usize = 0;
     for (d < ndig) { buf[lpre + d] = digits[ndig - 1 - d]; d = d + 1; }
     buf[total] = 0;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -343,12 +343,9 @@ fun strtab_size(img: *of.ObjectImage) usize {
 
 # write an inline 8-byte symbol/section name field at `off`, zero-padded.
 fun write_inline_name(buf: *u8, off: usize, name: str) {
-    var i: usize = 0;
-    for (i < 8) { buf[off + i] = 0; i = i + 1; }
+    mem.raw_zero((buf::usize + off)::ptr, 8);
     if (name == nil) { ret; }
-    val len: usize = str_len(name);
-    i = 0;
-    for (i < len) { buf[off + i] = name[i]; i = i + 1; }
+    mem.raw_copy((buf::usize + off)::ptr, name::ptr, str_len(name));
 }
 
 # write the decimal text of `value` right-justified into `width` bytes starting
@@ -402,10 +399,8 @@ fun unresolved_reloc_message(alloc: *Allocator, sym: intern.StrId) str {
     val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
     if (is_err[*u8, str](r)) { ret generic; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
-    var k: usize = 0;
-    for (k < lpre) { buf[k] = pre[k]; k = k + 1; }
-    var n: usize = 0;
-    for (n < lnam) { buf[lpre + n] = name[n]; n = n + 1; }
+    mem.raw_copy(buf::ptr, pre::ptr, lpre);
+    mem.raw_copy((buf::usize + lpre)::ptr, name::ptr, lnam);
     buf[total] = 0;
 
     val ir: Result[intern.StrId, str] = intern.intern(coff_interner, buf::str);
@@ -1090,11 +1085,7 @@ var name_scratch: [9]u8;
 # it, and return it as a str. the buffer is reused per call; the caller interns
 # the result immediately, so no two live names overlap.
 fun framed_name(buf: *u8, off: usize) str {
-    var i: usize = 0;
-    for (i < 8) {
-        name_scratch[i] = buf[off + i];
-        i = i + 1;
-    }
+    mem.raw_copy((?name_scratch[0])::ptr, (buf::usize + off)::ptr, 8);
     name_scratch[8] = 0;
     ret ((?name_scratch[0])::usize)::str;
 }


### PR DESCRIPTION
Sweeps `src/lang/` for hand-rolled reimplementations of mach-std primitives and replaces them with the std imports (string utilities first, per the maintainer note). CLI (#1296) is intentionally out of scope to avoid colliding with the in-flight manifest work.

Full file:line inventory (replaced / kept-with-reason / std gaps) posted on the issue: https://github.com/octalide/mach/issues/1302#issuecomment-4676501467

### Families

- **`std.types.string` predicates** — `mnemonic_is`/`name_has_prefix` → `str_starts_with`, `bind_name_eq` → `str_region_equals`, `strip_mach_suffix` → `str_ends_with`.
- **`std.memory` byte copies/fills** — the per-symbol/per-name copy and zero-fill loops in the object writers (coff/bin/ar/linker) and the diagnostic / name-mangling string builders → `mem.raw_copy` / `mem.raw_zero` / `mem.copy[T]`.

### Kept (std gaps, flagged `TODO(#1302)`)

No matching mach-std primitive today; left local and flagged for a follow-up mach-std PR:
- `bytes_equal` / `id_seq_equals` — no `std.memory.raw_equal` / `equal[T]`
- `contains_byte` (StrView) — no `view_index_char` / `view_contains_char`

All changes are behavior-preserving. The vendored mach-std already exposes every primitive used, so **no submodule bump**. Loop shapes change, so the binary differs from the prior release, but the 3-stage self-host fixpoint still converges.

Refs #1302
