### PR TITLE
release: mach 2.2.0

### DIFF
--- a/.github/tests/aarch64hfa/app/mach.toml
+++ b/.github/tests/aarch64hfa/app/mach.toml
@@ -1,0 +1,26 @@
+[project]
+id      = "aarch64hfa"
+name    = "AAPCS64 HFA/HVA float-aggregate passing — App"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux-arm64"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[bin.aarch64hfa]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/aarch64hfa/app/src/main.mach
+++ b/.github/tests/aarch64hfa/app/src/main.mach
@@ -1,0 +1,91 @@
+# aarch64hfa — a runnable smoke for AAPCS64 HFA/HVA float-aggregate passing (#1174):
+# a struct/array of 1–4 same-typed FP members (a Homogeneous Floating-point
+# Aggregate) is passed in consecutive V registers (V0–V7) and returned likewise,
+# including HFAs larger than 16 bytes (3×/4× f64) that ride V registers rather than
+# memory, plus the all-or-memory spill when the V bank cannot fit the whole run.
+# every check returns a distinct nonzero exit code on failure; main exits 0 only when
+# every HFA placement round-trips, so qemu running this to 0 proves the placement
+# end-to-end. the SAME source builds for x86_64-linux, where these float structs ride
+# the SysV SSE-eightbyte path instead — a cross-check that the shared lowering, and
+# x64 emission, stay correct.
+use std.runtime.linux;
+
+# single-precision HFAs (S registers): 1–4 f32 members.
+rec V2f { x: f32; y: f32; }
+rec V3f { x: f32; y: f32; z: f32; }
+rec V4f { x: f32; y: f32; z: f32; w: f32; }
+
+# double-precision HFAs (D registers): 2 fits in 16 bytes, 3 / 4 exceed 16 bytes yet
+# still ride V registers (the HFA rule precedes the >16-byte by-reference / sret rule).
+rec D2 { a: f64; b: f64; }
+rec D3 { a: f64; b: f64; c: f64; }
+rec D4 { a: f64; b: f64; c: f64; d: f64; }
+
+# HFA argument consumers: each reads every member (a per-member V-register load),
+# widening f32 members to f64 so the result compares exactly against an f64 literal.
+fun sum_v2(v: V2f) f64 { ret v.x::f64 + v.y::f64; }
+fun sum_v3(v: V3f) f64 { ret v.x::f64 + v.y::f64 + v.z::f64; }
+fun sum_v4(v: V4f) f64 { ret v.x::f64 + v.y::f64 + v.z::f64 + v.w::f64; }
+fun sum_d2(d: D2) f64 { ret d.a + d.b; }
+fun sum_d3(d: D3) f64 { ret d.a + d.b + d.c; }
+fun sum_d4(d: D4) f64 { ret d.a + d.b + d.c + d.d; }
+
+# HFA returns: produce a struct by value (each member placed into its V return register).
+fun make_v3(x: f32, y: f32, z: f32) V3f { var v: V3f; v.x = x; v.y = y; v.z = z; ret v; }
+fun make_d4(a: f64, b: f64, c: f64, d: f64) D4 { var r: D4; r.a = a; r.b = b; r.c = c; r.d = d; ret r; }
+
+# a scalar float ahead of an HFA: `a` takes V0, so the HFA must start at V1 (the V
+# cursor honors the scalar before it).
+fun mix(a: f64, v: D2) f64 { ret a + v.a + v.b; }
+
+# all-or-memory: seven scalar f32 arguments consume V0–V6, so a 2-member HFA cannot
+# fit the V bank (it would need V7 and V8) and the WHOLE aggregate spills to the stack
+# by value — caller and callee must agree on that placement.
+fun spill(a: f32, b: f32, c: f32, d: f32, e: f32, f: f32, g: f32, v: V2f) f64 {
+    ret a::f64 + b::f64 + c::f64 + d::f64 + e::f64 + f::f64 + g::f64 + v.x::f64 + v.y::f64;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    var v2: V2f; v2.x = 1.0; v2.y = 2.0;
+    if (sum_v2(v2) != 3.0) { ret 1; }
+
+    var v3: V3f; v3.x = 1.0; v3.y = 2.0; v3.z = 4.0;
+    if (sum_v3(v3) != 7.0) { ret 2; }
+
+    var v4: V4f; v4.x = 1.0; v4.y = 2.0; v4.z = 4.0; v4.w = 8.0;
+    if (sum_v4(v4) != 15.0) { ret 3; }
+
+    var d2: D2; d2.a = 1.5; d2.b = 2.5;
+    if (sum_d2(d2) != 4.0) { ret 4; }
+
+    # 24-byte HFA (>16): rides V0:V1:V2, not a by-reference pointer.
+    var d3: D3; d3.a = 1.0; d3.b = 2.0; d3.c = 4.0;
+    if (sum_d3(d3) != 7.0) { ret 5; }
+
+    # 32-byte HFA (>16): rides V0:V1:V2:V3.
+    var d4: D4; d4.a = 1.0; d4.b = 2.0; d4.c = 4.0; d4.d = 8.0;
+    if (sum_d4(d4) != 15.0) { ret 6; }
+
+    # HFA return round-trip (each member read back from its V return register).
+    val rv: V3f = make_v3(3.0, 5.0, 7.0);
+    if (rv.x::f64 != 3.0) { ret 7; }
+    if (rv.y::f64 != 5.0) { ret 8; }
+    if (rv.z::f64 != 7.0) { ret 9; }
+
+    # >16-byte HFA return, then fed back through an HFA argument.
+    val rd: D4 = make_d4(10.0, 20.0, 30.0, 40.0);
+    if (rd.a != 10.0) { ret 10; }
+    if (rd.d != 40.0) { ret 11; }
+    if (sum_d4(rd) != 100.0) { ret 12; }
+
+    # scalar float ahead of an HFA argument.
+    var md: D2; md.a = 100.0; md.b = 200.0;
+    if (mix(1.0, md) != 301.0) { ret 13; }
+
+    # all-or-memory spill of an HFA whose run cannot fit the remaining V bank.
+    var sv: V2f; sv.x = 100.0; sv.y = 200.0;
+    if (spill(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, sv) != 328.0) { ret 14; }
+
+    ret 0;
+}

--- a/.github/tests/aarch64hfa/run.sh
+++ b/.github/tests/aarch64hfa/run.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# AAPCS64 HFA/HVA float-aggregate passing (#1174): passes structs of 1–4 same-typed
+# floats by value through non-inlined calls and returns them, including >16-byte HFAs
+# (3×/4× f64) that ride V registers and the all-or-memory spill when the V bank cannot
+# fit the run. the aarch64 cross-build is the case the HFA classifier targets — run
+# under qemu-aarch64, main exits 0 only when every placement round-trips. the SAME
+# source is also built and run natively for x86_64, where these float structs ride the
+# SysV SSE-eightbyte path: a cross-check that the shared lowering and x64 emission are
+# unperturbed by the aarch64-only change.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# x86_64 cross-check: build natively at -O0 (so the float-struct calls are real, not
+# inlined) and run on the host. these structs are not AAPCS64 HFAs on SysV — they ride
+# the SSE-eightbyte path — so a correct exit proves the shared lowering still places
+# them right under the unchanged x64 emitter.
+if ! ( cd "$WORK/app" && "$MACH" build . --target linux -O0 ) >/dev/null 2>&1; then
+    echo "FAIL aarch64hfa: x86_64 native build failed" >&2
+    exit 1
+fi
+X64BIN="$WORK/app/out/linux/bin/aarch64hfa"
+test -x "$X64BIN" || { echo "error: x86_64 binary not produced at $X64BIN" >&2; exit 1; }
+set +e
+"$X64BIN" >/dev/null 2>&1
+x64code=$?
+set -e
+if [ "$x64code" -ne 0 ]; then
+    echo "FAIL aarch64hfa: x86_64 SysV float-struct passing miscompiled (exit $x64code)" >&2
+    exit 1
+fi
+
+# aarch64: cross-build at -O0 so the HFA placement at the call boundary is exercised.
+if ! ( cd "$WORK/app" && "$MACH" build . --target linux-arm64 -O0 ) >/dev/null 2>&1; then
+    echo "FAIL aarch64hfa: aarch64 cross-build failed" >&2
+    exit 1
+fi
+ARMBIN="$WORK/app/out/linux-arm64/bin/aarch64hfa"
+test -f "$ARMBIN" || { echo "error: aarch64 binary not produced at $ARMBIN" >&2; exit 1; }
+
+# the HFA placement is only observable by executing the aarch64 binary; without
+# qemu-aarch64 there is nothing to run it, so the run is skipped (the cross-build
+# above still verifies the emitter accepts the HFA path).
+RUNNER="$(command -v qemu-aarch64 || command -v qemu-aarch64-static || true)"
+if [ -z "$RUNNER" ]; then
+    echo "PASS aarch64hfa: x86_64 SysV float-struct cross-check passed; aarch64 cross-build OK (SKIP qemu run: 'qemu-aarch64' not available)"
+    exit 0
+fi
+
+set +e
+"$RUNNER" "$ARMBIN" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -eq 0 ]; then
+    echo "PASS aarch64hfa: HFA/HVA float aggregates pass and return in V registers under qemu (x86_64 SysV cross-check also passed)"
+    exit 0
+fi
+
+echo "FAIL aarch64hfa: AAPCS64 HFA passing miscompiled under qemu (exit $code; see main.mach for the per-check codes)" >&2
+exit 1

--- a/.github/tests/eachfieldsgeneric/app/mach.toml
+++ b/.github/tests/eachfieldsgeneric/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "eachfieldsgeneric"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.eachfieldsgeneric]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/eachfieldsgeneric/app/src/main.mach
+++ b/.github/tests/eachfieldsgeneric/app/src/main.mach
@@ -1,0 +1,77 @@
+use std.runtime;
+use std.types.string.str;
+use std.types.string.str_equals;
+
+# generic `$each $fields(T)` deferral integration test (#1523). proves that
+# `$each f in $fields(T)` inside a generic function defers to monomorphization
+# and unrolls correctly for each concrete instantiation, including heterogeneous
+# field types and `v.[f]` projection. exits 0 only when all assertions pass;
+# a failing check returns its id.
+
+rec Pair  { x: i64; y: i64; }
+rec Mixed { a: i64; b: u8; }
+rec Empty { }
+
+# generic field-sum: iterates every field of T via the loop variable, casts to
+# i64, and accumulates. deferred at template sema; unrolled per instantiation.
+fun sum_fields[T](v: T) i64 {
+    var total: i64 = 0;
+    $each f in $fields(T) {
+        total = total + v.[f]::i64;
+    }
+    ret total;
+}
+
+# generic field-zero: writes zero to every field of T through a pointer receiver.
+fun zero_fields[T](v: *T) {
+    $each f in $fields(T) {
+        v.[f] = 0;
+    }
+}
+
+# generic field-count: counts how many fields T has by incrementing per iteration.
+fun field_count[T](v: T) i64 {
+    var n: i64 = 0;
+    $each f in $fields(T) {
+        n = n + 1;
+    }
+    ret n;
+}
+
+# generic name-match: counts fields of T whose compile-time name equals `target`.
+fun count_named[T](v: T, target: str) i64 {
+    var n: i64 = 0;
+    $each f in $fields(T) {
+        if (str_equals(f.name, target)) { n = n + 1; }
+    }
+    ret n;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    # homogeneous record: sum via generic sum_fields
+    var p: Pair = Pair { x: 3, y: 4 };
+    if (sum_fields[Pair](p) != 7) { ret 1; }
+
+    # heterogeneous record: cast each field to i64 before accumulating
+    var m: Mixed = Mixed { a: 100, b: 5 };
+    if (sum_fields[Mixed](m) != 105) { ret 2; }
+
+    # generic pointer-receiver zero: writes 0 to every field
+    zero_fields[Mixed](?m);
+    if (sum_fields[Mixed](m) != 0) { ret 3; }
+
+    # empty record: no iterations, count stays 0
+    var e: Empty = Empty { };
+    if (field_count[Empty](e) != 0) { ret 4; }
+
+    # field counts match the record layouts
+    if (field_count[Pair](p) != 2) { ret 5; }
+    if (field_count[Mixed](m) != 2) { ret 6; }
+
+    # generic name search: Pair has one field named "x"
+    if (count_named[Pair](p, "x") != 1) { ret 7; }
+    if (count_named[Pair](p, "z") != 0) { ret 8; }
+
+    ret 0;
+}

--- a/.github/tests/eachfieldsgeneric/nonrec/mach.toml
+++ b/.github/tests/eachfieldsgeneric/nonrec/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "eachfieldsgeneric-nonrec"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.eachfieldsgeneric-nonrec]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/eachfieldsgeneric/nonrec/src/main.mach
+++ b/.github/tests/eachfieldsgeneric/nonrec/src/main.mach
@@ -1,0 +1,19 @@
+use std.runtime;
+
+# negative: instantiating $fields(T) with a non-record type must fail at
+# compile time with a record-type diagnostic (#1523). this file must NOT
+# compile; the test harness asserts the build fails.
+
+fun bad[T](v: T) i64 {
+    var n: i64 = 0;
+    $each f in $fields(T) {
+        n = n + 1;
+    }
+    ret n;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    # instantiating with u64 (a primitive, not a record) must error
+    ret bad[u64](42::u64)::i64;
+}

--- a/.github/tests/eachfieldsgeneric/run.sh
+++ b/.github/tests/eachfieldsgeneric/run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# generic $each $fields(T) deferral integration test (#1523). two halves:
+#
+#   app — a generic fun instantiated on concrete records must COMPILE and
+#   produce correct results for homogeneous / heterogeneous / empty records,
+#   pointer-receiver zero, field counts, and name queries. exits 0 on pass.
+#
+#   nonrec — `$fields(T)` where T is instantiated as a non-record (e.g. u64)
+#   must FAIL at compile time with a recognisable diagnostic so the error is
+#   surfaced at the call site rather than silently producing wrong code.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# half 1: the generic fields app must build and run correctly.
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL eachfieldsgeneric(app): build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/eachfieldsgeneric"
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL eachfieldsgeneric(app): check $code returned wrong value" >&2
+    exit 1
+fi
+
+# half 2: instantiating $fields(T) with a non-record must fail at compile time.
+cp -r "$HERE/nonrec" "$WORK/"
+mkdir -p "$WORK/nonrec/dep"
+ln -s "$STD" "$WORK/nonrec/dep/mach-std"
+
+set +e
+BUILD_OUT="$( cd "$WORK/nonrec" && "$MACH" build . 2>&1 )"
+code=$?
+set -e
+if [ "$code" -eq 0 ]; then
+    echo "FAIL eachfieldsgeneric(nonrec): build should have failed but succeeded" >&2
+    exit 1
+fi
+if ! echo "$BUILD_OUT" | grep -qi "non-record\|record type\|not a record"; then
+    echo "FAIL eachfieldsgeneric(nonrec): expected a record-type diagnostic, got:" >&2
+    echo "$BUILD_OUT" >&2
+    exit 1
+fi
+
+echo "PASS eachfieldsgeneric: generic \$each \$fields(T) defers and unrolls correctly"

