### PR TITLE
feat(comptime): $each + $fields + v.[f] expansion cluster (#1473)

### DIFF
--- a/.github/tests/eachfields/app/mach.toml
+++ b/.github/tests/eachfields/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "eachfields"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.eachfields]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -42,6 +42,17 @@ fun noop(e: Empty) i64 {
     ret n;
 }
 
+# nested $each: a cross-product of every field pair, two projections deep.
+fun cross(p: Pair, q: Pair) i64 {
+    var t: i64 = 0;
+    $each f in $fields(Pair) {
+        $each g in $fields(Pair) {
+            t = t + p.[f] * q.[g];
+        }
+    }
+    ret t;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     var p: Pair = Pair { x: 3, y: 4 };
@@ -54,5 +65,9 @@ fun main(argc: i64, argv: **u8) i64 {
 
     var e: Empty = Empty { };
     if (noop(e) != 0) { ret 4; }
+
+    var u: Pair = Pair { x: 1, y: 2 };
+    var w: Pair = Pair { x: 3, y: 4 };
+    if (cross(u, w) != 21) { ret 5; }
     ret 0;
 }

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -63,6 +63,24 @@ fun offsum(m: Mixed) i64 {
     ret s;
 }
 
+# f.type descriptor read in a type comparison: count i64 fields via
+# `$if (f.type == i64)`, reusing the #1472 type `==`.
+fun count_i64(m: Mixed) i64 {
+    var n: i64 = 0;
+    $each f in $fields(Mixed) {
+        $if (f.type == i64) { n = n + 1; } $or { }
+    }
+    ret n;
+}
+
+# a real record field named `type` must stay an ordinary field access, never a
+# descriptor projection (the disambiguation keys on the `$each` loop variable).
+rec HasType { type: i64; other: i64; }
+fun field_named_type(h: HasType) i64 {
+    if (h.type == 7) { ret 1; }
+    ret 0;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     var p: Pair = Pair { x: 3, y: 4 };
@@ -83,5 +101,11 @@ fun main(argc: i64, argv: **u8) i64 {
     # Mixed is { a: i64 @0, b: u8 @8 } -> offsets sum to 8
     var m2: Mixed = Mixed { a: 0, b: 0 };
     if (offsum(m2) != 8) { ret 6; }
+
+    # Mixed has one i64 field (a); b is u8
+    if (count_i64(m2) != 1) { ret 7; }
+    # a real field named `type` is untouched by the descriptor machinery
+    var h: HasType = HasType { type: 7, other: 0 };
+    if (field_named_type(h) != 1) { ret 8; }
     ret 0;
 }

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -1,4 +1,5 @@
 use std.runtime;
+use std.types.string.str_equals;
 
 # `$each f in $fields(T) { ... v.[f] ... }` unrolls at compile time, once per
 # field of T, binding `f` to that field's descriptor so `v.[f]` projects the
@@ -81,6 +82,16 @@ fun field_named_type(h: HasType) i64 {
     ret 0;
 }
 
+# f.name descriptor read: the field's name as a runtime string. count fields
+# whose name equals "a".
+fun count_named_a(m: Mixed) i64 {
+    var n: i64 = 0;
+    $each f in $fields(Mixed) {
+        if (str_equals(f.name, "a")) { n = n + 1; }
+    }
+    ret n;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     var p: Pair = Pair { x: 3, y: 4 };
@@ -107,5 +118,7 @@ fun main(argc: i64, argv: **u8) i64 {
     # a real field named `type` is untouched by the descriptor machinery
     var h: HasType = HasType { type: 7, other: 0 };
     if (field_named_type(h) != 1) { ret 8; }
+    # f.name: Mixed has exactly one field named "a"
+    if (count_named_a(m2) != 1) { ret 9; }
     ret 0;
 }

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -53,6 +53,16 @@ fun cross(p: Pair, q: Pair) i64 {
     ret t;
 }
 
+# f.offset descriptor read: each field's byte offset in the target layout, folded
+# per iteration as a comptime usize.
+fun offsum(m: Mixed) i64 {
+    var s: i64 = 0;
+    $each f in $fields(Mixed) {
+        s = s + f.offset::i64;
+    }
+    ret s;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     var p: Pair = Pair { x: 3, y: 4 };
@@ -69,5 +79,9 @@ fun main(argc: i64, argv: **u8) i64 {
     var u: Pair = Pair { x: 1, y: 2 };
     var w: Pair = Pair { x: 3, y: 4 };
     if (cross(u, w) != 21) { ret 5; }
+
+    # Mixed is { a: i64 @0, b: u8 @8 } -> offsets sum to 8
+    var m2: Mixed = Mixed { a: 0, b: 0 };
+    if (offsum(m2) != 8) { ret 6; }
     ret 0;
 }

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -1,0 +1,58 @@
+use std.runtime;
+
+# `$each f in $fields(T) { ... v.[f] ... }` unrolls at compile time, once per
+# field of T, binding `f` to that field's descriptor so `v.[f]` projects the
+# concrete field (#1473). exits 0 only when every splice computes the value its
+# field layout dictates; a wrong result returns that check's id.
+rec Pair  { x: i64; y: i64; }
+rec Mixed { a: i64; b: u8; }
+rec Empty { }
+
+# homogeneous: sum every field via v.[f] (rvalue projection).
+fun sum(p: Pair) i64 {
+    var total: i64 = 0;
+    $each f in $fields(Pair) {
+        total = total + p.[f];
+    }
+    ret total;
+}
+
+# heterogeneous: each iteration re-types v.[f] to the concrete field's type.
+fun total(m: Mixed) i64 {
+    var t: i64 = 0;
+    $each f in $fields(Mixed) {
+        t = t + m.[f]::i64;
+    }
+    ret t;
+}
+
+# v.[f] as a write lvalue, through a pointer receiver (auto-deref).
+fun zero(m: *Mixed) {
+    $each f in $fields(Mixed) {
+        m.[f] = 0;
+    }
+}
+
+# an empty record's $fields expands to nothing.
+fun noop(e: Empty) i64 {
+    var n: i64 = 0;
+    $each f in $fields(Empty) {
+        n = n + 1;
+    }
+    ret n;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    var p: Pair = Pair { x: 3, y: 4 };
+    if (sum(p) != 7) { ret 1; }
+
+    var m: Mixed = Mixed { a: 100, b: 5 };
+    if (total(m) != 105) { ret 2; }
+    zero(?m);
+    if (total(m) != 0) { ret 3; }
+
+    var e: Empty = Empty { };
+    if (noop(e) != 0) { ret 4; }
+    ret 0;
+}

--- a/.github/tests/eachfields/run.sh
+++ b/.github/tests/eachfields/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# $each / $fields / v.[f] expansion integration test (#1473).
+#
+# `$each f in $fields(T) { ... v.[f] ... }` unrolls at compile time, once per
+# field of T, binding `f` to that field's descriptor so `v.[f]` projects the
+# concrete field. the app asserts the splice computes correct values for a
+# homogeneous record (rvalue projection), a heterogeneous record (per-iteration
+# typing), a pointer-receiver write (v.[f] lvalue), and an empty record (no
+# expansion); it exits 0 only when all pass, returning the failed check's id
+# otherwise. end-to-end proof that the sema + lowering unroll splice agree.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL eachfields: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/eachfields"
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL eachfields: check $code computed the wrong value" >&2
+    exit 1
+fi
+echo "PASS eachfields: \$each over \$fields projects v.[f] correctly"

--- a/src/lang/fe/ast/expr.mach
+++ b/src/lang/fe/ast/expr.mach
@@ -26,6 +26,9 @@ pub val EXPR_KIND_CAST:           ExprKind = 12;
 pub val EXPR_KIND_ARRAY_LIT:      ExprKind = 13;
 pub val EXPR_KIND_STRUCT_LIT:     ExprKind = 14;
 pub val EXPR_KIND_COMPTIME_IDENT: ExprKind = 15;
+# a `v.[f]` field projection (#1472/#1473): project the field named by a comptime
+# field descriptor `f` (bound by `$each`) off an instance `v`. an lvalue.
+pub val EXPR_KIND_PROJECT:        ExprKind = 16;
 pub val EXPR_KIND_ERROR:          ExprKind = 255;
 
 # BinOp: binary operator encoded in ExprBinary.op.
@@ -120,6 +123,17 @@ pub rec ExprMember {
     name:   token.Span;
 }
 
+# ExprProject: a `v.[f]` field projection (#1472/#1473). `f` is a comptime field
+# descriptor bound by an enclosing `$each`; the projection resolves to the field
+# `f` names off the instance `object`. an lvalue (readable and writable).
+# ---
+# object: the instance whose field is projected
+# field:  the comptime field-descriptor expression (the `$each` loop variable)
+pub rec ExprProject {
+    object: id.ExprId;
+    field:  id.ExprId;
+}
+
 # ExprCast: a type cast expression. `::` performs a value conversion
 # (`value::Type`) and `:~` a same-size bit reinterpretation (`value:~Type`).
 # ---
@@ -183,5 +197,6 @@ pub rec Expr {
         cast:       ExprCast;
         array_lit:  ExprArrayLit;
         struct_lit: ExprStructLit;
+        project:    ExprProject;
     };
 }

--- a/src/lang/fe/ast/stmt.mach
+++ b/src/lang/fe/ast/stmt.mach
@@ -20,6 +20,8 @@ pub val STMT_KIND_FIN:         StmtKind = 7;
 pub val STMT_KIND_DECL:        StmtKind = 8;
 pub val STMT_KIND_ASM:         StmtKind = 9;
 pub val STMT_KIND_COMPTIME_IF: StmtKind = 10;
+# a `$each <ident> in <seq> { body }` bounded compile-time unroll (#1473).
+pub val STMT_KIND_COMPTIME_EACH: StmtKind = 11;
 pub val STMT_KIND_ERROR:       StmtKind = 255;
 
 # StmtExpr: a bare expression used as a statement.
@@ -97,6 +99,22 @@ pub rec StmtComptimeIf {
     branches_len:   u32;
 }
 
+# StmtComptimeEach: a `$each <ident> in <seq> { body }` bounded compile-time
+# unroll (#1473). the body is spliced once per element of the comptime-known
+# sequence, with `var_name` bound to that element. body statements live in a
+# contiguous slice of ast.stmt_ids.
+# ---
+# var_name:   span of the loop variable identifier
+# seq:        the comptime sequence expression (e.g. `$fields(T)`)
+# body_start: start index into ast.stmt_ids
+# body_len:   number of body statements
+pub rec StmtComptimeEach {
+    var_name:   token.Span;
+    seq:        id.ExprId;
+    body_start: u32;
+    body_len:   u32;
+}
+
 # Stmt: a syntactic statement node.
 # ---
 # span: byte range of the statement in source
@@ -106,14 +124,15 @@ pub rec Stmt {
     span: token.Span;
     kind: StmtKind;
     data: uni {
-        expr:        StmtExpr;
-        block:       StmtBlock;
-        if_:         StmtIf;
-        for_:        StmtFor;
-        ret_:        StmtRet;
-        fin_:        StmtFin;
-        decl:        StmtDecl;
-        asm_:        StmtAsm;
-        comptime_if: StmtComptimeIf;
+        expr:          StmtExpr;
+        block:         StmtBlock;
+        if_:           StmtIf;
+        for_:          StmtFor;
+        ret_:          StmtRet;
+        fin_:          StmtFin;
+        decl:          StmtDecl;
+        asm_:          StmtAsm;
+        comptime_if:   StmtComptimeIf;
+        comptime_each: StmtComptimeEach;
     };
 }

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -987,7 +987,9 @@ fun eval_binary(
     # compare. recognized structurally here so a type operand never reaches the
     # numeric / value evaluator below.
     if ((bin.op == expr.BIN_EQ || bin.op == expr.BIN_NEQ)
-        && is_type_comparison(a, source, bin)) {
+        && (is_type_comparison(a, source, bin)
+         || field_type_eval_operand(c, a, source, bin.lhs, interner)
+         || field_type_eval_operand(c, a, source, bin.rhs, interner))) {
         ret eval_type_comparison(c, a, source, bin, interner);
     }
 
@@ -1170,6 +1172,45 @@ pub fun is_type_comparison(a: *ast.Ast, source: str, bin: *expr.ExprBinary) bool
     ret is_type_of_call(a, source, bin.lhs) || is_type_of_call(a, source, bin.rhs);
 }
 
+# is_field_type_member: whether `eid` is structurally a `.type` member access (a
+# candidate `f.type` field-descriptor type, #1473). a structural test only — the
+# object is confirmed to be a field descriptor by the typed layers (resolve via
+# the loop variable, eval via the bound value), so a real record field named
+# `type` is never mistaken for one.
+# ---
+# a:      the ast that owns `eid`
+# source: source text (for the member span)
+# eid:    expression id to test
+# ret:    true when `eid` is a `<expr>.type` member access
+pub fun is_field_type_member(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_MEMBER) { ret false; }
+    ret view_eq_str(span_text(source, node.data.member.name), "type");
+}
+
+# field_type_eval_operand: whether `eid` is an `f.type` operand whose object
+# actually evaluates to a field descriptor (a fold-time check used to recognize a
+# `f.type == T` type comparison precisely, without mistaking a real `.type`
+# field). returns false when no field resolver is installed (pre-lowering).
+fun field_type_eval_operand(
+    c:        *ComptimeCtx,
+    a:        *ast.Ast,
+    source:   str,
+    eid:      id.ExprId,
+    interner: *intern.Interner
+) bool {
+    if (!is_field_type_member(a, source, eid)) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    val obj_r: Result[CTValue, str] = eval(c, a, source, node.data.member.object, interner);
+    if (is_err[CTValue, str](obj_r)) { ret false; }
+    ret unwrap_ok[CTValue, str](obj_r).kind == CT_KIND_FIELD;
+}
+
 # folds a type comparison: each operand resolves to a TYPE value through the
 # installed resolver, and the result is an identity compare. a context with no
 # resolver (every pass before lowering) defers loudly so arm selection happens at
@@ -1181,22 +1222,32 @@ fun eval_type_comparison(
     bin:      *expr.ExprBinary,
     interner: *intern.Interner
 ) Result[CTValue, str] {
-    val l_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.lhs);
+    val l_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.lhs, interner);
     if (is_err[CTValue, str](l_r)) { ret l_r; }
-    val r_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.rhs);
+    val r_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.rhs, interner);
     if (is_err[CTValue, str](r_r)) { ret r_r; }
     ret apply_equality(bin.op, unwrap_ok[CTValue, str](l_r), unwrap_ok[CTValue, str](r_r));
 }
 
