### PR TITLE
chore(target): remove the dead test-runner write-primitive machinery

### DIFF
--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -12,7 +12,6 @@ use std.types.option.none;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
-use std.types.string.str;
 
 use intern: mach.lang.intern;
 
@@ -26,28 +25,6 @@ pub val OS_LINUX:        u32 = 1;
 pub val OS_DARWIN:       u32 = 2;
 pub val OS_WINDOWS:      u32 = 3;
 pub val OS_FREESTANDING: u32 = 4;
-
-# the freestanding inline-asm write primitive the synthesized `mach test` runner
-# uses to emit its output on a given (os, arch). `body` is the OP_ASM body — with
-# `{buf}` / `{len}` placeholders the runner binds to its buffer and length
-# arguments — and `isa_tag` is the OP_ASM architecture tag. produced by the
-# OsVTable's `runner_write` accessor for the resolved architecture; an OS / arch
-# pair with no freestanding write returns none and the runner is unavailable.
-# ---
-# body:    the OP_ASM body text (with {buf} / {len} placeholders)
-# isa_tag: the OP_ASM architecture tag for the resolved arch
-pub rec RunnerWrite {
-    body:    str;
-    isa_tag: str;
-}
-
-# RunnerWriteFn: the concrete signature the erased `OsVTable.runner_write` pointer
-# casts back to. given the resolved architecture id (one of isa.ARCH_*), returns
-# the runner's write primitive for this (os, arch), or none when the OS exposes no
-# freestanding inline-asm write for that architecture (e.g. Windows, which needs
-# imported kernel32 calls rather than a syscall). the test-runner synthesizer reads
-# it through the selected target's OS vtable so the runner stays target-agnostic.
-pub def RunnerWriteFn: fun(u32) Option[RunnerWrite];
 
 # the operating-system runtime-dispatch interface. exactly one of these exists
 # per OS; the driver and linker read the entry symbol, library directory, and
@@ -68,11 +45,6 @@ pub def RunnerWriteFn: fun(u32) Option[RunnerWrite];
 #                  linker assigns section vaddrs upward from it
 # page_size:       virtual-memory page size in bytes the linker page-aligns
 #                  segment virtual addresses to
