### PR TITLE
test(ci): timeout the win64fnptr wine run; pin threadsync dep to branch/main

### DIFF
--- a/.github/tests/threadsync/app/mach.toml
+++ b/.github/tests/threadsync/app/mach.toml
@@ -19,4 +19,4 @@ entry = "main.mach"
 
 [deps.mach-std]
 git = "https://github.com/octalide/mach-std"
-ref = "branch/dev"
+ref = "branch/main"

--- a/.github/tests/win64fnptr/run.sh
+++ b/.github/tests/win64fnptr/run.sh
@@ -50,8 +50,11 @@ fi
 EXE="$WORK/app/out/windows/bin/win64fnptr.exe"
 test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
 
+# bound the run with `timeout`: a regressed binary faults, and wine's crash
+# handler (winedbg --auto) can hang rather than exit, which would stall the
+# integration job — the timeout turns that hang into a fast nonzero exit (124).
 set +e
-WINEDEBUG=-all wine "$EXE" >/dev/null 2>&1
+WINEDEBUG=-all timeout 60 wine "$EXE" >/dev/null 2>&1
 code=$?
 set -e
 


### PR DESCRIPTION
Two small CI test-hardening nits (both ride v1.5.2; non-blocking).

1. **win64fnptr wine timeout** (follow-up from #1399 review): the win64fnptr integration test had the same latent hang-on-failure as threadsync — a regressed binary faults under wine and `winedbg --auto` can hang instead of exiting, stalling the integration job. Wrap its wine run in `timeout 60` so a regression fails fast (exit 124). The pass case is unaffected (verified locally: PASS in 0.6s).
2. **threadsync dep ref → branch/main**: the threadsync test app's `[deps.mach-std]` ref was `branch/dev`; flip to `branch/main` per the standing dep-pin directive. It's unused at runtime (run.sh symlink-injects the repo's vendored std before build), so this is consistency-only.

Test-infra only; no compiler change.