### PR TITLE
fix: nil coerces to fun types and folds in global initialisers (#1369)

### DIFF
--- a/.github/tests/nilfun/fold/mach.toml
+++ b/.github/tests/nilfun/fold/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "nilfunfold"
+name = "Nil into fun — explicit nil-init of fun-typed globals folds (#1369)"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.nilfunfold]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/nilfun/fold/src/main.mach
+++ b/.github/tests/nilfun/fold/src/main.mach
@@ -1,0 +1,39 @@
+use std.runtime;
+
+def F: fun(u32);
+
+# facet 1 (#1369): a fun-typed global explicitly nil-initialised. before the fix
+# nil did not coerce to a fun type, so this was rejected with
+# "type mismatch: expected fun(u32), found *u8" and only default-init worked.
+pub var glClear: fun(u32) = nil;
+
+# facet 2 (#1369): `nil::F` in a global initialiser. before the fix the cast over
+# nil was not const-foldable, so this was rejected with
+# "global initialiser of `glKey` must be a constant expression".
+pub var glKey: F = nil::F;
+
+var hits: u32 = 0;
+fun cb(x: u32) { hits = hits + x; }
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # both globals start as the null address.
+    if (glClear != nil) { ret 1; }
+    if (glKey != nil) { ret 2; }
+
+    # assign a real function and call through, then clear with bare nil and the
+    # `nil::F` cast spelling — both must round-trip back to the null address.
+    glClear = cb;
+    if (glClear == nil) { ret 3; }
+    glClear(40);
+    glClear = nil::fun(u32);
+    if (glClear != nil) { ret 4; }
+
+    glKey = cb;
+    glKey(2);
+    glKey = nil;
+    if (glKey != nil) { ret 5; }
+
+    if (hits != 42) { ret 6; }
+    ret 0;
+}

