### PR TITLE
feat(target): aarch64 backend skeleton + register-model fixes + AAPCS64 (Phase 1)

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -21,6 +21,11 @@ os   = "windows"
 abi  = "win64"
 ext  = ".exe"
 
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
 [bin.mach]
 entry = "main.mach"
 

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -78,6 +78,7 @@ use intern: mach.lang.intern;
 use target: mach.lang.target;
 use isa:    mach.lang.target.isa;
 use abi:    mach.lang.target.abi;
+use os:     mach.lang.target.os;
 use mir:    mach.lang.be.codegen.mir;
 
 # REG_CLASS_GP: index of the general-purpose register bank in `reg_classes`.
@@ -689,9 +690,12 @@ fun seed_callee_saved(tgt: *target.Target, ctx: *AllocCtx) {
 # seed_reserved: mark every register the ISA holds off-limits to value allocation:
 # the never-allocatable stack and frame pointers (`tgt.arch.reserved_regs`), the
 # spill-reload scratch pool (`tgt.arch.reload_scratch_regs`, drawn from by
-# `reload_temp`), and the encoder's mem-mem split scratch (`tgt.arch.scratch_reg`).
-# every register is read from the ISA vtable rather than named directly, so a new
-# ISA needs no edit here. registers outside the GP bank are ignored.
+# `reload_temp`), and the encoder's two split scratch registers
+# (`tgt.arch.scratch_reg` and `tgt.arch.scratch_reg2`). every register is read from
+# the ISA vtable rather than named directly, so a new ISA needs no edit here.
+# registers outside the GP bank are ignored. reserving both scratch registers is
+# idempotent for x86-64 (R10 = `scratch_reg2` is already in the reload pool) and
+# closes the AArch64 gap where IP1 = `scratch_reg2` would otherwise stay allocatable.
 # ---
 # tgt: the active target; supplies the ISA reserved-register lists
 # ctx: the allocation context whose `reserved` flags are set
@@ -707,6 +711,7 @@ fun seed_reserved(tgt: *target.Target, ctx: *AllocCtx) {
         j = j + 1;
     }
     reserve_reg(ctx, tgt.arch.scratch_reg);
+    reserve_reg(ctx, tgt.arch.scratch_reg2);
 }
 
 # function_has_divide: true when any instruction is an integer division /
@@ -2756,4 +2761,41 @@ fun free_ops(ctx: *AllocCtx, ops: *mir.MirOperand, n: u32) {
     if (ops != nil && n > 0) {
         deallocate[mir.MirOperand](ctx.alloc, ops, n::usize);
     }
+}
+
+# the AArch64 register model holds its silent-miscompile-class registers off-limits
+# to value allocation: LR (X30) is reserved by the frame layout, IP0/IP1 (X16/X17)
+# are the encoder's split scratch registers (reached through `scratch_reg` /
+# `scratch_reg2`, the latter only reserved after the seed_reserved fix), and V31 is
+# the FP scratch held outside the allocatable vector bank. `seed_reserved` must mark
+# all three GP registers reserved, and the vector bank count must exclude V31.
+test "regalloc: AArch64 reserves LR/IP0/IP1 and holds V31 out of the vector bank (#1171)" {
+    var reg: target.TargetRegistry = target.registry_init();
+    val rr: Result[bool, str] = target.register_all(?reg);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    val ts: Result[target.Target, str] = target.select(?reg, os.OS_LINUX, isa.ARCH_AARCH64);
+    if (is_err[target.Target, str](ts)) { ret 1; }
+    var t: target.Target = unwrap_ok[target.Target, str](ts);
+
+    # a minimal allocation context sized to the GP bank; seed_reserved only reads
+    # gp_count and writes the reserved flags.
+    var ctx: AllocCtx;
+    ctx.gp_count = bank_count(?t, REG_CLASS_GP);
+    var reserved: [64]bool;
+    var i: u32 = 0;
+    for (i < 64) { reserved[i] = false; i = i + 1; }
+    ctx.reserved = ?reserved[0];
+
+    seed_reserved(?t, ?ctx);
+
+    # LR (X30), IP0 (X16), and IP1 (X17) are all off-limits.
+    if (!reserved[30]) { ret 1; }
+    if (!reserved[16]) { ret 1; }
+    if (!reserved[17]) { ret 1; }
+
+    # V31 is excluded from the allocatable vector bank (count 31, ids 0..30).
+    if (bank_count(?t, fp_class_index(?t)) != 31) { ret 1; }
+
+    ret 0;
 }

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -11,6 +11,7 @@ use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
 use std.types.result.is_err;
+use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 use std.types.option.Option;
 use std.types.option.is_none;
@@ -29,9 +30,10 @@ use of:  mach.lang.target.of;
 use os:  mach.lang.target.os;
 
 use x64:     mach.lang.target.isa.x64.register;
-use arm64:   mach.lang.target.isa.arm64;
+use arm64:   mach.lang.target.isa.arm64.register;
 use sysv:    mach.lang.target.abi.sysv;
 use win64:   mach.lang.target.abi.win64;
+use aapcs64: mach.lang.target.abi.aapcs64;
 use elf:     mach.lang.target.of.elf;
 use coff:    mach.lang.target.of.coff;
 use macho:   mach.lang.target.of.macho;
