### PR TITLE
ir/passes cleanup wave: storage unification, alloca aux_ty, post-inline mem2reg, quadratic hot paths

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -170,7 +170,7 @@ fun mark_eightbyte_classes(ctx: *lctx.LowerCtx, ty: ir_type.IrTypeId, base_off: 
         ret;
     }
     if (t.kind == ir_type.IRT_ARRAY) {
-        val elem: ir_type.IrTypeId = t.data.element;
+        val elem: ir_type.IrTypeId = t.data.array_.element;
         val es:   u64 = ir_type.byte_size(ctx.types, elem, ctx.tgt)::u64;
         val n:    u32 = ir_type.array_count(ctx.types, ty);
         var i: u32 = 0;

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -150,13 +150,10 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) Result[
         ctx.instr_vregs[ii] = mir.MIR_VREG_NIL;
         val inst: *instr.Instruction = ?fn.instrs[ii];
         if (defines_value(ctx, inst)) {
-            # an alloca's instruction type is the allocated element type, but its
-            # result is always a pointer, so its result vreg is general-purpose;
-            # every other result takes its class from its own result type.
-            var cls: u32 = mir.REG_CLASS_GP;
-            if (inst.kind != instr.OP_ALLOCA) {
-                cls = reg_class_of(ctx, tgt, inst.ty);
-            }
+            # every result's vreg class comes from its own result type; an alloca
+            # now carries the IR pointer type (its element type rides on aux_ty),
+            # so it classifies general-purpose without a special case.
+            val cls: u32 = reg_class_of(ctx, tgt, inst.ty);
             val vr: Result[u32, str] = new_vreg(ctx, cls);
             if (is_err[u32, str](vr)) { ret err[bool, str](unwrap_err[u32, str](vr)); }
             ctx.instr_vregs[ii] = unwrap_ok[u32, str](vr);

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -1709,8 +1709,8 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
             }
             val ct: *ir_type.IrType = unwrap[*ir_type.IrType](ct_opt);
             if (ct.kind == ir_type.IRT_ARRAY) {
-                stride = ir_type.byte_size(ctx.types, ct.data.element, ctx.tgt)::u64;
-                cur_ty = ct.data.element;
+                stride = ir_type.byte_size(ctx.types, ct.data.array_.element, ctx.tgt)::u64;
+                cur_ty = ct.data.array_.element;
             } or (ct.kind == ir_type.IRT_STRUCT || ct.kind == ir_type.IRT_UNION) {
                 is_struct = true;
             } or {

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -1387,8 +1387,8 @@ fun is_float_kind(ctx: *lctx.LowerCtx, inst: *instr.Instruction) bool {
 }
 
 # lower_alloca: lower an OP_ALLOCA into a stack-slot reservation plus the address
-# materialization. the instruction's type is the allocated ELEMENT type (the
-# result Value is a pointer); operand 0 is the element count. a fresh internal
+# materialization. the instruction's `aux_ty` is the allocated ELEMENT type (the
+# result type and Value are the untyped pointer); operand 0 is the element count. a fresh internal
 # slot-key vreg owns a mir.SLOT_ALLOCA frame slot sized `element_size * count` and is
 # used only as the LEA base, so regalloc never register-allocates it and the
 # encoder resolves it to `[rbp + offset]`. the emitted `mir.MIR_ALLOCA (result) <-
@@ -1404,10 +1404,10 @@ fun lower_alloca(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructio
     }
     val count: u64 = cv.data.int_lit;
 
-    # the element type is the instruction's own type; size and align the slot from
-    # it. the allocated region is `count` contiguous elements.
-    val elem_size: u32  = ir_type.byte_size(ctx.types, inst.ty, ctx.tgt);
-    val elem_align: u32 = ir_type.byte_align(ctx.types, inst.ty, ctx.tgt);
+    # the element type rides on `aux_ty`; size and align the slot from it. the
+    # allocated region is `count` contiguous elements.
+    val elem_size: u32  = ir_type.byte_size(ctx.types, inst.aux_ty, ctx.tgt);
+    val elem_align: u32 = ir_type.byte_align(ctx.types, inst.aux_ty, ctx.tgt);
     val total: u64 = elem_size::u64 * count;
 
     val dst: u32 = lctx.result_vreg(ctx, iid);

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -456,7 +456,9 @@ fun dnit_block(m: *Module, blk: *Block) {
     }
 }
 
-val INITIAL_INSTR_CAP: u32 = 16;
+# initial instruction-pool capacity. the single seed for every pool — the
+# builder shares this primitive — sized for the lowerer's hot path.
+val INITIAL_INSTR_CAP: u32 = 64;
 
 # builds a block-target operand encoding `block`, matching the IR convention
 # used by the builder and read back by `block_target`: a VAL_CONST_INT carrying
@@ -631,6 +633,58 @@ pub fun block_append_pred(m: *Module, blk: *Block, pred: id.BlockId) Result[bool
     }
     blk.preds[blk.pred_count] = pred;
     blk.pred_count = blk.pred_count + 1;
+    ret ok[bool, str](true);
+}
+
+# replaces an instruction's operand array wholesale with `ops` (owned, length
+# `n`), freeing the old array by its true allocation size (`operand_cap`) and
+# normalizing count and capacity to `n`. the single primitive for swapping an
+# operand array, so no caller frees by a count a pass may have shrunk.
+# ---
+# m:   module owning the allocator
+# ins: instruction whose operands are replaced
+# ops: the new owned operand array (nil for n == 0)
+# n:   number of operands in `ops` (its allocation size)
+pub fun instr_replace_operands(m: *Module, ins: *instr.Instruction, ops: *value.Value, n: u32) {
+    if (ins.operands != nil && ins.operand_cap > 0) {
+        deallocate[value.Value](m.alloc, ins.operands, ins.operand_cap::usize);
+    }
+    ins.operands      = ops;
+    ins.operand_count = n;
+    ins.operand_cap   = n;
+}
+
+val INITIAL_PHI_OPERAND_CAP: u32 = 4;
+
+# appends one incoming `(pred, value)` edge to a phi's operand list
+# ([block0, val0, block1, val1, ...] per the OP_PHI convention), growing the
+# array geometrically while keeping `operand_cap` in step with the true
+# allocation size. the single phi-grow primitive shared by the builder and the
+# passes (inline, mem2reg), completing the operand-capacity contract.
+# ---
+# m:        module owning the allocator
+# phi:      the OP_PHI instruction receiving the incoming
+# pred:     predecessor block contributing `incoming`
+# incoming: the value flowing in from `pred`
+# ret:      ok(true) on success, or an allocation error
+pub fun phi_append_incoming(m: *Module, phi: *instr.Instruction, pred: id.BlockId, incoming: value.Value) Result[bool, str] {
+    val rbt: Result[value.Value, str] = make_block_target(m, pred);
+    if (is_err[value.Value, str](rbt)) { ret err[bool, str](unwrap_err[value.Value, str](rbt)); }
+
+    val needed: u32 = phi.operand_count + 2;
+    if (needed > phi.operand_cap) {
+        var new_cap: u32 = phi.operand_cap * 2;
+        if (new_cap < INITIAL_PHI_OPERAND_CAP) { new_cap = INITIAL_PHI_OPERAND_CAP; }
+        for (new_cap < needed) { new_cap = new_cap * 2; }
+        val r: Result[*value.Value, str] =
+            reallocate[value.Value](m.alloc, phi.operands, phi.operand_cap::usize, new_cap::usize);
+        if (is_err[*value.Value, str](r)) { ret err[bool, str](unwrap_err[*value.Value, str](r)); }
+        phi.operands    = unwrap_ok[*value.Value, str](r);
+        phi.operand_cap = new_cap;
+    }
+    phi.operands[phi.operand_count]     = unwrap_ok[value.Value, str](rbt);
+    phi.operands[phi.operand_count + 1] = incoming;
+    phi.operand_count = needed;
     ret ok[bool, str](true);
 }
 

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -528,8 +528,8 @@ pub fun get_instruction(fn: *Function, i: id.InstructionId) Option[*instr.Instru
 }
 
 # appends an instruction to a function's pool, growing it as needed, and
-# returns its freshly assigned InstructionId. the instruction's `block` field
-# is the caller's responsibility; this only manages pool storage and identity.
+# returns its freshly assigned InstructionId. this only manages pool storage
+# and identity; block membership lives solely in the Block lists.
 # the operand array a caller hands in is freshly allocated to exactly
 # `operand_count`, so `operand_cap` is normalized to match here; a caller that
 # later grows the operands in place (e.g. appending phi incomings) must keep
@@ -944,7 +944,6 @@ test "ir: module teardown frees operands by capacity and agg blobs under a freei
     cbr.ty = i64t;
     cbr.operands = o3;
     cbr.operand_count = 3;
-    cbr.block = 0::id.BlockId;
     cbr.flags = 0;
     cbr.aux_ty = ir_type.IRT_NIL;
     val cr: Result[id.InstructionId, str] = add_instruction(?m, fn, cbr);
@@ -962,7 +961,6 @@ test "ir: module teardown frees operands by capacity and agg blobs under a freei
     phi.ty = i64t;
     phi.operands = o4;
     phi.operand_count = 4;
-    phi.block = 0::id.BlockId;
     phi.flags = 0;
     phi.aux_ty = ir_type.IRT_NIL;
     val pr2: Result[id.InstructionId, str] = add_instruction(?m, fn, phi);

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -9,9 +9,11 @@
 # Storage model: instructions live in a flat per-`Function` pool
 # (`Function.instrs`); an `InstructionId` is an index into that pool, so
 # `Value.data.instr` and `Block.instructions` are stable handles for the
-# function's lifetime. The builder owns the growth of the pool, of each
-# block's instruction / phi / pred arrays, and of every instruction's operand
-# array.
+# function's lifetime. All storage growth — the pool, each block's
+# instruction / phi / pred arrays, and every instruction's operand array —
+# goes through the `ir.mach` primitives (`add_block`, `add_instruction`,
+# `block_append_*`, `phi_append_incoming`), so the capacity invariants live
+# in exactly one place.
 #
 # Terminator emitters (`emit_br` / `emit_cbr` / `emit_ret` /
 # `emit_unreachable`) additionally record the control-flow edge by appending
@@ -31,7 +33,6 @@ use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 
 use std.allocator.allocate;
-use std.allocator.reallocate;
 use std.allocator.deallocate;
 
 use ir:      mach.lang.me.ir;
@@ -39,11 +40,6 @@ use instr:   mach.lang.me.ir.instruction;
 use value:   mach.lang.me.ir.value;
 use ir_type: mach.lang.me.ir.type;
 use id:      mach.lang.me.ir.id;
-
-val INITIAL_INSTR_CAP:      u32 = 64;
-val INITIAL_BLOCK_BODY_CAP: u32 = 8;
-val INITIAL_PHI_CAP:        u32 = 4;
-val INITIAL_BLOCK_CAP:      u32 = 4;
 
 # an insertion cursor over an IR module.
 # ---
@@ -94,29 +90,7 @@ pub fun set_block(b: *Builder, blk: id.BlockId) {
 # ret: the new block's id, or an allocation / state error
 pub fun new_block(b: *Builder) Result[id.BlockId, str] {
     if (b.fn == nil) { ret err[id.BlockId, str]("builder: new_block with no current function"); }
-    val fn: *ir.Function = b.fn;
-
-    if (fn.block_count == fn.block_cap) {
-        val gr: Result[bool, str] = grow_blocks(b);
-        if (is_err[bool, str](gr)) { ret err[id.BlockId, str](unwrap_err[bool, str](gr)); }
-    }
-
-    val bid: id.BlockId = fn.block_count;
-    var blk: ir.Block;
-    blk.id           = bid;
-    blk.instructions = nil;
-    blk.instr_count  = 0;
-    blk.instr_cap    = 0;
-    blk.phis         = nil;
-    blk.phi_count    = 0;
-    blk.phi_cap      = 0;
-    blk.terminator   = id.INSTR_NIL;
-    blk.preds        = nil;
-    blk.pred_count   = 0;
-    blk.pred_cap     = 0;
-    fn.blocks[bid]   = blk;
-    fn.block_count   = bid + 1;
-    ret ok[id.BlockId, str](bid);
+    ret ir.add_block(b.m, b.fn);
 }
 
 # emits an integer addition `lhs + rhs`.
@@ -642,14 +616,15 @@ pub fun emit_phi(b: *Builder, ty: ir_type.IrTypeId) Result[value.Value, str] {
     val iid: id.InstructionId = unwrap_ok[id.InstructionId, str](ir_res);
 
     val blk: *ir.Block = ?b.fn.blocks[b.block];
-    val ar: Result[bool, str] = block_push_phi(b, blk, iid);
+    val ar: Result[bool, str] = ir.block_append_phi(b.m, blk, iid);
     if (is_err[bool, str](ar)) { ret err[value.Value, str](unwrap_err[bool, str](ar)); }
     ret ok[value.Value, str](value.instr_value(iid, ty));
 }
 
 # appends one incoming `(source_block, val)` edge to a phi instruction. the
 # operand layout is [block0, val0, block1, val1, ...]; the predecessor block
-# id rides in the value slot it pairs with, encoded as a const_int.
+# id rides in the value slot it pairs with, encoded as a const_int. growth
+# goes through the single capacity-maintaining ir.phi_append_incoming.
 # ---
 # b:      the builder
 # phi:    the phi value returned by emit_phi
@@ -665,22 +640,7 @@ pub fun phi_add_incoming(b: *Builder, phi: value.Value, source: id.BlockId, valu
     val ins: *instr.Instruction = ?b.fn.instrs[iid];
     if (ins.kind != instr.OP_PHI) { ret err[bool, str]("builder: phi_add_incoming on a non-phi instruction"); }
 
-    val br: Result[ir_type.IrTypeId, str] = ptr_type(b);
-    if (is_err[ir_type.IrTypeId, str](br)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](br)); }
-    val block_ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](br);
-
-    val block_val: value.Value = value.const_int(source::u64, block_ty);
-
-    val new_count: u32 = ins.operand_count + 2;
-    val gr: Result[*value.Value, str] = grow_operands(b, ins.operands, ins.operand_count, new_count);
-    if (is_err[*value.Value, str](gr)) { ret err[bool, str](unwrap_err[*value.Value, str](gr)); }
-    val ops: *value.Value = unwrap_ok[*value.Value, str](gr);
-    ops[ins.operand_count]     = block_val;
-    ops[ins.operand_count + 1] = value_arg;
-    ins.operands      = ops;
-    ins.operand_count = new_count;
-    ins.operand_cap   = new_count;  # grow reallocated `operands` to new_count
-    ret ok[bool, str](true);
+    ret ir.phi_append_incoming(b.m, ins, source, value_arg);
 }
 
 # emits a call to `callee` with the given arguments. the result type is the
@@ -928,7 +888,7 @@ fun emit_raw_owned(b: *Builder, k: instr.InstrKind, ty: ir_type.IrTypeId, owned:
     # once appended, the operand array is owned by the pool entry; a
     # block-link failure leaves the instruction (with its operands) in the
     # pool for dnit_function to reclaim — do not free here.
-    val pr: Result[bool, str] = block_push_instr(b, blk, iid);
+    val pr: Result[bool, str] = ir.block_append_instr(b.m, blk, iid);
     if (is_err[bool, str](pr)) { ret err[id.InstructionId, str](unwrap_err[bool, str](pr)); }
     ret ok[id.InstructionId, str](iid);
 }
