### PR TITLE
feat(x64): numeric local labels in inline asm

### DIFF
--- a/.github/tests/asmlocal/app/mach.toml
+++ b/.github/tests/asmlocal/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "asmlocal"
+name = "inline-asm numeric local labels — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "linux"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.asmlocal]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/asmlocal/app/src/main.mach
+++ b/.github/tests/asmlocal/app/src/main.mach
@@ -1,0 +1,92 @@
+use std.runtime.linux.x86_64;
+
+# inline-asm numeric local labels (#1365). the x64 inline-asm grammar had no
+# NASM-style numeric locals: a `<digits>:` label definition and `<digits>f` /
+# `<digits>b` references could not be parsed, so a block-local forward / backward
+# branch (the `jc 1f` / `1:` shape dep/mach-std's darwin syscall wrappers use)
+# was impossible — branch targets had to be relocatable symbols. each function
+# below resolves only when local labels encode to the right block-local rel32.
+
+# backward branch: `1:` marks the loop top and `jnz 1b` loops back to the nearest
+# preceding definition while the counter is nonzero. sums n + (n-1) + ... + 1.
+fun sum_to(n: u64) u64 {
+    var out: u64 = 0;
+    asm x86_64 {
+        mov rcx, {n}
+        xor rax, rax
+    1:
+        add rax, rcx
+        dec rcx
+        jnz 1b
+        mov {out}, rax
+    }
+    ret out;
+}
+
+# forward branches: `jc 1f` jumps over the CF=0 arm to `1:`, and `jmp 2f` skips
+# the CF=1 arm to `2:` — the exact two-label shape the darwin `pipe` wrapper uses.
+# CF=1 (a < b) -> 9; CF=0 (a >= b) -> 7.
+fun fwd(a: u64, b: u64) u64 {
+    var out: u64 = 0;
+    asm x86_64 {
+        mov rcx, {a}
+        sub rcx, {b}
+        jc 1f
+        mov rax, 7
+        jmp 2f
+    1:
+        mov rax, 9
+    2:
+        mov {out}, rax
+    }
+    ret out;
+}
+
+# forward redefinition: label `1` is defined twice. the first `jmp 1f` must bind
+# to the FIRST `1:` (nearest following) and the second `jmp 1f` to the SECOND
+# `1:`; a wrong binding would run a skipped `add` and change the sum. returns 11.
+fun redef_fwd() u64 {
+    var out: u64 = 0;
+    asm x86_64 {
+        xor rax, rax
+        jmp 1f
+        add rax, 100
+    1:
+        add rax, 1
+        jmp 1f
+        add rax, 200
+    1:
+        add rax, 10
+        mov {out}, rax
+    }
+    ret out;
+}
+
+# backward redefinition: after the second `1:`, `jnz 1b` must bind to the SECOND
+# (nearest preceding) `1:`, looping over only the second segment. the first
+# segment runs once (+1000); the second loops three times (+1 each). returns 1003.
+fun redef_back() u64 {
+    var out: u64 = 0;
+    asm x86_64 {
+        xor rax, rax
+    1:
+        add rax, 1000
+        mov rcx, 3
+    1:
+        add rax, 1
+        dec rcx
+        jnz 1b
+        mov {out}, rax
+    }
+    ret out;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    if (sum_to(5) != 15) { ret 1; }
+    if (fwd(3, 9) != 9) { ret 2; }
+    if (fwd(9, 3) != 7) { ret 3; }
+    if (redef_fwd() != 11) { ret 4; }
+    if (redef_back() != 1003) { ret 5; }
+    ret 0;
+}

--- a/.github/tests/asmlocal/bad/mach.toml
+++ b/.github/tests/asmlocal/bad/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "asmlocalbad"
+name = "inline-asm numeric local labels — undefined reference"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "linux"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.asmlocalbad]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/asmlocal/bad/src/main.mach
+++ b/.github/tests/asmlocal/bad/src/main.mach
@@ -1,0 +1,21 @@
+use std.runtime.linux.x86_64;
+
+# negative case for #1365: a forward reference to a numeric local label with no
+# matching definition in the block must be a hard compile error, never a silent
+# zero-displacement branch. `jc 1f` references label `1` but no `1:` is ever
+# defined, so the encoder must reject the build with a located message.
+fun undefined_ref() u64 {
+    var out: u64 = 0;
+    asm x86_64 {
+        mov rcx, {out}
+        sub rcx, rcx
+        jc 1f
+        mov {out}, rax
+    }
+    ret out;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret undefined_ref()::i64;
+}

