### PR TITLE
refactor(cli): dissolve eq/emit/emit_num bridges; migrate build.mach + config.mach onto std

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -20,6 +20,8 @@ use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_empty;
+use std.types.string.str_equals;
+use std.types.string.str_len;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
@@ -42,10 +44,10 @@ use std.allocator.reallocate;
 use page:  std.allocator.page;
 use arena: std.allocator.arena;
 
-use os: std.system.os;
 use fs: std.filesystem;
 
 use writer: std.io.writer;
+use print:  std.print;
 
 use intern:   mach.lang.intern;
 use sess:     mach.lang.session;
@@ -112,10 +114,10 @@ fun emit_id(p: *driver.Project, id: intern.StrId) {
     val o: Option[str] = intern.lookup(?p.s.interner, id);
     if (is_some[str](o)) {
         val v: str = unwrap[str](o);
-        os.write(os.STDERR_FD, v::*u8, util.slen(v::*u8));
+        print.eprint(v);
     }
     or {
-        util.emit("<?>");
+        print.eprint("<?>");
     }
 }
 
@@ -124,12 +126,12 @@ fun emit_id(p: *driver.Project, id: intern.StrId) {
 # ---
 # p: the project carrying the selected target and module graph
 fun emit_target(p: *driver.Project) {
-    util.emit("target ");
+    print.eprint("target ");
     if (p.target_entry != nil) { emit_id(p, p.target_entry.name); }
-    or                         { util.emit("<none>"); }
-    util.emit(" (");
-    util.emit_num(p.topo_len::usize);
-    util.emit(" module(s))\n");
+    or                         { print.eprint("<none>"); }
+    print.eprint(" (");
+    print.eu64(p.topo_len::u64);
+    print.eprint(" module(s))\n");
 }
 
 # emit_stage: write a `<stage> <fqn>` progress line to stderr for one module.
@@ -138,10 +140,10 @@ fun emit_target(p: *driver.Project) {
 # stage: a short stage label (e.g. "sema", "lower/codegen")
 # fqn:   the module's interned fully-qualified name
 fun emit_stage(p: *driver.Project, stage: *u8, fqn: intern.StrId) {
-    util.emit(stage);
-    util.emit(" ");
+    print.eprint(stage::str);
+    print.eprint(" ");
     emit_id(p, fqn);
-    util.emit("\n");
+    print.eprint("\n");
 }
 
 # build_sema_deps: build the SemaDeps for module `m`, one ModuleSema entry
@@ -374,7 +376,7 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
 
     val cfg_opt: Option[cfg.Config] = cfg.parse(eff, argv);
     if (is_none[cfg.Config](cfg_opt)) {
-        util.emit("error: invalid command-line flags\n");
+        print.eprint("error: invalid command-line flags\n");
         br.code = 1;
         ret br;
     }
@@ -387,7 +389,7 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
     val pix: usize = util.positional_index(eff, argv, 2);
     if (pix < eff) {
         if (config.cwd != nil) {
-            util.emit("error: cannot combine a project-path positional with --cwd\n");
+            print.eprint("error: cannot combine a project-path positional with --cwd\n");
             br.code = 1;
             ret br;
         }
@@ -396,7 +398,7 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
 
     var root: [4096]u8;
     if (!util.find_project_root(start, ?root[0], 4096)) {
-        util.emit("error: no mach.toml found in the working directory or any parent\n");
+        print.eprint("error: no mach.toml found in the working directory or any parent\n");
         br.code = 1;
         ret br;
     }
@@ -441,7 +443,7 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
         var want_lib:      bool = false;
         var has_artifact:  bool = false;
         if (config.bin != nil && config.lib != nil) {
-            util.emit("error: --bin and --lib cannot be combined\n");
+            print.eprint("error: --bin and --lib cannot be combined\n");
             br.code = 1;
             ret br;
         }
@@ -455,9 +457,9 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
 
     val sess_r: Result[sess.Session, str] = sess.init(alloc);
     if (is_err[sess.Session, str](sess_r)) {
-        util.emit("error: failed to initialise compiler session: ");
-        util.emit(unwrap_err[sess.Session, str](sess_r));
-        util.emit("\n");
+        print.eprint("error: failed to initialise compiler session: ");
+        print.eprint(unwrap_err[sess.Session, str](sess_r));
+        print.eprint("\n");
         br.code = 2;
         ret br;
     }
@@ -470,9 +472,9 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
     # is idempotent.
     val reg_r: Result[bool, str] = tgt.register_all(?s.interner);
     if (is_err[bool, str](reg_r)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[bool, str](reg_r));
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[bool, str](reg_r));
+        print.eprint("\n");
         sess.dnit(?s);
         br.code = 2;
         ret br;
@@ -480,9 +482,9 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
 
     val proj_r: Result[driver.Project, str] = driver.build_project_sel(?s, util.cstr_str(?root[0]), ?sel);
     if (is_err[driver.Project, str](proj_r)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[driver.Project, str](proj_r));
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[driver.Project, str](proj_r));
+        print.eprint("\n");
         sess.dnit(?s);
         br.code = 1;
         ret br;
@@ -539,7 +541,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
                      argc: usize, argv: **u8, out_path: **u8) i64 {
     val n: usize = p.module_len::usize;
     if (n == 0) {
-        util.emit("error: project graph is empty\n");
+        print.eprint("error: project graph is empty\n");
         ret 1;
     }
 
@@ -557,39 +559,39 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
     ea.want_ir  = emit_ir;
     if (emit_ir) {
         if (!resolve_emit_base(p, root, true, art_override, ?ir_base[0], 4096)) {
-            util.emit("error: project ir output dir not interned\n");
+            print.eprint("error: project ir output dir not interned\n");
             ret 2;
         }
     }
     if (emit_asm) {
         if (!resolve_emit_base(p, root, false, art_override, ?asm_base[0], 4096)) {
-            util.emit("error: project asm output dir not interned\n");
+            print.eprint("error: project asm output dir not interned\n");
             ret 2;
         }
     }
 
     val rr: Result[*sema.SemaResult, str] = allocate[sema.SemaResult](p.s.alloc, n);
-    if (is_err[*sema.SemaResult, str](rr)) { util.emit("error: out of memory\n"); ret 2; }
+    if (is_err[*sema.SemaResult, str](rr)) { print.eprint("error: out of memory\n"); ret 2; }
     val results: *sema.SemaResult = unwrap_ok[*sema.SemaResult, str](rr);
 
     val rdy: Result[*bool, str] = allocate[bool](p.s.alloc, n);
-    if (is_err[*bool, str](rdy)) { deallocate[sema.SemaResult](p.s.alloc, results, n); util.emit("error: out of memory\n"); ret 2; }
+    if (is_err[*bool, str](rdy)) { deallocate[sema.SemaResult](p.s.alloc, results, n); print.eprint("error: out of memory\n"); ret 2; }
     val ready: *bool = unwrap_ok[*bool, str](rdy);
 
     val iri: Result[*ir.Module, str] = allocate[ir.Module](p.s.alloc, n);
-    if (is_err[*ir.Module, str](iri)) { deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); util.emit("error: out of memory\n"); ret 2; }
+    if (is_err[*ir.Module, str](iri)) { deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); print.eprint("error: out of memory\n"); ret 2; }
     val irs: *ir.Module = unwrap_ok[*ir.Module, str](iri);
 
     val irr: Result[*bool, str] = allocate[bool](p.s.alloc, n);