-# resolves one type-comparison operand to its TYPE value through the installed
-# type resolver. errors when no resolver is installed, or when the operand has no
-# resolvable type identity.
+# resolves one type-comparison operand to its TYPE value. an `f.type`
+# field-descriptor type folds directly through the field resolver (#1473); a
+# `$type_of(...)` or type-name operand resolves through the installed type
+# resolver (#1472). errors when no resolver is installed, or when the operand has
+# no resolvable type identity.
 fun eval_type_operand(
-    c:       *ComptimeCtx,
-    a:       *ast.Ast,
-    source:  str,
-    operand: id.ExprId
+    c:        *ComptimeCtx,
+    a:        *ast.Ast,
+    source:   str,
+    operand:  id.ExprId,
+    interner: *intern.Interner
 ) Result[CTValue, str] {
+    # an `f.type` field-descriptor type folds directly to a TYPE value via the
+    # field resolver; the `$type_of` / type-name path does not fold this way.
+    if (is_field_type_member(a, source, operand)) {
+        val direct: Result[CTValue, str] = eval(c, a, source, operand, interner);
+        if (is_err[CTValue, str](direct)) { ret direct; }
+        if (unwrap_ok[CTValue, str](direct).kind == CT_KIND_TYPE) { ret direct; }
+    }
     if (c.type_fn == nil) { ret err[CTValue, str](COMPTIME_TYPE_NO_RESOLVER_MSG); }
     val fn: TypeIdentFn = c.type_fn::TypeIdentFn;
     val value_eid: id.ExprId = type_operand_value(a, source, operand);

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1051,6 +1051,44 @@ pub fun type_of_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
     ret a.expr_ids[node.data.call.args_start];
 }
 
+# is_fields_call: whether `eid` is a `$fields(T)` intrinsic call (#1473),
+# recognized structurally by a `$`-rooted COMPTIME_IDENT callee spelled `fields`.
+# ---
+# a:      the ast that owns `eid`
+# source: source text (for the callee span)
+# eid:    expression id to test
+# ret:    true when `eid` is a `$fields(...)` call
+pub fun is_fields_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL) { ret false; }
+    val ce_opt: Option[*expr.Expr] = ast.get_expr(a, node.data.call.callee);
+    if (is_none[*expr.Expr](ce_opt)) { ret false; }
+    val ce: *expr.Expr = unwrap[*expr.Expr](ce_opt);
+    if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret false; }
+    val ns: token.Span = comptime_ident_name(ce.span);
+    if (ns.len == 0) { ret false; }
+    ret view_eq_str(span_text(source, ns), "fields");
+}
+
+# fields_type_arg: the single type-naming argument of a `$fields(T)` call, or
+# EXPR_NIL when `eid` is not such a call or carries no argument.
+# ---
+# a:   the ast that owns `eid`
+# eid: a `$fields(...)` call expression id
+# ret: the type-argument expression id, or EXPR_NIL
+pub fun fields_type_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
+    if (eid == id.EXPR_NIL) { ret id.EXPR_NIL; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret id.EXPR_NIL; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL) { ret id.EXPR_NIL; }
+    if (node.data.call.args_len < 1) { ret id.EXPR_NIL; }
+    ret a.expr_ids[node.data.call.args_start];
+}
+
 # type_operand_value: the expression whose type identity a type-comparison operand
 # denotes. `$type_of(e)` denotes the type of its inner value `e`; any other
 # operand is a type-name spelling (`i64`, `module.Foo`) and denotes itself. the
@@ -1859,6 +1897,17 @@ fun type_value(t: u32) Result[CTValue, str] {
     v.kind   = CT_KIND_TYPE;
     v.data.t = t;
     ret ok[CTValue, str](v);
+}
+
+# field_value: a comptime FIELD descriptor (#1473) naming the owning record's
+# sema TypeId and a field ordinal. bound to the `$each` loop variable; read by
+# `.name` / `.type` / `.offset` and `v.[f]`.
+pub fun field_value(owner: u32, index: u32) CTValue {
+    var v: CTValue;
+    v.kind          = CT_KIND_FIELD;
+    v.data.fld.owner = owner;
+    v.data.fld.index = index;
+    ret v;
 }
 
 # helper: builds a full-length span over a literal and evaluates it as an integer.

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -185,6 +185,36 @@ pub val COMPTIME_TYPE_NO_RESOLVER_MSG: str =
 pub val COMPTIME_TYPE_UNRESOLVED_MSG: str =
     "type comparison operand does not name a type";
 
