### PR TITLE
fix(cli): migrate src/cli off hand-rolled std string/print primitives

### DIFF
--- a/src/cli/cmd.mach
+++ b/src/cli/cmd.mach
@@ -6,6 +6,10 @@
 # applicable, invokes help, and returns a nonzero exit code.
 
 use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_equals;
+
+use print: std.print;
 
 use cmd_build: mach.cli.cmd.build;
 use cmd_run:   mach.cli.cmd.run;
@@ -15,8 +19,6 @@ use cmd_dep:   mach.cli.cmd.dep;
 use cmd_init:  mach.cli.cmd.init;
 use cmd_doc:   mach.cli.cmd.doc;
 use cmd_help:  mach.cli.cmd.help;
-
-use util: mach.cli.util;
 
 # dispatch: route a CLI invocation to its subcommand handler.
 # ---
@@ -29,20 +31,20 @@ pub fun dispatch(argc: usize, argv: **u8) i64 {
         ret 1;
     }
 
-    val command: *u8 = argv[1];
+    val command: str = argv[1]::str;
 
-    if (util.eq(command, "build")) { ret cmd_build.run(argc, argv); }
-    if (util.eq(command, "run"))   { ret cmd_run.run(argc, argv); }
-    if (util.eq(command, "test"))  { ret cmd_test.run(argc, argv); }
-    if (util.eq(command, "check")) { ret cmd_check.run(argc, argv); }
-    if (util.eq(command, "dep"))   { ret cmd_dep.run(argc, argv); }
-    if (util.eq(command, "init"))  { ret cmd_init.run(argc, argv); }
-    if (util.eq(command, "doc"))   { ret cmd_doc.run(argc, argv); }
-    if (util.eq(command, "help"))  { ret cmd_help.run(argc, argv); }
+    if (str_equals(command, "build")) { ret cmd_build.run(argc, argv); }
+    if (str_equals(command, "run"))   { ret cmd_run.run(argc, argv); }
+    if (str_equals(command, "test"))  { ret cmd_test.run(argc, argv); }
+    if (str_equals(command, "check")) { ret cmd_check.run(argc, argv); }
+    if (str_equals(command, "dep"))   { ret cmd_dep.run(argc, argv); }
+    if (str_equals(command, "init"))  { ret cmd_init.run(argc, argv); }
+    if (str_equals(command, "doc"))   { ret cmd_doc.run(argc, argv); }
+    if (str_equals(command, "help"))  { ret cmd_help.run(argc, argv); }
 
-    util.emit("error: unknown command '");
-    util.emit(command);
-    util.emit("'\n");
+    print.eprint("error: unknown command '");
+    print.eprint(command);
+    print.eprint("'\n");
     cmd_help.run(argc, argv);
     ret 1;
 }

--- a/src/cli/cmd/check.mach
+++ b/src/cli/cmd/check.mach
@@ -27,14 +27,14 @@ use std.allocator.Allocator;
 use page:  std.allocator.page;
 use arena: std.allocator.arena;
 
-use fs: std.filesystem;
+use fs:    std.filesystem;
+use print: std.print;
 
 use sess:   mach.lang.session;
 use src:    mach.lang.source;
 use diag:   mach.lang.diagnostic;
 use editor: mach.lang.editor;
 
-use util:     mach.cli.util;
 use cli_diag: mach.cli.diagnostic;
 
 # run: `mach check` subcommand entry point. reads `argv[2]` as the file path,
@@ -45,33 +45,33 @@ use cli_diag: mach.cli.diagnostic;
 # ret:  0 when the buffer has no errors, 1 on errors or a usage / io failure
 pub fun run(argc: usize, argv: **u8) i64 {
     if (argc < 3) {
-        util.emit("usage: mach check <file>\n");
+        print.eprint("usage: mach check <file>\n");
         ret 1;
     }
     val path: str = argv[2]::str;
 
     var backing: Allocator;
     if (is_some[str](page.make(?backing))) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 1;
     }
     var ar: arena.Arena;
     if (is_some[str](arena.init(?ar, ?backing, 0))) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 1;
     }
     var alloc: Allocator;
     if (is_some[str](arena.make(?alloc, ?ar))) {
         arena.dnit(?ar);
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 1;
     }
 
     val text_r: Result[str, str] = fs.read_all(?alloc, path);
     if (is_err[str, str](text_r)) {
-        util.emit("error: cannot read '");
-        util.emit(path::*u8);
-        util.emit("'\n");
+        print.eprint("error: cannot read '");
+        print.eprint(path);
+        print.eprint("'\n");
         arena.dnit(?ar);
         ret 1;
     }
@@ -79,9 +79,9 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
     val sr: Result[sess.Session, str] = sess.init(?alloc);
     if (is_err[sess.Session, str](sr)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[sess.Session, str](sr)::*u8);
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[sess.Session, str](sr));
+        print.eprint("\n");
         arena.dnit(?ar);
         ret 1;
     }
@@ -102,18 +102,18 @@ pub fun run(argc: usize, argv: **u8) i64 {
 fun check_buffer(es: *editor.EditorSession, s: *sess.Session, path: str, text: str) i64 {
     val fr: Result[src.FileId, str] = editor.open(es, path, text);
     if (is_err[src.FileId, str](fr)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[src.FileId, str](fr)::*u8);
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[src.FileId, str](fr));
+        print.eprint("\n");
         ret 1;
     }
     val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
 
     val dr: Result[*diag.DiagList, str] = editor.diagnostics(es, fid);
     if (is_err[*diag.DiagList, str](dr)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[*diag.DiagList, str](dr)::*u8);
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[*diag.DiagList, str](dr));
+        print.eprint("\n");
         ret 1;
     }
     val list: *diag.DiagList = unwrap_ok[*diag.DiagList, str](dr);

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -20,6 +20,8 @@ use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_empty;
 use std.types.string.str_equals;
+use std.types.string.str_starts_with;
+use std.types.string.str_region_equals;
 use std.types.option.Option;
 use std.types.option.is_some;
 use std.types.result.Result;
@@ -39,10 +41,11 @@ use std.text.string.str_free;
 
 use page: std.allocator.page;
 
-use os:   std.system.os;
-use fs:   std.filesystem;
-use toml: std.data.toml;
-use exec: std.process.exec;
+use os:    std.system.os;
+use fs:    std.filesystem;
+use toml:  std.data.toml;
+use exec:  std.process.exec;
+use print: std.print;
 
 use util: mach.cli.util;
 
@@ -62,22 +65,12 @@ val SEG_COMMIT: *u8 = "\"\ncommit = \"";
 val SEG_CLOSE:  *u8 = "\"\n";
 val SEG_MREF:   *u8 = "ref = \"";
 
