### PR TITLE
test(me-passes): #1242 group C — pass and IR invariants

### DIFF
--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -43,6 +43,8 @@ use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
+use page: std.allocator.page;
+use isa:  mach.lang.target.isa;
 
 use std.system.panic.panic;
 
@@ -655,4 +657,40 @@ fun eq_ir_type(pa: ptr, pb: ptr) bool {
     }
     # IRT_VOID and IRT_PTR are equal by kind alone.
     ret true;
+}
+
+test "ir.type: struct{i8,i64} has size 16, align 8, field offsets 0 and 8" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val itr: Result[IrTypeTable, str] = init(?alloc);
+    if (is_err[IrTypeTable, str](itr)) { ret 1; }
+    var types: IrTypeTable = unwrap_ok[IrTypeTable, str](itr);
+
+    val r8: Result[IrTypeId, str] = intern_int(?types, 8);
+    if (is_err[IrTypeId, str](r8)) { ret 1; }
+    val i8ty: IrTypeId = unwrap_ok[IrTypeId, str](r8);
+    val r64: Result[IrTypeId, str] = intern_int(?types, 64);
+    if (is_err[IrTypeId, str](r64)) { ret 1; }
+    val i64ty: IrTypeId = unwrap_ok[IrTypeId, str](r64);
+
+    var fields: [2]IrTypeId;
+    fields[0] = i8ty;
+    fields[1] = i64ty;
+    val rs: Result[IrTypeId, str] = intern_struct(?types, ?fields[0], 2);
+    if (is_err[IrTypeId, str](rs)) { ret 1; }
+    val stty: IrTypeId = unwrap_ok[IrTypeId, str](rs);
+
+    # minimal target: only pointer_width is needed, and only for IRT_PTR (not used here)
+    var arch: isa.IsaVTable;
+    arch.pointer_width = 8;
+    var tgt: target.Target;
+    tgt.arch = ?arch;
+
+    # natural C-style layout: i8@0 (size 1, align 1), pad to 8, i64@8 (size 8, align 8),
+    # total size rounds to align 8 -> 16
+    if (byte_size(?types, stty, ?tgt) != 16) { ret 1; }
+    if (byte_align(?types, stty, ?tgt) != 8) { ret 1; }
+    if (byte_offset(?types, stty, 0, ?tgt) != 0) { ret 1; }
+    if (byte_offset(?types, stty, 1, ?tgt) != 8) { ret 1; }
+    ret 0;
 }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -1499,6 +1499,43 @@ test "ir.verify: pred consistency catches a right-length wrong-member pred list"
     ret 0;
 }
 
+test "ir.verify: aggregate representation (repr) rejects a non-address-producing add result as a struct operand" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+
+    # intern a single-field struct type to use as an aggregate operand type
+    val sr: Result[ir_type.IrTypeId, str] = ir_type.intern_struct(?env.m.types, ?env.i64ty, 1);
+    if (is_err[ir_type.IrTypeId, str](sr)) { ret 1; }
+    val stty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](sr);
+
+    val b0: id.BlockId = t_block(?env);
+    if (b0 != 0) { ret 1; }
+    builder.set_block(?env.bld, b0);
+
+    # alloca a struct slot — the store needs an address-typed destination
+    val ar: Result[value.Value, str] = builder.emit_alloca(?env.bld, stty, t_ci(?env, 1));
+    if (is_err[value.Value, str](ar)) { ret 1; }
+    val aptr: value.Value = unwrap_ok[value.Value, str](ar);
+
+    # add(c0, c0): a pure arithmetic result — NOT address-producing
+    val c0: value.Value = t_ci(?env, 0);
+    val addv: Result[value.Value, str] = builder.emit_add(?env.bld, c0, c0);
+    if (is_err[value.Value, str](addv)) { ret 1; }
+    val add_val: value.Value = unwrap_ok[value.Value, str](addv);
+
+    # retype the add result to the struct type: VAL_INSTR with ty=stty but from OP_ADD
+    val struct_add: value.Value = value.retype(add_val, stty);
+
+    # store(struct_add, aptr): struct-typed value operand that is not address-producing
+    if (is_err[bool, str](builder.emit_store(?env.bld, struct_add, aptr))) { ret 1; }
+    if (is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
+
+    # repr=true must fire VC_AGG_ADDRESS; always-on (repr=false) must not
+    if (t_count(?env, false, true, VC_AGG_ADDRESS) < 1) { ret 1; }
+    if (t_count(?env, false, false, VC_AGG_ADDRESS) != 0) { ret 1; }
+    ret 0;
+}
+
 test "ir.verify: rebuild_preds keeps both edges of a same-target cbr" {
     var env: TEnv;
     if (!t_env(?env)) { ret 1; }

--- a/src/lang/me/pass/algebraic.mach
+++ b/src/lang/me/pass/algebraic.mach
@@ -57,6 +57,10 @@ use std.types.result.unwrap_err;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 
+use std.allocator.Allocator;
+use page:   std.allocator.page;
+use intern: mach.lang.intern;
+
 use ir:      mach.lang.me.ir;
 use instr:   mach.lang.me.ir.instruction;
 use value:   mach.lang.me.ir.value;
@@ -357,4 +361,42 @@ fun apply_substitutions(fn: *ir.Function, subst: *value.Value, has_sub: *bool, i
         }
         i = i + 1;
     }
