### PR TITLE
fix(comptime): fold module-qualified constant paths in global initialisers (#1290) + span the rejection (#1289)

### DIFF
--- a/.github/tests/globalmember/fold/mach.toml
+++ b/.github/tests/globalmember/fold/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "gmemberfold"
+name = "Global member fold — module-qualified constant paths fold in global initialisers (#1290)"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/gmemberfold"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/globalmember/fold/src/flags.mach
+++ b/.github/tests/globalmember/fold/src/flags.mach
@@ -1,0 +1,17 @@
+# a `shared`-style module of clone-flag constants, mirroring the
+# std.system.os.linux.shared shape #1290 is about. each is a plain comptime
+# constant the importer reaches through a module alias.
+use std.types.size.usize;
+
+pub val CLONE_VM:      usize = 256;
+pub val CLONE_FS:      usize = 512;
+pub val CLONE_FILES:   usize = 1024;
+pub val CLONE_SIGHAND: usize = 2048;
+pub val CLONE_THREAD:  usize = 65536;
+pub val CLONE_SYSVSEM: usize = 262144;
+
+# chained constants: built from other module-level constants in THIS module and
+# pre-folded here, so an aliased importer that reads `flags.CLONE_BASE` /
+# `flags.CLONE_ALL` gets the folded value (the chained-constant case of #1290).
+pub val CLONE_BASE: usize = CLONE_VM | CLONE_FS;
+pub val CLONE_ALL:  usize = CLONE_BASE | CLONE_FILES | CLONE_SIGHAND;

--- a/.github/tests/globalmember/fold/src/main.mach
+++ b/.github/tests/globalmember/fold/src/main.mach
@@ -1,0 +1,26 @@
+use std.runtime.linux.x86_64;
+use std.types.size.usize;
+use flags: gmemberfold.flags;
+
+# the exact mach-std THREAD_CLONE_FLAGS shape (#1290): a global folded from
+# aliased module-qualified constant paths. before #1290 this failed with
+# "a global initialiser must be a constant expression"; mach-std worked around
+# it by importing each constant unaliased so the bare names bound into the
+# comptime env. 256|512|1024|2048|65536|262144 = 331520.
+val THREAD_CLONE_FLAGS: usize =
+    flags.CLONE_VM | flags.CLONE_FS | flags.CLONE_FILES
+  | flags.CLONE_SIGHAND | flags.CLONE_THREAD | flags.CLONE_SYSVSEM;
+
+# an aliased chained constant OR an aliased leaf: (256|512)|1024 = 1792.
+val CHAINED: usize = flags.CLONE_BASE | flags.CLONE_FILES;
+
+# a single aliased member that is itself a chained constant: (256|512)|1024|2048 = 3840.
+val ALL_VIA_ALIAS: usize = flags.CLONE_ALL;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    if (THREAD_CLONE_FLAGS != 331520) { ret 1; }
+    if (CHAINED != 1792) { ret 2; }
+    if (ALL_VIA_ALIAS != 3840) { ret 3; }
+    ret 0;
+}

--- a/.github/tests/globalmember/reject/mach.toml
+++ b/.github/tests/globalmember/reject/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "gmemberreject"
+name = "Global member reject — a non-constant module-qualified member path errors with a span (#1290, #1289)"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/gmemberreject"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/globalmember/reject/src/flags.mach
+++ b/.github/tests/globalmember/reject/src/flags.mach
@@ -1,0 +1,7 @@
+use std.types.size.usize;
+
+# a pub `var` is mutable state, not a comptime constant, so it is never
+# registered in this module's comptime context. an importer that reads it
+# through a module alias in a global initialiser must be rejected — the scope
+# guard for #1290 is "module-level constants only".
+pub var COUNTER: usize = 0;

--- a/.github/tests/globalmember/reject/src/main.mach
+++ b/.github/tests/globalmember/reject/src/main.mach
@@ -1,0 +1,14 @@
+use std.runtime.linux.x86_64;
+use std.types.size.usize;
+use flags: gmemberreject.flags;
+
+# `flags.COUNTER` resolves to a module-level `var`, not a comptime constant, so
+# this global initialiser is not foldable. it must be rejected with a diagnostic
+# that is LOCATED on the binding and names the symbol (#1289) — never a fileless
+# "a global initialiser must be a constant expression" abort.
+val NOT_CONST: usize = flags.COUNTER;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret NOT_CONST::i64;
+}

