### PR TITLE
refactor(target): push the interner out of the OsVTable into the linker consumers (#1402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on i64 exponent overflow. The exponent accumulator is now clamped past the point
   f64 saturates, so such literals fold to `inf`/`0.0` instead (#1408).
 
+### Changed
+
+- The `OsVTable` `entry_symbol`, `syscall_layer`, `libdir`, and `dynamic_linker`
+  fields are immutable `str` constants set directly by the OS registrars, no longer
+  `StrId` fields re-interned per session; the linker now interns these at the point
+  of use (the entry-symbol lookup and the dynamic interpreter path), completing the
+  interner-elimination from the OS vtable started in #1377. Behavior-preserving,
+  verified by the byte-identical self-host fixpoint (#1402).
+
 ## [1.5.2] - 2026-06-13
 
 Maintenance patch: path dependencies materialize through the standard library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default target's branches win" — and a module that does not fully resolve there
   records diagnostics without aborting the build (#1391).
 
+### Changed
+
+- The `OsVTable` `entry_symbol`, `syscall_layer`, `libdir`, and `dynamic_linker`
+  fields are immutable `str` constants set directly by the OS registrars, no longer
+  `StrId` fields re-interned per session; the linker now interns these at the point
+  of use (the entry-symbol lookup and the dynamic interpreter path), completing the
+  interner-elimination from the OS vtable started in #1377. Behavior-preserving,
+  verified by the byte-identical self-host fixpoint (#1402).
+
 ## [1.5.3] - 2026-06-13
 
 Correctness patch for two silent defects in shipped v1.5.2: a relocation

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1705,11 +1705,11 @@ fun resolve_shared_into(p: *driver.Project, name: *u8, argc: usize, argv: **u8, 
         }
         li = li + 1;
     }
-    # the OS default library directory from the target vtable.
+    # the OS default library directory from the target vtable (a plain str).
     if (p.target.os != nil) {
-        val ld: Option[str] = intern.lookup(?p.s.interner, p.target.os.libdir);
-        if (is_some[str](ld)) {
-            if (try_shared_in_dir(p, unwrap[str](ld)::*u8, name, buf, cap)) { ret true; }
+        val ld: str = p.target.os.libdir;
+        if (!str_empty(ld)) {
+            if (try_shared_in_dir(p, ld::*u8, name, buf, cap)) { ret true; }
         }
     }
     # the common multiarch/system library directories. NOTE: the x86_64-linux

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -699,7 +699,12 @@ fun emit_dynamic_executable(s: *sess.Session, tgt: *target.Target, out_img: *of.
 # address. an undefined or missing entry symbol is an error.
 fun entry_vaddr(s: *sess.Session, tgt: *target.Target,
                 sym_locs: *map.Map[intern.StrId, SymbolLoc]) Result[u64, str] {
-    val entry_name: intern.StrId = tgt.os.entry_symbol;
+    # the OS entry symbol is a plain str on the vtable; intern it here to key the
+    # symbol-location map (interning is idempotent, so it matches the id the
+    # symbol table merged under).
+    val er: Result[intern.StrId, str] = intern.intern(?s.interner, tgt.os.entry_symbol);
+    if (is_err[intern.StrId, str](er)) { ret err[u64, str](unwrap_err[intern.StrId, str](er)); }
+    val entry_name: intern.StrId = unwrap_ok[intern.StrId, str](er);
     val el: Result[*SymbolLoc, str] =
         map.get[intern.StrId, SymbolLoc](sym_locs, ?entry_name);
     if (is_err[*SymbolLoc, str](el)) {
@@ -1361,8 +1366,15 @@ fun build_dynamic_info(s: *sess.Session, tgt: *target.Target, dyn: *DynState,
 
     # the interpreter path is the OS's run-time loader recorded into a PT_INTERP
     # (ELF); a format that embeds the loader differently (PE's import directory,
-    # Mach-O's dyld bind) supplies STR_NIL and the format writer ignores it.
-    dyn.info.interp = tgt.os.dynamic_linker;
+    # Mach-O's dyld bind) supplies an empty path and the format writer ignores it.
+    # the path is a plain str on the vtable; intern it here for the StrId-keyed
+    # DynInfo, mapping the empty path to STR_NIL.
+    dyn.info.interp = intern.STR_NIL;
+    if (str_len(tgt.os.dynamic_linker) > 0) {
+        val dr: Result[intern.StrId, str] = intern.intern(?s.interner, tgt.os.dynamic_linker);
+        if (is_err[intern.StrId, str](dr)) { ret err[bool, str](unwrap_err[intern.StrId, str](dr)); }
+        dyn.info.interp = unwrap_ok[intern.StrId, str](dr);
+    }
 
     # one DynLib per soname, in input order.
     if (soname_count > 0) {

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -29,6 +29,7 @@ use std.types.bool.true;
 use std.types.bool.false;
 use std.types.string.str;
 use std.types.string.str_len;
+use std.types.string.str_empty;
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
@@ -1370,7 +1371,7 @@ fun build_dynamic_info(s: *sess.Session, tgt: *target.Target, dyn: *DynState,
     # the path is a plain str on the vtable; intern it here for the StrId-keyed
     # DynInfo, mapping the empty path to STR_NIL.
     dyn.info.interp = intern.STR_NIL;
-    if (str_len(tgt.os.dynamic_linker) > 0) {
+    if (!str_empty(tgt.os.dynamic_linker)) {
         val dr: Result[intern.StrId, str] = intern.intern(?s.interner, tgt.os.dynamic_linker);
         if (is_err[intern.StrId, str](dr)) { ret err[bool, str](unwrap_err[intern.StrId, str](dr)); }
         dyn.info.interp = unwrap_ok[intern.StrId, str](dr);

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -33,16 +33,18 @@ pub val OS_FREESTANDING: u32 = 4;
 # executable load parameters through it and never branch on the numeric `id`.
 # ---
 # id:              operating-system id (one of OS_*)
-# name:            interned os name ("linux", "darwin", "windows")
-# entry_symbol:    interned program entry-point symbol ("_start", "_main", ...)
-# syscall_layer:   interned syscall-layer name selecting the runtime backend
-# libdir:          interned default system library directory
-# dynamic_linker:  interned run-time dynamic-loader path the linker writes into a
+# name:            os name ("linux", "darwin", "windows")
+# entry_symbol:    program entry-point symbol ("_start", "_main", ...); the linker
+#                  interns it where it keys the symbol table
+# syscall_layer:   syscall-layer name selecting the runtime backend
+# libdir:          default system library directory
+# dynamic_linker:  run-time dynamic-loader path the linker writes into a
 #                  dynamically-linked image's interpreter record (the ELF
-#                  PT_INTERP), or intern.STR_NIL when no fixed interpreter-path
-#                  record applies — PE and Mach-O still support dynamic linking,
-#                  but load imports through their own mechanisms (the import
-#                  directory, LC_LOAD_DYLINKER) rather than a PT_INTERP path
+#                  PT_INTERP), interned by the linker at that point; empty ("")
+#                  when no fixed interpreter-path record applies — PE and Mach-O
+#                  still support dynamic linking, but load imports through their
+#                  own mechanisms (the import directory, LC_LOAD_DYLINKER) rather
+#                  than a PT_INTERP path
 # base_addr:       base virtual address the first loadable segment maps at; the
 #                  linker assigns section vaddrs upward from it
 # page_size:       virtual-memory page size in bytes the linker page-aligns

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -56,10 +56,10 @@ pub val OS_FREESTANDING: u32 = 4;
 pub rec OsVTable {
     id:             u32;
     name:           str;
-    entry_symbol:   intern.StrId;
-    syscall_layer:  intern.StrId;
-    libdir:         intern.StrId;
-    dynamic_linker: intern.StrId;
+    entry_symbol:   str;
+    syscall_layer:  str;
+    libdir:         str;
+    dynamic_linker: str;
     base_addr:      u64;
     page_size:      u64;
     stack_probe:    bool;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -50,23 +50,14 @@ var darwin_vtable: os.OsVTable;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_darwin(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
-    val re: Result[intern.StrId, str] = intern.intern(i, "_main");
-    if (is_err[intern.StrId, str](re)) { ret err[bool, str](unwrap_err[intern.StrId, str](re)); }
-
-    val rs: Result[intern.StrId, str] = intern.intern(i, "darwin");
-    if (is_err[intern.StrId, str](rs)) { ret err[bool, str](unwrap_err[intern.StrId, str](rs)); }
-
-    val rl: Result[intern.StrId, str] = intern.intern(i, "/usr/lib");
-    if (is_err[intern.StrId, str](rl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rl)); }
-
     darwin_vtable.id             = os.OS_DARWIN;
     darwin_vtable.name           = "darwin";
-    darwin_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
-    darwin_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
-    darwin_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);
+    darwin_vtable.entry_symbol   = "_main";
+    darwin_vtable.syscall_layer  = "darwin";
+    darwin_vtable.libdir         = "/usr/lib";
     # Mach-O loads imports through LC_LOAD_DYLINKER + dyld bind, not a PT_INTERP
     # path, so no interpreter-path record applies; the writer is deferred (#1176).
-    darwin_vtable.dynamic_linker = intern.STR_NIL;
+    darwin_vtable.dynamic_linker = "";
     darwin_vtable.base_addr      = DARWIN_BASE_ADDR;
     darwin_vtable.page_size      = DARWIN_PAGE_SIZE;
     # Darwin commits the thread stack up front and auto-grows the main thread; no

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -5,8 +5,8 @@
 # compose a Darwin target descriptor. Darwin code generation is not yet
 # supported: the unsupported surface lives in the Mach-O object-format
 # operations, which return a clear "unsupported object format" error. This
-# vtable carries data only and registers honestly; `register` interns the os
-# strings and is idempotent.
+# vtable carries data only and registers honestly; `register` sets the vtable's
+# str fields directly (no interning) and is idempotent.
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -38,16 +38,16 @@ var darwin_vtable: os.OsVTable;
 
 # register_darwin: build and install the Darwin OsVTable.
 #
-# interns the os name, entry symbol ("_main"), syscall layer, and default
-# library directory, fills the module-level vtable, and installs it into `reg`
-# under os.OS_DARWIN. re-interns the strings into `i` on every call (the registry
-# entry is write-once) so a later build with a fresh interner gets consistent
-# ids. must be invoked at startup before target.select requests a Darwin target.
+# sets the os name, entry symbol ("_main"), syscall layer, and default library
+# directory as plain str constants, fills the module-level vtable, and installs it
+# into `reg` under os.OS_DARWIN. the vtable strings are no longer interned here —
+# the linker interns the ones it needs at the point of use (#1402). must be invoked
+# at startup before target.select requests a Darwin target.
 # ---
 # reg:   the OS registry to install the vtable into
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields
-# ret:   true on success, or an error string if name interning fails
+# alloc: backing allocator (unused; retained for registrar-signature parity)
+# i:     interner (unused; retained for registrar-signature parity)
+# ret:   true (always; the Result return is kept for registrar-signature parity)
 pub fun register_darwin(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
     darwin_vtable.id             = os.OS_DARWIN;

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -47,18 +47,17 @@ var linux_vtable: os.OsVTable;
 
 # register_linux: build and install the Linux OsVTable.
 #
-# interns the os name, entry symbol ("_start"), syscall layer, and default
-# library directory, fills the module-level vtable (including the 0x400000 base
-# address and 4096-byte page), and installs it into `reg` under os.OS_LINUX.
-# re-interns the strings into `i` on every call (the registry entry is
-# write-once) so a later build with a fresh interner gets consistent ids rather
-# than ones left over from the first. must be invoked at startup before
+# sets the os name, entry symbol ("_start"), syscall layer, and default library
+# directory as plain str constants, fills the module-level vtable (including the
+# 0x400000 base address and 4096-byte page), and installs it into `reg` under
+# os.OS_LINUX. the vtable strings are no longer interned here — the linker interns
+# the ones it needs at the point of use (#1402). must be invoked at startup before
 # target.select requests a Linux target.
 # ---
 # reg:   the OS registry to install the vtable into
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields
-# ret:   true on success, or an error string if name interning fails
+# alloc: backing allocator (unused; retained for registrar-signature parity)
+# i:     interner (unused; retained for registrar-signature parity)
+# ret:   true (always; the Result return is kept for registrar-signature parity)
 pub fun register_linux(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
     linux_vtable.id             = os.OS_LINUX;

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -61,24 +61,12 @@ var linux_vtable: os.OsVTable;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_linux(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
-    val re: Result[intern.StrId, str] = intern.intern(i, "_start");
-    if (is_err[intern.StrId, str](re)) { ret err[bool, str](unwrap_err[intern.StrId, str](re)); }
-
-    val rs: Result[intern.StrId, str] = intern.intern(i, "linux");
-    if (is_err[intern.StrId, str](rs)) { ret err[bool, str](unwrap_err[intern.StrId, str](rs)); }
-
-    val rl: Result[intern.StrId, str] = intern.intern(i, "/usr/lib");
-    if (is_err[intern.StrId, str](rl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rl)); }
-
-    val rd: Result[intern.StrId, str] = intern.intern(i, LINUX_DYNAMIC_LINKER);
-    if (is_err[intern.StrId, str](rd)) { ret err[bool, str](unwrap_err[intern.StrId, str](rd)); }
-
     linux_vtable.id             = os.OS_LINUX;
     linux_vtable.name           = "linux";
-    linux_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
-    linux_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
-    linux_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);
-    linux_vtable.dynamic_linker = unwrap_ok[intern.StrId, str](rd);
+    linux_vtable.entry_symbol   = "_start";
+    linux_vtable.syscall_layer  = "linux";
+    linux_vtable.libdir         = "/usr/lib";
+    linux_vtable.dynamic_linker = LINUX_DYNAMIC_LINKER;
     linux_vtable.base_addr      = LINUX_BASE_ADDR;
     linux_vtable.page_size      = LINUX_PAGE_SIZE;
     # Linux auto-grows the stack on any in-range fault; no per-page probe needed.

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -53,22 +53,13 @@ var windows_vtable: os.OsVTable;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_windows(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
-    val re: Result[intern.StrId, str] = intern.intern(i, "mainCRTStartup");
-    if (is_err[intern.StrId, str](re)) { ret err[bool, str](unwrap_err[intern.StrId, str](re)); }
-
-    val rs: Result[intern.StrId, str] = intern.intern(i, "windows");
-    if (is_err[intern.StrId, str](rs)) { ret err[bool, str](unwrap_err[intern.StrId, str](rs)); }
-
-    val rl: Result[intern.StrId, str] = intern.intern(i, "C:\\Windows\\System32");
-    if (is_err[intern.StrId, str](rl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rl)); }
-
     windows_vtable.id             = os.OS_WINDOWS;
     windows_vtable.name           = "windows";
-    windows_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
-    windows_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
-    windows_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);
+    windows_vtable.entry_symbol   = "mainCRTStartup";
+    windows_vtable.syscall_layer  = "windows";
+    windows_vtable.libdir         = "C:\\Windows\\System32";
     # PE imports load through the import directory, not a PT_INTERP-style path.
-    windows_vtable.dynamic_linker = intern.STR_NIL;
+    windows_vtable.dynamic_linker = "";
     # the linker's base is the first content segment's vaddr: one page above the
     # 64 KiB-aligned ImageBase, reserving RVA 0..0x1000 for the PE headers so the
     # first section maps immediately after them with no gap.

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -5,8 +5,8 @@
 # library directory, and the executable load parameters (ImageBase 0x140000000,
 # 4096-byte page) — so target.select composes a runnable Windows target through
 # the win64 ABI and the COFF/PE writer. PE links via the import directory, not a
-# PT_INTERP path, so `dynamic_linker` is STR_NIL. `register` interns the os
-# strings and is idempotent.
+# PT_INTERP path, so `dynamic_linker` is empty (""). `register` sets the vtable's
+# str fields directly (no interning) and is idempotent.
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -40,17 +40,16 @@ var windows_vtable: os.OsVTable;
 
 # register_windows: build and install the Windows OsVTable.
 #
-# interns the os name, entry symbol ("mainCRTStartup"), syscall layer, and
-# default library directory, fills the module-level vtable, and installs it into
-# `reg` under os.OS_WINDOWS. re-interns the strings into `i` on every call (the
-# registry entry is write-once) so a later build with a fresh interner gets
-# consistent ids. must be invoked at startup before target.select requests a
-# Windows target.
+# sets the os name, entry symbol ("mainCRTStartup"), syscall layer, and default
+# library directory as plain str constants, fills the module-level vtable, and
+# installs it into `reg` under os.OS_WINDOWS. the vtable strings are no longer
+# interned here — the linker interns the ones it needs at the point of use (#1402).
+# must be invoked at startup before target.select requests a Windows target.
 # ---
 # reg:   the OS registry to install the vtable into
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields
-# ret:   true on success, or an error string if name interning fails
+# alloc: backing allocator (unused; retained for registrar-signature parity)
+# i:     interner (unused; retained for registrar-signature parity)
+# ret:   true (always; the Result return is kept for registrar-signature parity)
 pub fun register_windows(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
     windows_vtable.id             = os.OS_WINDOWS;


### PR DESCRIPTION
Behavior-preserving refactor — the **OS-vtable scope** of #1402. Converts the four `OsVTable` string fields to `str` and pushes interning to the linker consumers, mirroring #1377.

## Changes
- `OsVTable.{entry_symbol, syscall_layer, libdir, dynamic_linker}` : `intern.StrId` -> `str` (joining the already-`str` `name`).
- The 3 OS registrars (linux/darwin/windows) set the four strings as `str` literals; the per-field interning is removed. PE/Mach-O's absent interpreter is `""` (the `str` analog of the old `STR_NIL`). Registrar signatures are kept stable (mirroring #1377's ISA/ABI registrars).
- Consumers intern at the point of use: `linker.entry_vaddr` interns `entry_symbol` into the session interner to key the symbol-location map (idempotent, so it resolves to the id the symbol table merged under — this holds the fixpoint); `linker.build_dynamic_info` defaults `DynInfo.interp` to `STR_NIL` and interns `dynamic_linker` only when non-empty; `build.resolve_shared_into` reads `libdir` as a plain `str`.

## Verification
- `mach build` clean; `mach test .` -> 428 passed, 0 failed, 428 total.
- **Self-host fixpoint: byte-identical** (this refactor emits identical code).

## Scope note
This does NOT yet drop the interner param from `register_all`: the ELF and COFF registrars still intern (section/symbol names), so `register_all` must keep forwarding the interner. The remaining x64/arm64/sysv/win64/macho/os registrars now carry an unused `i` param. The full param-drop capstone (eliminate elf/coff registrar interning, then drop the param across `register_all` + registrars + the 4 callers) is tracked in #1418.

Part of #1402.