### PR TITLE
release: integrate v1.5.2 to main

### DIFF
--- a/.github/tests/threadsync/app/mach.toml
+++ b/.github/tests/threadsync/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "threadsync"
+name = "win64 trailing PE import-descriptor call-thunk regression — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "windows"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+ext  = ".exe"
+
+[bin.threadsync]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/threadsync/app/mach.toml
+++ b/.github/tests/threadsync/app/mach.toml
@@ -19,4 +19,4 @@ entry = "main.mach"
 
 [deps.mach-std]
 git = "https://github.com/octalide/mach-std"
-ref = "branch/dev"
+ref = "branch/main"

--- a/.github/tests/threadsync/app/src/main.mach
+++ b/.github/tests/threadsync/app/src/main.mach
@@ -1,0 +1,30 @@
+use std.runtime;
+use std.types.size.usize;
+use thread: std.sync.thread;
+use atomic: std.sync.atomic;
+
+# whether the spawned worker ran, flipped 0 -> 1 by the child and read back after
+# join. join() waits on the worker's completion flag via WaitOnAddress, and the
+# worker wakes it via WakeByAddressSingle — both imported from
+# api-ms-win-core-synch-l1-2-0.dll, std's 4th (trailing) PE import descriptor.
+var ran: i64 = 0;
+
+fun worker() {
+    atomic.store(?ran, 1);
+}
+
+# main: spawn a worker, join it (the synch wait/wake round-trip), and verify the
+# worker observably ran. before mach#1388 the call-thunk for a trailing import
+# descriptor jumped through the previous descriptor's null IAT slot, so the
+# WaitOnAddress call in join() dispatched through a null pointer and faulted
+# (`jmp 0`) — a nonzero exit. exits 0 only when the trailing-descriptor synch
+# calls dispatch correctly.
+$main.symbol = "main";
+fun main(argc: usize, argv: **u8) i64 {
+    atomic.store(?ran, 0);
+    var t: thread.Thread;
+    thread.spawn(worker, ?t);
+    thread.join(?t);
+    if (atomic.load(?ran) != 1) { ret 1; }
+    ret 0;
+}

--- a/.github/tests/threadsync/run.sh
+++ b/.github/tests/threadsync/run.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# trailing PE import-descriptor call-thunk regression test (#1388 / #1399): the
+# import call-thunk for the LAST import descriptor must jump through its own
+# descriptor's IAT slot, not the previous descriptor's null terminator. std links
+# four windows DLLs in order [kernel32, ws2_32, advapi32, api-ms-win-core-synch];
+# WaitOnAddress / WakeByAddressSingle live in the 4th (trailing) descriptor.
+#
+# mach's native windows lane does not cover this: the compiler does not import
+# std.sync.thread, so mach.exe imports the synch DLL dead (no call site) and the
+# 2 std thread tests are not in its corpus; std's own CI is linux-only. this test
+# closes that gap on every PR — it cross-compiles a thread spawn+join program
+# (whose join() calls into the trailing synch descriptor) and runs it under wine.
+# before #1388 the synch call dispatched through a null pointer and faulted; a
+# regressed thunk faults again and fails the test.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+# the test runs a windows binary; without wine there is nothing to execute it.
+if ! command -v wine >/dev/null 2>&1; then
+    echo "SKIP threadsync: 'wine' not available to run the windows binary"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL threadsync: windows cross-build failed" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/windows/bin/threadsync.exe"
+test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
+
+# a correct run completes in well under a second. bound it with `timeout`: a
+# regressed thunk faults on the synch call, and wine's crash handler (winedbg
+# --auto) can hang rather than exit, so a bare `wine` would stall CI instead of
+# failing — the timeout turns that hang into a fast nonzero exit (124).
+set +e
+WINEDEBUG=-all timeout 60 wine "$EXE" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS threadsync: trailing-descriptor synch call-thunk dispatches (spawn+join under wine)"
+    exit 0
+fi
+
+echo "FAIL threadsync: trailing-descriptor synch call faulted, hung, or worker did not run (exit $code)" >&2
+exit 1