-# runner_write:    erased fn ptr — the synthesized `mach test` runner's freestanding
-#                  write primitive for a resolved architecture (cast back to
-#                  `RunnerWriteFn`); none when the OS has no inline-asm write for
-#                  that arch, which makes `mach test` fail loudly rather than emit a
-#                  wrong-OS output sequence
 pub rec OsVTable {
     id:             u32;
     name:           intern.StrId;
@@ -82,7 +54,6 @@ pub rec OsVTable {
     dynamic_linker: intern.StrId;
     base_addr:      u64;
     page_size:      u64;
-    runner_write:   *u8;
 }
 
 val OS_REGISTRY_CAP: u32 = 8;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -20,23 +20,11 @@ use std.types.bool.true;
 use std.types.bool.false;
 
 use std.types.string.str;
-use std.types.option.Option;
-use std.types.option.none;
 
 use std.allocator.Allocator;
 
 use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
-
-# runner_write: Darwin has no freestanding inline-asm `mach test` write yet (its
-# write syscall number differs from Linux's), so every architecture returns none
-# and `mach test --target darwin` fails loudly — tracked by #1292.
-# ---
-# arch_id: resolved architecture id (one of isa.ARCH_*)
-# ret:     none (no Darwin runner write implemented)
-fun runner_write(arch_id: u32) Option[os.RunnerWrite] {
-    ret none[os.RunnerWrite]();
-}
 
 # default base virtual address for Darwin executables (4 GiB).
 pub val DARWIN_BASE_ADDR: u64 = 0x100000000;
@@ -84,7 +72,6 @@ pub fun register_darwin(alloc: *Allocator, i: *intern.Interner) Result[bool, str
     darwin_vtable.dynamic_linker = intern.STR_NIL;
     darwin_vtable.base_addr      = DARWIN_BASE_ADDR;
     darwin_vtable.page_size      = DARWIN_PAGE_SIZE;
-    darwin_vtable.runner_write   = runner_write::*u8;
 
     os.register(?darwin_vtable);
     ret ok[bool, str](true);

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -19,14 +19,10 @@ use std.types.bool.true;
 use std.types.bool.false;
 
 use std.types.string.str;
-use std.types.option.Option;
-use std.types.option.some;
-use std.types.option.none;
 
 use std.allocator.Allocator;
 
 use intern: mach.lang.intern;
-use isa:    mach.lang.target.isa;
 use os:     mach.lang.target.os;
 
 # default base virtual address for Linux executables. the first PT_LOAD
@@ -44,24 +40,6 @@ pub val LINUX_PAGE_SIZE: u64 = 4096;
 # target/sysroot-configurable setting to avoid emitting an ELF whose interpreter
 # is absent at exec time.
 pub val LINUX_DYNAMIC_LINKER: str = "/lib64/ld-linux-x86-64.so.2";
-
-# runner_write: the synthesized `mach test` runner's freestanding write primitive
-# on Linux. for x86-64 it is the `write(1, buf, len)` syscall (rax=1) tagged for the
-# x86_64 OP_ASM encoder; other architectures have no inline-asm write here yet and
-# return none so `mach test` fails loudly rather than emitting a wrong sequence (the
-# aarch64 runner lands with #1045's freestanding write).
-# ---
-# arch_id: resolved architecture id (one of isa.ARCH_*)
-# ret:     the write primitive for this arch, or none if unsupported
-fun runner_write(arch_id: u32) Option[os.RunnerWrite] {
-    if (arch_id == isa.ARCH_X86_64) {
-        var w: os.RunnerWrite;
-        w.body    = "mov rax, 1\nmov rdi, 1\nmov rsi, {buf}\nmov rdx, {len}\nsyscall\n";
-        w.isa_tag = "x86_64";
-        ret some[os.RunnerWrite](w);
-    }
-    ret none[os.RunnerWrite]();
-}
 
 # the Linux OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry; remains valid for the process lifetime.
@@ -105,7 +83,6 @@ pub fun register_linux(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     linux_vtable.dynamic_linker = unwrap_ok[intern.StrId, str](rd);
     linux_vtable.base_addr      = LINUX_BASE_ADDR;
     linux_vtable.page_size      = LINUX_PAGE_SIZE;
-    linux_vtable.runner_write   = runner_write::*u8;
 
     os.register(?linux_vtable);
     ret ok[bool, str](true);

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -20,24 +20,11 @@ use std.types.bool.true;
 use std.types.bool.false;
 
 use std.types.string.str;
-use std.types.option.Option;
-use std.types.option.none;
 
 use std.allocator.Allocator;
 
 use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
-
-# runner_write: Windows writes to standard output through kernel32 (GetStdHandle +
-# WriteFile imports), not a freestanding syscall, so the synthesized inline-asm
-# runner cannot express it; every architecture returns none and `mach test --target
-# windows` fails loudly — the import-based runner is tracked by #1292.
-# ---
-# arch_id: resolved architecture id (one of isa.ARCH_*)
-# ret:     none (no Windows runner write implemented)
-fun runner_write(arch_id: u32) Option[os.RunnerWrite] {
-    ret none[os.RunnerWrite]();
-}
 
 # default base virtual address for Windows x86_64 executables.
 pub val WINDOWS_BASE_ADDR: u64 = 0x140000000;
@@ -84,7 +71,6 @@ pub fun register_windows(alloc: *Allocator, i: *intern.Interner) Result[bool, st
     windows_vtable.dynamic_linker = intern.STR_NIL;
     windows_vtable.base_addr      = WINDOWS_BASE_ADDR;
     windows_vtable.page_size      = WINDOWS_PAGE_SIZE;
-    windows_vtable.runner_write   = runner_write::*u8;
 
     os.register(?windows_vtable);
     ret ok[bool, str](true);


### PR DESCRIPTION
Addresses the windows half of #1292 by removing its premise: the post-#1336 per-test-executable architecture made the runner write primitive obsolete — test binaries perform no OS output; the host `mach test` process spawns each one and reports PASS/FAIL from its exit status.

## What changed
- `src/lang/target/os.mach`: drop `RunnerWrite`, `RunnerWriteFn`, and the `OsVTable.runner_write` field (and its doc lines).
- `src/lang/target/os/{linux,windows,darwin}.mach`: drop the per-OS `runner_write` accessors and their vtable assignments, plus the `Option`/`isa` imports only they used.

These have had **zero consumers** since #1336 merged: the synthesized per-test entry is `main(){ret <test>();}` with no OS interaction, so no OS/arch write-primitive dispatch exists anywhere — the constraint #1292 set (no OS/arch branch in `testrunner.mach`) is now satisfied vacuously for every OS, including the future darwin and aarch64 cases.

## Why removal rather than the import-based variant
The issue's design fork (grow `RunnerWrite` with an import-based variant vs. emit `ext` calls) predates #1336. Implementing either today would add dead structure to a mechanism nothing calls. `mach test --target windows` already meets the issue's acceptance on dev HEAD: it cross-compiles per-test PE32+ binaries whose kernel32 imports (`GetCommandLineA`, `ExitProcess`) flow through the declared `[os.windows]` manifest cascade from mach-std into every per-test link, and they run under wine with correct PASS/FAIL reporting and per-test isolation.

## Verification
- 3-stage self-host fixpoint from the v1.4.0 seed: stage2 == stage3 byte-identical (`sha256 bb35b2ef…`).
- `mach test .` with the fixpoint compiler: **405 passed, 0 failed, 405 total**.
- All 28 `.github/tests/*/run.sh` suites pass with the fixpoint compiler (including the four win64 wine suites).
- Windows acceptance re-demonstrated with the post-removal compiler on a scratch project (pass / deliberate-fail / deliberate-crash tests), executed under wine:

  ```
  $ mach test . --target windows
  add works ./src/main.mach:10 PASS
  deliberate failure ./src/main.mach:15 FAIL(exit 7)
  deliberate crash ./src/main.mach:19 FAIL(exit 5)   # wine page fault, isolated; run continues
  1 passed, 2 failed, 3 total                        # exit code 1
  ```

  Artifacts are `PE32+ executable for MS Windows 6.00 (console), x86-64` importing `kernel32.dll!GetCommandLineA, ExitProcess`.

Refs #1292