### PR TITLE
release: v1.4.1

### DIFF
--- a/.github/tests/absout/app/mach.toml
+++ b/.github/tests/absout/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "absout"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.absout]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/absout/app/src/main.mach
+++ b/.github/tests/absout/app/src/main.mach
@@ -1,0 +1,4 @@
+use std.runtime.linux.x86_64;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/absout/run.sh
+++ b/.github/tests/absout/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# absout integration test: verify that an absolute -o path is honored verbatim
+# and that a relative -o path is still resolved against the project root.
+#
+# regression for issue #1340: mach build . -o /abs/path produced the binary at
+# <project>/abs/path (the leading slash was eaten by the unconditional join with
+# the project root). an absolute -o must be used as-is; relative -o must still
+# resolve under the project root.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/app"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+APP="$WORK/app"
+
+fail=0
+
+# absolute -o: the binary must appear at exactly the given absolute path.
+ABS_OUT="$WORK/abs-out/mach-absout"
+mkdir -p "$WORK/abs-out"
+if ! ( cd "$APP" && "$MACH" build . -o "$ABS_OUT" ) >/dev/null 2>&1; then
+    echo "FAIL absout: absolute -o build failed" >&2
+    fail=1
+else
+    if [ -x "$ABS_OUT" ]; then
+        echo "PASS absout: absolute -o writes to the exact absolute path"
+    else
+        echo "FAIL absout: binary not at absolute path '$ABS_OUT'" >&2
+        # diagnose: show where it actually landed
+        find "$APP/out" -type f 2>/dev/null | head -5 | while read -r f; do
+            echo "  found: $f" >&2
+        done
+        fail=1
+    fi
+fi
+
+# relative -o: the binary must appear under the project root.
+REL_OUT="rel-out/mach-absout"
+rm -rf "$APP/out" "$APP/rel-out"
+if ! ( cd "$APP" && "$MACH" build . -o "$REL_OUT" ) >/dev/null 2>&1; then
+    echo "FAIL absout: relative -o build failed" >&2
+    fail=1
+else
+    if [ -x "$APP/$REL_OUT" ]; then
+        echo "PASS absout: relative -o resolves under the project root"
+    else
+        echo "FAIL absout: binary not at relative path '$APP/$REL_OUT'" >&2
+        find "$APP" -type f -name "mach-absout" 2>/dev/null | head -5 | while read -r f; do
+            echo "  found: $f" >&2
+        done
+        fail=1
+    fi
+fi
+
+exit "$fail"

--- a/.github/tests/envfwd/app/mach.toml
+++ b/.github/tests/envfwd/app/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id      = "envfwd"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+ir      = "out/{target}/ir"
+asm     = "out/{target}/asm"
+tests   = "out/{target}/test/{name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.envfwd]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.6.0"

--- a/.github/tests/envfwd/app/src/main.mach
+++ b/.github/tests/envfwd/app/src/main.mach
@@ -1,0 +1,31 @@
+# envfwd integration app: asserts the harness forwards the parent environment.
+# the suite's run.sh exports MACH_ENVFWD_PROBE=octarine before invoking
+# `mach test` / `mach run`; both the test child and the run child must see it.
+
+use std.runtime;
+use std.types.size.usize;
+use env: std.process.env;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret probe()::i64;
+}
+
+var probe_buf: [4096]u8;
+
+# probe: 0 when MACH_ENVFWD_PROBE is inherited with the expected value.
+fun probe() i32 {
+    val n: i64 = env.get("MACH_ENVFWD_PROBE", ?probe_buf[0], 4096);
+    if (n != 8) { ret 1; }
+    val want: *u8 = "octarine";
+    var i: usize = 0;
+    for (i < 8) {
+        if (probe_buf[i] != want[i]) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+test "envfwd: parent environment variable is inherited" {
+    ret probe();
+}

--- a/.github/tests/envfwd/run.sh
+++ b/.github/tests/envfwd/run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# envfwd integration test: `mach test` and `mach run` forward the parent
+# environment to spawned user programs (mach-std#197).
+#
+# the app's test and main both assert MACH_ENVFWD_PROBE arrives with the
+# value exported here; under a nil-envp harness both would fail.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/app"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+APP="$WORK/app"
+
+export MACH_ENVFWD_PROBE=octarine
+fail=0
+
+if ( cd "$APP" && "$MACH" test . --filter envfwd ) >"$WORK/test.out" 2>&1; then
+    echo "PASS envfwd: mach test forwards the environment"
+else
+    echo "FAIL envfwd: mach test child did not inherit MACH_ENVFWD_PROBE" >&2
+    cat "$WORK/test.out" >&2
+    fail=1
+fi
+
+if ( cd "$APP" && "$MACH" run . ) >"$WORK/run.out" 2>&1; then
+    echo "PASS envfwd: mach run forwards the environment"
+else
+    echo "FAIL envfwd: mach run child did not inherit MACH_ENVFWD_PROBE" >&2
+    cat "$WORK/run.out" >&2
+    fail=1
+fi
+
+exit "$fail"

--- a/.github/tests/fwdreexport/app/mach.toml
+++ b/.github/tests/fwdreexport/app/mach.toml
@@ -1,0 +1,29 @@
+# consumer of the demo library: reaches the sibling submodules only through the
+# entrypoint's `fwd` re-exports, proving the re-exported surface is identical
+# whether demo is the root project or a dependency (octalide/mach-std#186).
+[project]
+id      = "fwdapp"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.app]
+entry = "main.mach"
+
+[profile.debug]
+opt = 0
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.5.0"
+
+[deps.demo]
+path = "dep/demo"

--- a/.github/tests/fwdreexport/app/mach.toml
+++ b/.github/tests/fwdreexport/app/mach.toml
@@ -1,6 +1,8 @@
-# consumer of the demo library: reaches the sibling submodules only through the
-# entrypoint's `fwd` re-exports, proving the re-exported surface is identical
-# whether demo is the root project or a dependency (octalide/mach-std#186).
+# consumer of the demo and outer libraries: reaches the sibling submodules only
+# through `fwd` re-exports, proving the re-exported surface is identical whether
+# demo is the root project or a dependency (octalide/mach-std#186), consumable
+# as a module-alias chain in expression position, and stable across a second
+# fwd hop (#1343).
 [project]
 id      = "fwdapp"
 version = "0.1.0"
@@ -27,3 +29,6 @@ ref = "v0.5.0"
 
 [deps.demo]
 path = "dep/demo"
+
+[deps.outer]
+path = "dep/outer"

--- a/.github/tests/fwdreexport/app/src/main.mach
+++ b/.github/tests/fwdreexport/app/src/main.mach
@@ -1,0 +1,9 @@
+use std.runtime;
+use demo.lib;
+
+# `answer` is reached only through lib.mach's symbol re-export — demo.alpha is
+# never imported here, so the call proves the fwd surface is live.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret lib.answer();
+}

