### PR TITLE
test: decorator coverage — COFF section, negative resolve, discriminating asserts

### DIFF
--- a/.github/tests/aligndec/app/src/main.mach
+++ b/.github/tests/aligndec/app/src/main.mach
@@ -8,13 +8,12 @@ rec Pair { a: u64; b: u64; }
 `align(64)` `symbol("g_lit64")`
 pub var g_lit64: u8 = 7;
 
-# a comptime-expr alignment, also observably different from the default.
+# a comptime-expr alignment, also observably different from the default. this is
+# the discriminating comptime-expr case: 16 != the 8-byte default, so it fails if
+# the decorator is ignored. (`$align_of(u64)` folds to 8 — equal to the default,
+# so it could never discriminate; the natural alignment of any type is <= 8.)
 `align($size_of(Pair))` `symbol("g_cmp16")`
 pub var g_cmp16: u8 = 9;
-
-# the acceptance-criteria spelling: `$align_of(u64)` folds to 8.
-`align($align_of(u64))` `symbol("g_cmp8")`
-pub var g_cmp8: u8 = 5;
 
 # no decorator: the back end's default section alignment (8) applies.
 `symbol("g_plain")`
@@ -30,5 +29,12 @@ pub var g_over: Over;
 
 `symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
-    ret (g_lit64 + g_cmp16 + g_cmp8 + g_plain)::i64;
+    # alignment-dependent runtime probe: each over-aligned global's actual address
+    # must satisfy its requested alignment. this proves the layout even where the
+    # structural readelf check is unavailable, and a distinct sentinel makes a
+    # misalignment self-identifying instead of folding into the value sum.
+    if (((?g_lit64)::u64 & 63) != 0) { ret 91; }
+    if (((?g_cmp16)::u64 & 15) != 0) { ret 92; }
+    if (((?g_over)::u64  & 31) != 0) { ret 93; }
+    ret (g_lit64 + g_cmp16 + g_plain)::i64;
 }

--- a/.github/tests/aligndec/run.sh
+++ b/.github/tests/aligndec/run.sh
@@ -6,10 +6,10 @@
 # each decorated global lands in its own data section whose `sh_addralign` is the
 # requested alignment; the object file carries the per-symbol section header that
 # readelf reads (the final static executable strips section headers). the build
-# asserts: g_lit64 -> 64 (literal), g_cmp16 -> 16 (comptime expr), g_cmp8 -> 8
-# (`$align_of(u64)`), g_plain -> 8 (default). the binary must also run, confirming
-# the over-aligned data is laid out correctly. readelf absent -> structural check
-# skipped, run still asserted.
+# asserts: g_lit64 -> 64 (literal), g_cmp16 -> 16 (comptime expr), g_plain -> 8
+# (default), g_over -> 32 (type-raised). the binary itself ALSO probes each over-
+# aligned global's address at runtime — an alignment-dependent check that holds
+# even when readelf is absent — exiting 27 only when every probe passes.
 #
 # usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -45,15 +45,16 @@ fi
 BIN="$WORK/app/out/linux/bin/aligndec"
 OBJ="$WORK/app/out/linux/obj/aligndec/main.o"
 
-# run: the over-aligned globals sum to 7 + 9 + 5 + 11 == 32.
+# run: the alignment probes pass (exit 27 = 7 + 9 + 11); a misaligned global
+# would exit 91/92/93 instead, naming which probe failed.
 set +e
 "$BIN"; code=$?
 set -e
-if [ "$code" -ne 32 ]; then
-    echo "FAIL aligndec: program ran with exit $code, expected 32" >&2
+if [ "$code" -ne 27 ]; then
+    echo "FAIL aligndec: program ran with exit $code, expected 27 (91/92/93 = a runtime misalignment)" >&2
     fail=1
 else
-    echo "PASS aligndec: the program with over-aligned globals runs correctly"
+    echo "PASS aligndec: the over-aligned globals are correctly aligned at runtime"
 fi
 
 # structural check: each global's section header alignment in the object file.
@@ -77,7 +78,6 @@ if command -v readelf >/dev/null 2>&1 && [ -f "$OBJ" ]; then
     }
     expect_align g_lit64 64
     expect_align g_cmp16 16
-    expect_align g_cmp8  8
     expect_align g_plain 8
     # a global of an `align(32)` record inherits the type's raised alignment.
     expect_align g_over  32

--- a/.github/tests/decarg/branch/mach.toml
+++ b/.github/tests/decarg/branch/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "decbranch"
+name = "Decorator-Arg Resolution Test — $if branch"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.decbranch]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/decarg/branch/src/main.mach
+++ b/.github/tests/decarg/branch/src/main.mach
@@ -1,0 +1,16 @@
+use std.runtime.linux.x86_64;
+
+# a decl inside a TAKEN `$if (...)` decl-scope branch is collected and bound like
+# any top-level decl (bind_comptime_if -> bind_decl_list -> bind_decorator_args),
+# so its decorator args are resolved too. an unresolved identifier in the in-branch
+# decorator must surface the same name-resolution error — proving the resolver
+# descends into comptime decl branches and validates the decorators it finds.
+val FLAG: i64 = 1;
+
+$if (FLAG == 1) {
+    `section(NoSuchThing)`
+    pub var g_in_if: u64 = 7;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/decarg/run.sh
+++ b/.github/tests/decarg/run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# decorator-argument resolution test (#1491, fast-follow #1476): bind_decorator_args
+# (resolve.mach) walks the comptime expression in each backtick decorator, so an
+# unresolved identifier there must surface a name-resolution error rather than be
+# silently dropped. two placements are covered:
+#   unresolved — a top-level decl whose decorator names an undeclared identifier.
+#   branch     — the same, on a decl inside a TAKEN `$if (...)` decl-scope branch,
+#                proving the resolver descends into comptime decl branches and binds
+#                the decorators it finds there.
+# each build must FAIL with a located `unresolved identifier` naming the offender.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# vendor <app-dir>: copy the app into the temp dir and symlink the vendored std.
+vendor() {
+    local app="$1" dst="$WORK/$1"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+}
+
+# expect_unresolved <app-dir> <name>: build the app and require it to FAIL with a
+# diagnostic that reports <name> as an `unresolved identifier`, located on main.mach.
+expect_unresolved() {
+    local app="$1" name="$2" out dst="$WORK/$1"
+    vendor "$app"
+    if out="$( cd "$dst" && "$MACH" build . 2>&1 )"; then
+        echo "FAIL decarg/$app: build unexpectedly succeeded (the decorator arg was not resolved)" >&2
+        fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF "unresolved identifier"; then
+        echo "FAIL decarg/$app: diagnostic missing 'unresolved identifier'; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF "$name"; then
+        echo "FAIL decarg/$app: diagnostic did not name '$name'; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qE 'main\.mach:[0-9]+:[0-9]+:'; then
+        echo "FAIL decarg/$app: diagnostic missing file:line:col; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    echo "PASS decarg/$app: an unresolved decorator-arg identifier is a located name-resolution error"
+}
+
+expect_unresolved unresolved NoSuchThing
+expect_unresolved branch     NoSuchThing
+
+exit "$fail"

--- a/.github/tests/decarg/unresolved/mach.toml
+++ b/.github/tests/decarg/unresolved/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "decunres"
+name = "Decorator-Arg Resolution Test — Unresolved"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.decunres]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/decarg/unresolved/src/main.mach
+++ b/.github/tests/decarg/unresolved/src/main.mach
@@ -1,0 +1,10 @@
+use std.runtime.linux.x86_64;
+
+# a backtick decorator's argument is a comptime expression whose identifiers are
+# resolved by bind_decorator_args (resolve.mach). an unresolved identifier there
+# must surface a name-resolution error — proving the args are walked, not ignored.
+`align(NoSuchThing)`
+rec R { a: u8; }
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/inline/app/src/main.mach
+++ b/.github/tests/inline/app/src/main.mach
@@ -2,9 +2,12 @@ use std.runtime.linux.x86_64;
 
 # `big` exceeds the inline pass's instruction threshold and is called from two
 # sites, so the size and single-use heuristics both decline to inline it — only
-# the `inline` decorator (which sets FN_FLAG_INLINE) forces it. the run.sh
-# control confirms the calls survive when the decorator is removed.
+# the `inline` decorator (which sets FN_FLAG_INLINE) forces it. the `symbol`
+# decorator pins its link name so the call-site grep matches a stable mnemonic
+# (`call big`) rather than a mangled internal name. the run.sh control confirms
+# the calls survive when the `inline` decorator alone is removed.
 `inline`
+`symbol("big")`
 fun big(a: i64, b: i64) i64 {
     var x: i64 = a + b;
     x = x + a; x = x - b; x = x * 2; x = x + 3;
@@ -18,8 +21,12 @@ fun big(a: i64, b: i64) i64 {
 
 `symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
