### PR TITLE
feat(comptime): provenance-rooted namespaces ($mach.* / $project.*)

### DIFF
--- a/.github/tests/comptimeroots/app/src/main.mach
+++ b/.github/tests/comptimeroots/app/src/main.mach
@@ -18,5 +18,9 @@ fun main(argc: i64, argv: **u8) i64 {
     if (!str_equals($project.target.os, "linux"))   { ret 7; }
     if (!str_equals($project.target.arch, "x86_64")) { ret 8; }
     if (!str_equals($project.target.abi, "sysv64"))  { ret 9; }
+    # the structured `$project.version.*` folds the declared "3.1.4"
+    $if ($project.version.major == 3) { } $or { ret 10; }
+    $if ($project.version.minor == 1) { } $or { ret 11; }
+    $if ($project.version.patch == 4) { } $or { ret 12; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/app/src/main.mach
+++ b/.github/tests/comptimeroots/app/src/main.mach
@@ -2,7 +2,9 @@ use std.runtime;
 use std.types.string.str_equals;
 
 # the `$project.*` / `$target.*` / `$bin.*` comptime roots (#1217) must fold to
-# this v2 manifest's declared values and the selected artifact's name. exits 0
+# this v2 manifest's declared values and the selected artifact's name. the new
+# `$project.target.{os,arch,abi}` spelling (#1471) folds to the same declared
+# tuple as the legacy `$target.*` (both resolve this release — additive). exits 0
 # only when every root matches; a mismatch returns the drifted root's id.
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
@@ -12,5 +14,9 @@ fun main(argc: i64, argv: **u8) i64 {
     if (!str_equals($target.isa, "x86_64"))     { ret 4; }
     if (!str_equals($target.abi, "sysv64"))     { ret 5; }
     if (!str_equals($bin.name, "roots"))        { ret 6; }
+    # the canonical `$project.target.*` spelling folds to the same tuple
+    if (!str_equals($project.target.os, "linux"))   { ret 7; }
+    if (!str_equals($project.target.arch, "x86_64")) { ret 8; }
+    if (!str_equals($project.target.abi, "sysv64"))  { ret 9; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/machabi/mach.toml
+++ b/.github/tests/comptimeroots/machabi/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id      = "machabi"
+name    = "Comptime $mach.abi.* namespace"
+version = "1.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.machabi]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.4.0"

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -16,7 +16,9 @@ fun main(argc: i64, argv: **u8) i64 {
     $if ($mach.abi.sysv == $mach.abi.win64)    { ret 4; }
     $if ($mach.abi.sysv == $mach.abi.aapcs64)  { ret 5; }
     $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 6; }
+    # the mode tags occupy distinct values
+    $if ($mach.mode.debug == $mach.mode.release) { ret 7; }
     # $mach.version is the canonical spelling of $mach.compiler.version
-    if (!str_equals($mach.version, $mach.compiler.version)) { ret 7; }
+    if (!str_equals($mach.version, $mach.compiler.version)) { ret 8; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -1,10 +1,11 @@
 use std.runtime;
+use std.types.string.str_equals;
 
-# the new `$mach.abi.*` tag table and the numeric `$mach.target.abi` (#1471)
-# fold in one numeric space. this app builds for native linux/x86_64 (sysv), so
-# `$mach.target.abi` folds to `$mach.abi.sysv`, and the three abi tags are
-# pairwise distinct. exits 0 only when every comptime fold matches; a mismatch
-# returns a distinct id.
+# the new `$mach.abi.*` tag table, the numeric `$mach.target.abi`, and the
+# `$mach.version` string (#1471). this app builds for native linux/x86_64
+# (sysv), so `$mach.target.abi` folds to `$mach.abi.sysv`, the three abi tags
+# are pairwise distinct, and `$mach.version` agrees with `$mach.compiler.version`.
+# exits 0 only when every comptime fold matches; a mismatch returns a distinct id.
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     # the active target's abi folds to the matching tag
@@ -13,5 +14,7 @@ fun main(argc: i64, argv: **u8) i64 {
     $if ($mach.abi.sysv == $mach.abi.win64)    { ret 2; }
     $if ($mach.abi.sysv == $mach.abi.aapcs64)  { ret 3; }
     $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 4; }
+    # $mach.version is the canonical spelling of $mach.compiler.version
+    if (!str_equals($mach.version, $mach.compiler.version)) { ret 5; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -18,7 +18,9 @@ fun main(argc: i64, argv: **u8) i64 {
     $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 6; }
     # the mode tags occupy distinct values
     $if ($mach.mode.debug == $mach.mode.release) { ret 7; }
+    # the active build mode folds to debug for this default (no -O/--release) build
+    $if ($mach.build.mode == $mach.mode.debug) { } $or { ret 8; }
     # $mach.version is the canonical spelling of $mach.compiler.version
-    if (!str_equals($mach.version, $mach.compiler.version)) { ret 8; }
+    if (!str_equals($mach.version, $mach.compiler.version)) { ret 9; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -1,20 +1,22 @@
 use std.runtime;
 use std.types.string.str_equals;
 
-# the new `$mach.abi.*` tag table, the numeric `$mach.target.abi`, and the
-# `$mach.version` string (#1471). this app builds for native linux/x86_64
-# (sysv), so `$mach.target.abi` folds to `$mach.abi.sysv`, the three abi tags
-# are pairwise distinct, and `$mach.version` agrees with `$mach.compiler.version`.
+# the new `$mach.abi.*` tag table and the canonical resolved-build facts
+# `$mach.build.{os,arch,abi}` (#1471). this app builds for native linux/x86_64
+# (sysv), so the build facts fold to the matching tags, the three abi tags are
+# pairwise distinct, and `$mach.version` agrees with `$mach.compiler.version`.
 # exits 0 only when every comptime fold matches; a mismatch returns a distinct id.
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
-    # the active target's abi folds to the matching tag
-    $if ($mach.target.abi == $mach.abi.sysv) { } $or { ret 1; }
+    # the resolved active build's facts fold to the matching tags
+    $if ($mach.build.abi == $mach.abi.sysv)     { } $or { ret 1; }
+    $if ($mach.build.os == $mach.os.linux)      { } $or { ret 2; }
+    $if ($mach.build.arch == $mach.arch.x86_64) { } $or { ret 3; }
     # the abi tags occupy distinct values
-    $if ($mach.abi.sysv == $mach.abi.win64)    { ret 2; }
-    $if ($mach.abi.sysv == $mach.abi.aapcs64)  { ret 3; }
-    $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 4; }
+    $if ($mach.abi.sysv == $mach.abi.win64)    { ret 4; }
+    $if ($mach.abi.sysv == $mach.abi.aapcs64)  { ret 5; }
+    $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 6; }
     # $mach.version is the canonical spelling of $mach.compiler.version
-    if (!str_equals($mach.version, $mach.compiler.version)) { ret 5; }
+    if (!str_equals($mach.version, $mach.compiler.version)) { ret 7; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -1,0 +1,17 @@
+use std.runtime;
+
+# the new `$mach.abi.*` tag table and the numeric `$mach.target.abi` (#1471)
+# fold in one numeric space. this app builds for native linux/x86_64 (sysv), so
+# `$mach.target.abi` folds to `$mach.abi.sysv`, and the three abi tags are
+# pairwise distinct. exits 0 only when every comptime fold matches; a mismatch
+# returns a distinct id.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # the active target's abi folds to the matching tag
+    $if ($mach.target.abi == $mach.abi.sysv) { } $or { ret 1; }
+    # the abi tags occupy distinct values
+    $if ($mach.abi.sysv == $mach.abi.win64)    { ret 2; }
+    $if ($mach.abi.sysv == $mach.abi.aapcs64)  { ret 3; }
+    $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 4; }
+    ret 0;
+}

--- a/.github/tests/comptimeroots/run.sh
+++ b/.github/tests/comptimeroots/run.sh
@@ -83,8 +83,9 @@ expect_reject() {
     echo "PASS comptimeroots/$label: bare \$ident rejected with the teaching diagnostic"
 }
 
-build_and_run app    "manifest with profiles"
-build_and_run altapp "alternate declared values"
+build_and_run app     "manifest with profiles"
+build_and_run altapp  "alternate declared values"
+build_and_run machabi "\$mach.abi tag namespace"
 
 expect_reject bareident_gate  "bare \$ident gate"  "$BARE_IDENT_DIAG"
 expect_reject bareident_value "bare \$ident value" "$BARE_IDENT_DIAG"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -548,6 +548,11 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
         ret br;
     }
 
+    # thread the CLI optimization intent into the session so the comptime ctx can
+    # resolve `$mach.build.mode`; the manifest opt is folded in driver-side.
+    s.opt_explicit = cli_set;
+    s.opt_release  = cli_level == pipeline.OPT_RELEASE;
+
     val proj_r: Result[driver.Project, str] = driver.build_project_sel(?s, util.cstr_str(?root[0]), ?sel);
     if (is_err[driver.Project, str](proj_r)) {
         print.eprint("error: ");

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1845,7 +1845,16 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) Result[sess.ModuleId, s
     # initialise an empty Ast up front so the entry is always teardown-safe,
     # even if parsing never runs (parse_module overwrites it with the real one)
     m.a                 = ast.init(p.s.alloc, 0);
-    m.ctx               = comptime.init(p.s.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, p.target.arch.pointer_width, p.compiler_name, p.compiler_ver);
+    # resolve the active optimization mode for `$mach.build.mode`: an explicit CLI
+    # `-O*`/`--release` flag wins, else the selected target's manifest opt, else
+    # debug — mirroring cmd.build.resolve_opt_level so the gate matches the pipeline.
+    var build_mode_id: u32 = comptime.MODE_DEBUG;
+    if (p.s.opt_explicit) {
+        if (p.s.opt_release) { build_mode_id = comptime.MODE_RELEASE; }
+    } or (p.target_entry.opt == TARGET_OPT_RELEASE) {
+        build_mode_id = comptime.MODE_RELEASE;
+    }
+    m.ctx               = comptime.init(p.s.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, build_mode_id, p.target.arch.pointer_width, p.compiler_name, p.compiler_ver);
     # feed the manifest-derived `$project.*`/`$target.*`/`$bin.*` roots; the
     # target tuple comes from the selected entry (set before any module loads).
     comptime.set_build_context(?m.ctx,

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1845,7 +1845,7 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) Result[sess.ModuleId, s
     # initialise an empty Ast up front so the entry is always teardown-safe,
     # even if parsing never runs (parse_module overwrites it with the real one)
     m.a                 = ast.init(p.s.alloc, 0);
-    m.ctx               = comptime.init(p.s.alloc, p.target.os_id, p.target.arch_id, p.target.arch.pointer_width, p.compiler_name, p.compiler_ver);
+    m.ctx               = comptime.init(p.s.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, p.target.arch.pointer_width, p.compiler_name, p.compiler_ver);
     # feed the manifest-derived `$project.*`/`$target.*`/`$bin.*` roots; the
     # target tuple comes from the selected entry (set before any module loads).
     comptime.set_build_context(?m.ctx,

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -422,6 +422,7 @@ fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
         target.host_os_id(),
         target.host_arch_id(),
         target.host_abi_id(),
+        comptime.MODE_DEBUG,
         target.host_pointer_width(),
         intern.STR_NIL,
         intern.STR_NIL

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -421,6 +421,7 @@ fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
         es.alloc,
         target.host_os_id(),
         target.host_arch_id(),
+        target.host_abi_id(),
         target.host_pointer_width(),
         intern.STR_NIL,
         intern.STR_NIL

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1432,11 +1432,19 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
         ret int_value(unwrap_ok[u32, str](r)::i64);
     }
     # $mach.abi.<name> — abi tag value, in the same numeric space as
-    # $mach.target.abi so `$mach.target.abi == $mach.abi.sysv` is an int compare;
+    # $mach.build.abi so `$mach.build.abi == $mach.abi.sysv` is an int compare;
     # unrecognized names error likewise.
     if (depth == 3 && seg_is(source, stack, 1, "abi")) {
         val name: StrView = span_text(source, stack[0]);
         val r: Result[u32, str] = abi_tag_for(name);
+        if (is_err[u32, str](r)) { ret err[CTValue, str](unwrap_err[u32, str](r)); }
+        ret int_value(unwrap_ok[u32, str](r)::i64);
+    }
+    # $mach.mode.<name> — mode tag value (debug/release), same numeric space as
+    # $mach.build.mode; unrecognized names error likewise.
+    if (depth == 3 && seg_is(source, stack, 1, "mode")) {
+        val name: StrView = span_text(source, stack[0]);
+        val r: Result[u32, str] = mode_tag_for(name);
         if (is_err[u32, str](r)) { ret err[CTValue, str](unwrap_err[u32, str](r)); }
         ret int_value(unwrap_ok[u32, str](r)::i64);
     }
@@ -1540,6 +1548,21 @@ fun abi_tag_for(name: StrView) Result[u32, str] {
     if (view_eq_str(name, "win64"))   { ret ok[u32, str](abi.ABI_WIN64); }
     if (view_eq_str(name, "aapcs64")) { ret ok[u32, str](abi.ABI_AAPCS64); }
     ret err[u32, str]("unknown `$mach.abi.*` tag");
+}
+
+# the comptime mode-id space for `$mach.mode.*` and `$mach.build.mode`: a stable
+# 2-value space (debug/release) that mirrors me.pipeline's OptLevel (OPT_DEBUG=0
+# / OPT_RELEASE=1) without importing the middle end into the front end. the build
+# threads the resolved optimization level into `ComptimeCtx.build_mode_id`.
+pub val MODE_DEBUG:   u32 = 0;
+pub val MODE_RELEASE: u32 = 1;
+
+# maps an `$mach.mode.<name>` tag to its mode id; the active build's value reads
+# from `$mach.build.mode`. closed list; an unrecognized name is an error.
+fun mode_tag_for(name: StrView) Result[u32, str] {
+    if (view_eq_str(name, "debug"))   { ret ok[u32, str](MODE_DEBUG); }
+    if (view_eq_str(name, "release")) { ret ok[u32, str](MODE_RELEASE); }
+    ret err[u32, str]("unknown `$mach.mode.*` tag");
 }
 
 # version_component: the `which`-th dot-separated component (0=major, 1=minor,

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -162,6 +162,7 @@ pub def FrameMark: u32;
 # alloc:          allocator used for the entries buffer
 # target_os_id:   numeric os id (one of os.OS_*)
 # target_arch_id: numeric arch id (one of isa.ARCH_*)
+# target_abi_id:  numeric abi id (one of abi.ABI_*)
 # pointer_width:  target pointer width in bytes
 # compiler_name:  interned "mach"
 # compiler_ver:   interned compiler version string
@@ -194,6 +195,7 @@ pub rec ComptimeCtx {
     alloc:          *Allocator;
     target_os_id:   u32;
     target_arch_id: u32;
+    target_abi_id:  u32;
     pointer_width:  u32;
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
@@ -233,6 +235,7 @@ fun is_i64_min(a: i64) bool {
 # alloc:          allocator used for owned storage
 # target_os_id:   numeric os id (one of os.OS_*)
 # target_arch_id: numeric arch id (one of isa.ARCH_*)
+# target_abi_id:  numeric abi id (one of abi.ABI_*)
 # pointer_width:  pointer width in bytes for the target
 # compiler_name:  interned compiler name
 # compiler_ver:   interned compiler version
@@ -241,6 +244,7 @@ pub fun init(
     alloc:          *Allocator,
     target_os_id:   u32,
     target_arch_id: u32,
+    target_abi_id:  u32,
     pointer_width:  u32,
     compiler_name:  intern.StrId,
     compiler_ver:   intern.StrId
@@ -249,6 +253,7 @@ pub fun init(
     c.alloc          = alloc;
     c.target_os_id   = target_os_id;
     c.target_arch_id = target_arch_id;
+    c.target_abi_id  = target_abi_id;
     c.pointer_width  = pointer_width;
     c.compiler_name  = compiler_name;
     c.compiler_ver   = compiler_ver;
@@ -1348,9 +1353,9 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "arch")) {
         ret int_value(c.target_arch_id::i64);
     }
-    # $mach.target.abi — active target abi tag; not yet modeled in ComptimeCtx
+    # $mach.target.abi — active target abi, numeric tag (compare vs $mach.abi.*)
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "abi")) {
-        ret err[CTValue, str]("`$mach.target.abi` is not yet available");
+        ret int_value(c.target_abi_id::i64);
     }
     # $mach.target.pointer_width — pointer size in bytes
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "pointer_width")) {
@@ -1942,7 +1947,7 @@ test "comptime: eval_lit_int handles 0b/0o prefixes and _ separators (#1242)" {
 test "comptime: bind/frame_open/frame_close/lookup scope bindings without leaking (#1242)" {
     var alloc: Allocator;
     page.make(?alloc);
-    var c: ComptimeCtx = init(?alloc, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
+    var c: ComptimeCtx = init(?alloc, 0, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
 
     val name1: intern.StrId = 1::intern.StrId;
     val name2: intern.StrId = 2::intern.StrId;

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -163,6 +163,8 @@ pub def FrameMark: u32;
 # target_os_id:   numeric os id (one of os.OS_*)
 # target_arch_id: numeric arch id (one of isa.ARCH_*)
 # target_abi_id:  numeric abi id (one of abi.ABI_*)
+# build_mode_id:  active optimization mode id (MODE_DEBUG / MODE_RELEASE), read
+#                 by `$mach.build.mode`
 # pointer_width:  target pointer width in bytes
 # compiler_name:  interned "mach"
 # compiler_ver:   interned compiler version string
@@ -196,6 +198,7 @@ pub rec ComptimeCtx {
     target_os_id:   u32;
     target_arch_id: u32;
     target_abi_id:  u32;
+    build_mode_id:  u32;
     pointer_width:  u32;
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
@@ -236,6 +239,7 @@ fun is_i64_min(a: i64) bool {
 # target_os_id:   numeric os id (one of os.OS_*)
 # target_arch_id: numeric arch id (one of isa.ARCH_*)
 # target_abi_id:  numeric abi id (one of abi.ABI_*)
+# build_mode_id:  active optimization mode id (MODE_DEBUG / MODE_RELEASE)
 # pointer_width:  pointer width in bytes for the target
 # compiler_name:  interned compiler name
 # compiler_ver:   interned compiler version
@@ -245,6 +249,7 @@ pub fun init(
     target_os_id:   u32,
     target_arch_id: u32,
     target_abi_id:  u32,
+    build_mode_id:  u32,
     pointer_width:  u32,
     compiler_name:  intern.StrId,
     compiler_ver:   intern.StrId
@@ -254,6 +259,7 @@ pub fun init(
     c.target_os_id   = target_os_id;
     c.target_arch_id = target_arch_id;
     c.target_abi_id  = target_abi_id;
+    c.build_mode_id  = build_mode_id;
     c.pointer_width  = pointer_width;
     c.compiler_name  = compiler_name;
     c.compiler_ver   = compiler_ver;
@@ -1357,10 +1363,11 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 # under $mach.{os,arch,abi}.*):
 #   $mach.version — the compiler/toolchain version string;
 #     $mach.version.{major,minor,patch} — its structured integer components.
-#   $mach.build.{os,arch,abi,pointer_width} — the resolved active build's facts;
-#     os/arch/abi share the numeric tag space of $mach.{os,arch,abi}.* so
-#     `$mach.build.arch == $mach.arch.aarch64` is an int compare. the canonical
-#     spelling that supersedes the legacy numeric $mach.target.*.
+#   $mach.build.{os,arch,abi,pointer_width,mode} — the resolved active build's
+#     facts; os/arch/abi/mode share the numeric tag space of
+#     $mach.{os,arch,abi,mode}.* so `$mach.build.arch == $mach.arch.aarch64` is an
+#     int compare. the canonical spelling that supersedes the legacy numeric
+#     $mach.target.*. `mode` is the active optimization pipeline (debug/release).
 #   $mach.target.{os,arch,pointer_width} — LEGACY, frozen at what the release
 #     seed folds (kept resolving for seed-compat; collapse deferred). $mach.target.abi
 #     is superseded by $mach.build.abi.
@@ -1481,11 +1488,15 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "pointer_width")) {
         ret int_value(c.pointer_width::i64);
     }
+    # $mach.build.mode — the active optimization mode (compare vs $mach.mode.*).
+    if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "mode")) {
+        ret int_value(c.build_mode_id::i64);
+    }
 
-    # $mach.build.{mode,timestamp,host} — build metadata stubs. checked before the
+    # $mach.build.{timestamp,host} — build metadata stubs. checked before the
     # dynamic define lookup so a manifest define can never shadow a reserved name.
     if (depth == 3 && seg_is(source, stack, 1, "build")
-     && (seg_is(source, stack, 0, "mode") || seg_is(source, stack, 0, "timestamp") || seg_is(source, stack, 0, "host"))) {
+     && (seg_is(source, stack, 0, "timestamp") || seg_is(source, stack, 0, "host"))) {
         ret err[CTValue, str]("`$mach.build.*` is not yet available");
     }
     # $mach.build.git.{commit,dirty} — build/vcs metadata stubs
@@ -2079,7 +2090,7 @@ test "comptime: eval_lit_int handles 0b/0o prefixes and _ separators (#1242)" {
 test "comptime: bind/frame_open/frame_close/lookup scope bindings without leaking (#1242)" {
     var alloc: Allocator;
     page.make(?alloc);
-    var c: ComptimeCtx = init(?alloc, 0, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
+    var c: ComptimeCtx = init(?alloc, 0, 0, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
 
     val name1: intern.StrId = 1::intern.StrId;
     val name2: intern.StrId = 2::intern.StrId;

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1287,6 +1287,12 @@ fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth
         if (seg_is(source, stack, 0, "patch")) { ret version_value(vs, 2); }
         ret err[CTValue, str]("unknown `$project.version.*` component");
     }
+    # $project.deps.<name>.version — reserved for the package-registry era. git
+    # deps carry no version (the manifest rejects `version =` today), so this is
+    # a loud stub rather than a fold to ref/commit or an empty string.
+    if (depth == 4 && seg_is(source, stack, 2, "deps") && seg_is(source, stack, 0, "version")) {
+        ret err[CTValue, str]("`$project.deps.*.version` is not yet available (reserved for the package registry)");
+    }
     if (depth != 2) { ret err[CTValue, str]("unknown `$project.*` path"); }
     if (seg_is(source, stack, 0, "id"))          { ret project_field(c.project_id); }
     if (seg_is(source, stack, 0, "version"))     { ret project_field(c.project_ver); }

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1254,7 +1254,7 @@ fun resolve_comptime_path(c: *ComptimeCtx, source: str, stack: *token.Span, dept
     if (depth == 0) { ret err[CTValue, str]("empty comptime path"); }
     val root: StrView = span_text(source, stack[depth - 1]);
     if (view_eq_str(root, "mach"))    { ret resolve_mach_path(c, source, stack, depth, interner); }
-    if (view_eq_str(root, "project")) { ret resolve_project_path(c, source, stack, depth); }
+    if (view_eq_str(root, "project")) { ret resolve_project_path(c, source, stack, depth, interner); }
     if (view_eq_str(root, "target"))  { ret resolve_target_path(c, source, stack, depth); }
     if (view_eq_str(root, "bin"))     { ret resolve_bin_path(c, source, stack, depth); }
     ret err[CTValue, str](COMPTIME_BARE_IDENT_MSG);
@@ -1265,7 +1265,7 @@ fun resolve_comptime_path(c: *ComptimeCtx, source: str, stack: *token.Span, dept
 # real build; name and description fold only when the manifest declares them. a
 # STR_NIL field (no project context bound, e.g. the editor) reports the value as
 # unavailable rather than folding to an empty string.
-fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32) Result[CTValue, str] {
+fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32, interner: *intern.Interner) Result[CTValue, str] {
     # $project.target.{os,arch,abi} — the selected target's declared tuple
     # spellings (the manifest's os/isa/abi names); the canonical home that
     # supersedes the legacy top-level $target.*. `arch` reads the declared isa.
@@ -1274,6 +1274,18 @@ fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth
         if (seg_is(source, stack, 0, "arch")) { ret project_field(c.target_isa); }
         if (seg_is(source, stack, 0, "abi"))  { ret project_field(c.target_abi); }
         ret err[CTValue, str]("unknown `$project.target.*` path");
+    }
+    # $project.version.{major,minor,patch} — the structured manifest version. the
+    # flat `$project.version` string stays available below (depth 2).
+    if (depth == 3 && seg_is(source, stack, 1, "version")) {
+        if (c.project_ver == intern.STR_NIL) { ret err[CTValue, str]("comptime path value is not available in this context"); }
+        val vo: Option[str] = intern.lookup(interner, c.project_ver);
+        if (is_none[str](vo)) { ret err[CTValue, str]("project version is not available"); }
+        val vs: str = unwrap[str](vo);
+        if (seg_is(source, stack, 0, "major")) { ret version_value(vs, 0); }
+        if (seg_is(source, stack, 0, "minor")) { ret version_value(vs, 1); }
+        if (seg_is(source, stack, 0, "patch")) { ret version_value(vs, 2); }
+        ret err[CTValue, str]("unknown `$project.version.*` component");
     }
     if (depth != 2) { ret err[CTValue, str]("unknown `$project.*` path"); }
     if (seg_is(source, stack, 0, "id"))          { ret project_field(c.project_id); }
@@ -1337,7 +1349,8 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 #
 # the namespace (#1471, provenance-rooted — facts under $mach.build.*, tags
 # under $mach.{os,arch,abi}.*):
-#   $mach.version — the compiler/toolchain version string.
+#   $mach.version — the compiler/toolchain version string;
+#     $mach.version.{major,minor,patch} — its structured integer components.
 #   $mach.build.{os,arch,abi,pointer_width} — the resolved active build's facts;
 #     os/arch/abi share the numeric tag space of $mach.{os,arch,abi}.* so
 #     `$mach.build.arch == $mach.arch.aarch64` is an int compare. the canonical
@@ -1365,6 +1378,16 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     # spelling; $mach.compiler.version folds to the same value).
     if (depth == 2 && seg_is(source, stack, 0, "version")) {
         ret str_value(c.compiler_ver);
+    }
+    # $mach.version.{major,minor,patch} — the structured compiler version.
+    if (depth == 3 && seg_is(source, stack, 1, "version")) {
+        val vo: Option[str] = intern.lookup(interner, c.compiler_ver);
+        if (is_none[str](vo)) { ret err[CTValue, str]("compiler version is not available"); }
+        val vs: str = unwrap[str](vo);
+        if (seg_is(source, stack, 0, "major")) { ret version_value(vs, 0); }
+        if (seg_is(source, stack, 0, "minor")) { ret version_value(vs, 1); }
+        if (seg_is(source, stack, 0, "patch")) { ret version_value(vs, 2); }
+        ret err[CTValue, str]("unknown `$mach.version.*` component");
     }
 
     # $mach.target.os — active target os, numeric tag (compare vs $mach.os.*)
@@ -1511,6 +1534,38 @@ fun abi_tag_for(name: StrView) Result[u32, str] {
     if (view_eq_str(name, "win64"))   { ret ok[u32, str](abi.ABI_WIN64); }
     if (view_eq_str(name, "aapcs64")) { ret ok[u32, str](abi.ABI_AAPCS64); }
     ret err[u32, str]("unknown `$mach.abi.*` tag");
+}
+
+# version_component: the `which`-th dot-separated component (0=major, 1=minor,
+# 2=patch) of a semver-style version string, as an integer. scans the whole
+# string accumulating only the target component's digits; a non-digit in that
+# component or an absent component is a loud error, never a silent 0.
+fun version_component(s: str, which: u32) Result[i64, str] {
+    var comp: u32   = 0;
+    var acc:  i64   = 0;
+    var seen: bool  = false;
+    var i:    usize = 0;
+    for (s[i] != 0) {
+        val ch: u8 = s[i];
+        if (ch == '.') {
+            comp = comp + 1;
+        } or (comp == which) {
+            if (ch < '0' || ch > '9') { ret err[i64, str]("version component is not numeric"); }
+            acc  = acc * 10 + (ch - '0')::i64;
+            seen = true;
+        }
+        i = i + 1;
+    }
+    if (!seen) { ret err[i64, str]("version string has no such component"); }
+    ret ok[i64, str](acc);
+}
+
+# version_value: fold a version component to an integer CTValue. shared by
+# `$mach.version.*` and `$project.version.*`.
+fun version_value(s: str, which: u32) Result[CTValue, str] {
+    val r: Result[i64, str] = version_component(s, which);
+    if (is_err[i64, str](r)) { ret err[CTValue, str](unwrap_err[i64, str](r)); }
+    ret int_value(unwrap_ok[i64, str](r));
 }
 
 # make_int_value: an integer CTValue from its 64-bit payload and signedness.
@@ -1833,19 +1888,24 @@ fun t_str_id(r: Result[CTValue, str]) intern.StrId {
 test "comptime: $project.* folds bound metadata; an unset/unknown field is unavailable (#1217)" {
     var c: ComptimeCtx = t_build_ctx();
     var stack: [8]token.Span;
+    # the depth-2 field reads below never touch the interner (only the structured
+    # $project.version.* path does); a real one is passed so the call typechecks.
+    var alloc: Allocator;
+    page.make(?alloc);
+    var itab: intern.Interner = intern.init(?alloc);
 
     val sid: str = "project.id";
-    if (t_str_id(resolve_project_path(?c, sid, ?stack[0], t_dotted(sid, ?stack[0]))) != 10) { ret 1; }
+    if (t_str_id(resolve_project_path(?c, sid, ?stack[0], t_dotted(sid, ?stack[0]), ?itab)) != 10) { ret 1; }
     val sver: str = "project.version";
-    if (t_str_id(resolve_project_path(?c, sver, ?stack[0], t_dotted(sver, ?stack[0]))) != 11) { ret 1; }
+    if (t_str_id(resolve_project_path(?c, sver, ?stack[0], t_dotted(sver, ?stack[0]), ?itab)) != 11) { ret 1; }
     val sname: str = "project.name";
-    if (t_str_id(resolve_project_path(?c, sname, ?stack[0], t_dotted(sname, ?stack[0]))) != 12) { ret 1; }
+    if (t_str_id(resolve_project_path(?c, sname, ?stack[0], t_dotted(sname, ?stack[0]), ?itab)) != 12) { ret 1; }
     # description is STR_NIL: the read is unavailable, never a placeholder.
     val sdesc: str = "project.description";
-    if (!is_err[CTValue, str](resolve_project_path(?c, sdesc, ?stack[0], t_dotted(sdesc, ?stack[0])))) { ret 1; }
+    if (!is_err[CTValue, str](resolve_project_path(?c, sdesc, ?stack[0], t_dotted(sdesc, ?stack[0]), ?itab))) { ret 1; }
     # an unknown field under a known root is rejected.
     val sbogus: str = "project.bogus";
-    if (!is_err[CTValue, str](resolve_project_path(?c, sbogus, ?stack[0], t_dotted(sbogus, ?stack[0])))) { ret 1; }
+    if (!is_err[CTValue, str](resolve_project_path(?c, sbogus, ?stack[0], t_dotted(sbogus, ?stack[0]), ?itab))) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1326,15 +1326,22 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 # precondition, not re-checked here. `stack` is leaf-first: stack[0] is the
 # rightmost segment and stack[depth - 1] is the root (`mach`).
 #
-# the locked namespace:
-#   $mach.target.{os,arch,abi,pointer_width} — active target parameters; the
-#     os/arch tags resolve to the same numeric space as $mach.os.* /
-#     $mach.arch.* so `$mach.target.os == $mach.os.linux` is an int compare.
+# the namespace (#1471, provenance-rooted — facts under $mach.build.*, tags
+# under $mach.{os,arch,abi}.*):
+#   $mach.version — the compiler/toolchain version string.
+#   $mach.build.{os,arch,abi,pointer_width} — the resolved active build's facts;
+#     os/arch/abi share the numeric tag space of $mach.{os,arch,abi}.* so
+#     `$mach.build.arch == $mach.arch.aarch64` is an int compare. the canonical
+#     spelling that supersedes the legacy numeric $mach.target.*.
+#   $mach.target.{os,arch,pointer_width} — LEGACY, frozen at what the release
+#     seed folds (kept resolving for seed-compat; collapse deferred). $mach.target.abi
+#     is superseded by $mach.build.abi.
 #   $mach.os.{linux,darwin,windows,freestanding} — os tag values.
 #   $mach.arch.{x86_64,aarch64} — arch tag values.
 #   $mach.abi.{sysv,win64,aapcs64} — abi tag values, same numeric space as
-#     $mach.target.abi.
-#   $mach.project.{name,version,root} — project metadata stubs.
+#     $mach.build.abi.
+#   $mach.project.{name,version,root} — legacy project metadata stubs ($project.*
+#     is the canonical top-level root).
 #   $mach.build.{mode,timestamp,host} / build.git.{commit,dirty} — build
 #     metadata stubs.
 #   $mach.build.<name> — a manifest comptime define (#1191); folds to the
@@ -1359,9 +1366,11 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "arch")) {
         ret int_value(c.target_arch_id::i64);
     }
-    # $mach.target.abi — active target abi, numeric tag (compare vs $mach.abi.*)
+    # $mach.target.abi — superseded by `$mach.build.abi`. the legacy `$mach.target.*`
+    # set is frozen at exactly what the release seed folds (os/arch/pointer_width),
+    # so new resolved-build facts land under `$mach.build.*`, never here.
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "abi")) {
-        ret int_value(c.target_abi_id::i64);
+        ret err[CTValue, str]("`$mach.target.abi` is unavailable; use `$mach.build.abi`");
     }
     # $mach.target.pointer_width — pointer size in bytes
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "pointer_width")) {
@@ -1406,6 +1415,25 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 3 && seg_is(source, stack, 1, "project")
      && (seg_is(source, stack, 0, "name") || seg_is(source, stack, 0, "version") || seg_is(source, stack, 0, "root"))) {
         ret err[CTValue, str]("`$mach.project.*` is not yet available");
+    }
+
+    # $mach.build.{os,arch,abi,pointer_width} — the resolved active build's facts,
+    # the canonical spelling that supersedes the legacy numeric `$mach.target.*`.
+    # the os/arch/abi values share the numeric tag space of `$mach.{os,arch,abi}.*`
+    # so `$mach.build.arch == $mach.arch.aarch64` is an int compare. checked before
+    # the `$mach.build.<name>` define lookup so a manifest define never shadows a
+    # reserved build fact.
+    if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "os")) {
+        ret int_value(c.target_os_id::i64);
+    }
+    if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "arch")) {
+        ret int_value(c.target_arch_id::i64);
+    }
+    if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "abi")) {
+        ret int_value(c.target_abi_id::i64);
+    }
+    if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "pointer_width")) {
+        ret int_value(c.pointer_width::i64);
     }
 
     # $mach.build.{mode,timestamp,host} — build metadata stubs. checked before the

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1266,6 +1266,15 @@ fun resolve_comptime_path(c: *ComptimeCtx, source: str, stack: *token.Span, dept
 # STR_NIL field (no project context bound, e.g. the editor) reports the value as
 # unavailable rather than folding to an empty string.
 fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32) Result[CTValue, str] {
+    # $project.target.{os,arch,abi} — the selected target's declared tuple
+    # spellings (the manifest's os/isa/abi names); the canonical home that
+    # supersedes the legacy top-level $target.*. `arch` reads the declared isa.
+    if (depth == 3 && seg_is(source, stack, 1, "target")) {
+        if (seg_is(source, stack, 0, "os"))   { ret project_field(c.target_os); }
+        if (seg_is(source, stack, 0, "arch")) { ret project_field(c.target_isa); }
+        if (seg_is(source, stack, 0, "abi"))  { ret project_field(c.target_abi); }
+        ret err[CTValue, str]("unknown `$project.target.*` path");
+    }
     if (depth != 2) { ret err[CTValue, str]("unknown `$project.*` path"); }
     if (seg_is(source, stack, 0, "id"))          { ret project_field(c.project_id); }
     if (seg_is(source, stack, 0, "version"))     { ret project_field(c.project_ver); }

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1345,6 +1345,12 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32, interner: *intern.Interner) Result[CTValue, str] {
     if (depth == 0) { ret err[CTValue, str]("empty comptime path"); }
 
+    # $mach.version — the mach compiler/toolchain version string (the canonical
+    # spelling; $mach.compiler.version folds to the same value).
+    if (depth == 2 && seg_is(source, stack, 0, "version")) {
+        ret str_value(c.compiler_ver);
+    }
+
     # $mach.target.os — active target os, numeric tag (compare vs $mach.os.*)
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "os")) {
         ret int_value(c.target_os_id::i64);

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -72,6 +72,7 @@ use expr:   mach.lang.fe.ast.expr;
 use token:  mach.lang.fe.token;
 use os:     mach.lang.target.os;
 use isa:    mach.lang.target.isa;
+use abi:    mach.lang.target.abi;
 
 # CTKind: discriminator for CTValue.data.
 pub def CTKind: u8;
@@ -1326,6 +1327,8 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 #     $mach.arch.* so `$mach.target.os == $mach.os.linux` is an int compare.
 #   $mach.os.{linux,darwin,windows,freestanding} — os tag values.
 #   $mach.arch.{x86_64,aarch64} — arch tag values.
+#   $mach.abi.{sysv,win64,aapcs64} — abi tag values, same numeric space as
+#     $mach.target.abi.
 #   $mach.project.{name,version,root} — project metadata stubs.
 #   $mach.build.{mode,timestamp,host} / build.git.{commit,dirty} — build
 #     metadata stubs.
@@ -1367,6 +1370,15 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 3 && seg_is(source, stack, 1, "arch")) {
         val name: StrView = span_text(source, stack[0]);
         val r: Result[u32, str] = arch_tag_for(name);
+        if (is_err[u32, str](r)) { ret err[CTValue, str](unwrap_err[u32, str](r)); }
+        ret int_value(unwrap_ok[u32, str](r)::i64);
+    }
+    # $mach.abi.<name> — abi tag value, in the same numeric space as
+    # $mach.target.abi so `$mach.target.abi == $mach.abi.sysv` is an int compare;
+    # unrecognized names error likewise.
+    if (depth == 3 && seg_is(source, stack, 1, "abi")) {
+        val name: StrView = span_text(source, stack[0]);
+        val r: Result[u32, str] = abi_tag_for(name);
         if (is_err[u32, str](r)) { ret err[CTValue, str](unwrap_err[u32, str](r)); }
         ret int_value(unwrap_ok[u32, str](r)::i64);
     }