--- a/.github/tests/fwdreexport/app/src/main.mach
+++ b/.github/tests/fwdreexport/app/src/main.mach
@@ -1,9 +1,13 @@
 use std.runtime;
 use demo.lib;
+use olib: outer.lib;
 
-# `answer` is reached only through lib.mach's symbol re-export — demo.alpha is
-# never imported here, so the call proves the fwd surface is live.
+# every published fwd surface shape, reached only through re-exports: a symbol
+# re-export (`lib.answer`), module re-exports chained in expression position
+# (`lib.alpha.answer`, and `lib.beta.value` through the nested-FQN alias)
+# (#1343), and a fwd-of-a-fwd through a second library (`olib.answer`,
+# `olib.alpha.answer`).
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
-    ret lib.answer();
+    ret lib.answer() + lib.alpha.answer() + lib.beta.value() + olib.answer() + olib.alpha.answer();
 }

--- a/.github/tests/fwdreexport/demo/mach.toml
+++ b/.github/tests/fwdreexport/demo/mach.toml
@@ -1,0 +1,23 @@
+# standalone library whose entrypoint only `fwd`-re-exports its own sibling
+# submodules — the mach-std lib.mach shape that octalide/mach-std#186 found
+# rejected with "re-exported module is not in the dep set" when built as the
+# root project instead of as a dependency.
+[project]
+id      = "demo"
+version = "0.1.0"
+src     = "src"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[lib.demo]
+entry = "lib.mach"
+kind  = "static"
+
+[profile.debug]
+opt = 0

--- a/.github/tests/fwdreexport/demo/src/alpha.mach
+++ b/.github/tests/fwdreexport/demo/src/alpha.mach
@@ -1,0 +1,5 @@
+# sibling submodule re-exported by the lib entrypoint, both as a whole module
+# (`fwd demo.alpha;`) and per symbol (`fwd demo.alpha.answer;`).
+pub fun answer() i64 {
+    ret 7;
+}

--- a/.github/tests/fwdreexport/demo/src/deep/beta.mach
+++ b/.github/tests/fwdreexport/demo/src/deep/beta.mach
@@ -1,0 +1,5 @@
+# nested sibling submodule re-exported as a module alias by the lib entrypoint —
+# the multi-segment FQN shape (`fwd std.types.bool;`) the original failure named.
+pub fun value() i64 {
+    ret 35;
+}

--- a/.github/tests/fwdreexport/demo/src/lib.mach
+++ b/.github/tests/fwdreexport/demo/src/lib.mach
@@ -1,0 +1,7 @@
+# library surface built purely from same-package re-exports: two sibling module
+# fwds (one nested) and one symbol fwd through a sibling. nothing here `use`s the
+# siblings, so the load walk must record the fwd dependency edges itself
+# (octalide/mach-std#186).
+fwd demo.alpha;
+fwd demo.deep.beta;
+fwd demo.alpha.answer;

--- a/.github/tests/fwdreexport/outer/mach.toml
+++ b/.github/tests/fwdreexport/outer/mach.toml
@@ -1,0 +1,26 @@
+# library that re-exports another library's re-exports: its entrypoint fwds
+# demo's lib.mach surface — a module alias that is itself a fwd, and a symbol
+# that is itself a fwd — proving a fwd-of-a-fwd chain stays consumable (#1343).
+[project]
+id      = "outer"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[lib.outer]
+entry = "lib.mach"
+kind  = "static"
+
+[profile.debug]
+opt = 0
+
+[deps.demo]
+path = "dep/demo"

--- a/.github/tests/fwdreexport/outer/src/lib.mach
+++ b/.github/tests/fwdreexport/outer/src/lib.mach
@@ -1,0 +1,6 @@
+# re-exports of demo's own re-exports (#1343): `alpha` is a module alias that
+# demo.lib itself published via `fwd demo.alpha;`, and `answer` is a symbol
+# demo.lib published via `fwd demo.alpha.answer;`. both must survive a second
+# fwd hop with their resolution intact.
+fwd demo.lib.alpha;
+fwd demo.lib.answer;