-    val p: i64 = big(1, 2);
+    # feed `big` a runtime value (argc) so the optimizer can't constant-fold the
+    # calls away, and RETURN the result so they can't be dead-code-eliminated as
+    # dead pure calls — the control build's "call survives" signal depends on the
+    # result being consumed. run with no arguments argc == 1, so big(big(1,2),3)
+    # is deterministic; its low byte is the exit code 204.
+    val p: i64 = big(argc, 2);
     val q: i64 = big(p, 3);
-    # the result is discarded; the test asserts on emission, not the value.
-    ret q - q + 42;
+    ret q;
 }

--- a/.github/tests/inline/run.sh
+++ b/.github/tests/inline/run.sh
@@ -6,8 +6,13 @@
 # sites, so neither the size nor the single-use heuristic inlines it — only
 # FN_FLAG_INLINE does. building at -O2 with `--emit-asm`, the decorated build
 # must contain NO call to `big` in the caller's assembly (fully inlined), while a
-# control build with the decorator stripped must still call it. the binary must
-# also run, confirming the inlined code is correct.
+# control build with the `inline` decorator stripped must still call it.
+#
+# `big` is fed a runtime value and its result is returned, so the calls can't be
+# constant-folded or dead-code-eliminated — without that the control's surviving-
+# call signal would be a no-op. its link name is pinned with `symbol`, so the
+# `call big` grep matches a stable mnemonic. run with no arguments the program is
+# deterministic: exit 204 (the low byte of big(big(1,2),3)).
 #
 # usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -61,16 +66,17 @@ else
     "$WORK/app/out/linux/bin/inldec"
     code=$?
     set -e
