### PR TITLE
fix(parser): disambiguate bare statement keywords cnt/brk from identifiers (#1458)

### DIFF
--- a/.github/tests/kwident/prog/mach.toml
+++ b/.github/tests/kwident/prog/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "kwidentprog"
+name = "Contextual keyword used as identifier (#1458)"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.kwidentprog]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/kwident/prog/src/main.mach
+++ b/.github/tests/kwident/prog/src/main.mach
@@ -1,0 +1,38 @@
+use std.runtime;
+use std.types.size.usize;
+
+fun g() usize { ret 1; }
+
+# the #1458 repro: `cnt` (the continue keyword) used as a variable. binding
+# (`var cnt`) and r-value (`ret cnt`) positions always worked; the assignment
+# `cnt = g();` used to misparse as a continue statement and fail the build with
+# "expected ';' after 'cnt'". all three positions must now agree.
+fun repro() usize {
+    var cnt: usize = 0;
+    cnt = g();
+    ret cnt;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    if (repro() != 1) { ret 1; }
+
+    # a variable named `cnt` and bare `cnt;`/`brk;` coexist in one scope: the
+    # bare forms drive control flow while the name reads and assigns normally.
+    var cnt: i32 = 0;
+    cnt = 5;
+    if (cnt != 5) { ret 2; }
+
+    var sum: i32 = 0;
+    var i: i32 = 0;
+    for (true) {
+        i = i + 1;
+        if (i > 10) { brk; }
+        if (i == 3) { cnt; }
+        sum = sum + i;
+    }
+    # 1+2+4+5+6+7+8+9+10 with 3 skipped via continue = 52
+    if (sum != 52) { ret 3; }
+
+    ret 0;
+}

--- a/.github/tests/kwident/prog/src/main.mach
+++ b/.github/tests/kwident/prog/src/main.mach
@@ -1,4 +1,5 @@
 use std.runtime;
+use std.types.bool.true;
 use std.types.size.usize;
 
 fun g() usize { ret 1; }

