### PR TITLE
fix(diag): remaining MEDIUM/LOW diagnostic quality items from #1046 audit

### DIFF
--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -52,6 +52,11 @@ use std.types.bool.false;
 use std.types.size.usize;
 
 use std.types.string.str;
+use std.types.string.str_len;
+
+use std.types.option.Option;
+use std.types.option.is_some;
+use std.types.option.unwrap;
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -67,7 +72,9 @@ use std.allocator.deallocate;
 use std.allocator.reallocate;
 
 use std.system.panic.panic;
+use mem: std.memory;
 
+use intern: mach.lang.intern;
 use target: mach.lang.target;
 use isa:    mach.lang.target.isa;
 use abi:    mach.lang.target.abi;
@@ -174,6 +181,7 @@ rec BlockSpan {
 
 rec AllocCtx {
     alloc:         *Allocator;
+    interner:      *intern.Interner;
     f:             *mir.MirFunction;
     flat:          *FlatInstr;
     flat_count:    u32;
@@ -225,6 +233,37 @@ rec AllocCtx {
     # slots added later name only spilled vregs, which `is_spilled` rejects before
     # consulting this, so the flag stays correct after the scan.
     vreg_slot_flag:     *bool;
+}
+
+# ctx_fn_name: the allocating function's source name, or "<unknown>" when unresolved.
+fun ctx_fn_name(ctx: *AllocCtx) str {
+    if (ctx.interner == nil) { ret "<unknown>"; }
+    val nm: Option[str] = intern.lookup(ctx.interner, ctx.f.name);
+    if (is_some[str](nm)) { ret unwrap[str](nm); }
+    ret "<unknown>";
+}
+
+# regalloc_msg: build "<prefix><fn-name><suffix>" using the context's allocator.
+# degrades to `fallback` when the function name is unavailable or allocation fails.
+fun regalloc_msg(ctx: *AllocCtx, prefix: str, suffix: str, fallback: str) str {
+    val name: str = ctx_fn_name(ctx);
+    val lp: usize = str_len(prefix);
+    val ln: usize = str_len(name);
+    val ls: usize = str_len(suffix);
+    val total: usize = lp + ln + ls;
+    val r: Result[*u8, str] = allocate[u8](ctx.alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret fallback; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    mem.raw_copy(buf::ptr, prefix::ptr, lp);
+    mem.raw_copy((buf::usize + lp)::ptr, name::ptr, ln);
+    mem.raw_copy((buf::usize + lp + ln)::ptr, suffix::ptr, ls);
+    buf[total] = 0;
+    val ir: Result[intern.StrId, str] = intern.intern(ctx.interner, buf::str);
+    deallocate[u8](ctx.alloc, buf, total + 1);
+    if (is_err[intern.StrId, str](ir)) { ret fallback; }
+    val lo: Option[str] = intern.lookup(ctx.interner, unwrap_ok[intern.StrId, str](ir));
+    if (is_some[str](lo)) { ret unwrap[str](lo); }
+    ret fallback;
 }
 
 # run: allocate physical registers for every function in a MIR module.
@@ -393,6 +432,7 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
 # descriptors (callee-saved, reserved). one live range slot exists per vreg.
 fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) Result[bool, str] {
     ctx.alloc        = m.alloc;
+    ctx.interner     = m.interner;
     ctx.f            = f;
     ctx.flat         = nil;
     ctx.flat_count   = 0;
@@ -2467,7 +2507,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     ops[k] = mir.op_mem_slot(v, 0);
                 } or (is_spilled(ctx, v)) {
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, -1, is_entry, src_pos);
-                    if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str]("regalloc: no free register for spilled destination"); }
+                    if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str](regalloc_msg(ctx, "regalloc: no free register for spilled destination in '", "'", "regalloc: no free register for spilled destination")); }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
                     ops[k] = mir.op_preg(tmp::u32);
                     store_dst_vreg = v;
@@ -2490,7 +2530,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     ops[k] = mir.op_preg(store_dst_tmp::u32);
                 } or (is_spilled(ctx, v)) {
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, -1, is_entry, src_pos);
-                    if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str]("regalloc: no free register for spilled source"); }
+                    if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str](regalloc_msg(ctx, "regalloc: no free register for spilled source in '", "'", "regalloc: no free register for spilled source")); }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
                     val er: Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v);
                     if (is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }
@@ -2516,7 +2556,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     # a spilled pointer value: reload the pointer into a temp so the
                     # base addresses what it points to, not its spill slot.
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, -1, is_entry, src_pos);
-                    if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str]("regalloc: no free register for spilled MEM base"); }
+                    if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str](regalloc_msg(ctx, "regalloc: no free register for spilled MEM base in '", "'", "regalloc: no free register for spilled MEM base")); }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
                     val er: Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v);
                     if (is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }
