### PR TITLE
feat(manifest): v2 matrix builds, cascading dep libs, defines wiring (phase 2)

### DIFF
--- a/.github/tests/manifestv2/app/mach.toml
+++ b/.github/tests/manifestv2/app/mach.toml
@@ -13,6 +13,7 @@ asm     = "out/{target}/{profile}/asm"
 isa = "x86_64"
 os  = "linux"
 abi = "sysv64"
+defines = ["shared_flag", "tier=1"]
 
 [target.windows]
 isa  = "x86_64"
@@ -26,6 +27,16 @@ entry = "hello.mach"
 
 [bin.bye]
 entry = "bye.mach"
+
+# tier exercises the #1191 define precedence end to end: a target-level flag, an
+# artifact-level flag, and a per-cell override of an integer define the program
+# branches on with `$if ($mach.build.<name>)`.
+[bin.tier]
+entry = "tier.mach"
+defines = ["extra_flag", "tier=2"]
+
+[bin.tier.target.linux]
+defines = ["tier=9"]
 
 [profile.debug]
 opt = "O0"

--- a/.github/tests/manifestv2/app/mach.toml
+++ b/.github/tests/manifestv2/app/mach.toml
@@ -21,6 +21,10 @@ os   = "windows"
 abi  = "win64"
 ext  = ".exe"
 libs = ["kernel32.dll"]
+# mirror the linux flags so the tier bin's `$mach.build.shared_flag` gate also
+# resolves under --all-targets; without a windows cell `tier` stays the artifact
+# default (3), exercising precedence falling back across targets.
+defines = ["shared_flag", "tier=1"]
 
 [bin.hello]
 entry = "hello.mach"

--- a/.github/tests/manifestv2/app/src/tier.mach
+++ b/.github/tests/manifestv2/app/src/tier.mach
@@ -1,0 +1,15 @@
+use std.runtime;
+
+# tier derives its exit code from the manifest defines (#1191) so the build can
+# assert each precedence level folded into the comptime context: the target-level
+# `shared_flag` (+1), the artifact-level `extra_flag` (+2), and `tier`, an integer
+# define the per-cell `[bin.tier.target.linux]` raises to 9 over the artifact's 2
+# and the target's 1 (+40). a clean linux build exits 43.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    var n: i64 = 0;
+    $if ($mach.build.shared_flag) { n = n + 1; }
+    $if ($mach.build.extra_flag)  { n = n + 2; }
+    $if ($mach.build.tier == 9)   { n = n + 40; }
+    ret n;
+}

--- a/.github/tests/manifestv2/cascade/dep/kdep/mach.toml
+++ b/.github/tests/manifestv2/cascade/dep/kdep/mach.toml
@@ -1,0 +1,15 @@
+# kdep: a v2-format dependency declaring its own windows link requirement. a
+# consumer building the windows tuple inherits kernel32.dll without naming it.
+[project]
+id      = "kdep"
+version = "0.1.0"
+src     = "src"
+
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+libs = ["kernel32.dll"]
+
+[lib.kdep]
+entry = "lib.mach"

--- a/.github/tests/manifestv2/cascade/dep/kdep/src/lib.mach
+++ b/.github/tests/manifestv2/cascade/dep/kdep/src/lib.mach
@@ -1,0 +1,4 @@
+# k: a trivial export so the consumer has a real reason to depend on kdep.
+pub fun k() i64 {
+    ret 0;
+}

--- a/.github/tests/manifestv2/cascade/dep/vdep/mach.toml
+++ b/.github/tests/manifestv2/cascade/dep/vdep/mach.toml
@@ -1,0 +1,16 @@
+# vdep: a v1-format (plural [targets.*]) dependency, proving the cascade reads
+# both manifest formats on the dep side during the transition. its windows link
+# requirement (user32.dll) is inherited by a windows consumer the same way.
+[project]
+id      = "vdep"
+version = "0.1.0"
+dir_src = "src"
+
+[targets.windows]
+os         = "windows"
+isa        = "x86_64"
+abi        = "win64"
+mode       = "library"
+entrypoint = "lib.mach"
+binary     = "windows/bin/libvdep.a"
+libs       = ["user32.dll"]

--- a/.github/tests/manifestv2/cascade/dep/vdep/src/lib.mach
+++ b/.github/tests/manifestv2/cascade/dep/vdep/src/lib.mach
@@ -1,0 +1,4 @@
+# v: a trivial export so the consumer has a real reason to depend on vdep.
+pub fun v() i64 {
+    ret 0;
+}

--- a/.github/tests/manifestv2/cascade/mach.toml
+++ b/.github/tests/manifestv2/cascade/mach.toml
@@ -1,0 +1,43 @@
+# cascade consumer: declares NO platform link libs of its own. its windows .exe
+# must still import kernel32.dll and user32.dll, inherited transitively from the
+# kdep (v2 manifest) and vdep (v1 manifest) dependencies by target-tuple equality
+# (#1218). a native (linux) build inherits neither — the deps declare those libs
+# only for the windows tuple — which a tuple-match bug would expose as a hard
+# "DLL against a non-PE target" link error.
+[project]
+id      = "cons"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+ir      = "out/{target}/{profile}/ir"
+asm     = "out/{target}/{profile}/asm"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+ext = ".exe"
+
+[bin.cons]
+entry = "main.mach"
+
+[profile.debug]
+opt = "O0"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.4.0"
+
+[deps.kdep]
+path = "dep/kdep"
+
+[deps.vdep]
+path = "dep/vdep"

--- a/.github/tests/manifestv2/cascade/src/main.mach
+++ b/.github/tests/manifestv2/cascade/src/main.mach
@@ -1,0 +1,10 @@
+use std.runtime;
+use k: kdep.lib;
+use v: vdep.lib;
+
+# the consumer links against both dep libs; the windows link inputs they each
+# require (kernel32.dll, user32.dll) arrive only through the manifest cascade.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret k.k() + v.v();
+}

