### PR TITLE
release: v1.6.0 — aarch64-linux debut

### DIFF
--- a/.github/tests/aarch64enc/app/mach.toml
+++ b/.github/tests/aarch64enc/app/mach.toml
@@ -1,0 +1,16 @@
+[project]
+id      = "aarch64enc"
+name    = "aarch64 encode/reloc byte-verification — App"
+version = "0.0.0"
+src     = "src"
+target  = "arm64"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[bin.aarch64enc]
+entry = "main.mach"

--- a/.github/tests/aarch64enc/app/src/main.mach
+++ b/.github/tests/aarch64enc/app/src/main.mach
@@ -1,0 +1,36 @@
+# aarch64enc — a self-contained aarch64-linux program whose emitted object and
+# linked executable are byte-verified by run.sh (no qemu, no runtime).
+#
+# the program carries its own `_start` so it links to an aarch64 executable
+# WITHOUT the mach-std aarch64 runtime (not yet merged): the byte-verification
+# only disassembles and reads ELF headers, it never runs the binary. it is
+# written to force every aarch64 relocation kind the back end emits:
+#   - a `bl` to a defined function            -> R_AARCH64_CALL26
+#   - a global load through ADRP + LDR        -> R_AARCH64_ADR_PREL_PG_HI21
+#                                                + R_AARCH64_LDST64_ABS_LO12_NC
+#   - taking a global's address via ADRP+ADD  -> R_AARCH64_ADD_ABS_LO12_NC
+# every function also emits the leaf prologue (`stp x29, x30, [sp, #-0x10]!`)
+# and `ret` epilogue run.sh asserts the mnemonic order of.
+
+# a global the program both reads/writes (LDST*_LO12) and takes the address of
+# (ADD_LO12), forcing the ADRP page-relative pair on every access.
+$counter.symbol = "counter";
+var counter: i64 = 0;
+
+# a defined callee — the `bl` to it emits R_AARCH64_CALL26.
+fun helper(x: i64) i64 {
+    ret x + 1;
+}
+
+# a defined callee taking a pointer — its argument is the address of `counter`,
+# materialized by the ADRP + ADD_LO12 pair.
+fun sink(p: *i64) i64 {
+    ret p[0];
+}
+
+# the ELF entry point; named `_start` so the link needs no external runtime.
+$_start.symbol = "_start";
+pub fun _start() i64 {
+    counter = helper(counter);
+    ret sink(?counter);
+}

--- a/.github/tests/aarch64enc/run.sh
+++ b/.github/tests/aarch64enc/run.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# aarch64enc integration test: byte-verify the aarch64-linux back end's emitted
+# object and linked executable WITHOUT a qemu or any runnable aarch64 binary.
+#
+# the aarch64 target is complete through Phase 4 (compiles + links + correct
+# scalar/FP/ABI) but the self-host fixpoint and a runtime to run binaries need
+# qemu-user-static and the mach-std aarch64 runtime, neither of which is in this
+# lane. this suite therefore proves the emitter statically: it cross-builds a
+# tiny self-contained program (its own `_start`, no mach-std dependency) and
+# inspects the bytes three ways:
+#   1. instruction encoding — `llvm-objdump -d` shows the leaf prologue
+#      (`stp x29, x30, [sp, #-0x10]!`), a body that calls (`bl`) and accesses a
+#      global (`adrp`), and the `ret` epilogue, in that order; and, when llvm-mc
+#      is present, the prologue/ret words are byte-identical to the assembler's.
+#   2. relocations — `llvm-objdump -r` shows the four aarch64 reloc kinds the
+#      back end emits: R_AARCH64_CALL26, R_AARCH64_ADR_PREL_PG_HI21,
+#      R_AARCH64_LDST*_ABS_LO12_NC and R_AARCH64_ADD_ABS_LO12_NC.
+#   3. object format — `readelf -h` shows Machine = AArch64 on both the object
+#      and the linked EXEC, proving the reused (x86-shared) ELF writer stamps
+#      EM_AARCH64 and the linker patches the aarch64 relocs into a real ELF exe.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# the byte-verification needs an aarch64 disassembler and an ELF header reader;
+# skip cleanly (not fail) when the host lacks them, matching the other suites.
+if ! command -v llvm-objdump >/dev/null 2>&1; then
+    echo "SKIP aarch64enc: 'llvm-objdump' not available for the byte-verification"
+    exit 0
+fi
+if ! command -v readelf >/dev/null 2>&1; then
+    echo "SKIP aarch64enc: 'readelf' not available for the ELF-header check"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cp -r "$HERE/app" "$WORK/app"
+APP="$WORK/app"
+
+fail=0
+
+# cross-compile to a relocatable object (stops before the link) and to a linked
+# aarch64 executable (the own-`_start` makes the link runtime-free).
+if ! ( cd "$APP" && "$MACH" build . --target arm64 --emit obj ) >"$WORK/obj.out" 2>&1; then
+    echo "FAIL aarch64enc: cross-compile to object failed" >&2
+    cat "$WORK/obj.out" >&2
+    exit 1
+fi
+if ! ( cd "$APP" && "$MACH" build . --target arm64 ) >"$WORK/exe.out" 2>&1; then
+    echo "FAIL aarch64enc: cross-link to executable failed" >&2
+    cat "$WORK/exe.out" >&2
+    exit 1
+fi
+
+OBJ="$(find "$APP/out" -name '*.o' -type f | head -1)"
+EXE="$(find "$APP/out" -path '*/bin/*' -type f | head -1)"
+test -n "$OBJ" || { echo "FAIL aarch64enc: no object produced" >&2; exit 1; }
+test -n "$EXE" || { echo "FAIL aarch64enc: no executable produced" >&2; exit 1; }
+
+# 3. object format: the reused ELF writer must stamp Machine = AArch64 on the
+# object, and the linker must produce a real AArch64 EXEC.
+if readelf -h "$OBJ" | grep -qi 'Machine:.*AArch64'; then
+    echo "PASS aarch64enc: object ELF header is Machine = AArch64"
+else
+    echo "FAIL aarch64enc: object is not an AArch64 ELF" >&2
+    readelf -h "$OBJ" >&2
+    fail=1
+fi
+if readelf -h "$EXE" | grep -qi 'Machine:.*AArch64' && readelf -h "$EXE" | grep -qi 'Type:.*EXEC'; then
+    echo "PASS aarch64enc: linked binary is an AArch64 EXEC ELF"
+else
+    echo "FAIL aarch64enc: linked binary is not an AArch64 EXEC" >&2
+    readelf -h "$EXE" >&2
+    fail=1
+fi
+
+# 1. instruction encoding: the ordered mnemonic stream of the object's .text.
+mnem="$(llvm-objdump -d --no-show-raw-insn "$OBJ" | grep -E '^[[:space:]]+[0-9a-f]+:' | awk '{print $2}')"
+first="$(printf '%s\n' "$mnem" | head -1)"
+last="$(printf '%s\n' "$mnem" | tail -1)"
+
+# the first instruction is the leaf prologue store-pair; the last is the return.
+if [ "$first" = "stp" ]; then
+    echo "PASS aarch64enc: first instruction is the prologue 'stp'"
+else
+    echo "FAIL aarch64enc: expected leading 'stp' prologue, got '$first'" >&2
+    fail=1
+fi
+if [ "$last" = "ret" ]; then
+    echo "PASS aarch64enc: last instruction is the 'ret' epilogue"
+else
+    echo "FAIL aarch64enc: expected trailing 'ret' epilogue, got '$last'" >&2
+    fail=1
+fi
+# the body between prologue and epilogue must contain a call and a global access.
+for want in bl adrp; do
+    if printf '%s\n' "$mnem" | grep -qx "$want"; then
+        echo "PASS aarch64enc: body emits '$want'"
+    else
+        echo "FAIL aarch64enc: body missing '$want'" >&2
+        fail=1
+    fi
+done
+# prologue must precede the first epilogue (stp before the first ret).
+stp_line="$(printf '%s\n' "$mnem" | grep -nx stp | head -1 | cut -d: -f1)"
+ret_line="$(printf '%s\n' "$mnem" | grep -nx ret | head -1 | cut -d: -f1)"
+if [ -n "$stp_line" ] && [ -n "$ret_line" ] && [ "$stp_line" -lt "$ret_line" ]; then
+    echo "PASS aarch64enc: prologue precedes epilogue (stp before ret)"
+else
+    echo "FAIL aarch64enc: prologue/epilogue order wrong (stp@$stp_line ret@$ret_line)" >&2
+    fail=1
+fi
+
+# 1b. byte-identity cross-check against the reference assembler, when present:
+# the mach-encoded prologue/ret words must equal llvm-mc's encoding of the same
+# mnemonics. mc_word assembles one single-word instruction and returns its
+# 32-bit encoding as the big-endian hex word llvm-objdump prints.
+if command -v llvm-mc >/dev/null 2>&1; then
+    mc_word() {
+        printf '%s\n' "$1" | llvm-mc -triple=aarch64 --show-encoding 2>/dev/null \
+            | sed -n 's/.*encoding: \[\(.*\)\].*/\1/p' | tr -d ' ' \
+            | awk -F, '{ for (i = NF; i >= 1; i--) { b = $i; sub(/0x/, "", b); printf "%s", b } printf "\n" }'
+    }
+    words="$(llvm-objdump -d "$OBJ" | grep -oiE '^[[:space:]]+[0-9a-f]+:[[:space:]]+[0-9a-f]{8}' | awk '{print tolower($2)}')"
+    check_word() {
+        local w; w="$(mc_word "$1")"
+        if [ -n "$w" ] && printf '%s\n' "$words" | grep -qx "$w"; then
+            echo "PASS aarch64enc: '$1' encodes to 0x$w, byte-identical to llvm-mc"
+        else
+            echo "FAIL aarch64enc: '$1' word 0x$w not found in the object (encoder vs llvm-mc)" >&2
+            fail=1
+        fi
+    }
+    check_word 'stp x29, x30, [sp, #-16]!'
+    check_word 'ret'
+else
+    echo "INFO aarch64enc: 'llvm-mc' not available; skipping the assembler byte-identity cross-check"
+fi
+
+# 2. relocations: the object must carry each aarch64 reloc kind the back end
+# emits. LDST*_ABS_LO12_NC matches any access width (the suite forces a 64-bit
+# global, so LDST64; the suffix is left open so a width change can't silently
+# break the assertion).
+relocs="$(llvm-objdump -r "$OBJ")"
+assert_reloc() {
+    if printf '%s\n' "$relocs" | grep -qE "$1"; then
+        echo "PASS aarch64enc: relocation $2 present"
+    else
+        echo "FAIL aarch64enc: relocation $2 missing" >&2
+        fail=1
+    fi
+}
+assert_reloc 'R_AARCH64_CALL26'                  'R_AARCH64_CALL26 (call)'
+assert_reloc 'R_AARCH64_ADR_PREL_PG_HI21'        'R_AARCH64_ADR_PREL_PG_HI21 (ADRP page)'
+assert_reloc 'R_AARCH64_LDST[0-9]+_ABS_LO12_NC'  'R_AARCH64_LDST*_ABS_LO12_NC (folded load/store)'
+assert_reloc 'R_AARCH64_ADD_ABS_LO12_NC'         'R_AARCH64_ADD_ABS_LO12_NC (address-of low-12)'
+
+exit "$fail"

--- a/.github/tests/aarch64run/app/mach.toml
+++ b/.github/tests/aarch64run/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id      = "aarch64run"
+name    = "aarch64 f64 memory-load run smoke — App"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux-arm64"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[bin.aarch64run]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/aarch64run/app/src/main.mach
+++ b/.github/tests/aarch64run/app/src/main.mach
@@ -1,0 +1,42 @@
+# aarch64run — a runnable aarch64-linux smoke exercising the f64 memory-load paths
+# the #1459 register-class fix repairs: an f64 ARRAY-ELEMENT load and an f64
+# STRUCT-FIELD load, each feeding a floating-point op. on the pre-fix compiler the
+# loads used the general-purpose register path, so the FP op read a stale vector
+# register (garbage) and the result was wrong. main returns 0 only when both loads
+# read correctly (1 = array-element misread, 2 = struct-field misread), so qemu
+# running this to exit 0 proves the fix end-to-end through the real runtime.
+use std.runtime.linux.aarch64;
+
+# an f64 struct field; `b.val` is a memory-loaded f64 feeding an FP multiply.
+rec Box {
+    tag: u64;
+    val: f64;
+}
+
+fun scale(b: *Box, factor: f64) f64 {
+    ret b.val * factor;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # f64 array-element load feeding an FP add.
+    var tbl: [4]f64;
+    tbl[0] = 1.0;
+    tbl[1] = 10.0;
+    tbl[2] = 100.0;
+    tbl[3] = 1000.0;
+    var acc: f64 = 0.0;
+    var i: u64 = 0;
+    for (i < 4) {
+        acc = acc + tbl[i];
+        i = i + 1;
+    }
+    if (acc != 1111.0) { ret 1; }
+
+    # f64 struct-field load (through a pointer) feeding an FP multiply.
+    var b: Box;
+    b.val = 2.5;
+    if (scale(?b, 4.0) != 10.0) { ret 2; }
+
+    ret 0;
+}

--- a/.github/tests/aarch64run/run.sh
+++ b/.github/tests/aarch64run/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# aarch64 f64 memory-load run smoke (#1459): cross-builds a tiny aarch64-linux
+# program that loads f64s from an array element and a struct field — each feeding
+# an FP op — and runs it under qemu-aarch64. on the pre-fix compiler those loads
+# used the general-purpose register path, so the FP op read a stale vector
+# register and the result was garbage; main returns 0 only when both loads read
+# correctly (1 = array-element misread, 2 = struct-field misread).
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+# the test runs an aarch64 binary; without qemu-aarch64 there is nothing to run it.
+RUNNER="$(command -v qemu-aarch64 || command -v qemu-aarch64-static || true)"
+if [ -z "$RUNNER" ]; then
+    echo "SKIP aarch64run: 'qemu-aarch64' not available to run the aarch64 binary"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# build at -O0 so the loads are not optimized away — the f64 memory-load path
+# must actually be exercised.
+if ! ( cd "$WORK/app" && "$MACH" build . -O0 ) >/dev/null 2>&1; then
+    echo "FAIL aarch64run: aarch64 cross-build failed" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/linux-arm64/bin/aarch64run"
+test -f "$EXE" || { echo "error: aarch64 binary not produced at $EXE" >&2; exit 1; }
+
+set +e
+"$RUNNER" "$EXE" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS aarch64run: f64 array-element and struct-field loads read correctly under qemu"
+    exit 0
+fi
+
+echo "FAIL aarch64run: f64 memory-load miscompiled (exit $code: 1=array-element, 2=struct-field)" >&2
+exit 1

--- a/.github/tests/kwident/prog/mach.toml
+++ b/.github/tests/kwident/prog/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "kwidentprog"
+name = "Contextual keyword used as identifier (#1458)"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.kwidentprog]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/kwident/prog/src/main.mach
+++ b/.github/tests/kwident/prog/src/main.mach
@@ -1,0 +1,38 @@
+use std.runtime;
+use std.types.size.usize;
+
+fun g() usize { ret 1; }
+
+# the #1458 repro: `cnt` (the continue keyword) used as a variable. binding
+# (`var cnt`) and r-value (`ret cnt`) positions always worked; the assignment
+# `cnt = g();` used to misparse as a continue statement and fail the build with
+# "expected ';' after 'cnt'". all three positions must now agree.
+fun repro() usize {
+    var cnt: usize = 0;
+    cnt = g();
+    ret cnt;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    if (repro() != 1) { ret 1; }
+
+    # a variable named `cnt` and bare `cnt;`/`brk;` coexist in one scope: the
+    # bare forms drive control flow while the name reads and assigns normally.
+    var cnt: i32 = 0;
+    cnt = 5;
+    if (cnt != 5) { ret 2; }
+
+    var sum: i32 = 0;
+    var i: i32 = 0;
+    for (true) {
+        i = i + 1;
+        if (i > 10) { brk; }
+        if (i == 3) { cnt; }
+        sum = sum + i;
+    }
+    # 1+2+4+5+6+7+8+9+10 with 3 skipped via continue = 52
+    if (sum != 52) { ret 3; }
+
+    ret 0;
+}

--- a/.github/tests/kwident/prog/src/main.mach
+++ b/.github/tests/kwident/prog/src/main.mach
@@ -1,4 +1,5 @@
 use std.runtime;
+use std.types.bool.true;
 use std.types.size.usize;
 
 fun g() usize { ret 1; }

--- a/.github/tests/kwident/run.sh
+++ b/.github/tests/kwident/run.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Contextual statement keywords used as identifiers (#1458). `cnt`/`brk` are the
+# continue/break keywords only in their bare `cnt;`/`brk;` form; the same word
+# used as a name (`var cnt`, `cnt = g()`, `ret cnt`) must compile and run as an
+# ordinary identifier. before the fix `cnt = g();` misparsed as a continue
+# statement and the build failed with "expected ';' after 'cnt'". the app exits
+# 0 only when every position agrees and bare cnt/brk still drive control flow.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# vendor <app-dir>: copy the app into the temp dir and symlink the vendored std.
+vendor() {
+    local app="$1"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+}
+
+# build_and_run <app-dir> <expected-exit>: build the app, run the binary, and
+# require the build to succeed and the run to exit with the expected code.
+build_and_run() {
+    local app="$1"; local want="$2"
+    vendor "$app"
+    local dst="$WORK/$app"
+    if ! ( cd "$dst" && "$MACH" build . ) >/dev/null 2>&1; then
+        echo "FAIL kwident/$app: build failed" >&2; fail=1; return
+    fi
+    local bin
+    bin="$(find "$dst/out" -type f -path '*/bin/*' | head -n1)"
+    if [ -z "$bin" ]; then
+        echo "FAIL kwident/$app: no binary produced" >&2; fail=1; return
+    fi
+    set +e
+    "$bin"; local code=$?
+    set -e
+    if [ "$code" -ne "$want" ]; then
+        echo "FAIL kwident/$app: ran with exit $code, expected $want" >&2; fail=1; return
+    fi
+    echo "PASS kwident/$app: cnt/brk used as identifiers compile and run; bare cnt;/brk; still control flow"
+}
+
+build_and_run prog 0
+
+exit "$fail"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download -R ${{ github.repository }} -p mach -D /usr/local/bin
+          set -euo pipefail
+          # the versioned linux tarball from the most recent release is the build seed.
+          tmp="$(mktemp -d)"
+          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
+          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
 
       - name: Build the compiler
@@ -43,7 +47,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download -R ${{ github.repository }} -p mach -D /usr/local/bin
+          set -euo pipefail
+          # the versioned linux tarball from the most recent release is the build seed.
+          tmp="$(mktemp -d)"
+          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
+          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
 
       - name: Test corpus
@@ -61,7 +69,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download -R ${{ github.repository }} -p mach -D /usr/local/bin
+          set -euo pipefail
+          # the versioned linux tarball from the most recent release is the build seed.
+          tmp="$(mktemp -d)"
+          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
+          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
 
       - name: Install wine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,3 +138,72 @@ jobs:
         run: |
           out/windows/bin/mach.exe test .
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  # aarch64 cross lane: the aarch64-linux back end is complete through Phase 4
+  # (compiles + links + correct scalar/FP/ABI). this lane byte-verifies the
+  # emitter statically — `mach build . --target arm64 --emit obj`/`exe` on a tiny
+  # self-contained program, then llvm-objdump/llvm-mc/readelf assert the encoded
+  # instructions, the R_AARCH64_* relocs, and the AArch64 ELF headers — with NO
+  # qemu and no runnable aarch64 mach. it mirrors the windows lane's wine shape:
+  # qemu-aarch64 is to aarch64 binaries what wine is to windows binaries, and the
+  # two run-steps that need it are GATED off until qemu-user-static AND the
+  # mach-std aarch64 runtime (OS layer + `_start`) land in Phase 5.
+  aarch64:
+    name: AArch64 (cross)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Fetch released mach (build seed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download -R ${{ github.repository }} -p mach -D /usr/local/bin
+          chmod +x /usr/local/bin/mach
+
+      - name: Install the aarch64 byte-verification + emulation toolchain
+        run: |
+          sudo apt-get update -qq
+          # llvm-objdump/llvm-mc disassemble and cross-check the emitted aarch64
+          # encodings; readelf (binutils) reads the ELF headers. qemu-user-static
+          # registers the binfmt handler that runs aarch64 binaries on this x86
+          # host — needed only by the GATED run-steps below, harmless to install
+          # now (the byte-verification uses none of it). mirrors the integration
+          # lane's `apt-get install wine64`.
+          sudo apt-get install -y -qq llvm binutils qemu-user-static
+
+      - name: Build the compiler
+        run: |
+          set -euo pipefail
+          mach build .
+          test -x out/linux/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
+
+      - name: Byte-verify the aarch64 emitter (no qemu)
+        run: bash .github/tests/aarch64enc/run.sh "$GITHUB_WORKSPACE/out/linux/bin/mach"
+
+      # GATED: cross-compiling mach itself to aarch64 needs the mach-std aarch64
+      # std/runtime (OS layer + `_start`), not yet merged — until then the build
+      # fails at sema on the missing std symbols, so it cannot run in CI. flip the
+      # `if` to a real condition once that runtime lands. mirrors the integration
+      # lane's `mach build . --target windows`.
+      - name: Cross-compile mach to aarch64 (GATED — needs mach-std aarch64 runtime)
+        if: false
+        run: out/linux/bin/mach build . --target linux-arm64
+
+      # GATED: run the in-source test suite as aarch64 binaries under
+      # qemu-user-static. needs the runtime above (to link runnable test exes)
+      # AND qemu-aarch64 on PATH; flip the `if` once both are in place. the
+      # `command -v` guard keeps it a no-op even if enabled before the binfmt name
+      # is pinned. mirrors the windows native lane's `mach test .` under emulation.
+      - name: Test corpus under qemu-aarch64 (GATED — needs runtime + qemu)
+        if: false
+        run: |
+          set -euo pipefail
+          runner="$(command -v qemu-aarch64 || command -v qemu-aarch64-static || true)"
+          if [ -z "$runner" ]; then
+            echo "::notice::qemu-aarch64 not found; skipping the aarch64 run"
+            exit 0
+          fi
+          out/linux/bin/mach test . --target linux-arm64 --runner "$(basename "$runner")"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download -R ${{ github.repository }} -p mach -D /usr/local/bin
+          set -euo pipefail
+          # the versioned linux tarball from the most recent release is the build seed
+          # (v1.6.0 drops the unversioned `mach` alias asset, matching the other lanes).
+          tmp="$(mktemp -d)"
+          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
+          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
 
       - name: Install the aarch64 byte-verification + emulation toolchain
@@ -181,9 +186,8 @@ jobs:
           # llvm-objdump/llvm-mc disassemble and cross-check the emitted aarch64
           # encodings; readelf (binutils) reads the ELF headers. qemu-user-static
           # registers the binfmt handler that runs aarch64 binaries on this x86
-          # host — needed only by the GATED run-steps below, harmless to install
-          # now (the byte-verification uses none of it). mirrors the integration
-          # lane's `apt-get install wine64`.
+          # host — used by the cross-compile + qemu run-steps below. mirrors the
+          # integration lane's `apt-get install wine64`.
           sudo apt-get install -y -qq llvm binutils qemu-user-static
 
       - name: Build the compiler
@@ -195,21 +199,20 @@ jobs:
       - name: Byte-verify the aarch64 emitter (no qemu)
         run: bash .github/tests/aarch64enc/run.sh "$GITHUB_WORKSPACE/out/linux/bin/mach"
 
-      # GATED: cross-compiling mach itself to aarch64 needs the mach-std aarch64
-      # std/runtime (OS layer + `_start`), not yet merged — until then the build
-      # fails at sema on the missing std symbols, so it cannot run in CI. flip the
-      # `if` to a real condition once that runtime lands. mirrors the integration
-      # lane's `mach build . --target windows`.
-      - name: Cross-compile mach to aarch64 (GATED — needs mach-std aarch64 runtime)
-        if: false
+      # cross-compile mach itself to aarch64. the mach-std aarch64 std/runtime (OS
+      # layer + `_start`) is vendored via the dep/mach-std submodule, so the build
+      # links cleanly. mirrors the integration lane's `mach build . --target windows`.
+      - name: Cross-compile mach to aarch64
         run: out/linux/bin/mach build . --target linux-arm64
 
-      # GATED: run the in-source test suite as aarch64 binaries under
-      # qemu-user-static. needs the runtime above (to link runnable test exes)
-      # AND qemu-aarch64 on PATH; flip the `if` once both are in place. the
-      # `command -v` guard keeps it a no-op even if enabled before the binfmt name
-      # is pinned. mirrors the windows native lane's `mach test .` under emulation.
-      - name: Test corpus under qemu-aarch64 (GATED — needs runtime + qemu)
+      # GATED (#1464): `mach test . --target linux-arm64` on the mach project — which
+      # has a `main` bin entry — fails at link with "multiple definition of 'main'"
+      # (the project main collides with the test-runner main on the aarch64 path;
+      # native x86 is unaffected). the cross-compile + byte-verify lanes above and
+      # the release qemu-smoke already exercise the aarch64 runtime end-to-end;
+      # un-gate once `mach test` cross-target handles the bin-entry main. mirrors the
+      # windows native lane's `mach test .` under emulation.
+      - name: Test corpus under qemu-aarch64 (GATED — see #1464)
         if: false
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: write
 
+env:
+  # gate the aarch64 linux release asset; inert until the mach-std aarch64
+  # runtime + qemu self-host land and a runnable aarch64 mach can link.
+  RELEASE_AARCH64: "false"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,7 +33,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download -R ${{ github.repository }} -p mach -D /usr/local/bin
+          set -euo pipefail
+          # the versioned linux tarball from the most recent release is the bootstrap seed.
+          tmp="$(mktemp -d)"
+          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
+          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
 
       - name: Build to the fixpoint
@@ -69,33 +78,30 @@ jobs:
           set -euo pipefail
           ver="${GITHUB_REF_NAME#v}"
           mkdir -p dist
-          # `mach` is the bootstrap-seed alias (ci.yml / release.yml fetch `-p mach`
-          # from the most recent release); the bare per-target names are the legacy
-          # public assets, kept until consumers move to the versioned archives (#1352).
-          cp out/linux/bin/mach dist/mach
-          cp out/linux/bin/mach dist/mach-x86_64-linux
-          ( cd out/windows/bin && zip -q "$GITHUB_WORKSPACE/dist/mach-x86_64-windows.zip" mach.exe )
-          # versioned archives: the standard format install.sh / install.ps1 consume.
+          # the standard versioned archives install.sh / install.ps1 consume.
           stage="$(mktemp -d)"
           cp out/linux/bin/mach LICENSE "$stage"
           tar -C "$stage" -czf "dist/mach-$ver-x86_64-linux.tar.gz" mach LICENSE
           rm "$stage/mach"
           cp out/windows/bin/mach.exe "$stage"
           ( cd "$stage" && zip -q "$GITHUB_WORKSPACE/dist/mach-$ver-x86_64-windows.zip" mach.exe LICENSE )
-          cp install.sh install.ps1 dist/
-          ( cd dist && sha256sum mach-x86_64-linux mach-x86_64-windows.zip \
-              "mach-$ver-x86_64-linux.tar.gz" "mach-$ver-x86_64-windows.zip" \
-              install.sh install.ps1 > SHA256SUMS )
+          archives="mach-$ver-x86_64-linux.tar.gz mach-$ver-x86_64-windows.zip"
+          if [ "$RELEASE_AARCH64" = "true" ]; then
+            # gated aarch64 linux tarball, matching the x86_64 linux shape (`mach` + LICENSE).
+            out/linux/bin/mach build . --target linux-arm64
+            cp out/linux-arm64/bin/mach "$stage"
+            tar -C "$stage" -czf "dist/mach-$ver-aarch64-linux.tar.gz" mach LICENSE
+            rm "$stage/mach"
+            archives="$archives mach-$ver-aarch64-linux.tar.gz"
+          fi
+          # SHA256SUMS covers exactly the published archives.
+          ( cd dist && sha256sum $archives > SHA256SUMS )
 
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v3
         with:
           files: |
-            dist/mach
-            dist/mach-x86_64-linux
-            dist/mach-x86_64-windows.zip
             dist/mach-*-x86_64-linux.tar.gz
             dist/mach-*-x86_64-windows.zip
+            dist/mach-*-aarch64-linux.tar.gz
             dist/SHA256SUMS
-            dist/install.sh
-            dist/install.ps1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ permissions:
   contents: write
 
 env:
-  # gate the aarch64 linux release asset; inert until the mach-std aarch64
-  # runtime + qemu self-host land and a runnable aarch64 mach can link.
-  RELEASE_AARCH64: "false"
+  # the aarch64-linux release asset (v1.6.0): the mach-std aarch64 runtime + the
+  # qemu self-host have landed, so a runnable aarch64 mach links and ships.
+  RELEASE_AARCH64: "true"
 
 jobs:
   build:
@@ -73,6 +73,28 @@ jobs:
           ( cd "$work/app" && WINEDEBUG=-all wine "$GITHUB_WORKSPACE/out/windows/bin/mach.exe" build . )
           WINEDEBUG=-all wine "$work/app/out/windows/bin/win64byref.exe"
 
+      - name: Cross-compile the aarch64 target
+        if: env.RELEASE_AARCH64 == 'true'
+        run: out/linux/bin/mach build . --target linux-arm64
+
+      - name: Smoke-test the aarch64 binary under qemu
+        if: env.RELEASE_AARCH64 == 'true'
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq qemu-user-static
+          # emitted-code smoke: the aarch64 integration app must build and run.
+          bash .github/tests/aarch64run/run.sh out/linux/bin/mach
+          # compiler smoke: the cross-built aarch64 mach itself must build a real
+          # project under qemu before it ships — a release artifact that cannot
+          # compile is not a release.
+          work="$(mktemp -d)"
+          cp -r .github/tests/aarch64run/app "$work/app"
+          mkdir -p "$work/app/dep"
+          cp -r dep/mach-std "$work/app/dep/mach-std"
+          ( cd "$work/app" && qemu-aarch64 "$GITHUB_WORKSPACE/out/linux-arm64/bin/mach" build . )
+          qemu-aarch64 "$work/app/out/linux-arm64/bin/aarch64run"
+
       - name: Package artifacts
         run: |
           set -euo pipefail
@@ -88,7 +110,7 @@ jobs:
           archives="mach-$ver-x86_64-linux.tar.gz mach-$ver-x86_64-windows.zip"
           if [ "$RELEASE_AARCH64" = "true" ]; then
             # gated aarch64 linux tarball, matching the x86_64 linux shape (`mach` + LICENSE).
-            out/linux/bin/mach build . --target linux-arm64
+            # the binary was cross-built and qemu-smoke-tested in the steps above.
             cp out/linux-arm64/bin/mach "$stage"
             tar -C "$stage" -czf "dist/mach-$ver-aarch64-linux.tar.gz" mach LICENSE
             rm "$stage/mach"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-06-14
+
+The aarch64-linux debut: mach now cross-compiles and self-hosts on 64-bit ARM
+linux (AAPCS64) alongside x86_64 linux and windows. The compiler itself makes no
+variadic calls, so the self-host fixpoint converges byte-identical on aarch64
+under qemu exactly as it does natively on x86_64.
+
+### Added
+
+- target/aarch64: a complete aarch64-linux back end (#1431). The A64 fixed-width
+  encoder emits 32-bit instruction words directly; instruction selection covers
+  the scalar integer and floating-point paths; integer division and remainder
+  lower to `sdiv`/`udiv` + `msub` with the defined divide-by-zero and
+  signed-overflow trap semantics; and variable (runtime-count) shifts lower to
+  the register-operand shift forms.
+- target/aarch64: the AAPCS64 calling convention — argument and result
+  classification across the general-purpose (x0–x7) and SIMD/FP (v0–v7) register
+  banks, the x8 indirect-result register for large/`sret` returns, and
+  natural-alignment of stack-passed arguments.
+- target/aarch64: calls, relocations, and frames — `bl` calls and the
+  `adrp`+`add`/`ldr` symbol-address idiom emitting the R_AARCH64_CALL26,
+  ADR_PREL_PG_HI21, ADD_ABS_LO12_NC, and LDST\*_ABS_LO12_NC relocation kinds,
+  with the leaf and non-leaf frame prologue/epilogue (`stp`/`ldp` of x29/x30).
+- target/aarch64: inline-asm mnemonic support for the A64 instruction set, so the
+  mach-std aarch64 runtime entry (`_start`) and OS layer assemble through the same
+  per-architecture asm path as the x86_64 runtime.
+- ci/release: the aarch64-linux release asset is enabled (`RELEASE_AARCH64`), with
+  a qemu-aarch64 smoke-test that proves the cross-built aarch64 `mach` can both
+  build and run a real project under emulation before it ships — mirroring the
+  windows/wine compiler smoke. CI's aarch64 lane cross-builds mach to aarch64 and
+  byte-verifies the emitted encodings; the runtime is exercised by that qemu smoke
+  and the aarch64 self-host fixpoint, with the in-source test corpus run under
+  qemu-user-static gated pending #1464.
+
+### Fixed
+
+- target/aarch64: f64 and f32 memory loads and stores selected the wrong register
+  class — addressing a general-purpose register where a SIMD/FP register was
+  required — so a float loaded from or stored to memory (a struct field, array
+  element, or pointer dereference) now uses the SIMD `ldr`/`str` forms (#1459).
+- parser: the bare statement keywords `cnt` / `brk` are disambiguated from
+  identifiers via lookahead — they are keywords only in the bare `cnt;` / `brk;`
+  statement form, so `cnt = expr;` now parses as an assignment instead of failing
+  with the misleading "expected ';' after 'cnt'" (#1458). This was a prerequisite
+  for aarch64: the aarch64 std runtime's inline asm uses the `brk` mnemonic
+  (`asm aarch64 { brk 0 }`), which the pre-fix parser mis-parsed as the keyword.
+
+### Known limitations
+
+- aarch64-linux v1.6.0 ships without variadic formatting (`printf`/`format`/
+  `vformat`): mach-std gates the variadic surface out of the aarch64 build, with
+  the redesign deferred to v1.6.x as a cross-platform varargs effort. The
+  compiler makes no variadic calls, so self-host is unaffected; only aarch64
+  programs that call the variadic formatting helpers are impacted.
+
 ## [1.5.5] - 2026-06-14
 
 Tooling-prep patch. Adds reload-friendly source handling so a long-lived session

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Read the [language reference](doc/language/README.md) before installing. The doc
 Install the latest release with one line:
 
 ```bash
-curl -fsSL https://github.com/octalide/mach/releases/latest/download/install.sh | sh
+curl -fsSL https://machlang.org/install.sh | sh
 ```
 
 On Windows (PowerShell):
 
 ```powershell
-irm https://github.com/octalide/mach/releases/latest/download/install.ps1 | iex
+irm https://machlang.org/install.ps1 | iex
 ```
 
 The scripts verify the download against the release `SHA256SUMS` and install to

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -95,7 +95,10 @@ nil  or   pub  rec  ret  test uni  use  val  var
 `nil` is an expression literal; the rest are statement/declaration/type
 introducers. Note these are *contextual*: nothing in the lexer prevents a
 binding or field from being named after one, but the parser will treat the
-keyword in its keyword position. The primitive type names (`u8`, `u16`,
+keyword in its keyword position. The operand-less statement keywords `brk`
+and `cnt` are keywords only in their bare form (`brk;` / `cnt;`); the same
+word followed by anything else is an ordinary identifier, so `cnt = x;` is an
+assignment to a variable named `cnt`. The primitive type names (`u8`, `u16`,
 `u32`, `u64`, `i8`, `i16`, `i32`, `i64`, `f32`, `f64`, `ptr`) are *not*
 keywords — they are ordinary identifiers resolved by name later.
 

--- a/doc/language/statements.md
+++ b/doc/language/statements.md
@@ -51,6 +51,11 @@ for (i < 10) {
 }
 ```
 
+Both are operand-less, so they are keywords only in their bare `brk;` / `cnt;`
+form. The same word followed by anything else is an ordinary identifier — a
+variable named `cnt` reads and assigns normally (`cnt = x;`), even inside a
+loop that also uses bare `cnt;` for control flow.
+
 ## `fin` — deferred statement
 
 `fin` schedules a statement (or block) to execute when the enclosing scope

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,5 @@
 # installs the mach release binary.
-# usage: irm https://github.com/octalide/mach/releases/latest/download/install.ps1 | iex
+# usage: irm https://machlang.org/install.ps1 | iex
 #
 # MACH_VERSION      version to install (e.g. 1.4.2); defaults to the latest release
 # MACH_INSTALL_DIR  install directory; defaults to $env:LOCALAPPDATA\mach\bin

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # installs the mach release binary.
-# usage: curl -fsSL https://github.com/octalide/mach/releases/latest/download/install.sh | sh
+# usage: curl -fsSL https://machlang.org/install.sh | sh
 #
 # MACH_VERSION      version to install (e.g. 1.4.2); defaults to the latest release
 # MACH_INSTALL_DIR  install directory; defaults to ~/.local/bin

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ command -v sha256sum >/dev/null || err "sha256sum is required"
 
 case "$(uname -s)-$(uname -m)" in
     Linux-x86_64) target="x86_64-linux" ;;
+    Linux-aarch64|Linux-arm64) target="aarch64-linux" ;;
     *) err "unsupported host $(uname -s)-$(uname -m); prebuilt binaries: https://github.com/octalide/mach/releases" ;;
 esac
 

--- a/mach.toml
+++ b/mach.toml
@@ -21,6 +21,11 @@ os   = "windows"
 abi  = "win64"
 ext  = ".exe"
 
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
 [bin.mach]
 entry = "main.mach"
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "1.5.5"
+version = "1.6.0"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -15,22 +15,46 @@
 # `of.ObjectImage`, and the per-arch encoder (e.g. `target/isa/x64/encode.mach`)
 # allocates and populates them. Keeping the records here lets the driver and every
 # ISA agree on one common output without depending on any specific architecture.
+#
+# It also owns the ISA-agnostic two-pass *encoder driver* every architecture's
+# encoder runs over a module: `encode_driver` initialises an `EncodeState`
+# (the growable text `ByteBuf` plus the symbol / relocation / branch-fixup /
+# block-offset arrays), walks every function through an ISA-supplied per-function
+# encode hook (recording marks, relocs, fixups, and block offsets via the shared
+# `push_*` helpers), patches every intra-module branch in pass 2 through an
+# ISA-supplied per-branch patch hook, right-sizes the text, and assembles the
+# `EncoderOutput`. The two `EncodeHooks` are the only per-ISA seams: how one
+# function's bytes are emitted (opcodes, prologue/epilogue, relocation offsets)
+# and how one resolved branch displacement is written into the text. No opcode,
+# register, displacement-width, or byte-encoding knowledge lives here.
 
 use std.types.bool.bool;
 use std.types.bool.true;
+use std.types.bool.false;
 use std.types.string.str;
+use std.types.size.usize;
 
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
 
 use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.reallocate;
+use std.allocator.deallocate;
+
+use std.system.panic.panic;
 
 use writer: std.io.writer;
 
 use intern: mach.lang.intern;
 use of:     mach.lang.target.of;
 use target: mach.lang.target.resolved;
+use abi:    mach.lang.target.abi;
+use tos:    mach.lang.target.os;
 use mir:    mach.lang.be.codegen.mir;
 
 # EncoderOutput: the per-module result an ISA's encoder produces — the encoded
@@ -167,4 +191,543 @@ pub fun print_asm(tgt: *target.Target, m: *mir.MirModule, out: *writer.Writer) R
 
     val emit_asm: PrintAsmFn = tgt.arch.emit_asm::PrintAsmFn;
     ret emit_asm(tgt, m, out);
+}
+
+# initial capacity of a freshly grown encoder byte buffer.
+val BYTEBUF_INIT_CAP: usize = 256;
+
+# a growable byte sink the encoders write machine code into. the back end drains
+# `data[0..len]` into the object image's `.text` section after every function is
+# encoded; keeping the growth bookkeeping here lets `of.Section` stay a finalized
+# container. the sink is ISA-general — it carries no opcode or width knowledge, so
+# every architecture's encoder writes its bytes through the same buffer.
+# ---
+# data:  backing byte array (nil until the first byte is appended)
+# len:   number of bytes written
+# cap:   allocated capacity
+# alloc: allocator backing `data`
+pub rec ByteBuf {
+    data:  *u8;
+    len:   usize;
+    cap:   usize;
+    alloc: *Allocator;
+}
+
+# buf_init: construct an empty encoder byte buffer.
+# ---
+# alloc: allocator backing the buffer's storage
+# ret:   an empty ByteBuf
+pub fun buf_init(alloc: *Allocator) ByteBuf {
+    var buf: ByteBuf;
+    buf.data  = nil;
+    buf.len   = 0;
+    buf.cap   = 0;
+    buf.alloc = alloc;
+    ret buf;
+}
+
+# buf_dnit: free a byte buffer's backing storage.
+# ---
+# buf: buffer to destroy; safe on nil
+pub fun buf_dnit(buf: *ByteBuf) {
+    if (buf == nil) { ret; }
+    if (buf.data != nil && buf.cap > 0) {
+        deallocate[u8](buf.alloc, buf.data, buf.cap);
+        buf.data = nil;
+    }
+    buf.len = 0;
+    buf.cap = 0;
+}
+
+# emit_byte: append a single byte to the buffer, growing it if needed.
+pub fun emit_byte(buf: *ByteBuf, byte: u8) {
+    if (buf.len >= buf.cap) {
+        var new_cap: usize = BYTEBUF_INIT_CAP;
+        if (buf.cap > 0) { new_cap = buf.cap * 2; }
+        val res_realloc: Result[*u8, str] = reallocate[u8](
+            buf.alloc, buf.data, buf.cap, new_cap
+        );
+        if (is_err[*u8, str](res_realloc)) {
+            panic("encode: byte buffer realloc failed\n");
+        }
+        buf.data = unwrap_ok[*u8, str](res_realloc);
+        buf.cap = new_cap;
+    }
+    buf.data[buf.len] = byte;
+    buf.len = buf.len + 1;
+}
+
+# emit_u16: append 2 bytes little-endian.
+pub fun emit_u16(buf: *ByteBuf, value: u16) {
+    emit_byte(buf, (value & 0xFF)::u8);
+    emit_byte(buf, ((value >> 8) & 0xFF)::u8);
+}
+
+# emit_u32: append 4 bytes little-endian.
+pub fun emit_u32(buf: *ByteBuf, value: u32) {
+    emit_byte(buf, (value & 0xFF)::u8);
+    emit_byte(buf, ((value >> 8) & 0xFF)::u8);
+    emit_byte(buf, ((value >> 16) & 0xFF)::u8);
+    emit_byte(buf, ((value >> 24) & 0xFF)::u8);
+}
+
+# emit_u64: append 8 bytes little-endian.
+pub fun emit_u64(buf: *ByteBuf, value: u64) {
+    emit_u32(buf, (value & 0xFFFFFFFF)::u32);
+    emit_u32(buf, ((value >> 32) & 0xFFFFFFFF)::u32);
+}
+
+# initial capacity for the encoder driver's symbol, relocation, fixup, and
+# block-offset arrays.
+val DRIVER_INIT_CAP: u32 = 16;
+
+# a single pending branch fixup recorded in pass 1 and patched in pass 2: an
+# intra-module branch whose displacement field is at `patch_pos` and whose target
+# is block `target_block` within the function based at `fn_text_base`. the field's
+# width and how a resolved displacement is written into it are ISA-specific (the
+# `EncodeHooks.patch_branch` hook), so this record names only the offsets the
+# shared driver resolves.
+# ---
+# patch_pos:    byte offset of the displacement field within `.text`
+# next_ip:      byte offset of the instruction following the branch within `.text`
+# target_block: destination MIR block id (function-local)
+# fn_text_base: text offset of the owning function's first block
+pub rec BranchFixup {
+    patch_pos:    u32;
+    next_ip:      u32;
+    target_block: u32;
+    fn_text_base: u32;
+}
+
+# one resolved block start: a function-local block id paired with its `.text`
+# offset, used to compute branch displacements in pass 2.
+# ---
+# fn_text_base: text offset of the owning function's first block
+# block_id:     function-local MIR block id
+# offset:       byte offset of the block's first instruction within `.text`
+rec BlockOffset {
+    fn_text_base: u32;
+    block_id:     u32;
+    offset:       u32;
+}
+
+# mutable bookkeeping shared across the encoder driver's two passes. owns the
+# growable text / symbol / relocation / fixup / block-offset arrays until
+# `encode_driver` either transfers the text + symbol + relocation arrays into the
+# returned `EncoderOutput` or frees everything on error. carries no
+# architecture-specific state — every field is ISA-general bookkeeping the shared
+# driver and every ISA's encode hook populate through the `push_*` helpers.
+# ---
+# alloc:        backing allocator
+# buf:          text byte sink
+# syms:         symbol marks
+# sym_count:    number of symbol marks
+# sym_cap:      capacity of `syms`
+# relocs:       pending relocations
+# reloc_count:  number of relocations
+# reloc_cap:    capacity of `relocs`
+# fixups:       pending branch fixups
+# fixup_count:  number of fixups
+# fixup_cap:    capacity of `fixups`
+# blocks:       resolved block offsets
+# block_count:  number of block offsets
+# block_cap:    capacity of `blocks`
+# interner:     session interner; resolves inline-asm `{name}` binding names and
+#               interns symbol names referenced from inline asm into relocations
+# abi:          the target ABI vtable (frame / argument model the encode hook reads)
+# os:           the target OS vtable (stack-probe / commit model the encode hook reads)
+pub rec EncodeState {
+    alloc:       *Allocator;
+    buf:         ByteBuf;
+    syms:        *SymbolMark;
+    sym_count:   u32;
+    sym_cap:     u32;
+    relocs:      *PendingReloc;
+    reloc_count: u32;
+    reloc_cap:   u32;
+    fixups:      *BranchFixup;
+    fixup_count: u32;
+    fixup_cap:   u32;
+    blocks:      *BlockOffset;
+    block_count: u32;
+    block_cap:   u32;
+    interner:    *intern.Interner;
+    abi:         *abi.AbiVTable;
+    os:          *tos.OsVTable;
+}
+
+# EncodeFunctionFn: the per-function encode hook. emits one function's machine
+# code into the shared `EncodeState` — the prologue, the instruction stream, and
+# the epilogue — recording its entry `SymbolMark`, every block's `.text` offset
+# (`push_block`), each cross-function / global symbol reference as a
+# `PendingReloc` (`push_reloc`), and each intra-module branch as a `BranchFixup`
+# (`push_fixup`) for pass 2. owns all opcode, register, relocation-offset, and
+# prologue/epilogue knowledge; the driver supplies only the shared state.
+# ---
+# st: the shared encode state (text sink + mark / reloc / fixup / block arrays)
+# f:  the function to encode
+# ret: ok(true) on success, or an error string from the per-arch encoder
+pub def EncodeFunctionFn: fun(*EncodeState, *mir.MirFunction) Result[bool, str];
+
+# PatchBranchFn: the per-branch patch hook. writes the resolved displacement of
+# one pass-1 `BranchFixup` into its `.text` field now that its target block's
+# offset is known. owns the ISA's branch encoding — the field width and the byte /
+# bitfield layout (x86-64 overwrites a 4-byte rel32; AArch64 inserts an imm26 /
+# imm19 into a 32-bit instruction word) and the displacement convention (relative
+# to `next_ip`, the branch start, etc.). the driver resolves `target_off` and
+# leaves the displacement computation and the write to the hook.
+# ---
+# st:         the shared encode state (its `buf` holds the text being patched)
+# fx:         the fixup to patch (its `patch_pos` / `next_ip` name the site)
+# target_off: the `.text` offset of the branch's resolved target block
+# ret:        ok(true) on success, or an error string (e.g. an out-of-range site)
+pub def PatchBranchFn: fun(*EncodeState, *BranchFixup, u32) Result[bool, str];
+
+# EncodeHooks: the per-ISA seam of the shared two-pass encoder driver. an
+# architecture's encoder supplies one of each and calls `encode_driver`; the
+# driver owns everything else (state lifetime, the function loop, pass-2 block
+# resolution, text right-sizing, and output assembly). these two are the only
+# operations that carry opcode / register / displacement knowledge.
+# ---
+# encode_function: emit one function's bytes into the shared state (pass 1)
+# patch_branch:    write one resolved branch displacement into the text (pass 2)
+pub rec EncodeHooks {
+    encode_function: EncodeFunctionFn;
+    patch_branch:    PatchBranchFn;
+}
+
+# encode_driver: the ISA-agnostic two-pass encoder driver every architecture runs
+# over a fully-resolved MIR module to produce its `EncoderOutput`.
+#
+# initialises an `EncodeState` (empty text sink and mark / reloc / fixup / block
+# arrays, threading the module interner and the target ABI / OS vtables), then
+# runs pass 1 — walking every function in layout order through the ISA's
+# `encode_function` hook, which appends bytes and records symbol marks, pending
+# relocations, branch fixups, and block offsets through the shared `push_*`
+# helpers. pass 2 resolves every recorded `BranchFixup`'s target block offset and
+# hands it to the ISA's `patch_branch` hook to write the displacement. the text is
+# then right-sized (so the object builder's free-by-length matches the allocation)
+# and transferred, with the symbol and relocation arrays, into the returned
+# `EncoderOutput`; the driver-internal fixup and block arrays are released. on any
+# error every owned array is freed and the error propagated. carries no
+# architecture-specific knowledge — the two hooks own all of it.
+# ---
+# alloc: backing allocator for the encoder's output arrays (threaded for parity
+#        with `EncodeFn`; the state is backed by the module allocator, as before)
+# tgt:   resolved compilation target; supplies the ABI / OS vtables the hook reads
+# m:     the fully-resolved MIR module (post isel / regalloc / frame)
+# hooks: the per-ISA encode / patch operations
+# ret:   the populated `EncoderOutput` (owned arrays), or an error string
+pub fun encode_driver(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule, hooks: *EncodeHooks) Result[EncoderOutput, str] {
+    if (tgt == nil)   { ret err[EncoderOutput, str]("encode: nil target"); }
+    if (m == nil)     { ret err[EncoderOutput, str]("encode: nil mir module"); }
+    if (hooks == nil) { ret err[EncoderOutput, str]("encode: nil encode hooks"); }
+    if (hooks.encode_function == nil) {
+        ret err[EncoderOutput, str]("encode: ISA supplied no per-function encode hook");
+    }
+    if (hooks.patch_branch == nil) {
+        ret err[EncoderOutput, str]("encode: ISA supplied no per-branch patch hook");
+    }
+
+    var st: EncodeState;
+    st.alloc       = m.alloc;
+    st.buf         = buf_init(m.alloc);
+    st.syms        = nil;
+    st.sym_count   = 0;
+    st.sym_cap     = 0;
+    st.relocs      = nil;
+    st.reloc_count = 0;
+    st.reloc_cap   = 0;
+    st.fixups      = nil;
+    st.fixup_count = 0;
+    st.fixup_cap   = 0;
+    st.blocks      = nil;
+    st.block_count = 0;
+    st.block_cap   = 0;
+    st.interner    = m.interner;
+    st.abi         = tgt.abi;
+    st.os          = tgt.os;
+
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val ef: Result[bool, str] = hooks.encode_function(?st, ?m.functions[fi]);
+        if (is_err[bool, str](ef)) {
+            free_state(?st);
+            ret err[EncoderOutput, str](unwrap_err[bool, str](ef));
+        }
+        fi = fi + 1;
+    }
+
+    val pb: Result[bool, str] = patch_branches(?st, hooks);
+    if (is_err[bool, str](pb)) {
+        free_state(?st);
+        ret err[EncoderOutput, str](unwrap_err[bool, str](pb));
+    }
+
+    # right-size the text buffer so its allocation length equals `text_len`: the
+    # object builder owns these bytes and frees them by `len`, so the backing
+    # allocation must match exactly rather than the byte buffer's over-allocated
+    # capacity.
+    val tr: Result[bool, str] = shrink_text(?st);
+    if (is_err[bool, str](tr)) {
+        free_state(?st);
+        ret err[EncoderOutput, str](unwrap_err[bool, str](tr));
+    }
+
+    var out: EncoderOutput;
+    out.text         = st.buf.data;
+    out.text_len     = st.buf.len::u32;
+    out.relocations  = st.relocs;
+    out.reloc_count  = st.reloc_count;
+    out.symbols      = st.syms;
+    out.symbol_count = st.sym_count;
+
+    # the text / symbol / relocation arrays are transferred to the output; the
+    # driver-internal fixup and block-offset arrays are released.
+    free_scratch(?st);
+    ret ok[EncoderOutput, str](out);
+}
+
+# shrink the text byte sink so its backing allocation length equals the number of
+# bytes written. the object builder frees the transferred `.text` buffer by its
+# `len`, so the allocation must be exactly `len` bytes wide. a no-op when the
+# buffer is already exact, empty, or unallocated.
+fun shrink_text(st: *EncodeState) Result[bool, str] {
+    if (st.buf.data == nil) { ret ok[bool, str](true); }
+    if (st.buf.len == 0) {
+        deallocate[u8](st.alloc, st.buf.data, st.buf.cap);
+        st.buf.data = nil;
+        st.buf.cap  = 0;
+        ret ok[bool, str](true);
+    }
+    if (st.buf.cap == st.buf.len) { ret ok[bool, str](true); }
+    val r: Result[*u8, str] = reallocate[u8](st.alloc, st.buf.data, st.buf.cap, st.buf.len);
+    if (is_err[*u8, str](r)) { ret err[bool, str](unwrap_err[*u8, str](r)); }
+    st.buf.data = unwrap_ok[*u8, str](r);
+    st.buf.cap  = st.buf.len;
+    ret ok[bool, str](true);
+}
+
+# pass 2: resolve each recorded intra-module branch fixup's target block offset
+# and hand it to the ISA's `patch_branch` hook, which writes the displacement into
+# the text. the displacement convention and field layout are the hook's; the
+# driver only resolves block offsets in the shared block-offset table.
+fun patch_branches(st: *EncodeState, hooks: *EncodeHooks) Result[bool, str] {
+    if (st.buf.data == nil) { ret ok[bool, str](true); }
+    var i: u32 = 0;
+    for (i < st.fixup_count) {
+        val fx: *BranchFixup = ?st.fixups[i];
+        val tr: Result[u32, str] = block_offset(st, fx.fn_text_base, fx.target_block);
+        if (is_err[u32, str](tr)) { ret err[bool, str](unwrap_err[u32, str](tr)); }
+        val target_off: u32 = unwrap_ok[u32, str](tr);
+        val pr: Result[bool, str] = hooks.patch_branch(st, fx, target_off);
+        if (is_err[bool, str](pr)) { ret err[bool, str](unwrap_err[bool, str](pr)); }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# resolve a function-local block id to its `.text` offset. an unrecorded target is
+# a backend bug (a branch to a block the encoder never emitted), rejected loudly
+# rather than resolved to offset 0 (a branch into the first function's middle).
+fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) Result[u32, str] {
+    var i: u32 = 0;
+    for (i < st.block_count) {
+        if (st.blocks[i].fn_text_base == fn_base && st.blocks[i].block_id == block_id) {
+            ret ok[u32, str](st.blocks[i].offset);
+        }
+        i = i + 1;
+    }
+    ret err[u32, str]("encode: branch target block was never recorded");
+}
+
+# classify_refs: determine whether an instruction names an intra-module branch
+# target (a MIR_OP_BLOCK operand) or a relocatable symbol (a MIR_OP_SYM operand),
+# reporting the target block id / interned symbol name through the out-parameters.
+# MIR-level and ISA-agnostic — it reads only the generic operand model, so every
+# architecture's encode hook uses it to drive fixup / relocation recording.
+# ---
+# mi:           the instruction to inspect
+# target_block: out — the referenced block id (0 when none)
+# has_block:    out — true when a MIR_OP_BLOCK operand was found
+# sym:          out — the referenced interned symbol name (STR_NIL when none)
+# has_sym:      out — true when a MIR_OP_SYM operand was found
+# sym_addend:   out — the symbol operand's constant offset
+pub fun classify_refs(mi: *mir.MirInstr, target_block: *u32, has_block: *bool,
+                      sym: *intern.StrId, has_sym: *bool, sym_addend: *i32) {
+    var found_block: bool = false;
+    var found_sym: bool = false;
+    @has_block = false;
+    @has_sym   = false;
+    @target_block = 0;
+    @sym = intern.STR_NIL;
+    @sym_addend = 0;
+    var k: u32 = 0;
+    for (k < mi.operand_count) {
+        val op: *mir.MirOperand = ?mi.operands[k];
+        if (op.kind == mir.MIR_OP_BLOCK && found_block == false) {
+            found_block = true;
+            @has_block = true;
+            @target_block = op.imm::u32;
+        }
+        if (op.kind == mir.MIR_OP_SYM && found_sym == false) {
+            found_sym = true;
+            @has_sym = true;
+            @sym = op.sym;
+            @sym_addend = op.sym_off;
+        }
+        k = k + 1;
+    }
+}
+
+# push_symbol: append a symbol mark, growing the symbol array on demand.
+pub fun push_symbol(st: *EncodeState, name: intern.StrId, offset: u32, flags: u32) Result[bool, str] {
+    if (st.sym_count >= st.sym_cap) {
+        val gr: Result[bool, str] = grow_symbols(st);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    st.syms[st.sym_count].name   = name;
+    st.syms[st.sym_count].offset = offset;
+    st.syms[st.sym_count].flags  = flags;
+    st.sym_count = st.sym_count + 1;
+    ret ok[bool, str](true);
+}
+
+# push_reloc: append a pending relocation, growing the relocation array on demand.
+pub fun push_reloc(st: *EncodeState, offset: u32, kind: of.RelocKind, sym: intern.StrId, addend: i32) Result[bool, str] {
+    if (st.reloc_count >= st.reloc_cap) {
+        val gr: Result[bool, str] = grow_relocs(st);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    st.relocs[st.reloc_count].offset = offset;
+    st.relocs[st.reloc_count].kind   = kind;
+    st.relocs[st.reloc_count].sym    = sym;
+    st.relocs[st.reloc_count].addend = addend;
+    st.reloc_count = st.reloc_count + 1;
+    ret ok[bool, str](true);
+}
+
+# push_fixup: append a branch fixup, growing the fixup array on demand.
+pub fun push_fixup(st: *EncodeState, patch_pos: u32, next_ip: u32, target_block: u32, fn_text_base: u32) Result[bool, str] {
+    if (st.fixup_count >= st.fixup_cap) {
+        val gr: Result[bool, str] = grow_fixups(st);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    st.fixups[st.fixup_count].patch_pos    = patch_pos;
+    st.fixups[st.fixup_count].next_ip      = next_ip;
+    st.fixups[st.fixup_count].target_block = target_block;
+    st.fixups[st.fixup_count].fn_text_base = fn_text_base;
+    st.fixup_count = st.fixup_count + 1;
+    ret ok[bool, str](true);
+}
+
+# push_block: append a resolved block offset, growing the block-offset array on demand.
+pub fun push_block(st: *EncodeState, fn_text_base: u32, block_id: u32, offset: u32) Result[bool, str] {
+    if (st.block_count >= st.block_cap) {
+        val gr: Result[bool, str] = grow_blocks(st);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    st.blocks[st.block_count].fn_text_base = fn_text_base;
+    st.blocks[st.block_count].block_id     = block_id;
+    st.blocks[st.block_count].offset       = offset;
+    st.block_count = st.block_count + 1;
+    ret ok[bool, str](true);
+}
+
+# grow the symbol-mark array (or allocate it on first use).
+fun grow_symbols(st: *EncodeState) Result[bool, str] {
+    if (st.syms == nil) {
+        val r: Result[*SymbolMark, str] = allocate[SymbolMark](st.alloc, DRIVER_INIT_CAP::usize);
+        if (is_err[*SymbolMark, str](r)) { ret err[bool, str](unwrap_err[*SymbolMark, str](r)); }
+        st.syms    = unwrap_ok[*SymbolMark, str](r);
+        st.sym_cap = DRIVER_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = st.sym_cap * 2;
+    val r: Result[*SymbolMark, str] = reallocate[SymbolMark](st.alloc, st.syms, st.sym_cap::usize, nc::usize);
+    if (is_err[*SymbolMark, str](r)) { ret err[bool, str](unwrap_err[*SymbolMark, str](r)); }
+    st.syms    = unwrap_ok[*SymbolMark, str](r);
+    st.sym_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# grow the relocation array (or allocate it on first use).
+fun grow_relocs(st: *EncodeState) Result[bool, str] {
+    if (st.relocs == nil) {
+        val r: Result[*PendingReloc, str] = allocate[PendingReloc](st.alloc, DRIVER_INIT_CAP::usize);
+        if (is_err[*PendingReloc, str](r)) { ret err[bool, str](unwrap_err[*PendingReloc, str](r)); }
+        st.relocs    = unwrap_ok[*PendingReloc, str](r);
+        st.reloc_cap = DRIVER_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = st.reloc_cap * 2;
+    val r: Result[*PendingReloc, str] = reallocate[PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize, nc::usize);
+    if (is_err[*PendingReloc, str](r)) { ret err[bool, str](unwrap_err[*PendingReloc, str](r)); }
+    st.relocs    = unwrap_ok[*PendingReloc, str](r);
+    st.reloc_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# grow the branch-fixup array (or allocate it on first use).
+fun grow_fixups(st: *EncodeState) Result[bool, str] {
+    if (st.fixups == nil) {
+        val r: Result[*BranchFixup, str] = allocate[BranchFixup](st.alloc, DRIVER_INIT_CAP::usize);
+        if (is_err[*BranchFixup, str](r)) { ret err[bool, str](unwrap_err[*BranchFixup, str](r)); }
+        st.fixups    = unwrap_ok[*BranchFixup, str](r);
+        st.fixup_cap = DRIVER_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = st.fixup_cap * 2;
+    val r: Result[*BranchFixup, str] = reallocate[BranchFixup](st.alloc, st.fixups, st.fixup_cap::usize, nc::usize);
+    if (is_err[*BranchFixup, str](r)) { ret err[bool, str](unwrap_err[*BranchFixup, str](r)); }
+    st.fixups    = unwrap_ok[*BranchFixup, str](r);
+    st.fixup_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# grow the block-offset array (or allocate it on first use).
+fun grow_blocks(st: *EncodeState) Result[bool, str] {
+    if (st.blocks == nil) {
+        val r: Result[*BlockOffset, str] = allocate[BlockOffset](st.alloc, DRIVER_INIT_CAP::usize);
+        if (is_err[*BlockOffset, str](r)) { ret err[bool, str](unwrap_err[*BlockOffset, str](r)); }
+        st.blocks    = unwrap_ok[*BlockOffset, str](r);
+        st.block_cap = DRIVER_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = st.block_cap * 2;
+    val r: Result[*BlockOffset, str] = reallocate[BlockOffset](st.alloc, st.blocks, st.block_cap::usize, nc::usize);
+    if (is_err[*BlockOffset, str](r)) { ret err[bool, str](unwrap_err[*BlockOffset, str](r)); }
+    st.blocks    = unwrap_ok[*BlockOffset, str](r);
+    st.block_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# free_scratch: release the driver-internal scratch arrays (fixups, block offsets)
+# once their work is done; the text / symbol / relocation arrays survive into
+# EncoderOutput.
+fun free_scratch(st: *EncodeState) {
+    if (st.fixups != nil && st.fixup_cap > 0) {
+        deallocate[BranchFixup](st.alloc, st.fixups, st.fixup_cap::usize);
+        st.fixups = nil;
+    }
+    if (st.blocks != nil && st.block_cap > 0) {
+        deallocate[BlockOffset](st.alloc, st.blocks, st.block_cap::usize);
+        st.blocks = nil;
+    }
+}
+
+# free_state: release every owned array on the error path, including the text sink
+# and the symbol / relocation arrays that would otherwise transfer into
+# EncoderOutput.
+fun free_state(st: *EncodeState) {
+    buf_dnit(?st.buf);
+    if (st.syms != nil && st.sym_cap > 0) {
+        deallocate[SymbolMark](st.alloc, st.syms, st.sym_cap::usize);
+        st.syms = nil;
+    }
+    if (st.relocs != nil && st.reloc_cap > 0) {
+        deallocate[PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize);
+        st.relocs = nil;
+    }
+    free_scratch(st);
 }

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -15,6 +15,7 @@
 
 use std.types.bool.bool;
 use std.types.bool.true;
+use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.option.Option;
@@ -73,10 +74,10 @@ pub fun require_abi(tgt: *target.Target) Result[bool, str] {
 
 # abi_gp_arg_reg: the physical register id of the `index`-th GP argument register
 # of the active ABI, read from `tgt.abi.gp_arg_regs` (the convention's GP argument
-# bank in passing order). used for the hidden sret-pointer argument, which rides
-# in the first GP argument register the same way an ordinary argument does. errors
-# loudly when `index` is past the convention's GP argument file (a classification
-# bug) rather than returning a wrong register.
+# bank in passing order). used to find the integer register a win64 variadic float
+# duplicates into (the hidden sret pointer rides `tgt.abi.indirect_result_reg`,
+# which may be a dedicated register outside this file). errors loudly when `index`
+# is past the convention's GP argument file rather than returning a wrong register.
 # ---
 # tgt:   the active target
 # index: zero-based GP argument-register index
@@ -225,6 +226,53 @@ fun advance_arg_cursors(slot: *abi.ParamSlot, gp_used: *i32, fp_used: *i32) {
     advance_one_cursor(slot.reg2, gp_used, fp_used);
 }
 
+# sret_reserves_gp: whether a CLASS_SRET return reserves the first GP argument
+# register for its hidden result-storage pointer. true only when the convention
+# routes the pointer through the argument file (`indirect_result_in_argfile` — the
+# AMD64 conventions, whose pointer rides RDI / RCX), so the fixed parameters
+# classify against `gp_used = 1`; a dedicated indirect-result register outside the
+# argument file (AAPCS64's X8) reserves no argument register, leaving the GP cursor
+# at 0 so the first real argument lands in the first GP argument register.
+# ---
+# ret_class:  the return value's classification
+# in_argfile: the convention's `indirect_result_in_argfile`
+# ret:        true when an argument GP register must be reserved for the sret pointer
+fun sret_reserves_gp(ret_class: abi.ParamClass, in_argfile: bool) bool {
+    ret ret_class == abi.CLASS_SRET && in_argfile;
+}
+
+# round_up_i64: round `value` up to the next multiple of `align` (a power-of-two
+# alignment). an alignment of 0 or 1 returns `value` unchanged. used to align an
+# outgoing stack-argument offset to its slot's required alignment.
+# ---
+# value: the offset to align
+# align: the alignment to round up to
+# ret:   the smallest multiple of `align` that is >= `value`
+fun round_up_i64(value: i64, align: u64) i64 {
+    if (align <= 1) { ret value; }
+    val a:   i64 = align::i64;
+    val rem: i64 = value % a;
+    if (rem == 0) { ret value; }
+    ret value + (a - rem);
+}
+
+# stack_arg_align: the alignment in bytes a stack-passed argument's slot rounds to.
+# a by-value stack slot (CLASS_STACK) rounds to the value's natural alignment,
+# clamped to the eight-byte outgoing-slot granularity; a by-reference spill
+# (CLASS_STACK_BYREF) holds only an eight-byte pointer, so it rounds to eight
+# regardless of the aggregate's alignment. on x86 every stack argument is
+# ≤8-aligned, so this is always eight and the round-up is identity; AAPCS64 honors a
+# 16-byte-aligned by-value argument.
+# ---
+# class: the slot's classification (CLASS_STACK or CLASS_STACK_BYREF)
+# align: the value's natural alignment in bytes
+# ret:   the slot's stack alignment in bytes
+fun stack_arg_align(class: abi.ParamClass, align: u64) u64 {
+    if (class == abi.CLASS_STACK_BYREF) { ret 8; }
+    if (align < 8) { ret 8; }
+    ret align;
+}
+
 # classify_signature: classify a whole function ABI in ONE left-to-right walk and
 # fill `out` with the resulting `SigLayout`. this is the single ABI-lowering oracle
 # the param / return / call lowering all read, so they can never disagree on a
@@ -289,9 +337,12 @@ pub fun classify_signature(ctx: *lctx.LowerCtx, sig: ir_type.IrTypeId, ret_ty: i
     # into this region, so a stack argument placed below it would be clobbered.
     var stack_off: i64 = ctx.tgt.abi.shadow_space::i64;
 
-    # a CLASS_SRET return reserves the first GP argument register for the hidden
-    # result-storage pointer, so the parameters classify against that reservation.
-    if (out.ret_slot.class == abi.CLASS_SRET) {
+    # a CLASS_SRET return whose hidden result-storage pointer rides the first GP
+    # argument register (the AMD64 conventions) reserves that register, so the
+    # parameters classify against it; a convention with a dedicated indirect-result
+    # register outside the argument file (AAPCS64's X8) reserves none, leaving the GP
+    # cursor at 0 so the first real argument lands in the first GP argument register.
+    if (sret_reserves_gp(out.ret_slot.class, ctx.tgt.abi.indirect_result_in_argfile)) {
         gp_used = 1;
     }
 
@@ -325,10 +376,11 @@ pub fun classify_signature(ctx: *lctx.LowerCtx, sig: ir_type.IrTypeId, ret_ty: i
     for (pi < pc) {
         val pty:  ir_type.IrTypeId = t.data.fn.params[pi];
         val psz:  u64  = ir_type.byte_size(ctx.types, pty, ctx.tgt)::u64;
+        val pal:  u64  = ir_type.byte_align(ctx.types, pty, ctx.tgt)::u64;
         val pfl:  bool = lctx.value_is_float(ctx, pty);
         val pag:  bool = lctx.value_is_aggregate(ctx, pty);
         val peb:  u8   = aggregate_sse_mask(ctx, pty);
-        var slot: abi.ParamSlot = classify_arg(pi::i32, psz, 0, pfl, peb, pag, gp_used, fp_used);
+        var slot: abi.ParamSlot = classify_arg(pi::i32, psz, pal, pfl, peb, pag, gp_used, fp_used);
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering
@@ -336,8 +388,11 @@ pub fun classify_signature(ctx: *lctx.LowerCtx, sig: ir_type.IrTypeId, ret_ty: i
         # occupies the same eight-byte slot as a by-value one — only its contents
         # (a hidden pointer) differ — so it advances the cursor identically. a
         # register slot advances each assigned register's bank cursor (a mixed
-        # GP/SSE aggregate consumes one of each).
+        # GP/SSE aggregate consumes one of each). a by-value stack slot is first
+        # rounded up to the value's alignment (identity on x86, where every stack
+        # argument is ≤8-aligned; honors a 16-aligned AAPCS64 by-value argument).
         if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
+            stack_off   = round_up_i64(stack_off, stack_arg_align(slot.class, pal));
             slot.offset = stack_off;
             stack_off   = stack_off + lctx.stack_slot_bytes(slot.size);
         } or {
@@ -438,16 +493,11 @@ pub fun lower_call(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
 
     if (rslot.class == abi.CLASS_SRET) {
         # the caller allocates the return storage (above) and passes its address in
-        # the first GP argument register (the ABI's GP argument file, RDI under
-        # SysV); the result vreg names that storage. the layout already reserved the
-        # GP slot in `gp_used`, so emit the pre-coloring move into the first register.
+        # the convention's indirect-result register (RDI under SysV, RCX under win64,
+        # the dedicated X8 under AAPCS64); the result vreg names that storage. for an
+        # in-argfile convention the layout already reserved the GP slot in `gp_used`.
         if (res_dst != mir.MIR_VREG_NIL) {
-            var sret_reg: i32 = 0;
-            val sr: Result[bool, str] = abi_gp_arg_reg(ctx.tgt, 0, ?sret_reg);
-            if (is_err[bool, str](sr)) {
-                sig_layout_free(ctx, ?layout);
-                ret sr;
-            }
+            val sret_reg: i32 = ctx.tgt.abi.indirect_result_reg;
             val pre: Result[bool, str] = lctx.emit_mov(ctx, mb,
                 mir.op_preg(sret_reg::u32), mir.op_vreg(res_dst));
             if (is_err[bool, str](pre)) {
@@ -472,13 +522,19 @@ pub fun lower_call(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
             soff = slot.offset;
         } or {
             val asz:  u64  = ir_type.byte_size(ctx.types, av.ty, ctx.tgt)::u64;
+            val aal:  u64  = ir_type.byte_align(ctx.types, av.ty, ctx.tgt)::u64;
             val afl:  bool = lctx.value_is_float(ctx, av.ty);
             val aag:  bool = lctx.value_is_aggregate(ctx, av.ty);
             # a variadic tail aggregate is classified as integer eightbytes (mask 0):
             # the va_arg read path walks the GP register-save / overflow areas, so the
             # caller and callee stay consistent. SSE-eightbyte aggregate passing is for
             # fixed parameters and returns (the C-FFI boundary), not the varargs tail.
-            slot = classify_arg(pidx::i32, asz, 0, afl, 0, aag, gp_used, fp_used);
+            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, gp_used, fp_used);
+            # round a stack-passed tail argument up to its slot alignment before
+            # placing it (identity on x86; honors a 16-aligned AAPCS64 by-value arg).
+            if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
+                stack_off = round_up_i64(stack_off, stack_arg_align(slot.class, aal));
+            }
             soff = stack_off;
         }
 
@@ -574,8 +630,9 @@ pub fun lower_call(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
     val pc: Result[bool, str] = lctx.push_instr(ctx, mb, cmi);
     if (is_err[bool, str](pc)) { ret pc; }
 
-    # bind the result. an sret call already named its storage via RDI; otherwise
-    # move the value out of the canonical return register(s) into the result vreg.
+    # bind the result. an sret call already named its storage via the indirect-result
+    # register; otherwise move the value out of the canonical return register(s) into
+    # the result vreg.
     val dst: u32 = lctx.result_vreg(ctx, iid);
     if (dst != mir.MIR_VREG_NIL && rslot.class != abi.CLASS_SRET) {
         val rr: Result[bool, str] = emit_ret_slot_to_vreg(ctx, mb, rslot, dst, ret_aggr);
@@ -747,23 +804,20 @@ fun emit_ret_slot_to_vreg(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, slot: abi.Para
 pub fun lower_params(ctx: *lctx.LowerCtx, mb: *mir.MirBlock) Result[bool, str] {
     # classify the whole function signature once: the same layout the caller's
     # `lower_call` derives, so a parameter is placed exactly where the call passed
-    # it. an sret return reserves the first GP register (in the layout); the per-
-    # parameter slots carry their real `[rbp + 16 + offset]` stack offsets.
+    # it. an in-argfile sret return reserves the first GP register (in the layout);
+    # an out-of-argfile one (AAPCS64's X8) reserves none. the per-parameter slots
+    # carry their real `[rbp + 16 + offset]` stack offsets.
     val ret_ty: ir_type.IrTypeId = lctx.fn_return_type(ctx);
     var layout: abi.SigLayout;
     val cls: Result[bool, str] = classify_signature(ctx, ctx.fn.sig, ret_ty, ?layout);
     if (is_err[bool, str](cls)) { ret cls; }
 
     # an sret return: the caller passes the hidden result-storage pointer in the
-    # first GP argument register; capture it into a vreg so `lower_ret` copies the
-    # returned aggregate into that storage and returns the pointer in RAX.
+    # convention's indirect-result register (RDI/RCX in the argument file, or the
+    # dedicated X8 under AAPCS64); capture it into a vreg so `lower_ret` copies the
+    # returned aggregate into that storage and returns the pointer in the return reg.
     if (layout.ret_slot.class == abi.CLASS_SRET) {
-        var sret_reg: i32 = 0;
-        val sr: Result[bool, str] = abi_gp_arg_reg(ctx.tgt, 0, ?sret_reg);
-        if (is_err[bool, str](sr)) {
-            sig_layout_free(ctx, ?layout);
-            ret sr;
-        }
+        val sret_reg: i32 = ctx.tgt.abi.indirect_result_reg;
         val svr: Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
         if (is_err[u32, str](svr)) {
             sig_layout_free(ctx, ?layout);
@@ -952,4 +1006,32 @@ fun emit_bare_ret(ctx: *lctx.LowerCtx, mb: *mir.MirBlock) Result[bool, str] {
     mi.width         = mir.WORD_WIDTH;
     mi.src_width     = mir.WORD_WIDTH;
     ret lctx.push_instr(ctx, mb, mi);
+}
+
+test "mir.abi: an sret return seeds a GP argument slot only when the pointer is in the argument file" {
+    # x86 (SysV/win64): the hidden result pointer rides the first GP argument
+    # register, so classify_signature seeds gp_used = 1 (reserves a GP slot).
+    if (!sret_reserves_gp(abi.CLASS_SRET, true)) { ret 1; }
+    # AAPCS64: a dedicated X8 indirect-result register reserves no argument register,
+    # so the first real argument still lands in X0.
+    if (sret_reserves_gp(abi.CLASS_SRET, false)) { ret 1; }
+    # a non-sret return never reserves a GP slot regardless of the convention.
+    if (sret_reserves_gp(abi.CLASS_GP, true)) { ret 1; }
+    ret 0;
+}
+
+test "mir.abi: a stack argument offset rounds up to its slot alignment" {
+    # an 8-aligned argument at an already-8-aligned cursor is identity (the x86 path).
+    if (round_up_i64(8, 8) != 8)   { ret 1; }
+    if (round_up_i64(0, 8) != 0)   { ret 1; }
+    # a 16-aligned by-value argument rounds the cursor up to 16 (the AAPCS64 path).
+    if (round_up_i64(8, 16) != 16) { ret 1; }
+    if (round_up_i64(24, 16) != 32) { ret 1; }
+    # a by-reference spill holds an 8-byte pointer, so it rounds to 8 regardless of
+    # the aggregate's natural alignment.
+    if (stack_arg_align(abi.CLASS_STACK_BYREF, 16) != 8) { ret 1; }
+    # a by-value slot honors the value's alignment, clamped to the 8-byte minimum.
+    if (stack_arg_align(abi.CLASS_STACK, 16) != 16) { ret 1; }
+    if (stack_arg_align(abi.CLASS_STACK, 4) != 8)   { ret 1; }
+    ret 0;
 }

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -771,11 +771,10 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
         ret lower_div(ctx, mb, inst, iid);
     }
 
-    # a shift (SHL / SHR_S / SHR_U) is two-address on x86-64 (`value op= count`),
-    # and a register count must occupy the ISA's shift-count register (x86-64 CL).
-    # it is lowered into the two-address form with a runtime count pre-colored into
-    # `tgt.arch.shift_count_reg`; an ISA wiring no fixed shift-count register reports
-    # -1 and `lower_shift` errors loudly rather than emitting an un-pre-colored shift.
+    # a shift (SHL / SHR_S / SHR_U): an ISA whose variable-shift form hard-wires the
+    # count register (x86-64 CL) pre-colors a runtime count into `tgt.arch.shift_count_reg`;
+    # an ISA wiring no fixed shift-count register (-1, e.g. AArch64 LSLV/LSRV/ASRV)
+    # passes the count straight through to the three-address register-shift form.
     if (inst.kind == instr.OP_SHL || inst.kind == instr.OP_SHR_S ||
         inst.kind == instr.OP_SHR_U) {
         ret lower_shift(ctx, mb, inst, iid);
@@ -978,18 +977,20 @@ fun lower_shift(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
 
     var count_op: mir.MirOperand = count;
     if (count.kind != mir.MIR_OP_IMM) {
-        # a runtime count must occupy the ISA's shift-count register (x86-64 CL);
-        # move it there and reference it so the encoder selects the `shift r/m, CL`
-        # form. the register is reserved from allocation for the whole function, so
-        # this move cannot clobber a live value. an ISA wiring no fixed shift-count
-        # register (`shift_count_reg < 0`) cannot lower a runtime-count shift here.
+        # an ISA whose variable-shift form hard-wires the count register (x86-64 CL,
+        # `shift_count_reg >= 0`) pre-colors the runtime count into it and references it
+        # so the encoder selects the `shift r/m, CL` form; the register is reserved from
+        # allocation for the whole function, so the move cannot clobber a live value. an
+        # ISA wiring no fixed shift-count register (`shift_count_reg < 0`, e.g. AArch64
+        # LSLV/LSRV/ASRV, which read the count from any GP register) passes the count
+        # straight through to the three-address register-shift form — mirroring the
+        # division's `div_reg < 0` three-address path.
         val cnt_reg: i32 = ctx.tgt.arch.shift_count_reg;
-        if (cnt_reg < 0) {
-            ret err[bool, str]("mir.lower_ir: ISA wires no shift-count register for a runtime shift count");
+        if (cnt_reg >= 0) {
+            val mc: Result[bool, str] = lctx.emit_mov_w(ctx, mb, mir.op_preg(cnt_reg::u32), count, w);
+            if (is_err[bool, str](mc)) { ret mc; }
+            count_op = mir.op_preg(cnt_reg::u32);
         }
-        val mc: Result[bool, str] = lctx.emit_mov_w(ctx, mb, mir.op_preg(cnt_reg::u32), count, w);
-        if (is_err[bool, str](mc)) { ret mc; }
-        count_op = mir.op_preg(cnt_reg::u32);
     }
 
     # the three-address shift: operand 0 is the pure-def destination, operand 1 the

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -1009,8 +1009,15 @@ fun lower_shift(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
     ret lctx.push_instr(ctx, mb, mi);
 }
 
-# lower_div: lower an integer OP_DIV_*/OP_REM_* into the x86-64 RAX:RDX division
-# sequence with explicit register pre-coloring, mirroring the call/return ABI
+# lower_div: lower an integer OP_DIV_*/OP_REM_*. an ISA whose division form
+# hard-wires the dividend / quotient accumulator and the high-half / remainder
+# register (`div_reg >= 0`, x86-64 RAX:RDX) takes the pre-coloring path below; an ISA
+# that wires no fixed division register (`div_reg < 0`, e.g. AArch64 SDIV/UDIV, which
+# write a normal destination register) takes the generic three-address path
+# (`lower_div_three_address`).
+#
+# the pre-coloring path lowers into the x86-64 RAX:RDX division sequence with explicit
+# register pre-coloring, mirroring the call/return ABI
 # pre-coloring approach. the IR operands are `[a, b]` (dividend, divisor). the
 # emitted sequence is, in order:
 #   - `mir.MIR_MOV RAX <- a` — the dividend occupies the accumulator;
@@ -1042,13 +1049,13 @@ fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     }
     # the ISA's division form hard-wires the dividend / quotient accumulator and the
     # high-half / remainder register (x86-64 RAX:RDX). an ISA wiring no fixed
-    # division register (`div_reg < 0` / `div_hi_reg < 0`) cannot lower an integer
-    # division through this pre-coloring path; fail loudly rather than emit one with
-    # an invalid register.
+    # division register (`div_reg < 0` / `div_hi_reg < 0`, e.g. AArch64 SDIV/UDIV)
+    # lowers to the generic three-address divide the per-ISA encoder realizes, rather
+    # than this pre-coloring path.
     val acc_reg: i32 = ctx.tgt.arch.div_reg;
     val hi_reg:  i32 = ctx.tgt.arch.div_hi_reg;
     if (acc_reg < 0 || hi_reg < 0) {
-        ret err[bool, str]("mir.lower_ir: ISA wires no division registers for an integer divide");
+        ret lower_div_three_address(ctx, mb, inst, iid, dst);
     }
     val signed: bool = inst.kind == instr.OP_DIV_S || inst.kind == instr.OP_REM_S;
 
@@ -1110,6 +1117,73 @@ fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
         res_reg = hi_reg;
     }
     ret lctx.emit_mov_w(ctx, mb, mir.op_vreg(dst), mir.op_preg(res_reg::u32), natural_w);
+}
+
+# lower_div_three_address: lower an integer division / remainder on an ISA that wires
+# no fixed division register (`div_reg < 0`, e.g. AArch64 SDIV/UDIV, which write a
+# normal destination register). emits a clean three-address divide
+# `[dst, dividend, divisor]` carrying the OP_DIV_*/OP_REM_* kind and the operation
+# width; instruction selection rewrites it to the per-ISA selection-output sentinel
+# and the encoder materializes the quotient / remainder plus the defined
+# division-by-zero and signed-overflow traps. operand 0 is a pure def the register
+# allocator reads directly (no RAX/RDX pre-coloring). mirrors the pre-coloring path's
+# operand handling — a narrower-than-32-bit operand is promoted to the divide width
+# (the encoder's divides have only 32- and 64-bit forms) and an immediate operand is
+# materialized into a value vreg (so both operands reach the divide in a register,
+# which the SDIV/UDIV and the trap checks require; a constant-zero divisor thus lands
+# in a register and still traps). the destination IS the divide result, so a promoted
+# narrow result needs no truncating move (a consumer reads its low bytes).
+fun lower_div_three_address(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
+                            iid: id.InstructionId, dst: u32) Result[bool, str] {
+    val signed: bool = inst.kind == instr.OP_DIV_S || inst.kind == instr.OP_REM_S;
+
+    val natural_w: u8 = lctx.op_width_of(ctx, inst.ty);
+    var w: u8 = natural_w;
+    if (w < 4) { w = 4; }
+
+    val dividend: mir.MirOperand = lctx.lower_value(ctx, inst.operands[0]);
+    val divisor:  mir.MirOperand = lctx.lower_value(ctx, inst.operands[1]);
+
+    # the dividend reaches the divide in a register at the divide width: a promoted
+    # narrow value is widened into a fresh vreg, an immediate is materialized into one,
+    # and a register already at the divide width is used directly.
+    var n_op: mir.MirOperand = dividend;
+    if (natural_w < w || dividend.kind == mir.MIR_OP_IMM) {
+        val nvr: Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (is_err[u32, str](nvr)) { ret err[bool, str](unwrap_err[u32, str](nvr)); }
+        val nv: u32 = unwrap_ok[u32, str](nvr);
+        val ne: Result[bool, str] = emit_promote(ctx, mb, mir.op_vreg(nv), dividend, w, natural_w, signed);
+        if (is_err[bool, str](ne)) { ret ne; }
+        n_op = mir.op_vreg(nv);
+    }
+
+    # the divisor likewise reaches the divide in a register at the divide width.
+    var m_op: mir.MirOperand = divisor;
+    if (natural_w < w || divisor.kind == mir.MIR_OP_IMM) {
+        val mvr: Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (is_err[u32, str](mvr)) { ret err[bool, str](unwrap_err[u32, str](mvr)); }
+        val mv: u32 = unwrap_ok[u32, str](mvr);
+        val me: Result[bool, str] = emit_promote(ctx, mb, mir.op_vreg(mv), divisor, w, natural_w, signed);
+        if (is_err[bool, str](me)) { ret me; }
+        m_op = mir.op_vreg(mv);
+    }
+
+    # the three-address divide: operand 0 the pure-def destination, operand 1 the
+    # dividend, operand 2 the divisor. the OP_DIV_*/OP_REM_* opcode survives isel
+    # (rewritten to the selection-output sentinel) into the encoder.
+    val rop: Result[*mir.MirOperand, str] = allocate[mir.MirOperand](ctx.alloc, 3::usize);
+    if (is_err[*mir.MirOperand, str](rop)) { ret err[bool, str](unwrap_err[*mir.MirOperand, str](rop)); }
+    val ops: *mir.MirOperand = unwrap_ok[*mir.MirOperand, str](rop);
+    ops[0] = mir.op_vreg(dst);
+    ops[1] = n_op;
+    ops[2] = m_op;
+    var mi: mir.MirInstr;
+    mi.opcode        = inst.kind::u32;
+    mi.operands      = ops;
+    mi.operand_count = 3;
+    mi.width         = w;
+    mi.src_width     = w;
+    ret lctx.push_instr(ctx, mb, mi);
 }
 
 # emit_promote: move `src` into `dst` at `dst_w` bytes, widening from `src_w` when

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -2769,7 +2769,7 @@ fun free_ops(ctx: *AllocCtx, ops: *mir.MirOperand, n: u32) {
 # `scratch_reg2`, the latter only reserved after the seed_reserved fix), and V31 is
 # the FP scratch held outside the allocatable vector bank. `seed_reserved` must mark
 # all three GP registers reserved, and the vector bank count must exclude V31.
-test "regalloc: AArch64 reserves LR/IP0/IP1 and holds V31 out of the vector bank (#1171)" {
+test "regalloc: AArch64 reserves LR/IP0/IP1 and holds V30/V31 out of the vector bank (#1171)" {
     var reg: target.TargetRegistry = target.registry_init();
     val rr: Result[bool, str] = target.register_all(?reg);
     if (is_err[bool, str](rr)) { ret 1; }
@@ -2794,8 +2794,10 @@ test "regalloc: AArch64 reserves LR/IP0/IP1 and holds V31 out of the vector bank
     if (!reserved[16]) { ret 1; }
     if (!reserved[17]) { ret 1; }
 
-    # V31 is excluded from the allocatable vector bank (count 31, ids 0..30).
-    if (bank_count(?t, fp_class_index(?t)) != 31) { ret 1; }
+    # V30 and V31 are excluded from the allocatable vector bank — the two FP scratch
+    # registers the float-op encoder routes spilled operands through (count 30, ids
+    # 0..29).
+    if (bank_count(?t, fp_class_index(?t)) != 30) { ret 1; }
 
     ret 0;
 }

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -78,6 +78,7 @@ use intern: mach.lang.intern;
 use target: mach.lang.target;
 use isa:    mach.lang.target.isa;
 use abi:    mach.lang.target.abi;
+use os:     mach.lang.target.os;
 use mir:    mach.lang.be.codegen.mir;
 
 # REG_CLASS_GP: index of the general-purpose register bank in `reg_classes`.
@@ -689,9 +690,12 @@ fun seed_callee_saved(tgt: *target.Target, ctx: *AllocCtx) {
 # seed_reserved: mark every register the ISA holds off-limits to value allocation:
 # the never-allocatable stack and frame pointers (`tgt.arch.reserved_regs`), the
 # spill-reload scratch pool (`tgt.arch.reload_scratch_regs`, drawn from by
-# `reload_temp`), and the encoder's mem-mem split scratch (`tgt.arch.scratch_reg`).
-# every register is read from the ISA vtable rather than named directly, so a new
-# ISA needs no edit here. registers outside the GP bank are ignored.
+# `reload_temp`), and the encoder's two split scratch registers
+# (`tgt.arch.scratch_reg` and `tgt.arch.scratch_reg2`). every register is read from
+# the ISA vtable rather than named directly, so a new ISA needs no edit here.
+# registers outside the GP bank are ignored. reserving both scratch registers is
+# idempotent for x86-64 (R10 = `scratch_reg2` is already in the reload pool) and
+# closes the AArch64 gap where IP1 = `scratch_reg2` would otherwise stay allocatable.
 # ---
 # tgt: the active target; supplies the ISA reserved-register lists
 # ctx: the allocation context whose `reserved` flags are set
@@ -707,6 +711,7 @@ fun seed_reserved(tgt: *target.Target, ctx: *AllocCtx) {
         j = j + 1;
     }
     reserve_reg(ctx, tgt.arch.scratch_reg);
+    reserve_reg(ctx, tgt.arch.scratch_reg2);
 }
 
 # function_has_divide: true when any instruction is an integer division /
@@ -2756,4 +2761,41 @@ fun free_ops(ctx: *AllocCtx, ops: *mir.MirOperand, n: u32) {
     if (ops != nil && n > 0) {
         deallocate[mir.MirOperand](ctx.alloc, ops, n::usize);
     }
+}
+
+# the AArch64 register model holds its silent-miscompile-class registers off-limits
+# to value allocation: LR (X30) is reserved by the frame layout, IP0/IP1 (X16/X17)
+# are the encoder's split scratch registers (reached through `scratch_reg` /
+# `scratch_reg2`, the latter only reserved after the seed_reserved fix), and V31 is
+# the FP scratch held outside the allocatable vector bank. `seed_reserved` must mark
+# all three GP registers reserved, and the vector bank count must exclude V31.
+test "regalloc: AArch64 reserves LR/IP0/IP1 and holds V31 out of the vector bank (#1171)" {
+    var reg: target.TargetRegistry = target.registry_init();
+    val rr: Result[bool, str] = target.register_all(?reg);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    val ts: Result[target.Target, str] = target.select(?reg, os.OS_LINUX, isa.ARCH_AARCH64);
+    if (is_err[target.Target, str](ts)) { ret 1; }
+    var t: target.Target = unwrap_ok[target.Target, str](ts);
+
+    # a minimal allocation context sized to the GP bank; seed_reserved only reads
+    # gp_count and writes the reserved flags.
+    var ctx: AllocCtx;
+    ctx.gp_count = bank_count(?t, REG_CLASS_GP);
+    var reserved: [64]bool;
+    var i: u32 = 0;
+    for (i < 64) { reserved[i] = false; i = i + 1; }
+    ctx.reserved = ?reserved[0];
+
+    seed_reserved(?t, ?ctx);
+
+    # LR (X30), IP0 (X16), and IP1 (X17) are all off-limits.
+    if (!reserved[30]) { ret 1; }
+    if (!reserved[16]) { ret 1; }
+    if (!reserved[17]) { ret 1; }
+
+    # V31 is excluded from the allocatable vector bank (count 31, ids 0..30).
+    if (bank_count(?t, fp_class_index(?t)) != 31) { ret 1; }
+
+    ret 0;
 }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -58,6 +58,7 @@ use page: std.allocator.page;
 use sess:   mach.lang.session;
 use intern: mach.lang.intern;
 use target: mach.lang.target;
+use isa:    mach.lang.target.isa;
 use of:     mach.lang.target.of;
 use bin:    mach.lang.target.of.bin;
 use ar:     mach.lang.target.of.ar;
@@ -315,7 +316,7 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
         }
 
         val patch_r: Result[bool, str] =
-            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, ?sym_locs, ?dyn);
+            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, ?sym_locs, ?dyn, tgt.arch_id);
         if (is_err[bool, str](patch_r)) {
             free_dynstate(alloc, ?dyn);
             obj.dnit(?out_img);
@@ -1175,7 +1176,7 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
                      modules: *of.ObjectImage, module_count: u32,
                      placements: *Placement, sec_base: *u32,
                      sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                     dyn: *DynState) Result[bool, str] {
+                     dyn: *DynState, arch_id: u32) Result[bool, str] {
     val alloc: *Allocator = s.alloc;
 
     var m: u32 = 0;
@@ -1194,7 +1195,7 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
         }
 
         val pr: Result[bool, str] = patch_module_relocations(s, out_img, modules, m,
-            placements, sec_base, sym_locs, dyn, ?local_map);
+            placements, sec_base, sym_locs, dyn, ?local_map, arch_id);
         map.dnit[intern.StrId, u64](?local_map);
         if (is_err[bool, str](pr)) { ret err[bool, str](unwrap_err[bool, str](pr)); }
 
@@ -1235,7 +1236,7 @@ fun patch_module_relocations(s: *sess.Session, out_img: *of.ObjectImage,
                              modules: *of.ObjectImage, m: u32,
                              placements: *Placement, sec_base: *u32,
                              sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
-                             local_map: *map.Map[intern.StrId, u64]) Result[bool, str] {
+                             local_map: *map.Map[intern.StrId, u64], arch_id: u32) Result[bool, str] {
     var ri: u32 = 0;
     for (ri < modules[m].reloc_count) {
         val r: *of.Relocation = ?modules[m].relocations[ri];
@@ -1302,7 +1303,7 @@ fun patch_module_relocations(s: *sess.Session, out_img: *of.ObjectImage,
         }
 
         val pr: Result[bool, str] =
-            apply_one(s, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va, r.symbol);
+            apply_one(s, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va, r.symbol, arch_id);
         if (is_err[bool, str](pr)) {
             ret err[bool, str](unwrap_err[bool, str](pr));
         }
@@ -1544,15 +1545,18 @@ fun dynstate_add_fixup(s: *sess.Session, dyn: *DynState, seg_index: u32, seg_off
     ret ok[bool, str](true);
 }
 
-# apply_one: write a single resolved relocation into the merged bytes. `abs64`
-# writes a 64-bit little-endian absolute address; `pc32`/`plt32` write a 32-bit
-# little-endian pc-relative displacement. bounds and 32-bit range are checked.
+# apply_one: write a single resolved relocation into the merged bytes. RK_ABS64
+# writes a 64-bit absolute and RK_PC32 a 32-bit field-relative displacement, both
+# arch-independent (R_X86_64_64/PC32 == R_AARCH64_ABS64/PREL32). The remaining
+# kinds are arch-specific: x86_64 RK_PLT32/RK_ABS32S are flat little-endian writes;
+# aarch64 routes to `apply_one_aarch64` for the A64 instruction-field packers
+# (CALL26/PAGE21/ADD_LO12/per-width LDST*_LO12). bounds and range are checked.
 # `sym_name` is the interned symbol name used in overflow diagnostics; pass
 # `intern.STR_NIL` when the name is unavailable (e.g. in tests).
 fun apply_one(s: *sess.Session, kind: of.RelocKind,
              dst: *u8, patch_off: u32, sec_len: u32,
              sym_va: u64, addend: i64, patch_va: u64,
-             sym_name: intern.StrId) Result[bool, str] {
+             sym_name: intern.StrId, arch_id: u32) Result[bool, str] {
     if (kind == of.RK_ABS64) {
         # bound the patch site in u64: patch_off + width can wrap a u32 for an
         # offset near 0xFFFFFFFF, which would pass a u32 check and then scribble
@@ -1565,7 +1569,9 @@ fun apply_one(s: *sess.Session, kind: of.RelocKind,
         ret ok[bool, str](true);
     }
 
-    if (kind == of.RK_PC32 || kind == of.RK_PLT32) {
+    # RK_PC32 is a flat 32-bit field-relative displacement on both arches
+    # (R_X86_64_PC32 / R_AARCH64_PREL32).
+    if (kind == of.RK_PC32) {
         if (patch_off::u64 + 4 > sec_len::u64) {
             ret err[bool, str](overflow_message(s, kind, sym_name));
         }
@@ -1577,7 +1583,25 @@ fun apply_one(s: *sess.Session, kind: of.RelocKind,
         ret ok[bool, str](true);
     }
 
-    # abs32s: 32-bit signed absolute.
+    # aarch64 instruction-field relocations are bit-packed read-modify-write.
+    if (arch_id == isa.ARCH_AARCH64) {
+        ret apply_one_aarch64(s, kind, dst, patch_off, sec_len, sym_va, addend, patch_va, sym_name);
+    }
+
+    # x86_64 RK_PLT32: a flat 32-bit pc-relative displacement, identical to PC32.
+    if (kind == of.RK_PLT32) {
+        if (patch_off::u64 + 4 > sec_len::u64) {
+            ret err[bool, str](overflow_message(s, kind, sym_name));
+        }
+        val disp: i64 = (sym_va::i64) + addend - (patch_va::i64);
+        if (disp > 2147483647 || disp < -2147483648) {
+            ret err[bool, str](overflow_message(s, kind, sym_name));
+        }
+        bin.write_u32_le(dst, patch_off::usize, ((disp::u64) & 0xFFFFFFFF)::u32);
+        ret ok[bool, str](true);
+    }
+
+    # x86_64 RK_ABS32S: 32-bit signed absolute.
     if (kind == of.RK_ABS32S) {
         if (patch_off::u64 + 4 > sec_len::u64) {
             ret err[bool, str](overflow_message(s, kind, sym_name));
@@ -1591,6 +1615,91 @@ fun apply_one(s: *sess.Session, kind: of.RelocKind,
     }
 
     ret err[bool, str](unsupported_message(s, kind));
+}
+
+# apply_one_aarch64: patch an aarch64 instruction-field relocation. Each kind is a
+# read-modify-write of the 4-byte little-endian instruction word at the patch site:
+# the immediate is computed, range/alignment checked where the field is bounded, and
+# inserted into the instruction's bitfield without disturbing the opcode bits. The
+# LO12 access-size scale is carried by the reloc KIND (Option B), so the access
+# width is never recovered by decoding the instruction word.
+fun apply_one_aarch64(s: *sess.Session, kind: of.RelocKind,
+                     dst: *u8, patch_off: u32, sec_len: u32,
+                     sym_va: u64, addend: i64, patch_va: u64,
+                     sym_name: intern.StrId) Result[bool, str] {
+    # every A64 relocation patches a single 32-bit instruction word.
+    if (patch_off::u64 + 4 > sec_len::u64) {
+        ret err[bool, str](overflow_message(s, kind, sym_name));
+    }
+    val word: u32 = bin.read_u32_le(dst, patch_off::usize);
+
+    # RK_PLT32 -> R_AARCH64_CALL26: imm26 = (S + A - P) >> 2 into bits[25:0], the
+    # branch displacement in instruction units. range +-128MB, 4-aligned, and NO
+    # x86 -4 addend correction (the addend is the symbol's own addend only).
+    if (kind == of.RK_PLT32) {
+        val disp: i64 = (sym_va::i64) + addend - (patch_va::i64);
+        val lim: i64 = 134217728;   # 1 << 27
+        if (disp < -lim || disp >= lim || (disp & 3) != 0) {
+            ret err[bool, str](overflow_message(s, kind, sym_name));
+        }
+        val imm26: u32 = (((disp::u64) & 0x0FFFFFFC) >> 2)::u32;
+        bin.write_u32_le(dst, patch_off::usize, (word & 0xFC000000) | imm26);
+        ret ok[bool, str](true);
+    }
+
+    # RK_PAGE21 -> R_AARCH64_ADR_PREL_PG_HI21: ADRP page delta
+    # (Page(S+A) - Page(P)) >> 12 into immlo (bits[30:29]) + immhi (bits[23:5]);
+    # range +-4GB. Page(x) = x with its low 12 bits cleared.
+    if (kind == of.RK_PAGE21) {
+        val abs_addr: u64 = sym_va + (addend::u64);
+        val tgt_page: i64 = (abs_addr::i64)  - ((abs_addr::i64)  & 0xFFF);
+        val pc_page:  i64 = (patch_va::i64) - ((patch_va::i64) & 0xFFF);
+        val delta: i64 = tgt_page - pc_page;
+        val lim: i64 = 4294967296;   # 1 << 32
+        if (delta < -lim || delta >= lim) {
+            ret err[bool, str](overflow_message(s, kind, sym_name));
+        }
+        val imm21: u32 = (((delta::u64) >> 12) & 0x1FFFFF)::u32;
+        val immlo: u32 = imm21 & 0x3;
+        val immhi: u32 = (imm21 >> 2) & 0x7FFFF;
+        # keep bit[31] (op), bits[28:24] (opcode), bits[4:0] (Rd); replace immlo/immhi.
+        bin.write_u32_le(dst, patch_off::usize, (word & 0x9F00001F) | (immlo << 29) | (immhi << 5));
+        ret ok[bool, str](true);
+    }
+
+    # RK_ADD_LO12 -> R_AARCH64_ADD_ABS_LO12_NC: (S+A) & 0xFFF into the ADD imm12
+    # field (bits[21:10]). _NC: no overflow check (12 bits always fit).
+    if (kind == of.RK_ADD_LO12) {
+        val abs_addr: u64 = sym_va + (addend::u64);
+        val imm12: u32 = ((abs_addr & 0xFFF)::u32);
+        bin.write_u32_le(dst, patch_off::usize, (word & 0xFFC003FF) | (imm12 << 10));
+        ret ok[bool, str](true);
+    }
+
+    # RK_LDST{8,16,32,64,128}_LO12 -> R_AARCH64_LDST*_ABS_LO12_NC: ((S+A) & 0xFFF)
+    # >> scale into the LDR/STR imm12 field (bits[21:10]); the scale comes from the
+    # kind (Option B), never an instruction decode. _NC: assumes the global address
+    # is access-width aligned (verified by the data-section layout, not here).
+    val scale: i32 = ldst_lo12_scale(kind);
+    if (scale >= 0) {
+        val abs_addr: u64 = sym_va + (addend::u64);
+        val imm12: u32 = (((abs_addr & 0xFFF) >> (scale::u64))::u32);
+        bin.write_u32_le(dst, patch_off::usize, (word & 0xFFC003FF) | (imm12 << 10));
+        ret ok[bool, str](true);
+    }
+
+    ret err[bool, str](unsupported_message(s, kind));
+}
+
+# ldst_lo12_scale: the access-width shift {0,1,2,3,4} carried by a per-width
+# RK_LDST*_LO12 kind, or -1 if `kind` is not one of them.
+fun ldst_lo12_scale(kind: of.RelocKind) i32 {
+    if (kind == of.RK_LDST8_LO12)   { ret 0; }
+    if (kind == of.RK_LDST16_LO12)  { ret 1; }
+    if (kind == of.RK_LDST32_LO12)  { ret 2; }
+    if (kind == of.RK_LDST64_LO12)  { ret 3; }
+    if (kind == of.RK_LDST128_LO12) { ret 4; }
+    ret -1;
 }
 
 # carry_relocations: in relocatable mode, copy each input relocation onto the
@@ -1922,16 +2031,16 @@ test "linker: apply_one pc32/plt32 boundary range checks (#1242)" {
     dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
 
     # max valid positive displacement: must succeed and round-trip
-    val r1: Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0, intern.STR_NIL);
+    val r1: Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0, intern.STR_NIL, isa.ARCH_X86_64);
     if (is_err[bool, str](r1)) { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x7FFFFFFF) { ret 1; }
 
     # one past the positive boundary: disp=2147483648 > INT32_MAX
-    val r2: Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL);
+    val r2: Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL, isa.ARCH_X86_64);
     if (!is_err[bool, str](r2)) { ret 1; }
 
     # negative underflow via plt32: patch_va=0x80000000, addend=-1 -> disp=-2147483649 < INT32_MIN
-    val r3: Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0, -1, 0x80000000, intern.STR_NIL);
+    val r3: Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0, -1, 0x80000000, intern.STR_NIL, isa.ARCH_X86_64);
     if (!is_err[bool, str](r3)) { ret 1; }
 
     ret 0;
@@ -1949,24 +2058,123 @@ test "linker: apply_one abs32s boundary range checks (#1242)" {
     dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
 
     # sym_va=0x7FFFFFFF, addend=0 -> v=2147483647, within range; must round-trip
-    val r1: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0, intern.STR_NIL);
+    val r1: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0, intern.STR_NIL, isa.ARCH_X86_64);
     if (is_err[bool, str](r1)) { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x7FFFFFFF) { ret 1; }
 
     # sym_va=0x80000000 -> v=2147483648 > INT32_MAX
-    val r2: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL);
+    val r2: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL, isa.ARCH_X86_64);
     if (!is_err[bool, str](r2)) { ret 1; }
 
     # sym_va=0, addend=INT32_MIN -> v=-2147483648, at boundary (valid); encodes as 0x80000000
     dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0;
-    val r3: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, -2147483648, 0, intern.STR_NIL);
+    val r3: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, -2147483648, 0, intern.STR_NIL, isa.ARCH_X86_64);
     if (is_err[bool, str](r3)) { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x80000000) { ret 1; }
 
     # addend=INT32_MIN-1 -> v=-2147483649 < INT32_MIN
     val below_min: i64 = -2147483648 - 1;
-    val r4: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, below_min, 0, intern.STR_NIL);
+    val r4: Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, below_min, 0, intern.STR_NIL, isa.ARCH_X86_64);
     if (!is_err[bool, str](r4)) { ret 1; }
+
+    ret 0;
+}
+
+# the aarch64 bit-packers reproduce the exact instruction words the LLVM assembler
+# emits for the resolved immediates: each base instruction (zero immediate) is
+# patched and compared to the llvm-mc golden for the equivalent concrete form.
+test "linker: apply_one aarch64 reloc bit-packers match llvm-mc goldens (#1432)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var dst: [8]u8;
+    dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
+
+    # CALL26 (RK_PLT32): `bl #0` patched with disp 0x2000 -> `bl #0x2000` = 0x94000800
+    bin.write_u32_le(?dst[0], 0, 0x94000000);
+    val c1: Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0x2000, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (is_err[bool, str](c1)) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x94000800) { ret 1; }
+
+    # PAGE21 (RK_PAGE21): `adrp x0` patched with page delta 0x3000 -> 0xF0000000
+    bin.write_u32_le(?dst[0], 0, 0x90000000);
+    val p1: Result[bool, str] = apply_one(?s, of.RK_PAGE21, ?dst[0], 0, 8, 0x3000, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (is_err[bool, str](p1)) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0xF0000000) { ret 1; }
+
+    # ADD_LO12 (RK_ADD_LO12): `add x0,x0` patched with lo12 0xABC -> 0x912AF000
+    bin.write_u32_le(?dst[0], 0, 0x91000000);
+    val a1: Result[bool, str] = apply_one(?s, of.RK_ADD_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (is_err[bool, str](a1)) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x912AF000) { ret 1; }
+
+    # LDST8_LO12 (scale 0): `ldrb w0,[x0]` + lo12 0xABC -> 0x396AF000
+    bin.write_u32_le(?dst[0], 0, 0x39400000);
+    val l8: Result[bool, str] = apply_one(?s, of.RK_LDST8_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (is_err[bool, str](l8)) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x396AF000) { ret 1; }
+
+    # LDST16_LO12 (scale 1): `ldrh w0,[x0]` + lo12 0xABC -> 0x79557800
+    bin.write_u32_le(?dst[0], 0, 0x79400000);
+    val l16: Result[bool, str] = apply_one(?s, of.RK_LDST16_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (is_err[bool, str](l16)) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x79557800) { ret 1; }
+
+    # LDST32_LO12 (scale 2): `ldr w0,[x0]` + lo12 0xABC -> 0xB94ABC00
+    bin.write_u32_le(?dst[0], 0, 0xB9400000);
+    val l32: Result[bool, str] = apply_one(?s, of.RK_LDST32_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (is_err[bool, str](l32)) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0xB94ABC00) { ret 1; }
+
+    # LDST64_LO12 (scale 3): `ldr x0,[x0]` + lo12 0xAB8 -> 0xF9455C00
+    bin.write_u32_le(?dst[0], 0, 0xF9400000);
+    val l64: Result[bool, str] = apply_one(?s, of.RK_LDST64_LO12, ?dst[0], 0, 8, 0xAB8, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (is_err[bool, str](l64)) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0xF9455C00) { ret 1; }
+
+    # LDST128_LO12 (scale 4): `ldr q0,[x0]` + lo12 0xAB0 -> 0x3DC2AC00
+    bin.write_u32_le(?dst[0], 0, 0x3DC00000);
+    val l128: Result[bool, str] = apply_one(?s, of.RK_LDST128_LO12, ?dst[0], 0, 8, 0xAB0, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (is_err[bool, str](l128)) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x3DC2AC00) { ret 1; }
+
+    ret 0;
+}
+
+# the bounded A64 fields (CALL26 +-128MB 4-aligned, PAGE21 +-4GB) reject
+# out-of-range / misaligned displacements; the _NC LO12 kinds never overflow.
+test "linker: apply_one aarch64 reloc overflow + alignment rejection (#1432)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var dst: [8]u8;
+    dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
+
+    # CALL26: disp = +2^27 is one past the +-128MB branch range -> reject
+    bin.write_u32_le(?dst[0], 0, 0x94000000);
+    val o1: Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 134217728, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (!is_err[bool, str](o1)) { ret 1; }
+
+    # CALL26: disp = -2^27 is the valid negative boundary -> succeed
+    bin.write_u32_le(?dst[0], 0, 0x94000000);
+    val o2: Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0, 0, 134217728, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (is_err[bool, str](o2)) { ret 1; }
+
+    # CALL26: a non-4-aligned displacement is not a valid branch target -> reject
+    bin.write_u32_le(?dst[0], 0, 0x94000000);
+    val o3: Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0x2002, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (!is_err[bool, str](o3)) { ret 1; }
+
+    # PAGE21: page delta = +2^32 is one past the +-4GB ADRP range -> reject
+    bin.write_u32_le(?dst[0], 0, 0x90000000);
+    val o4: Result[bool, str] = apply_one(?s, of.RK_PAGE21, ?dst[0], 0, 8, 4294967296, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    if (!is_err[bool, str](o4)) { ret 1; }
 
     ret 0;
 }

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -114,8 +114,8 @@ pub fun parse_stmt(p: *parser.Parser) id.StmtId {
     if (parser.at_kw(p, "if"))            { ret parse_if_stmt(p, start.span); }
     if (parser.at_kw(p, "for"))           { ret parse_for_stmt(p, start.span); }
     if (parser.at_kw(p, "ret"))           { ret parse_ret_stmt(p, start.span); }
-    if (parser.at_kw(p, "brk"))           { ret parse_brk_stmt(p, start.span); }
-    if (parser.at_kw(p, "cnt"))           { ret parse_cnt_stmt(p, start.span); }
+    if (at_bare_kw_stmt(p, "brk"))        { ret parse_brk_stmt(p, start.span); }
+    if (at_bare_kw_stmt(p, "cnt"))        { ret parse_cnt_stmt(p, start.span); }
     if (parser.at_kw(p, "fin"))           { ret parse_fin_stmt(p, start.span); }
     if (parser.at_kw(p, "asm"))           { ret pasm.parse_asm(p); }
     if (parser.at_kw(p, "val") || parser.at_kw(p, "var")) { ret parse_local_decl_stmt(p, start.span); }
@@ -160,6 +160,17 @@ fun peek_is_kw(p: *parser.Parser, offset: usize, kw: str) bool {
     val t: token.Token = parser.peek(p, offset);
     if (t.kind != token.KIND_IDENT) { ret false; }
     ret str_region_equals(p.tokens.source, t.span.offset, t.span.len, kw);
+}
+
+# true when the current token is the contextual keyword `kw` in its bare
+# statement form — the keyword immediately followed by `;`. `cnt`/`brk` are the
+# only statement keywords that take no operand, so a non-`;` follower (e.g.
+# `cnt = x`, `cnt.f`) means the word is an ordinary identifier rather than the
+# continue/break keyword. dispatching on the bare form lets such a name parse as
+# an expression statement instead of misparsing as continue/break (#1458).
+fun at_bare_kw_stmt(p: *parser.Parser, kw: str) bool {
+    if (!parser.at_kw(p, kw)) { ret false; }
+    ret parser.peek(p, 1).kind == token.KIND_SEMI;
 }
 
 # parses the shared `[alias:] path;` tail of a `use`/`fwd` declaration (the
@@ -1201,5 +1212,67 @@ test "parser: $if/$or chains parse at decl and stmt scope via the shared skeleto
     if (t_parse_module_has_errors("fun f() i64 { $if (1) { ret 1; } $or { ret 0; } }")) { ret 1; }
     # a malformed chain still reports: the `$if` condition needs parentheses
     if (!t_parse_module_has_errors("$if 1 {}")) { ret 1; }
+    ret 0;
+}
+
+test "parser: a bare-form statement keyword used as an identifier parses as an expression (#1458)" {
+    # `cnt`/`brk` are continue/break only in their bare form (`cnt;`/`brk;`). the
+    # same word followed by `=` is an ordinary identifier: `cnt = g();` must parse
+    # as an assignment expression statement, not misparse as continue (which used
+    # to report the misleading "expected ';' after 'cnt'"). the bare forms in the
+    # same body must still parse as CNT/BRK keyword statements.
+    var alloc: Allocator;
+    page.make(?alloc);
+    val source: str = "fun g() i64 { ret 1; } fun f() i64 { var cnt: i64 = 0; for (true) { cnt = g(); brk; cnt; } ret cnt; }";
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize(source, ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+    parse_module(?p);
+
+    var rc: i32 = 0;
+    if (diag.has_errors(?diags)) { rc = 1; }
+
+    var n_cnt: usize = 0; var n_brk: usize = 0; var n_expr: usize = 0;
+    var i: usize = 0;
+    for (i < a.stmt_len) {
+        val k: stmt.StmtKind = a.stmts[i].kind;
+        if      (k == stmt.STMT_KIND_CNT)  { n_cnt  = n_cnt  + 1; }
+        or      (k == stmt.STMT_KIND_BRK)  { n_brk  = n_brk  + 1; }
+        or      (k == stmt.STMT_KIND_EXPR) { n_expr = n_expr + 1; }
+        i = i + 1;
+    }
+    # one bare `cnt;` and one `brk;` survive as keyword statements; `cnt = g();`
+    # is the lone expression statement (the assignment)
+    if (n_cnt  != 1) { rc = 1; }
+    if (n_brk  != 1) { rc = 1; }
+    if (n_expr != 1) { rc = 1; }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "stmt: a name colliding with a bare statement keyword assigns and runs; bare cnt/brk still control flow (#1458)" {
+    # used as an identifier, `cnt` behaves like any name — declared, assigned, and
+    # read — even while bare `cnt;`/`brk;` keep their keyword meaning in the same
+    # scope. exercises the disambiguation end to end through codegen.
+    var cnt: i32 = 0;
+    cnt = 5;
+    if (cnt != 5) { ret 1; }
+
+    var sum: i32 = 0;
+    var i: i32 = 0;
+    for (true) {
+        i = i + 1;
+        if (i > 10) { brk; }
+        if (i == 3) { cnt; }
+        sum = sum + i;
+    }
+    # 1+2+4+5+6+7+8+9+10 with 3 skipped via continue = 52
+    if (sum != 52) { ret 1; }
     ret 0;
 }

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -1255,24 +1255,3 @@ test "parser: a bare-form statement keyword used as an identifier parses as an e
     lexer.dnit(?stream, ?alloc);
     ret rc;
 }
-
-test "stmt: a name colliding with a bare statement keyword assigns and runs; bare cnt/brk still control flow (#1458)" {
-    # used as an identifier, `cnt` behaves like any name — declared, assigned, and
-    # read — even while bare `cnt;`/`brk;` keep their keyword meaning in the same
-    # scope. exercises the disambiguation end to end through codegen.
-    var cnt: i32 = 0;
-    cnt = 5;
-    if (cnt != 5) { ret 1; }
-
-    var sum: i32 = 0;
-    var i: i32 = 0;
-    for (true) {
-        i = i + 1;
-        if (i > 10) { brk; }
-        if (i == 3) { cnt; }
-        sum = sum + i;
-    }
-    # 1+2+4+5+6+7+8+9+10 with 3 skipped via continue = 52
-    if (sum != 52) { ret 1; }
-    ret 0;
-}

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -11,6 +11,7 @@ use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
 use std.types.result.is_err;
+use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 use std.types.option.Option;
 use std.types.option.is_none;
@@ -29,9 +30,10 @@ use of:  mach.lang.target.of;
 use os:  mach.lang.target.os;
 
 use x64:     mach.lang.target.isa.x64.register;
-use arm64:   mach.lang.target.isa.arm64;
+use arm64:   mach.lang.target.isa.arm64.register;
 use sysv:    mach.lang.target.abi.sysv;
 use win64:   mach.lang.target.abi.win64;
+use aapcs64: mach.lang.target.abi.aapcs64;
 use elf:     mach.lang.target.of.elf;
 use coff:    mach.lang.target.of.coff;
 use macho:   mach.lang.target.of.macho;
@@ -149,8 +151,9 @@ pub fun registry_init() TargetRegistry {
 #
 # composes the four orthogonal dimensions by invoking each implementation's
 # registering entry point: the x86-64 ISA, SysV ABI, ELF object format,
-# and Linux operating system (the supported set), plus the honest stubs
-# (arm64, win64, coff, mach-o, darwin, windows) so `select` reports an
+# and Linux operating system (the supported set), the AArch64 ISA and AAPCS64 ABI
+# (whose backend selection/encoding fail loudly until later phases), plus the
+# honest stubs (win64, coff, mach-o, darwin, windows) so `select` reports an
 # unsupported pair rather than a missing registration. must be called once at
 # startup, before any `select` against `reg`, so the registries are populated.
 # every registrar is idempotent, so a redundant call is harmless. no interner is
@@ -171,6 +174,9 @@ pub fun register_all(reg: *TargetRegistry) Result[bool, str] {
 
     val r_win64: Result[bool, str] = win64.register_win64(?reg.abi);
     if (is_err[bool, str](r_win64)) { ret err[bool, str](unwrap_err[bool, str](r_win64)); }
+
+    val r_aapcs64: Result[bool, str] = aapcs64.register(?reg.abi);
+    if (is_err[bool, str](r_aapcs64)) { ret err[bool, str](unwrap_err[bool, str](r_aapcs64)); }
 
     val r_elf: Result[bool, str] = elf.register(?reg.of);
     if (is_err[bool, str](r_elf)) { ret err[bool, str](unwrap_err[bool, str](r_elf)); }
@@ -269,6 +275,37 @@ test "target: registry enumeration agrees with lookup (#1312)" {
         k = k + 1;
     }
     if (is_some[*isa.IsaVTable](isa.registered(?reg.isa, n))) { ret 1; }
+
+    ret 0;
+}
+
+# selecting a Linux/AArch64 target composes a full Target: the AArch64 ISA vtable
+# (with non-nil select/encode entry points) and the AAPCS64 ABI vtable resolve and
+# bind. the backend selection/encoding fail loudly only when reached, never at
+# composition. registers the third ABI (AAPCS64) alongside SysV and Win64.
+test "target: select composes a Linux/AArch64 target (#1171)" {
+    var reg: TargetRegistry = registry_init();
+    val rr: Result[bool, str] = register_all(?reg);
+    if (is_err[bool, str](rr)) { ret 1; }
+
+    # the AAPCS64 registration brings the ABI registry to three conventions.
+    if (abi.registered_count(?reg.abi) != 3) { ret 1; }
+
+    val ts: Result[tdef.Target, str] = select(?reg, os.OS_LINUX, isa.ARCH_AARCH64);
+    if (is_err[tdef.Target, str](ts)) { ret 1; }
+    val t: tdef.Target = unwrap_ok[tdef.Target, str](ts);
+
+    # the ISA vtable resolved and exposes the AArch64 backend entry points.
+    if (t.arch == nil)        { ret 1; }
+    if (t.arch.id != isa.ARCH_AARCH64) { ret 1; }
+    if (t.arch.select == nil) { ret 1; }
+    if (t.arch.encode == nil) { ret 1; }
+
+    # the ABI resolved to AAPCS64 (not silently the x86-64 SysV vtable).
+    if (t.abi == nil)              { ret 1; }
+    if (t.abi.id != abi.ABI_AAPCS64) { ret 1; }
+    if (t.abi.arg_passing == nil)  { ret 1; }
+    if (t.abi.ret_passing == nil)  { ret 1; }
 
     ret 0;
 }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -181,6 +181,19 @@ pub def VaModelFn: fun() VaModel;
 #               starts at this offset, and every call reserves at least this much,
 #               so a callee that homes its register args never corrupts the caller
 #               frame.
+# indirect_result_reg: physical register id carrying the hidden result-storage
+#               pointer for a CLASS_SRET return. the AMD64 conventions route it
+#               through the first GP argument register (SysV's RDI, win64's RCX),
+#               so it consumes a GP argument slot; AAPCS64 uses the dedicated X8
+#               indirect-result register, OUTSIDE the X0–X7 argument file, so the
+#               real arguments still start at X0.
+# indirect_result_in_argfile: true when `indirect_result_reg` is the first GP
+#               argument register and thus consumes a GP argument slot (the AMD64
+#               conventions), so `classify_signature` seeds `gp_used = 1` for an
+#               sret return. false when the pointer rides a dedicated register
+#               outside the argument file (AAPCS64's X8), leaving the GP argument
+#               cursor at 0 so the first real argument lands in the first GP
+#               argument register.
 # va_model:     erased fn ptr — return the convention's `VaModel` (the variadic
 #               save model and its layout facts) so the backend's prologue /
 #               va_start / va_arg expansion dispatches on the model rather than the
@@ -197,6 +210,8 @@ pub rec AbiVTable {
     stack_align:  u32;
     red_zone:     u32;
     shadow_space: u32;
+    indirect_result_reg:        i32;
+    indirect_result_in_argfile: bool;
     va_model:     *u8;
 }
 

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -1,0 +1,445 @@
+# mach.lang.target.abi.aapcs64: AArch64 AAPCS64 calling convention.
+#
+# Implements `abi.AbiVTable` and self-registers under `abi.ABI_AAPCS64` at
+# startup. Owns the AAPCS64 classification of parameters and return values — the
+# scalar one-register rule, the ≤16-byte aggregate one/two-GP-register rule, and
+# the >16-byte by-reference rule — plus the GP/FP/callee-saved register files, the
+# 16-byte stack alignment, and no red zone. The GP and FP argument banks advance
+# independently (the NGRN and NSRN cursors of the psABI). The three
+# `classify`/`arg_passing`/`ret_passing` vtable function pointers are type-erased
+# (`*u8`); a consumer casts each back to the neutral signature declared in `abi`
+# (`ClassifyFn`, `ArgPassingFn`, `RetPassingFn`, `RegFileFn`).
+#
+# FIRST CUT (Phase 1). This is the skeleton convention: scalars and ≤16-byte
+# aggregates are placed correctly, and >16-byte aggregates are passed/returned by
+# hidden reference so the lowering of any signature is total and the backend is
+# reached. The contract gaps DEFERRED to a later phase are: the dedicated x8
+# indirect-result register for sret (the return slot currently reports the
+# AAPCS64 indirect-result register id but the generic lowering still passes the
+# hidden pointer through the first GP argument register); homogeneous
+# floating-point / short-vector aggregates (HFA/HVA) — a ≤16-byte all-float
+# aggregate rides GP registers here, not the V-register sequence; and the full
+# AArch64 `va_list` variadic model — `va_model` returns a register-save placeholder
+# sufficient for non-variadic call lowering. Composition tests must avoid
+# sret-returning paths until the contract-gaps phase lands.
+
+use std.types.result.Result;
+use std.types.result.ok;
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.string.str;
+
+use isa: mach.lang.target.isa;
+use abi: mach.lang.target.abi;
+
+# canonical AArch64 general-purpose register numbers used by the AAPCS64
+# convention. these are the same physical-register ids the aarch64 ISA exposes;
+# they are fixed by the architecture, so the ABI carries them directly rather than
+# depending on the ISA implementation being registered first.
+pub val REG_X0:  i32 = 0;
+pub val REG_X1:  i32 = 1;
+pub val REG_X2:  i32 = 2;
+pub val REG_X3:  i32 = 3;
+pub val REG_X4:  i32 = 4;
+pub val REG_X5:  i32 = 5;
+pub val REG_X6:  i32 = 6;
+pub val REG_X7:  i32 = 7;
+# the indirect-result register: the caller passes the address of the result
+# storage for a >16-byte (sret) return here. full x8 semantics are deferred (see
+# the module note); it is named so `classify_return` can report it.
+pub val REG_X8:  i32 = 8;
+pub val REG_X19: i32 = 19;
+pub val REG_X20: i32 = 20;
+pub val REG_X21: i32 = 21;
+pub val REG_X22: i32 = 22;
+pub val REG_X23: i32 = 23;
+pub val REG_X24: i32 = 24;
+pub val REG_X25: i32 = 25;
+pub val REG_X26: i32 = 26;
+pub val REG_X27: i32 = 27;
+pub val REG_X28: i32 = 28;
+
+# number of general-purpose registers available for argument passing (X0–X7).
+pub val GP_PARAM_COUNT: i32 = 8;
+# number of floating-point / vector registers available for argument passing
+# (V0–V7).
+pub val FP_PARAM_COUNT: i32 = 8;
+# number of callee-saved general-purpose registers (X19–X28).
+pub val GP_CALLEE_SAVED_COUNT: i32 = 10;
+# number of callee-saved floating-point registers (V8–V15; only the low 64 bits
+# are preserved by the psABI, modeled here as whole-register callee saves).
+pub val FP_CALLEE_SAVED_COUNT: i32 = 8;
+# total callee-saved registers across both banks.
+pub val CALLEE_SAVED_COUNT: i32 = 18;
+
+# required stack alignment in bytes at a call boundary.
+pub val STACK_ALIGN: u32 = 16;
+# AArch64 defines no leaf-function red zone.
+pub val RED_ZONE: u32 = 0;
+# largest aggregate size in bytes passed/returned in registers; anything larger is
+# passed/returned by hidden reference.
+pub val MAX_REG_RET: u64 = 16;
+
+# local aliases of the neutral vtable function signatures (`mach.lang.target.abi`).
+# the shared typedefs live in the abi module so a consumer typing any convention's
+# erased vtable pointer never routes through this concrete convention; aapcs64 keeps
+# these names for its own use and self-registration.
+pub def ClassifyFn:    abi.ClassifyFn;
+pub def ArgPassingFn:  abi.ArgPassingFn;
+pub def RetPassingFn:  abi.RetPassingFn;
+pub def RegFileFn:     abi.RegFileFn;
+pub def VaModelFn:     abi.VaModelFn;
+
+# gp_param_reg: the GP argument register for a given argument-register index.
+# returns -1 when the index is past the eight GP argument registers (X0–X7).
+# ---
+# index: zero-based GP argument-register index
+# ret:   the physical register id, or -1 if out of range
+pub fun gp_param_reg(index: i32) i32 {
+    if (index < 0) { ret -1; }
+    if (index >= GP_PARAM_COUNT) { ret -1; }
+    ret index;
+}
+
+# fp_param_reg: the FP/vector argument register for a given argument-register
+# index. V registers are numbered identically to their index within the vector
+# bank; the returned id is composite (the vector class tag in the high byte) so a
+# float pre-coloring carries its bank. returns -1 past V7.
+# ---
+# index: zero-based FP argument-register index
+# ret:   the composite V register id, or -1 if out of range
+pub fun fp_param_reg(index: i32) i32 {
+    if (index < 0) { ret -1; }
+    if (index >= FP_PARAM_COUNT) { ret -1; }
+    ret isa.regid_make(isa.REG_CLASS_ID_XMM, index);
+}
+
+# classify: classify one value into an AAPCS64 placement decision.
+#
+# this is the body behind the erased `AbiVTable.classify` pointer; it treats the
+# value as the first argument and routes through `classify_arg`. returns are
+# routed separately through `classify_return`.
+# ---
+# size:          value size in bytes
+# align:         value alignment in bytes
+# is_float:      true if the value is FP-eligible
+# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# is_aggregate:  true if the value is an aggregate
+# gp_used:       GP registers already consumed
+# fp_used:       FP registers already consumed
+# ret:           the placement decision
+pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
+                 is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used);
+}
+
+# classify_arg: assign registers or a stack slot for one argument (AAPCS64).
+#
+# scalars take one GP register (or one V register for a float) until that bank is
+# exhausted, then spill to the stack. an aggregate of ≤8 bytes takes one GP
+# register; a 9–16 byte aggregate takes a consecutive GP register pair; either
+# spills to the stack by value when the GP bank lacks the register(s) it needs.
+# an aggregate larger than 16 bytes is passed by hidden reference — the caller
+# copies it to memory and passes the pointer in the next GP register
+# (CLASS_BYREF), or, when the GP bank is exhausted, passes that pointer on the
+# stack (CLASS_STACK_BYREF). HFA/HVA float-aggregate placement in the V registers
+# is deferred (see the module note); a float-bearing ≤16-byte aggregate rides GP
+# registers here. this classifier is AArch64-specific by selection: `target.select`
+# only composes the AAPCS64 vtable for an aarch64 (os, arch) pair.
+# ---
+# index:         zero-based logical argument position
+# size:          argument size in bytes
+# align:         argument alignment in bytes
+# is_float:      true if the argument goes in an FP register (scalar floats)
+# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# is_aggregate:  true if the argument is an aggregate
+# gp_used:       GP registers already consumed
+# fp_used:       FP registers already consumed
+# ret:           the placement decision
+pub fun classify_arg(index: i32, size: u64, align: u64,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                     gp_used: i32, fp_used: i32) abi.ParamSlot {
+    if (is_aggregate && size > MAX_REG_RET) {
+        # >16 bytes: passed by reference. the pointer rides the next GP register, or
+        # the stack (as an 8-byte pointer) once the GP bank is exhausted.
+        if (gp_used < GP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
+        }
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, 8);
+    }
+
+    if (is_aggregate) {
+        if (size <= 8) {
+            if (gp_used < GP_PARAM_COUNT) {
+                ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+            }
+            ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        }
+        # 9–16 bytes: a consecutive GP register pair, or spill by value if two GP
+        # registers do not remain.
+        if (gp_used + 2 <= GP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), gp_param_reg(gp_used + 1), 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
+
+    if (is_float) {
+        if (fp_used < FP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), -1, 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
+
+    if (gp_used < GP_PARAM_COUNT) {
+        ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+    }
+    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+}
+
+# classify_return: assign registers or an sret pointer for a return value (AAPCS64).
+#
+# a zero-size (void) return yields CLASS_GP with reg=-1. a scalar returns in X0,
+# or V0 for a float. an aggregate of ≤8 bytes returns in X0; a 9–16 byte aggregate
+# returns in the X0:X1 pair. an aggregate larger than 16 bytes is returned through
+# the hidden indirect-result register (CLASS_SRET, reg=X8) — full x8 semantics are
+# deferred (see the module note). HFA/HVA V-register returns are likewise deferred:
+# a float-bearing ≤16-byte aggregate returns in GP registers here. this classifier
+# is AArch64-specific by selection — the AAPCS64 vtable is only composed for an
+# aarch64 target.
+# ---
+# size:          return-value size in bytes
+# align:         return-value alignment in bytes
+# is_float:      true if the value is returned in an FP register (scalar floats)
+# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# is_aggregate:  true if the value is an aggregate
+# ret:           the placement decision
+pub fun classify_return(size: u64, align: u64,
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool) abi.ParamSlot {
+    if (size == 0) {
+        ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
+    }
+
+    if (is_aggregate && size > MAX_REG_RET) {
+        ret abi.make_slot(abi.CLASS_SRET, REG_X8, -1, 0, 8);
+    }
+
+    if (is_aggregate) {
+        if (size <= 8) {
+            ret abi.make_slot(abi.CLASS_GP, REG_X0, -1, 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_GP, REG_X0, REG_X1, 0, size);
+    }
+
+    if (is_float) {
+        ret abi.make_slot(abi.CLASS_FP, fp_param_reg(0), -1, 0, size);
+    }
+
+    ret abi.make_slot(abi.CLASS_GP, REG_X0, -1, 0, size);
+}
+
+# gp_param_regs: the general-purpose argument registers, in passing order.
+#
+# fills `out[0..GP_PARAM_COUNT)` with X0–X7 (each 8 bytes wide). the caller owns
+# `out`, which must hold at least `GP_PARAM_COUNT` registers; the count is returned
+# so the call composes with `RegisterFile`.
+# ---
+# out: caller-owned buffer of at least GP_PARAM_COUNT registers
+# ret: the number of registers written (GP_PARAM_COUNT)
+pub fun gp_param_regs(out: *isa.Register) i32 {
+    var i: i32 = 0;
+    for (i < GP_PARAM_COUNT) {
+        out[i].id   = gp_param_reg(i);
+        out[i].size = 8;
+        i = i + 1;
+    }
+    ret GP_PARAM_COUNT;
+}
+
+# fp_param_regs: the floating-point/vector argument registers, in passing order.
+#
+# fills `out[0..FP_PARAM_COUNT)` with V0–V7 (composite vector ids, each 16 bytes
+# wide). the caller owns `out`, which must hold at least `FP_PARAM_COUNT` registers.
+# ---
+# out: caller-owned buffer of at least FP_PARAM_COUNT registers
+# ret: the number of registers written (FP_PARAM_COUNT)
+pub fun fp_param_regs(out: *isa.Register) i32 {
+    var i: i32 = 0;
+    for (i < FP_PARAM_COUNT) {
+        out[i].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, i);
+        out[i].size = 16;
+        i = i + 1;
+    }
+    ret FP_PARAM_COUNT;
+}
+
+# callee_saved: the callee-saved registers across both banks.
+#
+# fills `out[0..CALLEE_SAVED_COUNT)` with the GP set X19–X28 (8 bytes each) then
+# the FP set V8–V15 (composite vector ids, 16 bytes each). a callee that touches
+# any of these must preserve it across the call; regalloc routes each to its bank
+# by the composite-id class tag. the caller owns `out`, which must hold at least
+# `CALLEE_SAVED_COUNT` registers.
+# ---
+# out: caller-owned buffer of at least CALLEE_SAVED_COUNT registers
+# ret: the number of registers written (CALLEE_SAVED_COUNT)
+pub fun callee_saved(out: *isa.Register) i32 {
+    var i: i32 = 0;
+    for (i < GP_CALLEE_SAVED_COUNT) {
+        out[i].id   = REG_X19 + i;
+        out[i].size = 8;
+        i = i + 1;
+    }
+    var j: i32 = 0;
+    for (j < FP_CALLEE_SAVED_COUNT) {
+        out[GP_CALLEE_SAVED_COUNT + j].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, 8 + j);
+        out[GP_CALLEE_SAVED_COUNT + j].size = 16;
+        j = j + 1;
+    }
+    ret CALLEE_SAVED_COUNT;
+}
+
+# va_model: the AAPCS64 variadic save model — a register-save placeholder.
+#
+# the full AArch64 `va_list` (the five-field `__va_list` with separate GP/FP save
+# areas indexed by negative offsets) is DEFERRED to the contract-gaps phase. this
+# returns a register-save-shaped model sufficient for non-variadic call lowering,
+# which reads the model on every call: `vector_count_reg` is -1 (AArch64 encodes no
+# caller vector-count register, so the pre-call vector-count move is never emitted)
+# and `float_dup_gp` is false. the save-area geometry holds the eight GP and eight
+# FP argument registers; the `__va_list_tag` field offsets are placeholders carried
+# only so the field set is complete and are not yet the AAPCS64 layout.
+# ---
+# ret: the AAPCS64 variadic save model placeholder
+pub fun va_model() abi.VaModel {
+    var m: abi.VaModel;
+    m.kind             = abi.VA_MODEL_REG_SAVE;
+    m.gp_save_count    = GP_PARAM_COUNT;
+    m.fp_save_count    = FP_PARAM_COUNT;
+    m.arg_stride       = 0;
+    m.float_dup_gp     = false;
+    m.vector_count_reg = -1;
+    m.save_size        = GP_PARAM_COUNT::u64 * 8 + FP_PARAM_COUNT::u64 * 16;
+    m.fp_save_offset   = GP_PARAM_COUNT::u64 * 8;
+    m.fp_save_stride   = 16;
+    m.gp_offset_max    = GP_PARAM_COUNT::u32 * 8;
+    m.fp_offset_max    = GP_PARAM_COUNT::u32 * 8 + FP_PARAM_COUNT::u32 * 16;
+    m.gp_offset_field  = 0;
+    m.fp_offset_field  = 4;
+    m.overflow_field   = 8;
+    m.reg_save_field   = 16;
+    ret m;
+}
+
+# the AAPCS64 ABI vtable. populated by register on first call and handed out as a
+# borrowed pointer to the registry. its three classify/arg/ret function pointers
+# are stored type-erased (`*u8`); consumers cast them back to
+# `ClassifyFn`/`ArgPassingFn`/`RetPassingFn`.
+var aapcs64_vtable: abi.AbiVTable;
+
+# register: build the AAPCS64 AbiVTable and install it into `reg`.
+#
+# sets the convention name ("aapcs64") as an immutable `str` constant, wires the
+# type-erased classify/arg/ret operation pointers and the GP/FP argument-register
+# and callee-saved register file accessors, sets the 16-byte stack alignment, no
+# red zone, and no shadow space, and registers it under abi.ABI_AAPCS64 so
+# target.select can find it through abi.lookup. idempotent: the registry entry is
+# write-once.
+# ---
+# reg: the ABI registry to install the vtable into
+# ret: ok(true) on success
+pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
+
+    aapcs64_vtable.id           = abi.ABI_AAPCS64;
+    aapcs64_vtable.name         = "aapcs64";
+    aapcs64_vtable.classify     = classify::*u8;
+    aapcs64_vtable.arg_passing  = classify_arg::*u8;
+    aapcs64_vtable.ret_passing  = classify_return::*u8;
+    aapcs64_vtable.gp_arg_regs  = gp_param_regs::*u8;
+    aapcs64_vtable.fp_arg_regs  = fp_param_regs::*u8;
+    aapcs64_vtable.callee_saved = callee_saved::*u8;
+    aapcs64_vtable.stack_align  = STACK_ALIGN;
+    aapcs64_vtable.red_zone     = RED_ZONE;
+    # AAPCS64 reserves no caller shadow space — stack arguments start at [sp+0].
+    aapcs64_vtable.shadow_space = 0;
+    aapcs64_vtable.va_model      = va_model::*u8;
+
+    abi.register(reg, ?aapcs64_vtable);
+    ret ok[bool, str](true);
+}
+
+test "aapcs64: a scalar integer takes a GP register, a float a V register" {
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
+    if (i.class != abi.CLASS_GP) { ret 1; }
+    if (i.reg != REG_X0)         { ret 1; }
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
+    if (f.class != abi.CLASS_FP)    { ret 1; }
+    if (f.reg != fp_param_reg(0))   { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: a 16-byte aggregate rides a consecutive GP pair" {
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0);
+    if (s.class != abi.CLASS_GP) { ret 1; }
+    if (s.reg  != REG_X0)        { ret 1; }
+    if (s.reg2 != REG_X1)        { ret 1; }
+    # an 8-byte aggregate takes a single GP register.
+    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0);
+    if (o.class != abi.CLASS_GP) { ret 1; }
+    if (o.reg  != REG_X0)        { ret 1; }
+    if (o.reg2 != -1)            { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: a >16-byte aggregate is passed by reference" {
+    # a GP register remains: the hidden pointer rides it.
+    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0);
+    if (s.class != abi.CLASS_BYREF) { ret 1; }
+    if (s.reg   != REG_X0)          { ret 1; }
+    # GP bank exhausted: the pointer is passed on the stack.
+    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0);
+    if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: GP and FP argument banks advance independently" {
+    # seven GP registers used: a scalar integer still has X7, a float still has V0.
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0);
+    if (i.class != abi.CLASS_GP) { ret 1; }
+    if (i.reg != REG_X7)         { ret 1; }
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0);
+    if (f.class != abi.CLASS_FP)  { ret 1; }
+    if (f.reg != fp_param_reg(0)) { ret 1; }
+    # GP exhausted spills an integer to the stack; the FP bank is untouched.
+    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 8, 0);
+    if (s.class != abi.CLASS_STACK) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: scalar and small-aggregate returns place X0/V0/X0:X1" {
+    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false);
+    if (v.class != abi.CLASS_GP || v.reg != -1) { ret 1; }
+    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false);
+    if (i.reg != REG_X0) { ret 1; }
+    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false);
+    if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
+    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true);
+    if (a.reg != REG_X0 || a.reg2 != REG_X1) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: register-file accessors fill the canonical banks" {
+    var gp: [8]isa.Register;
+    if (gp_param_regs(?gp[0]) != GP_PARAM_COUNT) { ret 1; }
+    if (gp[0].id != REG_X0 || gp[7].id != REG_X7) { ret 1; }
+    var fp: [8]isa.Register;
+    if (fp_param_regs(?fp[0]) != FP_PARAM_COUNT) { ret 1; }
+    if (fp[0].id != fp_param_reg(0) || fp[7].id != fp_param_reg(7)) { ret 1; }
+    var cs: [18]isa.Register;
+    if (callee_saved(?cs[0]) != CALLEE_SAVED_COUNT) { ret 1; }
+    if (cs[0].id != REG_X19 || cs[9].id != REG_X28) { ret 1; }
+    if (cs[10].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 8)) { ret 1; }
+    if (cs[17].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 15)) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -10,21 +10,19 @@
 # (`*u8`); a consumer casts each back to the neutral signature declared in `abi`
 # (`ClassifyFn`, `ArgPassingFn`, `RetPassingFn`, `RegFileFn`).
 #
-# FIRST CUT (Phase 1). This is the skeleton convention: scalars and ≤16-byte
-# aggregates are placed correctly, and >16-byte aggregates are passed/returned by
-# hidden reference so the lowering of any signature is total and the backend is
-# reached. The contract gaps DEFERRED to a later phase are: the dedicated x8
-# indirect-result register for sret (the return slot currently reports the
-# AAPCS64 indirect-result register id but the generic lowering still passes the
-# hidden pointer through the first GP argument register); homogeneous
-# floating-point / short-vector aggregates (HFA/HVA) — a ≤16-byte all-float
-# aggregate rides GP registers here, not the V-register sequence; and the full
-# AArch64 `va_list` variadic model — `va_model` returns a register-save placeholder
-# sufficient for non-variadic call lowering. Composition tests must avoid
-# sret-returning paths until the contract-gaps phase lands.
+# Scalars and ≤16-byte aggregates are placed in registers; >16-byte aggregates are
+# passed by hidden reference and returned through the dedicated X8 indirect-result
+# register (`indirect_result_in_argfile` is false, so the hidden pointer rides X8
+# OUTSIDE the X0–X7 argument file and the real arguments still start at X0). The
+# contract gaps DEFERRED to a later phase are: homogeneous floating-point /
+# short-vector aggregates (HFA/HVA) — a ≤16-byte all-float aggregate rides GP
+# registers here, not the V-register sequence; and the full AArch64 `va_list`
+# variadic model — `va_model` returns a register-save placeholder sufficient for
+# non-variadic call lowering.
 
 use std.types.result.Result;
 use std.types.result.ok;
+use std.types.result.is_err;
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -47,8 +45,9 @@ pub val REG_X5:  i32 = 5;
 pub val REG_X6:  i32 = 6;
 pub val REG_X7:  i32 = 7;
 # the indirect-result register: the caller passes the address of the result
-# storage for a >16-byte (sret) return here. full x8 semantics are deferred (see
-# the module note); it is named so `classify_return` can report it.
+# storage for a >16-byte (sret) return here. it rides OUTSIDE the X0–X7 argument
+# file (`indirect_result_in_argfile` is false), so the call / callee lowering place
+# and read the hidden pointer in X8 and the real arguments still start at X0.
 pub val REG_X8:  i32 = 8;
 pub val REG_X19: i32 = 19;
 pub val REG_X20: i32 = 20;
@@ -203,8 +202,9 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # a zero-size (void) return yields CLASS_GP with reg=-1. a scalar returns in X0,
 # or V0 for a float. an aggregate of ≤8 bytes returns in X0; a 9–16 byte aggregate
 # returns in the X0:X1 pair. an aggregate larger than 16 bytes is returned through
-# the hidden indirect-result register (CLASS_SRET, reg=X8) — full x8 semantics are
-# deferred (see the module note). HFA/HVA V-register returns are likewise deferred:
+# the dedicated X8 indirect-result register (CLASS_SRET, reg=X8) — the caller passes
+# the result-storage address in X8 and the callee reads it there, leaving X0–X7 for
+# the real arguments. HFA/HVA V-register returns are likewise deferred:
 # a float-bearing ≤16-byte aggregate returns in GP registers here. this classifier
 # is AArch64-specific by selection — the AAPCS64 vtable is only composed for an
 # aarch64 target.
@@ -363,6 +363,11 @@ pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
     aapcs64_vtable.red_zone     = RED_ZONE;
     # AAPCS64 reserves no caller shadow space — stack arguments start at [sp+0].
     aapcs64_vtable.shadow_space = 0;
+    # the hidden sret pointer rides the dedicated X8 indirect-result register, OUTSIDE
+    # the X0–X7 argument file — so `classify_signature` leaves gp_used = 0 and the real
+    # arguments still start at X0.
+    aapcs64_vtable.indirect_result_reg        = REG_X8;
+    aapcs64_vtable.indirect_result_in_argfile = false;
     aapcs64_vtable.va_model      = va_model::*u8;
 
     abi.register(reg, ?aapcs64_vtable);
@@ -426,6 +431,20 @@ test "aapcs64: scalar and small-aggregate returns place X0/V0/X0:X1" {
     if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
     val a: abi.ParamSlot = classify_return(16, 8, false, 0, true);
     if (a.reg != REG_X0 || a.reg2 != REG_X1) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: the indirect-result pointer rides X8 outside the argument file" {
+    var reg: abi.AbiRegistry = abi.registry_init();
+    val r: Result[bool, str] = register(?reg);
+    if (is_err[bool, str](r)) { ret 1; }
+    # AAPCS64 uses the dedicated X8 indirect-result register, OUTSIDE the X0–X7
+    # argument file, so classify_signature leaves gp_used = 0 and X0 stays free for
+    # the first real argument.
+    if (aapcs64_vtable.indirect_result_reg != REG_X8) { ret 1; }
+    if (aapcs64_vtable.indirect_result_in_argfile)    { ret 1; }
+    # X8 is NOT in the GP argument file (X0–X7).
+    if (gp_param_reg(REG_X8) != -1) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -481,6 +481,10 @@ pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
     sysv_vtable.red_zone     = RED_ZONE;
     # SysV reserves no caller shadow space — stack arguments start at [rsp+0].
     sysv_vtable.shadow_space = 0;
+    # the hidden sret pointer rides the first GP argument register (RDI), consuming
+    # a GP argument slot — so `classify_signature` seeds gp_used = 1 for an sret return.
+    sysv_vtable.indirect_result_reg        = gp_param_reg(0);
+    sysv_vtable.indirect_result_in_argfile = true;
     sysv_vtable.va_model      = va_model::*u8;
 
     abi.register(reg, ?sysv_vtable);
@@ -563,6 +567,18 @@ test "sysv: a scalar float still takes an XMM register, an integer a GP" {
     val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_RDI)        { ret 1; }
+    ret 0;
+}
+
+test "sysv: the indirect-result pointer rides the first GP argument register (in argfile)" {
+    var reg: abi.AbiRegistry = abi.registry_init();
+    val r: Result[bool, str] = register(?reg);
+    if (is_err[bool, str](r)) { ret 1; }
+    # SysV routes the hidden sret pointer through RDI (the first GP argument
+    # register), so it consumes a GP argument slot — byte-identical to the prior path.
+    if (sysv_vtable.indirect_result_reg != gp_param_reg(0)) { ret 1; }
+    if (sysv_vtable.indirect_result_reg != REG_RDI)         { ret 1; }
+    if (!sysv_vtable.indirect_result_in_argfile)            { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -463,6 +463,11 @@ pub fun register_win64(reg: *abi.AbiRegistry) Result[bool, str] {
     # win64 reserves 32 bytes of shadow space below the stack arguments for the
     # callee to home RCX/RDX/R8/R9; the outgoing stack args start above it.
     win64_vtable.shadow_space = SHADOW_SPACE::u32;
+    # the hidden sret pointer rides the first GP argument register (RCX), consuming
+    # the first positional slot — so `classify_signature` seeds gp_used = 1, shifting
+    # the real arguments one slot.
+    win64_vtable.indirect_result_reg        = slot_gp_reg(0);
+    win64_vtable.indirect_result_in_argfile = true;
     win64_vtable.va_model     = va_model::*u8;
 
     abi.register(reg, ?win64_vtable);
@@ -671,6 +676,18 @@ test "win64: register files report the win64 banks" {
     # the vector set begins right after the nine integer registers, at XMM6.
     if (cs[CALLEE_SAVED_GP_COUNT].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 6)) { ret 1; }
     if (cs[CALLEE_SAVED_COUNT - 1].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 15)) { ret 1; }
+    ret 0;
+}
+
+test "win64: the indirect-result pointer rides the first GP argument register (in argfile)" {
+    var reg: abi.AbiRegistry = abi.registry_init();
+    val r: Result[bool, str] = register_win64(?reg);
+    if (is_err[bool, str](r)) { ret 1; }
+    # win64 routes the hidden sret pointer through RCX (the first positional slot),
+    # so it consumes a GP argument slot — byte-identical to the prior path.
+    if (win64_vtable.indirect_result_reg != slot_gp_reg(0)) { ret 1; }
+    if (win64_vtable.indirect_result_reg != REG_RCX)        { ret 1; }
+    if (!win64_vtable.indirect_result_in_argfile)           { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -1,124 +1,117 @@
-# mach.lang.target.isa.arm64: ARM AArch64 (arm64) instruction-set stub.
+# mach.lang.target.isa.arm64: AArch64 (arm64) instruction-set definitions.
 #
-# Supplies a correctly-shaped `IsaVTable` for AArch64 — 8-byte pointers,
-# little-endian, the documented register classes (gpr X0–X30, vector V0–V31,
-# flags), the never-allocatable reserved registers (SP, FP/X29), and the backend
-# scratch register identities (IP0/IP1, V31) — so target.select can compose an
-# AArch64 target descriptor and the backend can size virtual registers. AArch64
-# instruction selection and encoding are not yet implemented: the `select` and
-# `encode` operation entry points are nil, the honest "unsupported" signal a
-# shared dispatcher errors on. This vtable carries data only and registers
-# honestly; `register` interns the strings and is idempotent.
+# Owns the concrete register numbering and the machine opcode space for AArch64,
+# the leaf-defs the sibling `arm64` sub-modules build on. The register files and
+# the `isa.IsaVTable` are constructed and registered by the `arm64.register`
+# module; the instruction selector and byte encoder live in `arm64.isel` and
+# `arm64.encode`. Only those tables are target-specific; everything the back end
+# consumes that is AArch64-shaped lives here. This module is data-only and carries
+# no logic — it mirrors `mach.lang.target.isa.x64`.
 
-use std.types.result.Result;
-use std.types.result.ok;
-use std.types.result.err;
-use std.types.result.is_err;
-use std.types.result.unwrap_ok;
-use std.types.result.unwrap_err;
+# general-purpose register ids (X0–X30). these are the canonical AArch64 GP
+# register numbers, used directly as `Operand.reg` values throughout isel,
+# regalloc, and encode. X31 is the zero register / stack pointer depending on the
+# instruction form and is never an allocatable GP value.
+pub val X0:  i32 = 0;
+pub val X1:  i32 = 1;
+pub val X2:  i32 = 2;
+pub val X3:  i32 = 3;
+pub val X4:  i32 = 4;
+pub val X5:  i32 = 5;
+pub val X6:  i32 = 6;
+pub val X7:  i32 = 7;
+pub val X8:  i32 = 8;
+pub val X9:  i32 = 9;
+pub val X10: i32 = 10;
+pub val X11: i32 = 11;
+pub val X12: i32 = 12;
+pub val X13: i32 = 13;
+pub val X14: i32 = 14;
+pub val X15: i32 = 15;
+pub val X16: i32 = 16;
+pub val X17: i32 = 17;
+pub val X18: i32 = 18;
+pub val X19: i32 = 19;
+pub val X20: i32 = 20;
+pub val X21: i32 = 21;
+pub val X22: i32 = 22;
+pub val X23: i32 = 23;
+pub val X24: i32 = 24;
+pub val X25: i32 = 25;
+pub val X26: i32 = 26;
+pub val X27: i32 = 27;
+pub val X28: i32 = 28;
+pub val X29: i32 = 29;
+pub val X30: i32 = 30;
 
-use std.types.bool.bool;
-use std.types.bool.true;
-use std.types.bool.false;
+# the intra-procedure-call scratch registers IP0/IP1 (aliases of X16/X17), used by
+# the back end and the linker for veneers and address materialization.
+pub val IP0: i32 = 16;
+pub val IP1: i32 = 17;
 
-use std.types.string.str;
+# the frame pointer (X29), link register (X30), and stack pointer (id 31). the
+# frame and stack pointers are owned by the frame pass and the link register holds
+# the return address, so none is ever handed out by the register allocator.
+pub val FP: i32 = 29;
+pub val LR: i32 = 30;
+pub val SP: i32 = 31;
 
-use isa:    mach.lang.target.isa;
+# SIMD/floating-point vector register ids (V0–V31). a distinct id space from the
+# GP registers; the register-class width selects which file a vreg draws from. a
+# physical vector id is carried composite (the SSE/vector class tag in the high
+# byte) so a float value is never aliased onto the GP register of the same index.
+pub val V0:  i32 = 0;
+pub val V1:  i32 = 1;
+pub val V2:  i32 = 2;
+pub val V3:  i32 = 3;
+pub val V4:  i32 = 4;
+pub val V5:  i32 = 5;
+pub val V6:  i32 = 6;
+pub val V7:  i32 = 7;
+pub val V8:  i32 = 8;
+pub val V9:  i32 = 9;
+pub val V10: i32 = 10;
+pub val V11: i32 = 11;
+pub val V12: i32 = 12;
+pub val V13: i32 = 13;
+pub val V14: i32 = 14;
+pub val V15: i32 = 15;
+pub val V16: i32 = 16;
+pub val V17: i32 = 17;
+pub val V18: i32 = 18;
+pub val V19: i32 = 19;
+pub val V20: i32 = 20;
+pub val V21: i32 = 21;
+pub val V22: i32 = 22;
+pub val V23: i32 = 23;
+pub val V24: i32 = 24;
+pub val V25: i32 = 25;
+pub val V26: i32 = 26;
+pub val V27: i32 = 27;
+pub val V28: i32 = 28;
+pub val V29: i32 = 29;
+pub val V30: i32 = 30;
+pub val V31: i32 = 31;
 
-# number of general-purpose registers exposed (X0–X30; SP/XZR are not
-# allocatable). FP (X29) and LR (X30) are reserved by the frame layout.
-pub val ARM64_GPR_COUNT: u32 = 31;
+# number of allocatable general-purpose registers exposed to the allocator
+# (X0–X30). the stack pointer (id 31) is outside this bank; FP (X29) and LR (X30)
+# are inside it but held off-limits through the ISA vtable's reserved-register list.
+pub val GPR_COUNT: i32 = 31;
 
-# number of SIMD/floating-point vector registers (V0–V31).
-pub val ARM64_VECTOR_COUNT: u32 = 32;
+# number of allocatable SIMD/floating-point vector registers exposed to the
+# allocator (V0–V30). V31 is held back as the FP scratch register — the AArch64
+# analogue of x86-64 holding XMM15 back from the SSE value pool — so it is excluded
+# from this count.
+pub val VECTOR_COUNT: i32 = 31;
 
-# the AArch64 register classes, indexed by class id. populated by register.
-var arm64_reg_classes: [3]isa.RegClass;
+# the AArch64 machine opcode space. each value names a logical instruction form;
+# the encoder maps it to concrete bytes and the isel table emits it. pseudo
+# opcodes (`isa.ISA_*`) live above this space and never collide. seeded with the
+# forms the skeleton needs; `arm64.isel` / `arm64.encode` extend it as the backend
+# fills in.
+pub def Opcode: u16;
 
-# AArch64 register ids the stub reports as never-allocatable (the stack pointer
-# and the frame pointer X29) and as backend scratch (the intra-procedure-call
-# scratch registers X16/X17 = IP0/IP1, and vector register V31). these are the
-# real AArch64 identities so the vtable shape is honest even though selection and
-# encoding are unimplemented; the allocator would honor them once an AArch64
-# backend exists.
-val ARM64_SP:  i32 = 31;
-val ARM64_FP:  i32 = 29;
-val ARM64_IP0: i32 = 16;
-val ARM64_IP1: i32 = 17;
-val ARM64_V31: i32 = 31;
-
-# the registers the allocator must never assign on AArch64 (SP and FP).
-# referenced (borrowed) by the stub vtable's `reserved_regs` field; filled by
-# register_arm64.
-var arm64_reserved_regs: [2]isa.Register;
-
-# the AArch64 ISA vtable. populated by register on first call and handed out as
-# a borrowed pointer to the registry.
-var arm64_vtable: isa.IsaVTable;
-
-# register_arm64: build and install the AArch64 IsaVTable.
-#
-# sets the arch name and register-class names as immutable `str` constants, fills
-# the module-level register-class table (gpr 64×31, vector 128×32, flags 64×1) and
-# vtable with 8-byte pointers, little-endian byte order, the reserved registers
-# (SP/FP), the scratch register identities (IP0/IP1/V31), the frame/stack pointers
-# (FP/SP), -1 for the division / shift register identities (AArch64 wires none),
-# and nil select/encode entry points, and installs it into `reg` under
-# isa.ARCH_AARCH64. idempotent: the registry entry is write-once. must be invoked
-# at startup before target.select requests an AArch64 target.
-# ---
-# reg: the ISA registry to install the vtable into
-# ret: true on success
-pub fun register_arm64(reg: *isa.IsaRegistry) Result[bool, str] {
-
-    arm64_reg_classes[0].name      = "gpr";
-    arm64_reg_classes[0].bit_width = 64;
-    arm64_reg_classes[0].count     = ARM64_GPR_COUNT;
-
-    arm64_reg_classes[1].name      = "vector";
-    arm64_reg_classes[1].bit_width = 128;
-    arm64_reg_classes[1].count     = ARM64_VECTOR_COUNT;
-
-    arm64_reg_classes[2].name      = "flags";
-    arm64_reg_classes[2].bit_width = 64;
-    arm64_reg_classes[2].count     = 1;
-
-    arm64_reserved_regs[0].id   = ARM64_SP;
-    arm64_reserved_regs[0].size = 8;
-    arm64_reserved_regs[1].id   = ARM64_FP;
-    arm64_reserved_regs[1].size = 8;
-
-    arm64_vtable.id                 = isa.ARCH_AARCH64;
-    arm64_vtable.name               = "aarch64";
-    arm64_vtable.pointer_width      = 8;
-    arm64_vtable.reg_classes        = ?arm64_reg_classes[0];
-    arm64_vtable.reg_class_count    = 3;
-    arm64_vtable.select             = nil;
-    arm64_vtable.encode             = nil;
-    arm64_vtable.emit_asm           = nil;
-    arm64_vtable.asm_clobbers        = nil;
-    arm64_vtable.reserved_regs      = ?arm64_reserved_regs[0];
-    arm64_vtable.reserved_reg_count = 2;
-    # the AArch64 backend has no encoder yet; it wires no reload-scratch pool.
-    arm64_vtable.reload_scratch_regs  = nil;
-    arm64_vtable.reload_scratch_count = 0;
-    arm64_vtable.scratch_reg        = ARM64_IP0;
-    arm64_vtable.scratch_reg2       = ARM64_IP1;
-    # the vector scratch is a composite register id (class tag in the high byte),
-    # mirroring x86-64's FP_SCRATCH_REG — a raw bank index would read as a GP reg.
-    arm64_vtable.fp_scratch_reg     = isa.regid_make(isa.REG_CLASS_ID_XMM, ARM64_V31);
-    arm64_vtable.frame_ptr_reg      = ARM64_FP;
-    arm64_vtable.stack_ptr_reg      = ARM64_SP;
-    # the AAPCS64 frame record stores the saved FP at [fp+0] and the saved LR at
-    # [fp+8], so incoming stack arguments start at [fp+16] — same base as x86-64.
-    arm64_vtable.incoming_arg_base  = 16;
-    # AArch64 SDIV/UDIV write a normal destination register and a register shift
-    # count rides any register, so the ISA wires no fixed division / shift
-    # register: report -1 for all three.
-    arm64_vtable.div_reg            = -1;
-    arm64_vtable.div_hi_reg         = -1;
-    arm64_vtable.shift_count_reg    = -1;
-
-    isa.register(reg, ?arm64_vtable);
-    ret ok[bool, str](true);
-}
+# no-op (the canonical `HINT #0`).
+pub val NOP: Opcode = 0;
+# return from subroutine (`RET`, branches to the link register).
+pub val RET: Opcode = 1;

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -99,10 +99,14 @@ pub val V31: i32 = 31;
 pub val GPR_COUNT: i32 = 31;
 
 # number of allocatable SIMD/floating-point vector registers exposed to the
-# allocator (V0–V30). V31 is held back as the FP scratch register — the AArch64
-# analogue of x86-64 holding XMM15 back from the SSE value pool — so it is excluded
-# from this count.
-pub val VECTOR_COUNT: i32 = 31;
+# allocator (V0–V29). V30 and V31 are held back as the two fixed FP scratch
+# registers the float-op encoder routes spilled operands through — the AArch64
+# analogue of x86-64 holding XMM14/XMM15 back from the SSE value pool. two are
+# required (not one): a binary float op whose destination AND both sources are all
+# spilled to frame slots needs two FP registers live at once to materialize
+# `op Sd, Sn, Sm`, which a single scratch cannot supply. both are caller-saved
+# under AAPCS64, so neither perturbs the callee-save prologue.
+pub val VECTOR_COUNT: i32 = 30;
 
 # the AArch64 machine opcode space. each value names a logical instruction form;
 # the encoder maps it to concrete bytes and the isel table emits it. pseudo
@@ -154,3 +158,12 @@ pub val MOV: Opcode = 13;
 pub val B: Opcode = 14;
 # breakpoint trap `brk #0`, the unreachable-terminator form.
 pub val BRK: Opcode = 15;
+# scalar floating-point register move (`fmov`), the concrete form the selector
+# rewrites a float register copy and a GP<->FP `:~` bitcast into. the encoder
+# dispatches the S/D copy, the GP->FP (`fmov Sd,Wn` / `fmov Dd,Xn`), and the FP->GP
+# (`fmov Wd,Sn` / `fmov Xd,Dn`) forms on operand register CLASS, so a float copy or
+# a cross-bank reinterpret can never mis-select to a GP move of the aliasing index.
+# value 16 is free of any surviving generic MIR opcode (MIR_CMP_NE=16 is rewritten
+# to its selection sentinel in isel, and the surviving MIR pass-throughs the encoder
+# dispatches by opcode — MIR_TRUNC=21 onward — sit above it).
+pub val FMOV: Opcode = 16;

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -111,7 +111,46 @@ pub val VECTOR_COUNT: i32 = 31;
 # fills in.
 pub def Opcode: u16;
 
+# the concrete leaf-integer opcode forms the selector rewrites generic MIR
+# opcodes into and the encoder packs into 32-bit A64 words. they occupy a low,
+# dense range distinct from the high MIR selection-output sentinels
+# (`mir.MIR_SEL_*`, 0x1100+) and pass-through pseudos (`mir.MIR_CALL`, 0x1000+)
+# that survive instruction selection, so the encoder's dispatch never confuses a
+# concrete A64 form with a surviving generic op. unlike x86-64 the A64 ALU is
+# three-address, so the binary ops are rewritten to a concrete opcode rather than
+# surviving as a sentinel (register allocation keys def/use on operand shape, not
+# opcode, so a concrete three-address form is read correctly).
+
 # no-op (the canonical `HINT #0`).
 pub val NOP: Opcode = 0;
-# return from subroutine (`RET`, branches to the link register).
+# return from subroutine (`RET`, branches to the link register X30).
 pub val RET: Opcode = 1;
+# integer add, three-address `add Rd, Rn, Rm` (or `add Rd, Rn, #imm12`).
+pub val ADD: Opcode = 2;
+# integer subtract, three-address `sub Rd, Rn, Rm` (or `sub Rd, Rn, #imm12`).
+pub val SUB: Opcode = 3;
+# integer multiply, `mul Rd, Rn, Rm` (the `madd Rd, Rn, Rm, XZR` alias).
+pub val MUL: Opcode = 4;
+# bitwise and, `and Rd, Rn, Rm` (logical shifted register).
+pub val AND: Opcode = 5;
+# bitwise or, `orr Rd, Rn, Rm`.
+pub val ORR: Opcode = 6;
+# bitwise exclusive or, `eor Rd, Rn, Rm`.
+pub val EOR: Opcode = 7;
+# left shift, `lsl Rd, Rn, Rm` (LSLV) or `lsl Rd, Rn, #imm` (UBFM alias).
+pub val LSL: Opcode = 8;
+# logical right shift, `lsr Rd, Rn, Rm` (LSRV) or `lsr Rd, Rn, #imm` (UBFM).
+pub val LSR: Opcode = 9;
+# arithmetic right shift, `asr Rd, Rn, Rm` (ASRV) or `asr Rd, Rn, #imm` (SBFM).
+pub val ASR: Opcode = 10;
+# integer negate, `neg Rd, Rm` (the `sub Rd, XZR, Rm` alias).
+pub val NEG: Opcode = 11;
+# bitwise complement, `mvn Rd, Rm` (the `orn Rd, XZR, Rm` alias).
+pub val MVN: Opcode = 12;
+# register move, `mov Rd, Rm` (the `orr Rd, XZR, Rm` alias) or a MOVZ/MOVK
+# immediate materialization for an immediate source.
+pub val MOV: Opcode = 13;
+# unconditional branch to a block, `b label` (imm26 displacement).
+pub val B: Opcode = 14;
+# breakpoint trap `brk #0`, the unreachable-terminator form.
+pub val BRK: Opcode = 15;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1,0 +1,47 @@
+# mach.lang.target.isa.arm64.encode: AArch64 machine-code encoding — the arm64 ISA's `encode` entry point.
+#
+# This is the AArch64 implementation of the ISA vtable's `encode` operation,
+# reached only through `tgt.arch.encode` by the shared `be.codegen.encode`
+# dispatcher. Byte encoding is not yet implemented: `encode_arm64` is a total
+# function that fails loudly with an "not implemented" error. The encoder that
+# turns the resolved `isa.Inst` stream into AArch64 bytes (with prologue/epilogue
+# emission, branch fixups, and relocation offsets) is filled in a later phase; the
+# four-file ISA shape mirrors the x86-64 backend.
+
+use std.types.string.str;
+
+use std.types.result.Result;
+use std.types.result.err;
+
+use std.allocator.Allocator;
+
+use target: mach.lang.target.resolved;
+use mir:    mach.lang.be.codegen.mir;
+use enc:    mach.lang.be.codegen.encode;
+
+# EncodeFn: the concrete signature the erased `isa.IsaVTable.encode` pointer is
+# cast back to, matching the shared `be.codegen.encode.EncodeFn`. the vtable stores
+# `encode` type-erased (`*u8`); the shared dispatcher casts it back to this type
+# before calling it.
+# ---
+# alloc: allocator backing the encoder output's owned arrays
+# tgt:   resolved compilation target (must be AArch64)
+# m:     the fully-resolved MIR module to encode
+# ret:   the populated enc.EncoderOutput, or an error string
+pub def EncodeFn: fun(*Allocator, *target.Target, *mir.MirModule) Result[enc.EncoderOutput, str];
+
+# encode_arm64: encode a fully-resolved MIR module into AArch64 `.text` bytes,
+# symbol marks, and pending relocations.
+#
+# the AArch64 implementation behind the ISA vtable's `encode` slot; the shared
+# `be.codegen.encode.run` dispatcher reaches it only through `tgt.arch.encode`.
+# byte encoding is not yet implemented, so this fails loudly — a total function
+# that signals the unimplemented backend rather than emitting wrong bytes.
+# ---
+# alloc: allocator (unused until encoding is implemented)
+# tgt:   resolved compilation target (must be AArch64)
+# m:     the fully-resolved MIR module
+# ret:   an error reporting that AArch64 encoding is unimplemented
+pub fun encode_arm64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Result[enc.EncoderOutput, str] {
+    ret err[enc.EncoderOutput, str]("aarch64 encode not implemented");
+}

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -299,6 +299,17 @@ val LDUR_S_FP: u32 = 0xBC400000; val STUR_S_FP: u32 = 0xBC000000;
 val LDR_D_REG: u32 = 0xFC606800; val STR_D_REG: u32 = 0xFC206800;
 val LDR_S_REG: u32 = 0xBC606800; val STR_S_REG: u32 = 0xBC206800;
 
+# acquire/release ordered load-stores + the LL/SC exclusive pair (atomic.mach's
+# LL/SC core): Rt[4:0], Rn[9:5], Rt2 fixed 11111; stlxr's status Rs is [20:16];
+# the X (64-bit) base sets the size bit, the W (32-bit) base clears it.
+val LDAR_X:  u32 = 0xC8DFFC00; val LDAR_W:  u32 = 0x88DFFC00;
+val STLR_X:  u32 = 0xC89FFC00; val STLR_W:  u32 = 0x889FFC00;
+val LDAXR_X: u32 = 0xC85FFC00; val LDAXR_W: u32 = 0x885FFC00;
+val STLXR_X: u32 = 0xC800FC00; val STLXR_W: u32 = 0x8800FC00;
+# yield = HINT #1; dmb's barrier option goes in CRm[11:8].
+val YIELD_WORD: u32 = 0xD503203F;
+val DMB_BASE:   u32 = 0xD50330BF;
+
 # ---- bitfield packers (pure: each returns one A64 word) ----
 
 # pack_alu3: a three-register data-processing word — Rm[20:16], Rn[9:5], Rd[4:0]
@@ -2959,6 +2970,73 @@ fun emit_asm_ldstp(st: *EncodeState, args: str, is_load: bool) Result[bool, str]
     ret ok[bool, str](true);
 }
 
+# emit_asm_ldordered: `ldar` / `stlr` / `ldaxr Rt, [Xn]` — acquire/release ordered
+# load-store or load-acquire-exclusive, addressing the bare base register only.
+fun emit_asm_ldordered(st: *EncodeState, mnem: str, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm ldar/stlr/ldaxr operands"); }
+    if (n != 2) { ret err[bool, str]("encode: inline-asm ldar/stlr/ldaxr expects Rt, [Xn]"); }
+    var rt: AsmOp;
+    var mem: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rt) || rt.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm ldar/stlr/ldaxr value must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret err[bool, str]("encode: inline-asm ldar/stlr/ldaxr address must be a memory operand"); }
+    if (mem.has_index || mem.has_disp || mem.wb_pre) { ret err[bool, str]("encode: inline-asm ldar/stlr/ldaxr addressing must be a bare [Xn]"); }
+    var base: u32 = sel(rt.is64, LDAXR_X, LDAXR_W);
+    if (str_equals(mnem, "ldar")) { base = sel(rt.is64, LDAR_X, LDAR_W); }
+    or (str_equals(mnem, "stlr")) { base = sel(rt.is64, STLR_X, STLR_W); }
+    emit_word(st, pack_ldst(base, rt.reg, mem.base, 0));
+    ret ok[bool, str](true);
+}
+
+# emit_asm_stlxr: `stlxr Ws, Rt, [Xn]` — store-release exclusive; the 32-bit status
+# result Ws is Rs[20:16], the stored value Rt sizes the op.
+fun emit_asm_stlxr(st: *EncodeState, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm stlxr operands"); }
+    if (n != 3) { ret err[bool, str]("encode: inline-asm stlxr expects Ws, Rt, [Xn]"); }
+    var rs: AsmOp;
+    var rt: AsmOp;
+    var mem: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rs) || rs.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm stlxr status must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?rt) || rt.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm stlxr value must be a register"); }
+    if (!asm_parse_operand((?b2[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret err[bool, str]("encode: inline-asm stlxr address must be a memory operand"); }
+    if (mem.has_index || mem.has_disp || mem.wb_pre) { ret err[bool, str]("encode: inline-asm stlxr addressing must be a bare [Xn]"); }
+    val base: u32 = sel(rt.is64, STLXR_X, STLXR_W);
+    emit_word(st, pack_ldst(base, rt.reg, mem.base, 0) | ((rs.reg & 0x1F) << 16));
+    ret ok[bool, str](true);
+}
+
+# emit_asm_dmb: `dmb <option>` — data memory barrier; the option name selects CRm[11:8].
+fun emit_asm_dmb(st: *EncodeState, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm dmb operand"); }
+    if (n != 1) { ret err[bool, str]("encode: inline-asm dmb expects one barrier option"); }
+    var opt: u32 = 0;
+    if (!asm_barrier_option((?b0[0])::str, ?opt)) { ret err[bool, str]("encode: unsupported inline-asm dmb barrier option"); }
+    emit_word(st, DMB_BASE | ((opt & 0xF) << 8));
+    ret ok[bool, str](true);
+}
+
+# asm_barrier_option: the CRm value for a dmb barrier-domain name.
+fun asm_barrier_option(name: str, out: *u32) bool {
+    if (str_equals(name, "sy"))    { @out = 15; ret true; }
+    if (str_equals(name, "st"))    { @out = 14; ret true; }
+    if (str_equals(name, "ld"))    { @out = 13; ret true; }
+    if (str_equals(name, "ish"))   { @out = 11; ret true; }
+    if (str_equals(name, "ishst")) { @out = 10; ret true; }
+    if (str_equals(name, "ishld")) { @out = 9;  ret true; }
+    if (str_equals(name, "nsh"))   { @out = 7;  ret true; }
+    if (str_equals(name, "nshst")) { @out = 6;  ret true; }
+    if (str_equals(name, "nshld")) { @out = 5;  ret true; }
+    if (str_equals(name, "osh"))   { @out = 3;  ret true; }
+    if (str_equals(name, "oshst")) { @out = 2;  ret true; }
+    if (str_equals(name, "oshld")) { @out = 1;  ret true; }
+    ret false;
+}
+
 # emit_asm_branch_label: emit a branch (B / B.cond / CBZ / CBNZ) to a numeric local
 # label. a backward reference patches immediately against the nearest preceding
 # definition; a forward reference is recorded and patched when its definition is
@@ -3134,6 +3212,12 @@ fun encode_asm_stmt_arm64(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, l
     }
     if (str_equals(mnem, "stp")) { ret emit_asm_ldstp(st, args, false); }
     if (str_equals(mnem, "ldp")) { ret emit_asm_ldstp(st, args, true); }
+    if (str_equals(mnem, "dmb"))   { ret emit_asm_dmb(st, args); }
+    if (str_equals(mnem, "yield")) { emit_word(st, YIELD_WORD); ret ok[bool, str](true); }
+    if (str_equals(mnem, "ldar") || str_equals(mnem, "stlr") || str_equals(mnem, "ldaxr")) {
+        ret emit_asm_ldordered(st, mnem, args);
+    }
+    if (str_equals(mnem, "stlxr")) { ret emit_asm_stlxr(st, args); }
 
     ret err[bool, str](asm_named_err(st, "unsupported aarch64 inline-asm mnemonic '", mnem, "'", "unsupported aarch64 inline-asm mnemonic"));
 }
@@ -4547,6 +4631,46 @@ test "arm64.encode: inline-asm load/store forms match llvm-mc" {
     if (read_word(?st.buf, 56) != 0xA90007E0) { bad = 1; }
     if (read_word(?st.buf, 60) != 0xA88107E0) { bad = 1; }
     if (read_word(?st.buf, 64) != 0xA9C107E0) { bad = 1; }
+
+    asm_labels_dnit(?labels);
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the atomic / barrier family (atomic.mach's LL/SC core): `dmb`, `yield`, the
+# acquire/release ordered load-stores, and the load-acquire-exclusive / store-release
+# -exclusive pair. words match llvm-mc (Rt=0, Rn=1, stlxr status Rs=2).
+test "arm64.encode: inline-asm atomic/barrier forms match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: AsmLabels;
+    asm_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "dmb ish");           # 0
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "yield");            # 4
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldar x0, [x1]");    # 8
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldar w0, [x1]");    # 12
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlr x0, [x1]");    # 16
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlr w0, [x1]");    # 20
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldaxr x0, [x1]");   # 24
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldaxr w0, [x1]");   # 28
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlxr w2, x0, [x1]"); # 32
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlxr w2, w0, [x1]"); # 36
+
+    if (read_word(?st.buf, 0)  != 0xD5033BBF) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0xD503203F) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0xC8DFFC20) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0x88DFFC20) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0xC89FFC20) { bad = 1; }
+    if (read_word(?st.buf, 20) != 0x889FFC20) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0xC85FFC20) { bad = 1; }
+    if (read_word(?st.buf, 28) != 0x885FFC20) { bad = 1; }
+    if (read_word(?st.buf, 32) != 0xC802FC20) { bad = 1; }
+    if (read_word(?st.buf, 36) != 0x8802FC20) { bad = 1; }
 
     asm_labels_dnit(?labels);
     buf_dnit(?st.buf);

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -15,7 +15,9 @@
 # SCOPE (Phase 3b — calls + symbol relocations, atop the Phase 3a frames + memory +
 # conversions core). Every modeled form is byte-exact against llvm-mc: the three-
 # address integer ALU (ADD/SUB/MUL/AND/ORR/EOR), the shifts (register LSLV/LSRV/ASRV
-# and immediate UBFM/SBFM aliases), NEG/MVN/MOV, the MOVZ/MOVK immediate
+# and immediate UBFM/SBFM aliases), the integer divides (SDIV/UDIV, remainder via
+# MSUB) with the defined division-by-zero / signed-overflow trap checks (CBNZ/CMN/
+# CMP + BRK), NEG/MVN/MOV, the MOVZ/MOVK immediate
 # materialization, RET, CMP (SUBS XZR) + CSET, the unconditional branch B, the
 # conditional branch (CBNZ + B), and the BRK unreachable trap; plus the record-at-top
 # non-leaf prologue (STP/MOV record, `SUB SP` frame, GP callee-save STP/LDP pairs)
@@ -125,6 +127,13 @@ val MUL_X: u32 = 0x9B007C00; val MUL_W: u32 = 0x1B007C00;
 val LSLV_X: u32 = 0x9AC02000; val LSLV_W: u32 = 0x1AC02000;
 val LSRV_X: u32 = 0x9AC02400; val LSRV_W: u32 = 0x1AC02400;
 val ASRV_X: u32 = 0x9AC02800; val ASRV_W: u32 = 0x1AC02800;
+# the integer divides (SDIV signed / UDIV unsigned), same data-processing-2-source
+# group as the register shifts (op2 = 0x03 signed / 0x02 unsigned).
+val SDIV_X: u32 = 0x9AC00C00; val SDIV_W: u32 = 0x1AC00C00;
+val UDIV_X: u32 = 0x9AC00800; val UDIV_W: u32 = 0x1AC00800;
+# MSUB Rd,Rn,Rm,Ra (Rd = Ra - Rn*Rm) — the multiply-subtract the remainder uses to
+# recover `Rn - (Rn/Rm)*Rm`; the o0 bit (bit 15) distinguishes it from MADD.
+val MSUB_X: u32 = 0x9B008000; val MSUB_W: u32 = 0x1B008000;
 # ADD / SUB immediate (imm12, optional left-shift by 12 via the `sh` bit).
 val ADDI_X: u32 = 0x91000000; val ADDI_W: u32 = 0x11000000;
 val SUBI_X: u32 = 0xD1000000; val SUBI_W: u32 = 0x51000000;
@@ -137,6 +146,9 @@ val MOVK_X: u32 = 0xF2800000; val MOVK_W: u32 = 0x72800000;
 # SUBS XZR (the CMP alias), register and immediate forms.
 val SUBS_REG_X: u32 = 0xEB000000; val SUBS_REG_W: u32 = 0x6B000000;
 val SUBS_IMM_X: u32 = 0xF1000000; val SUBS_IMM_W: u32 = 0x71000000;
+# ADDS XZR, Rn, #imm (the CMN-immediate alias) — the signed-overflow check compares
+# the divisor to -1 with `cmn Rm, #1` (sets Z when Rm + 1 == 0, i.e. Rm == -1).
+val ADDS_IMM_X: u32 = 0xB1000000; val ADDS_IMM_W: u32 = 0x31000000;
 # CSINC Rd,XZR,XZR (the CSET alias): the base bakes the XZR sources and op2 bit.
 val CSINC_X: u32 = 0x9A800400; val CSINC_W: u32 = 0x1A800400;
 # STP pre-index / LDP post-index (the FP/LR frame record) and the signed-offset
@@ -302,6 +314,26 @@ fun pack_ldst(base: u32, rt: u32, rn: u32, imm12: u32) u32 {
 # pass 2 inserts the resolved imm19 displacement.
 fun pack_cbnz(base: u32, rt: u32) u32 {
     ret base | (rt & 0x1F);
+}
+
+# pack_cbnz_off: a compare-and-branch word with a resolved (signed) imm19 word
+# displacement — imm19[23:5], Rt[4:0]. used by the self-contained divide trap checks,
+# whose forward skip distance is fixed at emit time (no pass-2 fixup needed).
+fun pack_cbnz_off(base: u32, rt: u32, imm19: u32) u32 {
+    ret base | ((imm19 & 0x7FFFF) << 5) | (rt & 0x1F);
+}
+
+# pack_bcond: a conditional-branch (B.cond) word — imm19[23:5] (the signed word
+# displacement), cond[3:0]. used by the divide trap checks' fixed forward skips.
+fun pack_bcond(imm19: u32, cond: u32) u32 {
+    ret BCOND | ((imm19 & 0x7FFFF) << 5) | (cond & 0xF);
+}
+
+# pack_madd: a multiply-add/sub word — Rm[20:16], Ra[14:10], Rn[9:5], Rd[4:0] OR-ed
+# into `base` (MADD or MSUB, which bakes the o0 bit). used for the remainder's
+# `msub Rd, Rn, Rm, Ra` = Rd = Ra - Rn*Rm.
+fun pack_madd(base: u32, rd: u32, rn: u32, rm: u32, ra: u32) u32 {
+    ret base | ((rm & 0x1F) << 16) | ((ra & 0x1F) << 10) | ((rn & 0x1F) << 5) | (rd & 0x1F);
 }
 
 # pack_alu3_sh: a three-register data-processing word with a left-shift amount —
@@ -1125,6 +1157,83 @@ fun encode_cbr(st: *EncodeState, fn_base: u32, mi: *mir.MirInstr) Result[bool, s
     ret push_fixup(st, b_pos, b_next, else_block, fn_base);
 }
 
+# is_mir_divide: true when a post-isel opcode is a surviving division / remainder
+# sentinel (MIR_SEL_DIV_*/MIR_SEL_REM_*) — the encoder materializes the SDIV/UDIV
+# (+ MSUB for a remainder) and the defined division-by-zero / signed-overflow traps
+# from it. AArch64 wires no fixed division register, so the divide reaches the
+# encoder as the clean three-address `[dst, dividend, divisor]` op the shared
+# lowering emitted and arm64 isel rewrote to the high sentinel.
+fun is_mir_divide(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_SEL_DIV_S || op == mir.MIR_SEL_DIV_U ||
+        op == mir.MIR_SEL_REM_S || op == mir.MIR_SEL_REM_U;
+}
+
+# encode_divide: materialize a surviving division / remainder `[dst, dividend,
+# divisor]` into the A64 SDIV/UDIV (+ MSUB for a remainder), guarded by the runtime
+# traps mach defines for integer division. unlike x86-64's IDIV/DIV, AArch64
+# SDIV/UDIV do NOT fault, so the trapping semantics are made explicit:
+#   - division by zero (all forms): `cbnz Rm, .Lok ; brk #0` — the BRK fires when the
+#     divisor is zero (cbnz skips it otherwise).
+#   - signed overflow INT_MIN / -1 (signed forms only): `cmn Rm, #1` (Rm == -1?) then,
+#     only when equal, `movz IP1, #INT_MIN ; cmp Rn, IP1` (Rn == INT_MIN?) reach a brk.
+# the quotient is `sdiv/udiv Rd, Rn, Rm`; the remainder is `sdiv/udiv IP0, Rn, Rm ;
+# msub Rd, IP0, Rm, Rn` (Rd = Rn - (Rn/Rm)*Rm). IP0/IP1 are the reserved encoder
+# scratch (never an allocated operand), so the divisor / dividend survive to every
+# use; the trap skips are fixed forward word displacements (no pass-2 fixup).
+fun encode_divide(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: divide missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val rnr: Result[i32, str] = req_gpr(?mi.operands[1]);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val rmr: Result[i32, str] = req_gpr(?mi.operands[2]);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+
+    val op: mir.MirOpcode = mi.opcode;
+    val signed: bool = op == mir.MIR_SEL_DIV_S || op == mir.MIR_SEL_REM_S;
+    val rem:    bool = op == mir.MIR_SEL_REM_S || op == mir.MIR_SEL_REM_U;
+
+    # division-by-zero trap: skip the brk (one word ahead) when the divisor is non-zero.
+    emit_word(st, pack_cbnz_off(sel(use64, CBNZ_X, CBNZ_W), rm, 2));
+    emit_word(st, BRK_BASE);
+
+    # signed-overflow (INT_MIN / -1) trap: only the signed divides can overflow.
+    if (signed) {
+        # cmn Rm, #1 sets Z iff Rm == -1; if not, no overflow — skip the rest (5 words).
+        emit_word(st, pack_addsub_imm(sel(use64, ADDS_IMM_X, ADDS_IMM_W), ZR, rm, 1, 0));
+        emit_word(st, pack_bcond(5, CC_NE));
+        # IP1 = INT_MIN for this width (a single MOVZ: 0x80000000 W / 0x8000000000000000
+        # X); cmp Rn, IP1 sets Z iff the dividend is INT_MIN — then the brk (2 words).
+        var hw: u32 = 1;
+        if (use64) { hw = 3; }
+        emit_word(st, pack_movewide(sel(use64, MOVZ_X, MOVZ_W), SCRATCH1, hw, 0x8000));
+        emit_word(st, pack_cmp_reg(sel(use64, SUBS_REG_X, SUBS_REG_W), rn, SCRATCH1));
+        emit_word(st, pack_bcond(2, CC_NE));
+        emit_word(st, BRK_BASE);
+    }
+
+    # the divide base (SDIV signed / UDIV unsigned) for this form.
+    var dbase_x: u32 = SDIV_X; var dbase_w: u32 = SDIV_W;
+    if (!signed) { dbase_x = UDIV_X; dbase_w = UDIV_W; }
+
+    if (rem) {
+        # remainder: the quotient lands in IP0, then `msub Rd, IP0, Rm, Rn`.
+        emit_word(st, pack_alu3(sel(use64, dbase_x, dbase_w), SCRATCH0, rn, rm));
+        emit_word(st, pack_madd(sel(use64, MSUB_X, MSUB_W), rd, SCRATCH0, rm, rn));
+        ret ok[bool, str](true);
+    }
+    # quotient: Rd = Rn / Rm.
+    emit_word(st, pack_alu3(sel(use64, dbase_x, dbase_w), rd, rn, rm));
+    ret ok[bool, str](true);
+}
+
 # ---- frame layout, prologue, epilogue ----
 
 # popcount32: the number of set bits in a 32-bit mask.
@@ -1288,6 +1397,10 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     # multi-instruction byte sequences.
     if (is_mir_compare(mi.opcode)) { ret encode_compare(st, mi); }
     if (mi.opcode == mir.MIR_SEL_CBR) { ret encode_cbr(st, fn_base, mi); }
+
+    # the surviving division / remainder sentinel expands into its SDIV/UDIV (+ MSUB)
+    # byte sequence with the defined division-by-zero / signed-overflow traps.
+    if (is_mir_divide(mi.opcode)) { ret encode_divide(st, mi); }
 
     # the register-allocator's spill reload / store, inserted after instruction
     # selection, carries the GENERIC MIR_MOV opcode (isel only rewrites the moves
@@ -2781,6 +2894,145 @@ test "arm64.encode: compare with an immediate lhs materializes (real-std char ga
     if (read_word(?st.buf, 4) != 0x6B01023F) { bad = 1; }  # cmp w17, w1
     if (read_word(?st.buf, 8) != 0x1A9F87E0) { bad = 1; }  # cset w0, ls
 
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the divide / remainder packers and the trap-check building blocks, byte-exact vs
+# `llvm-mc -triple=aarch64 --show-encoding`. registers x0/x1/x2 = Rd/Rn/Rm, IP1 = x17.
+test "arm64.encode: SDIV/UDIV/MSUB + divide trap packers match llvm-mc" {
+    var bad: i32 = 0;
+    # sdiv / udiv w0,w1,w2 and x0,x1,x2
+    if (pack_alu3(SDIV_W, 0, 1, 2) != 0x1AC20C20) { bad = 1; }  # sdiv w0, w1, w2
+    if (pack_alu3(SDIV_X, 0, 1, 2) != 0x9AC20C20) { bad = 1; }  # sdiv x0, x1, x2
+    if (pack_alu3(UDIV_W, 0, 1, 2) != 0x1AC20820) { bad = 1; }  # udiv w0, w1, w2
+    if (pack_alu3(UDIV_X, 0, 1, 2) != 0x9AC20820) { bad = 1; }  # udiv x0, x1, x2
+    # msub w0,w16,w2,w1 and x0,x16,x2,x1 (Rd = Rn - IP0*Rm, the remainder recovery)
+    if (pack_madd(MSUB_W, 0, 16, 2, 1) != 0x1B028600) { bad = 1; }  # msub w0, w16, w2, w1
+    if (pack_madd(MSUB_X, 0, 16, 2, 1) != 0x9B028600) { bad = 1; }  # msub x0, x16, x2, x1
+    # division-by-zero check: cbnz w2/x2, #8 (imm19 = 2 words, skipping the brk)
+    if (pack_cbnz_off(CBNZ_W, 2, 2) != 0x35000042) { bad = 1; }  # cbnz w2, #8
+    if (pack_cbnz_off(CBNZ_X, 2, 2) != 0xB5000042) { bad = 1; }  # cbnz x2, #8
+    # signed-overflow check: cmn w2/x2,#1 ; b.ne #20 ; movz IP1,#INT_MIN ; b.ne #8
+    if (pack_addsub_imm(ADDS_IMM_W, ZR, 2, 1, 0) != 0x3100045F) { bad = 1; }  # cmn w2, #1
+    if (pack_addsub_imm(ADDS_IMM_X, ZR, 2, 1, 0) != 0xB100045F) { bad = 1; }  # cmn x2, #1
+    if (pack_bcond(5, CC_NE) != 0x540000A1) { bad = 1; }  # b.ne #20
+    if (pack_bcond(2, CC_NE) != 0x54000041) { bad = 1; }  # b.ne #8
+    if (pack_movewide(MOVZ_W, 17, 1, 0x8000) != 0x52B00011) { bad = 1; }  # movz w17, #0x80000000
+    if (pack_movewide(MOVZ_X, 17, 3, 0x8000) != 0xD2F00011) { bad = 1; }  # movz x17, #0x8000000000000000
+    ret bad;
+}
+
+# the full encode_divide byte sequences — quotient / remainder plus the defined
+# division-by-zero (all forms) and signed-overflow INT_MIN/-1 (signed forms) trap
+# checks — byte-exact vs llvm-mc. operands [dst x0/w0, dividend x1/w1, divisor x2/w2];
+# a remainder uses IP0 (x16) as the quotient temp, the overflow check IP1 (x17).
+test "arm64.encode: unsigned divide (UDIV X) + div-by-zero trap matches llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+    mi.opcode = mir.MIR_SEL_DIV_U; mi.width = 8;
+
+    val r: Result[bool, str] = encode_divide(?st, ?mi);
+    if (is_err[bool, str](r)) { bad = 1; }
+    if (st.buf.len != 12) { bad = 1; }
+    or {
+        if (read_word(?st.buf, 0) != 0xB5000042) { bad = 1; }   # cbnz x2, #8
+        if (read_word(?st.buf, 4) != 0xD4200000) { bad = 1; }   # brk #0
+        if (read_word(?st.buf, 8) != 0x9AC20820) { bad = 1; }   # udiv x0, x1, x2
+    }
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+test "arm64.encode: signed divide (SDIV X) + zero/overflow traps matches llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+    mi.opcode = mir.MIR_SEL_DIV_S; mi.width = 8;
+
+    val r: Result[bool, str] = encode_divide(?st, ?mi);
+    if (is_err[bool, str](r)) { bad = 1; }
+    if (st.buf.len != 36) { bad = 1; }
+    or {
+        if (read_word(?st.buf, 0)  != 0xB5000042) { bad = 1; }  # cbnz x2, #8
+        if (read_word(?st.buf, 4)  != 0xD4200000) { bad = 1; }  # brk #0
+        if (read_word(?st.buf, 8)  != 0xB100045F) { bad = 1; }  # cmn x2, #1
+        if (read_word(?st.buf, 12) != 0x540000A1) { bad = 1; }  # b.ne #20
+        if (read_word(?st.buf, 16) != 0xD2F00011) { bad = 1; }  # movz x17, #INT_MIN
+        if (read_word(?st.buf, 20) != 0xEB11003F) { bad = 1; }  # cmp x1, x17
+        if (read_word(?st.buf, 24) != 0x54000041) { bad = 1; }  # b.ne #8
+        if (read_word(?st.buf, 28) != 0xD4200000) { bad = 1; }  # brk #0
+        if (read_word(?st.buf, 32) != 0x9AC20C20) { bad = 1; }  # sdiv x0, x1, x2
+    }
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+test "arm64.encode: signed remainder (SREM W) + zero/overflow traps matches llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+    mi.opcode = mir.MIR_SEL_REM_S; mi.width = 4;
+
+    val r: Result[bool, str] = encode_divide(?st, ?mi);
+    if (is_err[bool, str](r)) { bad = 1; }
+    if (st.buf.len != 40) { bad = 1; }
+    or {
+        if (read_word(?st.buf, 0)  != 0x35000042) { bad = 1; }  # cbnz w2, #8
+        if (read_word(?st.buf, 4)  != 0xD4200000) { bad = 1; }  # brk #0
+        if (read_word(?st.buf, 8)  != 0x3100045F) { bad = 1; }  # cmn w2, #1
+        if (read_word(?st.buf, 12) != 0x540000A1) { bad = 1; }  # b.ne #20
+        if (read_word(?st.buf, 16) != 0x52B00011) { bad = 1; }  # movz w17, #INT_MIN
+        if (read_word(?st.buf, 20) != 0x6B11003F) { bad = 1; }  # cmp w1, w17
+        if (read_word(?st.buf, 24) != 0x54000041) { bad = 1; }  # b.ne #8
+        if (read_word(?st.buf, 28) != 0xD4200000) { bad = 1; }  # brk #0
+        if (read_word(?st.buf, 32) != 0x1AC20C30) { bad = 1; }  # sdiv w16, w1, w2
+        if (read_word(?st.buf, 36) != 0x1B028600) { bad = 1; }  # msub w0, w16, w2, w1
+    }
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+test "arm64.encode: unsigned remainder (UREM X) + div-by-zero trap matches llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+    mi.opcode = mir.MIR_SEL_REM_U; mi.width = 8;
+
+    val r: Result[bool, str] = encode_divide(?st, ?mi);
+    if (is_err[bool, str](r)) { bad = 1; }
+    if (st.buf.len != 16) { bad = 1; }
+    or {
+        if (read_word(?st.buf, 0)  != 0xB5000042) { bad = 1; }  # cbnz x2, #8
+        if (read_word(?st.buf, 4)  != 0xD4200000) { bad = 1; }  # brk #0
+        if (read_word(?st.buf, 8)  != 0x9AC20830) { bad = 1; }  # udiv x16, x1, x2
+        if (read_word(?st.buf, 12) != 0x9B028600) { bad = 1; }  # msub x0, x16, x2, x1
+    }
     buf_dnit(?st.buf);
     ret bad;
 }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -999,6 +999,16 @@ fun emit_store_mem(st: *EncodeState, f: *mir.MirFunction, dst_mem: *mir.MirOpera
     val m: A64Mem = unwrap_ok[A64Mem, str](mr);
     if (m.has_index) { ret err[bool, str]("encode: indexed store not expected"); }
 
+    # a FLOAT store names a vector source: dispatch on the source class to the scalar-
+    # FP store (`str Sd|Dd, [base, #off]`). a symbol destination never reaches here for
+    # a float (lowering LEA-materializes it into a base vreg first).
+    if (reg_is_vec(val_op)) {
+        val rvr: Result[i32, str] = req_vec(val_op);
+        if (is_err[i32, str](rvr)) { ret err[bool, str](unwrap_err[i32, str](rvr)); }
+        emit_fp_mem(st, unwrap_ok[i32, str](rvr)::u32, m.base, m.off, width, false);
+        ret ok[bool, str](true);
+    }
+
     var rt: u32 = ZR;
     if (val_op.kind == mir.MIR_OP_IMM) {
         if (val_op.imm != 0) {
@@ -1018,13 +1028,30 @@ fun emit_store_mem(st: *EncodeState, f: *mir.MirFunction, dst_mem: *mir.MirOpera
 # is a frame-slot or pointer-register memory operand loaded at the access width
 # (`src_width`) with the zero-extending form, or a folded-global symbol source
 # (`adrp IP0, sym` + `ldr Xt, [IP0, :lo12:sym]`, the two-reloc primary global path).
+# a FLOAT load names a vector destination: it dispatches on the destination class to
+# the scalar-FP load (`ldr Sd|Dd, [base, #off]`) off the resolved frame-slot /
+# pointer MEM — lowering has already LEA-materialized any symbol pointer into a base
+# vreg, so a float load's source is never a bare symbol here.
 fun encode_load(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
     if (mi.operand_count < 2) { ret err[bool, str]("encode: load missing operands"); }
-    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    val dstop: *mir.MirOperand = ?mi.operands[0];
+    val src: *mir.MirOperand = ?mi.operands[1];
+
+    if (reg_is_vec(dstop)) {
+        val rvr: Result[i32, str] = req_vec(dstop);
+        if (is_err[i32, str](rvr)) { ret err[bool, str](unwrap_err[i32, str](rvr)); }
+        val fmr: Result[A64Mem, str] = resolve_mem(f, src);
+        if (is_err[A64Mem, str](fmr)) { ret err[bool, str](unwrap_err[A64Mem, str](fmr)); }
+        val fm: A64Mem = unwrap_ok[A64Mem, str](fmr);
+        if (fm.has_index) { ret err[bool, str]("encode: indexed float load not expected"); }
+        emit_fp_mem(st, unwrap_ok[i32, str](rvr)::u32, fm.base, fm.off, mi.src_width, true);
+        ret ok[bool, str](true);
+    }
+
+    val rdr: Result[i32, str] = req_gpr(dstop);
     if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
     val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
 
-    val src: *mir.MirOperand = ?mi.operands[1];
     if (src.kind == mir.MIR_OP_SYM) {
         ret emit_global_load(st, rd, src, mi.src_width);
     }
@@ -2058,13 +2085,39 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     ret err[bool, str]("internal compiler error: unhandled opcode in arm64 encode");
 }
 
+# function_is_naked: a function whose inline asm owns the stack and must be emitted
+# with NO compiler prologue/epilogue — no frame (frame.size), no callee-saved GP/FP
+# registers, no outgoing-argument area, and a body containing an inline-asm block.
+# the entry-point `_start` reads the kernel-supplied SP directly (`mov x9, sp; ldr x0,
+# [x9]` = argc), so a frame-record `stp x29, x30, [sp, #-16]!` ahead of it would shift
+# SP and corrupt the argc/argv it extracts. mirrors x86-64's `function_is_naked` (the
+# asm-block opcode survives selection as `mir.MIR_ASM` on AArch64).
+fun function_is_naked(f: *mir.MirFunction) bool {
+    if (f.frame.size != 0) { ret false; }
+    if (f.callee_mask != 0) { ret false; }
+    if (f.callee_mask_fp != 0) { ret false; }
+    if (f.frame.outgoing_size != 0) { ret false; }
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            if (mi.opcode == mir.MIR_ASM) { ret true; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret false;
+}
+
 # encode_function_arm64: the per-function encode hook (pass 1). marks the function
-# entry symbol, emits the record-at-top prologue, then each block — emitting the
-# epilogue before every RET — recording each block's `.text` offset for branch
-# patching. extern / body-less functions contribute no text. an oversized frame (a
-# `SUB SP` past the two-immediate range, or GP callee-saves below the STP/LDP imm7
-# reach) is materialized through a scratch base; callee-saved FP registers remain a
-# Phase 4 loud defer.
+# entry symbol, emits the record-at-top prologue (skipped for a naked asm-only
+# function, whose inline asm owns the stack), then each block — emitting the epilogue
+# before every RET — recording each block's `.text` offset for branch patching. extern
+# / body-less functions contribute no text. an oversized frame (a `SUB SP` past the
+# two-immediate range, or GP callee-saves below the STP/LDP imm7 reach) is materialized
+# through a scratch base.
 fun encode_function_arm64(st: *EncodeState, f: *mir.MirFunction) Result[bool, str] {
     val fn_base: u32 = st.buf.len::u32;
     if (f.block_count == 0) { ret ok[bool, str](true); }
@@ -2072,8 +2125,9 @@ fun encode_function_arm64(st: *EncodeState, f: *mir.MirFunction) Result[bool, st
     val ms: Result[bool, str] = push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
     if (is_err[bool, str](ms)) { ret ms; }
 
+    val naked: bool = function_is_naked(f);
     val subsize: u32 = frame_subsize(f);
-    emit_prologue(st, f, subsize);
+    if (!naked) { emit_prologue(st, f, subsize); }
 
     var bi: u32 = 0;
     for (bi < f.block_count) {
@@ -2084,7 +2138,7 @@ fun encode_function_arm64(st: *EncodeState, f: *mir.MirFunction) Result[bool, st
         var ii: u32 = 0;
         for (ii < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
-            if (mi.opcode::u16 == arm64.RET::u16) {
+            if (mi.opcode::u16 == arm64.RET::u16 && !naked) {
                 emit_epilogue(st, f, subsize);
             }
             val ei: Result[bool, str] = encode_mir_instr(st, f, fn_base, mi);
@@ -3301,6 +3355,115 @@ fun emit_asm_ret(st: *EncodeState, args: str) Result[bool, str] {
     if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm 'ret' operand must be a register"); }
     emit_word(st, RET_BASE | ((op.reg & 0x1F) << 5));
     ret ok[bool, str](true);
+}
+
+# asm_clobbers: the AsmClobbersFn the arm64 ISA vtable exposes — infer the registers
+# an inline-asm body writes, so the allocator leaves no live value in one and the
+# prologue preserves any callee-saved register the body clobbers. without this hook a
+# nil slot forced a conservative all-register clobber, framing every asm function
+# (e.g. `_start`, whose frame `sub sp` then mis-reads argc off the entry stack).
+# mirrors x86-64's `asm_clobbers` for the grammar encode_asm_stmt_arm64 accepts:
+# `{name}` locals substitute to `[x29,#off]` memory (never registers) and contribute
+# nothing; the grammar has no FP mnemonic, so `fp_out` stays empty; an unrecognized
+# statement is opaque and conservatively clobbers every register.
+pub fun asm_clobbers(body: str, gp_out: *u32, fp_out: *u32) {
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+    val len: usize = str_len(body);
+    var start: usize = 0;
+    for (start < len) {
+        var end: usize = start;
+        for (end < len && body[end] != '\n'::char && body[end] != ';'::char) { end = end + 1; }
+        var lo: usize = start;
+        for (lo < end && asm_is_space(body[lo])) { lo = lo + 1; }
+        var hi: usize = end;
+        for (hi > lo && asm_is_space(body[hi - 1])) { hi = hi - 1; }
+        if (hi > lo) {
+            var line: [512]u8;
+            val ll: usize = hi - lo;
+            if (ll >= 512) { gp = 0xFFFFFFFF; fp = 0xFFFFFFFF; }
+            or {
+                var c: usize = 0;
+                for (c < ll) { line[c] = body[lo + c]::u8; c = c + 1; }
+                line[ll] = 0;
+                asm_stmt_clobbers((?line[0])::str, ?gp, ?fp);
+            }
+        }
+        start = end + 1;
+    }
+    @gp_out = gp;
+    @fp_out = fp;
+}
+
+# asm_mark_op: OR the GP register named by operand `idx` of `args` into `@gp`. a non-
+# register operand (memory / immediate / barrier option / symbol) writes no register;
+# a malformed operand list the encoder will reject clobbers conservatively.
+fun asm_mark_op(args: str, idx: u32, gp: *u32) {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { @gp = @gp | 0xFFFFFFFF; ret; }
+    if (idx >= n) { ret; }
+    var bp: *u8 = ?b0[0];
+    if (idx == 1) { bp = ?b1[0]; } or (idx == 2) { bp = ?b2[0]; } or (idx == 3) { bp = ?b3[0]; }
+    var op: AsmOp;
+    if (asm_parse_operand((bp)::str, ?op) && op.kind == ASMOP_REG && op.reg < 32) {
+        @gp = @gp | (1::u32 << op.reg);
+    }
+}
+
+# asm_stmt_clobbers: OR the registers one trimmed aarch64 inline-asm statement writes
+# into `@gp` (the grammar has no FP write). a dest-writing form clobbers operand 0 (ldp
+# both loaded registers; stlxr the status result); a `bl`/`blr`/`br` call clobbers the
+# caller-saved file (x0-x18, x30) and `svc` clobbers x0 — none callee-saved, so they add
+# no frame; stores / compares / branches / barriers write nothing. an unrecognized
+# statement conservatively clobbers everything.
+fun asm_stmt_clobbers(stmt: str, gp: *u32, fp: *u32) {
+    var lnum: u64 = 0;
+    val dlen: usize = asm_label_def_len(stmt, ?lnum);
+    if (dlen > 0) {
+        val rest: str = asm_trim((stmt::usize + dlen)::str);
+        if (rest[0] == 0) { ret; }
+        asm_stmt_clobbers(rest, gp, fp);
+        ret;
+    }
+    var mbuf: [24]u8;
+    var args: str;
+    if (!asm_first_token(stmt, ?mbuf[0], 24, ?args)) { @gp = @gp | 0xFFFFFFFF; @fp = @fp | 0xFFFFFFFF; ret; }
+    val mnem: str = (?mbuf[0])::str;
+
+    # write nothing: barriers, return, trap, compare, stores, plain/conditional branches.
+    if (str_equals(mnem, "nop") || str_equals(mnem, "yield") || str_equals(mnem, "dmb") ||
+        str_equals(mnem, "ret") || str_equals(mnem, "brk") || str_equals(mnem, "cmp") ||
+        str_equals(mnem, "str") || str_equals(mnem, "strb") || str_equals(mnem, "strh") ||
+        str_equals(mnem, "stp") || str_equals(mnem, "stlr") ||
+        str_equals(mnem, "b") || str_equals(mnem, "cbz") || str_equals(mnem, "cbnz")) { ret; }
+    if (str_starts_with(mnem, "b.")) { ret; }
+
+    # a call clobbers the caller-saved file (+ LR); svc clobbers x0. none callee-saved.
+    if (str_equals(mnem, "bl") || str_equals(mnem, "blr") || str_equals(mnem, "br")) {
+        @gp = @gp | 0x4007FFFF;
+        ret;
+    }
+    if (str_equals(mnem, "svc")) { @gp = @gp | 0x1; ret; }
+
+    # ldp writes both loaded registers.
+    if (str_equals(mnem, "ldp")) { asm_mark_op(args, 0, gp); asm_mark_op(args, 1, gp); ret; }
+
+    # dest = operand 0: data-processing / load / shift forms and stlxr's status reg.
+    if (str_equals(mnem, "mov") || str_equals(mnem, "movz") || str_equals(mnem, "movk") ||
+        str_equals(mnem, "add") || str_equals(mnem, "sub") || str_equals(mnem, "and") ||
+        str_equals(mnem, "orr") || str_equals(mnem, "eor") || str_equals(mnem, "adrp") ||
+        str_equals(mnem, "ldr") || str_equals(mnem, "ldrb") || str_equals(mnem, "ldrh") ||
+        str_equals(mnem, "ldar") || str_equals(mnem, "ldaxr") || str_equals(mnem, "stlxr") ||
+        str_equals(mnem, "lsl") || str_equals(mnem, "lsr") || str_equals(mnem, "asr") ||
+        str_equals(mnem, "lslv") || str_equals(mnem, "lsrv") || str_equals(mnem, "asrv")) {
+        asm_mark_op(args, 0, gp);
+        ret;
+    }
+
+    # unrecognized: opaque, clobber everything (a sound over-approximation).
+    @gp = @gp | 0xFFFFFFFF;
+    @fp = @fp | 0xFFFFFFFF;
 }
 
 # encode_asm_stmt_arm64: parse and encode one trimmed inline-asm statement. a numeric

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1188,11 +1188,29 @@ fun emit_fp_slot_store(st: *EncodeState, f: *mir.MirFunction, memop: *mir.MirOpe
     ret ok[bool, str](true);
 }
 
+# emit_fp_imm: materialize a float-constant bit pattern into vector register index
+# `vd`. the bits — a 32-bit pattern for an f32, a 64-bit pattern for an f64 (the
+# shape a float CONSTANT carries through lowering) — are materialized into the IP0 GP
+# scratch via the shared movewide sequence, then bit-copied into `vd` with the GP->FP
+# reinterpret FMOV (Sd,Wn for an f32, Dd,Xn for an f64). the AArch64 twin of x86-64's
+# float-constant load (MOVABS R11 + MOVQ xmm); IP0 is the reserved encoder scratch,
+# so a single instruction's materialization never collides with a live value.
+# `width` is 4 (S) or 8 (D).
+fun emit_fp_imm(st: *EncodeState, vd: u32, bits: u64, width: u8) {
+    val use64: bool = width == 8;
+    emit_movewide_seq(st, SCRATCH0, bits, use64);
+    var base: u32 = FMOV_S_FROM_W;
+    if (use64) { base = FMOV_D_FROM_X; }
+    emit_word(st, pack_alu3(base, vd, SCRATCH0, 0));
+}
+
 # resolve_fp_source: the vector register index a float source operand contributes.
 # a physical vector register is used directly; a spilled float arrives as a frame-
 # slot MEM operand (the shared allocator leaves a spilled float in place rather than
 # reloading it through a GP temp) and is loaded into `scratch`, whose index is then
-# returned. `width` (4 / 8) sizes the load.
+# returned; a float-constant immediate is materialized into `scratch` through IP0 +
+# a GP->FP FMOV (mirroring x86-64), whose index is returned. `width` (4 / 8) sizes
+# the load / the S-vs-D materialization.
 fun resolve_fp_source(st: *EncodeState, f: *mir.MirFunction, op: *mir.MirOperand, scratch: u32, width: u8) Result[i32, str] {
     if (op.kind == mir.MIR_OP_MEM) {
         val mr: Result[A64Mem, str] = resolve_mem(f, op);
@@ -1200,6 +1218,10 @@ fun resolve_fp_source(st: *EncodeState, f: *mir.MirFunction, op: *mir.MirOperand
         val m: A64Mem = unwrap_ok[A64Mem, str](mr);
         if (m.has_index) { ret err[i32, str]("encode: indexed float spill operand not expected"); }
         emit_fp_mem(st, scratch, m.base, m.off, width, true);
+        ret ok[i32, str](scratch::i32);
+    }
+    if (op.kind == mir.MIR_OP_IMM) {
+        emit_fp_imm(st, scratch, op.imm::u64, width);
         ret ok[i32, str](scratch::i32);
     }
     ret req_vec(op);
@@ -1437,8 +1459,12 @@ fun encode_fp_conv(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Res
     ret ok[bool, str](true);
 }
 
-# encode_fmov: materialize a float register copy or a GP<->FP `:~` bitcast (both
-# selected to FMOV), dispatching on operand register CLASS and spill state:
+# encode_fmov: materialize a float register copy, a GP<->FP `:~` bitcast (both
+# selected to FMOV), or a float-constant immediate move, dispatching on the source
+# shape, operand register CLASS, and spill state:
+#   - immediate source (a float CONSTANT): the bit pattern is materialized into the
+#     destination vector register (or V31 then stored for a spilled destination) via
+#     IP0 + a GP->FP FMOV — see `emit_fp_imm`.
 #   - vector <- vector: `fmov Sd|Dd, Sn|Dn` (float copy).
 #   - vector <- GP / GP <- vector: the cross-bank `fmov Sd,Wn` / `fmov Dd,Xn` and
 #     `fmov Wd,Sn` / `fmov Xd,Dn` bit reinterprets.
@@ -1453,6 +1479,22 @@ fun encode_fmov(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result
     val dbl: bool = w == 8;
     val dst: *mir.MirOperand = ?mi.operands[0];
     val src: *mir.MirOperand = ?mi.operands[1];
+
+    # a float-constant immediate source: the FP isel's CONSTANT move and the pre-colored
+    # FP return move to V0 both reach here as `FMOV vec <- imm`. materialize the bit
+    # pattern into the destination vector register (the register IS the target, IP0 for
+    # the bits + a GP->FP FMOV), or into V31 then store for a spilled destination — never
+    # routed to the GP req_* paths, which would mis-read the float constant.
+    if (src.kind == mir.MIR_OP_IMM) {
+        if (dst.kind == mir.MIR_OP_MEM) {
+            emit_fp_imm(st, FP_SCRATCH0, src.imm::u64, w);
+            ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, w);
+        }
+        val rdr: Result[i32, str] = req_vec(dst);
+        if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+        emit_fp_imm(st, unwrap_ok[i32, str](rdr)::u32, src.imm::u64, w);
+        ret ok[bool, str](true);
+    }
 
     if (dst.kind != mir.MIR_OP_MEM && src.kind != mir.MIR_OP_MEM) {
         val dvec: bool = reg_is_vec(dst);
@@ -3934,6 +3976,56 @@ test "arm64.encode: FCVT S<->D and GP<->FP bitcast FMOV match llvm-mc" {
     encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E260020) { bad = 1; }
     mi.width = 8; st.buf.len = 0;
     encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E660020) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# float-constant immediate materialization: a float CONSTANT reaches the encoder as a
+# MIR_OP_IMM carrying the value's bit pattern (an f32's 32-bit / an f64's 64-bit
+# pattern). a `FMOV vec <- imm` (the FP isel's CONSTANT move and the pre-colored FP
+# return move) materializes the bits into IP0 with the movewide sequence then bit-
+# copies them into the destination vector register with the GP->FP FMOV; an FP-arith
+# immediate operand routes the same materialization into the held-back FP scratch.
+test "arm64.encode: float-constant immediate materialization matches llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [3]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # f64 0.1 = 0x3FB999999999999A -> v0:
+    #   movz x16,#0x999a ; movk x16,#0x9999,lsl#16 ; movk x16,#0x9999,lsl#32 ;
+    #   movk x16,#0x3fb9,lsl#48 ; fmov d0, x16
+    ops[0] = tvec(0); ops[1] = mir.op_imm(0x3FB999999999999A);
+    mi.opcode = arm64.FMOV::u32; mi.width = 8; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0)  != 0xD2933350) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0xF2B33330) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0xF2D33330) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0xF2E7F730) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0x9E670200) { bad = 1; }
+
+    # f32 0.1 = 0x3DCCCCCD -> v0: movz w16,#0xcccd ; movk w16,#0x3dcc,lsl#16 ; fmov s0, w16
+    ops[1] = mir.op_imm(0x3DCCCCCD);
+    mi.width = 4; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0) != 0x529999B0) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x72A7B990) { bad = 1; }
+    if (read_word(?st.buf, 8) != 0x1E270200) { bad = 1; }
+
+    # FP-arith immediate operand: a * 2.0 (rhs 2.0 = 0x4000000000000000) -> fmul d0, d1, d30
+    #   movz x16,#0x4000,lsl#48 ; fmov d30, x16 ; fmul d0, d1, d30
+    mi.operand_count = 3;
+    ops[0] = tvec(0); ops[1] = tvec(1); ops[2] = mir.op_imm(0x4000000000000000);
+    mi.opcode = mir.MIR_FMUL; mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0) != 0xD2E80010) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x9E67021E) { bad = 1; }
+    if (read_word(?st.buf, 8) != 0x1E7E0820) { bad = 1; }
 
     buf_dnit(?st.buf);
     ret bad;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -12,22 +12,24 @@
 # the shared `enc` module; this backend supplies only the A64 bitfield packers,
 # prologue/epilogue emission, and branch patching.
 #
-# SCOPE (Phase 3a — frames + non-symbol memory + integer conversions, atop the
-# Phase 2b leaf integer core). Every modeled form is byte-exact against llvm-mc:
-# the three-address integer ALU (ADD/SUB/MUL/AND/ORR/EOR), the shifts (register
-# LSLV/LSRV/ASRV and immediate UBFM/SBFM aliases), NEG/MVN/MOV, the MOVZ/MOVK
-# immediate materialization, RET, CMP (SUBS XZR) + CSET, the unconditional branch
-# B, the conditional branch (CBNZ + B), and the BRK unreachable trap; plus the
-# record-at-top non-leaf prologue (STP/MOV record, `SUB SP` frame, GP callee-save
-# STP/LDP pairs) and epilogue, frame-slot / spill memory operands addressed
-# `[x29 + slot.offset]`, non-symbol LDR/STR with scaled-imm12 / unscaled-imm9 /
-# register-offset legalization, GEP / ALLOCA address arithmetic, and the integer
-# conversions (TRUNC / SEXT-SXTB/SXTH/SXTW / ZEXT-UXTB/UXTH / GP BITCAST). The
-# contract gaps DEFERRED to a later phase (an in-scope function never reaches them,
-# so they fail loudly rather than emit wrong bytes): calls and their relocations
-# (Phase 3b), symbol relocations incl. folded-global ADRP+LDR and address-of
-# ADRP+ADD (Phase 3b), inline asm (Phase 3c), callee-saved FP registers, and the
-# float / float-conversion families (Phase 4).
+# SCOPE (Phase 3b — calls + symbol relocations, atop the Phase 3a frames + memory +
+# conversions core). Every modeled form is byte-exact against llvm-mc: the three-
+# address integer ALU (ADD/SUB/MUL/AND/ORR/EOR), the shifts (register LSLV/LSRV/ASRV
+# and immediate UBFM/SBFM aliases), NEG/MVN/MOV, the MOVZ/MOVK immediate
+# materialization, RET, CMP (SUBS XZR) + CSET, the unconditional branch B, the
+# conditional branch (CBNZ + B), and the BRK unreachable trap; plus the record-at-top
+# non-leaf prologue (STP/MOV record, `SUB SP` frame, GP callee-save STP/LDP pairs)
+# and epilogue — oversized frames materialized through a scratch base — frame-slot /
+# spill memory operands addressed `[x29 + slot.offset]`, non-symbol LDR/STR with
+# scaled-imm12 / unscaled-imm9 / register-offset legalization, GEP / ALLOCA address
+# arithmetic, the integer conversions (TRUNC / SEXT-SXTB/SXTH/SXTW / ZEXT-UXTB/UXTH /
+# GP BITCAST), the direct (`BL` + RK_PLT32→CALL26) and indirect (`BLR Xn`) call, the
+# folded-global load/store (`ADRP IP0` + `LDR/STR :lo12:`, RK_PAGE21 + the per-width
+# RK_LDST*_LO12), and the address-of rvalue (`ADRP` + `ADD :lo12:`, RK_PAGE21 +
+# RK_ADD_LO12). The contract gaps DEFERRED to a later phase (an in-scope function
+# never reaches them, so they fail loudly rather than emit wrong bytes): inline asm
+# (Phase 3c), callee-saved FP registers, and the float / float-conversion families
+# (Phase 4).
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -49,6 +51,7 @@ use std.types.option.is_some;
 use std.types.option.unwrap;
 
 use std.allocator.Allocator;
+use std.allocator.deallocate;
 use page: std.allocator.page;
 
 use intern: mach.lang.intern;
@@ -156,6 +159,18 @@ val CBNZ_X:    u32 = 0xB5000000; val CBNZ_W: u32 = 0x35000000;
 val RET_WORD:  u32 = 0xD65F03C0;
 val BRK_BASE:  u32 = 0xD4200000;
 val NOP_WORD:  u32 = 0xD503201F;
+# the call family: BL (imm26 displacement placeholder, the RK_PLT32 patch site for a
+# direct call) and the register-indirect BLR (Rn[9:5] zeroed in the base).
+val BL_BASE:   u32 = 0x94000000;
+val BLR_BASE:  u32 = 0xD63F0000;
+# ADRP (page-relative high-21 address, immlo/immhi zeroed) — the high half of a
+# symbol reference; it pairs with an ADD `:lo12:` (address-of) or an LDR/STR
+# `:lo12:` (folded global) low half, both naming the same symbol.
+val ADRP_BASE: u32 = 0x90000000;
+# SUB SP, SP, Xm (extended-register, UXTX, imm3=0) — the oversized-frame `SUB SP`
+# fallback when the allocation exceeds the imm12 / imm12<<12 two-immediate reach.
+# the base bakes Rn=SP, Rd=SP, option=UXTX; only Rm[20:16] is OR-ed in.
+val SUB_SP_REG_X: u32 = 0xCB2063FF;
 
 # the zero register / stack pointer encode as register 31 in the relevant fields.
 val ZR: u32 = 31;
@@ -168,12 +183,12 @@ val SCRATCH1: u32 = 17;
 # the deepest the GP callee-save STP/LDP pairs reach below x29: the scaled 7-bit
 # signed immediate spans -64..63 eightbytes, so the pair offset `-(frame.size +
 # pair_bytes)` is bounded below by -512. a function whose `frame.size + GP-save
-# area` exceeds this reaches Phase 3b's scratch-base callee-save addressing; until
-# then it fails loudly rather than truncate the STP immediate.
+# area` exceeds this switches `save_callee_gp` to scratch-base (IP0-anchored)
+# addressing rather than truncate the STP immediate.
 val MAX_CALLEE_SAVE_REACH: u32 = 504;
-# the largest frame the prologue's `SUB SP` can allocate with the two-immediate
+# the largest frame the prologue's `SUB SP` allocates with the two-immediate
 # (imm12 + imm12<<12) form: `(0xFFF << 12) + 0xFF0` rounded to 16. a frame beyond
-# ~16 MiB fails loudly rather than mis-encode the subtraction.
+# ~16 MiB falls back to materializing the size into IP0 and `SUB SP, SP, X16`.
 val MAX_FRAME_SUB: u32 = 0xFFFFF0;
 
 # A64 condition codes (bits[3:0] of a conditional form). the CSET / B.cond
@@ -273,6 +288,29 @@ fun pack_ldur(base: u32, rt: u32, rn: u32, imm9: u32) u32 {
 # materialized into the scratch register).
 fun pack_ldst_reg(base: u32, rt: u32, rn: u32, rm: u32) u32 {
     ret base | ((rm & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rt & 0x1F);
+}
+
+# pack_blr: a register-indirect branch-with-link word — Rn[9:5] OR-ed into BLR_BASE.
+fun pack_blr(rn: u32) u32 {
+    ret BLR_BASE | ((rn & 0x1F) << 5);
+}
+
+# pack_adrp: an ADRP word with a zero page-delta placeholder — Rd[4:0] OR-ed into
+# ADRP_BASE. the linker's RK_PAGE21 packer fills immlo/immhi at link time.
+fun pack_adrp(rd: u32) u32 {
+    ret ADRP_BASE | (rd & 0x1F);
+}
+
+# ldst_lo12_kind: the per-width LDR/STR low-12 relocation kind for an access width
+# (Option B — the linker derives the imm12 scale from the kind, never an instruction
+# decode). mirrors `ldst_base_scaled`'s width branching: 1/2/4 select the byte /
+# halfword / word kinds, every other width (8, or a 0 pseudo-width defaulted to the
+# machine word) the doubleword kind.
+fun ldst_lo12_kind(w: u8) of.RelocKind {
+    if (w == 1) { ret of.RK_LDST8_LO12; }
+    if (w == 2) { ret of.RK_LDST16_LO12; }
+    if (w == 4) { ret of.RK_LDST32_LO12; }
+    ret of.RK_LDST64_LO12;
 }
 
 # width_shift: the log2 of an access size (1/2/4/8 -> 0/1/2/3) — the scaled-offset
@@ -540,6 +578,105 @@ fun scale_shift(scale: u8) u32 {
     ret 0;
 }
 
+# ---- symbol relocations (ADRP page + lo12 low half) ----
+
+# emit_adrp_reloc: emit `adrp Xd, sym` with a zero page-delta placeholder and record
+# the RK_PAGE21 relocation at the instruction-word start (the A64 reloc-offset
+# convention). the high half of every symbol reference; the caller pairs it with an
+# ADD or LDR/STR `:lo12:` low half naming the same symbol.
+fun emit_adrp_reloc(st: *EncodeState, rd: u32, sym: intern.StrId, addend: i32) Result[bool, str] {
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_adrp(rd));
+    ret push_reloc(st, arm64_reloc_offset(pos), of.RK_PAGE21, sym, addend);
+}
+
+# emit_global_addr: a symbol address as an rvalue (the LEA equivalent) —
+# `adrp Xd, sym` (RK_PAGE21) ; `add Xd, Xd, :lo12:sym` (RK_ADD_LO12). both immediates
+# are zero placeholders the linker fills; the addend is the symbol's own constant
+# only (no pc-relative correction — the ADD low half is absolute).
+fun emit_global_addr(st: *EncodeState, rd: u32, symop: *mir.MirOperand) Result[bool, str] {
+    if (symop.sym == intern.STR_NIL) {
+        ret err[bool, str]("encode: address-of has no resolved symbol name");
+    }
+    val ar: Result[bool, str] = emit_adrp_reloc(st, rd, symop.sym, symop.sym_off);
+    if (is_err[bool, str](ar)) { ret ar; }
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_addsub_imm(ADDI_X, rd, rd, 0, 0));
+    ret push_reloc(st, arm64_reloc_offset(pos), of.RK_ADD_LO12, symop.sym, symop.sym_off);
+}
+
+# emit_global_load: a folded-global load — `adrp IP0, sym` (RK_PAGE21) ;
+# `ldr Xt, [IP0, :lo12:sym]` (the per-width RK_LDST*_LO12). IP0 (reserved scratch)
+# holds the page base; the LDR imm12 is a zero placeholder the linker shifts the
+# low-12 into by the kind's access-width scale (Option B). the zero-extending load
+# form covers a sub-word access exactly as the non-symbol path does.
+fun emit_global_load(st: *EncodeState, rt: u32, symop: *mir.MirOperand, width: u8) Result[bool, str] {
+    if (symop.sym == intern.STR_NIL) {
+        ret err[bool, str]("encode: folded-global load has no resolved symbol name");
+    }
+    var w: u8 = width;
+    if (w == 0) { w = 8; }
+    val ar: Result[bool, str] = emit_adrp_reloc(st, SCRATCH0, symop.sym, symop.sym_off);
+    if (is_err[bool, str](ar)) { ret ar; }
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_ldst(ldst_base_scaled(w, true), rt, SCRATCH0, 0));
+    ret push_reloc(st, arm64_reloc_offset(pos), ldst_lo12_kind(w), symop.sym, symop.sym_off);
+}
+
+# emit_global_store: a folded-global store — `adrp IP0, sym` (RK_PAGE21) ;
+# `str Xt, [IP0, :lo12:sym]` (the per-width RK_LDST*_LO12). the stored value resolves
+# first (the zero register for an immediate 0, IP1 for a non-zero immediate, the
+# value's own register otherwise) so the page-base materialization in IP0 never
+# clobbers it. IP0 / IP1 are reserved scratch, never an allocated value.
+fun emit_global_store(st: *EncodeState, symop: *mir.MirOperand, val_op: *mir.MirOperand, width: u8) Result[bool, str] {
+    if (symop.sym == intern.STR_NIL) {
+        ret err[bool, str]("encode: folded-global store has no resolved symbol name");
+    }
+    var w: u8 = width;
+    if (w == 0) { w = 8; }
+
+    var rt: u32 = ZR;
+    if (val_op.kind == mir.MIR_OP_IMM) {
+        if (val_op.imm != 0) {
+            emit_movewide_seq(st, SCRATCH1, val_op.imm::u64, is64(width));
+            rt = SCRATCH1;
+        }
+    } or {
+        val rr: Result[i32, str] = req_gpr(val_op);
+        if (is_err[i32, str](rr)) { ret err[bool, str](unwrap_err[i32, str](rr)); }
+        rt = unwrap_ok[i32, str](rr)::u32;
+    }
+
+    val ar: Result[bool, str] = emit_adrp_reloc(st, SCRATCH0, symop.sym, symop.sym_off);
+    if (is_err[bool, str](ar)) { ret ar; }
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_ldst(ldst_base_scaled(w, false), rt, SCRATCH0, 0));
+    ret push_reloc(st, arm64_reloc_offset(pos), ldst_lo12_kind(w), symop.sym, symop.sym_off);
+}
+
+# encode_call: a direct or indirect call. a MIR_OP_SYM callee emits `bl sym` with a
+# zero imm26 placeholder and records RK_PLT32 at the instruction-word start (the
+# linker maps it to CALL26; addend is the symbol's own constant only — no x86 -4
+# correction, per the Phase-0 CALL26 packer). a register callee (a function pointer
+# regalloc placed in a preg) emits the register-indirect `blr Xn`. MIR_CALL stays the
+# caller-saved clobber barrier the allocator keyed on; this only emits its bytes.
+fun encode_call(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 1) { ret err[bool, str]("encode: call missing callee operand"); }
+    val callee: *mir.MirOperand = ?mi.operands[0];
+    if (callee.kind == mir.MIR_OP_SYM) {
+        if (callee.sym == intern.STR_NIL) {
+            ret err[bool, str]("encode: direct call has no resolved symbol name");
+        }
+        val pos: u32 = st.buf.len::u32;
+        emit_word(st, BL_BASE);
+        ret push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, callee.sym, callee.sym_off);
+    }
+    val rr: Result[i32, str] = req_gpr(callee);
+    if (is_err[i32, str](rr)) { ret err[bool, str](unwrap_err[i32, str](rr)); }
+    emit_word(st, pack_blr(unwrap_ok[i32, str](rr)::u32));
+    ret ok[bool, str](true);
+}
+
 # ---- per-opcode encoders ----
 
 # encode_alu3: a three-address integer ALU op `op Rd, Rn, Rm`. the right operand
@@ -718,10 +855,10 @@ fun encode_mov(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[
 # emit_store_mem: store the value operand `val_op` to the resolved memory operand
 # `dst_mem` at byte `width`. a register value stores directly; an immediate 0 stores
 # the zero register; a non-zero immediate is materialized into IP1 first. a symbol
-# destination (a folded-global store) is a Phase 3b relocation, deferred loudly.
+# destination is a folded-global store: `adrp IP0, sym` + `str Xt, [IP0, :lo12:sym]`.
 fun emit_store_mem(st: *EncodeState, f: *mir.MirFunction, dst_mem: *mir.MirOperand, val_op: *mir.MirOperand, width: u8) Result[bool, str] {
     if (dst_mem.kind == mir.MIR_OP_SYM) {
-        ret err[bool, str]("aarch64 folded-global store relocation not implemented (Phase 3b)");
+        ret emit_global_store(st, dst_mem, val_op, width);
     }
     val mr: Result[A64Mem, str] = resolve_mem(f, dst_mem);
     if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
@@ -744,9 +881,9 @@ fun emit_store_mem(st: *EncodeState, f: *mir.MirFunction, dst_mem: *mir.MirOpera
 }
 
 # encode_load: a `MIR_LOAD reg <- [mem]`. the destination is a register; the source
-# is a non-symbol frame-slot or pointer-register memory operand loaded at the access
-# width (`src_width`) with the zero-extending form. a symbol source (a folded-global
-# load) is a Phase 3b relocation, deferred loudly.
+# is a frame-slot or pointer-register memory operand loaded at the access width
+# (`src_width`) with the zero-extending form, or a folded-global symbol source
+# (`adrp IP0, sym` + `ldr Xt, [IP0, :lo12:sym]`, the two-reloc primary global path).
 fun encode_load(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
     if (mi.operand_count < 2) { ret err[bool, str]("encode: load missing operands"); }
     val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
@@ -755,7 +892,7 @@ fun encode_load(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result
 
     val src: *mir.MirOperand = ?mi.operands[1];
     if (src.kind == mir.MIR_OP_SYM) {
-        ret err[bool, str]("aarch64 folded-global load relocation not implemented (Phase 3b)");
+        ret emit_global_load(st, rd, src, mi.src_width);
     }
     val mr: Result[A64Mem, str] = resolve_mem(f, src);
     if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
@@ -775,8 +912,8 @@ fun encode_store(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Resul
 # encode_addr: a `MIR_GEP` / `MIR_ALLOCA` address computation `Rd <- base +
 # index*scale + disp` (the x86-64 LEA analogue). the constant displacement folds
 # into an ADD/SUB immediate (or a materialized add); a scaled runtime index folds
-# into an `add Rd, base, index, lsl #shift`. a symbol base (an address-of relocation)
-# is a Phase 3b ADRP+ADD sequence, deferred loudly.
+# into an `add Rd, base, index, lsl #shift`. a symbol base is the address-of
+# `adrp Rd, sym` + `add Rd, Rd, :lo12:sym` rvalue sequence.
 fun encode_addr(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
     if (mi.operand_count < 2) { ret err[bool, str]("encode: address op missing operands"); }
     val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
@@ -785,7 +922,7 @@ fun encode_addr(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result
 
     val memop: *mir.MirOperand = ?mi.operands[1];
     if (memop.kind == mir.MIR_OP_SYM) {
-        ret err[bool, str]("aarch64 address-of relocation not implemented (Phase 3b)");
+        ret emit_global_addr(st, rd, memop);
     }
     val mr: Result[A64Mem, str] = resolve_mem(f, memop);
     if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
@@ -978,19 +1115,25 @@ fun frame_subsize(f: *mir.MirFunction) u32 {
     ret align16(gp_bytes + fp_bytes + f.frame.size + f.frame.outgoing_size);
 }
 
-# emit_sp_sub: subtract a 16-aligned frame size from SP, folding it into a single
-# `SUB SP, SP, #imm12`, a `SUB SP, SP, #imm12, lsl #12` (plus a low `SUB` remainder)
-# for a frame beyond 12 bits, per the imm12 / imm12<<12 split. `subsize` is non-zero
-# and within `MAX_FRAME_SUB` (the caller range-checks).
+# emit_sp_sub: subtract a 16-aligned frame size from SP. a frame within 12 bits folds
+# into a single `SUB SP, SP, #imm12`; one within the imm12 / imm12<<12 two-immediate
+# split (up to `MAX_FRAME_SUB`) into `SUB SP, SP, #hi, lsl #12` plus a low `SUB`
+# remainder; a larger frame materializes the size into IP0 and subtracts the register
+# (`SUB SP, SP, X16`, the extended-register form SP requires). `subsize` is non-zero.
 fun emit_sp_sub(st: *EncodeState, subsize: u32) {
     if (subsize <= 0xFFF) {
         emit_word(st, pack_addsub_imm(SUBI_X, ZR, ZR, subsize, 0));
         ret;
     }
-    val hi: u32 = subsize >> 12;
-    val lo: u32 = subsize & 0xFFF;
-    emit_word(st, pack_addsub_imm(SUBI_X, ZR, ZR, hi, 1));
-    if (lo != 0) { emit_word(st, pack_addsub_imm(SUBI_X, ZR, ZR, lo, 0)); }
+    if (subsize <= MAX_FRAME_SUB) {
+        val hi: u32 = subsize >> 12;
+        val lo: u32 = subsize & 0xFFF;
+        emit_word(st, pack_addsub_imm(SUBI_X, ZR, ZR, hi, 1));
+        if (lo != 0) { emit_word(st, pack_addsub_imm(SUBI_X, ZR, ZR, lo, 0)); }
+        ret;
+    }
+    emit_movewide_seq(st, SCRATCH0, subsize::u64, true);
+    emit_word(st, SUB_SP_REG_X | ((SCRATCH0 & 0x1F) << 16));
 }
 
 # emit_prologue: the AArch64 record-at-top prologue. `STP X29, X30, [SP, #-16]!`
@@ -1025,11 +1168,18 @@ fun emit_epilogue(st: *EncodeState, f: *mir.MirFunction, subsize: u32) {
 
 # save_callee_gp: save (or restore) the callee-saved GP registers `callee_mask`
 # selects, in ascending register order, just below the local frame (`frame.size`).
-# they are addressed x29-relatively at descending negative offsets: each STP/LDP
-# pair occupies a 16-byte slot (the first at `[x29, #-(frame.size + 16)]`), and a
-# trailing odd register takes an 8-byte STUR/LDUR slot below the last pair. the
-# whole area sits within `frame_subsize`'s GP region, below the locals and above the
-# outgoing-argument region, so it overlaps neither.
+# they are addressed at descending negative offsets: each STP/LDP pair occupies a
+# 16-byte slot (the first at offset `-(frame.size + 16)`), and a trailing odd
+# register takes an 8-byte STUR/LDUR slot below the last pair. the whole area sits
+# within `frame_subsize`'s GP region, below the locals and above the outgoing-
+# argument region, so it overlaps neither.
+#
+# the area is addressed x29-relatively (the Phase 3a form, byte-identical for an
+# in-reach frame) while `frame.size + GP-save area` is within the STP/LDP scaled
+# imm7 reach (`MAX_CALLEE_SAVE_REACH`). beyond it, a scratch base (IP0) is anchored
+# at the area start (`IP0 = x29 - (frame.size + 16)`) so the per-pair offsets — which
+# span only the small callee-save area (at most ~31 registers, far within imm7) —
+# stay encodable; the deep `frame.size` distance is absorbed once into the anchor.
 fun save_callee_gp(st: *EncodeState, f: *mir.MirFunction, store: bool) {
     var regs: [32]u32;
     var n: u32 = 0;
@@ -1038,31 +1188,46 @@ fun save_callee_gp(st: *EncodeState, f: *mir.MirFunction, store: bool) {
         if ((f.callee_mask & (1::u32 << r)) != 0) { regs[n] = r; n = n + 1; }
         r = r + 1;
     }
+    if (n == 0) { ret; }
 
     val fs: i32 = f.frame.size::i32;
+    val gp_bytes: u32 = n * 8;
     val num_pairs: u32 = n / 2;
+
+    # the base register and the magnitude of the first pair's offset from it: x29
+    # directly (anchor = frame.size + 16) when in reach, else IP0 anchored at the
+    # area start (anchor = 0).
+    var base_reg: u32 = 29;
+    var anchor: i32 = fs + 16;
+    if (f.frame.size + gp_bytes > MAX_CALLEE_SAVE_REACH) {
+        emit_add_imm(st, SCRATCH0, 29, 0 - ((fs + 16)::i64));
+        base_reg = SCRATCH0;
+        anchor = 0;
+    }
+
     var p: u32 = 0;
     for (p < num_pairs) {
-        val base_off: i32 = 0 - (fs + 16 + (16 * p)::i32);
+        val base_off: i32 = 0 - (anchor + (16 * p)::i32);
         val imm7: u32 = (base_off / 8)::u32 & 0x7F;
-        if (store) { emit_word(st, pack_ldstp(STP_OFF_X, regs[2 * p], regs[2 * p + 1], 29, imm7)); }
-        or         { emit_word(st, pack_ldstp(LDP_OFF_X, regs[2 * p], regs[2 * p + 1], 29, imm7)); }
+        if (store) { emit_word(st, pack_ldstp(STP_OFF_X, regs[2 * p], regs[2 * p + 1], base_reg, imm7)); }
+        or         { emit_word(st, pack_ldstp(LDP_OFF_X, regs[2 * p], regs[2 * p + 1], base_reg, imm7)); }
         p = p + 1;
     }
     if ((n & 1) == 1) {
-        val single_off: i32 = 0 - (fs + 8 + (16 * num_pairs)::i32);
-        emit_mem_access(st, regs[n - 1], 29, single_off::i64, 8, !store);
+        val single_off: i32 = 0 - (anchor + (16 * num_pairs)::i32 - 8);
+        emit_mem_access(st, regs[n - 1], base_reg, single_off::i64, 8, !store);
     }
 }
 
 # ---- per-instruction dispatch ----
 
 # encode_mir_instr: translate one post-regalloc MIR instruction into A64 bytes,
-# recording any intra-module branch fixup. the regalloc parallel-copy / liveness
-# pseudos emit nothing; the surviving comparison / conditional-branch / memory /
-# conversion opcodes expand into their byte sequences; the float, call, symbol-
-# relocation, inline-asm, and varargs families are rejected loudly (an in-scope
-# function never reaches them).
+# recording any intra-module branch fixup or symbol relocation. the regalloc
+# parallel-copy / liveness pseudos emit nothing; the surviving comparison /
+# conditional-branch / memory / conversion opcodes expand into their byte sequences;
+# MIR_CALL emits the direct/indirect call (recording its CALL26 relocation); the
+# float, inline-asm, and varargs families are rejected loudly (an in-scope function
+# never reaches them).
 fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) Result[bool, str] {
     val op: u16 = mi.opcode::u16;
 
@@ -1116,7 +1281,7 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
         ret err[bool, str]("aarch64 float conversions not implemented (Phase 4)");
     }
     if (mi.opcode == mir.MIR_CALL) {
-        ret err[bool, str]("aarch64 calls not implemented (Phase 3b)");
+        ret encode_call(st, mi);
     }
     if (mi.opcode == mir.MIR_ASM) {
         ret err[bool, str]("aarch64 inline asm not implemented (Phase 3c)");
@@ -1146,10 +1311,10 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
 # encode_function_arm64: the per-function encode hook (pass 1). marks the function
 # entry symbol, emits the record-at-top prologue, then each block — emitting the
 # epilogue before every RET — recording each block's `.text` offset for branch
-# patching. extern / body-less functions contribute no text. a frame beyond this
-# phase's reach (callee-saved FP registers, a `SUB SP` past the two-immediate range,
-# or GP callee-saves below the STP/LDP immediate reach) is rejected loudly rather
-# than mis-encoded.
+# patching. extern / body-less functions contribute no text. an oversized frame (a
+# `SUB SP` past the two-immediate range, or GP callee-saves below the STP/LDP imm7
+# reach) is materialized through a scratch base; callee-saved FP registers remain a
+# Phase 4 loud defer.
 fun encode_function_arm64(st: *EncodeState, f: *mir.MirFunction) Result[bool, str] {
     val fn_base: u32 = st.buf.len::u32;
     if (f.block_count == 0) { ret ok[bool, str](true); }
@@ -1161,17 +1326,6 @@ fun encode_function_arm64(st: *EncodeState, f: *mir.MirFunction) Result[bool, st
         ret err[bool, str]("aarch64 callee-saved FP registers not implemented (Phase 4)");
     }
     val subsize: u32 = frame_subsize(f);
-    if (subsize > MAX_FRAME_SUB) {
-        ret err[bool, str]("aarch64 frame larger than the SUB SP two-immediate range not implemented (Phase 3b)");
-    }
-    # the GP callee-save STP/LDP pairs address x29-relatively below `frame.size`; a
-    # frame whose locals + GP-save area exceed the scaled imm7 reach needs Phase 3b's
-    # scratch-base addressing, so reject it rather than truncate the STP immediate.
-    val gp_bytes: u32 = popcount32(f.callee_mask) * 8;
-    if (gp_bytes != 0 && f.frame.size + gp_bytes > MAX_CALLEE_SAVE_REACH) {
-        ret err[bool, str]("aarch64 callee-save area beyond the STP/LDP immediate reach not implemented (Phase 3b)");
-    }
-
     emit_prologue(st, f, subsize);
 
     var bi: u32 = 0;
@@ -1238,10 +1392,10 @@ fun patch_branch_arm64(st: *EncodeState, fx: *BranchFixup, target_off: u32) Resu
 
 # arm64_reloc_offset: the byte offset, within an encoded instruction, where a
 # relocation field begins — always the instruction-word start on A64 (the linker
-# packers read the access kind from the relocation, not an instruction decode). a
-# leaf integer function emits no symbol references, so no relocation is recorded in
-# this phase; this is the patch-site convention the call/global lowering of Phase 3
-# will record against.
+# packers read the access kind from the relocation, not an instruction decode). every
+# A64 relocation (CALL26, PAGE21, ADD_LO12, the per-width LDST*_LO12) patches a
+# single 32-bit instruction word, so the call / folded-global / address-of encoders
+# record their relocs against this offset.
 fun arm64_reloc_offset(inst_start: u32) u32 {
     ret inst_start;
 }
@@ -1825,6 +1979,177 @@ test "arm64.encode: end-to-end leaf add(w0,w1) body matches llvm-mc" {
     encode_addsub(?st, ?mi, false);
     # add w0, w0, w1 = 0x0b010000
     if (read_word(?st.buf, 0) != 0x0B010000) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the Phase 3b call + symbol-relocation base words (reloc fields zero pre-link): the
+# direct/indirect call, the folded-global ADRP+LDR/STR per width, and the address-of
+# ADRP+ADD, all asserted against llvm-mc, plus the per-width LO12 kind mapping.
+test "arm64.encode: call + symbol-reloc base words match llvm-mc" {
+    var bad: i32 = 0;
+    # bl 0 = 0x94000000 ; blr x0 = 0xd63f0000 ; blr x9 = 0xd63f0120 ; blr x16 = 0xd63f0200
+    if (BL_BASE != 0x94000000) { bad = 1; }
+    if (pack_blr(0)  != 0xD63F0000) { bad = 1; }
+    if (pack_blr(9)  != 0xD63F0120) { bad = 1; }
+    if (pack_blr(16) != 0xD63F0200) { bad = 1; }
+    # adrp x0,#0 = 0x90000000 ; adrp x16,#0 = 0x90000010 (zero page-delta placeholder)
+    if (pack_adrp(0)  != 0x90000000) { bad = 1; }
+    if (pack_adrp(16) != 0x90000010) { bad = 1; }
+    # add x0,x0,#0 = 0x91000000 ; add x16,x16,#0 = 0x91000210 (zero lo12 placeholder)
+    if (pack_addsub_imm(ADDI_X, 0, 0, 0, 0)   != 0x91000000) { bad = 1; }
+    if (pack_addsub_imm(ADDI_X, 16, 16, 0, 0) != 0x91000210) { bad = 1; }
+    # folded-global ldr/str x0,[x16] per access width (zero lo12 placeholder):
+    # ldrb 0x39400200 ; ldrh 0x79400200 ; ldr w 0xb9400200 ; ldr x 0xf9400200
+    if (pack_ldst(ldst_base_scaled(1, true), 0, 16, 0) != 0x39400200) { bad = 1; }
+    if (pack_ldst(ldst_base_scaled(2, true), 0, 16, 0) != 0x79400200) { bad = 1; }
+    if (pack_ldst(ldst_base_scaled(4, true), 0, 16, 0) != 0xB9400200) { bad = 1; }
+    if (pack_ldst(ldst_base_scaled(8, true), 0, 16, 0) != 0xF9400200) { bad = 1; }
+    # strb 0x39000200 ; strh 0x79000200 ; str w 0xb9000200 ; str x 0xf9000200
+    if (pack_ldst(ldst_base_scaled(1, false), 0, 16, 0) != 0x39000200) { bad = 1; }
+    if (pack_ldst(ldst_base_scaled(2, false), 0, 16, 0) != 0x79000200) { bad = 1; }
+    if (pack_ldst(ldst_base_scaled(4, false), 0, 16, 0) != 0xB9000200) { bad = 1; }
+    if (pack_ldst(ldst_base_scaled(8, false), 0, 16, 0) != 0xF9000200) { bad = 1; }
+    # the per-width LO12 kind mapping (Option B: the linker reads the scale from the kind).
+    if (ldst_lo12_kind(1) != of.RK_LDST8_LO12)  { bad = 1; }
+    if (ldst_lo12_kind(2) != of.RK_LDST16_LO12) { bad = 1; }
+    if (ldst_lo12_kind(4) != of.RK_LDST32_LO12) { bad = 1; }
+    if (ldst_lo12_kind(8) != of.RK_LDST64_LO12) { bad = 1; }
+    ret bad;
+}
+
+# the call / folded-global / address-of emitters drive the byte words AND record the
+# correct relocation kinds at the instruction-word starts (the reloc fields are zero
+# placeholders pre-link; the linker fills them).
+test "arm64.encode: call/global emitters record relocs + base words" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    st.alloc       = ?alloc;
+    st.relocs      = nil;
+    st.reloc_count = 0;
+    st.reloc_cap   = 0;
+
+    val sym: intern.StrId = 7::intern.StrId;
+
+    # direct call: bl sym -> 0x94000000, RK_PLT32 @0 addend 0.
+    var ci: mir.MirInstr;
+    var cops: [1]mir.MirOperand;
+    cops[0] = mir.op_sym(sym, 0);
+    ci.operands = ?cops[0]; ci.operand_count = 1;
+    encode_call(?st, ?ci);
+    if (read_word(?st.buf, 0) != 0x94000000) { bad = 1; }
+    if (st.reloc_count != 1) { bad = 1; }
+    or {
+        if (st.relocs[0].kind != of.RK_PLT32) { bad = 1; }
+        if (st.relocs[0].offset != 0)         { bad = 1; }
+        if (st.relocs[0].sym != sym)          { bad = 1; }
+        if (st.relocs[0].addend != 0)         { bad = 1; }
+    }
+
+    # indirect call: blr x9 -> 0xd63f0120, no new reloc.
+    var ii: mir.MirInstr;
+    var iops: [1]mir.MirOperand;
+    iops[0] = mir.op_preg(9);
+    ii.operands = ?iops[0]; ii.operand_count = 1;
+    encode_call(?st, ?ii);
+    if (read_word(?st.buf, 4) != 0xD63F0120) { bad = 1; }
+    if (st.reloc_count != 1) { bad = 1; }
+
+    # address-of: adrp x0,sym ; add x0,x0,:lo12:sym -> 0x90000000 ; 0x91000000,
+    # RK_PAGE21 @8, RK_ADD_LO12 @12.
+    var ao: mir.MirOperand = mir.op_sym(sym, 0);
+    emit_global_addr(?st, 0, ?ao);
+    if (read_word(?st.buf, 8)  != 0x90000000) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0x91000000) { bad = 1; }
+    if (st.reloc_count != 3) { bad = 1; }
+    or {
+        if (st.relocs[1].kind != of.RK_PAGE21)   { bad = 1; }
+        if (st.relocs[1].offset != 8)            { bad = 1; }
+        if (st.relocs[2].kind != of.RK_ADD_LO12) { bad = 1; }
+        if (st.relocs[2].offset != 12)           { bad = 1; }
+    }
+
+    # folded-global 8-byte load: adrp x16,sym ; ldr x0,[x16,:lo12:sym] ->
+    # 0x90000010 ; 0xf9400200, RK_PAGE21 @16, RK_LDST64_LO12 @20.
+    var lo: mir.MirOperand = mir.op_sym(sym, 0);
+    emit_global_load(?st, 0, ?lo, 8);
+    if (read_word(?st.buf, 16) != 0x90000010) { bad = 1; }
+    if (read_word(?st.buf, 20) != 0xF9400200) { bad = 1; }
+    if (st.reloc_count != 5) { bad = 1; }
+    or {
+        if (st.relocs[3].kind != of.RK_PAGE21)      { bad = 1; }
+        if (st.relocs[4].kind != of.RK_LDST64_LO12) { bad = 1; }
+        if (st.relocs[4].offset != 20)              { bad = 1; }
+    }
+
+    # folded-global 4-byte register store: adrp x16,sym ; str w1,[x16,:lo12:sym] ->
+    # 0x90000010 ; 0xb9000201, RK_PAGE21 @24, RK_LDST32_LO12 @28.
+    var so: mir.MirOperand = mir.op_sym(sym, 0);
+    var sv: mir.MirOperand = mir.op_preg(1);
+    emit_global_store(?st, ?so, ?sv, 4);
+    if (read_word(?st.buf, 24) != 0x90000010) { bad = 1; }
+    if (read_word(?st.buf, 28) != 0xB9000201) { bad = 1; }
+    if (st.reloc_count != 7) { bad = 1; }
+    or {
+        if (st.relocs[6].kind != of.RK_LDST32_LO12) { bad = 1; }
+        if (st.relocs[6].offset != 28)              { bad = 1; }
+    }
+
+    buf_dnit(?st.buf);
+    if (st.relocs != nil && st.reloc_cap > 0) {
+        deallocate[enc.PendingReloc](?alloc, st.relocs, st.reloc_cap::usize);
+    }
+    ret bad;
+}
+
+# an oversized callee-save frame (locals + GP-save area beyond the STP imm7 reach)
+# anchors a scratch base (IP0 = x29 - (frame.size + 16)) and addresses the small
+# callee-save area off it, rather than truncating the STP immediate.
+test "arm64.encode: oversized callee-save frame uses scratch-base STP" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # three GP callee-saves (x19,x20,x21), frame.size 4000 -> 4000+24 > 504.
+    var f: mir.MirFunction;
+    f.callee_mask = (1::u32 << 19) | (1::u32 << 20) | (1::u32 << 21);
+    f.callee_mask_fp = 0;
+    f.frame.size = 4000;
+    f.frame.outgoing_size = 0;
+
+    save_callee_gp(?st, ?f, true);
+    # sub x16,x29,#4016 ; stp x19,x20,[x16] ; stur x21,[x16,#-8]
+    if (read_word(?st.buf, 0) != 0xD13EC3B0) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0xA9005213) { bad = 1; }
+    if (read_word(?st.buf, 8) != 0xF81F8215) { bad = 1; }
+
+    save_callee_gp(?st, ?f, false);
+    # sub x16,x29,#4016 ; ldp x19,x20,[x16] ; ldur x21,[x16,#-8]
+    if (read_word(?st.buf, 12) != 0xD13EC3B0) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0xA9405213) { bad = 1; }
+    if (read_word(?st.buf, 20) != 0xF85F8215) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the oversized `SUB SP` fallback: a frame beyond the imm12 / imm12<<12 two-immediate
+# reach materializes the size into IP0 and subtracts the register (`SUB SP, SP, X16`).
+test "arm64.encode: oversized SUB SP uses the register form" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # 0x1000000 (16 MiB) is one past MAX_FRAME_SUB -> register-form sub.
+    emit_sp_sub(?st, 0x1000000);
+    # movz x16,#0x100,lsl#16 ; sub sp,sp,x16
+    if (read_word(?st.buf, 0) != pack_movewide(MOVZ_X, 16, 1, 0x100)) { bad = 1; }
+    if (read_word(?st.buf, 4) != (SUB_SP_REG_X | (16 << 16)))         { bad = 1; }
 
     buf_dnit(?st.buf);
     ret bad;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -26,20 +26,30 @@
 # GP BITCAST), the direct (`BL` + RK_PLT32→CALL26) and indirect (`BLR Xn`) call, the
 # folded-global load/store (`ADRP IP0` + `LDR/STR :lo12:`, RK_PAGE21 + the per-width
 # RK_LDST*_LO12), and the address-of rvalue (`ADRP` + `ADD :lo12:`, RK_PAGE21 +
-# RK_ADD_LO12). The contract gaps DEFERRED to a later phase (an in-scope function
-# never reaches them, so they fail loudly rather than emit wrong bytes): inline asm
-# (Phase 3c), callee-saved FP registers, and the float / float-conversion families
-# (Phase 4).
+# RK_ADD_LO12). Phase 3c adds the inline-asm assembler (`encode_asm_block_arm64`):
+# it parses an `asm aarch64 { ... }` body, resolves `{name}` locals to `[x29, #off]`
+# frame slots and bare-symbol / `:lo12:` operands to the #1163 relocations, and
+# emits A64 words for the std `_start` / syscall path. The contract gaps DEFERRED to
+# a later phase (an in-scope function never reaches them, so they fail loudly rather
+# than emit wrong bytes): callee-saved FP registers and the float / float-conversion
+# families (Phase 4).
 
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
+use std.types.char.char;
 use std.types.string.str;
+use std.types.string.str_len;
+use std.types.string.str_equals;
+use std.types.string.str_starts_with;
+use std.types.string.str_region_equals;
+use std.types.string.str_contains;
 
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
+use std.types.result.is_ok;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
@@ -50,7 +60,11 @@ use std.types.option.none;
 use std.types.option.is_some;
 use std.types.option.unwrap;
 
+use parse: std.text.parse;
+
 use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.reallocate;
 use std.allocator.deallocate;
 use page: std.allocator.page;
 
@@ -71,6 +85,7 @@ use mach.lang.be.codegen.encode.BranchFixup;
 use mach.lang.be.codegen.encode.EncodeHooks;
 use mach.lang.be.codegen.encode.buf_init;
 use mach.lang.be.codegen.encode.buf_dnit;
+use mach.lang.be.codegen.encode.emit_byte;
 use mach.lang.be.codegen.encode.emit_u32;
 use mach.lang.be.codegen.encode.classify_refs;
 use mach.lang.be.codegen.encode.push_symbol;
@@ -155,10 +170,22 @@ val STR_REG_X: u32 = 0xF8206800; val LDR_REG_X: u32 = 0xF8606800;
 val B_BASE:    u32 = 0x14000000;
 val BCOND:     u32 = 0x54000000;
 val CBNZ_X:    u32 = 0xB5000000; val CBNZ_W: u32 = 0x35000000;
+# compare-and-branch-if-zero (the CBNZ twin) by width, for inline-asm `cbz`.
+val CBZ_X:     u32 = 0xB4000000; val CBZ_W: u32 = 0x34000000;
 # RET x30, BRK #0, NOP.
 val RET_WORD:  u32 = 0xD65F03C0;
+# RET base (Rn[9:5] zeroed; RET_WORD is `ret x30`), for an explicit `ret Xn`.
+val RET_BASE:  u32 = 0xD65F0000;
 val BRK_BASE:  u32 = 0xD4200000;
 val NOP_WORD:  u32 = 0xD503201F;
+# register-indirect branch (no link), for inline-asm `br Xn` — Rn[9:5] OR-ed in.
+val BR_BASE:   u32 = 0xD61F0000;
+# supervisor call, for inline-asm `svc #imm` — `0xD4000001 | (imm16 << 5)`.
+val SVC_BASE:  u32 = 0xD4000001;
+# load/store-pair pre-index and post-index bases (64-bit) the inline-asm `stp`/`ldp`
+# writeback forms use; the signed-offset STP_OFF_X / LDP_OFF_X are above.
+val STP_POST_X: u32 = 0xA8800000;
+val LDP_PRE_X:  u32 = 0xA9C00000;
 # the call family: BL (imm26 displacement placeholder, the RK_PLT32 patch site for a
 # direct call) and the register-indirect BLR (Rn[9:5] zeroed in the base).
 val BL_BASE:   u32 = 0x94000000;
@@ -195,10 +222,19 @@ val MAX_FRAME_SUB: u32 = 0xFFFFF0;
 # encodings read these directly; `pack_cset` writes the inverted condition.
 val CC_EQ: u32 = 0;
 val CC_NE: u32 = 1;
+val CC_HS: u32 = 2;
 val CC_CC: u32 = 3;
+val CC_MI: u32 = 4;
+val CC_PL: u32 = 5;
+val CC_VS: u32 = 6;
+val CC_VC: u32 = 7;
+val CC_HI: u32 = 8;
 val CC_LS: u32 = 9;
+val CC_GE: u32 = 10;
 val CC_LT: u32 = 11;
+val CC_GT: u32 = 12;
 val CC_LE: u32 = 13;
+val CC_AL: u32 = 14;
 
 # ---- bitfield packers (pure: each returns one A64 word) ----
 
@@ -1284,7 +1320,7 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
         ret encode_call(st, mi);
     }
     if (mi.opcode == mir.MIR_ASM) {
-        ret err[bool, str]("aarch64 inline asm not implemented (Phase 3c)");
+        ret encode_asm_block_arm64(st, f, fn_base, mi);
     }
 
     # concrete A64 opcodes.
@@ -1416,6 +1452,1150 @@ pub fun encode_arm64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) 
     hooks.encode_function = encode_function_arm64;
     hooks.patch_branch    = patch_branch_arm64;
     ret encode_driver(alloc, tgt, m, ?hooks);
+}
+
+# ============================================================================
+# inline-asm assembler (Phase 3c)
+#
+# parses an `asm aarch64 { ... }` body line-by-line and emits A64 words, resolving
+# `{name}` locals to frame slots (`[x29, #off]`) and bare-symbol / `:lo12:`
+# operands to the #1163 relocations — the AArch64 analogue of x86-64's
+# `encode_asm_block`. numeric local labels (1:/1f/1b) resolve within the block; the
+# imm26 / imm19 displacement insert reuses the shared `patch_branch_arm64`. an
+# unrecognized mnemonic or malformed operand is a hard error rather than wrong bytes.
+# ============================================================================
+
+# a parsed inline-asm operand. distinguishes a register / immediate / memory form
+# (encoded directly) from a bare symbol or `:lo12:sym` (resolved to a relocation).
+# ---
+# kind:      one of ASMOP_*
+# reg:       register index (0..31) for ASMOP_REG
+# is64:      true for an X register / 64-bit form, false for W
+# is_sp:     true when register 31 names SP/WSP (false when it names XZR/WZR)
+# imm:       immediate (ASMOP_IMM) or memory displacement (ASMOP_MEM)
+# base:      memory base register index (ASMOP_MEM)
+# base_sp:   true when the memory base register 31 is SP
+# index:     memory scaled-index register index (ASMOP_MEM, when has_index)
+# index64:   true when the index register is an X register
+# has_index: true when an ASMOP_MEM carries a `[Xn, Xm]` index
+# has_disp:  true when an ASMOP_MEM carries a `[Xn, #imm]` displacement
+# wb_pre:    true when an ASMOP_MEM is a pre-index writeback `[Xn, #imm]!`
+# is_lo12:   true when the operand (or the memory offset) is `:lo12:sym`
+# name:      borrowed symbol name (ASMOP_SYM / ASMOP_LO12 / lo12 memory offset)
+# name_len:  length of `name`
+rec AsmOp {
+    kind:      u8;
+    reg:       u32;
+    is64:      bool;
+    is_sp:     bool;
+    imm:       i64;
+    base:      u32;
+    base_sp:   bool;
+    index:     u32;
+    index64:   bool;
+    has_index: bool;
+    has_disp:  bool;
+    wb_pre:    bool;
+    is_lo12:   bool;
+    name:      str;
+    name_len:  usize;
+}
+
+# no operand parsed.
+val ASMOP_NONE: u8 = 0;
+# a register operand.
+val ASMOP_REG:  u8 = 1;
+# an immediate constant.
+val ASMOP_IMM:  u8 = 2;
+# a `[base (, #imm | , Xm | , :lo12:sym)?]` memory operand.
+val ASMOP_MEM:  u8 = 3;
+# a bare symbol / branch-target name (resolved to a relocation).
+val ASMOP_SYM:  u8 = 4;
+# a `:lo12:sym` relocation specifier (the low-half ADD / LDR/STR operand).
+val ASMOP_LO12: u8 = 5;
+
+# asm_op_clear: reset an operand to the empty (ASMOP_NONE) state.
+fun asm_op_clear(op: *AsmOp) {
+    op.kind = ASMOP_NONE; op.reg = 0; op.is64 = false; op.is_sp = false;
+    op.imm = 0; op.base = 0; op.base_sp = false; op.index = 0; op.index64 = false;
+    op.has_index = false; op.has_disp = false; op.wb_pre = false;
+    op.is_lo12 = false; op.name = nil; op.name_len = 0;
+}
+
+# initial capacity for the numeric local-label definition / forward-ref arrays.
+val ASM_LABEL_INIT_CAP: u32 = 8;
+
+# a numeric local label's nearest definition: the label number and its `.text` offset.
+# ---
+# number: the numeric label
+# offset: byte offset of the definition within `.text`
+rec AsmLabelDef { number: u64; offset: u32; }
+
+# a pending forward reference to a numeric local label: the placeholder branch word
+# is at `patch_pos`, resolved by `patch_branch_arm64` when the definition is reached.
+# ---
+# patch_pos: byte offset of the branch instruction word within `.text`
+# number:    the referenced numeric label
+rec AsmLabelRef { patch_pos: u32; number: u64; }
+
+# per-asm-block numeric-local-label scope (1:/1f/1b). owns its def / forward-ref
+# arrays, freed when the block finishes. the displacement insert reuses the shared
+# `patch_branch_arm64` (imm26 for B, imm19 for B.cond/CBZ/CBNZ — distinguished there
+# by the placeholder word's top bits), so this bookkeeping carries no encoding.
+# ---
+# alloc:     backing allocator
+# defs:      recorded label definitions (latest offset per number)
+# def_count: number of definitions
+# def_cap:   capacity of `defs`
+# refs:      pending forward references
+# ref_count: number of pending forward references
+# ref_cap:   capacity of `refs`
+rec AsmLabels {
+    alloc:     *Allocator;
+    defs:      *AsmLabelDef;
+    def_count: u32;
+    def_cap:   u32;
+    refs:      *AsmLabelRef;
+    ref_count: u32;
+    ref_cap:   u32;
+}
+
+# asm_labels_init: initialize an empty numeric-local-label scope backed by `alloc`.
+fun asm_labels_init(labels: *AsmLabels, alloc: *Allocator) {
+    labels.alloc = alloc;
+    labels.defs = nil; labels.def_count = 0; labels.def_cap = 0;
+    labels.refs = nil; labels.ref_count = 0; labels.ref_cap = 0;
+}
+
+# asm_labels_dnit: release a label scope's owned arrays.
+fun asm_labels_dnit(labels: *AsmLabels) {
+    if (labels.defs != nil && labels.def_cap > 0) {
+        deallocate[AsmLabelDef](labels.alloc, labels.defs, labels.def_cap::usize);
+        labels.defs = nil; labels.def_cap = 0; labels.def_count = 0;
+    }
+    if (labels.refs != nil && labels.ref_cap > 0) {
+        deallocate[AsmLabelRef](labels.alloc, labels.refs, labels.ref_cap::usize);
+        labels.refs = nil; labels.ref_cap = 0; labels.ref_count = 0;
+    }
+}
+
+# grow the label-definition array (or allocate it on first use).
+fun grow_asm_defs(labels: *AsmLabels) Result[bool, str] {
+    if (labels.defs == nil) {
+        val r: Result[*AsmLabelDef, str] = allocate[AsmLabelDef](labels.alloc, ASM_LABEL_INIT_CAP::usize);
+        if (is_err[*AsmLabelDef, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelDef, str](r)); }
+        labels.defs = unwrap_ok[*AsmLabelDef, str](r); labels.def_cap = ASM_LABEL_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = labels.def_cap * 2;
+    val r: Result[*AsmLabelDef, str] = reallocate[AsmLabelDef](labels.alloc, labels.defs, labels.def_cap::usize, nc::usize);
+    if (is_err[*AsmLabelDef, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelDef, str](r)); }
+    labels.defs = unwrap_ok[*AsmLabelDef, str](r); labels.def_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# grow the forward-reference array (or allocate it on first use).
+fun grow_asm_refs(labels: *AsmLabels) Result[bool, str] {
+    if (labels.refs == nil) {
+        val r: Result[*AsmLabelRef, str] = allocate[AsmLabelRef](labels.alloc, ASM_LABEL_INIT_CAP::usize);
+        if (is_err[*AsmLabelRef, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelRef, str](r)); }
+        labels.refs = unwrap_ok[*AsmLabelRef, str](r); labels.ref_cap = ASM_LABEL_INIT_CAP;
+        ret ok[bool, str](true);
+    }
+    val nc: u32 = labels.ref_cap * 2;
+    val r: Result[*AsmLabelRef, str] = reallocate[AsmLabelRef](labels.alloc, labels.refs, labels.ref_cap::usize, nc::usize);
+    if (is_err[*AsmLabelRef, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelRef, str](r)); }
+    labels.refs = unwrap_ok[*AsmLabelRef, str](r); labels.ref_cap = nc;
+    ret ok[bool, str](true);
+}
+
+# asm_label_lookup: the nearest preceding definition offset of `number`, or none.
+fun asm_label_lookup(labels: *AsmLabels, number: u64) Option[u32] {
+    var i: u32 = 0;
+    for (i < labels.def_count) {
+        if (labels.defs[i].number == number) { ret some[u32](labels.defs[i].offset); }
+        i = i + 1;
+    }
+    ret none[u32]();
+}
+
+# asm_label_push_ref: record a pending forward reference to `number` whose branch
+# word is at `patch_pos`.
+fun asm_label_push_ref(labels: *AsmLabels, patch_pos: u32, number: u64) Result[bool, str] {
+    if (labels.ref_count >= labels.ref_cap) {
+        val gr: Result[bool, str] = grow_asm_refs(labels);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    labels.refs[labels.ref_count].patch_pos = patch_pos;
+    labels.refs[labels.ref_count].number    = number;
+    labels.ref_count = labels.ref_count + 1;
+    ret ok[bool, str](true);
+}
+
+# asm_label_record_def: record a definition of `number` at `.text` offset `off`,
+# patching (and dropping) every pending forward reference to it through the shared
+# `patch_branch_arm64`, and updating the nearest-preceding-definition offset.
+fun asm_label_record_def(st: *EncodeState, labels: *AsmLabels, number: u64, off: u32) Result[bool, str] {
+    var w: u32 = 0;
+    var r: u32 = 0;
+    for (r < labels.ref_count) {
+        if (labels.refs[r].number == number) {
+            var fx: BranchFixup;
+            fx.patch_pos = labels.refs[r].patch_pos; fx.next_ip = 0;
+            fx.target_block = 0; fx.fn_text_base = 0;
+            val pr: Result[bool, str] = patch_branch_arm64(st, ?fx, off);
+            if (is_err[bool, str](pr)) { ret pr; }
+        } or {
+            labels.refs[w].patch_pos = labels.refs[r].patch_pos;
+            labels.refs[w].number    = labels.refs[r].number;
+            w = w + 1;
+        }
+        r = r + 1;
+    }
+    labels.ref_count = w;
+
+    var i: u32 = 0;
+    for (i < labels.def_count) {
+        if (labels.defs[i].number == number) { labels.defs[i].offset = off; ret ok[bool, str](true); }
+        i = i + 1;
+    }
+    if (labels.def_count >= labels.def_cap) {
+        val gr: Result[bool, str] = grow_asm_defs(labels);
+        if (is_err[bool, str](gr)) { ret gr; }
+    }
+    labels.defs[labels.def_count].number = number;
+    labels.defs[labels.def_count].offset = off;
+    labels.def_count = labels.def_count + 1;
+    ret ok[bool, str](true);
+}
+
+# ---- inline-asm lexing helpers ----
+
+# asm_is_space: true for the ASCII whitespace the asm tokenizer trims.
+fun asm_is_space(c: char) bool { ret c == ' '::char || c == '\t'::char || c == '\r'::char; }
+
+# asm_is_digit: true for an ASCII decimal digit.
+fun asm_is_digit(c: char) bool { ret c >= '0'::char && c <= '9'::char; }
+
+# asm_is_sym_char: true for a character valid inside a bare symbol name.
+fun asm_is_sym_char(c: char) bool {
+    ret c == '_'::char || c == '.'::char ||
+        (c >= 'a'::char && c <= 'z'::char) ||
+        (c >= 'A'::char && c <= 'Z'::char) ||
+        (c >= '0'::char && c <= '9'::char);
+}
+
+# asm_is_sym_token: true when `tok[0..len)` is a valid bare symbol name (leading
+# char a letter / underscore, the rest symbol characters).
+fun asm_is_sym_token(tok: str, len: usize) bool {
+    if (len == 0) { ret false; }
+    val c0: char = tok[0];
+    if (!(c0 == '_'::char || (c0 >= 'a'::char && c0 <= 'z'::char) || (c0 >= 'A'::char && c0 <= 'Z'::char))) {
+        ret false;
+    }
+    var i: usize = 1;
+    for (i < len) { if (!asm_is_sym_char(tok[i])) { ret false; } i = i + 1; }
+    ret true;
+}
+
+# asm_trim: a pointer past leading whitespace in `s` (trailing whitespace already
+# stripped by the statement tokenizer).
+fun asm_trim(s: str) str {
+    var i: usize = 0;
+    for (s[i] != 0 && asm_is_space(s[i])) { i = i + 1; }
+    ret (s::usize + i)::str;
+}
+
+# asm_copy_region: copy `s[lo..hi)` (trimming surrounding whitespace) into `dst` as
+# a NUL-terminated string. returns false on an empty or oversized slice.
+fun asm_copy_region(s: str, lo: usize, hi: usize, dst: *u8, cap: usize) bool {
+    var a: usize = lo;
+    var b: usize = hi;
+    for (a < b && asm_is_space(s[a])) { a = a + 1; }
+    for (b > a && asm_is_space(s[b - 1])) { b = b - 1; }
+    val n: usize = b - a;
+    if (n == 0 || n + 1 > cap) { ret false; }
+    var i: usize = 0;
+    for (i < n) { dst[i] = s[a + i]::u8; i = i + 1; }
+    dst[n] = 0;
+    ret true;
+}
+
+# asm_region_is_lo12: true when `tok[s..e)` begins with the `:lo12:` prefix.
+fun asm_region_is_lo12(tok: str, s: usize, e: usize) bool {
+    if (e - s < 6) { ret false; }
+    ret tok[s] == ':'::char && tok[s + 1] == 'l'::char && tok[s + 2] == 'o'::char &&
+        tok[s + 3] == '1'::char && tok[s + 4] == '2'::char && tok[s + 5] == ':'::char;
+}
+
+# asm_label_def_len: if `tok` begins with `<digits>:`, return the prefix length
+# (through the colon) and the parsed number via `num_out`; otherwise return 0.
+fun asm_label_def_len(tok: str, num_out: *u64) usize {
+    if (!asm_is_digit(tok[0])) { ret 0; }
+    var i: usize = 0;
+    var n: u64 = 0;
+    for (asm_is_digit(tok[i])) { n = n * 10 + (tok[i]::u64 - '0'::u64); i = i + 1; }
+    if (tok[i] != ':'::char) { ret 0; }
+    @num_out = n;
+    ret i + 1;
+}
+
+# asm_label_ref: parse a numeric local-label reference `<digits>f` / `<digits>b`
+# into its number and direction. returns false when `tok` is not that shape.
+fun asm_label_ref(tok: str, num_out: *u64, fwd_out: *bool) bool {
+    val len: usize = str_len(tok);
+    if (len < 2) { ret false; }
+    if (!asm_is_digit(tok[0])) { ret false; }
+    var n: u64 = 0;
+    var i: usize = 0;
+    for (i < len - 1) {
+        if (!asm_is_digit(tok[i])) { ret false; }
+        n = n * 10 + (tok[i]::u64 - '0'::u64);
+        i = i + 1;
+    }
+    val suf: char = tok[len - 1];
+    if (suf == 'f'::char) { @fwd_out = true; }
+    or (suf == 'b'::char) { @fwd_out = false; }
+    or { ret false; }
+    @num_out = n;
+    ret true;
+}
+
+# asm_first_token: copy the first whitespace-delimited token of `tok` (the mnemonic)
+# into `mbuf` NUL-terminated and set `args_out` to the trimmed remainder. returns
+# false when the mnemonic exceeds `cap`.
+fun asm_first_token(tok: str, mbuf: *u8, cap: usize, args_out: *str) bool {
+    var i: usize = 0;
+    for (tok[i] != 0 && asm_is_space(tok[i])) { i = i + 1; }
+    var k: usize = 0;
+    for (tok[i] != 0 && !asm_is_space(tok[i])) {
+        if (k + 1 >= cap) { ret false; }
+        mbuf[k] = tok[i]::u8; k = k + 1; i = i + 1;
+    }
+    mbuf[k] = 0;
+    for (tok[i] != 0 && asm_is_space(tok[i])) { i = i + 1; }
+    @args_out = (tok::usize + i)::str;
+    ret true;
+}
+
+# asm_named_err: build "<prefix><name><suffix>" interned into the session interner so
+# the diagnostic outlives this call; degrades to `fallback` when interning is
+# unavailable. mirrors the x86-64 `enc_named_message`.
+fun asm_named_err(st: *EncodeState, prefix: str, name: str, suffix: str, fallback: str) str {
+    if (st.interner == nil || name == nil) { ret fallback; }
+    val lp: usize = str_len(prefix);
+    val ln: usize = str_len(name);
+    val ls: usize = str_len(suffix);
+    val total: usize = lp + ln + ls;
+    val r: Result[*u8, str] = allocate[u8](st.alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret fallback; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    var j: usize = 0;
+    for (j < lp) { buf[k] = prefix[j]::u8; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < ln) { buf[k] = name[j]::u8; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < ls) { buf[k] = suffix[j]::u8; k = k + 1; j = j + 1; }
+    buf[total] = 0;
+    val ir: Result[intern.StrId, str] = intern.intern(st.interner, buf::str);
+    deallocate[u8](st.alloc, buf, total + 1);
+    if (is_err[intern.StrId, str](ir)) { ret fallback; }
+    val nm: Option[str] = intern.lookup(st.interner, unwrap_ok[intern.StrId, str](ir));
+    if (is_some[str](nm)) { ret unwrap[str](nm); }
+    ret fallback;
+}
+
+# ---- inline-asm operand parsing ----
+
+# asm_parse_reg: map a register token to its (index, width, SP-ness). recognizes
+# x0–x30 / w0–w30, sp / wsp (register 31, SP), and xzr / wzr (register 31, zero).
+fun asm_parse_reg(name: str, op: *AsmOp) bool {
+    val len: usize = str_len(name);
+    if (len == 0) { ret false; }
+    if (str_equals(name, "xzr")) { op.kind = ASMOP_REG; op.reg = 31; op.is64 = true;  op.is_sp = false; ret true; }
+    if (str_equals(name, "wzr")) { op.kind = ASMOP_REG; op.reg = 31; op.is64 = false; op.is_sp = false; ret true; }
+    if (str_equals(name, "sp"))  { op.kind = ASMOP_REG; op.reg = 31; op.is64 = true;  op.is_sp = true;  ret true; }
+    if (str_equals(name, "wsp")) { op.kind = ASMOP_REG; op.reg = 31; op.is64 = false; op.is_sp = true;  ret true; }
+    val c0: char = name[0];
+    if (c0 != 'x'::char && c0 != 'w'::char) { ret false; }
+    if (len < 2 || len > 3) { ret false; }
+    var n: u32 = 0;
+    var i: usize = 1;
+    for (i < len) {
+        if (!asm_is_digit(name[i])) { ret false; }
+        n = n * 10 + (name[i]::u32 - '0'::u32);
+        i = i + 1;
+    }
+    if (n > 30) { ret false; }
+    op.kind = ASMOP_REG; op.reg = n; op.is64 = (c0 == 'x'::char); op.is_sp = false;
+    ret true;
+}
+
+# asm_parse_mem: parse the inner text of a `[...]` memory operand into `op`. forms:
+# `[Xn]`, `[Xn, #imm]`, `[Xn, #imm]!` (pre-index writeback), `[Xn, Xm]` (register
+# offset), and `[Xn, :lo12:sym]` (folded-global low half). the `:lo12:` symbol name
+# is recorded as a borrowed slice of `tok` (stable for the statement).
+fun asm_parse_mem(tok: str, len: usize, op: *AsmOp) bool {
+    op.kind = ASMOP_MEM;
+    var hi: usize = len;
+    if (tok[hi - 1] == '!'::char) { op.wb_pre = true; hi = hi - 1; }
+    if (hi < 2) { ret false; }
+    if (tok[0] != '['::char || tok[hi - 1] != ']'::char) { ret false; }
+    val ilo: usize = 1;
+    val ihi: usize = hi - 1;
+
+    var comma: usize = ihi;
+    var found: bool = false;
+    var i: usize = ilo;
+    for (i < ihi && !found) {
+        if (tok[i] == ','::char) { comma = i; found = true; }
+        i = i + 1;
+    }
+
+    var bbuf: [16]u8;
+    if (!asm_copy_region(tok, ilo, comma, ?bbuf[0], 16)) { ret false; }
+    var bop: AsmOp;
+    if (!asm_parse_reg((?bbuf[0])::str, ?bop)) { ret false; }
+    op.base = bop.reg; op.base_sp = bop.is_sp;
+    if (!found) { ret true; }
+
+    var s: usize = comma + 1;
+    var e: usize = ihi;
+    for (s < e && asm_is_space(tok[s])) { s = s + 1; }
+    for (e > s && asm_is_space(tok[e - 1])) { e = e - 1; }
+    if (e <= s) { ret false; }
+
+    # the `:lo12:sym` folded-global low half (symbol name borrowed from `tok`).
+    if (asm_region_is_lo12(tok, s, e)) {
+        op.is_lo12 = true;
+        op.name = (tok::usize + s + 6)::str;
+        op.name_len = e - (s + 6);
+        if (op.name_len == 0) { ret false; }
+        ret true;
+    }
+    # a scaled-index register `[Xn, Xm]`, else a displacement. the displacement is
+    # written bare (`[Xn, 8]`) — `#` is the inline-asm comment character, stripped at
+    # lower time — though a leading `#` is also tolerated here.
+    var ibuf: [32]u8;
+    var ds: usize = s;
+    if (tok[ds] == '#'::char) { ds = ds + 1; }
+    if (!asm_copy_region(tok, ds, e, ?ibuf[0], 32)) { ret false; }
+    var iop: AsmOp;
+    if (tok[s] != '#'::char && asm_parse_reg((?ibuf[0])::str, ?iop)) {
+        op.has_index = true; op.index = iop.reg; op.index64 = iop.is64;
+        ret true;
+    }
+    val r: Result[i64, str] = parse.parse_i64_exact((?ibuf[0])::str, 0);
+    if (is_err[i64, str](r)) { ret false; }
+    op.imm = unwrap_ok[i64, str](r); op.has_disp = true;
+    ret true;
+}
+
+# asm_parse_operand: parse one trimmed operand token into `op` — a register, an
+# `#imm` / bare immediate, a `[...]` memory reference, a `:lo12:sym` low-half
+# specifier, or a bare symbol. returns false when the token matches none.
+fun asm_parse_operand(tok: str, op: *AsmOp) bool {
+    asm_op_clear(op);
+    val len: usize = str_len(tok);
+    if (len == 0) { ret false; }
+    if (asm_parse_reg(tok, op)) { ret true; }
+    asm_op_clear(op);
+    if (tok[0] == '['::char) { ret asm_parse_mem(tok, len, op); }
+    if (tok[0] == '#'::char) {
+        val r: Result[i64, str] = parse.parse_i64_exact((tok::usize + 1)::str, 0);
+        if (is_ok[i64, str](r)) { op.kind = ASMOP_IMM; op.imm = unwrap_ok[i64, str](r); ret true; }
+        ret false;
+    }
+    if (str_starts_with(tok, ":lo12:")) {
+        op.kind = ASMOP_LO12; op.is_lo12 = true;
+        op.name = (tok::usize + 6)::str; op.name_len = len - 6;
+        if (op.name_len == 0) { ret false; }
+        ret true;
+    }
+    if (asm_is_sym_token(tok, len)) {
+        op.kind = ASMOP_SYM; op.name = tok; op.name_len = len;
+        ret true;
+    }
+    val r2: Result[i64, str] = parse.parse_i64_exact(tok, 0);
+    if (is_ok[i64, str](r2)) { op.kind = ASMOP_IMM; op.imm = unwrap_ok[i64, str](r2); ret true; }
+    ret false;
+}
+
+# asm_split: split `args` into trimmed top-level operand tokens (commas outside
+# `[...]`), copying each NUL-terminated into `b0`..`b3` (each `cap` bytes). returns
+# false on more than four operands, an empty token, or an oversized token.
+fun asm_split(args: str, b0: *u8, b1: *u8, b2: *u8, b3: *u8, cap: usize, count_out: *u32) bool {
+    val len: usize = str_len(args);
+    var count: u32 = 0;
+    var depth: i32 = 0;
+    var start: usize = 0;
+    var i: usize = 0;
+    for (i <= len) {
+        var is_sep: bool = false;
+        if (i == len) { is_sep = true; }
+        or (args[i] == '['::char) { depth = depth + 1; }
+        or (args[i] == ']'::char) { depth = depth - 1; }
+        or (args[i] == ','::char && depth == 0) { is_sep = true; }
+        if (is_sep) {
+            if (count >= 4) { ret false; }
+            var dst: *u8 = b0;
+            if (count == 1) { dst = b1; }
+            or (count == 2) { dst = b2; }
+            or (count == 3) { dst = b3; }
+            if (!asm_copy_region(args, start, i, dst, cap)) { ret false; }
+            count = count + 1;
+            start = i + 1;
+        }
+        i = i + 1;
+    }
+    @count_out = count;
+    ret true;
+}
+
+# asm_parse_cond: map an A64 condition mnemonic (eq/ne/cs/hs/cc/lo/.../le/al) to its
+# 4-bit condition code, or return false for an unknown condition.
+fun asm_parse_cond(s: str, out: *u32) bool {
+    if (str_equals(s, "eq")) { @out = CC_EQ; ret true; }
+    if (str_equals(s, "ne")) { @out = CC_NE; ret true; }
+    if (str_equals(s, "cs") || str_equals(s, "hs")) { @out = CC_HS; ret true; }
+    if (str_equals(s, "cc") || str_equals(s, "lo")) { @out = CC_CC; ret true; }
+    if (str_equals(s, "mi")) { @out = CC_MI; ret true; }
+    if (str_equals(s, "pl")) { @out = CC_PL; ret true; }
+    if (str_equals(s, "vs")) { @out = CC_VS; ret true; }
+    if (str_equals(s, "vc")) { @out = CC_VC; ret true; }
+    if (str_equals(s, "hi")) { @out = CC_HI; ret true; }
+    if (str_equals(s, "ls")) { @out = CC_LS; ret true; }
+    if (str_equals(s, "ge")) { @out = CC_GE; ret true; }
+    if (str_equals(s, "lt")) { @out = CC_LT; ret true; }
+    if (str_equals(s, "gt")) { @out = CC_GT; ret true; }
+    if (str_equals(s, "le")) { @out = CC_LE; ret true; }
+    if (str_equals(s, "al")) { @out = CC_AL; ret true; }
+    ret false;
+}
+
+# asm_parse_lsl_amount: parse a `lsl #N` (or `lsl N`) shift token into the amount.
+fun asm_parse_lsl_amount(s: str, out: *u32) bool {
+    if (!str_starts_with(s, "lsl")) { ret false; }
+    var rest: str = asm_trim((s::usize + 3)::str);
+    if (rest[0] == '#'::char) { rest = (rest::usize + 1)::str; }
+    val r: Result[i64, str] = parse.parse_i64_exact(rest, 0);
+    if (is_err[i64, str](r)) { ret false; }
+    val v: i64 = unwrap_ok[i64, str](r);
+    if (v < 0) { ret false; }
+    @out = v::u32;
+    ret true;
+}
+
+# asm_push_sym_reloc: intern a borrowed symbol name and record a relocation of
+# `kind` at the instruction-word start `pos` (the A64 reloc-offset convention).
+fun asm_push_sym_reloc(st: *EncodeState, pos: u32, kind: of.RelocKind, name: str, name_len: usize, addend: i32) Result[bool, str] {
+    val r: Result[intern.StrId, str] = intern.intern_bytes(st.interner, name, name_len);
+    if (is_err[intern.StrId, str](r)) { ret err[bool, str](unwrap_err[intern.StrId, str](r)); }
+    ret push_reloc(st, arm64_reloc_offset(pos), kind, unwrap_ok[intern.StrId, str](r), addend);
+}
+
+# ---- inline-asm `{name}` substitution ----
+
+# asm_emit_dec: append the base-10 digits of `n` (at least one digit for zero).
+fun asm_emit_dec(out: *ByteBuf, n: u64) {
+    if (n == 0) { emit_byte(out, '0'::u8); ret; }
+    var tmp: [20]u8;
+    var len: usize = 0;
+    var v: u64 = n;
+    for (v > 0) { tmp[len] = (v % 10)::u8 + '0'::u8; v = v / 10; len = len + 1; }
+    var k: usize = 0;
+    for (k < len) { emit_byte(out, tmp[len - 1 - k]); k = k + 1; }
+}
+
+# asm_emit_frame_ref: append the `[x29, #off]` / `[x29, #-off]` text for a local's
+# frame-slot displacement (the AArch64 analogue of x86-64's `[rbp+off]`).
+fun asm_emit_frame_ref(out: *ByteBuf, off: i64) {
+    emit_byte(out, '['::u8); emit_byte(out, 'x'::u8); emit_byte(out, '2'::u8); emit_byte(out, '9'::u8);
+    emit_byte(out, ','::u8); emit_byte(out, ' '::u8); emit_byte(out, '#'::u8);
+    var mag: i64 = off;
+    if (off < 0) { emit_byte(out, '-'::u8); mag = -off; }
+    asm_emit_dec(out, mag::u64);
+    emit_byte(out, ']'::u8);
+}
+
+# asm_bind_name_eq: true when the interned binding name equals `body[start..start+n)`.
+fun asm_bind_name_eq(interner: *intern.Interner, name: intern.StrId, body: str, start: usize, name_len: usize) bool {
+    val nopt: Option[str] = intern.lookup(interner, name);
+    if (!is_some[str](nopt)) { ret false; }
+    ret str_region_equals(body, start, name_len, unwrap[str](nopt));
+}
+
+# asm_free_buf: release a byte buffer's backing storage on an error path.
+fun asm_free_buf(b: *ByteBuf) {
+    if (b.data != nil && b.cap > 0) {
+        deallocate[u8](b.alloc, b.data, b.cap);
+        b.data = nil; b.cap = 0; b.len = 0;
+    }
+}
+
+# substitute_asm_locals_arm64: produce a NUL-terminated copy of the asm body with
+# each `{name}` replaced by its local's `[x29, #off]` frame-slot text. the offset
+# comes from the slot-vreg binding resolved against the laid-out frame. an unbound
+# `{name}` is a hard error. mirrors x86-64's `substitute_asm_locals`.
+fun substitute_asm_locals_arm64(alloc: *Allocator, interner: *intern.Interner, f: *mir.MirFunction, pl: *mir.MirAsm) Result[str, str] {
+    var out: ByteBuf = buf_init(alloc);
+    val body: str = pl.body;
+    var i: usize = 0;
+    for (body[i] != 0) {
+        if (body[i] != '{'::char) {
+            emit_byte(?out, body[i]::u8);
+            i = i + 1;
+            cnt;
+        }
+        val name_start: usize = i + 1;
+        var j: usize = name_start;
+        for (body[j] != 0 && body[j] != '}'::char) { j = j + 1; }
+        if (body[j] == 0) {
+            asm_free_buf(?out);
+            ret err[str, str]("encode: unterminated '{' in inline asm body");
+        }
+        val name_len: usize = j - name_start;
+
+        var off: i64 = 0;
+        var found: bool = false;
+        var b: u32 = 0;
+        for (b < pl.bind_count) {
+            if (asm_bind_name_eq(interner, pl.binds[b].name, body, name_start, name_len)) {
+                val so: Option[i64] = frame_slot_offset(f, pl.binds[b].slot_vreg);
+                if (!is_some[i64](so)) {
+                    asm_free_buf(?out);
+                    ret err[str, str]("encode: inline-asm '{name}' local has no frame slot");
+                }
+                off = unwrap[i64](so);
+                found = true;
+                b = pl.bind_count;
+            } or {
+                b = b + 1;
+            }
+        }
+        if (!found) {
+            asm_free_buf(?out);
+            ret err[str, str]("encode: unknown local in inline asm '{name}' reference");
+        }
+
+        asm_emit_frame_ref(?out, off);
+        i = j + 1;
+    }
+    emit_byte(?out, 0);
+
+    if (out.data == nil || out.len == 0) {
+        asm_free_buf(?out);
+        val r: Result[*u8, str] = allocate[u8](alloc, 1::usize);
+        if (is_err[*u8, str](r)) { ret err[str, str](unwrap_err[*u8, str](r)); }
+        val one: *u8 = unwrap_ok[*u8, str](r);
+        one[0] = 0;
+        ret ok[str, str](one::str);
+    }
+    if (out.cap != out.len) {
+        val r: Result[*u8, str] = reallocate[u8](alloc, out.data, out.cap, out.len);
+        if (is_err[*u8, str](r)) { ret err[str, str](unwrap_err[*u8, str](r)); }
+        out.data = unwrap_ok[*u8, str](r);
+        out.cap  = out.len;
+    }
+    ret ok[str, str](out.data::str);
+}
+
+# ---- inline-asm per-mnemonic encoders ----
+
+# emit_asm_mov_imm: materialize `mov Rd, #imm`. a value representable as a single
+# 16-bit chunk at one of the `lsl #{0,16,32,48}` positions emits one MOVZ (matching
+# llvm-mc's alias); any other value falls back to the full MOVZ/MOVK sequence (the
+# exact bit pattern; no MOVN form).
+fun emit_asm_mov_imm(st: *EncodeState, rd: u32, value: u64, use64: bool) {
+    var v: u64 = value;
+    if (!use64) { v = value & 0xFFFFFFFF; }
+    var chunks: u32 = 2;
+    if (use64) { chunks = 4; }
+    var i: u32 = 0;
+    for (i < chunks) {
+        val sh: u64 = 16::u64 * i::u64;
+        val chunk: u64 = (v >> sh) & 0xFFFF;
+        if ((chunk << sh) == v) {
+            emit_word(st, pack_movewide(sel(use64, MOVZ_X, MOVZ_W), rd, i, chunk::u32));
+            ret;
+        }
+        i = i + 1;
+    }
+    emit_movewide_seq(st, rd, value, use64);
+}
+
+# emit_asm_mov: `mov Rd, Rm` (an `add` when SP is involved, else `orr Rd, XZR, Rm`)
+# or `mov Rd, #imm` (MOVZ / MOVZ+MOVK).
+fun emit_asm_mov(st: *EncodeState, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm 'mov' operands"); }
+    if (n != 2) { ret err[bool, str]("encode: inline-asm 'mov' expects two operands"); }
+    var dst: AsmOp;
+    var src: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?dst)) { ret err[bool, str]("encode: malformed inline-asm 'mov' destination"); }
+    if (!asm_parse_operand((?b1[0])::str, ?src)) { ret err[bool, str]("encode: malformed inline-asm 'mov' source"); }
+    if (dst.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm 'mov' destination must be a register"); }
+    val use64: bool = dst.is64;
+    if (src.kind == ASMOP_REG) {
+        if (dst.is_sp || src.is_sp) {
+            emit_word(st, pack_addsub_imm(sel(use64, ADDI_X, ADDI_W), dst.reg, src.reg, 0, 0));
+        } or {
+            emit_word(st, pack_alu3(sel(use64, ORR_X, ORR_W), dst.reg, ZR, src.reg));
+        }
+        ret ok[bool, str](true);
+    }
+    if (src.kind == ASMOP_IMM) {
+        emit_asm_mov_imm(st, dst.reg, src.imm::u64, use64);
+        ret ok[bool, str](true);
+    }
+    ret err[bool, str]("encode: inline-asm 'mov' source must be a register or immediate");
+}
+
+# emit_asm_movewide: `movz` / `movk Rd, #imm16 [, lsl #N]`.
+fun emit_asm_movewide(st: *EncodeState, args: str, is_movk: bool) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm movz/movk operands"); }
+    if (n < 2 || n > 3) { ret err[bool, str]("encode: inline-asm movz/movk expects Rd, #imm [, lsl #N]"); }
+    var rd: AsmOp;
+    var im: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm movz/movk destination must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?im) || im.kind != ASMOP_IMM) { ret err[bool, str]("encode: inline-asm movz/movk needs an immediate"); }
+    if (im.imm < 0 || im.imm > 0xFFFF) { ret err[bool, str]("encode: inline-asm movz/movk immediate is out of 16-bit range"); }
+    var hw: u32 = 0;
+    if (n == 3) {
+        if (!asm_parse_lsl_amount((?b2[0])::str, ?hw)) { ret err[bool, str]("encode: inline-asm movz/movk shift must be 'lsl #N'"); }
+        if ((hw & 0xF) != 0) { ret err[bool, str]("encode: inline-asm movz/movk shift must be a multiple of 16"); }
+        hw = hw / 16;
+        if (rd.is64) {
+            if (hw > 3) { ret err[bool, str]("encode: inline-asm movz/movk 64-bit shift exceeds lsl #48"); }
+        } or {
+            if (hw > 1) { ret err[bool, str]("encode: inline-asm movz/movk 32-bit shift exceeds lsl #16"); }
+        }
+    }
+    var base: u32 = sel(rd.is64, MOVZ_X, MOVZ_W);
+    if (is_movk) { base = sel(rd.is64, MOVK_X, MOVK_W); }
+    emit_word(st, pack_movewide(base, rd.reg, hw, im.imm::u32));
+    ret ok[bool, str](true);
+}
+
+# emit_asm_addsub: `add` / `sub Rd, Rn, (#imm | Rm | :lo12:sym)`. an immediate folds
+# into the imm12 (or imm12<<12) form; a `:lo12:sym` (add only) emits the low-half ADD
+# with RK_ADD_LO12; a register uses the shifted-register form. SP with a register
+# operand needs the extended-register form (unsupported, rejected loud).
+fun emit_asm_addsub(st: *EncodeState, args: str, is_sub: bool) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm add/sub operands"); }
+    if (n != 3) { ret err[bool, str]("encode: inline-asm add/sub expects three operands"); }
+    var rd: AsmOp;
+    var rn: AsmOp;
+    var op3: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm add/sub destination must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?rn) || rn.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm add/sub first source must be a register"); }
+    if (!asm_parse_operand((?b2[0])::str, ?op3)) { ret err[bool, str]("encode: malformed inline-asm add/sub operand"); }
+    val use64: bool = rd.is64;
+
+    if (op3.kind == ASMOP_IMM) {
+        val v: i64 = op3.imm;
+        var base_i: u32 = sel(use64, ADDI_X, ADDI_W);
+        if (is_sub) { base_i = sel(use64, SUBI_X, SUBI_W); }
+        if (v >= 0 && v <= 4095) {
+            emit_word(st, pack_addsub_imm(base_i, rd.reg, rn.reg, v::u32, 0));
+            ret ok[bool, str](true);
+        }
+        if (v > 0 && (v & 0xFFF) == 0 && (v >> 12) <= 4095) {
+            emit_word(st, pack_addsub_imm(base_i, rd.reg, rn.reg, (v >> 12)::u32, 1));
+            ret ok[bool, str](true);
+        }
+        ret err[bool, str]("encode: inline-asm add/sub immediate is out of imm12 range");
+    }
+    if (op3.kind == ASMOP_LO12) {
+        if (is_sub) { ret err[bool, str]("encode: inline-asm 'sub' has no :lo12: form"); }
+        val pos: u32 = st.buf.len::u32;
+        emit_word(st, pack_addsub_imm(sel(use64, ADDI_X, ADDI_W), rd.reg, rn.reg, 0, 0));
+        ret asm_push_sym_reloc(st, pos, of.RK_ADD_LO12, op3.name, op3.name_len, 0);
+    }
+    if (op3.kind == ASMOP_REG) {
+        if (rd.is_sp || rn.is_sp || op3.is_sp) {
+            ret err[bool, str]("encode: inline-asm add/sub with SP and a register operand requires the extended-register form (unsupported)");
+        }
+        var base_r: u32 = sel(use64, ADD_X, ADD_W);
+        if (is_sub) { base_r = sel(use64, SUB_X, SUB_W); }
+        emit_word(st, pack_alu3(base_r, rd.reg, rn.reg, op3.reg));
+        ret ok[bool, str](true);
+    }
+    ret err[bool, str]("encode: malformed inline-asm add/sub operand");
+}
+
+# emit_asm_logical: `and` / `orr` / `eor Rd, Rn, Rm` (register form). the logical
+# immediate (bitmask) form is unsupported and rejected loud.
+fun emit_asm_logical(st: *EncodeState, args: str, base_x: u32, base_w: u32) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm logical operands"); }
+    if (n != 3) { ret err[bool, str]("encode: inline-asm and/orr/eor expects three operands"); }
+    var rd: AsmOp;
+    var rn: AsmOp;
+    var rm: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm and/orr/eor destination must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?rn) || rn.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm and/orr/eor first source must be a register"); }
+    if (!asm_parse_operand((?b2[0])::str, ?rm) || rm.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm and/orr/eor immediate (bitmask) form unsupported; use a register operand"); }
+    emit_word(st, pack_alu3(sel(rd.is64, base_x, base_w), rd.reg, rn.reg, rm.reg));
+    ret ok[bool, str](true);
+}
+
+# emit_asm_cmp: `cmp Rn, (#imm | Rm)` — the SUBS XZR alias.
+fun emit_asm_cmp(st: *EncodeState, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm 'cmp' operands"); }
+    if (n != 2) { ret err[bool, str]("encode: inline-asm 'cmp' expects two operands"); }
+    var rn: AsmOp;
+    var op2: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rn) || rn.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm 'cmp' first operand must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?op2)) { ret err[bool, str]("encode: malformed inline-asm 'cmp' operand"); }
+    val use64: bool = rn.is64;
+    if (op2.kind == ASMOP_IMM && op2.imm >= 0 && op2.imm <= 4095) {
+        emit_word(st, pack_cmp_imm(sel(use64, SUBS_IMM_X, SUBS_IMM_W), rn.reg, op2.imm::u32));
+        ret ok[bool, str](true);
+    }
+    if (op2.kind == ASMOP_REG) {
+        emit_word(st, pack_cmp_reg(sel(use64, SUBS_REG_X, SUBS_REG_W), rn.reg, op2.reg));
+        ret ok[bool, str](true);
+    }
+    ret err[bool, str]("encode: inline-asm 'cmp' second operand must be a register or imm12");
+}
+
+# emit_asm_adrp: `adrp Xd, sym` — the page-relative high half, RK_PAGE21.
+fun emit_asm_adrp(st: *EncodeState, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm 'adrp' operands"); }
+    if (n != 2) { ret err[bool, str]("encode: inline-asm 'adrp' expects Xd, symbol"); }
+    var rd: AsmOp;
+    var sym: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm 'adrp' destination must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?sym) || sym.kind != ASMOP_SYM) { ret err[bool, str]("encode: inline-asm 'adrp' target must be a symbol"); }
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_adrp(rd.reg));
+    ret asm_push_sym_reloc(st, pos, of.RK_PAGE21, sym.name, sym.name_len, 0);
+}
+
+# emit_asm_ldst: `ldr` / `str` / `ldrb` / `strb` / `ldrh` / `strh Rt, <mem>`. the
+# `[Xn, :lo12:sym]` form emits the per-width RK_LDST*_LO12 folded-global low half;
+# `[Xn, Xm]` the register-offset form; `[Xn]` / `[Xn, #imm]` legalize through
+# `emit_mem_access`. writeback (`!`) is rejected.
+fun emit_asm_ldst(st: *EncodeState, mnem: str, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm ldr/str operands"); }
+    if (n != 2) { ret err[bool, str]("encode: inline-asm ldr/str expects Rt, [mem]"); }
+    var rt: AsmOp;
+    var mem: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rt) || rt.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm ldr/str value must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret err[bool, str]("encode: inline-asm ldr/str address must be a memory operand"); }
+    if (mem.wb_pre) { ret err[bool, str]("encode: inline-asm ldr/str writeback addressing unsupported"); }
+
+    val is_load: bool = mnem[0] == 'l'::char;
+    var w: u8 = 4;
+    if (rt.is64) { w = 8; }
+    if (str_len(mnem) == 4) {
+        if (mnem[3] == 'b'::char) { w = 1; }
+        or (mnem[3] == 'h'::char) { w = 2; }
+        or { ret err[bool, str]("encode: unsupported aarch64 inline-asm load/store width"); }
+    }
+
+    if (mem.is_lo12) {
+        val pos: u32 = st.buf.len::u32;
+        emit_word(st, pack_ldst(ldst_base_scaled(w, is_load), rt.reg, mem.base, 0));
+        ret asm_push_sym_reloc(st, pos, ldst_lo12_kind(w), mem.name, mem.name_len, 0);
+    }
+    if (mem.has_index) {
+        emit_word(st, pack_ldst_reg(ldst_base_reg(w, is_load), rt.reg, mem.base, mem.index));
+        ret ok[bool, str](true);
+    }
+    var off: i64 = 0;
+    if (mem.has_disp) { off = mem.imm; }
+    emit_mem_access(st, rt.reg, mem.base, off, w, is_load);
+    ret ok[bool, str](true);
+}
+
+# emit_asm_ldstp: `stp` / `ldp Xa, Xb, <mem>` for the signed-offset, pre-index, and
+# post-index 64-bit forms. the W-register pair forms are unsupported.
+fun emit_asm_ldstp(st: *EncodeState, args: str, is_load: bool) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm stp/ldp operands"); }
+    if (n < 3 || n > 4) { ret err[bool, str]("encode: inline-asm stp/ldp expects Xa, Xb, [mem] [, #imm]"); }
+    var ra: AsmOp;
+    var rb: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?ra) || ra.kind != ASMOP_REG || !ra.is64) { ret err[bool, str]("encode: inline-asm stp/ldp registers must be X registers"); }
+    if (!asm_parse_operand((?b1[0])::str, ?rb) || rb.kind != ASMOP_REG || !rb.is64) { ret err[bool, str]("encode: inline-asm stp/ldp registers must be X registers"); }
+    var mem: AsmOp;
+    if (!asm_parse_operand((?b2[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret err[bool, str]("encode: inline-asm stp/ldp address must be a memory operand"); }
+    if (mem.has_index || mem.is_lo12) { ret err[bool, str]("encode: inline-asm stp/ldp address must be [Xn] or [Xn, #imm]"); }
+
+    var disp: i64 = 0;
+    var base_word: u32 = sel(is_load, LDP_OFF_X, STP_OFF_X);
+    if (n == 4) {
+        if (mem.has_disp || mem.wb_pre) { ret err[bool, str]("encode: inline-asm stp/ldp post-index base must be a bare [Xn]"); }
+        var imo: AsmOp;
+        if (!asm_parse_operand((?b3[0])::str, ?imo) || imo.kind != ASMOP_IMM) { ret err[bool, str]("encode: inline-asm stp/ldp post-index needs an immediate"); }
+        disp = imo.imm;
+        base_word = sel(is_load, LDP_POST_X, STP_POST_X);
+    } or {
+        if (mem.has_disp) { disp = mem.imm; }
+        if (mem.wb_pre) { base_word = sel(is_load, LDP_PRE_X, STP_PRE_X); }
+    }
+
+    if ((disp & 7) != 0) { ret err[bool, str]("encode: inline-asm stp/ldp offset must be a multiple of 8"); }
+    val q: i64 = disp / 8;
+    if (q < -64 || q > 63) { ret err[bool, str]("encode: inline-asm stp/ldp offset is out of the imm7 range"); }
+    emit_word(st, pack_ldstp(base_word, ra.reg, rb.reg, mem.base, q::u32 & 0x7F));
+    ret ok[bool, str](true);
+}
+
+# emit_asm_branch_label: emit a branch (B / B.cond / CBZ / CBNZ) to a numeric local
+# label. a backward reference patches immediately against the nearest preceding
+# definition; a forward reference is recorded and patched when its definition is
+# reached. the imm26 / imm19 insert is the shared `patch_branch_arm64`.
+fun emit_asm_branch_label(st: *EncodeState, labels: *AsmLabels, word: u32, number: u64, fwd: bool) Result[bool, str] {
+    val patch_pos: u32 = st.buf.len::u32;
+    emit_word(st, word);
+    if (fwd) { ret asm_label_push_ref(labels, patch_pos, number); }
+    val def: Option[u32] = asm_label_lookup(labels, number);
+    if (!is_some[u32](def)) {
+        ret err[bool, str]("encode: inline-asm backward reference to a local label has no preceding definition in this asm block");
+    }
+    var fx: BranchFixup;
+    fx.patch_pos = patch_pos; fx.next_ip = 0; fx.target_block = 0; fx.fn_text_base = 0;
+    ret patch_branch_arm64(st, ?fx, unwrap[u32](def));
+}
+
+# emit_asm_b: `b target` — an unconditional branch to a numeric local label (imm26
+# fixup) or a bare symbol (RK_PLT32, the branch26 the linker resolves).
+fun emit_asm_b(st: *EncodeState, labels: *AsmLabels, args: str) Result[bool, str] {
+    val target: str = asm_trim(args);
+    var number: u64 = 0;
+    var fwd: bool = false;
+    if (asm_label_ref(target, ?number, ?fwd)) {
+        ret emit_asm_branch_label(st, labels, B_BASE, number, fwd);
+    }
+    if (str_len(target) > 0 && asm_is_digit(target[0])) {
+        ret err[bool, str]("encode: inline-asm numeric local-label reference must be 'Nf' or 'Nb'");
+    }
+    var op: AsmOp;
+    if (!asm_parse_operand(target, ?op) || op.kind != ASMOP_SYM) {
+        ret err[bool, str]("encode: inline-asm 'b' target must be a symbol or a numeric local label");
+    }
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, B_BASE);
+    ret asm_push_sym_reloc(st, pos, of.RK_PLT32, op.name, op.name_len, 0);
+}
+
+# emit_asm_bcond: `b.<cond> target` — a conditional branch (imm19). a numeric local
+# label resolves in-block; a bare symbol has no imm19 relocation kind in the object
+# format and is rejected loud (x86-64 resolves the analogous `jz <sym>` with a
+# PC32 relocation, which the A64 conditional-branch field cannot express).
+fun emit_asm_bcond(st: *EncodeState, labels: *AsmLabels, cond: u32, args: str) Result[bool, str] {
+    val target: str = asm_trim(args);
+    var number: u64 = 0;
+    var fwd: bool = false;
+    if (asm_label_ref(target, ?number, ?fwd)) {
+        ret emit_asm_branch_label(st, labels, BCOND | (cond & 0xF), number, fwd);
+    }
+    if (str_len(target) > 0 && asm_is_digit(target[0])) {
+        ret err[bool, str]("encode: inline-asm numeric local-label reference must be 'Nf' or 'Nb'");
+    }
+    ret err[bool, str]("encode: inline-asm conditional branch to a symbol is unsupported (no imm19 relocation kind); branch to a numeric local label instead");
+}
+
+# emit_asm_cbr: `cbz` / `cbnz Rt, target` (imm19). a numeric local label resolves
+# in-block; a bare symbol is rejected loud (no imm19 relocation kind).
+fun emit_asm_cbr(st: *EncodeState, labels: *AsmLabels, args: str, is_nz: bool) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm cbz/cbnz operands"); }
+    if (n != 2) { ret err[bool, str]("encode: inline-asm cbz/cbnz expects Rt, target"); }
+    var rt: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rt) || rt.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm cbz/cbnz first operand must be a register"); }
+    var base: u32 = sel(rt.is64, CBZ_X, CBZ_W);
+    if (is_nz) { base = sel(rt.is64, CBNZ_X, CBNZ_W); }
+    val word: u32 = pack_cbnz(base, rt.reg);
+
+    val target: str = asm_trim((?b1[0])::str);
+    var number: u64 = 0;
+    var fwd: bool = false;
+    if (asm_label_ref(target, ?number, ?fwd)) {
+        ret emit_asm_branch_label(st, labels, word, number, fwd);
+    }
+    if (str_len(target) > 0 && asm_is_digit(target[0])) {
+        ret err[bool, str]("encode: inline-asm numeric local-label reference must be 'Nf' or 'Nb'");
+    }
+    ret err[bool, str]("encode: inline-asm cbz/cbnz to a symbol is unsupported (no imm19 relocation kind); branch to a numeric local label instead");
+}
+
+# emit_asm_one_reg: a single-register-operand instruction (`blr Xn` / `br Xn`).
+fun emit_asm_one_reg(st: *EncodeState, args: str, word_is_blr: bool) Result[bool, str] {
+    val s: str = asm_trim(args);
+    var op: AsmOp;
+    if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm blr/br operand must be a register"); }
+    if (word_is_blr) { emit_word(st, pack_blr(op.reg)); }
+    or { emit_word(st, BR_BASE | ((op.reg & 0x1F) << 5)); }
+    ret ok[bool, str](true);
+}
+
+# emit_asm_bl: `bl sym` — a direct call, RK_PLT32 (the CALL26 the linker resolves).
+fun emit_asm_bl(st: *EncodeState, args: str) Result[bool, str] {
+    val s: str = asm_trim(args);
+    var op: AsmOp;
+    if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_SYM) { ret err[bool, str]("encode: inline-asm 'bl' target must be a symbol"); }
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, BL_BASE);
+    ret asm_push_sym_reloc(st, pos, of.RK_PLT32, op.name, op.name_len, 0);
+}
+
+# emit_asm_imm16_op: a single-immediate instruction whose imm16 sits at bits[20:5]
+# (`svc #imm` / `brk #imm`). the value must fit 16 bits.
+fun emit_asm_imm16_op(st: *EncodeState, args: str, base: u32) Result[bool, str] {
+    val s: str = asm_trim(args);
+    var op: AsmOp;
+    if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_IMM) { ret err[bool, str]("encode: inline-asm svc/brk needs an immediate"); }
+    if (op.imm < 0 || op.imm > 0xFFFF) { ret err[bool, str]("encode: inline-asm svc/brk immediate is out of 16-bit range"); }
+    emit_word(st, base | ((op.imm::u32 & 0xFFFF) << 5));
+    ret ok[bool, str](true);
+}
+
+# emit_asm_ret: `ret` (return through x30) or `ret Xn`.
+fun emit_asm_ret(st: *EncodeState, args: str) Result[bool, str] {
+    val s: str = asm_trim(args);
+    if (s[0] == 0) { emit_word(st, RET_WORD); ret ok[bool, str](true); }
+    var op: AsmOp;
+    if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm 'ret' operand must be a register"); }
+    emit_word(st, RET_BASE | ((op.reg & 0x1F) << 5));
+    ret ok[bool, str](true);
+}
+
+# encode_asm_stmt_arm64: parse and encode one trimmed inline-asm statement. a numeric
+# local-label definition `<digits>:` records the current offset (resolving forward
+# references) and re-dispatches any instruction following it. an unrecognized
+# mnemonic is a hard error so the assembler is cleanly extensible.
+fun encode_asm_stmt_arm64(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, labels: *AsmLabels, tok: str) Result[bool, str] {
+    var label_num: u64 = 0;
+    val dlen: usize = asm_label_def_len(tok, ?label_num);
+    if (dlen > 0) {
+        val dr: Result[bool, str] = asm_label_record_def(st, labels, label_num, st.buf.len::u32);
+        if (is_err[bool, str](dr)) { ret dr; }
+        val rest: str = asm_trim((tok::usize + dlen)::str);
+        if (rest[0] == 0) { ret ok[bool, str](true); }
+        ret encode_asm_stmt_arm64(st, f, fn_base, labels, rest);
+    }
+
+    var mbuf: [24]u8;
+    var args: str;
+    if (!asm_first_token(tok, ?mbuf[0], 24, ?args)) { ret err[bool, str]("encode: inline-asm mnemonic too long"); }
+    val mnem: str = (?mbuf[0])::str;
+
+    if (str_equals(mnem, "nop"))  { emit_word(st, NOP_WORD); ret ok[bool, str](true); }
+    if (str_equals(mnem, "ret"))  { ret emit_asm_ret(st, args); }
+    if (str_equals(mnem, "svc"))  { ret emit_asm_imm16_op(st, args, SVC_BASE); }
+    if (str_equals(mnem, "brk"))  { ret emit_asm_imm16_op(st, args, BRK_BASE); }
+    if (str_equals(mnem, "mov"))  { ret emit_asm_mov(st, args); }
+    if (str_equals(mnem, "movz")) { ret emit_asm_movewide(st, args, false); }
+    if (str_equals(mnem, "movk")) { ret emit_asm_movewide(st, args, true); }
+    if (str_equals(mnem, "add"))  { ret emit_asm_addsub(st, args, false); }
+    if (str_equals(mnem, "sub"))  { ret emit_asm_addsub(st, args, true); }
+    if (str_equals(mnem, "and"))  { ret emit_asm_logical(st, args, AND_X, AND_W); }
+    if (str_equals(mnem, "orr"))  { ret emit_asm_logical(st, args, ORR_X, ORR_W); }
+    if (str_equals(mnem, "eor"))  { ret emit_asm_logical(st, args, EOR_X, EOR_W); }
+    if (str_equals(mnem, "cmp"))  { ret emit_asm_cmp(st, args); }
+    if (str_equals(mnem, "adrp")) { ret emit_asm_adrp(st, args); }
+    if (str_equals(mnem, "bl"))   { ret emit_asm_bl(st, args); }
+    if (str_equals(mnem, "blr"))  { ret emit_asm_one_reg(st, args, true); }
+    if (str_equals(mnem, "br"))   { ret emit_asm_one_reg(st, args, false); }
+    if (str_equals(mnem, "b"))    { ret emit_asm_b(st, labels, args); }
+    if (str_starts_with(mnem, "b.")) {
+        var cond: u32 = 0;
+        if (!asm_parse_cond((mnem::usize + 2)::str, ?cond)) {
+            ret err[bool, str](asm_named_err(st, "unsupported aarch64 inline-asm condition '", mnem, "'", "unsupported aarch64 inline-asm condition"));
+        }
+        ret emit_asm_bcond(st, labels, cond, args);
+    }
+    if (str_equals(mnem, "cbz"))  { ret emit_asm_cbr(st, labels, args, false); }
+    if (str_equals(mnem, "cbnz")) { ret emit_asm_cbr(st, labels, args, true); }
+    if (str_equals(mnem, "ldr") || str_equals(mnem, "str") ||
+        str_equals(mnem, "ldrb") || str_equals(mnem, "strb") ||
+        str_equals(mnem, "ldrh") || str_equals(mnem, "strh")) {
+        ret emit_asm_ldst(st, mnem, args);
+    }
+    if (str_equals(mnem, "stp")) { ret emit_asm_ldstp(st, args, false); }
+    if (str_equals(mnem, "ldp")) { ret emit_asm_ldstp(st, args, true); }
+
+    ret err[bool, str](asm_named_err(st, "unsupported aarch64 inline-asm mnemonic '", mnem, "'", "unsupported aarch64 inline-asm mnemonic"));
+}
+
+# encode_asm_text_arm64: tokenize the (already `{name}`-substituted) asm body on
+# newlines / `;`, trim each statement, and encode it. `#` line comments were stripped
+# at lower time, so none reach here. mirrors x86-64's `encode_asm_text`.
+fun encode_asm_text_arm64(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, labels: *AsmLabels, text: str) Result[bool, str] {
+    val len: usize = str_len(text);
+    var start: usize = 0;
+    for (start < len) {
+        var end: usize = start;
+        for (end < len && text[end] != '\n'::char && text[end] != ';'::char) { end = end + 1; }
+
+        var lo: usize = start;
+        for (lo < end && asm_is_space(text[lo])) { lo = lo + 1; }
+        var hi: usize = end;
+        for (hi > lo && asm_is_space(text[hi - 1])) { hi = hi - 1; }
+
+        if (hi > lo) {
+            var line: [512]u8;
+            val ll: usize = hi - lo;
+            if (ll >= 512) { ret err[bool, str]("encode: inline asm statement too long"); }
+            var c: usize = 0;
+            for (c < ll) { line[c] = text[lo + c]::u8; c = c + 1; }
+            line[ll] = 0;
+            val er: Result[bool, str] = encode_asm_stmt_arm64(st, f, fn_base, labels, (?line[0])::str);
+            if (is_err[bool, str](er)) { ret er; }
+        }
+        start = end + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# encode_asm_block_arm64: expand an inline-asm MIR_ASM instruction into A64 bytes.
+# substitutes `{name}` locals to `[x29, #off]`, encodes each statement, and verifies
+# every forward local-label reference was defined within the block. the A64 analogue
+# of x86-64's `encode_asm_block`.
+fun encode_asm_block_arm64(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.asm_block == nil) { ret err[bool, str]("encode: MIR_ASM has no payload"); }
+    val pl: *mir.MirAsm = mi.asm_block;
+    if (!str_equals(pl.isa, "aarch64")) {
+        ret err[bool, str]("encode: inline-asm block is not aarch64");
+    }
+
+    val sr: Result[str, str] = substitute_asm_locals_arm64(st.alloc, st.interner, f, pl);
+    if (is_err[str, str](sr)) { ret err[bool, str](unwrap_err[str, str](sr)); }
+    val text: str = unwrap_ok[str, str](sr);
+
+    var labels: AsmLabels;
+    asm_labels_init(?labels, st.alloc);
+    val er: Result[bool, str] = encode_asm_text_arm64(st, f, fn_base, ?labels, text);
+    deallocate[u8](st.alloc, text::*u8, (str_len(text) + 1)::usize);
+    if (is_err[bool, str](er)) {
+        asm_labels_dnit(?labels);
+        ret er;
+    }
+    if (labels.ref_count > 0) {
+        asm_labels_dnit(?labels);
+        ret err[bool, str]("encode: inline-asm forward reference to a local label has no definition in this asm block");
+    }
+    asm_labels_dnit(?labels);
+    ret ok[bool, str](true);
 }
 
 # ---- in-source encode tests (byte-exact vs llvm-mc goldens) ----
@@ -2151,6 +3331,353 @@ test "arm64.encode: oversized SUB SP uses the register form" {
     if (read_word(?st.buf, 0) != pack_movewide(MOVZ_X, 16, 1, 0x100)) { bad = 1; }
     if (read_word(?st.buf, 4) != (SUB_SP_REG_X | (16 << 16)))         { bad = 1; }
 
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# ---- inline-asm assembler tests (Phase 3c, byte-exact vs llvm-mc goldens) ----
+
+# tasm: a page-backed EncodeState with a live interner, for exercising the inline-asm
+# assembler (which interns symbol names and resolves `{name}` bindings).
+fun tasm(st: *EncodeState, alloc: *Allocator, interner: *intern.Interner) {
+    page.make(alloc);
+    @interner = intern.init(alloc);
+    st.alloc       = alloc;
+    st.buf         = buf_init(alloc);
+    st.interner    = interner;
+    st.syms        = nil; st.sym_count   = 0; st.sym_cap   = 0;
+    st.relocs      = nil; st.reloc_count = 0; st.reloc_cap = 0;
+    st.fixups      = nil; st.fixup_count = 0; st.fixup_cap = 0;
+    st.blocks      = nil; st.block_count = 0; st.block_cap = 0;
+}
+
+# every data-processing form the std `_start` / syscall path uses, byte-exact against
+# `llvm-mc -triple=aarch64 --show-encoding`. each statement is one 32-bit word.
+test "arm64.encode: inline-asm data-processing forms match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: AsmLabels;
+    asm_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "nop");                    # 0
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ret");                    # 4
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "svc #0");                 # 8
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "svc 0x1");               # 12
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "brk #0");                # 16
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov x0, x1");           # 20
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov sp, x0");           # 24
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov x0, sp");           # 28
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov w0, w1");           # 32
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov x8, #93");          # 36
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov x0, #0");           # 40
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "movz x0, #0x1234");     # 44
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "movz x0, #0x1234, lsl #16"); # 48
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "movk x0, #0x5678, lsl #16"); # 52
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "add x0, x1, #5");       # 56
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "add x0, x1, x2");       # 60
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "sub x0, x1, #5");       # 64
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "sub sp, sp, #16");      # 68
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "and x0, x1, x2");       # 72
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "orr x0, x1, x2");       # 76
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "eor x0, x1, x2");       # 80
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cmp x0, #5");           # 84
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cmp x0, x1");           # 88
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cmp w0, w1");           # 92
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "blr x0");              # 96
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "br x0");               # 100
+
+    if (read_word(?st.buf, 0)   != 0xD503201F) { bad = 1; }
+    if (read_word(?st.buf, 4)   != 0xD65F03C0) { bad = 1; }
+    if (read_word(?st.buf, 8)   != 0xD4000001) { bad = 1; }
+    if (read_word(?st.buf, 12)  != 0xD4000021) { bad = 1; }
+    if (read_word(?st.buf, 16)  != 0xD4200000) { bad = 1; }
+    if (read_word(?st.buf, 20)  != 0xAA0103E0) { bad = 1; }
+    if (read_word(?st.buf, 24)  != 0x9100001F) { bad = 1; }
+    if (read_word(?st.buf, 28)  != 0x910003E0) { bad = 1; }
+    if (read_word(?st.buf, 32)  != 0x2A0103E0) { bad = 1; }
+    if (read_word(?st.buf, 36)  != 0xD2800BA8) { bad = 1; }
+    if (read_word(?st.buf, 40)  != 0xD2800000) { bad = 1; }
+    if (read_word(?st.buf, 44)  != 0xD2824680) { bad = 1; }
+    if (read_word(?st.buf, 48)  != 0xD2A24680) { bad = 1; }
+    if (read_word(?st.buf, 52)  != 0xF2AACF00) { bad = 1; }
+    if (read_word(?st.buf, 56)  != 0x91001420) { bad = 1; }
+    if (read_word(?st.buf, 60)  != 0x8B020020) { bad = 1; }
+    if (read_word(?st.buf, 64)  != 0xD1001420) { bad = 1; }
+    if (read_word(?st.buf, 68)  != 0xD10043FF) { bad = 1; }
+    if (read_word(?st.buf, 72)  != 0x8A020020) { bad = 1; }
+    if (read_word(?st.buf, 76)  != 0xAA020020) { bad = 1; }
+    if (read_word(?st.buf, 80)  != 0xCA020020) { bad = 1; }
+    if (read_word(?st.buf, 84)  != 0xF100141F) { bad = 1; }
+    if (read_word(?st.buf, 88)  != 0xEB01001F) { bad = 1; }
+    if (read_word(?st.buf, 92)  != 0x6B01001F) { bad = 1; }
+    if (read_word(?st.buf, 96)  != 0xD63F0000) { bad = 1; }
+    if (read_word(?st.buf, 100) != 0xD61F0000) { bad = 1; }
+
+    asm_labels_dnit(?labels);
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# every load / store form (single registers + pairs) the std frame / syscall path
+# uses, byte-exact against llvm-mc.
+test "arm64.encode: inline-asm load/store forms match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: AsmLabels;
+    asm_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x1]");          # 0
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x1, #8]");      # 4
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x1, x2]");      # 8
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "str w0, [x1, #4]");      # 12
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldrb w0, [x1]");         # 16
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldrh w0, [x1, #2]");     # 20
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "strb w0, [x1, #1]");     # 24
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x1, #-8]");     # 28
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "str x0, [sp, #8]");      # 32
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [sp]");          # 36
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stp x29, x30, [sp, #-16]!"); # 40
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldp x29, x30, [sp], #16");   # 44
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stp x19, x20, [sp, #16]");   # 48
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldp x19, x20, [sp, #16]");   # 52
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stp x0, x1, [sp]");          # 56
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stp x0, x1, [sp], #16");     # 60
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldp x0, x1, [sp, #16]!");    # 64
+
+    if (read_word(?st.buf, 0)  != 0xF9400020) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0xF9400420) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0xF8626820) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0xB9000420) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0x39400020) { bad = 1; }
+    if (read_word(?st.buf, 20) != 0x79400420) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0x39000420) { bad = 1; }
+    if (read_word(?st.buf, 28) != 0xF85F8020) { bad = 1; }
+    if (read_word(?st.buf, 32) != 0xF90007E0) { bad = 1; }
+    if (read_word(?st.buf, 36) != 0xF94003E0) { bad = 1; }
+    if (read_word(?st.buf, 40) != 0xA9BF7BFD) { bad = 1; }
+    if (read_word(?st.buf, 44) != 0xA8C17BFD) { bad = 1; }
+    if (read_word(?st.buf, 48) != 0xA90153F3) { bad = 1; }
+    if (read_word(?st.buf, 52) != 0xA94153F3) { bad = 1; }
+    if (read_word(?st.buf, 56) != 0xA90007E0) { bad = 1; }
+    if (read_word(?st.buf, 60) != 0xA88107E0) { bad = 1; }
+    if (read_word(?st.buf, 64) != 0xA9C107E0) { bad = 1; }
+
+    asm_labels_dnit(?labels);
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the symbol-operand forms: `adrp` (RK_PAGE21), `add :lo12:` (RK_ADD_LO12), `bl`
+# (RK_PLT32 / CALL26), and the per-width folded-global `ldr/str [Xn, :lo12:]`
+# (RK_LDST*_LO12). base words match llvm-mc; the reloc fields are zero placeholders.
+test "arm64.encode: inline-asm symbol relocations record #1163 kinds" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: AsmLabels;
+    asm_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    val gr: Result[intern.StrId, str] = intern.intern(?interner, "gsym");
+    val fr: Result[intern.StrId, str] = intern.intern(?interner, "fsym");
+    if (is_err[intern.StrId, str](gr) || is_err[intern.StrId, str](fr)) { ret 1; }
+    val g: intern.StrId    = unwrap_ok[intern.StrId, str](gr);
+    val fsym: intern.StrId = unwrap_ok[intern.StrId, str](fr);
+
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "adrp x0, gsym");            # 0
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "add x0, x0, :lo12:gsym");   # 4
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "bl fsym");                  # 8
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x16, :lo12:gsym]"); # 12
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "str w1, [x16, :lo12:gsym]"); # 16
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldrb w0, [x16, :lo12:gsym]"); # 20
+
+    if (read_word(?st.buf, 0)  != 0x90000000) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0x91000000) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0x94000000) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0xF9400200) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0xB9000201) { bad = 1; }
+    if (read_word(?st.buf, 20) != 0x39400200) { bad = 1; }
+
+    if (st.reloc_count != 6) { bad = 1; }
+    or {
+        if (st.relocs[0].kind != of.RK_PAGE21      || st.relocs[0].offset != 0  || st.relocs[0].sym != g)    { bad = 1; }
+        if (st.relocs[1].kind != of.RK_ADD_LO12    || st.relocs[1].offset != 4  || st.relocs[1].sym != g)    { bad = 1; }
+        if (st.relocs[2].kind != of.RK_PLT32       || st.relocs[2].offset != 8  || st.relocs[2].sym != fsym) { bad = 1; }
+        if (st.relocs[3].kind != of.RK_LDST64_LO12 || st.relocs[3].offset != 12 || st.relocs[3].sym != g)    { bad = 1; }
+        if (st.relocs[4].kind != of.RK_LDST32_LO12 || st.relocs[4].offset != 16 || st.relocs[4].sym != g)    { bad = 1; }
+        if (st.relocs[5].kind != of.RK_LDST8_LO12  || st.relocs[5].offset != 20 || st.relocs[5].sym != g)    { bad = 1; }
+    }
+
+    if (st.relocs != nil && st.reloc_cap > 0) {
+        deallocate[enc.PendingReloc](?alloc, st.relocs, st.reloc_cap::usize);
+    }
+    asm_labels_dnit(?labels);
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the in-block numeric-local-label path (the only intra-module branch target for a
+# conditional/compare branch, mirroring x86-64's 1f/1b handling): forward references
+# patch when the label is defined, backward references patch immediately. the imm26 /
+# imm19 insert reuses `patch_branch_arm64`, so the patched words match llvm-mc.
+test "arm64.encode: inline-asm branches to numeric local labels (b/b.cond/cbz/cbnz)" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: AsmLabels;
+    asm_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "nop");          # 0
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cbz x0, 1f");   # 4  (forward)
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "b.eq 1f");      # 8  (forward)
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "1: nop");       # 12 (define label 1; patch fwd refs)
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "b 1b");         # 16 (backward, imm26)
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cbnz w1, 1b");  # 20 (backward, imm19)
+
+    # cbz x0 @4 -> 12: disp 8, imm19=2 -> 0xb4000040
+    if (read_word(?st.buf, 4)  != 0xB4000040) { bad = 1; }
+    # b.eq @8 -> 12: disp 4, imm19=1 -> 0x54000020
+    if (read_word(?st.buf, 8)  != 0x54000020) { bad = 1; }
+    # b @16 -> 12: disp -4, imm26 -> 0x17ffffff
+    if (read_word(?st.buf, 16) != 0x17FFFFFF) { bad = 1; }
+    # cbnz w1 @20 -> 12: disp -8, imm19 -> 0x35ffffc1
+    if (read_word(?st.buf, 20) != 0x35FFFFC1) { bad = 1; }
+    # all forward references resolved.
+    if (labels.ref_count != 0) { bad = 1; }
+
+    asm_labels_dnit(?labels);
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# a `{name}` local substitutes to its `[x29, #off]` frame slot (the AArch64 analogue
+# of x86-64's `[rbp+off]`); a slot at -8 loads/stores through the LDUR/STUR forms.
+test "arm64.encode: inline-asm {name} local resolves to a frame slot" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+
+    var slots: [1]mir.MirSlot;
+    slots[0].value  = 100;
+    slots[0].kind   = mir.SLOT_SPILL;
+    slots[0].offset = -8;
+    slots[0].size   = 4;
+    slots[0].align  = 4;
+    var f: mir.MirFunction;
+    f.frame.slots      = ?slots[0];
+    f.frame.slot_count = 1;
+
+    val xr: Result[intern.StrId, str] = intern.intern(?interner, "x");
+    if (is_err[intern.StrId, str](xr)) { ret 1; }
+    var binds: [1]mir.MirAsmBind;
+    binds[0].name      = unwrap_ok[intern.StrId, str](xr);
+    binds[0].slot_vreg = 100;
+
+    var pl: mir.MirAsm;
+    pl.isa        = "aarch64";
+    pl.body       = "ldr w0, {x}\nstr w0, {x}";
+    pl.binds      = ?binds[0];
+    pl.bind_count = 1;
+
+    var mi: mir.MirInstr;
+    mi.opcode        = mir.MIR_ASM;
+    mi.operands      = nil;
+    mi.operand_count = 0;
+    mi.width         = 0;
+    mi.src_width     = 0;
+    mi.asm_block     = ?pl;
+
+    val r: Result[bool, str] = encode_asm_block_arm64(?st, ?f, 0, ?mi);
+    if (is_err[bool, str](r)) { bad = 1; }
+    or {
+        # ldr w0, [x29, #-8] -> ldur w0,[x29,#-8] = 0xb85f83a0
+        if (read_word(?st.buf, 0) != 0xB85F83A0) { bad = 1; }
+        # str w0, [x29, #-8] -> stur w0,[x29,#-8] = 0xb81f83a0
+        if (read_word(?st.buf, 4) != 0xB81F83A0) { bad = 1; }
+    }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# in a mach inline-asm body `#` is the comment character (stripped at lower time), so
+# A64 immediates are written BARE — `mov x8, 93`, `ldr x0, [x1, 8]`, `stp ..., -16]!`.
+# the bare forms must encode identically to the `#`-prefixed forms.
+test "arm64.encode: inline-asm bare immediates (no '#') match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: AsmLabels;
+    asm_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov x8, 93");              # 0  0xd2800ba8
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "add x0, x1, 5");          # 4  0x91001420
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cmp x0, 5");              # 8  0xf100141f
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "svc 0");                  # 12 0xd4000001
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "movz x0, 0x1234, lsl 16"); # 16 0xd2a24680
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x1, 8]");        # 20 0xf9400420
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "str x0, [x1, -8]");       # 24 0xf81f8020
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stp x29, x30, [sp, -16]!"); # 28 0xa9bf7bfd
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldp x29, x30, [sp], 16");   # 32 0xa8c17bfd
+
+    if (read_word(?st.buf, 0)  != 0xD2800BA8) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0x91001420) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0xF100141F) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0xD4000001) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0xD2A24680) { bad = 1; }
+    if (read_word(?st.buf, 20) != 0xF9400420) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0xF81F8020) { bad = 1; }
+    if (read_word(?st.buf, 28) != 0xA9BF7BFD) { bad = 1; }
+    if (read_word(?st.buf, 32) != 0xA8C17BFD) { bad = 1; }
+
+    asm_labels_dnit(?labels);
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# an unrecognized mnemonic is a hard error naming the offending mnemonic, so the
+# assembler stays cleanly extensible; a conditional branch to a SYMBOL (no imm19
+# relocation kind) is likewise rejected loud rather than mis-encoded.
+test "arm64.encode: inline-asm rejects unknown mnemonic and condbr-to-symbol" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: AsmLabels;
+    asm_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    val r1: Result[bool, str] = encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "frobnicate x0, x1");
+    if (!is_err[bool, str](r1)) { bad = 1; }
+    or { if (!str_contains(unwrap_err[bool, str](r1), "unsupported aarch64 inline-asm mnemonic")) { bad = 1; } }
+
+    val r2: Result[bool, str] = encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cbz x0, some_symbol");
+    if (!is_err[bool, str](r2)) { bad = 1; }
+    or { if (!str_contains(unwrap_err[bool, str](r2), "no imm19 relocation kind")) { bad = 1; } }
+
+    val r3: Result[bool, str] = encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "b.eq some_symbol");
+    if (!is_err[bool, str](r3)) { bad = 1; }
+
+    asm_labels_dnit(?labels);
     buf_dnit(?st.buf);
     ret bad;
 }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -3136,6 +3136,52 @@ fun asm_barrier_option(name: str, out: *u32) bool {
     ret false;
 }
 
+# emit_asm_shift: `lsl`/`lsr`/`asr Rd, Rn, #imm|Rm` and the register-only
+# `lslv`/`lsrv`/`asrv Rd, Rn, Rm`. an immediate count emits the UBFM (lsl/lsr) /
+# SBFM (asr) bitfield alias — immr=(W-sh)&(W-1), imms=W-1-sh for lsl; immr=sh,
+# imms=W-1 for lsr/asr — the register form the LSLV/LSRV/ASRV variable shift,
+# mirroring the MIR `encode_shift`.
+fun emit_asm_shift(st: *EncodeState, mnem: str, args: str) Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret err[bool, str]("encode: malformed inline-asm shift operands"); }
+    if (n != 3) { ret err[bool, str]("encode: inline-asm shift expects Rd, Rn, Rm|#imm"); }
+    var rd: AsmOp; var rn: AsmOp; var cnt: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm shift destination must be a register"); }
+    if (!asm_parse_operand((?b1[0])::str, ?rn) || rn.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm shift source must be a register"); }
+    if (!asm_parse_operand((?b2[0])::str, ?cnt)) { ret err[bool, str]("encode: malformed inline-asm shift count"); }
+    val use64: bool = rd.is64;
+    var width: u32 = 32;
+    if (use64) { width = 64; }
+    # kind: 0 = lsl, 1 = lsr, 2 = asr; the `v` mnemonics are register-only.
+    var kind: u32 = 0;
+    var vform: bool = false;
+    if (str_equals(mnem, "lsr"))  { kind = 1; }
+    or (str_equals(mnem, "asr"))  { kind = 2; }
+    or (str_equals(mnem, "lslv")) { kind = 0; vform = true; }
+    or (str_equals(mnem, "lsrv")) { kind = 1; vform = true; }
+    or (str_equals(mnem, "asrv")) { kind = 2; vform = true; }
+    if (cnt.kind == ASMOP_IMM && !vform) {
+        val sh: u32 = (cnt.imm::u32) & (width - 1);
+        if (kind == 0) {
+            val immr: u32 = (width - sh) & (width - 1);
+            val imms: u32 = (width - 1) - sh;
+            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd.reg, rn.reg, immr, imms));
+        } or (kind == 1) {
+            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd.reg, rn.reg, sh, width - 1));
+        } or {
+            emit_word(st, pack_bitfield(sel(use64, SBFM_X, SBFM_W), rd.reg, rn.reg, sh, width - 1));
+        }
+        ret ok[bool, str](true);
+    }
+    if (cnt.kind != ASMOP_REG) { ret err[bool, str]("encode: inline-asm shift count must be a register or immediate"); }
+    var bx: u32 = LSLV_X; var bw: u32 = LSLV_W;
+    if (kind == 1) { bx = LSRV_X; bw = LSRV_W; }
+    or (kind == 2) { bx = ASRV_X; bw = ASRV_W; }
+    emit_word(st, pack_alu3(sel(use64, bx, bw), rd.reg, rn.reg, cnt.reg));
+    ret ok[bool, str](true);
+}
+
 # emit_asm_branch_label: emit a branch (B / B.cond / CBZ / CBNZ) to a numeric local
 # label. a backward reference patches immediately against the nearest preceding
 # definition; a forward reference is recorded and patched when its definition is
@@ -3317,6 +3363,10 @@ fun encode_asm_stmt_arm64(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, l
         ret emit_asm_ldordered(st, mnem, args);
     }
     if (str_equals(mnem, "stlxr")) { ret emit_asm_stlxr(st, args); }
+    if (str_equals(mnem, "lsl") || str_equals(mnem, "lsr") || str_equals(mnem, "asr") ||
+        str_equals(mnem, "lslv") || str_equals(mnem, "lsrv") || str_equals(mnem, "asrv")) {
+        ret emit_asm_shift(st, mnem, args);
+    }
 
     ret err[bool, str](asm_named_err(st, "unsupported aarch64 inline-asm mnemonic '", mnem, "'", "unsupported aarch64 inline-asm mnemonic"));
 }
@@ -4875,6 +4925,46 @@ test "arm64.encode: inline-asm atomic/barrier forms match llvm-mc" {
     if (read_word(?st.buf, 28) != 0x885FFC20) { bad = 1; }
     if (read_word(?st.buf, 32) != 0xC802FC20) { bad = 1; }
     if (read_word(?st.buf, 36) != 0x8802FC20) { bad = 1; }
+
+    asm_labels_dnit(?labels);
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the shift family (UBFM/SBFM immediate aliases + LSLV/LSRV/ASRV register forms): the
+# `lsl`/`lsr`/`asr` mnemonics over immediate and register counts, plus the register-only
+# `lslv`/`lsrv`/`asrv`. words match llvm-mc.
+test "arm64.encode: inline-asm shift forms match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: AsmLabels;
+    asm_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsl x10, x10, #3"); # 0
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsl w0, w1, #3");   # 4
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsr x0, x1, #3");   # 8
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsr w0, w1, #3");   # 12
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "asr x0, x1, #3");   # 16
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "asr w0, w1, #3");   # 20
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsl x0, x1, x2");   # 24
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsr x0, x1, x2");   # 28
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "asr x0, x1, x2");   # 32
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lslv x0, x1, x2");  # 36
+
+    if (read_word(?st.buf, 0)  != 0xD37DF14A) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0x531D7020) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0xD343FC20) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0x53037C20) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0x9343FC20) { bad = 1; }
+    if (read_word(?st.buf, 20) != 0x13037C20) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0x9AC22020) { bad = 1; }
+    if (read_word(?st.buf, 28) != 0x9AC22420) { bad = 1; }
+    if (read_word(?st.buf, 32) != 0x9AC22820) { bad = 1; }
+    if (read_word(?st.buf, 36) != 0x9AC22020) { bad = 1; }
 
     asm_labels_dnit(?labels);
     buf_dnit(?st.buf);

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -3411,11 +3411,32 @@ fun asm_mark_op(args: str, idx: u32, gp: *u32) {
     }
 }
 
+# asm_mark_ldstp_wb: OR the writeback base register of an `ldp`/`stp` into `@gp` when the
+# addressing form mutates it — pre-index `[Xn, #imm]!` (the MEM operand's `wb_pre`) or
+# post-index `[Xn], #imm` (a trailing immediate operand after the bare MEM). a plain
+# `[Xn{, #imm}]` writes no base. operand 2 is the MEM; operand 3 (post-index only) is the
+# displacement.
+fun asm_mark_ldstp_wb(args: str, gp: *u32) {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { @gp = @gp | 0xFFFFFFFF; ret; }
+    if (n < 3) { ret; }
+    var mem: AsmOp;
+    if (!asm_parse_operand((?b2[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret; }
+    var wb: bool = mem.wb_pre;
+    if (n >= 4) {
+        var disp: AsmOp;
+        if (asm_parse_operand((?b3[0])::str, ?disp) && disp.kind == ASMOP_IMM) { wb = true; }
+    }
+    if (wb && mem.base < 32) { @gp = @gp | (1::u32 << mem.base); }
+}
+
 # asm_stmt_clobbers: OR the registers one trimmed aarch64 inline-asm statement writes
 # into `@gp` (the grammar has no FP write). a dest-writing form clobbers operand 0 (ldp
-# both loaded registers; stlxr the status result); a `bl`/`blr`/`br` call clobbers the
-# caller-saved file (x0-x18, x30) and `svc` clobbers x0 — none callee-saved, so they add
-# no frame; stores / compares / branches / barriers write nothing. an unrecognized
+# both loaded registers; stlxr the status result); ldp/stp in a pre/post-index writeback
+# form also clobber the base register; a `bl`/`blr`/`br` call clobbers the caller-saved
+# file (x0-x18, x30) and `svc` clobbers x0 — none callee-saved, so they add no frame;
+# compares / branches / barriers and non-writeback stores write nothing. an unrecognized
 # statement conservatively clobbers everything.
 fun asm_stmt_clobbers(stmt: str, gp: *u32, fp: *u32) {
     var lnum: u64 = 0;
@@ -3435,7 +3456,7 @@ fun asm_stmt_clobbers(stmt: str, gp: *u32, fp: *u32) {
     if (str_equals(mnem, "nop") || str_equals(mnem, "yield") || str_equals(mnem, "dmb") ||
         str_equals(mnem, "ret") || str_equals(mnem, "brk") || str_equals(mnem, "cmp") ||
         str_equals(mnem, "str") || str_equals(mnem, "strb") || str_equals(mnem, "strh") ||
-        str_equals(mnem, "stp") || str_equals(mnem, "stlr") ||
+        str_equals(mnem, "stlr") ||
         str_equals(mnem, "b") || str_equals(mnem, "cbz") || str_equals(mnem, "cbnz")) { ret; }
     if (str_starts_with(mnem, "b.")) { ret; }
 
@@ -3446,8 +3467,10 @@ fun asm_stmt_clobbers(stmt: str, gp: *u32, fp: *u32) {
     }
     if (str_equals(mnem, "svc")) { @gp = @gp | 0x1; ret; }
 
-    # ldp writes both loaded registers.
-    if (str_equals(mnem, "ldp")) { asm_mark_op(args, 0, gp); asm_mark_op(args, 1, gp); ret; }
+    # ldp writes both loaded registers (+ the base in a writeback form); stp writes only
+    # the base, and only in a writeback form.
+    if (str_equals(mnem, "ldp")) { asm_mark_op(args, 0, gp); asm_mark_op(args, 1, gp); asm_mark_ldstp_wb(args, gp); ret; }
+    if (str_equals(mnem, "stp")) { asm_mark_ldstp_wb(args, gp); ret; }
 
     # dest = operand 0: data-processing / load / shift forms and stlxr's status reg.
     if (str_equals(mnem, "mov") || str_equals(mnem, "movz") || str_equals(mnem, "movk") ||

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -12,16 +12,22 @@
 # the shared `enc` module; this backend supplies only the A64 bitfield packers,
 # prologue/epilogue emission, and branch patching.
 #
-# SCOPE (Phase 2b — leaf integer). Every modeled form is byte-exact against
-# llvm-mc: the three-address integer ALU (ADD/SUB/MUL/AND/ORR/EOR), the shifts
-# (register LSLV/LSRV/ASRV and immediate UBFM/SBFM aliases), NEG/MVN/MOV, the
-# MOVZ/MOVK immediate materialization, RET, the STP/MOV prologue and LDP/RET
-# epilogue, CMP (SUBS XZR) + CSET, the unconditional branch B, the conditional
-# branch (CBNZ + B), and the BRK unreachable trap. The contract gaps DEFERRED to a
-# later phase (a leaf integer function never reaches them, so they fail loudly
-# rather than emit wrong bytes): frame-slot / spill memory operands, callee-saved
-# FP registers, frames larger than the pre-index STP range, inline asm, calls and
-# their relocations, and the float / conversion families.
+# SCOPE (Phase 3a — frames + non-symbol memory + integer conversions, atop the
+# Phase 2b leaf integer core). Every modeled form is byte-exact against llvm-mc:
+# the three-address integer ALU (ADD/SUB/MUL/AND/ORR/EOR), the shifts (register
+# LSLV/LSRV/ASRV and immediate UBFM/SBFM aliases), NEG/MVN/MOV, the MOVZ/MOVK
+# immediate materialization, RET, CMP (SUBS XZR) + CSET, the unconditional branch
+# B, the conditional branch (CBNZ + B), and the BRK unreachable trap; plus the
+# record-at-top non-leaf prologue (STP/MOV record, `SUB SP` frame, GP callee-save
+# STP/LDP pairs) and epilogue, frame-slot / spill memory operands addressed
+# `[x29 + slot.offset]`, non-symbol LDR/STR with scaled-imm12 / unscaled-imm9 /
+# register-offset legalization, GEP / ALLOCA address arithmetic, and the integer
+# conversions (TRUNC / SEXT-SXTB/SXTH/SXTW / ZEXT-UXTB/UXTH / GP BITCAST). The
+# contract gaps DEFERRED to a later phase (an in-scope function never reaches them,
+# so they fail loudly rather than emit wrong bytes): calls and their relocations
+# (Phase 3b), symbol relocations incl. folded-global ADRP+LDR and address-of
+# ADRP+ADD (Phase 3b), inline asm (Phase 3c), callee-saved FP registers, and the
+# float / float-conversion families (Phase 4).
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -35,6 +41,12 @@ use std.types.result.err;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
+
+use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_some;
+use std.types.option.unwrap;
 
 use std.allocator.Allocator;
 use page: std.allocator.page;
@@ -117,6 +129,25 @@ val STP_OFF_X:  u32 = 0xA9000000;
 val LDP_OFF_X:  u32 = 0xA9400000;
 val STR_OFF_X:  u32 = 0xF9000000;
 val LDR_OFF_X:  u32 = 0xF9400000;
+# single-register load/store base words by access size, for the three addressing
+# forms (each confirmed byte-exact against llvm-mc). the size bits[31:30] select
+# byte / halfword / word / doubleword; the load bit (bit 22) distinguishes load
+# from store. the 64-bit scaled forms are STR_OFF_X / LDR_OFF_X above.
+# scaled unsigned-offset (imm12 = byte offset / access size, bits[21:10]).
+val STRB_OFF: u32 = 0x39000000; val LDRB_OFF: u32 = 0x39400000;
+val STRH_OFF: u32 = 0x79000000; val LDRH_OFF: u32 = 0x79400000;
+val STRW_OFF: u32 = 0xB9000000; val LDRW_OFF: u32 = 0xB9400000;
+# unscaled signed-offset (LDUR / STUR, imm9 = byte offset, bits[20:12]).
+val STURB: u32 = 0x38000000; val LDURB: u32 = 0x38400000;
+val STURH: u32 = 0x78000000; val LDURH: u32 = 0x78400000;
+val STURW: u32 = 0xB8000000; val LDURW: u32 = 0xB8400000;
+val STUR_X: u32 = 0xF8000000; val LDUR_X: u32 = 0xF8400000;
+# register-offset (`[Xn, Xm]`, option=LSL/UXTX, S=0; the materialized-displacement
+# fallback addresses with the full byte offset in a scratch, so no scaling).
+val STRB_REG: u32 = 0x38206800; val LDRB_REG: u32 = 0x38606800;
+val STRH_REG: u32 = 0x78206800; val LDRH_REG: u32 = 0x78606800;
+val STRW_REG: u32 = 0xB8206800; val LDRW_REG: u32 = 0xB8606800;
+val STR_REG_X: u32 = 0xF8206800; val LDR_REG_X: u32 = 0xF8606800;
 # the unconditional branch (imm26) and the conditional / compare-branch family (imm19).
 val B_BASE:    u32 = 0x14000000;
 val BCOND:     u32 = 0x54000000;
@@ -134,10 +165,16 @@ val ZR: u32 = 31;
 val SCRATCH0: u32 = 16;
 val SCRATCH1: u32 = 17;
 
-# the largest frame the pre-index STP can allocate in one instruction: the scaled
-# 7-bit signed immediate spans -64..63 eightbytes, so -512..504 bytes; the negative
-# pre-index offset is `-total`, bounded below by -512, i.e. total <= 504.
-val MAX_PREINDEX_FRAME: u32 = 504;
+# the deepest the GP callee-save STP/LDP pairs reach below x29: the scaled 7-bit
+# signed immediate spans -64..63 eightbytes, so the pair offset `-(frame.size +
+# pair_bytes)` is bounded below by -512. a function whose `frame.size + GP-save
+# area` exceeds this reaches Phase 3b's scratch-base callee-save addressing; until
+# then it fails loudly rather than truncate the STP immediate.
+val MAX_CALLEE_SAVE_REACH: u32 = 504;
+# the largest frame the prologue's `SUB SP` can allocate with the two-immediate
+# (imm12 + imm12<<12) form: `(0xFFF << 12) + 0xFF0` rounded to 16. a frame beyond
+# ~16 MiB fails loudly rather than mis-encode the subtraction.
+val MAX_FRAME_SUB: u32 = 0xFFFFF0;
 
 # A64 condition codes (bits[3:0] of a conditional form). the CSET / B.cond
 # encodings read these directly; `pack_cset` writes the inverted condition.
@@ -216,6 +253,67 @@ fun pack_cbnz(base: u32, rt: u32) u32 {
     ret base | (rt & 0x1F);
 }
 
+# pack_alu3_sh: a three-register data-processing word with a left-shift amount —
+# Rm[20:16], shift[15:10], Rn[9:5], Rd[4:0]. used for the GEP scaled-index ADD
+# (`add Rd, Rn, Rm, lsl #sh`); `pack_alu3` is the `sh == 0` case.
+fun pack_alu3_sh(base: u32, rd: u32, rn: u32, rm: u32, sh: u32) u32 {
+    ret base | ((rm & 0x1F) << 16) | ((sh & 0x3F) << 10) | ((rn & 0x1F) << 5) | (rd & 0x1F);
+}
+
+# pack_ldur: an unscaled signed-offset load/store word — imm9[20:12] (the raw,
+# signed byte offset), Rn[9:5], Rt[4:0]. used for the LDUR / STUR forms covering a
+# negative or unaligned displacement the scaled imm12 cannot.
+fun pack_ldur(base: u32, rt: u32, rn: u32, imm9: u32) u32 {
+    ret base | ((imm9 & 0x1FF) << 12) | ((rn & 0x1F) << 5) | (rt & 0x1F);
+}
+
+# pack_ldst_reg: a register-offset load/store word — Rm[20:16], Rn[9:5], Rt[4:0]
+# (the option / S fields are baked into the `_REG` base for the unscaled `[Xn, Xm]`
+# form). used for the out-of-range-displacement fallback (the byte offset
+# materialized into the scratch register).
+fun pack_ldst_reg(base: u32, rt: u32, rn: u32, rm: u32) u32 {
+    ret base | ((rm & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rt & 0x1F);
+}
+
+# width_shift: the log2 of an access size (1/2/4/8 -> 0/1/2/3) — the scaled-offset
+# divisor for the imm12 form and the index shift for a scaled-index ADD. width 0
+# (a pseudo with no natural width) and width 4 both take the word shift.
+fun width_shift(w: u8) u32 {
+    if (w == 1) { ret 0; }
+    if (w == 2) { ret 1; }
+    if (w == 8) { ret 3; }
+    ret 2;
+}
+
+# ldst_base_scaled: the scaled unsigned-offset base word for an access width and
+# direction (load / store).
+fun ldst_base_scaled(w: u8, is_load: bool) u32 {
+    if (w == 1) { if (is_load) { ret LDRB_OFF; } ret STRB_OFF; }
+    if (w == 2) { if (is_load) { ret LDRH_OFF; } ret STRH_OFF; }
+    if (w == 4) { if (is_load) { ret LDRW_OFF; } ret STRW_OFF; }
+    if (is_load) { ret LDR_OFF_X; }
+    ret STR_OFF_X;
+}
+
+# ldst_base_unscaled: the unscaled signed-offset (LDUR / STUR) base word for an
+# access width and direction.
+fun ldst_base_unscaled(w: u8, is_load: bool) u32 {
+    if (w == 1) { if (is_load) { ret LDURB; } ret STURB; }
+    if (w == 2) { if (is_load) { ret LDURH; } ret STURH; }
+    if (w == 4) { if (is_load) { ret LDURW; } ret STURW; }
+    if (is_load) { ret LDUR_X; }
+    ret STUR_X;
+}
+
+# ldst_base_reg: the register-offset base word for an access width and direction.
+fun ldst_base_reg(w: u8, is_load: bool) u32 {
+    if (w == 1) { if (is_load) { ret LDRB_REG; } ret STRB_REG; }
+    if (w == 2) { if (is_load) { ret LDRH_REG; } ret STRH_REG; }
+    if (w == 4) { if (is_load) { ret LDRW_REG; } ret STRW_REG; }
+    if (is_load) { ret LDR_REG_X; }
+    ret STR_REG_X;
+}
+
 # ---- low-level emit / patch helpers ----
 
 # emit_word: append one 32-bit A64 instruction word to the text sink (little-endian).
@@ -288,19 +386,16 @@ fun emit_movewide_seq(st: *EncodeState, rd: u32, value: u64, use64: bool) {
 
 # ---- operand resolution ----
 
-# req_gpr: the GP register index a post-regalloc operand names. only a physical
-# register survives to encode; a surviving virtual register is a register-
-# allocation bug, and a frame-slot / memory operand is deferred to Phase 3. both
-# are rejected loudly rather than mis-encoded.
+# req_gpr: the GP register index a post-regalloc register operand names. only a
+# physical register survives to encode; a surviving virtual register is a register-
+# allocation bug. a memory operand reaches the dedicated load/store/address paths,
+# never this register-operand resolver, so it too is rejected loudly here.
 fun req_gpr(op: *mir.MirOperand) Result[i32, str] {
     if (op.kind == mir.MIR_OP_PREG) {
         ret ok[i32, str](isa.regid_index(op.preg::i32));
     }
     if (op.kind == mir.MIR_OP_VREG) {
         ret err[i32, str]("encode: virtual register survived register allocation");
-    }
-    if (op.kind == mir.MIR_OP_MEM) {
-        ret err[i32, str]("aarch64 frame-slot/memory operands not implemented (Phase 3)");
     }
     ret err[i32, str]("encode: expected a register operand");
 }
@@ -314,6 +409,135 @@ fun resolve_source(st: *EncodeState, op: *mir.MirOperand, scratch: u32, use64: b
         ret ok[i32, str](scratch::i32);
     }
     ret req_gpr(op);
+}
+
+# A64Mem: a resolved memory operand — a base register, a constant byte displacement
+# folded onto it, and an optional scaled index register. a frame-slot-key base
+# resolves to x29 with the slot offset folded into `off`; a physical-register base
+# keeps its register and displacement.
+# ---
+# base:      base register index (x29 for a frame slot, else the physical base)
+# off:       constant byte displacement folded onto the base
+# has_index: true when a scaled runtime index rides the address
+# index:     scaled index register index (when has_index)
+# scale:     index scale (1/2/4/8) (when has_index)
+rec A64Mem {
+    base:      u32;
+    off:       i64;
+    has_index: bool;
+    index:     u32;
+    scale:     u8;
+}
+
+# frame_slot_offset: the frame-pointer offset of the slot a MIR value owns, or none
+# when it owns no slot. the slot table is keyed on the slot-owning vreg ids, so a
+# physical-register base (carrying MIR_VREG_NIL) never matches. mirrors the x86-64
+# encoder's twin, reading the laid-out frame directly.
+fun frame_slot_offset(f: *mir.MirFunction, v: u32) Option[i64] {
+    val frame: *mir.MirFrame = ?f.frame;
+    if (frame.slots == nil) { ret none[i64](); }
+    var i: u32 = 0;
+    for (i < frame.slot_count) {
+        if (frame.slots[i].value == v) { ret some[i64](frame.slots[i].offset); }
+        i = i + 1;
+    }
+    ret none[i64]();
+}
+
+# resolve_mem: lower a post-regalloc MIR_OP_MEM operand to its A64 base / offset /
+# scaled-index form. a frame-slot-key base (`vreg != MIR_VREG_NIL`) folds the slot
+# offset onto x29; a physical-register base keeps `preg`. a surviving value vreg in
+# the base or index is a register-allocation bug, rejected loudly.
+fun resolve_mem(f: *mir.MirFunction, op: *mir.MirOperand) Result[A64Mem, str] {
+    if (op.kind != mir.MIR_OP_MEM) {
+        ret err[A64Mem, str]("encode: expected a memory operand");
+    }
+    var m: A64Mem;
+    m.has_index = false;
+    m.index     = 0;
+    m.scale     = 0;
+    if (op.index != mir.MIR_VREG_NIL) {
+        if (!op.index_is_preg) {
+            ret err[A64Mem, str]("encode: value vreg survived in a memory-operand index");
+        }
+        m.has_index = true;
+        m.index     = op.index;
+        m.scale     = op.scale;
+    }
+    if (op.vreg != mir.MIR_VREG_NIL) {
+        val slot: Option[i64] = frame_slot_offset(f, op.vreg);
+        if (!is_some[i64](slot)) {
+            ret err[A64Mem, str]("encode: value vreg survived in a memory-operand base");
+        }
+        m.base = arm64.FP::u32;
+        m.off  = unwrap[i64](slot) + op.imm;
+        ret ok[A64Mem, str](m);
+    }
+    m.base = op.preg;
+    m.off  = op.imm;
+    ret ok[A64Mem, str](m);
+}
+
+# emit_mem_access: emit a width-sized integer load or store of register `rt` at the
+# legalized address `[base + off]`, choosing the scaled unsigned-offset (imm12),
+# unscaled signed-offset (imm9 / LDUR-STUR), or register-offset form. an offset
+# outside both immediate ranges is materialized into IP0 and addressed `[base, IP0]`.
+# loads use the zero-extending forms, so a sub-word load defines the full register.
+fun emit_mem_access(st: *EncodeState, rt: u32, base: u32, off: i64, width: u8, is_load: bool) {
+    var w: u8 = width;
+    if (w == 0) { w = 8; }
+    val sh: u32 = width_shift(w);
+    # scaled unsigned imm12: non-negative, access-size aligned, within 12 bits.
+    if (off >= 0) {
+        val mask: i64 = (1::i64 << sh::i64) - 1;
+        if ((off & mask) == 0 && (off >> sh::i64) <= 4095) {
+            emit_word(st, pack_ldst(ldst_base_scaled(w, is_load), rt, base, (off >> sh::i64)::u32));
+            ret;
+        }
+    }
+    # unscaled signed imm9: -256..255.
+    if (off >= -256 && off <= 255) {
+        emit_word(st, pack_ldur(ldst_base_unscaled(w, is_load), rt, base, off::u32 & 0x1FF));
+        ret;
+    }
+    # out of range: materialize the byte offset into IP0 and use `[base + IP0]`.
+    emit_movewide_seq(st, SCRATCH0, off::u64, true);
+    emit_word(st, pack_ldst_reg(ldst_base_reg(w, is_load), rt, base, SCRATCH0));
+}
+
+# emit_add_imm: materialize `Rd = Rn + off` for a 64-bit address computation,
+# folding `off` into the ADD / SUB immediate (imm12, or imm12<<12 for a 4096-aligned
+# offset) and falling back to materializing `off` into IP0 then `add Rd, Rn, IP0`
+# for an offset beyond the immediate range. a zero offset still emits `add Rd, Rn, #0`.
+fun emit_add_imm(st: *EncodeState, rd: u32, rn: u32, off: i64) {
+    if (off >= 0 && off <= 4095) {
+        emit_word(st, pack_addsub_imm(ADDI_X, rd, rn, off::u32, 0));
+        ret;
+    }
+    if (off < 0 && off >= -4095) {
+        emit_word(st, pack_addsub_imm(SUBI_X, rd, rn, (-off)::u32, 0));
+        ret;
+    }
+    if (off > 0 && (off & 0xFFF) == 0 && (off >> 12) <= 4095) {
+        emit_word(st, pack_addsub_imm(ADDI_X, rd, rn, (off >> 12)::u32, 1));
+        ret;
+    }
+    if (off < 0 && ((-off) & 0xFFF) == 0 && ((-off) >> 12) <= 4095) {
+        emit_word(st, pack_addsub_imm(SUBI_X, rd, rn, ((-off) >> 12)::u32, 1));
+        ret;
+    }
+    emit_movewide_seq(st, SCRATCH0, off::u64, true);
+    emit_word(st, pack_alu3(ADD_X, rd, rn, SCRATCH0));
+}
+
+# scale_shift: the LSL amount realizing an index scale (1/2/4/8 -> 0/1/2/3) for the
+# GEP scaled-index ADD. an unmodeled scale (never produced by the SIB-legal lowering)
+# takes 0.
+fun scale_shift(scale: u8) u32 {
+    if (scale == 2) { ret 1; }
+    if (scale == 4) { ret 2; }
+    if (scale == 8) { ret 3; }
+    ret 0;
 }
 
 # ---- per-opcode encoders ----
@@ -449,17 +673,37 @@ fun encode_neg_mvn(st: *EncodeState, mi: *mir.MirInstr, base_x: u32, base_w: u32
     ret ok[bool, str](true);
 }
 
-# encode_mov: a register move (`orr Rd, XZR, Rm`) or, for an immediate source, a
-# MOVZ/MOVK materialization directly into the destination.
-fun encode_mov(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
+# encode_mov: a register move (`orr Rd, XZR, Rm`), an immediate materialization
+# (MOVZ/MOVK into the destination), or a spill load/store. the register-allocator
+# spill path emits its reload / store as a MIR_MOV with a frame-slot MEM operand
+# (`MOV reg <- [slot]` reload, `MOV [slot] <- reg` store), so a MEM destination
+# routes to a STR and a MEM source to a LDR at the spill width.
+fun encode_mov(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
     if (mi.operand_count < 2) { ret err[bool, str]("encode: mov missing operands"); }
     val use64: bool = is64(mi.width);
 
-    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    val src: *mir.MirOperand = ?mi.operands[1];
+
+    # a spill store: `MOV [slot] <- reg`.
+    if (dst.kind == mir.MIR_OP_MEM) {
+        ret emit_store_mem(st, f, dst, src, mi.width);
+    }
+
+    val rdr: Result[i32, str] = req_gpr(dst);
     if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
     val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
 
-    val src: *mir.MirOperand = ?mi.operands[1];
+    # a spill reload: `MOV reg <- [slot]`.
+    if (src.kind == mir.MIR_OP_MEM) {
+        val mr: Result[A64Mem, str] = resolve_mem(f, src);
+        if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+        val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+        if (m.has_index) { ret err[bool, str]("encode: indexed spill reload not expected"); }
+        emit_mem_access(st, rd, m.base, m.off, mi.width, true);
+        ret ok[bool, str](true);
+    }
+
     if (src.kind == mir.MIR_OP_IMM) {
         emit_movewide_seq(st, rd, src.imm::u64, use64);
         ret ok[bool, str](true);
@@ -468,6 +712,142 @@ fun encode_mov(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
     if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
     val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
     emit_word(st, pack_alu3(sel(use64, ORR_X, ORR_W), rd, ZR, rm));
+    ret ok[bool, str](true);
+}
+
+# emit_store_mem: store the value operand `val_op` to the resolved memory operand
+# `dst_mem` at byte `width`. a register value stores directly; an immediate 0 stores
+# the zero register; a non-zero immediate is materialized into IP1 first. a symbol
+# destination (a folded-global store) is a Phase 3b relocation, deferred loudly.
+fun emit_store_mem(st: *EncodeState, f: *mir.MirFunction, dst_mem: *mir.MirOperand, val_op: *mir.MirOperand, width: u8) Result[bool, str] {
+    if (dst_mem.kind == mir.MIR_OP_SYM) {
+        ret err[bool, str]("aarch64 folded-global store relocation not implemented (Phase 3b)");
+    }
+    val mr: Result[A64Mem, str] = resolve_mem(f, dst_mem);
+    if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+    val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+    if (m.has_index) { ret err[bool, str]("encode: indexed store not expected"); }
+
+    var rt: u32 = ZR;
+    if (val_op.kind == mir.MIR_OP_IMM) {
+        if (val_op.imm != 0) {
+            emit_movewide_seq(st, SCRATCH1, val_op.imm::u64, is64(width));
+            rt = SCRATCH1;
+        }
+    } or {
+        val rr: Result[i32, str] = req_gpr(val_op);
+        if (is_err[i32, str](rr)) { ret err[bool, str](unwrap_err[i32, str](rr)); }
+        rt = unwrap_ok[i32, str](rr)::u32;
+    }
+    emit_mem_access(st, rt, m.base, m.off, width, false);
+    ret ok[bool, str](true);
+}
+
+# encode_load: a `MIR_LOAD reg <- [mem]`. the destination is a register; the source
+# is a non-symbol frame-slot or pointer-register memory operand loaded at the access
+# width (`src_width`) with the zero-extending form. a symbol source (a folded-global
+# load) is a Phase 3b relocation, deferred loudly.
+fun encode_load(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: load missing operands"); }
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val src: *mir.MirOperand = ?mi.operands[1];
+    if (src.kind == mir.MIR_OP_SYM) {
+        ret err[bool, str]("aarch64 folded-global load relocation not implemented (Phase 3b)");
+    }
+    val mr: Result[A64Mem, str] = resolve_mem(f, src);
+    if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+    val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+    if (m.has_index) { ret err[bool, str]("encode: indexed load not expected"); }
+    emit_mem_access(st, rd, m.base, m.off, mi.src_width, true);
+    ret ok[bool, str](true);
+}
+
+# encode_store: a `MIR_STORE [mem] <- value` at the stored value's width. operand 0
+# is the memory destination, operand 1 the stored value.
+fun encode_store(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: store missing operands"); }
+    ret emit_store_mem(st, f, ?mi.operands[0], ?mi.operands[1], mi.width);
+}
+
+# encode_addr: a `MIR_GEP` / `MIR_ALLOCA` address computation `Rd <- base +
+# index*scale + disp` (the x86-64 LEA analogue). the constant displacement folds
+# into an ADD/SUB immediate (or a materialized add); a scaled runtime index folds
+# into an `add Rd, base, index, lsl #shift`. a symbol base (an address-of relocation)
+# is a Phase 3b ADRP+ADD sequence, deferred loudly.
+fun encode_addr(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: address op missing operands"); }
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val memop: *mir.MirOperand = ?mi.operands[1];
+    if (memop.kind == mir.MIR_OP_SYM) {
+        ret err[bool, str]("aarch64 address-of relocation not implemented (Phase 3b)");
+    }
+    val mr: Result[A64Mem, str] = resolve_mem(f, memop);
+    if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+    val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+
+    if (!m.has_index) {
+        emit_add_imm(st, rd, m.base, m.off);
+        ret ok[bool, str](true);
+    }
+    if (m.off == 0) {
+        emit_word(st, pack_alu3_sh(ADD_X, rd, m.base, m.index, scale_shift(m.scale)));
+        ret ok[bool, str](true);
+    }
+    emit_add_imm(st, rd, m.base, m.off);
+    emit_word(st, pack_alu3_sh(ADD_X, rd, rd, m.index, scale_shift(m.scale)));
+    ret ok[bool, str](true);
+}
+
+# encode_convert: an integer width / representation conversion `[dst, src]`. TRUNC
+# keeps the low bits with a 32-bit move (which zero-extends, covering every narrower
+# result width); a GP BITCAST is a same-width move; SEXT selects the SBFM alias
+# (SXTB/SXTH/SXTW) and ZEXT the UBFM alias (UXTB/UXTH, or a 32-bit move for the
+# 32->64 zero-extension the W-register write performs). operands arrive physical
+# (the allocator reloads any spilled operand before the instruction).
+fun encode_convert(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: conversion missing operands"); }
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+    val rsr: Result[i32, str] = req_gpr(?mi.operands[1]);
+    if (is_err[i32, str](rsr)) { ret err[bool, str](unwrap_err[i32, str](rsr)); }
+    val rs: u32 = unwrap_ok[i32, str](rsr)::u32;
+
+    val dw: u8 = mi.width;
+    val sw: u8 = mi.src_width;
+
+    if (mi.opcode == mir.MIR_TRUNC) {
+        emit_word(st, pack_alu3(ORR_W, rd, ZR, rs));
+        ret ok[bool, str](true);
+    }
+    if (mi.opcode == mir.MIR_BITCAST) {
+        emit_word(st, pack_alu3(sel(is64(dw), ORR_X, ORR_W), rd, ZR, rs));
+        ret ok[bool, str](true);
+    }
+    if (mi.opcode == mir.MIR_SEXT) {
+        if (sw >= 8) {
+            emit_word(st, pack_alu3(ORR_X, rd, ZR, rs));
+            ret ok[bool, str](true);
+        }
+        val imms: u32 = (sw::u32 * 8) - 1;
+        emit_word(st, pack_bitfield(sel(is64(dw), SBFM_X, SBFM_W), rd, rs, 0, imms));
+        ret ok[bool, str](true);
+    }
+    # MIR_ZEXT: a 32->64 (or wider source) zero-extension is a 32-bit move; a
+    # sub-word zero-extension is UXTB / UXTH (UBFM_W), which writes the W register
+    # (zero-extending to 64).
+    if (sw >= 4) {
+        emit_word(st, pack_alu3(ORR_W, rd, ZR, rs));
+        ret ok[bool, str](true);
+    }
+    val imms: u32 = (sw::u32 * 8) - 1;
+    emit_word(st, pack_bitfield(UBFM_W, rd, rs, 0, imms));
     ret ok[bool, str](true);
 }
 
@@ -585,41 +965,71 @@ fun align16(n: u32) u32 {
     ret (n + 15) & ~15::u32;
 }
 
-# frame_total: the 16-byte-aligned byte count the prologue reserves below the
-# caller's SP — the FP/LR frame record (16 bytes) plus the callee-saved GP/FP save
-# area, the local frame, and the outgoing-argument region, read from the SAME
-# shared frame facts the x86-64 encoder reads. SP stays 16-byte aligned.
-fun frame_total(f: *mir.MirFunction) u32 {
+# frame_subsize: the 16-byte-aligned byte count the prologue allocates with `SUB
+# SP` below the FP/LR frame record — the callee-saved GP/FP save area, the local
+# frame, and the outgoing-argument region, read from the SAME shared frame facts
+# the x86-64 encoder reads. the 16-byte FP/LR record itself is allocated separately
+# by the pre-index STP, so it is NOT counted here. a leaf function with no locals,
+# spills, callee-saves, or outgoing args yields 0 — the prologue then skips the
+# `SUB SP` and the byte stream matches the verified Phase 2b leaf output exactly.
+fun frame_subsize(f: *mir.MirFunction) u32 {
     val gp_bytes: u32 = popcount32(f.callee_mask) * 8;
     val fp_bytes: u32 = popcount32(f.callee_mask_fp) * 16;
-    ret align16(16 + gp_bytes + fp_bytes + f.frame.size + f.frame.outgoing_size);
+    ret align16(gp_bytes + fp_bytes + f.frame.size + f.frame.outgoing_size);
 }
 
-# emit_prologue: the standard AArch64 leaf prologue — `STP X29, X30, [SP, #-total]!`
-# (save the FP/LR frame record and allocate the whole frame) then `MOV X29, SP`
-# (an `add x29, sp, #0`). callee-saved GP registers are then saved in STP pairs
-# (a trailing odd one with STR) just above the frame record. SP stays 16-aligned.
-fun emit_prologue(st: *EncodeState, f: *mir.MirFunction, total: u32) {
-    val neg_off: u32 = (0::u32 - (total / 8)) & 0x7F;
-    emit_word(st, pack_ldstp(STP_PRE_X, 29, 30, ZR, neg_off));
+# emit_sp_sub: subtract a 16-aligned frame size from SP, folding it into a single
+# `SUB SP, SP, #imm12`, a `SUB SP, SP, #imm12, lsl #12` (plus a low `SUB` remainder)
+# for a frame beyond 12 bits, per the imm12 / imm12<<12 split. `subsize` is non-zero
+# and within `MAX_FRAME_SUB` (the caller range-checks).
+fun emit_sp_sub(st: *EncodeState, subsize: u32) {
+    if (subsize <= 0xFFF) {
+        emit_word(st, pack_addsub_imm(SUBI_X, ZR, ZR, subsize, 0));
+        ret;
+    }
+    val hi: u32 = subsize >> 12;
+    val lo: u32 = subsize & 0xFFF;
+    emit_word(st, pack_addsub_imm(SUBI_X, ZR, ZR, hi, 1));
+    if (lo != 0) { emit_word(st, pack_addsub_imm(SUBI_X, ZR, ZR, lo, 0)); }
+}
+
+# emit_prologue: the AArch64 record-at-top prologue. `STP X29, X30, [SP, #-16]!`
+# saves the FP/LR frame record and allocates its 16 bytes, `MOV X29, SP` (an `add
+# x29, sp, #0`) pins the frame pointer at the record, and — when the frame needs
+# more — `SUB SP, SP, #subsize` allocates the locals / spills / callee-save / outgoing
+# region. callee-saved GP registers are then saved in STP/LDP pairs (a trailing odd
+# one with STUR) at x29-relative offsets just below the local frame. when `subsize`
+# is 0 (a leaf with no frame) the `SUB SP` and the callee-save stores are skipped, so
+# the output is byte-identical to Phase 2b's `stp ; mov x29, sp`.
+fun emit_prologue(st: *EncodeState, f: *mir.MirFunction, subsize: u32) {
+    emit_word(st, pack_ldstp(STP_PRE_X, 29, 30, ZR, (0::u32 - 2) & 0x7F));
     emit_word(st, pack_addsub_imm(ADDI_X, 29, ZR, 0, 0));
+    if (subsize > 0) { emit_sp_sub(st, subsize); }
     save_callee_gp(st, f, true);
 }
 
-# emit_epilogue: the standard AArch64 leaf epilogue — restore the callee-saved GP
-# registers, then `LDP X29, X30, [SP], #total` (reload the FP/LR frame record and
-# deallocate the whole frame). the RET that follows returns through X30.
-fun emit_epilogue(st: *EncodeState, f: *mir.MirFunction, total: u32) {
+# emit_epilogue: the AArch64 record-at-top epilogue. it restores the callee-saved GP
+# registers (x29-relative, mirroring the prologue), deallocates the frame with `MOV
+# SP, X29` (an `add sp, x29, #0`, which reverses any `SUB SP` regardless of size),
+# then reloads the record with `LDP X29, X30, [SP], #16`. the RET that follows
+# returns through X30. when `subsize` is 0 the `MOV SP, X29` is skipped, so the leaf
+# output is byte-identical to Phase 2b's `ldp ; ret`.
+fun emit_epilogue(st: *EncodeState, f: *mir.MirFunction, subsize: u32) {
     save_callee_gp(st, f, false);
-    val pos_off: u32 = (total / 8) & 0x7F;
-    emit_word(st, pack_ldstp(LDP_POST_X, 29, 30, ZR, pos_off));
+    if (subsize > 0) {
+        # mov sp, x29  (add sp, x29, #0)
+        emit_word(st, pack_addsub_imm(ADDI_X, ZR, 29, 0, 0));
+    }
+    emit_word(st, pack_ldstp(LDP_POST_X, 29, 30, ZR, 2));
 }
 
 # save_callee_gp: save (or restore) the callee-saved GP registers `callee_mask`
-# selects, in ascending register order, in STP pairs at ascending 16-aligned
-# offsets above the FP/LR frame record (`[sp, #16]`, `[sp, #32]`, …). a trailing
-# odd register is handled with a single STR/LDR. SP-relative and self-contained,
-# so it is correct regardless of where X29 points.
+# selects, in ascending register order, just below the local frame (`frame.size`).
+# they are addressed x29-relatively at descending negative offsets: each STP/LDP
+# pair occupies a 16-byte slot (the first at `[x29, #-(frame.size + 16)]`), and a
+# trailing odd register takes an 8-byte STUR/LDUR slot below the last pair. the
+# whole area sits within `frame_subsize`'s GP region, below the locals and above the
+# outgoing-argument region, so it overlaps neither.
 fun save_callee_gp(st: *EncodeState, f: *mir.MirFunction, store: bool) {
     var regs: [32]u32;
     var n: u32 = 0;
@@ -629,19 +1039,19 @@ fun save_callee_gp(st: *EncodeState, f: *mir.MirFunction, store: bool) {
         r = r + 1;
     }
 
-    var off: u32 = 16;
-    var i: u32 = 0;
-    for (i + 1 < n) {
-        val imm7: u32 = (off / 8) & 0x7F;
-        if (store) { emit_word(st, pack_ldstp(STP_OFF_X, regs[i], regs[i + 1], ZR, imm7)); }
-        or         { emit_word(st, pack_ldstp(LDP_OFF_X, regs[i], regs[i + 1], ZR, imm7)); }
-        off = off + 16;
-        i = i + 2;
+    val fs: i32 = f.frame.size::i32;
+    val num_pairs: u32 = n / 2;
+    var p: u32 = 0;
+    for (p < num_pairs) {
+        val base_off: i32 = 0 - (fs + 16 + (16 * p)::i32);
+        val imm7: u32 = (base_off / 8)::u32 & 0x7F;
+        if (store) { emit_word(st, pack_ldstp(STP_OFF_X, regs[2 * p], regs[2 * p + 1], 29, imm7)); }
+        or         { emit_word(st, pack_ldstp(LDP_OFF_X, regs[2 * p], regs[2 * p + 1], 29, imm7)); }
+        p = p + 1;
     }
-    if (i < n) {
-        val imm12: u32 = off / 8;
-        if (store) { emit_word(st, pack_ldst(STR_OFF_X, regs[i], ZR, imm12)); }
-        or         { emit_word(st, pack_ldst(LDR_OFF_X, regs[i], ZR, imm12)); }
+    if ((n & 1) == 1) {
+        val single_off: i32 = 0 - (fs + 8 + (16 * num_pairs)::i32);
+        emit_mem_access(st, regs[n - 1], 29, single_off::i64, 8, !store);
     }
 }
 
@@ -649,9 +1059,10 @@ fun save_callee_gp(st: *EncodeState, f: *mir.MirFunction, store: bool) {
 
 # encode_mir_instr: translate one post-regalloc MIR instruction into A64 bytes,
 # recording any intra-module branch fixup. the regalloc parallel-copy / liveness
-# pseudos emit nothing; the surviving comparison and conditional-branch sentinels
-# expand into their byte sequences; the float / conversion families, calls, inline
-# asm, and varargs are rejected loudly (a leaf integer function never reaches them).
+# pseudos emit nothing; the surviving comparison / conditional-branch / memory /
+# conversion opcodes expand into their byte sequences; the float, call, symbol-
+# relocation, inline-asm, and varargs families are rejected loudly (an in-scope
+# function never reaches them).
 fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) Result[bool, str] {
     val op: u16 = mi.opcode::u16;
 
@@ -672,7 +1083,24 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     if (is_mir_compare(mi.opcode)) { ret encode_compare(st, mi); }
     if (mi.opcode == mir.MIR_SEL_CBR) { ret encode_cbr(st, fn_base, mi); }
 
-    # deferred families: a leaf integer function never emits these, so they are
+    # the register-allocator's spill reload / store, inserted after instruction
+    # selection, carries the GENERIC MIR_MOV opcode (isel only rewrites the moves
+    # present before regalloc); route it to the same move encoder, which handles its
+    # frame-slot MEM operand.
+    if (mi.opcode == mir.MIR_MOV) { ret encode_mov(st, f, mi); }
+
+    # memory: alloca / gep address arithmetic, and non-symbol load / store.
+    if (mi.opcode == mir.MIR_ALLOCA || mi.opcode == mir.MIR_GEP) { ret encode_addr(st, f, mi); }
+    if (mi.opcode == mir.MIR_LOAD)  { ret encode_load(st, f, mi); }
+    if (mi.opcode == mir.MIR_STORE) { ret encode_store(st, f, mi); }
+
+    # integer width / representation conversions.
+    if (mi.opcode == mir.MIR_TRUNC || mi.opcode == mir.MIR_SEXT ||
+        mi.opcode == mir.MIR_ZEXT || mi.opcode == mir.MIR_BITCAST) {
+        ret encode_convert(st, mi);
+    }
+
+    # deferred families: an in-scope function never emits these, so they are
     # rejected loudly rather than mis-encoded.
     if (mi.opcode == mir.MIR_VA_FP_SAVE) {
         ret err[bool, str]("aarch64 varargs not implemented (Phase 4)");
@@ -680,17 +1108,18 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     if (mi.opcode == mir.MIR_FADD || mi.opcode == mir.MIR_FSUB ||
         mi.opcode == mir.MIR_FMUL || mi.opcode == mir.MIR_FDIV ||
         mi.opcode == mir.MIR_FCMP || mi.opcode == mir.MIR_FNEG) {
-        ret err[bool, str]("aarch64 floating-point ops not implemented (Phase 3)");
+        ret err[bool, str]("aarch64 floating-point ops not implemented (Phase 4)");
     }
-    if (mi.opcode == mir.MIR_TRUNC || mi.opcode == mir.MIR_SEXT ||
-        mi.opcode == mir.MIR_ZEXT || mi.opcode == mir.MIR_BITCAST ||
-        mi.opcode == mir.MIR_FP_TRUNC || mi.opcode == mir.MIR_FP_EXT ||
+    if (mi.opcode == mir.MIR_FP_TRUNC || mi.opcode == mir.MIR_FP_EXT ||
         mi.opcode == mir.MIR_FP_TO_SI || mi.opcode == mir.MIR_FP_TO_UI ||
         mi.opcode == mir.MIR_SI_TO_FP || mi.opcode == mir.MIR_UI_TO_FP) {
-        ret err[bool, str]("aarch64 conversions not implemented (Phase 3)");
+        ret err[bool, str]("aarch64 float conversions not implemented (Phase 4)");
     }
     if (mi.opcode == mir.MIR_CALL) {
-        ret err[bool, str]("aarch64 calls not implemented (Phase 3)");
+        ret err[bool, str]("aarch64 calls not implemented (Phase 3b)");
+    }
+    if (mi.opcode == mir.MIR_ASM) {
+        ret err[bool, str]("aarch64 inline asm not implemented (Phase 3c)");
     }
 
     # concrete A64 opcodes.
@@ -705,7 +1134,7 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     if (op == arm64.ASR::u16) { ret encode_shift(st, mi, arm64.ASR::u32); }
     if (op == arm64.NEG::u16) { ret encode_neg_mvn(st, mi, SUB_X, SUB_W); }
     if (op == arm64.MVN::u16) { ret encode_neg_mvn(st, mi, ORN_X, ORN_W); }
-    if (op == arm64.MOV::u16) { ret encode_mov(st, mi); }
+    if (op == arm64.MOV::u16) { ret encode_mov(st, f, mi); }
     if (op == arm64.B::u16)   { ret encode_branch(st, fn_base, mi); }
     if (op == arm64.RET::u16) { emit_word(st, RET_WORD); ret ok[bool, str](true); }
     if (op == arm64.BRK::u16) { emit_word(st, BRK_BASE); ret ok[bool, str](true); }
@@ -715,11 +1144,12 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
 }
 
 # encode_function_arm64: the per-function encode hook (pass 1). marks the function
-# entry symbol, emits the prologue, then each block — emitting the epilogue before
-# every RET — recording each block's `.text` offset for branch patching. extern /
-# body-less functions contribute no text. a frame beyond the leaf-supported shape
-# (callee-saved FP registers, or a frame larger than the pre-index STP range) is
-# rejected loudly rather than mis-encoded.
+# entry symbol, emits the record-at-top prologue, then each block — emitting the
+# epilogue before every RET — recording each block's `.text` offset for branch
+# patching. extern / body-less functions contribute no text. a frame beyond this
+# phase's reach (callee-saved FP registers, a `SUB SP` past the two-immediate range,
+# or GP callee-saves below the STP/LDP immediate reach) is rejected loudly rather
+# than mis-encoded.
 fun encode_function_arm64(st: *EncodeState, f: *mir.MirFunction) Result[bool, str] {
     val fn_base: u32 = st.buf.len::u32;
     if (f.block_count == 0) { ret ok[bool, str](true); }
@@ -728,14 +1158,21 @@ fun encode_function_arm64(st: *EncodeState, f: *mir.MirFunction) Result[bool, st
     if (is_err[bool, str](ms)) { ret ms; }
 
     if (f.callee_mask_fp != 0) {
-        ret err[bool, str]("aarch64 callee-saved FP registers not implemented (Phase 3)");
+        ret err[bool, str]("aarch64 callee-saved FP registers not implemented (Phase 4)");
     }
-    val total: u32 = frame_total(f);
-    if (total > MAX_PREINDEX_FRAME) {
-        ret err[bool, str]("aarch64 frame larger than the pre-index STP range not implemented (Phase 3)");
+    val subsize: u32 = frame_subsize(f);
+    if (subsize > MAX_FRAME_SUB) {
+        ret err[bool, str]("aarch64 frame larger than the SUB SP two-immediate range not implemented (Phase 3b)");
+    }
+    # the GP callee-save STP/LDP pairs address x29-relatively below `frame.size`; a
+    # frame whose locals + GP-save area exceed the scaled imm7 reach needs Phase 3b's
+    # scratch-base addressing, so reject it rather than truncate the STP immediate.
+    val gp_bytes: u32 = popcount32(f.callee_mask) * 8;
+    if (gp_bytes != 0 && f.frame.size + gp_bytes > MAX_CALLEE_SAVE_REACH) {
+        ret err[bool, str]("aarch64 callee-save area beyond the STP/LDP immediate reach not implemented (Phase 3b)");
     }
 
-    emit_prologue(st, f, total);
+    emit_prologue(st, f, subsize);
 
     var bi: u32 = 0;
     for (bi < f.block_count) {
@@ -747,7 +1184,7 @@ fun encode_function_arm64(st: *EncodeState, f: *mir.MirFunction) Result[bool, st
         for (ii < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
             if (mi.opcode::u16 == arm64.RET::u16) {
-                emit_epilogue(st, f, total);
+                emit_epilogue(st, f, subsize);
             }
             val ei: Result[bool, str] = encode_mir_instr(st, f, fn_base, mi);
             if (is_err[bool, str](ei)) { ret ei; }
@@ -989,57 +1426,303 @@ test "arm64.encode: RET / BRK / NOP / B base match llvm-mc" {
     ret bad;
 }
 
-test "arm64.encode: prologue STP/MOV and epilogue LDP/RET match llvm-mc" {
+# the leaf (no-frame) prologue / epilogue must stay byte-identical to Phase 2b: a
+# zero `frame_subsize` skips the `SUB SP` and the `MOV SP, X29`, leaving exactly the
+# `stp ; mov x29, sp` prologue and `ldp ; ret`-shaped epilogue.
+test "arm64.encode: leaf prologue STP/MOV and epilogue LDP byte-identical to Phase 2b" {
     var bad: i32 = 0;
     var st: EncodeState;
     var alloc: Allocator;
     tbuf(?st, ?alloc);
 
-    # a leaf function: no callee saves, no locals, no outgoing -> total = 16.
     var f: mir.MirFunction;
     f.callee_mask = 0;
     f.callee_mask_fp = 0;
     f.frame.size = 0;
     f.frame.outgoing_size = 0;
-    val total: u32 = frame_total(?f);
-    if (total != 16) { bad = 1; }
+    val subsize: u32 = frame_subsize(?f);
+    if (subsize != 0) { bad = 1; }
 
-    emit_prologue(?st, ?f, total);
-    # stp x29, x30, [sp, #-16]! = 0xa9bf7bfd ; mov x29, sp = 0x910003fd
-    if (read_word(?st.buf, 0) != 0xA9BF7BFD) { bad = 1; }
-    if (read_word(?st.buf, 4) != 0x910003FD) { bad = 1; }
+    emit_prologue(?st, ?f, subsize);
+    # stp x29, x30, [sp, #-16]! = 0xa9bf7bfd ; mov x29, sp = 0x910003fd  (no sub sp)
+    if (st.buf.len != 8) { bad = 1; }
+    or {
+        if (read_word(?st.buf, 0) != 0xA9BF7BFD) { bad = 1; }
+        if (read_word(?st.buf, 4) != 0x910003FD) { bad = 1; }
+    }
 
-    emit_epilogue(?st, ?f, total);
-    # ldp x29, x30, [sp], #16 = 0xa8c17bfd
-    if (read_word(?st.buf, 8) != 0xA8C17BFD) { bad = 1; }
-
-    # a 32-byte frame's pre/post-index immediates: stp ...[sp,#-32]! = 0xa9be7bfd,
-    # ldp ...[sp],#32 = 0xa8c27bfd.
-    st.buf.len = 0;
-    var f2: mir.MirFunction;
-    f2.callee_mask = 0;
-    f2.callee_mask_fp = 0;
-    f2.frame.size = 8;
-    f2.frame.outgoing_size = 0;
-    val total2: u32 = frame_total(?f2);
-    if (total2 != 32) { bad = 1; }
-    emit_prologue(?st, ?f2, total2);
-    if (read_word(?st.buf, 0) != 0xA9BE7BFD) { bad = 1; }
-    emit_epilogue(?st, ?f2, total2);
-    if (read_word(?st.buf, 8) != 0xA8C27BFD) { bad = 1; }
+    emit_epilogue(?st, ?f, subsize);
+    # ldp x29, x30, [sp], #16 = 0xa8c17bfd  (no mov sp, x29)
+    if (st.buf.len != 12) { bad = 1; }
+    or {
+        if (read_word(?st.buf, 8) != 0xA8C17BFD) { bad = 1; }
+    }
 
     buf_dnit(?st.buf);
     ret bad;
 }
 
-test "arm64.encode: callee-saved STP/STR pair spills match llvm-mc" {
+# a non-leaf frame: the record-at-top prologue is `stp ; mov x29, sp ; sub sp, #N`
+# and the epilogue `mov sp, x29 ; ldp`, with GP callee-saves in STP/LDP pairs (a
+# trailing odd one with STUR/LDUR) at x29-relative offsets just below frame.size.
+test "arm64.encode: non-leaf prologue/epilogue + callee-save STP/LDP match llvm-mc" {
     var bad: i32 = 0;
-    # stp x19,x20,[sp,#16] = 0xa90153f3 ; ldp x19,x20,[sp,#16] = 0xa94153f3
-    if (pack_ldstp(STP_OFF_X, 19, 20, ZR, 2) != 0xA90153F3) { bad = 1; }
-    if (pack_ldstp(LDP_OFF_X, 19, 20, ZR, 2) != 0xA94153F3) { bad = 1; }
-    # str x19,[sp,#16] = 0xf9000bf3 ; ldr x19,[sp,#16] = 0xf9400bf3
-    if (pack_ldst(STR_OFF_X, 19, ZR, 2) != 0xF9000BF3) { bad = 1; }
-    if (pack_ldst(LDR_OFF_X, 19, ZR, 2) != 0xF9400BF3) { bad = 1; }
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # no callee saves, frame.size 16 -> subsize 16.
+    var f: mir.MirFunction;
+    f.callee_mask = 0;
+    f.callee_mask_fp = 0;
+    f.frame.size = 16;
+    f.frame.outgoing_size = 0;
+    if (frame_subsize(?f) != 16) { bad = 1; }
+    emit_prologue(?st, ?f, 16);
+    # stp x29,x30,[sp,#-16]! ; mov x29,sp ; sub sp,sp,#16
+    if (read_word(?st.buf, 0) != 0xA9BF7BFD) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x910003FD) { bad = 1; }
+    if (read_word(?st.buf, 8) != 0xD10043FF) { bad = 1; }
+    emit_epilogue(?st, ?f, 16);
+    # mov sp,x29 ; ldp x29,x30,[sp],#16
+    if (read_word(?st.buf, 12) != 0x910003BF) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0xA8C17BFD) { bad = 1; }
+
+    # three GP callee-saves (x19,x20,x21), frame.size 16 -> subsize align16(24+16)=48.
+    st.buf.len = 0;
+    var g: mir.MirFunction;
+    g.callee_mask = (1::u32 << 19) | (1::u32 << 20) | (1::u32 << 21);
+    g.callee_mask_fp = 0;
+    g.frame.size = 16;
+    g.frame.outgoing_size = 0;
+    if (frame_subsize(?g) != 48) { bad = 1; }
+    emit_prologue(?st, ?g, 48);
+    # stp x29,x30,[sp,#-16]! ; mov x29,sp ; sub sp,sp,#48
+    if (read_word(?st.buf, 0)  != 0xA9BF7BFD) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0x910003FD) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0xD100C3FF) { bad = 1; }
+    # stp x19,x20,[x29,#-32] ; stur x21,[x29,#-40]
+    if (read_word(?st.buf, 12) != 0xA93E53B3) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0xF81D83B5) { bad = 1; }
+    emit_epilogue(?st, ?g, 48);
+    # ldp x19,x20,[x29,#-32] ; ldur x21,[x29,#-40] ; mov sp,x29 ; ldp x29,x30,[sp],#16
+    if (read_word(?st.buf, 20) != 0xA97E53B3) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0xF85D83B5) { bad = 1; }
+    if (read_word(?st.buf, 28) != 0x910003BF) { bad = 1; }
+    if (read_word(?st.buf, 32) != 0xA8C17BFD) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the GP callee-save pair packers, asserted directly against llvm-mc for the
+# x29-relative negative-offset forms the prologue/epilogue emit.
+test "arm64.encode: callee-save STP/LDP/STUR pair words match llvm-mc" {
+    var bad: i32 = 0;
+    # stp x19,x20,[x29,#-16] = 0xa93f53b3 ; ldp = 0xa97f53b3 (imm7 = -2 & 0x7f)
+    if (pack_ldstp(STP_OFF_X, 19, 20, 29, (0::u32 - 2) & 0x7F) != 0xA93F53B3) { bad = 1; }
+    if (pack_ldstp(LDP_OFF_X, 19, 20, 29, (0::u32 - 2) & 0x7F) != 0xA97F53B3) { bad = 1; }
+    # stp x21,x22,[x29,#-32] = 0xa93e5bb5 (imm7 = -4 & 0x7f)
+    if (pack_ldstp(STP_OFF_X, 21, 22, 29, (0::u32 - 4) & 0x7F) != 0xA93E5BB5) { bad = 1; }
+    # stur/ldur x21,[x29,#-40] = 0xf81d83b5 / 0xf85d83b5 (imm9 = -40 & 0x1ff)
+    if (pack_ldur(STUR_X, 21, 29, (0::u32 - 40) & 0x1FF) != 0xF81D83B5) { bad = 1; }
+    if (pack_ldur(LDUR_X, 21, 29, (0::u32 - 40) & 0x1FF) != 0xF85D83B5) { bad = 1; }
+    ret bad;
+}
+
+# frame-slot load/store, the spill round-trip: a frame slot at a negative offset is
+# addressed `[x29 + slot.offset]` (LDUR/STUR for the negative displacement).
+test "arm64.encode: frame-slot LDR/STR and spill reload/store match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # one spill slot for value id 100 at offset -8.
+    var slots: [1]mir.MirSlot;
+    slots[0].value  = 100;
+    slots[0].kind   = mir.SLOT_SPILL;
+    slots[0].offset = -8;
+    slots[0].size   = 8;
+    slots[0].align  = 8;
+    var f: mir.MirFunction;
+    f.frame.slots      = ?slots[0];
+    f.frame.slot_count = 1;
+
+    # MIR_STORE [slot] <- x9  -> stur x9, [x29, #-8] = 0xf81f83a9
+    var sst: mir.MirInstr;
+    var sops: [2]mir.MirOperand;
+    sops[0] = mir.op_mem_slot(100, 0);
+    sops[1] = mir.op_preg(9);
+    sst.operands = ?sops[0]; sst.operand_count = 2; sst.width = 8; sst.src_width = 8;
+    encode_store(?st, ?f, ?sst);
+    if (read_word(?st.buf, 0) != 0xF81F83A9) { bad = 1; }
+
+    # MIR_LOAD x9 <- [slot]  -> ldur x9, [x29, #-8] = 0xf85f83a9
+    var lst: mir.MirInstr;
+    var lops: [2]mir.MirOperand;
+    lops[0] = mir.op_preg(9);
+    lops[1] = mir.op_mem_slot(100, 0);
+    lst.operands = ?lops[0]; lst.operand_count = 2; lst.width = 8; lst.src_width = 8;
+    encode_load(?st, ?f, ?lst);
+    if (read_word(?st.buf, 4) != 0xF85F83A9) { bad = 1; }
+
+    # the spill MIR_MOV reload (reg <- [slot]) / store ([slot] <- reg) round-trip
+    # through the same LDUR/STUR forms.
+    var mvl: mir.MirInstr;
+    mvl.operands = ?lops[0]; mvl.operand_count = 2; mvl.width = 8; mvl.src_width = 8;
+    encode_mov(?st, ?f, ?mvl);
+    if (read_word(?st.buf, 8) != 0xF85F83A9) { bad = 1; }
+    var mvs: mir.MirInstr;
+    mvs.operands = ?sops[0]; mvs.operand_count = 2; mvs.width = 8; mvs.src_width = 8;
+    encode_mov(?st, ?f, ?mvs);
+    if (read_word(?st.buf, 12) != 0xF81F83A9) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the three LDR/STR addressing forms: scaled unsigned imm12 (positive, aligned),
+# unscaled signed imm9 (negative / unaligned), and the register-offset fallback for
+# an out-of-range displacement (materialized into IP0).
+test "arm64.encode: LDR/STR addressing-mode legalization matches llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # scaled imm12: ldr x0,[x1,#8] = 0xf9400420 ; str x0,[x1,#8] = 0xf9000420
+    emit_mem_access(?st, 0, 1, 8, 8, true);
+    if (read_word(?st.buf, 0) != 0xF9400420) { bad = 1; }
+    emit_mem_access(?st, 0, 1, 8, 8, false);
+    if (read_word(?st.buf, 4) != 0xF9000420) { bad = 1; }
+    # scaled imm12 max: ldr x0,[x1,#32760] = 0xf97ffc20
+    emit_mem_access(?st, 0, 1, 32760, 8, true);
+    if (read_word(?st.buf, 8) != 0xF97FFC20) { bad = 1; }
+    # unscaled imm9: ldur x0,[x1,#-8] = 0xf85f8020 ; stur x0,[x1,#-8] = 0xf81f8020
+    emit_mem_access(?st, 0, 1, -8, 8, true);
+    if (read_word(?st.buf, 12) != 0xF85F8020) { bad = 1; }
+    emit_mem_access(?st, 0, 1, -8, 8, false);
+    if (read_word(?st.buf, 16) != 0xF81F8020) { bad = 1; }
+    # register-offset fallback: off 32768 is out of both imm ranges -> movz x16,#0x8000 ;
+    # ldr x0,[x1,x16] = 0xd2900010 ; 0xf8706820
+    emit_mem_access(?st, 0, 1, 32768, 8, true);
+    if (read_word(?st.buf, 20) != 0xD2900010) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0xF8706820) { bad = 1; }
+    # the sub-word zero-extending forms (byte / halfword / word) and a store reg form.
+    emit_mem_access(?st, 0, 1, 1, 1, true);   # ldrb w0,[x1,#1] = 0x39400420
+    if (read_word(?st.buf, 28) != 0x39400420) { bad = 1; }
+    emit_mem_access(?st, 0, 1, 2, 2, true);   # ldrh w0,[x1,#2] = 0x79400420
+    if (read_word(?st.buf, 32) != 0x79400420) { bad = 1; }
+    emit_mem_access(?st, 0, 1, 4, 4, true);   # ldr  w0,[x1,#4] = 0xb9400420
+    if (read_word(?st.buf, 36) != 0xB9400420) { bad = 1; }
+    emit_mem_access(?st, 0, 1, 1, 1, false);  # strb w0,[x1,#1] = 0x39000420
+    if (read_word(?st.buf, 40) != 0x39000420) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# GEP / ALLOCA address arithmetic: a frame-slot ALLOCA address folds the slot offset
+# into a SUB immediate; a constant displacement into ADD/SUB; a scaled runtime index
+# into `add Rd, base, index, lsl #log2(scale)`.
+test "arm64.encode: GEP/ALLOCA address arithmetic matches llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # alloca slot at -16: add x0 <- x29 + (-16) = sub x0,x29,#16 = 0xd10043a0
+    var slots: [1]mir.MirSlot;
+    slots[0].value  = 100;
+    slots[0].kind   = mir.SLOT_ALLOCA;
+    slots[0].offset = -16;
+    slots[0].size   = 16;
+    slots[0].align  = 16;
+    var f: mir.MirFunction;
+    f.frame.slots      = ?slots[0];
+    f.frame.slot_count = 1;
+
+    var al: mir.MirInstr;
+    var aops: [2]mir.MirOperand;
+    aops[0] = mir.op_preg(0);
+    aops[1] = mir.op_mem_slot(100, 0);
+    al.opcode = mir.MIR_ALLOCA; al.operands = ?aops[0]; al.operand_count = 2;
+    al.width = 8; al.src_width = 8;
+    encode_addr(?st, ?f, ?al);
+    if (read_word(?st.buf, 0) != 0xD10043A0) { bad = 1; }
+
+    # gep [x29 + 16] (a physical-register base + constant disp): add x0,x29,#16 = 0x910043a0
+    var g1: mir.MirInstr;
+    var g1ops: [2]mir.MirOperand;
+    g1ops[0] = mir.op_preg(0);
+    g1ops[1] = mir.op_mem_preg(29, 16);
+    g1.opcode = mir.MIR_GEP; g1.operands = ?g1ops[0]; g1.operand_count = 2;
+    g1.width = 8; g1.src_width = 8;
+    encode_addr(?st, ?f, ?g1);
+    if (read_word(?st.buf, 4) != 0x910043A0) { bad = 1; }
+
+    # gep [x1 + x2*8]: add x0,x1,x2,lsl#3 = 0x8b020c20
+    var g2: mir.MirInstr;
+    var g2ops: [2]mir.MirOperand;
+    g2ops[0] = mir.op_preg(0);
+    var m2: mir.MirOperand = mir.op_mem_preg(1, 0);
+    m2.index = 2; m2.scale = 8; m2.index_is_preg = true;
+    g2ops[1] = m2;
+    g2.opcode = mir.MIR_GEP; g2.operands = ?g2ops[0]; g2.operand_count = 2;
+    g2.width = 8; g2.src_width = 8;
+    encode_addr(?st, ?f, ?g2);
+    if (read_word(?st.buf, 8) != 0x8B020C20) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the integer conversions: TRUNC (a width-sized MOV), SEXT (SXTB/SXTH/SXTW), ZEXT
+# (UXTB/UXTH or the 32->64 MOV), and a GP BITCAST (a same-width MOV).
+test "arm64.encode: integer conversions (SXT/UXT/MOV) match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # operands [x0, w1] for every conversion.
+    var mi: mir.MirInstr;
+    var ops: [2]mir.MirOperand;
+    ops[0] = mir.op_preg(0);
+    ops[1] = mir.op_preg(1);
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # sxtb x0,w1 = 0x93401c20 (SEXT, dst 8, src 1)
+    mi.opcode = mir.MIR_SEXT; mi.width = 8; mi.src_width = 1;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 0) != 0x93401C20) { bad = 1; }
+    # sxth x0,w1 = 0x93403c20 (src 2)
+    mi.src_width = 2; encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 4) != 0x93403C20) { bad = 1; }
+    # sxtw x0,w1 = 0x93407c20 (src 4)
+    mi.src_width = 4; encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 8) != 0x93407C20) { bad = 1; }
+    # uxtb w0,w1 = 0x53001c20 (ZEXT, dst 4, src 1)
+    mi.opcode = mir.MIR_ZEXT; mi.width = 4; mi.src_width = 1;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 12) != 0x53001C20) { bad = 1; }
+    # uxth w0,w1 = 0x53003c20 (src 2)
+    mi.src_width = 2; encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 16) != 0x53003C20) { bad = 1; }
+    # zext 32->64 = mov w0,w1 = 0x2a0103e0 (src 4)
+    mi.width = 8; mi.src_width = 4; encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 20) != 0x2A0103E0) { bad = 1; }
+    # trunc i64->i32 = mov w0,w1 = 0x2a0103e0
+    mi.opcode = mir.MIR_TRUNC; mi.width = 4; mi.src_width = 8;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 24) != 0x2A0103E0) { bad = 1; }
+    # bitcast i64<->i64 = mov x0,x1 = 0xaa0103e0
+    mi.opcode = mir.MIR_BITCAST; mi.width = 8; mi.src_width = 8;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 28) != 0xAA0103E0) { bad = 1; }
+
+    buf_dnit(?st.buf);
     ret bad;
 }
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1068,15 +1068,22 @@ fun encode_addr(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result
 # (the allocator reloads any spilled operand before the instruction).
 fun encode_convert(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
     if (mi.operand_count < 2) { ret err[bool, str]("encode: conversion missing operands"); }
+    val dw: u8 = mi.width;
+    val sw: u8 = mi.src_width;
+
     val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
     if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
     val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
-    val rsr: Result[i32, str] = req_gpr(?mi.operands[1]);
+    # the source may be a constant: a same-width integer BITCAST of a literal
+    # (`5::u64`, `~(0::usize)`) reaches here as a MIR_OP_IMM — constfold folds the
+    # width-changing TRUNC/SEXT/ZEXT of a constant but not the same-width BITCAST.
+    # resolve_source materializes it into the GP scratch (mirroring the ALU paths);
+    # the x86-64 backend selects BITCAST to a MOV, which absorbs the immediate the
+    # same way. sized at the SOURCE width — BITCAST is same-width, and a register
+    # source resolves through unchanged.
+    val rsr: Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH0, is64(sw));
     if (is_err[i32, str](rsr)) { ret err[bool, str](unwrap_err[i32, str](rsr)); }
     val rs: u32 = unwrap_ok[i32, str](rsr)::u32;
-
-    val dw: u8 = mi.width;
-    val sw: u8 = mi.src_width;
 
     if (mi.opcode == mir.MIR_TRUNC) {
         emit_word(st, pack_alu3(ORR_W, rd, ZR, rs));
@@ -4225,6 +4232,20 @@ test "arm64.encode: integer conversions (SXT/UXT/MOV) match llvm-mc" {
     mi.opcode = mir.MIR_BITCAST; mi.width = 8; mi.src_width = 8;
     encode_convert(?st, ?mi);
     if (read_word(?st.buf, 28) != 0xAA0103E0) { bad = 1; }
+
+    # BITCAST of an IMMEDIATE source (the `5::u64` / `~(0::usize)` idiom): a same-width
+    # integer cast of a literal reaches the encoder as a MIR_OP_IMM (constfold folds
+    # TRUNC/SEXT/ZEXT of a constant but not BITCAST), so the constant is materialized
+    # into the GP scratch (IP0) then moved to the destination.
+    ops[1] = mir.op_imm(5);
+    mi.opcode = mir.MIR_BITCAST; mi.width = 8; mi.src_width = 8;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 32) != 0xD28000B0) { bad = 1; }   # movz x16,#5
+    if (read_word(?st.buf, 36) != 0xAA1003E0) { bad = 1; }   # mov  x0,x16
+    mi.width = 4; mi.src_width = 4;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 40) != 0x528000B0) { bad = 1; }   # movz w16,#5
+    if (read_word(?st.buf, 44) != 0x2A1003E0) { bad = 1; }   # mov  w0,w16
 
     buf_dnit(?st.buf);
     ret bad;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -2,22 +2,67 @@
 #
 # This is the AArch64 implementation of the ISA vtable's `encode` operation,
 # reached only through `tgt.arch.encode` by the shared `be.codegen.encode`
-# dispatcher. Byte encoding is not yet implemented: `encode_arm64` is a total
-# function that fails loudly with an "not implemented" error. The encoder that
-# turns the resolved `isa.Inst` stream into AArch64 bytes (with prologue/epilogue
-# emission, branch fixups, and relocation offsets) is filled in a later phase; the
-# four-file ISA shape mirrors the x86-64 backend.
+# dispatcher. It turns the resolved (post-isel, post-regalloc, post-frame)
+# `MirModule` into fixed-width little-endian A64 `.text` bytes, driving the
+# shared two-pass `enc.encode_driver` with two per-ISA hooks: `encode_function_arm64`
+# (prologue / instruction stream / epilogue, recording symbol marks and intra-
+# module branch fixups) and `patch_branch_arm64` (the imm26 / imm19 bitfield insert
+# in pass 2). The ISA-general driving — state lifetime, the function loop, pass-2
+# block resolution, text right-sizing, and `enc.EncoderOutput` assembly — lives in
+# the shared `enc` module; this backend supplies only the A64 bitfield packers,
+# prologue/epilogue emission, and branch patching.
+#
+# SCOPE (Phase 2b — leaf integer). Every modeled form is byte-exact against
+# llvm-mc: the three-address integer ALU (ADD/SUB/MUL/AND/ORR/EOR), the shifts
+# (register LSLV/LSRV/ASRV and immediate UBFM/SBFM aliases), NEG/MVN/MOV, the
+# MOVZ/MOVK immediate materialization, RET, the STP/MOV prologue and LDP/RET
+# epilogue, CMP (SUBS XZR) + CSET, the unconditional branch B, the conditional
+# branch (CBNZ + B), and the BRK unreachable trap. The contract gaps DEFERRED to a
+# later phase (a leaf integer function never reaches them, so they fail loudly
+# rather than emit wrong bytes): frame-slot / spill memory operands, callee-saved
+# FP registers, frames larger than the pre-index STP range, inline asm, calls and
+# their relocations, and the float / conversion families.
 
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
 use std.types.string.str;
 
 use std.types.result.Result;
+use std.types.result.ok;
 use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
 
 use std.allocator.Allocator;
+use page: std.allocator.page;
 
+use intern: mach.lang.intern;
+use isa:    mach.lang.target.isa;
+use arm64:  mach.lang.target.isa.arm64;
 use target: mach.lang.target.resolved;
+use of:     mach.lang.target.of;
 use mir:    mach.lang.be.codegen.mir;
 use enc:    mach.lang.be.codegen.encode;
+
+# the ISA-agnostic two-pass driver, its state, byte sink, and array helpers live
+# in the shared `enc` module; this backend consumes them by name and supplies the
+# two `enc.EncodeHooks` — `encode_function_arm64` and `patch_branch_arm64`.
+use mach.lang.be.codegen.encode.ByteBuf;
+use mach.lang.be.codegen.encode.EncodeState;
+use mach.lang.be.codegen.encode.BranchFixup;
+use mach.lang.be.codegen.encode.EncodeHooks;
+use mach.lang.be.codegen.encode.buf_init;
+use mach.lang.be.codegen.encode.buf_dnit;
+use mach.lang.be.codegen.encode.emit_u32;
+use mach.lang.be.codegen.encode.classify_refs;
+use mach.lang.be.codegen.encode.push_symbol;
+use mach.lang.be.codegen.encode.push_reloc;
+use mach.lang.be.codegen.encode.push_fixup;
+use mach.lang.be.codegen.encode.push_block;
+use mach.lang.be.codegen.encode.encode_driver;
 
 # EncodeFn: the concrete signature the erased `isa.IsaVTable.encode` pointer is
 # cast back to, matching the shared `be.codegen.encode.EncodeFn`. the vtable stores
@@ -30,18 +75,1024 @@ use enc:    mach.lang.be.codegen.encode;
 # ret:   the populated enc.EncoderOutput, or an error string
 pub def EncodeFn: fun(*Allocator, *target.Target, *mir.MirModule) Result[enc.EncoderOutput, str];
 
-# encode_arm64: encode a fully-resolved MIR module into AArch64 `.text` bytes,
-# symbol marks, and pending relocations.
-#
-# the AArch64 implementation behind the ISA vtable's `encode` slot; the shared
-# `be.codegen.encode.run` dispatcher reaches it only through `tgt.arch.encode`.
-# byte encoding is not yet implemented, so this fails loudly — a total function
-# that signals the unimplemented backend rather than emitting wrong bytes.
+# ---- A64 base words (Rd/Rn/Rm fields zeroed) ----
+# every base is the instruction word with its register and immediate fields clear;
+# a packer ORs the encoded fields in. each was confirmed byte-exact against
+# `llvm-mc -triple=aarch64 --show-encoding`. the `_X` forms set the 64-bit `sf`
+# bit (bit 31); the `_W` forms are the 32-bit variants.
+
+# ADD (shifted register), sub, and the logical / multiply three-address forms.
+val ADD_X: u32 = 0x8B000000; val ADD_W: u32 = 0x0B000000;
+val SUB_X: u32 = 0xCB000000; val SUB_W: u32 = 0x4B000000;
+val AND_X: u32 = 0x8A000000; val AND_W: u32 = 0x0A000000;
+val ORR_X: u32 = 0xAA000000; val ORR_W: u32 = 0x2A000000;
+val EOR_X: u32 = 0xCA000000; val EOR_W: u32 = 0x4A000000;
+# ORN (the MVN alias) sets the logical N bit (bit 21) of the ORR encoding.
+val ORN_X: u32 = 0xAA200000; val ORN_W: u32 = 0x2A200000;
+# MUL is MADD Rd,Rn,Rm,XZR — the base bakes the XZR accumulator (Ra=31 at [14:10]).
+val MUL_X: u32 = 0x9B007C00; val MUL_W: u32 = 0x1B007C00;
+# the register-variable shifts (LSLV / LSRV / ASRV).
+val LSLV_X: u32 = 0x9AC02000; val LSLV_W: u32 = 0x1AC02000;
+val LSRV_X: u32 = 0x9AC02400; val LSRV_W: u32 = 0x1AC02400;
+val ASRV_X: u32 = 0x9AC02800; val ASRV_W: u32 = 0x1AC02800;
+# ADD / SUB immediate (imm12, optional left-shift by 12 via the `sh` bit).
+val ADDI_X: u32 = 0x91000000; val ADDI_W: u32 = 0x11000000;
+val SUBI_X: u32 = 0xD1000000; val SUBI_W: u32 = 0x51000000;
+# the bitfield-move bases the immediate shifts alias (UBFM for LSL/LSR, SBFM for ASR).
+val UBFM_X: u32 = 0xD3400000; val UBFM_W: u32 = 0x53000000;
+val SBFM_X: u32 = 0x93400000; val SBFM_W: u32 = 0x13000000;
+# move-wide (MOVZ keeps, MOVK inserts) with a 16-bit immediate and an `hw` shift.
+val MOVZ_X: u32 = 0xD2800000; val MOVZ_W: u32 = 0x52800000;
+val MOVK_X: u32 = 0xF2800000; val MOVK_W: u32 = 0x72800000;
+# SUBS XZR (the CMP alias), register and immediate forms.
+val SUBS_REG_X: u32 = 0xEB000000; val SUBS_REG_W: u32 = 0x6B000000;
+val SUBS_IMM_X: u32 = 0xF1000000; val SUBS_IMM_W: u32 = 0x71000000;
+# CSINC Rd,XZR,XZR (the CSET alias): the base bakes the XZR sources and op2 bit.
+val CSINC_X: u32 = 0x9A800400; val CSINC_W: u32 = 0x1A800400;
+# STP pre-index / LDP post-index (the FP/LR frame record) and the signed-offset
+# pair / single forms (callee-saved register spills), all 64-bit.
+val STP_PRE_X:  u32 = 0xA9800000;
+val LDP_POST_X: u32 = 0xA8C00000;
+val STP_OFF_X:  u32 = 0xA9000000;
+val LDP_OFF_X:  u32 = 0xA9400000;
+val STR_OFF_X:  u32 = 0xF9000000;
+val LDR_OFF_X:  u32 = 0xF9400000;
+# the unconditional branch (imm26) and the conditional / compare-branch family (imm19).
+val B_BASE:    u32 = 0x14000000;
+val BCOND:     u32 = 0x54000000;
+val CBNZ_X:    u32 = 0xB5000000; val CBNZ_W: u32 = 0x35000000;
+# RET x30, BRK #0, NOP.
+val RET_WORD:  u32 = 0xD65F03C0;
+val BRK_BASE:  u32 = 0xD4200000;
+val NOP_WORD:  u32 = 0xD503201F;
+
+# the zero register / stack pointer encode as register 31 in the relevant fields.
+val ZR: u32 = 31;
+# the intra-procedure-call scratch registers (IP0 = X16, IP1 = X17) the encoder
+# claims for immediate materialization; both are caller-saved and never hold a live
+# value across the point the encoder uses them.
+val SCRATCH0: u32 = 16;
+val SCRATCH1: u32 = 17;
+
+# the largest frame the pre-index STP can allocate in one instruction: the scaled
+# 7-bit signed immediate spans -64..63 eightbytes, so -512..504 bytes; the negative
+# pre-index offset is `-total`, bounded below by -512, i.e. total <= 504.
+val MAX_PREINDEX_FRAME: u32 = 504;
+
+# A64 condition codes (bits[3:0] of a conditional form). the CSET / B.cond
+# encodings read these directly; `pack_cset` writes the inverted condition.
+val CC_EQ: u32 = 0;
+val CC_NE: u32 = 1;
+val CC_CC: u32 = 3;
+val CC_LS: u32 = 9;
+val CC_LT: u32 = 11;
+val CC_LE: u32 = 13;
+
+# ---- bitfield packers (pure: each returns one A64 word) ----
+
+# pack_alu3: a three-register data-processing word — Rm[20:16], Rn[9:5], Rd[4:0]
+# OR-ed into `base`. used for the register ALU forms (ADD/SUB/AND/ORR/EOR), the
+# register shifts (LSLV/LSRV/ASRV), MUL (whose base bakes the XZR accumulator),
+# and the NEG/MVN aliases (whose Rn is XZR).
+fun pack_alu3(base: u32, rd: u32, rn: u32, rm: u32) u32 {
+    ret base | ((rm & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rd & 0x1F);
+}
+
+# pack_addsub_imm: an ADD/SUB immediate word — `sh`[22], imm12[21:10], Rn[9:5],
+# Rd[4:0]. `sh` selects the optional left-shift-by-12 of the 12-bit immediate.
+fun pack_addsub_imm(base: u32, rd: u32, rn: u32, imm12: u32, sh: u32) u32 {
+    ret base | ((sh & 0x1) << 22) | ((imm12 & 0xFFF) << 10) | ((rn & 0x1F) << 5) | (rd & 0x1F);
+}
+
+# pack_bitfield: a bitfield-move word — immr[21:16], imms[15:10], Rn[9:5], Rd[4:0].
+# used for the immediate shift aliases (UBFM for LSL/LSR, SBFM for ASR).
+fun pack_bitfield(base: u32, rd: u32, rn: u32, immr: u32, imms: u32) u32 {
+    ret base | ((immr & 0x3F) << 16) | ((imms & 0x3F) << 10) | ((rn & 0x1F) << 5) | (rd & 0x1F);
+}
+
+# pack_movewide: a move-wide word — hw[22:21], imm16[20:5], Rd[4:0]. `hw` is the
+# 16-bit shift group (0..3 selecting lsl #0/16/32/48).
+fun pack_movewide(base: u32, rd: u32, hw: u32, imm16: u32) u32 {
+    ret base | ((hw & 0x3) << 21) | ((imm16 & 0xFFFF) << 5) | (rd & 0x1F);
+}
+
+# pack_cmp_reg: a SUBS XZR, Rn, Rm word (the register CMP) — Rm[20:16], Rn[9:5],
+# Rd = XZR.
+fun pack_cmp_reg(base: u32, rn: u32, rm: u32) u32 {
+    ret base | ((rm & 0x1F) << 16) | ((rn & 0x1F) << 5) | ZR;
+}
+
+# pack_cmp_imm: a SUBS XZR, Rn, #imm12 word (the immediate CMP) — imm12[21:10],
+# Rn[9:5], Rd = XZR.
+fun pack_cmp_imm(base: u32, rn: u32, imm12: u32) u32 {
+    ret base | ((imm12 & 0xFFF) << 10) | ((rn & 0x1F) << 5) | ZR;
+}
+
+# pack_cset: a CSINC Rd, XZR, XZR, invert(cc) word — the CSET alias. `cc` is the
+# condition the boolean captures; CSET encodes its inverse (`cc ^ 1`) in the
+# cond[15:12] field, with both sources held at XZR.
+fun pack_cset(base: u32, rd: u32, cc: u32) u32 {
+    val inv: u32 = cc ^ 1;
+    ret base | (ZR << 16) | ((inv & 0xF) << 12) | (ZR << 5) | (rd & 0x1F);
+}
+
+# pack_ldstp: a load/store-pair word — imm7[21:15] (the scaled, signed offset),
+# Rt2[14:10], Rn[9:5], Rt[4:0]. used for the FP/LR frame record (pre/post-index
+# bases) and callee-saved register pairs (signed-offset bases).
+fun pack_ldstp(base: u32, rt: u32, rt2: u32, rn: u32, imm7: u32) u32 {
+    ret base | ((imm7 & 0x7F) << 15) | ((rt2 & 0x1F) << 10) | ((rn & 0x1F) << 5) | (rt & 0x1F);
+}
+
+# pack_ldst: a scaled unsigned-offset load/store word — imm12[21:10] (the byte
+# offset divided by the access size), Rn[9:5], Rt[4:0]. used to spill a trailing
+# odd callee-saved register the pair forms cannot cover.
+fun pack_ldst(base: u32, rt: u32, rn: u32, imm12: u32) u32 {
+    ret base | ((imm12 & 0xFFF) << 10) | ((rn & 0x1F) << 5) | (rt & 0x1F);
+}
+
+# pack_cbnz: a compare-and-branch word with a zero imm19 placeholder — Rt[4:0].
+# pass 2 inserts the resolved imm19 displacement.
+fun pack_cbnz(base: u32, rt: u32) u32 {
+    ret base | (rt & 0x1F);
+}
+
+# ---- low-level emit / patch helpers ----
+
+# emit_word: append one 32-bit A64 instruction word to the text sink (little-endian).
+fun emit_word(st: *EncodeState, word: u32) {
+    emit_u32(?st.buf, word);
+}
+
+# read_word: read the 32-bit little-endian word at `pos` in the text sink.
+fun read_word(buf: *ByteBuf, pos: usize) u32 {
+    ret buf.data[pos]::u32 |
+        (buf.data[pos + 1]::u32 << 8) |
+        (buf.data[pos + 2]::u32 << 16) |
+        (buf.data[pos + 3]::u32 << 24);
+}
+
+# write_word: overwrite the 32-bit little-endian word at `pos` in the text sink.
+fun write_word(buf: *ByteBuf, pos: usize, word: u32) {
+    buf.data[pos]     = (word & 0xFF)::u8;
+    buf.data[pos + 1] = ((word >> 8) & 0xFF)::u8;
+    buf.data[pos + 2] = ((word >> 16) & 0xFF)::u8;
+    buf.data[pos + 3] = ((word >> 24) & 0xFF)::u8;
+}
+
+# sel: choose the 64-bit or 32-bit base word for an operation width.
+fun sel(use64: bool, base_x: u32, base_w: u32) u32 {
+    if (use64) { ret base_x; }
+    ret base_w;
+}
+
+# is64: true when an operation width selects the 64-bit (X-register, `sf`=1) form.
+# a width of 0 (a pseudo with no natural width) falls back to the machine word.
+fun is64(width: u8) bool {
+    if (width == 0) { ret true; }
+    ret width >= 8;
+}
+
+# emit_movewide_seq: materialize `value` into GP register index `rd` with a MOVZ
+# (the first non-zero 16-bit chunk) followed by a MOVK per remaining non-zero
+# chunk — up to four for a 64-bit value, two for a 32-bit one. a zero value emits
+# a single `MOVZ rd, #0`. always produces the exact bit pattern (no MOVN
+# optimization), so an out-of-range immediate legalizes correctly into a scratch.
+fun emit_movewide_seq(st: *EncodeState, rd: u32, value: u64, use64: bool) {
+    val base_z: u32 = sel(use64, MOVZ_X, MOVZ_W);
+    val base_k: u32 = sel(use64, MOVK_X, MOVK_W);
+    var chunks: u32 = 2;
+    if (use64) { chunks = 4; }
+    var v: u64 = value;
+    if (!use64) { v = value & 0xFFFFFFFF; }
+
+    if (v == 0) {
+        emit_word(st, pack_movewide(base_z, rd, 0, 0));
+        ret;
+    }
+
+    var first: bool = true;
+    var i: u32 = 0;
+    for (i < chunks) {
+        val chunk: u32 = ((v >> (16::u64 * i::u64)) & 0xFFFF)::u32;
+        if (chunk != 0) {
+            if (first) {
+                emit_word(st, pack_movewide(base_z, rd, i, chunk));
+                first = false;
+            } or {
+                emit_word(st, pack_movewide(base_k, rd, i, chunk));
+            }
+        }
+        i = i + 1;
+    }
+}
+
+# ---- operand resolution ----
+
+# req_gpr: the GP register index a post-regalloc operand names. only a physical
+# register survives to encode; a surviving virtual register is a register-
+# allocation bug, and a frame-slot / memory operand is deferred to Phase 3. both
+# are rejected loudly rather than mis-encoded.
+fun req_gpr(op: *mir.MirOperand) Result[i32, str] {
+    if (op.kind == mir.MIR_OP_PREG) {
+        ret ok[i32, str](isa.regid_index(op.preg::i32));
+    }
+    if (op.kind == mir.MIR_OP_VREG) {
+        ret err[i32, str]("encode: virtual register survived register allocation");
+    }
+    if (op.kind == mir.MIR_OP_MEM) {
+        ret err[i32, str]("aarch64 frame-slot/memory operands not implemented (Phase 3)");
+    }
+    ret err[i32, str]("encode: expected a register operand");
+}
+
+# resolve_source: the GP register index a source operand contributes. a physical
+# register is used directly; an immediate is materialized into `scratch` (and that
+# index returned). every other shape is rejected through `req_gpr`.
+fun resolve_source(st: *EncodeState, op: *mir.MirOperand, scratch: u32, use64: bool) Result[i32, str] {
+    if (op.kind == mir.MIR_OP_IMM) {
+        emit_movewide_seq(st, scratch, op.imm::u64, use64);
+        ret ok[i32, str](scratch::i32);
+    }
+    ret req_gpr(op);
+}
+
+# ---- per-opcode encoders ----
+
+# encode_alu3: a three-address integer ALU op `op Rd, Rn, Rm`. the right operand
+# folds into the ADD/SUB immediate form when it is a small non-negative immediate;
+# otherwise (and for the logical / multiply forms, which have no modeled immediate
+# encoding) it is materialized into the scratch register and the register form is
+# emitted. operand 0 is the destination, operand 1 the left source, operand 2 the
+# right source.
+fun encode_alu3(st: *EncodeState, mi: *mir.MirInstr, base_x: u32, base_w: u32) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: ALU op missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val rnr: Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH1, use64);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val rmr: Result[i32, str] = resolve_source(st, ?mi.operands[2], SCRATCH0, use64);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+
+    emit_word(st, pack_alu3(sel(use64, base_x, base_w), rd, rn, rm));
+    ret ok[bool, str](true);
+}
+
+# encode_addsub: ADD / SUB, taking the immediate form for a non-negative immediate
+# in imm12 (or imm12<<12) range and falling back to the register form (operand
+# materialized into the scratch) otherwise. mirrors `encode_alu3` for the register
+# case but reaches the dedicated immediate encoding the ALU bases cannot.
+fun encode_addsub(st: *EncodeState, mi: *mir.MirInstr, is_sub: bool) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: add/sub missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val rnr: Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH1, use64);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val rhs: *mir.MirOperand = ?mi.operands[2];
+    if (rhs.kind == mir.MIR_OP_IMM) {
+        val v: i64 = rhs.imm;
+        if (v >= 0 && v <= 4095) {
+            var base_i: u32 = sel(use64, ADDI_X, ADDI_W);
+            if (is_sub) { base_i = sel(use64, SUBI_X, SUBI_W); }
+            emit_word(st, pack_addsub_imm(base_i, rd, rn, v::u32, 0));
+            ret ok[bool, str](true);
+        }
+        if (v > 0 && (v & 0xFFF) == 0 && (v >> 12) <= 4095) {
+            var base_i: u32 = sel(use64, ADDI_X, ADDI_W);
+            if (is_sub) { base_i = sel(use64, SUBI_X, SUBI_W); }
+            emit_word(st, pack_addsub_imm(base_i, rd, rn, (v >> 12)::u32, 1));
+            ret ok[bool, str](true);
+        }
+    }
+
+    val rmr: Result[i32, str] = resolve_source(st, rhs, SCRATCH0, use64);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+    var base_r: u32 = sel(use64, ADD_X, ADD_W);
+    if (is_sub) { base_r = sel(use64, SUB_X, SUB_W); }
+    emit_word(st, pack_alu3(base_r, rd, rn, rm));
+    ret ok[bool, str](true);
+}
+
+# encode_shift: a left / logical-right / arithmetic-right shift. an immediate count
+# emits the UBFM / SBFM bitfield alias (the LSL immediate maps to immr=(width-sh),
+# imms=(width-1-sh); LSR / ASR map to immr=sh, imms=width-1); a register count
+# emits the register-variable form (LSLV / LSRV / ASRV).
+fun encode_shift(st: *EncodeState, mi: *mir.MirInstr, kind: u32) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: shift missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val rnr: Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH1, use64);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val cnt: *mir.MirOperand = ?mi.operands[2];
+    if (cnt.kind == mir.MIR_OP_IMM) {
+        var width_bits: u32 = 32;
+        if (use64) { width_bits = 64; }
+        val sh: u32 = cnt.imm::u32 & (width_bits - 1);
+        if (kind == arm64.LSL::u32) {
+            val immr: u32 = (width_bits - sh) & (width_bits - 1);
+            val imms: u32 = (width_bits - 1) - sh;
+            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd, rn, immr, imms));
+            ret ok[bool, str](true);
+        }
+        if (kind == arm64.LSR::u32) {
+            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd, rn, sh, width_bits - 1));
+            ret ok[bool, str](true);
+        }
+        emit_word(st, pack_bitfield(sel(use64, SBFM_X, SBFM_W), rd, rn, sh, width_bits - 1));
+        ret ok[bool, str](true);
+    }
+
+    val rmr: Result[i32, str] = req_gpr(cnt);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+    var base_x: u32 = LSLV_X; var base_w: u32 = LSLV_W;
+    if (kind == arm64.LSR::u32) { base_x = LSRV_X; base_w = LSRV_W; }
+    or (kind == arm64.ASR::u32) { base_x = ASRV_X; base_w = ASRV_W; }
+    emit_word(st, pack_alu3(sel(use64, base_x, base_w), rd, rn, rm));
+    ret ok[bool, str](true);
+}
+
+# encode_neg_mvn: NEG (`sub Rd, XZR, Rm`) or MVN (`orn Rd, XZR, Rm`), both reading
+# the `[dst, src]` operand pair and supplying XZR as Rn from the encoding.
+fun encode_neg_mvn(st: *EncodeState, mi: *mir.MirInstr, base_x: u32, base_w: u32) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: neg/not missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val rmr: Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH0, use64);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+
+    emit_word(st, pack_alu3(sel(use64, base_x, base_w), rd, ZR, rm));
+    ret ok[bool, str](true);
+}
+
+# encode_mov: a register move (`orr Rd, XZR, Rm`) or, for an immediate source, a
+# MOVZ/MOVK materialization directly into the destination.
+fun encode_mov(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: mov missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val src: *mir.MirOperand = ?mi.operands[1];
+    if (src.kind == mir.MIR_OP_IMM) {
+        emit_movewide_seq(st, rd, src.imm::u64, use64);
+        ret ok[bool, str](true);
+    }
+    val rmr: Result[i32, str] = req_gpr(src);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+    emit_word(st, pack_alu3(sel(use64, ORR_X, ORR_W), rd, ZR, rm));
+    ret ok[bool, str](true);
+}
+
+# cmp_cond: the A64 condition a surviving comparison sentinel captures. only the
+# EQ / NE / LT / LE forms exist in the generic opcode space (the lowerer
+# canonicalizes GT/GE by swapping operands); signedness selects the signed
+# (LT/LE) versus unsigned (CC/LS) condition.
+fun cmp_cond(op: mir.MirOpcode) u32 {
+    if (op == mir.MIR_SEL_CMP_EQ)   { ret CC_EQ; }
+    if (op == mir.MIR_SEL_CMP_NE)   { ret CC_NE; }
+    if (op == mir.MIR_SEL_CMP_LT_S) { ret CC_LT; }
+    if (op == mir.MIR_SEL_CMP_LT_U) { ret CC_CC; }
+    if (op == mir.MIR_SEL_CMP_LE_S) { ret CC_LE; }
+    ret CC_LS;
+}
+
+# is_mir_compare: true when a post-isel opcode is a surviving generic comparison
+# sentinel — the encoder materializes the SUBS XZR + CSET byte sequence from it.
+fun is_mir_compare(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_SEL_CMP_EQ || op == mir.MIR_SEL_CMP_NE ||
+        op == mir.MIR_SEL_CMP_LT_S || op == mir.MIR_SEL_CMP_LT_U ||
+        op == mir.MIR_SEL_CMP_LE_S || op == mir.MIR_SEL_CMP_LE_U;
+}
+
+# encode_compare: materialize a surviving comparison `[dst, lhs, rhs]` into
+# `SUBS XZR, lhs, rhs` (the flag-setting compare; an immediate right operand folds
+# into the immediate form) followed by `CSET dst, cc` (capture the condition into a
+# zero-extended boolean). the comparison runs at the operand width; the boolean is
+# captured in the 32-bit CSET form (a 0/1 value the W write zero-extends to 64).
+fun encode_compare(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: compare missing operands"); }
+    val use64: bool = is64(mi.width);
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    val rnr: Result[i32, str] = req_gpr(?mi.operands[1]);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val rhs: *mir.MirOperand = ?mi.operands[2];
+    if (rhs.kind == mir.MIR_OP_IMM && rhs.imm >= 0 && rhs.imm <= 4095) {
+        emit_word(st, pack_cmp_imm(sel(use64, SUBS_IMM_X, SUBS_IMM_W), rn, rhs.imm::u32));
+    } or {
+        val rmr: Result[i32, str] = resolve_source(st, rhs, SCRATCH0, use64);
+        if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+        val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+        emit_word(st, pack_cmp_reg(sel(use64, SUBS_REG_X, SUBS_REG_W), rn, rm));
+    }
+
+    emit_word(st, pack_cset(CSINC_W, rd, cmp_cond(mi.opcode)));
+    ret ok[bool, str](true);
+}
+
+# encode_branch: an unconditional branch to a block. emits the B word with a zero
+# imm26 placeholder and records a fixup (patch site = the instruction word start,
+# per `arm64_reloc_offset`) for pass 2 to fill with the resolved displacement.
+fun encode_branch(st: *EncodeState, fn_base: u32, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 1 || mi.operands[0].kind != mir.MIR_OP_BLOCK) {
+        ret err[bool, str]("encode: branch target is not a block");
+    }
+    val target_block: u32 = mi.operands[0].imm::u32;
+    val patch_pos: u32 = st.buf.len::u32;
+    emit_word(st, B_BASE);
+    val next_ip: u32 = st.buf.len::u32;
+    ret push_fixup(st, patch_pos, next_ip, target_block, fn_base);
+}
+
+# encode_cbr: a conditional branch `[cond, then_block, else_block]` materialized as
+# `CBNZ cond, then` (taken when the condition is non-zero) ; `B else` (the
+# fall-through edge, always emitted). each branch records a fixup against its
+# target block; pass 2 inserts the imm19 / imm26 displacement once both block
+# offsets are known.
+fun encode_cbr(st: *EncodeState, fn_base: u32, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: conditional branch missing operands"); }
+    if (mi.operands[1].kind != mir.MIR_OP_BLOCK || mi.operands[2].kind != mir.MIR_OP_BLOCK) {
+        ret err[bool, str]("encode: conditional branch target is not a block");
+    }
+    val then_block: u32 = mi.operands[1].imm::u32;
+    val else_block: u32 = mi.operands[2].imm::u32;
+    val use64: bool = is64(mi.width);
+
+    val rcr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rcr)) { ret err[bool, str](unwrap_err[i32, str](rcr)); }
+    val cond: u32 = unwrap_ok[i32, str](rcr)::u32;
+
+    val cbnz_pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_cbnz(sel(use64, CBNZ_X, CBNZ_W), cond));
+    val cbnz_next: u32 = st.buf.len::u32;
+    val f1: Result[bool, str] = push_fixup(st, cbnz_pos, cbnz_next, then_block, fn_base);
+    if (is_err[bool, str](f1)) { ret f1; }
+
+    val b_pos: u32 = st.buf.len::u32;
+    emit_word(st, B_BASE);
+    val b_next: u32 = st.buf.len::u32;
+    ret push_fixup(st, b_pos, b_next, else_block, fn_base);
+}
+
+# ---- frame layout, prologue, epilogue ----
+
+# popcount32: the number of set bits in a 32-bit mask.
+fun popcount32(m: u32) u32 {
+    var n: u32 = 0;
+    var x: u32 = m;
+    for (x != 0) {
+        n = n + (x & 1);
+        x = x >> 1;
+    }
+    ret n;
+}
+
+# align16: round a byte count up to a 16-byte boundary (the AAPCS64 stack alignment).
+fun align16(n: u32) u32 {
+    ret (n + 15) & ~15::u32;
+}
+
+# frame_total: the 16-byte-aligned byte count the prologue reserves below the
+# caller's SP — the FP/LR frame record (16 bytes) plus the callee-saved GP/FP save
+# area, the local frame, and the outgoing-argument region, read from the SAME
+# shared frame facts the x86-64 encoder reads. SP stays 16-byte aligned.
+fun frame_total(f: *mir.MirFunction) u32 {
+    val gp_bytes: u32 = popcount32(f.callee_mask) * 8;
+    val fp_bytes: u32 = popcount32(f.callee_mask_fp) * 16;
+    ret align16(16 + gp_bytes + fp_bytes + f.frame.size + f.frame.outgoing_size);
+}
+
+# emit_prologue: the standard AArch64 leaf prologue — `STP X29, X30, [SP, #-total]!`
+# (save the FP/LR frame record and allocate the whole frame) then `MOV X29, SP`
+# (an `add x29, sp, #0`). callee-saved GP registers are then saved in STP pairs
+# (a trailing odd one with STR) just above the frame record. SP stays 16-aligned.
+fun emit_prologue(st: *EncodeState, f: *mir.MirFunction, total: u32) {
+    val neg_off: u32 = (0::u32 - (total / 8)) & 0x7F;
+    emit_word(st, pack_ldstp(STP_PRE_X, 29, 30, ZR, neg_off));
+    emit_word(st, pack_addsub_imm(ADDI_X, 29, ZR, 0, 0));
+    save_callee_gp(st, f, true);
+}
+
+# emit_epilogue: the standard AArch64 leaf epilogue — restore the callee-saved GP
+# registers, then `LDP X29, X30, [SP], #total` (reload the FP/LR frame record and
+# deallocate the whole frame). the RET that follows returns through X30.
+fun emit_epilogue(st: *EncodeState, f: *mir.MirFunction, total: u32) {
+    save_callee_gp(st, f, false);
+    val pos_off: u32 = (total / 8) & 0x7F;
+    emit_word(st, pack_ldstp(LDP_POST_X, 29, 30, ZR, pos_off));
+}
+
+# save_callee_gp: save (or restore) the callee-saved GP registers `callee_mask`
+# selects, in ascending register order, in STP pairs at ascending 16-aligned
+# offsets above the FP/LR frame record (`[sp, #16]`, `[sp, #32]`, …). a trailing
+# odd register is handled with a single STR/LDR. SP-relative and self-contained,
+# so it is correct regardless of where X29 points.
+fun save_callee_gp(st: *EncodeState, f: *mir.MirFunction, store: bool) {
+    var regs: [32]u32;
+    var n: u32 = 0;
+    var r: u32 = 0;
+    for (r < 31) {
+        if ((f.callee_mask & (1::u32 << r)) != 0) { regs[n] = r; n = n + 1; }
+        r = r + 1;
+    }
+
+    var off: u32 = 16;
+    var i: u32 = 0;
+    for (i + 1 < n) {
+        val imm7: u32 = (off / 8) & 0x7F;
+        if (store) { emit_word(st, pack_ldstp(STP_OFF_X, regs[i], regs[i + 1], ZR, imm7)); }
+        or         { emit_word(st, pack_ldstp(LDP_OFF_X, regs[i], regs[i + 1], ZR, imm7)); }
+        off = off + 16;
+        i = i + 2;
+    }
+    if (i < n) {
+        val imm12: u32 = off / 8;
+        if (store) { emit_word(st, pack_ldst(STR_OFF_X, regs[i], ZR, imm12)); }
+        or         { emit_word(st, pack_ldst(LDR_OFF_X, regs[i], ZR, imm12)); }
+    }
+}
+
+# ---- per-instruction dispatch ----
+
+# encode_mir_instr: translate one post-regalloc MIR instruction into A64 bytes,
+# recording any intra-module branch fixup. the regalloc parallel-copy / liveness
+# pseudos emit nothing; the surviving comparison and conditional-branch sentinels
+# expand into their byte sequences; the float / conversion families, calls, inline
+# asm, and varargs are rejected loudly (a leaf integer function never reaches them).
+fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) Result[bool, str] {
+    val op: u16 = mi.opcode::u16;
+
+    # pseudo-opcodes the regalloc phase leaves behind emit no bytes.
+    if (op == isa.ISA_PCOPY || op == isa.ISA_PCOPY_FENCE ||
+        op == isa.ISA_USE || op == isa.ISA_LABEL) {
+        ret ok[bool, str](true);
+    }
+    if (mi.opcode == mir.MIR_CALL_RES || mi.opcode == mir.MIR_ARG) {
+        ret ok[bool, str](true);
+    }
+    if (mi.opcode == mir.MIR_PHI) {
+        ret err[bool, str]("internal compiler error: phi survived register allocation");
+    }
+
+    # the surviving comparison / conditional-branch sentinels expand into their
+    # multi-instruction byte sequences.
+    if (is_mir_compare(mi.opcode)) { ret encode_compare(st, mi); }
+    if (mi.opcode == mir.MIR_SEL_CBR) { ret encode_cbr(st, fn_base, mi); }
+
+    # deferred families: a leaf integer function never emits these, so they are
+    # rejected loudly rather than mis-encoded.
+    if (mi.opcode == mir.MIR_VA_FP_SAVE) {
+        ret err[bool, str]("aarch64 varargs not implemented (Phase 4)");
+    }
+    if (mi.opcode == mir.MIR_FADD || mi.opcode == mir.MIR_FSUB ||
+        mi.opcode == mir.MIR_FMUL || mi.opcode == mir.MIR_FDIV ||
+        mi.opcode == mir.MIR_FCMP || mi.opcode == mir.MIR_FNEG) {
+        ret err[bool, str]("aarch64 floating-point ops not implemented (Phase 3)");
+    }
+    if (mi.opcode == mir.MIR_TRUNC || mi.opcode == mir.MIR_SEXT ||
+        mi.opcode == mir.MIR_ZEXT || mi.opcode == mir.MIR_BITCAST ||
+        mi.opcode == mir.MIR_FP_TRUNC || mi.opcode == mir.MIR_FP_EXT ||
+        mi.opcode == mir.MIR_FP_TO_SI || mi.opcode == mir.MIR_FP_TO_UI ||
+        mi.opcode == mir.MIR_SI_TO_FP || mi.opcode == mir.MIR_UI_TO_FP) {
+        ret err[bool, str]("aarch64 conversions not implemented (Phase 3)");
+    }
+    if (mi.opcode == mir.MIR_CALL) {
+        ret err[bool, str]("aarch64 calls not implemented (Phase 3)");
+    }
+
+    # concrete A64 opcodes.
+    if (op == arm64.ADD::u16) { ret encode_addsub(st, mi, false); }
+    if (op == arm64.SUB::u16) { ret encode_addsub(st, mi, true); }
+    if (op == arm64.MUL::u16) { ret encode_alu3(st, mi, MUL_X, MUL_W); }
+    if (op == arm64.AND::u16) { ret encode_alu3(st, mi, AND_X, AND_W); }
+    if (op == arm64.ORR::u16) { ret encode_alu3(st, mi, ORR_X, ORR_W); }
+    if (op == arm64.EOR::u16) { ret encode_alu3(st, mi, EOR_X, EOR_W); }
+    if (op == arm64.LSL::u16) { ret encode_shift(st, mi, arm64.LSL::u32); }
+    if (op == arm64.LSR::u16) { ret encode_shift(st, mi, arm64.LSR::u32); }
+    if (op == arm64.ASR::u16) { ret encode_shift(st, mi, arm64.ASR::u32); }
+    if (op == arm64.NEG::u16) { ret encode_neg_mvn(st, mi, SUB_X, SUB_W); }
+    if (op == arm64.MVN::u16) { ret encode_neg_mvn(st, mi, ORN_X, ORN_W); }
+    if (op == arm64.MOV::u16) { ret encode_mov(st, mi); }
+    if (op == arm64.B::u16)   { ret encode_branch(st, fn_base, mi); }
+    if (op == arm64.RET::u16) { emit_word(st, RET_WORD); ret ok[bool, str](true); }
+    if (op == arm64.BRK::u16) { emit_word(st, BRK_BASE); ret ok[bool, str](true); }
+    if (op == arm64.NOP::u16) { emit_word(st, NOP_WORD); ret ok[bool, str](true); }
+
+    ret err[bool, str]("internal compiler error: unhandled opcode in arm64 encode");
+}
+
+# encode_function_arm64: the per-function encode hook (pass 1). marks the function
+# entry symbol, emits the prologue, then each block — emitting the epilogue before
+# every RET — recording each block's `.text` offset for branch patching. extern /
+# body-less functions contribute no text. a frame beyond the leaf-supported shape
+# (callee-saved FP registers, or a frame larger than the pre-index STP range) is
+# rejected loudly rather than mis-encoded.
+fun encode_function_arm64(st: *EncodeState, f: *mir.MirFunction) Result[bool, str] {
+    val fn_base: u32 = st.buf.len::u32;
+    if (f.block_count == 0) { ret ok[bool, str](true); }
+
+    val ms: Result[bool, str] = push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
+    if (is_err[bool, str](ms)) { ret ms; }
+
+    if (f.callee_mask_fp != 0) {
+        ret err[bool, str]("aarch64 callee-saved FP registers not implemented (Phase 3)");
+    }
+    val total: u32 = frame_total(f);
+    if (total > MAX_PREINDEX_FRAME) {
+        ret err[bool, str]("aarch64 frame larger than the pre-index STP range not implemented (Phase 3)");
+    }
+
+    emit_prologue(st, f, total);
+
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        val rb: Result[bool, str] = push_block(st, fn_base, blk.id, st.buf.len::u32);
+        if (is_err[bool, str](rb)) { ret rb; }
+
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            if (mi.opcode::u16 == arm64.RET::u16) {
+                emit_epilogue(st, f, total);
+            }
+            val ei: Result[bool, str] = encode_mir_instr(st, f, fn_base, mi);
+            if (is_err[bool, str](ei)) { ret ei; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# patch_branch_arm64: the per-branch patch hook (pass 2). reads the placeholder
+# instruction word at the fixup's patch site, inserts the resolved displacement
+# (instruction-relative: `target_off - patch_pos`, with no x86-64 next-instruction
+# bias), and writes the word back. an unconditional B takes an imm26[25:0]; a
+# B.cond / CBZ / CBNZ takes an imm19[23:5] — distinguished by the word's top bits
+# (a read-modify-write bitfield insert, not a byte overwrite).
+fun patch_branch_arm64(st: *EncodeState, fx: *BranchFixup, target_off: u32) Result[bool, str] {
+    val pos: usize = fx.patch_pos::usize;
+    if (pos + 4 > st.buf.len) {
+        ret err[bool, str]("encode: branch fixup site is outside the text buffer");
+    }
+    val word: u32 = read_word(?st.buf, pos);
+    val disp: u32 = target_off - fx.patch_pos;
+
+    var patched: u32 = 0;
+    if ((word & 0xFC000000) == B_BASE) {
+        patched = (word & 0xFC000000) | ((disp & 0x0FFFFFFC) >> 2);
+    } or {
+        patched = (word & 0xFF00001F) | (((disp >> 2) & 0x7FFFF) << 5);
+    }
+    write_word(?st.buf, pos, patched);
+    ret ok[bool, str](true);
+}
+
+# arm64_reloc_offset: the byte offset, within an encoded instruction, where a
+# relocation field begins — always the instruction-word start on A64 (the linker
+# packers read the access kind from the relocation, not an instruction decode). a
+# leaf integer function emits no symbol references, so no relocation is recorded in
+# this phase; this is the patch-site convention the call/global lowering of Phase 3
+# will record against.
+fun arm64_reloc_offset(inst_start: u32) u32 {
+    ret inst_start;
+}
+
+# encode_arm64: the AArch64 ISA's `encode` entry point — a thin wrapper that
+# supplies the two A64 `enc.EncodeHooks` and runs the shared two-pass driver. the
+# ISA-general driving lives in `enc.encode_driver`; this backend contributes only
+# its per-function encode (`encode_function_arm64`) and per-branch patch
+# (`patch_branch_arm64`). the erased vtable pointer is cast back to this exact
+# signature, so it must not change.
 # ---
-# alloc: allocator (unused until encoding is implemented)
-# tgt:   resolved compilation target (must be AArch64)
-# m:     the fully-resolved MIR module
-# ret:   an error reporting that AArch64 encoding is unimplemented
+# alloc: allocator backing the encoder output's owned arrays
+# tgt:   resolved target; must be AArch64
+# m:     the fully-resolved MIR module (post isel / regalloc / frame)
+# ret:   the populated enc.EncoderOutput (owned arrays), or an error string
 pub fun encode_arm64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Result[enc.EncoderOutput, str] {
-    ret err[enc.EncoderOutput, str]("aarch64 encode not implemented");
+    var hooks: EncodeHooks;
+    hooks.encode_function = encode_function_arm64;
+    hooks.patch_branch    = patch_branch_arm64;
+    ret encode_driver(alloc, tgt, m, ?hooks);
+}
+
+# ---- in-source encode tests (byte-exact vs llvm-mc goldens) ----
+
+# tbuf: a fresh page-backed EncodeState carrying only a byte sink, for exercising
+# the emit-level helpers (prologue / epilogue / branch patch) directly.
+fun tbuf(st: *EncodeState, alloc: *Allocator) {
+    page.make(alloc);
+    st.buf = buf_init(alloc);
+}
+
+test "arm64.encode: three-address ALU register forms match llvm-mc" {
+    var bad: i32 = 0;
+    # add x0, x1, x2 ; add w0, w1, w2
+    if (pack_alu3(ADD_X, 0, 1, 2) != 0x8B020020) { bad = 1; }
+    if (pack_alu3(ADD_W, 0, 1, 2) != 0x0B020020) { bad = 1; }
+    # sub x/w
+    if (pack_alu3(SUB_X, 0, 1, 2) != 0xCB020020) { bad = 1; }
+    if (pack_alu3(SUB_W, 0, 1, 2) != 0x4B020020) { bad = 1; }
+    # mul x/w (madd ...,xzr)
+    if (pack_alu3(MUL_X, 0, 1, 2) != 0x9B027C20) { bad = 1; }
+    if (pack_alu3(MUL_W, 0, 1, 2) != 0x1B027C20) { bad = 1; }
+    # and / orr / eor x
+    if (pack_alu3(AND_X, 0, 1, 2) != 0x8A020020) { bad = 1; }
+    if (pack_alu3(ORR_X, 0, 1, 2) != 0xAA020020) { bad = 1; }
+    if (pack_alu3(EOR_X, 0, 1, 2) != 0xCA020020) { bad = 1; }
+    if (pack_alu3(AND_W, 0, 1, 2) != 0x0A020020) { bad = 1; }
+    if (pack_alu3(ORR_W, 0, 1, 2) != 0x2A020020) { bad = 1; }
+    if (pack_alu3(EOR_W, 0, 1, 2) != 0x4A020020) { bad = 1; }
+    ret bad;
+}
+
+test "arm64.encode: register shifts (LSLV/LSRV/ASRV) match llvm-mc" {
+    var bad: i32 = 0;
+    if (pack_alu3(LSLV_X, 0, 1, 2) != 0x9AC22020) { bad = 1; }
+    if (pack_alu3(LSLV_W, 0, 1, 2) != 0x1AC22020) { bad = 1; }
+    if (pack_alu3(LSRV_X, 0, 1, 2) != 0x9AC22420) { bad = 1; }
+    if (pack_alu3(LSRV_W, 0, 1, 2) != 0x1AC22420) { bad = 1; }
+    if (pack_alu3(ASRV_X, 0, 1, 2) != 0x9AC22820) { bad = 1; }
+    if (pack_alu3(ASRV_W, 0, 1, 2) != 0x1AC22820) { bad = 1; }
+    ret bad;
+}
+
+test "arm64.encode: immediate shifts (UBFM/SBFM aliases) match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(0);
+    ops[1] = mir.op_preg(1);
+    ops[2] = mir.op_imm(3);
+    mi.operands = ?ops[0];
+    mi.operand_count = 3;
+
+    # lsl x0, x1, #3 = 0xd37df020 ; lsl w0, w1, #3 = 0x531d7020
+    mi.width = 8; encode_shift(?st, ?mi, arm64.LSL::u32);
+    if (read_word(?st.buf, 0) != 0xD37DF020) { bad = 1; }
+    mi.width = 4; encode_shift(?st, ?mi, arm64.LSL::u32);
+    if (read_word(?st.buf, 4) != 0x531D7020) { bad = 1; }
+    # lsr x0, x1, #3 = 0xd343fc20 ; lsr w0, w1, #3 = 0x53037c20
+    mi.width = 8; encode_shift(?st, ?mi, arm64.LSR::u32);
+    if (read_word(?st.buf, 8) != 0xD343FC20) { bad = 1; }
+    mi.width = 4; encode_shift(?st, ?mi, arm64.LSR::u32);
+    if (read_word(?st.buf, 12) != 0x53037C20) { bad = 1; }
+    # asr x0, x1, #3 = 0x9343fc20 ; asr w0, w1, #3 = 0x13037c20
+    mi.width = 8; encode_shift(?st, ?mi, arm64.ASR::u32);
+    if (read_word(?st.buf, 16) != 0x9343FC20) { bad = 1; }
+    mi.width = 4; encode_shift(?st, ?mi, arm64.ASR::u32);
+    if (read_word(?st.buf, 20) != 0x13037C20) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+test "arm64.encode: NEG/MVN/MOV register forms match llvm-mc" {
+    var bad: i32 = 0;
+    # neg x0,x1 = 0xcb0103e0 ; neg w0,w1 = 0x4b0103e0
+    if (pack_alu3(SUB_X, 0, ZR, 1) != 0xCB0103E0) { bad = 1; }
+    if (pack_alu3(SUB_W, 0, ZR, 1) != 0x4B0103E0) { bad = 1; }
+    # mvn x0,x1 = 0xaa2103e0 ; mvn w0,w1 = 0x2a2103e0
+    if (pack_alu3(ORN_X, 0, ZR, 1) != 0xAA2103E0) { bad = 1; }
+    if (pack_alu3(ORN_W, 0, ZR, 1) != 0x2A2103E0) { bad = 1; }
+    # mov x0,x1 = 0xaa0103e0 ; mov w0,w1 = 0x2a0103e0
+    if (pack_alu3(ORR_X, 0, ZR, 1) != 0xAA0103E0) { bad = 1; }
+    if (pack_alu3(ORR_W, 0, ZR, 1) != 0x2A0103E0) { bad = 1; }
+    ret bad;
+}
+
+test "arm64.encode: MOVZ/MOVK materialization matches llvm-mc" {
+    var bad: i32 = 0;
+    # movz x0, #0x1234 lsl {0,16,32,48}
+    if (pack_movewide(MOVZ_X, 0, 0, 0x1234) != 0xD2824680) { bad = 1; }
+    if (pack_movewide(MOVZ_X, 0, 1, 0x1234) != 0xD2A24680) { bad = 1; }
+    if (pack_movewide(MOVZ_X, 0, 2, 0x1234) != 0xD2C24680) { bad = 1; }
+    if (pack_movewide(MOVZ_X, 0, 3, 0x1234) != 0xD2E24680) { bad = 1; }
+    # movk x0, #0x5678 lsl {0,16}
+    if (pack_movewide(MOVK_X, 0, 0, 0x5678) != 0xF28ACF00) { bad = 1; }
+    if (pack_movewide(MOVK_X, 0, 1, 0x5678) != 0xF2AACF00) { bad = 1; }
+    # 32-bit movz/movk
+    if (pack_movewide(MOVZ_W, 0, 0, 0x1234) != 0x52824680) { bad = 1; }
+    if (pack_movewide(MOVK_W, 0, 1, 0x5678) != 0x72AACF00) { bad = 1; }
+
+    # the emitted sequence for 0x12345678 (32-bit): movz w0,#0x5678 ; movk w0,#0x1234,lsl#16
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    emit_movewide_seq(?st, 0, 0x12345678, false);
+    if (st.buf.len != 8) { bad = 1; }
+    or {
+        if (read_word(?st.buf, 0) != pack_movewide(MOVZ_W, 0, 0, 0x5678)) { bad = 1; }
+        if (read_word(?st.buf, 4) != pack_movewide(MOVK_W, 0, 1, 0x1234)) { bad = 1; }
+    }
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+test "arm64.encode: ADD/SUB immediate forms match llvm-mc" {
+    var bad: i32 = 0;
+    # add x0,x1,#5 = 0x91001420 ; sub x0,x1,#5 = 0xd1001420
+    if (pack_addsub_imm(ADDI_X, 0, 1, 5, 0) != 0x91001420) { bad = 1; }
+    if (pack_addsub_imm(SUBI_X, 0, 1, 5, 0) != 0xD1001420) { bad = 1; }
+    # add w0,w1,#5 = 0x11001420 ; sub w0,w1,#5 = 0x51001420
+    if (pack_addsub_imm(ADDI_W, 0, 1, 5, 0) != 0x11001420) { bad = 1; }
+    if (pack_addsub_imm(SUBI_W, 0, 1, 5, 0) != 0x51001420) { bad = 1; }
+    # add x0,x1,#5,lsl#12 = 0x91401420 ; add w0,w1,#5,lsl#12 = 0x11401420
+    if (pack_addsub_imm(ADDI_X, 0, 1, 5, 1) != 0x91401420) { bad = 1; }
+    if (pack_addsub_imm(ADDI_W, 0, 1, 5, 1) != 0x11401420) { bad = 1; }
+    # add sp,sp,#16 = 0x910043ff ; sub sp,sp,#16 = 0xd10043ff ; mov x29,sp = 0x910003fd
+    if (pack_addsub_imm(ADDI_X, ZR, ZR, 16, 0) != 0x910043FF) { bad = 1; }
+    if (pack_addsub_imm(SUBI_X, ZR, ZR, 16, 0) != 0xD10043FF) { bad = 1; }
+    if (pack_addsub_imm(ADDI_X, 29, ZR, 0, 0) != 0x910003FD) { bad = 1; }
+    ret bad;
+}
+
+test "arm64.encode: CMP + CSET match llvm-mc" {
+    var bad: i32 = 0;
+    # cmp x0,x1 = 0xeb01001f ; cmp w0,w1 = 0x6b01001f ; cmp x0,#5 = 0xf100141f ; cmp w0,#5 = 0x7100141f
+    if (pack_cmp_reg(SUBS_REG_X, 0, 1) != 0xEB01001F) { bad = 1; }
+    if (pack_cmp_reg(SUBS_REG_W, 0, 1) != 0x6B01001F) { bad = 1; }
+    if (pack_cmp_imm(SUBS_IMM_X, 0, 5) != 0xF100141F) { bad = 1; }
+    if (pack_cmp_imm(SUBS_IMM_W, 0, 5) != 0x7100141F) { bad = 1; }
+    # cset w0, <cc> family
+    if (pack_cset(CSINC_W, 0, CC_EQ) != 0x1A9F17E0) { bad = 1; }  # cset w0, eq
+    if (pack_cset(CSINC_W, 0, CC_NE) != 0x1A9F07E0) { bad = 1; }  # cset w0, ne
+    if (pack_cset(CSINC_W, 0, CC_LT) != 0x1A9FA7E0) { bad = 1; }  # cset w0, lt
+    if (pack_cset(CSINC_W, 0, CC_LE) != 0x1A9FC7E0) { bad = 1; }  # cset w0, le
+    if (pack_cset(CSINC_W, 0, CC_CC) != 0x1A9F27E0) { bad = 1; }  # cset w0, cc (lo)
+    if (pack_cset(CSINC_W, 0, CC_LS) != 0x1A9F87E0) { bad = 1; }  # cset w0, ls
+    if (pack_cset(CSINC_X, 0, CC_EQ) != 0x9A9F17E0) { bad = 1; }  # cset x0, eq
+    ret bad;
+}
+
+test "arm64.encode: RET / BRK / NOP / B base match llvm-mc" {
+    var bad: i32 = 0;
+    if (RET_WORD != 0xD65F03C0) { bad = 1; }  # ret
+    if (BRK_BASE != 0xD4200000) { bad = 1; }  # brk #0
+    if (NOP_WORD != 0xD503201F) { bad = 1; }  # nop
+    if (B_BASE   != 0x14000000) { bad = 1; }  # b (imm26=0)
+    ret bad;
+}
+
+test "arm64.encode: prologue STP/MOV and epilogue LDP/RET match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # a leaf function: no callee saves, no locals, no outgoing -> total = 16.
+    var f: mir.MirFunction;
+    f.callee_mask = 0;
+    f.callee_mask_fp = 0;
+    f.frame.size = 0;
+    f.frame.outgoing_size = 0;
+    val total: u32 = frame_total(?f);
+    if (total != 16) { bad = 1; }
+
+    emit_prologue(?st, ?f, total);
+    # stp x29, x30, [sp, #-16]! = 0xa9bf7bfd ; mov x29, sp = 0x910003fd
+    if (read_word(?st.buf, 0) != 0xA9BF7BFD) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x910003FD) { bad = 1; }
+
+    emit_epilogue(?st, ?f, total);
+    # ldp x29, x30, [sp], #16 = 0xa8c17bfd
+    if (read_word(?st.buf, 8) != 0xA8C17BFD) { bad = 1; }
+
+    # a 32-byte frame's pre/post-index immediates: stp ...[sp,#-32]! = 0xa9be7bfd,
+    # ldp ...[sp],#32 = 0xa8c27bfd.
+    st.buf.len = 0;
+    var f2: mir.MirFunction;
+    f2.callee_mask = 0;
+    f2.callee_mask_fp = 0;
+    f2.frame.size = 8;
+    f2.frame.outgoing_size = 0;
+    val total2: u32 = frame_total(?f2);
+    if (total2 != 32) { bad = 1; }
+    emit_prologue(?st, ?f2, total2);
+    if (read_word(?st.buf, 0) != 0xA9BE7BFD) { bad = 1; }
+    emit_epilogue(?st, ?f2, total2);
+    if (read_word(?st.buf, 8) != 0xA8C27BFD) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+test "arm64.encode: callee-saved STP/STR pair spills match llvm-mc" {
+    var bad: i32 = 0;
+    # stp x19,x20,[sp,#16] = 0xa90153f3 ; ldp x19,x20,[sp,#16] = 0xa94153f3
+    if (pack_ldstp(STP_OFF_X, 19, 20, ZR, 2) != 0xA90153F3) { bad = 1; }
+    if (pack_ldstp(LDP_OFF_X, 19, 20, ZR, 2) != 0xA94153F3) { bad = 1; }
+    # str x19,[sp,#16] = 0xf9000bf3 ; ldr x19,[sp,#16] = 0xf9400bf3
+    if (pack_ldst(STR_OFF_X, 19, ZR, 2) != 0xF9000BF3) { bad = 1; }
+    if (pack_ldst(LDR_OFF_X, 19, ZR, 2) != 0xF9400BF3) { bad = 1; }
+    ret bad;
+}
+
+test "arm64.encode: branch fixups insert imm26 / imm19 like llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # lay down four placeholder words: B (off 0), B.eq (off 4), CBZ x0 (off 8),
+    # CBNZ x1 (off 12), then patch each against a known target.
+    emit_word(?st, B_BASE);                       # off 0
+    emit_word(?st, BCOND | CC_EQ);                # off 4 (b.eq)
+    emit_word(?st, pack_cbnz(0xB4000000, 0));     # off 8 (cbz x0) — same imm19 field as cbnz
+    emit_word(?st, pack_cbnz(CBNZ_X, 1));         # off 12 (cbnz x1)
+
+    var fx: BranchFixup;
+    # B at 0 -> target 8: disp 8, imm26=2 -> 0x14000002.
+    fx.patch_pos = 0; fx.next_ip = 4;
+    patch_branch_arm64(?st, ?fx, 8);
+    if (read_word(?st.buf, 0) != 0x14000002) { bad = 1; }
+    # B.eq at 4 -> target 12: disp 8, imm19=2 -> 0x54000040.
+    fx.patch_pos = 4; fx.next_ip = 8;
+    patch_branch_arm64(?st, ?fx, 12);
+    if (read_word(?st.buf, 4) != 0x54000040) { bad = 1; }
+    # CBZ x0 at 8 -> target 16: disp 8, imm19=2 -> 0xb4000040.
+    fx.patch_pos = 8; fx.next_ip = 12;
+    patch_branch_arm64(?st, ?fx, 16);
+    if (read_word(?st.buf, 8) != 0xB4000040) { bad = 1; }
+    # CBNZ x1 at 12 -> target 12 (self): disp 0 -> 0xb5000001.
+    fx.patch_pos = 12; fx.next_ip = 16;
+    patch_branch_arm64(?st, ?fx, 12);
+    if (read_word(?st.buf, 12) != 0xB5000001) { bad = 1; }
+
+    # a backward B at 28 -> target 0: disp -28 -> 0x17fffff9 (matches llvm-objdump).
+    st.buf.len = 0;
+    var k: u32 = 0;
+    for (k < 8) { emit_word(?st, B_BASE); k = k + 1; }
+    fx.patch_pos = 28; fx.next_ip = 32;
+    patch_branch_arm64(?st, ?fx, 0);
+    if (read_word(?st.buf, 28) != 0x17FFFFF9) { bad = 1; }
+    # a backward B.eq at 32 -> target 0: disp -32 -> 0x54ffff00.
+    emit_word(?st, BCOND | CC_EQ);
+    fx.patch_pos = 32; fx.next_ip = 36;
+    patch_branch_arm64(?st, ?fx, 0);
+    if (read_word(?st.buf, 32) != 0x54FFFF00) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+test "arm64.encode: end-to-end leaf add(w0,w1) body matches llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # add w0, w0, w1  — the leaf integer body (operands already register-resolved).
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(0);
+    ops[1] = mir.op_preg(0);
+    ops[2] = mir.op_preg(1);
+    mi.operands = ?ops[0];
+    mi.operand_count = 3;
+    mi.width = 4;
+    encode_addsub(?st, ?mi, false);
+    # add w0, w0, w1 = 0x0b010000
+    if (read_word(?st.buf, 0) != 0x0B010000) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
 }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -770,12 +770,29 @@ fun patch_branch_arm64(st: *EncodeState, fx: *BranchFixup, target_off: u32) Resu
         ret err[bool, str]("encode: branch fixup site is outside the text buffer");
     }
     val word: u32 = read_word(?st.buf, pos);
+    # the displacement is instruction-relative and signed; range-check it against
+    # the field width BEFORE the bitfield insert. an out-of-range branch silently
+    # truncated into imm26/imm19 is a miscompile (a real risk in the self-host
+    # compiler's large functions, where an imm19 conditional branch can exceed
+    # +-1MB), so reject it loudly. A64 branch targets are always 4-aligned.
+    val sdisp: i64 = (target_off::i64) - (fx.patch_pos::i64);
+    if ((sdisp & 3) != 0) {
+        ret err[bool, str]("encode: aarch64 branch displacement is not 4-byte aligned");
+    }
     val disp: u32 = target_off - fx.patch_pos;
 
     var patched: u32 = 0;
     if ((word & 0xFC000000) == B_BASE) {
+        # unconditional B: imm26[25:0] scaled by 4 -> +-128MB range.
+        if (sdisp < -134217728 || sdisp >= 134217728) {
+            ret err[bool, str]("encode: aarch64 B displacement exceeds the +-128MB branch range");
+        }
         patched = (word & 0xFC000000) | ((disp & 0x0FFFFFFC) >> 2);
     } or {
+        # B.cond / CBZ / CBNZ: imm19[23:5] scaled by 4 -> +-1MB range.
+        if (sdisp < -1048576 || sdisp >= 1048576) {
+            ret err[bool, str]("encode: aarch64 conditional-branch displacement exceeds the +-1MB range");
+        }
         patched = (word & 0xFF00001F) | (((disp >> 2) & 0x7FFFF) << 5);
     }
     write_word(?st.buf, pos, patched);
@@ -1069,6 +1086,39 @@ test "arm64.encode: branch fixups insert imm26 / imm19 like llvm-mc" {
     fx.patch_pos = 32; fx.next_ip = 36;
     patch_branch_arm64(?st, ?fx, 0);
     if (read_word(?st.buf, 32) != 0x54FFFF00) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# an out-of-range branch displacement must fail loud rather than silently truncate
+# into imm26/imm19 (a miscompile the self-host compiler's large functions can hit).
+test "arm64.encode: branch fixups reject out-of-range displacements (#1436)" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # a conditional branch (imm19, +-1MB) past +-1MB -> reject.
+    emit_word(?st, BCOND | CC_EQ);
+    var fx: BranchFixup;
+    fx.patch_pos = 0; fx.next_ip = 4;
+    val r1: Result[bool, str] = patch_branch_arm64(?st, ?fx, 2000000);
+    if (!is_err[bool, str](r1)) { bad = 1; }
+
+    # an unconditional B (imm26, +-128MB) past +-128MB -> reject.
+    st.buf.len = 0;
+    emit_word(?st, B_BASE);
+    fx.patch_pos = 0; fx.next_ip = 4;
+    val r2: Result[bool, str] = patch_branch_arm64(?st, ?fx, 200000000);
+    if (!is_err[bool, str](r2)) { bad = 1; }
+
+    # the +1MB-4 boundary (max valid imm19 displacement) still succeeds.
+    st.buf.len = 0;
+    emit_word(?st, BCOND | CC_EQ);
+    fx.patch_pos = 0; fx.next_ip = 4;
+    val r3: Result[bool, str] = patch_branch_arm64(?st, ?fx, 1048572);
+    if (is_err[bool, str](r3)) { bad = 1; }
 
     buf_dnit(?st.buf);
     ret bad;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1022,7 +1022,12 @@ fun encode_compare(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
     if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
     val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
 
-    val rnr: Result[i32, str] = req_gpr(?mi.operands[1]);
+    # the lhs is usually a register, but the shared lowering canonicalizes the GE/GT
+    # relations (which have no MIR opcode) by SWAPPING operands into LE/LT — which can
+    # leave an immediate on the lhs (e.g. `c >= 48` -> `48 <= c`, lhs=48). materialize
+    # an immediate lhs into SCRATCH1 (distinct from the rhs's SCRATCH0) so the operand
+    # order — and thus `cmp_cond` — is preserved.
+    val rnr: Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH1, use64);
     if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
     val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
 
@@ -1568,6 +1573,35 @@ test "arm64.encode: CMP + CSET match llvm-mc" {
     if (pack_cset(CSINC_W, 0, CC_CC) != 0x1A9F27E0) { bad = 1; }  # cset w0, cc (lo)
     if (pack_cset(CSINC_W, 0, CC_LS) != 0x1A9F87E0) { bad = 1; }  # cset w0, ls
     if (pack_cset(CSINC_X, 0, CC_EQ) != 0x9A9F17E0) { bad = 1; }  # cset x0, eq
+    ret bad;
+}
+
+# regression: the GE/GT relations have no MIR opcode, so the shared lowering
+# canonicalizes them into LE/LT with SWAPPED operands — which can leave an immediate
+# on the compare lhs (e.g. `c >= 48` -> `48 <= c`, lhs=48). encode_compare must
+# materialize an immediate lhs into SCRATCH1 (IP1), not reject it (real-std char gap).
+test "arm64.encode: compare with an immediate lhs materializes (real-std char gap)" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # `48 <= c` at u8 width: [dst w0, lhs #48, rhs w1] -> movz w17,#48 ; cmp w17,w1 ; cset w0,ls
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(0);
+    ops[1] = mir.op_imm(48);
+    ops[2] = mir.op_preg(1);
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+    mi.opcode = mir.MIR_SEL_CMP_LE_U; mi.width = 1;
+
+    val r: Result[bool, str] = encode_compare(?st, ?mi);
+    if (is_err[bool, str](r)) { bad = 1; }
+    if (read_word(?st.buf, 0) != 0x52800611) { bad = 1; }  # movz w17, #48
+    if (read_word(?st.buf, 4) != 0x6B01023F) { bad = 1; }  # cmp w17, w1
+    if (read_word(?st.buf, 8) != 0x1A9F87E0) { bad = 1; }  # cset w0, ls
+
+    buf_dnit(?st.buf);
     ret bad;
 }
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -248,6 +248,57 @@ val CC_GT: u32 = 12;
 val CC_LE: u32 = 13;
 val CC_AL: u32 = 14;
 
+# the two fixed FP scratch registers held back from vector allocation (V0–V29 are
+# allocatable, so these are never an assigned value): V31 is the primary scratch
+# (the vtable's `fp_scratch_reg`) used for a spilled left/source operand and for a
+# spilled destination's result; V30 the secondary, used for a spilled right
+# operand. both are caller-saved under AAPCS64, so neither needs prologue saving.
+val FP_SCRATCH0: u32 = 31;
+val FP_SCRATCH1: u32 = 30;
+
+# scalar floating-point base words. all share the `pack_alu3` field layout (Rm[20:16],
+# Rn[9:5], Rd[4:0]), so the FP encoders reuse it: a two-source op fills all three, a
+# one-source / convert / fmov form passes Rm=0, and a compare passes Rd=0 (its
+# opcode2 field). the `_S` / `_D` suffix is the f32 (S, type=00) vs f64 (D, type=01)
+# form selected by operand width; for the conversions the `_W` / `_X` suffix is the
+# 32-bit (sf=0) vs 64-bit (sf=1) GP-register form. each word is byte-exact against
+# `llvm-mc -triple=aarch64`.
+val FADD_S: u32 = 0x1E202800; val FADD_D: u32 = 0x1E602800;
+val FSUB_S: u32 = 0x1E203800; val FSUB_D: u32 = 0x1E603800;
+val FMUL_S: u32 = 0x1E200800; val FMUL_D: u32 = 0x1E600800;
+val FDIV_S: u32 = 0x1E201800; val FDIV_D: u32 = 0x1E601800;
+# fneg Sd,Sn / Dd,Dn (sign-bit flip) and fmov Sd,Sn / Dd,Dn (register copy).
+val FNEG_S: u32 = 0x1E214000; val FNEG_D: u32 = 0x1E614000;
+val FMOV_S: u32 = 0x1E204000; val FMOV_D: u32 = 0x1E604000;
+# fcvt Dd,Sn (single->double, FP_EXT) and fcvt Sd,Dn (double->single, FP_TRUNC).
+val FCVT_S2D: u32 = 0x1E22C000; val FCVT_D2S: u32 = 0x1E624000;
+# fcmp Sn,Sm / Dn,Dm (set NZCV); the boolean is captured with a following CSET.
+val FCMP_S: u32 = 0x1E202000; val FCMP_D: u32 = 0x1E602000;
+# scvtf / ucvtf Sd|Dd, Wn|Xn (signed / unsigned integer -> float).
+val SCVTF_S_W: u32 = 0x1E220000; val SCVTF_D_W: u32 = 0x1E620000;
+val SCVTF_S_X: u32 = 0x9E220000; val SCVTF_D_X: u32 = 0x9E620000;
+val UCVTF_S_W: u32 = 0x1E230000; val UCVTF_D_W: u32 = 0x1E630000;
+val UCVTF_S_X: u32 = 0x9E230000; val UCVTF_D_X: u32 = 0x9E630000;
+# fcvtzs / fcvtzu Wd|Xd, Sn|Dn (float -> signed / unsigned integer, round-to-zero).
+val FCVTZS_W_S: u32 = 0x1E380000; val FCVTZS_X_S: u32 = 0x9E380000;
+val FCVTZS_W_D: u32 = 0x1E780000; val FCVTZS_X_D: u32 = 0x9E780000;
+val FCVTZU_W_S: u32 = 0x1E390000; val FCVTZU_X_S: u32 = 0x9E390000;
+val FCVTZU_W_D: u32 = 0x1E790000; val FCVTZU_X_D: u32 = 0x9E790000;
+# fmov across the GP / FP banks: GP->FP (`fmov Sd,Wn` / `fmov Dd,Xn`) and FP->GP
+# (`fmov Wd,Sn` / `fmov Xd,Dn`), the cross-bank `:~` bitcast forms.
+val FMOV_S_FROM_W: u32 = 0x1E270000; val FMOV_D_FROM_X: u32 = 0x9E670000;
+val FMOV_W_FROM_S: u32 = 0x1E260000; val FMOV_X_FROM_D: u32 = 0x9E660000;
+
+# scalar FP load/store base words (scaled unsigned-offset, unscaled signed-offset
+# LDUR/STUR, and register-offset), per S (32-bit) / D (64-bit) width. spilled float
+# operands ride frame slots the float encoders address through these.
+val LDR_D_OFF: u32 = 0xFD400000; val STR_D_OFF: u32 = 0xFD000000;
+val LDR_S_OFF: u32 = 0xBD400000; val STR_S_OFF: u32 = 0xBD000000;
+val LDUR_D_FP: u32 = 0xFC400000; val STUR_D_FP: u32 = 0xFC000000;
+val LDUR_S_FP: u32 = 0xBC400000; val STUR_S_FP: u32 = 0xBC000000;
+val LDR_D_REG: u32 = 0xFC606800; val STR_D_REG: u32 = 0xFC206800;
+val LDR_S_REG: u32 = 0xBC606800; val STR_S_REG: u32 = 0xBC206800;
+
 # ---- bitfield packers (pure: each returns one A64 word) ----
 
 # pack_alu3: a three-register data-processing word — Rm[20:16], Rn[9:5], Rd[4:0]
@@ -1056,6 +1107,434 @@ fun encode_convert(st: *EncodeState, mi: *mir.MirInstr) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
+# ---- scalar floating-point ----
+
+# reg_is_vec: true when an operand is a physical register in the float / vector
+# bank. reads the class straight off the composite register id — the seam that lets
+# the move family pick the FP versus GP machine form from the operands alone.
+fun reg_is_vec(op: *mir.MirOperand) bool {
+    ret op.kind == mir.MIR_OP_PREG && isa.regid_class(op.preg::i32) == isa.REG_CLASS_ID_XMM;
+}
+
+# req_vec: the within-bank vector register index a post-regalloc register operand
+# names. only a physical register survives to encode; a surviving virtual register
+# is a register-allocation bug. the index is recovered through `regid_index` so the
+# composite XMM id (class tag in the high byte) encodes to the same V-register field
+# as a raw index — a raw GP index would mis-encode.
+fun req_vec(op: *mir.MirOperand) Result[i32, str] {
+    if (op.kind == mir.MIR_OP_PREG) {
+        ret ok[i32, str](isa.regid_index(op.preg::i32));
+    }
+    if (op.kind == mir.MIR_OP_VREG) {
+        ret err[i32, str]("encode: virtual register survived register allocation");
+    }
+    ret err[i32, str]("encode: expected a float register operand");
+}
+
+# fp_mem_scaled_base / fp_mem_unscaled_base / fp_mem_reg_base: the SIMD&FP load /
+# store base word for a width (D = 64-bit when `use_d`, else S = 32-bit) and
+# direction, in the scaled unsigned-offset, unscaled signed-offset (LDUR/STUR), and
+# register-offset forms — the FP twins of `ldst_base_*`.
+fun fp_mem_scaled_base(use_d: bool, is_load: bool) u32 {
+    if (use_d) { if (is_load) { ret LDR_D_OFF; } ret STR_D_OFF; }
+    if (is_load) { ret LDR_S_OFF; }
+    ret STR_S_OFF;
+}
+fun fp_mem_unscaled_base(use_d: bool, is_load: bool) u32 {
+    if (use_d) { if (is_load) { ret LDUR_D_FP; } ret STUR_D_FP; }
+    if (is_load) { ret LDUR_S_FP; }
+    ret STUR_S_FP;
+}
+fun fp_mem_reg_base(use_d: bool, is_load: bool) u32 {
+    if (use_d) { if (is_load) { ret LDR_D_REG; } ret STR_D_REG; }
+    if (is_load) { ret LDR_S_REG; }
+    ret STR_S_REG;
+}
+
+# emit_fp_mem: emit a width-sized scalar float load or store of vector register `rt`
+# at the legalized address `[base + off]`, choosing the scaled unsigned-offset
+# (imm12), unscaled signed-offset (imm9 / LDUR-STUR), or register-offset form. an
+# offset outside both immediate ranges is materialized into IP0 and addressed
+# `[base, IP0]`. the FP analogue of `emit_mem_access`; `width` is 4 (S) or 8 (D).
+fun emit_fp_mem(st: *EncodeState, rt: u32, base: u32, off: i64, width: u8, is_load: bool) {
+    val use_d: bool = width == 8;
+    var sh: u32 = 2;
+    if (use_d) { sh = 3; }
+    if (off >= 0) {
+        val mask: i64 = (1::i64 << sh::i64) - 1;
+        if ((off & mask) == 0 && (off >> sh::i64) <= 4095) {
+            emit_word(st, pack_ldst(fp_mem_scaled_base(use_d, is_load), rt, base, (off >> sh::i64)::u32));
+            ret;
+        }
+    }
+    if (off >= -256 && off <= 255) {
+        emit_word(st, pack_ldur(fp_mem_unscaled_base(use_d, is_load), rt, base, off::u32 & 0x1FF));
+        ret;
+    }
+    emit_movewide_seq(st, SCRATCH0, off::u64, true);
+    emit_word(st, pack_ldst_reg(fp_mem_reg_base(use_d, is_load), rt, base, SCRATCH0));
+}
+
+# emit_fp_slot_store: store vector register `rt` to a frame-slot / pointer MEM
+# destination at float `width`. the spilled-float-destination counterpart of
+# `emit_fp_mem`, resolving the MEM operand first (an indexed float spill is never
+# produced).
+fun emit_fp_slot_store(st: *EncodeState, f: *mir.MirFunction, memop: *mir.MirOperand, rt: u32, width: u8) Result[bool, str] {
+    val mr: Result[A64Mem, str] = resolve_mem(f, memop);
+    if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+    val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+    if (m.has_index) { ret err[bool, str]("encode: indexed float spill destination not expected"); }
+    emit_fp_mem(st, rt, m.base, m.off, width, false);
+    ret ok[bool, str](true);
+}
+
+# resolve_fp_source: the vector register index a float source operand contributes.
+# a physical vector register is used directly; a spilled float arrives as a frame-
+# slot MEM operand (the shared allocator leaves a spilled float in place rather than
+# reloading it through a GP temp) and is loaded into `scratch`, whose index is then
+# returned. `width` (4 / 8) sizes the load.
+fun resolve_fp_source(st: *EncodeState, f: *mir.MirFunction, op: *mir.MirOperand, scratch: u32, width: u8) Result[i32, str] {
+    if (op.kind == mir.MIR_OP_MEM) {
+        val mr: Result[A64Mem, str] = resolve_mem(f, op);
+        if (is_err[A64Mem, str](mr)) { ret err[i32, str](unwrap_err[A64Mem, str](mr)); }
+        val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+        if (m.has_index) { ret err[i32, str]("encode: indexed float spill operand not expected"); }
+        emit_fp_mem(st, scratch, m.base, m.off, width, true);
+        ret ok[i32, str](scratch::i32);
+    }
+    ret req_vec(op);
+}
+
+# fp_arith_base: the A64 two-source base word for a float arithmetic MIR opcode and
+# precision (D when `dbl`, else S).
+fun fp_arith_base(op: mir.MirOpcode, dbl: bool) u32 {
+    if (op == mir.MIR_FADD) { if (dbl) { ret FADD_D; } ret FADD_S; }
+    if (op == mir.MIR_FSUB) { if (dbl) { ret FSUB_D; } ret FSUB_S; }
+    if (op == mir.MIR_FMUL) { if (dbl) { ret FMUL_D; } ret FMUL_S; }
+    if (dbl) { ret FDIV_D; }
+    ret FDIV_S;
+}
+
+# fp_cond: the A64 condition a float comparison materializes through CSET. mirrors
+# the x86-64 UCOMISD + unsigned-SETcc mapping: equality is EQ (the unordered/NaN
+# result has Z=0, so EQ is false on NaN), inequality NE, and the relations use the
+# unordered-aware conditions an FCMP's NZCV select — `<` is MI (N=1, set only for an
+# ordered less-than; an unordered compare leaves N=0), `<=` is LS, with GT / GE for
+# the swapped relations the lowerer never emits directly (canonicalized to LT/LE).
+fun fp_cond(cc: u8) u32 {
+    if (cc == mir.FCC_EQ) { ret CC_EQ; }
+    if (cc == mir.FCC_NE) { ret CC_NE; }
+    if (cc == mir.FCC_LT) { ret CC_MI; }
+    if (cc == mir.FCC_LE) { ret CC_LS; }
+    if (cc == mir.FCC_GT) { ret CC_GT; }
+    ret CC_GE;
+}
+
+# is_mir_float_arith: true when a surviving opcode is one of the scalar float
+# arithmetic ops the encoder materializes from its dedicated MIR opcode.
+fun is_mir_float_arith(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_FADD || op == mir.MIR_FSUB ||
+        op == mir.MIR_FMUL || op == mir.MIR_FDIV;
+}
+
+# is_mir_float_conv: true when a surviving opcode is one of the float conversions.
+fun is_mir_float_conv(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_FP_TRUNC || op == mir.MIR_FP_EXT ||
+        op == mir.MIR_FP_TO_SI || op == mir.MIR_FP_TO_UI ||
+        op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP;
+}
+
+# encode_fp_arith: materialize a surviving float arithmetic op `[dst, lhs, rhs]`
+# into its single A64 instruction `op Sd|Dd, Sn|Dn, Sm|Dm`. each source resolves to
+# a vector register (a spilled source loaded into a scratch: lhs -> V31, rhs -> V30);
+# a register destination encodes directly, a spilled destination computes the result
+# in V31 and stores it to the slot. `mi.width` (4 / 8) selects the S vs D form.
+fun encode_fp_arith(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: float arithmetic missing operands"); }
+    val w: u8 = mi.width;
+    if (w != 4 && w != 8) {
+        ret err[bool, str]("internal compiler error: float arithmetic has a non-float operand width (expected 4 or 8)");
+    }
+    val dbl: bool = w == 8;
+
+    val rnr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, w);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val rmr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[2], FP_SCRATCH1, w);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+
+    val base: u32 = fp_arith_base(mi.opcode, dbl);
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    if (dst.kind == mir.MIR_OP_MEM) {
+        emit_word(st, pack_alu3(base, FP_SCRATCH0, rn, rm));
+        ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, w);
+    }
+    val rdr: Result[i32, str] = req_vec(dst);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, rn, rm));
+    ret ok[bool, str](true);
+}
+
+# encode_fp_neg: materialize a surviving float negation `[dst, src]` into `fneg
+# Sd|Dd, Sn|Dn` (an IEEE-754 sign-bit flip). the source resolves to a vector
+# register (a spilled source loaded into V31); a spilled destination computes into
+# V31 and stores back.
+fun encode_fp_neg(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: float negate missing operands"); }
+    val w: u8 = mi.width;
+    if (w != 4 && w != 8) {
+        ret err[bool, str]("internal compiler error: float negate has a non-float operand width (expected 4 or 8)");
+    }
+    val rnr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, w);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    var base: u32 = FNEG_S;
+    if (w == 8) { base = FNEG_D; }
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    if (dst.kind == mir.MIR_OP_MEM) {
+        emit_word(st, pack_alu3(base, FP_SCRATCH0, rn, 0));
+        ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, w);
+    }
+    val rdr: Result[i32, str] = req_vec(dst);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, rn, 0));
+    ret ok[bool, str](true);
+}
+
+# encode_fp_cmp: materialize a surviving float comparison `[dst, lhs, rhs]` into
+# `fcmp Sn|Dn, Sm|Dm` (set NZCV) followed by `CSET dst, cc` capturing the boolean.
+# the two float sources resolve to vector registers (spilled sources loaded into
+# V31 / V30); the destination is the GP boolean. the compared width (`mi.width`:
+# 4 -> S, 8 -> D) selects the FCMP form; the condition rides `mi.src_width` (an
+# FCC_* code) and is mapped through `fp_cond`.
+fun encode_fp_cmp(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 3) { ret err[bool, str]("encode: float comparison missing operands"); }
+    val w: u8 = mi.width;
+    if (w != 4 && w != 8) {
+        ret err[bool, str]("internal compiler error: float comparison has a non-float operand width (expected 4 or 8)");
+    }
+    val cc: u8 = mi.src_width;
+
+    val rnr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, w);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+
+    val rmr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[2], FP_SCRATCH1, w);
+    if (is_err[i32, str](rmr)) { ret err[bool, str](unwrap_err[i32, str](rmr)); }
+    val rm: u32 = unwrap_ok[i32, str](rmr)::u32;
+
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+
+    var base: u32 = FCMP_S;
+    if (w == 8) { base = FCMP_D; }
+    emit_word(st, pack_alu3(base, 0, rn, rm));
+    emit_word(st, pack_cset(CSINC_W, rd, fp_cond(cc)));
+    ret ok[bool, str](true);
+}
+
+# cvt_int_to_fp_base: the SCVTF / UCVTF base word for an int->float conversion —
+# signedness, the destination precision (D when `dbl`, else S), and the source GP
+# width (X when `src_x`, else W).
+fun cvt_int_to_fp_base(signed: bool, dbl: bool, src_x: bool) u32 {
+    if (signed) {
+        if (dbl) { if (src_x) { ret SCVTF_D_X; } ret SCVTF_D_W; }
+        if (src_x) { ret SCVTF_S_X; }
+        ret SCVTF_S_W;
+    }
+    if (dbl) { if (src_x) { ret UCVTF_D_X; } ret UCVTF_D_W; }
+    if (src_x) { ret UCVTF_S_X; }
+    ret UCVTF_S_W;
+}
+
+# cvt_fp_to_int_base: the FCVTZS / FCVTZU base word for a float->int conversion —
+# signedness, the destination GP width (X when `dst_x`, else W), and the source
+# precision (D when `src_d`, else S). round-toward-zero, mach's defined cast rule.
+fun cvt_fp_to_int_base(signed: bool, dst_x: bool, src_d: bool) u32 {
+    if (signed) {
+        if (dst_x) { if (src_d) { ret FCVTZS_X_D; } ret FCVTZS_X_S; }
+        if (src_d) { ret FCVTZS_W_D; }
+        ret FCVTZS_W_S;
+    }
+    if (dst_x) { if (src_d) { ret FCVTZU_X_D; } ret FCVTZU_X_S; }
+    if (src_d) { ret FCVTZU_W_D; }
+    ret FCVTZU_W_S;
+}
+
+# encode_fp_conv: materialize a surviving float conversion. FP_TRUNC / FP_EXT are a
+# single FCVT between S and D (float on both sides, routed through V31 when spilled).
+# SI_TO_FP / UI_TO_FP convert a GP source (sign / zero extended to a clean value for
+# a sub-word source, the W or X form for a 4 / 8-byte source) into a float via SCVTF
+# / UCVTF. FP_TO_SI / FP_TO_UI convert a float source into a GP destination via
+# FCVTZS / FCVTZU (round-to-zero). `mi.width` is the destination width, `mi.src_width`
+# the source width — for FP_TRUNC/EXT both are float widths; for the int<->float
+# forms one side is the integer width and the other the float width.
+fun encode_fp_conv(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: float conversion missing operands"); }
+    val op: mir.MirOpcode = mi.opcode;
+    val dw: u8 = mi.width;
+    val sw: u8 = mi.src_width;
+
+    if (op == mir.MIR_FP_TRUNC || op == mir.MIR_FP_EXT) {
+        val rnr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, sw);
+        if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+        val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+        var base: u32 = FCVT_D2S;
+        if (op == mir.MIR_FP_EXT) { base = FCVT_S2D; }
+        val dst: *mir.MirOperand = ?mi.operands[0];
+        if (dst.kind == mir.MIR_OP_MEM) {
+            emit_word(st, pack_alu3(base, FP_SCRATCH0, rn, 0));
+            ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, dw);
+        }
+        val rdr: Result[i32, str] = req_vec(dst);
+        if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+        emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, rn, 0));
+        ret ok[bool, str](true);
+    }
+
+    if (op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP) {
+        val signed: bool = op == mir.MIR_SI_TO_FP;
+        val gpr: Result[i32, str] = req_gpr(?mi.operands[1]);
+        if (is_err[i32, str](gpr)) { ret err[bool, str](unwrap_err[i32, str](gpr)); }
+        var gp: u32 = unwrap_ok[i32, str](gpr)::u32;
+        var src_x: bool = sw >= 8;
+        # a sub-word source carries undefined bits above its width; sign / zero
+        # extend it into IP0 to a clean 32-bit value before the W-form convert.
+        if (sw < 4) {
+            val imms: u32 = (sw::u32 * 8) - 1;
+            if (signed) { emit_word(st, pack_bitfield(SBFM_W, SCRATCH0, gp, 0, imms)); }
+            or          { emit_word(st, pack_bitfield(UBFM_W, SCRATCH0, gp, 0, imms)); }
+            gp = SCRATCH0;
+            src_x = false;
+        }
+        val dbl: bool = dw == 8;
+        val base: u32 = cvt_int_to_fp_base(signed, dbl, src_x);
+        val dst: *mir.MirOperand = ?mi.operands[0];
+        if (dst.kind == mir.MIR_OP_MEM) {
+            emit_word(st, pack_alu3(base, FP_SCRATCH0, gp, 0));
+            ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, dw);
+        }
+        val rdr: Result[i32, str] = req_vec(dst);
+        if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+        emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, gp, 0));
+        ret ok[bool, str](true);
+    }
+
+    # FP_TO_SI / FP_TO_UI: float source -> GP destination.
+    val signed: bool = op == mir.MIR_FP_TO_SI;
+    val rnr: Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, sw);
+    if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+    val rn: u32 = unwrap_ok[i32, str](rnr)::u32;
+    val rdr: Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val rd: u32 = unwrap_ok[i32, str](rdr)::u32;
+    val base: u32 = cvt_fp_to_int_base(signed, dw >= 8, sw == 8);
+    emit_word(st, pack_alu3(base, rd, rn, 0));
+    ret ok[bool, str](true);
+}
+
+# encode_fmov: materialize a float register copy or a GP<->FP `:~` bitcast (both
+# selected to FMOV), dispatching on operand register CLASS and spill state:
+#   - vector <- vector: `fmov Sd|Dd, Sn|Dn` (float copy).
+#   - vector <- GP / GP <- vector: the cross-bank `fmov Sd,Wn` / `fmov Dd,Xn` and
+#     `fmov Wd,Sn` / `fmov Xd,Dn` bit reinterprets.
+#   - a spilled side (frame-slot MEM): a float copy round-trips through V31 / FP
+#     load-store; a cross-bank bitcast whose float side is spilled is a bit-identical
+#     GP load / store of the slot (the bits are the same in either bank).
+# `mi.width` (4 / 8) selects the S/W vs D/X form throughout.
+fun encode_fmov(st: *EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    if (mi.operand_count < 2) { ret err[bool, str]("encode: fmov missing operands"); }
+    var w: u8 = mi.width;
+    if (w != 4 && w != 8) { w = 8; }
+    val dbl: bool = w == 8;
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    val src: *mir.MirOperand = ?mi.operands[1];
+
+    if (dst.kind != mir.MIR_OP_MEM && src.kind != mir.MIR_OP_MEM) {
+        val dvec: bool = reg_is_vec(dst);
+        val svec: bool = reg_is_vec(src);
+        if (dvec && svec) {
+            val rdr: Result[i32, str] = req_vec(dst);
+            if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+            val rnr: Result[i32, str] = req_vec(src);
+            if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+            var base: u32 = FMOV_S;
+            if (dbl) { base = FMOV_D; }
+            emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, unwrap_ok[i32, str](rnr)::u32, 0));
+            ret ok[bool, str](true);
+        }
+        if (dvec) {
+            # GP -> FP bit reinterpret.
+            val rdr: Result[i32, str] = req_vec(dst);
+            if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+            val rnr: Result[i32, str] = req_gpr(src);
+            if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+            var base: u32 = FMOV_S_FROM_W;
+            if (dbl) { base = FMOV_D_FROM_X; }
+            emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, unwrap_ok[i32, str](rnr)::u32, 0));
+            ret ok[bool, str](true);
+        }
+        if (svec) {
+            # FP -> GP bit reinterpret.
+            val rdr: Result[i32, str] = req_gpr(dst);
+            if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+            val rnr: Result[i32, str] = req_vec(src);
+            if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+            var base: u32 = FMOV_W_FROM_S;
+            if (dbl) { base = FMOV_X_FROM_D; }
+            emit_word(st, pack_alu3(base, unwrap_ok[i32, str](rdr)::u32, unwrap_ok[i32, str](rnr)::u32, 0));
+            ret ok[bool, str](true);
+        }
+        ret err[bool, str]("encode: fmov names two general-purpose registers");
+    }
+
+    if (dst.kind == mir.MIR_OP_MEM) {
+        if (src.kind == mir.MIR_OP_MEM) {
+            # both spilled: a float mem-to-mem copy through V31.
+            val mr: Result[A64Mem, str] = resolve_mem(f, src);
+            if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+            val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+            if (m.has_index) { ret err[bool, str]("encode: indexed float spill operand not expected"); }
+            emit_fp_mem(st, FP_SCRATCH0, m.base, m.off, w, true);
+            ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, w);
+        }
+        if (reg_is_vec(src)) {
+            # float copy, spilled destination: FP store.
+            val rnr: Result[i32, str] = req_vec(src);
+            if (is_err[i32, str](rnr)) { ret err[bool, str](unwrap_err[i32, str](rnr)); }
+            ret emit_fp_slot_store(st, f, dst, unwrap_ok[i32, str](rnr)::u32, w);
+        }
+        # GP -> FP bitcast, spilled float destination: store the GP bits directly.
+        ret emit_store_mem(st, f, dst, src, w);
+    }
+
+    # src is the MEM operand, dst a register.
+    if (reg_is_vec(dst)) {
+        # float copy, spilled source: FP load.
+        val rdr: Result[i32, str] = req_vec(dst);
+        if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+        val mr: Result[A64Mem, str] = resolve_mem(f, src);
+        if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+        val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+        if (m.has_index) { ret err[bool, str]("encode: indexed float spill operand not expected"); }
+        emit_fp_mem(st, unwrap_ok[i32, str](rdr)::u32, m.base, m.off, w, true);
+        ret ok[bool, str](true);
+    }
+    # FP -> GP bitcast, spilled float source: load the bits into the GP destination.
+    val rdr: Result[i32, str] = req_gpr(dst);
+    if (is_err[i32, str](rdr)) { ret err[bool, str](unwrap_err[i32, str](rdr)); }
+    val mr: Result[A64Mem, str] = resolve_mem(f, src);
+    if (is_err[A64Mem, str](mr)) { ret err[bool, str](unwrap_err[A64Mem, str](mr)); }
+    val m: A64Mem = unwrap_ok[A64Mem, str](mr);
+    if (m.has_index) { ret err[bool, str]("encode: indexed float spill operand not expected"); }
+    emit_mem_access(st, unwrap_ok[i32, str](rdr)::u32, m.base, m.off, w, true);
+    ret ok[bool, str](true);
+}
+
 # cmp_cond: the A64 condition a surviving comparison sentinel captures. only the
 # EQ / NE / LT / LE forms exist in the generic opcode space (the lowerer
 # canonicalizes GT/GE by swapping operands); signedness selects the signed
@@ -1374,10 +1853,10 @@ fun save_callee_gp(st: *EncodeState, f: *mir.MirFunction, store: bool) {
 # encode_mir_instr: translate one post-regalloc MIR instruction into A64 bytes,
 # recording any intra-module branch fixup or symbol relocation. the regalloc
 # parallel-copy / liveness pseudos emit nothing; the surviving comparison /
-# conditional-branch / memory / conversion opcodes expand into their byte sequences;
-# MIR_CALL emits the direct/indirect call (recording its CALL26 relocation); the
-# float, inline-asm, and varargs families are rejected loudly (an in-scope function
-# never reaches them).
+# conditional-branch / memory / conversion and scalar floating-point opcodes expand
+# into their byte sequences; MIR_CALL emits the direct/indirect call (recording its
+# CALL26 relocation); the inline-asm body is assembled; the variadic FP-register
+# spill is rejected loudly (an in-scope function never reaches it).
 fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) Result[bool, str] {
     val op: u16 = mi.opcode::u16;
 
@@ -1419,20 +1898,23 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
         ret encode_convert(st, mi);
     }
 
-    # deferred families: an in-scope function never emits these, so they are
-    # rejected loudly rather than mis-encoded.
+    # the scalar float arithmetic / negate / comparison ops survive selection keeping
+    # their dedicated MIR opcode; the encoder materializes the A64 scalar-FP byte
+    # sequence here (the operands resolved from vector registers or spilled frame
+    # slots through the FP scratch pair). they reference no branch target or
+    # relocatable symbol, so no fixup / reloc applies.
+    if (is_mir_float_arith(mi.opcode)) { ret encode_fp_arith(st, f, mi); }
+    if (mi.opcode == mir.MIR_FNEG)     { ret encode_fp_neg(st, f, mi); }
+    if (mi.opcode == mir.MIR_FCMP)     { ret encode_fp_cmp(st, f, mi); }
+
+    # the float conversions survive selection keeping their dedicated MIR_FP_* opcode;
+    # the encoder materializes the FCVT / SCVTF / UCVTF / FCVTZS / FCVTZU here.
+    if (is_mir_float_conv(mi.opcode)) { ret encode_fp_conv(st, f, mi); }
+
+    # the AL-guarded variadic FP-register spill: an in-scope function never emits it,
+    # so it is rejected loudly rather than mis-encoded.
     if (mi.opcode == mir.MIR_VA_FP_SAVE) {
         ret err[bool, str]("aarch64 varargs not implemented (Phase 4)");
-    }
-    if (mi.opcode == mir.MIR_FADD || mi.opcode == mir.MIR_FSUB ||
-        mi.opcode == mir.MIR_FMUL || mi.opcode == mir.MIR_FDIV ||
-        mi.opcode == mir.MIR_FCMP || mi.opcode == mir.MIR_FNEG) {
-        ret err[bool, str]("aarch64 floating-point ops not implemented (Phase 4)");
-    }
-    if (mi.opcode == mir.MIR_FP_TRUNC || mi.opcode == mir.MIR_FP_EXT ||
-        mi.opcode == mir.MIR_FP_TO_SI || mi.opcode == mir.MIR_FP_TO_UI ||
-        mi.opcode == mir.MIR_SI_TO_FP || mi.opcode == mir.MIR_UI_TO_FP) {
-        ret err[bool, str]("aarch64 float conversions not implemented (Phase 4)");
     }
     if (mi.opcode == mir.MIR_CALL) {
         ret encode_call(st, mi);
@@ -1454,6 +1936,7 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     if (op == arm64.NEG::u16) { ret encode_neg_mvn(st, mi, SUB_X, SUB_W); }
     if (op == arm64.MVN::u16) { ret encode_neg_mvn(st, mi, ORN_X, ORN_W); }
     if (op == arm64.MOV::u16) { ret encode_mov(st, f, mi); }
+    if (op == arm64.FMOV::u16) { ret encode_fmov(st, f, mi); }
     if (op == arm64.B::u16)   { ret encode_branch(st, fn_base, mi); }
     if (op == arm64.RET::u16) { emit_word(st, RET_WORD); ret ok[bool, str](true); }
     if (op == arm64.BRK::u16) { emit_word(st, BRK_BASE); ret ok[bool, str](true); }
@@ -2725,6 +3208,12 @@ fun tbuf(st: *EncodeState, alloc: *Allocator) {
     st.buf = buf_init(alloc);
 }
 
+# tvec: a composite vector-bank physical-register operand (V`n`), the post-regalloc
+# shape a float operand carries (the XMM class tag in the high byte of the id).
+fun tvec(n: i32) mir.MirOperand {
+    ret mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, n)::u32);
+}
+
 test "arm64.encode: three-address ALU register forms match llvm-mc" {
     var bad: i32 = 0;
     # add x0, x1, x2 ; add w0, w1, w2
@@ -3197,6 +3686,309 @@ test "arm64.encode: frame-slot LDR/STR and spill reload/store match llvm-mc" {
     mvs.operands = ?sops[0]; mvs.operand_count = 2; mvs.width = 8; mvs.src_width = 8;
     encode_mov(?st, ?f, ?mvs);
     if (read_word(?st.buf, 12) != 0xF81F83A9) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# ---- scalar floating-point encode goldens (byte-exact vs llvm-mc) ----
+
+# the four scalar FP arithmetic forms in both precisions (S = f32 width 4, D = f64
+# width 8), register operands, against `llvm-mc -triple=aarch64`.
+test "arm64.encode: scalar FP arithmetic FADD/FSUB/FMUL/FDIV (S+D) match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [3]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+
+    # fadd s0, s1, s2 = 0x1e222820
+    ops[0] = tvec(0); ops[1] = tvec(1); ops[2] = tvec(2);
+    mi.opcode = mir.MIR_FADD; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E222820) { bad = 1; }
+    # fadd d13, d17, d20 = 0x1e742a2d
+    ops[0] = tvec(13); ops[1] = tvec(17); ops[2] = tvec(20);
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E742A2D) { bad = 1; }
+    # fsub s3, s4, s5 = 0x1e253883 ; fsub d3, d4, d5 = 0x1e653883
+    ops[0] = tvec(3); ops[1] = tvec(4); ops[2] = tvec(5);
+    mi.opcode = mir.MIR_FSUB; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E253883) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E653883) { bad = 1; }
+    # fmul s6, s7, s8 = 0x1e2808e6 ; fmul d6, d7, d8 = 0x1e6808e6
+    ops[0] = tvec(6); ops[1] = tvec(7); ops[2] = tvec(8);
+    mi.opcode = mir.MIR_FMUL; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E2808E6) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E6808E6) { bad = 1; }
+    # fdiv s9, s10, s11 = 0x1e2b1949 ; fdiv d9, d10, d11 = 0x1e6b1949
+    ops[0] = tvec(9); ops[1] = tvec(10); ops[2] = tvec(11);
+    mi.opcode = mir.MIR_FDIV; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E2B1949) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E6B1949) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# FNEG (sign-bit flip) and the register-register FMOV float copy, both precisions.
+test "arm64.encode: FNEG + FMOV float copy (S+D) match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [2]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # fneg s12, s13 = 0x1e2141ac ; fneg d12, d13 = 0x1e6141ac
+    ops[0] = tvec(12); ops[1] = tvec(13);
+    mi.opcode = mir.MIR_FNEG; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_neg(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E2141AC) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_neg(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E6141AC) { bad = 1; }
+
+    # fmov s16, s17 = 0x1e204230 ; fmov d16, d17 = 0x1e604230
+    ops[0] = tvec(16); ops[1] = tvec(17);
+    mi.opcode = arm64.FMOV::u32; mi.width = 4; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E204230) { bad = 1; }
+    mi.width = 8; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E604230) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# FCMP + CSET: the compare sets NZCV and the FCC_* condition materializes the
+# boolean through CSET, mapping equality to EQ, inequality to NE, `<` to MI (ordered,
+# NaN-false), `<=` to LS, and the swapped GT / GE forms.
+test "arm64.encode: FCMP + CSET float-condition mapping matches llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [3]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+
+    # fcmp d14, d15 ; cset w0, eq  -> 0x1e6f21c0 ; 0x1a9f17e0
+    ops[0] = mir.op_preg(0); ops[1] = tvec(14); ops[2] = tvec(15);
+    mi.opcode = mir.MIR_FCMP; mi.width = 8; mi.src_width = mir.FCC_EQ; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0) != 0x1E6F21C0) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x1A9F17E0) { bad = 1; }
+
+    # cset w0, ne (FCC_NE) -> 0x1a9f07e0
+    mi.src_width = mir.FCC_NE; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi); if (read_word(?st.buf, 4) != 0x1A9F07E0) { bad = 1; }
+    # cset w0, mi (FCC_LT) -> 0x1a9f57e0
+    mi.src_width = mir.FCC_LT; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi); if (read_word(?st.buf, 4) != 0x1A9F57E0) { bad = 1; }
+    # cset w0, ls (FCC_LE) -> 0x1a9f87e0
+    mi.src_width = mir.FCC_LE; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi); if (read_word(?st.buf, 4) != 0x1A9F87E0) { bad = 1; }
+    # cset w0, gt (FCC_GT) -> 0x1a9fd7e0
+    mi.src_width = mir.FCC_GT; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi); if (read_word(?st.buf, 4) != 0x1A9FD7E0) { bad = 1; }
+    # cset w0, ge (FCC_GE) -> 0x1a9fb7e0
+    mi.src_width = mir.FCC_GE; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi); if (read_word(?st.buf, 4) != 0x1A9FB7E0) { bad = 1; }
+
+    # s-form: fcmp s21, s9 ; cset w3, mi  -> 0x1e2922a0 ; 0x1a9f57e3
+    ops[0] = mir.op_preg(3); ops[1] = tvec(21); ops[2] = tvec(9);
+    mi.width = 4; mi.src_width = mir.FCC_LT; st.buf.len = 0;
+    encode_fp_cmp(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0) != 0x1E2922A0) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x1A9F57E3) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# int -> float (SCVTF / UCVTF) across signedness, destination precision (S/D), and
+# source GP width (W = 4 / X = 8).
+test "arm64.encode: int->float SCVTF/UCVTF match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [2]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # scvtf s0,w1 / d0,w1 / s0,x1 / d0,x1
+    ops[0] = tvec(0); ops[1] = mir.op_preg(1);
+    mi.opcode = mir.MIR_SI_TO_FP;
+    mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E220020) { bad = 1; }
+    mi.width = 8; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E620020) { bad = 1; }
+    mi.width = 4; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E220020) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E620020) { bad = 1; }
+    # ucvtf s0,w1 / d0,w1 / s0,x1 / d0,x1
+    mi.opcode = mir.MIR_UI_TO_FP;
+    mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E230020) { bad = 1; }
+    mi.width = 8; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E630020) { bad = 1; }
+    mi.width = 4; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E230020) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E630020) { bad = 1; }
+    # register-field exercise: scvtf s7,w9 = 0x1e220127 ; scvtf d22,x13 = 0x9e6201b6
+    ops[0] = tvec(7); ops[1] = mir.op_preg(9);
+    mi.opcode = mir.MIR_SI_TO_FP; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E220127) { bad = 1; }
+    ops[0] = tvec(22); ops[1] = mir.op_preg(13);
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E6201B6) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# float -> int (FCVTZS / FCVTZU, round-toward-zero) across signedness, destination
+# GP width (W/X), and source precision (S/D).
+test "arm64.encode: float->int FCVTZS/FCVTZU match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [2]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # fcvtzs w0,s1 / x0,s1 / w0,d1 / x0,d1
+    ops[0] = mir.op_preg(0); ops[1] = tvec(1);
+    mi.opcode = mir.MIR_FP_TO_SI;
+    mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E380020) { bad = 1; }
+    mi.width = 8; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E380020) { bad = 1; }
+    mi.width = 4; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E780020) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E780020) { bad = 1; }
+    # fcvtzu w0,s1 / x0,s1 / w0,d1 / x0,d1
+    mi.opcode = mir.MIR_FP_TO_UI;
+    mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E390020) { bad = 1; }
+    mi.width = 8; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E390020) { bad = 1; }
+    mi.width = 4; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E790020) { bad = 1; }
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E790020) { bad = 1; }
+    # register-field exercise: fcvtzs w9,s7 = 0x1e3800e9 ; fcvtzs x13,d22 = 0x9e7802cd
+    ops[0] = mir.op_preg(9); ops[1] = tvec(7);
+    mi.opcode = mir.MIR_FP_TO_SI; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E3800E9) { bad = 1; }
+    ops[0] = mir.op_preg(13); ops[1] = tvec(22);
+    mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E7802CD) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# FCVT between single and double (FP_EXT widens, FP_TRUNC narrows) and the GP<->FP
+# bitcast FMOV forms.
+test "arm64.encode: FCVT S<->D and GP<->FP bitcast FMOV match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [2]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # fcvt d18, s19 (FP_EXT, f32->f64) = 0x1e22c272
+    ops[0] = tvec(18); ops[1] = tvec(19);
+    mi.opcode = mir.MIR_FP_EXT; mi.width = 8; mi.src_width = 4; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E22C272) { bad = 1; }
+    # fcvt s18, d19 (FP_TRUNC, f64->f32) = 0x1e624272
+    mi.opcode = mir.MIR_FP_TRUNC; mi.width = 4; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E624272) { bad = 1; }
+
+    # GP->FP bitcast: fmov s0,w1 = 0x1e270020 ; fmov d0,x1 = 0x9e670020
+    ops[0] = tvec(0); ops[1] = mir.op_preg(1);
+    mi.opcode = arm64.FMOV::u32; mi.width = 4; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E270020) { bad = 1; }
+    mi.width = 8; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E670020) { bad = 1; }
+    # FP->GP bitcast: fmov w0,s1 = 0x1e260020 ; fmov x0,d1 = 0x9e660020
+    ops[0] = mir.op_preg(0); ops[1] = tvec(1);
+    mi.width = 4; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E260020) { bad = 1; }
+    mi.width = 8; st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E660020) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
+# spilled float operands: the shared allocator leaves a spilled float as a frame-slot
+# MEM operand, which the FP encoders route through the held-back scratch (V31 / V30)
+# — a spilled source loads in, a spilled destination computes in V31 and stores out,
+# and a float copy reloads / stores through the FP load/store forms.
+test "arm64.encode: spilled float operands route through FP scratch (vs llvm-mc)" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # one spill slot for value id 100 at offset -8.
+    var slots: [1]mir.MirSlot;
+    slots[0].value  = 100;
+    slots[0].kind   = mir.SLOT_SPILL;
+    slots[0].offset = -8;
+    slots[0].size   = 8;
+    slots[0].align  = 8;
+    var f: mir.MirFunction;
+    f.frame.slots      = ?slots[0];
+    f.frame.slot_count = 1;
+
+    var ops: [3]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+
+    # spilled lhs: ldur d31,[x29,#-8] ; fadd d0, d31, d2
+    ops[0] = tvec(0); ops[1] = mir.op_mem_slot(100, 0); ops[2] = tvec(2);
+    mi.opcode = mir.MIR_FADD; mi.width = 8; mi.src_width = 8; st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0) != 0xFC5F83BF) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x1E622BE0) { bad = 1; }
+
+    # spilled dst: fadd d31, d1, d2 ; stur d31,[x29,#-8]
+    ops[0] = mir.op_mem_slot(100, 0); ops[1] = tvec(1); ops[2] = tvec(2);
+    st.buf.len = 0;
+    encode_fp_arith(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0) != 0x1E62283F) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0xFC1F83BF) { bad = 1; }
+
+    # float copy spill reload: ldur d5,[x29,#-8]
+    var mv: mir.MirInstr;
+    var mops: [2]mir.MirOperand;
+    mv.operands = ?mops[0]; mv.operand_count = 2; mv.width = 8;
+    mops[0] = tvec(5); mops[1] = mir.op_mem_slot(100, 0);
+    st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mv); if (read_word(?st.buf, 0) != 0xFC5F83A5) { bad = 1; }
+    # float copy spill store: stur d5,[x29,#-8]
+    mops[0] = mir.op_mem_slot(100, 0); mops[1] = tvec(5);
+    st.buf.len = 0;
+    encode_fmov(?st, ?f, ?mv); if (read_word(?st.buf, 0) != 0xFC1F83A5) { bad = 1; }
 
     buf_dnit(?st.buf);
     ret bad;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -157,6 +157,10 @@ val STP_PRE_X:  u32 = 0xA9800000;
 val LDP_POST_X: u32 = 0xA8C00000;
 val STP_OFF_X:  u32 = 0xA9000000;
 val LDP_OFF_X:  u32 = 0xA9400000;
+# the 64-bit SIMD&FP signed-offset pair forms (callee-saved D8-D15 spills): the load
+# bit (0x400000) distinguishes LDP from STP, the FP twins of STP_OFF_X / LDP_OFF_X.
+val STP_OFF_D:  u32 = 0x6D000000;
+val LDP_OFF_D:  u32 = 0x6D400000;
 val STR_OFF_X:  u32 = 0xF9000000;
 val LDR_OFF_X:  u32 = 0xF9400000;
 # single-register load/store base words by access size, for the three addressing
@@ -1789,7 +1793,9 @@ fun align16(n: u32) u32 {
 # `SUB SP` and the byte stream matches the verified Phase 2b leaf output exactly.
 fun frame_subsize(f: *mir.MirFunction) u32 {
     val gp_bytes: u32 = popcount32(f.callee_mask) * 8;
-    val fp_bytes: u32 = popcount32(f.callee_mask_fp) * 16;
+    # only the low 64 bits (Dn) of V8-V15 are callee-saved under AAPCS64, so each FP
+    # callee-save occupies 8 bytes (a D register), not a full 16-byte Q register.
+    val fp_bytes: u32 = popcount32(f.callee_mask_fp) * 8;
     ret align16(gp_bytes + fp_bytes + f.frame.size + f.frame.outgoing_size);
 }
 
@@ -1819,23 +1825,26 @@ fun emit_sp_sub(st: *EncodeState, subsize: u32) {
 # x29, sp, #0`) pins the frame pointer at the record, and — when the frame needs
 # more — `SUB SP, SP, #subsize` allocates the locals / spills / callee-save / outgoing
 # region. callee-saved GP registers are then saved in STP/LDP pairs (a trailing odd
-# one with STUR) at x29-relative offsets just below the local frame. when `subsize`
-# is 0 (a leaf with no frame) the `SUB SP` and the callee-save stores are skipped, so
-# the output is byte-identical to Phase 2b's `stp ; mov x29, sp`.
+# one with STUR) at x29-relative offsets just below the local frame, then the callee-
+# saved FP registers (D8-D15) in the area just below them. when `subsize` is 0 (a leaf
+# with no frame) the `SUB SP` and the callee-save stores are skipped, so the output is
+# byte-identical to Phase 2b's `stp ; mov x29, sp`.
 fun emit_prologue(st: *EncodeState, f: *mir.MirFunction, subsize: u32) {
     emit_word(st, pack_ldstp(STP_PRE_X, 29, 30, ZR, (0::u32 - 2) & 0x7F));
     emit_word(st, pack_addsub_imm(ADDI_X, 29, ZR, 0, 0));
     if (subsize > 0) { emit_sp_sub(st, subsize); }
     save_callee_gp(st, f, true);
+    save_callee_fp(st, f, true);
 }
 
-# emit_epilogue: the AArch64 record-at-top epilogue. it restores the callee-saved GP
-# registers (x29-relative, mirroring the prologue), deallocates the frame with `MOV
-# SP, X29` (an `add sp, x29, #0`, which reverses any `SUB SP` regardless of size),
-# then reloads the record with `LDP X29, X30, [SP], #16`. the RET that follows
-# returns through X30. when `subsize` is 0 the `MOV SP, X29` is skipped, so the leaf
-# output is byte-identical to Phase 2b's `ldp ; ret`.
+# emit_epilogue: the AArch64 record-at-top epilogue. it restores the callee-saved FP
+# then GP registers (x29-relative, reversing the prologue's save order), deallocates
+# the frame with `MOV SP, X29` (an `add sp, x29, #0`, which reverses any `SUB SP`
+# regardless of size), then reloads the record with `LDP X29, X30, [SP], #16`. the RET
+# that follows returns through X30. when `subsize` is 0 the `MOV SP, X29` is skipped,
+# so the leaf output is byte-identical to Phase 2b's `ldp ; ret`.
 fun emit_epilogue(st: *EncodeState, f: *mir.MirFunction, subsize: u32) {
+    save_callee_fp(st, f, false);
     save_callee_gp(st, f, false);
     if (subsize > 0) {
         # mov sp, x29  (add sp, x29, #0)
@@ -1894,6 +1903,50 @@ fun save_callee_gp(st: *EncodeState, f: *mir.MirFunction, store: bool) {
     if ((n & 1) == 1) {
         val single_off: i32 = 0 - (anchor + (16 * num_pairs)::i32 - 8);
         emit_mem_access(st, regs[n - 1], base_reg, single_off::i64, 8, !store);
+    }
+}
+
+# save_callee_fp: save (or restore) the callee-saved FP registers `callee_mask_fp`
+# selects (only the low 64 bits / Dn of V8-V15 are callee-saved under AAPCS64), in
+# ascending order, in the FP-save area that sits just below the GP callee-save area.
+# the mask bits are the raw V-register indices (V8 = bit 8), used directly in the
+# D-register STP/LDP pairs (a trailing odd one with STUR/LDUR). it addresses x29-
+# relatively, or through an IP0 anchor when the frame is past the imm7 reach — the FP
+# twin of save_callee_gp.
+fun save_callee_fp(st: *EncodeState, f: *mir.MirFunction, store: bool) {
+    var regs: [32]u32;
+    var n: u32 = 0;
+    var r: u32 = 0;
+    for (r < 32) {
+        if ((f.callee_mask_fp & (1::u32 << r)) != 0) { regs[n] = r; n = n + 1; }
+        r = r + 1;
+    }
+    if (n == 0) { ret; }
+
+    val fs: i32 = f.frame.size::i32;
+    val gp_bytes: u32 = popcount32(f.callee_mask) * 8;
+    val fp_bytes: u32 = n * 8;
+    val num_pairs: u32 = n / 2;
+
+    var base_reg: u32 = 29;
+    var anchor: i32 = fs + gp_bytes::i32 + 16;
+    if (f.frame.size + gp_bytes + fp_bytes > MAX_CALLEE_SAVE_REACH) {
+        emit_add_imm(st, SCRATCH0, 29, 0 - ((fs + gp_bytes::i32 + 16)::i64));
+        base_reg = SCRATCH0;
+        anchor = 0;
+    }
+
+    var p: u32 = 0;
+    for (p < num_pairs) {
+        val base_off: i32 = 0 - (anchor + (16 * p)::i32);
+        val imm7: u32 = (base_off / 8)::u32 & 0x7F;
+        if (store) { emit_word(st, pack_ldstp(STP_OFF_D, regs[2 * p], regs[2 * p + 1], base_reg, imm7)); }
+        or         { emit_word(st, pack_ldstp(LDP_OFF_D, regs[2 * p], regs[2 * p + 1], base_reg, imm7)); }
+        p = p + 1;
+    }
+    if ((n & 1) == 1) {
+        val single_off: i32 = 0 - (anchor + (16 * num_pairs)::i32 - 8);
+        emit_fp_mem(st, regs[n - 1], base_reg, single_off::i64, 8, !store);
     }
 }
 
@@ -2008,9 +2061,6 @@ fun encode_function_arm64(st: *EncodeState, f: *mir.MirFunction) Result[bool, st
     val ms: Result[bool, str] = push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
     if (is_err[bool, str](ms)) { ret ms; }
 
-    if (f.callee_mask_fp != 0) {
-        ret err[bool, str]("aarch64 callee-saved FP registers not implemented (Phase 4)");
-    }
     val subsize: u32 = frame_subsize(f);
     emit_prologue(st, f, subsize);
 
@@ -3673,6 +3723,41 @@ test "arm64.encode: non-leaf prologue/epilogue + callee-save STP/LDP match llvm-
     ret bad;
 }
 
+# the callee-saved FP registers (D8-D15) save below the GP area: their D-register
+# STP/LDP pairs (a trailing odd one with STUR/LDUR) sit just under the GP saves, the
+# FP twin of the GP path. with no GP saves the FP area abuts the local frame directly.
+test "arm64.encode: callee-save FP STP/LDP/STUR D-register prologue/epilogue match llvm-mc" {
+    var bad: i32 = 0;
+    var st: EncodeState;
+    var alloc: Allocator;
+    tbuf(?st, ?alloc);
+
+    # three FP callee-saves (v8,v9,v10), frame.size 16 -> subsize align16(24+16)=48.
+    var f: mir.MirFunction;
+    f.callee_mask = 0;
+    f.callee_mask_fp = (1::u32 << 8) | (1::u32 << 9) | (1::u32 << 10);
+    f.frame.size = 16;
+    f.frame.outgoing_size = 0;
+    if (frame_subsize(?f) != 48) { bad = 1; }
+    emit_prologue(?st, ?f, 48);
+    # stp x29,x30,[sp,#-16]! ; mov x29,sp ; sub sp,sp,#48
+    if (read_word(?st.buf, 0)  != 0xA9BF7BFD) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0x910003FD) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0xD100C3FF) { bad = 1; }
+    # stp d8,d9,[x29,#-32] ; stur d10,[x29,#-40]
+    if (read_word(?st.buf, 12) != 0x6D3E27A8) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0xFC1D83AA) { bad = 1; }
+    emit_epilogue(?st, ?f, 48);
+    # ldp d8,d9,[x29,#-32] ; ldur d10,[x29,#-40] ; mov sp,x29 ; ldp x29,x30,[sp],#16
+    if (read_word(?st.buf, 20) != 0x6D7E27A8) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0xFC5D83AA) { bad = 1; }
+    if (read_word(?st.buf, 28) != 0x910003BF) { bad = 1; }
+    if (read_word(?st.buf, 32) != 0xA8C17BFD) { bad = 1; }
+
+    buf_dnit(?st.buf);
+    ret bad;
+}
+
 # the GP callee-save pair packers, asserted directly against llvm-mc for the
 # x29-relative negative-offset forms the prologue/epilogue emit.
 test "arm64.encode: callee-save STP/LDP/STUR pair words match llvm-mc" {
@@ -3685,6 +3770,12 @@ test "arm64.encode: callee-save STP/LDP/STUR pair words match llvm-mc" {
     # stur/ldur x21,[x29,#-40] = 0xf81d83b5 / 0xf85d83b5 (imm9 = -40 & 0x1ff)
     if (pack_ldur(STUR_X, 21, 29, (0::u32 - 40) & 0x1FF) != 0xF81D83B5) { bad = 1; }
     if (pack_ldur(LDUR_X, 21, 29, (0::u32 - 40) & 0x1FF) != 0xF85D83B5) { bad = 1; }
+    # the FP D-register twins: stp/ldp d8,d9,[x29,#-16] = 0x6d3f27a8 / 0x6d7f27a8.
+    if (pack_ldstp(STP_OFF_D, 8, 9, 29, (0::u32 - 2) & 0x7F) != 0x6D3F27A8) { bad = 1; }
+    if (pack_ldstp(LDP_OFF_D, 8, 9, 29, (0::u32 - 2) & 0x7F) != 0x6D7F27A8) { bad = 1; }
+    # stur/ldur d10,[x29,#-40] = 0xfc1d83aa / 0xfc5d83aa (imm9 = -40 & 0x1ff)
+    if (pack_ldur(STUR_D_FP, 10, 29, (0::u32 - 40) & 0x1FF) != 0xFC1D83AA) { bad = 1; }
+    if (pack_ldur(LDUR_D_FP, 10, 29, (0::u32 - 40) & 0x1FF) != 0xFC5D83AA) { bad = 1; }
     ret bad;
 }
 

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -30,15 +30,23 @@
 #     one terminator so the allocator can read the condition as a use and resolve
 #     both successor edges for liveness.
 #
+# The memory opcodes (`MIR_ALLOCA`, `MIR_GEP`, `MIR_LOAD`, `MIR_STORE`) and the
+# integer width / representation conversions (`MIR_TRUNC`, `MIR_SEXT`, `MIR_ZEXT`,
+# `MIR_BITCAST`) also survive selection unchanged: their generic opcode values sit
+# above the concrete A64 opcode space, so the encoder dispatches them directly
+# (ALLOCA/GEP to ADD/SUB address arithmetic, LOAD/STORE to LDR/STR with addressing-
+# mode legalization, the conversions to SXTB/SXTH/SXTW / UXTB/UXTH / a width-sized
+# MOV) without a sentinel rewrite, and the register allocator reads operand 0 as a
+# clean def (or the memory destination for a store).
+#
 # The call / phi pseudo-opcodes (`MIR_CALL`, `MIR_CALL_RES`, `MIR_ARG`, `MIR_PHI`)
-# pass through unchanged for the shared ABI / register-allocation passes (a leaf
-# function has none, but the selector must not choke on them). The scalar float
-# arithmetic / comparison ops and the width / representation conversions also pass
-# through unchanged — their AArch64 encoding lands in a later phase (Phase 3/4);
-# selection only needs to not reject them. The variadic FP-register spill
-# (`MIR_VA_FP_SAVE`) is rejected with a Phase-4 message (a leaf function never
-# emits it). Any opcode this selector does not model fails loudly with an ICE so
-# `select` is total — every opcode path returns a definite result.
+# pass through unchanged for the shared ABI / register-allocation passes. The scalar
+# float arithmetic / comparison ops and the float conversions pass through unchanged
+# — their AArch64 encoding lands in Phase 4; selection only needs to not reject
+# them. The variadic FP-register spill (`MIR_VA_FP_SAVE`, Phase 4) and inline asm
+# (`MIR_ASM`, Phase 3c) are rejected with a phase message. Any opcode this selector
+# does not model fails loudly with an ICE so `select` is total — every opcode path
+# returns a definite result.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -184,6 +192,18 @@ fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
     # encoder materializes the `CBNZ cond, then ; B else` byte sequence.
     if (o == mir.MIR_CBR) { mi.opcode = mir.MIR_SEL_CBR; ret ok[bool, str](true); }
 
+    # memory ops survive selection unchanged (their generic opcode values are above
+    # the concrete A64 opcode space, so the encoder dispatches them without a
+    # sentinel rewrite). ALLOCA / GEP select to A64 address arithmetic (ADD / SUB),
+    # and LOAD / STORE to LDR / STR with addressing-mode legalization; operand 0
+    # stays a clean def (or the memory destination for a store), so the register
+    # allocator reads the def/use shape correctly. a frame-slot MEM base survives to
+    # the encoder, which resolves it to `[x29 + slot.offset]`.
+    if (o == mir.MIR_ALLOCA || o == mir.MIR_LOAD || o == mir.MIR_STORE ||
+        o == mir.MIR_GEP) {
+        ret ok[bool, str](true);
+    }
+
     # call / phi pseudo-opcodes survive selection unchanged. MIR_CALL is the
     # caller-saved clobber barrier the shared register allocator keys on; the
     # argument, result, and phi pseudos are resolved (or skipped) downstream. a leaf
@@ -212,6 +232,11 @@ fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
     # leaf function never emits it, so this is reported rather than modeled.
     if (o == mir.MIR_VA_FP_SAVE) {
         ret err[bool, str]("aarch64 varargs not implemented (Phase 4)");
+    }
+
+    # inline assembly lands in Phase 3c; report it rather than mis-select it.
+    if (o == mir.MIR_ASM) {
+        ret err[bool, str]("aarch64 inline asm not implemented (Phase 3c)");
     }
 
     write_opcode_ice(o);

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -29,6 +29,11 @@
 #     `CBNZ cond, then ; B else`, keeping both block targets and the condition on
 #     one terminator so the allocator can read the condition as a use and resolve
 #     both successor edges for liveness.
+#   - the division / remainder family (`MIR_DIV_*`/`MIR_REM_*` -> `MIR_SEL_DIV_*`/
+#     `MIR_SEL_REM_*`): the shared lowering emits a clean three-address `[dst,
+#     dividend, divisor]` op (AArch64 wires no fixed division register); the encoder
+#     lowers it to `SDIV`/`UDIV` (+ `MSUB` for a remainder) guarded by the defined
+#     division-by-zero / signed-overflow trap checks.
 #
 # The memory opcodes (`MIR_ALLOCA`, `MIR_GEP`, `MIR_LOAD`, `MIR_STORE`) and the
 # integer width / representation conversions (`MIR_TRUNC`, `MIR_SEXT`, `MIR_ZEXT`,
@@ -157,6 +162,17 @@ fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
     if (o == mir.MIR_SHL)   { mi.opcode = arm64.LSL::u32; ret ok[bool, str](true); }
     if (o == mir.MIR_SHR_U) { mi.opcode = arm64.LSR::u32; ret ok[bool, str](true); }
     if (o == mir.MIR_SHR_S) { mi.opcode = arm64.ASR::u32; ret ok[bool, str](true); }
+
+    # division / remainder survive selection as a three-address `[dst, dividend,
+    # divisor]` instruction (operand 0 a pure def the allocator reads directly),
+    # rewritten to a high SELECTION-OUTPUT sentinel so the encoder never confuses the
+    # generic opcode with a concrete A64 opcode of the same low value (MIR_REM_U = 6 =
+    # arm64.ORR). the encoder materializes the SDIV/UDIV (+ MSUB for a remainder) and
+    # the defined division-by-zero / signed-overflow trap checks from the sentinel.
+    if (o == mir.MIR_DIV_S) { mi.opcode = mir.MIR_SEL_DIV_S; ret ok[bool, str](true); }
+    if (o == mir.MIR_DIV_U) { mi.opcode = mir.MIR_SEL_DIV_U; ret ok[bool, str](true); }
+    if (o == mir.MIR_REM_S) { mi.opcode = mir.MIR_SEL_REM_S; ret ok[bool, str](true); }
+    if (o == mir.MIR_REM_U) { mi.opcode = mir.MIR_SEL_REM_U; ret ok[bool, str](true); }
 
     # negate and complement are single A64 instructions (no x86-64 multi-instruction
     # expansion): NEG is `sub Rd, XZR, Rm` and NOT is `mvn Rd, Rm` (`orn Rd, XZR,

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -2,23 +2,62 @@
 #
 # This is the AArch64 implementation of the ISA vtable's `select` operation,
 # reached only through `tgt.arch.select` by the shared `be.codegen.isel`
-# dispatcher. Instruction selection is not yet implemented: `select` is a total
-# function that fails loudly with an "not implemented" error so an AArch64 build
-# reaches the backend and stops here rather than miscompiling. The selector that
-# rewrites generic MIR opcodes into concrete AArch64 forms is filled in a later
-# phase; the four-file ISA shape (`arm64` defs, `arm64.register` vtable seam,
-# `arm64.isel`, `arm64.encode`) mirrors the x86-64 backend.
+# dispatcher. It is the only target-specific back-end selection phase; register
+# allocation, frame layout, and encoding are shared. `mir.lower_ir` has already
+# produced a `MirFunction` whose instructions carry *generic* MIR opcodes that
+# mirror the IR `OP_*` values, plus the call/phi pseudo-opcodes. Instruction
+# selection rewrites each generic opcode into the concrete AArch64 encoder opcode
+# this ISA owns (see `arm64` and `arm64.encode`).
+#
+# The A64 ALU is three-address (`Rd, Rn, Rm`), so unlike x86-64 the integer
+# binary ops are rewritten IN PLACE to a concrete three-address opcode rather than
+# surviving as a generic sentinel: register allocation keys an instruction's
+# def/use shape on its operands (operand 0 a pure def), not its opcode, so a
+# concrete three-address form is read correctly. Every rewrite is therefore 1:1 —
+# the operand list already matches the machine form and only `opcode` changes —
+# and no block-list rebuild is ever needed (the x86-64 NEG/NOT multi-instruction
+# expansion has no A64 analogue: NEG is a single `sub Rd, XZR, Rm` and NOT a
+# single `mvn Rd, Rm`).
+#
+# A handful of generic opcodes survive selection with a high selection-output
+# sentinel so the encoder can materialize a short byte sequence from them:
+#   - the comparison family (`MIR_CMP_*` -> `MIR_SEL_CMP_*`): the encoder lowers it
+#     to `SUBS XZR, lhs, rhs ; CSET dst, cc`, keeping operand 0 a clean boolean def
+#     the register allocator reads correctly (a flag-setting compare carries a
+#     source in operand 0, which the allocator's def convention would misread).
+#   - the conditional branch (`MIR_CBR` -> `MIR_SEL_CBR`): the encoder lowers it to
+#     `CBNZ cond, then ; B else`, keeping both block targets and the condition on
+#     one terminator so the allocator can read the condition as a use and resolve
+#     both successor edges for liveness.
+#
+# The call / phi pseudo-opcodes (`MIR_CALL`, `MIR_CALL_RES`, `MIR_ARG`, `MIR_PHI`)
+# pass through unchanged for the shared ABI / register-allocation passes (a leaf
+# function has none, but the selector must not choke on them). The scalar float
+# arithmetic / comparison ops and the width / representation conversions also pass
+# through unchanged — their AArch64 encoding lands in a later phase (Phase 3/4);
+# selection only needs to not reject them. The variadic FP-register spill
+# (`MIR_VA_FP_SAVE`) is rejected with a Phase-4 message (a leaf function never
+# emits it). Any opcode this selector does not model fails loudly with an ICE so
+# `select` is total — every opcode path returns a definite result.
 
 use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+
+use std.types.size.usize;
 
 use std.types.string.str;
 
 use std.types.result.Result;
+use std.types.result.ok;
 use std.types.result.err;
+use std.types.result.is_err;
 
 use std.allocator.Allocator;
 
+use os:     std.system.os;
 use target: mach.lang.target.resolved;
+use arm64:  mach.lang.target.isa.arm64;
 use mir:    mach.lang.be.codegen.mir;
 
 # SelectFn: the concrete signature the erased `isa.IsaVTable.select` pointer is
@@ -26,7 +65,8 @@ use mir:    mach.lang.be.codegen.mir;
 # `select` type-erased (`*u8`); the shared dispatcher casts it back to this type
 # before calling it.
 # ---
-# alloc: backing allocator used to rebuild expanded blocks' instruction lists
+# alloc: backing allocator (threaded for parity with the shared SelectFn; the
+#        AArch64 selector rewrites in place and never reallocates a block)
 # tgt:   resolved compilation target (must be AArch64)
 # fn:    the MIR function to select instructions for; mutated in place
 # ret:   ok(true) on success, or an error naming the failure
@@ -34,16 +74,146 @@ pub def SelectFn: fun(*Allocator, *target.Target, *mir.MirFunction) Result[bool,
 
 # select: select concrete AArch64 instructions for one MIR function.
 #
-# the AArch64 implementation behind the ISA vtable's `select` slot; the shared
-# `be.codegen.isel.run` dispatcher reaches it only through `tgt.arch.select`.
-# instruction selection is not yet implemented, so this fails loudly — a total
-# function that signals the unimplemented backend rather than producing wrong
-# instructions.
+# walks every block and rewrites each generic MIR opcode in place into the
+# concrete AArch64 encoder opcode (or leaves it as a surviving sentinel / pass-
+# through). fails loudly on an opcode this selector does not model. the AArch64
+# implementation behind the ISA vtable's `select` slot; reached only through
+# `tgt.arch.select` by the shared `be.codegen.isel.run` dispatcher.
 # ---
-# alloc: backing allocator (unused until selection is implemented)
+# alloc: backing allocator (unused; the AArch64 selector rewrites in place)
 # tgt:   resolved compilation target (must be AArch64)
-# fn:    the MIR function to select instructions for
-# ret:   an error reporting that AArch64 instruction selection is unimplemented
+# fn:    the MIR function to select instructions for; mutated in place
+# ret:   ok(true) on success, or an error naming the failure
 pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Result[bool, str] {
-    ret err[bool, str]("aarch64 isel not implemented");
+    if (alloc == nil) { ret err[bool, str]("isel: nil allocator"); }
+    if (tgt == nil)   { ret err[bool, str]("isel: nil target"); }
+    if (fn == nil)    { ret err[bool, str]("isel: nil mir function"); }
+
+    var bi: u32 = 0;
+    for (bi < fn.block_count) {
+        val b: *mir.MirBlock = ?fn.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < b.instr_count) {
+            val r: Result[bool, str] = rewrite(?b.instrs[ii]);
+            if (is_err[bool, str](r)) { ret r; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+
+    ret ok[bool, str](true);
+}
+
+# write_opcode_ice: writes "internal compiler error: unhandled MIR opcode <N>\n"
+# to stderr before an ICE return so the numeric opcode is visible in crash logs.
+fun write_opcode_ice(opcode: u32) {
+    os.write(os.STDERR_FD, "internal compiler error: unhandled MIR opcode ", 46);
+    var buf: [16]u8;
+    var len: usize = 0;
+    var v: u32 = opcode;
+    if (v == 0) { buf[0] = '0'; len = 1; }
+    or {
+        var tmp: [16]u8;
+        var t: usize = 0;
+        for (v > 0) { tmp[t] = (v % 10)::u8 + '0'; v = v / 10; t = t + 1; }
+        var ri: usize = 0;
+        for (ri < t) { buf[ri] = tmp[t - 1 - ri]; ri = ri + 1; }
+        len = t;
+    }
+    os.write(os.STDERR_FD, ?buf[0], len);
+    os.write(os.STDERR_FD, "\n", 1);
+}
+
+# rewrite a single generic MIR opcode in place into its concrete AArch64 encoder
+# opcode (or leave it as a surviving sentinel / pass-through). the operand list
+# already matches the machine form, so only `opcode` changes. fails loudly on an
+# opcode the AArch64 leaf backend does not model.
+fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
+    val o: mir.MirOpcode = mi.opcode;
+
+    # the three-address integer binary ALU ops rewrite to a concrete A64
+    # three-address opcode (N=1): A64 ALU is three-address, so operand 0 stays a
+    # pure def and the encoder packs one `op Rd, Rn, Rm` word (folding an immediate
+    # right operand into the immediate form or materializing it through a scratch).
+    if (o == mir.MIR_ADD) { mi.opcode = arm64.ADD::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_SUB) { mi.opcode = arm64.SUB::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_MUL) { mi.opcode = arm64.MUL::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_AND) { mi.opcode = arm64.AND::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_OR)  { mi.opcode = arm64.ORR::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_XOR) { mi.opcode = arm64.EOR::u32; ret ok[bool, str](true); }
+
+    # the shifts rewrite to a single A64 shift opcode (no x86-64 CL constraint): the
+    # encoder selects the register variant (LSLV/LSRV/ASRV) or the immediate variant
+    # (UBFM/SBFM alias) from operand 2's kind.
+    if (o == mir.MIR_SHL)   { mi.opcode = arm64.LSL::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_SHR_U) { mi.opcode = arm64.LSR::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_SHR_S) { mi.opcode = arm64.ASR::u32; ret ok[bool, str](true); }
+
+    # negate and complement are single A64 instructions (no x86-64 multi-instruction
+    # expansion): NEG is `sub Rd, XZR, Rm` and NOT is `mvn Rd, Rm` (`orn Rd, XZR,
+    # Rm`). the encoder supplies the XZR operand from the surviving `[dst, src]`.
+    if (o == mir.MIR_NEG) { mi.opcode = arm64.NEG::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_NOT) { mi.opcode = arm64.MVN::u32; ret ok[bool, str](true); }
+
+    # the register-to-register / ABI pre-coloring move selects to a plain MOV; the
+    # encoder emits `orr Rd, XZR, Rm` for a register source or a MOVZ/MOVK sequence
+    # for an immediate source.
+    if (o == mir.MIR_MOV) { mi.opcode = arm64.MOV::u32; ret ok[bool, str](true); }
+
+    # control flow. an unconditional branch selects to B; a return to RET; an
+    # unreachable terminator to a `brk #0` trap.
+    if (o == mir.MIR_BR)          { mi.opcode = arm64.B::u32;   ret ok[bool, str](true); }
+    if (o == mir.MIR_RET)         { mi.opcode = arm64.RET::u32; ret ok[bool, str](true); }
+    if (o == mir.MIR_UNREACHABLE) { mi.opcode = arm64.BRK::u32; ret ok[bool, str](true); }
+
+    # the comparison family survives selection as a single `[dst, lhs, rhs]`
+    # instruction keeping its generic opcode, rewritten to a high SELECTION-OUTPUT
+    # sentinel so the encoder never confuses it with a concrete A64 opcode of the
+    # same low value; the encoder materializes the `SUBS XZR, lhs, rhs ; CSET dst,
+    # cc` byte sequence, reading the condition (and its signedness) from the opcode.
+    if (o == mir.MIR_CMP_EQ)   { mi.opcode = mir.MIR_SEL_CMP_EQ;   ret ok[bool, str](true); }
+    if (o == mir.MIR_CMP_NE)   { mi.opcode = mir.MIR_SEL_CMP_NE;   ret ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LT_S) { mi.opcode = mir.MIR_SEL_CMP_LT_S; ret ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LT_U) { mi.opcode = mir.MIR_SEL_CMP_LT_U; ret ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LE_S) { mi.opcode = mir.MIR_SEL_CMP_LE_S; ret ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LE_U) { mi.opcode = mir.MIR_SEL_CMP_LE_U; ret ok[bool, str](true); }
+
+    # the conditional branch survives selection as a single
+    # `[cond, then_block, else_block]` instruction (high sentinel): the allocator
+    # reads `cond` as a use and both block operands as the two successor edges; the
+    # encoder materializes the `CBNZ cond, then ; B else` byte sequence.
+    if (o == mir.MIR_CBR) { mi.opcode = mir.MIR_SEL_CBR; ret ok[bool, str](true); }
+
+    # call / phi pseudo-opcodes survive selection unchanged. MIR_CALL is the
+    # caller-saved clobber barrier the shared register allocator keys on; the
+    # argument, result, and phi pseudos are resolved (or skipped) downstream. a leaf
+    # function has none, but the selector must pass them through (Phase 3 lowers calls).
+    if (o == mir.MIR_CALL || o == mir.MIR_ARG || o == mir.MIR_CALL_RES ||
+        o == mir.MIR_PHI) { ret ok[bool, str](true); }
+
+    # the scalar float arithmetic / comparison / negate ops survive selection
+    # unchanged: their AArch64 encoding lands in a later phase (Phase 3/4). a leaf
+    # integer function never emits them; selection only needs to not reject them.
+    if (o == mir.MIR_FADD || o == mir.MIR_FSUB || o == mir.MIR_FMUL ||
+        o == mir.MIR_FDIV || o == mir.MIR_FCMP || o == mir.MIR_FNEG) {
+        ret ok[bool, str](true);
+    }
+
+    # the width / representation conversions survive selection unchanged (Phase 3/4).
+    if (o == mir.MIR_TRUNC || o == mir.MIR_SEXT || o == mir.MIR_ZEXT ||
+        o == mir.MIR_BITCAST ||
+        o == mir.MIR_FP_TRUNC || o == mir.MIR_FP_EXT ||
+        o == mir.MIR_FP_TO_SI || o == mir.MIR_FP_TO_UI ||
+        o == mir.MIR_SI_TO_FP || o == mir.MIR_UI_TO_FP) {
+        ret ok[bool, str](true);
+    }
+
+    # the AL-guarded variadic FP-register spill: AArch64 varargs land in Phase 4. a
+    # leaf function never emits it, so this is reported rather than modeled.
+    if (o == mir.MIR_VA_FP_SAVE) {
+        ret err[bool, str]("aarch64 varargs not implemented (Phase 4)");
+    }
+
+    write_opcode_ice(o);
+    ret err[bool, str]("internal compiler error: unhandled MIR opcode in instruction selection");
 }

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -46,13 +46,14 @@
 #
 # The call / phi pseudo-opcodes (`MIR_CALL`, `MIR_CALL_RES`, `MIR_ARG`, `MIR_PHI`)
 # pass through unchanged for the shared ABI / register-allocation passes. The scalar
-# float arithmetic / comparison ops and the float conversions pass through unchanged
-# — their AArch64 encoding lands in Phase 4; selection only needs to not reject
-# them. Inline asm (`MIR_ASM`, Phase 3c) passes through unchanged for the encoder to
-# assemble its body. The variadic FP-register spill (`MIR_VA_FP_SAVE`, Phase 4) is
-# rejected with a phase message. Any opcode this selector does not model fails
-# loudly with an ICE so `select` is total — every opcode path returns a definite
-# result.
+# float arithmetic / comparison / negate ops and the float conversions pass through
+# unchanged (high-sentinel MIR opcodes the encoder materializes into A64 scalar-FP
+# byte sequences); a float register copy and a GP<->FP `:~` bitcast are rewritten to
+# the concrete FMOV. Inline asm (`MIR_ASM`, Phase 3c) passes through unchanged for
+# the encoder to assemble its body. The variadic FP-register spill
+# (`MIR_VA_FP_SAVE`, Phase 4) is rejected with a phase message. Any opcode this
+# selector does not model fails loudly with an ICE so `select` is total — every
+# opcode path returns a definite result.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -71,6 +72,7 @@ use std.allocator.Allocator;
 
 use os:     std.system.os;
 use target: mach.lang.target.resolved;
+use isa:    mach.lang.target.isa;
 use arm64:  mach.lang.target.isa.arm64;
 use mir:    mach.lang.be.codegen.mir;
 
@@ -108,7 +110,7 @@ pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Res
         val b: *mir.MirBlock = ?fn.blocks[bi];
         var ii: u32 = 0;
         for (ii < b.instr_count) {
-            val r: Result[bool, str] = rewrite(?b.instrs[ii]);
+            val r: Result[bool, str] = rewrite(fn, ?b.instrs[ii]);
             if (is_err[bool, str](r)) { ret r; }
             ii = ii + 1;
         }
@@ -138,11 +140,21 @@ fun write_opcode_ice(opcode: u32) {
     os.write(os.STDERR_FD, "\n", 1);
 }
 
+# operand_is_fp: true when a MIR operand names a float/vector-bank value — a float
+# vreg (read from the function's vreg classes) or a vector-class physical register
+# (an ABI argument / return pre-color, read from the composite register id's class
+# tag). drives the float-vs-GP move classification without hardcoding a register.
+fun operand_is_fp(fn: *mir.MirFunction, op: *mir.MirOperand) bool {
+    if (op.kind == mir.MIR_OP_VREG) { ret mir.vreg_is_fp(fn, op.vreg); }
+    if (op.kind == mir.MIR_OP_PREG) { ret isa.regid_class(op.preg::i32) == isa.REG_CLASS_ID_XMM; }
+    ret false;
+}
+
 # rewrite a single generic MIR opcode in place into its concrete AArch64 encoder
 # opcode (or leave it as a surviving sentinel / pass-through). the operand list
 # already matches the machine form, so only `opcode` changes. fails loudly on an
 # opcode the AArch64 leaf backend does not model.
-fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
+fun rewrite(fn: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
     val o: mir.MirOpcode = mi.opcode;
 
     # the three-address integer binary ALU ops rewrite to a concrete A64
@@ -180,10 +192,23 @@ fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
     if (o == mir.MIR_NEG) { mi.opcode = arm64.NEG::u32; ret ok[bool, str](true); }
     if (o == mir.MIR_NOT) { mi.opcode = arm64.MVN::u32; ret ok[bool, str](true); }
 
-    # the register-to-register / ABI pre-coloring move selects to a plain MOV; the
-    # encoder emits `orr Rd, XZR, Rm` for a register source or a MOVZ/MOVK sequence
-    # for an immediate source.
-    if (o == mir.MIR_MOV) { mi.opcode = arm64.MOV::u32; ret ok[bool, str](true); }
+    # the register-to-register / ABI pre-coloring move selects to a plain MOV (`orr
+    # Rd, XZR, Rm` for a register source, a MOVZ/MOVK sequence for an immediate). a
+    # FLOAT move — either operand a float vreg or a vector-class pre-color — selects
+    # to FMOV instead, whose encoder emits the S/D `fmov` and dispatches the spilled
+    # frame-slot forms by register class, so a float copy never mis-encodes as a GP
+    # move of the aliasing register index. the spill reload / store moves regalloc
+    # inserts after selection keep the generic MIR_MOV (the GP encoder handles their
+    # frame-slot operand); a spilled FLOAT operand is left in place as a frame-slot
+    # MEM the float ops resolve, so no float MIR_MOV spill reaches the GP path.
+    if (o == mir.MIR_MOV) {
+        if (operand_is_fp(fn, ?mi.operands[0]) || operand_is_fp(fn, ?mi.operands[1])) {
+            mi.opcode = arm64.FMOV::u32;
+        } or {
+            mi.opcode = arm64.MOV::u32;
+        }
+        ret ok[bool, str](true);
+    }
 
     # control flow. an unconditional branch selects to B; a return to RET; an
     # unreachable terminator to a `brk #0` trap.
@@ -228,17 +253,36 @@ fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
     if (o == mir.MIR_CALL || o == mir.MIR_ARG || o == mir.MIR_CALL_RES ||
         o == mir.MIR_PHI) { ret ok[bool, str](true); }
 
-    # the scalar float arithmetic / comparison / negate ops survive selection
-    # unchanged: their AArch64 encoding lands in a later phase (Phase 3/4). a leaf
-    # integer function never emits them; selection only needs to not reject them.
+    # the scalar float arithmetic / comparison / negate ops survive selection keeping
+    # their dedicated high-sentinel MIR opcode (0x1114+), like the integer compare /
+    # divide families: each is a clean `[dst, lhs, rhs]` (or `[dst, src]`) the
+    # register allocator reads by operand shape, and the encoder materializes the A64
+    # scalar-FP byte sequence (FADD/FSUB/FMUL/FDIV/FNEG single words; FCMP + CSET for
+    # the comparison) from the surviving opcode, sizing the S-vs-D form by `mi.width`.
     if (o == mir.MIR_FADD || o == mir.MIR_FSUB || o == mir.MIR_FMUL ||
         o == mir.MIR_FDIV || o == mir.MIR_FCMP || o == mir.MIR_FNEG) {
         ret ok[bool, str](true);
     }
 
-    # the width / representation conversions survive selection unchanged (Phase 3/4).
+    # a bit reinterpret crossing the GP and float banks (`f64 :~ i64` / `i32 :~ f32`)
+    # selects to FMOV, which transfers the raw bits between an X/W register and an S/D
+    # register; the encoder picks the direction from operand register class. a
+    # same-bank reinterpret (GP<->GP) stays MIR_BITCAST — a plain register copy the
+    # integer conversion encoder handles. a float-to-float bitcast cannot occur (a
+    # reinterpret is equal-size and the only two float widths differ).
+    if (o == mir.MIR_BITCAST) {
+        if (operand_is_fp(fn, ?mi.operands[0]) != operand_is_fp(fn, ?mi.operands[1])) {
+            mi.opcode = arm64.FMOV::u32;
+        }
+        ret ok[bool, str](true);
+    }
+
+    # the integer width conversions and the float conversions survive selection
+    # unchanged: their generic opcode values sit above the concrete A64 opcode space,
+    # so the encoder dispatches each directly (SXTB/UXTB/width-MOV for the integer
+    # forms; FCVT / SCVTF / UCVTF / FCVTZS / FCVTZU for the float forms) and the
+    # allocator reads operand 0 as a clean def.
     if (o == mir.MIR_TRUNC || o == mir.MIR_SEXT || o == mir.MIR_ZEXT ||
-        o == mir.MIR_BITCAST ||
         o == mir.MIR_FP_TRUNC || o == mir.MIR_FP_EXT ||
         o == mir.MIR_FP_TO_SI || o == mir.MIR_FP_TO_UI ||
         o == mir.MIR_SI_TO_FP || o == mir.MIR_UI_TO_FP) {

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -43,10 +43,11 @@
 # pass through unchanged for the shared ABI / register-allocation passes. The scalar
 # float arithmetic / comparison ops and the float conversions pass through unchanged
 # — their AArch64 encoding lands in Phase 4; selection only needs to not reject
-# them. The variadic FP-register spill (`MIR_VA_FP_SAVE`, Phase 4) and inline asm
-# (`MIR_ASM`, Phase 3c) are rejected with a phase message. Any opcode this selector
-# does not model fails loudly with an ICE so `select` is total — every opcode path
-# returns a definite result.
+# them. Inline asm (`MIR_ASM`, Phase 3c) passes through unchanged for the encoder to
+# assemble its body. The variadic FP-register spill (`MIR_VA_FP_SAVE`, Phase 4) is
+# rejected with a phase message. Any opcode this selector does not model fails
+# loudly with an ICE so `select` is total — every opcode path returns a definite
+# result.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -234,10 +235,11 @@ fun rewrite(mi: *mir.MirInstr) Result[bool, str] {
         ret err[bool, str]("aarch64 varargs not implemented (Phase 4)");
     }
 
-    # inline assembly lands in Phase 3c; report it rather than mis-select it.
-    if (o == mir.MIR_ASM) {
-        ret err[bool, str]("aarch64 inline asm not implemented (Phase 3c)");
-    }
+    # inline assembly survives selection unchanged: the encoder parses the asm body
+    # and emits A64 words directly (Phase 3c). MIR_ASM carries no operands the
+    # selector rewrites; its `asm_block` payload is the inline-asm clobber barrier
+    # the register allocator keys on.
+    if (o == mir.MIR_ASM) { ret ok[bool, str](true); }
 
     write_opcode_ice(o);
     ret err[bool, str]("internal compiler error: unhandled MIR opcode in instruction selection");

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -1,0 +1,49 @@
+# mach.lang.target.isa.arm64.isel: AArch64 instruction selection — the arm64 ISA's `select` entry point.
+#
+# This is the AArch64 implementation of the ISA vtable's `select` operation,
+# reached only through `tgt.arch.select` by the shared `be.codegen.isel`
+# dispatcher. Instruction selection is not yet implemented: `select` is a total
+# function that fails loudly with an "not implemented" error so an AArch64 build
+# reaches the backend and stops here rather than miscompiling. The selector that
+# rewrites generic MIR opcodes into concrete AArch64 forms is filled in a later
+# phase; the four-file ISA shape (`arm64` defs, `arm64.register` vtable seam,
+# `arm64.isel`, `arm64.encode`) mirrors the x86-64 backend.
+
+use std.types.bool.bool;
+
+use std.types.string.str;
+
+use std.types.result.Result;
+use std.types.result.err;
+
+use std.allocator.Allocator;
+
+use target: mach.lang.target.resolved;
+use mir:    mach.lang.be.codegen.mir;
+
+# SelectFn: the concrete signature the erased `isa.IsaVTable.select` pointer is
+# cast back to, matching the shared `be.codegen.isel.SelectFn`. the vtable stores
+# `select` type-erased (`*u8`); the shared dispatcher casts it back to this type
+# before calling it.
+# ---
+# alloc: backing allocator used to rebuild expanded blocks' instruction lists
+# tgt:   resolved compilation target (must be AArch64)
+# fn:    the MIR function to select instructions for; mutated in place
+# ret:   ok(true) on success, or an error naming the failure
+pub def SelectFn: fun(*Allocator, *target.Target, *mir.MirFunction) Result[bool, str];
+
+# select: select concrete AArch64 instructions for one MIR function.
+#
+# the AArch64 implementation behind the ISA vtable's `select` slot; the shared
+# `be.codegen.isel.run` dispatcher reaches it only through `tgt.arch.select`.
+# instruction selection is not yet implemented, so this fails loudly — a total
+# function that signals the unimplemented backend rather than producing wrong
+# instructions.
+# ---
+# alloc: backing allocator (unused until selection is implemented)
+# tgt:   resolved compilation target (must be AArch64)
+# fn:    the MIR function to select instructions for
+# ret:   an error reporting that AArch64 instruction selection is unimplemented
+pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Result[bool, str] {
+    ret err[bool, str]("aarch64 isel not implemented");
+}

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -1,0 +1,37 @@
+# mach.lang.target.isa.arm64.printer: AArch64 assembly text printer — the arm64 ISA's `emit_asm` entry point.
+#
+# This is the AArch64 implementation of the ISA vtable's `emit_asm` operation,
+# reached only through `tgt.arch.emit_asm` by the shared `be.codegen.encode.print_asm`
+# dispatcher. The assembly-text printer is not yet implemented; the ISA leaves its
+# `emit_asm` slot nil, which the dispatcher treats as a clean no-op (no `.s` file
+# for an AArch64 target). This stub completes the four-file ISA shape and is wired
+# into the build graph so it stays type-checked; a later phase fills in the printer
+# and points the vtable slot at `print_asm_arm64`.
+
+use std.types.bool.bool;
+
+use std.types.string.str;
+
+use std.types.result.Result;
+use std.types.result.err;
+
+use writer: std.io.writer;
+
+use target: mach.lang.target.resolved;
+use mir:    mach.lang.be.codegen.mir;
+
+# print_asm_arm64: format a fully-resolved MIR module as AArch64 assembly text.
+#
+# the `emit_asm` entry point shape the arm64 ISA will register; matches the shared
+# `be.codegen.encode.PrintAsmFn`. not yet implemented, so this fails loudly. the
+# ISA currently wires `emit_asm` to nil (the dispatcher's clean no-op), so this is
+# never reached in Phase 1; it exists so the four-file shape is complete and a
+# later phase only flips the vtable slot.
+# ---
+# tgt: resolved compilation target
+# m:   the fully-resolved MIR module to format
+# out: destination writer
+# ret: an error reporting that the AArch64 printer is unimplemented
+pub fun print_asm_arm64(tgt: *target.Target, m: *mir.MirModule, out: *writer.Writer) Result[bool, str] {
+    ret err[bool, str]("aarch64 emit_asm not implemented");
+}

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -61,9 +61,10 @@ var arm64_reload_scratch_regs: [3]isa.Register;
 # the `select` and `encode` operation entry points are the AArch64 instruction
 # selector (`arm64/isel.mach`) and byte encoder (`arm64/encode.mach`), stored
 # type-erased (`*u8`) and cast back to their `SelectFn` / `EncodeFn` signatures by
-# the shared `be.codegen.isel` / `be.codegen.encode` dispatchers. both currently
-# fail loudly with a "not implemented" error, so an AArch64 build reaches the
-# backend and stops there rather than at composition. `emit_asm` is nil — the
+# the shared `be.codegen.isel` / `be.codegen.encode` dispatchers. both implement
+# the leaf-integer backend (Phase 2b): a leaf integer function compiles to byte-
+# correct AArch64; the deferred families (calls, floats, conversions, varargs,
+# spills) fail loudly rather than emit wrong bytes. `emit_asm` is nil — the
 # dispatcher's clean no-op for an ISA with no assembly printer; `arm64.printer`
 # carries the stub the later phase wires here. `asm_clobbers` is nil, which the
 # allocator treats conservatively.

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -66,8 +66,9 @@ var arm64_reload_scratch_regs: [3]isa.Register;
 # correct AArch64; the deferred families (calls, floats, conversions, varargs,
 # spills) fail loudly rather than emit wrong bytes. `emit_asm` is nil — the
 # dispatcher's clean no-op for an ISA with no assembly printer; `arm64.printer`
-# carries the stub the later phase wires here. `asm_clobbers` is nil, which the
-# allocator treats conservatively.
+# carries the stub the later phase wires here. `asm_clobbers` infers the registers an
+# inline-asm body writes, so an asm function clobbering only caller-saved registers
+# (e.g. `_start`) is not framed — its body reads the unmodified entry stack.
 # ---
 # reg: the ISA registry to install the vtable into
 # ret: true on success
@@ -116,7 +117,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) Result[bool, str] {
     # no assembly printer yet: nil is the dispatcher's clean no-op. the later phase
     # points this at `arm64printer.print_asm_arm64::*u8`.
     arm64_vtable.emit_asm           = nil;
-    arm64_vtable.asm_clobbers       = nil;
+    arm64_vtable.asm_clobbers       = arm64encode.asm_clobbers::*u8;
     arm64_vtable.reserved_regs      = ?arm64_reserved_regs[0];
     arm64_vtable.reserved_reg_count = 3;
     arm64_vtable.reload_scratch_regs  = ?arm64_reload_scratch_regs[0];

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -1,0 +1,140 @@
+# mach.lang.target.isa.arm64.register: AArch64 ISA vtable registration.
+#
+# this is the composition seam for the AArch64 backend: it imports the ISA
+# definitions (`arm64`), the instruction selector (`arm64.isel`), and the byte
+# encoder (`arm64.encode`), and wires their entry points into an `IsaVTable`
+# installed in the registry. it lives in its own module — apart from the `arm64`
+# definitions the isel/encode modules import — so wiring the children into the
+# parent does not close an import cycle. it mirrors `isa.x64.register`.
+
+use std.types.result.Result;
+use std.types.result.ok;
+
+use std.types.bool.bool;
+use std.types.bool.true;
+
+use std.types.string.str;
+
+use isa:          mach.lang.target.isa;
+use arm64:        mach.lang.target.isa.arm64;
+use arm64isel:    mach.lang.target.isa.arm64.isel;
+use arm64encode:  mach.lang.target.isa.arm64.encode;
+# the printer stub: `emit_asm` is nil for now (the dispatcher's no-op for an ISA
+# with no assembly printer), so this is imported to keep the stub in the build
+# graph and type-checked until the later phase points `emit_asm` at it.
+use arm64printer: mach.lang.target.isa.arm64.printer;
+
+# process-global storage for the AArch64 vtable and its register classes. written
+# once by `register_arm64` and referenced (borrowed) by the vtable installed into
+# the ISA registry; lives for the lifetime of the process.
+var arm64_vtable: isa.IsaVTable;
+var arm64_classes: [3]isa.RegClass;
+
+# the registers the allocator must never assign: the stack pointer (SP), the frame
+# pointer (FP/X29), and the link register (LR/X30, which holds the return address).
+# referenced (borrowed) by the `reserved_regs` field of the installed ISA vtable;
+# lives for the process lifetime. filled by `register_arm64`.
+var arm64_reserved_regs: [3]isa.Register;
+
+# the caller-saved GP registers the allocator reserves from value allocation and
+# draws spill-reload temporaries from (X9/X10/X11). a single high-pressure
+# instruction can reload its memory base, scaled index, and value operands at
+# once, so three temporaries cover the worst case. these are temporary (caller-
+# saved) AAPCS64 registers, distinct from the IP0/IP1 (`scratch_reg`/`scratch_reg2`)
+# the encoder claims for address materialization and the two-register lowering
+# sequences. referenced (borrowed) by the `reload_scratch_regs` field of the
+# installed vtable; lives for the process lifetime. filled by `register_arm64`.
+var arm64_reload_scratch_regs: [3]isa.Register;
+
+# register_arm64: build and install the AArch64 ISA vtable.
+#
+# sets the architecture and register-class names as immutable `str` constants,
+# fills the three register classes (gpr 64×31 for X0–X30, vector 128×31 for V0–V30
+# with V31 held back as the FP scratch, flags 64×1), populates the vtable with the
+# pointer width (8), the reserved registers (SP/FP/LR), the reload-scratch pool
+# (X9/X10/X11), the scratch register identities (IP0/IP1 and the composite V31 FP
+# scratch), the frame/stack pointers (FP/SP), and -1 for the division / shift
+# register identities (AArch64 wires none), and installs it into `reg`.
+# idempotent: the registry entry is write-once. must be invoked at compiler startup
+# before `target.select` requests an AArch64 target.
+#
+# the `select` and `encode` operation entry points are the AArch64 instruction
+# selector (`arm64/isel.mach`) and byte encoder (`arm64/encode.mach`), stored
+# type-erased (`*u8`) and cast back to their `SelectFn` / `EncodeFn` signatures by
+# the shared `be.codegen.isel` / `be.codegen.encode` dispatchers. both currently
+# fail loudly with a "not implemented" error, so an AArch64 build reaches the
+# backend and stops there rather than at composition. `emit_asm` is nil — the
+# dispatcher's clean no-op for an ISA with no assembly printer; `arm64.printer`
+# carries the stub the later phase wires here. `asm_clobbers` is nil, which the
+# allocator treats conservatively.
+# ---
+# reg: the ISA registry to install the vtable into
+# ret: true on success
+pub fun register_arm64(reg: *isa.IsaRegistry) Result[bool, str] {
+
+    arm64_classes[0].name      = "gpr";
+    arm64_classes[0].bit_width = 64;
+    arm64_classes[0].count     = arm64.GPR_COUNT::u32;
+
+    # the vector bank exposes only V0–V30 (count 31) to the allocator. V31
+    # (FP_SCRATCH_REG) is held back as the fixed FP scratch register the float-op
+    # backend loads operands into, so a live float vreg can never occupy it and be
+    # clobbered — the AArch64 analogue of x86-64 holding XMM14/XMM15 back from the
+    # SSE value pool.
+    arm64_classes[1].name      = "vector";
+    arm64_classes[1].bit_width = 128;
+    arm64_classes[1].count     = arm64.VECTOR_COUNT::u32;
+
+    arm64_classes[2].name      = "flags";
+    arm64_classes[2].bit_width = 64;
+    arm64_classes[2].count     = 1;
+
+    arm64_reserved_regs[0].id   = arm64.SP;
+    arm64_reserved_regs[0].size = 8;
+    arm64_reserved_regs[1].id   = arm64.FP;
+    arm64_reserved_regs[1].size = 8;
+    arm64_reserved_regs[2].id   = arm64.LR;
+    arm64_reserved_regs[2].size = 8;
+
+    arm64_reload_scratch_regs[0].id   = arm64.X9;
+    arm64_reload_scratch_regs[0].size = 8;
+    arm64_reload_scratch_regs[1].id   = arm64.X10;
+    arm64_reload_scratch_regs[1].size = 8;
+    arm64_reload_scratch_regs[2].id   = arm64.X11;
+    arm64_reload_scratch_regs[2].size = 8;
+
+    arm64_vtable.id                 = isa.ARCH_AARCH64;
+    arm64_vtable.name               = "aarch64";
+    arm64_vtable.pointer_width      = 8;
+    arm64_vtable.reg_classes        = ?arm64_classes[0];
+    arm64_vtable.reg_class_count    = 3;
+    arm64_vtable.select             = arm64isel.select::*u8;
+    arm64_vtable.encode             = arm64encode.encode_arm64::*u8;
+    # no assembly printer yet: nil is the dispatcher's clean no-op. the later phase
+    # points this at `arm64printer.print_asm_arm64::*u8`.
+    arm64_vtable.emit_asm           = nil;
+    arm64_vtable.asm_clobbers       = nil;
+    arm64_vtable.reserved_regs      = ?arm64_reserved_regs[0];
+    arm64_vtable.reserved_reg_count = 3;
+    arm64_vtable.reload_scratch_regs  = ?arm64_reload_scratch_regs[0];
+    arm64_vtable.reload_scratch_count = 3;
+    arm64_vtable.scratch_reg        = arm64.IP0;
+    arm64_vtable.scratch_reg2       = arm64.IP1;
+    # the vector scratch is a composite register id (class tag in the high byte),
+    # mirroring x86-64's FP_SCRATCH_REG — a raw bank index would read as a GP reg.
+    arm64_vtable.fp_scratch_reg     = isa.regid_make(isa.REG_CLASS_ID_XMM, arm64.V31);
+    arm64_vtable.frame_ptr_reg      = arm64.FP;
+    arm64_vtable.stack_ptr_reg      = arm64.SP;
+    # the AAPCS64 frame record stores the saved FP at [fp+0] and the saved LR at
+    # [fp+8], so incoming stack arguments start at [fp+16] — same base as x86-64.
+    arm64_vtable.incoming_arg_base  = 16;
+    # AArch64 SDIV/UDIV write a normal destination register and a register shift
+    # count rides any register, so the ISA wires no fixed division / shift
+    # register: report -1 for all three.
+    arm64_vtable.div_reg            = -1;
+    arm64_vtable.div_hi_reg         = -1;
+    arm64_vtable.shift_count_reg    = -1;
+
+    isa.register(reg, ?arm64_vtable);
+    ret ok[bool, str](true);
+}

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -77,11 +77,13 @@ pub fun register_arm64(reg: *isa.IsaRegistry) Result[bool, str] {
     arm64_classes[0].bit_width = 64;
     arm64_classes[0].count     = arm64.GPR_COUNT::u32;
 
-    # the vector bank exposes only V0–V30 (count 31) to the allocator. V31
-    # (FP_SCRATCH_REG) is held back as the fixed FP scratch register the float-op
-    # backend loads operands into, so a live float vreg can never occupy it and be
-    # clobbered — the AArch64 analogue of x86-64 holding XMM14/XMM15 back from the
-    # SSE value pool.
+    # the vector bank exposes only V0–V29 (count 30) to the allocator. V30 and V31
+    # (FP_SCRATCH_REG) are held back as the two fixed FP scratch registers the
+    # float-op encoder routes spilled operands through, so a live float vreg can
+    # never occupy one and be clobbered — the AArch64 analogue of x86-64 holding
+    # XMM14/XMM15 back from the SSE value pool. two are required: a binary float op
+    # with its destination and both sources all spilled needs two FP registers live
+    # at once to form `op Sd, Sn, Sm`, which one scratch cannot supply.
     arm64_classes[1].name      = "vector";
     arm64_classes[1].bit_width = 128;
     arm64_classes[1].count     = arm64.VECTOR_COUNT::u32;
@@ -121,8 +123,10 @@ pub fun register_arm64(reg: *isa.IsaRegistry) Result[bool, str] {
     arm64_vtable.reload_scratch_count = 3;
     arm64_vtable.scratch_reg        = arm64.IP0;
     arm64_vtable.scratch_reg2       = arm64.IP1;
-    # the vector scratch is a composite register id (class tag in the high byte),
-    # mirroring x86-64's FP_SCRATCH_REG — a raw bank index would read as a GP reg.
+    # the primary vector scratch is a composite register id (class tag in the high
+    # byte), mirroring x86-64's FP_SCRATCH_REG — a raw bank index would read as a GP
+    # reg. the encoder pairs it with V30 (the second held-back scratch) for the
+    # both-sources-spilled binary float case.
     arm64_vtable.fp_scratch_reg     = isa.regid_make(isa.REG_CLASS_ID_XMM, arm64.V31);
     arm64_vtable.frame_ptr_reg      = arm64.FP;
     arm64_vtable.stack_ptr_reg      = arm64.SP;

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -66,88 +66,26 @@ use tos:    mach.lang.target.os;
 use mir:    mach.lang.be.codegen.mir;
 use enc:    mach.lang.be.codegen.encode;
 
-# initial capacity of a freshly grown encoder byte buffer.
-val BYTEBUF_INIT_CAP: usize = 256;
-
-# a growable byte sink the encoders write machine code into. the back end
-# drains `data[0..len]` into the object image's `.text` section after every
-# function is encoded; keeping the growth bookkeeping here lets `of.Section`
-# stay a finalized container.
-# ---
-# data:  backing byte array (nil until the first byte is appended)
-# len:   number of bytes written
-# cap:   allocated capacity
-# alloc: allocator backing `data`
-pub rec ByteBuf {
-    data:  *u8;
-    len:   usize;
-    cap:   usize;
-    alloc: *Allocator;
-}
-
-# buf_init: construct an empty encoder byte buffer.
-# ---
-# alloc: allocator backing the buffer's storage
-# ret:   an empty ByteBuf
-pub fun buf_init(alloc: *Allocator) ByteBuf {
-    var buf: ByteBuf;
-    buf.data  = nil;
-    buf.len   = 0;
-    buf.cap   = 0;
-    buf.alloc = alloc;
-    ret buf;
-}
-
-# buf_dnit: free a byte buffer's backing storage.
-# ---
-# buf: buffer to destroy; safe on nil
-pub fun buf_dnit(buf: *ByteBuf) {
-    if (buf == nil) { ret; }
-    if (buf.data != nil && buf.cap > 0) {
-        deallocate[u8](buf.alloc, buf.data, buf.cap);
-        buf.data = nil;
-    }
-    buf.len = 0;
-    buf.cap = 0;
-}
-
-# emit_byte: append a single byte to the buffer, growing it if needed.
-fun emit_byte(buf: *ByteBuf, byte: u8) {
-    if (buf.len >= buf.cap) {
-        var new_cap: usize = BYTEBUF_INIT_CAP;
-        if (buf.cap > 0) { new_cap = buf.cap * 2; }
-        val res_realloc: Result[*u8, str] = reallocate[u8](
-            buf.alloc, buf.data, buf.cap, new_cap
-        );
-        if (is_err[*u8, str](res_realloc)) {
-            panic("encode: byte buffer realloc failed\n");
-        }
-        buf.data = unwrap_ok[*u8, str](res_realloc);
-        buf.cap = new_cap;
-    }
-    buf.data[buf.len] = byte;
-    buf.len = buf.len + 1;
-}
-
-# emit_u16: append 2 bytes little-endian.
-fun emit_u16(buf: *ByteBuf, value: u16) {
-    emit_byte(buf, (value & 0xFF)::u8);
-    emit_byte(buf, ((value >> 8) & 0xFF)::u8);
-}
-
-# emit_u32: append 4 bytes little-endian.
-fun emit_u32(buf: *ByteBuf, value: u32) {
-    emit_byte(buf, (value & 0xFF)::u8);
-    emit_byte(buf, ((value >> 8) & 0xFF)::u8);
-    emit_byte(buf, ((value >> 16) & 0xFF)::u8);
-    emit_byte(buf, ((value >> 24) & 0xFF)::u8);
-}
-
-# emit_u64: append 8 bytes little-endian.
-fun emit_u64(buf: *ByteBuf, value: u64) {
-    emit_u32(buf, (value & 0xFFFFFFFF)::u32);
-    emit_u32(buf, ((value >> 32) & 0xFFFFFFFF)::u32);
-}
+# the ISA-agnostic two-pass driver, its state, byte sink, and array helpers live
+# in the shared `enc` module; this backend consumes them by name (the per-ISA
+# opcode / register / displacement knowledge stays here) and supplies the two
+# `enc.EncodeHooks` — `encode_function` and `patch_branch_x86`.
+use mach.lang.be.codegen.encode.ByteBuf;
+use mach.lang.be.codegen.encode.EncodeState;
+use mach.lang.be.codegen.encode.BranchFixup;
+use mach.lang.be.codegen.encode.EncodeHooks;
+use mach.lang.be.codegen.encode.buf_init;
+use mach.lang.be.codegen.encode.buf_dnit;
+use mach.lang.be.codegen.encode.emit_byte;
+use mach.lang.be.codegen.encode.emit_u16;
+use mach.lang.be.codegen.encode.emit_u32;
+use mach.lang.be.codegen.encode.emit_u64;
+use mach.lang.be.codegen.encode.classify_refs;
+use mach.lang.be.codegen.encode.push_symbol;
+use mach.lang.be.codegen.encode.push_reloc;
+use mach.lang.be.codegen.encode.push_fixup;
+use mach.lang.be.codegen.encode.push_block;
+use mach.lang.be.codegen.encode.encode_driver;
 
 # reg_bits: low 3 bits of a register id for encoding. the id is a composite
 # register id (class tag in the high byte); the within-bank index drives the
@@ -2502,89 +2440,17 @@ fun zero_inst(inst: *isa.Inst) {
 # universal operand size — only the word-sized default.
 val DEFAULT_OPERAND_SIZE: u8 = 8;
 
-# initial capacity for the encoder driver's symbol, relocation, fixup, and
-# block-offset arrays.
-val DRIVER_INIT_CAP: u32 = 16;
-
-# a single pending branch fixup recorded in pass 1 and patched in pass 2: an
-# intra-module branch whose rel32 displacement field is at `patch_pos` and whose
-# target is block `target_block` within the function based at `fn_text_base`.
-# ---
-# patch_pos:    byte offset of the rel32 field within `.text`
-# next_ip:      byte offset of the instruction following the branch within `.text`
-# target_block: destination MIR block id (function-local)
-# fn_text_base: text offset of the owning function's first block
-rec BranchFixup {
-    patch_pos:    u32;
-    next_ip:      u32;
-    target_block: u32;
-    fn_text_base: u32;
-}
-
-# one resolved block start: a function-local block id paired with its `.text`
-# offset, used to compute branch displacements in pass 2.
-# ---
-# fn_text_base: text offset of the owning function's first block
-# block_id:     function-local MIR block id
-# offset:       byte offset of the block's first instruction within `.text`
-rec BlockOffset {
-    fn_text_base: u32;
-    block_id:     u32;
-    offset:       u32;
-}
-
-# mutable bookkeeping shared across the encoder driver's two passes. owns the
-# growable text/symbol/relocation/fixup/block-offset arrays until `run` either
-# transfers the text + symbol + relocation arrays into the returned
-# `enc.EncoderOutput` or frees everything on error.
-# ---
-# alloc:        backing allocator
-# buf:          text byte sink
-# syms:         symbol marks
-# sym_count:    number of symbol marks
-# sym_cap:      capacity of `syms`
-# relocs:       pending relocations
-# reloc_count:  number of relocations
-# reloc_cap:    capacity of `relocs`
-# fixups:       pending branch fixups
-# fixup_count:  number of fixups
-# fixup_cap:    capacity of `fixups`
-# blocks:       resolved block offsets
-# block_count:  number of block offsets
-# block_cap:    capacity of `blocks`
-# interner:     session interner; resolves inline-asm `{name}` binding names and
-#               interns symbol names referenced from inline asm into relocations
-rec EncodeState {
-    alloc:       *Allocator;
-    buf:         ByteBuf;
-    syms:        *enc.SymbolMark;
-    sym_count:   u32;
-    sym_cap:     u32;
-    relocs:      *enc.PendingReloc;
-    reloc_count: u32;
-    reloc_cap:   u32;
-    fixups:      *BranchFixup;
-    fixup_count: u32;
-    fixup_cap:   u32;
-    blocks:      *BlockOffset;
-    block_count: u32;
-    block_cap:   u32;
-    interner:    *intern.Interner;
-    abi:         *abi.AbiVTable;
-    os:          *tos.OsVTable;
-}
-
-# encode_x64: encode a fully-resolved MIR module into `.text` bytes, symbol
-# marks, and pending relocations.
+# encode_x64: the x86-64 ISA's `encode` entry point — a thin wrapper that supplies
+# the two x86-64 `enc.EncodeHooks` and runs the shared two-pass driver.
 #
-# walks every function in layout order. each function entry is recorded as a
-# `enc.SymbolMark`. instructions are translated from the post-regalloc MIR operand
-# model into the target-agnostic `isa.Inst` form and emitted through the
-# per-instruction encoder. pass 1 emits bytes (branch displacements to
-# not-yet-known blocks are left as the encoder's zero placeholders and recorded
-# as fixups); cross-function / global symbol references become `enc.PendingReloc`
-# entries placed with `x86_reloc_offset`. pass 2 patches every intra-module
-# branch displacement now that every block offset is known.
+# the ISA-general driving — state lifetime, the per-function loop, pass-2 block
+# resolution, text right-sizing, and `enc.EncoderOutput` assembly — lives in
+# `enc.encode_driver`. this backend contributes only its per-function encode
+# (`encode_function`: prologue / instruction stream / epilogue, recording symbol
+# marks, `enc.PendingReloc` entries placed with `x86_reloc_offset`, and branch
+# fixups) and its per-branch patch (`patch_branch_x86`: the rel32 overwrite). the
+# erased vtable pointer is cast back to this exact signature, so it must not
+# change.
 # ---
 # alloc: allocator backing the encoder output's owned arrays
 # tgt:   resolved target; must be x86-64. relocations are emitted with the
@@ -2592,85 +2458,31 @@ rec EncodeState {
 # m:     the fully-resolved MIR module (post isel / regalloc / frame)
 # ret:   the populated enc.EncoderOutput (owned arrays), or an error string
 pub fun encode_x64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Result[enc.EncoderOutput, str] {
-    if (tgt == nil) { ret err[enc.EncoderOutput, str]("encode: nil target"); }
-    if (m == nil)   { ret err[enc.EncoderOutput, str]("encode: nil mir module"); }
-
-    var st: EncodeState;
-    st.alloc       = m.alloc;
-    st.buf         = buf_init(m.alloc);
-    st.syms        = nil;
-    st.sym_count   = 0;
-    st.sym_cap     = 0;
-    st.relocs      = nil;
-    st.reloc_count = 0;
-    st.reloc_cap   = 0;
-    st.fixups      = nil;
-    st.fixup_count = 0;
-    st.fixup_cap   = 0;
-    st.blocks      = nil;
-    st.block_count = 0;
-    st.block_cap   = 0;
-    st.interner    = m.interner;
-    st.abi         = tgt.abi;
-    st.os          = tgt.os;
-
-    var fi: u32 = 0;
-    for (fi < m.function_len) {
-        val ef: Result[bool, str] = encode_function(?st, ?m.functions[fi]);
-        if (is_err[bool, str](ef)) {
-            free_state(?st);
-            ret err[enc.EncoderOutput, str](unwrap_err[bool, str](ef));
-        }
-        fi = fi + 1;
-    }
-
-    val pb: Result[bool, str] = patch_branches(?st);
-    if (is_err[bool, str](pb)) {
-        free_state(?st);
-        ret err[enc.EncoderOutput, str](unwrap_err[bool, str](pb));
-    }
-
-    # right-size the text buffer so its allocation length equals `text_len`: the
-    # object builder owns these bytes and frees them by `len`, so the backing
-    # allocation must match exactly rather than the byte buffer's over-allocated
-    # capacity.
-    val tr: Result[bool, str] = shrink_text(?st);
-    if (is_err[bool, str](tr)) {
-        free_state(?st);
-        ret err[enc.EncoderOutput, str](unwrap_err[bool, str](tr));
-    }
-
-    var out: enc.EncoderOutput;
-    out.text         = st.buf.data;
-    out.text_len     = st.buf.len::u32;
-    out.relocations  = st.relocs;
-    out.reloc_count  = st.reloc_count;
-    out.symbols      = st.syms;
-    out.symbol_count = st.sym_count;
-
-    # the text / symbol / relocation arrays are transferred to the output; the
-    # driver-internal fixup and block-offset arrays are released.
-    free_scratch(?st);
-    ret ok[enc.EncoderOutput, str](out);
+    var hooks: EncodeHooks;
+    hooks.encode_function = encode_function;
+    hooks.patch_branch    = patch_branch_x86;
+    ret encode_driver(alloc, tgt, m, ?hooks);
 }
 
-# shrink the text byte sink so its backing allocation length equals the number
-# of bytes written. the object builder frees the transferred `.text` buffer by
-# its `len`, so the allocation must be exactly `len` bytes wide. a no-op when the
-# buffer is already exact, empty, or unallocated.
-fun shrink_text(st: *EncodeState) Result[bool, str] {
-    if (st.buf.data == nil) { ret ok[bool, str](true); }
-    if (st.buf.len == 0) {
-        deallocate[u8](st.alloc, st.buf.data, st.buf.cap);
-        st.buf.data = nil;
-        st.buf.cap  = 0;
-        ret ok[bool, str](true);
+# patch_branch_x86: the x86-64 per-branch patch hook (pass 2). writes the resolved
+# intra-module branch displacement into its rel32 field — the distance from the
+# end of the branch (`fx.next_ip`) to the start of its target block (`target_off`),
+# overwritten as four little-endian bytes at `fx.patch_pos`. the rel32 width and
+# the `next_ip`-relative convention are x86-64's, so they live here rather than in
+# the shared driver. an out-of-range patch site is a backend bug (the site was
+# recorded when its branch was emitted), rejected loudly rather than skipped (which
+# would leave a zero rel32 branching into the first function).
+# ---
+# st:         the shared encode state (its `buf` holds the text being patched)
+# fx:         the fixup to patch
+# target_off: the `.text` offset of the resolved target block
+# ret:        ok(true) on success, or an error on an out-of-range site
+fun patch_branch_x86(st: *EncodeState, fx: *BranchFixup, target_off: u32) Result[bool, str] {
+    val disp: i32 = target_off::i32 - fx.next_ip::i32;
+    if (fx.patch_pos::usize + 4 > st.buf.len) {
+        ret err[bool, str]("encode: branch fixup site is outside the text buffer");
     }
-    if (st.buf.cap == st.buf.len) { ret ok[bool, str](true); }
-    val r: Result[*u8, str] = reallocate[u8](st.alloc, st.buf.data, st.buf.cap, st.buf.len);
-    if (is_err[*u8, str](r)) { ret err[bool, str](unwrap_err[*u8, str](r)); }
-    st.buf.data = unwrap_ok[*u8, str](r);
-    st.buf.cap  = st.buf.len;
+    patch_rel32(?st.buf, fx.patch_pos::usize, disp);
     ret ok[bool, str](true);
 }
 
@@ -4312,6 +4124,9 @@ val ASMOP_SYM:  u8 = 4;
 # same number updates `offset`, so a backward `Nb` reference always binds to the
 # nearest preceding definition.
 # ---
+# initial capacity for the inline-asm numeric-label definition / fixup arrays.
+val ASM_LABEL_INIT_CAP: u32 = 16;
+
 # number: the numeric label
 # offset: byte offset of the definition within `.text`
 rec AsmLabelDef {
@@ -4493,10 +4308,10 @@ fun asm_label_push_fixup(labels: *AsmLabelState, patch_pos: u32, next_ip: u32, n
 # grow the label-definition array (or allocate it on first use).
 fun grow_asm_label_defs(labels: *AsmLabelState) Result[bool, str] {
     if (labels.defs == nil) {
-        val r: Result[*AsmLabelDef, str] = allocate[AsmLabelDef](labels.alloc, DRIVER_INIT_CAP::usize);
+        val r: Result[*AsmLabelDef, str] = allocate[AsmLabelDef](labels.alloc, ASM_LABEL_INIT_CAP::usize);
         if (is_err[*AsmLabelDef, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelDef, str](r)); }
         labels.defs    = unwrap_ok[*AsmLabelDef, str](r);
-        labels.def_cap = DRIVER_INIT_CAP;
+        labels.def_cap = ASM_LABEL_INIT_CAP;
         ret ok[bool, str](true);
     }
     val nc: u32 = labels.def_cap * 2;
@@ -4510,10 +4325,10 @@ fun grow_asm_label_defs(labels: *AsmLabelState) Result[bool, str] {
 # grow the label-fixup array (or allocate it on first use).
 fun grow_asm_label_fixups(labels: *AsmLabelState) Result[bool, str] {
     if (labels.fixups == nil) {
-        val r: Result[*AsmLabelFixup, str] = allocate[AsmLabelFixup](labels.alloc, DRIVER_INIT_CAP::usize);
+        val r: Result[*AsmLabelFixup, str] = allocate[AsmLabelFixup](labels.alloc, ASM_LABEL_INIT_CAP::usize);
         if (is_err[*AsmLabelFixup, str](r)) { ret err[bool, str](unwrap_err[*AsmLabelFixup, str](r)); }
         labels.fixups    = unwrap_ok[*AsmLabelFixup, str](r);
-        labels.fixup_cap = DRIVER_INIT_CAP;
+        labels.fixup_cap = ASM_LABEL_INIT_CAP;
         ret ok[bool, str](true);
     }
     val nc: u32 = labels.fixup_cap * 2;
@@ -5842,74 +5657,6 @@ test "x64.encode: encode_push imm8/imm32 boundaries and out-of-range rejection" 
     ret bad;
 }
 
-# determine whether an instruction names an intra-module branch target (a
-# MIR_OP_BLOCK operand) or a relocatable symbol (a MIR_OP_SYM operand), reporting
-# the target block id / interned symbol name through the out-parameters.
-fun classify_refs(mi: *mir.MirInstr, target_block: *u32, has_block: *bool,
-                  sym: *intern.StrId, has_sym: *bool, sym_addend: *i32) {
-    var found_block: bool = false;
-    var found_sym: bool = false;
-    @has_block = false;
-    @has_sym   = false;
-    @target_block = 0;
-    @sym = intern.STR_NIL;
-    @sym_addend = 0;
-    var k: u32 = 0;
-    for (k < mi.operand_count) {
-        val op: *mir.MirOperand = ?mi.operands[k];
-        if (op.kind == mir.MIR_OP_BLOCK && found_block == false) {
-            found_block = true;
-            @has_block = true;
-            @target_block = op.imm::u32;
-        }
-        if (op.kind == mir.MIR_OP_SYM && found_sym == false) {
-            found_sym = true;
-            @has_sym = true;
-            @sym = op.sym;
-            @sym_addend = op.sym_off;
-        }
-        k = k + 1;
-    }
-}
-
-# pass 2: patch each recorded intra-module branch fixup with the rel32
-# displacement from the end of the branch to the start of its target block.
-fun patch_branches(st: *EncodeState) Result[bool, str] {
-    if (st.buf.data == nil) { ret ok[bool, str](true); }
-    var i: u32 = 0;
-    for (i < st.fixup_count) {
-        val fx: *BranchFixup = ?st.fixups[i];
-        val tr: Result[u32, str] = block_offset(st, fx.fn_text_base, fx.target_block);
-        if (is_err[u32, str](tr)) { ret err[bool, str](unwrap_err[u32, str](tr)); }
-        val target_off: u32 = unwrap_ok[u32, str](tr);
-        val disp: i32 = target_off::i32 - fx.next_ip::i32;
-        # the fixup site was recorded when its branch was emitted, so it must lie
-        # within the text buffer; an out-of-range site is a backend bug, rejected
-        # loudly rather than skipped (which would leave a zero rel32 branching into
-        # the first function).
-        if (fx.patch_pos::usize + 4 > st.buf.len) {
-            ret err[bool, str]("encode: branch fixup site is outside the text buffer");
-        }
-        patch_rel32(?st.buf, fx.patch_pos::usize, disp);
-        i = i + 1;
-    }
-    ret ok[bool, str](true);
-}
-
-# resolve a function-local block id to its `.text` offset. an unrecorded target is
-# a backend bug (a branch to a block the encoder never emitted), rejected loudly
-# rather than resolved to offset 0 (a branch into the first function's middle).
-fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) Result[u32, str] {
-    var i: u32 = 0;
-    for (i < st.block_count) {
-        if (st.blocks[i].fn_text_base == fn_base && st.blocks[i].block_id == block_id) {
-            ret ok[u32, str](st.blocks[i].offset);
-        }
-        i = i + 1;
-    }
-    ret err[u32, str]("encode: branch target block was never recorded");
-}
-
 # build an inactive (OPK_NONE) operand with no register references.
 fun none_operand() isa.Operand {
     var op: isa.Operand;
@@ -5924,156 +5671,6 @@ fun none_operand() isa.Operand {
     op.sym_id = 0;
     op.label  = nil;
     ret op;
-}
-
-# append a symbol mark, growing the symbol array on demand.
-fun push_symbol(st: *EncodeState, name: intern.StrId, offset: u32, flags: u32) Result[bool, str] {
-    if (st.sym_count >= st.sym_cap) {
-        val gr: Result[bool, str] = grow_symbols(st);
-        if (is_err[bool, str](gr)) { ret gr; }
-    }
-    st.syms[st.sym_count].name   = name;
-    st.syms[st.sym_count].offset = offset;
-    st.syms[st.sym_count].flags  = flags;
-    st.sym_count = st.sym_count + 1;
-    ret ok[bool, str](true);
-}
-
-# append a pending relocation, growing the relocation array on demand.
-fun push_reloc(st: *EncodeState, offset: u32, kind: of.RelocKind, sym: intern.StrId, addend: i32) Result[bool, str] {
-    if (st.reloc_count >= st.reloc_cap) {
-        val gr: Result[bool, str] = grow_relocs(st);
-        if (is_err[bool, str](gr)) { ret gr; }
-    }
-    st.relocs[st.reloc_count].offset = offset;
-    st.relocs[st.reloc_count].kind   = kind;
-    st.relocs[st.reloc_count].sym    = sym;
-    st.relocs[st.reloc_count].addend = addend;
-    st.reloc_count = st.reloc_count + 1;
-    ret ok[bool, str](true);
-}
-
-# append a branch fixup, growing the fixup array on demand.
-fun push_fixup(st: *EncodeState, patch_pos: u32, next_ip: u32, target_block: u32, fn_text_base: u32) Result[bool, str] {
-    if (st.fixup_count >= st.fixup_cap) {
-        val gr: Result[bool, str] = grow_fixups(st);
-        if (is_err[bool, str](gr)) { ret gr; }
-    }
-    st.fixups[st.fixup_count].patch_pos    = patch_pos;
-    st.fixups[st.fixup_count].next_ip      = next_ip;
-    st.fixups[st.fixup_count].target_block = target_block;
-    st.fixups[st.fixup_count].fn_text_base = fn_text_base;
-    st.fixup_count = st.fixup_count + 1;
-    ret ok[bool, str](true);
-}
-
-# append a resolved block offset, growing the block-offset array on demand.
-fun push_block(st: *EncodeState, fn_text_base: u32, block_id: u32, offset: u32) Result[bool, str] {
-    if (st.block_count >= st.block_cap) {
-        val gr: Result[bool, str] = grow_blocks(st);
-        if (is_err[bool, str](gr)) { ret gr; }
-    }
-    st.blocks[st.block_count].fn_text_base = fn_text_base;
-    st.blocks[st.block_count].block_id     = block_id;
-    st.blocks[st.block_count].offset       = offset;
-    st.block_count = st.block_count + 1;
-    ret ok[bool, str](true);
-}
-
-# grow the symbol-mark array (or allocate it on first use).
-fun grow_symbols(st: *EncodeState) Result[bool, str] {
-    if (st.syms == nil) {
-        val r: Result[*enc.SymbolMark, str] = allocate[enc.SymbolMark](st.alloc, DRIVER_INIT_CAP::usize);
-        if (is_err[*enc.SymbolMark, str](r)) { ret err[bool, str](unwrap_err[*enc.SymbolMark, str](r)); }
-        st.syms    = unwrap_ok[*enc.SymbolMark, str](r);
-        st.sym_cap = DRIVER_INIT_CAP;
-        ret ok[bool, str](true);
-    }
-    val nc: u32 = st.sym_cap * 2;
-    val r: Result[*enc.SymbolMark, str] = reallocate[enc.SymbolMark](st.alloc, st.syms, st.sym_cap::usize, nc::usize);
-    if (is_err[*enc.SymbolMark, str](r)) { ret err[bool, str](unwrap_err[*enc.SymbolMark, str](r)); }
-    st.syms    = unwrap_ok[*enc.SymbolMark, str](r);
-    st.sym_cap = nc;
-    ret ok[bool, str](true);
-}
-
-# grow the relocation array (or allocate it on first use).
-fun grow_relocs(st: *EncodeState) Result[bool, str] {
-    if (st.relocs == nil) {
-        val r: Result[*enc.PendingReloc, str] = allocate[enc.PendingReloc](st.alloc, DRIVER_INIT_CAP::usize);
-        if (is_err[*enc.PendingReloc, str](r)) { ret err[bool, str](unwrap_err[*enc.PendingReloc, str](r)); }
-        st.relocs    = unwrap_ok[*enc.PendingReloc, str](r);
-        st.reloc_cap = DRIVER_INIT_CAP;
-        ret ok[bool, str](true);
-    }
-    val nc: u32 = st.reloc_cap * 2;
-    val r: Result[*enc.PendingReloc, str] = reallocate[enc.PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize, nc::usize);
-    if (is_err[*enc.PendingReloc, str](r)) { ret err[bool, str](unwrap_err[*enc.PendingReloc, str](r)); }
-    st.relocs    = unwrap_ok[*enc.PendingReloc, str](r);
-    st.reloc_cap = nc;
-    ret ok[bool, str](true);
-}
-
-# grow the branch-fixup array (or allocate it on first use).
-fun grow_fixups(st: *EncodeState) Result[bool, str] {
-    if (st.fixups == nil) {
-        val r: Result[*BranchFixup, str] = allocate[BranchFixup](st.alloc, DRIVER_INIT_CAP::usize);
-        if (is_err[*BranchFixup, str](r)) { ret err[bool, str](unwrap_err[*BranchFixup, str](r)); }
-        st.fixups    = unwrap_ok[*BranchFixup, str](r);
-        st.fixup_cap = DRIVER_INIT_CAP;
-        ret ok[bool, str](true);
-    }
-    val nc: u32 = st.fixup_cap * 2;
-    val r: Result[*BranchFixup, str] = reallocate[BranchFixup](st.alloc, st.fixups, st.fixup_cap::usize, nc::usize);
-    if (is_err[*BranchFixup, str](r)) { ret err[bool, str](unwrap_err[*BranchFixup, str](r)); }
-    st.fixups    = unwrap_ok[*BranchFixup, str](r);
-    st.fixup_cap = nc;
-    ret ok[bool, str](true);
-}
-
-# grow the block-offset array (or allocate it on first use).
-fun grow_blocks(st: *EncodeState) Result[bool, str] {
-    if (st.blocks == nil) {
-        val r: Result[*BlockOffset, str] = allocate[BlockOffset](st.alloc, DRIVER_INIT_CAP::usize);
-        if (is_err[*BlockOffset, str](r)) { ret err[bool, str](unwrap_err[*BlockOffset, str](r)); }
-        st.blocks    = unwrap_ok[*BlockOffset, str](r);
-        st.block_cap = DRIVER_INIT_CAP;
-        ret ok[bool, str](true);
-    }
-    val nc: u32 = st.block_cap * 2;
-    val r: Result[*BlockOffset, str] = reallocate[BlockOffset](st.alloc, st.blocks, st.block_cap::usize, nc::usize);
-    if (is_err[*BlockOffset, str](r)) { ret err[bool, str](unwrap_err[*BlockOffset, str](r)); }
-    st.blocks    = unwrap_ok[*BlockOffset, str](r);
-    st.block_cap = nc;
-    ret ok[bool, str](true);
-}
-
-# release the driver-internal scratch arrays (fixups, block offsets) once their
-# work is done; the text / symbol / relocation arrays survive into enc.EncoderOutput.
-fun free_scratch(st: *EncodeState) {
-    if (st.fixups != nil && st.fixup_cap > 0) {
-        deallocate[BranchFixup](st.alloc, st.fixups, st.fixup_cap::usize);
-        st.fixups = nil;
-    }
-    if (st.blocks != nil && st.block_cap > 0) {
-        deallocate[BlockOffset](st.alloc, st.blocks, st.block_cap::usize);
-        st.blocks = nil;
-    }
-}
-
-# release every owned array on the error path, including the text sink and the
-# symbol / relocation arrays that would otherwise transfer into enc.EncoderOutput.
-fun free_state(st: *EncodeState) {
-    buf_dnit(?st.buf);
-    if (st.syms != nil && st.sym_cap > 0) {
-        deallocate[enc.SymbolMark](st.alloc, st.syms, st.sym_cap::usize);
-        st.syms = nil;
-    }
-    if (st.relocs != nil && st.reloc_cap > 0) {
-        deallocate[enc.PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize);
-        st.relocs = nil;
-    }
-    free_scratch(st);
 }
 
 test "x64.encode: stack probe emits the exact __chkstk page-walk body (#1395)" {

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -66,6 +66,21 @@ pub val RK_ABS32S:   RelocKind = 4;
 # target from the PE image base, used by exception/unwind tables. ELF and
 # Mach-O have no equivalent and never emit it.
 pub val RK_ADDR32NB: RelocKind = 5;
+# aarch64 ADRP page-relative high-21 bits (R_AARCH64_ADR_PREL_PG_HI21): the signed
+# page delta (Page(S+A) - Page(P)) >> 12 packed into the ADRP immlo/immhi fields.
+pub val RK_PAGE21:     RelocKind = 6;
+# aarch64 ADD low-12 (R_AARCH64_ADD_ABS_LO12_NC): (S+A) & 0xFFF into an ADD imm12;
+# pairs with RK_PAGE21 to materialize a symbol's absolute address.
+pub val RK_ADD_LO12:   RelocKind = 7;
+# aarch64 scaled LDR/STR low-12 (R_AARCH64_LDST{8,16,32,64,128}_ABS_LO12_NC): one
+# kind per access width so the access-size scale {0,1,2,3,4} comes from the kind,
+# never an instruction decode (Option B); the linker shifts ((S+A) & 0xFFF) >>
+# scale into the LDR/STR imm12. pairs with RK_PAGE21 for a folded global access.
+pub val RK_LDST8_LO12:   RelocKind = 8;
+pub val RK_LDST16_LO12:  RelocKind = 9;
+pub val RK_LDST32_LO12:  RelocKind = 10;
+pub val RK_LDST64_LO12:  RelocKind = 11;
+pub val RK_LDST128_LO12: RelocKind = 12;
 
 # object-symbol flags. combined as a bitmask in `Symbol.flags`.
 # ---
@@ -478,5 +493,12 @@ pub fun reloc_kind_name(kind: RelocKind) str {
     if (kind == RK_GOTPCREL) { ret "gotpcrel"; }
     if (kind == RK_ABS32S)   { ret "abs32s"; }
     if (kind == RK_ADDR32NB) { ret "addr32nb"; }
+    if (kind == RK_PAGE21)      { ret "page21"; }
+    if (kind == RK_ADD_LO12)    { ret "add_lo12"; }
+    if (kind == RK_LDST8_LO12)  { ret "ldst8_lo12"; }
+    if (kind == RK_LDST16_LO12) { ret "ldst16_lo12"; }
+    if (kind == RK_LDST32_LO12) { ret "ldst32_lo12"; }
+    if (kind == RK_LDST64_LO12) { ret "ldst64_lo12"; }
+    if (kind == RK_LDST128_LO12) { ret "ldst128_lo12"; }
     ret "unknown";
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3786,6 +3786,29 @@ test "coff: parse_function_unwind rejects an [r13+disp] store as a save (REX.B)"
     ret 0;
 }
 
+# the aarch64 page/lo12 reloc kinds (#1163) are ELF/aarch64-only; COFF has no
+# machine type for them and must keep them in the error path rather than
+# mis-serializing them as another type.
+test "coff: aarch64 page/lo12 reloc kinds have no COFF machine type (#1163)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var kinds: [7]of.RelocKind;
+    kinds[0] = of.RK_PAGE21;      kinds[1] = of.RK_ADD_LO12;
+    kinds[2] = of.RK_LDST8_LO12;  kinds[3] = of.RK_LDST16_LO12;
+    kinds[4] = of.RK_LDST32_LO12; kinds[5] = of.RK_LDST64_LO12;
+    kinds[6] = of.RK_LDST128_LO12;
+
+    var n: usize = 0;
+    for (n < 7) {
+        val tr: Result[u16, str] = reloc_type_for(?i, ?alloc, kinds[n]);
+        if (!is_err[u16, str](tr)) { ret 1; }
+        n = n + 1;
+    }
+    ret 0;
+}
+
 test "coff: emit rejects a relocation whose kind has no COFF machine type (#1256)" {
     var alloc: Allocator;
     page.make(?alloc);

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -99,7 +99,14 @@ val R_X86_64_32S:      u32 = 11;
 # aarch64 relocation types.
 val R_AARCH64_ABS64:  u32 = 257;
 val R_AARCH64_PREL32: u32 = 261;
+val R_AARCH64_ADR_PREL_PG_HI21: u32 = 275;
+val R_AARCH64_ADD_ABS_LO12_NC:  u32 = 277;
+val R_AARCH64_LDST8_ABS_LO12_NC:   u32 = 278;
 val R_AARCH64_CALL26: u32 = 283;
+val R_AARCH64_LDST16_ABS_LO12_NC:  u32 = 284;
+val R_AARCH64_LDST32_ABS_LO12_NC:  u32 = 285;
+val R_AARCH64_LDST64_ABS_LO12_NC:  u32 = 286;
+val R_AARCH64_LDST128_ABS_LO12_NC: u32 = 299;
 
 # ELF program header types and flags.
 val PT_LOAD:    u32 = 1;
@@ -163,6 +170,13 @@ fun reloc_type_for(itn: *intern.Interner, alloc: *Allocator, kind: of.RelocKind,
         if (kind == of.RK_ABS64) { ret ok[u32, str](R_AARCH64_ABS64); }
         if (kind == of.RK_PC32)  { ret ok[u32, str](R_AARCH64_PREL32); }
         if (kind == of.RK_PLT32) { ret ok[u32, str](R_AARCH64_CALL26); }
+        if (kind == of.RK_PAGE21)       { ret ok[u32, str](R_AARCH64_ADR_PREL_PG_HI21); }
+        if (kind == of.RK_ADD_LO12)     { ret ok[u32, str](R_AARCH64_ADD_ABS_LO12_NC); }
+        if (kind == of.RK_LDST8_LO12)   { ret ok[u32, str](R_AARCH64_LDST8_ABS_LO12_NC); }
+        if (kind == of.RK_LDST16_LO12)  { ret ok[u32, str](R_AARCH64_LDST16_ABS_LO12_NC); }
+        if (kind == of.RK_LDST32_LO12)  { ret ok[u32, str](R_AARCH64_LDST32_ABS_LO12_NC); }
+        if (kind == of.RK_LDST64_LO12)  { ret ok[u32, str](R_AARCH64_LDST64_ABS_LO12_NC); }
+        if (kind == of.RK_LDST128_LO12) { ret ok[u32, str](R_AARCH64_LDST128_ABS_LO12_NC); }
         ret err[u32, str](unsupported_kind_message(itn, alloc, kind));
     }
     if (kind == of.RK_ABS64)    { ret ok[u32, str](R_X86_64_64); }
@@ -183,6 +197,13 @@ fun reloc_kind_for(itn: *intern.Interner, alloc: *Allocator, r_type: u32) Result
     if (r_type == R_X86_64_PLT32 || r_type == R_AARCH64_CALL26) { ret ok[of.RelocKind, str](of.RK_PLT32); }
     if (r_type == R_X86_64_GOTPCREL) { ret ok[of.RelocKind, str](of.RK_GOTPCREL); }
     if (r_type == R_X86_64_32S) { ret ok[of.RelocKind, str](of.RK_ABS32S); }
+    if (r_type == R_AARCH64_ADR_PREL_PG_HI21) { ret ok[of.RelocKind, str](of.RK_PAGE21); }
+    if (r_type == R_AARCH64_ADD_ABS_LO12_NC)  { ret ok[of.RelocKind, str](of.RK_ADD_LO12); }
+    if (r_type == R_AARCH64_LDST8_ABS_LO12_NC)   { ret ok[of.RelocKind, str](of.RK_LDST8_LO12); }
+    if (r_type == R_AARCH64_LDST16_ABS_LO12_NC)  { ret ok[of.RelocKind, str](of.RK_LDST16_LO12); }
+    if (r_type == R_AARCH64_LDST32_ABS_LO12_NC)  { ret ok[of.RelocKind, str](of.RK_LDST32_LO12); }
+    if (r_type == R_AARCH64_LDST64_ABS_LO12_NC)  { ret ok[of.RelocKind, str](of.RK_LDST64_LO12); }
+    if (r_type == R_AARCH64_LDST128_ABS_LO12_NC) { ret ok[of.RelocKind, str](of.RK_LDST128_LO12); }
     ret err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
 }
 
@@ -2046,6 +2067,41 @@ test "elf: emit rejects a relocation whose kind has no ELF machine type (#1256)"
 
     if (!is_err[bool, str](em)) { ret 1; }
     if (!str_contains(unwrap_err[bool, str](em), "addr32nb")) { ret 1; }
+    ret 0;
+}
+
+# the aarch64 page/page-offset reloc kinds (#1163) map 1:1 to their R_AARCH64
+# machine types and back; each per-width LDST kind maps to a distinct
+# R_AARCH64_LDST*_ABS_LO12_NC so the linker recovers the access-size scale from the
+# kind alone (Option B).
+test "elf: aarch64 page/lo12 reloc kinds round-trip through the machine map (#1163)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var kinds: [7]of.RelocKind;
+    kinds[0] = of.RK_PAGE21;      kinds[1] = of.RK_ADD_LO12;
+    kinds[2] = of.RK_LDST8_LO12;  kinds[3] = of.RK_LDST16_LO12;
+    kinds[4] = of.RK_LDST32_LO12; kinds[5] = of.RK_LDST64_LO12;
+    kinds[6] = of.RK_LDST128_LO12;
+
+    var expect: [7]u32;
+    expect[0] = R_AARCH64_ADR_PREL_PG_HI21; expect[1] = R_AARCH64_ADD_ABS_LO12_NC;
+    expect[2] = R_AARCH64_LDST8_ABS_LO12_NC; expect[3] = R_AARCH64_LDST16_ABS_LO12_NC;
+    expect[4] = R_AARCH64_LDST32_ABS_LO12_NC; expect[5] = R_AARCH64_LDST64_ABS_LO12_NC;
+    expect[6] = R_AARCH64_LDST128_ABS_LO12_NC;
+
+    var n: usize = 0;
+    for (n < 7) {
+        val tr: Result[u32, str] = reloc_type_for(?i, ?alloc, kinds[n], isa.ARCH_AARCH64);
+        if (is_err[u32, str](tr)) { ret 1; }
+        if (unwrap_ok[u32, str](tr) != expect[n]) { ret 1; }
+
+        val kr: Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, expect[n]);
+        if (is_err[of.RelocKind, str](kr)) { ret 1; }
+        if (unwrap_ok[of.RelocKind, str](kr) != kinds[n]) { ret 1; }
+        n = n + 1;
+    }
     ret 0;
 }
 


### PR DESCRIPTION
Integration merge for the **v1.6.0** release — the aarch64-linux debut.

- Complete aarch64-linux back end (A64 encoder, AAPCS64, isel, division traps, calls/relocs/frames, inline-asm, FP) — epic #1431
- #1458 parser fix (bare cnt/brk vs identifiers) — a hard prerequisite for the aarch64 std
- release.yml publishes the aarch64 asset + qemu smoke; ci.yml aarch64 cross-compile + byte-verify enabled (qemu corpus gated pending #1464/#1391)
- vendored dep/mach-std → std main e8ce7dc1 (runtime-bearing)

**Validated byte-identical by two independent runs:** x86_64 fixpoint 99faee73; aarch64 self-host fixpoint under qemu f3e4f923 (s1==s2==s3). All CI lanes green on dev.

Tagging v1.6.0 on merge triggers the release.