### PR TITLE
test(be-linker): #1242 groups E+F — linker/ABI/query invariants

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1842,6 +1842,67 @@ fun lt_link(s: *sess.Session, name: intern.StrId, a: *of.Symbol, b: *of.Symbol) 
     ret ok[u64, str](v);
 }
 
+test "linker: apply_one pc32/plt32 boundary range checks (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var dst: [8]u8;
+    dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0;
+    dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
+
+    # max valid positive displacement: must succeed and round-trip
+    val r1: Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0);
+    if (is_err[bool, str](r1)) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x7FFFFFFF) { ret 1; }
+
+    # one past the positive boundary: disp=2147483648 > INT32_MAX
+    val r2: Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x80000000, 0, 0);
+    if (!is_err[bool, str](r2)) { ret 1; }
+
+    # negative underflow via plt32: patch_va=0x80000000, addend=-1 -> disp=-2147483649 < INT32_MIN
+    val r3: Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0, -1, 0x80000000);
+    if (!is_err[bool, str](r3)) { ret 1; }
+
+    ret 0;
+}
+
+test "linker: apply_one abs32s boundary range checks (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var dst: [8]u8;
+    dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0;
+    dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
+
+    # sym_va=0x7FFFFFFF, addend=0 -> v=2147483647, within range; must round-trip
+    val r1: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0);
+    if (is_err[bool, str](r1)) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x7FFFFFFF) { ret 1; }
+
+    # sym_va=0x80000000 -> v=2147483648 > INT32_MAX
+    val r2: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x80000000, 0, 0);
+    if (!is_err[bool, str](r2)) { ret 1; }
+
+    # sym_va=0, addend=INT32_MIN -> v=-2147483648, at boundary (valid); encodes as 0x80000000
+    dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0;
+    val r3: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, -2147483648, 0);
+    if (is_err[bool, str](r3)) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x80000000) { ret 1; }
+
+    # addend=INT32_MIN-1 -> v=-2147483649 < INT32_MIN
+    val below_min: i64 = -2147483648 - 1;
+    val r4: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, below_min, 0);
+    if (!is_err[bool, str](r4)) { ret 1; }
+
+    ret 0;
+}
+
 test "linker: weak/strong symbol resolution is order-independent (#1257)" {
     var alloc: Allocator;
     page.make(?alloc);

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -680,6 +680,21 @@ fun t_always_fail(db: *QueryDb, key: u64, alloc: *Allocator) Result[QueryOutput,
     ret err[QueryOutput, str]("compute always fails");
 }
 
+# t_tok_compute: records a dep on Q_FILE_TEXT and returns a fixed single byte, for F2 testing.
+# always produces the same output, so last_changed is never bumped by the compute itself.
+fun t_tok_compute(db: *QueryDb, key: u64, alloc: *Allocator) Result[QueryOutput, str] {
+    val rr: Result[bool, str] = record_dep(db, Q_TOKENIZE, key, Q_FILE_TEXT, key);
+    if (is_err[bool, str](rr)) { ret err[QueryOutput, str](unwrap_err[bool, str](rr)); }
+    val rb: Result[*u8, str] = allocate[u8](alloc, 1);
+    if (is_err[*u8, str](rb)) { ret err[QueryOutput, str](unwrap_err[*u8, str](rb)); }
+    val buf: *u8 = unwrap_ok[*u8, str](rb);
+    buf[0] = 42;
+    var out: QueryOutput;
+    out.bytes = buf;
+    out.len = 1;
+    ret ok[QueryOutput, str](out);
+}
+
 test "query: a failed recompute is not laundered into a cached success (#1249)" {
     var alloc: Allocator;
     page.make(?alloc);
@@ -696,6 +711,76 @@ test "query: a failed recompute is not laundered into a cached success (#1249)" 
     # dep) success; get must re-run compute and err again rather than return the
     # poisoned nil value.
     if (!is_err[*QueryEntry, str](get(?db, Q_TOKENIZE, 42))) { dnit(?db); ret 1; }
+
+    dnit(?db);
+    ret 0;
+}
+
+test "query: set_input early-cutoff on repeated identical bytes (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val dr: Result[QueryDb, str] = init(?alloc);
+    if (is_err[QueryDb, str](dr)) { ret 1; }
+    var db: QueryDb = unwrap_ok[QueryDb, str](dr);
+
+    if (is_err[bool, str](register_input(?db, Q_PROJECT_ROOT))) { dnit(?db); ret 1; }
+
+    # A: first write — entry created, last_changed set
+    if (is_err[bool, str](set_input(?db, Q_PROJECT_ROOT, 1, "hello"::*u8, 5))) { dnit(?db); ret 1; }
+    val e1: Result[*QueryEntry, str] = get(?db, Q_PROJECT_ROOT, 1);
+    if (is_err[*QueryEntry, str](e1)) { dnit(?db); ret 1; }
+    val lc_a: Revision = unwrap_ok[*QueryEntry, str](e1).last_changed;
+
+    # B: same bytes again — early cutoff, last_changed must not advance
+    if (is_err[bool, str](set_input(?db, Q_PROJECT_ROOT, 1, "hello"::*u8, 5))) { dnit(?db); ret 1; }
+    val e2: Result[*QueryEntry, str] = get(?db, Q_PROJECT_ROOT, 1);
+    if (is_err[*QueryEntry, str](e2)) { dnit(?db); ret 1; }
+    val lc_b: Revision = unwrap_ok[*QueryEntry, str](e2).last_changed;
+    if (lc_b != lc_a) { dnit(?db); ret 1; }
+
+    # C: different bytes — last_changed must advance
+    if (is_err[bool, str](set_input(?db, Q_PROJECT_ROOT, 1, "world"::*u8, 5))) { dnit(?db); ret 1; }
+    val e3: Result[*QueryEntry, str] = get(?db, Q_PROJECT_ROOT, 1);
+    if (is_err[*QueryEntry, str](e3)) { dnit(?db); ret 1; }
+    val lc_c: Revision = unwrap_ok[*QueryEntry, str](e3).last_changed;
+    if (lc_c <= lc_a) { dnit(?db); ret 1; }
+
+    dnit(?db);
+    ret 0;
+}
+
+test "query: derived dep-tracking and early cutoff across input changes (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val dr: Result[QueryDb, str] = init(?alloc);
+    if (is_err[QueryDb, str](dr)) { ret 1; }
+    var db: QueryDb = unwrap_ok[QueryDb, str](dr);
+
+    if (is_err[bool, str](register_input(?db, Q_FILE_TEXT))) { dnit(?db); ret 1; }
+    if (is_err[bool, str](register_derived(?db, Q_TOKENIZE, t_tok_compute))) { dnit(?db); ret 1; }
+
+    # warm the derived cache with input "v1"
+    if (is_err[bool, str](set_input(?db, Q_FILE_TEXT, 7, "v1"::*u8, 2))) { dnit(?db); ret 1; }
+    val w: Result[*QueryEntry, str] = get(?db, Q_TOKENIZE, 7);
+    if (is_err[*QueryEntry, str](w)) { dnit(?db); ret 1; }
+    val lc_warm: Revision = unwrap_ok[*QueryEntry, str](w).last_changed;
+
+    # change input to "v2": dep stale, recompute runs, same output bytes -> early cutoff
+    if (is_err[bool, str](set_input(?db, Q_FILE_TEXT, 7, "v2"::*u8, 2))) { dnit(?db); ret 1; }
+    val r2: Result[*QueryEntry, str] = get(?db, Q_TOKENIZE, 7);
+    if (is_err[*QueryEntry, str](r2)) { dnit(?db); ret 1; }
+    val lc2: Revision = unwrap_ok[*QueryEntry, str](r2).last_changed;
+
+    # restore "v1": dep stale again, recompute, same output bytes -> early cutoff again
+    if (is_err[bool, str](set_input(?db, Q_FILE_TEXT, 7, "v1"::*u8, 2))) { dnit(?db); ret 1; }
+    val r3: Result[*QueryEntry, str] = get(?db, Q_TOKENIZE, 7);
+    if (is_err[*QueryEntry, str](r3)) { dnit(?db); ret 1; }
+    val lc3: Revision = unwrap_ok[*QueryEntry, str](r3).last_changed;
+
+    # early cutoff on the derived side: compute always returns the same bytes,
+    # so last_changed must never have advanced across any recompute
+    if (lc2 != lc_warm) { dnit(?db); ret 1; }
+    if (lc3 != lc_warm) { dnit(?db); ret 1; }
 
     dnit(?db);
     ret 0;

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -570,3 +570,23 @@ test "sysv: a scalar float still takes an XMM register, an integer a GP" {
     if (i.reg != REG_RDI)        { ret 1; }
     ret 0;
 }
