### PR TITLE
feat(arm64): atomic/barrier inline-asm mnemonics (dmb/yield/ldar/stlr/ldaxr/stlxr)

### DIFF
--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -299,6 +299,17 @@ val LDUR_S_FP: u32 = 0xBC400000; val STUR_S_FP: u32 = 0xBC000000;
 val LDR_D_REG: u32 = 0xFC606800; val STR_D_REG: u32 = 0xFC206800;
 val LDR_S_REG: u32 = 0xBC606800; val STR_S_REG: u32 = 0xBC206800;
 
+# acquire/release ordered load-stores + the LL/SC exclusive pair (atomic.mach's
+# LL/SC core): Rt[4:0], Rn[9:5], Rt2 fixed 11111; stlxr's status Rs is [20:16];
+# the X (64-bit) base sets the size bit, the W (32-bit) base clears it.
+val LDAR_X:  u32 = 0xC8DFFC00; val LDAR_W:  u32 = 0x88DFFC00;
+val STLR_X:  u32 = 0xC89FFC00; val STLR_W:  u32 = 0x889FFC00;
+val LDAXR_X: u32 = 0xC85FFC00; val LDAXR_W: u32 = 0x885FFC00;
+val STLXR_X: u32 = 0xC800FC00; val STLXR_W: u32 = 0x8800FC00;
+# yield = HINT #1; dmb's barrier option goes in CRm[11:8].
+val YIELD_WORD: u32 = 0xD503203F;
+val DMB_BASE:   u32 = 0xD50330BF;
+
 # ---- bitfield packers (pure: each returns one A64 word) ----
 
 # pack_alu3: a three-register data-processing word — Rm[20:16], Rn[9:5], Rd[4:0]
@@ -2959,6 +2970,73 @@ fun emit_asm_ldstp(st: *EncodeState, args: str, is_load: bool) Result[bool, str]
     ret ok[bool, str](true);
 }
 
+# emit_asm_ldordered: `ldar` / `stlr` / `ldaxr Rt, [Xn]` — acquire/release ordered
+# load-store or load-acquire-exclusive, addressing the bare base register only.
+fun emit_asm_ldordered(st: *EncodeState, mnem: str, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm ldar/stlr/ldaxr operands"); }
+    if (n != 2) { ret err[bool, str]("encode: inline-asm ldar/stlr/ldaxr expects Rt, [Xn]"); }
+    var rt: AsmOp;
+    var mem: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rt) || rt.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm ldar/stlr/ldaxr value must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret err[bool, str]("encode: inline-asm ldar/stlr/ldaxr address must be a memory operand"); }
+    if (mem.has_index || mem.has_disp || mem.wb_pre) { ret err[bool, str]("encode: inline-asm ldar/stlr/ldaxr addressing must be a bare [Xn]"); }
+    var base: u32 = sel(rt.is64, LDAXR_X, LDAXR_W);
+    if (str_equals(mnem, "ldar")) { base = sel(rt.is64, LDAR_X, LDAR_W); }
+    or (str_equals(mnem, "stlr")) { base = sel(rt.is64, STLR_X, STLR_W); }
+    emit_word(st, pack_ldst(base, rt.reg, mem.base, 0));
+    ret ok[bool, str](true);
+}
+
+# emit_asm_stlxr: `stlxr Ws, Rt, [Xn]` — store-release exclusive; the 32-bit status
+# result Ws is Rs[20:16], the stored value Rt sizes the op.
+fun emit_asm_stlxr(st: *EncodeState, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm stlxr operands"); }
+    if (n != 3) { ret err[bool, str]("encode: inline-asm stlxr expects Ws, Rt, [Xn]"); }
+    var rs: AsmOp;
+    var rt: AsmOp;
+    var mem: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rs) || rs.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm stlxr status must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?rt) || rt.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm stlxr value must be a register"); }
+    if (!asm_parse_operand((?b2[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret err[bool, str]("encode: inline-asm stlxr address must be a memory operand"); }
+    if (mem.has_index || mem.has_disp || mem.wb_pre) { ret err[bool, str]("encode: inline-asm stlxr addressing must be a bare [Xn]"); }
+    val base: u32 = sel(rt.is64, STLXR_X, STLXR_W);
+    emit_word(st, pack_ldst(base, rt.reg, mem.base, 0) | ((rs.reg & 0x1F) << 16));
+    ret ok[bool, str](true);
+}
+
+# emit_asm_dmb: `dmb <option>` — data memory barrier; the option name selects CRm[11:8].
+fun emit_asm_dmb(st: *EncodeState, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm dmb operand"); }
+    if (n != 1) { ret err[bool, str]("encode: inline-asm dmb expects one barrier option"); }
+    var opt: u32 = 0;
+    if (!asm_barrier_option((?b0[0])::str, ?opt)) { ret err[bool, str]("encode: unsupported inline-asm dmb barrier option"); }
+    emit_word(st, DMB_BASE | ((opt & 0xF) << 8));
+    ret ok[bool, str](true);
+}
+
+# asm_barrier_option: the CRm value for a dmb barrier-domain name.
+fun asm_barrier_option(name: str, out: *u32) bool {
+    if (str_equals(name, "sy"))    { @out = 15; ret true; }
+    if (str_equals(name, "st"))    { @out = 14; ret true; }
+    if (str_equals(name, "ld"))    { @out = 13; ret true; }
+    if (str_equals(name, "ish"))   { @out = 11; ret true; }
+    if (str_equals(name, "ishst")) { @out = 10; ret true; }
+    if (str_equals(name, "ishld")) { @out = 9;  ret true; }
+    if (str_equals(name, "nsh"))   { @out = 7;  ret true; }
+    if (str_equals(name, "nshst")) { @out = 6;  ret true; }
+    if (str_equals(name, "nshld")) { @out = 5;  ret true; }
+    if (str_equals(name, "osh"))   { @out = 3;  ret true; }
+    if (str_equals(name, "oshst")) { @out = 2;  ret true; }
+    if (str_equals(name, "oshld")) { @out = 1;  ret true; }
+    ret false;
+}
+
 # emit_asm_branch_label: emit a branch (B / B.cond / CBZ / CBNZ) to a numeric local
 # label. a backward reference patches immediately against the nearest preceding
 # definition; a forward reference is recorded and patched when its definition is
@@ -3134,6 +3212,12 @@ fun encode_asm_stmt_arm64(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, l
     }
     if (str_equals(mnem, "stp")) { ret emit_asm_ldstp(st, args, false); }
     if (str_equals(mnem, "ldp")) { ret emit_asm_ldstp(st, args, true); }
+    if (str_equals(mnem, "dmb"))   { ret emit_asm_dmb(st, args); }
+    if (str_equals(mnem, "yield")) { emit_word(st, YIELD_WORD); ret ok[bool, str](true); }
+    if (str_equals(mnem, "ldar") || str_equals(mnem, "stlr") || str_equals(mnem, "ldaxr")) {
+        ret emit_asm_ldordered(st, mnem, args);
+    }
+    if (str_equals(mnem, "stlxr")) { ret emit_asm_stlxr(st, args); }
 
     ret err[bool, str](asm_named_err(st, "unsupported aarch64 inline-asm mnemonic '", mnem, "'", "unsupported aarch64 inline-asm mnemonic"));
 }
@@ -4547,6 +4631,46 @@ test "arm64.encode: inline-asm load/store forms match llvm-mc" {
     if (read_word(?st.buf, 56) != 0xA90007E0) { bad = 1; }
     if (read_word(?st.buf, 60) != 0xA88107E0) { bad = 1; }
     if (read_word(?st.buf, 64) != 0xA9C107E0) { bad = 1; }
+
+    asm_labels_dnit(?labels);
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the atomic / barrier family (atomic.mach's LL/SC core): `dmb`, `yield`, the
+# acquire/release ordered load-stores, and the load-acquire-exclusive / store-release
+# -exclusive pair. words match llvm-mc (Rt=0, Rn=1, stlxr status Rs=2).
+test "arm64.encode: inline-asm atomic/barrier forms match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: AsmLabels;
+    asm_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "dmb ish");           # 0
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "yield");            # 4
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldar x0, [x1]");    # 8
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldar w0, [x1]");    # 12
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlr x0, [x1]");    # 16
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlr w0, [x1]");    # 20
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldaxr x0, [x1]");   # 24
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldaxr w0, [x1]");   # 28
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlxr w2, x0, [x1]"); # 32
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlxr w2, w0, [x1]"); # 36
+
+    if (read_word(?st.buf, 0)  != 0xD5033BBF) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0xD503203F) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0xC8DFFC20) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0x88DFFC20) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0xC89FFC20) { bad = 1; }
+    if (read_word(?st.buf, 20) != 0x889FFC20) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0xC85FFC20) { bad = 1; }
+    if (read_word(?st.buf, 28) != 0x885FFC20) { bad = 1; }
+    if (read_word(?st.buf, 32) != 0xC802FC20) { bad = 1; }
+    if (read_word(?st.buf, 36) != 0x8802FC20) { bad = 1; }
 
     asm_labels_dnit(?labels);
     buf_dnit(?st.buf);


