### PR TITLE
test(fe-sema): #1242 group A — interner and comptime evaluator invariants

### DIFF
--- a/.github/tests/literalboundary/app/mach.toml
+++ b/.github/tests/literalboundary/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "literalboundary"
+name = "Integer literal boundary test — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/literalboundary"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/literalboundary/app/src/main.mach
+++ b/.github/tests/literalboundary/app/src/main.mach
@@ -1,0 +1,31 @@
+use std.runtime.linux.x86_64;
+
+# integer literal boundary regression coverage (issue #1242 A9). assigns the
+# max-valid literal to a variable of each integer type, then casts or compares
+# the stored value against its expected magnitude. pins sema coerce (accept the
+# max-valid literal) and backend encoding (store/load the value correctly)
+# simultaneously. exits 0 when every check passes; returns a non-zero check id
+# on the first mismatch.
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    var vi8:  i8  = 127;
+    var vu8:  u8  = 255;
+    var vi16: i16 = 32767;
+    var vu16: u16 = 65535;
+    var vi32: i32 = 2147483647;
+    var vu32: u32 = 4294967295;
+    var vi64: i64 = 9223372036854775807;
+    var vu64: u64 = 18446744073709551615;
+
+    if (vi8  != 127::i8)              { ret 1; }
+    if (vu8  != 255::u8)              { ret 2; }
+    if (vi16 != 32767::i16)           { ret 3; }
+    if (vu16 != 65535::u16)           { ret 4; }
+    if (vi32 != 2147483647::i32)      { ret 5; }
+    if (vu32 != 4294967295::u32)      { ret 6; }
+    if (vi64 != 9223372036854775807)  { ret 7; }
+    if (vu64 != 18446744073709551615) { ret 8; }
+
+    ret 0;
+}

--- a/.github/tests/literalboundary/run.sh
+++ b/.github/tests/literalboundary/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# integer literal boundary regression test (issue #1242 A9): build the `app`
+# project with the freshly-built compiler and run it. the app assigns the
+# max-valid literal to a variable of each integer type, then checks that the
+# stored value matches the expected magnitude, exiting 0 only when every check
+# passes. a mismatch exits with a non-zero check id.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL literalboundary: build failed" >&2
+    exit 1
+fi
+
+set +e
+"$WORK/app/out/linux/bin/literalboundary"
+code=$?
+set -e
+
+if [ "$code" -ne 0 ]; then
+    echo "FAIL literalboundary: check $code produced a wrong value" >&2
+    exit 1
+fi
+
+echo "PASS literalboundary: max-valid integer literals accepted and round-trip correctly"
+exit 0

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -62,6 +62,8 @@ use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
+use page: std.allocator.page;
+
 use intern: mach.lang.intern;
 use ast:    mach.lang.fe.ast;
 use id:     mach.lang.fe.ast.id;
@@ -1756,5 +1758,151 @@ test "comptime: $bin.name folds the artifact name, unavailable when unset (#1217
     # with no artifact bound (v1 manifest) the read is unavailable.
     c.bin_name = intern.STR_NIL;
     if (!is_err[CTValue, str](resolve_bin_path(?c, sn, ?stack[0], t_dotted(sn, ?stack[0])))) { ret 1; }
