### PR TITLE
feat: parse #[attr] decorators (additive, alongside backticks)

### DIFF
--- a/.github/tests/attr/app/mach.toml
+++ b/.github/tests/attr/app/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "attrlin"
+name = "Attribute Decorators — Linux App"
+version = "0.0.0"
+src = "src"
+dep = "dep"
+target = "native"
+out = "out/{target}/bin/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.attrlin]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/attr/app/src/main.mach
+++ b/.github/tests/attr/app/src/main.mach
@@ -1,0 +1,23 @@
+use std.runtime.linux.x86_64;
+
+# `#[align(64)]` over-aligns the global and `#[section(...)]` lifts it out of the
+# default .data; `#[symbol(...)]` pins its link name. all three compose on one decl.
+#[align(64)]
+#[section(".attrdata")]
+#[symbol("attr_g")]
+pub var attr_g: i64 = 7;
+
+# `#[inline]` forces inlining regardless of the cost model; `#[symbol(...)]` pins
+# the link name so this build and the backtick control name the symbol identically.
+#[inline]
+#[symbol("attr_add")]
+fun attr_add(a: i64, b: i64) i64 { ret a + b; }
+
+# [this spaced-`#` line is a comment, NOT an attribute — proves the lexer exception:
+# a literal comment that begins `#[` would open an attribute, so it needs a space]
+#[section(".attrtext")]
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    # argc is 1 when run with no args: attr_add(1, 34) + attr_g == 35 + 7 == 42.
+    ret attr_add(argc, 34) + attr_g;
+}

--- a/.github/tests/attr/run.sh
+++ b/.github/tests/attr/run.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# attr integration test (#1532): prove the `#[attr]` decorator surface parses and
+# drives codegen identically to the backtick form across all five directives —
+# symbol/inline/align/section on a linux object, and library on a windows PE —
+# and that a spaced `# [...]` comment is still a comment, not an attribute.
+#
+# the backtick control for each app is *derived from the attr source by sed*
+# (`#[name(args)]` -> `` `name(args)` ``), so the two trees differ only in the
+# decorator delimiters; any divergence in an emitted artifact is therefore
+# attributable to the surface alone. the linux pair is built and run (both must
+# exit 42) and their `main.o` — code, custom sections, pinned symbols and
+# relocations — compared byte-for-byte; the windows pair is cross-built and the
+# emitted PEs compared. the attr app's `# [...]` line proves the lexer exception:
+# were `#` not de-special-cased before a space, that comment would open an
+# attribute and the build would fail.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+# absolutize a path argument: the suites cd into temp dirs, so a relative
+# compiler path would break after the first cd.
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# stage SRC DST — copy an app tree to DST under WORK and wire its vendored std.
+stage() {
+    cp -r "$1" "$2"
+    mkdir -p "$2/dep"
+    ln -s "$STD" "$2/dep/mach-std"
+}
+
+# derive_control SRC DST — stage the backtick twin: identical to SRC except every
+# `#[name(args)]` is rewritten to `` `name(args)` ``. spaced `# [...]` comments do
+# not match `#\[` and are left untouched, so only the decorator surface differs.
+derive_control() {
+    stage "$1" "$2"
+    sed -E 's/#\[([^][]*)\]/`\1`/g' "$1/src/main.mach" > "$2/src/main.mach"
+}
+
+# build APP_DIR — build a staged app, capturing output for diagnostics on failure.
+build() {
+    ( cd "$1" && "$MACH" build . ) >"$1/build.out" 2>&1
+}
+
+# --- linux pair: symbol / inline / align / section ---
+stage "$HERE/app" "$WORK/app"
+derive_control "$HERE/app" "$WORK/ctl"
+sed -i 's/attrlin/attrctl/' "$WORK/ctl/mach.toml"
+
+if ! build "$WORK/app"; then
+    echo "FAIL attr: attribute (#[...]) linux build failed" >&2
+    cat "$WORK/app/build.out" >&2
+    fail=1
+elif ! build "$WORK/ctl"; then
+    echo "FAIL attr: backtick control linux build failed" >&2
+    cat "$WORK/ctl/build.out" >&2
+    fail=1
+else
+    # the attr app carries a spaced `# [...]` comment; a clean build proves the
+    # lexer kept it a comment rather than opening an attribute.
+    echo "PASS attr: a #[...] app (with a spaced '# [...]' comment) builds clean"
+
+    set +e
+    "$WORK/app/out/linux/bin/attrlin"; ca=$?
+    "$WORK/ctl/out/linux/bin/attrctl"; cc=$?
+    set -e
+    if [ "$ca" -ne 42 ] || [ "$cc" -ne 42 ]; then
+        echo "FAIL attr: linux runtime mismatch — attr exit $ca, backtick exit $cc, expected 42" >&2
+        fail=1
+    else
+        echo "PASS attr: #[...] and backtick decls run identically (exit 42)"
+    fi
+
+    obj_a="$(find "$WORK/app/out" -name main.o | head -1)"
+    obj_c="$(find "$WORK/ctl/out" -name main.o | head -1)"
+    if [ -n "$obj_a" ] && [ -n "$obj_c" ] && cmp -s "$obj_a" "$obj_c"; then
+        echo "PASS attr: #[...] and backtick emit a byte-identical object"
+    else
+        echo "FAIL attr: #[...] and backtick objects diverged" >&2
+        fail=1
+    fi
+
+    # positive: confirm the attributes actually took effect, so the equivalence
+    # above is not two no-ops matching. `symbol` pins the link names (unmangled
+    # `attr_g`/`attr_add`), `section` creates `.attrtext`/`.attrdata`. skip the
+    # structural half if no ELF inspector is present rather than failing.
+    if command -v readelf >/dev/null 2>&1 && command -v nm >/dev/null 2>&1; then
+        secs="$(readelf -S "$obj_a" 2>/dev/null | grep -oE '\.attr[a-z]+' | sort -u | tr '\n' ' ')"
+        syms="$(nm "$obj_a" 2>/dev/null | grep -cE ' (attr_g|attr_add)$' || true)"
+        if printf '%s' "$secs" | grep -q '.attrtext' && printf '%s' "$secs" | grep -q '.attrdata' && [ "$syms" -eq 2 ]; then
+            echo "PASS attr: the symbol/section attributes took effect (sections: $secs)"
+        else
+            echo "FAIL attr: expected pinned symbols / named sections missing (sections: '$secs', symbols: $syms)" >&2
+            fail=1
+        fi
+    else
+        echo "INFO attr: no ELF inspector (readelf/nm); skipping the structural check"
+    fi
+fi
+
+# --- windows pair: library ---
+# `library` is the windows-only PE import-routing directive. cross-build the attr
+# app and its backtick twin (no run: the PE comparison needs no emulator) and
+# require the emitted binaries to be byte-identical.
+stage "$HERE/win" "$WORK/win"
+derive_control "$HERE/win" "$WORK/winctl"
+sed -i 's/attrwin/attrwinctl/' "$WORK/winctl/mach.toml"
+
+if ! build "$WORK/win"; then
+    echo "FAIL attr: attribute (#[...]) windows cross-build failed" >&2
+    cat "$WORK/win/build.out" >&2
+    fail=1
+elif ! build "$WORK/winctl"; then
+    echo "FAIL attr: backtick control windows cross-build failed" >&2
+    cat "$WORK/winctl/build.out" >&2
+    fail=1
+else
+    exe_a="$WORK/win/out/windows/bin/attrwin.exe"
+    exe_c="$WORK/winctl/out/windows/bin/attrwinctl.exe"
+    if cmp -s "$exe_a" "$exe_c"; then
+        echo "PASS attr: #[library(...)] and backtick emit a byte-identical PE"
+    else
+        echo "FAIL attr: #[library(...)] and backtick PEs diverged" >&2
+        fail=1
+    fi
+fi
+
+exit "$fail"

