### PR TITLE
feat(comptime): clean type-directed dispatch — prune dead $type_of arms + $error directive (#1511)

### DIFF
--- a/.github/tests/comptimedispatch/clean/mach.toml
+++ b/.github/tests/comptimedispatch/clean/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "ctdispatch-clean"
+name    = "Comptime dispatch — clean no-cast $type_of skeleton"
+version = "1.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.clean]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.12.0"

--- a/.github/tests/comptimedispatch/clean/src/main.mach
+++ b/.github/tests/comptimedispatch/clean/src/main.mach
@@ -1,0 +1,36 @@
+use std.runtime;
+use std.types.string.str;
+
+# the clean no-cast type-directed `$type_of` dispatch skeleton (#1511). each arm
+# uses `arg` at its OWN concrete type with no per-arm identity cast: sema prunes
+# the provably-dead arms at monomorphization, so an arm written for `str` is never
+# type-checked against a `u64` element (and vice versa). this is the form the §5
+# vformat skeleton wants; before #1511 it required a cast in every arm.
+
+fun take_u64(x: u64) u64 { ret x; }
+fun take_str(x: str) u64 { if (x == nil) { ret 0; } ret 1; }
+
+fun show(va: ...) u64 {
+    var total: u64 = 0;
+    $each arg in va {
+        var n: u64 = 0;
+        $if ($type_of(arg) == u64) {
+            n = take_u64(arg);
+        } $or ($type_of(arg) == str) {
+            n = take_str(arg);
+        } $or {
+            $error("show: unsupported argument type");
+        }
+        total = total + n;
+    }
+    ret total;
+}
+
+# exits 0 only when the dispatch routed each element to its own arm: 42 (u64) +
+# 1 (a non-nil str) == 43.
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    val n: u64 = show(42::u64, "hello");
+    if (n != 43) { ret 1; }
+    ret 0;
+}

--- a/.github/tests/comptimedispatch/run.sh
+++ b/.github/tests/comptimedispatch/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# type-directed comptime dispatch integration test (#1511). two halves:
+#
+#   clean — the no-cast `$type_of` dispatch skeleton must COMPILE: each arm uses
+#   the loop variable at its own concrete type with no per-arm cast, and sema
+#   prunes the provably-dead arms at monomorphization. the app exits 0 only when
+#   the dispatch routed each element to its own arm (42 + 1 == 43).
+#
+#   unhandled — a statement-position `$error` in the unhandled-type `$or {}` arm
+#   must FAIL the build with its message verbatim, so a type-directed dispatch
+#   fails at COMPILE time on an unhandled type instead of a runtime fallback.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+# the exact diagnostic the unhandled app's `$error` directive emits.
+ERROR_DIAG='show: unsupported argument type'
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# build_and_run <app-dir> <label>: vendor std, build, run, require exit 0.
+build_and_run() {
+    local app="$1"; local label="$2"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    if ! ( cd "$dst" && "$MACH" build . ) >/dev/null 2>&1; then
+        echo "FAIL comptimedispatch/$label: build failed" >&2; fail=1; return
+    fi
+    local bin
+    bin="$(find "$dst/out" -type f -path '*/bin/*' | head -n1)"
+    if [ -z "$bin" ]; then
+        echo "FAIL comptimedispatch/$label: no binary produced" >&2; fail=1; return
+    fi
+    set +e
+    "$bin"; local code=$?
+    set -e
+    if [ "$code" -ne 0 ]; then
+        echo "FAIL comptimedispatch/$label: dispatch routed wrong (exit $code)" >&2; fail=1; return
+    fi
+    echo "PASS comptimedispatch/$label: clean no-cast \$type_of dispatch compiles and routes per arm"
+}
+
+# expect_error <app-dir> <label> <diagnostic>: vendor std, build, require the
+# build to FAIL with `diagnostic` present verbatim on stderr.
+expect_error() {
+    local app="$1"; local label="$2"; local want="$3"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    local out
+    if out="$( cd "$dst" && "$MACH" build . 2>&1 )"; then
+        echo "FAIL comptimedispatch/$label: build unexpectedly succeeded on an unhandled type" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF -- "$want"; then
+        echo "FAIL comptimedispatch/$label: missing the \$error diagnostic; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    echo "PASS comptimedispatch/$label: statement-position \$error fails the build with its message"
+}
+
+build_and_run clean     "clean no-cast dispatch"
+expect_error  unhandled "statement-position \$error" "$ERROR_DIAG"
+
+exit "$fail"

