### PR TITLE
feat(comptime): #1475 monomorphization — pack-consuming fns per type-list

### DIFF
--- a/.github/tests/packfwd/app/mach.toml
+++ b/.github/tests/packfwd/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "packfwd"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.packfwd]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/packfwd/app/src/main.mach
+++ b/.github/tests/packfwd/app/src/main.mach
@@ -1,0 +1,39 @@
+use std.runtime;
+
+# va... forward (#1475): inside a pack instance, `g(va...)` threads the
+# instance's concrete pack parameters through to another pack-tailed callee,
+# monomorphized for the forwarded type-list. exits 0 when every forward
+# delivers the right elements; a wrong result returns that check's id.
+
+fun sum(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + a;
+    }
+    ret t;
+}
+
+# outer: a pack-tailed function that forwards its whole pack to sum.
+fun outer(va: ...) i64 {
+    ret sum(va...);
+}
+
+# fwdpre: a leading fixed param, then forward the pack.
+fun fwdpre(base: i64, va: ...) i64 {
+    ret base + sum(va...);
+}
+
+# outer2: forward-of-forward — two levels of pack threading.
+fun outer2(va: ...) i64 {
+    ret outer(va...);
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    if (outer(1, 2, 3) != 6)         { ret 1; }
+    if (outer() != 0)                 { ret 2; }
+    if (fwdpre(100, 1, 2, 3) != 106) { ret 3; }
+    if (fwdpre(100) != 100)           { ret 4; }
+    if (outer2(4, 5, 6) != 15)       { ret 5; }
+    ret 0;
+}

--- a/.github/tests/packfwd/run.sh
+++ b/.github/tests/packfwd/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# whole-pack `va...` forward (#1475): inside a pack instance, `g(va...)` threads the
+# instance's concrete pack parameters through to another pack-tailed callee, which
+# is monomorphized for the forwarded type-list. this builds a program that forwards
+# packs (incl. into a callee with a leading fixed param, and a forward-of-a-forward)
+# and runs it; main exits 0 only when every forward delivers the right elements.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL packfwd: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/packfwd"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL packfwd: check $code forwarded the wrong elements" >&2
+    exit 1
+fi
+echo "PASS packfwd: va... threads the instance's concrete pack through to a pack-tailed callee"

--- a/.github/tests/packmono/app/mach.toml
+++ b/.github/tests/packmono/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "packmono"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.packmono]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/packmono/app/src/main.mach
+++ b/.github/tests/packmono/app/src/main.mach
@@ -26,6 +26,17 @@ fun bias(base: i64, va: ...) i64 {
     ret t;
 }
 
+# a heterogeneous pack: each element a different concrete type. the body is
+# re-typed per element at monomorphization, so `a::i64` casts each element's own
+# type — the defining property of comptime packs over a uniform C-variadic.
+fun sumc(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + a::i64;
+    }
+    ret t;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     # distinct arities are distinct instances, deduped by their type-list.
@@ -42,5 +53,10 @@ fun main(argc: i64, argv: **u8) i64 {
     # a fixed parameter ahead of the pack; the pack expands the trailing args.
     if (bias(100, 1, 2, 3) != 106)       { ret 8; }
     if (bias(0) != 0)                    { ret 9; }
+
+    # heterogeneous element types in one pack, each re-typed and cast per element.
+    if (sumc(1000, 50::i32, 7::u8, 200::i16) != 1257) { ret 10; }
+    if (sumc(5::u8, 5::u8) != 10)                     { ret 11; }
+    if (sumc(10, 2.5::f64, 3::i32) != 15)             { ret 12; }
     ret 0;
 }

--- a/.github/tests/packmono/app/src/main.mach
+++ b/.github/tests/packmono/app/src/main.mach
@@ -1,0 +1,46 @@
+use std.runtime;
+
+# `$each a in va` over a comptime variadic pack (#1475): a pack-tailed function is
+# monomorphized once per distinct call-site arg-type-list, the pack expanded to N
+# concrete parameters and the `$each` unrolled over them. exits 0 only when every
+# instance computes the value its argument list dictates; a wrong result returns
+# that check's id.
+
+# homogeneous i64 packs: one instance per arity, the body re-typed per element.
+fun sum(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + a;
+    }
+    ret t;
+}
+
+# a leading fixed parameter ahead of the pack: the pack absorbs only the trailing
+# arguments, so the same type-list (here two i64s) names one instance regardless of
+# the fixed argument's value.
+fun bias(base: i64, va: ...) i64 {
+    var t: i64 = base;
+    $each a in va {
+        t = t + a;
+    }
+    ret t;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # distinct arities are distinct instances, deduped by their type-list.
+    if (sum(1, 2, 3) != 6)               { ret 1; }
+    if (sum(10, 20) != 30)               { ret 2; }
+    if (sum(5) != 5)                     { ret 3; }
+    if (sum() != 0)                      { ret 4; }
+    if (sum(100, 200, 300, 400) != 1000) { ret 5; }
+
+    # the same arity / type-list reuses one instance across call sites.
+    if (sum(7, 7, 7) != 21)              { ret 6; }
+    if (sum(2, 2, 2) != 6)               { ret 7; }
+
+    # a fixed parameter ahead of the pack; the pack expands the trailing args.
+    if (bias(100, 1, 2, 3) != 106)       { ret 8; }
+    if (bias(0) != 0)                    { ret 9; }
+    ret 0;
+}

--- a/.github/tests/packmono/app/src/main.mach
+++ b/.github/tests/packmono/app/src/main.mach
@@ -37,6 +37,12 @@ fun sumc(va: ...) i64 {
     ret t;
 }
 
+# `va.len` folds to the instance's element count, a compile-time constant fixed by
+# the call site.
+fun count(va: ...) i64 {
+    ret va.len::i64;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     # distinct arities are distinct instances, deduped by their type-list.
@@ -58,5 +64,10 @@ fun main(argc: i64, argv: **u8) i64 {
     if (sumc(1000, 50::i32, 7::u8, 200::i16) != 1257) { ret 10; }
     if (sumc(5::u8, 5::u8) != 10)                     { ret 11; }
     if (sumc(10, 2.5::f64, 3::i32) != 15)             { ret 12; }
+
+    # va.len folds to the element count.
+    if (count(1, 2, 3) != 3)             { ret 13; }
+    if (count() != 0)                    { ret 14; }
+    if (count(9) != 1)                   { ret 15; }
     ret 0;
 }

--- a/.github/tests/packmono/run.sh
+++ b/.github/tests/packmono/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# comptime variadic-pack monomorphization (#1475): a pack-tailed function (`va: ...`)
+# is monomorphized once per distinct call-site arg-type-list, the pack expanded to N
+# concrete parameters and `$each a in va` unrolled over them. this builds a program
+# that sums packs of several arities (and one with a leading fixed parameter), then
+# runs it natively; main exits 0 only when every instance computes the right value.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL packmono: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/packmono"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL packmono: check $code computed the wrong value" >&2
+    exit 1
+fi
+echo "PASS packmono: pack-tailed fns monomorphize per type-list and \$each a in va unrolls"

--- a/.github/tests/packxmod/app/mach.toml
+++ b/.github/tests/packxmod/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "packxmod"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.packxmod]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/packxmod/app/src/helper.mach
+++ b/.github/tests/packxmod/app/src/helper.mach
@@ -1,0 +1,5 @@
+# functions in a second module, called from a pack body in main: the pack-body
+# re-inference at monomorphization (#1475) must resolve their signatures from the
+# all-modules typing-snapshot set, not just main's own declarations.
+pub fun dbl(x: i64) i64 { ret x * 2; }
+pub fun add3(x: i64) i64 { ret x + 3; }

--- a/.github/tests/packxmod/app/src/main.mach
+++ b/.github/tests/packxmod/app/src/main.mach
@@ -1,0 +1,31 @@
+use std.runtime;
+use helper: packxmod.helper;
+
+# pack bodies that call CROSS-MODULE functions per element. the body is re-typed
+# per element at monomorphization, and resolving `helper.dbl` / `helper.add3`
+# requires the all-modules dep set the re-inference assembles (#1475).
+fun sumdbl(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + helper.dbl(a);
+    }
+    ret t;
+}
+
+# a nested cross-module call in the body: add3(dbl(a)) = a*2 + 3 per element.
+fun chain(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + helper.add3(helper.dbl(a));
+    }
+    ret t;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    if (sumdbl(1, 2, 3) != 12) { ret 1; }  # 2 + 4 + 6
+    if (sumdbl(10) != 20)      { ret 2; }
+    if (sumdbl() != 0)         { ret 3; }
+    if (chain(1, 2) != 12)     { ret 4; }  # (2+3) + (4+3)
+    ret 0;
+}

--- a/.github/tests/packxmod/run.sh
+++ b/.github/tests/packxmod/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# cross-module pack bodies (#1475): a `va: ...` function whose `$each a in va` body
+# calls functions in ANOTHER module. monomorphizing it re-types the body per
+# element, which must resolve the cross-module callees' signatures from the
+# all-modules typing-snapshot set the re-inference assembles. this builds a
+# two-module program (main + helper) and runs it; main exits 0 only when every
+# instance computes the right value.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL packxmod: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/packxmod"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL packxmod: check $code computed the wrong value" >&2
+    exit 1
+fi
+echo "PASS packxmod: pack bodies resolve cross-module calls at per-element re-inference"

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -106,6 +106,23 @@ pub rec FieldRef {
     index: u32;
 }
 
+# a comptime PACK-ELEMENT descriptor (#1475): one element of a variadic pack,
+# bound to the `$each a in va` loop variable during monomorphization. the payload
+# `data.pelem` names the element's concrete sema type and its ordinal in the
+# instance's expanded parameter list. sema re-infers the body reading the element
+# TYPE; lowering reads the ORDINAL to load the matching expanded parameter slot.
+pub val CT_KIND_PACK_ELEM: CTKind = 6;
+
+# PackElemRef: the payload of a CT_KIND_PACK_ELEM value — the element's concrete
+# sema TypeId and its ordinal in the pack instance's expanded parameter list.
+# ---
+# index: the element's ordinal among the expanded pack parameters
+# ty:    the element's concrete sema TypeId at this call site
+pub rec PackElemRef {
+    index: u32;
+    ty:    u32;
+}
+
 # COMPTIME_BARE_IDENT_MSG: the single teaching diagnostic for a standalone bare
 # `$ident` (#1249). the comptime channel's shapes are a closed set; a lone
 # `$ident` is none of them — a comptime parameter is referenced without `$`, and
@@ -134,6 +151,7 @@ pub rec CTValue {
         s: intern.StrId;
         t: u32;
         fld: FieldRef;
+        pelem: PackElemRef;
     };
 }
 
@@ -2046,6 +2064,18 @@ pub fun field_value(owner: u32, index: u32) CTValue {
     v.kind          = CT_KIND_FIELD;
     v.data.fld.owner = owner;
     v.data.fld.index = index;
+    ret v;
+}
+
+# pack_elem_value: a comptime PACK-ELEMENT descriptor (#1475) naming a pack
+# element's concrete sema type and its ordinal in the instance's expanded
+# parameter list. bound to the `$each a in va` loop variable during
+# monomorphization; sema reads `.ty`, lowering reads `.index`.
+pub fun pack_elem_value(index: u32, ty: u32) CTValue {
+    var v: CTValue;
+    v.kind            = CT_KIND_PACK_ELEM;
+    v.data.pelem.index = index;
+    v.data.pelem.ty    = ty;
     ret v;
 }
 

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -180,6 +180,66 @@ pub fun reinfer_pack_each_body(
     ret infer_stmt_list(?sc, body_start, body_len, fn_ret);
 }
 