+# field-descriptor member selectors (#1473): which attribute of a `CT_KIND_FIELD`
+# descriptor a `.name` / `.type` / `.offset` projection reads.
+pub val FIELD_SEL_NAME:   u8 = 0;
+pub val FIELD_SEL_TYPE:   u8 = 1;
+pub val FIELD_SEL_OFFSET: u8 = 2;
+
+# FieldMemberFn: projects an attribute of a comptime field descriptor (#1473).
+# given the owning record's sema TypeId, the field ordinal, and a FIELD_SEL_*
+# selector, it returns the attribute as a CTValue (`.name` -> str, `.type` ->
+# type, `.offset` -> int), or none when the attribute is unavailable in this
+# context (`.offset` before lowering, which needs the target layout). eval has no
+# type system, so the typed layer (sema for name/type, lowering for all three)
+# installs this hook with `set_field_resolver`.
+pub def FieldMemberFn: fun(ptr, u32, u32, u8) Result[Option[CTValue], str];
+
+# COMPTIME_FIELD_NO_RESOLVER_MSG: surfaced when a field-descriptor member is read
+# in a context that installed no field resolver (every pass before sema).
+pub val COMPTIME_FIELD_NO_RESOLVER_MSG: str =
+    "a field descriptor member is only comptime-evaluable after type checking";
+
+# COMPTIME_FIELD_UNKNOWN_MEMBER_MSG: surfaced when a field descriptor is projected
+# with a member other than `.name` / `.type` / `.offset`.
+pub val COMPTIME_FIELD_UNKNOWN_MEMBER_MSG: str =
+    "a field descriptor has only `.name`, `.type`, and `.offset`";
+
+# COMPTIME_FIELD_UNAVAILABLE_MSG: surfaced when a field-descriptor member is not
+# available in the active context (e.g. `.offset` before lowering).
+pub val COMPTIME_FIELD_UNAVAILABLE_MSG: str =
+    "this field descriptor member is not available until lowering";
+
 # COMPTIME_MEMBER_NOT_CONST_MSG: surfaced when a module-qualified member path
 # resolves but does not name a module-level comptime constant (a function, a
 # `var`, a non-constant `val`, or an unexported / unknown member).
@@ -273,6 +303,8 @@ pub rec ComptimeCtx {
     member_data:    ptr;
     type_fn:        *u8;
     type_data:      ptr;
+    field_fn:       *u8;
+    field_data:     ptr;
 }
 
 val INITIAL_CONST_CAP: u32 = 8;
@@ -336,6 +368,8 @@ pub fun init(
     c.member_data    = nil;
     c.type_fn        = nil;
     c.type_data      = nil;
+    c.field_fn       = nil;
+    c.field_data     = nil;
     ret c;
 }
 
@@ -365,6 +399,19 @@ pub fun set_member_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
 pub fun set_type_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
     c.type_fn   = fn;
     c.type_data = data;
+}
+
+# set_field_resolver: install (or clear) the field-descriptor member resolver
+# this context consults when comptime.eval projects `.name` / `.type` / `.offset`
+# off a `CT_KIND_FIELD` value (#1473). sema installs the name/type half; lowering
+# installs all three. passing `nil` for both clears it.
+# ---
+# c:    context to update
+# fn:   erased FieldMemberFn, or nil to clear
+# data: opaque context handed back to fn, or nil to clear
+pub fun set_field_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
+    c.field_fn   = fn;
+    c.field_data = data;
 }
 
 # set_build_context: bind the manifest-derived project metadata, the selected
@@ -605,6 +652,13 @@ pub fun eval(
     # resolved through the installed member resolver.
     if (k == expr.EXPR_KIND_MEMBER) {
         if (is_comptime_path(a, e)) { ret eval_path(c, a, source, e, interner); }
+        # a `.name` / `.type` / `.offset` projection off a comptime field
+        # descriptor (#1473): fires only when the object evaluates to a
+        # CT_KIND_FIELD, so a member of any other value falls through to the
+        # module-member path (no collision with a record field named `type`).
+        val fld: Option[Result[CTValue, str]] =
+            eval_field_member(c, a, source, node.data.member.object, node.data.member.name, interner);
+        if (is_some[Result[CTValue, str]](fld)) { ret unwrap[Result[CTValue, str]](fld); }
         ret eval_module_member(c, e);
     }
 
@@ -1410,6 +1464,40 @@ fun eval_module_member(c: *ComptimeCtx, e: id.ExprId) Result[CTValue, str] {
     ret err[CTValue, str](COMPTIME_MEMBER_NOT_CONST_MSG);
 }
 
+# eval_field_member: projects `.name` / `.type` / `.offset` off a comptime field
+# descriptor (#1473). returns none when `object` does not evaluate to a
+# CT_KIND_FIELD — so the MEMBER dispatch falls through to the module-member path,
+# leaving an ordinary `value.field` access untouched. some(...) carries the
+# projected value, or the error explaining why it could not fold.
+fun eval_field_member(
+    c:           *ComptimeCtx,
+    a:           *ast.Ast,
+    source:      str,
+    object_eid:  id.ExprId,
+    member_span: token.Span,
+    interner:    *intern.Interner
+) Option[Result[CTValue, str]] {
+    val obj_r: Result[CTValue, str] = eval(c, a, source, object_eid, interner);
+    if (is_err[CTValue, str](obj_r)) { ret none[Result[CTValue, str]](); }
+    val obj: CTValue = unwrap_ok[CTValue, str](obj_r);
+    if (obj.kind != CT_KIND_FIELD) { ret none[Result[CTValue, str]](); }
+
+    val mtext: StrView = span_text(source, member_span);
+    var sel: u8 = FIELD_SEL_NAME;
+    if      (view_eq_str(mtext, "name"))   { sel = FIELD_SEL_NAME; }
+    or      (view_eq_str(mtext, "type"))   { sel = FIELD_SEL_TYPE; }
+    or      (view_eq_str(mtext, "offset")) { sel = FIELD_SEL_OFFSET; }
+    or      { ret some[Result[CTValue, str]](err[CTValue, str](COMPTIME_FIELD_UNKNOWN_MEMBER_MSG)); }
+
+    if (c.field_fn == nil) { ret some[Result[CTValue, str]](err[CTValue, str](COMPTIME_FIELD_NO_RESOLVER_MSG)); }
+    val fn: FieldMemberFn = c.field_fn::FieldMemberFn;
+    val r: Result[Option[CTValue], str] = fn(c.field_data, obj.data.fld.owner, obj.data.fld.index, sel);
+    if (is_err[Option[CTValue], str](r)) { ret some[Result[CTValue, str]](err[CTValue, str](unwrap_err[Option[CTValue], str](r))); }
+    val o: Option[CTValue] = unwrap_ok[Option[CTValue], str](r);
+    if (is_none[CTValue](o)) { ret some[Result[CTValue, str]](err[CTValue, str](COMPTIME_FIELD_UNAVAILABLE_MSG)); }
+    ret some[Result[CTValue, str]](ok[CTValue, str](unwrap[CTValue](o)));
+}
+
 # reports whether `e` is a comptime path expression: a bare COMPTIME_IDENT
 # (`$foo`) or a chain of MEMBER expressions whose leftmost root is a
 # COMPTIME_IDENT (`$mach.target.os`). a path is comptime-evaluable in form
@@ -1907,6 +1995,34 @@ pub fun field_value(owner: u32, index: u32) CTValue {
     v.kind          = CT_KIND_FIELD;
     v.data.fld.owner = owner;
     v.data.fld.index = index;
+    ret v;
+}
+
+# ct_str: a comptime string value over an interned StrId. used by the field
+# resolver to build a `f.name` projection (#1473).
+pub fun ct_str(s: intern.StrId) CTValue {
+    var v: CTValue;
+    v.kind   = CT_KIND_STR;
+    v.data.s = s;
+    ret v;
+}
+
+# ct_type: a comptime TYPE value over a sema TypeId token. used by the field
+# resolver to build a `f.type` projection (#1473).
+pub fun ct_type(t: u32) CTValue {
+    var v: CTValue;
+    v.kind   = CT_KIND_TYPE;
+    v.data.t = t;
+    ret v;
+}
+
+# ct_uint: a comptime unsigned-integer value. used by the field resolver to build
+# a `f.offset` projection (#1473), an unsigned `usize` magnitude.
+pub fun ct_uint(n: u64) CTValue {
+    var v: CTValue;
+    v.kind         = CT_KIND_INT;
+    v.int_unsigned = true;
+    v.data.i       = n:~i64;
     ret v;
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -89,6 +89,23 @@ pub val CT_KIND_STR:   CTKind = 3;
 # type. eval never interprets the token, only compares it.
 pub val CT_KIND_TYPE:  CTKind = 4;
 
+# a comptime FIELD descriptor (#1473): one element of a `$fields(T)` sequence,
+# bound to the `$each` loop variable. the payload `data.fld` names the owning
+# record type and the field's ordinal; `.name` / `.type` / `.offset` project the
+# field's attributes, and `v.[f]` projects the field off an instance.
+pub val CT_KIND_FIELD: CTKind = 5;
+
+# FieldRef: the payload of a CT_KIND_FIELD value — the owning record's canonical
+# sema TypeId and the field's declaration-order ordinal. the typed layer resolves
+# the field's name / type / offset from this pair.
+# ---
+# owner: the owning record's sema TypeId
+# index: the field's declaration-order ordinal
+pub rec FieldRef {
+    owner: u32;
+    index: u32;
+}
+
 # COMPTIME_BARE_IDENT_MSG: the single teaching diagnostic for a standalone bare
 # `$ident` (#1249). the comptime channel's shapes are a closed set; a lone
 # `$ident` is none of them — a comptime parameter is referenced without `$`, and
@@ -116,6 +133,7 @@ pub rec CTValue {
         b: bool;
         s: intern.StrId;
         t: u32;
+        fld: FieldRef;
     };
 }
 

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -210,6 +210,9 @@ pub fun parse_stmt(p: *parser.Parser) id.StmtId {
     if (parser.at(p, token.KIND_DOLLAR) && peek_is_kw(p, 1, "if")) {
         ret parse_comptime_if_stmt(p, start.span);
     }
+    if (parser.at(p, token.KIND_DOLLAR) && peek_is_kw(p, 1, "each")) {
+        ret parse_comptime_each_stmt(p, start.span);
+    }
 
     ret parse_expr_stmt(p, start.span);
 }
@@ -1155,6 +1158,37 @@ fun parse_expr_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
     node.span = parser.span_of(start, end.span);
     node.kind = stmt.STMT_KIND_EXPR;
     node.data.expr = se;
+    ret parser.push_stmt(p, node);
+}
+
+# parses `$each <ident> in <seq> { body }` at statement scope (#1473). the
+# sequence is a comptime expression (e.g. `$fields(T)`); the body is spliced once
+# per element with the loop variable bound to that element.
+fun parse_comptime_each_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
+    parser.expect(p, token.KIND_DOLLAR, "expected '$' to open a comptime $each");
+    parser.eat_kw(p, "each");
+
+    val var_tok: token.Token = parser.current(p);
+    parser.expect(p, token.KIND_IDENT, "expected a loop variable name after '$each'");
+    if (!parser.eat_kw(p, "in")) {
+        parser.error_at_current(p, "expected 'in' after the $each loop variable");
+    }
+    val seq: id.ExprId = pexpr.parse_expr(p);
+
+    var body_start: u32 = 0;
+    var body_len:   u32 = 0;
+    val end: token.Span = parse_comptime_stmt_body(p, ?body_start, ?body_len);
+
+    var ce: stmt.StmtComptimeEach;
+    ce.var_name   = var_tok.span;
+    ce.seq        = seq;
+    ce.body_start = body_start;
+    ce.body_len   = body_len;
+
+    var node: stmt.Stmt;
+    node.span = parser.span_of(start, end);
+    node.kind = stmt.STMT_KIND_COMPTIME_EACH;
+    node.data.comptime_each = ce;
     ret parser.push_stmt(p, node);
 }
 

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -152,7 +152,15 @@ fun parse_postfix(p: *parser.Parser, base: id.ExprId) id.ExprId {
                 lhs = parse_index(p, lhs);
             }
         }
