### PR TITLE
feat(cli): `mach info` — version, build host, and target capabilities

### DIFF
--- a/.github/tests/info/run.sh
+++ b/.github/tests/info/run.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# `mach info` integration test (#1312). asserts the at-a-glance compiler info
+# surface, all of which must work with NO project (run from an empty temp dir):
+#
+#   info       — exit 0 and the expected line-oriented surface (version banner,
+#                build host, and the four capability lines from the registries).
+#   --version  — `mach info --version` prints the version string alone, one line.
+#   banner     — the bare `mach` usage banner header surfaces the version.
+#   no flag    — bare `mach --version` is NOT a recognized version flag: it falls
+#                through to the unknown-command path (non-zero, no one-line
+#                version), distinguishing it from the `mach info --version` alias.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# run from the empty WORK dir so every assertion proves the no-project path.
+cd "$WORK"
+
+# info — exit 0 and the full surface from an empty dir.
+set +e
+out="$("$MACH" info)"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL info/run: 'mach info' exited $code from a project-less dir" >&2
+    printf '%s\n' "$out" >&2; fail=1
+fi
+for want in "^mach [0-9]" "^host: " "^isa: " "^os: " "^abi: " "^object: "; do
+    if ! printf '%s\n' "$out" | grep -qE -- "$want"; then
+        echo "FAIL info/run: 'mach info' output missing line matching /$want/" >&2
+        printf '%s\n' "$out" >&2; fail=1
+    fi
+done
+# the build host folds to a concrete os/isa, never the comptime-dead fallback.
+if printf '%s\n' "$out" | grep -qE -- "^host: unknown"; then
+    echo "FAIL info/run: 'mach info' host did not fold to a concrete os/isa" >&2
+    printf '%s\n' "$out" >&2; fail=1
+fi
+if [ "$fail" -eq 0 ]; then echo "PASS info/run: 'mach info' prints the no-project surface"; fi
+
+# --version — exactly one line, the version string alone (no "mach " prefix).
+set +e
+vout="$("$MACH" info --version)"; vcode=$?
+set -e
+vlines="$(printf '%s\n' "$vout" | grep -c '')"
+if [ "$vcode" -ne 0 ]; then
+    echo "FAIL info/version: 'mach info --version' exited $vcode" >&2; fail=1
+elif [ "$vlines" -ne 1 ]; then
+    echo "FAIL info/version: 'mach info --version' printed $vlines lines, want 1" >&2
+    printf '%s\n' "$vout" >&2; fail=1
+elif ! printf '%s' "$vout" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+    echo "FAIL info/version: 'mach info --version' is not a bare version string" >&2
+    printf '%s\n' "$vout" >&2; fail=1
+else
+    echo "PASS info/version: 'mach info --version' is one bare version line"
+fi
+
+# banner — the bare 'mach' usage header surfaces the version.
+set +e
+banner="$("$MACH" 2>&1)"; bcode=$?
+set -e
+if ! printf '%s\n' "$banner" | grep -qE -- "^mach [0-9]+\.[0-9]+\.[0-9]+ — "; then
+    echo "FAIL info/banner: bare 'mach' usage header does not surface the version" >&2
+    printf '%s\n' "$banner" >&2; fail=1
+else
+    echo "PASS info/banner: bare 'mach' usage header surfaces the version"
+fi
+
+# no flag — bare 'mach --version' is unrecognized: non-zero, unknown-command path,
+# and no standalone one-line version (its first line is the error, not a version).
+set +e
+gvout="$("$MACH" --version 2>&1)"; gvcode=$?
+set -e
+gvfirst="$(printf '%s\n' "$gvout" | head -n1)"
+if [ "$gvcode" -eq 0 ]; then
+    echo "FAIL info/global: bare 'mach --version' unexpectedly succeeded" >&2
+    printf '%s\n' "$gvout" >&2; fail=1
+elif ! printf '%s' "$gvout" | grep -qF -- "unknown command '--version'"; then
+    echo "FAIL info/global: bare 'mach --version' is not handled as an unknown command" >&2
+    printf '%s\n' "$gvout" >&2; fail=1
+elif printf '%s' "$gvfirst" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "FAIL info/global: bare 'mach --version' printed a standalone version line" >&2
+    printf '%s\n' "$gvout" >&2; fail=1
+else
+    echo "PASS info/global: bare 'mach --version' is not a recognized version flag"
+fi
+
+exit "$fail"

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -24,6 +24,7 @@ matched exactly: `--flag value` (a value follows in the next argument) or a bare
 | `dep`   | manage git-backed dependencies (clone, lock, vendor) under `<dir_dep>` |
 | `init`  | scaffold a new project |
 | `doc`   | generate Markdown reference docs from source doc-comments |