+# collect_module_deps: assemble a typing-snapshot set spanning EVERY registered
+# module, for a re-inference that runs after the whole program is sema'd (#1475).
+# the original per-module sema pass receives only its actual dependencies, but the
+# pack-body re-inference at monomorphization may reach any module the body
+# references, so it consults the full set. each entry borrows a module's
+# SemaResult.decl_type array (owned by the session), so the returned SemaDeps must
+# be released with `free_module_deps` (which frees only the entries array) before
+# the SemaResults are torn down. a module with no registered SemaResult yields a
+# decl-type-less entry (a lookup against it returns TYPE_ERROR, like a miss).
+# ---
+# s:   the session (its module registries)
+# ret: a SemaDeps spanning every module, or an allocation error
+pub fun collect_module_deps(s: *sess.Session) Result[ctxm.SemaDeps, str] {
+    var deps: ctxm.SemaDeps;
+    deps.entries = nil;
+    deps.count   = 0;
+
+    val n: u32 = sess.module_count(s);
+    if (n == 0) { ret ok[ctxm.SemaDeps, str](deps); }
+
+    val r: Result[*ctxm.ModuleSema, str] = allocate[ctxm.ModuleSema](s.alloc, n::usize);
+    if (is_err[*ctxm.ModuleSema, str](r)) { ret err[ctxm.SemaDeps, str](unwrap_err[*ctxm.ModuleSema, str](r)); }
+    val arr: *ctxm.ModuleSema = unwrap_ok[*ctxm.ModuleSema, str](r);
+
+    var mid: u32 = 0;
+    for (mid < n) {
+        var ms: ctxm.ModuleSema;
+        ms.path       = sess.module_fqn(s, mid::sess.ModuleId);
+        ms.module     = mid::sess.ModuleId;
+        ms.decl_type  = nil;
+        ms.decl_count = 0;
+        val sp: ptr = sess.module_sema_ptr(s, mid::sess.ModuleId);
+        if (sp != nil) {
+            val sr: *ctxm.SemaResult = sp::*ctxm.SemaResult;
+            ms.decl_type  = sr.decl_type;
+            ms.decl_count = sr.decl_count;
+        }
+        arr[mid] = ms;
+        mid = mid + 1;
+    }
+
+    deps.entries = arr;
+    deps.count   = n;
+    ret ok[ctxm.SemaDeps, str](deps);
+}
+
+# free_module_deps: release the entries array a `collect_module_deps` allocated.
+# the borrowed decl_type arrays it points into are owned by the session and are
+# NOT freed here.
+# ---
+# s:    the session (allocator)
+# deps: the SemaDeps to release (entries freed, fields zeroed)
+pub fun free_module_deps(s: *sess.Session, deps: *ctxm.SemaDeps) {
+    if (deps.entries != nil && deps.count > 0) {
+        deallocate[ctxm.ModuleSema](s.alloc, deps.entries, deps.count::usize);
+    }
+    deps.entries = nil;
+    deps.count   = 0;
+}
+
 # dnit_result: releases the parallel arrays held by the result and zeroes its fields; nil is a no-op.
 # ---
 # r: result to tear down; nil is a no-op

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -134,6 +134,52 @@ pub fun sema(
     ret build_result(?sc);
 }
 
+# reinfer_pack_each_body: re-type a `$each a in va` pack-unroll body for ONE
+# concrete element at monomorphization (#1475). a pack element's type is fixed
+# only at the call site, so the body cannot be typed at the original sema pass;
+# the monomorphizer binds the loop variable in the comptime context to the
+# element's CT_KIND_PACK_ELEM descriptor (so `infer_ident` types `a` to the
+# element type) and calls this to write the body expressions' types into the
+# origin module's shared `expr_type` array — exactly the array lowering then
+# reads. distinct elements / instances are typed in turn (the array is overwritten
+# per element; lowering interleaves typing and emission), so one shared array
+# suffices. the transient context reuses the origin SemaResult's arrays in place
+# rather than allocating, so it must not be torn down.
+# ---
+# s, a, rr, deps, ctx, own_module: the origin module's phase inputs (the module
+#   declaring the pack-tailed template)
+# sema_result: the origin module's SemaResult, whose arrays this reuses in place
+# fn_ret:      the instance's semantic return type (checks any body `ret`)
+# body_start / body_len: the `$each` body statement slice
+# ret:         true once the body is typed, or the first inference error
+pub fun reinfer_pack_each_body(
+    s:           *sess.Session,
+    a:           *ast.Ast,
+    rr:          *resolve.ResolveResult,
+    deps:        *ctxm.SemaDeps,
+    ctx:         *comptime.ComptimeCtx,
+    own_module:  sess.ModuleId,
+    sema_result: *ctxm.SemaResult,
+    fn_ret:      type.TypeId,
+    body_start:  u32,
+    body_len:    u32
+) Result[bool, str] {
+    var sc: ctxm.SemaContext;
+    sc.s          = s;
+    sc.a          = a;
+    sc.rr         = rr;
+    sc.deps       = deps;
+    sc.ctx        = ctx;
+    sc.own_module = own_module;
+    sc.source     = source_text_of(s, a);
+    sc.expr_type        = sema_result.expr_type;
+    sc.type_resolved_ty = sema_result.type_resolved_ty;
+    sc.decl_type        = sema_result.decl_type;
+    sc.callee_eid       = id.EXPR_NIL;
+    sc.in_comptime_gate = false;
+    ret infer_stmt_list(?sc, body_start, body_len, fn_ret);
+}
+
 # dnit_result: releases the parallel arrays held by the result and zeroes its fields; nil is a no-op.
 # ---
 # r: result to tear down; nil is a no-op

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -345,6 +345,13 @@ fun infer_ident(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
     if (is_none[*resolve.Symbol](sym_opt)) { ret type.TYPE_ERROR; }
     val sym: *resolve.Symbol = unwrap[*resolve.Symbol](sym_opt);
 
+    # a `$each a in va` pack loop variable (#1475): a comptime-flagged `SYM_VAL`
+    # with no declaration, bound during monomorphization to a pack-element
+    # descriptor carrying the element's concrete type. its value-position type is
+    # that element type (the body is re-inferred per element at instantiation).
+    val pe: type.TypeId = pack_elem_loop_var_type(sc, sym);
+    if (pe != type.TYPE_NIL) { ret pe; }
+
     # a symbol that names a module or a type (module alias, record, union,
     # def alias, generic parameter, primitive) resolves cleanly but can never
     # be a value; report it loudly — a silent poison here lets a clean sema
@@ -361,6 +368,24 @@ fun infer_ident(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
     }
 
     ret sema.decl_type_for(sc, sym);
+}
+
+# pack_elem_loop_var_type: the concrete element type of a `$each a in va` pack
+# loop variable (#1475), or TYPE_NIL when `sym` is not such a variable. the loop
+# variable is a comptime-flagged `SYM_VAL` with no declaration (DECL_NIL); during
+# monomorphization the unroller binds its name in the comptime context to a
+# CT_KIND_PACK_ELEM descriptor whose `.ty` carries the element's concrete sema
+# type. consulted before the general symbol-type path so the body re-infers `a`
+# to the right element type per iteration.
+fun pack_elem_loop_var_type(sc: *sema.SemaContext, sym: *resolve.Symbol) type.TypeId {
+    if (sym.kind != resolve.SYM_VAL) { ret type.TYPE_NIL; }
+    if ((sym.flags & resolve.SYM_FLAG_COMPTIME) == 0) { ret type.TYPE_NIL; }
+    if (sym.decl != id.DECL_NIL) { ret type.TYPE_NIL; }
+    val nc: Option[*comptime.NamedConst] = comptime.lookup(sc.ctx, sym.name);
+    if (is_none[*comptime.NamedConst](nc)) { ret type.TYPE_NIL; }
+    val cv: comptime.CTValue = unwrap[*comptime.NamedConst](nc).value;
+    if (cv.kind != comptime.CT_KIND_PACK_ELEM) { ret type.TYPE_NIL; }
+    ret cv.data.pelem.ty::type.TypeId;
 }
 
 # reports whether `sym` names a function declaring at least one comptime value

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -147,6 +147,17 @@ pub fun lower_module(
         ret err[ir.Module, str](unwrap_err[bool, str](vdrain_r));
     }
 
+    # emit one concrete body per comptime variadic-pack instance collected at this
+    # module's call sites, draining to fixpoint. a pack body may call generics, other
+    # comptime-param functions, or further pack-tailed functions, so this re-drains
+    # all three worklists until none remains.
+    val pdrain_r: Result[bool, str] = drain_pack_instances(?lc, s, a, sema_result, rr);
+    if (is_err[bool, str](pdrain_r)) {
+        lctx.dnit_context(?lc);
+        ir.dnit_module(?m);
+        ret err[ir.Module, str](unwrap_err[bool, str](pdrain_r));
+    }
+
     lctx.dnit_context(?lc);
     ret ok[ir.Module, str](m);
 }