@@ -2535,7 +2575,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                 val iv: u32 = ops[k].index;
                 if (is_spilled(ctx, iv)) {
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, -1, is_entry, src_pos);
-                    if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str]("regalloc: no free register for spilled MEM index"); }
+                    if (tmp < 0) { free_ops(ctx, ops, n); ret err[bool, str](regalloc_msg(ctx, "regalloc: no free register for spilled MEM index in '", "'", "regalloc: no free register for spilled MEM index")); }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
                     val er: Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, iv);
                     if (is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1294,7 +1294,7 @@ fun patch_module_relocations(s: *sess.Session, out_img: *of.ObjectImage,
         }
 
         val pr: Result[bool, str] =
-            apply_one(s, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va);
+            apply_one(s, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va, r.symbol);
         if (is_err[bool, str](pr)) {
             ret err[bool, str](unwrap_err[bool, str](pr));
         }
@@ -1504,15 +1504,18 @@ fun dynstate_add_fixup(s: *sess.Session, dyn: *DynState, seg_index: u32, seg_off
 # apply_one: write a single resolved relocation into the merged bytes. `abs64`
 # writes a 64-bit little-endian absolute address; `pc32`/`plt32` write a 32-bit
 # little-endian pc-relative displacement. bounds and 32-bit range are checked.
+# `sym_name` is the interned symbol name used in overflow diagnostics; pass
+# `intern.STR_NIL` when the name is unavailable (e.g. in tests).
 fun apply_one(s: *sess.Session, kind: of.RelocKind,
              dst: *u8, patch_off: u32, sec_len: u32,
-             sym_va: u64, addend: i64, patch_va: u64) Result[bool, str] {
+             sym_va: u64, addend: i64, patch_va: u64,
+             sym_name: intern.StrId) Result[bool, str] {
     if (kind == of.RK_ABS64) {
         # bound the patch site in u64: patch_off + width can wrap a u32 for an
         # offset near 0xFFFFFFFF, which would pass a u32 check and then scribble
         # outside the merged buffer.
         if (patch_off::u64 + 8 > sec_len::u64) {
-            ret err[bool, str](overflow_message(s, kind));
+            ret err[bool, str](overflow_message(s, kind, sym_name));
         }
         val value: u64 = sym_va + (addend::u64);
         bin.write_u64_le(dst, patch_off::usize, value);
@@ -1521,11 +1524,11 @@ fun apply_one(s: *sess.Session, kind: of.RelocKind,
 
     if (kind == of.RK_PC32 || kind == of.RK_PLT32) {
         if (patch_off::u64 + 4 > sec_len::u64) {
-            ret err[bool, str](overflow_message(s, kind));
+            ret err[bool, str](overflow_message(s, kind, sym_name));
         }
         val disp: i64 = (sym_va::i64) + addend - (patch_va::i64);
         if (disp > 2147483647 || disp < -2147483648) {
-            ret err[bool, str](overflow_message(s, kind));
+            ret err[bool, str](overflow_message(s, kind, sym_name));
         }
         bin.write_u32_le(dst, patch_off::usize, ((disp::u64) & 0xFFFFFFFF)::u32);
         ret ok[bool, str](true);
@@ -1534,11 +1537,11 @@ fun apply_one(s: *sess.Session, kind: of.RelocKind,
     # abs32s: 32-bit signed absolute.
     if (kind == of.RK_ABS32S) {
         if (patch_off::u64 + 4 > sec_len::u64) {
-            ret err[bool, str](overflow_message(s, kind));
+            ret err[bool, str](overflow_message(s, kind, sym_name));
         }
         val v: i64 = (sym_va::i64) + addend;
         if (v > 2147483647 || v < -2147483648) {
-            ret err[bool, str](overflow_message(s, kind));
+            ret err[bool, str](overflow_message(s, kind, sym_name));
         }
         bin.write_u32_le(dst, patch_off::usize, ((v::u64) & 0xFFFFFFFF)::u32);
         ret ok[bool, str](true);
@@ -1681,9 +1684,17 @@ fun undef_message(s: *sess.Session, name: intern.StrId) str {
     ret "undefined symbol";
 }
 
-# overflow_message: build the "relocation '<kind>' overflows" diagnostic string.
-fun overflow_message(s: *sess.Session, kind: of.RelocKind) str {
-    ret join3(s, "relocation '", of.reloc_kind_name(kind), "' overflows", "relocation overflows");
+# overflow_message: build the "relocation '<kind>' to '<sym>' overflows" diagnostic
+# string. includes the symbol name when `sym_name` is not `intern.STR_NIL` and can
+# be resolved; degrades to the kind-only form when the name is unavailable.
+fun overflow_message(s: *sess.Session, kind: of.RelocKind, sym_name: intern.StrId) str {
+    val kn: str = of.reloc_kind_name(kind);
+    val sno: Option[str] = intern.lookup(?s.interner, sym_name);
+    if (is_some[str](sno)) {
+        val pre: str = join3(s, "relocation '", kn, "' to '", "relocation overflows");
+        ret join3(s, pre, unwrap[str](sno), "' overflows", "relocation overflows");
+    }
+    ret join3(s, "relocation '", kn, "' overflows", "relocation overflows");
 }
 
 # unsupported_message: build the "relocation '<kind>' not supported" string.
@@ -1854,16 +1865,16 @@ test "linker: apply_one pc32/plt32 boundary range checks (#1242)" {
     dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
 
     # max valid positive displacement: must succeed and round-trip
-    val r1: Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0);
+    val r1: Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0, intern.STR_NIL);
     if (is_err[bool, str](r1)) { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x7FFFFFFF) { ret 1; }
 
     # one past the positive boundary: disp=2147483648 > INT32_MAX
-    val r2: Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x80000000, 0, 0);
+    val r2: Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL);
     if (!is_err[bool, str](r2)) { ret 1; }
 
     # negative underflow via plt32: patch_va=0x80000000, addend=-1 -> disp=-2147483649 < INT32_MIN
-    val r3: Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0, -1, 0x80000000);
+    val r3: Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0, -1, 0x80000000, intern.STR_NIL);
     if (!is_err[bool, str](r3)) { ret 1; }
 
     ret 0;
@@ -1881,23 +1892,23 @@ test "linker: apply_one abs32s boundary range checks (#1242)" {
     dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
 
     # sym_va=0x7FFFFFFF, addend=0 -> v=2147483647, within range; must round-trip
-    val r1: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0);
+    val r1: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0, intern.STR_NIL);
     if (is_err[bool, str](r1)) { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x7FFFFFFF) { ret 1; }
 
     # sym_va=0x80000000 -> v=2147483648 > INT32_MAX
-    val r2: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x80000000, 0, 0);
+    val r2: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL);
     if (!is_err[bool, str](r2)) { ret 1; }
 
     # sym_va=0, addend=INT32_MIN -> v=-2147483648, at boundary (valid); encodes as 0x80000000
     dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0;
-    val r3: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, -2147483648, 0);
+    val r3: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, -2147483648, 0, intern.STR_NIL);
     if (is_err[bool, str](r3)) { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x80000000) { ret 1; }
 
     # addend=INT32_MIN-1 -> v=-2147483649 < INT32_MIN
     val below_min: i64 = -2147483648 - 1;
