### PR TITLE
ci: bump GitHub Actions to Node 24-ready versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Full Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -35,7 +35,7 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -53,7 +53,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -88,7 +88,7 @@ jobs:
               install.sh install.ps1 > SHA256SUMS )
 
       - name: Upload release artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/mach

--- a/.github/workflows/scrub-attribution.yml
+++ b/.github/workflows/scrub-attribution.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Strip generated-with footers from the body
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const isPR = !!context.payload.pull_request;


### PR DESCRIPTION
Mechanical version bumps per #1368, ahead of GitHub's forced Node 24 default on 2026-06-16.

Closes #1368