### PR TITLE
release: mach 2.1.0

### DIFF
--- a/.github/tests/comptimedispatch/clean/mach.toml
+++ b/.github/tests/comptimedispatch/clean/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "ctdispatch-clean"
+name    = "Comptime dispatch — clean no-cast $type_of skeleton"
+version = "1.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.clean]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.12.0"

--- a/.github/tests/comptimedispatch/clean/src/main.mach
+++ b/.github/tests/comptimedispatch/clean/src/main.mach
@@ -1,0 +1,36 @@
+use std.runtime;
+use std.types.string.str;
+
+# the clean no-cast type-directed `$type_of` dispatch skeleton (#1511). each arm
+# uses `arg` at its OWN concrete type with no per-arm identity cast: sema prunes
+# the provably-dead arms at monomorphization, so an arm written for `str` is never
+# type-checked against a `u64` element (and vice versa). this is the form the §5
+# vformat skeleton wants; before #1511 it required a cast in every arm.
+
+fun take_u64(x: u64) u64 { ret x; }
+fun take_str(x: str) u64 { if (x == nil) { ret 0; } ret 1; }
+
+fun show(va: ...) u64 {
+    var total: u64 = 0;
+    $each arg in va {
+        var n: u64 = 0;
+        $if ($type_of(arg) == u64) {
+            n = take_u64(arg);
+        } $or ($type_of(arg) == str) {
+            n = take_str(arg);
+        } $or {
+            $error("show: unsupported argument type");
+        }
+        total = total + n;
+    }
+    ret total;
+}
+
+# exits 0 only when the dispatch routed each element to its own arm: 42 (u64) +
+# 1 (a non-nil str) == 43.
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    val n: u64 = show(42::u64, "hello");
+    if (n != 43) { ret 1; }
+    ret 0;
+}

--- a/.github/tests/comptimedispatch/run.sh
+++ b/.github/tests/comptimedispatch/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# type-directed comptime dispatch integration test (#1511). two halves:
+#
+#   clean — the no-cast `$type_of` dispatch skeleton must COMPILE: each arm uses
+#   the loop variable at its own concrete type with no per-arm cast, and sema
+#   prunes the provably-dead arms at monomorphization. the app exits 0 only when
+#   the dispatch routed each element to its own arm (42 + 1 == 43).
+#
+#   unhandled — a statement-position `$error` in the unhandled-type `$or {}` arm
+#   must FAIL the build with its message verbatim, so a type-directed dispatch
+#   fails at COMPILE time on an unhandled type instead of a runtime fallback.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+# the exact diagnostic the unhandled app's `$error` directive emits.
+ERROR_DIAG='show: unsupported argument type'
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# build_and_run <app-dir> <label>: vendor std, build, run, require exit 0.
+build_and_run() {
+    local app="$1"; local label="$2"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    if ! ( cd "$dst" && "$MACH" build . ) >/dev/null 2>&1; then
+        echo "FAIL comptimedispatch/$label: build failed" >&2; fail=1; return
+    fi
+    local bin
+    bin="$(find "$dst/out" -type f -path '*/bin/*' | head -n1)"
+    if [ -z "$bin" ]; then
+        echo "FAIL comptimedispatch/$label: no binary produced" >&2; fail=1; return
+    fi
+    set +e
+    "$bin"; local code=$?
+    set -e
+    if [ "$code" -ne 0 ]; then
+        echo "FAIL comptimedispatch/$label: dispatch routed wrong (exit $code)" >&2; fail=1; return
+    fi
+    echo "PASS comptimedispatch/$label: clean no-cast \$type_of dispatch compiles and routes per arm"
+}
+
+# expect_error <app-dir> <label> <diagnostic>: vendor std, build, require the
+# build to FAIL with `diagnostic` present verbatim on stderr.
+expect_error() {
+    local app="$1"; local label="$2"; local want="$3"
+    local dst="$WORK/$app"
+    cp -r "$HERE/$app" "$dst"
+    mkdir -p "$dst/dep"
+    ln -s "$STD" "$dst/dep/mach-std"
+    local out
+    if out="$( cd "$dst" && "$MACH" build . 2>&1 )"; then
+        echo "FAIL comptimedispatch/$label: build unexpectedly succeeded on an unhandled type" >&2; fail=1; return
+    fi
+    if ! printf '%s' "$out" | grep -qF -- "$want"; then
+        echo "FAIL comptimedispatch/$label: missing the \$error diagnostic; got:" >&2
+        printf '%s\n' "$out" >&2; fail=1; return
+    fi
+    echo "PASS comptimedispatch/$label: statement-position \$error fails the build with its message"
+}
+
+build_and_run clean     "clean no-cast dispatch"
+expect_error  unhandled "statement-position \$error" "$ERROR_DIAG"
+
+exit "$fail"

--- a/.github/tests/comptimedispatch/unhandled/mach.toml
+++ b/.github/tests/comptimedispatch/unhandled/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "ctdispatch-unhandled"
+name    = "Comptime dispatch — statement-position $error on an unhandled type"
+version = "1.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.unhandled]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.12.0"

