### PR TITLE
fix(coff): trailing PE import descriptor's call-thunk jumps through a null IAT slot (#1388)

### DIFF
--- a/.github/tests/dlllib/app/mach.toml
+++ b/.github/tests/dlllib/app/mach.toml
@@ -13,7 +13,7 @@ isa  = "x86_64"
 os   = "windows"
 abi  = "win64"
 ext  = ".exe"
-libs = ["kernel32.dll", "ws2_32.dll"]
+libs = ["kernel32.dll", "ws2_32.dll", "advapi32.dll"]
 
 [bin.dlllib]
 entry = "main.mach"

--- a/.github/tests/dlllib/app/src/main.mach
+++ b/.github/tests/dlllib/app/src/main.mach
@@ -1,11 +1,16 @@
-# dlllib integration app (#1382): per-symbol windows DLL attribution. the PE
-# import directory used to be position-based — every `ext` import was forced
+# dlllib integration app (#1382 attribution, #1388 trailing call-thunk): per-symbol
+# windows DLL attribution and the import call-thunk that dispatches each call. the
+# PE import directory used to be position-based — every `ext` import was forced
 # onto the first dependency (kernel32.dll) — and `register_ext_fun` clobbered
-# `$<sym>.symbol` renames. this app spreads imports across kernel32.dll and
-# ws2_32.dll using `$<sym>.library`, and renames decls with `$<sym>.symbol`,
-# including both directives on one decl. it must build with two correct import
-# descriptors and run under wine: the winsock calls only resolve when they are
-# attributed to ws2_32.dll rather than kernel32.dll.
+# `$<sym>.symbol` renames. this app spreads imports across kernel32.dll, ws2_32.dll
+# and advapi32.dll using `$<sym>.library`, and renames decls with `$<sym>.symbol`,
+# including both directives on one decl. it must build with three correct import
+# descriptors and run under wine.
+#
+# advapi32.dll is deliberately the *trailing* descriptor and its import is actually
+# called: #1388 dropped the call-thunk for the last descriptor, so its stub jumped
+# through the previous descriptor's null IAT slot (a `jmp 0` access violation).
+# `rng_fill` exercising RtlGenRandom proves the trailing thunk dispatches.
 
 use std.runtime;
 
@@ -24,6 +29,13 @@ $ws2_cleanup.library = "ws2_32.dll";
 $ws2_cleanup.symbol  = "WSACleanup";
 ext fun ws2_cleanup() i32;
 
+# the trailing descriptor (#1388): `rng_fill` is renamed to `SystemFunction036`
+# (RtlGenRandom) and pinned to advapi32.dll. it fills a buffer with random bytes
+# and returns nonzero on success, so a correct trailing call-thunk is observable.
+$rng_fill.library = "advapi32.dll";
+$rng_fill.symbol  = "SystemFunction036";
+ext fun rng_fill(buf: *u8, len: u32) u8;
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     var wsadata: [512]u8;
@@ -34,5 +46,16 @@ fun main(argc: i64, argv: **u8) i64 {
     # aborted at call time.
     if (WSAStartup(0x0202::u16, ?wsadata[0]) != 0) { ret 1; }
     if (ws2_cleanup() != 0) { ret 2; }
+    # the trailing-descriptor call: #1388 made this dispatch through a null IAT
+    # slot. fill 32 bytes and require a nonzero result and at least one nonzero
+    # byte, so a broken thunk faults or yields zeros rather than passing.
+    var rnd: [32]u8;
+    var k: u64 = 0;
+    for (k < 32) { rnd[k] = 0; k = k + 1; }
+    if (rng_fill(?rnd[0], 32) == 0) { ret 3; }
+    var nz: u8 = 0;
+    k = 0;
+    for (k < 32) { nz = nz | rnd[k]; k = k + 1; }
+    if (nz == 0) { ret 4; }
     ret 0;
 }

--- a/.github/tests/dlllib/run.sh
+++ b/.github/tests/dlllib/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# dlllib integration test (#1382): per-symbol windows DLL attribution.
+# dlllib integration test (#1382 attribution, #1388 trailing call-thunk):
+# per-symbol windows DLL attribution and the import call-thunk dispatch.
 #
 # the PE import directory used to be built position-based — build_dynamic_info
 # pinned every undefined `ext` import to DYNLIB_ANY, which the COFF writer
