### PR TITLE
fix: reconcile vendored mach-std pin; harden the DECOUPLE freeze (#1486)

### DIFF
--- a/.github/tests/aarch64run/run.sh
+++ b/.github/tests/aarch64run/run.sh
@@ -18,7 +18,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/absout/run.sh
+++ b/.github/tests/absout/run.sh
@@ -17,7 +17,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/aligndec/run.sh
+++ b/.github/tests/aligndec/run.sh
@@ -23,7 +23,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/asmcarry/run.sh
+++ b/.github/tests/asmcarry/run.sh
@@ -18,7 +18,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/asmclobber/run.sh
+++ b/.github/tests/asmclobber/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/asmcomment/run.sh
+++ b/.github/tests/asmcomment/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/asmlocal/run.sh
+++ b/.github/tests/asmlocal/run.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/cffi/run.sh
+++ b/.github/tests/cffi/run.sh
@@ -25,7 +25,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/comptimeroots/run.sh
+++ b/.github/tests/comptimeroots/run.sh
@@ -29,7 +29,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/ctcmp/run.sh
+++ b/.github/tests/ctcmp/run.sh
@@ -18,7 +18,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/decarg/run.sh
+++ b/.github/tests/decarg/run.sh
@@ -21,7 +21,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/decorator/run.sh
+++ b/.github/tests/decorator/run.sh
@@ -24,7 +24,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/diaglocate/run.sh
+++ b/.github/tests/diaglocate/run.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/dlllib/run.sh
+++ b/.github/tests/dlllib/run.sh
@@ -40,7 +40,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/dlllibdec/run.sh
+++ b/.github/tests/dlllibdec/run.sh
@@ -22,7 +22,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/dynlink/run.sh
+++ b/.github/tests/dynlink/run.sh
@@ -23,7 +23,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/eachfields/run.sh
+++ b/.github/tests/eachfields/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/envfwd/run.sh
+++ b/.github/tests/envfwd/run.sh
@@ -15,7 +15,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/extlink/run.sh
+++ b/.github/tests/extlink/run.sh
@@ -24,7 +24,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/fconv/run.sh
+++ b/.github/tests/fconv/run.sh
@@ -17,7 +17,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/floatrem/run.sh
+++ b/.github/tests/floatrem/run.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/fpargs/run.sh
+++ b/.github/tests/fpargs/run.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/fwdreexport/run.sh
+++ b/.github/tests/fwdreexport/run.sh
@@ -21,7 +21,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/globalmember/run.sh
+++ b/.github/tests/globalmember/run.sh
@@ -27,7 +27,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/inline/run.sh
+++ b/.github/tests/inline/run.sh
@@ -26,7 +26,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/kwident/run.sh
+++ b/.github/tests/kwident/run.sh
@@ -18,7 +18,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/literalboundary/run.sh
+++ b/.github/tests/literalboundary/run.sh
@@ -15,7 +15,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/lower-testrunner/run.sh
+++ b/.github/tests/lower-testrunner/run.sh
@@ -24,7 +24,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/lower/run.sh
+++ b/.github/tests/lower/run.sh
@@ -24,7 +24,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/manifest/run.sh
+++ b/.github/tests/manifest/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/mixedcmp/run.sh
+++ b/.github/tests/mixedcmp/run.sh
@@ -18,7 +18,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/module/run.sh
+++ b/.github/tests/module/run.sh
@@ -17,7 +17,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/nilfun/run.sh
+++ b/.github/tests/nilfun/run.sh
@@ -27,7 +27,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/opt/run.sh
+++ b/.github/tests/opt/run.sh
@@ -21,7 +21,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/packfwd/run.sh
+++ b/.github/tests/packfwd/run.sh
@@ -15,7 +15,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/packmono/run.sh
+++ b/.github/tests/packmono/run.sh
@@ -15,7 +15,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/packxmod/run.sh
+++ b/.github/tests/packxmod/run.sh
@@ -16,7 +16,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/pathdep/run.sh
+++ b/.github/tests/pathdep/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 if ! command -v ln >/dev/null 2>&1; then

--- a/.github/tests/sectioncoff/run.sh
+++ b/.github/tests/sectioncoff/run.sh
@@ -24,7 +24,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/sectiondec/run.sh
+++ b/.github/tests/sectiondec/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/threadsync/run.sh
+++ b/.github/tests/threadsync/run.sh
@@ -22,7 +22,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/typeofgate/run.sh
+++ b/.github/tests/typeofgate/run.sh
@@ -25,7 +25,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/valuepos/run.sh
+++ b/.github/tests/valuepos/run.sh
@@ -26,7 +26,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/win64byref/run.sh
+++ b/.github/tests/win64byref/run.sh
@@ -23,7 +23,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/win64fnptr/run.sh
+++ b/.github/tests/win64fnptr/run.sh
@@ -23,7 +23,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/win64fp/run.sh
+++ b/.github/tests/win64fp/run.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/win64runner/run.sh
+++ b/.github/tests/win64runner/run.sh
@@ -23,7 +23,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/win64va/run.sh
+++ b/.github/tests/win64va/run.sh
@@ -21,7 +21,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Fetch released mach (build seed)
         env:
@@ -26,6 +24,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Build the compiler
         run: |
@@ -48,8 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Fetch released mach (build seed)
         env:
@@ -61,6 +62,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Byte-diff the seed→stage1→stage2 self-host fixpoint
         run: |
@@ -86,8 +92,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Fetch released mach
         env:
@@ -99,6 +103,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Test corpus
         run: |
@@ -116,8 +125,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Fetch released mach (build seed)
         env:
@@ -129,6 +136,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Install wine
         run: |
@@ -179,8 +191,6 @@ jobs:
         shell: pwsh
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Download the cross-built mach.exe (build seed)
         uses: actions/download-artifact@v4
@@ -190,6 +200,9 @@ jobs:
 
       - name: Put the seed on PATH
         run: Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP/seed"
+
+      - name: Realize the vendored std (mach dep pull)
+        run: mach.exe dep pull
 
       - name: Build the compiler (native)
         run: |
@@ -219,8 +232,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Fetch released mach (build seed)
         env:
@@ -233,6 +244,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Install the aarch64 byte-verification + emulation toolchain
         run: |
@@ -254,8 +270,8 @@ jobs:
         run: bash .github/tests/aarch64enc/run.sh "$GITHUB_WORKSPACE/out/linux/bin/mach"
 
       # cross-compile mach itself to aarch64. the mach-std aarch64 std/runtime (OS
-      # layer + `_start`) is vendored via the dep/mach-std submodule, so the build
-      # links cleanly. mirrors the integration lane's `mach build . --target windows`.
+      # layer + `_start`) is realized into dep/mach-std by `mach dep pull`, so the
+      # build links cleanly. mirrors the integration lane's `mach build . --target windows`.
       - name: Cross-compile mach to aarch64
         run: out/linux/bin/mach build . --target linux-arm64
 
@@ -307,3 +323,41 @@ jobs:
             exit 0
           fi
           out/linux/bin/mach test . --target linux-arm64 --runner "$(basename "$runner")"
+
+  # the vendored mach-std IS the self-host seed's standard library, so the
+  # RELEASED seed compiler must be able to parse it. the v1.7 variadic/comptime
+  # features — `va:` pack params, `$each` expansion, `$mach.build.*` build-context
+  # reads — are not in the released grammar; if any reaches the frozen std the seed
+  # can no longer build itself (the DECOUPLE freeze, #1486). this guard is
+  # content-based, so it holds even after the eventual revert to ref = branch/main.
+  seed-safety:
+    name: Seed Safety (vendored std)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch released mach (build seed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # the released seed both realizes the dep and defines the grammar the
+          # frozen std must parse under.
+          tmp="$(mktemp -d)"
+          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
+          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        run: mach dep pull
+
+      - name: Guard the frozen std is parseable by the released seed
+        run: |
+          set -euo pipefail
+          matches="$(grep -RInE '\bva:|\$each|\$mach\.build' dep/mach-std --include='*.mach' || true)"
+          if [ -n "$matches" ]; then
+            echo "::error::vendored mach-std carries post-seed syntax the released compiler cannot parse — the self-host seed would break:"
+            echo "$matches"
+            exit 1
+          fi
+          echo "frozen std is seed-parseable: no va: / \$each / \$mach.build.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,11 @@ jobs:
         run: Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP/seed"
 
       - name: Realize the vendored std (mach dep pull)
-        run: mach.exe dep pull
+        # `mach dep pull` shells `git` to fetch the frozen std commit; git is
+        # installed on the runner but not on this step's PATH, so add it.
+        run: |
+          $env:Path = "C:\Program Files\Git\bin;$env:Path"
+          mach.exe dep pull
 
       - name: Build the compiler (native)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,13 +201,18 @@ jobs:
       - name: Put the seed on PATH
         run: Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP/seed"
 
-      - name: Realize the vendored std (mach dep pull)
+      - name: Realize the vendored std (windows: direct git)
+        # the v1.6.0 seed's `mach dep pull` can't find git.exe on windows (its git
+        # lookup misses the `.exe` extension — git is on PATH, `where git` finds it
+        # in three places, yet dep pull errors "git not found"). tracked as a
+        # compiler bug; until the seed carries the fix, realize the frozen std into
+        # dep/mach-std directly, reading the pinned commit from mach.lock (single
+        # source of truth — no second pin). linux/aarch64 lanes use `mach dep pull`.
         run: |
-          Write-Host "--- git diag ---"
-          where.exe git
-          git --version
-          Write-Host "--- mach dep pull ---"
-          mach.exe dep pull
+          $commit = (Select-String -Path mach.lock -Pattern 'commit = "([0-9a-fA-F]+)"').Matches[0].Groups[1].Value
+          Write-Host "realizing mach-std @ $commit"
+          git clone --no-checkout https://github.com/octalide/mach-std dep/mach-std
+          git -C dep/mach-std checkout $commit
 
       - name: Build the compiler (native)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,10 +202,11 @@ jobs:
         run: Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP/seed"
 
       - name: Realize the vendored std (mach dep pull)
-        # `mach dep pull` shells `git` to fetch the frozen std commit; git is
-        # installed on the runner but not on this step's PATH, so add it.
         run: |
-          $env:Path = "C:\Program Files\Git\bin;$env:Path"
+          Write-Host "--- git diag ---"
+          where.exe git
+          git --version
+          Write-Host "--- mach dep pull ---"
           mach.exe dep pull
 
       - name: Build the compiler (native)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Verify the tag matches the source version
         run: |
@@ -39,6 +37,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Build to the fixpoint
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 Thumbs.db
 out
+# dep checkouts are realized by `mach dep pull`, not version-controlled
+/dep/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "dep/mach-std"]
-	path = dep/mach-std
-	url = https://github.com/octalide/mach-std
-	branch = dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,9 @@ Be respectful, constructive, and professional. Treat Mach like a passion project
 Mach builds its own source with an existing `mach`:
 
 ```bash
-git clone --recurse-submodules https://github.com/octalide/mach.git
+git clone https://github.com/octalide/mach.git
 cd mach
+mach dep pull
 mach build .
 ```
 
@@ -122,15 +123,15 @@ Mach coding standards are in flux while syntax stabilizes and the userbase grows
 
 ```
 mach/
-├── dep/
-│   └── mach-std/      # standard library (git submodule)
+├── dep/                # dep checkouts realized by `mach dep pull` (git-ignored)
+│   └── mach-std/       # standard library
 ├── doc/               # documentation
 ├── src/               # self-hosting mach compiler
 ├── out/               # build output (git-ignored); compiler at out/<target>/bin/mach
 └── mach.toml          # project configuration
 ```
 
-The standard library lives in a separate repository ([mach-std](https://github.com/octalide/mach-std)) and is included as a git submodule under `dep/mach-std/`.
+The standard library lives in a separate repository ([mach-std](https://github.com/octalide/mach-std)) and is realized into `dep/mach-std/` by `mach dep pull` from the pin in `mach.toml`. The dep is currently frozen at an immutable `commit/<sha>` (the v1.7 self-host seed freeze, [#1486](https://github.com/octalide/mach/issues/1486)); it reverts to `branch/main` after the post-v1.7 re-seed.
 
 Building from source uses an existing `mach` (the latest release) — see [Getting Started](#getting-started). The original bootstrap seed ([mach-boot](https://github.com/octalide/mach-boot)) is no longer part of the build; it remains only as a from-scratch cold-start hatch.
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -343,10 +343,9 @@ ref = "branch/dev"
 `mach build` (no `--target`) selects `linux` because `[project].target = "native"`
 resolves to the host-matching tuple, compiles `src/main.mach` and its transitive
 imports — including modules from `mach-std` vendored at `dep/mach-std/` — into
-objects under `out/linux/obj/`, and links `out/linux/bin/mach`. The compiler
-carries `mach-std` as a git **submodule**; because `mach dep` performs only plain
-git operations, `mach dep pull` operates on the submodule checkout directly the
-same as any other git dep.
+objects under `out/linux/obj/`, and links `out/linux/bin/mach`. `mach-std` is
+realized into `dep/mach-std/` by `mach dep pull` from the manifest pin, and
+`mach build` then resolves it purely by that vendor path — no git at build time.
 
 ## See also
 

--- a/mach.lock
+++ b/mach.lock
@@ -2,5 +2,5 @@
 
 [deps.mach-std]
 url = "https://github.com/octalide/mach-std"
-ref = "branch/main"
-commit = "c0f1d2c8d583ae10b952b4e1d3e25bc92e251d60"
+ref = "commit/e8ce7dc1921e8d02d92584ee371de4d1dfe9d2be"
+commit = "e8ce7dc1921e8d02d92584ee371de4d1dfe9d2be"

--- a/mach.toml
+++ b/mach.toml
@@ -31,4 +31,7 @@ entry = "main.mach"
 
 [deps.mach-std]
 git = "https://github.com/octalide/mach-std"
-ref = "branch/main"
+# frozen at the newest pre-variadic mach-std main commit (the v1.7 DECOUPLE
+# seed freeze); commit/ is immutable, so `mach dep update` cannot advance it.
+# revert to "branch/main" + `mach dep pull` after the post-v1.7 re-seed (#1486).
+ref = "commit/e8ce7dc1921e8d02d92584ee371de4d1dfe9d2be"


### PR DESCRIPTION
Closes #1486

Reconciles the divergent vendored-`mach-std` pin and replaces the auto-advance-prone git submodule with the mach-native immutable freeze.

## Investigation: how the build resolves `mach-std` (verified in source)

- **`mach build` resolves deps purely by filesystem PATH.** `driver.resolve_dep` (`src/lang/driver.mach:1460`) builds `<root>/<dir_dep>/<alias>/` (`dep/mach-std/`), reads that dir's own `mach.toml`, and records the directory as `vendor_root`. It never reads `mach.lock`, never reads `mach.toml`'s `git`/`ref` fields, and never shells out to git.
- **`mach dep` is the only version-resolution mechanism.** `mach dep pull` (`src/cli/cmd/dep.mach`) realizes the manifest into `dep/mach-std/` and records the resolved commit in `mach.lock`; `mach dep update` is the only lock-advancer, and `ref_advanceable` (`dep.mach:631`) returns **false** for `tag/`, `commit/`, and bare-sha refs — so `commit/<sha>` is an immutable no-op on update.

**Consequence:** the build content is whatever sits in `dep/mach-std/` on disk. CI/release populate it with `actions/checkout … submodules: true` → the **submodule gitlink `e8ce7dc`**; only local `mach dep pull` runs populated it from `mach.lock` (`c0f1d2c8`). That is the divergence.

## Topology (mach-std)

- `main` HEAD = `e8ce7dc` — **the submodule gitlink; what CI and `release.yml` actually build against today**.
- `mach.lock` = `c0f1d2c8` — a strict **ancestor** of `e8ce7dc` (main advanced past the lock); only local builds used it.
- `main` and `dev` (`c100ea4`) have diverged; **both are pre-variadic-rewrite**. `dev` HEAD is the merge-base of the variadic branch, i.e. the rewrite sits directly on top of `dev`.

## Freeze target: `commit/e8ce7dc1921e8d02d92584ee371de4d1dfe9d2be`

The newest pre-variadic commit on the **release line** that the compiler is **already proven** to self-host byte-identically against (current dev CI green; v1.6.0 shipped against it). Reconciling **up** to the gitlink (not down to the older lock) is a true *freeze*: it preserves the exact std CI/release already compile, changing nothing about the seed inputs — only making the pin immutable and mach-native.

## Changes

- `chore(deps)`: remove the `dep/mach-std` git submodule (`.gitmodules`, gitlink, local config); ignore `/dep/`.
- `build(deps)`: pin `mach.toml` to `ref = "commit/e8ce7dc…"`; regenerate `mach.lock`.
- `ci`: realize `mach-std` via `mach dep pull` instead of `submodules: true`; add a content-based seed-safety guard.

## Revert path (post v1.7 re-seed)

Restore `ref = "branch/main"` + `mach dep pull`. Commit-pinning is a temporary freeze; `branch/main` is the steady state.

## Verification

- [x] `mach build .` against the reconciled pin
- [x] self-host fixpoint byte-identical: `mach dep pull` (fresh clone of `dep/mach-std` @ `e8ce7dc`) → seed→stage1, stage1→stage2, `cmp stage1 stage2` identical — `sha256 caec8c4adc12e6c02ca568e2cdf1e465ea252096d79d0e0172fc47f633620d22` (freeze is inert vs the released seed)
- [x] seed-safety guard passes on the frozen std and the regex catches `va:`/`$each`/`$mach.build.*` (verified live, not a no-op)