--- a/.github/tests/globalmember/run.sh
+++ b/.github/tests/globalmember/run.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# module-qualified constant paths in global initialisers (#1290) and the span on
+# their rejection (#1289). two halves:
+#
+#   fold — a global folded from aliased `alias.CONST` member paths must compile.
+#   the `fold` app reproduces the exact mach-std THREAD_CLONE_FLAGS shape (a
+#   global OR-ed from clone-flag constants reached through a module alias) plus
+#   chained constants (an aliased member that is itself built from other
+#   constants), and asserts every folded value at runtime, exiting 0 only when
+#   all match. before #1290 this failed with "a global initialiser must be a
+#   constant expression"; mach-std worked around it with unaliased imports.
+#
+#   reject — a module-qualified member that does NOT name a module-level constant
+#   (a pub `var`) must still be rejected, and the diagnostic must carry the file,
+#   line, and symbol name (#1289), never the old fileless abort. the `reject`
+#   app's build must fail with a located, named diagnostic.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# vendor <app-dir>: copy the app into the temp dir and symlink the vendored std.
+vendor() {
+    local app="$1"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+}
+
+# build_and_run <app-dir> <expected-exit>: build the app, run the binary, and
+# require the build to succeed and the run to exit with the expected code.
+build_and_run() {
+    local app="$1"; local want="$2"
+    vendor "$app"
+    local dst="$WORK/$app"
+    if ! ( cd "$dst" && "$MACH" build . ) >/dev/null 2>&1; then
+        echo "FAIL globalmember/$app: build failed" >&2; fail=1; return
+    fi
+    local bin
+    bin="$(find "$dst/out" -type f -path '*/bin/*' | head -n1)"
+    if [ -z "$bin" ]; then
+        echo "FAIL globalmember/$app: no binary produced" >&2; fail=1; return
+    fi
+    set +e
+    "$bin"; local code=$?
+    set -e
+    if [ "$code" -ne "$want" ]; then
+        echo "FAIL globalmember/$app: ran with exit $code, expected $want" >&2; fail=1; return
+    fi
+    echo "PASS globalmember/$app: aliased module-qualified constants fold in global initialisers"
+}
+
+# expect_reject <app-dir>: build the app and require the build to FAIL with a
+# diagnostic that is located on the binding (file:line:col) AND names the symbol
+# (#1289), never the old fileless "a global initialiser must be a constant
+# expression" abort.
+expect_reject() {
+    local app="$1"
+    vendor "$app"
+    local dst="$WORK/$app"
+    local out
+    if out="$( cd "$dst" && "$MACH" build . 2>&1 )"; then
+        echo "FAIL globalmember/$app: build unexpectedly succeeded for a non-constant member path" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF -- 'global initialiser of `NOT_CONST` must be a constant expression'; then
+        echo "FAIL globalmember/$app: diagnostic missing the symbol name; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qE 'main\.mach:[0-9]+:[0-9]+:'; then
+        echo "FAIL globalmember/$app: diagnostic missing file:line:col; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    echo "PASS globalmember/$app: a non-constant member path is rejected with a located, named diagnostic"
+}
+
+build_and_run fold 0
+expect_reject reject
+
+exit "$fail"

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -117,6 +117,27 @@ pub rec NamedConst {
     value: CTValue;
 }
 
+# ModuleMemberFn: resolves a module-qualified member path (`alias.CONST`) to its
+# comptime value, or none when the path does not name a module-level comptime
+# constant. eval owns the MEMBER dispatch but cannot depend on name resolution
+# without an import cycle, so the resolution-owning layer (lowering) installs
+# this hook with `set_member_resolver`. the first argument is the installer's
+# opaque context; the second is the MEMBER expression id, valid in the ast eval
+# is currently walking.
+pub def ModuleMemberFn: fun(ptr, id.ExprId) Result[Option[CTValue], str];
+
+# COMPTIME_MEMBER_NO_RESOLVER_MSG: surfaced when a module-qualified member path
+# is evaluated in a context that installed no member resolver — name resolution
+# is not available before lowering, so such a path cannot fold there.
+pub val COMPTIME_MEMBER_NO_RESOLVER_MSG: str =
+    "a module-qualified member path is only comptime-evaluable after name resolution";
+
+# COMPTIME_MEMBER_NOT_CONST_MSG: surfaced when a module-qualified member path
+# resolves but does not name a module-level comptime constant (a function, a
+# `var`, a non-constant `val`, or an unexported / unknown member).
+pub val COMPTIME_MEMBER_NOT_CONST_MSG: str =
+    "module-qualified member does not name a module-level constant";
+
 # FrameMark: an opaque entries-array depth, returned by `frame_open` and passed
 # to `frame_close` to pop exactly the bindings introduced after the mark.
 pub def FrameMark: u32;
