### PR TITLE
release: standard artifact format + one-line install scripts (step 1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,13 +67,25 @@ jobs:
       - name: Package artifacts
         run: |
           set -euo pipefail
+          ver="${GITHUB_REF_NAME#v}"
           mkdir -p dist
           # `mach` is the bootstrap-seed alias (ci.yml / release.yml fetch `-p mach`
-          # from the most recent release); the per-target names are the public ones.
+          # from the most recent release); the bare per-target names are the legacy
+          # public assets, kept until consumers move to the versioned archives (#1352).
           cp out/linux/bin/mach dist/mach
           cp out/linux/bin/mach dist/mach-x86_64-linux
           ( cd out/windows/bin && zip -q "$GITHUB_WORKSPACE/dist/mach-x86_64-windows.zip" mach.exe )
-          ( cd dist && sha256sum mach-x86_64-linux mach-x86_64-windows.zip > SHA256SUMS )
+          # versioned archives: the standard format install.sh / install.ps1 consume.
+          stage="$(mktemp -d)"
+          cp out/linux/bin/mach LICENSE "$stage"
+          tar -C "$stage" -czf "dist/mach-$ver-x86_64-linux.tar.gz" mach LICENSE
+          rm "$stage/mach"
+          cp out/windows/bin/mach.exe "$stage"
+          ( cd "$stage" && zip -q "$GITHUB_WORKSPACE/dist/mach-$ver-x86_64-windows.zip" mach.exe LICENSE )
+          cp install.sh install.ps1 dist/
+          ( cd dist && sha256sum mach-x86_64-linux mach-x86_64-windows.zip \
+              "mach-$ver-x86_64-linux.tar.gz" "mach-$ver-x86_64-windows.zip" \
+              install.sh install.ps1 > SHA256SUMS )
 
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2
@@ -82,4 +94,8 @@ jobs:
             dist/mach
             dist/mach-x86_64-linux
             dist/mach-x86_64-windows.zip
+            dist/mach-*-x86_64-linux.tar.gz
+            dist/mach-*-x86_64-windows.zip
             dist/SHA256SUMS
+            dist/install.sh
+            dist/install.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- One-line install scripts: `install.sh` (Linux) and `install.ps1` (Windows),
+  shipped in the repo and as release assets. They resolve the latest tag from
+  the `releases/latest` redirect, download the versioned archive for the host,
+  verify it against `SHA256SUMS`, and install to `~/.local/bin`
+  (`%LOCALAPPDATA%\mach\bin` on Windows); `MACH_VERSION` and
+  `MACH_INSTALL_DIR` override the release and destination (#1352).
+- Releases now ship versioned archives — `mach-<version>-x86_64-linux.tar.gz`
+  and `mach-<version>-x86_64-windows.zip`, each containing the binary and
+  LICENSE — alongside the existing assets, with `SHA256SUMS` covering the
+  full set (#1352).
+
 ## [1.4.1] - 2026-06-12
 
 Patch release clearing the open bug board: environment forwarding for spawned

--- a/README.md
+++ b/README.md
@@ -27,10 +27,28 @@ Use Mach when you want C's reach with one coherent toolchain: a single binary th
 Read the [language reference](doc/language/README.md) before installing. The docs are written more like a pamphlet than a bible and assume familiarity with basic programming concepts from other languages.
 
 
+## Installing Mach
+
+Install the latest release with one line:
+
+```bash
+curl -fsSL https://github.com/octalide/mach/releases/latest/download/install.sh | sh
+```
+
+On Windows (PowerShell):
+
+```powershell
+irm https://github.com/octalide/mach/releases/latest/download/install.ps1 | iex
+```
+
+The scripts verify the download against the release `SHA256SUMS` and install to
+`~/.local/bin` (`%LOCALAPPDATA%\mach\bin` on Windows). Precompiled binaries are
+also available directly on the [releases](https://github.com/octalide/mach/releases) page.
+
+
 ## Building Mach
 
 Mach builds itself, so building from source needs an existing `mach` installation.
-You can download precompiled binaries for your system on the [releases](https://github.com/octalide/mach/releases) page.
 
 ```bash
 git clone https://github.com/octalide/mach

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,62 @@
+# installs the mach release binary.
+# usage: irm https://github.com/octalide/mach/releases/latest/download/install.ps1 | iex
+#
+# MACH_VERSION      version to install (e.g. 1.4.2); defaults to the latest release
+# MACH_INSTALL_DIR  install directory; defaults to $env:LOCALAPPDATA\mach\bin
+# MACH_BASE_URL     release base url override (for testing)
+
+$ErrorActionPreference = 'Stop'
+
+$base = if ($env:MACH_BASE_URL) { $env:MACH_BASE_URL } else { 'https://github.com/octalide/mach/releases' }
+$dir = if ($env:MACH_INSTALL_DIR) { $env:MACH_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA 'mach\bin' }
+$target = 'x86_64-windows'
+
+if (-not [System.Environment]::Is64BitOperatingSystem) {
+    throw 'install.ps1: unsupported host; mach requires 64-bit windows'
+}
+
+if ($env:MACH_VERSION) {
+    $tag = if ($env:MACH_VERSION.StartsWith('v')) { $env:MACH_VERSION } else { "v$($env:MACH_VERSION)" }
+} else {
+    $handler = New-Object System.Net.Http.HttpClientHandler
+    $handler.AllowAutoRedirect = $false
+    $client = New-Object System.Net.Http.HttpClient($handler)
+    try {
+        $req = New-Object System.Net.Http.HttpRequestMessage([System.Net.Http.HttpMethod]::Head, "$base/latest")
+        $resp = $client.SendAsync($req).GetAwaiter().GetResult()
+        if (-not $resp.Headers.Location) { throw 'install.ps1: could not resolve the latest release tag' }
+        $tag = ($resp.Headers.Location.ToString() -split '/tag/')[-1]
+    } finally {
+        $client.Dispose()
+    }
+}
+$version = $tag.TrimStart('v')
+
+$archive = "mach-$version-$target.zip"
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) "mach-install-$([System.IO.Path]::GetRandomFileName())"
+New-Item -ItemType Directory -Path $tmp | Out-Null
+try {
+    Write-Host "downloading $archive ($tag)"
+    Invoke-WebRequest -Uri "$base/download/$tag/$archive" -OutFile (Join-Path $tmp $archive)
+    Invoke-WebRequest -Uri "$base/download/$tag/SHA256SUMS" -OutFile (Join-Path $tmp 'SHA256SUMS')
+
+    $line = Select-String -Path (Join-Path $tmp 'SHA256SUMS') -Pattern ([regex]::Escape($archive) + '$') | Select-Object -First 1
+    if (-not $line) { throw "install.ps1: no checksum for $archive in SHA256SUMS" }
+    $expected = ($line.Line -split '\s+')[0].ToLower()
+    $actual = (Get-FileHash -Algorithm SHA256 -Path (Join-Path $tmp $archive)).Hash.ToLower()
+    if ($actual -ne $expected) {
+        throw "install.ps1: checksum verification FAILED for $archive (expected $expected, got $actual); aborting"
+    }
+
+    Expand-Archive -Path (Join-Path $tmp $archive) -DestinationPath $tmp -Force
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    Copy-Item (Join-Path $tmp 'mach.exe') (Join-Path $dir 'mach.exe') -Force
+    Write-Host "installed mach $version to $(Join-Path $dir 'mach.exe')"
+
+    if (-not (($env:Path -split ';') -contains $dir)) {
+        Write-Host "note: $dir is not on PATH; add it, e.g.:"
+        Write-Host "  [Environment]::SetEnvironmentVariable('Path', `"$dir;`" + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
+    }
+} finally {
+    Remove-Item -Recurse -Force $tmp
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# installs the mach release binary.
+# usage: curl -fsSL https://github.com/octalide/mach/releases/latest/download/install.sh | sh
+#
+# MACH_VERSION      version to install (e.g. 1.4.2); defaults to the latest release
+# MACH_INSTALL_DIR  install directory; defaults to ~/.local/bin
+# MACH_BASE_URL     release base url override (for testing)
+set -eu
+
+base="${MACH_BASE_URL:-https://github.com/octalide/mach/releases}"
+dir="${MACH_INSTALL_DIR:-$HOME/.local/bin}"
+version="${MACH_VERSION:-${1:-}}"
+
+err() { echo "install.sh: $*" >&2; exit 1; }
+
+command -v curl >/dev/null || err "curl is required"
+command -v sha256sum >/dev/null || err "sha256sum is required"
+
+case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64) target="x86_64-linux" ;;
+    *) err "unsupported host $(uname -s)-$(uname -m); prebuilt binaries: https://github.com/octalide/mach/releases" ;;
+esac
+
+if [ -n "$version" ]; then
+    case "$version" in
+        v*) tag="$version" ;;
+        *)  tag="v$version" ;;
+    esac
+else
+    tag="$(curl -fsSI "$base/latest" | tr -d '\r' | grep -i '^location:' | sed 's|.*/tag/||')"
+    [ -n "$tag" ] || err "could not resolve the latest release tag"
+fi
+version="${tag#v}"
+
+archive="mach-$version-$target.tar.gz"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "downloading $archive ($tag)"
+curl -fsSL -o "$tmp/$archive" "$base/download/$tag/$archive"
+curl -fsSL -o "$tmp/SHA256SUMS" "$base/download/$tag/SHA256SUMS"
+
+grep " $archive\$" "$tmp/SHA256SUMS" > "$tmp/SHA256SUMS.want" || err "no checksum for $archive in SHA256SUMS"
+( cd "$tmp" && sha256sum -c SHA256SUMS.want >/dev/null 2>&1 ) || err "checksum verification FAILED for $archive; aborting"
+
+tar -xzf "$tmp/$archive" -C "$tmp" mach
+mkdir -p "$dir"
+install -m 755 "$tmp/mach" "$dir/mach"
+echo "installed mach $version to $dir/mach"
+
+case ":$PATH:" in
+    *":$dir:"*) ;;
+    *) echo "note: $dir is not on PATH; add it to your shell profile" ;;
+esac


