### PR TITLE
feat(aarch64): AAPCS64 HFA/HVA float-aggregate classification (#1174)

### DIFF
--- a/.github/tests/aarch64hfa/app/mach.toml
+++ b/.github/tests/aarch64hfa/app/mach.toml
@@ -1,0 +1,26 @@
+[project]
+id      = "aarch64hfa"
+name    = "AAPCS64 HFA/HVA float-aggregate passing — App"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux-arm64"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[bin.aarch64hfa]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/aarch64hfa/app/src/main.mach
+++ b/.github/tests/aarch64hfa/app/src/main.mach
@@ -1,0 +1,91 @@
+# aarch64hfa — a runnable smoke for AAPCS64 HFA/HVA float-aggregate passing (#1174):
+# a struct/array of 1–4 same-typed FP members (a Homogeneous Floating-point
+# Aggregate) is passed in consecutive V registers (V0–V7) and returned likewise,
+# including HFAs larger than 16 bytes (3×/4× f64) that ride V registers rather than
+# memory, plus the all-or-memory spill when the V bank cannot fit the whole run.
+# every check returns a distinct nonzero exit code on failure; main exits 0 only when
+# every HFA placement round-trips, so qemu running this to 0 proves the placement
+# end-to-end. the SAME source builds for x86_64-linux, where these float structs ride
+# the SysV SSE-eightbyte path instead — a cross-check that the shared lowering, and
+# x64 emission, stay correct.
+use std.runtime.linux;
+
+# single-precision HFAs (S registers): 1–4 f32 members.
+rec V2f { x: f32; y: f32; }
+rec V3f { x: f32; y: f32; z: f32; }
+rec V4f { x: f32; y: f32; z: f32; w: f32; }
+
+# double-precision HFAs (D registers): 2 fits in 16 bytes, 3 / 4 exceed 16 bytes yet
+# still ride V registers (the HFA rule precedes the >16-byte by-reference / sret rule).
+rec D2 { a: f64; b: f64; }
+rec D3 { a: f64; b: f64; c: f64; }
+rec D4 { a: f64; b: f64; c: f64; d: f64; }
+
+# HFA argument consumers: each reads every member (a per-member V-register load),
+# widening f32 members to f64 so the result compares exactly against an f64 literal.
+fun sum_v2(v: V2f) f64 { ret v.x::f64 + v.y::f64; }
+fun sum_v3(v: V3f) f64 { ret v.x::f64 + v.y::f64 + v.z::f64; }
+fun sum_v4(v: V4f) f64 { ret v.x::f64 + v.y::f64 + v.z::f64 + v.w::f64; }
+fun sum_d2(d: D2) f64 { ret d.a + d.b; }
+fun sum_d3(d: D3) f64 { ret d.a + d.b + d.c; }
+fun sum_d4(d: D4) f64 { ret d.a + d.b + d.c + d.d; }
+
+# HFA returns: produce a struct by value (each member placed into its V return register).
+fun make_v3(x: f32, y: f32, z: f32) V3f { var v: V3f; v.x = x; v.y = y; v.z = z; ret v; }
+fun make_d4(a: f64, b: f64, c: f64, d: f64) D4 { var r: D4; r.a = a; r.b = b; r.c = c; r.d = d; ret r; }
+
+# a scalar float ahead of an HFA: `a` takes V0, so the HFA must start at V1 (the V
+# cursor honors the scalar before it).
+fun mix(a: f64, v: D2) f64 { ret a + v.a + v.b; }
+
+# all-or-memory: seven scalar f32 arguments consume V0–V6, so a 2-member HFA cannot
+# fit the V bank (it would need V7 and V8) and the WHOLE aggregate spills to the stack
+# by value — caller and callee must agree on that placement.
+fun spill(a: f32, b: f32, c: f32, d: f32, e: f32, f: f32, g: f32, v: V2f) f64 {
+    ret a::f64 + b::f64 + c::f64 + d::f64 + e::f64 + f::f64 + g::f64 + v.x::f64 + v.y::f64;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    var v2: V2f; v2.x = 1.0; v2.y = 2.0;
+    if (sum_v2(v2) != 3.0) { ret 1; }
+
+    var v3: V3f; v3.x = 1.0; v3.y = 2.0; v3.z = 4.0;
+    if (sum_v3(v3) != 7.0) { ret 2; }
+
+    var v4: V4f; v4.x = 1.0; v4.y = 2.0; v4.z = 4.0; v4.w = 8.0;
+    if (sum_v4(v4) != 15.0) { ret 3; }
+
+    var d2: D2; d2.a = 1.5; d2.b = 2.5;
+    if (sum_d2(d2) != 4.0) { ret 4; }
+
+    # 24-byte HFA (>16): rides V0:V1:V2, not a by-reference pointer.
+    var d3: D3; d3.a = 1.0; d3.b = 2.0; d3.c = 4.0;
+    if (sum_d3(d3) != 7.0) { ret 5; }
+
+    # 32-byte HFA (>16): rides V0:V1:V2:V3.
+    var d4: D4; d4.a = 1.0; d4.b = 2.0; d4.c = 4.0; d4.d = 8.0;
+    if (sum_d4(d4) != 15.0) { ret 6; }
+
+    # HFA return round-trip (each member read back from its V return register).
+    val rv: V3f = make_v3(3.0, 5.0, 7.0);
+    if (rv.x::f64 != 3.0) { ret 7; }
+    if (rv.y::f64 != 5.0) { ret 8; }
+    if (rv.z::f64 != 7.0) { ret 9; }
+
+    # >16-byte HFA return, then fed back through an HFA argument.
+    val rd: D4 = make_d4(10.0, 20.0, 30.0, 40.0);
+    if (rd.a != 10.0) { ret 10; }
+    if (rd.d != 40.0) { ret 11; }
+    if (sum_d4(rd) != 100.0) { ret 12; }
+
+    # scalar float ahead of an HFA argument.
+    var md: D2; md.a = 100.0; md.b = 200.0;
+    if (mix(1.0, md) != 301.0) { ret 13; }
+
+    # all-or-memory spill of an HFA whose run cannot fit the remaining V bank.
+    var sv: V2f; sv.x = 100.0; sv.y = 200.0;
+    if (spill(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, sv) != 328.0) { ret 14; }
+
+    ret 0;
+}

--- a/.github/tests/aarch64hfa/run.sh
+++ b/.github/tests/aarch64hfa/run.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# AAPCS64 HFA/HVA float-aggregate passing (#1174): passes structs of 1–4 same-typed
+# floats by value through non-inlined calls and returns them, including >16-byte HFAs
+# (3×/4× f64) that ride V registers and the all-or-memory spill when the V bank cannot
+# fit the run. the aarch64 cross-build is the case the HFA classifier targets — run
+# under qemu-aarch64, main exits 0 only when every placement round-trips. the SAME
+# source is also built and run natively for x86_64, where these float structs ride the
+# SysV SSE-eightbyte path: a cross-check that the shared lowering and x64 emission are
+# unperturbed by the aarch64-only change.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# x86_64 cross-check: build natively at -O0 (so the float-struct calls are real, not
+# inlined) and run on the host. these structs are not AAPCS64 HFAs on SysV — they ride
+# the SSE-eightbyte path — so a correct exit proves the shared lowering still places
+# them right under the unchanged x64 emitter.
+if ! ( cd "$WORK/app" && "$MACH" build . --target linux -O0 ) >/dev/null 2>&1; then
+    echo "FAIL aarch64hfa: x86_64 native build failed" >&2
+    exit 1
+fi
+X64BIN="$WORK/app/out/linux/bin/aarch64hfa"
+test -x "$X64BIN" || { echo "error: x86_64 binary not produced at $X64BIN" >&2; exit 1; }
+set +e
+"$X64BIN" >/dev/null 2>&1
+x64code=$?
+set -e
+if [ "$x64code" -ne 0 ]; then
+    echo "FAIL aarch64hfa: x86_64 SysV float-struct passing miscompiled (exit $x64code)" >&2
+    exit 1
+fi
+
+# aarch64: cross-build at -O0 so the HFA placement at the call boundary is exercised.
+if ! ( cd "$WORK/app" && "$MACH" build . --target linux-arm64 -O0 ) >/dev/null 2>&1; then
+    echo "FAIL aarch64hfa: aarch64 cross-build failed" >&2
+    exit 1
+fi
+ARMBIN="$WORK/app/out/linux-arm64/bin/aarch64hfa"
+test -f "$ARMBIN" || { echo "error: aarch64 binary not produced at $ARMBIN" >&2; exit 1; }
+
+# the HFA placement is only observable by executing the aarch64 binary; without
+# qemu-aarch64 there is nothing to run it, so the run is skipped (the cross-build
+# above still verifies the emitter accepts the HFA path).
+RUNNER="$(command -v qemu-aarch64 || command -v qemu-aarch64-static || true)"
+if [ -z "$RUNNER" ]; then
+    echo "PASS aarch64hfa: x86_64 SysV float-struct cross-check passed; aarch64 cross-build OK (SKIP qemu run: 'qemu-aarch64' not available)"
+    exit 0
+fi
+
+set +e
+"$RUNNER" "$ARMBIN" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS aarch64hfa: HFA/HVA float aggregates pass and return in V registers under qemu (x86_64 SysV cross-check also passed)"
+    exit 0
+fi
+
+echo "FAIL aarch64hfa: AAPCS64 HFA passing miscompiled under qemu (exit $code; see main.mach for the per-check codes)" >&2
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,14 @@ jobs:
         # branch/main pin in mach.toml into dep/mach-std for the path-based build.
         run: mach dep pull
 
-      - name: Install wine
+      - name: Install wine + qemu-aarch64
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq wine64
+          # wine64 runs the cross-built windows binaries; qemu-user-static registers
+          # the binfmt handler that runs aarch64 binaries on this x86 host, so the
+          # aarch64 integration suites (aarch64hfa, aarch64run) execute their qemu run
+          # here instead of skipping it. mirrors the AArch64 lane's qemu-user-static.
+          sudo apt-get install -y -qq wine64 qemu-user-static
           command -v wine >/dev/null || sudo ln -s "$(command -v wine64)" /usr/local/bin/wine
 
       - name: Build the compiler

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -204,6 +204,99 @@ fun aggregate_sse_mask(ctx: *lctx.LowerCtx, ty: ir_type.IrTypeId) u8 {
     ret mask;
 }
 
+# hfa_walk: recursively test whether `ty` is a homogeneous floating-point aggregate
+# and, if so, report its fundamental member width (`out_elem`) and flattened member
+# count (`out_count`). a float leaf is one member of its own width; a struct flattens
+# its fields (all of which must share the same fundamental width); an array multiplies
+# its element's member count by the length; a union takes the widest member's count
+# (its members overlap). any non-FP leaf, an empty aggregate, or a mix of fundamental
+# widths makes the whole aggregate non-homogeneous (returns false, out params unset).
+# member counting is by recursion, never `size / width`, so an explicit `align(...)`
+# that pads the aggregate's size never inflates the count.
+fun hfa_walk(ctx: *lctx.LowerCtx, ty: ir_type.IrTypeId, out_elem: *u32, out_count: *u32) bool {
+    val it: Option[*ir_type.IrType] = ir_type.get(ctx.types, ty);
+    if (!is_some[*ir_type.IrType](it)) { ret false; }
+    val t: *ir_type.IrType = unwrap[*ir_type.IrType](it);
+
+    if (t.kind == ir_type.IRT_FLOAT) {
+        @out_elem  = ir_type.byte_size(ctx.types, ty, ctx.tgt);
+        @out_count = 1;
+        ret true;
+    }
+    if (t.kind == ir_type.IRT_ARRAY) {
+        var ee: u32 = 0;
+        var ec: u32 = 0;
+        if (!hfa_walk(ctx, t.data.array_.element, ?ee, ?ec)) { ret false; }
+        @out_elem  = ee;
+        @out_count = ec * ir_type.array_count(ctx.types, ty);
+        ret true;
+    }
+    if (t.kind == ir_type.IRT_STRUCT) {
+        var elem:  u32 = 0;
+        var total: u32 = 0;
+        var i:     u32 = 0;
+        for (i < t.data.struct_.field_count) {
+            var fe: u32 = 0;
+            var fc: u32 = 0;
+            if (!hfa_walk(ctx, t.data.struct_.fields[i], ?fe, ?fc)) { ret false; }
+            if (elem == 0) { elem = fe; } or (elem != fe) { ret false; }
+            total = total + fc;
+            i = i + 1;
+        }
+        if (total == 0) { ret false; }
+        @out_elem  = elem;
+        @out_count = total;
+        ret true;
+    }
+    if (t.kind == ir_type.IRT_UNION) {
+        var elem: u32 = 0;
+        var maxc: u32 = 0;
+        var i:    u32 = 0;
+        for (i < t.data.struct_.field_count) {
+            var me: u32 = 0;
+            var mc: u32 = 0;
+            if (!hfa_walk(ctx, t.data.struct_.fields[i], ?me, ?mc)) { ret false; }
+            if (elem == 0) { elem = me; } or (elem != me) { ret false; }
+            if (mc > maxc) { maxc = mc; }
+            i = i + 1;
+        }
+        if (elem == 0) { ret false; }
+        @out_elem  = elem;
+        @out_count = maxc;
+        ret true;
+    }
+    ret false;
+}
+
+# hfa_info: the AAPCS64 HFA descriptor for a type — its member count (1–4) in
+# `out_members` and fundamental member width in `out_elem` — or (0, 0) when `ty` is
+# not a Homogeneous Floating-point Aggregate: a non-aggregate, a heterogeneous or
+# over-4-member aggregate, or one whose fundamental width is not a width mach's FP
+# types expose. computed once per value by the backend and threaded to the ABI
+# classifier; only the AAPCS64 classifier acts on it (the AMD64 conventions ignore
+# it, as they do the SSE-eightbyte mask).
+fun hfa_info(ctx: *lctx.LowerCtx, ty: ir_type.IrTypeId, out_members: *u8, out_elem: *u8) {
+    @out_members = 0;
+    @out_elem    = 0;
+    if (!lctx.value_is_aggregate(ctx, ty)) { ret; }
+    var elem:  u32 = 0;
+    var count: u32 = 0;
+    if (!hfa_walk(ctx, ty, ?elem, ?count)) { ret; }
+    if (count < 1 || count > 4) { ret; }
+    # mach exposes only f32 / f64 fundamentals, so an HFA member is 4 or 8 bytes —
+    # the widths the scalar-FP move encoders are sized for.
+    if (elem != 4 && elem != 8) { ret; }
+    @out_members = count::u8;
+    @out_elem    = elem::u8;
+}
+
+# hfa_member_reg: the physical V register for member `i` of a CLASS_HFA run — the
+# i-th register above the run's base (`slot.reg`). used to place each HFA member into
+# its consecutive argument / return register.
+fun hfa_member_reg(base_reg: i32, i: u32) i32 {
+    ret isa.regid_make(isa.REG_CLASS_ID_XMM, isa.regid_index(base_reg) + i::i32);
+}
+
 # advance_one_cursor: advance the GP or FP argument-register cursor for one assigned
 # register, dispatching on the register's bank (the composite id encodes it). a
 # negative id (no register) advances neither. so a register aggregate's GP and SSE
@@ -220,8 +313,13 @@ fun advance_one_cursor(reg: i32, gp_used: *i32, fp_used: *i32) {
 # advance_arg_cursors: advance the GP / FP cursors for a register-passed slot by the
 # bank of each register it occupies (`reg` and, for a two-register aggregate, `reg2`),
 # so a scalar, a by-reference pointer, and a mixed GP/SSE aggregate each consume the
-# correct registers. stack slots carry no register and advance neither.
+# correct registers. a CLASS_HFA run consumes `reg_count` consecutive V registers from
+# the FP bank. stack slots carry no register and advance neither.
 fun advance_arg_cursors(slot: *abi.ParamSlot, gp_used: *i32, fp_used: *i32) {
+    if (slot.class == abi.CLASS_HFA) {
+        @fp_used = @fp_used + slot.reg_count::i32;
+        ret;
+    }
     advance_one_cursor(slot.reg, gp_used, fp_used);
     advance_one_cursor(slot.reg2, gp_used, fp_used);
 }
@@ -328,7 +426,10 @@ pub fun classify_signature(ctx: *lctx.LowerCtx, sig: ir_type.IrTypeId, ret_ty: i
     val ret_float: bool = lctx.value_is_float(ctx, ret_ty);
     val ret_aggr:  bool = lctx.value_is_aggregate(ctx, ret_ty);
     val ret_eb:    u8   = aggregate_sse_mask(ctx, ret_ty);
-    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr);
+    var ret_hm:    u8   = 0;
+    var ret_he:    u8   = 0;
+    hfa_info(ctx, ret_ty, ?ret_hm, ?ret_he);
+    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr, ret_hm, ret_he);
 
     var gp_used:   i32 = 0;
     var fp_used:   i32 = 0;
@@ -380,7 +481,10 @@ pub fun classify_signature(ctx: *lctx.LowerCtx, sig: ir_type.IrTypeId, ret_ty: i
         val pfl:  bool = lctx.value_is_float(ctx, pty);
         val pag:  bool = lctx.value_is_aggregate(ctx, pty);
         val peb:  u8   = aggregate_sse_mask(ctx, pty);
-        var slot: abi.ParamSlot = classify_arg(pi::i32, psz, pal, pfl, peb, pag, gp_used, fp_used);
+        var phm:  u8   = 0;
+        var phe:  u8   = 0;
+        hfa_info(ctx, pty, ?phm, ?phe);
+        var slot: abi.ParamSlot = classify_arg(pi::i32, psz, pal, pfl, peb, pag, gp_used, fp_used, phm, phe);
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering
@@ -525,11 +629,12 @@ pub fun lower_call(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
             val aal:  u64  = ir_type.byte_align(ctx.types, av.ty, ctx.tgt)::u64;
             val afl:  bool = lctx.value_is_float(ctx, av.ty);
             val aag:  bool = lctx.value_is_aggregate(ctx, av.ty);
-            # a variadic tail aggregate is classified as integer eightbytes (mask 0):
-            # the va_arg read path walks the GP register-save / overflow areas, so the
-            # caller and callee stay consistent. SSE-eightbyte aggregate passing is for
-            # fixed parameters and returns (the C-FFI boundary), not the varargs tail.
-            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, gp_used, fp_used);
+            # a variadic tail aggregate is classified as integer eightbytes (mask 0)
+            # and never as an HFA (members 0): the va_arg read path walks the GP
+            # register-save / overflow areas, so the caller and callee stay consistent.
+            # SSE-eightbyte and HFA V-register passing are for fixed parameters and
+            # returns (the C-FFI boundary), not the varargs tail.
+            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, gp_used, fp_used, 0, 0);
             # round a stack-passed tail argument up to its slot alignment before
             # placing it (identity on x86; honors a 16-aligned AAPCS64 by-value arg).
             if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
@@ -687,9 +792,25 @@ fun lower_value_addr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, v: value.Value) Res
 # exhausted-slot case) stores only that pointer value, the stack analog of BYREF.
 # `lctx.addr_to_vreg` normalizes a global's symbol address into a value vreg so the
 # two-register / by-reference forms index a register pointer base. a scalar argop
