### PR TITLE
docs(language): document v1.7 language features

### DIFF
--- a/doc/language/README.md
+++ b/doc/language/README.md
@@ -17,6 +17,7 @@ neighboring links; start from the index below.
 ## Declarations
 
 - [visibility.md](visibility.md) — `pub` and `ext` modifiers
+- [decorators.md](decorators.md) — backtick codegen decorators (`symbol`, `library`, `inline`, `align`, `section`)
 - [def.md](def.md) — type alias
 - [rec.md](rec.md) — record
 - [uni.md](uni.md) — raw union and the discriminated-value convention
@@ -24,6 +25,7 @@ neighboring links; start from the index below.
 - [ext-fun.md](ext-fun.md) — external function
 - [val-var.md](val-var.md) — immutable and mutable bindings
 - [test.md](test.md) — `test` declaration and the `mach test` workflow
+- [variadics.md](variadics.md) — variadic packs (`va: ...`, `$each`, `va.len`, `va...`)
 
 ## Values and types
 
@@ -40,8 +42,8 @@ neighboring links; start from the index below.
 
 - [comptime.md](comptime.md) — channel overview
 - [comptime-mach.md](comptime-mach.md) — `$mach.*` compiler-owned namespace
-- [comptime-attrs.md](comptime-attrs.md) — symbol attributes
-- [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`, `$align_of`, `$offset_of`, `$error`, `$assert`
+- [comptime-attrs.md](comptime-attrs.md) — symbol attributes (see [decorators.md](decorators.md))
+- [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`, `$align_of`, `$offset_of`, `$type_of`, `$fields`, `$each`, `$error`, `$assert`
 - [comptime-control.md](comptime-control.md) — `$if` / `$or`
 
 ## Low-level

--- a/doc/language/comptime-attrs.md
+++ b/doc/language/comptime-attrs.md
@@ -1,63 +1,24 @@
 # Symbol attributes
 
-A symbol attribute is a piece of metadata the developer attaches to a
-declared symbol via a write into the comptime channel. The compiler reads
-attributes during codegen to influence emission (linker names, alignment,
-inlining, etc.).
-
-## Grammar
+In v1.7, symbol attributes are expressed as **backtick decorators** —
+leading, per-declaration codegen directives on the declared symbol. See
+[decorators.md](decorators.md) for the full reference.
 
 ```mach
-$sym.attr = value;          # write
-$sym.attr                   # read
+`symbol("main")`
+fun entry(argc: i64, argv: **u8) i64 { ... }
+
+`library("ws2_32.dll")` `symbol("WSAStartup")`
+ext fun wsa_startup(ver: u16, data: *u8) i32;
+
+`align(64)`
+pub var cache_line: u8 = 0;
 ```
 
-- `sym` must be a symbol declared in the same module.
-- `attr` must be a known attribute name (closed set).
-- The path is flat: exactly one symbol component, one attribute component.
-- Writes are write-once. RHS must be comptime-evaluable.
-
-## Header-form convention
-
-Attribute writes can appear at any point in the source, but by convention
-they go **before** the declaration they target. The compiler resolves
-binding at module scope; lexical order doesn't matter for correctness, but
-the header placement reads as part of the decl.
-
-```mach
-$panic.noreturn = true;
-pub fun panic(msg: *u8) {
-    asm x86_64 { ud2 }
-}
-```
-
-## Known attribute names
-
-| Attribute | Applies to | Value | Purpose | Status |
-|---|---|---|---|---|
-| `.symbol` | functions, vars | `*u8` literal | Linker name override | honored |
-| `.library` | `ext` functions | `*u8` literal | Pin a dynamic import to a dependency DLL (PE) | honored |
-| `.noreturn` | functions | `u8` flag | Function never returns | not yet honored |
-| `.inline` | functions | `u8` flag | Strong hint to inline at call sites | not yet honored |
-| `.align` | vars, records, unions | power-of-two int | Storage / type alignment in bytes | not yet honored |
-| `.section` | functions, vars | `*u8` literal | Linker section name | not yet honored |
-| `.packed` | records, unions | `u8` flag | Disable field padding | not yet honored |
-
-The set is closed. New attributes require a compiler change.
-
-> **Implementation status.** Any well-formed `$sym.attr = value;` write
-> parses, but only `.symbol` and `.library` currently change compiler output
-> (the registered linker name and the PE import descriptor an import is routed
-> to). The remaining attributes are accepted and ignored — record/union layout
-> uses the natural C-style rule regardless of `.align` / `.packed`, and
-> `.noreturn` / `.inline` / `.section` do not yet feed codegen.
-
-Flag attributes take a `u8` (`1` on, `0` off). The stdlib constants `true` /
-`false` (`def bool: u8;` with `true`/`false` = `1`/`0`) are the idiomatic
-spelling when stdlib is in scope; `$panic.noreturn = true;` and
-`$panic.noreturn = 1;` are equivalent.
+The previous `$sym.attr = value;` setter form is deprecated in favor of
+decorators and will be removed in a future release.
 
 ## See also
 
-- [comptime.md](comptime.md) — channel overview
-- [ext-fun.md](ext-fun.md) — common `.symbol` and `.library` use cases
+- [decorators.md](decorators.md) — full decorator reference
+- [ext-fun.md](ext-fun.md) — `ext` imports and `library` / `symbol` use cases

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -22,6 +22,138 @@ pub val POINT_SIZE: i64 = $size_of(Point);
 pub val POINT_X:    i64 = $offset_of(Point, x);
 ```
 
+## Type intrinsic
+
+`$type_of(expr)` produces a comptime type value — the resolved type of its
+argument `expr`. Type values have no runtime representation; they are only
+meaningful as operands in comptime type comparisons.
+
+```mach
+$type_of(expr)          # comptime type value of expr
+```
+
+Type values can be compared with `==` / `!=` inside `$if` conditions:
+
+```mach
+$if ($type_of(arg) == i64) { write_i64(w, arg); }
+$or ($type_of(arg) == str) { write_str(w, arg); }
+$or { $error("unsupported type"); }
+```
+
+A bare type name (e.g. `i64`, `str`, `Point`) is the other valid operand.
+The comparison selects one branch at compile time per monomorphization
+instance — useful for per-element type dispatch inside `$each` bodies.
+
+## Field intrinsic and projection
+
+`$fields(T)` produces a comptime sequence of field descriptors for record or
+union type `T`. Each descriptor carries three readable properties:
+
+| Property   | Type     | Value                                        |
+|------------|----------|----------------------------------------------|
+| `f.name`   | `*u8`    | field name as a NUL-terminated string        |
+| `f.type`   | type val | comptime type value of the field's type      |
+| `f.offset` | integer  | byte offset of the field in `T`'s layout     |
+
+`$fields(T)` is consumed by `$each f in $fields(T)`. Inside the loop body,
+`v.[f]` projects the concrete field off an instance `v` — it is an lvalue
+(readable and writable, including through a pointer receiver).
+
+```mach
+$fields(T)              # comptime field sequence for record/union T
+v.[f]                   # comptime field projection: access the field f on v
+```
+
+```mach
+rec Pair { x: i64; y: i64; }
+
+fun sum(p: Pair) i64 {
+    var total: i64 = 0;
+    $each f in $fields(Pair) {
+        total = total + p.[f];      # p.x on iteration 1, p.y on iteration 2
+    }
+    ret total;
+}
+```
+
+`$each f in $fields(Empty)` expands to nothing when `T` has no fields.
+
+### Heterogeneous fields
+
+Because each `$each` iteration re-types `v.[f]` to the concrete field type,
+heterogeneous records work naturally:
+
+```mach
+rec Mixed { a: i64; b: u8; }
+
+fun total(m: Mixed) i64 {
+    var t: i64 = 0;
+    $each f in $fields(Mixed) {
+        t = t + m.[f]::i64;     # m.a (i64) on iter 1, m.b (u8) cast to i64 on iter 2
+    }
+    ret t;
+}
+```
+
+### Descriptor reads
+
+Field descriptor properties can be read inside the loop body:
+
+```mach
+fun offsum(m: Mixed) i64 {
+    var s: i64 = 0;
+    $each f in $fields(Mixed) {
+        s = s + f.offset::i64;    # 0 + 8 = 8 for Mixed { a: i64; b: u8; }
+    }
+    ret s;
+}
+
+fun count_i64(m: Mixed) i64 {
+    var n: i64 = 0;
+    $each f in $fields(Mixed) {
+        $if (f.type == i64) { n = n + 1; } $or { }
+    }
+    ret n;
+}
+```
+
+Note: if a record has a field literally named `type`, that ordinary field
+access (`v.type`) is unaffected — `v.[f]` projection uses the `$each` loop
+variable, which is always a field descriptor, never a regular member.
+
+### Nested `$each`
+
+`$each` can be nested:
+
+```mach
+fun cross(p: Pair, q: Pair) i64 {
+    var t: i64 = 0;
+    $each f in $fields(Pair) {
+        $each g in $fields(Pair) {
+            t = t + p.[f] * q.[g];
+        }
+    }
+    ret t;
+}
+```
+
+## `$each` — compile-time unroll
+
+`$each` is a statement form that splices its body once per element of a
+comptime sequence. There are two sequence forms:
+
+```mach
+$each f in $fields(T) { ... }    # one iteration per field of T
+$each a in va { ... }            # one iteration per element of pack va
+```
+
+`$each` is valid only in statement scope (inside a function body). It is not
+a loop — the body is duplicated at compile time, not iterated at runtime.
+Enclosing runtime variables (e.g. an index or accumulator) are shared across
+all unrolled copies.
+
+See [variadics.md](variadics.md) for the pack form (`$each a in va`).
+
 ## Diagnostic intrinsics
 
 > **Not yet implemented.** `$error` and `$assert` parse as comptime
@@ -55,3 +187,4 @@ functions with per-arch `asm` bodies. See [policy.md](policy.md).
 
 - [comptime.md](comptime.md) — channel overview
 - [comptime-control.md](comptime-control.md) — `$if` / `$or`
+- [variadics.md](variadics.md) — `$each a in va`, `va: ...`, `va.len`, `va...`

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -62,8 +62,9 @@ to `ext` functions only.
 ext fun wsa_startup(ver: u16, data: *u8) i32;
 ```
 
-- The named DLL must appear in `[target.*].libs` in `mach.toml`. Pinning to
-  an absent library is a link error, never a silent fallback.
+- The named DLL must appear in the manifest's `[os.*].libs` for the target OS
+  (e.g. `[os.windows].libs = ["kernel32.dll", "ws2_32.dll", ...]`). Pinning
+  to an absent library is a link error, never a silent fallback.
 - Without `library`, an unattributed PE import binds to the **first** declared
   dependency. Every import that belongs to a different DLL needs an explicit
   `library` pin.

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -1,0 +1,142 @@
+# Backtick decorators
+
+A decorator is a codegen directive attached to a declaration. It expresses
+metadata that influences how the compiler emits the symbol: its linker name,
+alignment, section placement, inlining, or PE import routing.
+
+Decorators are **codegen-only**. Visibility (`pub` / `ext`) is separate and
+unaffected by decorators.
+
+## Grammar
+
+```
+`symbol("name")`    # linker name override
+`library("dep")`    # PE import routing (ext only)
+`inline`            # force inlining (no arguments)
+`align(expr)`       # alignment; expr is a comptime integer
+`section(".name")`  # place in a named object section
+```
+
+Decorators appear **before** the declaration they target, one per line or
+space-separated on the same line. They attach to the immediately following
+declaration only and do not bleed across declarations.
+
+```mach
+`inline`
+`symbol("big")`
+fun big(a: i64, b: i64) i64 { ... }
+
+`align(64)` `symbol("g_lit64")`
+pub var g_lit64: u8 = 7;
+```
+
+Each directive is wrapped in its own backtick pair: `` `name` `` for a bare
+flag or `` `name(args)` `` for a directive that takes arguments. Arguments are
+comptime expressions.
+
+## Directives
+
+### `symbol(str)` — linker name
+
+Overrides the emitted or imported symbol name. Applies to functions and
+globals.
+
+```mach
+`symbol("main")`
+fun entry(argc: i64, argv: **u8) i64 { ... }
+
+`symbol("write")`
+ext fun libc_write(fd: i64, buf: *u8, n: i64) i64;
+```
+
+Without `symbol`, the compiler mangles the Mach name. `symbol` gives the
+exact name the linker sees.
+
+### `library(str)` — PE import routing
+
+Pins an `ext` import to a specific DLL in the link's dependency set. Applies
+to `ext` functions only.
+
+```mach
+`library("ws2_32.dll")` `symbol("WSAStartup")`
+ext fun wsa_startup(ver: u16, data: *u8) i32;
+```
+
+- The named DLL must appear in `[target.*].libs` in `mach.toml`. Pinning to
+  an absent library is a link error, never a silent fallback.
+- Without `library`, an unattributed PE import binds to the **first** declared
+  dependency. Every import that belongs to a different DLL needs an explicit
+  `library` pin.
+- On ELF (Linux) the loader resolves imports by global search, so `library`
+  has no effect on the emitted binary; the value is still validated against
+  the link's dependency set.
+- `library` composes with `symbol`: the import is emitted under the renamed
+  symbol within the named DLL.
+
+### `inline` — force inlining
+
+Marks a function for inlining at every call site, overriding the compiler's
+size- and use-count heuristics. Applies to functions only; takes no arguments.
+
+```mach
+`inline`
+fun fast_path(x: i64) i64 { ret x * 2; }
+```
+
+### `align(expr)` — alignment override
+
+Sets the alignment of a global variable or a record/union type. `expr` must
+be a comptime integer — either a literal or a comptime expression such as
+`$size_of(T)` or `$align_of(T)`.
+
+```mach
+`align(64)`
+pub var cache_line: u8 = 0;
+
+`align($size_of(Pair))`
+pub var g_cmp: u8 = 0;
+
+`align(32)`
+rec Over { a: u8; }
+```
+
+- On a `var` / `val`, sets the global's section alignment and address
+  alignment.
+- On a `rec` or `uni`, sets the type's own alignment, which is then inherited
+  by any global of that type.
+- `align` does not apply to `def` aliases (transparent, no layout of their
+  own).
+
+### `section(str)` — object section placement
+
+Places a function or global variable in a named section instead of the
+default `.text` / `.data`.
+
+```mach
+`section(".hottext")` `symbol("f_hot")`
+fun f_hot(x: i64) i64 { ret x + 1; }
+
+`section(".machsec")` `symbol("g_sec")`
+pub var g_sec: u64 = 100;
+```
+
+The named section is created if absent. Cross-section calls and accesses use
+ordinary relocations.
+
+## Applicability
+
+| Directive  | `fun` | `ext fun` | `val` / `var` | `rec` / `uni` |
+|------------|:-----:|:---------:|:-------------:|:-------------:|
+| `symbol`   |  yes  |    yes    |      yes      |      no       |
+| `library`  |  no   |    yes    |      no       |      no       |
+| `inline`   |  yes  |    no     |      no       |      no       |
+| `align`    |  no   |    no     |      yes      |      yes      |
+| `section`  |  yes  |    yes    |      yes      |      no       |
+
+The set is closed. New directives require a compiler change.
+
+## See also
+
+- [ext-fun.md](ext-fun.md) — `ext` imports, `library` and `symbol` use cases
+- [visibility.md](visibility.md) — `pub` / `ext` visibility (not decorator-controlled)
+- [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of` / `$align_of` as `align` arguments

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -26,10 +26,10 @@ ext fun strlen(s: *u8) i64;             # private, file-local
 ## Symbol rename
 
 By default the linker symbol matches the Mach name. Override it with the
-`.symbol` attribute:
+`symbol` decorator:
 
 ```mach
-$libc_write.symbol = "write";
+`symbol("write")`
 pub ext fun libc_write(fd: i64, buf: *u8, n: i64) i64;
 ```
 
@@ -42,11 +42,11 @@ Common reasons to rename:
 ## Library attribution
 
 On a dynamic format that attributes each import to a specific dependency — the
-PE (Windows) import directory — the `.library` attribute pins an `ext` import to
+PE (Windows) import directory — the `library` decorator pins an `ext` import to
 the DLL that exports it:
 
 ```mach
-$WSAStartup.library = "ws2_32.dll";
+`library("ws2_32.dll")`
 ext fun WSAStartup(ver: u16, data: *u8) i32;
 ```
 
@@ -55,25 +55,24 @@ ext fun WSAStartup(ver: u16, data: *u8) i32;
   dependencies; pinning to a library that is not is a hard link error
   (`import '<sym>' pinned to library '<lib>' not among the link's dependencies`),
   never a silent fallback.
-- An `ext` import with no `.library` is unattributed. On PE the loader has no
+- An `ext` import with no `library` is unattributed. On PE the loader has no
   global search, so an unattributed import binds to the **first** declared
   dependency. Pin every import that does not belong to that first library —
   adding extra DLLs to `libs` without attribution only emits empty import
   descriptors.
 
-`.library` composes with `.symbol`: the rename sets the imported symbol's name,
-`.library` sets the DLL it is imported from. On one decl the import is emitted
+`library` composes with `symbol`: the rename sets the imported symbol's name,
+`library` sets the DLL it is imported from. On one decl the import is emitted
 under the renamed symbol within the named library.
 
 ```mach
 # imported as `socket` from ws2_32.dll, called as `ws2_socket` in Mach.
-$ws2_socket.library = "ws2_32.dll";
-$ws2_socket.symbol  = "socket";
+`library("ws2_32.dll")` `symbol("socket")`
 ext fun ws2_socket(af: i32, kind: i32, proto: i32) i64;
 ```
 
 On a format whose loader resolves imports by global search (ELF), an import is
-not bound to a single dependency, so `.library` has no effect on the emitted
+not bound to a single dependency, so `library` has no effect on the emitted
 binary — the value is still validated against the link's dependencies, but every
 dependency is searched at load time regardless.
 
@@ -145,4 +144,4 @@ is currently implemented for the ELF (Linux) target; the PE (Windows) and Mach-O
 
 - [fun.md](fun.md) — regular function declarations
 - [visibility.md](visibility.md) — `pub` and `ext` modifiers
-- [comptime-attrs.md](comptime-attrs.md) — `.symbol` and other attributes
+- [decorators.md](decorators.md) — `symbol`, `library`, and other codegen decorators

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -50,9 +50,10 @@ the DLL that exports it:
 ext fun WSAStartup(ver: u16, data: *u8) i32;
 ```
 
-- The value names one of the target's dependency libraries (the manifest
-  `[target.*].libs` / `-l` set). The named library **must** be among the link's
-  dependencies; pinning to a library that is not is a hard link error
+- The value names one of the OS's dependency libraries (the manifest
+  `[os.*].libs` set, e.g. `[os.windows].libs = ["kernel32.dll", "ws2_32.dll"]`).
+  The named library **must** be among the link's dependencies; pinning to a
+  library that is not is a hard link error
   (`import '<sym>' pinned to library '<lib>' not among the link's dependencies`),
   never a silent fallback.
 - An `ext` import with no `library` is unattributed. On PE the loader has no

--- a/doc/language/fun.md
+++ b/doc/language/fun.md
@@ -10,7 +10,7 @@ fun NAME(args) RET { ... }              # function with return type
 fun NAME(args) { ... }                  # no return type
 fun NAME[T](args) RET { ... }           # generic over type parameters
 fun NAME($p: T, args) RET { ... }       # comptime value parameter
-fun NAME(a, b, ...) RET { ... }         # variadic (trailing ...)
+fun NAME(fixed, va: ...) RET { ... }    # variadic pack parameter
 ```
 
 ## Examples
@@ -35,18 +35,6 @@ pub fun make_pair[T, U](a: T, b: U) Pair[T, U] {
     ret p;
 }
 
-pub fun sum(count: i64, ...) i64 {
-    var ap: va_list;
-    va_start(?ap);
-    var total: i64 = 0;
-    var i:     i64 = 0;
-    for (i < count) {
-        total = total + va_arg[i64](?ap);
-        i = i + 1;
-    }
-    va_end(?ap);
-    ret total;
-}
 ```
 
 ## Generic type parameters
@@ -84,21 +72,38 @@ pub fun pick_op($mode: Mode, a: i64, b: i64) i64 {
 Comptime value parameters apply to function parameters only — not record
 fields, not other contexts.
 
-## Variadic functions
+## Variadic packs
 
-> **Partially implemented.** The parser accepts a trailing `...` parameter
-> and the function type carries a `variadic` flag, but the `va_list` type
-> and the `va_start` / `va_arg` / `va_end` intrinsics are not yet seeded or
-> lowered. The `sum` example above describes the intended form, not what
-> compiles today. Tracked in #1028.
+A function with a trailing named pack parameter (`va: ...`) accepts a
+variable number of trailing arguments. The compiler monomorphizes the
+function once per distinct call-site type-list; the pack is consumed by
+`$each a in va` at compile time — there is no runtime `va_list`.
 
-A function ending in `...` accepts a variable number of trailing arguments.
-The body accesses them through `va_list` / `va_start` / `va_arg` / `va_end`,
-matching C's convention.
+```mach
+pub fun sum(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + a;
+    }
+    ret t;
+}
+
+# leading fixed params are allowed before the pack
+pub fun bias(base: i64, va: ...) i64 {
+    var t: i64 = base;
+    $each a in va { t = t + a; }
+    ret t;
+}
+```
+
+`va.len` folds to the element count. `g(va...)` forwards the whole pack to
+another pack-tailed callee. See [variadics.md](variadics.md) for the full
+reference.
 
 ## See also
 
 - [ext-fun.md](ext-fun.md) — body-less external functions
+- [variadics.md](variadics.md) — variadic pack parameter reference
 - [comptime-control.md](comptime-control.md) — `$if` inside function bodies
 - [expressions.md](expressions.md) — function calls and generic
   instantiation

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -49,7 +49,7 @@ token ::= IDENT
         | ERROR    (* emitted for an unexpected character, see below *)
 
 punctuation ::= "(" | ")" | "{" | "}" | "[" | "]"
-              | ";" | ":" | "," | "." | "?" | "@" | "$"
+              | ";" | ":" | "," | "." | "?" | "@" | "$" | "`"
               | "::" | ":~" | "..."
 
 operator ::= "+" | "-" | "*" | "/" | "%"
@@ -179,10 +179,12 @@ tokens and are otherwise discarded.
 ### Unexpected characters
 
 The lexer has no fall-through quote or reserved class: any byte that begins
-none of the token forms above — the backtick `` ` `` among them — is an
-**unexpected character**. The lexer records a `LEX_ERR_UNEXPECTED_CHAR`,
-emits a one-byte `ERROR` token (`KIND_ERROR`) for it, and continues. The
-backtick carries no special role; it is just one such character.
+none of the token forms above is an **unexpected character**. The lexer
+records a `LEX_ERR_UNEXPECTED_CHAR`, emits a one-byte `ERROR` token
+(`KIND_ERROR`) for it, and continues.
+
+The backtick `` ` `` is a real punctuation token (`KIND_BACKTICK`) used to
+delimit backtick decorators (see [Decorators](#decorators) below).
 
 
 ## Module
@@ -192,6 +194,28 @@ A source file is a single module: a sequence of declarations.
 ```ebnf
 module ::= { decl }
 ```
+
+
+## Decorators
+
+Zero or more leading backtick decorator clauses may appear before any
+declaration. Each clause is a comptime directive name, optionally followed
+by a parenthesized argument list of comptime expressions.
+
+```ebnf
+decorator     ::= "`" IDENT [ "(" [ expr { "," expr } ] ")" ] "`"
+decorated-decl ::= { decorator } decl
+```
+
+- Decorators attach to the **immediately following** declaration and do not
+  bleed across declarations.
+- Multiple decorators may appear on the same line (space-separated) or one
+  per line.
+- The argument list is optional; a bare `` `inline` `` carries no arguments.
+- Arguments are comptime expressions (not types): `$size_of(T)` is a valid
+  argument; `T` as a raw type name is not.
+- The closed directive set is `symbol`, `section`, `inline`, `align`,
+  `library`. See [decorators.md](decorators.md).
 
 
 ## Declarations
@@ -258,14 +282,20 @@ fun-decl ::= "fun" IDENT [ generic-params ] param-list [ type ] ( block | ";" )
 param-list ::= "(" [ params ] ")"
 
 params ::= "..."
-         | typed-name { "," typed-name } [ "," "..." ]
+         | typed-name { "," typed-name } [ "," ( "..." | pack-param ) ]
+         | pack-param
+
+pack-param ::= IDENT ":" "..."
 
 typed-name ::= [ "$" ] IDENT ":" type
 ```
 
-- A trailing `...` marks the function variadic (it may appear alone, or
-  after the last named parameter). It must be last.
-- A leading `$` on a parameter marks it a **comptime value parameter**.
+- A trailing standalone `...` marks the function variadic (C-style; it may
+  appear alone or after the last named parameter). It must be last.
+- A trailing `name: ...` declares a **comptime variadic pack parameter**
+  (`TYPE_KIND_PACK`). The two forms are grammatically distinct: `name: ...`
+  is a pack; bare `...` is the C-style variadic marker. It must be last.
+- A leading `$` on a `typed-name` marks it a **comptime value parameter**.
 
 > **Divergence (parser vs. doc).** `typed-name` is shared between function
 > parameters and `rec`/`uni` fields, so the parser will *accept* a leading
@@ -426,12 +456,15 @@ postfix ::= call-args
           | generic-call
           | index
           | member
+          | project
           | cast
 
-call-args    ::= "(" [ expr { "," expr } [ "," ] ] ")"
+call-args    ::= "(" [ call-arg { "," call-arg } [ "," ] ] ")"
+call-arg     ::= expr [ "..." ]     (* trailing "..." makes it a va... spread *)
 generic-call ::= type-args call-args        (* callee[T, U](args) *)
 index        ::= "[" expr "]"
 member       ::= "." IDENT
+project      ::= "." "[" expr "]"          (* v.[f]: comptime field projection *)
 cast         ::= ( "::" | ":~" ) type
 ```
 
@@ -527,6 +560,7 @@ stmt ::= block
        | asm-stmt
        | local-decl-stmt
        | comptime-if-stmt
+       | comptime-each-stmt
        | expr-stmt
 
 block ::= "{" { stmt } "}"
@@ -550,7 +584,13 @@ comptime-if-stmt ::= "$" "if" "(" expr ")" stmt-branch-body
                      { "$" "or" "(" expr ")" stmt-branch-body }
                      [ "$" "or" stmt-branch-body ]
 stmt-branch-body ::= "{" { stmt } "}"
+
+comptime-each-stmt ::= "$" "each" IDENT "in" expr stmt-branch-body
 ```
+
+`$each` is a compile-time unroll: the body is duplicated once per element of
+the sequence, which must be `$fields(T)` or a variadic pack identifier. `in`
+is a contextual keyword.
 
 Notes:
 - `if` / `or`: the `or` chain models both `else if` (`or (cond) { ... }`)
@@ -594,22 +634,21 @@ compiler actually resolves is a semantic concern (several are documented
 stubs).
 
 ```ebnf
-comptime-ident ::= "$" IDENT                       (* $size_of, $mach, $assert, ... *)
+comptime-ident ::= "$" IDENT                       (* $size_of, $mach, $type_of, ... *)
 
-intrinsic-call ::= comptime-ident call-args         (* $size_of(T), $offset_of(T, field) *)
+intrinsic-call ::= comptime-ident call-args         (* $size_of(T), $fields(T), $type_of(e) *)
 mach-read      ::= comptime-ident { member }        (* $mach.target.os, $mach.arch.x86_64 *)
 ```
 
 - Intrinsic calls (`$size_of(T)`, `$align_of(T)`, `$offset_of(T, field)`,
-  `$error("msg")`, `$assert(cond, "msg")`) are syntactically just a
-  `comptime-ident` callee with `call-args`. Their *arguments* are parsed as
-  ordinary expressions — note `$size_of(T)` passes a type name that the
-  expression grammar reads as an `IDENT` / `named` reference; the intrinsic
-  reinterprets it as a type at evaluation time.
-- `$mach.*` reads (`$mach.target.os`, `$mach.compiler.version`,
-  `$mach.os.linux`, `$mach.arch.x86_64`, …) are a `comptime-ident` followed
-  by a `.`-member chain. They appear in `$if` conditions and as comptime
-  initializers.
+  `$type_of(e)`, `$fields(T)`, `$error("msg")`, `$assert(cond, "msg")`) are
+  syntactically a `comptime-ident` callee with `call-args`. Their *arguments*
+  are parsed as ordinary expressions — `$size_of(T)` and `$fields(T)` pass a
+  type name that the expression grammar reads as an `IDENT`; the intrinsic
+  reinterprets it as a type at evaluation time. `$type_of(e)` takes a value
+  expression and produces a comptime type value.
+- `$mach.*` reads are a `comptime-ident` followed by a `.`-member chain. They
+  appear in `$if` conditions and as comptime initializers.
 - An **attribute write** `$sym.attr = value;` and a bare **directive**
   `$intrinsic(args);` are the `comptime-directive` declaration form above.
 
@@ -617,33 +656,44 @@ The `$mach.*` tag/path set is closed and documented in
 [comptime-mach.md](comptime-mach.md); this grammar treats every `$ident`
 and `.`-chain off it uniformly.
 
+### Field projection (`v.[f]`)
+
+`v.[f]` is a postfix form that projects the field described by a comptime
+field descriptor `f` (bound by a `$each f in $fields(T)` loop) off an
+instance `v`. Syntactically: `.` followed immediately by `[expr]`. It is
+disambiguated from a regular member access `v.name` by the `[` lookahead:
+`.` then `[` = projection; `.` then `IDENT` = member.
+
 
 ## Verification notes
 
 Productions verified directly against the parser source:
 
-- **Lexical grammar** — `lexer.mach` / `token.mach`: token set, operator
-  maximal-munch, number/char/string scanning and escapes, comment and
-  whitespace handling, the "keywords are `IDENT`s" model.
+- **Lexical grammar** — `lexer.mach` / `token.mach`: token set (incl.
+  `KIND_BACKTICK`), operator maximal-munch, number/char/string scanning and
+  escapes, comment and whitespace handling, the "keywords are `IDENT`s" model.
 - **Precedence ladder** — `token.infix_precedence` / `token.is_right_assoc`
   (the table is a direct transcription; only `=` is right-associative).
+- **Decorators** — `parser/decl.mach` `parse_decorators` / `parse_one_decorator`:
+  leading `` `name` `` / `` `name(args)` `` clauses, closed directive set.
 - **Declarations** — `parser/decl.mach`: `use`, `fwd` (incl. `pub fwd`
-  rejection), `fun` (generics, params, variadic `...`, comptime `$` params,
-  optional return type, block-or-`;` body), `rec`, `uni`, `val`/`var`
-  (both annotations optional), `def`, `test`, `flags` (`pub`/`ext` any
-  order/count), the decl-scope `$if`/`$or` chain, and the
+  rejection), `fun` (generics, params, variadic `...`, named pack `name: ...`,
+  comptime `$` params, optional return type, block-or-`;` body), `rec`, `uni`,
+  `val`/`var` (both annotations optional), `def`, `test`, `flags`
+  (`pub`/`ext` any order/count), the decl-scope `$if`/`$or` chain, and the
   `comptime-directive` (attribute-write vs. bare directive) form.
 - **Statements** — `parser/decl.mach`: `block`, `if`/`or` chain, `for`
   (optional condition), `ret`/`brk`/`cnt`/`fin`, local `val`/`var`, the
-  stmt-scope `$if`/`$or` chain, and `expr-stmt`.
+  stmt-scope `$if`/`$or` chain, `$each … in … { }`, and `expr-stmt`.
 - **Expressions** — `parser/expr.mach`: prefix atoms, all five unary
   prefix operators (`-`, `!`, `~`, `?`, `@`), the postfix chain
-  (call, generic-call, index, member, cast), struct/array literals and the
+  (call with optional `...` spread on arguments, generic-call, index,
+  member, field projection `.[f]`, cast), struct/array literals and the
   typed-literal lookahead, the generic-call-vs-index `[` disambiguation,
   and `comptime-ident`.
-- **Types** — `parser/expr.mach`: `*T`, `[N]T`, `fun(...) R` (with variadic
-  and optional return), anonymous `rec {...}` / `uni {...}`, and named types
-  with generic args / dotted paths.
+- **Types** — `parser/expr.mach`: `*T`, `[N]T`, `fun(...) R` (with variadic,
+  pack `name: ...`, and optional return), anonymous `rec {...}` / `uni {...}`,
+  and named types with generic args / dotted paths.
 - **Inline asm** — `parser/iasm.mach`: mandatory ISA tag, raw brace-balanced
   body, no operand/clobber list.
 
@@ -658,8 +708,11 @@ Doc-only (intended surface, not a distinct parser production):
   sets are enforced later (see [asm.md](asm.md),
   [comptime-mach.md](comptime-mach.md)).
 - The closed intrinsic set (`$size_of`, `$align_of`, `$offset_of`,
-  `$error`, `$assert`) — syntactically indistinguishable from any other
-  `comptime-ident` call.
+  `$type_of`, `$fields`, `$error`, `$assert`) — syntactically
+  indistinguishable from any other `comptime-ident` call.
+- The closed decorator directive set (`symbol`, `library`, `inline`, `align`,
+  `section`) — the parser accepts any `IDENT` after `` ` ``; sema enforces
+  the closed set.
 
 Divergences flagged inline:
 

--- a/doc/language/variadics.md
+++ b/doc/language/variadics.md
@@ -1,0 +1,157 @@
+# Variadic packs
+
+A **variadic pack** (`va: ...`) is a trailing function parameter that collects
+a variable number of call-site arguments into a compile-time sequence. The
+compiler monomorphizes the function once per distinct argument type-list at
+each call site; there is no runtime structure, no `va_list`, and no `any`.
+
+## Declaring a pack parameter
+
+A pack parameter is written as a named parameter whose type is `...`:
+
+```mach
+fun name(va: ...) RetType { ... }
+fun name(fixed: T, va: ...) RetType { ... }   # leading fixed params are allowed
+```
+
+The pack parameter must be last. Any number of fixed (typed) parameters may
+precede it.
+
+## Iterating with `$each`
+
+`$each a in va` unrolls the body once per element, with `a` bound to the
+element and re-typed to that element's concrete type per instantiation.
+This is the only way to consume a pack.
+
+```mach
+fun sum(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + a;
+    }
+    ret t;
+}
+
+sum(1, 2, 3)       # 6
+sum(10, 20)        # 30
+sum()              # 0 — empty pack, body never runs
+```
+
+Because each element has its own concrete type at monomorphization, the body
+can handle heterogeneous packs:
+
+```mach
+fun sumc(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + a::i64;          # cast each element's concrete type to i64
+    }
+    ret t;
+}
+
+sumc(1000, 50::i32, 7::u8, 200::i16)   # 1257
+```
+
+A `$each` body is a normal statement block; it may nest arbitrarily, call
+functions, read outer-scope runtime variables, and write them back. Runtime
+variables in the enclosing scope (e.g. a cursor) thread across all unrolled
+iterations — each iteration reads where the previous one left off.
+
+## `va.len` — element count
+
+`va.len` folds to the instance's element count at compile time.
+
+```mach
+fun count(va: ...) i64 { ret va.len::i64; }
+
+count(1, 2, 3)   # 3
+count()          # 0
+```
+
+## `va...` — forwarding a whole pack
+
+Inside a pack instance, `g(va...)` forwards the whole pack to another
+pack-tailed function, which is monomorphized for the forwarded type-list.
+
+```mach
+fun outer(va: ...) i64 { ret sum(va...); }
+
+outer(1, 2, 3)   # forwards (1, 2, 3) to sum → 6
+```
+
+Leading fixed arguments may precede the spread at the call site:
+
+```mach
+fun fwdpre(base: i64, va: ...) i64 { ret base + sum(va...); }
+
+fwdpre(100, 1, 2, 3)   # 106
+```
+
+`va...` is valid **only as the sole trailing argument of a pack-tailed
+callee**. The compiler rejects:
+- Spreading into a callee with no pack parameter.
+- Spreading when other arguments follow the spread.
+- Spreading only part of a pack (partial forward is not supported).
+
+## Monomorphization and ABI
+
+A pack-tailed function is compiled once per distinct argument type-list at
+each call site. Different arities, or the same arity with different types,
+produce separate instances:
+
+```mach
+sum(1, 2, 3)           # instance: (i64, i64, i64)
+sum(10, 20)            # instance: (i64, i64)
+sum(5::u8, 1::u32)     # instance: (u8, u32)
+```
+
+Because a pack-tailed function has no single entry point, it is **not a
+stable-ABI symbol** — it cannot be the target of `ext fun` or a function
+pointer shared across compilation units. It is source-level only.
+
+## Cross-module packs
+
+Pack-tailed functions may call functions in other modules from inside the
+`$each` body. The compiler re-infers the body per monomorphization instance
+against the full module set.
+
+```mach
+fun sumdbl(va: ...) i64 {
+    var t: i64 = 0;
+    $each a in va {
+        t = t + helper.dbl(a);   # helper.dbl resolved per element type
+    }
+    ret t;
+}
+```
+
+## Real-world example: format
+
+The standard library's `vformat` is a pack-tailed function. Each `$each`
+iteration handles one format argument in order, with `$type_of` dispatch
+selecting the right writer per element type:
+
+```mach
+pub fun vformat(w: *Writer, fmt: str, va: ...) Result[usize, str] {
+    var i: usize = 0;
+    $each arg in va {
+        for (fmt[i] != 0 && fmt[i] != '{') { write_byte(w, fmt[i]); i = i + 1; }
+        if (fmt[i] != '{') { ret err[usize, str](ERR_FEW_HOLES); }
+        i = i + 2;
+        $if ($type_of(arg) == str) { write_str(w, arg); }
+        $or ($type_of(arg) == i64) { write_i64(w, arg); }
+        $or { $error("no writer for this argument type"); }
+    }
+    for (fmt[i] != 0) { write_byte(w, fmt[i]); i = i + 1; }
+    ret ok[usize, str](i);
+}
+```
+
+The runtime format cursor `i` threads across all unrolled iterations; the
+arg sequence is consumed entirely at compile time.
+
+## See also
+
+- [fun.md](fun.md) — function declarations, generic and comptime parameters
+- [comptime-intrinsics.md](comptime-intrinsics.md) — `$type_of`, `$fields`, `$each`
+- [comptime-control.md](comptime-control.md) — `$if` / `$or` used inside pack bodies


### PR DESCRIPTION
Adds and updates reference docs for v1.7.0 language features that shipped but were not yet documented.

## Pages added / updated

- **`decorators.md`** (new) — backtick decorator reference: `symbol`, `library`, `inline`, `align`, `section`; applicability table; grammar
- **`comptime-attrs.md`** — replaced with a redirect to `decorators.md`; notes old `$sym.attr` setters are deprecated in favor of decorators
- **`ext-fun.md`** — updated symbol-rename and library-attribution examples to use decorator syntax
- **`variadics.md`** (new) — variadic pack reference: `va: ...` declaration, `$each a in va` unroll, `va.len`, `va...` forward, monomorphization model, cross-module packs, real-world `vformat` example
- **`fun.md`** — replaced the old `va_list` stub (marked "partially implemented") with a summary of the shipped pack form; links to `variadics.md`
- **`comptime-intrinsics.md`** — added `$type_of`, `$fields(T)`, `v.[f]` projection, `$each` statement form, field descriptor reads (`f.name`, `f.type`, `f.offset`)
- **`grammar.md`** — added BACKTICK token; `Decorators` production; `pack-param` alternative in `params`; `comptime-each-stmt`; `v.[f]` projection; `va...` spread; extended comptime surface; updated verification notes
- **`README.md`** — added entries for `decorators.md` and `variadics.md`; updated `comptime-intrinsics` line

## Verification

Code examples were compile-checked against the installed `~/.local/bin/mach` (v1.7.0) before committing. No examples were invented — all reflect actual test apps in `.github/tests/{decorator,aligndec,dlllibdec,sectiondec,inline,packmono,packfwd,packxmod,eachfields}`.

Do NOT touch `comptime-mach.md` or `comptime-control.md` (another worker owns the namespace collapse update).