--- a/.github/tests/comptimedispatch/unhandled/mach.toml
+++ b/.github/tests/comptimedispatch/unhandled/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "ctdispatch-unhandled"
+name    = "Comptime dispatch — statement-position $error on an unhandled type"
+version = "1.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.unhandled]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.12.0"

--- a/.github/tests/comptimedispatch/unhandled/src/main.mach
+++ b/.github/tests/comptimedispatch/unhandled/src/main.mach
@@ -1,0 +1,33 @@
+use std.runtime;
+use std.types.string.str;
+
+# a statement-position `$error` in the unhandled-type `$or {}` arm (#1511). when a
+# call passes an element of a type no arm handles, sema selects this arm and the
+# `$error` directive fails the build at COMPILE time — replacing the runtime
+# fallback a type-directed dispatch would otherwise need.
+
+fun take_u64(x: u64) u64 { ret x; }
+fun take_str(x: str) u64 { if (x == nil) { ret 0; } ret 1; }
+
+fun show(va: ...) u64 {
+    var total: u64 = 0;
+    $each arg in va {
+        var n: u64 = 0;
+        $if ($type_of(arg) == u64) {
+            n = take_u64(arg);
+        } $or ($type_of(arg) == str) {
+            n = take_str(arg);
+        } $or {
+            $error("show: unsupported argument type");
+        }
+        total = total + n;
+    }
+    ret total;
+}
+
+# `7::i32` is handled by no arm, so the `$or {}` arm's `$error` fires at build time.
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    val n: u64 = show(42::u64, 7::i32);
+    ret 0;
+}

--- a/doc/language/comptime-control.md
+++ b/doc/language/comptime-control.md
@@ -133,6 +133,12 @@ type checking run over **all** arms structurally, and only the selected arm is
 emitted into each instance. Each arm must therefore be independently
 resolvable and type-checkable.
 
+A `$if` gated on a `$type_of` type comparison is *not* such an exception: at
+monomorphization the operand's concrete type is known, so the provably-dead arms
+are **pruned** and only the selected arm is type-checked (and emitted). Each arm
+may therefore use its value at its own concrete type with no per-arm cast — see
+[comptime-intrinsics.md](comptime-intrinsics.md).
+
 ## See also
 
 - [comptime-mach.md](comptime-mach.md) — `$mach.*` for target reads

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -44,6 +44,11 @@ A bare type name (e.g. `i64`, `str`, `Point`) is the other valid operand.
 The comparison selects one branch at compile time per monomorphization
 instance — useful for per-element type dispatch inside `$each` bodies.
 
+The provably-dead arms are **pruned** before type-checking, so each arm uses
+`arg` at its own concrete type with no per-arm cast: the `str` arm above is
+never checked against a `u64` element. Only the selected arm is type-checked
+and emitted.
+
 ## Field intrinsic and projection
 
 `$fields(T)` produces a comptime sequence of field descriptors for record or
@@ -156,26 +161,31 @@ See [variadics.md](variadics.md) for the pack form (`$each a in va`).
 
 ## Diagnostic intrinsics
 
