### PR TITLE
feat(comptime): type values — $type_of + type == (#1472)

### DIFF
--- a/.github/tests/typeofgate/app/mach.toml
+++ b/.github/tests/typeofgate/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "typeofgate"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.typeofgate]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/typeofgate/app/src/main.mach
+++ b/.github/tests/typeofgate/app/src/main.mach
@@ -1,0 +1,25 @@
+use std.runtime;
+
+# `$type_of(expr)` yields a comptime TYPE value; a type `==` / `!=` inside a `$if`
+# gate folds to an identity compare at lowering (#1472). exits 0 only when every
+# gate selects the arm its operand types dictate; a wrong arm returns that gate's
+# id. covers a primitive name operand, `!=`, the `$type_of` == `$type_of` form
+# (both operands type values), pointer-type identity, and a distinct-type miss.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    var a:  i64  = 0;
+    var a2: i64  = 0;
+    var b:  u8   = 0;
+    var c:  *i64 = nil;
+    var d:  *i64 = nil;
+
+    $if ($type_of(a) == i64) { } $or { ret 1; }
+    $if ($type_of(b) == i64) { ret 2; } $or { }
+    $if ($type_of(a) != i64) { ret 3; } $or { }
+    $if ($type_of(a) == $type_of(a2)) { } $or { ret 4; }
+    $if ($type_of(a) == $type_of(b)) { ret 5; } $or { }
+    $if ($type_of(c) == $type_of(d)) { } $or { ret 6; }
+    $if ($type_of(c) == $type_of(a)) { ret 7; } $or { }
+    $if ($type_of(b) == u8) { } $or { ret 8; }
+    ret 0;
+}

--- a/.github/tests/typeofgate/app/src/main.mach
+++ b/.github/tests/typeofgate/app/src/main.mach
@@ -1,14 +1,21 @@
 use std.runtime;
 
 # `$type_of(expr)` yields a comptime TYPE value; a type `==` / `!=` inside a `$if`
-# gate folds to an identity compare at lowering (#1472). exits 0 only when every
-# gate selects the arm its operand types dictate; a wrong arm returns that gate's
-# id. covers a primitive name operand, `!=`, the `$type_of` == `$type_of` form
-# (both operands type values), pointer-type identity, nominal record identity
-# (distinct records differ; same record matches), and a transparent `def`
-# (identity-equal to its underlying type, like `def str: *u8`).
+# gate folds to an identity compare at lowering (#1472). type identity is the
+# resolved sema TypeId, so the compare inherits the type system's exact rules.
+# exits 0 only when every gate selects the arm its operand types dictate; a wrong
+# arm returns that gate's id. covers: a primitive name operand, `!=`, the
+# `$type_of` == `$type_of` form (both operands type values), pointer identity,
+# nominal record identity (distinct decls with identical fields stay distinct),
+# a record named directly, transparent `def` aliases (identity-equal to the
+# underlying type, like `def str: *u8`), and generic-instance identity
+# (canonicalized by type-arg list).
 rec Pair { x: i64; y: i64; }
 rec Trip { a: i64; b: i64; c: i64; }
+# A and B share an identical field shape but are distinct nominal types.
+rec A { x: i64; y: i64; }
+rec B { x: i64; y: i64; }
+rec Box[T] { v: T; }
 def MyInt: i64;
 
 $main.symbol = "main";
@@ -41,5 +48,19 @@ fun main(argc: i64, argv: **u8) i64 {
     # a transparent `def` is identity-equal to its underlying type
     $if ($type_of(m) == MyInt) { } $or { ret 13; }
     $if ($type_of(m) == i64) { } $or { ret 14; }
+
+    # nominal: identical field shape, distinct declarations -> distinct types
+    var ra: A = A { x: 0, y: 0 };
+    var rb: B = B { x: 0, y: 0 };
+    $if ($type_of(ra) == $type_of(rb)) { ret 15; } $or { }
+    $if ($type_of(ra) == A) { } $or { ret 16; }
+    $if ($type_of(ra) == B) { ret 17; } $or { }
+
+    # generic instances canonicalize by type-arg list
+    var bi:  Box[i64] = Box[i64] { v: 0 };
+    var bi2: Box[i64] = Box[i64] { v: 0 };
+    var bu:  Box[u8]  = Box[u8]  { v: 0 };
+    $if ($type_of(bi) == $type_of(bi2)) { } $or { ret 18; }
+    $if ($type_of(bi) == $type_of(bu))  { ret 19; } $or { }
     ret 0;
 }

--- a/.github/tests/typeofgate/app/src/main.mach
+++ b/.github/tests/typeofgate/app/src/main.mach
@@ -4,14 +4,24 @@ use std.runtime;
 # gate folds to an identity compare at lowering (#1472). exits 0 only when every
 # gate selects the arm its operand types dictate; a wrong arm returns that gate's
 # id. covers a primitive name operand, `!=`, the `$type_of` == `$type_of` form
-# (both operands type values), pointer-type identity, and a distinct-type miss.
+# (both operands type values), pointer-type identity, nominal record identity
+# (distinct records differ; same record matches), and a transparent `def`
+# (identity-equal to its underlying type, like `def str: *u8`).
+rec Pair { x: i64; y: i64; }
+rec Trip { a: i64; b: i64; c: i64; }
+def MyInt: i64;
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
-    var a:  i64  = 0;
-    var a2: i64  = 0;
-    var b:  u8   = 0;
-    var c:  *i64 = nil;
-    var d:  *i64 = nil;
+    var a:  i64   = 0;
+    var a2: i64   = 0;
+    var b:  u8    = 0;
+    var c:  *i64  = nil;
+    var d:  *i64  = nil;
+    var p:  Pair  = Pair { x: 0, y: 0 };
+    var q:  Pair  = Pair { x: 0, y: 0 };
+    var t:  Trip  = Trip { a: 0, b: 0, c: 0 };
+    var m:  MyInt = 0;
 
     $if ($type_of(a) == i64) { } $or { ret 1; }
     $if ($type_of(b) == i64) { ret 2; } $or { }