@@ -149,8 +151,9 @@ pub fun registry_init() TargetRegistry {
 #
 # composes the four orthogonal dimensions by invoking each implementation's
 # registering entry point: the x86-64 ISA, SysV ABI, ELF object format,
-# and Linux operating system (the supported set), plus the honest stubs
-# (arm64, win64, coff, mach-o, darwin, windows) so `select` reports an
+# and Linux operating system (the supported set), the AArch64 ISA and AAPCS64 ABI
+# (whose backend selection/encoding fail loudly until later phases), plus the
+# honest stubs (win64, coff, mach-o, darwin, windows) so `select` reports an
 # unsupported pair rather than a missing registration. must be called once at
 # startup, before any `select` against `reg`, so the registries are populated.
 # every registrar is idempotent, so a redundant call is harmless. no interner is
@@ -171,6 +174,9 @@ pub fun register_all(reg: *TargetRegistry) Result[bool, str] {
 
     val r_win64: Result[bool, str] = win64.register_win64(?reg.abi);
     if (is_err[bool, str](r_win64)) { ret err[bool, str](unwrap_err[bool, str](r_win64)); }
+
+    val r_aapcs64: Result[bool, str] = aapcs64.register(?reg.abi);
+    if (is_err[bool, str](r_aapcs64)) { ret err[bool, str](unwrap_err[bool, str](r_aapcs64)); }
 
     val r_elf: Result[bool, str] = elf.register(?reg.of);
     if (is_err[bool, str](r_elf)) { ret err[bool, str](unwrap_err[bool, str](r_elf)); }
@@ -269,6 +275,37 @@ test "target: registry enumeration agrees with lookup (#1312)" {
         k = k + 1;
     }
     if (is_some[*isa.IsaVTable](isa.registered(?reg.isa, n))) { ret 1; }
+
+    ret 0;
+}
+
+# selecting a Linux/AArch64 target composes a full Target: the AArch64 ISA vtable
+# (with non-nil select/encode entry points) and the AAPCS64 ABI vtable resolve and
+# bind. the backend selection/encoding fail loudly only when reached, never at
+# composition. registers the third ABI (AAPCS64) alongside SysV and Win64.
+test "target: select composes a Linux/AArch64 target (#1171)" {
+    var reg: TargetRegistry = registry_init();
+    val rr: Result[bool, str] = register_all(?reg);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    # the AAPCS64 registration brings the ABI registry to three conventions.
+    if (abi.registered_count(?reg.abi) != 3) { ret 1; }
+
+    val ts: Result[tdef.Target, str] = select(?reg, os.OS_LINUX, isa.ARCH_AARCH64);
+    if (is_err[tdef.Target, str](ts)) { ret 1; }
+    val t: tdef.Target = unwrap_ok[tdef.Target, str](ts);
+
+    # the ISA vtable resolved and exposes the AArch64 backend entry points.
+    if (t.arch == nil)        { ret 1; }
+    if (t.arch.id != isa.ARCH_AARCH64) { ret 1; }
+    if (t.arch.select == nil) { ret 1; }
+    if (t.arch.encode == nil) { ret 1; }
+
+    # the ABI resolved to AAPCS64 (not silently the x86-64 SysV vtable).
+    if (t.abi == nil)              { ret 1; }
+    if (t.abi.id != abi.ABI_AAPCS64) { ret 1; }
+    if (t.abi.arg_passing == nil)  { ret 1; }
+    if (t.abi.ret_passing == nil)  { ret 1; }
 
     ret 0;
 }

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -1,0 +1,445 @@
+# mach.lang.target.abi.aapcs64: AArch64 AAPCS64 calling convention.
+#
+# Implements `abi.AbiVTable` and self-registers under `abi.ABI_AAPCS64` at
+# startup. Owns the AAPCS64 classification of parameters and return values — the
+# scalar one-register rule, the ≤16-byte aggregate one/two-GP-register rule, and
+# the >16-byte by-reference rule — plus the GP/FP/callee-saved register files, the
+# 16-byte stack alignment, and no red zone. The GP and FP argument banks advance
+# independently (the NGRN and NSRN cursors of the psABI). The three
+# `classify`/`arg_passing`/`ret_passing` vtable function pointers are type-erased
+# (`*u8`); a consumer casts each back to the neutral signature declared in `abi`
+# (`ClassifyFn`, `ArgPassingFn`, `RetPassingFn`, `RegFileFn`).
+#
+# FIRST CUT (Phase 1). This is the skeleton convention: scalars and ≤16-byte
+# aggregates are placed correctly, and >16-byte aggregates are passed/returned by
+# hidden reference so the lowering of any signature is total and the backend is
+# reached. The contract gaps DEFERRED to a later phase are: the dedicated x8
+# indirect-result register for sret (the return slot currently reports the
+# AAPCS64 indirect-result register id but the generic lowering still passes the
+# hidden pointer through the first GP argument register); homogeneous
+# floating-point / short-vector aggregates (HFA/HVA) — a ≤16-byte all-float
+# aggregate rides GP registers here, not the V-register sequence; and the full
+# AArch64 `va_list` variadic model — `va_model` returns a register-save placeholder
+# sufficient for non-variadic call lowering. Composition tests must avoid
+# sret-returning paths until the contract-gaps phase lands.
+
+use std.types.result.Result;
+use std.types.result.ok;
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.string.str;
+
+use isa: mach.lang.target.isa;
+use abi: mach.lang.target.abi;
+
+# canonical AArch64 general-purpose register numbers used by the AAPCS64
+# convention. these are the same physical-register ids the aarch64 ISA exposes;
+# they are fixed by the architecture, so the ABI carries them directly rather than
+# depending on the ISA implementation being registered first.
+pub val REG_X0:  i32 = 0;
+pub val REG_X1:  i32 = 1;
+pub val REG_X2:  i32 = 2;
+pub val REG_X3:  i32 = 3;
+pub val REG_X4:  i32 = 4;
+pub val REG_X5:  i32 = 5;
+pub val REG_X6:  i32 = 6;
+pub val REG_X7:  i32 = 7;
+# the indirect-result register: the caller passes the address of the result
+# storage for a >16-byte (sret) return here. full x8 semantics are deferred (see
+# the module note); it is named so `classify_return` can report it.
+pub val REG_X8:  i32 = 8;
+pub val REG_X19: i32 = 19;
+pub val REG_X20: i32 = 20;
+pub val REG_X21: i32 = 21;
+pub val REG_X22: i32 = 22;
+pub val REG_X23: i32 = 23;
+pub val REG_X24: i32 = 24;
+pub val REG_X25: i32 = 25;
+pub val REG_X26: i32 = 26;
+pub val REG_X27: i32 = 27;
+pub val REG_X28: i32 = 28;
+
+# number of general-purpose registers available for argument passing (X0–X7).
+pub val GP_PARAM_COUNT: i32 = 8;
+# number of floating-point / vector registers available for argument passing
+# (V0–V7).
+pub val FP_PARAM_COUNT: i32 = 8;
+# number of callee-saved general-purpose registers (X19–X28).
+pub val GP_CALLEE_SAVED_COUNT: i32 = 10;
+# number of callee-saved floating-point registers (V8–V15; only the low 64 bits
+# are preserved by the psABI, modeled here as whole-register callee saves).
+pub val FP_CALLEE_SAVED_COUNT: i32 = 8;
+# total callee-saved registers across both banks.
+pub val CALLEE_SAVED_COUNT: i32 = 18;
+
+# required stack alignment in bytes at a call boundary.
+pub val STACK_ALIGN: u32 = 16;
+# AArch64 defines no leaf-function red zone.
+pub val RED_ZONE: u32 = 0;
+# largest aggregate size in bytes passed/returned in registers; anything larger is
+# passed/returned by hidden reference.
+pub val MAX_REG_RET: u64 = 16;
+
+# local aliases of the neutral vtable function signatures (`mach.lang.target.abi`).
+# the shared typedefs live in the abi module so a consumer typing any convention's
+# erased vtable pointer never routes through this concrete convention; aapcs64 keeps
+# these names for its own use and self-registration.
+pub def ClassifyFn:    abi.ClassifyFn;
+pub def ArgPassingFn:  abi.ArgPassingFn;
+pub def RetPassingFn:  abi.RetPassingFn;
+pub def RegFileFn:     abi.RegFileFn;
+pub def VaModelFn:     abi.VaModelFn;
+
+# gp_param_reg: the GP argument register for a given argument-register index.
+# returns -1 when the index is past the eight GP argument registers (X0–X7).
+# ---
+# index: zero-based GP argument-register index
+# ret:   the physical register id, or -1 if out of range
+pub fun gp_param_reg(index: i32) i32 {
+    if (index < 0) { ret -1; }
+    if (index >= GP_PARAM_COUNT) { ret -1; }
+    ret index;
+}
+
+# fp_param_reg: the FP/vector argument register for a given argument-register
+# index. V registers are numbered identically to their index within the vector
+# bank; the returned id is composite (the vector class tag in the high byte) so a
+# float pre-coloring carries its bank. returns -1 past V7.
+# ---
+# index: zero-based FP argument-register index
+# ret:   the composite V register id, or -1 if out of range
+pub fun fp_param_reg(index: i32) i32 {
+    if (index < 0) { ret -1; }
+    if (index >= FP_PARAM_COUNT) { ret -1; }
+    ret isa.regid_make(isa.REG_CLASS_ID_XMM, index);
+}
+
+# classify: classify one value into an AAPCS64 placement decision.
+#
+# this is the body behind the erased `AbiVTable.classify` pointer; it treats the
+# value as the first argument and routes through `classify_arg`. returns are
+# routed separately through `classify_return`.
+# ---
+# size:          value size in bytes
+# align:         value alignment in bytes
+# is_float:      true if the value is FP-eligible
+# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# is_aggregate:  true if the value is an aggregate
+# gp_used:       GP registers already consumed
+# fp_used:       FP registers already consumed
+# ret:           the placement decision
+pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
+                 is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used);
+}
+
+# classify_arg: assign registers or a stack slot for one argument (AAPCS64).
+#
+# scalars take one GP register (or one V register for a float) until that bank is
+# exhausted, then spill to the stack. an aggregate of ≤8 bytes takes one GP
+# register; a 9–16 byte aggregate takes a consecutive GP register pair; either
+# spills to the stack by value when the GP bank lacks the register(s) it needs.
+# an aggregate larger than 16 bytes is passed by hidden reference — the caller
+# copies it to memory and passes the pointer in the next GP register
+# (CLASS_BYREF), or, when the GP bank is exhausted, passes that pointer on the
+# stack (CLASS_STACK_BYREF). HFA/HVA float-aggregate placement in the V registers
+# is deferred (see the module note); a float-bearing ≤16-byte aggregate rides GP
+# registers here. this classifier is AArch64-specific by selection: `target.select`
+# only composes the AAPCS64 vtable for an aarch64 (os, arch) pair.
+# ---
+# index:         zero-based logical argument position
+# size:          argument size in bytes
+# align:         argument alignment in bytes
+# is_float:      true if the argument goes in an FP register (scalar floats)
+# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# is_aggregate:  true if the argument is an aggregate
+# gp_used:       GP registers already consumed
+# fp_used:       FP registers already consumed
+# ret:           the placement decision
+pub fun classify_arg(index: i32, size: u64, align: u64,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                     gp_used: i32, fp_used: i32) abi.ParamSlot {
+    if (is_aggregate && size > MAX_REG_RET) {
+        # >16 bytes: passed by reference. the pointer rides the next GP register, or
+        # the stack (as an 8-byte pointer) once the GP bank is exhausted.
+        if (gp_used < GP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
+        }
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, 8);
+    }
+
+    if (is_aggregate) {
+        if (size <= 8) {
+            if (gp_used < GP_PARAM_COUNT) {
+                ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+            }
+            ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        }
+        # 9–16 bytes: a consecutive GP register pair, or spill by value if two GP
+        # registers do not remain.
+        if (gp_used + 2 <= GP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), gp_param_reg(gp_used + 1), 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
+
+    if (is_float) {
+        if (fp_used < FP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), -1, 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
+
+    if (gp_used < GP_PARAM_COUNT) {
+        ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+    }
+    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+}
+
+# classify_return: assign registers or an sret pointer for a return value (AAPCS64).
+#
+# a zero-size (void) return yields CLASS_GP with reg=-1. a scalar returns in X0,
+# or V0 for a float. an aggregate of ≤8 bytes returns in X0; a 9–16 byte aggregate
+# returns in the X0:X1 pair. an aggregate larger than 16 bytes is returned through
+# the hidden indirect-result register (CLASS_SRET, reg=X8) — full x8 semantics are
+# deferred (see the module note). HFA/HVA V-register returns are likewise deferred:
+# a float-bearing ≤16-byte aggregate returns in GP registers here. this classifier
+# is AArch64-specific by selection — the AAPCS64 vtable is only composed for an
+# aarch64 target.
+# ---
+# size:          return-value size in bytes
+# align:         return-value alignment in bytes
+# is_float:      true if the value is returned in an FP register (scalar floats)
+# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# is_aggregate:  true if the value is an aggregate
+# ret:           the placement decision
+pub fun classify_return(size: u64, align: u64,
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool) abi.ParamSlot {
+    if (size == 0) {
+        ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
+    }
+
+    if (is_aggregate && size > MAX_REG_RET) {
+        ret abi.make_slot(abi.CLASS_SRET, REG_X8, -1, 0, 8);
+    }
+
+    if (is_aggregate) {
+        if (size <= 8) {
+            ret abi.make_slot(abi.CLASS_GP, REG_X0, -1, 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_GP, REG_X0, REG_X1, 0, size);
+    }
+
+    if (is_float) {
+        ret abi.make_slot(abi.CLASS_FP, fp_param_reg(0), -1, 0, size);
+    }
+
+    ret abi.make_slot(abi.CLASS_GP, REG_X0, -1, 0, size);
+}
+
+# gp_param_regs: the general-purpose argument registers, in passing order.
+#
+# fills `out[0..GP_PARAM_COUNT)` with X0–X7 (each 8 bytes wide). the caller owns
+# `out`, which must hold at least `GP_PARAM_COUNT` registers; the count is returned
+# so the call composes with `RegisterFile`.
+# ---
+# out: caller-owned buffer of at least GP_PARAM_COUNT registers
+# ret: the number of registers written (GP_PARAM_COUNT)
+pub fun gp_param_regs(out: *isa.Register) i32 {
+    var i: i32 = 0;
+    for (i < GP_PARAM_COUNT) {
+        out[i].id   = gp_param_reg(i);
+        out[i].size = 8;
+        i = i + 1;
+    }
+    ret GP_PARAM_COUNT;
+}
+
+# fp_param_regs: the floating-point/vector argument registers, in passing order.
+#
+# fills `out[0..FP_PARAM_COUNT)` with V0–V7 (composite vector ids, each 16 bytes
+# wide). the caller owns `out`, which must hold at least `FP_PARAM_COUNT` registers.
+# ---
+# out: caller-owned buffer of at least FP_PARAM_COUNT registers
+# ret: the number of registers written (FP_PARAM_COUNT)
+pub fun fp_param_regs(out: *isa.Register) i32 {
+    var i: i32 = 0;
+    for (i < FP_PARAM_COUNT) {
+        out[i].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, i);
+        out[i].size = 16;
+        i = i + 1;
+    }
+    ret FP_PARAM_COUNT;
+}
+
+# callee_saved: the callee-saved registers across both banks.
+#
+# fills `out[0..CALLEE_SAVED_COUNT)` with the GP set X19–X28 (8 bytes each) then
+# the FP set V8–V15 (composite vector ids, 16 bytes each). a callee that touches
+# any of these must preserve it across the call; regalloc routes each to its bank
+# by the composite-id class tag. the caller owns `out`, which must hold at least
+# `CALLEE_SAVED_COUNT` registers.
+# ---
+# out: caller-owned buffer of at least CALLEE_SAVED_COUNT registers
+# ret: the number of registers written (CALLEE_SAVED_COUNT)
+pub fun callee_saved(out: *isa.Register) i32 {
+    var i: i32 = 0;
+    for (i < GP_CALLEE_SAVED_COUNT) {
+        out[i].id   = REG_X19 + i;
+        out[i].size = 8;
+        i = i + 1;
+    }
+    var j: i32 = 0;
+    for (j < FP_CALLEE_SAVED_COUNT) {
+        out[GP_CALLEE_SAVED_COUNT + j].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, 8 + j);
+        out[GP_CALLEE_SAVED_COUNT + j].size = 16;
+        j = j + 1;
+    }
+    ret CALLEE_SAVED_COUNT;
+}
+
+# va_model: the AAPCS64 variadic save model — a register-save placeholder.
+#
+# the full AArch64 `va_list` (the five-field `__va_list` with separate GP/FP save
+# areas indexed by negative offsets) is DEFERRED to the contract-gaps phase. this
+# returns a register-save-shaped model sufficient for non-variadic call lowering,
+# which reads the model on every call: `vector_count_reg` is -1 (AArch64 encodes no
+# caller vector-count register, so the pre-call vector-count move is never emitted)
+# and `float_dup_gp` is false. the save-area geometry holds the eight GP and eight
+# FP argument registers; the `__va_list_tag` field offsets are placeholders carried
+# only so the field set is complete and are not yet the AAPCS64 layout.
+# ---
+# ret: the AAPCS64 variadic save model placeholder
+pub fun va_model() abi.VaModel {
+    var m: abi.VaModel;
+    m.kind             = abi.VA_MODEL_REG_SAVE;
+    m.gp_save_count    = GP_PARAM_COUNT;
+    m.fp_save_count    = FP_PARAM_COUNT;
+    m.arg_stride       = 0;
+    m.float_dup_gp     = false;
+    m.vector_count_reg = -1;
+    m.save_size        = GP_PARAM_COUNT::u64 * 8 + FP_PARAM_COUNT::u64 * 16;
+    m.fp_save_offset   = GP_PARAM_COUNT::u64 * 8;
+    m.fp_save_stride   = 16;
+    m.gp_offset_max    = GP_PARAM_COUNT::u32 * 8;
+    m.fp_offset_max    = GP_PARAM_COUNT::u32 * 8 + FP_PARAM_COUNT::u32 * 16;
+    m.gp_offset_field  = 0;
+    m.fp_offset_field  = 4;
+    m.overflow_field   = 8;
+    m.reg_save_field   = 16;
+    ret m;
+}
+
+# the AAPCS64 ABI vtable. populated by register on first call and handed out as a
+# borrowed pointer to the registry. its three classify/arg/ret function pointers
+# are stored type-erased (`*u8`); consumers cast them back to
+# `ClassifyFn`/`ArgPassingFn`/`RetPassingFn`.
+var aapcs64_vtable: abi.AbiVTable;
+
+# register: build the AAPCS64 AbiVTable and install it into `reg`.
+#
+# sets the convention name ("aapcs64") as an immutable `str` constant, wires the
+# type-erased classify/arg/ret operation pointers and the GP/FP argument-register
+# and callee-saved register file accessors, sets the 16-byte stack alignment, no
+# red zone, and no shadow space, and registers it under abi.ABI_AAPCS64 so
+# target.select can find it through abi.lookup. idempotent: the registry entry is
+# write-once.
+# ---
+# reg: the ABI registry to install the vtable into
+# ret: ok(true) on success
+pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
+
+    aapcs64_vtable.id           = abi.ABI_AAPCS64;
+    aapcs64_vtable.name         = "aapcs64";
+    aapcs64_vtable.classify     = classify::*u8;
+    aapcs64_vtable.arg_passing  = classify_arg::*u8;
+    aapcs64_vtable.ret_passing  = classify_return::*u8;
+    aapcs64_vtable.gp_arg_regs  = gp_param_regs::*u8;
+    aapcs64_vtable.fp_arg_regs  = fp_param_regs::*u8;
+    aapcs64_vtable.callee_saved = callee_saved::*u8;
+    aapcs64_vtable.stack_align  = STACK_ALIGN;
+    aapcs64_vtable.red_zone     = RED_ZONE;
+    # AAPCS64 reserves no caller shadow space — stack arguments start at [sp+0].
+    aapcs64_vtable.shadow_space = 0;
+    aapcs64_vtable.va_model      = va_model::*u8;
+
+    abi.register(reg, ?aapcs64_vtable);
+    ret ok[bool, str](true);
+}
+
+test "aapcs64: a scalar integer takes a GP register, a float a V register" {
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
+    if (i.class != abi.CLASS_GP) { ret 1; }
+    if (i.reg != REG_X0)         { ret 1; }
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
+    if (f.class != abi.CLASS_FP)    { ret 1; }
+    if (f.reg != fp_param_reg(0))   { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: a 16-byte aggregate rides a consecutive GP pair" {
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0);
+    if (s.class != abi.CLASS_GP) { ret 1; }
+    if (s.reg  != REG_X0)        { ret 1; }
+    if (s.reg2 != REG_X1)        { ret 1; }
+    # an 8-byte aggregate takes a single GP register.
+    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0);
+    if (o.class != abi.CLASS_GP) { ret 1; }
+    if (o.reg  != REG_X0)        { ret 1; }
+    if (o.reg2 != -1)            { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: a >16-byte aggregate is passed by reference" {
+    # a GP register remains: the hidden pointer rides it.
+    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0);
+    if (s.class != abi.CLASS_BYREF) { ret 1; }
+    if (s.reg   != REG_X0)          { ret 1; }
+    # GP bank exhausted: the pointer is passed on the stack.
+    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0);
+    if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: GP and FP argument banks advance independently" {
+    # seven GP registers used: a scalar integer still has X7, a float still has V0.
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0);
+    if (i.class != abi.CLASS_GP) { ret 1; }
+    if (i.reg != REG_X7)         { ret 1; }
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0);
+    if (f.class != abi.CLASS_FP)  { ret 1; }
+    if (f.reg != fp_param_reg(0)) { ret 1; }
+    # GP exhausted spills an integer to the stack; the FP bank is untouched.
+    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 8, 0);
+    if (s.class != abi.CLASS_STACK) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: scalar and small-aggregate returns place X0/V0/X0:X1" {
+    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false);
+    if (v.class != abi.CLASS_GP || v.reg != -1) { ret 1; }
+    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false);
+    if (i.reg != REG_X0) { ret 1; }
+    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false);
+    if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
+    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true);
+    if (a.reg != REG_X0 || a.reg2 != REG_X1) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: register-file accessors fill the canonical banks" {
+    var gp: [8]isa.Register;
+    if (gp_param_regs(?gp[0]) != GP_PARAM_COUNT) { ret 1; }
+    if (gp[0].id != REG_X0 || gp[7].id != REG_X7) { ret 1; }
+    var fp: [8]isa.Register;
+    if (fp_param_regs(?fp[0]) != FP_PARAM_COUNT) { ret 1; }
+    if (fp[0].id != fp_param_reg(0) || fp[7].id != fp_param_reg(7)) { ret 1; }
+    var cs: [18]isa.Register;
+    if (callee_saved(?cs[0]) != CALLEE_SAVED_COUNT) { ret 1; }
+    if (cs[0].id != REG_X19 || cs[9].id != REG_X28) { ret 1; }
+    if (cs[10].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 8)) { ret 1; }
+    if (cs[17].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 15)) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -1,124 +1,117 @@
-# mach.lang.target.isa.arm64: ARM AArch64 (arm64) instruction-set stub.
+# mach.lang.target.isa.arm64: AArch64 (arm64) instruction-set definitions.
 #
