### PR TITLE
fix(resolve): consumer member chains through fwd module re-exports

### DIFF
--- a/.github/tests/fwdreexport/app/mach.toml
+++ b/.github/tests/fwdreexport/app/mach.toml
@@ -1,6 +1,8 @@
-# consumer of the demo library: reaches the sibling submodules only through the
-# entrypoint's `fwd` re-exports, proving the re-exported surface is identical
-# whether demo is the root project or a dependency (octalide/mach-std#186).
+# consumer of the demo and outer libraries: reaches the sibling submodules only
+# through `fwd` re-exports, proving the re-exported surface is identical whether
+# demo is the root project or a dependency (octalide/mach-std#186), consumable
+# as a module-alias chain in expression position, and stable across a second
+# fwd hop (#1343).
 [project]
 id      = "fwdapp"
 version = "0.1.0"
@@ -27,3 +29,6 @@ ref = "v0.5.0"
 
 [deps.demo]
 path = "dep/demo"
+
+[deps.outer]
+path = "dep/outer"

--- a/.github/tests/fwdreexport/app/src/main.mach
+++ b/.github/tests/fwdreexport/app/src/main.mach
@@ -1,9 +1,13 @@
 use std.runtime;
 use demo.lib;
+use olib: outer.lib;
 
-# `answer` is reached only through lib.mach's symbol re-export — demo.alpha is
-# never imported here, so the call proves the fwd surface is live.
+# every published fwd surface shape, reached only through re-exports: a symbol
+# re-export (`lib.answer`), module re-exports chained in expression position
+# (`lib.alpha.answer`, and `lib.beta.value` through the nested-FQN alias)
+# (#1343), and a fwd-of-a-fwd through a second library (`olib.answer`,
+# `olib.alpha.answer`).
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
-    ret lib.answer();
+    ret lib.answer() + lib.alpha.answer() + lib.beta.value() + olib.answer() + olib.alpha.answer();
 }

--- a/.github/tests/fwdreexport/outer/mach.toml
+++ b/.github/tests/fwdreexport/outer/mach.toml
@@ -1,0 +1,26 @@
+# library that re-exports another library's re-exports: its entrypoint fwds
+# demo's lib.mach surface — a module alias that is itself a fwd, and a symbol
+# that is itself a fwd — proving a fwd-of-a-fwd chain stays consumable (#1343).
+[project]
+id      = "outer"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[lib.outer]
+entry = "lib.mach"
+kind  = "static"
+
+[profile.debug]
+opt = 0
+
+[deps.demo]
+path = "dep/demo"

--- a/.github/tests/fwdreexport/outer/src/lib.mach
+++ b/.github/tests/fwdreexport/outer/src/lib.mach
@@ -1,0 +1,6 @@
+# re-exports of demo's own re-exports (#1343): `alpha` is a module alias that
+# demo.lib itself published via `fwd demo.alpha;`, and `answer` is a symbol
+# demo.lib published via `fwd demo.alpha.answer;`. both must survive a second
+# fwd hop with their resolution intact.
+fwd demo.lib.alpha;
+fwd demo.lib.answer;

--- a/.github/tests/fwdreexport/run.sh
+++ b/.github/tests/fwdreexport/run.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 # fwd re-export integration test: same-package sibling re-exports in a library
-# entrypoint (octalide/mach-std#186, fixed by #1185 / PR #1186).
+# entrypoint (octalide/mach-std#186, fixed by #1185 / PR #1186) and consumer
+# chains through the published surface (#1343).
 #
 # proves that a standalone `mach build .` of a library whose entrypoint only
 # `fwd`-re-exports its own sibling submodules succeeds — the mach-std lib.mach
 # shape that used to fail with "re-exported module is not in the dep set" when
 # the library was the root project (it always worked as a dependency) — and
-# that a consumer can call through the entrypoint's symbol re-export.
+# that a consumer can reach every re-export shape: a symbol re-export, module
+# re-exports chained in expression position (including a nested-FQN alias),
+# and a second library's fwd-of-a-fwd of both.
 #
 # usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -28,9 +31,12 @@ trap 'rm -rf "$WORK"' EXIT
 fail=0
 
 cp -r "$HERE/demo" "$WORK/demo"
