### PR TITLE
test(fe-syntax): #1242 group B — lexer/parser/pool invariants

### DIFF
--- a/src/lang/fe/lexer.mach
+++ b/src/lang/fe/lexer.mach
@@ -509,6 +509,70 @@ test "lexer: emit_diagnostics drains lex errors onto the sink" {
     ret 0;
 }
 
+test "lexer: 0b and 0o integer prefixes produce correct token spans (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    val tr: Result[TokenStream, str] = tokenize("0b1010 0o755 0xFF", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr)) { ret 1; }
+    var stream: TokenStream = unwrap_ok[TokenStream, str](tr);
+
+    var rc: i32 = 0;
+    # 3 integer tokens + EOF = 4
+    if (stream.len != 4)        { rc = 1; }
+    or (stream.error_len != 0)  { rc = 1; }
+    or {
+        if (stream.tokens[0].kind != token.KIND_LIT_INT) { rc = 1; }
+        or (stream.tokens[0].span.offset != 0) { rc = 1; }
+        or (stream.tokens[0].span.len    != 6) { rc = 1; }
+        or (stream.tokens[1].kind != token.KIND_LIT_INT) { rc = 1; }
+        or (stream.tokens[1].span.offset != 7) { rc = 1; }
+        or (stream.tokens[1].span.len    != 5) { rc = 1; }
+        or (stream.tokens[2].kind != token.KIND_LIT_INT) { rc = 1; }
+        or (stream.tokens[2].span.len    != 4) { rc = 1; }
+    }
+
+    dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "lexer: char literal, escape in char, and unterminated char recovery (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    # (1) plain char literal: span covers all 3 bytes, no error
+    val tr1: Result[TokenStream, str] = tokenize("'a'", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr1)) { ret 1; }
+    var s1: TokenStream = unwrap_ok[TokenStream, str](tr1);
+    var rc: i32 = 0;
+    if (s1.tokens[0].kind     != token.KIND_LIT_CHAR) { rc = 1; }
+    or (s1.tokens[0].span.len != 3)                   { rc = 1; }
+    or (s1.error_len          != 0)                   { rc = 1; }
+    dnit(?s1, ?alloc);
+    if (rc != 0) { ret rc; }
+
+    # (2) escape sequence in char literal: '\n' spans 4 bytes ('\\','n' plus quotes), no error
+    val tr2: Result[TokenStream, str] = tokenize("'\\n'", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr2)) { ret 1; }
+    var s2: TokenStream = unwrap_ok[TokenStream, str](tr2);
+    if (s2.tokens[0].kind     != token.KIND_LIT_CHAR) { rc = 1; }
+    or (s2.tokens[0].span.len != 4)                   { rc = 1; }
+    or (s2.error_len          != 0)                   { rc = 1; }
+    dnit(?s2, ?alloc);
+    if (rc != 0) { ret rc; }
+
+    # (3) unterminated char: scan stops at the embedded newline; recovery
+    # continues so the subsequent `val` identifier is still lexed
+    val tr3: Result[TokenStream, str] = tokenize("'x\nval b: u8 = 1;", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr3)) { ret 1; }
+    var s3: TokenStream = unwrap_ok[TokenStream, str](tr3);
+    if (s3.error_len                  != 1)                         { rc = 1; }
+    or (s3.errors[0].code             != LEX_ERR_UNTERMINATED_CHAR) { rc = 1; }
+    or (s3.tokens[1].kind             != token.KIND_IDENT)          { rc = 1; }
+    dnit(?s3, ?alloc);
+    ret rc;
+}
+
 test "lexer: a string literal stops at a newline and is reported unterminated (#1247)" {
     var alloc: Allocator;
     page.make(?alloc);

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -1096,6 +1096,86 @@ fun t_parse_module_has_errors(source: str) bool {
     ret had;
 }
 
+test "parser: parse_decl error span is pinned to the offending token (#1242)" {
+    # (a) bare expression `42;` at module scope: one error whose span covers `42`
+    # and an error decl is recorded so the ast is non-empty
+    var alloc_a: Allocator;
+    page.make(?alloc_a);
+    val tr_a: Result[lexer.TokenStream, str] = lexer.tokenize("42;", ?alloc_a, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr_a)) { ret 1; }
+    var stream_a: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr_a);
+    var a_a: ast.Ast = ast.init(?alloc_a, 0::src.FileId);
+    var diags_a: diag.DiagList = diag.init(?alloc_a);
+    var p_a: parser.Parser = parser.init(?stream_a, ?a_a, ?diags_a);
+    parse_module(?p_a);
+    var rc: i32 = 0;
+    if (diags_a.len != 1)                     { rc = 1; }
+    or (diags_a.items[0].span.offset != 0)    { rc = 1; }
+    or (diags_a.items[0].span.len    != 2)    { rc = 1; }
+    or (a_a.decl_len < 1)                     { rc = 1; }
+    diag.dnit(?diags_a);
+    ast.dnit(?a_a);
+    lexer.dnit(?stream_a, ?alloc_a);
+    if (rc != 0) { ret rc; }
+
+    # `42; fun f() {}` — one error for `42`, and the fun decl is still captured
+    var alloc_b: Allocator;
+    page.make(?alloc_b);
+    val tr_b: Result[lexer.TokenStream, str] = lexer.tokenize("42; fun f() {}", ?alloc_b, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr_b)) { ret 1; }
+    var stream_b: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr_b);
+    var a_b: ast.Ast = ast.init(?alloc_b, 0::src.FileId);
+    var diags_b: diag.DiagList = diag.init(?alloc_b);
+    var p_b: parser.Parser = parser.init(?stream_b, ?a_b, ?diags_b);
+    parse_module(?p_b);
+    if (diags_b.len != 1)                                          { rc = 1; }
+    or (a_b.decl_len < 2)                                          { rc = 1; }
+    or (a_b.decls[a_b.decl_len - 1].kind != decl.DECL_KIND_FUN)   { rc = 1; }
+    diag.dnit(?diags_b);
+    ast.dnit(?a_b);
+    lexer.dnit(?stream_b, ?alloc_b);
+    ret rc;
+}
+
+test "parser: sync_to_decl realigns without error cascade after a malformed decl (#1242)" {
+    # (b) `42 + 3; fun f() {}` — one error only (no cascade from `+` or `3`)
+    # and the fun decl is the last captured decl
+    var alloc_c: Allocator;
+    page.make(?alloc_c);
+    val tr_c: Result[lexer.TokenStream, str] = lexer.tokenize("42 + 3; fun f() {}", ?alloc_c, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr_c)) { ret 1; }
+    var stream_c: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr_c);
+    var a_c: ast.Ast = ast.init(?alloc_c, 0::src.FileId);
+    var diags_c: diag.DiagList = diag.init(?alloc_c);
+    var p_c: parser.Parser = parser.init(?stream_c, ?a_c, ?diags_c);
+    parse_module(?p_c);
+    var rc: i32 = 0;
+    if (diags_c.len != 1)                                          { rc = 1; }
+    or (a_c.decl_len < 1)                                          { rc = 1; }
+    or (a_c.decls[a_c.decl_len - 1].kind != decl.DECL_KIND_FUN)   { rc = 1; }
+    diag.dnit(?diags_c);
+    ast.dnit(?a_c);
+    lexer.dnit(?stream_c, ?alloc_c);
+    if (rc != 0) { ret rc; }
+
+    # `42; val a: i64 = 1; fun g() {}` — one error, both subsequent decls captured
+    var alloc_d: Allocator;
+    page.make(?alloc_d);
+    val tr_d: Result[lexer.TokenStream, str] = lexer.tokenize("42; val a: i64 = 1; fun g() {}", ?alloc_d, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr_d)) { ret 1; }
+    var stream_d: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr_d);
+    var a_d: ast.Ast = ast.init(?alloc_d, 0::src.FileId);
+    var diags_d: diag.DiagList = diag.init(?alloc_d);
+    var p_d: parser.Parser = parser.init(?stream_d, ?a_d, ?diags_d);
+    parse_module(?p_d);
+    if (diags_d.len != 1)     { rc = 1; }
+    or (a_d.decl_len < 3)     { rc = 1; }
+    diag.dnit(?diags_d);
+    ast.dnit(?a_d);
+    lexer.dnit(?stream_d, ?alloc_d);
+    ret rc;
+}
+
 test "parser: a binding with no type annotation is rejected (val-var.md, #1247)" {
     # val-var.md: bindings require an explicit type — neither form may omit it
     if (!t_parse_module_has_errors("val a = 42;")) { ret 1; }

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -982,6 +982,37 @@ fun at_type_boundary(p: *parser.Parser) bool {
     ret false;
 }
 
+test "parser: chained assignment x = y = 0 parses right-associatively (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize("x = y = 0", ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+
+    val eid: id.ExprId = parse_expr(?p);
+    var rc: i32 = 0;
+    val e: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, eid));
+    # top-level node is `x = (y = 0)`: a binary ASSIGN
+    if (e.kind != expr.EXPR_KIND_BINARY)         { rc = 1; }
+    or (e.data.binary.op != expr.BIN_ASSIGN)     { rc = 1; }
+    or {
+        # RHS must itself be a binary ASSIGN (right-associative grouping)
+        val rhs: *expr.Expr = unwrap[*expr.Expr](ast.get_expr(?a, e.data.binary.rhs));
+        if (rhs.kind != expr.EXPR_KIND_BINARY)   { rc = 1; }
+        or (rhs.data.binary.op != expr.BIN_ASSIGN) { rc = 1; }
+    }
+    if (diag.has_errors(?diags)) { rc = 1; }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
 test "parser: expr[i](args) parses as index-then-call, not a generic call (#1247)" {
     var alloc: Allocator;
     page.make(?alloc);

--- a/src/lang/fe/pool.mach
+++ b/src/lang/fe/pool.mach
@@ -19,6 +19,9 @@ use std.types.result.unwrap_err;
 use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.reallocate;
+use std.allocator.deallocate;
+
+use page: std.allocator.page;
 
 # grow: make room for one more element in a `*T`/len/cap buffer, returning the
 # (possibly relocated) buffer and writing the new capacity through `out_cap`.
@@ -47,4 +50,34 @@ pub fun grow[T](alloc: *Allocator, data: *T, cap: usize, seed: usize, out_cap: *
     if (is_err[*T, str](r)) { ret err[*T, str](unwrap_err[*T, str](r)); }
     @out_cap = new_cap;
     ret ok[*T, str](unwrap_ok[*T, str](r));
+}
+
+test "pool: grow nil/seed path allocates seed capacity and doubling path doubles it (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    # nil/seed path: capacity is exactly seed on first growth
+    var cap1: usize = 0;
+    val r1: Result[*u8, str] = grow[u8](?alloc, nil::*u8, 0, 16, ?cap1);
+    if (is_err[*u8, str](r1)) { ret 1; }
+    if (cap1 != 16) { ret 1; }
+    val ptr1: *u8 = unwrap_ok[*u8, str](r1);
+
+    # doubling path: capacity doubles when existing buffer is non-nil
+    var cap2: usize = 0;
+    val r2: Result[*u8, str] = grow[u8](?alloc, ptr1, 16, 16, ?cap2);
+    if (is_err[*u8, str](r2)) { ret 1; }
+    if (cap2 != 32) { ret 1; }
+    val ptr2: *u8 = unwrap_ok[*u8, str](r2);
+    deallocate[u8](?alloc, ptr2, 32);
+
+    # seed is honoured, not hardcoded: a different seed yields a different first capacity
+    var cap3: usize = 0;
+    val r3: Result[*u8, str] = grow[u8](?alloc, nil::*u8, 0, 8, ?cap3);
+    if (is_err[*u8, str](r3)) { ret 1; }
+    if (cap3 != 8) { ret 1; }
+    val ptr3: *u8 = unwrap_ok[*u8, str](r3);
+    deallocate[u8](?alloc, ptr3, 8);
+
+    ret 0;
 }