@@ -172,11 +183,11 @@ fun drain_value_instances(lc: *lctx.LowerContext, s: *sess.Session,
     # alternate value-instance and type-instance draining to fixpoint: a value
     # body may queue type instances (a generic call), and a type body may queue
     # value instances (a comptime-param call), so loop until both worklists are
-    # fully consumed. each worklist resumes from its own cursor, so every body —
-    # value or generic — is emitted exactly once.
-    var processed: u32 = 0;
-    for (processed < lc.vinst_len || lc.inst_drained < lc.inst_len) {
-        for (processed < lc.vinst_len) {
+    # fully consumed. each worklist resumes from its own PERSISTENT cursor (so this
+    # drain is re-entrant — the pack drain re-invokes it — and emits every body once.
+    for (lc.vinst_drained < lc.vinst_len || lc.inst_drained < lc.inst_len) {
+        for (lc.vinst_drained < lc.vinst_len) {
+            val processed: u32 = lc.vinst_drained;
             # snapshot the entry by value: the worklist array may grow (reallocate)
             # while this instance's body enqueues transitive instances.
             val decl_id: aid.DeclId    = lc.vinsts[processed].decl;
@@ -197,7 +208,7 @@ fun drain_value_instances(lc: *lctx.LowerContext, s: *sess.Session,
                 ret r;
             }
 
-            processed = processed + 1;
+            lc.vinst_drained = lc.vinst_drained + 1;
         }
 
         # drain any type instances queued by the value bodies just emitted; the
@@ -288,6 +299,114 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
     lc.ctx        = home_ctx;
     lc.own_module = home_own;
     if (is_err[bool, str](cr)) { ret err[bool, str](unwrap_err[bool, str](cr)); }
+    ret lr;
+}
+
+# drains the comptime variadic-pack instance worklist to fixpoint, emitting one
+# weak body per collected `(decl, origin, type-list)` instance. each body is
+# lowered against its DECLARING module's AST / typing / name-resolution, with the
+# pack expanded to the instance's concrete element parameters; the `$each a in va`
+# unroll inside it re-types and lowers per element (lower_pack_instance). a pack
+# body may queue type instances (a generic call), value instances (a comptime-param
+# call), or further pack instances, so the type and value worklists are re-drained
+# in turn and the loop repeats until all three are empty. each worklist resumes
+# from its persistent cursor, so every body is emitted exactly once. the context's
+# phase inputs are restored after the drain.
+# ---
+# lc:        the active lowering context (its pack worklist is drained)
+# s:         shared session (origin-module registries)
+# home_a:    the current module's AST (restored after the drain)
+# home_sema: the current module's typing (restored after the drain)
+# home_rr:   the current module's name resolution (restored after the drain)
+# ret:       true once all three worklists are empty, or the first lowering error
+fun drain_pack_instances(lc: *lctx.LowerContext, s: *sess.Session,
+                         home_a: *ast.Ast, home_sema: *sema.SemaResult,
+                         home_rr: *resolve.ResolveResult) Result[bool, str] {
+    for (lc.pinst_drained < lc.pinst_len || lc.inst_drained < lc.inst_len || lc.vinst_drained < lc.vinst_len) {
+        for (lc.pinst_drained < lc.pinst_len) {
+            val processed: u32 = lc.pinst_drained;
+            # snapshot the entry by value: the worklist array may grow (reallocate)
+            # while this instance's body enqueues transitive instances.
+            val decl_id:  aid.DeclId    = lc.pinsts[processed].decl;
+            val origin:   sess.ModuleId = lc.pinsts[processed].origin;
+            val type_len: u32           = lc.pinsts[processed].type_len;
+            val name:     intern.StrId  = lc.pinsts[processed].name;
+            val types:    *ty.TypeId    = lc.pinsts[processed].types;
+
+            val r: Result[bool, str] = emit_one_pack_instance(lc, s, decl_id, origin, types, type_len, name);
+            if (is_err[bool, str](r)) {
+                lc.a           = home_a;
+                lc.sema_result = home_sema;
+                lc.rr          = home_rr;
+                lc.fqn         = sess.module_fqn(s, lc.own_module);
+                lc.subst       = nil;
+                lc.subst_len   = 0;
+                ret r;
+            }
+
+            lc.pinst_drained = lc.pinst_drained + 1;
+        }
+
+        # drain any type / value instances the pack bodies just emitted queued; both
+        # resume from their persistent cursors, so each body is emitted once.
+        val td: Result[bool, str] = drain_instances(lc, s, home_a, home_sema, home_rr);
+        if (is_err[bool, str](td)) { ret td; }
+        val vd: Result[bool, str] = drain_value_instances(lc, s, home_a, home_sema, home_rr);
+        if (is_err[bool, str](vd)) { ret vd; }
+    }
+
+    lc.a           = home_a;
+    lc.sema_result = home_sema;
+    lc.rr          = home_rr;
+    lc.fqn         = sess.module_fqn(s, lc.own_module);
+    lc.subst       = nil;
+    lc.subst_len   = 0;
+    ret ok[bool, str](true);
+}
+
+# emits one pack-instance body: binds the context to the instance's origin module
+# (AST, typing, name-resolution, FQN, comptime context, own_module), installs the
+# comptime resolvers, and lowers the pack-tailed template under the instance name
+# with its concrete element type-list. mirrors emit_one_value_instance but without
+# a comptime parameter frame — the per-element loop-variable binding is opened and
+# closed inside the `$each` unroll (lower_pack_each). a missing origin registry is
+# a coherence violation (the caller already emitted an extern reference to this
+# instance), so it aborts rather than silently dropping the body.
+fun emit_one_pack_instance(lc: *lctx.LowerContext, s: *sess.Session,
+                           decl_id: aid.DeclId, origin: sess.ModuleId,
+                           types: *ty.TypeId, type_len: u32, name: intern.StrId) Result[bool, str] {
+    val oa: *ast.Ast = sess.module_ast(s, origin);
+    if (oa == nil) { ret err[bool, str]("lower: pack-instance origin AST not registered"); }
+    val osema: *sema.SemaResult = (sess.module_sema_ptr(s, origin))::*sema.SemaResult;
+    if (osema == nil) { ret err[bool, str]("lower: pack-instance origin typing not registered"); }
+    val orr: *resolve.ResolveResult = (sess.module_resolve_ptr(s, origin))::*resolve.ResolveResult;
+    if (orr == nil) { ret err[bool, str]("lower: pack-instance origin name-resolution not registered"); }
+    val octx: *comptime.ComptimeCtx = (sess.module_comptime_ptr(s, origin))::*comptime.ComptimeCtx;
+    if (octx == nil) { ret err[bool, str]("lower: pack-instance origin comptime context not registered"); }
+
+    val d_opt: Option[*adecl.Decl] = ast.get_decl(oa, decl_id);
+    if (is_none[*adecl.Decl](d_opt)) { ret err[bool, str]("lower: pack-instance origin declaration not found"); }
+    val d: *adecl.Decl = unwrap[*adecl.Decl](d_opt);
+    if (d.kind != adecl.DECL_KIND_FUN) { ret err[bool, str]("lower: pack-instance origin declaration is not a function"); }
+
+    val home_ctx: *comptime.ComptimeCtx = lc.ctx;
+    val home_own: sess.ModuleId         = lc.own_module;
+    lc.a           = oa;
+    lc.sema_result = osema;
+    lc.rr          = orr;
+    lc.fqn         = sess.module_fqn(s, origin);
+    lc.ctx         = octx;
+    lc.own_module  = origin;
+    lc.subst       = nil;
+    lc.subst_len   = 0;
+
+    comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
+    comptime.set_type_resolver(octx, lctx.resolve_type_comparison_operand::*u8, lc::ptr);
+    comptime.set_field_resolver(octx, lctx.resolve_field_member::*u8, lc::ptr);
+
+    val lr: Result[bool, str] = decl.lower_pack_instance(lc, decl_id, d, name, types, type_len);
+    lc.ctx        = home_ctx;
+    lc.own_module = home_own;
     ret lr;
 }
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -120,6 +120,26 @@ pub rec ValueInstance {
     name:    intern.StrId;
 }
 
+# one collected comptime variadic-pack instance awaiting body emission: a
+# `(decl, origin, pack element type-list)` triple plus the mangled symbol name
+# the instance is emitted under. mirrors `Instance` but keys on the concrete
+# TYPES the pack absorbs at a call site (#1475), so a pack-tailed function is
+# monomorphized once per distinct trailing arg-type sequence. the worklist
+# dedups by `name`.
+# ---
+# decl:     DeclId of the pack-tailed function in `origin`'s AST
+# origin:   ModuleId that declares the function
+# types:    owned copy of the pack element type-list (by pack ordinal)
+# type_len: number of pack element types
+# name:     instance linkage name (mangled, with the type-list suffix)
+pub rec PackInstance {
+    decl:     aid.DeclId;
+    origin:   sess.ModuleId;
+    types:    *ty.TypeId;
+    type_len: u32;
+    name:     intern.StrId;
+}
+
 # per-module lowering state, threaded through every decl / stmt / expr.
 # the leading fields are the phase inputs and the IR being built; the
 # trailing fields are the working state for the function currently being
@@ -167,6 +187,12 @@ pub rec ValueInstance {
 #              active so the comptime evaluator selects each `$if` arm
 # vinst_len:   number of value-instance worklist entries
 # vinst_cap:   allocated capacity of the value-instance worklist
+# pinsts:      per-module worklist of comptime variadic-pack instances collected at
+#              call sites, drained to fixpoint alongside the type / value worklists;
+#              each emits one concrete weak body with the pack expanded to N params
+#              typed by the instance's element type-list
+# pinst_len:   number of pack-instance worklist entries
+# pinst_cap:   allocated capacity of the pack-instance worklist
 pub rec LowerContext {
     s:           *sess.Session;
     tgt:         *target.Target;
@@ -203,6 +229,10 @@ pub rec LowerContext {
     vinsts:      *ValueInstance;
     vinst_len:   u32;
     vinst_cap:   u32;
+
+    pinsts:      *PackInstance;
+    pinst_len:   u32;
+    pinst_cap:   u32;
 }
 
 
@@ -291,6 +321,9 @@ pub fun init_context(
     lc.vinsts    = nil;
     lc.vinst_len = 0;
     lc.vinst_cap = 0;
+    lc.pinsts    = nil;
+    lc.pinst_len = 0;
+    lc.pinst_cap = 0;
 
     ret ok[bool, str](true);
 }
@@ -338,6 +371,16 @@ pub fun dnit_context(lc: *LowerContext) {
         }
         deallocate[ValueInstance](lc.s.alloc, lc.vinsts, lc.vinst_cap::usize);
     }
+    if (lc.pinsts != nil && lc.pinst_cap > 0) {
+        var pi: u32 = 0;
+        for (pi < lc.pinst_len) {
+            if (lc.pinsts[pi].types != nil && lc.pinsts[pi].type_len > 0) {
+                deallocate[ty.TypeId](lc.s.alloc, lc.pinsts[pi].types, lc.pinsts[pi].type_len::usize);
+            }
+            pi = pi + 1;
+        }
+        deallocate[PackInstance](lc.s.alloc, lc.pinsts, lc.pinst_cap::usize);
+    }
     lc.loops    = nil;
     lc.loop_len = 0;
     lc.loop_cap = 0;
@@ -351,6 +394,9 @@ pub fun dnit_context(lc: *LowerContext) {
     lc.vinsts    = nil;
     lc.vinst_len = 0;
     lc.vinst_cap = 0;
+    lc.pinsts    = nil;
+    lc.pinst_len = 0;
+    lc.pinst_cap = 0;
 }
 
 # resolve_module_member_const: the `alias.CONST` member resolver lowering
@@ -692,6 +738,62 @@ pub fun enqueue_value_instance(lc: *LowerContext, decl: aid.DeclId, origin: sess
     inst.name    = name;
     lc.vinsts[lc.vinst_len] = inst;
     lc.vinst_len = lc.vinst_len + 1;
+    ret ok[bool, str](true);
+}
+
+# enqueue_pack_instance: record a comptime variadic-pack instance `(decl, origin,
+# type-list)` on the per-module worklist under its mangled `name`, deduped by name
+# (identical to `enqueue_instance` — a linear scan, no map/hash, so determinism is
+# preserved). takes an OWNED copy of `types` so the caller's buffer can be reused /
+# freed; the copy is released when the context is torn down.
+# ---
+# lc:       the context
+# decl:     DeclId of the pack-tailed function in `origin`'s AST
+# origin:   ModuleId declaring the function
+# types:    pack element type-list (copied), by pack ordinal
+# type_len: number of pack element types
+# name:     instance linkage name
+# ret:      true on success, or an allocation error
+pub fun enqueue_pack_instance(lc: *LowerContext, decl: aid.DeclId, origin: sess.ModuleId,
+                              types: *ty.TypeId, type_len: u32, name: intern.StrId) Result[bool, str] {
+    var i: u32 = 0;
+    for (i < lc.pinst_len) {
+        if (lc.pinsts[i].name == name) { ret ok[bool, str](true); }
+        i = i + 1;
+    }
+
+    if (lc.pinst_len == lc.pinst_cap) {
+        var new_cap: u32 = lc.pinst_cap * 2;
+        if (new_cap == 0) { new_cap = INITIAL_STACK_CAP; }
+        if (lc.pinsts == nil) {
+            val r: Result[*PackInstance, str] = allocate[PackInstance](lc.s.alloc, new_cap::usize);
+            if (is_err[*PackInstance, str](r)) { ret err[bool, str](unwrap_err[*PackInstance, str](r)); }
+            lc.pinsts = unwrap_ok[*PackInstance, str](r);
+        } or {
+            val r: Result[*PackInstance, str] = reallocate[PackInstance](lc.s.alloc, lc.pinsts, lc.pinst_cap::usize, new_cap::usize);
+            if (is_err[*PackInstance, str](r)) { ret err[bool, str](unwrap_err[*PackInstance, str](r)); }
+            lc.pinsts = unwrap_ok[*PackInstance, str](r);
+        }
+        lc.pinst_cap = new_cap;
+    }
+
+    var copy: *ty.TypeId = nil;
+    if (type_len > 0) {
+        val r: Result[*ty.TypeId, str] = allocate[ty.TypeId](lc.s.alloc, type_len::usize);
+        if (is_err[*ty.TypeId, str](r)) { ret err[bool, str](unwrap_err[*ty.TypeId, str](r)); }
+        copy = unwrap_ok[*ty.TypeId, str](r);
+        var j: u32 = 0;
+        for (j < type_len) { copy[j] = types[j]; j = j + 1; }
+    }
+
+    var inst: PackInstance;
+    inst.decl     = decl;
+    inst.origin   = origin;
+    inst.types    = copy;
+    inst.type_len = type_len;
+    inst.name     = name;
+    lc.pinsts[lc.pinst_len] = inst;
+    lc.pinst_len = lc.pinst_len + 1;
     ret ok[bool, str](true);
 }
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -204,12 +204,6 @@ pub rec PackInstance {
 # pack_len:    number of expanded pack parameters (0 outside a pack instance)
 # pack_ret_ty: the pack instance's semantic return type, supplied to the per-
 #              element body re-inference so a body `ret` checks against it
-# pack_each_name:  interned name of the loop variable of the pack `$each` currently
-#              unrolling, or STR_NIL outside one; an IDENT resolving to the
-#              (synthetic, decl-nil) loop-var symbol of this name is lowered from
-#              `pack_slots[pack_each_index]` rather than a normal local lookup
-# pack_each_index: the current element ordinal of the unrolling pack `$each`,
-#              selecting the loop variable's slot in pack_slots
 pub rec LowerContext {
     s:           *sess.Session;
     tgt:         *target.Target;
@@ -258,9 +252,6 @@ pub rec LowerContext {
     pack_types:  *ty.TypeId;
     pack_len:    u32;
     pack_ret_ty: ty.TypeId;
-
-    pack_each_name:  intern.StrId;
-    pack_each_index: u32;
 }
 
 
@@ -358,8 +349,6 @@ pub fun init_context(
     lc.pack_types  = nil;
     lc.pack_len    = 0;
     lc.pack_ret_ty = ty.TYPE_NIL;
-    lc.pack_each_name  = intern.STR_NIL;
-    lc.pack_each_index = 0;
 
     ret ok[bool, str](true);
 }
@@ -439,8 +428,6 @@ pub fun dnit_context(lc: *LowerContext) {
     lc.pack_types  = nil;
     lc.pack_len    = 0;
     lc.pack_ret_ty = ty.TYPE_NIL;
-    lc.pack_each_name  = intern.STR_NIL;
-    lc.pack_each_index = 0;
 }
 
 # resolve_module_member_const: the `alias.CONST` member resolver lowering
@@ -561,8 +548,6 @@ pub fun begin_function(lc: *LowerContext, fn_index: u32, ret_ty: ir_type.IrTypeI
     lc.pack_types  = nil;
     lc.pack_len    = 0;
     lc.pack_ret_ty = ty.TYPE_NIL;
-    lc.pack_each_name  = intern.STR_NIL;
-    lc.pack_each_index = 0;
 }
 
 # binds a source SymbolId to the IR Value that names its storage. for
@@ -619,26 +604,6 @@ pub fun lookup_local(lc: *LowerContext, sym: resolve.SymbolId) Option[value.Valu
         ret some[value.Value](@unwrap_ok[*value.Value, str](r));
     }
     ret none[value.Value]();
-}
-
-# pack_each_storage: the storage slot bound to the loop variable of the pack
-# `$each` currently unrolling, when `sym` names that loop variable. the loop var
-# is the synthetic (decl-nil) symbol whose interned name matches the active
-# pack-each name; its per-element storage is the expanded pack-parameter alloca
-# slot at the current unroll index. none outside a pack `$each`, or for any other
-# symbol — so an ordinary IDENT falls through to the normal local / global path.
-# ---
-# lc:  the context
-# sym: the IDENT's resolved SymbolId
-# ret: some(slot Value) when sym is the active pack loop variable, else none
-pub fun pack_each_storage(lc: *LowerContext, sym: resolve.SymbolId) Option[value.Value] {
-    if (lc.pack_each_name == intern.STR_NIL) { ret none[value.Value](); }
-    val so: Option[*resolve.Symbol] = symbol_of(lc, sym);
-    if (is_none[*resolve.Symbol](so)) { ret none[value.Value](); }
-    val s: *resolve.Symbol = unwrap[*resolve.Symbol](so);
-    if (s.decl != aid.DECL_NIL || s.name != lc.pack_each_name) { ret none[value.Value](); }
-    if (lc.pack_slots == nil || lc.pack_each_index >= lc.pack_len) { ret none[value.Value](); }
-    ret some[value.Value](lc.pack_slots[lc.pack_each_index]);
 }
 
 # pushes a loop frame, recording the header and exit blocks the innermost

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -193,6 +193,23 @@ pub rec PackInstance {
 #              typed by the instance's element type-list
 # pinst_len:   number of pack-instance worklist entries
 # pinst_cap:   allocated capacity of the pack-instance worklist
+# inst_drained / vinst_drained / pinst_drained: persistent cursors into the three
+#              worklists; entries below each are already emitted, so the unified
+#              drain emits every instance body exactly once even as the worklists
+#              grow re-entrantly (a body of one kind enqueuing instances of another)
+# pack_slots:  while lowering a pack instance body, the N expanded pack-parameter
+#              alloca slots (by pack ordinal); nil outside a pack instance
+# pack_types:  the N concrete pack element semantic types (by pack ordinal),
+#              parallel to pack_slots; nil outside a pack instance
+# pack_len:    number of expanded pack parameters (0 outside a pack instance)
+# pack_ret_ty: the pack instance's semantic return type, supplied to the per-
+#              element body re-inference so a body `ret` checks against it
+# pack_each_name:  interned name of the loop variable of the pack `$each` currently
+#              unrolling, or STR_NIL outside one; an IDENT resolving to the
+#              (synthetic, decl-nil) loop-var symbol of this name is lowered from
+#              `pack_slots[pack_each_index]` rather than a normal local lookup
+# pack_each_index: the current element ordinal of the unrolling pack `$each`,
+#              selecting the loop variable's slot in pack_slots
 pub rec LowerContext {
     s:           *sess.Session;
     tgt:         *target.Target;
@@ -233,6 +250,17 @@ pub rec LowerContext {
     pinsts:      *PackInstance;
     pinst_len:   u32;
     pinst_cap:   u32;
+
+    vinst_drained: u32;
+    pinst_drained: u32;
+
+    pack_slots:  *value.Value;
+    pack_types:  *ty.TypeId;
+    pack_len:    u32;
+    pack_ret_ty: ty.TypeId;
+
+    pack_each_name:  intern.StrId;
+    pack_each_index: u32;
 }
 
 
@@ -324,6 +352,14 @@ pub fun init_context(
     lc.pinsts    = nil;
     lc.pinst_len = 0;
     lc.pinst_cap = 0;
+    lc.vinst_drained  = 0;
+    lc.pinst_drained  = 0;
+    lc.pack_slots  = nil;
+    lc.pack_types  = nil;
+    lc.pack_len    = 0;
+    lc.pack_ret_ty = ty.TYPE_NIL;
+    lc.pack_each_name  = intern.STR_NIL;
+    lc.pack_each_index = 0;
 
     ret ok[bool, str](true);
 }
@@ -397,6 +433,14 @@ pub fun dnit_context(lc: *LowerContext) {
     lc.pinsts    = nil;
     lc.pinst_len = 0;
     lc.pinst_cap = 0;
+    lc.vinst_drained = 0;
+    lc.pinst_drained = 0;
+    lc.pack_slots  = nil;
+    lc.pack_types  = nil;
+    lc.pack_len    = 0;
+    lc.pack_ret_ty = ty.TYPE_NIL;
+    lc.pack_each_name  = intern.STR_NIL;
+    lc.pack_each_index = 0;
 }
 
 # resolve_module_member_const: the `alias.CONST` member resolver lowering
@@ -511,6 +555,14 @@ pub fun begin_function(lc: *LowerContext, fn_index: u32, ret_ty: ir_type.IrTypeI
     lc.fin_len  = 0;
     lc.fn_index = fn_index;
     lc.ret_ty   = ret_ty;
+    # pack-instance body state defaults off; lower_pack_instance sets it after this
+    # reset, and an ordinary function (or a generic / value instance) never reads it.
+    lc.pack_slots  = nil;
+    lc.pack_types  = nil;
+    lc.pack_len    = 0;
+    lc.pack_ret_ty = ty.TYPE_NIL;
+    lc.pack_each_name  = intern.STR_NIL;
+    lc.pack_each_index = 0;
 }
 
 # binds a source SymbolId to the IR Value that names its storage. for
@@ -567,6 +619,26 @@ pub fun lookup_local(lc: *LowerContext, sym: resolve.SymbolId) Option[value.Valu
         ret some[value.Value](@unwrap_ok[*value.Value, str](r));
     }
     ret none[value.Value]();
+}
+
+# pack_each_storage: the storage slot bound to the loop variable of the pack
+# `$each` currently unrolling, when `sym` names that loop variable. the loop var
+# is the synthetic (decl-nil) symbol whose interned name matches the active
+# pack-each name; its per-element storage is the expanded pack-parameter alloca
+# slot at the current unroll index. none outside a pack `$each`, or for any other
+# symbol — so an ordinary IDENT falls through to the normal local / global path.
+# ---
+# lc:  the context
+# sym: the IDENT's resolved SymbolId
+# ret: some(slot Value) when sym is the active pack loop variable, else none
+pub fun pack_each_storage(lc: *LowerContext, sym: resolve.SymbolId) Option[value.Value] {
+    if (lc.pack_each_name == intern.STR_NIL) { ret none[value.Value](); }
+    val so: Option[*resolve.Symbol] = symbol_of(lc, sym);
+    if (is_none[*resolve.Symbol](so)) { ret none[value.Value](); }
+    val s: *resolve.Symbol = unwrap[*resolve.Symbol](so);
+    if (s.decl != aid.DECL_NIL || s.name != lc.pack_each_name) { ret none[value.Value](); }
+    if (lc.pack_slots == nil || lc.pack_each_index >= lc.pack_len) { ret none[value.Value](); }
+    ret some[value.Value](lc.pack_slots[lc.pack_each_index]);
 }
 
 # pushes a loop frame, recording the header and exit blocks the innermost

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -116,6 +116,12 @@ pub fun lower_fun(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, is_
     # cannot fold without a bound value.
     if (fun_has_comptime_param(ctx, d)) { ret ok[bool, str](true); }
 
+    # a pack-tailed function (`va: ...`) is likewise a TEMPLATE: it is emitted once
+    # per distinct call-site pack type-list through the pack-instance worklist
+    # (lower_pack_instance), never as a standalone body here. emitting it directly
+    # would fail — its pack `$each` cannot unroll without a concrete element list.
+    if (fun_has_pack_param(ctx, d)) { ret ok[bool, str](true); }
+
     val sig_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, lower.decl_type_of(ctx, did));
     if (is_err[ir_type.IrTypeId, str](sig_r)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](sig_r)); }
     val sig: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](sig_r);
@@ -273,6 +279,23 @@ pub fun fun_has_comptime_param(ctx: *lower.LowerContext, d: *adecl.Decl) bool {
         i = i + 1;
     }
     ret false;
+}
+
+# reports whether a function declaration ends in a comptime variadic-pack parameter
+# (`va: ...`, #1475), read from its own AST typed_names. a pack-tailed function is a
+# TEMPLATE — monomorphized once per distinct call-site pack type-list — so it is
+# never emitted as a standalone body. the pack may only be the trailing parameter,
+# so only the last param's resolved type is consulted.
+pub fun fun_has_pack_param(ctx: *lower.LowerContext, d: *adecl.Decl) bool {
+    val n: u32 = d.data.fun_.params_len;
+    if (n == 0) { ret false; }
+    val pool_ix: u32 = d.data.fun_.params_start + (n - 1);
+    if (pool_ix::usize >= ctx.a.typed_name_len) { ret false; }
+    val tn: *adecl.TypedName = ?ctx.a.typed_names[pool_ix];
+    val pt: ty.TypeId = lower.type_resolved_of(ctx, tn.ty);
+    val to: Option[*ty.Type] = ty.get(?ctx.s.types, pt);
+    if (is_none[*ty.Type](to)) { ret false; }
+    ret unwrap[*ty.Type](to).kind == ty.TYPE_PACK;
 }
 
 # reports a duplicate test label, naming the label text when lookup succeeds.

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -269,6 +269,242 @@ pub fun lower_value_instance(ctx: *lower.LowerContext, did: aid.DeclId, d: *adec
     ret close_function(ctx, ret_ir);
 }
 
+# lowers one comptime variadic-pack instance: a concrete body for the pack-tailed
+# template `did` under the instance linkage `name`, with the trailing pack
+# parameter EXPANDED into `type_len` concrete parameters typed by the call site's
+# element type-list (`types`). the context must already be bound to the template's
+# origin module (AST / typing / name-resolution / comptime ctx). the lowered
+# signature is the leading fixed parameters followed by the N expanded element
+# parameters; the body's `$each a in va` unrolls over those N parameters, binding
+# the loop variable to each (lower_comptime_each). the emitted function is
+# PUB | WEAK so any using object binds to it and the linker collapses the copies.
+# a body-less template is not a valid instance and is skipped.
+# ---
+# ctx:      the context, already bound to the origin module
+# did:      DeclId of the pack-tailed template in the origin AST
+# d:        the resolved template Decl
+# name:     the instance's mangled linkage name
+# types:    the concrete pack element type-list (by pack ordinal)
+# type_len: number of pack element types (the expanded parameter count)
+# ret:      true on success, or an error
+pub fun lower_pack_instance(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl,
+                            name: intern.StrId, types: *ty.TypeId, type_len: u32) Result[bool, str] {
+    if (d.data.fun_.body == aid.STMT_NIL) { ret ok[bool, str](true); }
+
+    # leading fixed parameter count: every declared parameter except the trailing
+    # pack. the pack expands to `type_len` concrete parameters after them.
+    val fixed_count: u32 = d.data.fun_.params_len - 1;
+
+    val ret_ir_r: Result[ir_type.IrTypeId, str] = function_return_ir(ctx, did);
+    if (is_err[ir_type.IrTypeId, str](ret_ir_r)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](ret_ir_r)); }
+    val ret_ir: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](ret_ir_r);
+
+    val sig_r: Result[ir_type.IrTypeId, str] = pack_instance_sig(ctx, d, fixed_count, types, type_len, ret_ir);
+    if (is_err[ir_type.IrTypeId, str](sig_r)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](sig_r)); }
+    val sig: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](sig_r);
+
+    val flags: u32 = ir.FN_FLAG_PUB | ir.FN_FLAG_WEAK;
+    val idx_r: Result[u32, str] = append_function(ctx, name, sig, flags, fixed_count + type_len);
+    if (is_err[u32, str](idx_r)) { ret err[bool, str](unwrap_err[u32, str](idx_r)); }
+    val fn_index: u32 = unwrap_ok[u32, str](idx_r);
+
+    lower.begin_function(ctx, fn_index, ret_ir);
+
+    # publish the pack body state the `$each a in va` unroll reads: the N element
+    # types and the semantic return type now; the N alloca slots are filled by
+    # lower_pack_params below.
+    ctx.pack_types  = types;
+    ctx.pack_len    = type_len;
+    ctx.pack_ret_ty = pack_instance_ret_sem(ctx, did);
+
+    builder.set_function(?ctx.builder, ?ctx.m.functions[fn_index]);
+
+    val entry_r: Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
+    if (is_err[ir.BlockId, str](entry_r)) { ret err[bool, str](unwrap_err[ir.BlockId, str](entry_r)); }
+    builder.set_block(?ctx.builder, unwrap_ok[ir.BlockId, str](entry_r));
+
+    val params_r: Result[bool, str] = lower_pack_params(ctx, did, d, fn_index, fixed_count, types, type_len);
+    if (is_err[bool, str](params_r)) { clear_pack_state(ctx); ret params_r; }
+
+    val br: Result[bool, str] = stmt.lower_stmt(ctx, d.data.fun_.body);
+    if (is_err[bool, str](br)) { clear_pack_state(ctx); ret br; }
+
+    val cr: Result[bool, str] = close_function(ctx, ret_ir);
+    clear_pack_state(ctx);
+    ret cr;
+}
+
+# clear_pack_state: releases the pack instance body's expanded-parameter slot
+# buffer and clears the pack body state, so the next function lowered sees no
+# stale pack parameters. the element type-list (`pack_types`) is borrowed from the
+# worklist entry, so it is not freed here.
+fun clear_pack_state(ctx: *lower.LowerContext) {
+    if (ctx.pack_slots != nil && ctx.pack_len > 0) {
+        deallocate[value.Value](ctx.s.alloc, ctx.pack_slots, ctx.pack_len::usize);
+    }
+    ctx.pack_slots  = nil;
+    ctx.pack_types  = nil;
+    ctx.pack_len    = 0;
+    ctx.pack_ret_ty = ty.TYPE_NIL;
+}
+
+# pack_instance_sig: interns the IR function type of a pack instance — the leading
+# fixed parameter IR types followed by the N expanded element IR types, returning
+# `ret_ir`. the expanded elements take the place of the single TYPE_PACK parameter,
+# so the instance's ABI matches the collected call rather than the opaque pack.
+fun pack_instance_sig(ctx: *lower.LowerContext, d: *adecl.Decl, fixed_count: u32,
+                      types: *ty.TypeId, type_len: u32, ret_ir: ir_type.IrTypeId) Result[ir_type.IrTypeId, str] {
+    val total: u32 = fixed_count + type_len;
+    if (total == 0) {
+        ret ir_type.intern_fn(?ctx.m.types, ret_ir, nil, 0, false);
+    }
+
+    val buf_r: Result[*ir_type.IrTypeId, str] = allocate[ir_type.IrTypeId](ctx.s.alloc, total::usize);
+    if (is_err[*ir_type.IrTypeId, str](buf_r)) { ret err[ir_type.IrTypeId, str](unwrap_err[*ir_type.IrTypeId, str](buf_r)); }
+    val buf: *ir_type.IrTypeId = unwrap_ok[*ir_type.IrTypeId, str](buf_r);
+
+    var i: u32 = 0;
+    for (i < fixed_count) {
+        val pool_ix: u32 = d.data.fun_.params_start + i;
+        var p_sem: ty.TypeId = ty.TYPE_NIL;
+        if (pool_ix::usize < ctx.a.typed_name_len) {
+            p_sem = lower.type_resolved_of(ctx, ctx.a.typed_names[pool_ix].ty);
+        }
+        val pr: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, p_sem);
+        if (is_err[ir_type.IrTypeId, str](pr)) {
+            deallocate[ir_type.IrTypeId](ctx.s.alloc, buf, total::usize);
+            ret pr;
+        }
+        buf[i] = unwrap_ok[ir_type.IrTypeId, str](pr);
+        i = i + 1;
+    }
+
+    var j: u32 = 0;
+    for (j < type_len) {
+        val er: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, types[j]);
+        if (is_err[ir_type.IrTypeId, str](er)) {
+            deallocate[ir_type.IrTypeId](ctx.s.alloc, buf, total::usize);
+            ret er;
+        }
+        buf[fixed_count + j] = unwrap_ok[ir_type.IrTypeId, str](er);
+        j = j + 1;
+    }
+
+    val fr: Result[ir_type.IrTypeId, str] = ir_type.intern_fn(?ctx.m.types, ret_ir, buf, total, false);
+    deallocate[ir_type.IrTypeId](ctx.s.alloc, buf, total::usize);
+    ret fr;
+}
+
+# pack_instance_ret_sem: the semantic return type of a pack instance, recovered
+# from its template's TYPE_FUN signature; supplied to the per-element body
+# re-inference so a `ret` inside the `$each` body checks against it.
+fun pack_instance_ret_sem(ctx: *lower.LowerContext, did: aid.DeclId) ty.TypeId {
+    val sem: ty.TypeId = lower.decl_type_of(ctx, did);
+    val t_opt: Option[*ty.Type] = ty.get(?ctx.s.types, sem);
+    if (is_none[*ty.Type](t_opt)) { ret ty.TYPE_NIL; }
+    val t: *ty.Type = unwrap[*ty.Type](t_opt);
+    if (t.kind != ty.TYPE_FUN) { ret ty.TYPE_NIL; }
+    ret t.data.fn.ret_ty;
+}
+
+# lower_pack_params: materialises the pack instance's parameters. the leading fixed
+# parameters are spilled and bound to their symbols exactly like lower_params; the
+# N expanded element parameters are spilled into alloca slots recorded on
+# `ctx.pack_slots` (by pack ordinal) for the `$each a in va` unroll to load, and
+# are NOT bound to any source symbol (the pack itself names no runtime value). the
+# function's `params` / `param_count` cover the fixed plus expanded parameters.
+fun lower_pack_params(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, fn_index: u32,
+                      fixed_count: u32, types: *ty.TypeId, type_len: u32) Result[bool, str] {
+    val cr: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](cr)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](cr)); }
+    val xty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](cr);
+
+    val total: u32 = fixed_count + type_len;
+    var params: *value.Value = nil;
+    if (total > 0) {
+        val ar: Result[*value.Value, str] = allocate[value.Value](ctx.s.alloc, total::usize);
+        if (is_err[*value.Value, str](ar)) { ret err[bool, str](unwrap_err[*value.Value, str](ar)); }
+        params = unwrap_ok[*value.Value, str](ar);
+    }
+
+    var slots: *value.Value = nil;
+    if (type_len > 0) {
+        val sr: Result[*value.Value, str] = allocate[value.Value](ctx.s.alloc, type_len::usize);
+        if (is_err[*value.Value, str](sr)) {
+            if (params != nil) { deallocate[value.Value](ctx.s.alloc, params, total::usize); }
+            ret err[bool, str](unwrap_err[*value.Value, str](sr));
+        }
+        slots = unwrap_ok[*value.Value, str](sr);
+    }
+
+    var w: u32 = 0;
+    var i: u32 = 0;
+    for (i < fixed_count) {
+        val pool_ix: u32 = d.data.fun_.params_start + i;
+        var p_sem: ty.TypeId = ty.TYPE_NIL;
+        if (pool_ix::usize < ctx.a.typed_name_len) {
+            p_sem = lower.type_resolved_of(ctx, ctx.a.typed_names[pool_ix].ty);
+        }
+        val pr: Result[value.Value, str] = emit_pack_param(ctx, params, w, p_sem, xty);
+        if (is_err[value.Value, str](pr)) { free_pack_param_bufs(ctx, params, total, slots, type_len); ret err[bool, str](unwrap_err[value.Value, str](pr)); }
+        val slot: value.Value = unwrap_ok[value.Value, str](pr);
+
+        # a fixed parameter is read through its slot, like an ordinary parameter.
+        val sid: resolve.SymbolId = param_symbol(ctx, did, i);
+        if (sid != resolve.SYMBOL_NIL) {
+            val bind_r: Result[bool, str] = lower.bind_local(ctx, sid, slot);
+            if (is_err[bool, str](bind_r)) { free_pack_param_bufs(ctx, params, total, slots, type_len); ret bind_r; }
+        }
+        w = w + 1;
+        i = i + 1;
+    }
+
+    var j: u32 = 0;
+    for (j < type_len) {
+        val pr: Result[value.Value, str] = emit_pack_param(ctx, params, w, types[j], xty);
+        if (is_err[value.Value, str](pr)) { free_pack_param_bufs(ctx, params, total, slots, type_len); ret err[bool, str](unwrap_err[value.Value, str](pr)); }
+        # an expanded element is reached by ordinal: its slot is the storage the
+        # `$each a in va` unroll loads for the matching iteration.
+        slots[j] = unwrap_ok[value.Value, str](pr);
+        w = w + 1;
+        j = j + 1;
+    }
+
+    ctx.m.functions[fn_index].params      = params;
+    ctx.m.functions[fn_index].param_count = total;
+    ctx.pack_slots = slots;
+    ret ok[bool, str](true);
+}
+
+# emit_pack_param: materialise one parameter at ordinal `w` of the IR type lowered
+# from `p_sem` — a VAL_PARAM recorded in `params[w]`, spilled into a fresh alloca —
+# and returns the alloca slot pointer (a fixed parameter binds it to its symbol; an
+# expanded element keeps it by ordinal for the `$each` unroll).
+fun emit_pack_param(ctx: *lower.LowerContext, params: *value.Value, w: u32, p_sem: ty.TypeId, xty: ir_type.IrTypeId) Result[value.Value, str] {
+    val tr: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, p_sem);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](tr)); }
+    val p_ir: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+
+    val pval: value.Value = value.param_value(w, p_ir);
+
+    val slot_r: Result[value.Value, str] = builder.emit_alloca(?ctx.builder, p_ir, value.const_int(1, xty));
+    if (is_err[value.Value, str](slot_r)) { ret slot_r; }
+    val slot: value.Value = unwrap_ok[value.Value, str](slot_r);
+
+    val sr: Result[bool, str] = builder.emit_store(?ctx.builder, pval, slot);
+    if (is_err[bool, str](sr)) { ret err[value.Value, str](unwrap_err[bool, str](sr)); }
+
+    params[w] = pval;
+    ret ok[value.Value, str](slot);
+}
+
+# free_pack_param_bufs: releases the parameter / slot buffers on a lowering error
+# before they are handed to the function / context.
+fun free_pack_param_bufs(ctx: *lower.LowerContext, params: *value.Value, total: u32, slots: *value.Value, type_len: u32) {
+    if (params != nil && total > 0) { deallocate[value.Value](ctx.s.alloc, params, total::usize); }
+    if (slots != nil && type_len > 0) { deallocate[value.Value](ctx.s.alloc, slots, type_len::usize); }
+}
+
 # reports whether a function declaration declares any comptime value parameter,
 # read from its own AST typed_names.
 pub fun fun_has_comptime_param(ctx: *lower.LowerContext, d: *adecl.Decl) bool {

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -45,6 +45,7 @@ use ast:      mach.lang.fe.ast;
 use aid:      mach.lang.fe.ast.id;
 use aexpr:    mach.lang.fe.ast.expr;
 use adecl:    mach.lang.fe.ast.decl;
+use atype:    mach.lang.fe.ast.type;
 use resolve:  mach.lang.fe.resolve;
 use comptime: mach.lang.fe.comptime;
 use token:    mach.lang.fe.token;
@@ -295,6 +296,14 @@ fun lower_ident_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.V
         ret const_value_of(ctx, eid, unwrap[comptime.CTValue](cv));
     }
 