+cp -r "$HERE/outer" "$WORK/outer"
 cp -r "$HERE/app" "$WORK/app"
-mkdir -p "$WORK/app/dep"
+mkdir -p "$WORK/outer/dep" "$WORK/app/dep"
+ln -s "$WORK/demo" "$WORK/outer/dep/demo"
 ln -s "$WORK/demo" "$WORK/app/dep/demo"
+ln -s "$WORK/outer" "$WORK/app/dep/outer"
 ln -s "$STD" "$WORK/app/dep/mach-std"
 
 # the library builds as the ROOT project: every module it contains is in its
@@ -42,25 +48,36 @@ else
     fail=1
 fi
 
-# the same library consumed as a dependency: the consumer reaches `answer`
-# only through the entrypoint's symbol re-export.
+# a library whose entrypoint only re-exports ANOTHER library's re-exports
+# builds standalone too: each fwd hop preserves the leaf's resolution (#1343).
+if ( cd "$WORK/outer" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "PASS fwdreexport: standalone lib build with fwd-of-a-fwd re-exports"
+else
+    echo "FAIL fwdreexport: standalone lib build with fwd-of-a-fwd re-exports — build failed" >&2
+    fail=1
+fi
+
+# the libraries consumed as dependencies: the consumer reaches every target
+# only through re-exports — the symbol re-export (7), the module re-exports
+# chained in expression position (7 + 35), and the fwd-of-a-fwd surface
+# (7 + 7) — totalling 63.
 if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
-    echo "FAIL fwdreexport: consumer build through fwd re-export — build failed" >&2
+    echo "FAIL fwdreexport: consumer build through fwd re-exports — build failed" >&2
     fail=1
 else
     bin="$WORK/app/out/linux/debug/bin/app"
     if [ ! -x "$bin" ]; then
-        echo "FAIL fwdreexport: consumer build through fwd re-export — binary not produced at $bin" >&2
+        echo "FAIL fwdreexport: consumer build through fwd re-exports — binary not produced at $bin" >&2
         fail=1
     else
         set +e
         "$bin"; got=$?
         set -e
-        if [ "$got" -ne 7 ]; then
-            echo "FAIL fwdreexport: consumer call through fwd re-export — exit $got, expected 7" >&2
+        if [ "$got" -ne 63 ]; then
+            echo "FAIL fwdreexport: consumer calls through fwd re-exports — exit $got, expected 63" >&2
             fail=1
         else
-            echo "PASS fwdreexport: consumer call through fwd symbol re-export"
+            echo "PASS fwdreexport: consumer calls through symbol, module-chain, and fwd-of-a-fwd re-exports"
         fi
     fi
 fi

--- a/doc/language/fwd.md
+++ b/doc/language/fwd.md
@@ -1,7 +1,7 @@
 # `fwd` — re-exports
 
-`fwd` re-exports a symbol from another module under this module's public
-surface. It is the public counterpart to `use`.
+`fwd` re-exports a symbol or module from another module under this
+module's public surface. It is the public counterpart to `use`.
 
 ## Grammar
 
@@ -24,6 +24,29 @@ fwd Pt: impl.Point;         # re-exports as 'Pt'
 
 The surface file in a shadow-module pattern is typically a long list of
 `fwd` lines — one per symbol the surface exposes.
+
+## Module re-exports
+
+A `fwd` path that ends at a **module** re-exports the whole module as a
+public module alias, mirroring `use`'s module binding:
+
+```mach
+fwd demo.alpha;             # re-exports module 'alpha'
+fwd deep: demo.deep.beta;   # re-exports module under 'deep'
+```
+
+A consumer reaches the alias's members with qualified access, chaining
+through any depth of re-export — including a `fwd` of another library's
+`fwd`:
+
+```mach
+use demo.lib;               # lib.mach contains `fwd demo.alpha;`
+
+lib.alpha.answer();         # resolves through the module re-export
+```
+
+As with `use`, a module alias is not a value; only its members can be
+named.
 
 ## When to use
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -987,20 +987,22 @@ fun find_module_exports_by_module(rc: *ResolveContext, mid: sess.ModuleId) *Modu
 }
 
 # resolves a qualified member access `alias.symbol`, recording the referenced
