### PR TITLE
refactor(be): hoist the ISA-agnostic two-pass encoder driver to be/codegen/encode (Phase 2a)

### DIFF
--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -15,22 +15,46 @@
 # `of.ObjectImage`, and the per-arch encoder (e.g. `target/isa/x64/encode.mach`)
 # allocates and populates them. Keeping the records here lets the driver and every
 # ISA agree on one common output without depending on any specific architecture.
+#
+# It also owns the ISA-agnostic two-pass *encoder driver* every architecture's
+# encoder runs over a module: `encode_driver` initialises an `EncodeState`
+# (the growable text `ByteBuf` plus the symbol / relocation / branch-fixup /
+# block-offset arrays), walks every function through an ISA-supplied per-function
+# encode hook (recording marks, relocs, fixups, and block offsets via the shared
+# `push_*` helpers), patches every intra-module branch in pass 2 through an
+# ISA-supplied per-branch patch hook, right-sizes the text, and assembles the
+# `EncoderOutput`. The two `EncodeHooks` are the only per-ISA seams: how one
+# function's bytes are emitted (opcodes, prologue/epilogue, relocation offsets)
+# and how one resolved branch displacement is written into the text. No opcode,
+# register, displacement-width, or byte-encoding knowledge lives here.
 
 use std.types.bool.bool;
 use std.types.bool.true;
+use std.types.bool.false;
 use std.types.string.str;
+use std.types.size.usize;
 
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
 
 use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.reallocate;
+use std.allocator.deallocate;
+
+use std.system.panic.panic;
 
 use writer: std.io.writer;
 
 use intern: mach.lang.intern;
 use of:     mach.lang.target.of;
 use target: mach.lang.target.resolved;
+use abi:    mach.lang.target.abi;
+use tos:    mach.lang.target.os;
 use mir:    mach.lang.be.codegen.mir;
 
 # EncoderOutput: the per-module result an ISA's encoder produces — the encoded
@@ -167,4 +191,543 @@ pub fun print_asm(tgt: *target.Target, m: *mir.MirModule, out: *writer.Writer) R
 
     val emit_asm: PrintAsmFn = tgt.arch.emit_asm::PrintAsmFn;
     ret emit_asm(tgt, m, out);