--- a/.github/tests/nancmp/app/mach.toml
+++ b/.github/tests/nancmp/app/mach.toml
@@ -1,0 +1,26 @@
+[project]
+id      = "nancmp"
+name    = "IEEE-754 NaN float-comparison test — App"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[bin.nancmp]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/nancmp/app/src/main.mach
+++ b/.github/tests/nancmp/app/src/main.mach
@@ -1,0 +1,80 @@
+use std.runtime.linux;
+
+# IEEE-754 NaN float-comparison regression coverage (issue #1446). On the pre-fix
+# x86_64 backend every float compare lowered to a single unsigned SETcc after
+# UCOMISD; an unordered (NaN-involving) compare leaves CF=ZF=PF=1, so `==` / `<` /
+# `<=` wrongly returned true and `!=` wrongly returned false on NaN — diverging from
+# aarch64, which already emits the IEEE-754 results. IEEE-754 defines every ordered
+# relation (`<` `<=` `>` `>=` `==`) as FALSE when an operand is NaN, and `!=` as TRUE.
+#
+# A NaN is exactly the operand that is neither less than, equal to, nor greater than
+# the other, so the (lt, eq, gt) = (0, 0, 0) outcome the `chk_*` helpers assert is
+# the IEEE-754 NaN result: all ordered relations false, `!=` true. Every operand is
+# derived from a runtime, non-foldable zero (n = argc - 1, which is 0 when run with
+# no arguments) and the NaN is produced at runtime as 0.0 / 0.0, so the comparisons
+# are genuinely lowered rather than constant-folded. The same assertions hold on
+# whatever architecture the app is built for, so x86_64 and aarch64 must agree.
+
+# asserts the six f64 comparisons of `a` against `b`, forward and reversed, against
+# the expected (lt, eq, gt) outcome as 0/1; returns a nonzero check id on the first
+# disagreement, else 0. driven with (0, 0, 0) it asserts the IEEE-754 NaN result.
+fun chk_f64(a: f64, b: f64, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)        { ret base + 0; }
+    if ((a <= b) != (lt | eq)) { ret base + 1; }
+    if ((a >  b) != gt)        { ret base + 2; }
+    if ((a >= b) != (gt | eq)) { ret base + 3; }
+    if ((a == b) != eq)        { ret base + 4; }
+    if ((a != b) != (1 - eq))  { ret base + 5; }
+    if ((b <  a) != gt)        { ret base + 6; }
+    if ((b <= a) != (gt | eq)) { ret base + 7; }
+    if ((b >  a) != lt)        { ret base + 8; }
+    if ((b >= a) != (lt | eq)) { ret base + 9; }
+    if ((b == a) != eq)        { ret base + 10; }
+    if ((b != a) != (1 - eq))  { ret base + 11; }
+    ret 0;
+}
+
+# f32 counterpart, exercising the narrower UCOMISS / FCMP-S compare form.
+fun chk_f32(a: f32, b: f32, lt: u8, eq: u8, gt: u8, base: i64) i64 {
+    if ((a <  b) != lt)        { ret base + 0; }
+    if ((a <= b) != (lt | eq)) { ret base + 1; }
+    if ((a >  b) != gt)        { ret base + 2; }
+    if ((a >= b) != (gt | eq)) { ret base + 3; }
+    if ((a == b) != eq)        { ret base + 4; }
+    if ((a != b) != (1 - eq))  { ret base + 5; }
+    if ((b <  a) != gt)        { ret base + 6; }
+    if ((b <= a) != (gt | eq)) { ret base + 7; }
+    if ((b >  a) != lt)        { ret base + 8; }
+    if ((b >= a) != (lt | eq)) { ret base + 9; }
+    if ((b == a) != eq)        { ret base + 10; }
+    if ((b != a) != (1 - eq))  { ret base + 11; }
+    ret 0;
+}
+
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    val n:     f64 = (argc - 1)::f64;   # 0.0 at runtime, non-foldable
+    val nan64: f64 = n / n;             # 0.0 / 0.0 = NaN
+    val one64: f64 = n + 1.0;           # a finite value
+    val zero64: f64 = n;                # +0.0
+
+    val m:     f32 = (argc - 1)::f32;
+    val nan32: f32 = m / m;
+    val one32: f32 = m + 1.0::f32;
+    val zero32: f32 = m;
+
+    var r: i64 = 0;
+
+    # f64: NaN against a finite value, against zero, and against itself — every case
+    # is unordered, so the expected outcome is (lt, eq, gt) = (0, 0, 0).
+    r = chk_f64(nan64, one64,  0, 0, 0, 100); if (r != 0) { ret r; }
+    r = chk_f64(nan64, zero64, 0, 0, 0, 120); if (r != 0) { ret r; }
+    r = chk_f64(nan64, nan64,  0, 0, 0, 140); if (r != 0) { ret r; }
+
+    # f32: the same three shapes through the narrower compare form.
+    r = chk_f32(nan32, one32,  0, 0, 0, 200); if (r != 0) { ret r; }
+    r = chk_f32(nan32, zero32, 0, 0, 0, 220); if (r != 0) { ret r; }
+    r = chk_f32(nan32, nan32,  0, 0, 0, 240); if (r != 0) { ret r; }
+
+    ret 0;
+}

--- a/.github/tests/nancmp/run.sh
+++ b/.github/tests/nancmp/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# IEEE-754 NaN float-comparison regression test (issue #1446): build the `app`
+# project with the freshly-built compiler and run it. the app asserts that every
+# ordered float relation (`<` `<=` `>` `>=` `==`) is false when an operand is NaN and
+# that `!=` is true — for f32 and f64, in both operand orders — exiting 0 only when
+# every result is value-correct (a wrong comparison exits with its check id).
+#
+# the pre-fix x86_64 backend lowered a float compare to one unsigned SETcc after
+# UCOMISD and so miscompiled the unordered case; the native (x86_64) half therefore
+# fails before the fix and passes after. the aarch64 half cross-builds the same app
+# and runs it under qemu to prove the two architectures agree on the IEEE-754 result;
+# it is skipped when qemu-aarch64 is unavailable (mirroring aarch64run).
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suite cds into a temp dir, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# x86_64 (native): the architecture the fix changes — must build, run, and pass.
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL nancmp: x86_64 build failed" >&2
+    exit 1
+fi
+
+set +e
+"$WORK/app/out/linux/bin/nancmp"
+code=$?
+set -e
+
+if [ "$code" -ne 0 ]; then
+    echo "FAIL nancmp: x86_64 NaN comparison check $code produced a non-IEEE-754 result" >&2
+    exit 1
+fi
+echo "PASS nancmp: x86_64 NaN comparisons are IEEE-754-correct"
+
+# aarch64 (under qemu): proves the two architectures agree on the IEEE-754 result.
+# built at -O0 so the comparisons are not optimized away. skipped without qemu.
+RUNNER="$(command -v qemu-aarch64 || command -v qemu-aarch64-static || true)"
+if [ -z "$RUNNER" ]; then
+    echo "SKIP nancmp: 'qemu-aarch64' not available to run the aarch64 binary"
+    exit 0
+fi
+
+if ! ( cd "$WORK/app" && "$MACH" build . --target linux-arm64 -O0 ) >/dev/null 2>&1; then
+    echo "FAIL nancmp: aarch64 cross-build failed" >&2
+    exit 1
+fi
+
+EXE="$WORK/app/out/linux-arm64/bin/nancmp"
+test -f "$EXE" || { echo "error: aarch64 binary not produced at $EXE" >&2; exit 1; }
+
+set +e
+"$RUNNER" "$EXE" >/dev/null 2>&1
+code=$?
+set -e
+
+if [ "$code" -ne 0 ]; then
+    echo "FAIL nancmp: aarch64 NaN comparison check $code disagrees with IEEE-754" >&2
+    exit 1
+fi
+echo "PASS nancmp: aarch64 NaN comparisons agree with x86_64 (IEEE-754)"
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Realize the vendored std (mach dep pull)
         # the std is no longer a git submodule; mach dep resolves it from the
-        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        # branch/main pin in mach.toml into dep/mach-std for the path-based build.
         run: mach dep pull
 
       - name: Build the compiler
@@ -65,7 +65,7 @@ jobs:
 
       - name: Realize the vendored std (mach dep pull)
         # the std is no longer a git submodule; mach dep resolves it from the
-        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        # branch/main pin in mach.toml into dep/mach-std for the path-based build.
         run: mach dep pull
 
       - name: Byte-diff the seed→stage1→stage2 self-host fixpoint
@@ -106,19 +106,11 @@ jobs:
 
       - name: Realize the vendored std (mach dep pull)
         # the std is no longer a git submodule; mach dep resolves it from the
-        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        # branch/main pin in mach.toml into dep/mach-std for the path-based build.
         run: mach dep pull
 
       - name: Test corpus
-        run: |
-          # `mach test` builds one full-compiler (~4.6MB) executable per test in a
-          # single long-lived process — a large virtual size — then fork()s to run
-          # each. on the swap-less runner with heuristic overcommit (vm.overcommit_memory=0)
-          # the kernel refuses fork() for a large-VSZ process regardless of free RAM
-          # (the child immediately execve's, so the COW copy is never written).
-          # allow overcommit so the spawns succeed.
-          sudo sysctl -w vm.overcommit_memory=1
-          mach test .
+        run: mach test .
 
   integration:
     name: Integration Tests
@@ -139,7 +131,7 @@ jobs:
 
       - name: Realize the vendored std (mach dep pull)
         # the std is no longer a git submodule; mach dep resolves it from the
-        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        # branch/main pin in mach.toml into dep/mach-std for the path-based build.
         run: mach dep pull
 
       - name: Install wine
@@ -257,7 +249,7 @@ jobs:
 
       - name: Realize the vendored std (mach dep pull)
         # the std is no longer a git submodule; mach dep resolves it from the
-        # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
+        # branch/main pin in mach.toml into dep/mach-std for the path-based build.
         run: mach dep pull
 
       - name: Install the aarch64 byte-verification + emulation toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,15 @@ jobs:
         run: mach dep pull
 
       - name: Test corpus
-        run: mach test .
+        run: |
+          set -euo pipefail
+          # build the compiler from the seed, then run the corpus with the
+          # freshly-built binary (clone-spawn os.spawn), not the fork-based seed —
+          # otherwise the seed driver forks with the full corpus resident and
+          # ENOMEMs under heuristic overcommit. #1487.
+          mach build .
+          test -x out/linux/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
+          out/linux/bin/mach test .
 
   integration:
     name: Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,15 +228,13 @@ jobs:
           out/windows/bin/mach.exe test .
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-  # aarch64 cross lane: the aarch64-linux back end is complete through Phase 4
-  # (compiles + links + correct scalar/FP/ABI). this lane byte-verifies the
-  # emitter statically — `mach build . --target arm64 --emit obj`/`exe` on a tiny
-  # self-contained program, then llvm-objdump/llvm-mc/readelf assert the encoded
-  # instructions, the R_AARCH64_* relocs, and the AArch64 ELF headers — with NO
-  # qemu and no runnable aarch64 mach. it mirrors the windows lane's wine shape:
-  # qemu-aarch64 is to aarch64 binaries what wine is to windows binaries, and the
-  # two run-steps that need it are GATED off until qemu-user-static AND the
-  # mach-std aarch64 runtime (OS layer + `_start`) land in Phase 5.
+  # aarch64 cross lane: the aarch64-linux back end is complete through Phase 5
+  # (compiles + links + correct scalar/FP/ABI + qemu-user-static + mach-std
+  # aarch64 runtime). this lane byte-verifies the emitter statically —
+  # llvm-objdump/llvm-mc/readelf assert the encoded instructions, the
+  # R_AARCH64_* relocs, and the AArch64 ELF headers — and runs the in-source
+  # test corpus under qemu-aarch64. mirrors the windows lane's wine shape:
+  # qemu-aarch64 is to aarch64 binaries what wine is to windows binaries.
   aarch64:
     name: AArch64 (cross)
     runs-on: ubuntu-latest
@@ -316,20 +314,19 @@ jobs:
           done
           echo "structurally verified ${#objs[@]} cross-built aarch64 object(s): AArch64 ELF, power-of-two section alignments"
 