+    ret 0;
+}
+
+# helper: builds a full-length span over a char literal source string and
+# evaluates it. the argument must not embed a null byte (use inline span
+# construction for '\0' cases).
+fun t_char(s: str) Result[CTValue, str] {
+    var span: token.Span;
+    span.offset = 0;
+    span.len    = str_len(s);
+    ret eval_lit_char(s, span);
+}
+
+# helper: builds a full-length span over a float literal source string and
+# evaluates it.
+fun t_float(s: str) Result[CTValue, str] {
+    var span: token.Span;
+    span.offset = 0;
+    span.len    = str_len(s);
+    ret eval_lit_float(s, span);
+}
+
+test "comptime: eval_lit_char decodes escape sequences and rejects malformed literals (#1242)" {
+    # \n escape — mach source "'\n'" contains a literal newline byte passed
+    # through as-is; "'\\ n'" (backslash + n in runtime string) tests the escape
+    # decoder. the spec targets escape decoding, so we drive the decoder:
+    # "'\\n'" in mach source → runtime "'", '\', 'n', "'" → decode \n → 10.
+    if (is_err[CTValue, str](t_char("'\\n'")))                     { ret 1; }
+    if (unwrap_ok[CTValue, str](t_char("'\\n'")).data.i != 10)     { ret 1; }
+    # \t escape → 9
+    if (is_err[CTValue, str](t_char("'\\t'")))                     { ret 1; }
+    if (unwrap_ok[CTValue, str](t_char("'\\t'")).data.i != 9)      { ret 1; }
+    # \\ escape → 92 ("'\\\\'" in mach source → "'\\'" as runtime text)
+    if (is_err[CTValue, str](t_char("'\\\\'")))                    { ret 1; }
+    if (unwrap_ok[CTValue, str](t_char("'\\\\'")).data.i != 92)    { ret 1; }
+    # \0 escape → 0 ("'\\0'" avoids null-terminated string issue via \\)
+    if (is_err[CTValue, str](t_char("'\\0'")))                     { ret 1; }
+    if (unwrap_ok[CTValue, str](t_char("'\\0'")).data.i != 0)      { ret 1; }
+    # \' escape → 39
+    if (is_err[CTValue, str](t_char("'\\''"))  )                   { ret 1; }
+    if (unwrap_ok[CTValue, str](t_char("'\\''")).data.i != 39)     { ret 1; }
+    # multi-char body → error
+    if (!is_err[CTValue, str](t_char("'ab'")))  { ret 1; }
+    # empty body → error (len < 3)
+    if (!is_err[CTValue, str](t_char("''")))    { ret 1; }
+    # unterminated → error (len < 3)
+    if (!is_err[CTValue, str](t_char("'a")))    { ret 1; }
+    ret 0;
+}
+
+test "comptime: eval_lit_float parses exponent forms and rejects empty input (#1242)" {
+    # 1.5e2 → 150.0 (exact)
+    val r1: Result[CTValue, str] = t_float("1.5e2");
+    if (is_err[CTValue, str](r1)) { ret 1; }
+    if (unwrap_ok[CTValue, str](r1).data.f != 150.0) { ret 1; }
+    # 1.0E-1 ≈ 0.1 (use epsilon for precision)
+    val r2: Result[CTValue, str] = t_float("1.0E-1");
+    if (is_err[CTValue, str](r2)) { ret 1; }
+    var d2: f64 = unwrap_ok[CTValue, str](r2).data.f - 0.1;
+    if (d2 < 0.0) { d2 = 0.0 - d2; }
+    if (d2 > 1.0e-9) { ret 1; }
+    # 3.14 ≈ 3.14
+    val r3: Result[CTValue, str] = t_float("3.14");
+    if (is_err[CTValue, str](r3)) { ret 1; }
+    var d3: f64 = unwrap_ok[CTValue, str](r3).data.f - 3.14;
+    if (d3 < 0.0) { d3 = 0.0 - d3; }
+    if (d3 > 1.0e-9) { ret 1; }
+    # "1." → 1.0 (no fractional part)
+    val r4: Result[CTValue, str] = t_float("1.");
+    if (is_err[CTValue, str](r4)) { ret 1; }
+    if (unwrap_ok[CTValue, str](r4).data.f != 1.0) { ret 1; }
+    # empty → error
+    if (!is_err[CTValue, str](t_float(""))) { ret 1; }
+    ret 0;
+}
+
+test "comptime: eval_lit_int handles 0b/0o prefixes and _ separators (#1242)" {
+    # binary prefix: 0b11111111 = 255
+    val r1: Result[CTValue, str] = t_eval_int("0b11111111");
+    if (is_err[CTValue, str](r1)) { ret 1; }
+    if (unwrap_ok[CTValue, str](r1).data.i:~u64 != 255) { ret 1; }
+    # octal prefix: 0o377 = 255
+    val r2: Result[CTValue, str] = t_eval_int("0o377");
+    if (is_err[CTValue, str](r2)) { ret 1; }
+    if (unwrap_ok[CTValue, str](r2).data.i:~u64 != 255) { ret 1; }
+    # underscore separator: 1_000 = 1000
+    val r3: Result[CTValue, str] = t_eval_int("1_000");
+    if (is_err[CTValue, str](r3)) { ret 1; }
+    if (unwrap_ok[CTValue, str](r3).data.i != 1000) { ret 1; }
+    # binary with separator: 0b1_0000_0000 = 256
+    val r4: Result[CTValue, str] = t_eval_int("0b1_0000_0000");
+    if (is_err[CTValue, str](r4)) { ret 1; }
+    if (unwrap_ok[CTValue, str](r4).data.i:~u64 != 256) { ret 1; }
+    # prefix with no digits → error
+    if (!is_err[CTValue, str](t_eval_int("0b"))) { ret 1; }
+    if (!is_err[CTValue, str](t_eval_int("0o"))) { ret 1; }
+    if (!is_err[CTValue, str](t_eval_int("0x"))) { ret 1; }
+    ret 0;
+}
+
+test "comptime: bind/frame_open/frame_close/lookup scope bindings without leaking (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var c: ComptimeCtx = init(?alloc, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
+
+    val name1: intern.StrId = 1::intern.StrId;
+    val name2: intern.StrId = 2::intern.StrId;
+
+    val v10: CTValue = unwrap_ok[CTValue, str](int_value(10));
+    val v20: CTValue = unwrap_ok[CTValue, str](int_value(20));
+
+    # bind name1 → 10 in the bottom frame
+    val b1: Result[bool, str] = bind(?c, name1, v10);
+    if (is_err[bool, str](b1)) { dnit(?c); ret 1; }
+
+    # open an inner frame, rebind name1 → 20
+    val m: FrameMark = frame_open(?c);
+    val b2: Result[bool, str] = bind(?c, name1, v20);
+    if (is_err[bool, str](b2)) { dnit(?c); ret 1; }
+
+    # inner lookup finds 20 (shadow wins)
+    val lk1: Option[*NamedConst] = lookup(?c, name1);
+    if (is_none[*NamedConst](lk1)) { dnit(?c); ret 1; }
+    if (unwrap[*NamedConst](lk1).value.data.i != 20) { dnit(?c); ret 1; }
+
+    # close the inner frame
+    val fc: Result[bool, str] = frame_close(?c, m);
+    if (is_err[bool, str](fc)) { dnit(?c); ret 1; }
+
+    # after close, name1 resolves back to the outer binding (10)
+    val lk2: Option[*NamedConst] = lookup(?c, name1);
+    if (is_none[*NamedConst](lk2)) { dnit(?c); ret 1; }
+    if (unwrap[*NamedConst](lk2).value.data.i != 10) { dnit(?c); ret 1; }
+
+    # name2 was never bound: lookup returns none
+    val lk3: Option[*NamedConst] = lookup(?c, name2);
+    if (!is_none[*NamedConst](lk3)) { dnit(?c); ret 1; }
+
+    # empty-frame no-op: open and immediately close, depth unchanged
+    val depth_before: u32 = c.entries_len;
+    val m2: FrameMark = frame_open(?c);
+    val fc2: Result[bool, str] = frame_close(?c, m2);
+    if (is_err[bool, str](fc2)) { dnit(?c); ret 1; }
+    if (c.entries_len != depth_before) { dnit(?c); ret 1; }
+
+    dnit(?c);
     ret 0;
 }

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -42,6 +42,8 @@ use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
+use page: std.allocator.page;
+
 use map:   std.collections.map;
 use fnv1a: std.crypto.hash.fnv1a;
 