-# is the value itself, placed directly.
+# is the value itself, placed directly. a CLASS_HFA argument loads each member from
+# `[base + i*reg_width]` into its consecutive V argument register (AAPCS64 HFA/HVA).
 fun emit_arg_slot(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, argop: mir.MirOperand,
                   stack_off: i64, is_aggr: bool, size: u64) Result[bool, str] {
+    if (slot.class == abi.CLASS_HFA) {
+        # an HFA argument flows by address; load each member into its V register.
+        var base: u32 = mir.MIR_VREG_NIL;
+        val ar: Result[bool, str] = lctx.addr_to_vreg(ctx, mb, argop, ?base);
+        if (is_err[bool, str](ar)) { ret ar; }
+        var i: u32 = 0;
+        for (i < slot.reg_count::u32) {
+            val off: i64 = (i * slot.reg_width::u32)::i64;
+            val mr: Result[bool, str] = lctx.emit_fmov(ctx, mb,
+                mir.op_preg(hfa_member_reg(slot.reg, i)::u32), mir.op_mem_value(base, off), slot.reg_width);
+            if (is_err[bool, str](mr)) { ret mr; }
+            i = i + 1;
+        }
+        ret ok[bool, str](true);
+    }
     if (slot.class == abi.CLASS_STACK_BYREF) {
         # win64 by-reference overflow: store the hidden aggregate pointer into the
         # outgoing stack slot, not a by-value copy of the aggregate bytes.
@@ -778,11 +899,25 @@ fun record_outgoing_size(ctx: *lctx.LowerCtx, bytes: i64) {
 
 # emit_ret_slot_to_vreg: move a call's return value out of its canonical return
 # register(s) into the result vreg. for an aggregate return `dst` is the caller-
-# owned result storage pointer (see `lctx.alloc_result_storage`): a 9–16 byte RAX:RDX
-# pair stores each half into `[dst+0]` / `[dst+8]`, and a ≤8 byte single-register
-# aggregate stores RAX into `[dst+0]` so `dst` stays the storage pointer downstream
-# consumers read by. a scalar return is a plain move into the value vreg `dst`.
+# owned result storage pointer (see `lctx.alloc_result_storage`): an HFA stores each
+# V member into `[dst + i*reg_width]`, a 9–16 byte RAX:RDX pair stores each half into
+# `[dst+0]` / `[dst+8]`, and a ≤8 byte single-register aggregate stores RAX into
+# `[dst+0]` so `dst` stays the storage pointer downstream consumers read by. a scalar
+# return is a plain move into the value vreg `dst`.
 fun emit_ret_slot_to_vreg(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, dst: u32, is_aggr: bool) Result[bool, str] {
+    if (slot.class == abi.CLASS_HFA) {
+        # an HFA return arrives in V0..V(reg_count-1); store each member into the
+        # caller-owned result storage so `dst` stays the storage pointer.
+        var i: u32 = 0;
+        for (i < slot.reg_count::u32) {
+            val off: i64 = (i * slot.reg_width::u32)::i64;
+            val st: Result[bool, str] = lctx.emit_store_to_w(ctx, mb,
+                mir.op_mem_value(dst, off), mir.op_preg(hfa_member_reg(slot.reg, i)::u32), slot.reg_width);
+            if (is_err[bool, str](st)) { ret st; }
+            i = i + 1;
+        }
+        ret ok[bool, str](true);
+    }
     if (slot.reg2 >= 0) {
         val lo: Result[bool, str] = lctx.emit_store_to(ctx, mb, mir.op_mem_value(dst, 0), mir.op_preg(slot.reg::u32));
         if (is_err[bool, str](lo)) { ret lo; }
@@ -866,15 +1001,33 @@ pub fun lower_params(ctx: *lctx.LowerCtx, mb: *mir.MirBlock) Result[bool, str] {
 # is the caller's by-value copy at `[rbp + 16 + stack_off]`, whose address is LEA'd
 # into `pv`; a STACK_BYREF aggregate is the caller's spilled hidden pointer at that
 # slot, LOADED into `pv` (the stack analog of BYREF). a scalar parameter moves its
-# single register / stack word into the parameter value vreg `pv`. `stack_off` is
-# the callee-tracked running offset (the ABI classifier returns a sizing-only slot
-# — see `lower_params`).
+# single register / stack word into the parameter value vreg `pv`. an HFA parameter
+# arrives in V[reg]..V[reg+reg_count-1]; each member is stored into a fresh spill
+# slot keyed on `pv` so `pv` names that storage like the register-aggregate forms.
+# `stack_off` is the callee-tracked running offset (the ABI classifier returns a
+# sizing-only slot — see `lower_params`).
 fun emit_param_slot(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, pv: u32, size: u64,
                     stack_off: i64, is_aggr: bool) Result[bool, str] {
     # incoming stack parameters are addressed off the ISA's frame pointer at the
     # arch's incoming-argument base (`[fp + incoming_arg_base + off]`), both named
     # through the ISA vtable rather than bare literals.
     val arg_base: i64 = ctx.tgt.arch.incoming_arg_base;
+    if (slot.class == abi.CLASS_HFA) {
+        # spill each incoming V member into a slot keyed on `pv` so `pv` is the
+        # aggregate's storage pointer for downstream uses (the FP twin of the
+        # register-aggregate spill).
+        val sr: Result[bool, str] = lctx.add_spill_slot(ctx, pv, size);
+        if (is_err[bool, str](sr)) { ret sr; }
+        var i: u32 = 0;
+        for (i < slot.reg_count::u32) {
+            val off: i64 = (i * slot.reg_width::u32)::i64;
+            val st: Result[bool, str] = lctx.emit_store_to_w(ctx, mb,
+                mir.op_mem_slot(pv, off), mir.op_preg(hfa_member_reg(slot.reg, i)::u32), slot.reg_width);
+            if (is_err[bool, str](st)) { ret st; }
+            i = i + 1;
+        }
+        ret ok[bool, str](true);
+    }
     if (slot.class == abi.CLASS_STACK_BYREF) {
         # win64 by-reference overflow: the caller stored the hidden aggregate
         # pointer into this stack slot; load it so `pv` is the aggregate's address,
@@ -961,6 +1114,20 @@ pub fun lower_ret(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructi
         if (is_err[bool, str](cr)) { ret cr; }
         val mr: Result[bool, str] = lctx.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(ctx.sret_vreg));
         if (is_err[bool, str](mr)) { ret mr; }
+    } or (slot.class == abi.CLASS_HFA) {
+        # HFA return: the aggregate flows by address; load each member from its
+        # storage into the consecutive V return register (V0..V(reg_count-1)).
+        var base: u32 = mir.MIR_VREG_NIL;
+        val ar: Result[bool, str] = lctx.addr_to_vreg(ctx, mb, rvop, ?base);
+        if (is_err[bool, str](ar)) { ret ar; }
+        var i: u32 = 0;
+        for (i < slot.reg_count::u32) {
+            val off: i64 = (i * slot.reg_width::u32)::i64;
+            val mr: Result[bool, str] = lctx.emit_fmov(ctx, mb,
+                mir.op_preg(hfa_member_reg(slot.reg, i)::u32), mir.op_mem_value(base, off), slot.reg_width);
+            if (is_err[bool, str](mr)) { ret mr; }
+            i = i + 1;
+        }
     } or (slot.reg2 >= 0 && rag) {
         # 9–16 byte aggregate: load each half from the aggregate's storage (a
         # value-pointer base), materializing a global's symbol address first.

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -49,22 +49,36 @@ pub val CLASS_BYREF: ParamClass = 4;
 # aggregate's by-value bytes). distinct from CLASS_STACK, whose stack slot holds
 # the value's own bytes.
 pub val CLASS_STACK_BYREF: ParamClass = 5;
+# passed in a run of consecutive floating-point / vector registers — an AAPCS64
+# Homogeneous Floating-point / Short-Vector Aggregate (HFA/HVA): a composite of
+# 1–4 members all of the same fundamental FP type rides V[reg]..V[reg+reg_count-1],
+# one member per register at `reg_width` bytes each. distinct from CLASS_FP, which
+# is a single scalar float in one register.
+pub val CLASS_HFA: ParamClass = 6;
 
 # placement decision for one parameter or return value. `reg2` carries the
 # second register of a 9–16 byte aggregate split across two registers; it is
-# -1 when the value occupies a single register or the stack.
+# -1 when the value occupies a single register or the stack. `reg_count` /
+# `reg_width` describe a CLASS_HFA register run; they are 1 / 0 for every other
+# placement.
 # ---
-# class:  classification (CLASS_GP, CLASS_FP, CLASS_STACK, ...)
-# reg:    first register id if register-passed (-1 if stack/byref)
-# reg2:   second register id for a two-register aggregate (-1 otherwise)
-# offset: stack offset in bytes if stack-passed
-# size:   size in bytes of this slot
+# class:     classification (CLASS_GP, CLASS_FP, CLASS_STACK, ...)
+# reg:       first register id if register-passed (-1 if stack/byref); the base
+#            register of a CLASS_HFA run
+# reg2:      second register id for a two-register aggregate (-1 otherwise)
+# reg_count: number of consecutive registers from `reg` for a CLASS_HFA (1 for
+#            every other placement)
+# reg_width: per-register member width in bytes for a CLASS_HFA (0 otherwise)
+# offset:    stack offset in bytes if stack-passed
+# size:      size in bytes of this slot
 pub rec ParamSlot {
-    class:  ParamClass;
-    reg:    i32;
-    reg2:   i32;
-    offset: i64;
-    size:   u64;
+    class:     ParamClass;
+    reg:       i32;
+    reg2:      i32;
+    reg_count: u8;
+    reg_width: u8;
+    offset:    i64;
+    size:      u64;
 }
 
 # the concrete signatures the erased `AbiVTable` function pointers are cast back
@@ -86,6 +100,13 @@ pub rec ParamSlot {
 # registers. it is meaningful only for a ≤16 byte aggregate; 0 for scalars and
 # integer-only aggregates.
 # ---
+# `hfa_members` / `hfa_elem` are the backend's HFA descriptor: an AAPCS64
+# Homogeneous Floating-point / Short-Vector Aggregate is reported as its member
+# count (1–4) and fundamental member width in bytes, so the AAPCS64 classifier can
+# place it in consecutive V registers. `hfa_members` is 0 for a non-HFA (a scalar,
+# a heterogeneous or oversized aggregate, or any value on a convention that has no
+# HFA rule); the AMD64 conventions ignore both, as they do `fp_eightbytes`.
+# ---
 # size:          value size in bytes
 # align:         value alignment in bytes
 # is_float:      true if the value is FP-register-eligible
@@ -93,13 +114,15 @@ pub rec ParamSlot {
 # is_aggregate:  true if the value is a record/array (recursively classified)
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (1–4), or 0 if the value is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
-pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32) ParamSlot;
+pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
 
 # assign the registers or stack slot for a single argument, given the GP/FP usage
 # counters the caller tracks across the call's argument list. arch-specific by
 # selection, so no `arch_id` is threaded. `fp_eightbytes` is the per-eightbyte SSE
-# mask (see `ClassifyFn`).
+# mask and `hfa_members` / `hfa_elem` the HFA descriptor (see `ClassifyFn`).
 # ---
 # index:         zero-based logical argument position
 # size:          argument size in bytes
@@ -109,20 +132,24 @@ pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32) ParamSlot;
 # is_aggregate:  true if the argument is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (1–4), or 0 if the argument is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
-pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, i32, i32) ParamSlot;
+pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
 
 # assign the registers or sret slot for a return value. arch-specific by
 # selection, so no `arch_id` is threaded. `fp_eightbytes` is the per-eightbyte SSE
-# mask (see `ClassifyFn`).
+# mask and `hfa_members` / `hfa_elem` the HFA descriptor (see `ClassifyFn`).
 # ---
 # size:          return-value size in bytes
 # align:         return-value alignment in bytes
 # is_float:      true if the value is returned in FP registers
 # fp_eightbytes: per-eightbyte SSE mask (bit e -> eightbyte e is SSE class)
 # is_aggregate:  true if the value is an aggregate
+# hfa_members:   HFA member count (1–4), or 0 if the value is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
-pub def RetPassingFn: fun(u64, u64, bool, u8, bool) ParamSlot;
+pub def RetPassingFn: fun(u64, u64, bool, u8, bool, u8, u8) ParamSlot;
 
 # fill a caller-owned `out` buffer with a register bank in canonical order and
 # return the count written. the erased `gp_arg_regs` / `fp_arg_regs` /
@@ -361,7 +388,9 @@ pub rec VaModel {
     vector_count_reg: i32;
 }
 
-# make_slot: build a ParamSlot. convenience for ABI implementations.
+# make_slot: build a single-register / stack ParamSlot. convenience for ABI
+# implementations. `reg_count` is 1 and `reg_width` 0 — the CLASS_HFA register-run
+# fields are set only by `make_slot_hfa`.
 # ---
 # class:  classification
 # reg:    first register id (-1 if none)
@@ -371,10 +400,34 @@ pub rec VaModel {
 # ret:    the assembled ParamSlot
 pub fun make_slot(class: ParamClass, reg: i32, reg2: i32, offset: i64, size: u64) ParamSlot {
     var s: ParamSlot;
-    s.class  = class;
-    s.reg    = reg;
-    s.reg2   = reg2;
-    s.offset = offset;
-    s.size   = size;
+    s.class     = class;
+    s.reg       = reg;
+    s.reg2      = reg2;
+    s.reg_count = 1;
+    s.reg_width = 0;
+    s.offset    = offset;
+    s.size      = size;
+    ret s;
+}
+
+# make_slot_hfa: build a CLASS_HFA ParamSlot for a homogeneous FP aggregate placed
+# in a run of `count` consecutive registers from `base_reg`, each holding one
+# `elem`-byte member. used by the AAPCS64 classifier for HFA/HVA arguments and
+# returns.
+# ---
+# base_reg: the first (lowest-numbered) register of the run
+# count:    number of consecutive registers (the HFA member count, 1–4)
+# elem:     per-register member width in bytes
+# size:     total aggregate size in bytes
+# ret:      the assembled CLASS_HFA ParamSlot
+pub fun make_slot_hfa(base_reg: i32, count: u8, elem: u8, size: u64) ParamSlot {
+    var s: ParamSlot;
+    s.class     = CLASS_HFA;
+    s.reg       = base_reg;
+    s.reg2      = -1;
+    s.reg_count = count;
+    s.reg_width = elem;
+    s.offset    = 0;
+    s.size      = size;
     ret s;
 }

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -10,15 +10,17 @@
 # (`*u8`); a consumer casts each back to the neutral signature declared in `abi`
 # (`ClassifyFn`, `ArgPassingFn`, `RetPassingFn`, `RegFileFn`).
 #
-# Scalars and ≤16-byte aggregates are placed in registers; >16-byte aggregates are
-# passed by hidden reference and returned through the dedicated X8 indirect-result
-# register (`indirect_result_in_argfile` is false, so the hidden pointer rides X8
-# OUTSIDE the X0–X7 argument file and the real arguments still start at X0). The
-# contract gaps DEFERRED to a later phase are: homogeneous floating-point /
-# short-vector aggregates (HFA/HVA) — a ≤16-byte all-float aggregate rides GP
-# registers here, not the V-register sequence; and the full AArch64 `va_list`
-# variadic model — `va_model` returns a register-save placeholder sufficient for
-# non-variadic call lowering.
+# Scalars and ≤16-byte integer aggregates are placed in GP registers; a Homogeneous
+# Floating-point / Short-Vector Aggregate (HFA/HVA — a composite of 1–4 members all
+# of the same fundamental FP type) rides a run of consecutive V registers (V0–V7);
+# >16-byte non-HFA aggregates are passed by hidden reference and returned through the
+# dedicated X8 indirect-result register (`indirect_result_in_argfile` is false, so the
+# hidden pointer rides X8 OUTSIDE the X0–X7 argument file and the real arguments still
+# start at X0). The HFA descriptor (member count + fundamental width) is computed by
+# the backend and threaded in through `classify_arg` / `classify_return`. The one
+# contract gap DEFERRED to a later phase is the full AArch64 `va_list` variadic model —
+# `va_model` returns a register-save placeholder sufficient for non-variadic call
+# lowering.
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -124,42 +126,60 @@ pub fun fp_param_reg(index: i32) i32 {
 # size:          value size in bytes
 # align:         value alignment in bytes
 # is_float:      true if the value is FP-eligible
-# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# fp_eightbytes: per-eightbyte SSE mask (unused — AAPCS64 routes FP through HFA)
 # is_aggregate:  true if the value is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (1–4), or 0 if the value is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
-                 is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used);
+                 is_aggregate: bool, gp_used: i32, fp_used: i32,
+                 hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem);
 }
 
 # classify_arg: assign registers or a stack slot for one argument (AAPCS64).
 #
-# scalars take one GP register (or one V register for a float) until that bank is
-# exhausted, then spill to the stack. an aggregate of ≤8 bytes takes one GP
-# register; a 9–16 byte aggregate takes a consecutive GP register pair; either
-# spills to the stack by value when the GP bank lacks the register(s) it needs.
-# an aggregate larger than 16 bytes is passed by hidden reference — the caller
-# copies it to memory and passes the pointer in the next GP register
-# (CLASS_BYREF), or, when the GP bank is exhausted, passes that pointer on the
-# stack (CLASS_STACK_BYREF). HFA/HVA float-aggregate placement in the V registers
-# is deferred (see the module note); a float-bearing ≤16-byte aggregate rides GP
-# registers here. this classifier is AArch64-specific by selection: `target.select`
-# only composes the AAPCS64 vtable for an aarch64 (os, arch) pair.
+# an HFA/HVA (a homogeneous aggregate of 1–4 same-typed FP members, reported by the
+# backend through `hfa_members` / `hfa_elem`) rides a run of consecutive V registers
+# when the whole run fits in the remaining V bank; otherwise the WHOLE aggregate
+# spills to the stack by value (the AAPCS64 all-or-memory rule — members are never
+# split across registers and stack). this is checked before the by-reference rule,
+# since a 4×f64 HFA is 32 bytes yet still register-passed. scalars take one GP
+# register (or one V register for a float) until that bank is exhausted, then spill
+# to the stack. a non-HFA aggregate of ≤8 bytes takes one GP register; a 9–16 byte
+# one takes a consecutive GP register pair; either spills to the stack by value when
+# the GP bank lacks the register(s) it needs. a non-HFA aggregate larger than 16
+# bytes is passed by hidden reference — the caller copies it to memory and passes the
+# pointer in the next GP register (CLASS_BYREF), or, when the GP bank is exhausted,
+# passes that pointer on the stack (CLASS_STACK_BYREF). this classifier is
+# AArch64-specific by selection: `target.select` only composes the AAPCS64 vtable for
+# an aarch64 (os, arch) pair.
 # ---
 # index:         zero-based logical argument position
 # size:          argument size in bytes
 # align:         argument alignment in bytes
 # is_float:      true if the argument goes in an FP register (scalar floats)
-# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# fp_eightbytes: per-eightbyte SSE mask (unused — AAPCS64 routes FP through HFA)
 # is_aggregate:  true if the argument is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (1–4), or 0 if the argument is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                     gp_used: i32, fp_used: i32) abi.ParamSlot {
+                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+    if (is_aggregate && hfa_members > 0) {
+        # the run fits only if every member lands in the remaining V bank; otherwise
+        # the whole aggregate goes to the stack by value (all-or-memory).
+        if (fp_used + hfa_members::i32 <= FP_PARAM_COUNT) {
+            ret abi.make_slot_hfa(fp_param_reg(fp_used), hfa_members, hfa_elem, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
+
     if (is_aggregate && size > MAX_REG_RET) {
         # >16 bytes: passed by reference. the pointer rides the next GP register, or
         # the stack (as an 8-byte pointer) once the GP bank is exhausted.
@@ -200,25 +220,33 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # classify_return: assign registers or an sret pointer for a return value (AAPCS64).
 #
 # a zero-size (void) return yields CLASS_GP with reg=-1. a scalar returns in X0,
-# or V0 for a float. an aggregate of ≤8 bytes returns in X0; a 9–16 byte aggregate
-# returns in the X0:X1 pair. an aggregate larger than 16 bytes is returned through
-# the dedicated X8 indirect-result register (CLASS_SRET, reg=X8) — the caller passes
-# the result-storage address in X8 and the callee reads it there, leaving X0–X7 for
-# the real arguments. HFA/HVA V-register returns are likewise deferred:
-# a float-bearing ≤16-byte aggregate returns in GP registers here. this classifier
-# is AArch64-specific by selection — the AAPCS64 vtable is only composed for an
-# aarch64 target.
+# or V0 for a float. an HFA/HVA returns in the V0..V(members-1) run. a non-HFA
+# aggregate of ≤8 bytes returns in X0; a 9–16 byte one returns in the X0:X1 pair.
+# a non-HFA aggregate larger than 16 bytes is returned through the dedicated X8
+# indirect-result register (CLASS_SRET, reg=X8) — the caller passes the
+# result-storage address in X8 and the callee reads it there, leaving X0–X7 for the
+# real arguments. the HFA check precedes the >16-byte sret rule (a 4×f64 HFA is 32
+# bytes yet returns in V0–V3). this classifier is AArch64-specific by selection —
+# the AAPCS64 vtable is only composed for an aarch64 target.
 # ---
 # size:          return-value size in bytes
 # align:         return-value alignment in bytes
 # is_float:      true if the value is returned in an FP register (scalar floats)
-# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# fp_eightbytes: per-eightbyte SSE mask (unused — AAPCS64 routes FP through HFA)
 # is_aggregate:  true if the value is an aggregate
+# hfa_members:   HFA member count (1–4), or 0 if the value is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool) abi.ParamSlot {
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                        hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
+    }
+
+    # an HFA/HVA returns in V0..V(members-1); a return always has the full V bank.
+    if (is_aggregate && hfa_members > 0) {
+        ret abi.make_slot_hfa(fp_param_reg(0), hfa_members, hfa_elem, size);
     }
 
     if (is_aggregate && size > MAX_REG_RET) {
@@ -357,62 +385,104 @@ pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
 }
 
 test "aapcs64: a scalar integer takes a GP register, a float a V register" {
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_X0)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
     if (f.class != abi.CLASS_FP)    { ret 1; }
     if (f.reg != fp_param_reg(0))   { ret 1; }
     ret 0;
 }
 
-test "aapcs64: a 16-byte aggregate rides a consecutive GP pair" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0);
+test "aapcs64: a 16-byte integer aggregate rides a consecutive GP pair" {
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0);
     if (s.class != abi.CLASS_GP) { ret 1; }
     if (s.reg  != REG_X0)        { ret 1; }
     if (s.reg2 != REG_X1)        { ret 1; }
     # an 8-byte aggregate takes a single GP register.
-    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0);
+    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0);
     if (o.class != abi.CLASS_GP) { ret 1; }
     if (o.reg  != REG_X0)        { ret 1; }
     if (o.reg2 != -1)            { ret 1; }
     ret 0;
 }
 
-test "aapcs64: a >16-byte aggregate is passed by reference" {
+test "aapcs64: a >16-byte non-HFA aggregate is passed by reference" {
     # a GP register remains: the hidden pointer rides it.
-    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0);
     if (s.class != abi.CLASS_BYREF) { ret 1; }
     if (s.reg   != REG_X0)          { ret 1; }
     # GP bank exhausted: the pointer is passed on the stack.
-    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0);
+    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0, 0, 0);
     if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: an HFA rides a consecutive V run; all-or-memory when it cannot fit" {
+    # struct { f32, f32 } -> 2 members of 4 bytes in V0:V1.
+    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 2, 4);
+    if (s.class != abi.CLASS_HFA)        { ret 1; }
+    if (s.reg != fp_param_reg(0))        { ret 1; }
+    if (s.reg_count != 2)                { ret 1; }
+    if (s.reg_width != 4)                { ret 1; }
+    if (s.size != 8)                     { ret 1; }
+    # a 4×f64 HFA is 32 bytes yet still rides V0..V3 (HFA precedes the byref rule).
+    val q: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 4, 8);
+    if (q.class != abi.CLASS_HFA)        { ret 1; }
+    if (q.reg != fp_param_reg(0))        { ret 1; }
+    if (q.reg_count != 4)                { ret 1; }
+    if (q.reg_width != 8)                { ret 1; }
+    # the run starts at the next free V register (NSRN cursor honored).
+    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 5, 2, 4);
+    if (a.class != abi.CLASS_HFA)        { ret 1; }
+    if (a.reg != fp_param_reg(5))        { ret 1; }
+    # all-or-memory: a 3-member HFA cannot fit when only two V registers remain, so
+    # the WHOLE aggregate spills by value (no partial V placement).
+    val m: abi.ParamSlot = classify_arg(0, 12, 4, false, 0, true, 0, 6, 3, 4);
+    if (m.class != abi.CLASS_STACK)      { ret 1; }
     ret 0;
 }
 
 test "aapcs64: GP and FP argument banks advance independently" {
     # seven GP registers used: a scalar integer still has X7, a float still has V0.
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0);
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0, 0, 0);
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_X7)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0);
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0, 0, 0);
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     # GP exhausted spills an integer to the stack; the FP bank is untouched.
-    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 8, 0);
+    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 8, 0, 0, 0);
     if (s.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
 
 test "aapcs64: scalar and small-aggregate returns place X0/V0/X0:X1" {
-    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false);
+    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0);
     if (v.class != abi.CLASS_GP || v.reg != -1) { ret 1; }