+| `info`  | print compiler version, build host, and registered target capabilities |
 | `help`  | print usage; `mach help <command>` for detail |
 
 ## Global flags
@@ -299,6 +300,38 @@ hand-written `doc/language/` material is never touched.
 | `--target <name>`| name  | select a `[targets.<name>]` entry for module discovery |
 
 Plus the global flags. Exit codes: `0` ok, `1` user error, `2` internal error.
+
+## `mach info`
+
+```
+mach info [--version]
+```
+
+Prints an at-a-glance identity of the binary: its version, the host (`os/isa`)
+it was built for, and the registered capability surface — the instruction sets,
+operating systems, ABIs, and object formats it can compose into a target. This
+needs no project (it runs from anywhere, with or without a `mach.toml`). The
+output is line-oriented and stable for scripts:
+
+```
+mach 1.3.0
+host: linux/x86_64
+isa: x86_64 aarch64
+os: linux darwin windows
+abi: sysv win64
+object: elf macho coff
+```
+
+The version line and `host:` line fold at compile time; the four capability
+lines are read from the binary's target registries, so they report exactly what
+this build can target. `mach info --version` prints the version string alone on
+one line, for tooling.
+
+| Flag        | Value | Effect |
+|-------------|-------|--------|
+| `--version` | —     | print the version string alone, on one line |
+
+Exit codes: `0` ok, `2` internal error.
 
 ## `mach help`
 

--- a/src/cli/cmd.mach
+++ b/src/cli/cmd.mach
@@ -18,6 +18,7 @@ use cmd_check: mach.cli.cmd.check;
 use cmd_dep:   mach.cli.cmd.dep;
 use cmd_init:  mach.cli.cmd.init;
 use cmd_doc:   mach.cli.cmd.doc;
+use cmd_info:  mach.cli.cmd.info;
 use cmd_help:  mach.cli.cmd.help;
 
 # dispatch: route a CLI invocation to its subcommand handler.
