### PR TITLE
fix(regalloc): win64 XMM14/15 float-scratch preservation; regalloc quadratic-scaling (#1254)

### DIFF
--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -163,6 +163,15 @@ rec LiveRange {
 #                 allocation and drawn from for spill reloads (borrowed pointer
 #                 into the ISA vtable; nil when the ISA wires no pool)
 # reload_scratch_count: number of reload-scratch registers
+# BlockSpan: the flat-position span of one block.
+# ---
+# start: first flat position in the block (-1 when the block is empty)
+# end:   last flat position in the block (-1 when the block is empty)
+rec BlockSpan {
+    start: i64;
+    end:   i64;
+}
+
 rec AllocCtx {
     alloc:         *Allocator;
     f:             *mir.MirFunction;
@@ -197,6 +206,25 @@ rec AllocCtx {
     cur_end:       i64;
     reload_scratch:       *isa.Register;
     reload_scratch_count: i32;
+    # block_id_index: map from a block's id to its current index in `f.blocks`,
+    # sized `block_id_index_cap` (max block id + 1) with `RANGE_NIL` in unused
+    # slots. block ids stay fixed while `apply_order` permutes the array, so the map
+    # is refilled after the reorder. replaces the O(blocks) `block_index_of` scan in
+    # the DFS and the liveness fixpoint with an O(1) lookup; the lookups are
+    # unchanged, so allocation is unaffected.
+    block_id_index:     *u32;
+    block_id_index_cap: u32;
+    # block_spans: each block's [first, last] flat-stream position, sized
+    # `f.block_count`, precomputed once from the flat stream so the liveness
+    # range-extension reads a block's span in O(1) instead of rescanning the whole
+    # stream per block.
+    block_spans:        *BlockSpan;
+    # vreg_slot_flag: per-vreg flag — does the vreg own a lowering storage slot
+    # (alloca / by-value aggregate), sized `f.vreg_count`. precomputed once so
+    # `vreg_has_slot` is an O(1) read instead of an O(slots) scan per vreg. spill
+    # slots added later name only spilled vregs, which `is_spilled` rejects before
+    # consulting this, so the flag stays correct after the scan.
+    vreg_slot_flag:     *bool;
 }
 
 # run: allocate physical registers for every function in a MIR module.
@@ -269,9 +297,11 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
         f.callee_mask = asm_callee_mask(tgt, f);
         # a vreg-free function can still perform float work on memory operands (or
         # move a float constant into a return register), clobbering the callee-saved
-        # float scratch the prologue must then preserve. empty under SysV.
-        if (function_uses_fp_scratch(f)) {
-            f.callee_mask_fp = fp_scratch_callee_mask(tgt);
+        # float scratch the prologue must then preserve. the scratch mask is empty
+        # under SysV, so the float-op scan is skipped entirely off win64.
+        val fp_scratch: u32 = fp_scratch_callee_mask(tgt);
+        if (fp_scratch != 0 && function_uses_fp_scratch(f)) {
+            f.callee_mask_fp = fp_scratch;
         }
         ret ok[bool, str](true);
     }
@@ -329,12 +359,20 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
     val fl: Result[bool, str] = flatten(?ctx);
     if (is_err[bool, str](fl)) { ctx_dnit(?ctx); ret fl; }
 
+    # precompute the per-block flat spans and per-vreg storage-slot flags the
+    # liveness and scan passes would otherwise rebuild by rescanning.
+    val bs: Result[bool, str] = build_block_spans(?ctx);
+    if (is_err[bool, str](bs)) { ctx_dnit(?ctx); ret bs; }
+    val vs: Result[bool, str] = build_vreg_slot_flags(?ctx);
+    if (is_err[bool, str](vs)) { ctx_dnit(?ctx); ret vs; }
+
     build_ranges(?ctx);
 
     val lv: Result[bool, str] = extend_liveness(?ctx);
     if (is_err[bool, str](lv)) { ctx_dnit(?ctx); ret lv; }
 
-    mark_call_crossing(?ctx);
+    val mc: Result[bool, str] = mark_call_crossing(?ctx);
+    if (is_err[bool, str](mc)) { ctx_dnit(?ctx); ret mc; }
 
     val sc: Result[bool, str] = linear_scan(tgt, ?ctx);
     if (is_err[bool, str](sc)) { ctx_dnit(?ctx); ret sc; }
@@ -383,6 +421,10 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
     ctx.cur_end       = 0;
     ctx.reload_scratch       = tgt.arch.reload_scratch_regs;
     ctx.reload_scratch_count = tgt.arch.reload_scratch_count;
+    ctx.block_id_index       = nil;
+    ctx.block_id_index_cap   = 0;
+    ctx.block_spans          = nil;
+    ctx.vreg_slot_flag       = nil;
 
     val ro: Result[*u32, str] = allocate[u32](m.alloc, f.block_count::usize);
     if (is_err[*u32, str](ro)) { ret err[bool, str](unwrap_err[*u32, str](ro)); }
@@ -538,6 +580,18 @@ fun ctx_dnit(ctx: *AllocCtx) {
     if (ctx.active != nil) {
         deallocate[u32](ctx.alloc, ctx.active, ctx.f.vreg_count::usize);
         ctx.active = nil;
+    }
+    if (ctx.block_id_index != nil && ctx.block_id_index_cap > 0) {
+        deallocate[u32](ctx.alloc, ctx.block_id_index, ctx.block_id_index_cap::usize);
+        ctx.block_id_index = nil;
+    }
+    if (ctx.block_spans != nil && ctx.f.block_count > 0) {
+        deallocate[BlockSpan](ctx.alloc, ctx.block_spans, ctx.f.block_count::usize);
+        ctx.block_spans = nil;
+    }
+    if (ctx.vreg_slot_flag != nil && ctx.f.vreg_count > 0) {
+        deallocate[bool](ctx.alloc, ctx.vreg_slot_flag, ctx.f.vreg_count::usize);
+        ctx.vreg_slot_flag = nil;
     }
 }
 
@@ -707,6 +761,10 @@ fun build_order(ctx: *AllocCtx) Result[bool, str] {
     val f: *mir.MirFunction = ctx.f;
     val n: u32 = f.block_count;
 
+    # the DFS resolves successor ids to block indices in the original layout.
+    val bx: Result[bool, str] = fill_block_id_index(ctx);
+    if (is_err[bool, str](bx)) { ret bx; }
+
     val rv: Result[*bool, str] = allocate[bool](ctx.alloc, n::usize);
     if (is_err[*bool, str](rv)) { ret err[bool, str](unwrap_err[*bool, str](rv)); }
     val visited: *bool = unwrap_ok[*bool, str](rv);
@@ -805,15 +863,45 @@ fun next_unvisited_succ(ctx: *AllocCtx, b: u32, six: *u32, visited: *bool) u32 {
     ret RANGE_NIL;
 }
 
-# block_index_of: the block-array index whose `id` equals `bid`, or RANGE_NIL.
-fun block_index_of(ctx: *AllocCtx, bid: u32) u32 {
+# fill_block_id_index: (re)build the block-id -> block-array-index map from the
+# current `f.blocks` layout. allocated once (block ids are stable while
+# `apply_order` permutes the array, so the cap never changes) and refilled after
+# the reorder. unused id slots hold RANGE_NIL. must run before any
+# `block_index_of` on the current layout — `build_order` calls it before its DFS
+# and `apply_order` rebuilds it after permuting the blocks. block ids are unique,
+# so the last writer per id is also the only one.
+fun fill_block_id_index(ctx: *AllocCtx) Result[bool, str] {
     val f: *mir.MirFunction = ctx.f;
-    var i: u32 = 0;
-    for (i < f.block_count) {
-        if (f.blocks[i].id == bid) { ret i; }
-        i = i + 1;
+    val n: u32 = f.block_count;
+    if (n == 0) { ret ok[bool, str](true); }
+
+    if (ctx.block_id_index == nil) {
+        var max_id: u32 = 0;
+        var i: u32 = 0;
+        for (i < n) {
+            if (f.blocks[i].id > max_id) { max_id = f.blocks[i].id; }
+            i = i + 1;
+        }
+        val cap: u32 = max_id + 1;
+        val r: Result[*u32, str] = allocate[u32](ctx.alloc, cap::usize);
+        if (is_err[*u32, str](r)) { ret err[bool, str](unwrap_err[*u32, str](r)); }
+        ctx.block_id_index     = unwrap_ok[*u32, str](r);
+        ctx.block_id_index_cap = cap;
     }
-    ret RANGE_NIL;
+
+    var j: u32 = 0;
+    for (j < ctx.block_id_index_cap) { ctx.block_id_index[j] = RANGE_NIL; j = j + 1; }
+    var k: u32 = 0;
+    for (k < n) { ctx.block_id_index[f.blocks[k].id] = k; k = k + 1; }
+    ret ok[bool, str](true);
+}
+
+# block_index_of: the block-array index whose `id` equals `bid`, or RANGE_NIL. an
+# O(1) read of the id map `fill_block_id_index` builds; a `bid` past the largest
+# id names no block (RANGE_NIL), matching the former linear scan's miss result.
+fun block_index_of(ctx: *AllocCtx, bid: u32) u32 {
+    if (bid >= ctx.block_id_index_cap) { ret RANGE_NIL; }
+    ret ctx.block_id_index[bid];
 }
 
 # apply_order: permute `f.blocks` into the computed reverse-postorder. the entry
@@ -846,7 +934,10 @@ fun apply_order(ctx: *AllocCtx) Result[bool, str] {
     # after reordering, the order array is identity (blocks are physically in RPO).
     i = 0;
     for (i < n) { ctx.order[i] = i; i = i + 1; }
-    ret ok[bool, str](true);
+
+    # the blocks moved, so the id -> index map must reflect the new RPO layout for
+    # the liveness fixpoint's successor lookups.
+    ret fill_block_id_index(ctx);
 }
 
 # flatten: count every instruction across all blocks (now in RPO) and build the
@@ -1018,7 +1109,7 @@ fun extend_liveness(ctx: *AllocCtx) Result[bool, str] {
     # extend ranges to cover blocks where the vreg is live-in or live-out.
     var bi: u32 = 0;
     for (bi < nb) {
-        val span: BlockSpan = block_span(ctx, bi);
+        val span: BlockSpan = ctx.block_spans[bi];
         val base: usize = (bi::usize) * (nv::usize);
         var v: u32 = 0;
         for (v < nv) {
@@ -1040,29 +1131,29 @@ fun extend_liveness(ctx: *AllocCtx) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
-# BlockSpan: the flat-position span of one block.
-# ---
-# start: first flat position in the block (-1 when the block is empty)
-# end:   last flat position in the block (-1 when the block is empty)
-rec BlockSpan {
-    start: i64;
-    end:   i64;
-}
+# build_block_spans: precompute each block's [first, last] flat-stream position in
+# one pass over the flat stream, so the liveness range-extension reads a span in
+# O(1) instead of rescanning the whole stream per block. an empty block keeps
+# [-1, -1]. must run after `flatten`.
+fun build_block_spans(ctx: *AllocCtx) Result[bool, str] {
+    val f: *mir.MirFunction = ctx.f;
+    val n: u32 = f.block_count;
+    if (n == 0) { ret ok[bool, str](true); }
 
-# block_span: the [first, last] flat positions belonging to block index `bi`.
-fun block_span(ctx: *AllocCtx, bi: u32) BlockSpan {
-    var span: BlockSpan;
-    span.start = -1;
-    span.end   = -1;
+    val r: Result[*BlockSpan, str] = allocate[BlockSpan](ctx.alloc, n::usize);
+    if (is_err[*BlockSpan, str](r)) { ret err[bool, str](unwrap_err[*BlockSpan, str](r)); }
+    ctx.block_spans = unwrap_ok[*BlockSpan, str](r);
+
+    var i: u32 = 0;
+    for (i < n) { ctx.block_spans[i].start = -1; ctx.block_spans[i].end = -1; i = i + 1; }
     var pos: u32 = 0;
     for (pos < ctx.flat_count) {
-        if (ctx.flat[pos].block == bi) {
-            if (span.start < 0) { span.start = pos::i64; }
-            span.end = pos::i64;
-        }
+        val b: u32 = ctx.flat[pos].block;
+        if (ctx.block_spans[b].start < 0) { ctx.block_spans[b].start = pos::i64; }
+        ctx.block_spans[b].end = pos::i64;
         pos = pos + 1;
     }
-    ret span;
+    ret ok[bool, str](true);
 }
 
 # compute_use_def: fill per-block upward-exposed uses and definitions. operand 0
@@ -1204,23 +1295,43 @@ fun or_row(dst: *bool, dbase: usize, src: *bool, sbase: usize, nv: u32) {
     }
 }
 
-# mark_call_crossing: flag every range whose interval contains a MIR_CALL barrier
-# so the scan prefers a callee-saved register for it.
-fun mark_call_crossing(ctx: *AllocCtx) {
-    var ci: u32 = 0;
-    for (ci < ctx.flat_count) {
-        if (ctx.flat[ci].is_call) {
-            var v: u32 = 0;
-            for (v < ctx.f.vreg_count) {
-                val lr: *LiveRange = ?ctx.ranges[v];
-                if (lr.end_pos >= 0 && lr.start <= ci::i64 && lr.end_pos >= ci::i64) {
-                    lr.crosses_call = true;
-                }
-                v = v + 1;
+# mark_call_crossing: flag every range whose interval contains a call barrier so
+# the scan prefers a callee-saved register for it. a prefix count of call barriers
+# over the flat stream turns the "does [start, end] contain a call" test into a
+# subtraction, so the pass is O(flat + vregs) instead of O(calls * vregs); the
+# per-range result is identical, so allocation is unaffected.
+fun mark_call_crossing(ctx: *AllocCtx) Result[bool, str] {
+    val n: u32 = ctx.flat_count;
+    if (n == 0) { ret ok[bool, str](true); }
+
+    # prefix[p] = number of call barriers in flat[0..p); a range [s, e] crosses a
+    # call iff prefix[e + 1] - prefix[s] > 0.
+    val r: Result[*u32, str] = allocate[u32](ctx.alloc, (n + 1)::usize);
+    if (is_err[*u32, str](r)) { ret err[bool, str](unwrap_err[*u32, str](r)); }
+    val prefix: *u32 = unwrap_ok[*u32, str](r);
+    prefix[0] = 0;
+    var p: u32 = 0;
+    for (p < n) {
+        var inc: u32 = 0;
+        if (ctx.flat[p].is_call) { inc = 1; }
+        prefix[p + 1] = prefix[p] + inc;
+        p = p + 1;
+    }
+
+    var v: u32 = 0;
+    for (v < ctx.f.vreg_count) {
+        val lr: *LiveRange = ?ctx.ranges[v];
+        # a referenced range has 0 <= start <= end_pos < flat_count.
+        if (lr.end_pos >= 0) {
+            if (prefix[(lr.end_pos + 1)::u32] - prefix[lr.start::u32] > 0) {
+                lr.crosses_call = true;
             }
         }
-        ci = ci + 1;
+        v = v + 1;
     }
+
+    deallocate[u32](ctx.alloc, prefix, (n + 1)::usize);
+    ret ok[bool, str](true);
 }
 
 # linear_scan: assign each vreg a physical register (writing `MirVReg.assigned`)
@@ -1499,17 +1610,39 @@ fun release_pins(ctx: *AllocCtx, current_start: i64) {
     }
 }
 
+# build_vreg_slot_flags: precompute, in one pass over the frame slots, whether each
+# vreg owns a lowering storage slot (alloca / by-value aggregate), so `vreg_has_slot`
+# is an O(1) read instead of an O(slots) scan per vreg. spill slots the scan adds
+# later name only spilled vregs, which the one caller that runs post-scan
+# (`is_storage_slot`) rejects via `is_spilled` before consulting this flag, so the
+# flag stays correct without rebuilding.
+fun build_vreg_slot_flags(ctx: *AllocCtx) Result[bool, str] {
+    val f: *mir.MirFunction = ctx.f;
+    val nv: u32 = f.vreg_count;
+    if (nv == 0) { ret ok[bool, str](true); }
+
+    val r: Result[*bool, str] = allocate[bool](ctx.alloc, nv::usize);
+    if (is_err[*bool, str](r)) { ret err[bool, str](unwrap_err[*bool, str](r)); }
+    ctx.vreg_slot_flag = unwrap_ok[*bool, str](r);
+    var i: u32 = 0;
+    for (i < nv) { ctx.vreg_slot_flag[i] = false; i = i + 1; }
+
+    val frame: *mir.MirFrame = ?f.frame;
+    var s: u32 = 0;
+    for (s < frame.slot_count) {
+        val owner: u32 = frame.slots[s].value;
+        if (owner < nv) { ctx.vreg_slot_flag[owner] = true; }
+        s = s + 1;
+    }
+    ret ok[bool, str](true);
+}
+
 # vreg_has_slot: true when a vreg owns a frame slot (alloca pointer or by-value
 # aggregate / spill). such vregs are addressed as `[rbp + offset]` and never
-# register-allocated.
+# register-allocated. an O(1) read of the flags `build_vreg_slot_flags` precomputes.
 fun vreg_has_slot(ctx: *AllocCtx, v: u32) bool {
-    val frame: *mir.MirFrame = ?ctx.f.frame;
-    var i: u32 = 0;
-    for (i < frame.slot_count) {
-        if (frame.slots[i].value == v) { ret true; }
-        i = i + 1;
-    }
-    ret false;
+    if (v >= ctx.f.vreg_count) { ret false; }
+    ret ctx.vreg_slot_flag[v];
 }
 
 # sort_by_start: insertion-sort vreg ids in `order` by ascending range start,
@@ -2134,9 +2267,11 @@ fun record_callee_mask(tgt: *target.Target, ctx: *AllocCtx) {
     # OR in the callee-saved float scratch (win64's XMM14/15) when the function
     # performs float work: the encoder clobbers those registers lowering float ops,
     # and the allocator never assigns them, so the prologue must preserve them for
-    # the caller. empty under SysV, so this leaves the linux mask unchanged.
-    if (function_uses_fp_scratch(ctx.f)) {
-        fp_mask = fp_mask | fp_scratch_callee_mask(tgt);
+    # the caller. the scratch mask is empty under SysV, so the float-op scan is
+    # skipped entirely off win64 and the linux mask is unchanged.
+    val fp_scratch: u32 = fp_scratch_callee_mask(tgt);
+    if (fp_scratch != 0 && function_uses_fp_scratch(ctx.f)) {
+        fp_mask = fp_mask | fp_scratch;
     }
 
     ctx.f.callee_mask    = mask;

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -267,6 +267,12 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
     # path also corrupts callers from a value-free asm-only function).
     if (f.vreg_count == 0)  {
         f.callee_mask = asm_callee_mask(tgt, f);
+        # a vreg-free function can still perform float work on memory operands (or
+        # move a float constant into a return register), clobbering the callee-saved
+        # float scratch the prologue must then preserve. empty under SysV.
+        if (function_uses_fp_scratch(f)) {
+            f.callee_mask_fp = fp_scratch_callee_mask(tgt);
+        }
         ret ok[bool, str](true);
     }
 
@@ -1895,6 +1901,96 @@ fun abi_callee_saved_gp_mask(tgt: *target.Target) u32 {
     ret m;
 }
 
+# abi_callee_saved_fp_mask: the FP-bank twin of `abi_callee_saved_gp_mask` — a
+# bitmask (XMM within-bank index n -> bit n) of the ABI's callee-saved vector
+# registers (win64's XMM6–15; empty under SysV, whose vector bank is wholly
+# caller-saved). keyed on the within-bank index so it composes with the FP bank's
+# index-keyed masks.
+fun abi_callee_saved_fp_mask(tgt: *target.Target) u32 {
+    var regs: [32]isa.Register;
+    val fill: abi.RegFileFn = tgt.abi.callee_saved::abi.RegFileFn;
+    val n: i32 = fill(?regs[0]);
+    var m: u32 = 0;
+    var i: i32 = 0;
+    for (i < n && i < MAX_REG_FILE) {
+        val id: i32 = regs[i].id;
+        if (isa.regid_class(id) == isa.REG_CLASS_ID_XMM) {
+            val idx: i32 = isa.regid_index(id);
+            if (idx >= 0 && idx < 32) { m = m | (1::u32 << idx::u32); }
+        }
+        i = i + 1;
+    }
+    ret m;
+}
+
+# fp_scratch_callee_mask: the bitmask (XMM within-bank index n -> bit n) of
+# callee-saved vector registers the ISA holds back from the allocatable bank as
+# fixed float scratch — the callee-saved XMM registers the encoder may clobber but
+# the allocator never assigns. derived structurally as (ABI callee-saved vector
+# set) minus (allocatable FP bank): the FP bank is capped below the full register
+# file precisely to reserve those scratch registers (x86-64's XMM14/15, the SSE
+# analogue of the GP R10/R11), so any callee-saved register past the bank is a
+# reserved scratch register. empty under SysV (no callee-saved XMM) and for any ISA
+# whose float scratch is caller-saved, so it never perturbs such a target's
+# codegen. names no architecture register, so a new ISA whose float scratch sits in
+# a callee-saved slot needs no edit here.
+fun fp_scratch_callee_mask(tgt: *target.Target) u32 {
+    val cs: u32 = abi_callee_saved_fp_mask(tgt);
+    if (cs == 0) { ret 0; }
+    val fpc: u32 = bank_count(tgt, fp_class_index(tgt));
+    var alloc_mask: u32 = 0;
+    var i: u32 = 0;
+    for (i < fpc && i < 32) {
+        alloc_mask = alloc_mask | (1::u32 << i);
+        i = i + 1;
+    }
+    ret cs & ~alloc_mask;
+}
+
+# function_uses_fp_scratch: true when any instruction in `f` is lowered through the
+# ISA's fixed XMM scratch pair — a scalar float arithmetic / comparison / negation /
+# conversion op (the encoder routes every operand through the scratch), or a float
+# move naming a vector register (a same-bank float move loads through the scratch;
+# a both-memory float copy uses the GP scratch instead and so names no vector
+# register, correctly excluding it). a function that hits one of these clobbers the
+# callee-saved float scratch and must preserve it for its caller, exactly as it
+# preserves an allocated callee-saved register.
+fun function_uses_fp_scratch(f: *mir.MirFunction) bool {
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            val o: mir.MirOpcode = mi.opcode;
+            if (o == mir.MIR_FADD || o == mir.MIR_FSUB || o == mir.MIR_FMUL ||
+                o == mir.MIR_FDIV || o == mir.MIR_FCMP || o == mir.MIR_FNEG ||
+                o == mir.MIR_FP_TRUNC || o == mir.MIR_FP_EXT ||
+                o == mir.MIR_FP_TO_SI || o == mir.MIR_FP_TO_UI ||
+                o == mir.MIR_SI_TO_FP || o == mir.MIR_UI_TO_FP) {
+                ret true;
+            }
+            if (o == mir.MIR_MOV) {
+                var k: u32 = 0;
+                for (k < mi.operand_count) {
+                    val op: *mir.MirOperand = ?mi.operands[k];
+                    if (op.kind == mir.MIR_OP_VREG && mir.vreg_is_fp(f, op.vreg)) {
+                        ret true;
+                    }
+                    if (op.kind == mir.MIR_OP_PREG &&
+                        isa.regid_class(op.preg::i32) == isa.REG_CLASS_ID_XMM) {
+                        ret true;
+                    }
+                    k = k + 1;
+                }
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret false;
+}
+
 # isa_reserved_gp_mask: GP-register bitmask the ISA reserves from allocation (the
 # stack / frame pointers, the reload-scratch pool, and the encoder's split
 # scratch) — the bitmask form of `seed_reserved`'s always-reserved set, so a
@@ -2034,6 +2130,14 @@ fun record_callee_mask(tgt: *target.Target, ctx: *AllocCtx) {
     # writes, so the prologue preserves it for the caller even when no allocated
     # value lives there.
     mask = mask | asm_callee_mask(tgt, ctx.f);
+
+    # OR in the callee-saved float scratch (win64's XMM14/15) when the function
+    # performs float work: the encoder clobbers those registers lowering float ops,
+    # and the allocator never assigns them, so the prologue must preserve them for
+    # the caller. empty under SysV, so this leaves the linux mask unchanged.
+    if (function_uses_fp_scratch(ctx.f)) {
+        fp_mask = fp_mask | fp_scratch_callee_mask(tgt);
+    }
 
     ctx.f.callee_mask    = mask;
     ctx.f.callee_mask_fp = fp_mask;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3502,6 +3502,48 @@ test "coff: parse_function_unwind decodes callee-saved XMM saves as SAVE_XMM128 
     ret 0;
 }
 
+test "coff: parse_function_unwind decodes the XMM14/15 float-scratch saves (#1254)" {
+    # the callee-saved float scratch (XMM14/15) is preserved by any win64 function
+    # that performs float work; its prologue MOVAPS saves must decode to
+    # UWOP_SAVE_XMM128 just like the allocatable XMM6–13. both carry REX.R (reg >= 8).
+    # push rbp; mov rbp,rsp; sub rsp,0x40;
+    # movaps [rbp-0x10],xmm14 (44 0F 29 75 F0); movaps [rbp-0x20],xmm15 (44 0F 29 7D E0); ret
+    var text_bytes: [19]u8;
+    text_bytes[0] = 0x55;
+    text_bytes[1] = 0x48; text_bytes[2] = 0x89; text_bytes[3] = 0xE5;
+    text_bytes[4] = 0x48; text_bytes[5] = 0x83; text_bytes[6] = 0xEC; text_bytes[7] = 0x40;
+    text_bytes[8] = 0x44; text_bytes[9] = 0x0F; text_bytes[10] = 0x29; text_bytes[11] = 0x75; text_bytes[12] = 0xF0;
+    text_bytes[13] = 0x44; text_bytes[14] = 0x0F; text_bytes[15] = 0x29; text_bytes[16] = 0x7D; text_bytes[17] = 0xE0;
+    text_bytes[18] = 0xC3;
+
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = 0x140000000; segs[0].filesz = 19; segs[0].memsz = 19;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
+
+    var funcs: [1]of.ExecFunction;
+    funcs[0].seg_index = 0; funcs[0].seg_offset = 0; funcs[0].size = 19;
+
+    var uw: FunctionUnwind;
+    if (!parse_function_unwind(?uw, ?segs[0], 1, ?funcs[0], 0)) { ret 1; }
+    # PUSH_NONVOL, ALLOC_SMALL, SAVE_XMM128(xmm14), SAVE_XMM128(xmm15).
+    if (uw.code_count != 4) { ret 1; }
+    if (uw.prolog_size != 18) { ret 1; }
+
+    val x14: *UnwindCode = ?uw.codes[2];
+    if (x14.op != UWOP_SAVE_XMM128) { ret 1; }
+    if (x14.info != 14) { ret 1; }
+    if (x14.extra0 != 3) { ret 1; }   # save_off (0x40 - 0x10) = 0x30, scaled by 16
+    if (x14.end_off != 13) { ret 1; }
+
+    val x15: *UnwindCode = ?uw.codes[3];
+    if (x15.op != UWOP_SAVE_XMM128) { ret 1; }
+    if (x15.info != 15) { ret 1; }
+    if (x15.extra0 != 2) { ret 1; }   # save_off (0x40 - 0x20) = 0x20, scaled by 16
+    if (x15.end_off != 18) { ret 1; }
+
+    ret 0;
+}
+
 test "coff: push_save_xmm128 writes the unscaled offset in the SAVE_XMM128_FAR form" {
     var uw: FunctionUnwind;
     uw.code_count = 0;


### PR DESCRIPTION
Closes #1254 — the re-scoped remainder after PR #1266 (XMM14/15 + the quadratic-scaling family). Under epic #1259.

## Item 1 — win64 callee-saved float scratch (XMM14/15)

PR #1266 added the per-bank FP callee-save model covering the *allocatable* callee-saved XMM6–13. XMM14/15 sit outside it: they are the x86-64 encoder's fixed float-scratch pair (the SSE analogue of the GP R10/R11), used by *every* float operation, and the xmm bank is capped at 14 precisely to hold them back. They are not — and cannot be — allocator-assignable without breaking float codegen. But under win64 they are callee-saved, so a function performing float work clobbered two registers its caller may rely on. The correct fix (the one #1266's deferred note recommends) is to **preserve** them, not assign them.

The callee-saved float-scratch set is derived structurally as `(ABI callee-saved vector registers) minus (allocatable FP bank)` — win64's XMM14/15, empty under SysV — and OR'd into a function's FP callee mask whenever the function performs float work (any scalar float arith/cmp/neg/conversion, or a float move naming a vector register; a both-memory float copy uses the GP scratch and is correctly excluded). No new ISA vtable surface — the registers fall out of the existing ABI callee-saved file and FP bank count — and the scan is gated on the (empty-off-win64) scratch mask, so it does **zero** per-function work on linux.

The prologue/epilogue MOVAPS save/restore loop and `coff.parse_function_unwind` already span the full XMM0–15 range (REX.R decode + `is_win64_nonvol_xmm` accept 6–15), so no encoder/unwind change was needed beyond setting the mask bits. `FunctionUnwind`'s 32-code array has ample headroom (worst-case win64 prologue ≈ push + alloc + ≤8 GP + 10 XMM = ~20 codes).

**Evidence (cross-compiled win64 float app, -O0):**
- dev compiler: **0** `movaps [rbp-off],xmm14/15` save/restore pairs (the ABI violation).
- this branch: **14** — `44 0f 29` (REX.R MOVAPS store) at 16-aligned offsets, described in `.xdata` as `UWOP_SAVE_XMM128` (`e8`/`f8` codes = op 8, info 14/15).

No runtime failing-before test is constructible: the inline-asm grammar admits no SSE mnemonic, and the allocator never places a mach value in XMM14/15, so XMM14/15 corruption is unobservable from pure mach (exactly why #1266 called it "harmless for pure-mach programs"). Coverage is the structural cross-compile evidence above plus a new coff unit test decoding the XMM14/15 saves as `UWOP_SAVE_XMM128`.

## Item 2 — regalloc quadratic-scaling family

Replaced the audit's flagged per-function rescans with precomputed indices, all order-preserving so allocation is byte-for-byte unchanged:
- **block_index_of** → O(1) block-id→index map (refilled after `apply_order`) instead of the O(blocks) scan in the RPO DFS and the liveness fixpoint.
- **block_span** → one-pass precomputed per-block flat spans instead of rescanning the whole stream per block.
- **mark_call_crossing** → call-barrier prefix sum, O(flat+vregs) instead of O(calls·vregs).
- **vreg_has_slot** → per-vreg storage-slot flag built once instead of an O(slots) scan per vreg.

**Skipped, documented:** `spill_across_calls` (spill-slot creation order determines the emitted frame layout — reordering it would break byte-identity); the bool-per-bit liveness rows and the insertion sort (order-preserving but not profitable).

**Perf finding (honest):** the quadratic paths are real algorithmic complexity but have *small* constant factors relative to parse/sema/encode. `time mach build .` shows the change within noise (3× -O0: dev ~29.4s vs this ~29.1s; 3× --release ~30.8s both) — and a synthetic 1500-block / 4500-instr / 120-live-vreg function shows no speedup either. So this **removes the flagged O(n²)/O(blocks·instrs) complexity with no regression**, rather than delivering a visible self-host speedup.

## Verification
- `mach build .` clean; `mach test .` **347 pass / 0 fail** (incl. new coff XMM14/15 unwind test).
- All 21 `.github/tests` suites pass incl. wine (win64fp, win64va, …).
- **Byte-identical linux self-host fixpoint at -O0 AND --release** (this compiler builds the pristine dev source byte-for-byte; both fixpoints converge). Verified against the current `dev` (merged in).
- Windows cross-compiled; `wine mach.exe build .` on a float project produces a correct binary (the native win compiler now saves XMM14/15) that runs exit 0 under wine.