-      # GATED (#1464): `mach test . --target linux-arm64` on the mach project — which
-      # has a `main` bin entry — fails at link with "multiple definition of 'main'"
-      # (the project main collides with the test-runner main on the aarch64 path;
-      # native x86 is unaffected). the cross-compile + byte-verify lanes above and
-      # the release qemu-smoke already exercise the aarch64 runtime end-to-end;
-      # un-gate once `mach test` cross-target handles the bin-entry main. mirrors the
-      # windows native lane's `mach test .` under emulation.
-      - name: Test corpus under qemu-aarch64 (GATED — see #1464)
-        if: false
+      # runs the in-source test corpus under qemu-aarch64. mirrors the windows native
+      # lane's `mach test .` under emulation. qemu-user-static is installed above;
+      # binfmt registration happens automatically in the apt postinstall.
+      - name: Test corpus under qemu-aarch64
+        timeout-minutes: 60
         run: |
           set -euo pipefail
-          runner="$(command -v qemu-aarch64 || command -v qemu-aarch64-static || true)"
+          # mach test fork()s a large-VSZ process per test; allow overcommit so the
+          # spawns succeed (same fix as the native test-suite lane).
+          sudo sysctl -w vm.overcommit_memory=1
+          runner="$(command -v qemu-aarch64-static || command -v qemu-aarch64 || true)"
           if [ -z "$runner" ]; then
-            echo "::notice::qemu-aarch64 not found; skipping the aarch64 run"
-            exit 0
+            echo "::error::qemu-aarch64-static not found; install step may have failed"
+            exit 1
           fi
           out/linux/bin/mach test . --target linux-arm64 --runner "$(basename "$runner")"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,14 @@ jobs:
         # branch/main pin in mach.toml into dep/mach-std for the path-based build.
         run: mach dep pull
 
-      - name: Install wine
+      - name: Install wine + qemu-aarch64
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq wine64
+          # wine64 runs the cross-built windows binaries; qemu-user-static registers
+          # the binfmt handler that runs aarch64 binaries on this x86 host, so the
+          # aarch64 integration suites (aarch64hfa, aarch64run) execute their qemu run
+          # here instead of skipping it. mirrors the AArch64 lane's qemu-user-static.
+          sudo apt-get install -y -qq wine64 qemu-user-static
           command -v wine >/dev/null || sudo ln -s "$(command -v wine64)" /usr/local/bin/wine
 
       - name: Build the compiler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,9 +321,6 @@ jobs:
         timeout-minutes: 60
         run: |
           set -euo pipefail
-          # mach test fork()s a large-VSZ process per test; allow overcommit so the
-          # spawns succeed (same fix as the native test-suite lane).
-          sudo sysctl -w vm.overcommit_memory=1
           runner="$(command -v qemu-aarch64-static || command -v qemu-aarch64 || true)"
           if [ -z "$runner" ]; then
             echo "::error::qemu-aarch64-static not found; install step may have failed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- ci/aarch64: the `Test corpus under qemu-aarch64` CI step is un-gated. The step
+  was blocked on `ut_manifest` lacking a `[target.linux-arm64]` stanza, so
+  `target = "native"` couldn't resolve to the aarch64 host under qemu (#1391).
+  Adding the stanza brings the corpus to 500/500 under qemu-aarch64 (#1464).
+
 ## [2.1.0] - 2026-06-19
 
 Minor — comptime type-directed-dispatch ergonomics and multi-artifact tooling
@@ -161,9 +170,9 @@ under qemu exactly as it does natively on x86_64.
   a qemu-aarch64 smoke-test that proves the cross-built aarch64 `mach` can both
   build and run a real project under emulation before it ships — mirroring the
   windows/wine compiler smoke. CI's aarch64 lane cross-builds mach to aarch64 and
-  byte-verifies the emitted encodings; the runtime is exercised by that qemu smoke
-  and the aarch64 self-host fixpoint, with the in-source test corpus run under
-  qemu-user-static gated pending #1464.
+  byte-verifies the emitted encodings; the runtime is exercised by that qemu smoke,
+  the aarch64 self-host fixpoint, and the in-source test corpus run under qemu-aarch64
+  (#1464).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.0] - 2026-06-19
+
+Minor — correctness and cross-arch coverage, hardening the compiler ahead of a manual
+audit. This release changes how the compiler emits float comparisons (#1446), so it
+**re-seeds** the self-host baseline: it is intentionally *not* byte-reproducible from the
+2.1.0 seed (stage1≠stage2 by design) but converges to a byte-identical fixpoint
+(stage2==stage3) on both x86_64 and aarch64.
+
+### Added
+
+- target/aarch64: AAPCS64 **HFA/HVA** classification — a homogeneous floating-point
+  aggregate (1–4 members of the same FP type, counted recursively, including >16 bytes)
+  is passed and returned in consecutive SIMD/FP registers (V0–V7), with all-or-memory
+  spill when the run doesn't fit. Completes the aarch64 by-value float-aggregate ABI;
+  x86_64 SysV and win64 emission are unchanged (#1174).
 
 ### Fixed
 
-- ci/aarch64: the `Test corpus under qemu-aarch64` CI step is un-gated. The step
-  was blocked on `ut_manifest` lacking a `[target.linux-arm64]` stanza, so
-  `target = "native"` couldn't resolve to the aarch64 host under qemu (#1391).
-  Adding the stanza brings the corpus to 500/500 under qemu-aarch64 (#1464).
+- codegen/x86_64: floating-point comparisons now follow **IEEE-754** for NaN, matching
+  aarch64 — an unordered (NaN) operand yields false for `<`, `<=`, `>`, `>=`, `==` and
+  true for `!=` (`<`/`<=` via operand-reversed `SETA`/`SETAE`; `==` as `SETE ∧ SETNP`;
+  `!=` as `SETNE ∨ SETP`). Cross-arch NaN comparisons now agree (#1446).
+- comptime: `$each f in $fields(T)` over a **generic** type parameter no longer errors at
+  template sema — it defers to monomorphization (mirroring variadic packs), so reusable
+  generic derive helpers (`debug[T]`, `equals[T]`, …) compile. A non-record instantiation
+  is diagnosed at instantiation (#1523).
+- ci/aarch64: the `Test corpus under qemu-aarch64` step is un-gated — `ut_manifest`
+  gained the `[target.linux-arm64]` stanza so `target = "native"` resolves to the aarch64
+  host under qemu (#1391) — and the Integration lane installs `qemu-user-static`, so the
+  aarch64 integration suites (HFA register placement, `aarch64run`) **execute** under
+  emulation in CI instead of skipping (#1464).
 
 ## [2.1.0] - 2026-06-19
 

--- a/mach.lock
+++ b/mach.lock
@@ -2,5 +2,5 @@
 
 [deps.mach-std]
 url = "https://github.com/octalide/mach-std"
-ref = "commit/39d188b6830af57497ae9e82c42066fb121fcf0d"
-commit = "39d188b6830af57497ae9e82c42066fb121fcf0d"
+ref = "branch/main"
+commit = "88b4d33f5593ff1e598b77e710ae13d4fa8a5aa5"

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.1.0"
+version = "2.2.0"
 src = "src"
 dep = "dep"
 target = "native"

--- a/mach.toml
+++ b/mach.toml
@@ -31,7 +31,6 @@ entry = "main.mach"
 
 [deps.mach-std]
 git = "https://github.com/octalide/mach-std"
-# pinned to mach-std v0.12.0 — the migrated, new-only std (comptime packs +
-# `$mach.build.*`), which the v1.7.0 seed parses. the v1.7 DECOUPLE freeze is
-# over post-collapse; revert to "branch/main" once the std stabilizes.
-ref = "commit/39d188b6830af57497ae9e82c42066fb121fcf0d"
+# tracks mach-std main (>= v0.13.0, clone-spawn os.spawn). the v1.7 DECOUPLE
+# freeze ended post-collapse and the std has stabilized; deps pin to branch/main.
+ref = "branch/main"

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -204,6 +204,99 @@ fun aggregate_sse_mask(ctx: *lctx.LowerCtx, ty: ir_type.IrTypeId) u8 {
     ret mask;
 }
 
+# hfa_walk: recursively test whether `ty` is a homogeneous floating-point aggregate
+# and, if so, report its fundamental member width (`out_elem`) and flattened member
+# count (`out_count`). a float leaf is one member of its own width; a struct flattens
+# its fields (all of which must share the same fundamental width); an array multiplies
+# its element's member count by the length; a union takes the widest member's count
+# (its members overlap). any non-FP leaf, an empty aggregate, or a mix of fundamental
+# widths makes the whole aggregate non-homogeneous (returns false, out params unset).
+# member counting is by recursion, never `size / width`, so an explicit `align(...)`
+# that pads the aggregate's size never inflates the count.
+fun hfa_walk(ctx: *lctx.LowerCtx, ty: ir_type.IrTypeId, out_elem: *u32, out_count: *u32) bool {
+    val it: Option[*ir_type.IrType] = ir_type.get(ctx.types, ty);
+    if (!is_some[*ir_type.IrType](it)) { ret false; }
+    val t: *ir_type.IrType = unwrap[*ir_type.IrType](it);
+
+    if (t.kind == ir_type.IRT_FLOAT) {
+        @out_elem  = ir_type.byte_size(ctx.types, ty, ctx.tgt);
+        @out_count = 1;
+        ret true;
+    }
+    if (t.kind == ir_type.IRT_ARRAY) {
+        var ee: u32 = 0;
+        var ec: u32 = 0;
+        if (!hfa_walk(ctx, t.data.array_.element, ?ee, ?ec)) { ret false; }
+        @out_elem  = ee;
+        @out_count = ec * ir_type.array_count(ctx.types, ty);
+        ret true;
+    }
+    if (t.kind == ir_type.IRT_STRUCT) {
+        var elem:  u32 = 0;
+        var total: u32 = 0;
+        var i:     u32 = 0;
+        for (i < t.data.struct_.field_count) {
+            var fe: u32 = 0;
+            var fc: u32 = 0;
+            if (!hfa_walk(ctx, t.data.struct_.fields[i], ?fe, ?fc)) { ret false; }
+            if (elem == 0) { elem = fe; } or (elem != fe) { ret false; }
+            total = total + fc;
+            i = i + 1;
+        }
+        if (total == 0) { ret false; }
+        @out_elem  = elem;
+        @out_count = total;
+        ret true;
+    }
+    if (t.kind == ir_type.IRT_UNION) {
+        var elem: u32 = 0;
+        var maxc: u32 = 0;
+        var i:    u32 = 0;
+        for (i < t.data.struct_.field_count) {
+            var me: u32 = 0;
+            var mc: u32 = 0;
+            if (!hfa_walk(ctx, t.data.struct_.fields[i], ?me, ?mc)) { ret false; }
+            if (elem == 0) { elem = me; } or (elem != me) { ret false; }
+            if (mc > maxc) { maxc = mc; }
+            i = i + 1;
+        }
+        if (elem == 0) { ret false; }
+        @out_elem  = elem;
+        @out_count = maxc;
+        ret true;
+    }
+    ret false;
+}
+
+# hfa_info: the AAPCS64 HFA descriptor for a type — its member count (1–4) in
+# `out_members` and fundamental member width in `out_elem` — or (0, 0) when `ty` is
+# not a Homogeneous Floating-point Aggregate: a non-aggregate, a heterogeneous or
+# over-4-member aggregate, or one whose fundamental width is not a width mach's FP
+# types expose. computed once per value by the backend and threaded to the ABI
+# classifier; only the AAPCS64 classifier acts on it (the AMD64 conventions ignore
+# it, as they do the SSE-eightbyte mask).
+fun hfa_info(ctx: *lctx.LowerCtx, ty: ir_type.IrTypeId, out_members: *u8, out_elem: *u8) {
+    @out_members = 0;
+    @out_elem    = 0;
+    if (!lctx.value_is_aggregate(ctx, ty)) { ret; }
+    var elem:  u32 = 0;
+    var count: u32 = 0;
+    if (!hfa_walk(ctx, ty, ?elem, ?count)) { ret; }
+    if (count < 1 || count > 4) { ret; }
+    # mach exposes only f32 / f64 fundamentals, so an HFA member is 4 or 8 bytes —
+    # the widths the scalar-FP move encoders are sized for.
+    if (elem != 4 && elem != 8) { ret; }
+    @out_members = count::u8;
+    @out_elem    = elem::u8;
+}
+
+# hfa_member_reg: the physical V register for member `i` of a CLASS_HFA run — the
+# i-th register above the run's base (`slot.reg`). used to place each HFA member into
+# its consecutive argument / return register.
+fun hfa_member_reg(base_reg: i32, i: u32) i32 {
+    ret isa.regid_make(isa.REG_CLASS_ID_XMM, isa.regid_index(base_reg) + i::i32);
+}
+
 # advance_one_cursor: advance the GP or FP argument-register cursor for one assigned
 # register, dispatching on the register's bank (the composite id encodes it). a
 # negative id (no register) advances neither. so a register aggregate's GP and SSE
@@ -220,8 +313,13 @@ fun advance_one_cursor(reg: i32, gp_used: *i32, fp_used: *i32) {
 # advance_arg_cursors: advance the GP / FP cursors for a register-passed slot by the
 # bank of each register it occupies (`reg` and, for a two-register aggregate, `reg2`),
 # so a scalar, a by-reference pointer, and a mixed GP/SSE aggregate each consume the
-# correct registers. stack slots carry no register and advance neither.
+# correct registers. a CLASS_HFA run consumes `reg_count` consecutive V registers from
+# the FP bank. stack slots carry no register and advance neither.
 fun advance_arg_cursors(slot: *abi.ParamSlot, gp_used: *i32, fp_used: *i32) {
+    if (slot.class == abi.CLASS_HFA) {
+        @fp_used = @fp_used + slot.reg_count::i32;
+        ret;
+    }
     advance_one_cursor(slot.reg, gp_used, fp_used);
     advance_one_cursor(slot.reg2, gp_used, fp_used);
 }
@@ -328,7 +426,10 @@ pub fun classify_signature(ctx: *lctx.LowerCtx, sig: ir_type.IrTypeId, ret_ty: i
     val ret_float: bool = lctx.value_is_float(ctx, ret_ty);
     val ret_aggr:  bool = lctx.value_is_aggregate(ctx, ret_ty);
     val ret_eb:    u8   = aggregate_sse_mask(ctx, ret_ty);
-    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr);
+    var ret_hm:    u8   = 0;
+    var ret_he:    u8   = 0;
+    hfa_info(ctx, ret_ty, ?ret_hm, ?ret_he);
+    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr, ret_hm, ret_he);
 
     var gp_used:   i32 = 0;
     var fp_used:   i32 = 0;
@@ -380,7 +481,10 @@ pub fun classify_signature(ctx: *lctx.LowerCtx, sig: ir_type.IrTypeId, ret_ty: i
         val pfl:  bool = lctx.value_is_float(ctx, pty);
         val pag:  bool = lctx.value_is_aggregate(ctx, pty);
         val peb:  u8   = aggregate_sse_mask(ctx, pty);
-        var slot: abi.ParamSlot = classify_arg(pi::i32, psz, pal, pfl, peb, pag, gp_used, fp_used);
+        var phm:  u8   = 0;
+        var phe:  u8   = 0;
+        hfa_info(ctx, pty, ?phm, ?phe);
+        var slot: abi.ParamSlot = classify_arg(pi::i32, psz, pal, pfl, peb, pag, gp_used, fp_used, phm, phe);
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering
@@ -525,11 +629,12 @@ pub fun lower_call(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
             val aal:  u64  = ir_type.byte_align(ctx.types, av.ty, ctx.tgt)::u64;
             val afl:  bool = lctx.value_is_float(ctx, av.ty);
             val aag:  bool = lctx.value_is_aggregate(ctx, av.ty);
-            # a variadic tail aggregate is classified as integer eightbytes (mask 0):
-            # the va_arg read path walks the GP register-save / overflow areas, so the
-            # caller and callee stay consistent. SSE-eightbyte aggregate passing is for
-            # fixed parameters and returns (the C-FFI boundary), not the varargs tail.
-            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, gp_used, fp_used);
+            # a variadic tail aggregate is classified as integer eightbytes (mask 0)
+            # and never as an HFA (members 0): the va_arg read path walks the GP
+            # register-save / overflow areas, so the caller and callee stay consistent.
+            # SSE-eightbyte and HFA V-register passing are for fixed parameters and
+            # returns (the C-FFI boundary), not the varargs tail.
+            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, gp_used, fp_used, 0, 0);
             # round a stack-passed tail argument up to its slot alignment before
             # placing it (identity on x86; honors a 16-aligned AAPCS64 by-value arg).
             if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
@@ -687,9 +792,25 @@ fun lower_value_addr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, v: value.Value) Res
 # exhausted-slot case) stores only that pointer value, the stack analog of BYREF.
 # `lctx.addr_to_vreg` normalizes a global's symbol address into a value vreg so the
 # two-register / by-reference forms index a register pointer base. a scalar argop
-# is the value itself, placed directly.
+# is the value itself, placed directly. a CLASS_HFA argument loads each member from
+# `[base + i*reg_width]` into its consecutive V argument register (AAPCS64 HFA/HVA).
 fun emit_arg_slot(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, argop: mir.MirOperand,
                   stack_off: i64, is_aggr: bool, size: u64) Result[bool, str] {
+    if (slot.class == abi.CLASS_HFA) {
+        # an HFA argument flows by address; load each member into its V register.
+        var base: u32 = mir.MIR_VREG_NIL;
+        val ar: Result[bool, str] = lctx.addr_to_vreg(ctx, mb, argop, ?base);
+        if (is_err[bool, str](ar)) { ret ar; }
+        var i: u32 = 0;
+        for (i < slot.reg_count::u32) {
+            val off: i64 = (i * slot.reg_width::u32)::i64;
+            val mr: Result[bool, str] = lctx.emit_fmov(ctx, mb,
+                mir.op_preg(hfa_member_reg(slot.reg, i)::u32), mir.op_mem_value(base, off), slot.reg_width);
+            if (is_err[bool, str](mr)) { ret mr; }
+            i = i + 1;
+        }
+        ret ok[bool, str](true);
+    }
     if (slot.class == abi.CLASS_STACK_BYREF) {
         # win64 by-reference overflow: store the hidden aggregate pointer into the
         # outgoing stack slot, not a by-value copy of the aggregate bytes.
@@ -778,11 +899,25 @@ fun record_outgoing_size(ctx: *lctx.LowerCtx, bytes: i64) {
 
 # emit_ret_slot_to_vreg: move a call's return value out of its canonical return
 # register(s) into the result vreg. for an aggregate return `dst` is the caller-
-# owned result storage pointer (see `lctx.alloc_result_storage`): a 9–16 byte RAX:RDX
-# pair stores each half into `[dst+0]` / `[dst+8]`, and a ≤8 byte single-register
-# aggregate stores RAX into `[dst+0]` so `dst` stays the storage pointer downstream
-# consumers read by. a scalar return is a plain move into the value vreg `dst`.
+# owned result storage pointer (see `lctx.alloc_result_storage`): an HFA stores each
+# V member into `[dst + i*reg_width]`, a 9–16 byte RAX:RDX pair stores each half into
+# `[dst+0]` / `[dst+8]`, and a ≤8 byte single-register aggregate stores RAX into
+# `[dst+0]` so `dst` stays the storage pointer downstream consumers read by. a scalar
+# return is a plain move into the value vreg `dst`.
 fun emit_ret_slot_to_vreg(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, dst: u32, is_aggr: bool) Result[bool, str] {
+    if (slot.class == abi.CLASS_HFA) {
+        # an HFA return arrives in V0..V(reg_count-1); store each member into the
+        # caller-owned result storage so `dst` stays the storage pointer.
+        var i: u32 = 0;
+        for (i < slot.reg_count::u32) {
+            val off: i64 = (i * slot.reg_width::u32)::i64;
+            val st: Result[bool, str] = lctx.emit_store_to_w(ctx, mb,
+                mir.op_mem_value(dst, off), mir.op_preg(hfa_member_reg(slot.reg, i)::u32), slot.reg_width);
+            if (is_err[bool, str](st)) { ret st; }
+            i = i + 1;
+        }
+        ret ok[bool, str](true);
+    }
     if (slot.reg2 >= 0) {
         val lo: Result[bool, str] = lctx.emit_store_to(ctx, mb, mir.op_mem_value(dst, 0), mir.op_preg(slot.reg::u32));
         if (is_err[bool, str](lo)) { ret lo; }
@@ -866,15 +1001,33 @@ pub fun lower_params(ctx: *lctx.LowerCtx, mb: *mir.MirBlock) Result[bool, str] {
 # is the caller's by-value copy at `[rbp + 16 + stack_off]`, whose address is LEA'd
 # into `pv`; a STACK_BYREF aggregate is the caller's spilled hidden pointer at that
 # slot, LOADED into `pv` (the stack analog of BYREF). a scalar parameter moves its
-# single register / stack word into the parameter value vreg `pv`. `stack_off` is
-# the callee-tracked running offset (the ABI classifier returns a sizing-only slot
-# — see `lower_params`).
+# single register / stack word into the parameter value vreg `pv`. an HFA parameter
+# arrives in V[reg]..V[reg+reg_count-1]; each member is stored into a fresh spill
+# slot keyed on `pv` so `pv` names that storage like the register-aggregate forms.
+# `stack_off` is the callee-tracked running offset (the ABI classifier returns a
+# sizing-only slot — see `lower_params`).
 fun emit_param_slot(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, pv: u32, size: u64,
                     stack_off: i64, is_aggr: bool) Result[bool, str] {
     # incoming stack parameters are addressed off the ISA's frame pointer at the
     # arch's incoming-argument base (`[fp + incoming_arg_base + off]`), both named
     # through the ISA vtable rather than bare literals.
     val arg_base: i64 = ctx.tgt.arch.incoming_arg_base;
+    if (slot.class == abi.CLASS_HFA) {
+        # spill each incoming V member into a slot keyed on `pv` so `pv` is the
+        # aggregate's storage pointer for downstream uses (the FP twin of the
+        # register-aggregate spill).
+        val sr: Result[bool, str] = lctx.add_spill_slot(ctx, pv, size);
+        if (is_err[bool, str](sr)) { ret sr; }
+        var i: u32 = 0;
+        for (i < slot.reg_count::u32) {
+            val off: i64 = (i * slot.reg_width::u32)::i64;
+            val st: Result[bool, str] = lctx.emit_store_to_w(ctx, mb,
+                mir.op_mem_slot(pv, off), mir.op_preg(hfa_member_reg(slot.reg, i)::u32), slot.reg_width);
+            if (is_err[bool, str](st)) { ret st; }
+            i = i + 1;
+        }
+        ret ok[bool, str](true);
+    }
     if (slot.class == abi.CLASS_STACK_BYREF) {
         # win64 by-reference overflow: the caller stored the hidden aggregate
         # pointer into this stack slot; load it so `pv` is the aggregate's address,
@@ -961,6 +1114,20 @@ pub fun lower_ret(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructi
         if (is_err[bool, str](cr)) { ret cr; }
         val mr: Result[bool, str] = lctx.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(ctx.sret_vreg));
         if (is_err[bool, str](mr)) { ret mr; }
+    } or (slot.class == abi.CLASS_HFA) {
+        # HFA return: the aggregate flows by address; load each member from its
+        # storage into the consecutive V return register (V0..V(reg_count-1)).
+        var base: u32 = mir.MIR_VREG_NIL;
+        val ar: Result[bool, str] = lctx.addr_to_vreg(ctx, mb, rvop, ?base);
+        if (is_err[bool, str](ar)) { ret ar; }
+        var i: u32 = 0;
+        for (i < slot.reg_count::u32) {
+            val off: i64 = (i * slot.reg_width::u32)::i64;
+            val mr: Result[bool, str] = lctx.emit_fmov(ctx, mb,
+                mir.op_preg(hfa_member_reg(slot.reg, i)::u32), mir.op_mem_value(base, off), slot.reg_width);
+            if (is_err[bool, str](mr)) { ret mr; }
+            i = i + 1;
+        }
     } or (slot.reg2 >= 0 && rag) {
         # 9–16 byte aggregate: load each half from the aggregate's storage (a
         # value-pointer base), materializing a global's symbol address first.

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2968,10 +2968,10 @@ fun ut_cc3(alloc: *Allocator, a: str, b: str, c: str) str {
     ret buf::str;
 }
 
-# ut_manifest: the shared two-target manifest the union tests scaffold. `native`
-# resolves the default to the host-matching target (linux or windows in CI).
+# ut_manifest: the shared three-target manifest the union tests scaffold. `native`
+# resolves the default to the host-matching target (linux, windows, or linux-arm64 in CI).
 fun ut_manifest() str {
-    ret "[project]\nid = \"uniontest\"\nname = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\ntarget = \"native\"\nout = \"out/{target}/bin/{name}{ext}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\next = \".exe\"\n\n[bin.uniontest]\nentry = \"main.mach\"\n";
+    ret "[project]\nid = \"uniontest\"\nname = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\ntarget = \"native\"\nout = \"out/{target}/bin/{name}{ext}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\next = \".exe\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[bin.uniontest]\nentry = \"main.mach\"\n";
 }
 
 # ut_manifest_multi: a two-target, two-bin manifest for the multi-artifact union

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -718,6 +718,9 @@ fun eval_comptime_directive(sc: *ctxm.SemaContext, target: id.ExprId, span: toke
 # is typed against the concrete field of each iteration. this is the sema half of
 # the splice the lowerer mirrors; heterogeneous field types are handled because
 # each iteration re-types the body.
+#
+# when T is an unbound generic type parameter the unroll is deferred to
+# monomorphization (#1523), mirroring how variadic packs are handled (#1475).
 fun infer_stmt_comptime_each(sc: *ctxm.SemaContext, ce: *stmt.StmtComptimeEach, span: token.Span, fn_ret: type.TypeId) Result[bool, str] {
     if (!comptime.is_fields_call(sc.a, sc.source, ce.seq)) {
         # a variadic-pack sequence (`$each a in va`, #1474): the element types are
@@ -736,6 +739,8 @@ fun infer_stmt_comptime_each(sc: *ctxm.SemaContext, ce: *stmt.StmtComptimeEach, 
     }
     val owner: type.TypeId = infer.field_seq_owner(sc, ce.seq, span);
     if (owner == type.TYPE_ERROR) { ret ok[bool, str](true); }
+    # an unbound generic type param: defer body type-check to monomorphization (#1523)
+    if (infer.type_is_generic_param(sc, owner)) { ret ok[bool, str](true); }
 
     val name_r: Result[intern.StrId, str] = intern.intern_span(?sc.s.interner, sc.source, ce.var_name);
     if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -887,7 +887,9 @@ fun set_expr_type(sc: *sema.SemaContext, eid: id.ExprId, ty: type.TypeId) {
 # field_seq_owner: resolves a `$fields(T)` sequence (#1473) to its owning record
 # TypeId, requiring T to be a record. the type-argument's expr_type slot is
 # populated for the lowerer. TYPE_ERROR when the sequence is malformed or T is
-# not a record. shared by the `$each` unroll (sema and lowering).
+# not a record. returns the TYPE_GENERIC_PARAM TypeId when T is an unbound
+# generic param — the caller defers the unroll to monomorphization (#1523).
+# shared by the `$each` unroll (sema and lowering).
 pub fun field_seq_owner(sc: *sema.SemaContext, seq_eid: id.ExprId, span: token.Span) type.TypeId {
     val targ: id.ExprId = comptime.fields_type_arg(sc.a, seq_eid);
     if (targ == id.EXPR_NIL) {
@@ -897,6 +899,8 @@ pub fun field_seq_owner(sc: *sema.SemaContext, seq_eid: id.ExprId, span: token.S
     val owner: type.TypeId = intrinsic_operand_type(sc, targ, span);
     set_expr_type(sc, targ, owner);
     if (owner == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    # an unbound generic type param: defer the record check to monomorphization (#1523)
+    if (type_is_generic_param(sc, owner)) { ret owner; }
     if (!type_is_record(sc, owner)) {
         sema.report(sc, span, "$fields requires a record type");
         ret type.TYPE_ERROR;
@@ -936,7 +940,16 @@ fun project_receiver_matches(sc: *sema.SemaContext, obj_ty: type.TypeId, owner: 
     val to: Option[*type.Type] = type.get(?sc.s.types, obj_ty);
     if (is_none[*type.Type](to)) { ret false; }
     val t: *type.Type = unwrap[*type.Type](to);
-    ret t.kind == type.TYPE_POINTER && t.data.pointer.base == owner;
+    # unbound generic type param (T) during deferred $fields re-inference:
+    # lowering will substitute T to `owner`; accept the projection (#1523).
+    if (t.kind == type.TYPE_GENERIC_PARAM) { ret true; }
+    if (t.kind != type.TYPE_POINTER) { ret false; }
+    val base: type.TypeId = t.data.pointer.base;
+    if (base == owner) { ret true; }
+    # *T where T is an unbound generic param: also valid for the same reason.
+    val bo: Option[*type.Type] = type.get(?sc.s.types, base);
+    if (is_none[*type.Type](bo)) { ret false; }
+    ret unwrap[*type.Type](bo).kind == type.TYPE_GENERIC_PARAM;
 }
 
 # whether `ty` is a comptime variadic pack (#1474).
@@ -944,6 +957,14 @@ fun type_is_pack(sc: *sema.SemaContext, ty: type.TypeId) bool {
     val to: Option[*type.Type] = type.get(?sc.s.types, ty);
     if (is_none[*type.Type](to)) { ret false; }
     ret unwrap[*type.Type](to).kind == type.TYPE_PACK;
+}
+
+# whether `ty` is an unbound generic type parameter — signals that a
+# `$fields(T)` unroll must be deferred to monomorphization (#1523).
+pub fun type_is_generic_param(sc: *sema.SemaContext, ty: type.TypeId) bool {
+    val to: Option[*type.Type] = type.get(?sc.s.types, ty);
+    if (is_none[*type.Type](to)) { ret false; }
+    ret unwrap[*type.Type](to).kind == type.TYPE_GENERIC_PARAM;
 }
 
 # infer_spread: types a `va...` pack spread (#1474). a spread may only spread a

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -163,6 +163,9 @@ pub rec PackInstance {
 #              the inline-asm lowerer resolves `{name}` references against it
 # fn_index:    index into m.functions of the function being lowered
 # ret_ty:      IR return type of the function being lowered
+# fn_ret_sem:  semantic return type of the function being lowered (with generic
+#              substitution applied when inside a monomorphized instance body);
+#              used by deferred `$each $fields(T)` body re-inference (#1523)
 # loops:       active loop stack (innermost last) for brk / cnt
 # loop_len:    number of active loop frames
 # loop_cap:    allocated capacity of the loop stack
@@ -220,6 +223,7 @@ pub rec LowerContext {
 
     fn_index:    u32;
     ret_ty:      ir_type.IrTypeId;
+    fn_ret_sem:  ty.TypeId;
 
     loops:       *LoopFrame;
     loop_len:    u32;
@@ -538,10 +542,11 @@ pub fun resolve_field_member(data: ptr, owner: u32, index: u32, sel: u8) Result[
 pub fun begin_function(lc: *LowerContext, fn_index: u32, ret_ty: ir_type.IrTypeId) {
     map.clear[resolve.SymbolId, value.Value](?lc.locals);
     map.clear[intern.StrId, value.Value](?lc.local_names);
-    lc.loop_len = 0;
-    lc.fin_len  = 0;
-    lc.fn_index = fn_index;
-    lc.ret_ty   = ret_ty;
+    lc.loop_len  = 0;
+    lc.fin_len   = 0;
+    lc.fn_index  = fn_index;
+    lc.ret_ty    = ret_ty;
+    lc.fn_ret_sem = ty.TYPE_NIL;
     # pack-instance body state defaults off; lower_pack_instance sets it after this
     # reset, and an ordinary function (or a generic / value instance) never reads it.
     lc.pack_slots  = nil;
@@ -1053,6 +1058,15 @@ pub fun expr_type_of(lc: *LowerContext, eid: aid.ExprId) ty.TypeId {
     ret lc.sema_result.expr_type[eid];
 }
 
+# applies the active generic substitution to `tid`, returning the concrete
+# sema TypeId. when no substitution is active (not inside a monomorphized
+# generic instance body), `tid` is returned unchanged. used to resolve a
+# deferred `$fields(T)` type argument to its concrete record type (#1523).
+pub fun substitute_type(lc: *LowerContext, tid: ty.TypeId) ty.TypeId {
+    if (lc.subst == nil || lc.subst_len == 0) { ret tid; }
+    ret generics.substitute(lc.s, tid, lc.subst, lc.subst_len);
+}
+
 # returns the interned semantic type a syntactic AstType resolved to, or
 # TYPE_NIL when the id is out of range.
 # ---
@@ -1074,6 +1088,26 @@ pub fun decl_type_of(lc: *LowerContext, did: aid.DeclId) ty.TypeId {
     if (did == aid.DECL_NIL) { ret ty.TYPE_NIL; }
     if (did::usize >= lc.a.decl_len) { ret ty.TYPE_NIL; }
     ret lc.sema_result.decl_type[did];
+}
+
+# returns the semantic return type of a function decl, with any generic
+# substitution applied. used by `lower_instance` to populate `fn_ret_sem`
+# so deferred `$each $fields(T)` body re-inference can check `ret` (#1523).
+# ---
+# lc:  the context (subst/subst_len active when inside a generic instance body)
+# did: DeclId of the function declaration
+# ret: the substituted sema return TypeId, or TYPE_NIL when unavailable
+pub fun decl_ret_sem(lc: *LowerContext, did: aid.DeclId) ty.TypeId {
+    val fn_ty: ty.TypeId = decl_type_of(lc, did);
+    val to: Option[*ty.Type] = ty.get(?lc.s.types, fn_ty);
+    if (is_none[*ty.Type](to)) { ret ty.TYPE_NIL; }
+    val t: *ty.Type = unwrap[*ty.Type](to);
+    if (t.kind != ty.TYPE_FUN) { ret ty.TYPE_NIL; }
+    var ret_ty: ty.TypeId = t.data.fn.ret_ty;
+    if (lc.subst != nil && lc.subst_len > 0) {
+        ret_ty = generics.substitute(lc.s, ret_ty, lc.subst, lc.subst_len);
+    }
+    ret ret_ty;
 }
 
 # returns the resolved SymbolId for an expression reference, or SYMBOL_NIL.

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -207,6 +207,9 @@ pub fun lower_instance(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl
     val fn_index: u32 = unwrap_ok[u32, str](idx_r);
 
     lower.begin_function(ctx, fn_index, ret_ir);
+    # set the sema return type so deferred $each $fields(T) re-inference can
+    # check `ret` against the concrete return type of this instance (#1523)
+    ctx.fn_ret_sem = lower.decl_ret_sem(ctx, did);
     builder.set_function(?ctx.builder, ?ctx.m.functions[fn_index]);
 
     val entry_r: Result[ir.BlockId, str] = builder.new_block(?ctx.builder);

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -600,7 +600,8 @@ fun lower_comptime_if(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str
 # comptime frame to that field's descriptor, so a `v.[f]` in the body projects
 # the concrete field of each iteration. the lowering half of the splice sema
 # mirrors. the owning type was resolved and recorded on the `$fields(T)` argument
-# by sema.
+# by sema, except when T is a generic type param — in that case the unroll was
+# deferred to monomorphization (#1523), and the concrete type is substituted here.
 fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, str] {
     val ce: *astmt.StmtComptimeEach = ?s.data.comptime_each;
     val src: str = lower.module_source(ctx);
@@ -617,11 +618,39 @@ fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, s
     }
     val targ: aid.ExprId = comptime.fields_type_arg(ctx.a, ce.seq);
     if (targ == aid.EXPR_NIL) { ret err[bool, str]("lower: `$fields` is missing its type argument"); }
-    val owner: ty.TypeId = lower.expr_type_of(ctx, targ);
+
+    # when T was a generic type param at template sema, the unroll was deferred (#1523);
+    # apply the active substitution to get the concrete record type for this instance.
+    val raw_owner: ty.TypeId = lower.expr_type_of(ctx, targ);
+    val deferred: bool = is_generic_param_type(ctx, raw_owner);
+    var owner: ty.TypeId = raw_owner;
+    if (deferred) {
+        if (ctx.subst == nil || ctx.subst_len == 0) {
+            # no active substitution: this is the template body being lowered directly
+            # (not an instance). the concrete $fields unroll runs per-instance instead;
+            # emit nothing here, mirroring the pack path's body-skip approach.
+            ret ok[bool, str](true);
+        }
+        owner = lower.substitute_type(ctx, raw_owner);
+        if (!is_fields_record_type(ctx, owner)) {
+            diag.error(?ctx.s.diags, ctx.a.file_id, s.span,
+                "$fields(T): type argument instantiated as a non-record type");
+            ret err[bool, str](lower.REPORTED);
+        }
+    }
 
     val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, src, ce.var_name);
     if (is_err[intern.StrId, str](name_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](name_r)); }
     val fname: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+
+    # build a module-spanning typing snapshot for deferred body re-inference;
+    # mirrors the pack case (#1475) — the body was not typed at template sema.
+    var deps: sema.SemaDeps;
+    if (deferred) {
+        val deps_r: Result[sema.SemaDeps, str] = sema.collect_module_deps(ctx.s);
+        if (is_err[sema.SemaDeps, str](deps_r)) { ret err[bool, str](unwrap_err[sema.SemaDeps, str](deps_r)); }
+        deps = unwrap_ok[sema.SemaDeps, str](deps_r);
+    }
 
     val n: u32 = ty.field_count(?ctx.s.types, owner);
     var i: u32 = 0;
@@ -630,15 +659,29 @@ fun lower_comptime_each(ctx: *lower.LowerContext, s: *astmt.Stmt) Result[bool, s
         val br: Result[bool, str] = comptime.bind(ctx.ctx, fname, comptime.field_value(owner::u32, i));
         if (is_err[bool, str](br)) {
             val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            if (deferred) { sema.free_module_deps(ctx.s, ?deps); }
             if (is_err[bool, str](cc)) { ret cc; }
             ret br;
         }
+        if (deferred) {
+            # re-type the body for this field (deferred at template sema, #1523),
+            # writing expression types into the shared array lowering reads next.
+            val ir: Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, ?deps, ctx.ctx,
+                ctx.own_module, ctx.sema_result, ctx.fn_ret_sem, ce.body_start, ce.body_len);
+            if (is_err[bool, str](ir)) {
+                val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+                sema.free_module_deps(ctx.s, ?deps);
+                if (is_err[bool, str](cc)) { ret cc; }
+                ret ir;
+            }
+        }
         val rb: Result[bool, str] = lower_stmt_list(ctx, ce.body_start, ce.body_len);
         val cc: Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
-        if (is_err[bool, str](rb)) { ret rb; }
-        if (is_err[bool, str](cc)) { ret cc; }
+        if (is_err[bool, str](rb)) { if (deferred) { sema.free_module_deps(ctx.s, ?deps); } ret rb; }
+        if (is_err[bool, str](cc)) { if (deferred) { sema.free_module_deps(ctx.s, ?deps); } ret cc; }
         i = i + 1;
     }
+    if (deferred) { sema.free_module_deps(ctx.s, ?deps); }
     ret ok[bool, str](true);
 }
 
@@ -704,6 +747,25 @@ fun is_pack_type(ctx: *lower.LowerContext, t: ty.TypeId) bool {
     val to: Option[*ty.Type] = ty.get(?ctx.s.types, t);
     if (is_none[*ty.Type](to)) { ret false; }
     ret unwrap[*ty.Type](to).kind == ty.TYPE_PACK;
+}
+
+# true when `t` is an unbound generic type parameter — signals deferred
+# `$each $fields(T)` over a generic param that needs substitution (#1523).
+fun is_generic_param_type(ctx: *lower.LowerContext, t: ty.TypeId) bool {
+    val to: Option[*ty.Type] = ty.get(?ctx.s.types, t);
+    if (is_none[*ty.Type](to)) { ret false; }
+    ret unwrap[*ty.Type](to).kind == ty.TYPE_GENERIC_PARAM;
+}
+
+# true when `t` is a record or a generic record instance — the types
+# `$fields(T)` accepts after substitution at instantiation.
+fun is_fields_record_type(ctx: *lower.LowerContext, t: ty.TypeId) bool {
+    val to: Option[*ty.Type] = ty.get(?ctx.s.types, t);
+    if (is_none[*ty.Type](to)) { ret false; }
+    val k: ty.TypeKind = unwrap[*ty.Type](to).kind;
+    if (k == ty.TYPE_REC) { ret true; }
+    if (k == ty.TYPE_INSTANCE && is_some[*ty.FieldTable](ty.field_table_for(?ctx.s.types, t))) { ret true; }
+    ret false;
 }
 
 # true when the builder's current block already has a terminator. used to

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -49,22 +49,36 @@ pub val CLASS_BYREF: ParamClass = 4;
 # aggregate's by-value bytes). distinct from CLASS_STACK, whose stack slot holds
 # the value's own bytes.
 pub val CLASS_STACK_BYREF: ParamClass = 5;
+# passed in a run of consecutive floating-point / vector registers — an AAPCS64
+# Homogeneous Floating-point / Short-Vector Aggregate (HFA/HVA): a composite of
+# 1–4 members all of the same fundamental FP type rides V[reg]..V[reg+reg_count-1],
+# one member per register at `reg_width` bytes each. distinct from CLASS_FP, which
+# is a single scalar float in one register.
+pub val CLASS_HFA: ParamClass = 6;
 
 # placement decision for one parameter or return value. `reg2` carries the
 # second register of a 9–16 byte aggregate split across two registers; it is
-# -1 when the value occupies a single register or the stack.
+# -1 when the value occupies a single register or the stack. `reg_count` /
+# `reg_width` describe a CLASS_HFA register run; they are 1 / 0 for every other
+# placement.
 # ---
-# class:  classification (CLASS_GP, CLASS_FP, CLASS_STACK, ...)
-# reg:    first register id if register-passed (-1 if stack/byref)
-# reg2:   second register id for a two-register aggregate (-1 otherwise)
-# offset: stack offset in bytes if stack-passed
-# size:   size in bytes of this slot
+# class:     classification (CLASS_GP, CLASS_FP, CLASS_STACK, ...)
+# reg:       first register id if register-passed (-1 if stack/byref); the base
+#            register of a CLASS_HFA run
+# reg2:      second register id for a two-register aggregate (-1 otherwise)
+# reg_count: number of consecutive registers from `reg` for a CLASS_HFA (1 for
+#            every other placement)
+# reg_width: per-register member width in bytes for a CLASS_HFA (0 otherwise)
+# offset:    stack offset in bytes if stack-passed
+# size:      size in bytes of this slot
 pub rec ParamSlot {
-    class:  ParamClass;
-    reg:    i32;
-    reg2:   i32;
-    offset: i64;
-    size:   u64;
+    class:     ParamClass;
+    reg:       i32;
+    reg2:      i32;
+    reg_count: u8;
+    reg_width: u8;
+    offset:    i64;
+    size:      u64;
 }
 
 # the concrete signatures the erased `AbiVTable` function pointers are cast back
@@ -86,6 +100,13 @@ pub rec ParamSlot {
 # registers. it is meaningful only for a ≤16 byte aggregate; 0 for scalars and
 # integer-only aggregates.
 # ---
+# `hfa_members` / `hfa_elem` are the backend's HFA descriptor: an AAPCS64
+# Homogeneous Floating-point / Short-Vector Aggregate is reported as its member
+# count (1–4) and fundamental member width in bytes, so the AAPCS64 classifier can
+# place it in consecutive V registers. `hfa_members` is 0 for a non-HFA (a scalar,
+# a heterogeneous or oversized aggregate, or any value on a convention that has no
+# HFA rule); the AMD64 conventions ignore both, as they do `fp_eightbytes`.
+# ---
 # size:          value size in bytes
 # align:         value alignment in bytes
 # is_float:      true if the value is FP-register-eligible
@@ -93,13 +114,15 @@ pub rec ParamSlot {
 # is_aggregate:  true if the value is a record/array (recursively classified)
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (1–4), or 0 if the value is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
-pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32) ParamSlot;
+pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
 
 # assign the registers or stack slot for a single argument, given the GP/FP usage
 # counters the caller tracks across the call's argument list. arch-specific by
 # selection, so no `arch_id` is threaded. `fp_eightbytes` is the per-eightbyte SSE
-# mask (see `ClassifyFn`).
+# mask and `hfa_members` / `hfa_elem` the HFA descriptor (see `ClassifyFn`).
 # ---
 # index:         zero-based logical argument position
 # size:          argument size in bytes
@@ -109,20 +132,24 @@ pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32) ParamSlot;
 # is_aggregate:  true if the argument is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (1–4), or 0 if the argument is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
-pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, i32, i32) ParamSlot;
+pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
 
 # assign the registers or sret slot for a return value. arch-specific by
 # selection, so no `arch_id` is threaded. `fp_eightbytes` is the per-eightbyte SSE
-# mask (see `ClassifyFn`).
+# mask and `hfa_members` / `hfa_elem` the HFA descriptor (see `ClassifyFn`).
 # ---
 # size:          return-value size in bytes
 # align:         return-value alignment in bytes
 # is_float:      true if the value is returned in FP registers
 # fp_eightbytes: per-eightbyte SSE mask (bit e -> eightbyte e is SSE class)
 # is_aggregate:  true if the value is an aggregate
+# hfa_members:   HFA member count (1–4), or 0 if the value is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
-pub def RetPassingFn: fun(u64, u64, bool, u8, bool) ParamSlot;
+pub def RetPassingFn: fun(u64, u64, bool, u8, bool, u8, u8) ParamSlot;
 
 # fill a caller-owned `out` buffer with a register bank in canonical order and
 # return the count written. the erased `gp_arg_regs` / `fp_arg_regs` /
@@ -361,7 +388,9 @@ pub rec VaModel {
     vector_count_reg: i32;
 }
 
-# make_slot: build a ParamSlot. convenience for ABI implementations.
+# make_slot: build a single-register / stack ParamSlot. convenience for ABI
+# implementations. `reg_count` is 1 and `reg_width` 0 — the CLASS_HFA register-run
+# fields are set only by `make_slot_hfa`.
 # ---
 # class:  classification
 # reg:    first register id (-1 if none)
@@ -371,10 +400,34 @@ pub rec VaModel {
 # ret:    the assembled ParamSlot
 pub fun make_slot(class: ParamClass, reg: i32, reg2: i32, offset: i64, size: u64) ParamSlot {
     var s: ParamSlot;
-    s.class  = class;
-    s.reg    = reg;
-    s.reg2   = reg2;
-    s.offset = offset;
-    s.size   = size;
+    s.class     = class;
+    s.reg       = reg;
+    s.reg2      = reg2;
+    s.reg_count = 1;
+    s.reg_width = 0;
+    s.offset    = offset;
+    s.size      = size;
+    ret s;
+}
+
+# make_slot_hfa: build a CLASS_HFA ParamSlot for a homogeneous FP aggregate placed
+# in a run of `count` consecutive registers from `base_reg`, each holding one
+# `elem`-byte member. used by the AAPCS64 classifier for HFA/HVA arguments and
+# returns.
+# ---
+# base_reg: the first (lowest-numbered) register of the run
+# count:    number of consecutive registers (the HFA member count, 1–4)
+# elem:     per-register member width in bytes
+# size:     total aggregate size in bytes
+# ret:      the assembled CLASS_HFA ParamSlot
+pub fun make_slot_hfa(base_reg: i32, count: u8, elem: u8, size: u64) ParamSlot {
+    var s: ParamSlot;
+    s.class     = CLASS_HFA;
+    s.reg       = base_reg;
+    s.reg2      = -1;
+    s.reg_count = count;
+    s.reg_width = elem;
+    s.offset    = 0;
+    s.size      = size;
     ret s;
 }

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -10,15 +10,17 @@
 # (`*u8`); a consumer casts each back to the neutral signature declared in `abi`
 # (`ClassifyFn`, `ArgPassingFn`, `RetPassingFn`, `RegFileFn`).
 #
-# Scalars and ≤16-byte aggregates are placed in registers; >16-byte aggregates are
-# passed by hidden reference and returned through the dedicated X8 indirect-result
-# register (`indirect_result_in_argfile` is false, so the hidden pointer rides X8
-# OUTSIDE the X0–X7 argument file and the real arguments still start at X0). The
-# contract gaps DEFERRED to a later phase are: homogeneous floating-point /
-# short-vector aggregates (HFA/HVA) — a ≤16-byte all-float aggregate rides GP
-# registers here, not the V-register sequence; and the full AArch64 `va_list`
-# variadic model — `va_model` returns a register-save placeholder sufficient for
-# non-variadic call lowering.
+# Scalars and ≤16-byte integer aggregates are placed in GP registers; a Homogeneous
+# Floating-point / Short-Vector Aggregate (HFA/HVA — a composite of 1–4 members all
+# of the same fundamental FP type) rides a run of consecutive V registers (V0–V7);
+# >16-byte non-HFA aggregates are passed by hidden reference and returned through the
+# dedicated X8 indirect-result register (`indirect_result_in_argfile` is false, so the
+# hidden pointer rides X8 OUTSIDE the X0–X7 argument file and the real arguments still
+# start at X0). The HFA descriptor (member count + fundamental width) is computed by
+# the backend and threaded in through `classify_arg` / `classify_return`. The one
+# contract gap DEFERRED to a later phase is the full AArch64 `va_list` variadic model —
+# `va_model` returns a register-save placeholder sufficient for non-variadic call
+# lowering.
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -124,42 +126,60 @@ pub fun fp_param_reg(index: i32) i32 {
 # size:          value size in bytes
 # align:         value alignment in bytes
 # is_float:      true if the value is FP-eligible
-# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# fp_eightbytes: per-eightbyte SSE mask (unused — AAPCS64 routes FP through HFA)
 # is_aggregate:  true if the value is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (1–4), or 0 if the value is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
-                 is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used);
+                 is_aggregate: bool, gp_used: i32, fp_used: i32,
+                 hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem);
 }
 
 # classify_arg: assign registers or a stack slot for one argument (AAPCS64).
 #
-# scalars take one GP register (or one V register for a float) until that bank is
-# exhausted, then spill to the stack. an aggregate of ≤8 bytes takes one GP
-# register; a 9–16 byte aggregate takes a consecutive GP register pair; either
-# spills to the stack by value when the GP bank lacks the register(s) it needs.
-# an aggregate larger than 16 bytes is passed by hidden reference — the caller
-# copies it to memory and passes the pointer in the next GP register
-# (CLASS_BYREF), or, when the GP bank is exhausted, passes that pointer on the
-# stack (CLASS_STACK_BYREF). HFA/HVA float-aggregate placement in the V registers
-# is deferred (see the module note); a float-bearing ≤16-byte aggregate rides GP
-# registers here. this classifier is AArch64-specific by selection: `target.select`
-# only composes the AAPCS64 vtable for an aarch64 (os, arch) pair.
+# an HFA/HVA (a homogeneous aggregate of 1–4 same-typed FP members, reported by the
+# backend through `hfa_members` / `hfa_elem`) rides a run of consecutive V registers
+# when the whole run fits in the remaining V bank; otherwise the WHOLE aggregate
+# spills to the stack by value (the AAPCS64 all-or-memory rule — members are never
+# split across registers and stack). this is checked before the by-reference rule,
+# since a 4×f64 HFA is 32 bytes yet still register-passed. scalars take one GP
+# register (or one V register for a float) until that bank is exhausted, then spill
+# to the stack. a non-HFA aggregate of ≤8 bytes takes one GP register; a 9–16 byte
+# one takes a consecutive GP register pair; either spills to the stack by value when
+# the GP bank lacks the register(s) it needs. a non-HFA aggregate larger than 16
+# bytes is passed by hidden reference — the caller copies it to memory and passes the
+# pointer in the next GP register (CLASS_BYREF), or, when the GP bank is exhausted,
+# passes that pointer on the stack (CLASS_STACK_BYREF). this classifier is
+# AArch64-specific by selection: `target.select` only composes the AAPCS64 vtable for
+# an aarch64 (os, arch) pair.
 # ---
 # index:         zero-based logical argument position
 # size:          argument size in bytes
 # align:         argument alignment in bytes
 # is_float:      true if the argument goes in an FP register (scalar floats)
-# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# fp_eightbytes: per-eightbyte SSE mask (unused — AAPCS64 routes FP through HFA)
 # is_aggregate:  true if the argument is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (1–4), or 0 if the argument is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                     gp_used: i32, fp_used: i32) abi.ParamSlot {
+                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+    if (is_aggregate && hfa_members > 0) {
+        # the run fits only if every member lands in the remaining V bank; otherwise
+        # the whole aggregate goes to the stack by value (all-or-memory).
+        if (fp_used + hfa_members::i32 <= FP_PARAM_COUNT) {
+            ret abi.make_slot_hfa(fp_param_reg(fp_used), hfa_members, hfa_elem, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
+
     if (is_aggregate && size > MAX_REG_RET) {
         # >16 bytes: passed by reference. the pointer rides the next GP register, or
         # the stack (as an 8-byte pointer) once the GP bank is exhausted.
@@ -200,25 +220,33 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # classify_return: assign registers or an sret pointer for a return value (AAPCS64).
 #
 # a zero-size (void) return yields CLASS_GP with reg=-1. a scalar returns in X0,
-# or V0 for a float. an aggregate of ≤8 bytes returns in X0; a 9–16 byte aggregate
-# returns in the X0:X1 pair. an aggregate larger than 16 bytes is returned through
-# the dedicated X8 indirect-result register (CLASS_SRET, reg=X8) — the caller passes
-# the result-storage address in X8 and the callee reads it there, leaving X0–X7 for
-# the real arguments. HFA/HVA V-register returns are likewise deferred:
-# a float-bearing ≤16-byte aggregate returns in GP registers here. this classifier
-# is AArch64-specific by selection — the AAPCS64 vtable is only composed for an
-# aarch64 target.
+# or V0 for a float. an HFA/HVA returns in the V0..V(members-1) run. a non-HFA
+# aggregate of ≤8 bytes returns in X0; a 9–16 byte one returns in the X0:X1 pair.
+# a non-HFA aggregate larger than 16 bytes is returned through the dedicated X8
+# indirect-result register (CLASS_SRET, reg=X8) — the caller passes the
+# result-storage address in X8 and the callee reads it there, leaving X0–X7 for the
+# real arguments. the HFA check precedes the >16-byte sret rule (a 4×f64 HFA is 32
+# bytes yet returns in V0–V3). this classifier is AArch64-specific by selection —
+# the AAPCS64 vtable is only composed for an aarch64 target.
 # ---
 # size:          return-value size in bytes
 # align:         return-value alignment in bytes
 # is_float:      true if the value is returned in an FP register (scalar floats)
-# fp_eightbytes: per-eightbyte SSE mask (unused in this first cut; HFA deferred)
+# fp_eightbytes: per-eightbyte SSE mask (unused — AAPCS64 routes FP through HFA)
 # is_aggregate:  true if the value is an aggregate
+# hfa_members:   HFA member count (1–4), or 0 if the value is not an HFA
+# hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool) abi.ParamSlot {
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                        hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
+    }
+
+    # an HFA/HVA returns in V0..V(members-1); a return always has the full V bank.
+    if (is_aggregate && hfa_members > 0) {
+        ret abi.make_slot_hfa(fp_param_reg(0), hfa_members, hfa_elem, size);
     }
 
     if (is_aggregate && size > MAX_REG_RET) {
@@ -357,62 +385,104 @@ pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
 }
 
 test "aapcs64: a scalar integer takes a GP register, a float a V register" {
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_X0)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
     if (f.class != abi.CLASS_FP)    { ret 1; }
     if (f.reg != fp_param_reg(0))   { ret 1; }
     ret 0;
 }
 
-test "aapcs64: a 16-byte aggregate rides a consecutive GP pair" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0);
+test "aapcs64: a 16-byte integer aggregate rides a consecutive GP pair" {
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0);
     if (s.class != abi.CLASS_GP) { ret 1; }
     if (s.reg  != REG_X0)        { ret 1; }
     if (s.reg2 != REG_X1)        { ret 1; }
     # an 8-byte aggregate takes a single GP register.
-    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0);
+    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0);
     if (o.class != abi.CLASS_GP) { ret 1; }
     if (o.reg  != REG_X0)        { ret 1; }
     if (o.reg2 != -1)            { ret 1; }
     ret 0;
 }
 
-test "aapcs64: a >16-byte aggregate is passed by reference" {
+test "aapcs64: a >16-byte non-HFA aggregate is passed by reference" {
     # a GP register remains: the hidden pointer rides it.
-    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0);
     if (s.class != abi.CLASS_BYREF) { ret 1; }
     if (s.reg   != REG_X0)          { ret 1; }
     # GP bank exhausted: the pointer is passed on the stack.
-    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0);
+    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0, 0, 0);
     if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: an HFA rides a consecutive V run; all-or-memory when it cannot fit" {
+    # struct { f32, f32 } -> 2 members of 4 bytes in V0:V1.
+    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 2, 4);
+    if (s.class != abi.CLASS_HFA)        { ret 1; }
+    if (s.reg != fp_param_reg(0))        { ret 1; }
+    if (s.reg_count != 2)                { ret 1; }
+    if (s.reg_width != 4)                { ret 1; }
+    if (s.size != 8)                     { ret 1; }
+    # a 4×f64 HFA is 32 bytes yet still rides V0..V3 (HFA precedes the byref rule).
+    val q: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 4, 8);
+    if (q.class != abi.CLASS_HFA)        { ret 1; }
+    if (q.reg != fp_param_reg(0))        { ret 1; }
+    if (q.reg_count != 4)                { ret 1; }
+    if (q.reg_width != 8)                { ret 1; }
+    # the run starts at the next free V register (NSRN cursor honored).
+    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 5, 2, 4);
+    if (a.class != abi.CLASS_HFA)        { ret 1; }
+    if (a.reg != fp_param_reg(5))        { ret 1; }
+    # all-or-memory: a 3-member HFA cannot fit when only two V registers remain, so
+    # the WHOLE aggregate spills by value (no partial V placement).
+    val m: abi.ParamSlot = classify_arg(0, 12, 4, false, 0, true, 0, 6, 3, 4);
+    if (m.class != abi.CLASS_STACK)      { ret 1; }
     ret 0;
 }
 
 test "aapcs64: GP and FP argument banks advance independently" {
     # seven GP registers used: a scalar integer still has X7, a float still has V0.
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0);
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0, 0, 0);
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_X7)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0);
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0, 0, 0);
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     # GP exhausted spills an integer to the stack; the FP bank is untouched.
-    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 8, 0);
+    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 8, 0, 0, 0);
     if (s.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
 
 test "aapcs64: scalar and small-aggregate returns place X0/V0/X0:X1" {
-    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false);
+    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0);
     if (v.class != abi.CLASS_GP || v.reg != -1) { ret 1; }
-    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false);
+    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0);
     if (i.reg != REG_X0) { ret 1; }
-    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false);
+    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0);
     if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
-    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true);
+    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0);
     if (a.reg != REG_X0 || a.reg2 != REG_X1) { ret 1; }
+    ret 0;
+}
+
+test "aapcs64: an HFA return rides the V0 run, before the sret rule" {
+    # struct { f32, f32, f32 } returns in V0:V1:V2.
+    val s: abi.ParamSlot = classify_return(12, 4, false, 0, true, 3, 4);
+    if (s.class != abi.CLASS_HFA) { ret 1; }
+    if (s.reg != fp_param_reg(0)) { ret 1; }
+    if (s.reg_count != 3)         { ret 1; }
+    if (s.reg_width != 4)         { ret 1; }
+    # a 4×f64 HFA is 32 bytes yet returns in V0..V3, not via X8 sret.
+    val q: abi.ParamSlot = classify_return(32, 8, false, 0, true, 4, 8);
+    if (q.class != abi.CLASS_HFA) { ret 1; }
+    if (q.reg_count != 4)         { ret 1; }
+    # a >16-byte non-HFA aggregate still returns via the X8 indirect-result register.
+    val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0);
+    if (r.class != abi.CLASS_SRET || r.reg != REG_X8) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -126,10 +126,13 @@ pub fun fp_param_reg(index: i32) i32 {
 # is_aggregate: true if the value is an aggregate
 # gp_used:      GP registers already consumed
 # fp_used:      FP registers already consumed
+# hfa_members:  HFA member count (AAPCS64-only; unused under SysV)
+# hfa_elem:     HFA fundamental member width (AAPCS64-only; unused under SysV)
 # ret:          the placement decision
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
-                 is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used);
+                 is_aggregate: bool, gp_used: i32, fp_used: i32,
+                 hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem);
 }
 
 # ret_int_reg: the SysV integer return register for eightbyte index 0 / 1 (RAX, RDX).
@@ -171,10 +174,12 @@ fun ret_sse_reg(index: i32) i32 {
 # is_aggregate:  true if the argument is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (AAPCS64-only; unused under SysV)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under SysV)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                     gp_used: i32, fp_used: i32) abi.ParamSlot {
+                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     if (is_aggregate && size > MAX_REG_RET) {
         if (gp_used < GP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
@@ -250,9 +255,12 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_float:      true if the value is returned in FP registers (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask for an aggregate (bit e -> eightbyte e SSE)
 # is_aggregate:  true if the value is an aggregate
+# hfa_members:   HFA member count (AAPCS64-only; unused under SysV)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under SysV)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool) abi.ParamSlot {
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                        hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }
@@ -417,7 +425,7 @@ pub fun register(reg: *abi.AbiRegistry) Result[bool, str] {
 
 test "sysv: an all-float 16-byte aggregate rides XMM0:XMM1" {
     # {f64; f64} -> both eightbytes SSE -> the two vector argument registers.
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 0, 0, 0);
     if (s.class != abi.CLASS_GP) { ret 1; }
     if (s.reg  != fp_param_reg(0)) { ret 1; }
     if (s.reg2 != fp_param_reg(1)) { ret 1; }
@@ -426,7 +434,7 @@ test "sysv: an all-float 16-byte aggregate rides XMM0:XMM1" {
 
 test "sysv: an 8-byte all-float aggregate rides one XMM register" {
     # {f32; f32} (8 bytes) -> one SSE eightbyte -> XMM0.
-    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, 0, 0, 0, 0);
     if (s.class != abi.CLASS_GP) { ret 1; }
     if (s.reg  != fp_param_reg(0)) { ret 1; }
     if (s.reg2 != -1) { ret 1; }
@@ -435,12 +443,12 @@ test "sysv: an 8-byte all-float aggregate rides one XMM register" {
 
 test "sysv: a mixed INTEGER:SSE aggregate rides RDI:XMM0" {
     # {i64; f64} -> eightbyte 0 INTEGER (RDI), eightbyte 1 SSE (XMM0).
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, 0, 0, 0, 0);
     if (s.reg  != REG_RDI)        { ret 1; }
     if (s.reg2 != fp_param_reg(0)) { ret 1; }
     # the reverse {f64; i64} -> XMM0:RDI: the GP and SSE banks fill independently, so
     # the integer eightbyte takes the FIRST GP register (RDI), not the second.
-    val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, 0, 0);
+    val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, 0, 0, 0, 0);
     if (r.reg  != fp_param_reg(0)) { ret 1; }
     if (r.reg2 != REG_RDI)        { ret 1; }
     ret 0;
@@ -448,7 +456,7 @@ test "sysv: a mixed INTEGER:SSE aggregate rides RDI:XMM0" {
 
 test "sysv: an all-integer aggregate still rides the GP pair (unchanged)" {
     # {i64; i64} (mask 0) -> RDI:RSI, exactly as before SSE classification.
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0);
     if (s.reg  != REG_RDI) { ret 1; }
     if (s.reg2 != REG_RSI) { ret 1; }
     ret 0;
@@ -457,18 +465,18 @@ test "sysv: an all-integer aggregate still rides the GP pair (unchanged)" {
 test "sysv: SSE eightbytes consume the FP bank; exhaustion spills by value" {
     # with seven XMM registers already used, a two-SSE aggregate needs two but only
     # one remains, so the whole aggregate spills to the stack by value.
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 7);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 7, 0, 0);
     if (s.class != abi.CLASS_STACK) { ret 1; }
     if (s.size != 16)               { ret 1; }
     ret 0;
 }
 
 test "sysv: an all-float aggregate returns in XMM0:XMM1" {
-    val s: abi.ParamSlot = classify_return(16, 8, false, 3, true);
+    val s: abi.ParamSlot = classify_return(16, 8, false, 3, true, 0, 0);
     if (s.reg  != REG_XMM0) { ret 1; }
     if (s.reg2 != REG_XMM1) { ret 1; }
     # one all-float eightbyte returns in XMM0.
-    val o: abi.ParamSlot = classify_return(8, 4, false, 1, true);
+    val o: abi.ParamSlot = classify_return(8, 4, false, 1, true, 0, 0);
     if (o.reg  != REG_XMM0) { ret 1; }
     if (o.reg2 != -1)       { ret 1; }
     ret 0;
@@ -476,19 +484,19 @@ test "sysv: an all-float aggregate returns in XMM0:XMM1" {
 
 test "sysv: aggregate returns place each bank's eightbytes in order" {
     # {i64; i64} -> RAX:RDX (unchanged).
-    val gp: abi.ParamSlot = classify_return(16, 8, false, 0, true);
+    val gp: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0);
     if (gp.reg != REG_RAX || gp.reg2 != REG_RDX) { ret 1; }
     # {i64; f64} -> RAX:XMM0.
-    val mix: abi.ParamSlot = classify_return(16, 8, false, 2, true);
+    val mix: abi.ParamSlot = classify_return(16, 8, false, 2, true, 0, 0);
     if (mix.reg != REG_RAX || mix.reg2 != REG_XMM0) { ret 1; }
     ret 0;
 }
 
 test "sysv: a scalar float still takes an XMM register, an integer a GP" {
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
     if (f.class != abi.CLASS_FP)   { ret 1; }
     if (f.reg != fp_param_reg(0))  { ret 1; }
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_RDI)        { ret 1; }
     ret 0;
@@ -508,19 +516,19 @@ test "sysv: the indirect-result pointer rides the first GP argument register (in
 
 test "sysv: large aggregate is MEMORY-class when all GP registers consumed (#1242)" {
     # size=32 > MAX_REG_RET=16, gp_used=6 (exhausted) -> CLASS_STACK by value, reg=-1
-    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 6, 0);
+    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 6, 0, 0, 0);
     if (s1.class != abi.CLASS_STACK) { ret 1; }
     if (s1.reg   != -1)              { ret 1; }
     if (s1.size  != 32)              { ret 1; }
 
     # size=17 > MAX_REG_RET, gp_used=6 -> same MEMORY-class outcome
-    val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, 6, 0);
+    val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, 6, 0, 0, 0);
     if (s2.class != abi.CLASS_STACK) { ret 1; }
     if (s2.reg   != -1)              { ret 1; }
     if (s2.size  != 17)              { ret 1; }
 
     # gp_used=5 (one register remains) -> CLASS_BYREF, contrast with exhausted case
-    val s3: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 5, 0);
+    val s3: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 5, 0, 0, 0);
     if (s3.class != abi.CLASS_BYREF) { ret 1; }
 
     ret 0;

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -186,10 +186,13 @@ fun slot_index(gp_used: i32, fp_used: i32) i32 {
 # is_aggregate:  true if the value is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (AAPCS64-only; unused under win64)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under win64)
 # ret:           the placement decision
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
-                 is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used);
+                 is_aggregate: bool, gp_used: i32, fp_used: i32,
+                 hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem);
 }
 
 # classify_arg: assign a register or stack slot for one argument (win64).
@@ -219,10 +222,12 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_aggregate:  true if the argument is an aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
+# hfa_members:   HFA member count (AAPCS64-only; unused under win64)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under win64)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                     gp_used: i32, fp_used: i32) abi.ParamSlot {
+                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     val slot: i32 = slot_index(gp_used, fp_used);
 
     if (is_aggregate) {
@@ -273,9 +278,12 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_float:      true if the value is returned in FP registers (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask (unused — win64 returns aggregates in RAX)
 # is_aggregate:  true if the value is an aggregate
+# hfa_members:   HFA member count (AAPCS64-only; unused under win64)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under win64)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool) abi.ParamSlot {
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                        hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }
@@ -452,19 +460,19 @@ pub fun register_win64(reg: *abi.AbiRegistry) Result[bool, str] {
 }
 
 test "win64: scalar integer args take RCX, RDX, R8, R9 then spill" {
-    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
+    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
     if (s0.class != abi.CLASS_GP) { ret 1; }
     if (s0.reg != REG_RCX)        { ret 1; }
 
-    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 1, 0);
+    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 1, 0, 0, 0);
     if (s1.reg != REG_RDX) { ret 1; }
-    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, 2, 0);
+    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, 2, 0, 0, 0);
     if (s2.reg != REG_R8) { ret 1; }