@@ -967,15 +927,9 @@ fun emit_terminator(b: *Builder, k: instr.InstrKind, ty: ir_type.IrTypeId, stack
     ret ok[id.InstructionId, str](iid);
 }
 
-# allocates a slot in the function's instruction pool and writes a fresh
-# Instruction record; returns its id. takes ownership of `operands`.
+# builds a fresh Instruction record (owned operands, current-block tag) and
+# appends it to the pool through the single ir.add_instruction primitive.
 fun pool_append(b: *Builder, k: instr.InstrKind, ty: ir_type.IrTypeId, operands: *value.Value, n: u32) Result[id.InstructionId, str] {
-    val fn: *ir.Function = b.fn;
-    if (fn.instr_len == fn.instr_cap) {
-        val gr: Result[bool, str] = grow_instrs(b);
-        if (is_err[bool, str](gr)) { ret err[id.InstructionId, str](unwrap_err[bool, str](gr)); }
-    }
-    val iid: id.InstructionId = fn.instr_len;
     var ins: instr.Instruction;
     ins.kind          = k;
     ins.ty            = ty;
@@ -985,91 +939,7 @@ fun pool_append(b: *Builder, k: instr.InstrKind, ty: ir_type.IrTypeId, operands:
     ins.block         = b.block;
     ins.flags         = 0;
     ins.aux_ty        = ir_type.IRT_NIL;
-    fn.instrs[iid]    = ins;
-    fn.instr_len      = iid + 1;
-    ret ok[id.InstructionId, str](iid);
-}
-
-# grows the function's block array (doubling, or seeding from empty).
-fun grow_blocks(b: *Builder) Result[bool, str] {
-    val fn: *ir.Function = b.fn;
-    var new_cap: u32 = fn.block_cap * 2;
-    if (fn.block_cap == 0) { new_cap = INITIAL_BLOCK_CAP; }
-    if (fn.blocks == nil) {
-        val r: Result[*ir.Block, str] = allocate[ir.Block](b.m.alloc, new_cap::usize);
-        if (is_err[*ir.Block, str](r)) { ret err[bool, str](unwrap_err[*ir.Block, str](r)); }
-        fn.blocks = unwrap_ok[*ir.Block, str](r);
-    }
-    or {
-        val r: Result[*ir.Block, str] = reallocate[ir.Block](b.m.alloc, fn.blocks, fn.block_cap::usize, new_cap::usize);
-        if (is_err[*ir.Block, str](r)) { ret err[bool, str](unwrap_err[*ir.Block, str](r)); }
-        fn.blocks = unwrap_ok[*ir.Block, str](r);
-    }
-    fn.block_cap = new_cap;
-    ret ok[bool, str](true);
-}
-
-# grows the function's instruction pool (doubling, or seeding from empty).
-fun grow_instrs(b: *Builder) Result[bool, str] {
-    val fn: *ir.Function = b.fn;
-    var new_cap: u32 = fn.instr_cap * 2;
-    if (fn.instr_cap == 0) { new_cap = INITIAL_INSTR_CAP; }
-    if (fn.instrs == nil) {
-        val r: Result[*instr.Instruction, str] = allocate[instr.Instruction](b.m.alloc, new_cap::usize);
-        if (is_err[*instr.Instruction, str](r)) { ret err[bool, str](unwrap_err[*instr.Instruction, str](r)); }
-        fn.instrs = unwrap_ok[*instr.Instruction, str](r);
-    }
-    or {
-        val r: Result[*instr.Instruction, str] = reallocate[instr.Instruction](b.m.alloc, fn.instrs, fn.instr_cap::usize, new_cap::usize);
-        if (is_err[*instr.Instruction, str](r)) { ret err[bool, str](unwrap_err[*instr.Instruction, str](r)); }
-        fn.instrs = unwrap_ok[*instr.Instruction, str](r);
-    }
-    fn.instr_cap = new_cap;
-    ret ok[bool, str](true);
-}
-
-# appends an instruction id to a block's non-phi body list, growing it.
-fun block_push_instr(b: *Builder, blk: *ir.Block, iid: id.InstructionId) Result[bool, str] {
-    if (blk.instr_count == blk.instr_cap) {
-        var new_cap: u32 = blk.instr_cap * 2;
-        if (blk.instr_cap == 0) { new_cap = INITIAL_BLOCK_BODY_CAP; }
-        if (blk.instructions == nil) {
-            val r: Result[*id.InstructionId, str] = allocate[id.InstructionId](b.m.alloc, new_cap::usize);
-            if (is_err[*id.InstructionId, str](r)) { ret err[bool, str](unwrap_err[*id.InstructionId, str](r)); }
-            blk.instructions = unwrap_ok[*id.InstructionId, str](r);
-        }
-        or {
-            val r: Result[*id.InstructionId, str] = reallocate[id.InstructionId](b.m.alloc, blk.instructions, blk.instr_cap::usize, new_cap::usize);
-            if (is_err[*id.InstructionId, str](r)) { ret err[bool, str](unwrap_err[*id.InstructionId, str](r)); }
-            blk.instructions = unwrap_ok[*id.InstructionId, str](r);
-        }
-        blk.instr_cap = new_cap;
-    }
-    blk.instructions[blk.instr_count] = iid;
-    blk.instr_count = blk.instr_count + 1;
-    ret ok[bool, str](true);
-}
-
-# appends a phi instruction id to a block's phi list, growing it.
-fun block_push_phi(b: *Builder, blk: *ir.Block, iid: id.InstructionId) Result[bool, str] {
-    if (blk.phi_count == blk.phi_cap) {
-        var new_cap: u32 = blk.phi_cap * 2;
-        if (blk.phi_cap == 0) { new_cap = INITIAL_PHI_CAP; }
-        if (blk.phis == nil) {
-            val r: Result[*id.InstructionId, str] = allocate[id.InstructionId](b.m.alloc, new_cap::usize);
-            if (is_err[*id.InstructionId, str](r)) { ret err[bool, str](unwrap_err[*id.InstructionId, str](r)); }
-            blk.phis = unwrap_ok[*id.InstructionId, str](r);
-        }
-        or {
-            val r: Result[*id.InstructionId, str] = reallocate[id.InstructionId](b.m.alloc, blk.phis, blk.phi_cap::usize, new_cap::usize);
-            if (is_err[*id.InstructionId, str](r)) { ret err[bool, str](unwrap_err[*id.InstructionId, str](r)); }
-            blk.phis = unwrap_ok[*id.InstructionId, str](r);
-        }
-        blk.phi_cap = new_cap;
-    }
-    blk.phis[blk.phi_count] = iid;
-    blk.phi_count = blk.phi_count + 1;
-    ret ok[bool, str](true);
+    ret ir.add_instruction(b.m, b.fn, ins);
 }
 
 # records the current block as a predecessor of `target` via the single
@@ -1078,15 +948,6 @@ fun block_push_phi(b: *Builder, blk: *ir.Block, iid: id.InstructionId) Result[bo
 fun add_pred(b: *Builder, target: id.BlockId) Result[bool, str] {
     if (target >= b.fn.block_count) { ret err[bool, str]("builder: branch to out-of-range block"); }
     ret ir.block_append_pred(b.m, ?b.fn.blocks[target], b.block);
-}
-
-# grows an instruction's operand array from `old_count` to `new_count`,
-# copying existing operands. used by phi_add_incoming to append edges.
-fun grow_operands(b: *Builder, old: *value.Value, old_count: u32, new_count: u32) Result[*value.Value, str] {
-    if (old == nil || old_count == 0) {
-        ret allocate[value.Value](b.m.alloc, new_count::usize);
-    }
-    ret reallocate[value.Value](b.m.alloc, old, old_count::usize, new_count::usize);
 }
 
 # frees an owned operand array (used on a post-allocation failure path).

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -927,8 +927,8 @@ fun emit_terminator(b: *Builder, k: instr.InstrKind, ty: ir_type.IrTypeId, stack
     ret ok[id.InstructionId, str](iid);
 }
 
-# builds a fresh Instruction record (owned operands, current-block tag) and
-# appends it to the pool through the single ir.add_instruction primitive.
+# builds a fresh Instruction record (owned operands) and appends it to the pool
+# through the single ir.add_instruction primitive.
 fun pool_append(b: *Builder, k: instr.InstrKind, ty: ir_type.IrTypeId, operands: *value.Value, n: u32) Result[id.InstructionId, str] {
     var ins: instr.Instruction;
     ins.kind          = k;
@@ -936,7 +936,6 @@ fun pool_append(b: *Builder, k: instr.InstrKind, ty: ir_type.IrTypeId, operands:
     ins.operands      = operands;
     ins.operand_count = n;
     ins.operand_cap   = n;          # `operands` is allocated to exactly n here
-    ins.block         = b.block;
     ins.flags         = 0;
     ins.aux_ty        = ir_type.IRT_NIL;
     ret ir.add_instruction(b.m, b.fn, ins);

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -403,9 +403,10 @@ pub fun emit_bitcast(b: *Builder, operand: value.Value, to: ir_type.IrTypeId) Re
 
 # emits a stack allocation. the result is a pointer to `count` contiguous
 # slots of `ty`; `count` is a runtime value (use a const_int of 1 for a
-# single slot). the instruction's type records the allocated ELEMENT type so
-# the back end can size the stack slot (an untyped IR pointer carries none);
-# the result Value is an IR pointer.
+# single slot). the result type and the result Value are both the untyped IR
+# pointer; the allocated ELEMENT type (which sizes the stack slot, since the
+# pointer carries none) rides on `aux_ty`, the same convention GEP / MEMZERO /
+# CALL use for a type their result slot cannot itself carry.
 # ---
 # b:     the builder
 # ty:    the element type being allocated
@@ -418,9 +419,11 @@ pub fun emit_alloca(b: *Builder, ty: ir_type.IrTypeId, count: value.Value) Resul
 
     var ops: [1]value.Value;
     ops[0] = count;
-    val r: Result[id.InstructionId, str] = emit_raw(b, instr.OP_ALLOCA, ty, ?ops[0], 1);
+    val r: Result[id.InstructionId, str] = emit_raw(b, instr.OP_ALLOCA, pty, ?ops[0], 1);
     if (is_err[id.InstructionId, str](r)) { ret err[value.Value, str](unwrap_err[id.InstructionId, str](r)); }
-    ret ok[value.Value, str](value.instr_value(unwrap_ok[id.InstructionId, str](r), pty));
+    val iid: id.InstructionId = unwrap_ok[id.InstructionId, str](r);
+    b.fn.instrs[iid].aux_ty = ty;
+    ret ok[value.Value, str](value.instr_value(iid, pty));
 }
 
 # emits a load of type `ty` from a pointer.

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -29,7 +29,6 @@ use std.types.bool.false;
 
 use value:   mach.lang.me.ir.value;
 use ir_type: mach.lang.me.ir.type;
-use id:      mach.lang.me.ir.id;
 
 # the opcode of an instruction; selects operand interpretation and result type.
 pub def InstrKind: u8;
@@ -171,7 +170,9 @@ pub val INSTR_FLAG_VOLATILE: u16 = 0x08;
 #                depends on a count a pass may have shrunk. any code that allocates
 #                or grows `operands` must set this to the allocation size; a pass
 #                that only shrinks `operand_count` leaves it untouched.
-# block:         the block this instruction belongs to
+#                note: an instruction does NOT record its owning block — block
+#                membership lives solely in the Block lists (the liveness source
+#                of truth); a consumer needing placement derives it from them.
 # flags:         bitwise-or of INSTR_FLAG_* modifiers
 # aux_ty:        opcode-specific auxiliary type, used by the opcodes whose base
 #                pointer / result slot cannot itself carry the type the back end
@@ -190,7 +191,6 @@ pub rec Instruction {
     operands:      *value.Value;
     operand_count: u32;
     operand_cap:   u32;
-    block:         id.BlockId;
     flags:         u16;
     aux_ty:        ir_type.IrTypeId;
 }

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -181,10 +181,10 @@ pub val INSTR_FLAG_VOLATILE: u16 = 0x08;
 #                for OP_MEMZERO it is the aggregate pointee whose `byte_size` is
 #                the number of bytes zeroed. for OP_CALL it is the callee's
 #                IRT_FN signature, stamped so the back end classifies the ABI
-#                from the declaration rather than from per-arg operand types.
-#                IRT_NIL for every other opcode. OP_ALLOCA is the one exception
-#                that instead overloads `ty` to carry its allocated element type
-#                (its result Value is the IRT_PTR); see emit_alloca.
+#                from the declaration rather than from per-arg operand types. for
+#                OP_ALLOCA it is the allocated element type sizing the stack slot
+#                (its result type and Value are the IRT_PTR). IRT_NIL for every
+#                other opcode.
 pub rec Instruction {
     kind:          InstrKind;
     ty:            ir_type.IrTypeId;

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -254,7 +254,11 @@ pub fun print_instruction(out: *writer.Writer, m: *ir.Module, fn: *ir.Function, 
     if (produces_value(ins.kind)) {
         val rt: Result[bool, str] = ws(out, " ");
         if (is_err[bool, str](rt)) { ret rt; }
-        val rty: Result[bool, str] = print_type(out, m, ins.ty);
+        # an alloca's result type is the uninformative IR pointer; show the
+        # allocated element type (its aux_ty) instead, which is what it names.
+        var pty: ir_type.IrTypeId = ins.ty;
+        if (ins.kind == instr.OP_ALLOCA) { pty = ins.aux_ty; }
+        val rty: Result[bool, str] = print_type(out, m, pty);
         if (is_err[bool, str](rty)) { ret rty; }
     }
 

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -435,7 +435,7 @@ pub fun print_type(out: *writer.Writer, m: *ir.Module, tid: ir_type.IrTypeId) Re
         if (is_err[bool, str](r2)) { ret r2; }
         val r3: Result[bool, str] = ws(out, "]");
         if (is_err[bool, str](r3)) { ret r3; }
-        ret print_type(out, m, t.data.element);
+        ret print_type(out, m, t.data.array_.element);
     }
     if (t.kind == ir_type.IRT_STRUCT || t.kind == ir_type.IRT_UNION) {
         var open: str = "{";

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -44,6 +44,8 @@ use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
+use std.system.panic.panic;
+
 use mem:   std.memory;
 use map:   std.collections.map;
 use fnv1a: std.crypto.hash.fnv1a;
@@ -78,6 +80,16 @@ pub val IRT_FN:     IrTypeKind = 6;
 # align the max member align. shares the struct payload (the member type list).
 pub val IRT_UNION:  IrTypeKind = 7;
 
+# array payload: an element type plus a fixed element count, stored inline so
+# arrays are keyed by structural identity in the dedup map like every other kind.
+# ---
+# element: element IrTypeId
+# count:   number of elements
+pub rec IrTypeArray {
+    element: IrTypeId;
+    count:   u32;
+}
+
 # struct payload: an ordered list of field types stored inline.
 # ---
 # fields:      pointer to a contiguous array of field IrTypeIds (owned)
@@ -104,14 +116,13 @@ pub rec IrTypeFn {
 # ---
 # kind: which IRT_* variant is active
 # data: kind-specific payload. IRT_VOID/IRT_PTR carry no meaningful payload;
-#       IRT_INT/IRT_FLOAT use `bits`; IRT_ARRAY uses `element` and reads its
-#       length from the table's parallel `counts` array; IRT_STRUCT/IRT_FN
-#       use their respective sub-records.
+#       IRT_INT/IRT_FLOAT use `bits`; IRT_ARRAY uses `array_` (element + count);
+#       IRT_STRUCT/IRT_UNION/IRT_FN use their respective sub-records.
 pub rec IrType {
     kind: IrTypeKind;
     data: uni {
         bits:    u32;
-        element: IrTypeId;
+        array_:  IrTypeArray;
         struct_: IrTypeStruct;
         fn:      IrTypeFn;
     };
@@ -123,8 +134,6 @@ pub rec IrType {
 # types:  universe of IrType records indexed by IrTypeId
 # len:    number of types stored
 # cap:    allocated slots in types
-# counts: parallel array of array element counts, indexed by IrTypeId
-#         (meaningful only for IRT_ARRAY entries; 0 elsewhere)
 # dedup:  IrType -> IrTypeId map for structural identity
 pub rec IrTypeTable {
     alloc: *Allocator;
@@ -132,8 +141,6 @@ pub rec IrTypeTable {
     types: *IrType;
     len:   u32;
     cap:   u32;
-
-    counts: *u32;
 
     dedup: map.Map[IrType, IrTypeId];
 }
@@ -150,7 +157,6 @@ pub fun init(alloc: *Allocator) Result[IrTypeTable, str] {
     t.types  = nil;
     t.len    = 0;
     t.cap    = 0;
-    t.counts = nil;
     t.dedup  = map.init[IrType, IrTypeId](alloc, hash_ir_type, eq_ir_type);
 
     val rt: Result[*IrType, str] = allocate[IrType](alloc, INITIAL_TYPE_CAP::usize);
@@ -160,14 +166,6 @@ pub fun init(alloc: *Allocator) Result[IrTypeTable, str] {
     }
     t.types = unwrap_ok[*IrType, str](rt);
     t.cap   = INITIAL_TYPE_CAP;
-
-    val rc: Result[*u32, str] = allocate[u32](alloc, INITIAL_TYPE_CAP::usize);
-    if (is_err[*u32, str](rc)) {
-        deallocate[IrType](alloc, t.types, t.cap::usize);
-        map.dnit[IrType, IrTypeId](?t.dedup);
-        ret err[IrTypeTable, str](unwrap_err[*u32, str](rc));
-    }
-    t.counts = unwrap_ok[*u32, str](rc);
 
     ret ok[IrTypeTable, str](t);
 }
@@ -185,14 +183,10 @@ pub fun dnit(t: *IrTypeTable) {
     if (t.types != nil && t.cap > 0) {
         deallocate[IrType](t.alloc, t.types, t.cap::usize);
     }
-    if (t.counts != nil && t.cap > 0) {
-        deallocate[u32](t.alloc, t.counts, t.cap::usize);
-    }
     map.dnit[IrType, IrTypeId](?t.dedup);
     t.types  = nil;
     t.len    = 0;
     t.cap    = 0;
-    t.counts = nil;
 }
 
 # interns the void type.
@@ -203,7 +197,7 @@ pub fun intern_void(t: *IrTypeTable) Result[IrTypeId, str] {
     var ir: IrType;
     ir.kind = IRT_VOID;
     ir.data.bits = 0;
-    ret intern_scalar(t, ir);
+    ret intern_inline(t, ir);
 }
 
 # interns a machine integer of the given bit width.
@@ -215,7 +209,7 @@ pub fun intern_int(t: *IrTypeTable, bits: u32) Result[IrTypeId, str] {
     var ir: IrType;
     ir.kind = IRT_INT;
     ir.data.bits = bits;
-    ret intern_scalar(t, ir);
+    ret intern_inline(t, ir);
 }
 
 # interns a machine float of the given bit width.
@@ -227,7 +221,7 @@ pub fun intern_float(t: *IrTypeTable, bits: u32) Result[IrTypeId, str] {
     var ir: IrType;
     ir.kind = IRT_FLOAT;
     ir.data.bits = bits;
-    ret intern_scalar(t, ir);
+    ret intern_inline(t, ir);
 }
 
 # interns the untyped machine pointer type.
@@ -238,7 +232,7 @@ pub fun intern_ptr(t: *IrTypeTable) Result[IrTypeId, str] {
     var ir: IrType;
     ir.kind = IRT_PTR;
     ir.data.bits = 0;
-    ret intern_scalar(t, ir);
+    ret intern_inline(t, ir);
 }
 
 # interns a fixed-length array type.
@@ -248,18 +242,11 @@ pub fun intern_ptr(t: *IrTypeTable) Result[IrTypeId, str] {
 # count:   number of elements
 # ret:     the IrTypeId for [count]element, or an allocation error
 pub fun intern_array(t: *IrTypeTable, element: IrTypeId, count: u32) Result[IrTypeId, str] {
-    var i: u32 = 0;
-    for (i < t.len) {
-        val ex: *IrType = ?t.types[i];
-        if (ex.kind == IRT_ARRAY && ex.data.element == element && t.counts[i] == count) {
-            ret ok[IrTypeId, str](i);
-        }
-        i = i + 1;
-    }
     var ir: IrType;
     ir.kind = IRT_ARRAY;
-    ir.data.element = element;
-    ret append_with_count(t, ir, count);
+    ir.data.array_.element = element;
+    ir.data.array_.count   = count;
+    ret intern_inline(t, ir);
 }
 
 # interns a struct type. the field list is copied into table-owned storage.
@@ -308,7 +295,7 @@ fun intern_aggregate(t: *IrTypeTable, probe: IrType, fields: *IrTypeId, field_co
     }
     var ir: IrType = probe;
     ir.data.struct_.fields = unwrap_ok[*IrTypeId, str](owned);
-    val ap: Result[IrTypeId, str] = append_with_count(t, ir, 0);
+    val ap: Result[IrTypeId, str] = append_type(t, ir);
     if (is_err[IrTypeId, str](ap)) {
         deallocate[IrTypeId](t.alloc, ir.data.struct_.fields, field_count::usize);
         ret ap;
@@ -346,7 +333,7 @@ pub fun intern_fn(t: *IrTypeTable, ret_ty: IrTypeId, params: *IrTypeId, param_co
     }
     var ir: IrType = probe;
     ir.data.fn.params = unwrap_ok[*IrTypeId, str](owned);
-    val ap: Result[IrTypeId, str] = append_with_count(t, ir, 0);
+    val ap: Result[IrTypeId, str] = append_type(t, ir);
     if (is_err[IrTypeId, str](ap)) {
         deallocate[IrTypeId](t.alloc, ir.data.fn.params, param_count::usize);
         ret ap;
@@ -376,20 +363,24 @@ pub fun get(t: *IrTypeTable, id: IrTypeId) Option[*IrType] {
 # ret: the array length, or 0
 pub fun array_count(t: *IrTypeTable, id: IrTypeId) u32 {
     if (id >= t.len) { ret 0; }
-    ret t.counts[id];
+    val ir: *IrType = ?t.types[id];
+    if (ir.kind != IRT_ARRAY) { ret 0; }
+    ret ir.data.array_.count;
 }
 
 # returns the size in bytes of an IR type for the given target.
 # pointer size is taken from `tgt.arch.pointer_width`. aggregates use
 # natural C-style layout. a function type sizes as a pointer (a first-class
-# `fun(...)` value is a function pointer); out-of-range ids and IRT_VOID return 0.
+# `fun(...)` value is a function pointer); IRT_VOID is 0. an out-of-range id
+# is a stale handle the verifier's VC_TYPE_RESOLVE rules out, so it panics
+# rather than silently sizing to 0.
 # ---
 # t:   the table
 # id:  IrTypeId to measure
 # tgt: resolved compilation target supplying pointer width via its ISA
 # ret: size in bytes
 pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
-    if (id >= t.len) { ret 0; }
+    if (id >= t.len) { panic("ir.type.byte_size: type id out of range\n"); }
     val ir: *IrType = ?t.types[id];
     if (ir.kind == IRT_VOID) { ret 0; }
     if (ir.kind == IRT_INT)  { ret bits_to_bytes(ir.data.bits); }
@@ -399,7 +390,7 @@ pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
     # holding a callback), so it occupies one pointer of storage.
     if (ir.kind == IRT_FN)   { ret tgt.arch.pointer_width; }
     if (ir.kind == IRT_ARRAY) {
-        ret byte_size(t, ir.data.element, tgt) * t.counts[id];
+        ret byte_size(t, ir.data.array_.element, tgt) * ir.data.array_.count;
     }
     if (ir.kind == IRT_STRUCT) {
         var off:   u32 = 0;
@@ -436,21 +427,22 @@ pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
 # returns the alignment in bytes of an IR type for the given target.
 # pointer alignment equals pointer width (a function type aligns as a pointer).
 # struct alignment is the max of its field alignments (1 for an empty struct).
-# out-of-range ids and IRT_VOID return 1.
+# IRT_VOID aligns to 1. an out-of-range id is a stale handle the verifier's
+# VC_TYPE_RESOLVE rules out, so it panics rather than silently aligning to 1.
 # ---
 # t:   the table
 # id:  IrTypeId to measure
 # tgt: resolved compilation target supplying pointer width via its ISA
 # ret: alignment in bytes (always >= 1)
 pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
-    if (id >= t.len) { ret 1; }
+    if (id >= t.len) { panic("ir.type.byte_align: type id out of range\n"); }
     val ir: *IrType = ?t.types[id];
     if (ir.kind == IRT_INT)   { ret bits_to_bytes(ir.data.bits); }
     if (ir.kind == IRT_FLOAT) { ret bits_to_bytes(ir.data.bits); }
     if (ir.kind == IRT_PTR)   { ret tgt.arch.pointer_width; }
     # a function value is a function pointer; align like a pointer.
     if (ir.kind == IRT_FN)    { ret tgt.arch.pointer_width; }
-    if (ir.kind == IRT_ARRAY) { ret byte_align(t, ir.data.element, tgt); }
+    if (ir.kind == IRT_ARRAY) { ret byte_align(t, ir.data.array_.element, tgt); }
     if (ir.kind == IRT_STRUCT || ir.kind == IRT_UNION) {
         var align: u32 = 1;
         var i:     u32 = 0;
@@ -465,8 +457,10 @@ pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
 }
 
 # returns the byte offset of field `field_ix` within struct type `id`, using
-# the same natural C-style layout as byte_size. out-of-range struct ids or
-# field indices, and non-struct types, return 0.
+# the same natural C-style layout as byte_size. a union's members all overlap
+# at offset 0. an out-of-range id, a non-aggregate type, or a field index past
+# the struct's fields are all malformed inputs the front end and verifier rule
+# out, so each panics rather than silently landing on field 0.
 # ---
 # t:        the table
 # id:       the struct IrTypeId
@@ -474,11 +468,11 @@ pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
 # tgt:      resolved compilation target supplying pointer width via its ISA
 # ret:      byte offset of the field
 pub fun byte_offset(t: *IrTypeTable, id: IrTypeId, field_ix: u32, tgt: *target.Target) u32 {
-    if (id >= t.len) { ret 0; }
+    if (id >= t.len) { panic("ir.type.byte_offset: type id out of range\n"); }
     val ir: *IrType = ?t.types[id];
     # a union's members all overlap at offset 0.
     if (ir.kind == IRT_UNION) { ret 0; }
-    if (ir.kind != IRT_STRUCT) { ret 0; }
+    if (ir.kind != IRT_STRUCT) { panic("ir.type.byte_offset: field offset of a non-aggregate type\n"); }
     var off: u32 = 0;
     var i:   u32 = 0;
     for (i < ir.data.struct_.field_count) {
@@ -488,16 +482,19 @@ pub fun byte_offset(t: *IrTypeTable, id: IrTypeId, field_ix: u32, tgt: *target.T
         off = off + byte_size(t, fid, tgt);
         i = i + 1;
     }
+    panic("ir.type.byte_offset: field index out of range\n");
     ret 0;
 }
 
-# scalar (no owned payload) interning path with dedup map.
-fun intern_scalar(t: *IrTypeTable, ir: IrType) Result[IrTypeId, str] {
+# interning path through the dedup map for kinds whose IrType is a complete,
+# self-contained key — no externally-owned payload to copy (void/int/float/ptr
+# and arrays, whose element id and count both live inline in `data.array_`).
+fun intern_inline(t: *IrTypeTable, ir: IrType) Result[IrTypeId, str] {
     val cached: Result[*IrTypeId, str] = map.get[IrType, IrTypeId](?t.dedup, ?ir);
     if (is_ok[*IrTypeId, str](cached)) {
         ret ok[IrTypeId, str](@unwrap_ok[*IrTypeId, str](cached));
     }
-    val ap: Result[IrTypeId, str] = append_with_count(t, ir, 0);
+    val ap: Result[IrTypeId, str] = append_type(t, ir);
     if (is_err[IrTypeId, str](ap)) { ret ap; }
     val tid: IrTypeId = unwrap_ok[IrTypeId, str](ap);
     val ins: Result[bool, str] = map.insert[IrType, IrTypeId](?t.dedup, ir, tid);
@@ -505,21 +502,17 @@ fun intern_scalar(t: *IrTypeTable, ir: IrType) Result[IrTypeId, str] {
     ret ok[IrTypeId, str](tid);
 }
 
-# appends a type record plus its parallel array-count slot, growing both.
-fun append_with_count(t: *IrTypeTable, ir: IrType, count: u32) Result[IrTypeId, str] {
+# appends a type record to the universe, growing the array as needed.
+fun append_type(t: *IrTypeTable, ir: IrType) Result[IrTypeId, str] {
     if (t.len == t.cap) {
         val new_cap: u32 = t.cap * 2;
         val rt: Result[*IrType, str] = reallocate[IrType](t.alloc, t.types, t.cap::usize, new_cap::usize);
         if (is_err[*IrType, str](rt)) { ret err[IrTypeId, str](unwrap_err[*IrType, str](rt)); }
         t.types = unwrap_ok[*IrType, str](rt);
-        val rc: Result[*u32, str] = reallocate[u32](t.alloc, t.counts, t.cap::usize, new_cap::usize);
-        if (is_err[*u32, str](rc)) { ret err[IrTypeId, str](unwrap_err[*u32, str](rc)); }
-        t.counts = unwrap_ok[*u32, str](rc);
         t.cap = new_cap;
     }
     val tid: IrTypeId = t.len;
-    t.types[t.len]  = ir;
-    t.counts[t.len] = count;
+    t.types[t.len] = ir;
     t.len = t.len + 1;
     ret ok[IrTypeId, str](tid);
 }
@@ -594,19 +587,22 @@ fun bits_to_bytes(bits: u32) u32 {
     ret (bits + 7) / 8;
 }
 
-# structural FNV-1a hash over an IrType, covering every kind that reaches the
-# dedup map: scalars by their bits, structs/unions/functions by their full
+# structural FNV-1a hash over an IrType, covering every kind: scalars by their
+# bits, arrays by element id and count, structs/unions/functions by their full
 # payload (field/param type ids, return type, varargs). the payload pointers it
 # dereferences are the table-owned field/param arrays (stable for the table's
-# life). IRT_ARRAY is intentionally absent — an array's element count lives in
-# the table's parallel `counts` array, outside the IrType, so arrays cannot be
-# keyed by IrType and stay on the linear-scan path (never inserted here).
+# life); an array's element id and count both live inline in `data.array_`.
 fun hash_ir_type(p: ptr) u64 {
     val ir: *IrType = p::*IrType;
     var h: u64 = fnv1a.init();
     h = fnv1a.step_u8(h, ir.kind::u8);
     if (ir.kind == IRT_INT || ir.kind == IRT_FLOAT) {
         h = fnv1a.step_u32(h, ir.data.bits);
+        ret h;
+    }
+    if (ir.kind == IRT_ARRAY) {
+        h = fnv1a.step_u32(h, ir.data.array_.element);
+        h = fnv1a.step_u32(h, ir.data.array_.count);
         ret h;
     }
     if (ir.kind == IRT_STRUCT || ir.kind == IRT_UNION) {
@@ -633,15 +629,19 @@ fun hash_ir_type(p: ptr) u64 {
     ret h;
 }
 
-# structural equality matching hash_ir_type: scalars by bits, structs/unions by
-# field-id sequence, functions by return type, varargs, and param-id sequence.
-# IRT_VOID/IRT_PTR are equal by kind. arrays never enter the map (see hash).
+# structural equality matching hash_ir_type: scalars by bits, arrays by element
+# id and count, structs/unions by field-id sequence, functions by return type,
+# varargs, and param-id sequence. IRT_VOID/IRT_PTR are equal by kind.
 fun eq_ir_type(pa: ptr, pb: ptr) bool {
     val a: *IrType = pa::*IrType;
     val b: *IrType = pb::*IrType;
     if (a.kind != b.kind) { ret false; }
     if (a.kind == IRT_INT || a.kind == IRT_FLOAT) {
         ret a.data.bits == b.data.bits;
+    }
+    if (a.kind == IRT_ARRAY) {
+        ret a.data.array_.element == b.data.array_.element
+            && a.data.array_.count == b.data.array_.count;
     }
     if (a.kind == IRT_STRUCT || a.kind == IRT_UNION) {
         if (a.data.struct_.field_count != b.data.struct_.field_count) { ret false; }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -1568,10 +1568,10 @@ test "ir.verify: type resolution (repr) flags an unresolvable alloca element typ
 
     # well-formed: the element type resolves.
     if (t_count(?env, false, true, VC_TYPE_RESOLVE) != 0) { ret 1; }
-    # corrupt the element type (carried in ins.ty for alloca) to an out-of-range,
-    # non-sentinel id; check_aux_resolve must flag it.
+    # corrupt the element type (carried in ins.aux_ty for alloca) to an
+    # out-of-range, non-sentinel id; check_aux_resolve must flag it.
     val aid: id.InstructionId = av.data.instr;
-    env.m.functions[0].instrs[aid].ty = 0xFFFF::ir_type.IrTypeId;
+    env.m.functions[0].instrs[aid].aux_ty = 0xFFFF::ir_type.IrTypeId;
     if (t_count(?env, false, true, VC_TYPE_RESOLVE) < 1) { ret 1; }
     ret 0;
 }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -477,7 +477,7 @@ fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: 
 #   OP_GEP     aux_ty  the source pointee the index walk descends (when indexed)
 #   OP_MEMZERO aux_ty  the aggregate pointee whose byte_size sizes the fill
 #   OP_CALL    aux_ty  the stamped IRT_FN signature classifying the ABI
-#   OP_ALLOCA  ty      the allocated element type sizing the stack slot
+#   OP_ALLOCA  aux_ty  the allocated element type sizing the stack slot
 # a stale id silently classifies as scalar/size-8 (or zeroes nothing for
 # memzero) downstream, so an unresolvable aux type is a real miscompile.
 fun check_aux_resolve(m: *ir.Module, ins: *instr.Instruction, fi: u32, bid: id.BlockId, iid: id.InstructionId, r: *VerifyReport) Result[bool, str] {
@@ -485,7 +485,7 @@ fun check_aux_resolve(m: *ir.Module, ins: *instr.Instruction, fi: u32, bid: id.B
     if (ins.kind == instr.OP_GEP && ins.operand_count > 1) { ty = ins.aux_ty; }
     or (ins.kind == instr.OP_MEMZERO) { ty = ins.aux_ty; }
     or (ins.kind == instr.OP_CALL)    { ty = ins.aux_ty; }
-    or (ins.kind == instr.OP_ALLOCA)  { ty = ins.ty; }
+    or (ins.kind == instr.OP_ALLOCA)  { ty = ins.aux_ty; }
     or { ret ok[bool, str](true); }
 
     val at: Option[*ir_type.IrType] = ir_type.get(?m.types, ty);

--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -248,7 +248,7 @@ fun place_array(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId
     val t_opt: Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ity);
     if (is_none[*ir_type.IrType](t_opt)) { ret err[bool, str]("constagg: array leaf has unknown IR type"); }
     val t: *ir_type.IrType = unwrap[*ir_type.IrType](t_opt);
-    val ety: ir_type.IrTypeId = t.data.element;
+    val ety: ir_type.IrTypeId = t.data.array_.element;
     val stride: u32 = ir_type.byte_size(?ctx.m.types, ety, ctx.tgt);
     val cap: u32 = ir_type.array_count(?ctx.m.types, ity);
 

--- a/src/lang/me/pass/constfold.mach
+++ b/src/lang/me/pass/constfold.mach
@@ -629,7 +629,6 @@ fun build_const_phi(phi: *instr.Instruction, ops: *value.Value, vals: *value.Val
     phi.operands      = ops;
     phi.operand_count = n * 2;
     phi.operand_cap   = n * 2;
-    phi.block         = 0::id.BlockId;
     phi.flags         = 0;
     phi.aux_ty        = ir_type.IRT_NIL;
 }

--- a/src/lang/me/pass/cse.mach
+++ b/src/lang/me/pass/cse.mach
@@ -50,6 +50,7 @@ use instr: mach.lang.me.ir.instruction;
 use value: mach.lang.me.ir.value;
 use id:    mach.lang.me.ir.id;
 use float: mach.lang.float;
+use fnv1a: std.crypto.hash.fnv1a;
 
 # Pass entry. Runs local CSE on every non-extern function in the module.
 # ---
@@ -74,6 +75,12 @@ pub fun run(m: *ir.Module) Result[bool, str] {
 # instructions are visited in program order, and a candidate that matches an
 # earlier in-block candidate records a substitution. After every block the
 # substitutions are applied to every operand in the function.
+#
+# Candidates are matched through a per-block hash table (keyed by the structural
+# hash of opcode / flags / types / resolved operands) rather than a linear scan
+# of every prior candidate, so a block of n candidates costs O(n) rather than
+# O(n^2). The table chains collisions through `chain` and is invalidated between
+# blocks by bumping `epoch` instead of clearing it.
 fun cse_function(m: *ir.Module, fn: *ir.Function) Result[bool, str] {
     val ilen: u32 = fn.instr_len;
     if (ilen == 0) { ret ok[bool, str](true); }
@@ -89,41 +96,81 @@ fun cse_function(m: *ir.Module, fn: *ir.Function) Result[bool, str] {
     }
     val has_sub: *bool = unwrap_ok[*bool, str](rh);
 
-    # `seen` collects the canonical (kept) candidate instruction ids of the block
-    # currently being processed; it is reused per block.
-    val rw: Result[*id.InstructionId, str] = allocate[id.InstructionId](m.alloc, ilen::usize);
-    if (is_err[*id.InstructionId, str](rw)) {
+    # hash table sized to a power of two >= ilen: `bucket[idx]` heads a chain of
+    # candidate ids (linked through `chain`) that hashed to `idx`, valid only
+    # while `bucket_epoch[idx]` equals the block's current `epoch`.
+    val tsize: u32 = round_pow2(ilen);
+    val rb: Result[*id.InstructionId, str] = allocate[id.InstructionId](m.alloc, tsize::usize);
+    if (is_err[*id.InstructionId, str](rb)) {
         deallocate[value.Value](m.alloc, subst, ilen::usize);
         deallocate[bool](m.alloc, has_sub, ilen::usize);
-        ret err[bool, str](unwrap_err[*id.InstructionId, str](rw));
+        ret err[bool, str](unwrap_err[*id.InstructionId, str](rb));
     }
-    val seen: *id.InstructionId = unwrap_ok[*id.InstructionId, str](rw);
+    val bucket: *id.InstructionId = unwrap_ok[*id.InstructionId, str](rb);
+
+    val re: Result[*u32, str] = allocate[u32](m.alloc, tsize::usize);
+    if (is_err[*u32, str](re)) {
+        deallocate[value.Value](m.alloc, subst, ilen::usize);
+        deallocate[bool](m.alloc, has_sub, ilen::usize);
+        deallocate[id.InstructionId](m.alloc, bucket, tsize::usize);
+        ret err[bool, str](unwrap_err[*u32, str](re));
+    }
+    val bucket_epoch: *u32 = unwrap_ok[*u32, str](re);
+
+    val rc: Result[*id.InstructionId, str] = allocate[id.InstructionId](m.alloc, ilen::usize);
+    if (is_err[*id.InstructionId, str](rc)) {
+        deallocate[value.Value](m.alloc, subst, ilen::usize);
+        deallocate[bool](m.alloc, has_sub, ilen::usize);
+        deallocate[id.InstructionId](m.alloc, bucket, tsize::usize);
+        deallocate[u32](m.alloc, bucket_epoch, tsize::usize);
+        ret err[bool, str](unwrap_err[*id.InstructionId, str](rc));
+    }
+    val chain: *id.InstructionId = unwrap_ok[*id.InstructionId, str](rc);
 
     var i: u32 = 0;
     for (i < ilen) { has_sub[i] = false; i = i + 1; }
+    var j: u32 = 0;
+    for (j < tsize) { bucket_epoch[j] = 0; j = j + 1; }
 
+    val mask: u32 = tsize - 1;
     var any: bool = false;
+    var epoch: u32 = 0;
     var b: u32 = 0;
     for (b < fn.block_count) {
-        if (cse_block(m, fn, ?fn.blocks[b], subst, has_sub, ilen, seen)) { any = true; }
+        epoch = epoch + 1;
+        if (cse_block(m, fn, ?fn.blocks[b], subst, has_sub, ilen,
+                      bucket, bucket_epoch, chain, mask, epoch)) { any = true; }
         b = b + 1;
     }
     if (any) { apply_substitutions(fn, subst, has_sub, ilen); }
 
     deallocate[value.Value](m.alloc, subst, ilen::usize);
     deallocate[bool](m.alloc, has_sub, ilen::usize);
-    deallocate[id.InstructionId](m.alloc, seen, ilen::usize);
+    deallocate[id.InstructionId](m.alloc, bucket, tsize::usize);
+    deallocate[u32](m.alloc, bucket_epoch, tsize::usize);
+    deallocate[id.InstructionId](m.alloc, chain, ilen::usize);
     ret ok[bool, str](true);
+}
+
+# smallest power of two >= n (at least 1). sizes the per-block hash table.
+fun round_pow2(n: u32) u32 {
+    var p: u32 = 1;
+    for (p < n) { p = p * 2; }
+    ret p;
 }
 
 # processes one block: walks its instruction list in order, and for each pure
 # candidate either matches it against an already-seen canonical candidate (and
 # records a substitution to that candidate's result) or records it as a new
-# canonical candidate. Returns true if any substitution was recorded.
+# canonical candidate. Matching goes through the per-block hash table: a
+# candidate's structural hash selects a bucket whose (short) chain of distinct
+# canonicals is checked for an exact match. Returns true if any substitution was
+# recorded.
 fun cse_block(m: *ir.Module, fn: *ir.Function, blk: *ir.Block,
-              subst: *value.Value, has_sub: *bool, ilen: u32, seen: *id.InstructionId) bool {
+              subst: *value.Value, has_sub: *bool, ilen: u32,
+              bucket: *id.InstructionId, bucket_epoch: *u32, chain: *id.InstructionId,
+              mask: u32, epoch: u32) bool {
     var any: bool = false;
-    var seen_count: u32 = 0;
     var ix: u32 = 0;
     for (ix < blk.instr_count) {
         val iid: id.InstructionId = blk.instructions[ix];
@@ -131,33 +178,79 @@ fun cse_block(m: *ir.Module, fn: *ir.Function, blk: *ir.Block,
         if (is_some[*instr.Instruction](inst_opt)) {
             val inst: *instr.Instruction = unwrap[*instr.Instruction](inst_opt);
             if (is_candidate(inst)) {
-                # search the canonical candidates already seen in this block.
+                val h: u64 = hash_candidate(inst, subst, has_sub, ilen);
+                val idx: u32 = (h::u32) & mask;
                 var matched: bool = false;
-                var s: u32 = 0;
-                for (s < seen_count && matched == false) {
-                    val cid: id.InstructionId = seen[s];
-                    val cand_opt: Option[*instr.Instruction] = ir.get_instruction(fn, cid);
-                    if (is_some[*instr.Instruction](cand_opt)) {
-                        val cand: *instr.Instruction = unwrap[*instr.Instruction](cand_opt);
-                        if (instrs_equal(inst, cand, subst, has_sub, ilen)) {
-                            # redundant: reuse the canonical candidate's result.
-                            subst[iid::u32]   = value.instr_value(cid, inst.ty);
-                            has_sub[iid::u32] = true;
-                            matched           = true;
-                            any               = true;
+                # walk the bucket chain, but only if it belongs to this block.
+                if (bucket_epoch[idx] == epoch) {
+                    var cur: id.InstructionId = bucket[idx];
+                    for (cur != id.INSTR_NIL && matched == false) {
+                        val cand_opt: Option[*instr.Instruction] = ir.get_instruction(fn, cur);
+                        if (is_some[*instr.Instruction](cand_opt)) {
+                            val cand: *instr.Instruction = unwrap[*instr.Instruction](cand_opt);
+                            if (instrs_equal(inst, cand, subst, has_sub, ilen)) {
+                                # redundant: reuse the canonical candidate's result.
+                                subst[iid::u32]   = value.instr_value(cur, inst.ty);
+                                has_sub[iid::u32] = true;
+                                matched           = true;
+                                any               = true;
+                            }
                         }
+                        cur = chain[cur::u32];
                     }
-                    s = s + 1;
                 }
                 if (matched == false) {
-                    seen[seen_count] = iid;
-                    seen_count       = seen_count + 1;
+                    # prepend this candidate as a new canonical in its bucket.
+                    if (bucket_epoch[idx] == epoch) { chain[iid::u32] = bucket[idx]; }
+                    or { chain[iid::u32] = id.INSTR_NIL; }
+                    bucket[idx]       = iid;
+                    bucket_epoch[idx] = epoch;
                 }
             }
         }
         ix = ix + 1;
     }
     ret any;
+}
+
+# structural hash of a candidate matching instrs_equal: opcode, flag word,
+# result type, auxiliary type, operand count, and every operand resolved through
+# the substitution table. Two candidates instrs_equal therefore hash alike.
+fun hash_candidate(inst: *instr.Instruction, subst: *value.Value, has_sub: *bool, ilen: u32) u64 {
+    var h: u64 = fnv1a.init();
+    h = fnv1a.step_u8(h, inst.kind::u8);
+    h = fnv1a.step_u32(h, inst.flags::u32);
+    h = fnv1a.step_u32(h, inst.ty::u32);
+    h = fnv1a.step_u32(h, inst.aux_ty::u32);
+    h = fnv1a.step_u32(h, inst.operand_count);
+    var o: u32 = 0;
+    for (o < inst.operand_count) {
+        h = hash_value(h, resolve(inst.operands[o], subst, has_sub, ilen));
+        o = o + 1;
+    }
+    ret h;
+}
+
+# folds a resolved operand value into the running hash by the same identity
+# values_equal compares: kind plus the kind's payload (instruction id, parameter
+# index, integer / float bits, global / function index). VAL_CONST_NULL hashes by
+# kind alone; byte-blob / aggregate constants (which values_equal never treats as
+# equal) hash by kind alone too, so they share a bucket but never match.
+fun hash_value(h: u64, v: value.Value) u64 {
+    var hv: u64 = fnv1a.step_u8(h, v.kind::u8);
+    if (v.kind == value.VAL_INSTR)       { ret fnv1a.step_u32(hv, v.data.instr::u32); }
+    if (v.kind == value.VAL_PARAM)       { ret fnv1a.step_u32(hv, v.data.param_ix); }
+    if (v.kind == value.VAL_CONST_INT)   { ret step_u64(hv, v.data.int_lit); }
+    if (v.kind == value.VAL_CONST_FLOAT) { ret step_u64(hv, float.f64_bits(v.data.float_lit)); }
+    if (v.kind == value.VAL_GLOBAL)      { ret fnv1a.step_u32(hv, v.data.global_ix); }
+    if (v.kind == value.VAL_FN)          { ret fnv1a.step_u32(hv, v.data.fn_ix); }
+    ret hv;
+}
+
+# folds a 64-bit value into the hash as its low then high 32-bit halves
+# (fnv1a exposes only 8- and 32-bit steps).
+fun step_u64(h: u64, v: u64) u64 {
+    ret fnv1a.step_u32(fnv1a.step_u32(h, v::u32), (v >> 32)::u32);
 }
 
 # true when an instruction is a CSE candidate: a pure, value-producing opcode

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -465,7 +465,6 @@ fun clone_instructions(cx: *InlineCtx) Result[bool, str] {
         clone.operand_count = src.operand_count;
         clone.flags         = src.flags;
         clone.aux_ty        = src.aux_ty;        # preserve GEP source pointee type
-        clone.block         = id.BLOCK_NIL;      # set during populate_blocks
         clone.operands      = nil;
         if (src.operand_count > 0) {
             val ro: Result[*value.Value, str] = allocate[value.Value](m.alloc, src.operand_count::usize);
@@ -488,7 +487,7 @@ fun clone_instructions(cx: *InlineCtx) Result[bool, str] {
 
 # fills each cloned caller block's phi/instruction/terminator/pred lists by
 # mapping the corresponding callee block's lists through instr_map and
-# block_map, and sets each cloned instruction's owning block.
+# block_map.
 fun populate_blocks(cx: *InlineCtx) Result[bool, str] {
     val m: *ir.Module = cx.m;
     val callee: *ir.Function = cx.callee;
@@ -501,7 +500,6 @@ fun populate_blocks(cx: *InlineCtx) Result[bool, str] {
         var p: u32 = 0;
         for (p < src.phi_count) {
             val new_iid: id.InstructionId = cx.instr_map[src.phis[p]::u32]::id.InstructionId;
-            set_instr_block(cx.caller, new_iid, dst_id);
             val r: Result[bool, str] = ir.block_append_phi(m, dst, new_iid);
             if (is_err[bool, str](r)) { ret r; }
             p = p + 1;
@@ -509,14 +507,12 @@ fun populate_blocks(cx: *InlineCtx) Result[bool, str] {
         var ii: u32 = 0;
         for (ii < src.instr_count) {
             val new_iid: id.InstructionId = cx.instr_map[src.instructions[ii]::u32]::id.InstructionId;
-            set_instr_block(cx.caller, new_iid, dst_id);
             val r: Result[bool, str] = ir.block_append_instr(m, dst, new_iid);
             if (is_err[bool, str](r)) { ret r; }
             ii = ii + 1;
         }
         if (src.terminator != id.INSTR_NIL) {
             val new_term: id.InstructionId = cx.instr_map[src.terminator::u32]::id.InstructionId;
-            set_instr_block(cx.caller, new_term, dst_id);
             dst.terminator = new_term;
         }
         # predecessor lists are rebuilt wholesale from terminator edges once all
@@ -524,15 +520,6 @@ fun populate_blocks(cx: *InlineCtx) Result[bool, str] {
         cb = cb + 1;
     }
     ret ok[bool, str](true);
-}
-
-# sets the owning block field of a cloned instruction.
-fun set_instr_block(caller: *ir.Function, iid: id.InstructionId, blk: id.BlockId) {
-    val opt: Option[*instr.Instruction] = ir.get_instruction(caller, iid);
-    if (is_some[*instr.Instruction](opt)) {
-        val inst: *instr.Instruction = unwrap[*instr.Instruction](opt);
-        inst.block = blk;
-    }
 }
 
 # rewrites operands of every cloned instruction: VAL_PARAM -> the matching
@@ -597,16 +584,12 @@ fun split_call_block(cx: *InlineCtx, call_bi: u32, call_ii: u32) Result[bool, st
     var ii: u32 = call_ii + 1;
     for (ii < blk.instr_count) {
         val mv: id.InstructionId = blk.instructions[ii];
-        set_instr_block(caller, mv, cx.cont_blk);
         val r: Result[bool, str] = ir.block_append_instr(m, cont, mv);
         if (is_err[bool, str](r)) { ret r; }
         ii = ii + 1;
     }
     # the original terminator becomes the continuation's terminator.
     cont.terminator = blk.terminator;
-    if (cont.terminator != id.INSTR_NIL) {
-        set_instr_block(caller, cont.terminator, cx.cont_blk);
-    }
 
     # the continuation inherits the call block's outgoing edges, so every
     # successor of the moved terminator now reaches that edge from `cont`, not
@@ -619,7 +602,7 @@ fun split_call_block(cx: *InlineCtx, call_bi: u32, call_ii: u32) Result[bool, st
     blk.instr_count = call_ii;
 
     # the call block now branches unconditionally to the cloned callee entry.
-    val rbr: Result[id.InstructionId, str] = emit_br(cx, call_bi::id.BlockId, cx.entry_blk);
+    val rbr: Result[id.InstructionId, str] = emit_br(cx, cx.entry_blk);
     if (is_err[id.InstructionId, str](rbr)) { ret err[bool, str](unwrap_err[id.InstructionId, str](rbr)); }
     blk.terminator = unwrap_ok[id.InstructionId, str](rbr);
 
@@ -664,10 +647,10 @@ fun rekey_block_phis(caller: *ir.Function, bid: id.BlockId, old_blk: id.BlockId,
     }
 }
 
-# emits a fresh OP_BR terminator (in block `in_blk`) targeting `target` and
-# returns the new instruction id. Predecessor edges are restored later by the
-# wholesale ir.rebuild_preds.
-fun emit_br(cx: *InlineCtx, in_blk: id.BlockId, target: id.BlockId) Result[id.InstructionId, str] {
+# emits a fresh OP_BR terminator targeting `target` and returns the new
+# instruction id. Predecessor edges are restored later by the wholesale
+# ir.rebuild_preds.
+fun emit_br(cx: *InlineCtx, target: id.BlockId) Result[id.InstructionId, str] {
     val m: *ir.Module = cx.m;
     val rbt: Result[value.Value, str] = ir.make_block_target(m, target);
     if (is_err[value.Value, str](rbt)) { ret err[id.InstructionId, str](unwrap_err[value.Value, str](rbt)); }
@@ -685,7 +668,6 @@ fun emit_br(cx: *InlineCtx, in_blk: id.BlockId, target: id.BlockId) Result[id.In
     br.ty            = unwrap_ok[ir_type.IrTypeId, str](rvt);
     br.operands      = ops;
     br.operand_count = 1;
-    br.block         = in_blk;
     br.flags         = 0;
     br.aux_ty        = ir_type.IRT_NIL;
     val rid: Result[id.InstructionId, str] = ir.add_instruction(m, cx.caller, br);
@@ -721,7 +703,6 @@ fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) Result[bool, str] 
         phi.ty            = cx.ret_ty;
         phi.operands      = nil;
         phi.operand_count = 0;
-        phi.block         = cx.cont_blk;
         phi.flags         = 0;
         phi.aux_ty        = ir_type.IRT_NIL;
         val rp: Result[id.InstructionId, str] = ir.add_instruction(m, caller, phi);

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -11,11 +11,10 @@
 # an incoming predecessor is re-keyed to the continuation block.
 #
 # The inliner deliberately produces mechanical, un-cleaned output — the release
-# pipeline runs a late constfold / algebraic / cse / constfold / dce sweep
-# afterward to tidy it. mem2reg runs ONCE, before inline, and is not re-run, so a
-# caller alloca whose address only stops escaping after a callee is inlined is not
-# re-promoted (tracked as a known gap). Recursive functions and calls reaching
-# through inline asm are never inlined.
+# pipeline re-runs mem2reg immediately afterward (so a caller alloca whose
+# address only stops escaping once a callee is inlined gets promoted to SSA),
+# then a late constfold / algebraic / cse / constfold / dce sweep to tidy it.
+# Recursive functions and calls reaching through inline asm are never inlined.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -54,83 +53,100 @@ val INLINE_INSTR_THRESHOLD: u32 = 25;
 # unforeseen runaway, not as the termination mechanism.
 val INLINE_BUDGET: u32 = 1024;
 
-# Pass entry. Repeatedly inlines the first eligible call site found anywhere in
-# the module until none remain or the budget is exhausted.
+# Pass entry. Inlines eligible call sites until none remain or the budget is
+# exhausted. Functions are processed in index order, each driven to a local
+# fixpoint before moving on: inlining a call site only ever mutates the caller
+# (the callee body is cloned into it), so an exhausted earlier function never
+# regains an eligible site. That makes the left-to-right walk equivalent to
+# repeatedly restarting a whole-module scan from function 0, but without the
+# per-inline cross-function rescan.
 # ---
 # m:   module to mutate
 # tgt: target — reserved for target-derived cost-model parameters
 # ret: ok(true) after a full pass, or the first allocation error
 pub fun run(m: *ir.Module, tgt: *target.Target) Result[bool, str] {
+    if (m.function_len == 0) { ret ok[bool, str](true); }
+
     # mark the recursion-cycle members once on the original call graph; they are
     # never inlined (see should_inline). function_len does not change during the
     # pass — inlining never adds functions — so this marking stays valid.
-    var recursive: *bool = nil;
-    if (m.function_len > 0) {
-        val rr: Result[*bool, str] = allocate[bool](m.alloc, m.function_len::usize);
-        if (is_err[*bool, str](rr)) { ret err[bool, str](unwrap_err[*bool, str](rr)); }
-        recursive = unwrap_ok[*bool, str](rr);
-        val rm: Result[bool, str] = mark_recursive(m, recursive);
-        if (is_err[bool, str](rm)) {
-            deallocate[bool](m.alloc, recursive, m.function_len::usize);
-            ret rm;
-        }
+    val rr: Result[*bool, str] = allocate[bool](m.alloc, m.function_len::usize);
+    if (is_err[*bool, str](rr)) { ret err[bool, str](unwrap_err[*bool, str](rr)); }
+    val recursive: *bool = unwrap_ok[*bool, str](rr);
+    val rm: Result[bool, str] = mark_recursive(m, recursive);
+    if (is_err[bool, str](rm)) {
+        deallocate[bool](m.alloc, recursive, m.function_len::usize);
+        ret rm;
     }
+
+    # per-callee live direct-call count, built once and maintained incrementally
+    # by do_inline — so the single-use test in should_inline is an O(1) lookup
+    # rather than a full-module scan per candidate.
+    val rc: Result[*u32, str] = allocate[u32](m.alloc, m.function_len::usize);
+    if (is_err[*u32, str](rc)) {
+        deallocate[bool](m.alloc, recursive, m.function_len::usize);
+        ret err[bool, str](unwrap_err[*u32, str](rc));
+    }
+    val counts: *u32 = unwrap_ok[*u32, str](rc);
+    build_call_counts(m, counts);
 
     var budget: u32 = INLINE_BUDGET;
-    var progress: bool = true;
-    for (progress && budget > 0) {
-        progress = false;
-        val r: Result[bool, str] = inline_one(m, recursive, ?progress);
-        if (is_err[bool, str](r)) {
-            if (recursive != nil) { deallocate[bool](m.alloc, recursive, m.function_len::usize); }
-            ret r;
-        }
-        if (progress) { budget = budget - 1; }
-    }
-
-    if (recursive != nil) { deallocate[bool](m.alloc, recursive, m.function_len::usize); }
-    ret ok[bool, str](true);
-}
-
-# scans the module for the first eligible call site and inlines it. sets
-# `did` to true when an inline happened. returns ok(false-in-did) when no
-# eligible site remains. `recursive` flags the call-graph cycle members that
-# must never be inlined.
-fun inline_one(m: *ir.Module, recursive: *bool, did: *bool) Result[bool, str] {
-    @did = false;
     var fi: u32 = 0;
-    for (fi < m.function_len) {
+    for (fi < m.function_len && budget > 0) {
         val caller: *ir.Function = ?m.functions[fi];
         if ((caller.flags & ir.FN_FLAG_EXTERN) == 0) {
-            var bi: u32 = 0;
-            for (bi < caller.block_count) {
-                val blk: *ir.Block = ?caller.blocks[bi];
-                var ii: u32 = 0;
-                for (ii < blk.instr_count) {
-                    val iid: id.InstructionId = blk.instructions[ii];
-                    val inst_opt: Option[*instr.Instruction] = ir.get_instruction(caller, iid);
-                    if (is_some[*instr.Instruction](inst_opt)) {
-                        val inst: *instr.Instruction = unwrap[*instr.Instruction](inst_opt);
-                        if (inst.kind == instr.OP_CALL && inst.operand_count >= 1) {
-                            val callee_ix: u32 = callee_index(inst);
-                            if (callee_ix != 0xFFFFFFFF && callee_ix < m.function_len) {
-                                val callee: *ir.Function = ?m.functions[callee_ix];
-                                if (should_inline(m, recursive, fi, callee_ix, caller, callee)) {
-                                    val r: Result[bool, str] =
-                                        do_inline(m, caller, bi, ii, iid, callee_ix, callee);
-                                    if (is_err[bool, str](r)) { ret r; }
-                                    @did = true;
-                                    ret ok[bool, str](true);
-                                }
-                            }
-                        }
-                    }
-                    ii = ii + 1;
+            var progress: bool = true;
+            for (progress && budget > 0) {
+                progress = false;
+                val r: Result[bool, str] = inline_one_in_fn(m, recursive, counts, fi, caller, ?progress);
+                if (is_err[bool, str](r)) {
+                    deallocate[u32](m.alloc, counts, m.function_len::usize);
+                    deallocate[bool](m.alloc, recursive, m.function_len::usize);
+                    ret r;
                 }
-                bi = bi + 1;
+                if (progress) { budget = budget - 1; }
             }
         }
         fi = fi + 1;
+    }
+
+    deallocate[u32](m.alloc, counts, m.function_len::usize);
+    deallocate[bool](m.alloc, recursive, m.function_len::usize);
+    ret ok[bool, str](true);
+}
+
+# scans one function for the first eligible call site and inlines it. sets
+# `did` to true when an inline happened. returns ok(false-in-did) when the
+# function has no eligible site left. `recursive` flags the call-graph cycle
+# members that must never be inlined; `counts` is the live per-callee call count.
+fun inline_one_in_fn(m: *ir.Module, recursive: *bool, counts: *u32, fi: u32, caller: *ir.Function, did: *bool) Result[bool, str] {
+    @did = false;
+    var bi: u32 = 0;
+    for (bi < caller.block_count) {
+        val blk: *ir.Block = ?caller.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val iid: id.InstructionId = blk.instructions[ii];
+            val inst_opt: Option[*instr.Instruction] = ir.get_instruction(caller, iid);
+            if (is_some[*instr.Instruction](inst_opt)) {
+                val inst: *instr.Instruction = unwrap[*instr.Instruction](inst_opt);
+                if (inst.kind == instr.OP_CALL && inst.operand_count >= 1) {
+                    val callee_ix: u32 = callee_index(inst);
+                    if (callee_ix != 0xFFFFFFFF && callee_ix < m.function_len) {
+                        val callee: *ir.Function = ?m.functions[callee_ix];
+                        if (should_inline(m, recursive, counts, fi, callee_ix, caller, callee)) {
+                            val r: Result[bool, str] =
+                                do_inline(m, counts, caller, bi, ii, iid, callee_ix, callee);
+                            if (is_err[bool, str](r)) { ret r; }
+                            @did = true;
+                            ret ok[bool, str](true);
+                        }
+                    }
+                }
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
     }
     ret ok[bool, str](true);
 }
@@ -152,7 +168,7 @@ fun callee_index(call: *instr.Instruction) u32 {
 # A recursion-cycle member (`recursive[callee_ix]`) is never inlined — direct or
 # mutual; inlining one re-introduces a call into the cycle every iteration, so
 # the budget would be the only thing stopping the loop.
-fun should_inline(m: *ir.Module, recursive: *bool, caller_ix: u32, callee_ix: u32, caller: *ir.Function, callee: *ir.Function) bool {
+fun should_inline(m: *ir.Module, recursive: *bool, counts: *u32, caller_ix: u32, callee_ix: u32, caller: *ir.Function, callee: *ir.Function) bool {
     if ((callee.flags & ir.FN_FLAG_EXTERN) != 0) { ret false; }
     if (recursive[callee_ix]) { ret false; }         # direct or mutual recursion
     if (callee.block_count == 0) { ret false; }      # no body to inline
@@ -160,7 +176,7 @@ fun should_inline(m: *ir.Module, recursive: *bool, caller_ix: u32, callee_ix: u3
     if (callee_is_variadic(m, callee)) { ret false; } # variadic body is not inlinable
     if ((callee.flags & ir.FN_FLAG_INLINE) != 0) { ret true; }
     if (callee_instr_count(callee) < INLINE_INSTR_THRESHOLD) { ret true; }
-    if (call_count(m, callee_ix) == 1) { ret true; }
+    if (counts[callee_ix] == 1) { ret true; }
     ret false;
 }
 
@@ -204,33 +220,41 @@ fun callee_instr_count(callee: *ir.Function) u32 {
     ret total;
 }
 
-# counts live direct (VAL_FN) call sites of function `callee_ix` across the
-# module. Only calls still listed in a block's instruction stream count — calls
-# orphaned by a prior inline (left in the pool but unlinked) are ignored.
-fun call_count(m: *ir.Module, callee_ix: u32) u32 {
-    var total: u32 = 0;
+# fills `counts[callee] = number of live direct (VAL_FN) call sites of that
+# function across the module`, in one pass. Only calls still listed in a block's
+# instruction stream count — calls orphaned by a prior inline (left in the pool
+# but unlinked) are ignored, mirroring the block-list-as-liveness convention.
+fun build_call_counts(m: *ir.Module, counts: *u32) {
+    var i: u32 = 0;
+    for (i < m.function_len) { counts[i] = 0; i = i + 1; }
     var fi: u32 = 0;
     for (fi < m.function_len) {
-        val fn: *ir.Function = ?m.functions[fi];
-        var b: u32 = 0;
-        for (b < fn.block_count) {
-            val blk: *ir.Block = ?fn.blocks[b];
-            var ii: u32 = 0;
-            for (ii < blk.instr_count) {
-                val opt: Option[*instr.Instruction] = ir.get_instruction(fn, blk.instructions[ii]);
-                if (is_some[*instr.Instruction](opt)) {
-                    val inst: *instr.Instruction = unwrap[*instr.Instruction](opt);
-                    if (inst.kind == instr.OP_CALL && inst.operand_count >= 1) {
-                        if (callee_index(inst) == callee_ix) { total = total + 1; }
-                    }
-                }
-                ii = ii + 1;
-            }
-            b = b + 1;
-        }
+        add_fn_call_counts(m, ?m.functions[fi], counts);
         fi = fi + 1;
     }
-    ret total;
+}
+
+# adds every live direct call site in `fn` to the per-callee `counts` table.
+# used both to seed the table and, after an inline clones a callee body into a
+# caller, to fold the freshly cloned calls into the live counts.
+fun add_fn_call_counts(m: *ir.Module, fn: *ir.Function, counts: *u32) {
+    var b: u32 = 0;
+    for (b < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[b];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val opt: Option[*instr.Instruction] = ir.get_instruction(fn, blk.instructions[ii]);
+            if (is_some[*instr.Instruction](opt)) {
+                val inst: *instr.Instruction = unwrap[*instr.Instruction](opt);
+                if (inst.kind == instr.OP_CALL && inst.operand_count >= 1) {
+                    val c: u32 = callee_index(inst);
+                    if (c != 0xFFFFFFFF && c < m.function_len) { counts[c] = counts[c] + 1; }
+                }
+            }
+            ii = ii + 1;
+        }
+        b = b + 1;
+    }
 }
 
 # marks every function that lies on a recursion cycle (it can transitively reach
@@ -282,8 +306,8 @@ fun reaches_self(m: *ir.Module, start: u32, visited: *bool, queue: *u32, n: u32)
 
 # scans function `fn_ix`'s live call sites; for each direct callee c, returns
 # true when c == target (the cycle is closed) and otherwise enqueues c the first
-# time it is seen. Mirrors call_count's live-only view — pool entries orphaned by
-# a prior inline are not edges.
+# time it is seen. Considers only calls live in a block's instruction stream —
+# pool entries orphaned by a prior inline are not edges.
 fun scan_callees(m: *ir.Module, fn_ix: u32, target: u32, visited: *bool, queue: *u32, qt: *u32) bool {
     val fn: *ir.Function = ?m.functions[fn_ix];
     var b: u32 = 0;
@@ -340,9 +364,12 @@ rec InlineCtx {
 }
 
 # performs one inline: split the call block, clone the callee, wire returns into
-# a continuation phi, and replace the call result.
+# a continuation phi, and replace the call result. On success it keeps `counts`
+# in step with the mutation: the inlined call is gone (one fewer live call to
+# `callee_ix`) and the cloned callee body adds its own live calls to the caller.
 fun do_inline(
     m: *ir.Module,
+    counts: *u32,
     caller: *ir.Function,
     call_bi: u32,
     call_ii: u32,
@@ -385,6 +412,14 @@ fun do_inline(
     if (cx.block_map != nil) { deallocate[u32](m.alloc, cx.block_map, callee.block_count::usize); }
     if (cx.instr_map != nil) { deallocate[u32](m.alloc, cx.instr_map, callee.instr_len::usize); }
     if (args != nil) { deallocate[value.Value](m.alloc, args, arg_count::usize); }
+
+    # maintain the live call-count table: the inlined call no longer exists (it
+    # was a live call to callee_ix, so the count is at least 1), and the cloned
+    # callee body's own live calls now live in the caller.
+    if (!is_err[bool, str](r)) {
+        counts[callee_ix] = counts[callee_ix] - 1;
+        add_fn_call_counts(m, callee, counts);
+    }
     ret r;
 }
 

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -800,52 +800,32 @@ fun count_value_returns(cx: *InlineCtx, returns_value: bool) u32 {
     ret n;
 }
 
-# converts a cloned OP_RET into an OP_BR to the continuation block. The ret's
-# operands are released and replaced; predecessor edges are restored later by
+# converts a cloned OP_RET into an OP_BR to the continuation block. The old
+# operands are released by their true capacity and replaced through the single
+# ir.instr_replace_operands primitive; predecessor edges are restored later by
 # the wholesale ir.rebuild_preds.
 fun convert_ret_to_br(cx: *InlineCtx, term: *instr.Instruction) Result[bool, str] {
     val m: *ir.Module = cx.m;
     val rbt: Result[value.Value, str] = ir.make_block_target(m, cx.cont_blk);
     if (is_err[value.Value, str](rbt)) { ret err[bool, str](unwrap_err[value.Value, str](rbt)); }
-    if (term.operands != nil && term.operand_count > 0) {
-        deallocate[value.Value](m.alloc, term.operands, term.operand_count::usize);
-    }
     val rvt: Result[ir_type.IrTypeId, str] = void_ty(m);
     if (is_err[ir_type.IrTypeId, str](rvt)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](rvt)); }
     val ro: Result[*value.Value, str] = allocate[value.Value](m.alloc, 1::usize);
     if (is_err[*value.Value, str](ro)) { ret err[bool, str](unwrap_err[*value.Value, str](ro)); }
     val ops: *value.Value = unwrap_ok[*value.Value, str](ro);
     ops[0] = unwrap_ok[value.Value, str](rbt);
-    term.kind          = instr.OP_BR;
-    term.ty            = unwrap_ok[ir_type.IrTypeId, str](rvt);
-    term.operands      = ops;
-    term.operand_count = 1;
+    term.kind = instr.OP_BR;
+    term.ty   = unwrap_ok[ir_type.IrTypeId, str](rvt);
+    ir.instr_replace_operands(m, term, ops, 1);
     ret ok[bool, str](true);
 }
 
-# appends a (predecessor-block, value) pair to a phi's operand list.
+# appends a (predecessor-block, value) pair to a phi's operand list through the
+# single capacity-maintaining ir.phi_append_incoming primitive.
 fun phi_append(cx: *InlineCtx, phi_id: id.InstructionId, pred: id.BlockId, v: value.Value) Result[bool, str] {
-    val m: *ir.Module = cx.m;
-    val rbt: Result[value.Value, str] = ir.make_block_target(m, pred);
-    if (is_err[value.Value, str](rbt)) { ret err[bool, str](unwrap_err[value.Value, str](rbt)); }
     val opt: Option[*instr.Instruction] = ir.get_instruction(cx.caller, phi_id);
     if (is_none[*instr.Instruction](opt)) { ret err[bool, str]("inline: phi id out of range"); }
-    val phi: *instr.Instruction = unwrap[*instr.Instruction](opt);
-    val old_n: u32 = phi.operand_count;
-    val new_n: u32 = old_n + 2;
-    val rn: Result[*value.Value, str] = allocate[value.Value](m.alloc, new_n::usize);
-    if (is_err[*value.Value, str](rn)) { ret err[bool, str](unwrap_err[*value.Value, str](rn)); }
-    val ops: *value.Value = unwrap_ok[*value.Value, str](rn);
-    var k: u32 = 0;
-    for (k < old_n) { ops[k] = phi.operands[k]; k = k + 1; }
-    ops[old_n]     = unwrap_ok[value.Value, str](rbt);
-    ops[old_n + 1] = v;
-    if (phi.operands != nil && old_n > 0) {
-        deallocate[value.Value](m.alloc, phi.operands, old_n::usize);
-    }
-    phi.operands      = ops;
-    phi.operand_count = new_n;
-    ret ok[bool, str](true);
+    ret ir.phi_append_incoming(cx.m, unwrap[*instr.Instruction](opt), pred, v);
 }
 
 # replaces every VAL_INSTR operand naming `old_id` with `replacement` across all

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -1077,30 +1077,10 @@ fun add_phi_incomings(rc: *RenameCtx, pred: id.BlockId, succ: id.BlockId) Result
     ret ok[bool, str](true);
 }
 
-# grows a phi's operand array by one (block, value) pair, encoding the
-# predecessor block id via the shared block-target convention and pairing it
-# with the incoming SSA value.
+# grows a phi's operand array by one (block, value) pair through the single
+# capacity-maintaining ir.phi_append_incoming primitive.
 fun phi_push_incoming(rc: *RenameCtx, phi: *instr.Instruction, pred: id.BlockId, incoming: value.Value) Result[bool, str] {
-    val st: *State = rc.st;
-    val rbt: Result[value.Value, str] = ir.make_block_target(st.m, pred);
-    if (is_err[value.Value, str](rbt)) { ret err[bool, str](unwrap_err[value.Value, str](rbt)); }
-    val block_val: value.Value = unwrap_ok[value.Value, str](rbt);
-
-    val old_n: u32 = phi.operand_count;
-    val new_n: u32 = old_n + 2;
-    val rn: Result[*value.Value, str] = allocate[value.Value](st.alloc, new_n::usize);
-    if (is_err[*value.Value, str](rn)) { ret err[bool, str](unwrap_err[*value.Value, str](rn)); }
-    val ops: *value.Value = unwrap_ok[*value.Value, str](rn);
-    var k: u32 = 0;
-    for (k < old_n) { ops[k] = phi.operands[k]; k = k + 1; }
-    ops[old_n]     = block_val;
-    ops[old_n + 1] = incoming;
-    if (phi.operands != nil && old_n > 0) {
-        deallocate[value.Value](st.alloc, phi.operands, old_n::usize);
-    }
-    phi.operands      = ops;
-    phi.operand_count = new_n;
-    ret ok[bool, str](true);
+    ret ir.phi_append_incoming(rc.st.m, phi, pred, incoming);
 }
 
 # resolves a Value through the substitution table: if it names a promoted load,

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -61,11 +61,23 @@ val NONE_U32: u32 = 0xFFFFFFFF;
 # df_start:     block id -> start offset into `df`
 # df_len:       block id -> frontier size
 # df_total:     allocated length of `df`
-# alloca_ids:   the promotable alloca InstructionIds
+# pool_len:     snapshot of fn.instr_len at entry; sizes the per-instruction maps
+# instr_block:  instruction id -> owning block, filled from the block lists (the
+#               liveness source of truth); BLOCK_NIL marks a pool ghost a prior
+#               pass unlinked, which every sweep here skips
+# alloca_of:    instruction id -> index into the promotable set (NONE_U32 when
+#               not a promotable alloca); the O(1) alloca lookup
+# cand_cap:     allocation size of alloca_ids / alloca_ty
+# alloca_ids:   the promotable alloca InstructionIds, in pool-id order
 # alloca_ty:    parallel to alloca_ids: each promotable alloca's value (slot)
 #               type, derived from a load/store on it — NOT the alloca's own
 #               result type, which is always the IR pointer type
 # alloca_count: number of promotable allocas
+# store_start:  per-alloca slice start into store_blocks
+# store_len:    per-alloca slice length
+# store_blocks: flattened per-alloca lists of the blocks storing to the alloca,
+#               in store-id order; seeds the phi-insertion worklist
+# store_total:  allocation size of store_blocks
 # phi_alloca:   instruction id -> the alloca a phi resolves (INSTR_NIL if not a
 #               mem2reg phi); sized to the instruction pool
 rec State {
@@ -84,9 +96,19 @@ rec State {
     df_len:       *u32;
     df_total:     u32;
 
+    pool_len:     u32;
+    instr_block:  *id.BlockId;
+    alloca_of:    *u32;
+
+    cand_cap:     u32;
     alloca_ids:   *id.InstructionId;
     alloca_ty:    *ir_type.IrTypeId;
     alloca_count: u32;
+
+    store_start:  *u32;
+    store_len:    *u32;
+    store_blocks: *id.BlockId;
+    store_total:  u32;
 
     phi_alloca:     *id.InstructionId;
     phi_alloca_cap: u32;
@@ -127,9 +149,17 @@ fun promote_function(m: *ir.Module, fn: *ir.Function) Result[bool, str] {
     st.df_start     = nil;
     st.df_len       = nil;
     st.df_total     = 0;
+    st.pool_len     = 0;
+    st.instr_block  = nil;
+    st.alloca_of    = nil;
+    st.cand_cap       = 0;
     st.alloca_ids     = nil;
     st.alloca_ty      = nil;
     st.alloca_count   = 0;
+    st.store_start    = nil;
+    st.store_len      = nil;
+    st.store_blocks   = nil;
+    st.store_total    = 0;
     st.phi_alloca     = nil;
     st.phi_alloca_cap = 0;
 
@@ -168,8 +198,8 @@ fun promote_function(m: *ir.Module, fn: *ir.Function) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
-# frees every owned array in the working state. safe to call partway through
-# construction — each array is nil until allocated.
+# frees every owned array in the working state by its allocation size. safe to
+# call partway through construction — each array is nil until allocated.
 fun dnit_state(st: *State) {
     if (st.rpo != nil)        { deallocate[id.BlockId](st.alloc, st.rpo, st.block_count::usize); }
     if (st.rpo_index != nil)  { deallocate[u32](st.alloc, st.rpo_index, st.block_count::usize); }
@@ -177,8 +207,13 @@ fun dnit_state(st: *State) {
     if (st.df != nil)         { deallocate[id.BlockId](st.alloc, st.df, st.df_total::usize); }
     if (st.df_start != nil)   { deallocate[u32](st.alloc, st.df_start, st.block_count::usize); }
     if (st.df_len != nil)     { deallocate[u32](st.alloc, st.df_len, st.block_count::usize); }
-    if (st.alloca_ids != nil) { deallocate[id.InstructionId](st.alloc, st.alloca_ids, st.alloca_count::usize); }
-    if (st.alloca_ty != nil)  { deallocate[ir_type.IrTypeId](st.alloc, st.alloca_ty, st.alloca_count::usize); }
+    if (st.instr_block != nil)  { deallocate[id.BlockId](st.alloc, st.instr_block, st.pool_len::usize); }
+    if (st.alloca_of != nil)    { deallocate[u32](st.alloc, st.alloca_of, st.pool_len::usize); }
+    if (st.alloca_ids != nil)   { deallocate[id.InstructionId](st.alloc, st.alloca_ids, st.cand_cap::usize); }
+    if (st.alloca_ty != nil)    { deallocate[ir_type.IrTypeId](st.alloc, st.alloca_ty, st.cand_cap::usize); }
+    if (st.store_start != nil)  { deallocate[u32](st.alloc, st.store_start, st.alloca_count::usize); }
+    if (st.store_len != nil)    { deallocate[u32](st.alloc, st.store_len, st.alloca_count::usize); }
+    if (st.store_blocks != nil) { deallocate[id.BlockId](st.alloc, st.store_blocks, st.store_total::usize); }
     if (st.phi_alloca != nil) { deallocate[id.InstructionId](st.alloc, st.phi_alloca, st.phi_alloca_cap::usize); }
 }
 
@@ -186,114 +221,244 @@ fun dnit_state(st: *State) {
 # only as the pointer operand of an OP_LOAD or OP_STORE. Any other reference
 # (the stored value of a store, a gep base, a call argument, …) means the
 # address escaped and the alloca stays in memory. Each accepted alloca's value
-# (slot) type is recorded in the parallel `alloca_ty` array, derived from a
-# load/store on it — the alloca's own result type is always the IR pointer type.
+# (slot) type is recorded in the parallel `alloca_ty` array, derived from its
+# first (lowest-id) load/store — the alloca's own result type is always the IR
+# pointer type.
+#
+# Block lists are the liveness source of truth (mirroring dce): the per-
+# instruction `instr_block` map is filled from them first, and every sweep
+# skips pool ghosts — so a call a prior inline unlinked cannot poison escape
+# analysis, and a store in a block reachability-dce removed cannot seed a phi.
+# All sweeps run in ascending pool-id order and the whole classification is a
+# fixed number of linear passes, replacing the per-alloca pool rescans.
 fun collect_promotable(st: *State) Result[bool, str] {
     val fn: *ir.Function = st.fn;
+    val ilen: u32 = fn.instr_len;
+    if (ilen == 0) { ret ok[bool, str](true); }
+    st.pool_len = ilen;
 
-    var cap: u32 = fn.instr_len;
-    if (cap == 0) { ret ok[bool, str](true); }
-
-    val ra: Result[*id.InstructionId, str] = allocate[id.InstructionId](st.alloc, cap::usize);
+    val ra: Result[*id.InstructionId, str] = allocate[id.InstructionId](st.alloc, ilen::usize);
     if (is_err[*id.InstructionId, str](ra)) {
         ret err[bool, str](unwrap_err[*id.InstructionId, str](ra));
     }
     st.alloca_ids = unwrap_ok[*id.InstructionId, str](ra);
 
-    val rt: Result[*ir_type.IrTypeId, str] = allocate[ir_type.IrTypeId](st.alloc, cap::usize);
+    val rt: Result[*ir_type.IrTypeId, str] = allocate[ir_type.IrTypeId](st.alloc, ilen::usize);
     if (is_err[*ir_type.IrTypeId, str](rt)) {
         ret err[bool, str](unwrap_err[*ir_type.IrTypeId, str](rt));
     }
     st.alloca_ty = unwrap_ok[*ir_type.IrTypeId, str](rt);
+    st.cand_cap  = ilen;
 
+    val rib: Result[*id.BlockId, str] = allocate[id.BlockId](st.alloc, ilen::usize);
+    if (is_err[*id.BlockId, str](rib)) {
+        ret err[bool, str](unwrap_err[*id.BlockId, str](rib));
+    }
+    st.instr_block = unwrap_ok[*id.BlockId, str](rib);
+
+    val rao: Result[*u32, str] = allocate[u32](st.alloc, ilen::usize);
+    if (is_err[*u32, str](rao)) {
+        ret err[bool, str](unwrap_err[*u32, str](rao));
+    }
+    st.alloca_of = unwrap_ok[*u32, str](rao);
+
+    var z: u32 = 0;
+    for (z < ilen) {
+        st.instr_block[z] = id.BLOCK_NIL;
+        st.alloca_of[z]   = NONE_U32;
+        z = z + 1;
+    }
+    map_instr_blocks(st);
+
+    # candidates in pool-id order: every alloca still listed in a block.
     var i: u32 = 0;
-    for (i < fn.instr_len) {
-        val inst: *instr.Instruction = ?fn.instrs[i];
-        if (inst.kind == instr.OP_ALLOCA) {
-            if (alloca_is_promotable(st, i::id.InstructionId)) {
-                st.alloca_ids[st.alloca_count] = i::id.InstructionId;
-                st.alloca_ty[st.alloca_count]  = alloca_value_type(st, i::id.InstructionId);
-                st.alloca_count = st.alloca_count + 1;
-            }
+    for (i < ilen) {
+        if (fn.instrs[i].kind == instr.OP_ALLOCA && st.instr_block[i] != id.BLOCK_NIL) {
+            st.alloca_of[i] = st.alloca_count;
+            st.alloca_ids[st.alloca_count] = i::id.InstructionId;
+            st.alloca_ty[st.alloca_count]  = ir_type.IRT_NIL;
+            st.alloca_count = st.alloca_count + 1;
         }
         i = i + 1;
+    }
+    if (st.alloca_count == 0) { ret ok[bool, str](true); }
+
+    val cand_n: u32 = st.alloca_count;
+    val re: Result[*bool, str] = allocate[bool](st.alloc, cand_n::usize);
+    if (is_err[*bool, str](re)) { ret err[bool, str](unwrap_err[*bool, str](re)); }
+    val escaped: *bool = unwrap_ok[*bool, str](re);
+    var e: u32 = 0;
+    for (e < cand_n) { escaped[e] = false; e = e + 1; }
+
+    # one classification sweep over the live instructions: record each
+    # candidate's slot type from its first load/store and mark every escape
+    # (any reference outside load-slot-0 / store-slot-1, or an inline-asm
+    # `{name}` binding — an asm-referenced alloca is addressed as
+    # `[rbp + offset]` at encode time, so its storage must survive).
+    var c: u32 = 0;
+    for (c < ilen) {
+        if (st.instr_block[c] != id.BLOCK_NIL) {
+            val inst: *instr.Instruction = ?fn.instrs[c];
+            if (inst.kind == instr.OP_ASM) {
+                mark_asm_binds_escaped(st, c::id.InstructionId, escaped);
+            }
+            var o: u32 = 0;
+            for (o < inst.operand_count) {
+                val op: value.Value = inst.operands[o];
+                if (op.kind == value.VAL_INSTR && op.data.instr::u32 < ilen) {
+                    val ai: u32 = st.alloca_of[op.data.instr::u32];
+                    if (ai != NONE_U32) {
+                        val ok_load:  bool = inst.kind == instr.OP_LOAD  && o == 0;
+                        val ok_store: bool = inst.kind == instr.OP_STORE && o == 1;
+                        if (ok_load == false && ok_store == false) {
+                            escaped[ai] = true;
+                        } or {
+                            if (st.alloca_ty[ai] == ir_type.IRT_NIL) {
+                                if (ok_load) { st.alloca_ty[ai] = inst.ty; }
+                                or           { st.alloca_ty[ai] = inst.operands[0].ty; }
+                            }
+                        }
+                    }
+                }
+                o = o + 1;
+            }
+        }
+        c = c + 1;
+    }
+
+    # compact the escaped candidates out (keeping pool-id order) and retag the
+    # alloca_of map with the surviving indices.
+    var w: u32 = 0;
+    var r: u32 = 0;
+    for (r < cand_n) {
+        val aid: id.InstructionId = st.alloca_ids[r];
+        if (escaped[r] == false) {
+            st.alloca_ids[w] = aid;
+            st.alloca_ty[w]  = st.alloca_ty[r];
+            st.alloca_of[aid::u32] = w;
+            w = w + 1;
+        } or {
+            st.alloca_of[aid::u32] = NONE_U32;
+        }
+        r = r + 1;
+    }
+    st.alloca_count = w;
+    deallocate[bool](st.alloc, escaped, cand_n::usize);
+    if (w == 0) { ret ok[bool, str](true); }
+
+    ret collect_store_blocks(st);
+}
+
+# fills `instr_block` from the block lists: every listed phi, body instruction,
+# and terminator maps to its owning block. unlisted pool entries stay BLOCK_NIL.
+fun map_instr_blocks(st: *State) {
+    val fn: *ir.Function = st.fn;
+    var b: u32 = 0;
+    for (b < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[b];
+        var pi: u32 = 0;
+        for (pi < blk.phi_count) {
+            val pid: id.InstructionId = blk.phis[pi];
+            if (pid::u32 < st.pool_len) { st.instr_block[pid::u32] = b::id.BlockId; }
+            pi = pi + 1;
+        }
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val iid: id.InstructionId = blk.instructions[ii];
+            if (iid::u32 < st.pool_len) { st.instr_block[iid::u32] = b::id.BlockId; }
+            ii = ii + 1;
+        }
+        if (blk.terminator != id.INSTR_NIL && blk.terminator::u32 < st.pool_len) {
+            st.instr_block[blk.terminator::u32] = b::id.BlockId;
+        }
+        b = b + 1;
+    }
+}
+
+# marks every candidate alloca referenced by the OP_ASM's `{name}` bindings as
+# escaped. the bindings live in the asm payload (not the instruction's operand
+# array), so escape analysis must consult them explicitly.
+fun mark_asm_binds_escaped(st: *State, asm_id: id.InstructionId, escaped: *bool) {
+    var key: id.InstructionId = asm_id;
+    val r: Result[*ir.IrAsm, str] = map.get[id.InstructionId, ir.IrAsm](?st.fn.asm_blocks, ?key);
+    if (is_err[*ir.IrAsm, str](r)) { ret; }
+    val pl: *ir.IrAsm = unwrap_ok[*ir.IrAsm, str](r);
+    var b: u32 = 0;
+    for (b < pl.bind_count) {
+        val bid: id.InstructionId = pl.binds[b].instr;
+        if (bid::u32 < st.pool_len && st.alloca_of[bid::u32] != NONE_U32) {
+            escaped[st.alloca_of[bid::u32]] = true;
+        }
+        b = b + 1;
+    }
+}
+
+# gathers, per promotable alloca, the blocks containing its stores into the
+# flattened `store_blocks` slices, in ascending store-id order (matching the
+# pool-scan seed order the per-alloca rescans used). count, prefix-sum, fill.
+fun collect_store_blocks(st: *State) Result[bool, str] {
+    val fn: *ir.Function = st.fn;
+    val na: u32 = st.alloca_count;
+
+    val rs: Result[*u32, str] = allocate[u32](st.alloc, na::usize);
+    if (is_err[*u32, str](rs)) { ret err[bool, str](unwrap_err[*u32, str](rs)); }
+    st.store_start = unwrap_ok[*u32, str](rs);
+
+    val rl: Result[*u32, str] = allocate[u32](st.alloc, na::usize);
+    if (is_err[*u32, str](rl)) { ret err[bool, str](unwrap_err[*u32, str](rl)); }
+    st.store_len = unwrap_ok[*u32, str](rl);
+
+    var a: u32 = 0;
+    for (a < na) { st.store_len[a] = 0; st.store_start[a] = 0; a = a + 1; }
+
+    var i: u32 = 0;
+    for (i < st.pool_len) {
+        val ai: u32 = store_alloca_index(st, i);
+        if (ai != NONE_U32) { st.store_len[ai] = st.store_len[ai] + 1; }
+        i = i + 1;
+    }
+
+    var total: u32 = 0;
+    var p: u32 = 0;
+    for (p < na) {
+        st.store_start[p] = total;
+        total = total + st.store_len[p];
+        p = p + 1;
+    }
+    var alloc_n: u32 = total;
+    if (alloc_n == 0) { alloc_n = 1; }   # always allocate so dnit frees cleanly.
+    st.store_total = alloc_n;
+
+    val rb: Result[*id.BlockId, str] = allocate[id.BlockId](st.alloc, alloc_n::usize);
+    if (is_err[*id.BlockId, str](rb)) { ret err[bool, str](unwrap_err[*id.BlockId, str](rb)); }
+    st.store_blocks = unwrap_ok[*id.BlockId, str](rb);
+
+    var f: u32 = 0;
+    for (f < na) { st.store_len[f] = 0; f = f + 1; }
+    var j: u32 = 0;
+    for (j < st.pool_len) {
+        val ai: u32 = store_alloca_index(st, j);
+        if (ai != NONE_U32) {
+            st.store_blocks[st.store_start[ai] + st.store_len[ai]] = st.instr_block[j];
+            st.store_len[ai] = st.store_len[ai] + 1;
+        }
+        j = j + 1;
     }
     ret ok[bool, str](true);
 }
 
-# derives the value (slot) type of a promotable alloca by scanning the pool for
-# a load from it (use the load's result type) or a store to it (use the stored
-# value's type). The alloca's result Value is the IR pointer type, so the slot
-# type is recovered from its memory operations here rather than from the result.
-# Returns IRT_NIL when the alloca has neither a load nor a store (a degenerate
-# dead alloca); inserted phis for such an alloca carry no incoming values and are
-# stripped by dce.
-fun alloca_value_type(st: *State, alloca_id: id.InstructionId) ir_type.IrTypeId {
-    val fn: *ir.Function = st.fn;
-    var i: u32 = 0;
-    for (i < fn.instr_len) {
-        val inst: *instr.Instruction = ?fn.instrs[i];
-        if (inst.kind == instr.OP_LOAD && inst.operand_count >= 1) {
-            val ptr: value.Value = inst.operands[0];
-            if (ptr.kind == value.VAL_INSTR && ptr.data.instr == alloca_id) {
-                ret inst.ty;
-            }
-        }
-        if (inst.kind == instr.OP_STORE && inst.operand_count >= 2) {
-            val ptr: value.Value = inst.operands[1];
-            if (ptr.kind == value.VAL_INSTR && ptr.data.instr == alloca_id) {
-                ret inst.operands[0].ty;
-            }
-        }
-        i = i + 1;
-    }
-    ret ir_type.IRT_NIL;
-}
-
-# true when no use of the alloca's result Value escapes load/store-pointer
-# position. scans every operand of every instruction in the pool, and every
-# inline-asm `{name}` binding — an asm-referenced alloca is addressed as
-# `[rbp + offset]` at encode time, so its storage must survive (promoting it
-# away would leave the `{name}` with no frame slot).
-fun alloca_is_promotable(st: *State, alloca_id: id.InstructionId) bool {
-    val fn: *ir.Function = st.fn;
-    var i: u32 = 0;
-    for (i < fn.instr_len) {
-        val inst: *instr.Instruction = ?fn.instrs[i];
-        if (inst.kind == instr.OP_ASM && asm_binds_alloca(fn, i::id.InstructionId, alloca_id)) {
-            ret false;
-        }
-        var o: u32 = 0;
-        for (o < inst.operand_count) {
-            val op: value.Value = inst.operands[o];
-            if (op.kind == value.VAL_INSTR && op.data.instr == alloca_id) {
-                # legal uses: the ptr operand of a load (slot 0) or store (slot 1).
-                # any other reference means the address escaped.
-                val ok_load:  bool = inst.kind == instr.OP_LOAD  && o == 0;
-                val ok_store: bool = inst.kind == instr.OP_STORE && o == 1;
-                if (ok_load == false && ok_store == false) { ret false; }
-            }
-            o = o + 1;
-        }
-        i = i + 1;
-    }
-    ret true;
-}
-
-# true when the OP_ASM at `asm_id` has a `{name}` binding referencing the alloca
-# at `alloca_id`. the binding lives in the asm payload (not the instruction's
-# operand array), so escape analysis must consult it explicitly.
-fun asm_binds_alloca(fn: *ir.Function, asm_id: id.InstructionId, alloca_id: id.InstructionId) bool {
-    var key: id.InstructionId = asm_id;
-    val r: Result[*ir.IrAsm, str] = map.get[id.InstructionId, ir.IrAsm](?fn.asm_blocks, ?key);
-    if (is_err[*ir.IrAsm, str](r)) { ret false; }
-    val pl: *ir.IrAsm = unwrap_ok[*ir.IrAsm, str](r);
-    var b: u32 = 0;
-    for (b < pl.bind_count) {
-        if (pl.binds[b].instr == alloca_id) { ret true; }
-        b = b + 1;
-    }
-    ret false;
+# the promotable-set index of the alloca a live OP_STORE at pool id `i` writes,
+# or NONE_U32 when `i` is not such a store (a ghost, another opcode, or a store
+# to something other than a promotable alloca).
+fun store_alloca_index(st: *State, i: u32) u32 {
+    if (st.instr_block[i] == id.BLOCK_NIL) { ret NONE_U32; }
+    val inst: *instr.Instruction = ?st.fn.instrs[i];
+    if (inst.kind != instr.OP_STORE) { ret NONE_U32; }
+    if (inst.operand_count < 2) { ret NONE_U32; }
+    val ptr: value.Value = inst.operands[1];
+    if (ptr.kind != value.VAL_INSTR) { ret NONE_U32; }
+    if (ptr.data.instr::u32 >= st.pool_len) { ret NONE_U32; }
+    ret st.alloca_of[ptr.data.instr::u32];
 }
 
 # Compute reverse postorder, the dominator tree (Cooper-Harvey-Kennedy), and
@@ -619,20 +784,18 @@ fun insert_phis(st: *State) Result[bool, str] {
         var i: u32 = 0;
         for (i < n) { has_phi[i] = false; on_work[i] = false; i = i + 1; }
 
+        # seed from the alloca's precomputed store-block slice (gathered in
+        # ascending store-id order from the block lists); on_work dedups.
         var wlen: u32 = 0;
+        val sstart: u32 = st.store_start[a];
+        val slen:   u32 = st.store_len[a];
         var s: u32 = 0;
-        for (s < st.fn.instr_len) {
-            val inst: *instr.Instruction = ?st.fn.instrs[s];
-            if (inst.kind == instr.OP_STORE && inst.operand_count >= 2) {
-                val ptr: value.Value = inst.operands[1];
-                if (ptr.kind == value.VAL_INSTR && ptr.data.instr == alloca_id) {
-                    val bb: u32 = inst.block::u32;
-                    if (bb < n && on_work[bb] == false) {
-                        on_work[bb] = true;
-                        work[wlen] = bb::id.BlockId;
-                        wlen = wlen + 1;
-                    }
-                }
+        for (s < slen) {
+            val bb: u32 = st.store_blocks[sstart + s]::u32;
+            if (bb < n && on_work[bb] == false) {
+                on_work[bb] = true;
+                work[wlen] = bb::id.BlockId;
+                wlen = wlen + 1;
             }
             s = s + 1;
         }
@@ -787,15 +950,12 @@ rec RenameCtx {
     instr_len: u32;
 }
 
-# returns the index of `alloca_id` within the promotable set, or NONE_U32 if it
-# is not a promoted alloca.
+# returns the index of `alloca_id` within the promotable set via the O(1)
+# alloca_of map, or NONE_U32 if it is not a promoted alloca.
 fun alloca_index(st: *State, alloca_id: id.InstructionId) u32 {
-    var a: u32 = 0;
-    for (a < st.alloca_count) {
-        if (st.alloca_ids[a] == alloca_id) { ret a; }
-        a = a + 1;
-    }
-    ret NONE_U32;
+    if (alloca_id == id.INSTR_NIL) { ret NONE_U32; }
+    if (alloca_id::u32 >= st.pool_len) { ret NONE_U32; }
+    ret st.alloca_of[alloca_id::u32];
 }
 
 # Iterative pre-order walk of the dominator tree. At each block: bind phis as

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -849,7 +849,6 @@ fun place_phi(st: *State, bid: id.BlockId, alloca_id: id.InstructionId) Result[b
     phi.ty            = st.alloca_ty[ai];
     phi.operands      = nil;
     phi.operand_count = 0;
-    phi.block         = bid;
     phi.flags         = 0;
     phi.aux_ty        = ir_type.IRT_NIL;
 

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -39,8 +39,11 @@ use instr:   mach.lang.me.ir.instruction;
 use value:   mach.lang.me.ir.value;
 use ir_type: mach.lang.me.ir.type;
 use id:      mach.lang.me.ir.id;
+use builder: mach.lang.me.ir.builder;
+use intern:  mach.lang.intern;
 
 use map:     std.collections.map;
+use page:    std.allocator.page;
 
 # sentinel marking an unprocessed entry in u32 work arrays (idom / rpo index).
 val NONE_U32: u32 = 0xFFFFFFFF;
@@ -1328,4 +1331,103 @@ fun is_promoted_memop(st: *State, iid: id.InstructionId) bool {
         }
     }
     ret false;
+}
+
+# counts the OP_ALLOCA instructions still listed in a block's instruction stream
+# (test helper).
+fun live_alloca_count(fn: *ir.Function, blk: *ir.Block) u32 {
+    var n: u32 = 0;
+    var ix: u32 = 0;
+    for (ix < blk.instr_count) {
+        val opt: Option[*instr.Instruction] = ir.get_instruction(fn, blk.instructions[ix]);
+        if (is_some[*instr.Instruction](opt)) {
+            if (unwrap[*instr.Instruction](opt).kind == instr.OP_ALLOCA) { n = n + 1; }
+        }
+        ix = ix + 1;
+    }
+    ret n;
+}
+
+# unlinks instruction `iid` from a block's instruction list, leaving it in the
+# pool as a ghost — the exact state inline leaves a removed call in (test helper).
+fun unlink_block_instr(blk: *ir.Block, iid: id.InstructionId) {
+    var w: u32 = 0;
+    var ix: u32 = 0;
+    for (ix < blk.instr_count) {
+        if (blk.instructions[ix] != iid) {
+            blk.instructions[w] = blk.instructions[ix];
+            w = w + 1;
+        }
+        ix = ix + 1;
+    }
+    blk.instr_count = w;
+}
+
+test "mem2reg: an alloca whose escaping call is removed (as inline does) promotes on a re-run (#1281)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+
+    val tr: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret 1; }
+    val i64t: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+    val vr: Result[ir_type.IrTypeId, str] = ir_type.intern_void(?m.types);
+    if (is_err[ir_type.IrTypeId, str](vr)) { ret 1; }
+    val voidt: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](vr);
+    val ppr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (is_err[ir_type.IrTypeId, str](ppr)) { ret 1; }
+    val ptrt: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](ppr);
+
+    # a dummy callee for the escaping call to name.
+    val cer: Result[u32, str] = ir.add_function(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (is_err[u32, str](cer)) { ret 1; }
+    val callee_ix: u32 = unwrap_ok[u32, str](cer);
+
+    # caller: p = alloca i64; store 0 -> p; call dummy(p); v = load p; ret v.
+    val car: Result[u32, str] = ir.add_function(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (is_err[u32, str](car)) { ret 1; }
+    val caller_ix: u32 = unwrap_ok[u32, str](car);
+    val fn: *ir.Function = ?m.functions[caller_ix];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val e0: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](e0)) { ret 1; }
+    val entry: id.BlockId = unwrap_ok[id.BlockId, str](e0);
+    builder.set_block(?bld, entry);
+
+    val ar: Result[value.Value, str] = builder.emit_alloca(?bld, i64t, value.const_int(1, i64t));
+    if (is_err[value.Value, str](ar)) { ret 1; }
+    val p: value.Value = unwrap_ok[value.Value, str](ar);
+
+    if (is_err[bool, str](builder.emit_store(?bld, value.const_int(0, i64t), p))) { ret 1; }
+
+    var args: [1]value.Value;
+    args[0] = p;
+    val callee_val: value.Value = value.fn_value(callee_ix, ptrt);
+    val crr: Result[value.Value, str] = builder.emit_call(?bld, callee_val, ?args[0], 1, voidt);
+    if (is_err[value.Value, str](crr)) { ret 1; }
+    val call_v: value.Value = unwrap_ok[value.Value, str](crr);
+    val call_id: id.InstructionId = call_v.data.instr;
+
+    val lr: Result[value.Value, str] = builder.emit_load(?bld, p, i64t);
+    if (is_err[value.Value, str](lr)) { ret 1; }
+    if (is_err[bool, str](builder.emit_ret(?bld, unwrap_ok[value.Value, str](lr)))) { ret 1; }
+
+    val entry_blk: *ir.Block = ?fn.blocks[entry::u32];
+
+    # first mem2reg: p's address escapes into the call, so it is not promoted.
+    if (is_err[bool, str](run(?m))) { ret 1; }
+    if (live_alloca_count(fn, entry_blk) != 1) { ret 1; }
+
+    # simulate inline removing the call: unlink it, leaving a pool ghost.
+    unlink_block_instr(entry_blk, call_id);
+
+    # second mem2reg: the escaping call is gone (and the ghost is skipped), so p
+    # promotes to SSA and its alloca leaves the block.
+    if (is_err[bool, str](run(?m))) { ret 1; }
+    if (live_alloca_count(fn, entry_blk) != 0) { ret 1; }
+    ret 0;
 }

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -104,6 +104,20 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
             if (is_err[bool, str](rvi)) { ret rvi; }
         }
 
+        # post-inline mem2reg: a caller alloca whose address escaped into a call
+        # is non-promotable before inlining, but once the callee is inlined its
+        # uses become plain load/store and it becomes promotable. re-run mem2reg
+        # to promote those out-param-style slots to SSA. promotion is idempotent
+        # on already-SSA code, and mem2reg reads block lists as the liveness
+        # source of truth so inline's unlinked pool ghosts don't poison escape
+        # analysis.
+        val rm2: Result[bool, str] = mem2reg.run(m);
+        if (is_err[bool, str](rm2)) { ret rm2; }
+        if (verify_ir) {
+            val rvm2: Result[bool, str] = run_verify(m, false, true);
+            if (is_err[bool, str](rvm2)) { ret rvm2; }
+        }
+
         # late constfold: inlining substitutes constant arguments into callee
         # bodies, exposing fresh folding opportunities across the inlined code.
         # a constant-branch simplification here can strand a block with no


### PR DESCRIPTION
Three sibling cleanup issues in `me/`, one branch:

**#1278 — IR remainders**
- collapse the duplicated builder/ir storage-growth helper families onto the `ir.mach` primitives; one capacity-maintaining phi-grow / operand-replace primitive completes the #1277 `operand_cap` contract for the pass-side grows
- migrate `OP_ALLOCA`'s element type from `ty` to the `aux_ty` convention
- make `byte_offset` out-of-range a loud failure
- array-type interning joins the dedup map
- remove the vestigial `Instruction.block` field

**#1281 — passes(mem2reg)**
- re-run mem2reg after inline in the release pipeline so post-inline promotable allocas actually promote, with a test asserting a post-inline alloca promotes

**#1282 — perf(passes)**
- inline: per-pass call counts + call-site worklist (no per-inline module rescan)
- mem2reg: instruction→block / instruction→alloca index maps, single classification sweep
- cse: hashed candidate matching instead of O(block-len²)

Constraints honored: `-O0` output stays byte-identical; the release fixpoint converges on the new encoding; `mach build . --release --verify-ir` stays clean.

Closes #1278
Closes #1281
Closes #1282