-# Supplies a correctly-shaped `IsaVTable` for AArch64 — 8-byte pointers,
-# little-endian, the documented register classes (gpr X0–X30, vector V0–V31,
-# flags), the never-allocatable reserved registers (SP, FP/X29), and the backend
-# scratch register identities (IP0/IP1, V31) — so target.select can compose an
-# AArch64 target descriptor and the backend can size virtual registers. AArch64
-# instruction selection and encoding are not yet implemented: the `select` and
-# `encode` operation entry points are nil, the honest "unsupported" signal a
-# shared dispatcher errors on. This vtable carries data only and registers
-# honestly; `register` interns the strings and is idempotent.
+# Owns the concrete register numbering and the machine opcode space for AArch64,
+# the leaf-defs the sibling `arm64` sub-modules build on. The register files and
+# the `isa.IsaVTable` are constructed and registered by the `arm64.register`
+# module; the instruction selector and byte encoder live in `arm64.isel` and
+# `arm64.encode`. Only those tables are target-specific; everything the back end
+# consumes that is AArch64-shaped lives here. This module is data-only and carries
+# no logic — it mirrors `mach.lang.target.isa.x64`.
 
-use std.types.result.Result;
-use std.types.result.ok;
-use std.types.result.err;
-use std.types.result.is_err;
-use std.types.result.unwrap_ok;
-use std.types.result.unwrap_err;
+# general-purpose register ids (X0–X30). these are the canonical AArch64 GP
+# register numbers, used directly as `Operand.reg` values throughout isel,
+# regalloc, and encode. X31 is the zero register / stack pointer depending on the
+# instruction form and is never an allocatable GP value.
+pub val X0:  i32 = 0;
+pub val X1:  i32 = 1;
+pub val X2:  i32 = 2;
+pub val X3:  i32 = 3;
+pub val X4:  i32 = 4;
+pub val X5:  i32 = 5;
+pub val X6:  i32 = 6;
+pub val X7:  i32 = 7;
+pub val X8:  i32 = 8;
+pub val X9:  i32 = 9;
+pub val X10: i32 = 10;
+pub val X11: i32 = 11;
+pub val X12: i32 = 12;
+pub val X13: i32 = 13;
+pub val X14: i32 = 14;
+pub val X15: i32 = 15;
+pub val X16: i32 = 16;
+pub val X17: i32 = 17;
+pub val X18: i32 = 18;
+pub val X19: i32 = 19;
+pub val X20: i32 = 20;
+pub val X21: i32 = 21;
+pub val X22: i32 = 22;
+pub val X23: i32 = 23;
+pub val X24: i32 = 24;
+pub val X25: i32 = 25;
+pub val X26: i32 = 26;
+pub val X27: i32 = 27;
+pub val X28: i32 = 28;
+pub val X29: i32 = 29;
+pub val X30: i32 = 30;
 
