### PR TITLE
manifest: project module + [os.*] link overlays (#1326)

### DIFF
--- a/.github/tests/manifest/cascade/dep/vdep/mach.toml
+++ b/.github/tests/manifest/cascade/dep/vdep/mach.toml
@@ -1,15 +1,14 @@
 # vdep: a second dependency declaring its own windows link requirement
-# (user32.dll), inherited by a windows consumer the same way as kdep's. proves
-# the cascade aggregates libs from multiple deps by target-tuple equality.
+# (user32.dll) — this time as an `[os.windows]` overlay rather than a full-tuple
+# `[target.windows].libs`. a windows consumer inherits it by os-component match,
+# exactly like kdep's tuple lib; a linux consumer inherits neither. proves the os
+# overlay cascades transitively beside the full-tuple form (#1326).
 [project]
 id      = "vdep"
 version = "0.1.0"
 src     = "src"
 
-[target.windows]
-isa  = "x86_64"
-os   = "windows"
-abi  = "win64"
+[os.windows]
 libs = ["user32.dll"]
 
 [lib.vdep]

--- a/.github/tests/module/dangling/mach.toml
+++ b/.github/tests/module/dangling/mach.toml
@@ -1,0 +1,21 @@
+# a declared [project].module that names no file is a manifest error at build
+# start, imported or not — the entry below never imports it (#1326).
+[project]
+id      = "dangapp"
+version = "0.1.0"
+src     = "src"
+module  = "ghost.mach"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.dangapp]
+entry = "main.mach"
+
+[profile.debug]
+opt = 0

--- a/.github/tests/module/dangling/src/main.mach
+++ b/.github/tests/module/dangling/src/main.mach
@@ -1,0 +1,6 @@
+# the entry imports nothing special; the dangling [project].module still fails
+# the build at start.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret 0;
+}

--- a/.github/tests/module/nomodule/dep/plain/mach.toml
+++ b/.github/tests/module/nomodule/dep/plain/mach.toml
@@ -1,0 +1,9 @@
+# plain: a dependency that declares NO [project].module, so a bare `use plain;`
+# is unresolvable and must error.
+[project]
+id      = "plain"
+version = "0.1.0"
+src     = "src"
+
+[lib.plain]
+entry = "lib.mach"

--- a/.github/tests/module/nomodule/dep/plain/src/lib.mach
+++ b/.github/tests/module/nomodule/dep/plain/src/lib.mach
@@ -1,0 +1,2 @@
+# plain library root — reachable only by a full path, never by a bare id.
+pub fun p() i64 { ret 0; }

--- a/.github/tests/module/nomodule/mach.toml
+++ b/.github/tests/module/nomodule/mach.toml
@@ -1,0 +1,28 @@
+# a bare `use plain;` of a dependency that declares no [project].module must fail
+# with a resolution error naming the fix (#1326).
+[project]
+id      = "nomodapp"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.nomodapp]
+entry = "main.mach"
+
+[profile.debug]
+opt = 0
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.4.0"
+
+[deps.plain]
+path = "dep/plain"

--- a/.github/tests/module/nomodule/src/main.mach
+++ b/.github/tests/module/nomodule/src/main.mach
@@ -1,0 +1,7 @@
+use std.runtime;
+use plain;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret 0;
+}

--- a/.github/tests/module/ok/dep/gfx/mach.toml
+++ b/.github/tests/module/ok/dep/gfx/mach.toml
@@ -1,0 +1,10 @@
+# gfx: a library declaring the module a bare `use gfx;` resolves to. the module
+# path is src-relative, matching the `entry` form.
+[project]
+id      = "gfx"
+version = "0.1.0"
+src     = "src"
+module  = "gfx.mach"
+
+[lib.gfx]
+entry = "gfx.mach"

--- a/.github/tests/module/ok/dep/gfx/src/gfx.mach
+++ b/.github/tests/module/ok/dep/gfx/src/gfx.mach
@@ -1,0 +1,3 @@
+# gfx surface module, resolved by a bare `use gfx;` via [project].module, and
+# re-exported whole by shelf's bare-id `fwd gfx;`.
+pub fun value() i64 { ret 7; }

--- a/.github/tests/module/ok/dep/shelf/mach.toml
+++ b/.github/tests/module/ok/dep/shelf/mach.toml
@@ -1,0 +1,11 @@
+# shelf: a library whose own module re-exports the gfx module through a bare
+# project-id `fwd gfx;`. gfx is a sibling dep of the consumer, so the bare id
+# resolves against the consumer's flat dep set.
+[project]
+id      = "shelf"
+version = "0.1.0"
+src     = "src"
+module  = "shelf.mach"
+
+[lib.shelf]
+entry = "shelf.mach"

--- a/.github/tests/module/ok/dep/shelf/src/shelf.mach
+++ b/.github/tests/module/ok/dep/shelf/src/shelf.mach
@@ -1,0 +1,2 @@
+# shelf re-exports the gfx module through a bare-id `fwd` (#1326).
+fwd gfx;

--- a/.github/tests/module/ok/mach.toml
+++ b/.github/tests/module/ok/mach.toml
@@ -1,0 +1,34 @@
+# module-resolution consumer: imports two dependencies by their bare project id.
+# `use gfx;` resolves to gfx's declared [project].module, and `use shelf;` reaches
+# shelf, whose own module re-exports gfx's namesake symbol via a bare-id `fwd gfx;`
+# — so both the `use` and the `fwd` forms of bare project-id resolution are
+# exercised end to end (#1326).
+[project]
+id      = "modapp"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.ok]
+entry = "main.mach"
+
+[profile.debug]
+opt = 0
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.4.0"
+
+[deps.gfx]
+path = "dep/gfx"
+
+[deps.shelf]
+path = "dep/shelf"

--- a/.github/tests/module/ok/src/main.mach
+++ b/.github/tests/module/ok/src/main.mach
@@ -1,0 +1,11 @@
+use std.runtime;
+use gfx;
+use shelf;
+
+# `use gfx;` resolves the bare project id to gfx's [project].module. `use shelf;`
+# loads shelf, whose own module re-exports gfx through a bare-id `fwd gfx;` — so a
+# resolution failure in either form fails this build.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret gfx.value();
+}

--- a/.github/tests/module/run.sh
+++ b/.github/tests/module/run.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# module-resolution integration test: the `[project] module` bare project-id
+# import surface (#1326).
+#
+# proves end to end that a one-segment `use`/`fwd` path equal to a resolvable
+# project id resolves to that project's declared module — and that the loud
+# failures fire: a bare import of a module-less project, a declared-but-dangling
+# module path (imported or not), and a project module that re-exports its own id.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# stage <name> — copy a fixture into the work dir and link the vendored std.
+stage() {
+    cp -r "$HERE/$1" "$WORK/$1"
+    if grep -q 'mach-std' "$WORK/$1/mach.toml"; then
+        mkdir -p "$WORK/$1/dep"
+        ln -s "$STD" "$WORK/$1/dep/mach-std"
+    fi
+}
+
+# expect_run <desc> <expected-exit> <project> — build and run a bin, checking exit.
+expect_run() {
+    local desc="$1"; local want="$2"; local proj="$3"
+    if ! ( cd "$WORK/$proj" && "$MACH" build . ) >/dev/null 2>&1; then
+        echo "FAIL module: $desc — build failed" >&2; fail=1; return
+    fi
+    local bin="$WORK/$proj/out/linux/debug/bin/$proj"
+    if [ ! -x "$bin" ]; then
+        echo "FAIL module: $desc — binary not produced at $bin" >&2; fail=1; return
+    fi
+    set +e
+    "$bin"; local got=$?
+    set -e
+    if [ "$got" -ne "$want" ]; then
+        echo "FAIL module: $desc — exit $got, expected $want" >&2; fail=1; return
+    fi
+    echo "PASS module: $desc"
+}
+
+# expect_build_err <desc> <project> <substring> — the build must fail and its
+# stderr must contain <substring>.
+expect_build_err() {
+    local desc="$1"; local proj="$2"; local want="$3"
+    set +e
+    local out
+    out="$( cd "$WORK/$proj" && "$MACH" build . 2>&1 )"
+    local rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+        echo "FAIL module: $desc — build unexpectedly succeeded" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF "$want"; then
+        echo "FAIL module: $desc — message missing '$want'; got: $out" >&2; fail=1; return
+    fi
+    echo "PASS module: $desc"
+}
+
+stage ok
+stage nomodule
+stage dangling
+stage selfimport
+
+# a bare `use gfx;` resolves to gfx's [project].module (value() -> 7); `use shelf;`
+# loads shelf, whose bare-id `fwd gfx;` must also resolve or the build fails.
+expect_run "bare-id use + fwd resolve a project module" 7 ok
+
+# a bare import of a module-less dependency names the fix.
+expect_build_err "module-less project import errors" nomodule \
+    "project 'plain' declares no module"
+
+# a declared-but-dangling module fails at build start though nothing imports it.
+expect_build_err "dangling [project].module fails at build start" dangling \
+    "[project].module 'ghost.mach' names no file"
+
+# a project module re-exporting its own id trips circular-module detection.
+expect_build_err "self-fwd of the project id is circular" selfimport \
+    "circular module dependency"
+
+exit "$fail"

