### PR TITLE
fix(asm): inline-asm comments opaque to the instruction parser

### DIFF
--- a/.github/tests/asmcomment/app/mach.toml
+++ b/.github/tests/asmcomment/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "asmcomment"
+name = "inline-asm comment regression — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "linux"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/asmcomment"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/asmcomment/app/src/main.mach
+++ b/.github/tests/asmcomment/app/src/main.mach
@@ -1,0 +1,32 @@
+use std.runtime.linux.x86_64;
+
+# Inline-asm comment regression (#1297). a comment inside an `asm` block must be
+# opaque to the instruction parser no matter its bytes. before the fix the body
+# was split into statements on `;` and scanned for `{name}` bindings *before*
+# comments were stripped, so a comment containing `;` produced a phantom
+# instruction (`encode: unknown x86_64 inline-asm instruction`) and a comment
+# containing `{...}` was misread as a local binding (`unknown local in inline
+# asm`). the `%` / backtick named in the issue were incidental.
+
+# add_via_asm computes a + b through inline asm whose comments — both whole-line
+# and trailing — carry every byte that used to break the parser: `;`, `{...}`,
+# `%`, backtick, and quotes. with the fix they are stripped wholesale and the
+# instructions still encode, so the result is exactly a + b.
+fun add_via_asm(a: i64, b: i64) i64 {
+    var result: i64 = 0;
+    asm x86_64 {
+        # kitchen sink: RSP%16==8 ; nop {phantom} `tick` "q" 'c' : , } end
+        mov rax, {a}       # trailing: percent % backtick `x` ; brace {bad} done
+        add rax, {b}       # RSP%16 alignment ; second clause {also_bad}
+        mov {result}, rax
+    }
+    ret result;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # add_via_asm(40, 2) == 42; a phantom instruction or stray binding fails the
+    # build, and a mis-substitution would corrupt the result.
+    if (add_via_asm(40, 2) != 42) { ret 1; }
+    ret 0;
+}