@@ -21,5 +31,15 @@ fun main(argc: i64, argv: **u8) i64 {
     $if ($type_of(c) == $type_of(d)) { } $or { ret 6; }
     $if ($type_of(c) == $type_of(a)) { ret 7; } $or { }
     $if ($type_of(b) == u8) { } $or { ret 8; }
+
+    # nominal record identity
+    $if ($type_of(p) == $type_of(q)) { } $or { ret 9; }
+    $if ($type_of(p) == $type_of(t)) { ret 10; } $or { }
+    $if ($type_of(p) == Pair) { } $or { ret 11; }
+    $if ($type_of(p) == Trip) { ret 12; } $or { }
+
+    # a transparent `def` is identity-equal to its underlying type
+    $if ($type_of(m) == MyInt) { } $or { ret 13; }
+    $if ($type_of(m) == i64) { } $or { ret 14; }
     ret 0;
 }

--- a/.github/tests/typeofgate/reject/mach.toml
+++ b/.github/tests/typeofgate/reject/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "typeofreject"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.typeofreject]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/typeofgate/reject/src/main.mach
+++ b/.github/tests/typeofgate/reject/src/main.mach
@@ -1,0 +1,11 @@
+use std.runtime;
+
+# a `$type_of` type comparison is comptime-only: it folds to a selected arm at
+# lowering and has no runtime value, so using it as a value (here, a binding
+# initialiser) must FAIL rather than compile to garbage (#1472).
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    var a: i64 = 0;
+    var x: u8 = $type_of(a) == i64;
+    ret x::i64;
+}

--- a/.github/tests/typeofgate/run.sh
+++ b/.github/tests/typeofgate/run.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# $type_of type-gate integration test (#1472). two halves:
+#
+#   folding — `$type_of(expr)` yields a comptime TYPE value, and a type `==` / `!=`
+#   inside a `$if` gate folds to an identity compare at lowering. the app asserts
+#   every gate selects the arm its operand types dictate and exits 0 only when all
+#   match; a wrong arm returns that gate's id. this is the end-to-end proof that
+#   the lowering-time type resolver folds the gate against the real types.
+#
+#   rejection — a type comparison is comptime-only; used in a runtime value
+#   position the build must FAIL with the teaching diagnostic, never compile.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+# the exact diagnostic sema emits for a type comparison in a value position.
+REJECT_DIAG='a `$type_of` type comparison is comptime-only; it is valid only as a `$if` gate condition'
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# build_and_run <app-dir> <label>: vendor std, build, run, require exit 0. the
+# app's own main returns the misselected gate's id on a wrong arm.
+build_and_run() {
+    local app="$1"; local label="$2"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    if ! ( cd "$dst" && "$MACH" build . ) >/dev/null 2>&1; then
+        echo "FAIL typeofgate/$label: build failed" >&2; fail=1; return
+    fi
+    local bin
+    bin="$(find "$dst/out" -type f -path '*/bin/*' | head -n1)"
+    if [ -z "$bin" ]; then
+        echo "FAIL typeofgate/$label: no binary produced" >&2; fail=1; return
+    fi
+    set +e
+    "$bin"; local code=$?
+    set -e
+    if [ "$code" -ne 0 ]; then
+        echo "FAIL typeofgate/$label: gate id $code selected the wrong arm" >&2; fail=1; return
+    fi
+    echo "PASS typeofgate/$label: \$type_of gates fold to the right arm"
+}
+
+# expect_reject <app-dir> <label> <diagnostic>: vendor std, build, and require
+# the build to FAIL with `diagnostic` present verbatim on stderr.
+expect_reject() {
+    local app="$1"; local label="$2"; local want="$3"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    local out
+    if out="$( cd "$dst" && "$MACH" build . 2>&1 )"; then
+        echo "FAIL typeofgate/$label: build unexpectedly succeeded for a value-position type comparison" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF -- "$want"; then
+        echo "FAIL typeofgate/$label: missing the teaching diagnostic; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    echo "PASS typeofgate/$label: value-position type comparison rejected with the teaching diagnostic"
+}
+
+build_and_run app    "type gate folding"
+expect_reject reject "value-position type comparison" "$REJECT_DIAG"
+
+exit "$fail"

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -82,6 +82,13 @@ pub val CT_KIND_FLOAT: CTKind = 1;
 pub val CT_KIND_BOOL:  CTKind = 2;
 pub val CT_KIND_STR:   CTKind = 3;
 
+# a comptime TYPE value (#1472): `$type_of(expr)` and a type-name operand fold to
+# one of these so a type `==` / `!=` inside a `$if` gate is a plain identity
+# compare. the payload `data.t` is an opaque type-identity token minted by the
+# typed layer's resolver (a canonical sema TypeId): equal tokens name the same
+# type. eval never interprets the token, only compares it.
+pub val CT_KIND_TYPE:  CTKind = 4;
+
 # COMPTIME_BARE_IDENT_MSG: the single teaching diagnostic for a standalone bare
 # `$ident` (#1249). the comptime channel's shapes are a closed set; a lone
 # `$ident` is none of them — a comptime parameter is referenced without `$`, and
@@ -108,6 +115,7 @@ pub rec CTValue {
         f: f64;
         b: bool;
         s: intern.StrId;
+        t: u32;
     };
 }
 