+}
+
+test "algebraic: binary identity simplifications — sub self, and/or all-ones, xor self, mul zero" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val r32: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 32);
+    if (is_err[ir_type.IrTypeId, str](r32)) { ret 1; }
+    val i32ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](r32);
+
+    val p0: value.Value = value.param_value(0, i32ty);
+    val zero: value.Value = value.const_int(0, i32ty);
+    val ones: value.Value = value.const_int(0xFFFFFFFF, i32ty);
+    var out: value.Value;
+
+    # sub(p0, p0) -> 0 (x - x identity)
+    if (simplify_binary(?m, instr.OP_SUB, p0, p0, i32ty, ?out) == false) { ret 1; }
+    if (out.kind != value.VAL_CONST_INT || out.data.int_lit != 0) { ret 1; }
+
+    # and(p0, ~0) -> p0 (all-ones mask is identity for AND)
+    if (simplify_binary(?m, instr.OP_AND, p0, ones, i32ty, ?out) == false) { ret 1; }
+    if (out.kind != value.VAL_PARAM || out.data.param_ix != 0) { ret 1; }
+
+    # or(p0, ~0) -> ~0 (all-ones is annihilator for OR)
+    if (simplify_binary(?m, instr.OP_OR, p0, ones, i32ty, ?out) == false) { ret 1; }
+    if (out.kind != value.VAL_CONST_INT || out.data.int_lit != 0xFFFFFFFF) { ret 1; }
+
+    # xor(p0, p0) -> 0 (x ^ x identity)
+    if (simplify_binary(?m, instr.OP_XOR, p0, p0, i32ty, ?out) == false) { ret 1; }
+    if (out.kind != value.VAL_CONST_INT || out.data.int_lit != 0) { ret 1; }
+
+    # mul(p0, 0) -> 0 (zero annihilator)
+    if (simplify_binary(?m, instr.OP_MUL, p0, zero, i32ty, ?out) == false) { ret 1; }
+    if (out.kind != value.VAL_CONST_INT || out.data.int_lit != 0) { ret 1; }
+
+    ret 0;
 }

--- a/src/lang/me/pass/constfold.mach
+++ b/src/lang/me/pass/constfold.mach
@@ -65,6 +65,7 @@ use float:   mach.lang.float;
 use std.allocator.Allocator;
 use page:    std.allocator.page;
 use intern:  mach.lang.intern;
+use builder: mach.lang.me.ir.builder;
 
 # Pass entry. Folds, propagates, and simplifies branches on every function in
 # the module, iterating to a local fixpoint within each function.
