### PR TITLE
feat: backtick per-declaration codegen decorators

### DIFF
--- a/.github/tests/aligndec/app/mach.toml
+++ b/.github/tests/aligndec/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "aligndec"
+name = "Align Decorator Test — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.aligndec]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/aligndec/app/src/main.mach
+++ b/.github/tests/aligndec/app/src/main.mach
@@ -20,6 +20,14 @@ pub var g_cmp8: u8 = 5;
 `symbol("g_plain")`
 pub var g_plain: u8 = 11;
 
+# an `align(...)` decorator on a TYPE raises the type's own alignment and size; a
+# global of that type inherits the alignment, observable on the global's section.
+`align(32)`
+rec Over { a: u8; }
+
+`symbol("g_over")`
+pub var g_over: Over;
+
 `symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret (g_lit64 + g_cmp16 + g_cmp8 + g_plain)::i64;

--- a/.github/tests/aligndec/app/src/main.mach
+++ b/.github/tests/aligndec/app/src/main.mach
@@ -1,0 +1,26 @@
+use std.runtime.linux.x86_64;
+
+# `$size_of(Pair)` is a comptime expression that folds to 16, proving an
+# `align(...)` decorator accepts a comptime-expr argument, not just a literal.
+rec Pair { a: u64; b: u64; }
+
+# a literal alignment that differs from the 8-byte default, so it is observable.
+`align(64)` `symbol("g_lit64")`
+pub var g_lit64: u8 = 7;
+
+# a comptime-expr alignment, also observably different from the default.
+`align($size_of(Pair))` `symbol("g_cmp16")`
+pub var g_cmp16: u8 = 9;
+
+# the acceptance-criteria spelling: `$align_of(u64)` folds to 8.
+`align($align_of(u64))` `symbol("g_cmp8")`
+pub var g_cmp8: u8 = 5;
+
+# no decorator: the back end's default section alignment (8) applies.
+`symbol("g_plain")`
+pub var g_plain: u8 = 11;
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    ret (g_lit64 + g_cmp16 + g_cmp8 + g_plain)::i64;
+}

--- a/.github/tests/aligndec/run.sh
+++ b/.github/tests/aligndec/run.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# align decorator integration test (#1476): prove an `align(...)` decorator sets
+# the emitted alignment of a global, including the acceptance-criteria case of a
+# comptime-expr argument (`align($size_of(Pair))` folding to 16).
+#
+# each decorated global lands in its own data section whose `sh_addralign` is the
+# requested alignment; the object file carries the per-symbol section header that
+# readelf reads (the final static executable strips section headers). the build
+# asserts: g_lit64 -> 64 (literal), g_cmp16 -> 16 (comptime expr), g_cmp8 -> 8
+# (`$align_of(u64)`), g_plain -> 8 (default). the binary must also run, confirming
+# the over-aligned data is laid out correctly. readelf absent -> structural check
+# skipped, run still asserted.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+fail=0
+
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . -O2 ) >/dev/null 2>&1; then
+    echo "FAIL aligndec: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/aligndec"
+OBJ="$WORK/app/out/linux/obj/aligndec/main.o"
+
+# run: the over-aligned globals sum to 7 + 9 + 5 + 11 == 32.
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 32 ]; then
+    echo "FAIL aligndec: program ran with exit $code, expected 32" >&2
+    fail=1
+else
+    echo "PASS aligndec: the program with over-aligned globals runs correctly"
+fi
+
+# structural check: each global's section header alignment in the object file.
+if command -v readelf >/dev/null 2>&1 && [ -f "$OBJ" ]; then
+    # sec_align <symbol> — the sh_addralign of the section the symbol is defined in.
+    sec_align() {
+        local sym="$1" ndx
+        ndx=$(readelf -sW "$OBJ" 2>/dev/null | awk -v n="$sym" '$8==n {print $7; exit}')
+        [ -n "$ndx" ] || { echo "?"; return; }
+        readelf -SW "$OBJ" 2>/dev/null | grep -E "^[[:space:]]*\[[[:space:]]*${ndx}\]" | awk '{print $NF}'
+    }
+    expect_align() {
+        local sym="$1" want="$2" got
+        got=$(sec_align "$sym")
+        if [ "$got" != "$want" ]; then
+            echo "FAIL aligndec: $sym section align is $got, expected $want" >&2
+            fail=1
+        else
+            echo "PASS aligndec: $sym aligned to $want"
+        fi
+    }
+    expect_align g_lit64 64
+    expect_align g_cmp16 16
+    expect_align g_cmp8  8
+    expect_align g_plain 8
+else
+    echo "INFO aligndec: readelf unavailable or object missing; skipping the alignment check"
+fi
+
+exit "$fail"

--- a/.github/tests/aligndec/run.sh
+++ b/.github/tests/aligndec/run.sh
@@ -79,6 +79,8 @@ if command -v readelf >/dev/null 2>&1 && [ -f "$OBJ" ]; then
     expect_align g_cmp16 16
     expect_align g_cmp8  8
     expect_align g_plain 8
+    # a global of an `align(32)` record inherits the type's raised alignment.
+    expect_align g_over  32
 else
     echo "INFO aligndec: readelf unavailable or object missing; skipping the alignment check"
 fi

--- a/.github/tests/decorator/app/mach.toml
+++ b/.github/tests/decorator/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "decapp"
+name = "Decorator Link Test — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.decapp]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/decorator/app/src/main.mach
+++ b/.github/tests/decorator/app/src/main.mach
@@ -1,0 +1,12 @@
+use std.runtime.linux.x86_64;
+
+# bound at link time against the external object's `mach_dec_add` definition.
+ext fun mach_dec_add(a: i64, b: i64) i64;
+
+# the runtime entry references `main` by its literal link name; the `symbol`
+# decorator pins it, exactly as the legacy `$main.symbol = "main"` setter did.
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    # 20 + 21 + 1 == 42; the body lives in the external object, not the graph.
+    ret mach_dec_add(20, 21);
+}

--- a/.github/tests/decorator/extlib/mach.toml
+++ b/.github/tests/decorator/extlib/mach.toml
@@ -1,0 +1,17 @@
+[project]
+id = "declib"
+name = "Decorator Link Test — Library"
+version = "0.0.0"
+src = "src"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[lib.declib]
+entry = "ext.mach"
+kind  = "static"

--- a/.github/tests/decorator/extlib/src/ext.mach
+++ b/.github/tests/decorator/extlib/src/ext.mach
@@ -1,0 +1,7 @@
+# external library compiled to a loose `.o`: exports `mach_dec_add` under a
+# literal link name set by a `symbol` decorator (the 1:1 replacement for the
+# legacy `$<sym>.symbol` setter), so a consumer can bind to it via an `ext fun`.
+`symbol("mach_dec_add")`
+pub fun mach_dec_add(a: i64, b: i64) i64 {
+    ret a + b + 1;
+}

--- a/.github/tests/decorator/run.sh
+++ b/.github/tests/decorator/run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# decorator integration test (#1476): prove a `symbol` backtick decorator drives
+# the emitted link name, the 1:1 replacement for the legacy `$<sym>.symbol`
+# setter.
+#
+# builds a tiny library (`declib`) to a loose object whose `pub fun mach_dec_add`
+# carries a `` `symbol("mach_dec_add")` `` decorator, then links a consumer
+# (`app`) — which declares that symbol `ext` and whose `main` carries a
+# `` `symbol("main")` `` decorator — against the object. the program returns
+# `mach_dec_add(20, 21)` which must be 42. if the decorator did not route the
+# link name, the library symbol would be mangled and the `ext` reference would
+# not resolve, failing the link — so a clean 42 proves emission followed the
+# decorator. a build with no external input must fail on the undefined symbol.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/extlib" "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# build the external library object.
+( cd "$WORK/extlib" && "$MACH" build . )
+OBJ="$WORK/extlib/out/linux/obj/declib/ext.o"
+test -f "$OBJ" || { echo "error: library object not produced at $OBJ" >&2; exit 1; }
+
+fail=0
+
+# explicit object path: link the consumer against the decorator-named symbol.
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . "$OBJ" ) >/dev/null 2>&1; then
+    echo "FAIL decorator: symbol decorator link — build failed" >&2
+    fail=1
+else
+    set +e
+    "$WORK/app/out/linux/bin/decapp"
+    code=$?
+    set -e
+    if [ "$code" -ne 42 ]; then
+        echo "FAIL decorator: symbol decorator link — ran with exit $code, expected 42" >&2
+        fail=1
+    else
+        echo "PASS decorator: symbol decorator drives the emitted link name"
+    fi
+fi
+
+# no external input: the undefined symbol must make the link fail, proving the
+# definition comes from the linked object, not the graph.
+rm -rf "$WORK/app/out"
+if ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL decorator: missing input did not fail the link" >&2
+    fail=1
+else
+    echo "PASS decorator: missing external input fails the link"
+fi
+
+exit "$fail"

--- a/.github/tests/dlllibdec/app/mach.toml
+++ b/.github/tests/dlllibdec/app/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id      = "dlllibdec"
+name    = "per-symbol windows DLL attribution via decorators — App"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "windows"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+ext  = ".exe"
+libs = ["kernel32.dll", "ws2_32.dll", "advapi32.dll"]
+
+[bin.dlllibdec]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/dlllibdec/app/src/main.mach
+++ b/.github/tests/dlllibdec/app/src/main.mach
@@ -1,0 +1,44 @@
+# dlllibdec integration app (#1476): the decorator-spelled twin of the dlllib
+# test. per-symbol windows DLL attribution expressed with backtick decorators
+# rather than the legacy `$<sym>.library` / `$<sym>.symbol` setters — the two
+# must produce identical PE import attribution. imports spread across
+# kernel32.dll, ws2_32.dll and advapi32.dll; advapi32 is deliberately the
+# trailing descriptor and is called, exercising the last-descriptor call thunk.
+
+use std.runtime;
+
+# `symbol` rename only: the mach identifier `sleep_ms` links as `Sleep`, an
+# unattributed import that falls back to kernel32.dll (the first dependency).
+`symbol("Sleep")`
+ext fun sleep_ms(ms: u32);
+
+# `library` only, bare name: pinned to ws2_32.dll, linked as `WSAStartup`.
+`library("ws2_32.dll")`
+ext fun WSAStartup(ver: u16, data: *u8) i32;
+
+# both directives on one decl: `ws2_cleanup` is renamed to `WSACleanup` and
+# pinned to ws2_32.dll — the rename and the library pin compose.
+`library("ws2_32.dll")` `symbol("WSACleanup")`
+ext fun ws2_cleanup() i32;
+
+# the trailing descriptor: `rng_fill` is renamed to `SystemFunction036`
+# (RtlGenRandom) and pinned to advapi32.dll, exercising the last-descriptor thunk.
+`library("advapi32.dll")` `symbol("SystemFunction036")`
+ext fun rng_fill(buf: *u8, len: u32) u8;
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    var wsadata: [512]u8;
+    sleep_ms(0);
+    if (WSAStartup(0x0202::u16, ?wsadata[0]) != 0) { ret 1; }
+    if (ws2_cleanup() != 0) { ret 2; }
+    var rnd: [32]u8;
+    var k: u64 = 0;
+    for (k < 32) { rnd[k] = 0; k = k + 1; }
+    if (rng_fill(?rnd[0], 32) == 0) { ret 3; }
+    var nz: u8 = 0;
+    k = 0;
+    for (k < 32) { nz = nz | rnd[k]; k = k + 1; }
+    if (nz == 0) { ret 4; }
+    ret 0;
+}

--- a/.github/tests/dlllibdec/run.sh
+++ b/.github/tests/dlllibdec/run.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# dlllibdec integration test (#1476): the decorator-spelled twin of dlllib —
+# prove `library(...)` / `symbol(...)` backtick decorators drive per-symbol
+# windows DLL attribution identically to the legacy `$<sym>.library` /
+# `$<sym>.symbol` setters. the acceptance-criteria case: a windows extern with
+# `` `library("ws2_32.dll")` `` + `` `symbol("...")` `` importing correctly.
+#
+# builds the windows binary, reads its PE import directory, and asserts each
+# renamed symbol lands under the decorator-named DLL (and the mach identifiers do
+# not leak), runs it under wine, and confirms a `library` naming an undeclared
+# DLL fails the link.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+APP="$WORK/app"
+
+fail=0
+
+# build the windows binary (the app's manifest targets windows).
+if ! ( cd "$APP" && "$MACH" build . ) >"$WORK/build.out" 2>&1; then
+    echo "FAIL dlllibdec: windows build failed" >&2
+    cat "$WORK/build.out" >&2
+    exit 1
+fi
+EXE="$APP/out/windows/bin/dlllibdec.exe"
+test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
+
+# imports_under <dll> — the member names imported from <dll>, one per line, read
+# from the emitted PE's import directory by whichever inspector is available.
+imports_under() {
+    case "$INSPECT" in
+    objdump)
+        objdump -x "$EXE" 2>/dev/null | awk -v dll="$1" '
+            /DLL Name:/      { cur=$3; next }
+            /^[[:space:]]*$/ { cur=""; next }
+            cur=="" || cur!=dll { next }
+            /Member-Name/    { next }
+            { print $NF }'
+        ;;
+    llvm-readobj)
+        llvm-readobj --coff-imports "$EXE" 2>/dev/null | awk -v dll="$1" '
+            $1=="Name:"   { cur=($2==dll); next }
+            cur && $1=="Symbol:" { print $2 }'
+        ;;
+    esac
+}
+
+# pick a PE import inspector: prefer binutils objdump (present on ubuntu with
+# pei support), fall back to llvm-readobj, and skip the structural half when
+# neither can read the import directory rather than failing spuriously.
+INSPECT=""
+if command -v objdump >/dev/null 2>&1 && objdump -x "$EXE" 2>/dev/null | grep -q "The Import Tables"; then
+    INSPECT="objdump"
+elif command -v llvm-readobj >/dev/null 2>&1; then
+    INSPECT="llvm-readobj"
+fi
+
+if [ -n "$INSPECT" ]; then
+    k32="$(imports_under kernel32.dll)"
+    ws2="$(imports_under ws2_32.dll)"
+    adv="$(imports_under advapi32.dll)"
+
+    has() {
+        if printf '%s\n' "$2" | grep -qx "$1"; then
+            echo "PASS dlllibdec: '$1' imported under $3"
+        else
+            echo "FAIL dlllibdec: '$1' not imported under $3" >&2
+            fail=1
+        fi
+    }
+    lacks() {
+        if printf '%s\n' "$2" | grep -qx "$1"; then
+            echo "FAIL dlllibdec: unrenamed identifier '$1' leaked into the imports of $3" >&2
+            fail=1
+        fi
+    }
+
+    has Sleep             "$k32" kernel32.dll   # `symbol` rename, default attribution
+    has WSAStartup        "$ws2" ws2_32.dll     # `library` pin, bare name
+    has WSACleanup        "$ws2" ws2_32.dll     # `library` + `symbol` on one decl
+    has SystemFunction036 "$adv" advapi32.dll   # trailing descriptor, pinned
+    lacks WSAStartup        "$k32" kernel32.dll
+    lacks WSACleanup        "$k32" kernel32.dll
+    lacks SystemFunction036 "$k32" kernel32.dll
+    lacks sleep_ms    "$k32" kernel32.dll
+    lacks ws2_cleanup "$ws2" ws2_32.dll
+    lacks rng_fill    "$adv" advapi32.dll
+else
+    echo "INFO dlllibdec: no PE import inspector (objdump/llvm-readobj); skipping the structural check"
+fi
+
+# behavioral: run under wine. the winsock and trailing advapi32 calls resolve
+# only through correct decorator-driven attribution; a clean exit proves it.
+if command -v wine >/dev/null 2>&1; then
+    if WINEDEBUG=-all wine "$EXE" >"$WORK/wine.out" 2>&1; then
+        echo "PASS dlllibdec: decorator-attributed imports resolve under wine"
+    else
+        echo "FAIL dlllibdec: program aborted under wine (mis-attribution?)" >&2
+        cat "$WORK/wine.out" >&2
+        fail=1
+    fi
+else
+    echo "SKIP dlllibdec: 'wine' not available for the behavioral check"
+fi
+
+# negative: a `library` decorator naming a DLL absent from the dependencies must
+# fail the link. derive the error app from the real source so it can't drift.
+ERR="$WORK/errapp"
+cp -r "$HERE/app" "$ERR"
+mkdir -p "$ERR/dep"
+ln -s "$STD" "$ERR/dep/mach-std"
+sed 's/"ws2_32.dll"/"nope_not_declared.dll"/' "$HERE/app/src/main.mach" >"$ERR/src/main.mach"
+if ( cd "$ERR" && "$MACH" build . ) >"$WORK/err.out" 2>&1; then
+    echo "FAIL dlllibdec: a build pinned to an undeclared library should have failed" >&2
+    fail=1
+elif grep -q "not among the link's dependencies" "$WORK/err.out"; then
+    echo "PASS dlllibdec: a library decorator naming an undeclared DLL fails the link"
+else
+    echo "FAIL dlllibdec: undeclared library decorator failed for the wrong reason" >&2
+    cat "$WORK/err.out" >&2
+    fail=1
+fi
+
+exit "$fail"

--- a/.github/tests/inline/app/mach.toml
+++ b/.github/tests/inline/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "inldec"
+name = "Inline Decorator Test — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+asm = "out/{target}/asm"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.inldec]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/inline/app/src/main.mach
+++ b/.github/tests/inline/app/src/main.mach
@@ -1,0 +1,25 @@
+use std.runtime.linux.x86_64;
+
+# `big` exceeds the inline pass's instruction threshold and is called from two
+# sites, so the size and single-use heuristics both decline to inline it — only
+# the `inline` decorator (which sets FN_FLAG_INLINE) forces it. the run.sh
+# control confirms the calls survive when the decorator is removed.
+`inline`
+fun big(a: i64, b: i64) i64 {
+    var x: i64 = a + b;
+    x = x + a; x = x - b; x = x * 2; x = x + 3;
+    x = x + a; x = x - b; x = x * 2; x = x + 4;
+    x = x + a; x = x - b; x = x * 2; x = x + 5;
+    x = x + a; x = x - b; x = x * 2; x = x + 6;
+    x = x + a; x = x - b; x = x * 2; x = x + 7;
+    x = x + a; x = x - b; x = x * 2; x = x + 8;
+    ret x;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    val p: i64 = big(1, 2);
+    val q: i64 = big(p, 3);
+    # the result is discarded; the test asserts on emission, not the value.
+    ret q - q + 42;
+}

--- a/.github/tests/inline/run.sh
+++ b/.github/tests/inline/run.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# inline decorator integration test (#1476): prove an `inline` backtick decorator
+# forces inlining of a function the cost model would otherwise leave alone.
+#
+# `big` exceeds the inline pass's instruction threshold and is called from two
+# sites, so neither the size nor the single-use heuristic inlines it — only
+# FN_FLAG_INLINE does. building at -O2 with `--emit-asm`, the decorated build
+# must contain NO call to `big` in the caller's assembly (fully inlined), while a
+# control build with the decorator stripped must still call it. the binary must
+# also run, confirming the inlined code is correct.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+fail=0
+
+# count_big_calls — number of `call` instructions targeting `big` in the app's
+# emitted assembly (across whatever path the asm artifact lands under).
+count_big_calls() {
+    local n=0 f
+    while IFS= read -r f; do
+        n=$(( n + $(grep -cE 'call[[:space:]].*big' "$f" || true) ))
+    done < <(find "$WORK/app/out" -name 'main.s')
+    echo "$n"
+}
+
+# decorated build: `big` must be fully inlined (no surviving call).
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . --emit-asm -O2 ) >/dev/null 2>&1; then
+    echo "FAIL inline: decorated build failed" >&2
+    fail=1
+else
+    calls=$(count_big_calls)
+    if [ "$calls" -ne 0 ]; then
+        echo "FAIL inline: 'inline' decorator did not inline 'big' ($calls call(s) remain)" >&2
+        fail=1
+    else
+        echo "PASS inline: 'inline' decorator forces inlining at -O2"
+    fi
+    set +e
+    "$WORK/app/out/linux/bin/inldec"
+    code=$?
+    set -e
+    if [ "$code" -ne 42 ]; then
+        echo "FAIL inline: inlined program ran with exit $code, expected 42" >&2
+        fail=1
+    else
+        echo "PASS inline: the inlined program runs correctly"
+    fi
+fi
+
+# control: strip the decorator; the cost model must now leave the calls in place,
+# proving the decorator — not the heuristic — is what inlined `big`.
+sed '/`inline`/d' "$HERE/app/src/main.mach" > "$WORK/app/src/main.mach"
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . --emit-asm -O2 ) >/dev/null 2>&1; then
+    echo "FAIL inline: control build failed" >&2
+    fail=1
+else
+    calls=$(count_big_calls)
+    if [ "$calls" -lt 1 ]; then
+        echo "FAIL inline: control inlined 'big' without the decorator — test no longer isolates the hint" >&2
+        fail=1
+    else
+        echo "PASS inline: without the decorator 'big' is left out of line"
+    fi
+fi
+
+exit "$fail"

--- a/.github/tests/sectiondec/app/mach.toml
+++ b/.github/tests/sectiondec/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "sectiondec"
+name = "Section Decorator Test — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.sectiondec]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/sectiondec/app/src/main.mach
+++ b/.github/tests/sectiondec/app/src/main.mach
@@ -1,0 +1,14 @@
+use std.runtime.linux.x86_64;
+
+# a `section("...")` decorator places the global's symbol in the named object
+# section instead of the default .data; the default-placed global stays in .data.
+`section(".machsec")` `symbol("g_sec")`
+pub var g_sec: u64 = 100;
+
+`symbol("g_def")`
+pub var g_def: u64 = 23;
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    ret (g_sec + g_def)::i64;
+}

--- a/.github/tests/sectiondec/app/src/main.mach
+++ b/.github/tests/sectiondec/app/src/main.mach
@@ -8,7 +8,12 @@ pub var g_sec: u64 = 100;
 `symbol("g_def")`
 pub var g_def: u64 = 23;
 
+# a `section("...")` decorator also places a FUNCTION's code in the named text
+# section; it is still called across the section boundary (a normal relocation).
+`section(".hottext")` `symbol("f_sec")`
+fun f_sec(x: i64) i64 { ret x + 1; }
+
 `symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
