### PR TITLE
fix(cli): reject an invalid project id before scaffolding

### DIFF
--- a/.github/tests/init/run.sh
+++ b/.github/tests/init/run.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# `mach init` id-validation integration test (#1355). the project id (the
+# positional name, or `--name`) must be a valid id BEFORE any scaffolding: an id
+# the manifest grammar would reject (`.`, path separators, spaces) is refused and
+# nothing is written. a valid id scaffolds a grammatical `[bin.<id>]` manifest.
+#
+# the refusal cases run fully offline — validation fails before any filesystem
+# write or dependency clone. the valid case asserts on the written manifest
+# (which precedes the network `dep` sync), so it does not depend on connectivity.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+ok()  { echo "PASS init: $1"; }
+bad() { echo "FAIL init: $1" >&2; fail=1; }
+
+# refuse <desc> <name...> — `mach init <name>` in a fresh empty dir must exit
+# nonzero, name the bad id, and leave the directory untouched (no mach.toml, no
+# src/, and no derived target directory).
+refuse() {
+    local desc="$1"; shift
+    local d; d="$(mktemp -d "$WORK/case.XXXXXX")"
+    local out
+    set +e
+    out="$( cd "$d" && "$MACH" init "$@" 2>&1 )"; local code=$?
+    set -e
+    if [ "$code" -eq 0 ]; then
+        bad "$desc: init exited 0 (expected refusal)"; printf '%s\n' "$out" >&2; return
+    fi
+    if ! printf '%s\n' "$out" | grep -qF -- "is not a valid project id"; then
+        bad "$desc: error did not name an invalid id"; printf '%s\n' "$out" >&2; return
+    fi
+    # nothing written: the case dir must be empty (no mach.toml, src, or subdir).
+    if [ -n "$(ls -A "$d")" ]; then
+        bad "$desc: refused init left files behind: $(ls -A "$d" | tr '\n' ' ')"; return
+    fi
+    ok "$desc"
+}
+
+refuse "'.' is refused, nothing written"          .
+refuse "'..' is refused, nothing written"         ..
+refuse "a path-separator name is refused"         foo/bar
+refuse "a dotted name is refused"                 foo.bar
+refuse "a name with spaces is refused"            "a b"
+refuse "an invalid --name is refused"             proj --name "bad id"
+
+# valid case: a bare-key id scaffolds a grammatical manifest. assert on the
+# written files (which precede the network dep sync) so the case is offline-safe.
+VALID="$WORK/valid"; mkdir -p "$VALID"
+set +e
+( cd "$VALID" && "$MACH" init valid_name >/dev/null 2>&1 )
+set -e
+TOML="$VALID/valid_name/mach.toml"
+if [ ! -f "$TOML" ]; then
+    bad "a valid id writes mach.toml"
+else
+    grep -qF 'id = "valid_name"' "$TOML" && ok "the manifest carries the id verbatim" \
+        || bad "the manifest id is wrong"
+    grep -qF '[bin.valid_name]' "$TOML" && ok "the artifact table names the id" \
+        || bad "the artifact table is missing or misnamed"
+    grep -qF '[bin..]' "$TOML" && bad "the manifest contains an empty bin key" \
+        || ok "the manifest has no empty bin key"
+fi
+[ -f "$VALID/valid_name/src/main.mach" ] && ok "the starter source is written" \
+    || bad "src/main.mach is missing"
+
+exit "$fail"

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -7,8 +7,11 @@
 # `src/lib.mach`). for binary projects, the generated main is a standard-library
 # hello world. the command also syncs `mach-std` into `dep/mach-std` so a fresh
 # scaffold builds immediately. refuses to overwrite an existing mach.toml,
-# src/main.mach, or src/lib.mach unless `--force` is given. the project id
-# defaults to the directory name and is overridable with `--name <name>`.
+# src/main.mach, or src/lib.mach unless `--force` is given. the project id is the
+# positional name (or the current directory's base name for a bare `mach init`),
+# overridable with `--name <name>`. a name that is not a valid project id (`.`,
+# path separators, anything the manifest grammar would reject) is refused before
+# any filesystem write — invalid input is rejected, not repaired.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -25,8 +28,9 @@ use os:    std.system.os;
 use fs:    std.filesystem;
 use print: std.print;
 
