### PR TITLE
feat(target): aarch64 leaf-integer isel + encoder (Phase 2b)

### DIFF
--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -111,7 +111,46 @@ pub val VECTOR_COUNT: i32 = 31;
 # fills in.
 pub def Opcode: u16;
 
+# the concrete leaf-integer opcode forms the selector rewrites generic MIR
+# opcodes into and the encoder packs into 32-bit A64 words. they occupy a low,
+# dense range distinct from the high MIR selection-output sentinels
+# (`mir.MIR_SEL_*`, 0x1100+) and pass-through pseudos (`mir.MIR_CALL`, 0x1000+)
+# that survive instruction selection, so the encoder's dispatch never confuses a
+# concrete A64 form with a surviving generic op. unlike x86-64 the A64 ALU is
+# three-address, so the binary ops are rewritten to a concrete opcode rather than
+# surviving as a sentinel (register allocation keys def/use on operand shape, not
+# opcode, so a concrete three-address form is read correctly).
+
 # no-op (the canonical `HINT #0`).
 pub val NOP: Opcode = 0;
-# return from subroutine (`RET`, branches to the link register).
+# return from subroutine (`RET`, branches to the link register X30).
 pub val RET: Opcode = 1;
+# integer add, three-address `add Rd, Rn, Rm` (or `add Rd, Rn, #imm12`).
+pub val ADD: Opcode = 2;
+# integer subtract, three-address `sub Rd, Rn, Rm` (or `sub Rd, Rn, #imm12`).
+pub val SUB: Opcode = 3;
+# integer multiply, `mul Rd, Rn, Rm` (the `madd Rd, Rn, Rm, XZR` alias).
+pub val MUL: Opcode = 4;
+# bitwise and, `and Rd, Rn, Rm` (logical shifted register).
+pub val AND: Opcode = 5;
+# bitwise or, `orr Rd, Rn, Rm`.
+pub val ORR: Opcode = 6;
+# bitwise exclusive or, `eor Rd, Rn, Rm`.
+pub val EOR: Opcode = 7;
+# left shift, `lsl Rd, Rn, Rm` (LSLV) or `lsl Rd, Rn, #imm` (UBFM alias).
+pub val LSL: Opcode = 8;
+# logical right shift, `lsr Rd, Rn, Rm` (LSRV) or `lsr Rd, Rn, #imm` (UBFM).
+pub val LSR: Opcode = 9;
+# arithmetic right shift, `asr Rd, Rn, Rm` (ASRV) or `asr Rd, Rn, #imm` (SBFM).
+pub val ASR: Opcode = 10;
+# integer negate, `neg Rd, Rm` (the `sub Rd, XZR, Rm` alias).
+pub val NEG: Opcode = 11;
+# bitwise complement, `mvn Rd, Rm` (the `orn Rd, XZR, Rm` alias).
+pub val MVN: Opcode = 12;
+# register move, `mov Rd, Rm` (the `orr Rd, XZR, Rm` alias) or a MOVZ/MOVK
+# immediate materialization for an immediate source.
+pub val MOV: Opcode = 13;
+# unconditional branch to a block, `b label` (imm26 displacement).
+pub val B: Opcode = 14;
+# breakpoint trap `brk #0`, the unreachable-terminator form.
+pub val BRK: Opcode = 15;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -2,22 +2,67 @@
 #
 # This is the AArch64 implementation of the ISA vtable's `encode` operation,
 # reached only through `tgt.arch.encode` by the shared `be.codegen.encode`
-# dispatcher. Byte encoding is not yet implemented: `encode_arm64` is a total
-# function that fails loudly with an "not implemented" error. The encoder that
-# turns the resolved `isa.Inst` stream into AArch64 bytes (with prologue/epilogue
-# emission, branch fixups, and relocation offsets) is filled in a later phase; the
-# four-file ISA shape mirrors the x86-64 backend.
+# dispatcher. It turns the resolved (post-isel, post-regalloc, post-frame)
+# `MirModule` into fixed-width little-endian A64 `.text` bytes, driving the
+# shared two-pass `enc.encode_driver` with two per-ISA hooks: `encode_function_arm64`
+# (prologue / instruction stream / epilogue, recording symbol marks and intra-
+# module branch fixups) and `patch_branch_arm64` (the imm26 / imm19 bitfield insert
+# in pass 2). The ISA-general driving — state lifetime, the function loop, pass-2
+# block resolution, text right-sizing, and `enc.EncoderOutput` assembly — lives in
+# the shared `enc` module; this backend supplies only the A64 bitfield packers,
+# prologue/epilogue emission, and branch patching.
+#
+# SCOPE (Phase 2b — leaf integer). Every modeled form is byte-exact against
+# llvm-mc: the three-address integer ALU (ADD/SUB/MUL/AND/ORR/EOR), the shifts
+# (register LSLV/LSRV/ASRV and immediate UBFM/SBFM aliases), NEG/MVN/MOV, the
+# MOVZ/MOVK immediate materialization, RET, the STP/MOV prologue and LDP/RET
+# epilogue, CMP (SUBS XZR) + CSET, the unconditional branch B, the conditional
+# branch (CBNZ + B), and the BRK unreachable trap. The contract gaps DEFERRED to a
+# later phase (a leaf integer function never reaches them, so they fail loudly
+# rather than emit wrong bytes): frame-slot / spill memory operands, callee-saved
+# FP registers, frames larger than the pre-index STP range, inline asm, calls and
+# their relocations, and the float / conversion families.
 
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
 use std.types.string.str;
 
 use std.types.result.Result;
+use std.types.result.ok;
 use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
 
 use std.allocator.Allocator;
+use page: std.allocator.page;
 
+use intern: mach.lang.intern;
+use isa:    mach.lang.target.isa;
+use arm64:  mach.lang.target.isa.arm64;
 use target: mach.lang.target.resolved;
+use of:     mach.lang.target.of;
 use mir:    mach.lang.be.codegen.mir;
 use enc:    mach.lang.be.codegen.encode;
+
+# the ISA-agnostic two-pass driver, its state, byte sink, and array helpers live
+# in the shared `enc` module; this backend consumes them by name and supplies the
+# two `enc.EncodeHooks` — `encode_function_arm64` and `patch_branch_arm64`.
+use mach.lang.be.codegen.encode.ByteBuf;
+use mach.lang.be.codegen.encode.EncodeState;
+use mach.lang.be.codegen.encode.BranchFixup;
+use mach.lang.be.codegen.encode.EncodeHooks;
+use mach.lang.be.codegen.encode.buf_init;
+use mach.lang.be.codegen.encode.buf_dnit;
+use mach.lang.be.codegen.encode.emit_u32;
+use mach.lang.be.codegen.encode.classify_refs;
+use mach.lang.be.codegen.encode.push_symbol;
+use mach.lang.be.codegen.encode.push_reloc;
+use mach.lang.be.codegen.encode.push_fixup;
+use mach.lang.be.codegen.encode.push_block;
+use mach.lang.be.codegen.encode.encode_driver;
 
 # EncodeFn: the concrete signature the erased `isa.IsaVTable.encode` pointer is
 # cast back to, matching the shared `be.codegen.encode.EncodeFn`. the vtable stores
@@ -30,18 +75,1024 @@ use enc:    mach.lang.be.codegen.encode;
 # ret:   the populated enc.EncoderOutput, or an error string
 pub def EncodeFn: fun(*Allocator, *target.Target, *mir.MirModule) Result[enc.EncoderOutput, str];
 