@@ -135,6 +143,29 @@ pub def ModuleMemberFn: fun(ptr, id.ExprId) Result[Option[CTValue], str];
 # is not available before lowering, so such a path cannot fold there.
 pub val COMPTIME_MEMBER_NO_RESOLVER_MSG: str =
     "a module-qualified member path is only comptime-evaluable after name resolution";
+
+# TypeIdentFn: resolves a type-comparison operand expression to its opaque
+# type-identity token (a canonical sema TypeId), or none when the operand has no
+# resolvable type. eval recognizes the type-comparison shape structurally
+# (`$type_of(...)` against a type name) but has no type system, so the typed
+# layer (lowering, where monomorphized concrete types are known) installs this
+# hook with `set_type_resolver`. the first argument is the installer's opaque
+# context; the second is the operand expression id, already unwrapped past a
+# `$type_of(...)` to its inner value expression.
+pub def TypeIdentFn: fun(ptr, id.ExprId) Result[Option[u32], str];
+
+# COMPTIME_TYPE_NO_RESOLVER_MSG: surfaced when a type comparison is evaluated in
+# a context that installed no type resolver — type identities are only available
+# after types exist, so arm selection on a `$type_of(...)` gate is deferred to
+# lowering.
+pub val COMPTIME_TYPE_NO_RESOLVER_MSG: str =
+    "a type comparison is only comptime-evaluable after type checking";
+
+# COMPTIME_TYPE_UNRESOLVED_MSG: surfaced when a type-comparison operand has no
+# resolvable type identity (an untyped or erroneous operand) even though a
+# resolver is installed.
+pub val COMPTIME_TYPE_UNRESOLVED_MSG: str =
+    "type comparison operand does not name a type";
 
 # COMPTIME_MEMBER_NOT_CONST_MSG: surfaced when a module-qualified member path
 # resolves but does not name a module-level comptime constant (a function, a
@@ -193,6 +224,10 @@ pub def FrameMark: u32;
 # member_fn:      erased ModuleMemberFn resolving `alias.CONST` member paths, or
 #                 nil when no resolver is installed (every pass before lowering)
 # member_data:    opaque context passed to member_fn (the *LowerContext)
+# type_fn:        erased TypeIdentFn resolving a type-comparison operand to its
+#                 type-identity token, or nil when no resolver is installed (every
+#                 pass before lowering)
+# type_data:      opaque context passed to type_fn (the *LowerContext)
 pub rec ComptimeCtx {
     alloc:          *Allocator;
     target_os_id:   u32;
@@ -218,6 +253,8 @@ pub rec ComptimeCtx {
     bin_name:       intern.StrId;
     member_fn:      *u8;
     member_data:    ptr;
+    type_fn:        *u8;
+    type_data:      ptr;
 }
 
 val INITIAL_CONST_CAP: u32 = 8;
@@ -279,6 +316,8 @@ pub fun init(
     c.bin_name       = intern.STR_NIL;
     c.member_fn      = nil;
     c.member_data    = nil;
+    c.type_fn        = nil;
+    c.type_data      = nil;
     ret c;
 }
 
@@ -294,6 +333,20 @@ pub fun init(
 pub fun set_member_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
     c.member_fn   = fn;
     c.member_data = data;
+}
+
+# set_type_resolver: install (or clear) the type-comparison operand resolver this
+# context consults when comptime.eval folds a `$type_of(...)` type comparison.
+# lowering installs it pointing at the active LowerContext; passing `nil` for
+# both clears it. kept out of the build/target setters because it is per-pass
+# state, not manifest-derived.
+# ---
+# c:    context to update
+# fn:   erased TypeIdentFn, or nil to clear
+# data: opaque context handed back to fn, or nil to clear
+pub fun set_type_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
+    c.type_fn   = fn;
+    c.type_data = data;
 }
 
 # set_build_context: bind the manifest-derived project metadata, the selected
@@ -856,6 +909,16 @@ fun eval_binary(
         ret eval_logical(c, a, source, bin, interner);
     }
 
+    # a type comparison (`$type_of(...) == TypeName`, #1472) is a closed shape: an
+    # `==` / `!=` with a `$type_of(...)` operand. each operand folds to a TYPE
+    # value through the installed type resolver, and the result is an identity
+    # compare. recognized structurally here so a type operand never reaches the
+    # numeric / value evaluator below.
+    if ((bin.op == expr.BIN_EQ || bin.op == expr.BIN_NEQ)
+        && is_type_comparison(a, source, bin)) {
+        ret eval_type_comparison(c, a, source, bin, interner);
+    }
+
     val lhs_r: Result[CTValue, str] = eval(c, a, source, bin.lhs, interner);
     if (is_err[CTValue, str](lhs_r)) { ret lhs_r; }
     val rhs_r: Result[CTValue, str] = eval(c, a, source, bin.rhs, interner);
@@ -931,6 +994,109 @@ fun eval_logical(
     ret bool_value(rhs.data.b);
 }
 