-> **Not yet implemented.** `$error` and `$assert` parse as comptime
-> directives but the compiler does not yet evaluate them — a `$error(...)`
-> directive is currently accepted and ignored rather than failing
-> compilation. The shapes below describe the intended behavior.
+`$error("msg")` fails compilation with `msg` when it is **reached** — on a live
+path: an unconditional position, or a `$if` / `$or` arm the compiler selects. A
+`$error` in a discarded (dead) arm never fires, so it is the natural total-
+coverage fallback for a `$type_of` dispatch — the unhandled-type `$or {}` arm
+fails the build at compile time instead of falling through to a runtime error.
 
-Operate at compile time. `$error` fails compilation; `$assert` is sugar
-over `$if` plus `$error`.
-
-```mach
-$error("msg")
-$assert(cond, "msg")    # sugar: $if (!cond) { $error("msg"); }
-```
+`$error` is valid in both declaration and statement scope and takes one
+string-literal message.
 
 ```mach
-$assert($size_of(i64) == 8, "expected 64-bit i64");
+$error("msg")           # fails compilation when reached
 
 $if (!supported) {
     $error("this target is not supported");
 }
+
+$if ($type_of(arg) == i64) { write_i64(w, arg); }
+$or ($type_of(arg) == str) { write_str(w, arg); }
+$or { $error("no writer for this argument type"); }    # compile error on an unhandled type
 ```
+
+> **`$assert` not yet implemented.** `$assert` parses as a comptime directive
+> but the compiler does not yet evaluate it. It is intended as sugar over `$if`
+> plus `$error` — `$assert(cond, "msg")` ≡ `$if (!cond) { $error("msg"); }`,
+> e.g. `$assert($size_of(i64) == 8, "expected 64-bit i64");`.
 
 ## Not provided as intrinsics
 

--- a/src/lang/fe/ast/stmt.mach
+++ b/src/lang/fe/ast/stmt.mach
@@ -22,6 +22,9 @@ pub val STMT_KIND_ASM:         StmtKind = 9;
 pub val STMT_KIND_COMPTIME_IF: StmtKind = 10;
 # a `$each <ident> in <seq> { body }` bounded compile-time unroll (#1473).
 pub val STMT_KIND_COMPTIME_EACH: StmtKind = 11;
+# a bare statement-scope comptime directive `$intrinsic(args);` (e.g. `$error(...)`,
+# #1511), parallel to the decl-scope DECL_KIND_COMPTIME_ATTR.
+pub val STMT_KIND_COMPTIME_ATTR: StmtKind = 12;
 pub val STMT_KIND_ERROR:       StmtKind = 255;
 
 # StmtExpr: a bare expression used as a statement.
@@ -115,6 +118,16 @@ pub rec StmtComptimeEach {
     body_len:   u32;
 }
 
+# StmtComptimeAttr: a bare statement-scope comptime-channel directive
+# `$intrinsic(args);` (e.g. `$error("msg")`, #1511), parallel to the decl-scope
+# DeclComptimeAttr. it carries no value and emits no IR; a reached `$error`
+# directive fails the build at sema.
+# ---
+# target: the directive call expression
+pub rec StmtComptimeAttr {
+    target: id.ExprId;
+}
+
 # Stmt: a syntactic statement node.
 # ---
 # span: byte range of the statement in source
@@ -134,5 +147,6 @@ pub rec Stmt {
         asm_:          StmtAsm;
         comptime_if:   StmtComptimeIf;
         comptime_each: StmtComptimeEach;
+        comptime_attr: StmtComptimeAttr;
     };
 }

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1269,6 +1269,64 @@ pub fun fields_type_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
     ret a.expr_ids[node.data.call.args_start];
 }
 