@@ -706,6 +707,123 @@ test "constfold: an in-range shift folds, an out-of-range shift does not" {
     if (out.data.int_lit != 32) { ret 1; }
     # 8 << 40: count >= width is target-defined, so it must not fold here.
     if (fold_int_binary(?m, instr.OP_SHL, value.const_int(8, ty), value.const_int(40, ty), ty, ?out)) { ret 1; }
+    ret 0;
+}
+
+test "constfold: sext/zext/trunc of integer constants fold correctly" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val r8: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (is_err[ir_type.IrTypeId, str](r8)) { ret 1; }
+    val i8ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](r8);
+    val r64: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](r64)) { ret 1; }
+    val i64ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](r64);
+
+    var dummy_subst: value.Value;
+    var dummy_has_sub: bool = false;
+    var out: value.Value;
+
+    # sext(0xFF:i8)->i64 = 0xFFFFFFFFFFFFFFFF (sign bit set in 8-bit)
+    var sext_op: value.Value = value.const_int(0xFF, i8ty);
+    var sext_inst: instr.Instruction;
+    sext_inst.kind = instr.OP_SEXT;
+    sext_inst.ty = i64ty;
+    sext_inst.operands = ?sext_op;
+    sext_inst.operand_count = 1;
+    sext_inst.operand_cap = 1;
+    sext_inst.flags = 0;
+    sext_inst.aux_ty = ir_type.IRT_NIL;
+    if (try_fold(?m, ?sext_inst, 0, ?dummy_subst, ?dummy_has_sub, 0, ?out) == false) { ret 1; }
+    if (out.kind != value.VAL_CONST_INT) { ret 1; }
+    if (out.data.int_lit != 0xFFFFFFFFFFFFFFFF) { ret 1; }
+
+    # zext(0xFF:i8)->i64 = 0xFF (zero-extends, no sign fill)
+    var zext_inst: instr.Instruction;
+    zext_inst.kind = instr.OP_ZEXT;
+    zext_inst.ty = i64ty;
+    zext_inst.operands = ?sext_op;
+    zext_inst.operand_count = 1;
+    zext_inst.operand_cap = 1;
+    zext_inst.flags = 0;
+    zext_inst.aux_ty = ir_type.IRT_NIL;
+    if (try_fold(?m, ?zext_inst, 0, ?dummy_subst, ?dummy_has_sub, 0, ?out) == false) { ret 1; }
+    if (out.data.int_lit != 0xFF) { ret 1; }
+
+    # trunc(0x1FF:i64)->i8 = 0xFF (low 8 bits)
+    var trunc_op: value.Value = value.const_int(0x1FF, i64ty);
+    var trunc_inst: instr.Instruction;
+    trunc_inst.kind = instr.OP_TRUNC;
+    trunc_inst.ty = i8ty;
+    trunc_inst.operands = ?trunc_op;
+    trunc_inst.operand_count = 1;
+    trunc_inst.operand_cap = 1;
+    trunc_inst.flags = 0;
+    trunc_inst.aux_ty = ir_type.IRT_NIL;
+    if (try_fold(?m, ?trunc_inst, 0, ?dummy_subst, ?dummy_has_sub, 0, ?out) == false) { ret 1; }
+    if (out.data.int_lit != 0xFF) { ret 1; }
+    ret 0;
+}
+
+test "constfold: simplify_branches prunes a stale phi incoming from the dropped else-edge" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val r64: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](r64)) { ret 1; }
+    val i64ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](r64);
+    val rvt: Result[ir_type.IrTypeId, str] = ir_type.intern_void(?m.types);
+    if (is_err[ir_type.IrTypeId, str](rvt)) { ret 1; }
+    val voidty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](rvt);
+    val rst: Result[ir_type.IrTypeId, str] = ir_type.intern_fn(?m.types, voidty, nil, 0, false);
+    if (is_err[ir_type.IrTypeId, str](rst)) { ret 1; }
+    val sigty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](rst);
+    val rfn: Result[u32, str] = ir.add_function(?m, intern.STR_NIL, sigty, 0);
+    if (is_err[u32, str](rfn)) { ret 1; }
+    val fn: *ir.Function = ?m.functions[0];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    val rb0: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](rb0)) { ret 1; }
+    val entry: id.BlockId = unwrap_ok[id.BlockId, str](rb0);
+    val rb1: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](rb1)) { ret 1; }
+    val b_then: id.BlockId = unwrap_ok[id.BlockId, str](rb1);
+    val rb2: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](rb2)) { ret 1; }
+    val b_else: id.BlockId = unwrap_ok[id.BlockId, str](rb2);
+
+    # entry: CBR(1, b_then, b_else) — condition is always true
+    builder.set_block(?bld, entry);
+    if (is_err[bool, str](builder.emit_cbr(?bld, value.const_int(1, i64ty), b_then, b_else))) { ret 1; }
+
+    # b_then: phi with only a stale incoming from b_else (b_else never branches here);
+    # emit_ret_void keeps the block structurally valid without consuming the phi.
+    builder.set_block(?bld, b_then);
+    val rph: Result[value.Value, str] = builder.emit_phi(?bld, i64ty);
+    if (is_err[value.Value, str](rph)) { ret 1; }
+    val phi: value.Value = unwrap_ok[value.Value, str](rph);
+    if (is_err[bool, str](builder.phi_add_incoming(?bld, phi, b_else, value.const_int(0, i64ty)))) { ret 1; }
+    if (is_err[bool, str](builder.emit_ret_void(?bld))) { ret 1; }
+
+    # b_else: needs a terminator; branches nowhere near b_then
+    builder.set_block(?bld, b_else);
+    if (is_err[bool, str](builder.emit_ret_void(?bld))) { ret 1; }
+
+    if (is_err[bool, str](run(?m))) { ret 1; }
+
+    # simplify_branches turns CBR(1)->BR(b_then); rebuild_preds gives b_then
+    # preds={entry only}; prune_dead_phi_incomings drops the b_else pair.
+    val phi_id: id.InstructionId = phi.data.instr;
+    val phi_inst: *instr.Instruction = ?fn.instrs[phi_id];
+    if (phi_inst.operand_count != 0) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/me/pass/cse.mach
+++ b/src/lang/me/pass/cse.mach
@@ -45,6 +45,12 @@ use std.types.result.unwrap_err;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 
+use std.allocator.Allocator;
+use page:    std.allocator.page;
+use intern:  mach.lang.intern;
+use ir_type: mach.lang.me.ir.type;
+use builder: mach.lang.me.ir.builder;
+
 use ir:    mach.lang.me.ir;
 use instr: mach.lang.me.ir.instruction;
 use value: mach.lang.me.ir.value;