-    val r4: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, below_min, 0);
+    val r4: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, below_min, 0, intern.STR_NIL);
     if (!is_err[bool, str](r4)) { ret 1; }
 
     ret 0;

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -591,7 +591,10 @@ pub fun eval_lit_int(source: str, span: token.Span) Result[CTValue, str] {
             brk;
         }
         or {
-            ret err[CTValue, str]("invalid digit in integer literal");
+            if (base == 16) { ret err[CTValue, str]("invalid digit in hexadecimal literal (expected 0-9, a-f, A-F)"); }
+            if (base == 2)  { ret err[CTValue, str]("invalid digit in binary literal (expected 0 or 1)"); }
+            if (base == 8)  { ret err[CTValue, str]("invalid digit in octal literal (expected 0-7)"); }
+            ret err[CTValue, str]("invalid digit in decimal literal (expected 0-9)");
         }
     }
 
@@ -773,7 +776,7 @@ fun intern_decoded(interner: *intern.Interner, inner: StrView) Result[intern.Str
 
 # decodes a single character (or escape sequence) from a string view
 fun decode_char(inner: StrView) Result[u8, str] {
-    if (inner.len == 0) { ret err[u8, str]("empty character literal"); }
+    if (inner.len == 0) { ret err[u8, str]("empty character literal; must contain exactly one character or escape"); }
     if (inner.data[0] != '\\') {
         if (inner.len != 1) { ret err[u8, str]("character literal must contain exactly one character"); }
         ret ok[u8, str](inner.data[0]);
@@ -808,7 +811,7 @@ fun decode_escape(p: *u8, len: usize, out_consumed: *usize) Result[u8, str] {
         @out_consumed = 4;
         ret ok[u8, str]((hi * 16 + lo)::u8);
     }
-    ret err[u8, str]("unknown escape sequence");
+    ret err[u8, str]("unknown escape sequence (valid: \\n \\t \\r \\\\ \\' \\\" \\0 \\xHH)");
 }
 
 fun hex_digit(c: u8) i64 {

--- a/src/lang/fe/parser/iasm.mach
+++ b/src/lang/fe/parser/iasm.mach
@@ -40,7 +40,7 @@ pub fun parse_asm(p: *parser.Parser) id.StmtId {
     } or {
         val lbrace: token.Token = parser.advance(p);
         val body_start: usize = lbrace.span.offset + lbrace.span.len;
-        collect_body(p, body_start, ?body, ?end_span);
+        collect_body(p, body_start, start.span, ?body, ?end_span);
     }
 
     var asm_stmt: stmt.StmtAsm;
@@ -58,9 +58,10 @@ pub fun parse_asm(p: *parser.Parser) id.StmtId {
 # ---
 # p:            parser state; current token is the first token inside the body, after `{`
 # start_offset: byte offset immediately after the opening `{`
+# asm_span:     span of the opening `asm` keyword, used for the unterminated-body diagnostic
 # body:         out-parameter receiving the span covering the raw body text
 # end_span:     out-parameter receiving the span of the closing `}`
-fun collect_body(p: *parser.Parser, start_offset: usize, body: *token.Span, end_span: *token.Span) {
+fun collect_body(p: *parser.Parser, start_offset: usize, asm_span: token.Span, body: *token.Span, end_span: *token.Span) {
     var depth:       usize = 1;
     var last_offset: usize = start_offset;
 
@@ -90,7 +91,7 @@ fun collect_body(p: *parser.Parser, start_offset: usize, body: *token.Span, end_
         parser.advance(p);
     }
 
-    parser.error_at_current(p, "unterminated asm body");
+    parser.error_at(p, asm_span, "unterminated asm body");
     body.offset     = start_offset;
     body.len        = last_offset - start_offset;
     end_span.offset = last_offset;

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -593,7 +593,7 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
         val sym: *resolve.Symbol = unwrap[*resolve.Symbol](so);
         if (sym.kind == resolve.SYM_PARAM) {
             if ((sym.flags & resolve.SYM_FLAG_COMPTIME) == 0) {
-                ctxm.report(sc, e.span, "comptime `$if` gate cannot reference a runtime parameter");
+                check.report_named(sc, e.span, "comptime `$if` gate cannot reference runtime parameter '", sym.name, "'", "comptime `$if` gate cannot reference a runtime parameter");
             }
             ret;
         }
@@ -608,16 +608,16 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
             val is_module: bool = sym.kind == resolve.SYM_IMPORTED
                                 || (sym.flags & resolve.SYM_FLAG_MODULE) != 0;
             if (!is_module) {
-                ctxm.report(sc, e.span, "comptime `$if` gate cannot reference a runtime value");
+                check.report_named(sc, e.span, "comptime `$if` gate cannot reference runtime value '", sym.name, "'", "comptime `$if` gate cannot reference a runtime value");
                 ret;
             }
             val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
             if (is_err[comptime.CTValue, str](ev) && !check.imported_module_const_sym(sc, sym)) {
-                ctxm.report(sc, e.span, "comptime `$if` gate cannot reference a runtime value");
+                check.report_named(sc, e.span, "comptime `$if` gate cannot reference runtime value '", sym.name, "'", "comptime `$if` gate cannot reference a runtime value");
             }
             ret;
         }
-        ctxm.report(sc, e.span, "comptime `$if` gate cannot reference a runtime value");
+        check.report_named(sc, e.span, "comptime `$if` gate cannot reference runtime value '", sym.name, "'", "comptime `$if` gate cannot reference a runtime value");
         ret;
     }
 

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -269,6 +269,34 @@ pub fun fun_has_comptime_param(ctx: *lower.LowerContext, d: *adecl.Decl) bool {
     ret false;
 }
 
+# reports a duplicate test label, naming the label text when lookup succeeds.
+fun report_dup_test_label(ctx: *lower.LowerContext, span: token.Span, label: intern.StrId) {
+    val no: Option[str] = intern.lookup(?ctx.s.interner, label);
+    if (is_none[str](no)) {
+        diag.error(?ctx.s.diags, ctx.a.file_id, span, "duplicate test label in this module");
+        ret;
+    }
+    val name: str = unwrap[str](no);
+    val prefix: str = "duplicate test label ";
+    val suffix: str = " in this module";
+    val pn: usize = str_len(prefix);
+    val nn: usize = str_len(name);
+    val sn: usize = str_len(suffix);
+    val total: usize = pn + nn + sn;
+    val r: Result[*char, str] = allocate[char](ctx.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        diag.error(?ctx.s.diags, ctx.a.file_id, span, "duplicate test label in this module");
+        ret;
+    }
+    val buf: str = unwrap_ok[*char, str](r);
+    mem.raw_copy(buf::ptr, prefix::ptr, pn);
+    mem.raw_copy((buf::usize + pn)::ptr, name::ptr, nn);
+    mem.raw_copy((buf::usize + pn + nn)::ptr, suffix::ptr, sn);
+    buf[total] = 0;
+    diag.error(?ctx.s.diags, ctx.a.file_id, span, buf);
+    deallocate[char](ctx.s.alloc, buf, total + 1);
+}
+
 # lowers a `test "label" { ... }` decl as a zero-parameter, i32-returning
 # function tagged FN_FLAG_TEST so the test runner can iterate it. a test body
 # returns an integer process status (`ret 0` / `ret 1`), so the lowered
@@ -297,7 +325,7 @@ fun lower_test(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl) Result
     # symbol with no file / line. catch it here with a source-located diagnostic on
     # the label and skip the duplicate (the accumulated diagnostic gates the build).
     if (is_some[u32](ir.lookup_function(ctx.m, name))) {
-        diag.error(?ctx.s.diags, ctx.a.file_id, d.data.test_.label, "duplicate test label in this module");
+        report_dup_test_label(ctx, d.data.test_.label, bare);
         ret ok[bool, str](true);
     }
 

--- a/src/lang/me/lower/testrunner.mach
+++ b/src/lang/me/lower/testrunner.mach
@@ -395,7 +395,7 @@ fun emit_write_helper(c: *Ctx) Result[bool, str] {
     val wfn: os.RunnerWriteFn = c.tgt.os.runner_write::os.RunnerWriteFn;
     val spec_o: Option[os.RunnerWrite] = wfn(c.tgt.arch_id);
     if (is_none[os.RunnerWrite](spec_o)) {
-        ret err[bool, str]("mach test: the selected target has no freestanding test-runner write primitive (only linux/x86_64 is supported; the windows/darwin runner is tracked by #1292)");
+        ret err[bool, str]("mach test is not yet supported on this target — only linux/x86_64 is currently available");
     }
     val spec: os.RunnerWrite = unwrap[os.RunnerWrite](spec_o);
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2470,8 +2470,8 @@ rec EncodeState {
 # m:     the fully-resolved MIR module (post isel / regalloc / frame)
 # ret:   the populated enc.EncoderOutput (owned arrays), or an error string
 pub fun encode_x64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Result[enc.EncoderOutput, str] {
-    if (tgt == nil) { ret err[enc.EncoderOutput, str]("encode.encode_x64: nil target"); }
-    if (m == nil)   { ret err[enc.EncoderOutput, str]("encode.encode_x64: nil mir module"); }
+    if (tgt == nil) { ret err[enc.EncoderOutput, str]("encode: nil target"); }
+    if (m == nil)   { ret err[enc.EncoderOutput, str]("encode: nil mir module"); }
 
     var st: EncodeState;
     st.alloc       = m.alloc;
@@ -2804,7 +2804,7 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     # rejected loudly rather than silently dropped — a dropped instruction would
     # leave a gap the surrounding code falls through.
     if (inst_size <= 0) {
-        ret err[bool, str]("encode: concrete opcode produced no bytes (unmodeled operand shape)");
+        ret err[bool, str](enc_named_message(st, "internal compiler error: concrete opcode produced no bytes in '", enc_fn_name(st, f), "'", "internal compiler error: concrete opcode produced no bytes"));
     }
 
     if (has_block) {
@@ -3093,7 +3093,7 @@ fun encode_float_arith(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Re
     }
     val w: u8 = mi.width;
     if (w != 4 && w != 8) {
-        ret err[bool, str]("encode: float arithmetic has a non-float operand width");
+        ret err[bool, str]("internal compiler error: float arithmetic has a non-float operand width (expected 4 or 8)");
     }
 
     val rd: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], 16);
@@ -3147,7 +3147,7 @@ fun encode_float_neg(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Resu
     }
     val w: u8 = mi.width;
     if (w != 4 && w != 8) {
-        ret err[bool, str]("encode: float negate has a non-float operand width");
+        ret err[bool, str]("internal compiler error: float negate has a non-float operand width (expected 4 or 8)");
     }
 
     val rd: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], 16);
@@ -3593,7 +3593,7 @@ fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Resu
     }
     val w: u8 = mi.width;
     if (w != 4 && w != 8) {
-        ret err[bool, str]("encode: float comparison has a non-float operand width");
+        ret err[bool, str]("internal compiler error: float comparison has a non-float operand width (expected 4 or 8)");
     }
     val cc: u8 = mi.src_width;
 
@@ -4958,7 +4958,7 @@ fun emit_two_op(st: *EncodeState, opcode: u16, args: str, extra_flags: u16) Resu
         if (has_stack_slot_base_misuse(args)) {
             ret err[bool, str]("encode: inline-asm stack-slot binding cannot be used as a memory base (nested [[rbp+disp]]/[[rbp-disp]]); load it into a register first");
         }
-        ret err[bool, str]("encode: malformed inline-asm two-operand instruction");
+        ret err[bool, str](enc_named_message(st, "encode: malformed inline-asm two-operand instruction '", args, "'", "encode: malformed inline-asm two-operand instruction"));
     }
 
     # the operation width is the width of whichever side is a register (a memory

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -85,6 +85,7 @@ use std.allocator.allocate;
 use std.allocator.zallocate;
 use std.allocator.deallocate;
 
+use os:     std.system.os;
 use target: mach.lang.target.resolved;
 use x64:    mach.lang.target.isa.x64;
 use mir:    mach.lang.be.codegen.mir;
@@ -138,6 +139,26 @@ pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Res
     ret ok[bool, str](true);
 }
 
+# write_opcode_ice: writes "internal compiler error: unhandled MIR opcode <N>\n"
+# to stderr before an ICE return so the numeric opcode is visible in crash logs.
+fun write_opcode_ice(opcode: u32) {
+    os.write(os.STDERR_FD, "internal compiler error: unhandled MIR opcode ", 46);
+    var buf: [16]u8;
+    var len: usize = 0;
+    var v: u32 = opcode;
+    if (v == 0) { buf[0] = '0'; len = 1; }
+    or {
+        var tmp: [16]u8;
+        var t: usize = 0;
+        for (v > 0) { tmp[t] = (v % 10)::u8 + '0'; v = v / 10; t = t + 1; }
+        var ri: usize = 0;
+        for (ri < t) { buf[ri] = tmp[t - 1 - ri]; ri = ri + 1; }
+        len = t;
+    }
+    os.write(os.STDERR_FD, ?buf[0], len);
+    os.write(os.STDERR_FD, "\n", 1);
+}
+
 # select concrete instructions for one block. instructions that map 1:1 to a
 # concrete opcode are rewritten in place; the few that expand into a fixed
 # instruction sequence (NEG, NOT) force the block's instruction list to be
@@ -156,7 +177,10 @@ fun select_block(alloc: *Allocator, b: *mir.MirBlock) Result[bool, str] {
     var i: u32 = 0;
     for (i < b.instr_count) {
         val n: u32 = expansion_count(?b.instrs[i]);
-        if (n == 0) { ret err[bool, str]("internal compiler error: unhandled MIR opcode in instruction selection"); }
+        if (n == 0) {
+            write_opcode_ice(b.instrs[i].opcode);
+            ret err[bool, str]("internal compiler error: unhandled MIR opcode in instruction selection");
+        }
         if (n > 1) { needs_expand = true; }
         total = total + n;
         i = i + 1;
@@ -438,6 +462,7 @@ fun rewrite_simple(mi: *mir.MirInstr) Result[bool, str] {
     # encoder materializes its self-contained TEST ; JZ ; MOVSD sequence.
     if (o == mir.MIR_VA_FP_SAVE) { ret ok[bool, str](true); }
 
+    write_opcode_ice(o);
     ret err[bool, str]("internal compiler error: unhandled MIR opcode in instruction selection");
 }
 

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -709,8 +709,62 @@ fun coff_emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R
     ret sr;
 }
 
-# coff_serialize_image: lay out and write the COFF object file for an already
-# COMDAT-prepared image. `comdat[s]` selects the sections emitted with
+# decimal_len: number of decimal digits in `n` (minimum 1 for 0).
+fun decimal_len(n: usize) usize {
+    if (n == 0) { ret 1; }
+    var len: usize = 0;
+    var v: usize = n;
+    for (v > 0) { len = len + 1; v = v / 10; }
+    ret len;
+}
+
+# write_dec: write decimal digits of `n` into `buf` at offset `k`, returning new offset.
+fun write_dec(buf: *u8, k: usize, n: usize) usize {
+    if (n == 0) { buf[k] = '0'; ret k + 1; }
+    var tmp: [24]u8;
+    var t: usize = 0;
+    var v: usize = n;
+    for (v > 0) { tmp[t] = (v % 10)::u8 + '0'; v = v / 10; t = t + 1; }
+    var ri: usize = 0;
+    for (ri < t) { buf[k + ri] = tmp[t - 1 - ri]; ri = ri + 1; }
+    ret k + t;
+}
+
+# reloc_ovfl_message: build "coff: section '<name>' has <count> relocations; COFF limit is 65535".
+# degrades to the static fallback when the section name cannot be resolved or allocation fails.
+fun reloc_ovfl_message(itn: *intern.Interner, alloc: *Allocator, name_id: intern.StrId, count: u32) str {
+    val fallback: str = "coff: section relocation count exceeds the COFF 0xFFFF limit";
+    if (itn == nil) { ret fallback; }
+    val nmo: Option[str] = intern.lookup(itn, name_id);
+    if (!is_some[str](nmo)) { ret fallback; }
+    val nm: str = unwrap[str](nmo);
+    val pre: str = "coff: section '";
+    val mid: str = "' has ";
+    val suf: str = " relocations; this exceeds the COFF limit of 65535";
+    val lpre: usize = str_len(pre);
+    val lnm:  usize = str_len(nm);
+    val lmid: usize = str_len(mid);
+    val lcnt: usize = decimal_len(count::usize);
+    val lsuf: usize = str_len(suf);
+    val total: usize = lpre + lnm + lmid + lcnt + lsuf;
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret fallback; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    mem.raw_copy((buf::usize + off)::ptr, pre::ptr, lpre); off = off + lpre;
+    mem.raw_copy((buf::usize + off)::ptr, nm::ptr,  lnm);  off = off + lnm;
+    mem.raw_copy((buf::usize + off)::ptr, mid::ptr, lmid); off = off + lmid;
+    off = write_dec(buf, off, count::usize);
+    mem.raw_copy((buf::usize + off)::ptr, suf::ptr, lsuf);
+    buf[total] = 0;
+    val ir: Result[intern.StrId, str] = intern.intern(itn, buf::str);
+    deallocate[u8](alloc, buf, total + 1);
+    if (is_err[intern.StrId, str](ir)) { ret fallback; }
+    val lo: Option[str] = intern.lookup(itn, unwrap_ok[intern.StrId, str](ir));
+    if (is_some[str](lo)) { ret unwrap[str](lo); }
+    ret fallback;
+}
+
 # `IMAGE_SCN_LNK_COMDAT` and a `SELECT_ANY` section-symbol aux record. callers go
 # through `coff_emit_object`, which builds the COMDAT layout first.
 # ---
@@ -758,8 +812,9 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     var cs: u32 = 0;
     for (cs < num_secs) {
         if (counts[cs] > 0xFFFF) {
+            val ovfl_msg: str = reloc_ovfl_message(img.interner, alloc, img.sections[cs].name, counts[cs]);
             deallocate[u32](alloc, counts, num_secs::usize);
-            ret err[bool, str]("coff: section relocation count exceeds the COFF 0xFFFF limit");
+            ret err[bool, str](ovfl_msg);
         }
         cs = cs + 1;
     }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1596,6 +1596,43 @@ fun write_phdr(buf: *u8, pos: usize, p_type: u32, flags: u32, off: usize, vaddr:
     ret pos + PHDR_SIZE;
 }
 
+# bad_magic_message: build "elf: not an ELF object (expected 0x7F 'E' 'L' 'F', got 0xHH 0xHH 0xHH 0xHH)"
+# from the first 4 bytes of `buf`. degrades to the static fallback when allocation fails.
+fun bad_magic_message(itn: *intern.Interner, alloc: *Allocator, buf: *u8) str {
+    val fallback: str = "elf: not an ELF object (bad magic; expected 0x7F 'E' 'L' 'F')";
+    if (itn == nil) { ret fallback; }
+    val hex: str = "0123456789ABCDEF";
+    # "elf: not an ELF object (expected 0x7F 'E' 'L' 'F', got 0xHH 0xHH 0xHH 0xHH)"
+    val pre: str = "elf: not an ELF object (expected 0x7F 'E' 'L' 'F', got ";
+    val suf: str = ")";
+    val lpre: usize = str_len(pre);
+    # 4 bytes × "0xHH " - trailing space + suffix
+    val total: usize = lpre + 23 + str_len(suf);
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret fallback; }
+    val msg: *u8 = unwrap_ok[*u8, str](r);
+    mem.raw_copy(msg::ptr, pre::ptr, lpre);
+    var off: usize = lpre;
+    var bi: usize = 0;
+    for (bi < 4) {
+        val b: u8 = buf[bi];
+        msg[off] = '0'; off = off + 1;
+        msg[off] = 'x'; off = off + 1;
+        msg[off] = hex[(b >> 4)::usize]; off = off + 1;
+        msg[off] = hex[(b & 0x0F)::usize]; off = off + 1;
+        if (bi < 3) { msg[off] = ' '; off = off + 1; }
+        bi = bi + 1;
+    }
+    mem.raw_copy((msg::usize + off)::ptr, suf::ptr, str_len(suf));
+    msg[total] = 0;
+    val ir: Result[intern.StrId, str] = intern.intern(itn, msg::str);
+    deallocate[u8](alloc, msg, total + 1);
+    if (is_err[intern.StrId, str](ir)) { ret fallback; }
+    val lo: Option[str] = intern.lookup(itn, unwrap_ok[intern.StrId, str](ir));
+    if (is_some[str](lo)) { ret unwrap[str](lo); }
+    ret fallback;
+}
+
 # parse_object: parse a relocatable ELF64 object into an ObjectImage.
 #
 # reads the section, symbol, and relocation tables of a `.o` produced by
@@ -1616,7 +1653,7 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         ret err[bool, str]("elf: object too small");
     }
     if (buf[0] != 0x7F || buf[1] != 0x45 || buf[2] != 0x4C || buf[3] != 0x46) {
-        ret err[bool, str]("elf: not an ELF object (bad magic; expected 0x7F 'E' 'L' 'F')");
+        ret err[bool, str](bad_magic_message(itn, alloc, buf));
     }
     if (itn == nil) { ret err[bool, str]("elf: no interner for parse"); }
     out.interner = itn;