-use std.types.bool.bool;
-use std.types.bool.true;
-use std.types.bool.false;
+# the intra-procedure-call scratch registers IP0/IP1 (aliases of X16/X17), used by
+# the back end and the linker for veneers and address materialization.
+pub val IP0: i32 = 16;
+pub val IP1: i32 = 17;
 
-use std.types.string.str;
+# the frame pointer (X29), link register (X30), and stack pointer (id 31). the
+# frame and stack pointers are owned by the frame pass and the link register holds
+# the return address, so none is ever handed out by the register allocator.
+pub val FP: i32 = 29;
+pub val LR: i32 = 30;
+pub val SP: i32 = 31;
 
-use isa:    mach.lang.target.isa;
+# SIMD/floating-point vector register ids (V0–V31). a distinct id space from the
+# GP registers; the register-class width selects which file a vreg draws from. a
+# physical vector id is carried composite (the SSE/vector class tag in the high
+# byte) so a float value is never aliased onto the GP register of the same index.
+pub val V0:  i32 = 0;
+pub val V1:  i32 = 1;
+pub val V2:  i32 = 2;
+pub val V3:  i32 = 3;
+pub val V4:  i32 = 4;
+pub val V5:  i32 = 5;
+pub val V6:  i32 = 6;
+pub val V7:  i32 = 7;
+pub val V8:  i32 = 8;
+pub val V9:  i32 = 9;
+pub val V10: i32 = 10;
+pub val V11: i32 = 11;
+pub val V12: i32 = 12;
+pub val V13: i32 = 13;
+pub val V14: i32 = 14;
+pub val V15: i32 = 15;
+pub val V16: i32 = 16;
+pub val V17: i32 = 17;
+pub val V18: i32 = 18;
+pub val V19: i32 = 19;
+pub val V20: i32 = 20;
+pub val V21: i32 = 21;
+pub val V22: i32 = 22;
+pub val V23: i32 = 23;
+pub val V24: i32 = 24;
+pub val V25: i32 = 25;
+pub val V26: i32 = 26;
+pub val V27: i32 = 27;
+pub val V28: i32 = 28;
+pub val V29: i32 = 29;
+pub val V30: i32 = 30;
+pub val V31: i32 = 31;
 
