### PR TITLE
refactor(target): consolidate os/arch name<->id tables + real unknown-name diagnostic (#1412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default target's branches win" — and a module that does not fully resolve there
   records diagnostics without aborting the build (#1391).
 
+### Changed
+
+- target: the os/arch name↔id mapping is consolidated to one canonical table per
+  dimension — `os.os_id_for`/`os.os_name_for` and `isa.arch_id_for`/`isa.arch_name_for`
+  — replacing the copies that lived in `driver.mach` and `manifest.mach`. An
+  unrecognized manifest `os`/`isa` name now reports a distinct "unknown target os/isa
+  name '<name>' (expected: ...)" diagnostic instead of folding to `*_UNKNOWN` and being
+  mis-reported as an unsupported pair (#1412).
+
 ## [1.5.3] - 2026-06-13
 
 Correctness patch for two silent defects in shipped v1.5.2: a relocation

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -556,8 +556,8 @@ fun populate_union_tuples(p: *Project, m: *manifest.Manifest) Result[bool, str] 
             deallocate[TargetTuple](p.s.alloc, tuples, n::usize);
             ret err[bool, str]("internal: union target tuple name not interned");
         }
-        val os_id:   u32 = os_id_for(unwrap[str](os_opt));
-        val arch_id: u32 = arch_id_for(unwrap[str](isa_opt));
+        val os_id:   u32 = os.os_id_for(unwrap[str](os_opt));
+        val arch_id: u32 = isa.arch_id_for(unwrap[str](isa_opt));
         val sr: Result[tgt.Target, str] = tgt.select(?p.s.registry, os_id, arch_id);
         if (is_err[tgt.Target, str](sr)) {
             deallocate[TargetTuple](p.s.alloc, tuples, n::usize);
@@ -1507,8 +1507,15 @@ fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     if (is_none[str](isa_opt)) { ret err[bool, str]("target isa name not interned"); }
     val isa_name: str = unwrap[str](isa_opt);
 
-    val os_id:   u32 = os_id_for(os_name);
-    val arch_id: u32 = arch_id_for(isa_name);
+    val os_id:   u32 = os.os_id_for(os_name);
+    val arch_id: u32 = isa.arch_id_for(isa_name);
+
+    if (os_id == os.OS_UNKNOWN) {
+        ret err[bool, str](diag_join_named(p.s, "unknown target os name '", t.os_name, "' (expected: linux, darwin, windows)", "unknown target os name"));
+    }
+    if (arch_id == isa.ARCH_UNKNOWN) {
+        ret err[bool, str](diag_join_named(p.s, "unknown target isa name '", t.isa_name, "' (expected: x86_64, aarch64)", "unknown target isa name"));
+    }
 
     val tr: Result[tgt.Target, str] = tgt.select(?p.s.registry, os_id, arch_id);
     if (is_err[tgt.Target, str](tr)) { ret err[bool, str](unwrap_err[tgt.Target, str](tr)); }
@@ -1526,19 +1533,6 @@ fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     p.compiler_ver = unwrap_ok[intern.StrId, str](rcv);
 
     ret ok[bool, str](true);
-}
-
-fun os_id_for(name: str) u32 {
-    if (str_equals(name, "linux"))   { ret os.OS_LINUX; }
-    if (str_equals(name, "darwin"))  { ret os.OS_DARWIN; }
-    if (str_equals(name, "windows")) { ret os.OS_WINDOWS; }
-    ret os.OS_UNKNOWN;
-}
-
-fun arch_id_for(name: str) u32 {
-    if (str_equals(name, "x86_64"))  { ret isa.ARCH_X86_64; }
-    if (str_equals(name, "aarch64")) { ret isa.ARCH_AARCH64; }
-    ret isa.ARCH_UNKNOWN;
 }
 
 # entry_module_fqn: compute the entrypoint module's FQN: `<project.id>.<entrypoint stripped of .mach>`.

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -285,36 +285,14 @@ fun cc5(alloc: *Allocator, a: str, b: str, c: str, d: str, e: str) str {
     ret cc(alloc, cc3(alloc, a, b, c), cc(alloc, d, e));
 }
 
-# os_id_for: map a target os name to its canonical id.
-fun os_id_for(name: str) u32 {
-    if (str_equals(name, "linux"))   { ret os.OS_LINUX; }
-    if (str_equals(name, "darwin"))  { ret os.OS_DARWIN; }
-    if (str_equals(name, "windows")) { ret os.OS_WINDOWS; }
-    ret os.OS_UNKNOWN;
-}
-
-# arch_id_for: map a target isa name to its canonical id.
-fun arch_id_for(name: str) u32 {
-    if (str_equals(name, "x86_64"))  { ret isa.ARCH_X86_64; }
-    if (str_equals(name, "aarch64")) { ret isa.ARCH_AARCH64; }
-    ret isa.ARCH_UNKNOWN;
-}
-
 # host_isa_name: the build host's isa name.
 fun host_isa_name() str {
-    val a: u32 = tgt.host_arch_id();
-    if (a == isa.ARCH_X86_64)  { ret "x86_64"; }
-    if (a == isa.ARCH_AARCH64) { ret "aarch64"; }
-    ret "unknown";
+    ret isa.arch_name_for(tgt.host_arch_id());
 }
 
 # host_os_name: the build host's os name.
 fun host_os_name() str {
-    val o: u32 = tgt.host_os_id();
-    if (o == os.OS_LINUX)   { ret "linux"; }
-    if (o == os.OS_DARWIN)  { ret "darwin"; }
-    if (o == os.OS_WINDOWS) { ret "windows"; }
-    ret "unknown";
+    ret os.os_name_for(tgt.host_os_id());
 }
 
 # host_tuple: the build host's `<isa>-<os>` tuple string, for the no-match
@@ -1272,7 +1250,7 @@ fun target_matches_host(i: *intern.Interner, d: *TargetDef, host_os: u32, host_a
     val os_o: Option[str] = intern.lookup(i, d.os);
     val isa_o: Option[str] = intern.lookup(i, d.isa);
     if (is_none[str](os_o) || is_none[str](isa_o)) { ret false; }
-    ret os_id_for(unwrap[str](os_o)) == host_os && arch_id_for(unwrap[str](isa_o)) == host_arch;
+    ret os.os_id_for(unwrap[str](os_o)) == host_os && isa.arch_id_for(unwrap[str](isa_o)) == host_arch;
 }
 
 # resolve_target: resolve a target selector to a declared target. an empty

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -22,6 +22,7 @@ use std.types.bool.false;
 use std.types.size.usize;
 
 use std.types.string.str;
+use std.types.string.str_equals;
 
 use std.allocator.Allocator;
 use std.allocator.reallocate;
@@ -42,6 +43,20 @@ pub val ENDIAN_BIG:    u32 = 1;
 pub val ARCH_UNKNOWN: u32 = 0;
 pub val ARCH_X86_64:  u32 = 1;
 pub val ARCH_AARCH64: u32 = 2;
+
+# arch_id_for: map a target isa name to its canonical id (ARCH_UNKNOWN if unrecognized).
+pub fun arch_id_for(name: str) u32 {
+    if (str_equals(name, "x86_64"))  { ret ARCH_X86_64; }
+    if (str_equals(name, "aarch64")) { ret ARCH_AARCH64; }
+    ret ARCH_UNKNOWN;
+}
+
+# arch_name_for: the canonical name for an arch id ("unknown" if unrecognized).
+pub fun arch_name_for(id: u32) str {
+    if (id == ARCH_X86_64)  { ret "x86_64"; }
+    if (id == ARCH_AARCH64) { ret "aarch64"; }
+    ret "unknown";
+}
 
 # pseudo-opcodes shared by every ISA. they occupy the high end of the opcode
 # space so that no real machine opcode collides with them. the backend emits

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -14,6 +14,7 @@ use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.string.str;
+use std.types.string.str_equals;
 
 use intern: mach.lang.intern;
 
@@ -27,6 +28,22 @@ pub val OS_LINUX:        u32 = 1;
 pub val OS_DARWIN:       u32 = 2;
 pub val OS_WINDOWS:      u32 = 3;
 pub val OS_FREESTANDING: u32 = 4;
+
+# os_id_for: map a target os name to its canonical id (OS_UNKNOWN if unrecognized).
+pub fun os_id_for(name: str) u32 {
+    if (str_equals(name, "linux"))   { ret OS_LINUX; }
+    if (str_equals(name, "darwin"))  { ret OS_DARWIN; }
+    if (str_equals(name, "windows")) { ret OS_WINDOWS; }
+    ret OS_UNKNOWN;
+}
+
+# os_name_for: the canonical name for an os id ("unknown" if unrecognized).
+pub fun os_name_for(id: u32) str {
+    if (id == OS_LINUX)   { ret "linux"; }
+    if (id == OS_DARWIN)  { ret "darwin"; }
+    if (id == OS_WINDOWS) { ret "windows"; }
+    ret "unknown";
+}
 
 # the operating-system runtime-dispatch interface. exactly one of these exists
 # per OS; the driver and linker read the entry symbol, library directory, and


### PR DESCRIPTION
Closes #1412

## Part A — consolidate (behavior-preserving)

The os/arch name↔id mapping was duplicated across `driver.mach` and `manifest.mach`. Consolidated to one canonical table per dimension:

- `src/lang/target/os.mach`: add `pub fun os_id_for` / `pub fun os_name_for` (linux/darwin/windows only — `freestanding` stays #1179's job).
- `src/lang/target/isa.mach`: add `pub fun arch_id_for` / `pub fun arch_name_for` (x86_64/aarch64).
- `src/lang/driver.mach`: deleted the file-local `os_id_for`/`arch_id_for`; every caller now uses `os.os_id_for` / `isa.arch_id_for` (the two in `select_target` plus the one in `populate_union_tuples` added by the recent dev merge of #1391).
- `src/lang/manifest.mach`: deleted the file-local defs; `target_matches_host` now calls the canonical ones, and `host_os_name`/`host_isa_name` delegate to `os.os_name_for`/`isa.arch_name_for`.

## Part B — distinct "unknown name" diagnostic

In `select_target`, after computing `os_id`/`arch_id` and before `tgt.select`, an unrecognized name now reports a distinct error instead of folding to `*_UNKNOWN` and being mis-reported as an unsupported pair:

```
error: unknown target os name 'bogusos' (expected: linux, darwin, windows)
```

## Verification

- `mach build` exits 0.
- `mach test .` — 435 passed, 0 failed, 435 total.
- Self-host fixpoint: byte-identical (Part A is behavior-preserving; Part B only changes an error message on a path that already errors).
- Diagnostic repro (bogus os name) emits `error: unknown target os name 'bogusos' (expected: linux, darwin, windows)`.