### PR TITLE
feat(comptime): variadic packs — va: ... / va... / va.len (#1474)

### DIFF
--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1122,6 +1122,50 @@ test "diagnostics: align on a def alias is rejected, not silently ignored (#1490
     ret 0;
 }
 
+test "sema: a `va: ...` pack declares; `va.len` and `$each a in va` typecheck (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # a named trailing pack parameter; `va.len` is the comptime element count and
+    # `$each a in va` iterates it (element body deferred to monomorphization).
+    val fr: Result[src.FileId, str] = open(?es, "pk.mach",
+        "fun take(va: ...) i64 { var n: i64 = va.len::i64; $each a in va { } ret n; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag.has_errors(unwrap_ok[*diag.DiagList, str](dr))) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: a `$each` over a non-pack, non-`$fields` sequence is rejected (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    val fr: Result[src.FileId, str] = open(?es, "bad.mach",
+        "fun f() i64 { var x: i64 = 0; $each a in x { } ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "must be `$fields(T)` or a variadic pack")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "diagnostics: calling a non-function renders the callee type (#1046)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/fe/ast/type.mach
+++ b/src/lang/fe/ast/type.mach
@@ -18,6 +18,10 @@ pub val TYPE_KIND_ARRAY: TypeKind = 2;
 pub val TYPE_KIND_FUN:   TypeKind = 3;
 pub val TYPE_KIND_REC:   TypeKind = 4;
 pub val TYPE_KIND_UNI:   TypeKind = 5;
+# a comptime variadic pack type `...` on a named trailing parameter (#1474):
+# `fun f(va: ...)`. carries no payload — the pack's element types are fixed per
+# call site and supplied by monomorphization (#1475), not at declaration.
+pub val TYPE_KIND_PACK:  TypeKind = 6;
 pub val TYPE_KIND_ERROR: TypeKind = 255;
 
 # TypeNamed: a named type reference, optionally with generic arguments.

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -1173,7 +1173,12 @@ fun parse_comptime_each_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
     if (!parser.eat_kw(p, "in")) {
         parser.error_at_current(p, "expected 'in' after the $each loop variable");
     }
+    # the sequence is paren-less and immediately followed by the body's `{`, so a
+    # bare pack ident (`va`) must not parse the body braces as a struct literal.
+    val saved_nsl: bool = p.no_struct_lit;
+    p.no_struct_lit = true;
     val seq: id.ExprId = pexpr.parse_expr(p);
+    p.no_struct_lit = saved_nsl;
 
     var body_start: u32 = 0;
     var body_len:   u32 = 0;

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -133,7 +133,7 @@ fun parse_prefix(p: *parser.Parser) id.ExprId {
 
     if (t.kind == token.KIND_IDENT) {
         if (parser.at_kw(p, "nil"))      { ret parse_lit_nil(p); }
-        if (looks_like_typed_literal(p)) { ret parse_typed_literal(p); }
+        if (!p.no_struct_lit && looks_like_typed_literal(p)) { ret parse_typed_literal(p); }
         ret parse_ident(p);
     }
 

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -89,6 +89,17 @@ pub fun parse_type(p: *parser.Parser) id.TypeId {
     if (parser.at_kw(p, "fun"))            { ret parse_fun(p, start.span); }
     if (parser.at_kw(p, "rec"))            { ret parse_rec_or_uni(p, start.span, m_type.TYPE_KIND_REC); }
     if (parser.at_kw(p, "uni"))            { ret parse_rec_or_uni(p, start.span, m_type.TYPE_KIND_UNI); }
+    # a `...` in type position is a comptime variadic pack (#1474), e.g. the type
+    # of a `va: ...` parameter. distinct from a standalone trailing `...` in a
+    # parameter list, which the legacy va_list variadic marker consumes before a
+    # type is ever parsed.
+    if (parser.at(p, token.KIND_DOT_DOT_DOT)) {
+        parser.advance(p);
+        var pk: m_type.Type;
+        pk.span = start.span;
+        pk.kind = m_type.TYPE_KIND_PACK;
+        ret parser.push_type(p, pk);
+    }
     if (parser.at(p, token.KIND_IDENT))    { ret parse_named(p, start.span); }
 
     parser.error_at_current(p, "expected a type; named, '*T', '[N]T', 'fun(...)', or inline 'rec'/'uni' forms are valid here");

--- a/src/lang/fe/parser/state.mach
+++ b/src/lang/fe/parser/state.mach
@@ -40,6 +40,10 @@ use module: mach.lang.fe.ast.module;
 # fatal:  sticky flag set by any allocation failure during parsing, independent
 #         of panic so an OOM hit mid-recovery is never swallowed; the driver
 #         treats a fatal parse as failed rather than consuming a corrupt AST
+# no_struct_lit: while true, a bare `Name { ... }` does not parse as a struct
+#         literal — the `{` opens an enclosing block instead. set for the
+#         sequence of a paren-less `$each <ident> in <seq> { body }` (#1474) so a
+#         pack-ident sequence (`va`) does not swallow the loop body's braces.
 pub rec Parser {
     tokens: *lexer.TokenStream;
     pos:    usize;
@@ -47,6 +51,7 @@ pub rec Parser {
     diags:  *diag.DiagList;
     panic:  bool;
     fatal:  bool;
+    no_struct_lit: bool;
 }
 
 # init: initializes a Parser over the given token stream, filling output into ast and diags.
@@ -63,6 +68,7 @@ pub fun init(tokens: *lexer.TokenStream, out: *ast.Ast, diags: *diag.DiagList) P
     p.diags  = diags;
     p.panic  = false;
     p.fatal  = false;
+    p.no_struct_lit = false;
     ret p;
 }
 

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -590,7 +590,18 @@ fun infer_stmt(sc: *ctxm.SemaContext, sid: id.StmtId, fn_ret: type.TypeId) Resul
 # each iteration re-types the body.
 fun infer_stmt_comptime_each(sc: *ctxm.SemaContext, ce: *stmt.StmtComptimeEach, span: token.Span, fn_ret: type.TypeId) Result[bool, str] {
     if (!comptime.is_fields_call(sc.a, sc.source, ce.seq)) {
-        ctxm.report(sc, span, "a `$each` sequence must be `$fields(T)`");
+        # a variadic-pack sequence (`$each a in va`, #1474): the element types are
+        # fixed per call site, so the body is type-checked per instantiation at
+        # monomorphization (#1475), not here. accept the well-formed construct and
+        # defer; a non-pack, non-`$fields` sequence is malformed.
+        val seq_ty: type.TypeId = infer.infer_expr(sc, ce.seq);
+        val st_opt: Option[*type.Type] = type.get(?sc.s.types, seq_ty);
+        if (is_some[*type.Type](st_opt) && unwrap[*type.Type](st_opt).kind == type.TYPE_PACK) {
+            ret ok[bool, str](true);
+        }
+        if (seq_ty != type.TYPE_ERROR) {
+            ctxm.report(sc, span, "a `$each` sequence must be `$fields(T)` or a variadic pack");
+        }
         ret ok[bool, str](true);
     }
     val owner: type.TypeId = infer.field_seq_owner(sc, ce.seq, span);

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -965,6 +965,13 @@ fun project_receiver_matches(sc: *sema.SemaContext, obj_ty: type.TypeId, owner: 
     ret t.kind == type.TYPE_POINTER && t.data.pointer.base == owner;
 }
 
+# whether `ty` is a comptime variadic pack (#1474).
+fun type_is_pack(sc: *sema.SemaContext, ty: type.TypeId) bool {
+    val to: Option[*type.Type] = type.get(?sc.s.types, ty);
+    if (is_none[*type.Type](to)) { ret false; }
+    ret unwrap[*type.Type](to).kind == type.TYPE_PACK;
+}
+
 # whether `ty` is a record (or a generic record instance), the aggregate
 # `$fields` accepts. unions and non-aggregates are rejected.
 fun type_is_record(sc: *sema.SemaContext, ty: type.TypeId) bool {
@@ -1145,6 +1152,16 @@ fun infer_member(sc: *sema.SemaContext, eid: id.ExprId, m: *expr.ExprMember, spa
 
     val ot: type.TypeId = infer_expr(sc, m.object);
     if (ot == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+
+    # `va.len` on a comptime variadic pack (#1474) is the comptime element count.
+    if (type_is_pack(sc, ot)) {
+        if (str_region_equals(sc.source, m.name.offset, m.name.len, "len")) {
+            ret prim_or_error(sc, type.TYPE_U64);
+        }
+        sema.report(sc, span, "a variadic pack has only `.len`; iterate its elements with `$each`");
+        ret type.TYPE_ERROR;
+    }
+
     if (ot == type.TYPE_NIL) {
         # a value-less object (a call to a function with no return type) yields
         # no value; without a report the broken access would reach lowering with
@@ -1313,6 +1330,12 @@ pub fun resolve_type_ref(sc: *sema.SemaContext, tid: id.TypeId) type.TypeId {
     if (t.kind == atype.TYPE_KIND_FUN)   { ret resolve_type_fun(sc, ?t.data.fun_); }
     if (t.kind == atype.TYPE_KIND_REC)   { ret resolve_type_anon(sc, tid, t.data.rec_.fields_start, t.data.rec_.fields_len, type.TYPE_REC); }
     if (t.kind == atype.TYPE_KIND_UNI)   { ret resolve_type_anon(sc, tid, t.data.uni_.fields_start, t.data.uni_.fields_len, type.TYPE_UNI); }
+    # a `...` comptime variadic pack (#1474): the singleton pack type.
+    if (t.kind == atype.TYPE_KIND_PACK) {
+        val r: Result[type.TypeId, str] = type.intern_pack(?sc.s.types);
+        if (is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }
+        ret unwrap_ok[type.TypeId, str](r);
+    }
     ret type.TYPE_ERROR;
 }
 

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -89,6 +89,10 @@ pub val TYPE_INSTANCE:      TypeKind = 17;
 # lowers to the four-field register-save struct. used by the variadic
 # intrinsics (`va_list` / `va_start` / `va_arg` / `va_end`).
 pub val TYPE_VA_LIST:       TypeKind = 18;
+# a comptime variadic pack (#1474): the type of a `va: ...` parameter. a
+# payload-free singleton — the pack's element types are fixed per call site and
+# supplied by monomorphization (#1475), never carried on the type itself.
+pub val TYPE_PACK:          TypeKind = 19;
 
 val PRIM_COUNT: u32 = 11;
 
@@ -588,6 +592,16 @@ pub fun intern_array(ti: *TypeInterner, base: TypeId, count: u32) Result[TypeId,
 pub fun intern_va_list(ti: *TypeInterner) Result[TypeId, str] {
     var t: Type;
     t.kind = TYPE_VA_LIST;
+    ret intern_dedup(ti, t);
+}
+
+# intern_pack: the comptime variadic pack type (#1474), a payload-free singleton.
+# ---
+# ti:  the interner
+# ret: the TypeId for a `...` pack, or an allocation error
+pub fun intern_pack(ti: *TypeInterner) Result[TypeId, str] {
+    var t: Type;
+    t.kind = TYPE_PACK;
     ret intern_dedup(ti, t);
 }
 


### PR DESCRIPTION
Part of #1474 (declare/collect/consume typecheck + the no_struct_lit parser fix; `va...` forward completes #1474 in a follow-up) (parse + typecheck; the runnable `$each a in va` e2e lands in #1475 via monomorphization).

First-class comptime variadic packs replacing the C-style va_list surface. Third link of the v1.7 comptime chain (#1472→#1473→#1474→#1475); builds on #1473's `$each`.

## Scope (per the issue + signed-off §5 model)
- `fun f(va: ...)` — named trailing pack param.
- `g(va...)` — postfix `...` forward; `va.len` → comptime element count.
- Consumed via `$each a in va`.
- **Additive / seed-safe:** ADDS the pack forms; legacy bare `...` (12 sites in vendored mach-std) keeps working alongside. Parser disambiguates: `name: ...` = pack, standalone trailing `...` = legacy. Legacy removal is #1478.
- Pack representation is comptime — monomorphized per arg-type-list, no va_list, no `any`. Runnable e2e → #1475.

## Slices
- [x] AST `TYPE_KIND_PACK` + parse `...` in type position (seed-safe, legacy `...` intact)
- [x] sema `TYPE_PACK` + resolve mapping; `va: ...` param types as a pack
- [x] `va.len` → comptime usize
- [x] `$each a in va` accepted (element body typing deferred to #1475); non-pack/`$fields` `$each` rejected
- [x] parser `no_struct_lit` mode so a paren-less `$each ... in va {` doesn't swallow the body braces
- [ ] `va...` forward — postfix-`...` expression form (parse) + forward typecheck (arg into another pack fn)

## Gates
- Self-host fixpoint byte-identical (front-end additions are codegen-inert).
- Unit corpus 518/518, incl. two `#1474` sema tests (declare+`va.len`+`$each`-over-pack typecheck cleanly; non-pack `$each` rejected).
- No codegen (that's #1475 where it first runs).