-    if [ "$code" -ne 42 ]; then
-        echo "FAIL inline: inlined program ran with exit $code, expected 42" >&2
+    if [ "$code" -ne 204 ]; then
+        echo "FAIL inline: inlined program ran with exit $code, expected 204" >&2
         fail=1
     else
         echo "PASS inline: the inlined program runs correctly"
     fi
 fi
 
-# control: strip the decorator; the cost model must now leave the calls in place,
-# proving the decorator — not the heuristic — is what inlined `big`.
+# control: strip the `inline` decorator; the cost model must now leave the calls
+# in place, proving the decorator — not the heuristic — is what inlined `big`.
+# the `symbol("big")` pin is on its own line and survives, so `big` keeps its name.
 sed '/`inline`/d' "$HERE/app/src/main.mach" > "$WORK/app/src/main.mach"
 rm -rf "$WORK/app/out"
 if ! ( cd "$WORK/app" && "$MACH" build . --emit-asm -O2 ) >/dev/null 2>&1; then

--- a/.github/tests/sectioncoff/app/mach.toml
+++ b/.github/tests/sectioncoff/app/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id      = "sectioncoff"
+name    = "Section Decorator Test (COFF) — App"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "windows"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+ext  = ".exe"
+libs = ["kernel32.dll"]
+
+[bin.sectioncoff]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/sectioncoff/app/src/main.mach
+++ b/.github/tests/sectioncoff/app/src/main.mach
@@ -1,0 +1,24 @@
+use std.runtime;
+
+# the COFF twin of sectiondec: a `section("...")` decorator places a global's
+# symbol in the named COFF section instead of the default .data, and a function's
+# code in the named text section, carried into PE/COFF object emission.
+
+# `.machsec` is exactly 8 characters, so its name fits inline in the COFF section
+# header (the path sectiondec already covers on ELF).
+`section(".machsec")` `symbol("g_sec")`
+pub var g_sec: u64 = 100;
+
+`symbol("g_def")`
+pub var g_def: u64 = 23;
+
+# `.hottext_long` is >8 characters, so COFF cannot store it inline: it goes to the
+# string table and the section header holds a `/N` byte-offset redirection. this
+# is the path `.machsec` / `.hottext` (both exactly 8) never exercise.
+`section(".hottext_long")` `symbol("f_sec")`
+fun f_sec(x: i64) i64 { ret x + 1; }
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    ret f_sec((g_sec + g_def)::i64 - 1);
+}