-        or      (k == token.KIND_DOT)         { lhs = parse_member(p, lhs); }
+        or      (k == token.KIND_DOT) {
+            # `v.[f]` is a field projection (#1473); a plain `v.field` is a member.
+            if (parser.peek(p, 1).kind == token.KIND_LBRACKET) {
+                lhs = parse_project(p, lhs);
+            }
+            or {
+                lhs = parse_member(p, lhs);
+            }
+        }
         or      (k == token.KIND_COLON_COLON) { lhs = parse_cast(p, lhs, false); }
         or      (k == token.KIND_COLON_TILDE) { lhs = parse_cast(p, lhs, true); }
         or                                    { brk; }
@@ -560,6 +568,32 @@ fun parse_member(p: *parser.Parser, object: id.ExprId) id.ExprId {
     node.span = parser.span_of(start_span, name_tok.span);
     node.kind = expr.EXPR_KIND_MEMBER;
     node.data.member = member;
+    ret parser.push_expr(p, node);
+}
+
+# parses a field projection `v.[f]` (#1473): the field operand `f` is a comptime
+# field descriptor (the `$each` loop variable). the leading `.` is the current
+# token; `[` immediately follows.
+fun parse_project(p: *parser.Parser, object: id.ExprId) id.ExprId {
+    parser.expect(p, token.KIND_DOT, "expected '.' before '[' in a field projection");
+    parser.expect(p, token.KIND_LBRACKET, "expected '[' in a field projection");
+    val field: id.ExprId = parse_expr(p);
+    val close: token.Token = parser.current(p);
+    parser.expect(p, token.KIND_RBRACKET, "expected ']' to close a field projection");
+
+    var proj: expr.ExprProject;
+    proj.object = object;
+    proj.field  = field;
+
+    var start_span: token.Span = close.span;
+    if (object != id.EXPR_NIL) {
+        start_span = unwrap[*expr.Expr](ast.get_expr(p.ast, object)).span;
+    }
+
+    var node: expr.Expr;
+    node.span = parser.span_of(start_span, close.span);
+    node.kind = expr.EXPR_KIND_PROJECT;
+    node.data.project = proj;
     ret parser.push_expr(p, node);
 }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1625,7 +1625,40 @@ fun bind_stmt(rc: *ResolveContext, sid: id.StmtId) Result[bool, str] {
     if (s.kind == stmt.STMT_KIND_COMPTIME_IF) {
         ret bind_comptime_if(rc, s.data.comptime_if.branches_start, s.data.comptime_if.branches_len, false);
     }
+    if (s.kind == stmt.STMT_KIND_COMPTIME_EACH) {
+        ret bind_comptime_each(rc, ?s.data.comptime_each);
+    }
     ret ok[bool, str](true);
+}
+
+# binds a `$each <ident> in <seq> { body }` (#1473): the sequence's `$fields(T)`
+# binds T as a type; the loop variable is declared in a fresh scope as a comptime
+# binding visible to the body, which is then bound. arm selection / expansion is
+# deferred to sema + lowering.
+fun bind_comptime_each(rc: *ResolveContext, ce: *stmt.StmtComptimeEach) Result[bool, str] {
+    if (comptime.is_fields_call(rc.a, rc.source, ce.seq)) {
+        val targ: id.ExprId = comptime.fields_type_arg(rc.a, ce.seq);
+        if (targ != id.EXPR_NIL) {
+            val rt: Result[bool, str] = bind_intrinsic_type_arg(rc, targ);
+            if (is_err[bool, str](rt)) { ret rt; }
+        }
+    }
+    or {
+        val rs: Result[bool, str] = bind_expr(rc, ce.seq);
+        if (is_err[bool, str](rs)) { ret rs; }
+    }
+
+    val r_s: Result[ScopeId, str] = open_scope(rc, rc.current_scope);
+    if (is_err[ScopeId, str](r_s)) { ret err[bool, str](unwrap_err[ScopeId, str](r_s)); }
+    val saved: ScopeId = rc.current_scope;
+    rc.current_scope = unwrap_ok[ScopeId, str](r_s);
+
+    val rd: Result[SymbolId, str] = declare(rc, SYM_VAL, SYM_FLAG_COMPTIME, ce.var_name, id.DECL_NIL, 0, rc.own_module, rc.current_scope);
+    if (is_err[SymbolId, str](rd)) { rc.current_scope = saved; ret err[bool, str](unwrap_err[SymbolId, str](rd)); }
+
+    val rb: Result[bool, str] = bind_stmt_list(rc, ce.body_start, ce.body_len);
+    rc.current_scope = saved;
+    ret rb;
 }
 
 fun bind_block(rc: *ResolveContext, b: *stmt.StmtBlock) Result[bool, str] {
@@ -1740,6 +1773,13 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
         val ro: Result[bool, str] = bind_expr(rc, e.data.index.object);
         if (is_err[bool, str](ro)) { ret ro; }
         ret bind_expr(rc, e.data.index.index);
+    }
+    if (e.kind == expr.EXPR_KIND_PROJECT) {
+        # `v.[f]`: bind the instance, then the field descriptor (the `$each` loop
+        # variable, resolved against the enclosing `$each` scope).
+        val ro: Result[bool, str] = bind_expr(rc, e.data.project.object);
+        if (is_err[bool, str](ro)) { ret ro; }
+        ret bind_expr(rc, e.data.project.field);
     }
     if (e.kind == expr.EXPR_KIND_MEMBER) {
         val ro: Result[bool, str] = bind_expr(rc, e.data.member.object);

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1421,7 +1421,9 @@ fun gate_has_type_comparison(rc: *ResolveContext, eid: id.ExprId) bool {
     val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
     if (e.kind == expr.EXPR_KIND_BINARY) {
         if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
-            && comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)) {
+            && (comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)
+             || is_field_type_operand(rc, e.data.binary.lhs)
+             || is_field_type_operand(rc, e.data.binary.rhs))) {
             ret true;
         }
         ret gate_has_type_comparison(rc, e.data.binary.lhs)
@@ -1733,7 +1735,9 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
         # comptime-ident callee is a builtin), and the other operand is a type-name
         # spelling bound as a type so sema can recover the named type.
         if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
-            && comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)) {
+            && (comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)
+             || is_field_type_operand(rc, e.data.binary.lhs)
+             || is_field_type_operand(rc, e.data.binary.rhs))) {
             ret bind_type_comparison(rc, ?e.data.binary);
         }
         val rl: Result[bool, str] = bind_expr(rc, e.data.binary.lhs);