### PR DESCRIPTION
Closes #1352

Step 1 of the release-format transition: adds `install.sh` / `install.ps1`, packages the new versioned archives alongside the legacy assets in release.yml, and updates README/CHANGELOG. Legacy assets (`mach`, `mach-x86_64-linux`, `mach-x86_64-windows.zip`) and all consumers (ci.yml, mach-std workflows) are untouched — step 2 switches consumers after the next release ships.

## What changed

- **install.sh** (repo root): POSIX sh, `set -eu`. Resolves the latest tag from the `releases/latest` redirect `Location` header (no API), detects the host (`x86_64-linux` only for now, clear error otherwise), downloads `mach-<version>-x86_64-linux.tar.gz` + `SHA256SUMS`, verifies the checksum before extracting, installs to `~/.local/bin/mach`, prints a PATH hint. Overrides: `MACH_VERSION` (or `$1`), `MACH_INSTALL_DIR`, `MACH_BASE_URL` (for testing).
- **install.ps1**: same flow for `x86_64-windows`; installs `mach.exe` to `$env:LOCALAPPDATA\mach\bin`, prints a PATH hint (never mutates PATH). Same env overrides. Latest-tag resolution uses `HttpClient` with `AllowAutoRedirect=$false` via `SendAsync(...).GetAwaiter().GetResult()` so it works on both Windows PowerShell 5.1 and pwsh 7.
- **release.yml**: packaging now also produces `mach-<version>-x86_64-linux.tar.gz` (mach + LICENSE), `mach-<version>-x86_64-windows.zip` (mach.exe + LICENSE), copies `install.sh`/`install.ps1` into dist, and `SHA256SUMS` covers the full public set. `<version>` comes from `${GITHUB_REF_NAME#v}` (the tag is already validated against mach.toml earlier in the job). `zip` is installed by the wine smoke step that precedes packaging, as before.
- **README**: "Installing Mach" section with the two one-liners; build-from-source untouched.
- **CHANGELOG**: Unreleased > Added.

