### PR TITLE
feat(asm): jc/jnc/setc carry-flag inline-asm mnemonics

### DIFF
--- a/.github/tests/asmcarry/app/mach.toml
+++ b/.github/tests/asmcarry/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "asmcarry"
+name = "inline-asm carry-flag mnemonics — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "linux"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.asmcarry]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/asmcarry/app/src/main.mach
+++ b/.github/tests/asmcarry/app/src/main.mach
@@ -1,0 +1,95 @@
+use std.runtime.linux.x86_64;
+
+# inline-asm carry-flag mnemonics (#1359). the x64 inline-asm parser used to
+# dispatch only je/jz/jne/jnz, so jc/jnc/setc died with "unknown x86_64
+# inline-asm instruction" and std had to hand-encode carry handling via `.byte`.
+# this exercises setc (== setb) and the jc/jnc (== jb/jae/jnb) conditional
+# branches end to end: setc materializes the flag, the jumps fall through when
+# the flag says so. each function returns a value that is correct only when the
+# new mnemonics encode and execute as the carry-flag forms.
+
+# setc writes CF into a byte register. SUB borrows (sets CF) when a < b; xor
+# clears rax first so the byte setc writes is the whole returned value.
+fun carry_bit(a: u64, b: u64) u64 {
+    var out: u64 = 0;
+    asm x86_64 {
+        xor rax, rax
+        mov rcx, {a}
+        sub rcx, {b}
+        setc al
+        mov {out}, rax
+    }
+    ret out;
+}
+
+# the setb / setae aliases encode to the same SETcc opcodes as setc / setnc.
+# returns setb*10 + setae: CF=1 -> 10, CF=0 -> 1.
+fun carry_bits_alias(a: u64, b: u64) u64 {
+    var lo: u64 = 0;
+    var hi: u64 = 0;
+    asm x86_64 {
+        xor rax, rax
+        xor rdx, rdx
+        mov rcx, {a}
+        sub rcx, {b}
+        setb al
+        setae dl
+        mov {lo}, rax
+        mov {hi}, rdx
+    }
+    ret lo * 10 + hi;
+}
+
+# jc and its jb alias branch when CF=1. called with a >= b (CF=0) so both fall
+# through to the store; returns 7 only when neither branch is taken.
+fun jc_cf0(a: u64, b: u64) u64 {
+    var out: u64 = 0;
+    asm x86_64 {
+        mov rcx, {a}
+        sub rcx, {b}
+        jc asmcarry_never
+        jb asmcarry_never
+        mov rax, 7
+        mov {out}, rax
+    }
+    ret out;
+}
+
+# jnc and its jae / jnb aliases branch when CF=0. called with a < b (CF=1) so
+# all three fall through; returns 11 only when none is taken.
+fun jnc_cf1(a: u64, b: u64) u64 {
+    var out: u64 = 0;
+    asm x86_64 {
+        mov rcx, {a}
+        sub rcx, {b}
+        jnc asmcarry_never
+        jae asmcarry_never
+        jnb asmcarry_never
+        mov rax, 11
+        mov {out}, rax
+    }
+    ret out;
+}
+
+# unmangled branch target for the jc/jnc relocations. never reached at runtime
+# (every branch above falls through); the call in main keeps the symbol live so
+# the inline-asm PC32 relocations against its literal name resolve.
+$never.symbol = "asmcarry_never";
+fun never() u64 { ret 99; }
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # setc: 1 < 2 borrows (CF=1) -> 1; 5 >= 3 no borrow (CF=0) -> 0.
+    if (carry_bit(1, 2) != 1) { ret 1; }
+    if (carry_bit(5, 3) != 0) { ret 2; }
+    # setb / setae aliases: CF=1 -> 10, CF=0 -> 1.
+    if (carry_bits_alias(1, 2) != 10) { ret 3; }
+    if (carry_bits_alias(5, 3) != 1) { ret 4; }
+    # jc / jb fall through when CF=0 (a >= b).
+    if (jc_cf0(9, 4) != 7) { ret 5; }
+    # jnc / jae / jnb fall through when CF=1 (a < b).
+    if (jnc_cf1(4, 9) != 11) { ret 6; }
+    # keep the branch target symbol live.
+    if (never() != 99) { ret 7; }
+    ret 0;
+}