--- a/.github/tests/win64fnptr/run.sh
+++ b/.github/tests/win64fnptr/run.sh
@@ -50,8 +50,11 @@ fi
 EXE="$WORK/app/out/windows/bin/win64fnptr.exe"
 test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
 
+# bound the run with `timeout`: a regressed binary faults, and wine's crash
+# handler (winedbg --auto) can hang rather than exit, which would stall the
+# integration job — the timeout turns that hang into a fast nonzero exit (124).
 set +e
-WINEDEBUG=-all wine "$EXE" >/dev/null 2>&1
+WINEDEBUG=-all timeout 60 wine "$EXE" >/dev/null 2>&1
 code=$?
 set -e
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-06-13
+
+Maintenance patch: path dependencies materialize through the standard library
+instead of host `ln`/`rm`, the target vtables become immutable `str`-named
+singletons, and the windows CI gains a trailing-import-descriptor regression
+guard.
+
+### Fixed
+
+- Path dependencies materialize via the std filesystem primitives (`fs.symlink`,
+  `fs.remove_all`) instead of shelling to `ln -s` / `rm -rf`, so they no longer
+  require host `ln`/`rm` — fixing path-dependency materialization on native
+  Windows, where `ln` is not on `PATH`. The `git` transport is unchanged (#1392).
+
+### Changed
+
+- The OF/ISA/OS/ABI vtable `name` and register-class names are immutable `str`
+  constants set directly by the registrars, no longer `StrId` fields re-interned
+  per session; the dead `OfVTable.file_extension` is removed. Behavior-preserving,
+  verified by the byte-identical self-host fixpoint (#1377; the remaining
+  interner-elimination is tracked in #1402).
+- CI: a `threadsync` wine integration test guards the trailing PE
+  import-descriptor call-thunk against regression (#1388), and the win64 wine
+  tests are bounded with a `timeout` so a faulting binary fails fast instead of
+  hanging the lane (#1399, #1404).
+
 ## [1.5.1] - 2026-06-13
 
 Native Windows lane: CI now builds `mach.exe` and runs the in-source test suite

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "1.5.1"
+version = "1.5.2"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -433,7 +433,7 @@ fun materialize_path_node(alloc: *Allocator, node: *DepNode, dep_root: str, dep_
     val target_r: Result[str, str] = link_target(alloc, dep_name, node.dir);
     if (is_err[str, str](target_r)) { print.eprint("error: out of memory\n"); ret 2; }
     val target: str = unwrap_ok[str, str](target_r);
-    if (is_err[bool, str](make_symlink(alloc, target, vendor))) {
+    if (is_err[bool, str](make_symlink(target, vendor))) {
         print.eprint("error: failed to link ");
         print.eprint(vendor);
         print.eprint(" -> ");
@@ -491,29 +491,13 @@ fun path_segments(s: str) usize {
     ret count;
 }
 
-# make_symlink: create a symbolic link at `linkpath` pointing at `target` by
-# shelling to `ln -s`. resolution already shells to system git/rm; reusing `ln`
-# avoids a hand-rolled symlinkat across every host os. the caller has cleared any
-# prior link, so no `-f` is needed. ln's absence is a clean error.
-fun make_symlink(alloc: *Allocator, target: str, linkpath: str) Result[bool, str] {
-    val ln_r: Result[str, str] = find_on_path(alloc, "ln");
-    if (is_err[str, str](ln_r)) { ret err[bool, str]("ln not found on PATH (needed to materialize path dependencies)"); }
-    val ln: str = unwrap_ok[str, str](ln_r);
-    val env_r: Result[**u8, str] = build_env(alloc);
-    if (is_err[**u8, str](env_r)) { ret err[bool, str]("failed to build child environment for ln"); }
-    val env: **u8 = unwrap_ok[**u8, str](env_r);
-
-    var argv: [5]usize;
-    argv[0] = ln::usize;
-    argv[1] = "-s"::usize;
-    argv[2] = target::usize;
-    argv[3] = linkpath::usize;
-    argv[4] = 0;
-    val rr: Result[exec.ExitStatus, str] = exec.run(ln, (?argv[0])::**u8, env);
-    if (is_err[exec.ExitStatus, str](rr)) { ret err[bool, str]("failed to spawn ln"); }
-    val s: exec.ExitStatus = unwrap_ok[exec.ExitStatus, str](rr);
-    if (!exec.exited(s) || exec.code(s) != 0) { ret err[bool, str]("ln exited non-zero"); }
-    ret ok[bool, str](true);
+# make_symlink: create a symbolic link at `linkpath` pointing at `target`. the
+# target is recorded verbatim — a relative path the build resolves against the
+# link's own directory by the vendor layout — and the caller has already cleared
+# any prior link. delegates to the std filesystem primitive (no host `ln`, so
+# path dependencies materialize on hosts without it, e.g. native windows).
+fun make_symlink(target: str, linkpath: str) Result[bool, str] {
+    ret fs.symlink(target, linkpath);
 }
 
 # git_fail: the generic per-dep git failure exit, naming the dependency.
@@ -1447,23 +1431,11 @@ fun dep_dir_path(alloc: *Allocator, name: *u8) Result[str, str] {
     ret join2(alloc, unwrap_ok[str, str](root_r), name);
 }
 
-# remove_tree: delete a directory tree by shelling to `rm -rf`. resolution already
-# depends on `git` on PATH; reusing the system `rm` avoids a hand-rolled recursive
-# unlink.
+# remove_tree: best-effort recursive delete of a directory tree via the std
+# filesystem primitive (no host `rm`). errors are ignored — the tree is cleared
+# before re-vendoring, so a stale or partially removed dir is not fatal.
 fun remove_tree(alloc: *Allocator, dir: str) {
-    val rm_r: Result[str, str] = find_on_path(alloc, "rm");
-    if (is_err[str, str](rm_r)) { ret; }
-    val rm: str = unwrap_ok[str, str](rm_r);
-    val env_r: Result[**u8, str] = build_env(alloc);
-    if (is_err[**u8, str](env_r)) { ret; }
-    val env: **u8 = unwrap_ok[**u8, str](env_r);
-
-    var argv: [4]usize;
-    argv[0] = rm::usize;
-    argv[1] = "-rf"::usize;
-    argv[2] = dir::usize;
-    argv[3] = 0;
-    exec.run(rm, (?argv[0])::**u8, env);
+    fs.remove_all(alloc, dir);
 }
 
 # find_on_path: resolve an absolute path to `name` via util.resolve_cmd.

--- a/src/cli/cmd/info.mach
+++ b/src/cli/cmd/info.mach
@@ -81,7 +81,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     print.print(host_isa());
     print.print("\n");
 
-    val code: i64 = print_capabilities(?reg, ?interner);
+    val code: i64 = print_capabilities(?reg);
     intern.dnit(?interner);
     ret code;
 }
@@ -106,103 +106,76 @@ fun host_isa() str {
 }
 
 # print_capabilities: emit the four registry lines (isa / os / abi / object) from
-# `reg`. returns 0 on success, or 2 if a registered vtable's name is not interned —
-# an internal inconsistency, since register_all interned every name.
-fun print_capabilities(reg: *tgt.TargetRegistry, i: *intern.Interner) i64 {
-    if (is_err[bool, str](print_isa(?reg.isa, i))) { ret cap_fail(); }
-    if (is_err[bool, str](print_os(?reg.os, i)))   { ret cap_fail(); }
-    if (is_err[bool, str](print_abi(?reg.abi, i))) { ret cap_fail(); }
-    if (is_err[bool, str](print_of(?reg.of, i)))   { ret cap_fail(); }
+# `reg`. each vtable's name is now an immutable `str` constant, so reading it
+# cannot fail and no interner is needed for display.
+fun print_capabilities(reg: *tgt.TargetRegistry) i64 {
+    print_isa(?reg.isa);
+    print_os(?reg.os);
+    print_abi(?reg.abi);
+    print_of(?reg.of);
     ret 0;
 }
 
-# cap_fail: report a registry-name resolution failure and yield exit code 2.
-fun cap_fail() i64 {
-    print.eprint("error: a registered target component has no interned name\n");
-    ret 2;
-}
-
-# name_of: resolve a registry vtable's interned name. errors when the id is not
-# interned — register_all interns every name, so a miss is an internal bug, not
-# a value to paper over with a placeholder.
-fun name_of(i: *intern.Interner, id: intern.StrId) Result[str, str] {
-    val opt: Option[str] = intern.lookup(i, id);
-    if (is_some[str](opt)) { ret ok[str, str](unwrap[str](opt)); }
-    ret err[str, str]("name not interned");
-}
-
 # print_isa: list the registered instruction sets in `reg` on one `isa:` line.
-fun print_isa(reg: *isa.IsaRegistry, i: *intern.Interner) Result[bool, str] {
+fun print_isa(reg: *isa.IsaRegistry) {
     print.print("isa:");
     var k: u32 = 0;
     val n: u32 = isa.registered_count(reg);
     for (k < n) {
         val vt_opt: Option[*isa.IsaVTable] = isa.registered(reg, k);
         if (is_some[*isa.IsaVTable](vt_opt)) {
-            val nm: Result[str, str] = name_of(i, unwrap[*isa.IsaVTable](vt_opt).name);
-            if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }
             print.print(" ");
-            print.print(unwrap_ok[str, str](nm));
+            print.print(unwrap[*isa.IsaVTable](vt_opt).name);
         }
         k = k + 1;
     }
     print.print("\n");
-    ret ok[bool, str](true);
 }
 
 # print_os: list the registered operating systems in `reg` on one `os:` line.
-fun print_os(reg: *os.OsRegistry, i: *intern.Interner) Result[bool, str] {
+fun print_os(reg: *os.OsRegistry) {
     print.print("os:");
     var k: u32 = 0;
     val n: u32 = os.registered_count(reg);
     for (k < n) {
         val vt_opt: Option[*os.OsVTable] = os.registered(reg, k);
         if (is_some[*os.OsVTable](vt_opt)) {
-            val nm: Result[str, str] = name_of(i, unwrap[*os.OsVTable](vt_opt).name);
-            if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }
             print.print(" ");
-            print.print(unwrap_ok[str, str](nm));
+            print.print(unwrap[*os.OsVTable](vt_opt).name);
         }
         k = k + 1;
     }
     print.print("\n");
-    ret ok[bool, str](true);
 }
 
 # print_abi: list the registered calling conventions in `reg` on one `abi:` line.
-fun print_abi(reg: *abi.AbiRegistry, i: *intern.Interner) Result[bool, str] {
+fun print_abi(reg: *abi.AbiRegistry) {
     print.print("abi:");
     var k: u32 = 0;
     val n: u32 = abi.registered_count(reg);
     for (k < n) {
         val vt_opt: Option[*abi.AbiVTable] = abi.registered(reg, k);
         if (is_some[*abi.AbiVTable](vt_opt)) {
-            val nm: Result[str, str] = name_of(i, unwrap[*abi.AbiVTable](vt_opt).name);
-            if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }
             print.print(" ");
-            print.print(unwrap_ok[str, str](nm));
+            print.print(unwrap[*abi.AbiVTable](vt_opt).name);
         }
         k = k + 1;
     }
     print.print("\n");
-    ret ok[bool, str](true);
 }
 
 # print_of: list the registered object formats in `reg` on one `object:` line.
-fun print_of(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
+fun print_of(reg: *of.OfRegistry) {
     print.print("object:");
     var k: u32 = 0;
     val n: u32 = of.registered_count(reg);
     for (k < n) {
         val vt_opt: Option[*of.OfVTable] = of.registered(reg, k);
         if (is_some[*of.OfVTable](vt_opt)) {
-            val nm: Result[str, str] = name_of(i, unwrap[*of.OfVTable](vt_opt).name);
-            if (is_err[str, str](nm)) { ret err[bool, str](unwrap_err[str, str](nm)); }
             print.print(" ");
-            print.print(unwrap_ok[str, str](nm));
+            print.print(unwrap[*of.OfVTable](vt_opt).name);
         }
         k = k + 1;
     }
     print.print("\n");
-    ret ok[bool, str](true);
 }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -15,6 +15,7 @@ use std.types.option.none;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
+use std.types.string.str;
 
 use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
@@ -186,7 +187,7 @@ pub def VaModelFn: fun() VaModel;
 #               convention id (cast back to `VaModelFn`)
 pub rec AbiVTable {
     id:           u32;
-    name:         intern.StrId;
+    name:         str;
     classify:     *u8;
     arg_passing:  *u8;
     ret_passing:  *u8;

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -472,11 +472,8 @@ var sysv_vtable: abi.AbiVTable;
 # ret: ok(true) on success, or an allocation error from interning
 pub fun register(reg: *abi.AbiRegistry, i: *intern.Interner) Result[bool, str] {
 
-    val rn: Result[intern.StrId, str] = intern.intern(i, "sysv");
-    if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
-
     sysv_vtable.id           = abi.ABI_SYSV;
-    sysv_vtable.name         = unwrap_ok[intern.StrId, str](rn);
+    sysv_vtable.name         = "sysv";
     sysv_vtable.classify     = classify::*u8;
     sysv_vtable.arg_passing  = classify_arg::*u8;
     sysv_vtable.ret_passing  = classify_return::*u8;

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -456,11 +456,8 @@ var win64_vtable: abi.AbiVTable;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_win64(reg: *abi.AbiRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
-    val rn: Result[intern.StrId, str] = intern.intern(i, "win64");
-    if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
-
     win64_vtable.id           = abi.ABI_WIN64;
-    win64_vtable.name         = unwrap_ok[intern.StrId, str](rn);
+    win64_vtable.name         = "win64";
     win64_vtable.classify     = classify::*u8;
     win64_vtable.arg_passing  = classify_arg::*u8;
     win64_vtable.ret_passing  = classify_return::*u8;

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -173,7 +173,7 @@ pub rec InstBuf {
 # bit_width: width of one register in bits
 # count:     number of registers in the class
 pub rec RegClass {
-    name:      intern.StrId;
+    name:      str;
     bit_width: u32;
     count:     u32;
 }
@@ -285,7 +285,7 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 #                     (x86-64 RCX, used as CL), or -1
 pub rec IsaVTable {
     id:                 u32;
-    name:               intern.StrId;
+    name:               str;
     pointer_width:      u32;
     endianness:         u32;
     reg_classes:        *RegClass;

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -77,27 +77,15 @@ var arm64_vtable: isa.IsaVTable;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_arm64(reg: *isa.IsaRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
-    val rn: Result[intern.StrId, str] = intern.intern(i, "aarch64");
-    if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
-
-    val rg: Result[intern.StrId, str] = intern.intern(i, "gpr");
-    if (is_err[intern.StrId, str](rg)) { ret err[bool, str](unwrap_err[intern.StrId, str](rg)); }
-
-    val rv: Result[intern.StrId, str] = intern.intern(i, "vector");
-    if (is_err[intern.StrId, str](rv)) { ret err[bool, str](unwrap_err[intern.StrId, str](rv)); }
-
-    val rf: Result[intern.StrId, str] = intern.intern(i, "flags");
-    if (is_err[intern.StrId, str](rf)) { ret err[bool, str](unwrap_err[intern.StrId, str](rf)); }
-
-    arm64_reg_classes[0].name      = unwrap_ok[intern.StrId, str](rg);
+    arm64_reg_classes[0].name      = "gpr";
     arm64_reg_classes[0].bit_width = 64;
     arm64_reg_classes[0].count     = ARM64_GPR_COUNT;
 
-    arm64_reg_classes[1].name      = unwrap_ok[intern.StrId, str](rv);
+    arm64_reg_classes[1].name      = "vector";
     arm64_reg_classes[1].bit_width = 128;
     arm64_reg_classes[1].count     = ARM64_VECTOR_COUNT;
 
-    arm64_reg_classes[2].name      = unwrap_ok[intern.StrId, str](rf);
+    arm64_reg_classes[2].name      = "flags";
     arm64_reg_classes[2].bit_width = 64;
     arm64_reg_classes[2].count     = 1;
 
@@ -107,7 +95,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry, alloc: *Allocator, i: *intern.Inte
     arm64_reserved_regs[1].size = 8;
 
     arm64_vtable.id                 = isa.ARCH_AARCH64;
-    arm64_vtable.name               = unwrap_ok[intern.StrId, str](rn);
+    arm64_vtable.name               = "aarch64";
     arm64_vtable.pointer_width      = 8;
     arm64_vtable.endianness         = isa.ENDIAN_LITTLE;
     arm64_vtable.reg_classes        = ?arm64_reg_classes[0];

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -85,26 +85,7 @@ var x64_reload_scratch_regs: [3]isa.Register;
 # ret:      true on success, or an error string if name interning fails
 pub fun register_x64(reg: *isa.IsaRegistry, alloc: *Allocator, interner: *intern.Interner) Result[bool, str] {
 
-    val res_name: Result[intern.StrId, str] = intern.intern(interner, "x86_64");
-    if (is_err[intern.StrId, str](res_name)) {
-        ret err[bool, str](unwrap_err[intern.StrId, str](res_name));
-    }
-    val name_id: intern.StrId = unwrap_ok[intern.StrId, str](res_name);
-
-    val res_gpr: Result[intern.StrId, str] = intern.intern(interner, "gpr");
-    if (is_err[intern.StrId, str](res_gpr)) {
-        ret err[bool, str](unwrap_err[intern.StrId, str](res_gpr));
-    }
-    val res_xmm: Result[intern.StrId, str] = intern.intern(interner, "xmm");
-    if (is_err[intern.StrId, str](res_xmm)) {
-        ret err[bool, str](unwrap_err[intern.StrId, str](res_xmm));
-    }
-    val res_flags: Result[intern.StrId, str] = intern.intern(interner, "flags");
-    if (is_err[intern.StrId, str](res_flags)) {
-        ret err[bool, str](unwrap_err[intern.StrId, str](res_flags));
-    }
-
-    x64_classes[0].name      = unwrap_ok[intern.StrId, str](res_gpr);
+    x64_classes[0].name      = "gpr";
     x64_classes[0].bit_width = 64;
     x64_classes[0].count     = 16;
 
@@ -114,11 +95,11 @@ pub fun register_x64(reg: *isa.IsaRegistry, alloc: *Allocator, interner: *intern
     # a live float vreg can never occupy one and be clobbered by the expansion — the
     # SSE analogue of holding R10/R11 back from the GP value pool for the encoder's
     # reload / mem-mem scratch.
-    x64_classes[1].name      = unwrap_ok[intern.StrId, str](res_xmm);
+    x64_classes[1].name      = "xmm";
     x64_classes[1].bit_width = 128;
     x64_classes[1].count     = 14;
 
-    x64_classes[2].name      = unwrap_ok[intern.StrId, str](res_flags);
+    x64_classes[2].name      = "flags";
     x64_classes[2].bit_width = 64;
     x64_classes[2].count     = 1;
 
@@ -135,7 +116,7 @@ pub fun register_x64(reg: *isa.IsaRegistry, alloc: *Allocator, interner: *intern
     x64_reload_scratch_regs[2].size = 8;
 
     x64_vtable.id                 = isa.ARCH_X86_64;
-    x64_vtable.name               = name_id;
+    x64_vtable.name               = "x86_64";
     x64_vtable.pointer_width      = 8;
     x64_vtable.endianness         = isa.ENDIAN_LITTLE;
     x64_vtable.reg_classes        = ?x64_classes[0];

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -363,8 +363,7 @@ pub def DynExecFn: fun(*Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegmen
 # kinds to its own machine relocation types internally. it never branches on `id`.
 # ---
 # id:               object-format id (one of OF_*)
-# name:             interned format name ("elf", "coff", "macho")
-# file_extension:   interned default object-file extension ("o", "obj")
+# name:             format name ("elf", "coff", "macho"); an immutable str constant
 # emit_object:      serializes an ObjectImage to a relocatable object file
 # parse_object:     reads a relocatable object file into an ObjectImage
 # emit_exec:        serializes laid-out load segments into a static executable
@@ -372,8 +371,7 @@ pub def DynExecFn: fun(*Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegmen
 #                   when the format has no dynamic-link writer yet
 pub rec OfVTable {
     id:               u32;
-    name:             intern.StrId;
-    file_extension:   intern.StrId;
+    name:             str;
     emit_object:      WriterFn;
     parse_object:     ParserFn;
     emit_exec:        ExecFn;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2679,15 +2679,8 @@ var coff_vtable: of.OfVTable;
 # i:   string interner used to intern the vtable's string fields
 # ret: true on success, or an error string if name interning fails
 pub fun register_coff(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
-    val rn: Result[intern.StrId, str] = intern.intern(i, "coff");
-    if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
-
-    val rx: Result[intern.StrId, str] = intern.intern(i, "obj");
-    if (is_err[intern.StrId, str](rx)) { ret err[bool, str](unwrap_err[intern.StrId, str](rx)); }
-
     coff_vtable.id               = of.OF_COFF;
-    coff_vtable.name             = unwrap_ok[intern.StrId, str](rn);
-    coff_vtable.file_extension   = unwrap_ok[intern.StrId, str](rx);
+    coff_vtable.name             = "coff";
     coff_vtable.emit_object      = coff_emit_object;
     coff_vtable.parse_object     = coff_parse_object;
     coff_vtable.emit_exec        = coff_emit_exec;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -765,14 +765,8 @@ var elf_vtable: of.OfVTable;
 # i:   interner used to intern the vtable's string fields
 # ret: ok(true) on success, or an allocation error from interning
 pub fun register(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
-    val rname: Result[intern.StrId, str] = intern.intern(i, "elf");
-    if (is_err[intern.StrId, str](rname)) { ret err[bool, str](unwrap_err[intern.StrId, str](rname)); }
-    val rext: Result[intern.StrId, str] = intern.intern(i, "o");
-    if (is_err[intern.StrId, str](rext)) { ret err[bool, str](unwrap_err[intern.StrId, str](rext)); }
-
     elf_vtable.id               = of.OF_ELF;
-    elf_vtable.name             = unwrap_ok[intern.StrId, str](rname);
-    elf_vtable.file_extension   = unwrap_ok[intern.StrId, str](rext);
+    elf_vtable.name             = "elf";
     elf_vtable.emit_object      = emit_object;
     elf_vtable.parse_object     = parse_object;
     elf_vtable.emit_exec        = emit_exec;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -102,15 +102,8 @@ var macho_vtable: of.OfVTable;
 # i:   string interner used to intern the vtable's string fields
 # ret: true on success, or an error string if name interning fails
 pub fun register_macho(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
-    val rn: Result[intern.StrId, str] = intern.intern(i, "macho");
-    if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
-
-    val rx: Result[intern.StrId, str] = intern.intern(i, "o");
-    if (is_err[intern.StrId, str](rx)) { ret err[bool, str](unwrap_err[intern.StrId, str](rx)); }
-
     macho_vtable.id               = of.OF_MACHO;
-    macho_vtable.name             = unwrap_ok[intern.StrId, str](rn);
-    macho_vtable.file_extension   = unwrap_ok[intern.StrId, str](rx);
+    macho_vtable.name             = "macho";
     macho_vtable.emit_object      = macho_emit_object;
     macho_vtable.parse_object     = macho_parse_object;
     macho_vtable.emit_exec        = macho_emit_exec;

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -13,6 +13,7 @@ use std.types.option.none;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
+use std.types.string.str;
 
 use intern: mach.lang.intern;
 
@@ -54,7 +55,7 @@ pub val OS_FREESTANDING: u32 = 4;
 #                  suffices
 pub rec OsVTable {
     id:             u32;
-    name:           intern.StrId;
+    name:           str;
     entry_symbol:   intern.StrId;
     syscall_layer:  intern.StrId;
     libdir:         intern.StrId;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -50,9 +50,6 @@ var darwin_vtable: os.OsVTable;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_darwin(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
-    val rn: Result[intern.StrId, str] = intern.intern(i, "darwin");
-    if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
-
     val re: Result[intern.StrId, str] = intern.intern(i, "_main");
     if (is_err[intern.StrId, str](re)) { ret err[bool, str](unwrap_err[intern.StrId, str](re)); }
 
@@ -63,7 +60,7 @@ pub fun register_darwin(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Inter
     if (is_err[intern.StrId, str](rl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rl)); }
 
     darwin_vtable.id             = os.OS_DARWIN;
-    darwin_vtable.name           = unwrap_ok[intern.StrId, str](rn);
+    darwin_vtable.name           = "darwin";
     darwin_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
     darwin_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
     darwin_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -61,9 +61,6 @@ var linux_vtable: os.OsVTable;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_linux(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
-    val rn: Result[intern.StrId, str] = intern.intern(i, "linux");
-    if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
-
     val re: Result[intern.StrId, str] = intern.intern(i, "_start");
     if (is_err[intern.StrId, str](re)) { ret err[bool, str](unwrap_err[intern.StrId, str](re)); }
 
@@ -77,7 +74,7 @@ pub fun register_linux(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Intern
     if (is_err[intern.StrId, str](rd)) { ret err[bool, str](unwrap_err[intern.StrId, str](rd)); }
 
     linux_vtable.id             = os.OS_LINUX;
-    linux_vtable.name           = unwrap_ok[intern.StrId, str](rn);
+    linux_vtable.name           = "linux";
     linux_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
     linux_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
     linux_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -53,9 +53,6 @@ var windows_vtable: os.OsVTable;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_windows(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
-    val rn: Result[intern.StrId, str] = intern.intern(i, "windows");
-    if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
-
     val re: Result[intern.StrId, str] = intern.intern(i, "mainCRTStartup");
     if (is_err[intern.StrId, str](re)) { ret err[bool, str](unwrap_err[intern.StrId, str](re)); }
 
@@ -66,7 +63,7 @@ pub fun register_windows(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Inte
     if (is_err[intern.StrId, str](rl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rl)); }
 
     windows_vtable.id             = os.OS_WINDOWS;
-    windows_vtable.name           = unwrap_ok[intern.StrId, str](rn);
+    windows_vtable.name           = "windows";
     windows_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
     windows_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
     windows_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);


### PR DESCRIPTION
Integration merge of dev → main for the **v1.5.2** maintenance release. Carries #1392 (#1401, path-dep std fs primitives), #1377-A (#1403, immutable vtable names), the #1388 threadsync wine guard (#1400) + win64fnptr timeout/threadsync nits (#1404), and the version/CHANGELOG bump (#1405). All green on dev incl. the native lane. Tag v1.5.2 follows on main HEAD.