--- a/.github/tests/attr/win/mach.toml
+++ b/.github/tests/attr/win/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id      = "attrwin"
+name    = "Attribute Decorators — Windows library pins"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "windows"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+ext  = ".exe"
+libs = ["kernel32.dll", "ws2_32.dll", "advapi32.dll"]
+
+[bin.attrwin]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/dev"

--- a/.github/tests/attr/win/src/main.mach
+++ b/.github/tests/attr/win/src/main.mach
@@ -1,0 +1,38 @@
+use std.runtime;
+
+# `#[library(...)]` is the windows-only directive (PE import routing). this app is
+# the attribute-spelled twin of the dlllibdec backtick app: each import is pinned
+# to its DLL with `#[library(...)]` and optionally renamed with `#[symbol(...)]`.
+# the run.sh control derives the backtick form and the two emitted PEs must match.
+
+# `#[symbol]` rename only: `sleep_ms` links as `Sleep`, an unattributed import
+# that falls back to kernel32.dll (the first declared dependency).
+#[symbol("Sleep")]
+ext fun sleep_ms(ms: u32);
+
+# `#[library]` only, bare name: pinned to ws2_32.dll, linked as `WSAStartup`.
+#[library("ws2_32.dll")]
+ext fun WSAStartup(ver: u16, data: *u8) i32;
+
+# both directives on one decl: `ws2_cleanup` is renamed to `WSACleanup` and
+# pinned to ws2_32.dll — the rename and the library pin compose.
+#[library("ws2_32.dll")] #[symbol("WSACleanup")]
+ext fun ws2_cleanup() i32;
+
+# the trailing descriptor: `rng_fill` is renamed to `SystemFunction036`
+# (RtlGenRandom) and pinned to advapi32.dll.
+#[library("advapi32.dll")] #[symbol("SystemFunction036")]
+ext fun rng_fill(buf: *u8, len: u32) u8;
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    var wsadata: [512]u8;
+    sleep_ms(0);
+    if (WSAStartup(0x0202::u16, ?wsadata[0]) != 0) { ret 1; }
+    if (ws2_cleanup() != 0) { ret 2; }
+    var rnd: [32]u8;
+    var k: u64 = 0;
+    for (k < 32) { rnd[k] = 0; k = k + 1; }
+    if (rng_fill(?rnd[0], 32) == 0) { ret 3; }
+    ret 0;
+}