+# is_error_call: whether `eid` is a `$error(args)` compile-time directive call
+# (#1511), recognized structurally by a `$`-rooted COMPTIME_IDENT callee spelled
+# `error`. arity / message validity are checked by `error_message`, not here.
+# ---
+# a:      the ast that owns `eid`
+# source: source text (for the callee span)
+# eid:    expression id to test
+# ret:    true when `eid` is a `$error(...)` call
+pub fun is_error_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL) { ret false; }
+    val ce_opt: Option[*expr.Expr] = ast.get_expr(a, node.data.call.callee);
+    if (is_none[*expr.Expr](ce_opt)) { ret false; }
+    val ce: *expr.Expr = unwrap[*expr.Expr](ce_opt);
+    if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret false; }
+    val ns: token.Span = comptime_ident_name(ce.span);
+    if (ns.len == 0) { ret false; }
+    ret view_eq_str(span_text(source, ns), "error");
+}
+
+# error_message: the folded message of a `$error("msg")` directive call (#1511).
+# the directive takes exactly one argument that folds to a comptime string; the
+# returned text is the diagnostic a reached `$error` emits. a wrong arity or a
+# non-string / unfoldable argument yields an error describing the malformation,
+# which is itself surfaced as the build-failing diagnostic.
+# ---
+# c:        the comptime context
+# a:        the ast that owns `eid`
+# source:   source text
+# eid:      a `$error(...)` call expression id
+# interner: shared string interner
+# ret:      the message text, or an error describing the malformed directive
+pub fun error_message(
+    c:        *ComptimeCtx,
+    a:        *ast.Ast,
+    source:   str,
+    eid:      id.ExprId,
+    interner: *intern.Interner
+) Result[str, str] {
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret err[str, str]("comptime `$error` directive is malformed"); }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL || node.data.call.args_len != 1) {
+        ret err[str, str]("comptime `$error` takes one string-literal message");
+    }
+    val arg: id.ExprId = a.expr_ids[node.data.call.args_start];
+    val ev: Result[CTValue, str] = eval(c, a, source, arg, interner);
+    if (is_err[CTValue, str](ev)) { ret err[str, str](unwrap_err[CTValue, str](ev)); }
+    val v: CTValue = unwrap_ok[CTValue, str](ev);
+    if (v.kind != CT_KIND_STR) { ret err[str, str]("comptime `$error` message must be a string"); }
+    val txt: Option[str] = intern.lookup(interner, v.data.s);
+    if (is_none[str](txt)) { ret err[str, str]("comptime `$error` message could not be read"); }
+    ret ok[str, str](unwrap[str](txt));
+}
+
 # type_operand_value: the expression whose type identity a type-comparison operand
 # denotes. `$type_of(e)` denotes the type of its inner value `e`; any other
 # operand is a type-name spelling (`i64`, `module.Foo`) and denotes itself. the

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -213,8 +213,30 @@ pub fun parse_stmt(p: *parser.Parser) id.StmtId {
     if (parser.at(p, token.KIND_DOLLAR) && peek_is_kw(p, 1, "each")) {
         ret parse_comptime_each_stmt(p, start.span);
     }
+    if (parser.at(p, token.KIND_DOLLAR) && peek_is_kw(p, 1, "error")) {
+        ret parse_comptime_directive_stmt(p, start.span);
+    }
 
     ret parse_expr_stmt(p, start.span);
+}
+
+# parses a bare statement-scope comptime directive `$intrinsic(args);` (e.g.
+# `$error("msg")`, #1511), mirroring the decl-scope `parse_comptime_directive_decl`.
+# the directive carries no value and emits no IR; a reached `$error` fails the
+# build at sema.
+fun parse_comptime_directive_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
+    val target: id.ExprId = pexpr.parse_expr(p);
+    val end: token.Token = parser.current(p);
+    parser.expect(p, token.KIND_SEMI, "expected ';' after comptime directive");
+
+    var attr: stmt.StmtComptimeAttr;
+    attr.target = target;
+
+    var node: stmt.Stmt;
+    node.span = parser.span_of(start, end.span);
+    node.kind = stmt.STMT_KIND_COMPTIME_ATTR;
+    node.data.comptime_attr = attr;
+    ret parser.push_stmt(p, node);
 }
 
 # parses visibility and linkage flags (pub / ext) in any order, zero or more times

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1628,6 +1628,11 @@ fun bind_stmt(rc: *ResolveContext, sid: id.StmtId) Result[bool, str] {
     if (s.kind == stmt.STMT_KIND_COMPTIME_EACH) {
         ret bind_comptime_each(rc, ?s.data.comptime_each);
     }
+    if (s.kind == stmt.STMT_KIND_COMPTIME_ATTR) {
+        # a bare comptime directive (`$error(...)`) binds nothing; its evaluation
+        # is handled out of band at sema.
+        ret ok[bool, str](true);
+    }
     ret ok[bool, str](true);
 }
 

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -466,8 +466,10 @@ fun infer_one_body(sc: *ctxm.SemaContext, did: id.DeclId) Result[bool, str] {
         ret infer_binding_init(sc, did, d);
     }
     if (d.kind == decl.DECL_KIND_COMPTIME_ATTR) {
-        # a bare comptime directive (`$error(...)`) carries no assignable value
-        # to type; its evaluation is handled out of band.
+        # a bare comptime directive (`$error(...)`): evaluated here, on the body
+        # pass that recurses only into the selected comptime-if arm, so a reached
+        # `$error` fails the build (#1511) while a dead arm's directive is skipped.
+        eval_comptime_directive(sc, d.data.comptime_attr.target, d.span);
         ret ok[bool, str](true);
     }
     ret ok[bool, str](true);
