### PR TITLE
refactor(frontend): consolidate hand-rolled growable arrays onto a shared pool.grow primitive

### DIFF
--- a/src/lang/fe/ast.mach
+++ b/src/lang/fe/ast.mach
@@ -21,9 +21,7 @@ use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 
 use std.allocator.Allocator;
-use std.allocator.allocate;
 use std.allocator.deallocate;
-use std.allocator.reallocate;
 
 use page: std.allocator.page;
 
@@ -36,6 +34,7 @@ use expr:   mach.lang.fe.ast.expr;
 use stmt:   mach.lang.fe.ast.stmt;
 use decl:   mach.lang.fe.ast.decl;
 use m_type: mach.lang.fe.ast.type;
+use pool:   mach.lang.fe.pool;
 
 val INITIAL_NODE_CAP:   usize = 32;
 val INITIAL_AUX_CAP:    usize = 16;
@@ -316,22 +315,12 @@ pub fun dnit(a: *Ast) {
 # m:   module to append
 # ret: ModuleId of the newly added node
 pub fun add_module(a: *Ast, m: module.Module) Result[id.ModuleId, str] {
-    if (a.modules == nil) {
-        val r: Result[*module.Module, str] = allocate[module.Module](a.alloc, INITIAL_NODE_CAP);
+    if (a.module_len == a.module_cap) {
+        val r: Result[*module.Module, str] = pool.grow[module.Module](a.alloc, a.modules, a.module_cap, INITIAL_NODE_CAP, ?a.module_cap);
         if (is_err[*module.Module, str](r)) {
             ret err[id.ModuleId, str](unwrap_err[*module.Module, str](r));
         }
-        a.modules    = unwrap_ok[*module.Module, str](r);
-        a.module_cap = INITIAL_NODE_CAP;
-    }
-    or (a.module_len == a.module_cap) {
-        val new_cap: usize = a.module_cap * 2;
-        val r: Result[*module.Module, str] = reallocate[module.Module](a.alloc, a.modules, a.module_cap, new_cap);
-        if (is_err[*module.Module, str](r)) {
-            ret err[id.ModuleId, str](unwrap_err[*module.Module, str](r));
-        }
-        a.modules    = unwrap_ok[*module.Module, str](r);
-        a.module_cap = new_cap;
+        a.modules = unwrap_ok[*module.Module, str](r);
     }
     val new_id: id.ModuleId = a.module_len::u32;
     a.modules[a.module_len] = m;
@@ -355,22 +344,12 @@ pub fun get_module(a: *Ast, id_: id.ModuleId) Option[*module.Module] {
 # e:   expression to append
 # ret: ExprId of the newly added node
 pub fun add_expr(a: *Ast, e: expr.Expr) Result[id.ExprId, str] {
-    if (a.exprs == nil) {
-        val r: Result[*expr.Expr, str] = allocate[expr.Expr](a.alloc, INITIAL_NODE_CAP);
+    if (a.expr_len == a.expr_cap) {
+        val r: Result[*expr.Expr, str] = pool.grow[expr.Expr](a.alloc, a.exprs, a.expr_cap, INITIAL_NODE_CAP, ?a.expr_cap);
         if (is_err[*expr.Expr, str](r)) {
             ret err[id.ExprId, str](unwrap_err[*expr.Expr, str](r));
         }
-        a.exprs    = unwrap_ok[*expr.Expr, str](r);
-        a.expr_cap = INITIAL_NODE_CAP;
-    }
-    or (a.expr_len == a.expr_cap) {
-        val new_cap: usize = a.expr_cap * 2;
-        val r: Result[*expr.Expr, str] = reallocate[expr.Expr](a.alloc, a.exprs, a.expr_cap, new_cap);
-        if (is_err[*expr.Expr, str](r)) {
-            ret err[id.ExprId, str](unwrap_err[*expr.Expr, str](r));
-        }
-        a.exprs    = unwrap_ok[*expr.Expr, str](r);
-        a.expr_cap = new_cap;
+        a.exprs = unwrap_ok[*expr.Expr, str](r);
     }
     val new_id: id.ExprId = a.expr_len::u32;
     a.exprs[a.expr_len] = e;
@@ -394,22 +373,12 @@ pub fun get_expr(a: *Ast, id_: id.ExprId) Option[*expr.Expr] {
 # s:   statement to append
 # ret: StmtId of the newly added node
 pub fun add_stmt(a: *Ast, s: stmt.Stmt) Result[id.StmtId, str] {
-    if (a.stmts == nil) {
-        val r: Result[*stmt.Stmt, str] = allocate[stmt.Stmt](a.alloc, INITIAL_NODE_CAP);
+    if (a.stmt_len == a.stmt_cap) {
+        val r: Result[*stmt.Stmt, str] = pool.grow[stmt.Stmt](a.alloc, a.stmts, a.stmt_cap, INITIAL_NODE_CAP, ?a.stmt_cap);
         if (is_err[*stmt.Stmt, str](r)) {
             ret err[id.StmtId, str](unwrap_err[*stmt.Stmt, str](r));
         }
-        a.stmts    = unwrap_ok[*stmt.Stmt, str](r);
-        a.stmt_cap = INITIAL_NODE_CAP;
-    }
-    or (a.stmt_len == a.stmt_cap) {
-        val new_cap: usize = a.stmt_cap * 2;
-        val r: Result[*stmt.Stmt, str] = reallocate[stmt.Stmt](a.alloc, a.stmts, a.stmt_cap, new_cap);
-        if (is_err[*stmt.Stmt, str](r)) {
-            ret err[id.StmtId, str](unwrap_err[*stmt.Stmt, str](r));
-        }
-        a.stmts    = unwrap_ok[*stmt.Stmt, str](r);
-        a.stmt_cap = new_cap;
+        a.stmts = unwrap_ok[*stmt.Stmt, str](r);
     }
     val new_id: id.StmtId = a.stmt_len::u32;
     a.stmts[a.stmt_len] = s;
@@ -433,22 +402,12 @@ pub fun get_stmt(a: *Ast, id_: id.StmtId) Option[*stmt.Stmt] {
 # d:   declaration to append
 # ret: DeclId of the newly added node
 pub fun add_decl(a: *Ast, d: decl.Decl) Result[id.DeclId, str] {
-    if (a.decls == nil) {
-        val r: Result[*decl.Decl, str] = allocate[decl.Decl](a.alloc, INITIAL_NODE_CAP);
+    if (a.decl_len == a.decl_cap) {
+        val r: Result[*decl.Decl, str] = pool.grow[decl.Decl](a.alloc, a.decls, a.decl_cap, INITIAL_NODE_CAP, ?a.decl_cap);
         if (is_err[*decl.Decl, str](r)) {
             ret err[id.DeclId, str](unwrap_err[*decl.Decl, str](r));
         }
-        a.decls    = unwrap_ok[*decl.Decl, str](r);
-        a.decl_cap = INITIAL_NODE_CAP;
-    }
-    or (a.decl_len == a.decl_cap) {
-        val new_cap: usize = a.decl_cap * 2;
-        val r: Result[*decl.Decl, str] = reallocate[decl.Decl](a.alloc, a.decls, a.decl_cap, new_cap);
-        if (is_err[*decl.Decl, str](r)) {
-            ret err[id.DeclId, str](unwrap_err[*decl.Decl, str](r));
-        }
-        a.decls    = unwrap_ok[*decl.Decl, str](r);
-        a.decl_cap = new_cap;
+        a.decls = unwrap_ok[*decl.Decl, str](r);
     }
     val new_id: id.DeclId = a.decl_len::u32;
     a.decls[a.decl_len] = d;
@@ -472,22 +431,12 @@ pub fun get_decl(a: *Ast, id_: id.DeclId) Option[*decl.Decl] {
 # t:   type to append
 # ret: TypeId of the newly added node
 pub fun add_type(a: *Ast, t: m_type.Type) Result[id.TypeId, str] {
-    if (a.types == nil) {
-        val r: Result[*m_type.Type, str] = allocate[m_type.Type](a.alloc, INITIAL_NODE_CAP);
+    if (a.type_len == a.type_cap) {
+        val r: Result[*m_type.Type, str] = pool.grow[m_type.Type](a.alloc, a.types, a.type_cap, INITIAL_NODE_CAP, ?a.type_cap);
         if (is_err[*m_type.Type, str](r)) {
             ret err[id.TypeId, str](unwrap_err[*m_type.Type, str](r));
         }
-        a.types    = unwrap_ok[*m_type.Type, str](r);
-        a.type_cap = INITIAL_NODE_CAP;
-    }
-    or (a.type_len == a.type_cap) {
-        val new_cap: usize = a.type_cap * 2;
-        val r: Result[*m_type.Type, str] = reallocate[m_type.Type](a.alloc, a.types, a.type_cap, new_cap);
-        if (is_err[*m_type.Type, str](r)) {
-            ret err[id.TypeId, str](unwrap_err[*m_type.Type, str](r));
-        }
-        a.types    = unwrap_ok[*m_type.Type, str](r);
-        a.type_cap = new_cap;
+        a.types = unwrap_ok[*m_type.Type, str](r);
     }
     val new_id: id.TypeId = a.type_len::u32;
     a.types[a.type_len] = t;
@@ -511,22 +460,12 @@ pub fun get_type(a: *Ast, id_: id.TypeId) Option[*m_type.Type] {
 # tn:  entry to append (parameter or field)
 # ret: index into a.typed_names for the new entry
 pub fun add_typed_name(a: *Ast, tn: decl.TypedName) Result[u32, str] {
-    if (a.typed_names == nil) {
-        val r: Result[*decl.TypedName, str] = allocate[decl.TypedName](a.alloc, INITIAL_AUX_CAP);
+    if (a.typed_name_len == a.typed_name_cap) {
+        val r: Result[*decl.TypedName, str] = pool.grow[decl.TypedName](a.alloc, a.typed_names, a.typed_name_cap, INITIAL_AUX_CAP, ?a.typed_name_cap);
         if (is_err[*decl.TypedName, str](r)) {
             ret err[u32, str](unwrap_err[*decl.TypedName, str](r));
         }
-        a.typed_names    = unwrap_ok[*decl.TypedName, str](r);
-        a.typed_name_cap = INITIAL_AUX_CAP;
-    }
-    or (a.typed_name_len == a.typed_name_cap) {
-        val new_cap: usize = a.typed_name_cap * 2;
-        val r: Result[*decl.TypedName, str] = reallocate[decl.TypedName](a.alloc, a.typed_names, a.typed_name_cap, new_cap);
-        if (is_err[*decl.TypedName, str](r)) {
-            ret err[u32, str](unwrap_err[*decl.TypedName, str](r));
-        }
-        a.typed_names    = unwrap_ok[*decl.TypedName, str](r);
-        a.typed_name_cap = new_cap;
+        a.typed_names = unwrap_ok[*decl.TypedName, str](r);
     }
     val index: u32 = a.typed_name_len::u32;
     a.typed_names[a.typed_name_len] = tn;
@@ -540,22 +479,12 @@ pub fun add_typed_name(a: *Ast, tn: decl.TypedName) Result[u32, str] {
 # fi:  field initializer to append
 # ret: index into a.field_inits for the new entry
 pub fun add_field_init(a: *Ast, fi: expr.FieldInit) Result[u32, str] {
-    if (a.field_inits == nil) {
-        val r: Result[*expr.FieldInit, str] = allocate[expr.FieldInit](a.alloc, INITIAL_AUX_CAP);
+    if (a.field_init_len == a.field_init_cap) {
+        val r: Result[*expr.FieldInit, str] = pool.grow[expr.FieldInit](a.alloc, a.field_inits, a.field_init_cap, INITIAL_AUX_CAP, ?a.field_init_cap);
         if (is_err[*expr.FieldInit, str](r)) {
             ret err[u32, str](unwrap_err[*expr.FieldInit, str](r));
         }
-        a.field_inits    = unwrap_ok[*expr.FieldInit, str](r);
-        a.field_init_cap = INITIAL_AUX_CAP;
-    }
-    or (a.field_init_len == a.field_init_cap) {
-        val new_cap: usize = a.field_init_cap * 2;
-        val r: Result[*expr.FieldInit, str] = reallocate[expr.FieldInit](a.alloc, a.field_inits, a.field_init_cap, new_cap);
-        if (is_err[*expr.FieldInit, str](r)) {
-            ret err[u32, str](unwrap_err[*expr.FieldInit, str](r));
-        }
-        a.field_inits    = unwrap_ok[*expr.FieldInit, str](r);
-        a.field_init_cap = new_cap;
+        a.field_inits = unwrap_ok[*expr.FieldInit, str](r);
     }
     val index: u32 = a.field_init_len::u32;
     a.field_inits[a.field_init_len] = fi;
@@ -569,22 +498,12 @@ pub fun add_field_init(a: *Ast, fi: expr.FieldInit) Result[u32, str] {
 # name: span of the generic parameter identifier
 # ret:  index into a.generic_names for the new entry
 pub fun add_generic_name(a: *Ast, name: token.Span) Result[u32, str] {
-    if (a.generic_names == nil) {
-        val r: Result[*token.Span, str] = allocate[token.Span](a.alloc, INITIAL_AUX_CAP);
+    if (a.generic_name_len == a.generic_name_cap) {
+        val r: Result[*token.Span, str] = pool.grow[token.Span](a.alloc, a.generic_names, a.generic_name_cap, INITIAL_AUX_CAP, ?a.generic_name_cap);
         if (is_err[*token.Span, str](r)) {
             ret err[u32, str](unwrap_err[*token.Span, str](r));
         }
-        a.generic_names    = unwrap_ok[*token.Span, str](r);
-        a.generic_name_cap = INITIAL_AUX_CAP;
-    }
-    or (a.generic_name_len == a.generic_name_cap) {
-        val new_cap: usize = a.generic_name_cap * 2;
-        val r: Result[*token.Span, str] = reallocate[token.Span](a.alloc, a.generic_names, a.generic_name_cap, new_cap);
-        if (is_err[*token.Span, str](r)) {
-            ret err[u32, str](unwrap_err[*token.Span, str](r));
-        }
-        a.generic_names    = unwrap_ok[*token.Span, str](r);
-        a.generic_name_cap = new_cap;
+        a.generic_names = unwrap_ok[*token.Span, str](r);
     }
     val index: u32 = a.generic_name_len::u32;
     a.generic_names[a.generic_name_len] = name;
@@ -598,22 +517,12 @@ pub fun add_generic_name(a: *Ast, name: token.Span) Result[u32, str] {
 # br:  branch record to append
 # ret: index into a.comptime_branches for the new entry
 pub fun add_comptime_branch(a: *Ast, br: decl.ComptimeBranch) Result[u32, str] {
-    if (a.comptime_branches == nil) {
-        val r: Result[*decl.ComptimeBranch, str] = allocate[decl.ComptimeBranch](a.alloc, INITIAL_AUX_CAP);
+    if (a.comptime_branch_len == a.comptime_branch_cap) {
+        val r: Result[*decl.ComptimeBranch, str] = pool.grow[decl.ComptimeBranch](a.alloc, a.comptime_branches, a.comptime_branch_cap, INITIAL_AUX_CAP, ?a.comptime_branch_cap);
         if (is_err[*decl.ComptimeBranch, str](r)) {
             ret err[u32, str](unwrap_err[*decl.ComptimeBranch, str](r));
         }
-        a.comptime_branches   = unwrap_ok[*decl.ComptimeBranch, str](r);
-        a.comptime_branch_cap = INITIAL_AUX_CAP;
-    }
-    or (a.comptime_branch_len == a.comptime_branch_cap) {
-        val new_cap: usize = a.comptime_branch_cap * 2;
-        val r: Result[*decl.ComptimeBranch, str] = reallocate[decl.ComptimeBranch](a.alloc, a.comptime_branches, a.comptime_branch_cap, new_cap);
-        if (is_err[*decl.ComptimeBranch, str](r)) {
-            ret err[u32, str](unwrap_err[*decl.ComptimeBranch, str](r));
-        }
-        a.comptime_branches   = unwrap_ok[*decl.ComptimeBranch, str](r);
-        a.comptime_branch_cap = new_cap;
+        a.comptime_branches = unwrap_ok[*decl.ComptimeBranch, str](r);
     }
     val index: u32 = a.comptime_branch_len::u32;
     a.comptime_branches[a.comptime_branch_len] = br;
@@ -627,22 +536,12 @@ pub fun add_comptime_branch(a: *Ast, br: decl.ComptimeBranch) Result[u32, str] {
 # id_: DeclId to append
 # ret: index into a.decl_ids for the new entry
 pub fun add_decl_id(a: *Ast, id_: id.DeclId) Result[u32, str] {
-    if (a.decl_ids == nil) {
-        val r: Result[*id.DeclId, str] = allocate[id.DeclId](a.alloc, INITIAL_ID_POOL_CAP);
+    if (a.decl_id_len == a.decl_id_cap) {
+        val r: Result[*id.DeclId, str] = pool.grow[id.DeclId](a.alloc, a.decl_ids, a.decl_id_cap, INITIAL_ID_POOL_CAP, ?a.decl_id_cap);
         if (is_err[*id.DeclId, str](r)) {
             ret err[u32, str](unwrap_err[*id.DeclId, str](r));
         }
-        a.decl_ids    = unwrap_ok[*id.DeclId, str](r);
-        a.decl_id_cap = INITIAL_ID_POOL_CAP;
-    }
-    or (a.decl_id_len == a.decl_id_cap) {
-        val new_cap: usize = a.decl_id_cap * 2;
-        val r: Result[*id.DeclId, str] = reallocate[id.DeclId](a.alloc, a.decl_ids, a.decl_id_cap, new_cap);
-        if (is_err[*id.DeclId, str](r)) {
-            ret err[u32, str](unwrap_err[*id.DeclId, str](r));
-        }
-        a.decl_ids    = unwrap_ok[*id.DeclId, str](r);
-        a.decl_id_cap = new_cap;
+        a.decl_ids = unwrap_ok[*id.DeclId, str](r);
     }
     val index: u32 = a.decl_id_len::u32;
     a.decl_ids[a.decl_id_len] = id_;
@@ -656,22 +555,12 @@ pub fun add_decl_id(a: *Ast, id_: id.DeclId) Result[u32, str] {
 # id_: StmtId to append
 # ret: index into a.stmt_ids for the new entry
 pub fun add_stmt_id(a: *Ast, id_: id.StmtId) Result[u32, str] {
-    if (a.stmt_ids == nil) {
-        val r: Result[*id.StmtId, str] = allocate[id.StmtId](a.alloc, INITIAL_ID_POOL_CAP);
+    if (a.stmt_id_len == a.stmt_id_cap) {
+        val r: Result[*id.StmtId, str] = pool.grow[id.StmtId](a.alloc, a.stmt_ids, a.stmt_id_cap, INITIAL_ID_POOL_CAP, ?a.stmt_id_cap);
         if (is_err[*id.StmtId, str](r)) {
             ret err[u32, str](unwrap_err[*id.StmtId, str](r));
         }
-        a.stmt_ids    = unwrap_ok[*id.StmtId, str](r);
-        a.stmt_id_cap = INITIAL_ID_POOL_CAP;
-    }
-    or (a.stmt_id_len == a.stmt_id_cap) {
-        val new_cap: usize = a.stmt_id_cap * 2;
-        val r: Result[*id.StmtId, str] = reallocate[id.StmtId](a.alloc, a.stmt_ids, a.stmt_id_cap, new_cap);
-        if (is_err[*id.StmtId, str](r)) {
-            ret err[u32, str](unwrap_err[*id.StmtId, str](r));
-        }
-        a.stmt_ids    = unwrap_ok[*id.StmtId, str](r);
-        a.stmt_id_cap = new_cap;
+        a.stmt_ids = unwrap_ok[*id.StmtId, str](r);
     }
     val index: u32 = a.stmt_id_len::u32;
     a.stmt_ids[a.stmt_id_len] = id_;
@@ -685,22 +574,12 @@ pub fun add_stmt_id(a: *Ast, id_: id.StmtId) Result[u32, str] {
 # id_: ExprId to append
 # ret: index into a.expr_ids for the new entry
 pub fun add_expr_id(a: *Ast, id_: id.ExprId) Result[u32, str] {
-    if (a.expr_ids == nil) {
-        val r: Result[*id.ExprId, str] = allocate[id.ExprId](a.alloc, INITIAL_ID_POOL_CAP);
+    if (a.expr_id_len == a.expr_id_cap) {
+        val r: Result[*id.ExprId, str] = pool.grow[id.ExprId](a.alloc, a.expr_ids, a.expr_id_cap, INITIAL_ID_POOL_CAP, ?a.expr_id_cap);
         if (is_err[*id.ExprId, str](r)) {
             ret err[u32, str](unwrap_err[*id.ExprId, str](r));
         }
-        a.expr_ids    = unwrap_ok[*id.ExprId, str](r);
-        a.expr_id_cap = INITIAL_ID_POOL_CAP;
-    }
-    or (a.expr_id_len == a.expr_id_cap) {
-        val new_cap: usize = a.expr_id_cap * 2;
-        val r: Result[*id.ExprId, str] = reallocate[id.ExprId](a.alloc, a.expr_ids, a.expr_id_cap, new_cap);
-        if (is_err[*id.ExprId, str](r)) {
-            ret err[u32, str](unwrap_err[*id.ExprId, str](r));
-        }
-        a.expr_ids    = unwrap_ok[*id.ExprId, str](r);
-        a.expr_id_cap = new_cap;
+        a.expr_ids = unwrap_ok[*id.ExprId, str](r);
     }
     val index: u32 = a.expr_id_len::u32;
     a.expr_ids[a.expr_id_len] = id_;
@@ -823,22 +702,12 @@ pub fun offset_to_type(a: *Ast, offset: usize) id.TypeId {
 # id_: TypeId to append
 # ret: index into a.type_ids for the new entry
 pub fun add_type_id(a: *Ast, id_: id.TypeId) Result[u32, str] {
-    if (a.type_ids == nil) {
-        val r: Result[*id.TypeId, str] = allocate[id.TypeId](a.alloc, INITIAL_ID_POOL_CAP);
+    if (a.type_id_len == a.type_id_cap) {
+        val r: Result[*id.TypeId, str] = pool.grow[id.TypeId](a.alloc, a.type_ids, a.type_id_cap, INITIAL_ID_POOL_CAP, ?a.type_id_cap);
         if (is_err[*id.TypeId, str](r)) {
             ret err[u32, str](unwrap_err[*id.TypeId, str](r));
         }
-        a.type_ids    = unwrap_ok[*id.TypeId, str](r);
-        a.type_id_cap = INITIAL_ID_POOL_CAP;
-    }
-    or (a.type_id_len == a.type_id_cap) {
-        val new_cap: usize = a.type_id_cap * 2;
-        val r: Result[*id.TypeId, str] = reallocate[id.TypeId](a.alloc, a.type_ids, a.type_id_cap, new_cap);
-        if (is_err[*id.TypeId, str](r)) {
-            ret err[u32, str](unwrap_err[*id.TypeId, str](r));
-        }
-        a.type_ids    = unwrap_ok[*id.TypeId, str](r);
-        a.type_id_cap = new_cap;
+        a.type_ids = unwrap_ok[*id.TypeId, str](r);
     }
     val index: u32 = a.type_id_len::u32;
     a.type_ids[a.type_id_len] = id_;

--- a/src/lang/fe/lexer.mach
+++ b/src/lang/fe/lexer.mach
@@ -19,7 +19,6 @@ use std.types.result.unwrap_err;
 use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.deallocate;
-use std.allocator.reallocate;
 
 use page: std.allocator.page;
 
@@ -27,6 +26,7 @@ use token:   mach.lang.fe.token;
 use src:     mach.lang.source;
 use diag:    mach.lang.diagnostic;
 use strutil: std.types.string;
+use pool:    mach.lang.fe.pool;
 
 # error code stored in LexError.code, one per malformed-input category
 pub val LEX_ERR_UNEXPECTED_CHAR:   u8 = 1;
@@ -336,36 +336,35 @@ pub fun tokenize(source: str, alloc: *Allocator, file_id: src.FileId) Result[Tok
             pos = pos + 1;
         }
 
-        if (stream.len == stream.cap) {
-            val new_cap: usize = stream.cap * 2;
-            val r_grow: Result[*token.Token, str] = reallocate[token.Token](alloc, stream.tokens, stream.cap, new_cap);
-            if (is_err[*token.Token, str](r_grow)) {
-                deallocate[token.Token](alloc, stream.tokens, stream.cap);
-                ret err[TokenStream, str](unwrap_err[*token.Token, str](r_grow));
-            }
-            stream.tokens = unwrap_ok[*token.Token, str](r_grow);
-            stream.cap    = new_cap;
+        val r_push: Result[bool, str] = push_token(?stream, alloc, tok);
+        if (is_err[bool, str](r_push)) {
+            ret err[TokenStream, str](unwrap_err[bool, str](r_push));
         }
-
-        stream.tokens[stream.len] = tok;
-        stream.len = stream.len + 1;
     }
 
-    if (stream.len == stream.cap) {
-        val new_cap: usize = stream.cap * 2;
-        val r_grow: Result[*token.Token, str] = reallocate[token.Token](alloc, stream.tokens, stream.cap, new_cap);
-        if (is_err[*token.Token, str](r_grow)) {
-            deallocate[token.Token](alloc, stream.tokens, stream.cap);
-            ret err[TokenStream, str](unwrap_err[*token.Token, str](r_grow));
-        }
-        stream.tokens   = unwrap_ok[*token.Token, str](r_grow);
-        stream.cap = new_cap;
+    val r_eof: Result[bool, str] = push_token(?stream, alloc, token.make(token.KIND_EOF, pos, 0));
+    if (is_err[bool, str](r_eof)) {
+        ret err[TokenStream, str](unwrap_err[bool, str](r_eof));
     }
-
-    stream.tokens[stream.len] = token.make(token.KIND_EOF, pos, 0);
-    stream.len = stream.len + 1;
 
     ret ok[TokenStream, str](stream);
+}
+
+# push_token: append a token to the stream, growing the buffer (doubling) when
+# full. on allocation failure the token buffer is freed and the error returned
+# (the caller's error path frees the rest of the stream).
+fun push_token(stream: *TokenStream, alloc: *Allocator, tok: token.Token) Result[bool, str] {
+    if (stream.len == stream.cap) {
+        val r: Result[*token.Token, str] = pool.grow[token.Token](alloc, stream.tokens, stream.cap, INITIAL_CAP, ?stream.cap);
+        if (is_err[*token.Token, str](r)) {
+            deallocate[token.Token](alloc, stream.tokens, stream.cap);
+            ret err[bool, str](unwrap_err[*token.Token, str](r));
+        }
+        stream.tokens = unwrap_ok[*token.Token, str](r);
+    }
+    stream.tokens[stream.len] = tok;
+    stream.len = stream.len + 1;
+    ret ok[bool, str](true);
 }
 
 # dnit: releases the token and error buffers and clears the stream.
@@ -429,25 +428,19 @@ pub fun emit_diagnostics(stream: *TokenStream, diags: *diag.DiagList) Result[boo
 }
 
 fun push_error(stream: *TokenStream, alloc: *Allocator, offset: usize, len: usize, code: u8) Result[bool, str] {
-    if (stream.errors == nil) {
-        val r: Result[*LexError, str] = allocate[LexError](alloc, INITIAL_ERROR_CAP);
+    if (stream.error_len == stream.error_cap) {
+        val r: Result[*LexError, str] = pool.grow[LexError](alloc, stream.errors, stream.error_cap, INITIAL_ERROR_CAP, ?stream.error_cap);
         if (is_err[*LexError, str](r)) {
-            ret err[bool, str](unwrap_err[*LexError, str](r));
-        }
-        stream.errors    = unwrap_ok[*LexError, str](r);
-        stream.error_cap = INITIAL_ERROR_CAP;
-    }
-    or (stream.error_len == stream.error_cap) {
-        val new_cap: usize = stream.error_cap * 2;
-        val r: Result[*LexError, str] = reallocate[LexError](alloc, stream.errors, stream.error_cap, new_cap);
-        if (is_err[*LexError, str](r)) {
-            deallocate[LexError](alloc, stream.errors, stream.error_cap);
+            # free the existing error buffer (if any) since the caller's error
+            # path only tears down the token buffer.
+            if (stream.errors != nil && stream.error_cap > 0) {
+                deallocate[LexError](alloc, stream.errors, stream.error_cap);
+            }
             stream.errors    = nil;
             stream.error_cap = 0;
             ret err[bool, str](unwrap_err[*LexError, str](r));
         }
-        stream.errors    = unwrap_ok[*LexError, str](r);
-        stream.error_cap = new_cap;
+        stream.errors = unwrap_ok[*LexError, str](r);
     }
 
     var e: LexError;

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -42,13 +42,13 @@ pub fun parse_module(p: *parser.Parser) id.ModuleId {
 
     # buffer direct decls so a nested decl-list (comptime branch body) parsed
     # mid-stream cannot interleave into this module's contiguous decl-id slice
-    var buf: parser.DeclIdBuf = parser.decl_id_buf_init();
+    var buf: parser.ListBuf[id.DeclId] = parser.list_buf_init[id.DeclId]();
 
     for (!parser.at_eof(p)) {
         val before: usize = p.pos;
         val d: id.DeclId = parse_decl(p);
         if (d != id.DECL_NIL) {
-            parser.decl_id_buf_push(p, ?buf, d);
+            parser.list_buf_push[id.DeclId](p, ?buf, d);
         }
         if (p.panic) {
             # realign on the next real declaration boundary so a malformed decl
@@ -510,7 +510,7 @@ def ComptimeBodyFn: fun(*parser.Parser, *u32, *u32) token.Span;
 # interleave into this chain's contiguous slice. writes the branch-list pool
 # start/len through the out-params and returns the chain's end span.
 fun parse_comptime_chain(p: *parser.Parser, start: token.Span, parse_body: ComptimeBodyFn, branches_start_out: *u32, branches_len_out: *u32) token.Span {
-    var br_buf: parser.ComptimeBranchBuf = parser.comptime_branch_buf_init();
+    var br_buf: parser.ListBuf[decl.ComptimeBranch] = parser.list_buf_init[decl.ComptimeBranch]();
 
     parser.advance(p);
     parser.advance(p);
@@ -542,7 +542,7 @@ fun parse_comptime_chain(p: *parser.Parser, start: token.Span, parse_body: Compt
         br.cond       = cond;
         br.body_start = body_start;
         br.body_len   = body_len;
-        parser.comptime_branch_buf_push(p, ?br_buf, br);
+        parser.list_buf_push[decl.ComptimeBranch](p, ?br_buf, br);
 
         if (parser.at(p, token.KIND_DOLLAR) && peek_is_kw(p, 1, "or")) {
             parser.advance(p);
@@ -565,13 +565,13 @@ fun parse_comptime_chain(p: *parser.Parser, start: token.Span, parse_body: Compt
 # decls are buffered so a nested comptime branch body cannot interleave into this
 # branch's contiguous slice.
 fun parse_comptime_decl_body(p: *parser.Parser, body_start_out: *u32, body_len_out: *u32) token.Span {
-    var body_buf: parser.DeclIdBuf = parser.decl_id_buf_init();
+    var body_buf: parser.ListBuf[id.DeclId] = parser.list_buf_init[id.DeclId]();
 
     parser.expect(p, token.KIND_LBRACE, "expected '{' to open comptime branch body");
     for (!parser.at(p, token.KIND_RBRACE) && !parser.at_eof(p)) {
         val d: id.DeclId = parse_decl(p);
         if (d != id.DECL_NIL) {
-            parser.decl_id_buf_push(p, ?body_buf, d);
+            parser.list_buf_push[id.DeclId](p, ?body_buf, d);
         }
         if (p.panic) {
             parser.sync_to(p, token.KIND_SEMI, token.KIND_RBRACE, token.KIND_EOF);
@@ -592,13 +592,13 @@ fun parse_comptime_decl_body(p: *parser.Parser, body_start_out: *u32, body_len_o
 # statements are buffered so a nested block inside cannot interleave into this
 # branch's contiguous slice.
 fun parse_comptime_stmt_body(p: *parser.Parser, body_start_out: *u32, body_len_out: *u32) token.Span {
-    var body_buf: parser.StmtIdBuf = parser.stmt_id_buf_init();
+    var body_buf: parser.ListBuf[id.StmtId] = parser.list_buf_init[id.StmtId]();
 
     parser.expect(p, token.KIND_LBRACE, "expected '{' to open comptime branch body");
     for (!parser.at(p, token.KIND_RBRACE) && !parser.at_eof(p)) {
         val s: id.StmtId = parse_stmt(p);
         if (s != id.STMT_NIL) {
-            parser.stmt_id_buf_push(p, ?body_buf, s);
+            parser.list_buf_push[id.StmtId](p, ?body_buf, s);
         }
         if (p.panic) {
             parser.sync_to(p, token.KIND_SEMI, token.KIND_RBRACE, token.KIND_EOF);
@@ -715,7 +715,7 @@ fun parse_fun_params(p: *parser.Parser, variadic: *bool, out_start: *u32) u32 {
     @variadic = false;
     parser.expect(p, token.KIND_LPAREN, "expected '(' to open parameter list");
 
-    var buf: parser.TypedNameBuf = parser.typed_name_buf_init();
+    var buf: parser.ListBuf[decl.TypedName] = parser.list_buf_init[decl.TypedName]();
     var count: u32 = 0;
 
     if (parser.at(p, token.KIND_RPAREN)) {
@@ -761,7 +761,7 @@ fun parse_fun_params(p: *parser.Parser, variadic: *bool, out_start: *u32) u32 {
 fun parse_rec_fields(p: *parser.Parser, out_start: *u32) u32 {
     parser.expect(p, token.KIND_LBRACE, "expected '{' to open record body");
 
-    var buf: parser.TypedNameBuf = parser.typed_name_buf_init();
+    var buf: parser.ListBuf[decl.TypedName] = parser.list_buf_init[decl.TypedName]();
     var count: u32 = 0;
 
     for (!parser.at(p, token.KIND_RBRACE) && !parser.at_eof(p)) {
@@ -783,7 +783,7 @@ fun parse_rec_fields(p: *parser.Parser, out_start: *u32) u32 {
 # the comptime flag is recorded on the TypedName. the entry is buffered (not
 # pushed to ast.typed_names directly) so an inline rec/uni type cannot split the
 # enclosing list's contiguous slice.
-fun parse_typed_name(p: *parser.Parser, buf: *parser.TypedNameBuf, missing_name_msg: str) bool {
+fun parse_typed_name(p: *parser.Parser, buf: *parser.ListBuf[decl.TypedName], missing_name_msg: str) bool {
     var comptime: bool = false;
     if (parser.eat(p, token.KIND_DOLLAR)) {
         comptime = true;
@@ -801,7 +801,7 @@ fun parse_typed_name(p: *parser.Parser, buf: *parser.TypedNameBuf, missing_name_
     tn.name     = name;
     tn.ty       = ty;
     tn.comptime = comptime;
-    parser.typed_name_buf_push(p, buf, tn);
+    parser.list_buf_push[decl.TypedName](p, buf, tn);
     ret true;
 }
 
@@ -813,12 +813,12 @@ fun parse_block_stmt(p: *parser.Parser) id.StmtId {
     # buffer the statements: a statement containing a nested block (an inner
     # `{}`, or an `if`/`for` body) appends its own statement ids to the shared
     # pool mid-parse, so flush this block as one contiguous slice afterward.
-    var buf: parser.StmtIdBuf = parser.stmt_id_buf_init();
+    var buf: parser.ListBuf[id.StmtId] = parser.list_buf_init[id.StmtId]();
 
     for (!parser.at(p, token.KIND_RBRACE) && !parser.at_eof(p)) {
         val s: id.StmtId = parse_stmt(p);
         if (s != id.STMT_NIL) {
-            parser.stmt_id_buf_push(p, ?buf, s);
+            parser.list_buf_push[id.StmtId](p, ?buf, s);
         }
         if (p.panic) {
             parser.sync_to(p, token.KIND_SEMI, token.KIND_RBRACE, token.KIND_EOF);

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -276,13 +276,13 @@ fun parse_type_args(p: *parser.Parser, out_len: *u32) u32 {
     # buffer the type arguments: a nested generic type argument appends its own
     # child type ids to the shared type_id pool mid-parse, so flush the parent's
     # direct args as one contiguous block afterward (see parse_call).
-    var buf: parser.TypeIdBuf = parser.type_id_buf_init();
+    var buf: parser.ListBuf[id.TypeId] = parser.list_buf_init[id.TypeId]();
 
     if (!parser.at(p, token.KIND_RBRACKET)) {
-        parser.type_id_buf_push(p, ?buf, parse_type(p));
+        parser.list_buf_push[id.TypeId](p, ?buf, parse_type(p));
         for (parser.eat(p, token.KIND_COMMA)) {
             if (parser.at(p, token.KIND_RBRACKET)) { brk; }
-            parser.type_id_buf_push(p, ?buf, parse_type(p));
+            parser.list_buf_push[id.TypeId](p, ?buf, parse_type(p));
         }
     }
     parser.expect(p, token.KIND_RBRACKET, "expected ']' to close generic arguments");
@@ -476,13 +476,13 @@ fun parse_call(p: *parser.Parser, callee: id.ExprId, type_args_start: u32, type_
     # appends its own child ids to the same pool mid-parse, which would split
     # this list's (start, len) slice. flushing the buffer as one contiguous
     # block after parsing keeps the slice intact.
-    var buf: parser.ExprIdBuf = parser.expr_id_buf_init();
+    var buf: parser.ListBuf[id.ExprId] = parser.list_buf_init[id.ExprId]();
 
     if (!parser.at(p, token.KIND_RPAREN)) {
-        parser.expr_id_buf_push(p, ?buf, parse_expr(p));
+        parser.list_buf_push[id.ExprId](p, ?buf, parse_expr(p));
         for (parser.eat(p, token.KIND_COMMA)) {
             if (parser.at(p, token.KIND_RPAREN)) { brk; }
-            parser.expr_id_buf_push(p, ?buf, parse_expr(p));
+            parser.list_buf_push[id.ExprId](p, ?buf, parse_expr(p));
         }
     }
 
@@ -600,13 +600,13 @@ fun parse_array_literal(p: *parser.Parser) id.ExprId {
     # appends its own child ids to the shared expr_id pool mid-parse, so flush
     # the parent's direct elements as one contiguous block afterward (see
     # parse_call).
-    var buf: parser.ExprIdBuf = parser.expr_id_buf_init();
+    var buf: parser.ListBuf[id.ExprId] = parser.list_buf_init[id.ExprId]();
 
     if (!parser.at(p, token.KIND_RBRACE)) {
-        parser.expr_id_buf_push(p, ?buf, parse_expr(p));
+        parser.list_buf_push[id.ExprId](p, ?buf, parse_expr(p));
         for (parser.eat(p, token.KIND_COMMA)) {
             if (parser.at(p, token.KIND_RBRACE)) { brk; }
-            parser.expr_id_buf_push(p, ?buf, parse_expr(p));
+            parser.list_buf_push[id.ExprId](p, ?buf, parse_expr(p));
         }
     }
 
@@ -637,7 +637,7 @@ fun parse_typed_literal(p: *parser.Parser) id.ExprId {
     # buffer the fields: a field initializer may be a nested struct literal
     # that appends its own FieldInits to the shared pool mid-parse, so flush
     # this literal's fields as one contiguous block afterward (see parse_call).
-    var buf: parser.FieldInitBuf = parser.field_init_buf_init();
+    var buf: parser.ListBuf[expr.FieldInit] = parser.list_buf_init[expr.FieldInit]();
 
     if (!parser.at(p, token.KIND_RBRACE)) {
         if (!parse_field_init(p, ?buf)) {
@@ -673,7 +673,7 @@ fun parse_typed_literal(p: *parser.Parser) id.ExprId {
 # parses `name: value` and buffers it into `buf`; returns false on syntax
 # error. the field is buffered (not pushed to ast.field_inits directly) so a
 # nested struct-literal value cannot split the enclosing literal's field slice.
-fun parse_field_init(p: *parser.Parser, buf: *parser.FieldInitBuf) bool {
+fun parse_field_init(p: *parser.Parser, buf: *parser.ListBuf[expr.FieldInit]) bool {
     if (!parser.at(p, token.KIND_IDENT)) {
         parser.error_at_current(p, "expected field name in struct literal");
         ret false;
@@ -685,7 +685,7 @@ fun parse_field_init(p: *parser.Parser, buf: *parser.FieldInitBuf) bool {
     var fi: expr.FieldInit;
     fi.name  = name;
     fi.value = value;
-    parser.field_init_buf_push(p, buf, fi);
+    parser.list_buf_push[expr.FieldInit](p, buf, fi);
     ret true;
 }
 
@@ -770,12 +770,12 @@ fun parse_named(p: *parser.Parser, start: token.Span) id.TypeId {
         # buffer the generic arguments: a nested generic type argument appends
         # its own child type ids to the shared type_id pool mid-parse, so flush
         # this list as one contiguous block afterward (see parse_call).
-        var buf: parser.TypeIdBuf = parser.type_id_buf_init();
+        var buf: parser.ListBuf[id.TypeId] = parser.list_buf_init[id.TypeId]();
         if (!parser.at(p, token.KIND_RBRACKET)) {
-            parser.type_id_buf_push(p, ?buf, parse_type(p));
+            parser.list_buf_push[id.TypeId](p, ?buf, parse_type(p));
             for (parser.eat(p, token.KIND_COMMA)) {
                 if (parser.at(p, token.KIND_RBRACKET)) { brk; }
-                parser.type_id_buf_push(p, ?buf, parse_type(p));
+                parser.list_buf_push[id.TypeId](p, ?buf, parse_type(p));
             }
         }
         val close: token.Token = parser.current(p);
@@ -862,7 +862,7 @@ fun parse_fun(p: *parser.Parser, start: token.Span) id.TypeId {
     # mid-parse. flush this list as one contiguous block before parsing the
     # return type, so its nested ids cannot split the parameter slice (see
     # parse_call).
-    var buf: parser.TypeIdBuf = parser.type_id_buf_init();
+    var buf: parser.ListBuf[id.TypeId] = parser.list_buf_init[id.TypeId]();
     var variadic: bool = false;
 
     if (parser.at(p, token.KIND_DOT_DOT_DOT)) {
@@ -870,7 +870,7 @@ fun parse_fun(p: *parser.Parser, start: token.Span) id.TypeId {
         variadic = true;
     }
     or (!parser.at(p, token.KIND_RPAREN)) {
-        parser.type_id_buf_push(p, ?buf, parse_type(p));
+        parser.list_buf_push[id.TypeId](p, ?buf, parse_type(p));
         for (parser.eat(p, token.KIND_COMMA)) {
             if (parser.at(p, token.KIND_RPAREN)) { brk; }
             if (parser.at(p, token.KIND_DOT_DOT_DOT)) {
@@ -878,7 +878,7 @@ fun parse_fun(p: *parser.Parser, start: token.Span) id.TypeId {
                 variadic = true;
                 brk;
             }
-            parser.type_id_buf_push(p, ?buf, parse_type(p));
+            parser.list_buf_push[id.TypeId](p, ?buf, parse_type(p));
         }
     }
 
@@ -924,7 +924,7 @@ fun parse_rec_or_uni(p: *parser.Parser, start: token.Span, kind: m_type.TypeKind
     # buffer the fields: a field whose type is itself an inline rec/uni appends
     # its own typed_names to the shared pool mid-parse, so flush this type's
     # fields as one contiguous block afterward (see parse_call).
-    var buf: parser.TypedNameBuf = parser.typed_name_buf_init();
+    var buf: parser.ListBuf[decl.TypedName] = parser.list_buf_init[decl.TypedName]();
 
     for (!parser.at(p, token.KIND_RBRACE) && !parser.at_eof(p)) {
         if (!parser.at(p, token.KIND_IDENT)) {
@@ -941,7 +941,7 @@ fun parse_rec_or_uni(p: *parser.Parser, start: token.Span, kind: m_type.TypeKind
         tn.name     = name;
         tn.ty       = ty;
         tn.comptime = false;
-        parser.typed_name_buf_push(p, ?buf, tn);
+        parser.list_buf_push[decl.TypedName](p, ?buf, tn);
 
         parser.expect(p, token.KIND_SEMI, "expected ';' after field declaration");
     }

--- a/src/lang/fe/parser/state.mach
+++ b/src/lang/fe/parser/state.mach
@@ -16,15 +16,13 @@ use std.types.result.Result;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 
-use std.allocator.Allocator;
-use std.allocator.allocate;
-use std.allocator.reallocate;
 use std.allocator.deallocate;
 
 use token:  mach.lang.fe.token;
 use lexer:  mach.lang.fe.lexer;
 use diag:   mach.lang.diagnostic;
 use ast:    mach.lang.fe.ast;
+use pool:   mach.lang.fe.pool;
 use id:     mach.lang.fe.ast.id;
 use expr:   mach.lang.fe.ast.expr;
 use stmt:   mach.lang.fe.ast.stmt;
@@ -351,60 +349,62 @@ pub fun push_decl_id(p: *Parser, id_: id.DeclId) u32 {
     ret unwrap_ok[u32, str](r);
 }
 
-# DeclIdBuf: a temporary, contiguous buffer of DeclIds collected while
-# parsing a decl-list (a module body or a comptime branch body). because the
-# `ast.decl_ids` pool is shared and append-only, pushing a parent list's ids
-# directly would interleave with the ids a nested decl-list (e.g. a comptime
-# branch body) pushes mid-parse, breaking the parent's contiguous (start,len)
-# slice. buffering the parent's direct children and flushing them as one block
-# after all nested lists are parsed keeps every slice contiguous and disjoint.
+# ListBuf: a temporary, contiguous buffer of elements collected while parsing
+# one nested list. the matching `ast.*` pool is shared and append-only, and
+# fully parsing one element can append that element's own children to the same
+# pool mid-parse; buffering the parent's direct elements here and flushing them
+# as one block after every nested parse keeps each node's (start, len) slice
+# contiguous and disjoint. each pool keeps its own thin `*_buf_flush` helper
+# that appends the buffer to its pool and frees it.
 # ---
-# data: heap buffer of collected DeclIds
-# len:  number of ids buffered
+# data: heap buffer of collected elements
+# len:  number of elements buffered
 # cap:  allocated slots
-pub rec DeclIdBuf {
-    data: *id.DeclId;
-    len:  u32;
-    cap:  u32;
+pub rec ListBuf[T] {
+    data: *T;
+    len:  usize;
+    cap:  usize;
 }
 
-# decl_id_buf_init: start an empty DeclIdBuf.
-pub fun decl_id_buf_init() DeclIdBuf {
-    var b: DeclIdBuf;
+# list_buf_init: start an empty ListBuf.
+pub fun list_buf_init[T]() ListBuf[T] {
+    var b: ListBuf[T];
     b.data = nil;
     b.len  = 0;
     b.cap  = 0;
     ret b;
 }
 
-# decl_id_buf_push: buffer one DeclId, growing on demand. on allocation
-# failure it reports through the parser and leaves the buffer unchanged.
-pub fun decl_id_buf_push(p: *Parser, b: *DeclIdBuf, id_: id.DeclId) {
+# list_buf_push: buffer one element, growing on demand (seeded at 8, then
+# doubling). on allocation failure it flags the parse fatal and leaves the
+# buffer unchanged.
+pub fun list_buf_push[T](p: *Parser, b: *ListBuf[T], x: T) {
     if (b.len == b.cap) {
-        var new_cap: u32 = b.cap * 2;
-        if (new_cap == 0) { new_cap = 8; }
-        if (b.data == nil) {
-            val r: Result[*id.DeclId, str] = allocate[id.DeclId](p.ast.alloc, new_cap::usize);
-            if (is_err[*id.DeclId, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*id.DeclId, str](r);
-        }
-        or {
-            val r: Result[*id.DeclId, str] = reallocate[id.DeclId](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*id.DeclId, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*id.DeclId, str](r);
-        }
-        b.cap = new_cap;
+        val r: Result[*T, str] = pool.grow[T](p.ast.alloc, b.data, b.cap, 8, ?b.cap);
+        if (is_err[*T, str](r)) { fatal_oom(p); ret; }
+        b.data = unwrap_ok[*T, str](r);
     }
-    b.data[b.len] = id_;
+    b.data[b.len] = x;
     b.len = b.len + 1;
+}
+
+# list_buf_free: release a buffer's storage and reset it to empty. the shared
+# tail of every `*_buf_flush`.
+pub fun list_buf_free[T](p: *Parser, b: *ListBuf[T]) {
+    if (b.data != nil && b.cap > 0) {
+        deallocate[T](p.ast.alloc, b.data, b.cap);
+    }
+    b.data = nil;
+    b.len  = 0;
+    b.cap  = 0;
 }
 
 # decl_id_buf_flush: append the buffered DeclIds to `ast.decl_ids` as one
 # contiguous block and free the buffer. returns the pool start index of the
 # block (the run's `decls_start`/`body_start`); `*out_len` receives its length.
-pub fun decl_id_buf_flush(p: *Parser, b: *DeclIdBuf, out_len: *u32) u32 {
+pub fun decl_id_buf_flush(p: *Parser, b: *ListBuf[id.DeclId], out_len: *u32) u32 {
     val start: u32 = p.ast.decl_id_len::u32;
-    var i: u32 = 0;
+    var i: usize = 0;
     for (i < b.len) {
         push_decl_id(p, b.data[i]);
         i = i + 1;
@@ -412,70 +412,16 @@ pub fun decl_id_buf_flush(p: *Parser, b: *DeclIdBuf, out_len: *u32) u32 {
     # the count actually appended, not b.len: a fatal alloc failure mid-flush
     # leaves the slice covering only the ids that reached the pool.
     @out_len = (p.ast.decl_id_len::u32) - start;
-    if (b.data != nil && b.cap > 0) {
-        deallocate[id.DeclId](p.ast.alloc, b.data, b.cap::usize);
-    }
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
+    list_buf_free[id.DeclId](p, b);
     ret start;
-}
-
-# ExprIdBuf: a temporary, contiguous buffer of ExprIds collected while parsing
-# an expr-list (call arguments, array-literal elements). the `ast.expr_ids`
-# pool is shared and append-only, and parsing one element fully — including any
-# nested call/array-literal it contains — appends that element's own child ids
-# to the same pool. pushing the parent's element ids directly would therefore
-# interleave with a nested element's ids, corrupting the parent's (start, len)
-# slice. buffering the parent's direct elements and flushing them as one block
-# after every nested parse completes keeps each slice contiguous and disjoint.
-# ---
-# data: heap buffer of collected ExprIds
-# len:  number of ids buffered
-# cap:  allocated slots
-pub rec ExprIdBuf {
-    data: *id.ExprId;
-    len:  u32;
-    cap:  u32;
-}
-
-# expr_id_buf_init: start an empty ExprIdBuf.
-pub fun expr_id_buf_init() ExprIdBuf {
-    var b: ExprIdBuf;
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
-    ret b;
-}
-
-# expr_id_buf_push: buffer one ExprId, growing on demand. on allocation failure
-# it reports through the parser and leaves the buffer unchanged.
-pub fun expr_id_buf_push(p: *Parser, b: *ExprIdBuf, id_: id.ExprId) {
-    if (b.len == b.cap) {
-        var new_cap: u32 = b.cap * 2;
-        if (new_cap == 0) { new_cap = 8; }
-        if (b.data == nil) {
-            val r: Result[*id.ExprId, str] = allocate[id.ExprId](p.ast.alloc, new_cap::usize);
-            if (is_err[*id.ExprId, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*id.ExprId, str](r);
-        }
-        or {
-            val r: Result[*id.ExprId, str] = reallocate[id.ExprId](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*id.ExprId, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*id.ExprId, str](r);
-        }
-        b.cap = new_cap;
-    }
-    b.data[b.len] = id_;
-    b.len = b.len + 1;
 }
 
 # expr_id_buf_flush: append the buffered ExprIds to `ast.expr_ids` as one
 # contiguous block and free the buffer. returns the pool start index of the
 # block (the list's `args_start`/`elems_start`); `*out_len` receives its length.
-pub fun expr_id_buf_flush(p: *Parser, b: *ExprIdBuf, out_len: *u32) u32 {
+pub fun expr_id_buf_flush(p: *Parser, b: *ListBuf[id.ExprId], out_len: *u32) u32 {
     val start: u32 = p.ast.expr_id_len::u32;
-    var i: u32 = 0;
+    var i: usize = 0;
     for (i < b.len) {
         push_expr_id(p, b.data[i]);
         i = i + 1;
@@ -483,69 +429,16 @@ pub fun expr_id_buf_flush(p: *Parser, b: *ExprIdBuf, out_len: *u32) u32 {
     # the count actually appended, not b.len: a fatal alloc failure mid-flush
     # leaves the slice covering only the ids that reached the pool.
     @out_len = (p.ast.expr_id_len::u32) - start;
-    if (b.data != nil && b.cap > 0) {
-        deallocate[id.ExprId](p.ast.alloc, b.data, b.cap::usize);
-    }
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
+    list_buf_free[id.ExprId](p, b);
     ret start;
-}
-
-# TypeIdBuf: a temporary, contiguous buffer of TypeIds collected while parsing
-# a type-list (call-site or named-type generic arguments, function-type
-# parameters). the `ast.type_ids` pool is shared and append-only, and parsing
-# one element fully — including any nested generic type it contains — appends
-# that element's own child ids to the same pool. buffering the parent's direct
-# elements and flushing them after every nested parse completes keeps each
-# slice contiguous and disjoint, exactly as ExprIdBuf does for expr-lists.
-# ---
-# data: heap buffer of collected TypeIds
-# len:  number of ids buffered
-# cap:  allocated slots
-pub rec TypeIdBuf {
-    data: *id.TypeId;
-    len:  u32;
-    cap:  u32;
-}
-
-# type_id_buf_init: start an empty TypeIdBuf.
-pub fun type_id_buf_init() TypeIdBuf {
-    var b: TypeIdBuf;
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
-    ret b;
-}
-
-# type_id_buf_push: buffer one TypeId, growing on demand. on allocation failure
-# it reports through the parser and leaves the buffer unchanged.
-pub fun type_id_buf_push(p: *Parser, b: *TypeIdBuf, id_: id.TypeId) {
-    if (b.len == b.cap) {
-        var new_cap: u32 = b.cap * 2;
-        if (new_cap == 0) { new_cap = 8; }
-        if (b.data == nil) {
-            val r: Result[*id.TypeId, str] = allocate[id.TypeId](p.ast.alloc, new_cap::usize);
-            if (is_err[*id.TypeId, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*id.TypeId, str](r);
-        }
-        or {
-            val r: Result[*id.TypeId, str] = reallocate[id.TypeId](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*id.TypeId, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*id.TypeId, str](r);
-        }
-        b.cap = new_cap;
-    }
-    b.data[b.len] = id_;
-    b.len = b.len + 1;
 }
 
 # type_id_buf_flush: append the buffered TypeIds to `ast.type_ids` as one
 # contiguous block and free the buffer. returns the pool start index of the
 # block (the list's `args_start`/`params_start`); `*out_len` receives its length.
-pub fun type_id_buf_flush(p: *Parser, b: *TypeIdBuf, out_len: *u32) u32 {
+pub fun type_id_buf_flush(p: *Parser, b: *ListBuf[id.TypeId], out_len: *u32) u32 {
     val start: u32 = p.ast.type_id_len::u32;
-    var i: u32 = 0;
+    var i: usize = 0;
     for (i < b.len) {
         push_type_id(p, b.data[i]);
         i = i + 1;
@@ -553,68 +446,16 @@ pub fun type_id_buf_flush(p: *Parser, b: *TypeIdBuf, out_len: *u32) u32 {
     # the count actually appended, not b.len: a fatal alloc failure mid-flush
     # leaves the slice covering only the ids that reached the pool.
     @out_len = (p.ast.type_id_len::u32) - start;
-    if (b.data != nil && b.cap > 0) {
-        deallocate[id.TypeId](p.ast.alloc, b.data, b.cap::usize);
-    }
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
+    list_buf_free[id.TypeId](p, b);
     ret start;
-}
-
-# FieldInitBuf: a temporary, contiguous buffer of FieldInits collected while
-# parsing a struct literal's field list. the `ast.field_inits` pool is shared
-# and append-only, and a field's initializer may itself be a nested struct
-# literal that appends its own FieldInits to the same pool. buffering the
-# parent's direct fields and flushing them after every nested parse completes
-# keeps each literal's (start, len) slice contiguous and disjoint.
-# ---
-# data: heap buffer of collected FieldInits
-# len:  number of entries buffered
-# cap:  allocated slots
-pub rec FieldInitBuf {
-    data: *expr.FieldInit;
-    len:  u32;
-    cap:  u32;
-}
-
-# field_init_buf_init: start an empty FieldInitBuf.
-pub fun field_init_buf_init() FieldInitBuf {
-    var b: FieldInitBuf;
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
-    ret b;
-}
-
-# field_init_buf_push: buffer one FieldInit, growing on demand. on allocation
-# failure it reports through the parser and leaves the buffer unchanged.
-pub fun field_init_buf_push(p: *Parser, b: *FieldInitBuf, fi: expr.FieldInit) {
-    if (b.len == b.cap) {
-        var new_cap: u32 = b.cap * 2;
-        if (new_cap == 0) { new_cap = 8; }
-        if (b.data == nil) {
-            val r: Result[*expr.FieldInit, str] = allocate[expr.FieldInit](p.ast.alloc, new_cap::usize);
-            if (is_err[*expr.FieldInit, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*expr.FieldInit, str](r);
-        }
-        or {
-            val r: Result[*expr.FieldInit, str] = reallocate[expr.FieldInit](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*expr.FieldInit, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*expr.FieldInit, str](r);
-        }
-        b.cap = new_cap;
-    }
-    b.data[b.len] = fi;
-    b.len = b.len + 1;
 }
 
 # field_init_buf_flush: append the buffered FieldInits to `ast.field_inits` as
 # one contiguous block and free the buffer. returns the pool start index of the
 # block (the literal's `fields_start`); `*out_len` receives its length.
-pub fun field_init_buf_flush(p: *Parser, b: *FieldInitBuf, out_len: *u32) u32 {
+pub fun field_init_buf_flush(p: *Parser, b: *ListBuf[expr.FieldInit], out_len: *u32) u32 {
     val start: u32 = p.ast.field_init_len::u32;
-    var i: u32 = 0;
+    var i: usize = 0;
     for (i < b.len) {
         val r: Result[u32, str] = ast.add_field_init(p.ast, b.data[i]);
         if (is_err[u32, str](r)) { fatal_oom(p); }
@@ -623,69 +464,16 @@ pub fun field_init_buf_flush(p: *Parser, b: *FieldInitBuf, out_len: *u32) u32 {
     # the count actually appended, not b.len: a fatal alloc failure mid-flush
     # leaves the slice covering only the entries that reached the pool.
     @out_len = (p.ast.field_init_len::u32) - start;
-    if (b.data != nil && b.cap > 0) {
-        deallocate[expr.FieldInit](p.ast.alloc, b.data, b.cap::usize);
-    }
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
+    list_buf_free[expr.FieldInit](p, b);
     ret start;
-}
-
-# TypedNameBuf: a temporary, contiguous buffer of TypedNames collected while
-# parsing a typed-name list (function parameters, record/union fields). the
-# `ast.typed_names` pool is shared and append-only, and a parameter or field
-# whose type is an inline anonymous `rec {...}` / `uni {...}` appends that
-# inline type's own fields to the same pool mid-parse. buffering the parent's
-# direct entries and flushing them after every nested parse completes keeps
-# each list's (start, len) slice contiguous and disjoint.
-# ---
-# data: heap buffer of collected TypedNames
-# len:  number of entries buffered
-# cap:  allocated slots
-pub rec TypedNameBuf {
-    data: *decl.TypedName;
-    len:  u32;
-    cap:  u32;
-}
-
-# typed_name_buf_init: start an empty TypedNameBuf.
-pub fun typed_name_buf_init() TypedNameBuf {
-    var b: TypedNameBuf;
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
-    ret b;
-}
-
-# typed_name_buf_push: buffer one TypedName, growing on demand. on allocation
-# failure it reports through the parser and leaves the buffer unchanged.
-pub fun typed_name_buf_push(p: *Parser, b: *TypedNameBuf, tn: decl.TypedName) {
-    if (b.len == b.cap) {
-        var new_cap: u32 = b.cap * 2;
-        if (new_cap == 0) { new_cap = 8; }
-        if (b.data == nil) {
-            val r: Result[*decl.TypedName, str] = allocate[decl.TypedName](p.ast.alloc, new_cap::usize);
-            if (is_err[*decl.TypedName, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*decl.TypedName, str](r);
-        }
-        or {
-            val r: Result[*decl.TypedName, str] = reallocate[decl.TypedName](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*decl.TypedName, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*decl.TypedName, str](r);
-        }
-        b.cap = new_cap;
-    }
-    b.data[b.len] = tn;
-    b.len = b.len + 1;
 }
 
 # typed_name_buf_flush: append the buffered TypedNames to `ast.typed_names` as
 # one contiguous block and free the buffer. returns the pool start index of the
 # block (the list's `params_start`/`fields_start`); `*out_len` receives its length.
-pub fun typed_name_buf_flush(p: *Parser, b: *TypedNameBuf, out_len: *u32) u32 {
+pub fun typed_name_buf_flush(p: *Parser, b: *ListBuf[decl.TypedName], out_len: *u32) u32 {
     val start: u32 = p.ast.typed_name_len::u32;
-    var i: u32 = 0;
+    var i: usize = 0;
     for (i < b.len) {
         val r: Result[u32, str] = ast.add_typed_name(p.ast, b.data[i]);
         if (is_err[u32, str](r)) { fatal_oom(p); }
@@ -694,68 +482,16 @@ pub fun typed_name_buf_flush(p: *Parser, b: *TypedNameBuf, out_len: *u32) u32 {
     # the count actually appended, not b.len: a fatal alloc failure mid-flush
     # leaves the slice covering only the entries that reached the pool.
     @out_len = (p.ast.typed_name_len::u32) - start;
-    if (b.data != nil && b.cap > 0) {
-        deallocate[decl.TypedName](p.ast.alloc, b.data, b.cap::usize);
-    }
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
+    list_buf_free[decl.TypedName](p, b);
     ret start;
-}
-
-# StmtIdBuf: a temporary, contiguous buffer of StmtIds collected while parsing
-# a block or comptime-branch statement body. the `ast.stmt_ids` pool is shared
-# and append-only, and a statement that contains a nested block (an inner `{}`,
-# or an `if`/`for` body) appends that block's own statement ids to the same pool
-# mid-parse. buffering the parent's direct statements and flushing them after
-# every nested parse completes keeps each body's (start, len) slice contiguous.
-# ---
-# data: heap buffer of collected StmtIds
-# len:  number of ids buffered
-# cap:  allocated slots
-pub rec StmtIdBuf {
-    data: *id.StmtId;
-    len:  u32;
-    cap:  u32;
-}
-
-# stmt_id_buf_init: start an empty StmtIdBuf.
-pub fun stmt_id_buf_init() StmtIdBuf {
-    var b: StmtIdBuf;
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
-    ret b;
-}
-
-# stmt_id_buf_push: buffer one StmtId, growing on demand. on allocation failure
-# it reports through the parser and leaves the buffer unchanged.
-pub fun stmt_id_buf_push(p: *Parser, b: *StmtIdBuf, id_: id.StmtId) {
-    if (b.len == b.cap) {
-        var new_cap: u32 = b.cap * 2;
-        if (new_cap == 0) { new_cap = 8; }
-        if (b.data == nil) {
-            val r: Result[*id.StmtId, str] = allocate[id.StmtId](p.ast.alloc, new_cap::usize);
-            if (is_err[*id.StmtId, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*id.StmtId, str](r);
-        }
-        or {
-            val r: Result[*id.StmtId, str] = reallocate[id.StmtId](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*id.StmtId, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*id.StmtId, str](r);
-        }
-        b.cap = new_cap;
-    }
-    b.data[b.len] = id_;
-    b.len = b.len + 1;
 }
 
 # stmt_id_buf_flush: append the buffered StmtIds to `ast.stmt_ids` as one
 # contiguous block and free the buffer. returns the pool start index of the
 # block (the body's `stmts_start`/`body_start`); `*out_len` receives its length.
-pub fun stmt_id_buf_flush(p: *Parser, b: *StmtIdBuf, out_len: *u32) u32 {
+pub fun stmt_id_buf_flush(p: *Parser, b: *ListBuf[id.StmtId], out_len: *u32) u32 {
     val start: u32 = p.ast.stmt_id_len::u32;
-    var i: u32 = 0;
+    var i: usize = 0;
     for (i < b.len) {
         push_stmt_id(p, b.data[i]);
         i = i + 1;
@@ -763,70 +499,17 @@ pub fun stmt_id_buf_flush(p: *Parser, b: *StmtIdBuf, out_len: *u32) u32 {
     # the count actually appended, not b.len: a fatal alloc failure mid-flush
     # leaves the slice covering only the ids that reached the pool.
     @out_len = (p.ast.stmt_id_len::u32) - start;
-    if (b.data != nil && b.cap > 0) {
-        deallocate[id.StmtId](p.ast.alloc, b.data, b.cap::usize);
-    }
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
+    list_buf_free[id.StmtId](p, b);
     ret start;
-}
-
-# ComptimeBranchBuf: a temporary, contiguous buffer of ComptimeBranches
-# collected while parsing one `$if`/`$or` chain. the `ast.comptime_branches`
-# pool is shared and append-only, and a branch body may contain a nested
-# `$if`/`$or` chain that appends its own branches to the same pool mid-parse.
-# buffering this chain's direct branches and flushing them after every nested
-# parse completes keeps each chain's (start, len) slice contiguous and disjoint.
-# ---
-# data: heap buffer of collected ComptimeBranches
-# len:  number of branches buffered
-# cap:  allocated slots
-pub rec ComptimeBranchBuf {
-    data: *decl.ComptimeBranch;
-    len:  u32;
-    cap:  u32;
-}
-
-# comptime_branch_buf_init: start an empty ComptimeBranchBuf.
-pub fun comptime_branch_buf_init() ComptimeBranchBuf {
-    var b: ComptimeBranchBuf;
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
-    ret b;
-}
-
-# comptime_branch_buf_push: buffer one ComptimeBranch, growing on demand. on
-# allocation failure it reports through the parser and leaves the buffer
-# unchanged.
-pub fun comptime_branch_buf_push(p: *Parser, b: *ComptimeBranchBuf, br: decl.ComptimeBranch) {
-    if (b.len == b.cap) {
-        var new_cap: u32 = b.cap * 2;
-        if (new_cap == 0) { new_cap = 8; }
-        if (b.data == nil) {
-            val r: Result[*decl.ComptimeBranch, str] = allocate[decl.ComptimeBranch](p.ast.alloc, new_cap::usize);
-            if (is_err[*decl.ComptimeBranch, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*decl.ComptimeBranch, str](r);
-        }
-        or {
-            val r: Result[*decl.ComptimeBranch, str] = reallocate[decl.ComptimeBranch](p.ast.alloc, b.data, b.cap::usize, new_cap::usize);
-            if (is_err[*decl.ComptimeBranch, str](r)) { fatal_oom(p); ret; }
-            b.data = unwrap_ok[*decl.ComptimeBranch, str](r);
-        }
-        b.cap = new_cap;
-    }
-    b.data[b.len] = br;
-    b.len = b.len + 1;
 }
 
 # comptime_branch_buf_flush: append the buffered ComptimeBranches to
 # `ast.comptime_branches` as one contiguous block and free the buffer. returns
 # the pool start index of the block (the chain's `branches_start`); `*out_len`
 # receives its length.
-pub fun comptime_branch_buf_flush(p: *Parser, b: *ComptimeBranchBuf, out_len: *u32) u32 {
+pub fun comptime_branch_buf_flush(p: *Parser, b: *ListBuf[decl.ComptimeBranch], out_len: *u32) u32 {
     val start: u32 = p.ast.comptime_branch_len::u32;
-    var i: u32 = 0;
+    var i: usize = 0;
     for (i < b.len) {
         val r: Result[u32, str] = ast.add_comptime_branch(p.ast, b.data[i]);
         if (is_err[u32, str](r)) { fatal_oom(p); }
@@ -835,12 +518,7 @@ pub fun comptime_branch_buf_flush(p: *Parser, b: *ComptimeBranchBuf, out_len: *u
     # the count actually appended, not b.len: a fatal alloc failure mid-flush
     # leaves the slice covering only the branches that reached the pool.
     @out_len = (p.ast.comptime_branch_len::u32) - start;
-    if (b.data != nil && b.cap > 0) {
-        deallocate[decl.ComptimeBranch](p.ast.alloc, b.data, b.cap::usize);
-    }
-    b.data = nil;
-    b.len  = 0;
-    b.cap  = 0;
+    list_buf_free[decl.ComptimeBranch](p, b);
     ret start;
 }
 

--- a/src/lang/fe/pool.mach
+++ b/src/lang/fe/pool.mach
@@ -1,0 +1,50 @@
+# mach.lang.fe.pool: the single storage-growth primitive shared by the
+# frontend's growable arrays.
+#
+# the AST node/aux/id pools (ast.mach), the parser's nested-list buffers
+# (parser/state.mach), and the lexer's token/error streams (lexer.mach) all
+# keep raw `*T`/len/cap fields and append by direct indexing; `grow` is the one
+# doubling-realloc body they share, so the growth discipline lives in exactly
+# one place.
+
+use std.types.string.str;
+use std.types.size.usize;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
+
+use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.reallocate;
+
+# grow: make room for one more element in a `*T`/len/cap buffer, returning the
+# (possibly relocated) buffer and writing the new capacity through `out_cap`.
+# when `cap` is 0 the buffer is freshly allocated to `seed`; otherwise it is
+# reallocated to double its capacity. on failure the old buffer is left intact
+# and `out_cap` is untouched, so the caller can free or propagate as it sees
+# fit. callers keep their own `len == cap` guard inline so the no-grow path
+# costs nothing.
+# ---
+# alloc:   allocator backing the buffer
+# data:    current buffer (nil iff cap is 0)
+# cap:     current capacity
+# seed:    capacity to allocate on the first growth
+# out_cap: receives the new capacity on success
+# ret:     the (re)allocated buffer, or an allocation error
+pub fun grow[T](alloc: *Allocator, data: *T, cap: usize, seed: usize, out_cap: *usize) Result[*T, str] {
+    var new_cap: usize = seed;
+    if (cap != 0) { new_cap = cap * 2; }
+    if (data == nil) {
+        val r: Result[*T, str] = allocate[T](alloc, new_cap);
+        if (is_err[*T, str](r)) { ret err[*T, str](unwrap_err[*T, str](r)); }
+        @out_cap = new_cap;
+        ret ok[*T, str](unwrap_ok[*T, str](r));
+    }
+    val r: Result[*T, str] = reallocate[T](alloc, data, cap, new_cap);
+    if (is_err[*T, str](r)) { ret err[*T, str](unwrap_err[*T, str](r)); }
+    @out_cap = new_cap;
+    ret ok[*T, str](unwrap_ok[*T, str](r));
+}


### PR DESCRIPTION
Consolidates the frontend's hand-rolled growable-array code onto a single shared capacity primitive (`mach.lang.fe.pool.grow[T]`). Closes the deferred [SMELL/L] from #1247.

## Approach
Took the repo's established capacity-primitive pattern (PR #1306, `me/ir`) over embedding `std.collections.vector.Vector[T]` — full justification in the [inventory comment on #1271](https://github.com/octalide/mach/issues/1271#issuecomment-4683297264). In short: the AST pools are read by direct indexing and `(start,len)` slicing in 226+ sites across 15 files, so embedding `Vector[T]` would mean a large rename blast radius plus a per-access bounds-check regression on the compiler's hottest path. Instead the one thing the 20+ copies actually duplicate — the doubling-realloc growth body — is extracted into `pool.grow[T]`; the raw `*T`/len/cap layout is kept, so consumers are untouched and the no-grow hot path is unchanged.

```
pub fun grow[T](alloc: *Allocator, data: *T, cap: usize, seed: usize, out_cap: *usize) Result[*T, str]
```

## Changes (per family)
- **ast.mach** — 13 `add_*` growth bodies → `pool.grow` (raw fields kept).
- **parser/state.mach** — 7 byte-identical Buf families → one generic `ListBuf[T]` (`list_buf_init`/`push`/`free`); the 7 `*_buf_flush` stay as thin per-pool helpers, deriving `out_len` from the pool delta (the #1268 flush-count honesty). `decl.mach`/`expr.mach` call sites updated.
- **lexer.mach** — 2 inline token-grow blocks → one `push_token` helper over `pool.grow`; `push_error`'s growth routes through the same primitive (keeping its free-on-failure cleanup).

The `fatal_oom` sticky-flag OOM routing from #1268 is preserved exactly.

`resolve.mach` / `comptime.mach` / `sema/generics.mach` hold single-instance grows in the #1248/#1249 territories — out of scope here, noted on #1271 as a trivial follow-up.

## Verification
- `mach build .` clean (linux + windows cross-compile)
- `mach test .` — **342 pass / 0 fail** (baseline unchanged)
- self-host fixpoint **converges** (byte-identical rebuild)
- **cross-compiler output identity**: the origin/dev compiler and this branch's compiler both compile this source to the byte-identical binary `723143…` — output is provably unchanged
- **18/18 integration suites** pass (incl. win64 under wine)
- build-time: **no regression** — 3x `time mach build .` before `28.327/28.316/28.324s`, after `28.275/28.390/28.302s`

Net **+210 / −620 = −410 lines**.

Closes #1271
