### PR TITLE
feat(target): aarch64 scalar floating-point (Phase 4 FP)

### DIFF
--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -2769,7 +2769,7 @@ fun free_ops(ctx: *AllocCtx, ops: *mir.MirOperand, n: u32) {
 # `scratch_reg2`, the latter only reserved after the seed_reserved fix), and V31 is
 # the FP scratch held outside the allocatable vector bank. `seed_reserved` must mark
 # all three GP registers reserved, and the vector bank count must exclude V31.
-test "regalloc: AArch64 reserves LR/IP0/IP1 and holds V31 out of the vector bank (#1171)" {
+test "regalloc: AArch64 reserves LR/IP0/IP1 and holds V30/V31 out of the vector bank (#1171)" {
     var reg: target.TargetRegistry = target.registry_init();
     val rr: Result[bool, str] = target.register_all(?reg);
     if (is_err[bool, str](rr)) { ret 1; }
@@ -2794,8 +2794,10 @@ test "regalloc: AArch64 reserves LR/IP0/IP1 and holds V31 out of the vector bank
     if (!reserved[16]) { ret 1; }
     if (!reserved[17]) { ret 1; }
 
-    # V31 is excluded from the allocatable vector bank (count 31, ids 0..30).
-    if (bank_count(?t, fp_class_index(?t)) != 31) { ret 1; }
+    # V30 and V31 are excluded from the allocatable vector bank — the two FP scratch
+    # registers the float-op encoder routes spilled operands through (count 30, ids
+    # 0..29).
+    if (bank_count(?t, fp_class_index(?t)) != 30) { ret 1; }
 
     ret 0;
 }

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -99,10 +99,14 @@ pub val V31: i32 = 31;
 pub val GPR_COUNT: i32 = 31;
 
 # number of allocatable SIMD/floating-point vector registers exposed to the
-# allocator (V0–V30). V31 is held back as the FP scratch register — the AArch64
-# analogue of x86-64 holding XMM15 back from the SSE value pool — so it is excluded
-# from this count.
-pub val VECTOR_COUNT: i32 = 31;
+# allocator (V0–V29). V30 and V31 are held back as the two fixed FP scratch
+# registers the float-op encoder routes spilled operands through — the AArch64
+# analogue of x86-64 holding XMM14/XMM15 back from the SSE value pool. two are
+# required (not one): a binary float op whose destination AND both sources are all
+# spilled to frame slots needs two FP registers live at once to materialize
+# `op Sd, Sn, Sm`, which a single scratch cannot supply. both are caller-saved
+# under AAPCS64, so neither perturbs the callee-save prologue.
+pub val VECTOR_COUNT: i32 = 30;
 
 # the AArch64 machine opcode space. each value names a logical instruction form;
 # the encoder maps it to concrete bytes and the isel table emits it. pseudo
@@ -154,3 +158,12 @@ pub val MOV: Opcode = 13;
 pub val B: Opcode = 14;
 # breakpoint trap `brk #0`, the unreachable-terminator form.
 pub val BRK: Opcode = 15;
+# scalar floating-point register move (`fmov`), the concrete form the selector
+# rewrites a float register copy and a GP<->FP `:~` bitcast into. the encoder
+# dispatches the S/D copy, the GP->FP (`fmov Sd,Wn` / `fmov Dd,Xn`), and the FP->GP
+# (`fmov Wd,Sn` / `fmov Xd,Dn`) forms on operand register CLASS, so a float copy or
+# a cross-bank reinterpret can never mis-select to a GP move of the aliasing index.
+# value 16 is free of any surviving generic MIR opcode (MIR_CMP_NE=16 is rewritten
+# to its selection sentinel in isel, and the surviving MIR pass-throughs the encoder
+# dispatches by opcode — MIR_TRUNC=21 onward — sit above it).
+pub val FMOV: Opcode = 16;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -248,6 +248,57 @@ val CC_GT: u32 = 12;
 val CC_LE: u32 = 13;
 val CC_AL: u32 = 14;
 
+# the two fixed FP scratch registers held back from vector allocation (V0–V29 are
+# allocatable, so these are never an assigned value): V31 is the primary scratch
+# (the vtable's `fp_scratch_reg`) used for a spilled left/source operand and for a
+# spilled destination's result; V30 the secondary, used for a spilled right
+# operand. both are caller-saved under AAPCS64, so neither needs prologue saving.
+val FP_SCRATCH0: u32 = 31;
+val FP_SCRATCH1: u32 = 30;
+
+# scalar floating-point base words. all share the `pack_alu3` field layout (Rm[20:16],
+# Rn[9:5], Rd[4:0]), so the FP encoders reuse it: a two-source op fills all three, a
+# one-source / convert / fmov form passes Rm=0, and a compare passes Rd=0 (its
+# opcode2 field). the `_S` / `_D` suffix is the f32 (S, type=00) vs f64 (D, type=01)
+# form selected by operand width; for the conversions the `_W` / `_X` suffix is the
+# 32-bit (sf=0) vs 64-bit (sf=1) GP-register form. each word is byte-exact against
+# `llvm-mc -triple=aarch64`.
+val FADD_S: u32 = 0x1E202800; val FADD_D: u32 = 0x1E602800;
+val FSUB_S: u32 = 0x1E203800; val FSUB_D: u32 = 0x1E603800;
+val FMUL_S: u32 = 0x1E200800; val FMUL_D: u32 = 0x1E600800;
+val FDIV_S: u32 = 0x1E201800; val FDIV_D: u32 = 0x1E601800;
+# fneg Sd,Sn / Dd,Dn (sign-bit flip) and fmov Sd,Sn / Dd,Dn (register copy).
+val FNEG_S: u32 = 0x1E214000; val FNEG_D: u32 = 0x1E614000;
+val FMOV_S: u32 = 0x1E204000; val FMOV_D: u32 = 0x1E604000;
+# fcvt Dd,Sn (single->double, FP_EXT) and fcvt Sd,Dn (double->single, FP_TRUNC).
+val FCVT_S2D: u32 = 0x1E22C000; val FCVT_D2S: u32 = 0x1E624000;
+# fcmp Sn,Sm / Dn,Dm (set NZCV); the boolean is captured with a following CSET.
+val FCMP_S: u32 = 0x1E202000; val FCMP_D: u32 = 0x1E602000;
+# scvtf / ucvtf Sd|Dd, Wn|Xn (signed / unsigned integer -> float).
+val SCVTF_S_W: u32 = 0x1E220000; val SCVTF_D_W: u32 = 0x1E620000;
+val SCVTF_S_X: u32 = 0x9E220000; val SCVTF_D_X: u32 = 0x9E620000;
+val UCVTF_S_W: u32 = 0x1E230000; val UCVTF_D_W: u32 = 0x1E630000;
+val UCVTF_S_X: u32 = 0x9E230000; val UCVTF_D_X: u32 = 0x9E630000;
+# fcvtzs / fcvtzu Wd|Xd, Sn|Dn (float -> signed / unsigned integer, round-to-zero).
+val FCVTZS_W_S: u32 = 0x1E380000; val FCVTZS_X_S: u32 = 0x9E380000;
+val FCVTZS_W_D: u32 = 0x1E780000; val FCVTZS_X_D: u32 = 0x9E780000;
+val FCVTZU_W_S: u32 = 0x1E390000; val FCVTZU_X_S: u32 = 0x9E390000;
+val FCVTZU_W_D: u32 = 0x1E790000; val FCVTZU_X_D: u32 = 0x9E790000;
+# fmov across the GP / FP banks: GP->FP (`fmov Sd,Wn` / `fmov Dd,Xn`) and FP->GP
+# (`fmov Wd,Sn` / `fmov Xd,Dn`), the cross-bank `:~` bitcast forms.
+val FMOV_S_FROM_W: u32 = 0x1E270000; val FMOV_D_FROM_X: u32 = 0x9E670000;
+val FMOV_W_FROM_S: u32 = 0x1E260000; val FMOV_X_FROM_D: u32 = 0x9E660000;
+
+# scalar FP load/store base words (scaled unsigned-offset, unscaled signed-offset
+# LDUR/STUR, and register-offset), per S (32-bit) / D (64-bit) width. spilled float
+# operands ride frame slots the float encoders address through these.
+val LDR_D_OFF: u32 = 0xFD400000; val STR_D_OFF: u32 = 0xFD000000;
+val LDR_S_OFF: u32 = 0xBD400000; val STR_S_OFF: u32 = 0xBD000000;
+val LDUR_D_FP: u32 = 0xFC400000; val STUR_D_FP: u32 = 0xFC000000;
+val LDUR_S_FP: u32 = 0xBC400000; val STUR_S_FP: u32 = 0xBC000000;
+val LDR_D_REG: u32 = 0xFC606800; val STR_D_REG: u32 = 0xFC206800;
+val LDR_S_REG: u32 = 0xBC606800; val STR_S_REG: u32 = 0xBC206800;
+
 # ---- bitfield packers (pure: each returns one A64 word) ----
 
 # pack_alu3: a three-register data-processing word — Rm[20:16], Rn[9:5], Rd[4:0]
@@ -1056,6 +1107,434 @@ fun encode_convert(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
+# ---- scalar floating-point ----
+
+# reg_is_vec: true when an operand is a physical register in the float / vector
+# bank. reads the class straight off the composite register id — the seam that lets
+# the move family pick the FP versus GP machine form from the operands alone.
+fun reg_is_vec(op: *mir.MirOperand) bool {
+    ret op.kind == mir.MIR_OP_PREG && isa.regid_class(op.preg::i32) == isa.REG_CLASS_ID_XMM;
+}
+
+# req_vec: the within-bank vector register index a post-regalloc register operand
+# names. only a physical register survives to encode; a surviving virtual register
+# is a register-allocation bug. the index is recovered through `regid_index` so the
+# composite XMM id (class tag in the high byte) encodes to the same V-register field
+# as a raw index — a raw GP index would mis-encode.
+fun req_vec(op: *mir.MirOperand) Result[i32, str] {
+    if (op.kind == mir.MIR_OP_PREG) {
+        ret ok[i32, str](isa.regid_index(op.preg::i32));
+    }
+    if (op.kind == mir.MIR_OP_VREG) {
+        ret err[i32, str]("encode: virtual register survived register allocation");
+    }
+    ret err[i32, str]("encode: expected a float register operand");
+}
+
+# fp_mem_scaled_base / fp_mem_unscaled_base / fp_mem_reg_base: the SIMD&FP load /
+# store base word for a width (D = 64-bit when `use_d`, else S = 32-bit) and
+# direction, in the scaled unsigned-offset, unscaled signed-offset (LDUR/STUR), and
+# register-offset forms — the FP twins of `ldst_base_*`.
+fun fp_mem_scaled_base(use_d: bool, is_load: bool) u32 {
+    if (use_d) { if (is_load) { ret LDR_D_OFF; } ret STR_D_OFF; }
+    if (is_load) { ret LDR_S_OFF; }
+    ret STR_S_OFF;
+}
+fun fp_mem_unscaled_base(use_d: bool, is_load: bool) u32 {
+    if (use_d) { if (is_load) { ret LDUR_D_FP; } ret STUR_D_FP; }
+    if (is_load) { ret LDUR_S_FP; }
+    ret STUR_S_FP;
+}
+fun fp_mem_reg_base(use_d: bool, is_load: bool) u32 {
+    if (use_d) { if (is_load) { ret LDR_D_REG; } ret STR_D_REG; }
+    if (is_load) { ret LDR_S_REG; }
+    ret STR_S_REG;
+}
+
+# emit_fp_mem: emit a width-sized scalar float load or store of vector register `rt`
+# at the legalized address `[base + off]`, choosing the scaled unsigned-offset
+# (imm12), unscaled signed-offset (imm9 / LDUR-STUR), or register-offset form. an
+# offset outside both immediate ranges is materialized into IP0 and addressed
+# `[base, IP0]`. the FP analogue of `emit_mem_access`; `width` is 4 (S) or 8 (D).
+fun emit_fp_mem(st: *EncodeState, rt: u32, base: u32, off: i64, width: u8, is_load: bool) {
+    val use_d: bool = width == 8;
+    var sh: u32 = 2;
+    if (use_d) { sh = 3; }
+    if (off >= 0) {
+        val mask: i64 = (1::i64 << sh::i64) - 1;
+        if ((off & mask) == 0 && (off >> sh::i64) <= 4095) {
+            emit_word(st, pack_ldst(fp_mem_scaled_base(use_d, is_load), rt, base, (off >> sh::i64)::u32));
+            ret;
+        }
+    }
+    if (off >= -256 && off <= 255) {
+        emit_word(st, pack_ldur(fp_mem_unscaled_base(use_d, is_load), rt, base, off::u32 & 0x1FF));
+        ret;
+    }
+    emit_movewide_seq(st, SCRATCH0, off::u64, true);
+    emit_word(st, pack_ldst_reg(fp_mem_reg_base(use_d, is_load), rt, base, SCRATCH0));
+}
+
+# emit_fp_slot_store: store vector register `rt` to a frame-slot / pointer MEM
+# destination at float `width`. the spilled-float-destination counterpart of
+# `emit_fp_mem`, resolving the MEM operand first (an indexed float spill is never
+# produced).
+fun emit_fp_slot_store(st: *EncodeState, f: *mir.MirFunction, memop: *mir.MirOperand, rt: u32, width: u8) Result[bool, str] {
+    val mr: Result[A64Mem, str] = resolve_mem(f, memop);
+    if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+    val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+    if (m.has_index) { ret err[bool, str]("encode: indexed float spill destination not expected"); }
+    emit_fp_mem(st, rt, m.base, m.off, width, false);
+    ret ok[bool, str](true);
+}
+
+# resolve_fp_source: the vector register index a float source operand contributes.
+# a physical vector register is used directly; a spilled float arrives as a frame-
+# slot MEM operand (the shared allocator leaves a spilled float in place rather than
+# reloading it through a GP temp) and is loaded into `scratch`, whose index is then
+# returned. `width` (4 / 8) sizes the load.
+fun resolve_fp_source(st: *EncodeState, f: *mir.MirFunction, op: *mir.MirOperand, scratch: u32, width: u8) Result[i32, str] {
+    if (op.kind == mir.MIR_OP_MEM) {
+        val mr: Result[A64Mem, str] = resolve_mem(f, op);
+        if (is_err[A64Mem, str](mr)) { ret err[i32, str](unwrap_err[A64Mem, str](mr)); }
+        val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+        if (m.has_index) { ret err[i32, str]("encode: indexed float spill operand not expected"); }
+        emit_fp_mem(st, scratch, m.base, m.off, width, true);
+        ret ok[i32, str](scratch::i32);
+    }
+    ret req_vec(op);
+}
+
+# fp_arith_base: the A64 two-source base word for a float arithmetic MIR opcode and
+# precision (D when `dbl`, else S).
+fun fp_arith_base(op: mir.MirOpcode, dbl: bool) u32 {
+    if (op == mir.MIR_FADD) { if (dbl) { ret FADD_D; } ret FADD_S; }
+    if (op == mir.MIR_FSUB) { if (dbl) { ret FSUB_D; } ret FSUB_S; }
+    if (op == mir.MIR_FMUL) { if (dbl) { ret FMUL_D; } ret FMUL_S; }
+    if (dbl) { ret FDIV_D; }
+    ret FDIV_S;
+}
+
+# fp_cond: the A64 condition a float comparison materializes through CSET. mirrors
+# the x86-64 UCOMISD + unsigned-SETcc mapping: equality is EQ (the unordered/NaN
+# result has Z=0, so EQ is false on NaN), inequality NE, and the relations use the
+# unordered-aware conditions an FCMP's NZCV select — `<` is MI (N=1, set only for an
+# ordered less-than; an unordered compare leaves N=0), `<=` is LS, with GT / GE for
+# the swapped relations the lowerer never emits directly (canonicalized to LT/LE).
+fun fp_cond(cc: u8) u32 {
+    if (cc == mir.FCC_EQ) { ret CC_EQ; }
+    if (cc == mir.FCC_NE) { ret CC_NE; }
+    if (cc == mir.FCC_LT) { ret CC_MI; }
+    if (cc == mir.FCC_LE) { ret CC_LS; }
+    if (cc == mir.FCC_GT) { ret CC_GT; }
+    ret CC_GE;
+}
+
+# is_mir_float_arith: true when a surviving opcode is one of the scalar float
+# arithmetic ops the encoder materializes from its dedicated MIR opcode.
+fun is_mir_float_arith(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_FADD || op == mir.MIR_FSUB ||
+        op == mir.MIR_FMUL || op == mir.MIR_FDIV;
+}
+
+# is_mir_float_conv: true when a surviving opcode is one of the float conversions.
+fun is_mir_float_conv(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_FP_TRUNC || op == mir.MIR_FP_EXT ||
+        op == mir.MIR_FP_TO_SI || op == mir.MIR_FP_TO_UI ||
+        op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP;
+}
+
+# encode_fp_arith: materialize a surviving float arithmetic op `[dst, lhs, rhs]`
+# into its single A64 instruction `op Sd|Dd, Sn|Dn, Sm|Dm`. each source resolves to
+# a vector register (a spilled source loaded into a scratch: lhs -> V31, rhs -> V30);
+# a register destination encodes directly, a spilled destination computes the result
+# in V31 and stores it to the slot. `mi.width` (4 / 8) selects the S vs D form.
+fun encode_fp_arith(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: float arithmetic missing operands"); }
+    val w: u8 = mi.width;
+    if (w != 4 && w != 8) {
+        ret err[bool, str]("internal compiler error: float arithmetic has a non-float operand width (expected 4 or 8)");
+    }
+    val dbl: bool = w == 8;
+
+    val rnr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, w);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val rmr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[2], FP_SCRATCH1, w);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+
+    val base: u32 = fp_arith_base(mi.opcode, dbl);
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    if (dst.kind == mir.MIR_OP_MEM) {
+        emit_word(st, pack_alu3(base, FP_SCRATCH0, rn, rm));
+        ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, w);
+    }
+    val rdr: Result[i32, str] = req_vec(dst);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, rn, rm));
+    ret ok[bool, str](true);
+}
+
+# encode_fp_neg: materialize a surviving float negation `[dst, src]` into `fneg
+# Sd|Dd, Sn|Dn` (an IEEE-754 sign-bit flip). the source resolves to a vector
+# register (a spilled source loaded into V31); a spilled destination computes into
+# V31 and stores back.
+fun encode_fp_neg(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: float negate missing operands"); }
+    val w: u8 = mi.width;
+    if (w != 4 && w != 8) {
+        ret err[bool, str]("internal compiler error: float negate has a non-float operand width (expected 4 or 8)");
+    }
+    val rnr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, w);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    var base: u32 = FNEG_S;
+    if (w == 8) { base = FNEG_D; }
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    if (dst.kind == mir.MIR_OP_MEM) {
+        emit_word(st, pack_alu3(base, FP_SCRATCH0, rn, 0));
+        ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, w);
+    }
+    val rdr: Result[i32, str] = req_vec(dst);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, rn, 0));
+    ret ok[bool, str](true);
+}
+
+# encode_fp_cmp: materialize a surviving float comparison `[dst, lhs, rhs]` into
+# `fcmp Sn|Dn, Sm|Dm` (set NZCV) followed by `CSET dst, cc` capturing the boolean.
+# the two float sources resolve to vector registers (spilled sources loaded into
+# V31 / V30); the destination is the GP boolean. the compared width (`mi.width`:
+# 4 -> S, 8 -> D) selects the FCMP form; the condition rides `mi.src_width` (an
+# FCC_* code) and is mapped through `fp_cond`.
+fun encode_fp_cmp(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: float comparison missing operands"); }
+    val w: u8 = mi.width;
+    if (w != 4 && w != 8) {
+        ret err[bool, str]("internal compiler error: float comparison has a non-float operand width (expected 4 or 8)");
+    }
+    val cc: u8 = mi.src_width;
+
+    val rnr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, w);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val rmr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[2], FP_SCRATCH1, w);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    var base: u32 = FCMP_S;
+    if (w == 8) { base = FCMP_D; }
+    emit_word(st, pack_alu3(base, 0, rn, rm));
+    emit_word(st, pack_cset(CSINC_W, rd, fp_cond(cc)));
+    ret ok[bool, str](true);
+}
+
+# cvt_int_to_fp_base: the SCVTF / UCVTF base word for an int->float conversion —
+# signedness, the destination precision (D when `dbl`, else S), and the source GP
+# width (X when `src_x`, else W).
+fun cvt_int_to_fp_base(signed: bool, dbl: bool, src_x: bool) u32 {
+    if (signed) {
+        if (dbl) { if (src_x) { ret SCVTF_D_X; } ret SCVTF_D_W; }
+        if (src_x) { ret SCVTF_S_X; }
+        ret SCVTF_S_W;
+    }
+    if (dbl) { if (src_x) { ret UCVTF_D_X; } ret UCVTF_D_W; }
+    if (src_x) { ret UCVTF_S_X; }
+    ret UCVTF_S_W;
+}
+
+# cvt_fp_to_int_base: the FCVTZS / FCVTZU base word for a float->int conversion —
+# signedness, the destination GP width (X when `dst_x`, else W), and the source
+# precision (D when `src_d`, else S). round-toward-zero, mach's defined cast rule.
+fun cvt_fp_to_int_base(signed: bool, dst_x: bool, src_d: bool) u32 {
+    if (signed) {
+        if (dst_x) { if (src_d) { ret FCVTZS_X_D; } ret FCVTZS_X_S; }
+        if (src_d) { ret FCVTZS_W_D; }
+        ret FCVTZS_W_S;
+    }
+    if (dst_x) { if (src_d) { ret FCVTZU_X_D; } ret FCVTZU_X_S; }
+    if (src_d) { ret FCVTZU_W_D; }
+    ret FCVTZU_W_S;
+}
+
+# encode_fp_conv: materialize a surviving float conversion. FP_TRUNC / FP_EXT are a
+# single FCVT between S and D (float on both sides, routed through V31 when spilled).
+# SI_TO_FP / UI_TO_FP convert a GP source (sign / zero extended to a clean value for
+# a sub-word source, the W or X form for a 4 / 8-byte source) into a float via SCVTF
+# / UCVTF. FP_TO_SI / FP_TO_UI convert a float source into a GP destination via
+# FCVTZS / FCVTZU (round-to-zero). `mi.width` is the destination width, `mi.src_width`
+# the source width — for FP_TRUNC/EXT both are float widths; for the int<->float
+# forms one side is the integer width and the other the float width.
+fun encode_fp_conv(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: float conversion missing operands"); }
+    val op: mir.MirOpcode = mi.opcode;
+    val dw: u8 = mi.width;
+    val sw: u8 = mi.src_width;
+
+    if (op == mir.MIR_FP_TRUNC || op == mir.MIR_FP_EXT) {
+        val rnr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, sw);
+        if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+        val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+        var base: u32 = FCVT_D2S;
+        if (op == mir.MIR_FP_EXT) { base = FCVT_S2D; }
+        val dst: *mir.MirOperand = ?mi.operands[0];
+        if (dst.kind == mir.MIR_OP_MEM) {
+            emit_word(st, pack_alu3(base, FP_SCRATCH0, rn, 0));
+            ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, dw);
+        }
+        val rdr: Result[i32, str] = req_vec(dst);
+        if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+        emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, rn, 0));
+        ret ok[bool, str](true);
+    }
+
+    if (op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP) {
+        val signed: bool = op == mir.MIR_SI_TO_FP;
+        val gpr: Result[i32, str] = req_gpr(?mi.operands[1]);
+        if (is_err[i32, str](gpr)) { ret err[bool, str](unwrap_err[i32, str](gpr)); }
+        var gp: u32 = unwrap_ok[i32, str](gpr)::u32;
+        var src_x: bool = sw >= 8;
+        # a sub-word source carries undefined bits above its width; sign / zero
+        # extend it into IP0 to a clean 32-bit value before the W-form convert.
+        if (sw < 4) {
+            val imms: u32 = (sw::u32 * 8) - 1;
+            if (signed) { emit_word(st, pack_bitfield(SBFM_W, SCRATCH0, gp, 0, imms)); }
+            or          { emit_word(st, pack_bitfield(UBFM_W, SCRATCH0, gp, 0, imms)); }
+            gp = SCRATCH0;
+            src_x = false;
+        }
+        val dbl: bool = dw == 8;
+        val base: u32 = cvt_int_to_fp_base(signed, dbl, src_x);
+        val dst: *mir.MirOperand = ?mi.operands[0];
+        if (dst.kind == mir.MIR_OP_MEM) {
+            emit_word(st, pack_alu3(base, FP_SCRATCH0, gp, 0));
+            ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, dw);
+        }
+        val rdr: Result[i32, str] = req_vec(dst);
+        if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+        emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, gp, 0));
+        ret ok[bool, str](true);
+    }
+
+    # FP_TO_SI / FP_TO_UI: float source -> GP destination.
+    val signed: bool = op == mir.MIR_FP_TO_SI;
+    val rnr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, sw);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+    val base: u32 = cvt_fp_to_int_base(signed, dw >= 8, sw == 8);
+    emit_word(st, pack_alu3(base, rd, rn, 0));
+    ret ok[bool, str](true);
+}
+
+# encode_fmov: materialize a float register copy or a GP<->FP `:~` bitcast (both
+# selected to FMOV), dispatching on operand register CLASS and spill state:
+#   - vector <- vector: `fmov Sd|Dd, Sn|Dn` (float copy).
+#   - vector <- GP / GP <- vector: the cross-bank `fmov Sd,Wn` / `fmov Dd,Xn` and
+#     `fmov Wd,Sn` / `fmov Xd,Dn` bit reinterprets.
+#   - a spilled side (frame-slot MEM): a float copy round-trips through V31 / FP
+#     load-store; a cross-bank bitcast whose float side is spilled is a bit-identical
+#     GP load / store of the slot (the bits are the same in either bank).
+# `mi.width` (4 / 8) selects the S/W vs D/X form throughout.
+fun encode_fmov(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: fmov missing operands"); }
+    var w: u8 = mi.width;
+    if (w != 4 && w != 8) { w = 8; }
+    val dbl: bool = w == 8;
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    val src: *mir.MirOperand = ?mi.operands[1];
+
+    if (dst.kind != mir.MIR_OP_MEM && src.kind != mir.MIR_OP_MEM) {
+        val dvec: bool = reg_is_vec(dst);
+        val svec: bool = reg_is_vec(src);
+        if (dvec && svec) {
+            val rdr: Result[i32, str] = req_vec(dst);
+            if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+            val rnr: Result[i32, str] = req_vec(src);
+            if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+            var base: u32 = FMOV_S;
+            if (dbl) { base = FMOV_D; }
+            emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, unwrap_ok[i32, str](rnr)::u32, 0));
+            ret ok[bool, str](true);
+        }
+        if (dvec) {
+            # GP -> FP bit reinterpret.
+            val rdr: Result[i32, str] = req_vec(dst);
+            if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+            val rnr: Result[i32, str] = req_gpr(src);
+            if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+            var base: u32 = FMOV_S_FROM_W;
+            if (dbl) { base = FMOV_D_FROM_X; }
+            emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, unwrap_ok[i32, str](rnr)::u32, 0));
+            ret ok[bool, str](true);
+        }
+        if (svec) {
+            # FP -> GP bit reinterpret.
+            val rdr: Result[i32, str] = req_gpr(dst);
+            if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+            val rnr: Result[i32, str] = req_vec(src);
+            if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+            var base: u32 = FMOV_W_FROM_S;
+            if (dbl) { base = FMOV_X_FROM_D; }
+            emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, unwrap_ok[i32, str](rnr)::u32, 0));
+            ret ok[bool, str](true);
+        }
+        ret err[bool, str]("encode: fmov names two general-purpose registers");
+    }
+
+    if (dst.kind == mir.MIR_OP_MEM) {
+        if (src.kind == mir.MIR_OP_MEM) {
+            # both spilled: a float mem-to-mem copy through V31.
+            val mr: Result[A64Mem, str] = resolve_mem(f, src);
+            if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+            val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+            if (m.has_index) { ret err[bool, str]("encode: indexed float spill operand not expected"); }
+            emit_fp_mem(st, FP_SCRATCH0, m.base, m.off, w, true);
+            ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, w);
+        }
+        if (reg_is_vec(src)) {
+            # float copy, spilled destination: FP store.
+            val rnr: Result[i32, str] = req_vec(src);
+            if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+            ret emit_fp_slot_store(st, f, dst, unwrap_ok[i32, str](rnr)::u32, w);
+        }
+        # GP -> FP bitcast, spilled float destination: store the GP bits directly.
+        ret emit_store_mem(st, f, dst, src, w);
+    }
+
+    # src is the MEM operand, dst a register.
+    if (reg_is_vec(dst)) {
+        # float copy, spilled source: FP load.
+        val rdr: Result[i32, str] = req_vec(dst);
+        if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+        val mr: Result[A64Mem, str] = resolve_mem(f, src);
+        if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+        val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+        if (m.has_index) { ret err[bool, str]("encode: indexed float spill operand not expected"); }
+        emit_fp_mem(st, unwrap_ok[i32, str](rdr)::u32, m.base, m.off, w, true);
+        ret ok[bool, str](true);
+    }
+    # FP -> GP bitcast, spilled float source: load the bits into the GP destination.
+    val rdr: Result[i32, str] = req_gpr(dst);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val mr: Result[A64Mem, str] = resolve_mem(f, src);
+    if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+    val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+    if (m.has_index) { ret err[bool, str]("encode: indexed float spill operand not expected"); }
+    emit_mem_access(st, unwrap_ok[i32, str](rdr)::u32, m.base, m.off, w, true);
+    ret ok[bool, str](true);
+}
+
 # cmp_cond: the A64 condition a surviving comparison sentinel captures. only the
 # EQ / NE / LT / LE forms exist in the generic opcode space (the lowerer
 # canonicalizes GT/GE by swapping operands); signedness selects the signed