-    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, 3, 0);
+    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, 3, 0, 0, 0);
     if (s3.reg != REG_R9) { ret 1; }
 
     # the fifth argument has no register slot and spills to the stack by value.
-    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, 4, 0);
+    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, 4, 0, 0, 0);
     if (s4.class != abi.CLASS_STACK) { ret 1; }
     if (s4.reg != -1)                { ret 1; }
     if (s4.size != 8)                { ret 1; }
@@ -472,16 +480,16 @@ test "win64: scalar integer args take RCX, RDX, R8, R9 then spill" {
 }
 
 test "win64: float args take XMM0–XMM3 then spill" {
-    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
+    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
     if (f0.class != abi.CLASS_FP)                          { ret 1; }
     if (f0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
 
-    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, 0, 3);
+    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, 0, 3, 0, 0);
     if (f3.class != abi.CLASS_FP)                          { ret 1; }
     if (f3.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
 
     # the fifth positional argument (slot 4) spills regardless of bank.
-    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, 0, 4);
+    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, 0, 4, 0, 0);
     if (f4.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -490,16 +498,16 @@ test "win64: int and float share one positional slot per argument" {
     # argument 0 is an integer (slot 0 -> RCX). argument 1 is a float; under
     # win64 it takes the SECOND positional slot -> XMM1, not XMM0, because the
     # integer already consumed slot 0.
-    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0);
+    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
     if (i0.reg != REG_RCX) { ret 1; }
-    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, 1, 0);
+    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, 1, 0, 0, 0);
     if (f1.class != abi.CLASS_FP)                          { ret 1; }
     if (f1.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 1)) { ret 1; }
 
     # the reverse: a float (slot 0 -> XMM0) followed by an integer (slot 1 -> RDX).
