### PR TITLE
fix: decorator align silent-drops + validation nits

### DIFF
--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1039,14 +1039,14 @@ test "diagnostics: a decorator on an incompatible target is rejected (#1476)" {
     var s: sess.Session = unwrap_ok[sess.Session, str](sr);
     var es: EditorSession = init(?s);
 
-    # `align` targets data and types, not a function — the mismatch is reported.
+    # `align` targets records, unions, and globals, not a function — reported.
     val fr: Result[src.FileId, str] = open(?es, "wt.mach", "`align(8)` fun f() i64 { ret 0; }\n");
     if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
 
     val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
     if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
-    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "`align` decorator applies only to data and types")) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "`align` decorator applies only to records, unions, and globals")) { dnit(?es); sess.dnit(?s); ret 1; }
 
     dnit(?es);
     sess.dnit(?s);
@@ -1071,6 +1071,51 @@ test "diagnostics: a section decorator on a function or global is accepted; on a
     if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val list: *diag.DiagList = unwrap_ok[*diag.DiagList, str](dr);
     if (!diag_has(list, "`section` decorator applies only to functions and globals")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "diagnostics: a negative align on a type is reported, not silently dropped (#1490)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `align(-8)` on a record folds to a negative integer-typed constant — the
+    # body-pass validator can't catch it (it's integer-typed), so the decl-pass
+    # fold must report it rather than `ret` silently.
+    val fr: Result[src.FileId, str] = open(?es, "na.mach", "`align(-8)` rec R { a: u8; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "`align` value must be a non-zero power of two")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "diagnostics: align on a def alias is rejected, not silently ignored (#1490)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # a `def` alias has no layout of its own and emits no symbol, so an `align` on
+    # it would silently no-op; it is rejected as an invalid target instead.
+    val fr: Result[src.FileId, str] = open(?es, "da.mach", "`align(8)` def D: u64;\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "`align` decorator applies only to records, unions, and globals")) { dnit(?es); sess.dnit(?s); ret 1; }
 
     dnit(?es);
     sess.dnit(?s);

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -406,11 +406,19 @@ fun require_string_arg(sc: *ctxm.SemaContext, dec: *decl.Decorator, count_msg: s
     }
 }
 
-# true for decl kinds carrying data or a type (the `align` decorator's targets).
-fun is_data_or_type(kind: decl.DeclKind) bool {
+# true for an `align` decorator target: a global binding (val/var) or a record /
+# union nominal. a `def` alias is excluded — it is transparent (no layout of its
+# own and emits no symbol), so an alignment on it would silently no-op.
+fun is_align_target(kind: decl.DeclKind) bool {
     ret kind == decl.DECL_KIND_VAL || kind == decl.DECL_KIND_VAR ||
-        kind == decl.DECL_KIND_REC || kind == decl.DECL_KIND_UNI ||
-        kind == decl.DECL_KIND_DEF;
+        kind == decl.DECL_KIND_REC || kind == decl.DECL_KIND_UNI;
+}
+
+# true for a global binding (val/var) — the targets whose `align` argument the
+# body-pass validator type-checks (a rec/uni's argument is validated by the
+# decl-pass fold in record_type_align instead, to avoid a double report).
+fun is_global_binding(kind: decl.DeclKind) bool {
+    ret kind == decl.DECL_KIND_VAL || kind == decl.DECL_KIND_VAR;
 }
 
 # true for a function or a global binding (the `symbol`/`section` targets).
@@ -455,18 +463,18 @@ fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Deco
     if (decorator_named(sc, dec, "align")) {
         if (dec.args_len != 1) {
             ctxm.report(sc, dec.name, "`align` decorator takes one argument");
-        } or {
-            # the argument is a comptime expression that must fold to an integer
-            # alignment (a literal, or `$align_of(T)` / `$size_of(T)`). its exact
-            # value and the power-of-two check are computed at lowering, where type
-            # layout is available; here only its type is checked.
+        } or (is_global_binding(d.kind)) {
+            # for a global the value is folded at lowering (type layout available);
+            # here only its type is checked. a rec/uni argument is validated wholly
+            # by the decl-pass fold (record_type_align) — checking it here too would
+            # double-report — so the type check is global-only.
             val ae: id.ExprId = sc.a.expr_ids[dec.args_start];
             if (!type.is_integer(?sc.s.types, decorator_arg_type(sc, ae))) {
                 ctxm.report(sc, dec.name, "`align` decorator argument must be an integer comptime expression");
             }
         }
-        if (!is_data_or_type(d.kind)) {
-            ctxm.report(sc, dec.name, "`align` decorator applies only to data and types");
+        if (!is_align_target(d.kind)) {
+            ctxm.report(sc, dec.name, "`align` decorator applies only to records, unions, and globals");
         }
         ret;
     }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -189,10 +189,25 @@ fun record_type_align(sc: *sema.SemaContext, did: id.DeclId, ty: type.TypeId) {
                 ret;
             }
             val cv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
-            if (cv.kind != comptime.CT_KIND_INT || comptime.ct_is_negative(cv)) { ret; }
+            # the body-pass validator skips the type-arg checks for rec/uni (it
+            # would double-report against this fold), so every invalid case is
+            # reported here — a non-integer, a negative, a non-power-of-two, or one
+            # overflowing the u32 alignment field — never silently dropped.
+            if (cv.kind != comptime.CT_KIND_INT) {
+                sema.report(sc, dec.name, "`align` value must be an integer");
+                ret;
+            }
+            if (comptime.ct_is_negative(cv)) {
+                sema.report(sc, dec.name, "`align` value must be a non-zero power of two");
+                ret;
+            }
             val n: u64 = cv.data.i:~u64;
             if (n == 0 || (n & (n - 1)) != 0) {
                 sema.report(sc, dec.name, "`align` value must be a non-zero power of two");
+                ret;
+            }
+            if (n > 0xFFFFFFFF) {
+                sema.report(sc, dec.name, "`align` value exceeds the maximum alignment");
                 ret;
             }
             val rr: Result[bool, str] = sess.register_type_align(sc.s, ty::u32, n::u32);

--- a/src/lang/fe/token.mach
+++ b/src/lang/fe/token.mach
@@ -144,6 +144,7 @@ pub fun kind_str(kind: Kind) str {
     if (kind == KIND_COLON_COLON) { ret "::"; }
     if (kind == KIND_COLON_TILDE) { ret ":~"; }
     if (kind == KIND_DOT_DOT_DOT) { ret "..."; }
+    if (kind == KIND_BACKTICK)    { ret "`"; }
     if (kind == KIND_EOF)         { ret "eof"; }
     if (kind == KIND_ERROR)       { ret "error"; }
     ret "unknown";

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -826,6 +826,13 @@ fun global_align_of(ctx: *lower.LowerContext, d: *adecl.Decl) Result[u32, str] {
         if (is_err[bool, str](de)) { ret err[u32, str](unwrap_err[bool, str](de)); }
         ret ok[u32, str](0);
     }
+    # the alignment is stored in a u32 section field; a power of two past u32 would
+    # truncate (e.g. 2^32 -> 0), so reject it rather than emit a 0-aligned section.
+    if (n > 0xFFFFFFFF) {
+        val de: Result[bool, str] = diag.error(?ctx.s.diags, ctx.a.file_id, d.data.bind.name, "`align` value exceeds the maximum alignment");
+        if (is_err[bool, str](de)) { ret err[u32, str](unwrap_err[bool, str](de)); }
+        ret ok[u32, str](0);
+    }
     ret ok[u32, str](n::u32);
 }
 


### PR DESCRIPTION
Fast-follow to #1476, from the #1484 review. Closes #1490.

## Silent-drops (correctness)
- `align(-N)` on a type was accepted then silently ignored (`record_type_align` bailed on `ct_is_negative` with a bare `ret`; the body-pass validator can't catch it — a negative is integer-typed). Now reported as a non-power-of-two. `record_type_align` also now reports a non-integer arg, since the body-pass validator no longer type-checks rec/uni args (see double-report below), making the decl-pass fold the sole, complete validator for type-align.
- `align(N) def Foo` was accepted then silently no-op'd. Dropped `DECL_KIND_DEF` from the align targets — a transparent alias has no layout of its own and emits no symbol. Message: "applies only to records, unions, and globals".

## Nits
- u64 align narrowed via `n::u32` with no range check (a power of two ≥ 2^32 truncated to align 0) — bound-checked in both `record_type_align` and `global_align_of`.
- A non-integer non-constant align on a rec/uni double-reported — the body-pass type check is now global-only (the decl-pass fold owns rec/uni).
- `kind_str` had no `KIND_BACKTICK` case (rendered "unknown") — added.

## Verification
- Scratch-verified each case (negative / def / 2^32 / string / valid) reports exactly once, none silent.
- Regression tests added (negative-align, align-on-def).
- Full unit suite green (515); self-host fixpoint byte-identical including **seed(stage1)==stage2** (the comparison that catches a uniform codegen shift).