### PR TITLE
feat(comptime): va: ... collect + va... forward (typecheck) — #1474

### DIFF
--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1166,6 +1166,53 @@ test "sema: a `$each` over a non-pack, non-`$fields` sequence is rejected (#1474
     ret 0;
 }
 
+test "sema: a call collects trailing args into a `va: ...` pack param (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # the pack param absorbs every trailing argument (variable arity); a leading
+    # fixed param is still checked, and the collected args are typed but not
+    # checked against a concrete type (fixed at monomorphization, #1475).
+    val fr: Result[src.FileId, str] = open(?es, "col.mach",
+        "fun take(tag: i64, va: ...) i64 { ret tag; } fun sum(va: ...) i64 { ret 0; } fun main() i64 { ret take(1, 2, 3) + sum() + sum(4, 5); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag.has_errors(unwrap_ok[*diag.DiagList, str](dr))) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: a call below a pack's leading fixed arity is rejected (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `take` requires its leading fixed `tag`; a bare `take()` supplies fewer than
+    # the fixed count and is an arity error even though the pack accepts any tail.
+    val fr: Result[src.FileId, str] = open(?es, "few.mach",
+        "fun take(tag: i64, va: ...) i64 { ret tag; } fun main() i64 { ret take(); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "arity mismatch: expected at least")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "diagnostics: calling a non-function renders the callee type (#1046)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1213,6 +1213,96 @@ test "sema: a call below a pack's leading fixed arity is rejected (#1474)" {
     ret 0;
 }
 
+test "sema: `va...` forwards a whole pack into a trailing pack param (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `inner` has a leading fixed param then a pack; `fwd` has only a pack. each
+    # forward passes the whole pack as the sole trailing argument.
+    val fr: Result[src.FileId, str] = open(?es, "fwd.mach",
+        "fun inner(tag: i64, va: ...) i64 { ret tag; } fun fwd(va: ...) i64 { ret inner(7, va...); } fun bare(va: ...) i64 { ret fwd(va...); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag.has_errors(unwrap_ok[*diag.DiagList, str](dr))) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: spreading `...` into fixed parameters is rejected (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `point` has no pack parameter, so the whole pack cannot be spread into it.
+    val fr: Result[src.FileId, str] = open(?es, "intofixed.mach",
+        "fun point(x: i64, y: i64) i64 { ret x; } fun outer(va: ...) i64 { ret point(va...); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "cannot spread `...` into fixed parameters")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: a `...` spread of a non-pack operand is rejected (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `z` is an ordinary value, not a pack; spreading it is malformed.
+    val fr: Result[src.FileId, str] = open(?es, "nonpack.mach",
+        "fun g(va: ...) i64 { ret 0; } fun f() i64 { var z: i64 = 0; ret g(z...); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "may only spread a variadic pack")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: a `...` spread mixed with other trailing args is rejected (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `inner` is a pure pack; the spread must be the sole trailing argument, so a
+    # leading collected `1` alongside `va...` is rejected.
+    val fr: Result[src.FileId, str] = open(?es, "mixed.mach",
+        "fun inner(va: ...) i64 { ret 0; } fun outer(va: ...) i64 { ret inner(1, va...); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "sole trailing argument")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "diagnostics: calling a non-function renders the callee type (#1046)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/fe/ast/expr.mach
+++ b/src/lang/fe/ast/expr.mach
@@ -29,6 +29,10 @@ pub val EXPR_KIND_COMPTIME_IDENT: ExprKind = 15;
 # a `v.[f]` field projection (#1472/#1473): project the field named by a comptime
 # field descriptor `f` (bound by `$each`) off an instance `v`. an lvalue.
 pub val EXPR_KIND_PROJECT:        ExprKind = 16;
+# a `va...` pack spread (#1474): postfix `...` on a call argument, forwarding a
+# whole comptime variadic pack into a trailing pack parameter. recognized only
+# in call-argument position, never globally in the postfix grammar.
+pub val EXPR_KIND_SPREAD:         ExprKind = 17;
 pub val EXPR_KIND_ERROR:          ExprKind = 255;
 
 # BinOp: binary operator encoded in ExprBinary.op.
@@ -134,6 +138,14 @@ pub rec ExprProject {
     field:  id.ExprId;
 }
 
+# ExprSpread: a `va...` pack spread (#1474). `inner` is the spread operand — a
+# comptime variadic pack — forwarded whole into a trailing pack parameter.
+# ---
+# inner: the pack expression being spread
+pub rec ExprSpread {
+    inner: id.ExprId;
+}
+
 # ExprCast: a type cast expression. `::` performs a value conversion
 # (`value::Type`) and `:~` a same-size bit reinterpretation (`value:~Type`).
 # ---
@@ -198,5 +210,6 @@ pub rec Expr {
         array_lit:  ExprArrayLit;
         struct_lit: ExprStructLit;
         project:    ExprProject;
+        spread:     ExprSpread;
     };
 }

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -482,6 +482,33 @@ fun parse_paren(p: *parser.Parser) id.ExprId {
     ret inner;
 }
 
+# parses one call argument: an expression optionally suffixed with a postfix
+# `...` pack spread (#1474), e.g. `va...`, forwarding a whole comptime variadic
+# pack. the spread is recognized ONLY here, in call-argument position — never
+# globally in parse_postfix — so it cannot collide with the legacy standalone
+# `...` parameter marker (which is consumed in a parameter list, never after a
+# call argument). validity (a pack operand, the sole trailing argument of a
+# pack-tailed callee) is checked in sema.
+fun parse_call_arg(p: *parser.Parser) id.ExprId {
+    val e: id.ExprId = parse_expr(p);
+    if (!parser.at(p, token.KIND_DOT_DOT_DOT)) { ret e; }
+    val dots: token.Token = parser.advance(p);
+
+    var sp: expr.ExprSpread;
+    sp.inner = e;
+
+    var start_span: token.Span = dots.span;
+    if (e != id.EXPR_NIL) {
+        start_span = unwrap[*expr.Expr](ast.get_expr(p.ast, e)).span;
+    }
+
+    var node: expr.Expr;
+    node.span = parser.span_of(start_span, dots.span);
+    node.kind = expr.EXPR_KIND_SPREAD;
+    node.data.spread = sp;
+    ret parser.push_expr(p, node);
+}
+
 # parses a call expression `callee(args)`. type_args_start/type_args_len carry
 # any call-site generic arguments parsed by parse_generic_call; both are 0 for
 # a plain call. index_callee is EXPR_NIL except for a provisional bracket call,
@@ -498,10 +525,10 @@ fun parse_call(p: *parser.Parser, callee: id.ExprId, type_args_start: u32, type_
     var buf: parser.ListBuf[id.ExprId] = parser.list_buf_init[id.ExprId]();
 
     if (!parser.at(p, token.KIND_RPAREN)) {
-        parser.list_buf_push[id.ExprId](p, ?buf, parse_expr(p));
+        parser.list_buf_push[id.ExprId](p, ?buf, parse_call_arg(p));
         for (parser.eat(p, token.KIND_COMMA)) {
             if (parser.at(p, token.KIND_RPAREN)) { brk; }
-            parser.list_buf_push[id.ExprId](p, ?buf, parse_expr(p));
+            parser.list_buf_push[id.ExprId](p, ?buf, parse_call_arg(p));
         }
     }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1747,6 +1747,10 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
     if (e.kind == expr.EXPR_KIND_UNARY) {
         ret bind_expr(rc, e.data.unary.operand);
     }
+    if (e.kind == expr.EXPR_KIND_SPREAD) {
+        # `va...`: bind the spread operand (the pack identifier).
+        ret bind_expr(rc, e.data.spread.inner);
+    }
     if (e.kind == expr.EXPR_KIND_CALL) {
         # a provisional bracket call `callee[x](args)` whose payload read as both
         # a type list and an index expression: choose the reading now from the

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -84,6 +84,44 @@ fun param_is_pack(sc: *sema.SemaContext, param_idx: u32) bool {
     ret unwrap[*ty.Type](to).kind == ty.TYPE_PACK;
 }
 
+# whether the argument at `eid` is a `va...` pack spread (#1474).
+fun arg_is_spread(sc: *sema.SemaContext, eid: id.ExprId) bool {
+    val e_opt: Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (is_none[*expr.Expr](e_opt)) { ret false; }
+    ret unwrap[*expr.Expr](e_opt).kind == expr.EXPR_KIND_SPREAD;
+}
+
+# validates the placement of any `va...` pack spread (#1474) among a call's
+# arguments. a spread forwards a whole pack and is valid ONLY as the sole
+# trailing argument of a pack-tailed callee — i.e. at index `fixed_count` with
+# `args_len == fixed_count + 1`. spreading into fixed parameters (no pack tail)
+# or a spread mixed with other trailing args is rejected. a spread whose operand
+# is not a pack already reported in `infer_spread`, so it is not re-diagnosed
+# here. returns false (with a diagnostic) on the first ill-placed spread.
+fun validate_pack_spreads(sc: *sema.SemaContext, has_pack: bool, fixed_count: u32, args_start: u32, args_len: u32, span: token.Span) bool {
+    var ok: bool = true;
+    var i: u32 = 0;
+    for (i < args_len) {
+        val a_eid: id.ExprId = sc.a.expr_ids[args_start + i];
+        if (arg_is_spread(sc, a_eid)) {
+            val a_span: token.Span = expr_span_of(sc, a_eid, span);
+            if (expr_type_of(sc, a_eid) == ty.TYPE_ERROR) {
+                ok = false;
+            }
+            or (!has_pack) {
+                report(sc, a_span, "cannot spread `...` into fixed parameters: the callee has no variadic pack parameter");
+                ok = false;
+            }
+            or (i != fixed_count || args_len != fixed_count + 1) {
+                report(sc, a_span, "a `...` pack spread must be the sole trailing argument, forwarding the whole pack");
+                ok = false;
+            }
+        }
+        i = i + 1;
+    }
+    ret ok;
+}
+
 # checks a call against the callee's function signature: the callee type
 # must be a function, the argument count must match the fixed parameter
 # count (or be at least that many for a variadic or pack-tailed function), and
@@ -126,6 +164,14 @@ pub fun check_call(sc: *sema.SemaContext, callee_sig: ty.TypeId, args_start: u32
     var fixed_count: u32 = param_count;
     val has_pack: bool = param_count > 0 && param_is_pack(sc, params_start + param_count - 1);
     if (has_pack) { fixed_count = param_count - 1; }
+
+    # a `va...` pack spread (#1474) forwards a whole pack; reject an ill-placed
+    # one first — before arity and the per-argument check — so a misplaced spread
+    # reports its own clear diagnostic rather than an arity mismatch, and a pack
+    # operand is never additionally diagnosed against a fixed parameter type.
+    if (!validate_pack_spreads(sc, has_pack, fixed_count, args_start, args_len, span)) {
+        ret false;
+    }
 
     if (variadic || has_pack) {
         if (args_len < fixed_count) {

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -74,14 +74,25 @@ pub fun check_assignable(sc: *sema.SemaContext, expected: ty.TypeId, actual: ty.
     ret false;
 }
 
+# whether the parameter interned at `param_idx` is a comptime variadic pack
+# (#1474) — the trailing form that absorbs a call's remaining arguments.
+fun param_is_pack(sc: *sema.SemaContext, param_idx: u32) bool {
+    val pty_opt: Option[ty.TypeId] = ty.get_param(?sc.s.types, param_idx);
+    if (is_none[ty.TypeId](pty_opt)) { ret false; }
+    val to: Option[*ty.Type] = ty.get(?sc.s.types, unwrap[ty.TypeId](pty_opt));
+    if (is_none[*ty.Type](to)) { ret false; }
+    ret unwrap[*ty.Type](to).kind == ty.TYPE_PACK;
+}
+
 # checks a call against the callee's function signature: the callee type
 # must be a function, the argument count must match the fixed parameter
-# count (or be at least that many for a variadic function), and each fixed
-# argument must be assignable to its parameter. trailing variadic arguments
-# carry their inferred types unchecked, as the C-ABI variadic contract
-# imposes no parameter type. argument expressions are taken from
-# `sc.a.expr_ids[args_start ..]`, which allows untyped-literal arguments to
-# coerce to their parameter type.
+# count (or be at least that many for a variadic or pack-tailed function), and
+# each fixed argument must be assignable to its parameter. trailing variadic
+# arguments carry their inferred types unchecked, as the C-ABI variadic
+# contract imposes no parameter type; trailing pack arguments are likewise
+# unchecked here, their element types fixed per call site at monomorphization
+# (#1475). argument expressions are taken from `sc.a.expr_ids[args_start ..]`,
+# which allows untyped-literal arguments to coerce to their parameter type.
 # ---
 # sc:         the active sema context
 # callee_sig: the callee's type; must be TYPE_FUN
@@ -105,9 +116,20 @@ pub fun check_call(sc: *sema.SemaContext, callee_sig: ty.TypeId, args_start: u32
 
     val param_count: u32 = ft.data.fn.params_len;
     val variadic:    bool = ft.data.fn.variadic;
-    if (variadic) {
-        if (args_len < param_count) {
-            report_arity(sc, span, param_count, args_len, true);
+    val params_start: u32 = ft.data.fn.params_start;
+
+    # a trailing comptime variadic pack param (#1474) absorbs every trailing
+    # argument: arity is `>= the leading fixed count`, and the collected args
+    # carry their inferred types unchecked here — their concrete element types
+    # are fixed per call site and bound at monomorphization (#1475). the legacy
+    # C-variadic flag is a distinct, mutually exclusive trailing form.
+    var fixed_count: u32 = param_count;
+    val has_pack: bool = param_count > 0 && param_is_pack(sc, params_start + param_count - 1);
+    if (has_pack) { fixed_count = param_count - 1; }
+
+    if (variadic || has_pack) {
+        if (args_len < fixed_count) {
+            report_arity(sc, span, fixed_count, args_len, true);
             ret false;
         }
     }
@@ -116,10 +138,9 @@ pub fun check_call(sc: *sema.SemaContext, callee_sig: ty.TypeId, args_start: u32
         ret false;
     }
 
-    val params_start: u32 = ft.data.fn.params_start;
     var ok_all: bool = true;
     var i: u32 = 0;
-    for (i < param_count) {
+    for (i < fixed_count) {
         val pty_opt: Option[ty.TypeId] = ty.get_param(?sc.s.types, params_start + i);
         if (is_none[ty.TypeId](pty_opt)) { ok_all = false; brk; }
         val expected: ty.TypeId = unwrap[ty.TypeId](pty_opt);

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -315,6 +315,9 @@ pub fun infer_expr(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
     or (e.kind == expr.EXPR_KIND_PROJECT) {
         t = infer_project(sc, ?e.data.project, e.span);
     }
+    or (e.kind == expr.EXPR_KIND_SPREAD) {
+        t = infer_spread(sc, ?e.data.spread, e.span);
+    }
     or (e.kind == expr.EXPR_KIND_CAST) {
         t = infer_cast(sc, ?e.data.cast, e.span);
     }
@@ -970,6 +973,20 @@ fun type_is_pack(sc: *sema.SemaContext, ty: type.TypeId) bool {
     val to: Option[*type.Type] = type.get(?sc.s.types, ty);
     if (is_none[*type.Type](to)) { ret false; }
     ret unwrap[*type.Type](to).kind == type.TYPE_PACK;
+}
+
+# infer_spread: types a `va...` pack spread (#1474). a spread may only spread a
+# comptime variadic pack; its type is that pack. it forwards the whole pack into
+# a trailing pack parameter — that placement is validated at the call site
+# (check_call). a spread of a non-pack operand is malformed.
+fun infer_spread(sc: *sema.SemaContext, sp: *expr.ExprSpread, span: token.Span) type.TypeId {
+    val it: type.TypeId = infer_expr(sc, sp.inner);
+    if (it == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    if (!type_is_pack(sc, it)) {
+        sema.report(sc, span, "`...` may only spread a variadic pack");
+        ret type.TYPE_ERROR;
+    }
+    ret it;
 }
 
 # whether `ty` is a record (or a generic record instance), the aggregate


### PR DESCRIPTION
Completes the variadic-pack surface for #1474 (parse + typecheck only; codegen is #1475). Additive — legacy bare `...` (C-style va_list) coexists and the vendored mach-std keeps building.

## Slice 1 — collect (`839eb693`)
The merged 3/4 did *declare* / `va.len` / `$each a in va`, but the **call site** was missing: a `va: ...` param interns as a normal trailing `TYPE_PACK` param with `variadic=false`, so `take(1,2,3)` hit an arity error. `check_call` now detects a trailing `TYPE_PACK` param and switches to variable arity (`args_len >= leading-fixed-count`), checking only the leading fixed params and leaving the collected args typed-but-unchecked (element types fixed per call site at monomorphization, #1475). The legacy C-variadic flag stays a distinct, mutually exclusive trailing form.

## Slice 2 — `va...` forward-whole (`65de729b`)
Postfix `...` on a call argument (`g(va...)`) forwards a **whole** comptime variadic pack into a trailing `va: ...` parameter — the printf→vprintf wrapper need (incl. a fixed prefix, e.g. `vprintf(fmt, va...)`).

- **Scoped parse**: recognized ONLY in call-argument position (`parse_call_arg`), **never** globally in `parse_postfix` — a global postfix `...` perturbs the compiler's parse of its own legacy-`...` sites and breaks the self-host fixpoint, whereas the scoped form is provably inert (no `callarg...` anywhere in compiler/std source).
- New AST `EXPR_KIND_SPREAD` + `ExprSpread`; resolve binds the operand; `infer_spread` types spread-of-pack → `TYPE_PACK` and rejects a non-pack operand.
- `check_call` validates placement before arity: a spread is valid only as the **sole trailing argument** of a pack-tailed callee.

### Forward-whole is the complete `va...` surface (octalide ruling)
Per octalide, **forward-whole is the entire `va...` forwarding surface for v1.7** — spread-into-fixed-params (`h(va...)` into `(a, b)`) and partial forwarding (`g(x, va...)` prepending into a pack) are **out of scope / wontfix**, not deferred. This PR rejects every non-whole-pack spread with a clean diagnostic — there is no spread/partial overhang to design around. Matches §5: printf forwards the whole pack to vprintf; whole-pack is all std needs.

## Bar
- Typecheck tests in `editor.mach` (source-string sema; seed-safe): 8 #1474 sema tests — collect (±fixed prefix), below-fixed-arity rejected, forward-whole (±fixed prefix), spread-into-fixed rejected, spread-of-non-pack rejected, mixed-spread rejected. All pass.
- CI **Self-host Fixpoint** + **Test Suite** green; local fixpoint byte-identical (seed→stage1→stage2). The changes are inert over the compiler's own pack-free source.

Closes #1474.