-    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0);
+    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
     if (g0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
-    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 0, 1);
+    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 0, 1, 0, 0);
     if (g1.class != abi.CLASS_GP) { ret 1; }
     if (g1.reg != REG_RDX)        { ret 1; }
     ret 0;
@@ -517,24 +525,24 @@ test "win64: a variadic float duplicates into the matching integer register" {
 
 test "win64: 1/2/4/8-byte aggregates ride one register, others go by reference" {
     # an 8-byte aggregate rides RCX by value.
-    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0);
+    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0);
     if (by_val.class != abi.CLASS_GP) { ret 1; }
     if (by_val.reg != REG_RCX)        { ret 1; }
     if (by_val.size != 8)             { ret 1; }
 
     # a 4-byte aggregate also rides by value.
-    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, 0, 0);
+    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, 0, 0, 0, 0);
     if (four.class != abi.CLASS_GP) { ret 1; }
 
     # a 3-byte aggregate is not a by-value size: passed by hidden reference, the
     # pointer (8 bytes) in RCX.
-    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, 0, 0);
+    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, 0, 0, 0, 0);
     if (by_ref3.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref3.reg != REG_RCX)           { ret 1; }
     if (by_ref3.size != 8)                { ret 1; }
 
     # a 16-byte aggregate is also by reference.