@@ -40,6 +41,7 @@ pub fun dispatch(argc: usize, argv: **u8) i64 {
     if (str_equals(command, "dep"))   { ret cmd_dep.run(argc, argv); }
     if (str_equals(command, "init"))  { ret cmd_init.run(argc, argv); }
     if (str_equals(command, "doc"))   { ret cmd_doc.run(argc, argv); }
+    if (str_equals(command, "info"))  { ret cmd_info.run(argc, argv); }
     if (str_equals(command, "help"))  { ret cmd_help.run(argc, argv); }
 
     print.eprint("error: unknown command '");

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -12,6 +12,8 @@ use std.types.string.str_equals;
 
 use print: std.print;
 
+use version: mach.lang.version;
+
 # global_flags: the cross-cutting flags the shared config parser reads
 # (build, run, test, doc). printed under each command that honours them.
 fun global_flags() {
@@ -29,7 +31,9 @@ fun global_flags() {
 }
 
 fun top_level_usage() {
-    print.print("mach — the Mach compiler\n");
+    print.print("mach ");
+    print.print(version.string());
+    print.print(" — the Mach compiler\n");
     print.print("\n");
     print.print("usage: mach <command> [options]\n");
     print.print("\n");
@@ -41,6 +45,7 @@ fun top_level_usage() {
     print.print("  dep      manage project dependencies\n");
     print.print("  init     scaffold a new project\n");
     print.print("  doc      generate reference documentation\n");
+    print.print("  info     show compiler version and capabilities\n");
     print.print("  help     show this message\n");
     print.print("\n");
     global_flags();
@@ -147,6 +152,20 @@ fun help_doc() {
     print.print("exit: 0 ok, 1 user error, 2 internal error\n");
 }
 
+fun help_info() {
+    print.print("usage: mach info [--version]\n");
+    print.print("\n");
+    print.print("print the compiler version, the host (os/isa) this binary was built\n");
+    print.print("for, and the registered capability surface — the instruction sets,\n");
+    print.print("operating systems, ABIs, and object formats it can target. needs no\n");
+    print.print("project. the output is line-oriented and stable for scripts.\n");
+    print.print("\n");
+    print.print("options:\n");
+    print.print("  --version  print the version string alone, on one line\n");
+    print.print("\n");
+    print.print("exit: 0 ok, 2 internal error\n");
+}
+
 # run: `mach help` subcommand entry point. prints the top-level usage or a
 # subcommand detail page. called by cmd.dispatch, including its error path.
 # ---
@@ -167,6 +186,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     if (str_equals(sub, "dep"))   { help_dep();   ret 0; }
     if (str_equals(sub, "init"))  { help_init();  ret 0; }
     if (str_equals(sub, "doc"))   { help_doc();   ret 0; }
+    if (str_equals(sub, "info"))  { help_info();  ret 0; }
     if (str_equals(sub, "help"))  { top_level_usage(); ret 0; }
 
     print.print("error: unknown command '");

--- a/src/cli/cmd/info.mach
+++ b/src/cli/cmd/info.mach
@@ -1,0 +1,207 @@
+# mach.cli.cmd.info: `mach info` — at-a-glance compiler identity and capabilities.
+#
+# prints, one screen, line-oriented and stable for scripts: the compiler
+# version, the host (os/isa) this binary was built for, and the registered
+# capability surface — the instruction sets, operating systems, ABIs, and object
+# formats this binary can compose into a target. needs no project: the version
+# and host fold at compile time, and the capability surface is read from the
+# process-global target registries after a self-registration pass.
+#
+# `mach info --version` is the one-line version alias for tooling (the version
+# string alone). exit codes: 0 on success, 2 on an internal failure.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_equals;
+use std.types.option.Option;
+use std.types.option.is_some;
+use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
+
+use std.allocator.Allocator;
+
+use page:  std.allocator.page;
+use print: std.print;
+
+use intern:  mach.lang.intern;
+use tgt:     mach.lang.target;
+use isa:     mach.lang.target.isa;
+use os:      mach.lang.target.os;
+use abi:     mach.lang.target.abi;
+use of:      mach.lang.target.of;
+use version: mach.lang.version;
+
+# run: `mach info` subcommand entry point. with `--version` prints the version
+# alone; otherwise prints the full identity-and-capabilities screen.
+# ---
+# argc: argument count including argv[0]
+# argv: the argument vector (argc null-terminated byte pointers)
+# ret:  0 on success, 2 on an internal failure
+pub fun run(argc: usize, argv: **u8) i64 {
+    if (argc >= 3 && str_equals(argv[2]::str, "--version")) {
+        print.print(version.string());
+        print.print("\n");
+        ret 0;
+    }
+
+    # an interner is needed to name the registries: each vtable holds its name as
+    # an interned id, and register_all interns those into the interner it is given.
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) {
+        print.eprint("error: failed to initialise allocator\n");
+        ret 2;
+    }
+    var interner: intern.Interner = intern.init(?alloc);
+
+    val reg_r: Result[bool, str] = tgt.register_all(?interner);
+    if (is_err[bool, str](reg_r)) {
+        print.eprint("error: ");
+        print.eprint(unwrap_err[bool, str](reg_r));
+        print.eprint("\n");
+        intern.dnit(?interner);
+        ret 2;
+    }
+
+    print.print("mach ");
+    print.print(version.string());
+    print.print("\n");
+
+    # the host os/isa fold at compile time to the target this binary was built for.
+    print.print("host: ");
+    print.print(host_os());
+    print.print("/");
+    print.print(host_isa());
+    print.print("\n");
+
+    val code: i64 = print_capabilities(?interner);
+    intern.dnit(?interner);
+    ret code;
+}
+
+# host_os: the os name this binary was built for, folded at compile time. the
+# `$mach.target.os == $mach.os.*` comparison form is what the release seed can
+# fold (the value-context `$target.os` root only exists post-#1310). the final
+# branch is comptime-dead for the supported os set.
+fun host_os() str {
+    $if ($mach.target.os == $mach.os.linux)   { ret "linux"; }
+    $or ($mach.target.os == $mach.os.darwin)  { ret "darwin"; }
+    $or ($mach.target.os == $mach.os.windows) { ret "windows"; }
+    $or                                        { ret "unknown"; }
+}
+
+# host_isa: the isa name this binary was built for, folded at compile time. see
+# host_os for why the `$mach.arch.*` comparison form is used.
+fun host_isa() str {
+    $if ($mach.target.arch == $mach.arch.x86_64)  { ret "x86_64"; }
+    $or ($mach.target.arch == $mach.arch.aarch64) { ret "aarch64"; }
+    $or                                            { ret "unknown"; }
+}
+
+# print_capabilities: emit the four registry lines (isa / os / abi / object).
+# returns 0 on success, or 2 if a registered vtable's name is not interned —
+# an internal inconsistency, since register_all interned every name.
+fun print_capabilities(i: *intern.Interner) i64 {
+    if (is_err[bool, str](print_isa(i))) { ret cap_fail(); }
+    if (is_err[bool, str](print_os(i)))  { ret cap_fail(); }
+    if (is_err[bool, str](print_abi(i))) { ret cap_fail(); }
+    if (is_err[bool, str](print_of(i)))  { ret cap_fail(); }
+    ret 0;
+}
+
+# cap_fail: report a registry-name resolution failure and yield exit code 2.
+fun cap_fail() i64 {
+    print.eprint("error: a registered target component has no interned name\n");
+    ret 2;
+}
+
+# name_of: resolve a registry vtable's interned name. errors when the id is not
+# interned — register_all interns every name, so a miss is an internal bug, not
+# a value to paper over with a placeholder.
+fun name_of(i: *intern.Interner, id: intern.StrId) Result[str, str] {
+    val opt: Option[str] = intern.lookup(i, id);
+    if (is_some[str](opt)) { ret ok[str, str](unwrap[str](opt)); }
+    ret err[str, str]("name not interned");
+}
+
+# print_isa: list the registered instruction sets on one `isa:` line.
+fun print_isa(i: *intern.Interner) Result[bool, str] {
+    print.print("isa:");
+    var k: u32 = 0;
+    val n: u32 = isa.registered_count();
+    for (k < n) {
+        val vt_opt: Option[*isa.IsaVTable] = isa.registered(k);
+        if (is_some[*isa.IsaVTable](vt_opt)) {
+            val nm: Result[str, str] = name_of(i, unwrap[*isa.IsaVTable](vt_opt).name);
+            if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }
+            print.print(" ");
+            print.print(unwrap_ok[str, str](nm));
+        }
+        k = k + 1;
+    }
+    print.print("\n");
+    ret ok[bool, str](true);
+}
+
+# print_os: list the registered operating systems on one `os:` line.
+fun print_os(i: *intern.Interner) Result[bool, str] {
+    print.print("os:");
+    var k: u32 = 0;
+    val n: u32 = os.registered_count();
+    for (k < n) {
+        val vt_opt: Option[*os.OsVTable] = os.registered(k);
+        if (is_some[*os.OsVTable](vt_opt)) {
+            val nm: Result[str, str] = name_of(i, unwrap[*os.OsVTable](vt_opt).name);
+            if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }
+            print.print(" ");
+            print.print(unwrap_ok[str, str](nm));
+        }
+        k = k + 1;
+    }
+    print.print("\n");
+    ret ok[bool, str](true);
+}
+
+# print_abi: list the registered calling conventions on one `abi:` line.
+fun print_abi(i: *intern.Interner) Result[bool, str] {
+    print.print("abi:");
+    var k: u32 = 0;
+    val n: u32 = abi.registered_count();
+    for (k < n) {
+        val vt_opt: Option[*abi.AbiVTable] = abi.registered(k);
+        if (is_some[*abi.AbiVTable](vt_opt)) {
+            val nm: Result[str, str] = name_of(i, unwrap[*abi.AbiVTable](vt_opt).name);
+            if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }
+            print.print(" ");
+            print.print(unwrap_ok[str, str](nm));
+        }
+        k = k + 1;
+    }
+    print.print("\n");
+    ret ok[bool, str](true);
+}
+
+# print_of: list the registered object formats on one `object:` line.
+fun print_of(i: *intern.Interner) Result[bool, str] {
+    print.print("object:");
+    var k: u32 = 0;
+    val n: u32 = of.registered_count();
+    for (k < n) {
+        val vt_opt: Option[*of.OfVTable] = of.registered(k);
+        if (is_some[*of.OfVTable](vt_opt)) {
+            val nm: Result[str, str] = name_of(i, unwrap[*of.OfVTable](vt_opt).name);
+            if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }
+            print.print(" ");
+            print.print(unwrap_ok[str, str](nm));
+        }
+        k = k + 1;
+    }
+    print.print("\n");
+    ret ok[bool, str](true);
+}

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -72,6 +72,7 @@ use resolve:  mach.lang.fe.resolve;
 use os:  mach.lang.target.os;
 use isa: mach.lang.target.isa;
 use tgt: mach.lang.target;