-    if (is_err[*bool, str](irr)) { deallocate[ir.Module](p.s.alloc, irs, n); deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); util.emit("error: out of memory\n"); ret 2; }
+    if (is_err[*bool, str](irr)) { deallocate[ir.Module](p.s.alloc, irs, n); deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); print.eprint("error: out of memory\n"); ret 2; }
     val ir_ready: *bool = unwrap_ok[*bool, str](irr);
 
     val imi: Result[*of.ObjectImage, str] = allocate[of.ObjectImage](p.s.alloc, n);
-    if (is_err[*of.ObjectImage, str](imi)) { deallocate[bool](p.s.alloc, ir_ready, n); deallocate[ir.Module](p.s.alloc, irs, n); deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); util.emit("error: out of memory\n"); ret 2; }
+    if (is_err[*of.ObjectImage, str](imi)) { deallocate[bool](p.s.alloc, ir_ready, n); deallocate[ir.Module](p.s.alloc, irs, n); deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); print.eprint("error: out of memory\n"); ret 2; }
     val images: *of.ObjectImage = unwrap_ok[*of.ObjectImage, str](imi);
 
     val imr: Result[*bool, str] = allocate[bool](p.s.alloc, n);
-    if (is_err[*bool, str](imr)) { deallocate[of.ObjectImage](p.s.alloc, images, n); deallocate[bool](p.s.alloc, ir_ready, n); deallocate[ir.Module](p.s.alloc, irs, n); deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); util.emit("error: out of memory\n"); ret 2; }
+    if (is_err[*bool, str](imr)) { deallocate[of.ObjectImage](p.s.alloc, images, n); deallocate[bool](p.s.alloc, ir_ready, n); deallocate[ir.Module](p.s.alloc, irs, n); deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); print.eprint("error: out of memory\n"); ret 2; }
     val image_ready: *bool = unwrap_ok[*bool, str](imr);
 
     var i: u32 = 0;
@@ -610,9 +612,9 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
     var code: i64 = 0;
     val comp_r: Result[bool, str] = compile_modules(p, level, test_mode, verify_ir, verbose, ?ea, results, ready, irs, ir_ready, images, image_ready);
     if (is_err[bool, str](comp_r)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[bool, str](comp_r));
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[bool, str](comp_r));
+        print.eprint("\n");
         code = 1;
     }
     or (diag.has_errors(?p.s.diags)) {
@@ -651,14 +653,14 @@ fun build_test_runner(p: *driver.Project, level: u8, verify_ir: bool,
                       runner_img: *of.ObjectImage, runner_img_ok: *bool) i64 {
     val syn_r: Result[Option[ir.Module], str] = testrunner.synthesize(p.s, ?p.target, irs, p.module_len);
     if (is_err[Option[ir.Module], str](syn_r)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[Option[ir.Module], str](syn_r));
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[Option[ir.Module], str](syn_r));
+        print.eprint("\n");
         ret 2;
     }
     val syn: Option[ir.Module] = unwrap_ok[Option[ir.Module], str](syn_r);
     if (is_none[ir.Module](syn)) {
-        util.emit("error: no tests found in the project\n");
+        print.eprint("error: no tests found in the project\n");
         ret 1;
     }
     @runner_ir    = unwrap[ir.Module](syn);
@@ -666,17 +668,17 @@ fun build_test_runner(p: *driver.Project, level: u8, verify_ir: bool,
 
     val opt_r: Result[bool, str] = pipeline.run(runner_ir, ?p.target, level, verify_ir);
     if (is_err[bool, str](opt_r)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[bool, str](opt_r));
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[bool, str](opt_r));
+        print.eprint("\n");
         ret 2;
     }
 
     val cg_r: Result[of.ObjectImage, str] = codegen.codegen_module(p.s, ?p.target, runner_ir, nil);
     if (is_err[of.ObjectImage, str](cg_r)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[of.ObjectImage, str](cg_r));
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[of.ObjectImage, str](cg_r));
+        print.eprint("\n");
         ret 2;
     }
     @runner_img    = unwrap_ok[of.ObjectImage, str](cg_r);
