### PR TITLE
refactor(target): session-owned isa/os/abi/of registries

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -536,11 +536,11 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
     }
     var s: sess.Session = unwrap_ok[sess.Session, str](sess_r);
 
-    # populate the process-global target registries from the session interner.
-    # the registrars intern each vtable's string fields (format/os/abi names) into
-    # it; the format writers no longer capture it — they resolve names through the
+    # populate the session's target registry from the session interner. the
+    # registrars intern each vtable's string fields (format/os/abi names) into it;
+    # the format writers no longer capture it — they resolve names through the
     # interner each `ObjectImage` carries. register_all is idempotent.
-    val reg_r: Result[bool, str] = tgt.register_all(?s.interner);
+    val reg_r: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
     if (is_err[bool, str](reg_r)) {
         print.eprint("error: ");
         print.eprint(unwrap_err[bool, str](reg_r));

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -466,7 +466,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     var s: sess.Session = unwrap_ok[sess.Session, str](sess_r);
 
-    val reg_r: Result[bool, str] = tgt.register_all(?s.interner);
+    val reg_r: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
     if (is_err[bool, str](reg_r)) {
         print.eprint("error: failed to register targets\n");
         sess.dnit(?s);

--- a/src/cli/cmd/info.mach
+++ b/src/cli/cmd/info.mach
@@ -4,8 +4,8 @@
 # version, the host (os/isa) this binary was built for, and the registered
 # capability surface — the instruction sets, operating systems, ABIs, and object
 # formats this binary can compose into a target. needs no project: the version
-# and host fold at compile time, and the capability surface is read from the
-# process-global target registries after a self-registration pass.
+# and host fold at compile time, and the capability surface is read from a
+# locally-owned target registry after a registration pass.
 #
 # `mach info --version` is the one-line version alias for tooling (the version
 # string alone). exit codes: 0 on success, 2 on an internal failure.
@@ -60,7 +60,8 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     var interner: intern.Interner = intern.init(?alloc);
 
-    val reg_r: Result[bool, str] = tgt.register_all(?interner);
+    var reg: tgt.TargetRegistry = tgt.registry_init();
+    val reg_r: Result[bool, str] = tgt.register_all(?reg, ?interner);
     if (is_err[bool, str](reg_r)) {
         print.eprint("error: ");
         print.eprint(unwrap_err[bool, str](reg_r));
@@ -80,7 +81,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     print.print(host_isa());
     print.print("\n");
 
-    val code: i64 = print_capabilities(?interner);
+    val code: i64 = print_capabilities(?reg, ?interner);
     intern.dnit(?interner);
     ret code;
 }
@@ -104,14 +105,14 @@ fun host_isa() str {
     $or                                            { ret "unknown"; }
 }
 
-# print_capabilities: emit the four registry lines (isa / os / abi / object).
-# returns 0 on success, or 2 if a registered vtable's name is not interned —
+# print_capabilities: emit the four registry lines (isa / os / abi / object) from
+# `reg`. returns 0 on success, or 2 if a registered vtable's name is not interned —
 # an internal inconsistency, since register_all interned every name.
-fun print_capabilities(i: *intern.Interner) i64 {
-    if (is_err[bool, str](print_isa(i))) { ret cap_fail(); }
-    if (is_err[bool, str](print_os(i)))  { ret cap_fail(); }
-    if (is_err[bool, str](print_abi(i))) { ret cap_fail(); }
-    if (is_err[bool, str](print_of(i)))  { ret cap_fail(); }
+fun print_capabilities(reg: *tgt.TargetRegistry, i: *intern.Interner) i64 {
+    if (is_err[bool, str](print_isa(?reg.isa, i))) { ret cap_fail(); }
+    if (is_err[bool, str](print_os(?reg.os, i)))   { ret cap_fail(); }
+    if (is_err[bool, str](print_abi(?reg.abi, i))) { ret cap_fail(); }
+    if (is_err[bool, str](print_of(?reg.of, i)))   { ret cap_fail(); }
     ret 0;
 }
 
@@ -130,13 +131,13 @@ fun name_of(i: *intern.Interner, id: intern.StrId) Result[str, str] {
     ret err[str, str]("name not interned");
 }
 
-# print_isa: list the registered instruction sets on one `isa:` line.
-fun print_isa(i: *intern.Interner) Result[bool, str] {
+# print_isa: list the registered instruction sets in `reg` on one `isa:` line.
+fun print_isa(reg: *isa.IsaRegistry, i: *intern.Interner) Result[bool, str] {
     print.print("isa:");
     var k: u32 = 0;
-    val n: u32 = isa.registered_count();
+    val n: u32 = isa.registered_count(reg);
     for (k < n) {
-        val vt_opt: Option[*isa.IsaVTable] = isa.registered(k);
+        val vt_opt: Option[*isa.IsaVTable] = isa.registered(reg, k);
         if (is_some[*isa.IsaVTable](vt_opt)) {
             val nm: Result[str, str] = name_of(i, unwrap[*isa.IsaVTable](vt_opt).name);
             if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }
@@ -149,13 +150,13 @@ fun print_isa(i: *intern.Interner) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
-# print_os: list the registered operating systems on one `os:` line.
-fun print_os(i: *intern.Interner) Result[bool, str] {
+# print_os: list the registered operating systems in `reg` on one `os:` line.
+fun print_os(reg: *os.OsRegistry, i: *intern.Interner) Result[bool, str] {
     print.print("os:");
     var k: u32 = 0;
-    val n: u32 = os.registered_count();
+    val n: u32 = os.registered_count(reg);
     for (k < n) {
-        val vt_opt: Option[*os.OsVTable] = os.registered(k);
+        val vt_opt: Option[*os.OsVTable] = os.registered(reg, k);
         if (is_some[*os.OsVTable](vt_opt)) {
             val nm: Result[str, str] = name_of(i, unwrap[*os.OsVTable](vt_opt).name);
             if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }
@@ -168,13 +169,13 @@ fun print_os(i: *intern.Interner) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
-# print_abi: list the registered calling conventions on one `abi:` line.
-fun print_abi(i: *intern.Interner) Result[bool, str] {
+# print_abi: list the registered calling conventions in `reg` on one `abi:` line.
+fun print_abi(reg: *abi.AbiRegistry, i: *intern.Interner) Result[bool, str] {
     print.print("abi:");
     var k: u32 = 0;
-    val n: u32 = abi.registered_count();
+    val n: u32 = abi.registered_count(reg);
     for (k < n) {
-        val vt_opt: Option[*abi.AbiVTable] = abi.registered(k);
+        val vt_opt: Option[*abi.AbiVTable] = abi.registered(reg, k);
         if (is_some[*abi.AbiVTable](vt_opt)) {
             val nm: Result[str, str] = name_of(i, unwrap[*abi.AbiVTable](vt_opt).name);
             if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }
@@ -187,13 +188,13 @@ fun print_abi(i: *intern.Interner) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
-# print_of: list the registered object formats on one `object:` line.
-fun print_of(i: *intern.Interner) Result[bool, str] {
+# print_of: list the registered object formats in `reg` on one `object:` line.
+fun print_of(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
     print.print("object:");
     var k: u32 = 0;
-    val n: u32 = of.registered_count();
+    val n: u32 = of.registered_count(reg);
     for (k < n) {
-        val vt_opt: Option[*of.OfVTable] = of.registered(k);
+        val vt_opt: Option[*of.OfVTable] = of.registered(reg, k);
         if (is_some[*of.OfVTable](vt_opt)) {
             val nm: Result[str, str] = name_of(i, unwrap[*of.OfVTable](vt_opt).name);
             if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1318,7 +1318,7 @@ fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     val os_id:   u32 = os_id_for(os_name);
     val arch_id: u32 = arch_id_for(isa_name);
 
-    val tr: Result[tgt.Target, str] = tgt.select(os_id, arch_id);
+    val tr: Result[tgt.Target, str] = tgt.select(?p.s.registry, os_id, arch_id);
     if (is_err[tgt.Target, str](tr)) { ret err[bool, str](unwrap_err[tgt.Target, str](tr)); }
     p.target = unwrap_ok[tgt.Target, str](tr);
 

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -57,6 +57,7 @@ fwd modid.MODULE_NIL;
 # export_names: `(ModuleId << 32 | DeclId)` -> the literal link-name override declared by a `$<sym>.symbol = "..."` directive (or an `ext fun` foreign symbol); a decl present in this map keeps its literal name rather than being mangled, the sole exemption keeping the program entry, runtime, and foreign symbols linkable against the names written in inline asm
 # module_sema:    ModuleId -> its `*sema.SemaResult`, stored opaque (as `ptr`) to keep this leaf module free of an import cycle on the front end; the back-end monomorphizer casts it back to lower a generic template body against the typing of the module that declared it
 # module_resolve: ModuleId -> its `*resolve.ResolveResult`, stored opaque like module_sema, so a generic instance body is lowered against the declaring module's name resolution
+# registry: the owned target registry (isa/os/abi/of vtable tables); zeroed at init and populated by the owner's target.register_all call, then read by target.select to compose a Target
 pub rec Session {
     alloc:    *Allocator;
     sources:  source.SourceMap;
@@ -72,6 +73,7 @@ pub rec Session {
     module_sema:      map.Map[modid.ModuleId, ptr];
     module_resolve:   map.Map[modid.ModuleId, ptr];
     module_comptime:  map.Map[modid.ModuleId, ptr];
+    registry:         target.TargetRegistry;
 }
 
 # init: construct an empty Session backed by the given allocator. sub-services
@@ -79,11 +81,11 @@ pub rec Session {
 # and queries (fallible). queries registers the canonical catalog — the
 # input and metadata kinds whose registration needs nothing from a phase
 # module; derived kinds bind their compute functions when their owning
-# phase modules register them. the process-global target registries are NOT
-# populated here: the owner calls target.register_all on the session interner
-# after this by-value return so the vtable name strings are interned into the
-# session's final interner. on any failure the prior sub-services are torn down
-# in reverse construction order.
+# phase modules register them. the owned target registry is zeroed here but its
+# vtables are NOT installed: the owner calls target.register_all on the session's
+# registry and interner after this by-value return, so the vtable name strings
+# are interned into the session's final interner. on any failure the prior
+# sub-services are torn down in reverse construction order.
 # ---
 # alloc: allocator used for all session-owned storage
 # ret:   a new empty Session, or an allocation error from a fallible sub-service
@@ -101,6 +103,7 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
     s.module_sema      = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
     s.module_resolve   = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
     s.module_comptime  = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
+    s.registry         = target.registry_init();
 
     val r_types: Result[ty.TypeInterner, str] = ty.init(alloc);
     if (is_err[ty.TypeInterner, str](r_types)) {

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -2,9 +2,10 @@
 # dimensions — instruction set, ABI, operating system, and object format —
 # as borrowed vtable pointers plus their comptime identity ids. The middle
 # end and back end dispatch through the vtables and never branch on the ids.
-# `select` composes a Target from a process-global registry of self-registered
-# implementations, choosing the canonical ABI and object format for the
-# requested (os, arch) pair.
+# A `TargetRegistry` bundles the four per-dimension registries; the session (or
+# driver) owns one, `register_all` installs every implementation into it, and
+# `select` composes a Target from it, choosing the canonical ABI and object
+# format for the requested (os, arch) pair.
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -120,67 +121,96 @@ fun canonical_of(os_id: u32) u32 {
     ret of.OF_UNKNOWN;
 }
 
-# register_all: install every target-component implementation into the
-# process-global registries.
+# TargetRegistry: the session/driver-owned bundle of the four per-dimension
+# registries. `register_all` installs every implementation into it and `select`
+# composes a Target from it, so the registration-before-selection ordering is an
+# ordinary init dependency on this owned value rather than a process-global
+# invariant.
+# ---
+# isa: instruction-set vtable registry
+# os:  operating-system vtable registry
+# abi: calling-convention vtable registry
+# of:  object-format vtable registry
+pub rec TargetRegistry {
+    isa: isa.IsaRegistry;
+    os:  os.OsRegistry;
+    abi: abi.AbiRegistry;
+    of:  of.OfRegistry;
+}
+
+# registry_init: a fresh TargetRegistry with every per-dimension slot empty.
+# ---
+# ret: a zeroed TargetRegistry, ready for register_all
+pub fun registry_init() TargetRegistry {
+    var r: TargetRegistry;
+    r.isa = isa.registry_init();
+    r.os  = os.registry_init();
+    r.abi = abi.registry_init();
+    r.of  = of.registry_init();
+    ret r;
+}
+
+# register_all: install every target-component implementation into `reg`.
 #
 # composes the four orthogonal dimensions by invoking each implementation's
-# self-registering entry point: the x86-64 ISA, SysV ABI, ELF object format,
+# registering entry point: the x86-64 ISA, SysV ABI, ELF object format,
 # and Linux operating system (the supported set), plus the honest stubs
 # (arm64, win64, coff, mach-o, darwin, windows) so `select` reports an
-# unsupported pair rather than a missing registration. must be called exactly
-# once at startup, before any `select`, so the registries are populated.
+# unsupported pair rather than a missing registration. must be called once at
+# startup, before any `select` against `reg`, so the registries are populated.
 # every registrar is idempotent, so a redundant call is harmless. the
 # allocator threaded into the registrars that take one for parity is read from
 # the interner.
 # ---
+# reg: the target registry to install every implementation into
 # i:   interner used to intern each implementation's string fields
 # ret: ok(true) once every implementation is registered, or the first error
-pub fun register_all(i: *intern.Interner) Result[bool, str] {
-    val r_x64: Result[bool, str] = x64.register_x64(i.alloc, i);
+pub fun register_all(reg: *TargetRegistry, i: *intern.Interner) Result[bool, str] {
+    val r_x64: Result[bool, str] = x64.register_x64(?reg.isa, i.alloc, i);
     if (is_err[bool, str](r_x64)) { ret err[bool, str](unwrap_err[bool, str](r_x64)); }
 
-    val r_arm64: Result[bool, str] = arm64.register_arm64(i.alloc, i);
+    val r_arm64: Result[bool, str] = arm64.register_arm64(?reg.isa, i.alloc, i);
     if (is_err[bool, str](r_arm64)) { ret err[bool, str](unwrap_err[bool, str](r_arm64)); }
 
-    val r_sysv: Result[bool, str] = sysv.register(i);
+    val r_sysv: Result[bool, str] = sysv.register(?reg.abi, i);
     if (is_err[bool, str](r_sysv)) { ret err[bool, str](unwrap_err[bool, str](r_sysv)); }
 
-    val r_win64: Result[bool, str] = win64.register_win64(i.alloc, i);
+    val r_win64: Result[bool, str] = win64.register_win64(?reg.abi, i.alloc, i);
     if (is_err[bool, str](r_win64)) { ret err[bool, str](unwrap_err[bool, str](r_win64)); }
 
-    val r_elf: Result[bool, str] = elf.register(i);
+    val r_elf: Result[bool, str] = elf.register(?reg.of, i);
     if (is_err[bool, str](r_elf)) { ret err[bool, str](unwrap_err[bool, str](r_elf)); }
 
-    val r_coff: Result[bool, str] = coff.register_coff(i);
+    val r_coff: Result[bool, str] = coff.register_coff(?reg.of, i);
     if (is_err[bool, str](r_coff)) { ret err[bool, str](unwrap_err[bool, str](r_coff)); }
 
-    val r_macho: Result[bool, str] = macho.register_macho(i);
+    val r_macho: Result[bool, str] = macho.register_macho(?reg.of, i);
     if (is_err[bool, str](r_macho)) { ret err[bool, str](unwrap_err[bool, str](r_macho)); }
 
-    val r_linux: Result[bool, str] = linux.register_linux(i.alloc, i);
+    val r_linux: Result[bool, str] = linux.register_linux(?reg.os, i.alloc, i);
     if (is_err[bool, str](r_linux)) { ret err[bool, str](unwrap_err[bool, str](r_linux)); }
 
-    val r_darwin: Result[bool, str] = darwin.register_darwin(i.alloc, i);
+    val r_darwin: Result[bool, str] = darwin.register_darwin(?reg.os, i.alloc, i);
     if (is_err[bool, str](r_darwin)) { ret err[bool, str](unwrap_err[bool, str](r_darwin)); }
 
-    val r_windows: Result[bool, str] = windows.register_windows(i.alloc, i);
+    val r_windows: Result[bool, str] = windows.register_windows(?reg.os, i.alloc, i);
     if (is_err[bool, str](r_windows)) { ret err[bool, str](unwrap_err[bool, str](r_windows)); }
 
     ret ok[bool, str](true);
 }
 
-# select: compose a Target for an (os, arch) pair.
+# select: compose a Target for an (os, arch) pair from `reg`.
 #
 # resolves the canonical ABI for the (os, arch) pair and the object format for the
-# operating system, then looks up all four vtables from the process-global
-# registries that the implementations self-register into. allocates nothing —
+# operating system, then looks up all four vtables from `reg`. allocates nothing —
 # every vtable pointer is borrowed. fails if the pair has no canonical mapping or
-# if any required implementation is not registered.
+# if any required implementation is not registered in `reg`.
 # ---
+# reg:     the target registry populated by register_all
 # os_id:   operating-system id (one of os.OS_*)
 # arch_id: architecture id (one of isa.ARCH_*)
 # ret:     the composed Target, or an error describing the missing piece
-pub fun select(os_id: u32, arch_id: u32) Result[tdef.Target, str] {
+pub fun select(reg: *TargetRegistry, os_id: u32, arch_id: u32) Result[tdef.Target, str] {
     val abi_id: u32 = canonical_abi(os_id, arch_id);
     if (abi_id == abi.ABI_UNKNOWN) {
         ret err[tdef.Target, str]("unsupported (operating system, architecture) pair");
@@ -190,19 +220,19 @@ pub fun select(os_id: u32, arch_id: u32) Result[tdef.Target, str] {
         ret err[tdef.Target, str]("unsupported operating system");
     }
 
-    val os_vt: Option[*os.OsVTable] = os.lookup(os_id);
+    val os_vt: Option[*os.OsVTable] = os.lookup(?reg.os, os_id);
     if (is_none[*os.OsVTable](os_vt)) {
         ret err[tdef.Target, str]("no os implementation registered");
     }
-    val arch_vt: Option[*isa.IsaVTable] = isa.lookup(arch_id);
+    val arch_vt: Option[*isa.IsaVTable] = isa.lookup(?reg.isa, arch_id);
     if (is_none[*isa.IsaVTable](arch_vt)) {
         ret err[tdef.Target, str]("no isa implementation registered");
     }
-    val abi_vt: Option[*abi.AbiVTable] = abi.lookup(abi_id);
+    val abi_vt: Option[*abi.AbiVTable] = abi.lookup(?reg.abi, abi_id);
     if (is_none[*abi.AbiVTable](abi_vt)) {
         ret err[tdef.Target, str]("no abi implementation registered");
     }
-    val of_vt: Option[*of.OfVTable] = of.lookup(of_id);
+    val of_vt: Option[*of.OfVTable] = of.lookup(?reg.of, of_id);
     if (is_none[*of.OfVTable](of_vt)) {
         ret err[tdef.Target, str]("no object-format implementation registered");
     }
@@ -228,26 +258,27 @@ test "target: registry enumeration agrees with lookup (#1312)" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_all(?i);
+    var reg: TargetRegistry = registry_init();
+    val rr: Result[bool, str] = register_all(?reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     # the supported implementations are all enumerable.
-    if (isa.registered_count() < 2) { ret 1; }
-    if (os.registered_count()  < 3) { ret 1; }
-    if (abi.registered_count() < 2) { ret 1; }
-    if (of.registered_count()  < 3) { ret 1; }
+    if (isa.registered_count(?reg.isa) < 2) { ret 1; }
+    if (os.registered_count(?reg.os)   < 3) { ret 1; }
+    if (abi.registered_count(?reg.abi) < 2) { ret 1; }
+    if (of.registered_count(?reg.of)   < 3) { ret 1; }
 
     # every enumerated isa slot is present and agrees with id-keyed lookup;
     # one past the count, enumeration reports none.
     var k: u32 = 0;
-    val n: u32 = isa.registered_count();
+    val n: u32 = isa.registered_count(?reg.isa);
     for (k < n) {
-        val e: Option[*isa.IsaVTable] = isa.registered(k);
+        val e: Option[*isa.IsaVTable] = isa.registered(?reg.isa, k);
         if (!is_some[*isa.IsaVTable](e)) { ret 1; }
-        if (!is_some[*isa.IsaVTable](isa.lookup(unwrap[*isa.IsaVTable](e).id))) { ret 1; }
+        if (!is_some[*isa.IsaVTable](isa.lookup(?reg.isa, unwrap[*isa.IsaVTable](e).id))) { ret 1; }
         k = k + 1;
     }
-    if (is_some[*isa.IsaVTable](isa.registered(n))) { ret 1; }
+    if (is_some[*isa.IsaVTable](isa.registered(?reg.isa, n))) { ret 1; }
 
     ret 0;
 }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -1,10 +1,11 @@
 # mach.lang.target.abi: calling-convention interface.
 #
 # Defines the target-agnostic parameter-passing model — `ParamClass` and
-# `ParamSlot` — and the `AbiVTable` runtime-dispatch interface backed by a
-# process-global registry. The classification and register-assignment logic
-# lives in the per-ABI implementations (sysv, win64), which self-register from
-# module init. The three classify/arg/ret function pointers are type-erased
+# `ParamSlot` — and the `AbiVTable` runtime-dispatch interface backed by an
+# `AbiRegistry` (a session/driver-owned table of vtables indexed by convention
+# id). The classification and register-assignment logic lives in the per-ABI
+# implementations (sysv, win64), which are installed into a registry at startup.
+# The three classify/arg/ret function pointers are type-erased
 # (`*u8`) so the vtable carries no ABI-specific `ArgClass` type; each consumer
 # casts back to the concrete signature.
 
@@ -200,71 +201,80 @@ pub rec AbiVTable {
 
 val ABI_REGISTRY_CAP: u32 = 8;
 
-# process-global write-once registry of ABI vtables, indexed by convention id.
-# per-ABI implementations self-register from module init.
-var abi_registry: [8]*AbiVTable;
-var abi_registry_init: bool = false;
-
-fun ensure_abi_registry() {
-    if (abi_registry_init) { ret; }
-    var i: u32 = 0;
-    for (i < ABI_REGISTRY_CAP) {
-        abi_registry[i] = nil;
-        i = i + 1;
-    }
-    abi_registry_init = true;
+# AbiRegistry: a session/driver-owned table of ABI vtables, indexed by
+# convention id. bundled into `target.TargetRegistry`; per-ABI implementations
+# are installed through `register` at startup. a slot stays nil until its
+# implementation registers.
+# ---
+# slots: vtable pointers indexed by convention id (ABI_*)
+pub rec AbiRegistry {
+    slots: [8]*AbiVTable;
 }
 
-# register: install an ABI vtable into the process-global registry.
+# registry_init: a fresh ABI registry with every slot empty.
+# ---
+# ret: a zeroed AbiRegistry
+pub fun registry_init() AbiRegistry {
+    var r: AbiRegistry;
+    var i: u32 = 0;
+    for (i < ABI_REGISTRY_CAP) {
+        r.slots[i] = nil;
+        i = i + 1;
+    }
+    ret r;
+}
+
+# register: install an ABI vtable into `reg`.
 #
 # write-once per convention id: a second registration for the same id is
 # ignored so the first implementation to initialize wins deterministically.
 # ---
-# vt: the ABI vtable to register; its `id` selects the slot
-pub fun register(vt: *AbiVTable) {
-    ensure_abi_registry();
+# reg: the registry to install into
+# vt:  the ABI vtable to register; its `id` selects the slot
+pub fun register(reg: *AbiRegistry, vt: *AbiVTable) {
     if (vt == nil) { ret; }
     if (vt.id >= ABI_REGISTRY_CAP) { ret; }
-    if (abi_registry[vt.id] != nil) { ret; }
-    abi_registry[vt.id] = vt;
+    if (reg.slots[vt.id] != nil) { ret; }
+    reg.slots[vt.id] = vt;
 }
 
-# lookup: find the ABI vtable registered for a convention id.
+# lookup: find the ABI vtable registered for a convention id in `reg`.
 # ---
+# reg:    the registry to read
 # abi_id: calling-convention id (one of ABI_*)
 # ret:    the registered vtable, or none if no implementation is registered
-pub fun lookup(abi_id: u32) Option[*AbiVTable] {
-    ensure_abi_registry();
+pub fun lookup(reg: *AbiRegistry, abi_id: u32) Option[*AbiVTable] {
     if (abi_id >= ABI_REGISTRY_CAP) { ret none[*AbiVTable](); }
-    if (abi_registry[abi_id] == nil) { ret none[*AbiVTable](); }
-    ret some[*AbiVTable](abi_registry[abi_id]);
+    if (reg.slots[abi_id] == nil) { ret none[*AbiVTable](); }
+    ret some[*AbiVTable](reg.slots[abi_id]);
 }
 
-# registered_count: the number of ABI implementations currently registered.
+# registered_count: the number of ABI implementations registered in `reg`.
+# ---
+# reg: the registry to read
 # ret: count of non-empty registry slots
-pub fun registered_count() u32 {
-    ensure_abi_registry();
+pub fun registered_count(reg: *AbiRegistry) u32 {
     var n: u32 = 0;
     var i: u32 = 0;
     for (i < ABI_REGISTRY_CAP) {
-        if (abi_registry[i] != nil) { n = n + 1; }
+        if (reg.slots[i] != nil) { n = n + 1; }
         i = i + 1;
     }
     ret n;
 }
 
-# registered: the ABI vtable at enumeration index `idx` (0-based, in id order),
-# skipping empty slots. pairs with registered_count to walk the registry.
+# registered: the ABI vtable at enumeration index `idx` (0-based, in id order)
+# in `reg`, skipping empty slots. pairs with registered_count to walk the registry.
 # ---
+# reg: the registry to read
 # idx: enumeration index in [0, registered_count)
 # ret: the vtable at that index, or none when idx is out of range
-pub fun registered(idx: u32) Option[*AbiVTable] {
-    ensure_abi_registry();
+pub fun registered(reg: *AbiRegistry, idx: u32) Option[*AbiVTable] {
     var n: u32 = 0;
     var i: u32 = 0;
     for (i < ABI_REGISTRY_CAP) {
-        if (abi_registry[i] != nil) {
-            if (n == idx) { ret some[*AbiVTable](abi_registry[i]); }
+        if (reg.slots[i] != nil) {
+            if (n == idx) { ret some[*AbiVTable](reg.slots[i]); }
             n = n + 1;
         }
         i = i + 1;

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -458,18 +458,19 @@ pub fun va_model() abi.VaModel {
 # `ClassifyFn`/`ArgPassingFn`/`RetPassingFn`.
 var sysv_vtable: abi.AbiVTable;
 
-# register: build the SysV AMD64 AbiVTable and install it into the ABI registry.
+# register: build the SysV AMD64 AbiVTable and install it into `reg`.
 #
 # interns the convention name ("sysv"), wires the type-erased classify/arg/ret
 # operation pointers and the GP/FP argument-register and callee-saved register
 # file accessors, sets the 16-byte stack alignment and 128-byte red zone, and
 # registers it under abi.ABI_SYSV so target.select can find it through
-# abi.lookup. re-interns the name into `i` on every call (the registry pointer is
-# idempotent) so a later build with a fresh interner gets a consistent id.
+# abi.lookup. re-interns the name into `i` on every call (the registry entry is
+# write-once) so a later build with a fresh interner gets a consistent id.
 # ---
+# reg: the ABI registry to install the vtable into
 # i:   interner used to intern the vtable's string fields
 # ret: ok(true) on success, or an allocation error from interning
-pub fun register(i: *intern.Interner) Result[bool, str] {
+pub fun register(reg: *abi.AbiRegistry, i: *intern.Interner) Result[bool, str] {
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "sysv");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -488,7 +489,7 @@ pub fun register(i: *intern.Interner) Result[bool, str] {
     sysv_vtable.shadow_space = 0;
     sysv_vtable.va_model      = va_model::*u8;
 
-    abi.register(?sysv_vtable);
+    abi.register(reg, ?sysv_vtable);
     ret ok[bool, str](true);
 }
 

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -444,16 +444,17 @@ var win64_vtable: abi.AbiVTable;
 #
 # interns the convention name ("win64"), wires the type-erased classify/arg/ret
 # operation pointers and the gp_arg_regs / fp_arg_regs / callee_saved register-
-# file accessors, sets the stack alignment (16) and red-zone size (0), and self-
-# registers it into the process-global ABI registry under abi.ABI_WIN64. re-
-# interns the name into `i` on every call (the registry pointer is idempotent) so
-# a later build with a fresh interner gets a consistent id. must be invoked at
-# startup before target.select requests a Windows target.
+# file accessors, sets the stack alignment (16) and red-zone size (0), and
+# installs it into `reg` under abi.ABI_WIN64. re-interns the name into `i` on
+# every call (the registry entry is write-once) so a later build with a fresh
+# interner gets a consistent id. must be invoked at startup before target.select
+# requests a Windows target.
 # ---
+# reg:   the ABI registry to install the vtable into
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields
 # ret:   true on success, or an error string if name interning fails
-pub fun register_win64(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+pub fun register_win64(reg: *abi.AbiRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "win64");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -473,7 +474,7 @@ pub fun register_win64(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     win64_vtable.shadow_space = SHADOW_SPACE::u32;
     win64_vtable.va_model     = va_model::*u8;
 
-    abi.register(?win64_vtable);
+    abi.register(reg, ?win64_vtable);
     ret ok[bool, str](true);
 }
 

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -1,10 +1,11 @@
 # mach.lang.target.isa: instruction-set interface and id registry.
 #
 # Defines the target-agnostic machine model — operands, instructions,
-# instruction buffers — plus the `IsaVTable` runtime-dispatch interface and a
-# process-global registry that per-arch implementations self-register into from
-# module init. The numeric `ARCH_*` ids are stable across compiler versions and
-# drive comptime conditional compilation via `$mach.arch.<name>`.
+# instruction buffers — plus the `IsaVTable` runtime-dispatch interface and an
+# `IsaRegistry` (a session/driver-owned table of vtables indexed by architecture
+# id) that per-arch implementations are installed into at startup. The numeric
+# `ARCH_*` ids are stable across compiler versions and drive comptime conditional
+# compilation via `$mach.arch.<name>`.
 
 use std.types.result.Result;
 use std.types.result.is_err;
@@ -310,72 +311,80 @@ pub rec IsaVTable {
 
 val ISA_REGISTRY_CAP: u32 = 8;
 
-# process-global write-once registry of ISA vtables, indexed by architecture
-# id. per-arch implementations self-register from module init; the entry stays
-# nil until its implementation registers.
-var isa_registry: [8]*IsaVTable;
-var isa_registry_init: bool = false;
-
-fun ensure_isa_registry() {
-    if (isa_registry_init) { ret; }
-    var i: u32 = 0;
-    for (i < ISA_REGISTRY_CAP) {
-        isa_registry[i] = nil;
-        i = i + 1;
-    }
-    isa_registry_init = true;
+# IsaRegistry: a session/driver-owned table of ISA vtables, indexed by
+# architecture id. bundled into `target.TargetRegistry`; per-arch
+# implementations are installed through `register` at startup. a slot stays nil
+# until its implementation registers.
+# ---
+# slots: vtable pointers indexed by architecture id (ARCH_*)
+pub rec IsaRegistry {
+    slots: [8]*IsaVTable;
 }
 
-# register: install an ISA vtable into the process-global registry.
+# registry_init: a fresh ISA registry with every slot empty.
+# ---
+# ret: a zeroed IsaRegistry
+pub fun registry_init() IsaRegistry {
+    var r: IsaRegistry;
+    var i: u32 = 0;
+    for (i < ISA_REGISTRY_CAP) {
+        r.slots[i] = nil;
+        i = i + 1;
+    }
+    ret r;
+}
+
+# register: install an ISA vtable into `reg`.
 #
 # write-once per architecture id: a second registration for the same id is
 # ignored so the first implementation to initialize wins deterministically.
 # ---
-# vt: the ISA vtable to register; its `id` selects the slot
-pub fun register(vt: *IsaVTable) {
-    ensure_isa_registry();
+# reg: the registry to install into
+# vt:  the ISA vtable to register; its `id` selects the slot
+pub fun register(reg: *IsaRegistry, vt: *IsaVTable) {
     if (vt == nil) { ret; }
     if (vt.id >= ISA_REGISTRY_CAP) { ret; }
-    if (isa_registry[vt.id] != nil) { ret; }
-    isa_registry[vt.id] = vt;
+    if (reg.slots[vt.id] != nil) { ret; }
+    reg.slots[vt.id] = vt;
 }
 
-# lookup: find the ISA vtable registered for an architecture id.
+# lookup: find the ISA vtable registered for an architecture id in `reg`.
 # ---
+# reg:     the registry to read
 # arch_id: architecture id (one of ARCH_*)
 # ret:     the registered vtable, or none if no implementation is registered
-pub fun lookup(arch_id: u32) Option[*IsaVTable] {
-    ensure_isa_registry();
+pub fun lookup(reg: *IsaRegistry, arch_id: u32) Option[*IsaVTable] {
     if (arch_id >= ISA_REGISTRY_CAP) { ret none[*IsaVTable](); }
-    if (isa_registry[arch_id] == nil) { ret none[*IsaVTable](); }
-    ret some[*IsaVTable](isa_registry[arch_id]);
+    if (reg.slots[arch_id] == nil) { ret none[*IsaVTable](); }
+    ret some[*IsaVTable](reg.slots[arch_id]);
 }
 
-# registered_count: the number of ISA implementations currently registered.
+# registered_count: the number of ISA implementations registered in `reg`.
+# ---
+# reg: the registry to read
 # ret: count of non-empty registry slots
-pub fun registered_count() u32 {
-    ensure_isa_registry();
+pub fun registered_count(reg: *IsaRegistry) u32 {
     var n: u32 = 0;
     var i: u32 = 0;
     for (i < ISA_REGISTRY_CAP) {
-        if (isa_registry[i] != nil) { n = n + 1; }
+        if (reg.slots[i] != nil) { n = n + 1; }
         i = i + 1;
     }
     ret n;
 }
 
-# registered: the ISA vtable at enumeration index `idx` (0-based, in id order),
-# skipping empty slots. pairs with registered_count to walk the registry.
+# registered: the ISA vtable at enumeration index `idx` (0-based, in id order)
+# in `reg`, skipping empty slots. pairs with registered_count to walk the registry.
 # ---
+# reg: the registry to read
 # idx: enumeration index in [0, registered_count)
 # ret: the vtable at that index, or none when idx is out of range
-pub fun registered(idx: u32) Option[*IsaVTable] {
-    ensure_isa_registry();
+pub fun registered(reg: *IsaRegistry, idx: u32) Option[*IsaVTable] {
     var n: u32 = 0;
     var i: u32 = 0;
     for (i < ISA_REGISTRY_CAP) {
-        if (isa_registry[i] != nil) {
-            if (n == idx) { ret some[*IsaVTable](isa_registry[i]); }
+        if (reg.slots[i] != nil) {
+            if (n == idx) { ret some[*IsaVTable](reg.slots[i]); }
             n = n + 1;
         }
         i = i + 1;

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -66,16 +66,16 @@ var arm64_vtable: isa.IsaVTable;
 # 8-byte pointers, little-endian byte order, the reserved registers (SP/FP), the
 # scratch register identities (IP0/IP1/V31), the frame/stack pointers (FP/SP), -1
 # for the division / shift register identities (AArch64 wires none), and nil
-# select/encode entry points, and self-registers it into the process-global ISA
-# registry under isa.ARCH_AARCH64. re-interns the names into `i` on every call (the
-# registry pointer is idempotent) so a later build with a fresh interner gets
-# consistent ids. must be invoked at startup before target.select requests an
-# AArch64 target.
+# select/encode entry points, and installs it into `reg` under isa.ARCH_AARCH64.
+# re-interns the names into `i` on every call (the registry entry is write-once)
+# so a later build with a fresh interner gets consistent ids. must be invoked at
+# startup before target.select requests an AArch64 target.
 # ---
+# reg:   the ISA registry to install the vtable into
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields
 # ret:   true on success, or an error string if name interning fails
-pub fun register_arm64(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+pub fun register_arm64(reg: *isa.IsaRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "aarch64");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -136,6 +136,6 @@ pub fun register_arm64(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     arm64_vtable.div_hi_reg         = -1;
     arm64_vtable.shift_count_reg    = -1;
 
-    isa.register(?arm64_vtable);
+    isa.register(reg, ?arm64_vtable);
     ret ok[bool, str](true);
 }

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -65,11 +65,11 @@ var x64_reload_scratch_regs: [3]isa.Register;
 # the scratch register identities (R11/R10/XMM15), the frame/stack pointers
 # (RBP/RSP) the shared MIR lowering names when forming stack memory operands, and
 # the fixed division accumulator / high-half (RAX/RDX) and variable-shift count
-# (RCX) registers the x86-64 IDIV/DIV and shift forms hard-wire, and self-registers
-# it into the process-global ISA registry. re-interns the names into `interner` on
-# every call (the registry pointer is idempotent) so a later build with a fresh
-# interner gets consistent ids. must be invoked at compiler startup before
-# `target.select` requests an x86-64 target.
+# (RCX) registers the x86-64 IDIV/DIV and shift forms hard-wire, and installs it
+# into `reg`. re-interns the names into `interner` on every call (the registry
+# entry is write-once) so a later build with a fresh interner gets consistent
+# ids. must be invoked at compiler startup before `target.select` requests an
+# x86-64 target.
 #
 # the `select` and `encode` operation entry points are the x86-64 instruction
 # selector (`x64/isel.mach`) and byte encoder (`x64/encode.mach`), stored
@@ -79,10 +79,11 @@ var x64_reload_scratch_regs: [3]isa.Register;
 # and encoding logic lives under this module and is reached only through these
 # vtable slots; the shared backend drivers carry no x86-64 knowledge.
 # ---
+# reg:      the ISA registry to install the vtable into
 # alloc:    backing allocator (reserved for parity with other registrars)
 # interner: string interner used to intern the architecture and class names
 # ret:      true on success, or an error string if name interning fails
-pub fun register_x64(alloc: *Allocator, interner: *intern.Interner) Result[bool, str] {
+pub fun register_x64(reg: *isa.IsaRegistry, alloc: *Allocator, interner: *intern.Interner) Result[bool, str] {
 
     val res_name: Result[intern.StrId, str] = intern.intern(interner, "x86_64");
     if (is_err[intern.StrId, str](res_name)) {
@@ -159,7 +160,7 @@ pub fun register_x64(alloc: *Allocator, interner: *intern.Interner) Result[bool,
     x64_vtable.div_hi_reg         = x64.RDX;
     x64_vtable.shift_count_reg    = x64.RCX;
 
-    isa.register(?x64_vtable);
+    isa.register(reg, ?x64_vtable);
 
     ret ok[bool, str](true);
 }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -3,10 +3,11 @@
 # This file owns the `ObjectImage` data model — the contract between the back
 # end (which builds an image) and the format writer (which serializes it) — so
 # it lives here rather than in be.obj to avoid an import cycle. The `OfVTable`
-# runtime-dispatch interface plus a process-global registry let per-format
-# implementations (elf, coff, macho) self-register from module init. The back
-# end emits relocations using the abstract `RK_*` kinds; each format maps those
-# to its own machine relocation types internally with a plain integer compare.
+# runtime-dispatch interface plus an `OfRegistry` (a session/driver-owned table
+# of vtables indexed by format id) let per-format implementations (elf, coff,
+# macho) be installed at startup. The back end emits relocations using the
+# abstract `RK_*` kinds; each format maps those to its own machine relocation
+# types internally with a plain integer compare.
 
 use std.types.result.Result;
 use std.types.string.str;
@@ -381,72 +382,81 @@ pub rec OfVTable {
 
 val OF_REGISTRY_CAP: u32 = 8;
 
-# process-global write-once registry of object-format vtables, indexed by
-# format id. per-format implementations self-register from module init.
-var of_registry: [8]*OfVTable;
-var of_registry_init: bool = false;
-
-fun ensure_of_registry() {
-    if (of_registry_init) { ret; }
-    var i: u32 = 0;
-    for (i < OF_REGISTRY_CAP) {
-        of_registry[i] = nil;
-        i = i + 1;
-    }
-    of_registry_init = true;
+# OfRegistry: a session/driver-owned table of object-format vtables, indexed by
+# format id. bundled into `target.TargetRegistry`; per-format implementations
+# are installed through `register` at startup. a slot stays nil until its
+# implementation registers.
+# ---
+# slots: vtable pointers indexed by format id (OF_*)
+pub rec OfRegistry {
+    slots: [8]*OfVTable;
 }
 
-# register: install an object-format vtable into the process-global registry.
+# registry_init: a fresh object-format registry with every slot empty.
+# ---
+# ret: a zeroed OfRegistry
+pub fun registry_init() OfRegistry {
+    var r: OfRegistry;
+    var i: u32 = 0;
+    for (i < OF_REGISTRY_CAP) {
+        r.slots[i] = nil;
+        i = i + 1;
+    }
+    ret r;
+}
+
+# register: install an object-format vtable into `reg`.
 #
 # write-once per format id: a second registration for the same id is ignored
 # so the first implementation to initialize wins deterministically.
 # ---
-# vt: the object-format vtable to register; its `id` selects the slot
-pub fun register(vt: *OfVTable) {
-    ensure_of_registry();
+# reg: the registry to install into
+# vt:  the object-format vtable to register; its `id` selects the slot
+pub fun register(reg: *OfRegistry, vt: *OfVTable) {
     if (vt == nil) { ret; }
     if (vt.id >= OF_REGISTRY_CAP) { ret; }
-    if (of_registry[vt.id] != nil) { ret; }
-    of_registry[vt.id] = vt;
+    if (reg.slots[vt.id] != nil) { ret; }
+    reg.slots[vt.id] = vt;
 }
 
-# lookup: find the object-format vtable registered for a format id.
+# lookup: find the object-format vtable registered for a format id in `reg`.
 # ---
+# reg:   the registry to read
 # of_id: object-format id (one of OF_*)
 # ret:   the registered vtable, or none if no implementation is registered
-pub fun lookup(of_id: u32) Option[*OfVTable] {
-    ensure_of_registry();
+pub fun lookup(reg: *OfRegistry, of_id: u32) Option[*OfVTable] {
     if (of_id >= OF_REGISTRY_CAP) { ret none[*OfVTable](); }
-    if (of_registry[of_id] == nil) { ret none[*OfVTable](); }
-    ret some[*OfVTable](of_registry[of_id]);
+    if (reg.slots[of_id] == nil) { ret none[*OfVTable](); }
+    ret some[*OfVTable](reg.slots[of_id]);
 }
 
-# registered_count: the number of object-format implementations registered.
+# registered_count: the number of object-format implementations registered in `reg`.
+# ---
+# reg: the registry to read
 # ret: count of non-empty registry slots
-pub fun registered_count() u32 {
-    ensure_of_registry();
+pub fun registered_count(reg: *OfRegistry) u32 {
     var n: u32 = 0;
     var i: u32 = 0;
     for (i < OF_REGISTRY_CAP) {
-        if (of_registry[i] != nil) { n = n + 1; }
+        if (reg.slots[i] != nil) { n = n + 1; }
         i = i + 1;
     }
     ret n;
 }
 
 # registered: the object-format vtable at enumeration index `idx` (0-based, in
-# id order), skipping empty slots. pairs with registered_count to walk the
-# registry.
+# id order) in `reg`, skipping empty slots. pairs with registered_count to walk
+# the registry.
 # ---
+# reg: the registry to read
 # idx: enumeration index in [0, registered_count)
 # ret: the vtable at that index, or none when idx is out of range
-pub fun registered(idx: u32) Option[*OfVTable] {
-    ensure_of_registry();
+pub fun registered(reg: *OfRegistry, idx: u32) Option[*OfVTable] {
     var n: u32 = 0;
     var i: u32 = 0;
     for (i < OF_REGISTRY_CAP) {
-        if (of_registry[i] != nil) {
-            if (n == idx) { ret some[*OfVTable](of_registry[i]); }
+        if (reg.slots[i] != nil) {
+            if (n == idx) { ret some[*OfVTable](reg.slots[i]); }
             n = n + 1;
         }
         i = i + 1;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2657,19 +2657,20 @@ var coff_vtable: of.OfVTable;
 # register_coff: build and install the COFF OfVTable.
 #
 # interns the format name ("coff") and file extension ("obj") into the vtable's
-# string fields, wires the writer/reader, and self-registers it into the
-# process-global OF registry under of.OF_COFF. reentrant: every call re-interns
-# the names against `i`, so a second session (or test) with a different interner
-# is consistent rather than leaving stale ids; `of.register` itself is idempotent.
-# the reader/writer no longer capture an interner — they resolve names through the
-# `interner` each `ObjectImage` carries (and the one passed to parse/dyn-exec) —
-# and relocation kinds are a closed `of.RK_*` enum the writer maps with a plain
-# integer compare. must be invoked at compiler startup before target.select
-# requests a Windows target.
+# string fields, wires the writer/reader, and installs it into `reg` under
+# of.OF_COFF. reentrant: every call re-interns the names against `i`, so a second
+# session (or test) with a different interner is consistent rather than leaving
+# stale ids; `of.register` itself is idempotent. the reader/writer no longer
+# capture an interner — they resolve names through the `interner` each
+# `ObjectImage` carries (and the one passed to parse/dyn-exec) — and relocation
+# kinds are a closed `of.RK_*` enum the writer maps with a plain integer compare.
+# must be invoked at compiler startup before target.select requests a Windows
+# target.
 # ---
+# reg: the object-format registry to install the vtable into
 # i:   string interner used to intern the vtable's string fields
 # ret: true on success, or an error string if name interning fails
-pub fun register_coff(i: *intern.Interner) Result[bool, str] {
+pub fun register_coff(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
     val rn: Result[intern.StrId, str] = intern.intern(i, "coff");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
 
@@ -2684,7 +2685,7 @@ pub fun register_coff(i: *intern.Interner) Result[bool, str] {
     coff_vtable.emit_exec        = coff_emit_exec;
     coff_vtable.emit_dyn_exec    = coff_emit_dyn_exec;
 
-    of.register(?coff_vtable);
+    of.register(reg, ?coff_vtable);
     ret ok[bool, str](true);
 }
 
@@ -2704,10 +2705,11 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
     # register_coff captures `i` as the reader/writer interner and interns the
     # relocation-kind names into it; the kind StrIds resolve against this same
     # interner below.
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
+    val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     # a minimal isa vtable: the writer reads only its `id`.
@@ -2853,10 +2855,11 @@ test "coff: emit rejects a relocation naming an unresolved symbol (#1196)" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
+    val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -2910,10 +2913,11 @@ test "coff: a defined weak symbol round-trips its weak flag through a COMDAT sec
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
+    val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3045,7 +3049,8 @@ test "coff: long section and symbol names round-trip through the string table" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3115,7 +3120,8 @@ test "coff: emit_exec writes a well-formed PE32+ header" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3187,10 +3193,11 @@ test "coff: a function-flagged call-target import round-trips DT_FUNCTION" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
+    val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3263,10 +3270,11 @@ test "coff: parse infers function imports from a foreign object's call relocatio
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
+    val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3340,7 +3348,8 @@ test "coff: emit_exec emits .xdata/.pdata for a canonical x64 prologue" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3597,7 +3606,8 @@ test "coff: emit rejects a relocation whose kind has no COFF machine type (#1256
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3648,10 +3658,11 @@ test "coff: parse rejects a foreign ADDR32 relocation type (#1256)" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
+    val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3713,10 +3724,11 @@ test "coff: emit rejects a section reloc count above the u16 limit (#1256)" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: Option[*of.OfVTable] = of.lookup(of.OF_COFF);
+    val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
     if (!is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3776,7 +3788,8 @@ test "coff: parse rejects a truncated object instead of reading out of bounds (#
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register_coff(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -751,7 +751,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) Result
 # borrowed pointer for the process lifetime.
 var elf_vtable: of.OfVTable;
 
-# register: build the ELF OfVTable and install it into the format registry.
+# register: build the ELF OfVTable and install it into `reg`.
 #
 # interns the format name ("elf") and extension ("o") into the vtable's string
 # fields and registers it under `of.OF_ELF`. reentrant: every call re-interns the
@@ -761,9 +761,10 @@ var elf_vtable: of.OfVTable;
 # `interner` each `ObjectImage` carries — and relocation kinds are a closed
 # `of.RK_*` enum the writer maps with a plain integer compare.
 # ---
+# reg: the object-format registry to install the vtable into
 # i:   interner used to intern the vtable's string fields
 # ret: ok(true) on success, or an allocation error from interning
-pub fun register(i: *intern.Interner) Result[bool, str] {
+pub fun register(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
     val rname: Result[intern.StrId, str] = intern.intern(i, "elf");
     if (is_err[intern.StrId, str](rname)) { ret err[bool, str](unwrap_err[intern.StrId, str](rname)); }
     val rext: Result[intern.StrId, str] = intern.intern(i, "o");
@@ -777,7 +778,7 @@ pub fun register(i: *intern.Interner) Result[bool, str] {
     elf_vtable.emit_exec        = emit_exec;
     elf_vtable.emit_dyn_exec    = emit_dyn_exec;
 
-    of.register(?elf_vtable);
+    of.register(reg, ?elf_vtable);
     ret ok[bool, str](true);
 }
 
@@ -1936,7 +1937,8 @@ test "elf: emit rejects a relocation naming an unresolved symbol (#1196)" {
     var i: intern.Interner = intern.init(?alloc);
 
     # register captures `i` as the writer interner so names resolve against it.
-    val rr: Result[bool, str] = register(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -1988,7 +1990,8 @@ test "elf: emit rejects a relocation whose kind has no ELF machine type (#1256)"
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -2040,7 +2043,8 @@ test "elf: parse rejects an unknown machine relocation type (#1256)" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -2111,7 +2115,8 @@ test "elf: parse rejects a truncated object instead of reading out of bounds (#1
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val rr: Result[bool, str] = register(?i);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register(?of_reg, ?i);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -91,17 +91,17 @@ var macho_vtable: of.OfVTable;
 # register_macho: build and install the Mach-O OfVTable.
 #
 # interns the format name ("macho") and file extension ("o"), fills the vtable,
-# wires the (stub) writer, and self-registers it into the process-global OF
-# registry under of.OF_MACHO. reentrant: every call re-interns the names against
-# `i` so a second session (or test) with a different interner is consistent rather
-# than left with stale ids; `of.register` is itself idempotent. abstract
-# relocation kinds are a closed `of.RK_*` enum, so no per-format kind table is
-# interned. must be invoked at compiler startup before target.select requests a
-# Darwin target.
+# wires the (stub) writer, and installs it into `reg` under of.OF_MACHO.
+# reentrant: every call re-interns the names against `i` so a second session (or
+# test) with a different interner is consistent rather than left with stale ids;
+# `of.register` is itself idempotent. abstract relocation kinds are a closed
+# `of.RK_*` enum, so no per-format kind table is interned. must be invoked at
+# compiler startup before target.select requests a Darwin target.
 # ---
+# reg: the object-format registry to install the vtable into
 # i:   string interner used to intern the vtable's string fields
 # ret: true on success, or an error string if name interning fails
-pub fun register_macho(i: *intern.Interner) Result[bool, str] {
+pub fun register_macho(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
     val rn: Result[intern.StrId, str] = intern.intern(i, "macho");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
 
@@ -117,6 +117,6 @@ pub fun register_macho(i: *intern.Interner) Result[bool, str] {
     # dyld bind/rebase (LC_LOAD_DYLINKER + LC_LOAD_DYLIB) is unimplemented (#1176).
     macho_vtable.emit_dyn_exec    = nil::of.DynExecFn;
 
-    of.register(?macho_vtable);
+    of.register(reg, ?macho_vtable);
     ret ok[bool, str](true);
 }

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -1,10 +1,11 @@
 # mach.lang.target.os: operating-system interface and id registry.
 #
-# Defines the `OsVTable` runtime-dispatch interface backed by a process-global
-# registry, plus the stable numeric `OS_*` ids that drive comptime conditional
-# compilation via `$mach.os.<name>`. Per-OS implementations (linux, darwin,
-# windows) supply the entry-point symbol, syscall layer, and default library
-# directory, and self-register from module init.
+# Defines the `OsVTable` runtime-dispatch interface backed by an `OsRegistry` (a
+# session/driver-owned table of vtables indexed by os id), plus the stable
+# numeric `OS_*` ids that drive comptime conditional compilation via
+# `$mach.os.<name>`. Per-OS implementations (linux, darwin, windows) supply the
+# entry-point symbol, syscall layer, and default library directory, and are
+# installed into a registry at startup.
 
 use std.types.option.Option;
 use std.types.option.some;
@@ -58,71 +59,80 @@ pub rec OsVTable {
 
 val OS_REGISTRY_CAP: u32 = 8;
 
-# process-global write-once registry of OS vtables, indexed by os id. per-OS
-# implementations self-register from module init.
-var os_registry: [8]*OsVTable;
-var os_registry_init: bool = false;
-
-fun ensure_os_registry() {
-    if (os_registry_init) { ret; }
-    var i: u32 = 0;
-    for (i < OS_REGISTRY_CAP) {
-        os_registry[i] = nil;
-        i = i + 1;
-    }
-    os_registry_init = true;
+# OsRegistry: a session/driver-owned table of OS vtables, indexed by os id.
+# bundled into `target.TargetRegistry`; per-OS implementations are installed
+# through `register` at startup. a slot stays nil until its implementation
+# registers.
+# ---
+# slots: vtable pointers indexed by os id (OS_*)
+pub rec OsRegistry {
+    slots: [8]*OsVTable;
 }
 
-# register: install an OS vtable into the process-global registry.
+# registry_init: a fresh OS registry with every slot empty.
+# ---
+# ret: a zeroed OsRegistry
+pub fun registry_init() OsRegistry {
+    var r: OsRegistry;
+    var i: u32 = 0;
+    for (i < OS_REGISTRY_CAP) {
+        r.slots[i] = nil;
+        i = i + 1;
+    }
+    ret r;
+}
+
+# register: install an OS vtable into `reg`.
 #
 # write-once per os id: a second registration for the same id is ignored so
 # the first implementation to initialize wins deterministically.
 # ---
-# vt: the OS vtable to register; its `id` selects the slot
-pub fun register(vt: *OsVTable) {
-    ensure_os_registry();
+# reg: the registry to install into
+# vt:  the OS vtable to register; its `id` selects the slot
+pub fun register(reg: *OsRegistry, vt: *OsVTable) {
     if (vt == nil) { ret; }
     if (vt.id >= OS_REGISTRY_CAP) { ret; }
-    if (os_registry[vt.id] != nil) { ret; }
-    os_registry[vt.id] = vt;
+    if (reg.slots[vt.id] != nil) { ret; }
+    reg.slots[vt.id] = vt;
 }
 
-# lookup: find the OS vtable registered for an os id.
+# lookup: find the OS vtable registered for an os id in `reg`.
 # ---
+# reg:   the registry to read
 # os_id: operating-system id (one of OS_*)
 # ret:   the registered vtable, or none if no implementation is registered
-pub fun lookup(os_id: u32) Option[*OsVTable] {
-    ensure_os_registry();
+pub fun lookup(reg: *OsRegistry, os_id: u32) Option[*OsVTable] {
     if (os_id >= OS_REGISTRY_CAP) { ret none[*OsVTable](); }
-    if (os_registry[os_id] == nil) { ret none[*OsVTable](); }
-    ret some[*OsVTable](os_registry[os_id]);
+    if (reg.slots[os_id] == nil) { ret none[*OsVTable](); }
+    ret some[*OsVTable](reg.slots[os_id]);
 }
 
-# registered_count: the number of OS implementations currently registered.
+# registered_count: the number of OS implementations registered in `reg`.
+# ---
+# reg: the registry to read
 # ret: count of non-empty registry slots
-pub fun registered_count() u32 {
-    ensure_os_registry();
+pub fun registered_count(reg: *OsRegistry) u32 {
     var n: u32 = 0;
     var i: u32 = 0;
     for (i < OS_REGISTRY_CAP) {
-        if (os_registry[i] != nil) { n = n + 1; }
+        if (reg.slots[i] != nil) { n = n + 1; }
         i = i + 1;
     }
     ret n;
 }
 
-# registered: the OS vtable at enumeration index `idx` (0-based, in id order),
-# skipping empty slots. pairs with registered_count to walk the registry.
+# registered: the OS vtable at enumeration index `idx` (0-based, in id order)
+# in `reg`, skipping empty slots. pairs with registered_count to walk the registry.
 # ---
+# reg: the registry to read
 # idx: enumeration index in [0, registered_count)
 # ret: the vtable at that index, or none when idx is out of range
-pub fun registered(idx: u32) Option[*OsVTable] {
-    ensure_os_registry();
+pub fun registered(reg: *OsRegistry, idx: u32) Option[*OsVTable] {
     var n: u32 = 0;
     var i: u32 = 0;
     for (i < OS_REGISTRY_CAP) {
-        if (os_registry[i] != nil) {
-            if (n == idx) { ret some[*OsVTable](os_registry[i]); }
+        if (reg.slots[i] != nil) {
+            if (n == idx) { ret some[*OsVTable](reg.slots[i]); }
             n = n + 1;
         }
         i = i + 1;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -39,16 +39,16 @@ var darwin_vtable: os.OsVTable;
 # register_darwin: build and install the Darwin OsVTable.
 #
 # interns the os name, entry symbol ("_main"), syscall layer, and default
-# library directory, fills the module-level vtable, and self-registers it into
-# the process-global OS registry under os.OS_DARWIN. re-interns the strings into
-# `i` on every call (the registry pointer is idempotent) so a later build with a
-# fresh interner gets consistent ids. must be invoked at startup before
-# target.select requests a Darwin target.
+# library directory, fills the module-level vtable, and installs it into `reg`
+# under os.OS_DARWIN. re-interns the strings into `i` on every call (the registry
+# entry is write-once) so a later build with a fresh interner gets consistent
+# ids. must be invoked at startup before target.select requests a Darwin target.
 # ---
+# reg:   the OS registry to install the vtable into
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields
 # ret:   true on success, or an error string if name interning fails
-pub fun register_darwin(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+pub fun register_darwin(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "darwin");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -73,6 +73,6 @@ pub fun register_darwin(alloc: *Allocator, i: *intern.Interner) Result[bool, str
     darwin_vtable.base_addr      = DARWIN_BASE_ADDR;
     darwin_vtable.page_size      = DARWIN_PAGE_SIZE;
 
-    os.register(?darwin_vtable);
+    os.register(reg, ?darwin_vtable);
     ret ok[bool, str](true);
 }

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -49,16 +49,17 @@ var linux_vtable: os.OsVTable;
 #
 # interns the os name, entry symbol ("_start"), syscall layer, and default
 # library directory, fills the module-level vtable (including the 0x400000 base
-# address and 4096-byte page), and self-registers it into the process-global OS
-# registry under os.OS_LINUX. re-interns the strings into `i` on every call (the
-# registry pointer is idempotent) so a later build with a fresh interner gets
-# consistent ids rather than ones left over from the first. must be invoked at
-# startup before target.select requests a Linux target.
+# address and 4096-byte page), and installs it into `reg` under os.OS_LINUX.
+# re-interns the strings into `i` on every call (the registry entry is
+# write-once) so a later build with a fresh interner gets consistent ids rather
+# than ones left over from the first. must be invoked at startup before
+# target.select requests a Linux target.
 # ---
+# reg:   the OS registry to install the vtable into
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields
 # ret:   true on success, or an error string if name interning fails
-pub fun register_linux(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+pub fun register_linux(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "linux");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -84,6 +85,6 @@ pub fun register_linux(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     linux_vtable.base_addr      = LINUX_BASE_ADDR;
     linux_vtable.page_size      = LINUX_PAGE_SIZE;
 
-    os.register(?linux_vtable);
+    os.register(reg, ?linux_vtable);
     ret ok[bool, str](true);
 }

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -39,16 +39,17 @@ var windows_vtable: os.OsVTable;
 # register_windows: build and install the Windows OsVTable.
 #
 # interns the os name, entry symbol ("mainCRTStartup"), syscall layer, and
-# default library directory, fills the module-level vtable, and self-registers
-# it into the process-global OS registry under os.OS_WINDOWS. re-interns the
-# strings into `i` on every call (the registry pointer is idempotent) so a later
-# build with a fresh interner gets consistent ids. must be invoked at startup
-# before target.select requests a Windows target.
+# default library directory, fills the module-level vtable, and installs it into
+# `reg` under os.OS_WINDOWS. re-interns the strings into `i` on every call (the
+# registry entry is write-once) so a later build with a fresh interner gets
+# consistent ids. must be invoked at startup before target.select requests a
+# Windows target.
 # ---
+# reg:   the OS registry to install the vtable into
 # alloc: backing allocator (reserved for parity with other registrars)
 # i:     string interner used to intern the vtable's string fields
 # ret:   true on success, or an error string if name interning fails
-pub fun register_windows(alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+pub fun register_windows(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
     val rn: Result[intern.StrId, str] = intern.intern(i, "windows");
     if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
@@ -72,6 +73,6 @@ pub fun register_windows(alloc: *Allocator, i: *intern.Interner) Result[bool, st
     windows_vtable.base_addr      = WINDOWS_BASE_ADDR;
     windows_vtable.page_size      = WINDOWS_PAGE_SIZE;
 
-    os.register(?windows_vtable);
+    os.register(reg, ?windows_vtable);
     ret ok[bool, str](true);
 }


### PR DESCRIPTION
Piece 3 of #1285 (split out per that issue's allowance). Pieces 1–2 landed in #1317; this is the pure ownership/cleanliness refactor that remains — the correctness hazard was already removed in #1317.

## What changed
The `isa`/`os`/`abi`/`of` registries were process-global `[8]*XVTable` arrays behind `ensure_*_registry` lazy init. They are now session/driver-owned state:

- **per-dimension registry records**, local to each module to avoid the target↔dimension import cycle: `isa.IsaRegistry`, `os.OsRegistry`, `abi.AbiRegistry`, `of.OfRegistry` — each just the `[8]*XVTable` slot array, with a `registry_init` that zeroes it. `register`/`lookup`/`registered_count`/`registered` now take a `*XRegistry`; the process-global arrays and `ensure_*_registry` helpers are deleted.
- **`target.TargetRegistry`** bundles the four; `target.registry_init` builds a zeroed one.
- **`register_all(reg, i)`** threads `?reg.isa` / `?reg.os` / `?reg.abi` / `?reg.of` into the 10 registrars, which push into the passed registry. **`select(reg, os, arch)`** reads the passed registry.
- **the `Session` owns a `TargetRegistry`**, zeroed in `session.init` (the vtables are still installed by the owner's `register_all` after the by-value return). The driver passes `?p.s.registry` to `select`; `build`/`doc` pass `?s.registry` to `register_all`; `mach info` owns a local registry and threads it through its enumeration.
- the CLI "register_all before select" ordering is now an ordinary init dependency on the owned registry, not a process-global invariant.

The registry holds borrowed pointers to the (still process-global) vtable statics, so it needs no teardown.

## Vtable-singleton note (deferred)
The issue's "note on the vtable singletons" — making the vtable `name`/`file_extension` (and reg-class names) plain `str` so the vtables are truly immutable singletons and `register_all` needs no interner at all — is **not** folded in here. It is a logically distinct concern (vtable struct layout + dropping the interner contract from all 10 registrars, `register_all`, and the three CLI entry points) and keeping it out keeps this PR a focused ownership move. Tracking it as a follow-up.

## Verification
- `mach build .` clean; **strong self-host fixpoint** — stage a == b == c, byte-identical sha256 (`a50b8421…`).
- `mach test .` — 409 passed, 0 failed.
- full integration battery — all 31 `.github/tests/*/run.sh` green, including the win64 suites under wine and the `info` suite.
- `mach build . --target windows` clean (valid PE32+); `mach info` enumerates the owned registry correctly from a project-less dir.

Closes #1319