### PR TITLE
feat(manifest): v2 mach.toml schema model + parser + single-artifact wiring (phase 1)

### DIFF
--- a/.github/tests/manifestv2/app/mach.toml
+++ b/.github/tests/manifestv2/app/mach.toml
@@ -1,0 +1,39 @@
+[project]
+id      = "demo"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+ir      = "out/{target}/{profile}/ir"
+asm     = "out/{target}/{profile}/asm"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+ext  = ".exe"
+libs = ["kernel32.dll"]
+
+[bin.hello]
+entry = "hello.mach"
+
+[bin.bye]
+entry = "bye.mach"
+
+[profile.debug]
+opt = "O0"
+
+[profile.release]
+opt     = "O2"
+emit_ir = true
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.4.0"

--- a/.github/tests/manifestv2/app/src/bye.mach
+++ b/.github/tests/manifestv2/app/src/bye.mach
@@ -1,0 +1,7 @@
+use std.runtime;
+use code: demo.code;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret code.answer() + 4;
+}

--- a/.github/tests/manifestv2/app/src/code.mach
+++ b/.github/tests/manifestv2/app/src/code.mach
@@ -1,0 +1,7 @@
+# shared module imported by both binaries, proving the v2 build resolves a
+# multi-module graph per artifact.
+
+# answer: the value each binary derives its exit code from.
+pub fun answer() i64 {
+    ret 5;
+}

--- a/.github/tests/manifestv2/app/src/hello.mach
+++ b/.github/tests/manifestv2/app/src/hello.mach
@@ -1,0 +1,7 @@
+use std.runtime;
+use code: demo.code;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret code.answer() + 2;
+}

--- a/.github/tests/manifestv2/run.sh
+++ b/.github/tests/manifestv2/run.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# manifestv2 integration test: build a v2-format mach.toml project end to end.
+#
+# the project declares two binaries (hello, bye) sharing a module, two targets
+# (linux, windows), and two profiles (debug, release with emit_ir). this suite
+# proves the v2 manifest reader drives a real build: per-artifact selection
+# (`--bin`), profile selection (`--release`) routing outputs to a separate dir,
+# the profile's `emit_ir` toggle (and a `--no-emit-ir` override of it), windows
+# cross-compilation, and the loud failures for an ambiguous default, an unknown
+# artifact, and a path collision.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/app"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+APP="$WORK/app"
+
+fail=0
+
+# expect_exit <desc> <expected-code> <binary> — run a built binary and check it.
+expect_exit() {
+    local desc="$1"; local want="$2"; local bin="$3"
+    if [ ! -x "$bin" ]; then
+        echo "FAIL manifestv2: $desc — binary not produced at $bin" >&2
+        fail=1; return
+    fi
+    set +e
+    "$bin"; local got=$?
+    set -e
+    if [ "$got" -ne "$want" ]; then
+        echo "FAIL manifestv2: $desc — exit $got, expected $want" >&2
+        fail=1; return
+    fi
+    echo "PASS manifestv2: $desc"
+}
+
+# expect_fail <desc> <build args...> — the build must fail.
+expect_fail() {
+    local desc="$1"; shift
+    if ( cd "$APP" && "$MACH" build "$@" ) >/dev/null 2>&1; then
+        echo "FAIL manifestv2: $desc — build unexpectedly succeeded" >&2
+        fail=1; return
+    fi
+    echo "PASS manifestv2: $desc"
+}
+
+# default target (native -> linux) + default profile (debug), per-artifact.
+( cd "$APP" && "$MACH" build . --bin hello )
+( cd "$APP" && "$MACH" build . --bin bye )
+expect_exit "native debug --bin hello" 7 "$APP/out/linux/debug/bin/hello"
+expect_exit "native debug --bin bye"   9 "$APP/out/linux/debug/bin/bye"
+
+# release profile routes outputs to a separate directory (no debug overwrite).
+( cd "$APP" && "$MACH" build . --bin hello --release )
+expect_exit "native release --bin hello" 7 "$APP/out/linux/release/bin/hello"
+if [ ! -x "$APP/out/linux/debug/bin/hello" ]; then
+    echo "FAIL manifestv2: release build clobbered the debug binary" >&2; fail=1
+else
+    echo "PASS manifestv2: debug and release outputs coexist"
+fi
+
+# the release profile's emit_ir toggle writes per-module IR dumps.
+if [ -f "$APP/out/linux/release/ir/demo/hello.ir" ]; then
+    echo "PASS manifestv2: profile emit_ir writes per-module IR"
+else
+    echo "FAIL manifestv2: profile emit_ir produced no IR dump" >&2; fail=1
+fi
+
+# --no-emit-ir overrides the profile default off.
+rm -rf "$APP/out/linux/release"
+( cd "$APP" && "$MACH" build . --bin hello --release --no-emit-ir )
+if [ -d "$APP/out/linux/release/ir" ]; then
+    echo "FAIL manifestv2: --no-emit-ir did not override the profile default" >&2; fail=1
+else
+    echo "PASS manifestv2: --no-emit-ir overrides the profile emit_ir default"
+fi
+
+# --emit-asm writes per-module assembly even when the profile leaves it off.
+( cd "$APP" && "$MACH" build . --bin bye --emit-asm )
+if [ -f "$APP/out/linux/debug/asm/demo/bye.s" ]; then
+    echo "PASS manifestv2: --emit-asm writes per-module assembly"
+else
+    echo "FAIL manifestv2: --emit-asm produced no assembly dump" >&2; fail=1
+fi
+
+# windows cross-compilation produces a PE executable at the .exe template path.
+( cd "$APP" && "$MACH" build . --bin hello --target windows )
+EXE="$APP/out/windows/debug/bin/hello.exe"
+if [ -f "$EXE" ] && head -c2 "$EXE" | grep -q "MZ"; then
+    echo "PASS manifestv2: windows cross-compile produces a PE .exe"
+else
+    echo "FAIL manifestv2: windows cross-compile produced no PE at $EXE" >&2; fail=1
+fi
+
+# loud failures: ambiguous default, unknown artifact, unknown target/profile.
+expect_fail "ambiguous default (two bins, no selector)" .
+expect_fail "unknown bin selector" . --bin nope
+expect_fail "unknown target selector" . --bin hello --target bsd
+expect_fail "unknown profile selector" . --bin hello --profile fast
+
+# a path collision (both bins to one fixed path) is rejected at build start.
+COLL="$WORK/coll"
+cp -r "$APP" "$COLL"
+sed -i 's|^out     = .*|out     = "out/app"|' "$COLL/mach.toml"
+if ( cd "$COLL" && "$MACH" build . --bin hello ) >/dev/null 2>&1; then
+    echo "FAIL manifestv2: a path collision did not fail the build" >&2; fail=1
+else
+    echo "PASS manifestv2: colliding artifact paths fail at build start"
+fi
+
+exit "$fail"

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -37,11 +37,16 @@ Read by `build`, `run`, `test`, and `doc` (they share one config parser).
 | `--quiet`, `-q`  | —                | suppress non-error output |
 | `--color <mode>` | `auto`\|`always`\|`never` | color preference for terminal output (default `auto`); an unknown mode is a parse error |
 | `--cwd <path>`   | path             | run as if started in `<path>` (project-root search begins there) |
-| `--target <name>`| target name      | select a `[targets.<name>]` entry; absent, defers to `[project].target` |
+| `--target <name>`| target name      | select a declared target; absent, defers to `[project].target` |
+| `--profile <name>`| profile name    | select a `[profile.<name>]` build variant (v2 manifest); absent, the first declared profile |
+| `--bin <name>`   | artifact name    | narrow a v2 build to one `[bin.<name>]` artifact |
+| `--lib <name>`   | artifact name    | narrow a v2 build to one `[lib.<name>]` artifact (mutually exclusive with `--bin`) |
 | `-o <path>`      | path             | override the linked-binary path, rooted at the project root (build/run/test) |
-| `--artifacts <dir>` | dir           | override the per-target object directory, rooted at `<dir_out>` (build/run/test) |
-| `--emit-asm`     | —                | emit per-module assembly text (`.s`) beside each object |
-| `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`) beside each object |
+| `--artifacts <dir>` | dir           | override the per-target object directory, rooted at `<dir_out>` (old manifest only) |
+| `--emit-asm`     | —                | emit per-module assembly text (`.s`); on a v2 manifest, forces the profile toggle on |
+| `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`); on a v2 manifest, forces the profile toggle on |
+| `--no-emit-asm`  | —                | force per-module assembly emission off, overriding a v2 profile's `emit_asm` |
+| `--no-emit-ir`   | —                | force per-module IR emission off, overriding a v2 profile's `emit_ir` |
 | `--verify-ir`    | —                | run the IR verifier after each optimisation pass |
 
 > `mach dep` and `mach init` do not use the shared config parser; they read only

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -5,9 +5,114 @@ identity, one or more build targets, and its dependencies. The compiler finds
 it by walking up from the working directory until a `mach.toml` is seen, so any
 subcommand run inside a project tree resolves the same manifest.
 
