### PR TITLE
feat(comptime): closed shape set + $project/$target/$bin roots (#1217, #1249)

### DIFF
--- a/.github/tests/comptimeroots/bareident_gate/mach.toml
+++ b/.github/tests/comptimeroots/bareident_gate/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "ctbareidentgate"
+name = "Comptime roots — bare $ident in a gate"
+version = "1.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/ctbareidentgate"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/comptimeroots/bareident_gate/src/main.mach
+++ b/.github/tests/comptimeroots/bareident_gate/src/main.mach
@@ -1,0 +1,11 @@
+use std.runtime.linux.x86_64;
+
+# a standalone bare `$ident` in a `$if` gate is none of the closed comptime
+# channel shapes (#1249): comptime parameters are referenced without `$`, and
+# comptime paths are rooted. the build must reject it with the one teaching
+# diagnostic owned by comptime.eval — never fold it nor compile.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    $if ($mode) { ret 1; }
+    ret 0;
+}

--- a/.github/tests/comptimeroots/bareident_value/mach.toml
+++ b/.github/tests/comptimeroots/bareident_value/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "ctbareidentvalue"
+name = "Comptime roots — bare $ident in value position"
+version = "1.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/ctbareidentvalue"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/comptimeroots/bareident_value/src/main.mach
+++ b/.github/tests/comptimeroots/bareident_value/src/main.mach
@@ -1,0 +1,11 @@
+use std.runtime.linux.x86_64;
+
+# a standalone bare `$ident` in value position is none of the closed comptime
+# channel shapes (#1249): comptime parameters are referenced without `$`, and
+# comptime paths are rooted. sema defers to comptime.eval's one rejection rule,
+# so the build must fail with the same teaching diagnostic as the gate case.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    val x: i64 = $mode;
+    ret x;
+}

--- a/.github/tests/comptimeroots/run.sh
+++ b/.github/tests/comptimeroots/run.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# comptime roots integration test (#1217, #1249). two halves:
+#
+#   folding — the `$project.*` / `$target.*` / `$bin.*` roots must fold to the
+#   manifest's declared values for BOTH a v2 manifest and the legacy v1 format.
+#   each app asserts every root against its own manifest and exits 0 only when
+#   all match; a mismatch returns the drifted root's id. this is the end-to-end
+#   proof that the driver feeds the roots from the manifest model and the
+#   selected build unit.
+#
+#   rejection — a standalone bare `$ident` is none of the closed comptime
+#   channel shapes (#1249); the build must FAIL with the one teaching diagnostic,
+#   never fold. asserted in both a `$if` gate and value position to prove sema's
+#   two surfaces defer to the single rule owned by comptime.eval.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+# the exact teaching diagnostic comptime.eval emits for a bare `$ident`
+# (comptime.COMPTIME_BARE_IDENT_MSG); both rejection apps must surface it verbatim.
+BARE_IDENT_DIAG='comptime parameters are referenced without `$`; comptime paths are rooted: `$mach`, `$project`, `$target`, `$bin`'
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# build_and_run <app-dir> <label>: vendor std, build, run, require exit 0. the
+# app's own main returns the drifted root's id on a fold mismatch.
+build_and_run() {
+    local app="$1"; local label="$2"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    if ! ( cd "$dst" && "$MACH" build . ) >/dev/null 2>&1; then
+        echo "FAIL comptimeroots/$label: build failed" >&2; fail=1; return
+    fi
+    local bin
+    bin="$(find "$dst/out" -type f -path '*/bin/*' | head -n1)"
+    if [ -z "$bin" ]; then
+        echo "FAIL comptimeroots/$label: no binary produced" >&2; fail=1; return
+    fi
+    set +e
+    "$bin"; local code=$?
+    set -e
+    if [ "$code" -ne 0 ]; then
+        echo "FAIL comptimeroots/$label: root id $code folded to the wrong value" >&2; fail=1; return
+    fi
+    echo "PASS comptimeroots/$label: \$project/\$target/\$bin roots fold to the manifest values"
+}
+
+# expect_reject <app-dir> <label> <diagnostic>: vendor std, build, and require
+# the build to FAIL with `diagnostic` present verbatim on stderr. proves a bare
+# `$ident` is rejected by the one comptime rule rather than folded or compiled.
+expect_reject() {
+    local app="$1"; local label="$2"; local want="$3"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    local out
+    if out="$( cd "$dst" && "$MACH" build . 2>&1 )"; then
+        echo "FAIL comptimeroots/$label: build unexpectedly succeeded for a bare \$ident" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF -- "$want"; then
+        echo "FAIL comptimeroots/$label: missing the teaching diagnostic; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    echo "PASS comptimeroots/$label: bare \$ident rejected with the teaching diagnostic"
+}
+
+build_and_run v1app "v1 manifest"
+build_and_run v2app "v2 manifest"
+
+expect_reject bareident_gate  "bare \$ident gate"  "$BARE_IDENT_DIAG"
+expect_reject bareident_value "bare \$ident value" "$BARE_IDENT_DIAG"
+
+exit "$fail"

--- a/.github/tests/comptimeroots/v1app/mach.toml
+++ b/.github/tests/comptimeroots/v1app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "ctrootsv1"
+name = "Comptime roots — v1 manifest"
+version = "2.4.6"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/ctrootsv1"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/comptimeroots/v1app/src/main.mach
+++ b/.github/tests/comptimeroots/v1app/src/main.mach
@@ -1,0 +1,16 @@
+use std.runtime.linux.x86_64;
+use std.types.string.str_equals;
+
+# the `$project.*` / `$target.*` comptime roots (#1217) must fold to this v1
+# manifest's declared values. v1 has no artifact stanza, so `$bin.name` is not
+# asserted here (it folds to "not available"). exits 0 only when every root
+# matches; a mismatch returns the drifted root's id.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    if (!str_equals($project.version, "2.4.6")) { ret 1; }
+    if (!str_equals($project.id, "ctrootsv1"))  { ret 2; }
+    if (!str_equals($target.os, "linux"))       { ret 3; }
+    if (!str_equals($target.isa, "x86_64"))     { ret 4; }
+    if (!str_equals($target.abi, "sysv64"))     { ret 5; }
+    ret 0;
+}

--- a/.github/tests/comptimeroots/v2app/mach.toml
+++ b/.github/tests/comptimeroots/v2app/mach.toml
@@ -1,0 +1,27 @@
+[project]
+id      = "ctrootsv2"
+name    = "Comptime roots — v2 manifest"
+version = "3.1.4"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.roots]
+entry = "main.mach"
+
+[profile.debug]
+opt = "O0"
+
+[profile.release]
+opt = "O2"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.4.0"