## Verification

**install.sh** — shellcheck v0.10.0 (`shellcheck -s sh`): clean, zero findings. Plus `sh -n` / `bash -n`.

End-to-end against the real v1.4.1 binaries: built the new-format archives locally with the exact workflow commands, served them from `/tmp` with a python server that emulates the GitHub `releases/latest` 302 redirect, ran the script with `MACH_BASE_URL` pointed at it:

```
$ MACH_BASE_URL=http://127.0.0.1:8642 MACH_INSTALL_DIR=/tmp/m1352/install_dest sh install.sh
downloading mach-1.4.1-x86_64-linux.tar.gz (v1.4.1)        # tag resolved via Location header
installed mach 1.4.1 to /tmp/m1352/install_dest/mach
note: /tmp/m1352/install_dest is not on PATH; add it to your shell profile
$ /tmp/m1352/install_dest/mach info
mach 1.4.1
host: linux/x86_64
...
```

Corrupted archive (10 bytes overwritten at offset 100) — aborts loudly, exit 1, nothing installed:

```
downloading mach-1.4.1-x86_64-linux.tar.gz (v1.4.1)
install.sh: checksum verification FAILED for mach-1.4.1-x86_64-linux.tar.gz; aborting
exit=1
(install dir absent — nothing installed)
```

