### PR TITLE
release: v1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- driver/source: reload-friendly source handling for long-lived sessions. The
+  session `SourceMap` now dedups by path (`source.load`): re-loading a path returns
+  its existing `FileId` and swaps the text in place rather than appending, so a
+  session that reloads its project graph on every save no longer grows without
+  bound. `dnit_project` now also resets the session's per-build module registries
+  (AST/sema/resolve/comptime/fqn and export/import maps), dropping the borrowed
+  references the freed Project leaves behind so one Session is reusable across
+  rebuilds. This is path-dedup + reclamation only; reusing untouched ASTs/resolve
+  results across a rebuild (true incremental rebuild) is tracked separately in
+  #1164 (#1389).
+
 ## [1.5.4] - 2026-06-14
 
 Stabilization + multi-target-prep release. Adds the multi-target union Project for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.5] - 2026-06-14
+
+Tooling-prep patch. Adds reload-friendly source handling so a long-lived session
+(e.g. the language server) can rebuild its project graph on every save without
+growing without bound, and completes the target-layer interner-elimination by
+dropping the now-dead interner parameter from `register_all` and every target
+registrar — the target vtables are now immutable singletons.
 
 ### Added
 
@@ -19,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rebuilds. This is path-dedup + reclamation only; reusing untouched ASTs/resolve
   results across a rebuild (true incremental rebuild) is tracked separately in
   #1164 (#1389).
+
+### Changed
+
+- target: `register_all` and the target registrars no longer take an interner (or
+  the vestigial allocator) parameter. The registrars set immutable `str` vtable
+  fields and intern nothing, so the parameter had been dead since the OS-vtable
+  interner-elimination — each registrar is now trimmed to exactly the registry it
+  installs into, and `mach info` no longer builds a throwaway interner to call them.
+  Behavior-preserving, verified by the byte-identical self-host fixpoint; completes
+  the interner-elimination begun in #1402 (#1418).
 
 ## [1.5.4] - 2026-06-14
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "1.5.4"
+version = "1.5.5"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -536,11 +536,9 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
     }
     var s: sess.Session = unwrap_ok[sess.Session, str](sess_r);
 