-    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0);
+    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0);
     if (by_ref16.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref16.reg != REG_RCX)           { ret 1; }
     ret 0;
@@ -544,7 +552,7 @@ test "win64: an exhausted by-reference aggregate spills its pointer to the stack
     # all four positional slots are taken; a 16-byte by-ref aggregate spills the
     # 8-byte hidden pointer to the stack as CLASS_STACK_BYREF (not the full
     # aggregate, and distinct from a by-value CLASS_STACK spill).
-    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, 4, 0);
+    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, 4, 0, 0, 0);
     if (s.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s.reg != -1)                      { ret 1; }
     if (s.size != 8)                      { ret 1; }
@@ -552,28 +560,28 @@ test "win64: an exhausted by-reference aggregate spills its pointer to the stack
     # a sub-pointer (3-byte) aggregate is also by reference: win64 treats every
     # non-1/2/4/8-byte aggregate as byref, so an exhausted 3-byte aggregate spills
     # its 8-byte pointer too — the size-mismatch heuristic missed this case.
-    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, 4, 0);
+    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, 4, 0, 0, 0);
     if (s3.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s3.size != 8)                      { ret 1; }
 
     # an exhausted by-value-size aggregate (8 bytes) spills its own bytes by value,
     # so it stays CLASS_STACK — the byref class must not capture the by-value path.