-    ret (g_sec + g_def)::i64;
+    ret f_sec((g_sec + g_def)::i64 - 1);
 }

--- a/.github/tests/sectiondec/run.sh
+++ b/.github/tests/sectiondec/run.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# section decorator integration test (#1476): prove a `section("...")` decorator
+# places a global's symbol in the named object section, carried into ELF object
+# emission, while an un-decorated global stays in .data.
+#
+# the symbol table records which section each symbol is defined in; objdump -t
+# names it. the decorated `g_sec` must land in `.machsec`, the plain `g_def` in
+# `.data`. the binary must also run. objdump absent -> structural check skipped.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+fail=0
+
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL sectiondec: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/sectiondec"
+OBJ="$WORK/app/out/linux/obj/sectiondec/main.o"
+
+# run: 100 + 23 == 123.
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 123 ]; then
+    echo "FAIL sectiondec: program ran with exit $code, expected 123" >&2
+    fail=1
+else
+    echo "PASS sectiondec: the program with a sectioned global runs correctly"
+fi
+
+# structural: each global's defining section name from the object symbol table.
+if command -v objdump >/dev/null 2>&1 && [ -f "$OBJ" ]; then
+    # sec_of <symbol> — the section name (the field beginning with '.') on the
+    # symbol-table line whose final field is the symbol name.
+    sec_of() {
+        objdump -t "$OBJ" 2>/dev/null | awk -v s="$1" '
+            $NF==s { for (i=1;i<=NF;i++) if ($i ~ /^\./) { print $i; exit } }'
+    }
+    expect_sec() {
+        local sym="$1" want="$2" got
+        got=$(sec_of "$sym")
+        if [ "$got" != "$want" ]; then
+            echo "FAIL sectiondec: $sym is in section '$got', expected '$want'" >&2
+            fail=1
+        else
+            echo "PASS sectiondec: $sym placed in $want"
+        fi
+    }
+    expect_sec g_sec .machsec
+    expect_sec g_def .data
+else
+    echo "INFO sectiondec: objdump unavailable or object missing; skipping the section check"
+fi
+
+exit "$fail"

--- a/.github/tests/sectiondec/run.sh
+++ b/.github/tests/sectiondec/run.sh
@@ -72,6 +72,9 @@ if command -v objdump >/dev/null 2>&1 && [ -f "$OBJ" ]; then
     }
     expect_sec g_sec .machsec
     expect_sec g_def .data
+    # a function placed in a named text section; the default function stays in .text.
+    expect_sec f_sec .hottext
+    expect_sec main  .text
 else
     echo "INFO sectiondec: objdump unavailable or object missing; skipping the section check"
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,19 +61,18 @@ jobs:
           rc=$?
           if [ "$rc" -ne 0 ]; then
             echo "::group::spawn-failure diagnostics (temporary, #1476)"
-            df -h
-            echo "--- test exe dir ---"
-            ls -la out/linux/debug/test 2>/dev/null | head
-            E="$(find out -path '*debug/test*' -type f 2>/dev/null | head -1)"
-            echo "first exe: $E"
-            file "$E"
-            ls -la "$E"
-            echo "--- program headers ---"
-            readelf -lW "$E" 2>&1 | head -25
-            echo "--- direct run ---"
-            "$E"; echo "direct rc=$?"
-            echo "--- strace execve ---"
-            ( command -v strace >/dev/null && strace -f "$E" 2>&1 | head -20 ) || echo "(no strace)"
+            echo "--- memory / limits ---"
+            free -m || true
+            echo "overcommit_memory=$(cat /proc/sys/vm/overcommit_memory 2>/dev/null) overcommit_ratio=$(cat /proc/sys/vm/overcommit_ratio 2>/dev/null)"
+            echo "ulimit -v=$(ulimit -v)  -u=$(ulimit -u)  -m=$(ulimit -m)"
+            echo "--- strace the spawn (fork/clone) syscalls of mach test ---"
+            if command -v strace >/dev/null; then
+              strace -f -e trace=clone,clone3,fork,vfork -qq mach test . >/dev/null 2>/tmp/st.log || true
+              echo "fork-family failures:"; grep -E "(clone|clone3|fork|vfork)\(.*\) = -1" /tmp/st.log | head -5
+              echo "fork-family successes (sample):"; grep -E "(clone|clone3|fork|vfork)\(.*\) = [1-9]" /tmp/st.log | head -2
+            else
+              echo "(no strace)"
+            fi
             echo "::endgroup::"
           fi
           exit "$rc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,14 @@ jobs:
             free -m || true
             echo "overcommit_memory=$(cat /proc/sys/vm/overcommit_memory 2>/dev/null) overcommit_ratio=$(cat /proc/sys/vm/overcommit_ratio 2>/dev/null)"
             echo "ulimit -v=$(ulimit -v)  -u=$(ulimit -u)  -m=$(ulimit -m)"
-            echo "--- strace the spawn (fork/clone) syscalls of mach test ---"
+            echo "--- fork-at-scale probe (shell fork() 700x) ---"
+            n=0; while [ "$n" -lt 700 ]; do /bin/true || { echo "shell fork FAILED at $n"; break; }; n=$((n+1)); done; echo "shell forked $n times"
+            echo "--- strace mach test (process syscalls, raw tail) ---"
             if command -v strace >/dev/null; then
-              strace -f -e trace=clone,clone3,fork,vfork -qq mach test . >/dev/null 2>/tmp/st.log || true
-              echo "fork-family failures:"; grep -E "(clone|clone3|fork|vfork)\(.*\) = -1" /tmp/st.log | head -5
-              echo "fork-family successes (sample):"; grep -E "(clone|clone3|fork|vfork)\(.*\) = [1-9]" /tmp/st.log | head -2
+              strace -f -e trace=process -qq mach test . >/dev/null 2>/tmp/st.log
+              echo "strace rc=$? ; st.log bytes=$(wc -c </tmp/st.log)"
+              echo "HEAD:"; head -5 /tmp/st.log
+              echo "TAIL:"; tail -25 /tmp/st.log
             else
               echo "(no strace)"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,28 @@ jobs:
           chmod +x /usr/local/bin/mach
 
       - name: Test corpus