@@ -685,8 +687,29 @@ fun infer_stmt(sc: *ctxm.SemaContext, sid: id.StmtId, fn_ret: type.TypeId) Resul
     if (st.kind == stmt.STMT_KIND_COMPTIME_EACH) {
         ret infer_stmt_comptime_each(sc, ?st.data.comptime_each, st.span, fn_ret);
     }
+    if (st.kind == stmt.STMT_KIND_COMPTIME_ATTR) {
+        eval_comptime_directive(sc, st.data.comptime_attr.target, st.span);
+        ret ok[bool, str](true);
+    }
     # BRK, CNT, ASM, ERROR carry no expressions to infer
     ret ok[bool, str](true);
+}
+
+# evaluates a reached comptime directive (`$error("msg")`, #1511). a `$error`
+# directive fails the build with its folded message. the directive is reached
+# only on a live path — a selected comptime arm or an unconditional position — so
+# sema's per-arm walk (decl-scope active-arm recursion, statement-scope fold /
+# prune) fires it exactly when the surrounding code would compile, and never for a
+# pruned dead arm. a non-`$error` directive target is left as a no-op.
+fun eval_comptime_directive(sc: *ctxm.SemaContext, target: id.ExprId, span: token.Span) {
+    if (target == id.EXPR_NIL) { ret; }
+    if (!comptime.is_error_call(sc.a, sc.source, target)) { ret; }
+    val m: Result[str, str] = comptime.error_message(sc.ctx, sc.a, sc.source, target, ?sc.s.interner);
+    if (is_err[str, str](m)) {
+        ctxm.report(sc, span, unwrap_err[str, str](m));
+        ret;
+    }
+    ctxm.report(sc, span, unwrap_ok[str, str](m));
 }
 
 # type-checks a `$each <ident> in $fields(T) { body }` (#1473) by unrolling it:
