### PR TITLE
fix: out-of-imm32 global-store reloc miscompile + extreme float-exponent hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now tracks the legalized `disp32` (the same fix covers the ALU memory-destination
   and inline-asm `mov [sym], imm64` paths). No diagnostic was emitted; ordinary code
   storing a large constant to a global silently miscompiled (#1407).
+- comptime: a float literal with an extreme exponent (e.g. `1.0e2000000000`) hung the
+  compiler in the unbounded decimal-scale loop and could silently fold to its mantissa
+  on i64 exponent overflow. The exponent accumulator is now clamped past the point
+  f64 saturates, so such literals fold to `inf`/`0.0` instead (#1408).
 
 ## [1.5.2] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- codegen (x86-64): an 8-byte store of an immediate outside signed-`imm32` range to
+  a global is legalized into `MOVABS r11, imm64` + a register store, but the PC32
+  relocation was patched at the pre-legalization offset — landing 4 bytes early,
+  corrupting the encoding and leaving the store pointed at `rip+0`. The patch site
+  now tracks the legalized `disp32` (the same fix covers the ALU memory-destination
+  and inline-asm `mov [sym], imm64` paths). No diagnostic was emitted; ordinary code
+  storing a large constant to a global silently miscompiled (#1407).
+
 ## [1.5.2] - 2026-06-13
 
 Maintenance patch: path dependencies materialize through the standard library

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -661,7 +661,11 @@ pub fun eval_lit_float(source: str, span: token.Span) Result[CTValue, str] {
             val c: u8 = text.data[i];
             if (c == 'f') { brk; }
             if (c < '0' || c > '9') { ret err[CTValue, str]("invalid character in float exponent"); }
-            exp = exp * 10 + (c - '0')::i64;
+            # f64 saturates to inf/0 long before 10^1000, so clamp the accumulator: a
+            # larger exponent (e.g. 1.0e2000000000) would otherwise overflow i64 —
+            # silently folding to the mantissa — or spin the scale loop for billions of
+            # iterations. any exponent >= ~309 already yields the same saturated result.
+            if (exp < 1000) { exp = exp * 10 + (c - '0')::i64; }
             saw_exp_digit = true;
             i = i + 1;
         }
@@ -673,7 +677,11 @@ pub fun eval_lit_float(source: str, span: token.Span) Result[CTValue, str] {
             scale = scale * 10.0;
             k = k + 1;
         }
-        if (neg) { value = value / scale; } or { value = value * scale; }
+        # a zero mantissa stays zero at any exponent; the guard also avoids
+        # 0.0 * inf = NaN once the clamped exponent drives the scale to inf.
+        if (value != 0.0) {
+            if (neg) { value = value / scale; } or { value = value * scale; }
+        }
     }
 
     if (!saw_digit) { ret err[CTValue, str]("float literal has no digits"); }
@@ -1863,6 +1871,24 @@ test "comptime: eval_lit_float parses exponent forms and rejects empty input (#1
     if (unwrap_ok[CTValue, str](r4).data.f != 1.0) { ret 1; }
     # empty → error
     if (!is_err[CTValue, str](t_float(""))) { ret 1; }
+    ret 0;
+}
+
+test "comptime: an extreme float exponent saturates instead of hanging or silently folding (#1408)" {
+    # an enormous positive exponent must terminate and saturate to +inf — not spin the
+    # scale loop for billions of iterations, nor overflow the i64 exponent accumulator
+    # (which would silently fold the literal back to its mantissa).
+    val rp: Result[CTValue, str] = t_float("1.0e2000000000");
+    if (is_err[CTValue, str](rp))                          { ret 1; }
+    if (!(unwrap_ok[CTValue, str](rp).data.f > 1.0e308))   { ret 1; }
+    # an enormous negative exponent underflows to 0.0.
+    val rn: Result[CTValue, str] = t_float("1.0e-2000000000");
+    if (is_err[CTValue, str](rn))                          { ret 1; }
+    if (unwrap_ok[CTValue, str](rn).data.f != 0.0)         { ret 1; }
+    # a zero mantissa stays exactly 0.0 (not 0.0 * inf = NaN) at an extreme exponent.
+    val rz: Result[CTValue, str] = t_float("0.0e2000000000");
+    if (is_err[CTValue, str](rz))                          { ret 1; }
+    if (unwrap_ok[CTValue, str](rz).data.f != 0.0)         { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2394,10 +2394,15 @@ fun is_rip_mem(op: *isa.Operand) bool {
 # trailing_imm_width: the number of immediate bytes an instruction emits after its
 # ModR/M displacement, so a relocation against a rip-relative memory destination
 # can step back over them to find the disp32. the MOV / ALU memory-destination
-# forms emit an 8/16/32-bit immediate selected by operand width (a 64-bit operand
-# still takes the sign-extended 32-bit immediate). zero when no immediate trails.
+# forms emit an 8/16/32-bit immediate selected by operand width (an in-range 64-bit
+# operand takes the sign-extended 32-bit immediate). zero when no immediate trails.
 fun trailing_imm_width(mi: *isa.Inst) i32 {
     if (mi.src1.kind != isa.OPK_IMM) { ret 0; }
+    # an 8-byte memory-destination store of an immediate outside signed-imm32 range
+    # is legalized (in encode_mov / encode_alu) into a MOVABS/MOV of the immediate
+    # into R11 followed by a register-source store, so the immediate now precedes the
+    # disp32 instead of trailing it — no immediate bytes follow the patch site.
+    if (mi.size == 8 && (mi.src1.imm < -2147483648 || mi.src1.imm > 2147483647)) { ret 0; }
     if (mi.size == 1) { ret 1; }
     if (mi.size == 2) { ret 2; }
     ret 4;
@@ -6131,5 +6136,49 @@ test "x64.encode: needs_stack_probe gates on the OS commit model and the page bo
     or (needs_stack_probe(?win, 4096))       { bad = 1; }   # exactly one page: no
     or (!needs_stack_probe(?win, 4097))      { bad = 1; }   # one byte over: yes
     or (!needs_stack_probe(?win, 1048576))   { bad = 1; }   # large frame: yes
+    ret bad;
+}
+
+test "x64.encode: an out-of-imm32 store's reloc patch site tracks the legalized disp32 (#1407)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var st: EncodeState;
+    st.buf = buf_init(?alloc);
+
+    # `g = 0x100000000;` to a global: an 8-byte store whose immediate exceeds imm32
+    # cannot use the C7 imm32 form, so encode_mov legalizes it to `MOVABS r11,imm64`
+    # (10 bytes) + `MOV [rip+disp32], r11` (7). the disp32 patch site is therefore
+    # the trailing four bytes at offset 13 — not the offset-9 site the single
+    # pre-legalization instruction implies (the bug this guards: a PC32 reloc landing
+    # 4 bytes early, corrupting the encoding and leaving the store pointed at rip+0).
+    var big: isa.Inst;
+    zero_inst(?big);
+    big.opcode   = x64.MOV;
+    big.size     = 8;
+    big.dst.kind = isa.OPK_MEM;
+    big.dst.size = 8;
+    big.src1     = isa.make_imm(0x100000000, 8);
+    val big_sz: i32 = encode_mov(?big, ?st.buf);
+
+    # an in-range store (`g = 5;`) keeps the C7 form `MOV [rip+disp32], imm32`, whose
+    # disp32 precedes a trailing 4-byte immediate (patch site at offset 3).
+    var small: isa.Inst;
+    zero_inst(?small);
+    small.opcode   = x64.MOV;
+    small.size     = 8;
+    small.dst.kind = isa.OPK_MEM;
+    small.dst.size = 8;
+    small.src1     = isa.make_imm(5, 8);
+    val small_sz: i32 = encode_mov(?small, ?st.buf);
+
+    var bad: i32 = 0;
+    if (big_sz != 17)                                 { bad = 1; }
+    or (trailing_imm_width(?big) != 0)                { bad = 1; }
+    or (x86_reloc_offset(nil, ?big, big_sz) != 13)    { bad = 1; }
+    or (small_sz != 11)                               { bad = 1; }
+    or (trailing_imm_width(?small) != 4)              { bad = 1; }
+    or (x86_reloc_offset(nil, ?small, small_sz) != 3) { bad = 1; }
+
+    buf_dnit(?st.buf);
     ret bad;
 }


### PR DESCRIPTION
Fast correctness patch bundling the two audit findings that miscompile / hang **ordinary code on shipped v1.5.2**. Both have isolated regression tests; the suite is 428/428.

## #1407 — codegen reloc patch-site miscompute (HIGH, silent miscompile)

An 8-byte store of an immediate outside signed-`imm32` range to a global is legalized in `encode_mov` / `encode_alu` into `MOVABS r11, imm64` + a register store. `x86_reloc_offset` derived the PC32 patch site from the *pre-legalization* instruction (`is_rip_mem(dst)` held and `trailing_imm_width` counted a trailing immediate), so the reloc landed 4 bytes early — offset 9 vs the real `disp32` at 13 — corrupting the encoding and leaving the `disp32` = 0 (store → `rip+0`). No diagnostic.

`trailing_imm_width` now returns 0 for the legalized store (the immediate moved to the front MOVABS and no longer trails the `disp32`). The fix is opcode-agnostic, so the single reloc-offset path covers the MOV-store, the ALU memory-destination store, and the inline-asm `mov [sym], imm64` path.

**Verified end to end:** a program storing `0x100000000` to a global runs correctly under this build (exit 0) and crashes with SIGILL (exit 132) under v1.5.2. Unit test asserts the legalized patch site is offset 13 (vs offset 3 for the in-range C7 form).

## #1408 — extreme float-literal exponent hang / silent fold (MED)

`eval_lit_float` folded the exponent with an unbounded decimal-scale loop and an unchecked i64 accumulator: `1.0e2000000000` spun ~2 billion iterations (hang), and a 19+ digit exponent overflowed i64 (could silently fold to the mantissa). The accumulator is now clamped past f64 saturation, so such literals fold to `inf`/`0.0`; a zero mantissa is guarded against `0.0 * inf = NaN`.

Found in the compiler stability audit. Suggested release: v1.5.3 (ahead of the multi-target union).

Closes #1407
Closes #1408