-    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, true, 4, 0);
+    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, true, 4, 0, 0, 0);
     if (sv.class != abi.CLASS_STACK) { ret 1; }
     if (sv.size != 8)                { ret 1; }
     ret 0;
 }
 
 test "win64: scalar returns use RAX / XMM0, void returns reg=-1" {
-    val voidr: abi.ParamSlot = classify_return(0, 0, false, 0, false);
+    val voidr: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0);
     if (voidr.class != abi.CLASS_GP) { ret 1; }
     if (voidr.reg != -1)             { ret 1; }
 
-    val ir: abi.ParamSlot = classify_return(8, 8, false, 0, false);
+    val ir: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0);
     if (ir.class != abi.CLASS_GP) { ret 1; }
     if (ir.reg != REG_RAX)        { ret 1; }
 
-    val fr: abi.ParamSlot = classify_return(8, 8, true, 0, false);
+    val fr: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0);
     if (fr.class != abi.CLASS_FP) { ret 1; }
     if (fr.reg != REG_XMM0)       { ret 1; }
     ret 0;
@@ -581,19 +589,19 @@ test "win64: scalar returns use RAX / XMM0, void returns reg=-1" {
 
 test "win64: aggregate returns are RAX by value or an sret pointer" {
     # an 8-byte aggregate returns in RAX.
-    val small: abi.ParamSlot = classify_return(8, 8, false, 0, true);
+    val small: abi.ParamSlot = classify_return(8, 8, false, 0, true, 0, 0);
     if (small.class != abi.CLASS_GP) { ret 1; }
     if (small.reg != REG_RAX)        { ret 1; }
 
     # a small all-float UDT still returns in RAX under MS x64 (unlike SysV's XMM0):
     # the fp_eightbytes mask is ignored, every 1/2/4/8-byte aggregate uses RAX.
-    val fsmall: abi.ParamSlot = classify_return(8, 8, true, 1, true);
+    val fsmall: abi.ParamSlot = classify_return(8, 8, true, 1, true, 0, 0);
     if (fsmall.class != abi.CLASS_GP) { ret 1; }
     if (fsmall.reg != REG_RAX)        { ret 1; }
 
     # a 12-byte aggregate is not a by-value size: returned via an sret pointer,
     # which the callee yields in RAX.
-    val big: abi.ParamSlot = classify_return(12, 4, false, 0, true);
+    val big: abi.ParamSlot = classify_return(12, 4, false, 0, true, 0, 0);
     if (big.class != abi.CLASS_SRET) { ret 1; }
     if (big.reg != REG_RAX)          { ret 1; }
     ret 0;
@@ -602,9 +610,9 @@ test "win64: aggregate returns are RAX by value or an sret pointer" {
 test "win64: an sret return reserves the first positional slot, shifting args" {
     # a 24-byte aggregate return is sret. classify_signature seeds gp_used=1 for
     # the hidden RCX pointer, so the first real integer argument lands in RDX.
-    val ret_slot: abi.ParamSlot = classify_return(24, 8, false, 0, true);
+    val ret_slot: abi.ParamSlot = classify_return(24, 8, false, 0, true, 0, 0);
     if (ret_slot.class != abi.CLASS_SRET) { ret 1; }
-    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 1, 0);
+    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 1, 0, 0, 0);
     if (first_arg.class != abi.CLASS_GP) { ret 1; }
     if (first_arg.reg != REG_RDX)        { ret 1; }
     ret 0;

--- a/src/lang/target/isa/x64.mach
+++ b/src/lang/target/isa/x64.mach
@@ -255,6 +255,12 @@ pub val RAW_BYTE:  Opcode = 83;
 # save / restore a callee-saved XMM register to a 16-byte-aligned frame slot under
 # win64; the unwind tables describe it with UWOP_SAVE_XMM128.
 pub val MOVAPS:    Opcode = 84;
+# set byte if parity (PF set — an unordered SSE compare). materializes the
+# unordered half of the IEEE-754 float `!=` combine.
+pub val SETP:      Opcode = 85;
+# set byte if not parity (PF clear — an ordered SSE compare). materializes the
+# ordered half of the IEEE-754 float `==` combine.
+pub val SETNP:     Opcode = 86;
 
 # encoding flags carried on `isa.Inst.flags`. they steer prefix and width
 # selection in the encoder independently of the opcode.

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -3425,30 +3425,51 @@ fun emit_movd_movq_reg(gp: i32, xmm: i32, w: u8, gp_to_xmm: bool, buf: *ByteBuf)
 }
 
 
-# float_setcc_opcode: the concrete UNSIGNED SETcc opcode realizing a float
-# comparison condition. a UCOMISD/UCOMISS sets CF/ZF/PF (CF on below, ZF on equal;
-# an UNORDERED result sets CF=ZF=PF=1), so the float compare maps to the UNSIGNED
-# conditions SETE/SETNE/SETB/SETBE/SETA/SETAE — NOT the signed SETL/SETLE/SETG/SETGE
-# the integer compare path uses.
+# float_cmp_swap: true when an IEEE-754 float compare is realized by reversing its
+# operands. `<` / `<=` map to the NaN-false `>` / `>=` of the swapped operands
+# (`a < b` is `b > a`, which UCOMISD reads as false when unordered), so those two
+# conditions compare RHS against LHS. the lowerer already canonicalizes source
+# `>` / `>=` to LT / LE, so in practice these are the only relations that reach the
+# encoder; GT / GE remain handled identically for completeness.
+fun float_cmp_swap(cc: u8) bool {
+    ret cc == mir.FCC_LT || cc == mir.FCC_LE;
+}
+
+# float_setcc_opcode: the primary UNSIGNED SETcc realizing an IEEE-754 float
+# comparison. UCOMISD/UCOMISS sets CF/ZF/PF (CF on below, ZF on equal) and leaves
+# CF=ZF=PF=1 when unordered (a NaN operand), so an honest compare must read false
+# there for every relation except `!=`. the relations use the NaN-false SETA /
+# SETAE: `>` and `<` (operands reversed by float_cmp_swap) map to SETA, `>=` and
+# `<=` to SETAE. equality stays SETE / SETNE and is corrected for the unordered
+# case by the parity combine in encode_float_cmp. these are the UNSIGNED conditions
+# — NOT the signed SETL/SETLE/SETG/SETGE the integer compare path uses.
 fun float_setcc_opcode(cc: u8) u16 {
     if (cc == mir.FCC_EQ) { ret x64.SETE; }
     if (cc == mir.FCC_NE) { ret x64.SETNE; }
-    if (cc == mir.FCC_LT) { ret x64.SETB; }
-    if (cc == mir.FCC_LE) { ret x64.SETBE; }
+    if (cc == mir.FCC_LT) { ret x64.SETA; }
+    if (cc == mir.FCC_LE) { ret x64.SETAE; }
     if (cc == mir.FCC_GT) { ret x64.SETA; }
     ret x64.SETAE;
 }
 
 # encode_float_cmp: materialize a fully-resolved float comparison
-# `MIR_FCMP [dst, lhs, rhs]` into its SSE byte sequence, mirroring cmach's
-# `emit_float_cmp`: load `lhs` -> FLOAT_SCRATCH0 and `rhs` -> FLOAT_SCRATCH1, run
-# `UCOMISS/UCOMISD SCRATCH0, SCRATCH1` (set CF/ZF/PF), capture the condition into
-# the destination's low byte with the UNSIGNED SETcc selected from the FCC_* code
-# (carried on `mi.src_width`), then zero-extend the byte boolean to the machine
-# word (MOVZX). the compared operand width (`mi.width`: 4 -> UCOMISS, 8 -> UCOMISD)
-# selects the compare form; the i8 result is sized independently. the destination
-# is a GP register (the i8 result vreg is GP-classed); a spilled result is reloaded
-# into a register destination by the allocator before here.
+# `MIR_FCMP [dst, lhs, rhs]` into its IEEE-754 SSE byte sequence: load `lhs` ->
+# FLOAT_SCRATCH0 and `rhs` -> FLOAT_SCRATCH1, run `UCOMISS/UCOMISD` (set CF/ZF/PF),
+# capture the condition into the destination's low byte, then zero-extend the byte
+# boolean to the machine word (MOVZX). the compared operand width (`mi.width`:
+# 4 -> UCOMISS, 8 -> UCOMISD) selects the compare form; the i8 result is sized
+# independently. the destination is a GP register (the i8 result vreg is GP-classed);
+# a spilled result is reloaded into a register destination by the allocator here.
+#
+# an unordered (NaN-involving) compare leaves CF=ZF=PF=1, so an honest IEEE-754
+# result reads false for every relation except `!=`:
+#   - `<` / `<=`: the operands are reversed (float_cmp_swap) and read with the
+#     NaN-false SETA / SETAE, since `a < b` is `b > a`;
+#   - `>` / `>=`: SETA / SETAE directly (already NaN-false);
+#   - `==` / `!=`: SETE / SETNE alone ignore PF, so a NaN would read as ordered.
+#     the parity flag is folded in — `==` is ordered-and-equal (ZF & !PF), `!=` is
+#     unordered-or-unequal (!ZF | PF) — by capturing PF into the reserved R11 scratch
+#     (SETNP / SETP) and combining it with the primary byte (AND / OR) before MOVZX.
 fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Result[bool, str] {
     if (mi.operand_count < 3) {
         ret err[bool, str]("encode: float comparison missing operands");
@@ -3477,17 +3498,22 @@ fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Resu
     val lr: Result[bool, str] = emit_float_load(rhs, FLOAT_SCRATCH1, w, buf);
     if (is_err[bool, str](lr)) { ret lr; }
 
-    # UCOMISS / UCOMISD SCRATCH0, SCRATCH1  (set CF/ZF/PF)
+    # UCOMISS / UCOMISD lhs, rhs  (set CF/ZF/PF); `<` / `<=` reverse the operands so
+    # the relation reads as the NaN-false `>` / `>=` of the swapped pair.
     var ucom: isa.Inst;
     zero_inst(?ucom);
     ucom.opcode = x64.UCOMISD;
     if (w == 4) { ucom.opcode = x64.UCOMISS; }
     ucom.dst  = isa.make_reg(FLOAT_SCRATCH0, 16);
     ucom.src1 = isa.make_reg(FLOAT_SCRATCH1, 16);
+    if (float_cmp_swap(cc)) {
+        ucom.dst  = isa.make_reg(FLOAT_SCRATCH1, 16);
+        ucom.src1 = isa.make_reg(FLOAT_SCRATCH0, 16);
+    }
     ucom.size = w;
     encode_inst(?ucom, buf);
 
-    # SETcc dst  (one byte; UNSIGNED condition from the FCC_* code)
+    # SETcc dst  (one byte; the NaN-false UNSIGNED condition from the FCC_* code)
     var setcc: isa.Inst;
     zero_inst(?setcc);
     setcc.opcode   = float_setcc_opcode(cc);
@@ -3495,6 +3521,31 @@ fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Resu
     setcc.dst.size = 1;
     setcc.size     = 1;
     encode_inst(?setcc, buf);
+
+    # `==` / `!=`: fold the parity flag in so an unordered (NaN) compare is not read
+    # as ordered. capture PF into the reserved R11 scratch (SETNP for `==` -> !PF,
+    # SETP for `!=` -> PF) — both SETcc read the flags before the combine clobbers
+    # them — then AND (`==`: ZF & !PF) or OR (`!=`: !ZF | PF) it into the primary byte.
+    if (cc == mir.FCC_EQ || cc == mir.FCC_NE) {
+        var par: isa.Inst;
+        zero_inst(?par);
+        par.opcode   = x64.SETNP;
+        if (cc == mir.FCC_NE) { par.opcode = x64.SETP; }
+        par.dst      = isa.make_reg(x64.R11, 1);
+        par.dst.size = 1;
+        par.size     = 1;
+        encode_inst(?par, buf);
+
+        var comb: isa.Inst;
+        zero_inst(?comb);
+        comb.opcode   = x64.AND;
+        if (cc == mir.FCC_NE) { comb.opcode = x64.OR; }
+        comb.dst      = dst;
+        comb.dst.size = 1;
+        comb.src1     = isa.make_reg(x64.R11, 1);
+        comb.size     = 1;
+        encode_inst(?comb, buf);
+    }
 
     # MOVZX dst, dst  (zero-extend the byte boolean to the machine word)
     var movzx: isa.Inst;

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -464,6 +464,8 @@ fun cc_to_x86(opcode: u16) u8 {
     if (opcode == x64.JBE || opcode == x64.SETBE) { ret 0x06; }
     if (opcode == x64.JA  || opcode == x64.SETA)  { ret 0x07; }
     if (opcode == x64.JAE || opcode == x64.SETAE) { ret 0x03; }
+    if (opcode == x64.SETP)  { ret 0x0A; }
+    if (opcode == x64.SETNP) { ret 0x0B; }
     ret 0x04;
 }
 
@@ -472,8 +474,11 @@ fun is_jcc(opcode: u16) bool {
     ret opcode >= x64.JE && opcode <= x64.JAE;
 }
 
-# is_setcc: true if the opcode is a conditional set.
+# is_setcc: true if the opcode is a conditional set. the SETE..SETAE block is
+# contiguous; the parity sets SETP / SETNP (the IEEE-754 float compare combine)
+# sit outside it and are named explicitly.
 fun is_setcc(opcode: u16) bool {
+    if (opcode == x64.SETP || opcode == x64.SETNP) { ret true; }
     ret opcode >= x64.SETE && opcode <= x64.SETAE;
 }
 

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -482,6 +482,8 @@ fun x64_mnemonic(op: u16) str {
     if (op == x64.SETBE)     { ret "setbe"; }
     if (op == x64.SETA)      { ret "seta"; }
     if (op == x64.SETAE)     { ret "setae"; }
+    if (op == x64.SETP)      { ret "setp"; }
+    if (op == x64.SETNP)     { ret "setnp"; }
     if (op == x64.MOVSS)     { ret "movss"; }
     if (op == x64.MOVSD)     { ret "movsd"; }
     if (op == x64.ADDSS)     { ret "addss"; }


### PR DESCRIPTION
Integration merge for the **2.2.0** release — correctness & cross-arch coverage, hardening ahead of a manual audit.

Four fixes (all merged to dev, full CI green on each):
- **#1446** (PR #1527) — x86_64 FP comparisons now IEEE-754 for NaN, matching aarch64.
- **#1174** (PR #1530) — AAPCS64 HFA/HVA float-aggregate classification (V-register placement), executed under qemu in CI.
- **#1523** (PR #1529) — `$each $fields(T)` over a generic type param defers to monomorphization (generic derive helpers; unblocks mach-std#285).
- **#1464** (PR #1528) — un-gated the aarch64 qemu test corpus + lit up the integration lane's aarch64 execution.

Plus the version bump to 2.2.0 + CHANGELOG.

**Re-seed note:** #1446 changes the compiler's own float-compare emission, so this release is intentionally **not** byte-reproducible from the 2.1.0 seed (stage1≠stage2) but converges to a byte-identical fixpoint (stage2==stage3). The release CI's 'Build to the fixpoint' step is the convergence gate; the byte-repro report is informational.

Closes #1446, #1174, #1523, #1464 (already closed on dev merge).