-    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false);
+    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0);
     if (i.reg != REG_X0) { ret 1; }
-    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false);
+    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0);
     if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
-    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true);
+    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0);
     if (a.reg != REG_X0 || a.reg2 != REG_X1) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: an HFA return rides the V0 run, before the sret rule" {
+    # struct { f32, f32, f32 } returns in V0:V1:V2.
+    val s: abi.ParamSlot = classify_return(12, 4, false, 0, true, 3, 4);
+    if (s.class != abi.CLASS_HFA) { ret 1; }
+    if (s.reg != fp_param_reg(0)) { ret 1; }
+    if (s.reg_count != 3)         { ret 1; }
+    if (s.reg_width != 4)         { ret 1; }
+    # a 4×f64 HFA is 32 bytes yet returns in V0..V3, not via X8 sret.
+    val q: abi.ParamSlot = classify_return(32, 8, false, 0, true, 4, 8);
+    if (q.class != abi.CLASS_HFA) { ret 1; }
+    if (q.reg_count != 4)         { ret 1; }
+    # a >16-byte non-HFA aggregate still returns via the X8 indirect-result register.
+    val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0);
+    if (r.class != abi.CLASS_SRET || r.reg != REG_X8) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -126,10 +126,13 @@ pub fun fp_param_reg(index: i32) i32 {
 # is_aggregate: true if the value is an aggregate
 # gp_used:      GP registers already consumed
 # fp_used:      FP registers already consumed
+# hfa_members:  HFA member count (AAPCS64-only; unused under SysV)
+# hfa_elem:     HFA fundamental member width (AAPCS64-only; unused under SysV)
 # ret:          the placement decision
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
-                 is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used);
+                 is_aggregate: bool, gp_used: i32, fp_used: i32,
+                 hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem);
 }
 
 # ret_int_reg: the SysV integer return register for eightbyte index 0 / 1 (RAX, RDX).
