### PR TITLE
chore(release): stage v1.6.0 — aarch64-linux debut

### DIFF
--- a/.github/tests/aarch64run/app/mach.toml
+++ b/.github/tests/aarch64run/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id      = "aarch64run"
+name    = "aarch64 f64 memory-load run smoke — App"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux-arm64"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[bin.aarch64run]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/aarch64run/app/src/main.mach
+++ b/.github/tests/aarch64run/app/src/main.mach
@@ -1,0 +1,42 @@
+# aarch64run — a runnable aarch64-linux smoke exercising the f64 memory-load paths
+# the #1459 register-class fix repairs: an f64 ARRAY-ELEMENT load and an f64
+# STRUCT-FIELD load, each feeding a floating-point op. on the pre-fix compiler the
+# loads used the general-purpose register path, so the FP op read a stale vector
+# register (garbage) and the result was wrong. main returns 0 only when both loads
+# read correctly (1 = array-element misread, 2 = struct-field misread), so qemu
+# running this to exit 0 proves the fix end-to-end through the real runtime.
+use std.runtime.linux.aarch64;
+
+# an f64 struct field; `b.val` is a memory-loaded f64 feeding an FP multiply.
+rec Box {
+    tag: u64;
+    val: f64;
+}
+
+fun scale(b: *Box, factor: f64) f64 {
+    ret b.val * factor;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # f64 array-element load feeding an FP add.
+    var tbl: [4]f64;
+    tbl[0] = 1.0;
+    tbl[1] = 10.0;
+    tbl[2] = 100.0;
+    tbl[3] = 1000.0;
+    var acc: f64 = 0.0;
+    var i: u64 = 0;
+    for (i < 4) {
+        acc = acc + tbl[i];
+        i = i + 1;
+    }
+    if (acc != 1111.0) { ret 1; }
+
+    # f64 struct-field load (through a pointer) feeding an FP multiply.
+    var b: Box;
+    b.val = 2.5;
+    if (scale(?b, 4.0) != 10.0) { ret 2; }
+
+    ret 0;
+}

--- a/.github/tests/aarch64run/run.sh
+++ b/.github/tests/aarch64run/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# aarch64 f64 memory-load run smoke (#1459): cross-builds a tiny aarch64-linux
+# program that loads f64s from an array element and a struct field — each feeding
+# an FP op — and runs it under qemu-aarch64. on the pre-fix compiler those loads
+# used the general-purpose register path, so the FP op read a stale vector
+# register and the result was garbage; main returns 0 only when both loads read
+# correctly (1 = array-element misread, 2 = struct-field misread).
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+# the test runs an aarch64 binary; without qemu-aarch64 there is nothing to run it.
+RUNNER="$(command -v qemu-aarch64 || command -v qemu-aarch64-static || true)"
+if [ -z "$RUNNER" ]; then
+    echo "SKIP aarch64run: 'qemu-aarch64' not available to run the aarch64 binary"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# build at -O0 so the loads are not optimized away — the f64 memory-load path
+# must actually be exercised.
+if ! ( cd "$WORK/app" && "$MACH" build . -O0 ) >/dev/null 2>&1; then
+    echo "FAIL aarch64run: aarch64 cross-build failed" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/linux-arm64/bin/aarch64run"
+test -f "$EXE" || { echo "error: aarch64 binary not produced at $EXE" >&2; exit 1; }
+
+set +e
+"$RUNNER" "$EXE" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS aarch64run: f64 array-element and struct-field loads read correctly under qemu"
+    exit 0
+fi
+
+echo "FAIL aarch64run: f64 memory-load miscompiled (exit $code: 1=array-element, 2=struct-field)" >&2
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download -R ${{ github.repository }} -p mach -D /usr/local/bin
+          set -euo pipefail
+          # the versioned linux tarball from the most recent release is the build seed
+          # (v1.6.0 drops the unversioned `mach` alias asset, matching the other lanes).
+          tmp="$(mktemp -d)"
+          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
+          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
 
       - name: Install the aarch64 byte-verification + emulation toolchain
