### PR TITLE
fix: float % evaluates to the truncated (fmod) remainder

### DIFF
--- a/.github/tests/floatrem/app/mach.toml
+++ b/.github/tests/floatrem/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "floatrem"
+name = "float remainder semantics — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "linux"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.floatrem]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/floatrem/app/src/main.mach
+++ b/.github/tests/floatrem/app/src/main.mach
@@ -1,0 +1,64 @@
+use std.runtime.linux.x86_64;
+
+# float remainder `%` (#1378). the operator lowered through the integer IDIV/DIV
+# path over the raw IEEE-754 bit patterns instead of a float-remainder sequence,
+# so it returned a passthrough-below-divisor / near-zero-above shape rather than
+# the truncated (C fmod) remainder. this exercises the fix end to end: every
+# function returns the remainder whose result takes the dividend's sign, computed
+# from real float divides / conversions / multiplies, and main exits 0 only when
+# every case matches. the suite builds and runs this at -O0 and -O2 to prove the
+# debug and release pipelines agree.
+
+# a module-level val forces the comptime const-fold path (apply_arith), the
+# sibling of the runtime lowering that the same bug afflicted.
+val FOLDED: f64 = 5.5 % 3.0;   # 2.5
+
+fun rem64(a: f64, b: f64) f64 { ret a % b; }
+fun rem32(a: f32, b: f32) f32 { ret a % b; }
+
+# scale by 1000 and truncate so an exact integer encodes the three-decimal
+# result; the scale/cast path is independently exercised and known good.
+fun milli64(v: f64) i64 { ret (v * 1000.0)::i64; }
+fun milli32(v: f32) i64 { ret (v * 1000.0)::i64; }
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # const-folded module val.
+    if (milli64(FOLDED) != 2500) { ret 1; }
+
+    # f64, lhs > rhs.
+    var x: f64 = 5.5;
+    if (milli64(rem64(x, 3.0)) != 2500) { ret 2; }
+    # f64, lhs < rhs — the dividend passes through unchanged.
+    var lo: f64 = 0.45;
+    if (milli64(rem64(lo, 1.0)) != 450) { ret 3; }
+    # f64, exact multiple — remainder is zero.
+    var em: f64 = 6.0;
+    if (milli64(rem64(em, 3.0)) != 0) { ret 4; }
+    # f64, negative dividend — result takes the dividend's sign: -5.5 % 3.0 = -2.5.
+    var nl: f64 = 0.0 - 5.5;
+    if (milli64(rem64(nl, 3.0)) != (0 - 2500)) { ret 5; }
+    # f64, negative divisor — sign still follows the dividend: 5.5 % -3.0 = 2.5.
+    var nr: f64 = 0.0 - 3.0;
+    if (milli64(rem64(x, nr)) != 2500) { ret 6; }
+    # f64, both negative: -5.5 % -3.0 = -2.5.
+    if (milli64(rem64(nl, nr)) != (0 - 2500)) { ret 7; }
+    # f64, two runtime operands (neither a constant divisor).
+    var d: f64 = 3.0;
+    if (milli64(rem64(x, d)) != 2500) { ret 8; }
+
+    # f32, lhs > rhs.
+    var f: f32 = 5.5;
+    if (milli32(rem32(f, 3.0)) != 2500) { ret 9; }
+    # f32, lhs < rhs passthrough.
+    var g: f32 = 0.25;
+    if (milli32(rem32(g, 1.0)) != 250) { ret 10; }
+    # f32, exact multiple.
+    var fe: f32 = 9.0;
+    if (milli32(rem32(fe, 3.0)) != 0) { ret 11; }
+    # f32, negative dividend.
+    var nf: f32 = 0.0 - 5.5;
+    if (milli32(rem32(nf, 3.0)) != (0 - 2500)) { ret 12; }
+
+    ret 0;
+}

