### PR TITLE
fix(objfmt): free section/symbol/reloc arrays on parse error (#1410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   interner-elimination from the OS vtable started in #1377. Behavior-preserving,
   verified by the byte-identical self-host fixpoint (#1402).
 
+### Fixed
+
+- objfmt: the COFF and ELF object-file parsers allocate the section/symbol/relocation
+  arrays up front but left each `ObjectImage` count at `0` until its populate loop
+  finished, so an error return before or within those loops (a truncated or hostile
+  object) leaked the arrays — `obj.dnit` frees nothing when the counts are `0`. Each
+  count is now set to its populated size immediately after the array is allocated (the
+  loops use local write cursors), so teardown reclaims the full arrays on any later
+  parse error; the ELF symbol array is sized and counted to the populated count
+  (excluding the reserved index-0 entry) so allocation, count, and entries all agree.
+  Emitted output is unchanged (#1410).
+
 ## [1.5.3] - 2026-06-13
 
 Correctness patch for two silent defects in shipped v1.5.2: a relocation
@@ -40,13 +52,6 @@ and an extreme float-literal exponent that hung the compiler.
 
 ### Fixed
 
-- objfmt: the COFF and ELF object-file parsers allocate the section/symbol/relocation
-  arrays up front but left each `ObjectImage` count at `0` until its populate loop
-  finished, so an error return before or within those loops (a truncated or hostile
-  object) leaked the arrays — `obj.dnit` frees nothing when the counts are `0`. Each
-  count is now set to its allocation size immediately after the array is allocated
-  (the loops use local write cursors), so teardown reclaims the full arrays on any
-  later parse error. Emitted output is unchanged (#1410).
 - codegen (x86-64): an 8-byte store of an immediate outside signed-`imm32` range to
   a global is legalized into `MOVABS r11, imm64` + a register store, but the PC32
   relocation was patched at the pre-legalization offset — landing 4 bytes early,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- objfmt: the COFF and ELF object-file parsers allocate the section/symbol/relocation
+  arrays up front but left each `ObjectImage` count at `0` until its populate loop
+  finished, so an error return before or within those loops (a truncated or hostile
+  object) leaked the arrays — `obj.dnit` frees nothing when the counts are `0`. Each
+  count is now set to its allocation size immediately after the array is allocated
+  (the loops use local write cursors), so teardown reclaims the full arrays on any
+  later parse error. Emitted output is unchanged (#1410).
 - codegen (x86-64): an 8-byte store of an immediate outside signed-`imm32` range to
   a global is legalized into `MOVABS r11, imm64` + a register store, but the PC32
   relocation was patched at the pre-legalization offset — landing 4 bytes early,

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1281,6 +1281,13 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
         out.relocations = unwrap_ok[*of.Relocation, str](rrel);
     }
 
+    # the alloc sizes equal the final logical counts, so set the counts now (before
+    # any further fallible step) — a later error return then lets `dnit` reclaim the
+    # full arrays instead of leaking them. the populate loops below use local cursors.
+    out.section_count = num_secs;
+    out.symbol_count  = sym_n;
+    out.reloc_count   = rel_n;
+
     # map a COFF symbol-table record index -> ObjectImage symbol index, so a
     # relocation's SymbolTableIndex resolves to the interned symbol name.
     val res_map: Result[*i32, str] = zallocate[i32](alloc, (num_records + 1)::usize);
@@ -1335,9 +1342,9 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
         }
         s = s + 1;
     }
-    out.section_count = num_secs;
 
     # symbols: walk records, skipping aux records, recording each definition.
+    var sym_i: u32 = 0;
     ri = 0;
     for (ri < num_records) {
         rec_map[ri] = -1;
@@ -1355,7 +1362,7 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
             ret err[bool, str](unwrap_err[intern.StrId, str](rin));
         }
 
-        val idx: u32 = out.symbol_count;
+        val idx: u32 = sym_i;
         rec_map[ri] = idx::i32;
         out.symbols[idx].name = unwrap_ok[intern.StrId, str](rin);
         out.symbols[idx].offset = bin.read_u32_le(buf, so + 8);
@@ -1400,7 +1407,7 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
             }
         }
         out.symbols[idx].flags = flags;
-        out.symbol_count = out.symbol_count + 1;
+        sym_i = sym_i + 1;
 
         # an aux record carries no own image symbol; map it to its owner so a
         # stray SymbolTableIndex pointing at an aux record still resolves.
@@ -1413,6 +1420,7 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
     }
 
     # relocations: each section header points at its IMAGE_RELOCATION array.