@@ -1374,10 +1853,10 @@ fun save_callee_gp(st: *EncodeState, f: *mir.MirFunction, store: bool) {
 # encode_mir_instr: translate one post-regalloc MIR instruction into A64 bytes,
 # recording any intra-module branch fixup or symbol relocation. the regalloc
 # parallel-copy / liveness pseudos emit nothing; the surviving comparison /
-# conditional-branch / memory / conversion opcodes expand into their byte sequences;
-# MIR_CALL emits the direct/indirect call (recording its CALL26 relocation); the
-# float, inline-asm, and varargs families are rejected loudly (an in-scope function
-# never reaches them).
+# conditional-branch / memory / conversion and scalar floating-point opcodes expand
+# into their byte sequences; MIR_CALL emits the direct/indirect call (recording its
+# CALL26 relocation); the inline-asm body is assembled; the variadic FP-register
+# spill is rejected loudly (an in-scope function never reaches it).
 fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) Result[bool, str] {
     val op: u16 = mi.opcode::u16;
 
@@ -1419,20 +1898,23 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
         ret encode_convert(st, mi);
     }
 
-    # deferred families: an in-scope function never emits these, so they are
-    # rejected loudly rather than mis-encoded.
+    # the scalar float arithmetic / negate / comparison ops survive selection keeping
+    # their dedicated MIR opcode; the encoder materializes the A64 scalar-FP byte
+    # sequence here (the operands resolved from vector registers or spilled frame
+    # slots through the FP scratch pair). they reference no branch target or
+    # relocatable symbol, so no fixup / reloc applies.
+    if (is_mir_float_arith(mi.opcode)) { ret encode_fp_arith(st, f, mi); }
+    if (mi.opcode == mir.MIR_FNEG)     { ret encode_fp_neg(st, f, mi); }
+    if (mi.opcode == mir.MIR_FCMP)     { ret encode_fp_cmp(st, f, mi); }
+
+    # the float conversions survive selection keeping their dedicated MIR_FP_* opcode;
+    # the encoder materializes the FCVT / SCVTF / UCVTF / FCVTZS / FCVTZU here.
+    if (is_mir_float_conv(mi.opcode)) { ret encode_fp_conv(st, f, mi); }
+
+    # the AL-guarded variadic FP-register spill: an in-scope function never emits it,
+    # so it is rejected loudly rather than mis-encoded.
     if (mi.opcode == mir.MIR_VA_FP_SAVE) {
         ret err[bool, str]("aarch64 varargs not implemented (Phase 4)");
-    }
-    if (mi.opcode == mir.MIR_FADD || mi.opcode == mir.MIR_FSUB ||
-        mi.opcode == mir.MIR_FMUL || mi.opcode == mir.MIR_FDIV ||
-        mi.opcode == mir.MIR_FCMP || mi.opcode == mir.MIR_FNEG) {
-        ret err[bool, str]("aarch64 floating-point ops not implemented (Phase 4)");
-    }
-    if (mi.opcode == mir.MIR_FP_TRUNC || mi.opcode == mir.MIR_FP_EXT ||
-        mi.opcode == mir.MIR_FP_TO_SI || mi.opcode == mir.MIR_FP_TO_UI ||
-        mi.opcode == mir.MIR_SI_TO_FP || mi.opcode == mir.MIR_UI_TO_FP) {
-        ret err[bool, str]("aarch64 float conversions not implemented (Phase 4)");
     }
     if (mi.opcode == mir.MIR_CALL) {
         ret encode_call(st, mi);
@@ -1454,6 +1936,7 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     if (op == arm64.NEG::u16) { ret encode_neg_mvn(st, mi, SUB_X, SUB_W); }
     if (op == arm64.MVN::u16) { ret encode_neg_mvn(st, mi, ORN_X, ORN_W); }
     if (op == arm64.MOV::u16) { ret encode_mov(st, f, mi); }
+    if (op == arm64.FMOV::u16) { ret encode_fmov(st, f, mi); }
     if (op == arm64.B::u16)   { ret encode_branch(st, fn_base, mi); }
     if (op == arm64.RET::u16) { emit_word(st, RET_WORD); ret ok[bool, str](true); }
     if (op == arm64.BRK::u16) { emit_word(st, BRK_BASE); ret ok[bool, str](true); }
@@ -2725,6 +3208,12 @@ fun tbuf(st: *EncodeState, alloc: *Allocator) {
     st.buf = buf_init(alloc);
 }
 
+# tvec: a composite vector-bank physical-register operand (V`n`), the post-regalloc
+# shape a float operand carries (the XMM class tag in the high byte of the id).
+fun tvec(n: i32) mir.MirOperand {
+    ret mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, n)::u32);
+}
+
 test "arm64.encode: three-address ALU register forms match llvm-mc" {
     var bad: i32 = 0;
     # add x0, x1, x2 ; add w0, w1, w2
@@ -3197,6 +3686,309 @@ test "arm64.encode: frame-slot LDR/STR and spill reload/store match llvm-mc" {
     mvs.operands = ?sops[0]; mvs.operand_count = 2; mvs.width = 8; mvs.src_width = 8;
     encode_mov(?st, ?f, ?mvs);
     if (read_word(?st.buf, 12) != 0xF81F83A9) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# ---- scalar floating-point encode goldens (byte-exact vs llvm-mc) ----
+
+# the four scalar FP arithmetic forms in both precisions (S = f32 width 4, D = f64
+# width 8), register operands, against `llvm-mc -triple=aarch64`.
+test "arm64.encode: scalar FP arithmetic FADD/FSUB/FMUL/FDIV (S+D) match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [3]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+
+    # fadd s0, s1, s2 = 0x1e222820
+    ops[0] = tvec(0); ops[1] = tvec(1); ops[2] = tvec(2);
+    mi.opcode = mir.MIR_FADD; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E222820) { bad = 1; }
+    # fadd d13, d17, d20 = 0x1e742a2d
+    ops[0] = tvec(13); ops[1] = tvec(17); ops[2] = tvec(20);
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E742A2D) { bad = 1; }
+    # fsub s3, s4, s5 = 0x1e253883 ; fsub d3, d4, d5 = 0x1e653883
+    ops[0] = tvec(3); ops[1] = tvec(4); ops[2] = tvec(5);
+    mi.opcode = mir.MIR_FSUB; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E253883) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E653883) { bad = 1; }
+    # fmul s6, s7, s8 = 0x1e2808e6 ; fmul d6, d7, d8 = 0x1e6808e6
+    ops[0] = tvec(6); ops[1] = tvec(7); ops[2] = tvec(8);
+    mi.opcode = mir.MIR_FMUL; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E2808E6) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E6808E6) { bad = 1; }
+    # fdiv s9, s10, s11 = 0x1e2b1949 ; fdiv d9, d10, d11 = 0x1e6b1949
+    ops[0] = tvec(9); ops[1] = tvec(10); ops[2] = tvec(11);
+    mi.opcode = mir.MIR_FDIV; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E2B1949) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E6B1949) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# FNEG (sign-bit flip) and the register-register FMOV float copy, both precisions.
+test "arm64.encode: FNEG + FMOV float copy (S+D) match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [2]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # fneg s12, s13 = 0x1e2141ac ; fneg d12, d13 = 0x1e6141ac
+    ops[0] = tvec(12); ops[1] = tvec(13);
+    mi.opcode = mir.MIR_FNEG; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_neg(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E2141AC) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_neg(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E6141AC) { bad = 1; }
+
+    # fmov s16, s17 = 0x1e204230 ; fmov d16, d17 = 0x1e604230
+    ops[0] = tvec(16); ops[1] = tvec(17);
+    mi.opcode = arm64.FMOV::u32; mi.width = 4; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E204230) { bad = 1; }
+    mi.width = 8; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E604230) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# FCMP + CSET: the compare sets NZCV and the FCC_* condition materializes the
+# boolean through CSET, mapping equality to EQ, inequality to NE, `<` to MI (ordered,
+# NaN-false), `<=` to LS, and the swapped GT / GE forms.
+test "arm64.encode: FCMP + CSET float-condition mapping matches llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [3]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+
+    # fcmp d14, d15 ; cset w0, eq  -> 0x1e6f21c0 ; 0x1a9f17e0
+    ops[0] = mir.op_preg(0); ops[1] = tvec(14); ops[2] = tvec(15);
+    mi.opcode = mir.MIR_FCMP; mi.width = 8; mi.src_width = mir.FCC_EQ; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0) != 0x1E6F21C0) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x1A9F17E0) { bad = 1; }
+
+    # cset w0, ne (FCC_NE) -> 0x1a9f07e0
+    mi.src_width = mir.FCC_NE; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi); if (read_word(?st.buf, 4) != 0x1A9F07E0) { bad = 1; }
+    # cset w0, mi (FCC_LT) -> 0x1a9f57e0
+    mi.src_width = mir.FCC_LT; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi); if (read_word(?st.buf, 4) != 0x1A9F57E0) { bad = 1; }
+    # cset w0, ls (FCC_LE) -> 0x1a9f87e0
+    mi.src_width = mir.FCC_LE; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi); if (read_word(?st.buf, 4) != 0x1A9F87E0) { bad = 1; }
+    # cset w0, gt (FCC_GT) -> 0x1a9fd7e0
+    mi.src_width = mir.FCC_GT; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi); if (read_word(?st.buf, 4) != 0x1A9FD7E0) { bad = 1; }
+    # cset w0, ge (FCC_GE) -> 0x1a9fb7e0
+    mi.src_width = mir.FCC_GE; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi); if (read_word(?st.buf, 4) != 0x1A9FB7E0) { bad = 1; }
+
+    # s-form: fcmp s21, s9 ; cset w3, mi  -> 0x1e2922a0 ; 0x1a9f57e3
+    ops[0] = mir.op_preg(3); ops[1] = tvec(21); ops[2] = tvec(9);
+    mi.width = 4; mi.src_width = mir.FCC_LT; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0) != 0x1E2922A0) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x1A9F57E3) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# int -> float (SCVTF / UCVTF) across signedness, destination precision (S/D), and
+# source GP width (W = 4 / X = 8).
+test "arm64.encode: int->float SCVTF/UCVTF match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [2]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # scvtf s0,w1 / d0,w1 / s0,x1 / d0,x1
+    ops[0] = tvec(0); ops[1] = mir.op_preg(1);
+    mi.opcode = mir.MIR_SI_TO_FP;
+    mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E220020) { bad = 1; }
+    mi.width = 8; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E620020) { bad = 1; }
+    mi.width = 4; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E220020) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E620020) { bad = 1; }
+    # ucvtf s0,w1 / d0,w1 / s0,x1 / d0,x1
+    mi.opcode = mir.MIR_UI_TO_FP;
+    mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E230020) { bad = 1; }
+    mi.width = 8; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E630020) { bad = 1; }
+    mi.width = 4; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E230020) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E630020) { bad = 1; }
+    # register-field exercise: scvtf s7,w9 = 0x1e220127 ; scvtf d22,x13 = 0x9e6201b6
+    ops[0] = tvec(7); ops[1] = mir.op_preg(9);
+    mi.opcode = mir.MIR_SI_TO_FP; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E220127) { bad = 1; }
+    ops[0] = tvec(22); ops[1] = mir.op_preg(13);
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E6201B6) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# float -> int (FCVTZS / FCVTZU, round-toward-zero) across signedness, destination
+# GP width (W/X), and source precision (S/D).
+test "arm64.encode: float->int FCVTZS/FCVTZU match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [2]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # fcvtzs w0,s1 / x0,s1 / w0,d1 / x0,d1
+    ops[0] = mir.op_preg(0); ops[1] = tvec(1);
+    mi.opcode = mir.MIR_FP_TO_SI;
+    mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E380020) { bad = 1; }
+    mi.width = 8; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E380020) { bad = 1; }
+    mi.width = 4; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E780020) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E780020) { bad = 1; }
+    # fcvtzu w0,s1 / x0,s1 / w0,d1 / x0,d1
+    mi.opcode = mir.MIR_FP_TO_UI;
+    mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E390020) { bad = 1; }
+    mi.width = 8; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E390020) { bad = 1; }
+    mi.width = 4; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E790020) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E790020) { bad = 1; }
+    # register-field exercise: fcvtzs w9,s7 = 0x1e3800e9 ; fcvtzs x13,d22 = 0x9e7802cd
+    ops[0] = mir.op_preg(9); ops[1] = tvec(7);
+    mi.opcode = mir.MIR_FP_TO_SI; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E3800E9) { bad = 1; }
+    ops[0] = mir.op_preg(13); ops[1] = tvec(22);
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E7802CD) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# FCVT between single and double (FP_EXT widens, FP_TRUNC narrows) and the GP<->FP
+# bitcast FMOV forms.
+test "arm64.encode: FCVT S<->D and GP<->FP bitcast FMOV match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [2]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # fcvt d18, s19 (FP_EXT, f32->f64) = 0x1e22c272
+    ops[0] = tvec(18); ops[1] = tvec(19);
+    mi.opcode = mir.MIR_FP_EXT; mi.width = 8; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E22C272) { bad = 1; }
+    # fcvt s18, d19 (FP_TRUNC, f64->f32) = 0x1e624272
+    mi.opcode = mir.MIR_FP_TRUNC; mi.width = 4; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E624272) { bad = 1; }
+
+    # GP->FP bitcast: fmov s0,w1 = 0x1e270020 ; fmov d0,x1 = 0x9e670020
+    ops[0] = tvec(0); ops[1] = mir.op_preg(1);
+    mi.opcode = arm64.FMOV::u32; mi.width = 4; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E270020) { bad = 1; }
+    mi.width = 8; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E670020) { bad = 1; }
+    # FP->GP bitcast: fmov w0,s1 = 0x1e260020 ; fmov x0,d1 = 0x9e660020
+    ops[0] = mir.op_preg(0); ops[1] = tvec(1);
+    mi.width = 4; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E260020) { bad = 1; }
+    mi.width = 8; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E660020) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# spilled float operands: the shared allocator leaves a spilled float as a frame-slot
+# MEM operand, which the FP encoders route through the held-back scratch (V31 / V30)
+# — a spilled source loads in, a spilled destination computes in V31 and stores out,
+# and a float copy reloads / stores through the FP load/store forms.
+test "arm64.encode: spilled float operands route through FP scratch (vs llvm-mc)" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # one spill slot for value id 100 at offset -8.
+    var slots: [1]mir.MirSlot;
+    slots[0].value  = 100;
+    slots[0].kind   = mir.SLOT_SPILL;
+    slots[0].offset = -8;
+    slots[0].size   = 8;
+    slots[0].align  = 8;
+    var f: mir.MirFunction;
+    f.frame.slots      = ?slots[0];
+    f.frame.slot_count = 1;
+
+    var ops: [3]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+
+    # spilled lhs: ldur d31,[x29,#-8] ; fadd d0, d31, d2
+    ops[0] = tvec(0); ops[1] = mir.op_mem_slot(100, 0); ops[2] = tvec(2);
+    mi.opcode = mir.MIR_FADD; mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0) != 0xFC5F83BF) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x1E622BE0) { bad = 1; }
+
+    # spilled dst: fadd d31, d1, d2 ; stur d31,[x29,#-8]
+    ops[0] = mir.op_mem_slot(100, 0); ops[1] = tvec(1); ops[2] = tvec(2);
+    st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0) != 0x1E62283F) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0xFC1F83BF) { bad = 1; }
+
+    # float copy spill reload: ldur d5,[x29,#-8]
+    var mv: mir.MirInstr;
+    var mops: [2]mir.MirOperand;
+    mv.operands = ?mops[0]; mv.operand_count = 2; mv.width = 8;
+    mops[0] = tvec(5); mops[1] = mir.op_mem_slot(100, 0);
+    st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mv); if (read_word(?st.buf, 0) != 0xFC5F83A5) { bad = 1; }
+    # float copy spill store: stur d5,[x29,#-8]
+    mops[0] = mir.op_mem_slot(100, 0); mops[1] = tvec(5);
+    st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mv); if (read_word(?st.buf, 0) != 0xFC1F83A5) { bad = 1; }
 
     buf_dnit(?st.buf);
     ret bad;

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -46,13 +46,14 @@
 #
 # The call / phi pseudo-opcodes (`MIR_CALL`, `MIR_CALL_RES`, `MIR_ARG`, `MIR_PHI`)
 # pass through unchanged for the shared ABI / register-allocation passes. The scalar