--- a/.github/tests/comptimedispatch/unhandled/src/main.mach
+++ b/.github/tests/comptimedispatch/unhandled/src/main.mach
@@ -1,0 +1,33 @@
+use std.runtime;
+use std.types.string.str;
+
+# a statement-position `$error` in the unhandled-type `$or {}` arm (#1511). when a
+# call passes an element of a type no arm handles, sema selects this arm and the
+# `$error` directive fails the build at COMPILE time — replacing the runtime
+# fallback a type-directed dispatch would otherwise need.
+
+fun take_u64(x: u64) u64 { ret x; }
+fun take_str(x: str) u64 { if (x == nil) { ret 0; } ret 1; }
+
+fun show(va: ...) u64 {
+    var total: u64 = 0;
+    $each arg in va {
+        var n: u64 = 0;
+        $if ($type_of(arg) == u64) {
+            n = take_u64(arg);
+        } $or ($type_of(arg) == str) {
+            n = take_str(arg);
+        } $or {
+            $error("show: unsupported argument type");
+        }
+        total = total + n;
+    }
+    ret total;
+}
+
+# `7::i32` is handled by no arm, so the `$or {}` arm's `$error` fires at build time.
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    val n: u64 = show(42::u64, 7::i32);
+    ret 0;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-06-19
+
+Minor — comptime type-directed-dispatch ergonomics and multi-artifact tooling
+graphs, surfaced while building the mach-std `{}` formatter and loading
+multi-binary projects in mach-lsp.
+
+### Added
+
+- driver: the long-lived tooling union (`build_project_union`) now unions the
+  import closure over **every declared artifact** (the full target × artifact
+  matrix), not just one — a multi-artifact project (`[bin.*]` + `[lib.*]`) loads
+  its whole module graph in tooling/LSP instead of erroring on artifact
+  ambiguity. Single-artifact builds and the `mach build`/`mach run` ambiguity
+  guard are unchanged (#1505).
+- comptime: `$error("msg")` is now a real compile-time directive — it fails the
+  build with its message when reached on a live path (an unconditional position
+  or a selected `$if`/`$or` arm; a dead arm's `$error` never fires) and is valid
+  in both declaration and statement scope. It was previously parsed as a silent
+  no-op (#1511).
+
+### Changed
+
+- comptime/sema: a `$type_of`-comparison `$if`/`$or` chain now type-checks only
+  the **selected** arm, pruning provably-dead arms at monomorphization.
+  Type-directed dispatch over a concrete type no longer needs per-arm identity
+  casts and is statically total (#1511).
+
 ## [2.0.1] - 2026-06-19
 
 Patch — parser error-recovery and a grammar-doc fix surfaced while migrating the

--- a/doc/language/comptime-control.md
+++ b/doc/language/comptime-control.md
@@ -133,6 +133,12 @@ type checking run over **all** arms structurally, and only the selected arm is
 emitted into each instance. Each arm must therefore be independently
 resolvable and type-checkable.
 
+A `$if` gated on a `$type_of` type comparison is *not* such an exception: at
+monomorphization the operand's concrete type is known, so the provably-dead arms
+are **pruned** and only the selected arm is type-checked (and emitted). Each arm
+may therefore use its value at its own concrete type with no per-arm cast — see
+[comptime-intrinsics.md](comptime-intrinsics.md).
+
 ## See also
 
 - [comptime-mach.md](comptime-mach.md) — `$mach.*` for target reads

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -44,6 +44,11 @@ A bare type name (e.g. `i64`, `str`, `Point`) is the other valid operand.
 The comparison selects one branch at compile time per monomorphization
 instance — useful for per-element type dispatch inside `$each` bodies.
 
+The provably-dead arms are **pruned** before type-checking, so each arm uses
+`arg` at its own concrete type with no per-arm cast: the `str` arm above is
+never checked against a `u64` element. Only the selected arm is type-checked
+and emitted.
+
 ## Field intrinsic and projection
 
 `$fields(T)` produces a comptime sequence of field descriptors for record or
@@ -156,26 +161,31 @@ See [variadics.md](variadics.md) for the pack form (`$each a in va`).
 
 ## Diagnostic intrinsics
 
-> **Not yet implemented.** `$error` and `$assert` parse as comptime
-> directives but the compiler does not yet evaluate them — a `$error(...)`
-> directive is currently accepted and ignored rather than failing
-> compilation. The shapes below describe the intended behavior.
+`$error("msg")` fails compilation with `msg` when it is **reached** — on a live
+path: an unconditional position, or a `$if` / `$or` arm the compiler selects. A
+`$error` in a discarded (dead) arm never fires, so it is the natural total-
+coverage fallback for a `$type_of` dispatch — the unhandled-type `$or {}` arm
+fails the build at compile time instead of falling through to a runtime error.
 
-Operate at compile time. `$error` fails compilation; `$assert` is sugar
-over `$if` plus `$error`.
-
-```mach
-$error("msg")
-$assert(cond, "msg")    # sugar: $if (!cond) { $error("msg"); }
-```
+`$error` is valid in both declaration and statement scope and takes one
+string-literal message.
 
 ```mach
-$assert($size_of(i64) == 8, "expected 64-bit i64");
+$error("msg")           # fails compilation when reached
 
 $if (!supported) {
     $error("this target is not supported");
 }
+
+$if ($type_of(arg) == i64) { write_i64(w, arg); }
+$or ($type_of(arg) == str) { write_str(w, arg); }
+$or { $error("no writer for this argument type"); }    # compile error on an unhandled type
 ```
+
+> **`$assert` not yet implemented.** `$assert` parses as a comptime directive
+> but the compiler does not yet evaluate it. It is intended as sugar over `$if`
+> plus `$error` — `$assert(cond, "msg")` ≡ `$if (!cond) { $error("msg"); }`,
+> e.g. `$assert($size_of(i64) == 8, "expected 64-bit i64");`.
 
 ## Not provided as intrinsics
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.0.1"
+version = "2.1.0"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -291,6 +291,14 @@ pub rec Project {
     union_tuples:       *TargetTuple;
     union_tuple_count:  u32;
 
+    # union build (#1505): the entry-module FQN of every declared artifact, so the
+    # union loads the import closure over the whole (target × artifact) matrix — not
+    # just the primary artifact's. Recorded in `load_config` under `for_union`,
+    # walked after the primary `dfs_load` in `build_project_impl` (dedup by FQN is
+    # automatic). nil/0 on a single-artifact or single-target build.
+    union_entries:      *intern.StrId;
+    union_entry_count:  u32;
+
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
 
@@ -477,6 +485,20 @@ fun build_project_impl(s: *sess.Session, project_root: str, sel: *manifest.Selec
         ret err[Project, str](unwrap_err[sess.ModuleId, str](load_r));
     }
 
+    # union build (#1505): load every other declared artifact's entry into the same
+    # Project so tooling sees the closure over the whole (target × artifact) matrix,
+    # not just the primary artifact's. dfs_load dedups by FQN, so the primary entry
+    # (also present in union_entries) re-loads as a no-op, as do shared modules.
+    var ei: u32 = 0;
+    for (ei < p.union_entry_count) {
+        val ear: Result[sess.ModuleId, str] = dfs_load(?p, p.union_entries[ei]);
+        if (is_err[sess.ModuleId, str](ear)) {
+            dnit_project(?p);
+            ret err[Project, str](unwrap_err[sess.ModuleId, str](ear));
+        }
+        ei = ei + 1;
+    }
+
     # the module table is stable past the load pass; publish every module's
     # AST to the session registry so later phases can reach cross-module
     # declarations (imported record fields, generics from transitive deps).
@@ -520,15 +542,18 @@ pub fun build_project_sel(s: *sess.Session, project_root: str, sel: *manifest.Se
     ret build_project_impl(s, project_root, sel, false);
 }
 
-# build_project_union: build the union of EVERY manifest target's import closure
-# into one deduplicated Project, for long-lived multi-target tooling (#1391).
-# Modules are deduped by FQN. A module reachable only via a non-default target's
-# `$if` is still loaded and present — so workspace-wide tooling (e.g. rename) sees
-# it (lsp #58) — and is resolved under the DEFAULT target's ctx ("default target's
-# branches win", the documented v1 default). A module that does not fully resolve
-# under that ctx records per-module diagnostics and the Project stays usable; the
-# union build is not aborted. For ordinary single-target builds use
-# build_project_sel.
+# build_project_union: build the union of EVERY manifest target's AND artifact's
+# import closure into one deduplicated Project, for long-lived multi-target tooling
+# (#1391, #1505). Modules are deduped by FQN. A module reachable only via a
+# non-default target's `$if`, or only from a non-primary artifact's entry, is still
+# loaded and present — so workspace-wide tooling (e.g. rename) sees it (lsp #58) —
+# and is resolved under the DEFAULT target's ctx ("default target's branches win",
+# the documented v1 default). Several declared artifacts with no `--bin/--lib`
+# selector is NOT the ambiguity error `build_project_sel` raises: the union takes
+# the first declared artifact as the primary (ctx) and loads the rest's entries
+# too. A module that does not fully resolve under the default ctx records per-module
+# diagnostics and the Project stays usable; the union build is not aborted. For
+# ordinary single-target builds use build_project_sel.
 pub fun build_project_union(s: *sess.Session, project_root: str) Result[Project, str] {
     var sel: manifest.Selection;
     sel.target       = "";
@@ -577,6 +602,91 @@ fun populate_union_tuples(p: *Project, m: *manifest.Manifest) Result[bool, str] 
     p.union_tuple_count = n;
     p.union             = true;
     ret ok[bool, str](true);
+}
+
+# populate_union_entries: record the entry-module FQN of every declared artifact —
+# each artifact's base `entry` plus any per-cell `[*.target.*]` entry override —
+# deduped by FQN, so the union load walk covers the whole (target × artifact)
+# matrix (#1505). Requires `p.config.id` set (the FQN head). A manifest with no
+# artifacts is a no-op. Idempotent re-loads (the primary entry is among these) are
+# absorbed by `dfs_load`'s FQN dedup.
+fun populate_union_entries(p: *Project, m: *manifest.Manifest) Result[bool, str] {
+    if (m.artifact_count == 0) { ret ok[bool, str](true); }
+
+    # upper bound: one base entry per artifact plus every cell entry override.
+    var cap: u32 = 0;
+    var k: u32 = 0;
+    for (k < m.artifact_count) {
+        cap = cap + 1 + m.artifacts[k].cell_count;
+        k = k + 1;
+    }
+
+    val er: Result[*intern.StrId, str] = allocate[intern.StrId](p.s.alloc, cap::usize);
+    if (is_err[*intern.StrId, str](er)) { ret err[bool, str](unwrap_err[*intern.StrId, str](er)); }
+    val entries: *intern.StrId = unwrap_ok[*intern.StrId, str](er);
+
+    val id_opt: Option[str] = intern.lookup(?p.s.interner, p.config.id);
+    if (is_none[str](id_opt)) {
+        deallocate[intern.StrId](p.s.alloc, entries, cap::usize);
+        ret err[bool, str]("internal: union project id not interned");
+    }
+    val id_text: str = unwrap[str](id_opt);
+
+    var w: u32 = 0;
+    k = 0;
+    for (k < m.artifact_count) {
+        val a: *manifest.ArtifactDef = ?m.artifacts[k];
+        val br: Result[u32, str] = add_union_entry(p, entries, w, cap, id_text, a.entry);
+        if (is_err[u32, str](br)) { deallocate[intern.StrId](p.s.alloc, entries, cap::usize); ret err[bool, str](unwrap_err[u32, str](br)); }
+        w = unwrap_ok[u32, str](br);
+        var c: u32 = 0;
+        for (c < a.cell_count) {
+            if (a.cells[c].entry != intern.STR_NIL) {
+                val cr: Result[u32, str] = add_union_entry(p, entries, w, cap, id_text, a.cells[c].entry);
+                if (is_err[u32, str](cr)) { deallocate[intern.StrId](p.s.alloc, entries, cap::usize); ret err[bool, str](unwrap_err[u32, str](cr)); }
+                w = unwrap_ok[u32, str](cr);
+            }
+            c = c + 1;
+        }
+        k = k + 1;
+    }
+
+    # shrink to the deduped count so the freed size matches the allocation exactly
+    # (the page allocator's deallocate munmaps the recorded byte span).
+    if (w < cap) {
+        val sr: Result[*intern.StrId, str] = reallocate[intern.StrId](p.s.alloc, entries, cap::usize, w::usize);
+        if (is_err[*intern.StrId, str](sr)) {
+            deallocate[intern.StrId](p.s.alloc, entries, cap::usize);
+            ret err[bool, str](unwrap_err[*intern.StrId, str](sr));
+        }
+        p.union_entries = unwrap_ok[*intern.StrId, str](sr);
+    }
+    or {
+        p.union_entries = entries;
+    }
+    p.union_entry_count = w;
+    ret ok[bool, str](true);
+}
+
+# add_union_entry: compose the FQN of `entry_id` (an artifact/cell entry-source
+# path) under project id `id_text` and append it to `entries[0, w)` if not already
+# present, returning the new count. dedups by FQN StrId so shared entries are
+# recorded once.
+fun add_union_entry(p: *Project, entries: *intern.StrId, w: u32, cap: u32, id_text: str, entry_id: intern.StrId) Result[u32, str] {
+    val ep_opt: Option[str] = intern.lookup(?p.s.interner, entry_id);
+    if (is_none[str](ep_opt)) { ret err[u32, str]("internal: union artifact entry not interned"); }
+    val fqn_r: Result[intern.StrId, str] = compose_module_fqn(p, id_text, unwrap[str](ep_opt));
+    if (is_err[intern.StrId, str](fqn_r)) { ret err[u32, str](unwrap_err[intern.StrId, str](fqn_r)); }
+    val fqn: intern.StrId = unwrap_ok[intern.StrId, str](fqn_r);
+
+    var i: u32 = 0;
+    for (i < w) {
+        if (entries[i] == fqn) { ret ok[u32, str](w); }
+        i = i + 1;
+    }
+    if (w >= cap) { ret err[u32, str]("internal: union entry count exceeded capacity"); }
+    entries[w] = fqn;
+    ret ok[u32, str](w + 1);
 }
 
 # register_export_names: scan every module for `` `symbol("...")` `` decorators
@@ -830,6 +940,9 @@ pub fun dnit_project(p: *Project) {
     if (p.union_tuples != nil && p.union_tuple_count > 0) {
         deallocate[TargetTuple](p.s.alloc, p.union_tuples, p.union_tuple_count::usize);
     }
+    if (p.union_entries != nil && p.union_entry_count > 0) {
+        deallocate[intern.StrId](p.s.alloc, p.union_entries, p.union_entry_count::usize);
+    }
     map.dnit[intern.StrId, sess.ModuleId](?p.by_fqn);
     deallocate_config(?p.config, p.s.alloc);
 
@@ -844,6 +957,8 @@ fun init_project(p: *Project, s: *sess.Session) {
     p.union              = false;
     p.union_tuples       = nil;
     p.union_tuple_count  = 0;
+    p.union_entries      = nil;
+    p.union_entry_count  = 0;
     p.target.os_id   = os.OS_UNKNOWN;
     p.target.arch_id = isa.ARCH_UNKNOWN;
     p.target.abi_id  = 0;
@@ -944,7 +1059,26 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     if (is_err[manifest.Manifest, str](mr)) { ret err[bool, str](unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = unwrap_ok[manifest.Manifest, str](mr);
 
-    val ur: Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(p.s.alloc, ?p.s.interner, ?m, @sel);
+    # the primary selection drives the ctx every module resolves under. union mode
+    # (#1505): several declared artifacts with no selector is NOT the ambiguity
+    # `build_project_sel` raises — the union takes the first declared artifact as the
+    # primary (mirroring resolve_native's first-declared-target fallback) and unions
+    # the rest's entries below. a single-artifact or selected build is untouched.
+    var eff_sel: manifest.Selection;
+    eff_sel.target       = sel.target;
+    eff_sel.profile      = sel.profile;
+    eff_sel.artifact     = sel.artifact;
+    eff_sel.want_lib     = sel.want_lib;
+    eff_sel.has_artifact = sel.has_artifact;
+    if (for_union && !eff_sel.has_artifact && m.artifact_count > 1) {
+        val an_opt: Option[str] = intern.lookup(?p.s.interner, m.artifacts[0].name);
+        if (is_none[str](an_opt)) { manifest.dnit(?m, p.s.alloc); ret err[bool, str]("internal: union primary artifact name not interned"); }
+        eff_sel.artifact     = unwrap[str](an_opt);
+        eff_sel.want_lib     = m.artifacts[0].is_lib;
+        eff_sel.has_artifact = true;
+    }
+
+    val ur: Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(p.s.alloc, ?p.s.interner, ?m, eff_sel);
     if (is_err[manifest.BuildUnit, str](ur)) {
         manifest.dnit(?m, p.s.alloc);
         ret err[bool, str](unwrap_err[manifest.BuildUnit, str](ur));
@@ -1025,10 +1159,14 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     if (is_err[bool, str](mc)) { manifest.dnit(?m, p.s.alloc); ret mc; }
 
     # multi-target tooling build (#1391): record every manifest target's tuple so
-    # the union load walk can follow each target's `$if` branches.
+    # the union load walk can follow each target's `$if` branches. multi-artifact
+    # tooling build (#1505): record every artifact's entry FQN so the union loads
+    # the closure over the whole (target × artifact) matrix.
     if (for_union) {
         val ut: Result[bool, str] = populate_union_tuples(p, ?m);
         if (is_err[bool, str](ut)) { manifest.dnit(?m, p.s.alloc); ret ut; }
+        val ue: Result[bool, str] = populate_union_entries(p, ?m);
+        if (is_err[bool, str](ue)) { manifest.dnit(?m, p.s.alloc); ret ue; }
     }
 
     manifest.dnit(?m, p.s.alloc);
@@ -2836,9 +2974,23 @@ fun ut_manifest() str {
     ret "[project]\nid = \"uniontest\"\nname = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\ntarget = \"native\"\nout = \"out/{target}/bin/{name}{ext}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\next = \".exe\"\n\n[bin.uniontest]\nentry = \"main.mach\"\n";
 }
 
-# ut_scaffold: materialize a temp project (mach.toml + src/<files>) on disk and
-# return its root path; the caller removes the tree via fs.remove_all.
+# ut_manifest_multi: a two-target, two-bin manifest for the multi-artifact union
+# tests (#1505). bin.alpha is the first declared artifact (the union/sel primary);
+# bin.beta is a second whose entry the union must also load. id is "uniontest" so
+# the per-file `use uniontest.*` paths and FQN assertions match ut_manifest's.
+fun ut_manifest_multi() str {
+    ret "[project]\nid = \"uniontest\"\nname = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\ntarget = \"native\"\nout = \"out/{target}/bin/{name}{ext}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\next = \".exe\"\n\n[bin.alpha]\nentry = \"alpha.mach\"\n\n[bin.beta]\nentry = \"beta.mach\"\n";
+}
+
+# ut_scaffold: materialize a temp project (the shared ut_manifest + src/<files>) on
+# disk and return its root path; the caller removes the tree via fs.remove_all.
 fun ut_scaffold(alloc: *Allocator, names: *str, texts: *str, n: u32) Result[str, str] {
+    ret ut_scaffold_m(alloc, ut_manifest(), names, texts, n);
+}
+
+# ut_scaffold_m: ut_scaffold with a caller-supplied mach.toml, so the multi-artifact
+# tests can scaffold a different manifest over the same src-file mechanism.
+fun ut_scaffold_m(alloc: *Allocator, manifest_text: str, names: *str, texts: *str, n: u32) Result[str, str] {
     val tf_r: Result[fs.TempFile, str] = fs.temp_create(alloc, "mach_union_test");
     if (is_err[fs.TempFile, str](tf_r)) { ret err[str, str](unwrap_err[fs.TempFile, str](tf_r)); }
     var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
@@ -2854,8 +3006,7 @@ fun ut_scaffold(alloc: *Allocator, names: *str, texts: *str, n: u32) Result[str,
     if (is_err[bool, str](d2)) { ret err[str, str](unwrap_err[bool, str](d2)); }
 
     val mf: str = ut_cc3(alloc, root, "/", "mach.toml");
-    val mb: str = ut_manifest();
-    val w0: Result[bool, str] = fs.write_file(mf, mb, str_len(mb), 420);
+    val w0: Result[bool, str] = fs.write_file(mf, manifest_text, str_len(manifest_text), 420);
     if (is_err[bool, str](w0)) { ret err[str, str](unwrap_err[bool, str](w0)); }
 
     var i: u32 = 0;
@@ -2872,6 +3023,20 @@ fun ut_scaffold(alloc: *Allocator, names: *str, texts: *str, n: u32) Result[str,
 # the temp tree, and return the Project. the session is the caller's to tear down.
 fun ut_build(s: *sess.Session, alloc: *Allocator, names: *str, texts: *str, n: u32) Result[Project, str] {
     val root_r: Result[str, str] = ut_scaffold(alloc, names, texts, n);
+    if (is_err[str, str](root_r)) { ret err[Project, str](unwrap_err[str, str](root_r)); }
+    val root: str = unwrap_ok[str, str](root_r);
+    val rr: Result[bool, str] = tgt.register_all(?s.registry);
+    if (is_err[bool, str](rr)) { fs.remove_all(alloc, root); ret err[Project, str](unwrap_err[bool, str](rr)); }
+    val pr: Result[Project, str] = build_project_union(s, root);
+    fs.remove_all(alloc, root);
+    ret pr;
+}
+
+# ut_build_multi: ut_build over the two-bin ut_manifest_multi, for the multi-artifact
+# union tests (#1505). scaffolds the src files, builds the union Project, removes the
+# temp tree, and returns it. the session is the caller's to tear down.
+fun ut_build_multi(s: *sess.Session, alloc: *Allocator, names: *str, texts: *str, n: u32) Result[Project, str] {
+    val root_r: Result[str, str] = ut_scaffold_m(alloc, ut_manifest_multi(), names, texts, n);
     if (is_err[str, str](root_r)) { ret err[Project, str](unwrap_err[str, str](root_r)); }
     val root: str = unwrap_ok[str, str](root_r);
     val rr: Result[bool, str] = tgt.register_all(?s.registry);
@@ -3163,6 +3328,98 @@ test "driver union: branch selection via the $project.target.os string tag exerc
     or (cm.target_abi != cb.target_abi)      { bad = 1; }
 
     dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver union: every artifact's entry closure is loaded, not just the primary's (#1505)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var names: [4]str;
+    names[0] = "alpha.mach"; names[1] = "beta.mach"; names[2] = "shared_a.mach"; names[3] = "beta_only.mach";
+    var texts: [4]str;
+    # alpha is the primary (first declared) bin; beta is a second bin. beta_only is
+    # reachable ONLY from beta's entry — a single-artifact build resolving alpha alone
+    # would never see it, so its presence proves the artifact axis is unioned.
+    texts[0] = "use uniontest.shared_a;\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "use uniontest.beta_only;\n\nfun main() i32 { ret 0; }\n";
+    texts[2] = "pub fun sa() i32 { ret 1; }\n";
+    texts[3] = "pub fun bo() i32 { ret 2; }\n";
+
+    val pr: Result[Project, str] = ut_build_multi(?s, ?alloc, ?names[0], ?texts[0], 4);
+    if (is_err[Project, str](pr)) { sess.dnit(?s); ret 1; }
+    var p: Project = unwrap_ok[Project, str](pr);
+
+    # both artifacts' entries and their closures land in one deduplicated Project.
+    var bad: i32 = 0;
+    if (!ut_has(?p, ?s, "uniontest.alpha"))     { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.beta"))      { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.shared_a"))  { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.beta_only")) { bad = 1; }
+
+    dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver union: an ambiguous multi-artifact default errors for a single build but loads for the union (#1505)" {
+    # the SAME multi-artifact project, built three ways on one reused session: a
+    # selector-less single build is ambiguous and must error; a --bin alpha build
+    # loads only alpha's closure (never beta_only); the union loads every artifact.
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    val rr: Result[bool, str] = tgt.register_all(?s.registry);
+    if (is_err[bool, str](rr)) { sess.dnit(?s); ret 1; }
+
+    var names: [4]str;
+    names[0] = "alpha.mach"; names[1] = "beta.mach"; names[2] = "shared_a.mach"; names[3] = "beta_only.mach";
+    var texts: [4]str;
+    texts[0] = "use uniontest.shared_a;\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "use uniontest.beta_only;\n\nfun main() i32 { ret 0; }\n";
+    texts[2] = "pub fun sa() i32 { ret 1; }\n";
+    texts[3] = "pub fun bo() i32 { ret 2; }\n";
+
+    val root_r: Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_multi(), ?names[0], ?texts[0], 4);
+    if (is_err[str, str](root_r)) { sess.dnit(?s); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    # 1) no selector: the ambiguity error build_project_sel raises must still fire.
+    var sel_none: manifest.Selection;
+    sel_none.target = ""; sel_none.profile = ""; sel_none.artifact = ""; sel_none.want_lib = false; sel_none.has_artifact = false;
+    val p0r: Result[Project, str] = build_project_sel(?s, root, ?sel_none);
+    if (is_ok[Project, str](p0r)) { var p0: Project = unwrap_ok[Project, str](p0r); dnit_project(?p0); bad = 1; }
+
+    # 2) --bin alpha: the single-selected build loads alpha's closure and NOT beta's.
+    var sel_alpha: manifest.Selection;
+    sel_alpha.target = ""; sel_alpha.profile = ""; sel_alpha.artifact = "alpha"; sel_alpha.want_lib = false; sel_alpha.has_artifact = true;
+    val par: Result[Project, str] = build_project_sel(?s, root, ?sel_alpha);
+    if (is_err[Project, str](par)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+    var pa: Project = unwrap_ok[Project, str](par);
+    if (!ut_has(?pa, ?s, "uniontest.alpha"))    { bad = 1; }
+    or (!ut_has(?pa, ?s, "uniontest.shared_a")) { bad = 1; }
+    or (ut_has(?pa, ?s, "uniontest.beta"))      { bad = 1; }
+    or (ut_has(?pa, ?s, "uniontest.beta_only")) { bad = 1; }
+    dnit_project(?pa);
+
+    # 3) the union loads every artifact, including the beta-only module.
+    val pur: Result[Project, str] = build_project_union(?s, root);
+    if (is_err[Project, str](pur)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+    var pu: Project = unwrap_ok[Project, str](pur);
+    if (!ut_has(?pu, ?s, "uniontest.alpha"))     { bad = 1; }
+    or (!ut_has(?pu, ?s, "uniontest.beta"))      { bad = 1; }
+    or (!ut_has(?pu, ?s, "uniontest.beta_only")) { bad = 1; }
+    dnit_project(?pu);
+
+    fs.remove_all(?alloc, root);
     sess.dnit(?s);
     ret bad;
 }

--- a/src/lang/fe/ast/stmt.mach
+++ b/src/lang/fe/ast/stmt.mach
@@ -22,6 +22,9 @@ pub val STMT_KIND_ASM:         StmtKind = 9;
 pub val STMT_KIND_COMPTIME_IF: StmtKind = 10;
 # a `$each <ident> in <seq> { body }` bounded compile-time unroll (#1473).
 pub val STMT_KIND_COMPTIME_EACH: StmtKind = 11;
+# a bare statement-scope comptime directive `$intrinsic(args);` (e.g. `$error(...)`,
+# #1511), parallel to the decl-scope DECL_KIND_COMPTIME_ATTR.
+pub val STMT_KIND_COMPTIME_ATTR: StmtKind = 12;
 pub val STMT_KIND_ERROR:       StmtKind = 255;
 
 # StmtExpr: a bare expression used as a statement.
@@ -115,6 +118,16 @@ pub rec StmtComptimeEach {
     body_len:   u32;
 }
 
+# StmtComptimeAttr: a bare statement-scope comptime-channel directive
+# `$intrinsic(args);` (e.g. `$error("msg")`, #1511), parallel to the decl-scope
+# DeclComptimeAttr. it carries no value and emits no IR; a reached `$error`
+# directive fails the build at sema.
+# ---
+# target: the directive call expression
+pub rec StmtComptimeAttr {
+    target: id.ExprId;
+}
+
 # Stmt: a syntactic statement node.
 # ---
 # span: byte range of the statement in source
@@ -134,5 +147,6 @@ pub rec Stmt {
         asm_:          StmtAsm;
         comptime_if:   StmtComptimeIf;
         comptime_each: StmtComptimeEach;
+        comptime_attr: StmtComptimeAttr;
     };
 }

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1269,6 +1269,64 @@ pub fun fields_type_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
     ret a.expr_ids[node.data.call.args_start];
 }
 
+# is_error_call: whether `eid` is a `$error(args)` compile-time directive call
+# (#1511), recognized structurally by a `$`-rooted COMPTIME_IDENT callee spelled
+# `error`. arity / message validity are checked by `error_message`, not here.
+# ---
+# a:      the ast that owns `eid`
+# source: source text (for the callee span)
+# eid:    expression id to test
+# ret:    true when `eid` is a `$error(...)` call
+pub fun is_error_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret false; }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL) { ret false; }
+    val ce_opt: Option[*expr.Expr] = ast.get_expr(a, node.data.call.callee);
+    if (is_none[*expr.Expr](ce_opt)) { ret false; }
+    val ce: *expr.Expr = unwrap[*expr.Expr](ce_opt);
+    if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret false; }
+    val ns: token.Span = comptime_ident_name(ce.span);
+    if (ns.len == 0) { ret false; }
+    ret view_eq_str(span_text(source, ns), "error");
+}
+
+# error_message: the folded message of a `$error("msg")` directive call (#1511).
+# the directive takes exactly one argument that folds to a comptime string; the
+# returned text is the diagnostic a reached `$error` emits. a wrong arity or a
+# non-string / unfoldable argument yields an error describing the malformation,
+# which is itself surfaced as the build-failing diagnostic.
+# ---
+# c:        the comptime context
+# a:        the ast that owns `eid`
+# source:   source text
+# eid:      a `$error(...)` call expression id
+# interner: shared string interner
+# ret:      the message text, or an error describing the malformed directive
+pub fun error_message(
+    c:        *ComptimeCtx,
+    a:        *ast.Ast,
+    source:   str,
+    eid:      id.ExprId,
+    interner: *intern.Interner
+) Result[str, str] {
+    val n_opt: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (is_none[*expr.Expr](n_opt)) { ret err[str, str]("comptime `$error` directive is malformed"); }
+    val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_CALL || node.data.call.args_len != 1) {
+        ret err[str, str]("comptime `$error` takes one string-literal message");
+    }
+    val arg: id.ExprId = a.expr_ids[node.data.call.args_start];
+    val ev: Result[CTValue, str] = eval(c, a, source, arg, interner);
+    if (is_err[CTValue, str](ev)) { ret err[str, str](unwrap_err[CTValue, str](ev)); }
+    val v: CTValue = unwrap_ok[CTValue, str](ev);
+    if (v.kind != CT_KIND_STR) { ret err[str, str]("comptime `$error` message must be a string"); }
+    val txt: Option[str] = intern.lookup(interner, v.data.s);
+    if (is_none[str](txt)) { ret err[str, str]("comptime `$error` message could not be read"); }
+    ret ok[str, str](unwrap[str](txt));
+}
+
 # type_operand_value: the expression whose type identity a type-comparison operand
 # denotes. `$type_of(e)` denotes the type of its inner value `e`; any other
 # operand is a type-name spelling (`i64`, `module.Foo`) and denotes itself. the

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -213,8 +213,30 @@ pub fun parse_stmt(p: *parser.Parser) id.StmtId {
     if (parser.at(p, token.KIND_DOLLAR) && peek_is_kw(p, 1, "each")) {
         ret parse_comptime_each_stmt(p, start.span);
     }
+    if (parser.at(p, token.KIND_DOLLAR) && peek_is_kw(p, 1, "error")) {
+        ret parse_comptime_directive_stmt(p, start.span);
+    }
 
     ret parse_expr_stmt(p, start.span);
+}
+
+# parses a bare statement-scope comptime directive `$intrinsic(args);` (e.g.
+# `$error("msg")`, #1511), mirroring the decl-scope `parse_comptime_directive_decl`.
+# the directive carries no value and emits no IR; a reached `$error` fails the
+# build at sema.
+fun parse_comptime_directive_stmt(p: *parser.Parser, start: token.Span) id.StmtId {
+    val target: id.ExprId = pexpr.parse_expr(p);
+    val end: token.Token = parser.current(p);
+    parser.expect(p, token.KIND_SEMI, "expected ';' after comptime directive");
+
+    var attr: stmt.StmtComptimeAttr;
+    attr.target = target;
+
+    var node: stmt.Stmt;
+    node.span = parser.span_of(start, end.span);
+    node.kind = stmt.STMT_KIND_COMPTIME_ATTR;
+    node.data.comptime_attr = attr;
+    ret parser.push_stmt(p, node);
 }
 
 # parses visibility and linkage flags (pub / ext) in any order, zero or more times

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1628,6 +1628,11 @@ fun bind_stmt(rc: *ResolveContext, sid: id.StmtId) Result[bool, str] {
     if (s.kind == stmt.STMT_KIND_COMPTIME_EACH) {
         ret bind_comptime_each(rc, ?s.data.comptime_each);
     }
+    if (s.kind == stmt.STMT_KIND_COMPTIME_ATTR) {
+        # a bare comptime directive (`$error(...)`) binds nothing; its evaluation
+        # is handled out of band at sema.
+        ret ok[bool, str](true);
+    }
     ret ok[bool, str](true);
 }
 

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -466,8 +466,10 @@ fun infer_one_body(sc: *ctxm.SemaContext, did: id.DeclId) Result[bool, str] {
         ret infer_binding_init(sc, did, d);
     }
     if (d.kind == decl.DECL_KIND_COMPTIME_ATTR) {
-        # a bare comptime directive (`$error(...)`) carries no assignable value
-        # to type; its evaluation is handled out of band.
+        # a bare comptime directive (`$error(...)`): evaluated here, on the body
+        # pass that recurses only into the selected comptime-if arm, so a reached
+        # `$error` fails the build (#1511) while a dead arm's directive is skipped.
+        eval_comptime_directive(sc, d.data.comptime_attr.target, d.span);
         ret ok[bool, str](true);
     }
     ret ok[bool, str](true);
@@ -685,8 +687,29 @@ fun infer_stmt(sc: *ctxm.SemaContext, sid: id.StmtId, fn_ret: type.TypeId) Resul
     if (st.kind == stmt.STMT_KIND_COMPTIME_EACH) {
         ret infer_stmt_comptime_each(sc, ?st.data.comptime_each, st.span, fn_ret);
     }
+    if (st.kind == stmt.STMT_KIND_COMPTIME_ATTR) {
+        eval_comptime_directive(sc, st.data.comptime_attr.target, st.span);
+        ret ok[bool, str](true);
+    }
     # BRK, CNT, ASM, ERROR carry no expressions to infer
     ret ok[bool, str](true);
+}
+
+# evaluates a reached comptime directive (`$error("msg")`, #1511). a `$error`
+# directive fails the build with its folded message. the directive is reached
+# only on a live path — a selected comptime arm or an unconditional position — so
+# sema's per-arm walk (decl-scope active-arm recursion, statement-scope fold /
+# prune) fires it exactly when the surrounding code would compile, and never for a
+# pruned dead arm. a non-`$error` directive target is left as a no-op.
+fun eval_comptime_directive(sc: *ctxm.SemaContext, target: id.ExprId, span: token.Span) {
+    if (target == id.EXPR_NIL) { ret; }
+    if (!comptime.is_error_call(sc.a, sc.source, target)) { ret; }
+    val m: Result[str, str] = comptime.error_message(sc.ctx, sc.a, sc.source, target, ?sc.s.interner);
+    if (is_err[str, str](m)) {
+        ctxm.report(sc, span, unwrap_err[str, str](m));
+        ret;
+    }
+    ctxm.report(sc, span, unwrap_ok[str, str](m));
 }
 
 # type-checks a `$each <ident> in $fields(T) { body }` (#1473) by unrolling it:
@@ -749,13 +772,28 @@ fun infer_stmt_list(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: type.Ty
 }
 
 fun infer_stmt_comptime_if(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: type.TypeId) Result[bool, str] {
-    # a chain gated on a comptime value parameter, or on a type comparison
-    # (`$type_of(...)`, #1472), cannot select an arm at sema time — the
-    # parameter's value is fixed per call site, and a type comparison folds only
-    # once the type resolver is installed at lowering. type-check EVERY arm
-    # structurally; arm selection is deferred to per-value monomorphization.
-    if (stmt_comptime_if_gated_on_param(sc, start, len)
-        || stmt_comptime_if_has_type_comparison(sc, start, len)) {
+    val param_gated:  bool = stmt_comptime_if_gated_on_param(sc, start, len);
+    val has_type_cmp: bool = stmt_comptime_if_has_type_comparison(sc, start, len);
+
+    # a type-comparison chain (`$type_of(x) == T`, #1472) NOT gated on a comptime
+    # value parameter folds at monomorphization, where the type resolver is
+    # installed and x's concrete type is known: prune the provably-dead arms and
+    # type-check ONLY the selected one (#1511), so a clean no-cast skeleton
+    # compiles directly. when a gate cannot fold yet — the original sema pass
+    # installs no resolver, or x is still an abstract generic param — the prune
+    # defers and the all-arms check below runs unchanged.
+    if (has_type_cmp && !param_gated) {
+        val pr: Result[bool, str] = prune_type_comparison_chain(sc, start, len, fn_ret);
+        if (is_err[bool, str](pr)) { ret pr; }
+        if (unwrap_ok[bool, str](pr)) { ret ok[bool, str](true); }
+    }
+
+    # a chain gated on a comptime value parameter, or a type-comparison chain that
+    # did not fold above, cannot select an arm at sema time — the parameter's value
+    # is fixed per call site, and an unresolved type comparison folds only once the
+    # resolver is installed at lowering. type-check EVERY arm structurally; arm
+    # selection is deferred to per-value monomorphization.
+    if (param_gated || has_type_cmp) {
         var ai: u32 = 0;
         for (ai < len) {
             val arm: *decl.ComptimeBranch = ?sc.a.comptime_branches[start + ai];
@@ -791,6 +829,48 @@ fun infer_stmt_comptime_if(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: 
         }
         bi = bi + 1;
     }
+    ret ok[bool, str](true);
+}
+
+# folds a non-param-gated type-comparison `$if` chain and type-checks only the
+# selected arm, pruning the provably-dead arms (#1511). returns true once the
+# chain fully folds — the selected arm (if any) is checked and the rest are left
+# untyped — and false when a gate cannot be folded yet, in which case the caller
+# type-checks every arm. only the live arm is checked, so an arm written for one
+# concrete type never fails against another. the chain folds during monomorphization
+# (the type resolver installed, x's type concrete); in the original sema pass no
+# resolver is installed, so the first gate defers and every arm is checked instead.
+fun prune_type_comparison_chain(sc: *ctxm.SemaContext, start: u32, len: u32, fn_ret: type.TypeId) Result[bool, str] {
+    var i: u32 = 0;
+    for (i < len) {
+        val arm: *decl.ComptimeBranch = ?sc.a.comptime_branches[start + i];
+        if (arm.cond == id.EXPR_NIL) {
+            # the unconditional final `$or {}` arm: reached only when every prior
+            # gate folded false, so it is the selected arm.
+            val rb: Result[bool, str] = infer_stmt_list(sc, arm.body_start, arm.body_len, fn_ret);
+            if (is_err[bool, str](rb)) { ret rb; }
+            ret ok[bool, str](true);
+        }
+        # type the gate (populating the operand types the resolver reads), then
+        # fold it. a gate that does not fold to a bool defers the whole chain.
+        val saved_gate: bool = sc.in_comptime_gate;
+        sc.in_comptime_gate = true;
+        infer.infer_expr(sc, arm.cond);
+        sc.in_comptime_gate = saved_gate;
+
+        val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, arm.cond, ?sc.s.interner);
+        if (is_err[comptime.CTValue, str](ev)) { ret ok[bool, str](false); }
+        val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
+        if (v.kind != comptime.CT_KIND_BOOL) { ret ok[bool, str](false); }
+        if (v.data.b) {
+            val rb: Result[bool, str] = infer_stmt_list(sc, arm.body_start, arm.body_len, fn_ret);
+            if (is_err[bool, str](rb)) { ret rb; }
+            ret ok[bool, str](true);
+        }
+        # gate folded false: this arm is provably dead — prune it (skip checking).
+        i = i + 1;
+    }
+    # every gated arm folded false with no final `$or {}`: no arm is selected.
     ret ok[bool, str](true);
 }
 

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -84,6 +84,9 @@ pub fun lower_stmt(ctx: *lower.LowerContext, sid: aid.StmtId) Result[bool, str] 
     if (k == astmt.STMT_KIND_ASM)         { ret lower_asm(ctx, s); }
     if (k == astmt.STMT_KIND_COMPTIME_IF) { ret lower_comptime_if(ctx, s); }
     if (k == astmt.STMT_KIND_COMPTIME_EACH) { ret lower_comptime_each(ctx, s); }
+    # a comptime directive (`$error(...)`) is compile-time-only and emits no IR;
+    # a reached `$error` already failed the build at sema (#1511).
+    if (k == astmt.STMT_KIND_COMPTIME_ATTR) { ret ok[bool, str](true); }
     if (k == astmt.STMT_KIND_ERROR) {
         # an error stmt must never reach lowering: the driver aborts on
         # accumulated diagnostics before the middle end runs.


### PR DESCRIPTION
Integration merge for the **2.1.0** release.

Two additive features (both merged to dev, full CI gate green incl. self-host fixpoint):
- **#1511** (PR #1522) — comptime type-directed dispatch: prune dead `$type_of` arms at sema + real statement-position `$error`.
- **#1505** (PR #1507) — driver unions the import closure over every artifact (multi-artifact tooling/LSP graphs).

Plus the version bump to 2.1.0 + CHANGELOG. Tag `v2.1.0` cut on the merge commit triggers the release build.

Closes #1505 (already), #1511 (already).