@@ -162,6 +183,9 @@ pub def FrameMark: u32;
 # target_abi:     interned selected-target abi name, read by `$target.abi`
 # bin_name:       interned name of the artifact being built, read by `$bin.name`;
 #                 STR_NIL when no single artifact is selected (v1 manifests)
+# member_fn:      erased ModuleMemberFn resolving `alias.CONST` member paths, or
+#                 nil when no resolver is installed (every pass before lowering)
+# member_data:    opaque context passed to member_fn (the *LowerContext)
 pub rec ComptimeCtx {
     alloc:          *Allocator;
     target_os_id:   u32;
@@ -183,6 +207,8 @@ pub rec ComptimeCtx {
     target_isa:     intern.StrId;
     target_abi:     intern.StrId;
     bin_name:       intern.StrId;
+    member_fn:      *u8;
+    member_data:    ptr;
 }
 
 val INITIAL_CONST_CAP: u32 = 8;
@@ -236,7 +262,23 @@ pub fun init(
     c.target_isa     = intern.STR_NIL;
     c.target_abi     = intern.STR_NIL;
     c.bin_name       = intern.STR_NIL;
+    c.member_fn      = nil;
+    c.member_data    = nil;
     ret c;
+}
+
+# set_member_resolver: install (or clear) the `alias.CONST` member resolver this
+# context consults when comptime.eval meets a module-qualified member path.
+# lowering installs it pointing at the active LowerContext; passing `nil` for
+# both clears it. kept out of the build/target setters because it is per-pass
+# state, not manifest-derived.
+# ---
+# c:    context to update
+# fn:   erased ModuleMemberFn, or nil to clear
+# data: opaque context handed back to fn, or nil to clear
+pub fun set_member_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
+    c.member_fn   = fn;
+    c.member_data = data;
 }
 
 # set_build_context: bind the manifest-derived project metadata, the selected
@@ -472,8 +514,12 @@ pub fun eval(
     if (k == expr.EXPR_KIND_COMPTIME_IDENT) {
         ret err[CTValue, str](COMPTIME_BARE_IDENT_MSG);
     }
+    # a `$`-rooted MEMBER chain (`$mach.target.os`) is a builtin comptime path;
+    # a plain-identifier root (`alias.CONST`) is a module-qualified member path
+    # resolved through the installed member resolver.
     if (k == expr.EXPR_KIND_MEMBER) {
-        ret eval_path(c, a, source, e, interner);
+        if (is_comptime_path(a, e)) { ret eval_path(c, a, source, e, interner); }
+        ret eval_module_member(c, e);
     }
 
     if (k == expr.EXPR_KIND_CALL)       { ret err[CTValue, str]("function calls are not comptime-evaluable"); }
@@ -1095,6 +1141,22 @@ fun eval_ident(
         ret err[CTValue, str]("identifier is not a comptime constant in scope");
     }
     ret ok[CTValue, str](unwrap[*NamedConst](nc_opt).value);
+}
+
+# eval_module_member: folds a module-qualified member path (`alias.CONST`) by
+# delegating to the installed member resolver, which consults name resolution
+# for the member's symbol and returns the declaring module's pre-folded comptime
+# value. an evaluation context with no resolver (every pass before lowering) and
+# a member that does not name a module-level constant both surface a loud error
+# rather than a silent fold.
+fun eval_module_member(c: *ComptimeCtx, e: id.ExprId) Result[CTValue, str] {
+    if (c.member_fn == nil) { ret err[CTValue, str](COMPTIME_MEMBER_NO_RESOLVER_MSG); }
+    val fn: ModuleMemberFn = c.member_fn::ModuleMemberFn;
+    val r: Result[Option[CTValue], str] = fn(c.member_data, e);
+    if (is_err[Option[CTValue], str](r)) { ret err[CTValue, str](unwrap_err[Option[CTValue], str](r)); }
+    val o: Option[CTValue] = unwrap_ok[Option[CTValue], str](r);
+    if (is_some[CTValue](o)) { ret ok[CTValue, str](unwrap[CTValue](o)); }
+    ret err[CTValue, str](COMPTIME_MEMBER_NOT_CONST_MSG);
 }
 
 # reports whether `e` is a comptime path expression: a bare COMPTIME_IDENT

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -257,6 +257,10 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
     lc.subst       = nil;
     lc.subst_len   = 0;
 
