### PR TITLE
release: mach 2.0.1

### DIFF
--- a/.github/tests/recovery/run.sh
+++ b/.github/tests/recovery/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Parser error-recovery at declaration scope. A removed-syntax error — a comptime
+# attribute setter (`$sym.attr = value;`) or a C-style `...` variadic parameter,
+# both removed in v2.0.0 — must emit its ONE migration diagnostic and resync on
+# the NEXT declaration. It must NOT skip that declaration and reparse its body at
+# module scope, which used to spray a spurious "expected a declaration" for every
+# non-`val` body statement (sync_to_decl's unconditional leading advance, fixed
+# for v2.0.1). Each app's function body is all-valid, so a correct compiler emits
+# exactly the migration diagnostic and zero "expected a declaration" cascade.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+fail=0
+
+# check <app-dir> <expected-diagnostic-substring>
+check() {
+    local app="$1"; local want="$2"
+    cp -r "$HERE/$app" "$WORK/$app"
+    local out
+    if out="$( cd "$WORK/$app" && "$MACH" build . 2>&1 )"; then
+        echo "FAIL recovery/$app: build unexpectedly succeeded (removed syntax must error)" >&2
+        fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF -- "$want"; then
+        echo "FAIL recovery/$app: missing migration diagnostic '$want'; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    if printf '%s' "$out" | grep -qF -- "expected a declaration"; then
+        echo "FAIL recovery/$app: parse cascade — the error spilled into the function body:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    echo "PASS recovery/$app: one migration diagnostic, recovered at the next decl (no cascade)"
+}
+
+check setter  "comptime attribute setters were removed in v2.0.0"
+check varargs 'C-style variadic `...` was removed in v2.0.0'
+
+exit "$fail"

--- a/.github/tests/recovery/setter/mach.toml
+++ b/.github/tests/recovery/setter/mach.toml
@@ -1,0 +1,15 @@
+[project]
+id      = "recsetter"
+name    = "recovery: removed setter — no parse cascade"
+version = "0.0.0"
+src     = "src"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.rec]
+entry = "main.mach"

--- a/.github/tests/recovery/setter/src/main.mach
+++ b/.github/tests/recovery/setter/src/main.mach
@@ -1,0 +1,13 @@
+# a removed comptime attribute setter (`$sym.attr = value;`) must report ONE
+# migration diagnostic and recover at the NEXT declaration. before the v2.0.1
+# fix, sync_to_decl's unconditional leading advance skipped the following `fun`
+# and reparsed its body at module scope — every non-`val` body statement then
+# drew a spurious "expected a declaration". the body here is all-valid, so a
+# correct compiler emits exactly the setter diagnostic and nothing else.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    val a: i64 = 1;
+    val b: i64 = 2;
+    val c: i64 = 3;
+    ret a + b + c;
+}

--- a/.github/tests/recovery/varargs/mach.toml
+++ b/.github/tests/recovery/varargs/mach.toml
@@ -1,0 +1,15 @@
+[project]
+id      = "recvarargs"
+name    = "recovery: removed C-style varargs — no parse cascade"
+version = "0.0.0"
+src     = "src"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.rec]
+entry = "main.mach"

--- a/.github/tests/recovery/varargs/src/main.mach
+++ b/.github/tests/recovery/varargs/src/main.mach
@@ -1,0 +1,11 @@
+# a removed C-style `...` variadic parameter must report ONE migration
+# diagnostic and recover at the NEXT declaration — not skip the following `fun`
+# and cascade "expected a declaration" through its body. an `ext fun` one-liner
+# (no body block to absorb the recovery panic) is the context that exposed the
+# cascade; the following function's body is all-valid.
+ext fun cprintf(fmt: *u8, ...) i32;
+fun main(argc: i64, argv: **u8) i64 {
+    val a: i64 = 1;
+    val b: i64 = 2;
+    ret a + b;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-06-19
+
+Patch — parser error-recovery and a grammar-doc fix surfaced while migrating the
+mach ecosystem (blit, mach-glfw, mach-sieve, …) to 2.0.0.
+
+### Fixed
+
+- parser: a removed-syntax error at declaration scope — a comptime attribute
+  setter (`$sym.attr = value;`) or a C-style `...` variadic parameter — now
+  recovers at the **next** declaration instead of skipping it and reparsing its
+  body at module scope, which sprayed a spurious "expected a declaration" for
+  every non-`val` body statement. `sync_to_decl` no longer advances past a token
+  that already begins a declaration; a regression suite (`tests/recovery`)
+  guards both cases.
+
+### Documentation
+
+- grammar.md: removed the stale C-style `...` variadic **parameter** production
+  (rejected since 2.0.0) — the comptime variadic pack `name: ...` is the only
+  declaration form; function **pointer types** still carry `...` for FFI (#1518).
+
 ## [2.0.0] - 2026-06-19
 
 **BREAKING.** The comptime collapse completes the v1.7 metaprogramming arc and is

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -281,8 +281,7 @@ fun-decl ::= "fun" IDENT [ generic-params ] param-list [ type ] ( block | ";" )
 ```ebnf
 param-list ::= "(" [ params ] ")"
 
-params ::= "..."
-         | typed-name { "," typed-name } [ "," ( "..." | pack-param ) ]
+params ::= typed-name { "," typed-name } [ "," pack-param ]
          | pack-param
 
 pack-param ::= IDENT ":" "..."
@@ -290,11 +289,11 @@ pack-param ::= IDENT ":" "..."
 typed-name ::= [ "$" ] IDENT ":" type
 ```
 
-- A trailing standalone `...` marks the function variadic (C-style; it may
-  appear alone or after the last named parameter). It must be last.
 - A trailing `name: ...` declares a **comptime variadic pack parameter**
-  (`TYPE_KIND_PACK`). The two forms are grammatically distinct: `name: ...`
-  is a pack; bare `...` is the C-style variadic marker. It must be last.
+  (`TYPE_KIND_PACK`); it must be the last parameter. The C-style bare `...`
+  variadic-parameter marker was **removed in v2.0.0** — the parser rejects it
+  with a migration diagnostic pointing to `name: ...`. (A function *pointer
+  type* may still carry `...` for FFI; see `fun-type-params` below.)
 - A leading `$` on a `typed-name` marks it a **comptime value parameter**.
 
 > **Divergence (parser vs. doc).** `typed-name` is shared between function

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.0.0"
+version = "2.0.1"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/lang/fe/parser/state.mach
+++ b/src/lang/fe/parser/state.mach
@@ -260,7 +260,14 @@ pub fun at_decl_start(p: *Parser) bool {
 # turn every following body token into its own "expected a declaration"
 # error — the parser realigns on the next real declaration boundary instead.
 pub fun sync_to_decl(p: *Parser) {
-    advance(p);
+    # only skip the current token when it is not itself a declaration boundary.
+    # an error that consumed its malformed construct in-place (a removed-setter
+    # `$sym.attr = ...` or a `...` variadic directive) leaves the parser already
+    # at the NEXT real declaration; skipping it unconditionally would drop that
+    # decl and reparse its body at module scope, turning every non-decl statement
+    # into a spurious "expected a declaration". the caller's forward-progress
+    # guard still advances when a malformed decl-start fails to consume anything.
+    if (!at_decl_start(p)) { advance(p); }
     for (!at(p, token.KIND_EOF) && !at_decl_start(p)) {
         advance(p);
     }


### PR DESCRIPTION
Integration of the 2.0.1 patch (parser error-recovery + grammar.md fix) into main. CI-green on dev; self-host fixpoint stage1==stage2==stage3, 538/0. Tag v2.0.1 follows the merge.