### PR TITLE
chore: release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-06-13
+
+Maintenance patch: path dependencies materialize through the standard library
+instead of host `ln`/`rm`, the target vtables become immutable `str`-named
+singletons, and the windows CI gains a trailing-import-descriptor regression
+guard.
+
+### Fixed
+
+- Path dependencies materialize via the std filesystem primitives (`fs.symlink`,
+  `fs.remove_all`) instead of shelling to `ln -s` / `rm -rf`, so they no longer
+  require host `ln`/`rm` — fixing path-dependency materialization on native
+  Windows, where `ln` is not on `PATH`. The `git` transport is unchanged (#1392).
+
+### Changed
+
+- The OF/ISA/OS/ABI vtable `name` and register-class names are immutable `str`
+  constants set directly by the registrars, no longer `StrId` fields re-interned
+  per session; the dead `OfVTable.file_extension` is removed. Behavior-preserving,
+  verified by the byte-identical self-host fixpoint (#1377; the remaining
+  interner-elimination is tracked in #1402).
+- CI: a `threadsync` wine integration test guards the trailing PE
+  import-descriptor call-thunk against regression (#1388), and the win64 wine
+  tests are bounded with a `timeout` so a faulting binary fails fast instead of
+  hanging the lane (#1399, #1404).
+
 ## [1.5.1] - 2026-06-13
 
 Native Windows lane: CI now builds `mach.exe` and runs the in-source test suite

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "1.5.1"
+version = "1.5.2"
 src = "src"
 dep = "dep"
 target = "native"


### PR DESCRIPTION
Release v1.5.2 — maintenance patch. dev already carries the bundle (all merged + green incl. the native lane); this rolls the version + CHANGELOG.

Contents:
- #1392 (#1401): path deps materialize via std fs primitives, not ln/rm — fixes native-windows path deps.
- #1377-A (#1403): immutable vtable name/file_extension/reg-class str constants (behavior-preserving; self-host fixpoint byte-identical). Interner-elimination half tracked in #1402 (deferred).
- #1399/#1400 + #1404: threadsync wine regression guard for the trailing PE import call-thunk + win64fnptr wine timeout.

version 1.5.1 → 1.5.2; std lock already v0.10.0. Cut: this → dev, then dev → main (no-FF) → annotated tag v1.5.2.