@@ -8,15 +9,22 @@
 # renames silently did nothing. winsock bindings therefore landed on kernel32
 # under their mach identifiers and aborted at call time on real windows.
 #
-# this builds a windows app that spreads imports across kernel32.dll and
-# ws2_32.dll with `$<sym>.library`, renames decls with `$<sym>.symbol`, and uses
-# both directives on one decl, then verifies three ways:
+# #1388 then exposed the call-thunk side: pe_iat_slot_rva never advanced the
+# dependency index, so the *trailing* import descriptor's stubs jumped through
+# the previous descriptor's null IAT slot (a `jmp 0` access violation on the
+# first call). advapi32.dll is the trailing descriptor here and its import is
+# actually called, so a clean run proves the last thunk dispatches.
+#
+# this builds a windows app that spreads imports across kernel32.dll, ws2_32.dll
+# and advapi32.dll with `$<sym>.library`, renames decls with `$<sym>.symbol`, and
+# uses both directives on one decl, then verifies three ways:
 #   1. structurally — parse the emitted PE's import directory and assert each
 #      import sits under the DLL it was attributed to, by its final (renamed)
 #      link name. uses binutils objdump (BFD's pei support), falling back to
 #      llvm-readobj, and skips this half with a notice when neither reads a PE.
 #   2. behaviorally — run the binary under wine; WSAStartup/WSACleanup resolve
-#      only through a correct ws2_32 attribution, so exit 0 proves the routing.
+#      only through a correct ws2_32 attribution, and SystemFunction036 dispatches
+#      only through a correct trailing-descriptor thunk, so exit 0 proves both.
 #   3. negatively — a `$<sym>.library` naming a DLL absent from the link's
 #      dependencies must fail the build rather than silently fall back.
 #
@@ -91,6 +99,7 @@ fi
 if [ -n "$INSPECT" ]; then
     k32="$(imports_under kernel32.dll)"
     ws2="$(imports_under ws2_32.dll)"
+    adv="$(imports_under advapi32.dll)"
 
     # assert <list> contains <symbol> under <dll-label>.
     has() {
@@ -109,26 +118,33 @@ if [ -n "$INSPECT" ]; then
         fi
     }
 
-    has Sleep      "$k32" kernel32.dll   # `.symbol` rename, default attribution
-    has WSAStartup "$ws2" ws2_32.dll     # `.library` pin, bare name
-    has WSACleanup "$ws2" ws2_32.dll     # `.library` + `.symbol` on one decl
+    has Sleep            "$k32" kernel32.dll   # `.symbol` rename, default attribution
+    has WSAStartup       "$ws2" ws2_32.dll     # `.library` pin, bare name
+    has WSACleanup       "$ws2" ws2_32.dll     # `.library` + `.symbol` on one decl
+    has SystemFunction036 "$adv" advapi32.dll  # trailing descriptor (#1388)
     # the winsock imports must be attributed away from the first dependency.
     lacks WSAStartup  "$k32" kernel32.dll
     lacks WSACleanup  "$k32" kernel32.dll
+    # advapi32's import must not land on the first dependency either.
+    lacks SystemFunction036 "$k32" kernel32.dll
     # the mach identifiers must not survive their `.symbol` renames.
     lacks sleep_ms    "$k32" kernel32.dll
     lacks ws2_cleanup "$ws2" ws2_32.dll
+    lacks rng_fill    "$adv" advapi32.dll
 else
     echo "INFO dlllib: no PE import inspector (objdump/llvm-readobj); skipping the structural check"
 fi
 
 # behavioral: run the binary under wine. the winsock calls resolve only through
-# the ws2_32 attribution, so a clean exit proves the imports route correctly.
+# the ws2_32 attribution, and the trailing advapi32 call (SystemFunction036)
+# dispatches only through a correct last-descriptor thunk (#1388) — under the bug
+# it jumped through a null IAT slot and faulted with rip=0. a clean exit proves
+# both the attribution and the trailing call-thunk.
 if command -v wine >/dev/null 2>&1; then
     if WINEDEBUG=-all wine "$EXE" >"$WORK/wine.out" 2>&1; then
