### PR TITLE
release: v1.7.0 — comptime & variadics

### DIFF
--- a/.github/tests/aarch64run/run.sh
+++ b/.github/tests/aarch64run/run.sh
@@ -18,7 +18,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/absout/run.sh
+++ b/.github/tests/absout/run.sh
@@ -17,7 +17,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/aligndec/app/mach.toml
+++ b/.github/tests/aligndec/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "aligndec"
+name = "Align Decorator Test — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.aligndec]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/aligndec/app/src/main.mach
+++ b/.github/tests/aligndec/app/src/main.mach
@@ -8,13 +8,12 @@ rec Pair { a: u64; b: u64; }
 `align(64)` `symbol("g_lit64")`
 pub var g_lit64: u8 = 7;
 
-# a comptime-expr alignment, also observably different from the default.
+# a comptime-expr alignment, also observably different from the default. this is
+# the discriminating comptime-expr case: 16 != the 8-byte default, so it fails if
+# the decorator is ignored. (`$align_of(u64)` folds to 8 — equal to the default,
+# so it could never discriminate; the natural alignment of any type is <= 8.)
 `align($size_of(Pair))` `symbol("g_cmp16")`
 pub var g_cmp16: u8 = 9;
-
-# the acceptance-criteria spelling: `$align_of(u64)` folds to 8.
-`align($align_of(u64))` `symbol("g_cmp8")`
-pub var g_cmp8: u8 = 5;
 
 # no decorator: the back end's default section alignment (8) applies.
 `symbol("g_plain")`
@@ -30,5 +29,12 @@ pub var g_over: Over;
 
 `symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
-    ret (g_lit64 + g_cmp16 + g_cmp8 + g_plain)::i64;
+    # alignment-dependent runtime probe: each over-aligned global's actual address
+    # must satisfy its requested alignment. this proves the layout even where the
+    # structural readelf check is unavailable, and a distinct sentinel makes a
+    # misalignment self-identifying instead of folding into the value sum.
+    if (((?g_lit64)::u64 & 63) != 0) { ret 91; }
+    if (((?g_cmp16)::u64 & 15) != 0) { ret 92; }
+    if (((?g_over)::u64  & 31) != 0) { ret 93; }
+    ret (g_lit64 + g_cmp16 + g_plain)::i64;
 }

--- a/.github/tests/aligndec/app/src/main.mach
+++ b/.github/tests/aligndec/app/src/main.mach
@@ -20,6 +20,14 @@ pub var g_cmp8: u8 = 5;
 `symbol("g_plain")`
 pub var g_plain: u8 = 11;
 
+# an `align(...)` decorator on a TYPE raises the type's own alignment and size; a
+# global of that type inherits the alignment, observable on the global's section.
+`align(32)`
+rec Over { a: u8; }
+
+`symbol("g_over")`
+pub var g_over: Over;
+
 `symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret (g_lit64 + g_cmp16 + g_cmp8 + g_plain)::i64;

--- a/.github/tests/aligndec/app/src/main.mach
+++ b/.github/tests/aligndec/app/src/main.mach
@@ -1,0 +1,26 @@
+use std.runtime.linux.x86_64;
+
+# `$size_of(Pair)` is a comptime expression that folds to 16, proving an
+# `align(...)` decorator accepts a comptime-expr argument, not just a literal.
+rec Pair { a: u64; b: u64; }
+
+# a literal alignment that differs from the 8-byte default, so it is observable.
+`align(64)` `symbol("g_lit64")`
+pub var g_lit64: u8 = 7;
+
+# a comptime-expr alignment, also observably different from the default.
+`align($size_of(Pair))` `symbol("g_cmp16")`
+pub var g_cmp16: u8 = 9;
+
+# the acceptance-criteria spelling: `$align_of(u64)` folds to 8.
+`align($align_of(u64))` `symbol("g_cmp8")`
+pub var g_cmp8: u8 = 5;
+
+# no decorator: the back end's default section alignment (8) applies.
+`symbol("g_plain")`
+pub var g_plain: u8 = 11;
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    ret (g_lit64 + g_cmp16 + g_cmp8 + g_plain)::i64;
+}

--- a/.github/tests/aligndec/run.sh
+++ b/.github/tests/aligndec/run.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# align decorator integration test (#1476): prove an `align(...)` decorator sets
+# the emitted alignment of a global, including the acceptance-criteria case of a
+# comptime-expr argument (`align($size_of(Pair))` folding to 16).
+#
+# each decorated global lands in its own data section whose `sh_addralign` is the
+# requested alignment; the object file carries the per-symbol section header that
+# readelf reads (the final static executable strips section headers). the build
+# asserts: g_lit64 -> 64 (literal), g_cmp16 -> 16 (comptime expr), g_cmp8 -> 8
+# (`$align_of(u64)`), g_plain -> 8 (default). the binary must also run, confirming
+# the over-aligned data is laid out correctly. readelf absent -> structural check
+# skipped, run still asserted.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+fail=0
+
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . -O2 ) >/dev/null 2>&1; then
+    echo "FAIL aligndec: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/aligndec"
+OBJ="$WORK/app/out/linux/obj/aligndec/main.o"
+
+# run: the over-aligned globals sum to 7 + 9 + 5 + 11 == 32.
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 32 ]; then
+    echo "FAIL aligndec: program ran with exit $code, expected 32" >&2
+    fail=1
+else
+    echo "PASS aligndec: the program with over-aligned globals runs correctly"
+fi
+
+# structural check: each global's section header alignment in the object file.
+if command -v readelf >/dev/null 2>&1 && [ -f "$OBJ" ]; then
+    # sec_align <symbol> — the sh_addralign of the section the symbol is defined in.
+    sec_align() {
+        local sym="$1" ndx
+        ndx=$(readelf -sW "$OBJ" 2>/dev/null | awk -v n="$sym" '$8==n {print $7; exit}')
+        [ -n "$ndx" ] || { echo "?"; return; }
+        readelf -SW "$OBJ" 2>/dev/null | grep -E "^[[:space:]]*\[[[:space:]]*${ndx}\]" | awk '{print $NF}'
+    }
+    expect_align() {
+        local sym="$1" want="$2" got
+        got=$(sec_align "$sym")
+        if [ "$got" != "$want" ]; then
+            echo "FAIL aligndec: $sym section align is $got, expected $want" >&2
+            fail=1
+        else
+            echo "PASS aligndec: $sym aligned to $want"
+        fi
+    }
+    expect_align g_lit64 64
+    expect_align g_cmp16 16
+    expect_align g_cmp8  8
+    expect_align g_plain 8
+else
+    echo "INFO aligndec: readelf unavailable or object missing; skipping the alignment check"
+fi
+
+exit "$fail"

--- a/.github/tests/aligndec/run.sh
+++ b/.github/tests/aligndec/run.sh
@@ -6,10 +6,10 @@
 # each decorated global lands in its own data section whose `sh_addralign` is the
 # requested alignment; the object file carries the per-symbol section header that
 # readelf reads (the final static executable strips section headers). the build
-# asserts: g_lit64 -> 64 (literal), g_cmp16 -> 16 (comptime expr), g_cmp8 -> 8
-# (`$align_of(u64)`), g_plain -> 8 (default). the binary must also run, confirming
-# the over-aligned data is laid out correctly. readelf absent -> structural check
-# skipped, run still asserted.
+# asserts: g_lit64 -> 64 (literal), g_cmp16 -> 16 (comptime expr), g_plain -> 8
+# (default), g_over -> 32 (type-raised). the binary itself ALSO probes each over-
+# aligned global's address at runtime — an alignment-dependent check that holds
+# even when readelf is absent — exiting 27 only when every probe passes.
 #
 # usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -45,15 +45,16 @@ fi
 BIN="$WORK/app/out/linux/bin/aligndec"
 OBJ="$WORK/app/out/linux/obj/aligndec/main.o"
 
-# run: the over-aligned globals sum to 7 + 9 + 5 + 11 == 32.
+# run: the alignment probes pass (exit 27 = 7 + 9 + 11); a misaligned global
+# would exit 91/92/93 instead, naming which probe failed.
 set +e
 "$BIN"; code=$?
 set -e
-if [ "$code" -ne 32 ]; then
-    echo "FAIL aligndec: program ran with exit $code, expected 32" >&2
+if [ "$code" -ne 27 ]; then
+    echo "FAIL aligndec: program ran with exit $code, expected 27 (91/92/93 = a runtime misalignment)" >&2
     fail=1
 else
-    echo "PASS aligndec: the program with over-aligned globals runs correctly"
+    echo "PASS aligndec: the over-aligned globals are correctly aligned at runtime"
 fi
 
 # structural check: each global's section header alignment in the object file.
@@ -77,7 +78,6 @@ if command -v readelf >/dev/null 2>&1 && [ -f "$OBJ" ]; then
     }
     expect_align g_lit64 64
     expect_align g_cmp16 16
-    expect_align g_cmp8  8
     expect_align g_plain 8
     # a global of an `align(32)` record inherits the type's raised alignment.
     expect_align g_over  32

--- a/.github/tests/aligndec/run.sh
+++ b/.github/tests/aligndec/run.sh
@@ -79,6 +79,8 @@ if command -v readelf >/dev/null 2>&1 && [ -f "$OBJ" ]; then
     expect_align g_cmp16 16
     expect_align g_cmp8  8
     expect_align g_plain 8
+    # a global of an `align(32)` record inherits the type's raised alignment.
+    expect_align g_over  32
 else
     echo "INFO aligndec: readelf unavailable or object missing; skipping the alignment check"
 fi

--- a/.github/tests/aligndec/run.sh
+++ b/.github/tests/aligndec/run.sh
@@ -23,7 +23,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/asmcarry/run.sh
+++ b/.github/tests/asmcarry/run.sh
@@ -18,7 +18,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/asmclobber/run.sh
+++ b/.github/tests/asmclobber/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/asmcomment/run.sh
+++ b/.github/tests/asmcomment/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/asmlocal/run.sh
+++ b/.github/tests/asmlocal/run.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/cffi/run.sh
+++ b/.github/tests/cffi/run.sh
@@ -25,7 +25,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/comptimeroots/app/src/main.mach
+++ b/.github/tests/comptimeroots/app/src/main.mach
@@ -18,5 +18,9 @@ fun main(argc: i64, argv: **u8) i64 {
     if (!str_equals($project.target.os, "linux"))   { ret 7; }
     if (!str_equals($project.target.arch, "x86_64")) { ret 8; }
     if (!str_equals($project.target.abi, "sysv64"))  { ret 9; }
+    # the structured `$project.version.*` folds the declared "3.1.4"
+    $if ($project.version.major == 3) { } $or { ret 10; }
+    $if ($project.version.minor == 1) { } $or { ret 11; }
+    $if ($project.version.patch == 4) { } $or { ret 12; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/app/src/main.mach
+++ b/.github/tests/comptimeroots/app/src/main.mach
@@ -2,7 +2,9 @@ use std.runtime;
 use std.types.string.str_equals;
 
 # the `$project.*` / `$target.*` / `$bin.*` comptime roots (#1217) must fold to
-# this v2 manifest's declared values and the selected artifact's name. exits 0
+# this v2 manifest's declared values and the selected artifact's name. the new
+# `$project.target.{os,arch,abi}` spelling (#1471) folds to the same declared
+# tuple as the legacy `$target.*` (both resolve this release — additive). exits 0
 # only when every root matches; a mismatch returns the drifted root's id.
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
@@ -12,5 +14,9 @@ fun main(argc: i64, argv: **u8) i64 {
     if (!str_equals($target.isa, "x86_64"))     { ret 4; }
     if (!str_equals($target.abi, "sysv64"))     { ret 5; }
     if (!str_equals($bin.name, "roots"))        { ret 6; }
+    # the canonical `$project.target.*` spelling folds to the same tuple
+    if (!str_equals($project.target.os, "linux"))   { ret 7; }
+    if (!str_equals($project.target.arch, "x86_64")) { ret 8; }
+    if (!str_equals($project.target.abi, "sysv64"))  { ret 9; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/machabi/mach.toml
+++ b/.github/tests/comptimeroots/machabi/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id      = "machabi"
+name    = "Comptime $mach.abi.* namespace"
+version = "1.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.machabi]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.4.0"

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -16,7 +16,9 @@ fun main(argc: i64, argv: **u8) i64 {
     $if ($mach.abi.sysv == $mach.abi.win64)    { ret 4; }
     $if ($mach.abi.sysv == $mach.abi.aapcs64)  { ret 5; }
     $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 6; }
+    # the mode tags occupy distinct values
+    $if ($mach.mode.debug == $mach.mode.release) { ret 7; }
     # $mach.version is the canonical spelling of $mach.compiler.version
-    if (!str_equals($mach.version, $mach.compiler.version)) { ret 7; }
+    if (!str_equals($mach.version, $mach.compiler.version)) { ret 8; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -1,10 +1,11 @@
 use std.runtime;
+use std.types.string.str_equals;
 
-# the new `$mach.abi.*` tag table and the numeric `$mach.target.abi` (#1471)
-# fold in one numeric space. this app builds for native linux/x86_64 (sysv), so
-# `$mach.target.abi` folds to `$mach.abi.sysv`, and the three abi tags are
-# pairwise distinct. exits 0 only when every comptime fold matches; a mismatch
-# returns a distinct id.
+# the new `$mach.abi.*` tag table, the numeric `$mach.target.abi`, and the
+# `$mach.version` string (#1471). this app builds for native linux/x86_64
+# (sysv), so `$mach.target.abi` folds to `$mach.abi.sysv`, the three abi tags
+# are pairwise distinct, and `$mach.version` agrees with `$mach.compiler.version`.
+# exits 0 only when every comptime fold matches; a mismatch returns a distinct id.
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     # the active target's abi folds to the matching tag
@@ -13,5 +14,7 @@ fun main(argc: i64, argv: **u8) i64 {
     $if ($mach.abi.sysv == $mach.abi.win64)    { ret 2; }
     $if ($mach.abi.sysv == $mach.abi.aapcs64)  { ret 3; }
     $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 4; }
+    # $mach.version is the canonical spelling of $mach.compiler.version
+    if (!str_equals($mach.version, $mach.compiler.version)) { ret 5; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -18,7 +18,9 @@ fun main(argc: i64, argv: **u8) i64 {
     $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 6; }
     # the mode tags occupy distinct values
     $if ($mach.mode.debug == $mach.mode.release) { ret 7; }
+    # the active build mode folds to debug for this default (no -O/--release) build
+    $if ($mach.build.mode == $mach.mode.debug) { } $or { ret 8; }
     # $mach.version is the canonical spelling of $mach.compiler.version
-    if (!str_equals($mach.version, $mach.compiler.version)) { ret 8; }
+    if (!str_equals($mach.version, $mach.compiler.version)) { ret 9; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -1,20 +1,22 @@
 use std.runtime;
 use std.types.string.str_equals;
 
-# the new `$mach.abi.*` tag table, the numeric `$mach.target.abi`, and the
-# `$mach.version` string (#1471). this app builds for native linux/x86_64
-# (sysv), so `$mach.target.abi` folds to `$mach.abi.sysv`, the three abi tags
-# are pairwise distinct, and `$mach.version` agrees with `$mach.compiler.version`.
+# the new `$mach.abi.*` tag table and the canonical resolved-build facts
+# `$mach.build.{os,arch,abi}` (#1471). this app builds for native linux/x86_64
+# (sysv), so the build facts fold to the matching tags, the three abi tags are
+# pairwise distinct, and `$mach.version` agrees with `$mach.compiler.version`.
 # exits 0 only when every comptime fold matches; a mismatch returns a distinct id.
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
-    # the active target's abi folds to the matching tag
-    $if ($mach.target.abi == $mach.abi.sysv) { } $or { ret 1; }
+    # the resolved active build's facts fold to the matching tags
+    $if ($mach.build.abi == $mach.abi.sysv)     { } $or { ret 1; }
+    $if ($mach.build.os == $mach.os.linux)      { } $or { ret 2; }
+    $if ($mach.build.arch == $mach.arch.x86_64) { } $or { ret 3; }
     # the abi tags occupy distinct values
-    $if ($mach.abi.sysv == $mach.abi.win64)    { ret 2; }
-    $if ($mach.abi.sysv == $mach.abi.aapcs64)  { ret 3; }
-    $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 4; }
+    $if ($mach.abi.sysv == $mach.abi.win64)    { ret 4; }
+    $if ($mach.abi.sysv == $mach.abi.aapcs64)  { ret 5; }
+    $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 6; }
     # $mach.version is the canonical spelling of $mach.compiler.version
-    if (!str_equals($mach.version, $mach.compiler.version)) { ret 5; }
+    if (!str_equals($mach.version, $mach.compiler.version)) { ret 7; }
     ret 0;
 }

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -1,0 +1,17 @@
+use std.runtime;
+
+# the new `$mach.abi.*` tag table and the numeric `$mach.target.abi` (#1471)
+# fold in one numeric space. this app builds for native linux/x86_64 (sysv), so
+# `$mach.target.abi` folds to `$mach.abi.sysv`, and the three abi tags are
+# pairwise distinct. exits 0 only when every comptime fold matches; a mismatch
+# returns a distinct id.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # the active target's abi folds to the matching tag
+    $if ($mach.target.abi == $mach.abi.sysv) { } $or { ret 1; }
+    # the abi tags occupy distinct values
+    $if ($mach.abi.sysv == $mach.abi.win64)    { ret 2; }
+    $if ($mach.abi.sysv == $mach.abi.aapcs64)  { ret 3; }
+    $if ($mach.abi.win64 == $mach.abi.aapcs64) { ret 4; }
+    ret 0;
+}

--- a/.github/tests/comptimeroots/run.sh
+++ b/.github/tests/comptimeroots/run.sh
@@ -29,7 +29,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/comptimeroots/run.sh
+++ b/.github/tests/comptimeroots/run.sh
@@ -83,8 +83,9 @@ expect_reject() {
     echo "PASS comptimeroots/$label: bare \$ident rejected with the teaching diagnostic"
 }
 
-build_and_run app    "manifest with profiles"
-build_and_run altapp "alternate declared values"
+build_and_run app     "manifest with profiles"
+build_and_run altapp  "alternate declared values"
+build_and_run machabi "\$mach.abi tag namespace"
 
 expect_reject bareident_gate  "bare \$ident gate"  "$BARE_IDENT_DIAG"
 expect_reject bareident_value "bare \$ident value" "$BARE_IDENT_DIAG"

--- a/.github/tests/ctcmp/run.sh
+++ b/.github/tests/ctcmp/run.sh
@@ -18,7 +18,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/decarg/branch/mach.toml
+++ b/.github/tests/decarg/branch/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "decbranch"
+name = "Decorator-Arg Resolution Test — $if branch"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.decbranch]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/decarg/branch/src/main.mach
+++ b/.github/tests/decarg/branch/src/main.mach
@@ -1,0 +1,16 @@
+use std.runtime.linux.x86_64;
+
+# a decl inside a TAKEN `$if (...)` decl-scope branch is collected and bound like
+# any top-level decl (bind_comptime_if -> bind_decl_list -> bind_decorator_args),
+# so its decorator args are resolved too. an unresolved identifier in the in-branch
+# decorator must surface the same name-resolution error — proving the resolver
+# descends into comptime decl branches and validates the decorators it finds.
+val FLAG: i64 = 1;
+
+$if (FLAG == 1) {
+    `section(NoSuchThing)`
+    pub var g_in_if: u64 = 7;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/decarg/run.sh
+++ b/.github/tests/decarg/run.sh
@@ -21,7 +21,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/decarg/run.sh
+++ b/.github/tests/decarg/run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# decorator-argument resolution test (#1491, fast-follow #1476): bind_decorator_args
+# (resolve.mach) walks the comptime expression in each backtick decorator, so an
+# unresolved identifier there must surface a name-resolution error rather than be
+# silently dropped. two placements are covered:
+#   unresolved — a top-level decl whose decorator names an undeclared identifier.
+#   branch     — the same, on a decl inside a TAKEN `$if (...)` decl-scope branch,
+#                proving the resolver descends into comptime decl branches and binds
+#                the decorators it finds there.
+# each build must FAIL with a located `unresolved identifier` naming the offender.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# vendor <app-dir>: copy the app into the temp dir and symlink the vendored std.
+vendor() {
+    local app="$1" dst="$WORK/$1"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+}
+
+# expect_unresolved <app-dir> <name>: build the app and require it to FAIL with a
+# diagnostic that reports <name> as an `unresolved identifier`, located on main.mach.
+expect_unresolved() {
+    local app="$1" name="$2" out dst="$WORK/$1"
+    vendor "$app"
+    if out="$( cd "$dst" && "$MACH" build . 2>&1 )"; then
+        echo "FAIL decarg/$app: build unexpectedly succeeded (the decorator arg was not resolved)" >&2
+        fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF "unresolved identifier"; then
+        echo "FAIL decarg/$app: diagnostic missing 'unresolved identifier'; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF "$name"; then
+        echo "FAIL decarg/$app: diagnostic did not name '$name'; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qE 'main\.mach:[0-9]+:[0-9]+:'; then
+        echo "FAIL decarg/$app: diagnostic missing file:line:col; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    echo "PASS decarg/$app: an unresolved decorator-arg identifier is a located name-resolution error"
+}
+
+expect_unresolved unresolved NoSuchThing
+expect_unresolved branch     NoSuchThing
+
+exit "$fail"

--- a/.github/tests/decarg/unresolved/mach.toml
+++ b/.github/tests/decarg/unresolved/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "decunres"
+name = "Decorator-Arg Resolution Test — Unresolved"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.decunres]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/decarg/unresolved/src/main.mach
+++ b/.github/tests/decarg/unresolved/src/main.mach
@@ -1,0 +1,10 @@
+use std.runtime.linux.x86_64;
+
+# a backtick decorator's argument is a comptime expression whose identifiers are
+# resolved by bind_decorator_args (resolve.mach). an unresolved identifier there
+# must surface a name-resolution error — proving the args are walked, not ignored.
+`align(NoSuchThing)`
+rec R { a: u8; }
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/decorator/app/mach.toml
+++ b/.github/tests/decorator/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "decapp"
+name = "Decorator Link Test — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.decapp]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/decorator/app/src/main.mach
+++ b/.github/tests/decorator/app/src/main.mach
@@ -1,0 +1,12 @@
+use std.runtime.linux.x86_64;
+
+# bound at link time against the external object's `mach_dec_add` definition.
+ext fun mach_dec_add(a: i64, b: i64) i64;
+
+# the runtime entry references `main` by its literal link name; the `symbol`
+# decorator pins it, exactly as the legacy `$main.symbol = "main"` setter did.
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    # 20 + 21 + 1 == 42; the body lives in the external object, not the graph.
+    ret mach_dec_add(20, 21);
+}

--- a/.github/tests/decorator/extlib/mach.toml
+++ b/.github/tests/decorator/extlib/mach.toml
@@ -1,0 +1,17 @@
+[project]
+id = "declib"
+name = "Decorator Link Test — Library"
+version = "0.0.0"
+src = "src"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[lib.declib]
+entry = "ext.mach"
+kind  = "static"

--- a/.github/tests/decorator/extlib/src/ext.mach
+++ b/.github/tests/decorator/extlib/src/ext.mach
@@ -1,0 +1,7 @@
+# external library compiled to a loose `.o`: exports `mach_dec_add` under a
+# literal link name set by a `symbol` decorator (the 1:1 replacement for the
+# legacy `$<sym>.symbol` setter), so a consumer can bind to it via an `ext fun`.
+`symbol("mach_dec_add")`
+pub fun mach_dec_add(a: i64, b: i64) i64 {
+    ret a + b + 1;
+}

--- a/.github/tests/decorator/run.sh
+++ b/.github/tests/decorator/run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# decorator integration test (#1476): prove a `symbol` backtick decorator drives
+# the emitted link name, the 1:1 replacement for the legacy `$<sym>.symbol`
+# setter.
+#
+# builds a tiny library (`declib`) to a loose object whose `pub fun mach_dec_add`
+# carries a `` `symbol("mach_dec_add")` `` decorator, then links a consumer
+# (`app`) — which declares that symbol `ext` and whose `main` carries a
+# `` `symbol("main")` `` decorator — against the object. the program returns
+# `mach_dec_add(20, 21)` which must be 42. if the decorator did not route the
+# link name, the library symbol would be mangled and the `ext` reference would
+# not resolve, failing the link — so a clean 42 proves emission followed the
+# decorator. a build with no external input must fail on the undefined symbol.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/extlib" "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# build the external library object.
+( cd "$WORK/extlib" && "$MACH" build . )
+OBJ="$WORK/extlib/out/linux/obj/declib/ext.o"
+test -f "$OBJ" || { echo "error: library object not produced at $OBJ" >&2; exit 1; }
+
+fail=0
+
+# explicit object path: link the consumer against the decorator-named symbol.
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . "$OBJ" ) >/dev/null 2>&1; then
+    echo "FAIL decorator: symbol decorator link — build failed" >&2
+    fail=1
+else
+    set +e
+    "$WORK/app/out/linux/bin/decapp"
+    code=$?
+    set -e
+    if [ "$code" -ne 42 ]; then
+        echo "FAIL decorator: symbol decorator link — ran with exit $code, expected 42" >&2
+        fail=1
+    else
+        echo "PASS decorator: symbol decorator drives the emitted link name"
+    fi
+fi
+
+# no external input: the undefined symbol must make the link fail, proving the
+# definition comes from the linked object, not the graph.
+rm -rf "$WORK/app/out"
+if ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL decorator: missing input did not fail the link" >&2
+    fail=1
+else
+    echo "PASS decorator: missing external input fails the link"
+fi
+
+exit "$fail"

--- a/.github/tests/decorator/run.sh
+++ b/.github/tests/decorator/run.sh
@@ -24,7 +24,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/diaglocate/run.sh
+++ b/.github/tests/diaglocate/run.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/dlllib/run.sh
+++ b/.github/tests/dlllib/run.sh
@@ -40,7 +40,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/dlllibdec/app/mach.toml
+++ b/.github/tests/dlllibdec/app/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id      = "dlllibdec"
+name    = "per-symbol windows DLL attribution via decorators — App"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "windows"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+ext  = ".exe"
+libs = ["kernel32.dll", "ws2_32.dll", "advapi32.dll"]
+
+[bin.dlllibdec]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/dlllibdec/app/src/main.mach
+++ b/.github/tests/dlllibdec/app/src/main.mach
@@ -1,0 +1,44 @@
+# dlllibdec integration app (#1476): the decorator-spelled twin of the dlllib
+# test. per-symbol windows DLL attribution expressed with backtick decorators
+# rather than the legacy `$<sym>.library` / `$<sym>.symbol` setters — the two
+# must produce identical PE import attribution. imports spread across
+# kernel32.dll, ws2_32.dll and advapi32.dll; advapi32 is deliberately the
+# trailing descriptor and is called, exercising the last-descriptor call thunk.
+
+use std.runtime;
+
+# `symbol` rename only: the mach identifier `sleep_ms` links as `Sleep`, an
+# unattributed import that falls back to kernel32.dll (the first dependency).
+`symbol("Sleep")`
+ext fun sleep_ms(ms: u32);
+
+# `library` only, bare name: pinned to ws2_32.dll, linked as `WSAStartup`.
+`library("ws2_32.dll")`
+ext fun WSAStartup(ver: u16, data: *u8) i32;
+
+# both directives on one decl: `ws2_cleanup` is renamed to `WSACleanup` and
+# pinned to ws2_32.dll — the rename and the library pin compose.
+`library("ws2_32.dll")` `symbol("WSACleanup")`
+ext fun ws2_cleanup() i32;
+
+# the trailing descriptor: `rng_fill` is renamed to `SystemFunction036`
+# (RtlGenRandom) and pinned to advapi32.dll, exercising the last-descriptor thunk.
+`library("advapi32.dll")` `symbol("SystemFunction036")`
+ext fun rng_fill(buf: *u8, len: u32) u8;
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    var wsadata: [512]u8;
+    sleep_ms(0);
+    if (WSAStartup(0x0202::u16, ?wsadata[0]) != 0) { ret 1; }
+    if (ws2_cleanup() != 0) { ret 2; }
+    var rnd: [32]u8;
+    var k: u64 = 0;
+    for (k < 32) { rnd[k] = 0; k = k + 1; }
+    if (rng_fill(?rnd[0], 32) == 0) { ret 3; }
+    var nz: u8 = 0;
+    k = 0;
+    for (k < 32) { nz = nz | rnd[k]; k = k + 1; }
+    if (nz == 0) { ret 4; }
+    ret 0;
+}

--- a/.github/tests/dlllibdec/run.sh
+++ b/.github/tests/dlllibdec/run.sh
@@ -22,7 +22,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/dlllibdec/run.sh
+++ b/.github/tests/dlllibdec/run.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# dlllibdec integration test (#1476): the decorator-spelled twin of dlllib —
+# prove `library(...)` / `symbol(...)` backtick decorators drive per-symbol
+# windows DLL attribution identically to the legacy `$<sym>.library` /
+# `$<sym>.symbol` setters. the acceptance-criteria case: a windows extern with
+# `` `library("ws2_32.dll")` `` + `` `symbol("...")` `` importing correctly.
+#
+# builds the windows binary, reads its PE import directory, and asserts each
+# renamed symbol lands under the decorator-named DLL (and the mach identifiers do
+# not leak), runs it under wine, and confirms a `library` naming an undeclared
+# DLL fails the link.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+APP="$WORK/app"
+
+fail=0
+
+# build the windows binary (the app's manifest targets windows).
+if ! ( cd "$APP" && "$MACH" build . ) >"$WORK/build.out" 2>&1; then
+    echo "FAIL dlllibdec: windows build failed" >&2
+    cat "$WORK/build.out" >&2
+    exit 1
+fi
+EXE="$APP/out/windows/bin/dlllibdec.exe"
+test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
+
+# imports_under <dll> — the member names imported from <dll>, one per line, read
+# from the emitted PE's import directory by whichever inspector is available.
+imports_under() {
+    case "$INSPECT" in
+    objdump)
+        objdump -x "$EXE" 2>/dev/null | awk -v dll="$1" '
+            /DLL Name:/      { cur=$3; next }
+            /^[[:space:]]*$/ { cur=""; next }
+            cur=="" || cur!=dll { next }
+            /Member-Name/    { next }
+            { print $NF }'
+        ;;
+    llvm-readobj)
+        llvm-readobj --coff-imports "$EXE" 2>/dev/null | awk -v dll="$1" '
+            $1=="Name:"   { cur=($2==dll); next }
+            cur && $1=="Symbol:" { print $2 }'
+        ;;
+    esac
+}
+
+# pick a PE import inspector: prefer binutils objdump (present on ubuntu with
+# pei support), fall back to llvm-readobj, and skip the structural half when
+# neither can read the import directory rather than failing spuriously.
+INSPECT=""
+if command -v objdump >/dev/null 2>&1 && objdump -x "$EXE" 2>/dev/null | grep -q "The Import Tables"; then
+    INSPECT="objdump"
+elif command -v llvm-readobj >/dev/null 2>&1; then
+    INSPECT="llvm-readobj"
+fi
+
+if [ -n "$INSPECT" ]; then
+    k32="$(imports_under kernel32.dll)"
+    ws2="$(imports_under ws2_32.dll)"
+    adv="$(imports_under advapi32.dll)"
+
+    has() {
+        if printf '%s\n' "$2" | grep -qx "$1"; then
+            echo "PASS dlllibdec: '$1' imported under $3"
+        else
+            echo "FAIL dlllibdec: '$1' not imported under $3" >&2
+            fail=1
+        fi
+    }
+    lacks() {
+        if printf '%s\n' "$2" | grep -qx "$1"; then
+            echo "FAIL dlllibdec: unrenamed identifier '$1' leaked into the imports of $3" >&2
+            fail=1
+        fi
+    }
+
+    has Sleep             "$k32" kernel32.dll   # `symbol` rename, default attribution
+    has WSAStartup        "$ws2" ws2_32.dll     # `library` pin, bare name
+    has WSACleanup        "$ws2" ws2_32.dll     # `library` + `symbol` on one decl
+    has SystemFunction036 "$adv" advapi32.dll   # trailing descriptor, pinned
+    lacks WSAStartup        "$k32" kernel32.dll
+    lacks WSACleanup        "$k32" kernel32.dll
+    lacks SystemFunction036 "$k32" kernel32.dll
+    lacks sleep_ms    "$k32" kernel32.dll
+    lacks ws2_cleanup "$ws2" ws2_32.dll
+    lacks rng_fill    "$adv" advapi32.dll
+else
+    echo "INFO dlllibdec: no PE import inspector (objdump/llvm-readobj); skipping the structural check"
+fi
+
+# behavioral: run under wine. the winsock and trailing advapi32 calls resolve
+# only through correct decorator-driven attribution; a clean exit proves it.
+if command -v wine >/dev/null 2>&1; then
+    if WINEDEBUG=-all wine "$EXE" >"$WORK/wine.out" 2>&1; then
+        echo "PASS dlllibdec: decorator-attributed imports resolve under wine"
+    else
+        echo "FAIL dlllibdec: program aborted under wine (mis-attribution?)" >&2
+        cat "$WORK/wine.out" >&2
+        fail=1
+    fi
+else
+    echo "SKIP dlllibdec: 'wine' not available for the behavioral check"
+fi
+
+# negative: a `library` decorator naming a DLL absent from the dependencies must
+# fail the link. derive the error app from the real source so it can't drift.
+ERR="$WORK/errapp"
+cp -r "$HERE/app" "$ERR"
+mkdir -p "$ERR/dep"
+ln -s "$STD" "$ERR/dep/mach-std"
+sed 's/"ws2_32.dll"/"nope_not_declared.dll"/' "$HERE/app/src/main.mach" >"$ERR/src/main.mach"
+if ( cd "$ERR" && "$MACH" build . ) >"$WORK/err.out" 2>&1; then
+    echo "FAIL dlllibdec: a build pinned to an undeclared library should have failed" >&2
+    fail=1
+elif grep -q "not among the link's dependencies" "$WORK/err.out"; then
+    echo "PASS dlllibdec: a library decorator naming an undeclared DLL fails the link"
+else
+    echo "FAIL dlllibdec: undeclared library decorator failed for the wrong reason" >&2
+    cat "$WORK/err.out" >&2
+    fail=1
+fi
+
+exit "$fail"

--- a/.github/tests/dynlink/run.sh
+++ b/.github/tests/dynlink/run.sh
@@ -23,7 +23,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/eachfields/app/mach.toml
+++ b/.github/tests/eachfields/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "eachfields"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.eachfields]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -42,6 +42,17 @@ fun noop(e: Empty) i64 {
     ret n;
 }
 
+# nested $each: a cross-product of every field pair, two projections deep.
+fun cross(p: Pair, q: Pair) i64 {
+    var t: i64 = 0;
+    $each f in $fields(Pair) {
+        $each g in $fields(Pair) {
+            t = t + p.[f] * q.[g];
+        }
+    }
+    ret t;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     var p: Pair = Pair { x: 3, y: 4 };
@@ -54,5 +65,9 @@ fun main(argc: i64, argv: **u8) i64 {
 
     var e: Empty = Empty { };
     if (noop(e) != 0) { ret 4; }
+
+    var u: Pair = Pair { x: 1, y: 2 };
+    var w: Pair = Pair { x: 3, y: 4 };
+    if (cross(u, w) != 21) { ret 5; }
     ret 0;
 }

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -63,6 +63,24 @@ fun offsum(m: Mixed) i64 {
     ret s;
 }
 
+# f.type descriptor read in a type comparison: count i64 fields via
+# `$if (f.type == i64)`, reusing the #1472 type `==`.
+fun count_i64(m: Mixed) i64 {
+    var n: i64 = 0;
+    $each f in $fields(Mixed) {
+        $if (f.type == i64) { n = n + 1; } $or { }
+    }
+    ret n;
+}
+
+# a real record field named `type` must stay an ordinary field access, never a
+# descriptor projection (the disambiguation keys on the `$each` loop variable).
+rec HasType { type: i64; other: i64; }
+fun field_named_type(h: HasType) i64 {
+    if (h.type == 7) { ret 1; }
+    ret 0;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     var p: Pair = Pair { x: 3, y: 4 };
@@ -83,5 +101,11 @@ fun main(argc: i64, argv: **u8) i64 {
     # Mixed is { a: i64 @0, b: u8 @8 } -> offsets sum to 8
     var m2: Mixed = Mixed { a: 0, b: 0 };
     if (offsum(m2) != 8) { ret 6; }
+
+    # Mixed has one i64 field (a); b is u8
+    if (count_i64(m2) != 1) { ret 7; }
+    # a real field named `type` is untouched by the descriptor machinery
+    var h: HasType = HasType { type: 7, other: 0 };
+    if (field_named_type(h) != 1) { ret 8; }
     ret 0;
 }

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -1,4 +1,5 @@
 use std.runtime;
+use std.types.string.str_equals;
 
 # `$each f in $fields(T) { ... v.[f] ... }` unrolls at compile time, once per
 # field of T, binding `f` to that field's descriptor so `v.[f]` projects the
@@ -81,6 +82,16 @@ fun field_named_type(h: HasType) i64 {
     ret 0;
 }
 
+# f.name descriptor read: the field's name as a runtime string. count fields
+# whose name equals "a".
+fun count_named_a(m: Mixed) i64 {
+    var n: i64 = 0;
+    $each f in $fields(Mixed) {
+        if (str_equals(f.name, "a")) { n = n + 1; }
+    }
+    ret n;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     var p: Pair = Pair { x: 3, y: 4 };
@@ -107,5 +118,7 @@ fun main(argc: i64, argv: **u8) i64 {
     # a real field named `type` is untouched by the descriptor machinery
     var h: HasType = HasType { type: 7, other: 0 };
     if (field_named_type(h) != 1) { ret 8; }
+    # f.name: Mixed has exactly one field named "a"
+    if (count_named_a(m2) != 1) { ret 9; }
     ret 0;
 }

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -53,6 +53,16 @@ fun cross(p: Pair, q: Pair) i64 {
     ret t;
 }
 
+# f.offset descriptor read: each field's byte offset in the target layout, folded
+# per iteration as a comptime usize.
+fun offsum(m: Mixed) i64 {
+    var s: i64 = 0;
+    $each f in $fields(Mixed) {
+        s = s + f.offset::i64;
+    }
+    ret s;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     var p: Pair = Pair { x: 3, y: 4 };
@@ -69,5 +79,9 @@ fun main(argc: i64, argv: **u8) i64 {
     var u: Pair = Pair { x: 1, y: 2 };
     var w: Pair = Pair { x: 3, y: 4 };
     if (cross(u, w) != 21) { ret 5; }
+
+    # Mixed is { a: i64 @0, b: u8 @8 } -> offsets sum to 8
+    var m2: Mixed = Mixed { a: 0, b: 0 };
+    if (offsum(m2) != 8) { ret 6; }
     ret 0;
 }

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -1,0 +1,58 @@
+use std.runtime;
+
+# `$each f in $fields(T) { ... v.[f] ... }` unrolls at compile time, once per
+# field of T, binding `f` to that field's descriptor so `v.[f]` projects the
+# concrete field (#1473). exits 0 only when every splice computes the value its
+# field layout dictates; a wrong result returns that check's id.
+rec Pair  { x: i64; y: i64; }
+rec Mixed { a: i64; b: u8; }
+rec Empty { }
+
+# homogeneous: sum every field via v.[f] (rvalue projection).
+fun sum(p: Pair) i64 {
+    var total: i64 = 0;
+    $each f in $fields(Pair) {
+        total = total + p.[f];
+    }
+    ret total;
+}
+
+# heterogeneous: each iteration re-types v.[f] to the concrete field's type.
+fun total(m: Mixed) i64 {
+    var t: i64 = 0;
+    $each f in $fields(Mixed) {
+        t = t + m.[f]::i64;
+    }
+    ret t;
+}
+
+# v.[f] as a write lvalue, through a pointer receiver (auto-deref).
+fun zero(m: *Mixed) {
+    $each f in $fields(Mixed) {
+        m.[f] = 0;
+    }
+}
+
+# an empty record's $fields expands to nothing.
+fun noop(e: Empty) i64 {
+    var n: i64 = 0;
+    $each f in $fields(Empty) {
+        n = n + 1;
+    }
+    ret n;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    var p: Pair = Pair { x: 3, y: 4 };
+    if (sum(p) != 7) { ret 1; }
+
+    var m: Mixed = Mixed { a: 100, b: 5 };
+    if (total(m) != 105) { ret 2; }
+    zero(?m);
+    if (total(m) != 0) { ret 3; }
+
+    var e: Empty = Empty { };
+    if (noop(e) != 0) { ret 4; }
+    ret 0;
+}

--- a/.github/tests/eachfields/run.sh
+++ b/.github/tests/eachfields/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# $each / $fields / v.[f] expansion integration test (#1473).
+#
+# `$each f in $fields(T) { ... v.[f] ... }` unrolls at compile time, once per
+# field of T, binding `f` to that field's descriptor so `v.[f]` projects the
+# concrete field. the app asserts the splice computes correct values for a
+# homogeneous record (rvalue projection), a heterogeneous record (per-iteration
+# typing), a pointer-receiver write (v.[f] lvalue), and an empty record (no
+# expansion); it exits 0 only when all pass, returning the failed check's id
+# otherwise. end-to-end proof that the sema + lowering unroll splice agree.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL eachfields: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/eachfields"
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL eachfields: check $code computed the wrong value" >&2
+    exit 1
+fi
+echo "PASS eachfields: \$each over \$fields projects v.[f] correctly"

--- a/.github/tests/eachfields/run.sh
+++ b/.github/tests/eachfields/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/envfwd/run.sh
+++ b/.github/tests/envfwd/run.sh
@@ -15,7 +15,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/extlink/run.sh
+++ b/.github/tests/extlink/run.sh
@@ -24,7 +24,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/fconv/run.sh
+++ b/.github/tests/fconv/run.sh
@@ -17,7 +17,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/floatrem/run.sh
+++ b/.github/tests/floatrem/run.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/fpargs/run.sh
+++ b/.github/tests/fpargs/run.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/fwdreexport/run.sh
+++ b/.github/tests/fwdreexport/run.sh
@@ -21,7 +21,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/globalmember/run.sh
+++ b/.github/tests/globalmember/run.sh
@@ -27,7 +27,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/inline/app/mach.toml
+++ b/.github/tests/inline/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "inldec"
+name = "Inline Decorator Test — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+asm = "out/{target}/asm"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.inldec]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/inline/app/src/main.mach
+++ b/.github/tests/inline/app/src/main.mach
@@ -2,9 +2,12 @@ use std.runtime.linux.x86_64;
 
 # `big` exceeds the inline pass's instruction threshold and is called from two
 # sites, so the size and single-use heuristics both decline to inline it — only
-# the `inline` decorator (which sets FN_FLAG_INLINE) forces it. the run.sh
-# control confirms the calls survive when the decorator is removed.
+# the `inline` decorator (which sets FN_FLAG_INLINE) forces it. the `symbol`
+# decorator pins its link name so the call-site grep matches a stable mnemonic
+# (`call big`) rather than a mangled internal name. the run.sh control confirms
+# the calls survive when the `inline` decorator alone is removed.
 `inline`
+`symbol("big")`
 fun big(a: i64, b: i64) i64 {
     var x: i64 = a + b;
     x = x + a; x = x - b; x = x * 2; x = x + 3;
@@ -18,8 +21,12 @@ fun big(a: i64, b: i64) i64 {
 
 `symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
-    val p: i64 = big(1, 2);
+    # feed `big` a runtime value (argc) so the optimizer can't constant-fold the
+    # calls away, and RETURN the result so they can't be dead-code-eliminated as
+    # dead pure calls — the control build's "call survives" signal depends on the
+    # result being consumed. run with no arguments argc == 1, so big(big(1,2),3)
+    # is deterministic; its low byte is the exit code 204.
+    val p: i64 = big(argc, 2);
     val q: i64 = big(p, 3);
-    # the result is discarded; the test asserts on emission, not the value.
-    ret q - q + 42;
+    ret q;
 }

--- a/.github/tests/inline/app/src/main.mach
+++ b/.github/tests/inline/app/src/main.mach
@@ -1,0 +1,25 @@
+use std.runtime.linux.x86_64;
+
+# `big` exceeds the inline pass's instruction threshold and is called from two
+# sites, so the size and single-use heuristics both decline to inline it — only
+# the `inline` decorator (which sets FN_FLAG_INLINE) forces it. the run.sh
+# control confirms the calls survive when the decorator is removed.
+`inline`
+fun big(a: i64, b: i64) i64 {
+    var x: i64 = a + b;
+    x = x + a; x = x - b; x = x * 2; x = x + 3;
+    x = x + a; x = x - b; x = x * 2; x = x + 4;
+    x = x + a; x = x - b; x = x * 2; x = x + 5;
+    x = x + a; x = x - b; x = x * 2; x = x + 6;
+    x = x + a; x = x - b; x = x * 2; x = x + 7;
+    x = x + a; x = x - b; x = x * 2; x = x + 8;
+    ret x;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    val p: i64 = big(1, 2);
+    val q: i64 = big(p, 3);
+    # the result is discarded; the test asserts on emission, not the value.
+    ret q - q + 42;
+}

--- a/.github/tests/inline/run.sh
+++ b/.github/tests/inline/run.sh
@@ -26,7 +26,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/inline/run.sh
+++ b/.github/tests/inline/run.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# inline decorator integration test (#1476): prove an `inline` backtick decorator
+# forces inlining of a function the cost model would otherwise leave alone.
+#
+# `big` exceeds the inline pass's instruction threshold and is called from two
+# sites, so neither the size nor the single-use heuristic inlines it — only
+# FN_FLAG_INLINE does. building at -O2 with `--emit-asm`, the decorated build
+# must contain NO call to `big` in the caller's assembly (fully inlined), while a
+# control build with the decorator stripped must still call it. the binary must
+# also run, confirming the inlined code is correct.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+fail=0
+
+# count_big_calls — number of `call` instructions targeting `big` in the app's
+# emitted assembly (across whatever path the asm artifact lands under).
+count_big_calls() {
+    local n=0 f
+    while IFS= read -r f; do
+        n=$(( n + $(grep -cE 'call[[:space:]].*big' "$f" || true) ))
+    done < <(find "$WORK/app/out" -name 'main.s')
+    echo "$n"
+}
+
+# decorated build: `big` must be fully inlined (no surviving call).
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . --emit-asm -O2 ) >/dev/null 2>&1; then
+    echo "FAIL inline: decorated build failed" >&2
+    fail=1
+else
+    calls=$(count_big_calls)
+    if [ "$calls" -ne 0 ]; then
+        echo "FAIL inline: 'inline' decorator did not inline 'big' ($calls call(s) remain)" >&2
+        fail=1
+    else
+        echo "PASS inline: 'inline' decorator forces inlining at -O2"
+    fi
+    set +e
+    "$WORK/app/out/linux/bin/inldec"
+    code=$?
+    set -e
+    if [ "$code" -ne 42 ]; then
+        echo "FAIL inline: inlined program ran with exit $code, expected 42" >&2
+        fail=1
+    else
+        echo "PASS inline: the inlined program runs correctly"
+    fi
+fi
+
+# control: strip the decorator; the cost model must now leave the calls in place,
+# proving the decorator — not the heuristic — is what inlined `big`.
+sed '/`inline`/d' "$HERE/app/src/main.mach" > "$WORK/app/src/main.mach"
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . --emit-asm -O2 ) >/dev/null 2>&1; then
+    echo "FAIL inline: control build failed" >&2
+    fail=1
+else
+    calls=$(count_big_calls)
+    if [ "$calls" -lt 1 ]; then
+        echo "FAIL inline: control inlined 'big' without the decorator — test no longer isolates the hint" >&2
+        fail=1
+    else
+        echo "PASS inline: without the decorator 'big' is left out of line"
+    fi
+fi
+
+exit "$fail"

--- a/.github/tests/inline/run.sh
+++ b/.github/tests/inline/run.sh
@@ -6,8 +6,13 @@
 # sites, so neither the size nor the single-use heuristic inlines it — only
 # FN_FLAG_INLINE does. building at -O2 with `--emit-asm`, the decorated build
 # must contain NO call to `big` in the caller's assembly (fully inlined), while a
-# control build with the decorator stripped must still call it. the binary must
-# also run, confirming the inlined code is correct.
+# control build with the `inline` decorator stripped must still call it.
+#
+# `big` is fed a runtime value and its result is returned, so the calls can't be
+# constant-folded or dead-code-eliminated — without that the control's surviving-
+# call signal would be a no-op. its link name is pinned with `symbol`, so the
+# `call big` grep matches a stable mnemonic. run with no arguments the program is
+# deterministic: exit 204 (the low byte of big(big(1,2),3)).
 #
 # usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -61,16 +66,17 @@ else
     "$WORK/app/out/linux/bin/inldec"
     code=$?
     set -e
-    if [ "$code" -ne 42 ]; then
-        echo "FAIL inline: inlined program ran with exit $code, expected 42" >&2
+    if [ "$code" -ne 204 ]; then
+        echo "FAIL inline: inlined program ran with exit $code, expected 204" >&2
         fail=1
     else
         echo "PASS inline: the inlined program runs correctly"
     fi
 fi
 
-# control: strip the decorator; the cost model must now leave the calls in place,
-# proving the decorator — not the heuristic — is what inlined `big`.
+# control: strip the `inline` decorator; the cost model must now leave the calls
+# in place, proving the decorator — not the heuristic — is what inlined `big`.
+# the `symbol("big")` pin is on its own line and survives, so `big` keeps its name.
 sed '/`inline`/d' "$HERE/app/src/main.mach" > "$WORK/app/src/main.mach"
 rm -rf "$WORK/app/out"
 if ! ( cd "$WORK/app" && "$MACH" build . --emit-asm -O2 ) >/dev/null 2>&1; then

--- a/.github/tests/kwident/run.sh
+++ b/.github/tests/kwident/run.sh
@@ -18,7 +18,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/literalboundary/run.sh
+++ b/.github/tests/literalboundary/run.sh
@@ -15,7 +15,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/lower-testrunner/run.sh
+++ b/.github/tests/lower-testrunner/run.sh
@@ -24,7 +24,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/lower/run.sh
+++ b/.github/tests/lower/run.sh
@@ -24,7 +24,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/manifest/run.sh
+++ b/.github/tests/manifest/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/mixedcmp/run.sh
+++ b/.github/tests/mixedcmp/run.sh
@@ -18,7 +18,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/module/run.sh
+++ b/.github/tests/module/run.sh
@@ -17,7 +17,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/nilfun/run.sh
+++ b/.github/tests/nilfun/run.sh
@@ -27,7 +27,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/opt/run.sh
+++ b/.github/tests/opt/run.sh
@@ -21,7 +21,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/packfwd/app/mach.toml
+++ b/.github/tests/packfwd/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "packfwd"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.packfwd]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/packfwd/app/src/main.mach
+++ b/.github/tests/packfwd/app/src/main.mach
@@ -1,0 +1,39 @@
+use std.runtime;
+
+# va... forward (#1475): inside a pack instance, `g(va...)` threads the
+# instance's concrete pack parameters through to another pack-tailed callee,
+# monomorphized for the forwarded type-list. exits 0 when every forward
+# delivers the right elements; a wrong result returns that check's id.
+
+fun sum(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + a;
+    }
+    ret t;
+}
+
+# outer: a pack-tailed function that forwards its whole pack to sum.
+fun outer(va: ...) i64 {
+    ret sum(va...);
+}
+
+# fwdpre: a leading fixed param, then forward the pack.
+fun fwdpre(base: i64, va: ...) i64 {
+    ret base + sum(va...);
+}
+
+# outer2: forward-of-forward — two levels of pack threading.
+fun outer2(va: ...) i64 {
+    ret outer(va...);
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    if (outer(1, 2, 3) != 6)         { ret 1; }
+    if (outer() != 0)                 { ret 2; }
+    if (fwdpre(100, 1, 2, 3) != 106) { ret 3; }
+    if (fwdpre(100) != 100)           { ret 4; }
+    if (outer2(4, 5, 6) != 15)       { ret 5; }
+    ret 0;
+}

--- a/.github/tests/packfwd/run.sh
+++ b/.github/tests/packfwd/run.sh
@@ -15,7 +15,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/packfwd/run.sh
+++ b/.github/tests/packfwd/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# whole-pack `va...` forward (#1475): inside a pack instance, `g(va...)` threads the
+# instance's concrete pack parameters through to another pack-tailed callee, which
+# is monomorphized for the forwarded type-list. this builds a program that forwards
+# packs (incl. into a callee with a leading fixed param, and a forward-of-a-forward)
+# and runs it; main exits 0 only when every forward delivers the right elements.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL packfwd: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/packfwd"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL packfwd: check $code forwarded the wrong elements" >&2
+    exit 1
+fi
+echo "PASS packfwd: va... threads the instance's concrete pack through to a pack-tailed callee"

--- a/.github/tests/packmono/app/mach.toml
+++ b/.github/tests/packmono/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "packmono"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.packmono]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/packmono/app/src/main.mach
+++ b/.github/tests/packmono/app/src/main.mach
@@ -26,6 +26,17 @@ fun bias(base: i64, va: ...) i64 {
     ret t;
 }
 
+# a heterogeneous pack: each element a different concrete type. the body is
+# re-typed per element at monomorphization, so `a::i64` casts each element's own
+# type — the defining property of comptime packs over a uniform C-variadic.
+fun sumc(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + a::i64;
+    }
+    ret t;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     # distinct arities are distinct instances, deduped by their type-list.
@@ -42,5 +53,10 @@ fun main(argc: i64, argv: **u8) i64 {
     # a fixed parameter ahead of the pack; the pack expands the trailing args.
     if (bias(100, 1, 2, 3) != 106)       { ret 8; }
     if (bias(0) != 0)                    { ret 9; }
+
+    # heterogeneous element types in one pack, each re-typed and cast per element.
+    if (sumc(1000, 50::i32, 7::u8, 200::i16) != 1257) { ret 10; }
+    if (sumc(5::u8, 5::u8) != 10)                     { ret 11; }
+    if (sumc(10, 2.5::f64, 3::i32) != 15)             { ret 12; }
     ret 0;
 }

--- a/.github/tests/packmono/app/src/main.mach
+++ b/.github/tests/packmono/app/src/main.mach
@@ -1,0 +1,46 @@
+use std.runtime;
+
+# `$each a in va` over a comptime variadic pack (#1475): a pack-tailed function is
+# monomorphized once per distinct call-site arg-type-list, the pack expanded to N
+# concrete parameters and the `$each` unrolled over them. exits 0 only when every
+# instance computes the value its argument list dictates; a wrong result returns
+# that check's id.
+
+# homogeneous i64 packs: one instance per arity, the body re-typed per element.
+fun sum(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + a;
+    }
+    ret t;
+}
+
+# a leading fixed parameter ahead of the pack: the pack absorbs only the trailing
+# arguments, so the same type-list (here two i64s) names one instance regardless of
+# the fixed argument's value.
+fun bias(base: i64, va: ...) i64 {
+    var t: i64 = base;
+    $each a in va {
+        t = t + a;
+    }
+    ret t;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # distinct arities are distinct instances, deduped by their type-list.
+    if (sum(1, 2, 3) != 6)               { ret 1; }
+    if (sum(10, 20) != 30)               { ret 2; }
+    if (sum(5) != 5)                     { ret 3; }
+    if (sum() != 0)                      { ret 4; }
+    if (sum(100, 200, 300, 400) != 1000) { ret 5; }
+
+    # the same arity / type-list reuses one instance across call sites.
+    if (sum(7, 7, 7) != 21)              { ret 6; }
+    if (sum(2, 2, 2) != 6)               { ret 7; }
+
+    # a fixed parameter ahead of the pack; the pack expands the trailing args.
+    if (bias(100, 1, 2, 3) != 106)       { ret 8; }
+    if (bias(0) != 0)                    { ret 9; }
+    ret 0;
+}

--- a/.github/tests/packmono/app/src/main.mach
+++ b/.github/tests/packmono/app/src/main.mach
@@ -37,6 +37,12 @@ fun sumc(va: ...) i64 {
     ret t;
 }
 
+# `va.len` folds to the instance's element count, a compile-time constant fixed by
+# the call site.
+fun count(va: ...) i64 {
+    ret va.len::i64;
+}
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
     # distinct arities are distinct instances, deduped by their type-list.
@@ -58,5 +64,10 @@ fun main(argc: i64, argv: **u8) i64 {
     if (sumc(1000, 50::i32, 7::u8, 200::i16) != 1257) { ret 10; }
     if (sumc(5::u8, 5::u8) != 10)                     { ret 11; }
     if (sumc(10, 2.5::f64, 3::i32) != 15)             { ret 12; }
+
+    # va.len folds to the element count.
+    if (count(1, 2, 3) != 3)             { ret 13; }
+    if (count() != 0)                    { ret 14; }
+    if (count(9) != 1)                   { ret 15; }
     ret 0;
 }

--- a/.github/tests/packmono/run.sh
+++ b/.github/tests/packmono/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# comptime variadic-pack monomorphization (#1475): a pack-tailed function (`va: ...`)
+# is monomorphized once per distinct call-site arg-type-list, the pack expanded to N
+# concrete parameters and `$each a in va` unrolled over them. this builds a program
+# that sums packs of several arities (and one with a leading fixed parameter), then
+# runs it natively; main exits 0 only when every instance computes the right value.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL packmono: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/packmono"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL packmono: check $code computed the wrong value" >&2
+    exit 1
+fi
+echo "PASS packmono: pack-tailed fns monomorphize per type-list and \$each a in va unrolls"

--- a/.github/tests/packmono/run.sh
+++ b/.github/tests/packmono/run.sh
@@ -15,7 +15,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/packxmod/app/mach.toml
+++ b/.github/tests/packxmod/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "packxmod"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.packxmod]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/packxmod/app/src/helper.mach
+++ b/.github/tests/packxmod/app/src/helper.mach
@@ -1,0 +1,5 @@
+# functions in a second module, called from a pack body in main: the pack-body
+# re-inference at monomorphization (#1475) must resolve their signatures from the
+# all-modules typing-snapshot set, not just main's own declarations.
+pub fun dbl(x: i64) i64 { ret x * 2; }
+pub fun add3(x: i64) i64 { ret x + 3; }

--- a/.github/tests/packxmod/app/src/main.mach
+++ b/.github/tests/packxmod/app/src/main.mach
@@ -1,0 +1,31 @@
+use std.runtime;
+use helper: packxmod.helper;
+
+# pack bodies that call CROSS-MODULE functions per element. the body is re-typed
+# per element at monomorphization, and resolving `helper.dbl` / `helper.add3`
+# requires the all-modules dep set the re-inference assembles (#1475).
+fun sumdbl(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + helper.dbl(a);
+    }
+    ret t;
+}
+
+# a nested cross-module call in the body: add3(dbl(a)) = a*2 + 3 per element.
+fun chain(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + helper.add3(helper.dbl(a));
+    }
+    ret t;
+}
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    if (sumdbl(1, 2, 3) != 12) { ret 1; }  # 2 + 4 + 6
+    if (sumdbl(10) != 20)      { ret 2; }
+    if (sumdbl() != 0)         { ret 3; }
+    if (chain(1, 2) != 12)     { ret 4; }  # (2+3) + (4+3)
+    ret 0;
+}

--- a/.github/tests/packxmod/run.sh
+++ b/.github/tests/packxmod/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# cross-module pack bodies (#1475): a `va: ...` function whose `$each a in va` body
+# calls functions in ANOTHER module. monomorphizing it re-types the body per
+# element, which must resolve the cross-module callees' signatures from the
+# all-modules typing-snapshot set the re-inference assembles. this builds a
+# two-module program (main + helper) and runs it; main exits 0 only when every
+# instance computes the right value.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL packxmod: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/packxmod"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL packxmod: check $code computed the wrong value" >&2
+    exit 1
+fi
+echo "PASS packxmod: pack bodies resolve cross-module calls at per-element re-inference"

--- a/.github/tests/packxmod/run.sh
+++ b/.github/tests/packxmod/run.sh
@@ -16,7 +16,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/pathdep/run.sh
+++ b/.github/tests/pathdep/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 if ! command -v ln >/dev/null 2>&1; then

--- a/.github/tests/sectioncoff/app/mach.toml
+++ b/.github/tests/sectioncoff/app/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id      = "sectioncoff"
+name    = "Section Decorator Test (COFF) — App"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "windows"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+ext  = ".exe"
+libs = ["kernel32.dll"]
+
+[bin.sectioncoff]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/sectioncoff/app/src/main.mach
+++ b/.github/tests/sectioncoff/app/src/main.mach
@@ -1,0 +1,24 @@
+use std.runtime;
+
+# the COFF twin of sectiondec: a `section("...")` decorator places a global's
+# symbol in the named COFF section instead of the default .data, and a function's
+# code in the named text section, carried into PE/COFF object emission.
+
+# `.machsec` is exactly 8 characters, so its name fits inline in the COFF section
+# header (the path sectiondec already covers on ELF).
+`section(".machsec")` `symbol("g_sec")`
+pub var g_sec: u64 = 100;
+
+`symbol("g_def")`
+pub var g_def: u64 = 23;
+
+# `.hottext_long` is >8 characters, so COFF cannot store it inline: it goes to the
+# string table and the section header holds a `/N` byte-offset redirection. this
+# is the path `.machsec` / `.hottext` (both exactly 8) never exercise.
+`section(".hottext_long")` `symbol("f_sec")`
+fun f_sec(x: i64) i64 { ret x + 1; }
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    ret f_sec((g_sec + g_def)::i64 - 1);
+}

--- a/.github/tests/sectioncoff/run.sh
+++ b/.github/tests/sectioncoff/run.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# section decorator COFF integration test (#1491, fast-follow #1476): the
+# windows/COFF twin of sectiondec — prove a `section("...")` decorator places a
+# global's symbol and a function's code in the named COFF section, carried into
+# PE/COFF object emission, while an un-decorated global stays in .data.
+#
+# the symbol table records which section each symbol is defined in; objdump -t
+# reports a 1-based section index that maps to a name via objdump -h (the >8char
+# name is resolved from the COFF string table). the decorated `g_sec` must land
+# in `.machsec`, `f_sec` in `.hottext_long`, the plain `g_def` in `.data`.
+# `.hottext_long` is >8 characters, so it exercises the COFF string-table `/N`
+# redirection that the exactly-8 `.machsec` / `.hottext` names never reach. the
+# binary must also run under wine. no PE inspector -> structural check skipped.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+fail=0
+
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . ) >"$WORK/build.out" 2>&1; then
+    echo "FAIL sectioncoff: windows build failed" >&2
+    cat "$WORK/build.out" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/windows/bin/sectioncoff.exe"
+OBJ="$WORK/app/out/windows/obj/sectioncoff/main.o"
+test -f "$EXE" || { echo "error: windows binary not produced at $EXE" >&2; exit 1; }
+
+# pick a PE inspector: prefer binutils objdump (PE-capable on ubuntu), fall back
+# to llvm-readobj, and skip the structural half when neither can read the object
+# rather than failing spuriously — mirroring dlllibdec.
+INSPECT=""
+if command -v objdump >/dev/null 2>&1 && objdump -h "$OBJ" >/dev/null 2>&1; then
+    INSPECT="objdump"
+elif command -v llvm-readobj >/dev/null 2>&1; then
+    INSPECT="llvm-readobj"
+fi
+
+# sec_of <symbol> — the name of the COFF section the symbol is defined in.
+sec_of() {
+    local sym="$1" num
+    case "$INSPECT" in
+    objdump)
+        # objdump -t reports the defining section as a 1-based "(sec N)"; map N to
+        # the section name via objdump -h's 0-based Idx column.
+        num=$(objdump -t "$OBJ" 2>/dev/null | awk -v s="$sym" '
+            $NF==s { if (match($0, /\(sec +[0-9]+\)/)) { x=substr($0,RSTART,RLENGTH); gsub(/[^0-9]/,"",x); print x; exit } }')
+        [ -n "$num" ] || { echo "?"; return; }
+        objdump -h "$OBJ" 2>/dev/null | awk -v n="$num" '$1 ~ /^[0-9]+$/ && $1+0==n-1 {print $2; exit}'
+        ;;
+    llvm-readobj)
+        # --symbols gives the symbol's 1-based section number; --sections maps it
+        # to a name (the >8char name resolved from the string table).
+        num=$(llvm-readobj --symbols "$OBJ" 2>/dev/null | awk -v s="$sym" '
+            $1=="Name:" && $2==s { f=1; next }
+            f && $1=="Section:" { n=$NF; gsub(/[()]/,"",n); print n; exit }')
+        [ -n "$num" ] || { echo "?"; return; }
+        llvm-readobj --sections "$OBJ" 2>/dev/null | awk -v n="$num" '
+            $1=="Number:" { cur=($2==n) }
+            cur && $1=="Name:" { print $2; exit }'
+        ;;
+    esac
+}
+
+if [ -n "$INSPECT" ]; then
+    expect_sec() {
+        local sym="$1" want="$2" got
+        got=$(sec_of "$sym")
+        if [ "$got" != "$want" ]; then
+            echo "FAIL sectioncoff: $sym is in section '$got', expected '$want'" >&2
+            fail=1
+        else
+            echo "PASS sectioncoff: $sym placed in $want"
+        fi
+    }
+    expect_sec g_sec .machsec
+    expect_sec g_def .data
+    # the >8char text section exercises the COFF string-table /N redirection.
+    expect_sec f_sec .hottext_long
+    expect_sec main  .text
+else
+    echo "INFO sectioncoff: no PE inspector (objdump/llvm-readobj); skipping the section check"
+fi
+
+# behavioral: run under wine. f_sec lives in a section reached across a normal
+# relocation, and the sectioned global is read back — a clean 100 + 23 == 123
+# proves the placement did not break code or data references.
+if command -v wine >/dev/null 2>&1; then
+    set +e
+    WINEDEBUG=-all wine "$EXE" >"$WORK/wine.out" 2>&1
+    code=$?
+    set -e
+    if [ "$code" -eq 123 ]; then
+        echo "PASS sectioncoff: the program with sectioned globals/code runs under wine"
+    else
+        echo "FAIL sectioncoff: program ran under wine with exit $code, expected 123" >&2
+        cat "$WORK/wine.out" >&2
+        fail=1
+    fi
+else
+    echo "SKIP sectioncoff: 'wine' not available for the behavioral check"
+fi
+
+exit "$fail"

--- a/.github/tests/sectioncoff/run.sh
+++ b/.github/tests/sectioncoff/run.sh
@@ -24,7 +24,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/sectiondec/app/mach.toml
+++ b/.github/tests/sectiondec/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "sectiondec"
+name = "Section Decorator Test — App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.sectiondec]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/sectiondec/app/src/main.mach
+++ b/.github/tests/sectiondec/app/src/main.mach
@@ -1,0 +1,14 @@
+use std.runtime.linux.x86_64;
+
+# a `section("...")` decorator places the global's symbol in the named object
+# section instead of the default .data; the default-placed global stays in .data.
+`section(".machsec")` `symbol("g_sec")`
+pub var g_sec: u64 = 100;
+
+`symbol("g_def")`
+pub var g_def: u64 = 23;
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    ret (g_sec + g_def)::i64;
+}

--- a/.github/tests/sectiondec/app/src/main.mach
+++ b/.github/tests/sectiondec/app/src/main.mach
@@ -8,7 +8,12 @@ pub var g_sec: u64 = 100;
 `symbol("g_def")`
 pub var g_def: u64 = 23;
 
+# a `section("...")` decorator also places a FUNCTION's code in the named text
+# section; it is still called across the section boundary (a normal relocation).
+`section(".hottext")` `symbol("f_sec")`
+fun f_sec(x: i64) i64 { ret x + 1; }
+
 `symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
-    ret (g_sec + g_def)::i64;
+    ret f_sec((g_sec + g_def)::i64 - 1);
 }

--- a/.github/tests/sectiondec/run.sh
+++ b/.github/tests/sectiondec/run.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# section decorator integration test (#1476): prove a `section("...")` decorator
+# places a global's symbol in the named object section, carried into ELF object
+# emission, while an un-decorated global stays in .data.
+#
+# the symbol table records which section each symbol is defined in; objdump -t
+# names it. the decorated `g_sec` must land in `.machsec`, the plain `g_def` in
+# `.data`. the binary must also run. objdump absent -> structural check skipped.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+fail=0
+
+rm -rf "$WORK/app/out"
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL sectiondec: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/sectiondec"
+OBJ="$WORK/app/out/linux/obj/sectiondec/main.o"
+
+# run: 100 + 23 == 123.
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 123 ]; then
+    echo "FAIL sectiondec: program ran with exit $code, expected 123" >&2
+    fail=1
+else
+    echo "PASS sectiondec: the program with a sectioned global runs correctly"
+fi
+
+# structural: each global's defining section name from the object symbol table.
+if command -v objdump >/dev/null 2>&1 && [ -f "$OBJ" ]; then
+    # sec_of <symbol> — the section name (the field beginning with '.') on the
+    # symbol-table line whose final field is the symbol name.
+    sec_of() {
+        objdump -t "$OBJ" 2>/dev/null | awk -v s="$1" '
+            $NF==s { for (i=1;i<=NF;i++) if ($i ~ /^\./) { print $i; exit } }'
+    }
+    expect_sec() {
+        local sym="$1" want="$2" got
+        got=$(sec_of "$sym")
+        if [ "$got" != "$want" ]; then
+            echo "FAIL sectiondec: $sym is in section '$got', expected '$want'" >&2
+            fail=1
+        else
+            echo "PASS sectiondec: $sym placed in $want"
+        fi
+    }
+    expect_sec g_sec .machsec
+    expect_sec g_def .data
+else
+    echo "INFO sectiondec: objdump unavailable or object missing; skipping the section check"
+fi
+
+exit "$fail"

--- a/.github/tests/sectiondec/run.sh
+++ b/.github/tests/sectiondec/run.sh
@@ -19,7 +19,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/sectiondec/run.sh
+++ b/.github/tests/sectiondec/run.sh
@@ -72,6 +72,9 @@ if command -v objdump >/dev/null 2>&1 && [ -f "$OBJ" ]; then
     }
     expect_sec g_sec .machsec
     expect_sec g_def .data
+    # a function placed in a named text section; the default function stays in .text.
+    expect_sec f_sec .hottext
+    expect_sec main  .text
 else
     echo "INFO sectiondec: objdump unavailable or object missing; skipping the section check"
 fi

--- a/.github/tests/threadsync/run.sh
+++ b/.github/tests/threadsync/run.sh
@@ -22,7 +22,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/typeofgate/app/mach.toml
+++ b/.github/tests/typeofgate/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "typeofgate"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.typeofgate]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/typeofgate/app/src/main.mach
+++ b/.github/tests/typeofgate/app/src/main.mach
@@ -1,0 +1,25 @@
+use std.runtime;
+
+# `$type_of(expr)` yields a comptime TYPE value; a type `==` / `!=` inside a `$if`
+# gate folds to an identity compare at lowering (#1472). exits 0 only when every
+# gate selects the arm its operand types dictate; a wrong arm returns that gate's
+# id. covers a primitive name operand, `!=`, the `$type_of` == `$type_of` form
+# (both operands type values), pointer-type identity, and a distinct-type miss.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    var a:  i64  = 0;
+    var a2: i64  = 0;
+    var b:  u8   = 0;
+    var c:  *i64 = nil;
+    var d:  *i64 = nil;
+
+    $if ($type_of(a) == i64) { } $or { ret 1; }
+    $if ($type_of(b) == i64) { ret 2; } $or { }
+    $if ($type_of(a) != i64) { ret 3; } $or { }
+    $if ($type_of(a) == $type_of(a2)) { } $or { ret 4; }
+    $if ($type_of(a) == $type_of(b)) { ret 5; } $or { }
+    $if ($type_of(c) == $type_of(d)) { } $or { ret 6; }
+    $if ($type_of(c) == $type_of(a)) { ret 7; } $or { }
+    $if ($type_of(b) == u8) { } $or { ret 8; }
+    ret 0;
+}

--- a/.github/tests/typeofgate/app/src/main.mach
+++ b/.github/tests/typeofgate/app/src/main.mach
@@ -1,14 +1,21 @@
 use std.runtime;
 
 # `$type_of(expr)` yields a comptime TYPE value; a type `==` / `!=` inside a `$if`
-# gate folds to an identity compare at lowering (#1472). exits 0 only when every
-# gate selects the arm its operand types dictate; a wrong arm returns that gate's
-# id. covers a primitive name operand, `!=`, the `$type_of` == `$type_of` form
-# (both operands type values), pointer-type identity, nominal record identity
-# (distinct records differ; same record matches), and a transparent `def`
-# (identity-equal to its underlying type, like `def str: *u8`).
+# gate folds to an identity compare at lowering (#1472). type identity is the
+# resolved sema TypeId, so the compare inherits the type system's exact rules.
+# exits 0 only when every gate selects the arm its operand types dictate; a wrong
+# arm returns that gate's id. covers: a primitive name operand, `!=`, the
+# `$type_of` == `$type_of` form (both operands type values), pointer identity,
+# nominal record identity (distinct decls with identical fields stay distinct),
+# a record named directly, transparent `def` aliases (identity-equal to the
+# underlying type, like `def str: *u8`), and generic-instance identity
+# (canonicalized by type-arg list).
 rec Pair { x: i64; y: i64; }
 rec Trip { a: i64; b: i64; c: i64; }
+# A and B share an identical field shape but are distinct nominal types.
+rec A { x: i64; y: i64; }
+rec B { x: i64; y: i64; }
+rec Box[T] { v: T; }
 def MyInt: i64;
 
 $main.symbol = "main";
@@ -41,5 +48,19 @@ fun main(argc: i64, argv: **u8) i64 {
     # a transparent `def` is identity-equal to its underlying type
     $if ($type_of(m) == MyInt) { } $or { ret 13; }
     $if ($type_of(m) == i64) { } $or { ret 14; }
+
+    # nominal: identical field shape, distinct declarations -> distinct types
+    var ra: A = A { x: 0, y: 0 };
+    var rb: B = B { x: 0, y: 0 };
+    $if ($type_of(ra) == $type_of(rb)) { ret 15; } $or { }
+    $if ($type_of(ra) == A) { } $or { ret 16; }
+    $if ($type_of(ra) == B) { ret 17; } $or { }
+
+    # generic instances canonicalize by type-arg list
+    var bi:  Box[i64] = Box[i64] { v: 0 };
+    var bi2: Box[i64] = Box[i64] { v: 0 };
+    var bu:  Box[u8]  = Box[u8]  { v: 0 };
+    $if ($type_of(bi) == $type_of(bi2)) { } $or { ret 18; }
+    $if ($type_of(bi) == $type_of(bu))  { ret 19; } $or { }
     ret 0;
 }

--- a/.github/tests/typeofgate/app/src/main.mach
+++ b/.github/tests/typeofgate/app/src/main.mach
@@ -4,14 +4,24 @@ use std.runtime;
 # gate folds to an identity compare at lowering (#1472). exits 0 only when every
 # gate selects the arm its operand types dictate; a wrong arm returns that gate's
 # id. covers a primitive name operand, `!=`, the `$type_of` == `$type_of` form
-# (both operands type values), pointer-type identity, and a distinct-type miss.
+# (both operands type values), pointer-type identity, nominal record identity
+# (distinct records differ; same record matches), and a transparent `def`
+# (identity-equal to its underlying type, like `def str: *u8`).
+rec Pair { x: i64; y: i64; }
+rec Trip { a: i64; b: i64; c: i64; }
+def MyInt: i64;
+
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
-    var a:  i64  = 0;
-    var a2: i64  = 0;
-    var b:  u8   = 0;
-    var c:  *i64 = nil;
-    var d:  *i64 = nil;
+    var a:  i64   = 0;
+    var a2: i64   = 0;
+    var b:  u8    = 0;
+    var c:  *i64  = nil;
+    var d:  *i64  = nil;
+    var p:  Pair  = Pair { x: 0, y: 0 };
+    var q:  Pair  = Pair { x: 0, y: 0 };
+    var t:  Trip  = Trip { a: 0, b: 0, c: 0 };
+    var m:  MyInt = 0;
 
     $if ($type_of(a) == i64) { } $or { ret 1; }
     $if ($type_of(b) == i64) { ret 2; } $or { }
@@ -21,5 +31,15 @@ fun main(argc: i64, argv: **u8) i64 {
     $if ($type_of(c) == $type_of(d)) { } $or { ret 6; }
     $if ($type_of(c) == $type_of(a)) { ret 7; } $or { }
     $if ($type_of(b) == u8) { } $or { ret 8; }
+
+    # nominal record identity
+    $if ($type_of(p) == $type_of(q)) { } $or { ret 9; }
+    $if ($type_of(p) == $type_of(t)) { ret 10; } $or { }
+    $if ($type_of(p) == Pair) { } $or { ret 11; }
+    $if ($type_of(p) == Trip) { ret 12; } $or { }
+
+    # a transparent `def` is identity-equal to its underlying type
+    $if ($type_of(m) == MyInt) { } $or { ret 13; }
+    $if ($type_of(m) == i64) { } $or { ret 14; }
     ret 0;
 }

--- a/.github/tests/typeofgate/reject/mach.toml
+++ b/.github/tests/typeofgate/reject/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "typeofreject"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.typeofreject]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/typeofgate/reject/src/main.mach
+++ b/.github/tests/typeofgate/reject/src/main.mach
@@ -1,0 +1,11 @@
+use std.runtime;
+
+# a `$type_of` type comparison is comptime-only: it folds to a selected arm at
+# lowering and has no runtime value, so using it as a value (here, a binding
+# initialiser) must FAIL rather than compile to garbage (#1472).
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    var a: i64 = 0;
+    var x: u8 = $type_of(a) == i64;
+    ret x::i64;
+}

--- a/.github/tests/typeofgate/run.sh
+++ b/.github/tests/typeofgate/run.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# $type_of type-gate integration test (#1472). two halves:
+#
+#   folding — `$type_of(expr)` yields a comptime TYPE value, and a type `==` / `!=`
+#   inside a `$if` gate folds to an identity compare at lowering. the app asserts
+#   every gate selects the arm its operand types dictate and exits 0 only when all
+#   match; a wrong arm returns that gate's id. this is the end-to-end proof that
+#   the lowering-time type resolver folds the gate against the real types.
+#
+#   rejection — a type comparison is comptime-only; used in a runtime value
+#   position the build must FAIL with the teaching diagnostic, never compile.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+# the exact diagnostic sema emits for a type comparison in a value position.
+REJECT_DIAG='a `$type_of` type comparison is comptime-only; it is valid only as a `$if` gate condition'
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# build_and_run <app-dir> <label>: vendor std, build, run, require exit 0. the
+# app's own main returns the misselected gate's id on a wrong arm.
+build_and_run() {
+    local app="$1"; local label="$2"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    if ! ( cd "$dst" && "$MACH" build . ) >/dev/null 2>&1; then
+        echo "FAIL typeofgate/$label: build failed" >&2; fail=1; return
+    fi
+    local bin
+    bin="$(find "$dst/out" -type f -path '*/bin/*' | head -n1)"
+    if [ -z "$bin" ]; then
+        echo "FAIL typeofgate/$label: no binary produced" >&2; fail=1; return
+    fi
+    set +e
+    "$bin"; local code=$?
+    set -e
+    if [ "$code" -ne 0 ]; then
+        echo "FAIL typeofgate/$label: gate id $code selected the wrong arm" >&2; fail=1; return
+    fi
+    echo "PASS typeofgate/$label: \$type_of gates fold to the right arm"
+}
+
+# expect_reject <app-dir> <label> <diagnostic>: vendor std, build, and require
+# the build to FAIL with `diagnostic` present verbatim on stderr.
+expect_reject() {
+    local app="$1"; local label="$2"; local want="$3"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    local out
+    if out="$( cd "$dst" && "$MACH" build . 2>&1 )"; then
+        echo "FAIL typeofgate/$label: build unexpectedly succeeded for a value-position type comparison" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF -- "$want"; then
+        echo "FAIL typeofgate/$label: missing the teaching diagnostic; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    echo "PASS typeofgate/$label: value-position type comparison rejected with the teaching diagnostic"
+}
+
+build_and_run app    "type gate folding"
+expect_reject reject "value-position type comparison" "$REJECT_DIAG"
+
+exit "$fail"

--- a/.github/tests/typeofgate/run.sh
+++ b/.github/tests/typeofgate/run.sh
@@ -25,7 +25,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/valuepos/run.sh
+++ b/.github/tests/valuepos/run.sh
@@ -26,7 +26,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/win64byref/run.sh
+++ b/.github/tests/win64byref/run.sh
@@ -23,7 +23,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/win64fnptr/run.sh
+++ b/.github/tests/win64fnptr/run.sh
@@ -23,7 +23,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/win64fp/run.sh
+++ b/.github/tests/win64fp/run.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/win64runner/run.sh
+++ b/.github/tests/win64runner/run.sh
@@ -23,7 +23,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/tests/win64va/run.sh
+++ b/.github/tests/win64va/run.sh
@@ -21,7 +21,7 @@ REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
 STD="$REPO_ROOT/dep/mach-std"
 
 if [ ! -d "$STD/src" ]; then
-    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
     exit 2
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Fetch released mach (build seed)
         env:
@@ -26,6 +24,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Build the compiler
         run: |
@@ -48,8 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Fetch released mach (build seed)
         env:
@@ -61,6 +62,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Byte-diff the seed→stage1→stage2 self-host fixpoint
         run: |
@@ -86,8 +92,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Fetch released mach
         env:
@@ -99,6 +103,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Test corpus
         run: |
@@ -116,8 +125,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Fetch released mach (build seed)
         env:
@@ -129,6 +136,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Install wine
         run: |
@@ -179,8 +191,6 @@ jobs:
         shell: pwsh
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Download the cross-built mach.exe (build seed)
         uses: actions/download-artifact@v4
@@ -190,6 +200,9 @@ jobs:
 
       - name: Put the seed on PATH
         run: Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP/seed"
+
+      - name: Realize the vendored std (mach dep pull)
+        run: mach.exe dep pull
 
       - name: Build the compiler (native)
         run: |
@@ -219,8 +232,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Fetch released mach (build seed)
         env:
@@ -233,6 +244,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Install the aarch64 byte-verification + emulation toolchain
         run: |
@@ -254,8 +270,8 @@ jobs:
         run: bash .github/tests/aarch64enc/run.sh "$GITHUB_WORKSPACE/out/linux/bin/mach"
 
       # cross-compile mach itself to aarch64. the mach-std aarch64 std/runtime (OS
-      # layer + `_start`) is vendored via the dep/mach-std submodule, so the build
-      # links cleanly. mirrors the integration lane's `mach build . --target windows`.
+      # layer + `_start`) is realized into dep/mach-std by `mach dep pull`, so the
+      # build links cleanly. mirrors the integration lane's `mach build . --target windows`.
       - name: Cross-compile mach to aarch64
         run: out/linux/bin/mach build . --target linux-arm64
 
@@ -307,3 +323,41 @@ jobs:
             exit 0
           fi
           out/linux/bin/mach test . --target linux-arm64 --runner "$(basename "$runner")"
+
+  # the vendored mach-std IS the self-host seed's standard library, so the
+  # RELEASED seed compiler must be able to parse it. the v1.7 variadic/comptime
+  # features — `va:` pack params, `$each` expansion, `$mach.build.*` build-context
+  # reads — are not in the released grammar; if any reaches the frozen std the seed
+  # can no longer build itself (the DECOUPLE freeze, #1486). this guard is
+  # content-based, so it holds even after the eventual revert to ref = branch/main.
+  seed-safety:
+    name: Seed Safety (vendored std)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch released mach (build seed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # the released seed both realizes the dep and defines the grammar the
+          # frozen std must parse under.
+          tmp="$(mktemp -d)"
+          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
+          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        run: mach dep pull
+
+      - name: Guard the frozen std is parseable by the released seed
+        run: |
+          set -euo pipefail
+          matches="$(grep -RInE '\bva:|\$each|\$mach\.build' dep/mach-std --include='*.mach' || true)"
+          if [ -n "$matches" ]; then
+            echo "::error::vendored mach-std carries post-seed syntax the released compiler cannot parse — the self-host seed would break:"
+            echo "$matches"
+            exit 1
+          fi
+          echo "frozen std is seed-parseable: no va: / \$each / \$mach.build.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,19 +61,18 @@ jobs:
           rc=$?
           if [ "$rc" -ne 0 ]; then
             echo "::group::spawn-failure diagnostics (temporary, #1476)"
-            df -h
-            echo "--- test exe dir ---"
-            ls -la out/linux/debug/test 2>/dev/null | head
-            E="$(find out -path '*debug/test*' -type f 2>/dev/null | head -1)"
-            echo "first exe: $E"
-            file "$E"
-            ls -la "$E"
-            echo "--- program headers ---"
-            readelf -lW "$E" 2>&1 | head -25
-            echo "--- direct run ---"
-            "$E"; echo "direct rc=$?"
-            echo "--- strace execve ---"
-            ( command -v strace >/dev/null && strace -f "$E" 2>&1 | head -20 ) || echo "(no strace)"
+            echo "--- memory / limits ---"
+            free -m || true
+            echo "overcommit_memory=$(cat /proc/sys/vm/overcommit_memory 2>/dev/null) overcommit_ratio=$(cat /proc/sys/vm/overcommit_ratio 2>/dev/null)"
+            echo "ulimit -v=$(ulimit -v)  -u=$(ulimit -u)  -m=$(ulimit -m)"
+            echo "--- strace the spawn (fork/clone) syscalls of mach test ---"
+            if command -v strace >/dev/null; then
+              strace -f -e trace=clone,clone3,fork,vfork -qq mach test . >/dev/null 2>/tmp/st.log || true
+              echo "fork-family failures:"; grep -E "(clone|clone3|fork|vfork)\(.*\) = -1" /tmp/st.log | head -5
+              echo "fork-family successes (sample):"; grep -E "(clone|clone3|fork|vfork)\(.*\) = [1-9]" /tmp/st.log | head -2
+            else
+              echo "(no strace)"
+            fi
             echo "::endgroup::"
           fi
           exit "$rc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,14 @@ jobs:
             free -m || true
             echo "overcommit_memory=$(cat /proc/sys/vm/overcommit_memory 2>/dev/null) overcommit_ratio=$(cat /proc/sys/vm/overcommit_ratio 2>/dev/null)"
             echo "ulimit -v=$(ulimit -v)  -u=$(ulimit -u)  -m=$(ulimit -m)"
-            echo "--- strace the spawn (fork/clone) syscalls of mach test ---"
+            echo "--- fork-at-scale probe (shell fork() 700x) ---"
+            n=0; while [ "$n" -lt 700 ]; do /bin/true || { echo "shell fork FAILED at $n"; break; }; n=$((n+1)); done; echo "shell forked $n times"
+            echo "--- strace mach test (process syscalls, raw tail) ---"
             if command -v strace >/dev/null; then
-              strace -f -e trace=clone,clone3,fork,vfork -qq mach test . >/dev/null 2>/tmp/st.log || true
-              echo "fork-family failures:"; grep -E "(clone|clone3|fork|vfork)\(.*\) = -1" /tmp/st.log | head -5
-              echo "fork-family successes (sample):"; grep -E "(clone|clone3|fork|vfork)\(.*\) = [1-9]" /tmp/st.log | head -2
+              strace -f -e trace=process -qq mach test . >/dev/null 2>/tmp/st.log
+              echo "strace rc=$? ; st.log bytes=$(wc -c </tmp/st.log)"
+              echo "HEAD:"; head -5 /tmp/st.log
+              echo "TAIL:"; tail -25 /tmp/st.log
             else
               echo "(no strace)"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,28 @@ jobs:
           chmod +x /usr/local/bin/mach
 
       - name: Test corpus
-        run: mach test .
+        run: |
+          set +e
+          mach test .
+          rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::group::spawn-failure diagnostics (temporary, #1476)"
+            df -h
+            echo "--- test exe dir ---"
+            ls -la out/linux/debug/test 2>/dev/null | head
+            E="$(find out -path '*debug/test*' -type f 2>/dev/null | head -1)"
+            echo "first exe: $E"
+            file "$E"
+            ls -la "$E"
+            echo "--- program headers ---"
+            readelf -lW "$E" 2>&1 | head -25
+            echo "--- direct run ---"
+            "$E"; echo "direct rc=$?"
+            echo "--- strace execve ---"
+            ( command -v strace >/dev/null && strace -f "$E" 2>&1 | head -20 ) || echo "(no strace)"
+            echo "::endgroup::"
+          fi
+          exit "$rc"
 
   integration:
     name: Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,32 +259,36 @@ jobs:
       - name: Cross-compile mach to aarch64
         run: out/linux/bin/mach build . --target linux-arm64
 
-      - name: Structurally verify the cross-built aarch64 compiler (of.Section.align)
+      - name: Structurally verify the cross-built aarch64 objects (of.Section.align)
         run: |
           set -euo pipefail
-          bin=out/linux-arm64/bin/mach
-          test -x "$bin" || { echo "::error::aarch64 cross-build produced no binary"; exit 1; }
           # the x86 fixpoint lane byte-diffs the ELF emitter end-to-end; the aarch64
           # back end can't self-host to a fixpoint on PRs (a compiler build under qemu
           # is too slow), so structurally verify the generic of.Section.align path on
-          # the cross-built compiler instead: a valid AArch64 ELF whose every section
-          # alignment is a power of two. catches a malformed / non-pow2 section align on
-          # the second emitter that the x86-only fixpoint can't see.
-          readelf -h "$bin" | grep -q 'Machine:.*AArch64' || { echo "::error::cross-built mach is not an AArch64 ELF"; exit 1; }
-          readelf -SW "$bin"
-          aligns="$(readelf -SW "$bin" | grep -E '^[[:space:]]*\[[[:space:]]*[0-9]+\]' | awk '{print $NF}')"
-          for a in $aligns; do
-            case "$a" in
-              ''|*[!0-9]*) echo "::error::unparseable aarch64 section alignment: '$a'"; exit 1;;
-            esac
-            # a section alignment is well-formed iff it is 0 (unconstrained) or a power
-            # of two — i.e. a & (a-1) == 0.
-            if [ "$a" -ne 0 ] && [ "$(( a & (a - 1) ))" -ne 0 ]; then
-              echo "::error::aarch64 compiler section has a non-power-of-two alignment: $a"
-              exit 1
-            fi
+          # the cross-built objects instead. the linked executable carries only program
+          # headers (no section table), so inspect the relocatable objects the cross-
+          # build emits — they retain the section headers of.Section.align writes: each
+          # must be a valid AArch64 ELF whose every section alignment is a power of two.
+          # catches a malformed / non-pow2 section align on the second emitter that the
+          # x86-only fixpoint can't see.
+          mapfile -t objs < <(find out/linux-arm64 -name '*.o' -type f)
+          test "${#objs[@]}" -gt 0 || { echo "::error::no cross-built aarch64 objects under out/linux-arm64"; exit 1; }
+          for obj in "${objs[@]}"; do
+            readelf -h "$obj" | grep -qi 'Machine:.*AArch64' || { echo "::error::cross-built object is not an AArch64 ELF: $obj"; exit 1; }
+            aligns="$(readelf -SW "$obj" | grep -E '^[[:space:]]*\[[[:space:]]*[0-9]+\]' | awk '{print $NF}')"
+            for a in $aligns; do
+              case "$a" in
+                ''|*[!0-9]*) echo "::error::unparseable aarch64 section alignment '$a' in $obj"; exit 1;;
+              esac
+              # a section alignment is well-formed iff it is 0 (unconstrained) or a power
+              # of two — i.e. a & (a-1) == 0.
+              if [ "$a" -ne 0 ] && [ "$(( a & (a - 1) ))" -ne 0 ]; then
+                echo "::error::aarch64 object $obj has a non-power-of-two section alignment: $a"
+                exit 1
+              fi
+            done
           done
-          echo "aarch64 section alignments OK (all power-of-two): $(echo "$aligns" | tr '\n' ' ')"
+          echo "structurally verified ${#objs[@]} cross-built aarch64 object(s): AArch64 ELF, power-of-two section alignments"
 
       # GATED (#1464): `mach test . --target linux-arm64` on the mach project — which
       # has a `main` bin entry — fails at link with "multiple definition of 'main'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,11 @@ jobs:
         run: Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP/seed"
 
       - name: Realize the vendored std (mach dep pull)
-        run: mach.exe dep pull
+        # `mach dep pull` shells `git` to fetch the frozen std commit; git is
+        # installed on the runner but not on this step's PATH, so add it.
+        run: |
+          $env:Path = "C:\Program Files\Git\bin;$env:Path"
+          mach.exe dep pull
 
       - name: Build the compiler (native)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,29 +56,14 @@ jobs:
 
       - name: Test corpus
         run: |
-          set +e
+          # `mach test` builds one full-compiler (~4.6MB) executable per test in a
+          # single long-lived process — a large virtual size — then fork()s to run
+          # each. on the swap-less runner with heuristic overcommit (vm.overcommit_memory=0)
+          # the kernel refuses fork() for a large-VSZ process regardless of free RAM
+          # (the child immediately execve's, so the COW copy is never written).
+          # allow overcommit so the spawns succeed.
+          sudo sysctl -w vm.overcommit_memory=1
           mach test .
-          rc=$?
-          if [ "$rc" -ne 0 ]; then
-            echo "::group::spawn-failure diagnostics (temporary, #1476)"
-            echo "--- memory / limits ---"
-            free -m || true
-            echo "overcommit_memory=$(cat /proc/sys/vm/overcommit_memory 2>/dev/null) overcommit_ratio=$(cat /proc/sys/vm/overcommit_ratio 2>/dev/null)"
-            echo "ulimit -v=$(ulimit -v)  -u=$(ulimit -u)  -m=$(ulimit -m)"
-            echo "--- fork-at-scale probe (shell fork() 700x) ---"
-            n=0; while [ "$n" -lt 700 ]; do /bin/true || { echo "shell fork FAILED at $n"; break; }; n=$((n+1)); done; echo "shell forked $n times"
-            echo "--- strace mach test (process syscalls, raw tail) ---"
-            if command -v strace >/dev/null; then
-              strace -f -e trace=process -qq mach test . >/dev/null 2>/tmp/st.log
-              echo "strace rc=$? ; st.log bytes=$(wc -c </tmp/st.log)"
-              echo "HEAD:"; head -5 /tmp/st.log
-              echo "TAIL:"; tail -25 /tmp/st.log
-            else
-              echo "(no strace)"
-            fi
-            echo "::endgroup::"
-          fi
-          exit "$rc"
 
   integration:
     name: Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,13 +201,18 @@ jobs:
       - name: Put the seed on PATH
         run: Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP/seed"
 
-      - name: Realize the vendored std (mach dep pull)
+      - name: Realize the vendored std (windows: direct git)
+        # the v1.6.0 seed's `mach dep pull` can't find git.exe on windows (its git
+        # lookup misses the `.exe` extension — git is on PATH, `where git` finds it
+        # in three places, yet dep pull errors "git not found"). tracked as a
+        # compiler bug; until the seed carries the fix, realize the frozen std into
+        # dep/mach-std directly, reading the pinned commit from mach.lock (single
+        # source of truth — no second pin). linux/aarch64 lanes use `mach dep pull`.
         run: |
-          Write-Host "--- git diag ---"
-          where.exe git
-          git --version
-          Write-Host "--- mach dep pull ---"
-          mach.exe dep pull
+          $commit = (Select-String -Path mach.lock -Pattern 'commit = "([0-9a-fA-F]+)"').Matches[0].Groups[1].Value
+          Write-Host "realizing mach-std @ $commit"
+          git clone --no-checkout https://github.com/octalide/mach-std dep/mach-std
+          git -C dep/mach-std checkout $commit
 
       - name: Build the compiler (native)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,10 +202,11 @@ jobs:
         run: Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP/seed"
 
       - name: Realize the vendored std (mach dep pull)
-        # `mach dep pull` shells `git` to fetch the frozen std commit; git is
-        # installed on the runner but not on this step's PATH, so add it.
         run: |
-          $env:Path = "C:\Program Files\Git\bin;$env:Path"
+          Write-Host "--- git diag ---"
+          where.exe git
+          git --version
+          Write-Host "--- mach dep pull ---"
           mach.exe dep pull
 
       - name: Build the compiler (native)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,52 @@ jobs:
           mach build .
           test -x out/linux/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
 
+  # the self-host fixpoint is the project's load-bearing correctness invariant, but
+  # the release `cmp` is stage2-vs-stage3 — both emitted by the NEW compiler, so a
+  # *uniform* codegen change lands in both stages and cancels (invisible). this lane
+  # runs the comparison that actually catches it on PRs: seed→stage1 vs stage1→stage2.
+  # stage1 is emitted by the OLD released seed, stage2 by the PR's own compiler, so a
+  # byte-diff between them surfaces any change to how the compiler emits *itself*. a
+  # clean PR is byte-reproducible from the seed (stage1 == stage2); a divergence means
+  # the PR changed the compiler's self-emission relative to the released seed.
+  fixpoint:
+    name: Self-host Fixpoint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Fetch released mach (build seed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # the versioned linux tarball from the most recent release is the build seed.
+          tmp="$(mktemp -d)"
+          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
+          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: Byte-diff the seed→stage1→stage2 self-host fixpoint
+        run: |
+          set -euo pipefail
+          # the released seed builds the source (stage1); stage1 then rebuilds the
+          # source (stage2). one extra rebuild over the single-stage lanes — cheap.
+          mach build .
+          test -x out/linux/bin/mach || { echo "::error::seed build produced no binary"; exit 1; }
+          cp out/linux/bin/mach stage1; chmod +x stage1
+          ./stage1 build .
+          cp out/linux/bin/mach stage2
+          if cmp -s stage1 stage2; then
+            echo "stage1 == stage2 ($(sha256sum stage1 | cut -d' ' -f1)) — byte-reproducible from the released seed."
+            exit 0
+          fi
+          echo "::error::self-host fixpoint diverged — the seed-built compiler (stage1) is not byte-identical to the self-built compiler (stage2). this PR changes how the compiler emits itself relative to the released seed; if the codegen change is intentional, confirm the divergence is expected (the next release re-seeds), otherwise the seed mis-compiled the new source."
+          sha256sum stage1 stage2 || true
+          cmp stage1 stage2 || true
+          exit 1
+
   test-suite:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -212,6 +258,33 @@ jobs:
       # links cleanly. mirrors the integration lane's `mach build . --target windows`.
       - name: Cross-compile mach to aarch64
         run: out/linux/bin/mach build . --target linux-arm64
+
+      - name: Structurally verify the cross-built aarch64 compiler (of.Section.align)
+        run: |
+          set -euo pipefail
+          bin=out/linux-arm64/bin/mach
+          test -x "$bin" || { echo "::error::aarch64 cross-build produced no binary"; exit 1; }
+          # the x86 fixpoint lane byte-diffs the ELF emitter end-to-end; the aarch64
+          # back end can't self-host to a fixpoint on PRs (a compiler build under qemu
+          # is too slow), so structurally verify the generic of.Section.align path on
+          # the cross-built compiler instead: a valid AArch64 ELF whose every section
+          # alignment is a power of two. catches a malformed / non-pow2 section align on
+          # the second emitter that the x86-only fixpoint can't see.
+          readelf -h "$bin" | grep -q 'Machine:.*AArch64' || { echo "::error::cross-built mach is not an AArch64 ELF"; exit 1; }
+          readelf -SW "$bin"
+          aligns="$(readelf -SW "$bin" | grep -E '^[[:space:]]*\[[[:space:]]*[0-9]+\]' | awk '{print $NF}')"
+          for a in $aligns; do
+            case "$a" in
+              ''|*[!0-9]*) echo "::error::unparseable aarch64 section alignment: '$a'"; exit 1;;
+            esac
+            # a section alignment is well-formed iff it is 0 (unconstrained) or a power
+            # of two — i.e. a & (a-1) == 0.
+            if [ "$a" -ne 0 ] && [ "$(( a & (a - 1) ))" -ne 0 ]; then
+              echo "::error::aarch64 compiler section has a non-power-of-two alignment: $a"
+              exit 1
+            fi
+          done
+          echo "aarch64 section alignments OK (all power-of-two): $(echo "$aligns" | tr '\n' ' ')"
 
       # GATED (#1464): `mach test . --target linux-arm64` on the mach project — which
       # has a `main` bin entry — fails at link with "multiple definition of 'main'"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,22 @@ jobs:
             exit 1
           fi
 
+      - name: Report byte-reproducibility from the prior seed (informational)
+        run: |
+          set -euo pipefail
+          # the fixpoint cmp above is stage2(b) vs stage3 — both emitted by the NEW
+          # compiler, so a *uniform* codegen change vs the prior release lands in both
+          # and cancels (invisible). the seed→stage1(a) vs stage1→stage2(b) diff is the
+          # one that surfaces it: a is emitted by the OLD seed. a release legitimately
+          # changes codegen, so this is REPORTED, not gated — it records whether this
+          # version is byte-reproducible from the prior seed.
+          if cmp -s a b; then
+            echo "::notice::byte-reproducible from the prior seed (stage1 == stage2): no change to the compiler's self-emission."
+          else
+            echo "::notice::NOT byte-reproducible from the prior seed (stage1 != stage2): this release changes how the compiler emits itself — expected when it includes a codegen change."
+            sha256sum a b || true
+          fi
+
       - name: Cross-compile the windows target
         run: out/linux/bin/mach build . --target windows
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Verify the tag matches the source version
         run: |
@@ -39,6 +37,11 @@ jobs:
           gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
           tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
           chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        # the std is no longer a git submodule; mach dep resolves it from the
+        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        run: mach dep pull
 
       - name: Build to the fixpoint
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 Thumbs.db
 out
+# dep checkouts are realized by `mach dep pull`, not version-controlled
+/dep/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "dep/mach-std"]
-	path = dep/mach-std
-	url = https://github.com/octalide/mach-std
-	branch = dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,9 @@ Be respectful, constructive, and professional. Treat Mach like a passion project
 Mach builds its own source with an existing `mach`:
 
 ```bash
-git clone --recurse-submodules https://github.com/octalide/mach.git
+git clone https://github.com/octalide/mach.git
 cd mach
+mach dep pull
 mach build .
 ```
 
@@ -122,15 +123,15 @@ Mach coding standards are in flux while syntax stabilizes and the userbase grows
 
 ```
 mach/
-├── dep/
-│   └── mach-std/      # standard library (git submodule)
+├── dep/                # dep checkouts realized by `mach dep pull` (git-ignored)
+│   └── mach-std/       # standard library
 ├── doc/               # documentation
 ├── src/               # self-hosting mach compiler
 ├── out/               # build output (git-ignored); compiler at out/<target>/bin/mach
 └── mach.toml          # project configuration
 ```
 
-The standard library lives in a separate repository ([mach-std](https://github.com/octalide/mach-std)) and is included as a git submodule under `dep/mach-std/`.
+The standard library lives in a separate repository ([mach-std](https://github.com/octalide/mach-std)) and is realized into `dep/mach-std/` by `mach dep pull` from the pin in `mach.toml`. The dep is currently frozen at an immutable `commit/<sha>` (the v1.7 self-host seed freeze, [#1486](https://github.com/octalide/mach/issues/1486)); it reverts to `branch/main` after the post-v1.7 re-seed.
 
 Building from source uses an existing `mach` (the latest release) — see [Getting Started](#getting-started). The original bootstrap seed ([mach-boot](https://github.com/octalide/mach-boot)) is no longer part of the build; it remains only as a from-scratch cold-start hatch.
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -343,10 +343,9 @@ ref = "branch/dev"
 `mach build` (no `--target`) selects `linux` because `[project].target = "native"`
 resolves to the host-matching tuple, compiles `src/main.mach` and its transitive
 imports — including modules from `mach-std` vendored at `dep/mach-std/` — into
-objects under `out/linux/obj/`, and links `out/linux/bin/mach`. The compiler
-carries `mach-std` as a git **submodule**; because `mach dep` performs only plain
-git operations, `mach dep pull` operates on the submodule checkout directly the
-same as any other git dep.
+objects under `out/linux/obj/`, and links `out/linux/bin/mach`. `mach-std` is
+realized into `dep/mach-std/` by `mach dep pull` from the manifest pin, and
+`mach build` then resolves it purely by that vendor path — no git at build time.
 
 ## See also
 

--- a/mach.lock
+++ b/mach.lock
@@ -2,5 +2,5 @@
 
 [deps.mach-std]
 url = "https://github.com/octalide/mach-std"
-ref = "branch/main"
-commit = "c0f1d2c8d583ae10b952b4e1d3e25bc92e251d60"
+ref = "commit/e8ce7dc1921e8d02d92584ee371de4d1dfe9d2be"
+commit = "e8ce7dc1921e8d02d92584ee371de4d1dfe9d2be"

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "1.6.0"
+version = "1.7.0"
 src = "src"
 dep = "dep"
 target = "native"

--- a/mach.toml
+++ b/mach.toml
@@ -31,4 +31,7 @@ entry = "main.mach"
 
 [deps.mach-std]
 git = "https://github.com/octalide/mach-std"
-ref = "branch/main"
+# frozen at the newest pre-variadic mach-std main commit (the v1.7 DECOUPLE
+# seed freeze); commit/ is immutable, so `mach dep update` cannot advance it.
+# revert to "branch/main" + `mach dep pull` after the post-v1.7 re-seed (#1486).
+ref = "commit/e8ce7dc1921e8d02d92584ee371de4d1dfe9d2be"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -548,6 +548,11 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
         ret br;
     }
 
+    # thread the CLI optimization intent into the session so the comptime ctx can
+    # resolve `$mach.build.mode`; the manifest opt is folded in driver-side.
+    s.opt_explicit = cli_set;
+    s.opt_release  = cli_level == pipeline.OPT_RELEASE;
+
     val proj_r: Result[driver.Project, str] = driver.build_project_sel(?s, util.cstr_str(?root[0]), ?sel);
     if (is_err[driver.Project, str](proj_r)) {
         print.eprint("error: ");

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -925,7 +925,11 @@ fun read_dep_manifest(alloc: *Allocator, dir: str) Result[toml.Table, str] {
 # error naming the operation that needed git.
 fun ensure_git(alloc: *Allocator, gt: *GitTool) Result[bool, str] {
     if (gt.ready) { ret ok[bool, str](true); }
-    val git_r: Result[str, str] = find_on_path(alloc, "git");
+    # windows executables carry a `.exe` extension; the bare `git` name does not
+    # resolve on PATH there (it's `git.exe`), so look for the right name (#1506).
+    var gname: *u8 = "git";
+    $if ($mach.target.os == $mach.os.windows) { gname = "git.exe"; }
+    val git_r: Result[str, str] = find_on_path(alloc, gname);
     if (is_err[str, str](git_r)) { ret err[bool, str]("git not found on PATH (needed to fetch git dependencies)"); }
     val env_r: Result[**u8, str] = build_env(alloc);
     if (is_err[**u8, str](env_r)) { ret err[bool, str]("failed to build child environment for git"); }

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -24,9 +24,13 @@ use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 use std.types.size.usize;
 use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_some;
 use std.types.option.is_none;
 use std.types.option.unwrap;
 use std.allocator.allocate;
+use std.allocator.deallocate;
 
 use writer: std.io.writer;
 
@@ -168,13 +172,27 @@ fun pack_image(s: *sess.Session, tgt: *target.Target, irmod: *ir.Module,
     }
     val text_sec: u32 = unwrap_ok[u32, str](rtext);
 
-    val rsym: Result[bool, str] = pack_symbols(?image, irmod, enc, text_sec);
+    # `section("...")` decorators move individual functions out of the shared
+    # `.text` into named sections. build one placement per sectioned function
+    # (and create its section); the list is empty when no function is sectioned,
+    # in which case symbols and relocations all land in `.text` exactly as before.
+    var placements:      *SectionPlacement = nil;
+    var placement_count: u32 = 0;
+    val rpl: Result[bool, str] = build_section_placements(s, ?image, irmod, enc, ?placements, ?placement_count);
+    if (is_err[bool, str](rpl)) {
+        obj.dnit(?image);
+        ret err[of.ObjectImage, str](unwrap_err[bool, str](rpl));
+    }
+
+    val rsym: Result[bool, str] = pack_symbols(?image, irmod, enc, text_sec, placements, placement_count);
     if (is_err[bool, str](rsym)) {
+        if (placements != nil) { deallocate[SectionPlacement](s.alloc, placements, enc.symbol_count::usize); }
         obj.dnit(?image);
         ret err[of.ObjectImage, str](unwrap_err[bool, str](rsym));
     }
 
-    val rrel: Result[bool, str] = pack_relocs(?image, enc, text_sec);
+    val rrel: Result[bool, str] = pack_relocs(?image, enc, text_sec, placements, placement_count);
+    if (placements != nil) { deallocate[SectionPlacement](s.alloc, placements, enc.symbol_count::usize); }
     if (is_err[bool, str](rrel)) {
         obj.dnit(?image);
         ret err[of.ObjectImage, str](unwrap_err[bool, str](rrel));
@@ -281,6 +299,114 @@ fun image_has_symbol(image: *of.ObjectImage, name: intern.StrId) bool {
     ret false;
 }
 
+# SectionPlacement: a function moved out of `.text` by a `section("...")`
+# decorator. its [text_start, text_end) byte range in the encoder blob is copied
+# into the named section `sec`; a mark or relocation at offset O in that range is
+# re-homed to (sec, O - text_start). its bytes remain in `.text` as dead,
+# unreferenced content (no symbol or relocation points at them there).
+rec SectionPlacement {
+    text_start: u32;
+    text_end:   u32;
+    sec:        u32;
+}
+
+# function_section: the object section name a `section("...")` decorator places
+# the defined function `name` in, or STR_NIL for the default `.text`.
+fun function_section(irmod: *ir.Module, name: intern.StrId) intern.StrId {
+    var i: u32 = 0;
+    for (i < irmod.function_len) {
+        val fn: *ir.Function = ?irmod.functions[i];
+        if (fn.name == name && (fn.flags & ir.FN_FLAG_EXTERN) == 0) { ret fn.section; }
+        i = i + 1;
+    }
+    ret intern.STR_NIL;
+}
+
+# next_func_entry_offset: the encoder-blob offset of the first function-entry mark
+# after index `i`, or the total text length when `i` marks the last function. marks
+# are emitted in increasing offset order, so this bounds the function at index `i`.
+fun next_func_entry_offset(irmod: *ir.Module, enc: *encode.EncoderOutput, i: u32) u32 {
+    var j: u32 = i + 1;
+    for (j < enc.symbol_count) {
+        val m: *encode.SymbolMark = ?enc.symbols[j];
+        if (function_defined(irmod, m.name)) { ret m.offset; }
+        j = j + 1;
+    }
+    ret enc.text_len;
+}
+
+# placement_for: the placement whose text range contains `offset`, or none.
+fun placement_for(placements: *SectionPlacement, count: u32, offset: u32) Option[*SectionPlacement] {
+    var i: u32 = 0;
+    for (i < count) {
+        val p: *SectionPlacement = ?placements[i];
+        if (offset >= p.text_start && offset < p.text_end) { ret some[*SectionPlacement](p); }
+        i = i + 1;
+    }
+    ret none[*SectionPlacement]();
+}
+
+# make_func_section: copy the encoder blob's [start, end) bytes (one sectioned
+# function) into a fresh image-owned buffer, append a text-kind section named
+# `sname`, and return its index. same-named sections from sibling functions are
+# concatenated by the linker.
+fun make_func_section(s: *sess.Session, image: *of.ObjectImage, sname: intern.StrId,
+                      enc: *encode.EncoderOutput, start: u32, end: u32) Result[u32, str] {
+    val len: u32 = end - start;
+    val br: Result[*u8, str] = allocate[u8](s.alloc, len::usize);
+    if (is_err[*u8, str](br)) { ret err[u32, str](unwrap_err[*u8, str](br)); }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+    var k: u32 = 0;
+    for (k < len) { buf[k] = enc.text[start + k]; k = k + 1; }
+
+    var sec: of.Section;
+    sec.name  = sname;
+    sec.kind  = of.SK_TEXT;
+    sec.bytes = buf;
+    sec.len   = len;
+    sec.align = 16;
+    ret obj.add_section(image, sec);
+}
+
+# build_section_placements: create a named section for every sectioned defined
+# function and record its placement. writes the owned placement array (sized to the
+# mark count, freed by the caller) and the entry count through the out-params; an
+# empty result means no function is sectioned and emission is byte-for-byte unchanged.
+fun build_section_placements(s: *sess.Session, image: *of.ObjectImage, irmod: *ir.Module,
+                             enc: *encode.EncoderOutput, out_buf: **SectionPlacement, out_count: *u32) Result[bool, str] {
+    @out_buf   = nil;
+    @out_count = 0;
+    if (enc.symbol_count == 0) { ret ok[bool, str](true); }
+
+    val br: Result[*SectionPlacement, str] = allocate[SectionPlacement](s.alloc, enc.symbol_count::usize);
+    if (is_err[*SectionPlacement, str](br)) { ret err[bool, str](unwrap_err[*SectionPlacement, str](br)); }
+    val buf: *SectionPlacement = unwrap_ok[*SectionPlacement, str](br);
+
+    var count: u32 = 0;
+    var i: u32 = 0;
+    for (i < enc.symbol_count) {
+        val mark: *encode.SymbolMark = ?enc.symbols[i];
+        if (function_defined(irmod, mark.name)) {
+            val sname: intern.StrId = function_section(irmod, mark.name);
+            if (sname != intern.STR_NIL) {
+                val start: u32 = mark.offset;
+                val end:   u32 = next_func_entry_offset(irmod, enc, i);
+                val rsec: Result[u32, str] = make_func_section(s, image, sname, enc, start, end);
+                if (is_err[u32, str](rsec)) {
+                    deallocate[SectionPlacement](s.alloc, buf, enc.symbol_count::usize);
+                    ret err[bool, str](unwrap_err[u32, str](rsec));
+                }
+                buf[count] = SectionPlacement{text_start: start, text_end: end, sec: unwrap_ok[u32, str](rsec)};
+                count = count + 1;
+            }
+        }
+        i = i + 1;
+    }
+    @out_buf   = buf;
+    @out_count = count;
+    ret ok[bool, str](true);
+}
+
 # append the encoded `.text` section to the image.
 # ---
 # s:     session, for interning the section name
@@ -321,7 +447,8 @@ fun pack_text(s: *sess.Session, image: *of.ObjectImage,
 # text_sec: index of the `.text` section the marks are defined in
 # ret:      true on success, or an error string
 fun pack_symbols(image: *of.ObjectImage, irmod: *ir.Module,
-                 enc: *encode.EncoderOutput, text_sec: u32) Result[bool, str] {
+                 enc: *encode.EncoderOutput, text_sec: u32,
+                 placements: *SectionPlacement, placement_count: u32) Result[bool, str] {
     var i: u32 = 0;
     for (i < enc.symbol_count) {
         val mark: *encode.SymbolMark = ?enc.symbols[i];
@@ -334,10 +461,21 @@ fun pack_symbols(image: *of.ObjectImage, irmod: *ir.Module,
             flags = flags | of.SYM_OBJ_FLAG_WEAK;
         }
 
+        # a mark inside a sectioned function is re-homed to that function's named
+        # section at the rebased offset; everything else stays in `.text`.
+        var sec_ix: u32 = text_sec;
+        var off:    u32 = mark.offset;
+        val pl: Option[*SectionPlacement] = placement_for(placements, placement_count, mark.offset);
+        if (is_some[*SectionPlacement](pl)) {
+            val p: *SectionPlacement = unwrap[*SectionPlacement](pl);
+            sec_ix = p.sec;
+            off    = mark.offset - p.text_start;
+        }
+
         var sym: of.Symbol;
         sym.name    = mark.name;
-        sym.section = text_sec;
-        sym.offset  = mark.offset;
+        sym.section = sec_ix;
+        sym.offset  = off;
         sym.size    = 0;
         sym.flags   = flags;
 
@@ -398,14 +536,26 @@ fun function_is_weak(irmod: *ir.Module, name: intern.StrId) bool {
 # text_sec: index of the `.text` section the relocations patch
 # ret:      true on success, or an error string
 fun pack_relocs(image: *of.ObjectImage, enc: *encode.EncoderOutput,
-                text_sec: u32) Result[bool, str] {
+                text_sec: u32, placements: *SectionPlacement, placement_count: u32) Result[bool, str] {
     var i: u32 = 0;
     for (i < enc.reloc_count) {
         val pr: *encode.PendingReloc = ?enc.relocations[i];
 
+        # a patch site inside a sectioned function is re-homed to that function's
+        # named section at the rebased offset; the symbol target is unchanged
+        # (resolved by the linker), so cross-section calls just work.
+        var sec_ix: u32 = text_sec;
+        var off:    u32 = pr.offset;
+        val pl: Option[*SectionPlacement] = placement_for(placements, placement_count, pr.offset);
+        if (is_some[*SectionPlacement](pl)) {
+            val p: *SectionPlacement = unwrap[*SectionPlacement](pl);
+            sec_ix = p.sec;
+            off    = pr.offset - p.text_start;
+        }
+
         var rel: of.Relocation;
-        rel.section = text_sec;
-        rel.offset  = pr.offset;
+        rel.section = sec_ix;
+        rel.offset  = off;
         rel.kind    = pr.kind;
         rel.symbol  = pr.sym;
         rel.addend  = pr.addend::i64;

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -147,10 +147,11 @@ pub fun codegen_module(s: *sess.Session, tgt: *target.Target,
 
 # build the object image from the encoder output and the module's globals.
 #
-# creates the `.text` section from the encoded bytes, registers every symbol
-# mark against it, attaches the encoder's relocations, then materialises each
-# module global into a data / rodata / bss section with its defining symbol. on
-# any builder failure the partially built image is torn down before returning.
+# moves each `section("...")` function into its named section, builds `.text`
+# from the remaining non-sectioned bytes, registers every symbol mark against its
+# section, attaches the encoder's relocations, then materialises each module
+# global into a data / rodata / bss section with its defining symbol. on any
+# builder failure the partially built image is torn down before returning.
 # ---
 # s:     shared session; supplies the allocator and interner
 # tgt:   resolved target; supplies type sizes for bss global layout
@@ -165,24 +166,31 @@ fun pack_image(s: *sess.Session, tgt: *target.Target, irmod: *ir.Module,
     }
     var image: of.ObjectImage = unwrap_ok[of.ObjectImage, str](rimg);
 
-    val rtext: Result[u32, str] = pack_text(s, ?image, enc);
-    if (is_err[u32, str](rtext)) {
-        obj.dnit(?image);
-        ret err[of.ObjectImage, str](unwrap_err[u32, str](rtext));
-    }
-    val text_sec: u32 = unwrap_ok[u32, str](rtext);
-
     # `section("...")` decorators move individual functions out of the shared
     # `.text` into named sections. build one placement per sectioned function
-    # (and create its section); the list is empty when no function is sectioned,
-    # in which case symbols and relocations all land in `.text` exactly as before.
+    # (creating its section and copying the sectioned bytes out of the encoder
+    # blob) first, so pack_text can then assemble `.text` from the remaining
+    # non-sectioned bytes. the list is empty when no function is sectioned, in
+    # which case `.text` adopts the encoder blob whole and symbols / relocations
+    # all land in `.text` exactly as before.
     var placements:      *SectionPlacement = nil;
     var placement_count: u32 = 0;
     val rpl: Result[bool, str] = build_section_placements(s, ?image, irmod, enc, ?placements, ?placement_count);
     if (is_err[bool, str](rpl)) {
+        # the encoder blob was never adopted into a section; release it (the nil
+        # guard mirrors obj.dnit) before tearing the partial image down.
+        if (enc.text != nil) { deallocate[u8](s.alloc, enc.text, enc.text_len::usize); }
         obj.dnit(?image);
         ret err[of.ObjectImage, str](unwrap_err[bool, str](rpl));
     }
+
+    val rtext: Result[u32, str] = pack_text(s, ?image, enc, placements, placement_count);
+    if (is_err[u32, str](rtext)) {
+        if (placements != nil) { deallocate[SectionPlacement](s.alloc, placements, enc.symbol_count::usize); }
+        obj.dnit(?image);
+        ret err[of.ObjectImage, str](unwrap_err[u32, str](rtext));
+    }
+    val text_sec: u32 = unwrap_ok[u32, str](rtext);
 
     val rsym: Result[bool, str] = pack_symbols(?image, irmod, enc, text_sec, placements, placement_count);
     if (is_err[bool, str](rsym)) {
@@ -301,9 +309,9 @@ fun image_has_symbol(image: *of.ObjectImage, name: intern.StrId) bool {
 
 # SectionPlacement: a function moved out of `.text` by a `section("...")`
 # decorator. its [text_start, text_end) byte range in the encoder blob is copied
-# into the named section `sec`; a mark or relocation at offset O in that range is
-# re-homed to (sec, O - text_start). its bytes remain in `.text` as dead,
-# unreferenced content (no symbol or relocation points at them there).
+# into the named section `sec` and excised from `.text`; a mark or relocation at
+# offset O in that range is re-homed to (sec, O - text_start), while every
+# `.text`-resident site below the range shifts down by the range's length.
 rec SectionPlacement {
     text_start: u32;
     text_end:   u32;
@@ -344,6 +352,35 @@ fun placement_for(placements: *SectionPlacement, count: u32, offset: u32) Option
         i = i + 1;
     }
     ret none[*SectionPlacement]();
+}
+
+# total_excised: the summed byte length of every sectioned-function range. the
+# rebuilt `.text` is exactly this much shorter than the encoder blob.
+fun total_excised(placements: *SectionPlacement, count: u32) u32 {
+    var sum: u32 = 0;
+    var i: u32 = 0;
+    for (i < count) {
+        val p: *SectionPlacement = ?placements[i];
+        sum = sum + (p.text_end - p.text_start);
+        i = i + 1;
+    }
+    ret sum;
+}
+
+# rebased_text_offset: where a `.text`-resident site at encoder-blob offset `offset`
+# lands once every sectioned range below it is excised. each sectioned range lies
+# entirely below or entirely above a non-sectioned site, so the shift is the summed
+# length of the ranges ending at or before `offset`. with no sectioned function the
+# shift is zero and the offset is returned unchanged.
+fun rebased_text_offset(placements: *SectionPlacement, count: u32, offset: u32) u32 {
+    var shift: u32 = 0;
+    var i: u32 = 0;
+    for (i < count) {
+        val p: *SectionPlacement = ?placements[i];
+        if (p.text_end <= offset) { shift = shift + (p.text_end - p.text_start); }
+        i = i + 1;
+    }
+    ret offset - shift;
 }
 
 # make_func_section: copy the encoder blob's [start, end) bytes (one sectioned
@@ -407,14 +444,25 @@ fun build_section_placements(s: *sess.Session, image: *of.ObjectImage, irmod: *i
     ret ok[bool, str](true);
 }
 
-# append the encoded `.text` section to the image.
+# assemble the `.text` section from the NON-sectioned functions.
+#
+# with no `section("...")` decorator (`count == 0`) the encoder blob is adopted
+# whole and emission is byte-for-byte unchanged. otherwise each sectioned
+# function's [start, end) range — already copied into its named section by
+# build_section_placements — is excised and the remaining bytes are packed
+# contiguously into a fresh image-owned buffer; the now-orphaned encoder blob is
+# released. a module whose every function is sectioned yields an empty `.text`
+# (nil bytes, length 0). pack_text is the last reader of `enc.text`, so it owns
+# the blob's disposition: adopt it (default path) or free it (repartition path).
 # ---
-# s:     session, for interning the section name
-# image: object image being built
-# enc:   encoder output supplying the text bytes
-# ret:   the new section's index, or an error string
-fun pack_text(s: *sess.Session, image: *of.ObjectImage,
-              enc: *encode.EncoderOutput) Result[u32, str] {
+# s:          session, for interning the section name and allocating the buffer
+# image:      object image being built
+# enc:        encoder output supplying the text bytes (adopted or freed here)
+# placements: the sectioned-function ranges to excise, in increasing text offset
+# count:      number of placements (0 = default path, adopt the blob unchanged)
+# ret:        the new section's index, or an error string
+fun pack_text(s: *sess.Session, image: *of.ObjectImage, enc: *encode.EncoderOutput,
+              placements: *SectionPlacement, count: u32) Result[u32, str] {
     val rname: Result[intern.StrId, str] = intern.intern(?s.interner, ".text");
     if (is_err[intern.StrId, str](rname)) {
         ret err[u32, str](unwrap_err[intern.StrId, str](rname));
@@ -423,10 +471,48 @@ fun pack_text(s: *sess.Session, image: *of.ObjectImage,
     var sec: of.Section;
     sec.name  = unwrap_ok[intern.StrId, str](rname);
     sec.kind  = of.SK_TEXT;
-    sec.bytes = enc.text;
-    sec.len   = enc.text_len;
     sec.align = 16;
 
+    if (count == 0) {
+        sec.bytes = enc.text;
+        sec.len   = enc.text_len;
+        ret obj.add_section(image, sec);
+    }
+
+    val new_len: u32 = enc.text_len - total_excised(placements, count);
+    if (new_len == 0) {
+        # every function is sectioned: `.text` carries no bytes.
+        sec.bytes = nil;
+        sec.len   = 0;
+    }
+    or {
+        val br: Result[*u8, str] = allocate[u8](s.alloc, new_len::usize);
+        if (is_err[*u8, str](br)) {
+            deallocate[u8](s.alloc, enc.text, enc.text_len::usize);
+            ret err[u32, str](unwrap_err[*u8, str](br));
+        }
+        val buf: *u8 = unwrap_ok[*u8, str](br);
+
+        # copy the gaps between the excised ranges in order; placements are recorded
+        # in increasing text offset, so one forward walk packs `.text` contiguously.
+        var w: u32 = 0;
+        var prev_end: u32 = 0;
+        var i: u32 = 0;
+        for (i < count) {
+            val p: *SectionPlacement = ?placements[i];
+            var k: u32 = prev_end;
+            for (k < p.text_start) { buf[w] = enc.text[k]; w = w + 1; k = k + 1; }
+            prev_end = p.text_end;
+            i = i + 1;
+        }
+        var k2: u32 = prev_end;
+        for (k2 < enc.text_len) { buf[w] = enc.text[k2]; w = w + 1; k2 = k2 + 1; }
+
+        sec.bytes = buf;
+        sec.len   = new_len;
+    }
+
+    deallocate[u8](s.alloc, enc.text, enc.text_len::usize);
     ret obj.add_section(image, sec);
 }
 
@@ -462,14 +548,18 @@ fun pack_symbols(image: *of.ObjectImage, irmod: *ir.Module,
         }
 
         # a mark inside a sectioned function is re-homed to that function's named
-        # section at the rebased offset; everything else stays in `.text`.
+        # section at the rebased offset; a `.text`-resident mark shifts down by the
+        # sectioned ranges excised below it (zero shift, unchanged, by default).
         var sec_ix: u32 = text_sec;
-        var off:    u32 = mark.offset;
+        var off:    u32 = 0;
         val pl: Option[*SectionPlacement] = placement_for(placements, placement_count, mark.offset);
         if (is_some[*SectionPlacement](pl)) {
             val p: *SectionPlacement = unwrap[*SectionPlacement](pl);
             sec_ix = p.sec;
             off    = mark.offset - p.text_start;
+        }
+        or {
+            off = rebased_text_offset(placements, placement_count, mark.offset);
         }
 
         var sym: of.Symbol;
@@ -542,15 +632,20 @@ fun pack_relocs(image: *of.ObjectImage, enc: *encode.EncoderOutput,
         val pr: *encode.PendingReloc = ?enc.relocations[i];
 
         # a patch site inside a sectioned function is re-homed to that function's
-        # named section at the rebased offset; the symbol target is unchanged
-        # (resolved by the linker), so cross-section calls just work.
+        # named section at the rebased offset; a `.text`-resident site shifts down
+        # by the sectioned ranges excised below it (zero shift, unchanged, by
+        # default). the symbol target is unchanged (resolved by the linker), so
+        # cross-section calls just work.
         var sec_ix: u32 = text_sec;
-        var off:    u32 = pr.offset;
+        var off:    u32 = 0;
         val pl: Option[*SectionPlacement] = placement_for(placements, placement_count, pr.offset);
         if (is_some[*SectionPlacement](pl)) {
             val p: *SectionPlacement = unwrap[*SectionPlacement](pl);
             sec_ix = p.sec;
             off    = pr.offset - p.text_start;
+        }
+        or {
+            off = rebased_text_offset(placements, placement_count, pr.offset);
         }
 
         var rel: of.Relocation;

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -542,9 +542,14 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
         sec.kind  = kind;
         sec.bytes = bytes;
         sec.len   = sec_len;
-        # an `align(...)` decorator overrides the default; otherwise 8 bytes.
+        # the section is aligned to the strictest of: the 8-byte default, the
+        # global's own type alignment (which an `align(...)` decorator on the type
+        # can raise — natural alignment never exceeds 8, so un-decorated globals
+        # stay at 8), and an `align(...)` decorator on the global itself.
         sec.align = 8;
-        if (g.align > 0) { sec.align = g.align; }
+        val tya: u32 = ir_type.byte_align(?irmod.types, g.ty, tgt);
+        if (tya > sec.align) { sec.align = tya; }
+        if (g.align > sec.align) { sec.align = g.align; }
 
         val ridx: Result[u32, str] = obj.add_section(image, sec);
         if (is_err[u32, str](ridx)) {

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -542,7 +542,9 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
         sec.kind  = kind;
         sec.bytes = bytes;
         sec.len   = sec_len;
+        # an `align(...)` decorator overrides the default; otherwise 8 bytes.
         sec.align = 8;
+        if (g.align > 0) { sec.align = g.align; }
 
         val ridx: Result[u32, str] = obj.add_section(image, sec);
         if (is_err[u32, str](ridx)) {

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -522,9 +522,15 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
             }
         }
 
-        val rname: Result[intern.StrId, str] = intern.intern(?s.interner, sname);
-        if (is_err[intern.StrId, str](rname)) {
-            ret err[bool, str](unwrap_err[intern.StrId, str](rname));
+        # a `section("...")` decorator overrides the default section name (the
+        # data/rodata/bss kind is kept, so an over-named bss stays zero-filled).
+        var sec_name: intern.StrId = g.section;
+        if (sec_name == intern.STR_NIL) {
+            val rname: Result[intern.StrId, str] = intern.intern(?s.interner, sname);
+            if (is_err[intern.StrId, str](rname)) {
+                ret err[bool, str](unwrap_err[intern.StrId, str](rname));
+            }
+            sec_name = unwrap_ok[intern.StrId, str](rname);
         }
 
         # a section's length is the global's in-memory size. for initialized
@@ -538,7 +544,7 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
         }
 
         var sec: of.Section;
-        sec.name  = unwrap_ok[intern.StrId, str](rname);
+        sec.name  = sec_name;
         sec.kind  = kind;
         sec.bytes = bytes;
         sec.len   = sec_len;

--- a/src/lang/bignum.mach
+++ b/src/lang/bignum.mach
@@ -1,0 +1,266 @@
+# mach.lang.bignum: fixed-capacity big integer for exact decimal<->binary float
+# conversion.
+#
+# A leaf module (std-only deps) so comptime float-literal folding can fold a
+# literal to the exact correctly-rounded f64 bits without a lossy shortcut.
+# Ported from std.math.bignum (the proven path behind std.parse_f64); kept in
+# parity so the compiler folds a literal to the same bits std.parse_f64 yields.
+#
+# limbs are little-endian 32-bit; n counts active limbs (n == 0 is zero, no
+# leading-zero limbs). 128 limbs (4096 bits) covers every f64 conversion
+# (<= ~1100 bits). all multiplies are by small constants, so no 64x64->128
+# is needed.
+
+use std.types.bool.bool;
+use std.types.size.usize;
+
+# Big: a fixed-capacity unsigned big integer.
+pub rec Big {
+    n: usize;
+    d: [128]u32;
+}
+
+# zero: set b to zero.
+pub fun zero(b: *Big) {
+    b.n = 0;
+}
+
+# norm: drop leading-zero limbs so n is exact.
+pub fun norm(b: *Big) {
+    for (b.n > 0 && b.d[b.n - 1] == 0) {
+        b.n = b.n - 1;
+    }
+}
+
+# from_u64: set b to v.
+pub fun from_u64(b: *Big, v: u64) {
+    b.d[0] = (v & 0xFFFFFFFF)::u32;
+    b.d[1] = (v >> 32)::u32;
+    b.n = 2;
+    norm(b);
+}
+
+# is_zero: true iff b == 0.
+pub fun is_zero(b: *Big) bool {
+    ret b.n == 0;
+}
+
+# to_u64: low 64 bits of b (exact when b < 2^64).
+pub fun to_u64(b: *Big) u64 {
+    if (b.n == 0) { ret 0; }
+    if (b.n == 1) { ret b.d[0]::u64; }
+    ret b.d[0]::u64 | (b.d[1]::u64 << 32);
+}
+
+# copy: dst = src.
+pub fun copy(dst: *Big, src: *Big) {
+    dst.n = src.n;
+    var i: usize = 0;
+    for (i < src.n) {
+        dst.d[i] = src.d[i];
+        i = i + 1;
+    }
+}
+
+# cmp: -1 if a < b, 0 if equal, 1 if a > b.
+pub fun cmp(a: *Big, b: *Big) i64 {
+    if (a.n != b.n) {
+        if (a.n < b.n) { ret -1; }
+        ret 1;
+    }
+    var i: usize = a.n;
+    for (i > 0) {
+        i = i - 1;
+        if (a.d[i] != b.d[i]) {
+            if (a.d[i] < b.d[i]) { ret -1; }
+            ret 1;
+        }
+    }
+    ret 0;
+}
+
+# mul_small: b = b * m.
+pub fun mul_small(b: *Big, m: u32) {
+    if (b.n == 0 || m == 0) { zero(b); ret; }
+    var carry: u64 = 0;
+    var i: usize = 0;
+    for (i < b.n) {
+        val cur: u64 = b.d[i]::u64 * m::u64 + carry;
+        b.d[i] = (cur & 0xFFFFFFFF)::u32;
+        carry = cur >> 32;
+        i = i + 1;
+    }
+    if (carry > 0) {
+        b.d[b.n] = (carry & 0xFFFFFFFF)::u32;
+        b.n = b.n + 1;
+    }
+}
+
+# shl: b = b << bits (multiply by 2^bits).
+pub fun shl(b: *Big, bits: usize) {
+    if (b.n == 0 || bits == 0) { ret; }
+    val limb_shift: usize = bits / 32;
+    val bit_shift: usize = bits % 32;
+    if (bit_shift > 0) {
+        var carry: u64 = 0;
+        var i: usize = 0;
+        for (i < b.n) {
+            val v: u64 = (b.d[i]::u64 << bit_shift) | carry;
+            b.d[i] = (v & 0xFFFFFFFF)::u32;
+            carry = v >> 32;
+            i = i + 1;
+        }
+        if (carry > 0) {
+            b.d[b.n] = (carry & 0xFFFFFFFF)::u32;
+            b.n = b.n + 1;
+        }
+    }
+    if (limb_shift > 0) {
+        var i: usize = b.n;
+        for (i > 0) {
+            i = i - 1;
+            b.d[i + limb_shift] = b.d[i];
+        }
+        var j: usize = 0;
+        for (j < limb_shift) {
+            b.d[j] = 0;
+            j = j + 1;
+        }
+        b.n = b.n + limb_shift;
+    }
+}
+
+# add: a = a + b.
+pub fun add(a: *Big, b: *Big) {
+    var maxn: usize = a.n;
+    if (b.n > maxn) { maxn = b.n; }
+    var carry: u64 = 0;
+    var i: usize = 0;
+    for (i < maxn) {
+        var av: u64 = 0;
+        if (i < a.n) { av = a.d[i]::u64; }
+        var bv: u64 = 0;
+        if (i < b.n) { bv = b.d[i]::u64; }
+        val s: u64 = av + bv + carry;
+        a.d[i] = (s & 0xFFFFFFFF)::u32;
+        carry = s >> 32;
+        i = i + 1;
+    }
+    a.n = maxn;
+    if (carry > 0) {
+        a.d[a.n] = (carry & 0xFFFFFFFF)::u32;
+        a.n = a.n + 1;
+    }
+    norm(a);
+}
+
+# sub: a = a - b, requires a >= b.
+pub fun sub(a: *Big, b: *Big) {
+    var borrow: i64 = 0;
+    var i: usize = 0;
+    for (i < a.n) {
+        var bv: i64 = 0;
+        if (i < b.n) { bv = b.d[i]::i64; }
+        var t: i64 = a.d[i]::i64 - bv - borrow;
+        if (t < 0) {
+            t = t + 0x100000000;
+            borrow = 1;
+        }
+        or {
+            borrow = 0;
+        }
+        a.d[i] = t::u32;
+        i = i + 1;
+    }
+    norm(a);
+}
+
+# add_small: b = b + x.
+pub fun add_small(b: *Big, x: u32) {
+    if (b.n == 0) { from_u64(b, x::u64); ret; }
+    var carry: u64 = x::u64;
+    var i: usize = 0;
+    for (carry > 0 && i < b.n) {
+        val s: u64 = b.d[i]::u64 + carry;
+        b.d[i] = (s & 0xFFFFFFFF)::u32;
+        carry = s >> 32;
+        i = i + 1;
+    }
+    if (carry > 0) {
+        b.d[b.n] = (carry & 0xFFFFFFFF)::u32;
+        b.n = b.n + 1;
+    }
+}
+
+# mul_pow10: b = b * 10^k.
+pub fun mul_pow10(b: *Big, k: usize) {
+    var rem: usize = k;
+    for (rem >= 9) {
+        mul_small(b, 1000000000);
+        rem = rem - 9;
+    }
+    var p: u32 = 1;
+    var i: usize = 0;
+    for (i < rem) {
+        p = p * 10;
+        i = i + 1;
+    }
+    if (p > 1) {
+        mul_small(b, p);
+    }
+}
+
+# bitlen: number of significant bits (0 when b == 0).
+pub fun bitlen(b: *Big) usize {
+    if (b.n == 0) { ret 0; }
+    var top: u32 = b.d[b.n - 1];
+    var bits: usize = 0;
+    for (top > 0) {
+        bits = bits + 1;
+        top = top >> 1;
+    }
+    ret (b.n - 1) * 32 + bits;
+}
+
+test "bignum: from_u64 / to_u64 roundtrip" {
+    var a: Big;
+    from_u64(?a, 0);
+    if (!is_zero(?a)) { ret 1; }
+    from_u64(?a, 123456789);
+    if (to_u64(?a) != 123456789) { ret 1; }
+    from_u64(?a, 0xFFFFFFFFFF);
+    if (to_u64(?a) != 0xFFFFFFFFFF) { ret 1; }
+    ret 0;
+}
+
+test "bignum: mul_small, shl, mul_pow10" {
+    var a: Big;
+    from_u64(?a, 123);
+    mul_small(?a, 10);
+    if (to_u64(?a) != 1230) { ret 1; }
+    from_u64(?a, 1);
+    shl(?a, 40);
+    if (to_u64(?a) != 0x10000000000) { ret 1; }
+    from_u64(?a, 1);
+    mul_pow10(?a, 18);
+    if (to_u64(?a) != 1000000000000000000) { ret 1; }
+    ret 0;
+}
+
+test "bignum: add / sub / cmp / bitlen" {
+    var a: Big;
+    var b: Big;
+    from_u64(?a, 0xFFFFFFFF);
+    from_u64(?b, 1);
+    add(?a, ?b);
+    if (to_u64(?a) != 0x100000000) { ret 1; }
+    if (bitlen(?a) != 33) { ret 1; }
+    sub(?a, ?b);
+    if (to_u64(?a) != 0xFFFFFFFF) { ret 1; }
+    from_u64(?a, 1000);
+    from_u64(?b, 999);
+    if (cmp(?a, ?b) != 1) { ret 1; }
+    if (cmp(?b, ?a) != -1) { ret 1; }
+    if (cmp(?a, ?a) != 0) { ret 1; }
+    ret 0;
+}

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1845,7 +1845,16 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) Result[sess.ModuleId, s
     # initialise an empty Ast up front so the entry is always teardown-safe,
     # even if parsing never runs (parse_module overwrites it with the real one)
     m.a                 = ast.init(p.s.alloc, 0);
-    m.ctx               = comptime.init(p.s.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, p.target.arch.pointer_width, p.compiler_name, p.compiler_ver);
+    # resolve the active optimization mode for `$mach.build.mode`: an explicit CLI
+    # `-O*`/`--release` flag wins, else the selected target's manifest opt, else
+    # debug — mirroring cmd.build.resolve_opt_level so the gate matches the pipeline.
+    var build_mode_id: u32 = comptime.MODE_DEBUG;
+    if (p.s.opt_explicit) {
+        if (p.s.opt_release) { build_mode_id = comptime.MODE_RELEASE; }
+    } or (p.target_entry.opt == TARGET_OPT_RELEASE) {
+        build_mode_id = comptime.MODE_RELEASE;
+    }
+    m.ctx               = comptime.init(p.s.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, build_mode_id, p.target.arch.pointer_width, p.compiler_name, p.compiler_ver);
     # feed the manifest-derived `$project.*`/`$target.*`/`$bin.*` roots; the
     # target tuple comes from the selected entry (set before any module loads).
     comptime.set_build_context(?m.ctx,

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -704,6 +704,15 @@ fun scan_export_directives(p: *Project, mid: sess.ModuleId, source: str, start: 
                     bi = bi + 1;
                 }
             }
+
+            # leading backtick decorators attach directly to this decl, so a
+            # `symbol` / `library` decorator overrides the bare `ext` default
+            # registered above. run after the kind dispatch so the explicit name
+            # wins (the registries overwrite on a repeated key).
+            if (d.decorators_len > 0::u32) {
+                val rd: Result[bool, str] = register_decl_decorators(p, mid, source, d, did);
+                if (is_err[bool, str](rd)) { ret rd; }
+            }
         }
         i = i + 1;
     }
@@ -768,6 +777,52 @@ fun register_one_export_directive(p: *Project, mid: sess.ModuleId, source: str, 
         ret sess.register_export_library(p.s, mid, target_did::u32, unwrap_ok[intern.StrId, str](name_r));
     }
     ret sess.register_export_name(p.s, mid, target_did::u32, unwrap_ok[intern.StrId, str](name_r));
+}
+
+# register_decl_decorators: apply decl `d`'s leading backtick decorators the
+# link-name machinery owns — `` `symbol("name")` `` records the literal link name
+# and `` `library("lib")` `` pins an `ext` import's library — into the same
+# session registries the `$<sym>.symbol` / `.library` setters feed, so a
+# definition and its references resolve the name identically. each takes a single
+# string-literal argument. directives without a link-name effect (section /
+# inline / align) are left for the sema validation pass; a malformed argument is
+# likewise skipped here and diagnosed there.
+fun register_decl_decorators(p: *Project, mid: sess.ModuleId, source: str, d: *decl.Decl, did: id.DeclId) Result[bool, str] {
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *decl.Decorator = ?m.a.decorators[d.decorators_start + k];
+        val is_symbol:  bool = span_eq_str(source, dec.name, "symbol");
+        val is_library: bool = span_eq_str(source, dec.name, "library");
+
+        if ((is_symbol || is_library) && dec.args_len == 1::u32) {
+            val eid: id.ExprId = m.a.expr_ids[dec.args_start];
+            val ve_opt: Option[*expr.Expr] = ast.get_expr(?m.a, eid);
+            if (is_some[*expr.Expr](ve_opt)) {
+                val ve: *expr.Expr = unwrap[*expr.Expr](ve_opt);
+                if (ve.kind == expr.EXPR_KIND_LIT_STR && ve.span.len >= 2::usize) {
+                    # the string literal's inner content, quotes stripped.
+                    var inner: token.Span = ve.span;
+                    inner.offset = inner.offset + 1::usize;
+                    inner.len    = inner.len - 2::usize;
+
+                    val name_r: Result[intern.StrId, str] = intern.intern_span(?p.s.interner, source, inner);
+                    if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
+                    val sid: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+                    if (is_library) {
+                        val rl: Result[bool, str] = sess.register_export_library(p.s, mid, did::u32, sid);
+                        if (is_err[bool, str](rl)) { ret rl; }
+                    } or {
+                        val rn: Result[bool, str] = sess.register_export_name(p.s, mid, did::u32, sid);
+                        if (is_err[bool, str](rn)) { ret rn; }
+                    }
+                }
+            }
+        }
+        k = k + 1;
+    }
+    ret ok[bool, str](true);
 }
 
 # register_ext_fun: record an `ext fun` foreign symbol's literal link name (its

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1845,7 +1845,7 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) Result[sess.ModuleId, s
     # initialise an empty Ast up front so the entry is always teardown-safe,
     # even if parsing never runs (parse_module overwrites it with the real one)
     m.a                 = ast.init(p.s.alloc, 0);
-    m.ctx               = comptime.init(p.s.alloc, p.target.os_id, p.target.arch_id, p.target.arch.pointer_width, p.compiler_name, p.compiler_ver);
+    m.ctx               = comptime.init(p.s.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, p.target.arch.pointer_width, p.compiler_name, p.compiler_ver);
     # feed the manifest-derived `$project.*`/`$target.*`/`$bin.*` roots; the
     # target tuple comes from the selected entry (set before any module loads).
     comptime.set_build_context(?m.ctx,

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1122,6 +1122,50 @@ test "diagnostics: align on a def alias is rejected, not silently ignored (#1490
     ret 0;
 }
 
+test "sema: a `va: ...` pack declares; `va.len` and `$each a in va` typecheck (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # a named trailing pack parameter; `va.len` is the comptime element count and
+    # `$each a in va` iterates it (element body deferred to monomorphization).
+    val fr: Result[src.FileId, str] = open(?es, "pk.mach",
+        "fun take(va: ...) i64 { var n: i64 = va.len::i64; $each a in va { } ret n; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag.has_errors(unwrap_ok[*diag.DiagList, str](dr))) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: a `$each` over a non-pack, non-`$fields` sequence is rejected (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    val fr: Result[src.FileId, str] = open(?es, "bad.mach",
+        "fun f() i64 { var x: i64 = 0; $each a in x { } ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "must be `$fields(T)` or a variadic pack")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "diagnostics: calling a non-function renders the callee type (#1046)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1039,14 +1039,14 @@ test "diagnostics: a decorator on an incompatible target is rejected (#1476)" {
     var s: sess.Session = unwrap_ok[sess.Session, str](sr);
     var es: EditorSession = init(?s);
 
-    # `align` targets data and types, not a function — the mismatch is reported.
+    # `align` targets records, unions, and globals, not a function — reported.
     val fr: Result[src.FileId, str] = open(?es, "wt.mach", "`align(8)` fun f() i64 { ret 0; }\n");
     if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
 
     val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
     if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
-    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "`align` decorator applies only to data and types")) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "`align` decorator applies only to records, unions, and globals")) { dnit(?es); sess.dnit(?s); ret 1; }
 
     dnit(?es);
     sess.dnit(?s);
@@ -1071,6 +1071,51 @@ test "diagnostics: a section decorator on a function or global is accepted; on a
     if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val list: *diag.DiagList = unwrap_ok[*diag.DiagList, str](dr);
     if (!diag_has(list, "`section` decorator applies only to functions and globals")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "diagnostics: a negative align on a type is reported, not silently dropped (#1490)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `align(-8)` on a record folds to a negative integer-typed constant — the
+    # body-pass validator can't catch it (it's integer-typed), so the decl-pass
+    # fold must report it rather than `ret` silently.
+    val fr: Result[src.FileId, str] = open(?es, "na.mach", "`align(-8)` rec R { a: u8; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "`align` value must be a non-zero power of two")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "diagnostics: align on a def alias is rejected, not silently ignored (#1490)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # a `def` alias has no layout of its own and emits no symbol, so an `align` on
+    # it would silently no-op; it is rejected as an invalid target instead.
+    val fr: Result[src.FileId, str] = open(?es, "da.mach", "`align(8)` def D: u64;\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "`align` decorator applies only to records, unions, and globals")) { dnit(?es); sess.dnit(?s); ret 1; }
 
     dnit(?es);
     sess.dnit(?s);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -422,6 +422,7 @@ fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
         target.host_os_id(),
         target.host_arch_id(),
         target.host_abi_id(),
+        comptime.MODE_DEBUG,
         target.host_pointer_width(),
         intern.STR_NIL,
         intern.STR_NIL

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1166,6 +1166,53 @@ test "sema: a `$each` over a non-pack, non-`$fields` sequence is rejected (#1474
     ret 0;
 }
 
+test "sema: a call collects trailing args into a `va: ...` pack param (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # the pack param absorbs every trailing argument (variable arity); a leading
+    # fixed param is still checked, and the collected args are typed but not
+    # checked against a concrete type (fixed at monomorphization, #1475).
+    val fr: Result[src.FileId, str] = open(?es, "col.mach",
+        "fun take(tag: i64, va: ...) i64 { ret tag; } fun sum(va: ...) i64 { ret 0; } fun main() i64 { ret take(1, 2, 3) + sum() + sum(4, 5); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag.has_errors(unwrap_ok[*diag.DiagList, str](dr))) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: a call below a pack's leading fixed arity is rejected (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `take` requires its leading fixed `tag`; a bare `take()` supplies fewer than
+    # the fixed count and is an arity error even though the pack accepts any tail.
+    val fr: Result[src.FileId, str] = open(?es, "few.mach",
+        "fun take(tag: i64, va: ...) i64 { ret tag; } fun main() i64 { ret take(); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "arity mismatch: expected at least")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "diagnostics: calling a non-function renders the callee type (#1046)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1213,6 +1213,96 @@ test "sema: a call below a pack's leading fixed arity is rejected (#1474)" {
     ret 0;
 }
 
+test "sema: `va...` forwards a whole pack into a trailing pack param (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `inner` has a leading fixed param then a pack; `fwd` has only a pack. each
+    # forward passes the whole pack as the sole trailing argument.
+    val fr: Result[src.FileId, str] = open(?es, "fwd.mach",
+        "fun inner(tag: i64, va: ...) i64 { ret tag; } fun fwd(va: ...) i64 { ret inner(7, va...); } fun bare(va: ...) i64 { ret fwd(va...); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag.has_errors(unwrap_ok[*diag.DiagList, str](dr))) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: spreading `...` into fixed parameters is rejected (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `point` has no pack parameter, so the whole pack cannot be spread into it.
+    val fr: Result[src.FileId, str] = open(?es, "intofixed.mach",
+        "fun point(x: i64, y: i64) i64 { ret x; } fun outer(va: ...) i64 { ret point(va...); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "cannot spread `...` into fixed parameters")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: a `...` spread of a non-pack operand is rejected (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `z` is an ordinary value, not a pack; spreading it is malformed.
+    val fr: Result[src.FileId, str] = open(?es, "nonpack.mach",
+        "fun g(va: ...) i64 { ret 0; } fun f() i64 { var z: i64 = 0; ret g(z...); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "may only spread a variadic pack")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "sema: a `...` spread mixed with other trailing args is rejected (#1474)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `inner` is a pure pack; the spread must be the sole trailing argument, so a
+    # leading collected `1` alongside `va...` is rejected.
+    val fr: Result[src.FileId, str] = open(?es, "mixed.mach",
+        "fun inner(va: ...) i64 { ret 0; } fun outer(va: ...) i64 { ret inner(1, va...); }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "sole trailing argument")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "diagnostics: calling a non-function renders the callee type (#1046)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -421,6 +421,7 @@ fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
         es.alloc,
         target.host_os_id(),
         target.host_arch_id(),
+        target.host_abi_id(),
         target.host_pointer_width(),
         intern.STR_NIL,
         intern.STR_NIL

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1012,6 +1012,47 @@ test "diagnostics: a value name used as a type is told it does not name a type (
     ret 0;
 }
 
+test "diagnostics: an unknown backtick decorator is rejected (#1476)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    val fr: Result[src.FileId, str] = open(?es, "ud.mach", "`bogus` fun f() i64 { ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "unknown decorator; valid directives are symbol, section, inline, align, library")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "diagnostics: a decorator on an incompatible target is rejected (#1476)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `align` targets data and types, not a function — the mismatch is reported.
+    val fr: Result[src.FileId, str] = open(?es, "wt.mach", "`align(8)` fun f() i64 { ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(unwrap_ok[*diag.DiagList, str](dr), "`align` decorator applies only to data and types")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "diagnostics: calling a non-function renders the callee type (#1046)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1053,24 +1053,24 @@ test "diagnostics: a decorator on an incompatible target is rejected (#1476)" {
     ret 0;
 }
 
-test "diagnostics: a section decorator on a global places it; on a function is rejected (#1476)" {
+test "diagnostics: a section decorator on a function or global is accepted; on a type is rejected (#1476)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);
     if (is_err[sess.Session, str](sr)) { ret 1; }
     var s: sess.Session = unwrap_ok[sess.Session, str](sr);
     var es: EditorSession = init(?s);
 
-    # `section` on a global is accepted (no error); on a function it is reported
-    # as not yet implemented (the encoder cannot emit per-function sections yet).
+    # `section` applies to functions and globals (placed, no error); a `def` type
+    # is not a symbol-bearing decl, so a section on it is reported.
     val fr: Result[src.FileId, str] = open(?es, "se.mach",
-        "`section(\".s\")` pub var g: u64 = 0;\n`section(\".s\")` fun f() i64 { ret 0; }\n");
+        "`section(\".s\")` pub var g: u64 = 0;\n`section(\".s\")` fun f() i64 { ret 0; }\n`section(\".s\")` def D: u64;\n");
     if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
 
     val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
     if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val list: *diag.DiagList = unwrap_ok[*diag.DiagList, str](dr);
-    if (!diag_has(list, "`section` on functions is not yet implemented")) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!diag_has(list, "`section` decorator applies only to functions and globals")) { dnit(?es); sess.dnit(?s); ret 1; }
 
     dnit(?es);
     sess.dnit(?s);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1053,6 +1053,30 @@ test "diagnostics: a decorator on an incompatible target is rejected (#1476)" {
     ret 0;
 }
 
+test "diagnostics: a section decorator on a global places it; on a function is rejected (#1476)" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # `section` on a global is accepted (no error); on a function it is reported
+    # as not yet implemented (the encoder cannot emit per-function sections yet).
+    val fr: Result[src.FileId, str] = open(?es, "se.mach",
+        "`section(\".s\")` pub var g: u64 = 0;\n`section(\".s\")` fun f() i64 { ret 0; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val list: *diag.DiagList = unwrap_ok[*diag.DiagList, str](dr);
+    if (!diag_has(list, "`section` on functions is not yet implemented")) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
 test "diagnostics: calling a non-function renders the callee type (#1046)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);

--- a/src/lang/fe/ast.mach
+++ b/src/lang/fe/ast.mach
@@ -72,6 +72,9 @@ val INITIAL_ID_POOL_CAP: usize = 64;
 # comptime_branches:   pool of ComptimeBranch records referenced by DeclComptimeIf and StmtComptimeIf
 # comptime_branch_len: number of branches stored
 # comptime_branch_cap: allocated slots in comptime_branches
+# decorators:          pool of Decorator records referenced by a Decl's leading backtick clauses
+# decorator_len:       number of decorators stored
+# decorator_cap:       allocated slots in decorators
 # decl_ids:            typed pool of DeclIds for node-owned decl lists
 # decl_id_len:         number of DeclIds stored
 # decl_id_cap:         allocated slots in decl_ids
@@ -124,6 +127,10 @@ pub rec Ast {
     comptime_branches:    *decl.ComptimeBranch;
     comptime_branch_len:  usize;
     comptime_branch_cap:  usize;
+
+    decorators:    *decl.Decorator;
+    decorator_len: usize;
+    decorator_cap: usize;
 
     decl_ids:    *id.DeclId;
     decl_id_len: usize;
@@ -189,6 +196,10 @@ pub fun init(alloc: *Allocator, file_id: src.FileId) Ast {
     a.comptime_branch_len = 0;
     a.comptime_branch_cap = 0;
 
+    a.decorators    = nil;
+    a.decorator_len = 0;
+    a.decorator_cap = 0;
+
     a.decl_ids    = nil;
     a.decl_id_len = 0;
     a.decl_id_cap = 0;
@@ -241,6 +252,9 @@ pub fun dnit(a: *Ast) {
     if (a.comptime_branches != nil && a.comptime_branch_cap > 0) {
         deallocate[decl.ComptimeBranch](a.alloc, a.comptime_branches, a.comptime_branch_cap);
     }
+    if (a.decorators != nil && a.decorator_cap > 0) {
+        deallocate[decl.Decorator](a.alloc, a.decorators, a.decorator_cap);
+    }
     if (a.decl_ids != nil && a.decl_id_cap > 0) {
         deallocate[id.DeclId](a.alloc, a.decl_ids, a.decl_id_cap);
     }
@@ -289,6 +303,10 @@ pub fun dnit(a: *Ast) {
     a.comptime_branches   = nil;
     a.comptime_branch_len = 0;
     a.comptime_branch_cap = 0;
+
+    a.decorators    = nil;
+    a.decorator_len = 0;
+    a.decorator_cap = 0;
 
     a.decl_ids    = nil;
     a.decl_id_len = 0;
@@ -527,6 +545,25 @@ pub fun add_comptime_branch(a: *Ast, br: decl.ComptimeBranch) Result[u32, str] {
     val index: u32 = a.comptime_branch_len::u32;
     a.comptime_branches[a.comptime_branch_len] = br;
     a.comptime_branch_len = a.comptime_branch_len + 1;
+    ret ok[u32, str](index);
+}
+
+# add_decorator: appends a Decorator to the shared pool.
+# ---
+# a:   target Ast
+# d:   decorator record to append
+# ret: index into a.decorators for the new entry
+pub fun add_decorator(a: *Ast, d: decl.Decorator) Result[u32, str] {
+    if (a.decorator_len == a.decorator_cap) {
+        val r: Result[*decl.Decorator, str] = pool.grow[decl.Decorator](a.alloc, a.decorators, a.decorator_cap, INITIAL_AUX_CAP, ?a.decorator_cap);
+        if (is_err[*decl.Decorator, str](r)) {
+            ret err[u32, str](unwrap_err[*decl.Decorator, str](r));
+        }
+        a.decorators = unwrap_ok[*decl.Decorator, str](r);
+    }
+    val index: u32 = a.decorator_len::u32;
+    a.decorators[a.decorator_len] = d;
+    a.decorator_len = a.decorator_len + 1;
     ret ok[u32, str](index);
 }
 

--- a/src/lang/fe/ast/decl.mach
+++ b/src/lang/fe/ast/decl.mach
@@ -169,16 +169,34 @@ pub rec DeclComptimeAttr {
     value:  id.ExprId;
 }
 
+# Decorator: a leading backtick per-declaration codegen directive (#1476), e.g.
+# `` `symbol("_start")` `` / `` `inline` `` / `` `align($align_of(u64))` ``.
+# codegen-only (never visibility). attached to the following decl via the decl's
+# decorators_start/decorators_len range.
+# ---
+# name:       span of the directive identifier (symbol/section/inline/align/library)
+# args_start: start index into ast.expr_ids; each slot is a comptime-expr arg ExprId
+# args_len:   number of arguments (0 for a bare flag like `inline`)
+pub rec Decorator {
+    name:       token.Span;
+    args_start: u32;
+    args_len:   u32;
+}
+
 # Decl: a syntactic declaration node.
 # ---
-# span:  byte range of the declaration in source
-# kind:  which DECL_KIND_* variant is active
-# flags: bitfield of DECL_FLAG_* values (pub, ext)
-# data:  kind-specific payload; unused for ERROR (discriminated by kind alone)
+# span:            byte range of the declaration in source
+# kind:            which DECL_KIND_* variant is active
+# flags:           bitfield of DECL_FLAG_* values (pub, ext)
+# decorators_start: start index into ast.decorators of this decl's leading decorators
+# decorators_len:  number of leading backtick decorators (0 if none)
+# data:            kind-specific payload; unused for ERROR (discriminated by kind alone)
 pub rec Decl {
     span:  token.Span;
     kind:  DeclKind;
     flags: u8;
+    decorators_start: u32;
+    decorators_len:   u32;
     data: uni {
         use_:          DeclUse;
         fwd_:          DeclFwd;

--- a/src/lang/fe/ast/expr.mach
+++ b/src/lang/fe/ast/expr.mach
@@ -29,6 +29,10 @@ pub val EXPR_KIND_COMPTIME_IDENT: ExprKind = 15;
 # a `v.[f]` field projection (#1472/#1473): project the field named by a comptime
 # field descriptor `f` (bound by `$each`) off an instance `v`. an lvalue.
 pub val EXPR_KIND_PROJECT:        ExprKind = 16;
+# a `va...` pack spread (#1474): postfix `...` on a call argument, forwarding a
+# whole comptime variadic pack into a trailing pack parameter. recognized only
+# in call-argument position, never globally in the postfix grammar.
+pub val EXPR_KIND_SPREAD:         ExprKind = 17;
 pub val EXPR_KIND_ERROR:          ExprKind = 255;
 
 # BinOp: binary operator encoded in ExprBinary.op.
@@ -134,6 +138,14 @@ pub rec ExprProject {
     field:  id.ExprId;
 }
 
+# ExprSpread: a `va...` pack spread (#1474). `inner` is the spread operand — a
+# comptime variadic pack — forwarded whole into a trailing pack parameter.
+# ---
+# inner: the pack expression being spread
+pub rec ExprSpread {
+    inner: id.ExprId;
+}
+
 # ExprCast: a type cast expression. `::` performs a value conversion
 # (`value::Type`) and `:~` a same-size bit reinterpretation (`value:~Type`).
 # ---
@@ -198,5 +210,6 @@ pub rec Expr {
         array_lit:  ExprArrayLit;
         struct_lit: ExprStructLit;
         project:    ExprProject;
+        spread:     ExprSpread;
     };
 }

--- a/src/lang/fe/ast/expr.mach
+++ b/src/lang/fe/ast/expr.mach
@@ -26,6 +26,9 @@ pub val EXPR_KIND_CAST:           ExprKind = 12;
 pub val EXPR_KIND_ARRAY_LIT:      ExprKind = 13;
 pub val EXPR_KIND_STRUCT_LIT:     ExprKind = 14;
 pub val EXPR_KIND_COMPTIME_IDENT: ExprKind = 15;
+# a `v.[f]` field projection (#1472/#1473): project the field named by a comptime
+# field descriptor `f` (bound by `$each`) off an instance `v`. an lvalue.
+pub val EXPR_KIND_PROJECT:        ExprKind = 16;
 pub val EXPR_KIND_ERROR:          ExprKind = 255;
 
 # BinOp: binary operator encoded in ExprBinary.op.
@@ -120,6 +123,17 @@ pub rec ExprMember {
     name:   token.Span;
 }
 
+# ExprProject: a `v.[f]` field projection (#1472/#1473). `f` is a comptime field
+# descriptor bound by an enclosing `$each`; the projection resolves to the field
+# `f` names off the instance `object`. an lvalue (readable and writable).
+# ---
+# object: the instance whose field is projected
+# field:  the comptime field-descriptor expression (the `$each` loop variable)
+pub rec ExprProject {
+    object: id.ExprId;
+    field:  id.ExprId;
+}
+
 # ExprCast: a type cast expression. `::` performs a value conversion
 # (`value::Type`) and `:~` a same-size bit reinterpretation (`value:~Type`).
 # ---
@@ -183,5 +197,6 @@ pub rec Expr {
         cast:       ExprCast;
         array_lit:  ExprArrayLit;
         struct_lit: ExprStructLit;
+        project:    ExprProject;
     };
 }

--- a/src/lang/fe/ast/stmt.mach
+++ b/src/lang/fe/ast/stmt.mach
@@ -20,6 +20,8 @@ pub val STMT_KIND_FIN:         StmtKind = 7;
 pub val STMT_KIND_DECL:        StmtKind = 8;
 pub val STMT_KIND_ASM:         StmtKind = 9;
 pub val STMT_KIND_COMPTIME_IF: StmtKind = 10;
+# a `$each <ident> in <seq> { body }` bounded compile-time unroll (#1473).
+pub val STMT_KIND_COMPTIME_EACH: StmtKind = 11;
 pub val STMT_KIND_ERROR:       StmtKind = 255;
 
 # StmtExpr: a bare expression used as a statement.
@@ -97,6 +99,22 @@ pub rec StmtComptimeIf {
     branches_len:   u32;
 }
 
+# StmtComptimeEach: a `$each <ident> in <seq> { body }` bounded compile-time
+# unroll (#1473). the body is spliced once per element of the comptime-known
+# sequence, with `var_name` bound to that element. body statements live in a
+# contiguous slice of ast.stmt_ids.
+# ---
+# var_name:   span of the loop variable identifier
+# seq:        the comptime sequence expression (e.g. `$fields(T)`)
+# body_start: start index into ast.stmt_ids
+# body_len:   number of body statements
+pub rec StmtComptimeEach {
+    var_name:   token.Span;
+    seq:        id.ExprId;
+    body_start: u32;
+    body_len:   u32;
+}
+
 # Stmt: a syntactic statement node.
 # ---
 # span: byte range of the statement in source
@@ -106,14 +124,15 @@ pub rec Stmt {
     span: token.Span;
     kind: StmtKind;
     data: uni {
-        expr:        StmtExpr;
-        block:       StmtBlock;
-        if_:         StmtIf;
-        for_:        StmtFor;
-        ret_:        StmtRet;
-        fin_:        StmtFin;
-        decl:        StmtDecl;
-        asm_:        StmtAsm;
-        comptime_if: StmtComptimeIf;
+        expr:          StmtExpr;
+        block:         StmtBlock;
+        if_:           StmtIf;
+        for_:          StmtFor;
+        ret_:          StmtRet;
+        fin_:          StmtFin;
+        decl:          StmtDecl;
+        asm_:          StmtAsm;
+        comptime_if:   StmtComptimeIf;
+        comptime_each: StmtComptimeEach;
     };
 }

--- a/src/lang/fe/ast/type.mach
+++ b/src/lang/fe/ast/type.mach
@@ -18,6 +18,10 @@ pub val TYPE_KIND_ARRAY: TypeKind = 2;
 pub val TYPE_KIND_FUN:   TypeKind = 3;
 pub val TYPE_KIND_REC:   TypeKind = 4;
 pub val TYPE_KIND_UNI:   TypeKind = 5;
+# a comptime variadic pack type `...` on a named trailing parameter (#1474):
+# `fun f(va: ...)`. carries no payload — the pack's element types are fixed per
+# call site and supplied by monomorphization (#1475), not at declaration.
+pub val TYPE_KIND_PACK:  TypeKind = 6;
 pub val TYPE_KIND_ERROR: TypeKind = 255;
 
 # TypeNamed: a named type reference, optionally with generic arguments.

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -987,7 +987,9 @@ fun eval_binary(
     # compare. recognized structurally here so a type operand never reaches the
     # numeric / value evaluator below.
     if ((bin.op == expr.BIN_EQ || bin.op == expr.BIN_NEQ)
-        && is_type_comparison(a, source, bin)) {
+        && (is_type_comparison(a, source, bin)
+         || field_type_eval_operand(c, a, source, bin.lhs, interner)
+         || field_type_eval_operand(c, a, source, bin.rhs, interner))) {
         ret eval_type_comparison(c, a, source, bin, interner);
     }
 
@@ -1170,6 +1172,45 @@ pub fun is_type_comparison(a: *ast.Ast, source: str, bin: *expr.ExprBinary) bool
     ret is_type_of_call(a, source, bin.lhs) || is_type_of_call(a, source, bin.rhs);
 }
 
+# is_field_type_member: whether `eid` is structurally a `.type` member access (a
+# candidate `f.type` field-descriptor type, #1473). a structural test only — the
+# object is confirmed to be a field descriptor by the typed layers (resolve via
+# the loop variable, eval via the bound value), so a real record field named
+# `type` is never mistaken for one.
+# ---
+# a:      the ast that owns `eid`
+# source: source text (for the member span)
+# eid:    expression id to test
+# ret:    true when `eid` is a `<expr>.type` member access
+pub fun is_field_type_member(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_MEMBER) { ret false; }
+    ret view_eq_str(span_text(source, node.data.member.name), "type");
+}
+
+# field_type_eval_operand: whether `eid` is an `f.type` operand whose object
+# actually evaluates to a field descriptor (a fold-time check used to recognize a
+# `f.type == T` type comparison precisely, without mistaking a real `.type`
+# field). returns false when no field resolver is installed (pre-lowering).
+fun field_type_eval_operand(
+    c:        *ComptimeCtx,
+    a:        *ast.Ast,
+    source:   str,
+    eid:      id.ExprId,
+    interner: *intern.Interner
+) bool {
+    if (!is_field_type_member(a, source, eid)) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    val obj_r: Result[CTValue, str] = eval(c, a, source, node.data.member.object, interner);
+    if (is_err[CTValue, str](obj_r)) { ret false; }
+    ret unwrap_ok[CTValue, str](obj_r).kind == CT_KIND_FIELD;
+}
+
 # folds a type comparison: each operand resolves to a TYPE value through the
 # installed resolver, and the result is an identity compare. a context with no
 # resolver (every pass before lowering) defers loudly so arm selection happens at
@@ -1181,22 +1222,32 @@ fun eval_type_comparison(
     bin:      *expr.ExprBinary,
     interner: *intern.Interner
 ) Result[CTValue, str] {
-    val l_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.lhs);
+    val l_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.lhs, interner);
     if (is_err[CTValue, str](l_r)) { ret l_r; }
-    val r_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.rhs);
+    val r_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.rhs, interner);
     if (is_err[CTValue, str](r_r)) { ret r_r; }
     ret apply_equality(bin.op, unwrap_ok[CTValue, str](l_r), unwrap_ok[CTValue, str](r_r));
 }
 
-# resolves one type-comparison operand to its TYPE value through the installed
-# type resolver. errors when no resolver is installed, or when the operand has no
-# resolvable type identity.
+# resolves one type-comparison operand to its TYPE value. an `f.type`
+# field-descriptor type folds directly through the field resolver (#1473); a
+# `$type_of(...)` or type-name operand resolves through the installed type
+# resolver (#1472). errors when no resolver is installed, or when the operand has
+# no resolvable type identity.
 fun eval_type_operand(
-    c:       *ComptimeCtx,
-    a:       *ast.Ast,
-    source:  str,
-    operand: id.ExprId
+    c:        *ComptimeCtx,
+    a:        *ast.Ast,
+    source:   str,
+    operand:  id.ExprId,
+    interner: *intern.Interner
 ) Result[CTValue, str] {
+    # an `f.type` field-descriptor type folds directly to a TYPE value via the
+    # field resolver; the `$type_of` / type-name path does not fold this way.
+    if (is_field_type_member(a, source, operand)) {
+        val direct: Result[CTValue, str] = eval(c, a, source, operand, interner);
+        if (is_err[CTValue, str](direct)) { ret direct; }
+        if (unwrap_ok[CTValue, str](direct).kind == CT_KIND_TYPE) { ret direct; }
+    }
     if (c.type_fn == nil) { ret err[CTValue, str](COMPTIME_TYPE_NO_RESOLVER_MSG); }
     val fn: TypeIdentFn = c.type_fn::TypeIdentFn;
     val value_eid: id.ExprId = type_operand_value(a, source, operand);

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1051,6 +1051,44 @@ pub fun type_of_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
     ret a.expr_ids[node.data.call.args_start];
 }
 
+# is_fields_call: whether `eid` is a `$fields(T)` intrinsic call (#1473),
+# recognized structurally by a `$`-rooted COMPTIME_IDENT callee spelled `fields`.
+# ---
+# a:      the ast that owns `eid`
+# source: source text (for the callee span)
+# eid:    expression id to test
+# ret:    true when `eid` is a `$fields(...)` call
+pub fun is_fields_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL) { ret false; }
+    val ce_opt: Option[*expr.Expr] = ast.get_expr(a, node.data.call.callee);
+    if (is_none[*expr.Expr](ce_opt)) { ret false; }
+    val ce: *expr.Expr = unwrap[*expr.Expr](ce_opt);
+    if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret false; }
+    val ns: token.Span = comptime_ident_name(ce.span);
+    if (ns.len == 0) { ret false; }
+    ret view_eq_str(span_text(source, ns), "fields");
+}
+
+# fields_type_arg: the single type-naming argument of a `$fields(T)` call, or
+# EXPR_NIL when `eid` is not such a call or carries no argument.
+# ---
+# a:   the ast that owns `eid`
+# eid: a `$fields(...)` call expression id
+# ret: the type-argument expression id, or EXPR_NIL
+pub fun fields_type_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
+    if (eid == id.EXPR_NIL) { ret id.EXPR_NIL; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret id.EXPR_NIL; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL) { ret id.EXPR_NIL; }
+    if (node.data.call.args_len < 1) { ret id.EXPR_NIL; }
+    ret a.expr_ids[node.data.call.args_start];
+}
+
 # type_operand_value: the expression whose type identity a type-comparison operand
 # denotes. `$type_of(e)` denotes the type of its inner value `e`; any other
 # operand is a type-name spelling (`i64`, `module.Foo`) and denotes itself. the
@@ -1859,6 +1897,17 @@ fun type_value(t: u32) Result[CTValue, str] {
     v.kind   = CT_KIND_TYPE;
     v.data.t = t;
     ret ok[CTValue, str](v);
+}
+
+# field_value: a comptime FIELD descriptor (#1473) naming the owning record's
+# sema TypeId and a field ordinal. bound to the `$each` loop variable; read by
+# `.name` / `.type` / `.offset` and `v.[f]`.
+pub fun field_value(owner: u32, index: u32) CTValue {
+    var v: CTValue;
+    v.kind          = CT_KIND_FIELD;
+    v.data.fld.owner = owner;
+    v.data.fld.index = index;
+    ret v;
 }
 
 # helper: builds a full-length span over a literal and evaluates it as an integer.

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1432,11 +1432,19 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
         ret int_value(unwrap_ok[u32, str](r)::i64);
     }
     # $mach.abi.<name> — abi tag value, in the same numeric space as
-    # $mach.target.abi so `$mach.target.abi == $mach.abi.sysv` is an int compare;
+    # $mach.build.abi so `$mach.build.abi == $mach.abi.sysv` is an int compare;
     # unrecognized names error likewise.
     if (depth == 3 && seg_is(source, stack, 1, "abi")) {
         val name: StrView = span_text(source, stack[0]);
         val r: Result[u32, str] = abi_tag_for(name);
+        if (is_err[u32, str](r)) { ret err[CTValue, str](unwrap_err[u32, str](r)); }
+        ret int_value(unwrap_ok[u32, str](r)::i64);
+    }
+    # $mach.mode.<name> — mode tag value (debug/release), same numeric space as
+    # $mach.build.mode; unrecognized names error likewise.
+    if (depth == 3 && seg_is(source, stack, 1, "mode")) {
+        val name: StrView = span_text(source, stack[0]);
+        val r: Result[u32, str] = mode_tag_for(name);
         if (is_err[u32, str](r)) { ret err[CTValue, str](unwrap_err[u32, str](r)); }
         ret int_value(unwrap_ok[u32, str](r)::i64);
     }
@@ -1540,6 +1548,21 @@ fun abi_tag_for(name: StrView) Result[u32, str] {
     if (view_eq_str(name, "win64"))   { ret ok[u32, str](abi.ABI_WIN64); }
     if (view_eq_str(name, "aapcs64")) { ret ok[u32, str](abi.ABI_AAPCS64); }
     ret err[u32, str]("unknown `$mach.abi.*` tag");
+}
+
+# the comptime mode-id space for `$mach.mode.*` and `$mach.build.mode`: a stable
+# 2-value space (debug/release) that mirrors me.pipeline's OptLevel (OPT_DEBUG=0
+# / OPT_RELEASE=1) without importing the middle end into the front end. the build
+# threads the resolved optimization level into `ComptimeCtx.build_mode_id`.
+pub val MODE_DEBUG:   u32 = 0;
+pub val MODE_RELEASE: u32 = 1;
+
+# maps an `$mach.mode.<name>` tag to its mode id; the active build's value reads
+# from `$mach.build.mode`. closed list; an unrecognized name is an error.
+fun mode_tag_for(name: StrView) Result[u32, str] {
+    if (view_eq_str(name, "debug"))   { ret ok[u32, str](MODE_DEBUG); }
+    if (view_eq_str(name, "release")) { ret ok[u32, str](MODE_RELEASE); }
+    ret err[u32, str]("unknown `$mach.mode.*` tag");
 }
 
 # version_component: the `which`-th dot-separated component (0=major, 1=minor,

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -82,6 +82,13 @@ pub val CT_KIND_FLOAT: CTKind = 1;
 pub val CT_KIND_BOOL:  CTKind = 2;
 pub val CT_KIND_STR:   CTKind = 3;
 
+# a comptime TYPE value (#1472): `$type_of(expr)` and a type-name operand fold to
+# one of these so a type `==` / `!=` inside a `$if` gate is a plain identity
+# compare. the payload `data.t` is an opaque type-identity token minted by the
+# typed layer's resolver (a canonical sema TypeId): equal tokens name the same
+# type. eval never interprets the token, only compares it.
+pub val CT_KIND_TYPE:  CTKind = 4;
+
 # COMPTIME_BARE_IDENT_MSG: the single teaching diagnostic for a standalone bare
 # `$ident` (#1249). the comptime channel's shapes are a closed set; a lone
 # `$ident` is none of them — a comptime parameter is referenced without `$`, and
@@ -108,6 +115,7 @@ pub rec CTValue {
         f: f64;
         b: bool;
         s: intern.StrId;
+        t: u32;
     };
 }
 
@@ -135,6 +143,29 @@ pub def ModuleMemberFn: fun(ptr, id.ExprId) Result[Option[CTValue], str];
 # is not available before lowering, so such a path cannot fold there.
 pub val COMPTIME_MEMBER_NO_RESOLVER_MSG: str =
     "a module-qualified member path is only comptime-evaluable after name resolution";
+
+# TypeIdentFn: resolves a type-comparison operand expression to its opaque
+# type-identity token (a canonical sema TypeId), or none when the operand has no
+# resolvable type. eval recognizes the type-comparison shape structurally
+# (`$type_of(...)` against a type name) but has no type system, so the typed
+# layer (lowering, where monomorphized concrete types are known) installs this
+# hook with `set_type_resolver`. the first argument is the installer's opaque
+# context; the second is the operand expression id, already unwrapped past a
+# `$type_of(...)` to its inner value expression.
+pub def TypeIdentFn: fun(ptr, id.ExprId) Result[Option[u32], str];
+
+# COMPTIME_TYPE_NO_RESOLVER_MSG: surfaced when a type comparison is evaluated in
+# a context that installed no type resolver — type identities are only available
+# after types exist, so arm selection on a `$type_of(...)` gate is deferred to
+# lowering.
+pub val COMPTIME_TYPE_NO_RESOLVER_MSG: str =
+    "a type comparison is only comptime-evaluable after type checking";
+
+# COMPTIME_TYPE_UNRESOLVED_MSG: surfaced when a type-comparison operand has no
+# resolvable type identity (an untyped or erroneous operand) even though a
+# resolver is installed.
+pub val COMPTIME_TYPE_UNRESOLVED_MSG: str =
+    "type comparison operand does not name a type";
 
 # COMPTIME_MEMBER_NOT_CONST_MSG: surfaced when a module-qualified member path
 # resolves but does not name a module-level comptime constant (a function, a
@@ -193,6 +224,10 @@ pub def FrameMark: u32;
 # member_fn:      erased ModuleMemberFn resolving `alias.CONST` member paths, or
 #                 nil when no resolver is installed (every pass before lowering)
 # member_data:    opaque context passed to member_fn (the *LowerContext)
+# type_fn:        erased TypeIdentFn resolving a type-comparison operand to its
+#                 type-identity token, or nil when no resolver is installed (every
+#                 pass before lowering)
+# type_data:      opaque context passed to type_fn (the *LowerContext)
 pub rec ComptimeCtx {
     alloc:          *Allocator;
     target_os_id:   u32;
@@ -218,6 +253,8 @@ pub rec ComptimeCtx {
     bin_name:       intern.StrId;
     member_fn:      *u8;
     member_data:    ptr;
+    type_fn:        *u8;
+    type_data:      ptr;
 }
 
 val INITIAL_CONST_CAP: u32 = 8;
@@ -279,6 +316,8 @@ pub fun init(
     c.bin_name       = intern.STR_NIL;
     c.member_fn      = nil;
     c.member_data    = nil;
+    c.type_fn        = nil;
+    c.type_data      = nil;
     ret c;
 }
 
@@ -294,6 +333,20 @@ pub fun init(
 pub fun set_member_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
     c.member_fn   = fn;
     c.member_data = data;
+}
+
+# set_type_resolver: install (or clear) the type-comparison operand resolver this
+# context consults when comptime.eval folds a `$type_of(...)` type comparison.
+# lowering installs it pointing at the active LowerContext; passing `nil` for
+# both clears it. kept out of the build/target setters because it is per-pass
+# state, not manifest-derived.
+# ---
+# c:    context to update
+# fn:   erased TypeIdentFn, or nil to clear
+# data: opaque context handed back to fn, or nil to clear
+pub fun set_type_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
+    c.type_fn   = fn;
+    c.type_data = data;
 }
 
 # set_build_context: bind the manifest-derived project metadata, the selected
@@ -856,6 +909,16 @@ fun eval_binary(
         ret eval_logical(c, a, source, bin, interner);
     }
 
+    # a type comparison (`$type_of(...) == TypeName`, #1472) is a closed shape: an
+    # `==` / `!=` with a `$type_of(...)` operand. each operand folds to a TYPE
+    # value through the installed type resolver, and the result is an identity
+    # compare. recognized structurally here so a type operand never reaches the
+    # numeric / value evaluator below.
+    if ((bin.op == expr.BIN_EQ || bin.op == expr.BIN_NEQ)
+        && is_type_comparison(a, source, bin)) {
+        ret eval_type_comparison(c, a, source, bin, interner);
+    }
+
     val lhs_r: Result[CTValue, str] = eval(c, a, source, bin.lhs, interner);
     if (is_err[CTValue, str](lhs_r)) { ret lhs_r; }
     val rhs_r: Result[CTValue, str] = eval(c, a, source, bin.rhs, interner);
@@ -931,6 +994,109 @@ fun eval_logical(
     ret bool_value(rhs.data.b);
 }
 
+# is_type_of_call: whether `eid` is a `$type_of(arg)` intrinsic call, recognized
+# structurally by a `$`-rooted COMPTIME_IDENT callee spelled `type_of`. arity is
+# validated by sema, not here.
+# ---
+# a:      the ast that owns `eid`
+# source: source text (for the callee span)
+# eid:    expression id to test
+# ret:    true when `eid` is a `$type_of(...)` call
+pub fun is_type_of_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL) { ret false; }
+    val ce_opt: Option[*expr.Expr] = ast.get_expr(a, node.data.call.callee);
+    if (is_none[*expr.Expr](ce_opt)) { ret false; }
+    val ce: *expr.Expr = unwrap[*expr.Expr](ce_opt);
+    if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret false; }
+    val ns: token.Span = comptime_ident_name(ce.span);
+    if (ns.len == 0) { ret false; }
+    ret view_eq_str(span_text(source, ns), "type_of");
+}
+
+# type_of_arg: the single value-argument expression of a `$type_of(arg)` call, or
+# EXPR_NIL when `eid` is not such a call or carries no argument.
+# ---
+# a:   the ast that owns `eid`
+# eid: a `$type_of(...)` call expression id
+# ret: the argument expression id, or EXPR_NIL
+pub fun type_of_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
+    if (eid == id.EXPR_NIL) { ret id.EXPR_NIL; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret id.EXPR_NIL; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL) { ret id.EXPR_NIL; }
+    if (node.data.call.args_len < 1) { ret id.EXPR_NIL; }
+    ret a.expr_ids[node.data.call.args_start];
+}
+
+# type_operand_value: the expression whose type identity a type-comparison operand
+# denotes. `$type_of(e)` denotes the type of its inner value `e`; any other
+# operand is a type-name spelling (`i64`, `module.Foo`) and denotes itself. the
+# installed type resolver reads the resulting expression's type slot either way.
+# ---
+# a:       the ast that owns `operand`
+# source:  source text (for the callee span)
+# operand: a type-comparison operand expression id
+# ret:     the inner value expression for `$type_of(...)`, else `operand`
+pub fun type_operand_value(a: *ast.Ast, source: str, operand: id.ExprId) id.ExprId {
+    if (is_type_of_call(a, source, operand)) { ret type_of_arg(a, operand); }
+    ret operand;
+}
+
+# is_type_comparison: whether a binary `==` / `!=` is a type comparison — true
+# when at least one operand is a `$type_of(...)` call. shared by resolve (to bind
+# the type-name operand as a type), sema (to type the comparison), and the
+# evaluator (to fold it).
+# ---
+# a:      the ast that owns `bin`
+# source: source text (for callee spans)
+# bin:    the binary expression
+# ret:    true when the binary is a type comparison
+pub fun is_type_comparison(a: *ast.Ast, source: str, bin: *expr.ExprBinary) bool {
+    ret is_type_of_call(a, source, bin.lhs) || is_type_of_call(a, source, bin.rhs);
+}
+
+# folds a type comparison: each operand resolves to a TYPE value through the
+# installed resolver, and the result is an identity compare. a context with no
+# resolver (every pass before lowering) defers loudly so arm selection happens at
+# lowering, where monomorphized concrete types are known.
+fun eval_type_comparison(
+    c:        *ComptimeCtx,
+    a:        *ast.Ast,
+    source:   str,
+    bin:      *expr.ExprBinary,
+    interner: *intern.Interner
+) Result[CTValue, str] {
+    val l_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.lhs);
+    if (is_err[CTValue, str](l_r)) { ret l_r; }
+    val r_r: Result[CTValue, str] = eval_type_operand(c, a, source, bin.rhs);
+    if (is_err[CTValue, str](r_r)) { ret r_r; }
+    ret apply_equality(bin.op, unwrap_ok[CTValue, str](l_r), unwrap_ok[CTValue, str](r_r));
+}
+
+# resolves one type-comparison operand to its TYPE value through the installed
+# type resolver. errors when no resolver is installed, or when the operand has no
+# resolvable type identity.
+fun eval_type_operand(
+    c:       *ComptimeCtx,
+    a:       *ast.Ast,
+    source:  str,
+    operand: id.ExprId
+) Result[CTValue, str] {
+    if (c.type_fn == nil) { ret err[CTValue, str](COMPTIME_TYPE_NO_RESOLVER_MSG); }
+    val fn: TypeIdentFn = c.type_fn::TypeIdentFn;
+    val value_eid: id.ExprId = type_operand_value(a, source, operand);
+    val r: Result[Option[u32], str] = fn(c.type_data, value_eid);
+    if (is_err[Option[u32], str](r)) { ret err[CTValue, str](unwrap_err[Option[u32], str](r)); }
+    val o: Option[u32] = unwrap_ok[Option[u32], str](r);
+    if (is_none[u32](o)) { ret err[CTValue, str](COMPTIME_TYPE_UNRESOLVED_MSG); }
+    ret type_value(unwrap[u32](o));
+}
+
 # ct_is_negative: whether an integer CTValue denotes a negative mathematical
 # value. only a signed payload with its high bit set is negative; an unsigned
 # payload is always a non-negative magnitude. non-integer values are never
@@ -970,6 +1136,7 @@ fun apply_equality(op: expr.BinOp, lhs: CTValue, rhs: CTValue) Result[CTValue, s
     or (lhs.kind == CT_KIND_FLOAT) { eq = lhs.data.f == rhs.data.f; }
     or (lhs.kind == CT_KIND_BOOL)  { eq = lhs.data.b == rhs.data.b; }
     or (lhs.kind == CT_KIND_STR)   { eq = lhs.data.s == rhs.data.s; }
+    or (lhs.kind == CT_KIND_TYPE)  { eq = lhs.data.t == rhs.data.t; }
 
     if (op == expr.BIN_EQ)  { ret bool_value(eq); }
     ret bool_value(!eq);
@@ -1664,6 +1831,15 @@ fun str_value(s: intern.StrId) Result[CTValue, str] {
     var v: CTValue;
     v.kind   = CT_KIND_STR;
     v.data.s = s;
+    ret ok[CTValue, str](v);
+}
+
+# type_value: a comptime TYPE value carrying an opaque type-identity token (a
+# canonical sema TypeId minted by the resolver). compared only for identity.
+fun type_value(t: u32) Result[CTValue, str] {
+    var v: CTValue;
+    v.kind   = CT_KIND_TYPE;
+    v.data.t = t;
     ret ok[CTValue, str](v);
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -185,6 +185,36 @@ pub val COMPTIME_TYPE_NO_RESOLVER_MSG: str =
 pub val COMPTIME_TYPE_UNRESOLVED_MSG: str =
     "type comparison operand does not name a type";
 
+# field-descriptor member selectors (#1473): which attribute of a `CT_KIND_FIELD`
+# descriptor a `.name` / `.type` / `.offset` projection reads.
+pub val FIELD_SEL_NAME:   u8 = 0;
+pub val FIELD_SEL_TYPE:   u8 = 1;
+pub val FIELD_SEL_OFFSET: u8 = 2;
+
+# FieldMemberFn: projects an attribute of a comptime field descriptor (#1473).
+# given the owning record's sema TypeId, the field ordinal, and a FIELD_SEL_*
+# selector, it returns the attribute as a CTValue (`.name` -> str, `.type` ->
+# type, `.offset` -> int), or none when the attribute is unavailable in this
+# context (`.offset` before lowering, which needs the target layout). eval has no
+# type system, so the typed layer (sema for name/type, lowering for all three)
+# installs this hook with `set_field_resolver`.
+pub def FieldMemberFn: fun(ptr, u32, u32, u8) Result[Option[CTValue], str];
+
+# COMPTIME_FIELD_NO_RESOLVER_MSG: surfaced when a field-descriptor member is read
+# in a context that installed no field resolver (every pass before sema).
+pub val COMPTIME_FIELD_NO_RESOLVER_MSG: str =
+    "a field descriptor member is only comptime-evaluable after type checking";
+
+# COMPTIME_FIELD_UNKNOWN_MEMBER_MSG: surfaced when a field descriptor is projected
+# with a member other than `.name` / `.type` / `.offset`.
+pub val COMPTIME_FIELD_UNKNOWN_MEMBER_MSG: str =
+    "a field descriptor has only `.name`, `.type`, and `.offset`";
+
+# COMPTIME_FIELD_UNAVAILABLE_MSG: surfaced when a field-descriptor member is not
+# available in the active context (e.g. `.offset` before lowering).
+pub val COMPTIME_FIELD_UNAVAILABLE_MSG: str =
+    "this field descriptor member is not available until lowering";
+
 # COMPTIME_MEMBER_NOT_CONST_MSG: surfaced when a module-qualified member path
 # resolves but does not name a module-level comptime constant (a function, a
 # `var`, a non-constant `val`, or an unexported / unknown member).
@@ -273,6 +303,8 @@ pub rec ComptimeCtx {
     member_data:    ptr;
     type_fn:        *u8;
     type_data:      ptr;
+    field_fn:       *u8;
+    field_data:     ptr;
 }
 
 val INITIAL_CONST_CAP: u32 = 8;
@@ -336,6 +368,8 @@ pub fun init(
     c.member_data    = nil;
     c.type_fn        = nil;
     c.type_data      = nil;
+    c.field_fn       = nil;
+    c.field_data     = nil;
     ret c;
 }
 
@@ -365,6 +399,19 @@ pub fun set_member_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
 pub fun set_type_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
     c.type_fn   = fn;
     c.type_data = data;
+}
+
+# set_field_resolver: install (or clear) the field-descriptor member resolver
+# this context consults when comptime.eval projects `.name` / `.type` / `.offset`
+# off a `CT_KIND_FIELD` value (#1473). sema installs the name/type half; lowering
+# installs all three. passing `nil` for both clears it.
+# ---
+# c:    context to update
+# fn:   erased FieldMemberFn, or nil to clear
+# data: opaque context handed back to fn, or nil to clear
+pub fun set_field_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
+    c.field_fn   = fn;
+    c.field_data = data;
 }
 
 # set_build_context: bind the manifest-derived project metadata, the selected
@@ -605,6 +652,13 @@ pub fun eval(
     # resolved through the installed member resolver.
     if (k == expr.EXPR_KIND_MEMBER) {
         if (is_comptime_path(a, e)) { ret eval_path(c, a, source, e, interner); }
+        # a `.name` / `.type` / `.offset` projection off a comptime field
+        # descriptor (#1473): fires only when the object evaluates to a
+        # CT_KIND_FIELD, so a member of any other value falls through to the
+        # module-member path (no collision with a record field named `type`).
+        val fld: Option[Result[CTValue, str]] =
+            eval_field_member(c, a, source, node.data.member.object, node.data.member.name, interner);
+        if (is_some[Result[CTValue, str]](fld)) { ret unwrap[Result[CTValue, str]](fld); }
         ret eval_module_member(c, e);
     }
 
@@ -1410,6 +1464,40 @@ fun eval_module_member(c: *ComptimeCtx, e: id.ExprId) Result[CTValue, str] {
     ret err[CTValue, str](COMPTIME_MEMBER_NOT_CONST_MSG);
 }
 
+# eval_field_member: projects `.name` / `.type` / `.offset` off a comptime field
+# descriptor (#1473). returns none when `object` does not evaluate to a
+# CT_KIND_FIELD — so the MEMBER dispatch falls through to the module-member path,
+# leaving an ordinary `value.field` access untouched. some(...) carries the
+# projected value, or the error explaining why it could not fold.
+fun eval_field_member(
+    c:           *ComptimeCtx,
+    a:           *ast.Ast,
+    source:      str,
+    object_eid:  id.ExprId,
+    member_span: token.Span,
+    interner:    *intern.Interner
+) Option[Result[CTValue, str]] {
+    val obj_r: Result[CTValue, str] = eval(c, a, source, object_eid, interner);
+    if (is_err[CTValue, str](obj_r)) { ret none[Result[CTValue, str]](); }
+    val obj: CTValue = unwrap_ok[CTValue, str](obj_r);
+    if (obj.kind != CT_KIND_FIELD) { ret none[Result[CTValue, str]](); }
+
+    val mtext: StrView = span_text(source, member_span);
+    var sel: u8 = FIELD_SEL_NAME;
+    if      (view_eq_str(mtext, "name"))   { sel = FIELD_SEL_NAME; }
+    or      (view_eq_str(mtext, "type"))   { sel = FIELD_SEL_TYPE; }
+    or      (view_eq_str(mtext, "offset")) { sel = FIELD_SEL_OFFSET; }
+    or      { ret some[Result[CTValue, str]](err[CTValue, str](COMPTIME_FIELD_UNKNOWN_MEMBER_MSG)); }
+
+    if (c.field_fn == nil) { ret some[Result[CTValue, str]](err[CTValue, str](COMPTIME_FIELD_NO_RESOLVER_MSG)); }
+    val fn: FieldMemberFn = c.field_fn::FieldMemberFn;
+    val r: Result[Option[CTValue], str] = fn(c.field_data, obj.data.fld.owner, obj.data.fld.index, sel);
+    if (is_err[Option[CTValue], str](r)) { ret some[Result[CTValue, str]](err[CTValue, str](unwrap_err[Option[CTValue], str](r))); }
+    val o: Option[CTValue] = unwrap_ok[Option[CTValue], str](r);
+    if (is_none[CTValue](o)) { ret some[Result[CTValue, str]](err[CTValue, str](COMPTIME_FIELD_UNAVAILABLE_MSG)); }
+    ret some[Result[CTValue, str]](ok[CTValue, str](unwrap[CTValue](o)));
+}
+
 # reports whether `e` is a comptime path expression: a bare COMPTIME_IDENT
 # (`$foo`) or a chain of MEMBER expressions whose leftmost root is a
 # COMPTIME_IDENT (`$mach.target.os`). a path is comptime-evaluable in form
@@ -1907,6 +1995,34 @@ pub fun field_value(owner: u32, index: u32) CTValue {
     v.kind          = CT_KIND_FIELD;
     v.data.fld.owner = owner;
     v.data.fld.index = index;
+    ret v;
+}
+
+# ct_str: a comptime string value over an interned StrId. used by the field
+# resolver to build a `f.name` projection (#1473).
+pub fun ct_str(s: intern.StrId) CTValue {
+    var v: CTValue;
+    v.kind   = CT_KIND_STR;
+    v.data.s = s;
+    ret v;
+}
+
+# ct_type: a comptime TYPE value over a sema TypeId token. used by the field
+# resolver to build a `f.type` projection (#1473).
+pub fun ct_type(t: u32) CTValue {
+    var v: CTValue;
+    v.kind   = CT_KIND_TYPE;
+    v.data.t = t;
+    ret v;
+}
+
+# ct_uint: a comptime unsigned-integer value. used by the field resolver to build
+# a `f.offset` projection (#1473), an unsigned `usize` magnitude.
+pub fun ct_uint(n: u64) CTValue {
+    var v: CTValue;
+    v.kind         = CT_KIND_INT;
+    v.int_unsigned = true;
+    v.data.i       = n:~i64;
     ret v;
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -73,6 +73,8 @@ use token:  mach.lang.fe.token;
 use os:     mach.lang.target.os;
 use isa:    mach.lang.target.isa;
 use abi:    mach.lang.target.abi;
+use float:  mach.lang.float;
+use bignum: mach.lang.bignum;
 
 # CTKind: discriminator for CTValue.data.
 pub def CTKind: u8;
@@ -766,13 +768,117 @@ pub fun eval_lit_int(source: str, span: token.Span) Result[CTValue, str] {
 
 # parses a float literal from its source text. supports decimal `digit.digit`
 # form with optional exponent and `f<n>` width suffix; rejects malformed input
+# cmp_ratio_pow2: sign of (num/den - 2^p) — compares the rational num/den to 2^p.
+fun cmp_ratio_pow2(num: *bignum.Big, den: *bignum.Big, p: i64) i64 {
+    var a: bignum.Big;
+    var b: bignum.Big;
+    bignum.copy(?a, num);
+    bignum.copy(?b, den);
+    if (p >= 0) { bignum.shl(?b, p::usize); }
+    or { bignum.shl(?a, (0 - p)::usize); }
+    ret bignum.cmp(?a, ?b);
+}
+
+# decimal_to_f64: nearest f64 bit pattern (sign excluded) to M * 10^D, round-to-
+# nearest-even, via exact bignum arithmetic. M is non-negative. trunc records
+# that nonzero significand digits were dropped past the 768-digit cap (the sticky
+# bit), so an apparent exact midpoint is really above it and rounds up. handles
+# subnormals, overflow (-> inf), and underflow (-> 0).
+fun decimal_to_f64(M: *bignum.Big, D: i64, trunc: bool) u64 {
+    if (bignum.is_zero(M)) { ret 0; }
+
+    # short-circuit clearly out-of-range magnitudes (keeps the bignum bounded).
+    val approx: i64 = D + (bignum.bitlen(M)::i64 * 1233) / 4096;
+    if (approx > 320) { ret 0x7FF0000000000000; }
+    if (approx < -340) { ret 0; }
+
+    # exact rational num/den = M * 10^D.
+    var num: bignum.Big;
+    var den: bignum.Big;
+    bignum.copy(?num, M);
+    bignum.from_u64(?den, 1);
+    if (D >= 0) { bignum.mul_pow10(?num, D::usize); }
+    or { bignum.mul_pow10(?den, (0 - D)::usize); }
+
+    # find e2 with 2^(e2+52) <= value < 2^(e2+53) (53-bit normal mantissa window).
+    var e2: i64 = bignum.bitlen(?num)::i64 - bignum.bitlen(?den)::i64 - 53;
+    var done: bool = false;
+    for (!done) {
+        if (cmp_ratio_pow2(?num, ?den, e2 + 53) >= 0) { e2 = e2 + 1; cnt; }
+        if (cmp_ratio_pow2(?num, ?den, e2 + 52) < 0)  { e2 = e2 - 1; cnt; }
+        done = true;
+    }
+
+    # clamp the mantissa LSB to the subnormal floor (2^-1074) — a single rounding.
+    var lsb: i64 = e2;
+    if (lsb < -1074) { lsb = -1074; }
+
+    # nn/dd = value / 2^lsb.
+    var nn: bignum.Big;
+    var dd: bignum.Big;
+    bignum.copy(?nn, ?num);
+    bignum.copy(?dd, ?den);
+    if (lsb >= 0) { bignum.shl(?dd, lsb::usize); }
+    or { bignum.shl(?nn, (0 - lsb)::usize); }
+
+    # q = floor(nn / dd) via binary long division; remainder left in rem.
+    var q: u64 = 0;
+    var rem: bignum.Big;
+    bignum.copy(?rem, ?nn);
+    var b: i64 = 53;
+    for (b >= 0) {
+        var t: bignum.Big;
+        bignum.copy(?t, ?dd);
+        bignum.shl(?t, b::usize);
+        if (bignum.cmp(?rem, ?t) >= 0) {
+            bignum.sub(?rem, ?t);
+            q = q | (1::u64 << b::usize);
+        }
+        b = b - 1;
+    }
+
+    # round-to-nearest-even using 2*rem vs dd.
+    var rem2: bignum.Big;
+    bignum.copy(?rem2, ?rem);
+    bignum.shl(?rem2, 1);
+    val c: i64 = bignum.cmp(?rem2, ?dd);
+    if (c > 0) { q = q + 1; }
+    or (c == 0) {
+        # M*10^D sits exactly on the midpoint: dropped nonzero digits (trunc)
+        # push the true value above it, so round up instead of to-even.
+        if (trunc) { q = q + 1; }
+        or { if ((q & 1) == 1) { q = q + 1; } }
+    }
+
+    if (lsb == -1074) {
+        # subnormal regime (and the smallest normals): the bit pattern is q itself.
+        ret q;
+    }
+    var biased: i64 = e2 + 1075;
+    if (q == 0x20000000000000) {
+        q = 0x10000000000000;
+        biased = biased + 1;
+    }
+    if (biased >= 2047) { ret 0x7FF0000000000000; }
+    ret (biased::u64 << 52) | (q & 0xFFFFFFFFFFFFF);
+}
+
 pub fun eval_lit_float(source: str, span: token.Span) Result[CTValue, str] {
     val text: StrView = span_text(source, span);
     if (text.len == 0) { ret err[CTValue, str]("empty float literal"); }
 
-    var i: usize = 0;
-    var integer_part: f64 = 0.0;
+    # exact significand M and its decimal exponent: value-so-far = M * 10^dexp.
+    # at most 768 significant digits are kept (well past what f64 rounding can
+    # use); excess digits only set the sticky `trunc` bit.
+    var M: bignum.Big;
+    bignum.from_u64(?M, 0);
+    var dexp:      i64  = 0;
+    var sig:       i64  = 0;
+    var trunc:     bool = false;
     var saw_digit: bool = false;
+    val MAXSIG:    i64  = 768;
+
+    var i: usize = 0;
     for (i < text.len) {
         val c: u8 = text.data[i];
         if (c == '_') { i = i + 1; cnt; }
@@ -780,13 +886,19 @@ pub fun eval_lit_float(source: str, span: token.Span) Result[CTValue, str] {
         if (c == 'e' || c == 'E') { brk; }
         if (c == 'f') { brk; }
         if (c < '0' || c > '9') { ret err[CTValue, str]("invalid character in float literal"); }
-        integer_part = integer_part * 10.0 + (c - '0')::f64;
         saw_digit = true;
+        if (sig < MAXSIG) {
+            bignum.mul_small(?M, 10);
+            bignum.add_small(?M, (c - '0')::u32);
+            if (!bignum.is_zero(?M)) { sig = sig + 1; }
+        }
+        or {
+            dexp = dexp + 1;
+            if (c != '0') { trunc = true; }
+        }
         i = i + 1;
     }
 
-    var fraction: f64 = 0.0;
-    var fdiv:     f64 = 1.0;
     if (i < text.len && text.data[i] == '.') {
         i = i + 1;
         for (i < text.len) {
@@ -795,55 +907,51 @@ pub fun eval_lit_float(source: str, span: token.Span) Result[CTValue, str] {
             if (c == 'e' || c == 'E') { brk; }
             if (c == 'f') { brk; }
             if (c < '0' || c > '9') { ret err[CTValue, str]("invalid character in float literal"); }
-            fraction = fraction * 10.0 + (c - '0')::f64;
-            fdiv = fdiv * 10.0;
             saw_digit = true;
+            if (sig < MAXSIG) {
+                bignum.mul_small(?M, 10);
+                bignum.add_small(?M, (c - '0')::u32);
+                if (!bignum.is_zero(?M)) { sig = sig + 1; }
+                dexp = dexp - 1;
+            }
+            or {
+                if (c != '0') { trunc = true; }
+            }
             i = i + 1;
         }
     }
 
-    var value: f64 = integer_part + fraction / fdiv;
-
+    var exp: i64 = 0;
     if (i < text.len && (text.data[i] == 'e' || text.data[i] == 'E')) {
         i = i + 1;
         var neg: bool = false;
         if (i < text.len && text.data[i] == '-') { neg = true; i = i + 1; }
         or (i < text.len && text.data[i] == '+') { i = i + 1; }
 
-        var exp: i64 = 0;
         var saw_exp_digit: bool = false;
         for (i < text.len) {
             val c: u8 = text.data[i];
             if (c == 'f') { brk; }
+            if (c == '_') { i = i + 1; cnt; }
             if (c < '0' || c > '9') { ret err[CTValue, str]("invalid character in float exponent"); }
-            # f64 saturates to inf/0 long before 10^1000, so clamp the accumulator: a
-            # larger exponent (e.g. 1.0e2000000000) would otherwise overflow i64 —
-            # silently folding to the mantissa — or spin the scale loop for billions of
-            # iterations. any exponent >= ~309 already yields the same saturated result.
-            if (exp < 1000) { exp = exp * 10 + (c - '0')::i64; }
+            # |exp| >= 1e6 always saturates f64 to inf/0 (range ~1e+-308), so clamp
+            # the accumulator: it bounds the bignum and avoids i64 overflow on absurd
+            # exponents while yielding the same saturated result decimal_to_f64 gives.
+            if (exp < 1000000) { exp = exp * 10 + (c - '0')::i64; }
             saw_exp_digit = true;
             i = i + 1;
         }
         if (!saw_exp_digit) { ret err[CTValue, str]("missing digits in float exponent"); }
-
-        var scale: f64 = 1.0;
-        var k: i64 = 0;
-        for (k < exp) {
-            scale = scale * 10.0;
-            k = k + 1;
-        }
-        # a zero mantissa stays zero at any exponent; the guard also avoids
-        # 0.0 * inf = NaN once the clamped exponent drives the scale to inf.
-        if (value != 0.0) {
-            if (neg) { value = value / scale; } or { value = value * scale; }
-        }
+        if (neg) { exp = 0 - exp; }
     }
 
     if (!saw_digit) { ret err[CTValue, str]("float literal has no digits"); }
 
+    val bits: u64 = decimal_to_f64(?M, dexp + exp, trunc);
+
     var v: CTValue;
     v.kind   = CT_KIND_FLOAT;
-    v.data.f = value;
+    v.data.f = float.bits_f64(bits);
     ret ok[CTValue, str](v);
 }
 
@@ -2446,6 +2554,14 @@ fun t_float(s: str) Result[CTValue, str] {
     ret eval_lit_float(s, span);
 }
 
+# helper: folds a float literal and returns its raw f64 bits, or all-ones (a NaN
+# pattern none of the goldens fold to) on error.
+fun t_fbits(s: str) u64 {
+    val r: Result[CTValue, str] = t_float(s);
+    if (is_err[CTValue, str](r)) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret float.f64_bits(unwrap_ok[CTValue, str](r).data.f);
+}
+
 test "comptime: eval_lit_char decodes escape sequences and rejects malformed literals (#1242)" {
     # \n escape — mach source "'\n'" contains a literal newline byte passed
     # through as-is; "'\\ n'" (backslash + n in runtime string) tests the escape
@@ -2515,6 +2631,58 @@ test "comptime: an extreme float exponent saturates instead of hanging or silent
     val rz: Result[CTValue, str] = t_float("0.0e2000000000");
     if (is_err[CTValue, str](rz))                          { ret 1; }
     if (unwrap_ok[CTValue, str](rz).data.f != 0.0)         { ret 1; }
+    ret 0;
+}
+
+test "comptime: eval_lit_float is correctly-rounded to exact bits (#1483)" {
+    # headline regression: 1.0e100 folded to 1.0000000000000006e100 (~6 ULP off)
+    # under the old naive *=10 path; it must now be the exact nearest double.
+    if (t_fbits("1.0e100")                  != 0x54B249AD2594C37D) { ret 1; }
+
+    # large magnitudes, both signs of exponent.
+    if (t_fbits("1.0e308")                  != 0x7FE1CCF385EBC8A0) { ret 2; }
+    if (t_fbits("1.0e-308")                 != 0x000730D67819E8D2) { ret 3; }
+    if (t_fbits("1.0e-300")                 != 0x01A56E1FC2F8F359) { ret 4; }
+    if (t_fbits("1.0e23")                   != 0x44B52D02C7E14AF6) { ret 5; }
+    if (t_fbits("9.999999999999999e307")    != 0x7FE1CCF385EBC89F) { ret 6; }
+    if (t_fbits("8.98846567431158e307")     != 0x7FE0000000000000) { ret 7; }
+
+    # IEEE-754 boundary values.
+    if (t_fbits("1.7976931348623157e308")   != 0x7FEFFFFFFFFFFFFF) { ret 8; }  # largest normal
+    if (t_fbits("2.2250738585072014e-308")  != 0x0010000000000000) { ret 9; }  # smallest normal
+    if (t_fbits("2.2250738585072009e-308")  != 0x000FFFFFFFFFFFFF) { ret 10; } # largest subnormal
+    if (t_fbits("5.0e-324")                 != 0x0000000000000001) { ret 11; } # smallest subnormal
+    if (t_fbits("1.0e-323")                 != 0x0000000000000002) { ret 12; }
+    if (t_fbits("7.5e-324")                 != 0x0000000000000002) { ret 13; } # subnormal tie -> even
+
+    # ties-to-even at the 1.0 .. 1+ulp boundary (exact half-way decimals).
+    # exact midpoint 1.0 <-> 1+2^-52 -> ties to even (down) = 1.0
+    if (t_fbits("1.00000000000000011102230246251565404236316680908203125")
+                                            != 0x3FF0000000000000) { ret 14; }
+    # exact midpoint 1+2^-52 <-> 1+2*2^-52 -> ties to even (up) = ...0002
+    if (t_fbits("1.00000000000000033306690738754696212708950042724609375")
+                                            != 0x3FF0000000000002) { ret 15; }
+    # same lower midpoint plus a tiny nonzero tail (past 768 digits would be the
+    # sticky path; here it is within range) -> strictly above midpoint -> rounds up
+    if (t_fbits("1.000000000000000111022302462515654042363166809082031250000001")
+                                            != 0x3FF0000000000001) { ret 16; }
+
+    # overflow to +inf and small exact values.
+    if (t_fbits("1.0e320")                  != 0x7FF0000000000000) { ret 17; }
+    if (t_fbits("0.1")                      != 0x3FB999999999999A) { ret 18; }
+    if (t_fbits("3.141592653589793")        != 0x400921FB54442D18) { ret 19; }
+    if (t_fbits("1.5e2")                    != 0x4062C00000000000) { ret 20; }
+    if (t_fbits("123456789.0")              != 0x419D6F3454000000) { ret 21; }
+    ret 0;
+}
+
+test "comptime: eval_lit_float sticky bit rounds a truncated tie up (#1483)" {
+    # 769 significant digits: an exact midpoint in the first 768, then a nonzero
+    # digit past the cap. without the sticky bit this reads as an exact tie and
+    # rounds to-even (down); the dropped nonzero digit must push it up.
+    # value = 1 + 2^-53 (the 1.0 <-> 1+ulp midpoint), 768 sig digits, +1 ulp tail.
+    if (t_fbits("1.0000000000000001110223024625156540423631668090820312500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001")
+                                            != 0x3FF0000000000001) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -162,6 +162,7 @@ pub def FrameMark: u32;
 # alloc:          allocator used for the entries buffer
 # target_os_id:   numeric os id (one of os.OS_*)
 # target_arch_id: numeric arch id (one of isa.ARCH_*)
+# target_abi_id:  numeric abi id (one of abi.ABI_*)
 # pointer_width:  target pointer width in bytes
 # compiler_name:  interned "mach"
 # compiler_ver:   interned compiler version string
@@ -194,6 +195,7 @@ pub rec ComptimeCtx {
     alloc:          *Allocator;
     target_os_id:   u32;
     target_arch_id: u32;
+    target_abi_id:  u32;
     pointer_width:  u32;
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
@@ -233,6 +235,7 @@ fun is_i64_min(a: i64) bool {
 # alloc:          allocator used for owned storage
 # target_os_id:   numeric os id (one of os.OS_*)
 # target_arch_id: numeric arch id (one of isa.ARCH_*)
+# target_abi_id:  numeric abi id (one of abi.ABI_*)
 # pointer_width:  pointer width in bytes for the target
 # compiler_name:  interned compiler name
 # compiler_ver:   interned compiler version
@@ -241,6 +244,7 @@ pub fun init(
     alloc:          *Allocator,
     target_os_id:   u32,
     target_arch_id: u32,
+    target_abi_id:  u32,
     pointer_width:  u32,
     compiler_name:  intern.StrId,
     compiler_ver:   intern.StrId
@@ -249,6 +253,7 @@ pub fun init(
     c.alloc          = alloc;
     c.target_os_id   = target_os_id;
     c.target_arch_id = target_arch_id;
+    c.target_abi_id  = target_abi_id;
     c.pointer_width  = pointer_width;
     c.compiler_name  = compiler_name;
     c.compiler_ver   = compiler_ver;
@@ -1348,9 +1353,9 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "arch")) {
         ret int_value(c.target_arch_id::i64);
     }
-    # $mach.target.abi — active target abi tag; not yet modeled in ComptimeCtx
+    # $mach.target.abi — active target abi, numeric tag (compare vs $mach.abi.*)
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "abi")) {
-        ret err[CTValue, str]("`$mach.target.abi` is not yet available");
+        ret int_value(c.target_abi_id::i64);
     }
     # $mach.target.pointer_width — pointer size in bytes
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "pointer_width")) {
@@ -1942,7 +1947,7 @@ test "comptime: eval_lit_int handles 0b/0o prefixes and _ separators (#1242)" {
 test "comptime: bind/frame_open/frame_close/lookup scope bindings without leaking (#1242)" {
     var alloc: Allocator;
     page.make(?alloc);
-    var c: ComptimeCtx = init(?alloc, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
+    var c: ComptimeCtx = init(?alloc, 0, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
 
     val name1: intern.StrId = 1::intern.StrId;
     val name2: intern.StrId = 2::intern.StrId;

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -163,6 +163,8 @@ pub def FrameMark: u32;
 # target_os_id:   numeric os id (one of os.OS_*)
 # target_arch_id: numeric arch id (one of isa.ARCH_*)
 # target_abi_id:  numeric abi id (one of abi.ABI_*)
+# build_mode_id:  active optimization mode id (MODE_DEBUG / MODE_RELEASE), read
+#                 by `$mach.build.mode`
 # pointer_width:  target pointer width in bytes
 # compiler_name:  interned "mach"
 # compiler_ver:   interned compiler version string
@@ -196,6 +198,7 @@ pub rec ComptimeCtx {
     target_os_id:   u32;
     target_arch_id: u32;
     target_abi_id:  u32;
+    build_mode_id:  u32;
     pointer_width:  u32;
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
@@ -236,6 +239,7 @@ fun is_i64_min(a: i64) bool {
 # target_os_id:   numeric os id (one of os.OS_*)
 # target_arch_id: numeric arch id (one of isa.ARCH_*)
 # target_abi_id:  numeric abi id (one of abi.ABI_*)
+# build_mode_id:  active optimization mode id (MODE_DEBUG / MODE_RELEASE)
 # pointer_width:  pointer width in bytes for the target
 # compiler_name:  interned compiler name
 # compiler_ver:   interned compiler version
@@ -245,6 +249,7 @@ pub fun init(
     target_os_id:   u32,
     target_arch_id: u32,
     target_abi_id:  u32,
+    build_mode_id:  u32,
     pointer_width:  u32,
     compiler_name:  intern.StrId,
     compiler_ver:   intern.StrId
@@ -254,6 +259,7 @@ pub fun init(
     c.target_os_id   = target_os_id;
     c.target_arch_id = target_arch_id;
     c.target_abi_id  = target_abi_id;
+    c.build_mode_id  = build_mode_id;
     c.pointer_width  = pointer_width;
     c.compiler_name  = compiler_name;
     c.compiler_ver   = compiler_ver;
@@ -1357,10 +1363,11 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 # under $mach.{os,arch,abi}.*):
 #   $mach.version — the compiler/toolchain version string;
 #     $mach.version.{major,minor,patch} — its structured integer components.
-#   $mach.build.{os,arch,abi,pointer_width} — the resolved active build's facts;
-#     os/arch/abi share the numeric tag space of $mach.{os,arch,abi}.* so
-#     `$mach.build.arch == $mach.arch.aarch64` is an int compare. the canonical
-#     spelling that supersedes the legacy numeric $mach.target.*.
+#   $mach.build.{os,arch,abi,pointer_width,mode} — the resolved active build's
+#     facts; os/arch/abi/mode share the numeric tag space of
+#     $mach.{os,arch,abi,mode}.* so `$mach.build.arch == $mach.arch.aarch64` is an
+#     int compare. the canonical spelling that supersedes the legacy numeric
+#     $mach.target.*. `mode` is the active optimization pipeline (debug/release).
 #   $mach.target.{os,arch,pointer_width} — LEGACY, frozen at what the release
 #     seed folds (kept resolving for seed-compat; collapse deferred). $mach.target.abi
 #     is superseded by $mach.build.abi.
@@ -1481,11 +1488,15 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "pointer_width")) {
         ret int_value(c.pointer_width::i64);
     }
+    # $mach.build.mode — the active optimization mode (compare vs $mach.mode.*).
+    if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "mode")) {
+        ret int_value(c.build_mode_id::i64);
+    }
 
-    # $mach.build.{mode,timestamp,host} — build metadata stubs. checked before the
+    # $mach.build.{timestamp,host} — build metadata stubs. checked before the
     # dynamic define lookup so a manifest define can never shadow a reserved name.
     if (depth == 3 && seg_is(source, stack, 1, "build")
-     && (seg_is(source, stack, 0, "mode") || seg_is(source, stack, 0, "timestamp") || seg_is(source, stack, 0, "host"))) {
+     && (seg_is(source, stack, 0, "timestamp") || seg_is(source, stack, 0, "host"))) {
         ret err[CTValue, str]("`$mach.build.*` is not yet available");
     }
     # $mach.build.git.{commit,dirty} — build/vcs metadata stubs
@@ -2079,7 +2090,7 @@ test "comptime: eval_lit_int handles 0b/0o prefixes and _ separators (#1242)" {
 test "comptime: bind/frame_open/frame_close/lookup scope bindings without leaking (#1242)" {
     var alloc: Allocator;
     page.make(?alloc);
-    var c: ComptimeCtx = init(?alloc, 0, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
+    var c: ComptimeCtx = init(?alloc, 0, 0, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
 
     val name1: intern.StrId = 1::intern.StrId;
     val name2: intern.StrId = 2::intern.StrId;

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1287,6 +1287,12 @@ fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth
         if (seg_is(source, stack, 0, "patch")) { ret version_value(vs, 2); }
         ret err[CTValue, str]("unknown `$project.version.*` component");
     }
+    # $project.deps.<name>.version — reserved for the package-registry era. git
+    # deps carry no version (the manifest rejects `version =` today), so this is
+    # a loud stub rather than a fold to ref/commit or an empty string.
+    if (depth == 4 && seg_is(source, stack, 2, "deps") && seg_is(source, stack, 0, "version")) {
+        ret err[CTValue, str]("`$project.deps.*.version` is not yet available (reserved for the package registry)");
+    }
     if (depth != 2) { ret err[CTValue, str]("unknown `$project.*` path"); }
     if (seg_is(source, stack, 0, "id"))          { ret project_field(c.project_id); }
     if (seg_is(source, stack, 0, "version"))     { ret project_field(c.project_ver); }

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1254,7 +1254,7 @@ fun resolve_comptime_path(c: *ComptimeCtx, source: str, stack: *token.Span, dept
     if (depth == 0) { ret err[CTValue, str]("empty comptime path"); }
     val root: StrView = span_text(source, stack[depth - 1]);
     if (view_eq_str(root, "mach"))    { ret resolve_mach_path(c, source, stack, depth, interner); }
-    if (view_eq_str(root, "project")) { ret resolve_project_path(c, source, stack, depth); }
+    if (view_eq_str(root, "project")) { ret resolve_project_path(c, source, stack, depth, interner); }
     if (view_eq_str(root, "target"))  { ret resolve_target_path(c, source, stack, depth); }
     if (view_eq_str(root, "bin"))     { ret resolve_bin_path(c, source, stack, depth); }
     ret err[CTValue, str](COMPTIME_BARE_IDENT_MSG);
@@ -1265,7 +1265,7 @@ fun resolve_comptime_path(c: *ComptimeCtx, source: str, stack: *token.Span, dept
 # real build; name and description fold only when the manifest declares them. a
 # STR_NIL field (no project context bound, e.g. the editor) reports the value as
 # unavailable rather than folding to an empty string.
-fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32) Result[CTValue, str] {
+fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32, interner: *intern.Interner) Result[CTValue, str] {
     # $project.target.{os,arch,abi} — the selected target's declared tuple
     # spellings (the manifest's os/isa/abi names); the canonical home that
     # supersedes the legacy top-level $target.*. `arch` reads the declared isa.
@@ -1274,6 +1274,18 @@ fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth
         if (seg_is(source, stack, 0, "arch")) { ret project_field(c.target_isa); }
         if (seg_is(source, stack, 0, "abi"))  { ret project_field(c.target_abi); }
         ret err[CTValue, str]("unknown `$project.target.*` path");
+    }
+    # $project.version.{major,minor,patch} — the structured manifest version. the
+    # flat `$project.version` string stays available below (depth 2).
+    if (depth == 3 && seg_is(source, stack, 1, "version")) {
+        if (c.project_ver == intern.STR_NIL) { ret err[CTValue, str]("comptime path value is not available in this context"); }
+        val vo: Option[str] = intern.lookup(interner, c.project_ver);
+        if (is_none[str](vo)) { ret err[CTValue, str]("project version is not available"); }
+        val vs: str = unwrap[str](vo);
+        if (seg_is(source, stack, 0, "major")) { ret version_value(vs, 0); }
+        if (seg_is(source, stack, 0, "minor")) { ret version_value(vs, 1); }
+        if (seg_is(source, stack, 0, "patch")) { ret version_value(vs, 2); }
+        ret err[CTValue, str]("unknown `$project.version.*` component");
     }
     if (depth != 2) { ret err[CTValue, str]("unknown `$project.*` path"); }
     if (seg_is(source, stack, 0, "id"))          { ret project_field(c.project_id); }
@@ -1337,7 +1349,8 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 #
 # the namespace (#1471, provenance-rooted — facts under $mach.build.*, tags
 # under $mach.{os,arch,abi}.*):
-#   $mach.version — the compiler/toolchain version string.
+#   $mach.version — the compiler/toolchain version string;
+#     $mach.version.{major,minor,patch} — its structured integer components.
 #   $mach.build.{os,arch,abi,pointer_width} — the resolved active build's facts;
 #     os/arch/abi share the numeric tag space of $mach.{os,arch,abi}.* so
 #     `$mach.build.arch == $mach.arch.aarch64` is an int compare. the canonical
@@ -1365,6 +1378,16 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     # spelling; $mach.compiler.version folds to the same value).
     if (depth == 2 && seg_is(source, stack, 0, "version")) {
         ret str_value(c.compiler_ver);
+    }
+    # $mach.version.{major,minor,patch} — the structured compiler version.
+    if (depth == 3 && seg_is(source, stack, 1, "version")) {
+        val vo: Option[str] = intern.lookup(interner, c.compiler_ver);
+        if (is_none[str](vo)) { ret err[CTValue, str]("compiler version is not available"); }
+        val vs: str = unwrap[str](vo);
+        if (seg_is(source, stack, 0, "major")) { ret version_value(vs, 0); }
+        if (seg_is(source, stack, 0, "minor")) { ret version_value(vs, 1); }
+        if (seg_is(source, stack, 0, "patch")) { ret version_value(vs, 2); }
+        ret err[CTValue, str]("unknown `$mach.version.*` component");
     }
 
     # $mach.target.os — active target os, numeric tag (compare vs $mach.os.*)
@@ -1511,6 +1534,38 @@ fun abi_tag_for(name: StrView) Result[u32, str] {
     if (view_eq_str(name, "win64"))   { ret ok[u32, str](abi.ABI_WIN64); }
     if (view_eq_str(name, "aapcs64")) { ret ok[u32, str](abi.ABI_AAPCS64); }
     ret err[u32, str]("unknown `$mach.abi.*` tag");
+}
+
+# version_component: the `which`-th dot-separated component (0=major, 1=minor,
+# 2=patch) of a semver-style version string, as an integer. scans the whole
+# string accumulating only the target component's digits; a non-digit in that
+# component or an absent component is a loud error, never a silent 0.
+fun version_component(s: str, which: u32) Result[i64, str] {
+    var comp: u32   = 0;
+    var acc:  i64   = 0;
+    var seen: bool  = false;
+    var i:    usize = 0;
+    for (s[i] != 0) {
+        val ch: u8 = s[i];
+        if (ch == '.') {
+            comp = comp + 1;
+        } or (comp == which) {
+            if (ch < '0' || ch > '9') { ret err[i64, str]("version component is not numeric"); }
+            acc  = acc * 10 + (ch - '0')::i64;
+            seen = true;
+        }
+        i = i + 1;
+    }
+    if (!seen) { ret err[i64, str]("version string has no such component"); }
+    ret ok[i64, str](acc);
+}
+
+# version_value: fold a version component to an integer CTValue. shared by
+# `$mach.version.*` and `$project.version.*`.
+fun version_value(s: str, which: u32) Result[CTValue, str] {
+    val r: Result[i64, str] = version_component(s, which);
+    if (is_err[i64, str](r)) { ret err[CTValue, str](unwrap_err[i64, str](r)); }
+    ret int_value(unwrap_ok[i64, str](r));
 }
 
 # make_int_value: an integer CTValue from its 64-bit payload and signedness.
@@ -1833,19 +1888,24 @@ fun t_str_id(r: Result[CTValue, str]) intern.StrId {
 test "comptime: $project.* folds bound metadata; an unset/unknown field is unavailable (#1217)" {
     var c: ComptimeCtx = t_build_ctx();
     var stack: [8]token.Span;
+    # the depth-2 field reads below never touch the interner (only the structured
+    # $project.version.* path does); a real one is passed so the call typechecks.
+    var alloc: Allocator;
+    page.make(?alloc);
+    var itab: intern.Interner = intern.init(?alloc);
 
     val sid: str = "project.id";
-    if (t_str_id(resolve_project_path(?c, sid, ?stack[0], t_dotted(sid, ?stack[0]))) != 10) { ret 1; }
+    if (t_str_id(resolve_project_path(?c, sid, ?stack[0], t_dotted(sid, ?stack[0]), ?itab)) != 10) { ret 1; }
     val sver: str = "project.version";
-    if (t_str_id(resolve_project_path(?c, sver, ?stack[0], t_dotted(sver, ?stack[0]))) != 11) { ret 1; }
+    if (t_str_id(resolve_project_path(?c, sver, ?stack[0], t_dotted(sver, ?stack[0]), ?itab)) != 11) { ret 1; }
     val sname: str = "project.name";
-    if (t_str_id(resolve_project_path(?c, sname, ?stack[0], t_dotted(sname, ?stack[0]))) != 12) { ret 1; }
+    if (t_str_id(resolve_project_path(?c, sname, ?stack[0], t_dotted(sname, ?stack[0]), ?itab)) != 12) { ret 1; }
     # description is STR_NIL: the read is unavailable, never a placeholder.
     val sdesc: str = "project.description";
-    if (!is_err[CTValue, str](resolve_project_path(?c, sdesc, ?stack[0], t_dotted(sdesc, ?stack[0])))) { ret 1; }
+    if (!is_err[CTValue, str](resolve_project_path(?c, sdesc, ?stack[0], t_dotted(sdesc, ?stack[0]), ?itab))) { ret 1; }
     # an unknown field under a known root is rejected.
     val sbogus: str = "project.bogus";
-    if (!is_err[CTValue, str](resolve_project_path(?c, sbogus, ?stack[0], t_dotted(sbogus, ?stack[0])))) { ret 1; }
+    if (!is_err[CTValue, str](resolve_project_path(?c, sbogus, ?stack[0], t_dotted(sbogus, ?stack[0]), ?itab))) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1326,15 +1326,22 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 # precondition, not re-checked here. `stack` is leaf-first: stack[0] is the
 # rightmost segment and stack[depth - 1] is the root (`mach`).
 #
-# the locked namespace:
-#   $mach.target.{os,arch,abi,pointer_width} — active target parameters; the
-#     os/arch tags resolve to the same numeric space as $mach.os.* /
-#     $mach.arch.* so `$mach.target.os == $mach.os.linux` is an int compare.
+# the namespace (#1471, provenance-rooted — facts under $mach.build.*, tags
+# under $mach.{os,arch,abi}.*):
+#   $mach.version — the compiler/toolchain version string.
+#   $mach.build.{os,arch,abi,pointer_width} — the resolved active build's facts;
+#     os/arch/abi share the numeric tag space of $mach.{os,arch,abi}.* so
+#     `$mach.build.arch == $mach.arch.aarch64` is an int compare. the canonical
+#     spelling that supersedes the legacy numeric $mach.target.*.
+#   $mach.target.{os,arch,pointer_width} — LEGACY, frozen at what the release
+#     seed folds (kept resolving for seed-compat; collapse deferred). $mach.target.abi
+#     is superseded by $mach.build.abi.
 #   $mach.os.{linux,darwin,windows,freestanding} — os tag values.
 #   $mach.arch.{x86_64,aarch64} — arch tag values.
 #   $mach.abi.{sysv,win64,aapcs64} — abi tag values, same numeric space as
-#     $mach.target.abi.
-#   $mach.project.{name,version,root} — project metadata stubs.
+#     $mach.build.abi.
+#   $mach.project.{name,version,root} — legacy project metadata stubs ($project.*
+#     is the canonical top-level root).
 #   $mach.build.{mode,timestamp,host} / build.git.{commit,dirty} — build
 #     metadata stubs.
 #   $mach.build.<name> — a manifest comptime define (#1191); folds to the
@@ -1359,9 +1366,11 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "arch")) {
         ret int_value(c.target_arch_id::i64);
     }
-    # $mach.target.abi — active target abi, numeric tag (compare vs $mach.abi.*)
+    # $mach.target.abi — superseded by `$mach.build.abi`. the legacy `$mach.target.*`
+    # set is frozen at exactly what the release seed folds (os/arch/pointer_width),
+    # so new resolved-build facts land under `$mach.build.*`, never here.
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "abi")) {
-        ret int_value(c.target_abi_id::i64);
+        ret err[CTValue, str]("`$mach.target.abi` is unavailable; use `$mach.build.abi`");
     }
     # $mach.target.pointer_width — pointer size in bytes
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "pointer_width")) {
@@ -1406,6 +1415,25 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 3 && seg_is(source, stack, 1, "project")
      && (seg_is(source, stack, 0, "name") || seg_is(source, stack, 0, "version") || seg_is(source, stack, 0, "root"))) {
         ret err[CTValue, str]("`$mach.project.*` is not yet available");
+    }
+
+    # $mach.build.{os,arch,abi,pointer_width} — the resolved active build's facts,
+    # the canonical spelling that supersedes the legacy numeric `$mach.target.*`.
+    # the os/arch/abi values share the numeric tag space of `$mach.{os,arch,abi}.*`
+    # so `$mach.build.arch == $mach.arch.aarch64` is an int compare. checked before
+    # the `$mach.build.<name>` define lookup so a manifest define never shadows a
+    # reserved build fact.
+    if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "os")) {
+        ret int_value(c.target_os_id::i64);
+    }
+    if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "arch")) {
+        ret int_value(c.target_arch_id::i64);
+    }
+    if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "abi")) {
+        ret int_value(c.target_abi_id::i64);
+    }
+    if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "pointer_width")) {
+        ret int_value(c.pointer_width::i64);
     }
 
     # $mach.build.{mode,timestamp,host} — build metadata stubs. checked before the

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1986,6 +1986,21 @@ test "comptime: equal magnitudes across signedness compare equal (#1272)" {
     ret 0;
 }
 
+test "comptime: TYPE values compare by identity token, never against a scalar (#1472)" {
+    val a: CTValue = unwrap_ok[CTValue, str](type_value(7));
+    val b: CTValue = unwrap_ok[CTValue, str](type_value(7));
+    val c: CTValue = unwrap_ok[CTValue, str](type_value(9));
+    # equal tokens name the same type; distinct tokens do not.
+    if (!t_bool(apply_equality(expr.BIN_EQ, a, b)))  { ret 1; }
+    if (t_bool(apply_equality(expr.BIN_EQ, a, c)))   { ret 1; }
+    if (!t_bool(apply_equality(expr.BIN_NEQ, a, c))) { ret 1; }
+    # a TYPE value never compares against a non-type kind: the kind-mismatch
+    # guard rejects it rather than coercing to a scalar.
+    val i: CTValue = unwrap_ok[CTValue, str](int_value(7));
+    if (!is_err[CTValue, str](apply_equality(expr.BIN_EQ, a, i))) { ret 1; }
+    ret 0;
+}
+
 test "comptime: u64-range arithmetic computes the unsigned value, not the signed (#1272)" {
     val big: CTValue = unwrap_ok[CTValue, str](t_eval_int("0xFFFFFFFFFFFFFFFF"));
     val two: CTValue = unwrap_ok[CTValue, str](int_value(2));

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -89,6 +89,23 @@ pub val CT_KIND_STR:   CTKind = 3;
 # type. eval never interprets the token, only compares it.
 pub val CT_KIND_TYPE:  CTKind = 4;
 
+# a comptime FIELD descriptor (#1473): one element of a `$fields(T)` sequence,
+# bound to the `$each` loop variable. the payload `data.fld` names the owning
+# record type and the field's ordinal; `.name` / `.type` / `.offset` project the
+# field's attributes, and `v.[f]` projects the field off an instance.
+pub val CT_KIND_FIELD: CTKind = 5;
+
+# FieldRef: the payload of a CT_KIND_FIELD value — the owning record's canonical
+# sema TypeId and the field's declaration-order ordinal. the typed layer resolves
+# the field's name / type / offset from this pair.
+# ---
+# owner: the owning record's sema TypeId
+# index: the field's declaration-order ordinal
+pub rec FieldRef {
+    owner: u32;
+    index: u32;
+}
+
 # COMPTIME_BARE_IDENT_MSG: the single teaching diagnostic for a standalone bare
 # `$ident` (#1249). the comptime channel's shapes are a closed set; a lone
 # `$ident` is none of them — a comptime parameter is referenced without `$`, and
@@ -116,6 +133,7 @@ pub rec CTValue {
         b: bool;
         s: intern.StrId;
         t: u32;
+        fld: FieldRef;
     };
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1266,6 +1266,15 @@ fun resolve_comptime_path(c: *ComptimeCtx, source: str, stack: *token.Span, dept
 # STR_NIL field (no project context bound, e.g. the editor) reports the value as
 # unavailable rather than folding to an empty string.
 fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32) Result[CTValue, str] {
+    # $project.target.{os,arch,abi} — the selected target's declared tuple
+    # spellings (the manifest's os/isa/abi names); the canonical home that
+    # supersedes the legacy top-level $target.*. `arch` reads the declared isa.
+    if (depth == 3 && seg_is(source, stack, 1, "target")) {
+        if (seg_is(source, stack, 0, "os"))   { ret project_field(c.target_os); }
+        if (seg_is(source, stack, 0, "arch")) { ret project_field(c.target_isa); }
+        if (seg_is(source, stack, 0, "abi"))  { ret project_field(c.target_abi); }
+        ret err[CTValue, str]("unknown `$project.target.*` path");
+    }
     if (depth != 2) { ret err[CTValue, str]("unknown `$project.*` path"); }
     if (seg_is(source, stack, 0, "id"))          { ret project_field(c.project_id); }
     if (seg_is(source, stack, 0, "version"))     { ret project_field(c.project_ver); }

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -106,6 +106,23 @@ pub rec FieldRef {
     index: u32;
 }
 
+# a comptime PACK-ELEMENT descriptor (#1475): one element of a variadic pack,
+# bound to the `$each a in va` loop variable during monomorphization. the payload
+# `data.pelem` names the element's concrete sema type and its ordinal in the
+# instance's expanded parameter list. sema re-infers the body reading the element
+# TYPE; lowering reads the ORDINAL to load the matching expanded parameter slot.
+pub val CT_KIND_PACK_ELEM: CTKind = 6;
+
+# PackElemRef: the payload of a CT_KIND_PACK_ELEM value — the element's concrete
+# sema TypeId and its ordinal in the pack instance's expanded parameter list.
+# ---
+# index: the element's ordinal among the expanded pack parameters
+# ty:    the element's concrete sema TypeId at this call site
+pub rec PackElemRef {
+    index: u32;
+    ty:    u32;
+}
+
 # COMPTIME_BARE_IDENT_MSG: the single teaching diagnostic for a standalone bare
 # `$ident` (#1249). the comptime channel's shapes are a closed set; a lone
 # `$ident` is none of them — a comptime parameter is referenced without `$`, and
@@ -134,6 +151,7 @@ pub rec CTValue {
         s: intern.StrId;
         t: u32;
         fld: FieldRef;
+        pelem: PackElemRef;
     };
 }
 
@@ -2046,6 +2064,18 @@ pub fun field_value(owner: u32, index: u32) CTValue {
     v.kind          = CT_KIND_FIELD;
     v.data.fld.owner = owner;
     v.data.fld.index = index;
+    ret v;
+}
+
+# pack_elem_value: a comptime PACK-ELEMENT descriptor (#1475) naming a pack
+# element's concrete sema type and its ordinal in the instance's expanded
+# parameter list. bound to the `$each a in va` loop variable during
+# monomorphization; sema reads `.ty`, lowering reads `.index`.
+pub fun pack_elem_value(index: u32, ty: u32) CTValue {
+    var v: CTValue;
+    v.kind            = CT_KIND_PACK_ELEM;
+    v.data.pelem.index = index;
+    v.data.pelem.ty    = ty;
     ret v;
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1345,6 +1345,12 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32, interner: *intern.Interner) Result[CTValue, str] {
     if (depth == 0) { ret err[CTValue, str]("empty comptime path"); }
 
+    # $mach.version — the mach compiler/toolchain version string (the canonical
+    # spelling; $mach.compiler.version folds to the same value).
+    if (depth == 2 && seg_is(source, stack, 0, "version")) {
+        ret str_value(c.compiler_ver);
+    }
+
     # $mach.target.os — active target os, numeric tag (compare vs $mach.os.*)
     if (depth == 3 && seg_is(source, stack, 1, "target") && seg_is(source, stack, 0, "os")) {
         ret int_value(c.target_os_id::i64);

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -72,6 +72,7 @@ use expr:   mach.lang.fe.ast.expr;
 use token:  mach.lang.fe.token;
 use os:     mach.lang.target.os;
 use isa:    mach.lang.target.isa;
+use abi:    mach.lang.target.abi;
 
 # CTKind: discriminator for CTValue.data.
 pub def CTKind: u8;
@@ -1326,6 +1327,8 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
 #     $mach.arch.* so `$mach.target.os == $mach.os.linux` is an int compare.
 #   $mach.os.{linux,darwin,windows,freestanding} — os tag values.
 #   $mach.arch.{x86_64,aarch64} — arch tag values.
+#   $mach.abi.{sysv,win64,aapcs64} — abi tag values, same numeric space as
+#     $mach.target.abi.
 #   $mach.project.{name,version,root} — project metadata stubs.
 #   $mach.build.{mode,timestamp,host} / build.git.{commit,dirty} — build
 #     metadata stubs.
@@ -1367,6 +1370,15 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 3 && seg_is(source, stack, 1, "arch")) {
         val name: StrView = span_text(source, stack[0]);
         val r: Result[u32, str] = arch_tag_for(name);
+        if (is_err[u32, str](r)) { ret err[CTValue, str](unwrap_err[u32, str](r)); }
+        ret int_value(unwrap_ok[u32, str](r)::i64);
+    }
+    # $mach.abi.<name> — abi tag value, in the same numeric space as
+    # $mach.target.abi so `$mach.target.abi == $mach.abi.sysv` is an int compare;
+    # unrecognized names error likewise.
+    if (depth == 3 && seg_is(source, stack, 1, "abi")) {
+        val name: StrView = span_text(source, stack[0]);
+        val r: Result[u32, str] = abi_tag_for(name);
         if (is_err[u32, str](r)) { ret err[CTValue, str](unwrap_err[u32, str](r)); }
         ret int_value(unwrap_ok[u32, str](r)::i64);
     }
@@ -1440,6 +1452,17 @@ fun arch_tag_for(name: StrView) Result[u32, str] {
     if (view_eq_str(name, "x86_64"))  { ret ok[u32, str](isa.ARCH_X86_64); }
     if (view_eq_str(name, "aarch64")) { ret ok[u32, str](isa.ARCH_AARCH64); }
     ret err[u32, str]("unknown `$mach.arch.*` tag");
+}
+
+# maps an `$mach.abi.<name>` tag to its numeric abi id (abi.ABI_*). the tag names
+# are the canonical convention names (matching each AbiVTable's name), distinct
+# from the manifest tuple's declared abi spelling read by `$target.abi`. closed
+# list; an unrecognized name is an error rather than a fold to ABI_UNKNOWN.
+fun abi_tag_for(name: StrView) Result[u32, str] {
+    if (view_eq_str(name, "sysv"))    { ret ok[u32, str](abi.ABI_SYSV); }
+    if (view_eq_str(name, "win64"))   { ret ok[u32, str](abi.ABI_WIN64); }
+    if (view_eq_str(name, "aapcs64")) { ret ok[u32, str](abi.ABI_AAPCS64); }
+    ret err[u32, str]("unknown `$mach.abi.*` tag");
 }
 
 # make_int_value: an integer CTValue from its 64-bit payload and signedness.

--- a/src/lang/fe/lexer.mach
+++ b/src/lang/fe/lexer.mach
@@ -125,6 +125,7 @@ pub fun tokenize(source: str, alloc: *Allocator, file_id: src.FileId) Result[Tok
         or (c == '/')  { tok = token.make(token.KIND_SLASH,    pos, 1); pos = pos + 1; }
         or (c == '%')  { tok = token.make(token.KIND_PERCENT,  pos, 1); pos = pos + 1; }
         or (c == '^')  { tok = token.make(token.KIND_CARET,    pos, 1); pos = pos + 1; }
+        or (c == '`')  { tok = token.make(token.KIND_BACKTICK, pos, 1); pos = pos + 1; }
         or (c == ':')  {
             if (source[pos + 1] == ':') {
                 tok = token.make(token.KIND_COLON_COLON, pos, 2);
@@ -489,9 +490,9 @@ test "lexer: emit_diagnostics drains lex errors onto the sink" {
     var alloc: Allocator;
     page.make(?alloc);
 
-    # a backtick is not a valid token; the lexer records it as a lex error
+    # a backslash is not a valid token; the lexer records it as a lex error
     # rather than aborting, and emit_diagnostics surfaces it as a diagnostic.
-    val tr: Result[TokenStream, str] = tokenize("a ` b", ?alloc, 0::src.FileId);
+    val tr: Result[TokenStream, str] = tokenize("a \\ b", ?alloc, 0::src.FileId);
     if (is_err[TokenStream, str](tr)) { ret 1; }
     var stream: TokenStream = unwrap_ok[TokenStream, str](tr);
     if (stream.error_len == 0) { dnit(?stream, ?alloc); ret 1; }
@@ -530,6 +531,28 @@ test "lexer: 0b and 0o integer prefixes produce correct token spans (#1242)" {
         or (stream.tokens[1].span.len    != 5) { rc = 1; }
         or (stream.tokens[2].kind != token.KIND_LIT_INT) { rc = 1; }
         or (stream.tokens[2].span.len    != 4) { rc = 1; }
+    }
+
+    dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "lexer: a backtick lexes as KIND_BACKTICK (#1476)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    val tr: Result[TokenStream, str] = tokenize("`", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr)) { ret 1; }
+    var stream: TokenStream = unwrap_ok[TokenStream, str](tr);
+
+    var rc: i32 = 0;
+    # one backtick token + EOF = 2, with no lex error (it is a real token now)
+    if (stream.len != 2)       { rc = 1; }
+    or (stream.error_len != 0) { rc = 1; }
+    or {
+        if (stream.tokens[0].kind != token.KIND_BACKTICK) { rc = 1; }
+        or (stream.tokens[0].span.offset != 0) { rc = 1; }
+        or (stream.tokens[0].span.len    != 1) { rc = 1; }
     }
 
     dnit(?stream, ?alloc);

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -74,33 +74,120 @@ pub fun parse_module(p: *parser.Parser) id.ModuleId {
     ret mid;
 }
 
-# parse_decl: parses a single top-level declaration.
+# parse_decl: parses a single top-level declaration, including any leading
+# backtick decorators that attach to it.
 # ---
 # p:   parser state positioned at the first token of the declaration
 # ret: DeclId of the parsed declaration, or DECL_NIL on failure
 pub fun parse_decl(p: *parser.Parser) id.DeclId {
     val start: token.Token = parser.current(p);
 
-    if (parser.at(p, token.KIND_DOLLAR))  { ret parse_comptime_decl(p, start.span); }
+    var decorators_len: u32 = 0;
+    val decorators_start: u32 = parse_decorators(p, ?decorators_len);
+
+    val did: id.DeclId = parse_decl_dispatch(p, start.span);
+
+    # back-patch the decorator range onto the parsed decl; the pointer is taken
+    # after the dispatch's own appends complete, so the decls pool is stable.
+    if (did != id.DECL_NIL) {
+        val d: *decl.Decl = unwrap[*decl.Decl](ast.get_decl(p.ast, did));
+        d.decorators_start = decorators_start;
+        d.decorators_len   = decorators_len;
+    }
+    ret did;
+}
+
+# parse_decl_dispatch: dispatches on the leading `$` or keyword (after any
+# decorators) to the matching declaration parser, or reports an error and
+# yields an ERROR decl. `start` spans the declaration's first token (a
+# decorator backtick when decorators are present).
+fun parse_decl_dispatch(p: *parser.Parser, start: token.Span) id.DeclId {
+    if (parser.at(p, token.KIND_DOLLAR))  { ret parse_comptime_decl(p, start); }
 
     val flags: u8 = parse_flags(p);
 
-    if (parser.at_kw(p, "use"))   { ret parse_use_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "fwd"))   { ret parse_fwd_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "fun"))   { ret parse_fun_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "rec"))   { ret parse_rec_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "uni"))   { ret parse_uni_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "val"))   { ret parse_bind_decl(p, start.span, flags, decl.DECL_KIND_VAL); }
-    if (parser.at_kw(p, "var"))   { ret parse_bind_decl(p, start.span, flags, decl.DECL_KIND_VAR); }
-    if (parser.at_kw(p, "def"))   { ret parse_def_decl(p, start.span, flags); }
-    if (parser.at_kw(p, "test"))  { ret parse_test_decl(p, start.span, flags); }
+    if (parser.at_kw(p, "use"))   { ret parse_use_decl(p, start, flags); }
+    if (parser.at_kw(p, "fwd"))   { ret parse_fwd_decl(p, start, flags); }
+    if (parser.at_kw(p, "fun"))   { ret parse_fun_decl(p, start, flags); }
+    if (parser.at_kw(p, "rec"))   { ret parse_rec_decl(p, start, flags); }
+    if (parser.at_kw(p, "uni"))   { ret parse_uni_decl(p, start, flags); }
+    if (parser.at_kw(p, "val"))   { ret parse_bind_decl(p, start, flags, decl.DECL_KIND_VAL); }
+    if (parser.at_kw(p, "var"))   { ret parse_bind_decl(p, start, flags, decl.DECL_KIND_VAR); }
+    if (parser.at_kw(p, "def"))   { ret parse_def_decl(p, start, flags); }
+    if (parser.at_kw(p, "test"))  { ret parse_test_decl(p, start, flags); }
 
     parser.error_at_current(p, "expected a declaration; valid starters: use, fwd, fun, rec, uni, val, var, def, test");
     var err: decl.Decl;
-    err.span  = start.span;
+    err.span  = start;
     err.kind  = decl.DECL_KIND_ERROR;
     err.flags = flags;
     ret parser.push_decl(p, err);
+}
+
+# parse_decorators: parses zero or more leading `` `name(args)` `` / `` `flag` ``
+# backtick decorator clauses, appending each to ast.decorators as one contiguous
+# block. writes the block length through `out_len` and returns its start index.
+fun parse_decorators(p: *parser.Parser, out_len: *u32) u32 {
+    val start: u32 = p.ast.decorator_len::u32;
+    var count: u32 = 0;
+    for (parser.at(p, token.KIND_BACKTICK)) {
+        if (!parse_one_decorator(p)) { brk; }
+        count = count + 1;
+    }
+    @out_len = count;
+    ret start;
+}
+
+# parses a single `` `name` `` or `` `name(args)` `` clause and appends it to
+# ast.decorators. the directive name and any comptime-expr arguments are
+# validated later in sema; the parser only records the syntax.
+fun parse_one_decorator(p: *parser.Parser) bool {
+    parser.advance(p);
+
+    if (!parser.at(p, token.KIND_IDENT)) {
+        parser.error_at_current(p, "expected decorator name after '`'");
+        ret false;
+    }
+    val name: token.Span = parser.advance(p).span;
+
+    var args_start: u32 = 0;
+    var args_len:   u32 = 0;
+    if (parser.at(p, token.KIND_LPAREN)) {
+        args_start = parse_decorator_args(p, ?args_len);
+    }
+
+    parser.expect(p, token.KIND_BACKTICK, "expected closing '`' to end decorator");
+
+    var d: decl.Decorator;
+    d.name       = name;
+    d.args_start = args_start;
+    d.args_len   = args_len;
+
+    val r: Result[u32, str] = ast.add_decorator(p.ast, d);
+    if (is_err[u32, str](r)) {
+        parser.fatal_oom_at(p, name);
+        ret false;
+    }
+    ret true;
+}
+
+# parses `(expr, expr, ...)` decorator arguments as comptime exprs, buffering
+# each so a nested call argument cannot split the slice; flushes to ast.expr_ids
+# and returns the block start, writing its length through `out_len`.
+fun parse_decorator_args(p: *parser.Parser, out_len: *u32) u32 {
+    parser.advance(p);
+
+    var buf: parser.ListBuf[id.ExprId] = parser.list_buf_init[id.ExprId]();
+    if (!parser.at(p, token.KIND_RPAREN)) {
+        parser.list_buf_push[id.ExprId](p, ?buf, pexpr.parse_expr(p));
+        for (parser.eat(p, token.KIND_COMMA)) {
+            if (parser.at(p, token.KIND_RPAREN)) { brk; }
+            parser.list_buf_push[id.ExprId](p, ?buf, pexpr.parse_expr(p));
+        }
+    }
+    parser.expect(p, token.KIND_RPAREN, "expected ')' to close decorator arguments");
+
+    ret parser.expr_id_buf_flush(p, ?buf, out_len);
 }
 
 # parse_stmt: parses a single statement.
@@ -1254,4 +1341,50 @@ test "parser: a bare-form statement keyword used as an identifier parses as an e
     ast.dnit(?a);
     lexer.dnit(?stream, ?alloc);
     ret rc;
+}
+
+test "parser: leading backtick decorators attach to the following decl (#1476)" {
+    # `inline` (bare flag) and `symbol("_start")` (one comptime-expr arg) both
+    # attach to `f`; the following `g` has none — decorators do not bleed across.
+    var alloc: Allocator;
+    page.make(?alloc);
+    val source: str = "`inline` `symbol(\"_start\")` fun f() {} fun g() {}";
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize(source, ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+    parse_module(?p);
+
+    var rc: i32 = 0;
+    if      (diag.has_errors(?diags))               { rc = 1; }
+    or      (a.decl_len < 2)                        { rc = 1; }
+    or      (a.decls[0].kind != decl.DECL_KIND_FUN) { rc = 1; }
+    or      (a.decls[1].kind != decl.DECL_KIND_FUN) { rc = 1; }
+    or      (a.decls[0].decorators_len != 2)        { rc = 1; }
+    or      (a.decls[1].decorators_len != 0)        { rc = 1; }
+
+    if (rc == 0) {
+        val d0: decl.Decorator = a.decorators[a.decls[0].decorators_start];
+        val d1: decl.Decorator = a.decorators[a.decls[0].decorators_start + 1];
+        # `inline` is a bare flag; `symbol(...)` carries exactly one arg
+        if (!str_region_equals(p.tokens.source, d0.name.offset, d0.name.len, "inline")) { rc = 1; }
+        if (d0.args_len != 0)                                                           { rc = 1; }
+        if (!str_region_equals(p.tokens.source, d1.name.offset, d1.name.len, "symbol")) { rc = 1; }
+        if (d1.args_len != 1)                                                           { rc = 1; }
+    }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "parser: an unterminated backtick decorator reports an error (#1476)" {
+    # a decorator name with no closing backtick must diagnose, not silently parse
+    if (!t_parse_module_has_errors("`inline fun f() {}")) { ret 1; }
+    # a backtick with no directive name must diagnose
+    if (!t_parse_module_has_errors("`` fun f() {}")) { ret 1; }
+    ret 0;
 }

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -1173,7 +1173,12 @@ fun parse_comptime_each_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
     if (!parser.eat_kw(p, "in")) {
         parser.error_at_current(p, "expected 'in' after the $each loop variable");
     }
+    # the sequence is paren-less and immediately followed by the body's `{`, so a
+    # bare pack ident (`va`) must not parse the body braces as a struct literal.
+    val saved_nsl: bool = p.no_struct_lit;
+    p.no_struct_lit = true;
     val seq: id.ExprId = pexpr.parse_expr(p);
+    p.no_struct_lit = saved_nsl;
 
     var body_start: u32 = 0;
     var body_len:   u32 = 0;

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -210,6 +210,9 @@ pub fun parse_stmt(p: *parser.Parser) id.StmtId {
     if (parser.at(p, token.KIND_DOLLAR) && peek_is_kw(p, 1, "if")) {
         ret parse_comptime_if_stmt(p, start.span);
     }
+    if (parser.at(p, token.KIND_DOLLAR) && peek_is_kw(p, 1, "each")) {
+        ret parse_comptime_each_stmt(p, start.span);
+    }
 
     ret parse_expr_stmt(p, start.span);
 }
@@ -1155,6 +1158,37 @@ fun parse_expr_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
     node.span = parser.span_of(start, end.span);
     node.kind = stmt.STMT_KIND_EXPR;
     node.data.expr = se;
+    ret parser.push_stmt(p, node);
+}
+
+# parses `$each <ident> in <seq> { body }` at statement scope (#1473). the
+# sequence is a comptime expression (e.g. `$fields(T)`); the body is spliced once
+# per element with the loop variable bound to that element.
+fun parse_comptime_each_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
+    parser.expect(p, token.KIND_DOLLAR, "expected '$' to open a comptime $each");
+    parser.eat_kw(p, "each");
+
+    val var_tok: token.Token = parser.current(p);
+    parser.expect(p, token.KIND_IDENT, "expected a loop variable name after '$each'");
+    if (!parser.eat_kw(p, "in")) {
+        parser.error_at_current(p, "expected 'in' after the $each loop variable");
+    }
+    val seq: id.ExprId = pexpr.parse_expr(p);
+
+    var body_start: u32 = 0;
+    var body_len:   u32 = 0;
+    val end: token.Span = parse_comptime_stmt_body(p, ?body_start, ?body_len);
+
+    var ce: stmt.StmtComptimeEach;
+    ce.var_name   = var_tok.span;
+    ce.seq        = seq;
+    ce.body_start = body_start;
+    ce.body_len   = body_len;
+
+    var node: stmt.Stmt;
+    node.span = parser.span_of(start, end);
+    node.kind = stmt.STMT_KIND_COMPTIME_EACH;
+    node.data.comptime_each = ce;
     ret parser.push_stmt(p, node);
 }
 

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -133,7 +133,7 @@ fun parse_prefix(p: *parser.Parser) id.ExprId {
 
     if (t.kind == token.KIND_IDENT) {
         if (parser.at_kw(p, "nil"))      { ret parse_lit_nil(p); }
-        if (looks_like_typed_literal(p)) { ret parse_typed_literal(p); }
+        if (!p.no_struct_lit && looks_like_typed_literal(p)) { ret parse_typed_literal(p); }
         ret parse_ident(p);
     }
 

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -89,6 +89,17 @@ pub fun parse_type(p: *parser.Parser) id.TypeId {
     if (parser.at_kw(p, "fun"))            { ret parse_fun(p, start.span); }
     if (parser.at_kw(p, "rec"))            { ret parse_rec_or_uni(p, start.span, m_type.TYPE_KIND_REC); }
     if (parser.at_kw(p, "uni"))            { ret parse_rec_or_uni(p, start.span, m_type.TYPE_KIND_UNI); }
+    # a `...` in type position is a comptime variadic pack (#1474), e.g. the type
+    # of a `va: ...` parameter. distinct from a standalone trailing `...` in a
+    # parameter list, which the legacy va_list variadic marker consumes before a
+    # type is ever parsed.
+    if (parser.at(p, token.KIND_DOT_DOT_DOT)) {
+        parser.advance(p);
+        var pk: m_type.Type;
+        pk.span = start.span;
+        pk.kind = m_type.TYPE_KIND_PACK;
+        ret parser.push_type(p, pk);
+    }
     if (parser.at(p, token.KIND_IDENT))    { ret parse_named(p, start.span); }
 
     parser.error_at_current(p, "expected a type; named, '*T', '[N]T', 'fun(...)', or inline 'rec'/'uni' forms are valid here");

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -152,7 +152,15 @@ fun parse_postfix(p: *parser.Parser, base: id.ExprId) id.ExprId {
                 lhs = parse_index(p, lhs);
             }
         }
-        or      (k == token.KIND_DOT)         { lhs = parse_member(p, lhs); }
+        or      (k == token.KIND_DOT) {
+            # `v.[f]` is a field projection (#1473); a plain `v.field` is a member.
+            if (parser.peek(p, 1).kind == token.KIND_LBRACKET) {
+                lhs = parse_project(p, lhs);
+            }
+            or {
+                lhs = parse_member(p, lhs);
+            }
+        }
         or      (k == token.KIND_COLON_COLON) { lhs = parse_cast(p, lhs, false); }
         or      (k == token.KIND_COLON_TILDE) { lhs = parse_cast(p, lhs, true); }
         or                                    { brk; }
@@ -560,6 +568,32 @@ fun parse_member(p: *parser.Parser, object: id.ExprId) id.ExprId {
     node.span = parser.span_of(start_span, name_tok.span);
     node.kind = expr.EXPR_KIND_MEMBER;
     node.data.member = member;
+    ret parser.push_expr(p, node);
+}
+
+# parses a field projection `v.[f]` (#1473): the field operand `f` is a comptime
+# field descriptor (the `$each` loop variable). the leading `.` is the current
+# token; `[` immediately follows.
+fun parse_project(p: *parser.Parser, object: id.ExprId) id.ExprId {
+    parser.expect(p, token.KIND_DOT, "expected '.' before '[' in a field projection");
+    parser.expect(p, token.KIND_LBRACKET, "expected '[' in a field projection");
+    val field: id.ExprId = parse_expr(p);
+    val close: token.Token = parser.current(p);
+    parser.expect(p, token.KIND_RBRACKET, "expected ']' to close a field projection");
+
+    var proj: expr.ExprProject;
+    proj.object = object;
+    proj.field  = field;
+
+    var start_span: token.Span = close.span;
+    if (object != id.EXPR_NIL) {
+        start_span = unwrap[*expr.Expr](ast.get_expr(p.ast, object)).span;
+    }
+
+    var node: expr.Expr;
+    node.span = parser.span_of(start_span, close.span);
+    node.kind = expr.EXPR_KIND_PROJECT;
+    node.data.project = proj;
     ret parser.push_expr(p, node);
 }
 

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -482,6 +482,33 @@ fun parse_paren(p: *parser.Parser) id.ExprId {
     ret inner;
 }
 
+# parses one call argument: an expression optionally suffixed with a postfix
+# `...` pack spread (#1474), e.g. `va...`, forwarding a whole comptime variadic
+# pack. the spread is recognized ONLY here, in call-argument position — never
+# globally in parse_postfix — so it cannot collide with the legacy standalone
+# `...` parameter marker (which is consumed in a parameter list, never after a
+# call argument). validity (a pack operand, the sole trailing argument of a
+# pack-tailed callee) is checked in sema.
+fun parse_call_arg(p: *parser.Parser) id.ExprId {
+    val e: id.ExprId = parse_expr(p);
+    if (!parser.at(p, token.KIND_DOT_DOT_DOT)) { ret e; }
+    val dots: token.Token = parser.advance(p);
+
+    var sp: expr.ExprSpread;
+    sp.inner = e;
+
+    var start_span: token.Span = dots.span;
+    if (e != id.EXPR_NIL) {
+        start_span = unwrap[*expr.Expr](ast.get_expr(p.ast, e)).span;
+    }
+
+    var node: expr.Expr;
+    node.span = parser.span_of(start_span, dots.span);
+    node.kind = expr.EXPR_KIND_SPREAD;
+    node.data.spread = sp;
+    ret parser.push_expr(p, node);
+}
+
 # parses a call expression `callee(args)`. type_args_start/type_args_len carry
 # any call-site generic arguments parsed by parse_generic_call; both are 0 for
 # a plain call. index_callee is EXPR_NIL except for a provisional bracket call,
@@ -498,10 +525,10 @@ fun parse_call(p: *parser.Parser, callee: id.ExprId, type_args_start: u32, type_
     var buf: parser.ListBuf[id.ExprId] = parser.list_buf_init[id.ExprId]();
 
     if (!parser.at(p, token.KIND_RPAREN)) {
-        parser.list_buf_push[id.ExprId](p, ?buf, parse_expr(p));
+        parser.list_buf_push[id.ExprId](p, ?buf, parse_call_arg(p));
         for (parser.eat(p, token.KIND_COMMA)) {
             if (parser.at(p, token.KIND_RPAREN)) { brk; }
-            parser.list_buf_push[id.ExprId](p, ?buf, parse_expr(p));
+            parser.list_buf_push[id.ExprId](p, ?buf, parse_call_arg(p));
         }
     }
 

--- a/src/lang/fe/parser/state.mach
+++ b/src/lang/fe/parser/state.mach
@@ -40,6 +40,10 @@ use module: mach.lang.fe.ast.module;
 # fatal:  sticky flag set by any allocation failure during parsing, independent
 #         of panic so an OOM hit mid-recovery is never swallowed; the driver
 #         treats a fatal parse as failed rather than consuming a corrupt AST
+# no_struct_lit: while true, a bare `Name { ... }` does not parse as a struct
+#         literal — the `{` opens an enclosing block instead. set for the
+#         sequence of a paren-less `$each <ident> in <seq> { body }` (#1474) so a
+#         pack-ident sequence (`va`) does not swallow the loop body's braces.
 pub rec Parser {
     tokens: *lexer.TokenStream;
     pos:    usize;
@@ -47,6 +51,7 @@ pub rec Parser {
     diags:  *diag.DiagList;
     panic:  bool;
     fatal:  bool;
+    no_struct_lit: bool;
 }
 
 # init: initializes a Parser over the given token stream, filling output into ast and diags.
@@ -63,6 +68,7 @@ pub fun init(tokens: *lexer.TokenStream, out: *ast.Ast, diags: *diag.DiagList) P
     p.diags  = diags;
     p.panic  = false;
     p.fatal  = false;
+    p.no_struct_lit = false;
     ret p;
 }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1625,7 +1625,40 @@ fun bind_stmt(rc: *ResolveContext, sid: id.StmtId) Result[bool, str] {
     if (s.kind == stmt.STMT_KIND_COMPTIME_IF) {
         ret bind_comptime_if(rc, s.data.comptime_if.branches_start, s.data.comptime_if.branches_len, false);
     }
+    if (s.kind == stmt.STMT_KIND_COMPTIME_EACH) {
+        ret bind_comptime_each(rc, ?s.data.comptime_each);
+    }
     ret ok[bool, str](true);
+}
+
+# binds a `$each <ident> in <seq> { body }` (#1473): the sequence's `$fields(T)`
+# binds T as a type; the loop variable is declared in a fresh scope as a comptime
+# binding visible to the body, which is then bound. arm selection / expansion is
+# deferred to sema + lowering.
+fun bind_comptime_each(rc: *ResolveContext, ce: *stmt.StmtComptimeEach) Result[bool, str] {
+    if (comptime.is_fields_call(rc.a, rc.source, ce.seq)) {
+        val targ: id.ExprId = comptime.fields_type_arg(rc.a, ce.seq);
+        if (targ != id.EXPR_NIL) {
+            val rt: Result[bool, str] = bind_intrinsic_type_arg(rc, targ);
+            if (is_err[bool, str](rt)) { ret rt; }
+        }
+    }
+    or {
+        val rs: Result[bool, str] = bind_expr(rc, ce.seq);
+        if (is_err[bool, str](rs)) { ret rs; }
+    }
+
+    val r_s: Result[ScopeId, str] = open_scope(rc, rc.current_scope);
+    if (is_err[ScopeId, str](r_s)) { ret err[bool, str](unwrap_err[ScopeId, str](r_s)); }
+    val saved: ScopeId = rc.current_scope;
+    rc.current_scope = unwrap_ok[ScopeId, str](r_s);
+
+    val rd: Result[SymbolId, str] = declare(rc, SYM_VAL, SYM_FLAG_COMPTIME, ce.var_name, id.DECL_NIL, 0, rc.own_module, rc.current_scope);
+    if (is_err[SymbolId, str](rd)) { rc.current_scope = saved; ret err[bool, str](unwrap_err[SymbolId, str](rd)); }
+
+    val rb: Result[bool, str] = bind_stmt_list(rc, ce.body_start, ce.body_len);
+    rc.current_scope = saved;
+    ret rb;
 }
 
 fun bind_block(rc: *ResolveContext, b: *stmt.StmtBlock) Result[bool, str] {
@@ -1740,6 +1773,13 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
         val ro: Result[bool, str] = bind_expr(rc, e.data.index.object);
         if (is_err[bool, str](ro)) { ret ro; }
         ret bind_expr(rc, e.data.index.index);
+    }
+    if (e.kind == expr.EXPR_KIND_PROJECT) {
+        # `v.[f]`: bind the instance, then the field descriptor (the `$each` loop
+        # variable, resolved against the enclosing `$each` scope).
+        val ro: Result[bool, str] = bind_expr(rc, e.data.project.object);
+        if (is_err[bool, str](ro)) { ret ro; }
+        ret bind_expr(rc, e.data.project.field);
     }
     if (e.kind == expr.EXPR_KIND_MEMBER) {
         val ro: Result[bool, str] = bind_expr(rc, e.data.member.object);

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1421,7 +1421,9 @@ fun gate_has_type_comparison(rc: *ResolveContext, eid: id.ExprId) bool {
     val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
     if (e.kind == expr.EXPR_KIND_BINARY) {
         if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
-            && comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)) {
+            && (comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)
+             || is_field_type_operand(rc, e.data.binary.lhs)
+             || is_field_type_operand(rc, e.data.binary.rhs))) {
             ret true;
         }
         ret gate_has_type_comparison(rc, e.data.binary.lhs)
@@ -1733,7 +1735,9 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
         # comptime-ident callee is a builtin), and the other operand is a type-name
         # spelling bound as a type so sema can recover the named type.
         if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
-            && comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)) {
+            && (comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)
+             || is_field_type_operand(rc, e.data.binary.lhs)
+             || is_field_type_operand(rc, e.data.binary.rhs))) {
             ret bind_type_comparison(rc, ?e.data.binary);
         }
         val rl: Result[bool, str] = bind_expr(rc, e.data.binary.lhs);
@@ -2204,7 +2208,35 @@ fun bind_type_operand(rc: *ResolveContext, operand: id.ExprId) Result[bool, str]
         if (arg == id.EXPR_NIL) { ret ok[bool, str](true); }
         ret bind_expr(rc, arg);
     }
+    # an `f.type` field-descriptor type (#1473): bind only the object (the `$each`
+    # loop variable); `.type` is a descriptor projection, not a record field.
+    if (is_field_type_operand(rc, operand)) {
+        val n_opt: Option[*expr.Expr] = ast.get_expr(rc.a, operand);
+        if (is_none[*expr.Expr](n_opt)) { ret ok[bool, str](true); }
+        ret bind_expr(rc, unwrap[*expr.Expr](n_opt).data.member.object);
+    }
     ret bind_intrinsic_type_arg(rc, operand);
+}
+
+# whether `eid` is an `f.type` operand whose object resolves, in the current
+# scope, to a `$each` comptime loop variable (a field descriptor). this keys the
+# `f.type` type-comparison recognition on the loop variable, so a real record
+# field named `type` (`s.type`) is never treated as a descriptor projection.
+fun is_field_type_operand(rc: *ResolveContext, eid: id.ExprId) bool {
+    if (!comptime.is_field_type_member(rc.a, rc.source, eid)) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(rc.a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val obj: id.ExprId = unwrap[*expr.Expr](n_opt).data.member.object;
+    val o_opt: Option[*expr.Expr] = ast.get_expr(rc.a, obj);
+    if (is_none[*expr.Expr](o_opt)) { ret false; }
+    val oe: *expr.Expr = unwrap[*expr.Expr](o_opt);
+    if (oe.kind != expr.EXPR_KIND_IDENT) { ret false; }
+    val r: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, oe.span);
+    if (is_err[intern.StrId, str](r)) { ret false; }
+    val sid: SymbolId = scope_lookup_chain(rc, rc.current_scope, unwrap_ok[intern.StrId, str](r));
+    if (sid == SYMBOL_NIL) { ret false; }
+    val sym: *Symbol = ?rc.symbols[sid];
+    ret sym.kind == SYM_VAL && (sym.flags & SYM_FLAG_COMPTIME) != 0;
 }
 
 # interns a static literal in the session interner, returning its StrId or

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1287,7 +1287,8 @@ fun bind_fwd_module(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, 
 # value is fixed only per call site, at lowering — so EVERY arm is bound
 # structurally; arm selection is deferred to per-value monomorphization.
 fun bind_comptime_if(rc: *ResolveContext, branches_start: u32, branches_len: u32, at_decl_scope: bool) Result[bool, str] {
-    if (!at_decl_scope && comptime_if_gated_on_param(rc, branches_start, branches_len)) {
+    if (!at_decl_scope && (comptime_if_gated_on_param(rc, branches_start, branches_len)
+                        || comptime_if_has_type_comparison(rc, branches_start, branches_len))) {
         var ai: u32 = 0;
         for (ai < branches_len) {
             val arm: *decl.ComptimeBranch = ?rc.a.comptime_branches[branches_start + ai];
@@ -1391,6 +1392,43 @@ fun comptime_if_gated_on_param(rc: *ResolveContext, branches_start: u32, branche
             ret true;
         }
         bi = bi + 1;
+    }
+    ret false;
+}
+
+# reports whether any arm of a `$if` chain is gated on a type comparison
+# (`$type_of(...) == TypeName`, #1472). a type comparison cannot fold before
+# types exist, so — like a comptime-param gate — its chain binds every arm and
+# defers arm selection to lowering, where the type resolver is installed.
+fun comptime_if_has_type_comparison(rc: *ResolveContext, branches_start: u32, branches_len: u32) bool {
+    var bi: u32 = 0;
+    for (bi < branches_len) {
+        val br: *decl.ComptimeBranch = ?rc.a.comptime_branches[branches_start + bi];
+        if (br.cond != id.EXPR_NIL && gate_has_type_comparison(rc, br.cond)) {
+            ret true;
+        }
+        bi = bi + 1;
+    }
+    ret false;
+}
+
+# walks a `$if` gate reporting whether it contains a type comparison — an
+# `==` / `!=` with a `$type_of(...)` operand — at any depth.
+fun gate_has_type_comparison(rc: *ResolveContext, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val e_opt: Option[*expr.Expr] = ast.get_expr(rc.a, eid);
+    if (is_none[*expr.Expr](e_opt)) { ret false; }
+    val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
+    if (e.kind == expr.EXPR_KIND_BINARY) {
+        if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
+            && comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)) {
+            ret true;
+        }
+        ret gate_has_type_comparison(rc, e.data.binary.lhs)
+         || gate_has_type_comparison(rc, e.data.binary.rhs);
+    }
+    if (e.kind == expr.EXPR_KIND_UNARY) {
+        ret gate_has_type_comparison(rc, e.data.unary.operand);
     }
     ret false;
 }
@@ -1657,6 +1695,14 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
         ret bind_ident(rc, eid, e.span);
     }
     if (e.kind == expr.EXPR_KIND_BINARY) {
+        # a type comparison (`$type_of(...) == TypeName`, #1472) binds its operands
+        # specially: a `$type_of(e)` operand binds only its inner value `e` (the
+        # comptime-ident callee is a builtin), and the other operand is a type-name
+        # spelling bound as a type so sema can recover the named type.
+        if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
+            && comptime.is_type_comparison(rc.a, rc.source, ?e.data.binary)) {
+            ret bind_type_comparison(rc, ?e.data.binary);
+        }
         val rl: Result[bool, str] = bind_expr(rc, e.data.binary.lhs);
         if (is_err[bool, str](rl)) { ret rl; }
         ret bind_expr(rc, e.data.binary.rhs);
@@ -2098,6 +2144,27 @@ fun bind_intrinsic_type_arg(rc: *ResolveContext, eid: id.ExprId) Result[bool, st
     # any other argument shape is not a type spelling; bind it as a normal
     # expression so a diagnostic surfaces the misuse.
     ret bind_expr(rc, eid);
+}
+
+# binds the two operands of a type comparison (`$type_of(...) == TypeName`,
+# #1472). each operand binds through `bind_type_operand`.
+fun bind_type_comparison(rc: *ResolveContext, bin: *expr.ExprBinary) Result[bool, str] {
+    val rl: Result[bool, str] = bind_type_operand(rc, bin.lhs);
+    if (is_err[bool, str](rl)) { ret rl; }
+    ret bind_type_operand(rc, bin.rhs);
+}
+
+# binds one type-comparison operand. a `$type_of(e)` operand binds only its inner
+# value `e` (the `$`-rooted comptime-ident callee is a builtin, bound nowhere); a
+# type-name operand binds as a type spelling so its resolved symbol is recorded
+# for sema to recover the named type.
+fun bind_type_operand(rc: *ResolveContext, operand: id.ExprId) Result[bool, str] {
+    if (comptime.is_type_of_call(rc.a, rc.source, operand)) {
+        val arg: id.ExprId = comptime.type_of_arg(rc.a, operand);
+        if (arg == id.EXPR_NIL) { ret ok[bool, str](true); }
+        ret bind_expr(rc, arg);
+    }
+    ret bind_intrinsic_type_arg(rc, operand);
 }
 
 # interns a static literal in the session interner, returning its StrId or

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1092,10 +1092,31 @@ fun bind_decl_list(rc: *ResolveContext, start: u32, len: u32) Result[bool, str] 
     ret ok[bool, str](true);
 }
 
+# binds the identifiers in each of decl `d`'s backtick decorator arguments.
+fun bind_decorator_args(rc: *ResolveContext, d: *decl.Decl) Result[bool, str] {
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *decl.Decorator = ?rc.a.decorators[d.decorators_start + k];
+        var j: u32 = 0;
+        for (j < dec.args_len) {
+            val r: Result[bool, str] = bind_expr(rc, rc.a.expr_ids[dec.args_start + j]);
+            if (is_err[bool, str](r)) { ret r; }
+            j = j + 1;
+        }
+        k = k + 1;
+    }
+    ret ok[bool, str](true);
+}
+
 fun bind_one_decl(rc: *ResolveContext, decl_id: id.DeclId) Result[bool, str] {
     val d_opt: Option[*decl.Decl] = ast.get_decl(rc.a, decl_id);
     if (is_none[*decl.Decl](d_opt)) { ret err[bool, str]("DeclId out of range"); }
     val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+
+    # a decl's backtick decorator arguments are comptime expressions; bind their
+    # identifiers (e.g. the operand of `align($size_of(T))`) so sema can type them.
+    val rda: Result[bool, str] = bind_decorator_args(rc, d);
+    if (is_err[bool, str](rda)) { ret rda; }
 
     if (d.kind == decl.DECL_KIND_COMPTIME_IF) {
         val ci: *decl.DeclComptimeIf = ?d.data.comptime_if;

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1747,6 +1747,10 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
     if (e.kind == expr.EXPR_KIND_UNARY) {
         ret bind_expr(rc, e.data.unary.operand);
     }
+    if (e.kind == expr.EXPR_KIND_SPREAD) {
+        # `va...`: bind the spread operand (the pack identifier).
+        ret bind_expr(rc, e.data.spread.inner);
+    }
     if (e.kind == expr.EXPR_KIND_CALL) {
         # a provisional bracket call `callee[x](args)` whose payload read as both
         # a type list and an index expression: choose the reading now from the

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -590,7 +590,18 @@ fun infer_stmt(sc: *ctxm.SemaContext, sid: id.StmtId, fn_ret: type.TypeId) Resul
 # each iteration re-types the body.
 fun infer_stmt_comptime_each(sc: *ctxm.SemaContext, ce: *stmt.StmtComptimeEach, span: token.Span, fn_ret: type.TypeId) Result[bool, str] {
     if (!comptime.is_fields_call(sc.a, sc.source, ce.seq)) {
-        ctxm.report(sc, span, "a `$each` sequence must be `$fields(T)`");
+        # a variadic-pack sequence (`$each a in va`, #1474): the element types are
+        # fixed per call site, so the body is type-checked per instantiation at
+        # monomorphization (#1475), not here. accept the well-formed construct and
+        # defer; a non-pack, non-`$fields` sequence is malformed.
+        val seq_ty: type.TypeId = infer.infer_expr(sc, ce.seq);
+        val st_opt: Option[*type.Type] = type.get(?sc.s.types, seq_ty);
+        if (is_some[*type.Type](st_opt) && unwrap[*type.Type](st_opt).kind == type.TYPE_PACK) {
+            ret ok[bool, str](true);
+        }
+        if (seq_ty != type.TYPE_ERROR) {
+            ctxm.report(sc, span, "a `$each` sequence must be `$fields(T)` or a variadic pack");
+        }
         ret ok[bool, str](true);
     }
     val owner: type.TypeId = infer.field_seq_owner(sc, ce.seq, span);

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -714,7 +714,9 @@ fun gate_has_type_comparison(sc: *ctxm.SemaContext, eid: id.ExprId) bool {
     val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
     if (e.kind == expr.EXPR_KIND_BINARY) {
         if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
-            && comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)) {
+            && (comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)
+             || infer.sema_is_field_type_operand(sc, e.data.binary.lhs)
+             || infer.sema_is_field_type_operand(sc, e.data.binary.rhs))) {
             ret true;
         }
         ret gate_has_type_comparison(sc, e.data.binary.lhs)
@@ -772,7 +774,9 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
         # comptime gate; its operands name types (validated by infer) and it folds
         # at lowering, so it is not recursed into as value subexpressions.
         if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
-            && comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)) {
+            && (comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)
+             || infer.sema_is_field_type_operand(sc, e.data.binary.lhs)
+             || infer.sema_is_field_type_operand(sc, e.data.binary.rhs))) {
             ret;
         }
         check_comptime_gate(sc, e.data.binary.lhs);

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -328,6 +328,11 @@ fun infer_one_body(sc: *ctxm.SemaContext, did: id.DeclId) Result[bool, str] {
     if (is_none[*decl.Decl](d_opt)) { ret err[bool, str]("DeclId out of range"); }
     val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
 
+    # a decl's backtick decorator arguments are comptime expressions; infer them
+    # so their types resolve (e.g. `align($size_of(T))`) before the middle end
+    # folds them.
+    infer_decorator_args(sc, d);
+
     if (d.kind == decl.DECL_KIND_COMPTIME_IF) {
         ret infer_bodies_comptime_if(sc, ?d.data.comptime_if);
     }
@@ -356,6 +361,20 @@ fun infer_one_body(sc: *ctxm.SemaContext, did: id.DeclId) Result[bool, str] {
         ret ok[bool, str](true);
     }
     ret ok[bool, str](true);
+}
+
+# infers each of decl `d`'s backtick decorator arguments so their types resolve.
+fun infer_decorator_args(sc: *ctxm.SemaContext, d: *decl.Decl) {
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *decl.Decorator = ?sc.a.decorators[d.decorators_start + k];
+        var j: u32 = 0;
+        for (j < dec.args_len) {
+            infer.infer_expr(sc, sc.a.expr_ids[dec.args_start + j]);
+            j = j + 1;
+        }
+        k = k + 1;
+    }
 }
 
 # the return type a `test` body is checked against: the canonical i32

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -474,11 +474,14 @@ fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Deco
         require_string_arg(sc, dec,
             "`section` decorator takes one string argument",
             "`section` decorator argument must be a string literal");
-        if (!is_fun_or_global(d.kind)) {
+        if (d.kind == decl.DECL_KIND_FUN) {
+            # global section emission is wired; per-function sectioning needs the
+            # encoder to emit functions into separate text sections — reported
+            # rather than silently ignored until that lands.
+            ctxm.report(sc, dec.name, "`section` on functions is not yet implemented");
+        } or (!is_fun_or_global(d.kind)) {
             ctxm.report(sc, dec.name, "`section` decorator applies only to functions and globals");
         }
-        # emission is not wired yet; report rather than silently ignore.
-        ctxm.report(sc, dec.name, "`section` decorator is not yet implemented");
         ret;
     }
     ctxm.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, align, library");

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -180,6 +180,66 @@ pub fun reinfer_pack_each_body(
     ret infer_stmt_list(?sc, body_start, body_len, fn_ret);
 }
 
+# collect_module_deps: assemble a typing-snapshot set spanning EVERY registered
+# module, for a re-inference that runs after the whole program is sema'd (#1475).
+# the original per-module sema pass receives only its actual dependencies, but the
+# pack-body re-inference at monomorphization may reach any module the body
+# references, so it consults the full set. each entry borrows a module's
+# SemaResult.decl_type array (owned by the session), so the returned SemaDeps must
+# be released with `free_module_deps` (which frees only the entries array) before
+# the SemaResults are torn down. a module with no registered SemaResult yields a
+# decl-type-less entry (a lookup against it returns TYPE_ERROR, like a miss).
+# ---
+# s:   the session (its module registries)
+# ret: a SemaDeps spanning every module, or an allocation error
+pub fun collect_module_deps(s: *sess.Session) Result[ctxm.SemaDeps, str] {
+    var deps: ctxm.SemaDeps;
+    deps.entries = nil;
+    deps.count   = 0;
+
+    val n: u32 = sess.module_count(s);
+    if (n == 0) { ret ok[ctxm.SemaDeps, str](deps); }
+
+    val r: Result[*ctxm.ModuleSema, str] = allocate[ctxm.ModuleSema](s.alloc, n::usize);
+    if (is_err[*ctxm.ModuleSema, str](r)) { ret err[ctxm.SemaDeps, str](unwrap_err[*ctxm.ModuleSema, str](r)); }
+    val arr: *ctxm.ModuleSema = unwrap_ok[*ctxm.ModuleSema, str](r);
+
+    var mid: u32 = 0;
+    for (mid < n) {
+        var ms: ctxm.ModuleSema;
+        ms.path       = sess.module_fqn(s, mid::sess.ModuleId);
+        ms.module     = mid::sess.ModuleId;
+        ms.decl_type  = nil;
+        ms.decl_count = 0;
+        val sp: ptr = sess.module_sema_ptr(s, mid::sess.ModuleId);
+        if (sp != nil) {
+            val sr: *ctxm.SemaResult = sp::*ctxm.SemaResult;
+            ms.decl_type  = sr.decl_type;
+            ms.decl_count = sr.decl_count;
+        }
+        arr[mid] = ms;
+        mid = mid + 1;
+    }
+
+    deps.entries = arr;
+    deps.count   = n;
+    ret ok[ctxm.SemaDeps, str](deps);
+}
+
+# free_module_deps: release the entries array a `collect_module_deps` allocated.
+# the borrowed decl_type arrays it points into are owned by the session and are
+# NOT freed here.
+# ---
+# s:    the session (allocator)
+# deps: the SemaDeps to release (entries freed, fields zeroed)
+pub fun free_module_deps(s: *sess.Session, deps: *ctxm.SemaDeps) {
+    if (deps.entries != nil && deps.count > 0) {
+        deallocate[ctxm.ModuleSema](s.alloc, deps.entries, deps.count::usize);
+    }
+    deps.entries = nil;
+    deps.count   = 0;
+}
+
 # dnit_result: releases the parallel arrays held by the result and zeroes its fields; nil is a no-op.
 # ---
 # r: result to tear down; nil is a no-op

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -134,6 +134,52 @@ pub fun sema(
     ret build_result(?sc);
 }
 
+# reinfer_pack_each_body: re-type a `$each a in va` pack-unroll body for ONE
+# concrete element at monomorphization (#1475). a pack element's type is fixed
+# only at the call site, so the body cannot be typed at the original sema pass;
+# the monomorphizer binds the loop variable in the comptime context to the
+# element's CT_KIND_PACK_ELEM descriptor (so `infer_ident` types `a` to the
+# element type) and calls this to write the body expressions' types into the
+# origin module's shared `expr_type` array — exactly the array lowering then
+# reads. distinct elements / instances are typed in turn (the array is overwritten
+# per element; lowering interleaves typing and emission), so one shared array
+# suffices. the transient context reuses the origin SemaResult's arrays in place
+# rather than allocating, so it must not be torn down.
+# ---
+# s, a, rr, deps, ctx, own_module: the origin module's phase inputs (the module
+#   declaring the pack-tailed template)
+# sema_result: the origin module's SemaResult, whose arrays this reuses in place
+# fn_ret:      the instance's semantic return type (checks any body `ret`)
+# body_start / body_len: the `$each` body statement slice
+# ret:         true once the body is typed, or the first inference error
+pub fun reinfer_pack_each_body(
+    s:           *sess.Session,
+    a:           *ast.Ast,
+    rr:          *resolve.ResolveResult,
+    deps:        *ctxm.SemaDeps,
+    ctx:         *comptime.ComptimeCtx,
+    own_module:  sess.ModuleId,
+    sema_result: *ctxm.SemaResult,
+    fn_ret:      type.TypeId,
+    body_start:  u32,
+    body_len:    u32
+) Result[bool, str] {
+    var sc: ctxm.SemaContext;
+    sc.s          = s;
+    sc.a          = a;
+    sc.rr         = rr;
+    sc.deps       = deps;
+    sc.ctx        = ctx;
+    sc.own_module = own_module;
+    sc.source     = source_text_of(s, a);
+    sc.expr_type        = sema_result.expr_type;
+    sc.type_resolved_ty = sema_result.type_resolved_ty;
+    sc.decl_type        = sema_result.decl_type;
+    sc.callee_eid       = id.EXPR_NIL;
+    sc.in_comptime_gate = false;
+    ret infer_stmt_list(?sc, body_start, body_len, fn_ret);
+}
+
 # dnit_result: releases the parallel arrays held by the result and zeroes its fields; nil is a no-op.
 # ---
 # r: result to tear down; nil is a no-op

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -177,7 +177,8 @@ fun init_context(
     sc.type_resolved_ty = nil;
     sc.decl_type        = nil;
 
-    sc.callee_eid   = id.EXPR_NIL;
+    sc.callee_eid       = id.EXPR_NIL;
+    sc.in_comptime_gate = false;
 
     if (a.expr_len > 0) {
         val r: Result[*type.TypeId, str] = allocate[type.TypeId](s.alloc, a.expr_len);
@@ -590,15 +591,23 @@ fun infer_stmt_list(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: type.Ty
 }
 
 fun infer_stmt_comptime_if(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: type.TypeId) Result[bool, str] {
-    # a chain gated on a comptime value parameter cannot select an arm at sema
-    # time (the parameter's value is fixed per call site). type-check EVERY arm
+    # a chain gated on a comptime value parameter, or on a type comparison
+    # (`$type_of(...)`, #1472), cannot select an arm at sema time — the
+    # parameter's value is fixed per call site, and a type comparison folds only
+    # once the type resolver is installed at lowering. type-check EVERY arm
     # structurally; arm selection is deferred to per-value monomorphization.
-    if (stmt_comptime_if_gated_on_param(sc, start, len)) {
+    if (stmt_comptime_if_gated_on_param(sc, start, len)
+        || stmt_comptime_if_has_type_comparison(sc, start, len)) {
         var ai: u32 = 0;
         for (ai < len) {
             val arm: *decl.ComptimeBranch = ?sc.a.comptime_branches[start + ai];
             if (arm.cond != id.EXPR_NIL) {
+                # mark gate context so a `$type_of(...)` type comparison is accepted
+                # here (and rejected as a value elsewhere).
+                val saved_gate: bool = sc.in_comptime_gate;
+                sc.in_comptime_gate = true;
                 infer.infer_expr(sc, arm.cond);
+                sc.in_comptime_gate = saved_gate;
                 # every arm gate of a param-gated chain must itself be comptime-
                 # foldable: its free identifiers must all be comptime (comptime
                 # params or comptime constants), never a runtime local/param/var.
@@ -638,6 +647,41 @@ fun stmt_comptime_if_gated_on_param(sc: *ctxm.SemaContext, start: u32, len: u32)
             ret true;
         }
         bi = bi + 1;
+    }
+    ret false;
+}
+
+# reports whether any arm gate of a statement-level `$if` chain is a type
+# comparison (`$type_of(...) == TypeName`, #1472). such a gate folds only at
+# lowering, so — like a comptime-param gate — its chain defers arm selection.
+fun stmt_comptime_if_has_type_comparison(sc: *ctxm.SemaContext, start: u32, len: u32) bool {
+    var bi: u32 = 0;
+    for (bi < len) {
+        val br: *decl.ComptimeBranch = ?sc.a.comptime_branches[start + bi];
+        if (br.cond != id.EXPR_NIL && gate_has_type_comparison(sc, br.cond)) {
+            ret true;
+        }
+        bi = bi + 1;
+    }
+    ret false;
+}
+
+# walks a `$if` gate reporting whether it contains a type comparison at any depth.
+fun gate_has_type_comparison(sc: *ctxm.SemaContext, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val e_opt: Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (is_none[*expr.Expr](e_opt)) { ret false; }
+    val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
+    if (e.kind == expr.EXPR_KIND_BINARY) {
+        if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
+            && comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)) {
+            ret true;
+        }
+        ret gate_has_type_comparison(sc, e.data.binary.lhs)
+         || gate_has_type_comparison(sc, e.data.binary.rhs);
+    }
+    if (e.kind == expr.EXPR_KIND_UNARY) {
+        ret gate_has_type_comparison(sc, e.data.unary.operand);
     }
     ret false;
 }
@@ -684,6 +728,13 @@ fun check_comptime_gate(sc: *ctxm.SemaContext, eid: id.ExprId) {
     # composite operators: recurse into operands so a runtime leaf is reported at
     # its own span rather than masked by the parent.
     if (k == expr.EXPR_KIND_BINARY) {
+        # a type comparison (`$type_of(...) == TypeName`, #1472) is a well-formed
+        # comptime gate; its operands name types (validated by infer) and it folds
+        # at lowering, so it is not recursed into as value subexpressions.
+        if ((e.data.binary.op == expr.BIN_EQ || e.data.binary.op == expr.BIN_NEQ)
+            && comptime.is_type_comparison(sc.a, sc.source, ?e.data.binary)) {
+            ret;
+        }
         check_comptime_gate(sc, e.data.binary.lhs);
         check_comptime_gate(sc, e.data.binary.rhs);
         ret;

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -575,7 +575,47 @@ fun infer_stmt(sc: *ctxm.SemaContext, sid: id.StmtId, fn_ret: type.TypeId) Resul
     if (st.kind == stmt.STMT_KIND_COMPTIME_IF) {
         ret infer_stmt_comptime_if(sc, st.data.comptime_if.branches_start, st.data.comptime_if.branches_len, fn_ret);
     }
+    if (st.kind == stmt.STMT_KIND_COMPTIME_EACH) {
+        ret infer_stmt_comptime_each(sc, ?st.data.comptime_each, st.span, fn_ret);
+    }
     # BRK, CNT, ASM, ERROR carry no expressions to infer
+    ret ok[bool, str](true);
+}
+
+# type-checks a `$each <ident> in $fields(T) { body }` (#1473) by unrolling it:
+# the body is inferred once per field of T, with the loop variable bound in the
+# comptime frame to that field's descriptor, so a `v.[f]` / `f.type` in the body
+# is typed against the concrete field of each iteration. this is the sema half of
+# the splice the lowerer mirrors; heterogeneous field types are handled because
+# each iteration re-types the body.
+fun infer_stmt_comptime_each(sc: *ctxm.SemaContext, ce: *stmt.StmtComptimeEach, span: token.Span, fn_ret: type.TypeId) Result[bool, str] {
+    if (!comptime.is_fields_call(sc.a, sc.source, ce.seq)) {
+        ctxm.report(sc, span, "a `$each` sequence must be `$fields(T)`");
+        ret ok[bool, str](true);
+    }
+    val owner: type.TypeId = infer.field_seq_owner(sc, ce.seq, span);
+    if (owner == type.TYPE_ERROR) { ret ok[bool, str](true); }
+
+    val name_r: Result[intern.StrId, str] = intern.intern_span(?sc.s.interner, sc.source, ce.var_name);
+    if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
+    val fname: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+    val n: u32 = type.field_count(?sc.s.types, owner);
+    var i: u32 = 0;
+    for (i < n) {
+        val mark: comptime.FrameMark = comptime.frame_open(sc.ctx);
+        val br: Result[bool, str] = comptime.bind(sc.ctx, fname, comptime.field_value(owner::u32, i));
+        if (is_err[bool, str](br)) {
+            val cc: Result[bool, str] = comptime.frame_close(sc.ctx, mark);
+            if (is_err[bool, str](cc)) { ret cc; }
+            ret br;
+        }
+        val rb: Result[bool, str] = infer_stmt_list(sc, ce.body_start, ce.body_len, fn_ret);
+        val cc: Result[bool, str] = comptime.frame_close(sc.ctx, mark);
+        if (is_err[bool, str](rb)) { ret rb; }
+        if (is_err[bool, str](cc)) { ret cc; }
+        i = i + 1;
+    }
     ret ok[bool, str](true);
 }
 

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -406,11 +406,19 @@ fun require_string_arg(sc: *ctxm.SemaContext, dec: *decl.Decorator, count_msg: s
     }
 }
 
-# true for decl kinds carrying data or a type (the `align` decorator's targets).
-fun is_data_or_type(kind: decl.DeclKind) bool {
+# true for an `align` decorator target: a global binding (val/var) or a record /
+# union nominal. a `def` alias is excluded — it is transparent (no layout of its
+# own and emits no symbol), so an alignment on it would silently no-op.
+fun is_align_target(kind: decl.DeclKind) bool {
     ret kind == decl.DECL_KIND_VAL || kind == decl.DECL_KIND_VAR ||
-        kind == decl.DECL_KIND_REC || kind == decl.DECL_KIND_UNI ||
-        kind == decl.DECL_KIND_DEF;
+        kind == decl.DECL_KIND_REC || kind == decl.DECL_KIND_UNI;
+}
+
+# true for a global binding (val/var) — the targets whose `align` argument the
+# body-pass validator type-checks (a rec/uni's argument is validated by the
+# decl-pass fold in record_type_align instead, to avoid a double report).
+fun is_global_binding(kind: decl.DeclKind) bool {
+    ret kind == decl.DECL_KIND_VAL || kind == decl.DECL_KIND_VAR;
 }
 
 # true for a function or a global binding (the `symbol`/`section` targets).
@@ -455,18 +463,18 @@ fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Deco
     if (decorator_named(sc, dec, "align")) {
         if (dec.args_len != 1) {
             ctxm.report(sc, dec.name, "`align` decorator takes one argument");
-        } or {
-            # the argument is a comptime expression that must fold to an integer
-            # alignment (a literal, or `$align_of(T)` / `$size_of(T)`). its exact
-            # value and the power-of-two check are computed at lowering, where type
-            # layout is available; here only its type is checked.
+        } or (is_global_binding(d.kind)) {
+            # for a global the value is folded at lowering (type layout available);
+            # here only its type is checked. a rec/uni argument is validated wholly
+            # by the decl-pass fold (record_type_align) — checking it here too would
+            # double-report — so the type check is global-only.
             val ae: id.ExprId = sc.a.expr_ids[dec.args_start];
             if (!type.is_integer(?sc.s.types, decorator_arg_type(sc, ae))) {
                 ctxm.report(sc, dec.name, "`align` decorator argument must be an integer comptime expression");
             }
         }
-        if (!is_data_or_type(d.kind)) {
-            ctxm.report(sc, dec.name, "`align` decorator applies only to data and types");
+        if (!is_align_target(d.kind)) {
+            ctxm.report(sc, dec.name, "`align` decorator applies only to records, unions, and globals");
         }
         ret;
     }

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -35,6 +35,7 @@ use std.types.option.unwrap;
 use std.types.size.usize;
 
 use std.types.string.str;
+use std.types.string.str_region_equals;
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -332,6 +333,7 @@ fun infer_one_body(sc: *ctxm.SemaContext, did: id.DeclId) Result[bool, str] {
     # so their types resolve (e.g. `align($size_of(T))`) before the middle end
     # folds them.
     infer_decorator_args(sc, d);
+    validate_decorators(sc, d);
 
     if (d.kind == decl.DECL_KIND_COMPTIME_IF) {
         ret infer_bodies_comptime_if(sc, ?d.data.comptime_if);
@@ -375,6 +377,92 @@ fun infer_decorator_args(sc: *ctxm.SemaContext, d: *decl.Decl) {
         }
         k = k + 1;
     }
+}
+
+# validates a decl's backtick decorators: each must name a directive from the
+# closed set (symbol/section/inline/align/library), carry the right argument
+# shape, and apply to a compatible declaration. diagnostics are reported against
+# the offending span; sema does not halt.
+fun validate_decorators(sc: *ctxm.SemaContext, d: *decl.Decl) {
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        validate_one_decorator(sc, d, ?sc.a.decorators[d.decorators_start + k]);
+        k = k + 1;
+    }
+}
+
+# true when decorator `dec`'s directive name equals `name`.
+fun decorator_named(sc: *ctxm.SemaContext, dec: *decl.Decorator, name: str) bool {
+    ret str_region_equals(sc.source, dec.name.offset, dec.name.len, name);
+}
+
+# reports unless decorator `dec` carries exactly one string-literal argument.
+fun require_string_arg(sc: *ctxm.SemaContext, dec: *decl.Decorator, count_msg: str, kind_msg: str) {
+    if (dec.args_len != 1) { ctxm.report(sc, dec.name, count_msg); ret; }
+    val ae_opt: Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start]);
+    if (is_some[*expr.Expr](ae_opt)) {
+        val ae: *expr.Expr = unwrap[*expr.Expr](ae_opt);
+        if (ae.kind != expr.EXPR_KIND_LIT_STR) { ctxm.report(sc, ae.span, kind_msg); }
+    }
+}
+
+# true for decl kinds carrying data or a type (the `align` decorator's targets).
+fun is_data_or_type(kind: decl.DeclKind) bool {
+    ret kind == decl.DECL_KIND_VAL || kind == decl.DECL_KIND_VAR ||
+        kind == decl.DECL_KIND_REC || kind == decl.DECL_KIND_UNI ||
+        kind == decl.DECL_KIND_DEF;
+}
+
+# true for a function or a global binding (the `symbol`/`section` targets).
+fun is_fun_or_global(kind: decl.DeclKind) bool {
+    ret kind == decl.DECL_KIND_FUN || kind == decl.DECL_KIND_VAL || kind == decl.DECL_KIND_VAR;
+}
+
+fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Decorator) {
+    if (decorator_named(sc, dec, "symbol")) {
+        require_string_arg(sc, dec,
+            "`symbol` decorator takes one string argument",
+            "`symbol` decorator argument must be a string literal");
+        if (!is_fun_or_global(d.kind)) {
+            ctxm.report(sc, dec.name, "`symbol` decorator applies only to functions and globals");
+        }
+        ret;
+    }
+    if (decorator_named(sc, dec, "library")) {
+        require_string_arg(sc, dec,
+            "`library` decorator takes one string argument",
+            "`library` decorator argument must be a string literal");
+        if ((d.flags & decl.DECL_FLAG_EXT) == 0) {
+            ctxm.report(sc, dec.name, "`library` decorator applies only to ext imports");
+        }
+        ret;
+    }
+    if (decorator_named(sc, dec, "inline")) {
+        if (dec.args_len != 0) { ctxm.report(sc, dec.name, "`inline` decorator takes no arguments"); }
+        if (d.kind != decl.DECL_KIND_FUN) {
+            ctxm.report(sc, dec.name, "`inline` decorator applies only to functions");
+        }
+        ret;
+    }
+    if (decorator_named(sc, dec, "align")) {
+        if (dec.args_len != 1) { ctxm.report(sc, dec.name, "`align` decorator takes one argument"); }
+        if (!is_data_or_type(d.kind)) {
+            ctxm.report(sc, dec.name, "`align` decorator applies only to data and types");
+        }
+        ret;
+    }
+    if (decorator_named(sc, dec, "section")) {
+        require_string_arg(sc, dec,
+            "`section` decorator takes one string argument",
+            "`section` decorator argument must be a string literal");
+        if (!is_fun_or_global(d.kind)) {
+            ctxm.report(sc, dec.name, "`section` decorator applies only to functions and globals");
+        }
+        # emission is not wired yet; report rather than silently ignore.
+        ctxm.report(sc, dec.name, "`section` decorator is not yet implemented");
+        ret;
+    }
+    ctxm.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, align, library");
 }
 
 # the return type a `test` body is checked against: the canonical i32

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -474,12 +474,7 @@ fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Deco
         require_string_arg(sc, dec,
             "`section` decorator takes one string argument",
             "`section` decorator argument must be a string literal");
-        if (d.kind == decl.DECL_KIND_FUN) {
-            # global section emission is wired; per-function sectioning needs the
-            # encoder to emit functions into separate text sections — reported
-            # rather than silently ignored until that lands.
-            ctxm.report(sc, dec.name, "`section` on functions is not yet implemented");
-        } or (!is_fun_or_global(d.kind)) {
+        if (!is_fun_or_global(d.kind)) {
             ctxm.report(sc, dec.name, "`section` decorator applies only to functions and globals");
         }
         ret;

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -418,6 +418,14 @@ fun is_fun_or_global(kind: decl.DeclKind) bool {
     ret kind == decl.DECL_KIND_FUN || kind == decl.DECL_KIND_VAL || kind == decl.DECL_KIND_VAR;
 }
 
+# the inferred type of decorator-argument expression `eid`, or TYPE_ERROR when
+# the id is out of range (infer_decorator_args has already typed it).
+fun decorator_arg_type(sc: *ctxm.SemaContext, eid: id.ExprId) type.TypeId {
+    if (eid == id.EXPR_NIL) { ret type.TYPE_ERROR; }
+    if (eid::usize >= sc.a.expr_len) { ret type.TYPE_ERROR; }
+    ret sc.expr_type[eid];
+}
+
 fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Decorator) {
     if (decorator_named(sc, dec, "symbol")) {
         require_string_arg(sc, dec,
@@ -445,7 +453,18 @@ fun validate_one_decorator(sc: *ctxm.SemaContext, d: *decl.Decl, dec: *decl.Deco
         ret;
     }
     if (decorator_named(sc, dec, "align")) {
-        if (dec.args_len != 1) { ctxm.report(sc, dec.name, "`align` decorator takes one argument"); }
+        if (dec.args_len != 1) {
+            ctxm.report(sc, dec.name, "`align` decorator takes one argument");
+        } or {
+            # the argument is a comptime expression that must fold to an integer
+            # alignment (a literal, or `$align_of(T)` / `$size_of(T)`). its exact
+            # value and the power-of-two check are computed at lowering, where type
+            # layout is available; here only its type is checked.
+            val ae: id.ExprId = sc.a.expr_ids[dec.args_start];
+            if (!type.is_integer(?sc.s.types, decorator_arg_type(sc, ae))) {
+                ctxm.report(sc, dec.name, "`align` decorator argument must be an integer comptime expression");
+            }
+        }
         if (!is_data_or_type(d.kind)) {
             ctxm.report(sc, dec.name, "`align` decorator applies only to data and types");
         }

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -84,6 +84,44 @@ fun param_is_pack(sc: *sema.SemaContext, param_idx: u32) bool {
     ret unwrap[*ty.Type](to).kind == ty.TYPE_PACK;
 }
 
+# whether the argument at `eid` is a `va...` pack spread (#1474).
+fun arg_is_spread(sc: *sema.SemaContext, eid: id.ExprId) bool {
+    val e_opt: Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (is_none[*expr.Expr](e_opt)) { ret false; }
+    ret unwrap[*expr.Expr](e_opt).kind == expr.EXPR_KIND_SPREAD;
+}
+
+# validates the placement of any `va...` pack spread (#1474) among a call's
+# arguments. a spread forwards a whole pack and is valid ONLY as the sole
+# trailing argument of a pack-tailed callee — i.e. at index `fixed_count` with
+# `args_len == fixed_count + 1`. spreading into fixed parameters (no pack tail)
+# or a spread mixed with other trailing args is rejected. a spread whose operand
+# is not a pack already reported in `infer_spread`, so it is not re-diagnosed
+# here. returns false (with a diagnostic) on the first ill-placed spread.
+fun validate_pack_spreads(sc: *sema.SemaContext, has_pack: bool, fixed_count: u32, args_start: u32, args_len: u32, span: token.Span) bool {
+    var ok: bool = true;
+    var i: u32 = 0;
+    for (i < args_len) {
+        val a_eid: id.ExprId = sc.a.expr_ids[args_start + i];
+        if (arg_is_spread(sc, a_eid)) {
+            val a_span: token.Span = expr_span_of(sc, a_eid, span);
+            if (expr_type_of(sc, a_eid) == ty.TYPE_ERROR) {
+                ok = false;
+            }
+            or (!has_pack) {
+                report(sc, a_span, "cannot spread `...` into fixed parameters: the callee has no variadic pack parameter");
+                ok = false;
+            }
+            or (i != fixed_count || args_len != fixed_count + 1) {
+                report(sc, a_span, "a `...` pack spread must be the sole trailing argument, forwarding the whole pack");
+                ok = false;
+            }
+        }
+        i = i + 1;
+    }
+    ret ok;
+}
+
 # checks a call against the callee's function signature: the callee type
 # must be a function, the argument count must match the fixed parameter
 # count (or be at least that many for a variadic or pack-tailed function), and
@@ -126,6 +164,14 @@ pub fun check_call(sc: *sema.SemaContext, callee_sig: ty.TypeId, args_start: u32
     var fixed_count: u32 = param_count;
     val has_pack: bool = param_count > 0 && param_is_pack(sc, params_start + param_count - 1);
     if (has_pack) { fixed_count = param_count - 1; }
+
+    # a `va...` pack spread (#1474) forwards a whole pack; reject an ill-placed
+    # one first — before arity and the per-argument check — so a misplaced spread
+    # reports its own clear diagnostic rather than an arity mismatch, and a pack
+    # operand is never additionally diagnosed against a fixed parameter type.
+    if (!validate_pack_spreads(sc, has_pack, fixed_count, args_start, args_len, span)) {
+        ret false;
+    }
 
     if (variadic || has_pack) {
         if (args_len < fixed_count) {

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -74,14 +74,25 @@ pub fun check_assignable(sc: *sema.SemaContext, expected: ty.TypeId, actual: ty.
     ret false;
 }
 
+# whether the parameter interned at `param_idx` is a comptime variadic pack
+# (#1474) — the trailing form that absorbs a call's remaining arguments.
+fun param_is_pack(sc: *sema.SemaContext, param_idx: u32) bool {
+    val pty_opt: Option[ty.TypeId] = ty.get_param(?sc.s.types, param_idx);
+    if (is_none[ty.TypeId](pty_opt)) { ret false; }
+    val to: Option[*ty.Type] = ty.get(?sc.s.types, unwrap[ty.TypeId](pty_opt));
+    if (is_none[*ty.Type](to)) { ret false; }
+    ret unwrap[*ty.Type](to).kind == ty.TYPE_PACK;
+}
+
 # checks a call against the callee's function signature: the callee type
 # must be a function, the argument count must match the fixed parameter
-# count (or be at least that many for a variadic function), and each fixed
-# argument must be assignable to its parameter. trailing variadic arguments
-# carry their inferred types unchecked, as the C-ABI variadic contract
-# imposes no parameter type. argument expressions are taken from
-# `sc.a.expr_ids[args_start ..]`, which allows untyped-literal arguments to
-# coerce to their parameter type.
+# count (or be at least that many for a variadic or pack-tailed function), and
+# each fixed argument must be assignable to its parameter. trailing variadic
+# arguments carry their inferred types unchecked, as the C-ABI variadic
+# contract imposes no parameter type; trailing pack arguments are likewise
+# unchecked here, their element types fixed per call site at monomorphization
+# (#1475). argument expressions are taken from `sc.a.expr_ids[args_start ..]`,
+# which allows untyped-literal arguments to coerce to their parameter type.
 # ---
 # sc:         the active sema context
 # callee_sig: the callee's type; must be TYPE_FUN
@@ -105,9 +116,20 @@ pub fun check_call(sc: *sema.SemaContext, callee_sig: ty.TypeId, args_start: u32
 
     val param_count: u32 = ft.data.fn.params_len;
     val variadic:    bool = ft.data.fn.variadic;
-    if (variadic) {
-        if (args_len < param_count) {
-            report_arity(sc, span, param_count, args_len, true);
+    val params_start: u32 = ft.data.fn.params_start;
+
+    # a trailing comptime variadic pack param (#1474) absorbs every trailing
+    # argument: arity is `>= the leading fixed count`, and the collected args
+    # carry their inferred types unchecked here — their concrete element types
+    # are fixed per call site and bound at monomorphization (#1475). the legacy
+    # C-variadic flag is a distinct, mutually exclusive trailing form.
+    var fixed_count: u32 = param_count;
+    val has_pack: bool = param_count > 0 && param_is_pack(sc, params_start + param_count - 1);
+    if (has_pack) { fixed_count = param_count - 1; }
+
+    if (variadic || has_pack) {
+        if (args_len < fixed_count) {
+            report_arity(sc, span, fixed_count, args_len, true);
             ret false;
         }
     }
@@ -116,10 +138,9 @@ pub fun check_call(sc: *sema.SemaContext, callee_sig: ty.TypeId, args_start: u32
         ret false;
     }
 
-    val params_start: u32 = ft.data.fn.params_start;
     var ok_all: bool = true;
     var i: u32 = 0;
-    for (i < param_count) {
+    for (i < fixed_count) {
         val pty_opt: Option[ty.TypeId] = ty.get_param(?sc.s.types, params_start + i);
         if (is_none[ty.TypeId](pty_opt)) { ok_all = false; brk; }
         val expected: ty.TypeId = unwrap[ty.TypeId](pty_opt);

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -124,6 +124,12 @@ pub rec SemaContext {
     # function in callee position (it is a template, callable but not a value) and
     # rejects it everywhere else.
     callee_eid: id.ExprId;
+
+    # true while inferring a comptime `$if` gate condition. a type comparison
+    # (`$type_of(...)`, #1472) is comptime-only and valid only here; set
+    # transiently so infer_type_comparison can reject the same shape in a runtime
+    # value position.
+    in_comptime_gate: bool;
 }
 
 # resolved_type_of: returns the interned TypeId a syntactic AstType resolved to, or TYPE_ERROR/TYPE_NIL for out-of-range or absent ids.

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -315,6 +315,9 @@ pub fun infer_expr(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
     or (e.kind == expr.EXPR_KIND_PROJECT) {
         t = infer_project(sc, ?e.data.project, e.span);
     }
+    or (e.kind == expr.EXPR_KIND_SPREAD) {
+        t = infer_spread(sc, ?e.data.spread, e.span);
+    }
     or (e.kind == expr.EXPR_KIND_CAST) {
         t = infer_cast(sc, ?e.data.cast, e.span);
     }
@@ -970,6 +973,20 @@ fun type_is_pack(sc: *sema.SemaContext, ty: type.TypeId) bool {
     val to: Option[*type.Type] = type.get(?sc.s.types, ty);
     if (is_none[*type.Type](to)) { ret false; }
     ret unwrap[*type.Type](to).kind == type.TYPE_PACK;
+}
+
+# infer_spread: types a `va...` pack spread (#1474). a spread may only spread a
+# comptime variadic pack; its type is that pack. it forwards the whole pack into
+# a trailing pack parameter — that placement is validated at the call site
+# (check_call). a spread of a non-pack operand is malformed.
+fun infer_spread(sc: *sema.SemaContext, sp: *expr.ExprSpread, span: token.Span) type.TypeId {
+    val it: type.TypeId = infer_expr(sc, sp.inner);
+    if (it == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    if (!type_is_pack(sc, it)) {
+        sema.report(sc, span, "`...` may only spread a variadic pack");
+        ret type.TYPE_ERROR;
+    }
+    ret it;
 }
 
 # whether `ty` is a record (or a generic record instance), the aggregate

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -965,6 +965,13 @@ fun project_receiver_matches(sc: *sema.SemaContext, obj_ty: type.TypeId, owner: 
     ret t.kind == type.TYPE_POINTER && t.data.pointer.base == owner;
 }
 
+# whether `ty` is a comptime variadic pack (#1474).
+fun type_is_pack(sc: *sema.SemaContext, ty: type.TypeId) bool {
+    val to: Option[*type.Type] = type.get(?sc.s.types, ty);
+    if (is_none[*type.Type](to)) { ret false; }
+    ret unwrap[*type.Type](to).kind == type.TYPE_PACK;
+}
+
 # whether `ty` is a record (or a generic record instance), the aggregate
 # `$fields` accepts. unions and non-aggregates are rejected.
 fun type_is_record(sc: *sema.SemaContext, ty: type.TypeId) bool {
@@ -1145,6 +1152,16 @@ fun infer_member(sc: *sema.SemaContext, eid: id.ExprId, m: *expr.ExprMember, spa
 
     val ot: type.TypeId = infer_expr(sc, m.object);
     if (ot == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+
+    # `va.len` on a comptime variadic pack (#1474) is the comptime element count.
+    if (type_is_pack(sc, ot)) {
+        if (str_region_equals(sc.source, m.name.offset, m.name.len, "len")) {
+            ret prim_or_error(sc, type.TYPE_U64);
+        }
+        sema.report(sc, span, "a variadic pack has only `.len`; iterate its elements with `$each`");
+        ret type.TYPE_ERROR;
+    }
+
     if (ot == type.TYPE_NIL) {
         # a value-less object (a call to a function with no return type) yields
         # no value; without a report the broken access would reach lowering with
@@ -1313,6 +1330,12 @@ pub fun resolve_type_ref(sc: *sema.SemaContext, tid: id.TypeId) type.TypeId {
     if (t.kind == atype.TYPE_KIND_FUN)   { ret resolve_type_fun(sc, ?t.data.fun_); }
     if (t.kind == atype.TYPE_KIND_REC)   { ret resolve_type_anon(sc, tid, t.data.rec_.fields_start, t.data.rec_.fields_len, type.TYPE_REC); }
     if (t.kind == atype.TYPE_KIND_UNI)   { ret resolve_type_anon(sc, tid, t.data.uni_.fields_start, t.data.uni_.fields_len, type.TYPE_UNI); }
+    # a `...` comptime variadic pack (#1474): the singleton pack type.
+    if (t.kind == atype.TYPE_KIND_PACK) {
+        val r: Result[type.TypeId, str] = type.intern_pack(?sc.s.types);
+        if (is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }
+        ret unwrap_ok[type.TypeId, str](r);
+    }
     ret type.TYPE_ERROR;
 }
 

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -941,15 +941,14 @@ fun infer_field_member(sc: *sema.SemaContext, m: *expr.ExprMember, span: token.S
     if (is_err[comptime.CTValue, str](obj_r)) { ret type.TYPE_NIL; }
     if (unwrap_ok[comptime.CTValue, str](obj_r).kind != comptime.CT_KIND_FIELD) { ret type.TYPE_NIL; }
 
+    if (str_region_equals(sc.source, m.name.offset, m.name.len, "name")) {
+        ret ptr_to(sc, prim_or_error(sc, type.TYPE_U8));
+    }
     if (str_region_equals(sc.source, m.name.offset, m.name.len, "offset")) {
         ret prim_or_error(sc, type.TYPE_U64);
     }
     if (str_region_equals(sc.source, m.name.offset, m.name.len, "type")) {
         sema.report(sc, span, "`f.type` is a comptime type, not a value; use it as a type-comparison operand inside a `$if` gate");
-        ret type.TYPE_ERROR;
-    }
-    if (str_region_equals(sc.source, m.name.offset, m.name.len, "name")) {
-        sema.report(sc, span, "`f.name` is not yet available");
         ret type.TYPE_ERROR;
     }
     sema.report(sc, span, "a field descriptor has only `.name`, `.type`, and `.offset`");

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -189,10 +189,25 @@ fun record_type_align(sc: *sema.SemaContext, did: id.DeclId, ty: type.TypeId) {
                 ret;
             }
             val cv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
-            if (cv.kind != comptime.CT_KIND_INT || comptime.ct_is_negative(cv)) { ret; }
+            # the body-pass validator skips the type-arg checks for rec/uni (it
+            # would double-report against this fold), so every invalid case is
+            # reported here — a non-integer, a negative, a non-power-of-two, or one
+            # overflowing the u32 alignment field — never silently dropped.
+            if (cv.kind != comptime.CT_KIND_INT) {
+                sema.report(sc, dec.name, "`align` value must be an integer");
+                ret;
+            }
+            if (comptime.ct_is_negative(cv)) {
+                sema.report(sc, dec.name, "`align` value must be a non-zero power of two");
+                ret;
+            }
             val n: u64 = cv.data.i:~u64;
             if (n == 0 || (n & (n - 1)) != 0) {
                 sema.report(sc, dec.name, "`align` value must be a non-zero power of two");
+                ret;
+            }
+            if (n > 0xFFFFFFFF) {
+                sema.report(sc, dec.name, "`align` value exceeds the maximum alignment");
                 ret;
             }
             val rr: Result[bool, str] = sess.register_type_align(sc.s, ty::u32, n::u32);

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -312,6 +312,9 @@ pub fun infer_expr(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
     or (e.kind == expr.EXPR_KIND_MEMBER) {
         t = infer_member(sc, eid, ?e.data.member, e.span);
     }
+    or (e.kind == expr.EXPR_KIND_PROJECT) {
+        t = infer_project(sc, ?e.data.project, e.span);
+    }
     or (e.kind == expr.EXPR_KIND_CAST) {
         t = infer_cast(sc, ?e.data.cast, e.span);
     }
@@ -871,6 +874,79 @@ fun set_expr_type(sc: *sema.SemaContext, eid: id.ExprId, ty: type.TypeId) {
     if (sc.expr_type == nil) { ret; }
     if (eid >= sc.a.expr_len::u32) { ret; }
     sc.expr_type[eid] = ty;
+}
+
+# field_seq_owner: resolves a `$fields(T)` sequence (#1473) to its owning record
+# TypeId, requiring T to be a record. the type-argument's expr_type slot is
+# populated for the lowerer. TYPE_ERROR when the sequence is malformed or T is
+# not a record. shared by the `$each` unroll (sema and lowering).
+pub fun field_seq_owner(sc: *sema.SemaContext, seq_eid: id.ExprId, span: token.Span) type.TypeId {
+    val targ: id.ExprId = comptime.fields_type_arg(sc.a, seq_eid);
+    if (targ == id.EXPR_NIL) {
+        sema.report(sc, span, "$fields: expected one type argument `$fields(T)`");
+        ret type.TYPE_ERROR;
+    }
+    val owner: type.TypeId = intrinsic_operand_type(sc, targ, span);
+    set_expr_type(sc, targ, owner);
+    if (owner == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    if (!type_is_record(sc, owner)) {
+        sema.report(sc, span, "$fields requires a record type");
+        ret type.TYPE_ERROR;
+    }
+    ret owner;
+}
+
+# whether a `v.[f]` receiver type names the field's owning record directly or via
+# a single pointer indirection (auto-deref, mirroring member access).
+fun project_receiver_matches(sc: *sema.SemaContext, obj_ty: type.TypeId, owner: type.TypeId) bool {
+    if (obj_ty == owner) { ret true; }
+    val to: Option[*type.Type] = type.get(?sc.s.types, obj_ty);
+    if (is_none[*type.Type](to)) { ret false; }
+    val t: *type.Type = unwrap[*type.Type](to);
+    ret t.kind == type.TYPE_POINTER && t.data.pointer.base == owner;
+}
+
+# whether `ty` is a record (or a generic record instance), the aggregate
+# `$fields` accepts. unions and non-aggregates are rejected.
+fun type_is_record(sc: *sema.SemaContext, ty: type.TypeId) bool {
+    val to: Option[*type.Type] = type.get(?sc.s.types, ty);
+    if (is_none[*type.Type](to)) { ret false; }
+    val k: type.TypeKind = unwrap[*type.Type](to).kind;
+    if (k == type.TYPE_REC) { ret true; }
+    if (k == type.TYPE_INSTANCE && is_some[*type.FieldTable](type.field_table_for(?sc.s.types, ty))) { ret true; }
+    ret false;
+}
+
+# infer_project: types a `v.[f]` field projection (#1473). the field operand `f`
+# evaluates to a comptime FIELD descriptor (bound by an enclosing `$each`) naming
+# the owning record and a field ordinal; the projection's type is that field's
+# type, and the instance `v` must be of the owning record type.
+fun infer_project(sc: *sema.SemaContext, p: *expr.ExprProject, span: token.Span) type.TypeId {
+    val obj_ty: type.TypeId = infer_expr(sc, p.object);
+    val fr: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, p.field, ?sc.s.interner);
+    if (is_err[comptime.CTValue, str](fr)) {
+        sema.report(sc, span, "`v.[f]` requires a comptime field descriptor bound by an enclosing `$each`");
+        ret type.TYPE_ERROR;
+    }
+    val fv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](fr);
+    if (fv.kind != comptime.CT_KIND_FIELD) {
+        sema.report(sc, span, "`v.[f]` requires a comptime field descriptor bound by an enclosing `$each`");
+        ret type.TYPE_ERROR;
+    }
+    if (obj_ty == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    val owner: type.TypeId = fv.data.fld.owner::type.TypeId;
+    # the instance is the owning record, or a pointer to it (auto-deref, like a
+    # member access `p.field` on `p: *T`).
+    if (!project_receiver_matches(sc, obj_ty, owner)) {
+        sema.report(sc, span, "`v.[f]`: the instance type does not match the field descriptor's owning record");
+        ret type.TYPE_ERROR;
+    }
+    val fa: Option[*type.FieldEntry] = type.field_at(?sc.s.types, owner, fv.data.fld.index);
+    if (is_none[*type.FieldEntry](fa)) {
+        sema.report(sc, span, "`v.[f]`: field ordinal out of range");
+        ret type.TYPE_ERROR;
+    }
+    ret unwrap[*type.FieldEntry](fa).ty;
 }
 
 # interns the identifier text of a `$ident` comptime ident, with the leading

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -457,6 +457,15 @@ fun report_comptime_param_fn_ref(sc: *sema.SemaContext, eid: id.ExprId) type.Typ
 fun infer_binary(sc: *sema.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, span: token.Span) type.TypeId {
     if (b.op == expr.BIN_ASSIGN) { ret infer_assign(sc, b, span); }
 
+    # a type comparison (`$type_of(...) == TypeName`, #1472) is a comptime-only
+    # bool: its operands name types, not values, so they are typed specially and
+    # never reach the value comparison below (which would mis-infer the
+    # `$type_of(...)` call).
+    if ((b.op == expr.BIN_EQ || b.op == expr.BIN_NEQ)
+        && comptime.is_type_comparison(sc.a, sc.source, b)) {
+        ret infer_type_comparison(sc, b, span);
+    }
+
     var lt: type.TypeId = infer_expr(sc, b.lhs);
     var rt: type.TypeId = infer_expr(sc, b.rhs);
     if (lt == type.TYPE_ERROR || rt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
@@ -518,6 +527,45 @@ fun infer_binary(sc: *sema.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, spa
     # arithmetic: ADD, SUB, MUL, DIV, MOD
     if ((!operands_ok) || !is_numeric(sc, lt)) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
     ret lt;
+}
+
+# types a type comparison (`$type_of(...) == TypeName`, #1472). each operand is
+# typed for its type identity — a `$type_of(e)` operand by inferring its inner
+# value `e`, a type-name operand by resolving the named type into its expr_type
+# slot — so the lowering-time resolver reads a populated type either way. the
+# comparison itself is a bool (u8), foldable only at lowering where the resolver
+# is installed.
+fun infer_type_comparison(sc: *sema.SemaContext, b: *expr.ExprBinary, span: token.Span) type.TypeId {
+    # a type comparison is comptime-only: it folds to a selected arm at lowering
+    # and has no runtime value. valid only as a `$if` gate condition; in any
+    # runtime value position it is a misuse, reported at its own span.
+    if (!sc.in_comptime_gate) {
+        sema.report(sc, span, "a `$type_of` type comparison is comptime-only; it is valid only as a `$if` gate condition");
+        ret type.TYPE_ERROR;
+    }
+    val lt: type.TypeId = infer_type_operand(sc, b.lhs, span);
+    val rt: type.TypeId = infer_type_operand(sc, b.rhs, span);
+    if (lt == type.TYPE_ERROR || rt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    ret prim_or_error(sc, type.TYPE_U8);
+}
+
+# types one type-comparison operand and returns the type it names. a `$type_of(e)`
+# operand names the type of its inner value `e` (inferred so its expr_type slot
+# populates); any other operand is a type-name spelling resolved through the same
+# path as a `$size_of` argument, with the named type written into its expr_type
+# slot.
+fun infer_type_operand(sc: *sema.SemaContext, operand: id.ExprId, span: token.Span) type.TypeId {
+    if (comptime.is_type_of_call(sc.a, sc.source, operand)) {
+        val arg: id.ExprId = comptime.type_of_arg(sc.a, operand);
+        if (arg == id.EXPR_NIL) {
+            sema.report(sc, span, "$type_of: expected one argument");
+            ret type.TYPE_ERROR;
+        }
+        ret infer_expr(sc, arg);
+    }
+    val op_ty: type.TypeId = intrinsic_operand_type(sc, operand, span);
+    set_expr_type(sc, operand, op_ty);
+    ret op_ty;
 }
 
 # ASSIGN: RHS must be assignable to LHS; result is the LHS type. a literal
@@ -715,6 +763,17 @@ fun infer_comptime_intrinsic(sc: *sema.SemaContext, c: *expr.ExprCall, span: tok
 
     val name: intern.StrId = comptime_ident_name(sc, ce.span);
     if (name == intern.STR_NIL) { ret type.TYPE_NIL; }
+
+    # `$type_of(...)` (#1472) is not a value: it yields a comptime TYPE, valid only
+    # as a type-comparison operand inside a `$if` gate (typed by
+    # infer_type_comparison, which never reaches here). any `$type_of` arriving in
+    # a value call position is a misuse, reported precisely rather than left to
+    # surface as an opaque bare-comptime-ident error at lowering.
+    if (name == interned(sc, "type_of")) {
+        sema.report(sc, span, "`$type_of` yields a comptime type, not a value; use it as a type-comparison operand inside a `$if` gate");
+        ret type.TYPE_ERROR;
+    }
+
     val is_size:   bool = name == interned(sc, "size_of");
     val is_align:  bool = name == interned(sc, "align_of");
     val is_offset: bool = name == interned(sc, "offset_of");

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -345,6 +345,13 @@ fun infer_ident(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
     if (is_none[*resolve.Symbol](sym_opt)) { ret type.TYPE_ERROR; }
     val sym: *resolve.Symbol = unwrap[*resolve.Symbol](sym_opt);
 
+    # a `$each a in va` pack loop variable (#1475): a comptime-flagged `SYM_VAL`
+    # with no declaration, bound during monomorphization to a pack-element
+    # descriptor carrying the element's concrete type. its value-position type is
+    # that element type (the body is re-inferred per element at instantiation).
+    val pe: type.TypeId = pack_elem_loop_var_type(sc, sym);
+    if (pe != type.TYPE_NIL) { ret pe; }
+
     # a symbol that names a module or a type (module alias, record, union,
     # def alias, generic parameter, primitive) resolves cleanly but can never
     # be a value; report it loudly — a silent poison here lets a clean sema
@@ -361,6 +368,24 @@ fun infer_ident(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
     }
 
     ret sema.decl_type_for(sc, sym);
+}
+
+# pack_elem_loop_var_type: the concrete element type of a `$each a in va` pack
+# loop variable (#1475), or TYPE_NIL when `sym` is not such a variable. the loop
+# variable is a comptime-flagged `SYM_VAL` with no declaration (DECL_NIL); during
+# monomorphization the unroller binds its name in the comptime context to a
+# CT_KIND_PACK_ELEM descriptor whose `.ty` carries the element's concrete sema
+# type. consulted before the general symbol-type path so the body re-infers `a`
+# to the right element type per iteration.
+fun pack_elem_loop_var_type(sc: *sema.SemaContext, sym: *resolve.Symbol) type.TypeId {
+    if (sym.kind != resolve.SYM_VAL) { ret type.TYPE_NIL; }
+    if ((sym.flags & resolve.SYM_FLAG_COMPTIME) == 0) { ret type.TYPE_NIL; }
+    if (sym.decl != id.DECL_NIL) { ret type.TYPE_NIL; }
+    val nc: Option[*comptime.NamedConst] = comptime.lookup(sc.ctx, sym.name);
+    if (is_none[*comptime.NamedConst](nc)) { ret type.TYPE_NIL; }
+    val cv: comptime.CTValue = unwrap[*comptime.NamedConst](nc).value;
+    if (cv.kind != comptime.CT_KIND_PACK_ELEM) { ret type.TYPE_NIL; }
+    ret cv.data.pelem.ty::type.TypeId;
 }
 
 # reports whether `sym` names a function declaring at least one comptime value

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -32,6 +32,7 @@ use std.types.option.unwrap;
 use std.types.size.usize;
 
 use std.types.string.str;
+use std.types.string.str_region_equals;
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -149,6 +150,7 @@ fun infer_nominal(sc: *sema.SemaContext, did: id.DeclId, name_span: token.Span, 
     val ty: type.TypeId = unwrap_ok[type.TypeId, str](tr);
 
     build_field_table(sc, ty, r.fields_start, r.fields_len);
+    record_type_align(sc, did, ty);
     ret ty;
 }
 
@@ -160,7 +162,45 @@ fun infer_nominal_uni(sc: *sema.SemaContext, did: id.DeclId, name_span: token.Sp
     val ty: type.TypeId = unwrap_ok[type.TypeId, str](tr);
 
     build_field_table(sc, ty, u.fields_start, u.fields_len);
+    record_type_align(sc, did, ty);
     ret ty;
+}
+
+# folds an `align(...)` decorator on the record/union declaration `did` and
+# records the resulting alignment for nominal TypeId `ty` on the session, so the
+# middle end can over-align the lowered IR struct. the argument is a compile-time
+# constant (a literal or `$mach.build.*`) folded by `comptime.eval`; a non-constant
+# (e.g. a layout intrinsic, which has no value before layout) or non-power-of-two
+# is reported. absent decorator or a non-`align` set leaves the natural alignment.
+fun record_type_align(sc: *sema.SemaContext, did: id.DeclId, ty: type.TypeId) {
+    val d_opt: Option[*decl.Decl] = ast.get_decl(sc.a, did);
+    if (is_none[*decl.Decl](d_opt)) { ret; }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *decl.Decorator = ?sc.a.decorators[d.decorators_start + k];
+        if (str_region_equals(sc.source, dec.name.offset, dec.name.len, "align")) {
+            if (dec.args_len != 1) { ret; }
+            val arg: id.ExprId = sc.a.expr_ids[dec.args_start];
+            val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, arg, ?sc.s.interner);
+            if (is_err[comptime.CTValue, str](ev)) {
+                sema.report(sc, dec.name, "`align` on a type must be a compile-time constant");
+                ret;
+            }
+            val cv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
+            if (cv.kind != comptime.CT_KIND_INT || comptime.ct_is_negative(cv)) { ret; }
+            val n: u64 = cv.data.i:~u64;
+            if (n == 0 || (n & (n - 1)) != 0) {
+                sema.report(sc, dec.name, "`align` value must be a non-zero power of two");
+                ret;
+            }
+            val rr: Result[bool, str] = sess.register_type_align(sc.s, ty::u32, n::u32);
+            if (is_err[bool, str](rr)) { ret; }
+            ret;
+        }
+        k = k + 1;
+    }
 }
 
 # populates a field table for nominal `ty` from a typed_names slice, mapping

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -896,6 +896,32 @@ pub fun field_seq_owner(sc: *sema.SemaContext, seq_eid: id.ExprId, span: token.S
     ret owner;
 }
 
+# types a `.name` / `.type` / `.offset` projection off a `$each` field descriptor
+# (#1473), or TYPE_NIL when the object is not a field descriptor (a normal member
+# access). detection evaluates the object: only a CT_KIND_FIELD is a descriptor,
+# so a member of any other value falls through. `.name` is a string (`*u8`),
+# `.offset` an unsigned `usize` (`u64`); `.type` is a comptime-only TYPE value,
+# valid only as a type-comparison operand, rejected here in a value position.
+fun infer_field_member(sc: *sema.SemaContext, m: *expr.ExprMember, span: token.Span) type.TypeId {
+    val obj_r: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, m.object, ?sc.s.interner);
+    if (is_err[comptime.CTValue, str](obj_r)) { ret type.TYPE_NIL; }
+    if (unwrap_ok[comptime.CTValue, str](obj_r).kind != comptime.CT_KIND_FIELD) { ret type.TYPE_NIL; }
+
+    if (str_region_equals(sc.source, m.name.offset, m.name.len, "offset")) {
+        ret prim_or_error(sc, type.TYPE_U64);
+    }
+    if (str_region_equals(sc.source, m.name.offset, m.name.len, "type")) {
+        sema.report(sc, span, "`f.type` is a comptime type, not a value; use it as a type-comparison operand inside a `$if` gate");
+        ret type.TYPE_ERROR;
+    }
+    if (str_region_equals(sc.source, m.name.offset, m.name.len, "name")) {
+        sema.report(sc, span, "`f.name` is not yet available");
+        ret type.TYPE_ERROR;
+    }
+    sema.report(sc, span, "a field descriptor has only `.name`, `.type`, and `.offset`");
+    ret type.TYPE_ERROR;
+}
+
 # whether a `v.[f]` receiver type names the field's owning record directly or via
 # a single pointer indirection (auto-deref, mirroring member access).
 fun project_receiver_matches(sc: *sema.SemaContext, obj_ty: type.TypeId, owner: type.TypeId) bool {
@@ -1079,6 +1105,10 @@ fun infer_member(sc: *sema.SemaContext, eid: id.ExprId, m: *expr.ExprMember, spa
     if (cti != type.TYPE_NIL) { ret cti; }
     val cts: type.TypeId = infer_comptime_str_path(sc, eid);
     if (cts != type.TYPE_NIL) { ret cts; }
+
+    # `f.name` / `f.type` / `f.offset` on a `$each` field descriptor (#1473).
+    val fdm: type.TypeId = infer_field_member(sc, m, span);
+    if (fdm != type.TYPE_NIL) { ret fdm; }
 
     val ot: type.TypeId = infer_expr(sc, m.object);
     if (ot == type.TYPE_ERROR) { ret type.TYPE_ERROR; }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -465,7 +465,9 @@ fun infer_binary(sc: *sema.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, spa
     # never reach the value comparison below (which would mis-infer the
     # `$type_of(...)` call).
     if ((b.op == expr.BIN_EQ || b.op == expr.BIN_NEQ)
-        && comptime.is_type_comparison(sc.a, sc.source, b)) {
+        && (comptime.is_type_comparison(sc.a, sc.source, b)
+         || sema_is_field_type_operand(sc, b.lhs)
+         || sema_is_field_type_operand(sc, b.rhs))) {
         ret infer_type_comparison(sc, b, span);
     }
 
@@ -566,9 +568,41 @@ fun infer_type_operand(sc: *sema.SemaContext, operand: id.ExprId, span: token.Sp
         }
         ret infer_expr(sc, arg);
     }
+    # an `f.type` field-descriptor type names the bound field's type (#1473).
+    if (sema_is_field_type_operand(sc, operand)) {
+        ret field_type_operand_type(sc, operand);
+    }
     val op_ty: type.TypeId = intrinsic_operand_type(sc, operand, span);
     set_expr_type(sc, operand, op_ty);
     ret op_ty;
+}
+
+# whether `eid` is an `f.type` operand whose object evaluates to a comptime field
+# descriptor — the sema-time recognition of a field-descriptor type operand,
+# valid during the `$each` unroll where the loop variable is bound.
+pub fun sema_is_field_type_operand(sc: *sema.SemaContext, eid: id.ExprId) bool {
+    if (!comptime.is_field_type_member(sc.a, sc.source, eid)) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val obj: id.ExprId = unwrap[*expr.Expr](n_opt).data.member.object;
+    val r: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, obj, ?sc.s.interner);
+    if (is_err[comptime.CTValue, str](r)) { ret false; }
+    ret unwrap_ok[comptime.CTValue, str](r).kind == comptime.CT_KIND_FIELD;
+}
+
+# the type an `f.type` operand names: the bound field's type, read from the
+# descriptor the object evaluates to.
+fun field_type_operand_type(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
+    val n_opt: Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret type.TYPE_ERROR; }
+    val obj: id.ExprId = unwrap[*expr.Expr](n_opt).data.member.object;
+    val r: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, obj, ?sc.s.interner);
+    if (is_err[comptime.CTValue, str](r)) { ret type.TYPE_ERROR; }
+    val fv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](r);
+    if (fv.kind != comptime.CT_KIND_FIELD) { ret type.TYPE_ERROR; }
+    val fa: Option[*type.FieldEntry] = type.field_at(?sc.s.types, fv.data.fld.owner::type.TypeId, fv.data.fld.index);
+    if (is_none[*type.FieldEntry](fa)) { ret type.TYPE_ERROR; }
+    ret unwrap[*type.FieldEntry](fa).ty;
 }
 
 # ASSIGN: RHS must be assignable to LHS; result is the LHS type. a literal

--- a/src/lang/fe/token.mach
+++ b/src/lang/fe/token.mach
@@ -144,6 +144,7 @@ pub fun kind_str(kind: Kind) str {
     if (kind == KIND_COLON_COLON) { ret "::"; }
     if (kind == KIND_COLON_TILDE) { ret ":~"; }
     if (kind == KIND_DOT_DOT_DOT) { ret "..."; }
+    if (kind == KIND_BACKTICK)    { ret "`"; }
     if (kind == KIND_EOF)         { ret "eof"; }
     if (kind == KIND_ERROR)       { ret "error"; }
     ret "unknown";

--- a/src/lang/fe/token.mach
+++ b/src/lang/fe/token.mach
@@ -59,6 +59,9 @@ pub val KIND_COLON_COLON: Kind = 40;
 pub val KIND_DOT_DOT_DOT: Kind = 41;
 pub val KIND_COLON_TILDE: Kind = 42;
 
+# leading per-declaration codegen decorator marker (#1476): `` `name(args)` ``
+pub val KIND_BACKTICK: Kind = 43;
+
 pub val KIND_EOF:   Kind = 254;
 pub val KIND_ERROR: Kind = 255;
 

--- a/src/lang/float.mach
+++ b/src/lang/float.mach
@@ -20,6 +20,16 @@ pub fun f64_bits(f: f64) u64 {
     ret u.i;
 }
 
+# reinterprets a raw 64-bit IEEE-754 pattern as an f64. inverse of f64_bits.
+# ---
+# bits: the 64-bit bit pattern
+# ret:  the value
+pub fun bits_f64(bits: u64) f64 {
+    var u: uni { f: f64; i: u64; };
+    u.i = bits;
+    ret u.f;
+}
+
 # converts an IEEE-754 double bit pattern to the IEEE-754 single pattern with
 # round-to-nearest-even. handles zero, subnormal, normal, overflow-to-infinity,
 # and NaN/infinity inputs. matches a hardware `(float)(double)` narrowing.

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -196,6 +196,8 @@ pub rec Function {
 # align: explicit byte alignment from an `align(...)` decorator (a power of two),
 # or 0 to use the back end's default for the global's section. always a power of
 # two when non-zero (lowering validates the folded value).
+# section: the object section name from a `section("...")` decorator, or STR_NIL
+# to use the back end's default (.data / .rodata / .bss by mutability and init).
 pub rec Global {
     name:      intern.StrId;
     ty:        ir_type.IrTypeId;
@@ -205,6 +207,7 @@ pub rec Global {
     is_extern: bool;
     is_local:  bool;
     align:     u32;
+    section:   intern.StrId;
 }
 
 # an IR module: one per source module.
@@ -996,6 +999,7 @@ test "ir: module teardown frees operands by capacity and agg blobs under a freei
     gl.is_extern = false;
     gl.is_local  = true;
     gl.align     = 0;
+    gl.section   = intern.STR_NIL;
     m.globals[0] = gl;
     m.global_len = 1;
 

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -193,6 +193,9 @@ pub rec Function {
 #            modules' anonymous globals never collide. a named user global is
 #            not local: its name is module-path-mangled and globally unique, so
 #            it is given GLOBAL linkage and resolves cross-object.
+# align: explicit byte alignment from an `align(...)` decorator (a power of two),
+# or 0 to use the back end's default for the global's section. always a power of
+# two when non-zero (lowering validates the folded value).
 pub rec Global {
     name:      intern.StrId;
     ty:        ir_type.IrTypeId;
@@ -201,6 +204,7 @@ pub rec Global {
     is_pub:    bool;
     is_extern: bool;
     is_local:  bool;
+    align:     u32;
 }
 
 # an IR module: one per source module.
@@ -991,6 +995,7 @@ test "ir: module teardown frees operands by capacity and agg blobs under a freei
     gl.is_pub    = false;
     gl.is_extern = false;
     gl.is_local  = true;
+    gl.align     = 0;
     m.globals[0] = gl;
     m.global_len = 1;
 

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -173,6 +173,10 @@ pub rec Function {
     label:       intern.StrId;
     line:        u32;
 
+    # object section name from a `section("...")` decorator, or STR_NIL for the
+    # default `.text`; the back end places the function's encoded bytes there.
+    section:     intern.StrId;
+
     asm_blocks:  map.Map[id.InstructionId, IrAsm];
 }
 
@@ -519,6 +523,7 @@ pub fun add_function(m: *Module, name: intern.StrId, sig: ir_type.IrTypeId, flag
     f.flags       = flags;
     f.label       = intern.STR_NIL;
     f.line        = 0;
+    f.section     = intern.STR_NIL;
     f.asm_blocks  = map.init[id.InstructionId, IrAsm](m.alloc, map.hash_u32, map.eq_u32);
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -96,9 +96,13 @@ pub rec IrTypeArray {
 # ---
 # fields:      pointer to a contiguous array of field IrTypeIds (owned)
 # field_count: number of fields
+# align:       explicit alignment from an `align(...)` decorator (a power of two),
+#              or 0 for the type's natural alignment. part of the dedup key, so an
+#              over-aligned record is a distinct type from its un-aligned twin.
 pub rec IrTypeStruct {
     fields:      *IrTypeId;
     field_count: u32;
+    align:       u32;
 }
 
 # function-type payload.
@@ -257,12 +261,15 @@ pub fun intern_array(t: *IrTypeTable, element: IrTypeId, count: u32) Result[IrTy
 # t:           the table
 # fields:      pointer to a contiguous array of field IrTypeIds
 # field_count: number of fields
+# align:       explicit alignment (a power of two) from an `align(...)` decorator,
+#              or 0 for natural alignment
 # ret:         the IrTypeId for the struct, or an allocation error
-pub fun intern_struct(t: *IrTypeTable, fields: *IrTypeId, field_count: u32) Result[IrTypeId, str] {
+pub fun intern_struct(t: *IrTypeTable, fields: *IrTypeId, field_count: u32, align: u32) Result[IrTypeId, str] {
     var probe: IrType;
     probe.kind = IRT_STRUCT;
     probe.data.struct_.fields      = fields;
     probe.data.struct_.field_count = field_count;
+    probe.data.struct_.align       = align;
     ret intern_aggregate(t, probe, fields, field_count);
 }
 
@@ -273,12 +280,15 @@ pub fun intern_struct(t: *IrTypeTable, fields: *IrTypeId, field_count: u32) Resu
 # t:           the table
 # fields:      pointer to a contiguous array of member IrTypeIds
 # field_count: number of members
+# align:       explicit alignment (a power of two) from an `align(...)` decorator,
+#              or 0 for natural alignment
 # ret:         the IrTypeId for the union type, or an allocation error
-pub fun intern_union(t: *IrTypeTable, fields: *IrTypeId, field_count: u32) Result[IrTypeId, str] {
+pub fun intern_union(t: *IrTypeTable, fields: *IrTypeId, field_count: u32, align: u32) Result[IrTypeId, str] {
     var probe: IrType;
     probe.kind = IRT_UNION;
     probe.data.struct_.fields      = fields;
     probe.data.struct_.field_count = field_count;
+    probe.data.struct_.align       = align;
     ret intern_aggregate(t, probe, fields, field_count);
 }
 
@@ -407,6 +417,9 @@ pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
             if (fa > align) { align = fa; }
             i = i + 1;
         }
+        # an `align(...)` decorator can raise the alignment (never lower it), which
+        # also rounds the total size up to the larger alignment.
+        if (ir.data.struct_.align > align) { align = ir.data.struct_.align; }
         ret round_up(off, align);
     }
     if (ir.kind == IRT_UNION) {
@@ -421,6 +434,7 @@ pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
             if (fa > align) { align = fa; }
             i = i + 1;
         }
+        if (ir.data.struct_.align > align) { align = ir.data.struct_.align; }
         ret round_up(size, align);
     }
     ret 0;
@@ -453,6 +467,8 @@ pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
             if (fa > align) { align = fa; }
             i = i + 1;
         }
+        # an `align(...)` decorator raises the alignment above the natural maximum.
+        if (ir.data.struct_.align > align) { align = ir.data.struct_.align; }
         ret align;
     }
     ret 1;
@@ -603,6 +619,9 @@ fun hash_ir_type(p: ptr) u64 {
             h = fnv1a.step_u32(h, ir.data.struct_.fields[i]);
             i = i + 1;
         }
+        # only mixed in when present, so an un-aligned struct keeps the exact hash
+        # it had before the align field existed (the dedup universe is unperturbed).
+        if (ir.data.struct_.align != 0) { h = fnv1a.step_u32(h, ir.data.struct_.align); }
         ret h;
     }
     if (ir.kind == IRT_FN) {
@@ -636,6 +655,7 @@ fun eq_ir_type(pa: ptr, pb: ptr) bool {
     }
     if (a.kind == IRT_STRUCT || a.kind == IRT_UNION) {
         if (a.data.struct_.field_count != b.data.struct_.field_count) { ret false; }
+        if (a.data.struct_.align != b.data.struct_.align) { ret false; }
         ret mem.equal[IrTypeId](a.data.struct_.fields, b.data.struct_.fields, a.data.struct_.field_count::usize);
     }
     if (a.kind == IRT_FN) {
@@ -665,7 +685,7 @@ test "ir.type: struct{i8,i64} has size 16, align 8, field offsets 0 and 8" {
     var fields: [2]IrTypeId;
     fields[0] = i8ty;
     fields[1] = i64ty;
-    val rs: Result[IrTypeId, str] = intern_struct(?types, ?fields[0], 2);
+    val rs: Result[IrTypeId, str] = intern_struct(?types, ?fields[0], 2, 0);
     if (is_err[IrTypeId, str](rs)) { ret 1; }
     val stty: IrTypeId = unwrap_ok[IrTypeId, str](rs);
 
@@ -681,5 +701,42 @@ test "ir.type: struct{i8,i64} has size 16, align 8, field offsets 0 and 8" {
     if (byte_align(?types, stty, ?tgt) != 8) { ret 1; }
     if (byte_offset(?types, stty, 0, ?tgt) != 0) { ret 1; }
     if (byte_offset(?types, stty, 1, ?tgt) != 8) { ret 1; }
+    ret 0;
+}
+
+test "ir.type: an align override raises a struct's align and size and is a distinct type (#1476)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    val itr: Result[IrTypeTable, str] = init(?alloc);
+    if (is_err[IrTypeTable, str](itr)) { ret 1; }
+    var types: IrTypeTable = unwrap_ok[IrTypeTable, str](itr);
+
+    val r8: Result[IrTypeId, str] = intern_int(?types, 8);
+    if (is_err[IrTypeId, str](r8)) { ret 1; }
+    val i8ty: IrTypeId = unwrap_ok[IrTypeId, str](r8);
+
+    var fields: [1]IrTypeId;
+    fields[0] = i8ty;
+
+    val rn: Result[IrTypeId, str] = intern_struct(?types, ?fields[0], 1, 0);
+    if (is_err[IrTypeId, str](rn)) { ret 1; }
+    val natty: IrTypeId = unwrap_ok[IrTypeId, str](rn);
+
+    val ra: Result[IrTypeId, str] = intern_struct(?types, ?fields[0], 1, 32);
+    if (is_err[IrTypeId, str](ra)) { ret 1; }
+    val algty: IrTypeId = unwrap_ok[IrTypeId, str](ra);
+
+    var arch: isa.IsaVTable;
+    arch.pointer_width = 8;
+    var tgt: target.Target;
+    tgt.arch = ?arch;
+
+    # the natural struct{i8} is size 1, align 1; an align(32) override raises both
+    # the alignment and the rounded-up size, and dedups to a distinct type.
+    if (byte_align(?types, natty, ?tgt) != 1)  { ret 1; }
+    if (byte_size(?types, natty, ?tgt)  != 1)  { ret 1; }
+    if (byte_align(?types, algty, ?tgt) != 32) { ret 1; }
+    if (byte_size(?types, algty, ?tgt)  != 32) { ret 1; }
+    if (natty == algty) { ret 1; }
     ret 0;
 }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -1504,7 +1504,7 @@ test "ir.verify: aggregate representation (repr) rejects a non-address-producing
     if (!t_env(?env)) { ret 1; }
 
     # intern a single-field struct type to use as an aggregate operand type
-    val sr: Result[ir_type.IrTypeId, str] = ir_type.intern_struct(?env.m.types, ?env.i64ty, 1);
+    val sr: Result[ir_type.IrTypeId, str] = ir_type.intern_struct(?env.m.types, ?env.i64ty, 1, 0);
     if (is_err[ir_type.IrTypeId, str](sr)) { ret 1; }
     val stty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](sr);
 

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -262,6 +262,7 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
     # on lc.
     comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
     comptime.set_type_resolver(octx, lctx.resolve_type_comparison_operand::*u8, lc::ptr);
+    comptime.set_field_resolver(octx, lctx.resolve_field_member::*u8, lc::ptr);
 
     # open a frame on the ORIGIN context and bind the `$param -> CTValue`
     # bindings into it; the frame is closed afterward (on the error path too) so
@@ -382,6 +383,7 @@ fun emit_one_instance(lc: *lctx.LowerContext, s: *sess.Session,
     # on lc.
     comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
     comptime.set_type_resolver(octx, lctx.resolve_type_comparison_operand::*u8, lc::ptr);
+    comptime.set_field_resolver(octx, lctx.resolve_field_member::*u8, lc::ptr);
 
     val lr: Result[bool, str] = decl.lower_instance(lc, decl_id, d, name);
     lc.ctx        = home_ctx;

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -257,9 +257,11 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
     lc.subst       = nil;
     lc.subst_len   = 0;
 
-    # the origin ctx folds this body's `alias.CONST` paths against the origin
-    # module's name resolution, now active on lc.
+    # the origin ctx folds this body's `alias.CONST` paths and `$type_of(...)`
+    # type gates against the origin module's name resolution and types, now active
+    # on lc.
     comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
+    comptime.set_type_resolver(octx, lctx.resolve_type_comparison_operand::*u8, lc::ptr);
 
     # open a frame on the ORIGIN context and bind the `$param -> CTValue`
     # bindings into it; the frame is closed afterward (on the error path too) so
@@ -375,9 +377,11 @@ fun emit_one_instance(lc: *lctx.LowerContext, s: *sess.Session,
     lc.subst       = args;
     lc.subst_len   = arg_len;
 
-    # the origin ctx folds this body's `alias.CONST` paths against the origin
-    # module's name resolution, now active on lc.
+    # the origin ctx folds this body's `alias.CONST` paths and `$type_of(...)`
+    # type gates against the origin module's name resolution and types, now active
+    # on lc.
     comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
+    comptime.set_type_resolver(octx, lctx.resolve_type_comparison_operand::*u8, lc::ptr);
 
     val lr: Result[bool, str] = decl.lower_instance(lc, decl_id, d, name);
     lc.ctx        = home_ctx;

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -147,6 +147,17 @@ pub fun lower_module(
         ret err[ir.Module, str](unwrap_err[bool, str](vdrain_r));
     }
 
+    # emit one concrete body per comptime variadic-pack instance collected at this
+    # module's call sites, draining to fixpoint. a pack body may call generics, other
+    # comptime-param functions, or further pack-tailed functions, so this re-drains
+    # all three worklists until none remains.
+    val pdrain_r: Result[bool, str] = drain_pack_instances(?lc, s, a, sema_result, rr);
+    if (is_err[bool, str](pdrain_r)) {
+        lctx.dnit_context(?lc);
+        ir.dnit_module(?m);
+        ret err[ir.Module, str](unwrap_err[bool, str](pdrain_r));
+    }
+
     lctx.dnit_context(?lc);
     ret ok[ir.Module, str](m);
 }
@@ -172,11 +183,11 @@ fun drain_value_instances(lc: *lctx.LowerContext, s: *sess.Session,
     # alternate value-instance and type-instance draining to fixpoint: a value
     # body may queue type instances (a generic call), and a type body may queue
     # value instances (a comptime-param call), so loop until both worklists are
-    # fully consumed. each worklist resumes from its own cursor, so every body —
-    # value or generic — is emitted exactly once.
-    var processed: u32 = 0;
-    for (processed < lc.vinst_len || lc.inst_drained < lc.inst_len) {
-        for (processed < lc.vinst_len) {
+    # fully consumed. each worklist resumes from its own PERSISTENT cursor (so this
+    # drain is re-entrant — the pack drain re-invokes it — and emits every body once.
+    for (lc.vinst_drained < lc.vinst_len || lc.inst_drained < lc.inst_len) {
+        for (lc.vinst_drained < lc.vinst_len) {
+            val processed: u32 = lc.vinst_drained;
             # snapshot the entry by value: the worklist array may grow (reallocate)
             # while this instance's body enqueues transitive instances.
             val decl_id: aid.DeclId    = lc.vinsts[processed].decl;
@@ -197,7 +208,7 @@ fun drain_value_instances(lc: *lctx.LowerContext, s: *sess.Session,
                 ret r;
             }
 
-            processed = processed + 1;
+            lc.vinst_drained = lc.vinst_drained + 1;
         }
 
         # drain any type instances queued by the value bodies just emitted; the
@@ -288,6 +299,114 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
     lc.ctx        = home_ctx;
     lc.own_module = home_own;
     if (is_err[bool, str](cr)) { ret err[bool, str](unwrap_err[bool, str](cr)); }
+    ret lr;
+}
+
+# drains the comptime variadic-pack instance worklist to fixpoint, emitting one
+# weak body per collected `(decl, origin, type-list)` instance. each body is
+# lowered against its DECLARING module's AST / typing / name-resolution, with the
+# pack expanded to the instance's concrete element parameters; the `$each a in va`
+# unroll inside it re-types and lowers per element (lower_pack_instance). a pack
+# body may queue type instances (a generic call), value instances (a comptime-param
+# call), or further pack instances, so the type and value worklists are re-drained
+# in turn and the loop repeats until all three are empty. each worklist resumes
+# from its persistent cursor, so every body is emitted exactly once. the context's
+# phase inputs are restored after the drain.
+# ---
+# lc:        the active lowering context (its pack worklist is drained)
+# s:         shared session (origin-module registries)
+# home_a:    the current module's AST (restored after the drain)
+# home_sema: the current module's typing (restored after the drain)
+# home_rr:   the current module's name resolution (restored after the drain)
+# ret:       true once all three worklists are empty, or the first lowering error
+fun drain_pack_instances(lc: *lctx.LowerContext, s: *sess.Session,
+                         home_a: *ast.Ast, home_sema: *sema.SemaResult,
+                         home_rr: *resolve.ResolveResult) Result[bool, str] {
+    for (lc.pinst_drained < lc.pinst_len || lc.inst_drained < lc.inst_len || lc.vinst_drained < lc.vinst_len) {
+        for (lc.pinst_drained < lc.pinst_len) {
+            val processed: u32 = lc.pinst_drained;
+            # snapshot the entry by value: the worklist array may grow (reallocate)
+            # while this instance's body enqueues transitive instances.
+            val decl_id:  aid.DeclId    = lc.pinsts[processed].decl;
+            val origin:   sess.ModuleId = lc.pinsts[processed].origin;
+            val type_len: u32           = lc.pinsts[processed].type_len;
+            val name:     intern.StrId  = lc.pinsts[processed].name;
+            val types:    *ty.TypeId    = lc.pinsts[processed].types;
+
+            val r: Result[bool, str] = emit_one_pack_instance(lc, s, decl_id, origin, types, type_len, name);
+            if (is_err[bool, str](r)) {
+                lc.a           = home_a;
+                lc.sema_result = home_sema;
+                lc.rr          = home_rr;
+                lc.fqn         = sess.module_fqn(s, lc.own_module);
+                lc.subst       = nil;
+                lc.subst_len   = 0;
+                ret r;
+            }
+
+            lc.pinst_drained = lc.pinst_drained + 1;
+        }
+
+        # drain any type / value instances the pack bodies just emitted queued; both
+        # resume from their persistent cursors, so each body is emitted once.
+        val td: Result[bool, str] = drain_instances(lc, s, home_a, home_sema, home_rr);
+        if (is_err[bool, str](td)) { ret td; }
+        val vd: Result[bool, str] = drain_value_instances(lc, s, home_a, home_sema, home_rr);
+        if (is_err[bool, str](vd)) { ret vd; }
+    }
+
+    lc.a           = home_a;
+    lc.sema_result = home_sema;
+    lc.rr          = home_rr;
+    lc.fqn         = sess.module_fqn(s, lc.own_module);
+    lc.subst       = nil;
+    lc.subst_len   = 0;
+    ret ok[bool, str](true);
+}
+
+# emits one pack-instance body: binds the context to the instance's origin module
+# (AST, typing, name-resolution, FQN, comptime context, own_module), installs the
+# comptime resolvers, and lowers the pack-tailed template under the instance name
+# with its concrete element type-list. mirrors emit_one_value_instance but without
+# a comptime parameter frame — the per-element loop-variable binding is opened and
+# closed inside the `$each` unroll (lower_pack_each). a missing origin registry is
+# a coherence violation (the caller already emitted an extern reference to this
+# instance), so it aborts rather than silently dropping the body.
+fun emit_one_pack_instance(lc: *lctx.LowerContext, s: *sess.Session,
+                           decl_id: aid.DeclId, origin: sess.ModuleId,
+                           types: *ty.TypeId, type_len: u32, name: intern.StrId) Result[bool, str] {
+    val oa: *ast.Ast = sess.module_ast(s, origin);
+    if (oa == nil) { ret err[bool, str]("lower: pack-instance origin AST not registered"); }
+    val osema: *sema.SemaResult = (sess.module_sema_ptr(s, origin))::*sema.SemaResult;
+    if (osema == nil) { ret err[bool, str]("lower: pack-instance origin typing not registered"); }
+    val orr: *resolve.ResolveResult = (sess.module_resolve_ptr(s, origin))::*resolve.ResolveResult;
+    if (orr == nil) { ret err[bool, str]("lower: pack-instance origin name-resolution not registered"); }
+    val octx: *comptime.ComptimeCtx = (sess.module_comptime_ptr(s, origin))::*comptime.ComptimeCtx;
+    if (octx == nil) { ret err[bool, str]("lower: pack-instance origin comptime context not registered"); }
+
+    val d_opt: Option[*adecl.Decl] = ast.get_decl(oa, decl_id);
+    if (is_none[*adecl.Decl](d_opt)) { ret err[bool, str]("lower: pack-instance origin declaration not found"); }
+    val d: *adecl.Decl = unwrap[*adecl.Decl](d_opt);
+    if (d.kind != adecl.DECL_KIND_FUN) { ret err[bool, str]("lower: pack-instance origin declaration is not a function"); }
+
+    val home_ctx: *comptime.ComptimeCtx = lc.ctx;
+    val home_own: sess.ModuleId         = lc.own_module;
+    lc.a           = oa;
+    lc.sema_result = osema;
+    lc.rr          = orr;
+    lc.fqn         = sess.module_fqn(s, origin);
+    lc.ctx         = octx;
+    lc.own_module  = origin;
+    lc.subst       = nil;
+    lc.subst_len   = 0;
+
+    comptime.set_member_resolver(octx, lctx.resolve_module_member_const::*u8, lc::ptr);
+    comptime.set_type_resolver(octx, lctx.resolve_type_comparison_operand::*u8, lc::ptr);
+    comptime.set_field_resolver(octx, lctx.resolve_field_member::*u8, lc::ptr);
+
+    val lr: Result[bool, str] = decl.lower_pack_instance(lc, decl_id, d, name, types, type_len);
+    lc.ctx        = home_ctx;
+    lc.own_module = home_own;
     ret lr;
 }
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -120,6 +120,26 @@ pub rec ValueInstance {
     name:    intern.StrId;
 }
 
+# one collected comptime variadic-pack instance awaiting body emission: a
+# `(decl, origin, pack element type-list)` triple plus the mangled symbol name
+# the instance is emitted under. mirrors `Instance` but keys on the concrete
+# TYPES the pack absorbs at a call site (#1475), so a pack-tailed function is
+# monomorphized once per distinct trailing arg-type sequence. the worklist
+# dedups by `name`.
+# ---
+# decl:     DeclId of the pack-tailed function in `origin`'s AST
+# origin:   ModuleId that declares the function
+# types:    owned copy of the pack element type-list (by pack ordinal)
+# type_len: number of pack element types
+# name:     instance linkage name (mangled, with the type-list suffix)
+pub rec PackInstance {
+    decl:     aid.DeclId;
+    origin:   sess.ModuleId;
+    types:    *ty.TypeId;
+    type_len: u32;
+    name:     intern.StrId;
+}
+
 # per-module lowering state, threaded through every decl / stmt / expr.
 # the leading fields are the phase inputs and the IR being built; the
 # trailing fields are the working state for the function currently being
@@ -167,6 +187,12 @@ pub rec ValueInstance {
 #              active so the comptime evaluator selects each `$if` arm
 # vinst_len:   number of value-instance worklist entries
 # vinst_cap:   allocated capacity of the value-instance worklist
+# pinsts:      per-module worklist of comptime variadic-pack instances collected at
+#              call sites, drained to fixpoint alongside the type / value worklists;
+#              each emits one concrete weak body with the pack expanded to N params
+#              typed by the instance's element type-list
+# pinst_len:   number of pack-instance worklist entries
+# pinst_cap:   allocated capacity of the pack-instance worklist
 pub rec LowerContext {
     s:           *sess.Session;
     tgt:         *target.Target;
@@ -203,6 +229,10 @@ pub rec LowerContext {
     vinsts:      *ValueInstance;
     vinst_len:   u32;
     vinst_cap:   u32;
+
+    pinsts:      *PackInstance;
+    pinst_len:   u32;
+    pinst_cap:   u32;
 }
 
 
@@ -291,6 +321,9 @@ pub fun init_context(
     lc.vinsts    = nil;
     lc.vinst_len = 0;
     lc.vinst_cap = 0;
+    lc.pinsts    = nil;
+    lc.pinst_len = 0;
+    lc.pinst_cap = 0;
 
     ret ok[bool, str](true);
 }
@@ -338,6 +371,16 @@ pub fun dnit_context(lc: *LowerContext) {
         }
         deallocate[ValueInstance](lc.s.alloc, lc.vinsts, lc.vinst_cap::usize);
     }
+    if (lc.pinsts != nil && lc.pinst_cap > 0) {
+        var pi: u32 = 0;
+        for (pi < lc.pinst_len) {
+            if (lc.pinsts[pi].types != nil && lc.pinsts[pi].type_len > 0) {
+                deallocate[ty.TypeId](lc.s.alloc, lc.pinsts[pi].types, lc.pinsts[pi].type_len::usize);
+            }
+            pi = pi + 1;
+        }
+        deallocate[PackInstance](lc.s.alloc, lc.pinsts, lc.pinst_cap::usize);
+    }
     lc.loops    = nil;
     lc.loop_len = 0;
     lc.loop_cap = 0;
@@ -351,6 +394,9 @@ pub fun dnit_context(lc: *LowerContext) {
     lc.vinsts    = nil;
     lc.vinst_len = 0;
     lc.vinst_cap = 0;
+    lc.pinsts    = nil;
+    lc.pinst_len = 0;
+    lc.pinst_cap = 0;
 }
 
 # resolve_module_member_const: the `alias.CONST` member resolver lowering
@@ -692,6 +738,62 @@ pub fun enqueue_value_instance(lc: *LowerContext, decl: aid.DeclId, origin: sess
     inst.name    = name;
     lc.vinsts[lc.vinst_len] = inst;
     lc.vinst_len = lc.vinst_len + 1;
+    ret ok[bool, str](true);
+}
+
+# enqueue_pack_instance: record a comptime variadic-pack instance `(decl, origin,
+# type-list)` on the per-module worklist under its mangled `name`, deduped by name
+# (identical to `enqueue_instance` — a linear scan, no map/hash, so determinism is
+# preserved). takes an OWNED copy of `types` so the caller's buffer can be reused /
+# freed; the copy is released when the context is torn down.
+# ---
+# lc:       the context
+# decl:     DeclId of the pack-tailed function in `origin`'s AST
+# origin:   ModuleId declaring the function
+# types:    pack element type-list (copied), by pack ordinal
+# type_len: number of pack element types
+# name:     instance linkage name
+# ret:      true on success, or an allocation error
+pub fun enqueue_pack_instance(lc: *LowerContext, decl: aid.DeclId, origin: sess.ModuleId,
+                              types: *ty.TypeId, type_len: u32, name: intern.StrId) Result[bool, str] {
+    var i: u32 = 0;
+    for (i < lc.pinst_len) {
+        if (lc.pinsts[i].name == name) { ret ok[bool, str](true); }
+        i = i + 1;
+    }
+
+    if (lc.pinst_len == lc.pinst_cap) {
+        var new_cap: u32 = lc.pinst_cap * 2;
+        if (new_cap == 0) { new_cap = INITIAL_STACK_CAP; }
+        if (lc.pinsts == nil) {
+            val r: Result[*PackInstance, str] = allocate[PackInstance](lc.s.alloc, new_cap::usize);
+            if (is_err[*PackInstance, str](r)) { ret err[bool, str](unwrap_err[*PackInstance, str](r)); }
+            lc.pinsts = unwrap_ok[*PackInstance, str](r);
+        } or {
+            val r: Result[*PackInstance, str] = reallocate[PackInstance](lc.s.alloc, lc.pinsts, lc.pinst_cap::usize, new_cap::usize);
+            if (is_err[*PackInstance, str](r)) { ret err[bool, str](unwrap_err[*PackInstance, str](r)); }
+            lc.pinsts = unwrap_ok[*PackInstance, str](r);
+        }
+        lc.pinst_cap = new_cap;
+    }
+
+    var copy: *ty.TypeId = nil;
+    if (type_len > 0) {
+        val r: Result[*ty.TypeId, str] = allocate[ty.TypeId](lc.s.alloc, type_len::usize);
+        if (is_err[*ty.TypeId, str](r)) { ret err[bool, str](unwrap_err[*ty.TypeId, str](r)); }
+        copy = unwrap_ok[*ty.TypeId, str](r);
+        var j: u32 = 0;
+        for (j < type_len) { copy[j] = types[j]; j = j + 1; }
+    }
+
+    var inst: PackInstance;
+    inst.decl     = decl;
+    inst.origin   = origin;
+    inst.types    = copy;
+    inst.type_len = type_len;
+    inst.name     = name;
+    lc.pinsts[lc.pinst_len] = inst;
+    lc.pinst_len = lc.pinst_len + 1;
     ret ok[bool, str](true);
 }
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -757,9 +757,15 @@ pub fun lower_type(lc: *LowerContext, tid: ty.TypeId) Result[ir_type.IrTypeId, s
 # referenced from another module. a type with no field table lowers to an
 # empty struct, keeping lowering total.
 fun lower_nominal(lc: *LowerContext, tid: ty.TypeId, is_union: bool) Result[ir_type.IrTypeId, str] {
+    # an `align(...)` decorator on the record/union, folded by sema and keyed by
+    # this nominal TypeId; 0 leaves the natural alignment.
+    var nom_align: u32 = 0;
+    val ta: Option[u32] = sess.type_align(lc.s, tid::u32);
+    if (is_some[u32](ta)) { nom_align = unwrap[u32](ta); }
+
     val fields_len: u32 = ty.field_count(?lc.s.types, tid);
     if (fields_len == 0) {
-        ret ir_type.intern_struct(?lc.m.types, nil, 0);
+        ret ir_type.intern_struct(?lc.m.types, nil, 0, nom_align);
     }
 
     val buf_r: Result[*ir_type.IrTypeId, str] = allocate[ir_type.IrTypeId](lc.s.alloc, fields_len::usize);
@@ -794,10 +800,10 @@ fun lower_nominal(lc: *LowerContext, tid: ty.TypeId, is_union: bool) Result[ir_t
 
     var sr: Result[ir_type.IrTypeId, str];
     if (is_union) {
-        sr = ir_type.intern_union(?lc.m.types, buf, fields_len);
+        sr = ir_type.intern_union(?lc.m.types, buf, fields_len, nom_align);
     }
     or {
-        sr = ir_type.intern_struct(?lc.m.types, buf, fields_len);
+        sr = ir_type.intern_struct(?lc.m.types, buf, fields_len, nom_align);
     }
     deallocate[ir_type.IrTypeId](lc.s.alloc, buf, fields_len::usize);
     ret sr;
@@ -828,7 +834,7 @@ fun lower_va_list(lc: *LowerContext) Result[ir_type.IrTypeId, str] {
     buf[1] = i32t;
     buf[2] = ptrt;
     buf[3] = ptrt;
-    ret ir_type.intern_struct(?lc.m.types, ?buf[0], 4);
+    ret ir_type.intern_struct(?lc.m.types, ?buf[0], 4, 0);
 }
 
 # lowers a TYPE_FUN semantic type into an IRT_FN, propagating the semantic

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1030,6 +1030,7 @@ pub fun ensure_extern_global(lc: *LowerContext, name: intern.StrId, ty: ir_type.
     g.is_pub    = false;
     g.is_extern = true;
     g.is_local  = false;
+    g.align     = 0;
     m.globals[idx] = g;
     m.global_len   = m.global_len + 1;
     val reg: Result[bool, str] = ir.register_global(m, name, idx);
@@ -1069,6 +1070,7 @@ pub fun add_rodata_bytes(lc: *LowerContext, init: value.Value, pty: ir_type.IrTy
     g.is_pub    = false;
     g.is_extern = false;
     g.is_local  = true;
+    g.align     = 0;
     m.globals[idx] = g;
     m.global_len   = m.global_len + 1;
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -204,12 +204,6 @@ pub rec PackInstance {
 # pack_len:    number of expanded pack parameters (0 outside a pack instance)
 # pack_ret_ty: the pack instance's semantic return type, supplied to the per-
 #              element body re-inference so a body `ret` checks against it
-# pack_each_name:  interned name of the loop variable of the pack `$each` currently
-#              unrolling, or STR_NIL outside one; an IDENT resolving to the
-#              (synthetic, decl-nil) loop-var symbol of this name is lowered from
-#              `pack_slots[pack_each_index]` rather than a normal local lookup
-# pack_each_index: the current element ordinal of the unrolling pack `$each`,
-#              selecting the loop variable's slot in pack_slots
 pub rec LowerContext {
     s:           *sess.Session;
     tgt:         *target.Target;
@@ -258,9 +252,6 @@ pub rec LowerContext {
     pack_types:  *ty.TypeId;
     pack_len:    u32;
     pack_ret_ty: ty.TypeId;
-
-    pack_each_name:  intern.StrId;
-    pack_each_index: u32;
 }
 
 
@@ -358,8 +349,6 @@ pub fun init_context(
     lc.pack_types  = nil;
     lc.pack_len    = 0;
     lc.pack_ret_ty = ty.TYPE_NIL;
-    lc.pack_each_name  = intern.STR_NIL;
-    lc.pack_each_index = 0;
 
     ret ok[bool, str](true);
 }
@@ -439,8 +428,6 @@ pub fun dnit_context(lc: *LowerContext) {
     lc.pack_types  = nil;
     lc.pack_len    = 0;
     lc.pack_ret_ty = ty.TYPE_NIL;
-    lc.pack_each_name  = intern.STR_NIL;
-    lc.pack_each_index = 0;
 }
 
 # resolve_module_member_const: the `alias.CONST` member resolver lowering
@@ -561,8 +548,6 @@ pub fun begin_function(lc: *LowerContext, fn_index: u32, ret_ty: ir_type.IrTypeI
     lc.pack_types  = nil;
     lc.pack_len    = 0;
     lc.pack_ret_ty = ty.TYPE_NIL;
-    lc.pack_each_name  = intern.STR_NIL;
-    lc.pack_each_index = 0;
 }
 
 # binds a source SymbolId to the IR Value that names its storage. for
@@ -619,26 +604,6 @@ pub fun lookup_local(lc: *LowerContext, sym: resolve.SymbolId) Option[value.Valu
         ret some[value.Value](@unwrap_ok[*value.Value, str](r));
     }
     ret none[value.Value]();
-}
-
-# pack_each_storage: the storage slot bound to the loop variable of the pack
-# `$each` currently unrolling, when `sym` names that loop variable. the loop var
-# is the synthetic (decl-nil) symbol whose interned name matches the active
-# pack-each name; its per-element storage is the expanded pack-parameter alloca
-# slot at the current unroll index. none outside a pack `$each`, or for any other
-# symbol — so an ordinary IDENT falls through to the normal local / global path.
-# ---
-# lc:  the context
-# sym: the IDENT's resolved SymbolId
-# ret: some(slot Value) when sym is the active pack loop variable, else none
-pub fun pack_each_storage(lc: *LowerContext, sym: resolve.SymbolId) Option[value.Value] {
-    if (lc.pack_each_name == intern.STR_NIL) { ret none[value.Value](); }
-    val so: Option[*resolve.Symbol] = symbol_of(lc, sym);
-    if (is_none[*resolve.Symbol](so)) { ret none[value.Value](); }
-    val s: *resolve.Symbol = unwrap[*resolve.Symbol](so);
-    if (s.decl != aid.DECL_NIL || s.name != lc.pack_each_name) { ret none[value.Value](); }
-    if (lc.pack_slots == nil || lc.pack_each_index >= lc.pack_len) { ret none[value.Value](); }
-    ret some[value.Value](lc.pack_slots[lc.pack_each_index]);
 }
 
 # pushes a loop frame, recording the header and exit blocks the innermost

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -249,6 +249,9 @@ pub fun init_context(
     # the LowerContext itself, read live so the value-instance drains' module
     # swaps stay correct.
     comptime.set_member_resolver(ctx, resolve_module_member_const::*u8, lc::ptr);
+    # install the type-comparison operand resolver so comptime.eval can fold
+    # `$type_of(...)` type gates in this module's bodies (#1472).
+    comptime.set_type_resolver(ctx, resolve_type_comparison_operand::*u8, lc::ptr);
     lc.locals      = map.init[resolve.SymbolId, value.Value](s.alloc, maphash.hash_u32, maphash.eq_u32);
     lc.local_names = map.init[intern.StrId, value.Value](s.alloc, maphash.hash_u32, maphash.eq_u32);
 
@@ -299,6 +302,7 @@ pub fun init_context(
 pub fun dnit_context(lc: *LowerContext) {
     if (lc == nil) { ret; }
     if (lc.ctx != nil) { comptime.set_member_resolver(lc.ctx, nil, nil); }
+    if (lc.ctx != nil) { comptime.set_type_resolver(lc.ctx, nil, nil); }
     map.dnit[intern.StrId, value.Value](?lc.local_names);
     map.dnit[resolve.SymbolId, value.Value](?lc.locals);
     if (lc.loops != nil && lc.loop_cap > 0) {
@@ -384,6 +388,28 @@ pub fun resolve_module_member_const(data: ptr, eid: aid.ExprId) Result[Option[co
         ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]());
     }
     ret ok[Option[comptime.CTValue], str](some[comptime.CTValue](unwrap[*comptime.NamedConst](nc).value));
+}
+
+# resolve_type_comparison_operand: the type-comparison operand resolver lowering
+# installs on every ComptimeCtx it evaluates against (a comptime.TypeIdentFn).
+# given the value expression of a type-comparison operand — a `$type_of(...)`'s
+# inner value, or a type-name spelling — it returns the operand's interned
+# semantic TypeId as an opaque type-identity token, so a `$type_of(x) == i64`
+# gate folds to an identity compare. none when the expression carries no resolved
+# type (an untyped or erroneous operand), leaving comptime.eval to defer / error.
+# `data` is the *LowerContext driving the evaluation; reading its `sema_result`
+# live keeps the resolver correct across the value-instance drains that swap the
+# active module.
+# ---
+# data: the *LowerContext, erased to a ptr by the installer
+# eid:  the operand value expression id, valid in the active module's ast
+# ret:  some(type-id token) when the operand has a resolved type, else none
+pub fun resolve_type_comparison_operand(data: ptr, eid: aid.ExprId) Result[Option[u32], str] {
+    val lc: *LowerContext = data::*LowerContext;
+    if (lc == nil) { ret ok[Option[u32], str](none[u32]()); }
+    val t: ty.TypeId = expr_type_of(lc, eid);
+    if (t == ty.TYPE_NIL || t == ty.TYPE_ERROR) { ret ok[Option[u32], str](none[u32]()); }
+    ret ok[Option[u32], str](some[u32](t::u32));
 }
 
 # resets the per-function working state before lowering a new function:

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -252,6 +252,9 @@ pub fun init_context(
     # install the type-comparison operand resolver so comptime.eval can fold
     # `$type_of(...)` type gates in this module's bodies (#1472).
     comptime.set_type_resolver(ctx, resolve_type_comparison_operand::*u8, lc::ptr);
+    # install the field-descriptor member resolver so `f.name`/`f.type`/`f.offset`
+    # fold inside `$each` bodies (#1473).
+    comptime.set_field_resolver(ctx, resolve_field_member::*u8, lc::ptr);
     lc.locals      = map.init[resolve.SymbolId, value.Value](s.alloc, maphash.hash_u32, maphash.eq_u32);
     lc.local_names = map.init[intern.StrId, value.Value](s.alloc, maphash.hash_u32, maphash.eq_u32);
 
@@ -303,6 +306,7 @@ pub fun dnit_context(lc: *LowerContext) {
     if (lc == nil) { ret; }
     if (lc.ctx != nil) { comptime.set_member_resolver(lc.ctx, nil, nil); }
     if (lc.ctx != nil) { comptime.set_type_resolver(lc.ctx, nil, nil); }
+    if (lc.ctx != nil) { comptime.set_field_resolver(lc.ctx, nil, nil); }
     map.dnit[intern.StrId, value.Value](?lc.local_names);
     map.dnit[resolve.SymbolId, value.Value](?lc.locals);
     if (lc.loops != nil && lc.loop_cap > 0) {
@@ -410,6 +414,40 @@ pub fun resolve_type_comparison_operand(data: ptr, eid: aid.ExprId) Result[Optio
     val t: ty.TypeId = expr_type_of(lc, eid);
     if (t == ty.TYPE_NIL || t == ty.TYPE_ERROR) { ret ok[Option[u32], str](none[u32]()); }
     ret ok[Option[u32], str](some[u32](t::u32));
+}
+
+# resolve_field_member: the field-descriptor member resolver lowering installs on
+# every ComptimeCtx it evaluates against (a comptime.FieldMemberFn). given the
+# owning record's sema TypeId, a field ordinal, and a FIELD_SEL_* selector, it
+# projects the field's `.name` (str), `.type` (a sema TypeId token), or `.offset`
+# (its byte offset in the target layout, the same authority `$offset_of` reads).
+# none when the ordinal is out of range. `data` is the *LowerContext.
+# ---
+# data:  the *LowerContext, erased to a ptr by the installer
+# owner: the owning record's sema TypeId
+# index: the field ordinal
+# sel:   a comptime.FIELD_SEL_* selector
+# ret:   some(value) for the projected attribute, else none
+pub fun resolve_field_member(data: ptr, owner: u32, index: u32, sel: u8) Result[Option[comptime.CTValue], str] {
+    val lc: *LowerContext = data::*LowerContext;
+    if (lc == nil) { ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]()); }
+    val owner_ty: ty.TypeId = owner::ty.TypeId;
+    val fa: Option[*ty.FieldEntry] = ty.field_at(?lc.s.types, owner_ty, index);
+    if (is_none[*ty.FieldEntry](fa)) { ret ok[Option[comptime.CTValue], str](none[comptime.CTValue]()); }
+    val fe: *ty.FieldEntry = unwrap[*ty.FieldEntry](fa);
+
+    if (sel == comptime.FIELD_SEL_NAME) {
+        ret ok[Option[comptime.CTValue], str](some[comptime.CTValue](comptime.ct_str(fe.name)));
+    }
+    if (sel == comptime.FIELD_SEL_TYPE) {
+        ret ok[Option[comptime.CTValue], str](some[comptime.CTValue](comptime.ct_type(fe.ty::u32)));
+    }
+    # offset: the field's byte offset in the target layout (IR authority).
+    val ir_r: Result[ir_type.IrTypeId, str] = lower_type(lc, owner_ty);
+    if (is_err[ir_type.IrTypeId, str](ir_r)) { ret err[Option[comptime.CTValue], str](unwrap_err[ir_type.IrTypeId, str](ir_r)); }
+    val ir_id: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](ir_r);
+    val off: u32 = ir_type.byte_offset(?lc.m.types, ir_id, index, lc.tgt);
+    ret ok[Option[comptime.CTValue], str](some[comptime.CTValue](comptime.ct_uint(off::u64)));
 }
 
 # resets the per-function working state before lowering a new function:

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1037,6 +1037,7 @@ pub fun ensure_extern_global(lc: *LowerContext, name: intern.StrId, ty: ir_type.
     g.is_extern = true;
     g.is_local  = false;
     g.align     = 0;
+    g.section   = intern.STR_NIL;
     m.globals[idx] = g;
     m.global_len   = m.global_len + 1;
     val reg: Result[bool, str] = ir.register_global(m, name, idx);
@@ -1077,6 +1078,7 @@ pub fun add_rodata_bytes(lc: *LowerContext, init: value.Value, pty: ir_type.IrTy
     g.is_extern = false;
     g.is_local  = true;
     g.align     = 0;
+    g.section   = intern.STR_NIL;
     m.globals[idx] = g;
     m.global_len   = m.global_len + 1;
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -193,6 +193,23 @@ pub rec PackInstance {
 #              typed by the instance's element type-list
 # pinst_len:   number of pack-instance worklist entries
 # pinst_cap:   allocated capacity of the pack-instance worklist
+# inst_drained / vinst_drained / pinst_drained: persistent cursors into the three
+#              worklists; entries below each are already emitted, so the unified
+#              drain emits every instance body exactly once even as the worklists
+#              grow re-entrantly (a body of one kind enqueuing instances of another)
+# pack_slots:  while lowering a pack instance body, the N expanded pack-parameter
+#              alloca slots (by pack ordinal); nil outside a pack instance
+# pack_types:  the N concrete pack element semantic types (by pack ordinal),
+#              parallel to pack_slots; nil outside a pack instance
+# pack_len:    number of expanded pack parameters (0 outside a pack instance)
+# pack_ret_ty: the pack instance's semantic return type, supplied to the per-
+#              element body re-inference so a body `ret` checks against it
+# pack_each_name:  interned name of the loop variable of the pack `$each` currently
+#              unrolling, or STR_NIL outside one; an IDENT resolving to the
+#              (synthetic, decl-nil) loop-var symbol of this name is lowered from
+#              `pack_slots[pack_each_index]` rather than a normal local lookup
+# pack_each_index: the current element ordinal of the unrolling pack `$each`,
+#              selecting the loop variable's slot in pack_slots
 pub rec LowerContext {
     s:           *sess.Session;
     tgt:         *target.Target;
@@ -233,6 +250,17 @@ pub rec LowerContext {
     pinsts:      *PackInstance;
     pinst_len:   u32;
     pinst_cap:   u32;
+
+    vinst_drained: u32;
+    pinst_drained: u32;
+
+    pack_slots:  *value.Value;
+    pack_types:  *ty.TypeId;
+    pack_len:    u32;
+    pack_ret_ty: ty.TypeId;
+
+    pack_each_name:  intern.StrId;
+    pack_each_index: u32;
 }
 
 
@@ -324,6 +352,14 @@ pub fun init_context(
     lc.pinsts    = nil;
     lc.pinst_len = 0;
     lc.pinst_cap = 0;
+    lc.vinst_drained  = 0;
+    lc.pinst_drained  = 0;
+    lc.pack_slots  = nil;
+    lc.pack_types  = nil;
+    lc.pack_len    = 0;
+    lc.pack_ret_ty = ty.TYPE_NIL;
+    lc.pack_each_name  = intern.STR_NIL;
+    lc.pack_each_index = 0;
 
     ret ok[bool, str](true);
 }
@@ -397,6 +433,14 @@ pub fun dnit_context(lc: *LowerContext) {
     lc.pinsts    = nil;
     lc.pinst_len = 0;
     lc.pinst_cap = 0;
+    lc.vinst_drained = 0;
+    lc.pinst_drained = 0;
+    lc.pack_slots  = nil;
+    lc.pack_types  = nil;
+    lc.pack_len    = 0;
+    lc.pack_ret_ty = ty.TYPE_NIL;
+    lc.pack_each_name  = intern.STR_NIL;
+    lc.pack_each_index = 0;
 }
 
 # resolve_module_member_const: the `alias.CONST` member resolver lowering
@@ -511,6 +555,14 @@ pub fun begin_function(lc: *LowerContext, fn_index: u32, ret_ty: ir_type.IrTypeI
     lc.fin_len  = 0;
     lc.fn_index = fn_index;
     lc.ret_ty   = ret_ty;
+    # pack-instance body state defaults off; lower_pack_instance sets it after this
+    # reset, and an ordinary function (or a generic / value instance) never reads it.
+    lc.pack_slots  = nil;
+    lc.pack_types  = nil;
+    lc.pack_len    = 0;
+    lc.pack_ret_ty = ty.TYPE_NIL;
+    lc.pack_each_name  = intern.STR_NIL;
+    lc.pack_each_index = 0;
 }
 
 # binds a source SymbolId to the IR Value that names its storage. for
@@ -567,6 +619,26 @@ pub fun lookup_local(lc: *LowerContext, sym: resolve.SymbolId) Option[value.Valu
         ret some[value.Value](@unwrap_ok[*value.Value, str](r));
     }
     ret none[value.Value]();
+}
+
+# pack_each_storage: the storage slot bound to the loop variable of the pack
+# `$each` currently unrolling, when `sym` names that loop variable. the loop var
+# is the synthetic (decl-nil) symbol whose interned name matches the active
+# pack-each name; its per-element storage is the expanded pack-parameter alloca
+# slot at the current unroll index. none outside a pack `$each`, or for any other
+# symbol — so an ordinary IDENT falls through to the normal local / global path.
+# ---
+# lc:  the context
+# sym: the IDENT's resolved SymbolId
+# ret: some(slot Value) when sym is the active pack loop variable, else none
+pub fun pack_each_storage(lc: *LowerContext, sym: resolve.SymbolId) Option[value.Value] {
+    if (lc.pack_each_name == intern.STR_NIL) { ret none[value.Value](); }
+    val so: Option[*resolve.Symbol] = symbol_of(lc, sym);
+    if (is_none[*resolve.Symbol](so)) { ret none[value.Value](); }
+    val s: *resolve.Symbol = unwrap[*resolve.Symbol](so);
+    if (s.decl != aid.DECL_NIL || s.name != lc.pack_each_name) { ret none[value.Value](); }
+    if (lc.pack_slots == nil || lc.pack_each_index >= lc.pack_len) { ret none[value.Value](); }
+    ret some[value.Value](lc.pack_slots[lc.pack_each_index]);
 }
 
 # pushes a loop frame, recording the header and exit blocks the innermost

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -983,6 +983,7 @@ pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_ty
     f.instr_cap   = 0;
     f.flags       = ir.FN_FLAG_EXTERN;
     f.label       = intern.STR_NIL;
+    f.section     = intern.STR_NIL;
     f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, maphash.hash_u32, maphash.eq_u32);
 
     m.functions[idx] = f;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -557,6 +557,9 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
         }
     }
 
+    val align_r: Result[u32, str] = global_align_of(ctx, d);
+    if (is_err[u32, str](align_r)) { ret err[bool, str](unwrap_err[u32, str](align_r)); }
+
     var g: ir.Global;
     g.name      = name;
     g.ty        = gty;
@@ -565,6 +568,7 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
     g.is_pub    = (d.flags & adecl.DECL_FLAG_PUB) != 0;
     g.is_extern = false;
     g.is_local  = false;
+    g.align     = unwrap_ok[u32, str](align_r);
 
     val ai: Result[u32, str] = append_global(ctx, g);
     if (is_err[u32, str](ai)) { ret err[bool, str](unwrap_err[u32, str](ai)); }
@@ -745,6 +749,60 @@ fun decl_has_decorator(ctx: *lower.LowerContext, d: *adecl.Decl, name: str) bool
         k = k + 1;
     }
     ret false;
+}
+
+# decorator_arg_eid: the ExprId of decorator `name`'s argument at ordinal `ord`,
+# or none when the decl has no such decorator or it lacks that argument.
+fun decorator_arg_eid(ctx: *lower.LowerContext, d: *adecl.Decl, name: str, ord: u32) Option[aid.ExprId] {
+    val source: str = lower.module_source(ctx);
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *adecl.Decorator = ?ctx.a.decorators[d.decorators_start + k];
+        if (str_region_equals(source, dec.name.offset, dec.name.len, name)) {
+            if (ord >= dec.args_len) { ret none[aid.ExprId](); }
+            ret some[aid.ExprId](ctx.a.expr_ids[dec.args_start + ord]);
+        }
+        k = k + 1;
+    }
+    ret none[aid.ExprId]();
+}
+
+# global_align_of: the explicit alignment an `align(expr)` decorator pins a global
+# to, or 0 when none is present (the back end then uses its section default). the
+# argument is folded to a compile-time constant by the same constant path a global
+# initialiser uses (so `align($align_of(u64))` and `align(16)` both work) and must
+# be a power of two; a non-constant or non-power-of-two value is reported on the
+# binding's name and the build is gated.
+fun global_align_of(ctx: *lower.LowerContext, d: *adecl.Decl) Result[u32, str] {
+    val arg_opt: Option[aid.ExprId] = decorator_arg_eid(ctx, d, "align", 0);
+    if (is_none[aid.ExprId](arg_opt)) { ret ok[u32, str](0); }
+    val arg: aid.ExprId = unwrap[aid.ExprId](arg_opt);
+
+    val u64_r: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](u64_r)) { ret err[u32, str](unwrap_err[ir_type.IrTypeId, str](u64_r)); }
+    val u64t: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](u64_r);
+
+    val fr: Result[value.Value, str] = fold_global_init(ctx, arg, u64t);
+    if (is_err[value.Value, str](fr)) {
+        val de: Result[bool, str] = diag.error(?ctx.s.diags, ctx.a.file_id, d.data.bind.name, "`align` decorator requires a compile-time constant argument");
+        if (is_err[bool, str](de)) { ret err[u32, str](unwrap_err[bool, str](de)); }
+        ret ok[u32, str](0);
+    }
+    val v: value.Value = unwrap_ok[value.Value, str](fr);
+    if (v.kind != value.VAL_CONST_INT) {
+        val de: Result[bool, str] = diag.error(?ctx.s.diags, ctx.a.file_id, d.data.bind.name, "`align` decorator requires an integer argument");
+        if (is_err[bool, str](de)) { ret err[u32, str](unwrap_err[bool, str](de)); }
+        ret ok[u32, str](0);
+    }
+
+    val n: u64 = v.data.int_lit;
+    # a section alignment must be a non-zero power of two.
+    if (n == 0 || (n & (n - 1)) != 0) {
+        val de: Result[bool, str] = diag.error(?ctx.s.diags, ctx.a.file_id, d.data.bind.name, "`align` value must be a non-zero power of two");
+        if (is_err[bool, str](de)) { ret err[u32, str](unwrap_err[bool, str](de)); }
+        ret ok[u32, str](0);
+    }
+    ret ok[u32, str](n::u32);
 }
 
 # appends a fresh Function to the module, growing the functions array on

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -145,6 +145,8 @@ pub fun lower_fun(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, is_
     if (is_err[u32, str](idx_r)) { ret err[bool, str](unwrap_err[u32, str](idx_r)); }
     val fn_index: u32 = unwrap_ok[u32, str](idx_r);
 
+    ctx.m.functions[fn_index].section = decl_section_of(ctx, d);
+
     # external functions carry no body
     if ((flags & ir.FN_FLAG_EXTERN) != 0) {
         ret ok[bool, str](true);
@@ -855,6 +857,7 @@ fun append_function(ctx: *lower.LowerContext, name: intern.StrId, sig: ir_type.I
     f.flags       = flags;
     f.label       = intern.STR_NIL;
     f.line        = 0;
+    f.section     = intern.STR_NIL;
     f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, maphash.hash_u32, maphash.eq_u32);
 
     m.functions[idx] = f;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -18,6 +18,7 @@ use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
+use std.types.string.str_region_equals;
 use std.types.char.char;
 use std.types.option.Option;
 use std.types.option.some;
@@ -133,6 +134,8 @@ pub fun lower_fun(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, is_
         flags = flags | ir.FN_FLAG_EXTERN;
     }
     if (is_test) { flags = flags | ir.FN_FLAG_TEST; }
+    # an `inline` decorator hints the inline pass; it already honors FN_FLAG_INLINE.
+    if (decl_has_decorator(ctx, d, "inline")) { flags = flags | ir.FN_FLAG_INLINE; }
 
     val ret_ir_r: Result[ir_type.IrTypeId, str] = function_return_ir(ctx, did);
     if (is_err[ir_type.IrTypeId, str](ret_ir_r)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](ret_ir_r)); }
@@ -728,6 +731,20 @@ fun lower_comptime_if(ctx: *lower.LowerContext, d: *adecl.Decl) Result[bool, str
         bi = bi + 1;
     }
     ret ok[bool, str](true);
+}
+
+# decl_has_decorator: reports whether decl `d` carries a leading backtick
+# decorator whose directive name equals `name` (e.g. `inline`). decorator name
+# spans index into the current module's source via the lower context's AST.
+fun decl_has_decorator(ctx: *lower.LowerContext, d: *adecl.Decl, name: str) bool {
+    val source: str = lower.module_source(ctx);
+    var k: u32 = 0;
+    for (k < d.decorators_len) {
+        val dec: *adecl.Decorator = ?ctx.a.decorators[d.decorators_start + k];
+        if (str_region_equals(source, dec.name.offset, dec.name.len, name)) { ret true; }
+        k = k + 1;
+    }
+    ret false;
 }
 
 # appends a fresh Function to the module, growing the functions array on

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -569,6 +569,7 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
     g.is_extern = false;
     g.is_local  = false;
     g.align     = unwrap_ok[u32, str](align_r);
+    g.section   = decl_section_of(ctx, d);
 
     val ai: Result[u32, str] = append_global(ctx, g);
     if (is_err[u32, str](ai)) { ret err[bool, str](unwrap_err[u32, str](ai)); }
@@ -749,6 +750,27 @@ fun decl_has_decorator(ctx: *lower.LowerContext, d: *adecl.Decl, name: str) bool
         k = k + 1;
     }
     ret false;
+}
+
+# decl_section_of: the interned section name a `section("...")` decorator places
+# decl `d` in, or STR_NIL for the back end's default. the argument is a string
+# literal (sema validated the shape); its inner content (quotes stripped) is
+# interned.
+fun decl_section_of(ctx: *lower.LowerContext, d: *adecl.Decl) intern.StrId {
+    val arg_opt: Option[aid.ExprId] = decorator_arg_eid(ctx, d, "section", 0);
+    if (is_none[aid.ExprId](arg_opt)) { ret intern.STR_NIL; }
+    val ve_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, unwrap[aid.ExprId](arg_opt));
+    if (is_none[*aexpr.Expr](ve_opt)) { ret intern.STR_NIL; }
+    val ve: *aexpr.Expr = unwrap[*aexpr.Expr](ve_opt);
+    if (ve.kind != aexpr.EXPR_KIND_LIT_STR || ve.span.len < 2::usize) { ret intern.STR_NIL; }
+
+    var inner: token.Span = ve.span;
+    inner.offset = inner.offset + 1::usize;
+    inner.len    = inner.len - 2::usize;
+
+    val r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, lower.module_source(ctx), inner);
+    if (is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
+    ret unwrap_ok[intern.StrId, str](r);
 }
 
 # decorator_arg_eid: the ExprId of decorator `name`'s argument at ordinal `ord`,

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -116,6 +116,12 @@ pub fun lower_fun(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, is_
     # cannot fold without a bound value.
     if (fun_has_comptime_param(ctx, d)) { ret ok[bool, str](true); }
 
+    # a pack-tailed function (`va: ...`) is likewise a TEMPLATE: it is emitted once
+    # per distinct call-site pack type-list through the pack-instance worklist
+    # (lower_pack_instance), never as a standalone body here. emitting it directly
+    # would fail — its pack `$each` cannot unroll without a concrete element list.
+    if (fun_has_pack_param(ctx, d)) { ret ok[bool, str](true); }
+
     val sig_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, lower.decl_type_of(ctx, did));
     if (is_err[ir_type.IrTypeId, str](sig_r)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](sig_r)); }
     val sig: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](sig_r);
@@ -273,6 +279,23 @@ pub fun fun_has_comptime_param(ctx: *lower.LowerContext, d: *adecl.Decl) bool {
         i = i + 1;
     }
     ret false;
+}
+
+# reports whether a function declaration ends in a comptime variadic-pack parameter
+# (`va: ...`, #1475), read from its own AST typed_names. a pack-tailed function is a
+# TEMPLATE — monomorphized once per distinct call-site pack type-list — so it is
+# never emitted as a standalone body. the pack may only be the trailing parameter,
+# so only the last param's resolved type is consulted.
+pub fun fun_has_pack_param(ctx: *lower.LowerContext, d: *adecl.Decl) bool {
+    val n: u32 = d.data.fun_.params_len;
+    if (n == 0) { ret false; }
+    val pool_ix: u32 = d.data.fun_.params_start + (n - 1);
+    if (pool_ix::usize >= ctx.a.typed_name_len) { ret false; }
+    val tn: *adecl.TypedName = ?ctx.a.typed_names[pool_ix];
+    val pt: ty.TypeId = lower.type_resolved_of(ctx, tn.ty);
+    val to: Option[*ty.Type] = ty.get(?ctx.s.types, pt);
+    if (is_none[*ty.Type](to)) { ret false; }
+    ret unwrap[*ty.Type](to).kind == ty.TYPE_PACK;
 }
 
 # reports a duplicate test label, naming the label text when lookup succeeds.

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -269,6 +269,242 @@ pub fun lower_value_instance(ctx: *lower.LowerContext, did: aid.DeclId, d: *adec
     ret close_function(ctx, ret_ir);
 }
 
+# lowers one comptime variadic-pack instance: a concrete body for the pack-tailed
+# template `did` under the instance linkage `name`, with the trailing pack
+# parameter EXPANDED into `type_len` concrete parameters typed by the call site's
+# element type-list (`types`). the context must already be bound to the template's
+# origin module (AST / typing / name-resolution / comptime ctx). the lowered
+# signature is the leading fixed parameters followed by the N expanded element
+# parameters; the body's `$each a in va` unrolls over those N parameters, binding
+# the loop variable to each (lower_comptime_each). the emitted function is
+# PUB | WEAK so any using object binds to it and the linker collapses the copies.
+# a body-less template is not a valid instance and is skipped.
+# ---
+# ctx:      the context, already bound to the origin module
+# did:      DeclId of the pack-tailed template in the origin AST
+# d:        the resolved template Decl
+# name:     the instance's mangled linkage name
+# types:    the concrete pack element type-list (by pack ordinal)
+# type_len: number of pack element types (the expanded parameter count)
+# ret:      true on success, or an error
+pub fun lower_pack_instance(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl,
+                            name: intern.StrId, types: *ty.TypeId, type_len: u32) Result[bool, str] {
+    if (d.data.fun_.body == aid.STMT_NIL) { ret ok[bool, str](true); }
+
+    # leading fixed parameter count: every declared parameter except the trailing
+    # pack. the pack expands to `type_len` concrete parameters after them.
+    val fixed_count: u32 = d.data.fun_.params_len - 1;
+
+    val ret_ir_r: Result[ir_type.IrTypeId, str] = function_return_ir(ctx, did);
+    if (is_err[ir_type.IrTypeId, str](ret_ir_r)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](ret_ir_r)); }
+    val ret_ir: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](ret_ir_r);
+
+    val sig_r: Result[ir_type.IrTypeId, str] = pack_instance_sig(ctx, d, fixed_count, types, type_len, ret_ir);
+    if (is_err[ir_type.IrTypeId, str](sig_r)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](sig_r)); }
+    val sig: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](sig_r);
+
+    val flags: u32 = ir.FN_FLAG_PUB | ir.FN_FLAG_WEAK;
+    val idx_r: Result[u32, str] = append_function(ctx, name, sig, flags, fixed_count + type_len);
+    if (is_err[u32, str](idx_r)) { ret err[bool, str](unwrap_err[u32, str](idx_r)); }
+    val fn_index: u32 = unwrap_ok[u32, str](idx_r);
+
+    lower.begin_function(ctx, fn_index, ret_ir);
+
+    # publish the pack body state the `$each a in va` unroll reads: the N element
+    # types and the semantic return type now; the N alloca slots are filled by
+    # lower_pack_params below.
+    ctx.pack_types  = types;
+    ctx.pack_len    = type_len;
+    ctx.pack_ret_ty = pack_instance_ret_sem(ctx, did);
+
+    builder.set_function(?ctx.builder, ?ctx.m.functions[fn_index]);
+
+    val entry_r: Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
+    if (is_err[ir.BlockId, str](entry_r)) { ret err[bool, str](unwrap_err[ir.BlockId, str](entry_r)); }
+    builder.set_block(?ctx.builder, unwrap_ok[ir.BlockId, str](entry_r));
+
+    val params_r: Result[bool, str] = lower_pack_params(ctx, did, d, fn_index, fixed_count, types, type_len);
+    if (is_err[bool, str](params_r)) { clear_pack_state(ctx); ret params_r; }
+
+    val br: Result[bool, str] = stmt.lower_stmt(ctx, d.data.fun_.body);
+    if (is_err[bool, str](br)) { clear_pack_state(ctx); ret br; }
+
+    val cr: Result[bool, str] = close_function(ctx, ret_ir);
+    clear_pack_state(ctx);
+    ret cr;
+}
+
+# clear_pack_state: releases the pack instance body's expanded-parameter slot
+# buffer and clears the pack body state, so the next function lowered sees no
+# stale pack parameters. the element type-list (`pack_types`) is borrowed from the
+# worklist entry, so it is not freed here.
+fun clear_pack_state(ctx: *lower.LowerContext) {
+    if (ctx.pack_slots != nil && ctx.pack_len > 0) {
+        deallocate[value.Value](ctx.s.alloc, ctx.pack_slots, ctx.pack_len::usize);
+    }
+    ctx.pack_slots  = nil;
+    ctx.pack_types  = nil;
+    ctx.pack_len    = 0;
+    ctx.pack_ret_ty = ty.TYPE_NIL;
+}
+
+# pack_instance_sig: interns the IR function type of a pack instance — the leading
+# fixed parameter IR types followed by the N expanded element IR types, returning
+# `ret_ir`. the expanded elements take the place of the single TYPE_PACK parameter,
+# so the instance's ABI matches the collected call rather than the opaque pack.
+fun pack_instance_sig(ctx: *lower.LowerContext, d: *adecl.Decl, fixed_count: u32,
+                      types: *ty.TypeId, type_len: u32, ret_ir: ir_type.IrTypeId) Result[ir_type.IrTypeId, str] {
+    val total: u32 = fixed_count + type_len;
+    if (total == 0) {
+        ret ir_type.intern_fn(?ctx.m.types, ret_ir, nil, 0, false);
+    }
+
+    val buf_r: Result[*ir_type.IrTypeId, str] = allocate[ir_type.IrTypeId](ctx.s.alloc, total::usize);
+    if (is_err[*ir_type.IrTypeId, str](buf_r)) { ret err[ir_type.IrTypeId, str](unwrap_err[*ir_type.IrTypeId, str](buf_r)); }
+    val buf: *ir_type.IrTypeId = unwrap_ok[*ir_type.IrTypeId, str](buf_r);
+
+    var i: u32 = 0;
+    for (i < fixed_count) {
+        val pool_ix: u32 = d.data.fun_.params_start + i;
+        var p_sem: ty.TypeId = ty.TYPE_NIL;
+        if (pool_ix::usize < ctx.a.typed_name_len) {
+            p_sem = lower.type_resolved_of(ctx, ctx.a.typed_names[pool_ix].ty);
+        }
+        val pr: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, p_sem);
+        if (is_err[ir_type.IrTypeId, str](pr)) {
+            deallocate[ir_type.IrTypeId](ctx.s.alloc, buf, total::usize);
+            ret pr;
+        }
+        buf[i] = unwrap_ok[ir_type.IrTypeId, str](pr);
+        i = i + 1;
+    }
+
+    var j: u32 = 0;
+    for (j < type_len) {
+        val er: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, types[j]);
+        if (is_err[ir_type.IrTypeId, str](er)) {
+            deallocate[ir_type.IrTypeId](ctx.s.alloc, buf, total::usize);
+            ret er;
+        }
+        buf[fixed_count + j] = unwrap_ok[ir_type.IrTypeId, str](er);
+        j = j + 1;
+    }
+
+    val fr: Result[ir_type.IrTypeId, str] = ir_type.intern_fn(?ctx.m.types, ret_ir, buf, total, false);
+    deallocate[ir_type.IrTypeId](ctx.s.alloc, buf, total::usize);
+    ret fr;
+}
+
+# pack_instance_ret_sem: the semantic return type of a pack instance, recovered
+# from its template's TYPE_FUN signature; supplied to the per-element body
+# re-inference so a `ret` inside the `$each` body checks against it.
+fun pack_instance_ret_sem(ctx: *lower.LowerContext, did: aid.DeclId) ty.TypeId {
+    val sem: ty.TypeId = lower.decl_type_of(ctx, did);
+    val t_opt: Option[*ty.Type] = ty.get(?ctx.s.types, sem);
+    if (is_none[*ty.Type](t_opt)) { ret ty.TYPE_NIL; }
+    val t: *ty.Type = unwrap[*ty.Type](t_opt);
+    if (t.kind != ty.TYPE_FUN) { ret ty.TYPE_NIL; }
+    ret t.data.fn.ret_ty;
+}
+
+# lower_pack_params: materialises the pack instance's parameters. the leading fixed
+# parameters are spilled and bound to their symbols exactly like lower_params; the
+# N expanded element parameters are spilled into alloca slots recorded on
+# `ctx.pack_slots` (by pack ordinal) for the `$each a in va` unroll to load, and
+# are NOT bound to any source symbol (the pack itself names no runtime value). the
+# function's `params` / `param_count` cover the fixed plus expanded parameters.
+fun lower_pack_params(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, fn_index: u32,
+                      fixed_count: u32, types: *ty.TypeId, type_len: u32) Result[bool, str] {
+    val cr: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 64);
+    if (is_err[ir_type.IrTypeId, str](cr)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](cr)); }
+    val xty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](cr);
+
+    val total: u32 = fixed_count + type_len;
+    var params: *value.Value = nil;
+    if (total > 0) {
+        val ar: Result[*value.Value, str] = allocate[value.Value](ctx.s.alloc, total::usize);
+        if (is_err[*value.Value, str](ar)) { ret err[bool, str](unwrap_err[*value.Value, str](ar)); }
+        params = unwrap_ok[*value.Value, str](ar);
+    }
+
+    var slots: *value.Value = nil;
+    if (type_len > 0) {
+        val sr: Result[*value.Value, str] = allocate[value.Value](ctx.s.alloc, type_len::usize);
+        if (is_err[*value.Value, str](sr)) {
+            if (params != nil) { deallocate[value.Value](ctx.s.alloc, params, total::usize); }
+            ret err[bool, str](unwrap_err[*value.Value, str](sr));
+        }
+        slots = unwrap_ok[*value.Value, str](sr);
+    }
+
+    var w: u32 = 0;
+    var i: u32 = 0;
+    for (i < fixed_count) {
+        val pool_ix: u32 = d.data.fun_.params_start + i;
+        var p_sem: ty.TypeId = ty.TYPE_NIL;
+        if (pool_ix::usize < ctx.a.typed_name_len) {
+            p_sem = lower.type_resolved_of(ctx, ctx.a.typed_names[pool_ix].ty);
+        }
+        val pr: Result[value.Value, str] = emit_pack_param(ctx, params, w, p_sem, xty);
+        if (is_err[value.Value, str](pr)) { free_pack_param_bufs(ctx, params, total, slots, type_len); ret err[bool, str](unwrap_err[value.Value, str](pr)); }
+        val slot: value.Value = unwrap_ok[value.Value, str](pr);
+
+        # a fixed parameter is read through its slot, like an ordinary parameter.
+        val sid: resolve.SymbolId = param_symbol(ctx, did, i);
+        if (sid != resolve.SYMBOL_NIL) {
+            val bind_r: Result[bool, str] = lower.bind_local(ctx, sid, slot);
+            if (is_err[bool, str](bind_r)) { free_pack_param_bufs(ctx, params, total, slots, type_len); ret bind_r; }
+        }
+        w = w + 1;
+        i = i + 1;
+    }
+
+    var j: u32 = 0;
+    for (j < type_len) {
+        val pr: Result[value.Value, str] = emit_pack_param(ctx, params, w, types[j], xty);
+        if (is_err[value.Value, str](pr)) { free_pack_param_bufs(ctx, params, total, slots, type_len); ret err[bool, str](unwrap_err[value.Value, str](pr)); }
+        # an expanded element is reached by ordinal: its slot is the storage the
+        # `$each a in va` unroll loads for the matching iteration.
+        slots[j] = unwrap_ok[value.Value, str](pr);
+        w = w + 1;
+        j = j + 1;
+    }
+
+    ctx.m.functions[fn_index].params      = params;
+    ctx.m.functions[fn_index].param_count = total;
+    ctx.pack_slots = slots;
+    ret ok[bool, str](true);
+}
+
+# emit_pack_param: materialise one parameter at ordinal `w` of the IR type lowered
+# from `p_sem` — a VAL_PARAM recorded in `params[w]`, spilled into a fresh alloca —
+# and returns the alloca slot pointer (a fixed parameter binds it to its symbol; an
+# expanded element keeps it by ordinal for the `$each` unroll).
+fun emit_pack_param(ctx: *lower.LowerContext, params: *value.Value, w: u32, p_sem: ty.TypeId, xty: ir_type.IrTypeId) Result[value.Value, str] {
+    val tr: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, p_sem);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](tr)); }
+    val p_ir: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+
+    val pval: value.Value = value.param_value(w, p_ir);
+
+    val slot_r: Result[value.Value, str] = builder.emit_alloca(?ctx.builder, p_ir, value.const_int(1, xty));
+    if (is_err[value.Value, str](slot_r)) { ret slot_r; }
+    val slot: value.Value = unwrap_ok[value.Value, str](slot_r);
+
+    val sr: Result[bool, str] = builder.emit_store(?ctx.builder, pval, slot);
+    if (is_err[bool, str](sr)) { ret err[value.Value, str](unwrap_err[bool, str](sr)); }
+
+    params[w] = pval;
+    ret ok[value.Value, str](slot);
+}
+
+# free_pack_param_bufs: releases the parameter / slot buffers on a lowering error
+# before they are handed to the function / context.
+fun free_pack_param_bufs(ctx: *lower.LowerContext, params: *value.Value, total: u32, slots: *value.Value, type_len: u32) {
+    if (params != nil && total > 0) { deallocate[value.Value](ctx.s.alloc, params, total::usize); }
+    if (slots != nil && type_len > 0) { deallocate[value.Value](ctx.s.alloc, slots, type_len::usize); }
+}
+
 # reports whether a function declaration declares any comptime value parameter,
 # read from its own AST typed_names.
 pub fun fun_has_comptime_param(ctx: *lower.LowerContext, d: *adecl.Decl) bool {

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -826,6 +826,13 @@ fun global_align_of(ctx: *lower.LowerContext, d: *adecl.Decl) Result[u32, str] {
         if (is_err[bool, str](de)) { ret err[u32, str](unwrap_err[bool, str](de)); }
         ret ok[u32, str](0);
     }
+    # the alignment is stored in a u32 section field; a power of two past u32 would
+    # truncate (e.g. 2^32 -> 0), so reject it rather than emit a 0-aligned section.
+    if (n > 0xFFFFFFFF) {
+        val de: Result[bool, str] = diag.error(?ctx.s.diags, ctx.a.file_id, d.data.bind.name, "`align` value exceeds the maximum alignment");
+        if (is_err[bool, str](de)) { ret err[u32, str](unwrap_err[bool, str](de)); }
+        ret ok[u32, str](0);
+    }
     ret ok[u32, str](n::u32);
 }
 

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -45,6 +45,7 @@ use ast:      mach.lang.fe.ast;
 use aid:      mach.lang.fe.ast.id;
 use aexpr:    mach.lang.fe.ast.expr;
 use adecl:    mach.lang.fe.ast.decl;
+use atype:    mach.lang.fe.ast.type;
 use resolve:  mach.lang.fe.resolve;
 use comptime: mach.lang.fe.comptime;
 use token:    mach.lang.fe.token;
@@ -295,6 +296,14 @@ fun lower_ident_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.V
         ret const_value_of(ctx, eid, unwrap[comptime.CTValue](cv));
     }
 
+    # a `$each a in va` pack loop variable (#1475): bound in the comptime context
+    # to a pack-element descriptor; its rvalue is a load from the matching expanded
+    # parameter slot recorded on the context by lower_pack_instance.
+    val pe: Option[u32] = pack_elem_ordinal(ctx, sid);
+    if (is_some[u32](pe)) {
+        ret load_pack_elem(ctx, eid, unwrap[u32](pe));
+    }
+
     val local: Option[value.Value] = lower.lookup_local(ctx, sid);
     if (is_some[value.Value](local)) {
         val slot: value.Value = unwrap[value.Value](local);
@@ -312,6 +321,40 @@ fun lower_ident_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.V
         ret builder.emit_load(?ctx.builder, slot, ity);
     }
     ret symbol_reference(ctx, eid, sid);
+}
+
+# pack_elem_ordinal: the expanded-parameter ordinal of a `$each a in va` pack loop
+# variable (#1475), or none when `sid` is not such a variable. the loop variable is
+# a comptime-flagged SYM_VAL with no declaration, bound by the unroll to a
+# CT_KIND_PACK_ELEM descriptor whose `.index` is the element's ordinal among the
+# instance's expanded pack parameters.
+fun pack_elem_ordinal(ctx: *lower.LowerContext, sid: resolve.SymbolId) Option[u32] {
+    val so: Option[*resolve.Symbol] = lower.symbol_of(ctx, sid);
+    if (is_none[*resolve.Symbol](so)) { ret none[u32](); }
+    val sym: *resolve.Symbol = unwrap[*resolve.Symbol](so);
+    if (sym.kind != resolve.SYM_VAL || (sym.flags & resolve.SYM_FLAG_COMPTIME) == 0) { ret none[u32](); }
+    if (sym.decl != aid.DECL_NIL) { ret none[u32](); }
+    val nc: Option[*comptime.NamedConst] = comptime.lookup(ctx.ctx, sym.name);
+    if (is_none[*comptime.NamedConst](nc)) { ret none[u32](); }
+    val cval: comptime.CTValue = unwrap[*comptime.NamedConst](nc).value;
+    if (cval.kind != comptime.CT_KIND_PACK_ELEM) { ret none[u32](); }
+    ret some[u32](cval.data.pelem.index);
+}
+
+# load_pack_elem: the rvalue of a pack element at ordinal `i` — a load from the
+# expanded parameter slot lower_pack_instance recorded on the context. an aggregate
+# element flows by its storage address tagged with the aggregate IR type, mirroring
+# an ordinary local rvalue.
+fun load_pack_elem(ctx: *lower.LowerContext, eid: aid.ExprId, i: u32) Result[value.Value, str] {
+    if (ctx.pack_slots == nil || i >= ctx.pack_len) {
+        ret err[value.Value, str]("lower: pack element ordinal out of range");
+    }
+    val slot: value.Value = ctx.pack_slots[i];
+    val tr: Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](tr)); }
+    val ity: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+    if (is_aggregate_ir(ctx, ity)) { ret ok[value.Value, str](value.retype(slot, ity)); }
+    ret builder.emit_load(?ctx.builder, slot, ity);
 }
 
 # the folded comptime value of a symbol, when it is a comptime value parameter
@@ -1161,6 +1204,11 @@ fun lower_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Resu
             }
             ret lower_value_callee(ctx, eid, e, f);
         }
+        # a pack-tailed callee (`va: ...`) resolves to a per-type-list monomorphized
+        # instance (#1475), keyed by the trailing arguments' concrete types.
+        if (decl_fun_has_pack_param(ctx, e.data.call.callee, f)) {
+            ret lower_pack_callee(ctx, eid, e, f);
+        }
     }
     if (e.data.call.type_args_len == 0) {
         ret lower_rvalue(ctx, e.data.call.callee);
@@ -1201,6 +1249,21 @@ fun decl_fun_has_comptime_param(ctx: *lower.LowerContext, callee: aid.ExprId, f:
         i = i + 1;
     }
     ret false;
+}
+
+# reports whether the callee's DeclFun ends in a comptime variadic-pack parameter
+# (`va: ...`, #1475), read syntactically from the callee's origin AST — the
+# trailing parameter's AstType is a TYPE_KIND_PACK. detected without sema (mirrors
+# the comptime-flag check) so it works for a cross-module callee whose resolved
+# types live in another module.
+fun decl_fun_has_pack_param(ctx: *lower.LowerContext, callee: aid.ExprId, f: *adecl.DeclFun) bool {
+    val a: *ast.Ast = callee_ast(ctx, callee);
+    if (a == nil) { ret false; }
+    if (f.params_len == 0) { ret false; }
+    val tn: *adecl.TypedName = ?a.typed_names[f.params_start + (f.params_len - 1)];
+    val t_opt: Option[*atype.Type] = ast.get_type(a, tn.ty);
+    if (is_none[*atype.Type](t_opt)) { ret false; }
+    ret unwrap[*atype.Type](t_opt).kind == atype.TYPE_KIND_PACK;
 }
 
 # the AST the callee is declared in: the caller's own AST for a local callee, the
@@ -1425,6 +1488,82 @@ fun lower_generic_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Ex
 
     val enq: Result[bool, str] = lower.enqueue_instance(ctx, sym.decl, sym.origin, args, argc, link);
     deallocate[ty.TypeId](ctx.s.alloc, args, argc::usize);
+    if (is_err[bool, str](enq)) { ret err[value.Value, str](unwrap_err[bool, str](enq)); }
+
+    val vtr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);
+    if (is_err[ir_type.IrTypeId, str](vtr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](vtr)); }
+    val vty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](vtr);
+
+    val fi: Option[u32] = find_function(ctx, link);
+    if (is_some[u32](fi)) {
+        ret ok[value.Value, str](value.fn_value(unwrap[u32](fi), vty));
+    }
+    val xr: Result[u32, str] = lower.ensure_extern_function(ctx, link, vty);
+    if (is_err[u32, str](xr)) { ret err[value.Value, str](unwrap_err[u32, str](xr)); }
+    ret ok[value.Value, str](value.fn_value(unwrap_ok[u32, str](xr), vty));
+}
+
+# resolves a pack-tailed call to its monomorphized instance (#1475): reads the
+# trailing arguments' concrete types — the collected pack element type-list,
+# substituting any enclosing generic substitution so a transitive pack call
+# resolves element types to the concrete args — computes the instance's mangled
+# linkage name under the disjoint `Q...E` pack namespace, enqueues the instance for
+# body emission, and returns a function reference to it. the leading fixed
+# arguments and the collected elements are all passed at runtime (the instance's
+# expanded signature), so no argument is dropped here; the back end emits a
+# name-based call the linker binds to the (weak, deduped) instance body.
+fun lower_pack_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr, f: *adecl.DeclFun) Result[value.Value, str] {
+    val sid: resolve.SymbolId = lower.expr_symbol_of(ctx, e.data.call.callee);
+    val so: Option[*resolve.Symbol] = lower.symbol_of(ctx, sid);
+    if (is_none[*resolve.Symbol](so)) {
+        ret err[value.Value, str]("lower: unresolved pack-tailed call target");
+    }
+    val sym: *resolve.Symbol = unwrap[*resolve.Symbol](so);
+
+    # the pack is the trailing parameter; every argument past the leading fixed
+    # parameters is a collected pack element.
+    val fixed_count: u32 = f.params_len - 1;
+    if (e.data.call.args_len < fixed_count) {
+        ret err[value.Value, str]("lower: pack-tailed call has fewer arguments than fixed parameters");
+    }
+    val elem_count: u32 = e.data.call.args_len - fixed_count;
+
+    var types: *ty.TypeId = nil;
+    if (elem_count > 0) {
+        val ab: Result[*ty.TypeId, str] = allocate[ty.TypeId](ctx.s.alloc, elem_count::usize);
+        if (is_err[*ty.TypeId, str](ab)) { ret err[value.Value, str](unwrap_err[*ty.TypeId, str](ab)); }
+        types = unwrap_ok[*ty.TypeId, str](ab);
+
+        var j: u32 = 0;
+        for (j < elem_count) {
+            val pool_ix: u32 = e.data.call.args_start + fixed_count + j;
+            if (pool_ix::usize >= ctx.a.expr_id_len) {
+                deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize);
+                ret err[value.Value, str]("lower: pack-tailed call argument index out of range");
+            }
+            val arg_eid: aid.ExprId = ctx.a.expr_ids[pool_ix];
+            var et: ty.TypeId = lower.expr_type_of(ctx, arg_eid);
+            if (ctx.subst != nil && ctx.subst_len > 0) {
+                et = generics.substitute(ctx.s, et, ctx.subst, ctx.subst_len);
+            }
+            types[j] = et;
+            j = j + 1;
+        }
+    }
+
+    # the instance is owned by the function's origin module; mangle against that
+    # module's FQN so the definition (emitted by the drain) and every reference
+    # agree byte-for-byte.
+    val fqn: intern.StrId = sess.module_fqn(ctx.s, sym.origin);
+    val name_r: Result[intern.StrId, str] = mangle.pack_instance_name(ctx.s, fqn, sym.name, types, elem_count);
+    if (is_err[intern.StrId, str](name_r)) {
+        if (types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
+        ret err[value.Value, str](unwrap_err[intern.StrId, str](name_r));
+    }
+    val link: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+    val enq: Result[bool, str] = lower.enqueue_pack_instance(ctx, sym.decl, sym.origin, types, elem_count, link);
+    if (types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
     if (is_err[bool, str](enq)) { ret err[value.Value, str](unwrap_err[bool, str](enq)); }
 
     val vtr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -82,6 +82,7 @@ pub fun lower_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.Val
     if (k == aexpr.EXPR_KIND_LIT_NIL)        { ret lower_lit_nil(ctx, eid); }
     if (k == aexpr.EXPR_KIND_IDENT)          { ret lower_ident_rvalue(ctx, eid); }
     if (k == aexpr.EXPR_KIND_MEMBER)         { ret lower_member_rvalue(ctx, eid, e); }
+    if (k == aexpr.EXPR_KIND_PROJECT)        { ret lower_project_rvalue(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_INDEX)          { ret lower_index_rvalue(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_CALL)           { ret lower_call(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_BINARY)         { ret lower_binary(ctx, eid, e); }
@@ -111,6 +112,7 @@ pub fun lower_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.Val
 
     if (k == aexpr.EXPR_KIND_IDENT)  { ret lower_ident_lvalue(ctx, eid); }
     if (k == aexpr.EXPR_KIND_MEMBER) { ret lower_member_lvalue(ctx, eid, e); }
+    if (k == aexpr.EXPR_KIND_PROJECT) { ret lower_project_lvalue(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_INDEX)  { ret lower_index_lvalue(ctx, eid, e); }
     if (k == aexpr.EXPR_KIND_UNARY) {
         # @p as an lvalue is the rvalue of p (already a pointer)
@@ -608,6 +610,77 @@ fun lower_member_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Exp
     }
 
     val field_ix: u32 = field_index_in_type(ctx, rec_ty, e.data.member.name);
+
+    val rec_ir_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, rec_ty);
+    if (is_err[ir_type.IrTypeId, str](rec_ir_r)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](rec_ir_r)); }
+    val rec_ir: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](rec_ir_r);
+
+    val xr: Result[ir_type.IrTypeId, str] = index_type(ctx);
+    if (is_err[ir_type.IrTypeId, str](xr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](xr)); }
+    val xty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](xr);
+
+    var idx: [2]value.Value;
+    idx[0] = value.const_int(0, xty);
+    idx[1] = value.const_int(field_ix::u64, xty);
+    ret builder.emit_gep(?ctx.builder, base, rec_ir, ?idx[0], 2);
+}
+
+# project_field_index: the field ordinal a `v.[f]` projection names, read from the
+# comptime FIELD descriptor its field operand evaluates to (bound by an enclosing
+# `$each`). errors when the operand is not a field descriptor.
+fun project_field_index(ctx: *lower.LowerContext, field_eid: aid.ExprId) Result[u32, str] {
+    val fr: Result[comptime.CTValue, str] =
+        comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), field_eid, ?ctx.s.interner);
+    if (is_err[comptime.CTValue, str](fr)) { ret err[u32, str](unwrap_err[comptime.CTValue, str](fr)); }
+    val fv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](fr);
+    if (fv.kind != comptime.CT_KIND_FIELD) {
+        ret err[u32, str]("lower: `v.[f]` field operand is not a comptime field descriptor");
+    }
+    ret ok[u32, str](fv.data.fld.index);
+}
+
+# a `v.[f]` rvalue: a load from the projected field pointer, except for an
+# aggregate field whose rvalue is its storage address (mirrors lower_member_rvalue).
+fun lower_project_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
+    val ptr_r: Result[value.Value, str] = lower_project_lvalue(ctx, eid, e);
+    if (is_err[value.Value, str](ptr_r)) { ret ptr_r; }
+    val tr: Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
+    if (is_err[ir_type.IrTypeId, str](tr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](tr)); }
+    val ity: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+    if (is_aggregate_ir(ctx, ity)) { ret ok[value.Value, str](value.retype(unwrap_ok[value.Value, str](ptr_r), ity)); }
+    ret builder.emit_load(?ctx.builder, unwrap_ok[value.Value, str](ptr_r), ity);
+}
+
+# computes the field pointer of a `v.[f]` projection: like a member access, but
+# the field index comes from the comptime field descriptor rather than a name. a
+# pointer receiver auto-derefs; a value receiver uses its own storage.
+fun lower_project_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
+    val fix_r: Result[u32, str] = project_field_index(ctx, e.data.project.field);
+    if (is_err[u32, str](fix_r)) { ret err[value.Value, str](unwrap_err[u32, str](fix_r)); }
+    val field_ix: u32 = unwrap_ok[u32, str](fix_r);
+
+    val obj_ty: ty.TypeId = lower.expr_type_of(ctx, e.data.project.object);
+    val is_ptr: bool = is_pointer_type(ctx, obj_ty);
+
+    var rec_ty: ty.TypeId = obj_ty;
+    var base:   value.Value;
+    if (is_ptr) {
+        val pt_opt: Option[*ty.Type] = ty.get(?ctx.s.types, obj_ty);
+        if (is_none[*ty.Type](pt_opt)) { ret err[value.Value, str]("lower: projection base has no pointer type"); }
+        val pt: *ty.Type = unwrap[*ty.Type](pt_opt);
+        if (pt.kind != ty.TYPE_POINTER) {
+            ret report_expr(ctx, eid, "field projection on untyped pointer; cast to a typed pointer (*T) first");
+        }
+        rec_ty = pt.data.pointer.base;
+        val br: Result[value.Value, str] = lower_rvalue(ctx, e.data.project.object);
+        if (is_err[value.Value, str](br)) { ret br; }
+        base = unwrap_ok[value.Value, str](br);
+    }
+    or {
+        val br: Result[value.Value, str] = lower_lvalue(ctx, e.data.project.object);
+        if (is_err[value.Value, str](br)) { ret br; }
+        base = unwrap_ok[value.Value, str](br);
+    }
 
     val rec_ir_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, rec_ty);
     if (is_err[ir_type.IrTypeId, str](rec_ir_r)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](rec_ir_r)); }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -540,7 +540,30 @@ fun lower_ident_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.V
 # field whose rvalue is its storage address (a nested struct / array field is
 # left as a pointer the back end consumes at use sites; see
 # lower_ident_rvalue).
+# folds a `$each` field-descriptor member (`f.offset`, #1473) to a constant. none
+# when the object is not a field descriptor (an ordinary `value.field` access).
+fun try_lower_field_member(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Option[Result[value.Value, str]] {
+    val src: str = lower.module_source(ctx);
+    val obj_r: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, src, e.data.member.object, ?ctx.s.interner);
+    if (is_err[comptime.CTValue, str](obj_r)) { ret none[Result[value.Value, str]](); }
+    if (unwrap_ok[comptime.CTValue, str](obj_r).kind != comptime.CT_KIND_FIELD) { ret none[Result[value.Value, str]](); }
+
+    val mr: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, src, eid, ?ctx.s.interner);
+    if (is_err[comptime.CTValue, str](mr)) { ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[comptime.CTValue, str](mr))); }
+    val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](mr);
+    if (v.kind == comptime.CT_KIND_INT) {
+        val rt_r: Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
+        if (is_err[ir_type.IrTypeId, str](rt_r)) { ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](rt_r))); }
+        ret some[Result[value.Value, str]](ok[value.Value, str](value.const_int(v.data.i:~u64, unwrap_ok[ir_type.IrTypeId, str](rt_r))));
+    }
+    ret some[Result[value.Value, str]](err[value.Value, str]("lower: unsupported field descriptor member in value position"));
+}
+
 fun lower_member_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
+    # a `$each` field-descriptor member (`f.offset`) folds to a constant (#1473).
+    val fdm: Option[Result[value.Value, str]] = try_lower_field_member(ctx, eid, e);
+    if (is_some[Result[value.Value, str]](fdm)) { ret unwrap[Result[value.Value, str]](fdm); }
+
     # a module-qualified reference (`alias.name`, where `alias` is a `use`
     # binding) is recorded by resolve as a symbol on the member expression
     # itself; it denotes the imported value, not a field of a record. lower it

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -357,6 +357,41 @@ fun load_pack_elem(ctx: *lower.LowerContext, eid: aid.ExprId, i: u32) Result[val
     ret builder.emit_load(?ctx.builder, slot, ity);
 }
 
+# is_spread_expr: true when `eid` is a `va...` pack spread expression (#1474/#1475).
+fun is_spread_expr(ctx: *lower.LowerContext, eid: aid.ExprId) bool {
+    val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
+    if (is_none[*aexpr.Expr](e_opt)) { ret false; }
+    ret unwrap[*aexpr.Expr](e_opt).kind == aexpr.EXPR_KIND_SPREAD;
+}
+
+# call_has_spread: true when call expression `e` has any `va...` spread argument.
+fun call_has_spread(ctx: *lower.LowerContext, e: *aexpr.Expr) bool {
+    var i: u32 = 0;
+    for (i < e.data.call.args_len) {
+        val pool_ix: u32 = e.data.call.args_start + i;
+        if (pool_ix::usize >= ctx.a.expr_id_len) { ret false; }
+        if (is_spread_expr(ctx, ctx.a.expr_ids[pool_ix])) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# load_pack_slot: rvalue of pack slot `k` — typed from `ctx.pack_types[k]` rather
+# than an expr's sema type. used when splicing the whole pack into a `va...` forward.
+# aggregates flow by storage address tagged with the aggregate IR type, mirroring
+# load_pack_elem.
+fun load_pack_slot(ctx: *lower.LowerContext, k: u32) Result[value.Value, str] {
+    if (ctx.pack_slots == nil || k >= ctx.pack_len) {
+        ret err[value.Value, str]("lower: pack slot index out of range");
+    }
+    val slot: value.Value = ctx.pack_slots[k];
+    val ir_r: Result[ir_type.IrTypeId, str] = lower.lower_type(ctx, ctx.pack_types[k]);
+    if (is_err[ir_type.IrTypeId, str](ir_r)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](ir_r)); }
+    val ity: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](ir_r);
+    if (is_aggregate_ir(ctx, ity)) { ret ok[value.Value, str](value.retype(slot, ity)); }
+    ret builder.emit_load(?ctx.builder, slot, ity);
+}
+
 # the folded comptime value of a symbol, when it is a comptime value parameter
 # (SYM_PARAM with SYM_FLAG_COMPTIME) currently bound in the comptime context by a
 # value-instance drain. none for any other symbol, or when not in a value-instance
@@ -1144,7 +1179,10 @@ fun lower_call(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result
 
     val argc: u32 = e.data.call.args_len;
     var rtc: u32 = argc;
+    val has_spread: bool = call_has_spread(ctx, e);
     if (has_ct) { rtc = runtime_arg_count(ctx, cf_ast, cf_decl, argc); }
+    # a va... spread replaces one spread arg with ctx.pack_len concrete slot args.
+    if (has_spread) { rtc = (argc - 1) + ctx.pack_len; }
 
     var args: *value.Value = nil;
     if (rtc > 0) {
@@ -1162,6 +1200,22 @@ fun lower_call(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result
                 ret err[value.Value, str]("lower: call argument index out of range");
             }
             val arg_eid: aid.ExprId = ctx.a.expr_ids[pool_ix];
+            # va... spread: splice the current pack's N concrete slots into the arg list.
+            if (has_spread && is_spread_expr(ctx, arg_eid)) {
+                var k: u32 = 0;
+                for (k < ctx.pack_len) {
+                    val sr: Result[value.Value, str] = load_pack_slot(ctx, k);
+                    if (is_err[value.Value, str](sr)) {
+                        deallocate[value.Value](ctx.s.alloc, args, rtc::usize);
+                        ret sr;
+                    }
+                    args[w] = unwrap_ok[value.Value, str](sr);
+                    w = w + 1;
+                    k = k + 1;
+                }
+                i = i + 1;
+                cnt;
+            }
             val vr: Result[value.Value, str] = lower_rvalue(ctx, arg_eid);
             if (is_err[value.Value, str](vr)) {
                 deallocate[value.Value](ctx.s.alloc, args, rtc::usize);
@@ -1528,15 +1582,14 @@ fun lower_generic_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Ex
     ret ok[value.Value, str](value.fn_value(unwrap_ok[u32, str](xr), vty));
 }
 
-# resolves a pack-tailed call to its monomorphized instance (#1475): reads the
-# trailing arguments' concrete types — the collected pack element type-list,
-# substituting any enclosing generic substitution so a transitive pack call
-# resolves element types to the concrete args — computes the instance's mangled
-# linkage name under the disjoint `Q...E` pack namespace, enqueues the instance for
-# body emission, and returns a function reference to it. the leading fixed
-# arguments and the collected elements are all passed at runtime (the instance's
-# expanded signature), so no argument is dropped here; the back end emits a
-# name-based call the linker binds to the (weak, deduped) instance body.
+# resolves a pack-tailed call to its monomorphized instance (#1475). two paths:
+#   - `va...` spread: the call is a forward of the current pack instance; the
+#     type-list is borrowed from ctx.pack_types (enqueue copies it).
+#   - collected: the type-list is gathered from the trailing call-site arguments,
+#     with any enclosing generic substitution applied.
+# in both cases the instance's mangled linkage name is computed under the disjoint
+# `Q...E` pack namespace, the instance is enqueued for body emission, and a
+# function reference to it is returned. all arguments are passed at runtime.
 fun lower_pack_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr, f: *adecl.DeclFun) Result[value.Value, str] {
     val sid: resolve.SymbolId = lower.expr_symbol_of(ctx, e.data.call.callee);
     val so: Option[*resolve.Symbol] = lower.symbol_of(ctx, sid);
@@ -1548,31 +1601,41 @@ fun lower_pack_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr,
     # the pack is the trailing parameter; every argument past the leading fixed
     # parameters is a collected pack element.
     val fixed_count: u32 = f.params_len - 1;
-    if (e.data.call.args_len < fixed_count) {
-        ret err[value.Value, str]("lower: pack-tailed call has fewer arguments than fixed parameters");
-    }
-    val elem_count: u32 = e.data.call.args_len - fixed_count;
-
+    var elem_count: u32 = 0;
     var types: *ty.TypeId = nil;
-    if (elem_count > 0) {
-        val ab: Result[*ty.TypeId, str] = allocate[ty.TypeId](ctx.s.alloc, elem_count::usize);
-        if (is_err[*ty.TypeId, str](ab)) { ret err[value.Value, str](unwrap_err[*ty.TypeId, str](ab)); }
-        types = unwrap_ok[*ty.TypeId, str](ab);
+    var owns_types: bool = false;
 
-        var j: u32 = 0;
-        for (j < elem_count) {
-            val pool_ix: u32 = e.data.call.args_start + fixed_count + j;
-            if (pool_ix::usize >= ctx.a.expr_id_len) {
-                deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize);
-                ret err[value.Value, str]("lower: pack-tailed call argument index out of range");
+    if (call_has_spread(ctx, e)) {
+        # va... forward: borrow the current instance's type-list directly; enqueue
+        # copies it, so we must not free it after enqueueing.
+        elem_count = ctx.pack_len;
+        types = ctx.pack_types;
+    } or {
+        if (e.data.call.args_len < fixed_count) {
+            ret err[value.Value, str]("lower: pack-tailed call has fewer arguments than fixed parameters");
+        }
+        elem_count = e.data.call.args_len - fixed_count;
+        if (elem_count > 0) {
+            val ab: Result[*ty.TypeId, str] = allocate[ty.TypeId](ctx.s.alloc, elem_count::usize);
+            if (is_err[*ty.TypeId, str](ab)) { ret err[value.Value, str](unwrap_err[*ty.TypeId, str](ab)); }
+            types = unwrap_ok[*ty.TypeId, str](ab);
+            owns_types = true;
+
+            var j: u32 = 0;
+            for (j < elem_count) {
+                val pool_ix: u32 = e.data.call.args_start + fixed_count + j;
+                if (pool_ix::usize >= ctx.a.expr_id_len) {
+                    deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize);
+                    ret err[value.Value, str]("lower: pack-tailed call argument index out of range");
+                }
+                val arg_eid: aid.ExprId = ctx.a.expr_ids[pool_ix];
+                var et: ty.TypeId = lower.expr_type_of(ctx, arg_eid);
+                if (ctx.subst != nil && ctx.subst_len > 0) {
+                    et = generics.substitute(ctx.s, et, ctx.subst, ctx.subst_len);
+                }
+                types[j] = et;
+                j = j + 1;
             }
-            val arg_eid: aid.ExprId = ctx.a.expr_ids[pool_ix];
-            var et: ty.TypeId = lower.expr_type_of(ctx, arg_eid);
-            if (ctx.subst != nil && ctx.subst_len > 0) {
-                et = generics.substitute(ctx.s, et, ctx.subst, ctx.subst_len);
-            }
-            types[j] = et;
-            j = j + 1;
         }
     }
 
@@ -1582,13 +1645,13 @@ fun lower_pack_callee(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr,
     val fqn: intern.StrId = sess.module_fqn(ctx.s, sym.origin);
     val name_r: Result[intern.StrId, str] = mangle.pack_instance_name(ctx.s, fqn, sym.name, types, elem_count);
     if (is_err[intern.StrId, str](name_r)) {
-        if (types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
+        if (owns_types && types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
         ret err[value.Value, str](unwrap_err[intern.StrId, str](name_r));
     }
     val link: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
 
     val enq: Result[bool, str] = lower.enqueue_pack_instance(ctx, sym.decl, sym.origin, types, elem_count, link);
-    if (types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
+    if (owns_types && types != nil) { deallocate[ty.TypeId](ctx.s.alloc, types, elem_count::usize); }
     if (is_err[bool, str](enq)) { ret err[value.Value, str](unwrap_err[bool, str](enq)); }
 
     val vtr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -614,7 +614,32 @@ fun try_lower_field_member(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.
     ret some[Result[value.Value, str]](err[value.Value, str]("lower: unsupported field descriptor member in value position"));
 }
 
+# try_lower_pack_len: folds `va.len` to the current pack instance's element count
+# (#1475) when the member's receiver is a comptime variadic pack, or none when it
+# is not (an ordinary record/module member). the count is a compile-time constant
+# fixed by the call site (`ctx.pack_len`), emitted at the member expression's
+# lowered type (sema types `va.len` as `u64`).
+fun try_lower_pack_len(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Option[Result[value.Value, str]] {
+    val obj_ty: ty.TypeId = lower.expr_type_of(ctx, e.data.member.object);
+    val to: Option[*ty.Type] = ty.get(?ctx.s.types, obj_ty);
+    if (is_none[*ty.Type](to)) { ret none[Result[value.Value, str]](); }
+    if (unwrap[*ty.Type](to).kind != ty.TYPE_PACK) { ret none[Result[value.Value, str]](); }
+
+    val tr: Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
+    if (is_err[ir_type.IrTypeId, str](tr)) {
+        ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](tr)));
+    }
+    val ity: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](tr);
+    ret some[Result[value.Value, str]](ok[value.Value, str](value.const_int(ctx.pack_len::u64, ity)));
+}
+
 fun lower_member_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
+    # `va.len` on a comptime variadic pack (#1475): folds to the instance's element
+    # count, a compile-time constant fixed by the call site. sema already validated
+    # that `.len` is the pack's only member, so a pack receiver here is `.len`.
+    val pl: Option[Result[value.Value, str]] = try_lower_pack_len(ctx, eid, e);
+    if (is_some[Result[value.Value, str]](pl)) { ret unwrap[Result[value.Value, str]](pl); }
+
     # a `$each` field-descriptor member (`f.offset`) folds to a constant (#1473).
     val fdm: Option[Result[value.Value, str]] = try_lower_field_member(ctx, eid, e);
     if (is_some[Result[value.Value, str]](fdm)) { ret unwrap[Result[value.Value, str]](fdm); }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -556,6 +556,18 @@ fun try_lower_field_member(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.
         if (is_err[ir_type.IrTypeId, str](rt_r)) { ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](rt_r))); }
         ret some[Result[value.Value, str]](ok[value.Value, str](value.const_int(v.data.i:~u64, unwrap_ok[ir_type.IrTypeId, str](rt_r))));
     }
+    if (v.kind == comptime.CT_KIND_STR) {
+        # materialize the field name as an anonymous rodata string and yield a
+        # pointer to it, exactly like a string literal (`lower_lit_str`).
+        val pr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);
+        if (is_err[ir_type.IrTypeId, str](pr)) { ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](pr))); }
+        val pty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](pr);
+        val bytes_opt: Option[str] = intern.lookup(?ctx.s.interner, v.data.s);
+        if (is_none[str](bytes_opt)) { ret some[Result[value.Value, str]](err[value.Value, str]("lower: field name lookup failed")); }
+        val bytes: str = unwrap[str](bytes_opt);
+        val blob: value.Value = value.const_bytes(bytes::*u8, (str_len(bytes) + 1::usize)::u32, pty);
+        ret some[Result[value.Value, str]](lower.add_rodata_bytes(ctx, blob, pty));
+    }
     ret some[Result[value.Value, str]](err[value.Value, str]("lower: unsupported field descriptor member in value position"));
 }
 

--- a/src/lang/me/lower/mangle.mach
+++ b/src/lang/me/lower/mangle.mach
@@ -168,6 +168,78 @@ pub fun value_instance_name(
     ret r;
 }
 
+# pack_instance_name: the linkage name of a comptime variadic-pack instance: the
+# mangled base name with its pack element type-list encoded into a `Q...E` suffix,
+# so distinct type-lists (e.g. `sum(i64,i64)` vs `sum(f64)`) name distinct symbols.
+# the `Q` pack namespace is disjoint from the type-argument `I...E` and the value
+# `K...E` namespaces, so a pack instance can never collide with a type or value
+# instance (which would silently merge two different WEAK bodies). element types
+# encode through the same injective `write_encoded_type` the generic `I...E` suffix
+# uses. an instance is never exempted, so no export hook.
+# ---
+# s:        shared session (interner, type universe)
+# fqn:      FQN StrId of the function's defining (origin) module
+# bare:     function's source identifier StrId
+# types:    pointer to the pack element type-list
+# type_len: number of pack element types (must be > 0)
+# ret:      the pack-instance linkage-name StrId, or an allocation error
+pub fun pack_instance_name(
+    s:        *sess.Session,
+    fqn:      intern.StrId,
+    bare:     intern.StrId,
+    types:    *ty.TypeId,
+    type_len: u32
+) Result[intern.StrId, str] {
+    val path_opt: Option[str] = intern.lookup(?s.interner, fqn);
+    var path: str = "main";
+    if (is_some[str](path_opt)) {
+        val p: str = unwrap[str](path_opt);
+        if (str_len(p) > 0) { path = p; }
+    }
+
+    val name_opt: Option[str] = intern.lookup(?s.interner, bare);
+    if (is_none[str](name_opt)) { ret err[intern.StrId, str]("mangle: bare name not interned"); }
+    val name: str = unwrap[str](name_opt);
+
+    # byte length of the `Q<enc(type)...>E` pack type-list suffix. the `N<len>`
+    # prefix counts the bare name plus this suffix.
+    var suffix_len: usize = 2;
+    var si: u32 = 0;
+    for (si < type_len) {
+        suffix_len = suffix_len + encoded_type_len(s, types[si]);
+        si = si + 1;
+    }
+    val name_len: usize = str_len(name) + suffix_len;
+
+    var total: usize = 2;
+    total = total + encoded_path_len(path);
+    total = total + 1;
+    total = total + decimal_len(name_len) + name_len;
+
+    val buf_r: Result[*u8, str] = allocate[u8](s.alloc, total);
+    if (is_err[*u8, str](buf_r)) { ret err[intern.StrId, str](unwrap_err[*u8, str](buf_r)); }
+    val buf: *u8 = unwrap_ok[*u8, str](buf_r);
+
+    var k: usize = 0;
+    buf[k] = '_'; k = k + 1;
+    buf[k] = 'M'; k = k + 1;
+    k = write_encoded_path(buf, k, path);
+    buf[k] = 'N'; k = k + 1;
+    k = write_decimal(buf, k, name_len);
+    k = write_str(buf, k, name);
+    buf[k] = 'Q'; k = k + 1;
+    var ai: u32 = 0;
+    for (ai < type_len) {
+        k = write_encoded_type(s, buf, k, types[ai]);
+        ai = ai + 1;
+    }
+    buf[k] = 'E'; k = k + 1;
+
+    val r: Result[intern.StrId, str] = intern.intern_bytes(?s.interner, buf::str, k);
+    deallocate[u8](s.alloc, buf, total);
+    ret r;
+}
+
 # encoded_value_len / write_encoded_value: an injective encoding of one folded
 # comptime value into the value-instance name. distinct values map to distinct
 # byte sequences (a kind tag plus a self-delimiting, length-prefixed payload), so

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -654,6 +654,14 @@ fun lower_pack_each(ctx: *lower.LowerContext, ce: *astmt.StmtComptimeEach) Resul
     if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
     val fname: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
 
+    # one typing-snapshot set spanning every module, so the per-element body
+    # re-inference can resolve cross-module references the pack body makes (a call
+    # to a function in another module needs that module's signature types). built
+    # once here and shared across the element iterations.
+    val deps_r: Result[sema.SemaDeps, str] = sema.collect_module_deps(ctx.s);
+    if (is_err[sema.SemaDeps, str](deps_r)) { ret err[bool, str](unwrap_err[sema.SemaDeps, str](deps_r)); }
+    var deps: sema.SemaDeps = unwrap_ok[sema.SemaDeps, str](deps_r);
+
     var i: u32 = 0;
     for (i < ctx.pack_len) {
         val mark: comptime.FrameMark = comptime.frame_open(ctx.ctx);
@@ -661,26 +669,29 @@ fun lower_pack_each(ctx: *lower.LowerContext, ce: *astmt.StmtComptimeEach) Resul
         val br: Result[bool, str] = comptime.bind(ctx.ctx, fname, desc);
         if (is_err[bool, str](br)) {
             val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            sema.free_module_deps(ctx.s, ?deps);
             if (is_err[bool, str](cc)) { ret cc; }
             ret br;
         }
 
         # re-type the body for this element (its type is fixed only here), writing
         # the body expressions' types into the shared array lowering reads next.
-        val ir: Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, nil, ctx.ctx,
+        val ir: Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, ?deps, ctx.ctx,
             ctx.own_module, ctx.sema_result, ctx.pack_ret_ty, ce.body_start, ce.body_len);
         if (is_err[bool, str](ir)) {
             val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            sema.free_module_deps(ctx.s, ?deps);
             if (is_err[bool, str](cc)) { ret cc; }
             ret ir;
         }
 
         val rb: Result[bool, str] = lower_stmt_list(ctx, ce.body_start, ce.body_len);
         val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
-        if (is_err[bool, str](rb)) { ret rb; }
-        if (is_err[bool, str](cc)) { ret cc; }
+        if (is_err[bool, str](rb)) { sema.free_module_deps(ctx.s, ?deps); ret rb; }
+        if (is_err[bool, str](cc)) { sema.free_module_deps(ctx.s, ?deps); ret cc; }
         i = i + 1;
     }
+    sema.free_module_deps(ctx.s, ?deps);
     ret ok[bool, str](true);
 }
 

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -54,6 +54,8 @@ use builder:  mach.lang.me.ir.builder;
 
 use map: std.collections.map;
 
+use sema:  mach.lang.fe.sema;
+
 use lower: mach.lang.me.lower.context;
 use expr:  mach.lang.me.lower.expr;
 
@@ -599,8 +601,16 @@ fun lower_comptime_if(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str
 fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] {
     val ce: *astmt.StmtComptimeEach = ?s.data.comptime_each;
     val src: str = lower.module_source(ctx);
+
+    # a pack `$each a in va` (#1475): the sequence is a variadic-pack value (not a
+    # `$fields(T)` call), so unroll over the pack instance's expanded elements —
+    # re-typing then lowering the body per element, the loop variable bound to each.
+    if (is_pack_type(ctx, lower.expr_type_of(ctx, ce.seq))) {
+        ret lower_pack_each(ctx, ce);
+    }
+
     if (!comptime.is_fields_call(ctx.a, src, ce.seq)) {
-        ret err[bool, str]("lower: a `$each` sequence must be `$fields(T)`");
+        ret err[bool, str]("lower: a `$each` sequence must be `$fields(T)` or a variadic pack");
     }
     val targ: aid.ExprId = comptime.fields_type_arg(ctx.a, ce.seq);
     if (targ == aid.EXPR_NIL) { ret err[bool, str]("lower: `$fields` is missing its type argument"); }
@@ -627,6 +637,59 @@ fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, s
         i = i + 1;
     }
     ret ok[bool, str](true);
+}
+
+# lowers a pack `$each a in va { body }` (#1475) by unrolling it over the pack
+# instance's expanded elements (lower_pack_instance recorded the element slots and
+# types on the context). per element: the loop variable is bound in the comptime
+# frame to the element's descriptor — carrying the element's type (so the body
+# re-infers the loop variable to it) and its ordinal (so a body reference loads the
+# matching expanded parameter slot) — then the body is re-typed for that element
+# and lowered. typing and lowering interleave per element because a pack element's
+# type is fixed only at the call site; the body was deferred at the original sema
+# pass. the re-traverse-no-clone model mirrors the `$fields` unroll.
+fun lower_pack_each(ctx: *lower.LowerContext, ce: *astmt.StmtComptimeEach) Result[bool, str] {
+    val src: str = lower.module_source(ctx);
+    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, src, ce.var_name);
+    if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
+    val fname: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+    var i: u32 = 0;
+    for (i < ctx.pack_len) {
+        val mark: comptime.FrameMark = comptime.frame_open(ctx.ctx);
+        val desc: comptime.CTValue = comptime.pack_elem_value(i, ctx.pack_types[i]::u32);
+        val br: Result[bool, str] = comptime.bind(ctx.ctx, fname, desc);
+        if (is_err[bool, str](br)) {
+            val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            if (is_err[bool, str](cc)) { ret cc; }
+            ret br;
+        }
+
+        # re-type the body for this element (its type is fixed only here), writing
+        # the body expressions' types into the shared array lowering reads next.
+        val ir: Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, nil, ctx.ctx,
+            ctx.own_module, ctx.sema_result, ctx.pack_ret_ty, ce.body_start, ce.body_len);
+        if (is_err[bool, str](ir)) {
+            val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            if (is_err[bool, str](cc)) { ret cc; }
+            ret ir;
+        }
+
+        val rb: Result[bool, str] = lower_stmt_list(ctx, ce.body_start, ce.body_len);
+        val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+        if (is_err[bool, str](rb)) { ret rb; }
+        if (is_err[bool, str](cc)) { ret cc; }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# true when a semantic type is a comptime variadic pack (TYPE_PACK), the marker
+# that selects the pack unroll over the `$fields` unroll in lower_comptime_each.
+fun is_pack_type(ctx: *lower.LowerContext, t: ty.TypeId) bool {
+    val to: Option[*ty.Type] = ty.get(?ctx.s.types, t);
+    if (is_none[*ty.Type](to)) { ret false; }
+    ret unwrap[*ty.Type](to).kind == ty.TYPE_PACK;
 }
 
 # true when the builder's current block already has a terminator. used to

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -45,6 +45,7 @@ use astmt:    mach.lang.fe.ast.stmt;
 use adecl:    mach.lang.fe.ast.decl;
 use resolve:  mach.lang.fe.resolve;
 use comptime: mach.lang.fe.comptime;
+use ty:       mach.lang.type;
 
 use ir:       mach.lang.me.ir;
 use ir_type:  mach.lang.me.ir.type;
@@ -80,6 +81,7 @@ pub fun lower_stmt(ctx: *lower.LowerContext, sid: aid.StmtId) Result[bool, str] 
     if (k == astmt.STMT_KIND_DECL)        { ret lower_decl_stmt(ctx, s); }
     if (k == astmt.STMT_KIND_ASM)         { ret lower_asm(ctx, s); }
     if (k == astmt.STMT_KIND_COMPTIME_IF) { ret lower_comptime_if(ctx, s); }
+    if (k == astmt.STMT_KIND_COMPTIME_EACH) { ret lower_comptime_each(ctx, s); }
     if (k == astmt.STMT_KIND_ERROR) {
         # an error stmt must never reach lowering: the driver aborts on
         # accumulated diagnostics before the middle end runs.
@@ -584,6 +586,45 @@ fun lower_comptime_if(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str
             ret lower_stmt_list(ctx, branch.body_start, branch.body_len);
         }
         bi = bi + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# lowers a `$each <ident> in $fields(T) { body }` (#1473) by unrolling it: the
+# body is lowered once per field of T, with the loop variable bound in the
+# comptime frame to that field's descriptor, so a `v.[f]` in the body projects
+# the concrete field of each iteration. the lowering half of the splice sema
+# mirrors. the owning type was resolved and recorded on the `$fields(T)` argument
+# by sema.
+fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] {
+    val ce: *astmt.StmtComptimeEach = ?s.data.comptime_each;
+    val src: str = lower.module_source(ctx);
+    if (!comptime.is_fields_call(ctx.a, src, ce.seq)) {
+        ret err[bool, str]("lower: a `$each` sequence must be `$fields(T)`");
+    }
+    val targ: aid.ExprId = comptime.fields_type_arg(ctx.a, ce.seq);
+    if (targ == aid.EXPR_NIL) { ret err[bool, str]("lower: `$fields` is missing its type argument"); }
+    val owner: ty.TypeId = lower.expr_type_of(ctx, targ);
+
+    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, src, ce.var_name);
+    if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
+    val fname: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+    val n: u32 = ty.field_count(?ctx.s.types, owner);
+    var i: u32 = 0;
+    for (i < n) {
+        val mark: comptime.FrameMark = comptime.frame_open(ctx.ctx);
+        val br: Result[bool, str] = comptime.bind(ctx.ctx, fname, comptime.field_value(owner::u32, i));
+        if (is_err[bool, str](br)) {
+            val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            if (is_err[bool, str](cc)) { ret cc; }
+            ret br;
+        }
+        val rb: Result[bool, str] = lower_stmt_list(ctx, ce.body_start, ce.body_len);
+        val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+        if (is_err[bool, str](rb)) { ret rb; }
+        if (is_err[bool, str](cc)) { ret cc; }
+        i = i + 1;
     }
     ret ok[bool, str](true);
 }

--- a/src/lang/me/lower/testrunner.mach
+++ b/src/lang/me/lower/testrunner.mach
@@ -242,6 +242,7 @@ fun append_function(m: *ir.Module, name: intern.StrId, sig: ir_type.IrTypeId, fl
     f.flags       = flags;
     f.label       = intern.STR_NIL;
     f.line        = 0;
+    f.section     = intern.STR_NIL;
     f.asm_blocks  = map.init[irid.InstructionId, ir.IrAsm](m.alloc, maphash.hash_u32, maphash.eq_u32);
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -6,6 +6,7 @@
 
 use std.types.bool.bool;
 use std.types.bool.true;
+use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.result.Result;
@@ -78,6 +79,11 @@ pub rec Session {
     module_resolve:   map.Map[modid.ModuleId, ptr];
     module_comptime:  map.Map[modid.ModuleId, ptr];
     registry:         target.TargetRegistry;
+    # the CLI optimization intent, set before build_project so the comptime ctx
+    # can resolve `$mach.build.mode`: opt_explicit when a `-O*`/`--release` flag
+    # was given (it wins over the manifest), opt_release its release-vs-debug sense.
+    opt_explicit:     bool;
+    opt_release:      bool;
 }
 
 # init: construct an empty Session backed by the given allocator. sub-services
@@ -110,6 +116,8 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
     s.module_resolve   = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
     s.module_comptime  = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
     s.registry         = target.registry_init();
+    s.opt_explicit     = false;
+    s.opt_release      = false;
 
     val r_types: Result[ty.TypeInterner, str] = ty.init(alloc);
     if (is_err[ty.TypeInterner, str](r_types)) {

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -57,6 +57,7 @@ fwd modid.MODULE_NIL;
 # module_fqns:  ModuleId -> the module's fully-qualified path StrId; populated by the driver alongside module_asts, read by the back-end symbol mangler so a cross-module reference can name the defining module's mangled symbol (a reference is keyed on the referent's origin ModuleId, the definition on its own)
 # export_names: `(ModuleId << 32 | DeclId)` -> the literal link-name override declared by a `$<sym>.symbol = "..."` directive (or an `ext fun` foreign symbol); a decl present in this map keeps its literal name rather than being mangled, the sole exemption keeping the program entry, runtime, and foreign symbols linkable against the names written in inline asm
 # export_libraries: `(ModuleId << 32 | DeclId)` -> the dynamic library a `$<sym>.library = "..."` directive pins an `ext` import to (e.g. `"ws2_32.dll"`); consulted by the driver to build `import_libraries` once link names are final
+# type_aligns: nominal TypeId -> the explicit byte alignment an `align(...)` decorator pins a record/union to; folded once by sema (where the decl is visible) and read by the middle end when lowering the nominal to an IR struct so its layout honors the override
 # import_libraries: link symbol name StrId -> the library StrId an import is pinned to; the link-name-keyed projection of `export_libraries` the back-end linker consults to attribute each PE import descriptor to a specific dependency rather than the first one
 # module_sema:    ModuleId -> its `*sema.SemaResult`, stored opaque (as `ptr`) to keep this leaf module free of an import cycle on the front end; the back-end monomorphizer casts it back to lower a generic template body against the typing of the module that declared it
 # module_resolve: ModuleId -> its `*resolve.ResolveResult`, stored opaque like module_sema, so a generic instance body is lowered against the declaring module's name resolution
@@ -74,6 +75,7 @@ pub rec Session {
     module_fqns:      map.Map[modid.ModuleId, intern.StrId];
     export_names:     map.Map[u64, intern.StrId];
     export_libraries: map.Map[u64, intern.StrId];
+    type_aligns:      map.Map[u32, u32];
     import_libraries: map.Map[intern.StrId, intern.StrId];
     module_sema:      map.Map[modid.ModuleId, ptr];
     module_resolve:   map.Map[modid.ModuleId, ptr];
@@ -111,6 +113,7 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
     s.module_fqns      = map.init[modid.ModuleId, intern.StrId](alloc, maphash.hash_u32, maphash.eq_u32);
     s.export_names     = map.init[u64, intern.StrId](alloc, maphash.hash_u64, maphash.eq_u64);
     s.export_libraries = map.init[u64, intern.StrId](alloc, maphash.hash_u64, maphash.eq_u64);
+    s.type_aligns      = map.init[u32, u32](alloc, maphash.hash_u32, maphash.eq_u32);
     s.import_libraries = map.init[intern.StrId, intern.StrId](alloc, maphash.hash_u32, maphash.eq_u32);
     s.module_sema      = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
     s.module_resolve   = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
@@ -185,6 +188,7 @@ pub fun dnit(s: *Session) {
     map.dnit[modid.ModuleId, intern.StrId](?s.module_fqns);
     map.dnit[u64, intern.StrId](?s.export_names);
     map.dnit[u64, intern.StrId](?s.export_libraries);
+    map.dnit[u32, u32](?s.type_aligns);
     map.dnit[intern.StrId, intern.StrId](?s.import_libraries);
     map.dnit[modid.ModuleId, ptr](?s.module_sema);
     map.dnit[modid.ModuleId, ptr](?s.module_resolve);
@@ -224,6 +228,7 @@ pub fun reset_module_registry(s: *Session) {
     map.clear[modid.ModuleId, intern.StrId](?s.module_fqns);
     map.clear[u64, intern.StrId](?s.export_names);
     map.clear[u64, intern.StrId](?s.export_libraries);
+    map.clear[u32, u32](?s.type_aligns);
     map.clear[intern.StrId, intern.StrId](?s.import_libraries);
     map.clear[modid.ModuleId, ptr](?s.module_sema);
     map.clear[modid.ModuleId, ptr](?s.module_resolve);
@@ -361,6 +366,32 @@ pub fun export_library(s: *Session, mid: modid.ModuleId, did: u32) Option[intern
     val r: Result[*intern.StrId, str] = map.get[u64, intern.StrId](?s.export_libraries, ?key);
     if (is_ok[*intern.StrId, str](r)) { ret some[intern.StrId](@unwrap_ok[*intern.StrId, str](r)); }
     ret none[intern.StrId]();
+}
+
+# register_type_align: record the explicit alignment an `align(...)` decorator
+# pins nominal TypeId `tid` to. folded once by sema; the middle end reads it when
+# lowering the nominal so its IR struct carries the override. registering twice
+# overwrites.
+# ---
+# s:     the session
+# tid:   nominal TypeId (a `type.TypeId`, cast to u32)
+# align: the byte alignment (a power of two)
+# ret:   true on success, or an allocation error from the registry map
+pub fun register_type_align(s: *Session, tid: u32, align: u32) Result[bool, str] {
+    ret map.insert[u32, u32](?s.type_aligns, tid, align);
+}
+
+# type_align: the explicit alignment registered for nominal TypeId `tid`, or none
+# when the type uses its natural alignment.
+# ---
+# s:   the session
+# tid: nominal TypeId (cast to u32)
+# ret: some(align) when an override is registered, none otherwise
+pub fun type_align(s: *Session, tid: u32) Option[u32] {
+    var key: u32 = tid;
+    val r: Result[*u32, str] = map.get[u32, u32](?s.type_aligns, ?key);
+    if (is_ok[*u32, str](r)) { ret some[u32](@unwrap_ok[*u32, str](r)); }
+    ret none[u32]();
 }
 
 # register_import_library: pin the import emitted under link name `name` to

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -283,6 +283,16 @@ pub fun module_ast(s: *Session, mid: modid.ModuleId) *ast.Ast {
     ret s.module_asts[mid::u32];
 }
 
+# module_count: the number of registered modules — the dense upper bound on
+# ModuleIds (`0 .. module_count`). lets a phase enumerate every loaded module
+# (e.g. to assemble a typing-snapshot set for cross-module lookups).
+# ---
+# s:   the session
+# ret: the registered module count
+pub fun module_count(s: *Session) u32 {
+    ret s.module_ast_count;
+}
+
 # register_module_fqn: record `fqn` as the fully-qualified path of module `mid`,
 # so the back-end mangler can name a cross-module symbol against its defining
 # module. populated by the driver alongside register_module_ast. registering the

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -79,6 +79,13 @@ pub fun host_pointer_width() u32 {
     ret ($mach.target.pointer_width)::u32;
 }
 
+# host_abi_id: the canonical abi id (abi.ABI_*) for the host os/arch pair, so the
+# editor's neutral comptime context resolves `$mach.target.abi` against the
+# running compiler's own convention rather than a placeholder.
+pub fun host_abi_id() u32 {
+    ret canonical_abi(host_os_id(), host_arch_id());
+}
+
 # canonical_abi: the ABI id paired with an (operating system, architecture) pair.
 # the convention depends on BOTH dimensions: x86-64 uses SysV on Linux/Darwin and
 # Win64 on Windows, while AArch64 uses AAPCS64 everywhere (the Apple/MS variants

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -89,6 +89,10 @@ pub val TYPE_INSTANCE:      TypeKind = 17;
 # lowers to the four-field register-save struct. used by the variadic
 # intrinsics (`va_list` / `va_start` / `va_arg` / `va_end`).
 pub val TYPE_VA_LIST:       TypeKind = 18;
+# a comptime variadic pack (#1474): the type of a `va: ...` parameter. a
+# payload-free singleton — the pack's element types are fixed per call site and
+# supplied by monomorphization (#1475), never carried on the type itself.
+pub val TYPE_PACK:          TypeKind = 19;
 
 val PRIM_COUNT: u32 = 11;
 
@@ -588,6 +592,16 @@ pub fun intern_array(ti: *TypeInterner, base: TypeId, count: u32) Result[TypeId,
 pub fun intern_va_list(ti: *TypeInterner) Result[TypeId, str] {
     var t: Type;
     t.kind = TYPE_VA_LIST;
+    ret intern_dedup(ti, t);
+}
+
+# intern_pack: the comptime variadic pack type (#1474), a payload-free singleton.
+# ---
+# ti:  the interner
+# ret: the TypeId for a `...` pack, or an allocation error
+pub fun intern_pack(ti: *TypeInterner) Result[TypeId, str] {
+    var t: Type;
+    t.kind = TYPE_PACK;
     ret intern_dedup(ti, t);
 }
 


### PR DESCRIPTION
Integration merge of `dev` → `main` for the **v1.7.0 — comptime & variadics** release.

Headline: the comptime + first-class variadics rework (epic #1477).
- **Comptime:** `$type_of`, `$fields`, `v.[f]`, `$each`, type `==` in `$if`; provenance-rooted `$mach.*` / `$project.*` namespaces.
- **Variadic packs:** `va: ...` pack params consumed by `$each`, monomorphized per type-list; `va...` forward; `va.len`; cross-module pack bodies. aarch64 variadics re-enabled.
- **Backtick decorators:** `symbol` / `library` / `inline` / `align` / `section` (codegen-only).
- **Correctly-rounded float-literal folding** (#1483, exact bignum).
- **DECOUPLE seed freeze hardened** (#1486): single-source `mach.lock` pin + content-based seed-safety guard.
- **`mach dep pull` finds git.exe on Windows** (#1506).

Self-host verified byte-identical on dev (stage2==stage3). The seed-vs-stage2 fixpoint differs by design (the precise float folding changes the compiler's own constants); this release re-seeds and clears it.