-This page is the authoritative reference for the manifest schema as the current
-compiler reads it. Keys the parser does not consume are noted as **informational**
-— they are accepted (TOML still parses) but have no effect on the build today.
+## Two formats during the v2 transition
+
+The manifest is moving to a **v2 schema** (#1218) that separates the three axes
+the old `[targets.<name>]` table fused — *what* is built (artifacts), *where* it
+runs (targets), and *where* outputs land (templates). Both formats are accepted
+for now: a manifest with the new singular `[target.<name>]` table (and no plural
+`[targets.<name>]`) is read by the v2 reader; everything else uses the old reader
+documented in [The old format](#the-old-format) below. The old reader is removed
+once the ecosystem has migrated.
+
+## mach.toml v2
+
+The v2 manifest is the complete, readable statement of what a project builds.
+Repetition between axes is eliminated by the build engine's cartesian product,
+never by the file; layout rules the file states (the path templates) are
+explicit, and nothing is inferred.
+
+```toml
+[project]
+id      = "demo"            # required: root of every module path the project exposes
+version = "0.1.0"           # required
+src     = "src"             # source dir (default "src")
+dep     = "dep"             # vendored-dependency dir (default "dep")
+target  = "native"          # default target selector (default "native")
+out     = "out/{target}/{profile}/bin/{name}{ext}"  # artifact path template
+obj     = "out/{target}/{profile}/obj"              # intermediate-object dir template
+ir      = "out/{target}/{profile}/ir"               # IR-dump dir template
+asm     = "out/{target}/{profile}/asm"              # ASM-dump dir template
+# optional metadata: name, description, license, authors
+
+[target.linux]             # a platform: fully-spelled tuple, nothing inferred
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.windows]
+isa     = "x86_64"
+os      = "windows"
+abi     = "win64"
+ext     = ".exe"           # artifact extension (default "")
+libs    = ["kernel32.dll"] # platform link overlay, inherited by every artifact
+defines = []               # per-target comptime defines (reserved for #1191)
+
+[bin.hello]                # an executable artifact, named by its table key
+entry = "hello.mach"       # entry source, relative to the src dir (required)
+
+[lib.core]                 # a library artifact
+entry = "lib.mach"
+kind  = "static"           # "static" (default) | "shared"
+
+[bin.hello.target.windows] # a per-cell exception refining one artifact-target pair
+entry = "hello_win.mach"   # overrides the artifact's entry for this target only
+libs  = ["user32.dll"]     # appended to the merged link overlay
+
+[profile.debug]            # a build variant
+opt = "O0"                 # "O0"/"debug" | "O1"/"O2"/"release"
+
+[profile.release]
+opt      = "O2"
+emit_ir  = true            # emit per-module IR for this profile (default false)
+emit_asm = false           # emit per-module assembly for this profile (default false)
+
+[deps.mach-std]            # a dependency: exactly one of git|path, plus ref for git
+git = "https://github.com/octalide/mach-std"
+ref = "v0.4.0"
+```
+
+### Path templates
+
+Output paths come only from the declared templates, expanded over four variables
+— `{target}` (the resolved target name), `{profile}`, `{name}` (the artifact
+name), and `{ext}` (the target's extension). Manifest paths are always
+`/`-separated and normalized to the host separator at the filesystem boundary, so
+the same manifest is portable; a literal `\` in a path is a hard error. Two
+artifacts that resolve to the same `out` path collide and fail at build start.
+
+### Selection and the build matrix
+
+A build resolves one artifact × one target × one profile. `--bin <name>` /
+`--lib <name>` select an artifact, `--target <name>` selects a declared target,
+`--profile <name>` (with `--release` sugar) selects a profile. With several
+artifacts declared and no `--bin`/`--lib`, the build asks you to pick one (the
+full multi-artifact matrix is a later phase of #1218). Absent `--profile`/
+`--release`, the first declared profile is used; absent any declared profile, a
+`debug` default (no optimization, no emission) applies.
+
+### `native` target resolution
+
+`native` is a reserved selector (declaring `[target.native]` is an error). It
+resolves the host's `(isa, os)` tuple against the **declared** targets only —
+never a synthesized tuple. Exactly one host match is chosen; several matching
+tuples is an ambiguity error naming the candidates; no match warns
+(`no declared target matches the host (...)`) and falls back to the first
+declared target so cross-only projects still build on a foreign host. `{target}`
+always expands to the chosen target's name, never the literal `native`.
+
+### Precedence and link overlays
+
+A `[bin.X]`/`[lib.X]` field is overlaid by its `[target.Y]` platform overlay
+(`libs`, `defines`), which is overlaid by a `[bin.X.target.Y]` per-cell
+exception. Link inputs (`libs`) merge in that order, deduplicated by name. A
+dependency's source key is `git` (with `ref`) or `path`; a registry-style
+`version =` is reserved and rejected.
+
+## The old format
+
+The remainder of this page documents the old (plural `[targets.<name>]`) format,
+read unchanged during the transition.
 
 ## Tables
 

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -46,11 +46,12 @@ use fs: std.filesystem;
 
 use writer: std.io.writer;
 
-use intern: mach.lang.intern;
-use sess:   mach.lang.session;
-use src:    mach.lang.source;
-use diag:   mach.lang.diagnostic;
-use driver: mach.lang.driver;
+use intern:   mach.lang.intern;
+use sess:     mach.lang.session;
+use src:      mach.lang.source;
+use diag:     mach.lang.diagnostic;
+use driver:   mach.lang.driver;
+use manifest: mach.lang.manifest;
 
 use sema:    mach.lang.fe.sema;
 use token:   mach.lang.fe.token;
@@ -83,16 +84,20 @@ pub rec BuildResult {
 }
 
 # EmitArtifacts: the debug-artifact emission settings threaded into the per-module
-# compile loop. `base` is the resolved `<root>/<out>/<artifacts>` prefix the `asm/`
-# and `ir/` trees hang off (a borrowed pointer into the caller's path buffer, valid
-# for the compile); `want_asm` / `want_ir` toggle each text artifact (`--emit-asm` /
-# `--emit-ir`). when both flags are off `base` is unused.
+# compile loop. `ir_base` / `asm_base` are the resolved directories under which the
+# per-module `.ir` / `.s` files are written, FQN-mirrored (borrowed pointers into
+# the caller's path buffers, valid for the compile). the old reader sets both to
+# `<root>/<out>/<artifacts>/ir` and `.../asm`; the v2 reader sets each from its own
+# resolved template. `want_asm` / `want_ir` toggle each artifact; an off toggle
+# leaves the corresponding base unused.
 # ---
-# base: resolved `<root>/<out>/<artifacts>` directory prefix (borrowed)
+# ir_base:  resolved directory for per-module `.ir` files (borrowed)
+# asm_base: resolved directory for per-module `.s` files (borrowed)
 # want_asm: emit per-module `.s` assembly text
 # want_ir:  emit per-module `.ir` SSA IR text
 rec EmitArtifacts {
-    base:     *u8;
+    ir_base:  *u8;
+    asm_base: *u8;
     want_asm: bool;
     want_ir:  bool;
 }
@@ -264,7 +269,7 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
 
             var irf: fs.File;
             var irw: writer.Writer;
-            val oir: Result[bool, str] = open_artifact(ea.base, "ir", fqn, "ir", ?irf, ?irw);
+            val oir: Result[bool, str] = open_artifact(ea.ir_base, fqn, "ir", ?irf, ?irw);
             if (is_err[bool, str](oir)) { ret err[bool, str](unwrap_err[bool, str](oir)); }
             val pir: Result[bool, str] = ir_printer.print_module(?irw, ?irs[mid::u32], ?p.s.interner);
             val cir: Result[bool, str] = fs.close(?irf);
@@ -298,7 +303,7 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
             val fqn_opt: Option[str] = intern.lookup(?p.s.interner, m.fqn);
             if (is_none[str](fqn_opt)) { ret err[bool, str]("module FQN not interned"); }
             val fqn: str = unwrap[str](fqn_opt);
-            val oas: Result[bool, str] = open_artifact(ea.base, "asm", fqn, "s", ?asmf, ?asmw);
+            val oas: Result[bool, str] = open_artifact(ea.asm_base, fqn, "s", ?asmf, ?asmw);
             if (is_err[bool, str](oas)) { ret err[bool, str](unwrap_err[bool, str](oas)); }
             asm_out = ?asmw;
         }
@@ -405,6 +410,31 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_m
     var target_name: *u8 = config.target;
     if (target_name == nil) { target_name = ""; }
 
+    # the build selection threaded to the driver. for a v2 manifest it narrows
+    # target/profile/artifact; the old reader uses only the target. `--release`
+    # is sugar for `--profile release`, and `--bin`/`--lib` are mutually exclusive.
+    var profile_name: *u8 = config.profile;
+    if (profile_name == nil && config.release) { profile_name = "release"; }
+    if (profile_name == nil) { profile_name = ""; }
+
+    var artifact_name: *u8 = "";
+    var want_lib:      bool = false;
+    var has_artifact:  bool = false;
+    if (config.bin != nil && config.lib != nil) {
+        util.emit("error: --bin and --lib cannot be combined\n");
+        br.code = 1;
+        ret br;
+    }
+    if (config.bin != nil) { artifact_name = config.bin; has_artifact = true; }
+    or (config.lib != nil) { artifact_name = config.lib; want_lib = true; has_artifact = true; }
+
+    var sel: manifest.Selection;
+    sel.target       = util.cstr_str(target_name);
+    sel.profile      = util.cstr_str(profile_name);
+    sel.artifact     = util.cstr_str(artifact_name);
+    sel.want_lib     = want_lib;
+    sel.has_artifact = has_artifact;
+
     val sess_r: Result[sess.Session, str] = sess.init(alloc);
     if (is_err[sess.Session, str](sess_r)) {
         util.emit("error: failed to initialise compiler session: ");
@@ -430,7 +460,7 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_m
         ret br;
     }
 
-    val proj_r: Result[driver.Project, str] = driver.build_project(?s, util.cstr_str(?root[0]), util.cstr_str(target_name));
+    val proj_r: Result[driver.Project, str] = driver.build_project_sel(?s, util.cstr_str(?root[0]), ?sel);
     if (is_err[driver.Project, str](proj_r)) {
         util.emit("error: ");
         util.emit(unwrap_err[driver.Project, str](proj_r));
@@ -445,7 +475,20 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_m
     # otherwise the selected target's `[targets.*].opt` applies, else debug.
     val level: u8 = resolve_opt_level(?p, cli_level, cli_set);
 
-    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, config.verbose, config.emit_asm, config.emit_ir, ?root[0], config.output, config.artifacts, eff, argv, ?br.output_path);
+    # effective emission: a CLI `--emit-*` / `--no-emit-*` flag overrides the
+    # selected v2 profile's defaults; the old reader has only the CLI flags.
+    var eff_emit_asm: bool = config.emit_asm;
+    var eff_emit_ir:  bool = config.emit_ir;
+    if (p.config.is_v2) {
+        eff_emit_asm = p.config.v2_emit_asm;
+        eff_emit_ir  = p.config.v2_emit_ir;
+        if (config.emit_asm)    { eff_emit_asm = true; }
+        if (config.no_emit_asm) { eff_emit_asm = false; }
+        if (config.emit_ir)     { eff_emit_ir = true; }
+        if (config.no_emit_ir)  { eff_emit_ir = false; }
+    }
+
+    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, config.verbose, eff_emit_asm, eff_emit_ir, ?root[0], config.output, config.artifacts, eff, argv, ?br.output_path);
 
     cli_diag.flush(?s, ?s.diags, cfg.color_enabled(config.color));
     driver.dnit_project(?p);
@@ -484,16 +527,25 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
 
     if (verbose) { emit_target(p); }
 
-    # resolve the `<root>/<out>/<artifacts>` prefix the text-artifact trees hang
-    # off once, up front, so each module writes its `.s` / `.ir` next to its `.o`.
-    var art_base: [4096]u8;
+    # resolve the per-module `.ir` / `.s` output directories once, up front. the
+    # old reader hangs both off `<root>/<out>/<artifacts>`; the v2 reader takes
+    # each from its own resolved `ir`/`asm` template.
+    var ir_base:  [4096]u8;
+    var asm_base: [4096]u8;
     var ea: EmitArtifacts;
-    ea.base = ?art_base[0];
+    ea.ir_base  = ?ir_base[0];
+    ea.asm_base = ?asm_base[0];
     ea.want_asm = emit_asm;
     ea.want_ir  = emit_ir;
-    if (emit_asm || emit_ir) {
-        if (!resolve_art_base(p, root, art_override, ?art_base[0], 4096)) {
-            util.emit("error: project out / artifacts dir not interned\n");
+    if (emit_ir) {
+        if (!resolve_emit_base(p, root, true, art_override, ?ir_base[0], 4096)) {
+            util.emit("error: project ir output dir not interned\n");
+            ret 2;
+        }
+    }
+    if (emit_asm) {
+        if (!resolve_emit_base(p, root, false, art_override, ?asm_base[0], 4096)) {
+            util.emit("error: project asm output dir not interned\n");
             ret 2;
         }
     }
@@ -636,14 +688,14 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     val te: *driver.TargetEntry = p.target_entry;
     if (te == nil) { util.emit("error: no target selected\n"); ret 2; }
 
-    # <root>/<out>/<artifacts>/obj — the per-module object tree root.
-    # --artifacts overrides <artifacts>.
+    # the per-module object tree root. the old reader composes
+    # `<root>/<out>/<artifacts>/obj` (`--artifacts` overrides `<artifacts>`); the
+    # v2 reader takes `<root>/<resolved obj template>`.
     var obj_base: [4096]u8;
-    if (!resolve_art_base(p, root, art_override, ?obj_base[0], 4096)) {
-        util.emit("error: project out / artifacts dir not interned\n");
+    if (!resolve_obj_base(p, root, art_override, ?obj_base[0], 4096)) {
+        util.emit("error: project obj output dir not interned\n");
         ret 2;
     }
-    util.join_into(?obj_base[0], 4096, ?obj_base[0], "obj");
 
     var paths: **u8 = nil;
     val obj_code: i64 = write_objects(p, images, ?obj_base[0], ?paths);
@@ -704,10 +756,21 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     }
 
     # the executable path: `-o` overrides it with a path rooted directly at
-    # <root>; otherwise it is the target's <out>/<binary>.
+    # <root>; the v2 reader uses the unit's resolved artifact path; the old reader
+    # composes the target's <out>/<binary>.
     var artifact: [4096]u8;
     if (out_override != nil) {
         util.join_into(?artifact[0], 4096, root, out_override);
+    }
+    or (p.config.is_v2) {
+        val bin_opt: Option[str] = intern.lookup(?p.s.interner, p.config.v2_bin);
+        if (is_none[str](bin_opt) || util.slen(unwrap[str](bin_opt)::*u8) == 0) {
+            free_paths(p.s.alloc, paths, count, count);
+            free_sonames(p.s.alloc, sonames, soname_count);
+            util.emit("error: artifact has no resolved output path\n");
+            ret 1;
+        }
+        join_into_str(?artifact[0], 4096, root, unwrap[str](bin_opt));
     }
     or {
         val out_opt: Option[str] = intern.lookup(?p.s.interner, p.config.out);
@@ -1348,6 +1411,42 @@ fun resolve_art_base(p: *driver.Project, root: *u8, art_override: *u8, buf: *u8,
     ret true;
 }
 
+# join_v2_dir: write `<root>/<resolved template>` into `buf` for a v2 output dir.
+fun join_v2_dir(p: *driver.Project, root: *u8, dir_id: intern.StrId, buf: *u8, cap: usize) bool {
+    val o: Option[str] = intern.lookup(?p.s.interner, dir_id);
+    if (is_none[str](o)) { ret false; }
+    join_into_str(buf, cap, root, unwrap[str](o));
+    ret true;
+}
+
+# resolve_obj_base: write the per-module object tree root into `buf`. the v2
+# reader uses `<root>/<resolved obj template>`; the old reader composes
+# `<root>/<out>/<artifacts>/obj`.
+fun resolve_obj_base(p: *driver.Project, root: *u8, art_override: *u8, buf: *u8, cap: usize) bool {
+    if (p.config.is_v2) {
+        ret join_v2_dir(p, root, p.config.v2_obj_root, buf, cap);
+    }
+    if (!resolve_art_base(p, root, art_override, buf, cap)) { ret false; }
+    util.join_into(buf, cap, buf, "obj");
+    ret true;
+}
+
+# resolve_emit_base: write the per-module `.ir` (when `is_ir`) or `.s` output
+# directory into `buf`. the v2 reader uses `<root>/<resolved ir|asm template>`;
+# the old reader hangs each off `<root>/<out>/<artifacts>/<ir|asm>`.
+fun resolve_emit_base(p: *driver.Project, root: *u8, is_ir: bool, art_override: *u8, buf: *u8, cap: usize) bool {
+    if (p.config.is_v2) {
+        var dir_id: intern.StrId = p.config.v2_asm_root;
+        if (is_ir) { dir_id = p.config.v2_ir_root; }
+        ret join_v2_dir(p, root, dir_id, buf, cap);
+    }
+    if (!resolve_art_base(p, root, art_override, buf, cap)) { ret false; }
+    var leaf: *u8 = "asm";
+    if (is_ir) { leaf = "ir"; }
+    util.join_into(buf, cap, buf, leaf);
+    ret true;
+}
+
 # write_objects: write each per-module image to a relocatable object whose path
 # mirrors the module FQN under `obj_base` (FQN `a.b.c` -> `<obj_base>/a/b/c.o`,
 # creating parent directories), collecting the owned path strings — one per
@@ -1468,17 +1567,14 @@ fun mirror_fqn(buf: *u8, cap: usize, base: *u8, fqn: str, suffix: str) usize {
     ret k;
 }
 
-# open_artifact: create `<base>/<sub>/<rel>.<ext>` (making any parent directories)
-# and wire `w` to stream into it through the returned `file`. the FQN is mapped to
+# open_artifact: create `<base>/<rel>.<ext>` (making any parent directories) and
+# wire `w` to stream into it through the returned `file`. the FQN is mapped to
 # `<rel>` exactly as the object tree is. the caller owns `file` and must close it
 # once writing is done — the Writer borrows the File and must not outlive it.
-fun open_artifact(base: *u8, sub: str, fqn: str, suffix: str,
+fun open_artifact(base: *u8, fqn: str, suffix: str,
                   file: *fs.File, w: *writer.Writer) Result[bool, str] {
-    var sub_base: [4096]u8;
-    util.join_into(?sub_base[0], 4096, base, sub::*u8);
-
     var path: [4096]u8;
-    if (mirror_fqn(?path[0], 4096, ?sub_base[0], fqn, suffix) == 0) {
+    if (mirror_fqn(?path[0], 4096, base, fqn, suffix) == 0) {
         ret err[bool, str]("artifact path too long");
     }
     if (!util.ensure_parents(?path[0])) {

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -46,17 +46,35 @@ pub val COLOR_NEVER:  ColorMode = 2;
 #            (`.s`) alongside each object, for debugging / transparency
 # emit_ir:   --emit-ir was passed; emit per-module human-readable SSA IR text
 #            (`.ir`) alongside each object, for debugging / transparency
+# no_emit_asm: --no-emit-asm was passed; force ASM emission off, overriding a
+#              v2 profile's `emit_asm` default
+# no_emit_ir:  --no-emit-ir was passed; force IR emission off, overriding a v2
+#              profile's `emit_ir` default
+# profile:   --profile <name> selected build profile for a v2 manifest (nil when
+#            not given); `--release` is sugar for `--profile release`
+# release:   --release was passed; selects the `release` profile (v2) and the
+#            release optimization pipeline
+# bin:       --bin <name> narrows a v2 build to one `[bin.*]` artifact (nil when
+#            not given)
+# lib:       --lib <name> narrows a v2 build to one `[lib.*]` artifact (nil when
+#            not given)
 pub rec Config {
-    color:     ColorMode;
-    verbose:   bool;
-    quiet:     bool;
-    verify_ir: bool;
-    cwd:       *u8;
-    target:    *u8;
-    output:    *u8;
-    artifacts: *u8;
-    emit_asm:  bool;
-    emit_ir:   bool;
+    color:       ColorMode;
+    verbose:     bool;
+    quiet:       bool;
+    verify_ir:   bool;
+    cwd:         *u8;
+    target:      *u8;
+    output:      *u8;
+    artifacts:   *u8;
+    emit_asm:    bool;
+    emit_ir:     bool;
+    no_emit_asm: bool;
+    no_emit_ir:  bool;
+    profile:     *u8;
+    release:     bool;
+    bin:         *u8;
+    lib:         *u8;
 }
 
 # color_enabled: resolve a ColorMode to a concrete on/off decision for the
@@ -85,12 +103,18 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
     c.verbose   = false;
     c.quiet     = false;
     c.verify_ir = false;
-    c.cwd       = nil;
-    c.target    = nil;
-    c.output    = nil;
-    c.artifacts = nil;
-    c.emit_asm  = false;
-    c.emit_ir   = false;
+    c.cwd         = nil;
+    c.target      = nil;
+    c.output      = nil;
+    c.artifacts   = nil;
+    c.emit_asm    = false;
+    c.emit_ir     = false;
+    c.no_emit_asm = false;
+    c.no_emit_ir  = false;
+    c.profile     = nil;
+    c.release     = false;
+    c.bin         = nil;
+    c.lib         = nil;
 
     val verbose: bool = util.has_flag(argc, argv, "--verbose") || util.has_flag(argc, argv, "-v");
     val quiet:   bool = util.has_flag(argc, argv, "--quiet")   || util.has_flag(argc, argv, "-q");
@@ -102,6 +126,9 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
     c.verify_ir = util.has_flag(argc, argv, "--verify-ir");
     c.emit_asm  = util.has_flag(argc, argv, "--emit-asm");
     c.emit_ir   = util.has_flag(argc, argv, "--emit-ir");
+    c.no_emit_asm = util.has_flag(argc, argv, "--no-emit-asm");
+    c.no_emit_ir  = util.has_flag(argc, argv, "--no-emit-ir");
+    c.release     = util.has_flag(argc, argv, "--release");
 
     val color_opt: Option[*u8] = util.get_value(argc, argv, "--color");
     if (is_some[*u8](color_opt)) {
@@ -123,6 +150,15 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
 
     val artifacts_opt: Option[*u8] = util.get_value(argc, argv, "--artifacts");
     if (is_some[*u8](artifacts_opt)) { c.artifacts = unwrap[*u8](artifacts_opt); }
+
+    val profile_opt: Option[*u8] = util.get_value(argc, argv, "--profile");
+    if (is_some[*u8](profile_opt)) { c.profile = unwrap[*u8](profile_opt); }
+
+    val bin_opt: Option[*u8] = util.get_value(argc, argv, "--bin");
+    if (is_some[*u8](bin_opt)) { c.bin = unwrap[*u8](bin_opt); }
+
+    val lib_opt: Option[*u8] = util.get_value(argc, argv, "--lib");
+    if (is_some[*u8](lib_opt)) { c.lib = unwrap[*u8](lib_opt); }
 
     ret some[Config](c);
 }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -143,7 +143,8 @@ pub fun is_value_flag(a: *u8) bool {
     ret eq(a, "-L") || eq(a, "-l") || eq(a, "-o") ||
         eq(a, "--target") || eq(a, "--cwd") || eq(a, "--color") ||
         eq(a, "--artifacts") || eq(a, "--emit") || eq(a, "--filter") ||
-        eq(a, "--out") || eq(a, "--name") || eq(a, "--ref");
+        eq(a, "--out") || eq(a, "--name") || eq(a, "--ref") ||
+        eq(a, "--profile") || eq(a, "--bin") || eq(a, "--lib");
 }
 
 # separator_index: index of the `--` separator in argv, or argc when absent.

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -72,6 +72,8 @@ use os:  mach.lang.target.os;
 use isa: mach.lang.target.isa;
 use tgt: mach.lang.target;
 
+use manifest: mach.lang.manifest;
+
 # BuildMode: the kind of artifact a target build produces.
 pub def BuildMode: u8;
 
@@ -580,6 +582,13 @@ fun load_project_config(p: *Project, project_root: str) Result[bool, str] {
     if (is_err[toml.Table, str](toml_r)) { ret err[bool, str](unwrap_err[toml.Table, str](toml_r)); }
     var t: toml.Table = unwrap_ok[toml.Table, str](toml_r);
 
+    # transitional dual-format dispatch (#1218): a manifest with the new
+    # singular `[target.*]` schema (no plural `[targets.*]`) routes to the v2
+    # reader; everything below is the old reader, removed in the final phase.
+    if (manifest.is_v2(?t)) {
+        ret load_v2_config(p, project_root, ?t);
+    }
+
     val id_str: str = toml.get_str(?t, "project.id");
     if (str_empty(id_str)) { ret err[bool, str]("mach.toml is missing [project].id"); }
     val id_iv: Result[intern.StrId, str] = intern.intern(?p.s.interner, id_str);
@@ -611,6 +620,18 @@ fun load_project_config(p: *Project, project_root: str) Result[bool, str] {
     if (is_err[bool, str](deps_r)) { ret deps_r; }
 
     ret ok[bool, str](true);
+}
+
+# load_v2_config: parse and validate a v2 manifest. the build wiring that turns
+# the parsed Manifest into a selected Project (synthesized target, resolved
+# output paths) lands in the next increment of #1218; for now a valid v2
+# manifest is parsed (surfacing schema errors) and then reported as unwired.
+fun load_v2_config(p: *Project, project_root: str, t: *toml.Table) Result[bool, str] {
+    val mr: Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, t);
+    if (is_err[manifest.Manifest, str](mr)) { ret err[bool, str](unwrap_err[manifest.Manifest, str](mr)); }
+    var m: manifest.Manifest = unwrap_ok[manifest.Manifest, str](mr);
+    manifest.dnit(?m, p.s.alloc);
+    ret err[bool, str]("mach.toml: v2 manifest support is not yet wired (#1218)");
 }
 
 fun parse_targets_table(p: *Project, t: *toml.Table) Result[bool, str] {

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -72,6 +72,7 @@ use os:  mach.lang.target.os;
 use isa: mach.lang.target.isa;
 use tgt: mach.lang.target;
 
+use sysos:    std.system.os;
 use manifest: mach.lang.manifest;
 
 # BuildMode: the kind of artifact a target build produces.
@@ -152,6 +153,15 @@ pub rec DepEntry {
 # target_count: number of entries in targets
 # deps:         flat array of DepEntry records
 # dep_count:    number of entries in deps
+# is_v2:        true when this config came from the v2 manifest reader; the
+#               build then takes its concrete output paths from the resolved
+#               `v2_*` fields below rather than composing `out`/`binary`
+# v2_bin:       interned resolved artifact path (root-relative), v2 only
+# v2_obj_root:  interned resolved intermediate-object dir (root-relative), v2 only
+# v2_ir_root:   interned resolved IR-dump dir (root-relative), v2 only
+# v2_asm_root:  interned resolved ASM-dump dir (root-relative), v2 only
+# v2_emit_ir:   selected profile's IR-emission default, v2 only
+# v2_emit_asm:  selected profile's ASM-emission default, v2 only
 pub rec ProjectConfig {
     id:           intern.StrId;
     dir_src:      intern.StrId;
@@ -163,6 +173,13 @@ pub rec ProjectConfig {
     target_count: u32;
     deps:         *DepEntry;
     dep_count:    u32;
+    is_v2:        bool;
+    v2_bin:       intern.StrId;
+    v2_obj_root:  intern.StrId;
+    v2_ir_root:   intern.StrId;
+    v2_asm_root:  intern.StrId;
+    v2_emit_ir:   bool;
+    v2_emit_asm:  bool;
 }
 
 # PubConst: one comptime constant exported by a module to its importers.
@@ -246,28 +263,61 @@ val INITIAL_PUB_CAP:    u32 = 4;
 val INITIAL_DEP_CAP:    u32 = 4;
 
 # build_project: load `project_root/mach.toml`, select `target_name`, and
-# build the full module graph plus per-module ResolveResults.
+# build the full module graph plus per-module ResolveResults. a convenience
+# wrapper over build_project_sel that selects only a target (no profile/artifact
+# narrowing) — used by read-only consumers such as `mach doc`.
 # ---
 # s:            shared session
 # project_root: filesystem path to the project root (containing mach.toml)
-# target_name:  selector that must match a `[targets.<name>]` entry
+# target_name:  selector that must match a declared target
 # ret:          fully populated Project, or an error message
 pub fun build_project(s: *sess.Session, project_root: str, target_name: str) Result[Project, str] {
+    var sel: manifest.Selection;
+    sel.target       = target_name;
+    sel.profile      = "";
+    sel.artifact     = "";
+    sel.want_lib     = false;
+    sel.has_artifact = false;
+    ret build_project_sel(s, project_root, ?sel);
+}
+
+# build_project_sel: load `project_root/mach.toml` and build the module graph
+# for the given build selection (target, profile, and one artifact). the v2
+# reader resolves the selection into the project's single target entry and
+# concrete output paths; the old reader uses the selection's target only.
+# ---
+# s:            shared session
+# project_root: filesystem path to the project root (containing mach.toml)
+# sel:          the build selection narrowing target/profile/artifact
+# ret:          fully populated Project, or an error message
+pub fun build_project_sel(s: *sess.Session, project_root: str, sel: *manifest.Selection) Result[Project, str] {
     var p: Project;
     init_project(?p, s);
 
-    val cfg_r: Result[bool, str] = load_project_config(?p, project_root);
+    val cfg_r: Result[bool, str] = load_project_config(?p, project_root, sel);
     if (is_err[bool, str](cfg_r)) {
         dnit_project(?p);
         ret err[Project, str](unwrap_err[bool, str](cfg_r));
     }
 
-    val te: *TargetEntry = find_target(?p.config, target_name, ?p.s.interner);
-    if (te == nil) {
-        dnit_project(?p);
-        ret err[Project, str]("target not found in mach.toml");
+    var te: *TargetEntry = nil;
+    if (p.config.is_v2) {
+        # the v2 reader already selected and synthesized the target entry.
+        te = p.target_entry;
+        if (te == nil) {
+            dnit_project(?p);
+            ret err[Project, str]("internal: v2 manifest selected no target");
+        }
     }
-    p.target_entry = te;
+    or {
+        te = find_target(?p.config, sel.target, ?p.s.interner);
+        if (te == nil) {
+            dnit_project(?p);
+            ret err[Project, str]("target not found in mach.toml");
+        }
+        p.target_entry = te;
+    }
+
     val fp_r: Result[bool, str] = select_target(?p, te);
     if (is_err[bool, str](fp_r)) {
         dnit_project(?p);
@@ -536,6 +586,17 @@ fun init_project(p: *Project, s: *sess.Session) {
     p.target.of      = nil;
     p.compiler_name = intern.STR_NIL;
     p.compiler_ver  = intern.STR_NIL;
+    p.config.targets      = nil;
+    p.config.target_count = 0;
+    p.config.deps         = nil;
+    p.config.dep_count    = 0;
+    p.config.is_v2        = false;
+    p.config.v2_bin       = intern.STR_NIL;
+    p.config.v2_obj_root  = intern.STR_NIL;
+    p.config.v2_ir_root   = intern.STR_NIL;
+    p.config.v2_asm_root  = intern.STR_NIL;
+    p.config.v2_emit_ir   = false;
+    p.config.v2_emit_asm  = false;
     p.modules       = nil;
     p.module_len    = 0;
     p.module_cap    = 0;
@@ -568,7 +629,7 @@ fun deallocate_config(c: *ProjectConfig, alloc: *Allocator) {
     c.dep_count    = 0;
 }
 
-fun load_project_config(p: *Project, project_root: str) Result[bool, str] {
+fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection) Result[bool, str] {
     val abs_root_r: Result[intern.StrId, str] = intern.intern(?p.s.interner, project_root);
     if (is_err[intern.StrId, str](abs_root_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](abs_root_r)); }
     p.config.project_root = unwrap_ok[intern.StrId, str](abs_root_r);
@@ -586,7 +647,7 @@ fun load_project_config(p: *Project, project_root: str) Result[bool, str] {
     # singular `[target.*]` schema (no plural `[targets.*]`) routes to the v2
     # reader; everything below is the old reader, removed in the final phase.
     if (manifest.is_v2(?t)) {
-        ret load_v2_config(p, project_root, ?t);
+        ret load_v2_config(p, project_root, ?t, sel);
     }
 
     val id_str: str = toml.get_str(?t, "project.id");
@@ -622,16 +683,130 @@ fun load_project_config(p: *Project, project_root: str) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
-# load_v2_config: parse and validate a v2 manifest. the build wiring that turns
-# the parsed Manifest into a selected Project (synthesized target, resolved
-# output paths) lands in the next increment of #1218; for now a valid v2
-# manifest is parsed (surfacing schema errors) and then reported as unwired.
-fun load_v2_config(p: *Project, project_root: str, t: *toml.Table) Result[bool, str] {
+# load_v2_config: parse a v2 manifest, resolve the build selection into one
+# build unit, and synthesize the ProjectConfig the rest of the driver consumes —
+# a single target entry plus the unit's concrete, template-expanded output paths
+# (`v2_*`). collisions are checked before anything is built. a `native`
+# selection that finds no host match emits an unmissable warning here.
+fun load_v2_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.Selection) Result[bool, str] {
     val mr: Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, t);
     if (is_err[manifest.Manifest, str](mr)) { ret err[bool, str](unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = unwrap_ok[manifest.Manifest, str](mr);
+
+    val ur: Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(p.s.alloc, ?p.s.interner, ?m, @sel);
+    if (is_err[manifest.BuildUnit, str](ur)) {
+        manifest.dnit(?m, p.s.alloc);
+        ret err[bool, str](unwrap_err[manifest.BuildUnit, str](ur));
+    }
+    val bu: manifest.BuildUnit = unwrap_ok[manifest.BuildUnit, str](ur);
+
+    # honest collision guard over every artifact for the selected target/profile.
+    val pn_opt: Option[str] = intern.lookup(?p.s.interner, bu.profile_name);
+    if (is_some[str](pn_opt)) {
+        val cr: Result[bool, str] = manifest.check_collisions(p.s.alloc, ?p.s.interner, ?m, bu.target, unwrap[str](pn_opt));
+        if (is_err[bool, str](cr)) {
+            manifest.dnit(?m, p.s.alloc);
+            ret err[bool, str](unwrap_err[bool, str](cr));
+        }
+    }
+
+    if (bu.warned) { emit_native_warning(p, bu.target_name); }
+
+    # synthesize the single target entry the downstream driver selects on.
+    val ter: Result[*TargetEntry, str] = allocate[TargetEntry](p.s.alloc, 1::usize);
+    if (is_err[*TargetEntry, str](ter)) { manifest.dnit(?m, p.s.alloc); ret err[bool, str](unwrap_err[*TargetEntry, str](ter)); }
+    val targets: *TargetEntry = unwrap_ok[*TargetEntry, str](ter);
+    var entry: TargetEntry;
+    entry.name       = bu.target_name;
+    entry.os_name    = bu.target.os;
+    entry.isa_name   = bu.target.isa;
+    entry.entrypoint = bu.entry;
+    entry.artifacts  = intern.STR_NIL;
+    entry.binary     = bu.bin_path;
+    entry.mode       = MODE_EXECUTABLE;
+    if (bu.is_lib) { entry.mode = MODE_LIBRARY; }
+    entry.opt        = map_v2_opt(bu.opt);
+    entry.libs       = bu.libs;
+    entry.lib_count  = bu.lib_count;
+    targets[0] = entry;
+
+    p.config.id           = m.id;
+    p.config.dir_src      = m.src;
+    p.config.dir_dep      = m.dep;
+    p.config.out          = m.out_tmpl;
+    p.config.target       = bu.target_name;
+    p.config.targets      = targets;
+    p.config.target_count = 1;
+    p.config.is_v2        = true;
+    p.config.v2_bin       = bu.bin_path;
+    p.config.v2_obj_root  = bu.obj_root;
+    p.config.v2_ir_root   = bu.ir_root;
+    p.config.v2_asm_root  = bu.asm_root;
+    p.config.v2_emit_ir   = bu.emit_ir;
+    p.config.v2_emit_asm  = bu.emit_asm;
+    p.target_entry        = ?p.config.targets[0];
+
+    val dr: Result[bool, str] = resolve_v2_deps(p, ?m, project_root);
+    if (is_err[bool, str](dr)) { manifest.dnit(?m, p.s.alloc); ret dr; }
+
     manifest.dnit(?m, p.s.alloc);
-    ret err[bool, str]("mach.toml: v2 manifest support is not yet wired (#1218)");
+    ret ok[bool, str](true);
+}
+
+# map_v2_opt: map a manifest profile opt level to the driver's TargetOpt.
+fun map_v2_opt(o: manifest.MOpt) TargetOpt {
+    if (o == manifest.MOPT_RELEASE) { ret TARGET_OPT_RELEASE; }
+    if (o == manifest.MOPT_DEBUG)   { ret TARGET_OPT_DEBUG; }
+    ret TARGET_OPT_DEFAULT;
+}
+
+# emit_native_warning: write the unmissable `native` no-match warning to stderr,
+# naming the host tuple and the target being built instead.
+fun emit_native_warning(p: *Project, target_name: intern.StrId) {
+    val tuple: str = manifest.host_tuple(p.s.alloc);
+    val name_opt: Option[str] = intern.lookup(?p.s.interner, target_name);
+    var name: str = "?";
+    if (is_some[str](name_opt)) { name = unwrap[str](name_opt); }
+    emit_stderr("warning: no declared target matches the host (");
+    emit_stderr(tuple);
+    emit_stderr("); building '");
+    emit_stderr(name);
+    emit_stderr("'\n");
+}
+
+# emit_stderr: write a string to stderr, computing its length.
+fun emit_stderr(s: str) {
+    sysos.write(sysos.STDERR_FD, s::*u8, str_len(s));
+}
+
+# resolve_v2_deps: resolve each `[deps.*]` into a DepEntry by vendor layout,
+# reading the dependency's own mach.toml — identical to the old reader's dep
+# resolution, just driven off the v2 dependency list.
+fun resolve_v2_deps(p: *Project, m: *manifest.Manifest, project_root: str) Result[bool, str] {
+    if (m.dep_count == 0) {
+        p.config.deps      = nil;
+        p.config.dep_count = 0;
+        ret ok[bool, str](true);
+    }
+    val r: Result[*DepEntry, str] = allocate[DepEntry](p.s.alloc, m.dep_count::usize);
+    if (is_err[*DepEntry, str](r)) { ret err[bool, str](unwrap_err[*DepEntry, str](r)); }
+    p.config.deps      = unwrap_ok[*DepEntry, str](r);
+    p.config.dep_count = m.dep_count;
+
+    val dir_dep_opt: Option[str] = intern.lookup(?p.s.interner, p.config.dir_dep);
+    if (is_none[str](dir_dep_opt)) { ret err[bool, str]("dep dir StrId not interned"); }
+    val dir_dep: str = unwrap[str](dir_dep_opt);
+
+    var i: u32 = 0;
+    for (i < m.dep_count) {
+        val alias_opt: Option[str] = intern.lookup(?p.s.interner, m.deps[i].name);
+        if (is_none[str](alias_opt)) { ret err[bool, str]("dep alias StrId not interned"); }
+        val rd: Result[DepEntry, str] = resolve_dep(p.s, unwrap[str](alias_opt), project_root, dir_dep);
+        if (is_err[DepEntry, str](rd)) { ret err[bool, str](unwrap_err[DepEntry, str](rd)); }
+        p.config.deps[i] = unwrap_ok[DepEntry, str](rd);
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
 }
 
 fun parse_targets_table(p: *Project, t: *toml.Table) Result[bool, str] {
@@ -827,7 +1002,12 @@ fun resolve_dep(s: *sess.Session, alias: str, project_root: str, dir_dep: str) R
     }
     entry.project_id = unwrap_ok[intern.StrId, str](rp);
 
-    val rds: Result[intern.StrId, str] = intern_or(?s.interner, toml.get_str(?t, "project.dir_src"), "src");
+    # the dep's source dir: `dir_src` (old) or `src` (v2), defaulting to "src".
+    # reading both lets a consumer depend on a dep in either format during the
+    # transition (#1218); resolution is purely by vendor layout otherwise.
+    var dep_src_key: str = toml.get_str(?t, "project.dir_src");
+    if (str_empty(dep_src_key)) { dep_src_key = toml.get_str(?t, "project.src"); }
+    val rds: Result[intern.StrId, str] = intern_or(?s.interner, dep_src_key, "src");
     if (is_err[intern.StrId, str](rds)) {
         str_free(s.alloc, dep_dir);
         ret err[DepEntry, str](unwrap_err[intern.StrId, str](rds));

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -18,13 +18,11 @@ use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
-use std.types.char.char;
 
 use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_empty;
 use std.types.string.str_equals;
-use std.text.string.str_dup;
 use std.text.string.str_free;
 
 use std.types.option.Option;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1,0 +1,1774 @@
+# mach.lang.manifest: the v2 `mach.toml` schema model, parser, validator,
+# template engine, and build-unit resolver.
+#
+# this module is the single owner of the v2 manifest format (see #1218). it
+# reads an already-parsed `std.data.toml` table into a `Manifest` value,
+# validating loudly (unknown keys, missing required keys, reserved names,
+# `\` in paths), then resolves a build selection — a target (with `native`
+# host resolution), a profile, and one artifact — into a `BuildUnit` whose
+# output paths come only from the declared `out`/`obj`/`ir`/`asm` templates
+# expanded over `{target} {profile} {name} {ext}`. nothing is inferred: every
+# value resolves from a stanza present in the file.
+#
+# the old plural `[targets.*]` format is still parsed by `mach.lang.driver`
+# directly; `is_v2` distinguishes the two so a transitional manifest routes to
+# the right reader. the old reader is removed in the final phase of #1218.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.char.char;
+
+use std.types.string.str;
+use std.types.string.str_len;
+use std.types.string.str_empty;
+use std.types.string.str_equals;
+use std.text.string.str_dup;
+use std.text.string.str_free;
+
+use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_none;
+use std.types.option.is_some;
+use std.types.option.unwrap;
+
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_ok;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
+
+use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.deallocate;
+use std.allocator.reallocate;
+
+use page:  std.allocator.page;
+use arena: std.allocator.arena;
+
+use toml: std.data.toml;
+
+use intern: mach.lang.intern;
+use os:     mach.lang.target.os;
+use isa:    mach.lang.target.isa;
+use tgt:    mach.lang.target;
+
+# MOpt: a profile's declared optimization level. mirrors the driver's
+# TargetOpt values so the driver maps one to the other by identity.
+pub def MOpt: u8;
+
+# MOPT_DEFAULT: no `opt` key — the build's own default (debug).
+pub val MOPT_DEFAULT: MOpt = 0;
+# MOPT_DEBUG: `opt = "O0"` / `"debug"`.
+pub val MOPT_DEBUG:   MOpt = 1;
+# MOPT_RELEASE: `opt = "O1"` / `"O2"` / `"release"`.
+pub val MOPT_RELEASE: MOpt = 2;
+
+# LibKind: a `[lib.*]` artifact's link kind.
+pub def LibKind: u8;
+
+# LIBKIND_STATIC: `kind = "static"` — the default; objects are the deliverable.
+pub val LIBKIND_STATIC: LibKind = 0;
+# LIBKIND_SHARED: `kind = "shared"` — a shared library.
+pub val LIBKIND_SHARED: LibKind = 1;
+
+# TargetDef: one `[target.<name>]` platform stanza. tuples are fully spelled;
+# nothing is inferred. `ext` defaults to the empty string. `libs`/`defines`
+# are the per-target overlay applied over an artifact's own fields.
+# ---
+# name:         interned target selector (e.g. "linux")
+# isa:          interned instruction-set architecture (required)
+# os:           interned operating system (required)
+# abi:          interned ABI (required)
+# ext:          interned artifact extension, "" when omitted
+# libs:         interned platform link overlay; nil when none
+# lib_count:    number of entries in libs
+# defines:      interned per-target comptime defines (#1191); nil when none
+# define_count: number of entries in defines
+pub rec TargetDef {
+    name:         intern.StrId;
+    isa:          intern.StrId;
+    os:           intern.StrId;
+    abi:          intern.StrId;
+    ext:          intern.StrId;
+    libs:         *intern.StrId;
+    lib_count:    u32;
+    defines:      *intern.StrId;
+    define_count: u32;
+}
+
+# CellDef: one `[bin.<a>.target.<t>]` per-cell exception refining an artifact
+# for a single target. an unset override (STR_NIL) inherits the artifact field.
+# ---
+# target:    interned name of the target this cell refines
+# entry:     interned entry-file override, STR_NIL to inherit
+# out:       interned `out` template override, STR_NIL to inherit
+# libs:      interned per-cell link inputs appended to the merge; nil when none
+# lib_count: number of entries in libs
+pub rec CellDef {
+    target:    intern.StrId;
+    entry:     intern.StrId;
+    out:       intern.StrId;
+    libs:      *intern.StrId;
+    lib_count: u32;
+}
+
+# ArtifactDef: one `[bin.<name>]` or `[lib.<name>]` artifact. every artifact is
+# declared explicitly and named by its table key.
+# ---
+# name:         interned artifact name
+# is_lib:       true for `[lib.*]`, false for `[bin.*]`
+# entry:        interned entry-source path, relative to the project src dir (required)
+# kind:         link kind for a lib (LIBKIND_STATIC default); ignored for a bin
+# out:          interned per-artifact `out` template override, STR_NIL to inherit
+# libs:         interned per-artifact link inputs; nil when none
+# lib_count:    number of entries in libs
+# defines:      interned per-artifact defines (#1191); nil when none
+# define_count: number of entries in defines
+# cells:        per-cell `[*.target.*]` exceptions; nil when none
+# cell_count:   number of entries in cells
+pub rec ArtifactDef {
+    name:         intern.StrId;
+    is_lib:       bool;
+    entry:        intern.StrId;
+    kind:         LibKind;
+    out:          intern.StrId;
+    libs:         *intern.StrId;
+    lib_count:    u32;
+    defines:      *intern.StrId;
+    define_count: u32;
+    cells:        *CellDef;
+    cell_count:   u32;
+}
+
+# ProfileDef: one `[profile.<name>]` build variant. emission toggles live here
+# because emission is a build-variant concern (amendment 3).
+# ---
+# name:     interned profile name
+# opt:      declared optimization level
+# emit_ir:  default `--emit-ir` for this profile
+# emit_asm: default `--emit-asm` for this profile
+pub rec ProfileDef {
+    name:     intern.StrId;
+    opt:      MOpt;
+    emit_ir:  bool;
+    emit_asm: bool;
+}
+
+# DepDef: one `[deps.<name>]` dependency. exactly one source key — `git` or
+# `path` — plus an optional `ref` for git. registry `version =` is reserved
+# and rejected at parse time.
+# ---
+# name: interned dependency alias
+# git:  interned git url, STR_NIL when path-sourced
+# path: interned local path, STR_NIL when git-sourced
+# ref:  interned git ref, STR_NIL when omitted
+pub rec DepDef {
+    name: intern.StrId;
+    git:  intern.StrId;
+    path: intern.StrId;
+    ref:  intern.StrId;
+}
+
+# Manifest: a fully parsed and validated v2 manifest.
+# ---
+# id:             interned `[project].id` (required)
+# version:        interned `[project].version` (required)
+# name:           interned `[project].name` metadata, STR_NIL when omitted
+# description:    interned `[project].description` metadata, STR_NIL when omitted
+# license:        interned `[project].license` metadata, STR_NIL when omitted
+# src:            interned source dir (default "src")
+# dep:            interned vendored-dependency dir (default "dep")
+# default_target: interned `[project].target` default selector (default "native")
+# out_tmpl:       interned artifact path template
+# obj_tmpl:       interned intermediate-object dir template
+# ir_tmpl:        interned IR-dump dir template
+# asm_tmpl:       interned ASM-dump dir template
+# targets:        declared `[target.*]` platforms
+# target_count:   number of targets
+# artifacts:      declared `[bin.*]`/`[lib.*]` artifacts
+# artifact_count: number of artifacts
+# profiles:       declared `[profile.*]` variants
+# profile_count:  number of profiles
+# deps:           declared `[deps.*]` dependencies
+# dep_count:      number of deps
+pub rec Manifest {
+    id:             intern.StrId;
+    version:        intern.StrId;
+    name:           intern.StrId;
+    description:    intern.StrId;
+    license:        intern.StrId;
+    src:            intern.StrId;
+    dep:            intern.StrId;
+    default_target: intern.StrId;
+    out_tmpl:       intern.StrId;
+    obj_tmpl:       intern.StrId;
+    ir_tmpl:        intern.StrId;
+    asm_tmpl:       intern.StrId;
+    targets:        *TargetDef;
+    target_count:   u32;
+    artifacts:      *ArtifactDef;
+    artifact_count: u32;
+    profiles:       *ProfileDef;
+    profile_count:  u32;
+    deps:           *DepDef;
+    dep_count:      u32;
+}
+
+# DEFAULT_OUT: the init-written artifact path template.
+pub val DEFAULT_OUT: str = "out/{target}/{profile}/bin/{name}{ext}";
+# DEFAULT_OBJ: the init-written intermediate-object dir template.
+pub val DEFAULT_OBJ: str = "out/{target}/{profile}/obj";
+# DEFAULT_IR: the init-written IR-dump dir template.
+pub val DEFAULT_IR:  str = "out/{target}/{profile}/ir";
+# DEFAULT_ASM: the init-written ASM-dump dir template.
+pub val DEFAULT_ASM: str = "out/{target}/{profile}/asm";
+
+# is_v2: whether a parsed manifest table is in the v2 format. the old format is
+# distinguished solely by its plural `[targets.*]` table; its absence routes a
+# manifest through the v2 reader. (transitional, removed with the old reader in
+# the final phase of #1218.)
+pub fun is_v2(t: *toml.Table) bool {
+    ret toml.get_table(t, "targets") == nil;
+}
+
+# cc: concatenate two strings into a freshly-allocated owned string. used to
+# build span-free diagnostic messages with dynamic names. on allocation failure
+# the second part is returned as a best-effort fragment (the build is already
+# failing on OOM).
+fun cc(alloc: *Allocator, a: str, b: str) str {
+    val la: usize = str_len(a);
+    val lb: usize = str_len(b);
+    val r: Result[*u8, str] = allocate[u8](alloc, la + lb + 1);
+    if (is_err[*u8, str](r)) { ret b; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    var i: usize = 0;
+    for (i < la) { buf[k] = a[i]; k = k + 1; i = i + 1; }
+    i = 0;
+    for (i < lb) { buf[k] = b[i]; k = k + 1; i = i + 1; }
+    buf[k] = 0;
+    ret buf::str;
+}
+
+# cc3: concatenate three strings.
+fun cc3(alloc: *Allocator, a: str, b: str, c: str) str {
+    ret cc(alloc, cc(alloc, a, b), c);
+}
+
+# cc5: concatenate five strings.
+fun cc5(alloc: *Allocator, a: str, b: str, c: str, d: str, e: str) str {
+    ret cc(alloc, cc3(alloc, a, b, c), cc(alloc, d, e));
+}
+
+# host_sep: the host path separator, resolved at comptime. manifest paths are
+# `/`-canonical and normalized to this at the filesystem boundary (amendment 2).
+fun host_sep() u8 {
+    $if ($mach.target.os == $mach.os.windows) { ret '\\'; }
+    $or                                        { ret '/'; }
+}
+
+# os_id_for: map a target os name to its canonical id.
+fun os_id_for(name: str) u32 {
+    if (str_equals(name, "linux"))   { ret os.OS_LINUX; }
+    if (str_equals(name, "darwin"))  { ret os.OS_DARWIN; }
+    if (str_equals(name, "windows")) { ret os.OS_WINDOWS; }
+    ret os.OS_UNKNOWN;
+}
+
+# arch_id_for: map a target isa name to its canonical id.
+fun arch_id_for(name: str) u32 {
+    if (str_equals(name, "x86_64"))  { ret isa.ARCH_X86_64; }
+    if (str_equals(name, "aarch64")) { ret isa.ARCH_AARCH64; }
+    ret isa.ARCH_UNKNOWN;
+}
+
+# host_isa_name: the build host's isa name.
+fun host_isa_name() str {
+    val a: u32 = tgt.host_arch_id();
+    if (a == isa.ARCH_X86_64)  { ret "x86_64"; }
+    if (a == isa.ARCH_AARCH64) { ret "aarch64"; }
+    ret "unknown";
+}
+
+# host_os_name: the build host's os name.
+fun host_os_name() str {
+    val o: u32 = tgt.host_os_id();
+    if (o == os.OS_LINUX)   { ret "linux"; }
+    if (o == os.OS_DARWIN)  { ret "darwin"; }
+    if (o == os.OS_WINDOWS) { ret "windows"; }
+    ret "unknown";
+}
+
+# host_tuple: the build host's `<isa>-<os>` tuple string, for the no-match
+# native warning. owned by `alloc`.
+pub fun host_tuple(alloc: *Allocator) str {
+    ret cc3(alloc, host_isa_name(), "-", host_os_name());
+}
+
+# has_backslash: true when a path/template contains a literal `\`. manifest
+# paths are `/`-separated; a `\` is rejected so the same manifest is portable.
+fun has_backslash(s: str) bool {
+    if (str_empty(s)) { ret false; }
+    val n: usize = str_len(s);
+    var i: usize = 0;
+    for (i < n) {
+        if (s[i] == '\\') { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# intern_or: intern `text`, falling back to `default` when it is empty.
+fun intern_or(i: *intern.Interner, text: str, default: str) Result[intern.StrId, str] {
+    var t: str = text;
+    if (str_empty(t)) { t = default; }
+    ret intern.intern(i, t);
+}
+
+# intern_opt: intern `text`, or STR_NIL when it is empty (an absent optional).
+fun intern_opt(i: *intern.Interner, text: str) Result[intern.StrId, str] {
+    if (str_empty(text)) { ret ok[intern.StrId, str](intern.STR_NIL); }
+    ret intern.intern(i, text);
+}
+
+# StrArr: an interned string array carved from a TOML array of strings.
+rec StrArr {
+    items: *intern.StrId;
+    count: u32;
+}
+
+# parse_str_array: read a TOML string array into an interned StrArr. a nil array
+# yields an empty StrArr. a non-string element fails with `elem_err`.
+fun parse_str_array(alloc: *Allocator, i: *intern.Interner, arr: *toml.Array, elem_err: str) Result[StrArr, str] {
+    var out: StrArr;
+    out.items = nil;
+    out.count = 0;
+    if (arr == nil) { ret ok[StrArr, str](out); }
+
+    val n: usize = toml.array_len(arr);
+    if (n == 0) { ret ok[StrArr, str](out); }
+
+    val r: Result[*intern.StrId, str] = allocate[intern.StrId](alloc, n);
+    if (is_err[*intern.StrId, str](r)) { ret err[StrArr, str](unwrap_err[*intern.StrId, str](r)); }
+    out.items = unwrap_ok[*intern.StrId, str](r);
+    out.count = n::u32;
+
+    var k: usize = 0;
+    for (k < n) {
+        val v: *toml.Value = toml.array_get(arr, k);
+        if (v == nil || v.tag != toml.TYPE_STRING) {
+            deallocate[intern.StrId](alloc, out.items, n);
+            ret err[StrArr, str](elem_err);
+        }
+        val iv: Result[intern.StrId, str] = intern.intern(i, v.data.string);
+        if (is_err[intern.StrId, str](iv)) {
+            deallocate[intern.StrId](alloc, out.items, n);
+            ret err[StrArr, str](unwrap_err[intern.StrId, str](iv));
+        }
+        out.items[k] = unwrap_ok[intern.StrId, str](iv);
+        k = k + 1;
+    }
+    ret ok[StrArr, str](out);
+}
+
+# parse_opt_level: map a profile/target `opt` string to an MOpt. an empty value
+# is MOPT_DEFAULT; any unrecognized value is a manifest error.
+fun parse_opt_level(alloc: *Allocator, label: str, text: str) Result[MOpt, str] {
+    if (str_empty(text)) { ret ok[MOpt, str](MOPT_DEFAULT); }
+    if (str_equals(text, "O0") || str_equals(text, "debug")) { ret ok[MOpt, str](MOPT_DEBUG); }
+    if (str_equals(text, "O1") || str_equals(text, "O2") || str_equals(text, "release")) { ret ok[MOpt, str](MOPT_RELEASE); }
+    ret err[MOpt, str](cc(alloc, label, ".opt must be one of \"O0\"/\"debug\", \"O1\"/\"O2\"/\"release\""));
+}
+
+# unknown_key_msg: the "unknown key" diagnostic for `key` under `label`.
+fun unknown_key_msg(alloc: *Allocator, key: str, label: str) str {
+    ret cc(alloc, cc3(alloc, "mach.toml: unknown key '", key, "' in "), label);
+}
+
+# TK_*: table kinds for key-allowlist validation.
+val TK_PROJECT: u8 = 0;
+val TK_TARGET:  u8 = 1;
+val TK_BIN:     u8 = 2;
+val TK_LIB:     u8 = 3;
+val TK_PROFILE: u8 = 4;
+val TK_DEP:     u8 = 5;
+val TK_CELL:    u8 = 6;
+
+# key_known: whether `k` is an allowed key for the given table kind.
+fun key_known(kind: u8, k: str) bool {
+    if (kind == TK_PROJECT) {
+        ret str_equals(k, "id") || str_equals(k, "version") || str_equals(k, "name")
+            || str_equals(k, "description") || str_equals(k, "license") || str_equals(k, "authors")
+            || str_equals(k, "src") || str_equals(k, "dep") || str_equals(k, "target")
+            || str_equals(k, "out") || str_equals(k, "obj") || str_equals(k, "ir") || str_equals(k, "asm");
+    }
+    if (kind == TK_TARGET) {
+        ret str_equals(k, "isa") || str_equals(k, "os") || str_equals(k, "abi")
+            || str_equals(k, "ext") || str_equals(k, "libs") || str_equals(k, "defines");
+    }
+    if (kind == TK_BIN) {
+        ret str_equals(k, "entry") || str_equals(k, "out") || str_equals(k, "libs")
+            || str_equals(k, "defines") || str_equals(k, "target");
+    }
+    if (kind == TK_LIB) {
+        ret str_equals(k, "entry") || str_equals(k, "kind") || str_equals(k, "out")
+            || str_equals(k, "libs") || str_equals(k, "defines") || str_equals(k, "target");
+    }
+    if (kind == TK_PROFILE) {
+        ret str_equals(k, "opt") || str_equals(k, "emit_ir") || str_equals(k, "emit_asm");
+    }
+    if (kind == TK_DEP) {
+        ret str_equals(k, "git") || str_equals(k, "path") || str_equals(k, "ref");
+    }
+    if (kind == TK_CELL) {
+        ret str_equals(k, "entry") || str_equals(k, "out") || str_equals(k, "libs") || str_equals(k, "defines");
+    }
+    ret false;
+}
+
+# check_keys: reject the first unknown key in `tab` for the given table kind.
+fun check_keys(alloc: *Allocator, tab: *toml.Table, label: str, kind: u8) Result[bool, str] {
+    val n: usize = toml.table_len(tab);
+    var i: usize = 0;
+    for (i < n) {
+        val k: str = toml.table_key(tab, i);
+        if (!key_known(kind, k)) { ret err[bool, str](unknown_key_msg(alloc, k, label)); }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# check_path: reject a `\` in a path/template field, naming the offending value.
+fun check_path(alloc: *Allocator, value: str, field: str) Result[bool, str] {
+    if (has_backslash(value)) {
+        ret err[bool, str](cc3(alloc, "mach.toml: ", field, " contains a '\\'; manifest paths use '/'"));
+    }
+    ret ok[bool, str](true);
+}
+
+# parse: read a v2 manifest from an already-parsed TOML table. validates loudly
+# and returns a fully populated Manifest, or the first diagnostic.
+pub fun parse(alloc: *Allocator, i: *intern.Interner, t: *toml.Table) Result[Manifest, str] {
+    var m: Manifest;
+    m.targets        = nil;
+    m.target_count   = 0;
+    m.artifacts      = nil;
+    m.artifact_count = 0;
+    m.profiles       = nil;
+    m.profile_count  = 0;
+    m.deps           = nil;
+    m.dep_count      = 0;
+
+    val pr: *toml.Table = toml.get_table(t, "project");
+    if (pr == nil) { ret err[Manifest, str]("mach.toml: missing [project] table"); }
+    val pk: Result[bool, str] = check_keys(alloc, pr, "[project]", TK_PROJECT);
+    if (is_err[bool, str](pk)) { ret err[Manifest, str](unwrap_err[bool, str](pk)); }
+
+    val id_str: str = toml.get_str(pr, "id");
+    if (str_empty(id_str)) { ret err[Manifest, str]("mach.toml: [project] is missing required key 'id'"); }
+    val ver_str: str = toml.get_str(pr, "version");
+    if (str_empty(ver_str)) { ret err[Manifest, str]("mach.toml: [project] is missing required key 'version'"); }
+
+    val src_str: str = first_nonempty(toml.get_str(pr, "src"), "src");
+    val dep_str: str = first_nonempty(toml.get_str(pr, "dep"), "dep");
+    val out_str: str = first_nonempty(toml.get_str(pr, "out"), DEFAULT_OUT);
+    val obj_str: str = first_nonempty(toml.get_str(pr, "obj"), DEFAULT_OBJ);
+    val ir_str:  str = first_nonempty(toml.get_str(pr, "ir"),  DEFAULT_IR);
+    val asm_str: str = first_nonempty(toml.get_str(pr, "asm"), DEFAULT_ASM);
+
+    val cps: Result[bool, str] = check_path(alloc, src_str, "[project].src");
+    if (is_err[bool, str](cps)) { ret err[Manifest, str](unwrap_err[bool, str](cps)); }
+    val cpd: Result[bool, str] = check_path(alloc, dep_str, "[project].dep");
+    if (is_err[bool, str](cpd)) { ret err[Manifest, str](unwrap_err[bool, str](cpd)); }
+    val cpo: Result[bool, str] = check_path(alloc, out_str, "[project].out");
+    if (is_err[bool, str](cpo)) { ret err[Manifest, str](unwrap_err[bool, str](cpo)); }
+    val cpj: Result[bool, str] = check_path(alloc, obj_str, "[project].obj");
+    if (is_err[bool, str](cpj)) { ret err[Manifest, str](unwrap_err[bool, str](cpj)); }
+    val cpi: Result[bool, str] = check_path(alloc, ir_str, "[project].ir");
+    if (is_err[bool, str](cpi)) { ret err[Manifest, str](unwrap_err[bool, str](cpi)); }
+    val cpa: Result[bool, str] = check_path(alloc, asm_str, "[project].asm");
+    if (is_err[bool, str](cpa)) { ret err[Manifest, str](unwrap_err[bool, str](cpa)); }
+
+    val rid: Result[intern.StrId, str] = intern.intern(i, id_str);
+    if (is_err[intern.StrId, str](rid)) { ret err[Manifest, str](unwrap_err[intern.StrId, str](rid)); }
+    m.id = unwrap_ok[intern.StrId, str](rid);
+    val rver: Result[intern.StrId, str] = intern.intern(i, ver_str);
+    if (is_err[intern.StrId, str](rver)) { ret err[Manifest, str](unwrap_err[intern.StrId, str](rver)); }
+    m.version = unwrap_ok[intern.StrId, str](rver);
+
+    val rnm: Result[intern.StrId, str] = intern_opt(i, toml.get_str(pr, "name"));
+    if (is_err[intern.StrId, str](rnm)) { ret err[Manifest, str](unwrap_err[intern.StrId, str](rnm)); }
+    m.name = unwrap_ok[intern.StrId, str](rnm);
+    val rds: Result[intern.StrId, str] = intern_opt(i, toml.get_str(pr, "description"));
+    if (is_err[intern.StrId, str](rds)) { ret err[Manifest, str](unwrap_err[intern.StrId, str](rds)); }
+    m.description = unwrap_ok[intern.StrId, str](rds);
+    val rlc: Result[intern.StrId, str] = intern_opt(i, toml.get_str(pr, "license"));
+    if (is_err[intern.StrId, str](rlc)) { ret err[Manifest, str](unwrap_err[intern.StrId, str](rlc)); }
+    m.license = unwrap_ok[intern.StrId, str](rlc);
+
+    m.src            = intern_unwrap(i, src_str);
+    m.dep            = intern_unwrap(i, dep_str);
+    m.out_tmpl       = intern_unwrap(i, out_str);
+    m.obj_tmpl       = intern_unwrap(i, obj_str);
+    m.ir_tmpl        = intern_unwrap(i, ir_str);
+    m.asm_tmpl       = intern_unwrap(i, asm_str);
+    m.default_target = intern_unwrap(i, first_nonempty(toml.get_str(pr, "target"), "native"));
+
+    val tr: Result[bool, str] = parse_targets(alloc, i, t, ?m);
+    if (is_err[bool, str](tr)) { dnit(?m, alloc); ret err[Manifest, str](unwrap_err[bool, str](tr)); }
+
+    val ar: Result[bool, str] = parse_artifacts(alloc, i, t, ?m);
+    if (is_err[bool, str](ar)) { dnit(?m, alloc); ret err[Manifest, str](unwrap_err[bool, str](ar)); }
+
+    val plr: Result[bool, str] = parse_profiles(alloc, i, t, ?m);
+    if (is_err[bool, str](plr)) { dnit(?m, alloc); ret err[Manifest, str](unwrap_err[bool, str](plr)); }
+
+    val dr: Result[bool, str] = parse_deps(alloc, i, t, ?m);
+    if (is_err[bool, str](dr)) { dnit(?m, alloc); ret err[Manifest, str](unwrap_err[bool, str](dr)); }
+
+    ret ok[Manifest, str](m);
+}
+
+# first_nonempty: `a` when it is non-empty, else `b`.
+fun first_nonempty(a: str, b: str) str {
+    if (str_empty(a)) { ret b; }
+    ret a;
+}
+
+# intern_unwrap: intern `text`, returning STR_NIL on failure. used for values
+# already validated non-empty (project dirs/templates), so a failure here is an
+# allocator fault surfaced later as a lookup miss rather than swallowed silently.
+fun intern_unwrap(i: *intern.Interner, text: str) intern.StrId {
+    val r: Result[intern.StrId, str] = intern.intern(i, text);
+    if (is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
+    ret unwrap_ok[intern.StrId, str](r);
+}
+
+# parse_targets: read every `[target.<name>]` stanza. declaring `[target.native]`
+# is a hard error — `native` is the reserved host-resolution selector.
+fun parse_targets(alloc: *Allocator, i: *intern.Interner, t: *toml.Table, m: *Manifest) Result[bool, str] {
+    val tab: *toml.Table = toml.get_table(t, "target");
+    if (tab == nil) { ret ok[bool, str](true); }
+    val n: usize = toml.table_len(tab);
+    if (n == 0) { ret ok[bool, str](true); }
+
+    val r: Result[*TargetDef, str] = allocate[TargetDef](alloc, n);
+    if (is_err[*TargetDef, str](r)) { ret err[bool, str](unwrap_err[*TargetDef, str](r)); }
+    m.targets      = unwrap_ok[*TargetDef, str](r);
+    m.target_count = n::u32;
+
+    var k: usize = 0;
+    for (k < n) {
+        val name: str = toml.table_key(tab, k);
+        if (str_equals(name, "native")) {
+            ret err[bool, str]("mach.toml: [target.native] is reserved; 'native' resolves to a declared target");
+        }
+        val v: *toml.Value = toml.table_value(tab, k);
+        if (v == nil || v.tag != toml.TYPE_TABLE) {
+            ret err[bool, str](cc3(alloc, "mach.toml: [target.", name, "] must be a table"));
+        }
+        val sub: *toml.Table = ?v.data.table;
+        val label: str = cc3(alloc, "[target.", name, "]");
+        val ck: Result[bool, str] = check_keys(alloc, sub, label, TK_TARGET);
+        if (is_err[bool, str](ck)) { ret ck; }
+
+        var d: TargetDef;
+        d.libs         = nil;
+        d.lib_count    = 0;
+        d.defines      = nil;
+        d.define_count = 0;
+        d.name = intern_unwrap(i, name);
+
+        val isa_s: str = toml.get_str(sub, "isa");
+        if (str_empty(isa_s)) { ret err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'isa'")); }
+        val os_s: str = toml.get_str(sub, "os");
+        if (str_empty(os_s)) { ret err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'os'")); }
+        val abi_s: str = toml.get_str(sub, "abi");
+        if (str_empty(abi_s)) { ret err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'abi'")); }
+        d.isa = intern_unwrap(i, isa_s);
+        d.os  = intern_unwrap(i, os_s);
+        d.abi = intern_unwrap(i, abi_s);
+        d.ext = intern_unwrap(i, first_nonempty(toml.get_str(sub, "ext"), ""));
+
+        val lr: Result[StrArr, str] = parse_str_array(alloc, i, toml.get_array(sub, "libs"),
+            cc3(alloc, "mach.toml: ", label, ".libs must be an array of strings"));
+        if (is_err[StrArr, str](lr)) { ret err[bool, str](unwrap_err[StrArr, str](lr)); }
+        val la: StrArr = unwrap_ok[StrArr, str](lr);
+        d.libs = la.items; d.lib_count = la.count;
+
+        val dr: Result[StrArr, str] = parse_str_array(alloc, i, toml.get_array(sub, "defines"),
+            cc3(alloc, "mach.toml: ", label, ".defines must be an array of strings"));
+        if (is_err[StrArr, str](dr)) { ret err[bool, str](unwrap_err[StrArr, str](dr)); }
+        val da: StrArr = unwrap_ok[StrArr, str](dr);
+        d.defines = da.items; d.define_count = da.count;
+
+        m.targets[k] = d;
+        k = k + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# parse_artifacts: read every `[bin.<name>]` and `[lib.<name>]` stanza into the
+# single artifact array (bins first, then libs, in declaration order).
+fun parse_artifacts(alloc: *Allocator, i: *intern.Interner, t: *toml.Table, m: *Manifest) Result[bool, str] {
+    val bins: *toml.Table = toml.get_table(t, "bin");
+    val libs: *toml.Table = toml.get_table(t, "lib");
+    var bn: usize = 0;
+    var ln: usize = 0;
+    if (bins != nil) { bn = toml.table_len(bins); }
+    if (libs != nil) { ln = toml.table_len(libs); }
+    val total: usize = bn + ln;
+    if (total == 0) { ret ok[bool, str](true); }
+
+    val r: Result[*ArtifactDef, str] = allocate[ArtifactDef](alloc, total);
+    if (is_err[*ArtifactDef, str](r)) { ret err[bool, str](unwrap_err[*ArtifactDef, str](r)); }
+    m.artifacts      = unwrap_ok[*ArtifactDef, str](r);
+    m.artifact_count = total::u32;
+
+    var w: usize = 0;
+    if (bins != nil) {
+        var k: usize = 0;
+        for (k < bn) {
+            val ar: Result[ArtifactDef, str] = parse_one_artifact(alloc, i, bins, k, false);
+            if (is_err[ArtifactDef, str](ar)) { ret err[bool, str](unwrap_err[ArtifactDef, str](ar)); }
+            m.artifacts[w] = unwrap_ok[ArtifactDef, str](ar);
+            w = w + 1; k = k + 1;
+        }
+    }
+    if (libs != nil) {
+        var k: usize = 0;
+        for (k < ln) {
+            val ar: Result[ArtifactDef, str] = parse_one_artifact(alloc, i, libs, k, true);
+            if (is_err[ArtifactDef, str](ar)) { ret err[bool, str](unwrap_err[ArtifactDef, str](ar)); }
+            m.artifacts[w] = unwrap_ok[ArtifactDef, str](ar);
+            w = w + 1; k = k + 1;
+        }
+    }
+    ret ok[bool, str](true);
+}
+
+# parse_one_artifact: read one artifact stanza at index `k` of its `[bin]`/`[lib]`
+# container table.
+fun parse_one_artifact(alloc: *Allocator, i: *intern.Interner, tab: *toml.Table, k: usize, is_lib: bool) Result[ArtifactDef, str] {
+    val name: str = toml.table_key(tab, k);
+    val v: *toml.Value = toml.table_value(tab, k);
+    var kind_tag: str = "bin";
+    if (is_lib) { kind_tag = "lib"; }
+    val label: str = cc5(alloc, "[", kind_tag, ".", name, "]");
+    if (v == nil || v.tag != toml.TYPE_TABLE) {
+        ret err[ArtifactDef, str](cc3(alloc, "mach.toml: ", label, " must be a table"));
+    }
+    val sub: *toml.Table = ?v.data.table;
+
+    var tk: u8 = TK_BIN;
+    if (is_lib) { tk = TK_LIB; }
+    val ck: Result[bool, str] = check_keys(alloc, sub, label, tk);
+    if (is_err[bool, str](ck)) { ret err[ArtifactDef, str](unwrap_err[bool, str](ck)); }
+
+    var a: ArtifactDef;
+    a.libs         = nil;
+    a.lib_count    = 0;
+    a.defines      = nil;
+    a.define_count = 0;
+    a.cells        = nil;
+    a.cell_count   = 0;
+    a.name   = intern_unwrap(i, name);
+    a.is_lib = is_lib;
+    a.kind   = LIBKIND_STATIC;
+
+    val entry_s: str = toml.get_str(sub, "entry");
+    if (str_empty(entry_s)) { ret err[ArtifactDef, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'entry'")); }
+    val cpe: Result[bool, str] = check_path(alloc, entry_s, cc3(alloc, label, ".entry", ""));
+    if (is_err[bool, str](cpe)) { ret err[ArtifactDef, str](unwrap_err[bool, str](cpe)); }
+    a.entry = intern_unwrap(i, entry_s);
+
+    if (is_lib) {
+        val kind_s: str = toml.get_str(sub, "kind");
+        if (!str_empty(kind_s)) {
+            if (str_equals(kind_s, "static"))      { a.kind = LIBKIND_STATIC; }
+            or (str_equals(kind_s, "shared"))      { a.kind = LIBKIND_SHARED; }
+            or { ret err[ArtifactDef, str](cc3(alloc, "mach.toml: ", label, ".kind must be \"static\" or \"shared\"")); }
+        }
+    }
+
+    val out_s: str = toml.get_str(sub, "out");
+    if (!str_empty(out_s)) {
+        val cpo: Result[bool, str] = check_path(alloc, out_s, cc3(alloc, label, ".out", ""));
+        if (is_err[bool, str](cpo)) { ret err[ArtifactDef, str](unwrap_err[bool, str](cpo)); }
+        a.out = intern_unwrap(i, out_s);
+    }
+    or { a.out = intern.STR_NIL; }
+
+    val lr: Result[StrArr, str] = parse_str_array(alloc, i, toml.get_array(sub, "libs"),
+        cc3(alloc, "mach.toml: ", label, ".libs must be an array of strings"));
+    if (is_err[StrArr, str](lr)) { ret err[ArtifactDef, str](unwrap_err[StrArr, str](lr)); }
+    val laa: StrArr = unwrap_ok[StrArr, str](lr);
+    a.libs = laa.items; a.lib_count = laa.count;
+
+    val dr: Result[StrArr, str] = parse_str_array(alloc, i, toml.get_array(sub, "defines"),
+        cc3(alloc, "mach.toml: ", label, ".defines must be an array of strings"));
+    if (is_err[StrArr, str](dr)) { ret err[ArtifactDef, str](unwrap_err[StrArr, str](dr)); }
+    val daa: StrArr = unwrap_ok[StrArr, str](dr);
+    a.defines = daa.items; a.define_count = daa.count;
+
+    val cr: Result[bool, str] = parse_cells(alloc, i, sub, kind_tag, name, ?a);
+    if (is_err[bool, str](cr)) { ret err[ArtifactDef, str](unwrap_err[bool, str](cr)); }
+
+    ret ok[ArtifactDef, str](a);
+}
+
+# parse_cells: read an artifact's `[<kind>.<name>.target.<t>]` per-cell stanzas.
+fun parse_cells(alloc: *Allocator, i: *intern.Interner, sub: *toml.Table, kind_tag: str, art_name: str, a: *ArtifactDef) Result[bool, str] {
+    val ct: *toml.Table = toml.get_table(sub, "target");
+    if (ct == nil) { ret ok[bool, str](true); }
+    val n: usize = toml.table_len(ct);
+    if (n == 0) { ret ok[bool, str](true); }
+
+    val r: Result[*CellDef, str] = allocate[CellDef](alloc, n);
+    if (is_err[*CellDef, str](r)) { ret err[bool, str](unwrap_err[*CellDef, str](r)); }
+    a.cells      = unwrap_ok[*CellDef, str](r);
+    a.cell_count = n::u32;
+
+    var k: usize = 0;
+    for (k < n) {
+        val tname: str = toml.table_key(ct, k);
+        val v: *toml.Value = toml.table_value(ct, k);
+        val label: str = cc5(alloc, cc3(alloc, "[", kind_tag, "."), art_name, ".target.", tname, "]");
+        if (v == nil || v.tag != toml.TYPE_TABLE) {
+            ret err[bool, str](cc3(alloc, "mach.toml: ", label, " must be a table"));
+        }
+        val cs: *toml.Table = ?v.data.table;
+        val ck: Result[bool, str] = check_keys(alloc, cs, label, TK_CELL);
+        if (is_err[bool, str](ck)) { ret ck; }
+
+        var c: CellDef;
+        c.libs      = nil;
+        c.lib_count = 0;
+        c.target = intern_unwrap(i, tname);
+        c.entry  = intern_opt_unwrap(i, toml.get_str(cs, "entry"));
+        c.out    = intern_opt_unwrap(i, toml.get_str(cs, "out"));
+
+        val lr: Result[StrArr, str] = parse_str_array(alloc, i, toml.get_array(cs, "libs"),
+            cc3(alloc, "mach.toml: ", label, ".libs must be an array of strings"));
+        if (is_err[StrArr, str](lr)) { ret err[bool, str](unwrap_err[StrArr, str](lr)); }
+        val laa: StrArr = unwrap_ok[StrArr, str](lr);
+        c.libs = laa.items; c.lib_count = laa.count;
+
+        a.cells[k] = c;
+        k = k + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# intern_opt_unwrap: intern an optional value, STR_NIL when empty or on failure.
+fun intern_opt_unwrap(i: *intern.Interner, text: str) intern.StrId {
+    if (str_empty(text)) { ret intern.STR_NIL; }
+    ret intern_unwrap(i, text);
+}
+
+# parse_profiles: read every `[profile.<name>]` build variant.
+fun parse_profiles(alloc: *Allocator, i: *intern.Interner, t: *toml.Table, m: *Manifest) Result[bool, str] {
+    val tab: *toml.Table = toml.get_table(t, "profile");
+    if (tab == nil) { ret ok[bool, str](true); }
+    val n: usize = toml.table_len(tab);
+    if (n == 0) { ret ok[bool, str](true); }
+
+    val r: Result[*ProfileDef, str] = allocate[ProfileDef](alloc, n);
+    if (is_err[*ProfileDef, str](r)) { ret err[bool, str](unwrap_err[*ProfileDef, str](r)); }
+    m.profiles      = unwrap_ok[*ProfileDef, str](r);
+    m.profile_count = n::u32;
+
+    var k: usize = 0;
+    for (k < n) {
+        val name: str = toml.table_key(tab, k);
+        val v: *toml.Value = toml.table_value(tab, k);
+        val label: str = cc3(alloc, "[profile.", name, "]");
+        if (v == nil || v.tag != toml.TYPE_TABLE) {
+            ret err[bool, str](cc3(alloc, "mach.toml: ", label, " must be a table"));
+        }
+        val sub: *toml.Table = ?v.data.table;
+        val ck: Result[bool, str] = check_keys(alloc, sub, label, TK_PROFILE);
+        if (is_err[bool, str](ck)) { ret ck; }
+
+        var pf: ProfileDef;
+        pf.name = intern_unwrap(i, name);
+        val opr: Result[MOpt, str] = parse_opt_level(alloc, cc3(alloc, "mach.toml: ", label, ""), toml.get_str(sub, "opt"));
+        if (is_err[MOpt, str](opr)) { ret err[bool, str](unwrap_err[MOpt, str](opr)); }
+        pf.opt = unwrap_ok[MOpt, str](opr);
+        pf.emit_ir  = bool_or(toml.get_bool(sub, "emit_ir"), false);
+        pf.emit_asm = bool_or(toml.get_bool(sub, "emit_asm"), false);
+
+        m.profiles[k] = pf;
+        k = k + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# bool_or: the boolean value, or `default` when absent/mistyped.
+fun bool_or(o: Option[bool], default: bool) bool {
+    if (is_some[bool](o)) { ret unwrap[bool](o); }
+    ret default;
+}
+
+# parse_deps: read every `[deps.<name>]`. exactly one of `git`/`path` is
+# required; a registry-style `version =` is reserved and rejected.
+fun parse_deps(alloc: *Allocator, i: *intern.Interner, t: *toml.Table, m: *Manifest) Result[bool, str] {
+    val tab: *toml.Table = toml.get_table(t, "deps");
+    if (tab == nil) { ret ok[bool, str](true); }
+    val n: usize = toml.table_len(tab);
+    if (n == 0) { ret ok[bool, str](true); }
+
+    val r: Result[*DepDef, str] = allocate[DepDef](alloc, n);
+    if (is_err[*DepDef, str](r)) { ret err[bool, str](unwrap_err[*DepDef, str](r)); }
+    m.deps      = unwrap_ok[*DepDef, str](r);
+    m.dep_count = n::u32;
+
+    var k: usize = 0;
+    for (k < n) {
+        val name: str = toml.table_key(tab, k);
+        val v: *toml.Value = toml.table_value(tab, k);
+        val label: str = cc3(alloc, "[deps.", name, "]");
+        if (v == nil || v.tag != toml.TYPE_TABLE) {
+            ret err[bool, str](cc3(alloc, "mach.toml: ", label, " must be a table"));
+        }
+        val sub: *toml.Table = ?v.data.table;
+
+        if (toml.get(sub, "version") != nil) {
+            ret err[bool, str](cc3(alloc, "mach.toml: ", label, ".version is reserved for the registry era"));
+        }
+        val ck: Result[bool, str] = check_keys(alloc, sub, label, TK_DEP);
+        if (is_err[bool, str](ck)) { ret ck; }
+
+        var d: DepDef;
+        d.name = intern_unwrap(i, name);
+        val git_s:  str = toml.get_str(sub, "git");
+        val path_s: str = toml.get_str(sub, "path");
+        val has_git:  bool = !str_empty(git_s);
+        val has_path: bool = !str_empty(path_s);
+        if (has_git == has_path) {
+            ret err[bool, str](cc3(alloc, "mach.toml: ", label, " needs exactly one source key: 'git' or 'path'"));
+        }
+        d.git  = intern_opt_unwrap(i, git_s);
+        d.path = intern_opt_unwrap(i, path_s);
+        d.ref  = intern_opt_unwrap(i, toml.get_str(sub, "ref"));
+
+        m.deps[k] = d;
+        k = k + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# dnit: release every owned array on a Manifest (and its nested overlays).
+pub fun dnit(m: *Manifest, alloc: *Allocator) {
+    if (m.targets != nil && m.target_count > 0) {
+        var k: u32 = 0;
+        for (k < m.target_count) {
+            free_strarr(alloc, m.targets[k].libs, m.targets[k].lib_count);
+            free_strarr(alloc, m.targets[k].defines, m.targets[k].define_count);
+            k = k + 1;
+        }
+        deallocate[TargetDef](alloc, m.targets, m.target_count::usize);
+        m.targets = nil; m.target_count = 0;
+    }
+    if (m.artifacts != nil && m.artifact_count > 0) {
+        var k: u32 = 0;
+        for (k < m.artifact_count) {
+            val a: *ArtifactDef = ?m.artifacts[k];
+            free_strarr(alloc, a.libs, a.lib_count);
+            free_strarr(alloc, a.defines, a.define_count);
+            if (a.cells != nil && a.cell_count > 0) {
+                var c: u32 = 0;
+                for (c < a.cell_count) {
+                    free_strarr(alloc, a.cells[c].libs, a.cells[c].lib_count);
+                    c = c + 1;
+                }
+                deallocate[CellDef](alloc, a.cells, a.cell_count::usize);
+            }
+            k = k + 1;
+        }
+        deallocate[ArtifactDef](alloc, m.artifacts, m.artifact_count::usize);
+        m.artifacts = nil; m.artifact_count = 0;
+    }
+    if (m.profiles != nil && m.profile_count > 0) {
+        deallocate[ProfileDef](alloc, m.profiles, m.profile_count::usize);
+        m.profiles = nil; m.profile_count = 0;
+    }
+    if (m.deps != nil && m.dep_count > 0) {
+        deallocate[DepDef](alloc, m.deps, m.dep_count::usize);
+        m.deps = nil; m.dep_count = 0;
+    }
+}
+
+# free_strarr: release an interned string array, if any.
+fun free_strarr(alloc: *Allocator, items: *intern.StrId, count: u32) {
+    if (items != nil && count > 0) {
+        deallocate[intern.StrId](alloc, items, count::usize);
+    }
+}
+
+# seg_eq: whether the byte range tmpl[start, end) equals `lit`.
+fun seg_eq(tmpl: str, start: usize, end: usize, lit: str) bool {
+    val ll: usize = str_len(lit);
+    if (end - start != ll) { ret false; }
+    var i: usize = 0;
+    for (i < ll) {
+        if (tmpl[start + i] != lit[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# seg_dup: an owned copy of the byte range tmpl[start, end).
+fun seg_dup(alloc: *Allocator, tmpl: str, start: usize, end: usize) str {
+    val n: usize = end - start;
+    val r: Result[*u8, str] = allocate[u8](alloc, n + 1);
+    if (is_err[*u8, str](r)) { ret ""; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var i: usize = 0;
+    for (i < n) { buf[i] = tmpl[start + i]; i = i + 1; }
+    buf[n] = 0;
+    ret buf::str;
+}
+
+# tmpl_value: the substitution string for the variable named by tmpl[start, end).
+# only `{target} {profile} {name} {ext}` are valid; anything else is an error.
+fun tmpl_value(alloc: *Allocator, tmpl: str, start: usize, end: usize,
+               target_name: str, profile_name: str, art_name: str, ext: str) Result[str, str] {
+    if (seg_eq(tmpl, start, end, "target"))  { ret ok[str, str](target_name); }
+    if (seg_eq(tmpl, start, end, "profile")) { ret ok[str, str](profile_name); }
+    if (seg_eq(tmpl, start, end, "name"))    { ret ok[str, str](art_name); }
+    if (seg_eq(tmpl, start, end, "ext"))     { ret ok[str, str](ext); }
+    ret err[str, str](cc3(alloc, "mach.toml: unknown template variable '{", seg_dup(alloc, tmpl, start, end), "}'"));
+}
+
+# expand: expand a `/`-canonical path template over `{target} {profile} {name}
+# {ext}`, normalizing each separator to the host's at the same time (the
+# filesystem boundary for manifest paths). returns an owned string.
+pub fun expand(alloc: *Allocator, tmpl: str,
+               target_name: str, profile_name: str, art_name: str, ext: str) Result[str, str] {
+    val n: usize = str_len(tmpl);
+    val sep: u8 = host_sep();
+
+    # pass 1: measure the expanded length.
+    var total: usize = 0;
+    var i: usize = 0;
+    for (i < n) {
+        if (tmpl[i] == '{') {
+            var j: usize = i + 1;
+            for (j < n && tmpl[j] != '}') { j = j + 1; }
+            if (j >= n) { ret err[str, str]("mach.toml: unterminated '{' in a path template"); }
+            val vr: Result[str, str] = tmpl_value(alloc, tmpl, i + 1, j, target_name, profile_name, art_name, ext);
+            if (is_err[str, str](vr)) { ret err[str, str](unwrap_err[str, str](vr)); }
+            total = total + str_len(unwrap_ok[str, str](vr));
+            i = j + 1;
+        }
+        or {
+            total = total + 1;
+            i = i + 1;
+        }
+    }
+
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret err[str, str](unwrap_err[*u8, str](r)); }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+
+    # pass 2: fill, converting every '/' to the host separator.
+    var k: usize = 0;
+    i = 0;
+    for (i < n) {
+        if (tmpl[i] == '{') {
+            var j: usize = i + 1;
+            for (j < n && tmpl[j] != '}') { j = j + 1; }
+            val vr: Result[str, str] = tmpl_value(alloc, tmpl, i + 1, j, target_name, profile_name, art_name, ext);
+            val vv: str = unwrap_ok[str, str](vr);
+            val vl: usize = str_len(vv);
+            var x: usize = 0;
+            for (x < vl) {
+                var ch: u8 = vv[x];
+                if (ch == '/') { ch = sep; }
+                buf[k] = ch; k = k + 1; x = x + 1;
+            }
+            i = j + 1;
+        }
+        or {
+            var ch: u8 = tmpl[i];
+            if (ch == '/') { ch = sep; }
+            buf[k] = ch; k = k + 1; i = i + 1;
+        }
+    }
+    buf[k] = 0;
+    ret ok[str, str](buf::str);
+}
+
+# Selection: the build selection a CLI invocation narrows the manifest with.
+# every field is optional; an unset value resolves to the manifest default.
+# ---
+# target:       declared target name, "native"/"host", or nil for the manifest default
+# profile:      declared profile name, or nil for the default profile
+# artifact:     a `[bin.*]`/`[lib.*]` name, or nil for the default artifact
+# want_lib:     the artifact selector came from `--lib` (disambiguates a name)
+# has_artifact: whether an artifact selector was given
+pub rec Selection {
+    target:       str;
+    profile:      str;
+    artifact:     str;
+    want_lib:     bool;
+    has_artifact: bool;
+}
+
+# BuildUnit: one fully-resolved (artifact, target, profile) cell with concrete,
+# template-expanded output paths. `{target}` is the resolved name, never the
+# literal `native`. `libs` is the merged target+artifact+cell link overlay,
+# owned by the resolving allocator.
+# ---
+# target:       the resolved target stanza
+# artifact:     the selected artifact stanza
+# target_name:  interned resolved target name (drives `{target}`)
+# profile_name: interned resolved profile name (drives `{profile}`)
+# entry:        interned effective entry-source path
+# bin_path:     interned expanded artifact path
+# obj_root:     interned expanded intermediate-object dir
+# ir_root:      interned expanded IR-dump dir
+# asm_root:     interned expanded ASM-dump dir
+# opt:          resolved optimization level
+# emit_ir:      profile default for IR emission
+# emit_asm:     profile default for ASM emission
+# is_lib:       whether the artifact is a library
+# kind:         library link kind (meaningful when is_lib)
+# libs:         merged interned link overlay; nil when none
+# lib_count:    number of entries in libs
+# warned:       native resolution found no host match and fell back to the first target
+pub rec BuildUnit {
+    target:       *TargetDef;
+    artifact:     *ArtifactDef;
+    target_name:  intern.StrId;
+    profile_name: intern.StrId;
+    entry:        intern.StrId;
+    bin_path:     intern.StrId;
+    obj_root:     intern.StrId;
+    ir_root:      intern.StrId;
+    asm_root:     intern.StrId;
+    opt:          MOpt;
+    emit_ir:      bool;
+    emit_asm:     bool;
+    is_lib:       bool;
+    kind:         LibKind;
+    libs:         *intern.StrId;
+    lib_count:    u32;
+    warned:       bool;
+}
+
+# ResolvedTarget: a resolved target plus the native no-match warning flag.
+pub rec ResolvedTarget {
+    target: *TargetDef;
+    warned: bool;
+}
+
+# must_lookup: look up an interned StrId, erroring on a miss (a parser invariant
+# break rather than a user error).
+fun must_lookup(i: *intern.Interner, id: intern.StrId) Result[str, str] {
+    val o: Option[str] = intern.lookup(i, id);
+    if (is_none[str](o)) { ret err[str, str]("internal: manifest StrId not interned"); }
+    ret ok[str, str](unwrap[str](o));
+}
+
+# find_target_by_name: the declared target whose name equals `name`, or nil.
+fun find_target_by_name(i: *intern.Interner, m: *Manifest, name: str) *TargetDef {
+    val r: Result[intern.StrId, str] = intern.intern(i, name);
+    if (is_err[intern.StrId, str](r)) { ret nil; }
+    val id: intern.StrId = unwrap_ok[intern.StrId, str](r);
+    var k: u32 = 0;
+    for (k < m.target_count) {
+        if (m.targets[k].name == id) { ret ?m.targets[k]; }
+        k = k + 1;
+    }
+    ret nil;
+}
+
+# target_matches_host: whether a target's (isa, os) tuple equals the build host's.
+fun target_matches_host(i: *intern.Interner, d: *TargetDef, host_os: u32, host_arch: u32) bool {
+    val os_o: Option[str] = intern.lookup(i, d.os);
+    val isa_o: Option[str] = intern.lookup(i, d.isa);
+    if (is_none[str](os_o) || is_none[str](isa_o)) { ret false; }
+    ret os_id_for(unwrap[str](os_o)) == host_os && arch_id_for(unwrap[str](isa_o)) == host_arch;
+}
+
+# resolve_target: resolve a target selector to a declared target. an empty
+# selector defers to `[project].target`; `native`/`host` resolve the host tuple
+# against the declared set only (ambiguity is an error; no match warns and falls
+# back to the first declared target). a named selector must match a stanza.
+pub fun resolve_target(alloc: *Allocator, i: *intern.Interner, m: *Manifest, sel: str) Result[ResolvedTarget, str] {
+    if (m.target_count == 0) { ret err[ResolvedTarget, str]("mach.toml: no [target.*] declared"); }
+
+    var name: str = sel;
+    if (str_empty(name)) {
+        val d: Result[str, str] = must_lookup(i, m.default_target);
+        if (is_err[str, str](d)) { ret err[ResolvedTarget, str](unwrap_err[str, str](d)); }
+        name = unwrap_ok[str, str](d);
+    }
+
+    if (str_equals(name, "native") || str_equals(name, "host")) {
+        ret resolve_native(alloc, i, m);
+    }
+
+    val d: *TargetDef = find_target_by_name(i, m, name);
+    if (d == nil) { ret err[ResolvedTarget, str](cc3(alloc, "mach.toml: no target named '", name, "'")); }
+    var rt: ResolvedTarget;
+    rt.target = d;
+    rt.warned = false;
+    ret ok[ResolvedTarget, str](rt);
+}
+
+# resolve_native: the host-resolution rule. exactly one host-tuple match wins;
+# several is an ambiguity error naming the candidates; none warns (via the
+# `warned` flag) and falls back to the first declared target.
+fun resolve_native(alloc: *Allocator, i: *intern.Interner, m: *Manifest) Result[ResolvedTarget, str] {
+    val host_os:   u32 = tgt.host_os_id();
+    val host_arch: u32 = tgt.host_arch_id();
+
+    var first_match: *TargetDef = nil;
+    var match_count: u32 = 0;
+    var names: str = "";
+    var k: u32 = 0;
+    for (k < m.target_count) {
+        if (target_matches_host(i, ?m.targets[k], host_os, host_arch)) {
+            val no: Option[str] = intern.lookup(i, m.targets[k].name);
+            val nm: str = first_nonempty_opt(no);
+            if (match_count == 0) { first_match = ?m.targets[k]; names = nm; }
+            or                    { names = cc3(alloc, names, ", ", nm); }
+            match_count = match_count + 1;
+        }
+        k = k + 1;
+    }
+
+    if (match_count > 1) {
+        ret err[ResolvedTarget, str](cc3(alloc, "mach.toml: 'native' matches multiple targets for the host (", names, ")"));
+    }
+    var rt: ResolvedTarget;
+    if (match_count == 1) {
+        rt.target = first_match;
+        rt.warned = false;
+        ret ok[ResolvedTarget, str](rt);
+    }
+    rt.target = ?m.targets[0];
+    rt.warned = true;
+    ret ok[ResolvedTarget, str](rt);
+}
+
+# first_nonempty_opt: the string in `o`, or "" when absent.
+fun first_nonempty_opt(o: Option[str]) str {
+    if (is_some[str](o)) { ret unwrap[str](o); }
+    ret "";
+}
+
+# ResolvedProfile: a resolved (or implicit-default) profile's effective fields.
+pub rec ResolvedProfile {
+    name:     intern.StrId;
+    opt:      MOpt;
+    emit_ir:  bool;
+    emit_asm: bool;
+}
+
+# resolve_profile: resolve a profile selector. a named selector must match a
+# `[profile.*]`; an empty selector takes the first declared profile, or — when
+# none are declared — an implicit `debug` profile (default opt, emission off).
+pub fun resolve_profile(alloc: *Allocator, i: *intern.Interner, m: *Manifest, sel: str) Result[ResolvedProfile, str] {
+    var rp: ResolvedProfile;
+    if (!str_empty(sel)) {
+        val r: Result[intern.StrId, str] = intern.intern(i, sel);
+        if (is_err[intern.StrId, str](r)) { ret err[ResolvedProfile, str](unwrap_err[intern.StrId, str](r)); }
+        val id: intern.StrId = unwrap_ok[intern.StrId, str](r);
+        var k: u32 = 0;
+        for (k < m.profile_count) {
+            if (m.profiles[k].name == id) {
+                rp.name = m.profiles[k].name; rp.opt = m.profiles[k].opt;
+                rp.emit_ir = m.profiles[k].emit_ir; rp.emit_asm = m.profiles[k].emit_asm;
+                ret ok[ResolvedProfile, str](rp);
+            }
+            k = k + 1;
+        }
+        ret err[ResolvedProfile, str](cc3(alloc, "mach.toml: no profile named '", sel, "'"));
+    }
+
+    if (m.profile_count > 0) {
+        rp.name = m.profiles[0].name; rp.opt = m.profiles[0].opt;
+        rp.emit_ir = m.profiles[0].emit_ir; rp.emit_asm = m.profiles[0].emit_asm;
+        ret ok[ResolvedProfile, str](rp);
+    }
+
+    val di: Result[intern.StrId, str] = intern.intern(i, "debug");
+    if (is_err[intern.StrId, str](di)) { ret err[ResolvedProfile, str](unwrap_err[intern.StrId, str](di)); }
+    rp.name = unwrap_ok[intern.StrId, str](di);
+    rp.opt = MOPT_DEFAULT;
+    rp.emit_ir = false;
+    rp.emit_asm = false;
+    ret ok[ResolvedProfile, str](rp);
+}
+
+# resolve_artifact: resolve an artifact selector. with a `--bin`/`--lib`
+# selector, the named artifact of that kind must exist; without one, a single
+# declared artifact is taken, and several is an error directing the user to
+# select one (the multi-artifact matrix lands in a later phase of #1218).
+pub fun resolve_artifact(alloc: *Allocator, i: *intern.Interner, m: *Manifest, sel: Selection) *ArtifactDef {
+    if (m.artifact_count == 0) { ret nil; }
+
+    if (sel.has_artifact) {
+        val r: Result[intern.StrId, str] = intern.intern(i, sel.artifact);
+        if (is_err[intern.StrId, str](r)) { ret nil; }
+        val id: intern.StrId = unwrap_ok[intern.StrId, str](r);
+        var k: u32 = 0;
+        for (k < m.artifact_count) {
+            if (m.artifacts[k].name == id && m.artifacts[k].is_lib == sel.want_lib) { ret ?m.artifacts[k]; }
+            k = k + 1;
+        }
+        ret nil;
+    }
+
+    if (m.artifact_count == 1) { ret ?m.artifacts[0]; }
+    ret nil;
+}
+
+# find_cell: the per-cell override for `art` matching the target named `tname`,
+# or nil when none refines that target.
+fun find_cell(art: *ArtifactDef, tname: intern.StrId) *CellDef {
+    var c: u32 = 0;
+    for (c < art.cell_count) {
+        if (art.cells[c].target == tname) { ret ?art.cells[c]; }
+        c = c + 1;
+    }
+    ret nil;
+}
+
+# merge_libs: the deduplicated target+artifact+cell link overlay, in that
+# precedence order. owned by `alloc`; nil/0 when empty.
+fun merge_libs(alloc: *Allocator, t: *TargetDef, a: *ArtifactDef, cell: *CellDef) Result[StrArr, str] {
+    var out: StrArr;
+    out.items = nil;
+    out.count = 0;
+    var cell_n: u32 = 0;
+    if (cell != nil) { cell_n = cell.lib_count; }
+    val max: u32 = t.lib_count + a.lib_count + cell_n;
+    if (max == 0) { ret ok[StrArr, str](out); }
+
+    val r: Result[*intern.StrId, str] = allocate[intern.StrId](alloc, max::usize);
+    if (is_err[*intern.StrId, str](r)) { ret err[StrArr, str](unwrap_err[*intern.StrId, str](r)); }
+    val buf: *intern.StrId = unwrap_ok[*intern.StrId, str](r);
+    var c: u32 = 0;
+    c = append_unique(buf, c, t.libs, t.lib_count);
+    c = append_unique(buf, c, a.libs, a.lib_count);
+    if (cell != nil) { c = append_unique(buf, c, cell.libs, cell.lib_count); }
+
+    if (c == 0) {
+        deallocate[intern.StrId](alloc, buf, max::usize);
+        ret ok[StrArr, str](out);
+    }
+    if (c < max) {
+        val sr: Result[*intern.StrId, str] = reallocate[intern.StrId](alloc, buf, max::usize, c::usize);
+        if (is_ok[*intern.StrId, str](sr)) {
+            out.items = unwrap_ok[*intern.StrId, str](sr);
+            out.count = c;
+            ret ok[StrArr, str](out);
+        }
+    }
+    out.items = buf;
+    out.count = c;
+    ret ok[StrArr, str](out);
+}
+
+# append_unique: append each id in `src` not already in buf[0, c) and return the
+# new count.
+fun append_unique(buf: *intern.StrId, c: u32, src: *intern.StrId, n: u32) u32 {
+    var i: u32 = 0;
+    var w: u32 = c;
+    for (i < n) {
+        val id: intern.StrId = src[i];
+        var seen: bool = false;
+        var j: u32 = 0;
+        for (j < w) { if (buf[j] == id) { seen = true; } j = j + 1; }
+        if (!seen) { buf[w] = id; w = w + 1; }
+        i = i + 1;
+    }
+    ret w;
+}
+
+# effective_out: the effective `out` template for an artifact under a cell —
+# cell override, else artifact override, else the project template.
+fun effective_out(m: *Manifest, a: *ArtifactDef, cell: *CellDef) intern.StrId {
+    if (cell != nil && cell.out != intern.STR_NIL) { ret cell.out; }
+    if (a.out != intern.STR_NIL) { ret a.out; }
+    ret m.out_tmpl;
+}
+
+# resolve_build_unit: resolve a Selection into one BuildUnit with concrete
+# template-expanded output paths and the merged link overlay.
+pub fun resolve_build_unit(alloc: *Allocator, i: *intern.Interner, m: *Manifest, sel: Selection) Result[BuildUnit, str] {
+    val rt_r: Result[ResolvedTarget, str] = resolve_target(alloc, i, m, sel.target);
+    if (is_err[ResolvedTarget, str](rt_r)) { ret err[BuildUnit, str](unwrap_err[ResolvedTarget, str](rt_r)); }
+    val rt: ResolvedTarget = unwrap_ok[ResolvedTarget, str](rt_r);
+
+    val rp_r: Result[ResolvedProfile, str] = resolve_profile(alloc, i, m, sel.profile);
+    if (is_err[ResolvedProfile, str](rp_r)) { ret err[BuildUnit, str](unwrap_err[ResolvedProfile, str](rp_r)); }
+    val rp: ResolvedProfile = unwrap_ok[ResolvedProfile, str](rp_r);
+
+    val a: *ArtifactDef = resolve_artifact(alloc, i, m, sel);
+    if (a == nil) { ret err[BuildUnit, str](artifact_err(alloc, m, sel)); }
+
+    val cell: *CellDef = find_cell(a, rt.target.name);
+
+    var u: BuildUnit;
+    u.target       = rt.target;
+    u.artifact     = a;
+    u.target_name  = rt.target.name;
+    u.profile_name = rp.name;
+    u.opt          = rp.opt;
+    u.emit_ir      = rp.emit_ir;
+    u.emit_asm     = rp.emit_asm;
+    u.is_lib       = a.is_lib;
+    u.kind         = a.kind;
+    u.warned       = rt.warned;
+
+    u.entry = a.entry;
+    if (cell != nil && cell.entry != intern.STR_NIL) { u.entry = cell.entry; }
+
+    val lm: Result[StrArr, str] = merge_libs(alloc, rt.target, a, cell);
+    if (is_err[StrArr, str](lm)) { ret err[BuildUnit, str](unwrap_err[StrArr, str](lm)); }
+    val merged: StrArr = unwrap_ok[StrArr, str](lm);
+    u.libs = merged.items;
+    u.lib_count = merged.count;
+
+    # expansion variables, all from stanzas present in the file.
+    val tn_r: Result[str, str] = must_lookup(i, rt.target.name);
+    if (is_err[str, str](tn_r)) { ret err[BuildUnit, str](unwrap_err[str, str](tn_r)); }
+    val pn_r: Result[str, str] = must_lookup(i, rp.name);
+    if (is_err[str, str](pn_r)) { ret err[BuildUnit, str](unwrap_err[str, str](pn_r)); }
+    val an_r: Result[str, str] = must_lookup(i, a.name);
+    if (is_err[str, str](an_r)) { ret err[BuildUnit, str](unwrap_err[str, str](an_r)); }
+    val ex_r: Result[str, str] = must_lookup(i, rt.target.ext);
+    if (is_err[str, str](ex_r)) { ret err[BuildUnit, str](unwrap_err[str, str](ex_r)); }
+    val tn: str = unwrap_ok[str, str](tn_r);
+    val pn: str = unwrap_ok[str, str](pn_r);
+    val an: str = unwrap_ok[str, str](an_r);
+    val ex: str = unwrap_ok[str, str](ex_r);
+
+    val out_tmpl: intern.StrId = effective_out(m, a, cell);
+    val bin_r: Result[intern.StrId, str] = expand_intern(alloc, i, out_tmpl, tn, pn, an, ex);
+    if (is_err[intern.StrId, str](bin_r)) { ret err[BuildUnit, str](unwrap_err[intern.StrId, str](bin_r)); }
+    u.bin_path = unwrap_ok[intern.StrId, str](bin_r);
+
+    val obj_r: Result[intern.StrId, str] = expand_intern(alloc, i, m.obj_tmpl, tn, pn, an, ex);
+    if (is_err[intern.StrId, str](obj_r)) { ret err[BuildUnit, str](unwrap_err[intern.StrId, str](obj_r)); }
+    u.obj_root = unwrap_ok[intern.StrId, str](obj_r);
+
+    val ir_r: Result[intern.StrId, str] = expand_intern(alloc, i, m.ir_tmpl, tn, pn, an, ex);
+    if (is_err[intern.StrId, str](ir_r)) { ret err[BuildUnit, str](unwrap_err[intern.StrId, str](ir_r)); }
+    u.ir_root = unwrap_ok[intern.StrId, str](ir_r);
+
+    val asm_r: Result[intern.StrId, str] = expand_intern(alloc, i, m.asm_tmpl, tn, pn, an, ex);
+    if (is_err[intern.StrId, str](asm_r)) { ret err[BuildUnit, str](unwrap_err[intern.StrId, str](asm_r)); }
+    u.asm_root = unwrap_ok[intern.StrId, str](asm_r);
+
+    ret ok[BuildUnit, str](u);
+}
+
+# artifact_err: the diagnostic for a failed artifact selection.
+fun artifact_err(alloc: *Allocator, m: *Manifest, sel: Selection) str {
+    if (m.artifact_count == 0) { ret "mach.toml: no [bin.*] or [lib.*] artifacts declared"; }
+    if (sel.has_artifact) {
+        if (sel.want_lib) { ret cc3(alloc, "mach.toml: no lib named '", sel.artifact, "'"); }
+        ret cc3(alloc, "mach.toml: no bin named '", sel.artifact, "'");
+    }
+    ret "mach.toml: multiple artifacts declared; select one with --bin or --lib";
+}
+
+# expand_intern: expand a template then intern the result.
+fun expand_intern(alloc: *Allocator, i: *intern.Interner, tmpl_id: intern.StrId,
+                  tn: str, pn: str, an: str, ex: str) Result[intern.StrId, str] {
+    val ts_r: Result[str, str] = must_lookup(i, tmpl_id);
+    if (is_err[str, str](ts_r)) { ret err[intern.StrId, str](unwrap_err[str, str](ts_r)); }
+    val ex_r: Result[str, str] = expand(alloc, unwrap_ok[str, str](ts_r), tn, pn, an, ex);
+    if (is_err[str, str](ex_r)) { ret err[intern.StrId, str](unwrap_err[str, str](ex_r)); }
+    val s: str = unwrap_ok[str, str](ex_r);
+    val ir: Result[intern.StrId, str] = intern.intern(i, s);
+    str_free(alloc, s);
+    ret ir;
+}
+
+# check_collisions: reject two artifacts that resolve to the same `out` path for
+# the selected target and profile — the honest "build start" guard against a
+# degenerate template (amendment 2).
+pub fun check_collisions(alloc: *Allocator, i: *intern.Interner, m: *Manifest,
+                         t: *TargetDef, profile_name: str) Result[bool, str] {
+    if (m.artifact_count < 2) { ret ok[bool, str](true); }
+
+    val tn_r: Result[str, str] = must_lookup(i, t.name);
+    if (is_err[str, str](tn_r)) { ret err[bool, str](unwrap_err[str, str](tn_r)); }
+    val tn: str = unwrap_ok[str, str](tn_r);
+    val ex_r: Result[str, str] = must_lookup(i, t.ext);
+    if (is_err[str, str](ex_r)) { ret err[bool, str](unwrap_err[str, str](ex_r)); }
+    val ex: str = unwrap_ok[str, str](ex_r);
+
+    val pr: Result[*str, str] = allocate[str](alloc, m.artifact_count::usize);
+    if (is_err[*str, str](pr)) { ret err[bool, str](unwrap_err[*str, str](pr)); }
+    val paths: *str = unwrap_ok[*str, str](pr);
+
+    var k: u32 = 0;
+    for (k < m.artifact_count) {
+        val a: *ArtifactDef = ?m.artifacts[k];
+        val an_r: Result[str, str] = must_lookup(i, a.name);
+        if (is_err[str, str](an_r)) { ret err[bool, str](unwrap_err[str, str](an_r)); }
+        val cell: *CellDef = find_cell(a, t.name);
+        val ot_r: Result[str, str] = must_lookup(i, effective_out(m, a, cell));
+        if (is_err[str, str](ot_r)) { ret err[bool, str](unwrap_err[str, str](ot_r)); }
+        val pe: Result[str, str] = expand(alloc, unwrap_ok[str, str](ot_r), tn, profile_name, unwrap_ok[str, str](an_r), ex);
+        if (is_err[str, str](pe)) { ret err[bool, str](unwrap_err[str, str](pe)); }
+        paths[k] = unwrap_ok[str, str](pe);
+        k = k + 1;
+    }
+
+    var x: u32 = 0;
+    for (x < m.artifact_count) {
+        var y: u32 = x + 1;
+        for (y < m.artifact_count) {
+            if (str_equals(paths[x], paths[y])) {
+                val nx: str = first_nonempty_opt(intern.lookup(i, m.artifacts[x].name));
+                val ny: str = first_nonempty_opt(intern.lookup(i, m.artifacts[y].name));
+                ret err[bool, str](cc5(alloc, cc3(alloc, "mach.toml: artifacts '", nx, "' and '"), ny, "' both build to '", paths[x], "'"));
+            }
+            y = y + 1;
+        }
+        x = x + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# tinit: stand up a page-backed arena allocator and a fresh interner for a test.
+# `backing`/`ar` are owned by the caller's frame so the arena outlives the test.
+fun tinit(backing: *Allocator, ar: *arena.Arena, alloc: *Allocator, itn: *intern.Interner) bool {
+    if (is_some[str](page.make(backing))) { ret false; }
+    if (is_some[str](arena.init(ar, backing, 0))) { ret false; }
+    if (is_some[str](arena.make(alloc, ar))) { ret false; }
+    @itn = intern.init(alloc);
+    ret true;
+}
+
+# tparse: parse a manifest from TOML source text for a test.
+fun tparse(alloc: *Allocator, itn: *intern.Interner, source: str) Result[Manifest, str] {
+    val tr: Result[toml.Table, str] = toml.parse(alloc, source);
+    if (is_err[toml.Table, str](tr)) { ret err[Manifest, str](unwrap_err[toml.Table, str](tr)); }
+    var t: toml.Table = unwrap_ok[toml.Table, str](tr);
+    ret parse(alloc, itn, ?t);
+}
+
+# idstr: the interned string behind a StrId, or "" on a miss (test helper).
+fun idstr(itn: *intern.Interner, id: intern.StrId) str {
+    ret first_nonempty_opt(intern.lookup(itn, id));
+}
+
+# mk_sel: build a Selection for a test.
+fun mk_sel(target: str, profile: str, artifact: str, want_lib: bool, has_artifact: bool) Selection {
+    var s: Selection;
+    s.target = target; s.profile = profile; s.artifact = artifact;
+    s.want_lib = want_lib; s.has_artifact = has_artifact;
+    ret s;
+}
+
+# DEMO: a representative two-bin, two-target, two-profile manifest.
+fun demo_src() str {
+    ret "[project]\nid = \"demo\"\nversion = \"0.1.0\"\nsrc = \"src\"\ndep = \"dep\"\ntarget = \"native\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\next = \".exe\"\n\n[bin.ls]\nentry = \"bin/ls.mach\"\n\n[bin.cat]\nentry = \"bin/cat.mach\"\n\n[profile.debug]\nopt = \"O0\"\n\n[profile.release]\nopt = \"O2\"\nemit_ir = true\n\n[deps.mach-std]\ngit = \"https://github.com/octalide/mach-std\"\nref = \"v0.4.0\"\n";
+}
+
+test "manifest: is_v2 distinguishes the singular [target] schema from plural [targets]" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val v2r: Result[toml.Table, str] = toml.parse(?alloc, "[project]\nid=\"x\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    val v1r: Result[toml.Table, str] = toml.parse(?alloc, "[project]\nid=\"x\"\n[targets.linux]\nos=\"linux\"\n");
+    if (is_err[toml.Table, str](v2r) || is_err[toml.Table, str](v1r)) { code = 1; }
+    or {
+        var v2t: toml.Table = unwrap_ok[toml.Table, str](v2r);
+        var v1t: toml.Table = unwrap_ok[toml.Table, str](v1r);
+        if (!is_v2(?v2t)) { code = 1; }
+        if (is_v2(?v1t))  { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: a full v2 manifest parses every stanza" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, demo_src());
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        if (!str_equals(idstr(?itn, m.id), "demo")) { code = 1; }
+        if (!str_equals(idstr(?itn, m.version), "0.1.0")) { code = 1; }
+        if (m.target_count != 2)   { code = 1; }
+        if (m.artifact_count != 2) { code = 1; }
+        if (m.profile_count != 2)  { code = 1; }
+        if (m.dep_count != 1)      { code = 1; }
+        if (!str_equals(idstr(?itn, m.out_tmpl), DEFAULT_OUT)) { code = 1; }
+        if (!str_equals(idstr(?itn, m.targets[1].ext), ".exe")) { code = 1; }
+        if (!str_equals(idstr(?itn, m.deps[0].git), "https://github.com/octalide/mach-std")) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: missing required project keys are rejected by name" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val a: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (is_ok[Manifest, str](a) || !str_equals(unwrap_err[Manifest, str](a), "mach.toml: [project] is missing required key 'id'")) { code = 1; }
+
+    val b: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (is_ok[Manifest, str](b) || !str_equals(unwrap_err[Manifest, str](b), "mach.toml: [project] is missing required key 'version'")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: an unknown key is rejected naming the key and table" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val a: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nbogus=\"y\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (is_ok[Manifest, str](a) || !str_equals(unwrap_err[Manifest, str](a), "mach.toml: unknown key 'bogus' in [project]")) { code = 1; }
+
+    val b: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\nwat=\"z\"\n");
+    if (is_ok[Manifest, str](b) || !str_equals(unwrap_err[Manifest, str](b), "mach.toml: unknown key 'wat' in [target.l]")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: [target.native] is a reserved name" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val a: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.native]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (is_ok[Manifest, str](a) || !str_equals(unwrap_err[Manifest, str](a), "mach.toml: [target.native] is reserved; 'native' resolves to a declared target")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: a dependency 'version' key is reserved" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val a: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[deps.std]\nversion=\"1.0\"\n");
+    if (is_ok[Manifest, str](a) || !str_equals(unwrap_err[Manifest, str](a), "mach.toml: [deps.std].version is reserved for the registry era")) { code = 1; }
+
+    val b: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[deps.std]\ngit=\"u\"\npath=\"p\"\n");
+    if (is_ok[Manifest, str](b) || !str_equals(unwrap_err[Manifest, str](b), "mach.toml: [deps.std] needs exactly one source key: 'git' or 'path'")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: a backslash in a path is rejected" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val a: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"a\\\\b\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (is_ok[Manifest, str](a) || !str_equals(unwrap_err[Manifest, str](a), "mach.toml: [project].src contains a '\\'; manifest paths use '/'")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: a library kind other than static/shared is rejected" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val a: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[lib.core]\nentry=\"lib.mach\"\nkind=\"plugin\"\n");
+    if (is_ok[Manifest, str](a) || !str_equals(unwrap_err[Manifest, str](a), "mach.toml: [lib.core].kind must be \"static\" or \"shared\"")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: template expansion substitutes the four variables and nothing else" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val a: Result[str, str] = expand(?alloc, DEFAULT_OUT, "linux", "debug", "ls", "");
+    if (is_err[str, str](a) || !str_equals(unwrap_ok[str, str](a), "out/linux/debug/bin/ls")) { code = 1; }
+
+    val b: Result[str, str] = expand(?alloc, "{name}{ext}", "windows", "release", "cat", ".exe");
+    if (is_err[str, str](b) || !str_equals(unwrap_ok[str, str](b), "cat.exe")) { code = 1; }
+
+    val c: Result[str, str] = expand(?alloc, "out/{flavor}", "linux", "debug", "ls", "");
+    if (is_ok[str, str](c) || !str_equals(unwrap_err[str, str](c), "mach.toml: unknown template variable '{flavor}'")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: native resolves the host tuple against declared targets only" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, demo_src());
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        val rt: Result[ResolvedTarget, str] = resolve_target(?alloc, ?itn, ?m, "native");
+        if (is_err[ResolvedTarget, str](rt)) { code = 1; }
+        or {
+            val r: ResolvedTarget = unwrap_ok[ResolvedTarget, str](rt);
+            if (r.warned) { code = 1; }
+            if (!str_equals(idstr(?itn, r.target.name), "linux")) { code = 1; }
+        }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: native with no host match warns and falls back to the first target" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[bin.app]\nentry=\"main.mach\"\n");
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        val rt: Result[ResolvedTarget, str] = resolve_target(?alloc, ?itn, ?m, "native");
+        if (is_err[ResolvedTarget, str](rt)) { code = 1; }
+        or {
+            val r: ResolvedTarget = unwrap_ok[ResolvedTarget, str](rt);
+            if (!r.warned) { code = 1; }
+            if (!str_equals(idstr(?itn, r.target.name), "windows")) { code = 1; }
+        }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: native ambiguity among host-matching targets is an error naming candidates" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.linux2]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[bin.app]\nentry=\"main.mach\"\n");
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        val rt: Result[ResolvedTarget, str] = resolve_target(?alloc, ?itn, ?m, "native");
+        if (is_ok[ResolvedTarget, str](rt) || !str_equals(unwrap_err[ResolvedTarget, str](rt), "mach.toml: 'native' matches multiple targets for the host (linux, linux2)")) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: an unknown target/profile selector is an error" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, demo_src());
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        val t: Result[ResolvedTarget, str] = resolve_target(?alloc, ?itn, ?m, "bsd");
+        if (is_ok[ResolvedTarget, str](t) || !str_equals(unwrap_err[ResolvedTarget, str](t), "mach.toml: no target named 'bsd'")) { code = 1; }
+        val pf: Result[ResolvedProfile, str] = resolve_profile(?alloc, ?itn, ?m, "fast");
+        if (is_ok[ResolvedProfile, str](pf) || !str_equals(unwrap_err[ResolvedProfile, str](pf), "mach.toml: no profile named 'fast'")) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: a build unit resolves concrete paths from the templates" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, demo_src());
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        val u: Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("", "", "ls", false, true));
+        if (is_err[BuildUnit, str](u)) { code = 1; }
+        or {
+            val bu: BuildUnit = unwrap_ok[BuildUnit, str](u);
+            if (!str_equals(idstr(?itn, bu.target_name), "linux")) { code = 1; }
+            if (!str_equals(idstr(?itn, bu.profile_name), "debug")) { code = 1; }
+            if (!str_equals(idstr(?itn, bu.entry), "bin/ls.mach")) { code = 1; }
+            if (!str_equals(idstr(?itn, bu.bin_path), "out/linux/debug/bin/ls")) { code = 1; }
+            if (!str_equals(idstr(?itn, bu.obj_root), "out/linux/debug/obj")) { code = 1; }
+            if (bu.opt != MOPT_DEBUG) { code = 1; }
+            if (bu.is_lib) { code = 1; }
+        }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: a release profile selection switches opt and emission" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, demo_src());
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        val u: Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("", "release", "cat", false, true));
+        if (is_err[BuildUnit, str](u)) { code = 1; }
+        or {
+            val bu: BuildUnit = unwrap_ok[BuildUnit, str](u);
+            if (bu.opt != MOPT_RELEASE) { code = 1; }
+            if (!bu.emit_ir) { code = 1; }
+            if (!str_equals(idstr(?itn, bu.bin_path), "out/linux/release/bin/cat")) { code = 1; }
+        }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: two artifacts resolving to the same path collide at build start" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nout=\"bin/app\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[bin.a]\nentry=\"a.mach\"\n[bin.b]\nentry=\"b.mach\"\n");
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        val cr: Result[bool, str] = check_collisions(?alloc, ?itn, ?m, ?m.targets[0], "debug");
+        if (is_ok[bool, str](cr) || !str_equals(unwrap_err[bool, str](cr), "mach.toml: artifacts 'a' and 'b' both build to 'bin/app'")) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: a per-cell [bin.X.target.Y] override refines entry and merges libs" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\ntarget=\"windows\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\next=\".exe\"\nlibs=[\"kernel32.dll\"]\n[bin.app]\nentry=\"main.mach\"\nlibs=[\"base.o\"]\n[bin.app.target.windows]\nentry=\"win.mach\"\nlibs=[\"user32.dll\"]\n");
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        val u: Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("windows", "", "app", false, true));
+        if (is_err[BuildUnit, str](u)) { code = 1; }
+        or {
+            val bu: BuildUnit = unwrap_ok[BuildUnit, str](u);
+            if (!str_equals(idstr(?itn, bu.entry), "win.mach")) { code = 1; }
+            if (!str_equals(idstr(?itn, bu.bin_path), "out/windows/debug/bin/app.exe")) { code = 1; }
+            if (bu.lib_count != 3) { code = 1; }
+        }
+    }
+    arena.dnit(?ar);
+    ret code;
+}


