### PR TITLE
fix(dep): find git.exe on windows (#1506)

### DIFF
--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -925,7 +925,11 @@ fun read_dep_manifest(alloc: *Allocator, dir: str) Result[toml.Table, str] {
 # error naming the operation that needed git.
 fun ensure_git(alloc: *Allocator, gt: *GitTool) Result[bool, str] {
     if (gt.ready) { ret ok[bool, str](true); }
-    val git_r: Result[str, str] = find_on_path(alloc, "git");
+    # windows executables carry a `.exe` extension; the bare `git` name does not
+    # resolve on PATH there (it's `git.exe`), so look for the right name (#1506).
+    var gname: *u8 = "git";
+    $if ($mach.target.os == $mach.os.windows) { gname = "git.exe"; }
+    val git_r: Result[str, str] = find_on_path(alloc, gname);
     if (is_err[str, str](git_r)) { ret err[bool, str]("git not found on PATH (needed to fetch git dependencies)"); }
     val env_r: Result[**u8, str] = build_env(alloc);
     if (is_err[**u8, str](env_r)) { ret err[bool, str]("failed to build child environment for git"); }


### PR DESCRIPTION
The dep resolver looked up the bare name `git` on PATH, which never resolves on Windows (it's `git.exe`) — `mach dep pull` failed there even with git installed and on PATH (`where git` finds it in three places). Now looks for `git.exe` on Windows via the seed-safe `$if ($mach.target.os == $mach.os.windows)` form.

Self-host verified byte-identical (stage1==stage2==stage3); inert/additive change.

Closes #1506