### PR TITLE
fix(mir): runtime shift count on ISAs without a fixed count register (aarch64 LSLV/LSRV/ASRV)

### DIFF
--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -771,11 +771,10 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
         ret lower_div(ctx, mb, inst, iid);
     }
 
-    # a shift (SHL / SHR_S / SHR_U) is two-address on x86-64 (`value op= count`),
-    # and a register count must occupy the ISA's shift-count register (x86-64 CL).
-    # it is lowered into the two-address form with a runtime count pre-colored into
-    # `tgt.arch.shift_count_reg`; an ISA wiring no fixed shift-count register reports
-    # -1 and `lower_shift` errors loudly rather than emitting an un-pre-colored shift.
+    # a shift (SHL / SHR_S / SHR_U): an ISA whose variable-shift form hard-wires the
+    # count register (x86-64 CL) pre-colors a runtime count into `tgt.arch.shift_count_reg`;
+    # an ISA wiring no fixed shift-count register (-1, e.g. AArch64 LSLV/LSRV/ASRV)
+    # passes the count straight through to the three-address register-shift form.
     if (inst.kind == instr.OP_SHL || inst.kind == instr.OP_SHR_S ||
         inst.kind == instr.OP_SHR_U) {
         ret lower_shift(ctx, mb, inst, iid);
@@ -978,18 +977,20 @@ fun lower_shift(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
 
     var count_op: mir.MirOperand = count;
     if (count.kind != mir.MIR_OP_IMM) {
-        # a runtime count must occupy the ISA's shift-count register (x86-64 CL);
-        # move it there and reference it so the encoder selects the `shift r/m, CL`
-        # form. the register is reserved from allocation for the whole function, so
-        # this move cannot clobber a live value. an ISA wiring no fixed shift-count
-        # register (`shift_count_reg < 0`) cannot lower a runtime-count shift here.
+        # an ISA whose variable-shift form hard-wires the count register (x86-64 CL,
+        # `shift_count_reg >= 0`) pre-colors the runtime count into it and references it
+        # so the encoder selects the `shift r/m, CL` form; the register is reserved from
+        # allocation for the whole function, so the move cannot clobber a live value. an
+        # ISA wiring no fixed shift-count register (`shift_count_reg < 0`, e.g. AArch64
+        # LSLV/LSRV/ASRV, which read the count from any GP register) passes the count
+        # straight through to the three-address register-shift form — mirroring the
+        # division's `div_reg < 0` three-address path.
         val cnt_reg: i32 = ctx.tgt.arch.shift_count_reg;
-        if (cnt_reg < 0) {
-            ret err[bool, str]("mir.lower_ir: ISA wires no shift-count register for a runtime shift count");
+        if (cnt_reg >= 0) {
+            val mc: Result[bool, str] = lctx.emit_mov_w(ctx, mb, mir.op_preg(cnt_reg::u32), count, w);
+            if (is_err[bool, str](mc)) { ret mc; }
+            count_op = mir.op_preg(cnt_reg::u32);
         }
-        val mc: Result[bool, str] = lctx.emit_mov_w(ctx, mb, mir.op_preg(cnt_reg::u32), count, w);
-        if (is_err[bool, str](mc)) { ret mc; }
-        count_op = mir.op_preg(cnt_reg::u32);
     }
 
     # the three-address shift: operand 0 is the pure-def destination, operand 1 the


### PR DESCRIPTION
A shared middle-end lowering fix — the 5th gap the mach-std cross-build oracle surfaced (after FP/BITCAST/atomic/callee-FP), at `codegen std.system.os.linux.shared`.

## The gap
A variable shift with a **runtime** count fails to compile for aarch64:
```
pub fun f(x: u64, n: u64) u64 { ret x << n; }   # error (same for >>, signed/unsigned)
pub fun f(x: u64) u64 { ret x << 3; }           # OK (constant count)
```
`error: mir.lower_ir: ISA wires no shift-count register for a runtime shift count`

`lower_shift` pre-colored a runtime count into the ISA's shift-count register (x86-64 CL). An ISA wiring no fixed count register (`shift_count_reg < 0` — AArch64 LSLV/LSRV/ASRV read the count from any GP register, correctly wired -1 in the arm64 vtable) hit a loud error instead. Common in std (bit/hash/serialization), so it blocked the cross-build.

## The fix
Guard the pre-coloring with `shift_count_reg >= 0`; when -1, pass the runtime count straight through to the three-address `MIR_SHL/SHR_* [dst, value, count]`, which the AArch64 isel (→ LSL/LSR/ASR) and `encode_shift` (→ LSLV/LSRV/ASRV register-variable form) already handle. Constant counts already rode as immediates. **Mirrors the already-merged `lower_div` `div_reg < 0` three-address path** exactly. The regalloc shift-count reservation keys on a *physical-register* count operand (`function_has_reg_shift`), so the aarch64 vreg-count form correctly skips it (never `reserve_reg(-1)`) — same as the working aarch64 division path.

Shared file (`mir/lower.mach`), additive, x86-neutral by construction.

## Verification
- **x86-64 byte-identical (definitive):** the patched compiler rebuilds the *pre-fix* dev source to the byte-identical x86 binary (`6d90877e…`) — the change does not alter x86 codegen.
- **x86-64 self-host fixpoint:** patched compiler s2==s3 byte-identical (`f8e0f513…`).
- **qemu execution:** a program exercising LSLV/LSRV/ASRV with runtime counts returns the correct value (`(5<<3)>>3 + (-(−64>>3)) = 13`).
- **No regression:** the FP/BITCAST qemu program still exits 116.
- CI: full Test Suite + AArch64-cross + Windows-native cover x86-linux/windows + the aarch64 cross-build.

Refs #1431.