@@ -345,4 +351,79 @@ fun apply_substitutions(fn: *ir.Function, subst: *value.Value, has_sub: *bool, i
         }
         i = i + 1;
     }
+}
+
+# appends an empty non-extern function to `m`; returns its index.
+fun new_fn(m: *ir.Module) u32 {
+    val idx: u32 = m.function_len;
+    var f: ir.Function;
+    f.name  = intern.STR_NIL;
+    f.sig   = ir_type.IRT_NIL;
+    f.flags = 0;
+    m.functions[idx] = f;
+    m.function_len   = m.function_len + 1;
+    ret idx;
+}
+
+test "cse: within-block dedup merges identical adds; epoch boundary prevents cross-block merging" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val r64: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](r64)) { ret 1; }
+    val i64ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](r64);
+
+    val fi: u32 = new_fn(?m);
+    val fn: *ir.Function = ?m.functions[fi];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    val rb0: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](rb0)) { ret 1; }
+    val blk_a: id.BlockId = unwrap_ok[id.BlockId, str](rb0);
+    val rb1: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](rb1)) { ret 1; }
+    val blk_b: id.BlockId = unwrap_ok[id.BlockId, str](rb1);
+
+    val p0: value.Value = value.param_value(0, i64ty);
+    val p1: value.Value = value.param_value(1, i64ty);
+
+    # block A: add_1(p0,p1), add_2(p0,p1) — same, will be merged; mul(add_2, p0); br(blk_b)
+    builder.set_block(?bld, blk_a);
+    val ra1: Result[value.Value, str] = builder.emit_add(?bld, p0, p1);
+    if (is_err[value.Value, str](ra1)) { ret 1; }
+    val add_1: value.Value = unwrap_ok[value.Value, str](ra1);
+    val ra2: Result[value.Value, str] = builder.emit_add(?bld, p0, p1);
+    if (is_err[value.Value, str](ra2)) { ret 1; }
+    val add_2: value.Value = unwrap_ok[value.Value, str](ra2);
+    val rm: Result[value.Value, str] = builder.emit_mul(?bld, add_2, p0);
+    if (is_err[value.Value, str](rm)) { ret 1; }
+    val mul_: value.Value = unwrap_ok[value.Value, str](rm);
+    if (is_err[bool, str](builder.emit_br(?bld, blk_b))) { ret 1; }
+
+    # block B: add_3(p0,p1) — same expression but different epoch; ret(add_3)
+    builder.set_block(?bld, blk_b);
+    val ra3: Result[value.Value, str] = builder.emit_add(?bld, p0, p1);
+    if (is_err[value.Value, str](ra3)) { ret 1; }
+    val add_3: value.Value = unwrap_ok[value.Value, str](ra3);
+    if (is_err[bool, str](builder.emit_ret(?bld, add_3))) { ret 1; }
+
+    if (is_err[bool, str](run(?m))) { ret 1; }
+
+    # add_2 merged to add_1; mul's first operand rewritten to add_1.
+    val mul_inst: *instr.Instruction = ?fn.instrs[mul_.data.instr];
+    val mul_op0: value.Value = mul_inst.operands[0];
+    if (mul_op0.kind != value.VAL_INSTR) { ret 1; }
+    if (mul_op0.data.instr != add_1.data.instr) { ret 1; }
+
+    # add_3 is in a different epoch; the ret still references add_3 directly.
+    val ret_iid: id.InstructionId = fn.blocks[blk_b::u32].terminator;
+    val ret_inst: *instr.Instruction = ?fn.instrs[ret_iid];
+    val ret_op0: value.Value = ret_inst.operands[0];
+    if (ret_op0.kind != value.VAL_INSTR) { ret 1; }
+    if (ret_op0.data.instr != add_3.data.instr) { ret 1; }
+
+    ret 0;
 }

