### PR TITLE
release: v1.6.0 re-cut — aarch64 qemu runner fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,11 @@ jobs:
           cp -r .github/tests/aarch64run/app "$work/app"
           mkdir -p "$work/app/dep"
           cp -r dep/mach-std "$work/app/dep/mach-std"
-          ( cd "$work/app" && qemu-aarch64 "$GITHUB_WORKSPACE/out/linux-arm64/bin/mach" build . )
-          qemu-aarch64 "$work/app/out/linux-arm64/bin/aarch64run"
+          # qemu-user-static installs the runner as `qemu-aarch64-static`; resolve
+          # whichever name is present (matches the aarch64run/run.sh detection).
+          runner="$(command -v qemu-aarch64 || command -v qemu-aarch64-static)"
+          ( cd "$work/app" && "$runner" "$GITHUB_WORKSPACE/out/linux-arm64/bin/mach" build . )
+          "$runner" "$work/app/out/linux-arm64/bin/aarch64run"
 
       - name: Package artifacts
         run: |


### PR DESCRIPTION
Re-cut of v1.6.0: the first release run failed only at the aarch64 qemu smoke step (bare `qemu-aarch64` vs the installed `qemu-aarch64-static`; no release was published). This brings the #1469 runner-detection fix to main so the re-tagged v1.6.0 release run completes. Same validated binary (aarch64 f3e4f923); workflow-only delta over the prior dev→main (#1468, all lanes green).