-# encode_arm64: encode a fully-resolved MIR module into AArch64 `.text` bytes,
-# symbol marks, and pending relocations.
-#
-# the AArch64 implementation behind the ISA vtable's `encode` slot; the shared
-# `be.codegen.encode.run` dispatcher reaches it only through `tgt.arch.encode`.
-# byte encoding is not yet implemented, so this fails loudly — a total function
-# that signals the unimplemented backend rather than emitting wrong bytes.
+# ---- A64 base words (Rd/Rn/Rm fields zeroed) ----
+# every base is the instruction word with its register and immediate fields clear;
+# a packer ORs the encoded fields in. each was confirmed byte-exact against
+# `llvm-mc -triple=aarch64 --show-encoding`. the `_X` forms set the 64-bit `sf`
+# bit (bit 31); the `_W` forms are the 32-bit variants.
+
+# ADD (shifted register), sub, and the logical / multiply three-address forms.
+val ADD_X: u32 = 0x8B000000; val ADD_W: u32 = 0x0B000000;
+val SUB_X: u32 = 0xCB000000; val SUB_W: u32 = 0x4B000000;
+val AND_X: u32 = 0x8A000000; val AND_W: u32 = 0x0A000000;
+val ORR_X: u32 = 0xAA000000; val ORR_W: u32 = 0x2A000000;
+val EOR_X: u32 = 0xCA000000; val EOR_W: u32 = 0x4A000000;
+# ORN (the MVN alias) sets the logical N bit (bit 21) of the ORR encoding.
+val ORN_X: u32 = 0xAA200000; val ORN_W: u32 = 0x2A200000;
+# MUL is MADD Rd,Rn,Rm,XZR — the base bakes the XZR accumulator (Ra=31 at [14:10]).
+val MUL_X: u32 = 0x9B007C00; val MUL_W: u32 = 0x1B007C00;
+# the register-variable shifts (LSLV / LSRV / ASRV).
+val LSLV_X: u32 = 0x9AC02000; val LSLV_W: u32 = 0x1AC02000;
+val LSRV_X: u32 = 0x9AC02400; val LSRV_W: u32 = 0x1AC02400;
+val ASRV_X: u32 = 0x9AC02800; val ASRV_W: u32 = 0x1AC02800;
+# ADD / SUB immediate (imm12, optional left-shift by 12 via the `sh` bit).
+val ADDI_X: u32 = 0x91000000; val ADDI_W: u32 = 0x11000000;
+val SUBI_X: u32 = 0xD1000000; val SUBI_W: u32 = 0x51000000;
+# the bitfield-move bases the immediate shifts alias (UBFM for LSL/LSR, SBFM for ASR).
+val UBFM_X: u32 = 0xD3400000; val UBFM_W: u32 = 0x53000000;
+val SBFM_X: u32 = 0x93400000; val SBFM_W: u32 = 0x13000000;
+# move-wide (MOVZ keeps, MOVK inserts) with a 16-bit immediate and an `hw` shift.
+val MOVZ_X: u32 = 0xD2800000; val MOVZ_W: u32 = 0x52800000;
+val MOVK_X: u32 = 0xF2800000; val MOVK_W: u32 = 0x72800000;
+# SUBS XZR (the CMP alias), register and immediate forms.
+val SUBS_REG_X: u32 = 0xEB000000; val SUBS_REG_W: u32 = 0x6B000000;
+val SUBS_IMM_X: u32 = 0xF1000000; val SUBS_IMM_W: u32 = 0x71000000;
+# CSINC Rd,XZR,XZR (the CSET alias): the base bakes the XZR sources and op2 bit.
+val CSINC_X: u32 = 0x9A800400; val CSINC_W: u32 = 0x1A800400;
+# STP pre-index / LDP post-index (the FP/LR frame record) and the signed-offset
+# pair / single forms (callee-saved register spills), all 64-bit.
+val STP_PRE_X:  u32 = 0xA9800000;
+val LDP_POST_X: u32 = 0xA8C00000;
+val STP_OFF_X:  u32 = 0xA9000000;
+val LDP_OFF_X:  u32 = 0xA9400000;
+val STR_OFF_X:  u32 = 0xF9000000;
+val LDR_OFF_X:  u32 = 0xF9400000;
+# the unconditional branch (imm26) and the conditional / compare-branch family (imm19).
+val B_BASE:    u32 = 0x14000000;
+val BCOND:     u32 = 0x54000000;
+val CBNZ_X:    u32 = 0xB5000000; val CBNZ_W: u32 = 0x35000000;
+# RET x30, BRK #0, NOP.
+val RET_WORD:  u32 = 0xD65F03C0;
+val BRK_BASE:  u32 = 0xD4200000;
+val NOP_WORD:  u32 = 0xD503201F;
+
+# the zero register / stack pointer encode as register 31 in the relevant fields.
+val ZR: u32 = 31;
+# the intra-procedure-call scratch registers (IP0 = X16, IP1 = X17) the encoder
+# claims for immediate materialization; both are caller-saved and never hold a live
+# value across the point the encoder uses them.
+val SCRATCH0: u32 = 16;
+val SCRATCH1: u32 = 17;
+
+# the largest frame the pre-index STP can allocate in one instruction: the scaled
+# 7-bit signed immediate spans -64..63 eightbytes, so -512..504 bytes; the negative
+# pre-index offset is `-total`, bounded below by -512, i.e. total <= 504.
+val MAX_PREINDEX_FRAME: u32 = 504;
+
+# A64 condition codes (bits[3:0] of a conditional form). the CSET / B.cond
+# encodings read these directly; `pack_cset` writes the inverted condition.
+val CC_EQ: u32 = 0;
+val CC_NE: u32 = 1;
+val CC_CC: u32 = 3;
+val CC_LS: u32 = 9;
+val CC_LT: u32 = 11;
+val CC_LE: u32 = 13;
+
+# ---- bitfield packers (pure: each returns one A64 word) ----
+
+# pack_alu3: a three-register data-processing word — Rm[20:16], Rn[9:5], Rd[4:0]
+# OR-ed into `base`. used for the register ALU forms (ADD/SUB/AND/ORR/EOR), the
+# register shifts (LSLV/LSRV/ASRV), MUL (whose base bakes the XZR accumulator),
+# and the NEG/MVN aliases (whose Rn is XZR).
+fun pack_alu3(base: u32, rd: u32, rn: u32, rm: u32) u32 {
+    ret base | ((rm & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rd & 0x1F);
+}
+
+# pack_addsub_imm: an ADD/SUB immediate word — `sh`[22], imm12[21:10], Rn[9:5],
+# Rd[4:0]. `sh` selects the optional left-shift-by-12 of the 12-bit immediate.
+fun pack_addsub_imm(base: u32, rd: u32, rn: u32, imm12: u32, sh: u32) u32 {
+    ret base | ((sh & 0x1) << 22) | ((imm12 & 0xFFF) << 10) | ((rn & 0x1F) << 5) | (rd & 0x1F);
+}
+
+# pack_bitfield: a bitfield-move word — immr[21:16], imms[15:10], Rn[9:5], Rd[4:0].
+# used for the immediate shift aliases (UBFM for LSL/LSR, SBFM for ASR).
+fun pack_bitfield(base: u32, rd: u32, rn: u32, immr: u32, imms: u32) u32 {
+    ret base | ((immr & 0x3F) << 16) | ((imms & 0x3F) << 10) | ((rn & 0x1F) << 5) | (rd & 0x1F);
+}
+
+# pack_movewide: a move-wide word — hw[22:21], imm16[20:5], Rd[4:0]. `hw` is the
+# 16-bit shift group (0..3 selecting lsl #0/16/32/48).
+fun pack_movewide(base: u32, rd: u32, hw: u32, imm16: u32) u32 {
+    ret base | ((hw & 0x3) << 21) | ((imm16 & 0xFFFF) << 5) | (rd & 0x1F);
+}
+
+# pack_cmp_reg: a SUBS XZR, Rn, Rm word (the register CMP) — Rm[20:16], Rn[9:5],
+# Rd = XZR.
+fun pack_cmp_reg(base: u32, rn: u32, rm: u32) u32 {
+    ret base | ((rm & 0x1F) << 16) | ((rn & 0x1F) << 5) | ZR;
+}
+
+# pack_cmp_imm: a SUBS XZR, Rn, #imm12 word (the immediate CMP) — imm12[21:10],
+# Rn[9:5], Rd = XZR.
+fun pack_cmp_imm(base: u32, rn: u32, imm12: u32) u32 {
+    ret base | ((imm12 & 0xFFF) << 10) | ((rn & 0x1F) << 5) | ZR;
+}
+
+# pack_cset: a CSINC Rd, XZR, XZR, invert(cc) word — the CSET alias. `cc` is the
+# condition the boolean captures; CSET encodes its inverse (`cc ^ 1`) in the
+# cond[15:12] field, with both sources held at XZR.
+fun pack_cset(base: u32, rd: u32, cc: u32) u32 {
+    val inv: u32 = cc ^ 1;
+    ret base | (ZR << 16) | ((inv & 0xF) << 12) | (ZR << 5) | (rd & 0x1F);
+}
+
+# pack_ldstp: a load/store-pair word — imm7[21:15] (the scaled, signed offset),
+# Rt2[14:10], Rn[9:5], Rt[4:0]. used for the FP/LR frame record (pre/post-index
+# bases) and callee-saved register pairs (signed-offset bases).
+fun pack_ldstp(base: u32, rt: u32, rt2: u32, rn: u32, imm7: u32) u32 {
+    ret base | ((imm7 & 0x7F) << 15) | ((rt2 & 0x1F) << 10) | ((rn & 0x1F) << 5) | (rt & 0x1F);
+}
+
+# pack_ldst: a scaled unsigned-offset load/store word — imm12[21:10] (the byte
+# offset divided by the access size), Rn[9:5], Rt[4:0]. used to spill a trailing
+# odd callee-saved register the pair forms cannot cover.
+fun pack_ldst(base: u32, rt: u32, rn: u32, imm12: u32) u32 {
+    ret base | ((imm12 & 0xFFF) << 10) | ((rn & 0x1F) << 5) | (rt & 0x1F);
+}
+
+# pack_cbnz: a compare-and-branch word with a zero imm19 placeholder — Rt[4:0].
+# pass 2 inserts the resolved imm19 displacement.
+fun pack_cbnz(base: u32, rt: u32) u32 {
+    ret base | (rt & 0x1F);
+}
+
+# ---- low-level emit / patch helpers ----
+
+# emit_word: append one 32-bit A64 instruction word to the text sink (little-endian).
+fun emit_word(st: *EncodeState, word: u32) {
+    emit_u32(?st.buf, word);
+}
+
+# read_word: read the 32-bit little-endian word at `pos` in the text sink.
+fun read_word(buf: *ByteBuf, pos: usize) u32 {
+    ret buf.data[pos]::u32 |
+        (buf.data[pos + 1]::u32 << 8) |
+        (buf.data[pos + 2]::u32 << 16) |
+        (buf.data[pos + 3]::u32 << 24);
+}
+
+# write_word: overwrite the 32-bit little-endian word at `pos` in the text sink.
+fun write_word(buf: *ByteBuf, pos: usize, word: u32) {
+    buf.data[pos]     = (word & 0xFF)::u8;
+    buf.data[pos + 1] = ((word >> 8) & 0xFF)::u8;
+    buf.data[pos + 2] = ((word >> 16) & 0xFF)::u8;
+    buf.data[pos + 3] = ((word >> 24) & 0xFF)::u8;
+}
+
+# sel: choose the 64-bit or 32-bit base word for an operation width.
+fun sel(use64: bool, base_x: u32, base_w: u32) u32 {
+    if (use64) { ret base_x; }
+    ret base_w;
+}
+
+# is64: true when an operation width selects the 64-bit (X-register, `sf`=1) form.
+# a width of 0 (a pseudo with no natural width) falls back to the machine word.
+fun is64(width: u8) bool {
+    if (width == 0) { ret true; }
+    ret width >= 8;
+}
+
+# emit_movewide_seq: materialize `value` into GP register index `rd` with a MOVZ
+# (the first non-zero 16-bit chunk) followed by a MOVK per remaining non-zero
+# chunk — up to four for a 64-bit value, two for a 32-bit one. a zero value emits
+# a single `MOVZ rd, #0`. always produces the exact bit pattern (no MOVN
+# optimization), so an out-of-range immediate legalizes correctly into a scratch.
+fun emit_movewide_seq(st: *EncodeState, rd: u32, value: u64, use64: bool) {
+    val base_z: u32 = sel(use64, MOVZ_X, MOVZ_W);
+    val base_k: u32 = sel(use64, MOVK_X, MOVK_W);
+    var chunks: u32 = 2;
+    if (use64) { chunks = 4; }
+    var v: u64 = value;
+    if (!use64) { v = value & 0xFFFFFFFF; }
+
+    if (v == 0) {
+        emit_word(st, pack_movewide(base_z, rd, 0, 0));
+        ret;
+    }
+
+    var first: bool = true;
+    var i: u32 = 0;
+    for (i < chunks) {
+        val chunk: u32 = ((v >> (16::u64 * i::u64)) & 0xFFFF)::u32;
+        if (chunk != 0) {
+            if (first) {
+                emit_word(st, pack_movewide(base_z, rd, i, chunk));
+                first = false;
+            } or {
+                emit_word(st, pack_movewide(base_k, rd, i, chunk));
+            }
+        }
+        i = i + 1;
+    }
+}
+
+# ---- operand resolution ----
+
+# req_gpr: the GP register index a post-regalloc operand names. only a physical
+# register survives to encode; a surviving virtual register is a register-
+# allocation bug, and a frame-slot / memory operand is deferred to Phase 3. both
+# are rejected loudly rather than mis-encoded.
+fun req_gpr(op: *mir.MirOperand) Result[i32, str] {
+    if (op.kind == mir.MIR_OP_PREG) {
+        ret ok[i32, str](isa.regid_index(op.preg::i32));
+    }
+    if (op.kind == mir.MIR_OP_VREG) {
+        ret err[i32, str]("encode: virtual register survived register allocation");
+    }
+    if (op.kind == mir.MIR_OP_MEM) {
+        ret err[i32, str]("aarch64 frame-slot/memory operands not implemented (Phase 3)");
+    }
+    ret err[i32, str]("encode: expected a register operand");
+}
+
+# resolve_source: the GP register index a source operand contributes. a physical
+# register is used directly; an immediate is materialized into `scratch` (and that
+# index returned). every other shape is rejected through `req_gpr`.
+fun resolve_source(st: *EncodeState, op: *mir.MirOperand, scratch: u32, use64: bool) Result[i32, str] {
+    if (op.kind == mir.MIR_OP_IMM) {
+        emit_movewide_seq(st, scratch, op.imm::u64, use64);
+        ret ok[i32, str](scratch::i32);
+    }
+    ret req_gpr(op);
+}
+
+# ---- per-opcode encoders ----
+
+# encode_alu3: a three-address integer ALU op `op Rd, Rn, Rm`. the right operand
+# folds into the ADD/SUB immediate form when it is a small non-negative immediate;
+# otherwise (and for the logical / multiply forms, which have no modeled immediate
+# encoding) it is materialized into the scratch register and the register form is
+# emitted. operand 0 is the destination, operand 1 the left source, operand 2 the
+# right source.
+fun encode_alu3(st: *EncodeState, mi: *mir.MirInstr, base_x: u32, base_w: u32) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: ALU op missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val rnr: Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH1, use64);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val rmr: Result[i32, str] = resolve_source(st, ?mi.operands[2], SCRATCH0, use64);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+
+    emit_word(st, pack_alu3(sel(use64, base_x, base_w), rd, rn, rm));
+    ret ok[bool, str](true);
+}
+
+# encode_addsub: ADD / SUB, taking the immediate form for a non-negative immediate
+# in imm12 (or imm12<<12) range and falling back to the register form (operand
+# materialized into the scratch) otherwise. mirrors `encode_alu3` for the register
+# case but reaches the dedicated immediate encoding the ALU bases cannot.
+fun encode_addsub(st: *EncodeState, mi: *mir.MirInstr, is_sub: bool) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: add/sub missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val rnr: Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH1, use64);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val rhs: *mir.MirOperand = ?mi.operands[2];
+    if (rhs.kind == mir.MIR_OP_IMM) {
+        val v: i64 = rhs.imm;
+        if (v >= 0 && v <= 4095) {
+            var base_i: u32 = sel(use64, ADDI_X, ADDI_W);
+            if (is_sub) { base_i = sel(use64, SUBI_X, SUBI_W); }
+            emit_word(st, pack_addsub_imm(base_i, rd, rn, v::u32, 0));
+            ret ok[bool, str](true);
+        }
+        if (v > 0 && (v & 0xFFF) == 0 && (v >> 12) <= 4095) {
+            var base_i: u32 = sel(use64, ADDI_X, ADDI_W);
+            if (is_sub) { base_i = sel(use64, SUBI_X, SUBI_W); }
+            emit_word(st, pack_addsub_imm(base_i, rd, rn, (v >> 12)::u32, 1));
+            ret ok[bool, str](true);
+        }
+    }
+
+    val rmr: Result[i32, str] = resolve_source(st, rhs, SCRATCH0, use64);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+    var base_r: u32 = sel(use64, ADD_X, ADD_W);
+    if (is_sub) { base_r = sel(use64, SUB_X, SUB_W); }
+    emit_word(st, pack_alu3(base_r, rd, rn, rm));
+    ret ok[bool, str](true);
+}
+
+# encode_shift: a left / logical-right / arithmetic-right shift. an immediate count
+# emits the UBFM / SBFM bitfield alias (the LSL immediate maps to immr=(width-sh),
+# imms=(width-1-sh); LSR / ASR map to immr=sh, imms=width-1); a register count
+# emits the register-variable form (LSLV / LSRV / ASRV).
+fun encode_shift(st: *EncodeState, mi: *mir.MirInstr, kind: u32) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: shift missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val rnr: Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH1, use64);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val cnt: *mir.MirOperand = ?mi.operands[2];
+    if (cnt.kind == mir.MIR_OP_IMM) {
+        var width_bits: u32 = 32;
+        if (use64) { width_bits = 64; }
+        val sh: u32 = cnt.imm::u32 & (width_bits - 1);
+        if (kind == arm64.LSL::u32) {
+            val immr: u32 = (width_bits - sh) & (width_bits - 1);
+            val imms: u32 = (width_bits - 1) - sh;
+            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd, rn, immr, imms));
+            ret ok[bool, str](true);
+        }
+        if (kind == arm64.LSR::u32) {
+            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd, rn, sh, width_bits - 1));
+            ret ok[bool, str](true);
+        }
+        emit_word(st, pack_bitfield(sel(use64, SBFM_X, SBFM_W), rd, rn, sh, width_bits - 1));
+        ret ok[bool, str](true);
+    }
+
+    val rmr: Result[i32, str] = req_gpr(cnt);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+    var base_x: u32 = LSLV_X; var base_w: u32 = LSLV_W;
+    if (kind == arm64.LSR::u32) { base_x = LSRV_X; base_w = LSRV_W; }
+    or (kind == arm64.ASR::u32) { base_x = ASRV_X; base_w = ASRV_W; }
+    emit_word(st, pack_alu3(sel(use64, base_x, base_w), rd, rn, rm));
+    ret ok[bool, str](true);
+}
+
+# encode_neg_mvn: NEG (`sub Rd, XZR, Rm`) or MVN (`orn Rd, XZR, Rm`), both reading
+# the `[dst, src]` operand pair and supplying XZR as Rn from the encoding.
+fun encode_neg_mvn(st: *EncodeState, mi: *mir.MirInstr, base_x: u32, base_w: u32) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: neg/not missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val rmr: Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH0, use64);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+
+    emit_word(st, pack_alu3(sel(use64, base_x, base_w), rd, ZR, rm));
+    ret ok[bool, str](true);
+}
+
+# encode_mov: a register move (`orr Rd, XZR, Rm`) or, for an immediate source, a
+# MOVZ/MOVK materialization directly into the destination.
+fun encode_mov(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: mov missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val src: *mir.MirOperand = ?mi.operands[1];
+    if (src.kind == mir.MIR_OP_IMM) {
+        emit_movewide_seq(st, rd, src.imm::u64, use64);
+        ret ok[bool, str](true);
+    }
+    val rmr: Result[i32, str] = req_gpr(src);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+    emit_word(st, pack_alu3(sel(use64, ORR_X, ORR_W), rd, ZR, rm));
+    ret ok[bool, str](true);
+}
+
+# cmp_cond: the A64 condition a surviving comparison sentinel captures. only the
+# EQ / NE / LT / LE forms exist in the generic opcode space (the lowerer
+# canonicalizes GT/GE by swapping operands); signedness selects the signed
+# (LT/LE) versus unsigned (CC/LS) condition.
+fun cmp_cond(op: mir.MirOpcode) u32 {
+    if (op == mir.MIR_SEL_CMP_EQ)   { ret CC_EQ; }
+    if (op == mir.MIR_SEL_CMP_NE)   { ret CC_NE; }
+    if (op == mir.MIR_SEL_CMP_LT_S) { ret CC_LT; }
+    if (op == mir.MIR_SEL_CMP_LT_U) { ret CC_CC; }
+    if (op == mir.MIR_SEL_CMP_LE_S) { ret CC_LE; }
+    ret CC_LS;
+}
+
+# is_mir_compare: true when a post-isel opcode is a surviving generic comparison
+# sentinel — the encoder materializes the SUBS XZR + CSET byte sequence from it.
+fun is_mir_compare(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_SEL_CMP_EQ || op == mir.MIR_SEL_CMP_NE ||
+        op == mir.MIR_SEL_CMP_LT_S || op == mir.MIR_SEL_CMP_LT_U ||
+        op == mir.MIR_SEL_CMP_LE_S || op == mir.MIR_SEL_CMP_LE_U;
+}
+
+# encode_compare: materialize a surviving comparison `[dst, lhs, rhs]` into
+# `SUBS XZR, lhs, rhs` (the flag-setting compare; an immediate right operand folds
+# into the immediate form) followed by `CSET dst, cc` (capture the condition into a
+# zero-extended boolean). the comparison runs at the operand width; the boolean is
+# captured in the 32-bit CSET form (a 0/1 value the W write zero-extends to 64).
+fun encode_compare(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: compare missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val rnr: Result[i32, str] = req_gpr(?mi.operands[1]);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val rhs: *mir.MirOperand = ?mi.operands[2];
+    if (rhs.kind == mir.MIR_OP_IMM && rhs.imm >= 0 && rhs.imm <= 4095) {
+        emit_word(st, pack_cmp_imm(sel(use64, SUBS_IMM_X, SUBS_IMM_W), rn, rhs.imm::u32));
+    } or {
+        val rmr: Result[i32, str] = resolve_source(st, rhs, SCRATCH0, use64);
+        if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+        val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+        emit_word(st, pack_cmp_reg(sel(use64, SUBS_REG_X, SUBS_REG_W), rn, rm));
+    }
+
+    emit_word(st, pack_cset(CSINC_W, rd, cmp_cond(mi.opcode)));
+    ret ok[bool, str](true);
+}
+
+# encode_branch: an unconditional branch to a block. emits the B word with a zero
+# imm26 placeholder and records a fixup (patch site = the instruction word start,
+# per `arm64_reloc_offset`) for pass 2 to fill with the resolved displacement.
+fun encode_branch(st: *EncodeState, fn_base: u32, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 1 || mi.operands[0].kind != mir.MIR_OP_BLOCK) {
+        ret err[bool, str]("encode: branch target is not a block");
+    }
+    val target_block: u32 = mi.operands[0].imm::u32;
+    val patch_pos: u32 = st.buf.len::u32;
+    emit_word(st, B_BASE);
+    val next_ip: u32 = st.buf.len::u32;
+    ret push_fixup(st, patch_pos, next_ip, target_block, fn_base);
+}
+
+# encode_cbr: a conditional branch `[cond, then_block, else_block]` materialized as
+# `CBNZ cond, then` (taken when the condition is non-zero) ; `B else` (the
+# fall-through edge, always emitted). each branch records a fixup against its
+# target block; pass 2 inserts the imm19 / imm26 displacement once both block
+# offsets are known.
+fun encode_cbr(st: *EncodeState, fn_base: u32, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: conditional branch missing operands"); }
+    if (mi.operands[1].kind != mir.MIR_OP_BLOCK || mi.operands[2].kind != mir.MIR_OP_BLOCK) {
+        ret err[bool, str]("encode: conditional branch target is not a block");
+    }
+    val then_block: u32 = mi.operands[1].imm::u32;
+    val else_block: u32 = mi.operands[2].imm::u32;
+    val use64: bool = is64(mi.width);
+
+    val rcr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rcr)) { ret err[bool, str](unwrap_err[i32, str](rcr)); }
+    val cond: u32 = unwrap_ok[i32, str](rcr)::u32;
+
+    val cbnz_pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_cbnz(sel(use64, CBNZ_X, CBNZ_W), cond));
+    val cbnz_next: u32 = st.buf.len::u32;
+    val f1: Result[bool, str] = push_fixup(st, cbnz_pos, cbnz_next, then_block, fn_base);
+    if (is_err[bool, str](f1)) { ret f1; }
+
+    val b_pos: u32 = st.buf.len::u32;
+    emit_word(st, B_BASE);
+    val b_next: u32 = st.buf.len::u32;
+    ret push_fixup(st, b_pos, b_next, else_block, fn_base);
+}
+
+# ---- frame layout, prologue, epilogue ----
+
+# popcount32: the number of set bits in a 32-bit mask.
+fun popcount32(m: u32) u32 {
+    var n: u32 = 0;
+    var x: u32 = m;
+    for (x != 0) {
+        n = n + (x & 1);
+        x = x >> 1;
+    }
+    ret n;
+}
+
+# align16: round a byte count up to a 16-byte boundary (the AAPCS64 stack alignment).
+fun align16(n: u32) u32 {
+    ret (n + 15) & ~15::u32;
+}
+
+# frame_total: the 16-byte-aligned byte count the prologue reserves below the
+# caller's SP — the FP/LR frame record (16 bytes) plus the callee-saved GP/FP save
+# area, the local frame, and the outgoing-argument region, read from the SAME
+# shared frame facts the x86-64 encoder reads. SP stays 16-byte aligned.
+fun frame_total(f: *mir.MirFunction) u32 {
+    val gp_bytes: u32 = popcount32(f.callee_mask) * 8;
+    val fp_bytes: u32 = popcount32(f.callee_mask_fp) * 16;
+    ret align16(16 + gp_bytes + fp_bytes + f.frame.size + f.frame.outgoing_size);
+}
+
+# emit_prologue: the standard AArch64 leaf prologue — `STP X29, X30, [SP, #-total]!`
+# (save the FP/LR frame record and allocate the whole frame) then `MOV X29, SP`
+# (an `add x29, sp, #0`). callee-saved GP registers are then saved in STP pairs
+# (a trailing odd one with STR) just above the frame record. SP stays 16-aligned.
+fun emit_prologue(st: *EncodeState, f: *mir.MirFunction, total: u32) {
+    val neg_off: u32 = (0::u32 - (total / 8)) & 0x7F;
+    emit_word(st, pack_ldstp(STP_PRE_X, 29, 30, ZR, neg_off));
+    emit_word(st, pack_addsub_imm(ADDI_X, 29, ZR, 0, 0));
+    save_callee_gp(st, f, true);
+}
+
+# emit_epilogue: the standard AArch64 leaf epilogue — restore the callee-saved GP
+# registers, then `LDP X29, X30, [SP], #total` (reload the FP/LR frame record and
+# deallocate the whole frame). the RET that follows returns through X30.
+fun emit_epilogue(st: *EncodeState, f: *mir.MirFunction, total: u32) {
+    save_callee_gp(st, f, false);
+    val pos_off: u32 = (total / 8) & 0x7F;
+    emit_word(st, pack_ldstp(LDP_POST_X, 29, 30, ZR, pos_off));
+}
+
+# save_callee_gp: save (or restore) the callee-saved GP registers `callee_mask`
+# selects, in ascending register order, in STP pairs at ascending 16-aligned
+# offsets above the FP/LR frame record (`[sp, #16]`, `[sp, #32]`, …). a trailing
+# odd register is handled with a single STR/LDR. SP-relative and self-contained,
+# so it is correct regardless of where X29 points.
+fun save_callee_gp(st: *EncodeState, f: *mir.MirFunction, store: bool) {
+    var regs: [32]u32;
+    var n: u32 = 0;
+    var r: u32 = 0;
+    for (r < 31) {
+        if ((f.callee_mask & (1::u32 << r)) != 0) { regs[n] = r; n = n + 1; }
+        r = r + 1;
+    }
+
+    var off: u32 = 16;
+    var i: u32 = 0;
+    for (i + 1 < n) {
+        val imm7: u32 = (off / 8) & 0x7F;
+        if (store) { emit_word(st, pack_ldstp(STP_OFF_X, regs[i], regs[i + 1], ZR, imm7)); }
+        or         { emit_word(st, pack_ldstp(LDP_OFF_X, regs[i], regs[i + 1], ZR, imm7)); }
+        off = off + 16;
+        i = i + 2;
+    }
+    if (i < n) {
+        val imm12: u32 = off / 8;
+        if (store) { emit_word(st, pack_ldst(STR_OFF_X, regs[i], ZR, imm12)); }
+        or         { emit_word(st, pack_ldst(LDR_OFF_X, regs[i], ZR, imm12)); }
+    }
+}
+
+# ---- per-instruction dispatch ----
+
+# encode_mir_instr: translate one post-regalloc MIR instruction into A64 bytes,
+# recording any intra-module branch fixup. the regalloc parallel-copy / liveness
+# pseudos emit nothing; the surviving comparison and conditional-branch sentinels
+# expand into their byte sequences; the float / conversion families, calls, inline
+# asm, and varargs are rejected loudly (a leaf integer function never reaches them).
+fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) Result[bool, str] {
+    val op: u16 = mi.opcode::u16;
+
+    # pseudo-opcodes the regalloc phase leaves behind emit no bytes.
+    if (op == isa.ISA_PCOPY || op == isa.ISA_PCOPY_FENCE ||
+        op == isa.ISA_USE || op == isa.ISA_LABEL) {
+        ret ok[bool, str](true);
+    }
+    if (mi.opcode == mir.MIR_CALL_RES || mi.opcode == mir.MIR_ARG) {
+        ret ok[bool, str](true);
+    }
+    if (mi.opcode == mir.MIR_PHI) {
+        ret err[bool, str]("internal compiler error: phi survived register allocation");
+    }
+
+    # the surviving comparison / conditional-branch sentinels expand into their
+    # multi-instruction byte sequences.
+    if (is_mir_compare(mi.opcode)) { ret encode_compare(st, mi); }
+    if (mi.opcode == mir.MIR_SEL_CBR) { ret encode_cbr(st, fn_base, mi); }
+
+    # deferred families: a leaf integer function never emits these, so they are
+    # rejected loudly rather than mis-encoded.
+    if (mi.opcode == mir.MIR_VA_FP_SAVE) {
+        ret err[bool, str]("aarch64 varargs not implemented (Phase 4)");
+    }
+    if (mi.opcode == mir.MIR_FADD || mi.opcode == mir.MIR_FSUB ||
+        mi.opcode == mir.MIR_FMUL || mi.opcode == mir.MIR_FDIV ||
+        mi.opcode == mir.MIR_FCMP || mi.opcode == mir.MIR_FNEG) {
+        ret err[bool, str]("aarch64 floating-point ops not implemented (Phase 3)");
+    }
+    if (mi.opcode == mir.MIR_TRUNC || mi.opcode == mir.MIR_SEXT ||
+        mi.opcode == mir.MIR_ZEXT || mi.opcode == mir.MIR_BITCAST ||
+        mi.opcode == mir.MIR_FP_TRUNC || mi.opcode == mir.MIR_FP_EXT ||
+        mi.opcode == mir.MIR_FP_TO_SI || mi.opcode == mir.MIR_FP_TO_UI ||
+        mi.opcode == mir.MIR_SI_TO_FP || mi.opcode == mir.MIR_UI_TO_FP) {
+        ret err[bool, str]("aarch64 conversions not implemented (Phase 3)");
+    }
+    if (mi.opcode == mir.MIR_CALL) {
+        ret err[bool, str]("aarch64 calls not implemented (Phase 3)");
+    }
+
+    # concrete A64 opcodes.
+    if (op == arm64.ADD::u16) { ret encode_addsub(st, mi, false); }
+    if (op == arm64.SUB::u16) { ret encode_addsub(st, mi, true); }
+    if (op == arm64.MUL::u16) { ret encode_alu3(st, mi, MUL_X, MUL_W); }
+    if (op == arm64.AND::u16) { ret encode_alu3(st, mi, AND_X, AND_W); }
+    if (op == arm64.ORR::u16) { ret encode_alu3(st, mi, ORR_X, ORR_W); }
+    if (op == arm64.EOR::u16) { ret encode_alu3(st, mi, EOR_X, EOR_W); }
+    if (op == arm64.LSL::u16) { ret encode_shift(st, mi, arm64.LSL::u32); }
+    if (op == arm64.LSR::u16) { ret encode_shift(st, mi, arm64.LSR::u32); }
+    if (op == arm64.ASR::u16) { ret encode_shift(st, mi, arm64.ASR::u32); }
+    if (op == arm64.NEG::u16) { ret encode_neg_mvn(st, mi, SUB_X, SUB_W); }
+    if (op == arm64.MVN::u16) { ret encode_neg_mvn(st, mi, ORN_X, ORN_W); }
+    if (op == arm64.MOV::u16) { ret encode_mov(st, mi); }
+    if (op == arm64.B::u16)   { ret encode_branch(st, fn_base, mi); }
+    if (op == arm64.RET::u16) { emit_word(st, RET_WORD); ret ok[bool, str](true); }
+    if (op == arm64.BRK::u16) { emit_word(st, BRK_BASE); ret ok[bool, str](true); }
+    if (op == arm64.NOP::u16) { emit_word(st, NOP_WORD); ret ok[bool, str](true); }
+
+    ret err[bool, str]("internal compiler error: unhandled opcode in arm64 encode");
+}
+
+# encode_function_arm64: the per-function encode hook (pass 1). marks the function
+# entry symbol, emits the prologue, then each block — emitting the epilogue before
+# every RET — recording each block's `.text` offset for branch patching. extern /
+# body-less functions contribute no text. a frame beyond the leaf-supported shape
+# (callee-saved FP registers, or a frame larger than the pre-index STP range) is
+# rejected loudly rather than mis-encoded.
+fun encode_function_arm64(st: *EncodeState, f: *mir.MirFunction) Result[bool, str] {
+    val fn_base: u32 = st.buf.len::u32;
+    if (f.block_count == 0) { ret ok[bool, str](true); }
+
+    val ms: Result[bool, str] = push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
+    if (is_err[bool, str](ms)) { ret ms; }
+
+    if (f.callee_mask_fp != 0) {
+        ret err[bool, str]("aarch64 callee-saved FP registers not implemented (Phase 3)");
+    }
+    val total: u32 = frame_total(f);
+    if (total > MAX_PREINDEX_FRAME) {
+        ret err[bool, str]("aarch64 frame larger than the pre-index STP range not implemented (Phase 3)");
+    }
+
+    emit_prologue(st, f, total);
+
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        val rb: Result[bool, str] = push_block(st, fn_base, blk.id, st.buf.len::u32);
+        if (is_err[bool, str](rb)) { ret rb; }
+
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            if (mi.opcode::u16 == arm64.RET::u16) {
+                emit_epilogue(st, f, total);
+            }
+            val ei: Result[bool, str] = encode_mir_instr(st, f, fn_base, mi);
+            if (is_err[bool, str](ei)) { ret ei; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# patch_branch_arm64: the per-branch patch hook (pass 2). reads the placeholder
+# instruction word at the fixup's patch site, inserts the resolved displacement
+# (instruction-relative: `target_off - patch_pos`, with no x86-64 next-instruction
+# bias), and writes the word back. an unconditional B takes an imm26[25:0]; a
+# B.cond / CBZ / CBNZ takes an imm19[23:5] — distinguished by the word's top bits
+# (a read-modify-write bitfield insert, not a byte overwrite).
+fun patch_branch_arm64(st: *EncodeState, fx: *BranchFixup, target_off: u32) Result[bool, str] {
+    val pos: usize = fx.patch_pos::usize;
+    if (pos + 4 > st.buf.len) {
+        ret err[bool, str]("encode: branch fixup site is outside the text buffer");
+    }
+    val word: u32 = read_word(?st.buf, pos);
+    val disp: u32 = target_off - fx.patch_pos;
+
+    var patched: u32 = 0;
+    if ((word & 0xFC000000) == B_BASE) {
+        patched = (word & 0xFC000000) | ((disp & 0x0FFFFFFC) >> 2);
+    } or {
+        patched = (word & 0xFF00001F) | (((disp >> 2) & 0x7FFFF) << 5);
+    }
+    write_word(?st.buf, pos, patched);
+    ret ok[bool, str](true);
+}
+
+# arm64_reloc_offset: the byte offset, within an encoded instruction, where a
+# relocation field begins — always the instruction-word start on A64 (the linker
+# packers read the access kind from the relocation, not an instruction decode). a
+# leaf integer function emits no symbol references, so no relocation is recorded in
+# this phase; this is the patch-site convention the call/global lowering of Phase 3
+# will record against.
+fun arm64_reloc_offset(inst_start: u32) u32 {
+    ret inst_start;
+}
+
+# encode_arm64: the AArch64 ISA's `encode` entry point — a thin wrapper that
+# supplies the two A64 `enc.EncodeHooks` and runs the shared two-pass driver. the
+# ISA-general driving lives in `enc.encode_driver`; this backend contributes only
+# its per-function encode (`encode_function_arm64`) and per-branch patch
+# (`patch_branch_arm64`). the erased vtable pointer is cast back to this exact
+# signature, so it must not change.
 # ---
-# alloc: allocator (unused until encoding is implemented)
-# tgt:   resolved compilation target (must be AArch64)
-# m:     the fully-resolved MIR module
-# ret:   an error reporting that AArch64 encoding is unimplemented
+# alloc: allocator backing the encoder output's owned arrays
+# tgt:   resolved target; must be AArch64
+# m:     the fully-resolved MIR module (post isel / regalloc / frame)
+# ret:   the populated enc.EncoderOutput (owned arrays), or an error string
 pub fun encode_arm64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Result[enc.EncoderOutput, str] {
-    ret err[enc.EncoderOutput, str]("aarch64 encode not implemented");
+    var hooks: EncodeHooks;
+    hooks.encode_function = encode_function_arm64;
+    hooks.patch_branch    = patch_branch_arm64;
+    ret encode_driver(alloc, tgt, m, ?hooks);
+}
+
+# ---- in-source encode tests (byte-exact vs llvm-mc goldens) ----
+
+# tbuf: a fresh page-backed EncodeState carrying only a byte sink, for exercising
+# the emit-level helpers (prologue / epilogue / branch patch) directly.
+fun tbuf(st: *EncodeState, alloc: *Allocator) {
+    page.make(alloc);
+    st.buf = buf_init(alloc);
+}
+
+test "arm64.encode: three-address ALU register forms match llvm-mc" {
+    var bad: i32 = 0;
+    # add x0, x1, x2 ; add w0, w1, w2
+    if (pack_alu3(ADD_X, 0, 1, 2) != 0x8B020020) { bad = 1; }
+    if (pack_alu3(ADD_W, 0, 1, 2) != 0x0B020020) { bad = 1; }
+    # sub x/w
+    if (pack_alu3(SUB_X, 0, 1, 2) != 0xCB020020) { bad = 1; }
+    if (pack_alu3(SUB_W, 0, 1, 2) != 0x4B020020) { bad = 1; }
+    # mul x/w (madd ...,xzr)
+    if (pack_alu3(MUL_X, 0, 1, 2) != 0x9B027C20) { bad = 1; }
+    if (pack_alu3(MUL_W, 0, 1, 2) != 0x1B027C20) { bad = 1; }
+    # and / orr / eor x
+    if (pack_alu3(AND_X, 0, 1, 2) != 0x8A020020) { bad = 1; }
+    if (pack_alu3(ORR_X, 0, 1, 2) != 0xAA020020) { bad = 1; }
+    if (pack_alu3(EOR_X, 0, 1, 2) != 0xCA020020) { bad = 1; }
+    if (pack_alu3(AND_W, 0, 1, 2) != 0x0A020020) { bad = 1; }
+    if (pack_alu3(ORR_W, 0, 1, 2) != 0x2A020020) { bad = 1; }
+    if (pack_alu3(EOR_W, 0, 1, 2) != 0x4A020020) { bad = 1; }
+    ret bad;
+}
+
+test "arm64.encode: register shifts (LSLV/LSRV/ASRV) match llvm-mc" {
+    var bad: i32 = 0;
+    if (pack_alu3(LSLV_X, 0, 1, 2) != 0x9AC22020) { bad = 1; }
+    if (pack_alu3(LSLV_W, 0, 1, 2) != 0x1AC22020) { bad = 1; }
+    if (pack_alu3(LSRV_X, 0, 1, 2) != 0x9AC22420) { bad = 1; }
+    if (pack_alu3(LSRV_W, 0, 1, 2) != 0x1AC22420) { bad = 1; }
+    if (pack_alu3(ASRV_X, 0, 1, 2) != 0x9AC22820) { bad = 1; }
+    if (pack_alu3(ASRV_W, 0, 1, 2) != 0x1AC22820) { bad = 1; }
+    ret bad;
+}
+
+test "arm64.encode: immediate shifts (UBFM/SBFM aliases) match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(0);
+    ops[1] = mir.op_preg(1);
+    ops[2] = mir.op_imm(3);
+    mi.operands = ?ops[0];
+    mi.operand_count = 3;
+
+    # lsl x0, x1, #3 = 0xd37df020 ; lsl w0, w1, #3 = 0x531d7020
+    mi.width = 8; encode_shift(?st, ?mi, arm64.LSL::u32);
+    if (read_word(?st.buf, 0) != 0xD37DF020) { bad = 1; }
+    mi.width = 4; encode_shift(?st, ?mi, arm64.LSL::u32);
+    if (read_word(?st.buf, 4) != 0x531D7020) { bad = 1; }
+    # lsr x0, x1, #3 = 0xd343fc20 ; lsr w0, w1, #3 = 0x53037c20
+    mi.width = 8; encode_shift(?st, ?mi, arm64.LSR::u32);
+    if (read_word(?st.buf, 8) != 0xD343FC20) { bad = 1; }
+    mi.width = 4; encode_shift(?st, ?mi, arm64.LSR::u32);
+    if (read_word(?st.buf, 12) != 0x53037C20) { bad = 1; }
+    # asr x0, x1, #3 = 0x9343fc20 ; asr w0, w1, #3 = 0x13037c20
+    mi.width = 8; encode_shift(?st, ?mi, arm64.ASR::u32);
+    if (read_word(?st.buf, 16) != 0x9343FC20) { bad = 1; }
+    mi.width = 4; encode_shift(?st, ?mi, arm64.ASR::u32);
+    if (read_word(?st.buf, 20) != 0x13037C20) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+test "arm64.encode: NEG/MVN/MOV register forms match llvm-mc" {
+    var bad: i32 = 0;
+    # neg x0,x1 = 0xcb0103e0 ; neg w0,w1 = 0x4b0103e0
+    if (pack_alu3(SUB_X, 0, ZR, 1) != 0xCB0103E0) { bad = 1; }
+    if (pack_alu3(SUB_W, 0, ZR, 1) != 0x4B0103E0) { bad = 1; }
+    # mvn x0,x1 = 0xaa2103e0 ; mvn w0,w1 = 0x2a2103e0
+    if (pack_alu3(ORN_X, 0, ZR, 1) != 0xAA2103E0) { bad = 1; }
+    if (pack_alu3(ORN_W, 0, ZR, 1) != 0x2A2103E0) { bad = 1; }
+    # mov x0,x1 = 0xaa0103e0 ; mov w0,w1 = 0x2a0103e0
+    if (pack_alu3(ORR_X, 0, ZR, 1) != 0xAA0103E0) { bad = 1; }
+    if (pack_alu3(ORR_W, 0, ZR, 1) != 0x2A0103E0) { bad = 1; }
+    ret bad;
+}
+
+test "arm64.encode: MOVZ/MOVK materialization matches llvm-mc" {
+    var bad: i32 = 0;
+    # movz x0, #0x1234 lsl {0,16,32,48}
+    if (pack_movewide(MOVZ_X, 0, 0, 0x1234) != 0xD2824680) { bad = 1; }
+    if (pack_movewide(MOVZ_X, 0, 1, 0x1234) != 0xD2A24680) { bad = 1; }
+    if (pack_movewide(MOVZ_X, 0, 2, 0x1234) != 0xD2C24680) { bad = 1; }
+    if (pack_movewide(MOVZ_X, 0, 3, 0x1234) != 0xD2E24680) { bad = 1; }
+    # movk x0, #0x5678 lsl {0,16}
+    if (pack_movewide(MOVK_X, 0, 0, 0x5678) != 0xF28ACF00) { bad = 1; }
+    if (pack_movewide(MOVK_X, 0, 1, 0x5678) != 0xF2AACF00) { bad = 1; }
+    # 32-bit movz/movk
+    if (pack_movewide(MOVZ_W, 0, 0, 0x1234) != 0x52824680) { bad = 1; }
+    if (pack_movewide(MOVK_W, 0, 1, 0x5678) != 0x72AACF00) { bad = 1; }
+
+    # the emitted sequence for 0x12345678 (32-bit): movz w0,#0x5678 ; movk w0,#0x1234,lsl#16
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    emit_movewide_seq(?st, 0, 0x12345678, false);
+    if (st.buf.len != 8) { bad = 1; }
+    or {
+        if (read_word(?st.buf, 0) != pack_movewide(MOVZ_W, 0, 0, 0x5678)) { bad = 1; }
+        if (read_word(?st.buf, 4) != pack_movewide(MOVK_W, 0, 1, 0x1234)) { bad = 1; }
+    }
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+test "arm64.encode: ADD/SUB immediate forms match llvm-mc" {
+    var bad: i32 = 0;
+    # add x0,x1,#5 = 0x91001420 ; sub x0,x1,#5 = 0xd1001420
+    if (pack_addsub_imm(ADDI_X, 0, 1, 5, 0) != 0x91001420) { bad = 1; }
+    if (pack_addsub_imm(SUBI_X, 0, 1, 5, 0) != 0xD1001420) { bad = 1; }
+    # add w0,w1,#5 = 0x11001420 ; sub w0,w1,#5 = 0x51001420
+    if (pack_addsub_imm(ADDI_W, 0, 1, 5, 0) != 0x11001420) { bad = 1; }
+    if (pack_addsub_imm(SUBI_W, 0, 1, 5, 0) != 0x51001420) { bad = 1; }
+    # add x0,x1,#5,lsl#12 = 0x91401420 ; add w0,w1,#5,lsl#12 = 0x11401420
+    if (pack_addsub_imm(ADDI_X, 0, 1, 5, 1) != 0x91401420) { bad = 1; }
+    if (pack_addsub_imm(ADDI_W, 0, 1, 5, 1) != 0x11401420) { bad = 1; }
+    # add sp,sp,#16 = 0x910043ff ; sub sp,sp,#16 = 0xd10043ff ; mov x29,sp = 0x910003fd
+    if (pack_addsub_imm(ADDI_X, ZR, ZR, 16, 0) != 0x910043FF) { bad = 1; }
+    if (pack_addsub_imm(SUBI_X, ZR, ZR, 16, 0) != 0xD10043FF) { bad = 1; }
+    if (pack_addsub_imm(ADDI_X, 29, ZR, 0, 0) != 0x910003FD) { bad = 1; }
+    ret bad;
+}
+
+test "arm64.encode: CMP + CSET match llvm-mc" {
+    var bad: i32 = 0;
+    # cmp x0,x1 = 0xeb01001f ; cmp w0,w1 = 0x6b01001f ; cmp x0,#5 = 0xf100141f ; cmp w0,#5 = 0x7100141f
+    if (pack_cmp_reg(SUBS_REG_X, 0, 1) != 0xEB01001F) { bad = 1; }
+    if (pack_cmp_reg(SUBS_REG_W, 0, 1) != 0x6B01001F) { bad = 1; }
+    if (pack_cmp_imm(SUBS_IMM_X, 0, 5) != 0xF100141F) { bad = 1; }
+    if (pack_cmp_imm(SUBS_IMM_W, 0, 5) != 0x7100141F) { bad = 1; }
+    # cset w0, <cc> family
+    if (pack_cset(CSINC_W, 0, CC_EQ) != 0x1A9F17E0) { bad = 1; }  # cset w0, eq
+    if (pack_cset(CSINC_W, 0, CC_NE) != 0x1A9F07E0) { bad = 1; }  # cset w0, ne
+    if (pack_cset(CSINC_W, 0, CC_LT) != 0x1A9FA7E0) { bad = 1; }  # cset w0, lt
+    if (pack_cset(CSINC_W, 0, CC_LE) != 0x1A9FC7E0) { bad = 1; }  # cset w0, le
+    if (pack_cset(CSINC_W, 0, CC_CC) != 0x1A9F27E0) { bad = 1; }  # cset w0, cc (lo)
+    if (pack_cset(CSINC_W, 0, CC_LS) != 0x1A9F87E0) { bad = 1; }  # cset w0, ls
+    if (pack_cset(CSINC_X, 0, CC_EQ) != 0x9A9F17E0) { bad = 1; }  # cset x0, eq
+    ret bad;
+}
+
+test "arm64.encode: RET / BRK / NOP / B base match llvm-mc" {
+    var bad: i32 = 0;
+    if (RET_WORD != 0xD65F03C0) { bad = 1; }  # ret
+    if (BRK_BASE != 0xD4200000) { bad = 1; }  # brk #0
+    if (NOP_WORD != 0xD503201F) { bad = 1; }  # nop
+    if (B_BASE   != 0x14000000) { bad = 1; }  # b (imm26=0)
+    ret bad;
+}
+
+test "arm64.encode: prologue STP/MOV and epilogue LDP/RET match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # a leaf function: no callee saves, no locals, no outgoing -> total = 16.
+    var f: mir.MirFunction;
+    f.callee_mask = 0;
+    f.callee_mask_fp = 0;
+    f.frame.size = 0;
+    f.frame.outgoing_size = 0;
+    val total: u32 = frame_total(?f);
+    if (total != 16) { bad = 1; }
+
+    emit_prologue(?st, ?f, total);
+    # stp x29, x30, [sp, #-16]! = 0xa9bf7bfd ; mov x29, sp = 0x910003fd
+    if (read_word(?st.buf, 0) != 0xA9BF7BFD) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x910003FD) { bad = 1; }
+
+    emit_epilogue(?st, ?f, total);
+    # ldp x29, x30, [sp], #16 = 0xa8c17bfd
+    if (read_word(?st.buf, 8) != 0xA8C17BFD) { bad = 1; }
+
+    # a 32-byte frame's pre/post-index immediates: stp ...[sp,#-32]! = 0xa9be7bfd,
+    # ldp ...[sp],#32 = 0xa8c27bfd.
+    st.buf.len = 0;
+    var f2: mir.MirFunction;
+    f2.callee_mask = 0;
+    f2.callee_mask_fp = 0;
+    f2.frame.size = 8;
+    f2.frame.outgoing_size = 0;
+    val total2: u32 = frame_total(?f2);
+    if (total2 != 32) { bad = 1; }
+    emit_prologue(?st, ?f2, total2);
+    if (read_word(?st.buf, 0) != 0xA9BE7BFD) { bad = 1; }
+    emit_epilogue(?st, ?f2, total2);
+    if (read_word(?st.buf, 8) != 0xA8C27BFD) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+test "arm64.encode: callee-saved STP/STR pair spills match llvm-mc" {
+    var bad: i32 = 0;
+    # stp x19,x20,[sp,#16] = 0xa90153f3 ; ldp x19,x20,[sp,#16] = 0xa94153f3
+    if (pack_ldstp(STP_OFF_X, 19, 20, ZR, 2) != 0xA90153F3) { bad = 1; }
+    if (pack_ldstp(LDP_OFF_X, 19, 20, ZR, 2) != 0xA94153F3) { bad = 1; }
+    # str x19,[sp,#16] = 0xf9000bf3 ; ldr x19,[sp,#16] = 0xf9400bf3
+    if (pack_ldst(STR_OFF_X, 19, ZR, 2) != 0xF9000BF3) { bad = 1; }
+    if (pack_ldst(LDR_OFF_X, 19, ZR, 2) != 0xF9400BF3) { bad = 1; }
+    ret bad;
+}
+
+test "arm64.encode: branch fixups insert imm26 / imm19 like llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # lay down four placeholder words: B (off 0), B.eq (off 4), CBZ x0 (off 8),
+    # CBNZ x1 (off 12), then patch each against a known target.
+    emit_word(?st, B_BASE);                       # off 0
+    emit_word(?st, BCOND | CC_EQ);                # off 4 (b.eq)
+    emit_word(?st, pack_cbnz(0xB4000000, 0));     # off 8 (cbz x0) — same imm19 field as cbnz
+    emit_word(?st, pack_cbnz(CBNZ_X, 1));         # off 12 (cbnz x1)
+
+    var fx: BranchFixup;
+    # B at 0 -> target 8: disp 8, imm26=2 -> 0x14000002.
+    fx.patch_pos = 0; fx.next_ip = 4;
+    patch_branch_arm64(?st, ?fx, 8);
+    if (read_word(?st.buf, 0) != 0x14000002) { bad = 1; }
+    # B.eq at 4 -> target 12: disp 8, imm19=2 -> 0x54000040.
+    fx.patch_pos = 4; fx.next_ip = 8;
+    patch_branch_arm64(?st, ?fx, 12);
+    if (read_word(?st.buf, 4) != 0x54000040) { bad = 1; }
+    # CBZ x0 at 8 -> target 16: disp 8, imm19=2 -> 0xb4000040.
+    fx.patch_pos = 8; fx.next_ip = 12;
+    patch_branch_arm64(?st, ?fx, 16);
+    if (read_word(?st.buf, 8) != 0xB4000040) { bad = 1; }
+    # CBNZ x1 at 12 -> target 12 (self): disp 0 -> 0xb5000001.
+    fx.patch_pos = 12; fx.next_ip = 16;
+    patch_branch_arm64(?st, ?fx, 12);
+    if (read_word(?st.buf, 12) != 0xB5000001) { bad = 1; }
+
+    # a backward B at 28 -> target 0: disp -28 -> 0x17fffff9 (matches llvm-objdump).
+    st.buf.len = 0;
+    var k: u32 = 0;
+    for (k < 8) { emit_word(?st, B_BASE); k = k + 1; }
+    fx.patch_pos = 28; fx.next_ip = 32;
+    patch_branch_arm64(?st, ?fx, 0);
+    if (read_word(?st.buf, 28) != 0x17FFFFF9) { bad = 1; }
+    # a backward B.eq at 32 -> target 0: disp -32 -> 0x54ffff00.
+    emit_word(?st, BCOND | CC_EQ);
+    fx.patch_pos = 32; fx.next_ip = 36;
+    patch_branch_arm64(?st, ?fx, 0);
+    if (read_word(?st.buf, 32) != 0x54FFFF00) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+test "arm64.encode: end-to-end leaf add(w0,w1) body matches llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # add w0, w0, w1  — the leaf integer body (operands already register-resolved).
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(0);
+    ops[1] = mir.op_preg(0);
+    ops[2] = mir.op_preg(1);
+    mi.operands = ?ops[0];
+    mi.operand_count = 3;
+    mi.width = 4;
+    encode_addsub(?st, ?mi, false);
+    # add w0, w0, w1 = 0x0b010000
+    if (read_word(?st.buf, 0) != 0x0B010000) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
 }

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -2,23 +2,62 @@
 #
 # This is the AArch64 implementation of the ISA vtable's `select` operation,
 # reached only through `tgt.arch.select` by the shared `be.codegen.isel`
-# dispatcher. Instruction selection is not yet implemented: `select` is a total
-# function that fails loudly with an "not implemented" error so an AArch64 build
-# reaches the backend and stops here rather than miscompiling. The selector that
-# rewrites generic MIR opcodes into concrete AArch64 forms is filled in a later
-# phase; the four-file ISA shape (`arm64` defs, `arm64.register` vtable seam,
-# `arm64.isel`, `arm64.encode`) mirrors the x86-64 backend.
+# dispatcher. It is the only target-specific back-end selection phase; register
+# allocation, frame layout, and encoding are shared. `mir.lower_ir` has already
+# produced a `MirFunction` whose instructions carry *generic* MIR opcodes that
+# mirror the IR `OP_*` values, plus the call/phi pseudo-opcodes. Instruction
+# selection rewrites each generic opcode into the concrete AArch64 encoder opcode
+# this ISA owns (see `arm64` and `arm64.encode`).
+#
+# The A64 ALU is three-address (`Rd, Rn, Rm`), so unlike x86-64 the integer
+# binary ops are rewritten IN PLACE to a concrete three-address opcode rather than
+# surviving as a generic sentinel: register allocation keys an instruction's
+# def/use shape on its operands (operand 0 a pure def), not its opcode, so a
+# concrete three-address form is read correctly. Every rewrite is therefore 1:1 —
+# the operand list already matches the machine form and only `opcode` changes —
+# and no block-list rebuild is ever needed (the x86-64 NEG/NOT multi-instruction
+# expansion has no A64 analogue: NEG is a single `sub Rd, XZR, Rm` and NOT a
+# single `mvn Rd, Rm`).
+#
+# A handful of generic opcodes survive selection with a high selection-output
+# sentinel so the encoder can materialize a short byte sequence from them:
+#   - the comparison family (`MIR_CMP_*` -> `MIR_SEL_CMP_*`): the encoder lowers it
+#     to `SUBS XZR, lhs, rhs ; CSET dst, cc`, keeping operand 0 a clean boolean def
+#     the register allocator reads correctly (a flag-setting compare carries a
+#     source in operand 0, which the allocator's def convention would misread).
+#   - the conditional branch (`MIR_CBR` -> `MIR_SEL_CBR`): the encoder lowers it to
+#     `CBNZ cond, then ; B else`, keeping both block targets and the condition on
+#     one terminator so the allocator can read the condition as a use and resolve
+#     both successor edges for liveness.
+#
+# The call / phi pseudo-opcodes (`MIR_CALL`, `MIR_CALL_RES`, `MIR_ARG`, `MIR_PHI`)
+# pass through unchanged for the shared ABI / register-allocation passes (a leaf
+# function has none, but the selector must not choke on them). The scalar float
+# arithmetic / comparison ops and the width / representation conversions also pass
+# through unchanged — their AArch64 encoding lands in a later phase (Phase 3/4);
+# selection only needs to not reject them. The variadic FP-register spill
+# (`MIR_VA_FP_SAVE`) is rejected with a Phase-4 message (a leaf function never
+# emits it). Any opcode this selector does not model fails loudly with an ICE so
+# `select` is total — every opcode path returns a definite result.
 
 use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+
+use std.types.size.usize;
 
 use std.types.string.str;
 
 use std.types.result.Result;
+use std.types.result.ok;
 use std.types.result.err;
+use std.types.result.is_err;
 
 use std.allocator.Allocator;
 
+use os:     std.system.os;
 use target: mach.lang.target.resolved;
+use arm64:  mach.lang.target.isa.arm64;
 use mir:    mach.lang.be.codegen.mir;
 
 # SelectFn: the concrete signature the erased `isa.IsaVTable.select` pointer is
@@ -26,7 +65,8 @@ use mir:    mach.lang.be.codegen.mir;
 # `select` type-erased (`*u8`); the shared dispatcher casts it back to this type
 # before calling it.
 # ---
-# alloc: backing allocator used to rebuild expanded blocks' instruction lists
+# alloc: backing allocator (threaded for parity with the shared SelectFn; the
+#        AArch64 selector rewrites in place and never reallocates a block)
 # tgt:   resolved compilation target (must be AArch64)
 # fn:    the MIR function to select instructions for; mutated in place
 # ret:   ok(true) on success, or an error naming the failure
@@ -34,16 +74,146 @@ pub def SelectFn: fun(*Allocator, *target.Target, *mir.MirFunction) Result[bool,
 
 # select: select concrete AArch64 instructions for one MIR function.
 #
-# the AArch64 implementation behind the ISA vtable's `select` slot; the shared
-# `be.codegen.isel.run` dispatcher reaches it only through `tgt.arch.select`.
-# instruction selection is not yet implemented, so this fails loudly — a total
-# function that signals the unimplemented backend rather than producing wrong
-# instructions.
+# walks every block and rewrites each generic MIR opcode in place into the
+# concrete AArch64 encoder opcode (or leaves it as a surviving sentinel / pass-
+# through). fails loudly on an opcode this selector does not model. the AArch64
+# implementation behind the ISA vtable's `select` slot; reached only through
+# `tgt.arch.select` by the shared `be.codegen.isel.run` dispatcher.
 # ---
-# alloc: backing allocator (unused until selection is implemented)
+# alloc: backing allocator (unused; the AArch64 selector rewrites in place)
 # tgt:   resolved compilation target (must be AArch64)
-# fn:    the MIR function to select instructions for
-# ret:   an error reporting that AArch64 instruction selection is unimplemented
+# fn:    the MIR function to select instructions for; mutated in place
+# ret:   ok(true) on success, or an error naming the failure
 pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Result[bool, str] {
-    ret err[bool, str]("aarch64 isel not implemented");
+    if (alloc == nil) { ret err[bool, str]("isel: nil allocator"); }
+    if (tgt == nil)   { ret err[bool, str]("isel: nil target"); }
+    if (fn == nil)    { ret err[bool, str]("isel: nil mir function"); }
+
+    var bi: u32 = 0;
+    for (bi < fn.block_count) {
+        val b: *mir.MirBlock = ?fn.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < b.instr_count) {
+            val r: Result[bool, str] = rewrite(?b.instrs[ii]);
+            if (is_err[bool, str](r)) { ret r; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+
+    ret ok[bool, str](true);
+}
+
+# write_opcode_ice: writes "internal compiler error: unhandled MIR opcode <N>\n"
+# to stderr before an ICE return so the numeric opcode is visible in crash logs.
+fun write_opcode_ice(opcode: u32) {
+    os.write(os.STDERR_FD, "internal compiler error: unhandled MIR opcode ", 46);
+    var buf: [16]u8;
+    var len: usize = 0;
+    var v: u32 = opcode;
+    if (v == 0) { buf[0] = '0'; len = 1; }
+    or {
+        var tmp: [16]u8;
+        var t: usize = 0;
+        for (v > 0) { tmp[t] = (v % 10)::u8 + '0'; v = v / 10; t = t + 1; }
+        var ri: usize = 0;
+        for (ri < t) { buf[ri] = tmp[t - 1 - ri]; ri = ri + 1; }
+        len = t;
+    }
+    os.write(os.STDERR_FD, ?buf[0], len);
+    os.write(os.STDERR_FD, "\n", 1);
+}
+
+# rewrite a single generic MIR opcode in place into its concrete AArch64 encoder
+# opcode (or leave it as a surviving sentinel / pass-through). the operand list
+# already matches the machine form, so only `opcode` changes. fails loudly on an
+# opcode the AArch64 leaf backend does not model.
+fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
+    val o: mir.MirOpcode = mi.opcode;
+
+    # the three-address integer binary ALU ops rewrite to a concrete A64
+    # three-address opcode (N=1): A64 ALU is three-address, so operand 0 stays a
+    # pure def and the encoder packs one `op Rd, Rn, Rm` word (folding an immediate
+    # right operand into the immediate form or materializing it through a scratch).
+    if (o == mir.MIR_ADD) { mi.opcode = arm64.ADD::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_SUB) { mi.opcode = arm64.SUB::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_MUL) { mi.opcode = arm64.MUL::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_AND) { mi.opcode = arm64.AND::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_OR)  { mi.opcode = arm64.ORR::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_XOR) { mi.opcode = arm64.EOR::u32; ret ok[bool, str](true); }
+
+    # the shifts rewrite to a single A64 shift opcode (no x86-64 CL constraint): the
+    # encoder selects the register variant (LSLV/LSRV/ASRV) or the immediate variant
+    # (UBFM/SBFM alias) from operand 2's kind.
+    if (o == mir.MIR_SHL)   { mi.opcode = arm64.LSL::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_SHR_U) { mi.opcode = arm64.LSR::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_SHR_S) { mi.opcode = arm64.ASR::u32; ret ok[bool, str](true); }
+
+    # negate and complement are single A64 instructions (no x86-64 multi-instruction
+    # expansion): NEG is `sub Rd, XZR, Rm` and NOT is `mvn Rd, Rm` (`orn Rd, XZR,
+    # Rm`). the encoder supplies the XZR operand from the surviving `[dst, src]`.
+    if (o == mir.MIR_NEG) { mi.opcode = arm64.NEG::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_NOT) { mi.opcode = arm64.MVN::u32; ret ok[bool, str](true); }
+
+    # the register-to-register / ABI pre-coloring move selects to a plain MOV; the
+    # encoder emits `orr Rd, XZR, Rm` for a register source or a MOVZ/MOVK sequence
+    # for an immediate source.
+    if (o == mir.MIR_MOV) { mi.opcode = arm64.MOV::u32; ret ok[bool, str](true); }
+
+    # control flow. an unconditional branch selects to B; a return to RET; an
+    # unreachable terminator to a `brk #0` trap.
+    if (o == mir.MIR_BR)          { mi.opcode = arm64.B::u32;   ret ok[bool, str](true); }
+    if (o == mir.MIR_RET)         { mi.opcode = arm64.RET::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_UNREACHABLE) { mi.opcode = arm64.BRK::u32; ret ok[bool, str](true); }
+
+    # the comparison family survives selection as a single `[dst, lhs, rhs]`
+    # instruction keeping its generic opcode, rewritten to a high SELECTION-OUTPUT
+    # sentinel so the encoder never confuses it with a concrete A64 opcode of the
+    # same low value; the encoder materializes the `SUBS XZR, lhs, rhs ; CSET dst,
+    # cc` byte sequence, reading the condition (and its signedness) from the opcode.
+    if (o == mir.MIR_CMP_EQ)   { mi.opcode = mir.MIR_SEL_CMP_EQ;   ret ok[bool, str](true); }
+    if (o == mir.MIR_CMP_NE)   { mi.opcode = mir.MIR_SEL_CMP_NE;   ret ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LT_S) { mi.opcode = mir.MIR_SEL_CMP_LT_S; ret ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LT_U) { mi.opcode = mir.MIR_SEL_CMP_LT_U; ret ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LE_S) { mi.opcode = mir.MIR_SEL_CMP_LE_S; ret ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LE_U) { mi.opcode = mir.MIR_SEL_CMP_LE_U; ret ok[bool, str](true); }
+
+    # the conditional branch survives selection as a single
+    # `[cond, then_block, else_block]` instruction (high sentinel): the allocator
+    # reads `cond` as a use and both block operands as the two successor edges; the
+    # encoder materializes the `CBNZ cond, then ; B else` byte sequence.
+    if (o == mir.MIR_CBR) { mi.opcode = mir.MIR_SEL_CBR; ret ok[bool, str](true); }
+
+    # call / phi pseudo-opcodes survive selection unchanged. MIR_CALL is the
+    # caller-saved clobber barrier the shared register allocator keys on; the
+    # argument, result, and phi pseudos are resolved (or skipped) downstream. a leaf
+    # function has none, but the selector must pass them through (Phase 3 lowers calls).
+    if (o == mir.MIR_CALL || o == mir.MIR_ARG || o == mir.MIR_CALL_RES ||
+        o == mir.MIR_PHI) { ret ok[bool, str](true); }
+
+    # the scalar float arithmetic / comparison / negate ops survive selection
+    # unchanged: their AArch64 encoding lands in a later phase (Phase 3/4). a leaf
+    # integer function never emits them; selection only needs to not reject them.
+    if (o == mir.MIR_FADD || o == mir.MIR_FSUB || o == mir.MIR_FMUL ||
+        o == mir.MIR_FDIV || o == mir.MIR_FCMP || o == mir.MIR_FNEG) {
+        ret ok[bool, str](true);
+    }
+
+    # the width / representation conversions survive selection unchanged (Phase 3/4).
+    if (o == mir.MIR_TRUNC || o == mir.MIR_SEXT || o == mir.MIR_ZEXT ||
+        o == mir.MIR_BITCAST ||
+        o == mir.MIR_FP_TRUNC || o == mir.MIR_FP_EXT ||
+        o == mir.MIR_FP_TO_SI || o == mir.MIR_FP_TO_UI ||
+        o == mir.MIR_SI_TO_FP || o == mir.MIR_UI_TO_FP) {
+        ret ok[bool, str](true);
+    }
+
+    # the AL-guarded variadic FP-register spill: AArch64 varargs land in Phase 4. a
+    # leaf function never emits it, so this is reported rather than modeled.
+    if (o == mir.MIR_VA_FP_SAVE) {
+        ret err[bool, str]("aarch64 varargs not implemented (Phase 4)");
+    }
+
+    write_opcode_ice(o);
+    ret err[bool, str]("internal compiler error: unhandled MIR opcode in instruction selection");
 }

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -61,9 +61,10 @@ var arm64_reload_scratch_regs: [3]isa.Register;
 # the `select` and `encode` operation entry points are the AArch64 instruction
 # selector (`arm64/isel.mach`) and byte encoder (`arm64/encode.mach`), stored
 # type-erased (`*u8`) and cast back to their `SelectFn` / `EncodeFn` signatures by
-# the shared `be.codegen.isel` / `be.codegen.encode` dispatchers. both currently
-# fail loudly with a "not implemented" error, so an AArch64 build reaches the
-# backend and stops there rather than at composition. `emit_asm` is nil — the
+# the shared `be.codegen.isel` / `be.codegen.encode` dispatchers. both implement
+# the leaf-integer backend (Phase 2b): a leaf integer function compiles to byte-
+# correct AArch64; the deferred families (calls, floats, conversions, varargs,
+# spills) fail loudly rather than emit wrong bytes. `emit_asm` is nil — the
 # dispatcher's clean no-op for an ISA with no assembly printer; `arm64.printer`
 # carries the stub the later phase wires here. `asm_clobbers` is nil, which the
 # allocator treats conservatively.


### PR DESCRIPTION
Phase 2b of the aarch64-linux bring-up (epic #1431): the real leaf-integer backend. Replaces the two "not implemented" stubs with byte-correct isel (#1435) + encoder (#1436) consuming the hoisted `enc.encode_driver` via `EncodeHooks`. Milestone: a leaf integer function compiles to a byte-verifiable aarch64 ELF.

## isel (arm64/isel.mach)
A64 ALU is 3-address → in-place concrete rewrites (N=1, no survive-as-sentinel for ALU): ADD/SUB/MUL/AND/OR/XOR; SHL/SHR_U/SHR_S→LSL/LSR/ASR; NEG→`sub Rd,XZR,Rm`; NOT→`orn Rd,XZR,Rm` (MVN); MOV; BR→B; RET; UNREACHABLE→BRK. CMP family + CBR survive as sentinels (encoder lowers to SUBS+CSET / CBNZ+B). MIR_CALL/ARG/PHI/float/conversions pass through unchanged (Phase 3/4). MIR_VA_FP_SAVE + any unmodeled op fail loud — `select` is total.

## encoder (arm64/encode.mach)
Thin `encode_arm64` wrapper builds the two hooks (`encode_function_arm64` + `patch_branch_arm64`) and calls `enc.encode_driver`. Fixed-width 32-bit bitfield packers (Rd[4:0]/Rn[9:5]/Rm[20:16]/Rt2[14:10]/imm12[21:10]); bank index via `isa.regid_index` (vector regs stay composite). Prologue `stp x29,x30,[sp,#-N]! ; mov x29,sp` (callee-saves in STP pairs); epilogue `ldp x29,x30,[sp],#N ; ret`. MOVZ/MOVK materialization. `patch_branch_arm64` does read-modify-write imm26 (B) / imm19 (B.cond/CBZ/CBNZ) bitfield insert, instruction-relative (no x86 −4). `arm64_reloc_offset` = instruction-word start.

## Verification
- **Every emitted form byte-exact vs llvm-mc goldens** (in-source `test` decls): ALU/shifts/MOV/MOVZ/MOVK/NEG/NOT/RET/BRK/NOP, prologue STP+MOV, epilogue LDP+RET, callee-save STP, CMP+CSET, B, and branch-patch imm26/imm19 (verified vs llvm-objdump). I independently re-derived a representative set (stp `0xa9bf7bfd`, movz `0xd2824680`, cset `0x1a9f17e0`/`0x9a9f17e0`, lsl#3 `0xd37df020`, …) — all match.
- **462 tests pass, 0 fail** (450 baseline + 12 new).
- **x64 self-host fixpoint byte-identical** (independently re-run: s1==s2==s3, sha `4cda3c0b`) — only an arm64 path was added; x86 untouched.
- **Leaf .o cross-emit** (`add3(a,b,c){ret (a+b)*c}` → `--target linux-arm64 --emit obj`): `readelf -h` Machine AArch64, ELF64 REL; `llvm-objdump -d` well-formed (stp/mov prologue → add/mul body in W-regs → ldp/ret).

## Deferred (loud errors, never silent — a leaf integer fn never reaches them) → Phase 3
- Frame-slot / spill memory operands: **the arm64 prologue uses `[sp,#-N]!` with x29 at the bottom, while the shared `frame.run` emits x86-convention negative slot offsets — reconciling the slot-offset convention for non-leaf frames is genuine Phase-3 work**, so slot access errs rather than mis-addresses.
- Calls (MIR_CALL), symbol relocations, inline asm (MIR_ASM), float/conversion families, callee-saved FP, frames >504B (pre-index STP range): all err "Phase 3".

Refs #1435 #1436 #1431