@@ -704,14 +706,14 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
                   argc: usize, argv: **u8,
                   images: *of.ObjectImage, out_path: **u8) i64 {
     val te: *driver.TargetEntry = p.target_entry;
-    if (te == nil) { util.emit("error: no target selected\n"); ret 2; }
+    if (te == nil) { print.eprint("error: no target selected\n"); ret 2; }
 
     # the per-module object tree root. the old reader composes
     # `<root>/<out>/<artifacts>/obj` (`--artifacts` overrides `<artifacts>`); the
     # v2 reader takes `<root>/<resolved obj template>`.
     var obj_base: [4096]u8;
     if (!resolve_obj_base(p, root, art_override, ?obj_base[0], 4096)) {
-        util.emit("error: project obj output dir not interned\n");
+        print.eprint("error: project obj output dir not interned\n");
         ret 2;
     }
 
@@ -737,9 +739,9 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     # for a library target, since the test runner needs a runnable entry point.
     if ((te.mode == driver.MODE_LIBRARY || emit_obj) && !test_mode) {
         if (verbose) {
-            util.emit("output ");
-            util.emit(?obj_base[0]);
-            util.emit("\n");
+            print.eprint("output ");
+            print.eprint((?obj_base[0])::str);
+            print.eprint("\n");
         }
         free_paths(p.s.alloc, paths, count, count);
         @out_path = dup_cstr(p.s.alloc, ?obj_base[0]);
@@ -762,15 +764,15 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     }
 
     if (verbose) {
-        util.emit("link ");
-        util.emit_num(count::usize);
-        util.emit(" object(s)");
+        print.eprint("link ");
+        print.eu64(count::u64);
+        print.eprint(" object(s)");
         if (soname_count > 0) {
-            util.emit(", ");
-            util.emit_num(soname_count::usize);
-            util.emit(" shared lib(s)");
+            print.eprint(", ");
+            print.eu64(soname_count::u64);
+            print.eprint(" shared lib(s)");
         }
-        util.emit("\n");
+        print.eprint("\n");
     }
 
     # the executable path: `-o` overrides it with a path rooted directly at
@@ -782,10 +784,10 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     }
     or (p.config.is_v2) {
         val bin_opt: Option[str] = intern.lookup(?p.s.interner, p.config.v2_bin);
-        if (is_none[str](bin_opt) || util.slen(unwrap[str](bin_opt)::*u8) == 0) {
+        if (is_none[str](bin_opt) || str_empty(unwrap[str](bin_opt))) {
             free_paths(p.s.alloc, paths, count, count);
             free_sonames(p.s.alloc, sonames, soname_count);
-            util.emit("error: artifact has no resolved output path\n");
+            print.eprint("error: artifact has no resolved output path\n");
             ret 1;
         }
         join_into_str(?artifact[0], 4096, root, unwrap[str](bin_opt));
@@ -795,14 +797,14 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
         if (is_none[str](out_opt)) {
             free_paths(p.s.alloc, paths, count, count);
             free_sonames(p.s.alloc, sonames, soname_count);
-            util.emit("error: project out dir not interned\n");
+            print.eprint("error: project out dir not interned\n");
             ret 2;
         }
         val bin_opt: Option[str] = intern.lookup(?p.s.interner, te.binary);
-        if (is_none[str](bin_opt) || util.slen(unwrap[str](bin_opt)::*u8) == 0) {
+        if (is_none[str](bin_opt) || str_empty(unwrap[str](bin_opt))) {
             free_paths(p.s.alloc, paths, count, count);
             free_sonames(p.s.alloc, sonames, soname_count);
-            util.emit("error: target has no binary path configured\n");
+            print.eprint("error: target has no binary path configured\n");
             ret 1;
         }
         join_into_str(?artifact[0], 4096, root, unwrap[str](out_opt));
@@ -811,7 +813,7 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     if (!util.ensure_parents(?artifact[0])) {
         free_paths(p.s.alloc, paths, count, count);
         free_sonames(p.s.alloc, sonames, soname_count);
-        util.emit("error: failed to create binary directory\n");
+        print.eprint("error: failed to create binary directory\n");
         ret 2;
     }
 
@@ -820,16 +822,16 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     free_paths(p.s.alloc, paths, count, count);
     free_sonames(p.s.alloc, sonames, soname_count);
     if (is_err[bool, str](link_r)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[bool, str](link_r));
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[bool, str](link_r));
+        print.eprint("\n");
         ret 1;
     }
 
     if (verbose) {
-        util.emit("output ");
-        util.emit(?artifact[0]);
-        util.emit("\n");
+        print.eprint("output ");
+        print.eprint((?artifact[0])::str);
+        print.eprint("\n");
     }
 
     @out_path = dup_cstr(p.s.alloc, ?artifact[0]);
@@ -842,7 +844,7 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
 # object) or `.a` (a static archive).
 fun is_object_path(tok: *u8) bool {
     if (tok == nil) { ret false; }
-    val n: usize = util.slen(tok);
+    val n: usize = str_len(tok::str);
     if (n == 0) { ret false; }
     var i: usize = 0;
     for (i < n) {
@@ -862,10 +864,10 @@ fun is_object_path(tok: *u8) bool {
 # file is found and written; false when nothing resolves. `.so` shared libraries
 # are not handled — only loose `.o` objects and static `.a` archives.
 fun resolve_input_into(tok: *u8, argc: usize, argv: **u8, buf: *u8, cap: usize) bool {
-    if (tok == nil || util.slen(tok) == 0) { ret false; }
+    if (tok == nil || str_empty(tok::str)) { ret false; }
 
     if (is_object_path(tok)) {
-        val n: usize = util.slen(tok);
+        val n: usize = str_len(tok::str);
         if (n + 1 > cap) { ret false; }
         var i: usize = 0;
         for (i < n) { buf[i] = tok[i]; i = i + 1; }
@@ -877,7 +879,7 @@ fun resolve_input_into(tok: *u8, argc: usize, argv: **u8, buf: *u8, cap: usize) 
     # `lib<name>.o` and `<name>.o` candidates in turn.
     var li: usize = 0;
     for (li < argc) {
-        if (util.eq(argv[li], "-L") && li + 1 < argc) {
+        if (str_equals(argv[li]::str, "-L") && li + 1 < argc) {
             if (try_named_object(argv[li + 1], tok, buf, cap)) { ret true; }
         }
         li = li + 1;
@@ -904,10 +906,12 @@ fun try_named_object(dir: *u8, name: *u8, buf: *u8, cap: usize) bool {
 # `<prefix><name>.<ext>` when `dir` is nil) into `buf`, null-terminated. returns
 # false if it would not fit. `prefix` is "lib" or ""; `ext` is "o" or "a".
 fun write_named_candidate(dir: *u8, prefix: *u8, name: *u8, ext: *u8, buf: *u8, cap: usize) bool {
+    # dir is nil for a working-directory probe; util.slen is the nil-safe length
+    # adapter (str_len derefs nil — mach-std#204). the rest are never nil.
     val dl: usize = util.slen(dir);
-    val pl: usize = util.slen(prefix);
-    val nl: usize = util.slen(name);
-    val el: usize = util.slen(ext);
+    val pl: usize = str_len(prefix::str);
+    val nl: usize = str_len(name::str);
+    val el: usize = str_len(ext::str);
     var need: usize = dl;
     if (dl > 0) { need = need + 1; }
     need = need + pl + nl + 1 + el + 1;
@@ -947,7 +951,7 @@ fun count_external_tokens(p: *driver.Project, argc: usize, argv: **u8) u32 {
     var i: usize = 0;
     for (i < argc) {
         val a: *u8 = argv[i];
-        if (util.eq(a, "-l") && i + 1 < argc)      { n = n + 1; i = i + 2; cnt; }
+        if (str_equals(a::str, "-l") && i + 1 < argc)      { n = n + 1; i = i + 2; cnt; }
         if (util.is_value_flag(a) && i + 1 < argc) { i = i + 2; cnt; }
         if (i > 1 && i != proj_ix && a != nil && a[0] != '-' && is_object_path(a)) { n = n + 1; }
         i = i + 1;
@@ -977,7 +981,7 @@ fun append_external_inputs(p: *driver.Project, root: *u8, argc: usize, argv: **u
     val base: u32 = @count;
     val grown: u32 = base + extra;
     val gr: Result[**u8, str] = reallocate[*u8](p.s.alloc, @paths, base::usize, grown::usize);
-    if (is_err[**u8, str](gr)) { util.emit("error: out of memory\n"); ret 2; }
+    if (is_err[**u8, str](gr)) { print.eprint("error: out of memory\n"); ret 2; }
     @paths = unwrap_ok[**u8, str](gr);
 
     var z: u32 = base;
@@ -1019,7 +1023,7 @@ fun append_external_inputs(p: *driver.Project, root: *u8, argc: usize, argv: **u
     var i: usize = 0;
     for (i < argc) {
         val a: *u8 = argv[i];
-        if (util.eq(a, "-l") && i + 1 < argc) {
+        if (str_equals(a::str, "-l") && i + 1 < argc) {
             val code: i64 = resolve_and_store_input(p, argv[i + 1], root, argc, argv, ?buf[0], 4096,
                                                     @paths, ?written, sonames, soname_count);
             if (code != 0) { shrink_paths(p, paths, count, written, grown); ret code; }
@@ -1055,13 +1059,13 @@ fun shrink_paths(p: *driver.Project, paths: ***u8, count: *u32, written: u32, gr
 # non-zero exit code.
 fun append_soname(p: *driver.Project, name: *u8, sonames: **intern.StrId, soname_count: *u32) i64 {
     val ir: Result[intern.StrId, str] = intern.intern(?p.s.interner, util.cstr_str(name));
-    if (is_err[intern.StrId, str](ir)) { util.emit("error: out of memory\n"); ret 2; }
+    if (is_err[intern.StrId, str](ir)) { print.eprint("error: out of memory\n"); ret 2; }
     val id: intern.StrId = unwrap_ok[intern.StrId, str](ir);
 
     val old: u32 = @soname_count;
     val gr: Result[*intern.StrId, str] =
         reallocate[intern.StrId](p.s.alloc, @sonames, old::usize, (old + 1)::usize);
-    if (is_err[*intern.StrId, str](gr)) { util.emit("error: out of memory\n"); ret 2; }
+    if (is_err[*intern.StrId, str](gr)) { print.eprint("error: out of memory\n"); ret 2; }
     @sonames = unwrap_ok[*intern.StrId, str](gr);
     (@sonames)[old] = id;
     @soname_count = old + 1;
@@ -1085,9 +1089,9 @@ fun store_shared(p: *driver.Project, path: *u8, sonames: **intern.StrId, soname_
     if (read_so_soname(p, path, ?sname[0], 4096)) {
         ret append_soname(p, ?sname[0], sonames, soname_count);
     }
-    util.emit("error: '");
-    util.emit(path);
-    util.emit("' is not a loadable ELF shared object (an ld script or unsupported '.so')\n");
+    print.eprint("error: '");
+    print.eprint(path::str);
+    print.eprint("' is not a loadable ELF shared object (an ld script or unsupported '.so')\n");
     ret 1;
 }
 
@@ -1109,9 +1113,9 @@ fun resolve_and_store_input(p: *driver.Project, tok: *u8, root: *u8, argc: usize
     # Windows-style `C:\path\kernel32.dll` records the bare `kernel32.dll`.
     if (is_dll_path(tok)) {
         if (p.target.of_id != of.OF_COFF) {
-            util.emit("error: '");
-            util.emit(tok);
-            util.emit("' is a Windows DLL, but the selected target's object format is not PE/COFF\n");
+            print.eprint("error: '");
+            print.eprint(tok::str);
+            print.eprint("' is a Windows DLL, but the selected target's object format is not PE/COFF\n");
             ret 1;
         }
         ret append_soname(p, dll_basename(tok), sonames, soname_count);
@@ -1151,14 +1155,14 @@ fun resolve_and_store_input(p: *driver.Project, tok: *u8, root: *u8, argc: usize
     }
 
     if (!found) {
-        util.emit("error: cannot find link input '");
-        util.emit(tok);
-        util.emit("'\n");
+        print.eprint("error: cannot find link input '");
+        print.eprint(tok::str);
+        print.eprint("'\n");
         ret 1;
     }
 
     val dup: *u8 = dup_cstr(p.s.alloc, buf);
-    if (dup == nil) { util.emit("error: out of memory\n"); ret 2; }
+    if (dup == nil) { print.eprint("error: out of memory\n"); ret 2; }
     paths[@written] = dup;
     @written = @written + 1;
     ret 0;
@@ -1200,7 +1204,7 @@ fun read_so_soname(p: *driver.Project, path: *u8, out: *u8, cap: usize) bool {
             # a loadable shared object with no DT_SONAME: the basename is the
             # canonical dependency name.
             val base: *u8 = soname_basename(path);
-            val bl: usize = util.slen(base);
+            val bl: usize = str_len(base::str);
             if (bl + 1 <= cap) {
                 var k: usize = 0;
                 for (k < bl) { out[k] = base[k]; k = k + 1; }
@@ -1270,7 +1274,7 @@ fun extract_soname(buf: *u8, len: usize, out: *u8, cap: usize) bool {
 # explicit `libc.so.6` or `path/to/libfoo.so`).
 fun is_shared_path(tok: *u8) bool {
     if (tok == nil) { ret false; }
-    val n: usize = util.slen(tok);
+    val n: usize = str_len(tok::str);
     if (n < 3) { ret false; }
     var i: usize = 0;
     for (i + 3 <= n) {
@@ -1289,7 +1293,7 @@ fun is_shared_path(tok: *u8) bool {
 # so unlike an ELF `.so` it is recorded verbatim with no on-disk probe.
 fun is_dll_path(tok: *u8) bool {
     if (tok == nil) { ret false; }
-    val n: usize = util.slen(tok);
+    val n: usize = str_len(tok::str);
     if (n < 4) { ret false; }
     val d: u8 = tok[n - 4];
     val l1: u8 = tok[n - 3] | 0x20;
@@ -1304,7 +1308,7 @@ fun is_dll_path(tok: *u8) bool {
 # `C:\Windows\System32\kernel32.dll` -> `kernel32.dll`). returns a pointer into
 # `path` (no copy); the caller interns it.
 fun dll_basename(path: *u8) *u8 {
-    val n: usize = util.slen(path);
+    val n: usize = str_len(path::str);
     var last: usize = 0;
     var i: usize = 0;
     for (i < n) {
@@ -1318,7 +1322,7 @@ fun dll_basename(path: *u8) *u8 {
 # the loader resolves (e.g. `/usr/lib/libc.so.6` -> `libc.so.6`). returns the
 # pointer to the component within `path` (no copy); the caller interns it.
 fun soname_basename(path: *u8) *u8 {
-    val n: usize = util.slen(path);
+    val n: usize = str_len(path::str);
     var last: usize = 0;
     var i: usize = 0;
     for (i < n) {
@@ -1337,7 +1341,7 @@ fun soname_basename(path: *u8) *u8 {
 fun resolve_shared_into(p: *driver.Project, name: *u8, argc: usize, argv: **u8, buf: *u8, cap: usize) bool {
     var li: usize = 0;
     for (li < argc) {
-        if (util.eq(argv[li], "-L") && li + 1 < argc) {
+        if (str_equals(argv[li]::str, "-L") && li + 1 < argc) {
             if (try_shared_in_dir(p, argv[li + 1], name, buf, cap)) { ret true; }
         }
         li = li + 1;
@@ -1392,7 +1396,7 @@ fun accept_shared(p: *driver.Project, cand: *u8, buf: *u8, cap: usize) bool {
 fun write_named_versioned(dir: *u8, name: *u8, v: u32, buf: *u8, cap: usize) bool {
     if (v > 9) { ret false; }
     if (!write_named_candidate(dir, "lib", name, "so", buf, cap)) { ret false; }
-    val n: usize = util.slen(buf);
+    val n: usize = str_len(buf::str);
     if (n + 3 > cap) { ret false; }
     buf[n] = '.';
     buf[n + 1] = ('0'::u32 + v)::u8;
@@ -1406,8 +1410,8 @@ fun write_named_versioned(dir: *u8, name: *u8, v: u32, buf: *u8, cap: usize) boo
 # a `str` (length-counted) rather than a null-terminated `*u8`. returns the byte
 # length written, or 0 if it would not fit.
 fun join_into_str(buf: *u8, cap: usize, dir: *u8, leaf: str) usize {
-    val dl: usize = util.slen(dir);
-    val ll: usize = util.slen(leaf::*u8);
+    val dl: usize = str_len(dir::str);
+    val ll: usize = str_len(leaf);
     var need: usize = dl + 1 + ll + 1;
     if (need > cap) { ret 0; }
     var k: usize = 0;
@@ -1490,7 +1494,7 @@ fun write_objects(p: *driver.Project, images: *of.ObjectImage,
                   obj_base: *u8, paths_out: ***u8) i64 {
     val count: u32 = p.topo_len;
     val ar: Result[**u8, str] = allocate[*u8](p.s.alloc, count::usize);
-    if (is_err[**u8, str](ar)) { util.emit("error: out of memory\n"); ret 2; }
+    if (is_err[**u8, str](ar)) { print.eprint("error: out of memory\n"); ret 2; }
     val paths: **u8 = unwrap_ok[**u8, str](ar);
 
     var ti: u32 = 0;
@@ -1501,7 +1505,7 @@ fun write_objects(p: *driver.Project, images: *of.ObjectImage,
         val fqn_opt: Option[str] = intern.lookup(?p.s.interner, m.fqn);
         if (is_none[str](fqn_opt)) {
             free_paths(p.s.alloc, paths, ti, count);
-            util.emit("error: module FQN not interned\n");
+            print.eprint("error: module FQN not interned\n");
             ret 2;
         }
 
@@ -1510,23 +1514,23 @@ fun write_objects(p: *driver.Project, images: *of.ObjectImage,
 
         if (!util.ensure_parents(?path[0])) {
             free_paths(p.s.alloc, paths, ti, count);
-            util.emit("error: failed to create object directory\n");
+            print.eprint("error: failed to create object directory\n");
             ret 2;
         }
 
         val em: Result[bool, str] = obj.emit(?images[mid::u32], ?p.target, ?path[0]);
         if (is_err[bool, str](em)) {
             free_paths(p.s.alloc, paths, ti, count);
-            util.emit("error: ");
-            util.emit(unwrap_err[bool, str](em));
-            util.emit("\n");
+            print.eprint("error: ");
+            print.eprint(unwrap_err[bool, str](em));
+            print.eprint("\n");
             ret 1;
         }
 
         paths[ti] = dup_cstr(p.s.alloc, ?path[0]);
         if (paths[ti] == nil) {
             free_paths(p.s.alloc, paths, ti, count);
-            util.emit("error: out of memory\n");
+            print.eprint("error: out of memory\n");
             ret 2;
         }
         ti = ti + 1;
@@ -1546,24 +1550,24 @@ fun append_runner_object(p: *driver.Project, runner_img: *of.ObjectImage,
     var path: [4096]u8;
     util.join_into(?path[0], 4096, obj_base, "__mach_test.o");
     if (!util.ensure_parents(?path[0])) {
-        util.emit("error: failed to create object directory\n");
+        print.eprint("error: failed to create object directory\n");
         ret 2;
     }
 
     val em: Result[bool, str] = obj.emit(runner_img, ?p.target, ?path[0]);
     if (is_err[bool, str](em)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[bool, str](em));
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[bool, str](em));
+        print.eprint("\n");
         ret 1;
     }
 
     val gr: Result[**u8, str] = reallocate[*u8](p.s.alloc, @paths, count::usize, (count + 1)::usize);
-    if (is_err[**u8, str](gr)) { util.emit("error: out of memory\n"); ret 2; }
+    if (is_err[**u8, str](gr)) { print.eprint("error: out of memory\n"); ret 2; }
     @paths = unwrap_ok[**u8, str](gr);
 
     (@paths)[count] = dup_cstr(p.s.alloc, ?path[0]);
-    if ((@paths)[count] == nil) { util.emit("error: out of memory\n"); ret 2; }
+    if ((@paths)[count] == nil) { print.eprint("error: out of memory\n"); ret 2; }
     ret 0;
 }
 
@@ -1572,9 +1576,9 @@ fun append_runner_object(p: *driver.Project, runner_img: *of.ObjectImage,
 # `<base>/a/b/c.o`). returns the byte length written (excluding the terminator),
 # or 0 if it would not fit.
 fun mirror_fqn(buf: *u8, cap: usize, base: *u8, fqn: str, suffix: str) usize {
-    val bl: usize = util.slen(base);
-    val fl: usize = util.slen(fqn::*u8);
-    val el: usize = util.slen(suffix::*u8);
+    val bl: usize = str_len(base::str);
+    val fl: usize = str_len(fqn);
+    val el: usize = str_len(suffix);
     var need: usize = bl + 1 + fl + 1 + el + 1;
     if (need > cap) { ret 0; }
 
@@ -1633,7 +1637,7 @@ fun free_paths(alloc: *Allocator, paths: **u8, n: u32, cap: u32) {
     if (paths == nil) { ret; }
     var i: u32 = 0;
     for (i < n) {
-        if (paths[i] != nil) { deallocate[u8](alloc, paths[i], (util.slen(paths[i]) + 1)::usize); }
+        if (paths[i] != nil) { deallocate[u8](alloc, paths[i], (str_len(paths[i]::str) + 1)::usize); }
         i = i + 1;
     }
     if (cap > 0) { deallocate[*u8](alloc, paths, cap::usize); }
@@ -1643,7 +1647,7 @@ fun free_paths(alloc: *Allocator, paths: **u8, n: u32, cap: u32) {
 # storage. returns nil on allocation failure (the caller treats that as
 # "no path").
 fun dup_cstr(alloc: *Allocator, s: *u8) *u8 {
-    val n: usize = util.slen(s);
+    val n: usize = str_len(s::str);
     val r: Result[*u8, str] = allocate[u8](alloc, n + 1);
     if (is_err[*u8, str](r)) { ret nil; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
@@ -1665,10 +1669,10 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val emit_opt: Option[*u8] = emit_kind(argc, argv);
     if (is_some[*u8](emit_opt)) {
         val kind: *u8 = unwrap[*u8](emit_opt);
-        if (util.eq(kind, "obj"))      { emit_obj = true; }
-        or (util.eq(kind, "exe"))      { emit_obj = false; }
+        if (str_equals(kind::str, "obj"))      { emit_obj = true; }
+        or (str_equals(kind::str, "exe"))      { emit_obj = false; }
         or {
-            util.emit("error: --emit expects 'obj' or 'exe'\n");
+            print.eprint("error: --emit expects 'obj' or 'exe'\n");
             ret 1;
         }
     }
@@ -1680,7 +1684,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     # compile is suballocated through an arena and reclaimed in one dnit.
     var backing: Allocator;
     if (is_some[str](page.make(?backing))) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
@@ -1688,12 +1692,12 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val eff: usize = util.separator_index(argc, argv);
     val cfg_opt: Option[cfg.Config] = cfg.parse(eff, argv);
     if (is_none[cfg.Config](cfg_opt)) {
-        util.emit("error: invalid command-line flags\n");
+        print.eprint("error: invalid command-line flags\n");
         ret 1;
     }
     val config: cfg.Config = unwrap[cfg.Config](cfg_opt);
     if (config.bin != nil && config.lib != nil) {
-        util.emit("error: --bin and --lib cannot be combined\n");
+        print.eprint("error: --bin and --lib cannot be combined\n");
         ret 1;
     }
 
@@ -1702,14 +1706,14 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val pix: usize = util.positional_index(eff, argv, 2);
     if (pix < eff) {
         if (config.cwd != nil) {
-            util.emit("error: cannot combine a project-path positional with --cwd\n");
+            print.eprint("error: cannot combine a project-path positional with --cwd\n");
             ret 1;
         }
         start = argv[pix];
     }
     var root: [4096]u8;
     if (!util.find_project_root(start, ?root[0], 4096)) {
-        util.emit("error: no mach.toml found in the working directory or any parent\n");
+        print.eprint("error: no mach.toml found in the working directory or any parent\n");
         ret 1;
     }
 
@@ -1717,13 +1721,13 @@ pub fun run(argc: usize, argv: **u8) i64 {
     # the unit selectors it owns stay valid.
     var menu_ar: arena.Arena;
     if (is_some[str](arena.init(?menu_ar, ?backing, 0))) {
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
     var menu_alloc: Allocator;
     if (is_some[str](arena.make(?menu_alloc, ?menu_ar))) {
         arena.dnit(?menu_ar);
-        util.emit("error: failed to initialise allocator\n");
+        print.eprint("error: failed to initialise allocator\n");
         ret 2;
     }
 
@@ -1732,15 +1736,15 @@ pub fun run(argc: usize, argv: **u8) i64 {
         util.cstr_str(cstr_or(config.bin)), util.cstr_str(cstr_or(config.lib)),
         config.bin != nil, config.lib != nil);
     if (is_err[driver.Matrix, str](mx_r)) {
-        util.emit("error: ");
-        util.emit(unwrap_err[driver.Matrix, str](mx_r));
-        util.emit("\n");
+        print.eprint("error: ");
+        print.eprint(unwrap_err[driver.Matrix, str](mx_r));
+        print.eprint("\n");
         arena.dnit(?menu_ar);
         ret 1;
     }
     val mx: driver.Matrix = unwrap_ok[driver.Matrix, str](mx_r);
     if (mx.count == 0) {
-        util.emit("error: nothing to build\n");
+        print.eprint("error: nothing to build\n");
         arena.dnit(?menu_ar);
         ret 1;
     }
@@ -1755,7 +1759,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
         var u_ar: arena.Arena;
         if (is_some[str](arena.init(?u_ar, ?backing, 0))) {
-            util.emit("error: failed to initialise allocator\n");
+            print.eprint("error: failed to initialise allocator\n");
             arena.dnit(?menu_ar);
             ret 2;
         }
@@ -1763,7 +1767,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
         if (is_some[str](arena.make(?u_alloc, ?u_ar))) {
             arena.dnit(?u_ar);
             arena.dnit(?menu_ar);
-            util.emit("error: failed to initialise allocator\n");
+            print.eprint("error: failed to initialise allocator\n");
             ret 2;
         }
 
@@ -1787,15 +1791,15 @@ fun cstr_or(p: *u8) *u8 {
 # report_unit: write a `building <artifact> (<target>)` progress line to stderr
 # before a matrix unit compiles. the target is omitted when it is the default.
 fun report_unit(u: *driver.MatrixUnit) {
-    util.emit("building ");
-    if (u.has_artifact) { util.emit(u.artifact::*u8); }
-    or                  { util.emit("project"); }
+    print.eprint("building ");
+    if (u.has_artifact) { print.eprint(u.artifact); }
+    or                  { print.eprint("project"); }
     if (!str_empty(u.target)) {
-        util.emit(" (");
-        util.emit(u.target::*u8);
-        util.emit(")");
+        print.eprint(" (");
+        print.eprint(u.target);
+        print.eprint(")");
     }
-    util.emit("\n");
+    print.eprint("\n");
 }
 
 # emit_kind: scan argv for the value following `--emit`, exposed so
@@ -1808,7 +1812,7 @@ fun report_unit(u: *driver.MatrixUnit) {
 pub fun emit_kind(argc: usize, argv: **u8) Option[*u8] {
     var i: usize = 0;
     for (i < argc) {
-        if (util.eq(argv[i], "--emit")) {
+        if (str_equals(argv[i]::str, "--emit")) {
             if (i + 1 < argc) { ret some[*u8](argv[i + 1]); }
             ret none[*u8]();
         }

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -12,6 +12,8 @@ use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_equals;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
@@ -136,9 +138,9 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
     val color_opt: Option[*u8] = util.get_value(argc, argv, "--color");
     if (is_some[*u8](color_opt)) {
         val mode: *u8 = unwrap[*u8](color_opt);
-        if (util.eq(mode, "auto"))   { c.color = COLOR_AUTO; }
-        or (util.eq(mode, "always")) { c.color = COLOR_ALWAYS; }
-        or (util.eq(mode, "never"))  { c.color = COLOR_NEVER; }
+        if (str_equals(mode::str, "auto"))   { c.color = COLOR_AUTO; }
+        or (str_equals(mode::str, "always")) { c.color = COLOR_ALWAYS; }
+        or (str_equals(mode::str, "never"))  { c.color = COLOR_NEVER; }
         or                           { ret none[Config](); }
     }
 

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -8,10 +8,11 @@
 # operate on caller-provided buffers. `--flag=value` and bundled short flags
 # are intentionally not recognized.
 #
-# the `eq`/`slen`/`emit`/`emit_num` entries are thin `*u8` bridges over
-# `std.types.string` / `std.print`, retained only for the `*u8` call sites in
-# `cmd/build.mach` and `config.mach`; in-scope CLI code calls std directly
-# (#1296).
+# `slen` and `cstr_str` are the remaining thin `*u8` bridges: `slen` is the
+# nil-safe length adapter (std `str_len` derefs nil — mach-std#204) and
+# `cstr_str` views a `*u8` as a `str`. the equality and stderr-emit
+# reimplementations were removed in favour of `std.types.string` / `std.print`
+# at the call sites (#1296, #1302).
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -28,23 +29,11 @@ use std.types.result.is_ok;
 
 use os:    std.system.os;
 use fs:    std.filesystem;
-use print: std.print;
-
-# eq: byte-wise equality of two null-terminated `*u8` strings. a thin bridge
-# over `std.types.string.str_equals` (nil-safe, identical semantics) via the
-# free `::str` cast, kept for the build/config call sites still in `*u8`.
-# ---
-# a:   first null-terminated byte string
-# b:   second null-terminated byte string
-# ret: true if both reach the terminator at the same position with matching bytes
-pub fun eq(a: *u8, b: *u8) bool {
-    ret str_equals(a::str, b::str);
-}
 
 # slen: length in bytes of a null-terminated `*u8` string, excluding the
-# terminator. a nil-safe adapter over `std.types.string.str_len` (which derefs
-# nil); returns 0 for nil. kept for the build/config `*u8` call sites and the
-# nil-safety gap (mach-std#204).
+# terminator. the nil-safe length adapter over `std.types.string.str_len` (which
+# derefs nil); returns 0 for nil. kept for the CLI `*u8` call sites that can see
+# nil (mach-std#204 tracks the std-side gap).
 # ---
 # s:   null-terminated byte string
 # ret: number of bytes before the terminator (0 for nil)
@@ -62,23 +51,6 @@ pub fun cstr_str(s: *u8) str {
     ret s::str;
 }
 
-# emit: write a null-terminated `*u8` string to stderr. delegates to
-# `std.print.eprint` over the `::str` bridge (nil-safe; matches the prior
-# zero-byte write for nil). kept for the build/config `*u8` call sites.
-# ---
-# s: null-terminated byte string to write
-pub fun emit(s: *u8) {
-    print.eprint(s::str);
-}
-
-# emit_num: write the base-10 rendering of `n` to stderr via `std.print.eu64`.
-# kept for the build `*u8`-adjacent call sites.
-# ---
-# n: the value to render
-pub fun emit_num(n: usize) {
-    print.eu64(n::u64);
-}
-
 # has_flag: returns true if argv contains an exact match for `flag`.
 # ---
 # argc: the number of arguments to scan
@@ -88,7 +60,7 @@ pub fun emit_num(n: usize) {
 pub fun has_flag(argc: usize, argv: **u8, flag: *u8) bool {
     var i: usize = 0;
     for (i < argc) {
-        if (eq(argv[i], flag)) { ret true; }
+        if (str_equals(argv[i]::str, flag::str)) { ret true; }
         i = i + 1;
     }
     ret false;
@@ -103,7 +75,7 @@ pub fun has_flag(argc: usize, argv: **u8, flag: *u8) bool {
 pub fun get_value(argc: usize, argv: **u8, flag: *u8) Option[*u8] {
     var i: usize = 0;
     for (i < argc) {
-        if (eq(argv[i], flag)) {
+        if (str_equals(argv[i]::str, flag::str)) {
             if (i + 1 < argc) { ret some[*u8](argv[i + 1]); }
             ret none[*u8]();
         }
@@ -128,11 +100,11 @@ pub fun is_flag(s: *u8) bool {
 # a:   the token to test
 # ret: true when `a` is a value-taking flag
 pub fun is_value_flag(a: *u8) bool {
-    ret eq(a, "-L") || eq(a, "-l") || eq(a, "-o") ||
-        eq(a, "--target") || eq(a, "--cwd") || eq(a, "--color") ||
-        eq(a, "--artifacts") || eq(a, "--emit") || eq(a, "--filter") ||
-        eq(a, "--out") || eq(a, "--name") || eq(a, "--ref") ||
-        eq(a, "--profile") || eq(a, "--bin") || eq(a, "--lib");
+    ret str_equals(a::str, "-L") || str_equals(a::str, "-l") || str_equals(a::str, "-o") ||
+        str_equals(a::str, "--target") || str_equals(a::str, "--cwd") || str_equals(a::str, "--color") ||
+        str_equals(a::str, "--artifacts") || str_equals(a::str, "--emit") || str_equals(a::str, "--filter") ||
+        str_equals(a::str, "--out") || str_equals(a::str, "--name") || str_equals(a::str, "--ref") ||
+        str_equals(a::str, "--profile") || str_equals(a::str, "--bin") || str_equals(a::str, "--lib");
 }
 
 # separator_index: index of the `--` separator in argv, or argc when absent.
@@ -146,7 +118,7 @@ pub fun is_value_flag(a: *u8) bool {
 pub fun separator_index(argc: usize, argv: **u8) usize {
     var i: usize = 1;
     for (i < argc) {
-        if (eq(argv[i], "--")) { ret i; }
+        if (str_equals(argv[i]::str, "--")) { ret i; }
         i = i + 1;
     }
     ret argc;


### PR DESCRIPTION
Final slice of the CLI std-migration sweep (section F of the #1296 inventory, now unblocked by the manifest-v2 merge): migrate the remaining hand-rolled-helper call sites in \`src/cli/cmd/build.mach\` and \`src/cli/config.mach\` directly onto std, then delete the bridges that thereby become unreferenced.

## Migrated (build.mach + config.mach)
- \`util.eq\` ×10 (build 7, config 3) → \`str_equals(x::str, "...")\`
- \`util.emit\` ×110 (build) → \`std.print.eprint\` (\`::str\` only on \`*u8\` args; str/literals pass through)
- \`util.emit_num\` ×3 (build) → \`std.print.eu64(x::u64)\`
- \`util.slen\` ×22/23 (build) → \`str_len(x::str)\` / \`str_empty(...)\`; the one nil-reachable site kept on the adapter (see below)
- \`emit_id\`'s \`os.write\`+\`slen\` → \`print.eprint(str)\` (the \`os\` module import is now unused and dropped)

## Deleted from util.mach
\`eq\`, \`emit\`, \`emit_num\` — fully unreferenced once build/config and util's own argv helpers (\`has_flag\`/\`get_value\`/\`is_value_flag\`/\`separator_index\`) call \`str_equals\` directly.

## Kept, with reason
- \`util.slen\` — nil-safe length adapter; std \`str_len\` derefs nil (mach-std#204). Still consumed by out-of-scope cmd files (init/doc/dep) and one nil-reachable build.mach site (\`write_named_candidate\`'s working-dir probe, where \`dir\` is legitimately nil).
- \`util.cstr_str\` — the legitimate named \`*u8\`→\`str\` bridge (not a std reimplementation); still used by doc.mach and util's own path helpers.

\`util.mach\` now retains only argv scanning, project-root discovery, path-buffer helpers, and the two kept bridges.

## Verification
- \`mach build .\` clean; \`mach test .\` all pass.
- Byte-identical self-host fixpoint (B1 == B2).
- User-visible output byte-identical: 19 build/config flows (verbose v1 + v2 builds, multi-artifact matrix, release/emit-ir, emit-obj, library, every error path) diff-identical before/after in a fixed temp project (stdout + stderr + exit).
- Integration battery green: manifestv2, extlink, dynlink, cffi.

Net: **-22 lines** (168 +, 190 -).

Refs #1302, #1296.