### PR TITLE
fix(dep): materialize path deps via std fs primitives, not ln/rm shell-outs (#1392)

### DIFF
--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -433,7 +433,7 @@ fun materialize_path_node(alloc: *Allocator, node: *DepNode, dep_root: str, dep_
     val target_r: Result[str, str] = link_target(alloc, dep_name, node.dir);
     if (is_err[str, str](target_r)) { print.eprint("error: out of memory\n"); ret 2; }
     val target: str = unwrap_ok[str, str](target_r);
-    if (is_err[bool, str](make_symlink(alloc, target, vendor))) {
+    if (is_err[bool, str](make_symlink(target, vendor))) {
         print.eprint("error: failed to link ");
         print.eprint(vendor);
         print.eprint(" -> ");
@@ -491,29 +491,13 @@ fun path_segments(s: str) usize {
     ret count;
 }
 
-# make_symlink: create a symbolic link at `linkpath` pointing at `target` by
-# shelling to `ln -s`. resolution already shells to system git/rm; reusing `ln`
-# avoids a hand-rolled symlinkat across every host os. the caller has cleared any
-# prior link, so no `-f` is needed. ln's absence is a clean error.
-fun make_symlink(alloc: *Allocator, target: str, linkpath: str) Result[bool, str] {
-    val ln_r: Result[str, str] = find_on_path(alloc, "ln");
-    if (is_err[str, str](ln_r)) { ret err[bool, str]("ln not found on PATH (needed to materialize path dependencies)"); }
-    val ln: str = unwrap_ok[str, str](ln_r);
-    val env_r: Result[**u8, str] = build_env(alloc);
-    if (is_err[**u8, str](env_r)) { ret err[bool, str]("failed to build child environment for ln"); }
-    val env: **u8 = unwrap_ok[**u8, str](env_r);
-
-    var argv: [5]usize;
-    argv[0] = ln::usize;
-    argv[1] = "-s"::usize;
-    argv[2] = target::usize;
-    argv[3] = linkpath::usize;
-    argv[4] = 0;
-    val rr: Result[exec.ExitStatus, str] = exec.run(ln, (?argv[0])::**u8, env);
-    if (is_err[exec.ExitStatus, str](rr)) { ret err[bool, str]("failed to spawn ln"); }
-    val s: exec.ExitStatus = unwrap_ok[exec.ExitStatus, str](rr);
-    if (!exec.exited(s) || exec.code(s) != 0) { ret err[bool, str]("ln exited non-zero"); }
-    ret ok[bool, str](true);
+# make_symlink: create a symbolic link at `linkpath` pointing at `target`. the
+# target is recorded verbatim — a relative path the build resolves against the
+# link's own directory by the vendor layout — and the caller has already cleared
+# any prior link. delegates to the std filesystem primitive (no host `ln`, so
+# path dependencies materialize on hosts without it, e.g. native windows).
+fun make_symlink(target: str, linkpath: str) Result[bool, str] {
+    ret fs.symlink(target, linkpath);
 }
 
 # git_fail: the generic per-dep git failure exit, naming the dependency.
@@ -1447,23 +1431,11 @@ fun dep_dir_path(alloc: *Allocator, name: *u8) Result[str, str] {
     ret join2(alloc, unwrap_ok[str, str](root_r), name);
 }
 
-# remove_tree: delete a directory tree by shelling to `rm -rf`. resolution already
-# depends on `git` on PATH; reusing the system `rm` avoids a hand-rolled recursive
-# unlink.
+# remove_tree: best-effort recursive delete of a directory tree via the std
+# filesystem primitive (no host `rm`). errors are ignored — the tree is cleared
+# before re-vendoring, so a stale or partially removed dir is not fatal.
 fun remove_tree(alloc: *Allocator, dir: str) {
-    val rm_r: Result[str, str] = find_on_path(alloc, "rm");
-    if (is_err[str, str](rm_r)) { ret; }
-    val rm: str = unwrap_ok[str, str](rm_r);
-    val env_r: Result[**u8, str] = build_env(alloc);
-    if (is_err[**u8, str](env_r)) { ret; }
-    val env: **u8 = unwrap_ok[**u8, str](env_r);
-
-    var argv: [4]usize;
-    argv[0] = rm::usize;
-    argv[1] = "-rf"::usize;
-    argv[2] = dir::usize;
-    argv[3] = 0;
-    exec.run(rm, (?argv[0])::**u8, env);
+    fs.remove_all(alloc, dir);
 }
 
 # find_on_path: resolve an absolute path to `name` via util.resolve_cmd.


### PR DESCRIPTION
## Problem

`src/cli/cmd/dep.mach` shelled out to host `ln -s` (path-dep symlink) and `rm -rf` (stale vendor-dir cleanup). `ln` is not on PATH on native windows, so path-dependency materialization failed there. Now unblocked: std v0.10.0 (the current pin) ships `fs.symlink` and `fs.remove_all` (std #257).

## Change

- `make_symlink` → `fs.symlink(target, linkpath)` (relative target recorded verbatim; caller still clears any prior link). Dropped the now-unused `alloc` param.
- `remove_tree` → `fs.remove_all(alloc, dir)` (best-effort, errors ignored as before).
- Removed the `find_on_path("ln")` / `find_on_path("rm")` calls and their `exec.run` plumbing. **Kept** the `git` shell-out (legitimate network transport) — `find_on_path`, `build_env`, and `exec` remain for it.

Net `-40/+12` in one file.

## Verification

- Builds clean; unit suite **426/426**.
- `.github/tests/pathdep` (the behavior coverage) passes all 12 checks: materialize-as-symlink, symlink resolves, re-pull idempotency (exercises the recursive remove + re-link), stale real-dir is a hard error, and the built app calls into the path dep.

Closes #1392.