--- a/.github/tests/manifestv2/run.sh
+++ b/.github/tests/manifestv2/run.sh
@@ -66,6 +66,12 @@ expect_fail() {
 expect_exit "native debug --bin hello" 7 "$APP/out/linux/debug/bin/hello"
 expect_exit "native debug --bin bye"   9 "$APP/out/linux/debug/bin/bye"
 
+# manifest defines (#1191) fold into the comptime context at each precedence
+# level: tier exits 43 only when the target flag, artifact flag, and per-cell
+# integer override of `tier` all reached `$if ($mach.build.<name>)`.
+( cd "$APP" && "$MACH" build . --bin tier )
+expect_exit "defines fold target<artifact<cell into \$mach.build.*" 43 "$APP/out/linux/debug/bin/tier"
+
 # release profile routes outputs to a separate directory (no debug overwrite).
 ( cd "$APP" && "$MACH" build . --bin hello --release )
 expect_exit "native release --bin hello" 7 "$APP/out/linux/release/bin/hello"

--- a/.github/tests/manifestv2/run.sh
+++ b/.github/tests/manifestv2/run.sh
@@ -72,6 +72,25 @@ expect_exit "native debug --bin bye"   9 "$APP/out/linux/debug/bin/bye"
 ( cd "$APP" && "$MACH" build . --bin tier )
 expect_exit "defines fold target<artifact<cell into \$mach.build.*" 43 "$APP/out/linux/debug/bin/tier"
 
+# `mach build .` with no selector builds every declared artifact (the multi-
+# artifact matrix), each to its own resolved path.
+rm -rf "$APP/out/linux"
+( cd "$APP" && "$MACH" build . )
+expect_exit "matrix build . builds hello" 7  "$APP/out/linux/debug/bin/hello"
+expect_exit "matrix build . builds bye"   9  "$APP/out/linux/debug/bin/bye"
+expect_exit "matrix build . builds tier"  43 "$APP/out/linux/debug/bin/tier"
+
+# --all-targets crosses every artifact with every declared target.
+rm -rf "$APP/out"
+( cd "$APP" && "$MACH" build . --all-targets )
+expect_exit "all-targets builds the linux cell" 7 "$APP/out/linux/debug/bin/hello"
+WEXE="$APP/out/windows/debug/bin/hello.exe"
+if [ -f "$WEXE" ] && head -c2 "$WEXE" | grep -q MZ; then
+    echo "PASS manifestv2: --all-targets builds the windows cell too"
+else
+    echo "FAIL manifestv2: --all-targets did not build the windows .exe" >&2; fail=1
+fi
+
 # release profile routes outputs to a separate directory (no debug overwrite).
 ( cd "$APP" && "$MACH" build . --bin hello --release )
 expect_exit "native release --bin hello" 7 "$APP/out/linux/release/bin/hello"
@@ -114,11 +133,18 @@ else
     echo "FAIL manifestv2: windows cross-compile produced no PE at $EXE" >&2; fail=1
 fi
 
-# loud failures: ambiguous default, unknown artifact, unknown target/profile.
-expect_fail "ambiguous default (two bins, no selector)" .
+# loud failures: unknown artifact, unknown target/profile.
 expect_fail "unknown bin selector" . --bin nope
 expect_fail "unknown target selector" . --bin hello --target bsd
 expect_fail "unknown profile selector" . --bin hello --profile fast
+
+# mach run builds exactly one artifact to exec, so an ambiguous default must
+# require --bin (naming the candidates) rather than silently picking one.
+if ( cd "$APP" && "$MACH" run . ) >/dev/null 2>&1; then
+    echo "FAIL manifestv2: ambiguous 'mach run .' did not require --bin" >&2; fail=1
+else
+    echo "PASS manifestv2: ambiguous 'mach run .' requires --bin"
+fi
 
 # a path collision (both bins to one fixed path) is rejected at build start.
 COLL="$WORK/coll"

--- a/.github/tests/manifestv2/run.sh
+++ b/.github/tests/manifestv2/run.sh
@@ -130,4 +130,32 @@ else
     echo "PASS manifestv2: colliding artifact paths fail at build start"
 fi
 
+# cascading transitive dep libs (#1218): the consumer declares no platform libs;
+# its windows .exe must inherit kernel32.dll (from the v2 dep kdep) and user32.dll
+# (from the v1 dep vdep) by target-tuple equality, while the native (linux) build
+# inherits neither — proving tuple gating (a leak would fail the link with a DLL
+# against a non-PE target).
+CASC="$WORK/cascade"
+cp -r "$HERE/cascade" "$CASC"
+ln -s "$STD" "$CASC/dep/mach-std"
+
+( cd "$CASC" && "$MACH" build . --target windows )
+CEXE="$CASC/out/windows/debug/bin/cons.exe"
+if [ -f "$CEXE" ] && strings "$CEXE" | grep -qi kernel32 && strings "$CEXE" | grep -qi user32; then
+    echo "PASS manifestv2: windows .exe inherits kernel32 (v2 dep) + user32 (v1 dep) via cascade"
+else
+    echo "FAIL manifestv2: cascade did not import both dep libs into the windows .exe" >&2; fail=1
+fi
+
+if ( cd "$CASC" && "$MACH" build . ) >/dev/null 2>&1; then
+    CBIN="$CASC/out/linux/debug/bin/cons"
+    if [ -x "$CBIN" ] && ! strings "$CBIN" | grep -qiE "kernel32|user32"; then
+        echo "PASS manifestv2: linux build inherits no windows-only dep libs (tuple gating)"
+    else
+        echo "FAIL manifestv2: a windows-only dep lib leaked into the linux build" >&2; fail=1
+    fi
+else
+    echo "FAIL manifestv2: native cascade build failed (windows-only dep libs wrongly inherited?)" >&2; fail=1
+fi
+
 exit "$fail"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -912,15 +912,18 @@ fun write_named_candidate(dir: *u8, prefix: *u8, name: *u8, ext: *u8, buf: *u8, 
     ret true;
 }
 
-# count_external_tokens: number of external link-input tokens — manifest
-# `[targets.*].libs` entries plus every `-l <name>` flag and bare object-file
-# path argument in argv. argv[0] (the program), the subcommand, every known
-# flag and its value, and the project-path positional are skipped so only real
-# link inputs are counted.
+# count_external_tokens: number of external link-input tokens — the selected
+# target's manifest libs, the cascading transitive dep libs (#1218), and every
+# `-l <name>` flag and bare object-file path argument in argv. argv[0] (the
+# program), the subcommand, every known flag and its value, and the project-path
+# positional are skipped so only real link inputs are counted.
 fun count_external_tokens(p: *driver.Project, argc: usize, argv: **u8) u32 {
     var n: u32 = 0;
     val te: *driver.TargetEntry = p.target_entry;
     if (te != nil) { n = n + te.lib_count; }
+    # cascading transitive dep libs (#1218); 0 for the old reader, which never
+    # populates the cascade.
+    n = n + p.config.cascade_lib_count;
 
     val proj_ix: usize = util.positional_index(argc, argv, 2);
     var i: usize = 0;
@@ -966,7 +969,8 @@ fun append_external_inputs(p: *driver.Project, root: *u8, argc: usize, argv: **u
     var written: u32 = base;
     var buf: [4096]u8;
 
-    # manifest libs first, then the CLI tokens — a stable order keeps the link
+    # the consumer's own manifest libs first, then the cascading transitive dep
+    # libs (#1218), then the CLI tokens — a stable order keeps the link
     # deterministic across runs.
     val te: *driver.TargetEntry = p.target_entry;
     if (te != nil) {
@@ -980,6 +984,17 @@ fun append_external_inputs(p: *driver.Project, root: *u8, argc: usize, argv: **u
             if (code != 0) { shrink_paths(p, paths, count, written, grown); ret code; }
             li = li + 1;
         }
+    }
+
+    var ci: u32 = 0;
+    for (ci < p.config.cascade_lib_count) {
+        val lib_opt: Option[str] = intern.lookup(?p.s.interner, p.config.cascade_libs[ci]);
+        if (is_none[str](lib_opt)) { ret 2; }
+        val tok: *u8 = unwrap[str](lib_opt)::*u8;
+        val code: i64 = resolve_and_store_input(p, tok, root, argc, argv, ?buf[0], 4096,
+                                                @paths, ?written, sonames, soname_count);
+        if (code != 0) { shrink_paths(p, paths, count, written, grown); ret code; }
+        ci = ci + 1;
     }
 
     val proj_ix: usize = util.positional_index(argc, argv, 2);

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -19,6 +19,7 @@ use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_empty;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
@@ -337,11 +338,11 @@ fun free_modules(p: *driver.Project,
 }
 
 
-# build: run the full build pipeline, returning the exit code and (on
-# success) the produced artifact path. this is the shared body behind
-# `run` that `cmd.run` and `cmd.test` reuse so they can build and then
-# exec. the returned `output_path`, when non-nil, is owned by `alloc` —
-# the caller frees it (and tears `alloc` down) once done with it.
+# build: compile a single build unit selected from the CLI flags. the shared body
+# behind `run` that `cmd.run` and `cmd.test` reuse so they can build one artifact
+# and then exec it; `mach build` itself iterates the build matrix (`run` below).
+# the returned `output_path`, when non-nil, is owned by `alloc` — the caller frees
+# it (and tears `alloc` down) once done with it.
 # ---
 # alloc:    allocator owning the session and the returned artifact path;
 #           must outlive the returned BuildResult
@@ -353,6 +354,14 @@ fun free_modules(p: *driver.Project,
 #            entry point, and always link an executable (even a library target)
 # ret:      a BuildResult carrying the exit code and artifact path
 pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mode: bool) BuildResult {
+    ret build_unit(alloc, argc, argv, emit_obj, test_mode, nil);
+}
+
+# build_unit: the single-unit build body. with `ovr` nil the target/artifact are
+# derived from the CLI flags (the `cmd.run`/`cmd.test` path); with `ovr` set they
+# come from one enumerated matrix cell (the `mach build` loop), the only field the
+# override replaces — profile and every other flag still apply to each unit.
+fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mode: bool, ovr: *driver.MatrixUnit) BuildResult {
     var br: BuildResult;
     br.code        = 2;
     br.output_path = nil;
@@ -405,35 +414,44 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_m
     or (util.has_flag(eff, argv, "-O2"))      { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
     or (util.has_flag(eff, argv, "--release")) { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
 
-    # when --target is absent, defer to [project].target from mach.toml
-    # (the driver resolves "native"/"host" to the host-matching entry).
-    var target_name: *u8 = config.target;
-    if (target_name == nil) { target_name = ""; }
-
     # the build selection threaded to the driver. for a v2 manifest it narrows
     # target/profile/artifact; the old reader uses only the target. `--release`
     # is sugar for `--profile release`, and `--bin`/`--lib` are mutually exclusive.
+    # profile applies to every matrix unit, so it is read from the flags even under
+    # an override.
     var profile_name: *u8 = config.profile;
     if (profile_name == nil && config.release) { profile_name = "release"; }
     if (profile_name == nil) { profile_name = ""; }
 
-    var artifact_name: *u8 = "";
-    var want_lib:      bool = false;
-    var has_artifact:  bool = false;
-    if (config.bin != nil && config.lib != nil) {
-        util.emit("error: --bin and --lib cannot be combined\n");
-        br.code = 1;
-        ret br;
-    }
-    if (config.bin != nil) { artifact_name = config.bin; has_artifact = true; }
-    or (config.lib != nil) { artifact_name = config.lib; want_lib = true; has_artifact = true; }
-
     var sel: manifest.Selection;
-    sel.target       = util.cstr_str(target_name);
-    sel.profile      = util.cstr_str(profile_name);
-    sel.artifact     = util.cstr_str(artifact_name);
-    sel.want_lib     = want_lib;
-    sel.has_artifact = has_artifact;
+    sel.profile = util.cstr_str(profile_name);
+    if (ovr != nil) {
+        # one enumerated matrix cell: target and artifact are pre-selected.
+        sel.target       = ovr.target;
+        sel.artifact     = ovr.artifact;
+        sel.want_lib     = ovr.want_lib;
+        sel.has_artifact = ovr.has_artifact;
+    }
+    or {
+        # when --target is absent, defer to [project].target from mach.toml
+        # (the driver resolves "native"/"host" to the host-matching entry).
+        var target_name: *u8 = config.target;
+        if (target_name == nil) { target_name = ""; }
+        var artifact_name: *u8 = "";
+        var want_lib:      bool = false;
+        var has_artifact:  bool = false;
+        if (config.bin != nil && config.lib != nil) {
+            util.emit("error: --bin and --lib cannot be combined\n");
+            br.code = 1;
+            ret br;
+        }
+        if (config.bin != nil) { artifact_name = config.bin; has_artifact = true; }
+        or (config.lib != nil) { artifact_name = config.lib; want_lib = true; has_artifact = true; }
+        sel.target       = util.cstr_str(target_name);
+        sel.artifact     = util.cstr_str(artifact_name);
+        sel.want_lib     = want_lib;
+        sel.has_artifact = has_artifact;
+    }
 
     val sess_r: Result[sess.Session, str] = sess.init(alloc);
     if (is_err[sess.Session, str](sess_r)) {
@@ -1655,31 +1673,129 @@ pub fun run(argc: usize, argv: **u8) i64 {
         }
     }
 
-    # back the build with an arena over a page allocator: the page
-    # allocator mmaps once per allocation, so the allocation-heavy compile
-    # is suballocated through an arena and reclaimed in one dnit.
+    # back the build with a page allocator; the matrix enumeration and each unit
+    # get their own arena over it so a unit's compile memory is reclaimed before
+    # the next, while the enumerated selectors (owned by `menu_ar`) outlive the
+    # loop. the page allocator mmaps per allocation, so the allocation-heavy
+    # compile is suballocated through an arena and reclaimed in one dnit.
     var backing: Allocator;
     if (is_some[str](page.make(?backing))) {
         util.emit("error: failed to initialise allocator\n");
         ret 2;
     }
 
-    var ar: arena.Arena;
-    if (is_some[str](arena.init(?ar, ?backing, 0))) {
+    # post-`--` args are program arguments, never build flags; clip the scanners.
+    val eff: usize = util.separator_index(argc, argv);
+    val cfg_opt: Option[cfg.Config] = cfg.parse(eff, argv);
+    if (is_none[cfg.Config](cfg_opt)) {
+        util.emit("error: invalid command-line flags\n");
+        ret 1;
+    }
+    val config: cfg.Config = unwrap[cfg.Config](cfg_opt);
+    if (config.bin != nil && config.lib != nil) {
+        util.emit("error: --bin and --lib cannot be combined\n");
+        ret 1;
+    }
+
+    # the project root: the first non-flag positional, else --cwd, else the cwd.
+    var start: *u8 = config.cwd;
+    val pix: usize = util.positional_index(eff, argv, 2);
+    if (pix < eff) {
+        if (config.cwd != nil) {
+            util.emit("error: cannot combine a project-path positional with --cwd\n");
+            ret 1;
+        }
+        start = argv[pix];
+    }
+    var root: [4096]u8;
+    if (!util.find_project_root(start, ?root[0], 4096)) {
+        util.emit("error: no mach.toml found in the working directory or any parent\n");
+        ret 1;
+    }
+
+    # enumerate the build matrix in its own arena, kept alive across the loop so
+    # the unit selectors it owns stay valid.
+    var menu_ar: arena.Arena;
+    if (is_some[str](arena.init(?menu_ar, ?backing, 0))) {
+        util.emit("error: failed to initialise allocator\n");
+        ret 2;
+    }
+    var menu_alloc: Allocator;
+    if (is_some[str](arena.make(?menu_alloc, ?menu_ar))) {
+        arena.dnit(?menu_ar);
         util.emit("error: failed to initialise allocator\n");
         ret 2;
     }
 
-    var alloc: Allocator;
-    if (is_some[str](arena.make(?alloc, ?ar))) {
-        arena.dnit(?ar);
-        util.emit("error: failed to initialise allocator\n");
-        ret 2;
+    val mx_r: Result[driver.Matrix, str] = driver.enumerate_matrix(?menu_alloc, util.cstr_str(?root[0]),
+        util.cstr_str(cstr_or(config.target)), config.all_targets,
+        util.cstr_str(cstr_or(config.bin)), util.cstr_str(cstr_or(config.lib)),
+        config.bin != nil, config.lib != nil);
+    if (is_err[driver.Matrix, str](mx_r)) {
+        util.emit("error: ");
+        util.emit(unwrap_err[driver.Matrix, str](mx_r));
+        util.emit("\n");
+        arena.dnit(?menu_ar);
+        ret 1;
+    }
+    val mx: driver.Matrix = unwrap_ok[driver.Matrix, str](mx_r);
+    if (mx.count == 0) {
+        util.emit("error: nothing to build\n");
+        arena.dnit(?menu_ar);
+        ret 1;
     }
 
-    val br: BuildResult = build(?alloc, argc, argv, emit_obj, false);
-    arena.dnit(?ar);
-    ret br.code;
+    # build each unit in a fresh arena (its compile memory reclaimed per unit);
+    # report per unit when more than one, and fail the invocation if any unit does.
+    var code: i64 = 0;
+    var ui: u32 = 0;
+    for (ui < mx.count) {
+        val unit: *driver.MatrixUnit = ?mx.units[ui];
+        if (mx.count > 1) { report_unit(unit); }
+
+        var u_ar: arena.Arena;
+        if (is_some[str](arena.init(?u_ar, ?backing, 0))) {
+            util.emit("error: failed to initialise allocator\n");
+            arena.dnit(?menu_ar);
+            ret 2;
+        }
+        var u_alloc: Allocator;
+        if (is_some[str](arena.make(?u_alloc, ?u_ar))) {
+            arena.dnit(?u_ar);
+            arena.dnit(?menu_ar);
+            util.emit("error: failed to initialise allocator\n");
+            ret 2;
+        }
+
+        val br: BuildResult = build_unit(?u_alloc, argc, argv, emit_obj, false, unit);
+        if (br.code != 0 && code == 0) { code = br.code; }
+        arena.dnit(?u_ar);
+        ui = ui + 1;
+    }
+
+    arena.dnit(?menu_ar);
+    ret code;
+}
+
+# cstr_or: a non-nil view of an optional flag value — the value itself, or the
+# empty string when the flag is absent (so cstr_str always sees a valid pointer).
+fun cstr_or(p: *u8) *u8 {
+    if (p == nil) { ret ""; }
+    ret p;
+}
+
+# report_unit: write a `building <artifact> (<target>)` progress line to stderr
+# before a matrix unit compiles. the target is omitted when it is the default.
+fun report_unit(u: *driver.MatrixUnit) {
+    util.emit("building ");
+    if (u.has_artifact) { util.emit(u.artifact::*u8); }
+    or                  { util.emit("project"); }
+    if (!str_empty(u.target)) {
+        util.emit(" (");
+        util.emit(u.target::*u8);
+        util.emit(")");
+    }
+    util.emit("\n");
 }
 
 # emit_kind: scan argv for the value following `--emit`, exposed so

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -75,6 +75,7 @@ pub rec Config {
     release:     bool;
     bin:         *u8;
     lib:         *u8;
+    all_targets: bool;
 }
 
 # color_enabled: resolve a ColorMode to a concrete on/off decision for the
@@ -115,6 +116,7 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
     c.release     = false;
     c.bin         = nil;
     c.lib         = nil;
+    c.all_targets = false;
 
     val verbose: bool = util.has_flag(argc, argv, "--verbose") || util.has_flag(argc, argv, "-v");
     val quiet:   bool = util.has_flag(argc, argv, "--quiet")   || util.has_flag(argc, argv, "-q");
@@ -129,6 +131,7 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
     c.no_emit_asm = util.has_flag(argc, argv, "--no-emit-asm");
     c.no_emit_ir  = util.has_flag(argc, argv, "--no-emit-ir");
     c.release     = util.has_flag(argc, argv, "--release");
+    c.all_targets = util.has_flag(argc, argv, "--all-targets");
 
     val color_opt: Option[*u8] = util.get_value(argc, argv, "--color");
     if (is_some[*u8](color_opt)) {

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -295,6 +295,129 @@ pub fun build_project(s: *sess.Session, project_root: str, target_name: str) Res
     ret build_project_sel(s, project_root, ?sel);
 }
 
+# MatrixUnit: one (target, artifact) cell a `mach build` invocation compiles.
+# `target` is a declared target name, "native"/"host", or "" for the manifest
+# default; `artifact` is a `[bin.*]`/`[lib.*]` name, "" when none is named.
+# strings borrow the enumeration allocator and are valid for the build loop.
+# ---
+# target:       target selector for this cell
+# artifact:     artifact selector for this cell
+# want_lib:     the artifact is a `[lib.*]` (disambiguates a name)
+# has_artifact: an artifact is named
+pub rec MatrixUnit {
+    target:       str;
+    artifact:     str;
+    want_lib:     bool;
+    has_artifact: bool;
+}
+
+# Matrix: the enumerated build matrix for a `mach build` invocation.
+# ---
+# units: one MatrixUnit per (target, artifact) cell, in build order
+# count: number of units
+pub rec Matrix {
+    units: *MatrixUnit;
+    count: u32;
+}
+
+# enumerate_matrix: expand the build matrix a `mach build` invocation drives.
+# reads `project_root/mach.toml` and, for a v2 manifest, produces one MatrixUnit
+# per (target, artifact) cell to build: every declared `[bin.*]`/`[lib.*]` in
+# declaration order (bins then libs) unless narrowed by `bin`/`lib`, crossed with
+# the selected target(s) — `target_filter` when named, every declared target when
+# `all_targets`, else the single manifest default. an old-format manifest yields a
+# single target-only unit, its artifact model unchanged. the manifest and its
+# interned selector strings are allocated in `alloc` and must remain valid for the
+# whole build loop (so `alloc` outlives every per-unit build).
+pub fun enumerate_matrix(alloc: *Allocator, project_root: str,
+                         target_filter: str, all_targets: bool,
+                         bin: str, lib: str, has_bin: bool, has_lib: bool) Result[Matrix, str] {
+    val toml_path_r: Result[str, str] = join_path(alloc, project_root, "mach.toml");
+    if (is_err[str, str](toml_path_r)) { ret err[Matrix, str](unwrap_err[str, str](toml_path_r)); }
+    val toml_path: str = unwrap_ok[str, str](toml_path_r);
+    val toml_r: Result[toml.Table, str] = parse_toml_file(alloc, toml_path);
+    str_free(alloc, toml_path);
+    if (is_err[toml.Table, str](toml_r)) { ret err[Matrix, str](unwrap_err[toml.Table, str](toml_r)); }
+    var t: toml.Table = unwrap_ok[toml.Table, str](toml_r);
+
+    # the old reader has no artifact axis: a single target-only unit reproduces
+    # the legacy single-build behaviour exactly.
+    if (!manifest.is_v2(?t)) {
+        ret single_matrix(alloc, target_filter, "", false, false);
+    }
+
+    var itn: intern.Interner = intern.init(alloc);
+    val mr: Result[manifest.Manifest, str] = manifest.parse(alloc, ?itn, ?t);
+    if (is_err[manifest.Manifest, str](mr)) { ret err[Matrix, str](unwrap_err[manifest.Manifest, str](mr)); }
+    var m: manifest.Manifest = unwrap_ok[manifest.Manifest, str](mr);
+
+    # the target axis: a named filter, every declared target, or the default.
+    var tn: u32 = 1;
+    if (all_targets && str_empty(target_filter)) { tn = m.target_count; }
+    if (tn == 0) { ret err[Matrix, str]("mach.toml: --all-targets but no [target.*] declared"); }
+
+    # the artifact axis: a named bin/lib, or every declared artifact.
+    var an: u32 = 1;
+    if (!has_bin && !has_lib) { an = m.artifact_count; }
+    if (an == 0) { ret err[Matrix, str]("mach.toml: no [bin.*] or [lib.*] artifacts declared"); }
+
+    val ur: Result[*MatrixUnit, str] = allocate[MatrixUnit](alloc, (tn * an)::usize);
+    if (is_err[*MatrixUnit, str](ur)) { ret err[Matrix, str](unwrap_err[*MatrixUnit, str](ur)); }
+    val units: *MatrixUnit = unwrap_ok[*MatrixUnit, str](ur);
+
+    var w: u32 = 0;
+    var ti: u32 = 0;
+    for (ti < tn) {
+        var tname: str = target_filter;
+        if (all_targets && str_empty(target_filter)) {
+            val to: Option[str] = intern.lookup(?itn, m.targets[ti].name);
+            if (is_none[str](to)) { ret err[Matrix, str]("internal: target name not interned"); }
+            tname = unwrap[str](to);
+        }
+        var ai: u32 = 0;
+        for (ai < an) {
+            var u: MatrixUnit;
+            u.target       = tname;
+            u.has_artifact = true;
+            if (has_bin)      { u.artifact = bin; u.want_lib = false; }
+            or (has_lib)      { u.artifact = lib; u.want_lib = true;  }
+            or {
+                val ao: Option[str] = intern.lookup(?itn, m.artifacts[ai].name);
+                if (is_none[str](ao)) { ret err[Matrix, str]("internal: artifact name not interned"); }
+                u.artifact = unwrap[str](ao);
+                u.want_lib = m.artifacts[ai].is_lib;
+            }
+            units[w] = u;
+            w = w + 1;
+            ai = ai + 1;
+        }
+        ti = ti + 1;
+    }
+
+    var mx: Matrix;
+    mx.units = units;
+    mx.count = w;
+    ret ok[Matrix, str](mx);
+}
+
+# single_matrix: a one-unit matrix for the given selector — the old reader's only
+# shape, and the v2 narrowing where exactly one cell results.
+fun single_matrix(alloc: *Allocator, target: str, artifact: str, want_lib: bool, has_artifact: bool) Result[Matrix, str] {
+    val ur: Result[*MatrixUnit, str] = allocate[MatrixUnit](alloc, 1::usize);
+    if (is_err[*MatrixUnit, str](ur)) { ret err[Matrix, str](unwrap_err[*MatrixUnit, str](ur)); }
+    val units: *MatrixUnit = unwrap_ok[*MatrixUnit, str](ur);
+    var u: MatrixUnit;
+    u.target       = target;
+    u.artifact     = artifact;
+    u.want_lib     = want_lib;
+    u.has_artifact = has_artifact;
+    units[0] = u;
+    var mx: Matrix;
+    mx.units = units;
+    mx.count = 1;
+    ret ok[Matrix, str](mx);
+}
+
 # build_project_sel: load `project_root/mach.toml` and build the module graph
 # for the given build selection (target, profile, and one artifact). the v2
 # reader resolves the selection into the project's single target entry and

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -167,6 +167,11 @@ pub rec DepEntry {
 #                  < cell), each `NAME` or `NAME=VALUE`; bound into every module's
 #                  comptime ctx during load (#1191). v2 only; nil when none
 # v2_define_count: number of entries in v2_defines
+# cascade_libs:      transitive dependency link inputs whose declared target tuple
+#                    (isa, os, abi) matches the selected target's, in topological
+#                    dep then declaration order, deduplicated by name and excluding
+#                    the consumer's own libs (#1218); nil when none
+# cascade_lib_count: number of entries in cascade_libs
 pub rec ProjectConfig {
     id:           intern.StrId;
     dir_src:      intern.StrId;
@@ -187,6 +192,8 @@ pub rec ProjectConfig {
     v2_emit_asm:  bool;
     v2_defines:      *intern.StrId;
     v2_define_count: u32;
+    cascade_libs:      *intern.StrId;
+    cascade_lib_count: u32;
 }
 
 # PubConst: one comptime constant exported by a module to its importers.
@@ -606,6 +613,8 @@ fun init_project(p: *Project, s: *sess.Session) {
     p.config.v2_emit_asm  = false;
     p.config.v2_defines       = nil;
     p.config.v2_define_count  = 0;
+    p.config.cascade_libs      = nil;
+    p.config.cascade_lib_count = 0;
     p.modules       = nil;
     p.module_len    = 0;
     p.module_cap    = 0;
@@ -635,12 +644,17 @@ fun deallocate_config(c: *ProjectConfig, alloc: *Allocator) {
     if (c.v2_defines != nil && c.v2_define_count > 0) {
         deallocate[intern.StrId](alloc, c.v2_defines, c.v2_define_count::usize);
     }
+    if (c.cascade_libs != nil && c.cascade_lib_count > 0) {
+        deallocate[intern.StrId](alloc, c.cascade_libs, c.cascade_lib_count::usize);
+    }
     c.targets      = nil;
     c.target_count = 0;
     c.deps         = nil;
     c.dep_count    = 0;
     c.v2_defines       = nil;
     c.v2_define_count  = 0;
+    c.cascade_libs      = nil;
+    c.cascade_lib_count = 0;
 }
 
 fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection) Result[bool, str] {
@@ -765,6 +779,20 @@ fun load_v2_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifes
     val dr: Result[bool, str] = resolve_v2_deps(p, ?m, project_root);
     if (is_err[bool, str](dr)) { manifest.dnit(?m, p.s.alloc); ret dr; }
 
+    # cascade the transitive deps' tuple-matched link libs into the build. the
+    # tuple strings come from the selected target (interner-owned, so stable past
+    # the manifest teardown below); the dep manifests are read fresh.
+    val isa_opt: Option[str] = intern.lookup(?p.s.interner, bu.target.isa);
+    val os_opt:  Option[str] = intern.lookup(?p.s.interner, bu.target.os);
+    val abi_opt: Option[str] = intern.lookup(?p.s.interner, bu.target.abi);
+    if (is_none[str](isa_opt) || is_none[str](os_opt) || is_none[str](abi_opt)) {
+        manifest.dnit(?m, p.s.alloc);
+        ret err[bool, str]("internal: selected target tuple not interned");
+    }
+    val cr2: Result[bool, str] = resolve_cascade_libs(p, project_root,
+        unwrap[str](isa_opt), unwrap[str](os_opt), unwrap[str](abi_opt), bu.libs, bu.lib_count);
+    if (is_err[bool, str](cr2)) { manifest.dnit(?m, p.s.alloc); ret cr2; }
+
     manifest.dnit(?m, p.s.alloc);
     ret ok[bool, str](true);
 }
@@ -823,6 +851,188 @@ fun resolve_v2_deps(p: *Project, m: *manifest.Manifest, project_root: str) Resul
         i = i + 1;
     }
     ret ok[bool, str](true);
+}
+
+# resolve_cascade_libs: gather the transitive dependencies' tuple-matched link
+# libs into `p.config.cascade_libs` (#1218). a dependency declares its own
+# `[target.*].libs` (v2) or `[targets.*].libs`/`.link` (v1) — both formats are read
+# on the dep side during the transition — and a consumer inherits every such lib
+# whose target tuple (isa, os, abi) equals the one being built, so a platform link
+# requirement (e.g. `kernel32.dll`) lives once in the providing dependency's
+# manifest. order is topological (a dep's own deps first) then declaration order;
+# libs are deduplicated by name and the consumer's own `own_libs` are excluded, so
+# a shared requirement is never linked twice. an empty result leaves the cascade
+# nil/0, so a build with no inheriting deps is unaffected.
+fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi: str,
+                         own_libs: *intern.StrId, own_count: u32) Result[bool, str] {
+    p.config.cascade_libs      = nil;
+    p.config.cascade_lib_count = 0;
+    val n: u32 = p.config.dep_count;
+    if (n == 0) { ret ok[bool, str](true); }
+
+    # parse every dep manifest once and resolve its alias string up front; both
+    # drive the ordering and lib collection below.
+    val tr: Result[*toml.Table, str] = allocate[toml.Table](p.s.alloc, n::usize);
+    if (is_err[*toml.Table, str](tr)) { ret err[bool, str](unwrap_err[*toml.Table, str](tr)); }
+    val tables: *toml.Table = unwrap_ok[*toml.Table, str](tr);
+    val ar: Result[*str, str] = allocate[str](p.s.alloc, n::usize);
+    if (is_err[*str, str](ar)) { ret err[bool, str](unwrap_err[*str, str](ar)); }
+    val aliases: *str = unwrap_ok[*str, str](ar);
+
+    var i: u32 = 0;
+    for (i < n) {
+        val vr_opt: Option[str] = intern.lookup(?p.s.interner, p.config.deps[i].vendor_root);
+        val al_opt: Option[str] = intern.lookup(?p.s.interner, p.config.deps[i].alias);
+        if (is_none[str](vr_opt) || is_none[str](al_opt)) { ret err[bool, str]("internal: dep metadata not interned"); }
+        aliases[i] = unwrap[str](al_opt);
+        val tp_r: Result[str, str] = join_path(p.s.alloc, unwrap[str](vr_opt), "mach.toml");
+        if (is_err[str, str](tp_r)) { ret err[bool, str](unwrap_err[str, str](tp_r)); }
+        val tp: str = unwrap_ok[str, str](tp_r);
+        val pr: Result[toml.Table, str] = parse_toml_file(p.s.alloc, tp);
+        str_free(p.s.alloc, tp);
+        if (is_err[toml.Table, str](pr)) { ret err[bool, str](unwrap_err[toml.Table, str](pr)); }
+        tables[i] = unwrap_ok[toml.Table, str](pr);
+        i = i + 1;
+    }
+
+    # topological dep order via post-order DFS over the inter-dep `[deps.*]` graph.
+    val ov: Result[*u32, str] = allocate[u32](p.s.alloc, n::usize);
+    if (is_err[*u32, str](ov)) { ret err[bool, str](unwrap_err[*u32, str](ov)); }
+    val order: *u32 = unwrap_ok[*u32, str](ov);
+    val vv: Result[*bool, str] = allocate[bool](p.s.alloc, n::usize);
+    if (is_err[*bool, str](vv)) { ret err[bool, str](unwrap_err[*bool, str](vv)); }
+    val visited: *bool = unwrap_ok[*bool, str](vv);
+    i = 0;
+    for (i < n) { visited[i] = false; i = i + 1; }
+    var order_len: u32 = 0;
+    i = 0;
+    for (i < n) { cascade_dfs(?tables[0], aliases, visited, order, ?order_len, n, i); i = i + 1; }
+
+    # upper-bound by the total tuple-matched lib count, then fill with dedup.
+    var max: u32 = 0;
+    i = 0;
+    for (i < n) {
+        val arr: *toml.Array = tuple_libs(?tables[i], isa, os, abi);
+        if (arr != nil) { max = max + toml.array_len(arr)::u32; }
+        i = i + 1;
+    }
+    if (max == 0) { ret ok[bool, str](true); }
+
+    val br: Result[*intern.StrId, str] = allocate[intern.StrId](p.s.alloc, max::usize);
+    if (is_err[*intern.StrId, str](br)) { ret err[bool, str](unwrap_err[*intern.StrId, str](br)); }
+    val buf: *intern.StrId = unwrap_ok[*intern.StrId, str](br);
+    var w: u32 = 0;
+
+    var oi: u32 = 0;
+    for (oi < order_len) {
+        val di: u32 = order[oi];
+        val arr: *toml.Array = tuple_libs(?tables[di], isa, os, abi);
+        if (arr != nil) {
+            val cnt: usize = toml.array_len(arr);
+            var k: usize = 0;
+            for (k < cnt) {
+                val v: *toml.Value = toml.array_get(arr, k);
+                if (v == nil || v.tag != toml.TYPE_STRING) {
+                    deallocate[intern.StrId](p.s.alloc, buf, max::usize);
+                    ret err[bool, str]("dep mach.toml: a target's libs entry is not a string");
+                }
+                val idr: Result[intern.StrId, str] = intern.intern(?p.s.interner, v.data.string);
+                if (is_err[intern.StrId, str](idr)) {
+                    deallocate[intern.StrId](p.s.alloc, buf, max::usize);
+                    ret err[bool, str](unwrap_err[intern.StrId, str](idr));
+                }
+                val id: intern.StrId = unwrap_ok[intern.StrId, str](idr);
+                if (!strid_in(buf, w, id) && !strid_in(own_libs, own_count, id)) {
+                    buf[w] = id; w = w + 1;
+                }
+                k = k + 1;
+            }
+        }
+        oi = oi + 1;
+    }
+
+    if (w == 0) {
+        deallocate[intern.StrId](p.s.alloc, buf, max::usize);
+        ret ok[bool, str](true);
+    }
+    if (w < max) {
+        val sr: Result[*intern.StrId, str] = reallocate[intern.StrId](p.s.alloc, buf, max::usize, w::usize);
+        if (is_ok[*intern.StrId, str](sr)) {
+            p.config.cascade_libs      = unwrap_ok[*intern.StrId, str](sr);
+            p.config.cascade_lib_count = w;
+            ret ok[bool, str](true);
+        }
+    }
+    p.config.cascade_libs      = buf;
+    p.config.cascade_lib_count = w;
+    ret ok[bool, str](true);
+}
+
+# cascade_dfs: post-order DFS visiting a dep's own declared deps before the dep
+# itself, so the emitted order is topological (dependencies first) with siblings
+# kept in declaration order. `base` points at the dep manifest table array.
+fun cascade_dfs(base: *toml.Table, aliases: *str, visited: *bool, order: *u32, order_len: *u32, n: u32, i: u32) {
+    if (visited[i]) { ret; }
+    visited[i] = true;
+    var j: u32 = 0;
+    for (j < n) {
+        if (j != i && dep_declares(?base[i], aliases[j])) {
+            cascade_dfs(base, aliases, visited, order, order_len, n, j);
+        }
+        j = j + 1;
+    }
+    order[@order_len] = i;
+    @order_len = @order_len + 1;
+}
+
+# dep_declares: whether dep manifest `t` lists `alias` under its own `[deps.*]`.
+fun dep_declares(t: *toml.Table, alias: str) bool {
+    val deps_tab: *toml.Table = toml.get_table(t, "deps");
+    if (deps_tab == nil) { ret false; }
+    val m: usize = toml.table_len(deps_tab);
+    var k: usize = 0;
+    for (k < m) {
+        if (str_equals(toml.table_key(deps_tab, k), alias)) { ret true; }
+        k = k + 1;
+    }
+    ret false;
+}
+
+# tuple_libs: the `libs`/`link` array of the dep target whose (isa, os, abi) tuple
+# matches the build's, reading the v2 `[target.*]` table then the v1 `[targets.*]`
+# table. nil when the dep declares no matching target or it carries no libs.
+fun tuple_libs(t: *toml.Table, isa: str, os: str, abi: str) *toml.Array {
+    var parent: *toml.Table = toml.get_table(t, "target");
+    if (parent == nil) { parent = toml.get_table(t, "targets"); }
+    if (parent == nil) { ret nil; }
+    val m: usize = toml.table_len(parent);
+    var k: usize = 0;
+    for (k < m) {
+        val v: *toml.Value = toml.table_value(parent, k);
+        if (v != nil && v.tag == toml.TYPE_TABLE) {
+            val sub: *toml.Table = ?v.data.table;
+            if (str_equals(toml.get_str(sub, "isa"), isa)
+             && str_equals(toml.get_str(sub, "os"),  os)
+             && str_equals(toml.get_str(sub, "abi"), abi)) {
+                var arr: *toml.Array = toml.get_array(sub, "libs");
+                if (arr == nil) { arr = toml.get_array(sub, "link"); }
+                ret arr;
+            }
+        }
+        k = k + 1;
+    }
+    ret nil;
+}
+
+# strid_in: whether `id` already appears in the first `count` entries of `arr`.
+fun strid_in(arr: *intern.StrId, count: u32, id: intern.StrId) bool {
+    if (arr == nil) { ret false; }
+    var k: u32 = 0;
+    for (k < count) {
+        if (arr[k] == id) { ret true; }
+        k = k + 1;
+    }
+    ret false;
 }
 
 fun parse_targets_table(p: *Project, t: *toml.Table) Result[bool, str] {

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -163,6 +163,10 @@ pub rec DepEntry {
 # v2_asm_root:  interned resolved ASM-dump dir (root-relative), v2 only
 # v2_emit_ir:   selected profile's IR-emission default, v2 only
 # v2_emit_asm:  selected profile's ASM-emission default, v2 only
+# v2_defines:      merged comptime defines for the selected unit (artifact < target
+#                  < cell), each `NAME` or `NAME=VALUE`; bound into every module's
+#                  comptime ctx during load (#1191). v2 only; nil when none
+# v2_define_count: number of entries in v2_defines
 pub rec ProjectConfig {
     id:           intern.StrId;
     dir_src:      intern.StrId;
@@ -181,6 +185,8 @@ pub rec ProjectConfig {
     v2_asm_root:  intern.StrId;
     v2_emit_ir:   bool;
     v2_emit_asm:  bool;
+    v2_defines:      *intern.StrId;
+    v2_define_count: u32;
 }
 
 # PubConst: one comptime constant exported by a module to its importers.
@@ -598,6 +604,8 @@ fun init_project(p: *Project, s: *sess.Session) {
     p.config.v2_asm_root  = intern.STR_NIL;
     p.config.v2_emit_ir   = false;
     p.config.v2_emit_asm  = false;
+    p.config.v2_defines       = nil;
+    p.config.v2_define_count  = 0;
     p.modules       = nil;
     p.module_len    = 0;
     p.module_cap    = 0;
@@ -624,10 +632,15 @@ fun deallocate_config(c: *ProjectConfig, alloc: *Allocator) {
     if (c.deps != nil && c.dep_count > 0) {
         deallocate[DepEntry](alloc, c.deps, c.dep_count::usize);
     }
+    if (c.v2_defines != nil && c.v2_define_count > 0) {
+        deallocate[intern.StrId](alloc, c.v2_defines, c.v2_define_count::usize);
+    }
     c.targets      = nil;
     c.target_count = 0;
     c.deps         = nil;
     c.dep_count    = 0;
+    c.v2_defines       = nil;
+    c.v2_define_count  = 0;
 }
 
 fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection) Result[bool, str] {
@@ -745,6 +758,8 @@ fun load_v2_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifes
     p.config.v2_asm_root  = bu.asm_root;
     p.config.v2_emit_ir   = bu.emit_ir;
     p.config.v2_emit_asm  = bu.emit_asm;
+    p.config.v2_defines       = bu.defines;
+    p.config.v2_define_count  = bu.define_count;
     p.target_entry        = ?p.config.targets[0];
 
     val dr: Result[bool, str] = resolve_v2_deps(p, ?m, project_root);
@@ -1413,9 +1428,145 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) Result[sess.ModuleId, s
     p.modules[p.module_len] = m;
     p.module_len = p.module_len + 1;
 
+    # bind the selected unit's manifest defines (#1191) into this module's ctx so
+    # `$if ($mach.build.NAME)` folds identically in every module of the graph.
+    val bd_r: Result[bool, str] = bind_v2_defines(p, ?p.modules[mid::u32].ctx);
+    if (is_err[bool, str](bd_r)) { ret err[sess.ModuleId, str](unwrap_err[bool, str](bd_r)); }
+
     val ins_r: Result[bool, str] = map.insert[intern.StrId, sess.ModuleId](?p.by_fqn, fqn, mid);
     if (is_err[bool, str](ins_r)) { ret err[sess.ModuleId, str](unwrap_err[bool, str](ins_r)); }
     ret ok[sess.ModuleId, str](mid);
+}
+
+# bind_v2_defines: bind every selected-unit manifest define (#1191) into a freshly
+# initialised module ctx. each entry is `NAME` (a comptime bool flag, `true`) or
+# `NAME=VALUE` where VALUE is a comptime literal — `true`/`false` (bool), an
+# integer literal (int), else a string. an empty define list is a strict no-op, so
+# a manifest declaring no defines stays fixpoint-stable.
+fun bind_v2_defines(p: *Project, ctx: *comptime.ComptimeCtx) Result[bool, str] {
+    if (!p.config.is_v2 || p.config.v2_define_count == 0) { ret ok[bool, str](true); }
+    var i: u32 = 0;
+    for (i < p.config.v2_define_count) {
+        val s_opt: Option[str] = intern.lookup(?p.s.interner, p.config.v2_defines[i]);
+        if (is_none[str](s_opt)) { ret err[bool, str]("define StrId not interned"); }
+        val r: Result[bool, str] = bind_one_define(p, ctx, unwrap[str](s_opt));
+        if (is_err[bool, str](r)) { ret r; }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# bind_one_define: parse a single `NAME` / `NAME=VALUE` define and bind it as a
+# named comptime constant. the value typing is explicit: no `=` is a bool `true`
+# flag; `true`/`false` is a bool; a decimal/`0x`/`0b`/`0o` integer literal is an
+# int; anything else is a string.
+fun bind_one_define(p: *Project, ctx: *comptime.ComptimeCtx, s: str) Result[bool, str] {
+    val n: usize = str_len(s);
+    var eq: usize = n;
+    var k: usize = 0;
+    for (k < n) {
+        if (s[k] == '=') { eq = k; brk; }
+        k = k + 1;
+    }
+    if (eq == 0) { ret err[bool, str]("mach.toml: a define has an empty name"); }
+
+    val name_r: Result[intern.StrId, str] = intern.intern_bytes(?p.s.interner, s, eq);
+    if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
+    val name_id: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+    var v: comptime.CTValue;
+    v.int_unsigned = false;
+
+    if (eq == n) {
+        v.kind   = comptime.CT_KIND_BOOL;
+        v.data.b = true;
+    }
+    or {
+        val vstart: usize = eq + 1;
+        val vlen:   usize = n - vstart;
+        var iv: i64 = 0;
+        if (define_value_is(s, vstart, vlen, "true")) {
+            v.kind = comptime.CT_KIND_BOOL; v.data.b = true;
+        }
+        or (define_value_is(s, vstart, vlen, "false")) {
+            v.kind = comptime.CT_KIND_BOOL; v.data.b = false;
+        }
+        or (parse_define_int(s, vstart, vlen, ?iv)) {
+            v.kind = comptime.CT_KIND_INT; v.data.i = iv;
+        }
+        or {
+            val vr: Result[intern.StrId, str] = intern.intern_bytes(?p.s.interner, (s::usize + vstart)::str, vlen);
+            if (is_err[intern.StrId, str](vr)) { ret err[bool, str](unwrap_err[intern.StrId, str](vr)); }
+            v.kind = comptime.CT_KIND_STR; v.data.s = unwrap_ok[intern.StrId, str](vr);
+        }
+    }
+
+    ret comptime.bind_define(ctx, name_id, v);
+}
+
+# define_value_is: whether the value substring s[start, start+len) equals `lit`.
+fun define_value_is(s: str, start: usize, len: usize, lit: str) bool {
+    if (len != str_len(lit)) { ret false; }
+    var i: usize = 0;
+    for (i < len) {
+        if (s[start + i] != lit[i]::u8) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# parse_define_int: parse the value substring s[start, start+len) as an integer
+# literal (optional leading `-`, optional `0x`/`0b`/`0o` base prefix, digit
+# separators `_`), writing the i64 into `out` and returning true. a value that is
+# not a clean integer returns false so the caller treats it as a string. an
+# out-of-range value also returns false (a string is the honest fallback).
+fun parse_define_int(s: str, start: usize, len: usize, out: *i64) bool {
+    if (len == 0) { ret false; }
+    var i: usize = 0;
+    var neg: bool = false;
+    if (s[start] == '-') {
+        if (len == 1) { ret false; }
+        neg = true;
+        i = 1;
+    }
+    var base: u64 = 10;
+    if (len - i >= 2 && s[start + i] == '0') {
+        val c1: u8 = s[start + i + 1];
+        if (c1 == 'x') { base = 16; i = i + 2; }
+        or (c1 == 'b') { base = 2;  i = i + 2; }
+        or (c1 == 'o') { base = 8;  i = i + 2; }
+    }
+
+    var value:     u64 = 0;
+    var saw_digit: bool = false;
+    val u64_max:   u64 = 0xFFFFFFFFFFFFFFFF;
+    for (i < len) {
+        val c: u8 = s[start + i];
+        if (c == '_') { i = i + 1; cnt; }
+        var digit: i64 = 0 - 1;
+        if      (c >= '0' && c <= '9') { digit = (c - '0')::i64; }
+        or      (c >= 'a' && c <= 'f') { digit = (c - 'a')::i64 + 10; }
+        or      (c >= 'A' && c <= 'F') { digit = (c - 'A')::i64 + 10; }
+        if (digit < 0 || digit::u64 >= base) { ret false; }
+        val d: u64 = digit::u64;
+        if (value > (u64_max - d) / base) { ret false; }
+        value = value * base + d;
+        saw_digit = true;
+        i = i + 1;
+    }
+    if (!saw_digit) { ret false; }
+
+    # reject a magnitude that has no i64 representation (the string fallback keeps
+    # it honest rather than wrapping).
+    val signed_max: u64 = 0x7FFFFFFFFFFFFFFF;
+    if (neg) {
+        if (value > signed_max + 1) { ret false; }
+        @out = 0 - value::i64;
+        ret true;
+    }
+    if (value > signed_max) { ret false; }
+    @out = value::i64;
+    ret true;
 }
 
 fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool, str] {

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -28,6 +28,7 @@ use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_none;
+use std.types.option.is_some;
 use std.types.option.unwrap;
 
 use std.types.bool.bool;
@@ -123,6 +124,11 @@ pub def FrameMark: u32;
 #                 so an innermost (later-bound) name shadows an outer one
 # entries_len:    number of entries currently stored
 # entries_cap:    allocated slots in entries
+# defines:        manifest comptime defines (#1191), keyed by name, resolved only
+#                 through the `$mach.build.<name>` path — kept out of `entries` so a
+#                 define never shadows (nor is shadowed by) a bare comptime const
+# define_len:     number of defines stored
+# define_cap:     allocated slots in defines
 pub rec ComptimeCtx {
     alloc:          *Allocator;
     target_os_id:   u32;
@@ -133,6 +139,9 @@ pub rec ComptimeCtx {
     entries:        *NamedConst;
     entries_len:    u32;
     entries_cap:    u32;
+    defines:        *NamedConst;
+    define_len:     u32;
+    define_cap:     u32;
 }
 
 val INITIAL_CONST_CAP: u32 = 8;
@@ -175,6 +184,9 @@ pub fun init(
     c.entries        = nil;
     c.entries_len    = 0;
     c.entries_cap    = 0;
+    c.defines        = nil;
+    c.define_len     = 0;
+    c.define_cap     = 0;
     ret c;
 }
 
@@ -186,9 +198,15 @@ pub fun dnit(c: *ComptimeCtx) {
     if (c.entries != nil && c.entries_cap > 0) {
         deallocate[NamedConst](c.alloc, c.entries, c.entries_cap::usize);
     }
+    if (c.defines != nil && c.define_cap > 0) {
+        deallocate[NamedConst](c.alloc, c.defines, c.define_cap::usize);
+    }
     c.entries     = nil;
     c.entries_len = 0;
     c.entries_cap = 0;
+    c.defines     = nil;
+    c.define_len  = 0;
+    c.define_cap  = 0;
 }
 
 # bind: appends a comptime constant under `name` to the current (innermost)
@@ -268,6 +286,59 @@ pub fun lookup(c: *ComptimeCtx, name: intern.StrId) Option[*NamedConst] {
         if (c.entries[i].name == name) {
             ret some[*NamedConst](?c.entries[i]);
         }
+    }
+    ret none[*NamedConst]();
+}
+
+# bind_define: register a manifest comptime define (#1191) under `name`, readable
+# only through the `$mach.build.<name>` path. defines live in their own table,
+# isolated from the scoped `entries` environment, so a define neither shadows nor
+# is shadowed by a bare comptime constant. a later bind of the same name replaces
+# the earlier value (the manifest merge has already applied precedence).
+# ---
+# c:     context to extend
+# name:  interned define name
+# value: pre-evaluated define value
+# ret:   true on success, or an allocation error
+pub fun bind_define(c: *ComptimeCtx, name: intern.StrId, value: CTValue) Result[bool, str] {
+    var k: u32 = 0;
+    for (k < c.define_len) {
+        if (c.defines[k].name == name) { c.defines[k].value = value; ret ok[bool, str](true); }
+        k = k + 1;
+    }
+    if (c.defines == nil) {
+        val r: Result[*NamedConst, str] = allocate[NamedConst](c.alloc, INITIAL_CONST_CAP::usize);
+        if (is_err[*NamedConst, str](r)) { ret err[bool, str](unwrap_err[*NamedConst, str](r)); }
+        c.defines     = unwrap_ok[*NamedConst, str](r);
+        c.define_cap  = INITIAL_CONST_CAP;
+    }
+    or (c.define_len == c.define_cap) {
+        val new_cap: u32 = c.define_cap * 2;
+        val r: Result[*NamedConst, str] = reallocate[NamedConst](c.alloc, c.defines, c.define_cap::usize, new_cap::usize);
+        if (is_err[*NamedConst, str](r)) { ret err[bool, str](unwrap_err[*NamedConst, str](r)); }
+        c.defines    = unwrap_ok[*NamedConst, str](r);
+        c.define_cap = new_cap;
+    }
+
+    var nc: NamedConst;
+    nc.name  = name;
+    nc.value = value;
+    c.defines[c.define_len] = nc;
+    c.define_len = c.define_len + 1;
+    ret ok[bool, str](true);
+}
+
+# lookup_define: find a manifest define by interned name, or none. used by
+# `resolve_mach_path` to fold `$mach.build.<name>`.
+# ---
+# c:    context to search
+# name: interned define name
+# ret:  some(*NamedConst) when defined, none otherwise
+pub fun lookup_define(c: *ComptimeCtx, name: intern.StrId) Option[*NamedConst] {
+    var k: u32 = 0;
+    for (k < c.define_len) {
+        if (c.defines[k].name == name) { ret some[*NamedConst](?c.defines[k]); }
+        k = k + 1;
     }
     ret none[*NamedConst]();
 }
@@ -989,7 +1060,7 @@ fun eval_path(
         ret err[CTValue, str]("comptime path must start with a `$` identifier");
     }
 
-    ret resolve_mach_path(c, source, ?stack[0], depth);
+    ret resolve_mach_path(c, source, ?stack[0], depth, interner);
 }
 
 # comptime_ident_name: the span of the identifier portion of a `$ident` token,
@@ -1021,10 +1092,12 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 #   $mach.project.{name,version,root} — project metadata stubs.
 #   $mach.build.{mode,timestamp,host} / build.git.{commit,dirty} — build
 #     metadata stubs.
+#   $mach.build.<name> — a manifest comptime define (#1191); folds to the
+#     define's value, or errors when no such define was declared.
 #   $mach.source.{file,line,module,function} — source-location stubs.
 # stubbed paths report that the value is not yet populated rather than
 # silently folding to a placeholder.
-fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32) Result[CTValue, str] {
+fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32, interner: *intern.Interner) Result[CTValue, str] {
     if (depth == 0) { ret err[CTValue, str]("empty comptime path"); }
 
     val root: StrView = span_text(source, stack[depth - 1]);
@@ -1080,7 +1153,8 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
         ret err[CTValue, str]("`$mach.project.*` is not yet available");
     }
 
-    # $mach.build.{mode,timestamp,host} — build metadata stubs
+    # $mach.build.{mode,timestamp,host} — build metadata stubs. checked before the
+    # dynamic define lookup so a manifest define can never shadow a reserved name.
     if (depth == 3 && seg_is(source, stack, 1, "build")
      && (seg_is(source, stack, 0, "mode") || seg_is(source, stack, 0, "timestamp") || seg_is(source, stack, 0, "host"))) {
         ret err[CTValue, str]("`$mach.build.*` is not yet available");
@@ -1089,6 +1163,15 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 4 && seg_is(source, stack, 2, "build") && seg_is(source, stack, 1, "git")
      && (seg_is(source, stack, 0, "commit") || seg_is(source, stack, 0, "dirty"))) {
         ret err[CTValue, str]("`$mach.build.git.*` is not yet available");
+    }
+    # $mach.build.<name> — a manifest comptime define (#1191). folds to the
+    # define's value; an undeclared name is a loud error, never a silent default.
+    if (depth == 3 && seg_is(source, stack, 1, "build")) {
+        val nr: Result[intern.StrId, str] = intern.intern_span(interner, source, stack[0]);
+        if (is_err[intern.StrId, str](nr)) { ret err[CTValue, str](unwrap_err[intern.StrId, str](nr)); }
+        val d_opt: Option[*NamedConst] = lookup_define(c, unwrap_ok[intern.StrId, str](nr));
+        if (is_some[*NamedConst](d_opt)) { ret ok[CTValue, str](unwrap[*NamedConst](d_opt).value); }
+        ret err[CTValue, str]("no manifest define named in `$mach.build.<name>`");
     }
 
     # $mach.source.{file,line,module,function} — source-location stubs

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -23,6 +23,7 @@ use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_empty;
 use std.types.string.str_equals;
+use std.types.string.str_contains;
 use std.text.string.str_free;
 
 use std.types.option.Option;
@@ -1426,7 +1427,7 @@ pub fun resolve_build_unit(alloc: *Allocator, i: *intern.Interner, m: *Manifest,
     val rp: ResolvedProfile = unwrap_ok[ResolvedProfile, str](rp_r);
 
     val a: *ArtifactDef = resolve_artifact(alloc, i, m, sel);
-    if (a == nil) { ret err[BuildUnit, str](artifact_err(alloc, m, sel)); }
+    if (a == nil) { ret err[BuildUnit, str](artifact_err(alloc, i, m, sel)); }
 
     val cell: *CellDef = find_cell(a, rt.target.name);
 
@@ -1491,14 +1492,35 @@ pub fun resolve_build_unit(alloc: *Allocator, i: *intern.Interner, m: *Manifest,
     ret ok[BuildUnit, str](u);
 }
 
-# artifact_err: the diagnostic for a failed artifact selection.
-fun artifact_err(alloc: *Allocator, m: *Manifest, sel: Selection) str {
+# artifact_err: the diagnostic for a failed artifact selection. an ambiguous
+# default (several artifacts, none selected) names every candidate so `mach run`
+# and `mach test`, which build exactly one artifact, point straight at the choice.
+fun artifact_err(alloc: *Allocator, i: *intern.Interner, m: *Manifest, sel: Selection) str {
     if (m.artifact_count == 0) { ret "mach.toml: no [bin.*] or [lib.*] artifacts declared"; }
     if (sel.has_artifact) {
         if (sel.want_lib) { ret cc3(alloc, "mach.toml: no lib named '", sel.artifact, "'"); }
         ret cc3(alloc, "mach.toml: no bin named '", sel.artifact, "'");
     }
-    ret "mach.toml: multiple artifacts declared; select one with --bin or --lib";
+    ret cc3(alloc, "mach.toml: multiple artifacts declared; select one with --bin/--lib (",
+        artifact_candidates(alloc, i, m), ")");
+}
+
+# artifact_candidates: a comma-separated `bin <name>`/`lib <name>` list of every
+# declared artifact, in declaration order, for the ambiguous-selection diagnostic.
+fun artifact_candidates(alloc: *Allocator, i: *intern.Interner, m: *Manifest) str {
+    var s: str = "";
+    var k: u32 = 0;
+    for (k < m.artifact_count) {
+        if (k > 0) { s = cc(alloc, s, ", "); }
+        var label: str = "bin ";
+        if (m.artifacts[k].is_lib) { label = "lib "; }
+        var name: str = "?";
+        val no: Option[str] = intern.lookup(i, m.artifacts[k].name);
+        if (is_some[str](no)) { name = unwrap[str](no); }
+        s = cc(alloc, s, cc(alloc, label, name));
+        k = k + 1;
+    }
+    ret s;
 }
 
 # expand_intern: expand a template then intern the result.
@@ -1897,6 +1919,28 @@ test "manifest: defines merge with precedence artifact < target < per-cell" {
             if (strarr_has(?itn, bu.defines, bu.define_count, "plat=app"))   { code = 1; }
             if (!strarr_has(?itn, bu.defines, bu.define_count, "shared_flag")) { code = 1; }
             if (!strarr_has(?itn, bu.defines, bu.define_count, "art_flag"))    { code = 1; }
+        }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: an ambiguous artifact selection errors naming every candidate" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, demo_src());
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        # no artifact selector with two bins is ambiguous; the error names both.
+        val u: Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("", "", "", false, false));
+        if (is_ok[BuildUnit, str](u)) { code = 1; }
+        or {
+            val msg: str = unwrap_err[BuildUnit, str](u);
+            if (!str_contains(msg, "bin ls"))  { code = 1; }
+            if (!str_contains(msg, "bin cat")) { code = 1; }
         }
     }
     arena.dnit(?ar);

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -102,17 +102,22 @@ pub rec TargetDef {
 # CellDef: one `[bin.<a>.target.<t>]` per-cell exception refining an artifact
 # for a single target. an unset override (STR_NIL) inherits the artifact field.
 # ---
-# target:    interned name of the target this cell refines
-# entry:     interned entry-file override, STR_NIL to inherit
-# out:       interned `out` template override, STR_NIL to inherit
-# libs:      interned per-cell link inputs appended to the merge; nil when none
-# lib_count: number of entries in libs
+# target:       interned name of the target this cell refines
+# entry:        interned entry-file override, STR_NIL to inherit
+# out:          interned `out` template override, STR_NIL to inherit
+# libs:         interned per-cell link inputs appended to the merge; nil when none
+# lib_count:    number of entries in libs
+# defines:      interned per-cell comptime defines, the highest precedence level
+#               (#1191); nil when none
+# define_count: number of entries in defines
 pub rec CellDef {
-    target:    intern.StrId;
-    entry:     intern.StrId;
-    out:       intern.StrId;
-    libs:      *intern.StrId;
-    lib_count: u32;
+    target:       intern.StrId;
+    entry:        intern.StrId;
+    out:          intern.StrId;
+    libs:         *intern.StrId;
+    lib_count:    u32;
+    defines:      *intern.StrId;
+    define_count: u32;
 }
 
 # ArtifactDef: one `[bin.<name>]` or `[lib.<name>]` artifact. every artifact is
@@ -745,8 +750,10 @@ fun parse_cells(alloc: *Allocator, i: *intern.Interner, sub: *toml.Table, kind_t
         if (is_err[bool, str](ck)) { ret ck; }
 
         var c: CellDef;
-        c.libs      = nil;
-        c.lib_count = 0;
+        c.libs         = nil;
+        c.lib_count    = 0;
+        c.defines      = nil;
+        c.define_count = 0;
         c.target = intern_unwrap(i, tname);
         c.entry  = intern_opt_unwrap(i, toml.get_str(cs, "entry"));
         c.out    = intern_opt_unwrap(i, toml.get_str(cs, "out"));
@@ -756,6 +763,12 @@ fun parse_cells(alloc: *Allocator, i: *intern.Interner, sub: *toml.Table, kind_t
         if (is_err[StrArr, str](lr)) { ret err[bool, str](unwrap_err[StrArr, str](lr)); }
         val laa: StrArr = unwrap_ok[StrArr, str](lr);
         c.libs = laa.items; c.lib_count = laa.count;
+
+        val dr: Result[StrArr, str] = parse_str_array(alloc, i, toml.get_array(cs, "defines"),
+            cc3(alloc, "mach.toml: ", label, ".defines must be an array of strings"));
+        if (is_err[StrArr, str](dr)) { ret err[bool, str](unwrap_err[StrArr, str](dr)); }
+        val daa: StrArr = unwrap_ok[StrArr, str](dr);
+        c.defines = daa.items; c.define_count = daa.count;
 
         a.cells[k] = c;
         k = k + 1;
@@ -883,6 +896,7 @@ pub fun dnit(m: *Manifest, alloc: *Allocator) {
                 var c: u32 = 0;
                 for (c < a.cell_count) {
                     free_strarr(alloc, a.cells[c].libs, a.cells[c].lib_count);
+                    free_strarr(alloc, a.cells[c].defines, a.cells[c].define_count);
                     c = c + 1;
                 }
                 deallocate[CellDef](alloc, a.cells, a.cell_count::usize);
@@ -1040,6 +1054,9 @@ pub rec Selection {
 # kind:         library link kind (meaningful when is_lib)
 # libs:         merged interned link overlay; nil when none
 # lib_count:    number of entries in libs
+# defines:      merged interned comptime-define overlay (artifact < target < cell,
+#               override by name); nil when none
+# define_count: number of entries in defines
 # warned:       native resolution found no host match and fell back to the first target
 pub rec BuildUnit {
     target:       *TargetDef;
@@ -1058,6 +1075,8 @@ pub rec BuildUnit {
     kind:         LibKind;
     libs:         *intern.StrId;
     lib_count:    u32;
+    defines:      *intern.StrId;
+    define_count: u32;
     warned:       bool;
 }
 
@@ -1294,6 +1313,99 @@ fun append_unique(buf: *intern.StrId, c: u32, src: *intern.StrId, n: u32) u32 {
     ret w;
 }
 
+# define_name_len: the length of a define's NAME part — every byte before the
+# first `=` (the whole string when no `=` is present). a define is `NAME` (a
+# comptime flag) or `NAME=VALUE`; the merge keys on the NAME alone.
+fun define_name_len(s: str) usize {
+    val n: usize = str_len(s);
+    var i: usize = 0;
+    for (i < n) {
+        if (s[i] == '=') { ret i; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# define_name_eq: whether two define strings name the same constant — equal NAME
+# parts (up to the first `=`). a later precedence level redefining a NAME shadows
+# an earlier one, so the merge dedups on the NAME, not the full `NAME=VALUE`.
+fun define_name_eq(i: *intern.Interner, a: intern.StrId, b: intern.StrId) bool {
+    if (a == b) { ret true; }
+    val ao: Option[str] = intern.lookup(i, a);
+    val bo: Option[str] = intern.lookup(i, b);
+    if (is_none[str](ao) || is_none[str](bo)) { ret false; }
+    val as_: str = unwrap[str](ao);
+    val bs:  str = unwrap[str](bo);
+    val an: usize = define_name_len(as_);
+    if (an != define_name_len(bs)) { ret false; }
+    var k: usize = 0;
+    for (k < an) {
+        if (as_[k] != bs[k]) { ret false; }
+        k = k + 1;
+    }
+    ret true;
+}
+
+# append_override: merge each define in `src` into buf[0, c), replacing any entry
+# whose NAME already appears (so a later precedence level wins) and appending a
+# new NAME in first-seen position. returns the new count.
+fun append_override(i: *intern.Interner, buf: *intern.StrId, c: u32, src: *intern.StrId, n: u32) u32 {
+    var w: u32 = c;
+    var k: u32 = 0;
+    for (k < n) {
+        val id: intern.StrId = src[k];
+        var found: bool = false;
+        var j: u32 = 0;
+        for (j < w) {
+            if (define_name_eq(i, buf[j], id)) { buf[j] = id; found = true; }
+            j = j + 1;
+        }
+        if (!found) { buf[w] = id; w = w + 1; }
+        k = k + 1;
+    }
+    ret w;
+}
+
+# merge_defines: the target+artifact+cell comptime-define overlay, resolved with
+# the spec precedence artifact < target < per-cell. a later level's `NAME=VALUE`
+# overrides an earlier level's same NAME, so each named constant appears once with
+# its highest-precedence value, in first-seen order. owned by `alloc`; nil/0 when
+# empty.
+fun merge_defines(alloc: *Allocator, i: *intern.Interner, t: *TargetDef, a: *ArtifactDef, cell: *CellDef) Result[StrArr, str] {
+    var out: StrArr;
+    out.items = nil;
+    out.count = 0;
+    var cell_n: u32 = 0;
+    var cell_items: *intern.StrId = nil;
+    if (cell != nil) { cell_n = cell.define_count; cell_items = cell.defines; }
+    val max: u32 = t.define_count + a.define_count + cell_n;
+    if (max == 0) { ret ok[StrArr, str](out); }
+
+    val r: Result[*intern.StrId, str] = allocate[intern.StrId](alloc, max::usize);
+    if (is_err[*intern.StrId, str](r)) { ret err[StrArr, str](unwrap_err[*intern.StrId, str](r)); }
+    val buf: *intern.StrId = unwrap_ok[*intern.StrId, str](r);
+    var c: u32 = 0;
+    c = append_override(i, buf, c, a.defines, a.define_count);
+    c = append_override(i, buf, c, t.defines, t.define_count);
+    c = append_override(i, buf, c, cell_items, cell_n);
+
+    if (c == 0) {
+        deallocate[intern.StrId](alloc, buf, max::usize);
+        ret ok[StrArr, str](out);
+    }
+    if (c < max) {
+        val sr: Result[*intern.StrId, str] = reallocate[intern.StrId](alloc, buf, max::usize, c::usize);
+        if (is_ok[*intern.StrId, str](sr)) {
+            out.items = unwrap_ok[*intern.StrId, str](sr);
+            out.count = c;
+            ret ok[StrArr, str](out);
+        }
+    }
+    out.items = buf;
+    out.count = c;
+    ret ok[StrArr, str](out);
+}
+
 # effective_out: the effective `out` template for an artifact under a cell —
 # cell override, else artifact override, else the project template.
 fun effective_out(m: *Manifest, a: *ArtifactDef, cell: *CellDef) intern.StrId {
@@ -1338,6 +1450,12 @@ pub fun resolve_build_unit(alloc: *Allocator, i: *intern.Interner, m: *Manifest,
     val merged: StrArr = unwrap_ok[StrArr, str](lm);
     u.libs = merged.items;
     u.lib_count = merged.count;
+
+    val dm: Result[StrArr, str] = merge_defines(alloc, i, rt.target, a, cell);
+    if (is_err[StrArr, str](dm)) { ret err[BuildUnit, str](unwrap_err[StrArr, str](dm)); }
+    val mdef: StrArr = unwrap_ok[StrArr, str](dm);
+    u.defines = mdef.items;
+    u.define_count = mdef.count;
 
     # expansion variables, all from stanzas present in the file.
     val tn_r: Result[str, str] = must_lookup(i, rt.target.name);
@@ -1744,6 +1862,42 @@ test "manifest: two artifacts resolving to the same path collide at build start"
         var m: Manifest = unwrap_ok[Manifest, str](mr);
         val cr: Result[bool, str] = check_collisions(?alloc, ?itn, ?m, ?m.targets[0], "debug");
         if (is_ok[bool, str](cr) || !str_equals(unwrap_err[bool, str](cr), "mach.toml: artifacts 'a' and 'b' both build to 'bin/app'")) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# strarr_has: whether the interned StrId array holds an entry equal to `lit`.
+fun strarr_has(itn: *intern.Interner, items: *intern.StrId, count: u32, lit: str) bool {
+    var k: u32 = 0;
+    for (k < count) {
+        if (str_equals(idstr(itn, items[k]), lit)) { ret true; }
+        k = k + 1;
+    }
+    ret false;
+}
+
+test "manifest: defines merge with precedence artifact < target < per-cell" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\ntarget=\"windows\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\ndefines=[\"plat=win\",\"shared_flag\"]\n[bin.app]\nentry=\"main.mach\"\ndefines=[\"plat=app\",\"art_flag\"]\n[bin.app.target.windows]\ndefines=[\"plat=cell\"]\n");
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        val u: Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("windows", "", "app", false, true));
+        if (is_err[BuildUnit, str](u)) { code = 1; }
+        or {
+            val bu: BuildUnit = unwrap_ok[BuildUnit, str](u);
+            # plat resolves once at its first-seen position, with the cell value.
+            if (bu.define_count != 3) { code = 1; }
+            if (!strarr_has(?itn, bu.defines, bu.define_count, "plat=cell")) { code = 1; }
+            if (strarr_has(?itn, bu.defines, bu.define_count, "plat=win"))   { code = 1; }
+            if (strarr_has(?itn, bu.defines, bu.define_count, "plat=app"))   { code = 1; }
+            if (!strarr_has(?itn, bu.defines, bu.define_count, "shared_flag")) { code = 1; }
+            if (!strarr_has(?itn, bu.defines, bu.define_count, "art_flag"))    { code = 1; }
+        }
     }
     arena.dnit(?ar);
     ret code;

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -457,7 +457,6 @@ pub fun va_model() abi.VaModel {
 # pointers are stored type-erased (`*u8`); consumers cast them back to
 # `ClassifyFn`/`ArgPassingFn`/`RetPassingFn`.
 var sysv_vtable: abi.AbiVTable;
-var sysv_registered: bool = false;
 
 # register: build the SysV AMD64 AbiVTable and install it into the ABI registry.
 #
@@ -465,12 +464,12 @@ var sysv_registered: bool = false;
 # operation pointers and the GP/FP argument-register and callee-saved register
 # file accessors, sets the 16-byte stack alignment and 128-byte red zone, and
 # registers it under abi.ABI_SYSV so target.select can find it through
-# abi.lookup. idempotent: a second call returns ok without re-interning.
+# abi.lookup. re-interns the name into `i` on every call (the registry pointer is
+# idempotent) so a later build with a fresh interner gets a consistent id.
 # ---
 # i:   interner used to intern the vtable's string fields
 # ret: ok(true) on success, or an allocation error from interning
 pub fun register(i: *intern.Interner) Result[bool, str] {
-    if (sysv_registered) { ret ok[bool, str](true); }
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "sysv");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -490,7 +489,6 @@ pub fun register(i: *intern.Interner) Result[bool, str] {
     sysv_vtable.va_model      = va_model::*u8;
 
     abi.register(?sysv_vtable);
-    sysv_registered = true;
     ret ok[bool, str](true);
 }
 

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -439,22 +439,21 @@ pub fun va_model() abi.VaModel {
 # pointers are stored type-erased (`*u8`); consumers cast them back to the
 # shared `abi.ClassifyFn` / `abi.ArgPassingFn` / `abi.RetPassingFn`.
 var win64_vtable: abi.AbiVTable;
-var win64_registered: bool = false;
 
 # register_win64: build and install the win64 AbiVTable.
 #
 # interns the convention name ("win64"), wires the type-erased classify/arg/ret
 # operation pointers and the gp_arg_regs / fp_arg_regs / callee_saved register-
 # file accessors, sets the stack alignment (16) and red-zone size (0), and self-
-# registers it into the process-global ABI registry under abi.ABI_WIN64.
-# write-once: a second call is a no-op. must be invoked at compiler startup
-# before target.select requests a Windows target.
+# registers it into the process-global ABI registry under abi.ABI_WIN64. re-
+# interns the name into `i` on every call (the registry pointer is idempotent) so
+# a later build with a fresh interner gets a consistent id. must be invoked at
+# startup before target.select requests a Windows target.
 # ---
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields
 # ret:   true on success, or an error string if name interning fails
 pub fun register_win64(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
-    if (win64_registered) { ret ok[bool, str](true); }
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "win64");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -475,7 +474,6 @@ pub fun register_win64(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     win64_vtable.va_model     = va_model::*u8;
 
     abi.register(?win64_vtable);
-    win64_registered = true;
     ret ok[bool, str](true);
 }
 

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -58,7 +58,6 @@ var arm64_reserved_regs: [2]isa.Register;
 # the AArch64 ISA vtable. populated by register on first call and handed out as
 # a borrowed pointer to the registry.
 var arm64_vtable: isa.IsaVTable;
-var arm64_registered: bool = false;
 
 # register_arm64: build and install the AArch64 IsaVTable.
 #
@@ -68,14 +67,15 @@ var arm64_registered: bool = false;
 # scratch register identities (IP0/IP1/V31), the frame/stack pointers (FP/SP), -1
 # for the division / shift register identities (AArch64 wires none), and nil
 # select/encode entry points, and self-registers it into the process-global ISA
-# registry under isa.ARCH_AARCH64. write-once: a second call is a no-op. must be
-# invoked at compiler startup before target.select requests an AArch64 target.
+# registry under isa.ARCH_AARCH64. re-interns the names into `i` on every call (the
+# registry pointer is idempotent) so a later build with a fresh interner gets
+# consistent ids. must be invoked at startup before target.select requests an
+# AArch64 target.
 # ---
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields
 # ret:   true on success, or an error string if name interning fails
 pub fun register_arm64(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
-    if (arm64_registered) { ret ok[bool, str](true); }
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "aarch64");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -137,6 +137,5 @@ pub fun register_arm64(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     arm64_vtable.shift_count_reg    = -1;
 
     isa.register(?arm64_vtable);
-    arm64_registered = true;
     ret ok[bool, str](true);
 }

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -34,7 +34,6 @@ use x64printer: mach.lang.target.isa.x64.printer;
 # the ISA registry; lives for the lifetime of the process.
 var x64_vtable: isa.IsaVTable;
 var x64_classes: [3]isa.RegClass;
-var x64_registered: bool = false;
 
 # the registers the allocator must never assign: the stack pointer (RSP) and the
 # frame pointer (RBP), both owned by the frame pass. referenced (borrowed) by the
@@ -67,9 +66,10 @@ var x64_reload_scratch_regs: [3]isa.Register;
 # (RBP/RSP) the shared MIR lowering names when forming stack memory operands, and
 # the fixed division accumulator / high-half (RAX/RDX) and variable-shift count
 # (RCX) registers the x86-64 IDIV/DIV and shift forms hard-wire, and self-registers
-# it into the process-global ISA registry. write-once: a second call is a no-op.
-# must be invoked at compiler startup before `target.select` requests an x86-64
-# target.
+# it into the process-global ISA registry. re-interns the names into `interner` on
+# every call (the registry pointer is idempotent) so a later build with a fresh
+# interner gets consistent ids. must be invoked at compiler startup before
+# `target.select` requests an x86-64 target.
 #
 # the `select` and `encode` operation entry points are the x86-64 instruction
 # selector (`x64/isel.mach`) and byte encoder (`x64/encode.mach`), stored
@@ -83,7 +83,6 @@ var x64_reload_scratch_regs: [3]isa.Register;
 # interner: string interner used to intern the architecture and class names
 # ret:      true on success, or an error string if name interning fails
 pub fun register_x64(alloc: *Allocator, interner: *intern.Interner) Result[bool, str] {
-    if (x64_registered) { ret ok[bool, str](true); }
 
     val res_name: Result[intern.StrId, str] = intern.intern(interner, "x86_64");
     if (is_err[intern.StrId, str](res_name)) {
@@ -161,7 +160,6 @@ pub fun register_x64(alloc: *Allocator, interner: *intern.Interner) Result[bool,
     x64_vtable.shift_count_reg    = x64.RCX;
 
     isa.register(?x64_vtable);
-    x64_registered = true;
 
     ret ok[bool, str](true);
 }

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -47,21 +47,20 @@ pub val DARWIN_PAGE_SIZE: u64 = 4096;
 # the Darwin OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry.
 var darwin_vtable: os.OsVTable;
-var darwin_registered: bool = false;
 
 # register_darwin: build and install the Darwin OsVTable.
 #
 # interns the os name, entry symbol ("_main"), syscall layer, and default
 # library directory, fills the module-level vtable, and self-registers it into
-# the process-global OS registry under os.OS_DARWIN. write-once: a second call
-# is a no-op. must be invoked at compiler startup before target.select requests
-# a Darwin target.
+# the process-global OS registry under os.OS_DARWIN. re-interns the strings into
+# `i` on every call (the registry pointer is idempotent) so a later build with a
+# fresh interner gets consistent ids. must be invoked at startup before
+# target.select requests a Darwin target.
 # ---
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields
 # ret:   true on success, or an error string if name interning fails
 pub fun register_darwin(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
-    if (darwin_registered) { ret ok[bool, str](true); }
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "darwin");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -88,6 +87,5 @@ pub fun register_darwin(alloc: *Allocator, i: *intern.Interner) Result[bool, str
     darwin_vtable.runner_write   = runner_write::*u8;
 
     os.register(?darwin_vtable);
-    darwin_registered = true;
     ret ok[bool, str](true);
 }

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -66,21 +66,21 @@ fun runner_write(arch_id: u32) Option[os.RunnerWrite] {
 # the Linux OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry; remains valid for the process lifetime.
 var linux_vtable: os.OsVTable;
-var linux_registered: bool = false;
 
 # register_linux: build and install the Linux OsVTable.
 #
 # interns the os name, entry symbol ("_start"), syscall layer, and default
 # library directory, fills the module-level vtable (including the 0x400000 base
 # address and 4096-byte page), and self-registers it into the process-global OS
-# registry under os.OS_LINUX. write-once: a second call is a no-op. must be
-# invoked at compiler startup before target.select requests a Linux target.
+# registry under os.OS_LINUX. re-interns the strings into `i` on every call (the
+# registry pointer is idempotent) so a later build with a fresh interner gets
+# consistent ids rather than ones left over from the first. must be invoked at
+# startup before target.select requests a Linux target.
 # ---
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields
 # ret:   true on success, or an error string if name interning fails
 pub fun register_linux(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
-    if (linux_registered) { ret ok[bool, str](true); }
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "linux");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -108,6 +108,5 @@ pub fun register_linux(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     linux_vtable.runner_write   = runner_write::*u8;
 
     os.register(?linux_vtable);
-    linux_registered = true;
     ret ok[bool, str](true);
 }

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -48,21 +48,20 @@ pub val WINDOWS_PAGE_SIZE: u64 = 4096;
 # the Windows OS vtable. populated by register on first call and handed out as
 # a borrowed pointer to the registry.
 var windows_vtable: os.OsVTable;
-var windows_registered: bool = false;
 
 # register_windows: build and install the Windows OsVTable.
 #
 # interns the os name, entry symbol ("mainCRTStartup"), syscall layer, and
 # default library directory, fills the module-level vtable, and self-registers
-# it into the process-global OS registry under os.OS_WINDOWS. write-once: a
-# second call is a no-op. must be invoked at compiler startup before
-# target.select requests a Windows target.
+# it into the process-global OS registry under os.OS_WINDOWS. re-interns the
+# strings into `i` on every call (the registry pointer is idempotent) so a later
+# build with a fresh interner gets consistent ids. must be invoked at startup
+# before target.select requests a Windows target.
 # ---
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields
 # ret:   true on success, or an error string if name interning fails
 pub fun register_windows(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
-    if (windows_registered) { ret ok[bool, str](true); }
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "windows");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -88,6 +87,5 @@ pub fun register_windows(alloc: *Allocator, i: *intern.Interner) Result[bool, st
     windows_vtable.runner_write   = runner_write::*u8;
 
     os.register(?windows_vtable);
-    windows_registered = true;
     ret ok[bool, str](true);
 }


### PR DESCRIPTION
Phase 2 of the v2 `mach.toml` redesign (#1218), building on the phase-1 model + parser merged in #1305.

## Scope

1. **Multi-artifact matrix builds** — `mach build .` builds every `[bin.*]`/`[lib.*]` in declaration order (per-unit reporting, nonzero exit on any failure); `--all-targets` crosses every artifact with every declared target; `mach run`/`mach test` still build one artifact and require `--bin`/`--lib` when the default is ambiguous, naming every candidate.
2. **Cascading transitive dep libs** — a dependency's `[target.*].libs` (v2) or `[targets.*].libs`/`.link` (v1) are inherited by consumers, matched by tuple equality (isa, os, abi), deduped by name, in topological dep + declaration order, excluding the consumer's own libs. Both dep-side formats are read during the transition.
3. **defines wiring (#1191)** — `[target.*].defines` + `[bin.X]` + `[bin.X.target.Y]` merge with artifact < target < per-cell precedence into the comptime context, folding `$if ($mach.build.<name>)` at compile time; an undeclared name is a loud error, an empty set a strict no-op.

## Enabling refactor

Per-unit matrix builds run several compiles in one process. The OS/ISA/ABI target registrars were write-once and cached interned StrIds against the first interner, so a later build's fresh interner decoded the entry symbol as the target name. They now re-bind their strings on every `register_all` (the registry pointer stays idempotent), matching the ELF/COFF/Mach-O registrars. A single build calls `register_all` once, so the self-host fixpoint is unchanged.

## Verification

- `mach build .` clean (repo manifest is v1 → exercises the transitional path); 2-stage self-host fixpoint byte-identical.
- `mach test .` green (337 unit tests, incl. defines precedence + ambiguous-candidate diagnostic).
- Full integration battery green (all 17 `.github/tests/*/run.sh`), including the extended `manifestv2` suite: multi-artifact `build .`, `--all-targets`, defines precedence, the kernel32/user32 cascade (v2 + v1 deps), and tuple gating.

## Notes

- `mach test` v2 interaction documented on #1218 rather than redesigned.
- `$project.*`/`$target.*` comptime namespaces are #1217, out of scope.

- [x] defines wiring (#1191) + integration test
- [x] cascading dep libs + kernel32/user32 integration test
- [x] multi-artifact matrix builds + `--all-targets` + integration tests

Refs #1218
Closes #1191