### PR DESCRIPTION
Adds aarch64 inline-asm encoder coverage for the atomic / barrier mnemonic family that `atomic.mach`'s LL/SC core requires (unblocks `std.sync.atomic` / `mutex` / `thread` on the aarch64 self-host).

## Mnemonics
- `dmb <option>` — data memory barrier; option name selects CRm[11:8] (full standard table: sy/st/ld/ish/ishst/ishld/nsh/nshst/nshld/osh/oshst/oshld).
- `yield` — HINT #1.
- `ldar Xt|Wt, [Xn]` / `stlr Xt|Wt, [Xn]` — acquire/release ordered load-store.
- `ldaxr Xt|Wt, [Xn]` — load-acquire exclusive.
- `stlxr Ws, Xt|Wt, [Xn]` — store-release exclusive (32-bit status Rs[20:16]).

All forms take register + bare `[Xn]` operands (Rt[4:0], Rn[9:5], Rt2 fixed 11111, size in bit 30); non-bare addressing is rejected. LSE and the non-acquire `ldxr`/`stxr` are not included (atomic.mach is LL/SC).

## Verification
- Every form is golden-tested byte-identical to `llvm-mc -triple=aarch64`: `dmb ish`=`0xD5033BBF`, `yield`=`0xD503203F`, `ldar x0,[x1]`=`0xC8DFFC20`, `ldar w0,[x1]`=`0x88DFFC20`, `stlr x0,[x1]`=`0xC89FFC20`, `stlr w0,[x1]`=`0x889FFC20`, `ldaxr x0,[x1]`=`0xC85FFC20`, `ldaxr w0,[x1]`=`0x885FFC20`, `stlxr w2,x0,[x1]`=`0xC802FC20`, `stlxr w2,w0,[x1]`=`0x8802FC20`.
- Full test corpus: 498 passed, 0 failed.
- x86-64 self-host fixpoint byte-identical (stage2 == stage3, sha256 `75a60c56542bf2c36ebfb44320e3622167708bbc718614170ee4eba7d9314734`); aarch64-only change, x86 codegen unchanged.

Closes #1450
Refs #1431