+use version: mach.lang.version;
 
 use sysos:    std.system.os;
 use manifest: mach.lang.manifest;
@@ -1532,15 +1533,10 @@ fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     if (is_err[intern.StrId, str](rcn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rcn)); }
     p.compiler_name = unwrap_ok[intern.StrId, str](rcn);
 
-    # the `$project.version` root (#1217) now folds the manifest version, so the
-    # one-file release bump becomes `val rcv = $project.version;`. the flip is
-    # staged, not yet applied: the compiler is self-hosted by seeding from the
-    # most recent release (ci.yml `mach build .`), and that seed cannot fold
-    # `$project.version` until a release ships these roots. flipping now would
-    # make the seed fail to compile this file. the literal — kept in sync with
-    # `[project].version` in mach.toml — stays until the next release seed
-    # understands the root, at which point #1217's driver replacement lands.
-    val rcv: Result[intern.StrId, str] = intern.intern(?p.s.interner, "1.3.0");
+    # the compiler version is single-sourced in `mach.lang.version`; both this
+    # `$mach.compiler.version` feed and `mach info` read it through one function,
+    # so the staged `$project.version` flip (#1311) touches a single place.
+    val rcv: Result[intern.StrId, str] = intern.intern(?p.s.interner, version.string());
     if (is_err[intern.StrId, str](rcv)) { ret err[bool, str](unwrap_err[intern.StrId, str](rcv)); }
     p.compiler_ver = unwrap_ok[intern.StrId, str](rcv);
 

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -13,6 +13,7 @@ use std.types.result.is_err;
 use std.types.result.unwrap_err;
 use std.types.option.Option;
 use std.types.option.is_none;
