### PR TITLE
fix(cli): honor absolute -o path verbatim

### DIFF
--- a/.github/tests/absout/app/mach.toml
+++ b/.github/tests/absout/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "absout"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.absout]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/absout/app/src/main.mach
+++ b/.github/tests/absout/app/src/main.mach
@@ -1,0 +1,4 @@
+use std.runtime.linux.x86_64;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/absout/run.sh
+++ b/.github/tests/absout/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# absout integration test: verify that an absolute -o path is honored verbatim
+# and that a relative -o path is still resolved against the project root.
+#
+# regression for issue #1340: mach build . -o /abs/path produced the binary at
+# <project>/abs/path (the leading slash was eaten by the unconditional join with
+# the project root). an absolute -o must be used as-is; relative -o must still
+# resolve under the project root.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/app"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+APP="$WORK/app"
+
+fail=0
+
+# absolute -o: the binary must appear at exactly the given absolute path.
+ABS_OUT="$WORK/abs-out/mach-absout"
+mkdir -p "$WORK/abs-out"
+if ! ( cd "$APP" && "$MACH" build . -o "$ABS_OUT" ) >/dev/null 2>&1; then
+    echo "FAIL absout: absolute -o build failed" >&2
+    fail=1
+else
+    if [ -x "$ABS_OUT" ]; then
+        echo "PASS absout: absolute -o writes to the exact absolute path"
+    else
+        echo "FAIL absout: binary not at absolute path '$ABS_OUT'" >&2
+        # diagnose: show where it actually landed
+        find "$APP/out" -type f 2>/dev/null | head -5 | while read -r f; do
+            echo "  found: $f" >&2
+        done
+        fail=1
+    fi
+fi
+
+# relative -o: the binary must appear under the project root.
+REL_OUT="rel-out/mach-absout"
+rm -rf "$APP/out" "$APP/rel-out"
+if ! ( cd "$APP" && "$MACH" build . -o "$REL_OUT" ) >/dev/null 2>&1; then
+    echo "FAIL absout: relative -o build failed" >&2
+    fail=1
+else
+    if [ -x "$APP/$REL_OUT" ]; then
+        echo "PASS absout: relative -o resolves under the project root"
+    else
+        echo "FAIL absout: binary not at relative path '$APP/$REL_OUT'" >&2
+        find "$APP" -type f -name "mach-absout" 2>/dev/null | head -5 | while read -r f; do
+            echo "  found: $f" >&2
+        done
+        fail=1
+    fi
+fi
+
+exit "$fail"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1087,7 +1087,8 @@ fun subst_name(tmpl: str, name: str, out: *u8, cap: usize) usize {
 # resolved artifact path. the layout is `<root>/<resolved obj>/<rel>.o`, where
 # `<rel>` is the FQN with '.' turned into '/'; the executable is the resolved
 # `<root>/<bin_out>`. `out_override` (-o), when non-nil, replaces the artifact
-# path with one rooted directly at `<root>`. in library mode (or with
+# path: an absolute path is used verbatim; a relative path is rooted at `<root>`.
+# in library mode (or with
 # `--emit obj`) no executable is linked and the per-module objects are the
 # deliverable. returns the exit code and sets `*out_path` on success — the
 # binary in executable mode, the object tree root in library mode. the linker
@@ -1153,11 +1154,11 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
         print.eprint("\n");
     }
 
-    # the executable path: `-o` overrides it with a path rooted directly at
-    # <root>; otherwise the unit's resolved artifact path is used.
+    # the executable path: an absolute `-o` is used verbatim; a relative one is
+    # rooted at <root>; otherwise the unit's resolved artifact path is used.
     var artifact: [4096]u8;
     if (out_override != nil) {
-        util.join_into(?artifact[0], 4096, root, out_override);
+        util.path_into(?artifact[0], 4096, root, out_override);
     }
     or {
         val bin_opt: Option[str] = intern.lookup(?p.s.interner, p.config.bin_out);

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -167,6 +167,29 @@ pub fun join_into(buf: *u8, cap: usize, dir: *u8, leaf: *u8) usize {
     ret k;
 }
 
+# path_into: write `path` into `buf`, resolving it against `base` when
+# relative, or copying it verbatim when absolute (starts with '/'). an absolute
+# `path` ignores `base` entirely. returns the byte length written (excluding the
+# terminator), or 0 when it would not fit.
+# ---
+# buf:  destination buffer
+# cap:  capacity of `buf` in bytes
+# base: directory to join against when `path` is relative
+# path: the path to resolve (absolute or relative)
+# ret:  bytes written excluding the terminator, or 0 when it would overflow
+pub fun path_into(buf: *u8, cap: usize, base: *u8, path: *u8) usize {
+    val pl: usize = slen(path);
+    if (pl > 0 && path[0] == '/') {
+        val need: usize = pl + 1;
+        if (need > cap) { ret 0; }
+        var i: usize = 0;
+        for (i < pl) { buf[i] = path[i]; i = i + 1; }
+        buf[pl] = 0;
+        ret pl;
+    }
+    ret join_into(buf, cap, base, path);
+}
+
 # parent_dir: strip the final path component of `path` in place, turning the
 # last '/' into a terminator. returns true if a parent component remained,
 # false when `path` had no separator (already at a root or bare name).
@@ -257,6 +280,31 @@ pub fun ensure_parents(path: *u8) bool {
         i = i + 1;
     }
     ret true;
+}
+
+test "util: path_into uses absolute path verbatim and joins relative path" {
+    var buf: [256]u8;
+    # absolute path must land at exactly that path, ignoring base.
+    val al: usize = path_into(?buf[0], 256, "/base", "/tmp/out/mach");
+    if (al == 0) { ret 1; }
+    var i: usize = 0;
+    val want: *u8 = "/tmp/out/mach";
+    for (buf[i] != 0) {
+        if (want[i] == 0 || buf[i] != want[i]) { ret 1; }
+        i = i + 1;
+    }
+    if (want[i] != 0) { ret 1; }
+    # relative path must be joined with base.
+    val rl: usize = path_into(?buf[0], 256, "/base", "rel/out");
+    if (rl == 0) { ret 1; }
+    val rwant: *u8 = "/base/rel/out";
+    i = 0;
+    for (buf[i] != 0) {
+        if (rwant[i] == 0 || buf[i] != rwant[i]) { ret 1; }
+        i = i + 1;
+    }
+    if (rwant[i] != 0) { ret 1; }
+    ret 0;
 }
 
 test "util: separator_index reports the -- boundary as the effective argc" {


### PR DESCRIPTION
## Root cause

`link_artifact` called `util.join_into(artifact, root, out_override)` unconditionally regardless of whether `out_override` was absolute. `join_into` concatenates `root + '/' + leaf`, so `/tmp/foo` became `/project/root//tmp/foo`, which Linux normalizes to `/project/root/tmp/foo` — the leading slash of the absolute path was silently eaten.

## Fix

Added `path_into` to `mach.cli.util`: when `path[0] == '/'` it copies the path verbatim into the buffer; otherwise it delegates to `join_into` (relative behavior unchanged). `link_artifact` now uses `path_into` for the `-o` override.

No other CLI path flags share this join path. `--cwd` feeds `find_project_root` (not a root-relative join). `--artifacts` is parsed but not yet consumed. `--bin`/`--lib` are artifact names, not paths.

## Verification

- `mach test .`: 405 passed, 0 failed (404 before + 1 new `path_into` unit test)
- new `absout` integration suite: both absolute and relative `-o` cases PASS with the fixed binary, and the absolute case FAILs against the old binary (confirming the regression)
- all 26 existing integration suites: PASS

Closes #1340