+# is_type_of_call: whether `eid` is a `$type_of(arg)` intrinsic call, recognized
+# structurally by a `$`-rooted COMPTIME_IDENT callee spelled `type_of`. arity is
+# validated by sema, not here.
+# ---
+# a:      the ast that owns `eid`
+# source: source text (for the callee span)
+# eid:    expression id to test
+# ret:    true when `eid` is a `$type_of(...)` call
+pub fun is_type_of_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL) { ret false; }
+    val ce_opt: Option[*expr.Expr] = ast.get_expr(a, node.data.call.callee);
+    if (is_none[*expr.Expr](ce_opt)) { ret false; }
+    val ce: *expr.Expr = unwrap[*expr.Expr](ce_opt);
+    if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret false; }
+    val ns: token.Span = comptime_ident_name(ce.span);
+    if (ns.len == 0) { ret false; }
+    ret view_eq_str(span_text(source, ns), "type_of");
+}
+
+# type_of_arg: the single value-argument expression of a `$type_of(arg)` call, or
+# EXPR_NIL when `eid` is not such a call or carries no argument.
+# ---
+# a:   the ast that owns `eid`
+# eid: a `$type_of(...)` call expression id
+# ret: the argument expression id, or EXPR_NIL
+pub fun type_of_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
+    if (eid == id.EXPR_NIL) { ret id.EXPR_NIL; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret id.EXPR_NIL; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL) { ret id.EXPR_NIL; }
+    if (node.data.call.args_len < 1) { ret id.EXPR_NIL; }
+    ret a.expr_ids[node.data.call.args_start];
+}
+
+# type_operand_value: the expression whose type identity a type-comparison operand
+# denotes. `$type_of(e)` denotes the type of its inner value `e`; any other
+# operand is a type-name spelling (`i64`, `module.Foo`) and denotes itself. the
+# installed type resolver reads the resulting expression's type slot either way.
+# ---
+# a:       the ast that owns `operand`
+# source:  source text (for the callee span)
+# operand: a type-comparison operand expression id
+# ret:     the inner value expression for `$type_of(...)`, else `operand`
+pub fun type_operand_value(a: *ast.Ast, source: str, operand: id.ExprId) id.ExprId {
+    if (is_type_of_call(a, source, operand)) { ret type_of_arg(a, operand); }
+    ret operand;
+}
+
+# is_type_comparison: whether a binary `==` / `!=` is a type comparison — true
+# when at least one operand is a `$type_of(...)` call. shared by resolve (to bind
+# the type-name operand as a type), sema (to type the comparison), and the
+# evaluator (to fold it).
+# ---
+# a:      the ast that owns `bin`
+# source: source text (for callee spans)
+# bin:    the binary expression
+# ret:    true when the binary is a type comparison
+pub fun is_type_comparison(a: *ast.Ast, source: str, bin: *expr.ExprBinary) bool {
+    ret is_type_of_call(a, source, bin.lhs) || is_type_of_call(a, source, bin.rhs);
+}
+
+# folds a type comparison: each operand resolves to a TYPE value through the
+# installed resolver, and the result is an identity compare. a context with no
+# resolver (every pass before lowering) defers loudly so arm selection happens at
+# lowering, where monomorphized concrete types are known.
+fun eval_type_comparison(
+    c:        *ComptimeCtx,
+    a:        *ast.Ast,
+    source:   str,
+    bin:      *expr.ExprBinary,
+    interner: *intern.Interner
+) Result[CTValue, str] {
+    val l_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.lhs);
+    if (is_err[CTValue, str](l_r)) { ret l_r; }
+    val r_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.rhs);
+    if (is_err[CTValue, str](r_r)) { ret r_r; }
+    ret apply_equality(bin.op, unwrap_ok[CTValue, str](l_r), unwrap_ok[CTValue, str](r_r));
+}
+
+# resolves one type-comparison operand to its TYPE value through the installed
+# type resolver. errors when no resolver is installed, or when the operand has no
+# resolvable type identity.
+fun eval_type_operand(
+    c:       *ComptimeCtx,
+    a:       *ast.Ast,
+    source:  str,
+    operand: id.ExprId
+) Result[CTValue, str] {
+    if (c.type_fn == nil) { ret err[CTValue, str](COMPTIME_TYPE_NO_RESOLVER_MSG); }
+    val fn: TypeIdentFn = c.type_fn::TypeIdentFn;
+    val value_eid: id.ExprId = type_operand_value(a, source, operand);
+    val r: Result[Option[u32], str] = fn(c.type_data, value_eid);
+    if (is_err[Option[u32], str](r)) { ret err[CTValue, str](unwrap_err[Option[u32], str](r)); }
+    val o: Option[u32] = unwrap_ok[Option[u32], str](r);
+    if (is_none[u32](o)) { ret err[CTValue, str](COMPTIME_TYPE_UNRESOLVED_MSG); }
+    ret type_value(unwrap[u32](o));
+}
+
 # ct_is_negative: whether an integer CTValue denotes a negative mathematical
 # value. only a signed payload with its high bit set is negative; an unsigned
 # payload is always a non-negative magnitude. non-integer values are never