+    # a `$each a in va` pack loop variable (#1475): bound in the comptime context
+    # to a pack-element descriptor; its rvalue is a load from the matching expanded
+    # parameter slot recorded on the context by lower_pack_instance.
+    val pe: Option[u32] = pack_elem_ordinal(ctx, sid);
+    if (is_some[u32](pe)) {
+        ret load_pack_elem(ctx, eid, unwrap[u32](pe));
+    }
+
     val local: Option[value.Value] = lower.lookup_local(ctx, sid);
     if (is_some[value.Value](local)) {
         val slot: value.Value = unwrap[value.Value](local);
@@ -312,6 +321,40 @@ fun lower_ident_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.V
         ret builder.emit_load(?ctx.builder, slot, ity);
     }
     ret symbol_reference(ctx, eid, sid);
+}
+
+# pack_elem_ordinal: the expanded-parameter ordinal of a `$each a in va` pack loop
+# variable (#1475), or none when `sid` is not such a variable. the loop variable is
+# a comptime-flagged SYM_VAL with no declaration, bound by the unroll to a
+# CT_KIND_PACK_ELEM descriptor whose `.index` is the element's ordinal among the
+# instance's expanded pack parameters.
+fun pack_elem_ordinal(ctx: *lower.LowerContext, sid: resolve.SymbolId) Option[u32] {
+    val so: Option[*resolve.Symbol] = lower.symbol_of(ctx, sid);
+    if (is_none[*resolve.Symbol](so)) { ret none[u32](); }
+    val sym: *resolve.Symbol = unwrap[*resolve.Symbol](so);
+    if (sym.kind != resolve.SYM_VAL || (sym.flags & resolve.SYM_FLAG_COMPTIME) == 0) { ret none[u32](); }
+    if (sym.decl != aid.DECL_NIL) { ret none[u32](); }
+    val nc: Option[*comptime.NamedConst] = comptime.lookup(ctx.ctx, sym.name);
+    if (is_none[*comptime.NamedConst](nc)) { ret none[u32](); }
+    val cval: comptime.CTValue = unwrap[*comptime.NamedConst](nc).value;
+    if (cval.kind != comptime.CT_KIND_PACK_ELEM) { ret none[u32](); }
+    ret some[u32](cval.data.pelem.index);
+}
+
+# load_pack_elem: the rvalue of a pack element at ordinal `i` — a load from the
+# expanded parameter slot lower_pack_instance recorded on the context. an aggregate
+# element flows by its storage address tagged with the aggregate IR type, mirroring
+# an ordinary local rvalue.
+fun load_pack_elem(ctx: *lower.LowerContext, eid: aid.ExprId, i: u32) Result[value.Value, str] {
+    if (ctx.pack_slots == nil || i >= ctx.pack_len) {
+        ret err[value.Value, str]("lower: pack element ordinal out of range");
+    }
+    val slot: value.Value = ctx.pack_slots[i];
+    val tr: Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](tr)); }
+    val ity: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+    if (is_aggregate_ir(ctx, ity)) { ret ok[value.Value, str](value.retype(slot, ity)); }
+    ret builder.emit_load(?ctx.builder, slot, ity);
 }
 
 # the folded comptime value of a symbol, when it is a comptime value parameter
