### PR TITLE
test(integration): cover standalone lib fwd re-export of sibling modules

### DIFF
--- a/.github/tests/fwdreexport/app/mach.toml
+++ b/.github/tests/fwdreexport/app/mach.toml
@@ -1,0 +1,29 @@
+# consumer of the demo library: reaches the sibling submodules only through the
+# entrypoint's `fwd` re-exports, proving the re-exported surface is identical
+# whether demo is the root project or a dependency (octalide/mach-std#186).
+[project]
+id      = "fwdapp"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.app]
+entry = "main.mach"
+
+[profile.debug]
+opt = 0
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.5.0"
+
+[deps.demo]
+path = "dep/demo"

--- a/.github/tests/fwdreexport/app/src/main.mach
+++ b/.github/tests/fwdreexport/app/src/main.mach
@@ -1,0 +1,9 @@
+use std.runtime;
+use demo.lib;
+
+# `answer` is reached only through lib.mach's symbol re-export — demo.alpha is
+# never imported here, so the call proves the fwd surface is live.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret lib.answer();
+}

--- a/.github/tests/fwdreexport/demo/mach.toml
+++ b/.github/tests/fwdreexport/demo/mach.toml
@@ -1,0 +1,23 @@
+# standalone library whose entrypoint only `fwd`-re-exports its own sibling
+# submodules — the mach-std lib.mach shape that octalide/mach-std#186 found
+# rejected with "re-exported module is not in the dep set" when built as the
+# root project instead of as a dependency.
+[project]
+id      = "demo"
+version = "0.1.0"
+src     = "src"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[lib.demo]
+entry = "lib.mach"
+kind  = "static"
+
+[profile.debug]
+opt = 0

--- a/.github/tests/fwdreexport/demo/src/alpha.mach
+++ b/.github/tests/fwdreexport/demo/src/alpha.mach
@@ -1,0 +1,5 @@
+# sibling submodule re-exported by the lib entrypoint, both as a whole module
+# (`fwd demo.alpha;`) and per symbol (`fwd demo.alpha.answer;`).
+pub fun answer() i64 {
+    ret 7;
+}

--- a/.github/tests/fwdreexport/demo/src/deep/beta.mach
+++ b/.github/tests/fwdreexport/demo/src/deep/beta.mach
@@ -1,0 +1,5 @@
+# nested sibling submodule re-exported as a module alias by the lib entrypoint —
+# the multi-segment FQN shape (`fwd std.types.bool;`) the original failure named.
+pub fun value() i64 {
+    ret 35;
+}

--- a/.github/tests/fwdreexport/demo/src/lib.mach
+++ b/.github/tests/fwdreexport/demo/src/lib.mach
@@ -1,0 +1,7 @@
+# library surface built purely from same-package re-exports: two sibling module
+# fwds (one nested) and one symbol fwd through a sibling. nothing here `use`s the
+# siblings, so the load walk must record the fwd dependency edges itself
+# (octalide/mach-std#186).
+fwd demo.alpha;
+fwd demo.deep.beta;
+fwd demo.alpha.answer;

--- a/.github/tests/fwdreexport/run.sh
+++ b/.github/tests/fwdreexport/run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# fwd re-export integration test: same-package sibling re-exports in a library
+# entrypoint (octalide/mach-std#186, fixed by #1185 / PR #1186).
+#
+# proves that a standalone `mach build .` of a library whose entrypoint only
+# `fwd`-re-exports its own sibling submodules succeeds — the mach-std lib.mach
+# shape that used to fail with "re-exported module is not in the dep set" when
+# the library was the root project (it always worked as a dependency) — and
+# that a consumer can call through the entrypoint's symbol re-export.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+cp -r "$HERE/demo" "$WORK/demo"
+cp -r "$HERE/app" "$WORK/app"
+mkdir -p "$WORK/app/dep"
+ln -s "$WORK/demo" "$WORK/app/dep/demo"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# the library builds as the ROOT project: every module it contains is in its
+# own dep set, so the entrypoint's sibling re-exports must resolve.
+if ( cd "$WORK/demo" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "PASS fwdreexport: standalone lib build with sibling fwd re-exports"
+else
+    echo "FAIL fwdreexport: standalone lib build with sibling fwd re-exports — build failed" >&2
+    fail=1
+fi
+
+# the same library consumed as a dependency: the consumer reaches `answer`
+# only through the entrypoint's symbol re-export.
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL fwdreexport: consumer build through fwd re-export — build failed" >&2
+    fail=1
+else
+    bin="$WORK/app/out/linux/debug/bin/app"
+    if [ ! -x "$bin" ]; then
+        echo "FAIL fwdreexport: consumer build through fwd re-export — binary not produced at $bin" >&2
+        fail=1
+    else
+        set +e
+        "$bin"; got=$?
+        set -e
+        if [ "$got" -ne 7 ]; then
+            echo "FAIL fwdreexport: consumer call through fwd re-export — exit $got, expected 7" >&2
+            fail=1
+        else
+            echo "PASS fwdreexport: consumer call through fwd symbol re-export"
+        fi
+    fi
+fi
+
+exit "$fail"


### PR DESCRIPTION
Closes octalide/mach-std#186

## Context

octalide/mach-std#186 reported that a standalone `mach build .` of mach-std failed at `src/lib.mach:1` with `re-exported module is not in the dep set` on `fwd std.types.bool;`, while the identical code built fine when mach-std was consumed as a dependency.

The compiler-side fix already landed: #1185 / PR #1186 (merged 2026-06-07) taught the load walk to record dependency edges for `fwd` declarations (`walk_fwd_for_load`) and the resolver to bind whole-module re-exports (`bind_fwd_module`). The root cause was that the load walk only followed `use` declarations, so a library entrypoint that *only* `fwd`-re-exports its sibling modules never loaded them — as a dependency the consumer's own imports happened to load those modules first, masking the hole; as the root project nothing did. The fix shipped in a release, and mach-std `dev` now builds standalone with both the released v1.4.0 compiler and a dev-HEAD build (verified locally). The second blocker named in the issue, octalide/mach-std#187, is also closed — so the issue can close.

What PR #1186 did **not** add is regression coverage. This PR adds it.

## Change

New integration suite `.github/tests/fwdreexport/` (picked up automatically by CI's `.github/tests/*/run.sh` glob):

- **standalone lib build** — a library whose entrypoint only `fwd`-re-exports its own sibling submodules (`fwd demo.alpha;`, nested `fwd demo.deep.beta;`, symbol `fwd demo.alpha.answer;` — the mach-std `lib.mach` shape) must build as the root project.
- **consumer through the re-export** — the same library consumed as a path dep; the consumer reaches `answer` only via the entrypoint's symbol re-export and the binary must exit 7.

## Failing-before / passing-after

Reverse-applying PR #1186 from dev HEAD and rebuilding reproduces the exact original failure, which the suite catches:

```
FAIL fwdreexport: standalone lib build with sibling fwd re-exports — build failed
  error: ./src/lib.mach:5:5: re-exported module is not in the dep set
```

On dev HEAD both cases pass.

## Out of scope (found while writing the consumer fixture)

Chained member access through a `fwd` **module** re-export does not resolve from a consumer: with `use demo.lib;`, `lib.alpha.answer()` fails sema with `no field 'answer' on the receiver type` (plus a stray `mir.lower_ir: gep index into a non-aggregate type` error in the same build). `bind_fwd_module` publishes the alias, but expression-position member access does not traverse a module member that is itself a module alias. Symbol re-exports work. Reported for separate tracking; the suite's consumer case sticks to the supported symbol-fwd path.