--- a/.github/tests/sectioncoff/run.sh
+++ b/.github/tests/sectioncoff/run.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# section decorator COFF integration test (#1491, fast-follow #1476): the
+# windows/COFF twin of sectiondec — prove a `section("...")` decorator places a
+# global's symbol and a function's code in the named COFF section, carried into
+# PE/COFF object emission, while an un-decorated global stays in .data.
+#
+# the symbol table records which section each symbol is defined in; objdump -t
+# reports a 1-based section index that maps to a name via objdump -h (the >8char
+# name is resolved from the COFF string table). the decorated `g_sec` must land
+# in `.machsec`, `f_sec` in `.hottext_long`, the plain `g_def` in `.data`.
+# `.hottext_long` is >8 characters, so it exercises the COFF string-table `/N`
+# redirection that the exactly-8 `.machsec` / `.hottext` names never reach. the
+# binary must also run under wine. no PE inspector -> structural check skipped.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+fail=0
+
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . ) >"$WORK/build.out" 2>&1; then
+    echo "FAIL sectioncoff: windows build failed" >&2
+    cat "$WORK/build.out" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/windows/bin/sectioncoff.exe"
+OBJ="$WORK/app/out/windows/obj/sectioncoff/main.o"
+test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
+
+# pick a PE inspector: prefer binutils objdump (PE-capable on ubuntu), fall back
+# to llvm-readobj, and skip the structural half when neither can read the object
+# rather than failing spuriously — mirroring dlllibdec.
+INSPECT=""
+if command -v objdump >/dev/null 2>&1 && objdump -h "$OBJ" >/dev/null 2>&1; then
+    INSPECT="objdump"
+elif command -v llvm-readobj >/dev/null 2>&1; then
+    INSPECT="llvm-readobj"
+fi
+
+# sec_of <symbol> — the name of the COFF section the symbol is defined in.
+sec_of() {
+    local sym="$1" num
+    case "$INSPECT" in
+    objdump)
+        # objdump -t reports the defining section as a 1-based "(sec N)"; map N to
+        # the section name via objdump -h's 0-based Idx column.
+        num=$(objdump -t "$OBJ" 2>/dev/null | awk -v s="$sym" '
+            $NF==s { if (match($0, /\(sec +[0-9]+\)/)) { x=substr($0,RSTART,RLENGTH); gsub(/[^0-9]/,"",x); print x; exit } }')
+        [ -n "$num" ] || { echo "?"; return; }
+        objdump -h "$OBJ" 2>/dev/null | awk -v n="$num" '$1 ~ /^[0-9]+$/ && $1+0==n-1 {print $2; exit}'
+        ;;
+    llvm-readobj)
+        # --symbols gives the symbol's 1-based section number; --sections maps it
+        # to a name (the >8char name resolved from the string table).
+        num=$(llvm-readobj --symbols "$OBJ" 2>/dev/null | awk -v s="$sym" '
+            $1=="Name:" && $2==s { f=1; next }
+            f && $1=="Section:" { n=$NF; gsub(/[()]/,"",n); print n; exit }')
+        [ -n "$num" ] || { echo "?"; return; }
+        llvm-readobj --sections "$OBJ" 2>/dev/null | awk -v n="$num" '
+            $1=="Number:" { cur=($2==n) }
+            cur && $1=="Name:" { print $2; exit }'
+        ;;
+    esac
+}
+
+if [ -n "$INSPECT" ]; then
+    expect_sec() {
+        local sym="$1" want="$2" got
+        got=$(sec_of "$sym")
+        if [ "$got" != "$want" ]; then
+            echo "FAIL sectioncoff: $sym is in section '$got', expected '$want'" >&2
+            fail=1
+        else
+            echo "PASS sectioncoff: $sym placed in $want"
+        fi
+    }
+    expect_sec g_sec .machsec
+    expect_sec g_def .data
+    # the >8char text section exercises the COFF string-table /N redirection.
+    expect_sec f_sec .hottext_long
+    expect_sec main  .text
+else
+    echo "INFO sectioncoff: no PE inspector (objdump/llvm-readobj); skipping the section check"
+fi
+
+# behavioral: run under wine. f_sec lives in a section reached across a normal
+# relocation, and the sectioned global is read back — a clean 100 + 23 == 123
+# proves the placement did not break code or data references.
+if command -v wine >/dev/null 2>&1; then
+    set +e
+    WINEDEBUG=-all wine "$EXE" >"$WORK/wine.out" 2>&1
+    code=$?
+    set -e
+    if [ "$code" -eq 123 ]; then
+        echo "PASS sectioncoff: the program with sectioned globals/code runs under wine"
+    else
+        echo "FAIL sectioncoff: program ran under wine with exit $code, expected 123" >&2
+        cat "$WORK/wine.out" >&2
+        fail=1
+    fi
+else
+    echo "SKIP sectioncoff: 'wine' not available for the behavioral check"
+fi
+
+exit "$fail"