--- a/doc/language/README.md
+++ b/doc/language/README.md
@@ -17,7 +17,7 @@ neighboring links; start from the index below.
 ## Declarations
 
 - [visibility.md](visibility.md) — `pub` and `ext` modifiers
-- [decorators.md](decorators.md) — backtick codegen decorators (`symbol`, `library`, `inline`, `align`, `section`)
+- [decorators.md](decorators.md) — codegen decorators, `#[name]` or `` `name` `` (`symbol`, `library`, `inline`, `align`, `section`)
 - [def.md](def.md) — type alias
 - [rec.md](rec.md) — record
 - [uni.md](uni.md) — raw union and the discriminated-value convention
@@ -42,7 +42,7 @@ neighboring links; start from the index below.
 
 - [comptime.md](comptime.md) — channel overview
 - [comptime-mach.md](comptime-mach.md) — `$mach.*` compiler-owned namespace
-- [decorators.md](decorators.md) — backtick codegen decorators (replaces the removed `$sym.attr` setters)
+- [decorators.md](decorators.md) — codegen decorators, `#[name]` or `` `name` `` (replaces the removed `$sym.attr` setters)
 - [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`, `$align_of`, `$offset_of`, `$type_of`, `$fields`, `$each`, `$error`, `$assert`
 - [comptime-control.md](comptime-control.md) — `$if` / `$or`
 

--- a/doc/language/comptime-attrs.md
+++ b/doc/language/comptime-attrs.md
@@ -1,18 +1,30 @@
 # Symbol attributes
 
-In v1.7, symbol attributes are expressed as **backtick decorators** —
-leading, per-declaration codegen directives on the declared symbol. See
-[decorators.md](decorators.md) for the full reference.
+Symbol attributes are expressed as **decorators** — leading, per-declaration
+codegen directives on the declared symbol. A decorator is written in either of
+two interchangeable surfaces: the going-forward **attribute** form `#[name]` or
+the original **backtick** form `` `name` ``. Both produce the same directive;
+prefer `#[...]` in new code. See [decorators.md](decorators.md) for the full
+reference.
+
+```mach
+#[symbol("main")]
+fun entry(argc: i64, argv: **u8) i64 { ... }
+
+#[library("ws2_32.dll")] #[symbol("WSAStartup")]
+ext fun wsa_startup(ver: u16, data: *u8) i32;
+
+#[align(64)]
+pub var cache_line: u8 = 0;
+```
+
+The backtick form remains accepted this phase, so the two spellings may be
+mixed; the compiler's own source still uses backticks until the migration
+completes.
 
 ```mach
 `symbol("main")`
 fun entry(argc: i64, argv: **u8) i64 { ... }
-
-`library("ws2_32.dll")` `symbol("WSAStartup")`
-ext fun wsa_startup(ver: u16, data: *u8) i32;
-
-`align(64)`
-pub var cache_line: u8 = 0;
 ```
 
 The previous `$sym.attr = value;` setter form was removed in v2.0.0 in favor of

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -1,4 +1,4 @@
-# Backtick decorators
+# Decorators
 
 A decorator is a codegen directive attached to a declaration. It expresses
 metadata that influences how the compiler emits the symbol: its linker name,
@@ -7,14 +7,33 @@ alignment, section placement, inlining, or PE import routing.
 Decorators are **codegen-only**. Visibility (`pub` / `ext`) is separate and
 unaffected by decorators.
 
+## Surfaces
+
+A decorator is written in either of two interchangeable surfaces:
+
+```
+#[name]            # attribute form — preferred going forward
+`name`             # backtick form — original, still accepted
+```
+
+Both surfaces parse into the **same** decorator and feed the same sema and
+codegen path; only the delimiters differ. New code should prefer `#[...]`; the
+backtick form remains accepted this phase (the compiler's own source still uses
+it until the migration completes), and the two may be mixed freely. The
+examples below use the preferred `#[...]` form.
+
+> One caveat the attribute form introduces: a line comment that begins `#[`
+> (with no space) now opens an attribute. Write such a comment with a separating
+> space — `# [...]`.
+
 ## Grammar
 
 ```
-`symbol("name")`    # linker name override
-`library("dep")`    # PE import routing (ext only)
-`inline`            # force inlining (no arguments)
-`align(expr)`       # alignment; expr is a comptime integer
-`section(".name")`  # place in a named object section
+#[symbol("name")]    # linker name override
+#[library("dep")]    # PE import routing (ext only)
+#[inline]            # force inlining (no arguments)
+#[align(expr)]       # alignment; expr is a comptime integer
+#[section(".name")]  # place in a named object section
 ```
 
 Decorators appear **before** the declaration they target, one per line or
@@ -22,17 +41,18 @@ space-separated on the same line. They attach to the immediately following
 declaration only and do not bleed across declarations.
 
 ```mach
-`inline`
-`symbol("big")`
+#[inline]
+#[symbol("big")]
 fun big(a: i64, b: i64) i64 { ... }
 
-`align(64)` `symbol("g_lit64")`
+#[align(64)] #[symbol("g_lit64")]
 pub var g_lit64: u8 = 7;
 ```
 
-Each directive is wrapped in its own backtick pair: `` `name` `` for a bare
-flag or `` `name(args)` `` for a directive that takes arguments. Arguments are
-comptime expressions.
+Each directive is wrapped in its own clause: `#[name]` for a bare flag or
+`#[name(args)]` for a directive that takes arguments. Arguments are comptime
+expressions. The backtick form is the same with `` ` `` delimiters: `` `name` ``
+or `` `name(args)` ``.
 
 ## Directives
 
@@ -42,10 +62,10 @@ Overrides the emitted or imported symbol name. Applies to functions and
 globals.
 
 ```mach
-`symbol("main")`
+#[symbol("main")]
 fun entry(argc: i64, argv: **u8) i64 { ... }
 
-`symbol("write")`
+#[symbol("write")]
 ext fun libc_write(fd: i64, buf: *u8, n: i64) i64;
 ```
 
@@ -58,7 +78,7 @@ Pins an `ext` import to a specific DLL in the link's dependency set. Applies
 to `ext` functions only.
 
 ```mach
-`library("ws2_32.dll")` `symbol("WSAStartup")`
+#[library("ws2_32.dll")] #[symbol("WSAStartup")]
 ext fun wsa_startup(ver: u16, data: *u8) i32;
 ```
 
@@ -80,7 +100,7 @@ Marks a function for inlining at every call site, overriding the compiler's
 size- and use-count heuristics. Applies to functions only; takes no arguments.
 
 ```mach
-`inline`
+#[inline]
 fun fast_path(x: i64) i64 { ret x * 2; }
 ```
 
@@ -91,13 +111,13 @@ be a comptime integer — either a literal or a comptime expression such as
 `$size_of(T)` or `$align_of(T)`.
 
 ```mach
-`align(64)`
+#[align(64)]
 pub var cache_line: u8 = 0;
 
-`align($size_of(Pair))`
+#[align($size_of(Pair))]
 pub var g_cmp: u8 = 0;
 
-`align(32)`
+#[align(32)]
 rec Over { a: u8; }
 ```
 
@@ -114,10 +134,10 @@ Places a function or global variable in a named section instead of the
 default `.text` / `.data`.
 
 ```mach
-`section(".hottext")` `symbol("f_hot")`
+#[section(".hottext")] #[symbol("f_hot")]
 fun f_hot(x: i64) i64 { ret x + 1; }
 
-`section(".machsec")` `symbol("g_sec")`
+#[section(".machsec")] #[symbol("g_sec")]
 pub var g_sec: u64 = 100;
 ```
 

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -50,6 +50,7 @@ token ::= IDENT
 
 punctuation ::= "(" | ")" | "{" | "}" | "[" | "]"
               | ";" | ":" | "," | "." | "?" | "@" | "$" | "`"
+              | "#["    (* attribute-open: "#" immediately followed by "[" *)
               | "::" | ":~" | "..."
 
 operator ::= "+" | "-" | "*" | "/" | "%"
@@ -168,12 +169,15 @@ error but still produces a token span covering the rest of that line.
 ### Comments and whitespace
 
 ```ebnf
-comment    ::= "#" { any-char-except-newline }
+comment    ::= "#" { any-char-except-newline }   (* but "#[" is ATTR_OPEN, not a comment *)
 whitespace ::= " " | "\t" | "\n" | "\r"
 ```
 
 `#` begins a line comment that runs to (but not including) the next
-newline. There is no block-comment form. Whitespace and comments separate
+newline — **unless** it is immediately followed by `[`, which opens an
+attribute decorator (`#[`, `KIND_ATTR_OPEN`; see [Decorators](#decorators)).
+A literal comment that begins `#[` therefore needs a separating space
+(`# [...]`). There is no block-comment form. Whitespace and comments separate
 tokens and are otherwise discarded.
 
 ### Unexpected characters
@@ -183,8 +187,9 @@ none of the token forms above is an **unexpected character**. The lexer
 records a `LEX_ERR_UNEXPECTED_CHAR`, emits a one-byte `ERROR` token
 (`KIND_ERROR`) for it, and continues.
 
-The backtick `` ` `` is a real punctuation token (`KIND_BACKTICK`) used to
-delimit backtick decorators (see [Decorators](#decorators) below).
+The backtick `` ` `` is a real punctuation token (`KIND_BACKTICK`); `#[` is the
+two-byte attribute-open token (`KIND_ATTR_OPEN`). Both delimit decorators (see
+[Decorators](#decorators) below).
 
 
 ## Module
@@ -198,20 +203,29 @@ module ::= { decl }
 
 ## Decorators
 
-Zero or more leading backtick decorator clauses may appear before any
-declaration. Each clause is a comptime directive name, optionally followed
-by a parenthesized argument list of comptime expressions.
+Zero or more leading decorator clauses may appear before any declaration. Each
+clause is a comptime directive name, optionally followed by a parenthesized
+argument list of comptime expressions. A clause is written in either of two
+interchangeable surfaces: the backtick form `` `name(args)` `` or the attribute
+form `#[name(args)]`.
 
 ```ebnf
-decorator     ::= "`" IDENT [ "(" [ expr { "," expr } ] ")" ] "`"
-decorated-decl ::= { decorator } decl
+decorator          ::= backtick-decorator | attr-decorator
+backtick-decorator ::= "`"  IDENT [ "(" [ expr { "," expr } ] ")" ] "`"
+attr-decorator     ::= "#[" IDENT [ "(" [ expr { "," expr } ] ")" ] "]"
+decorated-decl     ::= { decorator } decl
 ```
 
+- Both surfaces produce the **same** decorator and feed the same sema /
+  codegen path; only the delimiters differ. `#[name]` is the going-forward
+  preferred form; backticks remain accepted (the compiler's own source still
+  uses them this phase).
 - Decorators attach to the **immediately following** declaration and do not
   bleed across declarations.
-- Multiple decorators may appear on the same line (space-separated) or one
-  per line.
-- The argument list is optional; a bare `` `inline` `` carries no arguments.
+- The two surfaces may be mixed freely, on the same line (space-separated) or
+  one per line.
+- The argument list is optional; a bare `#[inline]` / `` `inline` `` carries no
+  arguments.
 - Arguments are comptime expressions (not types): `$size_of(T)` is a valid
   argument; `T` as a raw type name is not.
 - The closed directive set is `symbol`, `section`, `inline`, `align`,
@@ -670,12 +684,14 @@ disambiguated from a regular member access `v.name` by the `[` lookahead:
 Productions verified directly against the parser source:
 
 - **Lexical grammar** — `lexer.mach` / `token.mach`: token set (incl.
-  `KIND_BACKTICK`), operator maximal-munch, number/char/string scanning and
-  escapes, comment and whitespace handling, the "keywords are `IDENT`s" model.
+  `KIND_BACKTICK` and `KIND_ATTR_OPEN`), operator maximal-munch,
+  number/char/string scanning and escapes, comment and whitespace handling
+  (incl. the `#[` attribute-open exception), the "keywords are `IDENT`s" model.
 - **Precedence ladder** — `token.infix_precedence` / `token.is_right_assoc`
   (the table is a direct transcription; only `=` is right-associative).
 - **Decorators** — `parser/decl.mach` `parse_decorators` / `parse_one_decorator`:
-  leading `` `name` `` / `` `name(args)` `` clauses, closed directive set.
+  leading `` `name(args)` `` and `#[name(args)]` clauses (both surfaces converge
+  on one Decorator node), closed directive set.
 - **Declarations** — `parser/decl.mach`: `use`, `fwd` (incl. `pub fwd`
   rejection), `fun` (generics, params, variadic `...`, named pack `name: ...`,
   comptime `$` params, optional return type, block-or-`;` body), `rec`, `uni`,
@@ -711,8 +727,8 @@ Doc-only (intended surface, not a distinct parser production):
   `$type_of`, `$fields`, `$error`, `$assert`) — syntactically
   indistinguishable from any other `comptime-ident` call.
 - The closed decorator directive set (`symbol`, `library`, `inline`, `align`,
-  `section`) — the parser accepts any `IDENT` after `` ` ``; sema enforces
-  the closed set.
+  `section`) — the parser accepts any `IDENT` after `` ` `` or `#[`; sema
+  enforces the closed set.
 
 Divergences flagged inline:
 

--- a/src/lang/fe/ast/decl.mach
+++ b/src/lang/fe/ast/decl.mach
@@ -184,7 +184,7 @@ pub rec Decorator {
 # kind:            which DECL_KIND_* variant is active
 # flags:           bitfield of DECL_FLAG_* values (pub, ext)
 # decorators_start: start index into ast.decorators of this decl's leading decorators
-# decorators_len:  number of leading backtick decorators (0 if none)
+# decorators_len:  number of leading decorators, backtick or `#[...]` (0 if none)
 # data:            kind-specific payload; unused for ERROR (discriminated by kind alone)
 pub rec Decl {
     span:  token.Span;

--- a/src/lang/fe/lexer.mach
+++ b/src/lang/fe/lexer.mach
@@ -98,7 +98,10 @@ pub fun tokenize(source: str, alloc: *Allocator, file_id: src.FileId) Result[Tok
             cnt;
         }
 
-        if (c == '#') {
+        # `#` immediately followed by `[` opens an attribute decorator (#1532);
+        # any other `#` is a line comment to end-of-line. a literal comment that
+        # begins `#[` therefore needs an intervening space (`# [...]`).
+        if (c == '#' && source[pos + 1] != '[') {
             for (source[pos] != 0 && source[pos] != '\n') {
                 pos = pos + 1;
             }
@@ -126,6 +129,9 @@ pub fun tokenize(source: str, alloc: *Allocator, file_id: src.FileId) Result[Tok
         or (c == '%')  { tok = token.make(token.KIND_PERCENT,  pos, 1); pos = pos + 1; }
         or (c == '^')  { tok = token.make(token.KIND_CARET,    pos, 1); pos = pos + 1; }
         or (c == '`')  { tok = token.make(token.KIND_BACKTICK, pos, 1); pos = pos + 1; }
+        # reaching here with `#` means the comment guard let it through, so the
+        # next byte is `[`: emit the two-byte attribute-open token.
+        or (c == '#')  { tok = token.make(token.KIND_ATTR_OPEN, pos, 2); pos = pos + 2; }
         or (c == ':')  {
             if (source[pos + 1] == ':') {
                 tok = token.make(token.KIND_COLON_COLON, pos, 2);
@@ -556,6 +562,43 @@ test "lexer: a backtick lexes as KIND_BACKTICK (#1476)" {
     }
 
     dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "lexer: `#[` lexes as KIND_ATTR_OPEN while a spaced `#` stays a comment (#1532)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    # (1) `#[` opens an attribute: a single 2-byte token then EOF, no lex error
+    val tr1: Result[TokenStream, str] = tokenize("#[", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr1)) { ret 1; }
+    var s1: TokenStream = unwrap_ok[TokenStream, str](tr1);
+    var rc: i32 = 0;
+    if (s1.len != 2)        { rc = 1; }
+    or (s1.error_len != 0)  { rc = 1; }
+    or {
+        if (s1.tokens[0].kind != token.KIND_ATTR_OPEN) { rc = 1; }
+        or (s1.tokens[0].span.offset != 0)             { rc = 1; }
+        or (s1.tokens[0].span.len    != 2)             { rc = 1; }
+    }
+    dnit(?s1, ?alloc);
+    if (rc != 0) { ret rc; }
+
+    # (2) `# [...]` with a space is still a line comment: only EOF survives
+    val tr2: Result[TokenStream, str] = tokenize("# [not an attr]", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr2)) { ret 1; }
+    var s2: TokenStream = unwrap_ok[TokenStream, str](tr2);
+    if (s2.len != 1)                         { rc = 1; }
+    or (s2.tokens[0].kind != token.KIND_EOF) { rc = 1; }
+    dnit(?s2, ?alloc);
+    if (rc != 0) { ret rc; }
+
+    # (3) a plain `#` comment runs to EOL; the token on the next line still lexes
+    val tr3: Result[TokenStream, str] = tokenize("# comment\nval", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr3)) { ret 1; }
+    var s3: TokenStream = unwrap_ok[TokenStream, str](tr3);
+    if (s3.tokens[0].kind != token.KIND_IDENT) { rc = 1; }
+    dnit(?s3, ?alloc);
     ret rc;
 }
 

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -75,7 +75,7 @@ pub fun parse_module(p: *parser.Parser) id.ModuleId {
 }
 
 # parse_decl: parses a single top-level declaration, including any leading
-# backtick decorators that attach to it.
+# decorators (backtick or `#[...]`) that attach to it.
 # ---
 # p:   parser state positioned at the first token of the declaration
 # ret: DeclId of the parsed declaration, or DECL_NIL on failure
@@ -100,7 +100,7 @@ pub fun parse_decl(p: *parser.Parser) id.DeclId {
 # parse_decl_dispatch: dispatches on the leading `$` or keyword (after any
 # decorators) to the matching declaration parser, or reports an error and
 # yields an ERROR decl. `start` spans the declaration's first token (a
-# decorator backtick when decorators are present).
+# decorator's opening backtick or `#[` when decorators are present).
 fun parse_decl_dispatch(p: *parser.Parser, start: token.Span) id.DeclId {
     if (parser.at(p, token.KIND_DOLLAR))  { ret parse_comptime_decl(p, start); }
 
@@ -124,13 +124,14 @@ fun parse_decl_dispatch(p: *parser.Parser, start: token.Span) id.DeclId {
     ret parser.push_decl(p, err);
 }
 
-# parse_decorators: parses zero or more leading `` `name(args)` `` / `` `flag` ``
-# backtick decorator clauses, appending each to ast.decorators as one contiguous
-# block. writes the block length through `out_len` and returns its start index.
+# parse_decorators: parses zero or more leading decorator clauses in either
+# surface — `` `name(args)` `` backticks or `#[name(args)]` attributes (#1532) —
+# appending each to ast.decorators as one contiguous block. writes the block
+# length through `out_len` and returns its start index.
 fun parse_decorators(p: *parser.Parser, out_len: *u32) u32 {
     val start: u32 = p.ast.decorator_len::u32;
     var count: u32 = 0;
-    for (parser.at(p, token.KIND_BACKTICK)) {
+    for (parser.at(p, token.KIND_BACKTICK) || parser.at(p, token.KIND_ATTR_OPEN)) {
         if (!parse_one_decorator(p)) { brk; }
         count = count + 1;
     }
@@ -138,14 +139,21 @@ fun parse_decorators(p: *parser.Parser, out_len: *u32) u32 {
     ret start;
 }
 
-# parses a single `` `name` `` or `` `name(args)` `` clause and appends it to
-# ast.decorators. the directive name and any comptime-expr arguments are
-# validated later in sema; the parser only records the syntax.
+# parses a single decorator clause — `` `name` ``/`` `name(args)` `` or its
+# `#[name]`/`#[name(args)]` attribute equivalent — and appends it to
+# ast.decorators. both surfaces converge on the same Decorator node; the
+# directive name and any comptime-expr arguments are validated later in sema,
+# so only the closing delimiter differs by surface.
 fun parse_one_decorator(p: *parser.Parser) bool {
+    val attr: bool = parser.at(p, token.KIND_ATTR_OPEN);
     parser.advance(p);
 
     if (!parser.at(p, token.KIND_IDENT)) {
-        parser.error_at_current(p, "expected decorator name after '`'");
+        if (attr) {
+            parser.error_at_current(p, "expected attribute name after '#['");
+        } or {
+            parser.error_at_current(p, "expected decorator name after '`'");
+        }
         ret false;
     }
     val name: token.Span = parser.advance(p).span;
@@ -156,7 +164,11 @@ fun parse_one_decorator(p: *parser.Parser) bool {
         args_start = parse_decorator_args(p, ?args_len);
     }
 
-    parser.expect(p, token.KIND_BACKTICK, "expected closing '`' to end decorator");
+    if (attr) {
+        parser.expect(p, token.KIND_RBRACKET, "expected closing ']' to end attribute");
+    } or {
+        parser.expect(p, token.KIND_BACKTICK, "expected closing '`' to end decorator");
+    }
 
     var d: decl.Decorator;
     d.name       = name;
@@ -1442,5 +1454,82 @@ test "parser: an unterminated backtick decorator reports an error (#1476)" {
     if (!t_parse_module_has_errors("`inline fun f() {}")) { ret 1; }
     # a backtick with no directive name must diagnose
     if (!t_parse_module_has_errors("`` fun f() {}")) { ret 1; }
+    ret 0;
+}
+
+test "parser: leading #[...] attributes attach with the same AST as backticks (#1532)" {
+    # `#[inline]` (bare flag) and `#[symbol("_start")]` (one comptime-expr arg)
+    # attach to `f`; `g` has none — the same shape the backtick form produces.
+    var alloc: Allocator;
+    page.make(?alloc);
+    val source: str = "#[inline] #[symbol(\"_start\")] fun f() {} fun g() {}";
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize(source, ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+    parse_module(?p);
+
+    var rc: i32 = 0;
+    if      (diag.has_errors(?diags))               { rc = 1; }
+    or      (a.decl_len < 2)                        { rc = 1; }
+    or      (a.decls[0].kind != decl.DECL_KIND_FUN) { rc = 1; }
+    or      (a.decls[1].kind != decl.DECL_KIND_FUN) { rc = 1; }
+    or      (a.decls[0].decorators_len != 2)        { rc = 1; }
+    or      (a.decls[1].decorators_len != 0)        { rc = 1; }
+
+    if (rc == 0) {
+        val d0: decl.Decorator = a.decorators[a.decls[0].decorators_start];
+        val d1: decl.Decorator = a.decorators[a.decls[0].decorators_start + 1];
+        if (!str_region_equals(p.tokens.source, d0.name.offset, d0.name.len, "inline")) { rc = 1; }
+        if (d0.args_len != 0)                                                           { rc = 1; }
+        if (!str_region_equals(p.tokens.source, d1.name.offset, d1.name.len, "symbol")) { rc = 1; }
+        if (d1.args_len != 1)                                                           { rc = 1; }
+    }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "parser: backtick and #[...] decorators mix on one decl (#1532)" {
+    # both surfaces may precede the same decl and accumulate into one block.
+    var alloc: Allocator;
+    page.make(?alloc);
+    val source: str = "`inline` #[symbol(\"_start\")] fun f() {}";
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize(source, ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+    parse_module(?p);
+
+    var rc: i32 = 0;
+    if      (diag.has_errors(?diags))        { rc = 1; }
+    or      (a.decl_len < 1)                 { rc = 1; }
+    or      (a.decls[0].decorators_len != 2) { rc = 1; }
+
+    if (rc == 0) {
+        val d0: decl.Decorator = a.decorators[a.decls[0].decorators_start];
+        val d1: decl.Decorator = a.decorators[a.decls[0].decorators_start + 1];
+        if (!str_region_equals(p.tokens.source, d0.name.offset, d0.name.len, "inline")) { rc = 1; }
+        if (!str_region_equals(p.tokens.source, d1.name.offset, d1.name.len, "symbol")) { rc = 1; }
+        if (d1.args_len != 1)                                                           { rc = 1; }
+    }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "parser: a malformed #[...] attribute reports an error (#1532)" {
+    # a directive name with no closing `]` must diagnose, not silently parse
+    if (!t_parse_module_has_errors("#[inline fun f() {}")) { ret 1; }
+    # `#[]` with no directive name must diagnose
+    if (!t_parse_module_has_errors("#[] fun f() {}")) { ret 1; }
     ret 0;
 }

--- a/src/lang/fe/token.mach
+++ b/src/lang/fe/token.mach
@@ -62,6 +62,10 @@ pub val KIND_COLON_TILDE: Kind = 42;
 # leading per-declaration codegen decorator marker (#1476): `` `name(args)` ``
 pub val KIND_BACKTICK: Kind = 43;
 
+# `#[` opening an attribute decorator (#1532): `#[name(args)]`, the going-forward
+# surface for the same Decorator clause as the backtick form.
+pub val KIND_ATTR_OPEN: Kind = 44;
+
 pub val KIND_EOF:   Kind = 254;
 pub val KIND_ERROR: Kind = 255;
 
@@ -145,6 +149,7 @@ pub fun kind_str(kind: Kind) str {
     if (kind == KIND_COLON_TILDE) { ret ":~"; }
     if (kind == KIND_DOT_DOT_DOT) { ret "..."; }
     if (kind == KIND_BACKTICK)    { ret "`"; }
+    if (kind == KIND_ATTR_OPEN)   { ret "#["; }
     if (kind == KIND_EOF)         { ret "eof"; }
     if (kind == KIND_ERROR)       { ret "error"; }
     ret "unknown";


### PR DESCRIPTION
Phase 1 of the `#[attr]` decorator migration (epic #1526). Adds `#[attr]` decorator parsing **alongside** the existing backtick decorators — additive and fully backward-compatible. The compiler's own source stays on backticks this phase, so the v2.2.0 seed still builds it; the v2.4.0 collapse migrates all source and removes backticks.

## Approach

- **Lexer** (`token.mach` / `lexer.mach`): new `KIND_ATTR_OPEN` token. `#` *immediately* followed by `[` consumes `#[` and emits `KIND_ATTR_OPEN`; any other `#` stays a line comment to end-of-line exactly as before. A literal comment beginning `#[` now needs a space (`# [...]`).
- **Parser** (`parser/decl.mach`): the decorator-clause loop accepts both surfaces — backtick `` `name(args)` `` and `#[name(args)]` closed by `]` — converging on the **same** `Decorator` AST node. Sema/resolve/validate are untouched; only the surface parse differs. Backtick parsing is unchanged.

## Tests

- Inline lexer/parser unit tests for `#[`, the spaced-comment exception, mixed backtick + `#[...]`, and malformed-attribute diagnostics.
- `.github/tests/attr/` integration suite proving `#[symbol/library/align/section/inline]` produce behavior identical to the backtick form, and that `# [comment]` stays a comment.

## Docs

`comptime-attrs.md`, `decorators.md`, `grammar.md` updated to document `#[attr]` as the going-forward preferred form, with backticks still accepted this phase.

## Verify

Self-host fixpoint stays byte-reproducible from the v2.2.0 seed (stage1 == stage2) — the compiler source is unchanged (still backticks), so its emission does not move.

Closes #1532