### PR TITLE
chore(release): v1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.5] - 2026-06-14
+
+Tooling-prep patch. Adds reload-friendly source handling so a long-lived session
+(e.g. the language server) can rebuild its project graph on every save without
+growing without bound, and completes the target-layer interner-elimination by
+dropping the now-dead interner parameter from `register_all` and every target
+registrar — the target vtables are now immutable singletons.
 
 ### Added
 
@@ -19,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rebuilds. This is path-dedup + reclamation only; reusing untouched ASTs/resolve
   results across a rebuild (true incremental rebuild) is tracked separately in
   #1164 (#1389).
+
+### Changed
+
+- target: `register_all` and the target registrars no longer take an interner (or
+  the vestigial allocator) parameter. The registrars set immutable `str` vtable
+  fields and intern nothing, so the parameter had been dead since the OS-vtable
+  interner-elimination — each registrar is now trimmed to exactly the registry it
+  installs into, and `mach info` no longer builds a throwaway interner to call them.
+  Behavior-preserving, verified by the byte-identical self-host fixpoint; completes
+  the interner-elimination begun in #1402 (#1418).
 
 ## [1.5.4] - 2026-06-14
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "1.5.4"
+version = "1.5.5"
 src = "src"
 dep = "dep"
 target = "native"


### PR DESCRIPTION
Roll the v1.5.5 release: `CHANGELOG.md` [Unreleased] → [1.5.5] and `mach.toml` version 1.5.4 → 1.5.5.

Content (already merged to dev):
- #1389 Part A — reload-friendly driver API: `source.load` path-dedup + `dnit_project` session-registry reclamation, so a long-lived session reloads without unbounded growth (PR #1427).
- #1418 — drop the now-dead interner (and vestigial allocator) parameter from `register_all` and every target registrar; completes the interner-elimination begun in #1402. Behavior-preserving, byte-identical self-host fixpoint (PR #1428).

No code change in this PR — version/changelog roll only.