@@ -2204,7 +2208,35 @@ fun bind_type_operand(rc: *ResolveContext, operand: id.ExprId) Result[bool, str]
         if (arg == id.EXPR_NIL) { ret ok[bool, str](true); }
         ret bind_expr(rc, arg);
     }
+    # an `f.type` field-descriptor type (#1473): bind only the object (the `$each`
+    # loop variable); `.type` is a descriptor projection, not a record field.
+    if (is_field_type_operand(rc, operand)) {
+        val n_opt: Option[*expr.Expr] = ast.get_expr(rc.a, operand);
+        if (is_none[*expr.Expr](n_opt)) { ret ok[bool, str](true); }
+        ret bind_expr(rc, unwrap[*expr.Expr](n_opt).data.member.object);
+    }
     ret bind_intrinsic_type_arg(rc, operand);
+}
+
+# whether `eid` is an `f.type` operand whose object resolves, in the current
+# scope, to a `$each` comptime loop variable (a field descriptor). this keys the
+# `f.type` type-comparison recognition on the loop variable, so a real record
+# field named `type` (`s.type`) is never treated as a descriptor projection.
+fun is_field_type_operand(rc: *ResolveContext, eid: id.ExprId) bool {
+    if (!comptime.is_field_type_member(rc.a, rc.source, eid)) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(rc.a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val obj: id.ExprId = unwrap[*expr.Expr](n_opt).data.member.object;
+    val o_opt: Option[*expr.Expr] = ast.get_expr(rc.a, obj);
+    if (is_none[*expr.Expr](o_opt)) { ret false; }
+    val oe: *expr.Expr = unwrap[*expr.Expr](o_opt);
+    if (oe.kind != expr.EXPR_KIND_IDENT) { ret false; }
+    val r: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, oe.span);
+    if (is_err[intern.StrId, str](r)) { ret false; }
+    val sid: SymbolId = scope_lookup_chain(rc, rc.current_scope, unwrap_ok[intern.StrId, str](r));
+    if (sid == SYMBOL_NIL) { ret false; }
+    val sym: *Symbol = ?rc.symbols[sid];
+    ret sym.kind == SYM_VAL && (sym.flags & SYM_FLAG_COMPTIME) != 0;
 }
 
 # interns a static literal in the session interner, returning its StrId or

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -714,7 +714,9 @@ fun gate_has_type_comparison(sc: *ctxm.SemaContext, eid: id.ExprId) bool {
     val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
     if (e.kind == expr.EXPR_KIND_BINARY) {
         if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
-            && comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)) {
+            && (comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)
+             || infer.sema_is_field_type_operand(sc, e.data.binary.lhs)
+             || infer.sema_is_field_type_operand(sc, e.data.binary.rhs))) {
             ret true;
         }
         ret gate_has_type_comparison(sc, e.data.binary.lhs)
@@ -772,7 +774,9 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
         # comptime gate; its operands name types (validated by infer) and it folds
         # at lowering, so it is not recursed into as value subexpressions.
         if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
-            && comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)) {
+            && (comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)
+             || infer.sema_is_field_type_operand(sc, e.data.binary.lhs)
+             || infer.sema_is_field_type_operand(sc, e.data.binary.rhs))) {
             ret;
         }
         check_comptime_gate(sc, e.data.binary.lhs);

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -575,7 +575,47 @@ fun infer_stmt(sc: *ctxm.SemaContext, sid: id.StmtId, fn_ret: type.TypeId) Resul
     if (st.kind == stmt.STMT_KIND_COMPTIME_IF) {
         ret infer_stmt_comptime_if(sc, st.data.comptime_if.branches_start, st.data.comptime_if.branches_len, fn_ret);
     }
+    if (st.kind == stmt.STMT_KIND_COMPTIME_EACH) {
+        ret infer_stmt_comptime_each(sc, ?st.data.comptime_each, st.span, fn_ret);
+    }
     # BRK, CNT, ASM, ERROR carry no expressions to infer
