### PR TITLE
fix(diagnostics): execute the #1046 quality fix list (Tier 1 + Tier 2 high)

### DIFF
--- a/.github/tests/diaglocate/asmlocal/mach.toml
+++ b/.github/tests/diaglocate/asmlocal/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "asmlocal"
+name = "located inline-asm diagnostic — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "linux"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/asmlocal"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/diaglocate/asmlocal/src/main.mach
+++ b/.github/tests/diaglocate/asmlocal/src/main.mach
@@ -1,0 +1,12 @@
+use std.runtime.linux.x86_64;
+
+# an inline-asm `{name}` reference to a name with no in-scope stack local is a
+# hard error. before the #1046 diagnostics pass it was a span-less propagated
+# string ("lower: unknown local in inline asm '{name}' reference"); it must now
+# be a located, name-bearing diagnostic carried on the asm body span.
+fun main() i64 {
+    asm x86_64 {
+        mov rax, {nosuch}
+    }
+    ret 0;
+}

--- a/.github/tests/diaglocate/run.sh
+++ b/.github/tests/diaglocate/run.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Diagnostic-location regression (#1046). Several middle-end lowering errors used
+# to propagate a span-less string with a `lower:` breadcrumb and no file:line:col.
+# They now file a structured diagnostic at the offending span and return a
+# `lower:reported` sentinel the driver suppresses, so the user sees exactly one
+# located, name-bearing message.
+#
+#   asmlocal — an inline-asm `{name}` reference to a name with no in-scope stack
+#   local. the build must fail with a diagnostic that (a) names the offending
+#   local and (b) is located on the asm body (main.mach:line:col), never the old
+#   span-less "lower: unknown local in inline asm '{name}' reference".
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# vendor <app-dir>: copy the app into the temp dir and symlink the vendored std.
+vendor() {
+    local app="$1"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+}
+
+# expect_located <app-dir> <substr>: build the app and require the build to FAIL
+# with a diagnostic that contains <substr> AND is located on main.mach with a
+# file:line:col prefix.
+expect_located() {
+    local app="$1"; local want="$2"
+    vendor "$app"
+    local dst="$WORK/$app"
+    local out
+    if out="$( cd "$dst" && "$MACH" build . 2>&1 )"; then
+        echo "FAIL diaglocate/$app: build unexpectedly succeeded" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF -- "$want"; then
+        echo "FAIL diaglocate/$app: diagnostic missing '$want'; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qE 'main\.mach:[0-9]+:[0-9]+:'; then
+        echo "FAIL diaglocate/$app: diagnostic missing file:line:col; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    echo "PASS diaglocate/$app: a formerly span-less lowering error is located and named"
+}
+
+expect_located asmlocal "unknown local 'nosuch' in inline asm"
+
+exit "$fail"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -374,13 +374,15 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
     # scan, or the project-path positional. with no `--` present this is argc.
     val eff: usize = util.separator_index(argc, argv);
 
-    val cfg_opt: Option[cfg.Config] = cfg.parse(eff, argv);
-    if (is_none[cfg.Config](cfg_opt)) {
-        print.eprint("error: invalid command-line flags\n");
+    val cfg_r: Result[cfg.Config, str] = cfg.parse(eff, argv);
+    if (is_err[cfg.Config, str](cfg_r)) {
+        print.eprint("error: ");
+        print.eprint(unwrap_err[cfg.Config, str](cfg_r));
+        print.eprint("\n");
         br.code = 1;
         ret br;
     }
-    val config: cfg.Config = unwrap[cfg.Config](cfg_opt);
+    val config: cfg.Config = unwrap_ok[cfg.Config, str](cfg_r);
 
     # the project root: the first non-flag positional after the subcommand
     # (`mach build <path>`), else --cwd, else the process cwd. a positional and
@@ -540,7 +542,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
                      argc: usize, argv: **u8, out_path: **u8) i64 {
     val n: usize = p.module_len::usize;
     if (n == 0) {
-        print.eprint("error: project graph is empty\n");
+        print.eprint("error: project graph is empty; the entrypoint loaded no modules\n");
         ret 1;
     }
 
@@ -659,7 +661,7 @@ fun build_test_runner(p: *driver.Project, level: u8, verify_ir: bool,
     }
     val syn: Option[ir.Module] = unwrap_ok[Option[ir.Module], str](syn_r);
     if (is_none[ir.Module](syn)) {
-        print.eprint("error: no tests found in the project\n");
+        print.eprint("error: no 'test' declarations found (add 'test <name> { ... }' blocks)\n");
         ret 1;
     }
     @runner_ir    = unwrap[ir.Module](syn);
@@ -786,7 +788,7 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
         if (is_none[str](bin_opt) || str_empty(unwrap[str](bin_opt))) {
             free_paths(p.s.alloc, paths, count, count);
             free_sonames(p.s.alloc, sonames, soname_count);
-            print.eprint("error: artifact has no resolved output path\n");
+            print.eprint("error: selected artifact has no output path; set the target's binary path in mach.toml\n");
             ret 1;
         }
         join_into_str(?artifact[0], 4096, root, unwrap[str](bin_opt));
@@ -1114,7 +1116,7 @@ fun resolve_and_store_input(p: *driver.Project, tok: *u8, root: *u8, argc: usize
         if (p.target.of_id != of.OF_COFF) {
             print.eprint("error: '");
             print.eprint(tok::str);
-            print.eprint("' is a Windows DLL, but the selected target's object format is not PE/COFF\n");
+            print.eprint("' is a Windows DLL; .dll inputs require a PE/COFF target\n");
             ret 1;
         }
         ret append_soname(p, dll_basename(tok), sonames, soname_count);
@@ -1689,12 +1691,14 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
     # post-`--` args are program arguments, never build flags; clip the scanners.
     val eff: usize = util.separator_index(argc, argv);
-    val cfg_opt: Option[cfg.Config] = cfg.parse(eff, argv);
-    if (is_none[cfg.Config](cfg_opt)) {
-        print.eprint("error: invalid command-line flags\n");
+    val cfg_r: Result[cfg.Config, str] = cfg.parse(eff, argv);
+    if (is_err[cfg.Config, str](cfg_r)) {
+        print.eprint("error: ");
+        print.eprint(unwrap_err[cfg.Config, str](cfg_r));
+        print.eprint("\n");
         ret 1;
     }
-    val config: cfg.Config = unwrap[cfg.Config](cfg_opt);
+    val config: cfg.Config = unwrap_ok[cfg.Config, str](cfg_r);
     if (config.bin != nil && config.lib != nil) {
         print.eprint("error: --bin and --lib cannot be combined\n");
         ret 1;

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -62,6 +62,7 @@ use token:   mach.lang.fe.token;
 use ir:         mach.lang.me.ir;
 use ir_printer: mach.lang.me.ir.printer;
 use lower:      mach.lang.me.lower;
+use lowctx:     mach.lang.me.lower.context;
 use testrunner: mach.lang.me.lower.testrunner;
 use pipeline:   mach.lang.me.pipeline;
 
@@ -613,9 +614,14 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
     var code: i64 = 0;
     val comp_r: Result[bool, str] = compile_modules(p, level, test_mode, verify_ir, verbose, ?ea, results, ready, irs, ir_ready, images, image_ready);
     if (is_err[bool, str](comp_r)) {
-        print.eprint("error: ");
-        print.eprint(unwrap_err[bool, str](comp_r));
-        print.eprint("\n");
+        # a `lower:reported` sentinel means lowering already filed a located
+        # diagnostic on the sink; the flush prints it, so skip the raw reprint.
+        val emsg: str = unwrap_err[bool, str](comp_r);
+        if (!str_equals(emsg, lowctx.REPORTED)) {
+            print.eprint("error: ");
+            print.eprint(emsg);
+            print.eprint("\n");
+        }
         code = 1;
     }
     or (diag.has_errors(?p.s.diags)) {

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -422,12 +422,14 @@ fun generate(p: *driver.Project, api_dir: *u8, stats: *DocStats) i64 {
 # argv: the argument vector (argc null-terminated byte pointers)
 # ret:  0 on success, 1 on a user error, 2 on an internal error
 pub fun run(argc: usize, argv: **u8) i64 {
-    val cfg_opt: Option[cfg.Config] = cfg.parse(argc, argv);
-    if (is_none[cfg.Config](cfg_opt)) {
-        print.eprint("error: invalid command-line flags\n");
+    val cfg_r: Result[cfg.Config, str] = cfg.parse(argc, argv);
+    if (is_err[cfg.Config, str](cfg_r)) {
+        print.eprint("error: ");
+        print.eprint(unwrap_err[cfg.Config, str](cfg_r));
+        print.eprint("\n");
         ret 1;
     }
-    val config: cfg.Config = unwrap[cfg.Config](cfg_opt);
+    val config: cfg.Config = unwrap_ok[cfg.Config, str](cfg_r);
 
     var root: [4096]u8;
     if (!util.find_project_root(config.cwd, ?root[0], 4096)) {

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -15,10 +15,11 @@ use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_equals;
 use std.types.option.Option;
-use std.types.option.some;
-use std.types.option.none;
 use std.types.option.is_some;
 use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
 
 use util: mach.cli.util;
 
@@ -94,13 +95,14 @@ pub fun color_enabled(mode: ColorMode) bool {
 
 # parse: read the cross-cutting flags out of `argv` and produce a
 # populated Config. per-subcommand flags are left in argv for the
-# subcommand to consume itself. returns `none` on a parse error: an
-# unknown `--color` mode, or both `--verbose` and `--quiet` together.
+# subcommand to consume itself. returns a specific error message on a parse
+# error so the caller can tell the user which flag was wrong: an unknown
+# `--color` mode, or both `--verbose` and `--quiet` together.
 # ---
 # argc: argument count including argv[0]
 # argv: the argument vector (argc null-terminated byte pointers)
-# ret:  the populated Config, or none on a parse error
-pub fun parse(argc: usize, argv: **u8) Option[Config] {
+# ret:  the populated Config, or a message naming the offending flag
+pub fun parse(argc: usize, argv: **u8) Result[Config, str] {
     var c: Config;
     c.color     = COLOR_AUTO;
     c.verbose   = false;
@@ -123,7 +125,7 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
     val verbose: bool = util.has_flag(argc, argv, "--verbose") || util.has_flag(argc, argv, "-v");
     val quiet:   bool = util.has_flag(argc, argv, "--quiet")   || util.has_flag(argc, argv, "-q");
     if (verbose && quiet) {
-        ret none[Config]();
+        ret err[Config, str]("`--verbose`/`-v` and `--quiet`/`-q` cannot be combined");
     }
     c.verbose = verbose;
     c.quiet   = quiet;
@@ -141,7 +143,7 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
         if (str_equals(mode::str, "auto"))   { c.color = COLOR_AUTO; }
         or (str_equals(mode::str, "always")) { c.color = COLOR_ALWAYS; }
         or (str_equals(mode::str, "never"))  { c.color = COLOR_NEVER; }
-        or                           { ret none[Config](); }
+        or                           { ret err[Config, str]("invalid --color mode (expected auto, always, or never)"); }
     }
 
     val cwd_opt: Option[*u8] = util.get_value(argc, argv, "--cwd");
@@ -165,5 +167,5 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
     val lib_opt: Option[*u8] = util.get_value(argc, argv, "--lib");
     if (is_some[*u8](lib_opt)) { c.lib = unwrap[*u8](lib_opt); }
 
-    ret some[Config](c);
+    ret ok[Config, str](c);
 }

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -31,10 +31,12 @@ use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_some;
+use std.types.option.is_none;
 use std.types.option.unwrap;
 use std.types.result.Result;
 use std.types.result.ok;
@@ -845,6 +847,35 @@ fun lower_cbr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     ret lctx.push_instr(ctx, mb, mi);
 }
 
+# asm_bind_message: build "<prefix><name><suffix>" naming an inline-asm bind by
+# resolving its interned name through the context interner, interned so the
+# message outlives this call. degrades to `fallback` on any failure.
+fun asm_bind_message(ctx: *lctx.LowerCtx, prefix: str, name_id: intern.StrId, suffix: str, fallback: str) str {
+    val no: Option[str] = intern.lookup(ctx.interner, name_id);
+    if (is_none[str](no)) { ret fallback; }
+    val nm: str = unwrap[str](no);
+
+    val total: usize = str_len(prefix) + str_len(nm) + str_len(suffix);
+    val r: Result[*u8, str] = allocate[u8](ctx.alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret fallback; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    var j: usize = 0;
+    for (j < str_len(prefix)) { buf[k] = prefix[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < str_len(nm)) { buf[k] = nm[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < str_len(suffix)) { buf[k] = suffix[j]; k = k + 1; j = j + 1; }
+    buf[total] = 0;
+
+    val ir: Result[intern.StrId, str] = intern.intern(ctx.interner, buf::str);
+    deallocate[u8](ctx.alloc, buf, total + 1);
+    if (is_err[intern.StrId, str](ir)) { ret fallback; }
+    val rn: Option[str] = intern.lookup(ctx.interner, unwrap_ok[intern.StrId, str](ir));
+    if (is_some[str](rn)) { ret unwrap[str](rn); }
+    ret fallback;
+}
+
 # lower_asm_instr: build a mir.MIR_ASM instruction from the IR `IrAsm` payload bound
 # to this OP_ASM instruction id. resolves the interned ISA / body strings to
 # text and maps each `{name}` binding's alloca instruction id to the slot-owning
@@ -886,9 +917,10 @@ fun lower_asm_instr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, iid: id.InstructionI
             var vreg: u32 = lctx.slot_key_vreg(ctx, src.binds[k].instr);
             if (vreg == mir.MIR_VREG_NIL) { vreg = lctx.instr_vreg(ctx, src.binds[k].instr); }
             if (vreg == mir.MIR_VREG_NIL) {
+                val msg: str = asm_bind_message(ctx, "inline-asm local '", src.binds[k].name, "' has no addressable storage slot", "inline-asm local has no addressable storage slot");
                 deallocate[mir.MirAsmBind](ctx.alloc, payload.binds, src.bind_count::usize);
                 deallocate[mir.MirAsm](ctx.alloc, payload, 1::usize);
-                ret err[bool, str]("mir.lower_ir: inline-asm '{name}' local has no slot vreg");
+                ret err[bool, str](msg);
             }
             payload.binds[k].name      = src.binds[k].name;
             payload.binds[k].slot_vreg = vreg;
@@ -1400,7 +1432,7 @@ fun lower_alloca(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructio
     }
     val cv: value.Value = inst.operands[0];
     if (cv.kind != value.VAL_CONST_INT) {
-        ret err[bool, str]("mir.lower_ir: non-constant alloca count unsupported");
+        ret err[bool, str]("variable-length alloca is not supported; use a constant size");
     }
     val count: u64 = cv.data.int_lit;
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -176,7 +176,7 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     if (tgt.of == nil) { ret err[bool, str]("link: target has no object-format vtable"); }
     if (tgt.os == nil) { ret err[bool, str]("link: target has no OS vtable"); }
     if (mode == LINK_SHARED) {
-        ret err[bool, str]("link: shared-object output (LINK_SHARED) is not supported");
+        ret err[bool, str]("link: shared-object output is not yet supported");
     }
     if (obj_paths == nil || obj_count == 0) {
         ret err[bool, str]("link: no input objects");
@@ -238,7 +238,7 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     sec_base = unwrap_ok[*u32, str](br);
 
     val acc_r: Result[bool, str] =
-        accumulate_sections(modules, module_count, ?merged[0], placements, sec_base);
+        accumulate_sections(s, modules, module_count, ?merged[0], placements, sec_base);
     if (is_err[bool, str](acc_r)) {
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
         free_modules(alloc, modules, module_count);
@@ -723,7 +723,7 @@ fun build_load_segments(alloc: *Allocator, out_img: *of.ObjectImage, merged: *Me
         k = k + 1;
     }
     if (count == 0) {
-        ret err[*of.LoadSegment, str]("link: no loadable sections");
+        ret err[*of.LoadSegment, str]("link: no loadable sections in any input object; verify inputs contain code or data");
     }
 
     val sr: Result[*of.LoadSegment, str] = zallocate[of.LoadSegment](alloc, count::usize);
@@ -907,7 +907,7 @@ fun total_sections(modules: *of.ObjectImage, module_count: u32) u32 {
 # record every input section's placement (merged index + offset within the
 # merged section). also fills `sec_base` with the per-module prefix offset into
 # the flat placement array.
-fun accumulate_sections(modules: *of.ObjectImage, module_count: u32,
+fun accumulate_sections(s: *sess.Session, modules: *of.ObjectImage, module_count: u32,
                         merged: *MergedSection, placements: *Placement, sec_base: *u32) Result[bool, str] {
     var flat: u32 = 0;
     var m: u32 = 0;
@@ -920,7 +920,7 @@ fun accumulate_sections(modules: *of.ObjectImage, module_count: u32,
             # out-of-range kind is a contract violation, not a section to silently
             # fold into .debug.
             if (sec.kind::u32 >= MERGED_KIND_COUNT) {
-                ret err[bool, str]("linker: input section has an unknown section kind");
+                ret err[bool, str](named_message(s, "linker: input section in object '", modules[m].name, "' has an unknown section kind", "linker: input section has an unknown section kind"));
             }
             val ki: u32 = sec.kind::u32;
 
@@ -935,7 +935,7 @@ fun accumulate_sections(modules: *of.ObjectImage, module_count: u32,
             val off64: u64 = bin.align_up_u64(merged[ki].len::u64, a::u64);
             val newlen: u64 = off64 + sec.len::u64;
             if (newlen > 0xFFFFFFFF) {
-                ret err[bool, str]("linker: merged section size exceeds the 4 GiB u32 limit");
+                ret err[bool, str](named_message(s, "linker: merged section '", merged_section_name(s, sec.kind), "' exceeds the 4 GiB u32 limit", "linker: merged section size exceeds the 4 GiB u32 limit"));
             }
 
             placements[flat].merged_index = ki;
@@ -1004,7 +1004,7 @@ fun collect_symbols(s: *sess.Session, modules: *of.ObjectImage, module_count: u3
             # object: erroring here surfaces it directly instead of letting the
             # definition vanish and resurface later as a baffling undefined symbol.
             if (sym.section >= modules[m].section_count) {
-                ret err[bool, str]("linker: symbol names an out-of-range section");
+                ret err[bool, str](oor_section_message(s, sym.name, modules[m].name));
             }
             if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0) { sy = sy + 1; cnt; }
 
@@ -1644,6 +1644,29 @@ fun os_page_size(tgt: *target.Target) u64 {
     ret tgt.os.page_size;
 }
 
+# named_message: build "<prefix><name><suffix>" with the interned `name_id`
+# looked up (zero-allocation) before any join, degrading to `fallback` when the
+# id has no text or the join allocation fails.
+fun named_message(s: *sess.Session, prefix: str, name_id: intern.StrId, suffix: str, fallback: str) str {
+    val nm: Option[str] = intern.lookup(?s.interner, name_id);
+    if (is_some[str](nm)) { ret join3(s, prefix, unwrap[str](nm), suffix, fallback); }
+    ret fallback;
+}
+
+# oor_section_message: build the "symbol '<sym>' in object '<obj>' names an
+# out-of-range section" diagnostic, naming both the symbol and the object the
+# corrupt section index came from.
+fun oor_section_message(s: *sess.Session, sym_name: intern.StrId, obj_name: intern.StrId) str {
+    val sn: Option[str] = intern.lookup(?s.interner, sym_name);
+    val on: Option[str] = intern.lookup(?s.interner, obj_name);
+    if (is_some[str](sn) && is_some[str](on)) {
+        val pre: str = join3(s, "linker: symbol '", unwrap[str](sn), "' in object '", "linker: symbol names an out-of-range section");
+        ret join3(s, pre, unwrap[str](on), "' names an out-of-range section", "linker: symbol names an out-of-range section");
+    }
+    if (is_some[str](sn)) { ret join3(s, "linker: symbol '", unwrap[str](sn), "' names an out-of-range section", "linker: symbol names an out-of-range section"); }
+    ret "linker: symbol names an out-of-range section";
+}
+
 # dup_message: build the "multiple definition of '<name>'" diagnostic string.
 fun dup_message(s: *sess.Session, name: intern.StrId) str {
     val nm: Option[str] = intern.lookup(?s.interner, name);
@@ -1668,12 +1691,13 @@ fun unsupported_message(s: *sess.Session, kind: of.RelocKind) str {
     ret join3(s, "relocation '", of.reloc_kind_name(kind), "' not supported", "relocation not supported");
 }
 
-# entry_message: build the "undefined entry symbol: <name>" diagnostic string
-# for a missing program entry point (the OS `entry_symbol`, e.g. "_start").
+# entry_message: build the "undefined entry symbol '<name>'" diagnostic string
+# for a missing program entry point (the OS `entry_symbol`, e.g. "_start"),
+# hinting that the target's startup library must be linked.
 fun entry_message(s: *sess.Session, name: intern.StrId) str {
     val nm: Option[str] = intern.lookup(?s.interner, name);
-    if (is_some[str](nm)) { ret join2(s, "undefined entry symbol: ", unwrap[str](nm), "undefined entry symbol"); }
-    ret "undefined entry symbol";
+    if (is_some[str](nm)) { ret join3(s, "undefined entry symbol '", unwrap[str](nm), "'; ensure the target startup library is linked", "undefined entry symbol; ensure the target startup library is linked"); }
+    ret "undefined entry symbol; ensure the target startup library is linked";
 }
 
 # read_message: build the "cannot read object '<path>': <reason>" diagnostic

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -620,7 +620,7 @@ fun emit_executable(s: *sess.Session, tgt: *target.Target, out_img: *of.ObjectIm
     val funcs: *of.ExecFunction = unwrap_ok[*of.ExecFunction, str](fr);
 
     val emit_r: Result[bool, str] =
-        tgt.of.emit_exec(alloc, tgt.arch, segs, seg_count, entry, funcs, func_count, out_path);
+        tgt.of.emit_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, entry, funcs, func_count, out_path);
 
     if (funcs != nil && func_count > 0) {
         deallocate[of.ExecFunction](alloc, funcs, func_count::usize);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -74,7 +74,6 @@ use isa: mach.lang.target.isa;
 use tgt: mach.lang.target;
 use version: mach.lang.version;
 
-use sysos:    std.system.os;
 use manifest: mach.lang.manifest;
 
 # BuildMode: the kind of artifact a target build produces.
@@ -464,8 +463,9 @@ pub fun build_project_sel(s: *sess.Session, project_root: str, sel: *manifest.Se
     or {
         te = find_target(?p.config, sel.target, ?p.s.interner);
         if (te == nil) {
+            val msg: str = diag_join3(p.s, "mach.toml: target '", sel.target, "' is not declared", "target not found in mach.toml");
             dnit_project(?p);
-            ret err[Project, str]("target not found in mach.toml");
+            ret err[Project, str](msg);
         }
         p.target_entry = te;
     }
@@ -967,23 +967,49 @@ fun map_v2_opt(o: manifest.MOpt) TargetOpt {
     ret TARGET_OPT_DEFAULT;
 }
 
-# emit_native_warning: write the unmissable `native` no-match warning to stderr,
-# naming the host tuple and the target being built instead.
+# emit_native_warning: file the `native` no-match warning on the session
+# diagnostic sink, naming the host tuple and the target being built instead.
+# filing it (rather than racing a raw stderr write) gives it a `warning:` label
+# and renders it in order with the structured diagnostics. the warning is not
+# tied to a source span, so it carries an out-of-range file id and renders
+# message-only.
 fun emit_native_warning(p: *Project, target_name: intern.StrId) {
     val tuple: str = manifest.host_tuple(p.s.alloc);
     val name_opt: Option[str] = intern.lookup(?p.s.interner, target_name);
     var name: str = "?";
     if (is_some[str](name_opt)) { name = unwrap[str](name_opt); }
-    emit_stderr("warning: no declared target matches the host (");
-    emit_stderr(tuple);
-    emit_stderr("); building '");
-    emit_stderr(name);
-    emit_stderr("'\n");
+
+    val a: str = "no declared target matches the host (";
+    val b: str = "); building '";
+    val c: str = "'";
+    val total: usize = str_len(a) + str_len(tuple) + str_len(b) + str_len(name) + str_len(c);
+
+    val r: Result[*u8, str] = allocate[u8](p.s.alloc, total + 1);
+    if (is_err[*u8, str](r)) { str_free(p.s.alloc, tuple); ret; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    k = dcopy(buf, k, a);
+    k = dcopy(buf, k, tuple);
+    k = dcopy(buf, k, b);
+    k = dcopy(buf, k, name);
+    k = dcopy(buf, k, c);
+    buf[total] = 0;
+
+    var span: token.Span;
+    span.offset = 0;
+    span.len    = 0;
+    diag.warning(?p.s.diags, 0xFFFFFFFF::src.FileId, span, buf::str);
+
+    deallocate[u8](p.s.alloc, buf, total + 1);
+    str_free(p.s.alloc, tuple);
 }
 
-# emit_stderr: write a string to stderr, computing its length.
-fun emit_stderr(s: str) {
-    sysos.write(sysos.STDERR_FD, s::*u8, str_len(s));
+# dcopy: append `s`'s bytes into `buf` at offset `k`, returning the new offset.
+fun dcopy(buf: *u8, k: usize, s: str) usize {
+    val n: usize = str_len(s);
+    var j: usize = 0;
+    for (j < n) { buf[k + j] = s[j]; j = j + 1; }
+    ret k + n;
 }
 
 # resolve_v2_deps: resolve each `[deps.*]` into a DepEntry by vendor layout,
@@ -1375,8 +1401,9 @@ fun resolve_dep(s: *sess.Session, alias: str, project_root: str, dir_dep: str) R
 
     val id_str: str = toml.get_str(?t, "project.id");
     if (str_empty(id_str)) {
+        val msg: str = diag_join3(s, "dep '", alias, "' mach.toml is missing [project].id", "dep mach.toml is missing [project].id");
         str_free(s.alloc, dep_dir);
-        ret err[DepEntry, str]("dep mach.toml is missing [project].id");
+        ret err[DepEntry, str](msg);
     }
 
     var entry: DepEntry;
@@ -1697,6 +1724,46 @@ fun build_module_path(alloc: *Allocator, root: str, src_dir: str, dotted_tail: S
     ret ok[str, str](buf::str);
 }
 
+# diag_join3: build `<a><b><c>` interned on the session, returning a borrowed
+# view valid for the session's lifetime. the module-load walk returns bare error
+# strings that surface before the diagnostic flush, so these name the offending
+# entity inline. returns the static `fallback` on any allocation/intern failure.
+fun diag_join3(s: *sess.Session, a: str, b: str, c: str, fallback: str) str {
+    val la: usize = str_len(a);
+    val lb: usize = str_len(b);
+    val lc: usize = str_len(c);
+    val total: usize = la + lb + lc;
+
+    val r: Result[*u8, str] = allocate[u8](s.alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret fallback; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+
+    var k: usize = 0;
+    var j: usize = 0;
+    for (j < la) { buf[k] = a[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < lb) { buf[k] = b[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < lc) { buf[k] = c[j]; k = k + 1; j = j + 1; }
+    buf[total] = 0;
+
+    val ir: Result[intern.StrId, str] = intern.intern(?s.interner, buf::str);
+    deallocate[u8](s.alloc, buf, total + 1);
+    if (is_err[intern.StrId, str](ir)) { ret fallback; }
+
+    val nm: Option[str] = intern.lookup(?s.interner, unwrap_ok[intern.StrId, str](ir));
+    if (is_some[str](nm)) { ret unwrap[str](nm); }
+    ret fallback;
+}
+
+# diag_join_named: diag_join3 with the middle drawn from an interned id's text;
+# falls back to the static message when the id has no recorded text.
+fun diag_join_named(s: *sess.Session, prefix: str, name_id: intern.StrId, suffix: str, fallback: str) str {
+    val no: Option[str] = intern.lookup(?s.interner, name_id);
+    if (is_none[str](no)) { ret fallback; }
+    ret diag_join3(s, prefix, unwrap[str](no), suffix, fallback);
+}
+
 # join_path: join two path segments with a single '/' separator and return an owned str.
 fun join_path(alloc: *Allocator, a: str, b: str) Result[str, str] {
     val a_len: usize = str_len(a);
@@ -1746,7 +1813,7 @@ fun dfs_load(p: *Project, fqn: intern.StrId) Result[sess.ModuleId, str] {
     if (is_ok[*sess.ModuleId, str](existing_r)) {
         val mid: sess.ModuleId = @unwrap_ok[*sess.ModuleId, str](existing_r);
         if (p.load_status[mid::u32] == LOAD_LOADING) {
-            ret err[sess.ModuleId, str]("circular module dependency");
+            ret err[sess.ModuleId, str](diag_join_named(p.s, "circular module dependency: '", fqn, "' is already being loaded", "circular module dependency"));
         }
         ret ok[sess.ModuleId, str](mid);
     }
@@ -2191,7 +2258,7 @@ fun resolve_use_target(p: *Project, source: str, path: token.Span) Result[UseTar
     for (seg_end > path.offset) {
         var dot: usize = seg_end;
         for (dot > path.offset && source[dot - 1] != '.') { dot = dot - 1; }
-        if (dot == path.offset) { ret err[UseTarget, str]("use path does not name a module"); }
+        if (dot == path.offset) { ret err[UseTarget, str](diag_join_named(p.s, "use path '", full_id, "' does not name a module", "use path does not name a module")); }
         var prefix: token.Span;
         prefix.offset = path.offset;
         prefix.len    = (dot - 1) - path.offset;
@@ -2206,7 +2273,7 @@ fun resolve_use_target(p: *Project, source: str, path: token.Span) Result[UseTar
         }
         seg_end = dot - 1;
     }
-    ret err[UseTarget, str]("use path does not name a module");
+    ret err[UseTarget, str](diag_join_named(p.s, "use path '", full_id, "' does not name a module", "use path does not name a module"));
 }
 
 # fqn_names_file: true when an FQN resolves to an existing `.mach` file.

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -942,6 +942,97 @@ test "diagnostics: unresolved type name names the type and suggests a near match
     ret 0;
 }
 
+test "diagnostics: a stray control character names the offending byte class (#1046)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # a NUL-region control byte (here a vertical tab, 0x0B) is not valid source;
+    # the lexer reports it as a stray control character with a 1-byte span.
+    val fr: Result[src.FileId, str] = open(?es, "ctrl.mach", "fun main() i64 { ret 0; }\n\x0B\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val tr: Result[lexer.TokenStream, str] = tokenize(?es, fid);
+    if (is_err[lexer.TokenStream, str](tr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+
+    val hit: bool = diag_has(?es.s.diags, "stray control character in source");
+    lexer.dnit(?stream, es.alloc);
+    if (!hit) { dnit(?es); sess.dnit(?s); ret 1; }
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "diagnostics: an unrecognized top-level token lists the valid declaration starters (#1046)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    val fr: Result[src.FileId, str] = open(?es, "decl.mach", "garbage\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val pr: Result[*ast.Ast, str] = parse(?es, fid);
+    if (is_err[*ast.Ast, str](pr)) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    if (!diag_has(?es.s.diags, "expected a declaration; valid starters: use, fwd, fun, rec, uni, val, var, def, test")) { dnit(?es); sess.dnit(?s); ret 1; }
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "diagnostics: a value name used as a type is told it does not name a type (#1046)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `f` names a function, not a type; using it in a parameter's type position
+    # reports that it does not name a type, embedding the symbol name.
+    val fr: Result[src.FileId, str] = open(?es, "nt.mach",
+        "fun f() i64 { ret 0; }\nfun main(p: f) i64 { ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "`f` does not name a type")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "diagnostics: calling a non-function renders the callee type (#1046)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `x` is an i64, not a function; calling it reports the callee's rendered
+    # type rather than a bare "callee is not a function".
+    val fr: Result[src.FileId, str] = open(?es, "nc.mach",
+        "fun main() i64 { var x: i64 = 0; ret x(); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "not callable: `i64` is not a function")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "sema: pointer reinterpret legality follows the target pointer width (#1248)" {
     var alloc: Allocator;
     val srr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/fe/lexer.mach
+++ b/src/lang/fe/lexer.mach
@@ -32,6 +32,7 @@ use pool:    mach.lang.fe.pool;
 pub val LEX_ERR_UNEXPECTED_CHAR:   u8 = 1;
 pub val LEX_ERR_UNTERMINATED_STR:  u8 = 2;
 pub val LEX_ERR_UNTERMINATED_CHAR: u8 = 3;
+pub val LEX_ERR_CONTROL_CHAR:      u8 = 4;
 
 # LexError: a structured lexer error pairing a bad span with an error code.
 # ---
@@ -328,7 +329,9 @@ pub fun tokenize(source: str, alloc: *Allocator, file_id: src.FileId) Result[Tok
         }
         or {
             tok = token.make(token.KIND_ERROR, pos, 1);
-            val r_err: Result[bool, str] = push_error(?stream, alloc, pos, 1, LEX_ERR_UNEXPECTED_CHAR);
+            var lex_code: u8 = LEX_ERR_UNEXPECTED_CHAR;
+            if (c < 0x20 || c == 0x7f) { lex_code = LEX_ERR_CONTROL_CHAR; }
+            val r_err: Result[bool, str] = push_error(?stream, alloc, pos, 1, lex_code);
             if (is_err[bool, str](r_err)) {
                 deallocate[token.Token](alloc, stream.tokens, stream.cap);
                 ret err[TokenStream, str](unwrap_err[bool, str](r_err));
@@ -403,7 +406,8 @@ pub fun text(stream: *TokenStream, tok: token.Token) strutil.StrView {
 fun err_message(code: u8) str {
     if (code == LEX_ERR_UNTERMINATED_STR)  { ret "unterminated string literal"; }
     if (code == LEX_ERR_UNTERMINATED_CHAR) { ret "unterminated character literal"; }
-    ret "unexpected character";
+    if (code == LEX_ERR_CONTROL_CHAR)      { ret "stray control character in source; only printable ASCII and whitespace are allowed"; }
+    ret "unexpected character; only ASCII source text is supported";
 }
 
 # emit_diagnostics: push every accumulated lex error onto a diagnostic sink

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -95,7 +95,7 @@ pub fun parse_decl(p: *parser.Parser) id.DeclId {
     if (parser.at_kw(p, "def"))   { ret parse_def_decl(p, start.span, flags); }
     if (parser.at_kw(p, "test"))  { ret parse_test_decl(p, start.span, flags); }
 
-    parser.error_at_current(p, "expected a declaration");
+    parser.error_at_current(p, "expected a declaration; valid starters: use, fwd, fun, rec, uni, val, var, def, test");
     var err: decl.Decl;
     err.span  = start.span;
     err.kind  = decl.DECL_KIND_ERROR;
@@ -396,7 +396,7 @@ fun parse_bind_decl(p: *parser.Parser, start: token.Span, flags: u8, kind: decl.
     if (parser.eat(p, token.KIND_COLON)) {
         ty = pexpr.parse_type(p);
     } or {
-        parser.error_at_current(p, "expected ':' and a type — bindings require an explicit type");
+        parser.error_at_current(p, "expected ':' and a type; bindings require an explicit type annotation");
     }
 
     # `val` requires an initializer (val-var.md); `var` may be default-initialized.
@@ -698,7 +698,7 @@ fun parse_generic_param(p: *parser.Parser) bool {
     val name: token.Span = parser.advance(p).span;
     val r: Result[u32, str] = ast.add_generic_name(p.ast, name);
     if (is_err[u32, str](r)) {
-        parser.error_at(p, name, "out of memory while parsing generic parameter");
+        parser.fatal_oom_at(p, name);
         ret false;
     }
     ret true;

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -91,7 +91,7 @@ pub fun parse_type(p: *parser.Parser) id.TypeId {
     if (parser.at_kw(p, "uni"))            { ret parse_rec_or_uni(p, start.span, m_type.TYPE_KIND_UNI); }
     if (parser.at(p, token.KIND_IDENT))    { ret parse_named(p, start.span); }
 
-    parser.error_at_current(p, "expected a type");
+    parser.error_at_current(p, "expected a type; named, '*T', '[N]T', 'fun(...)', or inline 'rec'/'uni' forms are valid here");
     var t: m_type.Type;
     t.span = start.span;
     t.kind = m_type.TYPE_KIND_ERROR;
@@ -126,7 +126,7 @@ fun parse_prefix(p: *parser.Parser) id.ExprId {
         ret parse_ident(p);
     }
 
-    parser.error_at_current(p, "expected an expression");
+    parser.error_at_current(p, "expected an expression; literals, identifiers, '(', and unary operators are valid here");
     var node: expr.Expr;
     node.span = t.span;
     node.kind = expr.EXPR_KIND_ERROR;
@@ -734,7 +734,7 @@ fun bin_op_from_kind(p: *parser.Parser, kind: token.Kind) expr.BinOp {
     if (kind == token.KIND_LT_LT)     { ret expr.BIN_SHL; }
     if (kind == token.KIND_GT_GT)     { ret expr.BIN_SHR; }
     if (kind == token.KIND_EQ)        { ret expr.BIN_ASSIGN; }
-    parser.error_at_current(p, "internal error: infix operator has no binary-operator mapping");
+    parser.fatal_ice_at(p, parser.current(p).span, "internal compiler error: infix operator has no binary-operator mapping");
     ret expr.BIN_ASSIGN;
 }
 
@@ -928,7 +928,7 @@ fun parse_rec_or_uni(p: *parser.Parser, start: token.Span, kind: m_type.TypeKind
 
     for (!parser.at(p, token.KIND_RBRACE) && !parser.at_eof(p)) {
         if (!parser.at(p, token.KIND_IDENT)) {
-            parser.error_at_current(p, "expected a field name");
+            parser.error_at_current(p, "expected a field name in anonymous type body");
             parser.sync_to(p, token.KIND_SEMI, token.KIND_RBRACE, token.KIND_EOF);
             if (parser.at(p, token.KIND_SEMI)) { parser.advance(p); }
             cnt;

--- a/src/lang/fe/parser/state.mach
+++ b/src/lang/fe/parser/state.mach
@@ -202,6 +202,22 @@ pub fun fatal_oom(p: *Parser) {
     fatal_oom_at(p, current(p).span);
 }
 
+# fatal_ice_at: records an internal compiler error at `span`. an ICE is a real
+# compiler defect (not a malformed program), so it bypasses the `panic` guard,
+# carries the `internal compiler error:` prefix, and sets the sticky `fatal`
+# flag so the driver refuses to consume the (now suspect) AST instead of
+# letting downstream passes read it out of bounds.
+# ---
+# p:       parser state
+# span:    span to pin the diagnostic to
+# message: description of the invariant that was violated
+pub fun fatal_ice_at(p: *Parser, span: token.Span, message: str) {
+    if (p.fatal) { ret; }
+    p.fatal = true;
+    val r: Result[bool, str] = diag.error(p.diags, p.tokens.file_id, span, message);
+    if (is_err[bool, str](r)) { ret; }
+}
+
 # sync_to: advances until the current token is EOF or matches one of the synchronization kinds, then clears panic.
 # ---
 # p:  parser state

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -786,7 +786,11 @@ fun comptime_branch_active(rc: *ResolveContext, br: *decl.ComptimeBranch) Result
     }
     val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](r);
     if (v.kind != comptime.CT_KIND_BOOL) {
-        val de: Result[bool, str] = diag.error(?rc.s.diags, rc.a.file_id, cond_span, "comptime branch condition must be a bool");
+        # the BOOL case is excluded above, so the value is int, float, or str.
+        var msg: str = "comptime branch condition must be a bool, found int";
+        if (v.kind == comptime.CT_KIND_FLOAT) { msg = "comptime branch condition must be a bool, found float"; }
+        or (v.kind == comptime.CT_KIND_STR)   { msg = "comptime branch condition must be a bool, found str"; }
+        val de: Result[bool, str] = diag.error(?rc.s.diags, rc.a.file_id, cond_span, msg);
         if (is_err[bool, str](de)) { ret de; }
         ret ok[bool, str](false);
     }
@@ -848,7 +852,7 @@ fun collect_use(rc: *ResolveContext, decl_id: id.DeclId, du: *decl.DeclUse, scop
 
     val ps: *PublicSymbol = find_export(pmx, leaf_id);
     if (ps == nil) {
-        diag.error(?rc.s.diags, rc.a.file_id, du.path, "imported symbol is not exported by its module");
+        report_named2(rc, du.path, "`", leaf_id, "` is not exported by `", pmx.path, "`");
         ret ok[bool, str](true);
     }
 
@@ -871,7 +875,7 @@ fun bind_imported_symbol(rc: *ResolveContext, decl_id: id.DeclId, bind_span: tok
 
     val existing: SymbolId = scope_lookup_local(rc, scope, name_id);
     if (existing != SYMBOL_NIL) {
-        diag.error(?rc.s.diags, rc.a.file_id, bind_span, "imported name already defined in this scope");
+        report_named(rc, bind_span, "imported name `", name_id, "` is already defined in this scope");
         ret ok[bool, str](true);
     }
 
@@ -1018,7 +1022,7 @@ fun bind_member_qualified(rc: *ResolveContext, eid: id.ExprId, member: *expr.Exp
         # (`sema.c:3634`) errors for `!sym || !sym->is_public`; mirror that
         # here, since sema's later TYPE_NIL early-out would otherwise drop the
         # access silently.
-        diag.error(?rc.s.diags, rc.a.file_id, member.name, "undefined symbol in module");
+        report_named2(rc, member.name, "no symbol `", leaf_id, "` exported by `", mx.path, "`");
         ret ok[bool, str](true);
     }
 
@@ -1196,7 +1200,7 @@ fun bind_fwd(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, flags: 
 
     val existing: SymbolId = scope_lookup_local(rc, rc.module_scope, name_id);
     if (existing != SYMBOL_NIL) {
-        diag.error(?rc.s.diags, rc.a.file_id, bind_span, "re-exported name already defined in this scope");
+        report_named(rc, bind_span, "re-exported name `", name_id, "` is already defined in this scope");
         ret ok[bool, str](true);
     }
 
@@ -1230,7 +1234,7 @@ fun bind_fwd_module(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, 
 
     val existing: SymbolId = scope_lookup_local(rc, rc.module_scope, name_id);
     if (existing != SYMBOL_NIL) {
-        diag.error(?rc.s.diags, rc.a.file_id, alias_span, "re-exported name already defined in this scope");
+        report_named(rc, alias_span, "re-exported name `", name_id, "` is already defined in this scope");
         ret ok[bool, str](true);
     }
 
@@ -1890,6 +1894,45 @@ fun report_named(rc: *ResolveContext, span: token.Span, prefix: str, name_id: in
     ret emit;
 }
 
+# report_named2: emit an error at `span` interpolating two interned names into
+# `<prefix><a><mid><b><suffix>`, e.g. ``no symbol `x` exported by `mod` ``. like
+# report_named it degrades to the static `prefix` on any lookup or allocation
+# failure so the diagnostic always lands.
+fun report_named2(rc: *ResolveContext, span: token.Span, prefix: str, a_id: intern.StrId, mid: str, b_id: intern.StrId, suffix: str) Result[bool, str] {
+    val ao: Option[str] = intern.lookup(?rc.s.interner, a_id);
+    val bo: Option[str] = intern.lookup(?rc.s.interner, b_id);
+    if (is_none[str](ao) || is_none[str](bo)) {
+        ret diag.error(?rc.s.diags, rc.a.file_id, span, prefix);
+    }
+    val a: str = unwrap[str](ao);
+    val b: str = unwrap[str](bo);
+
+    val pn: usize = str_len(prefix);
+    val an: usize = str_len(a);
+    val mn: usize = str_len(mid);
+    val bn: usize = str_len(b);
+    val sn: usize = str_len(suffix);
+    val total: usize = pn + an + mn + bn + sn;
+
+    val r: Result[*char, str] = allocate[char](rc.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        ret diag.error(?rc.s.diags, rc.a.file_id, span, prefix);
+    }
+    val buf: str = unwrap_ok[*char, str](r);
+
+    var off: usize = 0;
+    mem.raw_copy((buf::usize + off)::ptr, prefix::ptr, pn); off = off + pn;
+    mem.raw_copy((buf::usize + off)::ptr, a::ptr, an);      off = off + an;
+    mem.raw_copy((buf::usize + off)::ptr, mid::ptr, mn);    off = off + mn;
+    mem.raw_copy((buf::usize + off)::ptr, b::ptr, bn);      off = off + bn;
+    mem.raw_copy((buf::usize + off)::ptr, suffix::ptr, sn);
+    buf[total] = 0;
+
+    val emit: Result[bool, str] = diag.error(?rc.s.diags, rc.a.file_id, span, buf);
+    deallocate[char](rc.s.alloc, buf, total + 1);
+    ret emit;
+}
+
 # MAX_SUGGEST_DISTANCE: largest edit distance a "did you mean" candidate may
 # differ from the unresolved name by.
 val MAX_SUGGEST_DISTANCE: usize = 2;
@@ -2158,7 +2201,7 @@ fun resolve_type_path(rc: *ResolveContext, named: *atype.TypeNamed, full: token.
                 if (is_ok[bool, str](re)) { attach_suggestion(rc, seg_name); }
             }
             or {
-                diag.error(?rc.s.diags, rc.a.file_id, full, "unresolved type name");
+                report_named(rc, full, "unresolved type name `", seg_name, "`");
             }
             ret SYMBOL_NIL;
         }

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -99,7 +99,7 @@ pub fun check_call(sc: *sema.SemaContext, callee_sig: ty.TypeId, args_start: u32
     }
     val ft: *ty.Type = unwrap[*ty.Type](ft_opt);
     if (ft.kind != ty.TYPE_FUN) {
-        report(sc, span, "not callable: callee is not a function");
+        report_typed(sc, span, "not callable: `", callee_sig, "` is not a function", "not callable: callee is not a function");
         ret false;
     }
 
@@ -194,7 +194,9 @@ pub fun check_comptime_call(sc: *sema.SemaContext, callee_sig: ty.TypeId, callee
             if (!arg_references_comptime_param(sc, arg_eid) && !arg_names_module_constant(sc, arg_eid)) {
                 val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, arg_eid, ?sc.s.interner);
                 if (is_err[comptime.CTValue, str](ev)) {
-                    report(sc, arg_span, "comptime argument is not a compile-time constant");
+                    # the evaluator's reason (a static string) clarifies why the
+                    # fold failed; surface it on a note line.
+                    report_note(sc, arg_span, "comptime argument is not a compile-time constant", unwrap_err[comptime.CTValue, str](ev));
                     ok_all = false;
                 }
             }
@@ -1047,4 +1049,104 @@ pub fun report_no_field(sc: *sema.SemaContext, span: token.Span, name: intern.St
     report(sc, span, msg);
     deallocate[char](sc.s.alloc, msg, total + 1);
     type_str_free(sc, ts);
+}
+
+# report_named: report `<prefix><name><suffix>` at `span`, interpolating the
+# interned identifier `name`. on any allocation failure it degrades to the
+# static `fallback` so the diagnostic always lands.
+# ---
+# sc:       the active sema context
+# span:     source range to pin the diagnostic to
+# prefix:   text before the rendered name
+# name:     interned identifier to embed
+# suffix:   text after the rendered name
+# fallback: name-free message used when allocation fails
+pub fun report_named(sc: *sema.SemaContext, span: token.Span, prefix: str, name: intern.StrId, suffix: str, fallback: str) {
+    val total: usize = str_len(prefix) + name_str_len(sc, name) + str_len(suffix);
+    val r: Result[*char, str] = allocate[char](sc.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        report(sc, span, fallback);
+        ret;
+    }
+    val msg: str = unwrap_ok[*char, str](r);
+    var w: usize = write_kw(msg, 0, prefix);
+    w = write_name(sc, msg, w, name);
+    w = write_kw(msg, w, suffix);
+    msg[w] = 0;
+
+    report(sc, span, msg);
+    deallocate[char](sc.s.alloc, msg, total + 1);
+}
+
+# report_typed: report `<prefix><type><suffix>` at `span`, rendering `t` through
+# type_to_str so the message names the offending type. on any allocation failure
+# it degrades to the static `fallback` so the diagnostic always lands.
+# ---
+# sc:       the active sema context
+# span:     source range to pin the diagnostic to
+# prefix:   text before the rendered type
+# t:        the type to render into the message
+# suffix:   text after the rendered type
+# fallback: type-free message used when rendering or allocation fails
+pub fun report_typed(sc: *sema.SemaContext, span: token.Span, prefix: str, t: ty.TypeId, suffix: str, fallback: str) {
+    val tr: Result[str, str] = type_to_str(sc, t);
+    if (is_err[str, str](tr)) {
+        report(sc, span, fallback);
+        ret;
+    }
+    val ts: str = unwrap_ok[str, str](tr);
+
+    val total: usize = str_len(prefix) + str_len(ts) + str_len(suffix);
+    val r: Result[*char, str] = allocate[char](sc.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        report(sc, span, fallback);
+        type_str_free(sc, ts);
+        ret;
+    }
+    val msg: str = unwrap_ok[*char, str](r);
+    var w: usize = write_kw(msg, 0, prefix);
+    w = write_kw(msg, w, ts);
+    w = write_kw(msg, w, suffix);
+    msg[w] = 0;
+
+    report(sc, span, msg);
+    deallocate[char](sc.s.alloc, msg, total + 1);
+    type_str_free(sc, ts);
+}
+
+# report_typed2: report `<prefix><a><mid><b><suffix>` at `span`, rendering both
+# `a` and `b` through type_to_str. degrades to the static `fallback` on any
+# allocation failure so the diagnostic always lands.
+pub fun report_typed2(sc: *sema.SemaContext, span: token.Span, prefix: str, a: ty.TypeId, mid: str, b: ty.TypeId, suffix: str, fallback: str) {
+    val ar: Result[str, str] = type_to_str(sc, a);
+    val br: Result[str, str] = type_to_str(sc, b);
+    if (is_err[str, str](ar) || is_err[str, str](br)) {
+        report(sc, span, fallback);
+        if (is_ok[str, str](ar)) { type_str_free(sc, unwrap_ok[str, str](ar)); }
+        if (is_ok[str, str](br)) { type_str_free(sc, unwrap_ok[str, str](br)); }
+        ret;
+    }
+    val as_: str = unwrap_ok[str, str](ar);
+    val bs:  str = unwrap_ok[str, str](br);
+
+    val total: usize = str_len(prefix) + str_len(as_) + str_len(mid) + str_len(bs) + str_len(suffix);
+    val r: Result[*char, str] = allocate[char](sc.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        report(sc, span, fallback);
+        type_str_free(sc, as_);
+        type_str_free(sc, bs);
+        ret;
+    }
+    val msg: str = unwrap_ok[*char, str](r);
+    var w: usize = write_kw(msg, 0, prefix);
+    w = write_kw(msg, w, as_);
+    w = write_kw(msg, w, mid);
+    w = write_kw(msg, w, bs);
+    w = write_kw(msg, w, suffix);
+    msg[w] = 0;
+
+    report(sc, span, msg);
+    deallocate[char](sc.s.alloc, msg, total + 1);
+    type_str_free(sc, as_);
+    type_str_free(sc, bs);
 }

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -17,7 +17,9 @@ use std.types.option.unwrap;
 
 use std.types.size.usize;
 
+use std.types.char.char;
 use std.types.string.str;
+use std.types.string.str_len;
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -27,6 +29,10 @@ use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 
 use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.deallocate;
+
+use mem: std.memory;
 
 use sess:     mach.lang.session;
 use diag:     mach.lang.diagnostic;
@@ -267,6 +273,63 @@ pub fun report_note(sc: *SemaContext, span: token.Span, message: str, note: str)
     val r: Result[bool, str] = diag.error(?sc.s.diags, sc.a.file_id, span, message);
     if (is_err[bool, str](r)) { ret; }
     diag.attach_note(?sc.s.diags, note);
+}
+
+# report_numbered: report `<prefix><n><suffix>` at `span`, rendering `n` as a
+# base-10 decimal so the message can cite a 1-based position. lives here (not in
+# check) so generics can use it without closing an import cycle. degrades to the
+# static `fallback` on any allocation failure so the diagnostic always lands.
+# ---
+# sc:       sema context
+# span:     source span the diagnostic refers to
+# prefix:   text before the rendered number
+# n:        the value to render in decimal
+# suffix:   text after the rendered number
+# fallback: number-free message used when allocation fails
+pub fun report_numbered(sc: *SemaContext, span: token.Span, prefix: str, n: usize, suffix: str, fallback: str) {
+    val total: usize = str_len(prefix) + decimal_len(n) + str_len(suffix);
+    val r: Result[*char, str] = allocate[char](sc.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        report(sc, span, fallback);
+        ret;
+    }
+    val msg: str = unwrap_ok[*char, str](r);
+    var w: usize = write_decimal_str(msg, write_str_at(msg, 0, prefix), n);
+    w = write_str_at(msg, w, suffix);
+    msg[w] = 0;
+
+    report(sc, span, msg);
+    deallocate[char](sc.s.alloc, msg, total + 1);
+}
+
+# write_str_at: copy `s` into `buf` at offset `k`, returning the new offset.
+fun write_str_at(buf: str, k: usize, s: str) usize {
+    val n: usize = str_len(s);
+    mem.raw_copy((buf::usize + k)::ptr, s::ptr, n);
+    ret k + n;
+}
+
+# decimal_len: number of base-10 digits in `n` (1 for 0).
+fun decimal_len(n: usize) usize {
+    if (n == 0) { ret 1; }
+    var len: usize = 0;
+    var v:   usize = n;
+    for (v > 0) { len = len + 1; v = v / 10; }
+    ret len;
+}
+
+# write_decimal_str: write `n` as base-10 digits into `buf` at offset `k`,
+# returning the new offset.
+fun write_decimal_str(buf: str, k: usize, n: usize) usize {
+    val len: usize = decimal_len(n);
+    var v:   usize = n;
+    var i:   usize = len;
+    for (i > 0) {
+        i = i - 1;
+        buf[k + i] = (48 + (v % 10))::char;
+        v = v / 10;
+    }
+    ret k + len;
 }
 
 # field_table_begin: begins a new field table for nominal `ty`, returning the index of the table; fields are appended with `field_table_push`, and since a nominal type interns to a stable TypeId a table is built once per pass.

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -85,7 +85,7 @@ pub fun instantiate(
     var i: u32 = 0;
     for (i < arg_count) {
         if (args[i] == ty.TYPE_NIL || args[i] == ty.TYPE_ERROR) {
-            report(sc, span, "generic argument is not a valid type");
+            sema.report_numbered(sc, span, "generic argument ", (i + 1)::usize, " is not a valid type", "generic argument is not a valid type");
             ret ok[ty.TypeId, str](ty.TYPE_ERROR);
         }
         i = i + 1;

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -373,12 +373,12 @@ fun infer_binary(sc: *sema.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, spa
         # be assignable to a function type.
         if (int_float_mix) { report_int_float_cmp(sc, span); ret type.TYPE_ERROR; }
         val addr_ok: bool = is_pointer_like(sc, lt) && is_pointer_like(sc, rt);
-        if (!operands_ok && !both_float && !addr_ok) { type_mismatch(sc, span); ret type.TYPE_ERROR; }
+        if (!operands_ok && !both_float && !addr_ok) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
         ret u8t;
     }
     if (b.op == expr.BIN_LT || b.op == expr.BIN_LEQ || b.op == expr.BIN_GT || b.op == expr.BIN_GEQ) {
         if (int_float_mix) { report_int_float_cmp(sc, span); ret type.TYPE_ERROR; }
-        if (!both_int && !both_float) { type_mismatch(sc, span); ret type.TYPE_ERROR; }
+        if (!both_int && !both_float) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
         ret u8t;
     }
     if (b.op == expr.BIN_AND || b.op == expr.BIN_OR) {
@@ -390,11 +390,11 @@ fun infer_binary(sc: *sema.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, spa
     }
     if (b.op == expr.BIN_BIT_AND || b.op == expr.BIN_BIT_OR || b.op == expr.BIN_BIT_XOR
         || b.op == expr.BIN_SHL || b.op == expr.BIN_SHR) {
-        if (!both_int) { type_mismatch(sc, span); ret type.TYPE_ERROR; }
+        if (!both_int) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
         ret lt;
     }
     # arithmetic: ADD, SUB, MUL, DIV, MOD
-    if ((!operands_ok) || !is_numeric(sc, lt)) { type_mismatch(sc, span); ret type.TYPE_ERROR; }
+    if ((!operands_ok) || !is_numeric(sc, lt)) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
     ret lt;
 }
 
@@ -513,7 +513,7 @@ fun infer_call(sc: *sema.SemaContext, c: *expr.ExprCall, span: token.Span) type.
     if (is_none[*type.Type](fn_opt)) { ret type.TYPE_ERROR; }
     val fn: *type.Type = unwrap[*type.Type](fn_opt);
     if (fn.kind != type.TYPE_FUN) {
-        sema.report(sc, span, "not callable: target is not a function");
+        check.report_typed(sc, span, "not callable: `", ct, "` is not a function", "not callable: target is not a function");
         ret type.TYPE_ERROR;
     }
 
@@ -602,7 +602,10 @@ fun infer_comptime_intrinsic(sc: *sema.SemaContext, c: *expr.ExprCall, span: tok
     var need: u32 = want;
     if (is_offset) { need = 2; }
     if (c.args_len != need) {
-        sema.report(sc, span, "comptime intrinsic: wrong number of arguments");
+        var iname: str = "$size_of: expected ";
+        if (is_align)  { iname = "$align_of: expected "; }
+        if (is_offset) { iname = "$offset_of: expected "; }
+        sema.report_numbered(sc, span, iname, need::usize, " argument(s)", "comptime intrinsic: wrong number of arguments");
         ret type.TYPE_ERROR;
     }
 
@@ -742,7 +745,7 @@ fun infer_generic_call(sc: *sema.SemaContext, c: *expr.ExprCall, ct: type.TypeId
         ret type.TYPE_ERROR;
     }
     if (unwrap[*type.Type](fn_opt).kind != type.TYPE_FUN) {
-        sema.report(sc, span, "not callable: target is not a function");
+        check.report_typed(sc, span, "not callable: `", ct, "` is not a function", "not callable: target is not a function");
         free_params(sc, args, c.type_args_len);
         ret type.TYPE_ERROR;
     }
@@ -1006,12 +1009,12 @@ fun type_for_symbol(sc: *sema.SemaContext, sym: *resolve.Symbol, span: token.Spa
     if (sym.kind == resolve.SYM_IMPORTED) {
         val imported: type.TypeId = sema.decl_type_for(sc, sym);
         if (imported == type.TYPE_NIL || imported == type.TYPE_ERROR) {
-            sema.report(sc, span, "unresolved type: name does not denote a type");
+            check.report_named(sc, span, "imported `", sym.name, "` does not resolve to a type", "imported name does not resolve to a type");
             ret type.TYPE_ERROR;
         }
         ret imported;
     }
-    sema.report(sc, span, "unresolved type: name does not denote a type");
+    check.report_named(sc, span, "`", sym.name, "` does not name a type", "name does not denote a type");
     ret type.TYPE_ERROR;
 }
 
@@ -1277,9 +1280,10 @@ fun unify_literals(sc: *sema.SemaContext, lhs: id.ExprId, lt: type.TypeId, rhs: 
     ret none[type.TypeId]();
 }
 
-# emits a `type mismatch:` diagnostic for a binary operand-type clash.
-fun type_mismatch(sc: *sema.SemaContext, span: token.Span) {
-    sema.report(sc, span, "type mismatch: incompatible operand types");
+# emits a `type mismatch:` diagnostic for a binary operand-type clash, naming
+# both operand types via type_to_str.
+fun type_mismatch(sc: *sema.SemaContext, span: token.Span, lt: type.TypeId, rt: type.TypeId) {
+    check.report_typed2(sc, span, "type mismatch: incompatible operand types `", lt, "` and `", rt, "`", "type mismatch: incompatible operand types");
 }
 
 # reports an integer-versus-float comparison, which is rejected because a silent

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -63,6 +63,12 @@ val INITIAL_STACK_CAP: u32 = 8;
 # is reported as an error rather than exhausting memory.
 pub val MAX_VALUE_INSTANCES: u32 = 4096;
 
+# REPORTED: the sentinel error a lowering routine returns after it has already
+# filed a structured diagnostic at the offending span. the driver recognizes it
+# and suppresses the raw `error: <string>` reprint, leaving the located
+# diagnostic (flushed from the session sink) as the single user-facing message.
+pub val REPORTED: str = "lower:reported";
+
 # one entry on the loop stack: the header and exit blocks of an active
 # loop. `cnt` branches to `header`, `brk` branches to `exit`.
 # ---

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -381,7 +381,7 @@ pub fun symbol_linkage_name(ctx: *lower.LowerContext, eid: aid.ExprId) Option[in
 fun symbol_reference(ctx: *lower.LowerContext, eid: aid.ExprId, sid: resolve.SymbolId) Result[value.Value, str] {
     val sym_opt: Option[*resolve.Symbol] = lower.symbol_of(ctx, sid);
     if (is_none[*resolve.Symbol](sym_opt)) {
-        ret err[value.Value, str]("lower: unresolved identifier");
+        ret report_expr(ctx, eid, "unresolved identifier");
     }
     val sym: *resolve.Symbol = unwrap[*resolve.Symbol](sym_opt);
 
@@ -489,7 +489,7 @@ fun names_function(ctx: *lower.LowerContext, sym: *resolve.Symbol) bool {
 fun symbol_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, sid: resolve.SymbolId) Result[value.Value, str] {
     val sym_opt: Option[*resolve.Symbol] = lower.symbol_of(ctx, sid);
     if (is_none[*resolve.Symbol](sym_opt)) {
-        ret err[value.Value, str]("lower: unresolved lvalue identifier");
+        ret report_expr(ctx, eid, "unresolved identifier");
     }
     val sym: *resolve.Symbol = unwrap[*resolve.Symbol](sym_opt);
 
@@ -595,7 +595,7 @@ fun lower_member_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Exp
         if (is_none[*ty.Type](pt_opt)) { ret err[value.Value, str]("lower: member base has no pointer type"); }
         val pt: *ty.Type = unwrap[*ty.Type](pt_opt);
         if (pt.kind != ty.TYPE_POINTER) {
-            ret err[value.Value, str]("lower: cannot access a field of an untyped pointer");
+            ret report_expr(ctx, eid, "field access on untyped pointer — cast to a typed pointer (*T) first");
         }
         rec_ty = pt.data.pointer.base;
         val br: Result[value.Value, str] = lower_rvalue(ctx, e.data.member.object);
@@ -671,7 +671,7 @@ fun lower_index_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr
         if (is_none[*ty.Type](et_opt)) { ret err[value.Value, str]("lower: index base has no pointer type"); }
         val pt: *ty.Type = unwrap[*ty.Type](et_opt);
         if (pt.kind != ty.TYPE_POINTER) {
-            ret err[value.Value, str]("lower: cannot index an untyped pointer");
+            ret report_expr(ctx, eid, "index on untyped pointer — use a typed pointer (*T) to index");
         }
         val elem_ty: ty.TypeId = pt.data.pointer.base;
         val elem_ir_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, elem_ty);
@@ -1155,11 +1155,11 @@ fun lower_value_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr
             val arg_eid: aid.ExprId = ctx.a.expr_ids[e.data.call.args_start + i];
             val fv: Option[comptime.CTValue] = fold_comptime_arg(ctx, arg_eid);
             if (is_none[comptime.CTValue](fv)) {
-                val asp: token.Span = arg_span_of(ctx, arg_eid);
+                val asp: token.Span = expr_span_of(ctx, arg_eid);
                 diag.error(?ctx.s.diags, ctx.a.file_id, asp, "comptime argument is not a compile-time constant");
                 deallocate[comptime.CTValue](ctx.s.alloc, vals, ct_count::usize);
                 deallocate[intern.StrId](ctx.s.alloc, names, ct_count::usize);
-                ret err[value.Value, str]("comptime argument is not a compile-time constant");
+                ret err[value.Value, str](lower.REPORTED);
             }
             vals[w] = unwrap[comptime.CTValue](fv);
 
@@ -1252,13 +1252,21 @@ fun fold_comptime_arg(ctx: *lower.LowerContext, eid: aid.ExprId) Option[comptime
 
 # the source span of an argument expression, for an error pointing at a non-
 # constant comptime argument.
-fun arg_span_of(ctx: *lower.LowerContext, eid: aid.ExprId) token.Span {
+fun expr_span_of(ctx: *lower.LowerContext, eid: aid.ExprId) token.Span {
     val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
     if (is_some[*aexpr.Expr](e_opt)) { ret unwrap[*aexpr.Expr](e_opt).span; }
     var s: token.Span;
     s.offset = 0;
     s.len = 0;
     ret s;
+}
+
+# report_expr: file a located error at expr `eid`'s span and return the REPORTED
+# sentinel so lowering surfaces a single file:line:col diagnostic instead of a
+# span-less propagated string.
+fun report_expr(ctx: *lower.LowerContext, eid: aid.ExprId, message: str) Result[value.Value, str] {
+    diag.error(?ctx.s.diags, ctx.a.file_id, expr_span_of(ctx, eid), message);
+    ret err[value.Value, str](lower.REPORTED);
 }
 
 # resolves a generic call to its monomorphized instance: reads the call-site
@@ -1996,7 +2004,27 @@ pub fun field_index_in_type(ctx: *lower.LowerContext, rec_ty: ty.TypeId, name: t
         i = i + 1;
     }
 
-    diag.error(?ctx.s.diags, ctx.a.file_id, name, "no such field: type has no field with that name");
+    # name the missing field from its source text; the span already underlines it,
+    # and lowering has no semantic type renderer to also name the receiver type.
+    val prefix: str = "no field '";
+    val suffix: str = "' on the receiver type";
+    val total:  usize = str_len(prefix) + name.len + str_len(suffix);
+    val mr: Result[*u8, str] = allocate[u8](ctx.s.alloc, total + 1);
+    if (is_err[*u8, str](mr)) {
+        diag.error(?ctx.s.diags, ctx.a.file_id, name, "no such field on the receiver type");
+        ret 0;
+    }
+    val buf: *u8 = unwrap_ok[*u8, str](mr);
+    var k: usize = 0;
+    var j: usize = 0;
+    for (j < str_len(prefix)) { buf[k] = prefix[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < name.len) { buf[k] = src_text[name.offset + j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < str_len(suffix)) { buf[k] = suffix[j]; k = k + 1; j = j + 1; }
+    buf[total] = 0;
+    diag.error(?ctx.s.diags, ctx.a.file_id, name, buf::str);
+    deallocate[u8](ctx.s.alloc, buf, total + 1);
     ret 0;
 }
 

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -182,7 +182,7 @@ pub fun lower_lit_str(ctx: *lower.LowerContext, e: *aexpr.Expr) Result[value.Val
     # the blob length includes the trailing '\0' (the interned bytes are
     # null-terminated): a `str` is a thin `*char` walked to its terminator, so the
     # terminator must be part of the emitted data rather than left to depend on a
-    # section's alignment padding — which an empty literal (0 content bytes) has
+    # section's alignment padding; which an empty literal (0 content bytes) has
     # none of, and a literal whose length is a multiple of the alignment loses.
     val blob: value.Value = value.const_bytes(bytes::*u8, (str_len(bytes) + 1::usize)::u32, pty);
     ret lower.add_rodata_bytes(ctx, blob, pty);
@@ -346,7 +346,7 @@ fun reference_linkage_name(ctx: *lower.LowerContext, sym: *resolve.Symbol) Resul
 
 # symbol_linkage_name: the back-end symbol name an identifier (or module-
 # qualified member) expression resolves to, when it names a function or a
-# `val`/`var` binding (kinds SYM_FUN / SYM_VAL / SYM_VAR / SYM_IMPORTED) — the
+# `val`/`var` binding (kinds SYM_FUN / SYM_VAL / SYM_VAR / SYM_IMPORTED); the
 # symbol whose address a constant aggregate initializer's `?G` / function-pointer
 # leaf relocates against. returns none for a parameter, type, or otherwise non-
 # addressable reference, so the folder falls back rather than emitting a bad
@@ -400,7 +400,7 @@ fun symbol_reference(ctx: *lower.LowerContext, eid: aid.ExprId, sid: resolve.Sym
     # decl) resolves through a signature-only extern declaration so the back end
     # emits a name-based call relocation the linker binds to the defining object.
     # a `val`/`var` binding whose type is a function pointer is NOT a function
-    # reference — it falls through to the global-load path below, so a call
+    # reference; it falls through to the global-load path below, so a call
     # through it loads the stored pointer and dispatches indirectly.
     if (names_function(ctx, sym)) {
         val fi: Option[u32] = find_function(ctx, link);
@@ -414,7 +414,7 @@ fun symbol_reference(ctx: *lower.LowerContext, eid: aid.ExprId, sid: resolve.Sym
 
     # global val / var: a load from the global's storage pointer, except for
     # an aggregate global whose rvalue is its storage address (the back end
-    # loads halves / passes the pointer at use sites — see lower_ident_rvalue).
+    # loads halves / passes the pointer at use sites; see lower_ident_rvalue).
     val gi: Option[u32] = find_global(ctx, link);
     if (is_some[u32](gi)) {
         val pr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);
@@ -425,8 +425,8 @@ fun symbol_reference(ctx: *lower.LowerContext, eid: aid.ExprId, sid: resolve.Sym
     }
 
     # a comptime-const val that lives in another module has no global in this
-    # module's IR (its storage was never emitted here). such a constant — e.g.
-    # the stdlib `val true: bool = 1;` imported by name — folds to its value,
+    # module's IR (its storage was never emitted here). such a constant; e.g.
+    # the stdlib `val true: bool = 1;` imported by name; folds to its value,
     # read from the module's comptime context where the load walk registered it.
     val nc: Option[*comptime.NamedConst] = comptime.lookup(ctx.ctx, sym.name);
     if (is_some[*comptime.NamedConst](nc)) {
@@ -458,12 +458,12 @@ pub fun references_function(ctx: *lower.LowerContext, eid: aid.ExprId) bool {
 }
 
 # true when an identifier names a function DECLARATION (so a reference to it is the
-# function's code symbol — a direct call / PC32-relative reference), rather than a
+# function's code symbol; a direct call / PC32-relative reference), rather than a
 # `val`/`var` binding whose type merely happens to be a function pointer (storage
-# holding a pointer — a load, then an indirect call). the discriminator is the
+# holding a pointer; a load, then an indirect call). the discriminator is the
 # referent's nature, not its type: a `SYM_FUN` is a function; a `SYM_VAL`/`SYM_VAR`
 # is always a binding; an imported symbol resolves by reading the origin decl's
-# kind from its module AST. used by call/rvalue lowering — `references_function`
+# kind from its module AST. used by call/rvalue lowering; `references_function`
 # (type-based) cannot tell `f` from a `val P: fun(...)... = f` binding.
 fun names_function(ctx: *lower.LowerContext, sym: *resolve.Symbol) bool {
     if (sym.kind == resolve.SYM_FUN) { ret true; }
@@ -536,7 +536,7 @@ fun lower_ident_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.V
 
 # a member rvalue: a load from the field pointer, except for an aggregate
 # field whose rvalue is its storage address (a nested struct / array field is
-# left as a pointer the back end consumes at use sites — see
+# left as a pointer the back end consumes at use sites; see
 # lower_ident_rvalue).
 fun lower_member_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
     # a module-qualified reference (`alias.name`, where `alias` is a `use`
@@ -595,7 +595,7 @@ fun lower_member_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Exp
         if (is_none[*ty.Type](pt_opt)) { ret err[value.Value, str]("lower: member base has no pointer type"); }
         val pt: *ty.Type = unwrap[*ty.Type](pt_opt);
         if (pt.kind != ty.TYPE_POINTER) {
-            ret report_expr(ctx, eid, "field access on untyped pointer — cast to a typed pointer (*T) first");
+            ret report_expr(ctx, eid, "field access on untyped pointer; cast to a typed pointer (*T) first");
         }
         rec_ty = pt.data.pointer.base;
         val br: Result[value.Value, str] = lower_rvalue(ctx, e.data.member.object);
@@ -625,7 +625,7 @@ fun lower_member_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Exp
 
 # an index rvalue: a load from the element pointer, except for an aggregate
 # element whose rvalue is its storage address (an element of struct / array
-# type is left as a pointer the back end consumes at use sites — see
+# type is left as a pointer the back end consumes at use sites; see
 # lower_ident_rvalue).
 fun lower_index_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
     val ptr_r: Result[value.Value, str] = lower_index_lvalue(ctx, eid, e);
@@ -671,7 +671,7 @@ fun lower_index_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr
         if (is_none[*ty.Type](et_opt)) { ret err[value.Value, str]("lower: index base has no pointer type"); }
         val pt: *ty.Type = unwrap[*ty.Type](et_opt);
         if (pt.kind != ty.TYPE_POINTER) {
-            ret report_expr(ctx, eid, "index on untyped pointer — use a typed pointer (*T) to index");
+            ret report_expr(ctx, eid, "index on untyped pointer; use a typed pointer (*T) to index");
         }
         val elem_ty: ty.TypeId = pt.data.pointer.base;
         val elem_ir_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, elem_ty);
@@ -731,7 +731,7 @@ pub fun try_lower_comptime_intrinsic(ctx: *lower.LowerContext, eid: aid.ExprId, 
 
     # bound the argument pool slice this call reads: arg0 (and, for offset_of,
     # arg1) must lie within the expr-id pool. sema validates intrinsic arities, so
-    # this only guards the indexing — `args_start + args_len <= pool` makes every
+    # this only guards the indexing; `args_start + args_len <= pool` makes every
     # ordinal in [args_start, args_start + args_len) addressable, and the per-
     # intrinsic arity requires the ordinals actually read to be present.
     var arity: u32 = 1;
@@ -1220,7 +1220,7 @@ fun lower_value_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr
 # folds a comptime call argument to a CTValue. tries the comptime evaluator
 # against the caller's context first (handles literals, `$mach.*`, and bare-name
 # constants registered in the caller's context). on failure, resolves a cross-
-# module constant reference — a module-qualified member `alias.CONST` (or a bare
+# module constant reference; a module-qualified member `alias.CONST` (or a bare
 # import) binds to an imported symbol whose `(origin, name)` names a `pub val` in
 # the defining module; its folded value is read from that module's comptime
 # context. none when the argument is not a compile-time constant.
@@ -1713,9 +1713,9 @@ fun lower_unary(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Resul
 # lowers a cast. a `::` value-convert selects a single conversion instruction
 # from the source / target type pair (trunc/ext for integers, fp trunc/ext for
 # floats, int<->float CVT). when source and target share a width, the operand's
-# bit pattern already represents the target type — a same-type identity, a
+# bit pattern already represents the target type; a same-type identity, a
 # signedness flip (i64::u64, same bits, reinterpreted sign), or a pointer
-# retype — so it emits a same-size bitcast. a `:~` bit-reinterpret
+# retype; so it emits a same-size bitcast. a `:~` bit-reinterpret
 # (sema-validated equal size) always emits a same-size bitcast that reinterprets
 # the operand's raw bits as the target type, regardless of int / float category.
 fun lower_cast(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
@@ -1862,7 +1862,7 @@ fun lower_struct_lit(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) 
 # materialises a comptime CTValue as an IR constant Value at the expression's
 # IR type, in EXPRESSION position: a folded CT_KIND_STR is committed to an
 # anonymous `.rodata` global and the Value is a pointer to it, exactly as
-# `lower_lit_str` routes a string literal — a raw byte blob must never reach the
+# `lower_lit_str` routes a string literal; a raw byte blob must never reach the
 # back end as an operand. used by COMPTIME_IDENT / comptime-path lowering, the
 # imported-const fallback, and comptime value-parameter references.
 # ---
@@ -1930,7 +1930,7 @@ fun index_type(ctx: *lower.LowerContext) Result[ir_type.IrTypeId, str] {
 
 # the bit width of a scalar semantic type (int/float/pointer/function), or 0
 # for non-scalars. a function value is its code address, so it is pointer-width
-# — a `fn::*ptr` cast is then a same-size bitcast, not a truncate/extend.
+#; a `fn::*ptr` cast is then a same-size bitcast, not a truncate/extend.
 fun scalar_bits(ctx: *lower.LowerContext, tid: ty.TypeId) u32 {
     val t_opt: Option[*ty.Type] = ty.get(?ctx.s.types, tid);
     if (is_none[*ty.Type](t_opt)) { ret 0; }

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -462,7 +462,7 @@ fun collect_asm_binds(ctx: *lower.LowerContext, body_id: intern.StrId, body_span
         for (body[j] != 0 && body[j] != '}'::char) { j = j + 1; }
         if (body[j] == 0) { ret report_asm(ctx, body_span, "unterminated '{' in inline asm body"); }
         val name_len: usize = j - name_start;
-        if (name_len == 0) { ret report_asm(ctx, body_span, "empty '{}' in asm body — write '{name}' to reference a local"); }
+        if (name_len == 0) { ret report_asm(ctx, body_span, "empty '{}' in asm body; write '{name}' to reference a local"); }
 
         val nr: Result[intern.StrId, str] = intern.intern_bytes(?ctx.s.interner, (body::usize + name_start)::str, name_len);
         if (is_err[intern.StrId, str](nr)) { ret err[bool, str](unwrap_err[intern.StrId, str](nr)); }
@@ -489,7 +489,7 @@ fun add_asm_bind(ctx: *lower.LowerContext, body_span: token.Span, payload: *ir.I
 
     val vopt: Option[value.Value] = lower.lookup_local_name(ctx, name_id);
     if (!is_some[value.Value](vopt)) {
-        ret report_asm_named(ctx, body_span, "unknown local '", name_id, "' in inline asm — only stack-allocated variables in scope can be referenced");
+        ret report_asm_named(ctx, body_span, "unknown local '", name_id, "' in inline asm; only stack-allocated variables in scope can be referenced");
     }
     val v: value.Value = unwrap[value.Value](vopt);
     if (v.kind != value.VAL_INSTR) {

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -17,6 +17,7 @@ use std.types.bool.false;
 use std.types.size.usize;
 use std.types.char.char;
 use std.types.string.str;
+use std.types.string.str_len;
 use std.types.option.Option;
 use std.types.option.none;
 use std.types.option.is_none;
@@ -34,6 +35,8 @@ use std.allocator.deallocate;
 use std.allocator.reallocate;
 
 use intern:   mach.lang.intern;
+use diag:     mach.lang.diagnostic;
+use token:    mach.lang.fe.token;
 
 use ast:      mach.lang.fe.ast;
 use aid:      mach.lang.fe.ast.id;
@@ -386,7 +389,7 @@ fun lower_asm(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] {
     payload.bind_count = 0;
     payload.bind_cap   = 0;
 
-    val br: Result[bool, str] = collect_asm_binds(ctx, body_id, ?payload);
+    val br: Result[bool, str] = collect_asm_binds(ctx, body_id, s.data.asm_.body, ?payload);
     if (is_err[bool, str](br)) {
         if (payload.binds != nil) { deallocate[ir.IrAsmBind](ctx.s.alloc, payload.binds, payload.bind_cap::usize); }
         ret br;
@@ -407,12 +410,44 @@ fun lower_asm(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
+# report_asm: file a located error at the asm body `span` and return the
+# REPORTED sentinel so the driver shows a single file:line:col diagnostic.
+fun report_asm(ctx: *lower.LowerContext, span: token.Span, message: str) Result[bool, str] {
+    diag.error(?ctx.s.diags, ctx.a.file_id, span, message);
+    ret err[bool, str](lower.REPORTED);
+}
+
+# report_asm_named: report_asm with the interned `name_id` interpolated between
+# `prefix` and `suffix`. degrades to `prefix` alone on any lookup/alloc failure.
+fun report_asm_named(ctx: *lower.LowerContext, span: token.Span, prefix: str, name_id: intern.StrId, suffix: str) Result[bool, str] {
+    val no: Option[str] = intern.lookup(?ctx.s.interner, name_id);
+    if (is_none[str](no)) { ret report_asm(ctx, span, prefix); }
+    val nm: str = unwrap[str](no);
+
+    val total: usize = str_len(prefix) + str_len(nm) + str_len(suffix);
+    val r: Result[*u8, str] = allocate[u8](ctx.s.alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret report_asm(ctx, span, prefix); }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    var j: usize = 0;
+    for (j < str_len(prefix)) { buf[k] = prefix[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < str_len(nm)) { buf[k] = nm[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < str_len(suffix)) { buf[k] = suffix[j]; k = k + 1; j = j + 1; }
+    buf[total] = 0;
+    diag.error(?ctx.s.diags, ctx.a.file_id, span, buf::str);
+    deallocate[u8](ctx.s.alloc, buf, total + 1);
+    ret err[bool, str](lower.REPORTED);
+}
+
 # scans an inline-asm body for `{name}` references and records each as a
 # `{name}` -> alloca binding in `payload.binds`. a name is interned and resolved
 # against the locals in scope (`lookup_local_name`); a duplicate `{name}` is
 # recorded once. an unknown name, or one bound to a non-alloca Value, is a hard
-# error rather than a silently dropped substitution.
-fun collect_asm_binds(ctx: *lower.LowerContext, body_id: intern.StrId, payload: *ir.IrAsm) Result[bool, str] {
+# error rather than a silently dropped substitution. `body_span` locates every
+# diagnostic on the inline-asm body in the source.
+fun collect_asm_binds(ctx: *lower.LowerContext, body_id: intern.StrId, body_span: token.Span, payload: *ir.IrAsm) Result[bool, str] {
     val bopt: Option[str] = intern.lookup(?ctx.s.interner, body_id);
     if (is_none[str](bopt)) { ret err[bool, str]("lower: inline-asm body interning failed"); }
     val body: str = unwrap[str](bopt);
@@ -425,15 +460,15 @@ fun collect_asm_binds(ctx: *lower.LowerContext, body_id: intern.StrId, payload: 
         val name_start: usize = i + 1;
         var j: usize = name_start;
         for (body[j] != 0 && body[j] != '}'::char) { j = j + 1; }
-        if (body[j] == 0) { ret err[bool, str]("lower: unterminated '{' in inline asm body"); }
+        if (body[j] == 0) { ret report_asm(ctx, body_span, "unterminated '{' in inline asm body"); }
         val name_len: usize = j - name_start;
-        if (name_len == 0) { ret err[bool, str]("lower: empty '{}' reference in inline asm body"); }
+        if (name_len == 0) { ret report_asm(ctx, body_span, "empty '{}' in asm body — write '{name}' to reference a local"); }
 
         val nr: Result[intern.StrId, str] = intern.intern_bytes(?ctx.s.interner, (body::usize + name_start)::str, name_len);
         if (is_err[intern.StrId, str](nr)) { ret err[bool, str](unwrap_err[intern.StrId, str](nr)); }
         val name_id: intern.StrId = unwrap_ok[intern.StrId, str](nr);
 
-        val ar: Result[bool, str] = add_asm_bind(ctx, payload, name_id);
+        val ar: Result[bool, str] = add_asm_bind(ctx, body_span, payload, name_id);
         if (is_err[bool, str](ar)) { ret ar; }
 
         i = j + 1;
@@ -445,7 +480,7 @@ fun collect_asm_binds(ctx: *lower.LowerContext, body_id: intern.StrId, payload: 
 # `payload.binds` (once per distinct name). the local's storage Value must be a
 # VAL_INSTR naming the alloca whose slot the back end addresses; anything else
 # (an unbound name, a parameter still in a register, a constant) is rejected.
-fun add_asm_bind(ctx: *lower.LowerContext, payload: *ir.IrAsm, name_id: intern.StrId) Result[bool, str] {
+fun add_asm_bind(ctx: *lower.LowerContext, body_span: token.Span, payload: *ir.IrAsm, name_id: intern.StrId) Result[bool, str] {
     var k: u32 = 0;
     for (k < payload.bind_count) {
         if (payload.binds[k].name == name_id) { ret ok[bool, str](true); }
@@ -454,11 +489,11 @@ fun add_asm_bind(ctx: *lower.LowerContext, payload: *ir.IrAsm, name_id: intern.S
 
     val vopt: Option[value.Value] = lower.lookup_local_name(ctx, name_id);
     if (!is_some[value.Value](vopt)) {
-        ret err[bool, str]("lower: unknown local in inline asm '{name}' reference");
+        ret report_asm_named(ctx, body_span, "unknown local '", name_id, "' in inline asm — only stack-allocated variables in scope can be referenced");
     }
     val v: value.Value = unwrap[value.Value](vopt);
     if (v.kind != value.VAL_INSTR) {
-        ret err[bool, str]("lower: inline-asm '{name}' local has no addressable storage slot");
+        ret report_asm_named(ctx, body_span, "'", name_id, "' is not stack-allocated and cannot be used in inline asm");
     }
 
     if (payload.bind_count == payload.bind_cap) {

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2625,6 +2625,43 @@ fun encode_function(st: *EncodeState, f: *mir.MirFunction) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
+# enc_named_message: build "<prefix><name><suffix>" interned into the encoder's
+# session interner so the diagnostic outlives this call. degrades to `fallback`
+# when the interner is unavailable or building fails.
+fun enc_named_message(st: *EncodeState, prefix: str, name: str, suffix: str, fallback: str) str {
+    if (st.interner == nil || name == nil) { ret fallback; }
+    val lp: usize = str_len(prefix);
+    val ln: usize = str_len(name);
+    val ls: usize = str_len(suffix);
+    val total: usize = lp + ln + ls;
+
+    val r: Result[*u8, str] = allocate[u8](st.alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret fallback; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    var j: usize = 0;
+    for (j < lp) { buf[k] = prefix[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < ln) { buf[k] = name[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < ls) { buf[k] = suffix[j]; k = k + 1; j = j + 1; }
+    buf[total] = 0;
+
+    val ir: Result[intern.StrId, str] = intern.intern(st.interner, buf::str);
+    deallocate[u8](st.alloc, buf, total + 1);
+    if (is_err[intern.StrId, str](ir)) { ret fallback; }
+    val nm: Option[str] = intern.lookup(st.interner, unwrap_ok[intern.StrId, str](ir));
+    if (is_some[str](nm)) { ret unwrap[str](nm); }
+    ret fallback;
+}
+
+# enc_fn_name: the encoder function's source name, or "<unknown>" when unresolved.
+fun enc_fn_name(st: *EncodeState, f: *mir.MirFunction) str {
+    val fno: Option[str] = intern.lookup(st.interner, f.name);
+    if (is_some[str](fno)) { ret unwrap[str](fno); }
+    ret "<unknown>";
+}
+
 # translate one post-regalloc MIR instruction into the target-agnostic
 # `isa.Inst` form, encode it, and record any branch fixup or symbol relocation
 # it requires. `f` supplies the laid-out frame so that a memory operand whose
@@ -2649,7 +2686,7 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
         ret ok[bool, str](true);
     }
     if (mi.opcode == mir.MIR_PHI) {
-        ret err[bool, str]("encode: phi survived register allocation");
+        ret err[bool, str](enc_named_message(st, "internal compiler error: phi survived register allocation in '", enc_fn_name(st, f), "'", "internal compiler error: phi survived register allocation"));
     }
 
     # the comparison family survives selection as a single `[dst, lhs, rhs]`
@@ -4829,7 +4866,7 @@ fun encode_asm_stmt(st: *EncodeState, fn_base: u32, tok: str) Result[bool, str] 
     # `.byte b, b, ...` raw byte emission.
     if (mnemonic_is(tok, ".byte")) { ret emit_raw_bytes(st, arg_str(tok, 5)); }
 
-    ret err[bool, str]("encode: unknown x86_64 inline-asm instruction");
+    ret err[bool, str](enc_named_message(st, "unknown x86_64 inline-asm instruction '", tok, "'", "unknown x86_64 inline-asm instruction"));
 }
 
 # emit_simple: encode a zero-operand instruction (syscall / ret / hlt / ...).

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -156,7 +156,7 @@ fun select_block(alloc: *Allocator, b: *mir.MirBlock) Result[bool, str] {
     var i: u32 = 0;
     for (i < b.instr_count) {
         val n: u32 = expansion_count(?b.instrs[i]);
-        if (n == 0) { ret err[bool, str]("isel: unhandled MIR opcode"); }
+        if (n == 0) { ret err[bool, str]("internal compiler error: unhandled MIR opcode in instruction selection"); }
         if (n > 1) { needs_expand = true; }
         total = total + n;
         i = i + 1;
@@ -438,7 +438,7 @@ fun rewrite_simple(mi: *mir.MirInstr) Result[bool, str] {
     # encoder materializes its self-contained TEST ; JZ ; MOVSD sequence.
     if (o == mir.MIR_VA_FP_SAVE) { ret ok[bool, str](true); }
 
-    ret err[bool, str]("isel: unhandled MIR opcode");
+    ret err[bool, str]("internal compiler error: unhandled MIR opcode in instruction selection");
 }
 
 # expand a multi-instruction-form MIR opcode into its fixed concrete sequence,

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -314,15 +314,16 @@ pub def ParserFn: fun(*Allocator, *intern.Interner, *u8, usize, *ObjectImage) Re
 # program headers, Mach-O load commands) with a leading header-covering segment.
 # ---
 # arg 0: allocator backing the writer's output buffer
-# arg 1: the instruction-set vtable describing the machine
-# arg 2: the loadable segments, in ascending virtual-address order
-# arg 3: number of load segments
-# arg 4: program entry-point virtual address
-# arg 5: per-function descriptors (may be nil when count is 0)
-# arg 6: number of per-function descriptors
-# arg 7: null-terminated output file path
+# arg 1: interner used to build located I/O-failure diagnostics (may be nil)
+# arg 2: the instruction-set vtable describing the machine
+# arg 3: the loadable segments, in ascending virtual-address order
+# arg 4: number of load segments
+# arg 5: program entry-point virtual address
+# arg 6: per-function descriptors (may be nil when count is 0)
+# arg 7: number of per-function descriptors
+# arg 8: null-terminated output file path
 # ret:   true on success, or an error string
-pub def ExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64,
+pub def ExecFn: fun(*Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64,
                     *ExecFunction, u32, *u8) Result[bool, str];
 
 # a dynamically-linked-executable writer: serializes the linker's laid-out load

--- a/src/lang/target/of/bin.mach
+++ b/src/lang/target/of/bin.mach
@@ -212,6 +212,49 @@ pub fun number_message(itn: *intern.Interner, alloc: *Allocator, prefix: str, va
     ret generic;
 }
 
+# io_message: build the interned diagnostic "<op> '<path>': <os_error>" naming a
+# failed output I/O operation, the path it was attempted on, and the OS error
+# (all of which the of-layer writers have in scope but used to discard). degrades
+# to `generic` when the interner is unavailable or building fails. closes the
+# swallowed-OS-error class across the of-layer writers (#1046).
+# ---
+# itn:      interner the diagnostic is interned through (nil -> generic)
+# alloc:    allocator for the scratch buffer
+# op:       the leading text, e.g. "elf: cannot create" or "elf: write failed on"
+# path:     the output path the operation targeted
+# os_error: the OS error string (e.g. from os.message)
+# generic:  the fallback used when the formatted form cannot be built
+# ret:      the interned diagnostic, or `generic`
+pub fun io_message(itn: *intern.Interner, alloc: *Allocator, op: str, path: str, os_error: str, generic: str) str {
+    if (itn == nil || path == nil) { ret generic; }
+    val q1: str = " '";
+    val q2: str = "': ";
+    val lop:  usize = str_len(op);
+    val lq1:  usize = str_len(q1);
+    val lpat: usize = str_len(path);
+    val lq2:  usize = str_len(q2);
+    val ler:  usize = str_len(os_error);
+    val total: usize = lop + lq1 + lpat + lq2 + ler;
+
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret generic; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    mem.raw_copy((buf::usize + off)::ptr, op::ptr, lop);        off = off + lop;
+    mem.raw_copy((buf::usize + off)::ptr, q1::ptr, lq1);        off = off + lq1;
+    mem.raw_copy((buf::usize + off)::ptr, path::ptr, lpat);     off = off + lpat;
+    mem.raw_copy((buf::usize + off)::ptr, q2::ptr, lq2);        off = off + lq2;
+    mem.raw_copy((buf::usize + off)::ptr, os_error::ptr, ler);
+    buf[total] = 0;
+
+    val ir: Result[intern.StrId, str] = intern.intern(itn, buf::str);
+    deallocate[u8](alloc, buf, total + 1);
+    if (is_err[intern.StrId, str](ir)) { ret generic; }
+    val nm: Option[str] = intern.lookup(itn, unwrap_ok[intern.StrId, str](ir));
+    if (is_some[str](nm)) { ret unwrap[str](nm); }
+    ret generic;
+}
+
 # count the relocations targeting each section of `img` in one pass, returning a
 # `section_count`-long array (`counts[s]` = relocations patching section `s`).
 # replaces the per-section linear scan both writers ran in four separate layout

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1055,15 +1055,16 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
 
     val res_file: Result[fs.File, str] = fs.create(path, 0o644);
     if (is_err[fs.File, str](res_file)) {
+        val cm: str = bin.io_message(img.interner, img.alloc, "coff: cannot create", path::str, unwrap_err[fs.File, str](res_file), "coff: could not create output file");
         deallocate[u8](alloc, buf, total_file_size);
-        ret err[bool, str]("coff: could not create output file");
+        ret err[bool, str](cm);
     }
     var f: fs.File = unwrap_ok[fs.File, str](res_file);
     val res_write: Result[usize, str] = fs.write(?f, buf, total_file_size);
     fs.close(?f);
     deallocate[u8](alloc, buf, total_file_size);
 
-    if (is_err[usize, str](res_write)) { ret err[bool, str]("coff: write failed"); }
+    if (is_err[usize, str](res_write)) { ret err[bool, str](bin.io_message(img.interner, img.alloc, "coff: write failed on", path::str, unwrap_err[usize, str](res_write), "coff: write failed")); }
     ret ok[bool, str](true);
 }
 
@@ -2025,12 +2026,12 @@ fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegme
 # func_count: number of entries in funcs
 # path:       null-terminated output file path
 # ret:        ok(true) on success, or an error string
-fun coff_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
+fun coff_emit_exec(alloc: *Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                    seg_count: u32, entry: u64, funcs: *of.ExecFunction,
                    func_count: u32, path: *u8) Result[bool, str] {
-    # a static PE carries no dynamic plan, so it resolves no interned names — the
-    # writer takes a nil interner, used only by the import path the dyn writer hits.
-    ret write_pe(alloc, nil, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, path);
+    # a static PE carries no dynamic plan, so it resolves no interned names; the
+    # interner is forwarded only so a write failure can be located on its path.
+    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, path);
 }
 
 # coff_emit_dyn_exec: serialize laid-out load segments into a dynamically-linked
@@ -2148,15 +2149,16 @@ fun write_pe(alloc: *Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, s
 
     val res_file: Result[fs.File, str] = fs.create(path, 0o755);
     if (is_err[fs.File, str](res_file)) {
+        val cm: str = bin.io_message(itn, alloc, "coff: cannot create executable", path::str, unwrap_err[fs.File, str](res_file), "coff: could not create executable file");
         deallocate[u8](alloc, buf, total_size);
-        ret err[bool, str]("coff: could not create executable file");
+        ret err[bool, str](cm);
     }
     var f: fs.File = unwrap_ok[fs.File, str](res_file);
     val res_write: Result[usize, str] = fs.write(?f, buf, total_size);
     fs.close(?f);
     deallocate[u8](alloc, buf, total_size);
 
-    if (is_err[usize, str](res_write)) { ret err[bool, str]("coff: PE write failed"); }
+    if (is_err[usize, str](res_write)) { ret err[bool, str](bin.io_message(itn, alloc, "coff: PE write failed on", path::str, unwrap_err[usize, str](res_write), "coff: PE write failed")); }
     ret ok[bool, str](true);
 }
 
@@ -3086,7 +3088,7 @@ test "coff: emit_exec writes a well-formed PE32+ header" {
     if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
     var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
 
-    val em: Result[bool, str] = coff_emit_exec(?alloc, ?isa_vt, ?segs[0], 2, entry, nil, 0, fs.temp_path(?tf)::*u8);
+    val em: Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, entry, nil, 0, fs.temp_path(?tf)::*u8);
     if (is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: Result[fs.Buffer, str] = fs.read_all_sized(?alloc, fs.temp_path(?tf));
@@ -3314,7 +3316,7 @@ test "coff: emit_exec emits .xdata/.pdata for a canonical x64 prologue" {
     if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
     var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
 
-    val em: Result[bool, str] = coff_emit_exec(?alloc, ?isa_vt, ?segs[0], 1, entry, ?funcs[0], 1, fs.temp_path(?tf)::*u8);
+    val em: Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, entry, ?funcs[0], 1, fs.temp_path(?tf)::*u8);
     if (is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: Result[fs.Buffer, str] = fs.read_all_sized(?alloc, fs.temp_path(?tf));

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -437,15 +437,15 @@ fun validate_reloc_ranges(img: *of.ObjectImage) Result[bool, str] {
     for (i < img.reloc_count) {
         val rsec: u32 = img.relocations[i].section;
         if (rsec >= img.section_count) {
-            ret err[bool, str]("coff: relocation references an out-of-range section");
+            ret err[bool, str](bin.number_message(img.interner, img.alloc, "coff: out-of-range section referenced by relocation #", i::u64, "coff: relocation references an out-of-range section"));
         }
         if (!section_has_data(img.sections[rsec].kind)) {
-            ret err[bool, str]("coff: relocation patches a section with no raw data");
+            ret err[bool, str](bin.number_message(img.interner, img.alloc, "coff: relocation patches a section with no raw data; relocation #", i::u64, "coff: relocation patches a section with no raw data"));
         }
         val w:   usize = reloc_field_width(img.relocations[i].kind);
         val off: usize = img.relocations[i].offset::usize;
         if (off + w > img.sections[rsec].len::usize) {
-            ret err[bool, str]("coff: relocation offset out of range for its section");
+            ret err[bool, str](bin.number_message(img.interner, img.alloc, "coff: relocation offset out of range for its section; relocation #", i::u64, "coff: relocation offset out of range for its section"));
         }
         i = i + 1;
     }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -731,7 +731,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
         deallocate[u32](alloc, name_offsets, (num_secs + 1)::usize);
         deallocate[u32](alloc, rela_name_offsets, (num_secs + 1)::usize);
         deallocate[usize](alloc, rela_offsets, (num_secs + 1)::usize);
-        ret err[bool, str]("elf: could not create output file");
+        ret err[bool, str](bin.io_message(img.interner, img.alloc, "elf: cannot create", path::str, unwrap_err[fs.File, str](res_file), "elf: could not create output file"));
     }
     var f: fs.File = unwrap_ok[fs.File, str](res_file);
     val res_write: Result[usize, str] = fs.write(?f, buf, total_file_size);
@@ -743,7 +743,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
     deallocate[u32](alloc, rela_name_offsets, (num_secs + 1)::usize);
     deallocate[usize](alloc, rela_offsets, (num_secs + 1)::usize);
 
-    if (is_err[usize, str](res_write)) { ret err[bool, str]("elf: write failed"); }
+    if (is_err[usize, str](res_write)) { ret err[bool, str](bin.io_message(img.interner, img.alloc, "elf: write failed on", path::str, unwrap_err[usize, str](res_write), "elf: write failed")); }
     ret ok[bool, str](true);
 }
 
@@ -812,7 +812,7 @@ fun pf_flags_for(flags: u32) u32 {
 # func_count: number of entries in funcs
 # path:       null-terminated output file path
 # ret:        ok(true) on success, or an error string
-fun emit_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
+fun emit_exec(alloc: *Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, entry: u64, funcs: *of.ExecFunction,
               func_count: u32, path: *u8) Result[bool, str] {
     if (tgt_isa == nil) { ret err[bool, str]("elf: nil exec isa"); }
@@ -905,15 +905,16 @@ fun emit_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
 
     val res_file: Result[fs.File, str] = fs.create(path, 0o755);
     if (is_err[fs.File, str](res_file)) {
+        val cm: str = bin.io_message(itn, alloc, "elf: cannot create executable", path::str, unwrap_err[fs.File, str](res_file), "elf: could not create executable file");
         deallocate[u8](alloc, buf, total_size);
-        ret err[bool, str]("elf: could not create executable file");
+        ret err[bool, str](cm);
     }
     var f: fs.File = unwrap_ok[fs.File, str](res_file);
     val res_write: Result[usize, str] = fs.write(?f, buf, total_size);
     fs.close(?f);
     deallocate[u8](alloc, buf, total_size);
 
-    if (is_err[usize, str](res_write)) { ret err[bool, str]("elf: exec write failed"); }
+    if (is_err[usize, str](res_write)) { ret err[bool, str](bin.io_message(itn, alloc, "elf: exec write failed on", path::str, unwrap_err[usize, str](res_write), "elf: exec write failed")); }
     ret ok[bool, str](true);
 }
 
@@ -1148,15 +1149,16 @@ fun emit_dyn_exec(alloc: *Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
 
     val res_file: Result[fs.File, str] = fs.create(path, 0o755);
     if (is_err[fs.File, str](res_file)) {
+        val cm: str = bin.io_message(itn, alloc, "elf: cannot create dynamic executable", path::str, unwrap_err[fs.File, str](res_file), "elf: could not create dynamic executable file");
         deallocate[u8](alloc, buf, total_size);
-        ret err[bool, str]("elf: could not create dynamic executable file");
+        ret err[bool, str](cm);
     }
     var f: fs.File = unwrap_ok[fs.File, str](res_file);
     val res_write: Result[usize, str] = fs.write(?f, buf, total_size);
     fs.close(?f);
     deallocate[u8](alloc, buf, total_size);
 
-    if (is_err[usize, str](res_write)) { ret err[bool, str]("elf: dyn-exec write failed"); }
+    if (is_err[usize, str](res_write)) { ret err[bool, str](bin.io_message(itn, alloc, "elf: dyn-exec write failed on", path::str, unwrap_err[usize, str](res_write), "elf: dyn-exec write failed")); }
     ret ok[bool, str](true);
 }
 
@@ -1614,7 +1616,7 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         ret err[bool, str]("elf: object too small");
     }
     if (buf[0] != 0x7F || buf[1] != 0x45 || buf[2] != 0x4C || buf[3] != 0x46) {
-        ret err[bool, str]("elf: bad magic");
+        ret err[bool, str]("elf: not an ELF object (bad magic; expected 0x7F 'E' 'L' 'F')");
     }
     if (itn == nil) { ret err[bool, str]("elf: no interner for parse"); }
     out.interner = itn;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -78,7 +78,7 @@ fun macho_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_s
 # func_count: number of entries in funcs
 # path:       null-terminated output file path
 # ret:        the unsupported-target error
-fun macho_emit_exec(alloc: *Allocator, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
+fun macho_emit_exec(alloc: *Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                     seg_count: u32, entry: u64, funcs: *of.ExecFunction,
                     func_count: u32, path: *u8) Result[bool, str] {
     ret err[bool, str](MACHO_UNSUPPORTED);


### PR DESCRIPTION
Refs #1046

Executes the diagnostics-quality fix list from the #1046 audit: all of TIER 1 (15) plus every HIGH-severity item in TIER 2, with TIER 2 medium/low handled opportunistically in files already being edited. The issue stays open for the medium/low remainder (disposition posted on #1046).

## Per-tier disposition

| Bucket | Done | Deferred |
|---|---|---|
| TIER 1 | 15 / 15 | 0 |
| TIER 2 — theme A (swallowed OS errors, all HIGH) | all create/write sites | elf bad-magic first-4-bytes (reworded only) |
| TIER 2 — theme B (linker/format, incl. HIGH) | 1007, 726, 1676, coff 440/443/448, 938, 923, 179 | 1663, coff 762 |
| TIER 2 — theme C (ICE/codegen, incl. HIGH) | isel 159/441, encode 2652/4832, mir 891, parser 737, VLA | opcode/operand numbers, regalloc no-free-reg |
| TIER 2 — theme D | stmt 428/430 | iasm 93 |
| TIER 2 — theme E (incl. HIGH) | decl 701, expr 129/94, decl 399, expr 931/678 | — |
| TIER 2 — theme F | resolve 789/874/851/1199/1233, infer 605/1282, check 197, expr 1999/1162 | comptime 592/809/684, sema $if 596/611/616/620 |
| TIER 2 — theme G (incl. HIGH) | driver 1379/972, build 543/662/789/1115 | driver 1275/1862, testrunner 398, decl 300 |

## Systemic recommendations applied

- **1 (span threading):** `lower:reported` sentinel — lowering files a located diagnostic and returns the sentinel; the driver suppresses the raw reprint.
- **2 (`{name}` interpolation):** all three placeholder sites now resolve the interned name.
- **3 (OS errors):** shared `bin.io_message(path, op, err)` across every of-layer writer.
- **5 (zero-alloc lookup):** name lookups precede any join in the back-end helpers.
- **6 (ICE prefix + fatal flag):** parser `internal compiler error:` + `fatal_ice_at`; isel/encode ICEs reframed.
- **7 (report_named symmetry):** both branches of the resolve sites routed through name-aware helpers.

A shared `of.ExecFn` vtable gained an interner argument so the static-executable writers can locate I/O failures on their path (matching the dynamic writers).

## Changed assertions

**None.** No existing corpus test or integration suite asserted any of the changed message text (verified: all 351 corpus tests and all 21 pre-existing integration suites pass unmodified). New coverage was added rather than existing assertions rewritten:

- `src/lang/editor.mach`: 4 new sema/lex/parse tests pinning the new Tier 1 wording (stray control char, declaration-starter list, value-used-as-type, non-function callee).
- `.github/tests/diaglocate/`: a new reject fixture asserting a formerly span-less lowering error (inline-asm `{name}`) now carries both the named local and `file:line:col`.

## Verification

- `mach build .` clean.
- `mach test .`: 351 pass, 0 fail.
- Integration battery: 22 / 22 suites pass (21 existing + new `diaglocate`).
- Self-host fixpoint: byte-identical to the seed is expected to fail (error strings changed -> `.rodata` differs); the requirement is 3-stage convergence, and **stage2 == stage3 (byte-identical)** holds.