### PR TITLE
refactor(of): relocation-kind enum + interner threading (kill per-format module globals)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -465,11 +465,10 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
     }
     var s: sess.Session = unwrap_ok[sess.Session, str](sess_r);
 
-    # populate the process-global target registries from the session at its STABLE
-    # address (this frame's `s`, not init's local that was returned by value): the
-    # object-format registrar captures the interner BY POINTER (elf_interner) for
-    # use during linking, so it must bind the final home or it dangles. register_all
-    # is idempotent.
+    # populate the process-global target registries from the session interner.
+    # the registrars intern each vtable's string fields (format/os/abi names) into
+    # it; the format writers no longer capture it — they resolve names through the
+    # interner each `ObjectImage` carries. register_all is idempotent.
     val reg_r: Result[bool, str] = tgt.register_all(?s.interner);
     if (is_err[bool, str](reg_r)) {
         print.eprint("error: ");

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -155,7 +155,7 @@ pub fun codegen_module(s: *sess.Session, tgt: *target.Target,
 # ret:   the populated object image, or an error string
 fun pack_image(s: *sess.Session, tgt: *target.Target, irmod: *ir.Module,
                enc: *encode.EncoderOutput) Result[of.ObjectImage, str] {
-    val rimg: Result[of.ObjectImage, str] = obj.init(s.alloc, irmod.name);
+    val rimg: Result[of.ObjectImage, str] = obj.init(s.alloc, ?s.interner, irmod.name);
     if (is_err[of.ObjectImage, str](rimg)) {
         ret err[of.ObjectImage, str](unwrap_err[of.ObjectImage, str](rimg));
     }

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -389,9 +389,9 @@ fun function_is_weak(irmod: *ir.Module, name: intern.StrId) bool {
 }
 
 # attach every pending relocation from the encoder to the `.text` section. the
-# encoder already names each relocation's abstract kind ("pc32", "abs64", ...)
-# and target symbol as interned ids; the format writer maps the kind to its
-# machine type at emit time.
+# encoder tags each relocation with its abstract kind (`of.RK_*`) and the
+# interned target-symbol name; the format writer maps the kind to its machine
+# type at emit time.
 # ---
 # image:    object image being built
 # enc:      encoder output supplying the pending relocations
@@ -576,7 +576,7 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
         # (an anonymous rodata global already packed in this same loop). the
         # ELF writer emits a `.rela.<section>` for any section carrying these.
         if (g.init.kind == value.VAL_CONST_AGG) {
-            val rr: Result[bool, str] = pack_agg_relocs(s, tgt, image, ?g.init, sec_idx);
+            val rr: Result[bool, str] = pack_agg_relocs(image, ?g.init, sec_idx);
             if (is_err[bool, str](rr)) { ret err[bool, str](unwrap_err[bool, str](rr)); }
         }
         i = i + 1;
@@ -587,20 +587,14 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
 # attach the relocation side-table of an aggregate constant initializer to its
 # packed section: one abs64 relocation per pointer leaf, patching the leaf's
 # byte offset with the address of its target symbol plus the recorded addend.
+# the abstract abs64 kind is format-independent, so no target is needed.
 # ---
-# s:       session, for the interner
-# tgt:     resolved target, supplying the object format's abs64 kind name
 # image:   object image being built
 # init:    the VAL_CONST_AGG initializer carrying the side-table
 # sec_idx: index of the section the relocations patch
 # ret:     true on success, or an error string
-fun pack_agg_relocs(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
+fun pack_agg_relocs(image: *of.ObjectImage,
                     init: *value.Value, sec_idx: u32) Result[bool, str] {
-    val kind: intern.StrId = of.reloc_kind_name(tgt.of, of.RK_ABS64);
-    if (kind == intern.STR_NIL) {
-        ret err[bool, str]("codegen: target object format does not map the abs64 relocation kind");
-    }
-
     var i: u32 = 0;
     for (i < init.data.agg.reloc_count) {
         val ar: *value.AggReloc = ?init.data.agg.relocs[i];
@@ -608,7 +602,7 @@ fun pack_agg_relocs(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImag
         var rel: of.Relocation;
         rel.section = sec_idx;
         rel.offset  = ar.offset;
-        rel.kind    = kind;
+        rel.kind    = of.RK_ABS64;
         rel.symbol  = ar.symbol;
         rel.addend  = ar.addend;
 

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -29,6 +29,7 @@ use std.allocator.Allocator;
 use writer: std.io.writer;
 
 use intern: mach.lang.intern;
+use of:     mach.lang.target.of;
 use target: mach.lang.target.resolved;
 use mir:    mach.lang.be.codegen.mir;
 
@@ -52,16 +53,16 @@ pub rec EncoderOutput {
 }
 
 # PendingReloc: one relocation the encoder leaves for the object writer to
-# resolve. `kind` and `sym` are interned names (the abstract relocation kind and
-# the target symbol); `offset` is the patch site within `.text`.
+# resolve. `kind` is an abstract relocation kind (`of.RK_*`); `sym` is the
+# interned target-symbol name; `offset` is the patch site within `.text`.
 # ---
 # offset: byte offset of the patch site within the `.text` section
-# kind:   interned abstract relocation-kind name ("pc32", "abs64", ...)
+# kind:   abstract relocation kind (one of of.RK_*)
 # sym:    interned name of the referenced symbol
 # addend: constant added to the resolved symbol address
 pub rec PendingReloc {
     offset: u32;
-    kind:   intern.StrId;
+    kind:   of.RelocKind;
     sym:    intern.StrId;
     addend: i32;
 }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1167,8 +1167,6 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
                      placements: *Placement, sec_base: *u32,
                      sym_locs: *map.Map[intern.StrId, SymbolLoc],
                      dyn: *DynState) Result[bool, str] {
-    # intern the abstract relocation-kind names once for fast comparison.
-    val kinds: RelocKindIds = intern_reloc_kinds(s);
     val alloc: *Allocator = s.alloc;
 
     var m: u32 = 0;
@@ -1187,7 +1185,7 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
         }
 
         val pr: Result[bool, str] = patch_module_relocations(s, out_img, modules, m,
-            placements, sec_base, sym_locs, dyn, ?kinds, ?local_map);
+            placements, sec_base, sym_locs, dyn, ?local_map);
         map.dnit[intern.StrId, u64](?local_map);
         if (is_err[bool, str](pr)) { ret err[bool, str](unwrap_err[bool, str](pr)); }
 
@@ -1228,7 +1226,7 @@ fun patch_module_relocations(s: *sess.Session, out_img: *of.ObjectImage,
                              modules: *of.ObjectImage, m: u32,
                              placements: *Placement, sec_base: *u32,
                              sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
-                             kinds: *RelocKindIds, local_map: *map.Map[intern.StrId, u64]) Result[bool, str] {
+                             local_map: *map.Map[intern.StrId, u64]) Result[bool, str] {
     var ri: u32 = 0;
     for (ri < modules[m].reloc_count) {
         val r: *of.Relocation = ?modules[m].relocations[ri];
@@ -1282,7 +1280,7 @@ fun patch_module_relocations(s: *sess.Session, out_img: *of.ObjectImage,
                 # reference — including a call kind against a data import (deferred)
                 # — is rejected as undefined.
                 val imp: Result[u32, str] = dynstate_import_index(dyn, r.symbol);
-                if (is_ok[u32, str](imp) && is_call_kind(kinds, r.kind)
+                if (is_ok[u32, str](imp) && is_call_kind(r.kind)
                     && dynstate_import_is_func(dyn, unwrap_ok[u32, str](imp))) {
                     val rec_r: Result[bool, str] = dynstate_add_fixup(s, dyn,
                         segment_index_for(out_img, out_ix), patch_off,
@@ -1295,7 +1293,7 @@ fun patch_module_relocations(s: *sess.Session, out_img: *of.ObjectImage,
         }
 
         val pr: Result[bool, str] =
-            apply_one(s, kinds, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va);
+            apply_one(s, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va);
         if (is_err[bool, str](pr)) {
             ret err[bool, str](unwrap_err[bool, str](pr));
         }
@@ -1461,8 +1459,8 @@ fun dynstate_import_is_func(dyn: *DynState, idx: u32) bool {
 # is_call_kind: whether an abstract relocation kind is a pc-relative call/branch
 # that can be redirected through a PLT stub. only these are bound to an import's
 # thunk; an absolute reference to an import is unsupported and stays an error.
-fun is_call_kind(kinds: *RelocKindIds, kind: intern.StrId) bool {
-    ret kind == kinds.pc32 || kind == kinds.plt32;
+fun is_call_kind(kind: of.RelocKind) bool {
+    ret kind == of.RK_PC32 || kind == of.RK_PLT32;
 }
 
 # segment_index_for: the load-segment index a merged output section maps to in the
@@ -1505,10 +1503,10 @@ fun dynstate_add_fixup(s: *sess.Session, dyn: *DynState, seg_index: u32, seg_off
 # apply_one: write a single resolved relocation into the merged bytes. `abs64`
 # writes a 64-bit little-endian absolute address; `pc32`/`plt32` write a 32-bit
 # little-endian pc-relative displacement. bounds and 32-bit range are checked.
-fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
+fun apply_one(s: *sess.Session, kind: of.RelocKind,
              dst: *u8, patch_off: u32, sec_len: u32,
              sym_va: u64, addend: i64, patch_va: u64) Result[bool, str] {
-    if (kind == kinds.abs64) {
+    if (kind == of.RK_ABS64) {
         # bound the patch site in u64: patch_off + width can wrap a u32 for an
         # offset near 0xFFFFFFFF, which would pass a u32 check and then scribble
         # outside the merged buffer.
@@ -1520,7 +1518,7 @@ fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
         ret ok[bool, str](true);
     }
 
-    if (kind == kinds.pc32 || kind == kinds.plt32) {
+    if (kind == of.RK_PC32 || kind == of.RK_PLT32) {
         if (patch_off::u64 + 4 > sec_len::u64) {
             ret err[bool, str](overflow_message(s, kind));
         }
@@ -1533,7 +1531,7 @@ fun apply_one(s: *sess.Session, kinds: *RelocKindIds, kind: intern.StrId,
     }
 
     # abs32s: 32-bit signed absolute.
-    if (kind == kinds.abs32s) {
+    if (kind == of.RK_ABS32S) {
         if (patch_off::u64 + 4 > sec_len::u64) {
             ret err[bool, str](overflow_message(s, kind));
         }
@@ -1606,32 +1604,6 @@ fun out_section_for_merged(out_img: *of.ObjectImage, merged_index: u32) u32 {
     ret 0xFFFFFFFF;
 }
 
-# interned ids of the abstract relocation-kind names, resolved once per patch
-# pass for fast StrId comparison against each relocation's `kind`.
-# ---
-# abs64:  id of "abs64"  (64-bit absolute)
-# pc32:   id of "pc32"   (32-bit pc-relative)
-# plt32:  id of "plt32"  (32-bit pc-relative through the PLT)
-# abs32s: id of "abs32s" (32-bit signed absolute)
-rec RelocKindIds {
-    abs64:  intern.StrId;
-    pc32:   intern.StrId;
-    plt32:  intern.StrId;
-    abs32s: intern.StrId;
-}
-
-# intern_reloc_kinds: resolve the abstract relocation-kind names into StrIds for
-# comparison. interning is idempotent, so names already present (interned by the
-# format registrars) resolve to their existing ids.
-fun intern_reloc_kinds(s: *sess.Session) RelocKindIds {
-    var k: RelocKindIds;
-    k.abs64  = intern_or_nil(s, "abs64");
-    k.pc32   = intern_or_nil(s, "pc32");
-    k.plt32  = intern_or_nil(s, "plt32");
-    k.abs32s = intern_or_nil(s, "abs32s");
-    ret k;
-}
-
 # intern_or_nil: intern a name, returning STR_NIL on allocation failure so a
 # comparison against it never spuriously matches a real relocation kind.
 fun intern_or_nil(s: *sess.Session, name: str) intern.StrId {
@@ -1686,17 +1658,13 @@ fun undef_message(s: *sess.Session, name: intern.StrId) str {
 }
 
 # overflow_message: build the "relocation '<kind>' overflows" diagnostic string.
-fun overflow_message(s: *sess.Session, kind: intern.StrId) str {
-    val km: Option[str] = intern.lookup(?s.interner, kind);
-    if (is_some[str](km)) { ret join3(s, "relocation '", unwrap[str](km), "' overflows", "relocation overflows"); }
-    ret "relocation overflows";
+fun overflow_message(s: *sess.Session, kind: of.RelocKind) str {
+    ret join3(s, "relocation '", of.reloc_kind_name(kind), "' overflows", "relocation overflows");
 }
 
 # unsupported_message: build the "relocation '<kind>' not supported" string.
-fun unsupported_message(s: *sess.Session, kind: intern.StrId) str {
-    val km: Option[str] = intern.lookup(?s.interner, kind);
-    if (is_some[str](km)) { ret join3(s, "relocation '", unwrap[str](km), "' not supported", "relocation not supported"); }
-    ret "relocation not supported";
+fun unsupported_message(s: *sess.Session, kind: of.RelocKind) str {
+    ret join3(s, "relocation '", of.reloc_kind_name(kind), "' not supported", "relocation not supported");
 }
 
 # entry_message: build the "undefined entry symbol: <name>" diagnostic string

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -270,7 +270,7 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     # build the merged output image. allocate each merged section's byte buffer
     # and copy every contributing input section into place.
     var out_img: of.ObjectImage;
-    val img_r: Result[of.ObjectImage, str] = obj.init(alloc, image_name(modules, module_count));
+    val img_r: Result[of.ObjectImage, str] = obj.init(alloc, ?s.interner, image_name(modules, module_count));
     if (is_err[of.ObjectImage, str](img_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
@@ -427,7 +427,7 @@ fun read_objects(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
             input_r = parse_archive(s, tgt, path, buf.data, buf.len, ?modules, ?count, ?cap);
         }
         or {
-            input_r = parse_loose(alloc, tgt, buf.data, buf.len, ?modules, ?count, ?cap);
+            input_r = parse_loose(alloc, ?s.interner, tgt, buf.data, buf.len, ?modules, ?count, ?cap);
         }
 
         # the parser copies any bytes it keeps; the file buffer is no longer
@@ -511,6 +511,7 @@ fun grow_modules(alloc: *Allocator, modules: **of.ObjectImage, count: *u32, cap:
 # so the caller's teardown frees it cleanly) and the error is propagated.
 # ---
 # alloc:   allocator backing the image arrays
+# itn:     session interner the parser interns names into and records on the image
 # tgt:     active target — supplies the format parser
 # buf:     the object file bytes
 # buf_len: length of `buf`
@@ -518,13 +519,13 @@ fun grow_modules(alloc: *Allocator, modules: **of.ObjectImage, count: *u32, cap:
 # count:   in/out — current image count
 # cap:     in/out — current backing capacity
 # ret:     ok(true) on success, or an error string
-fun parse_loose(alloc: *Allocator, tgt: *target.Target, buf: *u8, buf_len: usize,
+fun parse_loose(alloc: *Allocator, itn: *intern.Interner, tgt: *target.Target, buf: *u8, buf_len: usize,
                 modules: **of.ObjectImage, count: *u32, cap: *u32) Result[bool, str] {
     val gr: Result[u32, str] = grow_modules(alloc, modules, count, cap);
     if (is_err[u32, str](gr)) { ret err[bool, str](unwrap_err[u32, str](gr)); }
     val ix: u32 = unwrap_ok[u32, str](gr);
     val arr: *of.ObjectImage = @modules;
-    ret tgt.of.parse_object(alloc, buf, buf_len, ?arr[ix]);
+    ret tgt.of.parse_object(alloc, itn, buf, buf_len, ?arr[ix]);
 }
 
 # parse_archive: expand every ordinary member of an `ar` archive into the image
@@ -563,7 +564,7 @@ fun parse_archive(s: *sess.Session, tgt: *target.Target, path: str, buf: *u8, bu
             val ix: u32 = unwrap_ok[u32, str](gr);
             val arr: *of.ObjectImage = @modules;
             val pr: Result[bool, str] =
-                tgt.of.parse_object(alloc, st.member.data, st.member.len, ?arr[ix]);
+                tgt.of.parse_object(alloc, ?s.interner, st.member.data, st.member.len, ?arr[ix]);
             if (is_err[bool, str](pr)) { ret err[bool, str](unwrap_err[bool, str](pr)); }
         }
 
@@ -678,7 +679,7 @@ fun emit_dynamic_executable(s: *sess.Session, tgt: *target.Target, out_img: *of.
     val funcs: *of.ExecFunction = unwrap_ok[*of.ExecFunction, str](fr);
 
     val emit_r: Result[bool, str] =
-        tgt.of.emit_dyn_exec(alloc, tgt.arch, segs, seg_count, entry,
+        tgt.of.emit_dyn_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, entry,
                              funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, out_path);
 
     if (funcs != nil && func_count > 0) {

--- a/src/lang/be/obj.mach
+++ b/src/lang/be/obj.mach
@@ -37,14 +37,18 @@ use of:     mach.lang.target.of;
 #
 # the section, symbol, and relocation arrays start `nil` and grow on first
 # append. the image owns every array it later allocates, plus each section's
-# `bytes` buffer once it is supplied; `dnit` releases them all.
+# `bytes` buffer once it is supplied; `dnit` releases them all. the interner is
+# recorded on the image so the format writer can resolve its interned names
+# without a captured module global.
 # ---
-# alloc: allocator backing every array on the image
-# name:  interned module name, used for the output file's basename
-# ret:   a fresh empty ObjectImage
-pub fun init(alloc: *Allocator, name: intern.StrId) Result[of.ObjectImage, str] {
+# alloc:    allocator backing every array on the image
+# interner: session interner backing every StrId name on the image
+# name:     interned module name, used for the output file's basename
+# ret:      a fresh empty ObjectImage
+pub fun init(alloc: *Allocator, interner: *intern.Interner, name: intern.StrId) Result[of.ObjectImage, str] {
     var o: of.ObjectImage;
     o.alloc         = alloc;
+    o.interner      = interner;
     o.name          = name;
     o.sections      = nil;
     o.section_count = 0;

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -80,10 +80,10 @@ pub rec Session {
 # input and metadata kinds whose registration needs nothing from a phase
 # module; derived kinds bind their compute functions when their owning
 # phase modules register them. the process-global target registries are NOT
-# populated here: the object-format registrar captures the interner by pointer
-# for use during linking, so the owner calls target.register_all on the session
-# at its stable address (after this by-value return), not on init's local. on
-# any failure the prior sub-services are torn down in reverse construction order.
+# populated here: the owner calls target.register_all on the session interner
+# after this by-value return so the vtable name strings are interned into the
+# session's final interner. on any failure the prior sub-services are torn down
+# in reverse construction order.
 # ---
 # alloc: allocator used for all session-owned storage
 # ret:   a new empty Session, or an allocation error from a fallible sub-service

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2431,10 +2431,6 @@ rec BlockOffset {
 # blocks:       resolved block offsets
 # block_count:  number of block offsets
 # block_cap:    capacity of `blocks`
-# rk_pc32:      interned "pc32" relocation-kind name from the target's `of` vtable
-# rk_abs64:     interned "abs64" relocation-kind name from the target's `of` vtable
-# rk_addr32nb:  interned image-relative kind name (COFF ADDR32NB), or STR_NIL on
-#               formats without one (ELF/Mach-O); names PE unwind-table relocs
 # interner:     session interner; resolves inline-asm `{name}` binding names and
 #               interns symbol names referenced from inline asm into relocations
 rec EncodeState {
@@ -2452,9 +2448,6 @@ rec EncodeState {
     blocks:      *BlockOffset;
     block_count: u32;
     block_cap:   u32;
-    rk_pc32:     intern.StrId;
-    rk_abs64:    intern.StrId;
-    rk_addr32nb: intern.StrId;
     interner:    *intern.Interner;
     abi:         *abi.AbiVTable;
 }
@@ -2472,8 +2465,8 @@ rec EncodeState {
 # branch displacement now that every block offset is known.
 # ---
 # alloc: allocator backing the encoder output's owned arrays
-# tgt:   resolved target; must be x86-64 and supply the object-format relocation
-#        kinds the encoder names its relocations with
+# tgt:   resolved target; must be x86-64. relocations are emitted with the
+#        abstract `of.RK_*` kinds the format writer maps to machine types
 # m:     the fully-resolved MIR module (post isel / regalloc / frame)
 # ret:   the populated enc.EncoderOutput (owned arrays), or an error string
 pub fun encode_x64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Result[enc.EncoderOutput, str] {
@@ -2495,9 +2488,6 @@ pub fun encode_x64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Re
     st.blocks      = nil;
     st.block_count = 0;
     st.block_cap   = 0;
-    st.rk_pc32     = reloc_kind_name(tgt, of.RK_PC32);
-    st.rk_abs64    = reloc_kind_name(tgt, of.RK_ABS64);
-    st.rk_addr32nb = reloc_kind_name(tgt, of.RK_ADDR32NB);
     st.interner    = m.interner;
     st.abi         = tgt.abi;
 
@@ -2539,22 +2529,6 @@ pub fun encode_x64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Re
     # driver-internal fixup and block-offset arrays are released.
     free_scratch(?st);
     ret ok[enc.EncoderOutput, str](out);
-}
-
-# look up the interned abstract relocation-kind name for an `of.RK_*` id from the
-# target's object-format vtable, so a `enc.PendingReloc.kind` matches the StrId the
-# format writer compares against. returns intern.STR_NIL when no `of` vtable is
-# attached or the kind is unmapped.
-fun reloc_kind_name(tgt: *target.Target, kind: of.RelocKind) intern.StrId {
-    if (tgt.of == nil) { ret intern.STR_NIL; }
-    var i: u32 = 0;
-    for (i < tgt.of.relocation_count) {
-        if (tgt.of.relocation_kinds[i].id == kind::u32) {
-            ret tgt.of.relocation_kinds[i].name;
-        }
-        i = i + 1;
-    }
-    ret intern.STR_NIL;
 }
 
 # shrink the text byte sink so its backing allocation length equals the number
@@ -2827,7 +2801,7 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
             ret err[bool, str]("encode: symbol-referencing instruction has no relocation patch site");
         }
         val patch_pos: u32 = (inst_start + reloc_off::usize)::u32;
-        var kind: intern.StrId = st.rk_pc32;
+        var kind: of.RelocKind = of.RK_PC32;
         # a PC32 patch site is corrected by the distance from the relocation field
         # to the end of the instruction (`inst_size - reloc_off`), so the resolved
         # `S + A - P` equals `S - next_ip`. for a disp32 immediately before the next
@@ -2835,7 +2809,7 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
         # the correction. an abs64 MOVABS takes no PC correction.
         var addend: i32 = sym_addend - (inst_size - reloc_off);
         if (inst.opcode == x64.MOVABS::u16) {
-            kind   = st.rk_abs64;
+            kind   = of.RK_ABS64;
             addend = sym_addend;
         }
         ret push_reloc(st, patch_pos, kind, sym, addend);
@@ -4889,7 +4863,7 @@ fun emit_branch_sym(st: *EncodeState, fn_base: u32, opcode: u16, target: str) Re
 
     val patch_pos: u32 = (inst_start + (n - 4)::usize)::u32;
     # PC32: S + A - P, where the field-to-next-ip correction is the trailing 4 bytes.
-    ret push_reloc(st, patch_pos, st.rk_pc32, sym, -4);
+    ret push_reloc(st, patch_pos, of.RK_PC32, sym, -4);
 }
 
 # emit_one_op: parse and encode a single-operand instruction (neg / not / inc /
@@ -4991,7 +4965,7 @@ fun emit_two_op(st: *EncodeState, opcode: u16, args: str, extra_flags: u16) Resu
         if (is_err[intern.StrId, str](symr)) { ret err[bool, str](unwrap_err[intern.StrId, str](symr)); }
         val sym: intern.StrId = unwrap_ok[intern.StrId, str](symr);
         val patch_pos: u32 = (inst_start + patch::usize)::u32;
-        ret push_reloc(st, patch_pos, st.rk_pc32, sym, -(n - patch));
+        ret push_reloc(st, patch_pos, of.RK_PC32, sym, -(n - patch));
     }
     ret ok[bool, str](true);
 }
@@ -5286,7 +5260,7 @@ fun push_symbol(st: *EncodeState, name: intern.StrId, offset: u32, flags: u32) R
 }
 
 # append a pending relocation, growing the relocation array on demand.
-fun push_reloc(st: *EncodeState, offset: u32, kind: intern.StrId, sym: intern.StrId, addend: i32) Result[bool, str] {
+fun push_reloc(st: *EncodeState, offset: u32, kind: of.RelocKind, sym: intern.StrId, addend: i32) Result[bool, str] {
     if (st.reloc_count >= st.reloc_cap) {
         val gr: Result[bool, str] = grow_relocs(st);
         if (is_err[bool, str](gr)) { ret gr; }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -142,9 +142,13 @@ pub rec Relocation {
 }
 
 # the complete, format-agnostic image the back end builds and the format
-# writer serializes. owns its section/symbol/relocation arrays.
+# writer serializes. owns its section/symbol/relocation arrays. carries the
+# session interner beside `alloc`: every name on the image is an interned StrId
+# that only means anything against this interner, so the format writer resolves
+# names through `image.interner` rather than a captured module global.
 # ---
 # alloc:         allocator backing the owned arrays
+# interner:      session interner backing every StrId name on the image
 # name:          interned object/module name
 # sections:      array of sections
 # section_count: number of sections
@@ -154,6 +158,7 @@ pub rec Relocation {
 # reloc_count:   number of relocations
 pub rec ObjectImage {
     alloc:         *Allocator;
+    interner:      *intern.Interner;
     name:          intern.StrId;
     sections:      *Section;
     section_count: u32;
@@ -273,10 +278,12 @@ pub rec ExecFunction {
 # a format writer: serializes an `ObjectImage` to a relocatable object file at
 # the given path. takes the `IsaVTable` (not the full Target) to break the
 # target↔object-format import cycle; the writer uses only what the ISA exposes
-# (machine type, endianness, pointer width).
+# (machine type, endianness, pointer width). it resolves the image's interned
+# names through `image.interner`, which the back end set when it built the image —
+# no module-global interner is captured.
 # ---
 # arg 0: the instruction-set vtable describing the machine
-# arg 1: the object image to serialize
+# arg 1: the object image to serialize (carries its allocator and interner)
 # arg 2: null-terminated output file path
 # ret:   true on success, or an error string
 pub def WriterFn: fun(*isa.IsaVTable, *ObjectImage, *u8) Result[bool, str];
@@ -286,14 +293,17 @@ pub def WriterFn: fun(*isa.IsaVTable, *ObjectImage, *u8) Result[bool, str];
 # the mirror of `WriterFn`; `parse_object` round-trips what `emit_object`
 # writes. names and relocation kinds are kept interned so the linker matches
 # symbols and maps relocations across objects; section bytes are copied into
-# the image, which owns them through `out.alloc`.
+# the image, which owns them through `out.alloc`. the interner is passed
+# explicitly (like the allocator) and recorded on `out.interner` so the names the
+# parser produces resolve against the linking session's interner.
 # ---
 # arg 0: allocator backing the image's owned section/symbol/relocation arrays
-# arg 1: the object file bytes
-# arg 2: length of the object file bytes
-# arg 3: image to populate (its arrays are allocated here)
+# arg 1: interner the parsed names are interned into and recorded on `out`
+# arg 2: the object file bytes
+# arg 3: length of the object file bytes
+# arg 4: image to populate (its arrays are allocated here)
 # ret:   true on success, or an error string
-pub def ParserFn: fun(*Allocator, *u8, usize, *ObjectImage) Result[bool, str];
+pub def ParserFn: fun(*Allocator, *intern.Interner, *u8, usize, *ObjectImage) Result[bool, str];
 
 # a static-executable writer: serializes the linker's laid-out load segments
 # into a static executable at the given path. like `WriterFn` it takes the
@@ -323,22 +333,25 @@ pub def ExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64,
 # fixups the linker could not resolve. the writer places each import's call-thunk
 # (ELF PLT stub) in its own layout, then patches every `PltFixup` to point at the
 # matching thunk. like the other writers it takes the `IsaVTable`, not the full
-# Target, to break the target↔object-format import cycle. used in place of
+# Target, to break the target↔object-format import cycle. the interner is passed
+# explicitly so the writer can resolve the interned names the `DynamicInfo` plan
+# carries (sonames, import symbols, interpreter path). used in place of
 # `emit_exec` when `DynamicInfo` carries any dependency or import.
 # ---
-# arg 0: allocator backing the writer's output buffer
-# arg 1: the instruction-set vtable describing the machine
-# arg 2: the loadable segments, in ascending virtual-address order
-# arg 3: number of load segments
-# arg 4: program entry-point virtual address
-# arg 5: per-function descriptors (may be nil when count is 0)
-# arg 6: number of per-function descriptors
-# arg 7: the dynamic-link plan (dependencies, imports, interpreter)
-# arg 8: the import call-site fixups to redirect to call-thunks
-# arg 9: number of fixups
-# arg 10: null-terminated output file path
-# ret:   true on success, or an error string
-pub def DynExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64,
+# arg 0:  allocator backing the writer's output buffer
+# arg 1:  interner resolving the DynamicInfo names (sonames, imports, interp)
+# arg 2:  the instruction-set vtable describing the machine
+# arg 3:  the loadable segments, in ascending virtual-address order
+# arg 4:  number of load segments
+# arg 5:  program entry-point virtual address
+# arg 6:  per-function descriptors (may be nil when count is 0)
+# arg 7:  number of per-function descriptors
+# arg 8:  the dynamic-link plan (dependencies, imports, interpreter)
+# arg 9:  the import call-site fixups to redirect to call-thunks
+# arg 10: number of fixups
+# arg 11: null-terminated output file path
+# ret:    true on success, or an error string
+pub def DynExecFn: fun(*Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64,
                        *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *u8) Result[bool, str];
 
 # the object-format runtime-dispatch interface. exactly one of these exists

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -6,7 +6,7 @@
 # runtime-dispatch interface plus a process-global registry let per-format
 # implementations (elf, coff, macho) self-register from module init. The back
 # end emits relocations using the abstract `RK_*` kinds; each format maps those
-# to its own machine relocation types through its `relocation_kinds` table.
+# to its own machine relocation types internally with a plain integer compare.
 
 use std.types.result.Result;
 use std.types.string.str;
@@ -46,8 +46,9 @@ pub val SK_BSS:    SectionKind = 3;
 # debug information.
 pub val SK_DEBUG:  SectionKind = 4;
 
-# abstract relocation kinds emitted by the back end. each object format maps
-# these to its own machine relocation types via its `relocation_kinds` table.
+# abstract relocation kinds emitted by the back end — a closed enum owned here.
+# each object format maps these to its own machine relocation types internally
+# with a plain integer compare; `reloc_kind_name` gives a kind its diagnostic name.
 pub def RelocKind: u8;
 
 # 64-bit absolute address (R_X86_64_64 / R_AARCH64_ABS64 / IMAGE_REL_*_ADDR64).
@@ -123,18 +124,19 @@ pub rec Symbol {
     flags:   u32;
 }
 
-# one relocation in an object image. `kind` names an abstract relocation kind
-# (an interned RK_* name); the format writer maps it to a machine type.
+# one relocation in an object image. `kind` is an abstract relocation kind (a
+# closed `RK_*` enum owned here); the format writer maps it to a machine type
+# with a plain integer compare, no interner involved.
 # ---
 # section: index of the section being patched
 # offset:  byte offset of the patch site within that section
-# kind:    interned abstract relocation-kind name ("abs64", "pc32", ...)
+# kind:    abstract relocation kind (one of RK_*)
 # symbol:  interned name of the referenced symbol
 # addend:  constant added to the resolved symbol address
 pub rec Relocation {
     section: u32;
     offset:  u32;
-    kind:    intern.StrId;
+    kind:    RelocKind;
     symbol:  intern.StrId;
     addend:  i64;
 }
@@ -268,20 +270,6 @@ pub rec ExecFunction {
     size:       u32;
 }
 
-# one entry in a format's relocation-kind table: the format's mapping of an
-# abstract relocation kind to its machine type and encoding properties.
-# ---
-# id:        abstract relocation kind this entry implements (one of RK_*)
-# name:      interned abstract kind name ("abs64", "pc32", ...)
-# bit_width: width in bits of the patched field
-# pc_rel:    true if the relocation is pc-relative
-pub rec RelocationKind {
-    id:        u32;
-    name:      intern.StrId;
-    bit_width: u32;
-    pc_rel:    bool;
-}
-
 # a format writer: serializes an `ObjectImage` to a relocatable object file at
 # the given path. takes the `IsaVTable` (not the full Target) to break the
 # target↔object-format import cycle; the writer uses only what the ISA exposes
@@ -356,8 +344,8 @@ pub def DynExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64,
 # the object-format runtime-dispatch interface. exactly one of these exists
 # per format; the back end serializes through `emit_object`, the linker reads
 # through `parse_object` and writes executables through `emit_exec` (or
-# `emit_dyn_exec` for a dynamic link), and all consult `relocation_kinds` to map
-# abstract relocations. it never branches on `id`.
+# `emit_dyn_exec` for a dynamic link). each format maps the abstract `RK_*`
+# kinds to its own machine relocation types internally. it never branches on `id`.
 # ---
 # id:               object-format id (one of OF_*)
 # name:             interned format name ("elf", "coff", "macho")
@@ -367,8 +355,6 @@ pub def DynExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64,
 # emit_exec:        serializes laid-out load segments into a static executable
 # emit_dyn_exec:    serializes them into a dynamically-linked executable, or nil
 #                   when the format has no dynamic-link writer yet
-# relocation_kinds: array mapping abstract RK_* kinds to machine types
-# relocation_count: number of relocation-kind entries
 pub rec OfVTable {
     id:               u32;
     name:             intern.StrId;
@@ -377,8 +363,6 @@ pub rec OfVTable {
     parse_object:     ParserFn;
     emit_exec:        ExecFn;
     emit_dyn_exec:    DynExecFn;
-    relocation_kinds: *RelocationKind;
-    relocation_count: u32;
 }
 
 val OF_REGISTRY_CAP: u32 = 8;
@@ -456,22 +440,19 @@ pub fun registered(idx: u32) Option[*OfVTable] {
     ret none[*OfVTable]();
 }
 
-# reloc_kind_name: the interned abstract relocation-kind name an `RK_*` id maps
-# to in a format vtable's `relocation_kinds` table — the StrId a `Relocation.kind`
-# must carry so the format writer matches it. returns intern.STR_NIL for a nil
-# vtable or an unmapped kind.
+# reloc_kind_name: the stable, format-independent name of an abstract relocation
+# kind, for diagnostics. unlike a format's machine mapping this is a plain string
+# constant — no interner, no per-format table — so any layer can name a kind in an
+# error without resolving an interned id.
 # ---
-# vt:   the object-format vtable (nil yields STR_NIL)
 # kind: the abstract relocation kind (one of RK_*)
-# ret:  the interned kind name, or intern.STR_NIL
-pub fun reloc_kind_name(vt: *OfVTable, kind: RelocKind) intern.StrId {
-    if (vt == nil) { ret intern.STR_NIL; }
-    var i: u32 = 0;
-    for (i < vt.relocation_count) {
-        if (vt.relocation_kinds[i].id == kind::u32) {
-            ret vt.relocation_kinds[i].name;
-        }
-        i = i + 1;
-    }
-    ret intern.STR_NIL;
+# ret:  the kind's diagnostic name, or "unknown" for an unrecognized id
+pub fun reloc_kind_name(kind: RelocKind) str {
+    if (kind == RK_ABS64)    { ret "abs64"; }
+    if (kind == RK_PC32)     { ret "pc32"; }
+    if (kind == RK_PLT32)    { ret "plt32"; }
+    if (kind == RK_GOTPCREL) { ret "gotpcrel"; }
+    if (kind == RK_ABS32S)   { ret "abs32s"; }
+    if (kind == RK_ADDR32NB) { ret "addr32nb"; }
+    ret "unknown";
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -10,14 +10,14 @@
 # image's own symbols), and a trailing string table for names longer than eight
 # bytes. The reader mirrors that back into a fresh `of.ObjectImage`.
 #
-# The abstract `of.RK_*` relocation kinds are interned at registration; the
-# writer matches a `Relocation.kind` StrId against those handles and maps it to
-# an `IMAGE_REL_AMD64_*` machine type, and the reader maps the machine type back.
+# The abstract `of.RK_*` relocation kinds are a closed enum; the writer maps a
+# `Relocation.kind` to an `IMAGE_REL_AMD64_*` machine type with a plain integer
+# compare and the reader maps the machine type back — no interner involved.
 #
-# `WriterFn`/`ParserFn` carry no interner, yet section/symbol names are
-# `intern.StrId`. `register_coff` captures the session interner in a module-level
-# pointer (exactly as it interns the vtable's own string fields), and the
-# reader/writer resolve names through it.
+# Section/symbol names are `intern.StrId`, so the writer resolves them through the
+# interner each `of.ObjectImage` carries beside its allocator; the reader and the
+# dynamic-executable writer take the interner as a parameter. no module-global
+# interner is captured — `register_coff` only interns the vtable's own name fields.
 #
 # It also provides the PE32+ executable emitters — `coff_emit_exec` (static) and
 # `coff_emit_dyn_exec` (with a dynamic-import plan). The writer frames the
@@ -162,16 +162,12 @@ val UWOP_SAVE_XMM128: u8 = 8;
 val UWOP_SAVE_XMM128_FAR: u8 = 9;
 val UWREG_RBP: u8 = 5;
 
-# session interner captured at registration so the reader/writer can resolve the
-# `intern.StrId` names carried by `of.ObjectImage`. set by `register_coff`.
-var coff_interner: *intern.Interner = nil;
-
-# resolve an interned StrId to its backing text through the captured interner,
-# or nil if no interner is set or the id is out of range.
-fun resolve(id: intern.StrId) str {
-    if (coff_interner == nil) { ret nil; }
+# resolve an interned StrId to its backing text through `itn`, or nil if no
+# interner is given or the id is out of range.
+fun resolve(itn: *intern.Interner, id: intern.StrId) str {
+    if (itn == nil) { ret nil; }
     if (id == intern.STR_NIL) { ret nil; }
-    val o: Option[str] = intern.lookup(coff_interner, id);
+    val o: Option[str] = intern.lookup(itn, id);
     if (is_some[str](o)) { ret unwrap[str](o); }
     ret nil;
 }
@@ -180,27 +176,27 @@ fun resolve(id: intern.StrId) str {
 # unmapped kind is an error naming the kind, never silently serialized as ADDR64
 # (an 8-byte write over what codegen sized as a 4-byte field). pc32/plt32 both
 # encode a 32-bit pc-relative reference (REL32); addr32nb is the image-relative
-# ADDR32NB. `alloc` backs the error string.
-fun reloc_type_for(alloc: *Allocator, kind: of.RelocKind) Result[u16, str] {
+# ADDR32NB. `itn`/`alloc` back the error string.
+fun reloc_type_for(itn: *intern.Interner, alloc: *Allocator, kind: of.RelocKind) Result[u16, str] {
     if (kind == of.RK_ABS64)    { ret ok[u16, str](IMAGE_REL_AMD64_ADDR64); }
     if (kind == of.RK_PC32)     { ret ok[u16, str](IMAGE_REL_AMD64_REL32); }
     if (kind == of.RK_PLT32)    { ret ok[u16, str](IMAGE_REL_AMD64_REL32); }
     if (kind == of.RK_ADDR32NB) { ret ok[u16, str](IMAGE_REL_AMD64_ADDR32NB); }
-    ret err[u16, str](unsupported_kind_message(alloc, kind));
+    ret err[u16, str](unsupported_kind_message(itn, alloc, kind));
 }
 
 # "coff: unsupported relocation kind: <name>" for an abstract kind the writer has
 # no width-correct COFF machine type for.
-fun unsupported_kind_message(alloc: *Allocator, kind: of.RelocKind) str {
-    ret bin.name_message(coff_interner, alloc, "coff: unsupported relocation kind: ",
+fun unsupported_kind_message(itn: *intern.Interner, alloc: *Allocator, kind: of.RelocKind) str {
+    ret bin.name_message(itn, alloc, "coff: unsupported relocation kind: ",
                          of.reloc_kind_name(kind), "coff: unsupported relocation kind");
 }
 
 # "coff: unsupported relocation type <n>" for a machine type the parser cannot
 # map to an abstract kind (e.g. a foreign ADDR32 — a 32-bit field that must not
 # be linked as a 64-bit absolute).
-fun unsupported_type_message(alloc: *Allocator, r_type: u64) str {
-    ret bin.number_message(coff_interner, alloc, "coff: unsupported relocation type ",
+fun unsupported_type_message(itn: *intern.Interner, alloc: *Allocator, r_type: u64) str {
+    ret bin.number_message(itn, alloc, "coff: unsupported relocation type ",
                            r_type, "coff: unsupported relocation type");
 }
 
@@ -209,7 +205,7 @@ fun unsupported_type_message(alloc: *Allocator, r_type: u64) str {
 fun validate_reloc_kinds(img: *of.ObjectImage) Result[bool, str] {
     var i: u32 = 0;
     for (i < img.reloc_count) {
-        val r: Result[u16, str] = reloc_type_for(img.alloc, img.relocations[i].kind);
+        val r: Result[u16, str] = reloc_type_for(img.interner, img.alloc, img.relocations[i].kind);
         if (is_err[u16, str](r)) { ret err[bool, str](unwrap_err[u16, str](r)); }
         i = i + 1;
     }
@@ -236,11 +232,11 @@ fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
 # to abs64. ADDR32 (a 32-bit absolute) is rejected too: there is no width-correct
 # abstract kind for it, and aliasing it to abs64 would link a foreign object's
 # 4-byte field with an 8-byte write.
-fun reloc_kind_for(alloc: *Allocator, r_type: u16) Result[of.RelocKind, str] {
+fun reloc_kind_for(itn: *intern.Interner, alloc: *Allocator, r_type: u16) Result[of.RelocKind, str] {
     if (r_type == IMAGE_REL_AMD64_ADDR64)   { ret ok[of.RelocKind, str](of.RK_ABS64); }
     if (r_type == IMAGE_REL_AMD64_REL32)    { ret ok[of.RelocKind, str](of.RK_PC32); }
     if (r_type == IMAGE_REL_AMD64_ADDR32NB) { ret ok[of.RelocKind, str](of.RK_ADDR32NB); }
-    ret err[of.RelocKind, str](unsupported_type_message(alloc, r_type::u64));
+    ret err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
 }
 
 # COFF section characteristics for an abstract section kind (the alignment bits
@@ -321,13 +317,13 @@ fun strtab_size(img: *of.ObjectImage) usize {
     var total: usize = 4;
     var s: u32 = 0;
     for (s < img.section_count) {
-        val sn: str = resolve(img.sections[s].name);
+        val sn: str = resolve(img.interner, img.sections[s].name);
         if (name_in_strtab(sn)) { total = total + str_len(sn) + 1; }
         s = s + 1;
     }
     var i: u32 = 0;
     for (i < img.symbol_count) {
-        val name: str = resolve(img.symbols[i].name);
+        val name: str = resolve(img.interner, img.symbols[i].name);
         if (name_in_strtab(name)) { total = total + str_len(name) + 1; }
         i = i + 1;
     }
@@ -373,16 +369,16 @@ fun reloc_sym_index(img: *of.ObjectImage, sym: intern.StrId) Result[u32, str] {
             i = i + 1;
         }
     }
-    ret err[u32, str](unresolved_reloc_message(img.alloc, sym));
+    ret err[u32, str](unresolved_reloc_message(img.interner, img.alloc, sym));
 }
 
 # build the "coff: unresolved relocation symbol: <name>" diagnostic, interned so
 # it outlives this call. an unnamed (STR_NIL) target, or interning failure under
 # memory pressure, degrades to the generic static form; the emit still fails.
-fun unresolved_reloc_message(alloc: *Allocator, sym: intern.StrId) str {
+fun unresolved_reloc_message(itn: *intern.Interner, alloc: *Allocator, sym: intern.StrId) str {
     val generic: str = "coff: relocation references an unresolved symbol";
-    val name: str = resolve(sym);
-    if (name == nil || coff_interner == nil) { ret generic; }
+    val name: str = resolve(itn, sym);
+    if (name == nil || itn == nil) { ret generic; }
 
     val pre:  str = "coff: unresolved relocation symbol: ";
     val lpre: usize = str_len(pre);
@@ -396,10 +392,10 @@ fun unresolved_reloc_message(alloc: *Allocator, sym: intern.StrId) str {
     mem.raw_copy((buf::usize + lpre)::ptr, name::ptr, lnam);
     buf[total] = 0;
 
-    val ir: Result[intern.StrId, str] = intern.intern(coff_interner, buf::str);
+    val ir: Result[intern.StrId, str] = intern.intern(itn, buf::str);
     deallocate[u8](alloc, buf, total + 1);
     if (is_err[intern.StrId, str](ir)) { ret generic; }
-    val nm: Option[str] = intern.lookup(coff_interner, unwrap_ok[intern.StrId, str](ir));
+    val nm: Option[str] = intern.lookup(itn, unwrap_ok[intern.StrId, str](ir));
     if (is_some[str](nm)) { ret unwrap[str](nm); }
     ret generic;
 }
@@ -528,6 +524,7 @@ fun build_weak_comdat_image(alloc: *Allocator, img: *of.ObjectImage,
     val new_secs: u32 = img.section_count + weak_n;
 
     out.alloc = alloc;
+    out.interner = img.interner;
     out.name = img.name;
     out.section_count = new_secs;
     out.symbol_count = img.symbol_count;
@@ -878,7 +875,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     s = 0;
     for (s < num_secs) {
         val sh: usize = COFF_HEADER_SIZE + s::usize * SECTION_HEADER_SIZE;
-        val sn: str = resolve(img.sections[s].name);
+        val sn: str = resolve(img.interner, img.sections[s].name);
         if (name_in_strtab(sn)) {
             sec_name_offsets[s] = str_pos::u32;
             buf[sh] = '/';
@@ -965,7 +962,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
         bin.write_u32_le(buf, ro + 4, sym_remap[rsi]);
         # validate_reloc_kinds proved every kind maps, so this lookup cannot miss;
         # ADDR64 is never silently substituted.
-        bin.write_u16_le(buf, ro + 8, unwrap_ok[u16, str](reloc_type_for(alloc, img.relocations[ri].kind)));
+        bin.write_u16_le(buf, ro + 8, unwrap_ok[u16, str](reloc_type_for(img.interner, alloc, img.relocations[ri].kind)));
         reloc_offsets[rsec] = ro + RELOCATION_SIZE;
         ri = ri + 1;
     }
@@ -976,7 +973,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     var sym_off: usize = symtab_offset;
     s = 0;
     for (s < num_secs) {
-        val sn: str = resolve(img.sections[s].name);
+        val sn: str = resolve(img.interner, img.sections[s].name);
         if (name_in_strtab(sn)) {
             bin.write_u32_le(buf, sym_off, 0);
             bin.write_u32_le(buf, sym_off + 4, sec_name_offsets[s]);
@@ -1007,7 +1004,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
 
     var symi: u32 = 0;
     for (symi < num_syms) {
-        val name: str = resolve(img.symbols[symi].name);
+        val name: str = resolve(img.interner, img.symbols[symi].name);
         if (name_in_strtab(name)) {
             bin.write_u32_le(buf, sym_off, 0);
             bin.write_u32_le(buf, sym_off + 4, str_pos::u32);
@@ -1146,23 +1143,25 @@ fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32,
 # reads the section, symbol, and relocation tables a COFF `.obj` produced by
 # `coff_emit_object` (or a compatible toolchain) carries into a fresh
 # `of.ObjectImage` owning copied section bytes and interned names. relocation
-# kinds map from the COFF machine type back to the abstract `RK_*` names; symbol
+# kinds map from the COFF machine type back to the abstract `RK_*` kinds; symbol
 # and section references are kept by interned name so the linker matches across
-# objects. the captured interner (see `register_coff`) interns the names.
+# objects. `itn` interns the names and is recorded on `out.interner`.
 # ---
 # alloc:    allocator for the image and its arrays
+# itn:      interner the parsed names are interned into and recorded on `out`
 # buf:      the object file bytes
 # buf_size: length of `buf`
 # out:      image to populate (its arrays are allocated here)
 # ret:      ok(true) on success, or an error string
-fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.ObjectImage) Result[bool, str] {
+fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_size: usize, out: *of.ObjectImage) Result[bool, str] {
     if (buf == nil || out == nil || buf_size < COFF_HEADER_SIZE) {
         ret err[bool, str]("coff: object too small");
     }
     if (bin.read_u16_le(buf, 0) != IMAGE_FILE_MACHINE_AMD64) {
         ret err[bool, str]("coff: not an x86-64 object");
     }
-    if (coff_interner == nil) { ret err[bool, str]("coff: no interner registered"); }
+    if (itn == nil) { ret err[bool, str]("coff: no interner for parse"); }
+    out.interner = itn;
 
     val num_secs:     u32   = bin.read_u16_le(buf, 2)::u32;
     val symtab_off:   usize = bin.read_u32_le(buf, 8)::usize;
@@ -1240,7 +1239,7 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
             deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
             ret err[bool, str](unwrap_err[str, str](rsn));
         }
-        val rin: Result[intern.StrId, str] = intern.intern(coff_interner, unwrap_ok[str, str](rsn));
+        val rin: Result[intern.StrId, str] = intern.intern(itn, unwrap_ok[str, str](rsn));
         if (is_err[intern.StrId, str](rin)) {
             deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
             ret err[bool, str](unwrap_err[intern.StrId, str](rin));
@@ -1293,7 +1292,7 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
             deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
             ret err[bool, str](unwrap_err[str, str](rsyn));
         }
-        val rin: Result[intern.StrId, str] = intern.intern(coff_interner, unwrap_ok[str, str](rsyn));
+        val rin: Result[intern.StrId, str] = intern.intern(itn, unwrap_ok[str, str](rsyn));
         if (is_err[intern.StrId, str](rin)) {
             deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
             ret err[bool, str](unwrap_err[intern.StrId, str](rin));
@@ -1376,7 +1375,7 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
             val r_off:  u32 = bin.read_u32_le(buf, ro);
             out.relocations[idx].section = s;
             out.relocations[idx].offset = r_off;
-            val rk: Result[of.RelocKind, str] = reloc_kind_for(alloc, r_type);
+            val rk: Result[of.RelocKind, str] = reloc_kind_for(itn, alloc, r_type);
             if (is_err[of.RelocKind, str](rk)) {
                 deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
                 ret err[bool, str](unwrap_err[of.RelocKind, str](rk));
@@ -1588,8 +1587,8 @@ fun func_import_count(dyn: *of.DynamicInfo) u32 {
 }
 
 # the byte length of an interned name plus its NUL terminator (1 for a nil name).
-fun name_len_z(id: intern.StrId) usize {
-    val s: str = resolve(id);
+fun name_len_z(itn: *intern.Interner, id: intern.StrId) usize {
+    val s: str = resolve(itn, id);
     if (s == nil) { ret 1; }
     ret str_len(s) + 1;
 }
@@ -1874,7 +1873,7 @@ fun collect_function_unwind(segs: *of.LoadSegment, seg_count: u32, funcs: *of.Ex
 # sections are placed at RVAs above the highest linker segment. file offsets and
 # RVAs advance under their own alignments (FileAlignment on disk, SectionAlignment
 # in memory). returns the total file size.
-fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
+fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
                       dyn: *of.DynamicInfo, seg_secs: *PeSection,
                       xdata_vsize: usize, pdata_vsize: usize) usize {
     lay.nimp      = func_import_count(dyn);
@@ -1964,7 +1963,7 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
         var i: u32 = 0;
         for (i < dyn.import_count) {
             if (dyn.imports[i].is_func) {
-                ioff = ioff + 2 + name_len_z(dyn.imports[i].symbol);
+                ioff = ioff + 2 + name_len_z(itn, dyn.imports[i].symbol);
                 ioff = bin.align_up(ioff, 2);
             }
             i = i + 1;
@@ -1973,7 +1972,7 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
         # dll-name strings (NUL-terminated, 2-byte aligned).
         i = 0;
         for (i < dyn.lib_count) {
-            ioff = ioff + name_len_z(dyn.libs[i].soname);
+            ioff = ioff + name_len_z(itn, dyn.libs[i].soname);
             ioff = bin.align_up(ioff, 2);
             i = i + 1;
         }
@@ -2029,7 +2028,9 @@ fun compute_pe_layout(lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
 fun coff_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                    seg_count: u32, entry: u64, funcs: *of.ExecFunction,
                    func_count: u32, path: *u8) Result[bool, str] {
-    ret write_pe(alloc, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, path);
+    # a static PE carries no dynamic plan, so it resolves no interned names — the
+    # writer takes a nil interner, used only by the import path the dyn writer hits.
+    ret write_pe(alloc, nil, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, path);
 }
 
 # coff_emit_dyn_exec: serialize laid-out load segments into a dynamically-linked
@@ -2041,6 +2042,7 @@ fun coff_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegm
 # of.DynExecFn signature exactly.
 # ---
 # alloc:       allocator for the output buffer and layout scratch
+# itn:         interner resolving the DynamicInfo names (import symbols, dll names)
 # isa_vt:      the instruction-set vtable describing the machine (must be x86-64)
 # segs:        the loadable segments, in ascending virtual-address order
 # seg_count:   number of load segments
@@ -2052,11 +2054,11 @@ fun coff_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegm
 # fixup_count: number of fixups
 # path:        null-terminated output file path
 # ret:         ok(true) on success, or an error string
-fun coff_emit_dyn_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
+fun coff_emit_dyn_exec(alloc: *Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                        seg_count: u32, entry: u64, funcs: *of.ExecFunction,
                        func_count: u32, dyn: *of.DynamicInfo,
                        fixups: *of.PltFixup, fixup_count: u32, path: *u8) Result[bool, str] {
-    ret write_pe(alloc, isa_vt, segs, seg_count, entry, funcs, func_count, dyn, fixups, fixup_count, path);
+    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, dyn, fixups, fixup_count, path);
 }
 
 # write_pe: the shared PE32+ executable writer behind `coff_emit_exec` (static)
@@ -2066,7 +2068,7 @@ fun coff_emit_dyn_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.Load
 # COFF file header, PE32+ optional header (ImageBase, alignments, entry, subsystem,
 # data directories), the section table, and every section's bytes. each `PltFixup`
 # call site is redirected to its import stub.
-fun write_pe(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
+fun write_pe(alloc: *Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
              seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
              dyn: *of.DynamicInfo,
              fixups: *of.PltFixup, fixup_count: u32, path: *u8) Result[bool, str] {
@@ -2103,7 +2105,7 @@ fun write_pe(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
     }
 
     var lay: PeLayout;
-    val total_size: usize = compute_pe_layout(?lay, segs, seg_count, dyn, seg_secs, xdata_vsize, pdata_vsize);
+    val total_size: usize = compute_pe_layout(itn, ?lay, segs, seg_count, dyn, seg_secs, xdata_vsize, pdata_vsize);
 
     val res_buf: Result[*u8, str] = zallocate[u8](alloc, total_size);
     if (is_err[*u8, str](res_buf)) {
@@ -2124,7 +2126,7 @@ fun write_pe(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
 
     # synthesized sections: the import directory + IAT, then the import stubs that
     # jump through the IAT slots the import section owns.
-    if (lay.have_idata) { write_pe_imports(buf, ?lay, dyn); }
+    if (lay.have_idata) { write_pe_imports(itn, buf, ?lay, dyn); }
     if (lay.have_stub)  { write_pe_stubs(buf, ?lay, dyn); }
     if (lay.have_xdata || lay.have_pdata) { write_pe_unwind(buf, ?lay, uw_all, uw_count); }
 
@@ -2168,7 +2170,7 @@ fun write_pe(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
 # hint/name entries); the loader overwrites each IAT thunk with the resolved
 # function address. a thunk with bit 63 set would be an import-by-ordinal; every
 # thunk here is an RVA into the hint/name table (import-by-name).
-fun write_pe_imports(buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo) {
+fun write_pe_imports(itn: *intern.Interner, buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo) {
     val sec_off: usize = lay.idata_sec.file_off;
     val sec_rva: u64   = lay.idata_sec.rva;
 
@@ -2205,7 +2207,7 @@ fun write_pe_imports(buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo) {
                 # hint = 0; the loader falls back to a binary search by name.
                 bin.write_u16_le(buf, sec_off + hcur, 0);
                 hcur = hcur + 2;
-                hcur = hcur + bin.write_str(buf, sec_off + hcur, resolve(dyn.imports[imp].symbol));
+                hcur = hcur + bin.write_str(buf, sec_off + hcur, resolve(itn, dyn.imports[imp].symbol));
                 hcur = bin.align_up(hcur, 2);
 
                 # ILT[thunk_ix] and IAT[thunk_ix] = RVA of the hint/name entry.
@@ -2222,7 +2224,7 @@ fun write_pe_imports(buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo) {
 
         # the dll-name string for this dependency.
         val name_rva: u64 = sec_rva + hcur::u64;
-        hcur = hcur + bin.write_str(buf, sec_off + hcur, resolve(dyn.libs[lib].soname));
+        hcur = hcur + bin.write_str(buf, sec_off + hcur, resolve(itn, dyn.libs[lib].soname));
         hcur = bin.align_up(hcur, 2);
 
         # IMAGE_IMPORT_DESCRIPTOR: OriginalFirstThunk(ILT), TimeDateStamp,
@@ -2597,23 +2599,20 @@ var coff_vtable: of.OfVTable;
 
 # register_coff: build and install the COFF OfVTable.
 #
-# captures the interner so the reader/writer can resolve `intern.StrId` names,
-# interns the format name ("coff") and file extension ("obj"), fills the vtable,
-# wires the writer/reader, and self-registers it into the process-global OF
-# registry under of.OF_COFF. reentrant: every call re-interns the names and
-# refreshes the captured interner against `i`, so a second session (or test) with
-# a different interner is fully consistent rather than leaving stale ids from the
-# first registration; `of.register` itself is idempotent. abstract relocation
-# kinds are a closed `of.RK_*` enum, so the writer maps them with a plain integer
-# compare and no per-format kind table is interned. must be invoked at compiler
-# startup before target.select requests a Windows target.
+# interns the format name ("coff") and file extension ("obj") into the vtable's
+# string fields, wires the writer/reader, and self-registers it into the
+# process-global OF registry under of.OF_COFF. reentrant: every call re-interns
+# the names against `i`, so a second session (or test) with a different interner
+# is consistent rather than leaving stale ids; `of.register` itself is idempotent.
+# the reader/writer no longer capture an interner — they resolve names through the
+# `interner` each `ObjectImage` carries (and the one passed to parse/dyn-exec) —
+# and relocation kinds are a closed `of.RK_*` enum the writer maps with a plain
+# integer compare. must be invoked at compiler startup before target.select
+# requests a Windows target.
 # ---
-# i:   string interner used to intern the vtable's string fields and captured for
-#      the reader/writer
+# i:   string interner used to intern the vtable's string fields
 # ret: true on success, or an error string if name interning fails
 pub fun register_coff(i: *intern.Interner) Result[bool, str] {
-    coff_interner = i;
-
     val rn: Result[intern.StrId, str] = intern.intern(i, "coff");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
 
@@ -2692,6 +2691,7 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 3;
     img.symbols = ?syms[0]; img.symbol_count = 3;
@@ -2728,7 +2728,7 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
 
     # parse the bytes back into a fresh image and verify the round-trip.
     var out: of.ObjectImage;
-    val pr: Result[bool, str] = coff_parse_object(?alloc, buf.data, buf.len, ?out);
+    val pr: Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
     if (is_err[bool, str](pr)) { ret 1; }
 
     if (out.section_count != 3) { ret 1; }
@@ -2829,6 +2829,7 @@ test "coff: emit rejects a relocation naming an unresolved symbol (#1196)" {
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 1;
@@ -2890,6 +2891,7 @@ test "coff: a defined weak symbol round-trips its weak flag through a COMDAT sec
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 3;
@@ -2924,7 +2926,7 @@ test "coff: a defined weak symbol round-trips its weak flag through a COMDAT sec
     if (comdat_secs != 1) { ret 1; }
 
     var out: of.ObjectImage;
-    val pr: Result[bool, str] = coff_parse_object(?alloc, buf.data, buf.len, ?out);
+    val pr: Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
     if (is_err[bool, str](pr)) { ret 1; }
 
     # the weak symbol recovers its WEAK flag; the strong `main` does not; `puts`
@@ -3010,6 +3012,7 @@ test "coff: long section and symbol names round-trip through the string table" {
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 1;
@@ -3031,7 +3034,7 @@ test "coff: long section and symbol names round-trip through the string table" {
     if (buf.data[COFF_HEADER_SIZE] != '/') { ret 1; }
 
     var out: of.ObjectImage;
-    val pr: Result[bool, str] = coff_parse_object(?alloc, buf.data, buf.len, ?out);
+    val pr: Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
     if (is_err[bool, str](pr)) { ret 1; }
 
     # the long section name interns to the same id it was emitted under.
@@ -3161,6 +3164,7 @@ test "coff: a function-flagged call-target import round-trips DT_FUNCTION" {
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 2;
@@ -3179,7 +3183,7 @@ test "coff: a function-flagged call-target import round-trips DT_FUNCTION" {
     val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
 
     var out: of.ObjectImage;
-    val pr: Result[bool, str] = coff_parse_object(?alloc, buf.data, buf.len, ?out);
+    val pr: Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
     if (is_err[bool, str](pr)) { ret 1; }
 
     var saw: bool = false;
@@ -3237,6 +3241,7 @@ test "coff: parse infers function imports from a foreign object's call relocatio
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 2;
@@ -3255,7 +3260,7 @@ test "coff: parse infers function imports from a foreign object's call relocatio
     val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
 
     var out: of.ObjectImage;
-    val pr: Result[bool, str] = coff_parse_object(?alloc, buf.data, buf.len, ?out);
+    val pr: Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
     if (is_err[bool, str](pr)) { ret 1; }
 
     var saw: bool = false;
@@ -3520,6 +3525,7 @@ test "coff: emit rejects a relocation whose kind has no COFF machine type (#1256
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 1;
@@ -3570,6 +3576,7 @@ test "coff: parse rejects a foreign ADDR32 relocation type (#1256)" {
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 1;
@@ -3596,7 +3603,7 @@ test "coff: parse rejects a foreign ADDR32 relocation type (#1256)" {
     bin.write_u16_le(buf.data, rptr + 8, IMAGE_REL_AMD64_ADDR32);
 
     var out: of.ObjectImage;
-    val pr: Result[bool, str] = coff_parse_object(?alloc, buf.data, buf.len, ?out);
+    val pr: Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
     if (!is_err[bool, str](pr)) { ret 1; }
     if (!str_contains(unwrap_err[bool, str](pr), "relocation type")) { ret 1; }
     ret 0;
@@ -3645,6 +3652,7 @@ test "coff: emit rejects a section reloc count above the u16 limit (#1256)" {
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 1;
@@ -3689,6 +3697,7 @@ test "coff: parse rejects a truncated object instead of reading out of bounds (#
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 1;
@@ -3711,10 +3720,10 @@ test "coff: parse rejects a truncated object instead of reading out of bounds (#
     # symbol table and relocation arrays now lie beyond the end) must error rather
     # than walk off the mapped bytes.
     var ok_out: of.ObjectImage;
-    if (is_err[bool, str](coff_parse_object(?alloc, buf.data, buf.len, ?ok_out))) { ret 1; }
+    if (is_err[bool, str](coff_parse_object(?alloc, ?i, buf.data, buf.len, ?ok_out))) { ret 1; }
 
     var out: of.ObjectImage;
-    val pr: Result[bool, str] = coff_parse_object(?alloc, buf.data, COFF_HEADER_SIZE + 8, ?out);
+    val pr: Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, COFF_HEADER_SIZE + 8, ?out);
     if (!is_err[bool, str](pr)) { ret 1; }
     if (!str_contains(unwrap_err[bool, str](pr), "out of bounds")) { ret 1; }
     ret 0;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -166,13 +166,6 @@ val UWREG_RBP: u8 = 5;
 # `intern.StrId` names carried by `of.ObjectImage`. set by `register_coff`.
 var coff_interner: *intern.Interner = nil;
 
-# interned names of the abstract relocation kinds, filled at registration. the
-# writer matches a `Relocation.kind` StrId directly against these.
-var rk_abs64:    intern.StrId = 0;
-var rk_pc32:     intern.StrId = 0;
-var rk_addr32nb: intern.StrId = 0;
-var rk_plt32:    intern.StrId = 0;
-
 # resolve an interned StrId to its backing text through the captured interner,
 # or nil if no interner is set or the id is out of range.
 fun resolve(id: intern.StrId) str {
@@ -183,24 +176,24 @@ fun resolve(id: intern.StrId) str {
     ret nil;
 }
 
-# map an abstract relocation-kind StrId to the COFF x86-64 machine relocation
-# type. an unmapped kind is an error naming the kind, never silently serialized
-# as ADDR64 (an 8-byte write over what codegen sized as a 4-byte field).
-# pc32/plt32 both encode a 32-bit pc-relative reference (REL32); addr32nb is the
-# image-relative ADDR32NB. `alloc` backs the error string.
-fun reloc_type_for(alloc: *Allocator, kind: intern.StrId) Result[u16, str] {
-    if (kind == rk_abs64)    { ret ok[u16, str](IMAGE_REL_AMD64_ADDR64); }
-    if (kind == rk_pc32)     { ret ok[u16, str](IMAGE_REL_AMD64_REL32); }
-    if (kind == rk_plt32)    { ret ok[u16, str](IMAGE_REL_AMD64_REL32); }
-    if (kind == rk_addr32nb) { ret ok[u16, str](IMAGE_REL_AMD64_ADDR32NB); }
+# map an abstract relocation kind to the COFF x86-64 machine relocation type. an
+# unmapped kind is an error naming the kind, never silently serialized as ADDR64
+# (an 8-byte write over what codegen sized as a 4-byte field). pc32/plt32 both
+# encode a 32-bit pc-relative reference (REL32); addr32nb is the image-relative
+# ADDR32NB. `alloc` backs the error string.
+fun reloc_type_for(alloc: *Allocator, kind: of.RelocKind) Result[u16, str] {
+    if (kind == of.RK_ABS64)    { ret ok[u16, str](IMAGE_REL_AMD64_ADDR64); }
+    if (kind == of.RK_PC32)     { ret ok[u16, str](IMAGE_REL_AMD64_REL32); }
+    if (kind == of.RK_PLT32)    { ret ok[u16, str](IMAGE_REL_AMD64_REL32); }
+    if (kind == of.RK_ADDR32NB) { ret ok[u16, str](IMAGE_REL_AMD64_ADDR32NB); }
     ret err[u16, str](unsupported_kind_message(alloc, kind));
 }
 
 # "coff: unsupported relocation kind: <name>" for an abstract kind the writer has
 # no width-correct COFF machine type for.
-fun unsupported_kind_message(alloc: *Allocator, kind: intern.StrId) str {
+fun unsupported_kind_message(alloc: *Allocator, kind: of.RelocKind) str {
     ret bin.name_message(coff_interner, alloc, "coff: unsupported relocation kind: ",
-                         resolve(kind), "coff: unsupported relocation kind");
+                         of.reloc_kind_name(kind), "coff: unsupported relocation kind");
 }
 
 # "coff: unsupported relocation type <n>" for a machine type the parser cannot
@@ -238,16 +231,16 @@ fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
     ret (bin.read_u32_le(sec.bytes, offset::usize)::i32)::i64;
 }
 
-# map a COFF x86-64 machine relocation type back to its abstract RK_* kind name.
-# an unrecognized type is an error naming the type rather than a silent
-# fall-through to abs64. ADDR32 (a 32-bit absolute) is rejected too: there is no
-# width-correct abstract kind for it, and aliasing it to abs64 would link a
-# foreign object's 4-byte field with an 8-byte write.
-fun reloc_kind_for(alloc: *Allocator, r_type: u16) Result[intern.StrId, str] {
-    if (r_type == IMAGE_REL_AMD64_ADDR64)   { ret ok[intern.StrId, str](rk_abs64); }
-    if (r_type == IMAGE_REL_AMD64_REL32)    { ret ok[intern.StrId, str](rk_pc32); }
-    if (r_type == IMAGE_REL_AMD64_ADDR32NB) { ret ok[intern.StrId, str](rk_addr32nb); }
-    ret err[intern.StrId, str](unsupported_type_message(alloc, r_type::u64));
+# map a COFF x86-64 machine relocation type back to its abstract RK_* kind. an
+# unrecognized type is an error naming the type rather than a silent fall-through
+# to abs64. ADDR32 (a 32-bit absolute) is rejected too: there is no width-correct
+# abstract kind for it, and aliasing it to abs64 would link a foreign object's
+# 4-byte field with an 8-byte write.
+fun reloc_kind_for(alloc: *Allocator, r_type: u16) Result[of.RelocKind, str] {
+    if (r_type == IMAGE_REL_AMD64_ADDR64)   { ret ok[of.RelocKind, str](of.RK_ABS64); }
+    if (r_type == IMAGE_REL_AMD64_REL32)    { ret ok[of.RelocKind, str](of.RK_PC32); }
+    if (r_type == IMAGE_REL_AMD64_ADDR32NB) { ret ok[of.RelocKind, str](of.RK_ADDR32NB); }
+    ret err[of.RelocKind, str](unsupported_type_message(alloc, r_type::u64));
 }
 
 # COFF section characteristics for an abstract section kind (the alignment bits
@@ -429,8 +422,8 @@ fun validate_reloc_symbols(img: *of.ObjectImage) Result[bool, str] {
 # 64-bit absolute kind, 4 for every other supported kind (pc32 / plt32 / addr32nb,
 # all 4-byte). derived from the abstract kind directly; `validate_reloc_kinds`
 # rejects any kind the writer cannot map before this is consulted.
-fun reloc_field_width(kind: intern.StrId) usize {
-    if (kind == rk_abs64) { ret 8; }
+fun reloc_field_width(kind: of.RelocKind) usize {
+    if (kind == of.RK_ABS64) { ret 8; }
     ret 4;
 }
 
@@ -1383,12 +1376,12 @@ fun coff_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obj
             val r_off:  u32 = bin.read_u32_le(buf, ro);
             out.relocations[idx].section = s;
             out.relocations[idx].offset = r_off;
-            val rk: Result[intern.StrId, str] = reloc_kind_for(alloc, r_type);
-            if (is_err[intern.StrId, str](rk)) {
+            val rk: Result[of.RelocKind, str] = reloc_kind_for(alloc, r_type);
+            if (is_err[of.RelocKind, str](rk)) {
                 deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
-                ret err[bool, str](unwrap_err[intern.StrId, str](rk));
+                ret err[bool, str](unwrap_err[of.RelocKind, str](rk));
             }
-            out.relocations[idx].kind = unwrap_ok[intern.StrId, str](rk);
+            out.relocations[idx].kind = unwrap_ok[of.RelocKind, str](rk);
             # COFF carries the addend in-place in the patched field, not in the
             # relocation record (no RELA addend). recover it as a signed value the
             # abstract `S + A - P` / `S + A` applier expects — a 64-bit field for
@@ -1476,7 +1469,7 @@ fun infer_extern_function_flags_from_calls(out: *of.ObjectImage) Result[bool, st
     for (ri < out.reloc_count) {
         val r: *of.Relocation = ?out.relocations[ri];
         if (r.symbol == intern.STR_NIL) { ri = ri + 1; cnt; }
-        if (r.kind != rk_pc32 && r.kind != rk_plt32) { ri = ri + 1; cnt; }
+        if (r.kind != of.RK_PC32 && r.kind != of.RK_PLT32) { ri = ri + 1; cnt; }
         if (r.section >= out.section_count) { ri = ri + 1; cnt; }
         val sec: *of.Section = ?out.sections[r.section];
         if (sec.bytes == nil || r.offset == 0) { ri = ri + 1; cnt; }
@@ -2598,9 +2591,6 @@ fun segment_name(flags: u32, has_data: bool) str {
     ret ".rdata";
 }
 
-# the COFF relocation-kind table, indexed by entry order. populated by register.
-var coff_reloc_kinds: [4]of.RelocationKind;
-
 # the COFF OF vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry.
 var coff_vtable: of.OfVTable;
@@ -2608,14 +2598,15 @@ var coff_vtable: of.OfVTable;
 # register_coff: build and install the COFF OfVTable.
 #
 # captures the interner so the reader/writer can resolve `intern.StrId` names,
-# interns the format name ("coff"), file extension ("obj"), and relocation-kind
-# names, fills the relocation-kind table and vtable, wires the writer/reader, and
-# self-registers it into the process-global OF registry under of.OF_COFF.
-# reentrant: every call re-interns all names and refreshes the captured interner
-# and the `rk_*` / vtable kind handles against `i`, so a second session (or test)
-# with a different interner is fully consistent rather than leaving stale ids from
-# the first registration; `of.register` itself is idempotent. must be invoked at
-# compiler startup before target.select requests a Windows target.
+# interns the format name ("coff") and file extension ("obj"), fills the vtable,
+# wires the writer/reader, and self-registers it into the process-global OF
+# registry under of.OF_COFF. reentrant: every call re-interns the names and
+# refreshes the captured interner against `i`, so a second session (or test) with
+# a different interner is fully consistent rather than leaving stale ids from the
+# first registration; `of.register` itself is idempotent. abstract relocation
+# kinds are a closed `of.RK_*` enum, so the writer maps them with a plain integer
+# compare and no per-format kind table is interned. must be invoked at compiler
+# startup before target.select requests a Windows target.
 # ---
 # i:   string interner used to intern the vtable's string fields and captured for
 #      the reader/writer
@@ -2629,48 +2620,6 @@ pub fun register_coff(i: *intern.Interner) Result[bool, str] {
     val rx: Result[intern.StrId, str] = intern.intern(i, "obj");
     if (is_err[intern.StrId, str](rx)) { ret err[bool, str](unwrap_err[intern.StrId, str](rx)); }
 
-    val ra: Result[intern.StrId, str] = intern.intern(i, "abs64");
-    if (is_err[intern.StrId, str](ra)) { ret err[bool, str](unwrap_err[intern.StrId, str](ra)); }
-
-    val rp: Result[intern.StrId, str] = intern.intern(i, "pc32");
-    if (is_err[intern.StrId, str](rp)) { ret err[bool, str](unwrap_err[intern.StrId, str](rp)); }
-
-    val rab: Result[intern.StrId, str] = intern.intern(i, "addr32nb");
-    if (is_err[intern.StrId, str](rab)) { ret err[bool, str](unwrap_err[intern.StrId, str](rab)); }
-
-    val rb: Result[intern.StrId, str] = intern.intern(i, "plt32");
-    if (is_err[intern.StrId, str](rb)) { ret err[bool, str](unwrap_err[intern.StrId, str](rb)); }
-
-    rk_abs64    = unwrap_ok[intern.StrId, str](ra);
-    rk_pc32     = unwrap_ok[intern.StrId, str](rp);
-    rk_addr32nb = unwrap_ok[intern.StrId, str](rab);
-    rk_plt32    = unwrap_ok[intern.StrId, str](rb);
-
-    # abs64 → IMAGE_REL_AMD64_ADDR64 (64-bit absolute, not pc-relative)
-    coff_reloc_kinds[0].id        = of.RK_ABS64::u32;
-    coff_reloc_kinds[0].name      = rk_abs64;
-    coff_reloc_kinds[0].bit_width = 64;
-    coff_reloc_kinds[0].pc_rel    = false;
-
-    # pc32 → IMAGE_REL_AMD64_REL32 (32-bit pc-relative)
-    coff_reloc_kinds[1].id        = of.RK_PC32::u32;
-    coff_reloc_kinds[1].name      = rk_pc32;
-    coff_reloc_kinds[1].bit_width = 32;
-    coff_reloc_kinds[1].pc_rel    = true;
-
-    # addr32nb → IMAGE_REL_AMD64_ADDR32NB (32-bit image-relative, not pc-rel)
-    coff_reloc_kinds[2].id        = of.RK_ADDR32NB::u32;
-    coff_reloc_kinds[2].name      = rk_addr32nb;
-    coff_reloc_kinds[2].bit_width = 32;
-    coff_reloc_kinds[2].pc_rel    = false;
-
-    # plt32 → IMAGE_REL_AMD64_REL32 (a call through an import thunk is a plain
-    # 32-bit pc-relative reference on x86-64; COFF has no separate PLT type).
-    coff_reloc_kinds[3].id        = of.RK_PLT32::u32;
-    coff_reloc_kinds[3].name      = rk_plt32;
-    coff_reloc_kinds[3].bit_width = 32;
-    coff_reloc_kinds[3].pc_rel    = true;
-
     coff_vtable.id               = of.OF_COFF;
     coff_vtable.name             = unwrap_ok[intern.StrId, str](rn);
     coff_vtable.file_extension   = unwrap_ok[intern.StrId, str](rx);
@@ -2678,8 +2627,6 @@ pub fun register_coff(i: *intern.Interner) Result[bool, str] {
     coff_vtable.parse_object     = coff_parse_object;
     coff_vtable.emit_exec        = coff_emit_exec;
     coff_vtable.emit_dyn_exec    = coff_emit_dyn_exec;
-    coff_vtable.relocation_kinds = ?coff_reloc_kinds[0];
-    coff_vtable.relocation_count = 4;
 
     of.register(?coff_vtable);
     ret ok[bool, str](true);
@@ -2706,7 +2653,6 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
-    val vt: *of.OfVTable = unwrap[*of.OfVTable](vt_o);
 
     # a minimal isa vtable: the writer reads only its `id`.
     var isa_vt: isa.IsaVTable;
@@ -2737,13 +2683,11 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
     syms[2].name = t_intern(?i, "puts"); syms[2].section = of.SECTION_EXTERNAL;
     syms[2].offset = 0; syms[2].size = 0; syms[2].flags = of.SYM_OBJ_FLAG_EXTERN;
 
-    val k_pc32:  intern.StrId = of.reloc_kind_name(vt, of.RK_PC32);
-    val k_abs64: intern.StrId = of.reloc_kind_name(vt, of.RK_ABS64);
 
     var relocs: [2]of.Relocation;
-    relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = k_pc32;
+    relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
     relocs[0].symbol = syms[2].name; relocs[0].addend = 0;
-    relocs[1].section = 0; relocs[1].offset = 4; relocs[1].kind = k_abs64;
+    relocs[1].section = 0; relocs[1].offset = 4; relocs[1].kind = of.RK_ABS64;
     relocs[1].symbol = syms[1].name; relocs[1].addend = 0;
 
     var img: of.ObjectImage;
@@ -2836,9 +2780,9 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
     var rj: u32 = 0;
     for (rj < out.reloc_count) {
         if (out.relocations[rj].section != 0) { ret 1; }
-        if (out.relocations[rj].offset == 1 && out.relocations[rj].kind == k_pc32
+        if (out.relocations[rj].offset == 1 && out.relocations[rj].kind == of.RK_PC32
             && out.relocations[rj].symbol == syms[2].name) { saw_pc32 = true; }
-        if (out.relocations[rj].offset == 4 && out.relocations[rj].kind == k_abs64
+        if (out.relocations[rj].offset == 4 && out.relocations[rj].kind == of.RK_ABS64
             && out.relocations[rj].symbol == syms[1].name) { saw_abs64 = true; }
         rj = rj + 1;
     }
@@ -2857,7 +2801,6 @@ test "coff: emit rejects a relocation naming an unresolved symbol (#1196)" {
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
-    val vt: *of.OfVTable = unwrap[*of.OfVTable](vt_o);
 
     var isa_vt: isa.IsaVTable;
     isa_vt.id = isa.ARCH_X86_64;
@@ -2880,9 +2823,8 @@ test "coff: emit rejects a relocation naming an unresolved symbol (#1196)" {
     # table — the back-end-invariant violation #1196 must surface as an error,
     # not silently alias the first section symbol.
     val ghost: intern.StrId = t_intern(?i, "ghost_symbol");
-    val k_pc32: intern.StrId = of.reloc_kind_name(vt, of.RK_PC32);
     var relocs: [1]of.Relocation;
-    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = k_pc32;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
     relocs[0].symbol = ghost; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
@@ -2915,7 +2857,6 @@ test "coff: a defined weak symbol round-trips its weak flag through a COMDAT sec
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
-    val vt: *of.OfVTable = unwrap[*of.OfVTable](vt_o);
 
     var isa_vt: isa.IsaVTable;
     isa_vt.id = isa.ARCH_X86_64;
@@ -2942,10 +2883,9 @@ test "coff: a defined weak symbol round-trips its weak flag through a COMDAT sec
     syms[2].name = t_intern(?i, "puts"); syms[2].section = of.SECTION_EXTERNAL;
     syms[2].offset = 0; syms[2].size = 0; syms[2].flags = of.SYM_OBJ_FLAG_EXTERN;
 
-    val k_pc32: intern.StrId = of.reloc_kind_name(vt, of.RK_PC32);
 
     var relocs: [1]of.Relocation;
-    relocs[0].section = 0; relocs[0].offset = 12; relocs[0].kind = k_pc32;
+    relocs[0].section = 0; relocs[0].offset = 12; relocs[0].kind = of.RK_PC32;
     relocs[0].symbol = syms[2].name; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
@@ -3192,7 +3132,6 @@ test "coff: a function-flagged call-target import round-trips DT_FUNCTION" {
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
-    val vt: *of.OfVTable = unwrap[*of.OfVTable](vt_o);
 
     var isa_vt: isa.IsaVTable;
     isa_vt.id = isa.ARCH_X86_64;
@@ -3216,9 +3155,8 @@ test "coff: a function-flagged call-target import round-trips DT_FUNCTION" {
     syms[1].flags =
         of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_FUNCTION;
 
-    val k_pc32: intern.StrId = of.reloc_kind_name(vt, of.RK_PC32);
     var relocs: [1]of.Relocation;
-    relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = k_pc32;
+    relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
     relocs[0].symbol = syms[1].name; relocs[0].addend = -4;
 
     var img: of.ObjectImage;
@@ -3269,7 +3207,6 @@ test "coff: parse infers function imports from a foreign object's call relocatio
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
-    val vt: *of.OfVTable = unwrap[*of.OfVTable](vt_o);
 
     var isa_vt: isa.IsaVTable;
     isa_vt.id = isa.ARCH_X86_64;
@@ -3294,9 +3231,8 @@ test "coff: parse infers function imports from a foreign object's call relocatio
     # parser must recover function intent from the call reloc so the import binds.
     syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN;
 
-    val k_pc32: intern.StrId = of.reloc_kind_name(vt, of.RK_PC32);
     var relocs: [1]of.Relocation;
-    relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = k_pc32;
+    relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
     relocs[0].symbol = syms[1].name; relocs[0].addend = -4;
 
     var img: of.ObjectImage;
@@ -3575,12 +3511,11 @@ test "coff: emit rejects a relocation whose kind has no COFF machine type (#1256
     syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
     syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
 
-    # a defined symbol but a kind COFF has no machine type for (gotpcrel is ELF-only)
-    # — before #1256 it was silently serialized as ADDR64 (an 8-byte write over the
-    # 4-byte field); it must now fail naming the kind.
-    val bogus: intern.StrId = t_intern(?i, "gotpcrel");
+    # a defined symbol but a kind COFF has no machine type for (RK_GOTPCREL is
+    # ELF-only) — before #1256 it was silently serialized as ADDR64 (an 8-byte write
+    # over the 4-byte field); it must now fail naming the kind.
     var relocs: [1]of.Relocation;
-    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = bogus;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_GOTPCREL;
     relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
@@ -3613,7 +3548,6 @@ test "coff: parse rejects a foreign ADDR32 relocation type (#1256)" {
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
-    val vt: *of.OfVTable = unwrap[*of.OfVTable](vt_o);
 
     var isa_vt: isa.IsaVTable;
     isa_vt.id = isa.ARCH_X86_64;
@@ -3630,9 +3564,8 @@ test "coff: parse rejects a foreign ADDR32 relocation type (#1256)" {
     syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
     syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
 
-    val k_pc32: intern.StrId = of.reloc_kind_name(vt, of.RK_PC32);
     var relocs: [1]of.Relocation;
-    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = k_pc32;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
     relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
@@ -3679,7 +3612,6 @@ test "coff: emit rejects a section reloc count above the u16 limit (#1256)" {
 
     val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
-    val k_pc32: intern.StrId = of.reloc_kind_name(unwrap[*of.OfVTable](vt_o), of.RK_PC32);
 
     var isa_vt: isa.IsaVTable;
     isa_vt.id = isa.ARCH_X86_64;
@@ -3706,7 +3638,7 @@ test "coff: emit rejects a section reloc count above the u16 limit (#1256)" {
     val relocs: *of.Relocation = unwrap_ok[*of.Relocation, str](rrl);
     var r: u32 = 0;
     for (r < nrel) {
-        relocs[r].section = 0; relocs[r].offset = 0; relocs[r].kind = k_pc32;
+        relocs[r].section = 0; relocs[r].offset = 0; relocs[r].kind = of.RK_PC32;
         relocs[r].symbol = syms[0].name; relocs[r].addend = 0;
         r = r + 1;
     }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -10,16 +10,15 @@
 # covers the ELF header and phdrs, page-aligned loadable segments) and the
 # object parser plus relocation applier that the linker drives.
 #
-# The abstract `of.RK_*` relocation kinds are interned at registration; the
-# writer matches a `Relocation.kind` StrId directly against those handles and
-# maps it to the machine relocation type for the ISA it is handed
-# (`ARCH_X86_64` -> R_X86_64_*; `ARCH_AARCH64` -> R_AARCH64_*).
+# The abstract `of.RK_*` relocation kinds are a closed enum; the writer maps a
+# `Relocation.kind` to the machine relocation type for the ISA it is handed with
+# a plain integer compare (`ARCH_X86_64` -> R_X86_64_*; `ARCH_AARCH64` ->
+# R_AARCH64_*), no interner involved.
 #
-# `WriterFn` carries no interner, yet section/symbol names are `intern.StrId`.
-# `register` captures the session interner in a module-level pointer (exactly
-# as it interns the vtable's own string fields), and the writer resolves names
-# through it. `be.obj.emit` must register the ELF format with the active
-# session interner before emitting.
+# Section/symbol names are `intern.StrId`, so the writer resolves them through the
+# interner each `of.ObjectImage` carries beside its allocator; the parser and the
+# dynamic-executable writer take the interner as a parameter. no module-global
+# interner is captured — `register` only interns the vtable's own name fields.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -144,16 +143,12 @@ val RELA_SIZE:       usize = 24;
 # default page size for static executables; segment vaddrs are page-aligned.
 val EXEC_PAGE_SIZE: u64 = 4096;
 
-# session interner captured at registration so the writer can resolve the
-# `intern.StrId` names carried by `of.ObjectImage`. set by `register`.
-var elf_interner: *intern.Interner = nil;
-
-# resolve an interned StrId to its backing text through the captured interner,
-# or nil if no interner is set or the id is out of range.
-fun resolve(id: intern.StrId) str {
-    if (elf_interner == nil) { ret nil; }
+# resolve an interned StrId to its backing text through `itn`, or nil if no
+# interner is given or the id is out of range.
+fun resolve(itn: *intern.Interner, id: intern.StrId) str {
+    if (itn == nil) { ret nil; }
     if (id == intern.STR_NIL) { ret nil; }
-    val o: Option[str] = intern.lookup(elf_interner, id);
+    val o: Option[str] = intern.lookup(itn, id);
     if (is_some[str](o)) { ret unwrap[str](o); }
     ret nil;
 }
@@ -162,46 +157,46 @@ fun resolve(id: intern.StrId) str {
 # given ISA. an unmapped kind is an error naming the kind, never silently
 # serialized as the 64-bit absolute type (an 8-byte write over a 4-byte field) —
 # a kind the format has no width-correct machine type for must fail the emit, not
-# corrupt the object. `alloc` backs the error string.
-fun reloc_type_for(alloc: *Allocator, kind: of.RelocKind, arch_id: u32) Result[u32, str] {
+# corrupt the object. `itn`/`alloc` back the error string.
+fun reloc_type_for(itn: *intern.Interner, alloc: *Allocator, kind: of.RelocKind, arch_id: u32) Result[u32, str] {
     if (arch_id == isa.ARCH_AARCH64) {
         if (kind == of.RK_ABS64) { ret ok[u32, str](R_AARCH64_ABS64); }
         if (kind == of.RK_PC32)  { ret ok[u32, str](R_AARCH64_PREL32); }
         if (kind == of.RK_PLT32) { ret ok[u32, str](R_AARCH64_CALL26); }
-        ret err[u32, str](unsupported_kind_message(alloc, kind));
+        ret err[u32, str](unsupported_kind_message(itn, alloc, kind));
     }
     if (kind == of.RK_ABS64)    { ret ok[u32, str](R_X86_64_64); }
     if (kind == of.RK_PC32)     { ret ok[u32, str](R_X86_64_PC32); }
     if (kind == of.RK_PLT32)    { ret ok[u32, str](R_X86_64_PLT32); }
     if (kind == of.RK_GOTPCREL) { ret ok[u32, str](R_X86_64_GOTPCREL); }
     if (kind == of.RK_ABS32S)   { ret ok[u32, str](R_X86_64_32S); }
-    ret err[u32, str](unsupported_kind_message(alloc, kind));
+    ret err[u32, str](unsupported_kind_message(itn, alloc, kind));
 }
 
 # map an ELF machine relocation type back to its abstract RK_* kind. an
 # unrecognized type is an error naming the type rather than a silent fall-through
 # to abs64 — a foreign object's 4-byte type (e.g. R_X86_64_32) must not be linked
 # as a 64-bit absolute, which would write 8 bytes over the 4-byte field.
-fun reloc_kind_for(alloc: *Allocator, r_type: u32) Result[of.RelocKind, str] {
+fun reloc_kind_for(itn: *intern.Interner, alloc: *Allocator, r_type: u32) Result[of.RelocKind, str] {
     if (r_type == R_X86_64_64 || r_type == R_AARCH64_ABS64) { ret ok[of.RelocKind, str](of.RK_ABS64); }
     if (r_type == R_X86_64_PC32 || r_type == R_AARCH64_PREL32) { ret ok[of.RelocKind, str](of.RK_PC32); }
     if (r_type == R_X86_64_PLT32 || r_type == R_AARCH64_CALL26) { ret ok[of.RelocKind, str](of.RK_PLT32); }
     if (r_type == R_X86_64_GOTPCREL) { ret ok[of.RelocKind, str](of.RK_GOTPCREL); }
     if (r_type == R_X86_64_32S) { ret ok[of.RelocKind, str](of.RK_ABS32S); }
-    ret err[of.RelocKind, str](unsupported_type_message(alloc, r_type::u64));
+    ret err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
 }
 
 # "elf: unsupported relocation kind: <name>" for an abstract kind the writer has
 # no width-correct ELF machine type for.
-fun unsupported_kind_message(alloc: *Allocator, kind: of.RelocKind) str {
-    ret bin.name_message(elf_interner, alloc, "elf: unsupported relocation kind: ",
+fun unsupported_kind_message(itn: *intern.Interner, alloc: *Allocator, kind: of.RelocKind) str {
+    ret bin.name_message(itn, alloc, "elf: unsupported relocation kind: ",
                          of.reloc_kind_name(kind), "elf: unsupported relocation kind");
 }
 
 # "elf: unsupported relocation type <n>" for a machine type the parser cannot map
 # to an abstract kind.
-fun unsupported_type_message(alloc: *Allocator, r_type: u64) str {
-    ret bin.number_message(elf_interner, alloc, "elf: unsupported relocation type ",
+fun unsupported_type_message(itn: *intern.Interner, alloc: *Allocator, r_type: u64) str {
+    ret bin.number_message(itn, alloc, "elf: unsupported relocation type ",
                            r_type, "elf: unsupported relocation type");
 }
 
@@ -211,7 +206,7 @@ fun unsupported_type_message(alloc: *Allocator, r_type: u64) str {
 fun validate_reloc_kinds(img: *of.ObjectImage, arch_id: u32) Result[bool, str] {
     var i: u32 = 0;
     for (i < img.reloc_count) {
-        val r: Result[u32, str] = reloc_type_for(img.alloc, img.relocations[i].kind, arch_id);
+        val r: Result[u32, str] = reloc_type_for(img.interner, img.alloc, img.relocations[i].kind, arch_id);
         if (is_err[u32, str](r)) { ret err[bool, str](unwrap_err[u32, str](r)); }
         i = i + 1;
     }
@@ -273,7 +268,7 @@ fun strtab_size(img: *of.ObjectImage) usize {
     var total: usize = 1;
     var i: u32 = 0;
     for (i < img.symbol_count) {
-        val name: str = resolve(img.symbols[i].name);
+        val name: str = resolve(img.interner, img.symbols[i].name);
         if (name != nil) { total = total + str_len(name) + 1; } or { total = total + 1; }
         i = i + 1;
     }
@@ -298,15 +293,15 @@ fun reloc_sym_index(img: *of.ObjectImage, sym: intern.StrId) Result[u32, str] {
             i = i + 1;
         }
     }
-    ret err[u32, str](unresolved_reloc_message(img.alloc, sym));
+    ret err[u32, str](unresolved_reloc_message(img.interner, img.alloc, sym));
 }
 
 # build the "elf: unresolved relocation symbol: <name>" diagnostic. an unnamed
 # (STR_NIL) target, or interning failure under memory pressure, degrades to the
 # generic static form; the emit still fails.
-fun unresolved_reloc_message(alloc: *Allocator, sym: intern.StrId) str {
-    ret bin.name_message(elf_interner, alloc, "elf: unresolved relocation symbol: ",
-                         resolve(sym), "elf: relocation references an unresolved symbol");
+fun unresolved_reloc_message(itn: *intern.Interner, alloc: *Allocator, sym: intern.StrId) str {
+    ret bin.name_message(itn, alloc, "elf: unresolved relocation symbol: ",
+                         resolve(itn, sym), "elf: relocation references an unresolved symbol");
 }
 
 # verify every relocation's target symbol resolves to an image symbol, up front
@@ -327,7 +322,7 @@ fun validate_reloc_symbols(img: *of.ObjectImage) Result[bool, str] {
 fun write_symbol(buf: *u8, sym_off: usize, str_off: usize, str_pos: *usize,
                  img: *of.ObjectImage, idx: u32, binding: u8) {
     val name_pos: usize = @str_pos;
-    @str_pos = @str_pos + bin.write_str(buf, str_off + @str_pos, resolve(img.symbols[idx].name));
+    @str_pos = @str_pos + bin.write_str(buf, str_off + @str_pos, resolve(img.interner, img.symbols[idx].name));
     bin.write_u32_le(buf, sym_off, name_pos::u32);
 
     var sym_type: u8 = STT_NOTYPE;
@@ -396,7 +391,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     var shstrtab_cap: usize = 1;
     var s: u32 = 0;
     for (s < num_secs) {
-        val sn: str = resolve(img.sections[s].name);
+        val sn: str = resolve(img.interner, img.sections[s].name);
         if (sn != nil) { shstrtab_cap = shstrtab_cap + str_len(sn) + 1; } or { shstrtab_cap = shstrtab_cap + 1; }
         s = s + 1;
     }
@@ -404,7 +399,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     s = 0;
     for (s < num_secs) {
         if (count_relocs_for_section(img, s) > 0) {
-            val sn: str = resolve(img.sections[s].name);
+            val sn: str = resolve(img.interner, img.sections[s].name);
             if (sn != nil) { shstrtab_cap = shstrtab_cap + 5 + str_len(sn) + 1; } or { shstrtab_cap = shstrtab_cap + 5 + 1; }
         }
         s = s + 1;
@@ -433,7 +428,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     s = 0;
     for (s < num_secs) {
         name_offsets[s] = shstrtab_off::u32;
-        shstrtab_off = shstrtab_off + bin.write_str(shstrtab, shstrtab_off, resolve(img.sections[s].name));
+        shstrtab_off = shstrtab_off + bin.write_str(shstrtab, shstrtab_off, resolve(img.interner, img.sections[s].name));
         s = s + 1;
     }
     val symtab_name_off: u32 = shstrtab_off::u32;
@@ -453,7 +448,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
             shstrtab[shstrtab_off + 3] = 'l';
             shstrtab[shstrtab_off + 4] = 'a';
             shstrtab_off = shstrtab_off + 5;
-            val sn: str = resolve(img.sections[s].name);
+            val sn: str = resolve(img.interner, img.sections[s].name);
             if (sn != nil) {
                 val nlen: usize = str_len(sn);
                 var ni: usize = 0;
@@ -623,7 +618,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
                     val elf_sym: u64 = sym_remap[rsi]::u64;
                     # validate_reloc_kinds proved every kind maps, so the lookup
                     # cannot miss; index 0 / abs64 is never silently substituted.
-                    val elf_type: u32 = unwrap_ok[u32, str](reloc_type_for(alloc, img.relocations[ri].kind, tgt_isa.id));
+                    val elf_type: u32 = unwrap_ok[u32, str](reloc_type_for(img.interner, alloc, img.relocations[ri].kind, tgt_isa.id));
                     val r_info: u64 = (elf_sym << 32) | elf_type::u64;
                     bin.write_u64_le(buf, ro + 8, r_info);
                     bin.write_u64_le(buf, ro + 16, img.relocations[ri].addend::u64);
@@ -758,20 +753,17 @@ var elf_vtable: of.OfVTable;
 
 # register: build the ELF OfVTable and install it into the format registry.
 #
-# captures the interner so the writer can resolve `intern.StrId` names, interns
-# the format name ("elf") and extension ("o"), fills the module-level vtable, and
-# registers it under `of.OF_ELF`. reentrant: every call re-interns the names and
-# refreshes the captured interner against `i`, so a second session (or test) with
-# a different interner is consistent rather than left with stale ids from the
-# first registration; `of.register` is itself idempotent. abstract relocation
-# kinds are a closed `of.RK_*` enum, so the writer maps them with a plain integer
-# compare and no per-format kind table is interned.
+# interns the format name ("elf") and extension ("o") into the vtable's string
+# fields and registers it under `of.OF_ELF`. reentrant: every call re-interns the
+# names against `i`, so a second session (or test) with a different interner is
+# consistent rather than left with stale ids; `of.register` is itself idempotent.
+# the writer no longer captures an interner — it resolves names through the
+# `interner` each `ObjectImage` carries — and relocation kinds are a closed
+# `of.RK_*` enum the writer maps with a plain integer compare.
 # ---
-# i:   interner used to intern the vtable's string fields and capture for the writer
+# i:   interner used to intern the vtable's string fields
 # ret: ok(true) on success, or an allocation error from interning
 pub fun register(i: *intern.Interner) Result[bool, str] {
-    elf_interner = i;
-
     val rname: Result[intern.StrId, str] = intern.intern(i, "elf");
     if (is_err[intern.StrId, str](rname)) { ret err[bool, str](unwrap_err[intern.StrId, str](rname)); }
     val rext: Result[intern.StrId, str] = intern.intern(i, "o");
@@ -976,8 +968,8 @@ fun func_import_count(dyn: *of.DynamicInfo) u32 {
 }
 
 # the byte length of an interned name (its text plus the NUL terminator).
-fun dynstr_name_len(id: intern.StrId) usize {
-    val s: str = resolve(id);
+fun dynstr_name_len(itn: *intern.Interner, id: intern.StrId) usize {
+    val s: str = resolve(itn, id);
     if (s == nil) { ret 1; }
     ret str_len(s) + 1;
 }
@@ -997,6 +989,7 @@ fun dynstr_name_len(id: intern.StrId) usize {
 # absolute virtual addresses stay valid; the static `emit_exec` path is untouched.
 # ---
 # alloc:       allocator for the output buffer and layout scratch
+# itn:         interner resolving the DynamicInfo names (interp, sonames, imports)
 # tgt_isa:     instruction-set vtable selecting the ELF machine and JUMP_SLOT type
 # segs:        the linker's loadable segments, ascending virtual-address order
 # seg_count:   number of segments
@@ -1008,14 +1001,14 @@ fun dynstr_name_len(id: intern.StrId) usize {
 # fixup_count: number of fixups
 # path:        null-terminated output file path
 # ret:         ok(true) on success, or an error string
-fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
+fun emit_dyn_exec(alloc: *Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, entry: u64, funcs: *of.ExecFunction,
                   func_count: u32, dyn: *of.DynamicInfo, fixups: *of.PltFixup,
                   fixup_count: u32, path: *u8) Result[bool, str] {
     if (tgt_isa == nil) { ret err[bool, str]("elf: nil dyn-exec isa"); }
     if (path == nil)    { ret err[bool, str]("elf: nil dyn-exec path"); }
     if (dyn == nil)     { ret err[bool, str]("elf: nil dynamic plan"); }
-    if (elf_interner == nil) { ret err[bool, str]("elf: no interner registered for dyn-exec"); }
+    if (itn == nil)     { ret err[bool, str]("elf: no interner for dyn-exec"); }
 
     # the PLT/GOT stubs below are raw x86-64 instruction bytes, so this writer is
     # x86-64-only; another ISA needs its own per-arch PLT writer. reject it loudly
@@ -1065,7 +1058,7 @@ fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegm
     }
 
     var lay: DynLayout;
-    compute_dyn_layout(?lay, dyn, nimp, bin.align_up(struct_file, EXEC_PAGE_SIZE::usize),
+    compute_dyn_layout(itn, ?lay, dyn, nimp, bin.align_up(struct_file, EXEC_PAGE_SIZE::usize),
                        bin.align_up_u64(hi_va, EXEC_PAGE_SIZE));
 
     val total_size: usize = lay.rw_off + lay.rw_size;
@@ -1133,7 +1126,7 @@ fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegm
     }
 
     # write the synthesized structures, then patch the import call sites.
-    write_dyn_structures(buf, ?lay, dyn, nimp, tgt_isa.id, imp_str, lib_str);
+    write_dyn_structures(itn, buf, ?lay, dyn, nimp, tgt_isa.id, imp_str, lib_str);
     val fx_r: Result[bool, str] =
         patch_plt_fixups(buf, ?lay, dyn, fixups, fixup_count, seg_offsets, segs, seg_count, nimp);
 
@@ -1173,7 +1166,7 @@ fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegm
 # each occupy their own page-aligned load segment so they get distinct loader
 # permissions. file offset and vaddr advance in lockstep within a segment so the
 # loader's `offset % page == vaddr % page` invariant holds.
-fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
+fun compute_dyn_layout(itn: *intern.Interner, lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
                        struct_file: usize, struct_va: u64) {
     val page: usize = EXEC_PAGE_SIZE::usize;
 
@@ -1187,7 +1180,7 @@ fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
     # .interp: the dynamic-loader path (NUL-terminated).
     lay.interp_off  = off;
     lay.interp_va   = va;
-    lay.interp_size = dynstr_name_len(dyn.interp);
+    lay.interp_size = dynstr_name_len(itn, dyn.interp);
     off = off + lay.interp_size;
     va  = va  + lay.interp_size::u64;
 
@@ -1204,14 +1197,14 @@ fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
     lay.dynstr_off = off;
     lay.dynstr_va  = va;
     var dynstr_size: usize = 1;
-    dynstr_size = dynstr_size + dynstr_name_len(dyn.interp);
+    dynstr_size = dynstr_size + dynstr_name_len(itn, dyn.interp);
     var i: u32 = 0;
     for (i < dyn.import_count) {
-        if (dyn.imports[i].is_func) { dynstr_size = dynstr_size + dynstr_name_len(dyn.imports[i].symbol); }
+        if (dyn.imports[i].is_func) { dynstr_size = dynstr_size + dynstr_name_len(itn, dyn.imports[i].symbol); }
         i = i + 1;
     }
     i = 0;
-    for (i < dyn.lib_count) { dynstr_size = dynstr_size + dynstr_name_len(dyn.libs[i].soname); i = i + 1; }
+    for (i < dyn.lib_count) { dynstr_size = dynstr_size + dynstr_name_len(itn, dyn.libs[i].soname); i = i + 1; }
     lay.dynstr_size = dynstr_size;
     off = off + dynstr_size;
     va  = va  + dynstr_size::u64;
@@ -1281,22 +1274,22 @@ fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
 # resolve the imports at run time. the .dynstr offsets computed here are recorded
 # into `imp_str` (per raw import index) and `lib_str` (per dependency) for reuse
 # by the .dynsym / .dynamic writers, so the string table is laid out first.
-fun write_dyn_structures(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
+fun write_dyn_structures(itn: *intern.Interner, buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
                          arch_id: u32, imp_str: *usize, lib_str: *usize) {
     # .interp: the loader path.
-    bin.write_str(buf, lay.interp_off, resolve(dyn.interp));
+    bin.write_str(buf, lay.interp_off, resolve(itn, dyn.interp));
 
     # .dynstr and the offset of every name within it, recorded for .dynsym /
     # .dynamic. the interp path is included so the table is self-contained.
     buf[lay.dynstr_off] = 0;
     var str_pos: usize = 1;
-    str_pos = str_pos + bin.write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.interp));
+    str_pos = str_pos + bin.write_str(buf, lay.dynstr_off + str_pos, resolve(itn, dyn.interp));
 
     var i: u32 = 0;
     for (i < dyn.import_count) {
         if (dyn.imports[i].is_func) {
             imp_str[i] = str_pos;
-            str_pos = str_pos + bin.write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.imports[i].symbol));
+            str_pos = str_pos + bin.write_str(buf, lay.dynstr_off + str_pos, resolve(itn, dyn.imports[i].symbol));
         } or {
             imp_str[i] = 0;
         }
@@ -1305,7 +1298,7 @@ fun write_dyn_structures(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo, nimp: 
     i = 0;
     for (i < dyn.lib_count) {
         lib_str[i] = str_pos;
-        str_pos = str_pos + bin.write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.libs[i].soname));
+        str_pos = str_pos + bin.write_str(buf, lay.dynstr_off + str_pos, resolve(itn, dyn.libs[i].soname));
         i = i + 1;
     }
 
@@ -1606,23 +1599,25 @@ fun write_phdr(buf: *u8, pos: usize, p_type: u32, flags: u32, off: usize, vaddr:
 # reads the section, symbol, and relocation tables of a `.o` produced by
 # `emit_object` (or a compatible toolchain) into a fresh `of.ObjectImage`
 # owning copied section bytes and interned names. relocation kinds are mapped
-# from the ELF machine type back to the abstract `RK_*` names; symbol and
+# from the ELF machine type back to the abstract `RK_*` kinds; symbol and
 # section references are kept by interned name so the linker matches across
-# objects. the captured interner (see `register`) interns the names.
+# objects. `itn` interns the names and is recorded on `out.interner`.
 # ---
 # alloc:    allocator for the image and its arrays
+# itn:      interner the parsed names are interned into and recorded on `out`
 # buf:      the object file bytes
 # buf_size: length of `buf`
 # out:      image to populate (its arrays are allocated here)
 # ret:      ok(true) on success, or an error string
-pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.ObjectImage) Result[bool, str] {
+pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_size: usize, out: *of.ObjectImage) Result[bool, str] {
     if (buf == nil || out == nil || buf_size < ELF_HEADER_SIZE) {
         ret err[bool, str]("elf: object too small");
     }
     if (buf[0] != 0x7F || buf[1] != 0x45 || buf[2] != 0x4C || buf[3] != 0x46) {
         ret err[bool, str]("elf: bad magic");
     }
-    if (elf_interner == nil) { ret err[bool, str]("elf: no interner registered"); }
+    if (itn == nil) { ret err[bool, str]("elf: no interner for parse"); }
+    out.interner = itn;
 
     val e_shoff:     usize = bin.read_u64_le(buf, 40)::usize;
     val e_shentsize: u16   = bin.read_u16_le(buf, 58);
@@ -1751,7 +1746,7 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
                 }
                 sec_name = unwrap_ok[str, str](rnm);
             }
-            val rin: Result[intern.StrId, str] = intern.intern(elf_interner, sec_name);
+            val rin: Result[intern.StrId, str] = intern.intern(itn, sec_name);
             if (is_err[intern.StrId, str](rin)) {
                 deallocate[i32](alloc, sec_map, e_shnum::usize);
                 ret err[bool, str](unwrap_err[intern.StrId, str](rin));
@@ -1803,7 +1798,7 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
                 deallocate[i32](alloc, sec_map, e_shnum::usize);
                 ret err[bool, str](unwrap_err[str, str](rnm));
             }
-            val rin: Result[intern.StrId, str] = intern.intern(elf_interner, unwrap_ok[str, str](rnm));
+            val rin: Result[intern.StrId, str] = intern.intern(itn, unwrap_ok[str, str](rnm));
             if (is_err[intern.StrId, str](rin)) {
                 deallocate[i32](alloc, sec_map, e_shnum::usize);
                 ret err[bool, str](unwrap_err[intern.StrId, str](rin));
@@ -1865,7 +1860,7 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
                 or { out.relocations[idx].section = of.SECTION_EXTERNAL; }
                 out.relocations[idx].offset = bin.read_u64_le(buf, ro)::u32;
                 out.relocations[idx].addend = bin.read_u64_le(buf, ro + 16)::i64;
-                val rk: Result[of.RelocKind, str] = reloc_kind_for(alloc, r_type);
+                val rk: Result[of.RelocKind, str] = reloc_kind_for(itn, alloc, r_type);
                 if (is_err[of.RelocKind, str](rk)) {
                     deallocate[i32](alloc, sec_map, e_shnum::usize);
                     ret err[bool, str](unwrap_err[of.RelocKind, str](rk));
@@ -1930,6 +1925,7 @@ test "elf: emit rejects a relocation naming an unresolved symbol (#1196)" {
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 1;
@@ -1981,6 +1977,7 @@ test "elf: emit rejects a relocation whose kind has no ELF machine type (#1256)"
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 1;
@@ -2028,6 +2025,7 @@ test "elf: parse rejects an unknown machine relocation type (#1256)" {
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 1;
@@ -2063,7 +2061,7 @@ test "elf: parse rejects an unknown machine relocation type (#1256)" {
     bin.write_u32_le(buf.data, rela_off + 8, 10);
 
     var out: of.ObjectImage;
-    val pr: Result[bool, str] = parse_object(?alloc, buf.data, buf.len, ?out);
+    val pr: Result[bool, str] = parse_object(?alloc, ?i, buf.data, buf.len, ?out);
     if (!is_err[bool, str](pr)) { ret 1; }
     if (!str_contains(unwrap_err[bool, str](pr), "relocation type")) { ret 1; }
     ret 0;
@@ -2094,6 +2092,7 @@ test "elf: parse rejects a truncated object instead of reading out of bounds (#1
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
+    img.interner = ?i;
     img.name = t_intern(?i, "test");
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 1;
@@ -2115,10 +2114,10 @@ test "elf: parse rejects a truncated object instead of reading out of bounds (#1
     # the full object parses cleanly; a buffer truncated so e_shoff's section-header
     # table lies past the end must error rather than dereference off the buffer.
     var ok_out: of.ObjectImage;
-    if (is_err[bool, str](parse_object(?alloc, buf.data, buf.len, ?ok_out))) { ret 1; }
+    if (is_err[bool, str](parse_object(?alloc, ?i, buf.data, buf.len, ?ok_out))) { ret 1; }
 
     var out: of.ObjectImage;
-    val pr: Result[bool, str] = parse_object(?alloc, buf.data, ELF_HEADER_SIZE, ?out);
+    val pr: Result[bool, str] = parse_object(?alloc, ?i, buf.data, ELF_HEADER_SIZE, ?out);
     if (!is_err[bool, str](pr)) { ret 1; }
     if (!str_contains(unwrap_err[bool, str](pr), "out of bounds")) { ret 1; }
     ret 0;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -148,14 +148,6 @@ val EXEC_PAGE_SIZE: u64 = 4096;
 # `intern.StrId` names carried by `of.ObjectImage`. set by `register`.
 var elf_interner: *intern.Interner = nil;
 
-# interned names of the abstract relocation kinds, filled at registration. the
-# writer matches a `Relocation.kind` StrId directly against these.
-var rk_abs64:    intern.StrId = 0;
-var rk_pc32:     intern.StrId = 0;
-var rk_plt32:    intern.StrId = 0;
-var rk_gotpcrel: intern.StrId = 0;
-var rk_abs32s:   intern.StrId = 0;
-
 # resolve an interned StrId to its backing text through the captured interner,
 # or nil if no interner is set or the id is out of range.
 fun resolve(id: intern.StrId) str {
@@ -166,44 +158,44 @@ fun resolve(id: intern.StrId) str {
     ret nil;
 }
 
-# map an abstract relocation-kind StrId to the ELF machine relocation type for
-# the given ISA. an unmapped kind is an error naming the kind, never silently
+# map an abstract relocation kind to the ELF machine relocation type for the
+# given ISA. an unmapped kind is an error naming the kind, never silently
 # serialized as the 64-bit absolute type (an 8-byte write over a 4-byte field) —
 # a kind the format has no width-correct machine type for must fail the emit, not
 # corrupt the object. `alloc` backs the error string.
-fun reloc_type_for(alloc: *Allocator, kind: intern.StrId, arch_id: u32) Result[u32, str] {
+fun reloc_type_for(alloc: *Allocator, kind: of.RelocKind, arch_id: u32) Result[u32, str] {
     if (arch_id == isa.ARCH_AARCH64) {
-        if (kind == rk_abs64) { ret ok[u32, str](R_AARCH64_ABS64); }
-        if (kind == rk_pc32)  { ret ok[u32, str](R_AARCH64_PREL32); }
-        if (kind == rk_plt32) { ret ok[u32, str](R_AARCH64_CALL26); }
+        if (kind == of.RK_ABS64) { ret ok[u32, str](R_AARCH64_ABS64); }
+        if (kind == of.RK_PC32)  { ret ok[u32, str](R_AARCH64_PREL32); }
+        if (kind == of.RK_PLT32) { ret ok[u32, str](R_AARCH64_CALL26); }
         ret err[u32, str](unsupported_kind_message(alloc, kind));
     }
-    if (kind == rk_abs64)    { ret ok[u32, str](R_X86_64_64); }
-    if (kind == rk_pc32)     { ret ok[u32, str](R_X86_64_PC32); }
-    if (kind == rk_plt32)    { ret ok[u32, str](R_X86_64_PLT32); }
-    if (kind == rk_gotpcrel) { ret ok[u32, str](R_X86_64_GOTPCREL); }
-    if (kind == rk_abs32s)   { ret ok[u32, str](R_X86_64_32S); }
+    if (kind == of.RK_ABS64)    { ret ok[u32, str](R_X86_64_64); }
+    if (kind == of.RK_PC32)     { ret ok[u32, str](R_X86_64_PC32); }
+    if (kind == of.RK_PLT32)    { ret ok[u32, str](R_X86_64_PLT32); }
+    if (kind == of.RK_GOTPCREL) { ret ok[u32, str](R_X86_64_GOTPCREL); }
+    if (kind == of.RK_ABS32S)   { ret ok[u32, str](R_X86_64_32S); }
     ret err[u32, str](unsupported_kind_message(alloc, kind));
 }
 
-# map an ELF machine relocation type back to its abstract RK_* kind name. an
+# map an ELF machine relocation type back to its abstract RK_* kind. an
 # unrecognized type is an error naming the type rather than a silent fall-through
 # to abs64 — a foreign object's 4-byte type (e.g. R_X86_64_32) must not be linked
 # as a 64-bit absolute, which would write 8 bytes over the 4-byte field.
-fun reloc_kind_for(alloc: *Allocator, r_type: u32) Result[intern.StrId, str] {
-    if (r_type == R_X86_64_64 || r_type == R_AARCH64_ABS64) { ret ok[intern.StrId, str](rk_abs64); }
-    if (r_type == R_X86_64_PC32 || r_type == R_AARCH64_PREL32) { ret ok[intern.StrId, str](rk_pc32); }
-    if (r_type == R_X86_64_PLT32 || r_type == R_AARCH64_CALL26) { ret ok[intern.StrId, str](rk_plt32); }
-    if (r_type == R_X86_64_GOTPCREL) { ret ok[intern.StrId, str](rk_gotpcrel); }
-    if (r_type == R_X86_64_32S) { ret ok[intern.StrId, str](rk_abs32s); }
-    ret err[intern.StrId, str](unsupported_type_message(alloc, r_type::u64));
+fun reloc_kind_for(alloc: *Allocator, r_type: u32) Result[of.RelocKind, str] {
+    if (r_type == R_X86_64_64 || r_type == R_AARCH64_ABS64) { ret ok[of.RelocKind, str](of.RK_ABS64); }
+    if (r_type == R_X86_64_PC32 || r_type == R_AARCH64_PREL32) { ret ok[of.RelocKind, str](of.RK_PC32); }
+    if (r_type == R_X86_64_PLT32 || r_type == R_AARCH64_CALL26) { ret ok[of.RelocKind, str](of.RK_PLT32); }
+    if (r_type == R_X86_64_GOTPCREL) { ret ok[of.RelocKind, str](of.RK_GOTPCREL); }
+    if (r_type == R_X86_64_32S) { ret ok[of.RelocKind, str](of.RK_ABS32S); }
+    ret err[of.RelocKind, str](unsupported_type_message(alloc, r_type::u64));
 }
 
 # "elf: unsupported relocation kind: <name>" for an abstract kind the writer has
 # no width-correct ELF machine type for.
-fun unsupported_kind_message(alloc: *Allocator, kind: intern.StrId) str {
+fun unsupported_kind_message(alloc: *Allocator, kind: of.RelocKind) str {
     ret bin.name_message(elf_interner, alloc, "elf: unsupported relocation kind: ",
-                         resolve(kind), "elf: unsupported relocation kind");
+                         of.reloc_kind_name(kind), "elf: unsupported relocation kind");
 }
 
 # "elf: unsupported relocation type <n>" for a machine type the parser cannot map
@@ -760,21 +752,20 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     ret ok[bool, str](true);
 }
 
-# the ELF object-format vtable plus its relocation-kind table, populated by
-# register and handed out as borrowed pointers for the process lifetime.
+# the ELF object-format vtable, populated by register and handed out as a
+# borrowed pointer for the process lifetime.
 var elf_vtable: of.OfVTable;
-var elf_reloc_kinds: [5]of.RelocationKind;
 
 # register: build the ELF OfVTable and install it into the format registry.
 #
 # captures the interner so the writer can resolve `intern.StrId` names, interns
-# the format name ("elf"), extension ("o"), and the five abstract relocation
-# kind names, fills the relocation-kind table and the module-level vtable, and
-# registers it under `of.OF_ELF`. reentrant: every call re-interns all names and
-# refreshes the captured interner and the `rk_*` / vtable kind handles against
-# `i`, so a second session (or test) with a different interner is consistent
-# rather than left with stale ids from the first registration; `of.register` is
-# itself idempotent.
+# the format name ("elf") and extension ("o"), fills the module-level vtable, and
+# registers it under `of.OF_ELF`. reentrant: every call re-interns the names and
+# refreshes the captured interner against `i`, so a second session (or test) with
+# a different interner is consistent rather than left with stale ids from the
+# first registration; `of.register` is itself idempotent. abstract relocation
+# kinds are a closed `of.RK_*` enum, so the writer maps them with a plain integer
+# compare and no per-format kind table is interned.
 # ---
 # i:   interner used to intern the vtable's string fields and capture for the writer
 # ret: ok(true) on success, or an allocation error from interning
@@ -786,29 +777,6 @@ pub fun register(i: *intern.Interner) Result[bool, str] {
     val rext: Result[intern.StrId, str] = intern.intern(i, "o");
     if (is_err[intern.StrId, str](rext)) { ret err[bool, str](unwrap_err[intern.StrId, str](rext)); }
 
-    val ra: Result[intern.StrId, str] = intern.intern(i, "abs64");
-    if (is_err[intern.StrId, str](ra)) { ret err[bool, str](unwrap_err[intern.StrId, str](ra)); }
-    val rp: Result[intern.StrId, str] = intern.intern(i, "pc32");
-    if (is_err[intern.StrId, str](rp)) { ret err[bool, str](unwrap_err[intern.StrId, str](rp)); }
-    val rpl: Result[intern.StrId, str] = intern.intern(i, "plt32");
-    if (is_err[intern.StrId, str](rpl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rpl)); }
-    val rg: Result[intern.StrId, str] = intern.intern(i, "gotpcrel");
-    if (is_err[intern.StrId, str](rg)) { ret err[bool, str](unwrap_err[intern.StrId, str](rg)); }
-    val rs: Result[intern.StrId, str] = intern.intern(i, "abs32s");
-    if (is_err[intern.StrId, str](rs)) { ret err[bool, str](unwrap_err[intern.StrId, str](rs)); }
-
-    rk_abs64    = unwrap_ok[intern.StrId, str](ra);
-    rk_pc32     = unwrap_ok[intern.StrId, str](rp);
-    rk_plt32    = unwrap_ok[intern.StrId, str](rpl);
-    rk_gotpcrel = unwrap_ok[intern.StrId, str](rg);
-    rk_abs32s   = unwrap_ok[intern.StrId, str](rs);
-
-    elf_reloc_kinds[0].id = of.RK_ABS64::u32;    elf_reloc_kinds[0].name = rk_abs64;    elf_reloc_kinds[0].bit_width = 64; elf_reloc_kinds[0].pc_rel = false;
-    elf_reloc_kinds[1].id = of.RK_PC32::u32;     elf_reloc_kinds[1].name = rk_pc32;     elf_reloc_kinds[1].bit_width = 32; elf_reloc_kinds[1].pc_rel = true;
-    elf_reloc_kinds[2].id = of.RK_PLT32::u32;    elf_reloc_kinds[2].name = rk_plt32;    elf_reloc_kinds[2].bit_width = 32; elf_reloc_kinds[2].pc_rel = true;
-    elf_reloc_kinds[3].id = of.RK_GOTPCREL::u32; elf_reloc_kinds[3].name = rk_gotpcrel; elf_reloc_kinds[3].bit_width = 32; elf_reloc_kinds[3].pc_rel = true;
-    elf_reloc_kinds[4].id = of.RK_ABS32S::u32;   elf_reloc_kinds[4].name = rk_abs32s;   elf_reloc_kinds[4].bit_width = 32; elf_reloc_kinds[4].pc_rel = false;
-
     elf_vtable.id               = of.OF_ELF;
     elf_vtable.name             = unwrap_ok[intern.StrId, str](rname);
     elf_vtable.file_extension   = unwrap_ok[intern.StrId, str](rext);
@@ -816,8 +784,6 @@ pub fun register(i: *intern.Interner) Result[bool, str] {
     elf_vtable.parse_object     = parse_object;
     elf_vtable.emit_exec        = emit_exec;
     elf_vtable.emit_dyn_exec    = emit_dyn_exec;
-    elf_vtable.relocation_kinds = ?elf_reloc_kinds[0];
-    elf_vtable.relocation_count = 5;
 
     of.register(?elf_vtable);
     ret ok[bool, str](true);
@@ -1899,12 +1865,12 @@ pub fun parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.Obje
                 or { out.relocations[idx].section = of.SECTION_EXTERNAL; }
                 out.relocations[idx].offset = bin.read_u64_le(buf, ro)::u32;
                 out.relocations[idx].addend = bin.read_u64_le(buf, ro + 16)::i64;
-                val rk: Result[intern.StrId, str] = reloc_kind_for(alloc, r_type);
-                if (is_err[intern.StrId, str](rk)) {
+                val rk: Result[of.RelocKind, str] = reloc_kind_for(alloc, r_type);
+                if (is_err[of.RelocKind, str](rk)) {
                     deallocate[i32](alloc, sec_map, e_shnum::usize);
-                    ret err[bool, str](unwrap_err[intern.StrId, str](rk));
+                    ret err[bool, str](unwrap_err[of.RelocKind, str](rk));
                 }
-                out.relocations[idx].kind = unwrap_ok[intern.StrId, str](rk);
+                out.relocations[idx].kind = unwrap_ok[of.RelocKind, str](rk);
                 # r_sym indexes the on-disk symtab (1-based, index 0 reserved),
                 # so the ObjectImage symbol is r_sym - 1.
                 if (r_sym > 0 && (r_sym - 1) < out.symbol_count) {
@@ -1939,10 +1905,6 @@ test "elf: emit rejects a relocation naming an unresolved symbol (#1196)" {
     val rr: Result[bool, str] = register(?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_ELF);
-    if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
-    val vt: *of.OfVTable = unwrap[*of.OfVTable](vt_o);
-
     var isa_vt: isa.IsaVTable;
     isa_vt.id = isa.ARCH_X86_64;
 
@@ -1962,9 +1924,8 @@ test "elf: emit rejects a relocation naming an unresolved symbol (#1196)" {
     # table — the back-end-invariant violation #1196 must surface as an error,
     # not silently alias the reserved undefined entry (index 0).
     val ghost: intern.StrId = t_intern(?i, "ghost_symbol");
-    val k_pc32: intern.StrId = of.reloc_kind_name(vt, of.RK_PC32);
     var relocs: [1]of.Relocation;
-    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = k_pc32;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
     relocs[0].symbol = ghost; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
@@ -2011,11 +1972,11 @@ test "elf: emit rejects a relocation whose kind has no ELF machine type (#1256)"
     syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
 
     # the relocation names a defined symbol but carries a kind the ELF writer has
-    # no machine type for — before #1256 it was silently serialized as R_X86_64_64
-    # (an 8-byte write over the 4-byte field); it must now fail naming the kind.
-    val bogus: intern.StrId = t_intern(?i, "bogus_kind");
+    # no machine type for (RK_ADDR32NB is COFF image-relative, never mapped by ELF)
+    # — before #1256 it was silently serialized as R_X86_64_64 (an 8-byte write over
+    # the 4-byte field); it must now fail naming the kind.
     var relocs: [1]of.Relocation;
-    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = bogus;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_ADDR32NB;
     relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
@@ -2034,7 +1995,7 @@ test "elf: emit rejects a relocation whose kind has no ELF machine type (#1256)"
     fs.temp_close_and_remove(?tf);
 
     if (!is_err[bool, str](em)) { ret 1; }
-    if (!str_contains(unwrap_err[bool, str](em), "bogus_kind")) { ret 1; }
+    if (!str_contains(unwrap_err[bool, str](em), "addr32nb")) { ret 1; }
     ret 0;
 }
 
@@ -2061,12 +2022,8 @@ test "elf: parse rejects an unknown machine relocation type (#1256)" {
     syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
     syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
 
-    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_ELF);
-    if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
-    val k_pc32: intern.StrId = of.reloc_kind_name(unwrap[*of.OfVTable](vt_o), of.RK_PC32);
-
     var relocs: [1]of.Relocation;
-    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = k_pc32;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
     relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
 
     var img: of.ObjectImage;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -54,11 +54,12 @@ fun macho_emit_object(isa_vt: *isa.IsaVTable, image: *of.ObjectImage, path: *u8)
 # of.ParserFn signature exactly.
 # ---
 # alloc:    allocator for the image and its arrays
+# itn:      interner the parsed names would be interned into
 # buf:      the object file bytes
 # buf_size: length of the object file bytes
 # out:      image to populate
 # ret:      the unsupported-target error
-fun macho_parse_object(alloc: *Allocator, buf: *u8, buf_size: usize, out: *of.ObjectImage) Result[bool, str] {
+fun macho_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_size: usize, out: *of.ObjectImage) Result[bool, str] {
     ret err[bool, str](MACHO_UNSUPPORTED);
 }
 

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1,9 +1,9 @@
 # mach.lang.target.of.macho: Mach-O object-format stub.
 #
 # Supplies a correctly-shaped `OfVTable` for Mach-O 64 (MH_OBJECT) — file
-# extension "o" and the abstract relocation-kind table mapping
-# abs64/pc32/got_load/page21 to Mach-O machine relocations — so target.select
-# can compose a Darwin target descriptor. Mach-O serialization and parsing are
+# extension "o", with the abstract `of.RK_*` relocation kinds mapped to Mach-O
+# machine relocations internally — so target.select can compose a Darwin target
+# descriptor. Mach-O serialization and parsing are
 # not yet implemented: both `emit_object` and `parse_object` return a clear
 # "unsupported object format" error rather than producing a malformed file or
 # partial image. `register` interns the strings, installs the reader/writer, and
@@ -83,22 +83,20 @@ fun macho_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSeg
     ret err[bool, str](MACHO_UNSUPPORTED);
 }
 
-# the Mach-O relocation-kind table, indexed by entry order. populated by register.
-var macho_reloc_kinds: [4]of.RelocationKind;
-
 # the Mach-O OF vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry.
 var macho_vtable: of.OfVTable;
 
 # register_macho: build and install the Mach-O OfVTable.
 #
-# interns the format name ("macho"), file extension ("o"), and relocation-kind
-# names, fills the relocation-kind table and vtable, wires the (stub) writer,
-# and self-registers it into the process-global OF registry under of.OF_MACHO.
-# reentrant: every call re-interns all names against `i` so a second session (or
-# test) with a different interner is consistent rather than left with stale ids;
-# `of.register` is itself idempotent. must be invoked at compiler startup before
-# target.select requests a Darwin target.
+# interns the format name ("macho") and file extension ("o"), fills the vtable,
+# wires the (stub) writer, and self-registers it into the process-global OF
+# registry under of.OF_MACHO. reentrant: every call re-interns the names against
+# `i` so a second session (or test) with a different interner is consistent rather
+# than left with stale ids; `of.register` is itself idempotent. abstract
+# relocation kinds are a closed `of.RK_*` enum, so no per-format kind table is
+# interned. must be invoked at compiler startup before target.select requests a
+# Darwin target.
 # ---
 # i:   string interner used to intern the vtable's string fields
 # ret: true on success, or an error string if name interning fails
@@ -109,45 +107,6 @@ pub fun register_macho(i: *intern.Interner) Result[bool, str] {
     val rx: Result[intern.StrId, str] = intern.intern(i, "o");
     if (is_err[intern.StrId, str](rx)) { ret err[bool, str](unwrap_err[intern.StrId, str](rx)); }
 
-    val ra: Result[intern.StrId, str] = intern.intern(i, "abs64");
-    if (is_err[intern.StrId, str](ra)) { ret err[bool, str](unwrap_err[intern.StrId, str](ra)); }
-
-    val rp: Result[intern.StrId, str] = intern.intern(i, "pc32");
-    if (is_err[intern.StrId, str](rp)) { ret err[bool, str](unwrap_err[intern.StrId, str](rp)); }
-
-    val rgl: Result[intern.StrId, str] = intern.intern(i, "got_load");
-    if (is_err[intern.StrId, str](rgl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rgl)); }
-
-    val rpg: Result[intern.StrId, str] = intern.intern(i, "page21");
-    if (is_err[intern.StrId, str](rpg)) { ret err[bool, str](unwrap_err[intern.StrId, str](rpg)); }
-
-    # abs64 → X86_64_RELOC_UNSIGNED (64-bit absolute, not pc-relative)
-    macho_reloc_kinds[0].id        = of.RK_ABS64::u32;
-    macho_reloc_kinds[0].name      = unwrap_ok[intern.StrId, str](ra);
-    macho_reloc_kinds[0].bit_width = 64;
-    macho_reloc_kinds[0].pc_rel    = false;
-
-    # pc32 → X86_64_RELOC_BRANCH (32-bit pc-relative)
-    macho_reloc_kinds[1].id        = of.RK_PC32::u32;
-    macho_reloc_kinds[1].name      = unwrap_ok[intern.StrId, str](rp);
-    macho_reloc_kinds[1].bit_width = 32;
-    macho_reloc_kinds[1].pc_rel    = true;
-
-    # got_load → X86_64_RELOC_GOT_LOAD (32-bit pc-relative GOT load); maps to
-    # the abstract GOT-relative kind RK_GOTPCREL.
-    macho_reloc_kinds[2].id        = of.RK_GOTPCREL::u32;
-    macho_reloc_kinds[2].name      = unwrap_ok[intern.StrId, str](rgl);
-    macho_reloc_kinds[2].bit_width = 32;
-    macho_reloc_kinds[2].pc_rel    = true;
-
-    # page21 → ARM64_RELOC_PAGE21 (ADRP 21-bit page-relative). the abstract RK_*
-    # set has no page-relative equivalent; RK_PC32 is the nearest pc-relative
-    # kind. deferred: a dedicated page-relative RK_*.
-    macho_reloc_kinds[3].id        = of.RK_PC32::u32;
-    macho_reloc_kinds[3].name      = unwrap_ok[intern.StrId, str](rpg);
-    macho_reloc_kinds[3].bit_width = 21;
-    macho_reloc_kinds[3].pc_rel    = true;
-
     macho_vtable.id               = of.OF_MACHO;
     macho_vtable.name             = unwrap_ok[intern.StrId, str](rn);
     macho_vtable.file_extension   = unwrap_ok[intern.StrId, str](rx);
@@ -156,8 +115,6 @@ pub fun register_macho(i: *intern.Interner) Result[bool, str] {
     macho_vtable.emit_exec        = macho_emit_exec;
     # dyld bind/rebase (LC_LOAD_DYLINKER + LC_LOAD_DYLIB) is unimplemented (#1176).
     macho_vtable.emit_dyn_exec    = nil::of.DynExecFn;
-    macho_vtable.relocation_kinds = ?macho_reloc_kinds[0];
-    macho_vtable.relocation_count = 4;
 
     of.register(?macho_vtable);
     ret ok[bool, str](true);


### PR DESCRIPTION
Structural redesign of the object-format layer's worst coupling, rescued from the #1256/#1258 design threads. Pieces 1 and 2 of #1285 land here; piece 3 (session-owned registries) is split out — see scoping note below.

## Piece 1 — relocation kinds become a closed `RK_*` enum owned by `of`
`Relocation.kind` / `PendingReloc.kind` were interned `StrId` names, so every writer, parser, and the linker captured `rk_*` `StrId` handles and the linker kept a parallel `RelocKindIds` mirror just to compare a kind. The abstract `RK_*` u8 ids already existed; storing them directly makes a kind a plain integer compare with no interner.

- `of.Relocation.kind` / `encode.PendingReloc.kind` are now `of.RelocKind`.
- deleted the per-format `relocation_kinds` table (`OfVTable.relocation_kinds`/`relocation_count`, `of.RelocationKind`, the `elf/coff/macho_reloc_kinds` arrays) — its only consumers were the two kind-name lookups now gone.
- `reloc_kind_name` is now a format-independent diagnostic-name mapper (`RelocKind -> str`), no interner, no table.
- elf/coff map/unmap kinds against `of.RK_*` directly; the x64 encoder emits `of.RK_*` directly (dropping the dead `rk_addr32nb` capture); the linker drops `RelocKindIds`/`intern_reloc_kinds`.

**This kills the per-reloc interner dependency entirely.**

## Piece 2 — thread the interner through the image and writer signatures
The format writers/parsers captured the session interner in module globals (`elf_interner`/`coff_interner`), bound at registration — hidden global state with an undocumented ordering requirement and runtime failure modes. With kinds enumified, the only remaining need for an interner was resolving the `StrId` names an image carries.

- `of.ObjectImage` carries `interner` beside `alloc`; the writer resolves through `image.interner`. `obj.init` records it.
- `ParserFn` / `DynExecFn` take an `*intern.Interner` parameter; `parse_object` records it on `out.interner`. `WriterFn`/`ExecFn` are unchanged.
- elf/coff drop their `*_interner` globals; `resolve` and every message/parse helper take the interner. `register`/`register_coff` no longer capture it.
- the linker passes `?s.interner` to `obj.init` / `parse_object` / `emit_dyn_exec`.

**No module-global interner state remains in the object-format layer** — which also neutralizes the registry/interner correctness hazard the issue describes, since the registrars no longer capture any per-session state.

## Piece 3 — session-owned registries: scoped to #1319
Moving the `isa`/`os`/`abi`/`of` registry arrays onto session/driver-owned state cascades across the entire target subsystem (the 4 registry modules, all 10 registrars, `select`, the driver, the 3 CLI entry points, `mach info`, and ~30 test sites) and — now that piece 2 removed the correctness hazard — is a pure ownership/cleanliness refactor. Split to **#1319** per #1285's allowance, rather than sprawl this PR.

## Verification
- `mach build .` clean; **strong self-host fixpoint** (stage a == b == c, byte-identical sha256).
- `mach test .` — 346 PASS, 0 fail.
- full integration battery — all 20 `.github/tests/*/run.sh` green, including dynlink/extlink, the win64 suites, and the windows cross-compile.
- `mach build . --target windows` clean; `wine mach.exe build .` builds a project under wine and the produced exe runs.

Refs #1285