### PR TITLE
fix(target): range-check aarch64 branch displacements (Phase 3 prereq)

### DIFF
--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -770,12 +770,29 @@ fun patch_branch_arm64(st: *EncodeState, fx: *BranchFixup, target_off: u32) Resu
         ret err[bool, str]("encode: branch fixup site is outside the text buffer");
     }
     val word: u32 = read_word(?st.buf, pos);
+    # the displacement is instruction-relative and signed; range-check it against
+    # the field width BEFORE the bitfield insert. an out-of-range branch silently
+    # truncated into imm26/imm19 is a miscompile (a real risk in the self-host
+    # compiler's large functions, where an imm19 conditional branch can exceed
+    # +-1MB), so reject it loudly. A64 branch targets are always 4-aligned.
+    val sdisp: i64 = (target_off::i64) - (fx.patch_pos::i64);
+    if ((sdisp & 3) != 0) {
+        ret err[bool, str]("encode: aarch64 branch displacement is not 4-byte aligned");
+    }
     val disp: u32 = target_off - fx.patch_pos;
 
     var patched: u32 = 0;
     if ((word & 0xFC000000) == B_BASE) {
+        # unconditional B: imm26[25:0] scaled by 4 -> +-128MB range.
+        if (sdisp < -134217728 || sdisp >= 134217728) {
+            ret err[bool, str]("encode: aarch64 B displacement exceeds the +-128MB branch range");
+        }
         patched = (word & 0xFC000000) | ((disp & 0x0FFFFFFC) >> 2);
     } or {
+        # B.cond / CBZ / CBNZ: imm19[23:5] scaled by 4 -> +-1MB range.
+        if (sdisp < -1048576 || sdisp >= 1048576) {
+            ret err[bool, str]("encode: aarch64 conditional-branch displacement exceeds the +-1MB range");
+        }
         patched = (word & 0xFF00001F) | (((disp >> 2) & 0x7FFFF) << 5);
     }
     write_word(?st.buf, pos, patched);
@@ -1069,6 +1086,39 @@ test "arm64.encode: branch fixups insert imm26 / imm19 like llvm-mc" {
     fx.patch_pos = 32; fx.next_ip = 36;
     patch_branch_arm64(?st, ?fx, 0);
     if (read_word(?st.buf, 32) != 0x54FFFF00) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# an out-of-range branch displacement must fail loud rather than silently truncate
+# into imm26/imm19 (a miscompile the self-host compiler's large functions can hit).
+test "arm64.encode: branch fixups reject out-of-range displacements (#1436)" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # a conditional branch (imm19, +-1MB) past +-1MB -> reject.
+    emit_word(?st, BCOND | CC_EQ);
+    var fx: BranchFixup;
+    fx.patch_pos = 0; fx.next_ip = 4;
+    val r1: Result[bool, str] = patch_branch_arm64(?st, ?fx, 2000000);
+    if (!is_err[bool, str](r1)) { bad = 1; }
+
+    # an unconditional B (imm26, +-128MB) past +-128MB -> reject.
+    st.buf.len = 0;
+    emit_word(?st, B_BASE);
+    fx.patch_pos = 0; fx.next_ip = 4;
+    val r2: Result[bool, str] = patch_branch_arm64(?st, ?fx, 200000000);
+    if (!is_err[bool, str](r2)) { bad = 1; }
+
+    # the +1MB-4 boundary (max valid imm19 displacement) still succeeds.
+    st.buf.len = 0;
+    emit_word(?st, BCOND | CC_EQ);
+    fx.patch_pos = 0; fx.next_ip = 4;
+    val r3: Result[bool, str] = patch_branch_arm64(?st, ?fx, 1048572);
+    if (is_err[bool, str](r3)) { bad = 1; }
 
     buf_dnit(?st.buf);
     ret bad;


### PR DESCRIPTION
First slice of Phase 3 — the required correctness follow-up from the Phase 2b review (out before the rest of Phase 3's frame/call/memory work, since it's a latent self-host miscompile).

`patch_branch_arm64` inserted the imm26 (B) / imm19 (B.cond/CBZ/CBNZ) displacement **without a range check**, silently truncating any branch beyond ±128MB / ±1MB. Leaf tests can't reach it, but the self-host compiler has large functions where an imm19 conditional-branch displacement can realistically overflow ±1MB → a silent miscompile.

Adds a fail-loud range + 4-alignment check before the bitfield insert (mirrors the Phase-0 `apply_one` CALL26/PAGE21 checks): B rejects beyond ±128MB, B.cond/CBZ/CBNZ beyond ±1MB, and any non-4-aligned displacement.

## Verification
- New in-source test rejects an out-of-range imm19 (~2MB) and imm26 (~200MB) displacement and accepts the +1MB−4 boundary.
- **463 tests pass, 0 fail** (462 + 1).
- x64 self-host fixpoint byte-identical (arm64-only change; x86 path never invokes patch_branch_arm64).

The larger Phase 3 work (frame-slot convention reconciliation → record-at-top non-leaf prologue, MIR_CALL, folded-global ADRP+LDR, address-of, conversions, inline-asm symbol lowering) follows in subsequent PRs.

Refs #1436 #1431