### PR TITLE
ci: real self-host fixpoint gate on PRs + aarch64 structural check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,32 +259,36 @@ jobs:
       - name: Cross-compile mach to aarch64
         run: out/linux/bin/mach build . --target linux-arm64
 
-      - name: Structurally verify the cross-built aarch64 compiler (of.Section.align)
+      - name: Structurally verify the cross-built aarch64 objects (of.Section.align)
         run: |
           set -euo pipefail
-          bin=out/linux-arm64/bin/mach
-          test -x "$bin" || { echo "::error::aarch64 cross-build produced no binary"; exit 1; }
           # the x86 fixpoint lane byte-diffs the ELF emitter end-to-end; the aarch64
           # back end can't self-host to a fixpoint on PRs (a compiler build under qemu
           # is too slow), so structurally verify the generic of.Section.align path on
-          # the cross-built compiler instead: a valid AArch64 ELF whose every section
-          # alignment is a power of two. catches a malformed / non-pow2 section align on
-          # the second emitter that the x86-only fixpoint can't see.
-          readelf -h "$bin" | grep -q 'Machine:.*AArch64' || { echo "::error::cross-built mach is not an AArch64 ELF"; exit 1; }
-          readelf -SW "$bin"
-          aligns="$(readelf -SW "$bin" | grep -E '^[[:space:]]*\[[[:space:]]*[0-9]+\]' | awk '{print $NF}')"
-          for a in $aligns; do
-            case "$a" in
-              ''|*[!0-9]*) echo "::error::unparseable aarch64 section alignment: '$a'"; exit 1;;
-            esac
-            # a section alignment is well-formed iff it is 0 (unconstrained) or a power
-            # of two — i.e. a & (a-1) == 0.
-            if [ "$a" -ne 0 ] && [ "$(( a & (a - 1) ))" -ne 0 ]; then
-              echo "::error::aarch64 compiler section has a non-power-of-two alignment: $a"
-              exit 1
-            fi
+          # the cross-built objects instead. the linked executable carries only program
+          # headers (no section table), so inspect the relocatable objects the cross-
+          # build emits — they retain the section headers of.Section.align writes: each
+          # must be a valid AArch64 ELF whose every section alignment is a power of two.
+          # catches a malformed / non-pow2 section align on the second emitter that the
+          # x86-only fixpoint can't see.
+          mapfile -t objs < <(find out/linux-arm64 -name '*.o' -type f)
+          test "${#objs[@]}" -gt 0 || { echo "::error::no cross-built aarch64 objects under out/linux-arm64"; exit 1; }
+          for obj in "${objs[@]}"; do
+            readelf -h "$obj" | grep -qi 'Machine:.*AArch64' || { echo "::error::cross-built object is not an AArch64 ELF: $obj"; exit 1; }
+            aligns="$(readelf -SW "$obj" | grep -E '^[[:space:]]*\[[[:space:]]*[0-9]+\]' | awk '{print $NF}')"
+            for a in $aligns; do
+              case "$a" in
+                ''|*[!0-9]*) echo "::error::unparseable aarch64 section alignment '$a' in $obj"; exit 1;;
+              esac
+              # a section alignment is well-formed iff it is 0 (unconstrained) or a power
+              # of two — i.e. a & (a-1) == 0.
+              if [ "$a" -ne 0 ] && [ "$(( a & (a - 1) ))" -ne 0 ]; then
+                echo "::error::aarch64 object $obj has a non-power-of-two section alignment: $a"
+                exit 1
+              fi
+            done
           done
-          echo "aarch64 section alignments OK (all power-of-two): $(echo "$aligns" | tr '\n' ' ')"
+          echo "structurally verified ${#objs[@]} cross-built aarch64 object(s): AArch64 ELF, power-of-two section alignments"
 
       # GATED (#1464): `mach test . --target linux-arm64` on the mach project — which
       # has a `main` bin entry — fails at link with "multiple definition of 'main'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,52 @@ jobs:
           mach build .
           test -x out/linux/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
 