@@ -181,9 +186,8 @@ jobs:
           # llvm-objdump/llvm-mc disassemble and cross-check the emitted aarch64
           # encodings; readelf (binutils) reads the ELF headers. qemu-user-static
           # registers the binfmt handler that runs aarch64 binaries on this x86
-          # host — needed only by the GATED run-steps below, harmless to install
-          # now (the byte-verification uses none of it). mirrors the integration
-          # lane's `apt-get install wine64`.
+          # host — used by the cross-compile + qemu run-steps below. mirrors the
+          # integration lane's `apt-get install wine64`.
           sudo apt-get install -y -qq llvm binutils qemu-user-static
 
       - name: Build the compiler
@@ -195,21 +199,20 @@ jobs:
       - name: Byte-verify the aarch64 emitter (no qemu)
         run: bash .github/tests/aarch64enc/run.sh "$GITHUB_WORKSPACE/out/linux/bin/mach"
 
-      # GATED: cross-compiling mach itself to aarch64 needs the mach-std aarch64
-      # std/runtime (OS layer + `_start`), not yet merged — until then the build
-      # fails at sema on the missing std symbols, so it cannot run in CI. flip the
-      # `if` to a real condition once that runtime lands. mirrors the integration
-      # lane's `mach build . --target windows`.
-      - name: Cross-compile mach to aarch64 (GATED — needs mach-std aarch64 runtime)
-        if: false
+      # cross-compile mach itself to aarch64. the mach-std aarch64 std/runtime (OS
+      # layer + `_start`) is vendored via the dep/mach-std submodule, so the build
+      # links cleanly. mirrors the integration lane's `mach build . --target windows`.
+      - name: Cross-compile mach to aarch64
         run: out/linux/bin/mach build . --target linux-arm64
 