-# out_str: write a length-delimited `str` view to stdout.
-fun out_str(v: str) {
-    os.write(os.STDOUT_FD, v::*u8, str_len(v));
-}
-
-# err_str: write a length-delimited `str` view to stderr.
-fun err_str(v: str) {
-    os.write(os.STDERR_FD, v::*u8, str_len(v));
-}
-
 # arg_after: return the argument immediately following the first occurrence of
 # `flag`, or nil if the flag is absent or terminates the vector.
 fun arg_after(argc: usize, argv: **u8, flag: *u8) *u8 {
     var i: usize = 0;
     for (i + 1 < argc) {
-        if (util.eq(argv[i], flag)) { ret argv[i + 1]; }
+        if (str_equals(argv[i]::str, flag::str)) { ret argv[i + 1]; }
         i = i + 1;
     }
     ret nil;
@@ -113,24 +106,24 @@ fun arg_quiet(argc: usize, argv: **u8) bool {
 # ret:  0 on success, 1 on a user error, 2 on an internal error
 pub fun run(argc: usize, argv: **u8) i64 {
     if (argc < 3) {
-        util.emit("error: missing dep action\n");
-        util.emit("usage: mach dep <list|add|remove|sync|vendor>\n");
+        print.eprint("error: missing dep action\n");
+        print.eprint("usage: mach dep <list|add|remove|sync|vendor>\n");
         ret 1;
     }
 
-    val action: *u8 = argv[2];
+    val action: str = argv[2]::str;
     val quiet:  bool = arg_quiet(argc, argv);
 
-    if (util.eq(action, "list"))   { ret dep_list(); }
-    if (util.eq(action, "add"))    { ret dep_add(argc, argv); }
-    if (util.eq(action, "remove")) { ret dep_remove(argc, argv); }
-    if (util.eq(action, "sync"))   { ret dep_sync(quiet); }
-    if (util.eq(action, "vendor")) { ret dep_sync(quiet); }
+    if (str_equals(action, "list"))   { ret dep_list(); }
+    if (str_equals(action, "add"))    { ret dep_add(argc, argv); }
+    if (str_equals(action, "remove")) { ret dep_remove(argc, argv); }
+    if (str_equals(action, "sync"))   { ret dep_sync(quiet); }
+    if (str_equals(action, "vendor")) { ret dep_sync(quiet); }
 
-    util.emit("error: unknown dep action '");
-    util.emit(action);
-    util.emit("'\n");
-    util.emit("usage: mach dep <list|add|remove|sync|vendor>\n");
+    print.eprint("error: unknown dep action '");
+    print.eprint(action);
+    print.eprint("'\n");
+    print.eprint("usage: mach dep <list|add|remove|sync|vendor>\n");
     ret 1;
 }
 
@@ -158,29 +151,29 @@ fun dep_list() i64 {
     var alloc: Allocator;
     val mk: Option[str] = page.make(?alloc);
     if (is_some[str](mk)) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
     val text_r: Result[str, str] = fs.read_all(?alloc, MANIFEST::str);
     if (is_err[str, str](text_r)) {
-        util.emit("error: no mach.toml in the current directory\n");
+        print.eprint("error: no mach.toml in the current directory\n");
         ret 1;
     }
     val text: str = unwrap_ok[str, str](text_r);
 
     val tab_r: Result[toml.Table, str] = toml.parse(?alloc, text);
     if (is_err[toml.Table, str](tab_r)) {
-        util.emit("error: failed to parse mach.toml: ");
-        err_str(unwrap_err[toml.Table, str](tab_r));
-        util.emit("\n");
+        print.eprint("error: failed to parse mach.toml: ");
+        print.eprint(unwrap_err[toml.Table, str](tab_r));
+        print.eprint("\n");
         ret 1;
     }
     var t: toml.Table = unwrap_ok[toml.Table, str](tab_r);
 
     val deps: *toml.Table = toml.get_table(?t, "deps");
     if (deps == nil || toml.table_len(deps) == 0) {
-        util.out("no dependencies\n");
+        print.print("no dependencies\n");
         ret 0;
     }
 
@@ -188,18 +181,18 @@ fun dep_list() i64 {
     var i: usize = 0;
     for (i < count) {
         val alias: str = toml.table_key(deps, i);
-        util.out("  ");
-        out_str(alias);
+        print.print("  ");
+        print.print(alias);
 
         val v: *toml.Value = toml.table_value(deps, i);
         if (v != nil && v.tag == toml.TYPE_TABLE) {
             val sub: *toml.Table = ?v.data.table;
             val url: str = dep_url(sub);
             val ref: str = dep_ref(sub);
-            if (str_len(url) > 0) { util.out("  url="); out_str(url); }
-            if (str_len(ref) > 0) { util.out("  ref="); out_str(ref); }
+            if (str_len(url) > 0) { print.print("  url="); print.print(url); }
+            if (str_len(ref) > 0) { print.print("  ref="); print.print(ref); }
         }
-        util.out("\n");
+        print.print("\n");
         i = i + 1;
     }
     ret 0;
@@ -212,7 +205,7 @@ fun table_has_key(deps: *toml.Table, alias: *u8) bool {
     val count: usize = toml.table_len(deps);
     var i: usize = 0;
     for (i < count) {
-        if (util.eq(toml.table_key(deps, i)::*u8, alias)) { ret true; }
+        if (str_equals(toml.table_key(deps, i), alias::str)) { ret true; }
         i = i + 1;
     }
     ret false;
@@ -234,7 +227,7 @@ fun dep_declared(alloc: *Allocator, alias: *u8) bool {
 # `[deps.<alias>]` entry to mach.toml, then syncs every declared dep.
 fun dep_add(argc: usize, argv: **u8) i64 {
     if (argc < 5) {
-        util.emit("error: usage: mach dep add <alias> <url> [--ref <ref>]\n");
+        print.eprint("error: usage: mach dep add <alias> <url> [--ref <ref>]\n");
         ret 1;
     }
     val alias: *u8 = argv[3];
@@ -246,29 +239,29 @@ fun dep_add(argc: usize, argv: **u8) i64 {
     var alloc: Allocator;
     val mk: Option[str] = page.make(?alloc);
     if (is_some[str](mk)) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
     if (dep_declared(?alloc, alias)) {
-        util.emit("error: dependency '");
-        util.emit(alias);
-        util.emit("' is already declared in mach.toml\n");
+        print.eprint("error: dependency '");
+        print.eprint(alias::str);
+        print.eprint("' is already declared in mach.toml\n");
         ret 1;
     }
 
     val wr: Result[bool, str] = append_dep_entry(?alloc, alias, url, ref);
     if (is_err[bool, str](wr)) {
-        util.emit("error: failed to update mach.toml: ");
-        err_str(unwrap_err[bool, str](wr));
-        util.emit("\n");
+        print.eprint("error: failed to update mach.toml: ");
+        print.eprint(unwrap_err[bool, str](wr));
+        print.eprint("\n");
         ret 2;
     }
 
     if (!quiet) {
-        util.out("added [deps.");
-        util.out(alias);
-        util.out("]\n");
+        print.print("added [deps.");
+        print.print(alias::str);
+        print.print("]\n");
     }
     ret dep_sync(quiet);
 }
@@ -317,7 +310,7 @@ fun append_dep_entry(alloc: *Allocator, alias: *u8, url: *u8, ref: *u8) Result[b
 # entry from mach.toml; with `--purge`, also deletes the vendored directory.
 fun dep_remove(argc: usize, argv: **u8) i64 {
     if (argc < 4) {
-        util.emit("error: usage: mach dep remove <alias> [--purge]\n");
+        print.eprint("error: usage: mach dep remove <alias> [--purge]\n");
         ret 1;
     }
     val alias: *u8 = argv[3];
@@ -327,22 +320,22 @@ fun dep_remove(argc: usize, argv: **u8) i64 {
     var alloc: Allocator;
     val mk: Option[str] = page.make(?alloc);
     if (is_some[str](mk)) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
     if (!dep_declared(?alloc, alias)) {
-        util.emit("error: dependency '");
-        util.emit(alias);
-        util.emit("' is not declared in mach.toml\n");
+        print.eprint("error: dependency '");
+        print.eprint(alias::str);
+        print.eprint("' is not declared in mach.toml\n");
         ret 1;
     }
 
     val rr: Result[bool, str] = strip_dep_entry(?alloc, MANIFEST, alias);
     if (is_err[bool, str](rr)) {
-        util.emit("error: failed to update mach.toml: ");
-        err_str(unwrap_err[bool, str](rr));
-        util.emit("\n");
+        print.eprint("error: failed to update mach.toml: ");
+        print.eprint(unwrap_err[bool, str](rr));
+        print.eprint("\n");
         ret 2;
     }
 
@@ -358,9 +351,9 @@ fun dep_remove(argc: usize, argv: **u8) i64 {
     }
 
     if (!quiet) {
-        util.out("removed [deps.");
-        util.out(alias);
-        util.out("]\n");
+        print.print("removed [deps.");
+        print.print(alias::str);
+        print.print("]\n");
     }
     ret 0;
 }
@@ -377,7 +370,6 @@ fun strip_dep_entry(alloc: *Allocator, file: *u8, alias: *u8) Result[bool, str] 
     val hr: Result[*u8, str] = dep_header(alloc, alias);
     if (is_err[*u8, str](hr)) { ret err[bool, str](unwrap_err[*u8, str](hr)); }
     val hdr: *u8 = unwrap_ok[*u8, str](hr);
-    val hdr_len: usize = util.slen(hdr);
 
     val r_buf: Result[*u8, str] = allocate[u8](alloc, n + 1);
     if (is_err[*u8, str](r_buf)) { ret err[bool, str](unwrap_err[*u8, str](r_buf)); }
@@ -393,7 +385,7 @@ fun strip_dep_entry(alloc: *Allocator, file: *u8, alias: *u8) Result[bool, str] 
         if (i < n) { i = i + 1; }
 
         val is_header: bool = le > ls && text[ls] == '[';
-        if (is_header) { dropping = line_matches(text, ls, le, hdr, hdr_len); }
+        if (is_header) { dropping = line_matches(text, ls, le, hdr); }
 
         if (!dropping) {
             var j: usize = ls;
@@ -407,18 +399,12 @@ fun strip_dep_entry(alloc: *Allocator, file: *u8, alias: *u8) Result[bool, str] 
 
 # line_matches: returns true if `text[start..end]`, trimmed of trailing ASCII
 # whitespace, equals the null-terminated `hdr`.
-fun line_matches(text: str, start: usize, end: usize, hdr: *u8, hdr_len: usize) bool {
+fun line_matches(text: str, start: usize, end: usize, hdr: *u8) bool {
     var e: usize = end;
     for (e > start && (text[e - 1] == ' ' || text[e - 1] == '\t' || text[e - 1] == '\r')) {
         e = e - 1;
     }
-    if (e - start != hdr_len) { ret false; }
-    var i: usize = 0;
-    for (i < hdr_len) {
-        if (text[start + i] != hdr[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
+    ret str_region_equals(text, start, e - start, hdr::str);
 }
 
 # dep_header: build the null-terminated table header `[deps.<alias>]`.
@@ -465,63 +451,63 @@ pub fun sync_project(root: str, quiet: bool) i64 {
     var alloc: Allocator;
     val mk: Option[str] = page.make(?alloc);
     if (is_some[str](mk)) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
     val manifest_r: Result[str, str] = join2(?alloc, root, MANIFEST);
     if (is_err[str, str](manifest_r)) {
-        util.emit("error: out of memory\n");
+        print.eprint("error: out of memory\n");
         ret 2;
     }
     val manifest_path: str = unwrap_ok[str, str](manifest_r);
 
     val text_r: Result[str, str] = fs.read_all(?alloc, manifest_path);
     if (is_err[str, str](text_r)) {
-        util.emit("error: no mach.toml in the project directory\n");
+        print.eprint("error: no mach.toml in the project directory\n");
         ret 1;
     }
     var mt: toml.Table;
     val tab_r: Result[toml.Table, str] = toml.parse(?alloc, unwrap_ok[str, str](text_r));
     if (is_err[toml.Table, str](tab_r)) {
-        util.emit("error: failed to parse mach.toml: ");
-        err_str(unwrap_err[toml.Table, str](tab_r));
-        util.emit("\n");
+        print.eprint("error: failed to parse mach.toml: ");
+        print.eprint(unwrap_err[toml.Table, str](tab_r));
+        print.eprint("\n");
         ret 1;
     }
     mt = unwrap_ok[toml.Table, str](tab_r);
 
     val deps: *toml.Table = toml.get_table(?mt, "deps");
     if (deps == nil || toml.table_len(deps) == 0) {
-        if (!quiet) { util.out("no dependencies to sync\n"); }
+        if (!quiet) { print.print("no dependencies to sync\n"); }
         ret 0;
     }
     val count: usize = toml.table_len(deps);
 
     val git_r: Result[str, str] = find_on_path(?alloc, "git");
     if (is_err[str, str](git_r)) {
-        util.emit("error: git not found on PATH\n");
+        print.eprint("error: git not found on PATH\n");
         ret 2;
     }
     val git: str = unwrap_ok[str, str](git_r);
 
     val env_r: Result[**u8, str] = build_env(?alloc);
     if (is_err[**u8, str](env_r)) {
-        util.emit("error: failed to build child environment\n");
+        print.eprint("error: failed to build child environment\n");
         ret 2;
     }
     val env: **u8 = unwrap_ok[**u8, str](env_r);
 
     val dep_root_r: Result[str, str] = resolve_dep_root(?alloc, root, ?mt);
     if (is_err[str, str](dep_root_r)) {
-        util.emit("error: out of memory\n");
+        print.eprint("error: out of memory\n");
         ret 2;
     }
     val dep_root: str = unwrap_ok[str, str](dep_root_r);
 
     val lock_r: Result[str, str] = join2(?alloc, root, LOCKFILE);
     if (is_err[str, str](lock_r)) {
-        util.emit("error: out of memory\n");
+        print.eprint("error: out of memory\n");
         ret 2;
     }
     val lock_path: str = unwrap_ok[str, str](lock_r);
@@ -540,7 +526,7 @@ pub fun sync_project(root: str, quiet: bool) i64 {
 
     val r_specs: Result[*DepSpec, str] = allocate[DepSpec](?alloc, count);
     if (is_err[*DepSpec, str](r_specs)) {
-        util.emit("error: out of memory\n");
+        print.eprint("error: out of memory\n");
         ret 2;
     }
     val specs: *DepSpec = unwrap_ok[*DepSpec, str](r_specs);
@@ -550,17 +536,17 @@ pub fun sync_project(root: str, quiet: bool) i64 {
         val alias_v: str = toml.table_key(deps, i);
         val v: *toml.Value = toml.table_value(deps, i);
         if (v == nil || v.tag != toml.TYPE_TABLE) {
-            util.emit("error: [deps.");
-            err_str(alias_v);
-            util.emit("] is not a table\n");
+            print.eprint("error: [deps.");
+            print.eprint(alias_v);
+            print.eprint("] is not a table\n");
             ret 1;
         }
         val sub: *toml.Table = ?v.data.table;
         val url_v: str = dep_url(sub);
         if (str_empty(url_v)) {
-            util.emit("error: [deps.");
-            err_str(alias_v);
-            util.emit("] has no git url (set 'url' or 'source')\n");
+            print.eprint("error: [deps.");
+            print.eprint(alias_v);
+            print.eprint("] has no git url (set 'url' or 'source')\n");
             ret 1;
         }
         val ref_v: str = dep_ref(sub);
@@ -573,16 +559,16 @@ pub fun sync_project(root: str, quiet: bool) i64 {
         # left untouched for backward compatibility.
         val dir_r: Result[str, str] = join2(?alloc, dep_root, alias::*u8);
         if (is_err[str, str](dir_r)) {
-            util.emit("error: out of memory\n");
+            print.eprint("error: out of memory\n");
             ret 2;
         }
         val dir: str = unwrap_ok[str, str](dir_r);
         if (fs.exists(dir) && !is_managed_clone(?alloc, dir)) {
             specs[i] = DepSpec{alias: alias, url: url, ref: ref, commit: "", managed: false};
             if (!quiet) {
-                util.out("vendored ");
-                out_str(alias);
-                util.out(" (skipped)\n");
+                print.print("vendored ");
+                print.print(alias);
+                print.print(" (skipped)\n");
             }
             i = i + 1;
             cnt;
@@ -595,36 +581,36 @@ pub fun sync_project(root: str, quiet: bool) i64 {
 
         val sr: Result[str, str] = fetch_dep(?alloc, git, env, dep_root, dir, url, checkout);
         if (is_err[str, str](sr)) {
-            util.emit("error: failed to sync '");
-            err_str(alias);
-            util.emit("': ");
-            err_str(unwrap_err[str, str](sr));
-            util.emit("\n");
+            print.eprint("error: failed to sync '");
+            print.eprint(alias);
+            print.eprint("': ");
+            print.eprint(unwrap_err[str, str](sr));
+            print.eprint("\n");
             ret 2;
         }
         val commit: str = unwrap_ok[str, str](sr);
         specs[i] = DepSpec{alias: alias, url: url, ref: ref, commit: commit, managed: true};
 
         if (!quiet) {
-            util.out("synced ");
-            out_str(alias);
-            util.out(" @ ");
-            out_str(commit);
-            util.out("\n");
+            print.print("synced ");
+            print.print(alias);
+            print.print(" @ ");
+            print.print(commit);
+            print.print("\n");
         }
         i = i + 1;
     }
 
     val lw: Result[bool, str] = write_lock(?alloc, specs, count, lock_path);
     if (is_err[bool, str](lw)) {
-        util.emit("error: failed to write mach.lock: ");
-        err_str(unwrap_err[bool, str](lw));
-        util.emit("\n");
+        print.eprint("error: failed to write mach.lock: ");
+        print.eprint(unwrap_err[bool, str](lw));
+        print.eprint("\n");
         ret 2;
     }
     if (!quiet) {
-        if (unwrap_ok[bool, str](lw)) { util.out("wrote mach.lock\n"); }
-        or                           { util.out("mach.lock up to date\n"); }
+        if (unwrap_ok[bool, str](lw)) { print.print("wrote mach.lock\n"); }
+        or                           { print.print("mach.lock up to date\n"); }
     }
     ret 0;
 }
@@ -636,7 +622,7 @@ fun lock_commit(lock_deps: *toml.Table, alias: *u8) str {
     val count: usize = toml.table_len(lock_deps);
     var i: usize = 0;
     for (i < count) {
-        if (util.eq(toml.table_key(lock_deps, i)::*u8, alias)) {
+        if (str_equals(toml.table_key(lock_deps, i), alias::str)) {
             val v: *toml.Value = toml.table_value(lock_deps, i);
             if (v != nil && v.tag == toml.TYPE_TABLE) {
                 ret toml.get_str(?v.data.table, "commit");
@@ -698,10 +684,10 @@ fun fetch_dep(alloc: *Allocator, git: str, env: **u8, dep_root: str, dir: str, u
 fun git_checkout(alloc: *Allocator, git: str, env: **u8, dir: str, ref: str) Result[bool, str] {
     if (str_empty(ref)) { ret git_checkout_one(git, env, dir, "origin/HEAD"); }
 
-    if (starts_with(ref, "branch/")) {
+    if (str_starts_with(ref, "branch/")) {
         ret git_checkout_one(git, env, dir, with_prefix(alloc, "origin/", drop_prefix(ref, 7)));
     }
-    if (starts_with(ref, "tag/")) {
+    if (str_starts_with(ref, "tag/")) {
         ret git_checkout_one(git, env, dir, drop_prefix(ref, 4));
     }
     if (is_hex_sha(ref)) {
@@ -741,16 +727,6 @@ fun git_checkout_one(git: str, env: **u8, dir: str, committish: str) Result[bool
     co[4] = committish::usize;
     co[5] = 0;
     ret run_git(git, env, (?co[0])::**u8);
-}
-
-# starts_with: true if `s` begins with the null-terminated prefix `p`.
-fun starts_with(s: str, p: *u8) bool {
-    var i: usize = 0;
-    for (p[i] != 0) {
-        if (s[i] != p[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
 }
 
 # drop_prefix: a view of `s` advanced past its first `n` bytes.
@@ -913,22 +889,12 @@ fun write_lock(alloc: *Allocator, specs: *DepSpec, count: usize, lock_path: str)
     val cur_r: Result[str, str] = fs.read_all(alloc, lock_path);
     if (is_ok[str, str](cur_r)) {
         val cur: str = unwrap_ok[str, str](cur_r);
-        if (str_len(cur) == k && mem_eq(cur, buf, k)) { ret ok[bool, str](false); }
+        if (str_equals(cur, buf::str)) { ret ok[bool, str](false); }
     }
 
     val wr: Result[bool, str] = fs.write_file(lock_path, buf, k, 0o644);
     if (is_err[bool, str](wr)) { ret wr; }
     ret ok[bool, str](true);
-}
-
-# mem_eq: byte-wise equality of the first `n` bytes of a `str` view and a `*u8`.
-fun mem_eq(a: str, b: *u8, n: usize) bool {
-    var i: usize = 0;
-    for (i < n) {
-        if (a[i] != b[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
 }
 
 # find_on_path: resolve an absolute path to `name` by scanning the `PATH`

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -10,8 +10,8 @@
 #
 # doc-comments are not retained on the AST — the lexer drops `#` comments at
 # tokenisation — so this is a textual extraction over the original source,
-# which is the tractable MVP. output is written straight to the filesystem;
-# no std.print or std.format is used.
+# which is the tractable MVP. page output is written straight to the
+# filesystem; only the run summary goes through `std.print`.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -34,8 +34,8 @@ use std.allocator.Allocator;
 use page:  std.allocator.page;
 use arena: std.allocator.arena;
 
-use os: std.system.os;
-use fs: std.filesystem;
+use fs:    std.filesystem;
+use print: std.print;
 
 use intern: mach.lang.intern;
 use sess:   mach.lang.session;
@@ -348,7 +348,7 @@ fun write_heading(f: *fs.File, s: *u8, pos: usize) {
 # ret:     0 on success, non-zero on a filesystem error
 fun generate(p: *driver.Project, api_dir: *u8, stats: *DocStats) i64 {
     if (!util.ensure_dir(api_dir)) {
-        util.emit("error: could not create output directory\n");
+        print.eprint("error: could not create output directory\n");
         ret 2;
     }
 
@@ -356,7 +356,7 @@ fun generate(p: *driver.Project, api_dir: *u8, stats: *DocStats) i64 {
     if (util.join_into(?index_path[0], 4096, api_dir, "README.md") == 0) { ret 2; }
     val ir: Result[fs.File, str] = fs.create(util.cstr_str(?index_path[0]), 420);
     if (is_err[fs.File, str](ir)) {
-        util.emit("error: could not create the documentation index\n");
+        print.eprint("error: could not create the documentation index\n");
         ret 2;
     }
     var index: fs.File = unwrap_ok[fs.File, str](ir);
@@ -391,9 +391,9 @@ fun generate(p: *driver.Project, api_dir: *u8, stats: *DocStats) i64 {
 
         val n: i64 = document_module(?page_path[0], fqn, source);
         if (n < 0) {
-            util.emit("error: failed to write page for ");
-            util.emit(fqn);
-            util.emit("\n");
+            print.eprint("error: failed to write page for ");
+            print.eprint(fqn::str);
+            print.eprint("\n");
             fs.close(?index);
             ret 2;
         }
@@ -414,22 +414,6 @@ fun generate(p: *driver.Project, api_dir: *u8, stats: *DocStats) i64 {
     ret 0;
 }
 
-# write_uint: write a decimal `u32` to stdout.
-# ---
-# v: value to render
-fun write_uint(v: u32) {
-    if (v == 0) { util.out("0"); ret; }
-    var buf: [16]u8;
-    var i: usize = 16;
-    var n: u32 = v;
-    for (n > 0) {
-        i = i - 1;
-        buf[i] = '0' + (n % 10)::u8;
-        n = n / 10;
-    }
-    os.write(os.STDOUT_FD, ?buf[i], 16 - i);
-}
-
 # run: `mach doc` subcommand entry point. loads the project's module graph and
 # generates Markdown reference documentation under `<root>/doc/api`, or a
 # directory given by `--out`. called by cmd.dispatch.
@@ -440,14 +424,14 @@ fun write_uint(v: u32) {
 pub fun run(argc: usize, argv: **u8) i64 {
     val cfg_opt: Option[cfg.Config] = cfg.parse(argc, argv);
     if (is_none[cfg.Config](cfg_opt)) {
-        util.emit("error: invalid command-line flags\n");
+        print.eprint("error: invalid command-line flags\n");
         ret 1;
     }
     val config: cfg.Config = unwrap[cfg.Config](cfg_opt);
 
     var root: [4096]u8;
     if (!util.find_project_root(config.cwd, ?root[0], 4096)) {
-        util.emit("error: no mach.toml found in the working directory or any parent\n");
+        print.eprint("error: no mach.toml found in the working directory or any parent\n");
         ret 1;
     }
 
@@ -457,24 +441,24 @@ pub fun run(argc: usize, argv: **u8) i64 {
     # and reclaimed in a single arena.dnit.
     var backing: Allocator;
     if (is_some[str](page.make(?backing))) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
     var ar: arena.Arena;
     if (is_some[str](arena.init(?ar, ?backing, 0))) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
     var alloc: Allocator;
     if (is_some[str](arena.make(?alloc, ?ar))) {
         arena.dnit(?ar);
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
     val sess_r: Result[sess.Session, str] = sess.init(?alloc);
     if (is_err[sess.Session, str](sess_r)) {
-        util.emit("error: failed to initialise compiler session\n");
+        print.eprint("error: failed to initialise compiler session\n");
         arena.dnit(?ar);
         ret 2;
     }
@@ -482,7 +466,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
     val reg_r: Result[bool, str] = tgt.register_all(?s.interner);
     if (is_err[bool, str](reg_r)) {
-        util.emit("error: failed to register targets\n");
+        print.eprint("error: failed to register targets\n");
         sess.dnit(?s);
         arena.dnit(?ar);
         ret 2;
@@ -493,9 +477,9 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
     val proj_r: Result[driver.Project, str] = driver.build_project(?s, util.cstr_str(?root[0]), util.cstr_str(target_name));
     if (is_err[driver.Project, str](proj_r)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[driver.Project, str](proj_r));
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[driver.Project, str](proj_r));
+        print.eprint("\n");
         sess.dnit(?s);
         arena.dnit(?ar);
         ret 1;
@@ -520,13 +504,13 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val code: i64 = generate(?p, ?api_dir[0], ?stats);
 
     if (code == 0 && !config.quiet) {
-        util.out("documented ");
-        write_uint(stats.entries);
-        util.out(" public entities across ");
-        write_uint(stats.modules);
-        util.out(" modules -> ");
-        util.out(?api_dir[0]);
-        util.out("\n");
+        print.print("documented ");
+        print.u64(stats.entries::u64);
+        print.print(" public entities across ");
+        print.u64(stats.modules::u64);
+        print.print(" modules -> ");
+        print.print(util.cstr_str(?api_dir[0]));
+        print.print("\n");
     }
 
     driver.dnit_project(?p);

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -7,140 +7,142 @@
 # non-zero. the pages mirror doc/cli.md's documented flag surface.
 
 use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_equals;
 
-use util: mach.cli.util;
+use print: std.print;
 
 # global_flags: the cross-cutting flags the shared config parser reads
 # (build, run, test, doc). printed under each command that honours them.
 fun global_flags() {
-    util.out("global flags:\n");
-    util.out("  --verbose, -v     surface extra detail (per-stage progress) on stderr\n");
-    util.out("  --quiet, -q       suppress non-error output (mutually exclusive with -v)\n");
-    util.out("  --color <mode>    auto | always | never (default auto)\n");
-    util.out("  --cwd <path>      run as if started in <path>\n");
-    util.out("  --target <name>   select a [targets.<name>] entry\n");
-    util.out("  -o <path>         override the linked-binary path (build/run/test)\n");
-    util.out("  --artifacts <dir> override the per-target object directory (build/run/test)\n");
-    util.out("  --emit-asm        emit per-module .s assembly text beside each object\n");
-    util.out("  --emit-ir         emit per-module .ir SSA text beside each object\n");
-    util.out("  --verify-ir       run the IR verifier after each optimisation pass\n");
+    print.print("global flags:\n");
+    print.print("  --verbose, -v     surface extra detail (per-stage progress) on stderr\n");
+    print.print("  --quiet, -q       suppress non-error output (mutually exclusive with -v)\n");
+    print.print("  --color <mode>    auto | always | never (default auto)\n");
+    print.print("  --cwd <path>      run as if started in <path>\n");
+    print.print("  --target <name>   select a [targets.<name>] entry\n");
+    print.print("  -o <path>         override the linked-binary path (build/run/test)\n");
+    print.print("  --artifacts <dir> override the per-target object directory (build/run/test)\n");
+    print.print("  --emit-asm        emit per-module .s assembly text beside each object\n");
+    print.print("  --emit-ir         emit per-module .ir SSA text beside each object\n");
+    print.print("  --verify-ir       run the IR verifier after each optimisation pass\n");
 }
 
 fun top_level_usage() {
-    util.out("mach — the Mach compiler\n");
-    util.out("\n");
-    util.out("usage: mach <command> [options]\n");
-    util.out("\n");
-    util.out("commands:\n");
-    util.out("  build    compile the current project\n");
-    util.out("  run      build and execute the current project\n");
-    util.out("  test     build and run the project's tests\n");
-    util.out("  check    report diagnostics for a single source file\n");
-    util.out("  dep      manage project dependencies\n");
-    util.out("  init     scaffold a new project\n");
-    util.out("  doc      generate reference documentation\n");
-    util.out("  help     show this message\n");
-    util.out("\n");
+    print.print("mach — the Mach compiler\n");
+    print.print("\n");
+    print.print("usage: mach <command> [options]\n");
+    print.print("\n");
+    print.print("commands:\n");
+    print.print("  build    compile the current project\n");
+    print.print("  run      build and execute the current project\n");
+    print.print("  test     build and run the project's tests\n");
+    print.print("  check    report diagnostics for a single source file\n");
+    print.print("  dep      manage project dependencies\n");
+    print.print("  init     scaffold a new project\n");
+    print.print("  doc      generate reference documentation\n");
+    print.print("  help     show this message\n");
+    print.print("\n");
     global_flags();
-    util.out("\n");
-    util.out("use 'mach help <command>' for detailed usage.\n");
+    print.print("\n");
+    print.print("use 'mach help <command>' for detailed usage.\n");
 }
 
 fun help_build() {
-    util.out("usage: mach build [path] [options] [inputs...]\n");
-    util.out("\n");
-    util.out("compile the current project to relocatable objects and, in executable\n");
-    util.out("mode, a linked binary. [path] is the project root (default: the cwd).\n");
-    util.out("\n");
-    util.out("options:\n");
-    util.out("  --release        select the release optimisation pipeline\n");
-    util.out("  -O0              force the debug pipeline (overrides --release)\n");
-    util.out("  -O1, -O2         select the release pipeline\n");
-    util.out("  --emit <kind>    obj | exe (default exe; obj stops at the objects)\n");
-    util.out("  -L <dir>         add a search directory for -l inputs; repeatable\n");
-    util.out("  -l <name>        link a named object, archive, or shared library; repeatable\n");
-    util.out("  <input>          a bare .o / .a / .so path or '/'-bearing path linked verbatim\n");
-    util.out("\n");
+    print.print("usage: mach build [path] [options] [inputs...]\n");
+    print.print("\n");
+    print.print("compile the current project to relocatable objects and, in executable\n");
+    print.print("mode, a linked binary. [path] is the project root (default: the cwd).\n");
+    print.print("\n");
+    print.print("options:\n");
+    print.print("  --release        select the release optimisation pipeline\n");
+    print.print("  -O0              force the debug pipeline (overrides --release)\n");
+    print.print("  -O1, -O2         select the release pipeline\n");
+    print.print("  --emit <kind>    obj | exe (default exe; obj stops at the objects)\n");
+    print.print("  -L <dir>         add a search directory for -l inputs; repeatable\n");
+    print.print("  -l <name>        link a named object, archive, or shared library; repeatable\n");
+    print.print("  <input>          a bare .o / .a / .so path or '/'-bearing path linked verbatim\n");
+    print.print("\n");
     global_flags();
-    util.out("\n");
-    util.out("exit: 0 ok, 1 user error, 2 internal error\n");
+    print.print("\n");
+    print.print("exit: 0 ok, 1 user error, 2 internal error\n");
 }
 
 fun help_run() {
-    util.out("usage: mach run [path] [options] [-- args...]\n");
-    util.out("\n");
-    util.out("build the project (all 'mach build' flags apply) and execute the\n");
-    util.out("resulting binary. arguments after '--' are forwarded to the program\n");
-    util.out("as its argv; the program's exit code becomes this command's.\n");
-    util.out("--emit is rejected — running a relocatable object is not meaningful.\n");
-    util.out("\n");
-    util.out("exit: the program's exit code, 1 on build error, 2 internal\n");
+    print.print("usage: mach run [path] [options] [-- args...]\n");
+    print.print("\n");
+    print.print("build the project (all 'mach build' flags apply) and execute the\n");
+    print.print("resulting binary. arguments after '--' are forwarded to the program\n");
+    print.print("as its argv; the program's exit code becomes this command's.\n");
+    print.print("--emit is rejected — running a relocatable object is not meaningful.\n");
+    print.print("\n");
+    print.print("exit: the program's exit code, 1 on build error, 2 internal\n");
 }
 
 fun help_test() {
-    util.out("usage: mach test [path] [options]\n");
-    util.out("\n");
-    util.out("build a test binary over every 'test' declaration and run it. all\n");
-    util.out("'mach build' and global flags apply.\n");
-    util.out("\n");
-    util.out("options:\n");
-    util.out("  --filter <pattern>  run only tests whose name matches <pattern>\n");
-    util.out("  --list              list the collected tests and exit\n");
-    util.out("\n");
-    util.out("exit: 0 all passed, 1 any failed, 2 build/internal error\n");
+    print.print("usage: mach test [path] [options]\n");
+    print.print("\n");
+    print.print("build a test binary over every 'test' declaration and run it. all\n");
+    print.print("'mach build' and global flags apply.\n");
+    print.print("\n");
+    print.print("options:\n");
+    print.print("  --filter <pattern>  run only tests whose name matches <pattern>\n");
+    print.print("  --list              list the collected tests and exit\n");
+    print.print("\n");
+    print.print("exit: 0 all passed, 1 any failed, 2 build/internal error\n");
 }
 
 fun help_check() {
-    util.out("usage: mach check <file>\n");
-    util.out("\n");
-    util.out("report diagnostics for a single source file, best-effort, with no\n");
-    util.out("project, module graph, or link step. the editor diagnostics path.\n");
-    util.out("\n");
-    util.out("exit: 0 when the file has no errors, 1 on errors or a usage / io failure\n");
+    print.print("usage: mach check <file>\n");
+    print.print("\n");
+    print.print("report diagnostics for a single source file, best-effort, with no\n");
+    print.print("project, module graph, or link step. the editor diagnostics path.\n");
+    print.print("\n");
+    print.print("exit: 0 when the file has no errors, 1 on errors or a usage / io failure\n");
 }
 
 fun help_dep() {
-    util.out("usage: mach dep <action> [args]\n");
-    util.out("\n");
-    util.out("manage git-backed dependencies under dir_dep.\n");
-    util.out("\n");
-    util.out("actions:\n");
-    util.out("  list                          list declared dependencies\n");
-    util.out("  add <alias> <url> [--ref R]   declare a git dependency and fetch it\n");
-    util.out("  remove <alias> [--purge]      drop a dependency (--purge deletes its dir)\n");
-    util.out("  sync                          fetch declared deps; honour mach.lock\n");
-    util.out("  vendor                        alias for sync (materialise all deps)\n");
-    util.out("\n");
-    util.out("a dependency is a git url plus a ref (tag, branch, or commit). sync\n");
-    util.out("clones each into dir_dep/<alias>/, checks out the ref, and records the\n");
-    util.out("resolved commit in mach.lock for reproducible builds. hand-vendored\n");
-    util.out("trees and git submodules under dir_dep are left untouched.\n");
+    print.print("usage: mach dep <action> [args]\n");
+    print.print("\n");
+    print.print("manage git-backed dependencies under dir_dep.\n");
+    print.print("\n");
+    print.print("actions:\n");
+    print.print("  list                          list declared dependencies\n");
+    print.print("  add <alias> <url> [--ref R]   declare a git dependency and fetch it\n");
+    print.print("  remove <alias> [--purge]      drop a dependency (--purge deletes its dir)\n");
+    print.print("  sync                          fetch declared deps; honour mach.lock\n");
+    print.print("  vendor                        alias for sync (materialise all deps)\n");
+    print.print("\n");
+    print.print("a dependency is a git url plus a ref (tag, branch, or commit). sync\n");
+    print.print("clones each into dir_dep/<alias>/, checks out the ref, and records the\n");
+    print.print("resolved commit in mach.lock for reproducible builds. hand-vendored\n");
+    print.print("trees and git submodules under dir_dep are left untouched.\n");
 }
 
 fun help_init() {
-    util.out("usage: mach init [dir] [options]\n");
-    util.out("\n");
-    util.out("scaffold a new project in <dir> (default: current directory).\n");
-    util.out("\n");
-    util.out("options:\n");
-    util.out("  --name <name>  project id (default: directory name)\n");
-    util.out("  --force        scaffold even when mach.toml / src already exist\n");
-    util.out("  --lib          library project layout (default: binary)\n");
+    print.print("usage: mach init [dir] [options]\n");
+    print.print("\n");
+    print.print("scaffold a new project in <dir> (default: current directory).\n");
+    print.print("\n");
+    print.print("options:\n");
+    print.print("  --name <name>  project id (default: directory name)\n");
+    print.print("  --force        scaffold even when mach.toml / src already exist\n");
+    print.print("  --lib          library project layout (default: binary)\n");
 }
 
 fun help_doc() {
-    util.out("usage: mach doc [options]\n");
-    util.out("\n");
-    util.out("generate Markdown reference documentation from source doc-comments.\n");
-    util.out("writes one page per module plus an index under doc/api.\n");
-    util.out("\n");
-    util.out("options:\n");
-    util.out("  --out <dir>      output directory, rooted at the project (default: doc/api)\n");
-    util.out("  --target <name>  select a [targets.<name>] entry for module discovery\n");
-    util.out("\n");
+    print.print("usage: mach doc [options]\n");
+    print.print("\n");
+    print.print("generate Markdown reference documentation from source doc-comments.\n");
+    print.print("writes one page per module plus an index under doc/api.\n");
+    print.print("\n");
+    print.print("options:\n");
+    print.print("  --out <dir>      output directory, rooted at the project (default: doc/api)\n");
+    print.print("  --target <name>  select a [targets.<name>] entry for module discovery\n");
+    print.print("\n");
     global_flags();
-    util.out("\n");
-    util.out("exit: 0 ok, 1 user error, 2 internal error\n");
+    print.print("\n");
+    print.print("exit: 0 ok, 1 user error, 2 internal error\n");
 }
 
 # run: `mach help` subcommand entry point. prints the top-level usage or a
@@ -155,19 +157,19 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret 0;
     }
 
-    val sub: *u8 = argv[2];
-    if (util.eq(sub, "build")) { help_build(); ret 0; }
-    if (util.eq(sub, "run"))   { help_run();   ret 0; }
-    if (util.eq(sub, "test"))  { help_test();  ret 0; }
-    if (util.eq(sub, "check")) { help_check(); ret 0; }
-    if (util.eq(sub, "dep"))   { help_dep();   ret 0; }
-    if (util.eq(sub, "init"))  { help_init();  ret 0; }
-    if (util.eq(sub, "doc"))   { help_doc();   ret 0; }
-    if (util.eq(sub, "help"))  { top_level_usage(); ret 0; }
+    val sub: str = argv[2]::str;
+    if (str_equals(sub, "build")) { help_build(); ret 0; }
+    if (str_equals(sub, "run"))   { help_run();   ret 0; }
+    if (str_equals(sub, "test"))  { help_test();  ret 0; }
+    if (str_equals(sub, "check")) { help_check(); ret 0; }
+    if (str_equals(sub, "dep"))   { help_dep();   ret 0; }
+    if (str_equals(sub, "init"))  { help_init();  ret 0; }
+    if (str_equals(sub, "doc"))   { help_doc();   ret 0; }
+    if (str_equals(sub, "help"))  { top_level_usage(); ret 0; }
 
-    util.out("error: unknown command '");
-    util.out(sub);
-    util.out("'\n");
+    print.print("error: unknown command '");
+    print.print(sub);
+    print.print("'\n");
     top_level_usage();
     ret 1;
 }

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -20,8 +20,9 @@ use std.types.option.unwrap;
 use std.types.result.Result;
 use std.types.result.is_err;
 
-use os: std.system.os;
-use fs: std.filesystem;
+use os:    std.system.os;
+use fs:    std.filesystem;
+use print: std.print;
 
 use util: mach.cli.util;
 use dep:  mach.cli.cmd.dep;
@@ -83,7 +84,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     var cwd_buf: [4096]u8;
     val gw: i64 = os.getcwd(?cwd_buf[0], 4096);
     if (gw < 0) {
-        util.emit("error: failed to read the working directory\n");
+        print.eprint("error: failed to read the working directory\n");
         ret 2;
     }
 
@@ -104,7 +105,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     var manifest: [4096]u8;
     util.join_into(?manifest[0], 4096, dir, "mach.toml");
     if (fs.exists(?manifest[0]) && !force) {
-        util.emit("error: mach.toml already exists (use --force to overwrite)\n");
+        print.eprint("error: mach.toml already exists (use --force to overwrite)\n");
         ret 1;
     }
 
@@ -115,14 +116,14 @@ pub fun run(argc: usize, argv: **u8) i64 {
     if (is_lib) {
         util.join_into(?entry[0], 4096, ?src_dir[0], "lib.mach");
         if (fs.exists(?entry[0]) && !force) {
-            util.emit("error: src/lib.mach already exists (use --force to overwrite)\n");
+            print.eprint("error: src/lib.mach already exists (use --force to overwrite)\n");
             ret 1;
         }
     }
     or {
         util.join_into(?entry[0], 4096, ?src_dir[0], "main.mach");
         if (fs.exists(?entry[0]) && !force) {
-            util.emit("error: src/main.mach already exists (use --force to overwrite)\n");
+            print.eprint("error: src/main.mach already exists (use --force to overwrite)\n");
             ret 1;
         }
     }
@@ -131,7 +132,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     if (!fs.is_dir(dir)) {
         val mk: Result[bool, str] = fs.create_dir(dir, 493);
         if (is_err[bool, str](mk)) {
-            util.emit("error: failed to create the project directory\n");
+            print.eprint("error: failed to create the project directory\n");
             ret 2;
         }
     }
@@ -139,25 +140,25 @@ pub fun run(argc: usize, argv: **u8) i64 {
     if (!fs.is_dir(?src_dir[0])) {
         val mk: Result[bool, str] = fs.create_dir(?src_dir[0], 493);
         if (is_err[bool, str](mk)) {
-            util.emit("error: failed to create the src directory\n");
+            print.eprint("error: failed to create the src directory\n");
             ret 2;
         }
     }
 
     if (!write_manifest(?manifest[0], id, is_lib)) {
-        util.emit("error: failed to write mach.toml\n");
+        print.eprint("error: failed to write mach.toml\n");
         ret 2;
     }
 
     if (is_lib) {
         if (!write_source(?entry[0], lib_template())) {
-            util.emit("error: failed to write src/lib.mach\n");
+            print.eprint("error: failed to write src/lib.mach\n");
             ret 2;
         }
     }
     or {
         if (!write_source(?entry[0], main_template())) {
-            util.emit("error: failed to write src/main.mach\n");
+            print.eprint("error: failed to write src/main.mach\n");
             ret 2;
         }
     }
@@ -170,9 +171,9 @@ pub fun run(argc: usize, argv: **u8) i64 {
     if (rc != 0) { ret rc; }
 
     if (!quiet) {
-        util.emit("created project '");
-        util.emit(id);
-        util.emit("'\n");
+        print.eprint("created project '");
+        print.eprint(id::str);
+        print.eprint("'\n");
     }
     ret 0;
 }

--- a/src/cli/cmd/run.mach
+++ b/src/cli/cmd/run.mach
@@ -23,8 +23,9 @@ use std.allocator.allocate;
 use page:  std.allocator.page;
 use arena: std.allocator.arena;
 
-use os:   std.system.os;
-use exec: std.process.exec;
+use os:    std.system.os;
+use exec:  std.process.exec;
+use print: std.print;
 
 use build: mach.cli.cmd.build;
 use util:  mach.cli.util;
@@ -44,7 +45,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
     val emit_opt: Option[*u8] = build.emit_kind(sep, argv);
     if (is_some[*u8](emit_opt)) {
-        util.emit("error: 'mach run' does not support --emit\n");
+        print.eprint("error: 'mach run' does not support --emit\n");
         ret 1;
     }
 
@@ -56,20 +57,20 @@ pub fun run(argc: usize, argv: **u8) i64 {
     # so `output_path` stays mapped until we are done with the child.
     var backing: Allocator;
     if (is_some[str](page.make(?backing))) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
     var ar: arena.Arena;
     if (is_some[str](arena.init(?ar, ?backing, 0))) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
     var alloc: Allocator;
     if (is_some[str](arena.make(?alloc, ?ar))) {
         arena.dnit(?ar);
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
@@ -80,7 +81,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     if (br.output_path == nil) {
         arena.dnit(?ar);
-        util.emit("error: build produced no executable\n");
+        print.eprint("error: build produced no executable\n");
         ret 2;
     }
 
@@ -92,7 +93,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val cv_r: Result[**u8, str] = allocate[*u8](?alloc, total);
     if (is_err[**u8, str](cv_r)) {
         arena.dnit(?ar);
-        util.emit("error: out of memory\n");
+        print.eprint("error: out of memory\n");
         ret 2;
     }
     val child_argv: **u8 = unwrap_ok[**u8, str](cv_r);
@@ -108,7 +109,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
     if (is_err[exec.ExitStatus, str](exec_r)) {
         arena.dnit(?ar);
-        util.emit("error: failed to execute the built binary\n");
+        print.eprint("error: failed to execute the built binary\n");
         ret 1;
     }
     val status: exec.ExitStatus = unwrap_ok[exec.ExitStatus, str](exec_r);

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -27,8 +27,9 @@ use std.allocator.allocate;
 use page:  std.allocator.page;
 use arena: std.allocator.arena;
 
-use os:   std.system.os;
-use exec: std.process.exec;
+use os:    std.system.os;
+use exec:  std.process.exec;
+use print: std.print;
 
 use build: mach.cli.cmd.build;
 use util:  mach.cli.util;
@@ -51,20 +52,20 @@ pub fun run(argc: usize, argv: **u8) i64 {
     # reclamation to a single `arena.dnit`, keeping `output_path` mapped.
     var backing: Allocator;
     if (is_some[str](page.make(?backing))) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
     var ar: arena.Arena;
     if (is_some[str](arena.init(?ar, ?backing, 0))) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
     var alloc: Allocator;
     if (is_some[str](arena.make(?alloc, ?ar))) {
         arena.dnit(?ar);
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
@@ -79,7 +80,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     if (br.output_path == nil) {
         arena.dnit(?ar);
-        util.emit("error: build produced no test binary\n");
+        print.eprint("error: build produced no test binary\n");
         ret 2;
     }
 
@@ -92,7 +93,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val cv_r: Result[**u8, str] = allocate[*u8](?alloc, total);
     if (is_err[**u8, str](cv_r)) {
         arena.dnit(?ar);
-        util.emit("error: out of memory\n");
+        print.eprint("error: out of memory\n");
         ret 2;
     }
     val child_argv: **u8 = unwrap_ok[**u8, str](cv_r);
@@ -109,7 +110,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
     if (is_err[exec.ExitStatus, str](exec_r)) {
         arena.dnit(?ar);
-        util.emit("error: failed to execute the test binary\n");
+        print.eprint("error: failed to execute the test binary\n");
         ret 2;
     }
     val status: exec.ExitStatus = unwrap_ok[exec.ExitStatus, str](exec_r);

--- a/src/cli/diagnostic.mach
+++ b/src/cli/diagnostic.mach
@@ -15,18 +15,18 @@ use std.types.option.Option;
 use std.types.option.is_some;
 use std.types.option.is_none;
 use std.types.option.unwrap;
+use std.types.string.str;
 
-use os: std.system.os;
+use os:    std.system.os;
+use print: std.print;
 
 use sess:  mach.lang.session;
 use src:   mach.lang.source;
 use diag:  mach.lang.diagnostic;
 use token: mach.lang.fe.token;
 
-use util: mach.cli.util;
-
 # severity_label: the leading `severity: ` text for a diagnostic severity.
-fun severity_label(severity: u8) *u8 {
+fun severity_label(severity: u8) str {
     if (severity == diag.SEVERITY_ERROR)   { ret "error: "; }
     if (severity == diag.SEVERITY_WARNING) { ret "warning: "; }
     if (severity == diag.SEVERITY_INFO)    { ret "info: "; }
@@ -36,7 +36,7 @@ fun severity_label(severity: u8) *u8 {
 # severity_color: the ANSI SGR sequence for a severity label, applied only when
 # color is enabled. error is bold red, warning bold magenta, info bold cyan,
 # help bold green.
-fun severity_color(severity: u8) *u8 {
+fun severity_color(severity: u8) str {
     if (severity == diag.SEVERITY_ERROR)   { ret "\x1b[1;31m"; }
     if (severity == diag.SEVERITY_WARNING) { ret "\x1b[1;35m"; }
     if (severity == diag.SEVERITY_INFO)    { ret "\x1b[1;36m"; }
@@ -54,33 +54,33 @@ pub fun flush(s: *sess.Session, list: *diag.DiagList, color: bool) {
     for (i < list.len) {
         val d: *diag.Diagnostic = ?list.items[i];
 
-        if (color) { util.emit(severity_color(d.severity)); }
-        util.emit(severity_label(d.severity));
-        if (color) { util.emit("\x1b[0m"); }
+        if (color) { print.eprint(severity_color(d.severity)); }
+        print.eprint(severity_label(d.severity));
+        if (color) { print.eprint("\x1b[0m"); }
 
         val so: Option[*src.SourceFile] = src.get(?s.sources, d.file_id);
         if (is_some[*src.SourceFile](so)) {
             val sf: *src.SourceFile = unwrap[*src.SourceFile](so);
             val pos: src.Position = src.position(sf, d.span.offset);
-            util.emit(sf.path::*u8);
-            util.emit(":");
-            util.emit_num(pos.line);
-            util.emit(":");
-            util.emit_num(pos.col);
-            util.emit(": ");
-            util.emit(d.message::*u8);
-            util.emit("\n");
+            print.eprint(sf.path);
+            print.eprint(":");
+            print.eu64(pos.line::u64);
+            print.eprint(":");
+            print.eu64(pos.col::u64);
+            print.eprint(": ");
+            print.eprint(d.message);
+            print.eprint("\n");
             emit_snippet(sf, ?d.span, pos.line);
         }
         or {
-            util.emit(d.message::*u8);
-            util.emit("\n");
+            print.eprint(d.message);
+            print.eprint("\n");
         }
 
         if (d.note != nil) {
-            util.emit("  note: ");
-            util.emit(d.note::*u8);
-            util.emit("\n");
+            print.eprint("  note: ");
+            print.eprint(d.note);
+            print.eprint("\n");
         }
         i = i + 1;
     }
@@ -97,7 +97,7 @@ fun emit_snippet(sf: *src.SourceFile, span: *token.Span, line: usize) {
     val lb: src.LineSpan = unwrap[src.LineSpan](lbo);
 
     os.write(os.STDERR_FD, ?sf.text[lb.start], lb.end - lb.start);
-    util.emit("\n");
+    print.eprint("\n");
 
     var caret_at: usize = span.offset;
     if (caret_at < lb.start) { caret_at = lb.start; }
@@ -105,18 +105,18 @@ fun emit_snippet(sf: *src.SourceFile, span: *token.Span, line: usize) {
 
     var c: usize = lb.start;
     for (c < caret_at) {
-        if (sf.text[c] == '\t') { util.emit("\t"); } or { util.emit(" "); }
+        if (sf.text[c] == '\t') { print.eprint("\t"); } or { print.eprint(" "); }
         c = c + 1;
     }
 
-    util.emit("^");
+    print.eprint("^");
 
     var span_end: usize = span.offset + span.len;
     if (span_end > lb.end) { span_end = lb.end; }
     var u: usize = caret_at + 1;
     for (u < span_end) {
-        util.emit("~");
+        print.eprint("~");
         u = u + 1;
     }
-    util.emit("\n");
+    print.eprint("\n");
 }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -1,52 +1,56 @@
-# mach.cli.util: shared CLI primitives — string, io, argv, and path helpers.
+# mach.cli.util: shared CLI argv and path helpers, plus thin std bridges.
 #
-# every subcommand needs the same handful of null-terminated-string,
-# argv-scanning, and project-path operations; this module owns the single
-# copy of each so a fix lands once. it allocates nothing and frames no parse
-# state: the argv helpers are exact-match scans over the raw vector, mirroring
-# `mach.cli.args` (which this supersedes), and the path helpers operate on
-# caller-provided buffers. `--flag=value` and bundled short flags are
-# intentionally not recognized.
+# every subcommand needs the same handful of argv-scanning and project-path
+# operations over the raw `**u8`/`*u8` argument vector; this module owns the
+# single copy of each so a fix lands once. it allocates nothing and frames no
+# parse state: the argv helpers are exact-match scans over the raw vector,
+# mirroring `mach.cli.args` (which this supersedes), and the path helpers
+# operate on caller-provided buffers. `--flag=value` and bundled short flags
+# are intentionally not recognized.
+#
+# the `eq`/`slen`/`emit`/`emit_num` entries are thin `*u8` bridges over
+# `std.types.string` / `std.print`, retained only for the `*u8` call sites in
+# `cmd/build.mach` and `config.mach`; in-scope CLI code calls std directly
+# (#1296).
 
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_equals;
+use std.types.string.str_len;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
 use std.types.result.Result;
 use std.types.result.is_ok;
 
-use os: std.system.os;
-use fs: std.filesystem;
+use os:    std.system.os;
+use fs:    std.filesystem;
+use print: std.print;
 
-# eq: byte-wise equality of two null-terminated `*u8` strings.
+# eq: byte-wise equality of two null-terminated `*u8` strings. a thin bridge
+# over `std.types.string.str_equals` (nil-safe, identical semantics) via the
+# free `::str` cast, kept for the build/config call sites still in `*u8`.
 # ---
 # a:   first null-terminated byte string
 # b:   second null-terminated byte string
 # ret: true if both reach the terminator at the same position with matching bytes
 pub fun eq(a: *u8, b: *u8) bool {
-    if (a == b)               { ret true; }
-    if (a == nil || b == nil) { ret false; }
-    var i: usize = 0;
-    for (a[i] != 0 && b[i] != 0) {
-        if (a[i] != b[i]) { ret false; }
-        i = i + 1;
-    }
-    ret a[i] == b[i];
+    ret str_equals(a::str, b::str);
 }
 
-# slen: length in bytes of a null-terminated `*u8` string, excluding the terminator.
+# slen: length in bytes of a null-terminated `*u8` string, excluding the
+# terminator. a nil-safe adapter over `std.types.string.str_len` (which derefs
+# nil); returns 0 for nil. kept for the build/config `*u8` call sites and the
+# nil-safety gap (mach-std#204).
 # ---
 # s:   null-terminated byte string
 # ret: number of bytes before the terminator (0 for nil)
 pub fun slen(s: *u8) usize {
     if (s == nil) { ret 0; }
-    var n: usize = 0;
-    for (s[n] != 0) { n = n + 1; }
-    ret n;
+    ret str_len(s::str);
 }
 
 # cstr_str: view a null-terminated `*u8` as a length-counted `str`. the result
@@ -58,37 +62,30 @@ pub fun cstr_str(s: *u8) str {
     ret s::str;
 }
 
-# out: write a null-terminated `*u8` string to stdout.
+# out: write a null-terminated `*u8` string to stdout. delegates to
+# `std.print.print` over the `::str` bridge. transitional — being removed as
+# in-scope callers migrate to std directly (#1296).
 # ---
 # s: null-terminated byte string to write
 pub fun out(s: *u8) {
-    os.write(os.STDOUT_FD, s, slen(s));
+    print.print(s::str);
 }
 
-# emit: write a null-terminated `*u8` string to stderr.
+# emit: write a null-terminated `*u8` string to stderr. delegates to
+# `std.print.eprint` over the `::str` bridge (nil-safe; matches the prior
+# zero-byte write for nil). kept for the build/config `*u8` call sites.
 # ---
 # s: null-terminated byte string to write
 pub fun emit(s: *u8) {
-    os.write(os.STDERR_FD, s, slen(s));
+    print.eprint(s::str);
 }
 
-# emit_num: write the base-10 rendering of `n` to stderr.
+# emit_num: write the base-10 rendering of `n` to stderr via `std.print.eu64`.
+# kept for the build `*u8`-adjacent call sites.
 # ---
 # n: the value to render
 pub fun emit_num(n: usize) {
-    var buf: [24]u8;
-    var blen: usize = 0;
-    var v: usize = n;
-    if (v == 0) { buf[0] = '0'; blen = 1; }
-    or {
-        var tmp: [24]u8;
-        var t: usize = 0;
-        for (v > 0) { tmp[t] = (v % 10)::u8 + '0'; v = v / 10; t = t + 1; }
-        var ri: usize = 0;
-        for (ri < t) { buf[ri] = tmp[t - 1 - ri]; ri = ri + 1; }
-        blen = t;
-    }
-    os.write(os.STDERR_FD, ?buf[0], blen);
+    print.eu64(n::u64);
 }
 
 # has_flag: returns true if argv contains an exact match for `flag`.

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -62,15 +62,6 @@ pub fun cstr_str(s: *u8) str {
     ret s::str;
 }
 
-# out: write a null-terminated `*u8` string to stdout. delegates to
-# `std.print.print` over the `::str` bridge. transitional — being removed as
-# in-scope callers migrate to std directly (#1296).
-# ---
-# s: null-terminated byte string to write
-pub fun out(s: *u8) {
-    print.print(s::str);
-}
-
 # emit: write a null-terminated `*u8` string to stderr. delegates to
 # `std.print.eprint` over the `::str` bridge (nil-safe; matches the prior
 # zero-byte write for nil). kept for the build/config `*u8` call sites.


### PR DESCRIPTION
Migrates `src/cli/` off its hand-rolled reimplementations of `std` string/print primitives, per the inventory posted on #1296.

## What changes

- **`util.mach`**: `eq`/`slen`/`emit`/`emit_num` become thin `std` bridges (`str_equals`/`str_len`/`print.eprint`/`print.eu64`); `out` is deleted once its callers migrate. `cstr_str` (named `*u8`→`str` bridge) and the argv/path helpers stay — they are genuinely CLI-domain.
- **In-scope command files** (`cmd.mach`, `diagnostic.mach`, `cmd/{init,dep,doc,run,testing,help,check}.mach`) call `std` directly: `print.print`/`print.eprint`/`print.eu64`/`print.u64` for io, `str_equals`/`str_starts_with`/`str_region_equals` for predicates.
- **`dep.mach`** local reimplementations deleted: `out_str`/`err_str` (exact `std.print` dupes), `mem_eq` (its sole use is string equality → `str_equals`), `starts_with` (→ `str_starts_with`). **`doc.mach`** `write_uint` deleted (→ `print.u64`).

## Out of scope

`cmd/build.mach` and `config.mach` (manifest-v2 worker) keep their `util.eq`/`slen`/`emit`/`emit_num`/`cstr_str` call sites — the kept bridges serve them until a follow-up sweep (listed on #1296).

## Kept with reason

- `util.slen` — nil-safe adapter; `std.types.string.str_len` derefs nil (gap → mach-std#204).
- `doc.mach` `wr`/`wr_n` — write to an arbitrary `File`, not stdout/stderr; no `std.print` equivalent.
- text scanners (`doc.mach` offset-based `starts_with`, `line_*`) and caller-buffer builders — genuine parsing / no `std` concat-builder.

## Verification

Behavior-preserving: every user-visible help/error output byte-diffed before/after (identical). `mach build .` clean, `mach test .` green, self-host fixpoint converges.

Closes #1296
