### PR TITLE
fix(x64): IEEE-754-correct FP-comparison NaN semantics

### DIFF
--- a/.github/tests/nancmp/app/mach.toml
+++ b/.github/tests/nancmp/app/mach.toml
@@ -1,0 +1,26 @@
+[project]
+id      = "nancmp"
+name    = "IEEE-754 NaN float-comparison test — App"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[bin.nancmp]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/nancmp/app/src/main.mach
+++ b/.github/tests/nancmp/app/src/main.mach
@@ -1,0 +1,80 @@
+use std.runtime.linux;
+
+# IEEE-754 NaN float-comparison regression coverage (issue #1446). On the pre-fix
+# x86_64 backend every float compare lowered to a single unsigned SETcc after
+# UCOMISD; an unordered (NaN-involving) compare leaves CF=ZF=PF=1, so `==` / `<` /
+# `<=` wrongly returned true and `!=` wrongly returned false on NaN — diverging from
+# aarch64, which already emits the IEEE-754 results. IEEE-754 defines every ordered
+# relation (`<` `<=` `>` `>=` `==`) as FALSE when an operand is NaN, and `!=` as TRUE.
+#
+# A NaN is exactly the operand that is neither less than, equal to, nor greater than
+# the other, so the (lt, eq, gt) = (0, 0, 0) outcome the `chk_*` helpers assert is
+# the IEEE-754 NaN result: all ordered relations false, `!=` true. Every operand is
+# derived from a runtime, non-foldable zero (n = argc - 1, which is 0 when run with
+# no arguments) and the NaN is produced at runtime as 0.0 / 0.0, so the comparisons
+# are genuinely lowered rather than constant-folded. The same assertions hold on
+# whatever architecture the app is built for, so x86_64 and aarch64 must agree.
+
+# asserts the six f64 comparisons of `a` against `b`, forward and reversed, against
+# the expected (lt, eq, gt) outcome as 0/1; returns a nonzero check id on the first
+# disagreement, else 0. driven with (0, 0, 0) it asserts the IEEE-754 NaN result.
+fun chk_f64(a: f64, b: f64, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)        { ret base + 0; }
+    if ((a <= b) != (lt | eq)) { ret base + 1; }
+    if ((a >  b) != gt)        { ret base + 2; }
+    if ((a >= b) != (gt | eq)) { ret base + 3; }
+    if ((a == b) != eq)        { ret base + 4; }
+    if ((a != b) != (1 - eq))  { ret base + 5; }
+    if ((b <  a) != gt)        { ret base + 6; }
+    if ((b <= a) != (gt | eq)) { ret base + 7; }
+    if ((b >  a) != lt)        { ret base + 8; }
+    if ((b >= a) != (lt | eq)) { ret base + 9; }
+    if ((b == a) != eq)        { ret base + 10; }
+    if ((b != a) != (1 - eq))  { ret base + 11; }
+    ret 0;
+}
+
+# f32 counterpart, exercising the narrower UCOMISS / FCMP-S compare form.
+fun chk_f32(a: f32, b: f32, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)        { ret base + 0; }
+    if ((a <= b) != (lt | eq)) { ret base + 1; }
+    if ((a >  b) != gt)        { ret base + 2; }
+    if ((a >= b) != (gt | eq)) { ret base + 3; }
+    if ((a == b) != eq)        { ret base + 4; }
+    if ((a != b) != (1 - eq))  { ret base + 5; }
+    if ((b <  a) != gt)        { ret base + 6; }
+    if ((b <= a) != (gt | eq)) { ret base + 7; }
+    if ((b >  a) != lt)        { ret base + 8; }
+    if ((b >= a) != (lt | eq)) { ret base + 9; }
+    if ((b == a) != eq)        { ret base + 10; }
+    if ((b != a) != (1 - eq))  { ret base + 11; }
+    ret 0;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    val n:     f64 = (argc - 1)::f64;   # 0.0 at runtime, non-foldable
+    val nan64: f64 = n / n;             # 0.0 / 0.0 = NaN
+    val one64: f64 = n + 1.0;           # a finite value
+    val zero64: f64 = n;                # +0.0
+
+    val m:     f32 = (argc - 1)::f32;
+    val nan32: f32 = m / m;
+    val one32: f32 = m + 1.0::f32;
+    val zero32: f32 = m;
+
+    var r: i64 = 0;
+
+    # f64: NaN against a finite value, against zero, and against itself — every case
+    # is unordered, so the expected outcome is (lt, eq, gt) = (0, 0, 0).
+    r = chk_f64(nan64, one64,  0, 0, 0, 100); if (r != 0) { ret r; }
+    r = chk_f64(nan64, zero64, 0, 0, 0, 120); if (r != 0) { ret r; }
+    r = chk_f64(nan64, nan64,  0, 0, 0, 140); if (r != 0) { ret r; }
+
+    # f32: the same three shapes through the narrower compare form.
+    r = chk_f32(nan32, one32,  0, 0, 0, 200); if (r != 0) { ret r; }
+    r = chk_f32(nan32, zero32, 0, 0, 0, 220); if (r != 0) { ret r; }
+    r = chk_f32(nan32, nan32,  0, 0, 0, 240); if (r != 0) { ret r; }
+
+    ret 0;
+}