@@ -171,10 +174,12 @@ fun ret_sse_reg(index: i32) i32 {
 # is_aggregate:  true if the argument is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (AAPCS64-only; unused under SysV)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under SysV)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                     gp_used: i32, fp_used: i32) abi.ParamSlot {
+                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     if (is_aggregate && size > MAX_REG_RET) {
         if (gp_used < GP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
@@ -250,9 +255,12 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_float:      true if the value is returned in FP registers (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask for an aggregate (bit e -> eightbyte e SSE)
 # is_aggregate:  true if the value is an aggregate
+# hfa_members:   HFA member count (AAPCS64-only; unused under SysV)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under SysV)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool) abi.ParamSlot {
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                        hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }
@@ -417,7 +425,7 @@ pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
 
 test "sysv: an all-float 16-byte aggregate rides XMM0:XMM1" {
     # {f64; f64} -> both eightbytes SSE -> the two vector argument registers.
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 0, 0, 0);
     if (s.class != abi.CLASS_GP) { ret 1; }
     if (s.reg  != fp_param_reg(0)) { ret 1; }
     if (s.reg2 != fp_param_reg(1)) { ret 1; }
@@ -426,7 +434,7 @@ test "sysv: an all-float 16-byte aggregate rides XMM0:XMM1" {
 
 test "sysv: an 8-byte all-float aggregate rides one XMM register" {
     # {f32; f32} (8 bytes) -> one SSE eightbyte -> XMM0.
-    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, 0, 0, 0, 0);
     if (s.class != abi.CLASS_GP) { ret 1; }
     if (s.reg  != fp_param_reg(0)) { ret 1; }
     if (s.reg2 != -1) { ret 1; }
@@ -435,12 +443,12 @@ test "sysv: an 8-byte all-float aggregate rides one XMM register" {
 
 test "sysv: a mixed INTEGER:SSE aggregate rides RDI:XMM0" {
     # {i64; f64} -> eightbyte 0 INTEGER (RDI), eightbyte 1 SSE (XMM0).
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, 0, 0, 0, 0);
     if (s.reg  != REG_RDI)        { ret 1; }
     if (s.reg2 != fp_param_reg(0)) { ret 1; }
     # the reverse {f64; i64} -> XMM0:RDI: the GP and SSE banks fill independently, so
     # the integer eightbyte takes the FIRST GP register (RDI), not the second.
-    val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, 0, 0);
+    val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, 0, 0, 0, 0);
     if (r.reg  != fp_param_reg(0)) { ret 1; }
     if (r.reg2 != REG_RDI)        { ret 1; }
     ret 0;
@@ -448,7 +456,7 @@ test "sysv: a mixed INTEGER:SSE aggregate rides RDI:XMM0" {
 
 test "sysv: an all-integer aggregate still rides the GP pair (unchanged)" {
     # {i64; i64} (mask 0) -> RDI:RSI, exactly as before SSE classification.
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0);
     if (s.reg  != REG_RDI) { ret 1; }
     if (s.reg2 != REG_RSI) { ret 1; }
     ret 0;
@@ -457,18 +465,18 @@ test "sysv: an all-integer aggregate still rides the GP pair (unchanged)" {
 test "sysv: SSE eightbytes consume the FP bank; exhaustion spills by value" {
     # with seven XMM registers already used, a two-SSE aggregate needs two but only
     # one remains, so the whole aggregate spills to the stack by value.
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 7);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 7, 0, 0);
     if (s.class != abi.CLASS_STACK) { ret 1; }
     if (s.size != 16)               { ret 1; }
     ret 0;
 }
 
 test "sysv: an all-float aggregate returns in XMM0:XMM1" {
-    val s: abi.ParamSlot = classify_return(16, 8, false, 3, true);
+    val s: abi.ParamSlot = classify_return(16, 8, false, 3, true, 0, 0);
     if (s.reg  != REG_XMM0) { ret 1; }
     if (s.reg2 != REG_XMM1) { ret 1; }
     # one all-float eightbyte returns in XMM0.
-    val o: abi.ParamSlot = classify_return(8, 4, false, 1, true);
+    val o: abi.ParamSlot = classify_return(8, 4, false, 1, true, 0, 0);
     if (o.reg  != REG_XMM0) { ret 1; }
     if (o.reg2 != -1)       { ret 1; }
     ret 0;
@@ -476,19 +484,19 @@ test "sysv: an all-float aggregate returns in XMM0:XMM1" {
 
 test "sysv: aggregate returns place each bank's eightbytes in order" {
     # {i64; i64} -> RAX:RDX (unchanged).
-    val gp: abi.ParamSlot = classify_return(16, 8, false, 0, true);
+    val gp: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0);
     if (gp.reg != REG_RAX || gp.reg2 != REG_RDX) { ret 1; }
     # {i64; f64} -> RAX:XMM0.
-    val mix: abi.ParamSlot = classify_return(16, 8, false, 2, true);
+    val mix: abi.ParamSlot = classify_return(16, 8, false, 2, true, 0, 0);
     if (mix.reg != REG_RAX || mix.reg2 != REG_XMM0) { ret 1; }
     ret 0;
 }
 
 test "sysv: a scalar float still takes an XMM register, an integer a GP" {
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
     if (f.class != abi.CLASS_FP)   { ret 1; }
     if (f.reg != fp_param_reg(0))  { ret 1; }
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_RDI)        { ret 1; }
     ret 0;
@@ -508,19 +516,19 @@ test "sysv: the indirect-result pointer rides the first GP argument register (in
 
 test "sysv: large aggregate is MEMORY-class when all GP registers consumed (#1242)" {
     # size=32 > MAX_REG_RET=16, gp_used=6 (exhausted) -> CLASS_STACK by value, reg=-1
-    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 6, 0);
+    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 6, 0, 0, 0);
     if (s1.class != abi.CLASS_STACK) { ret 1; }
     if (s1.reg   != -1)              { ret 1; }
     if (s1.size  != 32)              { ret 1; }
 
     # size=17 > MAX_REG_RET, gp_used=6 -> same MEMORY-class outcome
-    val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, 6, 0);
+    val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, 6, 0, 0, 0);
     if (s2.class != abi.CLASS_STACK) { ret 1; }
     if (s2.reg   != -1)              { ret 1; }
     if (s2.size  != 17)              { ret 1; }
 
     # gp_used=5 (one register remains) -> CLASS_BYREF, contrast with exhausted case
-    val s3: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 5, 0);
+    val s3: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 5, 0, 0, 0);
     if (s3.class != abi.CLASS_BYREF) { ret 1; }
 
     ret 0;

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -186,10 +186,13 @@ fun slot_index(gp_used: i32, fp_used: i32) i32 {
 # is_aggregate:  true if the value is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (AAPCS64-only; unused under win64)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under win64)
 # ret:           the placement decision
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
-                 is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used);
+                 is_aggregate: bool, gp_used: i32, fp_used: i32,
+                 hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem);
 }
 
 # classify_arg: assign a register or stack slot for one argument (win64).