--- a/src/lang/me/pass/dce.mach
+++ b/src/lang/me/pass/dce.mach
@@ -520,3 +520,56 @@ test "dce: an unused phi is removed (must be removable, not just is_pure-kept)" 
     if ((?fn.blocks[join::u32]).phi_count != 0) { ret 1; }
     ret 0;
 }
+
+test "dce: reachability removes a dead block and prunes its phi incoming" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val tr: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret 1; }
+    val i64t: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+
+    val fi: u32 = new_fn(?m);
+    val fn: *ir.Function = ?m.functions[fi];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    val re: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](re)) { ret 1; }
+    val entry: id.BlockId = unwrap_ok[id.BlockId, str](re);
+    val rl: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](rl)) { ret 1; }
+    val b_live: id.BlockId = unwrap_ok[id.BlockId, str](rl);
+    val rd: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](rd)) { ret 1; }
+    val b_dead: id.BlockId = unwrap_ok[id.BlockId, str](rd);
+
+    # entry: unconditional branch to b_live; b_dead is never reached.
+    builder.set_block(?bld, entry);
+    if (is_err[bool, str](builder.emit_br(?bld, b_live))) { ret 1; }
+
+    # b_live: phi with incomings from both entry (live) and b_dead (stale); ret(phi)
+    builder.set_block(?bld, b_live);
+    val rp: Result[value.Value, str] = builder.emit_phi(?bld, i64t);
+    if (is_err[value.Value, str](rp)) { ret 1; }
+    val phi: value.Value = unwrap_ok[value.Value, str](rp);
+    if (is_err[bool, str](builder.phi_add_incoming(?bld, phi, entry, value.const_int(10, i64t)))) { ret 1; }
+    if (is_err[bool, str](builder.phi_add_incoming(?bld, phi, b_dead, value.const_int(20, i64t)))) { ret 1; }
+    if (is_err[bool, str](builder.emit_ret(?bld, phi))) { ret 1; }
+
+    # b_dead: unreachable block that branches to b_live (gives the phi a source to prune)
+    builder.set_block(?bld, b_dead);
+    if (is_err[bool, str](builder.emit_br(?bld, b_live))) { ret 1; }
+
+    if (is_err[bool, str](run(?m))) { ret 1; }
+
+    # b_dead removed; exactly entry + b_live remain.
+    if (fn.block_count != 2) { ret 1; }
+    # b_live is now block 1; its phi has only the entry incoming (2 operands: one pair).
+    val phi_id: id.InstructionId = fn.blocks[1].phis[0];
+    val phi_inst: *instr.Instruction = ?fn.instrs[phi_id];
+    if (phi_inst.operand_count != 2) { ret 1; }
+    ret 0;
+}

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -35,6 +35,11 @@ use std.types.result.unwrap_err;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 
+use std.allocator.Allocator;
+use page:    std.allocator.page;
+use intern:  mach.lang.intern;
+use builder: mach.lang.me.ir.builder;
+
 use ir:      mach.lang.me.ir;
 use instr:   mach.lang.me.ir.instruction;
 use value:   mach.lang.me.ir.value;