--- a/.github/tests/comptimeroots/v2app/src/main.mach
+++ b/.github/tests/comptimeroots/v2app/src/main.mach
@@ -1,0 +1,16 @@
+use std.runtime;
+use std.types.string.str_equals;
+
+# the `$project.*` / `$target.*` / `$bin.*` comptime roots (#1217) must fold to
+# this v2 manifest's declared values and the selected artifact's name. exits 0
+# only when every root matches; a mismatch returns the drifted root's id.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    if (!str_equals($project.version, "3.1.4")) { ret 1; }
+    if (!str_equals($project.id, "ctrootsv2"))  { ret 2; }
+    if (!str_equals($target.os, "linux"))       { ret 3; }
+    if (!str_equals($target.isa, "x86_64"))     { ret 4; }
+    if (!str_equals($target.abi, "sysv64"))     { ret 5; }
+    if (!str_equals($bin.name, "roots"))        { ret 6; }
+    ret 0;
+}

--- a/doc/language/comptime-mach.md
+++ b/doc/language/comptime-mach.md
@@ -48,6 +48,11 @@ $mach.project.version
 $mach.project.root
 ```
 
+> Project metadata now lives at the top-level `$project.*` root
+> (`$project.{id,version,name,description}`), fed from `[project]` in
+> `mach.toml` — see [comptime.md](comptime.md). These `$mach.project.*` paths
+> remain reserved stubs.
+
 ### `$mach.source.*` — current source position (stubs)
 
 ```mach

--- a/doc/language/comptime.md
+++ b/doc/language/comptime.md
@@ -4,27 +4,63 @@ The `$` prefix opens the **bidirectional channel** between the developer
 and the compiler. Reads observe compiler-provided state; writes annotate
 declarations the developer made. Everything that touches comptime in
 Mach — conditional compilation, attributes, intrinsics, target queries —
-uses one of four shapes on this channel.
+uses one of the shapes on this channel.
 
-## The four shapes
+## The shapes
 
 | Shape | Meaning | Direction |
 |---|---|---|
-| `$mach.path.to.value` | Compiler-owned value | compiler → developer |
+| `$mach.*` / `$project.*` / `$target.*` / `$bin.*` | Rooted compiler-owned read | compiler → developer |
 | `$sym.attr = value` / `$sym.attr` | Attribute on declared symbol | bidirectional |
 | `$sym(args)` | Comptime function call (intrinsic) | call |
 | `$if`, `$or` | Comptime control flow | structural |
 
 The parser distinguishes these by structure:
 
-- `$mach.<anything>` — always a read into the compiler-owned tree.
-  `mach` is reserved at the top of `$`; user symbols cannot collide here.
+- `$<root>.<path>`, where `<root>` is one of the reserved roots `mach`,
+  `project`, `target`, `bin` — a read into a compiler-owned tree. The roots
+  are reserved at the top of `$`; user symbols cannot collide with them.
 - `$ident.attr = ...` — write to an attribute slot on `ident`, which must
   be a symbol declared in this module.
 - `$ident(args)` — comptime call; the closed compiler-intrinsic set lives
   here.
 - `$if` / `$or` — comptime branches, structurally distinct from runtime
   `if` / `or`.
+
+## Compiler-owned roots
+
+| Root | Reads | Source |
+|---|---|---|
+| `$mach.*` | target/os/arch tags, pointer width, compiler identity | active target + compiler |
+| `$project.{id,version,name,description}` | project metadata | `[project]` in `mach.toml` |
+| `$target.{os,isa,abi}` | the selected target's declared tuple, as strings | the selected `mach.toml` target |
+| `$bin.name` | the artifact being built | the selected build unit (`[bin.*]` / `[lib.*]`) |
+
+`$target.*` carries the manifest's declared **string** spellings (`"linux"`,
+`"x86_64"`, `"sysv64"`), distinct from `$mach.target.*`'s numeric tags used for
+`$mach.os.*` comparison — both keep working. A root field the manifest does not
+declare (`$project.description` on a v1 manifest, `$bin.name` on a v1 manifest
+with no artifact stanza) reports the read as unavailable rather than folding to
+an empty string. See [comptime-mach.md](comptime-mach.md) for the `$mach.*`
+subtree.
+
+```mach
+val ver: str = $project.version;            # "1.3.0", from [project].version
+$if ($target.os == "windows") { ... }       # the declared os string
+```
+
+## The bare `$ident` is rejected
+
+A standalone bare `$ident` — `$mode`, `$foo` — is **none** of the shapes above
+and is rejected with one teaching diagnostic, owned by the comptime evaluator:
+
+> comptime parameters are referenced without `$`; comptime paths are rooted:
+> `` $mach ``, `` $project ``, `` $target ``, `` $bin ``
+
+A comptime **parameter** is referenced by its bare name (no `$`); every comptime
+**path** is rooted. The rule applies identically in a `$if` gate and in value
+position — sema and lowering both defer to the evaluator's single verdict rather
+than each carrying their own.
 
 ## What's not in the channel
 
@@ -33,6 +69,7 @@ The parser distinguishes these by structure:
 - No decl-attached prefix sugar (`$inline pub fun ...` does not exist) —
   use attribute writes.
 - No comptime function definitions, no comptime loops.
+- No bare `$ident` — see above.
 
 ## See also
 

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1533,10 +1533,13 @@ fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     p.compiler_name = unwrap_ok[intern.StrId, str](rcn);
 
     # the `$project.version` root (#1217) now folds the manifest version, so the
-    # one-file release bump is `val rcv = $project.version;`. the flip is staged:
-    # the released build seed cannot fold `$project.version` yet, so it lands in
-    # the release after the one that ships these roots, when the seed understands
-    # them. the literal stays until then (see #1258).
+    # one-file release bump becomes `val rcv = $project.version;`. the flip is
+    # staged, not yet applied: the compiler is self-hosted by seeding from the
+    # most recent release (ci.yml `mach build .`), and that seed cannot fold
+    # `$project.version` until a release ships these roots. flipping now would
+    # make the seed fail to compile this file. the literal — kept in sync with
+    # `[project].version` in mach.toml — stays until the next release seed
+    # understands the root, at which point #1217's driver replacement lands.
     val rcv: Result[intern.StrId, str] = intern.intern(?p.s.interner, "1.3.0");
     if (is_err[intern.StrId, str](rcv)) { ret err[bool, str](unwrap_err[intern.StrId, str](rcv)); }
     p.compiler_ver = unwrap_ok[intern.StrId, str](rcv);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -99,8 +99,9 @@ pub val TARGET_OPT_RELEASE: TargetOpt = 2;
 # TargetEntry: one entry under `[targets.<name>]` in mach.toml.
 # ---
 # name:       interned target selector (e.g. "linux")