--- a/src/lang/fe/token.mach
+++ b/src/lang/fe/token.mach
@@ -181,3 +181,18 @@ pub fun is_right_assoc(kind: Kind) bool {
     ret kind == KIND_EQ;
 }
 
+test "token: infix_precedence table and is_right_assoc match the Pratt-table spec (#1242)" {
+    if (infix_precedence(KIND_STAR)      != 11) { ret 1; }
+    if (infix_precedence(KIND_PLUS)      != 10) { ret 1; }
+    if (infix_precedence(KIND_LT_LT)     != 9)  { ret 1; }
+    if (infix_precedence(KIND_LT)        != 8)  { ret 1; }
+    if (infix_precedence(KIND_AMP)       != 6)  { ret 1; }
+    if (infix_precedence(KIND_PIPE_PIPE) != 2)  { ret 1; }
+    if (infix_precedence(KIND_EQ)        != 1)  { ret 1; }
+    if (infix_precedence(KIND_EOF)       != 0)  { ret 1; }
+    if (infix_precedence(KIND_SEMI)      != 0)  { ret 1; }
+    if (!is_right_assoc(KIND_EQ))               { ret 1; }
+    if (is_right_assoc(KIND_PLUS))              { ret 1; }
+    ret 0;
+}
+


### PR DESCRIPTION
## Summary

