### PR TITLE
feat(arm64): shift inline-asm mnemonics (lsl/lsr/asr + lslv/lsrv/asrv)

### DIFF
--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -3136,6 +3136,52 @@ fun asm_barrier_option(name: str, out: *u32) bool {
     ret false;
 }
 
+# emit_asm_shift: `lsl`/`lsr`/`asr Rd, Rn, #imm|Rm` and the register-only
+# `lslv`/`lsrv`/`asrv Rd, Rn, Rm`. an immediate count emits the UBFM (lsl/lsr) /
+# SBFM (asr) bitfield alias — immr=(W-sh)&(W-1), imms=W-1-sh for lsl; immr=sh,
+# imms=W-1 for lsr/asr — the register form the LSLV/LSRV/ASRV variable shift,
+# mirroring the MIR `encode_shift`.
+fun emit_asm_shift(st: *EncodeState, mnem: str, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm shift operands"); }
+    if (n != 3) { ret err[bool, str]("encode: inline-asm shift expects Rd, Rn, Rm|#imm"); }
+    var rd: AsmOp; var rn: AsmOp; var cnt: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm shift destination must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?rn) || rn.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm shift source must be a register"); }
+    if (!asm_parse_operand((?b2[0])::str, ?cnt)) { ret err[bool, str]("encode: malformed inline-asm shift count"); }
+    val use64: bool = rd.is64;
+    var width: u32 = 32;
+    if (use64) { width = 64; }
+    # kind: 0 = lsl, 1 = lsr, 2 = asr; the `v` mnemonics are register-only.
+    var kind: u32 = 0;
+    var vform: bool = false;
+    if (str_equals(mnem, "lsr"))  { kind = 1; }
+    or (str_equals(mnem, "asr"))  { kind = 2; }
+    or (str_equals(mnem, "lslv")) { kind = 0; vform = true; }
+    or (str_equals(mnem, "lsrv")) { kind = 1; vform = true; }
+    or (str_equals(mnem, "asrv")) { kind = 2; vform = true; }
+    if (cnt.kind == ASMOP_IMM && !vform) {
+        val sh: u32 = (cnt.imm::u32) & (width - 1);
+        if (kind == 0) {
+            val immr: u32 = (width - sh) & (width - 1);
+            val imms: u32 = (width - 1) - sh;
+            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd.reg, rn.reg, immr, imms));
+        } or (kind == 1) {
+            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd.reg, rn.reg, sh, width - 1));
+        } or {
+            emit_word(st, pack_bitfield(sel(use64, SBFM_X, SBFM_W), rd.reg, rn.reg, sh, width - 1));
+        }
+        ret ok[bool, str](true);
+    }
+    if (cnt.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm shift count must be a register or immediate"); }
+    var bx: u32 = LSLV_X; var bw: u32 = LSLV_W;
+    if (kind == 1) { bx = LSRV_X; bw = LSRV_W; }
+    or (kind == 2) { bx = ASRV_X; bw = ASRV_W; }
+    emit_word(st, pack_alu3(sel(use64, bx, bw), rd.reg, rn.reg, cnt.reg));
+    ret ok[bool, str](true);
+}
+
 # emit_asm_branch_label: emit a branch (B / B.cond / CBZ / CBNZ) to a numeric local
 # label. a backward reference patches immediately against the nearest preceding
 # definition; a forward reference is recorded and patched when its definition is
@@ -3317,6 +3363,10 @@ fun encode_asm_stmt_arm64(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, l
         ret emit_asm_ldordered(st, mnem, args);
     }
     if (str_equals(mnem, "stlxr")) { ret emit_asm_stlxr(st, args); }
+    if (str_equals(mnem, "lsl") || str_equals(mnem, "lsr") || str_equals(mnem, "asr") ||
+        str_equals(mnem, "lslv") || str_equals(mnem, "lsrv") || str_equals(mnem, "asrv")) {
+        ret emit_asm_shift(st, mnem, args);
+    }
 
     ret err[bool, str](asm_named_err(st, "unsupported aarch64 inline-asm mnemonic '", mnem, "'", "unsupported aarch64 inline-asm mnemonic"));
 }
@@ -4875,6 +4925,46 @@ test "arm64.encode: inline-asm atomic/barrier forms match llvm-mc" {
     if (read_word(?st.buf, 28) != 0x885FFC20) { bad = 1; }
     if (read_word(?st.buf, 32) != 0xC802FC20) { bad = 1; }
     if (read_word(?st.buf, 36) != 0x8802FC20) { bad = 1; }
+
+    asm_labels_dnit(?labels);
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the shift family (UBFM/SBFM immediate aliases + LSLV/LSRV/ASRV register forms): the
+# `lsl`/`lsr`/`asr` mnemonics over immediate and register counts, plus the register-only
+# `lslv`/`lsrv`/`asrv`. words match llvm-mc.
+test "arm64.encode: inline-asm shift forms match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: AsmLabels;
+    asm_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsl x10, x10, #3"); # 0
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsl w0, w1, #3");   # 4
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsr x0, x1, #3");   # 8
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsr w0, w1, #3");   # 12
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "asr x0, x1, #3");   # 16
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "asr w0, w1, #3");   # 20
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsl x0, x1, x2");   # 24
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsr x0, x1, x2");   # 28
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "asr x0, x1, x2");   # 32
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lslv x0, x1, x2");  # 36
+
+    if (read_word(?st.buf, 0)  != 0xD37DF14A) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0x531D7020) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0xD343FC20) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0x53037C20) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0x9343FC20) { bad = 1; }
+    if (read_word(?st.buf, 20) != 0x13037C20) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0x9AC22020) { bad = 1; }
+    if (read_word(?st.buf, 28) != 0x9AC22420) { bad = 1; }
+    if (read_word(?st.buf, 32) != 0x9AC22820) { bad = 1; }
+    if (read_word(?st.buf, 36) != 0x9AC22020) { bad = 1; }
 
     asm_labels_dnit(?labels);
     buf_dnit(?st.buf);


### PR DESCRIPTION
Adds the shift mnemonic family to the aarch64 inline-asm encoder, unblocking `std.runtime.linux.aarch64` `_start` (#273), which uses `lsl x10, x10, 3`.

## Set added
- `lsl`/`lsr`/`asr Rd, Rn, #imm` — UBFM (lsl/lsr) / SBFM (asr) bitfield aliases (immr=(W-sh)&(W-1), imms=W-1-sh for lsl; immr=sh, imms=W-1 for lsr/asr).
- `lsl`/`lsr`/`asr Rd, Rn, Rm` — LSLV/LSRV/ASRV variable shift.
- register-only `lslv`/`lsrv`/`asrv Rd, Rn, Rm`.

W and X forms. `emit_asm_shift` mirrors the MIR-level `encode_shift` immr/imms formula and the #1453 atomic-handler structure; wired into `encode_asm_stmt_arm64` dispatch.

## Verification
- In-source golden `arm64.encode: inline-asm shift forms match llvm-mc` asserts every form byte-identical to `llvm-mc -triple=aarch64 -show-encoding` (all encodings re-derived).
- `mach test .`: 501 passed, 0 failed.
- x86-64 self-host fixpoint byte-identical (stage2 == stage3, sha256 `e731be53303528f1cf9f23ae666d6598a7939a73604cc4501f54ef2ce3aeda79`).
- aarch64-only change; x86-64 output byte-identical.

Closes #1456