+    # the origin ctx folds this body's `alias.CONST` paths against the origin
+    # module's name resolution, now active on lc.
+    comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
+
     # open a frame on the ORIGIN context and bind the `$param -> CTValue`
     # bindings into it; the frame is closed afterward (on the error path too) so
     # EXACTLY these bindings are popped. innermost-wins lookup makes a param
@@ -370,6 +374,10 @@ fun emit_one_instance(lc: *lctx.LowerContext, s: *sess.Session,
     lc.own_module  = origin;
     lc.subst       = args;
     lc.subst_len   = arg_len;
+
+    # the origin ctx folds this body's `alias.CONST` paths against the origin
+    # module's name resolution, now active on lc.
+    comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
 
     val lr: Result[bool, str] = decl.lower_instance(lc, decl_id, d, name);
     lc.ctx        = home_ctx;

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -237,6 +237,12 @@ pub fun init_context(
     lc.ctx         = ctx;
     lc.m           = m;
     lc.builder     = builder.init(m);
+
+    # install the `alias.CONST` member resolver so comptime.eval can fold module-
+    # qualified constant paths in this module's initialisers and gates. data is
+    # the LowerContext itself, read live so the value-instance drains' module
+    # swaps stay correct.
+    comptime.set_member_resolver(ctx, resolve_module_member_const::*u8, lc::ptr);
     lc.locals      = map.init[resolve.SymbolId, value.Value](s.alloc, maphash.hash_u32, maphash.eq_u32);
     lc.local_names = map.init[intern.StrId, value.Value](s.alloc, maphash.hash_u32, maphash.eq_u32);
 
@@ -278,12 +284,15 @@ pub fun init_context(
 }
 
 # releases the working storage held by a LowerContext (the locals map and
-# the loop / fin stacks). does not touch the borrowed phase inputs or the
-# module.
+# the loop / fin stacks) and clears the member resolver init_context installed
+# on the comptime ctx, so the borrowed ctx never keeps a dangling LowerContext
+# pointer past this module's lowering. does not otherwise touch the borrowed
+# phase inputs or the module.
 # ---
 # lc: context to tear down
 pub fun dnit_context(lc: *LowerContext) {
     if (lc == nil) { ret; }
+    if (lc.ctx != nil) { comptime.set_member_resolver(lc.ctx, nil, nil); }
     map.dnit[intern.StrId, value.Value](?lc.local_names);
     map.dnit[resolve.SymbolId, value.Value](?lc.locals);
     if (lc.loops != nil && lc.loop_cap > 0) {
@@ -328,6 +337,47 @@ pub fun dnit_context(lc: *LowerContext) {
     lc.vinsts    = nil;
     lc.vinst_len = 0;
     lc.vinst_cap = 0;
+}
+
+# resolve_module_member_const: the `alias.CONST` member resolver lowering
+# installs on every ComptimeCtx it evaluates against (a comptime.ModuleMemberFn).
+# given a module-qualified member expression, it reads the active module's name
+# resolution for the member's resolved symbol; when that symbol is a constant
+# imported from another module, it returns the constant's pre-folded comptime
+# value from the declaring module's ComptimeCtx. it returns none — leaving
+# comptime.eval to reject the path with a loud error — whenever the member
+# resolves to anything else (a function, a `var`, a non-constant `val`, or an
+# unexported / unknown member): the declaring module's ctx holds exactly its
+# transitively-constant module-level vals, so a lookup miss there is the scope
+# guard for everything that is not a constant. `data` is the *LowerContext
+# driving the evaluation; reading its `rr` / `s` live keeps the resolver correct
+# across the value-instance drains that swap the active module.
+# ---
+# data: the *LowerContext, erased to a ptr by the installer
+# eid:  the MEMBER expression id, valid in the active module's ast
+# ret:  some(value) when the member names a module-level constant, else none
+pub fun resolve_module_member_const(data: ptr, eid: aid.ExprId) Result[Option[comptime.CTValue], str] {
+    val lc: *LowerContext = data::*LowerContext;
+    if (lc == nil) { ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]()); }
+    val rr: *resolve.ResolveResult = lc.rr;
+    if (rr == nil || rr.expr_resolved == nil || eid::u32 >= rr.expr_count) {
+        ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]());
+    }
+    val sid: resolve.SymbolId = rr.expr_resolved[eid];
+    if (sid == resolve.SYMBOL_NIL || sid::u32 >= rr.symbol_count) {
+        ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]());
+    }
+    val sym: *resolve.Symbol = ?rr.symbols[sid];
+    if (sym.kind != resolve.SYM_IMPORTED) {
+        ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]());
+    }
+    val octx: *comptime.ComptimeCtx = (sess.module_comptime_ptr(lc.s, sym.origin))::*comptime.ComptimeCtx;
+    if (octx == nil) { ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]()); }
+    val nc: Option[*comptime.NamedConst] = comptime.lookup(octx, sym.name);
+    if (is_none[*comptime.NamedConst](nc)) {
+        ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]());
+    }
+    ret ok[Option[comptime.CTValue], str](some[comptime.CTValue](unwrap[*comptime.NamedConst](nc).value));
 }
 
 # resets the per-function working state before lowering a new function:

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -17,6 +17,8 @@ use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
+use std.types.char.char;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
@@ -39,6 +41,7 @@ use map: std.collections.map;
 use maphash: std.collections.map;
 
 use intern:   mach.lang.intern;