### PR DESCRIPTION
Phase 1 of the v2 `mach.toml` redesign (#1218).

## What this adds

- **`mach.lang.manifest`** — the single owner of the v2 format:
  - schema model: `[project]`, `[target.<name>]`, `[bin.<name>]`/`[lib.<name>]` (incl. per-cell `[bin.X.target.Y]`), `[profile.<name>]`, `[deps.<name>]`.
  - validating parser: unknown keys, missing required keys, reserved `[target.native]`, reserved `deps.version`, backslash-in-path — all loud and named.
  - template engine: `{target} {profile} {name} {ext}` with `/`→host-separator normalization at the FS boundary.
  - `native` host resolution against **declared** targets only (ambiguity = error; no-match = warn + first declared); `{target}` expands to the resolved name.
  - single build-unit resolution (artifact × target × profile) with template-expanded `out`/`obj`/`ir`/`asm` paths and start-time collision detection. The model supports the full matrix; CLI matrix iteration is deferred.
- **Transitional dual-format**: the driver detects the old plural `[targets.*]` and routes it through the existing reader **unchanged** (marked for removal in the final phase). New manifests route to the v2 reader.
- **17 unit tests** asserting every diagnostic, the template engine, native resolution, profile/collision/per-cell behavior.

## Status

- `mach build .` clean (repo manifest is old-format → exercises the transitional path), `mach test .` green, byte-identical fixpoint.
- The v2 reader currently parses + validates; the build wiring that turns a `Manifest` into a selected `Project` and the end-to-end integration suite land in the next commits on this branch.

Refs #1218