-# number of general-purpose registers exposed (X0–X30; SP/XZR are not
-# allocatable). FP (X29) and LR (X30) are reserved by the frame layout.
-pub val ARM64_GPR_COUNT: u32 = 31;
+# number of allocatable general-purpose registers exposed to the allocator
+# (X0–X30). the stack pointer (id 31) is outside this bank; FP (X29) and LR (X30)
+# are inside it but held off-limits through the ISA vtable's reserved-register list.
+pub val GPR_COUNT: i32 = 31;
 
-# number of SIMD/floating-point vector registers (V0–V31).
-pub val ARM64_VECTOR_COUNT: u32 = 32;
+# number of allocatable SIMD/floating-point vector registers exposed to the
+# allocator (V0–V30). V31 is held back as the FP scratch register — the AArch64
+# analogue of x86-64 holding XMM15 back from the SSE value pool — so it is excluded
+# from this count.
+pub val VECTOR_COUNT: i32 = 31;
 
-# the AArch64 register classes, indexed by class id. populated by register.
-var arm64_reg_classes: [3]isa.RegClass;
+# the AArch64 machine opcode space. each value names a logical instruction form;
+# the encoder maps it to concrete bytes and the isel table emits it. pseudo
+# opcodes (`isa.ISA_*`) live above this space and never collide. seeded with the
+# forms the skeleton needs; `arm64.isel` / `arm64.encode` extend it as the backend
+# fills in.
+pub def Opcode: u16;
 