-      # GATED: run the in-source test suite as aarch64 binaries under
-      # qemu-user-static. needs the runtime above (to link runnable test exes)
-      # AND qemu-aarch64 on PATH; flip the `if` once both are in place. the
-      # `command -v` guard keeps it a no-op even if enabled before the binfmt name
-      # is pinned. mirrors the windows native lane's `mach test .` under emulation.
-      - name: Test corpus under qemu-aarch64 (GATED — needs runtime + qemu)
+      # GATED (#1464): `mach test . --target linux-arm64` on the mach project — which
+      # has a `main` bin entry — fails at link with "multiple definition of 'main'"
+      # (the project main collides with the test-runner main on the aarch64 path;
+      # native x86 is unaffected). the cross-compile + byte-verify lanes above and
+      # the release qemu-smoke already exercise the aarch64 runtime end-to-end;
+      # un-gate once `mach test` cross-target handles the bin-entry main. mirrors the
+      # windows native lane's `mach test .` under emulation.
+      - name: Test corpus under qemu-aarch64 (GATED — see #1464)
         if: false
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ permissions:
   contents: write
 
 env:
-  # gate the aarch64 linux release asset; inert until the mach-std aarch64
-  # runtime + qemu self-host land and a runnable aarch64 mach can link.
-  RELEASE_AARCH64: "false"
+  # the aarch64-linux release asset (v1.6.0): the mach-std aarch64 runtime + the
+  # qemu self-host have landed, so a runnable aarch64 mach links and ships.
+  RELEASE_AARCH64: "true"
 
 jobs:
   build:
@@ -73,6 +73,28 @@ jobs:
           ( cd "$work/app" && WINEDEBUG=-all wine "$GITHUB_WORKSPACE/out/windows/bin/mach.exe" build . )
           WINEDEBUG=-all wine "$work/app/out/windows/bin/win64byref.exe"
 
+      - name: Cross-compile the aarch64 target
+        if: env.RELEASE_AARCH64 == 'true'
+        run: out/linux/bin/mach build . --target linux-arm64
+
+      - name: Smoke-test the aarch64 binary under qemu
+        if: env.RELEASE_AARCH64 == 'true'
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq qemu-user-static
+          # emitted-code smoke: the aarch64 integration app must build and run.
+          bash .github/tests/aarch64run/run.sh out/linux/bin/mach
+          # compiler smoke: the cross-built aarch64 mach itself must build a real
+          # project under qemu before it ships — a release artifact that cannot
+          # compile is not a release.
+          work="$(mktemp -d)"
+          cp -r .github/tests/aarch64run/app "$work/app"
+          mkdir -p "$work/app/dep"
+          cp -r dep/mach-std "$work/app/dep/mach-std"
+          ( cd "$work/app" && qemu-aarch64 "$GITHUB_WORKSPACE/out/linux-arm64/bin/mach" build . )
+          qemu-aarch64 "$work/app/out/linux-arm64/bin/aarch64run"
+
       - name: Package artifacts
         run: |
           set -euo pipefail
@@ -88,7 +110,7 @@ jobs:
           archives="mach-$ver-x86_64-linux.tar.gz mach-$ver-x86_64-windows.zip"
           if [ "$RELEASE_AARCH64" = "true" ]; then
             # gated aarch64 linux tarball, matching the x86_64 linux shape (`mach` + LICENSE).
-            out/linux/bin/mach build . --target linux-arm64
+            # the binary was cross-built and qemu-smoke-tested in the steps above.
             cp out/linux-arm64/bin/mach "$stage"
             tar -C "$stage" -czf "dist/mach-$ver-aarch64-linux.tar.gz" mach LICENSE
             rm "$stage/mach"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-06-14
+
+The aarch64-linux debut: mach now cross-compiles and self-hosts on 64-bit ARM
+linux (AAPCS64) alongside x86_64 linux and windows. The compiler itself makes no
+variadic calls, so the self-host fixpoint converges byte-identical on aarch64
+under qemu exactly as it does natively on x86_64.
+
+### Added
+
+- target/aarch64: a complete aarch64-linux back end (#1431). The A64 fixed-width
+  encoder emits 32-bit instruction words directly; instruction selection covers
+  the scalar integer and floating-point paths; integer division and remainder
+  lower to `sdiv`/`udiv` + `msub` with the defined divide-by-zero and
+  signed-overflow trap semantics; and variable (runtime-count) shifts lower to
+  the register-operand shift forms.
+- target/aarch64: the AAPCS64 calling convention — argument and result
+  classification across the general-purpose (x0–x7) and SIMD/FP (v0–v7) register
+  banks, the x8 indirect-result register for large/`sret` returns, and
+  natural-alignment of stack-passed arguments.
+- target/aarch64: calls, relocations, and frames — `bl` calls and the
+  `adrp`+`add`/`ldr` symbol-address idiom emitting the R_AARCH64_CALL26,
+  ADR_PREL_PG_HI21, ADD_ABS_LO12_NC, and LDST\*_ABS_LO12_NC relocation kinds,
+  with the leaf and non-leaf frame prologue/epilogue (`stp`/`ldp` of x29/x30).
+- target/aarch64: inline-asm mnemonic support for the A64 instruction set, so the
+  mach-std aarch64 runtime entry (`_start`) and OS layer assemble through the same
+  per-architecture asm path as the x86_64 runtime.
+- ci/release: the aarch64-linux release asset is enabled (`RELEASE_AARCH64`), with
+  a qemu-aarch64 smoke-test that proves the cross-built aarch64 `mach` can both
+  build and run a real project under emulation before it ships — mirroring the
+  windows/wine compiler smoke. CI's aarch64 lane cross-builds mach to aarch64 and
+  byte-verifies the emitted encodings; the runtime is exercised by that qemu smoke
+  and the aarch64 self-host fixpoint, with the in-source test corpus run under
+  qemu-user-static gated pending #1464.
+
+### Fixed
+
+- target/aarch64: f64 and f32 memory loads and stores selected the wrong register
+  class — addressing a general-purpose register where a SIMD/FP register was
+  required — so a float loaded from or stored to memory (a struct field, array
+  element, or pointer dereference) now uses the SIMD `ldr`/`str` forms (#1459).
+- parser: the bare statement keywords `cnt` / `brk` are disambiguated from
+  identifiers via lookahead — they are keywords only in the bare `cnt;` / `brk;`
+  statement form, so `cnt = expr;` now parses as an assignment instead of failing
+  with the misleading "expected ';' after 'cnt'" (#1458). This was a prerequisite
+  for aarch64: the aarch64 std runtime's inline asm uses the `brk` mnemonic
+  (`asm aarch64 { brk 0 }`), which the pre-fix parser mis-parsed as the keyword.
+
+### Known limitations
+
+- aarch64-linux v1.6.0 ships without variadic formatting (`printf`/`format`/
+  `vformat`): mach-std gates the variadic surface out of the aarch64 build, with
+  the redesign deferred to v1.6.x as a cross-platform varargs effort. The
+  compiler makes no variadic calls, so self-host is unaffected; only aarch64
+  programs that call the variadic formatting helpers are impacted.
+
 ## [1.5.5] - 2026-06-14
 
 Tooling-prep patch. Adds reload-friendly source handling so a long-lived session

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "1.5.5"
+version = "1.6.0"
 src = "src"
 dep = "dep"
 target = "native"


### PR DESCRIPTION
Stages the **v1.6.0** release (aarch64-linux debut). **Cut is held for octalide** — this only stages to dev; no main, no tag.

## Changes
- **mach.toml**: version 1.5.5 → 1.6.0 (mach-std dep pin stays `ref = "branch/main"`).
- **CHANGELOG.md**: `[1.6.0]` — aarch64-linux back end (#1431), the f64/f32 memory load/store register-class fix (#1459), and the variadic-formatting Known-limitation (deferred to v1.6.x).
- **release.yml**: `RELEASE_AARCH64="true"` + a qemu-aarch64 smoke that proves the cross-built aarch64 `mach` builds AND runs a real project under qemu before packaging (mirrors windows/wine); versioned-only artifacts.
- **ci.yml**: enable the aarch64 cross-compile lane (runtime now vendored); fix the seed fetch to the versioned tarball (v1.6.0 drops the unversioned `mach` alias asset). The qemu **test-corpus step stays gated (#1464)** — see below.
- **dep/mach-std**: submodule bumped c0f1d2c → **28955d9 (std DEV, runtime-bearing)** for staging validation. **⚠ Re-point to std MAIN at cut time** once std dev→main merges.
- **.github/tests/aarch64run**: a runnable f64 memory-load smoke (array-element + struct-field loads feeding FP ops) guarding the #1459 fix under qemu.

## Local validation (against this branch, std 28955d9)
- **x86_64 fixpoint**: byte-identical — `a==b==c`, sha `99faee73…`
- **aarch64 cross-build**: links cleanly against the runtime-bearing std (valid AArch64 ELF)
- **aarch64 self-host fixpoint under qemu**: byte-identical — `s1==s2==s3`, sha `f3e4f923…`
- **aarch64enc byte-verify**: green (all four R_AARCH64 reloc kinds)
- **aarch64run f64 smoke under qemu**: PASS (array-element + struct-field f64 loads correct)
- **mach test corpus under qemu**: ⚠ blocked by #1464 (`mach test . --target linux-arm64` dual-main link error for a project with a bin entry; x86 unaffected). The aarch64 runtime is otherwise validated by the items above + mach-std's 539/539 — so that one ci step is gated, not the lane.

Part of #1431