--- a/.github/tests/nilfun/reject/mach.toml
+++ b/.github/tests/nilfun/reject/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "nilfunreject"
+name = "Nil into fun — nil into a non-pointer global is rejected (#1369)"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.nilfunreject]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/nilfun/reject/src/main.mach
+++ b/.github/tests/nilfun/reject/src/main.mach
@@ -1,0 +1,10 @@
+use std.runtime;
+
+# nil is the null address and coerces only to pointer-like types (a raw `ptr`, a
+# typed `*T`, or a `fun(...)`). a non-pointer global initialised from nil must
+# still be rejected with a located type-mismatch diagnostic, so the relaxation
+# for fun types does not widen nil into arbitrary scalar slots.
+pub var bad: u32 = nil;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/nilfun/run.sh
+++ b/.github/tests/nilfun/run.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Explicit nil-init of fun-typed globals (#1369). nil is the null address and now
+# coerces to any pointer-like type, function types included, in every position.
+# Two halves:
+#
+#   fold — a fun-typed global initialised from nil, both bare (`= nil`) and
+#   through the cast spelling (`= nil::F`), must compile and start null, and the
+#   global must round-trip through a real function assignment, a call, and a
+#   clear back to null. before #1369 the bare form failed sema with
+#   "type mismatch: expected fun(u32), found *u8" and the cast form failed
+#   lowering with "global initialiser must be a constant expression"; only
+#   default-init worked. The app exits 0 only when every assertion holds.
+#
+#   reject — nil into a non-pointer global (a `u32`) must still fail the build
+#   with a located type-mismatch diagnostic, proving the relaxation admits only
+#   pointer-like targets, not arbitrary scalars.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# vendor <app-dir>: copy the app into the temp dir and symlink the vendored std.
+vendor() {
+    local app="$1"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+}
+
+# build_and_run <app-dir> <expected-exit>: build the app, run the binary, and
+# require the build to succeed and the run to exit with the expected code.
+build_and_run() {
+    local app="$1"; local want="$2"
+    vendor "$app"
+    local dst="$WORK/$app"
+    if ! ( cd "$dst" && "$MACH" build . ) >/dev/null 2>&1; then
+        echo "FAIL nilfun/$app: build failed" >&2; fail=1; return
+    fi
+    local bin
+    bin="$(find "$dst/out" -type f -path '*/bin/*' | head -n1)"
+    if [ -z "$bin" ]; then
+        echo "FAIL nilfun/$app: no binary produced" >&2; fail=1; return
+    fi
+    set +e
+    "$bin"; local code=$?
+    set -e
+    if [ "$code" -ne "$want" ]; then
+        echo "FAIL nilfun/$app: ran with exit $code, expected $want" >&2; fail=1; return
+    fi
+    echo "PASS nilfun/$app: fun-typed global nil-inits (bare and nil::F) fold, start null, and round-trip"
+}
+
+# expect_reject <app-dir>: build the app and require the build to FAIL with a
+# located type-mismatch diagnostic (file:line:col on main.mach).
+expect_reject() {
+    local app="$1"
+    vendor "$app"
+    local dst="$WORK/$app"
+    local out
+    if out="$( cd "$dst" && "$MACH" build . 2>&1 )"; then
+        echo "FAIL nilfun/$app: build unexpectedly succeeded for nil into a non-pointer global" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF -- 'type mismatch'; then
+        echo "FAIL nilfun/$app: diagnostic missing 'type mismatch'; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qE 'main\.mach:[0-9]+:[0-9]+:'; then
+        echo "FAIL nilfun/$app: diagnostic missing file:line:col; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    echo "PASS nilfun/$app: nil into a non-pointer global is rejected with a located diagnostic"
+}
+
+build_and_run fold 0
+expect_reject reject
+
+exit "$fail"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `nil` coerces to function types, so a fun-typed binding can be explicitly
+  nil-initialised, not only default-initialised. Previously `var q: fun(u32) =
+  nil` was rejected with `type mismatch: expected fun(u32), found *u8` and the
+  cast spelling `var r: F = nil::F` failed lowering with `global initialiser
+  must be a constant expression`, even though a fun-typed value already compares
+  `== nil` and `nil::F` was accepted in argument position. nil now coerces to
+  any pointer-like target — `ptr`, `*T`, or `fun(...)` — uniformly across
+  globals, locals, record fields, array elements, arguments, and return slots,
+  and a nil global initialiser (bare or written through pointer casts) folds to
+  the null constant. nil into a non-pointer slot remains a type error (#1369).
 - Sema reports a teaching diagnostic for every symbol kind that can never be a
   value reaching value position — a record, union, or `def` type name (local
   or imported, bare or `alias.member`), a generic type parameter, and a member

--- a/doc/language/literals.md
+++ b/doc/language/literals.md
@@ -43,14 +43,22 @@ long content uses `\n` escapes or lives in external files.
 ## `nil`
 
 The `nil` keyword is the null-address literal. With no context it types as
-`*u8`; it coerces to any pointer type. It is not assignable to a function
-type — function/`nil` relationships are expressed through `==` / `!=`
-comparison, not assignment.
+`*u8`; it coerces to any pointer-like type — a raw `ptr`, a typed `*T`, or a
+function type `fun(...)` (a function value is a code address, so the null
+address is a valid null callback). The coercion is uniform across every
+position a value flows into: globals, locals, record fields, array elements,
+call arguments, and return slots.
 
 ```mach
+def F: fun(u32);
 var p: *i64 = nil;          # null pointer
-val absent: u8 = p == nil;  # nil compares against any pointer
+var cb: fun(u32) = nil;     # null function pointer
+var k:  F = nil::F;         # the cast spelling works too
+val absent: u8 = p == nil;  # nil compares against any pointer-like value
 ```
+
+nil coerces only to pointer-like targets; assigning it to a non-pointer slot
+(`var x: u32 = nil;`) is a type error.
 
 ## Backticks
 

--- a/doc/language/operators.md
+++ b/doc/language/operators.md
@@ -39,8 +39,9 @@ values**, so the result is identical in either operand order:
 - **integer vs float** — a compile error; cast one operand explicitly with
   `::`. An implicit widening would hide `f64` rounding above `2^53`.
 
-A pointer may be compared against `nil` (the null-address literal). On the
-planned SIMD vectors, comparison produces a mask vector (lane-wise).
+A pointer-like value — a pointer or a function — may be compared against `nil`
+(the null-address literal). On the planned SIMD vectors, comparison produces a
+mask vector (lane-wise).
 
 ## Logical
 

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1187,3 +1187,51 @@ test "resolve: a standalone bare $ident gate is rejected with the teaching diagn
     sess.dnit(?s);
     ret 0;
 }
+
+test "sema: nil coerces to fun types in every position (#1369)" {
+    var alloc: Allocator;
+    val srr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](srr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](srr);
+    var es: EditorSession = init(?s);
+
+    # nil is the null address and takes any pointer-like type, function types
+    # included. it must coerce uniformly into a fun-typed global (bare and
+    # `nil::F`), a local, a record field, an argument, and a return slot, and an
+    # `== nil` comparison must still type. none of these may report a mismatch.
+    val fr: Result[src.FileId, str] = open(?es, "nilfun.mach",
+        "def F: fun(u32);\npub var gq: fun(u32) = nil;\npub var gr: F = nil::F;\nrec T { cb: fun(); k: F; }\nfun take(c: fun(u32)) u8 { if (c == nil) { ret 1; } ret 0; }\nfun give() fun(u32) { ret nil; }\nfun givec() F { ret nil::F; }\nfun main() i64 { var lq: fun(u32) = nil; var lr: F = nil::F; var t: T = T{ cb: nil, k: nil::F }; if (gq != nil) { ret 1; } if (lr != nil) { ret 2; } if (t.k != nil) { ret 3; } ret take(lq)::i64; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag_has(unwrap_ok[*diag.DiagList, str](dr), "type mismatch")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: nil into a non-pointer binding is still rejected (#1369)" {
+    var alloc: Allocator;
+    val srr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](srr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](srr);
+    var es: EditorSession = init(?s);
+
+    # the coercion admits only pointer-like targets; nil into an integer slot is
+    # still a mismatch, so widening nil to a non-address type stays an error.
+    val fr: Result[src.FileId, str] = open(?es, "nilint.mach",
+        "fun main() i64 { var bad: u32 = nil; ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "type mismatch")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -9,8 +9,9 @@
 # `try_coerce_literal` retypes a literal expression to a requested
 # destination type when the literal can legally take that type (an integer
 # literal to any integer the value fits, a float literal to f32/f64, a nil
-# literal to any pointer), rewriting the expression's entry in the parallel
-# `expr_type` array so downstream phases observe the coerced type.
+# literal to any pointer-like type — `ptr`, `*T`, or `fun(...)`), rewriting
+# the expression's entry in the parallel `expr_type` array so downstream
+# phases observe the coerced type.
 # `is_assignable` is identity-only: two types are assignable iff their
 # interned `TypeId`s are equal. the type interner canonicalizes every
 # compound type (pointers, arrays, nominals, instances) so identity of
@@ -60,7 +61,7 @@ use sema:     mach.lang.fe.sema.context;
 #     literal's value (range-checked against the destination width and
 #     signedness)
 #   - float literal -> f32 or f64
-#   - nil literal -> any pointer type (raw `ptr` or `*T`)
+#   - nil literal -> any pointer-like type (raw `ptr`, `*T`, or `fun(...)`)
 #   - unary -/~ over a coercible operand -> the coerced operand type
 #   - binary arithmetic/bitwise over coercible operands -> the coerced type
 # ---
@@ -97,11 +98,12 @@ fun coerce_to(sc: *sema.SemaContext, eid: id.ExprId, to: ty.TypeId, negated: boo
         ret commit(sc, eid, to);
     }
     if (e.kind == expr.EXPR_KIND_LIT_NIL) {
-        # nil is the null address; it takes any pointer type. it is NOT
-        # assignable to a function type — cmach `type_can_assign_to` relates
-        # only `ptr`<->`*T`. `fn == nil` / `fn != nil` are handled as
-        # comparisons in `infer_binary`, not via assignability.
-        if (!is_pointer(sc, to)) { ret none[ty.TypeId](); }
+        # nil is the null address; it takes any pointer-like type — a raw `ptr`,
+        # a typed `*T`, or a `fun(...)` (a function value is a code address, so
+        # the null address is a valid null callback). `fn == nil` / `fn != nil`
+        # are still related as comparisons in `infer_binary`, independently of
+        # this coercion.
+        if (!ty.is_pointer_like(?sc.s.types, to)) { ret none[ty.TypeId](); }
         ret commit(sc, eid, to);
     }
     if (e.kind == expr.EXPR_KIND_COMPTIME_IDENT || e.kind == expr.EXPR_KIND_MEMBER) {
@@ -250,14 +252,4 @@ fun int_literal_fits(sc: *sema.SemaContext, v: u64, to: ty.TypeId, negated: bool
     if (k == ty.TYPE_I32) { ret v <= 0x7FFFFFFF; }
     if (k == ty.TYPE_I64) { ret v <= 0x7FFFFFFFFFFFFFFF; }
     ret false;
-}
-
-# reports whether `t` is a pointer type — either the raw `ptr` primitive or
-# an interned `*T` pointer. reads the kind, so it does not depend on a
-# primitive's TypeId equaling its kind ordinal.
-fun is_pointer(sc: *sema.SemaContext, t: ty.TypeId) bool {
-    val to_opt: Option[*ty.Type] = ty.get(?sc.s.types, t);
-    if (is_none[*ty.Type](to_opt)) { ret false; }
-    val k: ty.TypeKind = unwrap[*ty.Type](to_opt).kind;
-    ret k == ty.TYPE_PTR || k == ty.TYPE_POINTER;
 }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -434,9 +434,10 @@ fun infer_binary(sc: *sema.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, spa
 
     if (b.op == expr.BIN_EQ || b.op == expr.BIN_NEQ) {
         # equality also relates two address-shaped operands (pointers and
-        # functions, both runtime code/data addresses). this covers `fn == nil`
-        # / `fn != nil`, where `nil` types as `*u8`, without permitting nil to
-        # be assignable to a function type.
+        # functions, both runtime code/data addresses). this covers a bare
+        # `fn == fn2` where neither side is a coercible literal; a comparison
+        # against `nil` instead coerces nil to the function type first (see
+        # `coerce`), so it arrives here already address-typed on both sides.
         if (int_float_mix) { report_int_float_cmp(sc, span); ret type.TYPE_ERROR; }
         val addr_ok: bool = is_pointer_like(sc, lt) && is_pointer_like(sc, rt);
         if (!operands_ok && !both_float && !addr_ok) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -573,11 +573,15 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
 # init-synthesis pass (`ir.Module.init_fn` is never populated), so an
 # initialiser that no constant path can fold is a hard error rather than a
 # silent zero placeholder. the folders are tried in turn:
-#   1. an aggregate (struct / array / `str`-into-pointer) whose bytes and
-#      pointer relocations are laid out as initialised data; tried first so a
-#      `val X: str = "..."` becomes a pointer-with-relocation, not inline bytes.
-#   2. a scalar comptime constant the frontend `comptime.eval` folds.
-#   3. a `nil` pointer initialiser, materialised as the null constant.
+#   1. a `nil` pointer initialiser — bare or written through pointer casts
+#      (`nil::F`, `nil:~*T`) — materialised as the null constant. tried first
+#      since `comptime.eval` has no CTValue for nil and a cast over nil bottoms
+#      out at the same non-constant leaf, so no other folder reaches it.
+#   2. an aggregate (struct / array / `str`-into-pointer) whose bytes and
+#      pointer relocations are laid out as initialised data; tried before the
+#      scalar fold so a `val X: str = "..."` becomes a pointer-with-relocation,
+#      not inline bytes.
+#   3. a scalar comptime constant the frontend `comptime.eval` folds.
 #   4. a constant scalar cast (`<const>::T`, including chains), folded with the
 #      same width / sign semantics `lower_cast` lowers.
 #   5. a type-introspection intrinsic (`$size_of` / `$align_of` / `$offset_of`)
@@ -588,6 +592,12 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
 # gty: the global's IR type
 # ret: the constant initialiser Value, or an error
 fun fold_global_init(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_type.IrTypeId) Result[value.Value, str] {
+    # a `nil` constant — bare or wrapped in pointer casts — is the null constant
+    # the global is emitted with, regardless of the cast chain (every cast of the
+    # null address preserves it). recognised here so a fun- or pointer-typed
+    # global can be explicitly `nil`-initialised, not only default-initialised.
+    if (is_null_init(ctx, eid)) { ret ok[value.Value, str](value.const_null(gty)); }
+
     val agg: Result[Option[value.Value], str] = constagg.try_const_aggregate(ctx, eid, gty);
     if (is_err[Option[value.Value], str](agg)) { ret err[value.Value, str](unwrap_err[Option[value.Value], str](agg)); }
     val agg_opt: Option[value.Value] = unwrap_ok[Option[value.Value], str](agg);
@@ -605,11 +615,6 @@ fun fold_global_init(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_type.IrT
     if (is_none[*aexpr.Expr](ie_opt)) { ret err[value.Value, str]("lower: global initialiser expression out of range"); }
     val ie: *aexpr.Expr = unwrap[*aexpr.Expr](ie_opt);
 
-    # a `nil` pointer initialiser is a constant null. `comptime.eval` has no
-    # CTValue for nil and the aggregate folder routes it here, so materialise it
-    # as the null constant the global is emitted with.
-    if (ie.kind == aexpr.EXPR_KIND_LIT_NIL) { ret ok[value.Value, str](value.const_null(gty)); }
-
     val cast: Option[Result[value.Value, str]] = expr.try_lower_comptime_cast(ctx, eid, ie);
     if (is_some[Result[value.Value, str]](cast)) { ret unwrap[Result[value.Value, str]](cast); }
 
@@ -619,6 +624,29 @@ fun fold_global_init(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_type.IrT
     }
 
     ret err[value.Value, str]("lower: a global initialiser must be a constant expression");
+}
+
+# whether a global initialiser is a `nil` constant: a bare `nil` literal, or a
+# `nil` wrapped in any chain of value / reinterpret casts (`nil::F`, `nil::*T`,
+# `nil:~T`). every cast of the null address preserves it, so such an initialiser
+# folds to the null constant regardless of the chain — the global's IR type is
+# what sizes it. sema already gates nil to pointer-like targets, so reaching here
+# guarantees the global is address-shaped.
+# ---
+# ctx: the context
+# eid: the initialiser expression
+# ret: true when the initialiser is a (possibly cast-wrapped) nil literal
+fun is_null_init(ctx: *lower.LowerContext, eid: aid.ExprId) bool {
+    var cur: aid.ExprId = eid;
+    for (true) {
+        val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, cur);
+        if (is_none[*aexpr.Expr](e_opt)) { ret false; }
+        val e: *aexpr.Expr = unwrap[*aexpr.Expr](e_opt);
+        if (e.kind == aexpr.EXPR_KIND_LIT_NIL) { ret true; }
+        if (e.kind != aexpr.EXPR_KIND_CAST) { ret false; }
+        cur = e.data.cast.value;
+    }
+    ret false;
 }
 
 # emits the source-located diagnostic for a global whose initialiser no constant


### PR DESCRIPTION
Closes #1369

A fun-typed global could not be explicitly nil-initialised; default-init was the only working spelling. nil already compared `== nil` against fun values and `nil::F` was accepted in argument position, but the coercion gap surfaced anywhere nil flowed into a fun-typed slot.

## Facets

1. `pub var q: fun(u32) = nil;` failed sema with `type mismatch: expected fun(u32), found *u8` — nil did not coerce to fun types.
2. `pub var r: F = nil::F;` failed lowering with `global initialiser must be a constant expression` — a cast over nil was not const-foldable.
3. `mach check` accepted the `= nil` form `mach build` rejected.

## Changes

- **sema coercion (`src/lang/fe/sema/coerce.mach`):** the nil-literal coercion case now tests `type.is_pointer_like` (which already admits `ptr` / `*T` / `fun`) instead of a pointer-only predicate. This is the single rule every position routes through (`try_coerce_literal`), so nil coerces uniformly into fun-typed globals, locals, record fields, array elements, arguments, and return slots. nil into a non-pointer slot stays a type error. The now-unused local `is_pointer` helper is removed.
- **const-eval (`src/lang/me/lower/decl.mach`):** `fold_global_init` recognises a nil constant — bare or wrapped in any chain of value/reinterpret casts (`nil::F`, `nil:~*T`) — and materialises the null constant the global is emitted with. Every cast of the null address preserves it, so the cast chain is irrelevant; the global's IR type sizes it. This covers facet 2 and is checked first since `comptime.eval` has no CTValue for nil.

## `mach check` divergence — structural

`mach check` is the editor `diagnostics` slice (`editor.diagnostics`), which runs **tokenize → parse only**, never resolve or sema. It accepts the `= nil` form because it accepts *every* semantic error (wrong return type, undefined symbol, any type mismatch) — single-file best-effort by design, not an accidental difference in the coercion path. Documented here rather than changed; running full sema in `mach check` is a separate, much larger surface. After this fix the divergence for the valid case disappears (build now also accepts it).

## Tests

- In-source sema tests (`src/lang/editor.mach`, via the full-sema test helper): nil coerces to fun types in every position incl. `nil::F` and `== nil`; nil into a non-pointer binding still reports a mismatch.
- Integration suite (`.github/tests/nilfun/`): `fold` builds and runs the full runtime matrix end-to-end (facet 1 bare nil + facet 2 `nil::F` globals, assign-and-call-through, clear back to null), `reject` requires nil into a `u32` global to fail with a located diagnostic.

## Verification

Clean rebuild from the 1.4.1 seed, three-stage self-build fixpoint (stage2 == stage3 byte-identical), `mach test .` 414/414, and the `nilfun` + adjacent (`globalmember`, `valuepos`, `lower`, `diaglocate`, …) integration suites all green.

## Docs

`doc/language/literals.md` (the `nil` section) and `doc/language/operators.md` updated to state nil coerces to pointer-like types incl. functions; CHANGELOG `Fixed` entry added.