+use std.types.option.is_some;
 use std.types.option.unwrap;
 
 use std.types.string.str;
@@ -20,6 +21,9 @@ use std.types.string.str;
 use std.types.bool.bool;
 use std.types.bool.true;
 
+use std.allocator.Allocator;
+
+use page:   std.allocator.page;
 use intern: mach.lang.intern;
 
 use tdef: mach.lang.target.resolved;
@@ -214,4 +218,36 @@ pub fun select(os_id: u32, arch_id: u32) Result[tdef.Target, str] {
     t.of      = unwrap[*of.OfVTable](of_vt);
 
     ret ok[tdef.Target, str](t);
+}
+
+# enumeration helpers (registered_count / registered) must agree with the
+# id-keyed lookups after register_all, and report none past the count. the
+# `mach info` capability surface reads the registries through exactly this pair.
+test "target: registry enumeration agrees with lookup (#1312)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val rr: Result[bool, str] = register_all(?i);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    # the supported implementations are all enumerable.
+    if (isa.registered_count() < 2) { ret 1; }
+    if (os.registered_count()  < 3) { ret 1; }
+    if (abi.registered_count() < 2) { ret 1; }
+    if (of.registered_count()  < 3) { ret 1; }
+
+    # every enumerated isa slot is present and agrees with id-keyed lookup;
+    # one past the count, enumeration reports none.
+    var k: u32 = 0;
+    val n: u32 = isa.registered_count();
+    for (k < n) {
+        val e: Option[*isa.IsaVTable] = isa.registered(k);
+        if (!is_some[*isa.IsaVTable](e)) { ret 1; }
+        if (!is_some[*isa.IsaVTable](isa.lookup(unwrap[*isa.IsaVTable](e).id))) { ret 1; }
+        k = k + 1;
+    }
+    if (is_some[*isa.IsaVTable](isa.registered(n))) { ret 1; }
+
+    ret 0;
 }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -240,6 +240,38 @@ pub fun lookup(abi_id: u32) Option[*AbiVTable] {
     ret some[*AbiVTable](abi_registry[abi_id]);
 }
 