### PR DESCRIPTION
Closes #1046

Implements the remaining MEDIUM and LOW severity items from the diagnostic quality audit that were deferred by PR #1320.

## Changes

**encode/isel** (`src/lang/target/isa/x64/`)
- `encode.mach`: ICE "produced no bytes" now names the function via `enc_named_message`; nil-target/nil-module messages shortened to `"encode: nil target"` / `"encode: nil mir module"`; float-width error gains `"(expected 4 or 8)"`; malformed two-operand asm includes the args string
- `isel.mach`: unhandled-opcode ICE now writes the opcode decimal to stderr before returning the static string

**regalloc** (`src/lang/be/codegen/regalloc.mach`)
- Added `interner` field to `AllocCtx` (set from `m.interner` in `ctx_init`)
- Added `ctx_fn_name` / `regalloc_msg` helpers
- All 4 "no free register" ICE messages now include the function name

**linker** (`src/lang/be/linker.mach`)
- `overflow_message` gains a `sym_name: intern.StrId` parameter; the production call passes `r.symbol`; test call sites pass `intern.STR_NIL`
- Formatted message: `"relocation '<kind>' to '<symbol>' overflows"`

**coff** (`src/lang/target/of/coff.mach`)
- Added `decimal_len` / `write_dec` helpers (named `write_dec` to avoid collision with the existing `write_decimal` right-justified helper at line 343)
- Added `reloc_ovfl_message` helper: `"coff: section '<name>' has <count> relocations; this exceeds the COFF limit of 65535"`