@@ -219,10 +222,12 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_aggregate:  true if the argument is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (AAPCS64-only; unused under win64)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under win64)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                     gp_used: i32, fp_used: i32) abi.ParamSlot {
+                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     val slot: i32 = slot_index(gp_used, fp_used);
 
     if (is_aggregate) {
@@ -273,9 +278,12 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_float:      true if the value is returned in FP registers (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask (unused — win64 returns aggregates in RAX)
 # is_aggregate:  true if the value is an aggregate
+# hfa_members:   HFA member count (AAPCS64-only; unused under win64)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under win64)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool) abi.ParamSlot {
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                        hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }
@@ -452,19 +460,19 @@ pub fun register_win64(reg: *abi.AbiRegistry) Result[bool, str] {
 }
 
 test "win64: scalar integer args take RCX, RDX, R8, R9 then spill" {
-    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
+    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
     if (s0.class != abi.CLASS_GP) { ret 1; }
     if (s0.reg != REG_RCX)        { ret 1; }
 
-    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 1, 0);
+    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 1, 0, 0, 0);
     if (s1.reg != REG_RDX) { ret 1; }
-    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, 2, 0);
+    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, 2, 0, 0, 0);
     if (s2.reg != REG_R8) { ret 1; }
-    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, 3, 0);
+    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, 3, 0, 0, 0);
     if (s3.reg != REG_R9) { ret 1; }
 
     # the fifth argument has no register slot and spills to the stack by value.