-use util: mach.cli.util;
-use dep:  mach.cli.cmd.dep;
+use util:     mach.cli.util;
+use dep:      mach.cli.cmd.dep;
+use manifest: mach.lang.manifest;
 
 val MACH_STD_URL: *u8 = "https://github.com/octalide/mach-std";
 val MACH_STD_REF: *u8 = "branch/main";
@@ -89,23 +93,38 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret 2;
     }
 
-    # positional directory: the first bare argv after `init`, skipping each
-    # value flag together with its value so `mach init --name myproj` takes the
-    # current directory (id `myproj`) rather than eating `myproj` as the dir.
+    # positional name: the first bare argv after `init`, skipping each value flag
+    # together with its value so `mach init --name myproj` keeps `myproj` as the
+    # id rather than eating it as the positional. it names both the target
+    # directory and the project id.
     var dir: *u8 = ?cwd_buf[0];
     val pix: usize = util.positional_index(argc, argv, 2);
     if (pix < argc) { dir = argv[pix]; }
 
-    # project id: --name, else the directory base name.
-    var id: *u8 = base_name(dir);
+    # project id: --name, else the positional name verbatim, else the current
+    # directory's base name for a bare `mach init`. the positional is taken as-is
+    # — no basename derivation, so a path or `.` is refused below, not repaired.
+    var id: *u8 = base_name(?cwd_buf[0]);
+    if (pix < argc) { id = argv[pix]; }
     val name_opt: Option[*u8] = util.get_value(argc, argv, "--name");
     if (is_some[*u8](name_opt)) { id = unwrap[*u8](name_opt); }
 
+    # validate the id before any filesystem write: an id the manifest grammar
+    # would reject (`.`, path separators, ...) is refused, leaving nothing behind.
+    if (!manifest.valid_id(id::str)) {
+        print.eprint("error: '");
+        print.eprint(id::str);
+        print.eprint("' is not a valid project id\n");
+        print.eprint("       a project id may contain only letters, digits, '_', or '-' (no '.', '/', or spaces)\n");
+        print.eprint("       pass a valid name as the argument or with --name <name>\n");
+        ret 1;
+    }
+
     # preflight every collision check before any filesystem write, so a refused
     # init (a populated path without --force) leaves nothing behind.
-    var manifest: [4096]u8;
-    util.join_into(?manifest[0], 4096, dir, "mach.toml");
-    if (fs.exists(?manifest[0]) && !force) {
+    var manifest_path: [4096]u8;
+    util.join_into(?manifest_path[0], 4096, dir, "mach.toml");
+    if (fs.exists(?manifest_path[0]) && !force) {
         print.eprint("error: mach.toml already exists (use --force to overwrite)\n");
         ret 1;
     }
@@ -146,7 +165,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
         }
     }
 
