### PR TITLE
fix(sema): align no-return-type diagnostics with mach vocabulary (no 'void')

### DIFF
--- a/.github/tests/valuepos/local/src/main.mach
+++ b/.github/tests/valuepos/local/src/main.mach
@@ -13,5 +13,6 @@ fun main() i64 {
     val p: Point = Point;
     val u: Box = Box;
     val x: i64 = MyInt;
-    ret nothing().x + pick[i64](p.x) + u.a + x;
+    val nv: i64 = nothing();
+    ret nothing().x + pick[i64](p.x) + u.a + x + nv;
 }

--- a/.github/tests/valuepos/run.sh
+++ b/.github/tests/valuepos/run.sh
@@ -2,13 +2,15 @@
 # Never-value teaching diagnostics (#1348, the #1343 silent-poison class). A
 # symbol that resolves cleanly but can never carry a value type — a record,
 # union, or def type name (local or imported), a generic type parameter, a
-# module alias — and a member access on a void expression used to pass sema
-# with ZERO diagnostics, surfacing only as link `undefined symbol` or span-less
-# `lower:` errors. Each misuse must now fail the build with a located teaching
-# diagnostic, and every adjacent legitimate construct must keep building.
+# module alias — a member access on a value-less call, and a binding initialized
+# from a value-less call used to pass sema with ZERO diagnostics, surfacing only
+# as link `undefined symbol` or span-less `lower:` errors. Each misuse must now
+# fail the build with a located teaching diagnostic, and every adjacent
+# legitimate construct must keep building.
 #
-#   local    — local rec/uni/def names, a generic parameter, and a void-object
-#              member access, all in value position in one module.
+#   local    — local rec/uni/def names, a generic parameter, a member access on
+#              a value-less call, and a value-less-call binding, all in value
+#              position in one module.
 #   imported — a module alias, an imported record, and an imported def alias in
 #              value position, reached through `use plib.lib`.
 #   ok       — the positives: record literal, function reference, `$size_of(T)`,
@@ -80,7 +82,8 @@ if out="$(build_expect_fail local)"; then
     expect_located local "is a union type, not a value" "$out"
     expect_located local "is a type alias, not a value" "$out"
     expect_located local "is a generic type parameter, not a value" "$out"
-    expect_located local "a void expression has no members" "$out"
+    expect_located local "a call that returns nothing has no members" "$out"
+    expect_located local "found no value" "$out"
 else
     fail=1
 fi

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -946,6 +946,18 @@ fun report_note(sc: *sema.SemaContext, span: token.Span, message: str, note: str
 # allocation failure degrades to the static, type-free message so a mismatch is
 # always reported.
 fun report_mismatch(sc: *sema.SemaContext, span: token.Span, expected: ty.TypeId, actual: ty.TypeId, note: str) {
+    # a value-less actual (a call to a function with no return type) carries
+    # TYPE_NIL, which has no spelling: rendering it would print the misleading
+    # `<error>` placeholder, and the widening note does not apply. name the
+    # missing value instead.
+    if (actual == ty.TYPE_NIL) {
+        report_typed_note(sc, span, "type mismatch: expected ", expected,
+            ", found no value",
+            "type mismatch: a value is required, but the expression produces none",
+            "a call to a function with no return type produces no value");
+        ret;
+    }
+
     val ex_r: Result[str, str] = type_to_str(sc, expected);
     val ac_r: Result[str, str] = type_to_str(sc, actual);
     if (is_err[str, str](ex_r) || is_err[str, str](ac_r)) {
@@ -1110,6 +1122,43 @@ pub fun report_typed(sc: *sema.SemaContext, span: token.Span, prefix: str, t: ty
     msg[w] = 0;
 
     report(sc, span, msg);
+    deallocate[char](sc.s.alloc, msg, total + 1);
+    type_str_free(sc, ts);
+}
+
+# report_typed_note: report_typed plus a static clarifying `note:` line. on any
+# allocation failure it degrades to the static `fallback` message, still carrying
+# the note so the explanation is never lost.
+# ---
+# sc:       the active sema context
+# span:     source range to pin the diagnostic to
+# prefix:   text before the rendered type
+# t:        the type to render into the message
+# suffix:   text after the rendered type
+# fallback: type-free message used when rendering or allocation fails
+# note:     clarifying note attached to whichever message lands
+fun report_typed_note(sc: *sema.SemaContext, span: token.Span, prefix: str, t: ty.TypeId, suffix: str, fallback: str, note: str) {
+    val tr: Result[str, str] = type_to_str(sc, t);
+    if (is_err[str, str](tr)) {
+        report_note(sc, span, fallback, note);
+        ret;
+    }
+    val ts: str = unwrap_ok[str, str](tr);
+
+    val total: usize = str_len(prefix) + str_len(ts) + str_len(suffix);
+    val r: Result[*char, str] = allocate[char](sc.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        report_note(sc, span, fallback, note);
+        type_str_free(sc, ts);
+        ret;
+    }
+    val msg: str = unwrap_ok[*char, str](r);
+    var w: usize = write_kw(msg, 0, prefix);
+    w = write_kw(msg, w, ts);
+    w = write_kw(msg, w, suffix);
+    msg[w] = 0;
+
+    report_note(sc, span, msg, note);
     deallocate[char](sc.s.alloc, msg, total + 1);
     type_str_free(sc, ts);
 }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -880,10 +880,10 @@ fun infer_member(sc: *sema.SemaContext, eid: id.ExprId, m: *expr.ExprMember, spa
     val ot: type.TypeId = infer_expr(sc, m.object);
     if (ot == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
     if (ot == type.TYPE_NIL) {
-        # a void object (a call to a function with no return type) yields no
-        # value; without a report the broken access would reach lowering with
+        # a value-less object (a call to a function with no return type) yields
+        # no value; without a report the broken access would reach lowering with
         # a clean sema pass (#1348).
-        sema.report(sc, span, "a void expression has no members; a member access requires a record or union value");
+        sema.report(sc, span, "a call that returns nothing has no members; a member access requires a record or union value");
         ret type.TYPE_ERROR;
     }
 


### PR DESCRIPTION
A call to a function with no return type produces no value (semantic `TYPE_NIL`). Two diagnostics rendered it misleadingly:

1. A type mismatch against such a call printed `found <error>` — the `TYPE_NIL` spelling, which falsely implies an upstream error. `report_mismatch` now special-cases a value-less `actual` and reports `found no value` with a clarifying note, rendered where `TYPE_NIL` would otherwise format.
2. The member-access diagnostic from PR #1357 said `a void expression has no members`. mach has no void type and no `void` keyword, so it now reads `a call that returns nothing has no members; ...`.

Audited every diagnostic string in `src/` for `void`: only the member-access message above used it; the remaining `void` occurrences are internal IR-level naming (`IRT_VOID`, comments), not user-facing diagnostics.

Before:
```
type mismatch: expected i64, found <error>
  note: mach has no implicit widening; cast the value with `value::Type`
```
After:
```
type mismatch: expected i64, found no value
  note: a call to a function with no return type produces no value
```

Verified with a full clean rebuild (`mach build .`), reproducing the diagnostics before/after on throwaway sources, the full in-source suite (409 passed), and the `valuepos` corpus test (extended to cover both reworded diagnostics).

Closes #1360