@@ -923,4 +925,162 @@ fun eq_type(pa: ptr, pb: ptr) bool {
     }
     # primitives and TYPE_ERROR are equal by kind alone
     ret true;
+}
+
+test "type: intern_function returns same TypeId for identical signatures (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val ti_r: Result[TypeInterner, str] = init(?alloc);
+    if (is_err[TypeInterner, str](ti_r)) { ret 1; }
+    var ti: TypeInterner = unwrap_ok[TypeInterner, str](ti_r);
+
+    val u8_id: TypeId = unwrap[TypeId](prim(?ti, TYPE_U8));
+
+    # same signature interned twice → same TypeId
+    val r1: Result[TypeId, str] = intern_function(?ti, u8_id, nil, 0, false);
+    val r2: Result[TypeId, str] = intern_function(?ti, u8_id, nil, 0, false);
+    if (is_err[TypeId, str](r1)) { dnit(?ti); ret 1; }
+    if (is_err[TypeId, str](r2)) { dnit(?ti); ret 1; }
+    if (unwrap_ok[TypeId, str](r1) != unwrap_ok[TypeId, str](r2)) { dnit(?ti); ret 1; }
+
+    # variadic=true yields a different TypeId
+    val r3: Result[TypeId, str] = intern_function(?ti, u8_id, nil, 0, true);
+    if (is_err[TypeId, str](r3)) { dnit(?ti); ret 1; }
+    if (unwrap_ok[TypeId, str](r1) == unwrap_ok[TypeId, str](r3)) { dnit(?ti); ret 1; }
+
+    # fun(u32)->u8 and fun(u64)->u8 differ because the param types differ
+    val u32_id: TypeId = unwrap[TypeId](prim(?ti, TYPE_U32));
+    val u64_id: TypeId = unwrap[TypeId](prim(?ti, TYPE_U64));
+    var p32: [1]TypeId;
+    p32[0] = u32_id;
+    var p64: [1]TypeId;
+    p64[0] = u64_id;
+    val r4: Result[TypeId, str] = intern_function(?ti, u8_id, ?p32[0], 1, false);
+    val r5: Result[TypeId, str] = intern_function(?ti, u8_id, ?p64[0], 1, false);
+    if (is_err[TypeId, str](r4)) { dnit(?ti); ret 1; }
+    if (is_err[TypeId, str](r5)) { dnit(?ti); ret 1; }
+    if (unwrap_ok[TypeId, str](r4) == unwrap_ok[TypeId, str](r5)) { dnit(?ti); ret 1; }
+
+    dnit(?ti);
+    ret 0;
+}
+
+test "type: intern_instance returns same TypeId for identical (origin,decl,args) (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val ti_r: Result[TypeInterner, str] = init(?alloc);
+    if (is_err[TypeInterner, str](ti_r)) { ret 1; }
+    var ti: TypeInterner = unwrap_ok[TypeInterner, str](ti_r);
+
+    val u32_id: TypeId = unwrap[TypeId](prim(?ti, TYPE_U32));
+    val u8_id:  TypeId = unwrap[TypeId](prim(?ti, TYPE_U8));
+
+    var a1: [1]TypeId;
+    a1[0] = u32_id;
+
+    # same (origin, decl, args) interned twice → same TypeId
+    val r1: Result[TypeId, str] = intern_instance(?ti, 1::sess.ModuleId, 0::id.DeclId, ?a1[0], 1);
+    val r2: Result[TypeId, str] = intern_instance(?ti, 1::sess.ModuleId, 0::id.DeclId, ?a1[0], 1);
+    if (is_err[TypeId, str](r1)) { dnit(?ti); ret 1; }
+    if (is_err[TypeId, str](r2)) { dnit(?ti); ret 1; }
+    if (unwrap_ok[TypeId, str](r1) != unwrap_ok[TypeId, str](r2)) { dnit(?ti); ret 1; }
+
+    # different arg type → different TypeId
+    var a1u8: [1]TypeId;
+    a1u8[0] = u8_id;
+    val r3: Result[TypeId, str] = intern_instance(?ti, 1::sess.ModuleId, 0::id.DeclId, ?a1u8[0], 1);
+    if (is_err[TypeId, str](r3)) { dnit(?ti); ret 1; }
+    if (unwrap_ok[TypeId, str](r1) == unwrap_ok[TypeId, str](r3)) { dnit(?ti); ret 1; }
+
+    # different arg count → different TypeId
+    var a2: [2]TypeId;
+    a2[0] = u32_id;
+    a2[1] = u8_id;
+    val r4: Result[TypeId, str] = intern_instance(?ti, 1::sess.ModuleId, 0::id.DeclId, ?a2[0], 2);
+    if (is_err[TypeId, str](r4)) { dnit(?ti); ret 1; }
+    if (unwrap_ok[TypeId, str](r1) == unwrap_ok[TypeId, str](r4)) { dnit(?ti); ret 1; }
+
+    dnit(?ti);
+    ret 0;
+}
+
+test "type: type_equals_signatures distinguishes variadic, param, and TYPE_NIL boundaries (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val ti_r: Result[TypeInterner, str] = init(?alloc);
+    if (is_err[TypeInterner, str](ti_r)) { ret 1; }
+    var ti: TypeInterner = unwrap_ok[TypeInterner, str](ti_r);
+
+    val i32_id: TypeId = unwrap[TypeId](prim(?ti, TYPE_I32));
+    val i64_id: TypeId = unwrap[TypeId](prim(?ti, TYPE_I64));
+
+    var pi32: [1]TypeId;
+    pi32[0] = i32_id;
+    var pi64: [1]TypeId;
+    pi64[0] = i64_id;
+
+    # fun(i32)->void non-variadic, interned twice → same TypeId via dedup
+    val ra: Result[TypeId, str] = intern_function(?ti, TYPE_NIL, ?pi32[0], 1, false);
+    val rb: Result[TypeId, str] = intern_function(?ti, TYPE_NIL, ?pi32[0], 1, true);
+    val rc: Result[TypeId, str] = intern_function(?ti, TYPE_NIL, ?pi32[0], 1, false);
+    val rd: Result[TypeId, str] = intern_function(?ti, TYPE_NIL, ?pi64[0], 1, false);
+    if (is_err[TypeId, str](ra)) { dnit(?ti); ret 1; }
+    if (is_err[TypeId, str](rb)) { dnit(?ti); ret 1; }
+    if (is_err[TypeId, str](rc)) { dnit(?ti); ret 1; }
+    if (is_err[TypeId, str](rd)) { dnit(?ti); ret 1; }
+
+    val tid_a: TypeId = unwrap_ok[TypeId, str](ra);
+    val tid_b: TypeId = unwrap_ok[TypeId, str](rb);
+    val tid_c: TypeId = unwrap_ok[TypeId, str](rc);
+    val tid_d: TypeId = unwrap_ok[TypeId, str](rd);
+
+    # a vs b: differ only on variadic → not equal
+    if (type_equals_signatures(?ti, tid_a, tid_b))  { dnit(?ti); ret 1; }
+    # a vs c: identical signatures → equal (deduped to same TypeId)
+    if (!type_equals_signatures(?ti, tid_a, tid_c)) { dnit(?ti); ret 1; }
+    # a vs d: differ on param type → not equal
+    if (type_equals_signatures(?ti, tid_a, tid_d))  { dnit(?ti); ret 1; }
+    # a vs TYPE_NIL sentinel: not equal (non-FUN or out-of-range)
+    if (type_equals_signatures(?ti, tid_a, TYPE_NIL)) { dnit(?ti); ret 1; }
+
+    dnit(?ti);
+    ret 0;
+}
+
+test "type: is_integer/is_numeric/is_float pin kind boundaries against va_list and array (#1242)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val ti_r: Result[TypeInterner, str] = init(?alloc);
+    if (is_err[TypeInterner, str](ti_r)) { ret 1; }
+    var ti: TypeInterner = unwrap_ok[TypeInterner, str](ti_r);
+
+    val ptr_id: TypeId = unwrap[TypeId](prim(?ti, TYPE_PTR));
+    val u8_id:  TypeId = unwrap[TypeId](prim(?ti, TYPE_U8));
+    val i64_id: TypeId = unwrap[TypeId](prim(?ti, TYPE_I64));
+    val f32_id: TypeId = unwrap[TypeId](prim(?ti, TYPE_F32));
+
+    val va_r: Result[TypeId, str] = intern_va_list(?ti);
+    if (is_err[TypeId, str](va_r)) { dnit(?ti); ret 1; }
+    val va_id: TypeId = unwrap_ok[TypeId, str](va_r);
+
+    val arr_r: Result[TypeId, str] = intern_array(?ti, u8_id, 4);
+    if (is_err[TypeId, str](arr_r)) { dnit(?ti); ret 1; }
+    val arr_id: TypeId = unwrap_ok[TypeId, str](arr_r);
+
+    # va_list is neither integer, numeric, nor float
+    if (is_integer(?ti, va_id))  { dnit(?ti); ret 1; }
+    if (is_numeric(?ti, va_id))  { dnit(?ti); ret 1; }
+    if (is_float(?ti, va_id))    { dnit(?ti); ret 1; }
+    # ptr is not an integer
+    if (is_integer(?ti, ptr_id)) { dnit(?ti); ret 1; }
+    # u8 and i64 are integers
+    if (!is_integer(?ti, u8_id))  { dnit(?ti); ret 1; }
+    if (!is_integer(?ti, i64_id)) { dnit(?ti); ret 1; }
+    # f32 is a float
+    if (!is_float(?ti, f32_id))  { dnit(?ti); ret 1; }
+    # array is not an integer
+    if (is_integer(?ti, arr_id)) { dnit(?ti); ret 1; }
+
+    dnit(?ti);
+    ret 0;
 }


