### PR TITLE
feat: reload-friendly driver API — source dedup + session registry reclamation (#1389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- driver/source: reload-friendly source handling for long-lived sessions. The
+  session `SourceMap` now dedups by path (`source.load`): re-loading a path returns
+  its existing `FileId` and swaps the text in place rather than appending, so a
+  session that reloads its project graph on every save no longer grows without
+  bound. `dnit_project` now also resets the session's per-build module registries
+  (AST/sema/resolve/comptime/fqn and export/import maps), dropping the borrowed
+  references the freed Project leaves behind so one Session is reusable across
+  rebuilds. This is path-dedup + reclamation only; reusing untouched ASTs/resolve
+  results across a rebuild (true incremental rebuild) is tracked separately in
+  #1164 (#1389).
+
 ## [1.5.4] - 2026-06-14
 
 Stabilization + multi-target-prep release. Adds the multi-target union Project for

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -513,7 +513,9 @@ fun build_project_impl(s: *sess.Session, project_root: str, sel: *manifest.Selec
 
 # build_project_sel: build the module graph for one build selection (target,
 # profile, artifact). The manifest reader resolves the selection into the
-# project's single target entry and concrete output paths.
+# project's single target entry and concrete output paths. Safe to call
+# repeatedly on one long-lived Session: sources dedup by path and dnit_project
+# resets the session's module registries (see dnit_project's reload contract).
 pub fun build_project_sel(s: *sess.Session, project_root: str, sel: *manifest.Selection) Result[Project, str] {
     ret build_project_impl(s, project_root, sel, false);
 }
@@ -828,7 +830,18 @@ fun span_eq_span(source: str, a: token.Span, b: token.Span) bool {
     ret true;
 }
 
-# dnit_project: release every owned array on the project.
+# dnit_project: release every owned array on the project, then clear the session's
+# per-build module registries so the session is reusable for the next build.
+#
+# reload contract: a long-lived consumer (an LSP reloading on save) keeps ONE
+# Session and, per reload, calls build_project_sel / build_project_union, drives
+# the build, then dnit_project. sources dedup by path (source.load) so re-reading
+# the same closure reuses FileIds instead of growing the SourceMap, and this call's
+# reset_module_registry drops the borrowed AST/sema/resolve/comptime references the
+# freed Project leaves behind — so memory stays bounded and the session stays clean
+# across rebuilds. this does NOT reuse untouched ASTs/resolve results across builds
+# (true incremental rebuild is tracked separately in #1164); each reload re-parses
+# and re-resolves the full closure.
 # ---
 # p: project to tear down; nil is a no-op
 pub fun dnit_project(p: *Project) {
@@ -863,6 +876,10 @@ pub fun dnit_project(p: *Project) {
     }
     map.dnit[intern.StrId, sess.ModuleId](?p.by_fqn);
     deallocate_config(?p.config, p.s.alloc);
+
+    # the freed Project leaves the session's module registries pointing at freed
+    # AST/sema/resolve/comptime storage; clear them so the session is reusable.
+    sess.reset_module_registry(p.s);
 }
 
 fun init_project(p: *Project, s: *sess.Session) {
@@ -3180,6 +3197,65 @@ test "driver union: branch selection via the $target.os string tag exercises and
     or (cm.target_abi != cb.target_abi)      { bad = 1; }
 
     dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver reload: a Session rebuilds after dnit_project, deduping changed sources by path (#1389)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    val rr: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
+    if (is_err[bool, str](rr)) { sess.dnit(?s); ret 1; }
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "a.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.a;\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+
+    # materialize the project once; both builds run against this same root so the
+    # changed file keeps its path and dedups instead of growing the SourceMap.
+    val root_r: Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (is_err[str, str](root_r)) { sess.dnit(?s); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    # first build.
+    val p1r: Result[Project, str] = build_project_union(?s, root);
+    if (is_err[Project, str](p1r)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+    var p1: Project = unwrap_ok[Project, str](p1r);
+    if (!ut_has(?p1, ?s, "uniontest.main")) { bad = 1; }
+    or (!ut_has(?p1, ?s, "uniontest.a"))    { bad = 1; }
+    val len1: usize = s.sources.len;
+    if (len1 == 0) { bad = 1; }
+    dnit_project(?p1);
+
+    # change a.mach's content in place (same path), then rebuild on the SAME session.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val a_path: str = ut_cc3(?alloc, src_dir, "/", "a.mach");
+    val new_a: str = "pub fun fa() i32 { ret 2; }\n";
+    val wr: Result[bool, str] = fs.write_file(a_path, new_a, str_len(new_a), 420);
+    if (is_err[bool, str](wr)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+
+    # second build on the reused session must succeed and stay valid.
+    val p2r: Result[Project, str] = build_project_union(?s, root);
+    if (is_err[Project, str](p2r)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+    var p2: Project = unwrap_ok[Project, str](p2r);
+    if (!ut_has(?p2, ?s, "uniontest.main")) { bad = 1; }
+    or (!ut_has(?p2, ?s, "uniontest.a"))    { bad = 1; }
+    val len2: usize = s.sources.len;
+
+    # every path is identical across the two builds (the changed file reuses its
+    # FileId via dedup), so the SourceMap did NOT grow: a long-lived session is bounded.
+    if (len2 != len1) { bad = 1; }
+
+    dnit_project(?p2);
+    fs.remove_all(?alloc, root);
     sess.dnit(?s);
     ret bad;
 }

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -188,6 +188,40 @@ pub fun dnit(s: *Session) {
     source.dnit(?s.sources);
 }
 
+# reset_module_registry: clear the per-build module registries so the session can
+# be reused for a fresh build. frees the module-AST array (reallocated lazily on
+# the next register_module_ast) and empties every per-build map.
+#
+# the module_sema/resolve/comptime maps hold BORROWED pointers into Project-owned
+# storage that the driver frees in dnit_project; the FQN / export / import maps are
+# keyed by per-build ModuleId/DeclId. NONE of the values are session-owned (they are
+# StrIds interned in the session's persistent interner, or borrowed Project pointers
+# already freed by the caller), so map.clear is used throughout — it empties the
+# slots while leaving value storage untouched, never freeing a borrowed pointer or a
+# live interned string. clearing the export/import maps too keeps a reused session
+# from inheriting a prior build's overrides for a ModuleId/DeclId the next build
+# repurposes. call this at the END of a project teardown (after the Project frees),
+# so the next build starts from a clean registry rather than entries pointing at
+# freed Project storage.
+# ---
+# s: the session whose module registries are emptied
+pub fun reset_module_registry(s: *Session) {
+    if (s == nil) { ret; }
+    if (s.module_asts != nil && s.module_ast_cap > 0) {
+        deallocate[*ast.Ast](s.alloc, s.module_asts, s.module_ast_cap::usize);
+    }
+    s.module_asts      = nil;
+    s.module_ast_count = 0;
+    s.module_ast_cap   = 0;
+    map.clear[modid.ModuleId, intern.StrId](?s.module_fqns);
+    map.clear[u64, intern.StrId](?s.export_names);
+    map.clear[u64, intern.StrId](?s.export_libraries);
+    map.clear[intern.StrId, intern.StrId](?s.import_libraries);
+    map.clear[modid.ModuleId, ptr](?s.module_sema);
+    map.clear[modid.ModuleId, ptr](?s.module_resolve);
+    map.clear[modid.ModuleId, ptr](?s.module_comptime);
+}
+
 # register_module_ast: record `a` as the AST of module `mid` in the session
 # registry, growing it to cover `mid` and zero-filling any gap. the registry
 # borrows `a`; the caller (the driver) owns the storage and must keep it alive
@@ -425,13 +459,16 @@ pub fun module_comptime_ptr(s: *Session, mid: modid.ModuleId) ptr {
 }
 
 # load_source: register a source file with the session and return its FileId.
-# delegates to source.add, which bumps s.queries.revision so derived
-# entries depending on this file invalidate.
+# delegates to source.load, which dedups by path: a path loaded for the first
+# time is appended, a path already loaded reuses its FileId and is text-swapped
+# in place — so a long-lived session (an LSP reloading on save) does not grow on
+# reload. either path bumps s.queries.revision so derived entries depending on
+# this file invalidate.
 # ---
 # s:    the session
 # path: file path to associate with this file
 # text: null-terminated source text to index and store
-# ret:  FileId of the newly added file, or an allocation error
+# ret:  FileId the path is registered under (stable across reloads of the same path), or an allocation error
 pub fun load_source(s: *Session, path: str, text: str) Result[source.FileId, str] {
-    ret source.add(?s.sources, ?s.queries, path, text);
+    ret source.load(?s.sources, ?s.queries, ?s.interner, path, text);
 }

--- a/src/lang/source.mach
+++ b/src/lang/source.mach
@@ -28,8 +28,13 @@ use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
+use page: std.allocator.page;
 
-use query: mach.lang.query;
+use map:     std.collections.map;
+use maphash: std.collections.map;
+
+use query:  mach.lang.query;
+use intern: mach.lang.intern;
 
 # FileId: stable handle into a SourceMap's file array.
 pub def FileId: u32;
@@ -60,15 +65,18 @@ pub rec SourceFile {
 
 # SourceMap: registry of loaded source files indexed by FileId.
 # ---
-# alloc: allocator used for all owned storage in this map
-# files: contiguous array of SourceFile records
-# len:   number of files currently stored
-# cap:   allocated slots in files
+# alloc:   allocator used for all owned storage in this map
+# files:   contiguous array of SourceFile records
+# len:     number of files currently stored
+# cap:     allocated slots in files
+# by_path: interned path StrId -> FileId index, maintained by load() so a path
+#          re-loaded in a long-lived session reuses its FileId instead of appending
 pub rec SourceMap {
-    alloc: *Allocator;
-    files: *SourceFile;
-    len:   usize;
-    cap:   usize;
+    alloc:   *Allocator;
+    files:   *SourceFile;
+    len:     usize;
+    cap:     usize;
+    by_path: map.Map[intern.StrId, FileId];
 }
 
 val INITIAL_MAP_CAP: usize = 8;
@@ -79,10 +87,11 @@ val INITIAL_MAP_CAP: usize = 8;
 # ret:   a new empty SourceMap
 pub fun init(alloc: *Allocator) SourceMap {
     var m: SourceMap;
-    m.alloc = alloc;
-    m.files = nil;
-    m.len   = 0;
-    m.cap   = 0;
+    m.alloc   = alloc;
+    m.files   = nil;
+    m.len     = 0;
+    m.cap     = 0;
+    m.by_path = map.init[intern.StrId, FileId](alloc, maphash.hash_u32, maphash.eq_u32);
     ret m;
 }
 
@@ -106,6 +115,7 @@ pub fun dnit(m: *SourceMap) {
     if (m.files != nil && m.cap > 0) {
         deallocate[SourceFile](m.alloc, m.files, m.cap);
     }
+    map.dnit[intern.StrId, FileId](?m.by_path);
     m.files = nil;
     m.len   = 0;
     m.cap   = 0;
@@ -263,6 +273,42 @@ pub fun update(m: *SourceMap, db: *query.QueryDb, id: FileId, text: str) Result[
     ret ok[bool, str](true);
 }
 
+# load: register a source file deduped by path. dedups by path: re-loading a
+# path returns its existing FileId and updates the text in place, so a long-lived
+# session (e.g. an LSP reloading project graphs on save) does not grow on reload.
+# a path seen for the first time appends a new file via add(); a path already
+# known is text-swapped in place via update() (id-stable, revision-bumping). the
+# by_path index is maintained only here; add/update remain raw primitives.
+# ---
+# m:        the source map
+# db:       query database whose revision is bumped so derived entries invalidate
+# interner: interner the path is interned into for the by_path lookup key
+# path:     file path to load
+# text:     source text to index and store; the stored copy is null-terminated
+# ret:      the FileId the path is registered under (stable across reloads of the same path), or an error
+pub fun load(m: *SourceMap, db: *query.QueryDb, interner: *intern.Interner, path: str, text: str) Result[FileId, str] {
+    val pid_r: Result[intern.StrId, str] = intern.intern(interner, path);
+    if (is_err[intern.StrId, str](pid_r)) {
+        ret err[FileId, str](unwrap_err[intern.StrId, str](pid_r));
+    }
+    var pid: intern.StrId = unwrap_ok[intern.StrId, str](pid_r);
+
+    val existing: Result[*FileId, str] = map.get[intern.StrId, FileId](?m.by_path, ?pid);
+    if (is_err[*FileId, str](existing)) {
+        val add_r: Result[FileId, str] = add(m, db, path, text);
+        if (is_err[FileId, str](add_r)) { ret add_r; }
+        val fid: FileId = unwrap_ok[FileId, str](add_r);
+        val ins_r: Result[bool, str] = map.insert[intern.StrId, FileId](?m.by_path, pid, fid);
+        if (is_err[bool, str](ins_r)) { ret err[FileId, str](unwrap_err[bool, str](ins_r)); }
+        ret ok[FileId, str](fid);
+    }
+
+    val fid: FileId = @unwrap_ok[*FileId, str](existing);
+    val up_r: Result[bool, str] = update(m, db, fid, text);
+    if (is_err[bool, str](up_r)) { ret err[FileId, str](unwrap_err[bool, str](up_r)); }
+    ret ok[FileId, str](fid);
+}
+
 # get: return a pointer to the SourceFile for a given FileId.
 # ---
 # m:   the source map
@@ -339,4 +385,45 @@ pub fun line_bounds(file: *SourceFile, line: usize) Option[LineSpan] {
     ls.start = start;
     ls.end   = end;
     ret some[LineSpan](ls);
+}
+
+test "source: load dedups by path, reusing the FileId and swapping text in place (#1389)" {
+    var a: Allocator;
+    page.make(?a);
+
+    val qr: Result[query.QueryDb, str] = query.init(?a);
+    if (is_err[query.QueryDb, str](qr)) { ret 1; }
+    var db: query.QueryDb = unwrap_ok[query.QueryDb, str](qr);
+    var ix: intern.Interner = intern.init(?a);
+    var m: SourceMap = init(?a);
+
+    val r1: Result[FileId, str] = load(?m, ?db, ?ix, "p1.mach", "a");
+    if (is_err[FileId, str](r1)) { ret 1; }
+    val fid1: FileId = unwrap_ok[FileId, str](r1);
+
+    # re-loading the SAME path returns the SAME FileId, updates text, no growth.
+    val r2: Result[FileId, str] = load(?m, ?db, ?ix, "p1.mach", "b");
+    if (is_err[FileId, str](r2)) { ret 1; }
+    val fid2: FileId = unwrap_ok[FileId, str](r2);
+
+    if (fid1 != fid2) { ret 1; }
+    if (m.by_path.len != 1) { ret 1; }
+    if (m.len != 1) { ret 1; }
+
+    val f1: *SourceFile = ?m.files[fid1::usize];
+    if (str_len(f1.text) != 1) { ret 1; }
+    if (f1.text[0] != 'b') { ret 1; }
+
+    # a DIFFERENT path appends a distinct new FileId, growing the map.
+    val r3: Result[FileId, str] = load(?m, ?db, ?ix, "p2.mach", "c");
+    if (is_err[FileId, str](r3)) { ret 1; }
+    val fid3: FileId = unwrap_ok[FileId, str](r3);
+    if (fid3 == fid1) { ret 1; }
+    if (m.by_path.len != 2) { ret 1; }
+    if (m.len != 2) { ret 1; }
+
+    dnit(?m);
+    intern.dnit(?ix);
+    query.dnit(?db);
+    ret 0;
 }


### PR DESCRIPTION
## Summary

Part A of the reload-friendly driver API for long-lived sessions (e.g. mach-lsp reloading project graphs on save). Two memory/reuse issues fixed:

1. **Path-dedup in the SourceMap.** `SourceMap` gains a `by_path` index and a new `source.load` entry that dedups by path: a path seen for the first time is appended via `add()`; a path already loaded reuses its `FileId` and is text-swapped in place via `update()` (id-stable, revision-bumping). `add`/`update` stay raw primitives; `by_path` is maintained only by `load`. `session.load_source` now routes through `source.load`, so the normal source-load path (driver `parse_module`, editor `open`) dedups automatically. A long-lived session no longer grows its SourceMap on reload.

2. **Session reuse across rebuilds.** `dnit_project` frees the Project's ASTs/sema/resolve/comptime, but the session still referenced them via its `module_*` registries. New `session.reset_module_registry` frees the module-AST array and clears the per-build FQN/sema/resolve/comptime + export/import maps **without freeing their values** (`map.clear` empties slots, leaving the borrowed Project pointers and interned StrIds untouched). It's called at the end of `dnit_project`, so a freed Project no longer leaves the session pointing at freed storage — one Session is reusable across rebuilds.

## Reload contract

Keep one Session; per reload call `build_project_sel`/`build_project_union`, drive the build, then `dnit_project` — sources dedup by path and the session registries reset, so memory is bounded and the session is reusable. Documented on `dnit_project`.

## Tests

- `source.mach`: `load` dedups by path (same path → same FileId, len stays 1, text updated; different path → distinct FileId, len 2).
- `driver.mach`: a Session builds, `dnit_project`s, has one source changed on disk, and rebuilds on the SAME Session — second build succeeds, modules present, and `s.sources.len` does not grow (changed file reused its FileId).

## Verification

- `mach build` exits 0.
- `mach test .`: 438 passed, 0 failed, 438 total (baseline 436 + 2 new).
- Self-host fixpoint byte-identical: FIXPOINT-OK.

Closes #1389

Incremental rebuild (reuse untouched ASTs/resolve) is out of scope — tracked in #1164.