--- a/.github/tests/kwident/run.sh
+++ b/.github/tests/kwident/run.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Contextual statement keywords used as identifiers (#1458). `cnt`/`brk` are the
+# continue/break keywords only in their bare `cnt;`/`brk;` form; the same word
+# used as a name (`var cnt`, `cnt = g()`, `ret cnt`) must compile and run as an
+# ordinary identifier. before the fix `cnt = g();` misparsed as a continue
+# statement and the build failed with "expected ';' after 'cnt'". the app exits
+# 0 only when every position agrees and bare cnt/brk still drive control flow.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# vendor <app-dir>: copy the app into the temp dir and symlink the vendored std.
+vendor() {
+    local app="$1"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+}
+
+# build_and_run <app-dir> <expected-exit>: build the app, run the binary, and
+# require the build to succeed and the run to exit with the expected code.
+build_and_run() {
+    local app="$1"; local want="$2"
+    vendor "$app"
+    local dst="$WORK/$app"
+    if ! ( cd "$dst" && "$MACH" build . ) >/dev/null 2>&1; then
+        echo "FAIL kwident/$app: build failed" >&2; fail=1; return
+    fi
+    local bin
+    bin="$(find "$dst/out" -type f -path '*/bin/*' | head -n1)"
+    if [ -z "$bin" ]; then
+        echo "FAIL kwident/$app: no binary produced" >&2; fail=1; return
+    fi
+    set +e
+    "$bin"; local code=$?
+    set -e
+    if [ "$code" -ne "$want" ]; then
+        echo "FAIL kwident/$app: ran with exit $code, expected $want" >&2; fail=1; return
+    fi
+    echo "PASS kwident/$app: cnt/brk used as identifiers compile and run; bare cnt;/brk; still control flow"
+}
+
+build_and_run prog 0
+
+exit "$fail"

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -95,7 +95,10 @@ nil  or   pub  rec  ret  test uni  use  val  var
 `nil` is an expression literal; the rest are statement/declaration/type
 introducers. Note these are *contextual*: nothing in the lexer prevents a
 binding or field from being named after one, but the parser will treat the
-keyword in its keyword position. The primitive type names (`u8`, `u16`,
+keyword in its keyword position. The operand-less statement keywords `brk`
+and `cnt` are keywords only in their bare form (`brk;` / `cnt;`); the same
+word followed by anything else is an ordinary identifier, so `cnt = x;` is an
+assignment to a variable named `cnt`. The primitive type names (`u8`, `u16`,
 `u32`, `u64`, `i8`, `i16`, `i32`, `i64`, `f32`, `f64`, `ptr`) are *not*
 keywords — they are ordinary identifiers resolved by name later.
 

--- a/doc/language/statements.md
+++ b/doc/language/statements.md
@@ -51,6 +51,11 @@ for (i < 10) {
 }
 ```
 
+Both are operand-less, so they are keywords only in their bare `brk;` / `cnt;`
+form. The same word followed by anything else is an ordinary identifier — a
+variable named `cnt` reads and assigns normally (`cnt = x;`), even inside a
+loop that also uses bare `cnt;` for control flow.
+
 ## `fin` — deferred statement
 
 `fin` schedules a statement (or block) to execute when the enclosing scope

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -114,8 +114,8 @@ pub fun parse_stmt(p: *parser.Parser) id.StmtId {
     if (parser.at_kw(p, "if"))            { ret parse_if_stmt(p, start.span); }
     if (parser.at_kw(p, "for"))           { ret parse_for_stmt(p, start.span); }
     if (parser.at_kw(p, "ret"))           { ret parse_ret_stmt(p, start.span); }
-    if (parser.at_kw(p, "brk"))           { ret parse_brk_stmt(p, start.span); }
-    if (parser.at_kw(p, "cnt"))           { ret parse_cnt_stmt(p, start.span); }
+    if (at_bare_kw_stmt(p, "brk"))        { ret parse_brk_stmt(p, start.span); }
+    if (at_bare_kw_stmt(p, "cnt"))        { ret parse_cnt_stmt(p, start.span); }
     if (parser.at_kw(p, "fin"))           { ret parse_fin_stmt(p, start.span); }
     if (parser.at_kw(p, "asm"))           { ret pasm.parse_asm(p); }
     if (parser.at_kw(p, "val") || parser.at_kw(p, "var")) { ret parse_local_decl_stmt(p, start.span); }
@@ -160,6 +160,17 @@ fun peek_is_kw(p: *parser.Parser, offset: usize, kw: str) bool {
     val t: token.Token = parser.peek(p, offset);
     if (t.kind != token.KIND_IDENT) { ret false; }
     ret str_region_equals(p.tokens.source, t.span.offset, t.span.len, kw);
+}
+
+# true when the current token is the contextual keyword `kw` in its bare
+# statement form — the keyword immediately followed by `;`. `cnt`/`brk` are the
+# only statement keywords that take no operand, so a non-`;` follower (e.g.
+# `cnt = x`, `cnt.f`) means the word is an ordinary identifier rather than the
+# continue/break keyword. dispatching on the bare form lets such a name parse as
+# an expression statement instead of misparsing as continue/break (#1458).
+fun at_bare_kw_stmt(p: *parser.Parser, kw: str) bool {
+    if (!parser.at_kw(p, kw)) { ret false; }
+    ret parser.peek(p, 1).kind == token.KIND_SEMI;
 }
 
 # parses the shared `[alias:] path;` tail of a `use`/`fwd` declaration (the
@@ -1201,5 +1212,67 @@ test "parser: $if/$or chains parse at decl and stmt scope via the shared skeleto
     if (t_parse_module_has_errors("fun f() i64 { $if (1) { ret 1; } $or { ret 0; } }")) { ret 1; }
     # a malformed chain still reports: the `$if` condition needs parentheses
     if (!t_parse_module_has_errors("$if 1 {}")) { ret 1; }
+    ret 0;
+}
+
+test "parser: a bare-form statement keyword used as an identifier parses as an expression (#1458)" {
+    # `cnt`/`brk` are continue/break only in their bare form (`cnt;`/`brk;`). the
+    # same word followed by `=` is an ordinary identifier: `cnt = g();` must parse
+    # as an assignment expression statement, not misparse as continue (which used
+    # to report the misleading "expected ';' after 'cnt'"). the bare forms in the
+    # same body must still parse as CNT/BRK keyword statements.
+    var alloc: Allocator;
+    page.make(?alloc);
+    val source: str = "fun g() i64 { ret 1; } fun f() i64 { var cnt: i64 = 0; for (true) { cnt = g(); brk; cnt; } ret cnt; }";
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize(source, ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+    parse_module(?p);
+
+    var rc: i32 = 0;
+    if (diag.has_errors(?diags)) { rc = 1; }
+
+    var n_cnt: usize = 0; var n_brk: usize = 0; var n_expr: usize = 0;
+    var i: usize = 0;
+    for (i < a.stmt_len) {
+        val k: stmt.StmtKind = a.stmts[i].kind;
+        if      (k == stmt.STMT_KIND_CNT)  { n_cnt  = n_cnt  + 1; }
+        or      (k == stmt.STMT_KIND_BRK)  { n_brk  = n_brk  + 1; }
+        or      (k == stmt.STMT_KIND_EXPR) { n_expr = n_expr + 1; }
+        i = i + 1;
+    }
+    # one bare `cnt;` and one `brk;` survive as keyword statements; `cnt = g();`
+    # is the lone expression statement (the assignment)
+    if (n_cnt  != 1) { rc = 1; }
+    if (n_brk  != 1) { rc = 1; }
+    if (n_expr != 1) { rc = 1; }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "stmt: a name colliding with a bare statement keyword assigns and runs; bare cnt/brk still control flow (#1458)" {
+    # used as an identifier, `cnt` behaves like any name — declared, assigned, and
+    # read — even while bare `cnt;`/`brk;` keep their keyword meaning in the same
+    # scope. exercises the disambiguation end to end through codegen.
+    var cnt: i32 = 0;
+    cnt = 5;
+    if (cnt != 5) { ret 1; }
+
+    var sum: i32 = 0;
+    var i: i32 = 0;
+    for (true) {
+        i = i + 1;
+        if (i > 10) { brk; }
+        if (i == 3) { cnt; }
+        sum = sum + i;
+    }
+    # 1+2+4+5+6+7+8+9+10 with 3 skipped via continue = 52
+    if (sum != 52) { ret 1; }
     ret 0;
 }

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -1255,24 +1255,3 @@ test "parser: a bare-form statement keyword used as an identifier parses as an e
     lexer.dnit(?stream, ?alloc);
     ret rc;
 }
-
-test "stmt: a name colliding with a bare statement keyword assigns and runs; bare cnt/brk still control flow (#1458)" {
-    # used as an identifier, `cnt` behaves like any name — declared, assigned, and
-    # read — even while bare `cnt;`/`brk;` keep their keyword meaning in the same
-    # scope. exercises the disambiguation end to end through codegen.
-    var cnt: i32 = 0;
-    cnt = 5;
-    if (cnt != 5) { ret 1; }
-
-    var sum: i32 = 0;
-    var i: i32 = 0;
-    for (true) {
-        i = i + 1;
-        if (i > 10) { brk; }
-        if (i == 3) { cnt; }
-        sum = sum + i;
-    }
-    # 1+2+4+5+6+7+8+9+10 with 3 skipped via continue = 52
-    if (sum != 52) { ret 1; }
-    ret 0;
-}


### PR DESCRIPTION
Closes #1458.

## Problem

`cnt`/`brk` are **contextual** keywords — the lexer emits every word as `KIND_IDENT` and the parser recognizes keywords by text in keyword positions. At statement start, `parse_stmt` dispatched `cnt`/`brk` purely on the keyword text, so a variable named `cnt` misparsed:

```mach
var cnt: usize = 0;
cnt = g();   // parsed as a `continue` statement → "expected ';' after 'cnt'"
ret cnt;     // fine
```

The diagnostic never mentioned a keyword/identifier collision, so it read like a stray-token error on a syntactically fine assignment.

## Why not "reserve the keywords" (issue Option 1)

A bind-time rejection would reject the declaration itself (`val cnt: usize`). The compiler's own source uses `cnt`/`fwd`/`def`/`rec`/`ext` as identifiers in ~18 core compiled sites (incl. the public field `TargetDef.ext`), so reservation would break the self-host build and the public API. These words are contextual *by design*; the fix preserves that.

## Fix (Path A — lookahead-disambiguate)

`cnt`/`brk` take no operand, so they're keywords only in their **bare** form — the keyword immediately followed by `;`. `parse_stmt` now dispatches them via `at_bare_kw_stmt`; any other follower (`=`, `.`, `(`, …) means the word is an ordinary identifier and the statement parses as an expression.

Result: `cnt = g();` is an assignment; bare `cnt;`/`brk;` keep their keyword meaning — the two even coexist in one scope (a variable named `cnt` plus `cnt;` for control flow). `ret`-style keywords that take an expression are unaffected (`ret cnt` was already unambiguous) and are left as-is.

## Tests (inline `test`, run by `mach test .`)

- **parser-level (AST shape):** the #1458 repro parses with no diagnostics; the body yields exactly one `CNT`, one `BRK`, and one `EXPR` (the assignment) — proving bare forms stay keywords and `cnt = g();` becomes an assignment.
- **runtime (end-to-end through codegen):** declares `var cnt`, assigns via `cnt = 5`, and runs a loop using bare `cnt;`/`brk;` for control flow — proving it compiles *and* runs correctly with the keyword and the identifier coexisting.

Docs: `grammar.md` and `statements.md` note the bare-form rule.

x86-frontend change only; no codegen impact. Verifying via CI.