### PR TITLE
fix(dep): materialize path dependencies

### DIFF
--- a/.github/tests/pathdep/run.sh
+++ b/.github/tests/pathdep/run.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# path-dependency integration test: `mach dep pull` materializes a `[deps.*]` path
+# entry as a relative symlink under `<dep>/<alias>`, the build resolves the dep's
+# modules through it, and the documented failure modes are loud (#1370).
+#
+# the build needs the vendored std, staged as an in-tree symlink (offline); every
+# other "dep" is a plain directory in the work tree, so the suite touches no
+# network. it proves: materialization + build-and-call, no lock entry for a path
+# dep, idempotent re-pull, and the missing-path / missing-manifest / real-directory
+# hard errors.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+if ! command -v ln >/dev/null 2>&1; then
+    echo "error: ln not found on PATH (required by the pathdep suite)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+ok()   { echo "PASS pathdep: $1"; }
+bad()  { echo "FAIL pathdep: $1" >&2; fail=1; }
+has()  { if grep -qF -- "$2" "$3"; then ok "$1"; else bad "$1 (missing: $2)"; fi; }
+hasnt(){ if grep -qF -- "$2" "$3"; then bad "$1 (unexpected: $2)"; else ok "$1"; fi; }
+
+# the library every consumer depends on by path.
+mkdir -p "$WORK/lib-x/src"
+cat > "$WORK/lib-x/mach.toml" <<'TOML'
+[project]
+id      = "libx"
+version = "0.1.0"
+src     = "src"
+
+[lib.libx]
+entry = "lib.mach"
+TOML
+printf 'pub fun answer() i64 { ret 42; }\n' > "$WORK/lib-x/src/lib.mach"
+
+# scaffold a fresh app that depends on lib-x by path; std is staged in place so the
+# offline pull's in-tree std path dep is a no-op.
+scaffold_app() {
+    local dir="$1"
+    mkdir -p "$dir/src" "$dir/dep"
+    cat > "$dir/mach.toml" <<'TOML'
+[project]
+id      = "app"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.app]
+entry = "main.mach"
+
+[profile.debug]
+opt = 0
+
+[deps.mach-std]
+path = "dep/mach-std"
+
+[deps.libx]
+path = "../lib-x"
+TOML
+    cat > "$dir/src/main.mach" <<'TOML'
+use std.runtime;
+use libx.lib.answer;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret answer();
+}
+TOML
+    ln -s "$STD" "$dir/dep/mach-std"
+}
+
+OUT="$WORK/out.txt"
+
+# --- materialize: pull links the path dep, no lock entry -----------------------
+APP="$WORK/app"; scaffold_app "$APP"
+( cd "$APP" && "$MACH" dep pull ) >"$OUT" 2>&1 || bad "pull exited nonzero"
+[ -L "$APP/dep/libx" ] && ok "pull materializes the path dep as a symlink" || bad "pull did not create the dep/libx symlink"
+[ -f "$APP/dep/libx/mach.toml" ] && ok "the symlink resolves to the lib's tree" || bad "dep/libx/mach.toml not reachable through the link"
+if [ -f "$APP/mach.lock" ]; then
+    hasnt "a path dep carries no lock entry" "[deps.libx]" "$APP/mach.lock"
+else
+    ok "a path dep carries no lock entry"
+fi
+
+# --- build: the app resolves the dep's modules through the symlink -------------
+( cd "$APP" && "$MACH" build . ) >"$OUT" 2>&1 || bad "build through the symlink failed"
+BIN="$APP/out/linux/debug/bin/app"
+if [ -x "$BIN" ]; then
+    set +e; "$BIN"; got=$?; set -e
+    [ "$got" -eq 42 ] && ok "the built app calls into the path dep (exit 42)" || bad "app exit $got, expected 42"
+else
+    bad "app binary not produced at $BIN"
+fi
+
+# --- idempotent: a second pull keeps the link and builds -----------------------
+( cd "$APP" && "$MACH" dep pull ) >"$OUT" 2>&1 || bad "re-pull exited nonzero"
+[ -L "$APP/dep/libx" ] && ok "re-pull leaves the symlink in place" || bad "re-pull lost the symlink"
+( cd "$APP" && "$MACH" build . ) >"$OUT" 2>&1 && [ -x "$BIN" ] && ok "the app still builds after re-pull" || bad "build after re-pull failed"
+
+# --- error: a path pointing at a missing directory -----------------------------
+MISS="$WORK/miss"; mkdir -p "$MISS"
+printf '[project]\nid = "miss"\n\n[deps.libx]\npath = "../nope"\n' > "$MISS/mach.toml"
+if ( cd "$MISS" && "$MACH" dep pull ) >"$OUT" 2>&1; then bad "a missing path dep did not fail"; else ok "a missing path dep is a hard error"; fi
+has "the missing-path error names the directory" "points at a missing directory" "$OUT"
+
+# --- error: a path with no mach.toml -------------------------------------------
+NOM="$WORK/nomanifest"; mkdir -p "$NOM" "$WORK/bare/src"
+printf '[project]\nid = "nm"\n\n[deps.libx]\npath = "../bare"\n' > "$NOM/mach.toml"
+if ( cd "$NOM" && "$MACH" dep pull ) >"$OUT" 2>&1; then bad "a path dep without a manifest did not fail"; else ok "a path dep without mach.toml is a hard error"; fi
+has "the no-manifest error names the cause" "has no mach.toml" "$OUT"
+
+# --- error: a real directory squatting the vendor location ---------------------
+SQ="$WORK/squat"; mkdir -p "$SQ/dep/libx/src"
+printf '[project]\nid = "sq"\ndep = "dep"\n\n[deps.libx]\npath = "../lib-x"\n' > "$SQ/mach.toml"
+printf '[project]\nid = "stale"\n' > "$SQ/dep/libx/mach.toml"
+if ( cd "$SQ" && "$MACH" dep pull ) >"$OUT" 2>&1; then bad "a real dir at the vendor location did not fail"; else ok "a real dir at the vendor location is a hard error"; fi
+has "the real-dir error names the path-dep link" "is a real directory" "$OUT"
+
+exit "$fail"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `mach dep pull` now materialises a `path` dependency at `<dep>/<alias>/` as a
+  relative symlink to the resolved source instead of silently doing nothing —
+  previously it printed "mach.lock up to date", exited 0, and never created the
+  dep directory, so any later build failed to resolve the dep's modules. The
+  `path` is resolved relative to the requiring manifest's directory; a stale link
+  is replaced and an already-correct one left in place (idempotent), while a
+  missing directory, a directory without a `mach.toml`, or a vendor location
+  occupied by a real directory is a hard error. A path dep carries no lock entry —
+  its manifest `path` is the record (#1370).
 - Sema reports a teaching diagnostic for every symbol kind that can never be a
   value reaching value position — a record, union, or `def` type name (local
   or imported, bare or `alias.member`), a generic type parameter, and a member

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -202,12 +202,13 @@ mach dep <action> [args]
 
 Manages the project's dependency tree under `<dep>`. Dispatches on `argv[2]`.
 A dependency has exactly one source form: a **git** URL plus a ref, which mach
-acquires into `<dep>/<name>/` with plain git operations, or a **path** into
-the project's own tree, which is never fetched.
+acquires into `<dep>/<name>/` with plain git operations, or a **path** to another
+project tree, never fetched but materialised at `<dep>/<name>/` as a relative
+symlink so the build resolves it by the same vendor layout.
 
 | Action   | Args | Effect |
 |----------|------|--------|
-| `pull`   | — | realise the manifest: clone missing git deps (transitively), re-resolve a changed ref, repair checkout-vs-lock drift, write `mach.lock`. Idempotent; the command routine use needs. |
+| `pull`   | — | realise the manifest: clone missing git deps (transitively), link path deps, re-resolve a changed ref, repair checkout-vs-lock drift, write `mach.lock`. Idempotent; the command routine use needs. |
 | `update` | `<name> \| --all` | the only lock-advancer: re-resolve branch refs to current remote tips. Tag/commit refs are an immutable no-op. Never edits the manifest. |
 | `add`    | `<name> --git <url> [--ref <ref>] \| --path <dir>` | append a `[deps.<name>]` `git`/`path` stanza to the manifest, then `pull`. |
 | `remove` | `<name> [--purge]` | drop the entry from `mach.toml` and `mach.lock`; `--purge` also deletes `<dep>/<name>/`. |
@@ -243,6 +244,17 @@ counts as a checkout.) An **empty** directory has nothing to vendor and is treat
 as absent — `pull` clones into it — so a plain `git clone` (without
 `--recurse-submodules`), which leaves a submodule dep dir empty, is repaired by a
 plain `mach dep pull` (#1329).
+
+For each **path** dependency, `pull` materialises the source at `<dep>/<name>/` as
+a relative symlink, so the build resolves its modules by the same vendor layout as
+a git dep. The `path` is resolved relative to the requiring manifest's directory;
+the link is relative, so a tree that moves as a whole (a monorepo, a committed
+examples dir) stays linked without a re-pull. The step is idempotent: a stale link
+is replaced, an already-correct link is left in place, and a source that already
+lives at the vendor location (in-tree vendoring) is a no-op. A `path` pointing at a
+missing directory, a directory without a `mach.toml`, or a vendor location occupied
+by a real directory (a stale git checkout, foreign vendored files) is a hard error
+— never silent success (#1370).
 
 ### Transitive resolution
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -165,13 +165,22 @@ A stanza declares exactly one source key:
 | Key    | Type   | Read by    | Meaning |
 |--------|--------|------------|---------|
 | `git`  | string | `mach dep` | Git URL to clone into `<dep>/<alias>/`. |
-| `path` | string | `mach dep` | Local path into the project's own tree; never fetched. |
+| `path` | string | `mach dep` | Local path to another project tree, resolved relative to this manifest's directory; never fetched. `mach dep pull` materialises it at `<dep>/<alias>/` as a relative symlink to the resolved source, so the build reaches its modules by the same vendor layout as a git dep. |
 | `ref`  | string | `mach dep` | Git ref to check out (with `git`): a `tag/<name>`, `branch/<name>`, bare tag/branch, or commit SHA. An absent ref means the remote default branch. |
 
 A registry-style `version =` is reserved and rejected. Cloning, lockfile
 handling, and transitive resolution are documented in [cli.md](cli.md#mach-dep).
 `mach dep` performs only plain git operations, so a checkout the user also commits
 as a **submodule** composes naturally; mach never invokes `git submodule`.
+
+A **git** dep is pinned to a resolved commit in `mach.lock`; a **path** dep has no
+pinned content, so it carries no lock entry — its `path` in the manifest is the
+whole record. `mach dep pull` materialises a path dep at `<dep>/<alias>/` as a
+relative symlink to the resolved source and is idempotent: a stale link is
+replaced, an already-correct one is left untouched, and a source that already
+lives at the vendor location is a no-op. A path that does not exist, that holds no
+`mach.toml`, or whose vendor location is occupied by a real directory (a stale git
+checkout, foreign vendored files) is a hard error — never silent success.
 
 ### Cascading link requirements
 

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -9,9 +9,11 @@
 #
 # a dependency stanza `[deps.<name>]` has exactly one source key: a `git` url plus
 # an optional `ref`, which mach acquires into `dep/<name>/` with plain git
-# operations (submodule-compatible, never `git submodule`), or a `path` pointing
-# into the project's own tree, which is never fetched. git is the only fetch
-# transport: `mach build` never needs it, but the network-shaped commands here do.
+# operations (submodule-compatible, never `git submodule`), or a `path` pointing at
+# a local project tree, never fetched but materialized at `dep/<name>/` as a
+# relative symlink so the build resolves it by the same vendor layout. git is the
+# only fetch transport: `mach build` never needs it, but the network-shaped
+# commands here do.
 # transitive deps resolve into the flat dep tree; the same name required from two
 # different sources/refs is a hard error.
 
@@ -214,7 +216,8 @@ pub fun pull_project(root: str, quiet: bool) i64 {
     }
     var mt: toml.Table = unwrap_ok[toml.Table, str](tr);
 
-    val dep_root_r: Result[str, str] = join2(?alloc, root, dep_dir_name(?mt)::*u8);
+    val dep_name: str = dep_dir_name(?mt);
+    val dep_root_r: Result[str, str] = join2(?alloc, root, dep_name::*u8);
     if (is_err[str, str](dep_root_r)) { print.eprint("error: out of memory\n"); ret 2; }
     val dep_root: str = unwrap_ok[str, str](dep_root_r);
 
@@ -253,13 +256,8 @@ pub fun pull_project(root: str, quiet: bool) i64 {
             if (rc != 0) { ret rc; }
         }
         or {
-            if (!fs.exists(nv.data[i].dir)) {
-                print.eprint("warning: path dependency '");
-                print.eprint(nv.data[i].name);
-                print.eprint("' points at a missing directory: ");
-                print.eprint(nv.data[i].path);
-                print.eprint("\n");
-            }
+            val rc: i64 = materialize_path_node(?alloc, ?nv.data[i], dep_root, dep_name, quiet);
+            if (rc != 0) { ret rc; }
         }
 
         # descend into the dep's own manifest to grow the flat tree transitively.
@@ -378,6 +376,144 @@ fun process_git_node(alloc: *Allocator, gt: *GitTool, node: *DepNode, dep_root: 
         print.print("\n");
     }
     ret 0;
+}
+
+# materialize_path_node: realize one path dependency at its flat-tree vendor
+# location `<dep_root>/<name>` as a symlink to the resolved source `node.dir`, so
+# the build (which resolves every dep purely by vendor layout) reaches the dep's
+# modules through it. the source must exist and carry a mach.toml — a missing
+# directory or manifest is a hard error, never silent success (#1370). a path that
+# already resolves to the vendor location (in-tree vendoring, `path = "<dep>/<name>"`)
+# is left as is. a real directory squatting the vendor location (a stale git
+# checkout, foreign vendored files) is a hard error rather than a clobber; a prior
+# symlink is replaced, so re-pull is idempotent. path deps carry no lock entry: the
+# manifest's `path` is the record.
+fun materialize_path_node(alloc: *Allocator, node: *DepNode, dep_root: str, dep_name: str, quiet: bool) i64 {
+    if (!fs.exists(node.dir)) {
+        print.eprint("error: path dependency '");
+        print.eprint(node.name);
+        print.eprint("' points at a missing directory: ");
+        print.eprint(node.path);
+        print.eprint("\n");
+        ret 1;
+    }
+    val mp_r: Result[str, str] = join2(alloc, node.dir, MANIFEST);
+    if (is_err[str, str](mp_r)) { print.eprint("error: out of memory\n"); ret 2; }
+    if (!fs.exists(unwrap_ok[str, str](mp_r))) {
+        print.eprint("error: path dependency '");
+        print.eprint(node.name);
+        print.eprint("' has no mach.toml: ");
+        print.eprint(node.path);
+        print.eprint("\n");
+        ret 1;
+    }
+
+    val v_r: Result[str, str] = join2(alloc, dep_root, node.name::*u8);
+    if (is_err[str, str](v_r)) { print.eprint("error: out of memory\n"); ret 2; }
+    val vendor: str = unwrap_ok[str, str](v_r);
+
+    # in-tree vendoring: the source already lives at the vendor location.
+    if (str_equals(node.dir, vendor)) { ret 0; }
+
+    fs.create_dir_all(alloc, dep_root, 0o755);
+    val pre_exists: bool = fs.exists(vendor);
+
+    # drop a stale symlink (its target may have moved); a real directory here is a
+    # hard error — unlink leaves a directory intact (EISDIR), so it remains a dir.
+    fs.unlink(vendor);
+    if (fs.is_dir(vendor)) {
+        print.eprint("error: ");
+        print.eprint(vendor);
+        print.eprint(" is a real directory, not a path-dependency link; remove it (e.g. `mach dep remove ");
+        print.eprint(node.name);
+        print.eprint(" --purge`) and re-pull\n");
+        ret 1;
+    }
+
+    val target_r: Result[str, str] = link_target(alloc, dep_name, node.dir);
+    if (is_err[str, str](target_r)) { print.eprint("error: out of memory\n"); ret 2; }
+    val target: str = unwrap_ok[str, str](target_r);
+    if (is_err[bool, str](make_symlink(alloc, target, vendor))) {
+        print.eprint("error: failed to link ");
+        print.eprint(vendor);
+        print.eprint(" -> ");
+        print.eprint(target);
+        print.eprint("\n");
+        ret 2;
+    }
+    if (!quiet && !pre_exists) {
+        print.print("linked ");
+        print.print(node.name);
+        print.print(" -> ");
+        print.print(node.path);
+        print.print("\n");
+    }
+    ret 0;
+}
+
+# link_target: the symlink target for a path dependency — a relative path from the
+# vendor location `<dep_root>/<name>` back to the resolved source `src` (expressed
+# relative to the project root). the symlink sits one directory below the project
+# root per path segment of the dep dir, so the target climbs that many `..` before
+# applying the source path. a relative target keeps a tree that moves as a whole (a
+# monorepo, a committed examples dir) linked without a re-pull. errors only on a
+# failed allocation.
+fun link_target(alloc: *Allocator, dep_name: str, src: str) Result[str, str] {
+    val depth: usize = path_segments(dep_name);
+    val sl: usize = str_len(src);
+    val r: Result[*u8, str] = allocate[u8](alloc, depth * 3 + sl + 1);
+    if (is_err[*u8, str](r)) { ret err[str, str](unwrap_err[*u8, str](r)); }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    var d: usize = 0;
+    for (d < depth) {
+        buf[k] = '.'::u8; buf[k + 1] = '.'::u8; buf[k + 2] = '/'::u8;
+        k = k + 3; d = d + 1;
+    }
+    k = put_n(buf, k, src::*u8, sl);
+    buf[k] = 0;
+    ret ok[str, str](buf::str);
+}
+
+# path_segments: the number of real path components in a `/`-separated path,
+# ignoring empty (`//`, leading/trailing `/`) and `.` components — the climb depth
+# from a `<dep>/<name>` link back to the project root.
+fun path_segments(s: str) usize {
+    val n: usize = str_len(s);
+    var count: usize = 0;
+    var i: usize = 0;
+    for (i < n) {
+        if (s[i] == '/'::u8) { i = i + 1; cnt; }
+        val start: usize = i;
+        for (i < n && s[i] != '/'::u8) { i = i + 1; }
+        if (!(i - start == 1 && s[start] == '.'::u8)) { count = count + 1; }
+    }
+    ret count;
+}
+
+# make_symlink: create a symbolic link at `linkpath` pointing at `target` by
+# shelling to `ln -s`. resolution already shells to system git/rm; reusing `ln`
+# avoids a hand-rolled symlinkat across every host os. the caller has cleared any
+# prior link, so no `-f` is needed. ln's absence is a clean error.
+fun make_symlink(alloc: *Allocator, target: str, linkpath: str) Result[bool, str] {
+    val ln_r: Result[str, str] = find_on_path(alloc, "ln");
+    if (is_err[str, str](ln_r)) { ret err[bool, str]("ln not found on PATH (needed to materialize path dependencies)"); }
+    val ln: str = unwrap_ok[str, str](ln_r);
+    val env_r: Result[**u8, str] = build_env(alloc);
+    if (is_err[**u8, str](env_r)) { ret err[bool, str]("failed to build child environment for ln"); }
+    val env: **u8 = unwrap_ok[**u8, str](env_r);
+
+    var argv: [5]usize;
+    argv[0] = ln::usize;
+    argv[1] = "-s"::usize;
+    argv[2] = target::usize;
+    argv[3] = linkpath::usize;
+    argv[4] = 0;
+    val rr: Result[exec.ExitStatus, str] = exec.run(ln, (?argv[0])::**u8, env);
+    if (is_err[exec.ExitStatus, str](rr)) { ret err[bool, str]("failed to spawn ln"); }
+    val s: exec.ExitStatus = unwrap_ok[exec.ExitStatus, str](rr);
+    if (!exec.exited(s) || exec.code(s) != 0) { ret err[bool, str]("ln exited non-zero"); }
+    ret ok[bool, str](true);
 }
 
 # git_fail: the generic per-dep git failure exit, naming the dependency.
@@ -1577,5 +1713,29 @@ test "dep: ref_advanceable advances branches and the default, freezes tags/commi
     if (ref_advanceable("tag/v1.0.0")) { ret 1; }
     if (ref_advanceable("commit/abcdef0")) { ret 1; }
     if (ref_advanceable("0123456789abcdef0123456789abcdef01234567")) { ret 1; }
+    ret 0;
+}
+
+test "dep: path_segments counts real components, ignoring empty and '.' (#1370)" {
+    if (path_segments("dep") != 1)         { ret 1; }
+    if (path_segments("vendor/deps") != 2) { ret 1; }
+    if (path_segments("./dep") != 1)       { ret 1; }
+    if (path_segments("a//b") != 2)        { ret 1; }
+    if (path_segments("") != 0)            { ret 1; }
+    if (path_segments("/") != 0)           { ret 1; }
+    ret 0;
+}
+
+test "dep: link_target climbs the dep dir, then applies the source path (#1370)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    # the vendor location sits one dir below the root for a single-segment dep dir.
+    val t1: Result[str, str] = link_target(?alloc, "dep", "./../lib-x");
+    if (is_err[str, str](t1)) { ret 1; }
+    if (!str_equals(unwrap_ok[str, str](t1), ".././../lib-x")) { ret 1; }
+    # a two-segment dep dir climbs twice.
+    val t2: Result[str, str] = link_target(?alloc, "a/b", "x");
+    if (is_err[str, str](t2)) { ret 1; }
+    if (!str_equals(unwrap_ok[str, str](t2), "../../x")) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Closes #1370

`mach dep pull` silently ignored a `[deps.*]` path entry — it printed "mach.lock up to date", exited 0, and never created `dep/<alias>/`, so any subsequent build failed to resolve the dep's modules. mach-gl's examples/demo only built after a hand-symlink.

## Change

`pull` now **materializes** a path dep at `<dep>/<alias>/` as a **relative symlink** to the resolved source, so the build reaches its modules by the same vendor layout as a git dep. The `path` is resolved relative to the requiring manifest's directory; the link is relative so a tree that moves as a whole stays linked without a re-pull.

## Lock semantics

A git dep pins a resolved commit in `mach.lock`; a path dep has no pinned content, so it carries **no lock entry** — its manifest `path` is the record. This matches the existing lock writer, which already serialized only git nodes. `pull` stays idempotent: the lock is untouched for a path-only manifest.

## Behavior covered

- **Materialize + build-and-call**: the app resolves the lib's modules through the symlink and runs (exit 42).
- **Idempotent re-pull**: a stale link is replaced, an already-correct one left in place, an in-tree source already at the vendor location is a no-op.
- **Nested deps**: a path dep's own deps resolve into the flat tree like any git dep (existing loop).
- **Hard errors, never silent success**: missing directory, directory without a `mach.toml`, and a real directory squatting the vendor location each fail loudly and name the cause.

## Tests / docs

- New integration suite `.github/tests/pathdep/run.sh` (auto-discovered by CI): two scaffolded projects, materialization, build-and-call, no-lock-entry, idempotent re-pull, and the three error cases — fully offline.
- Corpus unit tests for the relative-link math (`path_segments`, `link_target`).
- `doc/manifest.md` and `doc/cli.md` document materialization and the lock choice; CHANGELOG under Fixed.