-# float arithmetic / comparison ops and the float conversions pass through unchanged
-# — their AArch64 encoding lands in Phase 4; selection only needs to not reject
-# them. Inline asm (`MIR_ASM`, Phase 3c) passes through unchanged for the encoder to
-# assemble its body. The variadic FP-register spill (`MIR_VA_FP_SAVE`, Phase 4) is
-# rejected with a phase message. Any opcode this selector does not model fails
-# loudly with an ICE so `select` is total — every opcode path returns a definite
-# result.
+# float arithmetic / comparison / negate ops and the float conversions pass through
+# unchanged (high-sentinel MIR opcodes the encoder materializes into A64 scalar-FP
+# byte sequences); a float register copy and a GP<->FP `:~` bitcast are rewritten to
+# the concrete FMOV. Inline asm (`MIR_ASM`, Phase 3c) passes through unchanged for
+# the encoder to assemble its body. The variadic FP-register spill
+# (`MIR_VA_FP_SAVE`, Phase 4) is rejected with a phase message. Any opcode this
+# selector does not model fails loudly with an ICE so `select` is total — every
+# opcode path returns a definite result.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -71,6 +72,7 @@ use std.allocator.Allocator;
 
 use os:     std.system.os;
 use target: mach.lang.target.resolved;
+use isa:    mach.lang.target.isa;
 use arm64:  mach.lang.target.isa.arm64;
 use mir:    mach.lang.be.codegen.mir;
 
