### PR TITLE
chore: post-v1.4.0 std v0.5.0 closeout

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -27,4 +27,4 @@ entry = "main.mach"
 
 [deps.mach-std]
 git = "https://github.com/octalide/mach-std"
-ref = "branch/dev"
+ref = "v0.5.0"

--- a/mach.toml
+++ b/mach.toml
@@ -20,7 +20,6 @@ isa  = "x86_64"
 os   = "windows"
 abi  = "win64"
 ext  = ".exe"
-libs = ["kernel32.dll"]
 
 [bin.mach]
 entry = "main.mach"

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -56,6 +56,7 @@ use std.types.string.StrView;
 use std.types.string.str_len;
 use std.types.string.view;
 use std.types.string.view_eq_str;
+use std.types.string.view_contains_char;
 
 use std.allocator.Allocator;
 use std.allocator.allocate;
@@ -733,7 +734,7 @@ fun eval_lit_str(source: str, span: token.Span, interner: *intern.Interner) Resu
 
 # decodes escape sequences in `inner` and interns the result via `interner`
 fun intern_decoded(interner: *intern.Interner, inner: StrView) Result[intern.StrId, str] {
-    val has_escape: bool = contains_byte(inner, '\\');
+    val has_escape: bool = view_contains_char(inner, '\\');
     if (!has_escape) {
         ret intern.intern_bytes(interner, inner.data::str, inner.len);
     }
@@ -819,17 +820,6 @@ fun hex_digit(c: u8) i64 {
     if (c >= 'a' && c <= 'f') { ret (c - 'a')::i64 + 10; }
     if (c >= 'A' && c <= 'F') { ret (c - 'A')::i64 + 10; }
     ret 0 - 1;
-}
-
-# true when byte `b` occurs in view `s`.
-# TODO(#1302): kept local; std.types.string StrView has no view_index_char/contains.
-fun contains_byte(s: StrView, b: u8) bool {
-    var i: usize = 0;
-    for (i < s.len) {
-        if (s.data[i] == b) { ret true; }
-        i = i + 1;
-    }
-    ret false;
 }
 
 # binary-operator dispatch

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -539,17 +539,6 @@ fun free_payload(t: *IrTypeTable, ir: *IrType) {
     }
 }
 
-# true when two IrTypeId sequences of length `n` are element-wise equal.
-# TODO(#1302): kept local; std.memory has no generic equal[T] yet.
-fun id_seq_equals(a: *IrTypeId, b: *IrTypeId, n: u32) bool {
-    var i: u32 = 0;
-    for (i < n) {
-        if (a[i] != b[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
-}
-
 # rounds `value` up to the next multiple of `align` (a power-of-two alignment).
 # an alignment of 0 or 1 returns `value` unchanged. used by the natural C-style
 # aggregate-layout computations.
@@ -647,13 +636,13 @@ fun eq_ir_type(pa: ptr, pb: ptr) bool {
     }
     if (a.kind == IRT_STRUCT || a.kind == IRT_UNION) {
         if (a.data.struct_.field_count != b.data.struct_.field_count) { ret false; }
-        ret id_seq_equals(a.data.struct_.fields, b.data.struct_.fields, a.data.struct_.field_count);
+        ret mem.equal[IrTypeId](a.data.struct_.fields, b.data.struct_.fields, a.data.struct_.field_count::usize);
     }
     if (a.kind == IRT_FN) {
         if (a.data.fn.ret_ty != b.data.fn.ret_ty) { ret false; }
         if (a.data.fn.param_count != b.data.fn.param_count) { ret false; }
         if (a.data.fn.varargs != b.data.fn.varargs) { ret false; }
-        ret id_seq_equals(a.data.fn.params, b.data.fn.params, a.data.fn.param_count);
+        ret mem.equal[IrTypeId](a.data.fn.params, b.data.fn.params, a.data.fn.param_count::usize);
     }
     # IRT_VOID and IRT_PTR are equal by kind alone.
     ret true;

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -278,7 +278,8 @@ pub fun set_input(db: *QueryDb, kind: QueryKind, key: u64, value: *u8, value_len
 
     val existing: *QueryEntry = find_entry(sh, key);
     if (existing != nil) {
-        val same: bool = bytes_equal(existing.value, existing.value_len, value, value_len);
+        val same: bool = existing.value_len == value_len
+            && mem.raw_equal(existing.value::ptr, value::ptr, value_len::usize);
         val rcopy: Result[*u8, str] = dup_bytes(db.alloc, value, value_len);
         if (is_err[*u8, str](rcopy)) { ret err[bool, str](unwrap_err[*u8, str](rcopy)); }
         if (existing.value != nil && existing.value_len > 0) {
@@ -547,7 +548,8 @@ fun recompute(db: *QueryDb, sh: *QueryShard, e: *QueryEntry, key: u64) Result[*Q
     }
     val out: QueryOutput = unwrap_ok[QueryOutput, str](rout);
 
-    val same: bool = bytes_equal(e.value, e.value_len, out.bytes, out.len);
+    val same: bool = e.value_len == out.len
+        && mem.raw_equal(e.value::ptr, out.bytes::ptr, out.len::usize);
     if (same) {
         if (out.bytes != nil && out.len > 0) {
             deallocate[u8](db.alloc, out.bytes, out.len::usize);
@@ -660,19 +662,6 @@ fun dup_bytes(alloc: *Allocator, src: *u8, len: u32) Result[*u8, str] {
     val dst: *u8 = unwrap_ok[*u8, str](r);
     mem.raw_copy(dst::ptr, src::ptr, len::usize);
     ret ok[*u8, str](dst);
-}
-
-# bytes_equal: byte-wise equality of two buffers. nil buffers compare as length-0.
-# TODO(#1302): kept local; std.memory has no raw_equal/equal[T] yet.
-fun bytes_equal(a: *u8, a_len: u32, b: *u8, b_len: u32) bool {
-    if (a_len != b_len) { ret false; }
-    if (a_len == 0) { ret true; }
-    var i: u32 = 0;
-    for (i < a_len) {
-        if (a[i] != b[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
 }
 
 # a derived compute that always fails, to exercise the failed-recompute path.


### PR DESCRIPTION
Post-v1.4.0 std closeout against mach-std v0.5.0. Four pieces:

1. **dep bump** — vendored `dep/mach-std` submodule advanced to `3e4849ad` (v0.5.0 main merge; current-format manifest, kernel32 via `[os.windows]`). `[deps.mach-std]` pinned to the `v0.5.0` tag (origin/dev has advanced past it, so the old `branch/dev` ref would have diverged from the gitlink; the tag pin keeps resolution and the submodule in lockstep and avoids transitive ref-conflicts for downstream consumers).
2. **kernel32 cleanup** — dropped the redundant `[target.windows] libs = ["kernel32.dll"]` from the root manifest; std's `[os.windows]` overlay cascades it. **Verified**: `mach build . --target windows` links clean and `wine out/windows/bin/mach.exe info` runs (`kernel32.dll`/`GetCommandLineA` in the PE import table, resolved purely via the cascade).
3. **TODO(#1302) migrations** — replaced three local helpers with std v0.5.0 primitives, all behaviour-preserving:
   - `query.mach` `bytes_equal` → `std.memory.raw_equal` (length guard inlined)
   - `me/ir/type.mach` `id_seq_equals` → `mem.equal[IrTypeId]`
   - `fe/comptime.mach` `contains_byte` → `view_contains_char`
4. **init sanity** — `mach init` scaffolds `ref = "branch/main"`; mach-std `main` is now v0.5.0-current, no change needed.

Closes #1302