### PR TITLE
feat: AAPCS64 ABI gaps #1 (x8 indirect result) + #5 (arg alignment) — additive, x86 byte-identical

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -15,6 +15,7 @@
 
 use std.types.bool.bool;
 use std.types.bool.true;
+use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.option.Option;
@@ -73,10 +74,10 @@ pub fun require_abi(tgt: *target.Target) Result[bool, str] {
 
 # abi_gp_arg_reg: the physical register id of the `index`-th GP argument register
 # of the active ABI, read from `tgt.abi.gp_arg_regs` (the convention's GP argument
-# bank in passing order). used for the hidden sret-pointer argument, which rides
-# in the first GP argument register the same way an ordinary argument does. errors
-# loudly when `index` is past the convention's GP argument file (a classification
-# bug) rather than returning a wrong register.
+# bank in passing order). used to find the integer register a win64 variadic float
+# duplicates into (the hidden sret pointer rides `tgt.abi.indirect_result_reg`,
+# which may be a dedicated register outside this file). errors loudly when `index`
+# is past the convention's GP argument file rather than returning a wrong register.
 # ---
 # tgt:   the active target
 # index: zero-based GP argument-register index
@@ -225,6 +226,53 @@ fun advance_arg_cursors(slot: *abi.ParamSlot, gp_used: *i32, fp_used: *i32) {
     advance_one_cursor(slot.reg2, gp_used, fp_used);
 }
 
+# sret_reserves_gp: whether a CLASS_SRET return reserves the first GP argument
+# register for its hidden result-storage pointer. true only when the convention
+# routes the pointer through the argument file (`indirect_result_in_argfile` — the
+# AMD64 conventions, whose pointer rides RDI / RCX), so the fixed parameters
+# classify against `gp_used = 1`; a dedicated indirect-result register outside the
+# argument file (AAPCS64's X8) reserves no argument register, leaving the GP cursor
+# at 0 so the first real argument lands in the first GP argument register.
+# ---
+# ret_class:  the return value's classification
+# in_argfile: the convention's `indirect_result_in_argfile`
+# ret:        true when an argument GP register must be reserved for the sret pointer
+fun sret_reserves_gp(ret_class: abi.ParamClass, in_argfile: bool) bool {
+    ret ret_class == abi.CLASS_SRET && in_argfile;
+}
+
+# round_up_i64: round `value` up to the next multiple of `align` (a power-of-two
+# alignment). an alignment of 0 or 1 returns `value` unchanged. used to align an
+# outgoing stack-argument offset to its slot's required alignment.
+# ---
+# value: the offset to align
+# align: the alignment to round up to
+# ret:   the smallest multiple of `align` that is >= `value`
+fun round_up_i64(value: i64, align: u64) i64 {
+    if (align <= 1) { ret value; }
+    val a:   i64 = align::i64;
+    val rem: i64 = value % a;
+    if (rem == 0) { ret value; }
+    ret value + (a - rem);
+}
+
+# stack_arg_align: the alignment in bytes a stack-passed argument's slot rounds to.
+# a by-value stack slot (CLASS_STACK) rounds to the value's natural alignment,
+# clamped to the eight-byte outgoing-slot granularity; a by-reference spill
+# (CLASS_STACK_BYREF) holds only an eight-byte pointer, so it rounds to eight
+# regardless of the aggregate's alignment. on x86 every stack argument is
+# ≤8-aligned, so this is always eight and the round-up is identity; AAPCS64 honors a
+# 16-byte-aligned by-value argument.
+# ---
+# class: the slot's classification (CLASS_STACK or CLASS_STACK_BYREF)
+# align: the value's natural alignment in bytes
+# ret:   the slot's stack alignment in bytes
+fun stack_arg_align(class: abi.ParamClass, align: u64) u64 {
+    if (class == abi.CLASS_STACK_BYREF) { ret 8; }
+    if (align < 8) { ret 8; }
+    ret align;
+}
+
 # classify_signature: classify a whole function ABI in ONE left-to-right walk and
 # fill `out` with the resulting `SigLayout`. this is the single ABI-lowering oracle
 # the param / return / call lowering all read, so they can never disagree on a
@@ -289,9 +337,12 @@ pub fun classify_signature(ctx: *lctx.LowerCtx, sig: ir_type.IrTypeId, ret_ty: i
     # into this region, so a stack argument placed below it would be clobbered.
     var stack_off: i64 = ctx.tgt.abi.shadow_space::i64;
 
-    # a CLASS_SRET return reserves the first GP argument register for the hidden
-    # result-storage pointer, so the parameters classify against that reservation.
-    if (out.ret_slot.class == abi.CLASS_SRET) {
+    # a CLASS_SRET return whose hidden result-storage pointer rides the first GP
+    # argument register (the AMD64 conventions) reserves that register, so the
+    # parameters classify against it; a convention with a dedicated indirect-result
+    # register outside the argument file (AAPCS64's X8) reserves none, leaving the GP
+    # cursor at 0 so the first real argument lands in the first GP argument register.
+    if (sret_reserves_gp(out.ret_slot.class, ctx.tgt.abi.indirect_result_in_argfile)) {
         gp_used = 1;
     }
 
@@ -325,10 +376,11 @@ pub fun classify_signature(ctx: *lctx.LowerCtx, sig: ir_type.IrTypeId, ret_ty: i
     for (pi < pc) {
         val pty:  ir_type.IrTypeId = t.data.fn.params[pi];
         val psz:  u64  = ir_type.byte_size(ctx.types, pty, ctx.tgt)::u64;
+        val pal:  u64  = ir_type.byte_align(ctx.types, pty, ctx.tgt)::u64;
         val pfl:  bool = lctx.value_is_float(ctx, pty);
         val pag:  bool = lctx.value_is_aggregate(ctx, pty);
         val peb:  u8   = aggregate_sse_mask(ctx, pty);
-        var slot: abi.ParamSlot = classify_arg(pi::i32, psz, 0, pfl, peb, pag, gp_used, fp_used);
+        var slot: abi.ParamSlot = classify_arg(pi::i32, psz, pal, pfl, peb, pag, gp_used, fp_used);
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering
@@ -336,8 +388,11 @@ pub fun classify_signature(ctx: *lctx.LowerCtx, sig: ir_type.IrTypeId, ret_ty: i
         # occupies the same eight-byte slot as a by-value one — only its contents
         # (a hidden pointer) differ — so it advances the cursor identically. a
         # register slot advances each assigned register's bank cursor (a mixed
-        # GP/SSE aggregate consumes one of each).
+        # GP/SSE aggregate consumes one of each). a by-value stack slot is first
+        # rounded up to the value's alignment (identity on x86, where every stack
+        # argument is ≤8-aligned; honors a 16-aligned AAPCS64 by-value argument).
         if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
+            stack_off   = round_up_i64(stack_off, stack_arg_align(slot.class, pal));
             slot.offset = stack_off;
             stack_off   = stack_off + lctx.stack_slot_bytes(slot.size);
         } or {
@@ -438,16 +493,11 @@ pub fun lower_call(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
 
     if (rslot.class == abi.CLASS_SRET) {
         # the caller allocates the return storage (above) and passes its address in
-        # the first GP argument register (the ABI's GP argument file, RDI under
-        # SysV); the result vreg names that storage. the layout already reserved the
-        # GP slot in `gp_used`, so emit the pre-coloring move into the first register.
+        # the convention's indirect-result register (RDI under SysV, RCX under win64,
+        # the dedicated X8 under AAPCS64); the result vreg names that storage. for an
+        # in-argfile convention the layout already reserved the GP slot in `gp_used`.
         if (res_dst != mir.MIR_VREG_NIL) {
-            var sret_reg: i32 = 0;
-            val sr: Result[bool, str] = abi_gp_arg_reg(ctx.tgt, 0, ?sret_reg);
-            if (is_err[bool, str](sr)) {
-                sig_layout_free(ctx, ?layout);
-                ret sr;
-            }
+            val sret_reg: i32 = ctx.tgt.abi.indirect_result_reg;
             val pre: Result[bool, str] = lctx.emit_mov(ctx, mb,
                 mir.op_preg(sret_reg::u32), mir.op_vreg(res_dst));
             if (is_err[bool, str](pre)) {
@@ -472,13 +522,19 @@ pub fun lower_call(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
             soff = slot.offset;
         } or {
             val asz:  u64  = ir_type.byte_size(ctx.types, av.ty, ctx.tgt)::u64;
+            val aal:  u64  = ir_type.byte_align(ctx.types, av.ty, ctx.tgt)::u64;
             val afl:  bool = lctx.value_is_float(ctx, av.ty);
             val aag:  bool = lctx.value_is_aggregate(ctx, av.ty);
             # a variadic tail aggregate is classified as integer eightbytes (mask 0):
             # the va_arg read path walks the GP register-save / overflow areas, so the
             # caller and callee stay consistent. SSE-eightbyte aggregate passing is for
             # fixed parameters and returns (the C-FFI boundary), not the varargs tail.
-            slot = classify_arg(pidx::i32, asz, 0, afl, 0, aag, gp_used, fp_used);
+            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, gp_used, fp_used);
+            # round a stack-passed tail argument up to its slot alignment before
+            # placing it (identity on x86; honors a 16-aligned AAPCS64 by-value arg).
+            if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
+                stack_off = round_up_i64(stack_off, stack_arg_align(slot.class, aal));
+            }
             soff = stack_off;
         }
 
@@ -574,8 +630,9 @@ pub fun lower_call(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
     val pc: Result[bool, str] = lctx.push_instr(ctx, mb, cmi);
     if (is_err[bool, str](pc)) { ret pc; }
 
-    # bind the result. an sret call already named its storage via RDI; otherwise
-    # move the value out of the canonical return register(s) into the result vreg.
+    # bind the result. an sret call already named its storage via the indirect-result
+    # register; otherwise move the value out of the canonical return register(s) into
+    # the result vreg.
     val dst: u32 = lctx.result_vreg(ctx, iid);
     if (dst != mir.MIR_VREG_NIL && rslot.class != abi.CLASS_SRET) {
         val rr: Result[bool, str] = emit_ret_slot_to_vreg(ctx, mb, rslot, dst, ret_aggr);
@@ -747,23 +804,20 @@ fun emit_ret_slot_to_vreg(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, slot: abi.Para
 pub fun lower_params(ctx: *lctx.LowerCtx, mb: *mir.MirBlock) Result[bool, str] {
     # classify the whole function signature once: the same layout the caller's
     # `lower_call` derives, so a parameter is placed exactly where the call passed
-    # it. an sret return reserves the first GP register (in the layout); the per-
-    # parameter slots carry their real `[rbp + 16 + offset]` stack offsets.
+    # it. an in-argfile sret return reserves the first GP register (in the layout);
+    # an out-of-argfile one (AAPCS64's X8) reserves none. the per-parameter slots
+    # carry their real `[rbp + 16 + offset]` stack offsets.
     val ret_ty: ir_type.IrTypeId = lctx.fn_return_type(ctx);
     var layout: abi.SigLayout;
     val cls: Result[bool, str] = classify_signature(ctx, ctx.fn.sig, ret_ty, ?layout);
     if (is_err[bool, str](cls)) { ret cls; }
 
     # an sret return: the caller passes the hidden result-storage pointer in the
-    # first GP argument register; capture it into a vreg so `lower_ret` copies the
-    # returned aggregate into that storage and returns the pointer in RAX.
+    # convention's indirect-result register (RDI/RCX in the argument file, or the
+    # dedicated X8 under AAPCS64); capture it into a vreg so `lower_ret` copies the
+    # returned aggregate into that storage and returns the pointer in the return reg.
     if (layout.ret_slot.class == abi.CLASS_SRET) {
-        var sret_reg: i32 = 0;
-        val sr: Result[bool, str] = abi_gp_arg_reg(ctx.tgt, 0, ?sret_reg);
-        if (is_err[bool, str](sr)) {
-            sig_layout_free(ctx, ?layout);
-            ret sr;
-        }
+        val sret_reg: i32 = ctx.tgt.abi.indirect_result_reg;
         val svr: Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
         if (is_err[u32, str](svr)) {
             sig_layout_free(ctx, ?layout);
@@ -952,4 +1006,32 @@ fun emit_bare_ret(ctx: *lctx.LowerCtx, mb: *mir.MirBlock) Result[bool, str] {
     mi.width         = mir.WORD_WIDTH;
     mi.src_width     = mir.WORD_WIDTH;
     ret lctx.push_instr(ctx, mb, mi);
+}
+
+test "mir.abi: an sret return seeds a GP argument slot only when the pointer is in the argument file" {
+    # x86 (SysV/win64): the hidden result pointer rides the first GP argument
+    # register, so classify_signature seeds gp_used = 1 (reserves a GP slot).
+    if (!sret_reserves_gp(abi.CLASS_SRET, true)) { ret 1; }
+    # AAPCS64: a dedicated X8 indirect-result register reserves no argument register,
+    # so the first real argument still lands in X0.
+    if (sret_reserves_gp(abi.CLASS_SRET, false)) { ret 1; }
+    # a non-sret return never reserves a GP slot regardless of the convention.
+    if (sret_reserves_gp(abi.CLASS_GP, true)) { ret 1; }
+    ret 0;
+}
+
+test "mir.abi: a stack argument offset rounds up to its slot alignment" {
+    # an 8-aligned argument at an already-8-aligned cursor is identity (the x86 path).
+    if (round_up_i64(8, 8) != 8)   { ret 1; }
+    if (round_up_i64(0, 8) != 0)   { ret 1; }
+    # a 16-aligned by-value argument rounds the cursor up to 16 (the AAPCS64 path).
+    if (round_up_i64(8, 16) != 16) { ret 1; }
+    if (round_up_i64(24, 16) != 32) { ret 1; }
+    # a by-reference spill holds an 8-byte pointer, so it rounds to 8 regardless of
+    # the aggregate's natural alignment.
+    if (stack_arg_align(abi.CLASS_STACK_BYREF, 16) != 8) { ret 1; }
+    # a by-value slot honors the value's alignment, clamped to the 8-byte minimum.
+    if (stack_arg_align(abi.CLASS_STACK, 16) != 16) { ret 1; }
+    if (stack_arg_align(abi.CLASS_STACK, 4) != 8)   { ret 1; }
+    ret 0;
 }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -181,6 +181,19 @@ pub def VaModelFn: fun() VaModel;
 #               starts at this offset, and every call reserves at least this much,
 #               so a callee that homes its register args never corrupts the caller
 #               frame.
+# indirect_result_reg: physical register id carrying the hidden result-storage
+#               pointer for a CLASS_SRET return. the AMD64 conventions route it
+#               through the first GP argument register (SysV's RDI, win64's RCX),
+#               so it consumes a GP argument slot; AAPCS64 uses the dedicated X8
+#               indirect-result register, OUTSIDE the X0–X7 argument file, so the
+#               real arguments still start at X0.
+# indirect_result_in_argfile: true when `indirect_result_reg` is the first GP
+#               argument register and thus consumes a GP argument slot (the AMD64
+#               conventions), so `classify_signature` seeds `gp_used = 1` for an
+#               sret return. false when the pointer rides a dedicated register
+#               outside the argument file (AAPCS64's X8), leaving the GP argument
+#               cursor at 0 so the first real argument lands in the first GP
+#               argument register.
 # va_model:     erased fn ptr — return the convention's `VaModel` (the variadic
 #               save model and its layout facts) so the backend's prologue /
 #               va_start / va_arg expansion dispatches on the model rather than the
@@ -197,6 +210,8 @@ pub rec AbiVTable {
     stack_align:  u32;
     red_zone:     u32;
     shadow_space: u32;
+    indirect_result_reg:        i32;
+    indirect_result_in_argfile: bool;
     va_model:     *u8;
 }
 

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -10,21 +10,19 @@
 # (`*u8`); a consumer casts each back to the neutral signature declared in `abi`
 # (`ClassifyFn`, `ArgPassingFn`, `RetPassingFn`, `RegFileFn`).
 #
-# FIRST CUT (Phase 1). This is the skeleton convention: scalars and ≤16-byte
-# aggregates are placed correctly, and >16-byte aggregates are passed/returned by
-# hidden reference so the lowering of any signature is total and the backend is
-# reached. The contract gaps DEFERRED to a later phase are: the dedicated x8
-# indirect-result register for sret (the return slot currently reports the
-# AAPCS64 indirect-result register id but the generic lowering still passes the
-# hidden pointer through the first GP argument register); homogeneous
-# floating-point / short-vector aggregates (HFA/HVA) — a ≤16-byte all-float
-# aggregate rides GP registers here, not the V-register sequence; and the full
-# AArch64 `va_list` variadic model — `va_model` returns a register-save placeholder
-# sufficient for non-variadic call lowering. Composition tests must avoid
-# sret-returning paths until the contract-gaps phase lands.
+# Scalars and ≤16-byte aggregates are placed in registers; >16-byte aggregates are
+# passed by hidden reference and returned through the dedicated X8 indirect-result
+# register (`indirect_result_in_argfile` is false, so the hidden pointer rides X8
+# OUTSIDE the X0–X7 argument file and the real arguments still start at X0). The
+# contract gaps DEFERRED to a later phase are: homogeneous floating-point /
+# short-vector aggregates (HFA/HVA) — a ≤16-byte all-float aggregate rides GP
+# registers here, not the V-register sequence; and the full AArch64 `va_list`
+# variadic model — `va_model` returns a register-save placeholder sufficient for
+# non-variadic call lowering.
 
 use std.types.result.Result;
 use std.types.result.ok;
+use std.types.result.is_err;
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -47,8 +45,9 @@ pub val REG_X5:  i32 = 5;
 pub val REG_X6:  i32 = 6;
 pub val REG_X7:  i32 = 7;
 # the indirect-result register: the caller passes the address of the result
-# storage for a >16-byte (sret) return here. full x8 semantics are deferred (see
-# the module note); it is named so `classify_return` can report it.
+# storage for a >16-byte (sret) return here. it rides OUTSIDE the X0–X7 argument
+# file (`indirect_result_in_argfile` is false), so the call / callee lowering place
+# and read the hidden pointer in X8 and the real arguments still start at X0.
 pub val REG_X8:  i32 = 8;
 pub val REG_X19: i32 = 19;
 pub val REG_X20: i32 = 20;
@@ -203,8 +202,9 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # a zero-size (void) return yields CLASS_GP with reg=-1. a scalar returns in X0,
 # or V0 for a float. an aggregate of ≤8 bytes returns in X0; a 9–16 byte aggregate
 # returns in the X0:X1 pair. an aggregate larger than 16 bytes is returned through
-# the hidden indirect-result register (CLASS_SRET, reg=X8) — full x8 semantics are
-# deferred (see the module note). HFA/HVA V-register returns are likewise deferred:
+# the dedicated X8 indirect-result register (CLASS_SRET, reg=X8) — the caller passes
+# the result-storage address in X8 and the callee reads it there, leaving X0–X7 for
+# the real arguments. HFA/HVA V-register returns are likewise deferred:
 # a float-bearing ≤16-byte aggregate returns in GP registers here. this classifier
 # is AArch64-specific by selection — the AAPCS64 vtable is only composed for an
 # aarch64 target.
@@ -363,6 +363,11 @@ pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
     aapcs64_vtable.red_zone     = RED_ZONE;
     # AAPCS64 reserves no caller shadow space — stack arguments start at [sp+0].
     aapcs64_vtable.shadow_space = 0;
+    # the hidden sret pointer rides the dedicated X8 indirect-result register, OUTSIDE
+    # the X0–X7 argument file — so `classify_signature` leaves gp_used = 0 and the real
+    # arguments still start at X0.
+    aapcs64_vtable.indirect_result_reg        = REG_X8;
+    aapcs64_vtable.indirect_result_in_argfile = false;
     aapcs64_vtable.va_model      = va_model::*u8;
 
     abi.register(reg, ?aapcs64_vtable);
@@ -426,6 +431,20 @@ test "aapcs64: scalar and small-aggregate returns place X0/V0/X0:X1" {
     if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
     val a: abi.ParamSlot = classify_return(16, 8, false, 0, true);
     if (a.reg != REG_X0 || a.reg2 != REG_X1) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: the indirect-result pointer rides X8 outside the argument file" {
+    var reg: abi.AbiRegistry = abi.registry_init();
+    val r: Result[bool, str] = register(?reg);
+    if (is_err[bool, str](r)) { ret 1; }
+    # AAPCS64 uses the dedicated X8 indirect-result register, OUTSIDE the X0–X7
+    # argument file, so classify_signature leaves gp_used = 0 and X0 stays free for
+    # the first real argument.
+    if (aapcs64_vtable.indirect_result_reg != REG_X8) { ret 1; }
+    if (aapcs64_vtable.indirect_result_in_argfile)    { ret 1; }
+    # X8 is NOT in the GP argument file (X0–X7).
+    if (gp_param_reg(REG_X8) != -1) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -481,6 +481,10 @@ pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
     sysv_vtable.red_zone     = RED_ZONE;
     # SysV reserves no caller shadow space — stack arguments start at [rsp+0].
     sysv_vtable.shadow_space = 0;
+    # the hidden sret pointer rides the first GP argument register (RDI), consuming
+    # a GP argument slot — so `classify_signature` seeds gp_used = 1 for an sret return.
+    sysv_vtable.indirect_result_reg        = gp_param_reg(0);
+    sysv_vtable.indirect_result_in_argfile = true;
     sysv_vtable.va_model      = va_model::*u8;
 
     abi.register(reg, ?sysv_vtable);
@@ -563,6 +567,18 @@ test "sysv: a scalar float still takes an XMM register, an integer a GP" {
     val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_RDI)        { ret 1; }
+    ret 0;
+}
+
+test "sysv: the indirect-result pointer rides the first GP argument register (in argfile)" {
+    var reg: abi.AbiRegistry = abi.registry_init();
+    val r: Result[bool, str] = register(?reg);
+    if (is_err[bool, str](r)) { ret 1; }
+    # SysV routes the hidden sret pointer through RDI (the first GP argument
+    # register), so it consumes a GP argument slot — byte-identical to the prior path.
+    if (sysv_vtable.indirect_result_reg != gp_param_reg(0)) { ret 1; }
+    if (sysv_vtable.indirect_result_reg != REG_RDI)         { ret 1; }
+    if (!sysv_vtable.indirect_result_in_argfile)            { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -463,6 +463,11 @@ pub fun register_win64(reg: *abi.AbiRegistry) Result[bool, str] {
     # win64 reserves 32 bytes of shadow space below the stack arguments for the
     # callee to home RCX/RDX/R8/R9; the outgoing stack args start above it.
     win64_vtable.shadow_space = SHADOW_SPACE::u32;
+    # the hidden sret pointer rides the first GP argument register (RCX), consuming
+    # the first positional slot — so `classify_signature` seeds gp_used = 1, shifting
+    # the real arguments one slot.
+    win64_vtable.indirect_result_reg        = slot_gp_reg(0);
+    win64_vtable.indirect_result_in_argfile = true;
     win64_vtable.va_model     = va_model::*u8;
 
     abi.register(reg, ?win64_vtable);
@@ -671,6 +676,18 @@ test "win64: register files report the win64 banks" {
     # the vector set begins right after the nine integer registers, at XMM6.
     if (cs[CALLEE_SAVED_GP_COUNT].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 6)) { ret 1; }
     if (cs[CALLEE_SAVED_COUNT - 1].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 15)) { ret 1; }
+    ret 0;
+}
+
+test "win64: the indirect-result pointer rides the first GP argument register (in argfile)" {
+    var reg: abi.AbiRegistry = abi.registry_init();
+    val r: Result[bool, str] = register_win64(?reg);
+    if (is_err[bool, str](r)) { ret 1; }
+    # win64 routes the hidden sret pointer through RCX (the first positional slot),
+    # so it consumes a GP argument slot — byte-identical to the prior path.
+    if (win64_vtable.indirect_result_reg != slot_gp_reg(0)) { ret 1; }
+    if (win64_vtable.indirect_result_reg != REG_RCX)        { ret 1; }
+    if (!win64_vtable.indirect_result_in_argfile)           { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Phase 4 mandatory ABI subset — gap #1 (x8/sret) + gap #5 (argument alignment). ADDITIVE changes to SHARED abi.mach + mir/abi.mach; x86 path byte-identical (verified by the x64-linux self-host fixpoint, F1=F2=F3 sha a65bd4cd). team-lead-acked.

Gap #1: AbiVTable gains indirect_result_reg + indirect_result_in_argfile. SysV=RDI/true, win64=RCX/true (unchanged), AAPCS64=X8/false. classify_signature seeds gp_used=1 only when in_argfile (x86 unchanged; AAPCS64 keeps x0-x7 free). Call/callee place/read the hidden pointer at indirect_result_reg.

Gap #5: classify_arg receives the real byte_align at both sites (was 0); stack_off rounds up to the slot alignment. Identity for x86 (all stack args <=8-aligned; classify_arg ignores align there); AAPCS64 honors 16-byte-aligned by-value stack args.

AAPCS64: x8/in_argfile=false; >16B -> CLASS_SRET reg=X8 (return) / BYREF|STACK_BYREF (arg).

Verification: x64-linux fixpoint BYTE-IDENTICAL (the shared-change gate); the x64-windows self-host + win64 ABI suites run in this PR CI (windows-native + integration) to complete the bar. aarch64 sret independently disassembled correct (sret ptr in X8 at call + read from X8 in callee; first real arg in X0). 490 tests, 0 fail.

Deferred (flagged): mir/va.mach:72 counts sret as a GP-arg slot unconditionally - inaccurate only for AAPCS64 VARIADIC >16B-aggregate returns (deferred va_list, v1.6.x); byte-identical for x86.

Refs #1174 #1431