+  # the self-host fixpoint is the project's load-bearing correctness invariant, but
+  # the release `cmp` is stage2-vs-stage3 — both emitted by the NEW compiler, so a
+  # *uniform* codegen change lands in both stages and cancels (invisible). this lane
+  # runs the comparison that actually catches it on PRs: seed→stage1 vs stage1→stage2.
+  # stage1 is emitted by the OLD released seed, stage2 by the PR's own compiler, so a
+  # byte-diff between them surfaces any change to how the compiler emits *itself*. a
+  # clean PR is byte-reproducible from the seed (stage1 == stage2); a divergence means
+  # the PR changed the compiler's self-emission relative to the released seed.
+  fixpoint:
+    name: Self-host Fixpoint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Fetch released mach (build seed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # the versioned linux tarball from the most recent release is the build seed.
+          tmp="$(mktemp -d)"
+          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
+          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: Byte-diff the seed→stage1→stage2 self-host fixpoint
+        run: |
+          set -euo pipefail
+          # the released seed builds the source (stage1); stage1 then rebuilds the
+          # source (stage2). one extra rebuild over the single-stage lanes — cheap.
+          mach build .
+          test -x out/linux/bin/mach || { echo "::error::seed build produced no binary"; exit 1; }
+          cp out/linux/bin/mach stage1; chmod +x stage1
+          ./stage1 build .
+          cp out/linux/bin/mach stage2
+          if cmp -s stage1 stage2; then
+            echo "stage1 == stage2 ($(sha256sum stage1 | cut -d' ' -f1)) — byte-reproducible from the released seed."
+            exit 0
+          fi
+          echo "::error::self-host fixpoint diverged — the seed-built compiler (stage1) is not byte-identical to the self-built compiler (stage2). this PR changes how the compiler emits itself relative to the released seed; if the codegen change is intentional, confirm the divergence is expected (the next release re-seeds), otherwise the seed mis-compiled the new source."
+          sha256sum stage1 stage2 || true
+          cmp stage1 stage2 || true
+          exit 1
+
   test-suite:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -212,6 +258,33 @@ jobs:
       # links cleanly. mirrors the integration lane's `mach build . --target windows`.
       - name: Cross-compile mach to aarch64
         run: out/linux/bin/mach build . --target linux-arm64
+
+      - name: Structurally verify the cross-built aarch64 compiler (of.Section.align)
+        run: |
+          set -euo pipefail
+          bin=out/linux-arm64/bin/mach
+          test -x "$bin" || { echo "::error::aarch64 cross-build produced no binary"; exit 1; }
+          # the x86 fixpoint lane byte-diffs the ELF emitter end-to-end; the aarch64
+          # back end can't self-host to a fixpoint on PRs (a compiler build under qemu
+          # is too slow), so structurally verify the generic of.Section.align path on
+          # the cross-built compiler instead: a valid AArch64 ELF whose every section
+          # alignment is a power of two. catches a malformed / non-pow2 section align on
+          # the second emitter that the x86-only fixpoint can't see.
+          readelf -h "$bin" | grep -q 'Machine:.*AArch64' || { echo "::error::cross-built mach is not an AArch64 ELF"; exit 1; }
+          readelf -SW "$bin"
+          aligns="$(readelf -SW "$bin" | grep -E '^[[:space:]]*\[[[:space:]]*[0-9]+\]' | awk '{print $NF}')"
+          for a in $aligns; do
+            case "$a" in
+              ''|*[!0-9]*) echo "::error::unparseable aarch64 section alignment: '$a'"; exit 1;;
+            esac
+            # a section alignment is well-formed iff it is 0 (unconstrained) or a power
+            # of two — i.e. a & (a-1) == 0.
+            if [ "$a" -ne 0 ] && [ "$(( a & (a - 1) ))" -ne 0 ]; then
+              echo "::error::aarch64 compiler section has a non-power-of-two alignment: $a"
+              exit 1
+            fi
+          done
+          echo "aarch64 section alignments OK (all power-of-two): $(echo "$aligns" | tr '\n' ' ')"
 
       # GATED (#1464): `mach test . --target linux-arm64` on the mach project — which
       # has a `main` bin entry — fails at link with "multiple definition of 'main'"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,22 @@ jobs:
             exit 1
           fi
 
+      - name: Report byte-reproducibility from the prior seed (informational)
+        run: |
+          set -euo pipefail
+          # the fixpoint cmp above is stage2(b) vs stage3 — both emitted by the NEW
+          # compiler, so a *uniform* codegen change vs the prior release lands in both
+          # and cancels (invisible). the seed→stage1(a) vs stage1→stage2(b) diff is the
+          # one that surfaces it: a is emitted by the OLD seed. a release legitimately
+          # changes codegen, so this is REPORTED, not gated — it records whether this
+          # version is byte-reproducible from the prior seed.
+          if cmp -s a b; then
+            echo "::notice::byte-reproducible from the prior seed (stage1 == stage2): no change to the compiler's self-emission."
+          else
+            echo "::notice::NOT byte-reproducible from the prior seed (stage1 != stage2): this release changes how the compiler emits itself — expected when it includes a codegen change."
+            sha256sum a b || true
+          fi
+
       - name: Cross-compile the windows target
         run: out/linux/bin/mach build . --target windows
 


### PR DESCRIPTION
Closes #1488.

The self-host fixpoint — the project's load-bearing correctness invariant — was not measured where it matters, so a class of codegen change could land without it guarding.

## What this changes

**`ci.yml` — new `Self-host Fixpoint` lane (PRs).** Byte-diffs `seed→stage1` vs `stage1→stage2`. `stage1` is emitted by the OLD released seed, `stage2` by the PR's own compiler, so a divergence surfaces any change to how the compiler emits *itself* — including a *uniform* codegen shift that the release `stage2==stage3` cmp is blind to (there the change lands in both stages and cancels). One extra rebuild over the existing single-stage lanes. A clean PR is byte-reproducible from the seed (`stage1 == stage2`).

**`ci.yml` — aarch64 structural check.** The aarch64 back end can't self-host to a fixpoint on PRs (a compiler build under qemu is too slow), so the cross-built aarch64 compiler is structurally verified with `readelf`: a valid AArch64 ELF whose every section alignment is `0` or a power of two — covering the generic `of.Section.align` path on the second emitter (gap #3).

**`release.yml` — informational byte-reproducibility report (gap #2).** `a` (stage1) and `b` (stage2) already exist in the release fixpoint step; a non-fatal `cmp a b` now records whether the version is byte-reproducible from the prior seed. Non-gating because a release legitimately changes codegen.

## Semantics of the PR fixpoint gate

A `stage1 != stage2` divergence means the PR changes the compiler's self-emission relative to the released seed. For an intentional codegen change this is expected (the next release re-seeds) and is surfaced for review; otherwise it means the seed mis-compiled the new source. It fits the existing review-then-admin-merge flow — a red fixpoint check flags the divergence for the reviewer rather than silently passing.

## Notes
- The existing `Full Build` lane is left in place; once branch-protection required checks are updated it could be folded into `Self-host Fixpoint` (which subsumes it).
- The over-alignment canary from the issue is best realized via the discriminating `aligndec` improvements in the #1491 fast-follow; left out here to keep this PR purely CI/workflow.