@@ -749,13 +772,28 @@ fun infer_stmt_list(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: type.Ty
 }
 
 fun infer_stmt_comptime_if(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: type.TypeId) Result[bool, str] {
-    # a chain gated on a comptime value parameter, or on a type comparison
-    # (`$type_of(...)`, #1472), cannot select an arm at sema time — the
-    # parameter's value is fixed per call site, and a type comparison folds only
-    # once the type resolver is installed at lowering. type-check EVERY arm
-    # structurally; arm selection is deferred to per-value monomorphization.
-    if (stmt_comptime_if_gated_on_param(sc, start, len)
-        || stmt_comptime_if_has_type_comparison(sc, start, len)) {
+    val param_gated:  bool = stmt_comptime_if_gated_on_param(sc, start, len);
+    val has_type_cmp: bool = stmt_comptime_if_has_type_comparison(sc, start, len);
+
+    # a type-comparison chain (`$type_of(x) == T`, #1472) NOT gated on a comptime
+    # value parameter folds at monomorphization, where the type resolver is
+    # installed and x's concrete type is known: prune the provably-dead arms and
+    # type-check ONLY the selected one (#1511), so a clean no-cast skeleton
+    # compiles directly. when a gate cannot fold yet — the original sema pass
+    # installs no resolver, or x is still an abstract generic param — the prune
+    # defers and the all-arms check below runs unchanged.
+    if (has_type_cmp && !param_gated) {
+        val pr: Result[bool, str] = prune_type_comparison_chain(sc, start, len, fn_ret);
+        if (is_err[bool, str](pr)) { ret pr; }
+        if (unwrap_ok[bool, str](pr)) { ret ok[bool, str](true); }
+    }
+
+    # a chain gated on a comptime value parameter, or a type-comparison chain that
+    # did not fold above, cannot select an arm at sema time — the parameter's value
+    # is fixed per call site, and an unresolved type comparison folds only once the
+    # resolver is installed at lowering. type-check EVERY arm structurally; arm
+    # selection is deferred to per-value monomorphization.
+    if (param_gated || has_type_cmp) {
         var ai: u32 = 0;
         for (ai < len) {
             val arm: *decl.ComptimeBranch = ?sc.a.comptime_branches[start + ai];
@@ -791,6 +829,48 @@ fun infer_stmt_comptime_if(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: 
         }
         bi = bi + 1;
     }
+    ret ok[bool, str](true);
+}
+
+# folds a non-param-gated type-comparison `$if` chain and type-checks only the
+# selected arm, pruning the provably-dead arms (#1511). returns true once the
+# chain fully folds — the selected arm (if any) is checked and the rest are left
+# untyped — and false when a gate cannot be folded yet, in which case the caller
+# type-checks every arm. only the live arm is checked, so an arm written for one
+# concrete type never fails against another. the chain folds during monomorphization
+# (the type resolver installed, x's type concrete); in the original sema pass no
+# resolver is installed, so the first gate defers and every arm is checked instead.
+fun prune_type_comparison_chain(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: type.TypeId) Result[bool, str] {
+    var i: u32 = 0;
+    for (i < len) {
+        val arm: *decl.ComptimeBranch = ?sc.a.comptime_branches[start + i];
+        if (arm.cond == id.EXPR_NIL) {
+            # the unconditional final `$or {}` arm: reached only when every prior
+            # gate folded false, so it is the selected arm.
+            val rb: Result[bool, str] = infer_stmt_list(sc, arm.body_start, arm.body_len, fn_ret);
+            if (is_err[bool, str](rb)) { ret rb; }
+            ret ok[bool, str](true);
+        }
+        # type the gate (populating the operand types the resolver reads), then
+        # fold it. a gate that does not fold to a bool defers the whole chain.
+        val saved_gate: bool = sc.in_comptime_gate;
+        sc.in_comptime_gate = true;
+        infer.infer_expr(sc, arm.cond);
+        sc.in_comptime_gate = saved_gate;
+
+        val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, arm.cond, ?sc.s.interner);
+        if (is_err[comptime.CTValue, str](ev)) { ret ok[bool, str](false); }
+        val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
+        if (v.kind != comptime.CT_KIND_BOOL) { ret ok[bool, str](false); }
+        if (v.data.b) {
+            val rb: Result[bool, str] = infer_stmt_list(sc, arm.body_start, arm.body_len, fn_ret);
+            if (is_err[bool, str](rb)) { ret rb; }
+            ret ok[bool, str](true);
+        }
+        # gate folded false: this arm is provably dead — prune it (skip checking).
+        i = i + 1;
+    }
+    # every gated arm folded false with no final `$or {}`: no arm is selected.
     ret ok[bool, str](true);
 }
 

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -84,6 +84,9 @@ pub fun lower_stmt(ctx: *lower.LowerContext, sid: aid.StmtId) Result[bool, str] 
     if (k == astmt.STMT_KIND_ASM)         { ret lower_asm(ctx, s); }
     if (k == astmt.STMT_KIND_COMPTIME_IF) { ret lower_comptime_if(ctx, s); }
     if (k == astmt.STMT_KIND_COMPTIME_EACH) { ret lower_comptime_each(ctx, s); }
+    # a comptime directive (`$error(...)`) is compile-time-only and emits no IR;
+    # a reached `$error` already failed the build at sema (#1511).
+    if (k == astmt.STMT_KIND_COMPTIME_ATTR) { ret ok[bool, str](true); }
     if (k == astmt.STMT_KIND_ERROR) {
         # an error stmt must never reach lowering: the driver aborts on
         # accumulated diagnostics before the middle end runs.


### PR DESCRIPTION
Closes #1511.

Two comptime-ergonomics gaps surfaced by the type-directed `{}` formatter in mach-std #282. Both are fixed so the clean no-cast `$type_of` dispatch skeleton compiles and is statically total.

## Gap 1 — prune dead `$type_of` arms at sema
Sema used to type-check **every** arm of a `$if ($type_of(x) == T) {...} $or {...}` chain against `x`'s concrete type, so an arm written for type B failed once `x` was concretely type A (the workaround was a per-arm identity cast plus a `usize` hop). Now, when the chain is a type comparison and not gated on a comptime value parameter, sema folds each gate and type-checks **only the selected arm**, pruning the provably-dead ones. Folding happens at monomorphization (the type resolver installed, `x`'s type concrete); in the original sema pass no resolver is installed, so the chain defers to the existing all-arms check unchanged.

## Gap 2 — `$error` in statement position (and a real evaluation)
`$error("msg")` previously parsed as a comptime directive but the compiler never evaluated it (a silent no-op). It is now a real compile-time directive that fails the build with its message **when reached on a live path** — an unconditional position or a selected `$if`/`$or` arm; a dead arm's `$error` never fires. It is valid in both declaration and statement scope, so a type-directed dispatch fails at **compile** time on an unhandled type instead of falling through to a runtime fallback.

## Changes
- `src/lang/fe/sema.mach` — `prune_type_comparison_chain`; `eval_comptime_directive` wired into `infer_stmt` (statement scope) and `infer_one_body` (decl scope).
- `src/lang/fe/comptime.mach` — `is_error_call` / `error_message` helpers.
- `src/lang/fe/ast/stmt.mach`, `src/lang/fe/parser/decl.mach` — `STMT_KIND_COMPTIME_ATTR` + statement-scope directive parsing.
- `src/lang/fe/resolve.mach`, `src/lang/me/lower/stmt.mach` — bind / lower the directive statement (no IR).
- `.github/tests/comptimedispatch/` — fresh-compiler regression: a clean no-cast dispatch that compiles and routes per arm, and a statement-position `$error` that fails the build with its diagnostic.
- `doc/language/{comptime-intrinsics,comptime-control}.md` — document `$error` evaluation and `$type_of` arm pruning.

## Verification
- Self-host fixpoint holds: seed(2.0.1) → stage1 → stage2 → stage3 byte-identical (`0ddc95dc…`); the compiler source uses neither new path, so its self-emission is unchanged.
- `mach test .` — 538 passed, 0 failed.
- `.github/tests/comptimedispatch` passes on the fresh compiler; the 2.0.1 seed fails it (proving the feature), for exactly the two gaps above.
- comptime/pack integration suites (comptimeroots, eachfields, packmono/fwd/xmod) pass.