**elf** (`src/lang/target/of/elf.mach`)
- Added `bad_magic_message` helper: `"elf: not an ELF object (expected 0x7F 'E' 'L' 'F', got 0xHH 0xHH 0xHH 0xHH)"` using actual first 4 bytes (path not available in `ParseFn` vtable)

**parser/iasm** (`src/lang/fe/parser/iasm.mach`)
- `collect_body` gains `asm_span: token.Span` parameter; unterminated-asm-body error now pinned to the opening `asm` keyword span via `parser.error_at`

**comptime** (`src/lang/fe/comptime.mach`)
- Invalid digit errors are now base-specific: hex `(expected 0-9, a-f, A-F)`, binary `(expected 0 or 1)`, octal `(expected 0-7)`, decimal `(expected 0-9)`
- Empty character literal: `"empty character literal; must contain exactly one character or escape"`
- Unknown escape sequence: `"unknown escape sequence (valid: \n \t \r \\ \' \" \0 \xHH)"`

**sema** (`src/lang/fe/sema.mach`)
- All 4 `$if`-gate runtime-reference diagnostics now name the symbol via `check.report_named`

**lower** (`src/lang/me/lower/`)
- `testrunner.mach`: removed `#1292` issue reference from the unsupported-target error
- `decl.mach`: added `report_dup_test_label` helper; duplicate test label diagnostic now includes the label text

## Deferred (scope fence — owned by the hard-cut worker)

- `src/lang/driver.mach:1275` — opt-value: include offending text in unknown option-value diagnostic
- `src/lang/driver.mach:1862` — empty define name: include the entry text in the diagnostic

## Verification

- `mach build .` clean (seed binary)
- `mach test .`: 386 tests, 0 failures (updated coff reloc-overflow test assertion to match new message containing "exceeds")
- 3-stage fixpoint: stage2 == stage3 (`sha256: debc1ef72a38d675bfa0f461ae73757c268a26e13932f64aabbc2cf61c67e1d6`); seed→stage1 differs as expected (string constants changed .rodata)