--- a/.github/tests/asmcarry/run.sh
+++ b/.github/tests/asmcarry/run.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# inline-asm carry-flag mnemonic test (#1359): the x64 inline-asm parser only
+# dispatched je/jz/jne/jnz, so jc/jnc/setc failed with "unknown x86_64 inline-asm
+# instruction" and std had to hand-encode carry handling via `.byte`. this builds
+# a program that uses setc (== setb) to materialize the carry flag and jc/jnc
+# (== jb/jae/jnb) to branch on it, then runs it natively; main exits 0 only when
+# every new mnemonic encodes and executes as its carry-flag form.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL asmcarry: native build failed (jc/jnc/setc not encoded?)" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/asmcarry"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS asmcarry: setc / jc / jnc (and the jb/jae/jnb/setb/setae/setnb aliases) encode and run as the carry-flag forms"
+    exit 0
+fi
+
+echo "FAIL asmcarry: carry-flag inline-asm mnemonic miscompiled (exit $code)" >&2
+exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `mach-<version>-x86_64-windows.zip`, each containing the binary and
   LICENSE — alongside the existing assets, with `SHA256SUMS` covering the
   full set (#1352).
+- x64 inline assembly accepts the carry-flag mnemonics `jc` / `jnc` (and the
+  `jb` / `jae` / `jnb` aliases) and `setc` (and the `setb` / `setae` / `setnb`
+  aliases), reusing the existing conditional-branch and SETcc encoders. Previously
+  only `je` / `jz` / `jne` / `jnz` were recognized, forcing carry-flag handling
+  through `.byte` escape hatches (#1359).
 
 ### Fixed
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -4738,7 +4738,7 @@ fun clobber_two_both(args: str, gp: *u32) {
 }
 
 # clobber_one: mark the sole operand of a one-operand write form (neg / not / inc
-# / dec / pop) as written.
+# / dec / pop / setcc) as written.
 fun clobber_one(args: str, gp: *u32) {
     var op: AsmOperand;
     if (parse_asm_operand(trim_str(args), ?op)) {
@@ -4765,7 +4765,13 @@ fun stmt_clobbers(stmt: str, gp: *u32, fp: *u32) {
     # barrier already covers a call's caller-saved clobbers.
     if (mnemonic_is(stmt, "call") || mnemonic_is(stmt, "jmp")
         || mnemonic_is(stmt, "je") || mnemonic_is(stmt, "jz")
-        || mnemonic_is(stmt, "jne") || mnemonic_is(stmt, "jnz")) { ret; }
+        || mnemonic_is(stmt, "jne") || mnemonic_is(stmt, "jnz")
+        || mnemonic_is(stmt, "jc") || mnemonic_is(stmt, "jb")
+        || mnemonic_is(stmt, "jnc") || mnemonic_is(stmt, "jae") || mnemonic_is(stmt, "jnb")) { ret; }
+
+    # conditional set writes its single byte-register destination.
+    if (mnemonic_is(stmt, "setc") || mnemonic_is(stmt, "setb"))   { clobber_one(arg_str(stmt, 4), gp); ret; }
+    if (mnemonic_is(stmt, "setnc") || mnemonic_is(stmt, "setae") || mnemonic_is(stmt, "setnb")) { clobber_one(arg_str(stmt, 5), gp); ret; }
 
     # cmp / test write only the flags.
     if (mnemonic_is(stmt, "cmp"))  { ret; }
@@ -4833,6 +4839,15 @@ fun encode_asm_stmt(st: *EncodeState, fn_base: u32, tok: str) Result[bool, str] 
     if (mnemonic_is(tok, "jmp"))  { ret emit_branch_sym(st, fn_base, x64.JMP, arg_str(tok, 3)); }
     if (mnemonic_is(tok, "je") || mnemonic_is(tok, "jz"))   { ret emit_branch_sym(st, fn_base, x64.JE, arg_str(tok, 2)); }
     if (mnemonic_is(tok, "jne") || mnemonic_is(tok, "jnz")) { ret emit_branch_sym(st, fn_base, x64.JNE, arg_str(tok, 3)); }
+    # carry-flag conditionals: jc == jb (CF=1), jnc == jae == jnb (CF=0).
+    if (mnemonic_is(tok, "jc") || mnemonic_is(tok, "jb"))   { ret emit_branch_sym(st, fn_base, x64.JB, arg_str(tok, 2)); }
+    if (mnemonic_is(tok, "jnc") || mnemonic_is(tok, "jae") || mnemonic_is(tok, "jnb")) { ret emit_branch_sym(st, fn_base, x64.JAE, arg_str(tok, 3)); }
+
+    # conditional set into a byte register: setc == setb (CF=1), setnc == setae
+    # == setnb (CF=0). routed through the one-operand encoder, which dispatches the
+    # SETcc opcode to `encode_setcc`.
+    if (mnemonic_is(tok, "setc") || mnemonic_is(tok, "setb"))   { ret emit_one_op(st, x64.SETB, arg_str(tok, 4)); }
+    if (mnemonic_is(tok, "setnc") || mnemonic_is(tok, "setae") || mnemonic_is(tok, "setnb")) { ret emit_one_op(st, x64.SETAE, arg_str(tok, 5)); }
 
     # two-operand ALU / move family. the `lock`-prefixed RMW forms come first so
     # the bare mnemonic match below does not shadow them.
@@ -4905,7 +4920,8 @@ fun emit_branch_sym(st: *EncodeState, fn_base: u32, opcode: u16, target: str) Re
 }
 
 # emit_one_op: parse and encode a single-operand instruction (neg / not / inc /
-# dec / push / pop). a `[symbol]` or bare-symbol operand is not valid here.
+# dec / push / pop / setcc). a `[symbol]` or bare-symbol operand is not valid
+# here; a SETcc destination must be a byte register, not memory.
 fun emit_one_op(st: *EncodeState, opcode: u16, args: str) Result[bool, str] {
     var op: AsmOperand;
     if (!parse_asm_operand(trim_str(args), ?op)) {


### PR DESCRIPTION
Wires the carry-flag conditional mnemonics into the x64 inline-asm statement parser, reusing the existing encoders.

## What

- `encode_asm_stmt`: dispatch `jc`/`jnc` (+ `jb`/`jae`/`jnb` aliases) through `emit_branch_sym` with the `JB`/`JAE` opcodes, and `setc` (+ `setb`/`setnc`/`setae`/`setnb` aliases) through `emit_one_op` → `encode_setcc` with `SETB`/`SETAE`. No new encoder logic — the `encode_jcc`/`encode_setcc`/`cc_to_x86` machinery already existed.
- `stmt_clobbers`: the new jumps write no register (control transfer); the new SETcc forms write their single byte-register destination.
- Doc comments on `emit_one_op` / `clobber_one` updated to list setcc.

Previously only `je`/`jz`/`jne`/`jnz` were recognized, so anything else failed with `unknown x86_64 inline-asm instruction`, forcing mach-std to hand-encode carry handling via `.byte` (which also made `stmt_clobbers` conservatively clobber all registers).

## Verification

Disassembled the emitted object (`objdump -dr`) — bytes are exactly the carry-flag forms:

- `setc al` → `0f 92 c0`, `setnc dl` → `0f 93 c2`
- `jc` → `0f 82` rel32, `jnc` → `0f 83` rel32 (PC32 relocs against the target symbol)
- `jb`/`jnb`/`jae`/`setb`/`setae`/`setnb` aliases all emit the identical bytes as their canonical forms

New runtime test `.github/tests/asmcarry` exercises `setc` (materialize CF → 0/1) and `jc`/`jnc` (not-taken fall-through). Full clean rebuild from the release seed plus a stage-2 self-build both pass; `mach test .` (409/409), `asmclobber`, and `asmcarry` all green.

Note: inline-asm conditional branches resolve a literal (unmangled) symbol name; NASM-style numeric local labels (`1f`/`1:`) are still unsupported, so the std darwin `jc 1f` sites need either `setc` or a separate local-label feature — out of scope here.

Closes #1359