### PR TITLE
test(ci): guard the trailing PE import-descriptor call-thunk under wine (#1399)

### DIFF
--- a/.github/tests/threadsync/app/mach.toml
+++ b/.github/tests/threadsync/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "threadsync"
+name = "win64 trailing PE import-descriptor call-thunk regression — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "windows"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+ext  = ".exe"
+
+[bin.threadsync]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/threadsync/app/src/main.mach
+++ b/.github/tests/threadsync/app/src/main.mach
@@ -1,0 +1,30 @@
+use std.runtime;
+use std.types.size.usize;
+use thread: std.sync.thread;
+use atomic: std.sync.atomic;
+
+# whether the spawned worker ran, flipped 0 -> 1 by the child and read back after
+# join. join() waits on the worker's completion flag via WaitOnAddress, and the
+# worker wakes it via WakeByAddressSingle — both imported from
+# api-ms-win-core-synch-l1-2-0.dll, std's 4th (trailing) PE import descriptor.
+var ran: i64 = 0;
+
+fun worker() {
+    atomic.store(?ran, 1);
+}
+
+# main: spawn a worker, join it (the synch wait/wake round-trip), and verify the
+# worker observably ran. before mach#1388 the call-thunk for a trailing import
+# descriptor jumped through the previous descriptor's null IAT slot, so the
+# WaitOnAddress call in join() dispatched through a null pointer and faulted
+# (`jmp 0`) — a nonzero exit. exits 0 only when the trailing-descriptor synch
+# calls dispatch correctly.
+$main.symbol = "main";
+fun main(argc: usize, argv: **u8) i64 {
+    atomic.store(?ran, 0);
+    var t: thread.Thread;
+    thread.spawn(worker, ?t);
+    thread.join(?t);
+    if (atomic.load(?ran) != 1) { ret 1; }
+    ret 0;
+}

--- a/.github/tests/threadsync/run.sh
+++ b/.github/tests/threadsync/run.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# trailing PE import-descriptor call-thunk regression test (#1388 / #1399): the
+# import call-thunk for the LAST import descriptor must jump through its own
+# descriptor's IAT slot, not the previous descriptor's null terminator. std links
+# four windows DLLs in order [kernel32, ws2_32, advapi32, api-ms-win-core-synch];
+# WaitOnAddress / WakeByAddressSingle live in the 4th (trailing) descriptor.
+#
+# mach's native windows lane does not cover this: the compiler does not import
+# std.sync.thread, so mach.exe imports the synch DLL dead (no call site) and the
+# 2 std thread tests are not in its corpus; std's own CI is linux-only. this test
+# closes that gap on every PR — it cross-compiles a thread spawn+join program
+# (whose join() calls into the trailing synch descriptor) and runs it under wine.
+# before #1388 the synch call dispatched through a null pointer and faulted; a
+# regressed thunk faults again and fails the test.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+# the test runs a windows binary; without wine there is nothing to execute it.
+if ! command -v wine >/dev/null 2>&1; then
+    echo "SKIP threadsync: 'wine' not available to run the windows binary"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL threadsync: windows cross-build failed" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/windows/bin/threadsync.exe"
+test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
+
+# a correct run completes in well under a second. bound it with `timeout`: a
+# regressed thunk faults on the synch call, and wine's crash handler (winedbg
+# --auto) can hang rather than exit, so a bare `wine` would stall CI instead of
+# failing — the timeout turns that hang into a fast nonzero exit (124).
+set +e
+WINEDEBUG=-all timeout 60 wine "$EXE" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS threadsync: trailing-descriptor synch call-thunk dispatches (spawn+join under wine)"
+    exit 0
+fi
+
+echo "FAIL threadsync: trailing-descriptor synch call faulted, hung, or worker did not run (exit $code)" >&2
+exit 1


### PR DESCRIPTION
## Gap

The #1388 fix (trailing PE import descriptor's call-thunk targets its own `FirstThunk` slot) has **no runtime regression guard on a windows binary** in CI:

- The **native windows lane** (#1367) runs `mach.exe test .`, but the compiler doesn't import `std.sync.thread` — so the 2 synch-calling thread tests aren't in mach's corpus and mach.exe imports the synch DLL *dead* (no call site references its IAT slots). The lane proves the binary *loads* with 4 descriptors, not that a trailing-descriptor import is *called*.
- mach-std's CI is **linux-only**; its thread tests `running_under_wine()`-skip, so they never exercise the windows synch call path either.

Only the `coff` unit test (`pe_iat_slot_rva` nlib=4 slot math) guards #1388 today; nothing executes a trailing-descriptor call on a windows binary.

## Fix

A `.github/tests/threadsync` integration test — the `integration` job already installs wine and runs `.github/tests/*/run.sh` under it. It cross-compiles a thread spawn+join program and runs it under wine. `join()` waits via `WaitOnAddress`/`WakeByAddressSingle` from `api-ms-win-core-synch` — std's **4th/trailing** import descriptor — so a regressed call-thunk dispatches through a null IAT slot and faults (`jmp 0`), failing the test. Mirrors the existing `win64fnptr` wine test structure.

## Verification

- **Passes** with a #1388-carrying compiler (the program imports `[kernel32, ws2_32, advapi32, api-ms-win-core-synch]` with synch trailing; its synch stubs jump through their own IAT slots; spawn+join completes under wine, exit 0).
- The guard bites by construction: a pre-#1388 emitter faults on the synch call (nonzero exit).

Closes #1399. Follows the v1.5.1 windows-backend completion (#1388 / #1395 / #1367).