+# registered_count: the number of ABI implementations currently registered.
+# ret: count of non-empty registry slots
+pub fun registered_count() u32 {
+    ensure_abi_registry();
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < ABI_REGISTRY_CAP) {
+        if (abi_registry[i] != nil) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# registered: the ABI vtable at enumeration index `idx` (0-based, in id order),
+# skipping empty slots. pairs with registered_count to walk the registry.
+# ---
+# idx: enumeration index in [0, registered_count)
+# ret: the vtable at that index, or none when idx is out of range
+pub fun registered(idx: u32) Option[*AbiVTable] {
+    ensure_abi_registry();
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < ABI_REGISTRY_CAP) {
+        if (abi_registry[i] != nil) {
+            if (n == idx) { ret some[*AbiVTable](abi_registry[i]); }
+            n = n + 1;
+        }
+        i = i + 1;
+    }
+    ret none[*AbiVTable]();
+}
+
 # whole-signature ABI layout: the placement of a function's return value and
 # each of its fixed parameters, classified together in one left-to-right walk so
 # the running GP/FP register and stack cursors stay coherent across the return's

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -351,6 +351,38 @@ pub fun lookup(arch_id: u32) Option[*IsaVTable] {
     ret some[*IsaVTable](isa_registry[arch_id]);
 }
 
+# registered_count: the number of ISA implementations currently registered.
+# ret: count of non-empty registry slots
+pub fun registered_count() u32 {
+    ensure_isa_registry();
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < ISA_REGISTRY_CAP) {
+        if (isa_registry[i] != nil) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# registered: the ISA vtable at enumeration index `idx` (0-based, in id order),
+# skipping empty slots. pairs with registered_count to walk the registry.
+# ---
+# idx: enumeration index in [0, registered_count)
+# ret: the vtable at that index, or none when idx is out of range
+pub fun registered(idx: u32) Option[*IsaVTable] {
+    ensure_isa_registry();
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < ISA_REGISTRY_CAP) {
+        if (isa_registry[i] != nil) {
+            if (n == idx) { ret some[*IsaVTable](isa_registry[i]); }
+            n = n + 1;
+        }
+        i = i + 1;
+    }
+    ret none[*IsaVTable]();
+}
+
 val INSTBUF_INIT_CAP: i32 = 64;
 
 # buf_init: construct an empty instruction buffer.

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -423,6 +423,39 @@ pub fun lookup(of_id: u32) Option[*OfVTable] {
     ret some[*OfVTable](of_registry[of_id]);
 }
 
+# registered_count: the number of object-format implementations registered.
+# ret: count of non-empty registry slots
+pub fun registered_count() u32 {
+    ensure_of_registry();
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < OF_REGISTRY_CAP) {
+        if (of_registry[i] != nil) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# registered: the object-format vtable at enumeration index `idx` (0-based, in
+# id order), skipping empty slots. pairs with registered_count to walk the
+# registry.
+# ---
+# idx: enumeration index in [0, registered_count)
+# ret: the vtable at that index, or none when idx is out of range
+pub fun registered(idx: u32) Option[*OfVTable] {
+    ensure_of_registry();
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < OF_REGISTRY_CAP) {
+        if (of_registry[i] != nil) {
+            if (n == idx) { ret some[*OfVTable](of_registry[i]); }
+            n = n + 1;
+        }
+        i = i + 1;
+    }
+    ret none[*OfVTable]();
+}
+
 # reloc_kind_name: the interned abstract relocation-kind name an `RK_*` id maps
 # to in a format vtable's `relocation_kinds` table — the StrId a `Relocation.kind`
 # must carry so the format writer matches it. returns intern.STR_NIL for a nil

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -126,3 +126,35 @@ pub fun lookup(os_id: u32) Option[*OsVTable] {
     if (os_registry[os_id] == nil) { ret none[*OsVTable](); }
     ret some[*OsVTable](os_registry[os_id]);
 }