--- a/.github/tests/nancmp/run.sh
+++ b/.github/tests/nancmp/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# IEEE-754 NaN float-comparison regression test (issue #1446): build the `app`
+# project with the freshly-built compiler and run it. the app asserts that every
+# ordered float relation (`<` `<=` `>` `>=` `==`) is false when an operand is NaN and
+# that `!=` is true — for f32 and f64, in both operand orders — exiting 0 only when
+# every result is value-correct (a wrong comparison exits with its check id).
+#
+# the pre-fix x86_64 backend lowered a float compare to one unsigned SETcc after
+# UCOMISD and so miscompiled the unordered case; the native (x86_64) half therefore
+# fails before the fix and passes after. the aarch64 half cross-builds the same app
+# and runs it under qemu to prove the two architectures agree on the IEEE-754 result;
+# it is skipped when qemu-aarch64 is unavailable (mirroring aarch64run).
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# x86_64 (native): the architecture the fix changes — must build, run, and pass.
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL nancmp: x86_64 build failed" >&2
+    exit 1
+fi
+
+set +e
+"$WORK/app/out/linux/bin/nancmp"
+code=$?
+set -e
+
+if [ "$code" -ne 0 ]; then
+    echo "FAIL nancmp: x86_64 NaN comparison check $code produced a non-IEEE-754 result" >&2
+    exit 1
+fi
+echo "PASS nancmp: x86_64 NaN comparisons are IEEE-754-correct"
+
+# aarch64 (under qemu): proves the two architectures agree on the IEEE-754 result.
+# built at -O0 so the comparisons are not optimized away. skipped without qemu.
+RUNNER="$(command -v qemu-aarch64 || command -v qemu-aarch64-static || true)"
+if [ -z "$RUNNER" ]; then
+    echo "SKIP nancmp: 'qemu-aarch64' not available to run the aarch64 binary"
+    exit 0
+fi
+
+if ! ( cd "$WORK/app" && "$MACH" build . --target linux-arm64 -O0 ) >/dev/null 2>&1; then
+    echo "FAIL nancmp: aarch64 cross-build failed" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/linux-arm64/bin/nancmp"
+test -f "$EXE" || { echo "error: aarch64 binary not produced at $EXE" >&2; exit 1; }
+
+set +e
+"$RUNNER" "$EXE" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -ne 0 ]; then
+    echo "FAIL nancmp: aarch64 NaN comparison check $code disagrees with IEEE-754" >&2
+    exit 1
+fi
+echo "PASS nancmp: aarch64 NaN comparisons agree with x86_64 (IEEE-754)"
+exit 0

--- a/src/lang/target/isa/x64.mach
+++ b/src/lang/target/isa/x64.mach
@@ -255,6 +255,12 @@ pub val RAW_BYTE:  Opcode = 83;
 # save / restore a callee-saved XMM register to a 16-byte-aligned frame slot under
 # win64; the unwind tables describe it with UWOP_SAVE_XMM128.
 pub val MOVAPS:    Opcode = 84;