+}
+
+# initial capacity of a freshly grown encoder byte buffer.
+val BYTEBUF_INIT_CAP: usize = 256;
+
+# a growable byte sink the encoders write machine code into. the back end drains
+# `data[0..len]` into the object image's `.text` section after every function is
+# encoded; keeping the growth bookkeeping here lets `of.Section` stay a finalized
+# container. the sink is ISA-general — it carries no opcode or width knowledge, so
+# every architecture's encoder writes its bytes through the same buffer.
+# ---
+# data:  backing byte array (nil until the first byte is appended)
+# len:   number of bytes written
+# cap:   allocated capacity
+# alloc: allocator backing `data`
+pub rec ByteBuf {
+    data:  *u8;
+    len:   usize;
+    cap:   usize;
+    alloc: *Allocator;
+}
+
+# buf_init: construct an empty encoder byte buffer.
+# ---
+# alloc: allocator backing the buffer's storage
+# ret:   an empty ByteBuf
+pub fun buf_init(alloc: *Allocator) ByteBuf {
+    var buf: ByteBuf;
+    buf.data  = nil;
+    buf.len   = 0;
+    buf.cap   = 0;
+    buf.alloc = alloc;
+    ret buf;
+}
+
+# buf_dnit: free a byte buffer's backing storage.
+# ---
+# buf: buffer to destroy; safe on nil
+pub fun buf_dnit(buf: *ByteBuf) {
+    if (buf == nil) { ret; }
+    if (buf.data != nil && buf.cap > 0) {
+        deallocate[u8](buf.alloc, buf.data, buf.cap);
+        buf.data = nil;
+    }
+    buf.len = 0;
+    buf.cap = 0;
+}
+
+# emit_byte: append a single byte to the buffer, growing it if needed.
+pub fun emit_byte(buf: *ByteBuf, byte: u8) {
+    if (buf.len >= buf.cap) {
+        var new_cap: usize = BYTEBUF_INIT_CAP;
+        if (buf.cap > 0) { new_cap = buf.cap * 2; }
+        val res_realloc: Result[*u8, str] = reallocate[u8](
+            buf.alloc, buf.data, buf.cap, new_cap
+        );
+        if (is_err[*u8, str](res_realloc)) {
+            panic("encode: byte buffer realloc failed\n");
+        }
+        buf.data = unwrap_ok[*u8, str](res_realloc);
+        buf.cap = new_cap;
+    }
+    buf.data[buf.len] = byte;
+    buf.len = buf.len + 1;
+}
+
+# emit_u16: append 2 bytes little-endian.
+pub fun emit_u16(buf: *ByteBuf, value: u16) {
+    emit_byte(buf, (value & 0xFF)::u8);
+    emit_byte(buf, ((value >> 8) & 0xFF)::u8);
+}
+
+# emit_u32: append 4 bytes little-endian.
+pub fun emit_u32(buf: *ByteBuf, value: u32) {
+    emit_byte(buf, (value & 0xFF)::u8);
+    emit_byte(buf, ((value >> 8) & 0xFF)::u8);
+    emit_byte(buf, ((value >> 16) & 0xFF)::u8);
+    emit_byte(buf, ((value >> 24) & 0xFF)::u8);
+}
+
+# emit_u64: append 8 bytes little-endian.
+pub fun emit_u64(buf: *ByteBuf, value: u64) {
+    emit_u32(buf, (value & 0xFFFFFFFF)::u32);
+    emit_u32(buf, ((value >> 32) & 0xFFFFFFFF)::u32);
+}
+
+# initial capacity for the encoder driver's symbol, relocation, fixup, and
+# block-offset arrays.
+val DRIVER_INIT_CAP: u32 = 16;
+
+# a single pending branch fixup recorded in pass 1 and patched in pass 2: an
+# intra-module branch whose displacement field is at `patch_pos` and whose target
+# is block `target_block` within the function based at `fn_text_base`. the field's
+# width and how a resolved displacement is written into it are ISA-specific (the
+# `EncodeHooks.patch_branch` hook), so this record names only the offsets the
+# shared driver resolves.
+# ---
+# patch_pos:    byte offset of the displacement field within `.text`
+# next_ip:      byte offset of the instruction following the branch within `.text`
+# target_block: destination MIR block id (function-local)
+# fn_text_base: text offset of the owning function's first block
+pub rec BranchFixup {
+    patch_pos:    u32;
+    next_ip:      u32;
+    target_block: u32;
+    fn_text_base: u32;
+}
+
+# one resolved block start: a function-local block id paired with its `.text`
+# offset, used to compute branch displacements in pass 2.
+# ---
+# fn_text_base: text offset of the owning function's first block
+# block_id:     function-local MIR block id
+# offset:       byte offset of the block's first instruction within `.text`
+rec BlockOffset {
+    fn_text_base: u32;
+    block_id:     u32;
+    offset:       u32;
+}
+
+# mutable bookkeeping shared across the encoder driver's two passes. owns the
+# growable text / symbol / relocation / fixup / block-offset arrays until
+# `encode_driver` either transfers the text + symbol + relocation arrays into the
+# returned `EncoderOutput` or frees everything on error. carries no
+# architecture-specific state — every field is ISA-general bookkeeping the shared
+# driver and every ISA's encode hook populate through the `push_*` helpers.
+# ---
+# alloc:        backing allocator
+# buf:          text byte sink
+# syms:         symbol marks
+# sym_count:    number of symbol marks
+# sym_cap:      capacity of `syms`
+# relocs:       pending relocations
+# reloc_count:  number of relocations
+# reloc_cap:    capacity of `relocs`
+# fixups:       pending branch fixups
+# fixup_count:  number of fixups
+# fixup_cap:    capacity of `fixups`
+# blocks:       resolved block offsets
+# block_count:  number of block offsets
+# block_cap:    capacity of `blocks`
+# interner:     session interner; resolves inline-asm `{name}` binding names and
+#               interns symbol names referenced from inline asm into relocations
+# abi:          the target ABI vtable (frame / argument model the encode hook reads)
+# os:           the target OS vtable (stack-probe / commit model the encode hook reads)
+pub rec EncodeState {
+    alloc:       *Allocator;
+    buf:         ByteBuf;
+    syms:        *SymbolMark;
+    sym_count:   u32;
+    sym_cap:     u32;
+    relocs:      *PendingReloc;
+    reloc_count: u32;
+    reloc_cap:   u32;
+    fixups:      *BranchFixup;
+    fixup_count: u32;
+    fixup_cap:   u32;
+    blocks:      *BlockOffset;
+    block_count: u32;
+    block_cap:   u32;
+    interner:    *intern.Interner;
+    abi:         *abi.AbiVTable;
+    os:          *tos.OsVTable;
+}
+
+# EncodeFunctionFn: the per-function encode hook. emits one function's machine
+# code into the shared `EncodeState` — the prologue, the instruction stream, and
+# the epilogue — recording its entry `SymbolMark`, every block's `.text` offset
+# (`push_block`), each cross-function / global symbol reference as a
+# `PendingReloc` (`push_reloc`), and each intra-module branch as a `BranchFixup`
+# (`push_fixup`) for pass 2. owns all opcode, register, relocation-offset, and
+# prologue/epilogue knowledge; the driver supplies only the shared state.
+# ---
+# st: the shared encode state (text sink + mark / reloc / fixup / block arrays)
+# f:  the function to encode
+# ret: ok(true) on success, or an error string from the per-arch encoder
+pub def EncodeFunctionFn: fun(*EncodeState, *mir.MirFunction) Result[bool, str];
+
+# PatchBranchFn: the per-branch patch hook. writes the resolved displacement of
+# one pass-1 `BranchFixup` into its `.text` field now that its target block's
+# offset is known. owns the ISA's branch encoding — the field width and the byte /
+# bitfield layout (x86-64 overwrites a 4-byte rel32; AArch64 inserts an imm26 /
+# imm19 into a 32-bit instruction word) and the displacement convention (relative
+# to `next_ip`, the branch start, etc.). the driver resolves `target_off` and
+# leaves the displacement computation and the write to the hook.
+# ---
+# st:         the shared encode state (its `buf` holds the text being patched)
+# fx:         the fixup to patch (its `patch_pos` / `next_ip` name the site)
+# target_off: the `.text` offset of the branch's resolved target block
+# ret:        ok(true) on success, or an error string (e.g. an out-of-range site)
+pub def PatchBranchFn: fun(*EncodeState, *BranchFixup, u32) Result[bool, str];
+
+# EncodeHooks: the per-ISA seam of the shared two-pass encoder driver. an
+# architecture's encoder supplies one of each and calls `encode_driver`; the
+# driver owns everything else (state lifetime, the function loop, pass-2 block
+# resolution, text right-sizing, and output assembly). these two are the only
+# operations that carry opcode / register / displacement knowledge.
+# ---
+# encode_function: emit one function's bytes into the shared state (pass 1)
+# patch_branch:    write one resolved branch displacement into the text (pass 2)
+pub rec EncodeHooks {
+    encode_function: EncodeFunctionFn;
+    patch_branch:    PatchBranchFn;
+}
+
+# encode_driver: the ISA-agnostic two-pass encoder driver every architecture runs
+# over a fully-resolved MIR module to produce its `EncoderOutput`.
+#
+# initialises an `EncodeState` (empty text sink and mark / reloc / fixup / block
+# arrays, threading the module interner and the target ABI / OS vtables), then
+# runs pass 1 — walking every function in layout order through the ISA's
+# `encode_function` hook, which appends bytes and records symbol marks, pending
+# relocations, branch fixups, and block offsets through the shared `push_*`
+# helpers. pass 2 resolves every recorded `BranchFixup`'s target block offset and
+# hands it to the ISA's `patch_branch` hook to write the displacement. the text is
+# then right-sized (so the object builder's free-by-length matches the allocation)
+# and transferred, with the symbol and relocation arrays, into the returned
+# `EncoderOutput`; the driver-internal fixup and block arrays are released. on any
+# error every owned array is freed and the error propagated. carries no
+# architecture-specific knowledge — the two hooks own all of it.
+# ---
+# alloc: backing allocator for the encoder's output arrays (threaded for parity
+#        with `EncodeFn`; the state is backed by the module allocator, as before)
+# tgt:   resolved compilation target; supplies the ABI / OS vtables the hook reads
+# m:     the fully-resolved MIR module (post isel / regalloc / frame)
+# hooks: the per-ISA encode / patch operations
+# ret:   the populated `EncoderOutput` (owned arrays), or an error string
+pub fun encode_driver(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule, hooks: *EncodeHooks) Result[EncoderOutput, str] {
+    if (tgt == nil)   { ret err[EncoderOutput, str]("encode: nil target"); }
+    if (m == nil)     { ret err[EncoderOutput, str]("encode: nil mir module"); }
+    if (hooks == nil) { ret err[EncoderOutput, str]("encode: nil encode hooks"); }
+    if (hooks.encode_function == nil) {
+        ret err[EncoderOutput, str]("encode: ISA supplied no per-function encode hook");
+    }
+    if (hooks.patch_branch == nil) {
+        ret err[EncoderOutput, str]("encode: ISA supplied no per-branch patch hook");
+    }
+
+    var st: EncodeState;
+    st.alloc       = m.alloc;
+    st.buf         = buf_init(m.alloc);
+    st.syms        = nil;
+    st.sym_count   = 0;
+    st.sym_cap     = 0;
+    st.relocs      = nil;
+    st.reloc_count = 0;
+    st.reloc_cap   = 0;
+    st.fixups      = nil;
+    st.fixup_count = 0;
+    st.fixup_cap   = 0;
+    st.blocks      = nil;
+    st.block_count = 0;
+    st.block_cap   = 0;
+    st.interner    = m.interner;
+    st.abi         = tgt.abi;
+    st.os          = tgt.os;
+
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val ef: Result[bool, str] = hooks.encode_function(?st, ?m.functions[fi]);
+        if (is_err[bool, str](ef)) {
+            free_state(?st);
+            ret err[EncoderOutput, str](unwrap_err[bool, str](ef));
+        }
+        fi = fi + 1;
+    }
+
+    val pb: Result[bool, str] = patch_branches(?st, hooks);
+    if (is_err[bool, str](pb)) {
+        free_state(?st);
+        ret err[EncoderOutput, str](unwrap_err[bool, str](pb));
+    }
+
+    # right-size the text buffer so its allocation length equals `text_len`: the
+    # object builder owns these bytes and frees them by `len`, so the backing
+    # allocation must match exactly rather than the byte buffer's over-allocated
+    # capacity.
+    val tr: Result[bool, str] = shrink_text(?st);
+    if (is_err[bool, str](tr)) {
+        free_state(?st);
+        ret err[EncoderOutput, str](unwrap_err[bool, str](tr));
+    }
+
+    var out: EncoderOutput;
+    out.text         = st.buf.data;
+    out.text_len     = st.buf.len::u32;
+    out.relocations  = st.relocs;
+    out.reloc_count  = st.reloc_count;
+    out.symbols      = st.syms;
+    out.symbol_count = st.sym_count;
+
+    # the text / symbol / relocation arrays are transferred to the output; the
+    # driver-internal fixup and block-offset arrays are released.
+    free_scratch(?st);
+    ret ok[EncoderOutput, str](out);
+}
+
+# shrink the text byte sink so its backing allocation length equals the number of
+# bytes written. the object builder frees the transferred `.text` buffer by its
+# `len`, so the allocation must be exactly `len` bytes wide. a no-op when the
+# buffer is already exact, empty, or unallocated.
+fun shrink_text(st: *EncodeState) Result[bool, str] {
+    if (st.buf.data == nil) { ret ok[bool, str](true); }
+    if (st.buf.len == 0) {
+        deallocate[u8](st.alloc, st.buf.data, st.buf.cap);
+        st.buf.data = nil;
+        st.buf.cap  = 0;
+        ret ok[bool, str](true);
+    }
+    if (st.buf.cap == st.buf.len) { ret ok[bool, str](true); }
+    val r: Result[*u8, str] = reallocate[u8](st.alloc, st.buf.data, st.buf.cap, st.buf.len);
+    if (is_err[*u8, str](r)) { ret err[bool, str](unwrap_err[*u8, str](r)); }
+    st.buf.data = unwrap_ok[*u8, str](r);
+    st.buf.cap  = st.buf.len;
+    ret ok[bool, str](true);
+}
+
+# pass 2: resolve each recorded intra-module branch fixup's target block offset
+# and hand it to the ISA's `patch_branch` hook, which writes the displacement into
+# the text. the displacement convention and field layout are the hook's; the
+# driver only resolves block offsets in the shared block-offset table.
+fun patch_branches(st: *EncodeState, hooks: *EncodeHooks) Result[bool, str] {
+    if (st.buf.data == nil) { ret ok[bool, str](true); }
+    var i: u32 = 0;
+    for (i < st.fixup_count) {
+        val fx: *BranchFixup = ?st.fixups[i];
+        val tr: Result[u32, str] = block_offset(st, fx.fn_text_base, fx.target_block);
+        if (is_err[u32, str](tr)) { ret err[bool, str](unwrap_err[u32, str](tr)); }
+        val target_off: u32 = unwrap_ok[u32, str](tr);
+        val pr: Result[bool, str] = hooks.patch_branch(st, fx, target_off);
+        if (is_err[bool, str](pr)) { ret err[bool, str](unwrap_err[bool, str](pr)); }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# resolve a function-local block id to its `.text` offset. an unrecorded target is
+# a backend bug (a branch to a block the encoder never emitted), rejected loudly
+# rather than resolved to offset 0 (a branch into the first function's middle).
+fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) Result[u32, str] {
+    var i: u32 = 0;
+    for (i < st.block_count) {
+        if (st.blocks[i].fn_text_base == fn_base && st.blocks[i].block_id == block_id) {
+            ret ok[u32, str](st.blocks[i].offset);
+        }
+        i = i + 1;
+    }
+    ret err[u32, str]("encode: branch target block was never recorded");
+}
+
+# classify_refs: determine whether an instruction names an intra-module branch
+# target (a MIR_OP_BLOCK operand) or a relocatable symbol (a MIR_OP_SYM operand),
+# reporting the target block id / interned symbol name through the out-parameters.
+# MIR-level and ISA-agnostic — it reads only the generic operand model, so every
+# architecture's encode hook uses it to drive fixup / relocation recording.
+# ---
+# mi:           the instruction to inspect
+# target_block: out — the referenced block id (0 when none)
+# has_block:    out — true when a MIR_OP_BLOCK operand was found
+# sym:          out — the referenced interned symbol name (STR_NIL when none)
+# has_sym:      out — true when a MIR_OP_SYM operand was found
+# sym_addend:   out — the symbol operand's constant offset
+pub fun classify_refs(mi: *mir.MirInstr, target_block: *u32, has_block: *bool,
+                      sym: *intern.StrId, has_sym: *bool, sym_addend: *i32) {
+    var found_block: bool = false;
+    var found_sym: bool = false;
+    @has_block = false;
+    @has_sym   = false;
+    @target_block = 0;
+    @sym = intern.STR_NIL;
+    @sym_addend = 0;
+    var k: u32 = 0;
+    for (k < mi.operand_count) {
+        val op: *mir.MirOperand = ?mi.operands[k];
+        if (op.kind == mir.MIR_OP_BLOCK && found_block == false) {
+            found_block = true;
+            @has_block = true;
+            @target_block = op.imm::u32;
+        }
+        if (op.kind == mir.MIR_OP_SYM && found_sym == false) {
+            found_sym = true;
+            @has_sym = true;
+            @sym = op.sym;
+            @sym_addend = op.sym_off;
+        }
+        k = k + 1;
+    }
+}
+
+# push_symbol: append a symbol mark, growing the symbol array on demand.
+pub fun push_symbol(st: *EncodeState, name: intern.StrId, offset: u32, flags: u32) Result[bool, str] {
+    if (st.sym_count >= st.sym_cap) {
+        val gr: Result[bool, str] = grow_symbols(st);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    st.syms[st.sym_count].name   = name;
+    st.syms[st.sym_count].offset = offset;
+    st.syms[st.sym_count].flags  = flags;
+    st.sym_count = st.sym_count + 1;
+    ret ok[bool, str](true);
+}
+
+# push_reloc: append a pending relocation, growing the relocation array on demand.
+pub fun push_reloc(st: *EncodeState, offset: u32, kind: of.RelocKind, sym: intern.StrId, addend: i32) Result[bool, str] {
+    if (st.reloc_count >= st.reloc_cap) {
+        val gr: Result[bool, str] = grow_relocs(st);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    st.relocs[st.reloc_count].offset = offset;
+    st.relocs[st.reloc_count].kind   = kind;
+    st.relocs[st.reloc_count].sym    = sym;
+    st.relocs[st.reloc_count].addend = addend;
+    st.reloc_count = st.reloc_count + 1;
+    ret ok[bool, str](true);
+}
+
+# push_fixup: append a branch fixup, growing the fixup array on demand.
+pub fun push_fixup(st: *EncodeState, patch_pos: u32, next_ip: u32, target_block: u32, fn_text_base: u32) Result[bool, str] {
+    if (st.fixup_count >= st.fixup_cap) {
+        val gr: Result[bool, str] = grow_fixups(st);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    st.fixups[st.fixup_count].patch_pos    = patch_pos;
+    st.fixups[st.fixup_count].next_ip      = next_ip;
+    st.fixups[st.fixup_count].target_block = target_block;
+    st.fixups[st.fixup_count].fn_text_base = fn_text_base;
+    st.fixup_count = st.fixup_count + 1;
+    ret ok[bool, str](true);
+}
+
+# push_block: append a resolved block offset, growing the block-offset array on demand.
+pub fun push_block(st: *EncodeState, fn_text_base: u32, block_id: u32, offset: u32) Result[bool, str] {
+    if (st.block_count >= st.block_cap) {
+        val gr: Result[bool, str] = grow_blocks(st);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    st.blocks[st.block_count].fn_text_base = fn_text_base;
+    st.blocks[st.block_count].block_id     = block_id;
+    st.blocks[st.block_count].offset       = offset;
+    st.block_count = st.block_count + 1;
+    ret ok[bool, str](true);
+}
+
+# grow the symbol-mark array (or allocate it on first use).
+fun grow_symbols(st: *EncodeState) Result[bool, str] {
+    if (st.syms == nil) {
+        val r: Result[*SymbolMark, str] = allocate[SymbolMark](st.alloc, DRIVER_INIT_CAP::usize);
+        if (is_err[*SymbolMark, str](r)) { ret err[bool, str](unwrap_err[*SymbolMark, str](r)); }
+        st.syms    = unwrap_ok[*SymbolMark, str](r);
+        st.sym_cap = DRIVER_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = st.sym_cap * 2;
+    val r: Result[*SymbolMark, str] = reallocate[SymbolMark](st.alloc, st.syms, st.sym_cap::usize, nc::usize);
+    if (is_err[*SymbolMark, str](r)) { ret err[bool, str](unwrap_err[*SymbolMark, str](r)); }
+    st.syms    = unwrap_ok[*SymbolMark, str](r);
+    st.sym_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# grow the relocation array (or allocate it on first use).
+fun grow_relocs(st: *EncodeState) Result[bool, str] {
+    if (st.relocs == nil) {
+        val r: Result[*PendingReloc, str] = allocate[PendingReloc](st.alloc, DRIVER_INIT_CAP::usize);
+        if (is_err[*PendingReloc, str](r)) { ret err[bool, str](unwrap_err[*PendingReloc, str](r)); }
+        st.relocs    = unwrap_ok[*PendingReloc, str](r);
+        st.reloc_cap = DRIVER_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = st.reloc_cap * 2;
+    val r: Result[*PendingReloc, str] = reallocate[PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize, nc::usize);
+    if (is_err[*PendingReloc, str](r)) { ret err[bool, str](unwrap_err[*PendingReloc, str](r)); }
+    st.relocs    = unwrap_ok[*PendingReloc, str](r);
+    st.reloc_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# grow the branch-fixup array (or allocate it on first use).
+fun grow_fixups(st: *EncodeState) Result[bool, str] {
+    if (st.fixups == nil) {
+        val r: Result[*BranchFixup, str] = allocate[BranchFixup](st.alloc, DRIVER_INIT_CAP::usize);
+        if (is_err[*BranchFixup, str](r)) { ret err[bool, str](unwrap_err[*BranchFixup, str](r)); }
+        st.fixups    = unwrap_ok[*BranchFixup, str](r);
+        st.fixup_cap = DRIVER_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = st.fixup_cap * 2;
+    val r: Result[*BranchFixup, str] = reallocate[BranchFixup](st.alloc, st.fixups, st.fixup_cap::usize, nc::usize);
+    if (is_err[*BranchFixup, str](r)) { ret err[bool, str](unwrap_err[*BranchFixup, str](r)); }
+    st.fixups    = unwrap_ok[*BranchFixup, str](r);
+    st.fixup_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# grow the block-offset array (or allocate it on first use).
+fun grow_blocks(st: *EncodeState) Result[bool, str] {
+    if (st.blocks == nil) {
+        val r: Result[*BlockOffset, str] = allocate[BlockOffset](st.alloc, DRIVER_INIT_CAP::usize);
+        if (is_err[*BlockOffset, str](r)) { ret err[bool, str](unwrap_err[*BlockOffset, str](r)); }
+        st.blocks    = unwrap_ok[*BlockOffset, str](r);
+        st.block_cap = DRIVER_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = st.block_cap * 2;
+    val r: Result[*BlockOffset, str] = reallocate[BlockOffset](st.alloc, st.blocks, st.block_cap::usize, nc::usize);
+    if (is_err[*BlockOffset, str](r)) { ret err[bool, str](unwrap_err[*BlockOffset, str](r)); }
+    st.blocks    = unwrap_ok[*BlockOffset, str](r);
+    st.block_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# free_scratch: release the driver-internal scratch arrays (fixups, block offsets)
+# once their work is done; the text / symbol / relocation arrays survive into
+# EncoderOutput.
+fun free_scratch(st: *EncodeState) {
+    if (st.fixups != nil && st.fixup_cap > 0) {
+        deallocate[BranchFixup](st.alloc, st.fixups, st.fixup_cap::usize);
+        st.fixups = nil;
+    }
+    if (st.blocks != nil && st.block_cap > 0) {
+        deallocate[BlockOffset](st.alloc, st.blocks, st.block_cap::usize);
+        st.blocks = nil;
+    }
+}
+
+# free_state: release every owned array on the error path, including the text sink
+# and the symbol / relocation arrays that would otherwise transfer into
+# EncoderOutput.
+fun free_state(st: *EncodeState) {
+    buf_dnit(?st.buf);
+    if (st.syms != nil && st.sym_cap > 0) {
+        deallocate[SymbolMark](st.alloc, st.syms, st.sym_cap::usize);
+        st.syms = nil;
+    }
+    if (st.relocs != nil && st.reloc_cap > 0) {
+        deallocate[PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize);
+        st.relocs = nil;
+    }
+    free_scratch(st);
 }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -66,88 +66,26 @@ use tos:    mach.lang.target.os;
 use mir:    mach.lang.be.codegen.mir;
 use enc:    mach.lang.be.codegen.encode;
 
-# initial capacity of a freshly grown encoder byte buffer.
-val BYTEBUF_INIT_CAP: usize = 256;
-
-# a growable byte sink the encoders write machine code into. the back end
-# drains `data[0..len]` into the object image's `.text` section after every
-# function is encoded; keeping the growth bookkeeping here lets `of.Section`
-# stay a finalized container.
-# ---
-# data:  backing byte array (nil until the first byte is appended)
-# len:   number of bytes written
-# cap:   allocated capacity
-# alloc: allocator backing `data`
-pub rec ByteBuf {
-    data:  *u8;
-    len:   usize;
-    cap:   usize;
-    alloc: *Allocator;
-}
-
-# buf_init: construct an empty encoder byte buffer.
-# ---
-# alloc: allocator backing the buffer's storage
-# ret:   an empty ByteBuf
-pub fun buf_init(alloc: *Allocator) ByteBuf {
-    var buf: ByteBuf;
-    buf.data  = nil;
-    buf.len   = 0;
-    buf.cap   = 0;
-    buf.alloc = alloc;
-    ret buf;
-}
-
-# buf_dnit: free a byte buffer's backing storage.
-# ---
-# buf: buffer to destroy; safe on nil
-pub fun buf_dnit(buf: *ByteBuf) {
-    if (buf == nil) { ret; }
-    if (buf.data != nil && buf.cap > 0) {
-        deallocate[u8](buf.alloc, buf.data, buf.cap);
-        buf.data = nil;
-    }
-    buf.len = 0;
-    buf.cap = 0;
-}
-
-# emit_byte: append a single byte to the buffer, growing it if needed.
-fun emit_byte(buf: *ByteBuf, byte: u8) {
-    if (buf.len >= buf.cap) {
-        var new_cap: usize = BYTEBUF_INIT_CAP;
-        if (buf.cap > 0) { new_cap = buf.cap * 2; }
-        val res_realloc: Result[*u8, str] = reallocate[u8](
-            buf.alloc, buf.data, buf.cap, new_cap
-        );
-        if (is_err[*u8, str](res_realloc)) {
-            panic("encode: byte buffer realloc failed\n");
-        }
-        buf.data = unwrap_ok[*u8, str](res_realloc);
-        buf.cap = new_cap;
-    }
-    buf.data[buf.len] = byte;
-    buf.len = buf.len + 1;
-}
-
-# emit_u16: append 2 bytes little-endian.
-fun emit_u16(buf: *ByteBuf, value: u16) {
-    emit_byte(buf, (value & 0xFF)::u8);
-    emit_byte(buf, ((value >> 8) & 0xFF)::u8);
-}
-
-# emit_u32: append 4 bytes little-endian.
-fun emit_u32(buf: *ByteBuf, value: u32) {
-    emit_byte(buf, (value & 0xFF)::u8);
-    emit_byte(buf, ((value >> 8) & 0xFF)::u8);
-    emit_byte(buf, ((value >> 16) & 0xFF)::u8);
-    emit_byte(buf, ((value >> 24) & 0xFF)::u8);
-}
-
-# emit_u64: append 8 bytes little-endian.
-fun emit_u64(buf: *ByteBuf, value: u64) {
-    emit_u32(buf, (value & 0xFFFFFFFF)::u32);
-    emit_u32(buf, ((value >> 32) & 0xFFFFFFFF)::u32);
-}
+# the ISA-agnostic two-pass driver, its state, byte sink, and array helpers live
+# in the shared `enc` module; this backend consumes them by name (the per-ISA
+# opcode / register / displacement knowledge stays here) and supplies the two
+# `enc.EncodeHooks` — `encode_function` and `patch_branch_x86`.
+use mach.lang.be.codegen.encode.ByteBuf;
+use mach.lang.be.codegen.encode.EncodeState;
+use mach.lang.be.codegen.encode.BranchFixup;
+use mach.lang.be.codegen.encode.EncodeHooks;
+use mach.lang.be.codegen.encode.buf_init;
+use mach.lang.be.codegen.encode.buf_dnit;
+use mach.lang.be.codegen.encode.emit_byte;
+use mach.lang.be.codegen.encode.emit_u16;
+use mach.lang.be.codegen.encode.emit_u32;
+use mach.lang.be.codegen.encode.emit_u64;
+use mach.lang.be.codegen.encode.classify_refs;
+use mach.lang.be.codegen.encode.push_symbol;
+use mach.lang.be.codegen.encode.push_reloc;
+use mach.lang.be.codegen.encode.push_fixup;
+use mach.lang.be.codegen.encode.push_block;
+use mach.lang.be.codegen.encode.encode_driver;
 
 # reg_bits: low 3 bits of a register id for encoding. the id is a composite
 # register id (class tag in the high byte); the within-bank index drives the
@@ -2502,89 +2440,17 @@ fun zero_inst(inst: *isa.Inst) {
 # universal operand size — only the word-sized default.
 val DEFAULT_OPERAND_SIZE: u8 = 8;
 
-# initial capacity for the encoder driver's symbol, relocation, fixup, and
-# block-offset arrays.
-val DRIVER_INIT_CAP: u32 = 16;
-
-# a single pending branch fixup recorded in pass 1 and patched in pass 2: an
-# intra-module branch whose rel32 displacement field is at `patch_pos` and whose
-# target is block `target_block` within the function based at `fn_text_base`.
-# ---
-# patch_pos:    byte offset of the rel32 field within `.text`
-# next_ip:      byte offset of the instruction following the branch within `.text`
-# target_block: destination MIR block id (function-local)
-# fn_text_base: text offset of the owning function's first block
-rec BranchFixup {
-    patch_pos:    u32;
-    next_ip:      u32;
-    target_block: u32;
-    fn_text_base: u32;
-}
-
-# one resolved block start: a function-local block id paired with its `.text`
-# offset, used to compute branch displacements in pass 2.
-# ---
-# fn_text_base: text offset of the owning function's first block
-# block_id:     function-local MIR block id
-# offset:       byte offset of the block's first instruction within `.text`
-rec BlockOffset {
-    fn_text_base: u32;
-    block_id:     u32;
-    offset:       u32;
-}
-
-# mutable bookkeeping shared across the encoder driver's two passes. owns the
-# growable text/symbol/relocation/fixup/block-offset arrays until `run` either
-# transfers the text + symbol + relocation arrays into the returned
-# `enc.EncoderOutput` or frees everything on error.
-# ---
-# alloc:        backing allocator
-# buf:          text byte sink
-# syms:         symbol marks
-# sym_count:    number of symbol marks
-# sym_cap:      capacity of `syms`
-# relocs:       pending relocations
-# reloc_count:  number of relocations
-# reloc_cap:    capacity of `relocs`
-# fixups:       pending branch fixups
-# fixup_count:  number of fixups
-# fixup_cap:    capacity of `fixups`
-# blocks:       resolved block offsets
-# block_count:  number of block offsets
-# block_cap:    capacity of `blocks`
-# interner:     session interner; resolves inline-asm `{name}` binding names and
-#               interns symbol names referenced from inline asm into relocations
-rec EncodeState {
-    alloc:       *Allocator;
-    buf:         ByteBuf;
-    syms:        *enc.SymbolMark;
-    sym_count:   u32;
-    sym_cap:     u32;
-    relocs:      *enc.PendingReloc;
-    reloc_count: u32;
-    reloc_cap:   u32;
-    fixups:      *BranchFixup;
-    fixup_count: u32;
-    fixup_cap:   u32;
-    blocks:      *BlockOffset;
-    block_count: u32;
-    block_cap:   u32;
-    interner:    *intern.Interner;
-    abi:         *abi.AbiVTable;
-    os:          *tos.OsVTable;
-}
-
-# encode_x64: encode a fully-resolved MIR module into `.text` bytes, symbol
-# marks, and pending relocations.
+# encode_x64: the x86-64 ISA's `encode` entry point — a thin wrapper that supplies
+# the two x86-64 `enc.EncodeHooks` and runs the shared two-pass driver.
 #
-# walks every function in layout order. each function entry is recorded as a
-# `enc.SymbolMark`. instructions are translated from the post-regalloc MIR operand
-# model into the target-agnostic `isa.Inst` form and emitted through the
-# per-instruction encoder. pass 1 emits bytes (branch displacements to
-# not-yet-known blocks are left as the encoder's zero placeholders and recorded
-# as fixups); cross-function / global symbol references become `enc.PendingReloc`
-# entries placed with `x86_reloc_offset`. pass 2 patches every intra-module
-# branch displacement now that every block offset is known.
+# the ISA-general driving — state lifetime, the per-function loop, pass-2 block
+# resolution, text right-sizing, and `enc.EncoderOutput` assembly — lives in
+# `enc.encode_driver`. this backend contributes only its per-function encode
+# (`encode_function`: prologue / instruction stream / epilogue, recording symbol
+# marks, `enc.PendingReloc` entries placed with `x86_reloc_offset`, and branch
+# fixups) and its per-branch patch (`patch_branch_x86`: the rel32 overwrite). the
+# erased vtable pointer is cast back to this exact signature, so it must not
+# change.
 # ---
 # alloc: allocator backing the encoder output's owned arrays
 # tgt:   resolved target; must be x86-64. relocations are emitted with the
@@ -2592,85 +2458,31 @@ rec EncodeState {
 # m:     the fully-resolved MIR module (post isel / regalloc / frame)
 # ret:   the populated enc.EncoderOutput (owned arrays), or an error string
 pub fun encode_x64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Result[enc.EncoderOutput, str] {
-    if (tgt == nil) { ret err[enc.EncoderOutput, str]("encode: nil target"); }
-    if (m == nil)   { ret err[enc.EncoderOutput, str]("encode: nil mir module"); }
-
-    var st: EncodeState;
-    st.alloc       = m.alloc;
-    st.buf         = buf_init(m.alloc);
-    st.syms        = nil;
-    st.sym_count   = 0;
-    st.sym_cap     = 0;
-    st.relocs      = nil;
-    st.reloc_count = 0;
-    st.reloc_cap   = 0;
-    st.fixups      = nil;
-    st.fixup_count = 0;
-    st.fixup_cap   = 0;
-    st.blocks      = nil;
-    st.block_count = 0;
-    st.block_cap   = 0;
-    st.interner    = m.interner;
-    st.abi         = tgt.abi;
-    st.os          = tgt.os;
-
-    var fi: u32 = 0;
-    for (fi < m.function_len) {
-        val ef: Result[bool, str] = encode_function(?st, ?m.functions[fi]);
-        if (is_err[bool, str](ef)) {
-            free_state(?st);
-            ret err[enc.EncoderOutput, str](unwrap_err[bool, str](ef));
-        }
-        fi = fi + 1;
-    }
-
-    val pb: Result[bool, str] = patch_branches(?st);
-    if (is_err[bool, str](pb)) {
-        free_state(?st);
-        ret err[enc.EncoderOutput, str](unwrap_err[bool, str](pb));
-    }
-
-    # right-size the text buffer so its allocation length equals `text_len`: the
-    # object builder owns these bytes and frees them by `len`, so the backing
-    # allocation must match exactly rather than the byte buffer's over-allocated
-    # capacity.
-    val tr: Result[bool, str] = shrink_text(?st);
-    if (is_err[bool, str](tr)) {
-        free_state(?st);
-        ret err[enc.EncoderOutput, str](unwrap_err[bool, str](tr));
-    }
-
-    var out: enc.EncoderOutput;
-    out.text         = st.buf.data;
-    out.text_len     = st.buf.len::u32;
-    out.relocations  = st.relocs;
-    out.reloc_count  = st.reloc_count;
-    out.symbols      = st.syms;
-    out.symbol_count = st.sym_count;
-
-    # the text / symbol / relocation arrays are transferred to the output; the
-    # driver-internal fixup and block-offset arrays are released.
-    free_scratch(?st);
-    ret ok[enc.EncoderOutput, str](out);
+    var hooks: EncodeHooks;
+    hooks.encode_function = encode_function;
+    hooks.patch_branch    = patch_branch_x86;
+    ret encode_driver(alloc, tgt, m, ?hooks);
 }
 
-# shrink the text byte sink so its backing allocation length equals the number
-# of bytes written. the object builder frees the transferred `.text` buffer by
-# its `len`, so the allocation must be exactly `len` bytes wide. a no-op when the
-# buffer is already exact, empty, or unallocated.
-fun shrink_text(st: *EncodeState) Result[bool, str] {
-    if (st.buf.data == nil) { ret ok[bool, str](true); }
-    if (st.buf.len == 0) {
-        deallocate[u8](st.alloc, st.buf.data, st.buf.cap);
-        st.buf.data = nil;
-        st.buf.cap  = 0;
-        ret ok[bool, str](true);
+# patch_branch_x86: the x86-64 per-branch patch hook (pass 2). writes the resolved
+# intra-module branch displacement into its rel32 field — the distance from the
+# end of the branch (`fx.next_ip`) to the start of its target block (`target_off`),
+# overwritten as four little-endian bytes at `fx.patch_pos`. the rel32 width and
+# the `next_ip`-relative convention are x86-64's, so they live here rather than in
+# the shared driver. an out-of-range patch site is a backend bug (the site was
+# recorded when its branch was emitted), rejected loudly rather than skipped (which
+# would leave a zero rel32 branching into the first function).
+# ---
+# st:         the shared encode state (its `buf` holds the text being patched)
+# fx:         the fixup to patch
+# target_off: the `.text` offset of the resolved target block
+# ret:        ok(true) on success, or an error on an out-of-range site
+fun patch_branch_x86(st: *EncodeState, fx: *BranchFixup, target_off: u32) Result[bool, str] {
+    val disp: i32 = target_off::i32 - fx.next_ip::i32;
+    if (fx.patch_pos::usize + 4 > st.buf.len) {
+        ret err[bool, str]("encode: branch fixup site is outside the text buffer");
     }
-    if (st.buf.cap == st.buf.len) { ret ok[bool, str](true); }
-    val r: Result[*u8, str] = reallocate[u8](st.alloc, st.buf.data, st.buf.cap, st.buf.len);
-    if (is_err[*u8, str](r)) { ret err[bool, str](unwrap_err[*u8, str](r)); }
-    st.buf.data = unwrap_ok[*u8, str](r);
-    st.buf.cap  = st.buf.len;
+    patch_rel32(?st.buf, fx.patch_pos::usize, disp);
     ret ok[bool, str](true);
 }
 
@@ -4312,6 +4124,9 @@ val ASMOP_SYM:  u8 = 4;
 # same number updates `offset`, so a backward `Nb` reference always binds to the
 # nearest preceding definition.
 # ---
+# initial capacity for the inline-asm numeric-label definition / fixup arrays.
+val ASM_LABEL_INIT_CAP: u32 = 16;
+
 # number: the numeric label
 # offset: byte offset of the definition within `.text`
 rec AsmLabelDef {
@@ -4493,10 +4308,10 @@ fun asm_label_push_fixup(labels: *AsmLabelState, patch_pos: u32, next_ip: u32, n
 # grow the label-definition array (or allocate it on first use).
 fun grow_asm_label_defs(labels: *AsmLabelState) Result[bool, str] {
     if (labels.defs == nil) {
-        val r: Result[*AsmLabelDef, str] = allocate[AsmLabelDef](labels.alloc, DRIVER_INIT_CAP::usize);
+        val r: Result[*AsmLabelDef, str] = allocate[AsmLabelDef](labels.alloc, ASM_LABEL_INIT_CAP::usize);
         if (is_err[*AsmLabelDef, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelDef, str](r)); }
         labels.defs    = unwrap_ok[*AsmLabelDef, str](r);
-        labels.def_cap = DRIVER_INIT_CAP;
+        labels.def_cap = ASM_LABEL_INIT_CAP;
         ret ok[bool, str](true);
     }
     val nc: u32 = labels.def_cap * 2;
@@ -4510,10 +4325,10 @@ fun grow_asm_label_defs(labels: *AsmLabelState) Result[bool, str] {
 # grow the label-fixup array (or allocate it on first use).
 fun grow_asm_label_fixups(labels: *AsmLabelState) Result[bool, str] {
     if (labels.fixups == nil) {
-        val r: Result[*AsmLabelFixup, str] = allocate[AsmLabelFixup](labels.alloc, DRIVER_INIT_CAP::usize);
+        val r: Result[*AsmLabelFixup, str] = allocate[AsmLabelFixup](labels.alloc, ASM_LABEL_INIT_CAP::usize);
         if (is_err[*AsmLabelFixup, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelFixup, str](r)); }
         labels.fixups    = unwrap_ok[*AsmLabelFixup, str](r);
-        labels.fixup_cap = DRIVER_INIT_CAP;
+        labels.fixup_cap = ASM_LABEL_INIT_CAP;
         ret ok[bool, str](true);
     }
     val nc: u32 = labels.fixup_cap * 2;
@@ -5842,74 +5657,6 @@ test "x64.encode: encode_push imm8/imm32 boundaries and out-of-range rejection" 
     ret bad;
 }
 
-# determine whether an instruction names an intra-module branch target (a
-# MIR_OP_BLOCK operand) or a relocatable symbol (a MIR_OP_SYM operand), reporting
-# the target block id / interned symbol name through the out-parameters.
-fun classify_refs(mi: *mir.MirInstr, target_block: *u32, has_block: *bool,
-                  sym: *intern.StrId, has_sym: *bool, sym_addend: *i32) {
-    var found_block: bool = false;
-    var found_sym: bool = false;
-    @has_block = false;
-    @has_sym   = false;
-    @target_block = 0;
-    @sym = intern.STR_NIL;
-    @sym_addend = 0;
-    var k: u32 = 0;
-    for (k < mi.operand_count) {
-        val op: *mir.MirOperand = ?mi.operands[k];
-        if (op.kind == mir.MIR_OP_BLOCK && found_block == false) {
-            found_block = true;
-            @has_block = true;
-            @target_block = op.imm::u32;
-        }
-        if (op.kind == mir.MIR_OP_SYM && found_sym == false) {
-            found_sym = true;
-            @has_sym = true;
-            @sym = op.sym;
-            @sym_addend = op.sym_off;
-        }
-        k = k + 1;
-    }
-}
-
-# pass 2: patch each recorded intra-module branch fixup with the rel32
-# displacement from the end of the branch to the start of its target block.
-fun patch_branches(st: *EncodeState) Result[bool, str] {
-    if (st.buf.data == nil) { ret ok[bool, str](true); }
-    var i: u32 = 0;
-    for (i < st.fixup_count) {
-        val fx: *BranchFixup = ?st.fixups[i];
-        val tr: Result[u32, str] = block_offset(st, fx.fn_text_base, fx.target_block);
-        if (is_err[u32, str](tr)) { ret err[bool, str](unwrap_err[u32, str](tr)); }
-        val target_off: u32 = unwrap_ok[u32, str](tr);
-        val disp: i32 = target_off::i32 - fx.next_ip::i32;
-        # the fixup site was recorded when its branch was emitted, so it must lie
-        # within the text buffer; an out-of-range site is a backend bug, rejected
-        # loudly rather than skipped (which would leave a zero rel32 branching into
-        # the first function).
-        if (fx.patch_pos::usize + 4 > st.buf.len) {
-            ret err[bool, str]("encode: branch fixup site is outside the text buffer");
-        }
-        patch_rel32(?st.buf, fx.patch_pos::usize, disp);
-        i = i + 1;
-    }
-    ret ok[bool, str](true);
-}
-
-# resolve a function-local block id to its `.text` offset. an unrecorded target is
-# a backend bug (a branch to a block the encoder never emitted), rejected loudly
-# rather than resolved to offset 0 (a branch into the first function's middle).
-fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) Result[u32, str] {
-    var i: u32 = 0;
-    for (i < st.block_count) {
-        if (st.blocks[i].fn_text_base == fn_base && st.blocks[i].block_id == block_id) {
-            ret ok[u32, str](st.blocks[i].offset);
-        }
-        i = i + 1;
-    }
-    ret err[u32, str]("encode: branch target block was never recorded");
-}
-
 # build an inactive (OPK_NONE) operand with no register references.
 fun none_operand() isa.Operand {
     var op: isa.Operand;
@@ -5924,156 +5671,6 @@ fun none_operand() isa.Operand {
     op.sym_id = 0;
     op.label  = nil;
     ret op;
-}
-
-# append a symbol mark, growing the symbol array on demand.
-fun push_symbol(st: *EncodeState, name: intern.StrId, offset: u32, flags: u32) Result[bool, str] {
-    if (st.sym_count >= st.sym_cap) {
-        val gr: Result[bool, str] = grow_symbols(st);
-        if (is_err[bool, str](gr)) { ret gr; }
-    }
-    st.syms[st.sym_count].name   = name;
-    st.syms[st.sym_count].offset = offset;
-    st.syms[st.sym_count].flags  = flags;
-    st.sym_count = st.sym_count + 1;
-    ret ok[bool, str](true);
-}
-
-# append a pending relocation, growing the relocation array on demand.
-fun push_reloc(st: *EncodeState, offset: u32, kind: of.RelocKind, sym: intern.StrId, addend: i32) Result[bool, str] {
-    if (st.reloc_count >= st.reloc_cap) {
-        val gr: Result[bool, str] = grow_relocs(st);
-        if (is_err[bool, str](gr)) { ret gr; }
-    }
-    st.relocs[st.reloc_count].offset = offset;
-    st.relocs[st.reloc_count].kind   = kind;
-    st.relocs[st.reloc_count].sym    = sym;
-    st.relocs[st.reloc_count].addend = addend;
-    st.reloc_count = st.reloc_count + 1;
-    ret ok[bool, str](true);
-}
-
-# append a branch fixup, growing the fixup array on demand.
-fun push_fixup(st: *EncodeState, patch_pos: u32, next_ip: u32, target_block: u32, fn_text_base: u32) Result[bool, str] {
-    if (st.fixup_count >= st.fixup_cap) {
-        val gr: Result[bool, str] = grow_fixups(st);
-        if (is_err[bool, str](gr)) { ret gr; }
-    }
-    st.fixups[st.fixup_count].patch_pos    = patch_pos;
-    st.fixups[st.fixup_count].next_ip      = next_ip;
-    st.fixups[st.fixup_count].target_block = target_block;
-    st.fixups[st.fixup_count].fn_text_base = fn_text_base;
-    st.fixup_count = st.fixup_count + 1;
-    ret ok[bool, str](true);
-}
-
-# append a resolved block offset, growing the block-offset array on demand.
-fun push_block(st: *EncodeState, fn_text_base: u32, block_id: u32, offset: u32) Result[bool, str] {
-    if (st.block_count >= st.block_cap) {
-        val gr: Result[bool, str] = grow_blocks(st);
-        if (is_err[bool, str](gr)) { ret gr; }
-    }
-    st.blocks[st.block_count].fn_text_base = fn_text_base;
-    st.blocks[st.block_count].block_id     = block_id;
-    st.blocks[st.block_count].offset       = offset;
-    st.block_count = st.block_count + 1;
-    ret ok[bool, str](true);
-}
-
-# grow the symbol-mark array (or allocate it on first use).
-fun grow_symbols(st: *EncodeState) Result[bool, str] {
-    if (st.syms == nil) {
-        val r: Result[*enc.SymbolMark, str] = allocate[enc.SymbolMark](st.alloc, DRIVER_INIT_CAP::usize);
-        if (is_err[*enc.SymbolMark, str](r)) { ret err[bool, str](unwrap_err[*enc.SymbolMark, str](r)); }
-        st.syms    = unwrap_ok[*enc.SymbolMark, str](r);
-        st.sym_cap = DRIVER_INIT_CAP;
-        ret ok[bool, str](true);
-    }
-    val nc: u32 = st.sym_cap * 2;
-    val r: Result[*enc.SymbolMark, str] = reallocate[enc.SymbolMark](st.alloc, st.syms, st.sym_cap::usize, nc::usize);
-    if (is_err[*enc.SymbolMark, str](r)) { ret err[bool, str](unwrap_err[*enc.SymbolMark, str](r)); }
-    st.syms    = unwrap_ok[*enc.SymbolMark, str](r);
-    st.sym_cap = nc;
-    ret ok[bool, str](true);
-}
-
-# grow the relocation array (or allocate it on first use).
-fun grow_relocs(st: *EncodeState) Result[bool, str] {
-    if (st.relocs == nil) {
-        val r: Result[*enc.PendingReloc, str] = allocate[enc.PendingReloc](st.alloc, DRIVER_INIT_CAP::usize);
-        if (is_err[*enc.PendingReloc, str](r)) { ret err[bool, str](unwrap_err[*enc.PendingReloc, str](r)); }
-        st.relocs    = unwrap_ok[*enc.PendingReloc, str](r);
-        st.reloc_cap = DRIVER_INIT_CAP;
-        ret ok[bool, str](true);
-    }
-    val nc: u32 = st.reloc_cap * 2;
-    val r: Result[*enc.PendingReloc, str] = reallocate[enc.PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize, nc::usize);
-    if (is_err[*enc.PendingReloc, str](r)) { ret err[bool, str](unwrap_err[*enc.PendingReloc, str](r)); }
-    st.relocs    = unwrap_ok[*enc.PendingReloc, str](r);
-    st.reloc_cap = nc;
-    ret ok[bool, str](true);
-}
-
-# grow the branch-fixup array (or allocate it on first use).
-fun grow_fixups(st: *EncodeState) Result[bool, str] {
-    if (st.fixups == nil) {
-        val r: Result[*BranchFixup, str] = allocate[BranchFixup](st.alloc, DRIVER_INIT_CAP::usize);
-        if (is_err[*BranchFixup, str](r)) { ret err[bool, str](unwrap_err[*BranchFixup, str](r)); }
-        st.fixups    = unwrap_ok[*BranchFixup, str](r);
-        st.fixup_cap = DRIVER_INIT_CAP;
-        ret ok[bool, str](true);
-    }
-    val nc: u32 = st.fixup_cap * 2;
-    val r: Result[*BranchFixup, str] = reallocate[BranchFixup](st.alloc, st.fixups, st.fixup_cap::usize, nc::usize);
-    if (is_err[*BranchFixup, str](r)) { ret err[bool, str](unwrap_err[*BranchFixup, str](r)); }
-    st.fixups    = unwrap_ok[*BranchFixup, str](r);
-    st.fixup_cap = nc;
-    ret ok[bool, str](true);
-}
-
-# grow the block-offset array (or allocate it on first use).
-fun grow_blocks(st: *EncodeState) Result[bool, str] {
-    if (st.blocks == nil) {
-        val r: Result[*BlockOffset, str] = allocate[BlockOffset](st.alloc, DRIVER_INIT_CAP::usize);
-        if (is_err[*BlockOffset, str](r)) { ret err[bool, str](unwrap_err[*BlockOffset, str](r)); }
-        st.blocks    = unwrap_ok[*BlockOffset, str](r);
-        st.block_cap = DRIVER_INIT_CAP;
-        ret ok[bool, str](true);
-    }
-    val nc: u32 = st.block_cap * 2;
-    val r: Result[*BlockOffset, str] = reallocate[BlockOffset](st.alloc, st.blocks, st.block_cap::usize, nc::usize);
-    if (is_err[*BlockOffset, str](r)) { ret err[bool, str](unwrap_err[*BlockOffset, str](r)); }
-    st.blocks    = unwrap_ok[*BlockOffset, str](r);
-    st.block_cap = nc;
-    ret ok[bool, str](true);
-}
-
-# release the driver-internal scratch arrays (fixups, block offsets) once their
-# work is done; the text / symbol / relocation arrays survive into enc.EncoderOutput.
-fun free_scratch(st: *EncodeState) {
-    if (st.fixups != nil && st.fixup_cap > 0) {
-        deallocate[BranchFixup](st.alloc, st.fixups, st.fixup_cap::usize);
-        st.fixups = nil;
-    }
-    if (st.blocks != nil && st.block_cap > 0) {
-        deallocate[BlockOffset](st.alloc, st.blocks, st.block_cap::usize);
-        st.blocks = nil;
-    }
-}
-
-# release every owned array on the error path, including the text sink and the
-# symbol / relocation arrays that would otherwise transfer into enc.EncoderOutput.
-fun free_state(st: *EncodeState) {
-    buf_dnit(?st.buf);
-    if (st.syms != nil && st.sym_cap > 0) {
-        deallocate[enc.SymbolMark](st.alloc, st.syms, st.sym_cap::usize);
-        st.syms = nil;
-    }
-    if (st.relocs != nil && st.reloc_cap > 0) {
-        deallocate[enc.PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize);
-        st.relocs = nil;
-    }
-    free_scratch(st);
 }
 
 test "x64.encode: stack probe emits the exact __chkstk page-walk body (#1395)" {


### PR DESCRIPTION
Phase 2a of the aarch64-linux bring-up (epic #1431), prerequisite for the aarch64 encoder (#1436). **Pure refactor — x64 emitted output byte-identical.**

Lifts the ISA-agnostic two-pass encoder driver out of `isa/x64/encode.mach` into the shared `be/codegen/encode.mach` (`enc`) so the aarch64 encoder can reuse it. Only per-instruction encoding, prologue/epilogue, the pass-2 branch *patch*, and the reloc-offset differ per ISA — those stay in the ISA via hooks.

## Moved to `enc` (now ISA-general)
`EncodeState`, the `ByteBuf` sink + `emit_*`, `BranchFixup`/`BlockOffset`, `classify_refs`, the `push_*`/`grow_*` array helpers, `shrink_text`, `free_*`, and the top-level driver `encode_driver` (init state → per-function loop → pass-2 branch patch → shrink → assemble `EncoderOutput` → free).

## Hook interface (typed fn-pointer rec, the `query.mach` idiom)
```
pub def EncodeFunctionFn: fun(*EncodeState, *mir.MirFunction) Result[bool, str];
pub def PatchBranchFn:    fun(*EncodeState, *BranchFixup, u32) Result[bool, str];
pub rec EncodeHooks { encode_function: EncodeFunctionFn; patch_branch: PatchBranchFn; }
```
The driver resolves each fixup's target-block `.text` offset and hands `(st, fx, target_off)` to `patch_branch`. `BranchFixup` carries both `patch_pos` (instruction-word start) and `next_ip`, so x86 rel32 (`target − next_ip`, byte overwrite) and aarch64 imm26/imm19 (`target − patch_pos`, bitfield insert) both compute from it. No x86 assumptions remain in the shared module.

## x64 side
`encode_x64` is now a thin wrapper that builds the two x64 hooks (`encode_function` + `patch_branch_x86`) and calls `enc.encode_driver`; all x86-64 ModRM/REX/SIB/rel32 logic stays in x64. The `EncodeFn` vtable signature is unchanged.

## Verification
- **x64 self-host fixpoint byte-identical** (independently re-run: s1==s2==s3, sha `67b6f21b`; h-s1 emitted by the installed encoder, h-s2 by the refactored one → zero emitted-byte change).
- **450 tests pass, 0 fail.**
- x86-leakage scan of the shared module is empty (no rex/modrm/rel32/rbp/etc.).

Refs #1436 #1431