Inline `test` blocks for Group B specs from issue #1242. Zero production-code changes — all new lines are test-only.

## Per-spec disposition

| Spec | File | Status | Notes |
|---|---|---|---|
| B1 `infix_precedence` / `is_right_assoc` | `fe/token.mach` | implemented | no allocator needed; pure table lookup |
| B2 `parse_expr_bp` right-assoc assignment | `fe/parser/expr.mach` | implemented | `x = y = 0` → `x = (y = 0)` |
| B3 `tokenize` 0b/0o prefix spans | `fe/lexer.mach` | implemented | span offsets and lengths for all three tokens |
| B4 `tokenize` char literal + escape + unterminated | `fe/lexer.mach` | implemented | three sub-cases in one test |
| B5 `grow` nil/seed and doubling paths | `fe/pool.mach` | implemented | added `page` + `deallocate` imports for the test |
| B6 `parse_decl` error span + `sync_to_decl` recovery | `fe/parser/decl.mach` | implemented | split into two tests: error-span and recovery/no-cascade |

## Verification

- `mach build .` clean (zero diagnostics).
- `mach test .` 358 PASS, 0 FAIL (was 351 before; +7 new test blocks).
- Self-host fixpoint confirmed: two consecutive builds produce identical binaries (`88450aa928ce49d886d6a0758078b18a`). Test blocks compile only into the test binary, not the compiler binary.

Refs #1242