### PR TITLE
fix(sema/lower): defer $each $fields(T) for generic type params to monomorphization (#1523)

### DIFF
--- a/.github/tests/eachfieldsgeneric/app/mach.toml
+++ b/.github/tests/eachfieldsgeneric/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "eachfieldsgeneric"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.eachfieldsgeneric]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/eachfieldsgeneric/app/src/main.mach
+++ b/.github/tests/eachfieldsgeneric/app/src/main.mach
@@ -1,0 +1,77 @@
+use std.runtime;
+use std.types.string.str;
+use std.types.string.str_equals;
+
+# generic `$each $fields(T)` deferral integration test (#1523). proves that
+# `$each f in $fields(T)` inside a generic function defers to monomorphization
+# and unrolls correctly for each concrete instantiation, including heterogeneous
+# field types and `v.[f]` projection. exits 0 only when all assertions pass;
+# a failing check returns its id.
+
+rec Pair  { x: i64; y: i64; }
+rec Mixed { a: i64; b: u8; }
+rec Empty { }
+
+# generic field-sum: iterates every field of T via the loop variable, casts to
+# i64, and accumulates. deferred at template sema; unrolled per instantiation.
+fun sum_fields[T](v: T) i64 {
+    var total: i64 = 0;
+    $each f in $fields(T) {
+        total = total + v.[f]::i64;
+    }
+    ret total;
+}
+
+# generic field-zero: writes zero to every field of T through a pointer receiver.
+fun zero_fields[T](v: *T) {
+    $each f in $fields(T) {
+        v.[f] = 0;
+    }
+}
+
+# generic field-count: counts how many fields T has by incrementing per iteration.
+fun field_count[T](v: T) i64 {
+    var n: i64 = 0;
+    $each f in $fields(T) {
+        n = n + 1;
+    }
+    ret n;
+}
+
+# generic name-match: counts fields of T whose compile-time name equals `target`.
+fun count_named[T](v: T, target: str) i64 {
+    var n: i64 = 0;
+    $each f in $fields(T) {
+        if (str_equals(f.name, target)) { n = n + 1; }
+    }
+    ret n;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    # homogeneous record: sum via generic sum_fields
+    var p: Pair = Pair { x: 3, y: 4 };
+    if (sum_fields[Pair](p) != 7) { ret 1; }
+
+    # heterogeneous record: cast each field to i64 before accumulating
+    var m: Mixed = Mixed { a: 100, b: 5 };
+    if (sum_fields[Mixed](m) != 105) { ret 2; }
+
+    # generic pointer-receiver zero: writes 0 to every field
+    zero_fields[Mixed](?m);
+    if (sum_fields[Mixed](m) != 0) { ret 3; }
+
+    # empty record: no iterations, count stays 0
+    var e: Empty = Empty { };
+    if (field_count[Empty](e) != 0) { ret 4; }
+
+    # field counts match the record layouts
+    if (field_count[Pair](p) != 2) { ret 5; }
+    if (field_count[Mixed](m) != 2) { ret 6; }
+
+    # generic name search: Pair has one field named "x"
+    if (count_named[Pair](p, "x") != 1) { ret 7; }
+    if (count_named[Pair](p, "z") != 0) { ret 8; }
+
+    ret 0;
+}

--- a/.github/tests/eachfieldsgeneric/nonrec/mach.toml
+++ b/.github/tests/eachfieldsgeneric/nonrec/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "eachfieldsgeneric-nonrec"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.eachfieldsgeneric-nonrec]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/eachfieldsgeneric/nonrec/src/main.mach
+++ b/.github/tests/eachfieldsgeneric/nonrec/src/main.mach
@@ -1,0 +1,19 @@
+use std.runtime;
+
+# negative: instantiating $fields(T) with a non-record type must fail at
+# compile time with a record-type diagnostic (#1523). this file must NOT
+# compile; the test harness asserts the build fails.
+
+fun bad[T](v: T) i64 {
+    var n: i64 = 0;
+    $each f in $fields(T) {
+        n = n + 1;
+    }
+    ret n;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    # instantiating with u64 (a primitive, not a record) must error
+    ret bad[u64](42::u64)::i64;
+}