@@ -1161,6 +1204,11 @@ fun lower_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Resu
             }
             ret lower_value_callee(ctx, eid, e, f);
         }
+        # a pack-tailed callee (`va: ...`) resolves to a per-type-list monomorphized
+        # instance (#1475), keyed by the trailing arguments' concrete types.
+        if (decl_fun_has_pack_param(ctx, e.data.call.callee, f)) {
+            ret lower_pack_callee(ctx, eid, e, f);
+        }
     }
     if (e.data.call.type_args_len == 0) {
         ret lower_rvalue(ctx, e.data.call.callee);
@@ -1201,6 +1249,21 @@ fun decl_fun_has_comptime_param(ctx: *lower.LowerContext, callee: aid.ExprId, f:
         i = i + 1;
     }
     ret false;
+}
+
+# reports whether the callee's DeclFun ends in a comptime variadic-pack parameter
+# (`va: ...`, #1475), read syntactically from the callee's origin AST — the
+# trailing parameter's AstType is a TYPE_KIND_PACK. detected without sema (mirrors
+# the comptime-flag check) so it works for a cross-module callee whose resolved
+# types live in another module.
+fun decl_fun_has_pack_param(ctx: *lower.LowerContext, callee: aid.ExprId, f: *adecl.DeclFun) bool {
+    val a: *ast.Ast = callee_ast(ctx, callee);
+    if (a == nil) { ret false; }
+    if (f.params_len == 0) { ret false; }
+    val tn: *adecl.TypedName = ?a.typed_names[f.params_start + (f.params_len - 1)];
+    val t_opt: Option[*atype.Type] = ast.get_type(a, tn.ty);
+    if (is_none[*atype.Type](t_opt)) { ret false; }
+    ret unwrap[*atype.Type](t_opt).kind == atype.TYPE_KIND_PACK;
 }
 
 # the AST the callee is declared in: the caller's own AST for a local callee, the