### PR DESCRIPTION
Closes #1491. Fast-follow to #1476 — decorator test-coverage gaps from the #1484 review. Tests only; no compiler changes.

## What this adds / fixes

- **`sectioncoff` (new):** the windows/COFF twin of `sectiondec`. Builds the windows target, asserts `g_sec`→`.machsec`, `f_sec`→`.hottext_long`, `g_def`→`.data`, `main`→`.text` via objdump (llvm-readobj fallback), and runs under wine. `.hottext_long` is >8 chars, so it exercises the COFF string-table **`/N` redirection** that the exactly-8 `.machsec`/`.hottext` names never reach.
- **`decarg` (new):** negative decorator-arg resolution. `unresolved/` puts an undeclared identifier in a top-level decorator arg; `branch/` puts one on a decl inside a **taken `$if (...)` decl-scope branch**. Both must fail with a located `unresolved identifier` — proving `bind_decorator_args` walks the args and that the resolver descends into comptime decl branches (verified: the dead `$if` branch builds clean).
- **`aligndec`:** dropped `g_cmp8 = align($align_of(u64))` — it folds to 8 = the default section align, so it couldn't discriminate (and `$align_of` can never exceed 8, the very invariant at stake). `g_cmp16` already covers the comptime-expr case discriminatingly. Added an **alignment-dependent runtime probe** (`(&g & mask)==0` per over-aligned global, distinct sentinels) so the run proves layout even when readelf is absent.
- **`inline`:** `big` now takes a runtime value and its result is **returned** (consumed), so the calls can't be constant-folded or DCE'd — without that the control build's surviving-call signal was a no-op. Pinned `` `symbol("big")` `` so the `call big` grep matches a stable mnemonic.

All four suites verified locally against the dev compiler (aligndec exit 27 + structural; inline exit 204 + control call survives; sectioncoff symbol→section + wine 123; decarg both located errors).

Part of v1.7 epic #1477.