### PR TITLE
ci: scrub generated-with attribution from PR/issue bodies

### DIFF
--- a/.github/workflows/scrub-attribution.yml
+++ b/.github/workflows/scrub-attribution.yml
@@ -1,0 +1,36 @@
+name: Scrub attribution
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+  issues:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  scrub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Strip generated-with footers from the body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isPR = !!context.payload.pull_request;
+            const item = isPR ? context.payload.pull_request : context.payload.issue;
+            const body = item.body || "";
+            const scrubbed = body
+              .replace(/\n*-*\n*🤖 Generated with \[Claude Code\]\([^)]*\)[^\n]*\n*/g, "\n")
+              .replace(/\n*Co-Authored-By: Claude[^\n]*\n*/gi, "\n")
+              .trimEnd();
+            if (scrubbed !== body.trimEnd()) {
+              const params = { owner: context.repo.owner, repo: context.repo.repo };
+              if (isPR) {
+                await github.rest.pulls.update({ ...params, pull_number: item.number, body: scrubbed });
+              } else {
+                await github.rest.issues.update({ ...params, issue_number: item.number, body: scrubbed });
+              }
+              core.info(`scrubbed ${isPR ? "PR" : "issue"} #${item.number}`);
+            }


### PR DESCRIPTION
Mechanical enforcement of the no-attribution rule: a tiny workflow strips the 🤖-footer (and any stray Co-Authored-By lines) from PR and issue bodies on open/edit. Instruction-level bans on tool-authored PRs hold only ~2/3 of the time; this closes the gap regardless of author.