+
+# registered_count: the number of OS implementations currently registered.
+# ret: count of non-empty registry slots
+pub fun registered_count() u32 {
+    ensure_os_registry();
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < OS_REGISTRY_CAP) {
+        if (os_registry[i] != nil) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# registered: the OS vtable at enumeration index `idx` (0-based, in id order),
+# skipping empty slots. pairs with registered_count to walk the registry.
+# ---
+# idx: enumeration index in [0, registered_count)
+# ret: the vtable at that index, or none when idx is out of range
+pub fun registered(idx: u32) Option[*OsVTable] {
+    ensure_os_registry();
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < OS_REGISTRY_CAP) {
+        if (os_registry[i] != nil) {
+            if (n == idx) { ret some[*OsVTable](os_registry[i]); }
+            n = n + 1;
+        }
+        i = i + 1;
+    }
+    ret none[*OsVTable]();
+}

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -1,0 +1,15 @@
+# mach.lang.version: the compiler's own version string — the single source of
+# truth read by the driver (for `$mach.compiler.version`) and by `mach info`.
+#
+# the `$project.version` flip (#1311) lands here: once a release seed can fold
+# the root, this body becomes `ret $project.version;` and every consumer tracks
+# the manifest with no further edits. until then the literal is hand-synced with
+# `[project].version` in mach.toml. routing both consumers through this one
+# function is what keeps that flip a single-line change.
+
+use std.types.string.str;
+
+# string: the compiler version (e.g. "1.3.0").
+pub fun string() str {
+    ret "1.3.0";
+}


### PR DESCRIPTION
Closes #1312.

Adds `mach info`: an at-a-glance, project-less, script-stable identity of the binary.

## Output (sample, from an empty dir)

```
mach 1.3.0
host: linux/x86_64
isa: x86_64 aarch64
os: linux darwin windows
abi: sysv win64
object: elf macho coff
```

- **version** — single-sourced in the new `mach.lang.version`; the driver's `$mach.compiler.version` feed and `mach info` both read `version.string()`, so the staged `$project.version` flip (#1311) touches one place.
- **host** — `os/isa` this binary was built for, folded at compile time. Uses the `$mach.target.os == $mach.os.*` comparison form (the release seed CI's Full Build uses cannot fold the value-context `$target.os` root, which only landed in #1310 / dev). The windows cross-build folds `host: windows/x86_64`.
- **capability surface** — isa / os / abi / object lines read from the process-global target registries, answering "which targets can this binary build". Each registry gained `registered_count`/`registered` enumeration helpers.

## CLI surface

- `mach info --version` — the version string alone, one line, for tooling.
- bare `mach` usage banner header now surfaces the version (`mach 1.3.0 — the Mach compiler`).
- per the maintainer amendment: there is **no** global `mach --version` flag; bare `mach --version` falls through to the normal unknown-command/usage path (non-zero), not a version line.
- wired into `cmd.dispatch`, `mach help` (top-level + `help info` page), and `doc/cli.md`.

## Tests

- inline `test` in `target.mach`: registry enumeration agrees with id-keyed lookup and reports none past the count.
- `.github/tests/info/run.sh`: from an empty temp dir asserts `mach info` exit 0 + the six expected lines, `mach info --version` is one bare version line, the bare banner surfaces the version, and bare `mach --version` is unrecognized.

## Verification

- `mach build .` clean; **strong fixpoint** (stage1 == stage2 == stage3, identical sha256).
- `mach test .` — 346 PASS, 0 fail.
- full integration battery (all 20 `.github/tests/*/run.sh`, incl. windows cross-compile + wine win64 suites) — all green.
- windows cross-build runs under wine from an empty dir, folds `host: windows/x86_64`.
