### PR TITLE
fix(cli): forward the parent environment to spawned user programs

### DIFF
--- a/.github/tests/envfwd/app/mach.toml
+++ b/.github/tests/envfwd/app/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id      = "envfwd"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+ir      = "out/{target}/ir"
+asm     = "out/{target}/asm"
+tests   = "out/{target}/test/{name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.envfwd]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.6.0"

--- a/.github/tests/envfwd/app/src/main.mach
+++ b/.github/tests/envfwd/app/src/main.mach
@@ -1,0 +1,31 @@
+# envfwd integration app: asserts the harness forwards the parent environment.
+# the suite's run.sh exports MACH_ENVFWD_PROBE=octarine before invoking
+# `mach test` / `mach run`; both the test child and the run child must see it.
+
+use std.runtime;
+use std.types.size.usize;
+use env: std.process.env;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret probe()::i64;
+}
+
+var probe_buf: [4096]u8;
+
+# probe: 0 when MACH_ENVFWD_PROBE is inherited with the expected value.
+fun probe() i32 {
+    val n: i64 = env.get("MACH_ENVFWD_PROBE", ?probe_buf[0], 4096);
+    if (n != 8) { ret 1; }
+    val want: *u8 = "octarine";
+    var i: usize = 0;
+    for (i < 8) {
+        if (probe_buf[i] != want[i]) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+test "envfwd: parent environment variable is inherited" {
+    ret probe();
+}

--- a/.github/tests/envfwd/run.sh
+++ b/.github/tests/envfwd/run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# envfwd integration test: `mach test` and `mach run` forward the parent
+# environment to spawned user programs (mach-std#197).
+#
+# the app's test and main both assert MACH_ENVFWD_PROBE arrives with the
+# value exported here; under a nil-envp harness both would fail.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/app"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+APP="$WORK/app"
+
+export MACH_ENVFWD_PROBE=octarine
+fail=0
+
+if ( cd "$APP" && "$MACH" test . --filter envfwd ) >"$WORK/test.out" 2>&1; then
+    echo "PASS envfwd: mach test forwards the environment"
+else
+    echo "FAIL envfwd: mach test child did not inherit MACH_ENVFWD_PROBE" >&2
+    cat "$WORK/test.out" >&2
+    fail=1
+fi
+
+if ( cd "$APP" && "$MACH" run . ) >"$WORK/run.out" 2>&1; then
+    echo "PASS envfwd: mach run forwards the environment"
+else
+    echo "FAIL envfwd: mach run child did not inherit MACH_ENVFWD_PROBE" >&2
+    cat "$WORK/run.out" >&2
+    fail=1
+fi
+
+exit "$fail"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped the vendored mach-std to v0.6.0 (adds `std.process.env.environ()`).
+
 ### Fixed
 
+- `mach test` and `mach run` now forward the parent environment to spawned
+  user programs instead of execing them with an empty `envp`; `getenv` in a
+  test or run child sees the inherited variables (mach-std#197).
 - Inline-asm comments are now opaque to the instruction parser regardless of
   their bytes. A comment containing `;` was split into a phantom instruction
   and one containing `{...}` was misread as a local binding; comments are now

--- a/mach.toml
+++ b/mach.toml
@@ -26,4 +26,4 @@ entry = "main.mach"
 
 [deps.mach-std]
 git = "https://github.com/octalide/mach-std"
-ref = "v0.5.0"
+ref = "v0.6.0"

--- a/src/cli/cmd/run.mach
+++ b/src/cli/cmd/run.mach
@@ -2,9 +2,10 @@
 #
 # builds the project through the same pipeline as `build` and then
 # executes the produced binary, forwarding any arguments after a `--`
-# separator to the child as its argv. the child's exit code becomes this
-# subcommand's exit code. `--emit obj` is rejected since running a
-# relocatable object is not meaningful.
+# separator to the child as its argv. the child inherits the parent's
+# environment. the child's exit code becomes this subcommand's exit code.
+# `--emit obj` is rejected since running a relocatable object is not
+# meaningful.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -24,6 +25,7 @@ use page:  std.allocator.page;
 use arena: std.allocator.arena;
 
 use os:    std.system.os;
+use env:   std.process.env;
 use exec:  std.process.exec;
 use print: std.print;
 
@@ -105,7 +107,8 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     child_argv[1 + fwd_count] = nil;
 
-    val exec_r: Result[exec.ExitStatus, str] = exec.run(br.output_path, child_argv, nil);
+    # the child inherits the parent's environment unmodified.
+    val exec_r: Result[exec.ExitStatus, str] = exec.run(br.output_path, child_argv, env.environ());
 
     if (is_err[exec.ExitStatus, str](exec_r)) {
         arena.dnit(?ar);

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -27,6 +27,7 @@ use std.allocator.Allocator;
 use page:  std.allocator.page;
 use arena: std.allocator.arena;
 
+use env:   std.process.env;
 use exec:  std.process.exec;
 use print: std.print;
 
@@ -100,7 +101,8 @@ pub fun run(argc: usize, argv: **u8) i64 {
         report_location(a);
         print.print(" ");
 
-        val exec_r: Result[exec.ExitStatus, str] = exec.run(a.exe, ?child_argv[0], nil);
+        # each test child inherits the parent's environment unmodified.
+        val exec_r: Result[exec.ExitStatus, str] = exec.run(a.exe, ?child_argv[0], env.environ());
         if (is_err[exec.ExitStatus, str](exec_r)) {
             print.print("FAIL(spawn)\n");
             failed = failed + 1;


### PR DESCRIPTION
## Problem

`mach test` and `mach run` exec user binaries with `envp = nil`, so children see an empty environment and `getenv` legitimately fails for every variable — the false negative behind octalide/mach-std#197 (`getenv("PATH")` NOT_FOUND under the harness while correct when run directly).

## Fix

Pass the parent's captured environment (`std.process.env.environ()`, new in mach-std v0.6.0) straight through as `envp` at both user-program spawn sites:

- `src/cli/cmd/testing.mach` — per-test exec
- `src/cli/cmd/run.mach` — `mach run` child exec

Pure inheritance: no copying, no filtering, nothing automatic beyond passing the vector through.

## Spawn-site audit

All `exec.run` / `os.spawn` call sites in the compiler:

- `src/cli/cmd/dep.mach:910` (`run_git`) and `:1330` (`remove_tree`) spawn `git` / `rm` with a **deliberately allowlisted** environment (`build_env`: HOME, PATH, SSH/proxy/cert vars). Intentional sanitized-tool contract, not user-program inheritance — left untouched.

No other spawn sites exist.

## Regression coverage

New integration suite `.github/tests/envfwd/`: exports `MACH_ENVFWD_PROBE=octarine` and asserts both the `mach test` child and the `mach run` child inherit it with the exact value. Fails under released v1.4.0, passes with this branch.

## Verification

- Failing-before/passing-after: a scratch project asserting `getenv("PATH")` found — `FAIL(exit 1)` under released v1.4.0 `mach test`, `PASS` under the patched compiler; same shape confirmed for `mach run` ("PATH missing" → "PATH present").
- Full corpus: `mach test .` with the patched compiler — **409 passed, 0 failed**.
- All integration suites (27 existing + new envfwd, incl. win64 under wine) pass with the patched compiler.
- 3-stage fixpoint from the v1.4.0 seed: seed → a → b → c, `cmp b c` byte-identical.

Closes octalide/mach-std#197