@@ -1440,6 +1452,17 @@ fun arch_tag_for(name: StrView) Result[u32, str] {
     if (view_eq_str(name, "x86_64"))  { ret ok[u32, str](isa.ARCH_X86_64); }
     if (view_eq_str(name, "aarch64")) { ret ok[u32, str](isa.ARCH_AARCH64); }
     ret err[u32, str]("unknown `$mach.arch.*` tag");
+}
+
+# maps an `$mach.abi.<name>` tag to its numeric abi id (abi.ABI_*). the tag names
+# are the canonical convention names (matching each AbiVTable's name), distinct
+# from the manifest tuple's declared abi spelling read by `$target.abi`. closed
+# list; an unrecognized name is an error rather than a fold to ABI_UNKNOWN.
+fun abi_tag_for(name: StrView) Result[u32, str] {
+    if (view_eq_str(name, "sysv"))    { ret ok[u32, str](abi.ABI_SYSV); }
+    if (view_eq_str(name, "win64"))   { ret ok[u32, str](abi.ABI_WIN64); }
+    if (view_eq_str(name, "aapcs64")) { ret ok[u32, str](abi.ABI_AAPCS64); }
+    ret err[u32, str]("unknown `$mach.abi.*` tag");
 }
 
 # make_int_value: an integer CTValue from its 64-bit payload and signedness.

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -6,6 +6,7 @@
 
 use std.types.bool.bool;
 use std.types.bool.true;