+    ret ok[bool, str](true);
+}
+
+# type-checks a `$each <ident> in $fields(T) { body }` (#1473) by unrolling it:
+# the body is inferred once per field of T, with the loop variable bound in the
+# comptime frame to that field's descriptor, so a `v.[f]` / `f.type` in the body
+# is typed against the concrete field of each iteration. this is the sema half of
+# the splice the lowerer mirrors; heterogeneous field types are handled because
+# each iteration re-types the body.
+fun infer_stmt_comptime_each(sc: *ctxm.SemaContext, ce: *stmt.StmtComptimeEach, span: token.Span, fn_ret: type.TypeId) Result[bool, str] {
+    if (!comptime.is_fields_call(sc.a, sc.source, ce.seq)) {
+        ctxm.report(sc, span, "a `$each` sequence must be `$fields(T)`");
+        ret ok[bool, str](true);
+    }
+    val owner: type.TypeId = infer.field_seq_owner(sc, ce.seq, span);
+    if (owner == type.TYPE_ERROR) { ret ok[bool, str](true); }
+
+    val name_r: Result[intern.StrId, str] = intern.intern_span(?sc.s.interner, sc.source, ce.var_name);
+    if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
+    val fname: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+    val n: u32 = type.field_count(?sc.s.types, owner);
+    var i: u32 = 0;
+    for (i < n) {
+        val mark: comptime.FrameMark = comptime.frame_open(sc.ctx);
+        val br: Result[bool, str] = comptime.bind(sc.ctx, fname, comptime.field_value(owner::u32, i));
+        if (is_err[bool, str](br)) {
+            val cc: Result[bool, str] = comptime.frame_close(sc.ctx, mark);
+            if (is_err[bool, str](cc)) { ret cc; }
+            ret br;
+        }
+        val rb: Result[bool, str] = infer_stmt_list(sc, ce.body_start, ce.body_len, fn_ret);
+        val cc: Result[bool, str] = comptime.frame_close(sc.ctx, mark);
+        if (is_err[bool, str](rb)) { ret rb; }
+        if (is_err[bool, str](cc)) { ret cc; }
+        i = i + 1;
+    }
     ret ok[bool, str](true);
 }
 

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -941,15 +941,14 @@ fun infer_field_member(sc: *sema.SemaContext, m: *expr.ExprMember, span: token.S
     if (is_err[comptime.CTValue, str](obj_r)) { ret type.TYPE_NIL; }
     if (unwrap_ok[comptime.CTValue, str](obj_r).kind != comptime.CT_KIND_FIELD) { ret type.TYPE_NIL; }
 
+    if (str_region_equals(sc.source, m.name.offset, m.name.len, "name")) {
+        ret ptr_to(sc, prim_or_error(sc, type.TYPE_U8));
+    }
     if (str_region_equals(sc.source, m.name.offset, m.name.len, "offset")) {
         ret prim_or_error(sc, type.TYPE_U64);
     }
     if (str_region_equals(sc.source, m.name.offset, m.name.len, "type")) {
         sema.report(sc, span, "`f.type` is a comptime type, not a value; use it as a type-comparison operand inside a `$if` gate");
-        ret type.TYPE_ERROR;
-    }
-    if (str_region_equals(sc.source, m.name.offset, m.name.len, "name")) {
-        sema.report(sc, span, "`f.name` is not yet available");
         ret type.TYPE_ERROR;
     }
     sema.report(sc, span, "a field descriptor has only `.name`, `.type`, and `.offset`");

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -312,6 +312,9 @@ pub fun infer_expr(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
     or (e.kind == expr.EXPR_KIND_MEMBER) {
         t = infer_member(sc, eid, ?e.data.member, e.span);
     }
+    or (e.kind == expr.EXPR_KIND_PROJECT) {
+        t = infer_project(sc, ?e.data.project, e.span);
+    }
     or (e.kind == expr.EXPR_KIND_CAST) {
         t = infer_cast(sc, ?e.data.cast, e.span);
     }
@@ -871,6 +874,79 @@ fun set_expr_type(sc: *sema.SemaContext, eid: id.ExprId, ty: type.TypeId) {
     if (sc.expr_type == nil) { ret; }
     if (eid >= sc.a.expr_len::u32) { ret; }
     sc.expr_type[eid] = ty;
+}
+
+# field_seq_owner: resolves a `$fields(T)` sequence (#1473) to its owning record
+# TypeId, requiring T to be a record. the type-argument's expr_type slot is
+# populated for the lowerer. TYPE_ERROR when the sequence is malformed or T is
+# not a record. shared by the `$each` unroll (sema and lowering).
+pub fun field_seq_owner(sc: *sema.SemaContext, seq_eid: id.ExprId, span: token.Span) type.TypeId {
+    val targ: id.ExprId = comptime.fields_type_arg(sc.a, seq_eid);
+    if (targ == id.EXPR_NIL) {
+        sema.report(sc, span, "$fields: expected one type argument `$fields(T)`");
+        ret type.TYPE_ERROR;
+    }
+    val owner: type.TypeId = intrinsic_operand_type(sc, targ, span);
+    set_expr_type(sc, targ, owner);
+    if (owner == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    if (!type_is_record(sc, owner)) {
+        sema.report(sc, span, "$fields requires a record type");
+        ret type.TYPE_ERROR;
+    }
+    ret owner;
+}
+
+# whether a `v.[f]` receiver type names the field's owning record directly or via
+# a single pointer indirection (auto-deref, mirroring member access).
+fun project_receiver_matches(sc: *sema.SemaContext, obj_ty: type.TypeId, owner: type.TypeId) bool {
+    if (obj_ty == owner) { ret true; }
+    val to: Option[*type.Type] = type.get(?sc.s.types, obj_ty);
+    if (is_none[*type.Type](to)) { ret false; }
+    val t: *type.Type = unwrap[*type.Type](to);
+    ret t.kind == type.TYPE_POINTER && t.data.pointer.base == owner;
+}
+
+# whether `ty` is a record (or a generic record instance), the aggregate
+# `$fields` accepts. unions and non-aggregates are rejected.
+fun type_is_record(sc: *sema.SemaContext, ty: type.TypeId) bool {
+    val to: Option[*type.Type] = type.get(?sc.s.types, ty);
+    if (is_none[*type.Type](to)) { ret false; }
+    val k: type.TypeKind = unwrap[*type.Type](to).kind;
+    if (k == type.TYPE_REC) { ret true; }
+    if (k == type.TYPE_INSTANCE && is_some[*type.FieldTable](type.field_table_for(?sc.s.types, ty))) { ret true; }
+    ret false;
+}
+
+# infer_project: types a `v.[f]` field projection (#1473). the field operand `f`
+# evaluates to a comptime FIELD descriptor (bound by an enclosing `$each`) naming
+# the owning record and a field ordinal; the projection's type is that field's
+# type, and the instance `v` must be of the owning record type.
+fun infer_project(sc: *sema.SemaContext, p: *expr.ExprProject, span: token.Span) type.TypeId {
+    val obj_ty: type.TypeId = infer_expr(sc, p.object);
+    val fr: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, p.field, ?sc.s.interner);
+    if (is_err[comptime.CTValue, str](fr)) {
+        sema.report(sc, span, "`v.[f]` requires a comptime field descriptor bound by an enclosing `$each`");
+        ret type.TYPE_ERROR;
+    }
+    val fv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](fr);
+    if (fv.kind != comptime.CT_KIND_FIELD) {
+        sema.report(sc, span, "`v.[f]` requires a comptime field descriptor bound by an enclosing `$each`");
+        ret type.TYPE_ERROR;
+    }
+    if (obj_ty == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    val owner: type.TypeId = fv.data.fld.owner::type.TypeId;
+    # the instance is the owning record, or a pointer to it (auto-deref, like a
+    # member access `p.field` on `p: *T`).
+    if (!project_receiver_matches(sc, obj_ty, owner)) {
+        sema.report(sc, span, "`v.[f]`: the instance type does not match the field descriptor's owning record");
+        ret type.TYPE_ERROR;
+    }
+    val fa: Option[*type.FieldEntry] = type.field_at(?sc.s.types, owner, fv.data.fld.index);
+    if (is_none[*type.FieldEntry](fa)) {
+        sema.report(sc, span, "`v.[f]`: field ordinal out of range");
+        ret type.TYPE_ERROR;
+    }
+    ret unwrap[*type.FieldEntry](fa).ty;
 }
 
 # interns the identifier text of a `$ident` comptime ident, with the leading

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -896,6 +896,32 @@ pub fun field_seq_owner(sc: *sema.SemaContext, seq_eid: id.ExprId, span: token.S
     ret owner;
 }
 
+# types a `.name` / `.type` / `.offset` projection off a `$each` field descriptor
+# (#1473), or TYPE_NIL when the object is not a field descriptor (a normal member
+# access). detection evaluates the object: only a CT_KIND_FIELD is a descriptor,
+# so a member of any other value falls through. `.name` is a string (`*u8`),
+# `.offset` an unsigned `usize` (`u64`); `.type` is a comptime-only TYPE value,
+# valid only as a type-comparison operand, rejected here in a value position.
+fun infer_field_member(sc: *sema.SemaContext, m: *expr.ExprMember, span: token.Span) type.TypeId {
+    val obj_r: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, m.object, ?sc.s.interner);
+    if (is_err[comptime.CTValue, str](obj_r)) { ret type.TYPE_NIL; }
+    if (unwrap_ok[comptime.CTValue, str](obj_r).kind != comptime.CT_KIND_FIELD) { ret type.TYPE_NIL; }
+
+    if (str_region_equals(sc.source, m.name.offset, m.name.len, "offset")) {
+        ret prim_or_error(sc, type.TYPE_U64);
+    }
+    if (str_region_equals(sc.source, m.name.offset, m.name.len, "type")) {
+        sema.report(sc, span, "`f.type` is a comptime type, not a value; use it as a type-comparison operand inside a `$if` gate");
+        ret type.TYPE_ERROR;
+    }
+    if (str_region_equals(sc.source, m.name.offset, m.name.len, "name")) {
+        sema.report(sc, span, "`f.name` is not yet available");
+        ret type.TYPE_ERROR;
+    }
+    sema.report(sc, span, "a field descriptor has only `.name`, `.type`, and `.offset`");
+    ret type.TYPE_ERROR;
+}
+
 # whether a `v.[f]` receiver type names the field's owning record directly or via
 # a single pointer indirection (auto-deref, mirroring member access).
 fun project_receiver_matches(sc: *sema.SemaContext, obj_ty: type.TypeId, owner: type.TypeId) bool {
@@ -1079,6 +1105,10 @@ fun infer_member(sc: *sema.SemaContext, eid: id.ExprId, m: *expr.ExprMember, spa
     if (cti != type.TYPE_NIL) { ret cti; }
     val cts: type.TypeId = infer_comptime_str_path(sc, eid);
     if (cts != type.TYPE_NIL) { ret cts; }
+
+    # `f.name` / `f.type` / `f.offset` on a `$each` field descriptor (#1473).
+    val fdm: type.TypeId = infer_field_member(sc, m, span);
+    if (fdm != type.TYPE_NIL) { ret fdm; }
 
     val ot: type.TypeId = infer_expr(sc, m.object);
     if (ot == type.TYPE_ERROR) { ret type.TYPE_ERROR; }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -465,7 +465,9 @@ fun infer_binary(sc: *sema.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, spa
     # never reach the value comparison below (which would mis-infer the
     # `$type_of(...)` call).
     if ((b.op == expr.BIN_EQ || b.op == expr.BIN_NEQ)
-        && comptime.is_type_comparison(sc.a, sc.source, b)) {
+        && (comptime.is_type_comparison(sc.a, sc.source, b)
+         || sema_is_field_type_operand(sc, b.lhs)
+         || sema_is_field_type_operand(sc, b.rhs))) {
         ret infer_type_comparison(sc, b, span);
     }
 
@@ -566,9 +568,41 @@ fun infer_type_operand(sc: *sema.SemaContext, operand: id.ExprId, span: token.Sp
         }
         ret infer_expr(sc, arg);
     }
+    # an `f.type` field-descriptor type names the bound field's type (#1473).
+    if (sema_is_field_type_operand(sc, operand)) {
+        ret field_type_operand_type(sc, operand);
+    }
     val op_ty: type.TypeId = intrinsic_operand_type(sc, operand, span);
     set_expr_type(sc, operand, op_ty);
     ret op_ty;
+}
+
+# whether `eid` is an `f.type` operand whose object evaluates to a comptime field
+# descriptor — the sema-time recognition of a field-descriptor type operand,
+# valid during the `$each` unroll where the loop variable is bound.
+pub fun sema_is_field_type_operand(sc: *sema.SemaContext, eid: id.ExprId) bool {
+    if (!comptime.is_field_type_member(sc.a, sc.source, eid)) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val obj: id.ExprId = unwrap[*expr.Expr](n_opt).data.member.object;
+    val r: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, obj, ?sc.s.interner);
+    if (is_err[comptime.CTValue, str](r)) { ret false; }
+    ret unwrap_ok[comptime.CTValue, str](r).kind == comptime.CT_KIND_FIELD;
+}
+
+# the type an `f.type` operand names: the bound field's type, read from the
+# descriptor the object evaluates to.
+fun field_type_operand_type(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
+    val n_opt: Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret type.TYPE_ERROR; }
+    val obj: id.ExprId = unwrap[*expr.Expr](n_opt).data.member.object;
+    val r: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, obj, ?sc.s.interner);
+    if (is_err[comptime.CTValue, str](r)) { ret type.TYPE_ERROR; }
+    val fv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](r);
+    if (fv.kind != comptime.CT_KIND_FIELD) { ret type.TYPE_ERROR; }
+    val fa: Option[*type.FieldEntry] = type.field_at(?sc.s.types, fv.data.fld.owner::type.TypeId, fv.data.fld.index);
+    if (is_none[*type.FieldEntry](fa)) { ret type.TYPE_ERROR; }
+    ret unwrap[*type.FieldEntry](fa).ty;
 }
 
 # ASSIGN: RHS must be assignable to LHS; result is the LHS type. a literal

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -262,6 +262,7 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
     # on lc.
     comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
     comptime.set_type_resolver(octx, lctx.resolve_type_comparison_operand::*u8, lc::ptr);
+    comptime.set_field_resolver(octx, lctx.resolve_field_member::*u8, lc::ptr);
 
     # open a frame on the ORIGIN context and bind the `$param -> CTValue`
     # bindings into it; the frame is closed afterward (on the error path too) so
