### PR TITLE
chore: release v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.3] - 2026-06-13
+
+Correctness patch for two silent defects in shipped v1.5.2: a relocation
+patch-site miscompute that corrupted out-of-`imm32` constant stores to globals,
+and an extreme float-literal exponent that hung the compiler.
+
 ### Fixed
 
 - codegen (x86-64): an 8-byte store of an immediate outside signed-`imm32` range to

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "1.5.2"
+version = "1.5.3"
 src = "src"
 dep = "dep"
 target = "native"


### PR DESCRIPTION
Roll up the v1.5.3 correctness patch (already merged to dev as #1415): rolls CHANGELOG [Unreleased] -> [1.5.3] and bumps the version to 1.5.3.

- #1407 — reloc patch-site miscompute for out-of-imm32 constant stores to globals (silent miscompile in v1.5.2)
- #1408 — extreme float-literal exponent hang / silent fold

Build reports `mach 1.5.3`. After merge: dev -> main (no-FF) + annotated tag v1.5.3 to publish.