+# set byte if parity (PF set — an unordered SSE compare). materializes the
+# unordered half of the IEEE-754 float `!=` combine.
+pub val SETP:      Opcode = 85;
+# set byte if not parity (PF clear — an ordered SSE compare). materializes the
+# ordered half of the IEEE-754 float `==` combine.
+pub val SETNP:     Opcode = 86;
 
 # encoding flags carried on `isa.Inst.flags`. they steer prefix and width
 # selection in the encoder independently of the opcode.

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -3425,30 +3425,51 @@ fun emit_movd_movq_reg(gp: i32, xmm: i32, w: u8, gp_to_xmm: bool, buf: *ByteBuf)
 }
 
 
-# float_setcc_opcode: the concrete UNSIGNED SETcc opcode realizing a float
-# comparison condition. a UCOMISD/UCOMISS sets CF/ZF/PF (CF on below, ZF on equal;
-# an UNORDERED result sets CF=ZF=PF=1), so the float compare maps to the UNSIGNED
-# conditions SETE/SETNE/SETB/SETBE/SETA/SETAE — NOT the signed SETL/SETLE/SETG/SETGE
-# the integer compare path uses.
+# float_cmp_swap: true when an IEEE-754 float compare is realized by reversing its
+# operands. `<` / `<=` map to the NaN-false `>` / `>=` of the swapped operands
+# (`a < b` is `b > a`, which UCOMISD reads as false when unordered), so those two
+# conditions compare RHS against LHS. the lowerer already canonicalizes source
+# `>` / `>=` to LT / LE, so in practice these are the only relations that reach the
+# encoder; GT / GE remain handled identically for completeness.
+fun float_cmp_swap(cc: u8) bool {
+    ret cc == mir.FCC_LT || cc == mir.FCC_LE;
+}
+
+# float_setcc_opcode: the primary UNSIGNED SETcc realizing an IEEE-754 float
+# comparison. UCOMISD/UCOMISS sets CF/ZF/PF (CF on below, ZF on equal) and leaves
+# CF=ZF=PF=1 when unordered (a NaN operand), so an honest compare must read false
+# there for every relation except `!=`. the relations use the NaN-false SETA /
+# SETAE: `>` and `<` (operands reversed by float_cmp_swap) map to SETA, `>=` and
+# `<=` to SETAE. equality stays SETE / SETNE and is corrected for the unordered
+# case by the parity combine in encode_float_cmp. these are the UNSIGNED conditions
+# — NOT the signed SETL/SETLE/SETG/SETGE the integer compare path uses.
 fun float_setcc_opcode(cc: u8) u16 {
     if (cc == mir.FCC_EQ) { ret x64.SETE; }
     if (cc == mir.FCC_NE) { ret x64.SETNE; }
-    if (cc == mir.FCC_LT) { ret x64.SETB; }
-    if (cc == mir.FCC_LE) { ret x64.SETBE; }
+    if (cc == mir.FCC_LT) { ret x64.SETA; }
+    if (cc == mir.FCC_LE) { ret x64.SETAE; }
     if (cc == mir.FCC_GT) { ret x64.SETA; }
     ret x64.SETAE;
 }
 
 # encode_float_cmp: materialize a fully-resolved float comparison