@@ -1425,6 +1488,82 @@ fun lower_generic_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Ex
 
     val enq: Result[bool, str] = lower.enqueue_instance(ctx, sym.decl, sym.origin, args, argc, link);
     deallocate[ty.TypeId](ctx.s.alloc, args, argc::usize);
+    if (is_err[bool, str](enq)) { ret err[value.Value, str](unwrap_err[bool, str](enq)); }
+
+    val vtr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);
+    if (is_err[ir_type.IrTypeId, str](vtr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](vtr)); }
+    val vty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](vtr);
+
+    val fi: Option[u32] = find_function(ctx, link);
+    if (is_some[u32](fi)) {
+        ret ok[value.Value, str](value.fn_value(unwrap[u32](fi), vty));
+    }
+    val xr: Result[u32, str] = lower.ensure_extern_function(ctx, link, vty);
+    if (is_err[u32, str](xr)) { ret err[value.Value, str](unwrap_err[u32, str](xr)); }
+    ret ok[value.Value, str](value.fn_value(unwrap_ok[u32, str](xr), vty));
+}
+
+# resolves a pack-tailed call to its monomorphized instance (#1475): reads the
+# trailing arguments' concrete types — the collected pack element type-list,
+# substituting any enclosing generic substitution so a transitive pack call
+# resolves element types to the concrete args — computes the instance's mangled
+# linkage name under the disjoint `Q...E` pack namespace, enqueues the instance for
+# body emission, and returns a function reference to it. the leading fixed
+# arguments and the collected elements are all passed at runtime (the instance's
+# expanded signature), so no argument is dropped here; the back end emits a
+# name-based call the linker binds to the (weak, deduped) instance body.
+fun lower_pack_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr, f: *adecl.DeclFun) Result[value.Value, str] {
+    val sid: resolve.SymbolId = lower.expr_symbol_of(ctx, e.data.call.callee);
+    val so: Option[*resolve.Symbol] = lower.symbol_of(ctx, sid);
+    if (is_none[*resolve.Symbol](so)) {
+        ret err[value.Value, str]("lower: unresolved pack-tailed call target");
+    }
+    val sym: *resolve.Symbol = unwrap[*resolve.Symbol](so);
+
+    # the pack is the trailing parameter; every argument past the leading fixed
+    # parameters is a collected pack element.
+    val fixed_count: u32 = f.params_len - 1;
+    if (e.data.call.args_len < fixed_count) {
+        ret err[value.Value, str]("lower: pack-tailed call has fewer arguments than fixed parameters");
+    }
+    val elem_count: u32 = e.data.call.args_len - fixed_count;
+
+    var types: *ty.TypeId = nil;
+    if (elem_count > 0) {
+        val ab: Result[*ty.TypeId, str] = allocate[ty.TypeId](ctx.s.alloc, elem_count::usize);
+        if (is_err[*ty.TypeId, str](ab)) { ret err[value.Value, str](unwrap_err[*ty.TypeId, str](ab)); }
+        types = unwrap_ok[*ty.TypeId, str](ab);
+
+        var j: u32 = 0;
+        for (j < elem_count) {
+            val pool_ix: u32 = e.data.call.args_start + fixed_count + j;
+            if (pool_ix::usize >= ctx.a.expr_id_len) {
+                deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize);
+                ret err[value.Value, str]("lower: pack-tailed call argument index out of range");
+            }
+            val arg_eid: aid.ExprId = ctx.a.expr_ids[pool_ix];
+            var et: ty.TypeId = lower.expr_type_of(ctx, arg_eid);
+            if (ctx.subst != nil && ctx.subst_len > 0) {
+                et = generics.substitute(ctx.s, et, ctx.subst, ctx.subst_len);
+            }
+            types[j] = et;
+            j = j + 1;
+        }
+    }
+
+    # the instance is owned by the function's origin module; mangle against that
+    # module's FQN so the definition (emitted by the drain) and every reference
+    # agree byte-for-byte.
+    val fqn: intern.StrId = sess.module_fqn(ctx.s, sym.origin);
+    val name_r: Result[intern.StrId, str] = mangle.pack_instance_name(ctx.s, fqn, sym.name, types, elem_count);
+    if (is_err[intern.StrId, str](name_r)) {
+        if (types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
+        ret err[value.Value, str](unwrap_err[intern.StrId, str](name_r));
+    }
+    val link: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+    val enq: Result[bool, str] = lower.enqueue_pack_instance(ctx, sym.decl, sym.origin, types, elem_count, link);
+    if (types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
     if (is_err[bool, str](enq)) { ret err[value.Value, str](unwrap_err[bool, str](enq)); }
 
     val vtr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -357,6 +357,41 @@ fun load_pack_elem(ctx: *lower.LowerContext, eid: aid.ExprId, i: u32) Result[val
     ret builder.emit_load(?ctx.builder, slot, ity);
 }
 
+# is_spread_expr: true when `eid` is a `va...` pack spread expression (#1474/#1475).
+fun is_spread_expr(ctx: *lower.LowerContext, eid: aid.ExprId) bool {
+    val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
+    if (is_none[*aexpr.Expr](e_opt)) { ret false; }
+    ret unwrap[*aexpr.Expr](e_opt).kind == aexpr.EXPR_KIND_SPREAD;
+}
+
+# call_has_spread: true when call expression `e` has any `va...` spread argument.
+fun call_has_spread(ctx: *lower.LowerContext, e: *aexpr.Expr) bool {
+    var i: u32 = 0;
+    for (i < e.data.call.args_len) {
+        val pool_ix: u32 = e.data.call.args_start + i;
+        if (pool_ix::usize >= ctx.a.expr_id_len) { ret false; }
+        if (is_spread_expr(ctx, ctx.a.expr_ids[pool_ix])) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# load_pack_slot: rvalue of pack slot `k` — typed from `ctx.pack_types[k]` rather
+# than an expr's sema type. used when splicing the whole pack into a `va...` forward.
+# aggregates flow by storage address tagged with the aggregate IR type, mirroring
+# load_pack_elem.
+fun load_pack_slot(ctx: *lower.LowerContext, k: u32) Result[value.Value, str] {
+    if (ctx.pack_slots == nil || k >= ctx.pack_len) {
+        ret err[value.Value, str]("lower: pack slot index out of range");
+    }
+    val slot: value.Value = ctx.pack_slots[k];
+    val ir_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, ctx.pack_types[k]);
+    if (is_err[ir_type.IrTypeId, str](ir_r)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](ir_r)); }
+    val ity: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](ir_r);
+    if (is_aggregate_ir(ctx, ity)) { ret ok[value.Value, str](value.retype(slot, ity)); }
+    ret builder.emit_load(?ctx.builder, slot, ity);
+}
+
 # the folded comptime value of a symbol, when it is a comptime value parameter
 # (SYM_PARAM with SYM_FLAG_COMPTIME) currently bound in the comptime context by a
 # value-instance drain. none for any other symbol, or when not in a value-instance
