### PR TITLE
fix(release): resolve aarch64 qemu runner name in the smoke step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,11 @@ jobs:
           cp -r .github/tests/aarch64run/app "$work/app"
           mkdir -p "$work/app/dep"
           cp -r dep/mach-std "$work/app/dep/mach-std"
-          ( cd "$work/app" && qemu-aarch64 "$GITHUB_WORKSPACE/out/linux-arm64/bin/mach" build . )
-          qemu-aarch64 "$work/app/out/linux-arm64/bin/aarch64run"
+          # qemu-user-static installs the runner as `qemu-aarch64-static`; resolve
+          # whichever name is present (matches the aarch64run/run.sh detection).
+          runner="$(command -v qemu-aarch64 || command -v qemu-aarch64-static)"
+          ( cd "$work/app" && "$runner" "$GITHUB_WORKSPACE/out/linux-arm64/bin/mach" build . )
+          "$runner" "$work/app/out/linux-arm64/bin/aarch64run"
 
       - name: Package artifacts
         run: |


### PR DESCRIPTION
The v1.6.0 release run failed at `Smoke-test the aarch64 binary under qemu`: the inline compiler-smoke called bare `qemu-aarch64`, but `qemu-user-static` installs `qemu-aarch64-static` → exit 127 (the emitted-code smoke via run.sh had already PASSED — run.sh already detects the runner). No release was published (failure preceded Package/Upload). This applies run.sh's runner-detection to the inline smoke. Workflow-only — the validated binary (aarch64 f3e4f923) is unchanged. Re-tag v1.6.0 on main after this lands.