@@ -382,6 +383,7 @@ fun emit_one_instance(lc: *lctx.LowerContext, s: *sess.Session,
     # on lc.
     comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
     comptime.set_type_resolver(octx, lctx.resolve_type_comparison_operand::*u8, lc::ptr);
+    comptime.set_field_resolver(octx, lctx.resolve_field_member::*u8, lc::ptr);
 
     val lr: Result[bool, str] = decl.lower_instance(lc, decl_id, d, name);
     lc.ctx        = home_ctx;

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -252,6 +252,9 @@ pub fun init_context(
     # install the type-comparison operand resolver so comptime.eval can fold
     # `$type_of(...)` type gates in this module's bodies (#1472).
     comptime.set_type_resolver(ctx, resolve_type_comparison_operand::*u8, lc::ptr);
+    # install the field-descriptor member resolver so `f.name`/`f.type`/`f.offset`
+    # fold inside `$each` bodies (#1473).
+    comptime.set_field_resolver(ctx, resolve_field_member::*u8, lc::ptr);
     lc.locals      = map.init[resolve.SymbolId, value.Value](s.alloc, maphash.hash_u32, maphash.eq_u32);
     lc.local_names = map.init[intern.StrId, value.Value](s.alloc, maphash.hash_u32, maphash.eq_u32);
 
@@ -303,6 +306,7 @@ pub fun dnit_context(lc: *LowerContext) {
     if (lc == nil) { ret; }
     if (lc.ctx != nil) { comptime.set_member_resolver(lc.ctx, nil, nil); }
     if (lc.ctx != nil) { comptime.set_type_resolver(lc.ctx, nil, nil); }
+    if (lc.ctx != nil) { comptime.set_field_resolver(lc.ctx, nil, nil); }
     map.dnit[intern.StrId, value.Value](?lc.local_names);
     map.dnit[resolve.SymbolId, value.Value](?lc.locals);
     if (lc.loops != nil && lc.loop_cap > 0) {
@@ -410,6 +414,40 @@ pub fun resolve_type_comparison_operand(data: ptr, eid: aid.ExprId) Result[Optio
     val t: ty.TypeId = expr_type_of(lc, eid);
     if (t == ty.TYPE_NIL || t == ty.TYPE_ERROR) { ret ok[Option[u32], str](none[u32]()); }
     ret ok[Option[u32], str](some[u32](t::u32));
+}
+
+# resolve_field_member: the field-descriptor member resolver lowering installs on
+# every ComptimeCtx it evaluates against (a comptime.FieldMemberFn). given the
+# owning record's sema TypeId, a field ordinal, and a FIELD_SEL_* selector, it
+# projects the field's `.name` (str), `.type` (a sema TypeId token), or `.offset`
+# (its byte offset in the target layout, the same authority `$offset_of` reads).
+# none when the ordinal is out of range. `data` is the *LowerContext.
+# ---
+# data:  the *LowerContext, erased to a ptr by the installer
+# owner: the owning record's sema TypeId
+# index: the field ordinal
+# sel:   a comptime.FIELD_SEL_* selector
+# ret:   some(value) for the projected attribute, else none
+pub fun resolve_field_member(data: ptr, owner: u32, index: u32, sel: u8) Result[Option[comptime.CTValue], str] {
+    val lc: *LowerContext = data::*LowerContext;
+    if (lc == nil) { ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]()); }
+    val owner_ty: ty.TypeId = owner::ty.TypeId;
+    val fa: Option[*ty.FieldEntry] = ty.field_at(?lc.s.types, owner_ty, index);
+    if (is_none[*ty.FieldEntry](fa)) { ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]()); }
+    val fe: *ty.FieldEntry = unwrap[*ty.FieldEntry](fa);
+
+    if (sel == comptime.FIELD_SEL_NAME) {
+        ret ok[Option[comptime.CTValue], str](some[comptime.CTValue](comptime.ct_str(fe.name)));
+    }
+    if (sel == comptime.FIELD_SEL_TYPE) {
+        ret ok[Option[comptime.CTValue], str](some[comptime.CTValue](comptime.ct_type(fe.ty::u32)));
+    }
+    # offset: the field's byte offset in the target layout (IR authority).
+    val ir_r: Result[ir_type.IrTypeId, str] = lower_type(lc, owner_ty);
+    if (is_err[ir_type.IrTypeId, str](ir_r)) { ret err[Option[comptime.CTValue], str](unwrap_err[ir_type.IrTypeId, str](ir_r)); }
+    val ir_id: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](ir_r);
+    val off: u32 = ir_type.byte_offset(?lc.m.types, ir_id, index, lc.tgt);
+    ret ok[Option[comptime.CTValue], str](some[comptime.CTValue](comptime.ct_uint(off::u64)));
 }
 
 # resets the per-function working state before lowering a new function:

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -82,6 +82,7 @@ pub fun lower_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.Val
     if (k == aexpr.EXPR_KIND_LIT_NIL)        { ret lower_lit_nil(ctx, eid); }
     if (k == aexpr.EXPR_KIND_IDENT)          { ret lower_ident_rvalue(ctx, eid); }
     if (k == aexpr.EXPR_KIND_MEMBER)         { ret lower_member_rvalue(ctx, eid, e); }
+    if (k == aexpr.EXPR_KIND_PROJECT)        { ret lower_project_rvalue(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_INDEX)          { ret lower_index_rvalue(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_CALL)           { ret lower_call(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_BINARY)         { ret lower_binary(ctx, eid, e); }
@@ -111,6 +112,7 @@ pub fun lower_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.Val
 
     if (k == aexpr.EXPR_KIND_IDENT)  { ret lower_ident_lvalue(ctx, eid); }
     if (k == aexpr.EXPR_KIND_MEMBER) { ret lower_member_lvalue(ctx, eid, e); }
+    if (k == aexpr.EXPR_KIND_PROJECT) { ret lower_project_lvalue(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_INDEX)  { ret lower_index_lvalue(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_UNARY) {
         # @p as an lvalue is the rvalue of p (already a pointer)
@@ -608,6 +610,77 @@ fun lower_member_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Exp
     }
 
     val field_ix: u32 = field_index_in_type(ctx, rec_ty, e.data.member.name);
+
+    val rec_ir_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, rec_ty);
+    if (is_err[ir_type.IrTypeId, str](rec_ir_r)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](rec_ir_r)); }
+    val rec_ir: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](rec_ir_r);
+
+    val xr: Result[ir_type.IrTypeId, str] = index_type(ctx);
+    if (is_err[ir_type.IrTypeId, str](xr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](xr)); }
+    val xty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](xr);
+
+    var idx: [2]value.Value;
+    idx[0] = value.const_int(0, xty);
+    idx[1] = value.const_int(field_ix::u64, xty);
+    ret builder.emit_gep(?ctx.builder, base, rec_ir, ?idx[0], 2);
+}
+
+# project_field_index: the field ordinal a `v.[f]` projection names, read from the
+# comptime FIELD descriptor its field operand evaluates to (bound by an enclosing
+# `$each`). errors when the operand is not a field descriptor.
+fun project_field_index(ctx: *lower.LowerContext, field_eid: aid.ExprId) Result[u32, str] {
+    val fr: Result[comptime.CTValue, str] =
+        comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), field_eid, ?ctx.s.interner);
+    if (is_err[comptime.CTValue, str](fr)) { ret err[u32, str](unwrap_err[comptime.CTValue, str](fr)); }
+    val fv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](fr);
+    if (fv.kind != comptime.CT_KIND_FIELD) {
+        ret err[u32, str]("lower: `v.[f]` field operand is not a comptime field descriptor");
+    }
+    ret ok[u32, str](fv.data.fld.index);
+}
+
+# a `v.[f]` rvalue: a load from the projected field pointer, except for an
+# aggregate field whose rvalue is its storage address (mirrors lower_member_rvalue).
+fun lower_project_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
+    val ptr_r: Result[value.Value, str] = lower_project_lvalue(ctx, eid, e);
+    if (is_err[value.Value, str](ptr_r)) { ret ptr_r; }
+    val tr: Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](tr)); }
+    val ity: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+    if (is_aggregate_ir(ctx, ity)) { ret ok[value.Value, str](value.retype(unwrap_ok[value.Value, str](ptr_r), ity)); }
+    ret builder.emit_load(?ctx.builder, unwrap_ok[value.Value, str](ptr_r), ity);
+}
+
+# computes the field pointer of a `v.[f]` projection: like a member access, but
+# the field index comes from the comptime field descriptor rather than a name. a
+# pointer receiver auto-derefs; a value receiver uses its own storage.
+fun lower_project_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
+    val fix_r: Result[u32, str] = project_field_index(ctx, e.data.project.field);
+    if (is_err[u32, str](fix_r)) { ret err[value.Value, str](unwrap_err[u32, str](fix_r)); }
+    val field_ix: u32 = unwrap_ok[u32, str](fix_r);
+
+    val obj_ty: ty.TypeId = lower.expr_type_of(ctx, e.data.project.object);
+    val is_ptr: bool = is_pointer_type(ctx, obj_ty);
+
+    var rec_ty: ty.TypeId = obj_ty;
+    var base:   value.Value;
+    if (is_ptr) {
+        val pt_opt: Option[*ty.Type] = ty.get(?ctx.s.types, obj_ty);
+        if (is_none[*ty.Type](pt_opt)) { ret err[value.Value, str]("lower: projection base has no pointer type"); }
+        val pt: *ty.Type = unwrap[*ty.Type](pt_opt);
+        if (pt.kind != ty.TYPE_POINTER) {
+            ret report_expr(ctx, eid, "field projection on untyped pointer; cast to a typed pointer (*T) first");
+        }
+        rec_ty = pt.data.pointer.base;
+        val br: Result[value.Value, str] = lower_rvalue(ctx, e.data.project.object);
+        if (is_err[value.Value, str](br)) { ret br; }
+        base = unwrap_ok[value.Value, str](br);
+    }
+    or {
+        val br: Result[value.Value, str] = lower_lvalue(ctx, e.data.project.object);
+        if (is_err[value.Value, str](br)) { ret br; }
+        base = unwrap_ok[value.Value, str](br);
+    }
 
     val rec_ir_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, rec_ty);
     if (is_err[ir_type.IrTypeId, str](rec_ir_r)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](rec_ir_r)); }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -540,7 +540,30 @@ fun lower_ident_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.V
 # field whose rvalue is its storage address (a nested struct / array field is
 # left as a pointer the back end consumes at use sites; see
 # lower_ident_rvalue).
