### PR TITLE
fix(target): aarch64 compare with immediate lhs (real-std char gap)

### DIFF
--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1022,7 +1022,12 @@ fun encode_compare(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
     if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
     val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
 
-    val rnr: Result[i32, str] = req_gpr(?mi.operands[1]);
+    # the lhs is usually a register, but the shared lowering canonicalizes the GE/GT
+    # relations (which have no MIR opcode) by SWAPPING operands into LE/LT — which can
+    # leave an immediate on the lhs (e.g. `c >= 48` -> `48 <= c`, lhs=48). materialize
+    # an immediate lhs into SCRATCH1 (distinct from the rhs's SCRATCH0) so the operand
+    # order — and thus `cmp_cond` — is preserved.
+    val rnr: Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH1, use64);
     if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
     val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
 
@@ -1568,6 +1573,35 @@ test "arm64.encode: CMP + CSET match llvm-mc" {
     if (pack_cset(CSINC_W, 0, CC_CC) != 0x1A9F27E0) { bad = 1; }  # cset w0, cc (lo)
     if (pack_cset(CSINC_W, 0, CC_LS) != 0x1A9F87E0) { bad = 1; }  # cset w0, ls
     if (pack_cset(CSINC_X, 0, CC_EQ) != 0x9A9F17E0) { bad = 1; }  # cset x0, eq
+    ret bad;
+}
+
+# regression: the GE/GT relations have no MIR opcode, so the shared lowering
+# canonicalizes them into LE/LT with SWAPPED operands — which can leave an immediate
+# on the compare lhs (e.g. `c >= 48` -> `48 <= c`, lhs=48). encode_compare must
+# materialize an immediate lhs into SCRATCH1 (IP1), not reject it (real-std char gap).
+test "arm64.encode: compare with an immediate lhs materializes (real-std char gap)" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # `48 <= c` at u8 width: [dst w0, lhs #48, rhs w1] -> movz w17,#48 ; cmp w17,w1 ; cset w0,ls
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(0);
+    ops[1] = mir.op_imm(48);
+    ops[2] = mir.op_preg(1);
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+    mi.opcode = mir.MIR_SEL_CMP_LE_U; mi.width = 1;
+
+    val r: Result[bool, str] = encode_compare(?st, ?mi);
+    if (is_err[bool, str](r)) { bad = 1; }
+    if (read_word(?st.buf, 0) != 0x52800611) { bad = 1; }  # movz w17, #48
+    if (read_word(?st.buf, 4) != 0x6B01023F) { bad = 1; }  # cmp w17, w1
+    if (read_word(?st.buf, 8) != 0x1A9F87E0) { bad = 1; }  # cset w0, ls
+
+    buf_dnit(?st.buf);
     ret bad;
 }
 


### PR DESCRIPTION
First fix from the **real-std cross-build repro loop** (the Phase-3 completeness oracle): cross-building `std.types.char` failed with `encode: expected a register operand` — ordinary code, zero inline asm, a real operand shape synthetic goldens didn't enumerate.

## Root cause
The GE/GT relations have no MIR comparison opcode (`cmp_cond`/`is_mir_compare` cover only EQ/NE/LT/LE), so the shared lowering canonicalizes `a >= b` into `b <= a` (LE with **swapped operands**). For `c >= 48` that becomes `48 <= c` — putting the immediate `48` on the compare **lhs** (operand[1]). `encode_compare` called `req_gpr(operand[1])`, rejecting the immediate. (x86 handles this; the EQ/NE path worked because they're commutative so the immediate stayed on the rhs.) Pervasive — every `>=`/`>` against a constant.

## Fix (arm64-only)
Route operand[1] through `resolve_source` (materialize an immediate lhs into SCRATCH1/IP1, distinct from the rhs's SCRATCH0), preserving operand order so `cmp_cond` stays correct. `c >= 48` now emits `movz w17,#48 ; cmp w17,w1 ; cset w0,ls` (LS = unsigned `48<=c` = `c>=48` ✓ — verified vs llvm-mc: 0x52800611 / 0x6b01023f / 0x1a9f87e0).

## Verification
- The previously-failing char patterns (`c >= 48 && c <= 57`, `char_to_lower`, u32/i32 `>=`, etc.) now compile.
- New in-source regression test (immediate-lhs compare → materialize sequence).
- **473 tests pass, 0 fail.**
- **x64 self-host fixpoint byte-identical** (arm64-only change).

Part of the Phase-3 completeness loop. Next ordinary-code gap surfaced: integer division (shared-lowering, flagged separately).

Refs #1431