Also exercised: `MACH_VERSION=1.4.1` and `MACH_VERSION=v1.4.1` (both install), SHA256SUMS missing the archive entry (`install.sh: no checksum for ... in SHA256SUMS`, exit 1), unsupported host via a `uname` shim reporting aarch64 (`install.sh: unsupported host Linux-aarch64; ...`, exit 1), stdin pipe form (`cat install.sh | sh`), and the tag-parse against real GitHub headers (`curl -sI .../releases/latest` resolves `v1.4.1`).

**install.ps1** — executed for real under portable pwsh 7.5.2 on Linux (no Windows host): parse check, happy path via the local redirect server (mach.exe lands in `MACH_INSTALL_DIR`), corrupted zip (throws `checksum verification FAILED ... aborting`, exit 1, nothing installed), and the `irm <url>/install.ps1 | iex` form (works — no param block, env-var configuration only, deliberately iex-safe). NOT executed: Windows PowerShell 5.1, a real Windows host, and the `$env:LOCALAPPDATA` default path — those got static review only; the `SendAsync().GetAwaiter().GetResult()` pattern was chosen specifically because 5.1's .NET Framework HttpClient has no sync `Send`.

**release.yml** — `python3 -c "yaml.safe_load(...)"` ok. Packaging step executed locally verbatim (transcript above produced the dist below) with `GITHUB_REF_NAME=v1.4.1`; the only substitution was `bsdtar -a -cf` for `zip` (not installed locally; the workflow installs zip via apt in the preceding wine step, unchanged):

```
dist/
  install.ps1  install.sh  mach  mach-1.4.1-x86_64-linux.tar.gz  mach-1.4.1-x86_64-windows.zip
  mach-x86_64-linux  mach-x86_64-windows.zip  SHA256SUMS
$ tar -tzf dist/mach-1.4.1-x86_64-linux.tar.gz
mach
LICENSE
$ bsdtar -tf dist/mach-1.4.1-x86_64-windows.zip
mach.exe
LICENSE
$ cat dist/SHA256SUMS    # covers both legacy and versioned assets + scripts
db98485e...  mach-x86_64-linux
8ad43528...  mach-x86_64-windows.zip
0b7d018c...  mach-1.4.1-x86_64-linux.tar.gz
7a798581...  mach-1.4.1-x86_64-windows.zip
62b0495e...  install.sh
3f3193a3...  install.ps1
```

**Repo standard bar** — `mach build .` green in the worktree; `mach test .` 409 passed, 0 failed; all 28 integration suites under `.github/tests/` pass (including the win64 wine suites).
