### PR TITLE
refactor: migrate $<sym> attribute setters to backtick decorators

### DIFF
--- a/.github/tests/aarch64enc/app/src/main.mach
+++ b/.github/tests/aarch64enc/app/src/main.mach
@@ -14,7 +14,7 @@
 
 # a global the program both reads/writes (LDST*_LO12) and takes the address of
 # (ADD_LO12), forcing the ADRP page-relative pair on every access.
-$counter.symbol = "counter";
+`symbol("counter")`
 var counter: i64 = 0;
 
 # a defined callee — the `bl` to it emits R_AARCH64_CALL26.
@@ -29,7 +29,7 @@ fun sink(p: *i64) i64 {
 }
 
 # the ELF entry point; named `_start` so the link needs no external runtime.
-$_start.symbol = "_start";
+`symbol("_start")`
 pub fun _start() i64 {
     counter = helper(counter);
     ret sink(?counter);

--- a/.github/tests/aarch64run/app/src/main.mach
+++ b/.github/tests/aarch64run/app/src/main.mach
@@ -17,7 +17,7 @@ fun scale(b: *Box, factor: f64) f64 {
     ret b.val * factor;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # f64 array-element load feeding an FP add.
     var tbl: [4]f64;

--- a/.github/tests/absout/app/src/main.mach
+++ b/.github/tests/absout/app/src/main.mach
@@ -1,4 +1,4 @@
 use std.runtime.linux.x86_64;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/asmcarry/app/src/main.mach
+++ b/.github/tests/asmcarry/app/src/main.mach
@@ -74,10 +74,10 @@ fun jnc_cf1(a: u64, b: u64) u64 {
 # unmangled branch target for the jc/jnc relocations. never reached at runtime
 # (every branch above falls through); the call in main keeps the symbol live so
 # the inline-asm PC32 relocations against its literal name resolve.
-$never.symbol = "asmcarry_never";
+`symbol("asmcarry_never")`
 fun never() u64 { ret 99; }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # setc: 1 < 2 borrows (CF=1) -> 1; 5 >= 3 no borrow (CF=0) -> 0.
     if (carry_bit(1, 2) != 1) { ret 1; }

--- a/.github/tests/asmclobber/app/src/main.mach
+++ b/.github/tests/asmclobber/app/src/main.mach
@@ -37,7 +37,7 @@ fun caller(seed: i64) i64 {
     ret held + r;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # clobber(1) == 43; the bug returned 999.
     if (clobber(1) != 43) { ret 1; }

--- a/.github/tests/asmcomment/app/src/main.mach
+++ b/.github/tests/asmcomment/app/src/main.mach
@@ -23,7 +23,7 @@ fun add_via_asm(a: i64, b: i64) i64 {
     ret result;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # add_via_asm(40, 2) == 42; a phantom instruction or stray binding fails the
     # build, and a mis-substitution would corrupt the result.

--- a/.github/tests/asmlocal/app/src/main.mach
+++ b/.github/tests/asmlocal/app/src/main.mach
@@ -81,7 +81,7 @@ fun redef_back() u64 {
     ret out;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     if (sum_to(5) != 15) { ret 1; }
     if (fwd(3, 9) != 9) { ret 2; }

--- a/.github/tests/asmlocal/bad/src/main.mach
+++ b/.github/tests/asmlocal/bad/src/main.mach
@@ -15,7 +15,7 @@ fun undefined_ref() u64 {
     ret out;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret undefined_ref()::i64;
 }

--- a/.github/tests/cffi/app/src/main.mach
+++ b/.github/tests/cffi/app/src/main.mach
@@ -25,7 +25,7 @@ fun near(a: f64, b: f64) i64 {
     ret 0;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # {f64,f64} argument in XMM0:XMM1.
     val v: Vec2 = Vec2{ x: 3.0, y: 4.0 };

--- a/.github/tests/comptimeroots/altapp/src/main.mach
+++ b/.github/tests/comptimeroots/altapp/src/main.mach
@@ -5,7 +5,7 @@ use std.types.string.str_equals;
 # manifest's declared values — distinct from the other app's, proving the roots
 # come from the manifest and are not hardcoded. exits 0 only when every root
 # matches; a mismatch returns the drifted root's id.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     if (!str_equals($project.version, "2.4.6")) { ret 1; }
     if (!str_equals($project.id, "ctrootsv1"))  { ret 2; }

--- a/.github/tests/comptimeroots/app/src/main.mach
+++ b/.github/tests/comptimeroots/app/src/main.mach
@@ -6,7 +6,7 @@ use std.types.string.str_equals;
 # `$project.target.{os,arch,abi}` spelling (#1471) folds to the same declared
 # tuple as the legacy `$target.*` (both resolve this release — additive). exits 0
 # only when every root matches; a mismatch returns the drifted root's id.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     if (!str_equals($project.version, "3.1.4")) { ret 1; }
     if (!str_equals($project.id, "ctrootsv2"))  { ret 2; }

--- a/.github/tests/comptimeroots/bareident_gate/src/main.mach
+++ b/.github/tests/comptimeroots/bareident_gate/src/main.mach
@@ -4,7 +4,7 @@ use std.runtime.linux.x86_64;
 # channel shapes (#1249): comptime parameters are referenced without `$`, and
 # comptime paths are rooted. the build must reject it with the one teaching
 # diagnostic owned by comptime.eval — never fold it nor compile.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     $if ($mode) { ret 1; }
     ret 0;

--- a/.github/tests/comptimeroots/bareident_value/src/main.mach
+++ b/.github/tests/comptimeroots/bareident_value/src/main.mach
@@ -4,7 +4,7 @@ use std.runtime.linux.x86_64;
 # channel shapes (#1249): comptime parameters are referenced without `$`, and
 # comptime paths are rooted. sema defers to comptime.eval's one rejection rule,
 # so the build must fail with the same teaching diagnostic as the gate case.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     val x: i64 = $mode;
     ret x;

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -6,7 +6,7 @@ use std.types.string.str_equals;
 # (sysv), so the build facts fold to the matching tags, the three abi tags are
 # pairwise distinct, and `$mach.version` agrees with `$mach.compiler.version`.
 # exits 0 only when every comptime fold matches; a mismatch returns a distinct id.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # the resolved active build's facts fold to the matching tags
     $if ($mach.build.abi == $mach.abi.sysv)     { } $or { ret 1; }

--- a/.github/tests/ctcmp/app/src/main.mach
+++ b/.github/tests/ctcmp/app/src/main.mach
@@ -33,7 +33,7 @@ fun agree(ct_lt: u8, ct_eq: u8, ct_gt: u8, rt_lt: u8, rt_eq: u8, rt_gt: u8, base
     ret 0;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # non-foldable zeros: argc is >= 1, so each is 0 but opaque to const folding,
     # forcing the runtime comparisons through the back end instead of the folder.

--- a/.github/tests/dlllib/app/src/main.mach
+++ b/.github/tests/dlllib/app/src/main.mach
@@ -16,27 +16,27 @@ use std.runtime;
 
 # `.symbol` rename only: the mach identifier `sleep_ms` links as `Sleep`, an
 # unattributed import that falls back to kernel32.dll (the first dependency).
-$sleep_ms.symbol = "Sleep";
+`symbol("Sleep")`
 ext fun sleep_ms(ms: u32);
 
 # `.library` only, bare name: pinned to ws2_32.dll, linked as `WSAStartup`.
-$WSAStartup.library = "ws2_32.dll";
+`library("ws2_32.dll")`
 ext fun WSAStartup(ver: u16, data: *u8) i32;
 
 # both directives on one decl: the mach identifier `ws2_cleanup` is renamed to
 # `WSACleanup` and pinned to ws2_32.dll — the rename and the library pin compose.
-$ws2_cleanup.library = "ws2_32.dll";
-$ws2_cleanup.symbol  = "WSACleanup";
+`library("ws2_32.dll")`
+`symbol("WSACleanup")`
 ext fun ws2_cleanup() i32;
 
 # the trailing descriptor (#1388): `rng_fill` is renamed to `SystemFunction036`
 # (RtlGenRandom) and pinned to advapi32.dll. it fills a buffer with random bytes
 # and returns nonzero on success, so a correct trailing call-thunk is observable.
-$rng_fill.library = "advapi32.dll";
-$rng_fill.symbol  = "SystemFunction036";
+`library("advapi32.dll")`
+`symbol("SystemFunction036")`
 ext fun rng_fill(buf: *u8, len: u32) u8;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     var wsadata: [512]u8;
     # a kernel32 call through the renamed default attribution.

--- a/.github/tests/dynlink/app/src/main.mach
+++ b/.github/tests/dynlink/app/src/main.mach
@@ -5,7 +5,7 @@ use std.runtime.linux.x86_64;
 # time via the PLT the linker emitted.
 ext fun getpid() i32;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # every real process has a positive pid; a successful dynamic call returns it.
     # exit 0 proves the import resolved and the PLT call returned a sane value.

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -92,7 +92,7 @@ fun count_named_a(m: Mixed) i64 {
     ret n;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     var p: Pair = Pair { x: 3, y: 4 };
     if (sum(p) != 7) { ret 1; }

--- a/.github/tests/envfwd/app/src/main.mach
+++ b/.github/tests/envfwd/app/src/main.mach
@@ -6,7 +6,7 @@ use std.runtime;
 use std.types.size.usize;
 use env: std.process.env;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret probe()::i64;
 }

--- a/.github/tests/extlink/app/src/main.mach
+++ b/.github/tests/extlink/app/src/main.mach
@@ -3,7 +3,7 @@ use std.runtime.linux.x86_64;
 # bound at link time against the external object's `mach_ext_add` definition.
 ext fun mach_ext_add(a: i64, b: i64) i64;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # 20 + 21 + 1 == 42; the body lives in the external object, not the graph.
     ret mach_ext_add(20, 21);

--- a/.github/tests/extlink/extlib/src/ext.mach
+++ b/.github/tests/extlink/extlib/src/ext.mach
@@ -1,6 +1,6 @@
 # external library compiled to a loose `.o`: exports `mach_ext_add` under a
 # literal link name so a consumer can bind to it through an `ext fun`.
-$mach_ext_add.symbol = "mach_ext_add";
+`symbol("mach_ext_add")`
 pub fun mach_ext_add(a: i64, b: i64) i64 {
     ret a + b + 1;
 }

--- a/.github/tests/fconv/app/src/main.mach
+++ b/.github/tests/fconv/app/src/main.mach
@@ -16,7 +16,7 @@ fun pow2(k: i32) f64 {
     ret r;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     val n: u64 = argc::u64 - 1;
 

--- a/.github/tests/floatrem/app/src/main.mach
+++ b/.github/tests/floatrem/app/src/main.mach
@@ -21,7 +21,7 @@ fun rem32(a: f32, b: f32) f32 { ret a % b; }
 fun milli64(v: f64) i64 { ret (v * 1000.0)::i64; }
 fun milli32(v: f32) i64 { ret (v * 1000.0)::i64; }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # const-folded module val.
     if (milli64(FOLDED) != 2500) { ret 1; }

--- a/.github/tests/fpargs/app/src/main.mach
+++ b/.github/tests/fpargs/app/src/main.mach
@@ -34,7 +34,7 @@ fun acc(x: f64) f64 {
     ret keep + s;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # take(3.0, 10.0) == -7.0; the bug returned 0.0.
     if (near(swap_call(10.0, 3.0), -7.0) == 0) { ret 1; }

--- a/.github/tests/fwdreexport/app/src/main.mach
+++ b/.github/tests/fwdreexport/app/src/main.mach
@@ -7,7 +7,7 @@ use olib: outer.lib;
 # (`lib.alpha.answer`, and `lib.beta.value` through the nested-FQN alias)
 # (#1343), and a fwd-of-a-fwd through a second library (`olib.answer`,
 # `olib.alpha.answer`).
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret lib.answer() + lib.alpha.answer() + lib.beta.value() + olib.answer() + olib.alpha.answer();
 }

--- a/.github/tests/globalmember/fold/src/main.mach
+++ b/.github/tests/globalmember/fold/src/main.mach
@@ -17,7 +17,7 @@ val CHAINED: usize = flags.CLONE_BASE | flags.CLONE_FILES;
 # a single aliased member that is itself a chained constant: (256|512)|1024|2048 = 3840.
 val ALL_VIA_ALIAS: usize = flags.CLONE_ALL;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     if (THREAD_CLONE_FLAGS != 331520) { ret 1; }
     if (CHAINED != 1792) { ret 2; }

--- a/.github/tests/globalmember/reject/src/main.mach
+++ b/.github/tests/globalmember/reject/src/main.mach
@@ -8,7 +8,7 @@ use flags: gmemberreject.flags;
 # "a global initialiser must be a constant expression" abort.
 val NOT_CONST: usize = flags.COUNTER;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret NOT_CONST::i64;
 }

--- a/.github/tests/kwident/prog/src/main.mach
+++ b/.github/tests/kwident/prog/src/main.mach
@@ -14,7 +14,7 @@ fun repro() usize {
     ret cnt;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     if (repro() != 1) { ret 1; }
 

--- a/.github/tests/literalboundary/app/src/main.mach
+++ b/.github/tests/literalboundary/app/src/main.mach
@@ -7,7 +7,7 @@ use std.runtime.linux.x86_64;
 # simultaneously. exits 0 when every check passes; returns a non-zero check id
 # on the first mismatch.
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     var vi8:  i8  = 127;
     var vu8:  u8  = 255;

--- a/.github/tests/lower-testrunner/duplabel/src/main.mach
+++ b/.github/tests/lower-testrunner/duplabel/src/main.mach
@@ -1,6 +1,6 @@
 use std.runtime.linux.x86_64;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 { ret 0; }
 
 # two tests with the same label in one module. before issue #1251 the clash

--- a/.github/tests/lower-testrunner/nlabel/src/main.mach
+++ b/.github/tests/lower-testrunner/nlabel/src/main.mach
@@ -1,6 +1,6 @@
 use std.runtime.linux.x86_64;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 { ret 0; }
 
 # a label whose text itself contains `N<digit>`. before issue #1251 the runner

--- a/.github/tests/lower/comptime-str/src/main.mach
+++ b/.github/tests/lower/comptime-str/src/main.mach
@@ -9,7 +9,7 @@ fun first_byte(p: *u8) i64 { ret p[0]::i64; }
 # anonymous `.rodata` global and a pointer, exactly like a string literal.
 fun greet($name: *u8) i64 { ret first_byte(name); }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # "hello"[0] == 'h' == 104; main returns 0 only when the fold produced a
     # valid pointer to the rodata bytes.

--- a/.github/tests/lower/fnptr-table/src/main.mach
+++ b/.github/tests/lower/fnptr-table/src/main.mach
@@ -14,7 +14,7 @@ fun first[T](a: T, b: T) T { ret a; }
 # this exercises the bare-identifier index, a complex index expression, a nested
 # matrix index, a chained call, and a real generic call — main exits 0 only when
 # every dispatch lands on the right function.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     var table: [2]fun(i64, i64) i64;
     table[0] = add;

--- a/.github/tests/lower/xmod-generic/src/main.mach
+++ b/.github/tests/lower/xmod-generic/src/main.mach
@@ -1,7 +1,7 @@
 use std.runtime.linux.x86_64;
 use util: xmodgen.util;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # FLAG == 1, so pick selects its first argument (7); main returns 0 only when
     # the cross-module instance folded the right $if arm.

--- a/.github/tests/manifest/app/src/bye.mach
+++ b/.github/tests/manifest/app/src/bye.mach
@@ -1,7 +1,7 @@
 use std.runtime;
 use code: demo.code;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret code.answer() + 4;
 }

--- a/.github/tests/manifest/app/src/hello.mach
+++ b/.github/tests/manifest/app/src/hello.mach
@@ -1,7 +1,7 @@
 use std.runtime;
 use code: demo.code;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret code.answer() + 2;
 }

--- a/.github/tests/manifest/app/src/tier.mach
+++ b/.github/tests/manifest/app/src/tier.mach
@@ -5,7 +5,7 @@ use std.runtime;
 # `shared_flag` (+1), the artifact-level `extra_flag` (+2), and `tier`, an integer
 # define the per-cell `[bin.tier.target.linux]` raises to 9 over the artifact's 2
 # and the target's 1 (+40). a clean linux build exits 43.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     var n: i64 = 0;
     $if ($mach.build.shared_flag) { n = n + 1; }

--- a/.github/tests/manifest/cascade/src/main.mach
+++ b/.github/tests/manifest/cascade/src/main.mach
@@ -4,7 +4,7 @@ use v: vdep.lib;
 
 # the consumer links against both dep libs; the windows link inputs they each
 # require (kernel32.dll, user32.dll) arrive only through the manifest cascade.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret k.k() + v.v();
 }

--- a/.github/tests/mixedcmp/app/src/main.mach
+++ b/.github/tests/mixedcmp/app/src/main.mach
@@ -153,7 +153,7 @@ fun chk_f32_f64(a: f32, b: f64, lt: u8, eq: u8, gt: u8, base: i64) i64 {
     ret 0;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     val n:  u64 = argc::u64 - 1;
     val zi: i64 = n::i64;

--- a/.github/tests/module/dangling/src/main.mach
+++ b/.github/tests/module/dangling/src/main.mach
@@ -1,6 +1,6 @@
 # the entry imports nothing special; the dangling [project].module still fails
 # the build at start.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret 0;
 }

--- a/.github/tests/module/nomodule/src/main.mach
+++ b/.github/tests/module/nomodule/src/main.mach
@@ -1,7 +1,7 @@
 use std.runtime;
 use plain;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret 0;
 }

--- a/.github/tests/module/ok/src/main.mach
+++ b/.github/tests/module/ok/src/main.mach
@@ -5,7 +5,7 @@ use shelf;
 # `use gfx;` resolves the bare project id to gfx's [project].module. `use shelf;`
 # loads shelf, whose own module re-exports gfx through a bare-id `fwd gfx;` — so a
 # resolution failure in either form fails this build.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret gfx.value();
 }

--- a/.github/tests/nilfun/fold/src/main.mach
+++ b/.github/tests/nilfun/fold/src/main.mach
@@ -15,7 +15,7 @@ pub var glKey: F = nil::F;
 var hits: u32 = 0;
 fun cb(x: u32) { hits = hits + x; }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # both globals start as the null address.
     if (glClear != nil) { ret 1; }

--- a/.github/tests/nilfun/reject/src/main.mach
+++ b/.github/tests/nilfun/reject/src/main.mach
@@ -6,5 +6,5 @@ use std.runtime;
 # for fun types does not widen nil into arbitrary scalar slots.
 pub var bad: u32 = nil;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/opt/app/src/main.mach
+++ b/.github/tests/opt/app/src/main.mach
@@ -2,7 +2,7 @@ use std.runtime.linux.x86_64;
 
 # a small loop the optimizer can fold so the debug and release pipelines emit
 # observably different objects; the program's result is independent of the level.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     var x: i64 = 0;
     var i: i64 = 0;

--- a/.github/tests/packfwd/app/src/main.mach
+++ b/.github/tests/packfwd/app/src/main.mach
@@ -28,7 +28,7 @@ fun outer2(va: ...) i64 {
     ret outer(va...);
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     if (outer(1, 2, 3) != 6)         { ret 1; }
     if (outer() != 0)                 { ret 2; }

--- a/.github/tests/packmono/app/src/main.mach
+++ b/.github/tests/packmono/app/src/main.mach
@@ -43,7 +43,7 @@ fun count(va: ...) i64 {
     ret va.len::i64;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # distinct arities are distinct instances, deduped by their type-list.
     if (sum(1, 2, 3) != 6)               { ret 1; }

--- a/.github/tests/packxmod/app/src/main.mach
+++ b/.github/tests/packxmod/app/src/main.mach
@@ -21,7 +21,7 @@ fun chain(va: ...) i64 {
     ret t;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     if (sumdbl(1, 2, 3) != 12) { ret 1; }  # 2 + 4 + 6
     if (sumdbl(10) != 20)      { ret 2; }

--- a/.github/tests/pathdep/run.sh
+++ b/.github/tests/pathdep/run.sh
@@ -83,7 +83,7 @@ TOML
 use std.runtime;
 use libx.lib.answer;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     ret answer();
 }

--- a/.github/tests/threadsync/app/src/main.mach
+++ b/.github/tests/threadsync/app/src/main.mach
@@ -19,7 +19,7 @@ fun worker() {
 # WaitOnAddress call in join() dispatched through a null pointer and faulted
 # (`jmp 0`) — a nonzero exit. exits 0 only when the trailing-descriptor synch
 # calls dispatch correctly.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: usize, argv: **u8) i64 {
     atomic.store(?ran, 0);
     var t: thread.Thread;

--- a/.github/tests/typeofgate/app/src/main.mach
+++ b/.github/tests/typeofgate/app/src/main.mach
@@ -18,7 +18,7 @@ rec B { x: i64; y: i64; }
 rec Box[T] { v: T; }
 def MyInt: i64;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     var a:  i64   = 0;
     var a2: i64   = 0;

--- a/.github/tests/typeofgate/reject/src/main.mach
+++ b/.github/tests/typeofgate/reject/src/main.mach
@@ -3,7 +3,7 @@ use std.runtime;
 # a `$type_of` type comparison is comptime-only: it folds to a selected arm at
 # lowering and has no runtime value, so using it as a value (here, a binding
 # initialiser) must FAIL rather than compile to garbage (#1472).
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     var a: i64 = 0;
     var x: u8 = $type_of(a) == i64;

--- a/.github/tests/valuepos/ok/src/main.mach
+++ b/.github/tests/valuepos/ok/src/main.mach
@@ -10,7 +10,7 @@ fun seven() i64 { ret 7; }
 # building: a record literal, a function reference, a generic parameter in a
 # comptime intrinsic, and qualified value access through a module alias.
 # 8 + 7 + 8 + 7 + 7 = 37.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     val p: Point = Point{ x: 8, y: 1 };
     val f: fun() i64 = seven;

--- a/.github/tests/win64byref/app/src/main.mach
+++ b/.github/tests/win64byref/app/src/main.mach
@@ -32,7 +32,7 @@ fun sum5_big(p0: i64, p1: i64, p2: i64, p3: i64, b: Big) i64 {
 # main: pass each byref aggregate as the 5th argument and verify the callee read
 # it correctly. exits 0 on success, 1 if the 3-byte case is misread, 2 if the
 # 12-byte case is misread.
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     var t: Three;
     t.a = 10;

--- a/.github/tests/win64fnptr/app/src/main.mach
+++ b/.github/tests/win64fnptr/app/src/main.mach
@@ -22,7 +22,7 @@ var vt: VT;
 # code address. harmless on linux (addresses < 2GB) but on win64 (ImageBase
 # 0x140000000) the stored pointer becomes unmapped and `f(41)` faults. exits 0
 # only when the round-tripped pointer calls correctly (41 -> 42).
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     vt.op = inc::*u8;
     val f: Fn = vt.op::Fn;

--- a/.github/tests/win64fp/app/src/main.mach
+++ b/.github/tests/win64fp/app/src/main.mach
@@ -31,7 +31,7 @@ fun near(a: f64, b: f64) i64 {
     ret 0;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # (10+1)+(20+2)+(30+3)+(40+4) = 110; 10*5+20*6+30*7 = 380; mul2(40) = 80;
     # total = 570.

--- a/.github/tests/win64runner/app/src/main.mach
+++ b/.github/tests/win64runner/app/src/main.mach
@@ -5,7 +5,7 @@
 
 use std.runtime;
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     if (add(20, 22) == 42) { ret 0; }
     ret 1;

--- a/.github/tests/win64va/app/src/main.mach
+++ b/.github/tests/win64va/app/src/main.mach
@@ -60,7 +60,7 @@ fun near(a: f64, b: f64) i64 {
     ret 0;
 }
 
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: i64, argv: **u8) i64 {
     # three float varargs summed: requires the float-into-integer-register dup.
     if (near(fsum(3, 1.5, 2.5, 4.0), 8.0) == 0) { ret 1; }

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -299,7 +299,7 @@ fun write_source(path: *u8, content: *u8) bool {
 # `mach init`. this is a standard-library hello world wired through
 # `std.runtime` and `std.print`.
 fun main_template() *u8 {
-    ret "use std.runtime;\nuse print: std.print;\n\n$main.symbol = \"main\";\nfun main(argc: i64, argv: **u8) i64 {\n    print.println(\"Hello, World!\");\n    ret 0;\n}\n";
+    ret "use std.runtime;\nuse print: std.print;\n\n`symbol(\"main\")`\nfun main(argc: i64, argv: **u8) i64 {\n    print.println(\"Hello, World!\");\n    ret 0;\n}\n";
 }
 
 # lib_template: the starter library root module written by `mach init --lib`.

--- a/src/main.mach
+++ b/src/main.mach
@@ -13,7 +13,7 @@ use cmd: mach.cli.cmd;
 # argc: argument count including argv[0]
 # argv: the argument vector (argc null-terminated byte pointers)
 # ret:  the process exit code from the dispatched subcommand
-$main.symbol = "main";
+`symbol("main")`
 fun main(argc: usize, argv: **u8) i64 {
     ret cmd.dispatch(argc, argv);
 }


### PR DESCRIPTION
## Migrate `$<sym>` attribute setters → backtick decorators

Additive, mechanical prep for the v1.7.1 comptime collapse. Moves every consumer of the legacy `$<sym>.symbol` / `$<sym>.library` / `$main.symbol` attribute **setters** to the `` `symbol(...)` `` / `` `library(...)` `` backtick **decorators** added in v1.7.0 (#1476).

Both spellings resolve under the v1.7.0 seed, so **nothing is removed and the build/tests stay green**. This clears the path so the follow-up collapse PR can drop setter support without breaking any consumer.

### Scope (setter consumers only)
- `src/main.mach` — the compiler entry (`$main.symbol = "main"` → `` `symbol("main")` ``).
- `src/cli/cmd/init.mach` — the `mach init` scaffold template.
- 60 `.github/tests/**` fixtures + the `pathdep` `run.sh` heredoc.

No removals, no namespace/varargs changes, no version bump — those land in the focused collapse PR (#1480 + #1478) off updated `dev`.

### Verification
- Builds clean under the v1.7.0 seed (0 errors).
- Sample integration tests pass (`decorator`, `opt`, `comptimeroots`).

Part of #1478.