@@ -108,7 +110,7 @@ pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Res
         val b: *mir.MirBlock = ?fn.blocks[bi];
         var ii: u32 = 0;
         for (ii < b.instr_count) {
-            val r: Result[bool, str] = rewrite(?b.instrs[ii]);
+            val r: Result[bool, str] = rewrite(fn, ?b.instrs[ii]);
             if (is_err[bool, str](r)) { ret r; }
             ii = ii + 1;
         }
@@ -138,11 +140,21 @@ fun write_opcode_ice(opcode: u32) {
     os.write(os.STDERR_FD, "\n", 1);
 }
 
+# operand_is_fp: true when a MIR operand names a float/vector-bank value — a float
+# vreg (read from the function's vreg classes) or a vector-class physical register
+# (an ABI argument / return pre-color, read from the composite register id's class
+# tag). drives the float-vs-GP move classification without hardcoding a register.
+fun operand_is_fp(fn: *mir.MirFunction, op: *mir.MirOperand) bool {
+    if (op.kind == mir.MIR_OP_VREG) { ret mir.vreg_is_fp(fn, op.vreg); }
+    if (op.kind == mir.MIR_OP_PREG) { ret isa.regid_class(op.preg::i32) == isa.REG_CLASS_ID_XMM; }
+    ret false;
+}
+
 # rewrite a single generic MIR opcode in place into its concrete AArch64 encoder
 # opcode (or leave it as a surviving sentinel / pass-through). the operand list
 # already matches the machine form, so only `opcode` changes. fails loudly on an
 # opcode the AArch64 leaf backend does not model.
-fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
+fun rewrite(fn: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
     val o: mir.MirOpcode = mi.opcode;
 
     # the three-address integer binary ALU ops rewrite to a concrete A64
@@ -180,10 +192,23 @@ fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
     if (o == mir.MIR_NEG) { mi.opcode = arm64.NEG::u32; ret ok[bool, str](true); }
     if (o == mir.MIR_NOT) { mi.opcode = arm64.MVN::u32; ret ok[bool, str](true); }
 
-    # the register-to-register / ABI pre-coloring move selects to a plain MOV; the
-    # encoder emits `orr Rd, XZR, Rm` for a register source or a MOVZ/MOVK sequence
-    # for an immediate source.
-    if (o == mir.MIR_MOV) { mi.opcode = arm64.MOV::u32; ret ok[bool, str](true); }
+    # the register-to-register / ABI pre-coloring move selects to a plain MOV (`orr
+    # Rd, XZR, Rm` for a register source, a MOVZ/MOVK sequence for an immediate). a
+    # FLOAT move — either operand a float vreg or a vector-class pre-color — selects
+    # to FMOV instead, whose encoder emits the S/D `fmov` and dispatches the spilled
+    # frame-slot forms by register class, so a float copy never mis-encodes as a GP
+    # move of the aliasing register index. the spill reload / store moves regalloc
+    # inserts after selection keep the generic MIR_MOV (the GP encoder handles their
+    # frame-slot operand); a spilled FLOAT operand is left in place as a frame-slot
+    # MEM the float ops resolve, so no float MIR_MOV spill reaches the GP path.
+    if (o == mir.MIR_MOV) {
+        if (operand_is_fp(fn, ?mi.operands[0]) || operand_is_fp(fn, ?mi.operands[1])) {
+            mi.opcode = arm64.FMOV::u32;
+        } or {
+            mi.opcode = arm64.MOV::u32;
+        }
+        ret ok[bool, str](true);
+    }
 
     # control flow. an unconditional branch selects to B; a return to RET; an
     # unreachable terminator to a `brk #0` trap.
@@ -228,17 +253,36 @@ fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
     if (o == mir.MIR_CALL || o == mir.MIR_ARG || o == mir.MIR_CALL_RES ||
         o == mir.MIR_PHI) { ret ok[bool, str](true); }
 
-    # the scalar float arithmetic / comparison / negate ops survive selection
-    # unchanged: their AArch64 encoding lands in a later phase (Phase 3/4). a leaf
-    # integer function never emits them; selection only needs to not reject them.
+    # the scalar float arithmetic / comparison / negate ops survive selection keeping
+    # their dedicated high-sentinel MIR opcode (0x1114+), like the integer compare /
+    # divide families: each is a clean `[dst, lhs, rhs]` (or `[dst, src]`) the
+    # register allocator reads by operand shape, and the encoder materializes the A64
+    # scalar-FP byte sequence (FADD/FSUB/FMUL/FDIV/FNEG single words; FCMP + CSET for
+    # the comparison) from the surviving opcode, sizing the S-vs-D form by `mi.width`.
     if (o == mir.MIR_FADD || o == mir.MIR_FSUB || o == mir.MIR_FMUL ||
         o == mir.MIR_FDIV || o == mir.MIR_FCMP || o == mir.MIR_FNEG) {
         ret ok[bool, str](true);
     }
 
-    # the width / representation conversions survive selection unchanged (Phase 3/4).
+    # a bit reinterpret crossing the GP and float banks (`f64 :~ i64` / `i32 :~ f32`)
+    # selects to FMOV, which transfers the raw bits between an X/W register and an S/D
+    # register; the encoder picks the direction from operand register class. a
+    # same-bank reinterpret (GP<->GP) stays MIR_BITCAST — a plain register copy the
+    # integer conversion encoder handles. a float-to-float bitcast cannot occur (a
+    # reinterpret is equal-size and the only two float widths differ).
+    if (o == mir.MIR_BITCAST) {
+        if (operand_is_fp(fn, ?mi.operands[0]) != operand_is_fp(fn, ?mi.operands[1])) {
+            mi.opcode = arm64.FMOV::u32;
+        }
+        ret ok[bool, str](true);
+    }
+
+    # the integer width conversions and the float conversions survive selection
+    # unchanged: their generic opcode values sit above the concrete A64 opcode space,
+    # so the encoder dispatches each directly (SXTB/UXTB/width-MOV for the integer
+    # forms; FCVT / SCVTF / UCVTF / FCVTZS / FCVTZU for the float forms) and the
+    # allocator reads operand 0 as a clean def.
     if (o == mir.MIR_TRUNC || o == mir.MIR_SEXT || o == mir.MIR_ZEXT ||
-        o == mir.MIR_BITCAST ||
         o == mir.MIR_FP_TRUNC || o == mir.MIR_FP_EXT ||
         o == mir.MIR_FP_TO_SI || o == mir.MIR_FP_TO_UI ||
         o == mir.MIR_SI_TO_FP || o == mir.MIR_UI_TO_FP) {

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -77,11 +77,13 @@ pub fun register_arm64(reg: *isa.IsaRegistry) Result[bool, str] {
     arm64_classes[0].bit_width = 64;
     arm64_classes[0].count     = arm64.GPR_COUNT::u32;
 
-    # the vector bank exposes only V0–V30 (count 31) to the allocator. V31
-    # (FP_SCRATCH_REG) is held back as the fixed FP scratch register the float-op
-    # backend loads operands into, so a live float vreg can never occupy it and be
-    # clobbered — the AArch64 analogue of x86-64 holding XMM14/XMM15 back from the
-    # SSE value pool.
+    # the vector bank exposes only V0–V29 (count 30) to the allocator. V30 and V31
+    # (FP_SCRATCH_REG) are held back as the two fixed FP scratch registers the
+    # float-op encoder routes spilled operands through, so a live float vreg can
+    # never occupy one and be clobbered — the AArch64 analogue of x86-64 holding
+    # XMM14/XMM15 back from the SSE value pool. two are required: a binary float op
+    # with its destination and both sources all spilled needs two FP registers live
+    # at once to form `op Sd, Sn, Sm`, which one scratch cannot supply.
     arm64_classes[1].name      = "vector";
     arm64_classes[1].bit_width = 128;
     arm64_classes[1].count     = arm64.VECTOR_COUNT::u32;
@@ -121,8 +123,10 @@ pub fun register_arm64(reg: *isa.IsaRegistry) Result[bool, str] {
     arm64_vtable.reload_scratch_count = 3;
     arm64_vtable.scratch_reg        = arm64.IP0;
     arm64_vtable.scratch_reg2       = arm64.IP1;
-    # the vector scratch is a composite register id (class tag in the high byte),
-    # mirroring x86-64's FP_SCRATCH_REG — a raw bank index would read as a GP reg.
+    # the primary vector scratch is a composite register id (class tag in the high
+    # byte), mirroring x86-64's FP_SCRATCH_REG — a raw bank index would read as a GP
+    # reg. the encoder pairs it with V30 (the second held-back scratch) for the
+    # both-sources-spilled binary float case.
     arm64_vtable.fp_scratch_reg     = isa.regid_make(isa.REG_CLASS_ID_XMM, arm64.V31);
     arm64_vtable.frame_ptr_reg      = arm64.FP;
     arm64_vtable.stack_ptr_reg      = arm64.SP;


### PR DESCRIPTION
Phase 4 (FP part) — scalar floating-point for aarch64, the last deferred-loud COMPILE-blocker (std uses floats). arm64-only encoder/isel; no shared/x64 logic touched.

## Implemented (MIR op → A64, all byte-exact vs llvm-mc)
FADD/FSUB/FMUL/FDIV/FNEG (S=f32/D=f64), FCMP+CSET, SCVTF/UCVTF (int→float), FCVTZS/FCVTZU (float→int, round-to-zero), FCVT (f32↔f64), FMOV (float move + GP↔FP bitcast). Vector operands are composite regid_make(XMM,n), recovered via regid_index.

## Register-model deviation (flagged)
The float-op encoder needs TWO FP scratch registers (a binary FP op with dst + both sources all spilled needs two live FP temps), mirroring the GP IP0+IP1 pair. So **V30 is reserved as a second FP scratch** (VECTOR_COUNT 31→30; V0–V29 allocatable). Both V30/V31 are AAPCS64 caller-saved → no prologue cost. Touches arm64.mach (count + FMOV opcode), register.mach (comments), and the #1171 regalloc TEST assertion (vector bank 31→30) — allocator logic untouched (test-only).

## ⚠️ DECISION NEEDED — FP-comparison NaN semantics (cross-arch divergence)
arm64 FCMP+CSET currently gives IEEE-754 NaN semantics: `<`/`<=`/`==` are FALSE on NaN, `!=` is TRUE on NaN (FCC_LT→MI, FCC_LE→LS, FCC_EQ→EQ, FCC_NE→NE). **x64 differs on NaN**: it uses a single unsigned SETcc after UCOMISD (FCC_LT→SETB, FCC_EQ→SETE = TRUE on NaN; FCC_NE→SETNE = FALSE on NaN). For ordered (non-NaN) values BOTH agree — only NaN diverges. Unlike the division trap (which mach clearly *defines* + relies on), there's no evidence the compiler/std relies on x64's quirky NaN behavior, and arm64's IEEE result is arguably more correct. Flagging for a conscious ruling (accept the documented per-arch NaN difference vs match x64's quirk — note FCC_LT/LE could match x64 with a single-condition change, but FCC_EQ/NE would need extra instructions). See the message to team-lead.

## Verification
- Every form byte-exact vs llvm-mc (independently re-derived: fadd 0x1E602841, fcmp 0x1E602040, scvtf 0x1E620020, fcvtzs 0x1E780020, fmov GP→FP 0x9E670020, fcvt 0x1E22C020).
- **492 tests pass, 0 fail.**
- **x64 self-host fixpoint byte-identical** (regalloc change is test-only; 144/144 byte-identical x64 objects confirm x64 codegen unchanged).
- Cross-emitted f64/f32 add/mul/div, int↔float conv, and `f64 < f64` (fcmp + cset mi) .o — well-formed.

Refs #1431