--- a/.github/tests/asmcomment/run.sh
+++ b/.github/tests/asmcomment/run.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# inline-asm comment regression test (#1297): a comment inside an `asm { }` block
+# was not opaque to the instruction parser. the body was split on `;` and scanned
+# for `{name}` bindings before `#` comments were stripped, so a comment holding a
+# `;` became a phantom instruction and one holding `{...}` became a bogus local
+# binding — either aborted the build. this builds a program whose asm carries a
+# kitchen-sink comment (`;`, `{...}`, `%`, backtick, quotes) and runs it; main
+# exits 0 only when the asm encoded and computed the right value.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL asmcomment: native build failed (a comment's bytes leaked into the instruction parser)" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/asmcomment"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS asmcomment: a kitchen-sink asm comment is opaque to the instruction parser"
+    exit 0
+fi
+
+echo "FAIL asmcomment: inline-asm comment miscompiled (exit $code)" >&2
+exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Inline-asm comments are now opaque to the instruction parser regardless of
+  their bytes. A comment containing `;` was split into a phantom instruction
+  and one containing `{...}` was misread as a local binding; comments are now
+  stripped to end-of-line when the asm body is materialized, before any
+  substitution or statement tokenization (#1297).
+
 ## [1.3.0] - 2026-06-11
 
 Correctness and foundations release. A full-compiler audit (125 findings,

--- a/doc/language/asm.md
+++ b/doc/language/asm.md
@@ -18,7 +18,7 @@ asm <isa> {
 - The ISA tag is mandatory. Bare `asm { ... }` does not exist.
 - The tag comes from a closed set: `x86_64`, `aarch64`. Only `x86_64` has a working code generator today; `aarch64` is recognized for portable target-conditional source but is not yet a buildable target (see issue #1045).
 - Each line is an instruction in the ISA's native syntax.
-- `#` introduces a line comment.
+- `#` introduces a line comment: everything from `#` to the end of the line is ignored, whatever it contains (`;`, `{}`, `%`, and so on are all inert inside a comment).
 
 ## Operand substitution
 

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -30,6 +30,7 @@ use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 
+use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
@@ -361,6 +362,31 @@ fun lower_decl_stmt(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] 
     ret ok[bool, str](true);
 }
 
+# strip_asm_comments: allocate a NUL-terminated copy of the `len`-byte asm body
+# at `src + offset` with each `#` line comment removed through the end of its line;
+# the line's newline is kept so statement boundaries survive. the copy is sized to
+# `len + 1` (its longest possible form) so the caller frees exactly that.
+fun strip_asm_comments(alloc: *Allocator, src: str, offset: usize, len: usize) Result[str, str] {
+    val r: Result[*u8, str] = allocate[u8](alloc, len + 1);
+    if (is_err[*u8, str](r)) { ret err[str, str](unwrap_err[*u8, str](r)); }
+    val out: *u8 = unwrap_ok[*u8, str](r);
+    var i: usize = 0;
+    var o: usize = 0;
+    for (i < len) {
+        val c: u8 = src[offset + i];
+        if (c == '#'::char) {
+            # drop the comment through (but not including) the line's newline.
+            for (i < len && src[offset + i] != '\n'::char) { i = i + 1; }
+            cnt;
+        }
+        out[o] = c;
+        o = o + 1;
+        i = i + 1;
+    }
+    out[o] = 0;
+    ret ok[str, str](out::str);
+}
+
 # lowers an inline-asm statement to an OP_ASM instruction and registers its
 # `IrAsm` payload (interned ISA tag + raw body) in `Function.asm`, keyed by
 # the instruction id. operand / clobber inference happens in the back end,
@@ -378,7 +404,15 @@ fun lower_asm(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] {
     if (is_err[intern.StrId, str](isa_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](isa_r)); }
     val isa_id: intern.StrId = unwrap_ok[intern.StrId, str](isa_r);
 
-    val body_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, txt, s.data.asm_.body);
+    # strip `#` line comments before interning so a comment is opaque to bind
+    # collection, local substitution, statement tokenization, and clobber
+    # inference regardless of its bytes (a comment may hold `;`, `{`, `%`, ...).
+    val span: token.Span = s.data.asm_.body;
+    val strip_r: Result[str, str] = strip_asm_comments(ctx.s.alloc, txt, span.offset, span.len);
+    if (is_err[str, str](strip_r)) { ret err[bool, str](unwrap_err[str, str](strip_r)); }
+    val stripped: str = unwrap_ok[str, str](strip_r);
+    val body_r: Result[intern.StrId, str] = intern.intern_bytes(?ctx.s.interner, stripped, str_len(stripped));
+    deallocate[u8](ctx.s.alloc, stripped::*u8, span.len + 1);
     if (is_err[intern.StrId, str](body_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](body_r)); }
     val body_id: intern.StrId = unwrap_ok[intern.StrId, str](body_r);
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -4188,8 +4188,9 @@ val ASMOP_SYM:  u8 = 4;
 #
 # resolves the body's `{name}` references to `[rbp+off]` text using the carried
 # slot-vreg bindings and the laid-out frame, then tokenizes the substituted body
-# on newlines / `;`, strips `#` comments, and parses + encodes each instruction
-# through the existing per-mnemonic encoders — mirroring cmach's
+# on newlines / `;` and parses + encodes each instruction through the existing
+# per-mnemonic encoders (`#` comments were stripped at lower time) — mirroring
+# cmach's
 # `masm_x86_parse_inline_asm`. a `call` / `jmp` / bare-symbol operand records a
 # PC32 relocation against the named symbol. an unknown mnemonic or malformed
 # operand is a hard error rather than silently dropped.
@@ -4611,10 +4612,11 @@ fun arg_str(tok: str, mlen: usize) str {
 }
 
 # encode_asm_text: tokenize the (already `{name}`-substituted) asm body on
-# newlines / `;`, strip `#` comments and surrounding whitespace, then parse and
-# encode each instruction. mirrors `masm_x86_parse_inline_asm`. each emitted
-# instruction is written through `encode_inst`; a `call` / `jmp` / bare-symbol
-# operand records a PC32 relocation against the named symbol.
+# newlines / `;` and trim surrounding whitespace, then parse and encode each
+# instruction. `#` line comments are stripped when the body is materialized
+# (`lower_asm`), so none reach here. mirrors `masm_x86_parse_inline_asm`. each
+# emitted instruction is written through `encode_inst`; a `call` / `jmp` /
+# bare-symbol operand records a PC32 relocation against the named symbol.
 fun encode_asm_text(st: *EncodeState, fn_base: u32, text: str) Result[bool, str] {
     val len: usize = str_len(text);
     var start: usize = 0;
@@ -4627,9 +4629,8 @@ fun encode_asm_text(st: *EncodeState, fn_base: u32, text: str) Result[bool, str]
         var lo: usize = start;
         for (lo < end && is_asm_space(text[lo])) { lo = lo + 1; }
 
-        # strip an inline '#' comment, then trailing whitespace.
-        var hi: usize = lo;
-        for (hi < end && text[hi] != '#'::char) { hi = hi + 1; }
+        # trim trailing whitespace; comments were stripped at lower time.
+        var hi: usize = end;
         for (hi > lo && is_asm_space(text[hi - 1])) { hi = hi - 1; }
 
         if (hi > lo) {
@@ -4673,8 +4674,8 @@ pub fun asm_clobbers(body: str, gp_out: *u32, fp_out: *u32) {
         for (end < len && body[end] != '\n'::char && body[end] != ';'::char) { end = end + 1; }
         var lo: usize = start;
         for (lo < end && is_asm_space(body[lo])) { lo = lo + 1; }
-        var hi: usize = lo;
-        for (hi < end && body[hi] != '#'::char) { hi = hi + 1; }
+        # trim trailing whitespace; comments were stripped at lower time.
+        var hi: usize = end;
         for (hi > lo && is_asm_space(body[hi - 1])) { hi = hi - 1; }
         if (hi > lo) {
             var line: [256]u8;


### PR DESCRIPTION
## Summary

A comment inside an `asm { }` block was not opaque to the instruction parser. The asm body was split into statements on `;` and scanned for `{name}` bindings **before** `#` comments were stripped, so:

- a comment containing `;` was split, and its post-`;` remainder became a phantom instruction → `error: encode: unknown x86_64 inline-asm instruction`
- a comment containing `{...}` was misread as a `{name}` local binding → `error: lower: unknown local in inline asm '{name}' reference`

The `%` and backtick characters named in #1297 were incidental — the worker's failing `_start` comment also held a `;`/`{`. The real defect is the ordering: comment stripping happened per-statement (per `;`-segment), not per line, and never ran before `{name}` substitution.

## Fix

Strip `#` line comments **once**, when the asm body is materialized in `lower_asm`, before any downstream consumer sees it: bind collection, local substitution, statement tokenization, and clobber inference all now operate on comment-free text. Each comment is removed through the end of its line regardless of content, so a comment's bytes are inert. The now-redundant per-statement `#` handling in `encode_asm_text` and `asm_clobbers` is removed.

## Verification

- `mach build .` clean; byte-identical self-hosting fixpoint holds.
- `mach test .`: 386 unit tests pass.
- Full integration battery (24 suites) passes, including `asmclobber` and all four `win64*` suites.
- New `asmcomment` integration suite (kitchen-sink comment with `;`, `{...}`, `%`, backtick, quotes) fails on the pre-fix compiler and passes after.

Closes #1297