+use mem:      std.memory;
 use ty:       mach.lang.type;
 use sess:     mach.lang.session;
 use token:    mach.lang.fe.token;
@@ -474,7 +477,9 @@ fun terminate_orphan_blocks(ctx: *lower.LowerContext) Result[bool, str] {
 # lowers a module-level `val` / `var` into an IR `Global`. the initialiser is
 # folded to a constant `Value` by `fold_global_init`; a global with no
 # initialiser holds a zero placeholder. a present-but-non-constant initialiser
-# is a hard error — there is no runtime init-synthesis pass to fill it later.
+# is a build error — there is no runtime init-synthesis pass to fill it later —
+# reported as a diagnostic located on the binding's name (#1289) that gates the
+# build, with a zero placeholder emitted so references still resolve.
 # ---
 # ctx:    the context
 # did:    the binding's DeclId
@@ -497,8 +502,18 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
     var init_val: value.Value = value.const_int(0, gty);
     if (d.data.bind.init != aid.EXPR_NIL) {
         val fr: Result[value.Value, str] = fold_global_init(ctx, d.data.bind.init, gty);
-        if (is_err[value.Value, str](fr)) { ret err[bool, str](unwrap_err[value.Value, str](fr)); }
-        init_val = unwrap_ok[value.Value, str](fr);
+        if (is_err[value.Value, str](fr)) {
+            # a non-constant initialiser is a build error, but it is located on the
+            # binding's name and names the symbol (#1289) rather than aborting with
+            # a bare, fileless message. the diagnostic gates the build; a zero
+            # placeholder is still emitted so any reference to this global resolves
+            # against a real symbol instead of cascading into spurious errors.
+            val de: Result[bool, str] = report_global_init_error(ctx, d.data.bind.name, bare);
+            if (is_err[bool, str](de)) { ret err[bool, str](unwrap_err[bool, str](de)); }
+        }
+        or {
+            init_val = unwrap_ok[value.Value, str](fr);
+        }
     }
 
     var g: ir.Global;
@@ -566,6 +581,48 @@ fun fold_global_init(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_type.IrT
     }
 
     ret err[value.Value, str]("lower: a global initialiser must be a constant expression");
+}
+
+# emits the source-located diagnostic for a global whose initialiser no constant
+# path could fold (#1289). the binding's name span supplies the file / line and
+# the message names the symbol, so the report points at the offending decl
+# instead of the fileless `lower: a global initialiser must be a constant
+# expression` abort that cost a multi-hour misdiagnosis. a failure to look up the
+# interned name degrades to the unnamed message rather than dropping the report.
+# ---
+# ctx:       the context
+# name_span: the binding's name span (locates the diagnostic)
+# bare:      the binding's interned bare name (named in the message)
+# ret:       true once the diagnostic is recorded, or an allocation error
+fun report_global_init_error(ctx: *lower.LowerContext, name_span: token.Span, bare: intern.StrId) Result[bool, str] {
+    val prefix: str = "global initialiser of `";
+    val suffix: str = "` must be a constant expression";
+
+    val no: Option[str] = intern.lookup(?ctx.s.interner, bare);
+    if (is_none[str](no)) {
+        ret diag.error(?ctx.s.diags, ctx.a.file_id, name_span, "a global initialiser must be a constant expression");
+    }
+    val name: str = unwrap[str](no);
+
+    val pn: usize = str_len(prefix);
+    val nn: usize = str_len(name);
+    val sn: usize = str_len(suffix);
+    val total: usize = pn + nn + sn;
+
+    val r: Result[*char, str] = allocate[char](ctx.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        ret diag.error(?ctx.s.diags, ctx.a.file_id, name_span, "a global initialiser must be a constant expression");
+    }
+    val buf: str = unwrap_ok[*char, str](r);
+
+    mem.raw_copy(buf::ptr, prefix::ptr, pn);
+    mem.raw_copy((buf::usize + pn)::ptr, name::ptr, nn);
+    mem.raw_copy((buf::usize + pn + nn)::ptr, suffix::ptr, sn);
+    buf[total] = 0;
+
+    val emit: Result[bool, str] = diag.error(?ctx.s.diags, ctx.a.file_id, name_span, buf);
+    deallocate[char](ctx.s.alloc, buf, total + 1);
+    ret emit;
 }
 
 # lowers a decl-scope `$if` chain: evaluates each arm's condition and