--- a/.github/tests/module/selfimport/mach.toml
+++ b/.github/tests/module/selfimport/mach.toml
@@ -1,0 +1,21 @@
+# a project module that re-exports its own project id (`fwd solo;` inside the
+# module solo resolves to) trips the existing circular-module detection (#1326).
+[project]
+id      = "solo"
+version = "0.1.0"
+src     = "src"
+module  = "solo.mach"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[lib.solo]
+entry = "solo.mach"
+
+[profile.debug]
+opt = 0

--- a/.github/tests/module/selfimport/src/solo.mach
+++ b/.github/tests/module/selfimport/src/solo.mach
@@ -1,0 +1,3 @@
+# solo's module re-exports its own project id: `fwd solo;` resolves back to this
+# very module, so the load walk reports a circular module dependency.
+fwd solo;

--- a/doc/language/modules.md
+++ b/doc/language/modules.md
@@ -13,6 +13,17 @@ There is no `this.` self-prefix. Within a project, modules always reference
 each other by their full project-rooted path. Every reference is
 syntactically uniform regardless of where it appears.
 
+## Bare project-id imports
+
+A one-segment `use`/`fwd` path equal to a resolvable project id — a dependency's
+id or the current project's own id — resolves to that project's declared
+`[project].module` (the manifest names the surface file). So a library `glfw`
+that declares `module = "glfw.mach"` is imported as `use glfw;`, equivalent to
+naming the full path to its surface module. A bare import of a project that
+declares no module is an error directing you to a full path or to add the key;
+longer paths are unaffected. See
+[manifest.md](../manifest.md#bare-project-id-imports).
+
 ## Shadow-module pattern
 
 A file `foo.mach` may co-exist with a directory `foo/`. The file is the

--- a/doc/language/use.md
+++ b/doc/language/use.md
@@ -28,7 +28,12 @@ use std.types.size;             # binds module 'size'; use as `size.usize`
 use sz: std.types.size;         # binds module under 'sz'; use as `sz.usize`
 use std.types.size.usize;       # binds symbol 'usize'; use bare as `usize`
 use my_usize: std.types.size.usize;  # binds symbol under 'my_usize'
+use glfw;                        # bare project id: binds glfw's [project].module
 ```
+
+A one-segment path equal to a resolvable project id resolves to that project's
+declared `[project].module` — see
+[modules.md](modules.md#bare-project-id-imports).
 
 ## Design rule
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -70,6 +70,7 @@ ref = "v0.4.0"
 |-----------|--------|----------|------------|---------|
 | `id`      | string | yes      | —          | Root segment of every module path the project exposes. A file at `<src>/foo/bar.mach` is reachable as `<id>.foo.bar`. |
 | `version` | string | yes      | —          | Project version. Read by the `$project.version` comptime root. |
+| `module`  | string | no       | —          | Src-relative path of the module a bare `use <id>;` / `fwd <id>;` resolves to (see [Bare project-id imports](#bare-project-id-imports)). Never inferred; a library that wants to be importable by its id declares it. A declared path naming no file is an error at build start. |
 | `src`     | string | no       | `"src"`    | Source root, relative to the project root. Module paths resolve under it. |
 | `dep`     | string | no       | `"dep"`    | Vendored-dependency root, relative to the project root. Each dep lives at `<dep>/<alias>/`. |
 | `target`  | string | no       | `"native"` | Default target selector when `--target` is not passed. `native` resolves to the declared target whose tuple matches the host. |
@@ -172,12 +173,62 @@ as a **submodule** composes naturally; mach never invokes `git submodule`.
 
 ### Cascading link requirements
 
-A dependency declares its own `[target.*].libs`, and a consumer inherits every
-such lib whose target tuple `(isa, os, abi)` equals the one being built — so a
-platform link requirement (e.g. `kernel32.dll`) lives once, in the providing
-dependency's manifest, and out of every consumer. Matching is by tuple equality;
-target *names* are local to each manifest. Inherited libs are deduplicated by
-name in topological-dependency then declaration order.
+A dependency declares its own link requirements as `[target.*].libs` (full-tuple)
+or `[os.<name>].libs` (os-component) overlays, and a consumer inherits every such
+lib that matches the build it is producing — so a platform link requirement (e.g.
+`kernel32.dll`) lives once, in the providing dependency's manifest, and out of
+every consumer. Matching is by tuple/component equality; target *names* are local
+to each manifest. Within each dependency the matching os overlays precede the
+matching target libs; across dependencies the order is topological then
+declaration order, and the union is deduplicated by name. See
+[Link inputs](#link-inputs) for the overlay merge law.
+
+## `[os.<name>]`
+
+An os overlay scopes a link requirement to a single tuple component — the
+operating system — rather than a full `(isa, os, abi)` tuple. A build matches the
+overlay iff its selected target's `os` equals `<name>`, so a requirement that
+holds for every windows ISA and ABI is stated once:
+
+```toml
+[os.windows]
+libs = ["kernel32.dll"]   # linked into every windows build, this project's and any consumer's
+```
+
+| Key    | Type             | Default | Meaning |
+|--------|------------------|---------|---------|
+| `libs` | array of strings | `[]`    | Link inputs added to every build whose os matches `<name>` (see [Link inputs](#link-inputs)). |
+
+Os overlays cascade to consumers exactly like `[target.*].libs`. The
+single-component `[isa.<name>]` and `[abi.<name>]` overlays are **reserved**:
+declaring either is an error until a real case demands them.
+
+## Bare project-id imports
+
+A one-segment `use`/`fwd` path equal to a resolvable project id — a dependency's
+`[project].id`, or the current project's own id — resolves to that project's
+declared `[project].module`. So a library that sets `module = "glfw.mach"` is
+imported as `use glfw;` (binding the `glfw` module) instead of by the full path to
+its surface file. Longer paths are unaffected; a single segment is otherwise
+unresolvable, so this is purely additive.
+
+```toml
+# in glfw's manifest:
+[project]
+id     = "glfw"
+module = "glfw.mach"   # the surface a bare `use glfw;` binds
+```
+
+```mach
+// in a consumer:
+use glfw;              // binds the glfw module (glfw's [project].module)
+```
+
+A bare import of a project that declares no `module` is a resolution error naming
+the fix (import a full path, or add a `module` to the project's manifest). A
+declared `module` that names no file is a manifest error at build start whether or
+not anything imports it. A project module that `fwd`s its own id is caught by the
+existing circular-module detection.
 
 ## Path templates
 

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -181,7 +181,8 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
 # write_manifest: write the mach.toml manifest at `path` with project id `id`.
 # the `[project]` block declares explicit src/dep dirs and the output-path
-# templates; `[target.*]` declares linux/windows/darwin platforms on the host
+# templates (plus `module = "lib.mach"` for a library, the file a bare `use <id>;`
+# resolves to); `[target.*]` declares linux/windows/darwin platforms on the host
 # isa (windows carrying the `.exe` extension); one `[bin.<id>]` (or `[lib.<id>]`
 # with `kind = "static"`) names the artifact; debug/release `[profile.*]`s set
 # the optimization level; and `[deps.mach-std]` points at the standard library.
@@ -196,6 +197,9 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     off = put(?buf[0], 4096, off, "version = \"0.1.0\"\n");
     off = put(?buf[0], 4096, off, "src = \"src\"\n");
     off = put(?buf[0], 4096, off, "dep = \"dep\"\n");
+    # a library is importable by its project id; the module key names the file a
+    # bare `use <id>;` resolves to (the lib root). bins are not importable, so omit.
+    if (is_lib) { off = put(?buf[0], 4096, off, "module = \"lib.mach\"\n"); }
     off = put(?buf[0], 4096, off, "target = \"native\"\n");
     off = put(?buf[0], 4096, off, "out = \"out/{target}/{profile}/bin/{name}{ext}\"\n");
     off = put(?buf[0], 4096, off, "obj = \"out/{target}/{profile}/obj\"\n");

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1694,7 +1694,7 @@ fun bind_one_define(p: *Project, ctx: *comptime.ComptimeCtx, s: str) Result[bool
         if (s[k] == '=') { eq = k; brk; }
         k = k + 1;
     }
-    if (eq == 0) { ret err[bool, str]("mach.toml: a define has an empty name"); }
+    if (eq == 0) { ret err[bool, str](diag_join3(p.s, "mach.toml: define '", s, "' has an empty name", "mach.toml: a define has an empty name")); }
 
     val name_r: Result[intern.StrId, str] = intern.intern_bytes(?p.s.interner, s, eq);
     if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1321,9 +1321,9 @@ fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     if (is_err[intern.StrId, str](rcn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rcn)); }
     p.compiler_name = unwrap_ok[intern.StrId, str](rcn);
 
-    # the compiler version is single-sourced in `mach.lang.version`; both this
-    # `$mach.compiler.version` feed and `mach info` read it through one function,
-    # so the staged `$project.version` flip (#1311) touches a single place.
+    # the compiler version is single-sourced in `mach.lang.version`, which folds
+    # `[project].version` from the manifest; both this `$mach.compiler.version`
+    # feed and `mach info` read it through that one function (#1311).
     val rcv: Result[intern.StrId, str] = intern.intern(?p.s.interner, version.string());
     if (is_err[intern.StrId, str](rcv)) { ret err[bool, str](unwrap_err[intern.StrId, str](rcv)); }
     p.compiler_ver = unwrap_ok[intern.StrId, str](rcv);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -131,11 +131,15 @@ pub rec TargetEntry {
 # alias:           interned alias as written in `[deps.<alias>]`
 # project_id:      interned `[project].id` from the dep's own mach.toml
 # project_dir_src: interned `[project].src` from the dep's own mach.toml
+# project_module:  interned `[project].module` from the dep's own mach.toml — the
+#                  src-relative module a bare project-id import resolves to;
+#                  STR_NIL when the dep declares none
 # vendor_root:     interned absolute filesystem path to the dep root
 pub rec DepEntry {
     alias:           intern.StrId;
     project_id:      intern.StrId;
     project_dir_src: intern.StrId;
+    project_module:  intern.StrId;
     vendor_root:     intern.StrId;
 }
 
@@ -148,6 +152,8 @@ pub rec DepEntry {
 # description:  interned `[project].description` metadata; read by
 #               `$project.description`. STR_NIL when the manifest omits it
 # bin_name:     interned name of the selected artifact; read by `$bin.name`
+# module:       interned `[project].module` — the src-relative module a bare
+#               project-id import of this project resolves to; STR_NIL when none
 # dir_src:      interned `[project].src` (default "src")
 # dir_dep:      interned `[project].dep` (default "dep")
 # project_root: interned absolute filesystem path of the project root
@@ -176,6 +182,7 @@ pub rec ProjectConfig {
     name:         intern.StrId;
     description:  intern.StrId;
     bin_name:     intern.StrId;
+    module:       intern.StrId;
     dir_src:      intern.StrId;
     dir_dep:      intern.StrId;
     project_root: intern.StrId;
@@ -691,6 +698,7 @@ fun init_project(p: *Project, s: *sess.Session) {
     p.config.name         = intern.STR_NIL;
     p.config.description  = intern.STR_NIL;
     p.config.bin_name     = intern.STR_NIL;
+    p.config.module       = intern.STR_NIL;
     p.config.targets      = nil;
     p.config.target_count = 0;
     p.config.deps         = nil;
@@ -816,6 +824,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     p.config.description  = m.description;
     # the artifact name feeds `$bin.name`; STR_NIL when the selection bound none.
     if (bu.artifact != nil) { p.config.bin_name = bu.artifact.name; }
+    p.config.module       = m.module;
     p.config.dir_src      = m.src;
     p.config.dir_dep      = m.dep;
     p.config.targets      = targets;
@@ -847,8 +856,39 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
         unwrap[str](isa_opt), unwrap[str](os_opt), unwrap[str](abi_opt), bu.libs, bu.lib_count);
     if (is_err[bool, str](cr2)) { manifest.dnit(?m, p.s.alloc); ret cr2; }
 
+    # a declared `[project].module` that names no file is a manifest error at
+    # build start, imported or not (#1326).
+    val mc: Result[bool, str] = check_own_module(p, project_root);
+    if (is_err[bool, str](mc)) { manifest.dnit(?m, p.s.alloc); ret mc; }
+
     manifest.dnit(?m, p.s.alloc);
     ret ok[bool, str](true);
+}
+
+# check_own_module: verify the project's declared `[project].module` (if any)
+# names a real file under the project's src dir.
+fun check_own_module(p: *Project, project_root: str) Result[bool, str] {
+    if (p.config.module == intern.STR_NIL) { ret ok[bool, str](true); }
+    val mod_opt: Option[str] = intern.lookup(?p.s.interner, p.config.module);
+    val src_opt: Option[str] = intern.lookup(?p.s.interner, p.config.dir_src);
+    if (is_none[str](mod_opt) || is_none[str](src_opt)) { ret err[bool, str]("internal: project module/src not interned"); }
+    val mod_text: str = unwrap[str](mod_opt);
+    if (module_file_present(p.s.alloc, project_root, unwrap[str](src_opt), mod_text)) { ret ok[bool, str](true); }
+    ret err[bool, str](diag_join3(p.s, "mach.toml: [project].module '", mod_text, "' names no file", "mach.toml: [project].module names no file"));
+}
+
+# module_file_present: whether `<root>/<src_dir>/<module_rel>` is an existing file.
+fun module_file_present(alloc: *Allocator, root: str, src_dir: str, module_rel: str) bool {
+    val a: Result[str, str] = join_path(alloc, root, src_dir);
+    if (is_err[str, str](a)) { ret false; }
+    val mid: str = unwrap_ok[str, str](a);
+    val b: Result[str, str] = join_path(alloc, mid, module_rel);
+    str_free(alloc, mid);
+    if (is_err[str, str](b)) { ret false; }
+    val full: str = unwrap_ok[str, str](b);
+    val ok_: bool = fs.is_file(full);
+    str_free(alloc, full);
+    ret ok_;
 }
 
 # map_opt: map a manifest profile opt level to the driver's TargetOpt.
@@ -932,15 +972,16 @@ fun resolve_deps(p: *Project, m: *manifest.Manifest, project_root: str) Result[b
     ret ok[bool, str](true);
 }
 
-# resolve_cascade_libs: gather the transitive dependencies' tuple-matched link
-# libs into `p.config.cascade_libs` (#1218). a dependency declares its own
-# `[target.*].libs`, and a consumer inherits every such lib whose target tuple
-# (isa, os, abi) equals the one being built, so a platform link requirement (e.g.
-# `kernel32.dll`) lives once in the providing dependency's manifest. order is
-# topological (a dep's own deps first) then declaration order; libs are
-# deduplicated by name and the consumer's own `own_libs` are excluded, so a shared
-# requirement is never linked twice. an empty result leaves the cascade nil/0, so
-# a build with no inheriting deps is unaffected.
+# resolve_cascade_libs: gather the transitive dependencies' matched link libs into
+# `p.config.cascade_libs` (#1218, #1326). a dependency declares its own
+# `[os.<name>].libs` (matched on the os component) and `[target.*].libs` (matched
+# on the full (isa, os, abi) tuple), and a consumer inherits every such lib for the
+# build it is producing — so a platform link requirement (e.g. `kernel32.dll`)
+# lives once in the providing dependency's manifest. order is topological (a dep's
+# own deps first); within each dep the matching os overlays precede the matching
+# target libs. libs are deduplicated by name and the consumer's own `own_libs` are
+# excluded, so a shared requirement is never linked twice. an empty result leaves
+# the cascade nil/0, so a build with no inheriting deps is unaffected.
 fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi: str,
                          own_libs: *intern.StrId, own_count: u32) Result[bool, str] {
     p.config.cascade_libs      = nil;
@@ -986,10 +1027,13 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
     i = 0;
     for (i < n) { cascade_dfs(?tables[0], aliases, visited, order, ?order_len, n, i); i = i + 1; }
 
-    # upper-bound by the total tuple-matched lib count, then fill with dedup.
+    # upper-bound by the total matched lib count (os overlays + target libs), then
+    # fill with dedup.
     var max: u32 = 0;
     i = 0;
     for (i < n) {
+        val oarr: *toml.Array = os_libs(?tables[i], os);
+        if (oarr != nil) { max = max + toml.array_len(oarr)::u32; }
         val arr: *toml.Array = tuple_libs(?tables[i], isa, os, abi);
         if (arr != nil) { max = max + toml.array_len(arr)::u32; }
         i = i + 1;
@@ -1001,31 +1045,16 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
     val buf: *intern.StrId = unwrap_ok[*intern.StrId, str](br);
     var w: u32 = 0;
 
+    # per dep in topological order: matching os overlays first, then matching
+    # target libs (the merge law), each deduplicated and excluding the consumer's
+    # own libs.
     var oi: u32 = 0;
     for (oi < order_len) {
         val di: u32 = order[oi];
-        val arr: *toml.Array = tuple_libs(?tables[di], isa, os, abi);
-        if (arr != nil) {
-            val cnt: usize = toml.array_len(arr);
-            var k: usize = 0;
-            for (k < cnt) {
-                val v: *toml.Value = toml.array_get(arr, k);
-                if (v == nil || v.tag != toml.TYPE_STRING) {
-                    deallocate[intern.StrId](p.s.alloc, buf, max::usize);
-                    ret err[bool, str]("dep mach.toml: a target's libs entry is not a string");
-                }
-                val idr: Result[intern.StrId, str] = intern.intern(?p.s.interner, v.data.string);
-                if (is_err[intern.StrId, str](idr)) {
-                    deallocate[intern.StrId](p.s.alloc, buf, max::usize);
-                    ret err[bool, str](unwrap_err[intern.StrId, str](idr));
-                }
-                val id: intern.StrId = unwrap_ok[intern.StrId, str](idr);
-                if (!strid_in(buf, w, id) && !strid_in(own_libs, own_count, id)) {
-                    buf[w] = id; w = w + 1;
-                }
-                k = k + 1;
-            }
-        }
+        val osr: Result[bool, str] = append_cascade_array(p, buf, ?w, max, os_libs(?tables[di], os), own_libs, own_count);
+        if (is_err[bool, str](osr)) { ret err[bool, str](unwrap_err[bool, str](osr)); }
+        val tlr: Result[bool, str] = append_cascade_array(p, buf, ?w, max, tuple_libs(?tables[di], isa, os, abi), own_libs, own_count);
+        if (is_err[bool, str](tlr)) { ret err[bool, str](unwrap_err[bool, str](tlr)); }
         oi = oi + 1;
     }
 
@@ -1099,6 +1128,52 @@ fun tuple_libs(t: *toml.Table, isa: str, os: str, abi: str) *toml.Array {
     ret nil;
 }
 
+# os_libs: the `[os.<os>].libs` overlay array of a dep matching the build's os
+# component (#1326). nil when the dep declares no overlay for this os or it
+# carries no libs.
+fun os_libs(t: *toml.Table, os: str) *toml.Array {
+    val parent: *toml.Table = toml.get_table(t, "os");
+    if (parent == nil) { ret nil; }
+    val m: usize = toml.table_len(parent);
+    var k: usize = 0;
+    for (k < m) {
+        if (str_equals(toml.table_key(parent, k), os)) {
+            val v: *toml.Value = toml.table_value(parent, k);
+            if (v != nil && v.tag == toml.TYPE_TABLE) { ret toml.get_array(?v.data.table, "libs"); }
+        }
+        k = k + 1;
+    }
+    ret nil;
+}
+
+# append_cascade_array: intern each string in `arr` and append it to `buf[0,w)`,
+# advancing `w`, skipping any id already present or in the consumer's own libs.
+# frees `buf` and errors on a non-string element. a nil `arr` is a no-op.
+fun append_cascade_array(p: *Project, buf: *intern.StrId, w: *u32, max: u32, arr: *toml.Array,
+                         own_libs: *intern.StrId, own_count: u32) Result[bool, str] {
+    if (arr == nil) { ret ok[bool, str](true); }
+    val cnt: usize = toml.array_len(arr);
+    var k: usize = 0;
+    for (k < cnt) {
+        val v: *toml.Value = toml.array_get(arr, k);
+        if (v == nil || v.tag != toml.TYPE_STRING) {
+            deallocate[intern.StrId](p.s.alloc, buf, max::usize);
+            ret err[bool, str]("dep mach.toml: a libs entry is not a string");
+        }
+        val idr: Result[intern.StrId, str] = intern.intern(?p.s.interner, v.data.string);
+        if (is_err[intern.StrId, str](idr)) {
+            deallocate[intern.StrId](p.s.alloc, buf, max::usize);
+            ret err[bool, str](unwrap_err[intern.StrId, str](idr));
+        }
+        val id: intern.StrId = unwrap_ok[intern.StrId, str](idr);
+        if (!strid_in(buf, @w, id) && !strid_in(own_libs, own_count, id)) {
+            buf[@w] = id; @w = @w + 1;
+        }
+        k = k + 1;
+    }
+    ret ok[bool, str](true);
+}
+
 # strid_in: whether `id` already appears in the first `count` entries of `arr`.
 fun strid_in(arr: *intern.StrId, count: u32, id: intern.StrId) bool {
     if (arr == nil) { ret false; }
@@ -1164,6 +1239,26 @@ fun resolve_dep(s: *sess.Session, alias: str, project_root: str, dir_dep: str) R
         ret err[DepEntry, str](unwrap_err[intern.StrId, str](rds));
     }
     entry.project_dir_src = unwrap_ok[intern.StrId, str](rds);
+
+    # the dep's declared `[project].module` (bare project-id import target). a
+    # declared-but-dangling module is a manifest error at build start, imported or
+    # not — so it is checked here for every resolved dep.
+    entry.project_module = intern.STR_NIL;
+    val dep_src_text: str = unwrap[str](intern.lookup(?s.interner, entry.project_dir_src));
+    val mod_text: str = toml.get_str(?t, "project.module");
+    if (!str_empty(mod_text)) {
+        if (!module_file_present(s.alloc, dep_dir, dep_src_text, mod_text)) {
+            val msg: str = diag_join_named(s, "dep '", entry.alias, "' mach.toml: [project].module names no file", "dep mach.toml: [project].module names no file");
+            str_free(s.alloc, dep_dir);
+            ret err[DepEntry, str](msg);
+        }
+        val rmd: Result[intern.StrId, str] = intern.intern(?s.interner, mod_text);
+        if (is_err[intern.StrId, str](rmd)) {
+            str_free(s.alloc, dep_dir);
+            ret err[DepEntry, str](unwrap_err[intern.StrId, str](rmd));
+        }
+        entry.project_module = unwrap_ok[intern.StrId, str](rmd);
+    }
 
     val rvr: Result[intern.StrId, str] = intern.intern(?s.interner, dep_dir);
     if (is_err[intern.StrId, str](rvr)) {
@@ -1257,12 +1352,19 @@ fun entry_module_fqn(p: *Project, t: *TargetEntry) Result[intern.StrId, str] {
 
     val id_opt: Option[str] = intern.lookup(?p.s.interner, p.config.id);
     if (is_none[str](id_opt)) { ret err[intern.StrId, str]("project id StrId not interned"); }
-    val id_text: str = unwrap[str](id_opt);
 
-    val ep_stripped: StrView = strip_mach_suffix(ep_text);
+    ret compose_module_fqn(p, unwrap[str](id_opt), ep_text);
+}
+
+# compose_module_fqn: build `<id>.<rel stripped of .mach, with `/`/`\` turned
+# into `.`>` and intern it. shared by the entrypoint FQN and bare project-id
+# `use`/`fwd` resolution, so a project's `[project].module` resolves to the same
+# canonical FQN a full path to that file would name.
+fun compose_module_fqn(p: *Project, id_text: str, rel_text: str) Result[intern.StrId, str] {
+    val rel_stripped: StrView = strip_mach_suffix(rel_text);
 
     val id_len: usize = str_len(id_text);
-    val total:  usize = id_len + 1 + ep_stripped.len;
+    val total:  usize = id_len + 1 + rel_stripped.len;
     val r_buf: Result[*u8, str] = allocate[u8](p.s.alloc, total);
     if (is_err[*u8, str](r_buf)) { ret err[intern.StrId, str](unwrap_err[*u8, str](r_buf)); }
     val buf: *u8 = unwrap_ok[*u8, str](r_buf);
@@ -1273,8 +1375,8 @@ fun entry_module_fqn(p: *Project, t: *TargetEntry) Result[intern.StrId, str] {
     buf[k] = '.';
     k = k + 1;
     j = 0;
-    for (j < ep_stripped.len) {
-        val c: u8 = ep_stripped.data[j];
+    for (j < rel_stripped.len) {
+        val c: u8 = rel_stripped.data[j];
         if (c == '/' || c == '\\') { buf[k] = '.'; }
         or                          { buf[k] = c; }
         k = k + 1;
@@ -1901,6 +2003,41 @@ pub rec UseTarget {
 # a symbol, and an unaliased import binds the final path segment as its
 # leaf. resolution always interns the full path first so an exact module
 # file short-circuits before any prefix probing.
+# span_single_segment: whether the dotted path covers exactly one segment (no
+# `.` separator) — the shape a bare project-id import takes.
+fun span_single_segment(source: str, path: token.Span) bool {
+    var k: usize = path.offset;
+    val end: usize = path.offset + path.len;
+    for (k < end) {
+        if (source[k] == '.') { ret false; }
+        k = k + 1;
+    }
+    ret true;
+}
+
+# project_module_lookup: resolve a bare project id against this project and its
+# direct deps. on a match sets `out_found` and reports the project's declared
+# module (`out_module`, STR_NIL when the project declares none). project ids and
+# the path id share one interner, so StrId equality is the lookup.
+fun project_module_lookup(p: *Project, id: intern.StrId, out_found: *bool, out_module: *intern.StrId) {
+    @out_found  = false;
+    @out_module = intern.STR_NIL;
+    if (id == p.config.id) {
+        @out_found  = true;
+        @out_module = p.config.module;
+        ret;
+    }
+    var k: u32 = 0;
+    for (k < p.config.dep_count) {
+        if (p.config.deps[k].project_id == id) {
+            @out_found  = true;
+            @out_module = p.config.deps[k].project_module;
+            ret;
+        }
+        k = k + 1;
+    }
+}
+
 fun resolve_use_target(p: *Project, source: str, path: token.Span) Result[UseTarget, str] {
     val full_r: Result[intern.StrId, str] = intern.intern_span(?p.s.interner, source, path);
     if (is_err[intern.StrId, str](full_r)) { ret err[UseTarget, str](unwrap_err[intern.StrId, str](full_r)); }
@@ -1909,6 +2046,30 @@ fun resolve_use_target(p: *Project, source: str, path: token.Span) Result[UseTar
     val leaf_r: Result[intern.StrId, str] = leaf_name(?p.s.interner, source, path);
     if (is_err[intern.StrId, str](leaf_r)) { ret err[UseTarget, str](unwrap_err[intern.StrId, str](leaf_r)); }
     val leaf: intern.StrId = unwrap_ok[intern.StrId, str](leaf_r);
+
+    # a one-segment path equal to a resolvable project id (a dependency's manifest
+    # id or this project's own id) names that project's declared `[project].module`
+    # (#1326). length-≥2 paths are unchanged; a single segment is unresolvable as a
+    # file, so this interception is purely additive.
+    if (span_single_segment(source, path)) {
+        var found:  bool = false;
+        var mod_id: intern.StrId = intern.STR_NIL;
+        project_module_lookup(p, full_id, ?found, ?mod_id);
+        if (found) {
+            if (mod_id == intern.STR_NIL) {
+                ret err[UseTarget, str](diag_join_named(p.s, "project '", full_id, "' declares no module; import a full path or add one to its manifest", "project declares no module; import a full path or add one to its manifest"));
+            }
+            val id_opt:  Option[str] = intern.lookup(?p.s.interner, full_id);
+            val mod_opt: Option[str] = intern.lookup(?p.s.interner, mod_id);
+            if (is_none[str](id_opt) || is_none[str](mod_opt)) { ret err[UseTarget, str]("internal: project id/module not interned"); }
+            val fqn_r: Result[intern.StrId, str] = compose_module_fqn(p, unwrap[str](id_opt), unwrap[str](mod_opt));
+            if (is_err[intern.StrId, str](fqn_r)) { ret err[UseTarget, str](unwrap_err[intern.StrId, str](fqn_r)); }
+            var ut: UseTarget;
+            ut.module_fqn = unwrap_ok[intern.StrId, str](fqn_r);
+            ut.leaf       = leaf;
+            ret ok[UseTarget, str](ut);
+        }
+    }
 
     # the full path is itself a module file: bind it as a module, leaf is its own name.
     if (fqn_names_file(p, full_id)) {
@@ -2192,15 +2353,46 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
         head = head + 1;
     }
 
-    val r: Result[*resolve.ModuleExports, str] = allocate[resolve.ModuleExports](p.s.alloc, list_len::usize);
+    # a dep that is a project's declared `[project].module` is also nameable by the
+    # project's bare id (#1326), so it needs a second exports entry keyed by that
+    # id — matching the load walk, where `use <id>;` resolves to this same module.
+    val ar: Result[*intern.StrId, str] = allocate[intern.StrId](p.s.alloc, list_len::usize);
+    if (is_err[*intern.StrId, str](ar)) {
+        deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
+        deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+        ret err[resolve.ResolveDeps, str](unwrap_err[*intern.StrId, str](ar));
+    }
+    val aliases: *intern.StrId = unwrap_ok[*intern.StrId, str](ar);
+    var alias_n: u32 = 0;
+    var ai: u32 = 0;
+    for (ai < list_len) {
+        aliases[ai] = bare_alias_for_module(p, p.modules[list[ai]::u32].fqn);
+        if (aliases[ai] != intern.STR_NIL) { alias_n = alias_n + 1; }
+        ai = ai + 1;
+    }
+
+    val total: u32 = list_len + alias_n;
+    val r: Result[*resolve.ModuleExports, str] = allocate[resolve.ModuleExports](p.s.alloc, total::usize);
     if (is_err[*resolve.ModuleExports, str](r)) {
+        deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
         deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
         deallocate[bool](p.s.alloc, visited, p.module_len::usize);
         ret err[resolve.ResolveDeps, str](unwrap_err[*resolve.ModuleExports, str](r));
     }
     deps.entries = unwrap_ok[*resolve.ModuleExports, str](r);
-    deps.count   = list_len;
+    deps.count   = total;
 
+    # initialise every slot empty so a partial fill is teardown-safe: an error
+    # mid-loop frees only the slots already built (the rest carry nil symbols),
+    # while the array deallocation always sees the full `total` size.
+    var z: u32 = 0;
+    for (z < total) {
+        deps.entries[z].symbols = nil;
+        deps.entries[z].count   = 0;
+        z = z + 1;
+    }
+
+    var w: u32 = 0;
     var k: u32 = 0;
     for (k < list_len) {
         val dep_id: sess.ModuleId = list[k];
@@ -2208,17 +2400,63 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
         val mx_r: Result[resolve.ModuleExports, str] = build_module_exports(p, dep_id, dep);
         if (is_err[resolve.ModuleExports, str](mx_r)) {
             free_resolve_deps(p.s.alloc, ?deps);
+            deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
             deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
             deallocate[bool](p.s.alloc, visited, p.module_len::usize);
             ret err[resolve.ResolveDeps, str](unwrap_err[resolve.ModuleExports, str](mx_r));
         }
-        deps.entries[k] = unwrap_ok[resolve.ModuleExports, str](mx_r);
+        deps.entries[w] = unwrap_ok[resolve.ModuleExports, str](mx_r);
+        w = w + 1;
+        if (aliases[k] != intern.STR_NIL) {
+            val ax_r: Result[resolve.ModuleExports, str] = build_module_exports(p, dep_id, dep);
+            if (is_err[resolve.ModuleExports, str](ax_r)) {
+                free_resolve_deps(p.s.alloc, ?deps);
+                deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
+                deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
+                deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+                ret err[resolve.ResolveDeps, str](unwrap_err[resolve.ModuleExports, str](ax_r));
+            }
+            var ax: resolve.ModuleExports = unwrap_ok[resolve.ModuleExports, str](ax_r);
+            ax.path = aliases[k];
+            deps.entries[w] = ax;
+            w = w + 1;
+        }
         k = k + 1;
     }
 
+    deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
     deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
     deallocate[bool](p.s.alloc, visited, p.module_len::usize);
     ret ok[resolve.ResolveDeps, str](deps);
+}
+
+# bare_alias_for_module: the project id whose declared `[project].module` resolves
+# to module `mod_fqn`, or STR_NIL when `mod_fqn` is not any project's declared
+# module. lets resolve name such a module by the project's bare id (#1326). a
+# no-op when no project in the build declares a module.
+fun bare_alias_for_module(p: *Project, mod_fqn: intern.StrId) intern.StrId {
+    if (p.config.module != intern.STR_NIL && canonical_module_fqn_is(p, p.config.id, p.config.module, mod_fqn)) {
+        ret p.config.id;
+    }
+    var k: u32 = 0;
+    for (k < p.config.dep_count) {
+        val dep: *DepEntry = ?p.config.deps[k];
+        if (dep.project_module != intern.STR_NIL && canonical_module_fqn_is(p, dep.project_id, dep.project_module, mod_fqn)) {
+            ret dep.project_id;
+        }
+        k = k + 1;
+    }
+    ret intern.STR_NIL;
+}
+
+# canonical_module_fqn_is: whether `<id>.<module>` composes to the FQN `fqn`.
+fun canonical_module_fqn_is(p: *Project, id: intern.StrId, module: intern.StrId, fqn: intern.StrId) bool {
+    val id_opt:  Option[str] = intern.lookup(?p.s.interner, id);
+    val mod_opt: Option[str] = intern.lookup(?p.s.interner, module);
+    if (is_none[str](id_opt) || is_none[str](mod_opt)) { ret false; }
+    val cf_r: Result[intern.StrId, str] = compose_module_fqn(p, unwrap[str](id_opt), unwrap[str](mod_opt));
+    if (is_err[intern.StrId, str](cf_r)) { ret false; }
+    ret unwrap_ok[intern.StrId, str](cf_r) == fqn;
 }
 
 # add_reexport_targets: append every module that `mid` re-exports as a `fwd`

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -14,6 +14,7 @@ use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
+use std.types.char.char;
 
 use std.types.string.str;
 use std.types.string.str_len;
@@ -389,16 +390,56 @@ fun parse_str_array(alloc: *Allocator, i: *intern.Interner, arr: *toml.Array, el
 fun parse_opt_level(alloc: *Allocator, name: str, sub: *toml.Table) Result[MOpt, str] {
     val v: *toml.Value = toml.get(sub, "opt");
     if (v == nil) { ret ok[MOpt, str](MOPT_DEFAULT); }
-    if (v.tag != toml.TYPE_INTEGER) { ret err[MOpt, str](opt_err(alloc, name)); }
+    if (v.tag != toml.TYPE_INTEGER) { ret err[MOpt, str](opt_err(alloc, name, v)); }
     val n: i64 = v.data.integer;
     if (n == 0)            { ret ok[MOpt, str](MOPT_DEBUG); }
     if (n == 1 || n == 2)  { ret ok[MOpt, str](MOPT_RELEASE); }
-    ret err[MOpt, str](opt_err(alloc, name));
+    ret err[MOpt, str](opt_err(alloc, name, v));
 }
 
-# opt_err: the `profile '<name>': opt must be 0, 1, or 2` diagnostic.
-fun opt_err(alloc: *Allocator, name: str) str {
-    ret cc3(alloc, "mach.toml: profile '", name, "': opt must be 0, 1, or 2");
+# opt_err: the `profile '<name>': opt must be 0, 1, or 2 (got <value>)` diagnostic,
+# naming the offending value so the user sees exactly what was rejected.
+fun opt_err(alloc: *Allocator, name: str, v: *toml.Value) str {
+    ret cc5(alloc, "mach.toml: profile '", name, "': opt must be 0, 1, or 2 (got ",
+        opt_value_text(alloc, v), ")");
+}
+
+# opt_value_text: a human reading of the offending `opt` value for the diagnostic.
+fun opt_value_text(alloc: *Allocator, v: *toml.Value) str {
+    if (v.tag == toml.TYPE_INTEGER) { ret int_to_str(alloc, v.data.integer); }
+    if (v.tag == toml.TYPE_STRING)  { ret cc3(alloc, "\"", v.data.string, "\""); }
+    if (v.tag == toml.TYPE_BOOL) {
+        if (v.data.boolean) { ret "true"; }
+        ret "false";
+    }
+    if (v.tag == toml.TYPE_FLOAT) { ret "a float"; }
+    if (v.tag == toml.TYPE_ARRAY) { ret "an array"; }
+    if (v.tag == toml.TYPE_TABLE) { ret "a table"; }
+    ret "a value";
+}
+
+# int_to_str: the decimal text of an i64, freshly allocated and owned by `alloc`.
+fun int_to_str(alloc: *Allocator, n: i64) str {
+    if (n == 0) { ret "0"; }
+    var neg: bool = false;
+    var u: u64 = n::u64;
+    if (n < 0) { neg = true; u = (0 - n)::u64; }
+
+    var digits: [24]char;
+    var len: usize = 0;
+    for (u > 0) { digits[len] = (u % 10)::char + '0'; u = u / 10; len = len + 1; }
+
+    var total: usize = len;
+    if (neg) { total = total + 1; }
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret "?"; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    if (neg) { buf[0] = '-'; k = 1; }
+    var i: usize = len;
+    for (i > 0) { i = i - 1; buf[k] = digits[i]::u8; k = k + 1; }
+    buf[k] = 0;
+    ret buf::str;
 }
 
 # unknown_key_msg: the "unknown key" diagnostic for `key` under `label`.
@@ -1960,11 +2001,11 @@ test "manifest: a profile opt outside 0..2 is rejected naming the profile" {
     var code: i32 = 0;
 
     val a: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[bin.app]\nentry=\"main.mach\"\n[profile.debug]\nopt = 9\n");
-    if (is_ok[Manifest, str](a) || !str_equals(unwrap_err[Manifest, str](a), "mach.toml: profile 'debug': opt must be 0, 1, or 2")) { code = 1; }
+    if (is_ok[Manifest, str](a) || !str_equals(unwrap_err[Manifest, str](a), "mach.toml: profile 'debug': opt must be 0, 1, or 2 (got 9)")) { code = 1; }
 
-    # a string opt is the old form and is no longer accepted.
+    # a string opt is the old form and is no longer accepted; the error names it.
     val b: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[bin.app]\nentry=\"main.mach\"\n[profile.release]\nopt = \"O2\"\n");
-    if (is_ok[Manifest, str](b) || !str_equals(unwrap_err[Manifest, str](b), "mach.toml: profile 'release': opt must be 0, 1, or 2")) { code = 1; }
+    if (is_ok[Manifest, str](b) || !str_equals(unwrap_err[Manifest, str](b), "mach.toml: profile 'release': opt must be 0, 1, or 2 (got \"O2\")")) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -159,6 +159,20 @@ pub rec ProfileDef {
     emit_asm: bool;
 }
 
+# OsDef: one `[os.<name>] libs = [...]` link overlay scoped to a single tuple
+# component. a consumer's selected tuple matches the overlay iff its os equals
+# `<name>`, so a platform link requirement lives once and cascades like a target
+# lib without re-enumerating every isa/abi tuple it applies to.
+# ---
+# name:      interned os name this overlay gates on (e.g. "windows")
+# libs:      interned link inputs; nil when none
+# lib_count: number of entries in libs
+pub rec OsDef {
+    name:      intern.StrId;
+    libs:      *intern.StrId;
+    lib_count: u32;
+}
+
 # DepDef: one `[deps.<name>]` dependency. exactly one source key — `git` or
 # `path` — plus an optional `ref` for git. registry `version =` is reserved
 # and rejected at parse time.
@@ -181,6 +195,8 @@ pub rec DepDef {
 # name:           interned `[project].name` metadata, STR_NIL when omitted
 # description:    interned `[project].description` metadata, STR_NIL when omitted
 # license:        interned `[project].license` metadata, STR_NIL when omitted
+# module:         interned `[project].module` — the src-relative module file a
+#                 bare project-id `use`/`fwd` path resolves to; STR_NIL when none
 # src:            interned source dir (default "src")
 # dep:            interned vendored-dependency dir (default "dep")
 # default_target: interned `[project].target` default selector (default "native")
@@ -196,12 +212,15 @@ pub rec DepDef {
 # profile_count:  number of profiles
 # deps:           declared `[deps.*]` dependencies
 # dep_count:      number of deps
+# os_overlays:      declared `[os.*]` link overlays
+# os_overlay_count: number of os overlays
 pub rec Manifest {
     id:             intern.StrId;
     version:        intern.StrId;
     name:           intern.StrId;
     description:    intern.StrId;
     license:        intern.StrId;
+    module:         intern.StrId;
     src:            intern.StrId;
     dep:            intern.StrId;
     default_target: intern.StrId;
@@ -217,6 +236,8 @@ pub rec Manifest {
     profile_count:  u32;
     deps:           *DepDef;
     dep_count:      u32;
+    os_overlays:      *OsDef;
+    os_overlay_count: u32;
 }
 
 # DEFAULT_OUT: the init-written artifact path template.
@@ -393,14 +414,19 @@ val TK_LIB:     u8 = 3;
 val TK_PROFILE: u8 = 4;
 val TK_DEP:     u8 = 5;
 val TK_CELL:    u8 = 6;
+val TK_OS:      u8 = 7;
 
 # key_known: whether `k` is an allowed key for the given table kind.
 fun key_known(kind: u8, k: str) bool {
     if (kind == TK_PROJECT) {
         ret str_equals(k, "id") || str_equals(k, "version") || str_equals(k, "name")
             || str_equals(k, "description") || str_equals(k, "license") || str_equals(k, "authors")
-            || str_equals(k, "src") || str_equals(k, "dep") || str_equals(k, "target")
-            || str_equals(k, "out") || str_equals(k, "obj") || str_equals(k, "ir") || str_equals(k, "asm");
+            || str_equals(k, "module") || str_equals(k, "src") || str_equals(k, "dep")
+            || str_equals(k, "target") || str_equals(k, "out") || str_equals(k, "obj")
+            || str_equals(k, "ir") || str_equals(k, "asm");
+    }
+    if (kind == TK_OS) {
+        ret str_equals(k, "libs");
     }
     if (kind == TK_TARGET) {
         ret str_equals(k, "isa") || str_equals(k, "os") || str_equals(k, "abi")
@@ -458,6 +484,8 @@ pub fun parse(alloc: *Allocator, i: *intern.Interner, t: *toml.Table) Result[Man
     m.profile_count  = 0;
     m.deps           = nil;
     m.dep_count      = 0;
+    m.os_overlays      = nil;
+    m.os_overlay_count = 0;
 
     val pr: *toml.Table = toml.get_table(t, "project");
     if (pr == nil) { ret err[Manifest, str]("mach.toml: missing [project] table"); }
@@ -506,6 +534,13 @@ pub fun parse(alloc: *Allocator, i: *intern.Interner, t: *toml.Table) Result[Man
     if (is_err[intern.StrId, str](rlc)) { ret err[Manifest, str](unwrap_err[intern.StrId, str](rlc)); }
     m.license = unwrap_ok[intern.StrId, str](rlc);
 
+    val module_str: str = toml.get_str(pr, "module");
+    val cpm: Result[bool, str] = check_path(alloc, module_str, "[project].module");
+    if (is_err[bool, str](cpm)) { ret err[Manifest, str](unwrap_err[bool, str](cpm)); }
+    val rmd: Result[intern.StrId, str] = intern_opt(i, module_str);
+    if (is_err[intern.StrId, str](rmd)) { ret err[Manifest, str](unwrap_err[intern.StrId, str](rmd)); }
+    m.module = unwrap_ok[intern.StrId, str](rmd);
+
     m.src            = intern_unwrap(i, src_str);
     m.dep            = intern_unwrap(i, dep_str);
     m.out_tmpl       = intern_unwrap(i, out_str);
@@ -525,6 +560,14 @@ pub fun parse(alloc: *Allocator, i: *intern.Interner, t: *toml.Table) Result[Man
 
     val dr: Result[bool, str] = parse_deps(alloc, i, t, ?m);
     if (is_err[bool, str](dr)) { dnit(?m, alloc); ret err[Manifest, str](unwrap_err[bool, str](dr)); }
+
+    # `[isa.*]`/`[abi.*]` single-component overlays are reserved until a real case
+    # demands them; only `[os.*]` is implemented today.
+    if (toml.get_table(t, "isa") != nil) { dnit(?m, alloc); ret err[Manifest, str]("mach.toml: [isa.*] overlays are reserved"); }
+    if (toml.get_table(t, "abi") != nil) { dnit(?m, alloc); ret err[Manifest, str]("mach.toml: [abi.*] overlays are reserved"); }
+
+    val osr: Result[bool, str] = parse_os_overlays(alloc, i, t, ?m);
+    if (is_err[bool, str](osr)) { dnit(?m, alloc); ret err[Manifest, str](unwrap_err[bool, str](osr)); }
 
     ret ok[Manifest, str](m);
 }
@@ -866,6 +909,49 @@ fun parse_deps(alloc: *Allocator, i: *intern.Interner, t: *toml.Table, m: *Manif
     ret ok[bool, str](true);
 }
 
+# parse_os_overlays: read every `[os.<name>] libs = [...]` link overlay. each
+# stanza accepts only the `libs` key; the os name is the table key and gates the
+# overlay by tuple-component (os) equality.
+fun parse_os_overlays(alloc: *Allocator, i: *intern.Interner, t: *toml.Table, m: *Manifest) Result[bool, str] {
+    val tab: *toml.Table = toml.get_table(t, "os");
+    if (tab == nil) { ret ok[bool, str](true); }
+    val n: usize = toml.table_len(tab);
+    if (n == 0) { ret ok[bool, str](true); }
+
+    val r: Result[*OsDef, str] = allocate[OsDef](alloc, n);
+    if (is_err[*OsDef, str](r)) { ret err[bool, str](unwrap_err[*OsDef, str](r)); }
+    m.os_overlays      = unwrap_ok[*OsDef, str](r);
+    m.os_overlay_count = n::u32;
+
+    var k: usize = 0;
+    for (k < n) {
+        val name: str = toml.table_key(tab, k);
+        val v: *toml.Value = toml.table_value(tab, k);
+        val label: str = cc3(alloc, "[os.", name, "]");
+        if (v == nil || v.tag != toml.TYPE_TABLE) {
+            ret err[bool, str](cc3(alloc, "mach.toml: ", label, " must be a table"));
+        }
+        val sub: *toml.Table = ?v.data.table;
+        val ck: Result[bool, str] = check_keys(alloc, sub, label, TK_OS);
+        if (is_err[bool, str](ck)) { ret ck; }
+
+        var d: OsDef;
+        d.libs      = nil;
+        d.lib_count = 0;
+        d.name = intern_unwrap(i, name);
+
+        val lr: Result[StrArr, str] = parse_str_array(alloc, i, toml.get_array(sub, "libs"),
+            cc3(alloc, "mach.toml: ", label, ".libs must be an array of strings"));
+        if (is_err[StrArr, str](lr)) { ret err[bool, str](unwrap_err[StrArr, str](lr)); }
+        val la: StrArr = unwrap_ok[StrArr, str](lr);
+        d.libs = la.items; d.lib_count = la.count;
+
+        m.os_overlays[k] = d;
+        k = k + 1;
+    }
+    ret ok[bool, str](true);
+}
+
 # dnit: release every owned array on a Manifest (and its nested overlays).
 pub fun dnit(m: *Manifest, alloc: *Allocator) {
     if (m.targets != nil && m.target_count > 0) {
@@ -905,6 +991,15 @@ pub fun dnit(m: *Manifest, alloc: *Allocator) {
     if (m.deps != nil && m.dep_count > 0) {
         deallocate[DepDef](alloc, m.deps, m.dep_count::usize);
         m.deps = nil; m.dep_count = 0;
+    }
+    if (m.os_overlays != nil && m.os_overlay_count > 0) {
+        var k: u32 = 0;
+        for (k < m.os_overlay_count) {
+            free_strarr(alloc, m.os_overlays[k].libs, m.os_overlays[k].lib_count);
+            k = k + 1;
+        }
+        deallocate[OsDef](alloc, m.os_overlays, m.os_overlay_count::usize);
+        m.os_overlays = nil; m.os_overlay_count = 0;
     }
 }
 
@@ -1238,6 +1333,17 @@ pub fun resolve_artifact(alloc: *Allocator, i: *intern.Interner, m: *Manifest, s
     ret nil;
 }
 
+# find_os_overlay: the `[os.<name>]` overlay whose name equals the resolved
+# target's os id, or nil when none matches.
+fun find_os_overlay(m: *Manifest, os_id: intern.StrId) *OsDef {
+    var k: u32 = 0;
+    for (k < m.os_overlay_count) {
+        if (m.os_overlays[k].name == os_id) { ret ?m.os_overlays[k]; }
+        k = k + 1;
+    }
+    ret nil;
+}
+
 # find_cell: the per-cell override for `art` matching the target named `tname`,
 # or nil when none refines that target.
 fun find_cell(art: *ArtifactDef, tname: intern.StrId) *CellDef {
@@ -1249,21 +1355,26 @@ fun find_cell(art: *ArtifactDef, tname: intern.StrId) *CellDef {
     ret nil;
 }
 
-# merge_libs: the deduplicated target+artifact+cell link overlay, in that
-# precedence order. owned by `alloc`; nil/0 when empty.
-fun merge_libs(alloc: *Allocator, t: *TargetDef, a: *ArtifactDef, cell: *CellDef) Result[StrArr, str] {
+# merge_libs: the deduplicated os-overlay+target+artifact+cell link overlay, in
+# that precedence order — the os overlay leads (matching the cascade's merge law:
+# matching os overlays then matching target libs). owned by `alloc`; nil/0 when
+# empty.
+fun merge_libs(alloc: *Allocator, os_ov: *OsDef, t: *TargetDef, a: *ArtifactDef, cell: *CellDef) Result[StrArr, str] {
     var out: StrArr;
     out.items = nil;
     out.count = 0;
     var cell_n: u32 = 0;
     if (cell != nil) { cell_n = cell.lib_count; }
-    val max: u32 = t.lib_count + a.lib_count + cell_n;
+    var os_n: u32 = 0;
+    if (os_ov != nil) { os_n = os_ov.lib_count; }
+    val max: u32 = os_n + t.lib_count + a.lib_count + cell_n;
     if (max == 0) { ret ok[StrArr, str](out); }
 
     val r: Result[*intern.StrId, str] = allocate[intern.StrId](alloc, max::usize);
     if (is_err[*intern.StrId, str](r)) { ret err[StrArr, str](unwrap_err[*intern.StrId, str](r)); }
     val buf: *intern.StrId = unwrap_ok[*intern.StrId, str](r);
     var c: u32 = 0;
+    if (os_ov != nil) { c = append_unique(buf, c, os_ov.libs, os_ov.lib_count); }
     c = append_unique(buf, c, t.libs, t.lib_count);
     c = append_unique(buf, c, a.libs, a.lib_count);
     if (cell != nil) { c = append_unique(buf, c, cell.libs, cell.lib_count); }
@@ -1417,6 +1528,7 @@ pub fun resolve_build_unit(alloc: *Allocator, i: *intern.Interner, m: *Manifest,
     if (a == nil) { ret err[BuildUnit, str](artifact_err(alloc, i, m, sel)); }
 
     val cell: *CellDef = find_cell(a, rt.target.name);
+    val os_ov: *OsDef = find_os_overlay(m, rt.target.os);
 
     var u: BuildUnit;
     u.target       = rt.target;
@@ -1433,7 +1545,7 @@ pub fun resolve_build_unit(alloc: *Allocator, i: *intern.Interner, m: *Manifest,
     u.entry = a.entry;
     if (cell != nil && cell.entry != intern.STR_NIL) { u.entry = cell.entry; }
 
-    val lm: Result[StrArr, str] = merge_libs(alloc, rt.target, a, cell);
+    val lm: Result[StrArr, str] = merge_libs(alloc, os_ov, rt.target, a, cell);
     if (is_err[StrArr, str](lm)) { ret err[BuildUnit, str](unwrap_err[StrArr, str](lm)); }
     val merged: StrArr = unwrap_ok[StrArr, str](lm);
     u.libs = merged.items;
@@ -1949,6 +2061,83 @@ test "manifest: a per-cell [bin.X.target.Y] override refines entry and merges li
             if (bu.lib_count != 3) { code = 1; }
         }
     }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: a project module key parses, absent yields STR_NIL" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val a: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"glfw\"\nversion=\"1\"\nmodule=\"glfw.mach\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[lib.glfw]\nentry=\"glfw.mach\"\n");
+    if (is_err[Manifest, str](a)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](a);
+        if (!str_equals(idstr(?itn, m.module), "glfw.mach")) { code = 1; }
+    }
+
+    val b: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[lib.x]\nentry=\"lib.mach\"\n");
+    if (is_err[Manifest, str](b)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](b);
+        if (m.module != intern.STR_NIL) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: an [os.<name>] overlay merges into a matching os build only" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[os.windows]\nlibs=[\"user32.dll\"]\n[bin.app]\nentry=\"main.mach\"\n";
+    val mr: Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = unwrap_ok[Manifest, str](mr);
+        if (m.os_overlay_count != 1) { code = 1; }
+
+        # a windows build inherits the overlay; a linux build does not.
+        val uw: Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("windows", "", "app", false, true));
+        if (is_err[BuildUnit, str](uw)) { code = 1; }
+        or {
+            val bu: BuildUnit = unwrap_ok[BuildUnit, str](uw);
+            if (!strarr_has(?itn, bu.libs, bu.lib_count, "user32.dll")) { code = 1; }
+        }
+        val ul: Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("linux", "", "app", false, true));
+        if (is_err[BuildUnit, str](ul)) { code = 1; }
+        or {
+            val bu: BuildUnit = unwrap_ok[BuildUnit, str](ul);
+            if (strarr_has(?itn, bu.libs, bu.lib_count, "user32.dll")) { code = 1; }
+        }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: [isa.*] and [abi.*] overlays are reserved" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val a: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[isa.x86_64]\nlibs=[\"a.o\"]\n");
+    if (is_ok[Manifest, str](a) || !str_equals(unwrap_err[Manifest, str](a), "mach.toml: [isa.*] overlays are reserved")) { code = 1; }
+
+    val b: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[abi.sysv64]\nlibs=[\"a.o\"]\n");
+    if (is_ok[Manifest, str](b) || !str_equals(unwrap_err[Manifest, str](b), "mach.toml: [abi.*] overlays are reserved")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "manifest: an [os.<name>] overlay rejects an unknown key" {
+    var backing: Allocator; var ar: arena.Arena; var alloc: Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val a: Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[os.linux]\ndefines=[\"a\"]\n");
+    if (is_ok[Manifest, str](a) || !str_equals(unwrap_err[Manifest, str](a), "mach.toml: unknown key 'defines' in [os.linux]")) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -1,15 +1,15 @@
 # mach.lang.version: the compiler's own version string — the single source of
 # truth read by the driver (for `$mach.compiler.version`) and by `mach info`.
 #
-# the `$project.version` flip (#1311) lands here: once a release seed can fold
-# the root, this body becomes `ret $project.version;` and every consumer tracks
-# the manifest with no further edits. until then the literal is hand-synced with
-# `[project].version` in mach.toml. routing both consumers through this one
-# function is what keeps that flip a single-line change.
+# the value comes straight from the manifest: `$project.version` folds to
+# `[project].version` of the project being built, which for the compiler's own
+# build is its `mach.toml` version. routing both consumers through this one
+# function keeps the version single-sourced in the manifest, with no literal to
+# hand-sync (#1311).
 
 use std.types.string.str;
 
 # string: the compiler version (e.g. "1.3.1").
 pub fun string() str {
-    ret "1.3.1";
+    ret $project.version;
 }


### PR DESCRIPTION
Implements #1218's spec amendments 4+5 (project module, os link overlays), the two deferred #1046 diagnostics, and the #1311 version flip — four pieces, one PR on the post-hard-cut manifest surface.

## 1. `[project] module` — bare project-id imports
A one-segment `use`/`fwd` path equal to a resolvable project id (a dependency's manifest id, or the project's own id) resolves to that project's declared `[project].module` (src-relative, matching `entry`). Resolution composes the canonical module FQN `<id>.<module>`, so a bare `use glfw;` binds the same module a full path would — shared by the load walk and the resolver's dep surface.

- Bare import of a module-less project → resolution error naming the fix.
- Declared-but-dangling module path → manifest error at build start, imported or not.
- Self-`fwd` of the project id → existing circular-module detection.
- `mach init --lib` scaffolds `module = "lib.mach"`.

## 2. `[os.<name>] libs` overlays
Single-component link overlay matched on the selected tuple's `os`, cascading transitively beside the full-tuple `[target.*].libs`. Merge law: matching os overlays then matching target libs, deduped by name, topological dep order outermost. `[isa.*]`/`[abi.*]` parse to a reserved error.

## 3. Deferred diagnostics (#1046)
`opt` error names the offending value (`opt must be 0, 1, or 2 (got 9)` / `(got "O2")`); empty-define-name names the entry (`define '=x' has an empty name`).

## 4. `$project.version` flip (#1311)
`version.string()` returns `$project.version` instead of a hand-synced literal; the v1.3.1 seed folds the root. Folded value identical to the prior literal.

## Verification
- `mach build .` clean; `mach test .` 390/390 pass.
- **Byte-identical fixpoint** confirmed (seed→stage1→stage2 converge): pieces 1–3 add only inert-when-unused code (no project in the compiler build declares a module or os overlay), and the version flip yields the identical string value — `mach info --version` reports `1.3.1` from the manifest.
- Full integration battery (25 suites) green, including the new `module` suite (use+fwd, both error cases, self-import) and the extended `manifest` cascade (os overlay reaches windows, gated from linux).

Closes #1326
Closes #1311