-    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, 4, 0);
+    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, 4, 0, 0, 0);
     if (s4.class != abi.CLASS_STACK) { ret 1; }
     if (s4.reg != -1)                { ret 1; }
     if (s4.size != 8)                { ret 1; }
@@ -472,16 +480,16 @@ test "win64: scalar integer args take RCX, RDX, R8, R9 then spill" {
 }
 
 test "win64: float args take XMM0–XMM3 then spill" {
-    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
+    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
     if (f0.class != abi.CLASS_FP)                          { ret 1; }
     if (f0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
 
-    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, 0, 3);
+    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, 0, 3, 0, 0);
     if (f3.class != abi.CLASS_FP)                          { ret 1; }
     if (f3.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
 
     # the fifth positional argument (slot 4) spills regardless of bank.
-    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, 0, 4);
+    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, 0, 4, 0, 0);
     if (f4.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -490,16 +498,16 @@ test "win64: int and float share one positional slot per argument" {
     # argument 0 is an integer (slot 0 -> RCX). argument 1 is a float; under
     # win64 it takes the SECOND positional slot -> XMM1, not XMM0, because the
     # integer already consumed slot 0.
-    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
+    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
     if (i0.reg != REG_RCX) { ret 1; }
-    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, 1, 0);
+    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, 1, 0, 0, 0);
     if (f1.class != abi.CLASS_FP)                          { ret 1; }
     if (f1.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 1)) { ret 1; }
 
     # the reverse: a float (slot 0 -> XMM0) followed by an integer (slot 1 -> RDX).