@@ -869,5 +874,45 @@ fun replace_value_uses(caller: *ir.Function, old_id: id.InstructionId, replaceme
 # carries, matching the builder's terminator construction.
 fun void_ty(m: *ir.Module) Result[ir_type.IrTypeId, str] {
     ret ir_type.intern_void(?m.types);
+}
+
+test "inline: mark_recursive flags a direct self-calling function as recursive" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val mr: Result[ir.Module, str] = ir.init_module(?alloc, intern.STR_NIL);
+    if (is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = unwrap_ok[ir.Module, str](mr);
+    val rvt: Result[ir_type.IrTypeId, str] = ir_type.intern_void(?m.types);
+    if (is_err[ir_type.IrTypeId, str](rvt)) { ret 1; }
+    val voidty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](rvt);
+    val rst: Result[ir_type.IrTypeId, str] = ir_type.intern_fn(?m.types, voidty, nil, 0, false);
+    if (is_err[ir_type.IrTypeId, str](rst)) { ret 1; }
+    val sigty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](rst);
+    val rfn: Result[u32, str] = ir.add_function(?m, intern.STR_NIL, sigty, 0);
+    if (is_err[u32, str](rfn)) { ret 1; }
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, ?m.functions[0]);
+
+    val rb: Result[id.BlockId, str] = builder.new_block(?bld);
+    if (is_err[id.BlockId, str](rb)) { ret 1; }
+    val b0: id.BlockId = unwrap_ok[id.BlockId, str](rb);
+    builder.set_block(?bld, b0);
+
+    # direct self-call: callee is function 0 (itself)
+    val callee: value.Value = value.fn_value(0, sigty);
+    val rc: Result[value.Value, str] = builder.emit_call(?bld, callee, nil, 0, voidty);
+    if (is_err[value.Value, str](rc)) { ret 1; }
+    if (is_err[bool, str](builder.emit_ret_void(?bld))) { ret 1; }
+
+    val rr: Result[*bool, str] = allocate[bool](m.alloc, 1::usize);
+    if (is_err[*bool, str](rr)) { ret 1; }
+    val recursive: *bool = unwrap_ok[*bool, str](rr);
+    recursive[0] = false;
+    val rm: Result[bool, str] = mark_recursive(?m, recursive);
+    if (is_err[bool, str](rm)) { ret 1; }
+
+    if (recursive[0] == false) { ret 1; }
+    ret 0;
 }
 


### PR DESCRIPTION
## Summary

Implements specs C1–C8 from issue #1242 as inline `test` blocks in the files under test. Zero changes to non-test code.

| Spec | File | Test |
|------|------|------|
| C1 | `me/pass/constfold.mach` | `sext/zext/trunc of integer constants fold correctly` |
| C2 | `me/pass/constfold.mach` | `simplify_branches prunes a stale phi incoming from the dropped else-edge` |
| C3 | `me/pass/algebraic.mach` | `binary identity simplifications — sub self, and/or all-ones, xor self, mul zero` |
| C4 | `me/pass/cse.mach` | `within-block dedup merges identical adds; epoch boundary prevents cross-block merging` |
| C5 | `me/pass/dce.mach` | `reachability removes a dead block and prunes its phi incoming` |
| C6 | `me/ir/type.mach` | `struct{i8,i64} has size 16, align 8, field offsets 0 and 8` |
| C7 | `me/pass/inline.mach` | `mark_recursive flags a direct self-calling function as recursive` |
| C8 | `me/ir/verify.mach` | `aggregate representation (repr) rejects a non-address-producing add result as a struct operand` |

## Verification

- `mach build .` clean
- `mach test .` all pass (8 new tests)
- `mach build . --release --verify-ir` clean
- Byte-identical fixpoint confirmed

Refs #1242