-# symbol on the member expression. when the object identifier binds to a
-# module alias (a `SYM_USE` whose `slot` names the aliased module), the leaf
-# names a public symbol of that module rather than a record field; this looks
-# it up among the module's exports and records an imported symbol on the
-# member's `expr_resolved` slot so sema can type it directly. a non-module
-# object (an ordinary value) is left for sema's field-access path; an
-# unexported or missing leaf reports an error. `member` is the ExprMember
-# payload and `eid` its expression id.
+# symbol on the member expression. when the object expression resolves to a
+# module alias (a `SYM_USE` whose `slot` names the aliased module) — a bare
+# ident bound by `use`, or a nested member that itself resolved to a `fwd`
+# module re-export — the leaf names a public symbol of that module rather than
+# a record field; this looks it up among the module's exports and records an
+# imported symbol on the member's `expr_resolved` slot so sema can type it
+# directly. the object is bound before this runs, so a chain resolves left to
+# right through any depth of module aliases. a non-module object (an ordinary
+# value) is left for sema's field-access path; an unexported or missing leaf
+# reports an error. `member` is the ExprMember payload and `eid` its
+# expression id.
 fun bind_member_qualified(rc: *ResolveContext, eid: id.ExprId, member: *expr.ExprMember) Result[bool, str] {
     if (rc.expr_resolved == nil) { ret ok[bool, str](true); }
 
     val obj_opt: Option[*expr.Expr] = ast.get_expr(rc.a, member.object);
     if (is_none[*expr.Expr](obj_opt)) { ret ok[bool, str](true); }
-    if (unwrap[*expr.Expr](obj_opt).kind != expr.EXPR_KIND_IDENT) { ret ok[bool, str](true); }
 
     val osid: SymbolId = rc.expr_resolved[member.object];
     if (osid == SYMBOL_NIL || osid >= rc.sym_len) { ret ok[bool, str](true); }
@@ -1009,7 +1011,13 @@ fun bind_member_qualified(rc: *ResolveContext, eid: id.ExprId, member: *expr.Exp
 
     val target: sess.ModuleId = osym.slot::sess.ModuleId;
     val mx: *ModuleExports = find_module_exports_by_module(rc, target);
-    if (mx == nil) { ret ok[bool, str](true); }
+    if (mx == nil) {
+        # a SYM_USE always names a module the driver's dep-set closure included,
+        # so a miss is a broken build graph; report it rather than silently
+        # falling through to sema's field-access path.
+        diag.error(?rc.s.diags, rc.a.file_id, member.name, "module alias names a module that is not in the dep set");
+        ret ok[bool, str](true);
+    }
 
     val r_leaf: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, member.name);
     if (is_err[intern.StrId, str](r_leaf)) { ret err[bool, str](unwrap_err[intern.StrId, str](r_leaf)); }
@@ -1204,7 +1212,13 @@ fun bind_fwd(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, flags: 
         ret ok[bool, str](true);
     }
 
-    val r_sym: Result[SymbolId, str] = add_symbol(rc, ps.kind, SYM_FLAG_PUB, name_id, ps.decl, 0, ps.origin);
+    # a leaf that is itself a module re-export (SYM_USE) keeps its target-module
+    # slot, so a fwd of another library's fwd stays consumable downstream
+    # (mirrors imported_symbol_for's slot preservation)
+    var slot: u32 = 0;
+    if (ps.kind == SYM_USE) { slot = ps.slot; }
+
+    val r_sym: Result[SymbolId, str] = add_symbol(rc, ps.kind, SYM_FLAG_PUB, name_id, ps.decl, slot, ps.origin);
     if (is_err[SymbolId, str](r_sym)) { ret err[bool, str](unwrap_err[SymbolId, str](r_sym)); }
     val sid: SymbolId = unwrap_ok[SymbolId, str](r_sym);
 

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -284,6 +284,15 @@ fun infer_ident(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
     if (is_none[*resolve.Symbol](sym_opt)) { ret type.TYPE_ERROR; }
     val sym: *resolve.Symbol = unwrap[*resolve.Symbol](sym_opt);
 
+    # a module alias (`use`/`fwd` binding) names a module, not a value. a
+    # qualified member access consumes the alias in resolve and never infers
+    # it, so an alias reaching value inference is a misuse; report it loudly —
+    # resolve recorded the symbol without error, and a silent TYPE_ERROR here
+    # would let a clean sema pass hand the broken access to lowering.
+    if (sym.kind == resolve.SYM_USE) {
+        ret report_module_alias_value(sc, eid);
+    }
+
     # a comptime-parameter function is a TEMPLATE: it is only ever emitted as a
     # per-value instance at a call site, never as a standalone symbol. referencing
     # it as a VALUE (assigning it, passing it, comparing it) would bind to a
@@ -318,6 +327,16 @@ fun ident_is_comptime_param_fn(sc: *sema.SemaContext, sym: *resolve.Symbol) bool
         i = i + 1;
     }
     ret false;
+}
+
+# reports a module alias referenced in value position against the expression's
+# span and poisons the expression.
+fun report_module_alias_value(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
+    val e_opt: Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (is_some[*expr.Expr](e_opt)) {
+        sema.report(sc, unwrap[*expr.Expr](e_opt).span, "a module alias is not a value; name one of the module's members");
+    }
+    ret type.TYPE_ERROR;
 }
 
 # reports a comptime-parameter-function value reference against the ident span and