--- a/.github/tests/fwdreexport/run.sh
+++ b/.github/tests/fwdreexport/run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# fwd re-export integration test: same-package sibling re-exports in a library
+# entrypoint (octalide/mach-std#186, fixed by #1185 / PR #1186).
+#
+# proves that a standalone `mach build .` of a library whose entrypoint only
+# `fwd`-re-exports its own sibling submodules succeeds — the mach-std lib.mach
+# shape that used to fail with "re-exported module is not in the dep set" when
+# the library was the root project (it always worked as a dependency) — and
+# that a consumer can call through the entrypoint's symbol re-export.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+cp -r "$HERE/demo" "$WORK/demo"
+cp -r "$HERE/app" "$WORK/app"
+mkdir -p "$WORK/app/dep"
+ln -s "$WORK/demo" "$WORK/app/dep/demo"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# the library builds as the ROOT project: every module it contains is in its
+# own dep set, so the entrypoint's sibling re-exports must resolve.
+if ( cd "$WORK/demo" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "PASS fwdreexport: standalone lib build with sibling fwd re-exports"
+else
+    echo "FAIL fwdreexport: standalone lib build with sibling fwd re-exports — build failed" >&2
+    fail=1
+fi
+
+# the same library consumed as a dependency: the consumer reaches `answer`
+# only through the entrypoint's symbol re-export.
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL fwdreexport: consumer build through fwd re-export — build failed" >&2
+    fail=1
+else
+    bin="$WORK/app/out/linux/debug/bin/app"
+    if [ ! -x "$bin" ]; then
+        echo "FAIL fwdreexport: consumer build through fwd re-export — binary not produced at $bin" >&2
+        fail=1
+    else
+        set +e
+        "$bin"; got=$?
+        set -e
+        if [ "$got" -ne 7 ]; then
+            echo "FAIL fwdreexport: consumer call through fwd re-export — exit $got, expected 7" >&2
+            fail=1
+        else
+            echo "PASS fwdreexport: consumer call through fwd symbol re-export"
+        fi
+    fi
+fi
+
+exit "$fail"

--- a/.github/tests/fwdreexport/run.sh
+++ b/.github/tests/fwdreexport/run.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 # fwd re-export integration test: same-package sibling re-exports in a library
-# entrypoint (octalide/mach-std#186, fixed by #1185 / PR #1186).
+# entrypoint (octalide/mach-std#186, fixed by #1185 / PR #1186) and consumer
+# chains through the published surface (#1343).
 #
 # proves that a standalone `mach build .` of a library whose entrypoint only
 # `fwd`-re-exports its own sibling submodules succeeds — the mach-std lib.mach
 # shape that used to fail with "re-exported module is not in the dep set" when
 # the library was the root project (it always worked as a dependency) — and
-# that a consumer can call through the entrypoint's symbol re-export.
+# that a consumer can reach every re-export shape: a symbol re-export, module
+# re-exports chained in expression position (including a nested-FQN alias),
+# and a second library's fwd-of-a-fwd of both.
 #
 # usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -28,9 +31,12 @@ trap 'rm -rf "$WORK"' EXIT
 fail=0
 
 cp -r "$HERE/demo" "$WORK/demo"
+cp -r "$HERE/outer" "$WORK/outer"
 cp -r "$HERE/app" "$WORK/app"
-mkdir -p "$WORK/app/dep"
+mkdir -p "$WORK/outer/dep" "$WORK/app/dep"
+ln -s "$WORK/demo" "$WORK/outer/dep/demo"
 ln -s "$WORK/demo" "$WORK/app/dep/demo"
+ln -s "$WORK/outer" "$WORK/app/dep/outer"
 ln -s "$STD" "$WORK/app/dep/mach-std"
 
 # the library builds as the ROOT project: every module it contains is in its
@@ -42,25 +48,36 @@ else
     fail=1
 fi
 
-# the same library consumed as a dependency: the consumer reaches `answer`
-# only through the entrypoint's symbol re-export.
+# a library whose entrypoint only re-exports ANOTHER library's re-exports
+# builds standalone too: each fwd hop preserves the leaf's resolution (#1343).
+if ( cd "$WORK/outer" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "PASS fwdreexport: standalone lib build with fwd-of-a-fwd re-exports"
+else
+    echo "FAIL fwdreexport: standalone lib build with fwd-of-a-fwd re-exports — build failed" >&2
+    fail=1
+fi
+
+# the libraries consumed as dependencies: the consumer reaches every target
+# only through re-exports — the symbol re-export (7), the module re-exports
+# chained in expression position (7 + 35), and the fwd-of-a-fwd surface
+# (7 + 7) — totalling 63.
 if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
-    echo "FAIL fwdreexport: consumer build through fwd re-export — build failed" >&2
+    echo "FAIL fwdreexport: consumer build through fwd re-exports — build failed" >&2
     fail=1
 else
     bin="$WORK/app/out/linux/debug/bin/app"
     if [ ! -x "$bin" ]; then
-        echo "FAIL fwdreexport: consumer build through fwd re-export — binary not produced at $bin" >&2
+        echo "FAIL fwdreexport: consumer build through fwd re-exports — binary not produced at $bin" >&2
         fail=1
     else
         set +e
         "$bin"; got=$?
         set -e
-        if [ "$got" -ne 7 ]; then
-            echo "FAIL fwdreexport: consumer call through fwd re-export — exit $got, expected 7" >&2
+        if [ "$got" -ne 63 ]; then
+            echo "FAIL fwdreexport: consumer calls through fwd re-exports — exit $got, expected 63" >&2
             fail=1
         else
-            echo "PASS fwdreexport: consumer call through fwd symbol re-export"
+            echo "PASS fwdreexport: consumer calls through symbol, module-chain, and fwd-of-a-fwd re-exports"
         fi
     fi
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-06-12
+
+Patch release clearing the open bug board: environment forwarding for spawned
+user programs, the `-o` absolute-path override, `fwd` module re-export
+consumption, and inline-asm comment handling.
+
 ### Changed
 
-- Bumped the vendored mach-std to v0.6.0 (adds `std.process.env.environ()`).
+- Bumped the vendored mach-std to v0.6.0 (adds `std.process.env.environ()`;
+  fixes the thread spawn/join deadlock and json key lookup).
 
 ### Fixed
 
 - `mach test` and `mach run` now forward the parent environment to spawned
   user programs instead of execing them with an empty `envp`; `getenv` in a
   test or run child sees the inherited variables (mach-std#197).
+- An absolute `-o` path is honored verbatim; previously its leading slash was
+  swallowed by an unconditional join with the project root and the output
+  landed project-relative (#1340).
+- A consumer can chain through `fwd` module re-exports in expression position
+  (`lib.alpha.answer()`), at any depth including a `fwd` of another library's
+  `fwd`; a module alias referenced in value position now reports
+  `a module alias is not a value` instead of silently poisoning and surfacing
+  internal lowering errors (#1343).
 - Inline-asm comments are now opaque to the instruction parser regardless of
   their bytes. A comment containing `;` was split into a phantom instruction
   and one containing `{...}` was misread as a local binding; comments are now
   stripped to end-of-line when the asm body is materialized, before any
   substitution or statement tokenization (#1297).
+
+### Removed
+
+- The unused test-runner write-primitive machinery (`RunnerWrite`,
+  `OsVTable.runner_write`): since 1.4.0's per-test executables, test binaries
+  perform no OS output — the host process reports — so the vtable hook had no
+  consumers on any OS (#1292).
 
 ## [1.4.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped the vendored mach-std to v0.6.0 (adds `std.process.env.environ()`).
+
 ### Fixed
 
+- `mach test` and `mach run` now forward the parent environment to spawned
+  user programs instead of execing them with an empty `envp`; `getenv` in a
+  test or run child sees the inherited variables (mach-std#197).
 - Inline-asm comments are now opaque to the instruction parser regardless of
   their bytes. A comment containing `;` was split into a phantom instruction
   and one containing `{...}` was misread as a local binding; comments are now

--- a/doc/language/fwd.md
+++ b/doc/language/fwd.md
@@ -1,7 +1,7 @@
 # `fwd` — re-exports
 
-`fwd` re-exports a symbol from another module under this module's public
-surface. It is the public counterpart to `use`.
+`fwd` re-exports a symbol or module from another module under this
+module's public surface. It is the public counterpart to `use`.
 
 ## Grammar
 
@@ -24,6 +24,29 @@ fwd Pt: impl.Point;         # re-exports as 'Pt'
 
 The surface file in a shadow-module pattern is typically a long list of
 `fwd` lines — one per symbol the surface exposes.
+
+## Module re-exports
+
+A `fwd` path that ends at a **module** re-exports the whole module as a
+public module alias, mirroring `use`'s module binding:
+
+```mach
+fwd demo.alpha;             # re-exports module 'alpha'
+fwd deep: demo.deep.beta;   # re-exports module under 'deep'
+```
+
+A consumer reaches the alias's members with qualified access, chaining
+through any depth of re-export — including a `fwd` of another library's
+`fwd`:
+
+```mach
+use demo.lib;               # lib.mach contains `fwd demo.alpha;`
+
+lib.alpha.answer();         # resolves through the module re-export
+```
+
+As with `use`, a module alias is not a value; only its members can be
+named.
 
 ## When to use
 

--- a/mach.toml
+++ b/mach.toml
@@ -26,4 +26,4 @@ entry = "main.mach"
 
 [deps.mach-std]
 git = "https://github.com/octalide/mach-std"
-ref = "v0.5.0"
+ref = "v0.6.0"

--- a/mach.toml
+++ b/mach.toml
@@ -27,4 +27,4 @@ entry = "main.mach"
 
 [deps.mach-std]
 git = "https://github.com/octalide/mach-std"
-ref = "branch/dev"
+ref = "v0.5.0"

--- a/mach.toml
+++ b/mach.toml
@@ -20,7 +20,6 @@ isa  = "x86_64"
 os   = "windows"
 abi  = "win64"
 ext  = ".exe"
-libs = ["kernel32.dll"]
 
 [bin.mach]
 entry = "main.mach"

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "1.4.0"
+version = "1.4.1"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1087,7 +1087,8 @@ fun subst_name(tmpl: str, name: str, out: *u8, cap: usize) usize {
 # resolved artifact path. the layout is `<root>/<resolved obj>/<rel>.o`, where
 # `<rel>` is the FQN with '.' turned into '/'; the executable is the resolved
 # `<root>/<bin_out>`. `out_override` (-o), when non-nil, replaces the artifact
-# path with one rooted directly at `<root>`. in library mode (or with
+# path: an absolute path is used verbatim; a relative path is rooted at `<root>`.
+# in library mode (or with
 # `--emit obj`) no executable is linked and the per-module objects are the
 # deliverable. returns the exit code and sets `*out_path` on success — the
 # binary in executable mode, the object tree root in library mode. the linker
@@ -1153,11 +1154,11 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
         print.eprint("\n");
     }
 
-    # the executable path: `-o` overrides it with a path rooted directly at
-    # <root>; otherwise the unit's resolved artifact path is used.
+    # the executable path: an absolute `-o` is used verbatim; a relative one is
+    # rooted at <root>; otherwise the unit's resolved artifact path is used.
     var artifact: [4096]u8;
     if (out_override != nil) {
-        util.join_into(?artifact[0], 4096, root, out_override);
+        util.path_into(?artifact[0], 4096, root, out_override);
     }
     or {
         val bin_opt: Option[str] = intern.lookup(?p.s.interner, p.config.bin_out);

--- a/src/cli/cmd/run.mach
+++ b/src/cli/cmd/run.mach
@@ -2,9 +2,10 @@
 #
 # builds the project through the same pipeline as `build` and then
 # executes the produced binary, forwarding any arguments after a `--`
-# separator to the child as its argv. the child's exit code becomes this
-# subcommand's exit code. `--emit obj` is rejected since running a
-# relocatable object is not meaningful.
+# separator to the child as its argv. the child inherits the parent's
+# environment. the child's exit code becomes this subcommand's exit code.
+# `--emit obj` is rejected since running a relocatable object is not
+# meaningful.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -24,6 +25,7 @@ use page:  std.allocator.page;
 use arena: std.allocator.arena;
 
 use os:    std.system.os;
+use env:   std.process.env;
 use exec:  std.process.exec;
 use print: std.print;
 
@@ -105,7 +107,8 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     child_argv[1 + fwd_count] = nil;
 
-    val exec_r: Result[exec.ExitStatus, str] = exec.run(br.output_path, child_argv, nil);
+    # the child inherits the parent's environment unmodified.
+    val exec_r: Result[exec.ExitStatus, str] = exec.run(br.output_path, child_argv, env.environ());
 
     if (is_err[exec.ExitStatus, str](exec_r)) {
         arena.dnit(?ar);

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -27,6 +27,7 @@ use std.allocator.Allocator;
 use page:  std.allocator.page;
 use arena: std.allocator.arena;
 
+use env:   std.process.env;
 use exec:  std.process.exec;
 use print: std.print;
 
@@ -100,7 +101,8 @@ pub fun run(argc: usize, argv: **u8) i64 {
         report_location(a);
         print.print(" ");
 
-        val exec_r: Result[exec.ExitStatus, str] = exec.run(a.exe, ?child_argv[0], nil);
+        # each test child inherits the parent's environment unmodified.
+        val exec_r: Result[exec.ExitStatus, str] = exec.run(a.exe, ?child_argv[0], env.environ());
         if (is_err[exec.ExitStatus, str](exec_r)) {
             print.print("FAIL(spawn)\n");
             failed = failed + 1;

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -167,6 +167,29 @@ pub fun join_into(buf: *u8, cap: usize, dir: *u8, leaf: *u8) usize {
     ret k;
 }
 
+# path_into: write `path` into `buf`, resolving it against `base` when
+# relative, or copying it verbatim when absolute (starts with '/'). an absolute
+# `path` ignores `base` entirely. returns the byte length written (excluding the
+# terminator), or 0 when it would not fit.
+# ---
+# buf:  destination buffer
+# cap:  capacity of `buf` in bytes
+# base: directory to join against when `path` is relative
+# path: the path to resolve (absolute or relative)
+# ret:  bytes written excluding the terminator, or 0 when it would overflow
+pub fun path_into(buf: *u8, cap: usize, base: *u8, path: *u8) usize {
+    val pl: usize = slen(path);
+    if (pl > 0 && path[0] == '/') {
+        val need: usize = pl + 1;
+        if (need > cap) { ret 0; }
+        var i: usize = 0;
+        for (i < pl) { buf[i] = path[i]; i = i + 1; }
+        buf[pl] = 0;
+        ret pl;
+    }
+    ret join_into(buf, cap, base, path);
+}
+
 # parent_dir: strip the final path component of `path` in place, turning the
 # last '/' into a terminator. returns true if a parent component remained,
 # false when `path` had no separator (already at a root or bare name).
@@ -257,6 +280,31 @@ pub fun ensure_parents(path: *u8) bool {
         i = i + 1;
     }
     ret true;
+}
+
+test "util: path_into uses absolute path verbatim and joins relative path" {
+    var buf: [256]u8;
+    # absolute path must land at exactly that path, ignoring base.
+    val al: usize = path_into(?buf[0], 256, "/base", "/tmp/out/mach");
+    if (al == 0) { ret 1; }
+    var i: usize = 0;
+    val want: *u8 = "/tmp/out/mach";
+    for (buf[i] != 0) {
+        if (want[i] == 0 || buf[i] != want[i]) { ret 1; }
+        i = i + 1;
+    }
+    if (want[i] != 0) { ret 1; }
+    # relative path must be joined with base.
+    val rl: usize = path_into(?buf[0], 256, "/base", "rel/out");
+    if (rl == 0) { ret 1; }
+    val rwant: *u8 = "/base/rel/out";
+    i = 0;
+    for (buf[i] != 0) {
+        if (rwant[i] == 0 || buf[i] != rwant[i]) { ret 1; }
+        i = i + 1;
+    }
+    if (rwant[i] != 0) { ret 1; }
+    ret 0;
 }
 
 test "util: separator_index reports the -- boundary as the effective argc" {

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -56,6 +56,7 @@ use std.types.string.StrView;
 use std.types.string.str_len;
 use std.types.string.view;
 use std.types.string.view_eq_str;
+use std.types.string.view_contains_char;
 
 use std.allocator.Allocator;
 use std.allocator.allocate;
@@ -733,7 +734,7 @@ fun eval_lit_str(source: str, span: token.Span, interner: *intern.Interner) Resu
 
 # decodes escape sequences in `inner` and interns the result via `interner`
 fun intern_decoded(interner: *intern.Interner, inner: StrView) Result[intern.StrId, str] {
-    val has_escape: bool = contains_byte(inner, '\\');
+    val has_escape: bool = view_contains_char(inner, '\\');
     if (!has_escape) {
         ret intern.intern_bytes(interner, inner.data::str, inner.len);
     }
@@ -819,17 +820,6 @@ fun hex_digit(c: u8) i64 {
     if (c >= 'a' && c <= 'f') { ret (c - 'a')::i64 + 10; }
     if (c >= 'A' && c <= 'F') { ret (c - 'A')::i64 + 10; }
     ret 0 - 1;
-}
-
-# true when byte `b` occurs in view `s`.
-# TODO(#1302): kept local; std.types.string StrView has no view_index_char/contains.
-fun contains_byte(s: StrView, b: u8) bool {
-    var i: usize = 0;
-    for (i < s.len) {
-        if (s.data[i] == b) { ret true; }
-        i = i + 1;
-    }
-    ret false;
 }
 
 # binary-operator dispatch

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -987,20 +987,22 @@ fun find_module_exports_by_module(rc: *ResolveContext, mid: sess.ModuleId) *Modu
 }
 
 # resolves a qualified member access `alias.symbol`, recording the referenced
-# symbol on the member expression. when the object identifier binds to a
-# module alias (a `SYM_USE` whose `slot` names the aliased module), the leaf
-# names a public symbol of that module rather than a record field; this looks
-# it up among the module's exports and records an imported symbol on the
-# member's `expr_resolved` slot so sema can type it directly. a non-module
-# object (an ordinary value) is left for sema's field-access path; an
-# unexported or missing leaf reports an error. `member` is the ExprMember
-# payload and `eid` its expression id.
+# symbol on the member expression. when the object expression resolves to a
+# module alias (a `SYM_USE` whose `slot` names the aliased module) — a bare
+# ident bound by `use`, or a nested member that itself resolved to a `fwd`
+# module re-export — the leaf names a public symbol of that module rather than
+# a record field; this looks it up among the module's exports and records an
+# imported symbol on the member's `expr_resolved` slot so sema can type it
+# directly. the object is bound before this runs, so a chain resolves left to
+# right through any depth of module aliases. a non-module object (an ordinary
+# value) is left for sema's field-access path; an unexported or missing leaf
+# reports an error. `member` is the ExprMember payload and `eid` its
+# expression id.
 fun bind_member_qualified(rc: *ResolveContext, eid: id.ExprId, member: *expr.ExprMember) Result[bool, str] {
     if (rc.expr_resolved == nil) { ret ok[bool, str](true); }
 
     val obj_opt: Option[*expr.Expr] = ast.get_expr(rc.a, member.object);
     if (is_none[*expr.Expr](obj_opt)) { ret ok[bool, str](true); }
-    if (unwrap[*expr.Expr](obj_opt).kind != expr.EXPR_KIND_IDENT) { ret ok[bool, str](true); }
 
     val osid: SymbolId = rc.expr_resolved[member.object];
     if (osid == SYMBOL_NIL || osid >= rc.sym_len) { ret ok[bool, str](true); }
@@ -1009,7 +1011,13 @@ fun bind_member_qualified(rc: *ResolveContext, eid: id.ExprId, member: *expr.Exp
 
     val target: sess.ModuleId = osym.slot::sess.ModuleId;
     val mx: *ModuleExports = find_module_exports_by_module(rc, target);
-    if (mx == nil) { ret ok[bool, str](true); }
+    if (mx == nil) {
+        # a SYM_USE always names a module the driver's dep-set closure included,
+        # so a miss is a broken build graph; report it rather than silently
+        # falling through to sema's field-access path.
+        diag.error(?rc.s.diags, rc.a.file_id, member.name, "module alias names a module that is not in the dep set");
+        ret ok[bool, str](true);
+    }
 
     val r_leaf: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, member.name);
     if (is_err[intern.StrId, str](r_leaf)) { ret err[bool, str](unwrap_err[intern.StrId, str](r_leaf)); }
@@ -1204,7 +1212,13 @@ fun bind_fwd(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, flags: 
         ret ok[bool, str](true);
     }
 
-    val r_sym: Result[SymbolId, str] = add_symbol(rc, ps.kind, SYM_FLAG_PUB, name_id, ps.decl, 0, ps.origin);
+    # a leaf that is itself a module re-export (SYM_USE) keeps its target-module
+    # slot, so a fwd of another library's fwd stays consumable downstream
+    # (mirrors imported_symbol_for's slot preservation)
+    var slot: u32 = 0;
+    if (ps.kind == SYM_USE) { slot = ps.slot; }
+
+    val r_sym: Result[SymbolId, str] = add_symbol(rc, ps.kind, SYM_FLAG_PUB, name_id, ps.decl, slot, ps.origin);
     if (is_err[SymbolId, str](r_sym)) { ret err[bool, str](unwrap_err[SymbolId, str](r_sym)); }
     val sid: SymbolId = unwrap_ok[SymbolId, str](r_sym);
 

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -284,6 +284,15 @@ fun infer_ident(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
     if (is_none[*resolve.Symbol](sym_opt)) { ret type.TYPE_ERROR; }
     val sym: *resolve.Symbol = unwrap[*resolve.Symbol](sym_opt);
 
+    # a module alias (`use`/`fwd` binding) names a module, not a value. a
+    # qualified member access consumes the alias in resolve and never infers
+    # it, so an alias reaching value inference is a misuse; report it loudly —
+    # resolve recorded the symbol without error, and a silent TYPE_ERROR here
+    # would let a clean sema pass hand the broken access to lowering.
+    if (sym.kind == resolve.SYM_USE) {
+        ret report_module_alias_value(sc, eid);
+    }
+
     # a comptime-parameter function is a TEMPLATE: it is only ever emitted as a
     # per-value instance at a call site, never as a standalone symbol. referencing
     # it as a VALUE (assigning it, passing it, comparing it) would bind to a
@@ -318,6 +327,16 @@ fun ident_is_comptime_param_fn(sc: *sema.SemaContext, sym: *resolve.Symbol) bool
         i = i + 1;
     }
     ret false;
+}
+
+# reports a module alias referenced in value position against the expression's
+# span and poisons the expression.
+fun report_module_alias_value(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
+    val e_opt: Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (is_some[*expr.Expr](e_opt)) {
+        sema.report(sc, unwrap[*expr.Expr](e_opt).span, "a module alias is not a value; name one of the module's members");
+    }
+    ret type.TYPE_ERROR;
 }
 
 # reports a comptime-parameter-function value reference against the ident span and
@@ -785,7 +804,23 @@ fun infer_index(sc: *sema.SemaContext, ix: *expr.ExprIndex, span: token.Span) ty
 fun infer_member(sc: *sema.SemaContext, eid: id.ExprId, m: *expr.ExprMember, span: token.Span) type.TypeId {
     val qsym_opt: Option[*resolve.Symbol] = sema.symbol_for_expr(sc, eid);
     if (is_some[*resolve.Symbol](qsym_opt)) {
-        ret sema.decl_type_for(sc, unwrap[*resolve.Symbol](qsym_opt));
+        val qsym: *resolve.Symbol = unwrap[*resolve.Symbol](qsym_opt);
+        # a member that resolved to a module alias (`lib.alpha` through a `fwd`
+        # module re-export) names a module, not a value; in value position it
+        # is a misuse, exactly like a bare alias ident (see infer_ident).
+        if (qsym.kind == resolve.SYM_USE) {
+            ret report_module_alias_value(sc, eid);
+        }
+        ret sema.decl_type_for(sc, qsym);
+    }
+
+    # an unresolved member whose object IS a module alias: resolve already
+    # reported the failure (a missing export, or a missing dep-set target), so
+    # poison silently like any other unresolved reference instead of inferring
+    # the alias object as a value.
+    val osym_opt: Option[*resolve.Symbol] = sema.symbol_for_expr(sc, m.object);
+    if (is_some[*resolve.Symbol](osym_opt) && unwrap[*resolve.Symbol](osym_opt).kind == resolve.SYM_USE) {
+        ret type.TYPE_ERROR;
     }
 
     # a rooted comptime member chain (`$mach.*`, `$project.*`, `$target.*`,

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -539,17 +539,6 @@ fun free_payload(t: *IrTypeTable, ir: *IrType) {
     }
 }
 
-# true when two IrTypeId sequences of length `n` are element-wise equal.
-# TODO(#1302): kept local; std.memory has no generic equal[T] yet.
-fun id_seq_equals(a: *IrTypeId, b: *IrTypeId, n: u32) bool {
-    var i: u32 = 0;
-    for (i < n) {
-        if (a[i] != b[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
-}
-
 # rounds `value` up to the next multiple of `align` (a power-of-two alignment).
 # an alignment of 0 or 1 returns `value` unchanged. used by the natural C-style
 # aggregate-layout computations.
@@ -647,13 +636,13 @@ fun eq_ir_type(pa: ptr, pb: ptr) bool {
     }
     if (a.kind == IRT_STRUCT || a.kind == IRT_UNION) {
         if (a.data.struct_.field_count != b.data.struct_.field_count) { ret false; }
-        ret id_seq_equals(a.data.struct_.fields, b.data.struct_.fields, a.data.struct_.field_count);
+        ret mem.equal[IrTypeId](a.data.struct_.fields, b.data.struct_.fields, a.data.struct_.field_count::usize);
     }
     if (a.kind == IRT_FN) {
         if (a.data.fn.ret_ty != b.data.fn.ret_ty) { ret false; }
         if (a.data.fn.param_count != b.data.fn.param_count) { ret false; }
         if (a.data.fn.varargs != b.data.fn.varargs) { ret false; }
-        ret id_seq_equals(a.data.fn.params, b.data.fn.params, a.data.fn.param_count);
+        ret mem.equal[IrTypeId](a.data.fn.params, b.data.fn.params, a.data.fn.param_count::usize);
     }
     # IRT_VOID and IRT_PTR are equal by kind alone.
     ret true;

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -278,7 +278,8 @@ pub fun set_input(db: *QueryDb, kind: QueryKind, key: u64, value: *u8, value_len
 
     val existing: *QueryEntry = find_entry(sh, key);
     if (existing != nil) {
-        val same: bool = bytes_equal(existing.value, existing.value_len, value, value_len);
+        val same: bool = existing.value_len == value_len
+            && mem.raw_equal(existing.value::ptr, value::ptr, value_len::usize);
         val rcopy: Result[*u8, str] = dup_bytes(db.alloc, value, value_len);
         if (is_err[*u8, str](rcopy)) { ret err[bool, str](unwrap_err[*u8, str](rcopy)); }
         if (existing.value != nil && existing.value_len > 0) {
@@ -547,7 +548,8 @@ fun recompute(db: *QueryDb, sh: *QueryShard, e: *QueryEntry, key: u64) Result[*Q
     }
     val out: QueryOutput = unwrap_ok[QueryOutput, str](rout);
 
-    val same: bool = bytes_equal(e.value, e.value_len, out.bytes, out.len);
+    val same: bool = e.value_len == out.len
+        && mem.raw_equal(e.value::ptr, out.bytes::ptr, out.len::usize);
     if (same) {
         if (out.bytes != nil && out.len > 0) {
             deallocate[u8](db.alloc, out.bytes, out.len::usize);
@@ -660,19 +662,6 @@ fun dup_bytes(alloc: *Allocator, src: *u8, len: u32) Result[*u8, str] {
     val dst: *u8 = unwrap_ok[*u8, str](r);
     mem.raw_copy(dst::ptr, src::ptr, len::usize);
     ret ok[*u8, str](dst);
-}
-
-# bytes_equal: byte-wise equality of two buffers. nil buffers compare as length-0.
-# TODO(#1302): kept local; std.memory has no raw_equal/equal[T] yet.
-fun bytes_equal(a: *u8, a_len: u32, b: *u8, b_len: u32) bool {
-    if (a_len != b_len) { ret false; }
-    if (a_len == 0) { ret true; }
-    var i: u32 = 0;
-    for (i < a_len) {
-        if (a[i] != b[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
 }
 
 # a derived compute that always fails, to exercise the failed-recompute path.

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -12,7 +12,6 @@ use std.types.option.none;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
-use std.types.string.str;
 
 use intern: mach.lang.intern;
 
@@ -26,28 +25,6 @@ pub val OS_LINUX:        u32 = 1;
 pub val OS_DARWIN:       u32 = 2;
 pub val OS_WINDOWS:      u32 = 3;
 pub val OS_FREESTANDING: u32 = 4;
-
-# the freestanding inline-asm write primitive the synthesized `mach test` runner
-# uses to emit its output on a given (os, arch). `body` is the OP_ASM body — with
-# `{buf}` / `{len}` placeholders the runner binds to its buffer and length
-# arguments — and `isa_tag` is the OP_ASM architecture tag. produced by the
-# OsVTable's `runner_write` accessor for the resolved architecture; an OS / arch
-# pair with no freestanding write returns none and the runner is unavailable.
-# ---
-# body:    the OP_ASM body text (with {buf} / {len} placeholders)
-# isa_tag: the OP_ASM architecture tag for the resolved arch
-pub rec RunnerWrite {
-    body:    str;
-    isa_tag: str;
-}
-
-# RunnerWriteFn: the concrete signature the erased `OsVTable.runner_write` pointer
-# casts back to. given the resolved architecture id (one of isa.ARCH_*), returns
-# the runner's write primitive for this (os, arch), or none when the OS exposes no
-# freestanding inline-asm write for that architecture (e.g. Windows, which needs
-# imported kernel32 calls rather than a syscall). the test-runner synthesizer reads
-# it through the selected target's OS vtable so the runner stays target-agnostic.
-pub def RunnerWriteFn: fun(u32) Option[RunnerWrite];
 
 # the operating-system runtime-dispatch interface. exactly one of these exists
 # per OS; the driver and linker read the entry symbol, library directory, and
@@ -68,11 +45,6 @@ pub def RunnerWriteFn: fun(u32) Option[RunnerWrite];
 #                  linker assigns section vaddrs upward from it
 # page_size:       virtual-memory page size in bytes the linker page-aligns
 #                  segment virtual addresses to
-# runner_write:    erased fn ptr — the synthesized `mach test` runner's freestanding
-#                  write primitive for a resolved architecture (cast back to
-#                  `RunnerWriteFn`); none when the OS has no inline-asm write for
-#                  that arch, which makes `mach test` fail loudly rather than emit a
-#                  wrong-OS output sequence
 pub rec OsVTable {
     id:             u32;
     name:           intern.StrId;
@@ -82,7 +54,6 @@ pub rec OsVTable {
     dynamic_linker: intern.StrId;
     base_addr:      u64;
     page_size:      u64;
-    runner_write:   *u8;
 }
 
 val OS_REGISTRY_CAP: u32 = 8;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -20,23 +20,11 @@ use std.types.bool.true;
 use std.types.bool.false;
 
 use std.types.string.str;
-use std.types.option.Option;
-use std.types.option.none;
 
 use std.allocator.Allocator;
 
 use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
-
-# runner_write: Darwin has no freestanding inline-asm `mach test` write yet (its
-# write syscall number differs from Linux's), so every architecture returns none
-# and `mach test --target darwin` fails loudly — tracked by #1292.
-# ---
-# arch_id: resolved architecture id (one of isa.ARCH_*)
-# ret:     none (no Darwin runner write implemented)
-fun runner_write(arch_id: u32) Option[os.RunnerWrite] {
-    ret none[os.RunnerWrite]();
-}
 
 # default base virtual address for Darwin executables (4 GiB).
 pub val DARWIN_BASE_ADDR: u64 = 0x100000000;
@@ -84,7 +72,6 @@ pub fun register_darwin(alloc: *Allocator, i: *intern.Interner) Result[bool, str
     darwin_vtable.dynamic_linker = intern.STR_NIL;
     darwin_vtable.base_addr      = DARWIN_BASE_ADDR;
     darwin_vtable.page_size      = DARWIN_PAGE_SIZE;
-    darwin_vtable.runner_write   = runner_write::*u8;
 
     os.register(?darwin_vtable);
     ret ok[bool, str](true);

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -19,14 +19,10 @@ use std.types.bool.true;
 use std.types.bool.false;
 
 use std.types.string.str;
-use std.types.option.Option;
-use std.types.option.some;
-use std.types.option.none;
 
 use std.allocator.Allocator;
 
 use intern: mach.lang.intern;
-use isa:    mach.lang.target.isa;
 use os:     mach.lang.target.os;
 
 # default base virtual address for Linux executables. the first PT_LOAD
@@ -44,24 +40,6 @@ pub val LINUX_PAGE_SIZE: u64 = 4096;
 # target/sysroot-configurable setting to avoid emitting an ELF whose interpreter
 # is absent at exec time.
 pub val LINUX_DYNAMIC_LINKER: str = "/lib64/ld-linux-x86-64.so.2";
-
-# runner_write: the synthesized `mach test` runner's freestanding write primitive
-# on Linux. for x86-64 it is the `write(1, buf, len)` syscall (rax=1) tagged for the
-# x86_64 OP_ASM encoder; other architectures have no inline-asm write here yet and
-# return none so `mach test` fails loudly rather than emitting a wrong sequence (the
-# aarch64 runner lands with #1045's freestanding write).
-# ---
-# arch_id: resolved architecture id (one of isa.ARCH_*)
-# ret:     the write primitive for this arch, or none if unsupported
-fun runner_write(arch_id: u32) Option[os.RunnerWrite] {
-    if (arch_id == isa.ARCH_X86_64) {
-        var w: os.RunnerWrite;
-        w.body    = "mov rax, 1\nmov rdi, 1\nmov rsi, {buf}\nmov rdx, {len}\nsyscall\n";
-        w.isa_tag = "x86_64";
-        ret some[os.RunnerWrite](w);
-    }
-    ret none[os.RunnerWrite]();
-}
 
 # the Linux OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry; remains valid for the process lifetime.
@@ -105,7 +83,6 @@ pub fun register_linux(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     linux_vtable.dynamic_linker = unwrap_ok[intern.StrId, str](rd);
     linux_vtable.base_addr      = LINUX_BASE_ADDR;
     linux_vtable.page_size      = LINUX_PAGE_SIZE;
-    linux_vtable.runner_write   = runner_write::*u8;
 
     os.register(?linux_vtable);
     ret ok[bool, str](true);

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -20,24 +20,11 @@ use std.types.bool.true;
 use std.types.bool.false;
 
 use std.types.string.str;
-use std.types.option.Option;
-use std.types.option.none;
 
 use std.allocator.Allocator;
 
 use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
-
-# runner_write: Windows writes to standard output through kernel32 (GetStdHandle +
-# WriteFile imports), not a freestanding syscall, so the synthesized inline-asm
-# runner cannot express it; every architecture returns none and `mach test --target
-# windows` fails loudly — the import-based runner is tracked by #1292.
-# ---
-# arch_id: resolved architecture id (one of isa.ARCH_*)
-# ret:     none (no Windows runner write implemented)
-fun runner_write(arch_id: u32) Option[os.RunnerWrite] {
-    ret none[os.RunnerWrite]();
-}
 
 # default base virtual address for Windows x86_64 executables.
 pub val WINDOWS_BASE_ADDR: u64 = 0x140000000;
@@ -84,7 +71,6 @@ pub fun register_windows(alloc: *Allocator, i: *intern.Interner) Result[bool, st
     windows_vtable.dynamic_linker = intern.STR_NIL;
     windows_vtable.base_addr      = WINDOWS_BASE_ADDR;
     windows_vtable.page_size      = WINDOWS_PAGE_SIZE;
-    windows_vtable.runner_write   = runner_write::*u8;
 
     os.register(?windows_vtable);
     ret ok[bool, str](true);


### PR DESCRIPTION
Integration merge for the v1.4.1 release. Patch release clearing the bug board: env forwarding for spawned user programs (mach-std#197), absolute `-o` override (#1340), `fwd` module re-export consumption + silent-poison diagnostic (#1343), inline-asm comment handling (#1297), dead runner-write machinery removed (#1292), vendored mach-std v0.6.0. See CHANGELOG 1.4.1.