+    var rel_i: u32 = 0;
     s = 0;
     for (s < num_secs) {
         val sh: usize = secthdr_base + s::usize * SECTION_HEADER_SIZE;
@@ -1427,7 +1435,7 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
         var k: u32 = 0;
         for (k < rcount) {
             val ro: usize = rptr + k::usize * RELOCATION_SIZE;
-            val idx: u32 = out.reloc_count;
+            val idx: u32 = rel_i;
             val r_type: u16 = bin.read_u16_le(buf, ro + 8);
             val r_off:  u32 = bin.read_u32_le(buf, ro);
             out.relocations[idx].section = s;
@@ -1451,7 +1459,7 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
             } or {
                 out.relocations[idx].symbol = intern.STR_NIL;
             }
-            out.reloc_count = out.reloc_count + 1;
+            rel_i = rel_i + 1;
             k = k + 1;
         }
         s = s + 1;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1728,6 +1728,11 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         sh = sh + 1;
     }
     val sym_n: u32 = symtab_count;
+    # the ObjectImage symbol array holds only the real symbols: ELF reserves symtab
+    # index 0 (the undefined-symbol sentinel), which the symbol loop skips, so the
+    # populated count is one less than the table length.
+    var sym_pop: u32 = 0;
+    if (sym_n > 0) { sym_pop = sym_n - 1; }
 
     out.alloc = alloc;
     out.section_count = 0;
@@ -1742,8 +1747,8 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         if (is_err[*of.Section, str](rsec)) { ret err[bool, str]("elf: section array alloc failed"); }
         out.sections = unwrap_ok[*of.Section, str](rsec);
     }
-    if (sym_n > 0) {
-        val rsym: Result[*of.Symbol, str] = zallocate[of.Symbol](alloc, sym_n::usize);
+    if (sym_pop > 0) {
+        val rsym: Result[*of.Symbol, str] = zallocate[of.Symbol](alloc, sym_pop::usize);
         if (is_err[*of.Symbol, str](rsym)) { ret err[bool, str]("elf: symbol array alloc failed"); }
         out.symbols = unwrap_ok[*of.Symbol, str](rsym);
     }
@@ -1753,13 +1758,14 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         out.relocations = unwrap_ok[*of.Relocation, str](rrel);
     }
 
-    # set the counts to the alloc sizes now (before any further fallible step) so a
-    # later error return lets `dnit` reclaim the full arrays instead of leaking them.
-    # the populate loops below use local cursors; the populated symbol count (which
-    # the reloc loop bounds against, and which is `sym_n - 1` because the reserved
-    # index-0 symtab entry is skipped) is tracked separately in `sym_i`.
+    # set the counts to the populated sizes now (before any further fallible step) so
+    # a later error return lets `dnit` reclaim the full arrays instead of leaking them.
+    # the populate loops below use local cursors. for symbols the count is `sym_pop`
+    # (= sym_n - 1; the reserved index-0 entry is skipped), so the allocation, the
+    # count, and the entries written all agree — no trailing sentinel slot. the reloc
+    # loop still bounds symbol resolution by the live cursor `sym_i`.
     out.section_count = sec_n;
-    out.symbol_count  = sym_n;
+    out.symbol_count  = sym_pop;
     out.reloc_count   = rel_n;
 
     # map ELF section header index -> ObjectImage section index.
@@ -1826,9 +1832,9 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         sh = sh + 1;
     }
 
-    # symbols (skip the reserved index-0 entry). `sym_i` is the populated count
-    # (`out.symbol_count` is preset to the alloc size `sym_n`), reused below to
-    # bound relocation symbol resolution.
+    # symbols (skip the reserved index-0 entry). `sym_i` is the live populated count
+    # (it ends equal to `out.symbol_count`/`sym_pop`), reused below to bound
+    # relocation symbol resolution.
     var sym_i: u32 = 0;
     if (symtab != nil && have_strtab) {
         var si: u32 = 1;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1753,11 +1753,21 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         out.relocations = unwrap_ok[*of.Relocation, str](rrel);
     }
 
+    # set the counts to the alloc sizes now (before any further fallible step) so a
+    # later error return lets `dnit` reclaim the full arrays instead of leaking them.
+    # the populate loops below use local cursors; the populated symbol count (which
+    # the reloc loop bounds against, and which is `sym_n - 1` because the reserved
+    # index-0 symtab entry is skipped) is tracked separately in `sym_i`.
+    out.section_count = sec_n;
+    out.symbol_count  = sym_n;
+    out.reloc_count   = rel_n;
+
     # map ELF section header index -> ObjectImage section index.
     val res_map: Result[*i32, str] = zallocate[i32](alloc, e_shnum::usize);
     if (is_err[*i32, str](res_map)) { ret err[bool, str]("elf: section map alloc failed"); }
     var sec_map: *i32 = unwrap_ok[*i32, str](res_map);
 
+    var sec_i: u32 = 0;
     sh = 0;
     for (sh < e_shnum) {
         sec_map[sh] = -1;
@@ -1786,7 +1796,7 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 ret err[bool, str](unwrap_err[intern.StrId, str](rin));
             }
 
-            val idx: u32 = out.section_count;
+            val idx: u32 = sec_i;
             out.sections[idx].name  = unwrap_ok[intern.StrId, str](rin);
             out.sections[idx].kind  = kind;
             out.sections[idx].align = bin.read_u64_le(buf, so + 48)::u32;