-    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
+    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
     if (g0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
-    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 0, 1);
+    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 0, 1, 0, 0);
     if (g1.class != abi.CLASS_GP) { ret 1; }
     if (g1.reg != REG_RDX)        { ret 1; }
     ret 0;
@@ -517,24 +525,24 @@ test "win64: a variadic float duplicates into the matching integer register" {
 
 test "win64: 1/2/4/8-byte aggregates ride one register, others go by reference" {
     # an 8-byte aggregate rides RCX by value.
-    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0);
+    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0);
     if (by_val.class != abi.CLASS_GP) { ret 1; }
     if (by_val.reg != REG_RCX)        { ret 1; }
     if (by_val.size != 8)             { ret 1; }
 
     # a 4-byte aggregate also rides by value.
-    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, 0, 0);
+    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, 0, 0, 0, 0);
     if (four.class != abi.CLASS_GP) { ret 1; }
 
     # a 3-byte aggregate is not a by-value size: passed by hidden reference, the
     # pointer (8 bytes) in RCX.
-    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, 0, 0);
+    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, 0, 0, 0, 0);
     if (by_ref3.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref3.reg != REG_RCX)           { ret 1; }
     if (by_ref3.size != 8)                { ret 1; }
 
     # a 16-byte aggregate is also by reference.