-# AArch64 register ids the stub reports as never-allocatable (the stack pointer
-# and the frame pointer X29) and as backend scratch (the intra-procedure-call
-# scratch registers X16/X17 = IP0/IP1, and vector register V31). these are the
-# real AArch64 identities so the vtable shape is honest even though selection and
-# encoding are unimplemented; the allocator would honor them once an AArch64
-# backend exists.
-val ARM64_SP:  i32 = 31;
-val ARM64_FP:  i32 = 29;
-val ARM64_IP0: i32 = 16;
-val ARM64_IP1: i32 = 17;
-val ARM64_V31: i32 = 31;
-
-# the registers the allocator must never assign on AArch64 (SP and FP).
-# referenced (borrowed) by the stub vtable's `reserved_regs` field; filled by
-# register_arm64.
-var arm64_reserved_regs: [2]isa.Register;
-
-# the AArch64 ISA vtable. populated by register on first call and handed out as
-# a borrowed pointer to the registry.
-var arm64_vtable: isa.IsaVTable;
-
-# register_arm64: build and install the AArch64 IsaVTable.
-#
-# sets the arch name and register-class names as immutable `str` constants, fills
-# the module-level register-class table (gpr 64×31, vector 128×32, flags 64×1) and
-# vtable with 8-byte pointers, little-endian byte order, the reserved registers
-# (SP/FP), the scratch register identities (IP0/IP1/V31), the frame/stack pointers
-# (FP/SP), -1 for the division / shift register identities (AArch64 wires none),
-# and nil select/encode entry points, and installs it into `reg` under
-# isa.ARCH_AARCH64. idempotent: the registry entry is write-once. must be invoked
-# at startup before target.select requests an AArch64 target.
-# ---
-# reg: the ISA registry to install the vtable into
-# ret: true on success
-pub fun register_arm64(reg: *isa.IsaRegistry) Result[bool, str] {
-
-    arm64_reg_classes[0].name      = "gpr";
-    arm64_reg_classes[0].bit_width = 64;
-    arm64_reg_classes[0].count     = ARM64_GPR_COUNT;
-
-    arm64_reg_classes[1].name      = "vector";
-    arm64_reg_classes[1].bit_width = 128;
-    arm64_reg_classes[1].count     = ARM64_VECTOR_COUNT;
-
-    arm64_reg_classes[2].name      = "flags";
-    arm64_reg_classes[2].bit_width = 64;
-    arm64_reg_classes[2].count     = 1;
-
-    arm64_reserved_regs[0].id   = ARM64_SP;
-    arm64_reserved_regs[0].size = 8;
-    arm64_reserved_regs[1].id   = ARM64_FP;
-    arm64_reserved_regs[1].size = 8;
-
-    arm64_vtable.id                 = isa.ARCH_AARCH64;
-    arm64_vtable.name               = "aarch64";
-    arm64_vtable.pointer_width      = 8;
-    arm64_vtable.reg_classes        = ?arm64_reg_classes[0];
-    arm64_vtable.reg_class_count    = 3;
-    arm64_vtable.select             = nil;
-    arm64_vtable.encode             = nil;
-    arm64_vtable.emit_asm           = nil;
-    arm64_vtable.asm_clobbers        = nil;
-    arm64_vtable.reserved_regs      = ?arm64_reserved_regs[0];
-    arm64_vtable.reserved_reg_count = 2;
-    # the AArch64 backend has no encoder yet; it wires no reload-scratch pool.
-    arm64_vtable.reload_scratch_regs  = nil;
-    arm64_vtable.reload_scratch_count = 0;
-    arm64_vtable.scratch_reg        = ARM64_IP0;
-    arm64_vtable.scratch_reg2       = ARM64_IP1;
-    # the vector scratch is a composite register id (class tag in the high byte),
-    # mirroring x86-64's FP_SCRATCH_REG — a raw bank index would read as a GP reg.
-    arm64_vtable.fp_scratch_reg     = isa.regid_make(isa.REG_CLASS_ID_XMM, ARM64_V31);
-    arm64_vtable.frame_ptr_reg      = ARM64_FP;
-    arm64_vtable.stack_ptr_reg      = ARM64_SP;
-    # the AAPCS64 frame record stores the saved FP at [fp+0] and the saved LR at
-    # [fp+8], so incoming stack arguments start at [fp+16] — same base as x86-64.
-    arm64_vtable.incoming_arg_base  = 16;
-    # AArch64 SDIV/UDIV write a normal destination register and a register shift
-    # count rides any register, so the ISA wires no fixed division / shift
-    # register: report -1 for all three.
-    arm64_vtable.div_reg            = -1;
-    arm64_vtable.div_hi_reg         = -1;
-    arm64_vtable.shift_count_reg    = -1;
-
-    isa.register(reg, ?arm64_vtable);
-    ret ok[bool, str](true);
-}
+# no-op (the canonical `HINT #0`).
+pub val NOP: Opcode = 0;
+# return from subroutine (`RET`, branches to the link register).
+pub val RET: Opcode = 1;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1,0 +1,47 @@
+# mach.lang.target.isa.arm64.encode: AArch64 machine-code encoding — the arm64 ISA's `encode` entry point.
+#
+# This is the AArch64 implementation of the ISA vtable's `encode` operation,
+# reached only through `tgt.arch.encode` by the shared `be.codegen.encode`
+# dispatcher. Byte encoding is not yet implemented: `encode_arm64` is a total
+# function that fails loudly with an "not implemented" error. The encoder that
+# turns the resolved `isa.Inst` stream into AArch64 bytes (with prologue/epilogue
+# emission, branch fixups, and relocation offsets) is filled in a later phase; the
+# four-file ISA shape mirrors the x86-64 backend.
+
+use std.types.string.str;
+
+use std.types.result.Result;
+use std.types.result.err;
+
+use std.allocator.Allocator;
+
+use target: mach.lang.target.resolved;
+use mir:    mach.lang.be.codegen.mir;
+use enc:    mach.lang.be.codegen.encode;
+
+# EncodeFn: the concrete signature the erased `isa.IsaVTable.encode` pointer is
+# cast back to, matching the shared `be.codegen.encode.EncodeFn`. the vtable stores
+# `encode` type-erased (`*u8`); the shared dispatcher casts it back to this type
+# before calling it.
+# ---
+# alloc: allocator backing the encoder output's owned arrays
+# tgt:   resolved compilation target (must be AArch64)
+# m:     the fully-resolved MIR module to encode
+# ret:   the populated enc.EncoderOutput, or an error string
+pub def EncodeFn: fun(*Allocator, *target.Target, *mir.MirModule) Result[enc.EncoderOutput, str];
+
+# encode_arm64: encode a fully-resolved MIR module into AArch64 `.text` bytes,
+# symbol marks, and pending relocations.
+#
+# the AArch64 implementation behind the ISA vtable's `encode` slot; the shared
+# `be.codegen.encode.run` dispatcher reaches it only through `tgt.arch.encode`.
+# byte encoding is not yet implemented, so this fails loudly — a total function
+# that signals the unimplemented backend rather than emitting wrong bytes.
+# ---
+# alloc: allocator (unused until encoding is implemented)
+# tgt:   resolved compilation target (must be AArch64)
+# m:     the fully-resolved MIR module
+# ret:   an error reporting that AArch64 encoding is unimplemented
+pub fun encode_arm64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Result[enc.EncoderOutput, str] {
+    ret err[enc.EncoderOutput, str]("aarch64 encode not implemented");
+}

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -1,0 +1,49 @@
+# mach.lang.target.isa.arm64.isel: AArch64 instruction selection — the arm64 ISA's `select` entry point.
+#
+# This is the AArch64 implementation of the ISA vtable's `select` operation,
+# reached only through `tgt.arch.select` by the shared `be.codegen.isel`
+# dispatcher. Instruction selection is not yet implemented: `select` is a total
+# function that fails loudly with an "not implemented" error so an AArch64 build
+# reaches the backend and stops here rather than miscompiling. The selector that
+# rewrites generic MIR opcodes into concrete AArch64 forms is filled in a later
+# phase; the four-file ISA shape (`arm64` defs, `arm64.register` vtable seam,
+# `arm64.isel`, `arm64.encode`) mirrors the x86-64 backend.
+
+use std.types.bool.bool;
+
+use std.types.string.str;
+
+use std.types.result.Result;
+use std.types.result.err;
+
+use std.allocator.Allocator;
+
+use target: mach.lang.target.resolved;
+use mir:    mach.lang.be.codegen.mir;
+
+# SelectFn: the concrete signature the erased `isa.IsaVTable.select` pointer is
+# cast back to, matching the shared `be.codegen.isel.SelectFn`. the vtable stores
+# `select` type-erased (`*u8`); the shared dispatcher casts it back to this type
+# before calling it.
+# ---
+# alloc: backing allocator used to rebuild expanded blocks' instruction lists
+# tgt:   resolved compilation target (must be AArch64)
+# fn:    the MIR function to select instructions for; mutated in place
+# ret:   ok(true) on success, or an error naming the failure
+pub def SelectFn: fun(*Allocator, *target.Target, *mir.MirFunction) Result[bool, str];
+
+# select: select concrete AArch64 instructions for one MIR function.
+#
+# the AArch64 implementation behind the ISA vtable's `select` slot; the shared
+# `be.codegen.isel.run` dispatcher reaches it only through `tgt.arch.select`.
+# instruction selection is not yet implemented, so this fails loudly — a total
+# function that signals the unimplemented backend rather than producing wrong
+# instructions.
+# ---
+# alloc: backing allocator (unused until selection is implemented)
+# tgt:   resolved compilation target (must be AArch64)
+# fn:    the MIR function to select instructions for
+# ret:   an error reporting that AArch64 instruction selection is unimplemented
+pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Result[bool, str] {
+    ret err[bool, str]("aarch64 isel not implemented");
+}

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -1,0 +1,37 @@
+# mach.lang.target.isa.arm64.printer: AArch64 assembly text printer — the arm64 ISA's `emit_asm` entry point.
+#
+# This is the AArch64 implementation of the ISA vtable's `emit_asm` operation,
+# reached only through `tgt.arch.emit_asm` by the shared `be.codegen.encode.print_asm`
+# dispatcher. The assembly-text printer is not yet implemented; the ISA leaves its
+# `emit_asm` slot nil, which the dispatcher treats as a clean no-op (no `.s` file
+# for an AArch64 target). This stub completes the four-file ISA shape and is wired
+# into the build graph so it stays type-checked; a later phase fills in the printer
+# and points the vtable slot at `print_asm_arm64`.
+
+use std.types.bool.bool;
+
+use std.types.string.str;
+
+use std.types.result.Result;
+use std.types.result.err;
+
+use writer: std.io.writer;
+
+use target: mach.lang.target.resolved;
+use mir:    mach.lang.be.codegen.mir;
+
+# print_asm_arm64: format a fully-resolved MIR module as AArch64 assembly text.
+#
+# the `emit_asm` entry point shape the arm64 ISA will register; matches the shared
+# `be.codegen.encode.PrintAsmFn`. not yet implemented, so this fails loudly. the
+# ISA currently wires `emit_asm` to nil (the dispatcher's clean no-op), so this is
+# never reached in Phase 1; it exists so the four-file shape is complete and a
+# later phase only flips the vtable slot.
+# ---
+# tgt: resolved compilation target
+# m:   the fully-resolved MIR module to format
+# out: destination writer
+# ret: an error reporting that the AArch64 printer is unimplemented
+pub fun print_asm_arm64(tgt: *target.Target, m: *mir.MirModule, out: *writer.Writer) Result[bool, str] {
+    ret err[bool, str]("aarch64 emit_asm not implemented");
+}

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -1,0 +1,140 @@
+# mach.lang.target.isa.arm64.register: AArch64 ISA vtable registration.
+#
+# this is the composition seam for the AArch64 backend: it imports the ISA
+# definitions (`arm64`), the instruction selector (`arm64.isel`), and the byte
+# encoder (`arm64.encode`), and wires their entry points into an `IsaVTable`
+# installed in the registry. it lives in its own module — apart from the `arm64`
+# definitions the isel/encode modules import — so wiring the children into the
+# parent does not close an import cycle. it mirrors `isa.x64.register`.
+
+use std.types.result.Result;
+use std.types.result.ok;
+
+use std.types.bool.bool;
+use std.types.bool.true;
+
+use std.types.string.str;
+
+use isa:          mach.lang.target.isa;
+use arm64:        mach.lang.target.isa.arm64;
+use arm64isel:    mach.lang.target.isa.arm64.isel;
+use arm64encode:  mach.lang.target.isa.arm64.encode;
+# the printer stub: `emit_asm` is nil for now (the dispatcher's no-op for an ISA
+# with no assembly printer), so this is imported to keep the stub in the build
+# graph and type-checked until the later phase points `emit_asm` at it.
+use arm64printer: mach.lang.target.isa.arm64.printer;
+
+# process-global storage for the AArch64 vtable and its register classes. written
+# once by `register_arm64` and referenced (borrowed) by the vtable installed into
+# the ISA registry; lives for the lifetime of the process.
+var arm64_vtable: isa.IsaVTable;
+var arm64_classes: [3]isa.RegClass;
+
+# the registers the allocator must never assign: the stack pointer (SP), the frame
+# pointer (FP/X29), and the link register (LR/X30, which holds the return address).
+# referenced (borrowed) by the `reserved_regs` field of the installed ISA vtable;
+# lives for the process lifetime. filled by `register_arm64`.
+var arm64_reserved_regs: [3]isa.Register;
+
+# the caller-saved GP registers the allocator reserves from value allocation and
+# draws spill-reload temporaries from (X9/X10/X11). a single high-pressure
+# instruction can reload its memory base, scaled index, and value operands at
+# once, so three temporaries cover the worst case. these are temporary (caller-
+# saved) AAPCS64 registers, distinct from the IP0/IP1 (`scratch_reg`/`scratch_reg2`)
+# the encoder claims for address materialization and the two-register lowering
+# sequences. referenced (borrowed) by the `reload_scratch_regs` field of the
+# installed vtable; lives for the process lifetime. filled by `register_arm64`.
+var arm64_reload_scratch_regs: [3]isa.Register;
+
+# register_arm64: build and install the AArch64 ISA vtable.
+#
+# sets the architecture and register-class names as immutable `str` constants,
+# fills the three register classes (gpr 64×31 for X0–X30, vector 128×31 for V0–V30
+# with V31 held back as the FP scratch, flags 64×1), populates the vtable with the
+# pointer width (8), the reserved registers (SP/FP/LR), the reload-scratch pool
+# (X9/X10/X11), the scratch register identities (IP0/IP1 and the composite V31 FP
+# scratch), the frame/stack pointers (FP/SP), and -1 for the division / shift
+# register identities (AArch64 wires none), and installs it into `reg`.
+# idempotent: the registry entry is write-once. must be invoked at compiler startup
+# before `target.select` requests an AArch64 target.
+#
+# the `select` and `encode` operation entry points are the AArch64 instruction
+# selector (`arm64/isel.mach`) and byte encoder (`arm64/encode.mach`), stored
+# type-erased (`*u8`) and cast back to their `SelectFn` / `EncodeFn` signatures by
+# the shared `be.codegen.isel` / `be.codegen.encode` dispatchers. both currently
+# fail loudly with a "not implemented" error, so an AArch64 build reaches the
+# backend and stops there rather than at composition. `emit_asm` is nil — the
+# dispatcher's clean no-op for an ISA with no assembly printer; `arm64.printer`
+# carries the stub the later phase wires here. `asm_clobbers` is nil, which the
+# allocator treats conservatively.
+# ---
+# reg: the ISA registry to install the vtable into
+# ret: true on success
+pub fun register_arm64(reg: *isa.IsaRegistry) Result[bool, str] {
+
+    arm64_classes[0].name      = "gpr";
+    arm64_classes[0].bit_width = 64;
+    arm64_classes[0].count     = arm64.GPR_COUNT::u32;
+
+    # the vector bank exposes only V0–V30 (count 31) to the allocator. V31
+    # (FP_SCRATCH_REG) is held back as the fixed FP scratch register the float-op
+    # backend loads operands into, so a live float vreg can never occupy it and be
+    # clobbered — the AArch64 analogue of x86-64 holding XMM14/XMM15 back from the
+    # SSE value pool.
+    arm64_classes[1].name      = "vector";
+    arm64_classes[1].bit_width = 128;
+    arm64_classes[1].count     = arm64.VECTOR_COUNT::u32;
+
+    arm64_classes[2].name      = "flags";
+    arm64_classes[2].bit_width = 64;
+    arm64_classes[2].count     = 1;
+
+    arm64_reserved_regs[0].id   = arm64.SP;
+    arm64_reserved_regs[0].size = 8;
+    arm64_reserved_regs[1].id   = arm64.FP;
+    arm64_reserved_regs[1].size = 8;
+    arm64_reserved_regs[2].id   = arm64.LR;
+    arm64_reserved_regs[2].size = 8;
+
+    arm64_reload_scratch_regs[0].id   = arm64.X9;
+    arm64_reload_scratch_regs[0].size = 8;
+    arm64_reload_scratch_regs[1].id   = arm64.X10;
+    arm64_reload_scratch_regs[1].size = 8;
+    arm64_reload_scratch_regs[2].id   = arm64.X11;
+    arm64_reload_scratch_regs[2].size = 8;
+
+    arm64_vtable.id                 = isa.ARCH_AARCH64;
+    arm64_vtable.name               = "aarch64";
+    arm64_vtable.pointer_width      = 8;
+    arm64_vtable.reg_classes        = ?arm64_classes[0];
+    arm64_vtable.reg_class_count    = 3;
+    arm64_vtable.select             = arm64isel.select::*u8;
+    arm64_vtable.encode             = arm64encode.encode_arm64::*u8;
+    # no assembly printer yet: nil is the dispatcher's clean no-op. the later phase
+    # points this at `arm64printer.print_asm_arm64::*u8`.
+    arm64_vtable.emit_asm           = nil;
+    arm64_vtable.asm_clobbers       = nil;
+    arm64_vtable.reserved_regs      = ?arm64_reserved_regs[0];
+    arm64_vtable.reserved_reg_count = 3;
+    arm64_vtable.reload_scratch_regs  = ?arm64_reload_scratch_regs[0];
+    arm64_vtable.reload_scratch_count = 3;
+    arm64_vtable.scratch_reg        = arm64.IP0;
+    arm64_vtable.scratch_reg2       = arm64.IP1;
+    # the vector scratch is a composite register id (class tag in the high byte),
+    # mirroring x86-64's FP_SCRATCH_REG — a raw bank index would read as a GP reg.
+    arm64_vtable.fp_scratch_reg     = isa.regid_make(isa.REG_CLASS_ID_XMM, arm64.V31);
+    arm64_vtable.frame_ptr_reg      = arm64.FP;
+    arm64_vtable.stack_ptr_reg      = arm64.SP;
+    # the AAPCS64 frame record stores the saved FP at [fp+0] and the saved LR at
+    # [fp+8], so incoming stack arguments start at [fp+16] — same base as x86-64.
+    arm64_vtable.incoming_arg_base  = 16;
+    # AArch64 SDIV/UDIV write a normal destination register and a register shift
+    # count rides any register, so the ISA wires no fixed division / shift
+    # register: report -1 for all three.
+    arm64_vtable.div_reg            = -1;
+    arm64_vtable.div_hi_reg         = -1;
+    arm64_vtable.shift_count_reg    = -1;
+
+    isa.register(reg, ?arm64_vtable);
+    ret ok[bool, str](true);
+}


