### PR TITLE
ci: fix workflow rejected by GitHub (unquoted colon) — restores all ci.yml lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Put the seed on PATH
         run: Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP/seed"
 
-      - name: Realize the vendored std (windows: direct git)
+      - name: "Realize the vendored std (windows: direct git)"
         # the v1.6.0 seed's `mach dep pull` can't find git.exe on windows (its git
         # lookup misses the `.exe` extension — git is on PATH, `where git` finds it
         # in three places, yet dep pull errors "git not found"). tracked as a


### PR DESCRIPTION
`.github/workflows/ci.yml` was invalid YAML: an unquoted `: ` inside a step name (`Realize the vendored std (windows: direct git)`, added in #1486) made GitHub reject the workflow. Every push since failed at **0s** and **no ci.yml lane has run** — including the #1488 self-host fixpoint gate. v1.7.0 shipped without its PR gates (the release went out on the separate `release.yml`).

Quoting the step name restores a valid workflow. This PR self-validates: its own ci.yml run will execute now that the file parses.

Closes #1514