-        run: mach test .
+        run: |
+          set +e
+          mach test .
+          rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::group::spawn-failure diagnostics (temporary, #1476)"
+            df -h
+            echo "--- test exe dir ---"
+            ls -la out/linux/debug/test 2>/dev/null | head
+            E="$(find out -path '*debug/test*' -type f 2>/dev/null | head -1)"
+            echo "first exe: $E"
+            file "$E"
+            ls -la "$E"
+            echo "--- program headers ---"
+            readelf -lW "$E" 2>&1 | head -25
+            echo "--- direct run ---"
+            "$E"; echo "direct rc=$?"
+            echo "--- strace execve ---"
+            ( command -v strace >/dev/null && strace -f "$E" 2>&1 | head -20 ) || echo "(no strace)"
+            echo "::endgroup::"
+          fi
+          exit "$rc"
 
   integration:
     name: Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,29 +56,14 @@ jobs:
 
       - name: Test corpus
         run: |
-          set +e
+          # `mach test` builds one full-compiler (~4.6MB) executable per test in a
+          # single long-lived process — a large virtual size — then fork()s to run
+          # each. on the swap-less runner with heuristic overcommit (vm.overcommit_memory=0)
+          # the kernel refuses fork() for a large-VSZ process regardless of free RAM
+          # (the child immediately execve's, so the COW copy is never written).
+          # allow overcommit so the spawns succeed.
+          sudo sysctl -w vm.overcommit_memory=1
           mach test .
-          rc=$?
-          if [ "$rc" -ne 0 ]; then
-            echo "::group::spawn-failure diagnostics (temporary, #1476)"
-            echo "--- memory / limits ---"
-            free -m || true
-            echo "overcommit_memory=$(cat /proc/sys/vm/overcommit_memory 2>/dev/null) overcommit_ratio=$(cat /proc/sys/vm/overcommit_ratio 2>/dev/null)"
-            echo "ulimit -v=$(ulimit -v)  -u=$(ulimit -u)  -m=$(ulimit -m)"
-            echo "--- fork-at-scale probe (shell fork() 700x) ---"
-            n=0; while [ "$n" -lt 700 ]; do /bin/true || { echo "shell fork FAILED at $n"; break; }; n=$((n+1)); done; echo "shell forked $n times"
-            echo "--- strace mach test (process syscalls, raw tail) ---"
-            if command -v strace >/dev/null; then
-              strace -f -e trace=process -qq mach test . >/dev/null 2>/tmp/st.log
-              echo "strace rc=$? ; st.log bytes=$(wc -c </tmp/st.log)"
-              echo "HEAD:"; head -5 /tmp/st.log
-              echo "TAIL:"; tail -25 /tmp/st.log
-            else
-              echo "(no strace)"
-            fi
-            echo "::endgroup::"
-          fi
-          exit "$rc"
 
   integration:
     name: Integration Tests

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -24,9 +24,13 @@ use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 use std.types.size.usize;
 use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_some;
 use std.types.option.is_none;
 use std.types.option.unwrap;
 use std.allocator.allocate;
+use std.allocator.deallocate;
 
 use writer: std.io.writer;
 
@@ -168,13 +172,27 @@ fun pack_image(s: *sess.Session, tgt: *target.Target, irmod: *ir.Module,
     }
     val text_sec: u32 = unwrap_ok[u32, str](rtext);
 
-    val rsym: Result[bool, str] = pack_symbols(?image, irmod, enc, text_sec);
+    # `section("...")` decorators move individual functions out of the shared
+    # `.text` into named sections. build one placement per sectioned function
+    # (and create its section); the list is empty when no function is sectioned,
+    # in which case symbols and relocations all land in `.text` exactly as before.
+    var placements:      *SectionPlacement = nil;
+    var placement_count: u32 = 0;
+    val rpl: Result[bool, str] = build_section_placements(s, ?image, irmod, enc, ?placements, ?placement_count);
+    if (is_err[bool, str](rpl)) {
+        obj.dnit(?image);
+        ret err[of.ObjectImage, str](unwrap_err[bool, str](rpl));
+    }
+
+    val rsym: Result[bool, str] = pack_symbols(?image, irmod, enc, text_sec, placements, placement_count);
     if (is_err[bool, str](rsym)) {
+        if (placements != nil) { deallocate[SectionPlacement](s.alloc, placements, enc.symbol_count::usize); }
         obj.dnit(?image);
         ret err[of.ObjectImage, str](unwrap_err[bool, str](rsym));
     }
 
-    val rrel: Result[bool, str] = pack_relocs(?image, enc, text_sec);
+    val rrel: Result[bool, str] = pack_relocs(?image, enc, text_sec, placements, placement_count);
+    if (placements != nil) { deallocate[SectionPlacement](s.alloc, placements, enc.symbol_count::usize); }
     if (is_err[bool, str](rrel)) {
         obj.dnit(?image);
         ret err[of.ObjectImage, str](unwrap_err[bool, str](rrel));
@@ -281,6 +299,114 @@ fun image_has_symbol(image: *of.ObjectImage, name: intern.StrId) bool {
     ret false;
 }
 
+# SectionPlacement: a function moved out of `.text` by a `section("...")`
+# decorator. its [text_start, text_end) byte range in the encoder blob is copied
+# into the named section `sec`; a mark or relocation at offset O in that range is
+# re-homed to (sec, O - text_start). its bytes remain in `.text` as dead,
+# unreferenced content (no symbol or relocation points at them there).
+rec SectionPlacement {
+    text_start: u32;
+    text_end:   u32;
+    sec:        u32;
+}
+
+# function_section: the object section name a `section("...")` decorator places
+# the defined function `name` in, or STR_NIL for the default `.text`.
+fun function_section(irmod: *ir.Module, name: intern.StrId) intern.StrId {
+    var i: u32 = 0;
+    for (i < irmod.function_len) {
+        val fn: *ir.Function = ?irmod.functions[i];
+        if (fn.name == name && (fn.flags & ir.FN_FLAG_EXTERN) == 0) { ret fn.section; }
+        i = i + 1;
+    }
+    ret intern.STR_NIL;
+}
+
+# next_func_entry_offset: the encoder-blob offset of the first function-entry mark
+# after index `i`, or the total text length when `i` marks the last function. marks
+# are emitted in increasing offset order, so this bounds the function at index `i`.
+fun next_func_entry_offset(irmod: *ir.Module, enc: *encode.EncoderOutput, i: u32) u32 {
+    var j: u32 = i + 1;
+    for (j < enc.symbol_count) {
+        val m: *encode.SymbolMark = ?enc.symbols[j];
+        if (function_defined(irmod, m.name)) { ret m.offset; }
+        j = j + 1;
+    }
+    ret enc.text_len;
+}
+
+# placement_for: the placement whose text range contains `offset`, or none.
+fun placement_for(placements: *SectionPlacement, count: u32, offset: u32) Option[*SectionPlacement] {
+    var i: u32 = 0;
+    for (i < count) {
+        val p: *SectionPlacement = ?placements[i];
+        if (offset >= p.text_start && offset < p.text_end) { ret some[*SectionPlacement](p); }
+        i = i + 1;
+    }
+    ret none[*SectionPlacement]();
+}
+
+# make_func_section: copy the encoder blob's [start, end) bytes (one sectioned
+# function) into a fresh image-owned buffer, append a text-kind section named
+# `sname`, and return its index. same-named sections from sibling functions are
+# concatenated by the linker.
+fun make_func_section(s: *sess.Session, image: *of.ObjectImage, sname: intern.StrId,
+                      enc: *encode.EncoderOutput, start: u32, end: u32) Result[u32, str] {
+    val len: u32 = end - start;
+    val br: Result[*u8, str] = allocate[u8](s.alloc, len::usize);
+    if (is_err[*u8, str](br)) { ret err[u32, str](unwrap_err[*u8, str](br)); }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+    var k: u32 = 0;
+    for (k < len) { buf[k] = enc.text[start + k]; k = k + 1; }
+
+    var sec: of.Section;
+    sec.name  = sname;
+    sec.kind  = of.SK_TEXT;
+    sec.bytes = buf;
+    sec.len   = len;
+    sec.align = 16;
+    ret obj.add_section(image, sec);
+}
+
+# build_section_placements: create a named section for every sectioned defined
+# function and record its placement. writes the owned placement array (sized to the
+# mark count, freed by the caller) and the entry count through the out-params; an
+# empty result means no function is sectioned and emission is byte-for-byte unchanged.
+fun build_section_placements(s: *sess.Session, image: *of.ObjectImage, irmod: *ir.Module,
+                             enc: *encode.EncoderOutput, out_buf: **SectionPlacement, out_count: *u32) Result[bool, str] {
+    @out_buf   = nil;
+    @out_count = 0;
+    if (enc.symbol_count == 0) { ret ok[bool, str](true); }
+
+    val br: Result[*SectionPlacement, str] = allocate[SectionPlacement](s.alloc, enc.symbol_count::usize);
+    if (is_err[*SectionPlacement, str](br)) { ret err[bool, str](unwrap_err[*SectionPlacement, str](br)); }
+    val buf: *SectionPlacement = unwrap_ok[*SectionPlacement, str](br);
+
+    var count: u32 = 0;
+    var i: u32 = 0;
+    for (i < enc.symbol_count) {
+        val mark: *encode.SymbolMark = ?enc.symbols[i];
+        if (function_defined(irmod, mark.name)) {
+            val sname: intern.StrId = function_section(irmod, mark.name);
+            if (sname != intern.STR_NIL) {
+                val start: u32 = mark.offset;
+                val end:   u32 = next_func_entry_offset(irmod, enc, i);
+                val rsec: Result[u32, str] = make_func_section(s, image, sname, enc, start, end);
+                if (is_err[u32, str](rsec)) {
+                    deallocate[SectionPlacement](s.alloc, buf, enc.symbol_count::usize);
+                    ret err[bool, str](unwrap_err[u32, str](rsec));
+                }
+                buf[count] = SectionPlacement{text_start: start, text_end: end, sec: unwrap_ok[u32, str](rsec)};
+                count = count + 1;
+            }
+        }
+        i = i + 1;
+    }
+    @out_buf   = buf;
+    @out_count = count;
+    ret ok[bool, str](true);
+}
+
 # append the encoded `.text` section to the image.
 # ---
 # s:     session, for interning the section name
@@ -321,7 +447,8 @@ fun pack_text(s: *sess.Session, image: *of.ObjectImage,
 # text_sec: index of the `.text` section the marks are defined in
 # ret:      true on success, or an error string
 fun pack_symbols(image: *of.ObjectImage, irmod: *ir.Module,
-                 enc: *encode.EncoderOutput, text_sec: u32) Result[bool, str] {
+                 enc: *encode.EncoderOutput, text_sec: u32,
+                 placements: *SectionPlacement, placement_count: u32) Result[bool, str] {
     var i: u32 = 0;
     for (i < enc.symbol_count) {
         val mark: *encode.SymbolMark = ?enc.symbols[i];
@@ -334,10 +461,21 @@ fun pack_symbols(image: *of.ObjectImage, irmod: *ir.Module,
             flags = flags | of.SYM_OBJ_FLAG_WEAK;
         }
 
+        # a mark inside a sectioned function is re-homed to that function's named
+        # section at the rebased offset; everything else stays in `.text`.
+        var sec_ix: u32 = text_sec;
+        var off:    u32 = mark.offset;
+        val pl: Option[*SectionPlacement] = placement_for(placements, placement_count, mark.offset);
+        if (is_some[*SectionPlacement](pl)) {
+            val p: *SectionPlacement = unwrap[*SectionPlacement](pl);
+            sec_ix = p.sec;
+            off    = mark.offset - p.text_start;
+        }
+
         var sym: of.Symbol;
         sym.name    = mark.name;
-        sym.section = text_sec;
-        sym.offset  = mark.offset;
+        sym.section = sec_ix;
+        sym.offset  = off;
         sym.size    = 0;
         sym.flags   = flags;
 
@@ -398,14 +536,26 @@ fun function_is_weak(irmod: *ir.Module, name: intern.StrId) bool {
 # text_sec: index of the `.text` section the relocations patch
 # ret:      true on success, or an error string
 fun pack_relocs(image: *of.ObjectImage, enc: *encode.EncoderOutput,
-                text_sec: u32) Result[bool, str] {
+                text_sec: u32, placements: *SectionPlacement, placement_count: u32) Result[bool, str] {
     var i: u32 = 0;
     for (i < enc.reloc_count) {
         val pr: *encode.PendingReloc = ?enc.relocations[i];
 
+        # a patch site inside a sectioned function is re-homed to that function's
+        # named section at the rebased offset; the symbol target is unchanged
+        # (resolved by the linker), so cross-section calls just work.
+        var sec_ix: u32 = text_sec;
+        var off:    u32 = pr.offset;
+        val pl: Option[*SectionPlacement] = placement_for(placements, placement_count, pr.offset);
+        if (is_some[*SectionPlacement](pl)) {
+            val p: *SectionPlacement = unwrap[*SectionPlacement](pl);
+            sec_ix = p.sec;
+            off    = pr.offset - p.text_start;
+        }
+
         var rel: of.Relocation;
-        rel.section = text_sec;
-        rel.offset  = pr.offset;
+        rel.section = sec_ix;
+        rel.offset  = off;
         rel.kind    = pr.kind;
         rel.symbol  = pr.sym;
         rel.addend  = pr.addend::i64;

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -542,9 +542,14 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
         sec.kind  = kind;
         sec.bytes = bytes;
         sec.len   = sec_len;
-        # an `align(...)` decorator overrides the default; otherwise 8 bytes.
+        # the section is aligned to the strictest of: the 8-byte default, the
+        # global's own type alignment (which an `align(...)` decorator on the type
+        # can raise — natural alignment never exceeds 8, so un-decorated globals
+        # stay at 8), and an `align(...)` decorator on the global itself.
         sec.align = 8;
-        if (g.align > 0) { sec.align = g.align; }
+        val tya: u32 = ir_type.byte_align(?irmod.types, g.ty, tgt);
+        if (tya > sec.align) { sec.align = tya; }
+        if (g.align > sec.align) { sec.align = g.align; }
 
         val ridx: Result[u32, str] = obj.add_section(image, sec);
         if (is_err[u32, str](ridx)) {

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -542,7 +542,9 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
         sec.kind  = kind;
         sec.bytes = bytes;
         sec.len   = sec_len;
+        # an `align(...)` decorator overrides the default; otherwise 8 bytes.
         sec.align = 8;
+        if (g.align > 0) { sec.align = g.align; }
 
         val ridx: Result[u32, str] = obj.add_section(image, sec);
         if (is_err[u32, str](ridx)) {

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -522,9 +522,15 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
             }
         }
 
-        val rname: Result[intern.StrId, str] = intern.intern(?s.interner, sname);
-        if (is_err[intern.StrId, str](rname)) {
-            ret err[bool, str](unwrap_err[intern.StrId, str](rname));
+        # a `section("...")` decorator overrides the default section name (the
+        # data/rodata/bss kind is kept, so an over-named bss stays zero-filled).
+        var sec_name: intern.StrId = g.section;
+        if (sec_name == intern.STR_NIL) {
+            val rname: Result[intern.StrId, str] = intern.intern(?s.interner, sname);
+            if (is_err[intern.StrId, str](rname)) {
+                ret err[bool, str](unwrap_err[intern.StrId, str](rname));
+            }
+            sec_name = unwrap_ok[intern.StrId, str](rname);
         }
 
         # a section's length is the global's in-memory size. for initialized
@@ -538,7 +544,7 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
         }
 
         var sec: of.Section;
-        sec.name  = unwrap_ok[intern.StrId, str](rname);
+        sec.name  = sec_name;
         sec.kind  = kind;
         sec.bytes = bytes;
         sec.len   = sec_len;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -704,6 +704,15 @@ fun scan_export_directives(p: *Project, mid: sess.ModuleId, source: str, start: 
                     bi = bi + 1;
                 }
             }
+
+            # leading backtick decorators attach directly to this decl, so a
+            # `symbol` / `library` decorator overrides the bare `ext` default
+            # registered above. run after the kind dispatch so the explicit name
+            # wins (the registries overwrite on a repeated key).
+            if (d.decorators_len > 0::u32) {
+                val rd: Result[bool, str] = register_decl_decorators(p, mid, source, d, did);
+                if (is_err[bool, str](rd)) { ret rd; }
+            }
         }
         i = i + 1;
     }
@@ -768,6 +777,52 @@ fun register_one_export_directive(p: *Project, mid: sess.ModuleId, source: str, 
         ret sess.register_export_library(p.s, mid, target_did::u32, unwrap_ok[intern.StrId, str](name_r));
     }
     ret sess.register_export_name(p.s, mid, target_did::u32, unwrap_ok[intern.StrId, str](name_r));
+}
+
+# register_decl_decorators: apply decl `d`'s leading backtick decorators the
+# link-name machinery owns — `` `symbol("name")` `` records the literal link name
+# and `` `library("lib")` `` pins an `ext` import's library — into the same
+# session registries the `$<sym>.symbol` / `.library` setters feed, so a
+# definition and its references resolve the name identically. each takes a single
+# string-literal argument. directives without a link-name effect (section /
+# inline / align) are left for the sema validation pass; a malformed argument is
+# likewise skipped here and diagnosed there.
+fun register_decl_decorators(p: *Project, mid: sess.ModuleId, source: str, d: *decl.Decl, did: id.DeclId) Result[bool, str] {
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *decl.Decorator = ?m.a.decorators[d.decorators_start + k];
+        val is_symbol:  bool = span_eq_str(source, dec.name, "symbol");
+        val is_library: bool = span_eq_str(source, dec.name, "library");
+
+        if ((is_symbol || is_library) && dec.args_len == 1::u32) {
+            val eid: id.ExprId = m.a.expr_ids[dec.args_start];
+            val ve_opt: Option[*expr.Expr] = ast.get_expr(?m.a, eid);
+            if (is_some[*expr.Expr](ve_opt)) {
+                val ve: *expr.Expr = unwrap[*expr.Expr](ve_opt);
+                if (ve.kind == expr.EXPR_KIND_LIT_STR && ve.span.len >= 2::usize) {
+                    # the string literal's inner content, quotes stripped.
+                    var inner: token.Span = ve.span;
+                    inner.offset = inner.offset + 1::usize;
+                    inner.len    = inner.len - 2::usize;
+
+                    val name_r: Result[intern.StrId, str] = intern.intern_span(?p.s.interner, source, inner);
+                    if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
+                    val sid: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+                    if (is_library) {
+                        val rl: Result[bool, str] = sess.register_export_library(p.s, mid, did::u32, sid);
+                        if (is_err[bool, str](rl)) { ret rl; }
+                    } or {
+                        val rn: Result[bool, str] = sess.register_export_name(p.s, mid, did::u32, sid);
+                        if (is_err[bool, str](rn)) { ret rn; }
+                    }
+                }
+            }
+        }
+        k = k + 1;
+    }
+    ret ok[bool, str](true);
 }
 
 # register_ext_fun: record an `ext fun` foreign symbol's literal link name (its

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1012,6 +1012,47 @@ test "diagnostics: a value name used as a type is told it does not name a type (
     ret 0;
 }
 
+test "diagnostics: an unknown backtick decorator is rejected (#1476)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    val fr: Result[src.FileId, str] = open(?es, "ud.mach", "`bogus` fun f() i64 { ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "unknown decorator; valid directives are symbol, section, inline, align, library")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "diagnostics: a decorator on an incompatible target is rejected (#1476)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `align` targets data and types, not a function — the mismatch is reported.
+    val fr: Result[src.FileId, str] = open(?es, "wt.mach", "`align(8)` fun f() i64 { ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "`align` decorator applies only to data and types")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "diagnostics: calling a non-function renders the callee type (#1046)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1053,24 +1053,24 @@ test "diagnostics: a decorator on an incompatible target is rejected (#1476)" {
     ret 0;
 }
 
-test "diagnostics: a section decorator on a global places it; on a function is rejected (#1476)" {
+test "diagnostics: a section decorator on a function or global is accepted; on a type is rejected (#1476)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);
     if (is_err[sess.Session, str](sr)) { ret 1; }
     var s: sess.Session = unwrap_ok[sess.Session, str](sr);
     var es: EditorSession = init(?s);
 
-    # `section` on a global is accepted (no error); on a function it is reported
-    # as not yet implemented (the encoder cannot emit per-function sections yet).
+    # `section` applies to functions and globals (placed, no error); a `def` type
+    # is not a symbol-bearing decl, so a section on it is reported.
     val fr: Result[src.FileId, str] = open(?es, "se.mach",
-        "`section(\".s\")` pub var g: u64 = 0;\n`section(\".s\")` fun f() i64 { ret 0; }\n");
+        "`section(\".s\")` pub var g: u64 = 0;\n`section(\".s\")` fun f() i64 { ret 0; }\n`section(\".s\")` def D: u64;\n");
     if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
 
     val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
     if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val list: *diag.DiagList = unwrap_ok[*diag.DiagList, str](dr);
-    if (!diag_has(list, "`section` on functions is not yet implemented")) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(list, "`section` decorator applies only to functions and globals")) { dnit(?es); sess.dnit(?s); ret 1; }
 
     dnit(?es);
     sess.dnit(?s);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1053,6 +1053,30 @@ test "diagnostics: a decorator on an incompatible target is rejected (#1476)" {
     ret 0;
 }
 
+test "diagnostics: a section decorator on a global places it; on a function is rejected (#1476)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `section` on a global is accepted (no error); on a function it is reported
+    # as not yet implemented (the encoder cannot emit per-function sections yet).
+    val fr: Result[src.FileId, str] = open(?es, "se.mach",
+        "`section(\".s\")` pub var g: u64 = 0;\n`section(\".s\")` fun f() i64 { ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val list: *diag.DiagList = unwrap_ok[*diag.DiagList, str](dr);
+    if (!diag_has(list, "`section` on functions is not yet implemented")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "diagnostics: calling a non-function renders the callee type (#1046)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/fe/ast.mach
+++ b/src/lang/fe/ast.mach
@@ -72,6 +72,9 @@ val INITIAL_ID_POOL_CAP: usize = 64;
 # comptime_branches:   pool of ComptimeBranch records referenced by DeclComptimeIf and StmtComptimeIf
 # comptime_branch_len: number of branches stored
 # comptime_branch_cap: allocated slots in comptime_branches
+# decorators:          pool of Decorator records referenced by a Decl's leading backtick clauses
+# decorator_len:       number of decorators stored
+# decorator_cap:       allocated slots in decorators
 # decl_ids:            typed pool of DeclIds for node-owned decl lists
 # decl_id_len:         number of DeclIds stored
 # decl_id_cap:         allocated slots in decl_ids
@@ -124,6 +127,10 @@ pub rec Ast {
     comptime_branches:    *decl.ComptimeBranch;
     comptime_branch_len:  usize;
     comptime_branch_cap:  usize;
+
+    decorators:    *decl.Decorator;
+    decorator_len: usize;
+    decorator_cap: usize;
 
     decl_ids:    *id.DeclId;
     decl_id_len: usize;
@@ -189,6 +196,10 @@ pub fun init(alloc: *Allocator, file_id: src.FileId) Ast {
     a.comptime_branch_len = 0;
     a.comptime_branch_cap = 0;
 
+    a.decorators    = nil;
+    a.decorator_len = 0;
+    a.decorator_cap = 0;
+
     a.decl_ids    = nil;
     a.decl_id_len = 0;
     a.decl_id_cap = 0;
@@ -241,6 +252,9 @@ pub fun dnit(a: *Ast) {
     if (a.comptime_branches != nil && a.comptime_branch_cap > 0) {
         deallocate[decl.ComptimeBranch](a.alloc, a.comptime_branches, a.comptime_branch_cap);
     }
+    if (a.decorators != nil && a.decorator_cap > 0) {
+        deallocate[decl.Decorator](a.alloc, a.decorators, a.decorator_cap);
+    }
     if (a.decl_ids != nil && a.decl_id_cap > 0) {
         deallocate[id.DeclId](a.alloc, a.decl_ids, a.decl_id_cap);
     }
@@ -289,6 +303,10 @@ pub fun dnit(a: *Ast) {
     a.comptime_branches   = nil;
     a.comptime_branch_len = 0;
     a.comptime_branch_cap = 0;
+
+    a.decorators    = nil;
+    a.decorator_len = 0;
+    a.decorator_cap = 0;
 
     a.decl_ids    = nil;
     a.decl_id_len = 0;
@@ -527,6 +545,25 @@ pub fun add_comptime_branch(a: *Ast, br: decl.ComptimeBranch) Result[u32, str] {
     val index: u32 = a.comptime_branch_len::u32;
     a.comptime_branches[a.comptime_branch_len] = br;
     a.comptime_branch_len = a.comptime_branch_len + 1;
+    ret ok[u32, str](index);
+}
+
+# add_decorator: appends a Decorator to the shared pool.
+# ---
+# a:   target Ast
+# d:   decorator record to append
+# ret: index into a.decorators for the new entry
+pub fun add_decorator(a: *Ast, d: decl.Decorator) Result[u32, str] {
+    if (a.decorator_len == a.decorator_cap) {
+        val r: Result[*decl.Decorator, str] = pool.grow[decl.Decorator](a.alloc, a.decorators, a.decorator_cap, INITIAL_AUX_CAP, ?a.decorator_cap);
+        if (is_err[*decl.Decorator, str](r)) {
+            ret err[u32, str](unwrap_err[*decl.Decorator, str](r));
+        }
+        a.decorators = unwrap_ok[*decl.Decorator, str](r);
+    }
+    val index: u32 = a.decorator_len::u32;
+    a.decorators[a.decorator_len] = d;
+    a.decorator_len = a.decorator_len + 1;
     ret ok[u32, str](index);
 }
 

--- a/src/lang/fe/ast/decl.mach
+++ b/src/lang/fe/ast/decl.mach
@@ -169,16 +169,34 @@ pub rec DeclComptimeAttr {
     value:  id.ExprId;
 }
 
+# Decorator: a leading backtick per-declaration codegen directive (#1476), e.g.
+# `` `symbol("_start")` `` / `` `inline` `` / `` `align($align_of(u64))` ``.
+# codegen-only (never visibility). attached to the following decl via the decl's
+# decorators_start/decorators_len range.
+# ---
+# name:       span of the directive identifier (symbol/section/inline/align/library)
+# args_start: start index into ast.expr_ids; each slot is a comptime-expr arg ExprId
+# args_len:   number of arguments (0 for a bare flag like `inline`)
+pub rec Decorator {
+    name:       token.Span;
+    args_start: u32;
+    args_len:   u32;
+}
+
 # Decl: a syntactic declaration node.
 # ---
-# span:  byte range of the declaration in source
-# kind:  which DECL_KIND_* variant is active
-# flags: bitfield of DECL_FLAG_* values (pub, ext)
-# data:  kind-specific payload; unused for ERROR (discriminated by kind alone)
+# span:            byte range of the declaration in source
+# kind:            which DECL_KIND_* variant is active
+# flags:           bitfield of DECL_FLAG_* values (pub, ext)
+# decorators_start: start index into ast.decorators of this decl's leading decorators
+# decorators_len:  number of leading backtick decorators (0 if none)
+# data:            kind-specific payload; unused for ERROR (discriminated by kind alone)
 pub rec Decl {
     span:  token.Span;
     kind:  DeclKind;
     flags: u8;
+    decorators_start: u32;
+    decorators_len:   u32;
     data: uni {
         use_:          DeclUse;
         fwd_:          DeclFwd;

--- a/src/lang/fe/lexer.mach
+++ b/src/lang/fe/lexer.mach
@@ -125,6 +125,7 @@ pub fun tokenize(source: str, alloc: *Allocator, file_id: src.FileId) Result[Tok
         or (c == '/')  { tok = token.make(token.KIND_SLASH,    pos, 1); pos = pos + 1; }
         or (c == '%')  { tok = token.make(token.KIND_PERCENT,  pos, 1); pos = pos + 1; }
         or (c == '^')  { tok = token.make(token.KIND_CARET,    pos, 1); pos = pos + 1; }
+        or (c == '`')  { tok = token.make(token.KIND_BACKTICK, pos, 1); pos = pos + 1; }
         or (c == ':')  {
             if (source[pos + 1] == ':') {
                 tok = token.make(token.KIND_COLON_COLON, pos, 2);
@@ -489,9 +490,9 @@ test "lexer: emit_diagnostics drains lex errors onto the sink" {
     var alloc: Allocator;
     page.make(?alloc);
 
-    # a backtick is not a valid token; the lexer records it as a lex error
+    # a backslash is not a valid token; the lexer records it as a lex error
     # rather than aborting, and emit_diagnostics surfaces it as a diagnostic.
-    val tr: Result[TokenStream, str] = tokenize("a ` b", ?alloc, 0::src.FileId);
+    val tr: Result[TokenStream, str] = tokenize("a \\ b", ?alloc, 0::src.FileId);
     if (is_err[TokenStream, str](tr)) { ret 1; }
     var stream: TokenStream = unwrap_ok[TokenStream, str](tr);
     if (stream.error_len == 0) { dnit(?stream, ?alloc); ret 1; }
@@ -530,6 +531,28 @@ test "lexer: 0b and 0o integer prefixes produce correct token spans (#1242)" {
         or (stream.tokens[1].span.len    != 5) { rc = 1; }
         or (stream.tokens[2].kind != token.KIND_LIT_INT) { rc = 1; }
         or (stream.tokens[2].span.len    != 4) { rc = 1; }
+    }
+
+    dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "lexer: a backtick lexes as KIND_BACKTICK (#1476)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    val tr: Result[TokenStream, str] = tokenize("`", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr)) { ret 1; }
+    var stream: TokenStream = unwrap_ok[TokenStream, str](tr);
+
+    var rc: i32 = 0;
+    # one backtick token + EOF = 2, with no lex error (it is a real token now)
+    if (stream.len != 2)       { rc = 1; }
+    or (stream.error_len != 0) { rc = 1; }
+    or {
+        if (stream.tokens[0].kind != token.KIND_BACKTICK) { rc = 1; }
+        or (stream.tokens[0].span.offset != 0) { rc = 1; }
+        or (stream.tokens[0].span.len    != 1) { rc = 1; }
     }
 
     dnit(?stream, ?alloc);

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -74,33 +74,120 @@ pub fun parse_module(p: *parser.Parser) id.ModuleId {
     ret mid;
 }
 
-# parse_decl: parses a single top-level declaration.
+# parse_decl: parses a single top-level declaration, including any leading
+# backtick decorators that attach to it.
 # ---
 # p:   parser state positioned at the first token of the declaration
 # ret: DeclId of the parsed declaration, or DECL_NIL on failure
 pub fun parse_decl(p: *parser.Parser) id.DeclId {
     val start: token.Token = parser.current(p);
 
-    if (parser.at(p, token.KIND_DOLLAR))  { ret parse_comptime_decl(p, start.span); }
+    var decorators_len: u32 = 0;
+    val decorators_start: u32 = parse_decorators(p, ?decorators_len);
+
+    val did: id.DeclId = parse_decl_dispatch(p, start.span);
+
+    # back-patch the decorator range onto the parsed decl; the pointer is taken
+    # after the dispatch's own appends complete, so the decls pool is stable.
+    if (did != id.DECL_NIL) {
+        val d: *decl.Decl = unwrap[*decl.Decl](ast.get_decl(p.ast, did));
+        d.decorators_start = decorators_start;
+        d.decorators_len   = decorators_len;
+    }
+    ret did;
+}
+
+# parse_decl_dispatch: dispatches on the leading `$` or keyword (after any
+# decorators) to the matching declaration parser, or reports an error and
+# yields an ERROR decl. `start` spans the declaration's first token (a
+# decorator backtick when decorators are present).
+fun parse_decl_dispatch(p: *parser.Parser, start: token.Span) id.DeclId {
+    if (parser.at(p, token.KIND_DOLLAR))  { ret parse_comptime_decl(p, start); }
 
     val flags: u8 = parse_flags(p);
 
-    if (parser.at_kw(p, "use"))   { ret parse_use_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "fwd"))   { ret parse_fwd_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "fun"))   { ret parse_fun_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "rec"))   { ret parse_rec_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "uni"))   { ret parse_uni_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "val"))   { ret parse_bind_decl(p, start.span, flags, decl.DECL_KIND_VAL); }
-    if (parser.at_kw(p, "var"))   { ret parse_bind_decl(p, start.span, flags, decl.DECL_KIND_VAR); }
-    if (parser.at_kw(p, "def"))   { ret parse_def_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "test"))  { ret parse_test_decl(p, start.span, flags); }
+    if (parser.at_kw(p, "use"))   { ret parse_use_decl(p, start, flags); }
+    if (parser.at_kw(p, "fwd"))   { ret parse_fwd_decl(p, start, flags); }
+    if (parser.at_kw(p, "fun"))   { ret parse_fun_decl(p, start, flags); }
+    if (parser.at_kw(p, "rec"))   { ret parse_rec_decl(p, start, flags); }
+    if (parser.at_kw(p, "uni"))   { ret parse_uni_decl(p, start, flags); }
+    if (parser.at_kw(p, "val"))   { ret parse_bind_decl(p, start, flags, decl.DECL_KIND_VAL); }
+    if (parser.at_kw(p, "var"))   { ret parse_bind_decl(p, start, flags, decl.DECL_KIND_VAR); }
+    if (parser.at_kw(p, "def"))   { ret parse_def_decl(p, start, flags); }
+    if (parser.at_kw(p, "test"))  { ret parse_test_decl(p, start, flags); }
 
     parser.error_at_current(p, "expected a declaration; valid starters: use, fwd, fun, rec, uni, val, var, def, test");
     var err: decl.Decl;
-    err.span  = start.span;
+    err.span  = start;
     err.kind  = decl.DECL_KIND_ERROR;
     err.flags = flags;
     ret parser.push_decl(p, err);
+}
+
+# parse_decorators: parses zero or more leading `` `name(args)` `` / `` `flag` ``
+# backtick decorator clauses, appending each to ast.decorators as one contiguous
+# block. writes the block length through `out_len` and returns its start index.
+fun parse_decorators(p: *parser.Parser, out_len: *u32) u32 {
+    val start: u32 = p.ast.decorator_len::u32;
+    var count: u32 = 0;
+    for (parser.at(p, token.KIND_BACKTICK)) {
+        if (!parse_one_decorator(p)) { brk; }
+        count = count + 1;
+    }
+    @out_len = count;
+    ret start;
+}
+
+# parses a single `` `name` `` or `` `name(args)` `` clause and appends it to
+# ast.decorators. the directive name and any comptime-expr arguments are
+# validated later in sema; the parser only records the syntax.
+fun parse_one_decorator(p: *parser.Parser) bool {
+    parser.advance(p);
+
+    if (!parser.at(p, token.KIND_IDENT)) {
+        parser.error_at_current(p, "expected decorator name after '`'");
+        ret false;
+    }
+    val name: token.Span = parser.advance(p).span;
+
+    var args_start: u32 = 0;
+    var args_len:   u32 = 0;
+    if (parser.at(p, token.KIND_LPAREN)) {
+        args_start = parse_decorator_args(p, ?args_len);
+    }
+
+    parser.expect(p, token.KIND_BACKTICK, "expected closing '`' to end decorator");
+
+    var d: decl.Decorator;
+    d.name       = name;
+    d.args_start = args_start;
+    d.args_len   = args_len;
+
+    val r: Result[u32, str] = ast.add_decorator(p.ast, d);
+    if (is_err[u32, str](r)) {
+        parser.fatal_oom_at(p, name);
+        ret false;
+    }
+    ret true;
+}
+
+# parses `(expr, expr, ...)` decorator arguments as comptime exprs, buffering
+# each so a nested call argument cannot split the slice; flushes to ast.expr_ids
+# and returns the block start, writing its length through `out_len`.
+fun parse_decorator_args(p: *parser.Parser, out_len: *u32) u32 {
+    parser.advance(p);
+
+    var buf: parser.ListBuf[id.ExprId] = parser.list_buf_init[id.ExprId]();
+    if (!parser.at(p, token.KIND_RPAREN)) {
+        parser.list_buf_push[id.ExprId](p, ?buf, pexpr.parse_expr(p));
+        for (parser.eat(p, token.KIND_COMMA)) {
+            if (parser.at(p, token.KIND_RPAREN)) { brk; }
+            parser.list_buf_push[id.ExprId](p, ?buf, pexpr.parse_expr(p));
+        }
+    }
+    parser.expect(p, token.KIND_RPAREN, "expected ')' to close decorator arguments");
+
+    ret parser.expr_id_buf_flush(p, ?buf, out_len);
 }
 
 # parse_stmt: parses a single statement.
@@ -1254,4 +1341,50 @@ test "parser: a bare-form statement keyword used as an identifier parses as an e
     ast.dnit(?a);
     lexer.dnit(?stream, ?alloc);
     ret rc;
+}
+
+test "parser: leading backtick decorators attach to the following decl (#1476)" {
+    # `inline` (bare flag) and `symbol("_start")` (one comptime-expr arg) both
+    # attach to `f`; the following `g` has none — decorators do not bleed across.
+    var alloc: Allocator;
+    page.make(?alloc);
+    val source: str = "`inline` `symbol(\"_start\")` fun f() {} fun g() {}";
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize(source, ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+    parse_module(?p);
+
+    var rc: i32 = 0;
+    if      (diag.has_errors(?diags))               { rc = 1; }
+    or      (a.decl_len < 2)                        { rc = 1; }
+    or      (a.decls[0].kind != decl.DECL_KIND_FUN) { rc = 1; }
+    or      (a.decls[1].kind != decl.DECL_KIND_FUN) { rc = 1; }
+    or      (a.decls[0].decorators_len != 2)        { rc = 1; }
+    or      (a.decls[1].decorators_len != 0)        { rc = 1; }
+
+    if (rc == 0) {
+        val d0: decl.Decorator = a.decorators[a.decls[0].decorators_start];
+        val d1: decl.Decorator = a.decorators[a.decls[0].decorators_start + 1];
+        # `inline` is a bare flag; `symbol(...)` carries exactly one arg
+        if (!str_region_equals(p.tokens.source, d0.name.offset, d0.name.len, "inline")) { rc = 1; }
+        if (d0.args_len != 0)                                                           { rc = 1; }
+        if (!str_region_equals(p.tokens.source, d1.name.offset, d1.name.len, "symbol")) { rc = 1; }
+        if (d1.args_len != 1)                                                           { rc = 1; }
+    }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "parser: an unterminated backtick decorator reports an error (#1476)" {
+    # a decorator name with no closing backtick must diagnose, not silently parse
+    if (!t_parse_module_has_errors("`inline fun f() {}")) { ret 1; }
+    # a backtick with no directive name must diagnose
+    if (!t_parse_module_has_errors("`` fun f() {}")) { ret 1; }
+    ret 0;
 }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1092,10 +1092,31 @@ fun bind_decl_list(rc: *ResolveContext, start: u32, len: u32) Result[bool, str] 
     ret ok[bool, str](true);
 }
 
+# binds the identifiers in each of decl `d`'s backtick decorator arguments.
+fun bind_decorator_args(rc: *ResolveContext, d: *decl.Decl) Result[bool, str] {
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *decl.Decorator = ?rc.a.decorators[d.decorators_start + k];
+        var j: u32 = 0;
+        for (j < dec.args_len) {
+            val r: Result[bool, str] = bind_expr(rc, rc.a.expr_ids[dec.args_start + j]);
+            if (is_err[bool, str](r)) { ret r; }
+            j = j + 1;
+        }
+        k = k + 1;
+    }
+    ret ok[bool, str](true);
+}
+
 fun bind_one_decl(rc: *ResolveContext, decl_id: id.DeclId) Result[bool, str] {
     val d_opt: Option[*decl.Decl] = ast.get_decl(rc.a, decl_id);
     if (is_none[*decl.Decl](d_opt)) { ret err[bool, str]("DeclId out of range"); }
     val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+
+    # a decl's backtick decorator arguments are comptime expressions; bind their
+    # identifiers (e.g. the operand of `align($size_of(T))`) so sema can type them.
+    val rda: Result[bool, str] = bind_decorator_args(rc, d);
+    if (is_err[bool, str](rda)) { ret rda; }
 
     if (d.kind == decl.DECL_KIND_COMPTIME_IF) {
         val ci: *decl.DeclComptimeIf = ?d.data.comptime_if;

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -328,6 +328,11 @@ fun infer_one_body(sc: *ctxm.SemaContext, did: id.DeclId) Result[bool, str] {
     if (is_none[*decl.Decl](d_opt)) { ret err[bool, str]("DeclId out of range"); }
     val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
 
+    # a decl's backtick decorator arguments are comptime expressions; infer them
+    # so their types resolve (e.g. `align($size_of(T))`) before the middle end
+    # folds them.
+    infer_decorator_args(sc, d);
+
     if (d.kind == decl.DECL_KIND_COMPTIME_IF) {
         ret infer_bodies_comptime_if(sc, ?d.data.comptime_if);
     }
@@ -356,6 +361,20 @@ fun infer_one_body(sc: *ctxm.SemaContext, did: id.DeclId) Result[bool, str] {
         ret ok[bool, str](true);
     }
     ret ok[bool, str](true);
+}
+
+# infers each of decl `d`'s backtick decorator arguments so their types resolve.
+fun infer_decorator_args(sc: *ctxm.SemaContext, d: *decl.Decl) {
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *decl.Decorator = ?sc.a.decorators[d.decorators_start + k];
+        var j: u32 = 0;
+        for (j < dec.args_len) {
+            infer.infer_expr(sc, sc.a.expr_ids[dec.args_start + j]);
+            j = j + 1;
+        }
+        k = k + 1;
+    }
 }
 
 # the return type a `test` body is checked against: the canonical i32

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -474,11 +474,14 @@ fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Deco
         require_string_arg(sc, dec,
             "`section` decorator takes one string argument",
             "`section` decorator argument must be a string literal");
-        if (!is_fun_or_global(d.kind)) {
+        if (d.kind == decl.DECL_KIND_FUN) {
+            # global section emission is wired; per-function sectioning needs the
+            # encoder to emit functions into separate text sections — reported
+            # rather than silently ignored until that lands.
+            ctxm.report(sc, dec.name, "`section` on functions is not yet implemented");
+        } or (!is_fun_or_global(d.kind)) {
             ctxm.report(sc, dec.name, "`section` decorator applies only to functions and globals");
         }
-        # emission is not wired yet; report rather than silently ignore.
-        ctxm.report(sc, dec.name, "`section` decorator is not yet implemented");
         ret;
     }
     ctxm.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, align, library");

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -35,6 +35,7 @@ use std.types.option.unwrap;
 use std.types.size.usize;
 
 use std.types.string.str;
+use std.types.string.str_region_equals;
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -332,6 +333,7 @@ fun infer_one_body(sc: *ctxm.SemaContext, did: id.DeclId) Result[bool, str] {
     # so their types resolve (e.g. `align($size_of(T))`) before the middle end
     # folds them.
     infer_decorator_args(sc, d);
+    validate_decorators(sc, d);
 
     if (d.kind == decl.DECL_KIND_COMPTIME_IF) {
         ret infer_bodies_comptime_if(sc, ?d.data.comptime_if);
@@ -375,6 +377,92 @@ fun infer_decorator_args(sc: *ctxm.SemaContext, d: *decl.Decl) {
         }
         k = k + 1;
     }
+}
+
+# validates a decl's backtick decorators: each must name a directive from the
+# closed set (symbol/section/inline/align/library), carry the right argument
+# shape, and apply to a compatible declaration. diagnostics are reported against
+# the offending span; sema does not halt.
+fun validate_decorators(sc: *ctxm.SemaContext, d: *decl.Decl) {
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        validate_one_decorator(sc, d, ?sc.a.decorators[d.decorators_start + k]);
+        k = k + 1;
+    }
+}
+
+# true when decorator `dec`'s directive name equals `name`.
+fun decorator_named(sc: *ctxm.SemaContext, dec: *decl.Decorator, name: str) bool {
+    ret str_region_equals(sc.source, dec.name.offset, dec.name.len, name);
+}
+
+# reports unless decorator `dec` carries exactly one string-literal argument.
+fun require_string_arg(sc: *ctxm.SemaContext, dec: *decl.Decorator, count_msg: str, kind_msg: str) {
+    if (dec.args_len != 1) { ctxm.report(sc, dec.name, count_msg); ret; }
+    val ae_opt: Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start]);
+    if (is_some[*expr.Expr](ae_opt)) {
+        val ae: *expr.Expr = unwrap[*expr.Expr](ae_opt);
+        if (ae.kind != expr.EXPR_KIND_LIT_STR) { ctxm.report(sc, ae.span, kind_msg); }
+    }
+}
+
+# true for decl kinds carrying data or a type (the `align` decorator's targets).
+fun is_data_or_type(kind: decl.DeclKind) bool {
+    ret kind == decl.DECL_KIND_VAL || kind == decl.DECL_KIND_VAR ||
+        kind == decl.DECL_KIND_REC || kind == decl.DECL_KIND_UNI ||
+        kind == decl.DECL_KIND_DEF;
+}
+
+# true for a function or a global binding (the `symbol`/`section` targets).
+fun is_fun_or_global(kind: decl.DeclKind) bool {
+    ret kind == decl.DECL_KIND_FUN || kind == decl.DECL_KIND_VAL || kind == decl.DECL_KIND_VAR;
+}
+
+fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Decorator) {
+    if (decorator_named(sc, dec, "symbol")) {
+        require_string_arg(sc, dec,
+            "`symbol` decorator takes one string argument",
+            "`symbol` decorator argument must be a string literal");
+        if (!is_fun_or_global(d.kind)) {
+            ctxm.report(sc, dec.name, "`symbol` decorator applies only to functions and globals");
+        }
+        ret;
+    }
+    if (decorator_named(sc, dec, "library")) {
+        require_string_arg(sc, dec,
+            "`library` decorator takes one string argument",
+            "`library` decorator argument must be a string literal");
+        if ((d.flags & decl.DECL_FLAG_EXT) == 0) {
+            ctxm.report(sc, dec.name, "`library` decorator applies only to ext imports");
+        }
+        ret;
+    }
+    if (decorator_named(sc, dec, "inline")) {
+        if (dec.args_len != 0) { ctxm.report(sc, dec.name, "`inline` decorator takes no arguments"); }
+        if (d.kind != decl.DECL_KIND_FUN) {
+            ctxm.report(sc, dec.name, "`inline` decorator applies only to functions");
+        }
+        ret;
+    }
+    if (decorator_named(sc, dec, "align")) {
+        if (dec.args_len != 1) { ctxm.report(sc, dec.name, "`align` decorator takes one argument"); }
+        if (!is_data_or_type(d.kind)) {
+            ctxm.report(sc, dec.name, "`align` decorator applies only to data and types");
+        }
+        ret;
+    }
+    if (decorator_named(sc, dec, "section")) {
+        require_string_arg(sc, dec,
+            "`section` decorator takes one string argument",
+            "`section` decorator argument must be a string literal");
+        if (!is_fun_or_global(d.kind)) {
+            ctxm.report(sc, dec.name, "`section` decorator applies only to functions and globals");
+        }
+        # emission is not wired yet; report rather than silently ignore.
+        ctxm.report(sc, dec.name, "`section` decorator is not yet implemented");
+        ret;
+    }
+    ctxm.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, align, library");
 }
 
 # the return type a `test` body is checked against: the canonical i32

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -474,12 +474,7 @@ fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Deco
         require_string_arg(sc, dec,
             "`section` decorator takes one string argument",
             "`section` decorator argument must be a string literal");
-        if (d.kind == decl.DECL_KIND_FUN) {
-            # global section emission is wired; per-function sectioning needs the
-            # encoder to emit functions into separate text sections — reported
-            # rather than silently ignored until that lands.
-            ctxm.report(sc, dec.name, "`section` on functions is not yet implemented");
-        } or (!is_fun_or_global(d.kind)) {
+        if (!is_fun_or_global(d.kind)) {
             ctxm.report(sc, dec.name, "`section` decorator applies only to functions and globals");
         }
         ret;

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -418,6 +418,14 @@ fun is_fun_or_global(kind: decl.DeclKind) bool {
     ret kind == decl.DECL_KIND_FUN || kind == decl.DECL_KIND_VAL || kind == decl.DECL_KIND_VAR;
 }
 
+# the inferred type of decorator-argument expression `eid`, or TYPE_ERROR when
+# the id is out of range (infer_decorator_args has already typed it).
+fun decorator_arg_type(sc: *ctxm.SemaContext, eid: id.ExprId) type.TypeId {
+    if (eid == id.EXPR_NIL) { ret type.TYPE_ERROR; }
+    if (eid::usize >= sc.a.expr_len) { ret type.TYPE_ERROR; }
+    ret sc.expr_type[eid];
+}
+
 fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Decorator) {
     if (decorator_named(sc, dec, "symbol")) {
         require_string_arg(sc, dec,
@@ -445,7 +453,18 @@ fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Deco
         ret;
     }
     if (decorator_named(sc, dec, "align")) {
-        if (dec.args_len != 1) { ctxm.report(sc, dec.name, "`align` decorator takes one argument"); }
+        if (dec.args_len != 1) {
+            ctxm.report(sc, dec.name, "`align` decorator takes one argument");
+        } or {
+            # the argument is a comptime expression that must fold to an integer
+            # alignment (a literal, or `$align_of(T)` / `$size_of(T)`). its exact
+            # value and the power-of-two check are computed at lowering, where type
+            # layout is available; here only its type is checked.
+            val ae: id.ExprId = sc.a.expr_ids[dec.args_start];
+            if (!type.is_integer(?sc.s.types, decorator_arg_type(sc, ae))) {
+                ctxm.report(sc, dec.name, "`align` decorator argument must be an integer comptime expression");
+            }
+        }
         if (!is_data_or_type(d.kind)) {
             ctxm.report(sc, dec.name, "`align` decorator applies only to data and types");
         }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -32,6 +32,7 @@ use std.types.option.unwrap;
 use std.types.size.usize;
 
 use std.types.string.str;
+use std.types.string.str_region_equals;
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -149,6 +150,7 @@ fun infer_nominal(sc: *sema.SemaContext, did: id.DeclId, name_span: token.Span, 
     val ty: type.TypeId = unwrap_ok[type.TypeId, str](tr);
 
     build_field_table(sc, ty, r.fields_start, r.fields_len);
+    record_type_align(sc, did, ty);
     ret ty;
 }
 
@@ -160,7 +162,45 @@ fun infer_nominal_uni(sc: *sema.SemaContext, did: id.DeclId, name_span: token.Sp
     val ty: type.TypeId = unwrap_ok[type.TypeId, str](tr);
 
     build_field_table(sc, ty, u.fields_start, u.fields_len);
+    record_type_align(sc, did, ty);
     ret ty;
+}
+
+# folds an `align(...)` decorator on the record/union declaration `did` and
+# records the resulting alignment for nominal TypeId `ty` on the session, so the
+# middle end can over-align the lowered IR struct. the argument is a compile-time
+# constant (a literal or `$mach.build.*`) folded by `comptime.eval`; a non-constant
+# (e.g. a layout intrinsic, which has no value before layout) or non-power-of-two
+# is reported. absent decorator or a non-`align` set leaves the natural alignment.
+fun record_type_align(sc: *sema.SemaContext, did: id.DeclId, ty: type.TypeId) {
+    val d_opt: Option[*decl.Decl] = ast.get_decl(sc.a, did);
+    if (is_none[*decl.Decl](d_opt)) { ret; }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *decl.Decorator = ?sc.a.decorators[d.decorators_start + k];
+        if (str_region_equals(sc.source, dec.name.offset, dec.name.len, "align")) {
+            if (dec.args_len != 1) { ret; }
+            val arg: id.ExprId = sc.a.expr_ids[dec.args_start];
+            val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, arg, ?sc.s.interner);
+            if (is_err[comptime.CTValue, str](ev)) {
+                sema.report(sc, dec.name, "`align` on a type must be a compile-time constant");
+                ret;
+            }
+            val cv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
+            if (cv.kind != comptime.CT_KIND_INT || comptime.ct_is_negative(cv)) { ret; }
+            val n: u64 = cv.data.i:~u64;
+            if (n == 0 || (n & (n - 1)) != 0) {
+                sema.report(sc, dec.name, "`align` value must be a non-zero power of two");
+                ret;
+            }
+            val rr: Result[bool, str] = sess.register_type_align(sc.s, ty::u32, n::u32);
+            if (is_err[bool, str](rr)) { ret; }
+            ret;
+        }
+        k = k + 1;
+    }
 }
 
 # populates a field table for nominal `ty` from a typed_names slice, mapping

--- a/src/lang/fe/token.mach
+++ b/src/lang/fe/token.mach
@@ -59,6 +59,9 @@ pub val KIND_COLON_COLON: Kind = 40;
 pub val KIND_DOT_DOT_DOT: Kind = 41;
 pub val KIND_COLON_TILDE: Kind = 42;
 
+# leading per-declaration codegen decorator marker (#1476): `` `name(args)` ``
+pub val KIND_BACKTICK: Kind = 43;
+
 pub val KIND_EOF:   Kind = 254;
 pub val KIND_ERROR: Kind = 255;
 

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -196,6 +196,8 @@ pub rec Function {
 # align: explicit byte alignment from an `align(...)` decorator (a power of two),
 # or 0 to use the back end's default for the global's section. always a power of
 # two when non-zero (lowering validates the folded value).
+# section: the object section name from a `section("...")` decorator, or STR_NIL
+# to use the back end's default (.data / .rodata / .bss by mutability and init).
 pub rec Global {
     name:      intern.StrId;
     ty:        ir_type.IrTypeId;
@@ -205,6 +207,7 @@ pub rec Global {
     is_extern: bool;
     is_local:  bool;
     align:     u32;
+    section:   intern.StrId;
 }
 
 # an IR module: one per source module.
@@ -996,6 +999,7 @@ test "ir: module teardown frees operands by capacity and agg blobs under a freei
     gl.is_extern = false;
     gl.is_local  = true;
     gl.align     = 0;
+    gl.section   = intern.STR_NIL;
     m.globals[0] = gl;
     m.global_len = 1;
 

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -193,6 +193,9 @@ pub rec Function {
 #            modules' anonymous globals never collide. a named user global is
 #            not local: its name is module-path-mangled and globally unique, so
 #            it is given GLOBAL linkage and resolves cross-object.
+# align: explicit byte alignment from an `align(...)` decorator (a power of two),
+# or 0 to use the back end's default for the global's section. always a power of
+# two when non-zero (lowering validates the folded value).
 pub rec Global {
     name:      intern.StrId;
     ty:        ir_type.IrTypeId;
@@ -201,6 +204,7 @@ pub rec Global {
     is_pub:    bool;
     is_extern: bool;
     is_local:  bool;
+    align:     u32;
 }
 
 # an IR module: one per source module.
@@ -991,6 +995,7 @@ test "ir: module teardown frees operands by capacity and agg blobs under a freei
     gl.is_pub    = false;
     gl.is_extern = false;
     gl.is_local  = true;
+    gl.align     = 0;
     m.globals[0] = gl;
     m.global_len = 1;
 

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -173,6 +173,10 @@ pub rec Function {
     label:       intern.StrId;
     line:        u32;
 
+    # object section name from a `section("...")` decorator, or STR_NIL for the
+    # default `.text`; the back end places the function's encoded bytes there.
+    section:     intern.StrId;
+
     asm_blocks:  map.Map[id.InstructionId, IrAsm];
 }
 
@@ -519,6 +523,7 @@ pub fun add_function(m: *Module, name: intern.StrId, sig: ir_type.IrTypeId, flag
     f.flags       = flags;
     f.label       = intern.STR_NIL;
     f.line        = 0;
+    f.section     = intern.STR_NIL;
     f.asm_blocks  = map.init[id.InstructionId, IrAsm](m.alloc, map.hash_u32, map.eq_u32);
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -96,9 +96,13 @@ pub rec IrTypeArray {
 # ---
 # fields:      pointer to a contiguous array of field IrTypeIds (owned)
 # field_count: number of fields
+# align:       explicit alignment from an `align(...)` decorator (a power of two),
+#              or 0 for the type's natural alignment. part of the dedup key, so an
+#              over-aligned record is a distinct type from its un-aligned twin.
 pub rec IrTypeStruct {
     fields:      *IrTypeId;
     field_count: u32;
+    align:       u32;
 }
 
 # function-type payload.
@@ -257,12 +261,15 @@ pub fun intern_array(t: *IrTypeTable, element: IrTypeId, count: u32) Result[IrTy
 # t:           the table
 # fields:      pointer to a contiguous array of field IrTypeIds
 # field_count: number of fields
+# align:       explicit alignment (a power of two) from an `align(...)` decorator,
+#              or 0 for natural alignment
 # ret:         the IrTypeId for the struct, or an allocation error
-pub fun intern_struct(t: *IrTypeTable, fields: *IrTypeId, field_count: u32) Result[IrTypeId, str] {
+pub fun intern_struct(t: *IrTypeTable, fields: *IrTypeId, field_count: u32, align: u32) Result[IrTypeId, str] {
     var probe: IrType;
     probe.kind = IRT_STRUCT;
     probe.data.struct_.fields      = fields;
     probe.data.struct_.field_count = field_count;
+    probe.data.struct_.align       = align;
     ret intern_aggregate(t, probe, fields, field_count);
 }
 
@@ -273,12 +280,15 @@ pub fun intern_struct(t: *IrTypeTable, fields: *IrTypeId, field_count: u32) Resu
 # t:           the table
 # fields:      pointer to a contiguous array of member IrTypeIds
 # field_count: number of members
+# align:       explicit alignment (a power of two) from an `align(...)` decorator,
+#              or 0 for natural alignment
 # ret:         the IrTypeId for the union type, or an allocation error
-pub fun intern_union(t: *IrTypeTable, fields: *IrTypeId, field_count: u32) Result[IrTypeId, str] {
+pub fun intern_union(t: *IrTypeTable, fields: *IrTypeId, field_count: u32, align: u32) Result[IrTypeId, str] {
     var probe: IrType;
     probe.kind = IRT_UNION;
     probe.data.struct_.fields      = fields;
     probe.data.struct_.field_count = field_count;
+    probe.data.struct_.align       = align;
     ret intern_aggregate(t, probe, fields, field_count);
 }
 
@@ -407,6 +417,9 @@ pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
             if (fa > align) { align = fa; }
             i = i + 1;
         }
+        # an `align(...)` decorator can raise the alignment (never lower it), which
+        # also rounds the total size up to the larger alignment.
+        if (ir.data.struct_.align > align) { align = ir.data.struct_.align; }
         ret round_up(off, align);
     }
     if (ir.kind == IRT_UNION) {
@@ -421,6 +434,7 @@ pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
             if (fa > align) { align = fa; }
             i = i + 1;
         }
+        if (ir.data.struct_.align > align) { align = ir.data.struct_.align; }
         ret round_up(size, align);
     }
     ret 0;
@@ -453,6 +467,8 @@ pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
             if (fa > align) { align = fa; }
             i = i + 1;
         }
+        # an `align(...)` decorator raises the alignment above the natural maximum.
+        if (ir.data.struct_.align > align) { align = ir.data.struct_.align; }
         ret align;
     }
     ret 1;
@@ -603,6 +619,9 @@ fun hash_ir_type(p: ptr) u64 {
             h = fnv1a.step_u32(h, ir.data.struct_.fields[i]);
             i = i + 1;
         }
+        # only mixed in when present, so an un-aligned struct keeps the exact hash
+        # it had before the align field existed (the dedup universe is unperturbed).
+        if (ir.data.struct_.align != 0) { h = fnv1a.step_u32(h, ir.data.struct_.align); }
         ret h;
     }
     if (ir.kind == IRT_FN) {
@@ -636,6 +655,7 @@ fun eq_ir_type(pa: ptr, pb: ptr) bool {
     }
     if (a.kind == IRT_STRUCT || a.kind == IRT_UNION) {
         if (a.data.struct_.field_count != b.data.struct_.field_count) { ret false; }
+        if (a.data.struct_.align != b.data.struct_.align) { ret false; }
         ret mem.equal[IrTypeId](a.data.struct_.fields, b.data.struct_.fields, a.data.struct_.field_count::usize);
     }
     if (a.kind == IRT_FN) {
@@ -665,7 +685,7 @@ test "ir.type: struct{i8,i64} has size 16, align 8, field offsets 0 and 8" {
     var fields: [2]IrTypeId;
     fields[0] = i8ty;
     fields[1] = i64ty;
-    val rs: Result[IrTypeId, str] = intern_struct(?types, ?fields[0], 2);
+    val rs: Result[IrTypeId, str] = intern_struct(?types, ?fields[0], 2, 0);
     if (is_err[IrTypeId, str](rs)) { ret 1; }
     val stty: IrTypeId = unwrap_ok[IrTypeId, str](rs);
 
@@ -681,5 +701,42 @@ test "ir.type: struct{i8,i64} has size 16, align 8, field offsets 0 and 8" {
     if (byte_align(?types, stty, ?tgt) != 8) { ret 1; }
     if (byte_offset(?types, stty, 0, ?tgt) != 0) { ret 1; }
     if (byte_offset(?types, stty, 1, ?tgt) != 8) { ret 1; }
+    ret 0;
+}
+
+test "ir.type: an align override raises a struct's align and size and is a distinct type (#1476)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val itr: Result[IrTypeTable, str] = init(?alloc);
+    if (is_err[IrTypeTable, str](itr)) { ret 1; }
+    var types: IrTypeTable = unwrap_ok[IrTypeTable, str](itr);
+
+    val r8: Result[IrTypeId, str] = intern_int(?types, 8);
+    if (is_err[IrTypeId, str](r8)) { ret 1; }
+    val i8ty: IrTypeId = unwrap_ok[IrTypeId, str](r8);
+
+    var fields: [1]IrTypeId;
+    fields[0] = i8ty;
+
+    val rn: Result[IrTypeId, str] = intern_struct(?types, ?fields[0], 1, 0);
+    if (is_err[IrTypeId, str](rn)) { ret 1; }
+    val natty: IrTypeId = unwrap_ok[IrTypeId, str](rn);
+
+    val ra: Result[IrTypeId, str] = intern_struct(?types, ?fields[0], 1, 32);
+    if (is_err[IrTypeId, str](ra)) { ret 1; }
+    val algty: IrTypeId = unwrap_ok[IrTypeId, str](ra);
+
+    var arch: isa.IsaVTable;
+    arch.pointer_width = 8;
+    var tgt: target.Target;
+    tgt.arch = ?arch;
+
+    # the natural struct{i8} is size 1, align 1; an align(32) override raises both
+    # the alignment and the rounded-up size, and dedups to a distinct type.
+    if (byte_align(?types, natty, ?tgt) != 1)  { ret 1; }
+    if (byte_size(?types, natty, ?tgt)  != 1)  { ret 1; }
+    if (byte_align(?types, algty, ?tgt) != 32) { ret 1; }
+    if (byte_size(?types, algty, ?tgt)  != 32) { ret 1; }
+    if (natty == algty) { ret 1; }
     ret 0;
 }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -1504,7 +1504,7 @@ test "ir.verify: aggregate representation (repr) rejects a non-address-producing
     if (!t_env(?env)) { ret 1; }
 
     # intern a single-field struct type to use as an aggregate operand type
-    val sr: Result[ir_type.IrTypeId, str] = ir_type.intern_struct(?env.m.types, ?env.i64ty, 1);
+    val sr: Result[ir_type.IrTypeId, str] = ir_type.intern_struct(?env.m.types, ?env.i64ty, 1, 0);
     if (is_err[ir_type.IrTypeId, str](sr)) { ret 1; }
     val stty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](sr);
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -757,9 +757,15 @@ pub fun lower_type(lc: *LowerContext, tid: ty.TypeId) Result[ir_type.IrTypeId, s
 # referenced from another module. a type with no field table lowers to an
 # empty struct, keeping lowering total.
 fun lower_nominal(lc: *LowerContext, tid: ty.TypeId, is_union: bool) Result[ir_type.IrTypeId, str] {
+    # an `align(...)` decorator on the record/union, folded by sema and keyed by
+    # this nominal TypeId; 0 leaves the natural alignment.
+    var nom_align: u32 = 0;
+    val ta: Option[u32] = sess.type_align(lc.s, tid::u32);
+    if (is_some[u32](ta)) { nom_align = unwrap[u32](ta); }
+
     val fields_len: u32 = ty.field_count(?lc.s.types, tid);
     if (fields_len == 0) {
-        ret ir_type.intern_struct(?lc.m.types, nil, 0);
+        ret ir_type.intern_struct(?lc.m.types, nil, 0, nom_align);
     }
 
     val buf_r: Result[*ir_type.IrTypeId, str] = allocate[ir_type.IrTypeId](lc.s.alloc, fields_len::usize);
@@ -794,10 +800,10 @@ fun lower_nominal(lc: *LowerContext, tid: ty.TypeId, is_union: bool) Result[ir_t
 
     var sr: Result[ir_type.IrTypeId, str];
     if (is_union) {
-        sr = ir_type.intern_union(?lc.m.types, buf, fields_len);
+        sr = ir_type.intern_union(?lc.m.types, buf, fields_len, nom_align);
     }
     or {
-        sr = ir_type.intern_struct(?lc.m.types, buf, fields_len);
+        sr = ir_type.intern_struct(?lc.m.types, buf, fields_len, nom_align);
     }
     deallocate[ir_type.IrTypeId](lc.s.alloc, buf, fields_len::usize);
     ret sr;
@@ -828,7 +834,7 @@ fun lower_va_list(lc: *LowerContext) Result[ir_type.IrTypeId, str] {
     buf[1] = i32t;
     buf[2] = ptrt;
     buf[3] = ptrt;
-    ret ir_type.intern_struct(?lc.m.types, ?buf[0], 4);
+    ret ir_type.intern_struct(?lc.m.types, ?buf[0], 4, 0);
 }
 
 # lowers a TYPE_FUN semantic type into an IRT_FN, propagating the semantic

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1030,6 +1030,7 @@ pub fun ensure_extern_global(lc: *LowerContext, name: intern.StrId, ty: ir_type.
     g.is_pub    = false;
     g.is_extern = true;
     g.is_local  = false;
+    g.align     = 0;
     m.globals[idx] = g;
     m.global_len   = m.global_len + 1;
     val reg: Result[bool, str] = ir.register_global(m, name, idx);
@@ -1069,6 +1070,7 @@ pub fun add_rodata_bytes(lc: *LowerContext, init: value.Value, pty: ir_type.IrTy
     g.is_pub    = false;
     g.is_extern = false;
     g.is_local  = true;
+    g.align     = 0;
     m.globals[idx] = g;
     m.global_len   = m.global_len + 1;
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1037,6 +1037,7 @@ pub fun ensure_extern_global(lc: *LowerContext, name: intern.StrId, ty: ir_type.
     g.is_extern = true;
     g.is_local  = false;
     g.align     = 0;
+    g.section   = intern.STR_NIL;
     m.globals[idx] = g;
     m.global_len   = m.global_len + 1;
     val reg: Result[bool, str] = ir.register_global(m, name, idx);
@@ -1077,6 +1078,7 @@ pub fun add_rodata_bytes(lc: *LowerContext, init: value.Value, pty: ir_type.IrTy
     g.is_extern = false;
     g.is_local  = true;
     g.align     = 0;
+    g.section   = intern.STR_NIL;
     m.globals[idx] = g;
     m.global_len   = m.global_len + 1;
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -983,6 +983,7 @@ pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_ty
     f.instr_cap   = 0;
     f.flags       = ir.FN_FLAG_EXTERN;
     f.label       = intern.STR_NIL;
+    f.section     = intern.STR_NIL;
     f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, maphash.hash_u32, maphash.eq_u32);
 
     m.functions[idx] = f;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -557,6 +557,9 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
         }
     }
 
+    val align_r: Result[u32, str] = global_align_of(ctx, d);
+    if (is_err[u32, str](align_r)) { ret err[bool, str](unwrap_err[u32, str](align_r)); }
+
     var g: ir.Global;
     g.name      = name;
     g.ty        = gty;
@@ -565,6 +568,7 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
     g.is_pub    = (d.flags & adecl.DECL_FLAG_PUB) != 0;
     g.is_extern = false;
     g.is_local  = false;
+    g.align     = unwrap_ok[u32, str](align_r);
 
     val ai: Result[u32, str] = append_global(ctx, g);
     if (is_err[u32, str](ai)) { ret err[bool, str](unwrap_err[u32, str](ai)); }
@@ -745,6 +749,60 @@ fun decl_has_decorator(ctx: *lower.LowerContext, d: *adecl.Decl, name: str) bool
         k = k + 1;
     }
     ret false;
+}
+
+# decorator_arg_eid: the ExprId of decorator `name`'s argument at ordinal `ord`,
+# or none when the decl has no such decorator or it lacks that argument.
+fun decorator_arg_eid(ctx: *lower.LowerContext, d: *adecl.Decl, name: str, ord: u32) Option[aid.ExprId] {
+    val source: str = lower.module_source(ctx);
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *adecl.Decorator = ?ctx.a.decorators[d.decorators_start + k];
+        if (str_region_equals(source, dec.name.offset, dec.name.len, name)) {
+            if (ord >= dec.args_len) { ret none[aid.ExprId](); }
+            ret some[aid.ExprId](ctx.a.expr_ids[dec.args_start + ord]);
+        }
+        k = k + 1;
+    }
+    ret none[aid.ExprId]();
+}
+
+# global_align_of: the explicit alignment an `align(expr)` decorator pins a global
+# to, or 0 when none is present (the back end then uses its section default). the
+# argument is folded to a compile-time constant by the same constant path a global
+# initialiser uses (so `align($align_of(u64))` and `align(16)` both work) and must
+# be a power of two; a non-constant or non-power-of-two value is reported on the
+# binding's name and the build is gated.
+fun global_align_of(ctx: *lower.LowerContext, d: *adecl.Decl) Result[u32, str] {
+    val arg_opt: Option[aid.ExprId] = decorator_arg_eid(ctx, d, "align", 0);
+    if (is_none[aid.ExprId](arg_opt)) { ret ok[u32, str](0); }
+    val arg: aid.ExprId = unwrap[aid.ExprId](arg_opt);
+
+    val u64_r: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](u64_r)) { ret err[u32, str](unwrap_err[ir_type.IrTypeId, str](u64_r)); }
+    val u64t: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](u64_r);
+
+    val fr: Result[value.Value, str] = fold_global_init(ctx, arg, u64t);
+    if (is_err[value.Value, str](fr)) {
+        val de: Result[bool, str] = diag.error(?ctx.s.diags, ctx.a.file_id, d.data.bind.name, "`align` decorator requires a compile-time constant argument");
+        if (is_err[bool, str](de)) { ret err[u32, str](unwrap_err[bool, str](de)); }
+        ret ok[u32, str](0);
+    }
+    val v: value.Value = unwrap_ok[value.Value, str](fr);
+    if (v.kind != value.VAL_CONST_INT) {
+        val de: Result[bool, str] = diag.error(?ctx.s.diags, ctx.a.file_id, d.data.bind.name, "`align` decorator requires an integer argument");
+        if (is_err[bool, str](de)) { ret err[u32, str](unwrap_err[bool, str](de)); }
+        ret ok[u32, str](0);
+    }
+
+    val n: u64 = v.data.int_lit;
+    # a section alignment must be a non-zero power of two.
+    if (n == 0 || (n & (n - 1)) != 0) {
+        val de: Result[bool, str] = diag.error(?ctx.s.diags, ctx.a.file_id, d.data.bind.name, "`align` value must be a non-zero power of two");
+        if (is_err[bool, str](de)) { ret err[u32, str](unwrap_err[bool, str](de)); }
+        ret ok[u32, str](0);
+    }
+    ret ok[u32, str](n::u32);
 }
 
 # appends a fresh Function to the module, growing the functions array on

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -145,6 +145,8 @@ pub fun lower_fun(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, is_
     if (is_err[u32, str](idx_r)) { ret err[bool, str](unwrap_err[u32, str](idx_r)); }
     val fn_index: u32 = unwrap_ok[u32, str](idx_r);
 
+    ctx.m.functions[fn_index].section = decl_section_of(ctx, d);
+
     # external functions carry no body
     if ((flags & ir.FN_FLAG_EXTERN) != 0) {
         ret ok[bool, str](true);
@@ -855,6 +857,7 @@ fun append_function(ctx: *lower.LowerContext, name: intern.StrId, sig: ir_type.I
     f.flags       = flags;
     f.label       = intern.STR_NIL;
     f.line        = 0;
+    f.section     = intern.STR_NIL;
     f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, maphash.hash_u32, maphash.eq_u32);
 
     m.functions[idx] = f;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -18,6 +18,7 @@ use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
+use std.types.string.str_region_equals;
 use std.types.char.char;
 use std.types.option.Option;
 use std.types.option.some;
@@ -133,6 +134,8 @@ pub fun lower_fun(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, is_
         flags = flags | ir.FN_FLAG_EXTERN;
     }
     if (is_test) { flags = flags | ir.FN_FLAG_TEST; }
+    # an `inline` decorator hints the inline pass; it already honors FN_FLAG_INLINE.
+    if (decl_has_decorator(ctx, d, "inline")) { flags = flags | ir.FN_FLAG_INLINE; }
 
     val ret_ir_r: Result[ir_type.IrTypeId, str] = function_return_ir(ctx, did);
     if (is_err[ir_type.IrTypeId, str](ret_ir_r)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](ret_ir_r)); }
@@ -728,6 +731,20 @@ fun lower_comptime_if(ctx: *lower.LowerContext, d: *adecl.Decl) Result[bool, str
         bi = bi + 1;
     }
     ret ok[bool, str](true);
+}
+
+# decl_has_decorator: reports whether decl `d` carries a leading backtick
+# decorator whose directive name equals `name` (e.g. `inline`). decorator name
+# spans index into the current module's source via the lower context's AST.
+fun decl_has_decorator(ctx: *lower.LowerContext, d: *adecl.Decl, name: str) bool {
+    val source: str = lower.module_source(ctx);
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *adecl.Decorator = ?ctx.a.decorators[d.decorators_start + k];
+        if (str_region_equals(source, dec.name.offset, dec.name.len, name)) { ret true; }
+        k = k + 1;
+    }
+    ret false;
 }
 
 # appends a fresh Function to the module, growing the functions array on

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -569,6 +569,7 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
     g.is_extern = false;
     g.is_local  = false;
     g.align     = unwrap_ok[u32, str](align_r);
+    g.section   = decl_section_of(ctx, d);
 
     val ai: Result[u32, str] = append_global(ctx, g);
     if (is_err[u32, str](ai)) { ret err[bool, str](unwrap_err[u32, str](ai)); }
@@ -749,6 +750,27 @@ fun decl_has_decorator(ctx: *lower.LowerContext, d: *adecl.Decl, name: str) bool
         k = k + 1;
     }
     ret false;
+}
+
+# decl_section_of: the interned section name a `section("...")` decorator places
+# decl `d` in, or STR_NIL for the back end's default. the argument is a string
+# literal (sema validated the shape); its inner content (quotes stripped) is
+# interned.
+fun decl_section_of(ctx: *lower.LowerContext, d: *adecl.Decl) intern.StrId {
+    val arg_opt: Option[aid.ExprId] = decorator_arg_eid(ctx, d, "section", 0);
+    if (is_none[aid.ExprId](arg_opt)) { ret intern.STR_NIL; }
+    val ve_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, unwrap[aid.ExprId](arg_opt));
+    if (is_none[*aexpr.Expr](ve_opt)) { ret intern.STR_NIL; }
+    val ve: *aexpr.Expr = unwrap[*aexpr.Expr](ve_opt);
+    if (ve.kind != aexpr.EXPR_KIND_LIT_STR || ve.span.len < 2::usize) { ret intern.STR_NIL; }
+
+    var inner: token.Span = ve.span;
+    inner.offset = inner.offset + 1::usize;
+    inner.len    = inner.len - 2::usize;
+
+    val r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), inner);
+    if (is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
+    ret unwrap_ok[intern.StrId, str](r);
 }
 
 # decorator_arg_eid: the ExprId of decorator `name`'s argument at ordinal `ord`,

--- a/src/lang/me/lower/testrunner.mach
+++ b/src/lang/me/lower/testrunner.mach
@@ -242,6 +242,7 @@ fun append_function(m: *ir.Module, name: intern.StrId, sig: ir_type.IrTypeId, fl
     f.flags       = flags;
     f.label       = intern.STR_NIL;
     f.line        = 0;
+    f.section     = intern.STR_NIL;
     f.asm_blocks  = map.init[irid.InstructionId, ir.IrAsm](m.alloc, maphash.hash_u32, maphash.eq_u32);
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -57,6 +57,7 @@ fwd modid.MODULE_NIL;
 # module_fqns:  ModuleId -> the module's fully-qualified path StrId; populated by the driver alongside module_asts, read by the back-end symbol mangler so a cross-module reference can name the defining module's mangled symbol (a reference is keyed on the referent's origin ModuleId, the definition on its own)
 # export_names: `(ModuleId << 32 | DeclId)` -> the literal link-name override declared by a `$<sym>.symbol = "..."` directive (or an `ext fun` foreign symbol); a decl present in this map keeps its literal name rather than being mangled, the sole exemption keeping the program entry, runtime, and foreign symbols linkable against the names written in inline asm
 # export_libraries: `(ModuleId << 32 | DeclId)` -> the dynamic library a `$<sym>.library = "..."` directive pins an `ext` import to (e.g. `"ws2_32.dll"`); consulted by the driver to build `import_libraries` once link names are final
+# type_aligns: nominal TypeId -> the explicit byte alignment an `align(...)` decorator pins a record/union to; folded once by sema (where the decl is visible) and read by the middle end when lowering the nominal to an IR struct so its layout honors the override
 # import_libraries: link symbol name StrId -> the library StrId an import is pinned to; the link-name-keyed projection of `export_libraries` the back-end linker consults to attribute each PE import descriptor to a specific dependency rather than the first one
 # module_sema:    ModuleId -> its `*sema.SemaResult`, stored opaque (as `ptr`) to keep this leaf module free of an import cycle on the front end; the back-end monomorphizer casts it back to lower a generic template body against the typing of the module that declared it
 # module_resolve: ModuleId -> its `*resolve.ResolveResult`, stored opaque like module_sema, so a generic instance body is lowered against the declaring module's name resolution
@@ -74,6 +75,7 @@ pub rec Session {
     module_fqns:      map.Map[modid.ModuleId, intern.StrId];
     export_names:     map.Map[u64, intern.StrId];
     export_libraries: map.Map[u64, intern.StrId];
+    type_aligns:      map.Map[u32, u32];
     import_libraries: map.Map[intern.StrId, intern.StrId];
     module_sema:      map.Map[modid.ModuleId, ptr];
     module_resolve:   map.Map[modid.ModuleId, ptr];
@@ -111,6 +113,7 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
     s.module_fqns      = map.init[modid.ModuleId, intern.StrId](alloc, maphash.hash_u32, maphash.eq_u32);
     s.export_names     = map.init[u64, intern.StrId](alloc, maphash.hash_u64, maphash.eq_u64);
     s.export_libraries = map.init[u64, intern.StrId](alloc, maphash.hash_u64, maphash.eq_u64);
+    s.type_aligns      = map.init[u32, u32](alloc, maphash.hash_u32, maphash.eq_u32);
     s.import_libraries = map.init[intern.StrId, intern.StrId](alloc, maphash.hash_u32, maphash.eq_u32);
     s.module_sema      = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
     s.module_resolve   = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
@@ -185,6 +188,7 @@ pub fun dnit(s: *Session) {
     map.dnit[modid.ModuleId, intern.StrId](?s.module_fqns);
     map.dnit[u64, intern.StrId](?s.export_names);
     map.dnit[u64, intern.StrId](?s.export_libraries);
+    map.dnit[u32, u32](?s.type_aligns);
     map.dnit[intern.StrId, intern.StrId](?s.import_libraries);
     map.dnit[modid.ModuleId, ptr](?s.module_sema);
     map.dnit[modid.ModuleId, ptr](?s.module_resolve);
@@ -224,6 +228,7 @@ pub fun reset_module_registry(s: *Session) {
     map.clear[modid.ModuleId, intern.StrId](?s.module_fqns);
     map.clear[u64, intern.StrId](?s.export_names);
     map.clear[u64, intern.StrId](?s.export_libraries);
+    map.clear[u32, u32](?s.type_aligns);
     map.clear[intern.StrId, intern.StrId](?s.import_libraries);
     map.clear[modid.ModuleId, ptr](?s.module_sema);
     map.clear[modid.ModuleId, ptr](?s.module_resolve);
@@ -361,6 +366,32 @@ pub fun export_library(s: *Session, mid: modid.ModuleId, did: u32) Option[intern
     val r: Result[*intern.StrId, str] = map.get[u64, intern.StrId](?s.export_libraries, ?key);
     if (is_ok[*intern.StrId, str](r)) { ret some[intern.StrId](@unwrap_ok[*intern.StrId, str](r)); }
     ret none[intern.StrId]();
+}
+
+# register_type_align: record the explicit alignment an `align(...)` decorator
+# pins nominal TypeId `tid` to. folded once by sema; the middle end reads it when
+# lowering the nominal so its IR struct carries the override. registering twice
+# overwrites.
+# ---
+# s:     the session
+# tid:   nominal TypeId (a `type.TypeId`, cast to u32)
+# align: the byte alignment (a power of two)
+# ret:   true on success, or an allocation error from the registry map
+pub fun register_type_align(s: *Session, tid: u32, align: u32) Result[bool, str] {
+    ret map.insert[u32, u32](?s.type_aligns, tid, align);
+}
+
+# type_align: the explicit alignment registered for nominal TypeId `tid`, or none
+# when the type uses its natural alignment.
+# ---
+# s:   the session
+# tid: nominal TypeId (cast to u32)
+# ret: some(align) when an override is registered, none otherwise
+pub fun type_align(s: *Session, tid: u32) Option[u32] {
+    var key: u32 = tid;
+    val r: Result[*u32, str] = map.get[u32, u32](?s.type_aligns, ?key);
+    if (is_ok[*u32, str](r)) { ret some[u32](@unwrap_ok[*u32, str](r)); }
+    ret none[u32]();
 }
 
 # register_import_library: pin the import emitted under link name `name` to


### PR DESCRIPTION
Implements #1476 — per-declaration codegen decorators on the (previously reserved) backtick. Part of the v1.7 comptime epic (#1477).

## Scope (decorator set CLOSED)
`symbol(str)` / `section(str)` (fns & globals), `inline` (fns), `align(usize)` (data & types), `library(str)` (per-extern import routing → `mach.toml [os.*] libs`). Codegen-only — NOT visibility (that's `pub`).

## Plan (5 stages, incremental)
- [x] Lexer: backtick is a real token (`KIND_BACKTICK`), not a lex error.
- [ ] Parser: leading `` `name(args)` `` / `` `flag` `` clauses before a decl; args are comptime exprs.
- [ ] AST: decorator list on `Decl`.
- [ ] Sema: validate (known directive, arg type, target legality).
- [ ] Codegen: apply symbol/section/inline/align/library, reusing the existing `$sym`/`$main` setter codegen paths.

## Additive / seed-safe
KEEP the `$sym.*`/`$main.*` setters working this release (vendored std + seed compat); setter removal is the #1480 collapse (post-seed-bump), NOT here. `$align_of` already exists, so `` `align($align_of(u64))` `` (acceptance) works.

Draft until all 5 stages land. `mach test` 503/503 green so far.


Closes #1476