@@ -970,6 +1136,7 @@ fun apply_equality(op: expr.BinOp, lhs: CTValue, rhs: CTValue) Result[CTValue, s
     or (lhs.kind == CT_KIND_FLOAT) { eq = lhs.data.f == rhs.data.f; }
     or (lhs.kind == CT_KIND_BOOL)  { eq = lhs.data.b == rhs.data.b; }
     or (lhs.kind == CT_KIND_STR)   { eq = lhs.data.s == rhs.data.s; }
+    or (lhs.kind == CT_KIND_TYPE)  { eq = lhs.data.t == rhs.data.t; }
 
     if (op == expr.BIN_EQ)  { ret bool_value(eq); }
     ret bool_value(!eq);
@@ -1664,6 +1831,15 @@ fun str_value(s: intern.StrId) Result[CTValue, str] {
     var v: CTValue;
     v.kind   = CT_KIND_STR;
     v.data.s = s;
+    ret ok[CTValue, str](v);
+}
+
+# type_value: a comptime TYPE value carrying an opaque type-identity token (a
+# canonical sema TypeId minted by the resolver). compared only for identity.
+fun type_value(t: u32) Result[CTValue, str] {
+    var v: CTValue;
+    v.kind   = CT_KIND_TYPE;
+    v.data.t = t;
     ret ok[CTValue, str](v);
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1986,6 +1986,21 @@ test "comptime: equal magnitudes across signedness compare equal (#1272)" {
     ret 0;
 }
 
+test "comptime: TYPE values compare by identity token, never against a scalar (#1472)" {
+    val a: CTValue = unwrap_ok[CTValue, str](type_value(7));
+    val b: CTValue = unwrap_ok[CTValue, str](type_value(7));
+    val c: CTValue = unwrap_ok[CTValue, str](type_value(9));
+    # equal tokens name the same type; distinct tokens do not.
+    if (!t_bool(apply_equality(expr.BIN_EQ, a, b)))  { ret 1; }
+    if (t_bool(apply_equality(expr.BIN_EQ, a, c)))   { ret 1; }
+    if (!t_bool(apply_equality(expr.BIN_NEQ, a, c))) { ret 1; }
+    # a TYPE value never compares against a non-type kind: the kind-mismatch
+    # guard rejects it rather than coercing to a scalar.
+    val i: CTValue = unwrap_ok[CTValue, str](int_value(7));
+    if (!is_err[CTValue, str](apply_equality(expr.BIN_EQ, a, i))) { ret 1; }
+    ret 0;
+}
+
 test "comptime: u64-range arithmetic computes the unsigned value, not the signed (#1272)" {
     val big: CTValue = unwrap_ok[CTValue, str](t_eval_int("0xFFFFFFFFFFFFFFFF"));
     val two: CTValue = unwrap_ok[CTValue, str](int_value(2));

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1287,7 +1287,8 @@ fun bind_fwd_module(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, 
 # value is fixed only per call site, at lowering — so EVERY arm is bound
 # structurally; arm selection is deferred to per-value monomorphization.
 fun bind_comptime_if(rc: *ResolveContext, branches_start: u32, branches_len: u32, at_decl_scope: bool) Result[bool, str] {
-    if (!at_decl_scope && comptime_if_gated_on_param(rc, branches_start, branches_len)) {
+    if (!at_decl_scope && (comptime_if_gated_on_param(rc, branches_start, branches_len)
+                        || comptime_if_has_type_comparison(rc, branches_start, branches_len))) {
         var ai: u32 = 0;
         for (ai < branches_len) {
             val arm: *decl.ComptimeBranch = ?rc.a.comptime_branches[branches_start + ai];
@@ -1391,6 +1392,43 @@ fun comptime_if_gated_on_param(rc: *ResolveContext, branches_start: u32, branche
             ret true;
         }
         bi = bi + 1;
+    }
+    ret false;
+}
+
+# reports whether any arm of a `$if` chain is gated on a type comparison
+# (`$type_of(...) == TypeName`, #1472). a type comparison cannot fold before
+# types exist, so — like a comptime-param gate — its chain binds every arm and
+# defers arm selection to lowering, where the type resolver is installed.
+fun comptime_if_has_type_comparison(rc: *ResolveContext, branches_start: u32, branches_len: u32) bool {
+    var bi: u32 = 0;
+    for (bi < branches_len) {
+        val br: *decl.ComptimeBranch = ?rc.a.comptime_branches[branches_start + bi];
+        if (br.cond != id.EXPR_NIL && gate_has_type_comparison(rc, br.cond)) {
+            ret true;
+        }
+        bi = bi + 1;
+    }
+    ret false;
+}
+
+# walks a `$if` gate reporting whether it contains a type comparison — an
+# `==` / `!=` with a `$type_of(...)` operand — at any depth.
+fun gate_has_type_comparison(rc: *ResolveContext, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val e_opt: Option[*expr.Expr] = ast.get_expr(rc.a, eid);
+    if (is_none[*expr.Expr](e_opt)) { ret false; }
+    val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
+    if (e.kind == expr.EXPR_KIND_BINARY) {
+        if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
+            && comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)) {
+            ret true;
+        }
+        ret gate_has_type_comparison(rc, e.data.binary.lhs)
+         || gate_has_type_comparison(rc, e.data.binary.rhs);
+    }
+    if (e.kind == expr.EXPR_KIND_UNARY) {
+        ret gate_has_type_comparison(rc, e.data.unary.operand);
     }
     ret false;
 }
@@ -1657,6 +1695,14 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
         ret bind_ident(rc, eid, e.span);
     }
     if (e.kind == expr.EXPR_KIND_BINARY) {
+        # a type comparison (`$type_of(...) == TypeName`, #1472) binds its operands
+        # specially: a `$type_of(e)` operand binds only its inner value `e` (the
+        # comptime-ident callee is a builtin), and the other operand is a type-name
+        # spelling bound as a type so sema can recover the named type.
+        if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
+            && comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)) {
+            ret bind_type_comparison(rc, ?e.data.binary);
+        }
         val rl: Result[bool, str] = bind_expr(rc, e.data.binary.lhs);
         if (is_err[bool, str](rl)) { ret rl; }
         ret bind_expr(rc, e.data.binary.rhs);
@@ -2098,6 +2144,27 @@ fun bind_intrinsic_type_arg(rc: *ResolveContext, eid: id.ExprId) Result[bool, st
     # any other argument shape is not a type spelling; bind it as a normal
     # expression so a diagnostic surfaces the misuse.
     ret bind_expr(rc, eid);
+}
+
+# binds the two operands of a type comparison (`$type_of(...) == TypeName`,
+# #1472). each operand binds through `bind_type_operand`.
+fun bind_type_comparison(rc: *ResolveContext, bin: *expr.ExprBinary) Result[bool, str] {
+    val rl: Result[bool, str] = bind_type_operand(rc, bin.lhs);
+    if (is_err[bool, str](rl)) { ret rl; }
+    ret bind_type_operand(rc, bin.rhs);
+}
+
+# binds one type-comparison operand. a `$type_of(e)` operand binds only its inner
+# value `e` (the `$`-rooted comptime-ident callee is a builtin, bound nowhere); a
+# type-name operand binds as a type spelling so its resolved symbol is recorded
+# for sema to recover the named type.
+fun bind_type_operand(rc: *ResolveContext, operand: id.ExprId) Result[bool, str] {
+    if (comptime.is_type_of_call(rc.a, rc.source, operand)) {
+        val arg: id.ExprId = comptime.type_of_arg(rc.a, operand);
+        if (arg == id.EXPR_NIL) { ret ok[bool, str](true); }
+        ret bind_expr(rc, arg);
+    }
+    ret bind_intrinsic_type_arg(rc, operand);
 }
 
 # interns a static literal in the session interner, returning its StrId or

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -177,7 +177,8 @@ fun init_context(
     sc.type_resolved_ty = nil;
     sc.decl_type        = nil;
 
-    sc.callee_eid   = id.EXPR_NIL;
+    sc.callee_eid       = id.EXPR_NIL;
+    sc.in_comptime_gate = false;
 
     if (a.expr_len > 0) {
         val r: Result[*type.TypeId, str] = allocate[type.TypeId](s.alloc, a.expr_len);
@@ -590,15 +591,23 @@ fun infer_stmt_list(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: type.Ty
 }
 
 fun infer_stmt_comptime_if(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: type.TypeId) Result[bool, str] {
-    # a chain gated on a comptime value parameter cannot select an arm at sema
-    # time (the parameter's value is fixed per call site). type-check EVERY arm
+    # a chain gated on a comptime value parameter, or on a type comparison
+    # (`$type_of(...)`, #1472), cannot select an arm at sema time — the
+    # parameter's value is fixed per call site, and a type comparison folds only
+    # once the type resolver is installed at lowering. type-check EVERY arm
     # structurally; arm selection is deferred to per-value monomorphization.
-    if (stmt_comptime_if_gated_on_param(sc, start, len)) {
+    if (stmt_comptime_if_gated_on_param(sc, start, len)
+        || stmt_comptime_if_has_type_comparison(sc, start, len)) {
         var ai: u32 = 0;
         for (ai < len) {
             val arm: *decl.ComptimeBranch = ?sc.a.comptime_branches[start + ai];
             if (arm.cond != id.EXPR_NIL) {
+                # mark gate context so a `$type_of(...)` type comparison is accepted
+                # here (and rejected as a value elsewhere).
+                val saved_gate: bool = sc.in_comptime_gate;
+                sc.in_comptime_gate = true;
                 infer.infer_expr(sc, arm.cond);
+                sc.in_comptime_gate = saved_gate;
                 # every arm gate of a param-gated chain must itself be comptime-
                 # foldable: its free identifiers must all be comptime (comptime
                 # params or comptime constants), never a runtime local/param/var.
@@ -638,6 +647,41 @@ fun stmt_comptime_if_gated_on_param(sc: *ctxm.SemaContext, start: u32, len: u32)
             ret true;
         }
         bi = bi + 1;
+    }
+    ret false;
+}
+
+# reports whether any arm gate of a statement-level `$if` chain is a type
+# comparison (`$type_of(...) == TypeName`, #1472). such a gate folds only at
+# lowering, so — like a comptime-param gate — its chain defers arm selection.
+fun stmt_comptime_if_has_type_comparison(sc: *ctxm.SemaContext, start: u32, len: u32) bool {
+    var bi: u32 = 0;
+    for (bi < len) {
+        val br: *decl.ComptimeBranch = ?sc.a.comptime_branches[start + bi];
+        if (br.cond != id.EXPR_NIL && gate_has_type_comparison(sc, br.cond)) {
+            ret true;
+        }
+        bi = bi + 1;
+    }
+    ret false;
+}
+
+# walks a `$if` gate reporting whether it contains a type comparison at any depth.
+fun gate_has_type_comparison(sc: *ctxm.SemaContext, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val e_opt: Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (is_none[*expr.Expr](e_opt)) { ret false; }
+    val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
+    if (e.kind == expr.EXPR_KIND_BINARY) {
+        if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
+            && comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)) {
+            ret true;
+        }
+        ret gate_has_type_comparison(sc, e.data.binary.lhs)
+         || gate_has_type_comparison(sc, e.data.binary.rhs);
+    }
+    if (e.kind == expr.EXPR_KIND_UNARY) {
+        ret gate_has_type_comparison(sc, e.data.unary.operand);
     }
     ret false;
 }
@@ -684,6 +728,13 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
     # composite operators: recurse into operands so a runtime leaf is reported at
     # its own span rather than masked by the parent.
     if (k == expr.EXPR_KIND_BINARY) {
+        # a type comparison (`$type_of(...) == TypeName`, #1472) is a well-formed
+        # comptime gate; its operands name types (validated by infer) and it folds
+        # at lowering, so it is not recursed into as value subexpressions.
+        if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
+            && comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)) {
+            ret;
+        }
         check_comptime_gate(sc, e.data.binary.lhs);
         check_comptime_gate(sc, e.data.binary.rhs);
         ret;

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -124,6 +124,12 @@ pub rec SemaContext {
     # function in callee position (it is a template, callable but not a value) and
     # rejects it everywhere else.
     callee_eid: id.ExprId;
+
+    # true while inferring a comptime `$if` gate condition. a type comparison
+    # (`$type_of(...)`, #1472) is comptime-only and valid only here; set
+    # transiently so infer_type_comparison can reject the same shape in a runtime
+    # value position.
+    in_comptime_gate: bool;
 }
 
 # resolved_type_of: returns the interned TypeId a syntactic AstType resolved to, or TYPE_ERROR/TYPE_NIL for out-of-range or absent ids.

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -457,6 +457,15 @@ fun report_comptime_param_fn_ref(sc: *sema.SemaContext, eid: id.ExprId) type.Typ
 fun infer_binary(sc: *sema.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, span: token.Span) type.TypeId {
     if (b.op == expr.BIN_ASSIGN) { ret infer_assign(sc, b, span); }
 
+    # a type comparison (`$type_of(...) == TypeName`, #1472) is a comptime-only
+    # bool: its operands name types, not values, so they are typed specially and
+    # never reach the value comparison below (which would mis-infer the
+    # `$type_of(...)` call).
+    if ((b.op == expr.BIN_EQ || b.op == expr.BIN_NEQ)
+        && comptime.is_type_comparison(sc.a, sc.source, b)) {
+        ret infer_type_comparison(sc, b, span);
+    }
+
     var lt: type.TypeId = infer_expr(sc, b.lhs);
     var rt: type.TypeId = infer_expr(sc, b.rhs);
     if (lt == type.TYPE_ERROR || rt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
@@ -518,6 +527,45 @@ fun infer_binary(sc: *sema.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, spa
     # arithmetic: ADD, SUB, MUL, DIV, MOD
     if ((!operands_ok) || !is_numeric(sc, lt)) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
     ret lt;
+}
+
+# types a type comparison (`$type_of(...) == TypeName`, #1472). each operand is
+# typed for its type identity — a `$type_of(e)` operand by inferring its inner
+# value `e`, a type-name operand by resolving the named type into its expr_type
+# slot — so the lowering-time resolver reads a populated type either way. the
+# comparison itself is a bool (u8), foldable only at lowering where the resolver
+# is installed.
+fun infer_type_comparison(sc: *sema.SemaContext, b: *expr.ExprBinary, span: token.Span) type.TypeId {
+    # a type comparison is comptime-only: it folds to a selected arm at lowering
+    # and has no runtime value. valid only as a `$if` gate condition; in any
+    # runtime value position it is a misuse, reported at its own span.
+    if (!sc.in_comptime_gate) {
+        sema.report(sc, span, "a `$type_of` type comparison is comptime-only; it is valid only as a `$if` gate condition");
+        ret type.TYPE_ERROR;
+    }
+    val lt: type.TypeId = infer_type_operand(sc, b.lhs, span);
+    val rt: type.TypeId = infer_type_operand(sc, b.rhs, span);
+    if (lt == type.TYPE_ERROR || rt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    ret prim_or_error(sc, type.TYPE_U8);
+}
+
+# types one type-comparison operand and returns the type it names. a `$type_of(e)`
+# operand names the type of its inner value `e` (inferred so its expr_type slot
+# populates); any other operand is a type-name spelling resolved through the same
+# path as a `$size_of` argument, with the named type written into its expr_type
+# slot.
+fun infer_type_operand(sc: *sema.SemaContext, operand: id.ExprId, span: token.Span) type.TypeId {
+    if (comptime.is_type_of_call(sc.a, sc.source, operand)) {
+        val arg: id.ExprId = comptime.type_of_arg(sc.a, operand);
+        if (arg == id.EXPR_NIL) {
+            sema.report(sc, span, "$type_of: expected one argument");
+            ret type.TYPE_ERROR;
+        }
+        ret infer_expr(sc, arg);
+    }
+    val op_ty: type.TypeId = intrinsic_operand_type(sc, operand, span);
+    set_expr_type(sc, operand, op_ty);
+    ret op_ty;
 }
 
 # ASSIGN: RHS must be assignable to LHS; result is the LHS type. a literal
@@ -715,6 +763,17 @@ fun infer_comptime_intrinsic(sc: *sema.SemaContext, c: *expr.ExprCall, span: tok
 
     val name: intern.StrId = comptime_ident_name(sc, ce.span);
     if (name == intern.STR_NIL) { ret type.TYPE_NIL; }
+
+    # `$type_of(...)` (#1472) is not a value: it yields a comptime TYPE, valid only
+    # as a type-comparison operand inside a `$if` gate (typed by
+    # infer_type_comparison, which never reaches here). any `$type_of` arriving in
+    # a value call position is a misuse, reported precisely rather than left to
+    # surface as an opaque bare-comptime-ident error at lowering.
+    if (name == interned(sc, "type_of")) {
+        sema.report(sc, span, "`$type_of` yields a comptime type, not a value; use it as a type-comparison operand inside a `$if` gate");
+        ret type.TYPE_ERROR;
+    }
+
     val is_size:   bool = name == interned(sc, "size_of");
     val is_align:  bool = name == interned(sc, "align_of");
     val is_offset: bool = name == interned(sc, "offset_of");

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -257,9 +257,11 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
     lc.subst       = nil;
     lc.subst_len   = 0;
 
-    # the origin ctx folds this body's `alias.CONST` paths against the origin
-    # module's name resolution, now active on lc.
+    # the origin ctx folds this body's `alias.CONST` paths and `$type_of(...)`
+    # type gates against the origin module's name resolution and types, now active
+    # on lc.
     comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
+    comptime.set_type_resolver(octx, lctx.resolve_type_comparison_operand::*u8, lc::ptr);
 
     # open a frame on the ORIGIN context and bind the `$param -> CTValue`
     # bindings into it; the frame is closed afterward (on the error path too) so
@@ -375,9 +377,11 @@ fun emit_one_instance(lc: *lctx.LowerContext, s: *sess.Session,
     lc.subst       = args;
     lc.subst_len   = arg_len;
 
-    # the origin ctx folds this body's `alias.CONST` paths against the origin
-    # module's name resolution, now active on lc.
+    # the origin ctx folds this body's `alias.CONST` paths and `$type_of(...)`
+    # type gates against the origin module's name resolution and types, now active
+    # on lc.
     comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
+    comptime.set_type_resolver(octx, lctx.resolve_type_comparison_operand::*u8, lc::ptr);
 
     val lr: Result[bool, str] = decl.lower_instance(lc, decl_id, d, name);
     lc.ctx        = home_ctx;

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -249,6 +249,9 @@ pub fun init_context(
     # the LowerContext itself, read live so the value-instance drains' module
     # swaps stay correct.
     comptime.set_member_resolver(ctx, resolve_module_member_const::*u8, lc::ptr);
+    # install the type-comparison operand resolver so comptime.eval can fold
+    # `$type_of(...)` type gates in this module's bodies (#1472).
+    comptime.set_type_resolver(ctx, resolve_type_comparison_operand::*u8, lc::ptr);
     lc.locals      = map.init[resolve.SymbolId, value.Value](s.alloc, maphash.hash_u32, maphash.eq_u32);
     lc.local_names = map.init[intern.StrId, value.Value](s.alloc, maphash.hash_u32, maphash.eq_u32);
 
@@ -299,6 +302,7 @@ pub fun init_context(
 pub fun dnit_context(lc: *LowerContext) {
     if (lc == nil) { ret; }
     if (lc.ctx != nil) { comptime.set_member_resolver(lc.ctx, nil, nil); }
+    if (lc.ctx != nil) { comptime.set_type_resolver(lc.ctx, nil, nil); }
     map.dnit[intern.StrId, value.Value](?lc.local_names);
     map.dnit[resolve.SymbolId, value.Value](?lc.locals);
     if (lc.loops != nil && lc.loop_cap > 0) {
@@ -384,6 +388,28 @@ pub fun resolve_module_member_const(data: ptr, eid: aid.ExprId) Result[Option[co
         ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]());
     }
     ret ok[Option[comptime.CTValue], str](some[comptime.CTValue](unwrap[*comptime.NamedConst](nc).value));
+}
+
+# resolve_type_comparison_operand: the type-comparison operand resolver lowering
+# installs on every ComptimeCtx it evaluates against (a comptime.TypeIdentFn).
+# given the value expression of a type-comparison operand — a `$type_of(...)`'s
+# inner value, or a type-name spelling — it returns the operand's interned
+# semantic TypeId as an opaque type-identity token, so a `$type_of(x) == i64`
+# gate folds to an identity compare. none when the expression carries no resolved
+# type (an untyped or erroneous operand), leaving comptime.eval to defer / error.
+# `data` is the *LowerContext driving the evaluation; reading its `sema_result`
+# live keeps the resolver correct across the value-instance drains that swap the
+# active module.
+# ---
+# data: the *LowerContext, erased to a ptr by the installer
+# eid:  the operand value expression id, valid in the active module's ast
+# ret:  some(type-id token) when the operand has a resolved type, else none
+pub fun resolve_type_comparison_operand(data: ptr, eid: aid.ExprId) Result[Option[u32], str] {
+    val lc: *LowerContext = data::*LowerContext;
+    if (lc == nil) { ret ok[Option[u32], str](none[u32]()); }
+    val t: ty.TypeId = expr_type_of(lc, eid);
+    if (t == ty.TYPE_NIL || t == ty.TYPE_ERROR) { ret ok[Option[u32], str](none[u32]()); }
+    ret ok[Option[u32], str](some[u32](t::u32));
 }
 
 # resets the per-function working state before lowering a new function:


### PR DESCRIPTION
Closes #1472.

Comptime type values — `$type_of(expr)` and type `==` / `!=` inside `$if` gates. Head of the v1.7 comptime/variadics chain (#1472→#1473→#1474→#1475).

## Scope
This PR delivers the standalone, fully-testable `$type_of` slice of #1472. `$fields(T)` + `v.[f]` are resequenced into #1473 alongside `$each` — their only consumer and only lowering/test surface (#1475 spells out that those forms are spliced at monomorphization, so they have no standalone lowering). Resequencing approved by the team lead; same deliverables, cleaner PR boundaries.

## What this lands
- `$type_of(expr)` → a comptime TYPE value.
- type `==` / `!=` between a `$type_of(...)` and a type name, or between two `$type_of(...)`, usable inside a `$if` gate.
- A type comparison is comptime-only: rejected in a runtime value position with a teaching diagnostic.

## Design
`comptime.eval` is the single chokepoint for every `$if` gate (resolve / sema / driver / lower) and is deliberately type-system-free. Type introspection therefore folds at the layer that has type info — the same layering as `$size_of`/`$align_of` — via a type-resolver callback (`TypeIdentFn`) installed on `ComptimeCtx`, mirroring the existing `ModuleMemberFn`. A type comparison is a closed shape: an `==`/`!=` whose operand is a `$type_of(...)` call. eval recognizes it structurally and folds each operand to a `CT_KIND_TYPE` value, comparing by identity.

Type identity is the **resolved sema TypeId** (not a spelling string), so type `==` is bijective with type identity by construction — and inherits the type system's exact rules: transparent `def` aliases collapse to the underlying type, nominal records are distinct by `(origin, decl)`, generic instances canonicalize by type-arg list. Lowering installs the resolver (incl. cross-module value-instance drains), where monomorphized concrete types and `$if` arm selection live; pre-type passes defer arm selection loudly.

## Gates
- Self-host fixpoint: seed-built == stage1-built compiler, byte-identical (front-end additions are codegen-inert).
- Unit corpus: 516/516 (adds a `CT_KIND_TYPE` equality test).
- e2e `.github/tests/typeofgate` (19 gates + a rejection half): primitives, pointers, `!=`, the `$type_of == $type_of` form, nominal record identity (incl. distinct same-shaped records), a record named directly, transparent `def` aliases, and generic-instance identity; plus a value-position type comparison rejected with the teaching diagnostic.