-    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0);
+    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0);
     if (by_ref16.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref16.reg != REG_RCX)           { ret 1; }
     ret 0;
@@ -544,7 +552,7 @@ test "win64: an exhausted by-reference aggregate spills its pointer to the stack
     # all four positional slots are taken; a 16-byte by-ref aggregate spills the
     # 8-byte hidden pointer to the stack as CLASS_STACK_BYREF (not the full
     # aggregate, and distinct from a by-value CLASS_STACK spill).
-    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, 4, 0);
+    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, 4, 0, 0, 0);
     if (s.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s.reg != -1)                      { ret 1; }
     if (s.size != 8)                      { ret 1; }
@@ -552,28 +560,28 @@ test "win64: an exhausted by-reference aggregate spills its pointer to the stack
     # a sub-pointer (3-byte) aggregate is also by reference: win64 treats every
     # non-1/2/4/8-byte aggregate as byref, so an exhausted 3-byte aggregate spills
     # its 8-byte pointer too — the size-mismatch heuristic missed this case.
-    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, 4, 0);
+    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, 4, 0, 0, 0);
     if (s3.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s3.size != 8)                      { ret 1; }
 
     # an exhausted by-value-size aggregate (8 bytes) spills its own bytes by value,
     # so it stays CLASS_STACK — the byref class must not capture the by-value path.
-    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, true, 4, 0);
+    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, true, 4, 0, 0, 0);
     if (sv.class != abi.CLASS_STACK) { ret 1; }
     if (sv.size != 8)                { ret 1; }
     ret 0;
 }
 
 test "win64: scalar returns use RAX / XMM0, void returns reg=-1" {
-    val voidr: abi.ParamSlot = classify_return(0, 0, false, 0, false);
+    val voidr: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0);
     if (voidr.class != abi.CLASS_GP) { ret 1; }
     if (voidr.reg != -1)             { ret 1; }
 
-    val ir: abi.ParamSlot = classify_return(8, 8, false, 0, false);
+    val ir: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0);
     if (ir.class != abi.CLASS_GP) { ret 1; }
     if (ir.reg != REG_RAX)        { ret 1; }
 
-    val fr: abi.ParamSlot = classify_return(8, 8, true, 0, false);
+    val fr: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0);
     if (fr.class != abi.CLASS_FP) { ret 1; }
     if (fr.reg != REG_XMM0)       { ret 1; }
     ret 0;
@@ -581,19 +589,19 @@ test "win64: scalar returns use RAX / XMM0, void returns reg=-1" {
 
 test "win64: aggregate returns are RAX by value or an sret pointer" {
     # an 8-byte aggregate returns in RAX.
-    val small: abi.ParamSlot = classify_return(8, 8, false, 0, true);
+    val small: abi.ParamSlot = classify_return(8, 8, false, 0, true, 0, 0);
     if (small.class != abi.CLASS_GP) { ret 1; }
     if (small.reg != REG_RAX)        { ret 1; }
 
     # a small all-float UDT still returns in RAX under MS x64 (unlike SysV's XMM0):
     # the fp_eightbytes mask is ignored, every 1/2/4/8-byte aggregate uses RAX.
-    val fsmall: abi.ParamSlot = classify_return(8, 8, true, 1, true);
+    val fsmall: abi.ParamSlot = classify_return(8, 8, true, 1, true, 0, 0);
     if (fsmall.class != abi.CLASS_GP) { ret 1; }
     if (fsmall.reg != REG_RAX)        { ret 1; }
 
     # a 12-byte aggregate is not a by-value size: returned via an sret pointer,
     # which the callee yields in RAX.
-    val big: abi.ParamSlot = classify_return(12, 4, false, 0, true);
+    val big: abi.ParamSlot = classify_return(12, 4, false, 0, true, 0, 0);
     if (big.class != abi.CLASS_SRET) { ret 1; }
     if (big.reg != REG_RAX)          { ret 1; }
     ret 0;
@@ -602,9 +610,9 @@ test "win64: aggregate returns are RAX by value or an sret pointer" {
 test "win64: an sret return reserves the first positional slot, shifting args" {
     # a 24-byte aggregate return is sret. classify_signature seeds gp_used=1 for
     # the hidden RCX pointer, so the first real integer argument lands in RDX.
-    val ret_slot: abi.ParamSlot = classify_return(24, 8, false, 0, true);
+    val ret_slot: abi.ParamSlot = classify_return(24, 8, false, 0, true, 0, 0);
     if (ret_slot.class != abi.CLASS_SRET) { ret 1; }
-    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 1, 0);
+    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 1, 0, 0, 0);
     if (first_arg.class != abi.CLASS_GP) { ret 1; }
     if (first_arg.reg != REG_RDX)        { ret 1; }
     ret 0;


### PR DESCRIPTION
Closes #1174.

Implements the last AAPCS64 contract gap: **Homogeneous Floating-point / Short-Vector Aggregate (HFA/HVA)** classification. Previously every ≤16-byte aggregate routed to GP registers, ignoring `is_float`, so a `struct { f32, f32 }` was passed/returned in GP registers — an ABI non-conformance that miscompiled C FFI calls passing or returning float-aggregate structs.

## Classification approach

A composite of **1–4 members all of the same fundamental FP type** (recursively flattening nested structs/arrays; a union takes its widest member's count) is an HFA and rides **consecutive V registers** V0–V7:

- The backend (`be/codegen/mir/abi.mach`) computes the HFA descriptor — member count + fundamental width — from the **declared** type via a recursive `hfa_walk` (counting by recursion, not `size/width`, so an explicit `align(...)` never inflates the count), and threads it through the classifier interface alongside the existing SSE-eightbyte mask.
- The AAPCS64 classifier checks HFA **before** the >16-byte by-reference / sret rule, so a 4×f64 HFA (32 bytes) rides V0–V3 rather than going to memory. The run is placed only when it **wholly fits** the remaining V bank (`fp_used + members ≤ 8`); otherwise the whole aggregate spills to the stack by value (the AAPCS64 **all-or-memory** rule).
- `CLASS_HFA` + `ParamSlot.reg_count`/`reg_width` carry the V-register run; the MIR arg / param / return emit paths place each member with a per-element FP load/store (S/D per member width). HFA returns ride V0..V(n-1).
- Variadic-tail arguments are never classified as HFAs (matching the existing mask-0 decision), per the AArch64 anonymous-argument rule.

The AMD64 conventions (SysV, win64) ignore the new descriptor exactly as they ignore the SSE-eightbyte mask — their classifier bodies are unchanged — so **x64 emission is unperturbed**. mach exposes only f32/f64, so HFA member widths are 4/8 (the widths the FP move encoders handle); HVA reduces to the same path since mach has no vector type.

## Verification

- **x86_64 self-host fixpoint: byte-identical** (`stage1 == stage2` from the released seed) — the mandatory cross-arch regression bar; this aarch64-only change does not perturb x64 emission.
- **aarch64 qemu validation:** the new `aarch64hfa` smoke passes under `qemu-aarch64` locally — 2/3/4×f32 and 2/3/4×f64 HFAs (incl. >16-byte), HFA returns, a scalar-ahead-of-HFA V-cursor case, and the all-or-memory spill all round-trip.
- **No SysV/win64 regression:** in-source suite 547/547 pass (incl. new AAPCS64 HFA classifier unit tests); integration `cffi` (by-value float structs across the C boundary in SSE registers), `fpargs`, `aarch64run`, `fconv`, `win64byref` all pass.

The same `aarch64hfa` source also builds + runs natively on x86_64 (SysV SSE-eightbyte path) as an in-CI cross-check. Full matrix watched on CI (AArch64 cross + Self-host Fixpoint + Test Suite).