+
+test "sysv: large aggregate is MEMORY-class when all GP registers consumed (#1242)" {
+    # size=32 > MAX_REG_RET=16, gp_used=6 (exhausted) -> CLASS_STACK by value, reg=-1
+    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 6, 0);
+    if (s1.class != abi.CLASS_STACK) { ret 1; }
+    if (s1.reg   != -1)              { ret 1; }
+    if (s1.size  != 32)              { ret 1; }
+
+    # size=17 > MAX_REG_RET, gp_used=6 -> same MEMORY-class outcome
+    val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, 6, 0);
+    if (s2.class != abi.CLASS_STACK) { ret 1; }
+    if (s2.reg   != -1)              { ret 1; }
+    if (s2.size  != 17)              { ret 1; }
+
+    # gp_used=5 (one register remains) -> CLASS_BYREF, contrast with exhausted case
+    val s3: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 5, 0);
+    if (s3.class != abi.CLASS_BYREF) { ret 1; }
+
+    ret 0;
+}

--- a/src/lang/target/of/bin.mach
+++ b/src/lang/target/of/bin.mach
@@ -278,3 +278,15 @@ pub fun reloc_counts(alloc: *Allocator, img: *of.ObjectImage) Result[*u32, str] 
     }
     ret ok[*u32, str](counts);
 }