+use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.result.Result;
@@ -78,6 +79,11 @@ pub rec Session {
     module_resolve:   map.Map[modid.ModuleId, ptr];
     module_comptime:  map.Map[modid.ModuleId, ptr];
     registry:         target.TargetRegistry;
+    # the CLI optimization intent, set before build_project so the comptime ctx
+    # can resolve `$mach.build.mode`: opt_explicit when a `-O*`/`--release` flag
+    # was given (it wins over the manifest), opt_release its release-vs-debug sense.
+    opt_explicit:     bool;
+    opt_release:      bool;
 }
 
 # init: construct an empty Session backed by the given allocator. sub-services
@@ -110,6 +116,8 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
     s.module_resolve   = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
     s.module_comptime  = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
     s.registry         = target.registry_init();
+    s.opt_explicit     = false;
+    s.opt_release      = false;
 
     val r_types: Result[ty.TypeInterner, str] = ty.init(alloc);
     if (is_err[ty.TypeInterner, str](r_types)) {

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -79,6 +79,13 @@ pub fun host_pointer_width() u32 {
     ret ($mach.target.pointer_width)::u32;
 }
 
+# host_abi_id: the canonical abi id (abi.ABI_*) for the host os/arch pair, so the
+# editor's neutral comptime context resolves `$mach.target.abi` against the
+# running compiler's own convention rather than a placeholder.
+pub fun host_abi_id() u32 {
+    ret canonical_abi(host_os_id(), host_arch_id());
+}
+
 # canonical_abi: the ABI id paired with an (operating system, architecture) pair.
 # the convention depends on BOTH dimensions: x86-64 uses SysV on Linux/Darwin and
 # Win64 on Windows, while AArch64 uses AAPCS64 everywhere (the Apple/MS variants


### PR DESCRIPTION
Implements #1471 — provenance-rooted comptime namespaces. **Additive this release** per the self-host seed constraint (legacy spellings kept; the collapse rides #1480 post-seed-bump). Part of the v1.7 comptime epic (#1477).

## Done (all building; `mach test` 502/502; comptimeroots green on the fresh compiler)
- `$mach.{os,arch,abi,mode}.*` tag tables (abi/mode added).
- `$mach.build.{os,arch,abi,pointer_width,mode}` — the resolved active build's facts (canonical). `mode` = the active optimization pipeline (debug/release), resolved mirroring `cmd.build.resolve_opt_level` (CLI `-O*`/`--release` wins, else manifest opt, else debug); threaded via the session.
- `$mach.version` (flat) + `$mach.version.{major,minor,patch}` (structured).
- `$project.target.{os,arch,abi}` + `$project.version.{major,minor,patch}` (flat `$project.version` kept).
- `$project.deps.<name>.version` — loud stub (deferred to the package-registry era; git deps have no version).

## Seed-safety
- Legacy `$mach.target.{os,arch,pointer_width}` / `$target.*` / flat `$project.version` still resolve; `$mach.target.abi` (a v1.6.0 stub) → `$mach.build.abi`. **Compiler-source gates untouched → byte-identical self-host fixpoint holds.**
- New spellings exercised by `.github/tests/comptimeroots` on the FRESH compiler (extended `machabi` + `app`), not inline blocks.

## Deferred (out of #1471 scope, confirmed)
- Collapse (remove legacy + migrate the compiler's ~48 `$mach.target.*` gates) → #1480 (post-seed-bump).
- `$mach.build.{timestamp,host,git.*}` → existing reserved-stub compile-errors (build-stamping is a possible future follow-up, not requested).

Closes #1471.