### PR DESCRIPTION
## Summary

Two sibling issues, one fix at the comptime/lowering seam.

### #1290 — `alias.CONST` paths fold in global initialisers

`val THREAD_CLONE_FLAGS: usize = shared.CLONE_VM | shared.CLONE_FS | ...;` now folds. `comptime.eval` previously routed every MEMBER expression to `eval_path`, which only accepts `$`-rooted builtin paths (`$mach.*`, `$project.*`, ...), so a module-qualified `alias.CONST` member path was never comptime-evaluable. mach-std worked around it by importing each clone-flag constant unaliased so the bare names bound into the comptime env.

The fix splits the MEMBER dispatch in `eval`:
- a `$`-rooted chain stays a builtin comptime path (`eval_path`);
- a plain-identifier root (`alias.CONST`) is resolved through an **installable member resolver** (`comptime.ModuleMemberFn`).

`comptime.mach` owns the dispatch but cannot import `resolve` without a cycle, so **lowering installs the resolver** (`resolve_module_member_const`): it reads the active module's name resolution for the member's resolved symbol and returns the **declaring module's pre-folded comptime value** from that module's `ComptimeCtx`. This is the single-owner resolution path the issue asks for — sema/resolve already know what `shared.CLONE_VM` is, and the const-fold now asks.

**Scope guard:** the declaring module's comptime ctx holds exactly its transitively-constant module-level vals, so a lookup miss there is the guard for everything that is not a constant (a function, a `var`, a non-constant `val`, an unexported/unknown member) — each stays a loud error.

The resolver is reinstalled at every value-instance drain swap (so it tracks the active module) and cleared on teardown (so the borrowed ctx never keeps a dangling `LowerContext` pointer).

### #1289 — the rejection carries a span + symbol name

The non-constant global-initialiser error was a bare, fileless `lower: a global initialiser must be a constant expression`. It is now a diagnostic **located on the binding's name** that **names the symbol**: `error: <file>:<line>:<col>: global initialiser of \`NOT_CONST\` must be a constant expression`. The build is gated by the accumulated diagnostic; a zero placeholder global is still emitted so references resolve instead of cascading.

## Tests

New `.github/tests/globalmember/` integration suite:
- **fold** — the exact mach-std `THREAD_CLONE_FLAGS` shape (a global OR-ed from aliased `flags.CLONE_*` paths) plus chained constants (an aliased member that is itself built from other constants); asserts every folded value at runtime, exits 0.
- **reject** — a global initialised from an aliased pub `var`; the build must fail with a located, named diagnostic (`NOT_CONST` + `main.mach:line:col`).

## Verification

- `mach build .` clean; **byte-identical fixpoint** confirmed (stage1 == stage2).
- `mach test .` corpus all pass.
- Full `.github/tests/*` integration battery all pass (including the new suite).

The mach-std workaround imports in `std/system/os/linux/x86_64.mach` can be removed once a mach release ships this fix; the submodule is intentionally **not** bumped here (the released seed compiler that builds it lacks the fix).

Closes #1290
Closes #1289