+# folds a `$each` field-descriptor member (`f.offset`, #1473) to a constant. none
+# when the object is not a field descriptor (an ordinary `value.field` access).
+fun try_lower_field_member(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Option[Result[value.Value, str]] {
+    val src: str = lower.module_source(ctx);
+    val obj_r: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, src, e.data.member.object, ?ctx.s.interner);
+    if (is_err[comptime.CTValue, str](obj_r)) { ret none[Result[value.Value, str]](); }
+    if (unwrap_ok[comptime.CTValue, str](obj_r).kind != comptime.CT_KIND_FIELD) { ret none[Result[value.Value, str]](); }
+
+    val mr: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, src, eid, ?ctx.s.interner);
+    if (is_err[comptime.CTValue, str](mr)) { ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[comptime.CTValue, str](mr))); }
+    val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](mr);
+    if (v.kind == comptime.CT_KIND_INT) {
+        val rt_r: Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
+        if (is_err[ir_type.IrTypeId, str](rt_r)) { ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](rt_r))); }
+        ret some[Result[value.Value, str]](ok[value.Value, str](value.const_int(v.data.i:~u64, unwrap_ok[ir_type.IrTypeId, str](rt_r))));
+    }
+    ret some[Result[value.Value, str]](err[value.Value, str]("lower: unsupported field descriptor member in value position"));
+}
+
 fun lower_member_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
+    # a `$each` field-descriptor member (`f.offset`) folds to a constant (#1473).
+    val fdm: Option[Result[value.Value, str]] = try_lower_field_member(ctx, eid, e);
+    if (is_some[Result[value.Value, str]](fdm)) { ret unwrap[Result[value.Value, str]](fdm); }
+
     # a module-qualified reference (`alias.name`, where `alias` is a `use`
     # binding) is recorded by resolve as a symbol on the member expression
     # itself; it denotes the imported value, not a field of a record. lower it

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -556,6 +556,18 @@ fun try_lower_field_member(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.
         if (is_err[ir_type.IrTypeId, str](rt_r)) { ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](rt_r))); }
         ret some[Result[value.Value, str]](ok[value.Value, str](value.const_int(v.data.i:~u64, unwrap_ok[ir_type.IrTypeId, str](rt_r))));
     }
+    if (v.kind == comptime.CT_KIND_STR) {
+        # materialize the field name as an anonymous rodata string and yield a
+        # pointer to it, exactly like a string literal (`lower_lit_str`).
+        val pr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);
+        if (is_err[ir_type.IrTypeId, str](pr)) { ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](pr))); }
+        val pty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](pr);
+        val bytes_opt: Option[str] = intern.lookup(?ctx.s.interner, v.data.s);
+        if (is_none[str](bytes_opt)) { ret some[Result[value.Value, str]](err[value.Value, str]("lower: field name lookup failed")); }
+        val bytes: str = unwrap[str](bytes_opt);
+        val blob: value.Value = value.const_bytes(bytes::*u8, (str_len(bytes) + 1::usize)::u32, pty);
+        ret some[Result[value.Value, str]](lower.add_rodata_bytes(ctx, blob, pty));
+    }
     ret some[Result[value.Value, str]](err[value.Value, str]("lower: unsupported field descriptor member in value position"));
 }
 

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -45,6 +45,7 @@ use astmt:    mach.lang.fe.ast.stmt;
 use adecl:    mach.lang.fe.ast.decl;
 use resolve:  mach.lang.fe.resolve;
 use comptime: mach.lang.fe.comptime;
+use ty:       mach.lang.type;
 
 use ir:       mach.lang.me.ir;
 use ir_type:  mach.lang.me.ir.type;
@@ -80,6 +81,7 @@ pub fun lower_stmt(ctx: *lower.LowerContext, sid: aid.StmtId) Result[bool, str] 
     if (k == astmt.STMT_KIND_DECL)        { ret lower_decl_stmt(ctx, s); }
     if (k == astmt.STMT_KIND_ASM)         { ret lower_asm(ctx, s); }
     if (k == astmt.STMT_KIND_COMPTIME_IF) { ret lower_comptime_if(ctx, s); }
+    if (k == astmt.STMT_KIND_COMPTIME_EACH) { ret lower_comptime_each(ctx, s); }
     if (k == astmt.STMT_KIND_ERROR) {
         # an error stmt must never reach lowering: the driver aborts on
         # accumulated diagnostics before the middle end runs.
@@ -584,6 +586,45 @@ fun lower_comptime_if(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str
             ret lower_stmt_list(ctx, branch.body_start, branch.body_len);
         }
         bi = bi + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# lowers a `$each <ident> in $fields(T) { body }` (#1473) by unrolling it: the
+# body is lowered once per field of T, with the loop variable bound in the
+# comptime frame to that field's descriptor, so a `v.[f]` in the body projects
+# the concrete field of each iteration. the lowering half of the splice sema
+# mirrors. the owning type was resolved and recorded on the `$fields(T)` argument
+# by sema.
+fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] {
+    val ce: *astmt.StmtComptimeEach = ?s.data.comptime_each;
+    val src: str = lower.module_source(ctx);
+    if (!comptime.is_fields_call(ctx.a, src, ce.seq)) {
+        ret err[bool, str]("lower: a `$each` sequence must be `$fields(T)`");
+    }
+    val targ: aid.ExprId = comptime.fields_type_arg(ctx.a, ce.seq);
+    if (targ == aid.EXPR_NIL) { ret err[bool, str]("lower: `$fields` is missing its type argument"); }
+    val owner: ty.TypeId = lower.expr_type_of(ctx, targ);
+
+    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, src, ce.var_name);
+    if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
+    val fname: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+    val n: u32 = ty.field_count(?ctx.s.types, owner);
+    var i: u32 = 0;
+    for (i < n) {
+        val mark: comptime.FrameMark = comptime.frame_open(ctx.ctx);
+        val br: Result[bool, str] = comptime.bind(ctx.ctx, fname, comptime.field_value(owner::u32, i));
+        if (is_err[bool, str](br)) {
+            val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            if (is_err[bool, str](cc)) { ret cc; }
+            ret br;
+        }
+        val rb: Result[bool, str] = lower_stmt_list(ctx, ce.body_start, ce.body_len);
+        val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+        if (is_err[bool, str](rb)) { ret rb; }
+        if (is_err[bool, str](cc)) { ret cc; }
+        i = i + 1;
     }
     ret ok[bool, str](true);
 }


### PR DESCRIPTION
Closes #1473 (the `$fields` half; the `$each a in va` pack form lands with #1474, per the approved split).

Bounded compile-time expansion: `$each <ident> in <seq> { body }` unrolls a comptime-known sequence, with `$fields(T)` as the sequence and `v.[f]` projecting the bound field off an instance. Second link of the v1.7 comptime chain (#1472→#1473→#1474→#1475); builds on #1472's `CT_KIND_TYPE` / type-resolver infrastructure.

## Design
`$fields`/`v.[f]`/`f.*` are an expansion cluster whose only consumer is `$each`, designed and e2e-tested as one unit.

- **`$each f in $fields(T)`** unrolls at **both sema and lowering** by repeated traversal of the same body AST, binding the loop var `f` per-iteration in the comptime frame to a `CT_KIND_FIELD` descriptor — no AST cloning, mirroring how `$if` is handled at both layers and the generic substitution model. This is #1475's "splice before lowering" for the concrete-`T` case; generic-`T` defers to #1475's monomorphization. Heterogeneous fields are handled because each iteration re-types/re-lowers the body.
- **`v.[f]`** lowers to a field gep mirroring member access (read + write lvalue; pointer receiver auto-derefs).
- **`f.name` / `f.type` / `f.offset`** project the descriptor via a field-member resolver (`.name`→rodata string, `.type`→type value, `.offset`→target byte offset). They fire only when the object is a field descriptor, so a real record field named `type` is never mistaken for one.
- **`$if (f.type == i64)`** reuses #1472's type `==` for type-directed field iteration.

## Slices (all in)
- [x] AST + `CT_KIND_FIELD`; parser (`$each`, `v.[f]`)
- [x] `$fields(T)` + sema/lower unroll + `v.[f]` rvalue & lvalue
- [x] empty record + nested `$each`
- [x] `f.offset`, `f.type` (type comparison, no `s.type` regression), `f.name` (runtime string)
- [ ] `$each a in va` over a variadic pack → #1474

## Gates
- Self-host fixpoint: byte-identical (codegen-inert front-end additions).
- Unit corpus: 516/516.
- e2e `.github/tests/eachfields`: homogeneous/heterogeneous `v.[f]`, pointer-receiver lvalue write, empty record, nested, `f.offset`, `$if (f.type == i64)`, real field named `type`, and `f.name`.