### PR DESCRIPTION
## Summary

Implements specs A1–A9 from the Group A `fe-sema` selection in #1242.

### Per-spec disposition

| Spec | Status | Notes |
|---|---|---|
| A1 — `intern_function` dedup | done | `type.mach` — same-signature → same TypeId; variadic flip → different; param-type flip → different |
| A2 — `intern_instance` dedup | done | `type.mach` — same (origin,decl,args) → same TypeId; different arg type or count → different (Map-monomorphisation regression class) |
| A3 — `type_equals_signatures` | done | `type.mach` — variadic boundary, identical deduped, param-type differ, TYPE_NIL sentinel |
| A4 — `is_integer`/`is_numeric`/`is_float` | done | `type.mach` — va_list and array excluded; ptr excluded from integer; u8/i64 included; f32 float |
| A5 — `eval_lit_char` | done | `comptime.mach` — `\n`, `\t`, `\\`, `\0`, `\'` escape decoding; multi-char, empty, unterminated rejection |
| A6 — `eval_lit_float` | done | `comptime.mach` — `1.5e2` (exact), `1.0E-1`/`3.14` (epsilon), `1.` (no fractional), empty rejection |
| A7 — `eval_lit_int` prefix + separator | done | `comptime.mach` — `0b`, `0o` prefixes and `_` separators; bare-prefix error paths |
| A8 — `bind`/`frame_open`/`frame_close`/`lookup` | done | `comptime.mach` — inner shadow, restore-on-close, unbound returns none, empty-frame no-op |
| A9 — literal boundary integration | done | `.github/tests/literalboundary/` — max-valid literals i8..u64 accepted by sema and round-trip at runtime; modelled on `mixedcmp` |

### Additive non-test changes

Two `use page: std.allocator.page;` imports were added to `src/lang/type.mach` and `src/lang/fe/comptime.mach`. These are purely additive (no existing function is affected) and follow the established pattern in `target.mach` and `ir.mach`. They are required to construct real allocators inside the test blocks for A1–A4 and A8.

### Test counts

- Before: 351 inline tests passing
- After: 359 inline tests passing (+8 new)
- Integration: `bash .github/tests/literalboundary/run.sh <mach>` passes after `mach build .`

### Fixpoint

Test blocks compile into the test binary, not the compiler binary. The compiler binary is byte-identical to the pre-patch compiler, so the self-host fixpoint holds trivially.

Refs #1242