-# `MIR_FCMP [dst, lhs, rhs]` into its SSE byte sequence, mirroring cmach's
-# `emit_float_cmp`: load `lhs` -> FLOAT_SCRATCH0 and `rhs` -> FLOAT_SCRATCH1, run
-# `UCOMISS/UCOMISD SCRATCH0, SCRATCH1` (set CF/ZF/PF), capture the condition into
-# the destination's low byte with the UNSIGNED SETcc selected from the FCC_* code
-# (carried on `mi.src_width`), then zero-extend the byte boolean to the machine
-# word (MOVZX). the compared operand width (`mi.width`: 4 -> UCOMISS, 8 -> UCOMISD)
-# selects the compare form; the i8 result is sized independently. the destination
-# is a GP register (the i8 result vreg is GP-classed); a spilled result is reloaded
-# into a register destination by the allocator before here.
+# `MIR_FCMP [dst, lhs, rhs]` into its IEEE-754 SSE byte sequence: load `lhs` ->
+# FLOAT_SCRATCH0 and `rhs` -> FLOAT_SCRATCH1, run `UCOMISS/UCOMISD` (set CF/ZF/PF),
+# capture the condition into the destination's low byte, then zero-extend the byte
+# boolean to the machine word (MOVZX). the compared operand width (`mi.width`:
+# 4 -> UCOMISS, 8 -> UCOMISD) selects the compare form; the i8 result is sized
+# independently. the destination is a GP register (the i8 result vreg is GP-classed);
+# a spilled result is reloaded into a register destination by the allocator here.
+#
+# an unordered (NaN-involving) compare leaves CF=ZF=PF=1, so an honest IEEE-754
+# result reads false for every relation except `!=`:
+#   - `<` / `<=`: the operands are reversed (float_cmp_swap) and read with the
+#     NaN-false SETA / SETAE, since `a < b` is `b > a`;
+#   - `>` / `>=`: SETA / SETAE directly (already NaN-false);
+#   - `==` / `!=`: SETE / SETNE alone ignore PF, so a NaN would read as ordered.
+#     the parity flag is folded in — `==` is ordered-and-equal (ZF & !PF), `!=` is
+#     unordered-or-unequal (!ZF | PF) — by capturing PF into the reserved R11 scratch
+#     (SETNP / SETP) and combining it with the primary byte (AND / OR) before MOVZX.
 fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Result[bool, str] {
     if (mi.operand_count < 3) {
         ret err[bool, str]("encode: float comparison missing operands");
@@ -3477,17 +3498,22 @@ fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Resu
     val lr: Result[bool, str] = emit_float_load(rhs, FLOAT_SCRATCH1, w, buf);
     if (is_err[bool, str](lr)) { ret lr; }
 
-    # UCOMISS / UCOMISD SCRATCH0, SCRATCH1  (set CF/ZF/PF)
+    # UCOMISS / UCOMISD lhs, rhs  (set CF/ZF/PF); `<` / `<=` reverse the operands so
+    # the relation reads as the NaN-false `>` / `>=` of the swapped pair.
     var ucom: isa.Inst;
     zero_inst(?ucom);
     ucom.opcode = x64.UCOMISD;
     if (w == 4) { ucom.opcode = x64.UCOMISS; }
     ucom.dst  = isa.make_reg(FLOAT_SCRATCH0, 16);
     ucom.src1 = isa.make_reg(FLOAT_SCRATCH1, 16);
+    if (float_cmp_swap(cc)) {
+        ucom.dst  = isa.make_reg(FLOAT_SCRATCH1, 16);
+        ucom.src1 = isa.make_reg(FLOAT_SCRATCH0, 16);
+    }
     ucom.size = w;
     encode_inst(?ucom, buf);
 
-    # SETcc dst  (one byte; UNSIGNED condition from the FCC_* code)
+    # SETcc dst  (one byte; the NaN-false UNSIGNED condition from the FCC_* code)
     var setcc: isa.Inst;
     zero_inst(?setcc);
     setcc.opcode   = float_setcc_opcode(cc);
@@ -3495,6 +3521,31 @@ fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Resu
     setcc.dst.size = 1;
     setcc.size     = 1;
     encode_inst(?setcc, buf);
+
+    # `==` / `!=`: fold the parity flag in so an unordered (NaN) compare is not read
+    # as ordered. capture PF into the reserved R11 scratch (SETNP for `==` -> !PF,
+    # SETP for `!=` -> PF) — both SETcc read the flags before the combine clobbers
+    # them — then AND (`==`: ZF & !PF) or OR (`!=`: !ZF | PF) it into the primary byte.
+    if (cc == mir.FCC_EQ || cc == mir.FCC_NE) {
+        var par: isa.Inst;
+        zero_inst(?par);
+        par.opcode   = x64.SETNP;
+        if (cc == mir.FCC_NE) { par.opcode = x64.SETP; }
+        par.dst      = isa.make_reg(x64.R11, 1);
+        par.dst.size = 1;
+        par.size     = 1;
+        encode_inst(?par, buf);
+
+        var comb: isa.Inst;
+        zero_inst(?comb);
+        comb.opcode   = x64.AND;
+        if (cc == mir.FCC_NE) { comb.opcode = x64.OR; }
+        comb.dst      = dst;
+        comb.dst.size = 1;
+        comb.src1     = isa.make_reg(x64.R11, 1);
+        comb.size     = 1;
+        encode_inst(?comb, buf);
+    }
 
     # MOVZX dst, dst  (zero-extend the byte boolean to the machine word)
     var movzx: isa.Inst;

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -464,6 +464,8 @@ fun cc_to_x86(opcode: u16) u8 {
     if (opcode == x64.JBE || opcode == x64.SETBE) { ret 0x06; }
     if (opcode == x64.JA  || opcode == x64.SETA)  { ret 0x07; }
     if (opcode == x64.JAE || opcode == x64.SETAE) { ret 0x03; }
+    if (opcode == x64.SETP)  { ret 0x0A; }
+    if (opcode == x64.SETNP) { ret 0x0B; }
     ret 0x04;
 }
 
@@ -472,8 +474,11 @@ fun is_jcc(opcode: u16) bool {
     ret opcode >= x64.JE && opcode <= x64.JAE;
 }
 
-# is_setcc: true if the opcode is a conditional set.
+# is_setcc: true if the opcode is a conditional set. the SETE..SETAE block is
+# contiguous; the parity sets SETP / SETNP (the IEEE-754 float compare combine)
+# sit outside it and are named explicitly.
 fun is_setcc(opcode: u16) bool {
+    if (opcode == x64.SETP || opcode == x64.SETNP) { ret true; }
     ret opcode >= x64.SETE && opcode <= x64.SETAE;
 }
 

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -482,6 +482,8 @@ fun x64_mnemonic(op: u16) str {
     if (op == x64.SETBE)     { ret "setbe"; }
     if (op == x64.SETA)      { ret "seta"; }
     if (op == x64.SETAE)     { ret "setae"; }
+    if (op == x64.SETP)      { ret "setp"; }
+    if (op == x64.SETNP)     { ret "setnp"; }
     if (op == x64.MOVSS)     { ret "movss"; }
     if (op == x64.MOVSD)     { ret "movsd"; }
     if (op == x64.ADDSS)     { ret "addss"; }


### PR DESCRIPTION
Closes #1446.

x86_64 lowered every float comparison to a single unsigned `SETcc` after `UCOMISD`. An unordered (NaN-involving) compare leaves `CF=ZF=PF=1`, so `==`/`<`/`<=` wrongly returned **true** and `!=` wrongly returned **false** on NaN — diverging from aarch64, which already emits the IEEE-754-correct results (unordered is false for all relations except `!=`).

This makes x86_64 match aarch64's IEEE-754 semantics:

- `<` / `<=` → reverse the operands and use the NaN-false `SETA` / `SETAE` (`a < b` ≡ `b > a`, false when unordered).
- `>` / `>=` → unchanged (`SETA` / `SETAE`, already NaN-false).
- `==` → `SETE` AND `SETNP` (ordered **and** equal).
- `!=` → `SETNE` OR `SETP` (unordered **or** unequal).

The parity combine needs `SETP` / `SETNP`, added to the x64 opcode space (with cc nibbles, `is_setcc`, and printer mnemonics).

### Test
`.github/tests/nancmp` (fresh-compiler): the app asserts every operator with a NaN operand against the IEEE-754 result for f32/f64 in both operand orders, with runtime-derived non-foldable operands (NaN built as `0.0/0.0`). It builds and runs on **x86_64 (native)** and **aarch64 (under qemu, skipped when absent)**, so the two backends must agree. Verified locally: **fails** on the pre-fix v2.1.0 seed (check 100: `NaN < finite` returned true), **passes** on both arches after.

### Self-host fixpoint
The compiler itself compares floats (`f == 0.0` in the comptime evaluator), so this codegen change alters the compiler's self-emission **by design** (the issue calls this out). Verified locally with the v2.1.0 seed:

- **3-way fixpoint holds**: `stage2 == stage3` (byte-identical).
- **Not byte-reproducible from the v2.1.0 seed**: `stage1 != stage2`, expected — the `f == 0.0` site now encodes with the new sequence. **The `Self-host Fixpoint` CI lane (which asserts `stage1 == stage2`) will therefore go red; this is the intended, documented divergence, and the next release re-seeds.**

`mach test .` (self-built): 540 passed, 0 failed.

Correctness work for v2.2.0 — no version bump, no release.