### PR TITLE
fix(codegen): probe the stack per page in windows prologues (#1395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Windows function prologues now probe the stack one page at a time for frames
+  larger than a page, instead of a bare `sub rsp, N`. Windows commits the stack
+  one guard page at a time, so a single large subtraction skipped the guard page
+  and the first write near the bottom of the frame faulted on reserved memory
+  (`STATUS_ACCESS_VIOLATION`); Linux and wine auto-grow the stack on any in-range
+  fault and so never surfaced it. The encoder now emits the inline `__chkstk`
+  page-walk (mach links no runtime) when the target OS commits incrementally — a
+  new `OsVTable.stack_probe` flag (true on Windows, false on Linux/Darwin) gated
+  by the OS `page_size`. This was the root cause of the native-Windows exec
+  failures in octalide/mach-std#262 (a 32 KiB `spawn_redirected` cmdline frame)
+  (#1395).
 - PE import call-thunks for the **last** import descriptor jumped through the
   previous descriptor's null IAT slot (a `jmp 0` access violation on the first
   call). `pe_iat_slot_rva` never advanced its dependency index, so it re-scanned

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -62,6 +62,7 @@ use x64:    mach.lang.target.isa.x64;
 use target: mach.lang.target.resolved;
 use abi:    mach.lang.target.abi;
 use of:     mach.lang.target.of;
+use tos:    mach.lang.target.os;
 use mir:    mach.lang.be.codegen.mir;
 use enc:    mach.lang.be.codegen.encode;
 
@@ -2136,6 +2137,98 @@ fun emit_xmm_load(st: *EncodeState, idx: i32, disp: i32) {
     emit_inst(st, ?mi);
 }
 
+# emit_stack_probe: allocate `total` stack bytes with a per-page guard-page walk.
+#
+# on an OS that commits the stack one page at a time (Windows), a frame larger
+# than a page must touch each page in descending order so every access lands on
+# the current guard page and walks it down; a bare `sub rsp, total` jumps past the
+# guard onto reserved memory and faults (STATUS_ACCESS_VIOLATION). mach links no
+# runtime, so the `__chkstk` page-walk is emitted inline: the reserved GP scratch
+# (R11, free at prologue entry — never a win64 argument) counts the bytes left to
+# allocate, each iteration drops RSP one page and touches it, and the final
+# partial page (< one page) is allocated unprobed — its first access takes the one
+# legitimate guard-page fault the OS commits.
+# ---
+# st:         encoder state whose byte sink the probe bytes are appended to
+# total:      the (16-aligned) frame bytes to subtract from RSP; caller guarantees
+#             `total > page_bytes`
+# page_bytes: guard-page granularity to probe at (the OS page size; a power of two)
+fun emit_stack_probe(st: *EncodeState, total: usize, page_bytes: usize) {
+    # r11 = bytes still to allocate below the current RSP
+    var mov_cnt: isa.Inst;
+    zero_inst(?mov_cnt);
+    mov_cnt.opcode = x64.MOV;
+    mov_cnt.dst    = isa.make_reg(x64.SCRATCH_REG, 8);
+    mov_cnt.src1   = isa.make_imm(total::i64, 8);
+    mov_cnt.size   = 8;
+    mov_cnt.flags  = x64.FLAG_REX_W;
+    emit_inst(st, ?mov_cnt);
+
+    val loop_top: usize = st.buf.len;
+
+    # sub rsp, page  — descend onto the current guard page
+    var sub_sp: isa.Inst;
+    zero_inst(?sub_sp);
+    sub_sp.opcode = x64.SUB;
+    sub_sp.dst    = isa.make_reg(x64.RSP, 8);
+    sub_sp.src1   = isa.make_imm(page_bytes::i64, 8);
+    sub_sp.size   = 8;
+    sub_sp.flags  = x64.FLAG_REX_W;
+    emit_inst(st, ?sub_sp);
+
+    # mov [rsp], r11  — touch the page so the OS commits it and arms the next guard
+    var touch: isa.Inst;
+    zero_inst(?touch);
+    touch.opcode = x64.MOV;
+    touch.dst    = isa.make_mem(x64.RSP, 0, -1, 0, 8);
+    touch.src1   = isa.make_reg(x64.SCRATCH_REG, 8);
+    touch.size   = 8;
+    touch.flags  = x64.FLAG_REX_W;
+    emit_inst(st, ?touch);
+
+    # sub r11, page
+    var sub_cnt: isa.Inst;
+    zero_inst(?sub_cnt);
+    sub_cnt.opcode = x64.SUB;
+    sub_cnt.dst    = isa.make_reg(x64.SCRATCH_REG, 8);
+    sub_cnt.src1   = isa.make_imm(page_bytes::i64, 8);
+    sub_cnt.size   = 8;
+    sub_cnt.flags  = x64.FLAG_REX_W;
+    emit_inst(st, ?sub_cnt);
+
+    # cmp r11, page  — loop while more than a full page remains
+    var cmp_cnt: isa.Inst;
+    zero_inst(?cmp_cnt);
+    cmp_cnt.opcode = x64.CMP;
+    cmp_cnt.dst    = isa.make_reg(x64.SCRATCH_REG, 8);
+    cmp_cnt.src1   = isa.make_imm(page_bytes::i64, 8);
+    cmp_cnt.size   = 8;
+    cmp_cnt.flags  = x64.FLAG_REX_W;
+    emit_inst(st, ?cmp_cnt);
+
+    # ja loop_top  — unsigned above: another full page to probe. the rel32 is
+    # backpatched to the measured backward displacement (target minus the offset of
+    # the instruction following the branch).
+    var ja: isa.Inst;
+    zero_inst(?ja);
+    ja.opcode = x64.JA;
+    ja.dst    = isa.make_label(nil);
+    ja.size   = DEFAULT_OPERAND_SIZE;
+    emit_inst(st, ?ja);
+    val ja_patch: usize = st.buf.len - 4;
+    patch_rel32(?st.buf, ja_patch, (loop_top::i64 - st.buf.len::i64)::i32);
+
+    # sub rsp, r11  — allocate the final partial page (r11 in (0, page])
+    var sub_rem: isa.Inst;
+    zero_inst(?sub_rem);
+    sub_rem.opcode = x64.SUB;
+    sub_rem.dst    = isa.make_reg(x64.RSP, 8);
+    sub_rem.src1   = isa.make_reg(x64.SCRATCH_REG, 8);
+    sub_rem.size   = 8;
+    sub_rem.flags  = x64.FLAG_REX_W;
+    emit_inst(st, ?sub_rem);
+}
+
 # emit_prologue: encode the standard x86-64 function prologue into the `.text`
 # byte sink.
 #
@@ -2174,14 +2267,23 @@ fun emit_prologue(st: *EncodeState, frame_size: u32, callee_mask: u32, callee_ma
 
     val total: usize = frame_total(st.abi, frame_size, callee_mask, callee_mask_fp, outgoing_size);
     if (total > 0) {
-        var sub_rsp: isa.Inst;
-        zero_inst(?sub_rsp);
-        sub_rsp.opcode = x64.SUB;
-        sub_rsp.dst    = isa.make_reg(x64.RSP, 8);
-        sub_rsp.src1   = isa.make_imm(total::i64, 8);
-        sub_rsp.size   = 8;
-        sub_rsp.flags  = x64.FLAG_REX_W;
-        emit_inst(st, ?sub_rsp);
+        # on an OS that commits the stack one guard page at a time (Windows), a
+        # frame larger than a page must walk each page down or the allocation skips
+        # the guard and faults on reserved memory; emit the inline page-probe.
+        # otherwise the OS auto-grows on the first in-range fault and a single
+        # subtraction suffices.
+        if (st.os.stack_probe && total > st.os.page_size::usize) {
+            emit_stack_probe(st, total, st.os.page_size::usize);
+        } or {
+            var sub_rsp: isa.Inst;
+            zero_inst(?sub_rsp);
+            sub_rsp.opcode = x64.SUB;
+            sub_rsp.dst    = isa.make_reg(x64.RSP, 8);
+            sub_rsp.src1   = isa.make_imm(total::i64, 8);
+            sub_rsp.size   = 8;
+            sub_rsp.flags  = x64.FLAG_REX_W;
+            emit_inst(st, ?sub_rsp);
+        }
     }
 
     var list: [16]i32;
@@ -2450,6 +2552,7 @@ rec EncodeState {
     block_cap:   u32;
     interner:    *intern.Interner;
     abi:         *abi.AbiVTable;
+    os:          *tos.OsVTable;
 }
 
 # encode_x64: encode a fully-resolved MIR module into `.text` bytes, symbol
@@ -2490,6 +2593,7 @@ pub fun encode_x64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Re
     st.block_cap   = 0;
     st.interner    = m.interner;
     st.abi         = tgt.abi;
+    st.os          = tgt.os;
 
     var fi: u32 = 0;
     for (fi < m.function_len) {
@@ -5951,4 +6055,51 @@ fun free_state(st: *EncodeState) {
         st.relocs = nil;
     }
     free_scratch(st);
+}
+
+test "x64.encode: stack probe walks pages with a backward branch and a final reg sub (#1395)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var st: EncodeState;
+    st.buf = buf_init(?alloc);
+
+    # a 12 KiB frame at a 4 KiB page: the inline page-walk runs as a runtime loop
+    # (body emitted once), so the static bytes are mov-counter / page-step / touch /
+    # decrement / compare / backward-branch / final-sub regardless of frame size.
+    emit_stack_probe(?st, 12288, 4096);
+
+    val b: *u8   = st.buf.data;
+    val n: usize = st.buf.len;
+    var bad: i32 = 0;
+
+    # the final allocation is `sub rsp, r11` (REX.W 29 /r, ModRM 11 011 100 = 0xDC).
+    if (n < 3)             { bad = 1; }
+    or (b[n - 3] != 0x4C)  { bad = 1; }
+    or (b[n - 2] != 0x29)  { bad = 1; }
+    or (b[n - 1] != 0xDC)  { bad = 1; }
+
+    # locate the `ja` (0F 87) and confirm it branches backward onto the page-step
+    # `sub rsp, imm32` (REX.W 81 /5 = 48 81 EC) — i.e. the loop re-probes each page.
+    var j: usize = 0;
+    var found: bool = false;
+    for (j + 1 < n) {
+        if (b[j] == 0x0F && b[j + 1] == 0x87) { found = true; brk; }
+        j = j + 1;
+    }
+    if (!found) {
+        bad = 1;
+    } or {
+        val p: usize   = j + 2;
+        val rel: i32   = b[p]::i32 | (b[p + 1]::i32 << 8) | (b[p + 2]::i32 << 16) | (b[p + 3]::i32 << 24);
+        val tgt: i64   = (p + 4)::i64 + rel::i64;
+        if (rel >= 0)          { bad = 1; }
+        or (tgt < 0)           { bad = 1; }
+        or (tgt::usize + 2 >= n){ bad = 1; }
+        or (b[tgt::usize]     != 0x48) { bad = 1; }
+        or (b[tgt::usize + 1] != 0x81) { bad = 1; }
+        or (b[tgt::usize + 2] != 0xEC) { bad = 1; }
+    }
+
+    buf_dnit(?st.buf);
+    ret bad;
 }

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -46,6 +46,12 @@ pub val OS_FREESTANDING: u32 = 4;
 #                  linker assigns section vaddrs upward from it
 # page_size:       virtual-memory page size in bytes the linker page-aligns
 #                  segment virtual addresses to
+# stack_probe:     true when the OS commits the stack one guard page at a time, so
+#                  a function frame larger than `page_size` must touch each page in
+#                  descending order (the `__chkstk` contract) or it faults on
+#                  reserved memory (Windows); false when the OS auto-grows the stack
+#                  on any in-range fault (Linux, Darwin) and a bare `sub rsp, N`
+#                  suffices
 pub rec OsVTable {
     id:             u32;
     name:           intern.StrId;
@@ -55,6 +61,7 @@ pub rec OsVTable {
     dynamic_linker: intern.StrId;
     base_addr:      u64;
     page_size:      u64;
+    stack_probe:    bool;
 }
 
 val OS_REGISTRY_CAP: u32 = 8;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -72,6 +72,9 @@ pub fun register_darwin(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Inter
     darwin_vtable.dynamic_linker = intern.STR_NIL;
     darwin_vtable.base_addr      = DARWIN_BASE_ADDR;
     darwin_vtable.page_size      = DARWIN_PAGE_SIZE;
+    # Darwin commits the thread stack up front and auto-grows the main thread; no
+    # per-page probe needed.
+    darwin_vtable.stack_probe    = false;
 
     os.register(reg, ?darwin_vtable);
     ret ok[bool, str](true);

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -84,6 +84,8 @@ pub fun register_linux(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Intern
     linux_vtable.dynamic_linker = unwrap_ok[intern.StrId, str](rd);
     linux_vtable.base_addr      = LINUX_BASE_ADDR;
     linux_vtable.page_size      = LINUX_PAGE_SIZE;
+    # Linux auto-grows the stack on any in-range fault; no per-page probe needed.
+    linux_vtable.stack_probe    = false;
 
     os.register(reg, ?linux_vtable);
     ret ok[bool, str](true);

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -77,6 +77,9 @@ pub fun register_windows(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Inte
     # first section maps immediately after them with no gap.
     windows_vtable.base_addr      = WINDOWS_BASE_ADDR + WINDOWS_PAGE_SIZE;
     windows_vtable.page_size      = WINDOWS_PAGE_SIZE;
+    # Windows grows the committed stack one guard page at a time, so a frame larger
+    # than a page must probe each page in order (see encode.emit_stack_probe).
+    windows_vtable.stack_probe    = true;
 
     os.register(reg, ?windows_vtable);
     ret ok[bool, str](true);


### PR DESCRIPTION
## Problem

Windows commits the stack one guard page at a time, so a function prologue that drops `rsp` by more than a page with a bare `sub rsp, N` skips the guard page; the first write near the bottom of the frame then faults on reserved memory (`STATUS_ACCESS_VIOLATION`, `0xC0000005`). Linux and wine auto-grow the stack on any in-range fault, so the cross-compile + wine lanes never surfaced it — only the native-windows lane can.

This is the root cause of octalide/mach-std#262 (the 6 native exec tests die in `spawn_redirected`'s 32 KiB cmdline frame) and the sole remaining blocker for the native lane reaching 464/464.

## Fix

- New `OsVTable.stack_probe` flag — `true` on Windows (commits incrementally), `false` on Linux/Darwin (auto-grow). A data field on the OS vtable; no branching on the numeric OS id, consistent with the rest of the target model. Probe granularity reuses the existing `page_size`.
- The x64 encoder now carries the OS vtable. When `stack_probe` is set and a frame exceeds `page_size`, `emit_prologue` emits an inline `__chkstk`-style page-walk (mach links no runtime) instead of the bare subtraction: the reserved R11 scratch (free at prologue entry, never a win64 argument) counts bytes remaining, each iteration drops `rsp` one page and touches it, and the final partial page is allocated unprobed (its first access takes the one legitimate guard fault). Otherwise the single `sub rsp, N` is unchanged.

## Verification

- Unit test asserts the emitted loop structure (backward `ja` onto the page-step, final `sub rsp, r11`).
- Suite green on linux: **419/419**.
- Cross-compiling `mach.exe` with the fixed compiler turns all 59 large-frame prologues into a well-formed page-walk. The std `spawn_redirected` 0x8120 (33 KiB) frame disassembles to:

  ```
  mov  r11,0x8120
  sub  rsp,0x1000      ; loop top
  mov  [rsp],r11       ; touch guard page
  sub  r11,0x1000
  cmp  r11,0x1000
  ja   <loop top>      ; rel32 = -31
  sub  rsp,r11
  ```

  No bare `sub rsp` over one page remains anywhere. Binary still loads/runs under wine (no regression).

## Remaining for the native lane (not in this PR)

Real-Windows confirmation runs through the native CI lane (PR #1367). That lane is also gated on a std-side import pin (the `WaitOnAddress`/`WakeByAddress` family → `api-ms-win-core-synch-l1-2-0.dll` via `$<sym>.library`) — coordinating with mach-std separately. Once both land, the lane should hit 464/464.

Closes #1395