### PR DESCRIPTION
Phase 1 of the aarch64-linux bring-up (epic #1431). Makes `select(OS_LINUX, ARCH_AARCH64)` compose a full Target and reach codegen, and fixes three correctness-critical register-model bugs the prior stub shipped (silent-miscompile class — byte-tests cannot catch them).

## Register-model fixes (the crux)
- **LR(X30) reserved** — was allocatable (reserved_regs was [SP,FP] only); a BL or frame-record-eliding leaf could clobber the return address. Now reserved_regs=[SP,FP,LR].
- **V31 held back** — vector bank count 32→31, so the FP scratch V31 can no longer be colored onto a live float vreg (mirrors x86-64 holding XMM14/15 back).
- **IP1/scratch_reg2 reserved** — shared fix in `seed_reserved` (regalloc.mach): it now reserves `scratch_reg2` as well as `scratch_reg`. Idempotent/harmless for x64 (R10 is already reserved via the reload pool). A regalloc test builds a real (linux,aarch64) target and asserts LR/IP0/IP1 reserved + the vector bank == 31.

## Backend skeleton (#1171)
- `isa/arm64.mach` reduced to leaf-defs (reg ids + opcode space), mirroring `isa/x64.mach`.
- New `isa/arm64/{register,isel,encode,printer}.mach` (the x64 four-file shape). `register.mach` wires `select`/`encode` (type-erased `*u8`, exact x64 cast pattern); isel/encode are loud "not implemented" stubs (Phase 2/3 fill them); `emit_asm`=nil (Phase 5 wires the printer). Reload-scratch pool X9/X10/X11.

## AAPCS64 (#1174, first cut)
- New `abi/aapcs64.mach` (mirrors the sysv registrar): scalar + ≤16B-aggregate classify, gp_arg X0–X7, fp_arg V0–V7 (composite XMM ids), callee-saved X19–X28 + V8–V15, stack_align=16, red_zone=0, independent GP/FP banks. Registered under ABI_AAPCS64.
- sret/x8, 3–4-member HFA/HVA, and the AArch64 va_list are **documented placeholders deferred to the contract-gaps phase (Phase 4)** — consistent with the ABI-scope audit (the compiler returns >16B aggregates pervasively, so x8/sret/gap #1 is the mandatory Phase-4 item; HFA + C-varargs are not on the self-host path and can defer).

## Wiring
- `target.mach`: arm64 import → `isa.arm64.register`; `aapcs64.register(?reg.abi)` in register_all; positive (linux,aarch64) composition test.
- `mach.toml`: `[target.linux-arm64]`.

## Verification
- `mach build .` exits 0; **446 tests pass, 0 fail** (438 baseline + 8 new).
- **x64 self-host fixpoint byte-identical** (independently re-run: s1==s2==s3, sha 2d6a2dcd) — the shared `seed_reserved` change does not perturb x86 codegen.
- `mach build . --target linux-arm64` on a minimal program now reaches the backend and stops at `aarch64 isel not implemented` (not a composition/abi.lookup error).

## Note surfaced for Phase 5
mach-std has no Linux/AArch64 syscall backend (`dep/mach-std/src/system/os/linux` has x86_64 only), so the **full self-hosted** aarch64 build can't reach codegen for OS-using modules until that's ported — a newly-identified Phase-5 prerequisite for the self-host fixpoint, tracked separately. Not in Phase 1 scope.

Refs #1171 #1174 #1431