-# os_name:    interned os name (e.g. "linux")
-# isa_name:   interned isa name (e.g. "x86_64")
+# os_name:    interned os name (e.g. "linux"); read by `$target.os`
+# isa_name:   interned isa name (e.g. "x86_64"); read by `$target.isa`
+# abi_name:   interned abi name (e.g. "sysv64"); read by `$target.abi`
 # entrypoint: interned entrypoint file path, relative to dir_src (e.g. "main.mach")
 # artifacts:  interned artifact subdirectory under `out` (e.g. "linux"); may be
 #             nested (e.g. "smach/linux")
@@ -118,6 +119,7 @@ pub rec TargetEntry {
     name:       intern.StrId;
     os_name:    intern.StrId;
     isa_name:   intern.StrId;
+    abi_name:   intern.StrId;
     entrypoint: intern.StrId;
     artifacts:  intern.StrId;
     binary:     intern.StrId;
@@ -143,7 +145,15 @@ pub rec DepEntry {
 
 # ProjectConfig: parsed mach.toml plus the resolved dep metadata.
 # ---
-# id:           interned `[project].id`
+# id:           interned `[project].id`; read by `$project.id`
+# version:      interned `[project].version`; read by `$project.version`. STR_NIL
+#               when a v1 manifest omits it
+# name:         interned `[project].name` metadata; read by `$project.name`.
+#               STR_NIL when the manifest omits it
+# description:  interned `[project].description` metadata; read by
+#               `$project.description`. STR_NIL when the manifest omits it
+# bin_name:     interned name of the selected artifact; read by `$bin.name`.
+#               STR_NIL for a v1 manifest, which has no artifact stanza
 # dir_src:      interned `[project].dir_src` (default "src")
 # dir_dep:      interned `[project].dir_dep` (default "dep")
 # out:          interned `[project].dir_out` output root, with legacy `out`
@@ -174,6 +184,10 @@ pub rec DepEntry {
 # cascade_lib_count: number of entries in cascade_libs
 pub rec ProjectConfig {
     id:           intern.StrId;
+    version:      intern.StrId;
+    name:         intern.StrId;
+    description:  intern.StrId;
+    bin_name:     intern.StrId;
     dir_src:      intern.StrId;
     dir_dep:      intern.StrId;
     out:          intern.StrId;
@@ -723,6 +737,11 @@ fun init_project(p: *Project, s: *sess.Session) {
     p.target.of      = nil;
     p.compiler_name = intern.STR_NIL;
     p.compiler_ver  = intern.STR_NIL;
+    p.config.id           = intern.STR_NIL;
+    p.config.version      = intern.STR_NIL;
+    p.config.name         = intern.STR_NIL;
+    p.config.description  = intern.STR_NIL;
+    p.config.bin_name     = intern.STR_NIL;
     p.config.targets      = nil;
     p.config.target_count = 0;
     p.config.deps         = nil;
@@ -807,6 +826,20 @@ fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection
     if (is_err[intern.StrId, str](id_iv)) { ret err[bool, str](unwrap_err[intern.StrId, str](id_iv)); }
     p.config.id = unwrap_ok[intern.StrId, str](id_iv);
 
+    # project metadata for the `$project.*` comptime root; each is optional in a
+    # v1 manifest, so an absent key folds to "not available" rather than "".
+    val ver_iv: Result[intern.StrId, str] = intern_meta(?p.s.interner, toml.get_str(?t, "project.version"));
+    if (is_err[intern.StrId, str](ver_iv)) { ret err[bool, str](unwrap_err[intern.StrId, str](ver_iv)); }
+    p.config.version = unwrap_ok[intern.StrId, str](ver_iv);
+
+    val pname_iv: Result[intern.StrId, str] = intern_meta(?p.s.interner, toml.get_str(?t, "project.name"));
+    if (is_err[intern.StrId, str](pname_iv)) { ret err[bool, str](unwrap_err[intern.StrId, str](pname_iv)); }
+    p.config.name = unwrap_ok[intern.StrId, str](pname_iv);
+
+    val pdesc_iv: Result[intern.StrId, str] = intern_meta(?p.s.interner, toml.get_str(?t, "project.description"));
+    if (is_err[intern.StrId, str](pdesc_iv)) { ret err[bool, str](unwrap_err[intern.StrId, str](pdesc_iv)); }
+    p.config.description = unwrap_ok[intern.StrId, str](pdesc_iv);
+
     val dir_src_r: Result[intern.StrId, str] = intern_or(?p.s.interner, toml.get_str(?t, "project.dir_src"), "src");
     if (is_err[intern.StrId, str](dir_src_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](dir_src_r)); }
     p.config.dir_src = unwrap_ok[intern.StrId, str](dir_src_r);
@@ -871,6 +904,7 @@ fun load_v2_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifes
     entry.name       = bu.target_name;
     entry.os_name    = bu.target.os;
     entry.isa_name   = bu.target.isa;
+    entry.abi_name   = bu.target.abi;
     entry.entrypoint = bu.entry;
     entry.artifacts  = intern.STR_NIL;
     entry.binary     = bu.bin_path;
@@ -882,6 +916,11 @@ fun load_v2_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifes
     targets[0] = entry;
 
     p.config.id           = m.id;
+    p.config.version      = m.version;
+    p.config.name         = m.name;
+    p.config.description  = m.description;
+    # the artifact name feeds `$bin.name`; STR_NIL when the selection bound none.
+    if (bu.artifact != nil) { p.config.bin_name = bu.artifact.name; }
     p.config.dir_src      = m.src;
     p.config.dir_dep      = m.dep;
     p.config.out          = m.out_tmpl;
@@ -1189,6 +1228,10 @@ fun parse_targets_table(p: *Project, t: *toml.Table) Result[bool, str] {
         if (is_err[intern.StrId, str](ris)) { ret err[bool, str](unwrap_err[intern.StrId, str](ris)); }
         entry.isa_name = unwrap_ok[intern.StrId, str](ris);
 
+        val rab: Result[intern.StrId, str] = intern_meta(?p.s.interner, toml.get_str(sub, "abi"));
+        if (is_err[intern.StrId, str](rab)) { ret err[bool, str](unwrap_err[intern.StrId, str](rab)); }
+        entry.abi_name = unwrap_ok[intern.StrId, str](rab);
+
         val rep: Result[intern.StrId, str] = intern_required(?p.s.interner, toml.get_str(sub, "entrypoint"), "mach.toml: a [targets.*] entry is missing required key 'entrypoint'");
         if (is_err[intern.StrId, str](rep)) { ret err[bool, str](unwrap_err[intern.StrId, str](rep)); }
         entry.entrypoint = unwrap_ok[intern.StrId, str](rep);
@@ -1398,6 +1441,14 @@ fun intern_or(i: *intern.Interner, text: str, default: str) Result[intern.StrId,
     ret intern.intern(i, t);
 }
 
+# intern_meta: intern an optional manifest metadata value, yielding STR_NIL when
+# the key is absent/empty so the comptime root reads it as "not available"
+# rather than folding to an empty string.
+fun intern_meta(i: *intern.Interner, text: str) Result[intern.StrId, str] {
+    if (str_empty(text)) { ret ok[intern.StrId, str](intern.STR_NIL); }
+    ret intern.intern(i, text);
+}
+
 # intern_required: intern a required manifest value, erroring with `missing`
 # when the value is nil/empty. get_str returns a nil str for an absent key,
 # and interning a nil str dereferences NULL; this guards that for keys with
@@ -1481,9 +1532,11 @@ fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     if (is_err[intern.StrId, str](rcn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rcn)); }
     p.compiler_name = unwrap_ok[intern.StrId, str](rcn);
 
-    # note: the compiler version literal stays here until #1217 lands the
-    # `$project.version` design, which sources it from the manifest and retires
-    # this hardcoded string. left in place deliberately (see #1258).
+    # the `$project.version` root (#1217) now folds the manifest version, so the
+    # one-file release bump is `val rcv = $project.version;`. the flip is staged:
+    # the released build seed cannot fold `$project.version` yet, so it lands in
+    # the release after the one that ships these roots, when the seed understands
+    # them. the literal stays until then (see #1258).
     val rcv: Result[intern.StrId, str] = intern.intern(?p.s.interner, "1.3.0");
     if (is_err[intern.StrId, str](rcv)) { ret err[bool, str](unwrap_err[intern.StrId, str](rcv)); }
     p.compiler_ver = unwrap_ok[intern.StrId, str](rcv);
@@ -1751,6 +1804,12 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) Result[sess.ModuleId, s
     # even if parsing never runs (parse_module overwrites it with the real one)
     m.a                 = ast.init(p.s.alloc, 0);
     m.ctx               = comptime.init(p.s.alloc, p.target.os_id, p.target.arch_id, p.target.arch.pointer_width, p.compiler_name, p.compiler_ver);
+    # feed the manifest-derived `$project.*`/`$target.*`/`$bin.*` roots; the
+    # target tuple comes from the selected entry (set before any module loads).
+    comptime.set_build_context(?m.ctx,
+        p.config.id, p.config.version, p.config.name, p.config.description,
+        p.target_entry.os_name, p.target_entry.isa_name, p.target_entry.abi_name,
+        p.config.bin_name);
     m.pub_consts        = nil;
     m.pub_const_count   = 0;
     m.pub_const_cap     = 0;

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1071,3 +1071,28 @@ test "resolve: a runtime parameter shadowing a module const is rejected in a $if
     sess.dnit(?s);
     ret 0;
 }
+
+test "resolve: a standalone bare $ident gate is rejected with the teaching diagnostic (#1249)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # a lone `$mode` is none of the closed comptime channel shapes: a comptime
+    # parameter is referenced without `$`, and comptime paths are rooted. the
+    # gate must be rejected with the single teaching diagnostic owned by eval,
+    # not folded nor reported with a path-root message.
+    val fr: Result[src.FileId, str] = open(?es, "bareident.mach",
+        "fun g() i64 {\n    $if ($mode) { ret 1; }\n    ret 0;\n}\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val rr: Result[*res.ResolveResult, str] = resolve(?es, fid);
+    if (is_err[*res.ResolveResult, str](rr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(?es.s.diags, "comptime parameters are referenced without")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -15,6 +15,18 @@
 # `.id` suffix and no `$mach.build.target` chain. `$mach.target.abi`,
 # `$mach.project.*`, `$mach.build.*`, and `$mach.source.*` are reserved stubs:
 # reading one is a compile error until the value is populated.
+#
+# The comptime channel is a CLOSED set of shapes (#1249): a rooted path
+# (`$mach.<path>`, `$project.<field>`, `$target.<field>`, `$bin.<field>`), a
+# `$sym.attr = ...` attribute, a `$sym(args)` intrinsic call, and the `$if`/`$or`
+# gates. A comptime parameter is referenced WITHOUT `$` inside a body. A
+# standalone bare `$ident` is none of these and is REJECTED here with one
+# teaching diagnostic (COMPTIME_BARE_IDENT_MSG); sema and lowering defer to this
+# rejection rather than each carrying their own. The `$project.*`/`$target.*`/
+# `$bin.*` roots are fed from the manifest model and the selected build unit
+# (set by the driver via `set_build_context`); `$target.*` carries the declared
+# tuple's string names, distinct from `$mach.target.*`'s numeric tags, and
+# supersedes the `$mach.os/arch` naming while leaving `$mach.*` working.
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -65,6 +77,14 @@ pub val CT_KIND_INT:   CTKind = 0;
 pub val CT_KIND_FLOAT: CTKind = 1;
 pub val CT_KIND_BOOL:  CTKind = 2;
 pub val CT_KIND_STR:   CTKind = 3;
+
+# COMPTIME_BARE_IDENT_MSG: the single teaching diagnostic for a standalone bare
+# `$ident` (#1249). the comptime channel's shapes are a closed set; a lone
+# `$ident` is none of them — a comptime parameter is referenced without `$`, and
+# every comptime path is rooted. eval owns this rejection; sema and lowering
+# surface it rather than each inventing their own message.
+pub val COMPTIME_BARE_IDENT_MSG: str =
+    "comptime parameters are referenced without `$`; comptime paths are rooted: `$mach`, `$project`, `$target`, `$bin`";
 
 # CTValue: a tagged comptime-evaluated value.
 # ---
@@ -129,6 +149,19 @@ pub def FrameMark: u32;
 #                 define never shadows (nor is shadowed by) a bare comptime const
 # define_len:     number of defines stored
 # define_cap:     allocated slots in defines
+# project_id:     interned `[project].id`, read by `$project.id`; STR_NIL when no
+#                 project context is bound (e.g. the editor's single-buffer ctx)
+# project_ver:    interned `[project].version`, read by `$project.version`
+# project_name:   interned `[project].name`, read by `$project.name`; STR_NIL when
+#                 the manifest omits it
+# project_desc:   interned `[project].description`, read by `$project.description`;
+#                 STR_NIL when the manifest omits it
+# target_os:      interned selected-target os name, read by `$target.os` (the
+#                 declared tuple's string, distinct from `$mach.target.os`'s tag)
+# target_isa:     interned selected-target isa name, read by `$target.isa`
+# target_abi:     interned selected-target abi name, read by `$target.abi`
+# bin_name:       interned name of the artifact being built, read by `$bin.name`;
+#                 STR_NIL when no single artifact is selected (v1 manifests)
 pub rec ComptimeCtx {
     alloc:          *Allocator;
     target_os_id:   u32;
@@ -142,6 +175,14 @@ pub rec ComptimeCtx {
     defines:        *NamedConst;
     define_len:     u32;
     define_cap:     u32;
+    project_id:     intern.StrId;
+    project_ver:    intern.StrId;
+    project_name:   intern.StrId;
+    project_desc:   intern.StrId;
+    target_os:      intern.StrId;
+    target_isa:     intern.StrId;
+    target_abi:     intern.StrId;
+    bin_name:       intern.StrId;
 }
 
 val INITIAL_CONST_CAP: u32 = 8;
@@ -187,7 +228,54 @@ pub fun init(
     c.defines        = nil;
     c.define_len     = 0;
     c.define_cap     = 0;
+    c.project_id     = intern.STR_NIL;
+    c.project_ver    = intern.STR_NIL;
+    c.project_name   = intern.STR_NIL;
+    c.project_desc   = intern.STR_NIL;
+    c.target_os      = intern.STR_NIL;
+    c.target_isa     = intern.STR_NIL;
+    c.target_abi     = intern.STR_NIL;
+    c.bin_name       = intern.STR_NIL;
     ret c;
+}
+
+# set_build_context: bind the manifest-derived project metadata, the selected
+# target's declared tuple names, and the artifact name into the context, feeding
+# the `$project.*`, `$target.*`, and `$bin.*` roots. the driver calls this once
+# per module after `init`; a context that never receives it (the editor's
+# single-buffer analysis) leaves every field STR_NIL, so those roots report
+# "not available" rather than folding to a placeholder. each argument may be
+# STR_NIL when the manifest omits the value (e.g. `[project].name`, or `$bin.name`
+# for a v1 manifest with no artifact stanza).
+# ---
+# c:            context to populate
+# project_id:   interned `[project].id`
+# project_ver:  interned `[project].version`
+# project_name: interned `[project].name`, or STR_NIL
+# project_desc: interned `[project].description`, or STR_NIL
+# target_os:    interned selected-target os name
+# target_isa:   interned selected-target isa name
+# target_abi:   interned selected-target abi name, or STR_NIL
+# bin_name:     interned artifact name, or STR_NIL
+pub fun set_build_context(
+    c:            *ComptimeCtx,
+    project_id:   intern.StrId,
+    project_ver:  intern.StrId,
+    project_name: intern.StrId,
+    project_desc: intern.StrId,
+    target_os:    intern.StrId,
+    target_isa:   intern.StrId,
+    target_abi:   intern.StrId,
+    bin_name:     intern.StrId
+) {
+    c.project_id   = project_id;
+    c.project_ver  = project_ver;
+    c.project_name = project_name;
+    c.project_desc = project_desc;
+    c.target_os    = target_os;
+    c.target_isa   = target_isa;
+    c.target_abi   = target_abi;
+    c.bin_name     = bin_name;
 }
 
 # dnit: releases the entries buffer.
@@ -376,7 +464,15 @@ pub fun eval(
 
     if (k == expr.EXPR_KIND_IDENT) { ret eval_ident(c, source, node.span, interner); }
 
-    if (k == expr.EXPR_KIND_COMPTIME_IDENT || k == expr.EXPR_KIND_MEMBER) {
+    # a standalone bare `$ident` is not one of the closed comptime channel shapes
+    # (#1249): comptime parameters are referenced without `$`, and comptime paths
+    # are rooted. reject it here with the one teaching diagnostic sema and lowering
+    # defer to. a rooted path (`$mach.*`, `$project.*`, ...) arrives instead as a
+    # MEMBER chain whose leftmost object is the `$` root, handled by eval_path.
+    if (k == expr.EXPR_KIND_COMPTIME_IDENT) {
+        ret err[CTValue, str](COMPTIME_BARE_IDENT_MSG);
+    }
+    if (k == expr.EXPR_KIND_MEMBER) {
         ret eval_path(c, a, source, e, interner);
     }
 
@@ -1027,9 +1123,11 @@ pub fun is_comptime_path(a: *ast.Ast, e: id.ExprId) bool {
     ret false;
 }
 
-# resolves a `$mach.<...>` path expression. the path may bottom out at a
-# COMPTIME_IDENT (single-segment, e.g. `$foo`) or be a chain of MEMBER
-# expressions whose leftmost root is a COMPTIME_IDENT.
+# resolves a rooted comptime path expression (`$mach.*`, `$project.*`,
+# `$target.*`, `$bin.*`): a chain of MEMBER expressions whose leftmost object is
+# a `$` COMPTIME_IDENT root. a standalone bare `$ident` never reaches here — eval
+# rejects it before the dispatch — so the walk always bottoms at a root with at
+# least one member.
 fun eval_path(
     c:        *ComptimeCtx,
     a:        *ast.Ast,
@@ -1060,7 +1158,67 @@ fun eval_path(
         ret err[CTValue, str]("comptime path must start with a `$` identifier");
     }
 
-    ret resolve_mach_path(c, source, ?stack[0], depth, interner);
+    ret resolve_comptime_path(c, source, ?stack[0], depth, interner);
+}
+
+# dispatches a rooted comptime path on its leftmost segment (the `$` root). the
+# segment stack is leaf-first: stack[0] is the rightmost segment and
+# stack[depth - 1] is the root. each root owns its own namespace; an unrecognized
+# root is rejected with the single teaching diagnostic, the same verdict a
+# standalone bare `$ident` receives.
+fun resolve_comptime_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32, interner: *intern.Interner) Result[CTValue, str] {
+    if (depth == 0) { ret err[CTValue, str]("empty comptime path"); }
+    val root: StrView = span_text(source, stack[depth - 1]);
+    if (view_eq_str(root, "mach"))    { ret resolve_mach_path(c, source, stack, depth, interner); }
+    if (view_eq_str(root, "project")) { ret resolve_project_path(c, source, stack, depth); }
+    if (view_eq_str(root, "target"))  { ret resolve_target_path(c, source, stack, depth); }
+    if (view_eq_str(root, "bin"))     { ret resolve_bin_path(c, source, stack, depth); }
+    ret err[CTValue, str](COMPTIME_BARE_IDENT_MSG);
+}
+
+# resolves a `$project.<field>` path against the manifest-derived project
+# metadata bound by `set_build_context`. id and version are always present in a
+# real build; name and description fold only when the manifest declares them. a
+# STR_NIL field (no project context bound, e.g. the editor) reports the value as
+# unavailable rather than folding to an empty string.
+fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32) Result[CTValue, str] {
+    if (depth != 2) { ret err[CTValue, str]("unknown `$project.*` path"); }
+    if (seg_is(source, stack, 0, "id"))          { ret project_field(c.project_id); }
+    if (seg_is(source, stack, 0, "version"))     { ret project_field(c.project_ver); }
+    if (seg_is(source, stack, 0, "name"))        { ret project_field(c.project_name); }
+    if (seg_is(source, stack, 0, "description")) { ret project_field(c.project_desc); }
+    ret err[CTValue, str]("unknown `$project.*` path");
+}
+
+# resolves a `$target.<field>` path to the selected target's declared tuple name
+# string. these are the manifest's declared os/isa/abi spellings (e.g. "linux",
+# "x86_64", "sysv64") — distinct from `$mach.target.os`'s numeric tag, and the
+# preferred spelling going forward — bound by `set_build_context`.
+fun resolve_target_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32) Result[CTValue, str] {
+    if (depth != 2) { ret err[CTValue, str]("unknown `$target.*` path"); }
+    if (seg_is(source, stack, 0, "os"))  { ret project_field(c.target_os); }
+    if (seg_is(source, stack, 0, "isa")) { ret project_field(c.target_isa); }
+    if (seg_is(source, stack, 0, "abi")) { ret project_field(c.target_abi); }
+    ret err[CTValue, str]("unknown `$target.*` path");
+}
+
+# resolves a `$bin.<field>` path to the selected artifact's metadata. `name` is
+# the artifact being built (`[bin.<name>]` / `[lib.<name>]`); it is unavailable
+# for a v1 manifest, which has no artifact stanza.
+fun resolve_bin_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32) Result[CTValue, str] {
+    if (depth != 2) { ret err[CTValue, str]("unknown `$bin.*` path"); }
+    if (seg_is(source, stack, 0, "name")) { ret project_field(c.bin_name); }
+    ret err[CTValue, str]("unknown `$bin.*` path");
+}
+
+# folds a manifest-derived string field to a CTValue, or reports it unavailable
+# when no value was bound (STR_NIL) — the path's own span locates the read in the
+# reported diagnostic.
+fun project_field(value: intern.StrId) Result[CTValue, str] {
+    if (value == intern.STR_NIL) {
+        ret err[CTValue, str]("comptime path value is not available in this context");
+    }
+    ret str_value(value);
 }
 
 # comptime_ident_name: the span of the identifier portion of a `$ident` token,
@@ -1079,9 +1237,10 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 }
 
 # matches the path text built from the segment stack against the recognized
-# `$mach.*` namespace and returns the corresponding compile-time value.
-# `stack` is leaf-first: stack[0] is the rightmost segment and
-# stack[depth - 1] is the root (`mach`).
+# `$mach.*` namespace and returns the corresponding compile-time value. called by
+# resolve_comptime_path only when the root segment is `mach`, so the root is a
+# precondition, not re-checked here. `stack` is leaf-first: stack[0] is the
+# rightmost segment and stack[depth - 1] is the root (`mach`).
 #
 # the locked namespace:
 #   $mach.target.{os,arch,abi,pointer_width} — active target parameters; the
@@ -1099,11 +1258,6 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 # silently folding to a placeholder.
 fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32, interner: *intern.Interner) Result[CTValue, str] {
     if (depth == 0) { ret err[CTValue, str]("empty comptime path"); }
-
-    val root: StrView = span_text(source, stack[depth - 1]);
-    if (!view_eq_str(root, "mach")) {
-        ret err[CTValue, str]("comptime path root must be `$mach`");
-    }
 
     # $mach.target.os — active target os, numeric tag (compare vs $mach.os.*)
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "os")) {
@@ -1444,5 +1598,101 @@ test "comptime: negation is value-correct across the i64/u64 boundary (#1272)" {
     # negating a u64 magnitude above 2^63 has no representable result.
     val big: CTValue = unwrap_ok[CTValue, str](t_eval_int("0xFFFFFFFFFFFFFFFF"));
     if (!is_err[CTValue, str](ct_negate(big))) { ret 1; }
+    ret 0;
+}
+
+# helper: split a dotted path source (e.g. "project.version") into a leaf-first
+# span stack (stack[0] is the rightmost segment), returning the segment count.
+# mirrors the leaf-first ordering eval_path builds so the resolvers can be unit-
+# tested without constructing an AST.
+fun t_dotted(source: str, out_stack: *token.Span) u32 {
+    val n: usize = str_len(source);
+    var tmp: [8]token.Span;
+    var count: u32 = 0;
+    var start: usize = 0;
+    var i: usize = 0;
+    for (i <= n) {
+        if (i == n || source[i] == '.') {
+            var sp: token.Span;
+            sp.offset = start;
+            sp.len    = i - start;
+            tmp[count] = sp;
+            count = count + 1;
+            start = i + 1;
+        }
+        i = i + 1;
+    }
+    var k: u32 = 0;
+    for (k < count) {
+        out_stack[k] = tmp[count - 1 - k];
+        k = k + 1;
+    }
+    ret count;
+}
+
+# helper: a ComptimeCtx with the build-context fields populated with sentinel
+# StrIds, the rest zeroed. the resolvers under test read only the build-context
+# fields, so the target/env machinery stays unset.
+fun t_build_ctx() ComptimeCtx {
+    var c: ComptimeCtx;
+    c.project_id   = 10;
+    c.project_ver  = 11;
+    c.project_name = 12;
+    c.project_desc = intern.STR_NIL;
+    c.target_os    = 20;
+    c.target_isa   = 21;
+    c.target_abi   = 22;
+    c.bin_name     = 30;
+    ret c;
+}
+
+# helper: the StrId a folded CT_KIND_STR resolver result carries, or STR_NIL when
+# the result is an error or not a string.
+fun t_str_id(r: Result[CTValue, str]) intern.StrId {
+    if (is_err[CTValue, str](r)) { ret intern.STR_NIL; }
+    val v: CTValue = unwrap_ok[CTValue, str](r);
+    if (v.kind != CT_KIND_STR) { ret intern.STR_NIL; }
+    ret v.data.s;
+}
+
+test "comptime: $project.* folds bound metadata; an unset/unknown field is unavailable (#1217)" {
+    var c: ComptimeCtx = t_build_ctx();
+    var stack: [8]token.Span;
+
+    val sid: str = "project.id";
+    if (t_str_id(resolve_project_path(?c, sid, ?stack[0], t_dotted(sid, ?stack[0]))) != 10) { ret 1; }
+    val sver: str = "project.version";
+    if (t_str_id(resolve_project_path(?c, sver, ?stack[0], t_dotted(sver, ?stack[0]))) != 11) { ret 1; }
+    val sname: str = "project.name";
+    if (t_str_id(resolve_project_path(?c, sname, ?stack[0], t_dotted(sname, ?stack[0]))) != 12) { ret 1; }
+    # description is STR_NIL: the read is unavailable, never a placeholder.
+    val sdesc: str = "project.description";
+    if (!is_err[CTValue, str](resolve_project_path(?c, sdesc, ?stack[0], t_dotted(sdesc, ?stack[0])))) { ret 1; }
+    # an unknown field under a known root is rejected.
+    val sbogus: str = "project.bogus";
+    if (!is_err[CTValue, str](resolve_project_path(?c, sbogus, ?stack[0], t_dotted(sbogus, ?stack[0])))) { ret 1; }
+    ret 0;
+}
+
+test "comptime: $target.* folds the selected target's declared tuple strings (#1217)" {
+    var c: ComptimeCtx = t_build_ctx();
+    var stack: [8]token.Span;
+    val sos: str = "target.os";
+    if (t_str_id(resolve_target_path(?c, sos, ?stack[0], t_dotted(sos, ?stack[0]))) != 20) { ret 1; }
+    val sisa: str = "target.isa";
+    if (t_str_id(resolve_target_path(?c, sisa, ?stack[0], t_dotted(sisa, ?stack[0]))) != 21) { ret 1; }
+    val sabi: str = "target.abi";
+    if (t_str_id(resolve_target_path(?c, sabi, ?stack[0], t_dotted(sabi, ?stack[0]))) != 22) { ret 1; }
+    ret 0;
+}
+
+test "comptime: $bin.name folds the artifact name, unavailable when unset (#1217)" {
+    var c: ComptimeCtx = t_build_ctx();
+    var stack: [8]token.Span;
+    val sn: str = "bin.name";
+    if (t_str_id(resolve_bin_path(?c, sn, ?stack[0], t_dotted(sn, ?stack[0]))) != 30) { ret 1; }
+    # with no artifact bound (v1 manifest) the read is unavailable.
+    c.bin_name = intern.STR_NIL;
+    if (!is_err[CTValue, str](resolve_bin_path(?c, sn, ?stack[0], t_dotted(sn, ?stack[0])))) { ret 1; }
     ret 0;
 }

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -572,17 +572,15 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
         ret;
     }
 
-    # a bare `$ident` is only comptime-foldable when the evaluator accepts it
-    # (today: a `$mach.*` path; a single-segment `$mach` or a `$param` reference
-    # is not). fold-test it so an unfoldable one is reported here with a span
-    # rather than aborting lowering with a span-less `comptime path root must be
-    # $mach` error. a standalone bare `$ident` is not one of the four comptime
-    # channel shapes; its semantics remain the open `$ident` design question
-    # tracked in #1249.
+    # a bare COMPTIME_IDENT in a gate is a standalone `$ident`: not one of the
+    # closed comptime channel shapes (#1249). defer to the evaluator's single
+    # rejection rule, surfacing its teaching diagnostic against this span rather
+    # than inventing a sema-local message. a rooted path arrives as a MEMBER chain
+    # (handled below), never as a bare COMPTIME_IDENT here.
     if (k == expr.EXPR_KIND_COMPTIME_IDENT) {
         val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
         if (is_err[comptime.CTValue, str](ev)) {
-            ctxm.report(sc, e.span, "comptime `$if` gate is not a compile-time constant");
+            ctxm.report(sc, e.span, unwrap_err[comptime.CTValue, str](ev));
         }
         ret;
     }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -37,6 +37,7 @@ use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
 
 use std.allocator.allocate;
 use std.allocator.deallocate;
@@ -230,11 +231,16 @@ pub fun infer_expr(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
         t = infer_ident(sc, eid);
     }
     or (e.kind == expr.EXPR_KIND_COMPTIME_IDENT) {
-        t = infer_comptime_int_path(sc, eid);
-        if (t == type.TYPE_NIL) {
-            sema.report(sc, e.span, "cannot infer type: comptime identifier in value context");
-            t = type.TYPE_ERROR;
+        # a bare `$ident` in value position is not one of the closed comptime
+        # channel shapes (#1249): comptime parameters are referenced without `$`,
+        # and comptime paths are rooted. eval owns the single rejection rule;
+        # surface its teaching diagnostic against this span rather than inventing
+        # a sema-local message. a rooted path arrives as a MEMBER chain instead.
+        val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
+        if (is_err[comptime.CTValue, str](ev)) {
+            sema.report(sc, e.span, unwrap_err[comptime.CTValue, str](ev));
         }
+        t = type.TYPE_ERROR;
     }
     or (e.kind == expr.EXPR_KIND_BINARY) {
         t = infer_binary(sc, eid, ?e.data.binary, e.span);
@@ -779,11 +785,14 @@ fun infer_member(sc: *sema.SemaContext, eid: id.ExprId, m: *expr.ExprMember, spa
         ret sema.decl_type_for(sc, unwrap[*resolve.Symbol](qsym_opt));
     }
 
-    # a `$mach.*` member chain (rooted at a `$` comptime ident) is a comptime
-    # path, not a field access; its object is not a real record value. fold it
-    # to a comptime-int type when it resolves to an integer.
+    # a rooted comptime member chain (`$mach.*`, `$project.*`, `$target.*`,
+    # `$bin.*`) is a comptime path, not a field access; its object is not a real
+    # record value. fold it to a comptime-int type when it resolves to an
+    # integer, or to the string-literal type when it resolves to a string.
     val cti: type.TypeId = infer_comptime_int_path(sc, eid);
     if (cti != type.TYPE_NIL) { ret cti; }
+    val cts: type.TypeId = infer_comptime_str_path(sc, eid);
+    if (cts != type.TYPE_NIL) { ret cts; }
 
     val ot: type.TypeId = infer_expr(sc, m.object);
     if (ot == type.TYPE_ERROR || ot == type.TYPE_NIL) { ret type.TYPE_ERROR; }
@@ -809,6 +818,22 @@ fun infer_comptime_int_path(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
     val cv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
     if (cv.kind != comptime.CT_KIND_INT) { ret type.TYPE_NIL; }
     ret prim_or_error(sc, type.TYPE_I64);
+}
+
+# types a value-context comptime path that folds to a string (`$mach.compiler.name`,
+# `$project.version`, `$target.os`, `$bin.name`, ...). a folded comptime string is
+# materialised exactly as a string literal — an anonymous rodata blob referenced
+# by pointer — so it takes the string-literal type `*u8` and shares the literal's
+# assignability (a `*u8` flows into a `str`/`*char` slot). returns TYPE_NIL when
+# `eid` is not a comptime path or does not fold to a string, so the caller falls
+# back to its normal handling.
+fun infer_comptime_str_path(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
+    if (!comptime.is_comptime_path(sc.a, eid)) { ret type.TYPE_NIL; }
+    val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
+    if (is_err[comptime.CTValue, str](ev)) { ret type.TYPE_NIL; }
+    val cv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
+    if (cv.kind != comptime.CT_KIND_STR) { ret type.TYPE_NIL; }
+    ret ptr_to(sc, prim_or_error(sc, type.TYPE_U8));
 }
 
 # materializes the field layout of `tid` (and, if `tid` is a pointer, its

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -87,7 +87,7 @@ pub fun lower_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.Val
     if (k == aexpr.EXPR_KIND_BINARY)         { ret lower_binary(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_UNARY)          { ret lower_unary(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_CAST)           { ret lower_cast(ctx, eid, e); }
-    if (k == aexpr.EXPR_KIND_COMPTIME_IDENT) { ret lower_comptime_ident(ctx, eid, e); }
+    if (k == aexpr.EXPR_KIND_COMPTIME_IDENT) { ret lower_comptime_path(ctx, eid); }
     if (k == aexpr.EXPR_KIND_ARRAY_LIT)      { ret lower_array_lit(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_STRUCT_LIT)     { ret lower_struct_lit(ctx, eid, e); }
 
@@ -1753,25 +1753,13 @@ fun lower_cast(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result
     ret builder.emit_bitcast(?ctx.builder, v, dst);
 }
 
-# a comptime identifier folds to the constant the comptime evaluator
-# produced, looked up by the identifier's interned name in the module's
-# comptime context. the `$ident` span carries the leading `$`; constants are
-# registered under the bare name, so strip it before interning the lookup key.
-fun lower_comptime_ident(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
-    val name_span: token.Span = comptime.comptime_ident_name(e.span);
-    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), name_span);
-    if (is_err[intern.StrId, str](name_r)) { ret err[value.Value, str](unwrap_err[intern.StrId, str](name_r)); }
-    val nc: Option[*comptime.NamedConst] = comptime.lookup(ctx.ctx, unwrap_ok[intern.StrId, str](name_r));
-    if (is_none[*comptime.NamedConst](nc)) {
-        ret err[value.Value, str]("lower: comptime identifier not folded");
-    }
-    ret const_value_of(ctx, eid, unwrap[*comptime.NamedConst](nc).value);
-}
-
-# folds a value-context comptime path (`$mach.target.os`, `$mach.os.linux`, ...)
-# to its constant value via the comptime evaluator and materializes it at the
-# expression's IR type. used for `$mach.*` member chains in rvalue position,
-# whose semantic type was set to the usage-site type during coercion.
+# folds a value-context comptime path (`$mach.target.os`, `$mach.os.linux`,
+# `$project.version`, ...) to its constant value via the comptime evaluator and
+# materializes it at the expression's IR type. used for rooted comptime member
+# chains in rvalue position, whose semantic type was set to the usage-site type
+# during coercion. a standalone bare `$ident` also routes here: eval rejects it
+# with the single teaching diagnostic (#1249), so lowering carries no separate
+# resolution rule of its own.
 fun lower_comptime_path(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.Value, str] {
     val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner);
     if (is_err[comptime.CTValue, str](ev)) { ret err[value.Value, str](unwrap_err[comptime.CTValue, str](ev)); }


### PR DESCRIPTION
Implements the bare-`$ident` ruling (#1249) and the `$project.*`/`$target.*`/`$bin.*` comptime roots (#1217, per the #1218 manifest schema), end to end.

## Bare-`$ident` ruling (#1249)
- A standalone bare `$ident` is **rejected** with one teaching diagnostic, owned by `comptime.eval`. The gate (`check_comptime_gate`), value-context type inference, and lowering all **defer to that single rule** instead of each carrying a divergent message.
- The comptime channel stays a closed shape set: rooted compiler reads (`$mach`/`$project`/`$target`/`$bin`), `$sym.attr`, `$sym(args)`, `$if`/`$or`.

## New roots (#1217)
- `$project.{id,version,name,description}`, `$target.{os,isa,abi}` (the declared tuple **strings**, distinct from `$mach.target.*`'s numeric tags — `$mach.os.*` comparisons keep working), `$bin.name`.
- Fed from the resolved manifest + selected build unit via `comptime.set_build_context`, wired in the driver for **both v2 and v1** manifests. Absent optional fields report the read as unavailable rather than folding to an empty string.

## Missing end-to-end piece, now fixed (sema)
The inherited resolvers produced comptime **strings**, but sema could only type a comptime path that folded to an **integer** — a string path in value position failed with `cannot infer type: comptime identifier in value context`, so `$project.version` (and the long-documented `$mach.compiler.*`) were unreachable as values. `infer.mach` now types a string-folding comptime member chain as the string-literal type (`*u8`), sharing the literal's `.rodata`/assignability path. This is what makes the roots actually usable.

## Driver payoff (version single-source-of-truth)
Flipping the hardcoded compiler version to `$project.version` is **bootstrap-staged, not committed**: CI's Full Build runs `mach build .` with the **released** seed, which cannot fold `$project.version` until a release ships these roots — committing the flip now would make the seed fail to compile `driver.mach`. The flip is **proven** by a local bootstrap chain: building the compiler from a manifest pinned to `version = "9.9.9"` (with the flip applied and seeded by a root-aware stage1) yields a compiler whose `$mach.compiler.version` reports `"9.9.9"` — the version tracks the manifest, no hardcode. The driver comment documents the constraint and the remaining step. **Recommend a follow-up issue (or keeping #1217 open) for the actual flip once the next release seed understands the roots.**

## Tests
`.github/tests/comptimeroots/` (wired like the sibling suites, run by the CI integration job):
- `v1app` / `v2app` — every root folds to its own manifest's declared values (exit 0 only when all match).
- `bareident_gate` / `bareident_value` — the build must FAIL with the exact teaching diagnostic, proving both sema surfaces defer to the one rule.

## Verification
- `mach build .` clean; **strong fixpoint** (stage1 == stage2 == stage3, identical sha256).
- `mach test .` — 342 PASS, 0 fail.
- Full integration battery (all `.github/tests/*/run.sh`, incl. windows cross-compile + wine win64 suites) — all green.

Closes #1217
Refs #1249 #1218