--- a/.github/tests/eachfieldsgeneric/run.sh
+++ b/.github/tests/eachfieldsgeneric/run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# generic $each $fields(T) deferral integration test (#1523). two halves:
+#
+#   app — a generic fun instantiated on concrete records must COMPILE and
+#   produce correct results for homogeneous / heterogeneous / empty records,
+#   pointer-receiver zero, field counts, and name queries. exits 0 on pass.
+#
+#   nonrec — `$fields(T)` where T is instantiated as a non-record (e.g. u64)
+#   must FAIL at compile time with a recognisable diagnostic so the error is
+#   surfaced at the call site rather than silently producing wrong code.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# half 1: the generic fields app must build and run correctly.
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL eachfieldsgeneric(app): build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/eachfieldsgeneric"
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL eachfieldsgeneric(app): check $code returned wrong value" >&2
+    exit 1
+fi
+
+# half 2: instantiating $fields(T) with a non-record must fail at compile time.
+cp -r "$HERE/nonrec" "$WORK/"
+mkdir -p "$WORK/nonrec/dep"
+ln -s "$STD" "$WORK/nonrec/dep/mach-std"
+
+set +e
+BUILD_OUT="$( cd "$WORK/nonrec" && "$MACH" build . 2>&1 )"
+code=$?
+set -e
+if [ "$code" -eq 0 ]; then
+    echo "FAIL eachfieldsgeneric(nonrec): build should have failed but succeeded" >&2
+    exit 1
+fi
+if ! echo "$BUILD_OUT" | grep -qi "non-record\|record type\|not a record"; then
+    echo "FAIL eachfieldsgeneric(nonrec): expected a record-type diagnostic, got:" >&2
+    echo "$BUILD_OUT" >&2
+    exit 1
+fi
+
+echo "PASS eachfieldsgeneric: generic \$each \$fields(T) defers and unrolls correctly"

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -718,6 +718,9 @@ fun eval_comptime_directive(sc: *ctxm.SemaContext, target: id.ExprId, span: toke
 # is typed against the concrete field of each iteration. this is the sema half of
 # the splice the lowerer mirrors; heterogeneous field types are handled because
 # each iteration re-types the body.
+#
+# when T is an unbound generic type parameter the unroll is deferred to
+# monomorphization (#1523), mirroring how variadic packs are handled (#1475).
 fun infer_stmt_comptime_each(sc: *ctxm.SemaContext, ce: *stmt.StmtComptimeEach, span: token.Span, fn_ret: type.TypeId) Result[bool, str] {
     if (!comptime.is_fields_call(sc.a, sc.source, ce.seq)) {
         # a variadic-pack sequence (`$each a in va`, #1474): the element types are
@@ -736,6 +739,8 @@ fun infer_stmt_comptime_each(sc: *ctxm.SemaContext, ce: *stmt.StmtComptimeEach, 
     }
     val owner: type.TypeId = infer.field_seq_owner(sc, ce.seq, span);
     if (owner == type.TYPE_ERROR) { ret ok[bool, str](true); }
+    # an unbound generic type param: defer body type-check to monomorphization (#1523)
+    if (infer.type_is_generic_param(sc, owner)) { ret ok[bool, str](true); }
 
     val name_r: Result[intern.StrId, str] = intern.intern_span(?sc.s.interner, sc.source, ce.var_name);
     if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -887,7 +887,9 @@ fun set_expr_type(sc: *sema.SemaContext, eid: id.ExprId, ty: type.TypeId) {
 # field_seq_owner: resolves a `$fields(T)` sequence (#1473) to its owning record
 # TypeId, requiring T to be a record. the type-argument's expr_type slot is
 # populated for the lowerer. TYPE_ERROR when the sequence is malformed or T is
-# not a record. shared by the `$each` unroll (sema and lowering).
+# not a record. returns the TYPE_GENERIC_PARAM TypeId when T is an unbound
+# generic param — the caller defers the unroll to monomorphization (#1523).
+# shared by the `$each` unroll (sema and lowering).
 pub fun field_seq_owner(sc: *sema.SemaContext, seq_eid: id.ExprId, span: token.Span) type.TypeId {
     val targ: id.ExprId = comptime.fields_type_arg(sc.a, seq_eid);
     if (targ == id.EXPR_NIL) {
@@ -897,6 +899,8 @@ pub fun field_seq_owner(sc: *sema.SemaContext, seq_eid: id.ExprId, span: token.S
     val owner: type.TypeId = intrinsic_operand_type(sc, targ, span);
     set_expr_type(sc, targ, owner);
     if (owner == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    # an unbound generic type param: defer the record check to monomorphization (#1523)
+    if (type_is_generic_param(sc, owner)) { ret owner; }
     if (!type_is_record(sc, owner)) {
         sema.report(sc, span, "$fields requires a record type");
         ret type.TYPE_ERROR;
@@ -936,7 +940,16 @@ fun project_receiver_matches(sc: *sema.SemaContext, obj_ty: type.TypeId, owner: 
     val to: Option[*type.Type] = type.get(?sc.s.types, obj_ty);
     if (is_none[*type.Type](to)) { ret false; }
     val t: *type.Type = unwrap[*type.Type](to);
-    ret t.kind == type.TYPE_POINTER && t.data.pointer.base == owner;
+    # unbound generic type param (T) during deferred $fields re-inference:
+    # lowering will substitute T to `owner`; accept the projection (#1523).
+    if (t.kind == type.TYPE_GENERIC_PARAM) { ret true; }
+    if (t.kind != type.TYPE_POINTER) { ret false; }
+    val base: type.TypeId = t.data.pointer.base;
+    if (base == owner) { ret true; }
+    # *T where T is an unbound generic param: also valid for the same reason.
+    val bo: Option[*type.Type] = type.get(?sc.s.types, base);
+    if (is_none[*type.Type](bo)) { ret false; }
+    ret unwrap[*type.Type](bo).kind == type.TYPE_GENERIC_PARAM;
 }
 
 # whether `ty` is a comptime variadic pack (#1474).
@@ -944,6 +957,14 @@ fun type_is_pack(sc: *sema.SemaContext, ty: type.TypeId) bool {
     val to: Option[*type.Type] = type.get(?sc.s.types, ty);
     if (is_none[*type.Type](to)) { ret false; }
     ret unwrap[*type.Type](to).kind == type.TYPE_PACK;
+}
+
+# whether `ty` is an unbound generic type parameter — signals that a
+# `$fields(T)` unroll must be deferred to monomorphization (#1523).
+pub fun type_is_generic_param(sc: *sema.SemaContext, ty: type.TypeId) bool {
+    val to: Option[*type.Type] = type.get(?sc.s.types, ty);
+    if (is_none[*type.Type](to)) { ret false; }
+    ret unwrap[*type.Type](to).kind == type.TYPE_GENERIC_PARAM;
 }
 
 # infer_spread: types a `va...` pack spread (#1474). a spread may only spread a

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -163,6 +163,9 @@ pub rec PackInstance {
 #              the inline-asm lowerer resolves `{name}` references against it
 # fn_index:    index into m.functions of the function being lowered
 # ret_ty:      IR return type of the function being lowered
+# fn_ret_sem:  semantic return type of the function being lowered (with generic
+#              substitution applied when inside a monomorphized instance body);
+#              used by deferred `$each $fields(T)` body re-inference (#1523)
 # loops:       active loop stack (innermost last) for brk / cnt
 # loop_len:    number of active loop frames
 # loop_cap:    allocated capacity of the loop stack
@@ -220,6 +223,7 @@ pub rec LowerContext {
 
     fn_index:    u32;
     ret_ty:      ir_type.IrTypeId;
+    fn_ret_sem:  ty.TypeId;
 
     loops:       *LoopFrame;
     loop_len:    u32;
@@ -538,10 +542,11 @@ pub fun resolve_field_member(data: ptr, owner: u32, index: u32, sel: u8) Result[
 pub fun begin_function(lc: *LowerContext, fn_index: u32, ret_ty: ir_type.IrTypeId) {
     map.clear[resolve.SymbolId, value.Value](?lc.locals);
     map.clear[intern.StrId, value.Value](?lc.local_names);
-    lc.loop_len = 0;
-    lc.fin_len  = 0;
-    lc.fn_index = fn_index;
-    lc.ret_ty   = ret_ty;
+    lc.loop_len  = 0;
+    lc.fin_len   = 0;
+    lc.fn_index  = fn_index;
+    lc.ret_ty    = ret_ty;
+    lc.fn_ret_sem = ty.TYPE_NIL;
     # pack-instance body state defaults off; lower_pack_instance sets it after this
     # reset, and an ordinary function (or a generic / value instance) never reads it.
     lc.pack_slots  = nil;
@@ -1053,6 +1058,15 @@ pub fun expr_type_of(lc: *LowerContext, eid: aid.ExprId) ty.TypeId {
     ret lc.sema_result.expr_type[eid];
 }
 
+# applies the active generic substitution to `tid`, returning the concrete
+# sema TypeId. when no substitution is active (not inside a monomorphized
+# generic instance body), `tid` is returned unchanged. used to resolve a
+# deferred `$fields(T)` type argument to its concrete record type (#1523).
+pub fun substitute_type(lc: *LowerContext, tid: ty.TypeId) ty.TypeId {
+    if (lc.subst == nil || lc.subst_len == 0) { ret tid; }
+    ret generics.substitute(lc.s, tid, lc.subst, lc.subst_len);
+}
+
 # returns the interned semantic type a syntactic AstType resolved to, or
 # TYPE_NIL when the id is out of range.
 # ---
@@ -1074,6 +1088,26 @@ pub fun decl_type_of(lc: *LowerContext, did: aid.DeclId) ty.TypeId {
     if (did == aid.DECL_NIL) { ret ty.TYPE_NIL; }
     if (did::usize >= lc.a.decl_len) { ret ty.TYPE_NIL; }
     ret lc.sema_result.decl_type[did];
+}
+
+# returns the semantic return type of a function decl, with any generic
+# substitution applied. used by `lower_instance` to populate `fn_ret_sem`
+# so deferred `$each $fields(T)` body re-inference can check `ret` (#1523).
+# ---
+# lc:  the context (subst/subst_len active when inside a generic instance body)
+# did: DeclId of the function declaration
+# ret: the substituted sema return TypeId, or TYPE_NIL when unavailable
+pub fun decl_ret_sem(lc: *LowerContext, did: aid.DeclId) ty.TypeId {
+    val fn_ty: ty.TypeId = decl_type_of(lc, did);
+    val to: Option[*ty.Type] = ty.get(?lc.s.types, fn_ty);
+    if (is_none[*ty.Type](to)) { ret ty.TYPE_NIL; }
+    val t: *ty.Type = unwrap[*ty.Type](to);
+    if (t.kind != ty.TYPE_FUN) { ret ty.TYPE_NIL; }
+    var ret_ty: ty.TypeId = t.data.fn.ret_ty;
+    if (lc.subst != nil && lc.subst_len > 0) {
+        ret_ty = generics.substitute(lc.s, ret_ty, lc.subst, lc.subst_len);
+    }
+    ret ret_ty;
 }
 
 # returns the resolved SymbolId for an expression reference, or SYMBOL_NIL.

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -207,6 +207,9 @@ pub fun lower_instance(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl
     val fn_index: u32 = unwrap_ok[u32, str](idx_r);
 
     lower.begin_function(ctx, fn_index, ret_ir);
+    # set the sema return type so deferred $each $fields(T) re-inference can
+    # check `ret` against the concrete return type of this instance (#1523)
+    ctx.fn_ret_sem = lower.decl_ret_sem(ctx, did);
     builder.set_function(?ctx.builder, ?ctx.m.functions[fn_index]);
 
     val entry_r: Result[ir.BlockId, str] = builder.new_block(?ctx.builder);

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -600,7 +600,8 @@ fun lower_comptime_if(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str
 # comptime frame to that field's descriptor, so a `v.[f]` in the body projects
 # the concrete field of each iteration. the lowering half of the splice sema
 # mirrors. the owning type was resolved and recorded on the `$fields(T)` argument
-# by sema.
+# by sema, except when T is a generic type param — in that case the unroll was
+# deferred to monomorphization (#1523), and the concrete type is substituted here.
 fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] {
     val ce: *astmt.StmtComptimeEach = ?s.data.comptime_each;
     val src: str = lower.module_source(ctx);
@@ -617,11 +618,39 @@ fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, s
     }
     val targ: aid.ExprId = comptime.fields_type_arg(ctx.a, ce.seq);
     if (targ == aid.EXPR_NIL) { ret err[bool, str]("lower: `$fields` is missing its type argument"); }
-    val owner: ty.TypeId = lower.expr_type_of(ctx, targ);
+
+    # when T was a generic type param at template sema, the unroll was deferred (#1523);
+    # apply the active substitution to get the concrete record type for this instance.
+    val raw_owner: ty.TypeId = lower.expr_type_of(ctx, targ);
+    val deferred: bool = is_generic_param_type(ctx, raw_owner);
+    var owner: ty.TypeId = raw_owner;
+    if (deferred) {
+        if (ctx.subst == nil || ctx.subst_len == 0) {
+            # no active substitution: this is the template body being lowered directly
+            # (not an instance). the concrete $fields unroll runs per-instance instead;
+            # emit nothing here, mirroring the pack path's body-skip approach.
+            ret ok[bool, str](true);
+        }
+        owner = lower.substitute_type(ctx, raw_owner);
+        if (!is_fields_record_type(ctx, owner)) {
+            diag.error(?ctx.s.diags, ctx.a.file_id, s.span,
+                "$fields(T): type argument instantiated as a non-record type");
+            ret err[bool, str](lower.REPORTED);
+        }
+    }
 
     val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, src, ce.var_name);
     if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
     val fname: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+    # build a module-spanning typing snapshot for deferred body re-inference;
+    # mirrors the pack case (#1475) — the body was not typed at template sema.
+    var deps: sema.SemaDeps;
+    if (deferred) {
+        val deps_r: Result[sema.SemaDeps, str] = sema.collect_module_deps(ctx.s);
+        if (is_err[sema.SemaDeps, str](deps_r)) { ret err[bool, str](unwrap_err[sema.SemaDeps, str](deps_r)); }
+        deps = unwrap_ok[sema.SemaDeps, str](deps_r);
+    }
 
     val n: u32 = ty.field_count(?ctx.s.types, owner);
     var i: u32 = 0;
@@ -630,15 +659,29 @@ fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, s
         val br: Result[bool, str] = comptime.bind(ctx.ctx, fname, comptime.field_value(owner::u32, i));
         if (is_err[bool, str](br)) {
             val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            if (deferred) { sema.free_module_deps(ctx.s, ?deps); }
             if (is_err[bool, str](cc)) { ret cc; }
             ret br;
         }
+        if (deferred) {
+            # re-type the body for this field (deferred at template sema, #1523),
+            # writing expression types into the shared array lowering reads next.
+            val ir: Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, ?deps, ctx.ctx,
+                ctx.own_module, ctx.sema_result, ctx.fn_ret_sem, ce.body_start, ce.body_len);
+            if (is_err[bool, str](ir)) {
+                val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+                sema.free_module_deps(ctx.s, ?deps);
+                if (is_err[bool, str](cc)) { ret cc; }
+                ret ir;
+            }
+        }
         val rb: Result[bool, str] = lower_stmt_list(ctx, ce.body_start, ce.body_len);
         val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
-        if (is_err[bool, str](rb)) { ret rb; }
-        if (is_err[bool, str](cc)) { ret cc; }
+        if (is_err[bool, str](rb)) { if (deferred) { sema.free_module_deps(ctx.s, ?deps); } ret rb; }
+        if (is_err[bool, str](cc)) { if (deferred) { sema.free_module_deps(ctx.s, ?deps); } ret cc; }
         i = i + 1;
     }
+    if (deferred) { sema.free_module_deps(ctx.s, ?deps); }
     ret ok[bool, str](true);
 }
 
@@ -704,6 +747,25 @@ fun is_pack_type(ctx: *lower.LowerContext, t: ty.TypeId) bool {
     val to: Option[*ty.Type] = ty.get(?ctx.s.types, t);
     if (is_none[*ty.Type](to)) { ret false; }
     ret unwrap[*ty.Type](to).kind == ty.TYPE_PACK;
+}
+
+# true when `t` is an unbound generic type parameter — signals deferred
+# `$each $fields(T)` over a generic param that needs substitution (#1523).
+fun is_generic_param_type(ctx: *lower.LowerContext, t: ty.TypeId) bool {
+    val to: Option[*ty.Type] = ty.get(?ctx.s.types, t);
+    if (is_none[*ty.Type](to)) { ret false; }
+    ret unwrap[*ty.Type](to).kind == ty.TYPE_GENERIC_PARAM;
+}
+
+# true when `t` is a record or a generic record instance — the types
+# `$fields(T)` accepts after substitution at instantiation.
+fun is_fields_record_type(ctx: *lower.LowerContext, t: ty.TypeId) bool {
+    val to: Option[*ty.Type] = ty.get(?ctx.s.types, t);
+    if (is_none[*ty.Type](to)) { ret false; }
+    val k: ty.TypeKind = unwrap[*ty.Type](to).kind;
+    if (k == ty.TYPE_REC) { ret true; }
+    if (k == ty.TYPE_INSTANCE && is_some[*ty.FieldTable](ty.field_table_for(?ctx.s.types, t))) { ret true; }
+    ret false;
 }
 
 # true when the builder's current block already has a terminator. used to


### PR DESCRIPTION
Closes #1523

## Summary

- At template sema, `$fields(T)` where T is an unbound generic type parameter now returns the `TYPE_GENERIC_PARAM` TypeId from `field_seq_owner`, and `infer_stmt_comptime_each` skips body type-checking (deferred).
- At lowering, `lower_comptime_each` detects the deferred case via `is_generic_param_type`. In the template-body pass (subst nil), it returns early (no IR emitted). In the instance body (subst active), it substitutes T to the concrete type, validates it is a record, then calls `reinfer_pack_each_body` per field before lowering the body — mirroring how variadic pack bodies are re-inferred (#1475).
- `project_receiver_matches` is extended to accept `TYPE_GENERIC_PARAM` and `*TYPE_GENERIC_PARAM` as valid receivers during deferred re-inference — `v: T` and `v: *T` both work.
- Non-record instantiations (`$fields[u64]`) are caught at the lowering site with a recognisable diagnostic.
- Integration test added: `.github/tests/eachfieldsgeneric/` (app: build + run; nonrec: compile-fail with record-type diagnostic).

## Files changed

- `src/lang/fe/sema/infer.mach`: `field_seq_owner` defers on generic param; `type_is_generic_param` predicate added; `project_receiver_matches` extended.
- `src/lang/fe/sema.mach`: `infer_stmt_comptime_each` early-returns on deferred generic param.
- `src/lang/me/lower/context.mach`: `fn_ret_sem` field, `substitute_type`, `decl_ret_sem` helpers.
- `src/lang/me/lower/decl.mach`: `lower_instance` sets `ctx.fn_ret_sem` after `begin_function`.
- `src/lang/me/lower/stmt.mach`: `lower_comptime_each` deferred path; `is_generic_param_type` and `is_fields_record_type` helpers.
- `.github/tests/eachfieldsgeneric/`: integration tests (app + nonrec).

## Verification

- `mach test .`: 540/540 pass.
- Integration test `.github/tests/eachfieldsgeneric/run.sh`: PASS.
- Self-host fixpoint: stage2 == stage3 (byte-identical).

Unblocks mach-std#285 (generic `$fields` derive helpers).