### PR TITLE
fix(sema): report substitute / type-arg alloc failures in infer_generic_call

### DIFF
--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -786,7 +786,12 @@ fun infer_generic_call(sc: *sema.SemaContext, c: *expr.ExprCall, ct: type.TypeId
     val sym: *resolve.Symbol = unwrap[*resolve.Symbol](sym_opt);
 
     val pr: Result[*type.TypeId, str] = allocate_params(sc, c.type_args_len);
-    if (is_err[*type.TypeId, str](pr)) { ret type.TYPE_ERROR; }
+    if (is_err[*type.TypeId, str](pr)) {
+        # the type-argument scratch buffer failed to allocate; without a report
+        # the call would reach lowering on a clean sema pass (#1348).
+        sema.report(sc, span, "internal: out of memory allocating generic type arguments");
+        ret type.TYPE_ERROR;
+    }
     val args: *type.TypeId = unwrap_ok[*type.TypeId, str](pr);
 
     var i: u32 = 0;
@@ -818,7 +823,14 @@ fun infer_generic_call(sc: *sema.SemaContext, c: *expr.ExprCall, ct: type.TypeId
 
     val sig: type.TypeId = generics.substitute(sc.s, ct, args, c.type_args_len);
     free_params(sc, args, c.type_args_len);
-    if (sig == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    if (sig == type.TYPE_ERROR) {
+        # substitute collapses every failure (an out-of-range generic parameter,
+        # an allocation failure interning a rebuilt type) to the poison type;
+        # arity is pre-checked, so reaching here is an internal failure that must
+        # be reported rather than poisoning the call on a clean sema pass (#1348).
+        sema.report(sc, span, "internal: generic substitution failed");
+        ret type.TYPE_ERROR;
+    }
 
     val sfn_opt: Option[*type.Type] = type.get(?sc.s.types, sig);
     if (is_none[*type.Type](sfn_opt)) { ret type.TYPE_ERROR; }


### PR DESCRIPTION
## Summary

`infer_generic_call` (`src/lang/fe/sema/infer.mach`) returned `type.TYPE_ERROR` silently in two arms, poisoning the call expression on an otherwise-clean sema pass — the #1348 class of silent-poison trap:

- the `generics.substitute` failure arm (the arm called out by the issue), and
- the `allocate_params` (type-argument scratch buffer) allocation-failure arm, found in the same audit and the same trivial shape.

Both now emit a `sema.report` diagnostic before poisoning, matching the neighboring `void-member` arm's idiom, so a substitution or allocation failure can never reach lowering undiagnosed. No new error channel is introduced.

Neither arm is reachable today (arity is pre-checked; the remainder is allocation failure), so there is no live symptom — the change closes the latent trap against any future `substitute` failure mode.

Closes #1361