### PR TITLE
refactor(target): drop the dead endianness field + fix arm64 fp-scratch reg id (#1411, #1414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- target: the dead `IsaVTable.endianness` field is removed. It was set by the ISA
+  registrars but read by nobody — the object-format writers hardcode little-endian —
+  so the field documented a behavior that did not exist. The `ENDIAN_LITTLE`/
+  `ENDIAN_BIG` enum is retained for the eventual big-endian abstraction, and the
+  comments that claimed endianness was honored now state the little-endian
+  assumption plainly (#1411).
+
+### Fixed
+
+- target (aarch64): `IsaVTable.fp_scratch_reg` for the (stub) arm64 backend is now
+  the composite vector register id `regid_make(REG_CLASS_ID_XMM, 31)` instead of the
+  raw bank index `31`, which would have read as a GP register. Dead today (the arm64
+  backend has no encoder), corrected before it seeds the future backend (#1414).
+
 ## [1.5.3] - 2026-06-13
 
 Correctness patch for two silent defects in shipped v1.5.2: a relocation

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -255,7 +255,7 @@ val LOAD_DONE:    LoadStatus = 2;
 # config:       parsed project config (incl. dep metadata)
 # target_entry: pointer into config.targets selecting which target this build is
 # target:       composed target (isa/abi/os/of vtables) resolved via target.select;
-#               pointer width and endianness are read through target.arch
+#               pointer width is read through target.arch
 # modules:      flat array of ModuleEntry, indexed by ModuleId
 # topo:         module ids in dep-order (topo[0] has no deps within the graph)
 # load:         DFS bookkeeping; cleared when build_project completes
@@ -1387,8 +1387,8 @@ fun intern_or(i: *intern.Interner, text: str, default: str) Result[intern.StrId,
 # tgt.Target. maps the entry's os/isa names to canonical ids, calls
 # target.select to compose the isa/abi/os/of vtables, and stores the
 # result on Project. an unknown os/arch pair has no canonical mapping and
-# fails the build through target.select. pointer width and endianness are
-# not stored here — consumers read them through p.target.arch.
+# fails the build through target.select. pointer width is not stored here —
+# consumers read it through p.target.arch.
 fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     val os_opt: Option[str] = intern.lookup(?p.s.interner, t.os_name);
     if (is_none[str](os_opt)) { ret err[bool, str]("target os name not interned"); }

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -29,7 +29,10 @@ use std.allocator.deallocate;
 
 use intern: mach.lang.intern;
 
-# byte order of a target's scalar storage.
+# byte order of a target's scalar storage. no ISA vtable carries an endianness
+# field: every supported ISA is little-endian and the object-format writers
+# hardcode it. these constants remain for the eventual big-endian abstraction (an
+# ISA field wired through the writers), to be added with the first big-endian target.
 # ---
 # ENDIAN_LITTLE: least-significant byte first
 # ENDIAN_BIG:    most-significant byte first
@@ -193,9 +196,9 @@ pub rec RegClass {
 pub def AsmClobbersFn: fun(str, *u32, *u32);
 
 # the ISA runtime-dispatch interface. exactly one of these exists per
-# architecture; the backend reads pointer width, endianness, register classes,
-# and the arch-specific operation entry points through it and never branches on
-# the numeric `id`.
+# architecture; the backend reads pointer width, register classes, and the
+# arch-specific operation entry points through it and never branches on the
+# numeric `id`.
 #
 # `select`, `encode`, and `emit_asm` are the target-specific backend operations.
 # they are stored type-erased (`*u8`) for the same reason the ABI vtable erases its
@@ -230,7 +233,6 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 # id:                 architecture id (one of ARCH_*)
 # name:               interned architecture name ("x86_64", "aarch64")
 # pointer_width:      pointer width in bytes
-# endianness:         ENDIAN_LITTLE or ENDIAN_BIG (see target.mach)
 # reg_classes:        array of register classes
 # reg_class_count:    number of register classes
 # select:             erased fn ptr — perform instruction selection for one
@@ -287,7 +289,6 @@ pub rec IsaVTable {
     id:                 u32;
     name:               str;
     pointer_width:      u32;
-    endianness:         u32;
     reg_classes:        *RegClass;
     reg_class_count:    u32;
     select:             *u8;

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -97,7 +97,6 @@ pub fun register_arm64(reg: *isa.IsaRegistry, alloc: *Allocator, i: *intern.Inte
     arm64_vtable.id                 = isa.ARCH_AARCH64;
     arm64_vtable.name               = "aarch64";
     arm64_vtable.pointer_width      = 8;
-    arm64_vtable.endianness         = isa.ENDIAN_LITTLE;
     arm64_vtable.reg_classes        = ?arm64_reg_classes[0];
     arm64_vtable.reg_class_count    = 3;
     arm64_vtable.select             = nil;
@@ -111,7 +110,9 @@ pub fun register_arm64(reg: *isa.IsaRegistry, alloc: *Allocator, i: *intern.Inte
     arm64_vtable.reload_scratch_count = 0;
     arm64_vtable.scratch_reg        = ARM64_IP0;
     arm64_vtable.scratch_reg2       = ARM64_IP1;
-    arm64_vtable.fp_scratch_reg     = ARM64_V31;
+    # the vector scratch is a composite register id (class tag in the high byte),
+    # mirroring x86-64's FP_SCRATCH_REG — a raw bank index would read as a GP reg.
+    arm64_vtable.fp_scratch_reg     = isa.regid_make(isa.REG_CLASS_ID_XMM, ARM64_V31);
     arm64_vtable.frame_ptr_reg      = ARM64_FP;
     arm64_vtable.stack_ptr_reg      = ARM64_SP;
     # the AAPCS64 frame record stores the saved FP at [fp+0] and the saved LR at

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -118,7 +118,6 @@ pub fun register_x64(reg: *isa.IsaRegistry, alloc: *Allocator, interner: *intern
     x64_vtable.id                 = isa.ARCH_X86_64;
     x64_vtable.name               = "x86_64";
     x64_vtable.pointer_width      = 8;
-    x64_vtable.endianness         = isa.ENDIAN_LITTLE;
     x64_vtable.reg_classes        = ?x64_classes[0];
     x64_vtable.reg_class_count    = 3;
     x64_vtable.select             = x64isel.select::*u8;

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -279,7 +279,8 @@ pub rec ExecFunction {
 # a format writer: serializes an `ObjectImage` to a relocatable object file at
 # the given path. takes the `IsaVTable` (not the full Target) to break the
 # target↔object-format import cycle; the writer uses only what the ISA exposes
-# (machine type, endianness, pointer width). it resolves the image's interned
+# (machine type, pointer width) and hardcodes little-endian (every supported ISA
+# is LE). it resolves the image's interned
 # names through `image.interner`, which the back end set when it built the image —
 # no module-global interner is captured.
 # ---
@@ -309,7 +310,8 @@ pub def ParserFn: fun(*Allocator, *intern.Interner, *u8, usize, *ObjectImage) Re
 # a static-executable writer: serializes the linker's laid-out load segments
 # into a static executable at the given path. like `WriterFn` it takes the
 # `IsaVTable` (not the full Target) to break the target↔object-format import
-# cycle; the writer uses only the ISA's machine type and endianness. the linker
+# cycle; the writer uses only the ISA's machine type and pointer width, and
+# hardcodes little-endian. the linker
 # has already assigned every segment's virtual address and resolved the entry
 # point, so the writer only frames the segments in the format's container (ELF
 # program headers, Mach-O load commands) with a leading header-covering segment.

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -12,8 +12,8 @@ use os:  mach.lang.target.os;
 
 # a fully resolved compilation target. the `*_id` fields are comptime
 # identity (matching the constants in os/isa/abi/of); the vtable pointers are
-# the runtime-dispatch surface the backend calls through. pointer width and
-# endianness are read through `arch`, never duplicated here.
+# the runtime-dispatch surface the backend calls through. pointer width is read
+# through `arch`, never duplicated here.
 # ---
 # os_id:   operating-system id (one of os.OS_*)
 # arch_id: architecture id (one of isa.ARCH_*)


### PR DESCRIPTION
Two isa-layer audit findings, batched (Track C of the cleanup sweep). Behavior-preserving: 428/428 tests, byte-identical self-host fixpoint.

## #1411 — drop the dead `IsaVTable.endianness` field
The field was set by the ISA registrars (always `ENDIAN_LITTLE`) but **read by nobody** — the object-format writers hardcode little-endian — so it documented a behavior that did not exist (the audit's "documented-as-honored, read by nobody"). Removes the field + its two setters; the `ENDIAN_LITTLE`/`ENDIAN_BIG` enum is **kept** for the eventual big-endian abstraction (an ISA field wired through the writers, added with the first BE target); and the comments across isa/driver/of/resolved that claimed endianness was honored now state the little-endian assumption plainly.

## #1414 — arm64 `fp_scratch_reg` composite id
The (stub) arm64 vtable set `fp_scratch_reg` to the raw bank index `31`, which encodes as a **GP** register; it must be the composite vector id `regid_make(REG_CLASS_ID_XMM, 31)` (0x011F), mirroring x86-64's `FP_SCRATCH_REG = (1<<8)|15`. Dead today (the arm64 backend has no encoder), corrected before it seeds the future backend.

Part of the audit sweep; suggested release v1.5.5 (target-layer group).

Closes #1411
Closes #1414