### PR TITLE
release: v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   interner-elimination from the OS vtable started in #1377. Behavior-preserving,
   verified by the byte-identical self-host fixpoint (#1402).
 
+### Fixed
+
+- objfmt: the COFF and ELF object-file parsers allocate the section/symbol/relocation
+  arrays up front but left each `ObjectImage` count at `0` until its populate loop
+  finished, so an error return before or within those loops (a truncated or hostile
+  object) leaked the arrays — `obj.dnit` frees nothing when the counts are `0`. Each
+  count is now set to its populated size immediately after the array is allocated (the
+  loops use local write cursors), so teardown reclaims the full arrays on any later
+  parse error; the ELF symbol array is sized and counted to the populated count
+  (excluding the reserved index-0 entry) so allocation, count, and entries all agree.
+  Emitted output is unchanged (#1410).
+
 ## [1.5.3] - 2026-06-13
 
 Correctness patch for two silent defects in shipped v1.5.2: a relocation
@@ -40,13 +52,6 @@ and an extreme float-literal exponent that hung the compiler.
 
 ### Fixed
 
-- objfmt: the COFF and ELF object-file parsers allocate the section/symbol/relocation
-  arrays up front but left each `ObjectImage` count at `0` until its populate loop
-  finished, so an error return before or within those loops (a truncated or hostile
-  object) leaked the arrays — `obj.dnit` frees nothing when the counts are `0`. Each
-  count is now set to its allocation size immediately after the array is allocated
-  (the loops use local write cursors), so teardown reclaims the full arrays on any
-  later parse error. Emitted output is unchanged (#1410).
 - codegen (x86-64): an 8-byte store of an immediate outside signed-`imm32` range to
   a global is legalized into `MOVABS r11, imm64` + a register store, but the PC32
   relocation was patched at the pre-legalization offset — landing 4 bytes early,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   interner-elimination from the OS vtable started in #1377. Behavior-preserving,
   verified by the byte-identical self-host fixpoint (#1402).
 
+### Fixed
+
+- objfmt (COFF): REL32 relocations are next-byte-relative (`S + A − (P+4)`), but the
+  abstract addend uses ELF's field-relative convention (`S + A − P`), so the writer's
+  on-wire field and the reader's recovered addend were off by 4 — a foreign
+  (MSVC/clang/GAS) COFF read by mach landed calls 4 bytes past target, and mach's
+  emitted `.obj` was off by −4 under link.exe/lld. The writer now folds `A_coff =
+  A_elf + 4` and the reader recovers `A_elf = A_coff − 4` for REL32 only; ABS64
+  (ADDR64) and ADDR32NB are unaffected. mach↔mach output is byte-identical (the fold
+  and recovery cancel), so the fix changes only foreign-COFF interop (#1409).
+
 ## [1.5.3] - 2026-06-13
 
 Correctness patch for two silent defects in shipped v1.5.2: a relocation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default target's branches win" — and a module that does not fully resolve there
   records diagnostics without aborting the build (#1391).
 
+### Changed
+
+- target: the os/arch name↔id mapping is consolidated to one canonical table per
+  dimension — `os.os_id_for`/`os.os_name_for` and `isa.arch_id_for`/`isa.arch_name_for`
+  — replacing the copies that lived in `driver.mach` and `manifest.mach`. An
+  unrecognized manifest `os`/`isa` name now reports a distinct "unknown target os/isa
+  name '<name>' (expected: ...)" diagnostic instead of folding to `*_UNKNOWN` and being
+  mis-reported as an unsupported pair (#1412).
+
 ## [1.5.3] - 2026-06-13
 
 Correctness patch for two silent defects in shipped v1.5.2: a relocation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of use (the entry-symbol lookup and the dynamic interpreter path), completing the
   interner-elimination from the OS vtable started in #1377. Behavior-preserving,
   verified by the byte-identical self-host fixpoint (#1402).
+- objfmt (COFF): the writer/reader resolve every relocation's target symbol through a
+  name→index map built once per pass instead of a linear symbol-table scan per
+  relocation, turning the two reloc passes from O(reloc × symbol) into O(reloc +
+  symbol). Behavior-preserving (same indices resolved, same unresolved-symbol error),
+  verified by the byte-identical self-host fixpoint (#1413).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.4] - 2026-06-14
+
+Stabilization + multi-target-prep release. Adds the multi-target union Project for
+long-lived tooling (the language server now sees modules reachable only on a
+non-default target), lands the post-windows compiler-stability audit fixes
+(object-format parse-leak reclamation + truthful ELF symbol counts, the COFF REL32
+addend convention, a distinct unknown-target-name diagnostic, and an arm64
+register-id correction), and completes the OS-vtable interner-elimination — readying
+the target layer for the v1.6 architectures.
+
 ### Added
 
 - driver: `build_project_union` builds the union of every manifest target's import
@@ -64,8 +74,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (MSVC/clang/GAS) COFF read by mach landed calls 4 bytes past target, and mach's
   emitted `.obj` was off by −4 under link.exe/lld. The writer now folds `A_coff =
   A_elf + 4` and the reader recovers `A_elf = A_coff − 4` for REL32 only; ABS64
-  (ADDR64) and ADDR32NB are unaffected. mach↔mach output is byte-identical (the fold
-  and recovery cancel), so the fix changes only foreign-COFF interop (#1409).
+  (ADDR64) and ADDR32NB are unaffected. A mach-emitted `.obj`'s REL32 wire field
+  changes (that is the fix — a `call`'s field is now 0, the COFF convention), but a
+  mach→mach round-trip recovers the same abstract addend and links to the same final
+  binary; only foreign-COFF interop behavior changes (#1409).
 
 ## [1.5.3] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- target: the dead `IsaVTable.endianness` field is removed. It was set by the ISA
+  registrars but read by nobody — the object-format writers hardcode little-endian —
+  so the field documented a behavior that did not exist. The `ENDIAN_LITTLE`/
+  `ENDIAN_BIG` enum is retained for the eventual big-endian abstraction, and the
+  comments that claimed endianness was honored now state the little-endian
+  assumption plainly (#1411).
+
+### Fixed
+
+- target (aarch64): `IsaVTable.fp_scratch_reg` for the (stub) arm64 backend is now
+  the composite vector register id `regid_make(REG_CLASS_ID_XMM, 31)` instead of the
+  raw bank index `31`, which would have read as a GP register. Dead today (the arm64
+  backend has no encoder), corrected before it seeds the future backend (#1414).
+
 ## [1.5.3] - 2026-06-13
 
 Correctness patch for two silent defects in shipped v1.5.2: a relocation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- driver: `build_project_union` builds the union of every manifest target's import
+  closure into one deduplicated Project, so long-lived multi-target tooling (e.g. the
+  language server) sees modules reachable only on a non-default target. Each `$if`
+  chain follows the first active branch of every declared target; the Project resolves
+  under the default (native-resolved) target's tuple — the documented v1 default, "the
+  default target's branches win" — and a module that does not fully resolve there
+  records diagnostics without aborting the build (#1391).
+
 ## [1.5.2] - 2026-06-13
 
 Maintenance patch: path dependencies materialize through the standard library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on i64 exponent overflow. The exponent accumulator is now clamped past the point
   f64 saturates, so such literals fold to `inf`/`0.0` instead (#1408).
 
+### Changed
+
+- The `OsVTable` `entry_symbol`, `syscall_layer`, `libdir`, and `dynamic_linker`
+  fields are immutable `str` constants set directly by the OS registrars, no longer
+  `StrId` fields re-interned per session; the linker now interns these at the point
+  of use (the entry-symbol lookup and the dynamic interpreter path), completing the
+  interner-elimination from the OS vtable started in #1377. Behavior-preserving,
+  verified by the byte-identical self-host fixpoint (#1402).
+
 ## [1.5.2] - 2026-06-13
 
 Maintenance patch: path dependencies materialize through the standard library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- objfmt: the COFF and ELF object-file parsers allocate the section/symbol/relocation
+  arrays up front but left each `ObjectImage` count at `0` until its populate loop
+  finished, so an error return before or within those loops (a truncated or hostile
+  object) leaked the arrays — `obj.dnit` frees nothing when the counts are `0`. Each
+  count is now set to its allocation size immediately after the array is allocated
+  (the loops use local write cursors), so teardown reclaims the full arrays on any
+  later parse error. Emitted output is unchanged (#1410).
 - codegen (x86-64): an 8-byte store of an immediate outside signed-`imm32` range to
   a global is legalized into `MOVABS r11, imm64` + a register store, but the PC32
   relocation was patched at the pre-legalization offset — landing 4 bytes early,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default target's branches win" — and a module that does not fully resolve there
   records diagnostics without aborting the build (#1391).
 
+### Changed
+
+- The `OsVTable` `entry_symbol`, `syscall_layer`, `libdir`, and `dynamic_linker`
+  fields are immutable `str` constants set directly by the OS registrars, no longer
+  `StrId` fields re-interned per session; the linker now interns these at the point
+  of use (the entry-symbol lookup and the dynamic interpreter path), completing the
+  interner-elimination from the OS vtable started in #1377. Behavior-preserving,
+  verified by the byte-identical self-host fixpoint (#1402).
+
 ## [1.5.3] - 2026-06-13
 
 Correctness patch for two silent defects in shipped v1.5.2: a relocation

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "1.5.3"
+version = "1.5.4"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1705,11 +1705,11 @@ fun resolve_shared_into(p: *driver.Project, name: *u8, argc: usize, argv: **u8, 
         }
         li = li + 1;
     }
-    # the OS default library directory from the target vtable.
+    # the OS default library directory from the target vtable (a plain str).
     if (p.target.os != nil) {
-        val ld: Option[str] = intern.lookup(?p.s.interner, p.target.os.libdir);
-        if (is_some[str](ld)) {
-            if (try_shared_in_dir(p, unwrap[str](ld)::*u8, name, buf, cap)) { ret true; }
+        val ld: str = p.target.os.libdir;
+        if (!str_empty(ld)) {
+            if (try_shared_in_dir(p, ld::*u8, name, buf, cap)) { ret true; }
         }
     }
     # the common multiarch/system library directories. NOTE: the x86_64-linux

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -699,7 +699,12 @@ fun emit_dynamic_executable(s: *sess.Session, tgt: *target.Target, out_img: *of.
 # address. an undefined or missing entry symbol is an error.
 fun entry_vaddr(s: *sess.Session, tgt: *target.Target,
                 sym_locs: *map.Map[intern.StrId, SymbolLoc]) Result[u64, str] {
-    val entry_name: intern.StrId = tgt.os.entry_symbol;
+    # the OS entry symbol is a plain str on the vtable; intern it here to key the
+    # symbol-location map (interning is idempotent, so it matches the id the
+    # symbol table merged under).
+    val er: Result[intern.StrId, str] = intern.intern(?s.interner, tgt.os.entry_symbol);
+    if (is_err[intern.StrId, str](er)) { ret err[u64, str](unwrap_err[intern.StrId, str](er)); }
+    val entry_name: intern.StrId = unwrap_ok[intern.StrId, str](er);
     val el: Result[*SymbolLoc, str] =
         map.get[intern.StrId, SymbolLoc](sym_locs, ?entry_name);
     if (is_err[*SymbolLoc, str](el)) {
@@ -1361,8 +1366,15 @@ fun build_dynamic_info(s: *sess.Session, tgt: *target.Target, dyn: *DynState,
 
     # the interpreter path is the OS's run-time loader recorded into a PT_INTERP
     # (ELF); a format that embeds the loader differently (PE's import directory,
-    # Mach-O's dyld bind) supplies STR_NIL and the format writer ignores it.
-    dyn.info.interp = tgt.os.dynamic_linker;
+    # Mach-O's dyld bind) supplies an empty path and the format writer ignores it.
+    # the path is a plain str on the vtable; intern it here for the StrId-keyed
+    # DynInfo, mapping the empty path to STR_NIL.
+    dyn.info.interp = intern.STR_NIL;
+    if (str_len(tgt.os.dynamic_linker) > 0) {
+        val dr: Result[intern.StrId, str] = intern.intern(?s.interner, tgt.os.dynamic_linker);
+        if (is_err[intern.StrId, str](dr)) { ret err[bool, str](unwrap_err[intern.StrId, str](dr)); }
+        dyn.info.interp = unwrap_ok[intern.StrId, str](dr);
+    }
 
     # one DynLib per soname, in input order.
     if (soname_count > 0) {

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -29,6 +29,7 @@ use std.types.bool.true;
 use std.types.bool.false;
 use std.types.string.str;
 use std.types.string.str_len;
+use std.types.string.str_empty;
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
@@ -1370,7 +1371,7 @@ fun build_dynamic_info(s: *sess.Session, tgt: *target.Target, dyn: *DynState,
     # the path is a plain str on the vtable; intern it here for the StrId-keyed
     # DynInfo, mapping the empty path to STR_NIL.
     dyn.info.interp = intern.STR_NIL;
-    if (str_len(tgt.os.dynamic_linker) > 0) {
+    if (!str_empty(tgt.os.dynamic_linker)) {
         val dr: Result[intern.StrId, str] = intern.intern(?s.interner, tgt.os.dynamic_linker);
         if (is_err[intern.StrId, str](dr)) { ret err[bool, str](unwrap_err[intern.StrId, str](dr)); }
         dyn.info.interp = unwrap_ok[intern.StrId, str](dr);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2005,10 +2005,16 @@ fun walk_comptime_if_for_load(p: *Project, mid: sess.ModuleId, ci: *decl.DeclCom
     val src_opt: Option[*src.SourceFile] = src.get(?p.s.sources, m.file_id);
     if (is_none[*src.SourceFile](src_opt)) { ret err[bool, str]("module file_id not found in SourceMap"); }
     val source: str = unwrap[*src.SourceFile](src_opt).text;
+
+    # union build (#1391): load every branch taken by SOME manifest target, not
+    # just the selected target's branch (see walk_comptime_if_union).
+    if (p.union) { ret walk_comptime_if_union(p, mid, ci, source); }
+
+    # single-target build: the first branch active under the selected target wins.
     var bi: u32 = 0;
     for (bi < ci.branches_len) {
         val br: *decl.ComptimeBranch = ?m.a.comptime_branches[ci.branches_start + bi];
-        val take_r: Result[bool, str] = comptime_branch_active_load(p, mid, br, source);
+        val take_r: Result[bool, str] = comptime_branch_active_load(p, mid, br, source, true);
         if (is_err[bool, str](take_r)) { ret take_r; }
         if (unwrap_ok[bool, str](take_r)) {
             ret walk_decl_list_for_load(p, mid, br.body_start, br.body_len);
@@ -2018,7 +2024,13 @@ fun walk_comptime_if_for_load(p: *Project, mid: sess.ModuleId, ci: *decl.DeclCom
     ret ok[bool, str](true);
 }
 
-fun comptime_branch_active_load(p: *Project, mid: sess.ModuleId, br: *decl.ComptimeBranch, source: str) Result[bool, str] {
+# comptime_branch_active_load: whether a `$if`-chain branch's condition is active
+# under the module's CURRENT comptime ctx (its target tuple). An else branch
+# (`cond == EXPR_NIL`) is always active. A malformed / non-bool condition reports
+# a diagnostic and reads as inactive — but only when `emit_diag` is true, so the
+# union walk (which re-evaluates under every target) reports a bad cond once,
+# under the default tuple, not once per target.
+fun comptime_branch_active_load(p: *Project, mid: sess.ModuleId, br: *decl.ComptimeBranch, source: str, emit_diag: bool) Result[bool, str] {
     if (br.cond == id.EXPR_NIL) { ret ok[bool, str](true); }
     val m: *ModuleEntry = ?p.modules[mid::u32];
     val r: Result[comptime.CTValue, str] = comptime.eval(?m.ctx, ?m.a, source, br.cond, ?p.s.interner);
@@ -2026,17 +2038,109 @@ fun comptime_branch_active_load(p: *Project, mid: sess.ModuleId, br: *decl.Compt
     if (is_none[*expr.Expr](e_opt)) { ret err[bool, str]("comptime branch cond ExprId out of range"); }
     val cond_span: token.Span = unwrap[*expr.Expr](e_opt).span;
     if (is_err[comptime.CTValue, str](r)) {
-        val de: Result[bool, str] = diag.error(?p.s.diags, m.file_id, cond_span, unwrap_err[comptime.CTValue, str](r));
-        if (is_err[bool, str](de)) { ret de; }
+        if (emit_diag) {
+            val de: Result[bool, str] = diag.error(?p.s.diags, m.file_id, cond_span, unwrap_err[comptime.CTValue, str](r));
+            if (is_err[bool, str](de)) { ret de; }
+        }
         ret ok[bool, str](false);
     }
     val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](r);
     if (v.kind != comptime.CT_KIND_BOOL) {
-        val de: Result[bool, str] = diag.error(?p.s.diags, m.file_id, cond_span, "comptime branch condition must be a bool");
-        if (is_err[bool, str](de)) { ret de; }
+        if (emit_diag) {
+            val de: Result[bool, str] = diag.error(?p.s.diags, m.file_id, cond_span, "comptime branch condition must be a bool");
+            if (is_err[bool, str](de)) { ret de; }
+        }
         ret ok[bool, str](false);
     }
     ret ok[bool, str](v.data.b);
+}
+
+# first_active_branch: index of the first branch in the `$if` chain active under
+# the module's current comptime ctx, or `branches_len` when none is (no else).
+# The union walk calls this once per manifest target (swapping the ctx tuple in
+# beforehand): that target's taken branch is its first active one.
+fun first_active_branch(p: *Project, mid: sess.ModuleId, ci: *decl.DeclComptimeIf, source: str, emit_diag: bool) Result[u32, str] {
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    var bi: u32 = 0;
+    for (bi < ci.branches_len) {
+        val br: *decl.ComptimeBranch = ?m.a.comptime_branches[ci.branches_start + bi];
+        val a_r: Result[bool, str] = comptime_branch_active_load(p, mid, br, source, emit_diag);
+        if (is_err[bool, str](a_r)) { ret err[u32, str](unwrap_err[bool, str](a_r)); }
+        if (unwrap_ok[bool, str](a_r)) { ret ok[u32, str](bi); }
+        bi = bi + 1;
+    }
+    ret ok[u32, str](ci.branches_len);
+}
+
+# walk_comptime_if_union: load-walk a `$if` chain in union mode — load every
+# branch taken by SOME manifest target. Each target's taken branch is its first
+# active one (computed under that target's tuple, swapped into the module ctx and
+# restored after); the union of those branches is walked. Diagnostics fire only
+# under the default (selected) tuple. Modules pulled in by a non-default target's
+# branch thus land in the Project — visible to workspace-wide tooling — and still
+# resolve under the default ctx ("default target's branches win"). The default
+# tuple is the module's existing ctx; `union_tuples` covers every manifest target
+# (re-checking the default there is harmless).
+fun walk_comptime_if_union(p: *Project, mid: sess.ModuleId, ci: *decl.DeclComptimeIf, source: str) Result[bool, str] {
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    val n: u32 = ci.branches_len;
+    if (n == 0) { ret ok[bool, str](true); }
+
+    val tk_r: Result[*bool, str] = allocate[bool](p.s.alloc, n::usize);
+    if (is_err[*bool, str](tk_r)) { ret err[bool, str](unwrap_err[*bool, str](tk_r)); }
+    val taken: *bool = unwrap_ok[*bool, str](tk_r);
+    var z: u32 = 0;
+    for (z < n) { taken[z] = false; z = z + 1; }
+
+    # default tuple (the module's current ctx = selected target), WITH diagnostics.
+    val d_r: Result[u32, str] = first_active_branch(p, mid, ci, source, true);
+    if (is_err[u32, str](d_r)) { deallocate[bool](p.s.alloc, taken, n::usize); ret err[bool, str](unwrap_err[u32, str](d_r)); }
+    val d_idx: u32 = unwrap_ok[u32, str](d_r);
+    if (d_idx < n) { taken[d_idx] = true; }
+
+    # every other manifest target: swap its tuple into the ctx, no diagnostics.
+    val s_os_id: u32 = m.ctx.target_os_id;
+    val s_arch:  u32 = m.ctx.target_arch_id;
+    val s_pw:    u32 = m.ctx.pointer_width;
+    val s_os:  intern.StrId = m.ctx.target_os;
+    val s_isa: intern.StrId = m.ctx.target_isa;
+    val s_abi: intern.StrId = m.ctx.target_abi;
+    var ferr: bool = false;
+    var ferr_msg: str = "";
+    var ti: u32 = 0;
+    for (ti < p.union_tuple_count) {
+        m.ctx.target_os_id   = p.union_tuples[ti].os_id;
+        m.ctx.target_arch_id = p.union_tuples[ti].arch_id;
+        m.ctx.pointer_width  = p.union_tuples[ti].pointer_width;
+        m.ctx.target_os      = p.union_tuples[ti].os_name;
+        m.ctx.target_isa     = p.union_tuples[ti].isa_name;
+        m.ctx.target_abi     = p.union_tuples[ti].abi_name;
+        val a_r: Result[u32, str] = first_active_branch(p, mid, ci, source, false);
+        if (is_err[u32, str](a_r)) { ferr = true; ferr_msg = unwrap_err[u32, str](a_r); brk; }
+        val idx: u32 = unwrap_ok[u32, str](a_r);
+        if (idx < n) { taken[idx] = true; }
+        ti = ti + 1;
+    }
+    m.ctx.target_os_id   = s_os_id;
+    m.ctx.target_arch_id = s_arch;
+    m.ctx.pointer_width  = s_pw;
+    m.ctx.target_os      = s_os;
+    m.ctx.target_isa     = s_isa;
+    m.ctx.target_abi     = s_abi;
+    if (ferr) { deallocate[bool](p.s.alloc, taken, n::usize); ret err[bool, str](ferr_msg); }
+
+    # walk every taken branch's body into the load graph.
+    var bi: u32 = 0;
+    for (bi < n) {
+        if (taken[bi]) {
+            val br: *decl.ComptimeBranch = ?m.a.comptime_branches[ci.branches_start + bi];
+            val w: Result[bool, str] = walk_decl_list_for_load(p, mid, br.body_start, br.body_len);
+            if (is_err[bool, str](w)) { deallocate[bool](p.s.alloc, taken, n::usize); ret w; }
+        }
+        bi = bi + 1;
+    }
+    deallocate[bool](p.s.alloc, taken, n::usize);
+    ret ok[bool, str](true);
 }
 
 # walk_use_for_load: handle one `use` decl during the load walk: interns

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -436,11 +436,15 @@ pub fun enumerate_matrix(alloc: *Allocator, project_root: str,
 # project_root: filesystem path to the project root (containing mach.toml)
 # sel:          the build selection narrowing target/profile/artifact
 # ret:          fully populated Project, or an error message
-pub fun build_project_sel(s: *sess.Session, project_root: str, sel: *manifest.Selection) Result[Project, str] {
+# build_project_impl: the shared build pipeline behind both build_project_sel
+# (single target) and build_project_union (all targets). `for_union` records every
+# manifest target's tuple and flips on the union load walk (see load_config /
+# walk_comptime_if_union).
+fun build_project_impl(s: *sess.Session, project_root: str, sel: *manifest.Selection, for_union: bool) Result[Project, str] {
     var p: Project;
     init_project(?p, s);
 
-    val cfg_r: Result[bool, str] = load_project_config(?p, project_root, sel);
+    val cfg_r: Result[bool, str] = load_project_config(?p, project_root, sel, for_union);
     if (is_err[bool, str](cfg_r)) {
         dnit_project(?p);
         ret err[Project, str](unwrap_err[bool, str](cfg_r));
@@ -504,6 +508,72 @@ pub fun build_project_sel(s: *sess.Session, project_root: str, sel: *manifest.Se
     }
 
     ret ok[Project, str](p);
+}
+
+# build_project_sel: build the module graph for one build selection (target,
+# profile, artifact). The manifest reader resolves the selection into the
+# project's single target entry and concrete output paths.
+pub fun build_project_sel(s: *sess.Session, project_root: str, sel: *manifest.Selection) Result[Project, str] {
+    ret build_project_impl(s, project_root, sel, false);
+}
+
+# build_project_union: build the union of EVERY manifest target's import closure
+# into one deduplicated Project, for long-lived multi-target tooling (#1391).
+# Modules are deduped by FQN. A module reachable only via a non-default target's
+# `$if` is still loaded and present — so workspace-wide tooling (e.g. rename) sees
+# it (lsp #58) — and is resolved under the DEFAULT target's ctx ("default target's
+# branches win", the documented v1 default). A module that does not fully resolve
+# under that ctx records per-module diagnostics and the Project stays usable; the
+# union build is not aborted. For ordinary single-target builds use
+# build_project_sel.
+pub fun build_project_union(s: *sess.Session, project_root: str) Result[Project, str] {
+    var sel: manifest.Selection;
+    sel.target       = "";
+    sel.profile      = "";
+    sel.artifact     = "";
+    sel.want_lib     = false;
+    sel.has_artifact = false;
+    ret build_project_impl(s, project_root, ?sel, true);
+}
+
+# populate_union_tuples: record one TargetTuple per declared manifest target and
+# turn on union mode (#1391). The union load walk evaluates each `$if` branch
+# under every tuple, so a branch some target takes is followed. A manifest with no
+# `[target.*]` leaves the Project single-target (union stays off).
+fun populate_union_tuples(p: *Project, m: *manifest.Manifest) Result[bool, str] {
+    val n: u32 = m.target_count;
+    if (n == 0) { ret ok[bool, str](true); }
+    val tr: Result[*TargetTuple, str] = allocate[TargetTuple](p.s.alloc, n::usize);
+    if (is_err[*TargetTuple, str](tr)) { ret err[bool, str](unwrap_err[*TargetTuple, str](tr)); }
+    val tuples: *TargetTuple = unwrap_ok[*TargetTuple, str](tr);
+    var k: u32 = 0;
+    for (k < n) {
+        val td: *manifest.TargetDef = ?m.targets[k];
+        val os_opt:  Option[str] = intern.lookup(?p.s.interner, td.os);
+        val isa_opt: Option[str] = intern.lookup(?p.s.interner, td.isa);
+        if (is_none[str](os_opt) || is_none[str](isa_opt)) {
+            deallocate[TargetTuple](p.s.alloc, tuples, n::usize);
+            ret err[bool, str]("internal: union target tuple name not interned");
+        }
+        val os_id:   u32 = os_id_for(unwrap[str](os_opt));
+        val arch_id: u32 = arch_id_for(unwrap[str](isa_opt));
+        val sr: Result[tgt.Target, str] = tgt.select(?p.s.registry, os_id, arch_id);
+        if (is_err[tgt.Target, str](sr)) {
+            deallocate[TargetTuple](p.s.alloc, tuples, n::usize);
+            ret err[bool, str](unwrap_err[tgt.Target, str](sr));
+        }
+        tuples[k].os_id         = os_id;
+        tuples[k].arch_id       = arch_id;
+        tuples[k].pointer_width = unwrap_ok[tgt.Target, str](sr).arch.pointer_width;
+        tuples[k].os_name       = td.os;
+        tuples[k].isa_name      = td.isa;
+        tuples[k].abi_name      = td.abi;
+        k = k + 1;
+    }
+    p.union_tuples      = tuples;
+    p.union_tuple_count = n;
+    p.union             = true;
+    ret ok[bool, str](true);
 }
 
 # register_export_names: scan every module for `$<sym>.symbol = "..."` directives
@@ -873,7 +943,7 @@ fun deallocate_config(c: *ProjectConfig, alloc: *Allocator) {
     c.cascade_lib_count = 0;
 }
 
-fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection) Result[bool, str] {
+fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection, for_union: bool) Result[bool, str] {
     val abs_root_r: Result[intern.StrId, str] = intern.intern(?p.s.interner, project_root);
     if (is_err[intern.StrId, str](abs_root_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](abs_root_r)); }
     p.config.project_root = unwrap_ok[intern.StrId, str](abs_root_r);
@@ -887,7 +957,7 @@ fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection
     if (is_err[toml.Table, str](toml_r)) { ret err[bool, str](unwrap_err[toml.Table, str](toml_r)); }
     var t: toml.Table = unwrap_ok[toml.Table, str](toml_r);
 
-    ret load_config(p, project_root, ?t, sel);
+    ret load_config(p, project_root, ?t, sel, for_union);
 }
 
 # load_config: parse the manifest, resolve the build selection into one build
@@ -895,7 +965,7 @@ fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection
 # single target entry plus the unit's concrete, template-expanded output paths.
 # collisions are checked before anything is built. a `native` selection that
 # finds no host match emits an unmissable warning here.
-fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.Selection) Result[bool, str] {
+fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.Selection, for_union: bool) Result[bool, str] {
     val mr: Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, t);
     if (is_err[manifest.Manifest, str](mr)) { ret err[bool, str](unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = unwrap_ok[manifest.Manifest, str](mr);
@@ -979,6 +1049,13 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     # build start, imported or not (#1326).
     val mc: Result[bool, str] = check_own_module(p, project_root);
     if (is_err[bool, str](mc)) { manifest.dnit(?m, p.s.alloc); ret mc; }
+
+    # multi-target tooling build (#1391): record every manifest target's tuple so
+    # the union load walk can follow each target's `$if` branches.
+    if (for_union) {
+        val ut: Result[bool, str] = populate_union_tuples(p, ?m);
+        if (is_err[bool, str](ut)) { manifest.dnit(?m, p.s.alloc); ret ut; }
+    }
 
     manifest.dnit(?m, p.s.alloc);
     ret ok[bool, str](true);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -3144,3 +3144,48 @@ test "driver union: a malformed branch condition is reported once, not once per 
     sess.dnit(?s2);
     ret bad;
 }
+
+test "driver union: branch selection via the $target.os string tag exercises and restores the StrId tuple (#1391)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    # gate on the $target.os STRING tag (the StrId-backed ctx field), not the numeric
+    # $mach.target.os — so the per-target StrId override and its restore are both
+    # load-bearing (the numeric-tag tests would pass even with a broken StrId restore).
+    texts[0] = "$if ($target.os == \"linux\") { use uniontest.a; }\n$or ($target.os == \"windows\") { use uniontest.b; }\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    texts[2] = "pub fun fb() i32 { ret 2; }\n";
+
+    val pr: Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 3);
+    if (is_err[Project, str](pr)) { sess.dnit(?s); ret 1; }
+    var p: Project = unwrap_ok[Project, str](pr);
+
+    var bad: i32 = 0;
+    # both string-gated branches are taken — the per-target StrId override drives selection.
+    if (!ut_has(?p, ?s, "uniontest.a")) { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.b")) { bad = 1; }
+
+    # the StrId tuple fields (target_os/isa/abi) must be restored to the default after
+    # the walk: main runs the union $if walk, a and b do not, so a broken StrId restore
+    # would leave main carrying a non-default tuple while a/b keep the default.
+    val cm: *comptime.ComptimeCtx = ut_ctx(?p, ?s, "uniontest.main");
+    val ca: *comptime.ComptimeCtx = ut_ctx(?p, ?s, "uniontest.a");
+    val cb: *comptime.ComptimeCtx = ut_ctx(?p, ?s, "uniontest.b");
+    if (cm == nil || ca == nil || cb == nil) { bad = 1; }
+    or (cm.target_os != ca.target_os)        { bad = 1; }
+    or (cm.target_os != cb.target_os)        { bad = 1; }
+    or (cm.target_isa != ca.target_isa)      { bad = 1; }
+    or (cm.target_isa != cb.target_isa)      { bad = 1; }
+    or (cm.target_abi != ca.target_abi)      { bad = 1; }
+    or (cm.target_abi != cb.target_abi)      { bad = 1; }
+
+    dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -255,7 +255,7 @@ val LOAD_DONE:    LoadStatus = 2;
 # config:       parsed project config (incl. dep metadata)
 # target_entry: pointer into config.targets selecting which target this build is
 # target:       composed target (isa/abi/os/of vtables) resolved via target.select;
-#               pointer width and endianness are read through target.arch
+#               pointer width is read through target.arch
 # modules:      flat array of ModuleEntry, indexed by ModuleId
 # topo:         module ids in dep-order (topo[0] has no deps within the graph)
 # load:         DFS bookkeeping; cleared when build_project completes
@@ -1387,8 +1387,8 @@ fun intern_or(i: *intern.Interner, text: str, default: str) Result[intern.StrId,
 # tgt.Target. maps the entry's os/isa names to canonical ids, calls
 # target.select to compose the isa/abi/os/of vtables, and stores the
 # result on Project. an unknown os/arch pair has no canonical mapping and
-# fails the build through target.select. pointer width and endianness are
-# not stored here — consumers read them through p.target.arch.
+# fails the build through target.select. pointer width is not stored here —
+# consumers read it through p.target.arch.
 fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     val os_opt: Option[str] = intern.lookup(?p.s.interner, t.os_name);
     if (is_none[str](os_opt)) { ret err[bool, str]("target os name not interned"); }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -259,11 +259,36 @@ val LOAD_DONE:    LoadStatus = 2;
 # modules:      flat array of ModuleEntry, indexed by ModuleId
 # topo:         module ids in dep-order (topo[0] has no deps within the graph)
 # load:         DFS bookkeeping; cleared when build_project completes
+# TargetTuple: a manifest target's comptime-relevant axes — what a `$if` can fork
+# on (`$mach.target.{os,arch}`, `$target.{os,isa,abi}`). The #1391 union build
+# precomputes one per manifest target and evaluates each load-walk `$if` branch
+# under every tuple, so a branch taken by any target is followed (see
+# `comptime_branch_active_load`). Inert on a single-target build.
+rec TargetTuple {
+    os_id:         u32;
+    arch_id:       u32;
+    pointer_width: u32;
+    os_name:       intern.StrId;
+    isa_name:      intern.StrId;
+    abi_name:      intern.StrId;
+}
+
 pub rec Project {
     s:            *sess.Session;
     config:       ProjectConfig;
     target_entry: *TargetEntry;
     target:       tgt.Target;
+
+    # union build (#1391): true when this Project unions every manifest target's
+    # import closure for tooling (multi-target dedup). The load walk then takes a
+    # `$if` branch active under ANY `union_tuples` entry, not just the selected
+    # target, so modules reachable only from a non-default target are present
+    # (visible to workspace-wide rename). Modules still resolve under the selected
+    # (default) target's ctx — "default target's branches win". False/empty on an
+    # ordinary single-target build (`build_project_sel`), which is unchanged.
+    union:              bool;
+    union_tuples:       *TargetTuple;
+    union_tuple_count:  u32;
 
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
@@ -762,6 +787,9 @@ pub fun dnit_project(p: *Project) {
     if (p.topo != nil && p.topo_cap > 0) {
         deallocate[sess.ModuleId](p.s.alloc, p.topo, p.topo_cap::usize);
     }
+    if (p.union_tuples != nil && p.union_tuple_count > 0) {
+        deallocate[TargetTuple](p.s.alloc, p.union_tuples, p.union_tuple_count::usize);
+    }
     map.dnit[intern.StrId, sess.ModuleId](?p.by_fqn);
     deallocate_config(?p.config, p.s.alloc);
 }
@@ -769,6 +797,9 @@ pub fun dnit_project(p: *Project) {
 fun init_project(p: *Project, s: *sess.Session) {
     p.s             = s;
     p.target_entry  = nil;
+    p.union              = false;
+    p.union_tuples       = nil;
+    p.union_tuple_count  = 0;
     p.target.os_id   = os.OS_UNKNOWN;
     p.target.arch_id = isa.ARCH_UNKNOWN;
     p.target.abi_id  = 0;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -556,8 +556,8 @@ fun populate_union_tuples(p: *Project, m: *manifest.Manifest) Result[bool, str] 
             deallocate[TargetTuple](p.s.alloc, tuples, n::usize);
             ret err[bool, str]("internal: union target tuple name not interned");
         }
-        val os_id:   u32 = os_id_for(unwrap[str](os_opt));
-        val arch_id: u32 = arch_id_for(unwrap[str](isa_opt));
+        val os_id:   u32 = os.os_id_for(unwrap[str](os_opt));
+        val arch_id: u32 = isa.arch_id_for(unwrap[str](isa_opt));
         val sr: Result[tgt.Target, str] = tgt.select(?p.s.registry, os_id, arch_id);
         if (is_err[tgt.Target, str](sr)) {
             deallocate[TargetTuple](p.s.alloc, tuples, n::usize);
@@ -1507,8 +1507,15 @@ fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     if (is_none[str](isa_opt)) { ret err[bool, str]("target isa name not interned"); }
     val isa_name: str = unwrap[str](isa_opt);
 
-    val os_id:   u32 = os_id_for(os_name);
-    val arch_id: u32 = arch_id_for(isa_name);
+    val os_id:   u32 = os.os_id_for(os_name);
+    val arch_id: u32 = isa.arch_id_for(isa_name);
+
+    if (os_id == os.OS_UNKNOWN) {
+        ret err[bool, str](diag_join_named(p.s, "unknown target os name '", t.os_name, "' (expected: linux, darwin, windows)", "unknown target os name"));
+    }
+    if (arch_id == isa.ARCH_UNKNOWN) {
+        ret err[bool, str](diag_join_named(p.s, "unknown target isa name '", t.isa_name, "' (expected: x86_64, aarch64)", "unknown target isa name"));
+    }
 
     val tr: Result[tgt.Target, str] = tgt.select(?p.s.registry, os_id, arch_id);
     if (is_err[tgt.Target, str](tr)) { ret err[bool, str](unwrap_err[tgt.Target, str](tr)); }
@@ -1526,19 +1533,6 @@ fun select_target(p: *Project, t: *TargetEntry) Result[bool, str] {
     p.compiler_ver = unwrap_ok[intern.StrId, str](rcv);
 
     ret ok[bool, str](true);
-}
-
-fun os_id_for(name: str) u32 {
-    if (str_equals(name, "linux"))   { ret os.OS_LINUX; }
-    if (str_equals(name, "darwin"))  { ret os.OS_DARWIN; }
-    if (str_equals(name, "windows")) { ret os.OS_WINDOWS; }
-    ret os.OS_UNKNOWN;
-}
-
-fun arch_id_for(name: str) u32 {
-    if (str_equals(name, "x86_64"))  { ret isa.ARCH_X86_64; }
-    if (str_equals(name, "aarch64")) { ret isa.ARCH_AARCH64; }
-    ret isa.ARCH_UNKNOWN;
 }
 
 # entry_module_fqn: compute the entrypoint module's FQN: `<project.id>.<entrypoint stripped of .mach>`.

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2182,8 +2182,11 @@ fun walk_comptime_if_union(p: *Project, mid: sess.ModuleId, ci: *decl.DeclCompti
     val s_os:  intern.StrId = m.ctx.target_os;
     val s_isa: intern.StrId = m.ctx.target_isa;
     val s_abi: intern.StrId = m.ctx.target_abi;
-    var ferr: bool = false;
-    var ferr_msg: str = "";
+    # INVARIANT: m.ctx is the same object resolve uses afterward, with the default
+    # target tuple. A leaked non-default tuple would silently corrupt resolve with
+    # no diagnostic. So each iteration restores the default tuple IMMEDIATELY after
+    # the eval — before the result is inspected or any error returns. Do not add a
+    # return between the override and the restore below.
     var ti: u32 = 0;
     for (ti < p.union_tuple_count) {
         m.ctx.target_os_id   = p.union_tuples[ti].os_id;
@@ -2193,18 +2196,17 @@ fun walk_comptime_if_union(p: *Project, mid: sess.ModuleId, ci: *decl.DeclCompti
         m.ctx.target_isa     = p.union_tuples[ti].isa_name;
         m.ctx.target_abi     = p.union_tuples[ti].abi_name;
         val a_r: Result[u32, str] = first_active_branch(p, mid, ci, source, false);
-        if (is_err[u32, str](a_r)) { ferr = true; ferr_msg = unwrap_err[u32, str](a_r); brk; }
+        m.ctx.target_os_id   = s_os_id;
+        m.ctx.target_arch_id = s_arch;
+        m.ctx.pointer_width  = s_pw;
+        m.ctx.target_os      = s_os;
+        m.ctx.target_isa     = s_isa;
+        m.ctx.target_abi     = s_abi;
+        if (is_err[u32, str](a_r)) { deallocate[bool](p.s.alloc, taken, n::usize); ret err[bool, str](unwrap_err[u32, str](a_r)); }
         val idx: u32 = unwrap_ok[u32, str](a_r);
         if (idx < n) { taken[idx] = true; }
         ti = ti + 1;
     }
-    m.ctx.target_os_id   = s_os_id;
-    m.ctx.target_arch_id = s_arch;
-    m.ctx.pointer_width  = s_pw;
-    m.ctx.target_os      = s_os;
-    m.ctx.target_isa     = s_isa;
-    m.ctx.target_abi     = s_abi;
-    if (ferr) { deallocate[bool](p.s.alloc, taken, n::usize); ret err[bool, str](ferr_msg); }
 
     # walk every taken branch's body into the load graph.
     var bi: u32 = 0;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -46,6 +46,7 @@ use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
+use page: std.allocator.page;
 
 use fs:   std.filesystem;
 use toml: std.data.toml;
@@ -2830,4 +2831,316 @@ fun free_resolve_deps(alloc: *Allocator, deps: *resolve.ResolveDeps) {
     deallocate[resolve.ModuleExports](alloc, deps.entries, deps.count::usize);
     deps.entries = nil;
     deps.count   = 0;
+}
+
+# ut_cc3: concatenate three strings into a fresh nul-terminated buffer owned by
+# `alloc`. a path-join helper for the union-build tests below.
+fun ut_cc3(alloc: *Allocator, a: str, b: str, c: str) str {
+    val la: usize = str_len(a);
+    val lb: usize = str_len(b);
+    val lc: usize = str_len(c);
+    val r: Result[*u8, str] = allocate[u8](alloc, la + lb + lc + 1);
+    if (is_err[*u8, str](r)) { ret a; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    var j: usize = 0;
+    for (j < la) { buf[k] = a[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < lb) { buf[k] = b[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < lc) { buf[k] = c[j]; k = k + 1; j = j + 1; }
+    buf[k] = 0;
+    ret buf::str;
+}
+
+# ut_manifest: the shared two-target manifest the union tests scaffold. `native`
+# resolves the default to the host-matching target (linux or windows in CI).
+fun ut_manifest() str {
+    ret "[project]\nid = \"uniontest\"\nname = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\ntarget = \"native\"\nout = \"out/{target}/bin/{name}{ext}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\next = \".exe\"\n\n[bin.uniontest]\nentry = \"main.mach\"\n";
+}
+
+# ut_scaffold: materialize a temp project (mach.toml + src/<files>) on disk and
+# return its root path; the caller removes the tree via fs.remove_all.
+fun ut_scaffold(alloc: *Allocator, names: *str, texts: *str, n: u32) Result[str, str] {
+    val tf_r: Result[fs.TempFile, str] = fs.temp_create(alloc, "mach_union_test");
+    if (is_err[fs.TempFile, str](tf_r)) { ret err[str, str](unwrap_err[fs.TempFile, str](tf_r)); }
+    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
+    val dup_r: Result[str, str] = str_dup(alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (is_err[str, str](dup_r)) { ret dup_r; }
+    val root: str = unwrap_ok[str, str](dup_r);
+
+    val d1: Result[bool, str] = fs.create_dir_all(alloc, root, 493);
+    if (is_err[bool, str](d1)) { ret err[str, str](unwrap_err[bool, str](d1)); }
+    val src_dir: str = ut_cc3(alloc, root, "/", "src");
+    val d2: Result[bool, str] = fs.create_dir_all(alloc, src_dir, 493);
+    if (is_err[bool, str](d2)) { ret err[str, str](unwrap_err[bool, str](d2)); }
+
+    val mf: str = ut_cc3(alloc, root, "/", "mach.toml");
+    val mb: str = ut_manifest();
+    val w0: Result[bool, str] = fs.write_file(mf, mb, str_len(mb), 420);
+    if (is_err[bool, str](w0)) { ret err[str, str](unwrap_err[bool, str](w0)); }
+
+    var i: u32 = 0;
+    for (i < n) {
+        val fp: str = ut_cc3(alloc, src_dir, "/", names[i]);
+        val w: Result[bool, str] = fs.write_file(fp, texts[i], str_len(texts[i]), 420);
+        if (is_err[bool, str](w)) { ret err[str, str](unwrap_err[bool, str](w)); }
+        i = i + 1;
+    }
+    ret ok[str, str](root);
+}
+
+# ut_build: scaffold the module set, build the multi-target union Project, remove
+# the temp tree, and return the Project. the session is the caller's to tear down.
+fun ut_build(s: *sess.Session, alloc: *Allocator, names: *str, texts: *str, n: u32) Result[Project, str] {
+    val root_r: Result[str, str] = ut_scaffold(alloc, names, texts, n);
+    if (is_err[str, str](root_r)) { ret err[Project, str](unwrap_err[str, str](root_r)); }
+    val root: str = unwrap_ok[str, str](root_r);
+    val rr: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
+    if (is_err[bool, str](rr)) { fs.remove_all(alloc, root); ret err[Project, str](unwrap_err[bool, str](rr)); }
+    val pr: Result[Project, str] = build_project_union(s, root);
+    fs.remove_all(alloc, root);
+    ret pr;
+}
+
+# ut_has: whether the union Project loaded a module with the given FQN.
+fun ut_has(p: *Project, s: *sess.Session, fqn: str) bool {
+    val idr: Result[intern.StrId, str] = intern.intern(?s.interner, fqn);
+    if (is_err[intern.StrId, str](idr)) { ret false; }
+    var id: intern.StrId = unwrap_ok[intern.StrId, str](idr);
+    ret is_ok[*sess.ModuleId, str](map.get[intern.StrId, sess.ModuleId](?p.by_fqn, ?id));
+}
+
+# ut_ctx: the comptime ctx of the named module, or nil if it was not loaded.
+fun ut_ctx(p: *Project, s: *sess.Session, fqn: str) *comptime.ComptimeCtx {
+    val idr: Result[intern.StrId, str] = intern.intern(?s.interner, fqn);
+    if (is_err[intern.StrId, str](idr)) { ret nil; }
+    var id: intern.StrId = unwrap_ok[intern.StrId, str](idr);
+    val mr: Result[*sess.ModuleId, str] = map.get[intern.StrId, sess.ModuleId](?p.by_fqn, ?id);
+    if (is_err[*sess.ModuleId, str](mr)) { ret nil; }
+    val mid: sess.ModuleId = @unwrap_ok[*sess.ModuleId, str](mr);
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    ret ?m.ctx;
+}
+
+# ut_count_errors: number of error-severity diagnostics recorded on the session.
+fun ut_count_errors(d: *diag.DiagList) u32 {
+    var c: u32 = 0;
+    var i: usize = 0;
+    for (i < d.len) {
+        if (d.items[i].severity == diag.SEVERITY_ERROR) { c = c + 1; }
+        i = i + 1;
+    }
+    ret c;
+}
+
+test "driver union: a module gated behind a non-default target's $if is still loaded (#1391/lsp#58)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    texts[0] = "$if ($mach.target.os == $mach.os.linux) { use uniontest.a; }\n$or ($mach.target.os == $mach.os.windows) { use uniontest.b; }\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    texts[2] = "pub fun fb() i32 { ret 2; }\n";
+
+    val pr: Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 3);
+    if (is_err[Project, str](pr)) { sess.dnit(?s); ret 1; }
+    var p: Project = unwrap_ok[Project, str](pr);
+
+    # both the default-target module (a, on a linux host) and the non-default
+    # module (b, windows-only) are present, so workspace tooling sees the full graph.
+    var bad: i32 = 0;
+    if (!ut_has(?p, ?s, "uniontest.main")) { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.a"))    { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.b"))    { bad = 1; }
+
+    dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver union: each target contributes only its first active branch (#1391)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    # both targets are 64-bit, so the first branch (a) is every target's first active
+    # one; b's condition is true on linux but b is never a FIRST match, so the union
+    # includes a and excludes b (first-active per target, not include-every-true).
+    texts[0] = "$if ($mach.target.pointer_width == 8) { use uniontest.a; }\n$or ($mach.target.os == $mach.os.linux) { use uniontest.b; }\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    texts[2] = "pub fun fb() i32 { ret 2; }\n";
+
+    val pr: Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 3);
+    if (is_err[Project, str](pr)) { sess.dnit(?s); ret 1; }
+    var p: Project = unwrap_ok[Project, str](pr);
+
+    var bad: i32 = 0;
+    if (!ut_has(?p, ?s, "uniontest.a")) { bad = 1; }
+    or (ut_has(?p, ?s, "uniontest.b"))  { bad = 1; }
+
+    dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver union: every module's comptime ctx is restored to the default tuple (#1391)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    texts[0] = "$if ($mach.target.os == $mach.os.linux) { use uniontest.a; }\n$or ($mach.target.os == $mach.os.windows) { use uniontest.b; }\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    texts[2] = "pub fun fb() i32 { ret 2; }\n";
+
+    val pr: Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 3);
+    if (is_err[Project, str](pr)) { sess.dnit(?s); ret 1; }
+    var p: Project = unwrap_ok[Project, str](pr);
+
+    # the per-target tuple is overridden then restored per union-walk iteration; no
+    # module may carry a leaked non-default tuple afterward, so every loaded module's
+    # ctx tuple must match and equal the host (native-resolved default) tuple.
+    val cm: *comptime.ComptimeCtx = ut_ctx(?p, ?s, "uniontest.main");
+    val ca: *comptime.ComptimeCtx = ut_ctx(?p, ?s, "uniontest.a");
+    val cb: *comptime.ComptimeCtx = ut_ctx(?p, ?s, "uniontest.b");
+
+    var bad: i32 = 0;
+    if (cm == nil || ca == nil || cb == nil)     { bad = 1; }
+    or (cm.target_os_id != ca.target_os_id)      { bad = 1; }
+    or (cm.target_os_id != cb.target_os_id)      { bad = 1; }
+    or (cm.target_arch_id != ca.target_arch_id)  { bad = 1; }
+    or (cm.target_arch_id != cb.target_arch_id)  { bad = 1; }
+    or (cm.pointer_width != ca.pointer_width)    { bad = 1; }
+    or (cm.pointer_width != cb.pointer_width)    { bad = 1; }
+    or (cm.target_os_id != tgt.host_os_id())     { bad = 1; }
+    or (cm.target_arch_id != tgt.host_arch_id()) { bad = 1; }
+
+    dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver union: a comptime const in a branch condition survives the tuple override (#1391)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    # FLAG is a module const, not a target parameter, so it must read 1 under every
+    # per-target tuple the walk swaps in — selecting the second branch (b) for all.
+    texts[0] = "pub val FLAG: i32 = 1;\n$if (FLAG == 0) { use uniontest.a; }\n$or (FLAG == 1) { use uniontest.b; }\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    texts[2] = "pub fun fb() i32 { ret 2; }\n";
+
+    val pr: Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 3);
+    if (is_err[Project, str](pr)) { sess.dnit(?s); ret 1; }
+    var p: Project = unwrap_ok[Project, str](pr);
+
+    var bad: i32 = 0;
+    if (ut_has(?p, ?s, "uniontest.a"))  { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.b")) { bad = 1; }
+
+    dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver union: a non-default module that fails to resolve degrades gracefully (#1391)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    texts[0] = "$if ($mach.target.os == $mach.os.linux) { use uniontest.a; }\n$or ($mach.target.os == $mach.os.windows) { use uniontest.b; }\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    # b references an undefined symbol, so it fails to resolve under the default ctx.
+    texts[2] = "pub fun fb() i32 { ret undefined_symbol_xyz; }\n";
+
+    val pr: Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 3);
+    # the union build must NOT abort on a per-module resolve failure.
+    if (is_err[Project, str](pr)) { sess.dnit(?s); ret 1; }
+    var p: Project = unwrap_ok[Project, str](pr);
+
+    # the broken module is still loaded (tooling sees it) and its failure surfaces as
+    # a diagnostic rather than aborting the whole Project.
+    var bad: i32 = 0;
+    if (!ut_has(?p, ?s, "uniontest.b")) { bad = 1; }
+    or (!diag.has_errors(?s.diags))     { bad = 1; }
+
+    dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver union: a malformed branch condition is reported once, not once per target (#1391)" {
+    # build the same malformed-condition project two ways — a single-target build and
+    # the multi-target union — and require equal error counts. the union evaluates the
+    # condition under every target tuple but emits diagnostics only under the default
+    # one, so it must not multiply the condition error per target.
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "$if (5) { use uniontest.a; }\n\nfun main() i32 { ret 0; }\n";
+
+    var a1: Allocator;
+    if (is_some[str](page.make(?a1))) { ret 1; }
+    val sr1: Result[sess.Session, str] = sess.init(?a1);
+    if (is_err[sess.Session, str](sr1)) { ret 1; }
+    var s1: sess.Session = unwrap_ok[sess.Session, str](sr1);
+    val root1_r: Result[str, str] = ut_scaffold(?a1, ?names[0], ?texts[0], 1);
+    if (is_err[str, str](root1_r)) { sess.dnit(?s1); ret 1; }
+    val root1: str = unwrap_ok[str, str](root1_r);
+    val rr1: Result[bool, str] = tgt.register_all(?s1.registry, ?s1.interner);
+    if (is_err[bool, str](rr1)) { fs.remove_all(?a1, root1); sess.dnit(?s1); ret 1; }
+    var sel: manifest.Selection;
+    sel.target = ""; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false;
+    val p1r: Result[Project, str] = build_project_sel(?s1, root1, ?sel);
+    fs.remove_all(?a1, root1);
+    if (is_err[Project, str](p1r)) { sess.dnit(?s1); ret 1; }
+    var p1: Project = unwrap_ok[Project, str](p1r);
+    val single_errs: u32 = ut_count_errors(?s1.diags);
+
+    var a2: Allocator;
+    if (is_some[str](page.make(?a2))) { dnit_project(?p1); sess.dnit(?s1); ret 1; }
+    val sr2: Result[sess.Session, str] = sess.init(?a2);
+    if (is_err[sess.Session, str](sr2)) { dnit_project(?p1); sess.dnit(?s1); ret 1; }
+    var s2: sess.Session = unwrap_ok[sess.Session, str](sr2);
+    val p2r: Result[Project, str] = ut_build(?s2, ?a2, ?names[0], ?texts[0], 1);
+    if (is_err[Project, str](p2r)) { dnit_project(?p1); sess.dnit(?s1); sess.dnit(?s2); ret 1; }
+    var p2: Project = unwrap_ok[Project, str](p2r);
+    val union_errs: u32 = ut_count_errors(?s2.diags);
+
+    var bad: i32 = 0;
+    if (single_errs == 0)          { bad = 1; }
+    or (union_errs != single_errs) { bad = 1; }
+
+    dnit_project(?p1);
+    dnit_project(?p2);
+    sess.dnit(?s1);
+    sess.dnit(?s2);
+    ret bad;
 }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -285,36 +285,14 @@ fun cc5(alloc: *Allocator, a: str, b: str, c: str, d: str, e: str) str {
     ret cc(alloc, cc3(alloc, a, b, c), cc(alloc, d, e));
 }
 
-# os_id_for: map a target os name to its canonical id.
-fun os_id_for(name: str) u32 {
-    if (str_equals(name, "linux"))   { ret os.OS_LINUX; }
-    if (str_equals(name, "darwin"))  { ret os.OS_DARWIN; }
-    if (str_equals(name, "windows")) { ret os.OS_WINDOWS; }
-    ret os.OS_UNKNOWN;
-}
-
-# arch_id_for: map a target isa name to its canonical id.
-fun arch_id_for(name: str) u32 {
-    if (str_equals(name, "x86_64"))  { ret isa.ARCH_X86_64; }
-    if (str_equals(name, "aarch64")) { ret isa.ARCH_AARCH64; }
-    ret isa.ARCH_UNKNOWN;
-}
-
 # host_isa_name: the build host's isa name.
 fun host_isa_name() str {
-    val a: u32 = tgt.host_arch_id();
-    if (a == isa.ARCH_X86_64)  { ret "x86_64"; }
-    if (a == isa.ARCH_AARCH64) { ret "aarch64"; }
-    ret "unknown";
+    ret isa.arch_name_for(tgt.host_arch_id());
 }
 
 # host_os_name: the build host's os name.
 fun host_os_name() str {
-    val o: u32 = tgt.host_os_id();
-    if (o == os.OS_LINUX)   { ret "linux"; }
-    if (o == os.OS_DARWIN)  { ret "darwin"; }
-    if (o == os.OS_WINDOWS) { ret "windows"; }
-    ret "unknown";
+    ret os.os_name_for(tgt.host_os_id());
 }
 
 # host_tuple: the build host's `<isa>-<os>` tuple string, for the no-match
@@ -1272,7 +1250,7 @@ fun target_matches_host(i: *intern.Interner, d: *TargetDef, host_os: u32, host_a
     val os_o: Option[str] = intern.lookup(i, d.os);
     val isa_o: Option[str] = intern.lookup(i, d.isa);
     if (is_none[str](os_o) || is_none[str](isa_o)) { ret false; }
-    ret os_id_for(unwrap[str](os_o)) == host_os && arch_id_for(unwrap[str](isa_o)) == host_arch;
+    ret os.os_id_for(unwrap[str](os_o)) == host_os && isa.arch_id_for(unwrap[str](isa_o)) == host_arch;
 }
 
 # resolve_target: resolve a target selector to a declared target. an empty

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -29,7 +29,10 @@ use std.allocator.deallocate;
 
 use intern: mach.lang.intern;
 
-# byte order of a target's scalar storage.
+# byte order of a target's scalar storage. no ISA vtable carries an endianness
+# field: every supported ISA is little-endian and the object-format writers
+# hardcode it. these constants remain for the eventual big-endian abstraction (an
+# ISA field wired through the writers), to be added with the first big-endian target.
 # ---
 # ENDIAN_LITTLE: least-significant byte first
 # ENDIAN_BIG:    most-significant byte first
@@ -193,9 +196,9 @@ pub rec RegClass {
 pub def AsmClobbersFn: fun(str, *u32, *u32);
 
 # the ISA runtime-dispatch interface. exactly one of these exists per
-# architecture; the backend reads pointer width, endianness, register classes,
-# and the arch-specific operation entry points through it and never branches on
-# the numeric `id`.
+# architecture; the backend reads pointer width, register classes, and the
+# arch-specific operation entry points through it and never branches on the
+# numeric `id`.
 #
 # `select`, `encode`, and `emit_asm` are the target-specific backend operations.
 # they are stored type-erased (`*u8`) for the same reason the ABI vtable erases its
@@ -230,7 +233,6 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 # id:                 architecture id (one of ARCH_*)
 # name:               interned architecture name ("x86_64", "aarch64")
 # pointer_width:      pointer width in bytes
-# endianness:         ENDIAN_LITTLE or ENDIAN_BIG (see target.mach)
 # reg_classes:        array of register classes
 # reg_class_count:    number of register classes
 # select:             erased fn ptr — perform instruction selection for one
@@ -287,7 +289,6 @@ pub rec IsaVTable {
     id:                 u32;
     name:               str;
     pointer_width:      u32;
-    endianness:         u32;
     reg_classes:        *RegClass;
     reg_class_count:    u32;
     select:             *u8;

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -22,6 +22,7 @@ use std.types.bool.false;
 use std.types.size.usize;
 
 use std.types.string.str;
+use std.types.string.str_equals;
 
 use std.allocator.Allocator;
 use std.allocator.reallocate;
@@ -42,6 +43,20 @@ pub val ENDIAN_BIG:    u32 = 1;
 pub val ARCH_UNKNOWN: u32 = 0;
 pub val ARCH_X86_64:  u32 = 1;
 pub val ARCH_AARCH64: u32 = 2;
+
+# arch_id_for: map a target isa name to its canonical id (ARCH_UNKNOWN if unrecognized).
+pub fun arch_id_for(name: str) u32 {
+    if (str_equals(name, "x86_64"))  { ret ARCH_X86_64; }
+    if (str_equals(name, "aarch64")) { ret ARCH_AARCH64; }
+    ret ARCH_UNKNOWN;
+}
+
+# arch_name_for: the canonical name for an arch id ("unknown" if unrecognized).
+pub fun arch_name_for(id: u32) str {
+    if (id == ARCH_X86_64)  { ret "x86_64"; }
+    if (id == ARCH_AARCH64) { ret "aarch64"; }
+    ret "unknown";
+}
 
 # pseudo-opcodes shared by every ISA. they occupy the high end of the opcode
 # space so that no real machine opcode collides with them. the backend emits

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -97,7 +97,6 @@ pub fun register_arm64(reg: *isa.IsaRegistry, alloc: *Allocator, i: *intern.Inte
     arm64_vtable.id                 = isa.ARCH_AARCH64;
     arm64_vtable.name               = "aarch64";
     arm64_vtable.pointer_width      = 8;
-    arm64_vtable.endianness         = isa.ENDIAN_LITTLE;
     arm64_vtable.reg_classes        = ?arm64_reg_classes[0];
     arm64_vtable.reg_class_count    = 3;
     arm64_vtable.select             = nil;
@@ -111,7 +110,9 @@ pub fun register_arm64(reg: *isa.IsaRegistry, alloc: *Allocator, i: *intern.Inte
     arm64_vtable.reload_scratch_count = 0;
     arm64_vtable.scratch_reg        = ARM64_IP0;
     arm64_vtable.scratch_reg2       = ARM64_IP1;
-    arm64_vtable.fp_scratch_reg     = ARM64_V31;
+    # the vector scratch is a composite register id (class tag in the high byte),
+    # mirroring x86-64's FP_SCRATCH_REG — a raw bank index would read as a GP reg.
+    arm64_vtable.fp_scratch_reg     = isa.regid_make(isa.REG_CLASS_ID_XMM, ARM64_V31);
     arm64_vtable.frame_ptr_reg      = ARM64_FP;
     arm64_vtable.stack_ptr_reg      = ARM64_SP;
     # the AAPCS64 frame record stores the saved FP at [fp+0] and the saved LR at

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -118,7 +118,6 @@ pub fun register_x64(reg: *isa.IsaRegistry, alloc: *Allocator, interner: *intern
     x64_vtable.id                 = isa.ARCH_X86_64;
     x64_vtable.name               = "x86_64";
     x64_vtable.pointer_width      = 8;
-    x64_vtable.endianness         = isa.ENDIAN_LITTLE;
     x64_vtable.reg_classes        = ?x64_classes[0];
     x64_vtable.reg_class_count    = 3;
     x64_vtable.select             = x64isel.select::*u8;

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -279,7 +279,8 @@ pub rec ExecFunction {
 # a format writer: serializes an `ObjectImage` to a relocatable object file at
 # the given path. takes the `IsaVTable` (not the full Target) to break the
 # target↔object-format import cycle; the writer uses only what the ISA exposes
-# (machine type, endianness, pointer width). it resolves the image's interned
+# (machine type, pointer width) and hardcodes little-endian (every supported ISA
+# is LE). it resolves the image's interned
 # names through `image.interner`, which the back end set when it built the image —
 # no module-global interner is captured.
 # ---
@@ -309,7 +310,8 @@ pub def ParserFn: fun(*Allocator, *intern.Interner, *u8, usize, *ObjectImage) Re
 # a static-executable writer: serializes the linker's laid-out load segments
 # into a static executable at the given path. like `WriterFn` it takes the
 # `IsaVTable` (not the full Target) to break the target↔object-format import
-# cycle; the writer uses only the ISA's machine type and endianness. the linker
+# cycle; the writer uses only the ISA's machine type and pointer width, and
+# hardcodes little-endian. the linker
 # has already assigned every segment's virtual address and resolved the entry
 # point, so the writer only frames the segments in the format's container (ELF
 # program headers, Mach-O load commands) with a leading header-covering segment.

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1281,6 +1281,13 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
         out.relocations = unwrap_ok[*of.Relocation, str](rrel);
     }
 
+    # the alloc sizes equal the final logical counts, so set the counts now (before
+    # any further fallible step) — a later error return then lets `dnit` reclaim the
+    # full arrays instead of leaking them. the populate loops below use local cursors.
+    out.section_count = num_secs;
+    out.symbol_count  = sym_n;
+    out.reloc_count   = rel_n;
+
     # map a COFF symbol-table record index -> ObjectImage symbol index, so a
     # relocation's SymbolTableIndex resolves to the interned symbol name.
     val res_map: Result[*i32, str] = zallocate[i32](alloc, (num_records + 1)::usize);
@@ -1335,9 +1342,9 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
         }
         s = s + 1;
     }
-    out.section_count = num_secs;
 
     # symbols: walk records, skipping aux records, recording each definition.
+    var sym_i: u32 = 0;
     ri = 0;
     for (ri < num_records) {
         rec_map[ri] = -1;
@@ -1355,7 +1362,7 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
             ret err[bool, str](unwrap_err[intern.StrId, str](rin));
         }
 
-        val idx: u32 = out.symbol_count;
+        val idx: u32 = sym_i;
         rec_map[ri] = idx::i32;
         out.symbols[idx].name = unwrap_ok[intern.StrId, str](rin);
         out.symbols[idx].offset = bin.read_u32_le(buf, so + 8);
@@ -1400,7 +1407,7 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
             }
         }
         out.symbols[idx].flags = flags;
-        out.symbol_count = out.symbol_count + 1;
+        sym_i = sym_i + 1;
 
         # an aux record carries no own image symbol; map it to its owner so a
         # stray SymbolTableIndex pointing at an aux record still resolves.
@@ -1413,6 +1420,7 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
     }
 
     # relocations: each section header points at its IMAGE_RELOCATION array.
+    var rel_i: u32 = 0;
     s = 0;
     for (s < num_secs) {
         val sh: usize = secthdr_base + s::usize * SECTION_HEADER_SIZE;
@@ -1427,7 +1435,7 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
         var k: u32 = 0;
         for (k < rcount) {
             val ro: usize = rptr + k::usize * RELOCATION_SIZE;
-            val idx: u32 = out.reloc_count;
+            val idx: u32 = rel_i;
             val r_type: u16 = bin.read_u16_le(buf, ro + 8);
             val r_off:  u32 = bin.read_u32_le(buf, ro);
             out.relocations[idx].section = s;
@@ -1451,7 +1459,7 @@ fun coff_parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_si
             } or {
                 out.relocations[idx].symbol = intern.STR_NIL;
             }
-            out.reloc_count = out.reloc_count + 1;
+            rel_i = rel_i + 1;
             k = k + 1;
         }
         s = s + 1;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -214,10 +214,16 @@ fun validate_reloc_kinds(img: *of.ObjectImage) Result[bool, str] {
 }
 
 # read_inplace_addend: recover a COFF relocation's in-place addend from the
-# patched field of section `sec`. COFF has no RELA addend field — the addend is
-# the existing value at the field, which the linker adds to the resolved target.
-# an ADDR64 field is a full 64-bit value; every other type is a 32-bit field
-# sign-extended to i64. a bss/no-data section or an out-of-range offset yields 0.
+# patched field of section `sec`, in the abstract (ELF field-relative) convention
+# the RK_* kinds use. COFF has no RELA addend field — the addend is the existing
+# value at the field, which the linker adds to the resolved target. an ADDR64
+# field is a full 64-bit value; every other type is a 32-bit field sign-extended
+# to i64. a bss/no-data section or an out-of-range offset yields 0.
+#
+# REL32 is next-byte-relative: link.exe/lld resolve `S + A_coff - (P+4)`, four
+# bytes more than the abstract `S + A_elf - P`. so the recovered abstract addend
+# is `A_elf = A_coff - 4` — subtract 4 from the field for REL32 only. ADDR64
+# (absolute) and ADDR32NB (image-relative) carry no P+4 term and are unchanged.
 fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
     if (sec.bytes == nil) { ret 0; }
     if (r_type == IMAGE_REL_AMD64_ADDR64) {
@@ -225,7 +231,9 @@ fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
         ret bin.read_u64_le(sec.bytes, offset::usize)::i64;
     }
     if (offset::usize + 4 > sec.len::usize) { ret 0; }
-    ret (bin.read_u32_le(sec.bytes, offset::usize)::i32)::i64;
+    val field: i64 = (bin.read_u32_le(sec.bytes, offset::usize)::i32)::i64;
+    if (r_type == IMAGE_REL_AMD64_REL32) { ret field - 4; }
+    ret field;
 }
 
 # map a COFF x86-64 machine relocation type back to its abstract RK_* kind. an
@@ -984,18 +992,26 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     # fold each relocation's addend into its patch-site field. unlike ELF RELA,
     # a COFF IMAGE_RELOCATION carries no addend field — the addend is the in-place
     # value the linker adds to the resolved target, so it must live in the section
-    # bytes. (a `call sym` carries addend -4 for the pc32 field-to-next-ip
-    # correction; without folding it the call would land 4 bytes past its target.)
-    # `validate_reloc_ranges` already proved every field lies within its section.
+    # bytes. the abstract addend is in the ELF field-relative convention; a REL32
+    # field is next-byte-relative (link.exe/lld resolve `S + A_coff - (P+4)`), so
+    # the on-wire field must hold `A_coff = A_elf + 4`. fold that effective value:
+    # a `call sym` (RK_PC32/RK_PLT32, abstract addend -4) then writes 0, the
+    # correct COFF convention. ADDR64/ADDR32NB carry no P+4 term and fold the
+    # addend unchanged. `validate_reloc_ranges` already proved every field is in
+    # range; `read_inplace_addend` recovers `A_elf` on parse, so the round-trip
+    # is identity.
     var ridx: u32 = 0;
     for (ridx < img.reloc_count) {
         val rsec: u32 = img.relocations[ridx].section;
-        if (img.relocations[ridx].addend != 0) {
+        val rk: of.RelocKind = img.relocations[ridx].kind;
+        var eff: i64 = img.relocations[ridx].addend;
+        if (rk == of.RK_PC32 || rk == of.RK_PLT32) { eff = eff + 4; }
+        if (eff != 0) {
             val fld: usize = data_offsets[rsec] + img.relocations[ridx].offset::usize;
-            if (reloc_field_width(img.relocations[ridx].kind) == 8) {
-                bin.write_u64_le(buf, fld, bin.read_u64_le(buf, fld) + img.relocations[ridx].addend::u64);
+            if (reloc_field_width(rk) == 8) {
+                bin.write_u64_le(buf, fld, bin.read_u64_le(buf, fld) + eff::u64);
             } or {
-                bin.write_u32_le(buf, fld, bin.read_u32_le(buf, fld) + (img.relocations[ridx].addend::u64)::u32);
+                bin.write_u32_le(buf, fld, bin.read_u32_le(buf, fld) + (eff::u64)::u32);
             }
         }
         ridx = ridx + 1;
@@ -2743,9 +2759,12 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
     syms[2].offset = 0; syms[2].size = 0; syms[2].flags = of.SYM_OBJ_FLAG_EXTERN;
 
 
+    # the pc32 carries the -4 a `call` does (the abstract field-relative addend);
+    # the REL32 fold writes A_coff = A_elf + 4 = 0, leaving the .text field at its
+    # placeholder so the byte round-trip below holds.
     var relocs: [2]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = syms[2].name; relocs[0].addend = 0;
+    relocs[0].symbol = syms[2].name; relocs[0].addend = -4;
     relocs[1].section = 0; relocs[1].offset = 4; relocs[1].kind = of.RK_ABS64;
     relocs[1].symbol = syms[1].name; relocs[1].addend = 0;
 
@@ -2851,6 +2870,110 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
     ret 0;
 }
 
+test "coff: REL32 addend translates the COFF P+4 convention at parse and emit (#1409)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    # read side: a REL32 field is next-byte-relative, so the recovered abstract
+    # (ELF field-relative) addend is `field - 4`. ADDR32NB (image-relative) and
+    # ADDR64 (absolute) carry no P+4 term and read through unchanged.
+    var f0: [4]u8;
+    f0[0] = 0; f0[1] = 0; f0[2] = 0; f0[3] = 0;
+    var sec0: of.Section;
+    sec0.bytes = ?f0[0]; sec0.len = 4;
+    if (read_inplace_addend(?sec0, IMAGE_REL_AMD64_REL32, 0) != -4) { ret 1; }
+    if (read_inplace_addend(?sec0, IMAGE_REL_AMD64_ADDR32NB, 0) != 0) { ret 1; }
+
+    var f7: [4]u8;
+    f7[0] = 7; f7[1] = 0; f7[2] = 0; f7[3] = 0;
+    var sec7: of.Section;
+    sec7.bytes = ?f7[0]; sec7.len = 4;
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_REL32, 0) != 3) { ret 1; }
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_ADDR32NB, 0) != 7) { ret 1; }
+
+    # an 8-byte ADDR64 field reads the full 64-bit value, unchanged.
+    var f8: [8]u8;
+    var b: usize = 0;
+    for (b < 8) { f8[b] = 0; b = b + 1; }
+    f8[0] = 0x21; f8[1] = 0x43;
+    var sec8: of.Section;
+    sec8.bytes = ?f8[0]; sec8.len = 8;
+    if (read_inplace_addend(?sec8, IMAGE_REL_AMD64_ADDR64, 0) != 0x4321) { ret 1; }
+
+    # round-trip through the full emit/parse path: a REL32 reloc with abstract
+    # addend 0 folds A_coff = A_elf + 4 = 4 into the on-wire field, and the reader
+    # recovers A_elf = 4 - 4 = 0. a `call`'s -4 addend folds to 0 the same way.
+    var i: intern.Interner = intern.init(?alloc);
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    var text_bytes: [8]u8;
+    var k: usize = 0;
+    for (k < 8) { text_bytes[k] = 0; k = k + 1; }
+    text_bytes[0] = 0xE8;  # call rel32, the 4-byte field at offset 1 is zero
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 8; secs[0].align = 16;
+
+    var syms: [2]of.Symbol;
+    syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 8; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    syms[1].name = t_intern(?i, "callee"); syms[1].section = of.SECTION_EXTERNAL;
+    syms[1].offset = 0; syms[1].size = 0;
+    syms[1].flags =
+        of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_FUNCTION;
+
+    var relocs: [1]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
+    relocs[0].symbol = syms[1].name; relocs[0].addend = 0;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.interner = ?i;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 2;
+    img.relocations = ?relocs[0]; img.reloc_count = 1;
+
+    val tf_r: Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_p4");
+    if (is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
+
+    val em: Result[bool, str] = coff_emit_object(?isa_vt, ?img, fs.temp_path(?tf)::*u8);
+    if (is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: Result[fs.Buffer, str] = fs.read_all_sized(?alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (is_err[fs.Buffer, str](rb)) { ret 1; }
+    val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
+
+    var out: of.ObjectImage;
+    val pr: Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+    if (is_err[bool, str](pr)) { ret 1; }
+
+    var saw: bool = false;
+    var rj: u32 = 0;
+    for (rj < out.reloc_count) {
+        if (out.relocations[rj].kind == of.RK_PC32 && out.relocations[rj].offset == 1) {
+            saw = true;
+            # the on-wire field carries the folded COFF addend (A_elf 0 + 4).
+            if (out.sections[0].bytes == nil) { ret 1; }
+            if (bin.read_u32_le(out.sections[0].bytes, 1) != 4) { ret 1; }
+            # the reader recovers the abstract addend (4 - 4 = 0).
+            if (out.relocations[rj].addend != 0) { ret 1; }
+        }
+        rj = rj + 1;
+    }
+    if (!saw) { ret 1; }
+
+    ret 0;
+}
+
 test "coff: emit rejects a relocation naming an unresolved symbol (#1196)" {
     var alloc: Allocator;
     page.make(?alloc);
@@ -2926,9 +3049,9 @@ test "coff: a defined weak symbol round-trips its weak flag through a COMDAT sec
 
     # a .text holding two functions: a strong global `main` in [0,8) and a weak
     # monomorphized instance `okI3u64P2u8E` in [8,16), the kind emitted into every
-    # using object. a relocation patches a field inside the weak body (offset 12),
-    # so the COMDAT carve must move it with the symbol and the round-trip recover
-    # it. an undefined extern `puts` is the relocation's target.
+    # using object. a call relocation patches a field inside the weak body (offset
+    # 12), so the COMDAT carve must move it with the symbol and the round-trip
+    # recover it. an undefined extern `puts` is the relocation's target.
     var text_bytes: [16]u8;
     var k: usize = 0;
     for (k < 16) { text_bytes[k] = (0x10 + k)::u8; k = k + 1; }
@@ -2947,9 +3070,11 @@ test "coff: a defined weak symbol round-trips its weak flag through a COMDAT sec
     syms[2].offset = 0; syms[2].size = 0; syms[2].flags = of.SYM_OBJ_FLAG_EXTERN;
 
 
+    # the -4 a `call` carries: the REL32 fold writes A_coff = A_elf + 4 = 0, so the
+    # weak body bytes are unchanged and the carve's byte round-trip holds.
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 12; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = syms[2].name; relocs[0].addend = 0;
+    relocs[0].symbol = syms[2].name; relocs[0].addend = -4;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -363,20 +363,41 @@ fun write_decimal(buf: *u8, off: usize, width: usize, value: u32) {
     }
 }
 
-# resolve a relocation's target symbol to its index in the image symbol table.
-# every relocation must name a symbol the image defines or declares extern (the
-# back end guarantees this — `pack_reloc_externs` declares an extern for any
-# named target the module did not define, and lowering panics before emitting a
-# nameless target). a miss is therefore a back-end invariant violation, returned
-# as an error naming the symbol rather than silently aliased to index 0 (the
-# first section symbol), which would corrupt the link.
-fun reloc_sym_index(img: *of.ObjectImage, sym: intern.StrId) Result[u32, str] {
-    if (sym != intern.STR_NIL) {
-        var i: u32 = 0;
-        for (i < img.symbol_count) {
-            if (img.symbols[i].name == sym) { ret ok[u32, str](i); }
-            i = i + 1;
+# build a name->index map over the image symbol table so the relocation passes
+# resolve targets in O(reloc + symbol) rather than O(reloc x symbol). the first
+# symbol of a given name wins, matching the lowest-index scan a linear lookup
+# would return; a STR_NIL-named symbol is skipped so a STR_NIL relocation target
+# stays unresolved. the caller owns the returned map and must `map.dnit` it.
+fun build_reloc_sym_map(img: *of.ObjectImage) Result[map.Map[intern.StrId, u32], str] {
+    var idx: map.Map[intern.StrId, u32] =
+        map.init[intern.StrId, u32](img.alloc, map.hash_u32, map.eq_u32);
+    var i: u32 = 0;
+    for (i < img.symbol_count) {
+        if (img.symbols[i].name != intern.STR_NIL
+            && !map.contains[intern.StrId, u32](?idx, ?img.symbols[i].name)) {
+            val ins: Result[bool, str] =
+                map.insert[intern.StrId, u32](?idx, img.symbols[i].name, i);
+            if (is_err[bool, str](ins)) {
+                map.dnit[intern.StrId, u32](?idx);
+                ret err[map.Map[intern.StrId, u32], str](unwrap_err[bool, str](ins));
+            }
         }
+        i = i + 1;
+    }
+    ret ok[map.Map[intern.StrId, u32], str](idx);
+}
+
+# resolve a relocation's target symbol to its index in the image symbol table via
+# a prebuilt name->index map. every relocation must name a symbol the image
+# defines or declares extern (the back end guarantees this — `pack_reloc_externs`
+# declares an extern for any named target the module did not define, and lowering
+# panics before emitting a nameless target). a miss is therefore a back-end
+# invariant violation, returned as an error naming the symbol rather than silently
+# aliased to index 0 (the first section symbol), which would corrupt the link.
+fun reloc_sym_index(img: *of.ObjectImage, idx: *map.Map[intern.StrId, u32], sym: intern.StrId) Result[u32, str] {
+    if (sym != intern.STR_NIL) {
+        val g: Result[*u32, str] = map.get[intern.StrId, u32](idx, ?sym);
+        if (!is_err[*u32, str](g)) { ret ok[u32, str](@unwrap_ok[*u32, str](g)); }
     }
     ret err[u32, str](unresolved_reloc_message(img.interner, img.alloc, sym));
 }
@@ -414,12 +435,21 @@ fun unresolved_reloc_message(itn: *intern.Interner, alloc: *Allocator, sym: inte
 # unresolved target fails the emit naming the symbol instead of silently writing
 # a relocation against the first section symbol.
 fun validate_reloc_symbols(img: *of.ObjectImage) Result[bool, str] {
+    val mr: Result[map.Map[intern.StrId, u32], str] = build_reloc_sym_map(img);
+    if (is_err[map.Map[intern.StrId, u32], str](mr)) {
+        ret err[bool, str](unwrap_err[map.Map[intern.StrId, u32], str](mr));
+    }
+    var idx: map.Map[intern.StrId, u32] = unwrap_ok[map.Map[intern.StrId, u32], str](mr);
     var i: u32 = 0;
     for (i < img.reloc_count) {
-        val r: Result[u32, str] = reloc_sym_index(img, img.relocations[i].symbol);
-        if (is_err[u32, str](r)) { ret err[bool, str](unwrap_err[u32, str](r)); }
+        val r: Result[u32, str] = reloc_sym_index(img, ?idx, img.relocations[i].symbol);
+        if (is_err[u32, str](r)) {
+            map.dnit[intern.StrId, u32](?idx);
+            ret err[bool, str](unwrap_err[u32, str](r));
+        }
         i = i + 1;
     }
+    map.dnit[intern.StrId, u32](?idx);
     ret ok[bool, str](true);
 }
 
@@ -1021,7 +1051,19 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
     # relocation lands in its owning section's slot, advancing that section's reloc
     # cursor. `reloc_offsets` is no longer read after the section-header pass, so it
     # doubles as the per-section write cursor (each starts at the section's reloc
-    # base from the layout pass and ends one past its last record).
+    # base from the layout pass and ends one past its last record). a name->index
+    # map resolves each target in O(1), keeping the pass O(reloc + symbol).
+    val smr: Result[map.Map[intern.StrId, u32], str] = build_reloc_sym_map(img);
+    if (is_err[map.Map[intern.StrId, u32], str](smr)) {
+        deallocate[u32](alloc, counts, num_secs::usize);
+        deallocate[usize](alloc, data_offsets, (num_secs + 1)::usize);
+        deallocate[usize](alloc, reloc_offsets, (num_secs + 1)::usize);
+        deallocate[u32](alloc, sec_name_offsets, (num_secs + 1)::usize);
+        if (sym_remap != nil) { deallocate[u32](alloc, sym_remap, num_syms::usize); }
+        deallocate[u8](alloc, buf, total_file_size);
+        ret err[bool, str](unwrap_err[map.Map[intern.StrId, u32], str](smr));
+    }
+    var sym_map: map.Map[intern.StrId, u32] = unwrap_ok[map.Map[intern.StrId, u32], str](smr);
     var ri: u32 = 0;
     for (ri < img.reloc_count) {
         val rsec: u32 = img.relocations[ri].section;
@@ -1030,7 +1072,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
         # validate_reloc_symbols proved every reloc resolves, and a relocated
         # section implies symbols, so sym_remap is non-nil and the lookup cannot
         # miss; the first section symbol is never silently aliased.
-        val rsi: u32 = unwrap_ok[u32, str](reloc_sym_index(img, img.relocations[ri].symbol));
+        val rsi: u32 = unwrap_ok[u32, str](reloc_sym_index(img, ?sym_map, img.relocations[ri].symbol));
         bin.write_u32_le(buf, ro + 4, sym_remap[rsi]);
         # validate_reloc_kinds proved every kind maps, so this lookup cannot miss;
         # ADDR64 is never silently substituted.
@@ -1038,6 +1080,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) Result[
         reloc_offsets[rsec] = ro + RELOCATION_SIZE;
         ri = ri + 1;
     }
+    map.dnit[intern.StrId, u32](?sym_map);
 
     # symbol table: a section symbol (+ aux record) per section, then the image
     # symbols. the section symbol is class STATIC, value 0, 1-based section

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1728,6 +1728,11 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         sh = sh + 1;
     }
     val sym_n: u32 = symtab_count;
+    # the ObjectImage symbol array holds only the real symbols: ELF reserves symtab
+    # index 0 (the undefined-symbol sentinel), which the symbol loop skips, so the
+    # populated count is one less than the table length.
+    var sym_pop: u32 = 0;
+    if (sym_n > 0) { sym_pop = sym_n - 1; }
 
     out.alloc = alloc;
     out.section_count = 0;
@@ -1742,8 +1747,8 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         if (is_err[*of.Section, str](rsec)) { ret err[bool, str]("elf: section array alloc failed"); }
         out.sections = unwrap_ok[*of.Section, str](rsec);
     }
-    if (sym_n > 0) {
-        val rsym: Result[*of.Symbol, str] = zallocate[of.Symbol](alloc, sym_n::usize);
+    if (sym_pop > 0) {
+        val rsym: Result[*of.Symbol, str] = zallocate[of.Symbol](alloc, sym_pop::usize);
         if (is_err[*of.Symbol, str](rsym)) { ret err[bool, str]("elf: symbol array alloc failed"); }
         out.symbols = unwrap_ok[*of.Symbol, str](rsym);
     }
@@ -1753,13 +1758,14 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         out.relocations = unwrap_ok[*of.Relocation, str](rrel);
     }
 
-    # set the counts to the alloc sizes now (before any further fallible step) so a
-    # later error return lets `dnit` reclaim the full arrays instead of leaking them.
-    # the populate loops below use local cursors; the populated symbol count (which
-    # the reloc loop bounds against, and which is `sym_n - 1` because the reserved
-    # index-0 symtab entry is skipped) is tracked separately in `sym_i`.
+    # set the counts to the populated sizes now (before any further fallible step) so
+    # a later error return lets `dnit` reclaim the full arrays instead of leaking them.
+    # the populate loops below use local cursors. for symbols the count is `sym_pop`
+    # (= sym_n - 1; the reserved index-0 entry is skipped), so the allocation, the
+    # count, and the entries written all agree — no trailing sentinel slot. the reloc
+    # loop still bounds symbol resolution by the live cursor `sym_i`.
     out.section_count = sec_n;
-    out.symbol_count  = sym_n;
+    out.symbol_count  = sym_pop;
     out.reloc_count   = rel_n;
 
     # map ELF section header index -> ObjectImage section index.
@@ -1826,9 +1832,9 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         sh = sh + 1;
     }
 
-    # symbols (skip the reserved index-0 entry). `sym_i` is the populated count
-    # (`out.symbol_count` is preset to the alloc size `sym_n`), reused below to
-    # bound relocation symbol resolution.
+    # symbols (skip the reserved index-0 entry). `sym_i` is the live populated count
+    # (it ends equal to `out.symbol_count`/`sym_pop`), reused below to bound
+    # relocation symbol resolution.
     var sym_i: u32 = 0;
     if (symtab != nil && have_strtab) {
         var si: u32 = 1;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1753,11 +1753,21 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
         out.relocations = unwrap_ok[*of.Relocation, str](rrel);
     }
 
+    # set the counts to the alloc sizes now (before any further fallible step) so a
+    # later error return lets `dnit` reclaim the full arrays instead of leaking them.
+    # the populate loops below use local cursors; the populated symbol count (which
+    # the reloc loop bounds against, and which is `sym_n - 1` because the reserved
+    # index-0 symtab entry is skipped) is tracked separately in `sym_i`.
+    out.section_count = sec_n;
+    out.symbol_count  = sym_n;
+    out.reloc_count   = rel_n;
+
     # map ELF section header index -> ObjectImage section index.
     val res_map: Result[*i32, str] = zallocate[i32](alloc, e_shnum::usize);
     if (is_err[*i32, str](res_map)) { ret err[bool, str]("elf: section map alloc failed"); }
     var sec_map: *i32 = unwrap_ok[*i32, str](res_map);
 
+    var sec_i: u32 = 0;
     sh = 0;
     for (sh < e_shnum) {
         sec_map[sh] = -1;
@@ -1786,7 +1796,7 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 ret err[bool, str](unwrap_err[intern.StrId, str](rin));
             }
 
-            val idx: u32 = out.section_count;
+            val idx: u32 = sec_i;
             out.sections[idx].name  = unwrap_ok[intern.StrId, str](rin);
             out.sections[idx].kind  = kind;
             out.sections[idx].align = bin.read_u64_le(buf, so + 48)::u32;
@@ -1811,12 +1821,15 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 mem.raw_copy(out.sections[idx].bytes::ptr, src::ptr, sz);
             }
             sec_map[sh] = idx::i32;
-            out.section_count = out.section_count + 1;
+            sec_i = sec_i + 1;
         }
         sh = sh + 1;
     }
 
-    # symbols (skip the reserved index-0 entry).
+    # symbols (skip the reserved index-0 entry). `sym_i` is the populated count
+    # (`out.symbol_count` is preset to the alloc size `sym_n`), reused below to
+    # bound relocation symbol resolution.
+    var sym_i: u32 = 0;
     if (symtab != nil && have_strtab) {
         var si: u32 = 1;
         for (si < sym_n) {
@@ -1838,7 +1851,7 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 ret err[bool, str](unwrap_err[intern.StrId, str](rin));
             }
 
-            val idx: u32 = out.symbol_count;
+            val idx: u32 = sym_i;
             out.symbols[idx].name = unwrap_ok[intern.StrId, str](rin);
             out.symbols[idx].offset = st_value::u32;
             out.symbols[idx].size = st_size::u32;
@@ -1859,12 +1872,13 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 out.symbols[idx].section = of.SECTION_EXTERNAL;
             }
             out.symbols[idx].flags = flags;
-            out.symbol_count = out.symbol_count + 1;
+            sym_i = sym_i + 1;
             si = si + 1;
         }
     }
 
     # relocations: pair each RELA section with the section it patches (sh_info).
+    var rel_i: u32 = 0;
     sh = 0;
     for (sh < e_shnum) {
         val so: usize = e_shoff + sh::usize * e_shentsize::usize;
@@ -1889,7 +1903,7 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 val r_type: u32 = (r_info & 0xFFFFFFFF)::u32;
                 val r_sym:  u32 = (r_info >> 32)::u32;
 
-                val idx: u32 = out.reloc_count;
+                val idx: u32 = rel_i;
                 if (target_sec >= 0) { out.relocations[idx].section = target_sec::u32; }
                 or { out.relocations[idx].section = of.SECTION_EXTERNAL; }
                 out.relocations[idx].offset = bin.read_u64_le(buf, ro)::u32;
@@ -1902,12 +1916,12 @@ pub fun parse_object(alloc: *Allocator, itn: *intern.Interner, buf: *u8, buf_siz
                 out.relocations[idx].kind = unwrap_ok[of.RelocKind, str](rk);
                 # r_sym indexes the on-disk symtab (1-based, index 0 reserved),
                 # so the ObjectImage symbol is r_sym - 1.
-                if (r_sym > 0 && (r_sym - 1) < out.symbol_count) {
+                if (r_sym > 0 && (r_sym - 1) < sym_i) {
                     out.relocations[idx].symbol = out.symbols[r_sym - 1].name;
                 } or {
                     out.relocations[idx].symbol = intern.STR_NIL;
                 }
-                out.reloc_count = out.reloc_count + 1;
+                rel_i = rel_i + 1;
                 ri = ri + 1;
             }
         }

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -33,16 +33,18 @@ pub val OS_FREESTANDING: u32 = 4;
 # executable load parameters through it and never branch on the numeric `id`.
 # ---
 # id:              operating-system id (one of OS_*)
-# name:            interned os name ("linux", "darwin", "windows")
-# entry_symbol:    interned program entry-point symbol ("_start", "_main", ...)
-# syscall_layer:   interned syscall-layer name selecting the runtime backend
-# libdir:          interned default system library directory
-# dynamic_linker:  interned run-time dynamic-loader path the linker writes into a
+# name:            os name ("linux", "darwin", "windows")
+# entry_symbol:    program entry-point symbol ("_start", "_main", ...); the linker
+#                  interns it where it keys the symbol table
+# syscall_layer:   syscall-layer name selecting the runtime backend
+# libdir:          default system library directory
+# dynamic_linker:  run-time dynamic-loader path the linker writes into a
 #                  dynamically-linked image's interpreter record (the ELF
-#                  PT_INTERP), or intern.STR_NIL when no fixed interpreter-path
-#                  record applies — PE and Mach-O still support dynamic linking,
-#                  but load imports through their own mechanisms (the import
-#                  directory, LC_LOAD_DYLINKER) rather than a PT_INTERP path
+#                  PT_INTERP), interned by the linker at that point; empty ("")
+#                  when no fixed interpreter-path record applies — PE and Mach-O
+#                  still support dynamic linking, but load imports through their
+#                  own mechanisms (the import directory, LC_LOAD_DYLINKER) rather
+#                  than a PT_INTERP path
 # base_addr:       base virtual address the first loadable segment maps at; the
 #                  linker assigns section vaddrs upward from it
 # page_size:       virtual-memory page size in bytes the linker page-aligns

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -56,10 +56,10 @@ pub val OS_FREESTANDING: u32 = 4;
 pub rec OsVTable {
     id:             u32;
     name:           str;
-    entry_symbol:   intern.StrId;
-    syscall_layer:  intern.StrId;
-    libdir:         intern.StrId;
-    dynamic_linker: intern.StrId;
+    entry_symbol:   str;
+    syscall_layer:  str;
+    libdir:         str;
+    dynamic_linker: str;
     base_addr:      u64;
     page_size:      u64;
     stack_probe:    bool;

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -14,6 +14,7 @@ use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.string.str;
+use std.types.string.str_equals;
 
 use intern: mach.lang.intern;
 
@@ -27,6 +28,22 @@ pub val OS_LINUX:        u32 = 1;
 pub val OS_DARWIN:       u32 = 2;
 pub val OS_WINDOWS:      u32 = 3;
 pub val OS_FREESTANDING: u32 = 4;
+
+# os_id_for: map a target os name to its canonical id (OS_UNKNOWN if unrecognized).
+pub fun os_id_for(name: str) u32 {
+    if (str_equals(name, "linux"))   { ret OS_LINUX; }
+    if (str_equals(name, "darwin"))  { ret OS_DARWIN; }
+    if (str_equals(name, "windows")) { ret OS_WINDOWS; }
+    ret OS_UNKNOWN;
+}
+
+# os_name_for: the canonical name for an os id ("unknown" if unrecognized).
+pub fun os_name_for(id: u32) str {
+    if (id == OS_LINUX)   { ret "linux"; }
+    if (id == OS_DARWIN)  { ret "darwin"; }
+    if (id == OS_WINDOWS) { ret "windows"; }
+    ret "unknown";
+}
 
 # the operating-system runtime-dispatch interface. exactly one of these exists
 # per OS; the driver and linker read the entry symbol, library directory, and

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -50,23 +50,14 @@ var darwin_vtable: os.OsVTable;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_darwin(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
-    val re: Result[intern.StrId, str] = intern.intern(i, "_main");
-    if (is_err[intern.StrId, str](re)) { ret err[bool, str](unwrap_err[intern.StrId, str](re)); }
-
-    val rs: Result[intern.StrId, str] = intern.intern(i, "darwin");
-    if (is_err[intern.StrId, str](rs)) { ret err[bool, str](unwrap_err[intern.StrId, str](rs)); }
-
-    val rl: Result[intern.StrId, str] = intern.intern(i, "/usr/lib");
-    if (is_err[intern.StrId, str](rl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rl)); }
-
     darwin_vtable.id             = os.OS_DARWIN;
     darwin_vtable.name           = "darwin";
-    darwin_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
-    darwin_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
-    darwin_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);
+    darwin_vtable.entry_symbol   = "_main";
+    darwin_vtable.syscall_layer  = "darwin";
+    darwin_vtable.libdir         = "/usr/lib";
     # Mach-O loads imports through LC_LOAD_DYLINKER + dyld bind, not a PT_INTERP
     # path, so no interpreter-path record applies; the writer is deferred (#1176).
-    darwin_vtable.dynamic_linker = intern.STR_NIL;
+    darwin_vtable.dynamic_linker = "";
     darwin_vtable.base_addr      = DARWIN_BASE_ADDR;
     darwin_vtable.page_size      = DARWIN_PAGE_SIZE;
     # Darwin commits the thread stack up front and auto-grows the main thread; no

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -5,8 +5,8 @@
 # compose a Darwin target descriptor. Darwin code generation is not yet
 # supported: the unsupported surface lives in the Mach-O object-format
 # operations, which return a clear "unsupported object format" error. This
-# vtable carries data only and registers honestly; `register` interns the os
-# strings and is idempotent.
+# vtable carries data only and registers honestly; `register` sets the vtable's
+# str fields directly (no interning) and is idempotent.
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -38,16 +38,16 @@ var darwin_vtable: os.OsVTable;
 
 # register_darwin: build and install the Darwin OsVTable.
 #
-# interns the os name, entry symbol ("_main"), syscall layer, and default
-# library directory, fills the module-level vtable, and installs it into `reg`
-# under os.OS_DARWIN. re-interns the strings into `i` on every call (the registry
-# entry is write-once) so a later build with a fresh interner gets consistent
-# ids. must be invoked at startup before target.select requests a Darwin target.
+# sets the os name, entry symbol ("_main"), syscall layer, and default library
+# directory as plain str constants, fills the module-level vtable, and installs it
+# into `reg` under os.OS_DARWIN. the vtable strings are no longer interned here —
+# the linker interns the ones it needs at the point of use (#1402). must be invoked
+# at startup before target.select requests a Darwin target.
 # ---
 # reg:   the OS registry to install the vtable into
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields
-# ret:   true on success, or an error string if name interning fails
+# alloc: backing allocator (unused; retained for registrar-signature parity)
+# i:     interner (unused; retained for registrar-signature parity)
+# ret:   true (always; the Result return is kept for registrar-signature parity)
 pub fun register_darwin(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
     darwin_vtable.id             = os.OS_DARWIN;

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -47,18 +47,17 @@ var linux_vtable: os.OsVTable;
 
 # register_linux: build and install the Linux OsVTable.
 #
-# interns the os name, entry symbol ("_start"), syscall layer, and default
-# library directory, fills the module-level vtable (including the 0x400000 base
-# address and 4096-byte page), and installs it into `reg` under os.OS_LINUX.
-# re-interns the strings into `i` on every call (the registry entry is
-# write-once) so a later build with a fresh interner gets consistent ids rather
-# than ones left over from the first. must be invoked at startup before
+# sets the os name, entry symbol ("_start"), syscall layer, and default library
+# directory as plain str constants, fills the module-level vtable (including the
+# 0x400000 base address and 4096-byte page), and installs it into `reg` under
+# os.OS_LINUX. the vtable strings are no longer interned here — the linker interns
+# the ones it needs at the point of use (#1402). must be invoked at startup before
 # target.select requests a Linux target.
 # ---
 # reg:   the OS registry to install the vtable into
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields
-# ret:   true on success, or an error string if name interning fails
+# alloc: backing allocator (unused; retained for registrar-signature parity)
+# i:     interner (unused; retained for registrar-signature parity)
+# ret:   true (always; the Result return is kept for registrar-signature parity)
 pub fun register_linux(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
     linux_vtable.id             = os.OS_LINUX;

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -61,24 +61,12 @@ var linux_vtable: os.OsVTable;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_linux(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
-    val re: Result[intern.StrId, str] = intern.intern(i, "_start");
-    if (is_err[intern.StrId, str](re)) { ret err[bool, str](unwrap_err[intern.StrId, str](re)); }
-
-    val rs: Result[intern.StrId, str] = intern.intern(i, "linux");
-    if (is_err[intern.StrId, str](rs)) { ret err[bool, str](unwrap_err[intern.StrId, str](rs)); }
-
-    val rl: Result[intern.StrId, str] = intern.intern(i, "/usr/lib");
-    if (is_err[intern.StrId, str](rl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rl)); }
-
-    val rd: Result[intern.StrId, str] = intern.intern(i, LINUX_DYNAMIC_LINKER);
-    if (is_err[intern.StrId, str](rd)) { ret err[bool, str](unwrap_err[intern.StrId, str](rd)); }
-
     linux_vtable.id             = os.OS_LINUX;
     linux_vtable.name           = "linux";
-    linux_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
-    linux_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
-    linux_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);
-    linux_vtable.dynamic_linker = unwrap_ok[intern.StrId, str](rd);
+    linux_vtable.entry_symbol   = "_start";
+    linux_vtable.syscall_layer  = "linux";
+    linux_vtable.libdir         = "/usr/lib";
+    linux_vtable.dynamic_linker = LINUX_DYNAMIC_LINKER;
     linux_vtable.base_addr      = LINUX_BASE_ADDR;
     linux_vtable.page_size      = LINUX_PAGE_SIZE;
     # Linux auto-grows the stack on any in-range fault; no per-page probe needed.

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -53,22 +53,13 @@ var windows_vtable: os.OsVTable;
 # ret:   true on success, or an error string if name interning fails
 pub fun register_windows(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
-    val re: Result[intern.StrId, str] = intern.intern(i, "mainCRTStartup");
-    if (is_err[intern.StrId, str](re)) { ret err[bool, str](unwrap_err[intern.StrId, str](re)); }
-
-    val rs: Result[intern.StrId, str] = intern.intern(i, "windows");
-    if (is_err[intern.StrId, str](rs)) { ret err[bool, str](unwrap_err[intern.StrId, str](rs)); }
-
-    val rl: Result[intern.StrId, str] = intern.intern(i, "C:\\Windows\\System32");
-    if (is_err[intern.StrId, str](rl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rl)); }
-
     windows_vtable.id             = os.OS_WINDOWS;
     windows_vtable.name           = "windows";
-    windows_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
-    windows_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
-    windows_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);
+    windows_vtable.entry_symbol   = "mainCRTStartup";
+    windows_vtable.syscall_layer  = "windows";
+    windows_vtable.libdir         = "C:\\Windows\\System32";
     # PE imports load through the import directory, not a PT_INTERP-style path.
-    windows_vtable.dynamic_linker = intern.STR_NIL;
+    windows_vtable.dynamic_linker = "";
     # the linker's base is the first content segment's vaddr: one page above the
     # 64 KiB-aligned ImageBase, reserving RVA 0..0x1000 for the PE headers so the
     # first section maps immediately after them with no gap.

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -5,8 +5,8 @@
 # library directory, and the executable load parameters (ImageBase 0x140000000,
 # 4096-byte page) — so target.select composes a runnable Windows target through
 # the win64 ABI and the COFF/PE writer. PE links via the import directory, not a
-# PT_INTERP path, so `dynamic_linker` is STR_NIL. `register` interns the os
-# strings and is idempotent.
+# PT_INTERP path, so `dynamic_linker` is empty (""). `register` sets the vtable's
+# str fields directly (no interning) and is idempotent.
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -40,17 +40,16 @@ var windows_vtable: os.OsVTable;
 
 # register_windows: build and install the Windows OsVTable.
 #
-# interns the os name, entry symbol ("mainCRTStartup"), syscall layer, and
-# default library directory, fills the module-level vtable, and installs it into
-# `reg` under os.OS_WINDOWS. re-interns the strings into `i` on every call (the
-# registry entry is write-once) so a later build with a fresh interner gets
-# consistent ids. must be invoked at startup before target.select requests a
-# Windows target.
+# sets the os name, entry symbol ("mainCRTStartup"), syscall layer, and default
+# library directory as plain str constants, fills the module-level vtable, and
+# installs it into `reg` under os.OS_WINDOWS. the vtable strings are no longer
+# interned here — the linker interns the ones it needs at the point of use (#1402).
+# must be invoked at startup before target.select requests a Windows target.
 # ---
 # reg:   the OS registry to install the vtable into
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields
-# ret:   true on success, or an error string if name interning fails
+# alloc: backing allocator (unused; retained for registrar-signature parity)
+# i:     interner (unused; retained for registrar-signature parity)
+# ret:   true (always; the Result return is kept for registrar-signature parity)
 pub fun register_windows(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
 
     windows_vtable.id             = os.OS_WINDOWS;

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -12,8 +12,8 @@ use os:  mach.lang.target.os;
 
 # a fully resolved compilation target. the `*_id` fields are comptime
 # identity (matching the constants in os/isa/abi/of); the vtable pointers are
-# the runtime-dispatch surface the backend calls through. pointer width and
-# endianness are read through `arch`, never duplicated here.
+# the runtime-dispatch surface the backend calls through. pointer width is read
+# through `arch`, never duplicated here.
 # ---
 # os_id:   operating-system id (one of os.OS_*)
 # arch_id: architecture id (one of isa.ARCH_*)


### PR DESCRIPTION
Integration merge of dev into main for the **v1.5.4** release — the stabilization + multi-target-prep bundle.

- #1391 multi-target union Project
- #1402 OS-vtable interner-elimination
- #1409/#1413 COFF REL32 addend convention + O(reloc) symbol map
- #1410 objfmt parse-leak reclamation + truthful ELF count
- #1411/#1414 dead endianness drop + arm64 reg-id fix
- #1412 manifest name-table consolidation + unknown-name diagnostic

All CI green on dev (Full Build, Test Suite, Integration, Windows native). Tag v1.5.4 follows.