-        echo "PASS dlllib: WSAStartup/WSACleanup resolve through ws2_32.dll under wine"
+        echo "PASS dlllib: winsock and the trailing advapi32 call resolve under wine"
     else
-        echo "FAIL dlllib: ws2_32 program aborted under wine (mis-attribution?)" >&2
+        echo "FAIL dlllib: program aborted under wine (mis-attribution or trailing thunk?)" >&2
         cat "$WORK/wine.out" >&2
         fail=1
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- PE import call-thunks for the **last** import descriptor jumped through the
+  previous descriptor's null IAT slot (a `jmp 0` access violation on the first
+  call). `pe_iat_slot_rva` never advanced its dependency index, so it re-scanned
+  only the first descriptor when mapping an import ordinal to its IAT slot — the
+  trailing descriptor's stubs landed short of its `FirstThunk`. Reordering the
+  `libs` list moved the breakage to whichever DLL was last. Now every import's
+  thunk targets its own descriptor's slot, so the trailing descriptor's calls
+  (e.g. advapi32's `SystemFunction036`) dispatch correctly (#1388).
+
 ## [1.5.0] - 2026-06-12
 
 Inline-asm & foundations: carry-flag mnemonics and numeric local labels in x64

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2342,6 +2342,7 @@ fun pe_iat_slot_rva(lay: *PeLayout, dyn: *of.DynamicInfo, ord: u32) u64 {
             imp = imp + 1;
         }
         thunk_ix = thunk_ix + 1;
+        lib = lib + 1;
     }
     ret 0;
 }
@@ -3857,5 +3858,82 @@ test "coff: parse rejects a truncated object instead of reading out of bounds (#
     val pr: Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, COFF_HEADER_SIZE + 8, ?out);
     if (!is_err[bool, str](pr)) { ret 1; }
     if (!str_contains(unwrap_err[bool, str](pr), "out of bounds")) { ret 1; }
+    ret 0;
+}
+
+# t_iat_slots_exact: build a dynamic plan of `nlib` dependencies whose function-
+# import counts are `counts[0..nlib)`, then assert pe_iat_slot_rva places every
+# import's stub at the exact dependency-major IAT slot its descriptor's FirstThunk
+# owns — one null terminator slot after each dependency. returns false on the
+# first mismatch. test support for #1388.
+fun t_iat_slots_exact(i: *intern.Interner, counts: *u32, nlib: u32) bool {
+    var libs: [8]of.DynLib;
+    var imports: [64]of.DynImport;
+    var total: u32 = 0;
+    var l: u32 = 0;
+    for (l < nlib) {
+        libs[l].soname = t_intern(i, "lib.dll");
+        var j: u32 = 0;
+        for (j < counts[l]) {
+            imports[total].symbol = t_intern(i, "fn");
+            imports[total].lib_index = l;
+            imports[total].is_func = true;
+            total = total + 1;
+            j = j + 1;
+        }
+        l = l + 1;
+    }
+
+    var dyn: of.DynamicInfo;
+    dyn.libs = ?libs[0]; dyn.lib_count = nlib;
+    dyn.imports = ?imports[0]; dyn.import_count = total;
+    dyn.interp = intern.STR_NIL;
+
+    var lay: PeLayout;
+    lay.nimp = func_import_count(?dyn);
+    lay.idata_sec.rva = 0x10000;
+
+    # slot 0 is the IAT origin regardless of the bug; derive every other slot from
+    # it and the known dependency-major layout, then assert the thunk target lands
+    # exactly there for each function ordinal.
+    val base: u64 = pe_iat_slot_rva(?lay, ?dyn, 0);
+    var ord: u32 = 0;
+    var slot: u32 = 0;
+    var elib: u32 = 0;
+    for (elib < nlib) {
+        var j: u32 = 0;
+        for (j < counts[elib]) {
+            val got:  u64 = pe_iat_slot_rva(?lay, ?dyn, ord);
+            val want: u64 = base + slot::u64 * THUNK_SIZE::u64;
+            if (got != want) { ret false; }
+            ord = ord + 1;
+            slot = slot + 1;
+            j = j + 1;
+        }
+        # one null terminator slot ends each dependency's IAT.
+        slot = slot + 1;
+        elib = elib + 1;
+    }
+    ret true;
+}
+
+test "coff: pe_iat_slot_rva keeps every import in its own descriptor's IAT range (#1388)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    # four dependencies with uneven function-import counts — the
+    # kernel32/ws2_32/advapi32/apiset shape. v1.5.0 dropped the call-thunk for the
+    # trailing descriptor entirely: pe_iat_slot_rva never advanced the dependency
+    # index, so it re-scanned only the first dependency and pointed the last
+    # descriptor's stubs short of its FirstThunk, through the prior null terminator.
+    var counts: [4]u32;
+    counts[0] = 6; counts[1] = 3; counts[2] = 2; counts[3] = 1;
+    if (!t_iat_slots_exact(?i, ?counts[0], 4)) { ret 1; }
+
+    # reordering the dependencies moves the trailing descriptor; every position
+    # must still resolve, so the same multiset laid in a different order holds too.
+    counts[0] = 1; counts[1] = 2; counts[2] = 3; counts[3] = 6;
+    if (!t_iat_slots_exact(?i, ?counts[0], 4)) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Closes #1388.