@@ -785,7 +804,23 @@ fun infer_index(sc: *sema.SemaContext, ix: *expr.ExprIndex, span: token.Span) ty
 fun infer_member(sc: *sema.SemaContext, eid: id.ExprId, m: *expr.ExprMember, span: token.Span) type.TypeId {
     val qsym_opt: Option[*resolve.Symbol] = sema.symbol_for_expr(sc, eid);
     if (is_some[*resolve.Symbol](qsym_opt)) {
-        ret sema.decl_type_for(sc, unwrap[*resolve.Symbol](qsym_opt));
+        val qsym: *resolve.Symbol = unwrap[*resolve.Symbol](qsym_opt);
+        # a member that resolved to a module alias (`lib.alpha` through a `fwd`
+        # module re-export) names a module, not a value; in value position it
+        # is a misuse, exactly like a bare alias ident (see infer_ident).
+        if (qsym.kind == resolve.SYM_USE) {
+            ret report_module_alias_value(sc, eid);
+        }
+        ret sema.decl_type_for(sc, qsym);
+    }
+
+    # an unresolved member whose object IS a module alias: resolve already
+    # reported the failure (a missing export, or a missing dep-set target), so
+    # poison silently like any other unresolved reference instead of inferring
+    # the alias object as a value.
+    val osym_opt: Option[*resolve.Symbol] = sema.symbol_for_expr(sc, m.object);
+    if (is_some[*resolve.Symbol](osym_opt) && unwrap[*resolve.Symbol](osym_opt).kind == resolve.SYM_USE) {
+        ret type.TYPE_ERROR;
     }
 
     # a rooted comptime member chain (`$mach.*`, `$project.*`, `$target.*`,


### PR DESCRIPTION
Closes #1343

A consumer could not chain through a `fwd` module re-export in expression position (`use demo.lib;` then `lib.alpha.answer()` failed), even though symbol re-exports worked.

## Root cause

- `bind_member_qualified` only resolved module members when the object was a bare IDENT, so a nested member object (`lib.alpha`, itself resolved to a SYM_USE module alias) fell through to sema's field-access path.
- `bind_fwd`'s prefix+symbol path republished with `slot = 0`, dropping the target ModuleId when the re-exported leaf was itself a module alias — breaking a fwd of another library's fwd.

## Fix

- Resolve a qualified member through the object's recorded symbol regardless of expression shape: module-member resolution is now uniform for `use` aliases and `fwd` module re-exports, at any chain depth (type paths already chained via `resolve_type_path`).
- Preserve `ps.slot` for a SYM_USE leaf in `bind_fwd`, mirroring `imported_symbol_for`.

## The second finding (stray lowering errors)

The sema/lower error gate in `build.mach` exists and works. The failing build reached lowering because sema emitted **zero** diagnostics: a SYM_USE in value position was silently poisoned (TYPE_ERROR/TYPE_NIL with no report), so the broken access surfaced only as lowering's `no field ...` / `gep index into a non-aggregate type`. Fixed at the model level: sema now reports `a module alias is not a value` for any alias reaching value inference, and the `mx == nil` defensive fallthrough in `bind_member_qualified` reports instead of silently skipping. Unresolved members whose object is a module alias poison silently (resolve already reported).