### PR TITLE
refactor(target): drop the unused interner from register_all and the registrars

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -536,11 +536,9 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
     }
     var s: sess.Session = unwrap_ok[sess.Session, str](sess_r);
 
-    # populate the session's target registry from the session interner. the
-    # registrars intern each vtable's string fields (format/os/abi names) into it;
-    # the format writers no longer capture it — they resolve names through the
-    # interner each `ObjectImage` carries. register_all is idempotent.
-    val reg_r: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
+    # populate the session's target registry. register_all needs no interner —
+    # every vtable names itself with an immutable `str` constant. idempotent.
+    val reg_r: Result[bool, str] = tgt.register_all(?s.registry);
     if (is_err[bool, str](reg_r)) {
         print.eprint("error: ");
         print.eprint(unwrap_err[bool, str](reg_r));

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -466,7 +466,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     var s: sess.Session = unwrap_ok[sess.Session, str](sess_r);
 
-    val reg_r: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
+    val reg_r: Result[bool, str] = tgt.register_all(?s.registry);
     if (is_err[bool, str](reg_r)) {
         print.eprint("error: failed to register targets\n");
         sess.dnit(?s);

--- a/src/cli/cmd/info.mach
+++ b/src/cli/cmd/info.mach
@@ -25,12 +25,8 @@ use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 
-use std.allocator.Allocator;
-
-use page:  std.allocator.page;
 use print: std.print;
 
-use intern:  mach.lang.intern;
 use tgt:     mach.lang.target;
 use isa:     mach.lang.target.isa;
 use os:      mach.lang.target.os;
@@ -51,22 +47,14 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret 0;
     }
 
-    # an interner is needed to name the registries: each vtable holds its name as
-    # an interned id, and register_all interns those into the interner it is given.
-    var alloc: Allocator;
-    if (is_some[str](page.make(?alloc))) {
-        print.eprint("error: failed to initialise allocator\n");
-        ret 2;
-    }
-    var interner: intern.Interner = intern.init(?alloc);
-
+    # register_all needs no interner: each vtable names itself with an immutable
+    # `str` constant, read directly for the capability surface below.
     var reg: tgt.TargetRegistry = tgt.registry_init();
-    val reg_r: Result[bool, str] = tgt.register_all(?reg, ?interner);
+    val reg_r: Result[bool, str] = tgt.register_all(?reg);
     if (is_err[bool, str](reg_r)) {
         print.eprint("error: ");
         print.eprint(unwrap_err[bool, str](reg_r));
         print.eprint("\n");
-        intern.dnit(?interner);
         ret 2;
     }
 
@@ -82,7 +70,6 @@ pub fun run(argc: usize, argv: **u8) i64 {
     print.print("\n");
 
     val code: i64 = print_capabilities(?reg);
-    intern.dnit(?interner);
     ret code;
 }
 

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2908,7 +2908,7 @@ fun ut_build(s: *sess.Session, alloc: *Allocator, names: *str, texts: *str, n: u
     val root_r: Result[str, str] = ut_scaffold(alloc, names, texts, n);
     if (is_err[str, str](root_r)) { ret err[Project, str](unwrap_err[str, str](root_r)); }
     val root: str = unwrap_ok[str, str](root_r);
-    val rr: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
+    val rr: Result[bool, str] = tgt.register_all(?s.registry);
     if (is_err[bool, str](rr)) { fs.remove_all(alloc, root); ret err[Project, str](unwrap_err[bool, str](rr)); }
     val pr: Result[Project, str] = build_project_union(s, root);
     fs.remove_all(alloc, root);
@@ -3125,7 +3125,7 @@ test "driver union: a malformed branch condition is reported once, not once per 
     val root1_r: Result[str, str] = ut_scaffold(?a1, ?names[0], ?texts[0], 1);
     if (is_err[str, str](root1_r)) { sess.dnit(?s1); ret 1; }
     val root1: str = unwrap_ok[str, str](root1_r);
-    val rr1: Result[bool, str] = tgt.register_all(?s1.registry, ?s1.interner);
+    val rr1: Result[bool, str] = tgt.register_all(?s1.registry);
     if (is_err[bool, str](rr1)) { fs.remove_all(?a1, root1); sess.dnit(?s1); ret 1; }
     var sel: manifest.Selection;
     sel.target = ""; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false;
@@ -3208,7 +3208,7 @@ test "driver reload: a Session rebuilds after dnit_project, deduping changed sou
     if (is_err[sess.Session, str](sr)) { ret 1; }
     var s: sess.Session = unwrap_ok[sess.Session, str](sr);
 
-    val rr: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
+    val rr: Result[bool, str] = tgt.register_all(?s.registry);
     if (is_err[bool, str](rr)) { sess.dnit(?s); ret 1; }
 
     var names: [2]str;

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -22,11 +22,6 @@ use std.types.string.str;
 use std.types.bool.bool;
 use std.types.bool.true;
 
-use std.allocator.Allocator;
-
-use page:   std.allocator.page;
-use intern: mach.lang.intern;
-
 use tdef: mach.lang.target.resolved;
 use isa: mach.lang.target.isa;
 use abi: mach.lang.target.abi;
@@ -158,42 +153,41 @@ pub fun registry_init() TargetRegistry {
 # (arm64, win64, coff, mach-o, darwin, windows) so `select` reports an
 # unsupported pair rather than a missing registration. must be called once at
 # startup, before any `select` against `reg`, so the registries are populated.
-# every registrar is idempotent, so a redundant call is harmless. the
-# allocator threaded into the registrars that take one for parity is read from
-# the interner.
+# every registrar is idempotent, so a redundant call is harmless. no interner is
+# needed: vtable string fields are immutable `str` constants, interned at the
+# point of use in the linker and object-format consumers.
 # ---
 # reg: the target registry to install every implementation into
-# i:   interner used to intern each implementation's string fields
 # ret: ok(true) once every implementation is registered, or the first error
-pub fun register_all(reg: *TargetRegistry, i: *intern.Interner) Result[bool, str] {
-    val r_x64: Result[bool, str] = x64.register_x64(?reg.isa, i.alloc, i);
+pub fun register_all(reg: *TargetRegistry) Result[bool, str] {
+    val r_x64: Result[bool, str] = x64.register_x64(?reg.isa);
     if (is_err[bool, str](r_x64)) { ret err[bool, str](unwrap_err[bool, str](r_x64)); }
 
-    val r_arm64: Result[bool, str] = arm64.register_arm64(?reg.isa, i.alloc, i);
+    val r_arm64: Result[bool, str] = arm64.register_arm64(?reg.isa);
     if (is_err[bool, str](r_arm64)) { ret err[bool, str](unwrap_err[bool, str](r_arm64)); }
 
-    val r_sysv: Result[bool, str] = sysv.register(?reg.abi, i);
+    val r_sysv: Result[bool, str] = sysv.register(?reg.abi);
     if (is_err[bool, str](r_sysv)) { ret err[bool, str](unwrap_err[bool, str](r_sysv)); }
 
-    val r_win64: Result[bool, str] = win64.register_win64(?reg.abi, i.alloc, i);
+    val r_win64: Result[bool, str] = win64.register_win64(?reg.abi);
     if (is_err[bool, str](r_win64)) { ret err[bool, str](unwrap_err[bool, str](r_win64)); }
 
-    val r_elf: Result[bool, str] = elf.register(?reg.of, i);
+    val r_elf: Result[bool, str] = elf.register(?reg.of);
     if (is_err[bool, str](r_elf)) { ret err[bool, str](unwrap_err[bool, str](r_elf)); }
 
-    val r_coff: Result[bool, str] = coff.register_coff(?reg.of, i);
+    val r_coff: Result[bool, str] = coff.register_coff(?reg.of);
     if (is_err[bool, str](r_coff)) { ret err[bool, str](unwrap_err[bool, str](r_coff)); }
 
-    val r_macho: Result[bool, str] = macho.register_macho(?reg.of, i);
+    val r_macho: Result[bool, str] = macho.register_macho(?reg.of);
     if (is_err[bool, str](r_macho)) { ret err[bool, str](unwrap_err[bool, str](r_macho)); }
 
-    val r_linux: Result[bool, str] = linux.register_linux(?reg.os, i.alloc, i);
+    val r_linux: Result[bool, str] = linux.register_linux(?reg.os);
     if (is_err[bool, str](r_linux)) { ret err[bool, str](unwrap_err[bool, str](r_linux)); }
 
-    val r_darwin: Result[bool, str] = darwin.register_darwin(?reg.os, i.alloc, i);
+    val r_darwin: Result[bool, str] = darwin.register_darwin(?reg.os);
     if (is_err[bool, str](r_darwin)) { ret err[bool, str](unwrap_err[bool, str](r_darwin)); }
 
-    val r_windows: Result[bool, str] = windows.register_windows(?reg.os, i.alloc, i);
+    val r_windows: Result[bool, str] = windows.register_windows(?reg.os);
     if (is_err[bool, str](r_windows)) { ret err[bool, str](unwrap_err[bool, str](r_windows)); }
 
     ret ok[bool, str](true);
@@ -254,12 +248,8 @@ pub fun select(reg: *TargetRegistry, os_id: u32, arch_id: u32) Result[tdef.Targe
 # id-keyed lookups after register_all, and report none past the count. the
 # `mach info` capability surface reads the registries through exactly this pair.
 test "target: registry enumeration agrees with lookup (#1312)" {
-    var alloc: Allocator;
-    page.make(?alloc);
-    var i: intern.Interner = intern.init(?alloc);
-
     var reg: TargetRegistry = registry_init();
-    val rr: Result[bool, str] = register_all(?reg, ?i);
+    val rr: Result[bool, str] = register_all(?reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     # the supported implementations are all enumerable.

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -22,7 +22,6 @@ use std.types.bool.true;
 use std.types.bool.false;
 use std.types.string.str;
 
-use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 use abi:    mach.lang.target.abi;
 
@@ -460,17 +459,15 @@ var sysv_vtable: abi.AbiVTable;
 
 # register: build the SysV AMD64 AbiVTable and install it into `reg`.
 #
-# interns the convention name ("sysv"), wires the type-erased classify/arg/ret
-# operation pointers and the GP/FP argument-register and callee-saved register
-# file accessors, sets the 16-byte stack alignment and 128-byte red zone, and
-# registers it under abi.ABI_SYSV so target.select can find it through
-# abi.lookup. re-interns the name into `i` on every call (the registry entry is
-# write-once) so a later build with a fresh interner gets a consistent id.
+# sets the convention name ("sysv") as an immutable `str` constant, wires the
+# type-erased classify/arg/ret operation pointers and the GP/FP argument-register
+# and callee-saved register file accessors, sets the 16-byte stack alignment and
+# 128-byte red zone, and registers it under abi.ABI_SYSV so target.select can find
+# it through abi.lookup. idempotent: the registry entry is write-once.
 # ---
 # reg: the ABI registry to install the vtable into
-# i:   interner used to intern the vtable's string fields
-# ret: ok(true) on success, or an allocation error from interning
-pub fun register(reg: *abi.AbiRegistry, i: *intern.Interner) Result[bool, str] {
+# ret: ok(true) on success
+pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
 
     sysv_vtable.id           = abi.ABI_SYSV;
     sysv_vtable.name         = "sysv";

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -25,9 +25,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 use abi:    mach.lang.target.abi;
 use x64:    mach.lang.target.isa.x64;
@@ -442,19 +439,16 @@ var win64_vtable: abi.AbiVTable;
 
 # register_win64: build and install the win64 AbiVTable.
 #
-# interns the convention name ("win64"), wires the type-erased classify/arg/ret
-# operation pointers and the gp_arg_regs / fp_arg_regs / callee_saved register-
-# file accessors, sets the stack alignment (16) and red-zone size (0), and
-# installs it into `reg` under abi.ABI_WIN64. re-interns the name into `i` on
-# every call (the registry entry is write-once) so a later build with a fresh
-# interner gets a consistent id. must be invoked at startup before target.select
-# requests a Windows target.
+# sets the convention name ("win64") as an immutable `str` constant, wires the
+# type-erased classify/arg/ret operation pointers and the gp_arg_regs /
+# fp_arg_regs / callee_saved register-file accessors, sets the stack alignment
+# (16) and red-zone size (0), and installs it into `reg` under abi.ABI_WIN64.
+# idempotent: the registry entry is write-once. must be invoked at startup before
+# target.select requests a Windows target.
 # ---
-# reg:   the ABI registry to install the vtable into
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields
-# ret:   true on success, or an error string if name interning fails
-pub fun register_win64(reg: *abi.AbiRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# reg: the ABI registry to install the vtable into
+# ret: true on success
+pub fun register_win64(reg: *abi.AbiRegistry) Result[bool, str] {
 
     win64_vtable.id           = abi.ABI_WIN64;
     win64_vtable.name         = "win64";

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -23,9 +23,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 
 # number of general-purpose registers exposed (X0–X30; SP/XZR are not
@@ -61,21 +58,18 @@ var arm64_vtable: isa.IsaVTable;
 
 # register_arm64: build and install the AArch64 IsaVTable.
 #
-# interns the arch name and register-class names, fills the module-level
-# register-class table (gpr 64×31, vector 128×32, flags 64×1) and vtable with
-# 8-byte pointers, little-endian byte order, the reserved registers (SP/FP), the
-# scratch register identities (IP0/IP1/V31), the frame/stack pointers (FP/SP), -1
-# for the division / shift register identities (AArch64 wires none), and nil
-# select/encode entry points, and installs it into `reg` under isa.ARCH_AARCH64.
-# re-interns the names into `i` on every call (the registry entry is write-once)
-# so a later build with a fresh interner gets consistent ids. must be invoked at
-# startup before target.select requests an AArch64 target.
+# sets the arch name and register-class names as immutable `str` constants, fills
+# the module-level register-class table (gpr 64×31, vector 128×32, flags 64×1) and
+# vtable with 8-byte pointers, little-endian byte order, the reserved registers
+# (SP/FP), the scratch register identities (IP0/IP1/V31), the frame/stack pointers
+# (FP/SP), -1 for the division / shift register identities (AArch64 wires none),
+# and nil select/encode entry points, and installs it into `reg` under
+# isa.ARCH_AARCH64. idempotent: the registry entry is write-once. must be invoked
+# at startup before target.select requests an AArch64 target.
 # ---
-# reg:   the ISA registry to install the vtable into
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields
-# ret:   true on success, or an error string if name interning fails
-pub fun register_arm64(reg: *isa.IsaRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# reg: the ISA registry to install the vtable into
+# ret: true on success
+pub fun register_arm64(reg: *isa.IsaRegistry) Result[bool, str] {
 
     arm64_reg_classes[0].name      = "gpr";
     arm64_reg_classes[0].bit_width = 64;

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -20,9 +20,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 use x64:        mach.lang.target.isa.x64;
 use x64isel:    mach.lang.target.isa.x64.isel;
@@ -59,17 +56,16 @@ var x64_reload_scratch_regs: [3]isa.Register;
 
 # register_x64: build and install the x86-64 ISA vtable.
 #
-# interns the architecture and register-class names, fills the three register
-# classes (gpr 64×16, xmm 128×16, flags 64×1), populates the vtable with the
-# pointer width (8), little-endian byte order, the reserved registers (RSP/RBP),
-# the scratch register identities (R11/R10/XMM15), the frame/stack pointers
-# (RBP/RSP) the shared MIR lowering names when forming stack memory operands, and
-# the fixed division accumulator / high-half (RAX/RDX) and variable-shift count
-# (RCX) registers the x86-64 IDIV/DIV and shift forms hard-wire, and installs it
-# into `reg`. re-interns the names into `interner` on every call (the registry
-# entry is write-once) so a later build with a fresh interner gets consistent
-# ids. must be invoked at compiler startup before `target.select` requests an
-# x86-64 target.
+# sets the architecture and register-class names as immutable `str` constants,
+# fills the three register classes (gpr 64×16, xmm 128×16, flags 64×1), populates
+# the vtable with the pointer width (8), little-endian byte order, the reserved
+# registers (RSP/RBP), the scratch register identities (R11/R10/XMM15), the
+# frame/stack pointers (RBP/RSP) the shared MIR lowering names when forming stack
+# memory operands, and the fixed division accumulator / high-half (RAX/RDX) and
+# variable-shift count (RCX) registers the x86-64 IDIV/DIV and shift forms
+# hard-wire, and installs it into `reg`. idempotent: the registry entry is
+# write-once. must be invoked at compiler startup before `target.select` requests
+# an x86-64 target.
 #
 # the `select` and `encode` operation entry points are the x86-64 instruction
 # selector (`x64/isel.mach`) and byte encoder (`x64/encode.mach`), stored
@@ -79,11 +75,9 @@ var x64_reload_scratch_regs: [3]isa.Register;
 # and encoding logic lives under this module and is reached only through these
 # vtable slots; the shared backend drivers carry no x86-64 knowledge.
 # ---
-# reg:      the ISA registry to install the vtable into
-# alloc:    backing allocator (reserved for parity with other registrars)
-# interner: string interner used to intern the architecture and class names
-# ret:      true on success, or an error string if name interning fails
-pub fun register_x64(reg: *isa.IsaRegistry, alloc: *Allocator, interner: *intern.Interner) Result[bool, str] {
+# reg: the ISA registry to install the vtable into
+# ret: true on success
+pub fun register_x64(reg: *isa.IsaRegistry) Result[bool, str] {
 
     x64_classes[0].name      = "gpr";
     x64_classes[0].bit_width = 64;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2731,21 +2731,18 @@ var coff_vtable: of.OfVTable;
 
 # register_coff: build and install the COFF OfVTable.
 #
-# interns the format name ("coff") and file extension ("obj") into the vtable's
-# string fields, wires the writer/reader, and installs it into `reg` under
-# of.OF_COFF. reentrant: every call re-interns the names against `i`, so a second
-# session (or test) with a different interner is consistent rather than leaving
-# stale ids; `of.register` itself is idempotent. the reader/writer no longer
-# capture an interner — they resolve names through the `interner` each
+# sets the format name ("coff") as an immutable `str` constant in the vtable,
+# wires the writer/reader, and installs it into `reg` under of.OF_COFF.
+# idempotent: `of.register` overwrites the write-once entry. the reader/writer
+# capture no interner — they resolve names through the `interner` each
 # `ObjectImage` carries (and the one passed to parse/dyn-exec) — and relocation
 # kinds are a closed `of.RK_*` enum the writer maps with a plain integer compare.
 # must be invoked at compiler startup before target.select requests a Windows
 # target.
 # ---
 # reg: the object-format registry to install the vtable into
-# i:   string interner used to intern the vtable's string fields
-# ret: true on success, or an error string if name interning fails
-pub fun register_coff(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
+# ret: true on success
+pub fun register_coff(reg: *of.OfRegistry) Result[bool, str] {
     coff_vtable.id               = of.OF_COFF;
     coff_vtable.name             = "coff";
     coff_vtable.emit_object      = coff_emit_object;
@@ -2770,11 +2767,10 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    # register_coff captures `i` as the reader/writer interner and interns the
-    # relocation-kind names into it; the kind StrIds resolve against this same
-    # interner below.
+    # the image below carries `i`; the reader/writer resolve names through it, and
+    # the section/symbol StrIds interned into it resolve against this same interner.
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -2956,7 +2952,7 @@ test "coff: REL32 addend translates the COFF P+4 convention at parse and emit (#
     # recovers A_elf = 4 - 4 = 0. a `call`'s -4 addend folds to 0 the same way.
     var i: intern.Interner = intern.init(?alloc);
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3031,7 +3027,7 @@ test "coff: emit rejects a relocation naming an unresolved symbol (#1196)" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3089,7 +3085,7 @@ test "coff: a defined weak symbol round-trips its weak flag through a COMDAT sec
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3227,7 +3223,7 @@ test "coff: long section and symbol names round-trip through the string table" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3298,7 +3294,7 @@ test "coff: emit_exec writes a well-formed PE32+ header" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3382,7 +3378,7 @@ test "coff: a function-flagged call-target import round-trips DT_FUNCTION" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3459,7 +3455,7 @@ test "coff: parse infers function imports from a foreign object's call relocatio
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3537,7 +3533,7 @@ test "coff: emit_exec emits .xdata/.pdata for a canonical x64 prologue" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3796,7 +3792,7 @@ test "coff: emit rejects a relocation whose kind has no COFF machine type (#1256
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3848,7 +3844,7 @@ test "coff: parse rejects a foreign ADDR32 relocation type (#1256)" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3914,7 +3910,7 @@ test "coff: emit rejects a section reloc count above the u16 limit (#1256)" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3978,7 +3974,7 @@ test "coff: parse rejects a truncated object instead of reading out of bounds (#
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -753,18 +753,15 @@ var elf_vtable: of.OfVTable;
 
 # register: build the ELF OfVTable and install it into `reg`.
 #
-# interns the format name ("elf") and extension ("o") into the vtable's string
-# fields and registers it under `of.OF_ELF`. reentrant: every call re-interns the
-# names against `i`, so a second session (or test) with a different interner is
-# consistent rather than left with stale ids; `of.register` is itself idempotent.
-# the writer no longer captures an interner — it resolves names through the
+# sets the format name ("elf") as an immutable `str` constant in the vtable and
+# registers it under `of.OF_ELF`. idempotent: `of.register` overwrites the
+# write-once entry. the writer captures no interner — it resolves names through the
 # `interner` each `ObjectImage` carries — and relocation kinds are a closed
 # `of.RK_*` enum the writer maps with a plain integer compare.
 # ---
 # reg: the object-format registry to install the vtable into
-# i:   interner used to intern the vtable's string fields
-# ret: ok(true) on success, or an allocation error from interning
-pub fun register(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
+# ret: ok(true) on success
+pub fun register(reg: *of.OfRegistry) Result[bool, str] {
     elf_vtable.id               = of.OF_ELF;
     elf_vtable.name             = "elf";
     elf_vtable.emit_object      = emit_object;
@@ -1950,9 +1947,9 @@ test "elf: emit rejects a relocation naming an unresolved symbol (#1196)" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    # register captures `i` as the writer interner so names resolve against it.
+    # the image below carries `i`; the writer resolves names through it.
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register(?of_reg, ?i);
+    val rr: Result[bool, str] = register(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -2005,7 +2002,7 @@ test "elf: emit rejects a relocation whose kind has no ELF machine type (#1256)"
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register(?of_reg, ?i);
+    val rr: Result[bool, str] = register(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -2058,7 +2055,7 @@ test "elf: parse rejects an unknown machine relocation type (#1256)" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register(?of_reg, ?i);
+    val rr: Result[bool, str] = register(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -2130,7 +2127,7 @@ test "elf: parse rejects a truncated object instead of reading out of bounds (#1
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register(?of_reg, ?i);
+    val rr: Result[bool, str] = register(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -90,18 +90,15 @@ var macho_vtable: of.OfVTable;
 
 # register_macho: build and install the Mach-O OfVTable.
 #
-# interns the format name ("macho") and file extension ("o"), fills the vtable,
+# sets the format name ("macho") as an immutable `str` constant, fills the vtable,
 # wires the (stub) writer, and installs it into `reg` under of.OF_MACHO.
-# reentrant: every call re-interns the names against `i` so a second session (or
-# test) with a different interner is consistent rather than left with stale ids;
-# `of.register` is itself idempotent. abstract relocation kinds are a closed
-# `of.RK_*` enum, so no per-format kind table is interned. must be invoked at
-# compiler startup before target.select requests a Darwin target.
+# idempotent: `of.register` overwrites the write-once entry. abstract relocation
+# kinds are a closed `of.RK_*` enum, so no per-format kind table is interned. must
+# be invoked at compiler startup before target.select requests a Darwin target.
 # ---
 # reg: the object-format registry to install the vtable into
-# i:   string interner used to intern the vtable's string fields
-# ret: true on success, or an error string if name interning fails
-pub fun register_macho(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
+# ret: true on success
+pub fun register_macho(reg: *of.OfRegistry) Result[bool, str] {
     macho_vtable.id               = of.OF_MACHO;
     macho_vtable.name             = "macho";
     macho_vtable.emit_object      = macho_emit_object;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -21,9 +21,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
 
 # default base virtual address for Darwin executables (4 GiB).
@@ -40,15 +37,13 @@ var darwin_vtable: os.OsVTable;
 #
 # sets the os name, entry symbol ("_main"), syscall layer, and default library
 # directory as plain str constants, fills the module-level vtable, and installs it
-# into `reg` under os.OS_DARWIN. the vtable strings are no longer interned here —
-# the linker interns the ones it needs at the point of use (#1402). must be invoked
-# at startup before target.select requests a Darwin target.
+# into `reg` under os.OS_DARWIN. the vtable strings are not interned here — the
+# linker interns the ones it needs at the point of use (#1402). must be invoked at
+# startup before target.select requests a Darwin target.
 # ---
-# reg:   the OS registry to install the vtable into
-# alloc: backing allocator (unused; retained for registrar-signature parity)
-# i:     interner (unused; retained for registrar-signature parity)
-# ret:   true (always; the Result return is kept for registrar-signature parity)
-pub fun register_darwin(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# reg: the OS registry to install the vtable into
+# ret: true (always; the Result return is kept for registrar-signature parity)
+pub fun register_darwin(reg: *os.OsRegistry) Result[bool, str] {
 
     darwin_vtable.id             = os.OS_DARWIN;
     darwin_vtable.name           = "darwin";

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -20,9 +20,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
 
 # default base virtual address for Linux executables. the first PT_LOAD
@@ -50,15 +47,13 @@ var linux_vtable: os.OsVTable;
 # sets the os name, entry symbol ("_start"), syscall layer, and default library
 # directory as plain str constants, fills the module-level vtable (including the
 # 0x400000 base address and 4096-byte page), and installs it into `reg` under
-# os.OS_LINUX. the vtable strings are no longer interned here — the linker interns
-# the ones it needs at the point of use (#1402). must be invoked at startup before
+# os.OS_LINUX. the vtable strings are not interned here — the linker interns the
+# ones it needs at the point of use (#1402). must be invoked at startup before
 # target.select requests a Linux target.
 # ---
-# reg:   the OS registry to install the vtable into
-# alloc: backing allocator (unused; retained for registrar-signature parity)
-# i:     interner (unused; retained for registrar-signature parity)
-# ret:   true (always; the Result return is kept for registrar-signature parity)
-pub fun register_linux(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# reg: the OS registry to install the vtable into
+# ret: true (always; the Result return is kept for registrar-signature parity)
+pub fun register_linux(reg: *os.OsRegistry) Result[bool, str] {
 
     linux_vtable.id             = os.OS_LINUX;
     linux_vtable.name           = "linux";

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -21,9 +21,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
 
 # default ImageBase for Windows x86_64 executables (64 KiB-aligned). the PE
@@ -42,15 +39,13 @@ var windows_vtable: os.OsVTable;
 #
 # sets the os name, entry symbol ("mainCRTStartup"), syscall layer, and default
 # library directory as plain str constants, fills the module-level vtable, and
-# installs it into `reg` under os.OS_WINDOWS. the vtable strings are no longer
-# interned here — the linker interns the ones it needs at the point of use (#1402).
-# must be invoked at startup before target.select requests a Windows target.
+# installs it into `reg` under os.OS_WINDOWS. the vtable strings are not interned
+# here — the linker interns the ones it needs at the point of use (#1402). must be
+# invoked at startup before target.select requests a Windows target.
 # ---
-# reg:   the OS registry to install the vtable into
-# alloc: backing allocator (unused; retained for registrar-signature parity)
-# i:     interner (unused; retained for registrar-signature parity)
-# ret:   true (always; the Result return is kept for registrar-signature parity)
-pub fun register_windows(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# reg: the OS registry to install the vtable into
+# ret: true (always; the Result return is kept for registrar-signature parity)
+pub fun register_windows(reg: *os.OsRegistry) Result[bool, str] {
 
     windows_vtable.id             = os.OS_WINDOWS;
     windows_vtable.name           = "windows";


### PR DESCRIPTION
Capstone of #1402 (and completes #1418). Post #1402/#1417 no target registrar interns any longer — every vtable string field is an immutable `str` constant, interned at the linker and object-format consumers. This drops the now-vestigial interner plumbing.

## Changes
- `register_all` (`src/lang/target.mach`): drops the `interner` param; calls each registrar with only the registry it installs into.
- The ten registrars now take exactly the params they use:
  - `register_x64`, `register_arm64`, `register_win64`, `register_linux`, `register_darwin`, `register_windows` — dropped both `alloc` and the interner (each used neither); now `(reg)`.
  - `sysv.register`, `elf.register`, `coff.register_coff`, `macho.register_macho` — dropped the interner; now `(reg)`.
- Call sites updated: `build.mach`, `doc.mach`, `driver.mach` (3), and the `target`/`elf`/`coff` tests.
- `mach info` (`info.mach`): removed the throwaway interner+allocator it created solely to feed `register_all` (the capability surface reads vtable names as plain `str`). Same output, no allocator/interner setup.
- Cleared orphaned `intern`/`std.allocator.Allocator`/`page` imports left by the param drops, and corrected stale "registrars intern" comments.

Pure mechanical, behavior-preserving — the registrars already stopped interning under #1402; this only removes the dead parameters and their threading.

## Verification
- `mach build .` — green.
- `mach test .` — 438 passed, 0 failed.
- Self-host fixpoint — byte-identical: stage1 (bootstrap → source) == stage2 (stage1 → source) == stage3 (stage2 → source), all sha256 `068f3dec…`.

Closes #1402
Closes #1418