## Root cause

`pe_iat_slot_rva` (src/lang/target/of/coff.mach) maps a function-import ordinal to
its IAT slot by walking the dependencies dependency-major — the same walk
`write_pe_imports` and `func_ordinal` perform. But its outer loop was **missing
the `lib = lib + 1;` increment**, so `lib` stayed `0` and the loop re-scanned only
the **first** descriptor (kernel32) over and over instead of advancing through the
descriptors.

Because each re-scan adds exactly one null-terminator slot, the walk accounts for
only one inter-descriptor null per pass rather than one per actual descriptor. The
**trailing** descriptor's stubs therefore land short of its `FirstThunk`, through a
previous descriptor's null IAT slot, and the first call faults with a `jmp 0`
(`EXCEPTION_ACCESS_VIOLATION` at rip=0).

This explains the puzzling evidence in the issue:

- **Minimal vs std-sized.** Whether a descriptor's imports come out right is a
  coincidence of the first descriptor's import count: re-scanning kernel32 from its
  first null happens to align middle descriptors, but never the third+. A 1/1/1
  layout aligns by luck; 52/14/1 drifts the advapi32 slot by one.
- **Last descriptor / reorder bisect** (refined diagnosis): the trailing
  descriptor's real IAT slots are referenced by no stub, so its calls dispatch
  through null. Reordering `libs` moves the breakage to whichever DLL is last.

The import *directory* itself was always correct (#1383) — only the call-thunk
target was wrong.

## Fix

Add the missing `lib = lib + 1;` so the walk advances dependency-major and every
import's stub targets its own descriptor's slot. One line, structural — it makes
`pe_iat_slot_rva` identical to the two sibling walks.

## Tests

- **Unit** (`coff.mach`): a four-descriptor layout with uneven counts plus a
  reordered layout, asserting every import ordinal's thunk target lands exactly in
  its descriptor's IAT slot. Fails on the unfixed code, passes with the fix.
- **Integration** (`.github/tests/dlllib/`): extended from two to three descriptors;
  advapi32.dll is the trailing descriptor and its import (`SystemFunction036` /
  RtlGenRandom) is actually called and asserted nonzero. The wine behavioral check
  faults with the issue's exact `jmp 0` page fault on the unfixed compiler and
  exits 0 with the fix.

## Verification

- `mach test .` — 418 passed, 0 failed (incl. the new unit test).
- dlllib run.sh — green with the fix; the wine check fails (rip=0 page fault) on the
  unfixed compiler.
- 3- and 4-descriptor repros under wine: trailing import call works in every
  position post-fix; pre-fix the last descriptor faults and the bug follows a
  reorder.
- Stage-2/3 self-build fixpoint: stage2 == stage3, byte-identical (linux
  unaffected).