@@ -1144,7 +1179,10 @@ fun lower_call(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result
 
     val argc: u32 = e.data.call.args_len;
     var rtc: u32 = argc;
+    val has_spread: bool = call_has_spread(ctx, e);
     if (has_ct) { rtc = runtime_arg_count(ctx, cf_ast, cf_decl, argc); }
+    # a va... spread replaces one spread arg with ctx.pack_len concrete slot args.
+    if (has_spread) { rtc = (argc - 1) + ctx.pack_len; }
 
     var args: *value.Value = nil;
     if (rtc > 0) {
@@ -1162,6 +1200,22 @@ fun lower_call(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result
                 ret err[value.Value, str]("lower: call argument index out of range");
             }
             val arg_eid: aid.ExprId = ctx.a.expr_ids[pool_ix];
+            # va... spread: splice the current pack's N concrete slots into the arg list.
+            if (has_spread && is_spread_expr(ctx, arg_eid)) {
+                var k: u32 = 0;
+                for (k < ctx.pack_len) {
+                    val sr: Result[value.Value, str] = load_pack_slot(ctx, k);
+                    if (is_err[value.Value, str](sr)) {
+                        deallocate[value.Value](ctx.s.alloc, args, rtc::usize);
+                        ret sr;
+                    }
+                    args[w] = unwrap_ok[value.Value, str](sr);
+                    w = w + 1;
+                    k = k + 1;
+                }
+                i = i + 1;
+                cnt;
+            }
             val vr: Result[value.Value, str] = lower_rvalue(ctx, arg_eid);
             if (is_err[value.Value, str](vr)) {
                 deallocate[value.Value](ctx.s.alloc, args, rtc::usize);
@@ -1528,15 +1582,14 @@ fun lower_generic_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Ex
     ret ok[value.Value, str](value.fn_value(unwrap_ok[u32, str](xr), vty));
 }
 
-# resolves a pack-tailed call to its monomorphized instance (#1475): reads the
-# trailing arguments' concrete types — the collected pack element type-list,
-# substituting any enclosing generic substitution so a transitive pack call
-# resolves element types to the concrete args — computes the instance's mangled
-# linkage name under the disjoint `Q...E` pack namespace, enqueues the instance for
-# body emission, and returns a function reference to it. the leading fixed
-# arguments and the collected elements are all passed at runtime (the instance's
-# expanded signature), so no argument is dropped here; the back end emits a
-# name-based call the linker binds to the (weak, deduped) instance body.
+# resolves a pack-tailed call to its monomorphized instance (#1475). two paths:
+#   - `va...` spread: the call is a forward of the current pack instance; the
+#     type-list is borrowed from ctx.pack_types (enqueue copies it).
+#   - collected: the type-list is gathered from the trailing call-site arguments,
+#     with any enclosing generic substitution applied.
+# in both cases the instance's mangled linkage name is computed under the disjoint
+# `Q...E` pack namespace, the instance is enqueued for body emission, and a
+# function reference to it is returned. all arguments are passed at runtime.
 fun lower_pack_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr, f: *adecl.DeclFun) Result[value.Value, str] {
     val sid: resolve.SymbolId = lower.expr_symbol_of(ctx, e.data.call.callee);
     val so: Option[*resolve.Symbol] = lower.symbol_of(ctx, sid);
@@ -1548,31 +1601,41 @@ fun lower_pack_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr,
     # the pack is the trailing parameter; every argument past the leading fixed
     # parameters is a collected pack element.
     val fixed_count: u32 = f.params_len - 1;
-    if (e.data.call.args_len < fixed_count) {
-        ret err[value.Value, str]("lower: pack-tailed call has fewer arguments than fixed parameters");
-    }
-    val elem_count: u32 = e.data.call.args_len - fixed_count;
-
+    var elem_count: u32 = 0;
     var types: *ty.TypeId = nil;
-    if (elem_count > 0) {
-        val ab: Result[*ty.TypeId, str] = allocate[ty.TypeId](ctx.s.alloc, elem_count::usize);
-        if (is_err[*ty.TypeId, str](ab)) { ret err[value.Value, str](unwrap_err[*ty.TypeId, str](ab)); }
-        types = unwrap_ok[*ty.TypeId, str](ab);
+    var owns_types: bool = false;
 
-        var j: u32 = 0;
-        for (j < elem_count) {
-            val pool_ix: u32 = e.data.call.args_start + fixed_count + j;
-            if (pool_ix::usize >= ctx.a.expr_id_len) {
-                deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize);
-                ret err[value.Value, str]("lower: pack-tailed call argument index out of range");
+    if (call_has_spread(ctx, e)) {
+        # va... forward: borrow the current instance's type-list directly; enqueue
+        # copies it, so we must not free it after enqueueing.
+        elem_count = ctx.pack_len;
+        types = ctx.pack_types;
+    } or {
+        if (e.data.call.args_len < fixed_count) {
+            ret err[value.Value, str]("lower: pack-tailed call has fewer arguments than fixed parameters");
+        }
+        elem_count = e.data.call.args_len - fixed_count;
+        if (elem_count > 0) {
+            val ab: Result[*ty.TypeId, str] = allocate[ty.TypeId](ctx.s.alloc, elem_count::usize);
+            if (is_err[*ty.TypeId, str](ab)) { ret err[value.Value, str](unwrap_err[*ty.TypeId, str](ab)); }
+            types = unwrap_ok[*ty.TypeId, str](ab);
+            owns_types = true;
+
+            var j: u32 = 0;
+            for (j < elem_count) {
+                val pool_ix: u32 = e.data.call.args_start + fixed_count + j;
+                if (pool_ix::usize >= ctx.a.expr_id_len) {
+                    deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize);
+                    ret err[value.Value, str]("lower: pack-tailed call argument index out of range");
+                }
+                val arg_eid: aid.ExprId = ctx.a.expr_ids[pool_ix];
+                var et: ty.TypeId = lower.expr_type_of(ctx, arg_eid);
+                if (ctx.subst != nil && ctx.subst_len > 0) {
+                    et = generics.substitute(ctx.s, et, ctx.subst, ctx.subst_len);
+                }
+                types[j] = et;
+                j = j + 1;
             }
-            val arg_eid: aid.ExprId = ctx.a.expr_ids[pool_ix];
-            var et: ty.TypeId = lower.expr_type_of(ctx, arg_eid);
-            if (ctx.subst != nil && ctx.subst_len > 0) {
-                et = generics.substitute(ctx.s, et, ctx.subst, ctx.subst_len);
-            }
-            types[j] = et;
-            j = j + 1;
         }
     }
 
@@ -1582,13 +1645,13 @@ fun lower_pack_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr,
     val fqn: intern.StrId = sess.module_fqn(ctx.s, sym.origin);
     val name_r: Result[intern.StrId, str] = mangle.pack_instance_name(ctx.s, fqn, sym.name, types, elem_count);
     if (is_err[intern.StrId, str](name_r)) {
-        if (types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
+        if (owns_types && types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
         ret err[value.Value, str](unwrap_err[intern.StrId, str](name_r));
     }
     val link: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
 
     val enq: Result[bool, str] = lower.enqueue_pack_instance(ctx, sym.decl, sym.origin, types, elem_count, link);
-    if (types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
+    if (owns_types && types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
     if (is_err[bool, str](enq)) { ret err[value.Value, str](unwrap_err[bool, str](enq)); }
 
     val vtr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -614,7 +614,32 @@ fun try_lower_field_member(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.
     ret some[Result[value.Value, str]](err[value.Value, str]("lower: unsupported field descriptor member in value position"));
 }
 
+# try_lower_pack_len: folds `va.len` to the current pack instance's element count
+# (#1475) when the member's receiver is a comptime variadic pack, or none when it
+# is not (an ordinary record/module member). the count is a compile-time constant
+# fixed by the call site (`ctx.pack_len`), emitted at the member expression's
+# lowered type (sema types `va.len` as `u64`).
+fun try_lower_pack_len(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Option[Result[value.Value, str]] {
+    val obj_ty: ty.TypeId = lower.expr_type_of(ctx, e.data.member.object);
+    val to: Option[*ty.Type] = ty.get(?ctx.s.types, obj_ty);
+    if (is_none[*ty.Type](to)) { ret none[Result[value.Value, str]](); }
+    if (unwrap[*ty.Type](to).kind != ty.TYPE_PACK) { ret none[Result[value.Value, str]](); }
+
+    val tr: Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
+    if (is_err[ir_type.IrTypeId, str](tr)) {
+        ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](tr)));
+    }
+    val ity: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+    ret some[Result[value.Value, str]](ok[value.Value, str](value.const_int(ctx.pack_len::u64, ity)));
+}
+
 fun lower_member_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
+    # `va.len` on a comptime variadic pack (#1475): folds to the instance's element
+    # count, a compile-time constant fixed by the call site. sema already validated
+    # that `.len` is the pack's only member, so a pack receiver here is `.len`.
+    val pl: Option[Result[value.Value, str]] = try_lower_pack_len(ctx, eid, e);
+    if (is_some[Result[value.Value, str]](pl)) { ret unwrap[Result[value.Value, str]](pl); }
+
     # a `$each` field-descriptor member (`f.offset`) folds to a constant (#1473).
     val fdm: Option[Result[value.Value, str]] = try_lower_field_member(ctx, eid, e);
     if (is_some[Result[value.Value, str]](fdm)) { ret unwrap[Result[value.Value, str]](fdm); }

--- a/src/lang/me/lower/mangle.mach
+++ b/src/lang/me/lower/mangle.mach
@@ -168,6 +168,78 @@ pub fun value_instance_name(
     ret r;
 }
 
+# pack_instance_name: the linkage name of a comptime variadic-pack instance: the
+# mangled base name with its pack element type-list encoded into a `Q...E` suffix,
+# so distinct type-lists (e.g. `sum(i64,i64)` vs `sum(f64)`) name distinct symbols.
+# the `Q` pack namespace is disjoint from the type-argument `I...E` and the value
+# `K...E` namespaces, so a pack instance can never collide with a type or value
+# instance (which would silently merge two different WEAK bodies). element types
+# encode through the same injective `write_encoded_type` the generic `I...E` suffix
+# uses. an instance is never exempted, so no export hook.
+# ---
+# s:        shared session (interner, type universe)
+# fqn:      FQN StrId of the function's defining (origin) module
+# bare:     function's source identifier StrId
+# types:    pointer to the pack element type-list
+# type_len: number of pack element types (must be > 0)
+# ret:      the pack-instance linkage-name StrId, or an allocation error
+pub fun pack_instance_name(
+    s:        *sess.Session,
+    fqn:      intern.StrId,
+    bare:     intern.StrId,
+    types:    *ty.TypeId,
+    type_len: u32
+) Result[intern.StrId, str] {
+    val path_opt: Option[str] = intern.lookup(?s.interner, fqn);
+    var path: str = "main";
+    if (is_some[str](path_opt)) {
+        val p: str = unwrap[str](path_opt);
+        if (str_len(p) > 0) { path = p; }
+    }
+
+    val name_opt: Option[str] = intern.lookup(?s.interner, bare);
+    if (is_none[str](name_opt)) { ret err[intern.StrId, str]("mangle: bare name not interned"); }
+    val name: str = unwrap[str](name_opt);
+
+    # byte length of the `Q<enc(type)...>E` pack type-list suffix. the `N<len>`
+    # prefix counts the bare name plus this suffix.
+    var suffix_len: usize = 2;
+    var si: u32 = 0;
+    for (si < type_len) {
+        suffix_len = suffix_len + encoded_type_len(s, types[si]);
+        si = si + 1;
+    }
+    val name_len: usize = str_len(name) + suffix_len;
+
+    var total: usize = 2;
+    total = total + encoded_path_len(path);
+    total = total + 1;
+    total = total + decimal_len(name_len) + name_len;
+
+    val buf_r: Result[*u8, str] = allocate[u8](s.alloc, total);
+    if (is_err[*u8, str](buf_r)) { ret err[intern.StrId, str](unwrap_err[*u8, str](buf_r)); }
+    val buf: *u8 = unwrap_ok[*u8, str](buf_r);
+
+    var k: usize = 0;
+    buf[k] = '_'; k = k + 1;
+    buf[k] = 'M'; k = k + 1;
+    k = write_encoded_path(buf, k, path);
+    buf[k] = 'N'; k = k + 1;
+    k = write_decimal(buf, k, name_len);
+    k = write_str(buf, k, name);
+    buf[k] = 'Q'; k = k + 1;
+    var ai: u32 = 0;
+    for (ai < type_len) {
+        k = write_encoded_type(s, buf, k, types[ai]);
+        ai = ai + 1;
+    }
+    buf[k] = 'E'; k = k + 1;
+
+    val r: Result[intern.StrId, str] = intern.intern_bytes(?s.interner, buf::str, k);
+    deallocate[u8](s.alloc, buf, total);
+    ret r;
+}
+
 # encoded_value_len / write_encoded_value: an injective encoding of one folded
 # comptime value into the value-instance name. distinct values map to distinct
 # byte sequences (a kind tag plus a self-delimiting, length-prefixed payload), so

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -654,6 +654,14 @@ fun lower_pack_each(ctx: *lower.LowerContext, ce: *astmt.StmtComptimeEach) Resul
     if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
     val fname: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
 
+    # one typing-snapshot set spanning every module, so the per-element body
+    # re-inference can resolve cross-module references the pack body makes (a call
+    # to a function in another module needs that module's signature types). built
+    # once here and shared across the element iterations.
+    val deps_r: Result[sema.SemaDeps, str] = sema.collect_module_deps(ctx.s);
+    if (is_err[sema.SemaDeps, str](deps_r)) { ret err[bool, str](unwrap_err[sema.SemaDeps, str](deps_r)); }
+    var deps: sema.SemaDeps = unwrap_ok[sema.SemaDeps, str](deps_r);
+
     var i: u32 = 0;
     for (i < ctx.pack_len) {
         val mark: comptime.FrameMark = comptime.frame_open(ctx.ctx);
@@ -661,26 +669,29 @@ fun lower_pack_each(ctx: *lower.LowerContext, ce: *astmt.StmtComptimeEach) Resul
         val br: Result[bool, str] = comptime.bind(ctx.ctx, fname, desc);
         if (is_err[bool, str](br)) {
             val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            sema.free_module_deps(ctx.s, ?deps);
             if (is_err[bool, str](cc)) { ret cc; }
             ret br;
         }
 
         # re-type the body for this element (its type is fixed only here), writing
         # the body expressions' types into the shared array lowering reads next.
-        val ir: Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, nil, ctx.ctx,
+        val ir: Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, ?deps, ctx.ctx,
             ctx.own_module, ctx.sema_result, ctx.pack_ret_ty, ce.body_start, ce.body_len);
         if (is_err[bool, str](ir)) {
             val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            sema.free_module_deps(ctx.s, ?deps);
             if (is_err[bool, str](cc)) { ret cc; }
             ret ir;
         }
 
         val rb: Result[bool, str] = lower_stmt_list(ctx, ce.body_start, ce.body_len);
         val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
-        if (is_err[bool, str](rb)) { ret rb; }
-        if (is_err[bool, str](cc)) { ret cc; }
+        if (is_err[bool, str](rb)) { sema.free_module_deps(ctx.s, ?deps); ret rb; }
+        if (is_err[bool, str](cc)) { sema.free_module_deps(ctx.s, ?deps); ret cc; }
         i = i + 1;
     }
+    sema.free_module_deps(ctx.s, ?deps);
     ret ok[bool, str](true);
 }
 

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -54,6 +54,8 @@ use builder:  mach.lang.me.ir.builder;
 
 use map: std.collections.map;
 
+use sema:  mach.lang.fe.sema;
+
 use lower: mach.lang.me.lower.context;
 use expr:  mach.lang.me.lower.expr;
 
@@ -599,8 +601,16 @@ fun lower_comptime_if(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str
 fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] {
     val ce: *astmt.StmtComptimeEach = ?s.data.comptime_each;
     val src: str = lower.module_source(ctx);
+
+    # a pack `$each a in va` (#1475): the sequence is a variadic-pack value (not a
+    # `$fields(T)` call), so unroll over the pack instance's expanded elements —
+    # re-typing then lowering the body per element, the loop variable bound to each.
+    if (is_pack_type(ctx, lower.expr_type_of(ctx, ce.seq))) {
+        ret lower_pack_each(ctx, ce);
+    }
+
     if (!comptime.is_fields_call(ctx.a, src, ce.seq)) {
-        ret err[bool, str]("lower: a `$each` sequence must be `$fields(T)`");
+        ret err[bool, str]("lower: a `$each` sequence must be `$fields(T)` or a variadic pack");
     }
     val targ: aid.ExprId = comptime.fields_type_arg(ctx.a, ce.seq);
     if (targ == aid.EXPR_NIL) { ret err[bool, str]("lower: `$fields` is missing its type argument"); }
@@ -627,6 +637,59 @@ fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, s
         i = i + 1;
     }
     ret ok[bool, str](true);
+}
+
+# lowers a pack `$each a in va { body }` (#1475) by unrolling it over the pack
+# instance's expanded elements (lower_pack_instance recorded the element slots and
+# types on the context). per element: the loop variable is bound in the comptime
+# frame to the element's descriptor — carrying the element's type (so the body
+# re-infers the loop variable to it) and its ordinal (so a body reference loads the
+# matching expanded parameter slot) — then the body is re-typed for that element
+# and lowered. typing and lowering interleave per element because a pack element's
+# type is fixed only at the call site; the body was deferred at the original sema
+# pass. the re-traverse-no-clone model mirrors the `$fields` unroll.
+fun lower_pack_each(ctx: *lower.LowerContext, ce: *astmt.StmtComptimeEach) Result[bool, str] {
+    val src: str = lower.module_source(ctx);
+    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, src, ce.var_name);
+    if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
+    val fname: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+    var i: u32 = 0;
+    for (i < ctx.pack_len) {
+        val mark: comptime.FrameMark = comptime.frame_open(ctx.ctx);
+        val desc: comptime.CTValue = comptime.pack_elem_value(i, ctx.pack_types[i]::u32);
+        val br: Result[bool, str] = comptime.bind(ctx.ctx, fname, desc);
+        if (is_err[bool, str](br)) {
+            val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            if (is_err[bool, str](cc)) { ret cc; }
+            ret br;
+        }
+
+        # re-type the body for this element (its type is fixed only here), writing
+        # the body expressions' types into the shared array lowering reads next.
+        val ir: Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, nil, ctx.ctx,
+            ctx.own_module, ctx.sema_result, ctx.pack_ret_ty, ce.body_start, ce.body_len);
+        if (is_err[bool, str](ir)) {
+            val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            if (is_err[bool, str](cc)) { ret cc; }
+            ret ir;
+        }
+
+        val rb: Result[bool, str] = lower_stmt_list(ctx, ce.body_start, ce.body_len);
+        val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+        if (is_err[bool, str](rb)) { ret rb; }
+        if (is_err[bool, str](cc)) { ret cc; }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# true when a semantic type is a comptime variadic pack (TYPE_PACK), the marker
+# that selects the pack unroll over the `$fields` unroll in lower_comptime_each.
+fun is_pack_type(ctx: *lower.LowerContext, t: ty.TypeId) bool {
+    val to: Option[*ty.Type] = ty.get(?ctx.s.types, t);
+    if (is_none[*ty.Type](to)) { ret false; }
+    ret unwrap[*ty.Type](to).kind == ty.TYPE_PACK;
 }
 
 # true when the builder's current block already has a terminator. used to

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -283,6 +283,16 @@ pub fun module_ast(s: *Session, mid: modid.ModuleId) *ast.Ast {
     ret s.module_asts[mid::u32];
 }
 
+# module_count: the number of registered modules — the dense upper bound on
+# ModuleIds (`0 .. module_count`). lets a phase enumerate every loaded module
+# (e.g. to assemble a typing-snapshot set for cross-module lookups).
+# ---
+# s:   the session
+# ret: the registered module count
+pub fun module_count(s: *Session) u32 {
+    ret s.module_ast_count;
+}
+
 # register_module_fqn: record `fqn` as the fully-qualified path of module `mid`,
 # so the back-end mangler can name a cross-module symbol against its defining
 # module. populated by the driver alongside register_module_ast. registering the


### PR DESCRIPTION
Codegen for #1475: a pack-tailed function (`va: ...`) is monomorphized once per distinct call-site pack type-list — the third template kind alongside generic-type instances and comptime-value instances, emitted PUB|WEAK (no single entry point; source-level only, not a stable-ABI symbol).

## Approach
- **Worklist**: a `PackInstance` worklist on the lowering context keyed by `(decl, origin, pack element type-list)`, drained to fixpoint alongside the type/value worklists.
- **Mangle**: `pack_instance_name` under a disjoint `Q...E` namespace (never colliding with `I...E` type-args or `K...E` values).
- **Guard**: `fun_has_pack_param` skips a pack-tailed function from direct emission (it is a template).
- **lower_pack_instance**: expands the pack into N concrete params typed by the type-list; records the slots for the `$each` unroll.
- **lower_comptime_each (pack branch)**: per element, interleaves per-element body re-inference (the type-list is known only at the call site) with body lowering, binding the loop var to the i-th concrete param — same re-traverse-no-clone model as `$each over $fields`.
- **Call site**: a pack-tailed callee computes the arg-type-list, enqueues the instance, and lowers the call passing the collected args.

## Status
Landing in standalone-testable slices. First commit scaffolds the worklist, mangle, and template-skip guard (compiles clean; guard active, worklist/mangle dormant until wired). New-syntax e2e lives in `.github/tests` (seed-safe: the compiler source uses no packs).

Closes #1475