--- a/.github/tests/asmlocal/run.sh
+++ b/.github/tests/asmlocal/run.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# inline-asm numeric local label test (#1365): the x64 inline-asm grammar had no
+# NASM-style numeric locals, so a block-local forward / backward branch (the
+# `jc 1f` / `1:` shape dep/mach-std's darwin syscall wrappers use) could not be
+# written — branch targets had to be relocatable symbols. this builds a program
+# exercising a backward loop (`jnz 1b`), forward branches (`jc 1f` / `jmp 2f`),
+# and redefinition of the same number in both directions, runs it natively (main
+# exits 0 only when every label resolves and executes correctly), then proves an
+# undefined forward reference is a hard compile error with a located message.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+cp -r "$HERE/bad" "$WORK/"
+mkdir -p "$WORK/app/dep" "$WORK/bad/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+ln -s "$STD" "$WORK/bad/dep/mach-std"
+
+# positive cases: backward loop, forward branches, and redefinition.
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL asmlocal: native build failed (numeric local labels not encoded?)" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/asmlocal"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"
+code=$?
+set -e
+
+if [ "$code" -ne 0 ]; then
+    echo "FAIL asmlocal: numeric-local-label program miscompiled (exit $code)" >&2
+    exit 1
+fi
+echo "PASS asmlocal: backward (1b) loop, forward (1f / 2f) branches, and redefinition resolve and run"
+
+# negative case: an undefined forward reference is a hard, located compile error.
+set +e
+ERR="$( cd "$WORK/bad" && "$MACH" build . 2>&1 )"
+bcode=$?
+set -e
+
+if [ "$bcode" -eq 0 ]; then
+    echo "FAIL asmlocal: build of an undefined local-label reference unexpectedly succeeded" >&2
+    exit 1
+fi
+if ! printf '%s' "$ERR" | grep -q "local label"; then
+    echo "FAIL asmlocal: undefined local-label error lacked a located message:" >&2
+    printf '%s\n' "$ERR" >&2
+    exit 1
+fi
+echo "PASS asmlocal: an undefined forward reference is a located compile error"
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   aliases), reusing the existing conditional-branch and SETcc encoders. Previously
   only `je` / `jz` / `jne` / `jnz` were recognized, forcing carry-flag handling
   through `.byte` escape hatches (#1359).
+- x64 inline assembly accepts NASM-style numeric local labels: a `<digits>:`
+  statement defines a block-local label and `<digits>f` / `<digits>b` branch
+  targets resolve to a rel32 within the function (no relocation). Every branch
+  mnemonic takes a symbol or a local-label target; a backward reference binds to
+  the nearest preceding definition and a forward reference to the nearest
+  following one, redefinition of a number is allowed, and an unresolved or
+  malformed reference is a hard compile error. This unblocks block-local forward
+  branches such as the `jc 1f` / `1:` shape in std's darwin syscall wrappers
+  (#1365).
 
 ### Fixed
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -3234,8 +3234,8 @@ fun emit_cvt_reg(cvt_op: u16, dst_reg: i32, src_reg: i32, int_w: u8, buf: *ByteB
 }
 
 # patch_rel32: overwrite the 4-byte little-endian rel32 placeholder at `pos` with
-# `disp`. fills an intra-instruction forward jump once its target offset is known —
-# the self-contained sequences that branch within a single MIR instruction.
+# `disp`. shared by every rel32 resolver: intra-instruction forward jumps, the CFG
+# branch fixups (`patch_branches`), and inline-asm numeric-local-label references.
 fun patch_rel32(buf: *ByteBuf, pos: usize, disp: i32) {
     buf.data[pos]     = (disp & 0xFF)::u8;
     buf.data[pos + 1] = ((disp >> 8) & 0xFF)::u8;
@@ -4184,6 +4184,249 @@ val ASMOP_MEM:  u8 = 3;
 # a bare symbol / branch-target name (resolved to a relocation).
 val ASMOP_SYM:  u8 = 4;
 
+# a numeric local label's most recent definition within an asm block: the label
+# `number` and the `.text` offset its `N:` definition marks. a redefinition of the
+# same number updates `offset`, so a backward `Nb` reference always binds to the
+# nearest preceding definition.
+# ---
+# number: the numeric label
+# offset: byte offset of the definition within `.text`
+rec AsmLabelDef {
+    number: u64;
+    offset: u32;
+}
+
+# a pending forward reference to a numeric local label: the branch's rel32 field is
+# at `patch_pos`, the byte after the branch is `next_ip`, and the target is the
+# nearest following definition of `number`. resolved when that definition is
+# reached; an entry still pending at the end of the block is an undefined-label
+# error.
+# ---
+# patch_pos: byte offset of the rel32 field within `.text`
+# next_ip:   byte offset of the instruction after the branch within `.text`
+# number:    the referenced numeric label
+rec AsmLabelFixup {
+    patch_pos: u32;
+    next_ip:   u32;
+    number:    u64;
+}
+
+# per-asm-block numeric-local-label scope. `defs` tracks the nearest preceding
+# definition of each number for backward references; `fixups` holds forward
+# references awaiting their definition. both arrays are owned and freed when the
+# block finishes encoding.
+# ---
+# alloc:       backing allocator
+# defs:        recorded label definitions (latest offset per number)
+# def_count:   number of definitions
+# def_cap:     capacity of `defs`
+# fixups:      pending forward references
+# fixup_count: number of pending forward references
+# fixup_cap:   capacity of `fixups`
+rec AsmLabelState {
+    alloc:       *Allocator;
+    defs:        *AsmLabelDef;
+    def_count:   u32;
+    def_cap:     u32;
+    fixups:      *AsmLabelFixup;
+    fixup_count: u32;
+    fixup_cap:   u32;
+}
+
+# asm_labels_init: initialize an empty numeric-local-label scope backed by `alloc`.
+fun asm_labels_init(labels: *AsmLabelState, alloc: *Allocator) {
+    labels.alloc       = alloc;
+    labels.defs        = nil;
+    labels.def_count   = 0;
+    labels.def_cap     = 0;
+    labels.fixups      = nil;
+    labels.fixup_count = 0;
+    labels.fixup_cap   = 0;
+}
+
+# asm_labels_dnit: release a label scope's owned arrays.
+fun asm_labels_dnit(labels: *AsmLabelState) {
+    if (labels.defs != nil && labels.def_cap > 0) {
+        deallocate[AsmLabelDef](labels.alloc, labels.defs, labels.def_cap::usize);
+        labels.defs      = nil;
+        labels.def_cap   = 0;
+        labels.def_count = 0;
+    }
+    if (labels.fixups != nil && labels.fixup_cap > 0) {
+        deallocate[AsmLabelFixup](labels.alloc, labels.fixups, labels.fixup_cap::usize);
+        labels.fixups      = nil;
+        labels.fixup_cap   = 0;
+        labels.fixup_count = 0;
+    }
+}
+
+# is_asm_digit: true for an ASCII decimal digit.
+fun is_asm_digit(c: char) bool { ret c >= '0'::char && c <= '9'::char; }
+
+# asm_label_def_len: if `tok` begins with a numeric local-label definition
+# `<digits>:`, return the byte length of that prefix (through the colon) and the
+# parsed number via `num_out`; otherwise return 0.
+fun asm_label_def_len(tok: str, num_out: *u64) usize {
+    if (!is_asm_digit(tok[0])) { ret 0; }
+    var i: usize = 0;
+    var n: u64 = 0;
+    for (is_asm_digit(tok[i])) {
+        n = n * 10 + (tok[i]::u64 - '0'::u64);
+        i = i + 1;
+    }
+    if (tok[i] != ':'::char) { ret 0; }
+    @num_out = n;
+    ret i + 1;
+}
+
+# asm_label_ref: parse a numeric local-label reference token `<digits>f` /
+# `<digits>b` into its number and direction. returns false when `tok` is not that
+# shape (leading digit, all-digit body, trailing 'f' or 'b').
+fun asm_label_ref(tok: str, num_out: *u64, fwd_out: *bool) bool {
+    val len: usize = str_len(tok);
+    if (len < 2) { ret false; }
+    if (!is_asm_digit(tok[0])) { ret false; }
+    var n: u64 = 0;
+    var i: usize = 0;
+    for (i < len - 1) {
+        if (!is_asm_digit(tok[i])) { ret false; }
+        n = n * 10 + (tok[i]::u64 - '0'::u64);
+        i = i + 1;
+    }
+    val suf: char = tok[len - 1];
+    if (suf == 'f'::char) { @fwd_out = true; }
+    or (suf == 'b'::char) { @fwd_out = false; }
+    or { ret false; }
+    @num_out = n;
+    ret true;
+}
+
+# asm_label_record_def: record a definition of `number` at `.text` offset `off`,
+# patching every pending forward reference to it (this is their nearest following
+# definition) and updating the nearest-preceding-definition offset backward
+# references resolve against. a redefinition of the same number is allowed.
+fun asm_label_record_def(labels: *AsmLabelState, buf: *ByteBuf, number: u64, off: u32) Result[bool, str] {
+    # patch and drop every pending forward fixup for this number.
+    var w: u32 = 0;
+    var r: u32 = 0;
+    for (r < labels.fixup_count) {
+        if (labels.fixups[r].number == number) {
+            val disp: i32 = off::i32 - labels.fixups[r].next_ip::i32;
+            patch_rel32(buf, labels.fixups[r].patch_pos::usize, disp);
+        } or {
+            labels.fixups[w].patch_pos = labels.fixups[r].patch_pos;
+            labels.fixups[w].next_ip   = labels.fixups[r].next_ip;
+            labels.fixups[w].number    = labels.fixups[r].number;
+            w = w + 1;
+        }
+        r = r + 1;
+    }
+    labels.fixup_count = w;
+
+    # update (or insert) the nearest-preceding-definition offset.
+    var i: u32 = 0;
+    for (i < labels.def_count) {
+        if (labels.defs[i].number == number) {
+            labels.defs[i].offset = off;
+            ret ok[bool, str](true);
+        }
+        i = i + 1;
+    }
+    if (labels.def_count >= labels.def_cap) {
+        val gr: Result[bool, str] = grow_asm_label_defs(labels);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    labels.defs[labels.def_count].number = number;
+    labels.defs[labels.def_count].offset = off;
+    labels.def_count = labels.def_count + 1;
+    ret ok[bool, str](true);
+}
+
+# asm_label_lookup_def: the nearest preceding definition offset of `number`, or
+# none when the number has not yet been defined in this block.
+fun asm_label_lookup_def(labels: *AsmLabelState, number: u64) Option[u32] {
+    var i: u32 = 0;
+    for (i < labels.def_count) {
+        if (labels.defs[i].number == number) { ret some[u32](labels.defs[i].offset); }
+        i = i + 1;
+    }
+    ret none[u32]();
+}
+
+# asm_label_push_fixup: record a pending forward reference to `number` whose rel32
+# field is at `patch_pos` (the byte after the branch is `next_ip`).
+fun asm_label_push_fixup(labels: *AsmLabelState, patch_pos: u32, next_ip: u32, number: u64) Result[bool, str] {
+    if (labels.fixup_count >= labels.fixup_cap) {
+        val gr: Result[bool, str] = grow_asm_label_fixups(labels);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    labels.fixups[labels.fixup_count].patch_pos = patch_pos;
+    labels.fixups[labels.fixup_count].next_ip   = next_ip;
+    labels.fixups[labels.fixup_count].number    = number;
+    labels.fixup_count = labels.fixup_count + 1;
+    ret ok[bool, str](true);
+}
+
+# grow the label-definition array (or allocate it on first use).
+fun grow_asm_label_defs(labels: *AsmLabelState) Result[bool, str] {
+    if (labels.defs == nil) {
+        val r: Result[*AsmLabelDef, str] = allocate[AsmLabelDef](labels.alloc, DRIVER_INIT_CAP::usize);
+        if (is_err[*AsmLabelDef, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelDef, str](r)); }
+        labels.defs    = unwrap_ok[*AsmLabelDef, str](r);
+        labels.def_cap = DRIVER_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = labels.def_cap * 2;
+    val r: Result[*AsmLabelDef, str] = reallocate[AsmLabelDef](labels.alloc, labels.defs, labels.def_cap::usize, nc::usize);
+    if (is_err[*AsmLabelDef, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelDef, str](r)); }
+    labels.defs    = unwrap_ok[*AsmLabelDef, str](r);
+    labels.def_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# grow the label-fixup array (or allocate it on first use).
+fun grow_asm_label_fixups(labels: *AsmLabelState) Result[bool, str] {
+    if (labels.fixups == nil) {
+        val r: Result[*AsmLabelFixup, str] = allocate[AsmLabelFixup](labels.alloc, DRIVER_INIT_CAP::usize);
+        if (is_err[*AsmLabelFixup, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelFixup, str](r)); }
+        labels.fixups    = unwrap_ok[*AsmLabelFixup, str](r);
+        labels.fixup_cap = DRIVER_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = labels.fixup_cap * 2;
+    val r: Result[*AsmLabelFixup, str] = reallocate[AsmLabelFixup](labels.alloc, labels.fixups, labels.fixup_cap::usize, nc::usize);
+    if (is_err[*AsmLabelFixup, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelFixup, str](r)); }
+    labels.fixups    = unwrap_ok[*AsmLabelFixup, str](r);
+    labels.fixup_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# u64_to_dec: write the decimal digits of `n` into `dst` (at least one digit) and
+# return the digit count; `dst` must hold at least 20 bytes.
+fun u64_to_dec(n: u64, dst: *u8) usize {
+    if (n == 0) { dst[0] = '0'::u8; ret 1; }
+    var tmp: [20]u8;
+    var len: usize = 0;
+    var v: u64 = n;
+    for (v > 0) {
+        tmp[len] = (v % 10)::u8 + '0'::u8;
+        v = v / 10;
+        len = len + 1;
+    }
+    var k: usize = 0;
+    for (k < len) { dst[k] = tmp[len - 1 - k]; k = k + 1; }
+    ret len;
+}
+
+# asm_label_error: build an interned encode error naming the numeric local label
+# `number`, e.g. "<prefix>1<suffix>"; falls back to `fallback` when interning fails.
+fun asm_label_error(st: *EncodeState, prefix: str, number: u64, suffix: str, fallback: str) str {
+    var buf: [24]u8;
+    val len: usize = u64_to_dec(number, ?buf[0]);
+    buf[len] = 0;
+    ret enc_named_message(st, prefix, (?buf[0])::str, suffix, fallback);
+}
+
 # encode_asm_block: expand an inline-asm MIR_ASM instruction into machine bytes.
 #
 # resolves the body's `{name}` references to `[rbp+off]` text using the carried
@@ -4208,9 +4451,29 @@ fun encode_asm_block(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     if (is_err[str, str](sr)) { ret err[bool, str](unwrap_err[str, str](sr)); }
     val text: str = unwrap_ok[str, str](sr);
 
-    val er: Result[bool, str] = encode_asm_text(st, fn_base, text);
+    # numeric local labels are scoped to this block; their definitions and
+    # references resolve within it before the block finishes encoding.
+    var labels: AsmLabelState;
+    asm_labels_init(?labels, st.alloc);
+    val er: Result[bool, str] = encode_asm_text(st, fn_base, ?labels, text);
     deallocate[u8](st.alloc, text::*u8, (str_len(text) + 1)::usize);
-    ret er;
+    if (is_err[bool, str](er)) {
+        asm_labels_dnit(?labels);
+        ret er;
+    }
+
+    # a forward reference whose label was never defined in the block is a hard
+    # error, not a silently zero-displacement branch.
+    if (labels.fixup_count > 0) {
+        val msg: str = asm_label_error(st,
+            "encode: inline-asm forward reference to local label '", labels.fixups[0].number,
+            "f' has no definition in this asm block",
+            "encode: inline-asm forward reference to a local label has no definition in this asm block");
+        asm_labels_dnit(?labels);
+        ret err[bool, str](msg);
+    }
+    asm_labels_dnit(?labels);
+    ret ok[bool, str](true);
 }
 
 # substitute_asm_locals: produce a NUL-terminated copy of the asm body with each
@@ -4617,7 +4880,7 @@ fun arg_str(tok: str, mlen: usize) str {
 # (`lower_asm`), so none reach here. mirrors `masm_x86_parse_inline_asm`. each
 # emitted instruction is written through `encode_inst`; a `call` / `jmp` /
 # bare-symbol operand records a PC32 relocation against the named symbol.
-fun encode_asm_text(st: *EncodeState, fn_base: u32, text: str) Result[bool, str] {
+fun encode_asm_text(st: *EncodeState, fn_base: u32, labels: *AsmLabelState, text: str) Result[bool, str] {
     val len: usize = str_len(text);
     var start: usize = 0;
     for (start < len) {
@@ -4642,7 +4905,7 @@ fun encode_asm_text(st: *EncodeState, fn_base: u32, text: str) Result[bool, str]
             for (c < ll) { line[c] = text[lo + c]::u8; c = c + 1; }
             line[ll] = 0;
 
-            val er: Result[bool, str] = encode_asm_stmt(st, fn_base, (?line[0])::str);
+            val er: Result[bool, str] = encode_asm_stmt(st, fn_base, labels, (?line[0])::str);
             if (is_err[bool, str](er)) { ret er; }
         }
 
@@ -4753,6 +5016,18 @@ fun clobber_one(args: str, gp: *u32) {
 # unrecognized statement (including `.byte`) is opaque and conservatively clobbers
 # every register.
 fun stmt_clobbers(stmt: str, gp: *u32, fp: *u32) {
+    # a numeric local-label definition `<digits>:` clobbers nothing; strip the
+    # prefix and analyze any instruction that follows it on the same statement so a
+    # label line never trips the conservative all-clobber fallback below.
+    var label_num: u64 = 0;
+    val dlen: usize = asm_label_def_len(stmt, ?label_num);
+    if (dlen > 0) {
+        val rest: str = trim_str((stmt::usize + dlen)::str);
+        if (rest[0] == 0) { ret; }
+        stmt_clobbers(rest, gp, fp);
+        ret;
+    }
+
     # zero-operand forms: syscall implicitly clobbers RAX (return), RCX and R11.
     if (str_equals(stmt, "syscall")) {
         @gp = @gp | (1::u32 << x64.RAX::u32) | (1::u32 << x64.RCX::u32) | (1::u32 << x64.R11::u32);
@@ -4825,7 +5100,21 @@ fun stmt_clobbers(stmt: str, gp: *u32, fp: *u32) {
 }
 
 # encode_asm_stmt: parse and encode one trimmed inline-asm statement.
-fun encode_asm_stmt(st: *EncodeState, fn_base: u32, tok: str) Result[bool, str] {
+fun encode_asm_stmt(st: *EncodeState, fn_base: u32, labels: *AsmLabelState, tok: str) Result[bool, str] {
+    # a numeric local-label definition `<digits>:` records the current offset
+    # (resolving pending forward references to it) and is allowed to be followed by
+    # an instruction on the same statement, which is encoded by re-dispatching the
+    # remainder.
+    var label_num: u64 = 0;
+    val dlen: usize = asm_label_def_len(tok, ?label_num);
+    if (dlen > 0) {
+        val dr: Result[bool, str] = asm_label_record_def(labels, ?st.buf, label_num, st.buf.len::u32);
+        if (is_err[bool, str](dr)) { ret dr; }
+        val rest: str = trim_str((tok::usize + dlen)::str);
+        if (rest[0] == 0) { ret ok[bool, str](true); }
+        ret encode_asm_stmt(st, fn_base, labels, rest);
+    }
+
     # zero-operand mnemonics.
     if (str_equals(tok, "syscall")) { ret emit_simple(st, x64.SYSCALL); }
     if (str_equals(tok, "ret"))     { ret emit_simple(st, x64.RET); }
@@ -4834,14 +5123,14 @@ fun encode_asm_stmt(st: *EncodeState, fn_base: u32, tok: str) Result[bool, str] 
     if (str_equals(tok, "pause"))   { ret emit_simple(st, x64.PAUSE); }
     if (str_equals(tok, "nop"))     { ret emit_simple(st, x64.NOP); }
 
-    # control transfers to a symbol.
-    if (mnemonic_is(tok, "call")) { ret emit_branch_sym(st, fn_base, x64.CALL, arg_str(tok, 4)); }
-    if (mnemonic_is(tok, "jmp"))  { ret emit_branch_sym(st, fn_base, x64.JMP, arg_str(tok, 3)); }
-    if (mnemonic_is(tok, "je") || mnemonic_is(tok, "jz"))   { ret emit_branch_sym(st, fn_base, x64.JE, arg_str(tok, 2)); }
-    if (mnemonic_is(tok, "jne") || mnemonic_is(tok, "jnz")) { ret emit_branch_sym(st, fn_base, x64.JNE, arg_str(tok, 3)); }
+    # control transfers to a symbol or numeric local label.
+    if (mnemonic_is(tok, "call")) { ret emit_branch(st, fn_base, labels, x64.CALL, arg_str(tok, 4)); }
+    if (mnemonic_is(tok, "jmp"))  { ret emit_branch(st, fn_base, labels, x64.JMP, arg_str(tok, 3)); }
+    if (mnemonic_is(tok, "je") || mnemonic_is(tok, "jz"))   { ret emit_branch(st, fn_base, labels, x64.JE, arg_str(tok, 2)); }
+    if (mnemonic_is(tok, "jne") || mnemonic_is(tok, "jnz")) { ret emit_branch(st, fn_base, labels, x64.JNE, arg_str(tok, 3)); }
     # carry-flag conditionals: jc == jb (CF=1), jnc == jae == jnb (CF=0).
-    if (mnemonic_is(tok, "jc") || mnemonic_is(tok, "jb"))   { ret emit_branch_sym(st, fn_base, x64.JB, arg_str(tok, 2)); }
-    if (mnemonic_is(tok, "jnc") || mnemonic_is(tok, "jae") || mnemonic_is(tok, "jnb")) { ret emit_branch_sym(st, fn_base, x64.JAE, arg_str(tok, 3)); }
+    if (mnemonic_is(tok, "jc") || mnemonic_is(tok, "jb"))   { ret emit_branch(st, fn_base, labels, x64.JB, arg_str(tok, 2)); }
+    if (mnemonic_is(tok, "jnc") || mnemonic_is(tok, "jae") || mnemonic_is(tok, "jnb")) { ret emit_branch(st, fn_base, labels, x64.JAE, arg_str(tok, 3)); }
 
     # conditional set into a byte register: setc == setb (CF=1), setnc == setae
     # == setnb (CF=0). routed through the one-operand encoder, which dispatches the
@@ -4892,6 +5181,55 @@ fun emit_simple(st: *EncodeState, opcode: u16) Result[bool, str] {
     inst.opcode = opcode;
     val n: i32 = encode_inst(?inst, ?st.buf);
     if (n <= 0) { ret err[bool, str]("encode: inline-asm zero-operand encode produced no bytes"); }
+    ret ok[bool, str](true);
+}
+
+# emit_branch: encode a CALL / JMP / Jcc whose target is either a named symbol or a
+# numeric local label. a `<digits>f` / `<digits>b` token resolves to a block-local
+# rel32 (forward references are recorded as fixups, backward ones patched against
+# the nearest preceding definition); any other token is a symbol relocated by name.
+# a digit-led token that is neither shape is a malformed local label, not a symbol
+# (a bare symbol never starts with a digit).
+fun emit_branch(st: *EncodeState, fn_base: u32, labels: *AsmLabelState, opcode: u16, target: str) Result[bool, str] {
+    val name: str = trim_str(target);
+    var number: u64 = 0;
+    var fwd: bool = false;
+    if (asm_label_ref(name, ?number, ?fwd)) {
+        ret emit_branch_label(st, labels, opcode, number, fwd);
+    }
+    if (str_len(name) > 0 && is_asm_digit(name[0])) {
+        ret err[bool, str]("encode: inline-asm numeric local-label reference must be '<digits>f' or '<digits>b'");
+    }
+    ret emit_branch_sym(st, fn_base, opcode, name);
+}
+
+# emit_branch_label: encode a branch to a numeric local label. the branch is
+# emitted with a zero rel32 placeholder; a forward reference is recorded as a fixup
+# patched when its definition is reached, a backward reference is patched
+# immediately against the label's nearest preceding definition (an undefined one is
+# a hard error).
+fun emit_branch_label(st: *EncodeState, labels: *AsmLabelState, opcode: u16, number: u64, fwd: bool) Result[bool, str] {
+    var inst: isa.Inst;
+    zero_inst(?inst);
+    inst.opcode = opcode;
+    val inst_start: usize = st.buf.len;
+    val n: i32 = encode_inst(?inst, ?st.buf);
+    if (n <= 0) { ret err[bool, str]("encode: inline-asm branch encode produced no bytes"); }
+
+    val patch_pos: u32 = (inst_start + (n - 4)::usize)::u32;
+    val next_ip:   u32 = (inst_start + n::usize)::u32;
+    if (fwd) {
+        ret asm_label_push_fixup(labels, patch_pos, next_ip, number);
+    }
+    val def: Option[u32] = asm_label_lookup_def(labels, number);
+    if (!is_some[u32](def)) {
+        ret err[bool, str](asm_label_error(st,
+            "encode: inline-asm backward reference to local label '", number,
+            "b' has no preceding definition in this asm block",
+            "encode: inline-asm backward reference to a local label has no preceding definition in this asm block"));
+    }
+    val disp: i32 = unwrap[u32](def)::i32 - next_ip::i32;
+    patch_rel32(?st.buf, patch_pos::usize, disp);
     ret ok[bool, str](true);
 }
 
@@ -5356,10 +5694,7 @@ fun patch_branches(st: *EncodeState) Result[bool, str] {
         if (fx.patch_pos::usize + 4 > st.buf.len) {
             ret err[bool, str]("encode: branch fixup site is outside the text buffer");
         }
-        st.buf.data[fx.patch_pos]     = (disp & 0xFF)::u8;
-        st.buf.data[fx.patch_pos + 1] = ((disp >> 8) & 0xFF)::u8;
-        st.buf.data[fx.patch_pos + 2] = ((disp >> 16) & 0xFF)::u8;
-        st.buf.data[fx.patch_pos + 3] = ((disp >> 24) & 0xFF)::u8;
+        patch_rel32(?st.buf, fx.patch_pos::usize, disp);
         i = i + 1;
     }
     ret ok[bool, str](true);

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -5496,6 +5496,79 @@ test "x64.encode: inline-asm stack-slot used as memory base gets actionable diag
     ret 0;
 }
 
+test "x64.encode: numeric local-label tokens are recognized by shape" {
+    var num: u64 = 0;
+    var bad: i32 = 0;
+
+    # `<digits>:` is a definition; the prefix length includes the colon.
+    if (asm_label_def_len("1:", ?num) != 2 || num != 1) { bad = 1; }
+    if (asm_label_def_len("42: mov rax, rbx", ?num) != 3 || num != 42) { bad = 1; }
+    # not a definition: no colon, or a non-digit lead.
+    if (asm_label_def_len("mov rax, rbx", ?num) != 0) { bad = 1; }
+    if (asm_label_def_len("1f", ?num) != 0) { bad = 1; }
+
+    var fwd: bool = false;
+    # `<digits>f` is a forward reference, `<digits>b` a backward one.
+    if (!asm_label_ref("1f", ?num, ?fwd) || num != 1 || !fwd) { bad = 1; }
+    if (!asm_label_ref("23b", ?num, ?fwd) || num != 23 || fwd) { bad = 1; }
+    # a bare symbol, a digit-led non-f/b token, and a too-short token are not refs.
+    if (asm_label_ref("loop", ?num, ?fwd)) { bad = 1; }
+    if (asm_label_ref("1x", ?num, ?fwd)) { bad = 1; }
+    if (asm_label_ref("1", ?num, ?fwd)) { bad = 1; }
+    ret bad;
+}
+
+test "x64.encode: local-label branches encode block-local rel32 both directions" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var st: EncodeState;
+    st.alloc    = ?alloc;
+    st.buf      = buf_init(?alloc);
+    # the undefined-backward error formats through enc_named_message; a nil
+    # interner makes it return the plain fallback string instead of interning.
+    st.interner = nil;
+
+    var labels: AsmLabelState;
+    asm_labels_init(?labels, ?alloc);
+
+    var bad: i32 = 0;
+
+    # define label 1 at offset 0, then `jmp 1b`: a 5-byte E9 rel32 at offset 0
+    # whose rel32 (offset 1) is 0 - 5 = -5 (0xFFFFFFFB).
+    val dr: Result[bool, str] = asm_label_record_def(?labels, ?st.buf, 1, 0);
+    if (is_err[bool, str](dr)) { bad = 1; }
+    val br: Result[bool, str] = emit_branch_label(?st, ?labels, x64.JMP, 1, false);
+    if (is_err[bool, str](br)) { bad = 1; }
+    if (st.buf.len != 5) { bad = 1; }
+    or (st.buf.data[0] != 0xE9) { bad = 1; }
+    or (st.buf.data[1] != 0xFB) { bad = 1; }
+    or (st.buf.data[2] != 0xFF) { bad = 1; }
+    or (st.buf.data[3] != 0xFF) { bad = 1; }
+    or (st.buf.data[4] != 0xFF) { bad = 1; }
+
+    # `jmp 2f` at offset 5 records a forward fixup; defining label 2 at the next
+    # offset (10) patches the rel32 (offset 6) to 10 - 10 = 0.
+    val fr: Result[bool, str] = emit_branch_label(?st, ?labels, x64.JMP, 2, true);
+    if (is_err[bool, str](fr)) { bad = 1; }
+    if (labels.fixup_count != 1) { bad = 1; }
+    val dr2: Result[bool, str] = asm_label_record_def(?labels, ?st.buf, 2, st.buf.len::u32);
+    if (is_err[bool, str](dr2)) { bad = 1; }
+    if (labels.fixup_count != 0) { bad = 1; }
+    or (st.buf.data[5] != 0xE9) { bad = 1; }
+    or (st.buf.data[6] != 0x00) { bad = 1; }
+    or (st.buf.data[7] != 0x00) { bad = 1; }
+    or (st.buf.data[8] != 0x00) { bad = 1; }
+    or (st.buf.data[9] != 0x00) { bad = 1; }
+
+    # a backward reference to an undefined number is a hard error.
+    val ur: Result[bool, str] = emit_branch_label(?st, ?labels, x64.JMP, 9, false);
+    if (!is_err[bool, str](ur)) { bad = 1; }
+
+    asm_labels_dnit(?labels);
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
 test "x64.encode: imul r16, imm16 emits a 16-bit immediate (not imm32)" {
     var alloc: Allocator;
     page.make(?alloc);


### PR DESCRIPTION
Closes #1365.

Teaches the x86-64 inline-asm encoder NASM-style numeric local labels so inline asm can take a block-local forward/backward branch without a relocation — the hole #1359 exposed in `dep/mach-std`'s darwin syscall wrappers (`jc 1f` / `1:`).

## Design

Resolution is scoped to one `asm` block via a per-block `AsmLabelState`:
- `<digits>:` defines a label at the current `.text` offset.
- A backward `Nb` binds to the nearest preceding definition and is patched immediately.
- A forward `Nf` is emitted with a zero rel32 placeholder, recorded as a fixup, and patched when its definition (the nearest following one) is reached — reusing the shared `patch_rel32` writer that `patch_branches` now also calls.
- Redefining the same number is allowed (that is the point of numeric labels).
- An unresolved forward reference, an undefined backward reference, and a malformed digit-led target are all hard encode errors naming the label.

Every branch mnemonic (`jmp`, `je/jz`, `jne/jnz`, `jc/jb`, `jnc/jae/jnb`, `call`) routes through a unified `emit_branch` that decides symbol-vs-label by token shape (leading digit + `f`/`b` suffix vs identifier). A `N:` definition clobbers nothing, so `stmt_clobbers` strips the prefix instead of taking the conservative all-clobber path.

## Verification

- Full clean build with the 1.4.1 seed; `mach test .` 409/409 green.
- Stage-2 self-build is byte-identical to stage-1 (fixpoint holds).
- New `.github/tests/asmlocal` integration test: backward loop, forward branch, redefinition, and the undefined-reference error case; encodings cross-checked with `objdump`.