-    # populate the session's target registry from the session interner. the
-    # registrars intern each vtable's string fields (format/os/abi names) into it;
-    # the format writers no longer capture it — they resolve names through the
-    # interner each `ObjectImage` carries. register_all is idempotent.
-    val reg_r: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
+    # populate the session's target registry. register_all needs no interner —
+    # every vtable names itself with an immutable `str` constant. idempotent.
+    val reg_r: Result[bool, str] = tgt.register_all(?s.registry);
     if (is_err[bool, str](reg_r)) {
         print.eprint("error: ");
         print.eprint(unwrap_err[bool, str](reg_r));

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -466,7 +466,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     var s: sess.Session = unwrap_ok[sess.Session, str](sess_r);
 
-    val reg_r: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
+    val reg_r: Result[bool, str] = tgt.register_all(?s.registry);
     if (is_err[bool, str](reg_r)) {
         print.eprint("error: failed to register targets\n");
         sess.dnit(?s);

--- a/src/cli/cmd/info.mach
+++ b/src/cli/cmd/info.mach
@@ -25,12 +25,8 @@ use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 
-use std.allocator.Allocator;
-
-use page:  std.allocator.page;
 use print: std.print;
 
-use intern:  mach.lang.intern;
 use tgt:     mach.lang.target;
 use isa:     mach.lang.target.isa;
 use os:      mach.lang.target.os;
@@ -51,22 +47,14 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret 0;
     }
 
-    # an interner is needed to name the registries: each vtable holds its name as
-    # an interned id, and register_all interns those into the interner it is given.
-    var alloc: Allocator;
-    if (is_some[str](page.make(?alloc))) {
-        print.eprint("error: failed to initialise allocator\n");
-        ret 2;
-    }
-    var interner: intern.Interner = intern.init(?alloc);
-
+    # register_all needs no interner: each vtable names itself with an immutable
+    # `str` constant, read directly for the capability surface below.
     var reg: tgt.TargetRegistry = tgt.registry_init();
-    val reg_r: Result[bool, str] = tgt.register_all(?reg, ?interner);
+    val reg_r: Result[bool, str] = tgt.register_all(?reg);
     if (is_err[bool, str](reg_r)) {
         print.eprint("error: ");
         print.eprint(unwrap_err[bool, str](reg_r));
         print.eprint("\n");
-        intern.dnit(?interner);
         ret 2;
     }
 
@@ -82,7 +70,6 @@ pub fun run(argc: usize, argv: **u8) i64 {
     print.print("\n");
 
     val code: i64 = print_capabilities(?reg);
-    intern.dnit(?interner);
     ret code;
 }
 

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2908,7 +2908,7 @@ fun ut_build(s: *sess.Session, alloc: *Allocator, names: *str, texts: *str, n: u
     val root_r: Result[str, str] = ut_scaffold(alloc, names, texts, n);
     if (is_err[str, str](root_r)) { ret err[Project, str](unwrap_err[str, str](root_r)); }
     val root: str = unwrap_ok[str, str](root_r);
-    val rr: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
+    val rr: Result[bool, str] = tgt.register_all(?s.registry);
     if (is_err[bool, str](rr)) { fs.remove_all(alloc, root); ret err[Project, str](unwrap_err[bool, str](rr)); }
     val pr: Result[Project, str] = build_project_union(s, root);
     fs.remove_all(alloc, root);
@@ -3125,7 +3125,7 @@ test "driver union: a malformed branch condition is reported once, not once per 
     val root1_r: Result[str, str] = ut_scaffold(?a1, ?names[0], ?texts[0], 1);
     if (is_err[str, str](root1_r)) { sess.dnit(?s1); ret 1; }
     val root1: str = unwrap_ok[str, str](root1_r);
-    val rr1: Result[bool, str] = tgt.register_all(?s1.registry, ?s1.interner);
+    val rr1: Result[bool, str] = tgt.register_all(?s1.registry);
     if (is_err[bool, str](rr1)) { fs.remove_all(?a1, root1); sess.dnit(?s1); ret 1; }
     var sel: manifest.Selection;
     sel.target = ""; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false;
@@ -3208,7 +3208,7 @@ test "driver reload: a Session rebuilds after dnit_project, deduping changed sou
     if (is_err[sess.Session, str](sr)) { ret 1; }
     var s: sess.Session = unwrap_ok[sess.Session, str](sr);
 
-    val rr: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
+    val rr: Result[bool, str] = tgt.register_all(?s.registry);
     if (is_err[bool, str](rr)) { sess.dnit(?s); ret 1; }
 
     var names: [2]str;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -513,7 +513,9 @@ fun build_project_impl(s: *sess.Session, project_root: str, sel: *manifest.Selec
 
 # build_project_sel: build the module graph for one build selection (target,
 # profile, artifact). The manifest reader resolves the selection into the
-# project's single target entry and concrete output paths.
+# project's single target entry and concrete output paths. Safe to call
+# repeatedly on one long-lived Session: sources dedup by path and dnit_project
+# resets the session's module registries (see dnit_project's reload contract).
 pub fun build_project_sel(s: *sess.Session, project_root: str, sel: *manifest.Selection) Result[Project, str] {
     ret build_project_impl(s, project_root, sel, false);
 }
@@ -828,7 +830,18 @@ fun span_eq_span(source: str, a: token.Span, b: token.Span) bool {
     ret true;
 }
 
-# dnit_project: release every owned array on the project.
+# dnit_project: release every owned array on the project, then clear the session's
+# per-build module registries so the session is reusable for the next build.
+#
+# reload contract: a long-lived consumer (an LSP reloading on save) keeps ONE
+# Session and, per reload, calls build_project_sel / build_project_union, drives
+# the build, then dnit_project. sources dedup by path (source.load) so re-reading
+# the same closure reuses FileIds instead of growing the SourceMap, and this call's
+# reset_module_registry drops the borrowed AST/sema/resolve/comptime references the
+# freed Project leaves behind — so memory stays bounded and the session stays clean
+# across rebuilds. this does NOT reuse untouched ASTs/resolve results across builds
+# (true incremental rebuild is tracked separately in #1164); each reload re-parses
+# and re-resolves the full closure.
 # ---
 # p: project to tear down; nil is a no-op
 pub fun dnit_project(p: *Project) {
@@ -863,6 +876,10 @@ pub fun dnit_project(p: *Project) {
     }
     map.dnit[intern.StrId, sess.ModuleId](?p.by_fqn);
     deallocate_config(?p.config, p.s.alloc);
+
+    # the freed Project leaves the session's module registries pointing at freed
+    # AST/sema/resolve/comptime storage; clear them so the session is reusable.
+    sess.reset_module_registry(p.s);
 }
 
 fun init_project(p: *Project, s: *sess.Session) {
@@ -3180,6 +3197,65 @@ test "driver union: branch selection via the $target.os string tag exercises and
     or (cm.target_abi != cb.target_abi)      { bad = 1; }
 
     dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver reload: a Session rebuilds after dnit_project, deduping changed sources by path (#1389)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    val rr: Result[bool, str] = tgt.register_all(?s.registry, ?s.interner);
+    if (is_err[bool, str](rr)) { sess.dnit(?s); ret 1; }
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "a.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.a;\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+
+    # materialize the project once; both builds run against this same root so the
+    # changed file keeps its path and dedups instead of growing the SourceMap.
+    val root_r: Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (is_err[str, str](root_r)) { sess.dnit(?s); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    # first build.
+    val p1r: Result[Project, str] = build_project_union(?s, root);
+    if (is_err[Project, str](p1r)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+    var p1: Project = unwrap_ok[Project, str](p1r);
+    if (!ut_has(?p1, ?s, "uniontest.main")) { bad = 1; }
+    or (!ut_has(?p1, ?s, "uniontest.a"))    { bad = 1; }
+    val len1: usize = s.sources.len;
+    if (len1 == 0) { bad = 1; }
+    dnit_project(?p1);
+
+    # change a.mach's content in place (same path), then rebuild on the SAME session.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val a_path: str = ut_cc3(?alloc, src_dir, "/", "a.mach");
+    val new_a: str = "pub fun fa() i32 { ret 2; }\n";
+    val wr: Result[bool, str] = fs.write_file(a_path, new_a, str_len(new_a), 420);
+    if (is_err[bool, str](wr)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+
+    # second build on the reused session must succeed and stay valid.
+    val p2r: Result[Project, str] = build_project_union(?s, root);
+    if (is_err[Project, str](p2r)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+    var p2: Project = unwrap_ok[Project, str](p2r);
+    if (!ut_has(?p2, ?s, "uniontest.main")) { bad = 1; }
+    or (!ut_has(?p2, ?s, "uniontest.a"))    { bad = 1; }
+    val len2: usize = s.sources.len;
+
+    # every path is identical across the two builds (the changed file reuses its
+    # FileId via dedup), so the SourceMap did NOT grow: a long-lived session is bounded.
+    if (len2 != len1) { bad = 1; }
+
+    dnit_project(?p2);
+    fs.remove_all(?alloc, root);
     sess.dnit(?s);
     ret bad;
 }

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -188,6 +188,40 @@ pub fun dnit(s: *Session) {
     source.dnit(?s.sources);
 }
 
+# reset_module_registry: clear the per-build module registries so the session can
+# be reused for a fresh build. frees the module-AST array (reallocated lazily on
+# the next register_module_ast) and empties every per-build map.
+#
+# the module_sema/resolve/comptime maps hold BORROWED pointers into Project-owned
+# storage that the driver frees in dnit_project; the FQN / export / import maps are
+# keyed by per-build ModuleId/DeclId. NONE of the values are session-owned (they are
+# StrIds interned in the session's persistent interner, or borrowed Project pointers
+# already freed by the caller), so map.clear is used throughout — it empties the
+# slots while leaving value storage untouched, never freeing a borrowed pointer or a
+# live interned string. clearing the export/import maps too keeps a reused session
+# from inheriting a prior build's overrides for a ModuleId/DeclId the next build
+# repurposes. call this at the END of a project teardown (after the Project frees),
+# so the next build starts from a clean registry rather than entries pointing at
+# freed Project storage.
+# ---
+# s: the session whose module registries are emptied
+pub fun reset_module_registry(s: *Session) {
+    if (s == nil) { ret; }
+    if (s.module_asts != nil && s.module_ast_cap > 0) {
+        deallocate[*ast.Ast](s.alloc, s.module_asts, s.module_ast_cap::usize);
+    }
+    s.module_asts      = nil;
+    s.module_ast_count = 0;
+    s.module_ast_cap   = 0;
+    map.clear[modid.ModuleId, intern.StrId](?s.module_fqns);
+    map.clear[u64, intern.StrId](?s.export_names);
+    map.clear[u64, intern.StrId](?s.export_libraries);
+    map.clear[intern.StrId, intern.StrId](?s.import_libraries);
+    map.clear[modid.ModuleId, ptr](?s.module_sema);
+    map.clear[modid.ModuleId, ptr](?s.module_resolve);
+    map.clear[modid.ModuleId, ptr](?s.module_comptime);
+}
+
 # register_module_ast: record `a` as the AST of module `mid` in the session
 # registry, growing it to cover `mid` and zero-filling any gap. the registry
 # borrows `a`; the caller (the driver) owns the storage and must keep it alive
@@ -425,13 +459,16 @@ pub fun module_comptime_ptr(s: *Session, mid: modid.ModuleId) ptr {
 }
 
 # load_source: register a source file with the session and return its FileId.
-# delegates to source.add, which bumps s.queries.revision so derived
-# entries depending on this file invalidate.
+# delegates to source.load, which dedups by path: a path loaded for the first
+# time is appended, a path already loaded reuses its FileId and is text-swapped
+# in place — so a long-lived session (an LSP reloading on save) does not grow on
+# reload. either path bumps s.queries.revision so derived entries depending on
+# this file invalidate.
 # ---
 # s:    the session
 # path: file path to associate with this file
 # text: null-terminated source text to index and store
-# ret:  FileId of the newly added file, or an allocation error
+# ret:  FileId the path is registered under (stable across reloads of the same path), or an allocation error
 pub fun load_source(s: *Session, path: str, text: str) Result[source.FileId, str] {
-    ret source.add(?s.sources, ?s.queries, path, text);
+    ret source.load(?s.sources, ?s.queries, ?s.interner, path, text);
 }

--- a/src/lang/source.mach
+++ b/src/lang/source.mach
@@ -28,8 +28,13 @@ use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
+use page: std.allocator.page;
 
-use query: mach.lang.query;
+use map:     std.collections.map;
+use maphash: std.collections.map;
+
+use query:  mach.lang.query;
+use intern: mach.lang.intern;
 
 # FileId: stable handle into a SourceMap's file array.
 pub def FileId: u32;
@@ -60,15 +65,18 @@ pub rec SourceFile {
 
 # SourceMap: registry of loaded source files indexed by FileId.
 # ---
-# alloc: allocator used for all owned storage in this map
-# files: contiguous array of SourceFile records
-# len:   number of files currently stored
-# cap:   allocated slots in files
+# alloc:   allocator used for all owned storage in this map
+# files:   contiguous array of SourceFile records
+# len:     number of files currently stored
+# cap:     allocated slots in files
+# by_path: interned path StrId -> FileId index, maintained by load() so a path
+#          re-loaded in a long-lived session reuses its FileId instead of appending
 pub rec SourceMap {
-    alloc: *Allocator;
-    files: *SourceFile;
-    len:   usize;
-    cap:   usize;
+    alloc:   *Allocator;
+    files:   *SourceFile;
+    len:     usize;
+    cap:     usize;
+    by_path: map.Map[intern.StrId, FileId];
 }
 
 val INITIAL_MAP_CAP: usize = 8;
@@ -79,10 +87,11 @@ val INITIAL_MAP_CAP: usize = 8;
 # ret:   a new empty SourceMap
 pub fun init(alloc: *Allocator) SourceMap {
     var m: SourceMap;
-    m.alloc = alloc;
-    m.files = nil;
-    m.len   = 0;
-    m.cap   = 0;
+    m.alloc   = alloc;
+    m.files   = nil;
+    m.len     = 0;
+    m.cap     = 0;
+    m.by_path = map.init[intern.StrId, FileId](alloc, maphash.hash_u32, maphash.eq_u32);
     ret m;
 }
 
@@ -106,6 +115,7 @@ pub fun dnit(m: *SourceMap) {
     if (m.files != nil && m.cap > 0) {
         deallocate[SourceFile](m.alloc, m.files, m.cap);
     }
+    map.dnit[intern.StrId, FileId](?m.by_path);
     m.files = nil;
     m.len   = 0;
     m.cap   = 0;
@@ -263,6 +273,42 @@ pub fun update(m: *SourceMap, db: *query.QueryDb, id: FileId, text: str) Result[
     ret ok[bool, str](true);
 }
 
+# load: register a source file deduped by path. dedups by path: re-loading a
+# path returns its existing FileId and updates the text in place, so a long-lived
+# session (e.g. an LSP reloading project graphs on save) does not grow on reload.
+# a path seen for the first time appends a new file via add(); a path already
+# known is text-swapped in place via update() (id-stable, revision-bumping). the
+# by_path index is maintained only here; add/update remain raw primitives.
+# ---
+# m:        the source map
+# db:       query database whose revision is bumped so derived entries invalidate
+# interner: interner the path is interned into for the by_path lookup key
+# path:     file path to load
+# text:     source text to index and store; the stored copy is null-terminated
+# ret:      the FileId the path is registered under (stable across reloads of the same path), or an error
+pub fun load(m: *SourceMap, db: *query.QueryDb, interner: *intern.Interner, path: str, text: str) Result[FileId, str] {
+    val pid_r: Result[intern.StrId, str] = intern.intern(interner, path);
+    if (is_err[intern.StrId, str](pid_r)) {
+        ret err[FileId, str](unwrap_err[intern.StrId, str](pid_r));
+    }
+    var pid: intern.StrId = unwrap_ok[intern.StrId, str](pid_r);
+
+    val existing: Result[*FileId, str] = map.get[intern.StrId, FileId](?m.by_path, ?pid);
+    if (is_err[*FileId, str](existing)) {
+        val add_r: Result[FileId, str] = add(m, db, path, text);
+        if (is_err[FileId, str](add_r)) { ret add_r; }
+        val fid: FileId = unwrap_ok[FileId, str](add_r);
+        val ins_r: Result[bool, str] = map.insert[intern.StrId, FileId](?m.by_path, pid, fid);
+        if (is_err[bool, str](ins_r)) { ret err[FileId, str](unwrap_err[bool, str](ins_r)); }
+        ret ok[FileId, str](fid);
+    }
+
+    val fid: FileId = @unwrap_ok[*FileId, str](existing);
+    val up_r: Result[bool, str] = update(m, db, fid, text);
+    if (is_err[bool, str](up_r)) { ret err[FileId, str](unwrap_err[bool, str](up_r)); }
+    ret ok[FileId, str](fid);
+}
+
 # get: return a pointer to the SourceFile for a given FileId.
 # ---
 # m:   the source map
@@ -339,4 +385,45 @@ pub fun line_bounds(file: *SourceFile, line: usize) Option[LineSpan] {
     ls.start = start;
     ls.end   = end;
     ret some[LineSpan](ls);
+}
+
+test "source: load dedups by path, reusing the FileId and swapping text in place (#1389)" {
+    var a: Allocator;
+    page.make(?a);
+
+    val qr: Result[query.QueryDb, str] = query.init(?a);
+    if (is_err[query.QueryDb, str](qr)) { ret 1; }
+    var db: query.QueryDb = unwrap_ok[query.QueryDb, str](qr);
+    var ix: intern.Interner = intern.init(?a);
+    var m: SourceMap = init(?a);
+
+    val r1: Result[FileId, str] = load(?m, ?db, ?ix, "p1.mach", "a");
+    if (is_err[FileId, str](r1)) { ret 1; }
+    val fid1: FileId = unwrap_ok[FileId, str](r1);
+
+    # re-loading the SAME path returns the SAME FileId, updates text, no growth.
+    val r2: Result[FileId, str] = load(?m, ?db, ?ix, "p1.mach", "b");
+    if (is_err[FileId, str](r2)) { ret 1; }
+    val fid2: FileId = unwrap_ok[FileId, str](r2);
+
+    if (fid1 != fid2) { ret 1; }
+    if (m.by_path.len != 1) { ret 1; }
+    if (m.len != 1) { ret 1; }
+
+    val f1: *SourceFile = ?m.files[fid1::usize];
+    if (str_len(f1.text) != 1) { ret 1; }
+    if (f1.text[0] != 'b') { ret 1; }
+
+    # a DIFFERENT path appends a distinct new FileId, growing the map.
+    val r3: Result[FileId, str] = load(?m, ?db, ?ix, "p2.mach", "c");
+    if (is_err[FileId, str](r3)) { ret 1; }
+    val fid3: FileId = unwrap_ok[FileId, str](r3);
+    if (fid3 == fid1) { ret 1; }
+    if (m.by_path.len != 2) { ret 1; }
+    if (m.len != 2) { ret 1; }
+
+    dnit(?m);
+    intern.dnit(?ix);
+    query.dnit(?db);
+    ret 0;
 }

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -22,11 +22,6 @@ use std.types.string.str;
 use std.types.bool.bool;
 use std.types.bool.true;
 
-use std.allocator.Allocator;
-
-use page:   std.allocator.page;
-use intern: mach.lang.intern;
-
 use tdef: mach.lang.target.resolved;
 use isa: mach.lang.target.isa;
 use abi: mach.lang.target.abi;
@@ -158,42 +153,41 @@ pub fun registry_init() TargetRegistry {
 # (arm64, win64, coff, mach-o, darwin, windows) so `select` reports an
 # unsupported pair rather than a missing registration. must be called once at
 # startup, before any `select` against `reg`, so the registries are populated.
-# every registrar is idempotent, so a redundant call is harmless. the
-# allocator threaded into the registrars that take one for parity is read from
-# the interner.
+# every registrar is idempotent, so a redundant call is harmless. no interner is
+# needed: vtable string fields are immutable `str` constants, interned at the
+# point of use in the linker and object-format consumers.
 # ---
 # reg: the target registry to install every implementation into
-# i:   interner used to intern each implementation's string fields
 # ret: ok(true) once every implementation is registered, or the first error
-pub fun register_all(reg: *TargetRegistry, i: *intern.Interner) Result[bool, str] {
-    val r_x64: Result[bool, str] = x64.register_x64(?reg.isa, i.alloc, i);
+pub fun register_all(reg: *TargetRegistry) Result[bool, str] {
+    val r_x64: Result[bool, str] = x64.register_x64(?reg.isa);
     if (is_err[bool, str](r_x64)) { ret err[bool, str](unwrap_err[bool, str](r_x64)); }
 
-    val r_arm64: Result[bool, str] = arm64.register_arm64(?reg.isa, i.alloc, i);
+    val r_arm64: Result[bool, str] = arm64.register_arm64(?reg.isa);
     if (is_err[bool, str](r_arm64)) { ret err[bool, str](unwrap_err[bool, str](r_arm64)); }
 
-    val r_sysv: Result[bool, str] = sysv.register(?reg.abi, i);
+    val r_sysv: Result[bool, str] = sysv.register(?reg.abi);
     if (is_err[bool, str](r_sysv)) { ret err[bool, str](unwrap_err[bool, str](r_sysv)); }
 
-    val r_win64: Result[bool, str] = win64.register_win64(?reg.abi, i.alloc, i);
+    val r_win64: Result[bool, str] = win64.register_win64(?reg.abi);
     if (is_err[bool, str](r_win64)) { ret err[bool, str](unwrap_err[bool, str](r_win64)); }
 
-    val r_elf: Result[bool, str] = elf.register(?reg.of, i);
+    val r_elf: Result[bool, str] = elf.register(?reg.of);
     if (is_err[bool, str](r_elf)) { ret err[bool, str](unwrap_err[bool, str](r_elf)); }
 
-    val r_coff: Result[bool, str] = coff.register_coff(?reg.of, i);
+    val r_coff: Result[bool, str] = coff.register_coff(?reg.of);
     if (is_err[bool, str](r_coff)) { ret err[bool, str](unwrap_err[bool, str](r_coff)); }
 
-    val r_macho: Result[bool, str] = macho.register_macho(?reg.of, i);
+    val r_macho: Result[bool, str] = macho.register_macho(?reg.of);
     if (is_err[bool, str](r_macho)) { ret err[bool, str](unwrap_err[bool, str](r_macho)); }
 
-    val r_linux: Result[bool, str] = linux.register_linux(?reg.os, i.alloc, i);
+    val r_linux: Result[bool, str] = linux.register_linux(?reg.os);
     if (is_err[bool, str](r_linux)) { ret err[bool, str](unwrap_err[bool, str](r_linux)); }
 
-    val r_darwin: Result[bool, str] = darwin.register_darwin(?reg.os, i.alloc, i);
+    val r_darwin: Result[bool, str] = darwin.register_darwin(?reg.os);
     if (is_err[bool, str](r_darwin)) { ret err[bool, str](unwrap_err[bool, str](r_darwin)); }
 
-    val r_windows: Result[bool, str] = windows.register_windows(?reg.os, i.alloc, i);
+    val r_windows: Result[bool, str] = windows.register_windows(?reg.os);
     if (is_err[bool, str](r_windows)) { ret err[bool, str](unwrap_err[bool, str](r_windows)); }
 
     ret ok[bool, str](true);
@@ -254,12 +248,8 @@ pub fun select(reg: *TargetRegistry, os_id: u32, arch_id: u32) Result[tdef.Targe
 # id-keyed lookups after register_all, and report none past the count. the
 # `mach info` capability surface reads the registries through exactly this pair.
 test "target: registry enumeration agrees with lookup (#1312)" {
-    var alloc: Allocator;
-    page.make(?alloc);
-    var i: intern.Interner = intern.init(?alloc);
-
     var reg: TargetRegistry = registry_init();
-    val rr: Result[bool, str] = register_all(?reg, ?i);
+    val rr: Result[bool, str] = register_all(?reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     # the supported implementations are all enumerable.

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -22,7 +22,6 @@ use std.types.bool.true;
 use std.types.bool.false;
 use std.types.string.str;
 
-use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 use abi:    mach.lang.target.abi;
 
@@ -460,17 +459,15 @@ var sysv_vtable: abi.AbiVTable;
 
 # register: build the SysV AMD64 AbiVTable and install it into `reg`.
 #
-# interns the convention name ("sysv"), wires the type-erased classify/arg/ret
-# operation pointers and the GP/FP argument-register and callee-saved register
-# file accessors, sets the 16-byte stack alignment and 128-byte red zone, and
-# registers it under abi.ABI_SYSV so target.select can find it through
-# abi.lookup. re-interns the name into `i` on every call (the registry entry is
-# write-once) so a later build with a fresh interner gets a consistent id.
+# sets the convention name ("sysv") as an immutable `str` constant, wires the
+# type-erased classify/arg/ret operation pointers and the GP/FP argument-register
+# and callee-saved register file accessors, sets the 16-byte stack alignment and
+# 128-byte red zone, and registers it under abi.ABI_SYSV so target.select can find
+# it through abi.lookup. idempotent: the registry entry is write-once.
 # ---
 # reg: the ABI registry to install the vtable into
-# i:   interner used to intern the vtable's string fields
-# ret: ok(true) on success, or an allocation error from interning
-pub fun register(reg: *abi.AbiRegistry, i: *intern.Interner) Result[bool, str] {
+# ret: ok(true) on success
+pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
 
     sysv_vtable.id           = abi.ABI_SYSV;
     sysv_vtable.name         = "sysv";

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -25,9 +25,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 use abi:    mach.lang.target.abi;
 use x64:    mach.lang.target.isa.x64;
@@ -442,19 +439,16 @@ var win64_vtable: abi.AbiVTable;
 
 # register_win64: build and install the win64 AbiVTable.
 #
-# interns the convention name ("win64"), wires the type-erased classify/arg/ret
-# operation pointers and the gp_arg_regs / fp_arg_regs / callee_saved register-
-# file accessors, sets the stack alignment (16) and red-zone size (0), and
-# installs it into `reg` under abi.ABI_WIN64. re-interns the name into `i` on
-# every call (the registry entry is write-once) so a later build with a fresh
-# interner gets a consistent id. must be invoked at startup before target.select
-# requests a Windows target.
+# sets the convention name ("win64") as an immutable `str` constant, wires the
+# type-erased classify/arg/ret operation pointers and the gp_arg_regs /
+# fp_arg_regs / callee_saved register-file accessors, sets the stack alignment
+# (16) and red-zone size (0), and installs it into `reg` under abi.ABI_WIN64.
+# idempotent: the registry entry is write-once. must be invoked at startup before
+# target.select requests a Windows target.
 # ---
-# reg:   the ABI registry to install the vtable into
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields
-# ret:   true on success, or an error string if name interning fails
-pub fun register_win64(reg: *abi.AbiRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# reg: the ABI registry to install the vtable into
+# ret: true on success
+pub fun register_win64(reg: *abi.AbiRegistry) Result[bool, str] {
 
     win64_vtable.id           = abi.ABI_WIN64;
     win64_vtable.name         = "win64";

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -23,9 +23,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 
 # number of general-purpose registers exposed (X0–X30; SP/XZR are not
@@ -61,21 +58,18 @@ var arm64_vtable: isa.IsaVTable;
 
 # register_arm64: build and install the AArch64 IsaVTable.
 #
-# interns the arch name and register-class names, fills the module-level
-# register-class table (gpr 64×31, vector 128×32, flags 64×1) and vtable with
-# 8-byte pointers, little-endian byte order, the reserved registers (SP/FP), the
-# scratch register identities (IP0/IP1/V31), the frame/stack pointers (FP/SP), -1
-# for the division / shift register identities (AArch64 wires none), and nil
-# select/encode entry points, and installs it into `reg` under isa.ARCH_AARCH64.
-# re-interns the names into `i` on every call (the registry entry is write-once)
-# so a later build with a fresh interner gets consistent ids. must be invoked at
-# startup before target.select requests an AArch64 target.
+# sets the arch name and register-class names as immutable `str` constants, fills
+# the module-level register-class table (gpr 64×31, vector 128×32, flags 64×1) and
+# vtable with 8-byte pointers, little-endian byte order, the reserved registers
+# (SP/FP), the scratch register identities (IP0/IP1/V31), the frame/stack pointers
+# (FP/SP), -1 for the division / shift register identities (AArch64 wires none),
+# and nil select/encode entry points, and installs it into `reg` under
+# isa.ARCH_AARCH64. idempotent: the registry entry is write-once. must be invoked
+# at startup before target.select requests an AArch64 target.
 # ---
-# reg:   the ISA registry to install the vtable into
-# alloc: backing allocator (reserved for parity with other registrars)
-# i:     string interner used to intern the vtable's string fields
-# ret:   true on success, or an error string if name interning fails
-pub fun register_arm64(reg: *isa.IsaRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# reg: the ISA registry to install the vtable into
+# ret: true on success
+pub fun register_arm64(reg: *isa.IsaRegistry) Result[bool, str] {
 
     arm64_reg_classes[0].name      = "gpr";
     arm64_reg_classes[0].bit_width = 64;

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -20,9 +20,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 use x64:        mach.lang.target.isa.x64;
 use x64isel:    mach.lang.target.isa.x64.isel;
@@ -59,17 +56,16 @@ var x64_reload_scratch_regs: [3]isa.Register;
 
 # register_x64: build and install the x86-64 ISA vtable.
 #
-# interns the architecture and register-class names, fills the three register
-# classes (gpr 64×16, xmm 128×16, flags 64×1), populates the vtable with the
-# pointer width (8), little-endian byte order, the reserved registers (RSP/RBP),
-# the scratch register identities (R11/R10/XMM15), the frame/stack pointers
-# (RBP/RSP) the shared MIR lowering names when forming stack memory operands, and
-# the fixed division accumulator / high-half (RAX/RDX) and variable-shift count
-# (RCX) registers the x86-64 IDIV/DIV and shift forms hard-wire, and installs it
-# into `reg`. re-interns the names into `interner` on every call (the registry
-# entry is write-once) so a later build with a fresh interner gets consistent
-# ids. must be invoked at compiler startup before `target.select` requests an
-# x86-64 target.
+# sets the architecture and register-class names as immutable `str` constants,
+# fills the three register classes (gpr 64×16, xmm 128×16, flags 64×1), populates
+# the vtable with the pointer width (8), little-endian byte order, the reserved
+# registers (RSP/RBP), the scratch register identities (R11/R10/XMM15), the
+# frame/stack pointers (RBP/RSP) the shared MIR lowering names when forming stack
+# memory operands, and the fixed division accumulator / high-half (RAX/RDX) and
+# variable-shift count (RCX) registers the x86-64 IDIV/DIV and shift forms
+# hard-wire, and installs it into `reg`. idempotent: the registry entry is
+# write-once. must be invoked at compiler startup before `target.select` requests
+# an x86-64 target.
 #
 # the `select` and `encode` operation entry points are the x86-64 instruction
 # selector (`x64/isel.mach`) and byte encoder (`x64/encode.mach`), stored
@@ -79,11 +75,9 @@ var x64_reload_scratch_regs: [3]isa.Register;
 # and encoding logic lives under this module and is reached only through these
 # vtable slots; the shared backend drivers carry no x86-64 knowledge.
 # ---
-# reg:      the ISA registry to install the vtable into
-# alloc:    backing allocator (reserved for parity with other registrars)
-# interner: string interner used to intern the architecture and class names
-# ret:      true on success, or an error string if name interning fails
-pub fun register_x64(reg: *isa.IsaRegistry, alloc: *Allocator, interner: *intern.Interner) Result[bool, str] {
+# reg: the ISA registry to install the vtable into
+# ret: true on success
+pub fun register_x64(reg: *isa.IsaRegistry) Result[bool, str] {
 
     x64_classes[0].name      = "gpr";
     x64_classes[0].bit_width = 64;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2731,21 +2731,18 @@ var coff_vtable: of.OfVTable;
 
 # register_coff: build and install the COFF OfVTable.
 #
-# interns the format name ("coff") and file extension ("obj") into the vtable's
-# string fields, wires the writer/reader, and installs it into `reg` under
-# of.OF_COFF. reentrant: every call re-interns the names against `i`, so a second
-# session (or test) with a different interner is consistent rather than leaving
-# stale ids; `of.register` itself is idempotent. the reader/writer no longer
-# capture an interner — they resolve names through the `interner` each
+# sets the format name ("coff") as an immutable `str` constant in the vtable,
+# wires the writer/reader, and installs it into `reg` under of.OF_COFF.
+# idempotent: `of.register` overwrites the write-once entry. the reader/writer
+# capture no interner — they resolve names through the `interner` each
 # `ObjectImage` carries (and the one passed to parse/dyn-exec) — and relocation
 # kinds are a closed `of.RK_*` enum the writer maps with a plain integer compare.
 # must be invoked at compiler startup before target.select requests a Windows
 # target.
 # ---
 # reg: the object-format registry to install the vtable into
-# i:   string interner used to intern the vtable's string fields
-# ret: true on success, or an error string if name interning fails
-pub fun register_coff(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
+# ret: true on success
+pub fun register_coff(reg: *of.OfRegistry) Result[bool, str] {
     coff_vtable.id               = of.OF_COFF;
     coff_vtable.name             = "coff";
     coff_vtable.emit_object      = coff_emit_object;
@@ -2770,11 +2767,10 @@ test "coff: emit/parse round-trips an ObjectImage and writes a valid header" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    # register_coff captures `i` as the reader/writer interner and interns the
-    # relocation-kind names into it; the kind StrIds resolve against this same
-    # interner below.
+    # the image below carries `i`; the reader/writer resolve names through it, and
+    # the section/symbol StrIds interned into it resolve against this same interner.
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -2956,7 +2952,7 @@ test "coff: REL32 addend translates the COFF P+4 convention at parse and emit (#
     # recovers A_elf = 4 - 4 = 0. a `call`'s -4 addend folds to 0 the same way.
     var i: intern.Interner = intern.init(?alloc);
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3031,7 +3027,7 @@ test "coff: emit rejects a relocation naming an unresolved symbol (#1196)" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3089,7 +3085,7 @@ test "coff: a defined weak symbol round-trips its weak flag through a COMDAT sec
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3227,7 +3223,7 @@ test "coff: long section and symbol names round-trip through the string table" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3298,7 +3294,7 @@ test "coff: emit_exec writes a well-formed PE32+ header" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3382,7 +3378,7 @@ test "coff: a function-flagged call-target import round-trips DT_FUNCTION" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3459,7 +3455,7 @@ test "coff: parse infers function imports from a foreign object's call relocatio
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3537,7 +3533,7 @@ test "coff: emit_exec emits .xdata/.pdata for a canonical x64 prologue" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3796,7 +3792,7 @@ test "coff: emit rejects a relocation whose kind has no COFF machine type (#1256
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3848,7 +3844,7 @@ test "coff: parse rejects a foreign ADDR32 relocation type (#1256)" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3914,7 +3910,7 @@ test "coff: emit rejects a section reloc count above the u16 limit (#1256)" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     val vt_o: Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
@@ -3978,7 +3974,7 @@ test "coff: parse rejects a truncated object instead of reading out of bounds (#
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register_coff(?of_reg, ?i);
+    val rr: Result[bool, str] = register_coff(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -753,18 +753,15 @@ var elf_vtable: of.OfVTable;
 
 # register: build the ELF OfVTable and install it into `reg`.
 #
-# interns the format name ("elf") and extension ("o") into the vtable's string
-# fields and registers it under `of.OF_ELF`. reentrant: every call re-interns the
-# names against `i`, so a second session (or test) with a different interner is
-# consistent rather than left with stale ids; `of.register` is itself idempotent.
-# the writer no longer captures an interner — it resolves names through the
+# sets the format name ("elf") as an immutable `str` constant in the vtable and
+# registers it under `of.OF_ELF`. idempotent: `of.register` overwrites the
+# write-once entry. the writer captures no interner — it resolves names through the
 # `interner` each `ObjectImage` carries — and relocation kinds are a closed
 # `of.RK_*` enum the writer maps with a plain integer compare.
 # ---
 # reg: the object-format registry to install the vtable into
-# i:   interner used to intern the vtable's string fields
-# ret: ok(true) on success, or an allocation error from interning
-pub fun register(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
+# ret: ok(true) on success
+pub fun register(reg: *of.OfRegistry) Result[bool, str] {
     elf_vtable.id               = of.OF_ELF;
     elf_vtable.name             = "elf";
     elf_vtable.emit_object      = emit_object;
@@ -1950,9 +1947,9 @@ test "elf: emit rejects a relocation naming an unresolved symbol (#1196)" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    # register captures `i` as the writer interner so names resolve against it.
+    # the image below carries `i`; the writer resolves names through it.
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register(?of_reg, ?i);
+    val rr: Result[bool, str] = register(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -2005,7 +2002,7 @@ test "elf: emit rejects a relocation whose kind has no ELF machine type (#1256)"
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register(?of_reg, ?i);
+    val rr: Result[bool, str] = register(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -2058,7 +2055,7 @@ test "elf: parse rejects an unknown machine relocation type (#1256)" {
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register(?of_reg, ?i);
+    val rr: Result[bool, str] = register(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -2130,7 +2127,7 @@ test "elf: parse rejects a truncated object instead of reading out of bounds (#1
     var i: intern.Interner = intern.init(?alloc);
 
     var of_reg: of.OfRegistry = of.registry_init();
-    val rr: Result[bool, str] = register(?of_reg, ?i);
+    val rr: Result[bool, str] = register(?of_reg);
     if (is_err[bool, str](rr)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -90,18 +90,15 @@ var macho_vtable: of.OfVTable;
 
 # register_macho: build and install the Mach-O OfVTable.
 #
-# interns the format name ("macho") and file extension ("o"), fills the vtable,
+# sets the format name ("macho") as an immutable `str` constant, fills the vtable,
 # wires the (stub) writer, and installs it into `reg` under of.OF_MACHO.
-# reentrant: every call re-interns the names against `i` so a second session (or
-# test) with a different interner is consistent rather than left with stale ids;
-# `of.register` is itself idempotent. abstract relocation kinds are a closed
-# `of.RK_*` enum, so no per-format kind table is interned. must be invoked at
-# compiler startup before target.select requests a Darwin target.
+# idempotent: `of.register` overwrites the write-once entry. abstract relocation
+# kinds are a closed `of.RK_*` enum, so no per-format kind table is interned. must
+# be invoked at compiler startup before target.select requests a Darwin target.
 # ---
 # reg: the object-format registry to install the vtable into
-# i:   string interner used to intern the vtable's string fields
-# ret: true on success, or an error string if name interning fails
-pub fun register_macho(reg: *of.OfRegistry, i: *intern.Interner) Result[bool, str] {
+# ret: true on success
+pub fun register_macho(reg: *of.OfRegistry) Result[bool, str] {
     macho_vtable.id               = of.OF_MACHO;
     macho_vtable.name             = "macho";
     macho_vtable.emit_object      = macho_emit_object;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -21,9 +21,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
 
 # default base virtual address for Darwin executables (4 GiB).
@@ -40,15 +37,13 @@ var darwin_vtable: os.OsVTable;
 #
 # sets the os name, entry symbol ("_main"), syscall layer, and default library
 # directory as plain str constants, fills the module-level vtable, and installs it
-# into `reg` under os.OS_DARWIN. the vtable strings are no longer interned here —
-# the linker interns the ones it needs at the point of use (#1402). must be invoked
-# at startup before target.select requests a Darwin target.
+# into `reg` under os.OS_DARWIN. the vtable strings are not interned here — the
+# linker interns the ones it needs at the point of use (#1402). must be invoked at
+# startup before target.select requests a Darwin target.
 # ---
-# reg:   the OS registry to install the vtable into
-# alloc: backing allocator (unused; retained for registrar-signature parity)
-# i:     interner (unused; retained for registrar-signature parity)
-# ret:   true (always; the Result return is kept for registrar-signature parity)
-pub fun register_darwin(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# reg: the OS registry to install the vtable into
+# ret: true (always; the Result return is kept for registrar-signature parity)
+pub fun register_darwin(reg: *os.OsRegistry) Result[bool, str] {
 
     darwin_vtable.id             = os.OS_DARWIN;
     darwin_vtable.name           = "darwin";

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -20,9 +20,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
 
 # default base virtual address for Linux executables. the first PT_LOAD
@@ -50,15 +47,13 @@ var linux_vtable: os.OsVTable;
 # sets the os name, entry symbol ("_start"), syscall layer, and default library
 # directory as plain str constants, fills the module-level vtable (including the
 # 0x400000 base address and 4096-byte page), and installs it into `reg` under
-# os.OS_LINUX. the vtable strings are no longer interned here — the linker interns
-# the ones it needs at the point of use (#1402). must be invoked at startup before
+# os.OS_LINUX. the vtable strings are not interned here — the linker interns the
+# ones it needs at the point of use (#1402). must be invoked at startup before
 # target.select requests a Linux target.
 # ---
-# reg:   the OS registry to install the vtable into
-# alloc: backing allocator (unused; retained for registrar-signature parity)
-# i:     interner (unused; retained for registrar-signature parity)
-# ret:   true (always; the Result return is kept for registrar-signature parity)
-pub fun register_linux(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# reg: the OS registry to install the vtable into
+# ret: true (always; the Result return is kept for registrar-signature parity)
+pub fun register_linux(reg: *os.OsRegistry) Result[bool, str] {
 
     linux_vtable.id             = os.OS_LINUX;
     linux_vtable.name           = "linux";

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -21,9 +21,6 @@ use std.types.bool.false;
 
 use std.types.string.str;
 
-use std.allocator.Allocator;
-
-use intern: mach.lang.intern;
 use os:     mach.lang.target.os;
 
 # default ImageBase for Windows x86_64 executables (64 KiB-aligned). the PE
@@ -42,15 +39,13 @@ var windows_vtable: os.OsVTable;
 #
 # sets the os name, entry symbol ("mainCRTStartup"), syscall layer, and default
 # library directory as plain str constants, fills the module-level vtable, and
-# installs it into `reg` under os.OS_WINDOWS. the vtable strings are no longer
-# interned here — the linker interns the ones it needs at the point of use (#1402).
-# must be invoked at startup before target.select requests a Windows target.
+# installs it into `reg` under os.OS_WINDOWS. the vtable strings are not interned
+# here — the linker interns the ones it needs at the point of use (#1402). must be
+# invoked at startup before target.select requests a Windows target.
 # ---
-# reg:   the OS registry to install the vtable into
-# alloc: backing allocator (unused; retained for registrar-signature parity)
-# i:     interner (unused; retained for registrar-signature parity)
-# ret:   true (always; the Result return is kept for registrar-signature parity)
-pub fun register_windows(reg: *os.OsRegistry, alloc: *Allocator, i: *intern.Interner) Result[bool, str] {
+# reg: the OS registry to install the vtable into
+# ret: true (always; the Result return is kept for registrar-signature parity)
+pub fun register_windows(reg: *os.OsRegistry) Result[bool, str] {
 
     windows_vtable.id             = os.OS_WINDOWS;
     windows_vtable.name           = "windows";


### PR DESCRIPTION
Integration merge of `dev` into `main` for the **v1.5.5** patch release.

- #1389 Part A — reload-friendly driver API (source path-dedup + session-registry reclamation) for long-lived tooling (PR #1427).
- #1418 — drop the now-dead interner/allocator parameter from `register_all` and every target registrar; completes the interner-elimination begun in #1402 (PR #1428).

Behavior-preserving; byte-identical self-host fixpoint. Tag `v1.5.5` follows this merge to trigger the release workflow.