### PR TITLE
test(be-codegen): #1242 group D — frame/encoder invariants

### DIFF
--- a/src/lang/be/codegen/frame.mach
+++ b/src/lang/be/codegen/frame.mach
@@ -21,6 +21,7 @@ use std.types.result.err;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
+use std.types.option.unwrap;
 use std.types.option.is_some;
 
 use target: mach.lang.target.resolved;
@@ -159,6 +160,43 @@ pub fun slot_offset(frame: *mir.MirFrame, v: u32) Option[i64] {
 # ret:   true if `v` has an assigned stack slot
 pub fun is_slot(frame: *mir.MirFrame, v: u32) bool {
     ret is_some[i64](slot_offset(frame, v));
+}
+
+test "be.codegen.frame: slot_offset and is_alloca_slot distinguish alloca from spill" {
+    # build two manual slots without allocator (offset already set, no frame.run needed).
+    var slots: [2]mir.MirSlot;
+    slots[0].value  = 10;
+    slots[0].kind   = mir.SLOT_ALLOCA;
+    slots[0].offset = -16;
+    slots[0].size   = 16;
+    slots[0].align  = 16;
+    slots[1].value  = 20;
+    slots[1].kind   = mir.SLOT_SPILL;
+    slots[1].offset = -24;
+    slots[1].size   = 8;
+    slots[1].align  = 8;
+    var frame: mir.MirFrame;
+    frame.slots        = ?slots[0];
+    frame.slot_count   = 2;
+    frame.slot_cap     = 2;
+    frame.size         = 0;
+    frame.align        = 0;
+    frame.has_va_save  = false;
+    frame.va_save_size = 0;
+    frame.va_save_off  = 0;
+    frame.outgoing_size = 0;
+    val off10: Option[i64] = slot_offset(?frame, 10);
+    if (!is_some[i64](off10))        { ret 1; }
+    if (unwrap[i64](off10) != -16)   { ret 1; }
+    val off20: Option[i64] = slot_offset(?frame, 20);
+    if (!is_some[i64](off20))        { ret 1; }
+    if (unwrap[i64](off20) != -24)   { ret 1; }
+    val off99: Option[i64] = slot_offset(?frame, 99);
+    if (is_some[i64](off99))         { ret 1; }
+    if (!is_alloca_slot(?frame, 10)) { ret 1; }
+    if (is_alloca_slot(?frame, 20))  { ret 1; }
+    if (!is_slot(?frame, 10))        { ret 1; }
+    ret 0;
 }
 
 # is_alloca_slot: report whether a MIR value's slot is an addressed alloca rather than an aggregate spill.

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -945,6 +945,24 @@ fun param_vreg(ctx: *LowerCtx, ix: u32) u32 {
     ret ctx.param_vregs[ix];
 }
 
+test "be.codegen.mir.context: stack_slot_bytes rounds to 8-byte granularity" {
+    # size=0 treated as 8; 1..8 all round up to 8; 9 rounds to 16.
+    if (stack_slot_bytes(0) != 8)  { ret 1; }
+    if (stack_slot_bytes(1) != 8)  { ret 1; }
+    if (stack_slot_bytes(8) != 8)  { ret 1; }
+    if (stack_slot_bytes(9) != 16) { ret 1; }
+    ret 0;
+}
+
+test "be.codegen.mir.context: clamp_alu_width raises sub-4 widths to 4" {
+    if (clamp_alu_width(1) != 4) { ret 1; }
+    if (clamp_alu_width(2) != 4) { ret 1; }
+    if (clamp_alu_width(3) != 4) { ret 1; }
+    if (clamp_alu_width(4) != 4) { ret 1; }
+    if (clamp_alu_width(8) != 8) { ret 1; }
+    ret 0;
+}
+
 # appends a MIR instruction to a block, growing its instruction list on demand.
 pub fun push_instr(ctx: *LowerCtx, mb: *mir.MirBlock, mi: mir.MirInstr) Result[bool, str] {
     # enforce the asm_block invariant: a mir.MirInstr carries an inline-asm payload only

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -5196,6 +5196,101 @@ test "x64.encode: byte ALU on SIL/DIL forces a bare REX (shared prefix core)" {
     ret bad;
 }
 
+test "x64.encode: movzx r64,r32 dispatches to plain MOV (0x8B) not MOVZX escape" {
+    # spec D4: src_size>=4 → encode_movzx uses 0x8B (32-bit MOV, implicit zero-extend)
+    # rather than 0x0F 0xB7 (MOVZX r64,r16 — would truncate the source to 16 bits).
+    # note: a 32-bit MOV zero-extends without REX.W, so the encoding is 2 bytes for
+    # low-id registers (no REX extension bits needed for RAX=0, RBX=3). the spec D4
+    # byte sequence includes REX.W (0x48 8B C3, 3 bytes), but the code correctly omits
+    # it — a 32-bit MOV already zero-extends implicitly in x86-64 and needs no REX.W.
+    # we assert the KEY invariant (0x8B, not 0x0F) with the actual expected bytes.
+    var alloc: Allocator;
+    page.make(?alloc);
+    var buf: ByteBuf = buf_init(?alloc);
+    var mi: isa.Inst;
+    zero_inst(?mi);
+    mi.opcode    = x64.MOVZX;
+    mi.dst       = isa.make_reg(x64.RAX, 8);
+    mi.src1      = isa.make_reg(x64.RBX, 4);
+    mi.src1.size = 4;
+    mi.size      = 8;
+    mi.flags     = x64.FLAG_REX_W;
+    val n: i32 = encode_inst(?mi, ?buf);
+    var bad: i32 = 0;
+    if (n != 2)              { bad = 1; }
+    or (buf.data[0] != 0x8B) { bad = 1; }
+    or (buf.data[1] != 0xC3) { bad = 1; }
+    buf_dnit(?buf);
+    ret bad;
+}
+
+test "x64.encode: MOV rax,[rbp+0] forces mod=1 disp8=0 (RBP base at disp 0)" {
+    # spec D5: RBP(5)/R13(13) can't use mod=0 (that means rip-relative);
+    # the encoder forces mod=1 with disp8=0 for [rbp+0]. expected: 48 8B 45 00.
+    var alloc: Allocator;
+    page.make(?alloc);
+    var buf: ByteBuf = buf_init(?alloc);
+    var mi: isa.Inst;
+    zero_inst(?mi);
+    mi.opcode = x64.MOV;
+    mi.dst    = isa.make_reg(x64.RAX, 8);
+    mi.src1   = isa.make_mem(x64.RBP, 0, -1, 0, 8);
+    mi.size   = 8;
+    mi.flags  = x64.FLAG_REX_W;
+    val n: i32 = encode_inst(?mi, ?buf);
+    var bad: i32 = 0;
+    if (n != 4)              { bad = 1; }
+    or (buf.data[0] != 0x48) { bad = 1; }
+    or (buf.data[1] != 0x8B) { bad = 1; }
+    or (buf.data[2] != 0x45) { bad = 1; }
+    or (buf.data[3] != 0x00) { bad = 1; }
+    buf_dnit(?buf);
+    ret bad;
+}
+
+test "x64.encode: encode_push imm8/imm32 boundaries and out-of-range rejection" {
+    # spec D6: 0x6A form for imm8, 0x68 form for imm32, 0 bytes for > INT32_MAX.
+    var alloc: Allocator;
+    page.make(?alloc);
+    var buf: ByteBuf = buf_init(?alloc);
+    var bad: i32 = 0;
+
+    # case 1: imm8 (127 in -128..127 → 0x6A form)
+    var m1: isa.Inst;
+    zero_inst(?m1);
+    m1.opcode = x64.PUSH;
+    m1.dst    = isa.make_imm(127, 1);
+    m1.size   = 1;
+    val n1: i32 = encode_inst(?m1, ?buf);
+    if (n1 != 2)             { bad = 1; }
+    if (buf.data[0] != 0x6A) { bad = 1; }
+    if (buf.data[1] != 0x7F) { bad = 1; }
+
+    # case 2: imm32 boundary (0x1000 in signed-imm32 range → 0x68 form)
+    buf.len = 0;
+    var m2: isa.Inst;
+    zero_inst(?m2);
+    m2.opcode = x64.PUSH;
+    m2.dst    = isa.make_imm(0x1000, 4);
+    m2.size   = 4;
+    val n2: i32 = encode_inst(?m2, ?buf);
+    if (n2 != 5)             { bad = 1; }
+    if (buf.data[0] != 0x68) { bad = 1; }
+
+    # case 3: out-of-range (0x80000000 > INT32_MAX → rejected, 0 bytes emitted)
+    buf.len = 0;
+    var m3: isa.Inst;
+    zero_inst(?m3);
+    m3.opcode = x64.PUSH;
+    m3.dst    = isa.make_imm(0x80000000, 8);
+    m3.size   = 8;
+    val n3: i32 = encode_inst(?m3, ?buf);
+    if (n3 != 0) { bad = 1; }
+
+    buf_dnit(?buf);
+    ret bad;
+}
+
 # determine whether an instruction names an intra-module branch target (a
 # MIR_OP_BLOCK operand) or a relocatable symbol (a MIR_OP_SYM operand), reporting
 # the target block id / interned symbol name through the out-parameters.


### PR DESCRIPTION
Refs #1242

Implements Group D specs from the #1242 coverage-push selection: six inline tests across the three files owned by the `be-codegen` worktree. Zero changes to non-test code.

## Per-spec disposition

**D1 — `stack_slot_bytes` 8-byte granularity** (`mir/context.mach`): implemented as specified. Asserts size=0→8, 1→8, 8→8, 9→16.

**D2 — `clamp_alu_width` sub-4 raise** (`mir/context.mach`): implemented as specified. Asserts widths 1/2/3/4→4 and 8→8.

**D3 — `slot_offset`/`is_alloca_slot`** (`frame.mach`): implemented as specified. Two manually-constructed `MirSlot` entries (one SLOT_ALLOCA, one SLOT_SPILL) on the stack; asserts correct offsets, absent slot returns none, alloca vs spill discrimination, and `is_slot`. Added `use std.types.option.unwrap` import required to extract the `Option[i64]` value.

**D4 — `encode_movzx` src_size=4 path** (`encode.mach`): implemented with adjusted byte assertions. The spec expected `n==3; 0x48 0x8B 0xC3` (with REX.W), but `encode_movzx`'s src_size≥4 branch correctly calls `emit_rex_if_needed(buf, 0, dst, src)` — no REX.W, because a 32-bit MOV already zero-extends to 64-bit in x86-64 without it. For RAX(0) and RBX(3) neither extension bit is needed, so the correct encoding is `0x8B 0xC3` (2 bytes). The test still pins the key invariant (0x8B not 0x0F 0xB7). Emitting REX.W here would be redundant but harmless; making the test match the spec's 3-byte sequence would require changing non-test code, which the hard rule forbids.

**D5 — `encode_mem_operand` RBP base disp=0 forced disp8** (`encode.mach`): implemented as specified. `MOV rax,[rbp+0]` → `48 8B 45 00` (mod=1, disp8=0 forced by the base==5 guard).

**D6 — `encode_push` imm boundaries and rejection** (`encode.mach`): implemented as specified. Three cases: imm8 (127→`6A 7F`, 2 bytes), imm32 boundary (0x1000→`68 ...`, 5 bytes), out-of-range (0x80000000→0 bytes).

## Verification

- `mach build .` clean
- `mach test .` 357/357 PASS (was 351; +6 new tests)
- Fixpoint: stage-1 binary md5 matches stage-2 (`ad2eda7c307733dfc2c3e48b7a458ddf`)
- `bash .github/tests/win64fnptr/run.sh` → `PASS win64fnptr`