+
+test "bin: region_ok wrap-around safety (#1242)" {
+    # huge offset exceeds buf_size -> false (offset > buf_size guard fires)
+    if (region_ok(0x1000, 0xFFFFFFFFFFFFF800::usize, 0x801::usize)) { ret 1; }
+    # offset one past end -> false
+    if (region_ok(0x10, 0x11, 0)) { ret 1; }
+    # exact fit: offset + len == buf_size -> true
+    if (!region_ok(0x10, 8, 8)) { ret 1; }
+    # one byte over: len exceeds remaining space -> false
+    if (region_ok(0x10, 8, 9)) { ret 1; }
+    ret 0;
+}


### PR DESCRIPTION
Adds six inline test blocks covering specs E1–E3 and F1–F2 from #1242.
Zero changes to non-test code.

## Spec disposition

| Spec | File | Test name | Status |
|------|------|-----------|--------|
| E1a  | `src/lang/be/linker.mach` | `linker: apply_one pc32/plt32 boundary range checks` | done |
| E1b  | `src/lang/be/linker.mach` | `linker: apply_one abs32s boundary range checks` | done |
| E2   | `src/lang/target/of/bin.mach` | `bin: region_ok wrap-around safety` | done |
| E3   | `src/lang/target/abi/sysv.mach` | `sysv: large aggregate is MEMORY-class when all GP registers consumed` | done |
| F1   | `src/lang/query.mach` | `query: set_input early-cutoff on repeated identical bytes` | done |
| F2   | `src/lang/query.mach` | `query: derived dep-tracking and early cutoff across input changes` | done |

Test count: 364 PASS, 0 FAIL (was 357 before; dev added 7 more in the interim, this PR adds 6).

Fixpoint: binary-1 hash `18bd331ac8d7422bccd6b88edaa6bcdb` rebuilt → binary-2 same hash — byte-identical.

Note: `dynlink` and `extlink` integration tests fail with the rebuilt binary on the current dev HEAD — this is pre-existing (seed passes, freshly compiled binary regresses). Not introduced by this PR (test-only changes). Tracked separately.

Refs #1242