--- a/.github/tests/floatrem/run.sh
+++ b/.github/tests/floatrem/run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# float remainder semantics test (#1378): float `%` lowered through the integer
+# IDIV/DIV path over the raw IEEE-754 bit patterns instead of a float-remainder
+# sequence, so it returned a passthrough-below-divisor / near-zero-above shape
+# rather than the truncated (C fmod) remainder (result takes the dividend's sign).
+# this builds a self-checking program covering f32/f64, const-folded and runtime
+# operands, lhs<rhs / lhs>rhs / exact multiples, and negative dividend / divisor,
+# then runs it natively. it builds and runs the SAME source at -O0 and -O2 and
+# requires both to exit 0, proving the debug and release pipelines agree on fmod.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+for opt in O0 O2; do
+    BIN="$WORK/app/floatrem-$opt"
+    if ! ( cd "$WORK/app" && "$MACH" build . -$opt -o "$BIN" ) >/dev/null 2>&1; then
+        echo "FAIL floatrem: native build failed at -$opt" >&2
+        exit 1
+    fi
+    test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+    set +e
+    "$BIN"
+    code=$?
+    set -e
+
+    if [ "$code" -ne 0 ]; then
+        echo "FAIL floatrem: float % miscompiled at -$opt (case $code)" >&2
+        exit 1
+    fi
+    echo "PASS floatrem: float % matches the truncated (fmod) remainder at -$opt"
+done
+
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Float `%` now evaluates to the truncated (C `fmod`) remainder
+  `a - trunc(a / b) * b`, whose result takes the dividend's sign
+  (`5.5 % 3.0 == 2.5`, `-5.5 % 3.0 == -2.5`). The operator had no float lowering:
+  the runtime path fell through to the integer IDIV/DIV opcodes, running an
+  integer divide over the raw IEEE-754 bit patterns (a passthrough-below-divisor,
+  near-zero-above shape), and the comptime fold rejected it as non-constant. Both
+  now synthesize the remainder from the existing float divide / truncating
+  conversion / multiply / subtract primitives, exact for `|a / b| < 2^63` (#1378).
 - Sema reports a teaching diagnostic for every symbol kind that can never be a
   value reaching value position — a record, union, or `def` type name (local
   or imported, bare or `alias.member`), a generic type parameter, and a member

--- a/doc/language/operators.md
+++ b/doc/language/operators.md
@@ -14,6 +14,16 @@ val q: f32    = 1.5 * 2.0;
 val v: f32x4  = a + b;       # lane-wise add (vectors not yet implemented)
 ```
 
+`%` is the remainder. On integers it is the native truncated remainder, taking
+the sign of the dividend (`-7 % 3 == -1`). On floats it is the truncated (C
+`fmod`) remainder `a - trunc(a / b) * b`, likewise taking the sign of the
+dividend (`5.5 % 3.0 == 2.5`, `-5.5 % 3.0 == -2.5`). The exact float result is
+defined for `|a / b| < 2^63`.
+
+```mach
+val r: f64 = 5.5 % 3.0;      # 2.5
+```
+
 ## Bitwise
 
 `&` `|` `^` `~` `<<` `>>` — work on integer scalars and (planned) integer

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -976,6 +976,15 @@ fun apply_compare(op: expr.BinOp, lhs: CTValue, rhs: CTValue) Result[CTValue, st
     ret err[CTValue, str]("ordered comparison requires numeric operands");
 }
 
+# the truncated (C `fmod`) floating-point remainder: rem = a - trunc(a / b) * b,
+# taking the sign of the dividend `a`. `::i64` truncates the quotient toward zero,
+# matching the back end's FP_TO_SI lowering, so the comptime fold and the runtime
+# sequence agree bit for bit. the caller guards `b == 0`.
+fun float_trunc_rem(a: f64, b: f64) f64 {
+    val q: i64 = (a / b)::i64;
+    ret a - q::f64 * b;
+}
+
 fun apply_arith(op: expr.BinOp, lhs: CTValue, rhs: CTValue) Result[CTValue, str] {
     if (lhs.kind != rhs.kind) {
         ret err[CTValue, str]("arithmetic requires operands of the same kind");
@@ -988,6 +997,10 @@ fun apply_arith(op: expr.BinOp, lhs: CTValue, rhs: CTValue) Result[CTValue, str]
         if (op == expr.BIN_DIV) {
             if (rhs.data.f == 0.0) { ret err[CTValue, str]("float division by zero"); }
             ret float_value(lhs.data.f / rhs.data.f);
+        }
+        if (op == expr.BIN_MOD) {
+            if (rhs.data.f == 0.0) { ret err[CTValue, str]("float modulo by zero"); }
+            ret float_value(float_trunc_rem(lhs.data.f, rhs.data.f));
         }
         ret err[CTValue, str]("unsupported float operator");
     }
@@ -1532,6 +1545,32 @@ test "comptime: INT64_MIN / -1 and % -1 trap as errors instead of SIGFPE (#1249)
     val okd: Result[CTValue, str] = apply_arith(expr.BIN_DIV, ten, two);
     if (is_err[CTValue, str](okd)) { ret 1; }
     if (unwrap_ok[CTValue, str](okd).data.i != 5) { ret 1; }
+    ret 0;
+}
+
+test "comptime: float % folds to the truncated (fmod) remainder (#1378)" {
+    val a: CTValue = unwrap_ok[CTValue, str](float_value(5.5));
+    val b: CTValue = unwrap_ok[CTValue, str](float_value(3.0));
+    val r: Result[CTValue, str] = apply_arith(expr.BIN_MOD, a, b);
+    if (is_err[CTValue, str](r)) { ret 1; }
+    if (unwrap_ok[CTValue, str](r).data.f != 2.5) { ret 1; }
+
+    # the result takes the dividend's sign (C fmod): -5.5 % 3.0 = -2.5.
+    val na: CTValue = unwrap_ok[CTValue, str](float_value(0.0 - 5.5));
+    val rn: Result[CTValue, str] = apply_arith(expr.BIN_MOD, na, b);
+    if (is_err[CTValue, str](rn)) { ret 1; }
+    if (unwrap_ok[CTValue, str](rn).data.f != (0.0 - 2.5)) { ret 1; }
+
+    # lhs < rhs passes the dividend through unchanged.
+    val s:   CTValue = unwrap_ok[CTValue, str](float_value(0.45));
+    val one: CTValue = unwrap_ok[CTValue, str](float_value(1.0));
+    val rs: Result[CTValue, str] = apply_arith(expr.BIN_MOD, s, one);
+    if (is_err[CTValue, str](rs)) { ret 1; }
+    if (unwrap_ok[CTValue, str](rs).data.f != 0.45) { ret 1; }
+
+    # modulo by zero is an error, not a silent fold.
+    val z: CTValue = unwrap_ok[CTValue, str](float_value(0.0));
+    if (!is_err[CTValue, str](apply_arith(expr.BIN_MOD, a, z))) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1370,6 +1370,12 @@ fun lower_binary(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Resu
         ret builder.emit_div_u(?ctx.builder, lhs, rhs);
     }
     if (op == aexpr.BIN_MOD) {
+        # x86-64 SSE has no float-remainder instruction (unlike +/-/*//, which map
+        # to SSE forms). a floating-point `%` is synthesized as the truncated
+        # (C `fmod`) remainder from float primitives; the integer OP_REM_* opcodes
+        # stay integer-only. routing a float `%` to OP_REM_* would run the integer
+        # divide over the raw IEEE-754 bit patterns and miscompile (issue #1378).
+        if (is_float_type(ctx, lty)) { ret lower_float_rem(ctx, lhs, rhs); }
         if (signed) { ret builder.emit_rem_s(?ctx.builder, lhs, rhs); }
         ret builder.emit_rem_u(?ctx.builder, lhs, rhs);
     }
@@ -1383,6 +1389,41 @@ fun lower_binary(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Resu
     }
 
     ret err[value.Value, str]("lower: unsupported binary operator");
+}
+
+# lowers a floating-point remainder `lhs % rhs` to the truncated (C `fmod`)
+# remainder, whose result takes the sign of the dividend: q = trunc(lhs / rhs),
+# rem = lhs - q * rhs. x86-64 SSE has no float-remainder instruction, so the
+# operation is built from the float divide, a truncate-toward-zero round trip
+# through i64 (FP_TO_SI / SI_TO_FP), and a float multiply / subtract — all of
+# which the back end already selects to their SSE forms. the i64 round trip bounds
+# the exact range to |lhs / rhs| < 2^63, matching a libm-free fmod. both operands
+# share the float result type, so the divide / multiply / subtract carry `lhs.ty`.
+fun lower_float_rem(ctx: *lower.LowerContext, lhs: value.Value, rhs: value.Value) Result[value.Value, str] {
+    val i64r: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](i64r)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](i64r)); }
+    val i64ty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](i64r);
+
+    # q = lhs / rhs (float divide; OP_DIV_U mirrors how float `/` is emitted).
+    val qr: Result[value.Value, str] = builder.emit_div_u(?ctx.builder, lhs, rhs);
+    if (is_err[value.Value, str](qr)) { ret qr; }
+    val q: value.Value = unwrap_ok[value.Value, str](qr);
+
+    # trunc(q): float -> i64 truncates toward zero, then i64 -> float restores it.
+    val qir: Result[value.Value, str] = builder.emit_fp_to_si(?ctx.builder, q, i64ty);
+    if (is_err[value.Value, str](qir)) { ret qir; }
+    val qi: value.Value = unwrap_ok[value.Value, str](qir);
+
+    val qfr: Result[value.Value, str] = builder.emit_si_to_fp(?ctx.builder, qi, lhs.ty);
+    if (is_err[value.Value, str](qfr)) { ret qfr; }
+    val qf: value.Value = unwrap_ok[value.Value, str](qfr);
+
+    # rem = lhs - trunc(q) * rhs.
+    val pr: Result[value.Value, str] = builder.emit_mul(?ctx.builder, qf, rhs);
+    if (is_err[value.Value, str](pr)) { ret pr; }
+    val prod: value.Value = unwrap_ok[value.Value, str](pr);
+
+    ret builder.emit_sub(?ctx.builder, lhs, prod);
 }
 
 # true for the comparison binary operators, whose operands are read at a single


### PR DESCRIPTION
## Summary

Float `%` produced wrong values: `5.5 % 3.0` yielded ~0 instead of `2.5`, and
mach-gl's `(t * 0.5) % 1.0` froze after one cycle. The operator had **no float
lowering** — it shared the integer remainder machinery, which is wrong for floats.

## Root cause

The IR shares opcodes between int and float arithmetic; the back end's
`is_float_op` routes a shared opcode to the SSE forms when an operand is float.
It claimed `OP_ADD/SUB/MUL/DIV_S/DIV_U` but **not** `OP_REM_S/OP_REM_U`, so a
float `%` fell through to the integer IDIV/DIV path and ran an integer divide
over the raw IEEE-754 bit patterns. The observable shapes:

- **Immediate / most register divisors:** the bits are modulo'd as integers. For
  positive floats bit-order matches value-order, so `lhs < rhs` passes the
  dividend through (`0.45 % 1.0 → 0.45`) and `lhs >= rhs` leaves a tiny denormal
  ≈ 0 (`5.5 % 3.0 → ~0`). This is the same in **both** O0 and O2 — the reporter's
  "O0 unconditional zero" was a sampling artifact (all O0 samples had `lhs > rhs`);
  the O2 "passthrough then freeze" swept across the `lhs < rhs` boundary.
- **Divisor in an RAX-aliasing XMM register** (e.g. a non-inlined helper's
  param): the integer DIV encoder reads the divisor by register *index*, and an
  XMM index can collide with the dividend register RAX, degenerating to `a / a`
  → remainder 0 unconditionally.

The comptime const-fold path was distinct: it rejected float `%` as
non-constant (`apply_arith` had no float `BIN_MOD` case), so a folded
`val x: f64 = 5.5 % 3.0` was a hard compile error. No sibling float op shares the
gap — `+ - * /` and the comparisons were already routed to SSE.

## Fix

Synthesize the truncated (C `fmod`) remainder at the source from primitives the
back end already lowers to SSE — no libm, no new opcode:

```
q   = trunc(lhs / rhs)        # float divide, FP_TO_SI / SI_TO_FP round trip
rem = lhs - q * rhs           # float multiply / subtract
```

Result takes the dividend's sign; exact for `|lhs / rhs| < 2^63`. The comptime
fold computes the identical truncated remainder so const-fold, O0, and O2 agree.

## Tests

- In-source comptime unit test for the fold (sign semantics + modulo-by-zero).
- `.github/tests/floatrem/` integration suite running real native computations:
  f32/f64, folded and runtime operands, `lhs<rhs` / `lhs>rhs` / exact multiples,
  negative dividend and divisor — built and run at **both -O0 and -O2**,
  asserting identical results.

## Verification

- Full clean rebuild + stage-2 self-build: byte-identical fixpoint.
- `mach test .`: 413 passed, 0 failed (includes the new fold test).
- floatrem suite green at -O0 and -O2; fails to build on the 1.4.1 seed (the
  folding gap), confirming it guards the regression.

Closes #1378