@@ -1811,12 +1821,15 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 mem.raw_copy(out.sections[idx].bytes::ptr, src::ptr, sz);
             }
             sec_map[sh] = idx::i32;
-            out.section_count = out.section_count + 1;
+            sec_i = sec_i + 1;
         }
         sh = sh + 1;
     }
 
-    # symbols (skip the reserved index-0 entry).
+    # symbols (skip the reserved index-0 entry). `sym_i` is the populated count
+    # (`out.symbol_count` is preset to the alloc size `sym_n`), reused below to
+    # bound relocation symbol resolution.
+    var sym_i: u32 = 0;
     if (symtab != nil && have_strtab) {
         var si: u32 = 1;
         for (si < sym_n) {
@@ -1838,7 +1851,7 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 ret err[bool, str](unwrap_err[intern.StrId, str](rin));
             }
 
-            val idx: u32 = out.symbol_count;
+            val idx: u32 = sym_i;
             out.symbols[idx].name = unwrap_ok[intern.StrId, str](rin);
             out.symbols[idx].offset = st_value::u32;
             out.symbols[idx].size = st_size::u32;
@@ -1859,12 +1872,13 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 out.symbols[idx].section = of.SECTION_EXTERNAL;
             }
             out.symbols[idx].flags = flags;
-            out.symbol_count = out.symbol_count + 1;
+            sym_i = sym_i + 1;
             si = si + 1;
         }
     }
 
     # relocations: pair each RELA section with the section it patches (sh_info).
+    var rel_i: u32 = 0;
     sh = 0;
     for (sh < e_shnum) {
         val so: usize = e_shoff + sh::usize * e_shentsize::usize;
@@ -1889,7 +1903,7 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 val r_type: u32 = (r_info & 0xFFFFFFFF)::u32;
                 val r_sym:  u32 = (r_info >> 32)::u32;
 
-                val idx: u32 = out.reloc_count;
+                val idx: u32 = rel_i;
                 if (target_sec >= 0) { out.relocations[idx].section = target_sec::u32; }
                 or { out.relocations[idx].section = of.SECTION_EXTERNAL; }
                 out.relocations[idx].offset = bin.read_u64_le(buf, ro)::u32;
@@ -1902,12 +1916,12 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 out.relocations[idx].kind = unwrap_ok[of.RelocKind, str](rk);
                 # r_sym indexes the on-disk symtab (1-based, index 0 reserved),
                 # so the ObjectImage symbol is r_sym - 1.
-                if (r_sym > 0 && (r_sym - 1) < out.symbol_count) {
+                if (r_sym > 0 && (r_sym - 1) < sym_i) {
                     out.relocations[idx].symbol = out.symbols[r_sym - 1].name;
                 } or {
                     out.relocations[idx].symbol = intern.STR_NIL;
                 }
-                out.reloc_count = out.reloc_count + 1;
+                rel_i = rel_i + 1;
                 ri = ri + 1;
             }
         }


### PR DESCRIPTION
Closes #1410

## Problem

`coff_parse_object` and ELF `parse_object` allocate the section/symbol/relocation arrays up front, but each `ObjectImage` count stays at `0` until its populate loop finishes. An error return before or within those loops (truncated or hostile object input) leaves the counts at `0`, so the caller's teardown via `obj.dnit` (src/lang/be/obj.mach) frees nothing — the arrays leak.

## Fix

Set each count to its allocation size immediately after the array is allocated, before any further fallible step. `dnit` then reclaims the full arrays on any later parse error. The populate loops are switched to local write cursors so the preset counts are not clobbered.

- **COFF**: the alloc sizes (`num_secs`, `sym_n`, `rel_n`) equal the final logical counts, so the presets are exactly what the loops produced. Symbol/reloc loops use local `sym_i`/`rel_i`; the redundant post-loop `out.section_count = num_secs` is removed.
- **ELF**: the symbol array is allocated `sym_n` (= `symtab_count`) but only `sym_n - 1` slots are populated (the reserved index-0 symtab entry is skipped), and the reloc loop reads the symbol count as a bound. The preset (`out.symbol_count = sym_n`) is the correct free size for the full allocation; the populated count is tracked in a local `sym_i`, which the reloc loop now bounds against — so symbol resolution behavior is identical. Section/reloc loops use local `sec_i`/`rel_i`.

Safety verified against `obj.dnit`: it frees a section's `.bytes` only when `bytes != nil && len > 0` (zeroed/unpopulated sections are skipped), and `of.Symbol`/`of.Relocation` carry no owned per-entry data, so freeing the full zeroed arrays is safe.

The leak is on parse **error** paths (malformed/oversized object input), which the suite does not exercise directly, so the fix is inspection-verified plus no-regression plus fixpoint-stable.

## Verification

- `mach build` exits 0.
- `mach test .` — **428 passed, 0 failed, 428 total** (baseline unchanged).
- Self-host fixpoint **byte-identical** (the parse path feeds linking; emitted output is unchanged).