-    if (!write_manifest(?manifest[0], id, is_lib)) {
+    if (!write_manifest(?manifest_path[0], id, is_lib)) {
         print.eprint("error: failed to write mach.toml\n");
         ret 2;
     }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -323,6 +323,28 @@ pub fun host_tuple(alloc: *Allocator) str {
     ret cc3(alloc, host_isa_name(), "-", host_os_name());
 }
 
+# valid_id: whether `s` is acceptable as a `[project].id`. a project id heads
+# every module FQN (`use <id>...`) and names the `[bin.<id>]`/`[lib.<id>]`
+# artifact table, so it must be a non-empty run of TOML bare-key characters —
+# ASCII letters, digits, `_`, or `-`. anything the grammar would reject as a
+# bare key (`.`, path separators, spaces, empty) would make the generated
+# manifest ungrammatical and is refused here. the single authoritative notion of
+# a valid id; `mach init` reuses it to reject bad input before scaffolding.
+pub fun valid_id(s: str) bool {
+    if (str_empty(s)) { ret false; }
+    val n: usize = str_len(s);
+    var i: usize = 0;
+    for (i < n) {
+        val c: u8 = s[i];
+        if (!((c >= 'A' && c <= 'Z')
+           || (c >= 'a' && c <= 'z')
+           || (c >= '0' && c <= '9')
+           || c == '_' || c == '-')) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
 # has_backslash: true when a path/template contains a literal `\`. manifest
 # paths are `/`-separated; a `\` is rejected so the same manifest is portable.
 fun has_backslash(s: str) bool {
@@ -1786,6 +1808,23 @@ fun mk_sel(target: str, profile: str, artifact: str, want_lib: bool, has_artifac
 # DEMO: a representative two-bin, two-target, two-profile manifest.
 fun demo_src() str {
     ret "[project]\nid = \"demo\"\nversion = \"0.1.0\"\nsrc = \"src\"\ndep = \"dep\"\ntarget = \"native\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\next = \".exe\"\n\n[bin.ls]\nentry = \"bin/ls.mach\"\n\n[bin.cat]\nentry = \"bin/cat.mach\"\n\n[profile.debug]\nopt = 0\n\n[profile.release]\nopt = 2\nemit_ir = true\n\n[deps.mach-std]\ngit = \"https://github.com/octalide/mach-std\"\nref = \"v0.4.0\"\n";
+}
+
+test "manifest: valid_id accepts bare-key ids and rejects the rest" {
+    var code: i32 = 0;
+    if (!valid_id("foo"))    { code = 1; }
+    if (!valid_id("my_app")) { code = 1; }
+    if (!valid_id("my-app")) { code = 1; }
+    if (!valid_id("Proj2"))  { code = 1; }
+    if (!valid_id("9"))      { code = 1; }
+    if (valid_id(""))        { code = 1; }
+    if (valid_id("."))       { code = 1; }
+    if (valid_id(".."))      { code = 1; }
+    if (valid_id("foo/bar")) { code = 1; }
+    if (valid_id("foo.bar")) { code = 1; }
+    if (valid_id("a b"))     { code = 1; }
+    if (valid_id("name!"))   { code = 1; }
+    ret code;
 }
 
 test "manifest: a full manifest parses every stanza" {


### PR DESCRIPTION
Closes #1355

`mach init .` (and any path-bearing or otherwise ungrammatical name) silently scaffolded `id = "."` and `[bin..]` — a manifest the parser immediately rejects (`expected key`). Per the maintainer ruling, the name argument is now validated **before** any filesystem write: an id the manifest grammar would reject is refused, not repaired.

## What changed

- **`src/lang/manifest.mach`** — new `pub fun valid_id(s: str) bool`, the single authoritative notion of a valid project id: a non-empty run of TOML bare-key characters (`[A-Za-z0-9_-]`), exactly what may appear unquoted as the `[bin.<id>]`/`[lib.<id>]` artifact header and head a module FQN. Unit-tested.
- **`src/cli/cmd/init.mach`** — reuses `manifest.valid_id`. The positional name is now taken **verbatim** (no basename derivation), so `mach init foo/bar` is refused rather than silently scaffolding id `bar`. An invalid id prints a clear, actionable error and exits 1, leaving the filesystem untouched.
- **`.github/tests/init/run.sh`** — integration suite covering the refusal cases (offline) and the valid-scaffold manifest shape.

## Audit

`init` is the only command that scaffolds a project id; there is no `mach new`. No sibling shares the scaffold path.

## Verification

- Full clean rebuild green; `mach test .` → 410 passed, 0 failed (incl. the new `valid_id` test).
- Manual: `mach init .`, `mach init ..`, `mach init foo/bar`, `mach init "a b"` all error with nothing written; `mach init valid_name` scaffolds `[bin.valid_name]` and builds; `mach init my-proj` (hyphen) and `--name custom_id` still work.