### PR TITLE
feat: collapse decorators to #[attr] — migrate source + remove backtick parsing

### DIFF
--- a/.github/tests/aarch64enc/app/src/main.mach
+++ b/.github/tests/aarch64enc/app/src/main.mach
@@ -14,7 +14,7 @@
 
 # a global the program both reads/writes (LDST*_LO12) and takes the address of
 # (ADD_LO12), forcing the ADRP page-relative pair on every access.
-`symbol("counter")`
+#[symbol("counter")]
 var counter: i64 = 0;
 
 # a defined callee — the `bl` to it emits R_AARCH64_CALL26.
@@ -29,7 +29,7 @@ fun sink(p: *i64) i64 {
 }
 
 # the ELF entry point; named `_start` so the link needs no external runtime.
-`symbol("_start")`
+#[symbol("_start")]
 pub fun _start() i64 {
     counter = helper(counter);
     ret sink(?counter);

--- a/.github/tests/aarch64hfa/app/src/main.mach
+++ b/.github/tests/aarch64hfa/app/src/main.mach
@@ -45,7 +45,7 @@ fun spill(a: f32, b: f32, c: f32, d: f32, e: f32, f: f32, g: f32, v: V2f) f64 {
     ret a::f64 + b::f64 + c::f64 + d::f64 + e::f64 + f::f64 + g::f64 + v.x::f64 + v.y::f64;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     var v2: V2f; v2.x = 1.0; v2.y = 2.0;
     if (sum_v2(v2) != 3.0) { ret 1; }

--- a/.github/tests/aarch64run/app/src/main.mach
+++ b/.github/tests/aarch64run/app/src/main.mach
@@ -17,7 +17,7 @@ fun scale(b: *Box, factor: f64) f64 {
     ret b.val * factor;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # f64 array-element load feeding an FP add.
     var tbl: [4]f64;

--- a/.github/tests/absout/app/src/main.mach
+++ b/.github/tests/absout/app/src/main.mach
@@ -1,4 +1,4 @@
 use std.runtime.linux.x86_64;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/aligndec/app/src/main.mach
+++ b/.github/tests/aligndec/app/src/main.mach
@@ -1,33 +1,33 @@
 use std.runtime.linux.x86_64;
 
 # `$size_of(Pair)` is a comptime expression that folds to 16, proving an
-# `align(...)` decorator accepts a comptime-expr argument, not just a literal.
+# `#[align(...)]` decorator accepts a comptime-expr argument, not just a literal.
 rec Pair { a: u64; b: u64; }
 
 # a literal alignment that differs from the 8-byte default, so it is observable.
-`align(64)` `symbol("g_lit64")`
+#[align(64)] #[symbol("g_lit64")]
 pub var g_lit64: u8 = 7;
 
 # a comptime-expr alignment, also observably different from the default. this is
 # the discriminating comptime-expr case: 16 != the 8-byte default, so it fails if
 # the decorator is ignored. (`$align_of(u64)` folds to 8 — equal to the default,
 # so it could never discriminate; the natural alignment of any type is <= 8.)
-`align($size_of(Pair))` `symbol("g_cmp16")`
+#[align($size_of(Pair))] #[symbol("g_cmp16")]
 pub var g_cmp16: u8 = 9;
 
 # no decorator: the back end's default section alignment (8) applies.
-`symbol("g_plain")`
+#[symbol("g_plain")]
 pub var g_plain: u8 = 11;
 
-# an `align(...)` decorator on a TYPE raises the type's own alignment and size; a
+# an `#[align(...)]` decorator on a TYPE raises the type's own alignment and size; a
 # global of that type inherits the alignment, observable on the global's section.
-`align(32)`
+#[align(32)]
 rec Over { a: u8; }
 
-`symbol("g_over")`
+#[symbol("g_over")]
 pub var g_over: Over;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # alignment-dependent runtime probe: each over-aligned global's actual address
     # must satisfy its requested alignment. this proves the layout even where the

--- a/.github/tests/aligndec/run.sh
+++ b/.github/tests/aligndec/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# align decorator integration test (#1476): prove an `align(...)` decorator sets
+# align decorator integration test (#1476): prove an `#[align(...)]` decorator sets
 # the emitted alignment of a global, including the acceptance-criteria case of a
-# comptime-expr argument (`align($size_of(Pair))` folding to 16).
+# comptime-expr argument (`#[align($size_of(Pair))]` folding to 16).
 #
 # each decorated global lands in its own data section whose `sh_addralign` is the
 # requested alignment; the object file carries the per-symbol section header that
@@ -79,7 +79,7 @@ if command -v readelf >/dev/null 2>&1 && [ -f "$OBJ" ]; then
     expect_align g_lit64 64
     expect_align g_cmp16 16
     expect_align g_plain 8
-    # a global of an `align(32)` record inherits the type's raised alignment.
+    # a global of an `#[align(32)]` record inherits the type's raised alignment.
     expect_align g_over  32
 else
     echo "INFO aligndec: readelf unavailable or object missing; skipping the alignment check"

--- a/.github/tests/asmcarry/app/src/main.mach
+++ b/.github/tests/asmcarry/app/src/main.mach
@@ -74,10 +74,10 @@ fun jnc_cf1(a: u64, b: u64) u64 {
 # unmangled branch target for the jc/jnc relocations. never reached at runtime
 # (every branch above falls through); the call in main keeps the symbol live so
 # the inline-asm PC32 relocations against its literal name resolve.
-`symbol("asmcarry_never")`
+#[symbol("asmcarry_never")]
 fun never() u64 { ret 99; }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # setc: 1 < 2 borrows (CF=1) -> 1; 5 >= 3 no borrow (CF=0) -> 0.
     if (carry_bit(1, 2) != 1) { ret 1; }

--- a/.github/tests/asmclobber/app/src/main.mach
+++ b/.github/tests/asmclobber/app/src/main.mach
@@ -37,7 +37,7 @@ fun caller(seed: i64) i64 {
     ret held + r;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # clobber(1) == 43; the bug returned 999.
     if (clobber(1) != 43) { ret 1; }

--- a/.github/tests/asmcomment/app/src/main.mach
+++ b/.github/tests/asmcomment/app/src/main.mach
@@ -23,7 +23,7 @@ fun add_via_asm(a: i64, b: i64) i64 {
     ret result;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # add_via_asm(40, 2) == 42; a phantom instruction or stray binding fails the
     # build, and a mis-substitution would corrupt the result.

--- a/.github/tests/asmlocal/app/src/main.mach
+++ b/.github/tests/asmlocal/app/src/main.mach
@@ -81,7 +81,7 @@ fun redef_back() u64 {
     ret out;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     if (sum_to(5) != 15) { ret 1; }
     if (fwd(3, 9) != 9) { ret 2; }

--- a/.github/tests/asmlocal/bad/src/main.mach
+++ b/.github/tests/asmlocal/bad/src/main.mach
@@ -15,7 +15,7 @@ fun undefined_ref() u64 {
     ret out;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret undefined_ref()::i64;
 }

--- a/.github/tests/attr/app/src/main.mach
+++ b/.github/tests/attr/app/src/main.mach
@@ -8,7 +8,7 @@ use std.runtime.linux.x86_64;
 pub var attr_g: i64 = 7;
 
 # `#[inline]` forces inlining regardless of the cost model; `#[symbol(...)]` pins
-# the link name so this build and the backtick control name the symbol identically.
+# the link name so `attr_add` links unmangled.
 #[inline]
 #[symbol("attr_add")]
 fun attr_add(a: i64, b: i64) i64 { ret a + b; }

--- a/.github/tests/attr/run.sh
+++ b/.github/tests/attr/run.sh
@@ -1,18 +1,16 @@
 #!/usr/bin/env bash
-# attr integration test (#1532): prove the `#[attr]` decorator surface parses and
-# drives codegen identically to the backtick form across all five directives —
-# symbol/inline/align/section on a linux object, and library on a windows PE —
-# and that a spaced `# [...]` comment is still a comment, not an attribute.
+# attr integration test (#1532, #1526): prove the `#[attr]` decorator surface — the
+# sole decorator form since v2.4.0 (backtick decorators removed) — parses and drives
+# codegen across all five directives: symbol/inline/align/section on a linux object
+# and library on a windows PE, with every directive composing on a single decl. also
+# proves the lexer exception: a spaced `# [...]` line stays a comment, not an
+# attribute (were `#` not de-special-cased before a space, that line would open an
+# attribute and the build would fail).
 #
-# the backtick control for each app is *derived from the attr source by sed*
-# (`#[name(args)]` -> `` `name(args)` ``), so the two trees differ only in the
-# decorator delimiters; any divergence in an emitted artifact is therefore
-# attributable to the surface alone. the linux pair is built and run (both must
-# exit 42) and their `main.o` — code, custom sections, pinned symbols and
-# relocations — compared byte-for-byte; the windows pair is cross-built and the
-# emitted PEs compared. the attr app's `# [...]` line proves the lexer exception:
-# were `#` not de-special-cased before a space, that comment would open an
-# attribute and the build would fail.
+# the linux app is built and run (must exit 42), then its `main.o` is inspected to
+# confirm the attributes took effect — pinned symbols (`attr_g`/`attr_add`, unmangled)
+# and named sections (`.attrtext`/`.attrdata`). the windows app cross-builds the
+# `#[library(...)]`-routed imports into a PE (no run: the routing is structural).
 #
 # usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -42,61 +40,37 @@ stage() {
     ln -s "$STD" "$2/dep/mach-std"
 }
 
-# derive_control SRC DST — stage the backtick twin: identical to SRC except every
-# `#[name(args)]` is rewritten to `` `name(args)` ``. spaced `# [...]` comments do
-# not match `#\[` and are left untouched, so only the decorator surface differs.
-derive_control() {
-    stage "$1" "$2"
-    sed -E 's/#\[([^][]*)\]/`\1`/g' "$1/src/main.mach" > "$2/src/main.mach"
-}
-
 # build APP_DIR — build a staged app, capturing output for diagnostics on failure.
 build() {
     ( cd "$1" && "$MACH" build . ) >"$1/build.out" 2>&1
 }
 
-# --- linux pair: symbol / inline / align / section ---
+# --- linux app: symbol / inline / align / section ---
 stage "$HERE/app" "$WORK/app"
-derive_control "$HERE/app" "$WORK/ctl"
-sed -i 's/attrlin/attrctl/' "$WORK/ctl/mach.toml"
 
 if ! build "$WORK/app"; then
     echo "FAIL attr: attribute (#[...]) linux build failed" >&2
     cat "$WORK/app/build.out" >&2
     fail=1
-elif ! build "$WORK/ctl"; then
-    echo "FAIL attr: backtick control linux build failed" >&2
-    cat "$WORK/ctl/build.out" >&2
-    fail=1
 else
-    # the attr app carries a spaced `# [...]` comment; a clean build proves the
-    # lexer kept it a comment rather than opening an attribute.
+    # the app carries a spaced `# [...]` comment; a clean build proves the lexer
+    # kept it a comment rather than opening an attribute.
     echo "PASS attr: a #[...] app (with a spaced '# [...]' comment) builds clean"
 
     set +e
     "$WORK/app/out/linux/bin/attrlin"; ca=$?
-    "$WORK/ctl/out/linux/bin/attrctl"; cc=$?
     set -e
-    if [ "$ca" -ne 42 ] || [ "$cc" -ne 42 ]; then
-        echo "FAIL attr: linux runtime mismatch — attr exit $ca, backtick exit $cc, expected 42" >&2
+    if [ "$ca" -ne 42 ]; then
+        echo "FAIL attr: linux runtime mismatch — exit $ca, expected 42" >&2
         fail=1
     else
-        echo "PASS attr: #[...] and backtick decls run identically (exit 42)"
+        echo "PASS attr: the #[...] app runs (exit 42)"
     fi
 
     obj_a="$(find "$WORK/app/out" -name main.o | head -1)"
-    obj_c="$(find "$WORK/ctl/out" -name main.o | head -1)"
-    if [ -n "$obj_a" ] && [ -n "$obj_c" ] && cmp -s "$obj_a" "$obj_c"; then
-        echo "PASS attr: #[...] and backtick emit a byte-identical object"
-    else
-        echo "FAIL attr: #[...] and backtick objects diverged" >&2
-        fail=1
-    fi
-
-    # positive: confirm the attributes actually took effect, so the equivalence
-    # above is not two no-ops matching. `symbol` pins the link names (unmangled
-    # `attr_g`/`attr_add`), `section` creates `.attrtext`/`.attrdata`. skip the
-    # structural half if no ELF inspector is present rather than failing.
+    # confirm the attributes actually took effect: `symbol` pins the link names
+    # (unmangled `attr_g`/`attr_add`), `section` creates `.attrtext`/`.attrdata`.
+    # skip the structural half if no ELF inspector is present rather than failing.
     if command -v readelf >/dev/null 2>&1 && command -v nm >/dev/null 2>&1; then
         secs="$(readelf -S "$obj_a" 2>/dev/null | grep -oE '\.attr[a-z]+' | sort -u | tr '\n' ' ')"
         syms="$(nm "$obj_a" 2>/dev/null | grep -cE ' (attr_g|attr_add)$' || true)"
@@ -111,29 +85,21 @@ else
     fi
 fi
 
-# --- windows pair: library ---
-# `library` is the windows-only PE import-routing directive. cross-build the attr
-# app and its backtick twin (no run: the PE comparison needs no emulator) and
-# require the emitted binaries to be byte-identical.
+# --- windows app: library ---
+# `library` is the windows-only PE import-routing directive. cross-build the app
+# (no run: the routing is structural, no emulator needed) and require a clean build.
 stage "$HERE/win" "$WORK/win"
-derive_control "$HERE/win" "$WORK/winctl"
-sed -i 's/attrwin/attrwinctl/' "$WORK/winctl/mach.toml"
 
 if ! build "$WORK/win"; then
     echo "FAIL attr: attribute (#[...]) windows cross-build failed" >&2
     cat "$WORK/win/build.out" >&2
     fail=1
-elif ! build "$WORK/winctl"; then
-    echo "FAIL attr: backtick control windows cross-build failed" >&2
-    cat "$WORK/winctl/build.out" >&2
-    fail=1
 else
     exe_a="$WORK/win/out/windows/bin/attrwin.exe"
-    exe_c="$WORK/winctl/out/windows/bin/attrwinctl.exe"
-    if cmp -s "$exe_a" "$exe_c"; then
-        echo "PASS attr: #[library(...)] and backtick emit a byte-identical PE"
+    if [ -f "$exe_a" ]; then
+        echo "PASS attr: #[library(...)] imports cross-build into a PE"
     else
-        echo "FAIL attr: #[library(...)] and backtick PEs diverged" >&2
+        echo "FAIL attr: windows build produced no PE at $exe_a" >&2
         fail=1
     fi
 fi

--- a/.github/tests/attr/win/src/main.mach
+++ b/.github/tests/attr/win/src/main.mach
@@ -1,9 +1,8 @@
 use std.runtime;
 
-# `#[library(...)]` is the windows-only directive (PE import routing). this app is
-# the attribute-spelled twin of the dlllibdec backtick app: each import is pinned
-# to its DLL with `#[library(...)]` and optionally renamed with `#[symbol(...)]`.
-# the run.sh control derives the backtick form and the two emitted PEs must match.
+# `#[library(...)]` is the windows-only directive (PE import routing). each import
+# is pinned to its DLL with `#[library(...)]` and optionally renamed with
+# `#[symbol(...)]`; run.sh cross-builds this into a PE.
 
 # `#[symbol]` rename only: `sleep_ms` links as `Sleep`, an unattributed import
 # that falls back to kernel32.dll (the first declared dependency).

--- a/.github/tests/cffi/app/src/main.mach
+++ b/.github/tests/cffi/app/src/main.mach
@@ -25,7 +25,7 @@ fun near(a: f64, b: f64) i64 {
     ret 0;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # {f64,f64} argument in XMM0:XMM1.
     val v: Vec2 = Vec2{ x: 3.0, y: 4.0 };

--- a/.github/tests/comptimedispatch/clean/src/main.mach
+++ b/.github/tests/comptimedispatch/clean/src/main.mach
@@ -28,7 +28,7 @@ fun show(va: ...) u64 {
 
 # exits 0 only when the dispatch routed each element to its own arm: 42 (u64) +
 # 1 (a non-nil str) == 43.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     val n: u64 = show(42::u64, "hello");
     if (n != 43) { ret 1; }

--- a/.github/tests/comptimedispatch/unhandled/src/main.mach
+++ b/.github/tests/comptimedispatch/unhandled/src/main.mach
@@ -26,7 +26,7 @@ fun show(va: ...) u64 {
 }
 
 # `7::i32` is handled by no arm, so the `$or {}` arm's `$error` fires at build time.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     val n: u64 = show(42::u64, 7::i32);
     ret 0;

--- a/.github/tests/comptimeroots/altapp/src/main.mach
+++ b/.github/tests/comptimeroots/altapp/src/main.mach
@@ -5,7 +5,7 @@ use std.types.string.str_equals;
 # to this manifest's declared values — distinct from the other app's, proving the
 # roots come from the manifest and are not hardcoded. exits 0 only when every root
 # matches; a mismatch returns the drifted root's id.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     if (!str_equals($project.version, "2.4.6")) { ret 1; }
     if (!str_equals($project.id, "ctrootsv1"))  { ret 2; }

--- a/.github/tests/comptimeroots/app/src/main.mach
+++ b/.github/tests/comptimeroots/app/src/main.mach
@@ -5,7 +5,7 @@ use std.types.string.str_equals;
 # must fold to this v2 manifest's declared values and the selected artifact's
 # name. exits 0 only when every root matches; a mismatch returns the drifted
 # root's id.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     if (!str_equals($project.version, "3.1.4")) { ret 1; }
     if (!str_equals($project.id, "ctrootsv2"))  { ret 2; }

--- a/.github/tests/comptimeroots/bareident_gate/src/main.mach
+++ b/.github/tests/comptimeroots/bareident_gate/src/main.mach
@@ -4,7 +4,7 @@ use std.runtime.linux.x86_64;
 # channel shapes (#1249): comptime parameters are referenced without `$`, and
 # comptime paths are rooted. the build must reject it with the one teaching
 # diagnostic owned by comptime.eval — never fold it nor compile.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     $if ($mode) { ret 1; }
     ret 0;

--- a/.github/tests/comptimeroots/bareident_value/src/main.mach
+++ b/.github/tests/comptimeroots/bareident_value/src/main.mach
@@ -4,7 +4,7 @@ use std.runtime.linux.x86_64;
 # channel shapes (#1249): comptime parameters are referenced without `$`, and
 # comptime paths are rooted. sema defers to comptime.eval's one rejection rule,
 # so the build must fail with the same teaching diagnostic as the gate case.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     val x: i64 = $mode;
     ret x;

--- a/.github/tests/comptimeroots/machabi/src/main.mach
+++ b/.github/tests/comptimeroots/machabi/src/main.mach
@@ -6,7 +6,7 @@ use std.types.string.str_equals;
 # (sysv), so the build facts fold to the matching tags, the three abi tags are
 # pairwise distinct, and `$mach.version` agrees with `$mach.compiler.version`.
 # exits 0 only when every comptime fold matches; a mismatch returns a distinct id.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # the resolved active build's facts fold to the matching tags
     $if ($mach.build.abi == $mach.abi.sysv)     { } $or { ret 1; }

--- a/.github/tests/ctcmp/app/src/main.mach
+++ b/.github/tests/ctcmp/app/src/main.mach
@@ -33,7 +33,7 @@ fun agree(ct_lt: u8, ct_eq: u8, ct_gt: u8, rt_lt: u8, rt_eq: u8, rt_gt: u8, base
     ret 0;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # non-foldable zeros: argc is >= 1, so each is 0 but opaque to const folding,
     # forcing the runtime comparisons through the back end instead of the folder.

--- a/.github/tests/decarg/branch/src/main.mach
+++ b/.github/tests/decarg/branch/src/main.mach
@@ -8,9 +8,9 @@ use std.runtime.linux.x86_64;
 val FLAG: i64 = 1;
 
 $if (FLAG == 1) {
-    `section(NoSuchThing)`
+    #[section(NoSuchThing)]
     pub var g_in_if: u64 = 7;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/decarg/run.sh
+++ b/.github/tests/decarg/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # decorator-argument resolution test (#1491, fast-follow #1476): bind_decorator_args
-# (resolve.mach) walks the comptime expression in each backtick decorator, so an
+# (resolve.mach) walks the comptime expression in each `#[...]` decorator, so an
 # unresolved identifier there must surface a name-resolution error rather than be
 # silently dropped. two placements are covered:
 #   unresolved — a top-level decl whose decorator names an undeclared identifier.

--- a/.github/tests/decarg/unresolved/src/main.mach
+++ b/.github/tests/decarg/unresolved/src/main.mach
@@ -1,10 +1,10 @@
 use std.runtime.linux.x86_64;
 
-# a backtick decorator's argument is a comptime expression whose identifiers are
+# a decorator's argument is a comptime expression whose identifiers are
 # resolved by bind_decorator_args (resolve.mach). an unresolved identifier there
 # must surface a name-resolution error — proving the args are walked, not ignored.
-`align(NoSuchThing)`
+#[align(NoSuchThing)]
 rec R { a: u8; }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/decorator/app/src/main.mach
+++ b/.github/tests/decorator/app/src/main.mach
@@ -5,7 +5,7 @@ ext fun mach_dec_add(a: i64, b: i64) i64;
 
 # the runtime entry references `main` by its literal link name; the `symbol`
 # decorator pins it, replacing the legacy attribute setter removed in v2.0.0.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # 20 + 21 + 1 == 42; the body lives in the external object, not the graph.
     ret mach_dec_add(20, 21);

--- a/.github/tests/decorator/extlib/src/ext.mach
+++ b/.github/tests/decorator/extlib/src/ext.mach
@@ -1,7 +1,7 @@
 # external library compiled to a loose `.o`: exports `mach_dec_add` under a
 # literal link name set by a `symbol` decorator (the 1:1 replacement for the
 # legacy `$<sym>.symbol` setter), so a consumer can bind to it via an `ext fun`.
-`symbol("mach_dec_add")`
+#[symbol("mach_dec_add")]
 pub fun mach_dec_add(a: i64, b: i64) i64 {
     ret a + b + 1;
 }

--- a/.github/tests/decorator/run.sh
+++ b/.github/tests/decorator/run.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# decorator integration test (#1476): prove a `symbol` backtick decorator drives
+# decorator integration test (#1476): prove a `#[symbol(...)]` decorator drives
 # the emitted link name, the 1:1 replacement for the legacy `$<sym>.symbol`
 # setter.
 #
 # builds a tiny library (`declib`) to a loose object whose `pub fun mach_dec_add`
-# carries a `` `symbol("mach_dec_add")` `` decorator, then links a consumer
+# carries a `#[symbol("mach_dec_add")]` decorator, then links a consumer
 # (`app`) — which declares that symbol `ext` and whose `main` carries a
-# `` `symbol("main")` `` decorator — against the object. the program returns
+# `#[symbol("main")]` decorator — against the object. the program returns
 # `mach_dec_add(20, 21)` which must be 42. if the decorator did not route the
 # link name, the library symbol would be mangled and the `ext` reference would
 # not resolve, failing the link — so a clean 42 proves emission followed the

--- a/.github/tests/dlllib/app/src/main.mach
+++ b/.github/tests/dlllib/app/src/main.mach
@@ -16,27 +16,27 @@ use std.runtime;
 
 # `.symbol` rename only: the mach identifier `sleep_ms` links as `Sleep`, an
 # unattributed import that falls back to kernel32.dll (the first dependency).
-`symbol("Sleep")`
+#[symbol("Sleep")]
 ext fun sleep_ms(ms: u32);
 
 # `.library` only, bare name: pinned to ws2_32.dll, linked as `WSAStartup`.
-`library("ws2_32.dll")`
+#[library("ws2_32.dll")]
 ext fun WSAStartup(ver: u16, data: *u8) i32;
 
 # both directives on one decl: the mach identifier `ws2_cleanup` is renamed to
 # `WSACleanup` and pinned to ws2_32.dll — the rename and the library pin compose.
-`library("ws2_32.dll")`
-`symbol("WSACleanup")`
+#[library("ws2_32.dll")]
+#[symbol("WSACleanup")]
 ext fun ws2_cleanup() i32;
 
 # the trailing descriptor (#1388): `rng_fill` is renamed to `SystemFunction036`
 # (RtlGenRandom) and pinned to advapi32.dll. it fills a buffer with random bytes
 # and returns nonzero on success, so a correct trailing call-thunk is observable.
-`library("advapi32.dll")`
-`symbol("SystemFunction036")`
+#[library("advapi32.dll")]
+#[symbol("SystemFunction036")]
 ext fun rng_fill(buf: *u8, len: u32) u8;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     var wsadata: [512]u8;
     # a kernel32 call through the renamed default attribution.

--- a/.github/tests/dlllibdec/app/src/main.mach
+++ b/.github/tests/dlllibdec/app/src/main.mach
@@ -1,7 +1,7 @@
-# dlllibdec integration app (#1476): the decorator-spelled twin of the dlllib
-# test. per-symbol windows DLL attribution expressed with backtick decorators
-# rather than the legacy `$<sym>.library` / `$<sym>.symbol` setters — the two
-# must produce identical PE import attribution. imports spread across
+# dlllibdec integration app (#1476): per-symbol windows DLL attribution expressed
+# with `#[library(...)]` / `#[symbol(...)]` decorators rather than the legacy
+# `$<sym>.library` / `$<sym>.symbol` setters (removed in v2.0.0). imports spread
+# across
 # kernel32.dll, ws2_32.dll and advapi32.dll; advapi32 is deliberately the
 # trailing descriptor and is called, exercising the last-descriptor call thunk.
 
@@ -9,24 +9,24 @@ use std.runtime;
 
 # `symbol` rename only: the mach identifier `sleep_ms` links as `Sleep`, an
 # unattributed import that falls back to kernel32.dll (the first dependency).
-`symbol("Sleep")`
+#[symbol("Sleep")]
 ext fun sleep_ms(ms: u32);
 
 # `library` only, bare name: pinned to ws2_32.dll, linked as `WSAStartup`.
-`library("ws2_32.dll")`
+#[library("ws2_32.dll")]
 ext fun WSAStartup(ver: u16, data: *u8) i32;
 
 # both directives on one decl: `ws2_cleanup` is renamed to `WSACleanup` and
 # pinned to ws2_32.dll — the rename and the library pin compose.
-`library("ws2_32.dll")` `symbol("WSACleanup")`
+#[library("ws2_32.dll")] #[symbol("WSACleanup")]
 ext fun ws2_cleanup() i32;
 
 # the trailing descriptor: `rng_fill` is renamed to `SystemFunction036`
 # (RtlGenRandom) and pinned to advapi32.dll, exercising the last-descriptor thunk.
-`library("advapi32.dll")` `symbol("SystemFunction036")`
+#[library("advapi32.dll")] #[symbol("SystemFunction036")]
 ext fun rng_fill(buf: *u8, len: u32) u8;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     var wsadata: [512]u8;
     sleep_ms(0);

--- a/.github/tests/dlllibdec/run.sh
+++ b/.github/tests/dlllibdec/run.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # dlllibdec integration test (#1476): the decorator-spelled twin of dlllib —
-# prove `library(...)` / `symbol(...)` backtick decorators drive per-symbol
+# prove `#[library(...)]` / `#[symbol(...)]` decorators drive per-symbol
 # windows DLL attribution identically to the legacy `$<sym>.library` /
 # `$<sym>.symbol` setters. the acceptance-criteria case: a windows extern with
-# `` `library("ws2_32.dll")` `` + `` `symbol("...")` `` importing correctly.
+# `#[library("ws2_32.dll")]` + `#[symbol("...")]` importing correctly.
 #
 # builds the windows binary, reads its PE import directory, and asserts each
 # renamed symbol lands under the decorator-named DLL (and the mach identifiers do

--- a/.github/tests/dynlink/app/src/main.mach
+++ b/.github/tests/dynlink/app/src/main.mach
@@ -5,7 +5,7 @@ use std.runtime.linux.x86_64;
 # time via the PLT the linker emitted.
 ext fun getpid() i32;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # every real process has a positive pid; a successful dynamic call returns it.
     # exit 0 proves the import resolved and the PLT call returned a sane value.

--- a/.github/tests/eachfields/app/src/main.mach
+++ b/.github/tests/eachfields/app/src/main.mach
@@ -92,7 +92,7 @@ fun count_named_a(m: Mixed) i64 {
     ret n;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     var p: Pair = Pair { x: 3, y: 4 };
     if (sum(p) != 7) { ret 1; }

--- a/.github/tests/eachfieldsgeneric/app/src/main.mach
+++ b/.github/tests/eachfieldsgeneric/app/src/main.mach
@@ -47,7 +47,7 @@ fun count_named[T](v: T, target: str) i64 {
     ret n;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # homogeneous record: sum via generic sum_fields
     var p: Pair = Pair { x: 3, y: 4 };

--- a/.github/tests/eachfieldsgeneric/nonrec/src/main.mach
+++ b/.github/tests/eachfieldsgeneric/nonrec/src/main.mach
@@ -12,7 +12,7 @@ fun bad[T](v: T) i64 {
     ret n;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # instantiating with u64 (a primitive, not a record) must error
     ret bad[u64](42::u64)::i64;

--- a/.github/tests/envfwd/app/src/main.mach
+++ b/.github/tests/envfwd/app/src/main.mach
@@ -6,7 +6,7 @@ use std.runtime;
 use std.types.size.usize;
 use env: std.process.env;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret probe()::i64;
 }

--- a/.github/tests/extlink/app/src/main.mach
+++ b/.github/tests/extlink/app/src/main.mach
@@ -3,7 +3,7 @@ use std.runtime.linux.x86_64;
 # bound at link time against the external object's `mach_ext_add` definition.
 ext fun mach_ext_add(a: i64, b: i64) i64;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # 20 + 21 + 1 == 42; the body lives in the external object, not the graph.
     ret mach_ext_add(20, 21);

--- a/.github/tests/extlink/extlib/src/ext.mach
+++ b/.github/tests/extlink/extlib/src/ext.mach
@@ -1,6 +1,6 @@
 # external library compiled to a loose `.o`: exports `mach_ext_add` under a
 # literal link name so a consumer can bind to it through an `ext fun`.
-`symbol("mach_ext_add")`
+#[symbol("mach_ext_add")]
 pub fun mach_ext_add(a: i64, b: i64) i64 {
     ret a + b + 1;
 }

--- a/.github/tests/fconv/app/src/main.mach
+++ b/.github/tests/fconv/app/src/main.mach
@@ -16,7 +16,7 @@ fun pow2(k: i32) f64 {
     ret r;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     val n: u64 = argc::u64 - 1;
 

--- a/.github/tests/floatrem/app/src/main.mach
+++ b/.github/tests/floatrem/app/src/main.mach
@@ -21,7 +21,7 @@ fun rem32(a: f32, b: f32) f32 { ret a % b; }
 fun milli64(v: f64) i64 { ret (v * 1000.0)::i64; }
 fun milli32(v: f32) i64 { ret (v * 1000.0)::i64; }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # const-folded module val.
     if (milli64(FOLDED) != 2500) { ret 1; }

--- a/.github/tests/fpargs/app/src/main.mach
+++ b/.github/tests/fpargs/app/src/main.mach
@@ -34,7 +34,7 @@ fun acc(x: f64) f64 {
     ret keep + s;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # take(3.0, 10.0) == -7.0; the bug returned 0.0.
     if (near(swap_call(10.0, 3.0), -7.0) == 0) { ret 1; }

--- a/.github/tests/fwdreexport/app/src/main.mach
+++ b/.github/tests/fwdreexport/app/src/main.mach
@@ -7,7 +7,7 @@ use olib: outer.lib;
 # (`lib.alpha.answer`, and `lib.beta.value` through the nested-FQN alias)
 # (#1343), and a fwd-of-a-fwd through a second library (`olib.answer`,
 # `olib.alpha.answer`).
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret lib.answer() + lib.alpha.answer() + lib.beta.value() + olib.answer() + olib.alpha.answer();
 }

--- a/.github/tests/globalmember/fold/src/main.mach
+++ b/.github/tests/globalmember/fold/src/main.mach
@@ -17,7 +17,7 @@ val CHAINED: usize = flags.CLONE_BASE | flags.CLONE_FILES;
 # a single aliased member that is itself a chained constant: (256|512)|1024|2048 = 3840.
 val ALL_VIA_ALIAS: usize = flags.CLONE_ALL;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     if (THREAD_CLONE_FLAGS != 331520) { ret 1; }
     if (CHAINED != 1792) { ret 2; }

--- a/.github/tests/globalmember/reject/src/main.mach
+++ b/.github/tests/globalmember/reject/src/main.mach
@@ -8,7 +8,7 @@ use flags: gmemberreject.flags;
 # "a global initialiser must be a constant expression" abort.
 val NOT_CONST: usize = flags.COUNTER;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret NOT_CONST::i64;
 }

--- a/.github/tests/inline/app/src/main.mach
+++ b/.github/tests/inline/app/src/main.mach
@@ -6,8 +6,8 @@ use std.runtime.linux.x86_64;
 # decorator pins its link name so the call-site grep matches a stable mnemonic
 # (`call big`) rather than a mangled internal name. the run.sh control confirms
 # the calls survive when the `inline` decorator alone is removed.
-`inline`
-`symbol("big")`
+#[inline]
+#[symbol("big")]
 fun big(a: i64, b: i64) i64 {
     var x: i64 = a + b;
     x = x + a; x = x - b; x = x * 2; x = x + 3;
@@ -19,7 +19,7 @@ fun big(a: i64, b: i64) i64 {
     ret x;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # feed `big` a runtime value (argc) so the optimizer can't constant-fold the
     # calls away, and RETURN the result so they can't be dead-code-eliminated as

--- a/.github/tests/inline/run.sh
+++ b/.github/tests/inline/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# inline decorator integration test (#1476): prove an `inline` backtick decorator
+# inline decorator integration test (#1476): prove an `#[inline]` decorator
 # forces inlining of a function the cost model would otherwise leave alone.
 #
 # `big` exceeds the inline pass's instruction threshold and is called from two
@@ -74,10 +74,10 @@ else
     fi
 fi
 
-# control: strip the `inline` decorator; the cost model must now leave the calls
+# control: strip the `#[inline]` decorator; the cost model must now leave the calls
 # in place, proving the decorator — not the heuristic — is what inlined `big`.
-# the `symbol("big")` pin is on its own line and survives, so `big` keeps its name.
-sed '/`inline`/d' "$HERE/app/src/main.mach" > "$WORK/app/src/main.mach"
+# the `#[symbol("big")]` pin is on its own line and survives, so `big` keeps its name.
+sed '/#\[inline\]/d' "$HERE/app/src/main.mach" > "$WORK/app/src/main.mach"
 rm -rf "$WORK/app/out"
 if ! ( cd "$WORK/app" && "$MACH" build . --emit-asm -O2 ) >/dev/null 2>&1; then
     echo "FAIL inline: control build failed" >&2

--- a/.github/tests/kwident/prog/src/main.mach
+++ b/.github/tests/kwident/prog/src/main.mach
@@ -14,7 +14,7 @@ fun repro() usize {
     ret cnt;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     if (repro() != 1) { ret 1; }
 

--- a/.github/tests/literalboundary/app/src/main.mach
+++ b/.github/tests/literalboundary/app/src/main.mach
@@ -7,7 +7,7 @@ use std.runtime.linux.x86_64;
 # simultaneously. exits 0 when every check passes; returns a non-zero check id
 # on the first mismatch.
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     var vi8:  i8  = 127;
     var vu8:  u8  = 255;

--- a/.github/tests/lower-testrunner/duplabel/src/main.mach
+++ b/.github/tests/lower-testrunner/duplabel/src/main.mach
@@ -1,6 +1,6 @@
 use std.runtime.linux.x86_64;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 { ret 0; }
 
 # two tests with the same label in one module. before issue #1251 the clash

--- a/.github/tests/lower-testrunner/nlabel/src/main.mach
+++ b/.github/tests/lower-testrunner/nlabel/src/main.mach
@@ -1,6 +1,6 @@
 use std.runtime.linux.x86_64;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 { ret 0; }
 
 # a label whose text itself contains `N<digit>`. before issue #1251 the runner

--- a/.github/tests/lower/comptime-str/src/main.mach
+++ b/.github/tests/lower/comptime-str/src/main.mach
@@ -9,7 +9,7 @@ fun first_byte(p: *u8) i64 { ret p[0]::i64; }
 # anonymous `.rodata` global and a pointer, exactly like a string literal.
 fun greet($name: *u8) i64 { ret first_byte(name); }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # "hello"[0] == 'h' == 104; main returns 0 only when the fold produced a
     # valid pointer to the rodata bytes.

--- a/.github/tests/lower/fnptr-table/src/main.mach
+++ b/.github/tests/lower/fnptr-table/src/main.mach
@@ -14,7 +14,7 @@ fun first[T](a: T, b: T) T { ret a; }
 # this exercises the bare-identifier index, a complex index expression, a nested
 # matrix index, a chained call, and a real generic call — main exits 0 only when
 # every dispatch lands on the right function.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     var table: [2]fun(i64, i64) i64;
     table[0] = add;

--- a/.github/tests/lower/xmod-generic/src/main.mach
+++ b/.github/tests/lower/xmod-generic/src/main.mach
@@ -1,7 +1,7 @@
 use std.runtime.linux.x86_64;
 use util: xmodgen.util;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # FLAG == 1, so pick selects its first argument (7); main returns 0 only when
     # the cross-module instance folded the right $if arm.

--- a/.github/tests/manifest/app/src/bye.mach
+++ b/.github/tests/manifest/app/src/bye.mach
@@ -1,7 +1,7 @@
 use std.runtime;
 use code: demo.code;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret code.answer() + 4;
 }

--- a/.github/tests/manifest/app/src/hello.mach
+++ b/.github/tests/manifest/app/src/hello.mach
@@ -1,7 +1,7 @@
 use std.runtime;
 use code: demo.code;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret code.answer() + 2;
 }

--- a/.github/tests/manifest/app/src/tier.mach
+++ b/.github/tests/manifest/app/src/tier.mach
@@ -5,7 +5,7 @@ use std.runtime;
 # `shared_flag` (+1), the artifact-level `extra_flag` (+2), and `tier`, an integer
 # define the per-cell `[bin.tier.target.linux]` raises to 9 over the artifact's 2
 # and the target's 1 (+40). a clean linux build exits 43.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     var n: i64 = 0;
     $if ($mach.build.shared_flag) { n = n + 1; }

--- a/.github/tests/manifest/cascade/src/main.mach
+++ b/.github/tests/manifest/cascade/src/main.mach
@@ -4,7 +4,7 @@ use v: vdep.lib;
 
 # the consumer links against both dep libs; the windows link inputs they each
 # require (kernel32.dll, user32.dll) arrive only through the manifest cascade.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret k.k() + v.v();
 }

--- a/.github/tests/mixedcmp/app/src/main.mach
+++ b/.github/tests/mixedcmp/app/src/main.mach
@@ -153,7 +153,7 @@ fun chk_f32_f64(a: f32, b: f64, lt: u8, eq: u8, gt: u8, base: i64) i64 {
     ret 0;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     val n:  u64 = argc::u64 - 1;
     val zi: i64 = n::i64;

--- a/.github/tests/module/dangling/src/main.mach
+++ b/.github/tests/module/dangling/src/main.mach
@@ -1,6 +1,6 @@
 # the entry imports nothing special; the dangling [project].module still fails
 # the build at start.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret 0;
 }

--- a/.github/tests/module/nomodule/src/main.mach
+++ b/.github/tests/module/nomodule/src/main.mach
@@ -1,7 +1,7 @@
 use std.runtime;
 use plain;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret 0;
 }

--- a/.github/tests/module/ok/src/main.mach
+++ b/.github/tests/module/ok/src/main.mach
@@ -5,7 +5,7 @@ use shelf;
 # `use gfx;` resolves the bare project id to gfx's [project].module. `use shelf;`
 # loads shelf, whose own module re-exports gfx through a bare-id `fwd gfx;` — so a
 # resolution failure in either form fails this build.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret gfx.value();
 }

--- a/.github/tests/nancmp/app/src/main.mach
+++ b/.github/tests/nancmp/app/src/main.mach
@@ -51,7 +51,7 @@ fun chk_f32(a: f32, b: f32, lt: u8, eq: u8, gt: u8, base: i64) i64 {
     ret 0;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     val n:     f64 = (argc - 1)::f64;   # 0.0 at runtime, non-foldable
     val nan64: f64 = n / n;             # 0.0 / 0.0 = NaN

--- a/.github/tests/nilfun/fold/src/main.mach
+++ b/.github/tests/nilfun/fold/src/main.mach
@@ -15,7 +15,7 @@ pub var glKey: F = nil::F;
 var hits: u32 = 0;
 fun cb(x: u32) { hits = hits + x; }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # both globals start as the null address.
     if (glClear != nil) { ret 1; }

--- a/.github/tests/nilfun/reject/src/main.mach
+++ b/.github/tests/nilfun/reject/src/main.mach
@@ -6,5 +6,5 @@ use std.runtime;
 # for fun types does not widen nil into arbitrary scalar slots.
 pub var bad: u32 = nil;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 { ret 0; }

--- a/.github/tests/opt/app/src/main.mach
+++ b/.github/tests/opt/app/src/main.mach
@@ -2,7 +2,7 @@ use std.runtime.linux.x86_64;
 
 # a small loop the optimizer can fold so the debug and release pipelines emit
 # observably different objects; the program's result is independent of the level.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     var x: i64 = 0;
     var i: i64 = 0;

--- a/.github/tests/packfwd/app/src/main.mach
+++ b/.github/tests/packfwd/app/src/main.mach
@@ -28,7 +28,7 @@ fun outer2(va: ...) i64 {
     ret outer(va...);
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     if (outer(1, 2, 3) != 6)         { ret 1; }
     if (outer() != 0)                 { ret 2; }

--- a/.github/tests/packmono/app/src/main.mach
+++ b/.github/tests/packmono/app/src/main.mach
@@ -43,7 +43,7 @@ fun count(va: ...) i64 {
     ret va.len::i64;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # distinct arities are distinct instances, deduped by their type-list.
     if (sum(1, 2, 3) != 6)               { ret 1; }

--- a/.github/tests/packxmod/app/src/main.mach
+++ b/.github/tests/packxmod/app/src/main.mach
@@ -21,7 +21,7 @@ fun chain(va: ...) i64 {
     ret t;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     if (sumdbl(1, 2, 3) != 12) { ret 1; }  # 2 + 4 + 6
     if (sumdbl(10) != 20)      { ret 2; }

--- a/.github/tests/pathdep/run.sh
+++ b/.github/tests/pathdep/run.sh
@@ -83,7 +83,7 @@ TOML
 use std.runtime;
 use libx.lib.answer;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret answer();
 }

--- a/.github/tests/recovery/backtick/mach.toml
+++ b/.github/tests/recovery/backtick/mach.toml
@@ -1,0 +1,15 @@
+[project]
+id      = "recbacktick"
+name    = "recovery: removed backtick decorator — no parse cascade"
+version = "0.0.0"
+src     = "src"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.rec]
+entry = "main.mach"

--- a/.github/tests/recovery/backtick/src/main.mach
+++ b/.github/tests/recovery/backtick/src/main.mach
@@ -1,0 +1,13 @@
+# a removed backtick decorator (symbol("main") in the old backtick form, removed in
+# v2.4.0) must report ONE migration diagnostic and recover at the NEXT declaration —
+# never skip it and spray "expected a declaration" over the body. the body here is
+# all-valid, so a correct compiler emits exactly the backtick-removal diagnostic and
+# nothing else. the run.sh twin rewrites this clause to the going-forward
+# #[symbol("main")] form and confirms it checks clean.
+`symbol("main")`
+fun main(argc: i64, argv: **u8) i64 {
+    val a: i64 = 1;
+    val b: i64 = 2;
+    val c: i64 = 3;
+    ret a + b + c;
+}

--- a/.github/tests/recovery/run.sh
+++ b/.github/tests/recovery/run.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 # Parser error-recovery at declaration scope. A removed-syntax error — a comptime
 # attribute setter (`$sym.attr = value;`) or a C-style `...` variadic parameter,
-# both removed in v2.0.0 — must emit its ONE migration diagnostic and resync on
-# the NEXT declaration. It must NOT skip that declaration and reparse its body at
-# module scope, which used to spray a spurious "expected a declaration" for every
+# both removed in v2.0.0, or a backtick decorator (`` `name(...)` ``), removed in
+# v2.4.0 — must emit its ONE migration diagnostic and resync on the NEXT
+# declaration. It must NOT skip that declaration and reparse its body at module
+# scope, which used to spray a spurious "expected a declaration" for every
 # non-`val` body statement (sync_to_decl's unconditional leading advance, fixed
 # for v2.0.1). Each app's function body is all-valid, so a correct compiler emits
-# exactly the migration diagnostic and zero "expected a declaration" cascade.
+# exactly the migration diagnostic and zero "expected a declaration" cascade. The
+# backtick case additionally proves the going-forward `#[name(...)]` twin checks
+# clean — the same decl in the surviving surface.
 #
 # usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -39,7 +42,22 @@ check() {
     echo "PASS recovery/$app: one migration diagnostic, recovered at the next decl (no cascade)"
 }
 
-check setter  "comptime attribute setters were removed in v2.0.0"
-check varargs 'C-style variadic `...` was removed in v2.0.0'
+check setter   "comptime attribute setters were removed in v2.0.0"
+check varargs  'C-style variadic `...` was removed in v2.0.0'
+check backtick "backtick decorators were removed in v2.4.0"
+
+# positive twin: rewriting the rejected backtick clause to the going-forward
+# `#[name(...)]` surface must check clean — `mach check` (single file, parse + sema,
+# no link) emits no diagnostic for the surviving form, proving the migration target
+# is the same decl in a parseable surface.
+twin="$WORK/backtick-attr.mach"
+sed -E 's/`([^`]*)`/#[\1]/g' "$HERE/backtick/src/main.mach" > "$twin"
+if "$MACH" check "$twin" >/dev/null 2>&1; then
+    echo "PASS recovery/backtick: the #[name(...)] twin checks clean"
+else
+    echo "FAIL recovery/backtick: the #[name(...)] twin did not check clean:" >&2
+    "$MACH" check "$twin" >&2 || true
+    fail=1
+fi
 
 exit "$fail"

--- a/.github/tests/sectioncoff/app/src/main.mach
+++ b/.github/tests/sectioncoff/app/src/main.mach
@@ -1,24 +1,24 @@
 use std.runtime;
 
-# the COFF twin of sectiondec: a `section("...")` decorator places a global's
+# the COFF twin of sectiondec: a `#[section("...")]` decorator places a global's
 # symbol in the named COFF section instead of the default .data, and a function's
 # code in the named text section, carried into PE/COFF object emission.
 
 # `.machsec` is exactly 8 characters, so its name fits inline in the COFF section
 # header (the path sectiondec already covers on ELF).
-`section(".machsec")` `symbol("g_sec")`
+#[section(".machsec")] #[symbol("g_sec")]
 pub var g_sec: u64 = 100;
 
-`symbol("g_def")`
+#[symbol("g_def")]
 pub var g_def: u64 = 23;
 
 # `.hottext_long` is >8 characters, so COFF cannot store it inline: it goes to the
 # string table and the section header holds a `/N` byte-offset redirection. this
 # is the path `.machsec` / `.hottext` (both exactly 8) never exercise.
-`section(".hottext_long")` `symbol("f_sec")`
+#[section(".hottext_long")] #[symbol("f_sec")]
 fun f_sec(x: i64) i64 { ret x + 1; }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret f_sec((g_sec + g_def)::i64 - 1);
 }

--- a/.github/tests/sectioncoff/run.sh
+++ b/.github/tests/sectioncoff/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # section decorator COFF integration test (#1491, fast-follow #1476): the
-# windows/COFF twin of sectiondec — prove a `section("...")` decorator places a
+# windows/COFF twin of sectiondec — prove a `#[section("...")]` decorator places a
 # global's symbol and a function's code in the named COFF section, carried into
 # PE/COFF object emission, while an un-decorated global stays in .data.
 #

--- a/.github/tests/sectiondec/app/src/main.mach
+++ b/.github/tests/sectiondec/app/src/main.mach
@@ -1,19 +1,19 @@
 use std.runtime.linux.x86_64;
 
-# a `section("...")` decorator places the global's symbol in the named object
+# a `#[section("...")]` decorator places the global's symbol in the named object
 # section instead of the default .data; the default-placed global stays in .data.
-`section(".machsec")` `symbol("g_sec")`
+#[section(".machsec")] #[symbol("g_sec")]
 pub var g_sec: u64 = 100;
 
-`symbol("g_def")`
+#[symbol("g_def")]
 pub var g_def: u64 = 23;
 
-# a `section("...")` decorator also places a FUNCTION's code in the named text
+# a `#[section("...")]` decorator also places a FUNCTION's code in the named text
 # section; it is still called across the section boundary (a normal relocation).
-`section(".hottext")` `symbol("f_sec")`
+#[section(".hottext")] #[symbol("f_sec")]
 fun f_sec(x: i64) i64 { ret x + 1; }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     ret f_sec((g_sec + g_def)::i64 - 1);
 }

--- a/.github/tests/sectiondec/run.sh
+++ b/.github/tests/sectiondec/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# section decorator integration test (#1476): prove a `section("...")` decorator
+# section decorator integration test (#1476): prove a `#[section("...")]` decorator
 # places a global's symbol in the named object section, carried into ELF object
 # emission, while an un-decorated global stays in .data.
 #

--- a/.github/tests/threadsync/app/src/main.mach
+++ b/.github/tests/threadsync/app/src/main.mach
@@ -19,7 +19,7 @@ fun worker() {
 # WaitOnAddress call in join() dispatched through a null pointer and faulted
 # (`jmp 0`) — a nonzero exit. exits 0 only when the trailing-descriptor synch
 # calls dispatch correctly.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: usize, argv: **u8) i64 {
     atomic.store(?ran, 0);
     var t: thread.Thread;

--- a/.github/tests/typeofgate/app/src/main.mach
+++ b/.github/tests/typeofgate/app/src/main.mach
@@ -18,7 +18,7 @@ rec B { x: i64; y: i64; }
 rec Box[T] { v: T; }
 def MyInt: i64;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     var a:  i64   = 0;
     var a2: i64   = 0;

--- a/.github/tests/typeofgate/reject/src/main.mach
+++ b/.github/tests/typeofgate/reject/src/main.mach
@@ -3,7 +3,7 @@ use std.runtime;
 # a `$type_of` type comparison is comptime-only: it folds to a selected arm at
 # lowering and has no runtime value, so using it as a value (here, a binding
 # initialiser) must FAIL rather than compile to garbage (#1472).
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     var a: i64 = 0;
     var x: u8 = $type_of(a) == i64;

--- a/.github/tests/valuepos/ok/src/main.mach
+++ b/.github/tests/valuepos/ok/src/main.mach
@@ -10,7 +10,7 @@ fun seven() i64 { ret 7; }
 # building: a record literal, a function reference, a generic parameter in a
 # comptime intrinsic, and qualified value access through a module alias.
 # 8 + 7 + 8 + 7 + 7 = 37.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     val p: Point = Point{ x: 8, y: 1 };
     val f: fun() i64 = seven;

--- a/.github/tests/win64byref/app/src/main.mach
+++ b/.github/tests/win64byref/app/src/main.mach
@@ -32,7 +32,7 @@ fun sum5_big(p0: i64, p1: i64, p2: i64, p3: i64, b: Big) i64 {
 # main: pass each byref aggregate as the 5th argument and verify the callee read
 # it correctly. exits 0 on success, 1 if the 3-byte case is misread, 2 if the
 # 12-byte case is misread.
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     var t: Three;
     t.a = 10;

--- a/.github/tests/win64fnptr/app/src/main.mach
+++ b/.github/tests/win64fnptr/app/src/main.mach
@@ -22,7 +22,7 @@ var vt: VT;
 # code address. harmless on linux (addresses < 2GB) but on win64 (ImageBase
 # 0x140000000) the stored pointer becomes unmapped and `f(41)` faults. exits 0
 # only when the round-tripped pointer calls correctly (41 -> 42).
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     vt.op = inc::*u8;
     val f: Fn = vt.op::Fn;

--- a/.github/tests/win64fp/app/src/main.mach
+++ b/.github/tests/win64fp/app/src/main.mach
@@ -31,7 +31,7 @@ fun near(a: f64, b: f64) i64 {
     ret 0;
 }
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     # (10+1)+(20+2)+(30+3)+(40+4) = 110; 10*5+20*6+30*7 = 380; mul2(40) = 80;
     # total = 570.

--- a/.github/tests/win64runner/app/src/main.mach
+++ b/.github/tests/win64runner/app/src/main.mach
@@ -5,7 +5,7 @@
 
 use std.runtime;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     if (add(20, 22) == 42) { ret 0; }
     ret 1;

--- a/doc/language/README.md
+++ b/doc/language/README.md
@@ -17,7 +17,7 @@ neighboring links; start from the index below.
 ## Declarations
 
 - [visibility.md](visibility.md) — `pub` and `ext` modifiers
-- [decorators.md](decorators.md) — codegen decorators, `#[name]` or `` `name` `` (`symbol`, `library`, `inline`, `align`, `section`)
+- [decorators.md](decorators.md) — codegen decorators, `#[name]` (`symbol`, `library`, `inline`, `align`, `section`)
 - [def.md](def.md) — type alias
 - [rec.md](rec.md) — record
 - [uni.md](uni.md) — raw union and the discriminated-value convention
@@ -42,7 +42,7 @@ neighboring links; start from the index below.
 
 - [comptime.md](comptime.md) — channel overview
 - [comptime-mach.md](comptime-mach.md) — `$mach.*` compiler-owned namespace
-- [decorators.md](decorators.md) — codegen decorators, `#[name]` or `` `name` `` (replaces the removed `$sym.attr` setters)
+- [decorators.md](decorators.md) — codegen decorators, `#[name]` (replaces the removed `$sym.attr` setters)
 - [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`, `$align_of`, `$offset_of`, `$type_of`, `$fields`, `$each`, `$error`, `$assert`
 - [comptime-control.md](comptime-control.md) — `$if` / `$or`
 

--- a/doc/language/comptime-attrs.md
+++ b/doc/language/comptime-attrs.md
@@ -1,11 +1,9 @@
 # Symbol attributes
 
 Symbol attributes are expressed as **decorators** — leading, per-declaration
-codegen directives on the declared symbol. A decorator is written in either of
-two interchangeable surfaces: the going-forward **attribute** form `#[name]` or
-the original **backtick** form `` `name` ``. Both produce the same directive;
-prefer `#[...]` in new code. See [decorators.md](decorators.md) for the full
-reference.
+codegen directives on the declared symbol. A decorator is written as an
+attribute: `#[name]` for a bare flag or `#[name(args)]` for a directive with
+arguments. See [decorators.md](decorators.md) for the full reference.
 
 ```mach
 #[symbol("main")]
@@ -18,17 +16,10 @@ ext fun wsa_startup(ver: u16, data: *u8) i32;
 pub var cache_line: u8 = 0;
 ```
 
-The backtick form remains accepted this phase, so the two spellings may be
-mixed; the compiler's own source still uses backticks until the migration
-completes.
-
-```mach
-`symbol("main")`
-fun entry(argc: i64, argv: **u8) i64 { ... }
-```
-
-The previous `$sym.attr = value;` setter form was removed in v2.0.0 in favor of
-decorators; a stray `=` after a comptime directive is now a parse error.
+A backtick form (`` `name(args)` ``) existed through v2.3.0 and was removed in
+v2.4.0; a backtick at decorator position is now a migration error. The earlier
+`$sym.attr = value;` setter form was removed in v2.0.0 in favor of decorators; a
+stray `=` after a comptime directive is also a parse error.
 
 ## See also
 

--- a/doc/language/comptime.md
+++ b/doc/language/comptime.md
@@ -15,7 +15,7 @@ this channel.
 | `$if`, `$or` | Comptime control flow | structural |
 
 > Per-declaration codegen attributes (symbol rename, library pin, inline,
-> align, section) are written as **backtick decorators**, not `$`-comptime
+> align, section) are written as **`#[...]` decorators**, not `$`-comptime
 > shapes — see [decorators.md](decorators.md). The legacy `$sym.attr = value`
 > attribute setters were removed in v2.0.0.
 
@@ -72,14 +72,14 @@ than each carrying their own.
 - No reflection-via-`$<Type>.*` subtree. Types are not first-class
   comptime values.
 - No decl-attached prefix sugar (`$inline pub fun ...` does not exist) —
-  use backtick decorators (see [decorators.md](decorators.md)).
+  use `#[...]` decorators (see [decorators.md](decorators.md)).
 - No comptime function definitions, no comptime loops.
 - No bare `$ident` — see above.
 
 ## See also
 
 - [comptime-mach.md](comptime-mach.md) — the `$mach.*` namespace
-- [decorators.md](decorators.md) — backtick codegen decorators
+- [decorators.md](decorators.md) — `#[...]` codegen decorators
 - [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`,
   `$assert`, …
 - [comptime-control.md](comptime-control.md) — `$if` / `$or`

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -7,23 +7,21 @@ alignment, section placement, inlining, or PE import routing.
 Decorators are **codegen-only**. Visibility (`pub` / `ext`) is separate and
 unaffected by decorators.
 
-## Surfaces
+## Surface
 
-A decorator is written in either of two interchangeable surfaces:
+A decorator is written as an attribute:
 
 ```
-#[name]            # attribute form — preferred going forward
-`name`             # backtick form — original, still accepted
+#[name]            # bare flag (e.g. inline)
+#[name(args)]      # directive with comptime-expr arguments
 ```
 
-Both surfaces parse into the **same** decorator and feed the same sema and
-codegen path; only the delimiters differ. New code should prefer `#[...]`; the
-backtick form remains accepted this phase (the compiler's own source still uses
-it until the migration completes), and the two may be mixed freely. The
-examples below use the preferred `#[...]` form.
+> A backtick form (`` `name(args)` ``) existed through v2.3.0 and was removed in
+> v2.4.0; a backtick at decorator position is now a migration error. `#[...]` is
+> the only decorator surface.
 
 > One caveat the attribute form introduces: a line comment that begins `#[`
-> (with no space) now opens an attribute. Write such a comment with a separating
+> (with no space) opens an attribute. Write such a comment with a separating
 > space — `# [...]`.
 
 ## Grammar
@@ -51,8 +49,7 @@ pub var g_lit64: u8 = 7;
 
 Each directive is wrapped in its own clause: `#[name]` for a bare flag or
 `#[name(args)]` for a directive that takes arguments. Arguments are comptime
-expressions. The backtick form is the same with `` ` `` delimiters: `` `name` ``
-or `` `name(args)` ``.
+expressions.
 
 ## Directives
 

--- a/doc/language/documentation.md
+++ b/doc/language/documentation.md
@@ -42,7 +42,7 @@ follow the docstring, immediately above the decl:
 # panic: terminate the program with a message.
 # ---
 # msg: text to emit before terminating
-`symbol("panic")`
+#[symbol("panic")]
 pub fun panic(msg: *u8) { ... }
 ```
 

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -29,7 +29,7 @@ By default the linker symbol matches the Mach name. Override it with the
 `symbol` decorator:
 
 ```mach
-`symbol("write")`
+#[symbol("write")]
 pub ext fun libc_write(fd: i64, buf: *u8, n: i64) i64;
 ```
 
@@ -46,7 +46,7 @@ PE (Windows) import directory — the `library` decorator pins an `ext` import t
 the DLL that exports it:
 
 ```mach
-`library("ws2_32.dll")`
+#[library("ws2_32.dll")]
 ext fun WSAStartup(ver: u16, data: *u8) i32;
 ```
 
@@ -68,7 +68,7 @@ under the renamed symbol within the named library.
 
 ```mach
 # imported as `socket` from ws2_32.dll, called as `ws2_socket` in Mach.
-`library("ws2_32.dll")` `symbol("socket")`
+#[library("ws2_32.dll")] #[symbol("socket")]
 ext fun ws2_socket(af: i32, kind: i32, proto: i32) i64;
 ```
 

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -187,8 +187,10 @@ none of the token forms above is an **unexpected character**. The lexer
 records a `LEX_ERR_UNEXPECTED_CHAR`, emits a one-byte `ERROR` token
 (`KIND_ERROR`) for it, and continues.
 
-The backtick `` ` `` is a real punctuation token (`KIND_BACKTICK`); `#[` is the
-two-byte attribute-open token (`KIND_ATTR_OPEN`). Both delimit decorators (see
+The backtick `` ` `` is a real punctuation token (`KIND_BACKTICK`) but has no
+grammar production: it delimited decorators through v2.3.0 and was removed in
+v2.4.0, so a backtick at decorator position is now a migration error. `#[` is the
+two-byte attribute-open token (`KIND_ATTR_OPEN`) that opens a decorator (see
 [Decorators](#decorators) below).
 
 
@@ -203,33 +205,25 @@ module ::= { decl }
 
 ## Decorators
 
-Zero or more leading decorator clauses may appear before any declaration. Each
-clause is a comptime directive name, optionally followed by a parenthesized
-argument list of comptime expressions. A clause is written in either of two
-interchangeable surfaces: the backtick form `` `name(args)` `` or the attribute
-form `#[name(args)]`.
+Zero or more leading `#[...]` decorator clauses may appear before any
+declaration. Each clause is a comptime directive name, optionally followed by a
+parenthesized argument list of comptime expressions.
 
 ```ebnf
-decorator          ::= backtick-decorator | attr-decorator
-backtick-decorator ::= "`"  IDENT [ "(" [ expr { "," expr } ] ")" ] "`"
-attr-decorator     ::= "#[" IDENT [ "(" [ expr { "," expr } ] ")" ] "]"
-decorated-decl     ::= { decorator } decl
+decorator      ::= "#[" IDENT [ "(" [ expr { "," expr } ] ")" ] "]"
+decorated-decl ::= { decorator } decl
 ```
 
-- Both surfaces produce the **same** decorator and feed the same sema /
-  codegen path; only the delimiters differ. `#[name]` is the going-forward
-  preferred form; backticks remain accepted (the compiler's own source still
-  uses them this phase).
 - Decorators attach to the **immediately following** declaration and do not
   bleed across declarations.
-- The two surfaces may be mixed freely, on the same line (space-separated) or
-  one per line.
-- The argument list is optional; a bare `#[inline]` / `` `inline` `` carries no
-  arguments.
+- Clauses may appear on the same line (space-separated) or one per line.
+- The argument list is optional; a bare `#[inline]` carries no arguments.
 - Arguments are comptime expressions (not types): `$size_of(T)` is a valid
   argument; `T` as a raw type name is not.
 - The closed directive set is `symbol`, `section`, `inline`, `align`,
   `library`. See [decorators.md](decorators.md).
+- A backtick form (`` `name(args)` ``) existed through v2.3.0 and was removed in
+  v2.4.0; a backtick at decorator position is a migration error.
 
 
 ## Declarations
@@ -369,7 +363,7 @@ comptime-directive ::= expr-no-assign ";"
 - `comptime-directive` is a bare **comptime intrinsic / directive call**
   (`$error("msg");`). The legacy attribute-write setter (`$sym.attr = value;`)
   was removed in v2.0.0 — per-declaration codegen attributes are written as
-  backtick decorators now (see [decorators.md](decorators.md)) — so a stray `=`
+  `#[...]` decorators now (see [decorators.md](decorators.md)) — so a stray `=`
   after the target is a parse error. The target is parsed at a binding power
   above assignment so that `=` is detected rather than swallowed into the
   expression.
@@ -690,8 +684,8 @@ Productions verified directly against the parser source:
 - **Precedence ladder** — `token.infix_precedence` / `token.is_right_assoc`
   (the table is a direct transcription; only `=` is right-associative).
 - **Decorators** — `parser/decl.mach` `parse_decorators` / `parse_one_decorator`:
-  leading `` `name(args)` `` and `#[name(args)]` clauses (both surfaces converge
-  on one Decorator node), closed directive set.
+  leading `#[name(args)]` clauses (one Decorator node); a backtick at decorator
+  position is rejected as the removed surface (v2.4.0), closed directive set.
 - **Declarations** — `parser/decl.mach`: `use`, `fwd` (incl. `pub fwd`
   rejection), `fun` (generics, params, variadic `...`, named pack `name: ...`,
   comptime `$` params, optional return type, block-or-`;` body), `rec`, `uni`,
@@ -727,8 +721,8 @@ Doc-only (intended surface, not a distinct parser production):
   `$type_of`, `$fields`, `$error`, `$assert`) — syntactically
   indistinguishable from any other `comptime-ident` call.
 - The closed decorator directive set (`symbol`, `library`, `inline`, `align`,
-  `section`) — the parser accepts any `IDENT` after `` ` `` or `#[`; sema
-  enforces the closed set.
+  `section`) — the parser accepts any `IDENT` after `#[`; sema enforces the
+  closed set.
 
 Divergences flagged inline:
 

--- a/doc/language/rec.md
+++ b/doc/language/rec.md
@@ -43,8 +43,8 @@ val n: i64            = p.x;            # field access via .
 ## Layout
 
 By default the compiler may insert padding between fields for alignment. The
-`` `align(N)` `` backtick decorator on a record raises its minimum type
-alignment to `N` bytes (a power of two); see [decorators.md](decorators.md).
+`#[align(N)]` decorator on a record raises its minimum type alignment to `N`
+bytes (a power of two); see [decorators.md](decorators.md).
 
 > Disabling padding entirely (a `packed` layout for binary-protocol / on-disk
 > structs) is not yet available — the field-to-field padding always follows the

--- a/doc/language/visibility.md
+++ b/doc/language/visibility.md
@@ -25,14 +25,14 @@ Declares a function with C ABI as a forward reference — body-less. The
 linker resolves the symbol at link time. Only functions can be `ext`.
 
 ```mach
-`symbol("write")`
+#[symbol("write")]
 pub ext fun libc_write(fd: i64, buf: *u8, n: i64) i64;
 ```
 
 - `ext fun` declarations have no body.
 - The C ABI is the contract; argument and return types must be
   representable in C.
-- Use the `` `symbol("real_name")` `` decorator to override the linker name.
+- Use the `#[symbol("real_name")]` decorator to override the linker name.
 
 There are no body-less functions outside of `ext fun`. Regular forward
 declarations do not exist.

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/octalide/mach-std"
 ref = "branch/main"
-commit = "88b4d33f5593ff1e598b77e710ae13d4fa8a5aa5"
+commit = "2e95444191a98e8dd6419faeaff1a6fc23515d3a"

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -299,7 +299,7 @@ fun write_source(path: *u8, content: *u8) bool {
 # `mach init`. this is a standard-library hello world wired through
 # `std.runtime` and `std.print`.
 fun main_template() *u8 {
-    ret "use std.runtime;\nuse print: std.print;\n\n`symbol(\"main\")`\nfun main(argc: i64, argv: **u8) i64 {\n    print.println(\"Hello, World!\");\n    ret 0;\n}\n";
+    ret "use std.runtime;\nuse print: std.print;\n\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i64 {\n    print.println(\"Hello, World!\");\n    ret 0;\n}\n";
 }
 
 # lib_template: the starter library root module written by `mach init --lib`.

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -147,7 +147,7 @@ pub fun codegen_module(s: *sess.Session, tgt: *target.Target,
 
 # build the object image from the encoder output and the module's globals.
 #
-# moves each `section("...")` function into its named section, builds `.text`
+# moves each `#[section("...")]` function into its named section, builds `.text`
 # from the remaining non-sectioned bytes, registers every symbol mark against its
 # section, attaches the encoder's relocations, then materialises each module
 # global into a data / rodata / bss section with its defining symbol. on any
@@ -166,7 +166,7 @@ fun pack_image(s: *sess.Session, tgt: *target.Target, irmod: *ir.Module,
     }
     var image: of.ObjectImage = unwrap_ok[of.ObjectImage, str](rimg);
 
-    # `section("...")` decorators move individual functions out of the shared
+    # `#[section("...")]` decorators move individual functions out of the shared
     # `.text` into named sections. build one placement per sectioned function
     # (creating its section and copying the sectioned bytes out of the encoder
     # blob) first, so pack_text can then assemble `.text` from the remaining
@@ -307,7 +307,7 @@ fun image_has_symbol(image: *of.ObjectImage, name: intern.StrId) bool {
     ret false;
 }
 
-# SectionPlacement: a function moved out of `.text` by a `section("...")`
+# SectionPlacement: a function moved out of `.text` by a `#[section("...")]`
 # decorator. its [text_start, text_end) byte range in the encoder blob is copied
 # into the named section `sec` and excised from `.text`; a mark or relocation at
 # offset O in that range is re-homed to (sec, O - text_start), while every
@@ -318,7 +318,7 @@ rec SectionPlacement {
     sec:        u32;
 }
 
-# function_section: the object section name a `section("...")` decorator places
+# function_section: the object section name a `#[section("...")]` decorator places
 # the defined function `name` in, or STR_NIL for the default `.text`.
 fun function_section(irmod: *ir.Module, name: intern.StrId) intern.StrId {
     var i: u32 = 0;
@@ -446,7 +446,7 @@ fun build_section_placements(s: *sess.Session, image: *of.ObjectImage, irmod: *i
 
 # assemble the `.text` section from the NON-sectioned functions.
 #
-# with no `section("...")` decorator (`count == 0`) the encoder blob is adopted
+# with no `#[section("...")]` decorator (`count == 0`) the encoder blob is adopted
 # whole and emission is byte-for-byte unchanged. otherwise each sectioned
 # function's [start, end) range — already copied into its named section by
 # build_section_placements — is excised and the remaining bytes are packed
@@ -767,7 +767,7 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
             }
         }
 
-        # a `section("...")` decorator overrides the default section name (the
+        # a `#[section("...")]` decorator overrides the default section name (the
         # data/rodata/bss kind is kept, so an over-named bss stays zero-filled).
         var sec_name: intern.StrId = g.section;
         if (sec_name == intern.STR_NIL) {
@@ -794,9 +794,9 @@ fun pack_globals(s: *sess.Session, tgt: *target.Target, image: *of.ObjectImage,
         sec.bytes = bytes;
         sec.len   = sec_len;
         # the section is aligned to the strictest of: the 8-byte default, the
-        # global's own type alignment (which an `align(...)` decorator on the type
+        # global's own type alignment (which an `#[align(...)]` decorator on the type
         # can raise — natural alignment never exceeds 8, so un-decorated globals
-        # stay at 8), and an `align(...)` decorator on the global itself.
+        # stay at 8), and an `#[align(...)]` decorator on the global itself.
         sec.align = 8;
         val tya: u32 = ir_type.byte_align(?irmod.types, g.ty, tgt);
         if (tya > sec.align) { sec.align = tya; }

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -211,7 +211,7 @@ fun aggregate_sse_mask(ctx: *lctx.LowerCtx, ty: ir_type.IrTypeId) u8 {
 # its element's member count by the length; a union takes the widest member's count
 # (its members overlap). any non-FP leaf, an empty aggregate, or a mix of fundamental
 # widths makes the whole aggregate non-homogeneous (returns false, out params unset).
-# member counting is by recursion, never `size / width`, so an explicit `align(...)`
+# member counting is by recursion, never `size / width`, so an explicit `#[align(...)]`
 # that pads the aggregate's size never inflates the count.
 fun hfa_walk(ctx: *lctx.LowerCtx, ty: ir_type.IrTypeId, out_elem: *u32, out_count: *u32) bool {
     val it: Option[*ir_type.IrType] = ir_type.get(ctx.types, ty);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -514,7 +514,7 @@ fun build_project_impl(s: *sess.Session, project_root: str, sel: *manifest.Selec
         ret err[Project, str](unwrap_err[bool, str](resolve_r));
     }
 
-    # record every `` `symbol("...")` `` link-name override so the back-end
+    # record every `#[symbol("...")]` link-name override so the back-end
     # mangler keeps the named entry / runtime symbols literal.
     val exp_r: Result[bool, str] = register_export_names(?p);
     if (is_err[bool, str](exp_r)) {
@@ -522,8 +522,8 @@ fun build_project_impl(s: *sess.Session, project_root: str, sel: *manifest.Selec
         ret err[Project, str](unwrap_err[bool, str](exp_r));
     }
 
-    # project `` `library(...)` `` attributions onto link-name keys now that every
-    # import's final link name (`` `symbol` `` override or bare `ext` name) is settled.
+    # project `#[library(...)]` attributions onto link-name keys now that every
+    # import's final link name (`#[symbol]` override or bare `ext` name) is settled.
     val imp_r: Result[bool, str] = register_import_libraries(?p);
     if (is_err[bool, str](imp_r)) {
         dnit_project(?p);
@@ -689,7 +689,7 @@ fun add_union_entry(p: *Project, entries: *intern.StrId, w: u32, cap: u32, id_te
     ret ok[u32, str](w + 1);
 }
 
-# register_export_names: scan every module for `` `symbol("...")` `` decorators
+# register_export_names: scan every module for `#[symbol("...")]` decorators
 # and `ext fun` defaults and record each as a literal link-name override keyed by
 # (ModuleId, DeclId) on the session. the decorated decl keeps the literal string
 # verbatim as its emitted symbol name. this is the sole mechanism keeping the
@@ -719,7 +719,7 @@ fun register_module_export_names(p: *Project, mid: sess.ModuleId) Result[bool, s
     ret scan_export_directives(p, mid, source, mod_node.decls_start, mod_node.decls_len);
 }
 
-# register_import_libraries: project the per-decl `` `library(...)` `` attributions
+# register_import_libraries: project the per-decl `#[library(...)]` attributions
 # (keyed by decl) onto the session's link-name-keyed `import_libraries` map. run
 # after every `` `symbol`/`library` `` decorator and `ext fun` default is recorded,
 # so each import's final link name is settled. for every `ext` decl pinned to a
@@ -742,8 +742,8 @@ fun register_import_libraries(p: *Project) Result[bool, str] {
 
 # bind_import_libraries: walk a decl list (recursing into comptime-if branch
 # bodies, where target-selected `ext` bindings live) and, for each `ext fun`
-# pinned by a `` `library(...)` `` decorator, record `<final link name> -> <library>`
-# on the session. the final link name is the decl's `export_name` (the `` `symbol` ``
+# pinned by a `#[library(...)]` decorator, record `<final link name> -> <library>`
+# on the session. the final link name is the decl's `export_name` (the `#[symbol]`
 # value when present, else the bare identifier), so the key matches the object
 # symbol the linker later sees.
 fun bind_import_libraries(p: *Project, mid: sess.ModuleId, start: u32, len: u32) Result[bool, str] {
@@ -826,8 +826,8 @@ fun scan_export_directives(p: *Project, mid: sess.ModuleId, source: str, start: 
 }
 
 # register_decl_decorators: apply decl `d`'s leading backtick decorators the
-# link-name machinery owns — `` `symbol("name")` `` records the literal link name
-# and `` `library("lib")` `` pins an `ext` import's library — into the session
+# link-name machinery owns — `#[symbol("name")]` records the literal link name
+# and `#[library("lib")]` pins an `ext` import's library — into the session
 # registries, so a definition and its references resolve the name identically.
 # each takes a single string-literal argument. directives without a link-name
 # effect (section / inline / align) are left for the sema validation pass; a
@@ -873,7 +873,7 @@ fun register_decl_decorators(p: *Project, mid: sess.ModuleId, source: str, d: *d
 # register_ext_fun: record an `ext fun` foreign symbol's literal link name (its
 # bare source identifier) as the decl's export override, so it is never mangled.
 # the linker binds it to the imported C / syscall symbol of that name. the bare
-# name is only the default: a `` `symbol("...")` `` decorator on the same decl is
+# name is only the default: a `#[symbol("...")]` decorator on the same decl is
 # an explicit override that must win, so registration is skipped when one is
 # already recorded. a decorator scanned later still overwrites the default
 # through register_export_name.

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1012,14 +1012,14 @@ test "diagnostics: a value name used as a type is told it does not name a type (
     ret 0;
 }
 
-test "diagnostics: an unknown backtick decorator is rejected (#1476)" {
+test "diagnostics: an unknown decorator is rejected (#1476)" {
     var alloc: Allocator;
     val sr: Result[sess.Session, str] = t_session(?alloc);
     if (is_err[sess.Session, str](sr)) { ret 1; }
     var s: sess.Session = unwrap_ok[sess.Session, str](sr);
     var es: EditorSession = init(?s);
 
-    val fr: Result[src.FileId, str] = open(?es, "ud.mach", "`bogus` fun f() i64 { ret 0; }\n");
+    val fr: Result[src.FileId, str] = open(?es, "ud.mach", "#[bogus] fun f() i64 { ret 0; }\n");
     if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
 
@@ -1040,7 +1040,7 @@ test "diagnostics: a decorator on an incompatible target is rejected (#1476)" {
     var es: EditorSession = init(?s);
 
     # `align` targets records, unions, and globals, not a function — reported.
-    val fr: Result[src.FileId, str] = open(?es, "wt.mach", "`align(8)` fun f() i64 { ret 0; }\n");
+    val fr: Result[src.FileId, str] = open(?es, "wt.mach", "#[align(8)] fun f() i64 { ret 0; }\n");
     if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
 
@@ -1063,7 +1063,7 @@ test "diagnostics: a section decorator on a function or global is accepted; on a
     # `section` applies to functions and globals (placed, no error); a `def` type
     # is not a symbol-bearing decl, so a section on it is reported.
     val fr: Result[src.FileId, str] = open(?es, "se.mach",
-        "`section(\".s\")` pub var g: u64 = 0;\n`section(\".s\")` fun f() i64 { ret 0; }\n`section(\".s\")` def D: u64;\n");
+        "#[section(\".s\")] pub var g: u64 = 0;\n#[section(\".s\")] fun f() i64 { ret 0; }\n#[section(\".s\")] def D: u64;\n");
     if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
 
@@ -1084,10 +1084,10 @@ test "diagnostics: a negative align on a type is reported, not silently dropped 
     var s: sess.Session = unwrap_ok[sess.Session, str](sr);
     var es: EditorSession = init(?s);
 
-    # `align(-8)` on a record folds to a negative integer-typed constant — the
+    # `#[align(-8)]` on a record folds to a negative integer-typed constant — the
     # body-pass validator can't catch it (it's integer-typed), so the decl-pass
     # fold must report it rather than `ret` silently.
-    val fr: Result[src.FileId, str] = open(?es, "na.mach", "`align(-8)` rec R { a: u8; }\n");
+    val fr: Result[src.FileId, str] = open(?es, "na.mach", "#[align(-8)] rec R { a: u8; }\n");
     if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
 
@@ -1109,7 +1109,7 @@ test "diagnostics: align on a def alias is rejected, not silently ignored (#1490
 
     # a `def` alias has no layout of its own and emits no symbol, so an `align` on
     # it would silently no-op; it is rejected as an invalid target instead.
-    val fr: Result[src.FileId, str] = open(?es, "da.mach", "`align(8)` def D: u64;\n");
+    val fr: Result[src.FileId, str] = open(?es, "da.mach", "#[align(8)] def D: u64;\n");
     if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
     val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
 

--- a/src/lang/fe/ast/decl.mach
+++ b/src/lang/fe/ast/decl.mach
@@ -165,7 +165,7 @@ pub rec DeclComptimeAttr {
 }
 
 # Decorator: a leading backtick per-declaration codegen directive (#1476), e.g.
-# `` `symbol("_start")` `` / `` `inline` `` / `` `align($align_of(u64))` ``.
+# `#[symbol("_start")]` / `#[inline]` / `#[align($align_of(u64))]`.
 # codegen-only (never visibility). attached to the following decl via the decl's
 # decorators_start/decorators_len range.
 # ---

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -75,7 +75,7 @@ pub fun parse_module(p: *parser.Parser) id.ModuleId {
 }
 
 # parse_decl: parses a single top-level declaration, including any leading
-# decorators (backtick or `#[...]`) that attach to it.
+# `#[...]` decorators that attach to it.
 # ---
 # p:   parser state positioned at the first token of the declaration
 # ret: DeclId of the parsed declaration, or DECL_NIL on failure
@@ -100,7 +100,7 @@ pub fun parse_decl(p: *parser.Parser) id.DeclId {
 # parse_decl_dispatch: dispatches on the leading `$` or keyword (after any
 # decorators) to the matching declaration parser, or reports an error and
 # yields an ERROR decl. `start` spans the declaration's first token (a
-# decorator's opening backtick or `#[` when decorators are present).
+# decorator's opening `#[` when decorators are present).
 fun parse_decl_dispatch(p: *parser.Parser, start: token.Span) id.DeclId {
     if (parser.at(p, token.KIND_DOLLAR))  { ret parse_comptime_decl(p, start); }
 
@@ -124,36 +124,51 @@ fun parse_decl_dispatch(p: *parser.Parser, start: token.Span) id.DeclId {
     ret parser.push_decl(p, err);
 }
 
-# parse_decorators: parses zero or more leading decorator clauses in either
-# surface — `` `name(args)` `` backticks or `#[name(args)]` attributes (#1532) —
-# appending each to ast.decorators as one contiguous block. writes the block
-# length through `out_len` and returns its start index.
+# parse_decorators: parses zero or more leading `#[name(args)]` decorator clauses,
+# appending each to ast.decorators as one contiguous block. writes the block length
+# through `out_len` and returns its start index. backtick decorators (`` `name` ``)
+# were removed in v2.4.0; a backtick at decorator position is diagnosed once and its
+# clause skipped so the following declaration still parses (no cascade).
 fun parse_decorators(p: *parser.Parser, out_len: *u32) u32 {
     val start: u32 = p.ast.decorator_len::u32;
-    var count: u32 = 0;
-    for (parser.at(p, token.KIND_BACKTICK) || parser.at(p, token.KIND_ATTR_OPEN)) {
-        if (!parse_one_decorator(p)) { brk; }
-        count = count + 1;
+    var count:    u32  = 0;
+    var reported: bool = false;
+    for (parser.at(p, token.KIND_ATTR_OPEN) || parser.at(p, token.KIND_BACKTICK)) {
+        if (parser.at(p, token.KIND_BACKTICK)) {
+            if (!reported) {
+                parser.error_at_current(p, "backtick decorators were removed in v2.4.0; use #[name(...)]");
+                reported = true;
+            }
+            skip_backtick_decorator(p);
+        } or {
+            if (!parse_one_decorator(p)) { brk; }
+            count = count + 1;
+        }
     }
     @out_len = count;
     ret start;
 }
 
-# parses a single decorator clause — `` `name` ``/`` `name(args)` `` or its
-# `#[name]`/`#[name(args)]` attribute equivalent — and appends it to
-# ast.decorators. both surfaces converge on the same Decorator node; the
-# directive name and any comptime-expr arguments are validated later in sema,
-# so only the closing delimiter differs by surface.
+# skips a removed backtick decorator clause (`` `name` `` / `` `name(args)` ``) for
+# recovery after the v2.4.0 migration diagnostic: consumes the opening backtick and
+# every token through its closing backtick (or to end of file when unterminated), so
+# parsing resumes at the declaration the clause meant to attach to.
+fun skip_backtick_decorator(p: *parser.Parser) {
+    parser.advance(p);
+    for (!parser.at(p, token.KIND_BACKTICK) && !parser.at_eof(p)) {
+        parser.advance(p);
+    }
+    if (parser.at(p, token.KIND_BACKTICK)) { parser.advance(p); }
+}
+
+# parses a single `#[name]` / `#[name(args)]` decorator clause and appends it to
+# ast.decorators. the directive name and any comptime-expr arguments are validated
+# later in sema.
 fun parse_one_decorator(p: *parser.Parser) bool {
-    val attr: bool = parser.at(p, token.KIND_ATTR_OPEN);
     parser.advance(p);
 
     if (!parser.at(p, token.KIND_IDENT)) {
-        if (attr) {
-            parser.error_at_current(p, "expected attribute name after '#['");
-        } or {
-            parser.error_at_current(p, "expected decorator name after '`'");
-        }
+        parser.error_at_current(p, "expected attribute name after '#['");
         ret false;
     }
     val name: token.Span = parser.advance(p).span;
@@ -164,11 +179,7 @@ fun parse_one_decorator(p: *parser.Parser) bool {
         args_start = parse_decorator_args(p, ?args_len);
     }
 
-    if (attr) {
-        parser.expect(p, token.KIND_RBRACKET, "expected closing ']' to end attribute");
-    } or {
-        parser.expect(p, token.KIND_BACKTICK, "expected closing '`' to end decorator");
-    }
+    parser.expect(p, token.KIND_RBRACKET, "expected closing ']' to end attribute");
 
     var d: decl.Decorator;
     d.name       = name;
@@ -769,8 +780,8 @@ fun parse_comptime_if_decl(p: *parser.Parser, start: token.Span) id.DeclId {
 
 # parses a leading-`$` declaration that is not a `$if`: a bare comptime directive
 # `$intrinsic(args);` (e.g. `$error("msg")`). the legacy attribute-write setter
-# `$sym.attr = value;` was removed in v2.0.0 (superseded by `` `symbol(...)` `` /
-# `` `library(...)` `` backtick decorators); a stray `=` after the target is
+# `$sym.attr = value;` was removed in v2.0.0 (superseded by the `#[symbol(...)]` /
+# `#[library(...)]` decorators); a stray `=` after the target is
 # rejected with a migration diagnostic.
 fun parse_comptime_directive_decl(p: *parser.Parser, start: token.Span) id.DeclId {
     # parse the target above assignment precedence so a stray '=' is not swallowed
@@ -778,7 +789,7 @@ fun parse_comptime_directive_decl(p: *parser.Parser, start: token.Span) id.DeclI
     val target: id.ExprId = pexpr.parse_expr_bp(p, 2);
 
     if (parser.at(p, token.KIND_EQ)) {
-        parser.error_at_current(p, "comptime attribute setters were removed in v2.0.0; use a `symbol(\"...\")` or `library(\"...\")` backtick decorator on the declaration");
+        parser.error_at_current(p, "comptime attribute setters were removed in v2.0.0; use a #[symbol(\"...\")] or #[library(\"...\")] decorator on the declaration");
         # consume the assignment so recovery resumes at the next statement
         parser.advance(p);
         pexpr.parse_expr(p);
@@ -1411,12 +1422,13 @@ test "parser: a bare-form statement keyword used as an identifier parses as an e
     ret rc;
 }
 
-test "parser: leading backtick decorators attach to the following decl (#1476)" {
-    # `inline` (bare flag) and `symbol("_start")` (one comptime-expr arg) both
-    # attach to `f`; the following `g` has none — decorators do not bleed across.
+test "parser: a backtick decorator is rejected and the decl recovers (#1526)" {
+    # backtick decorators were removed in v2.4.0; `` `symbol(...)` `` must now
+    # diagnose and the following `f`/`g` must still parse (recovery, no cascade)
+    # with nothing attached by the rejected clause.
     var alloc: Allocator;
     page.make(?alloc);
-    val source: str = "`inline` `symbol(\"_start\")` fun f() {} fun g() {}";
+    val source: str = "`symbol(\"_start\")` fun f() {} fun g() {}";
     val tr: Result[lexer.TokenStream, str] = lexer.tokenize(source, ?alloc, 0::src.FileId);
     if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
     var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
@@ -1426,21 +1438,51 @@ test "parser: leading backtick decorators attach to the following decl (#1476)" 
     parse_module(?p);
 
     var rc: i32 = 0;
-    if      (diag.has_errors(?diags))               { rc = 1; }
+    if      (!diag.has_errors(?diags))              { rc = 1; }
     or      (a.decl_len < 2)                        { rc = 1; }
     or      (a.decls[0].kind != decl.DECL_KIND_FUN) { rc = 1; }
     or      (a.decls[1].kind != decl.DECL_KIND_FUN) { rc = 1; }
-    or      (a.decls[0].decorators_len != 2)        { rc = 1; }
+    or      (a.decls[0].decorators_len != 0)        { rc = 1; }
     or      (a.decls[1].decorators_len != 0)        { rc = 1; }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "parser: a bare backtick at decorator position is rejected (#1526)" {
+    # any backtick where a decorator may lead is the removed surface — diagnose it,
+    # whether the clause is well-formed, unterminated, or empty.
+    if (!t_parse_module_has_errors("`inline` fun f() {}")) { ret 1; }
+    if (!t_parse_module_has_errors("`inline fun f() {}")) { ret 1; }
+    if (!t_parse_module_has_errors("`` fun f() {}")) { ret 1; }
+    ret 0;
+}
+
+test "parser: a backtick clause is skipped but a following #[...] still attaches (#1526)" {
+    # `` `inline` `` is rejected; the trailing `#[symbol(...)]` must still attach to
+    # `f` — recovery does not discard valid attributes after the removed surface.
+    var alloc: Allocator;
+    page.make(?alloc);
+    val source: str = "`inline` #[symbol(\"_start\")] fun f() {}";
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize(source, ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+    parse_module(?p);
+
+    var rc: i32 = 0;
+    if      (!diag.has_errors(?diags))       { rc = 1; }
+    or      (a.decl_len < 1)                 { rc = 1; }
+    or      (a.decls[0].decorators_len != 1) { rc = 1; }
 
     if (rc == 0) {
         val d0: decl.Decorator = a.decorators[a.decls[0].decorators_start];
-        val d1: decl.Decorator = a.decorators[a.decls[0].decorators_start + 1];
-        # `inline` is a bare flag; `symbol(...)` carries exactly one arg
-        if (!str_region_equals(p.tokens.source, d0.name.offset, d0.name.len, "inline")) { rc = 1; }
-        if (d0.args_len != 0)                                                           { rc = 1; }
-        if (!str_region_equals(p.tokens.source, d1.name.offset, d1.name.len, "symbol")) { rc = 1; }
-        if (d1.args_len != 1)                                                           { rc = 1; }
+        if (!str_region_equals(p.tokens.source, d0.name.offset, d0.name.len, "symbol")) { rc = 1; }
+        if (d0.args_len != 1)                                                           { rc = 1; }
     }
 
     diag.dnit(?diags);
@@ -1449,17 +1491,9 @@ test "parser: leading backtick decorators attach to the following decl (#1476)" 
     ret rc;
 }
 
-test "parser: an unterminated backtick decorator reports an error (#1476)" {
-    # a decorator name with no closing backtick must diagnose, not silently parse
-    if (!t_parse_module_has_errors("`inline fun f() {}")) { ret 1; }
-    # a backtick with no directive name must diagnose
-    if (!t_parse_module_has_errors("`` fun f() {}")) { ret 1; }
-    ret 0;
-}
-
-test "parser: leading #[...] attributes attach with the same AST as backticks (#1532)" {
+test "parser: leading #[...] attributes attach to the following decl (#1532)" {
     # `#[inline]` (bare flag) and `#[symbol("_start")]` (one comptime-expr arg)
-    # attach to `f`; `g` has none — the same shape the backtick form produces.
+    # attach to `f`; `g` has none — decorators do not bleed across.
     var alloc: Allocator;
     page.make(?alloc);
     val source: str = "#[inline] #[symbol(\"_start\")] fun f() {} fun g() {}";
@@ -1484,38 +1518,6 @@ test "parser: leading #[...] attributes attach with the same AST as backticks (#
         val d1: decl.Decorator = a.decorators[a.decls[0].decorators_start + 1];
         if (!str_region_equals(p.tokens.source, d0.name.offset, d0.name.len, "inline")) { rc = 1; }
         if (d0.args_len != 0)                                                           { rc = 1; }
-        if (!str_region_equals(p.tokens.source, d1.name.offset, d1.name.len, "symbol")) { rc = 1; }
-        if (d1.args_len != 1)                                                           { rc = 1; }
-    }
-
-    diag.dnit(?diags);
-    ast.dnit(?a);
-    lexer.dnit(?stream, ?alloc);
-    ret rc;
-}
-
-test "parser: backtick and #[...] decorators mix on one decl (#1532)" {
-    # both surfaces may precede the same decl and accumulate into one block.
-    var alloc: Allocator;
-    page.make(?alloc);
-    val source: str = "`inline` #[symbol(\"_start\")] fun f() {}";
-    val tr: Result[lexer.TokenStream, str] = lexer.tokenize(source, ?alloc, 0::src.FileId);
-    if (is_err[lexer.TokenStream, str](tr)) { ret 1; }
-    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
-    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
-    var diags: diag.DiagList = diag.init(?alloc);
-    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
-    parse_module(?p);
-
-    var rc: i32 = 0;
-    if      (diag.has_errors(?diags))        { rc = 1; }
-    or      (a.decl_len < 1)                 { rc = 1; }
-    or      (a.decls[0].decorators_len != 2) { rc = 1; }
-
-    if (rc == 0) {
-        val d0: decl.Decorator = a.decorators[a.decls[0].decorators_start];
-        val d1: decl.Decorator = a.decorators[a.decls[0].decorators_start + 1];
-        if (!str_region_equals(p.tokens.source, d0.name.offset, d0.name.len, "inline")) { rc = 1; }
         if (!str_region_equals(p.tokens.source, d1.name.offset, d1.name.len, "symbol")) { rc = 1; }
         if (d1.args_len != 1)                                                           { rc = 1; }
     }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1110,7 +1110,7 @@ fun bind_one_decl(rc: *ResolveContext, decl_id: id.DeclId) Result[bool, str] {
     val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
 
     # a decl's backtick decorator arguments are comptime expressions; bind their
-    # identifiers (e.g. the operand of `align($size_of(T))`) so sema can type them.
+    # identifiers (e.g. the operand of `#[align($size_of(T))]`) so sema can type them.
     val rda: Result[bool, str] = bind_decorator_args(rc, d);
     if (is_err[bool, str](rda)) { ret rda; }
 

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -437,7 +437,7 @@ fun infer_one_body(sc: *ctxm.SemaContext, did: id.DeclId) Result[bool, str] {
     val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
 
     # a decl's backtick decorator arguments are comptime expressions; infer them
-    # so their types resolve (e.g. `align($size_of(T))`) before the middle end
+    # so their types resolve (e.g. `#[align($size_of(T))]`) before the middle end
     # folds them.
     infer_decorator_args(sc, d);
     validate_decorators(sc, d);

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -166,7 +166,7 @@ fun infer_nominal_uni(sc: *sema.SemaContext, did: id.DeclId, name_span: token.Sp
     ret ty;
 }
 
-# folds an `align(...)` decorator on the record/union declaration `did` and
+# folds an `#[align(...)]` decorator on the record/union declaration `did` and
 # records the resulting alignment for nominal TypeId `ty` on the session, so the
 # middle end can over-align the lowered IR struct. the argument is a compile-time
 # constant (a literal or `$mach.build.*`) folded by `comptime.eval`; a non-constant

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -173,7 +173,7 @@ pub rec Function {
     label:       intern.StrId;
     line:        u32;
 
-    # object section name from a `section("...")` decorator, or STR_NIL for the
+    # object section name from a `#[section("...")]` decorator, or STR_NIL for the
     # default `.text`; the back end places the function's encoded bytes there.
     section:     intern.StrId;
 
@@ -197,10 +197,10 @@ pub rec Function {
 #            modules' anonymous globals never collide. a named user global is
 #            not local: its name is module-path-mangled and globally unique, so
 #            it is given GLOBAL linkage and resolves cross-object.
-# align: explicit byte alignment from an `align(...)` decorator (a power of two),
+# align: explicit byte alignment from an `#[align(...)]` decorator (a power of two),
 # or 0 to use the back end's default for the global's section. always a power of
 # two when non-zero (lowering validates the folded value).
-# section: the object section name from a `section("...")` decorator, or STR_NIL
+# section: the object section name from a `#[section("...")]` decorator, or STR_NIL
 # to use the back end's default (.data / .rodata / .bss by mutability and init).
 pub rec Global {
     name:      intern.StrId;

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -96,7 +96,7 @@ pub rec IrTypeArray {
 # ---
 # fields:      pointer to a contiguous array of field IrTypeIds (owned)
 # field_count: number of fields
-# align:       explicit alignment from an `align(...)` decorator (a power of two),
+# align:       explicit alignment from an `#[align(...)]` decorator (a power of two),
 #              or 0 for the type's natural alignment. part of the dedup key, so an
 #              over-aligned record is a distinct type from its un-aligned twin.
 pub rec IrTypeStruct {
@@ -259,7 +259,7 @@ pub fun intern_array(t: *IrTypeTable, element: IrTypeId, count: u32) Result[IrTy
 # t:           the table
 # fields:      pointer to a contiguous array of field IrTypeIds
 # field_count: number of fields
-# align:       explicit alignment (a power of two) from an `align(...)` decorator,
+# align:       explicit alignment (a power of two) from an `#[align(...)]` decorator,
 #              or 0 for natural alignment
 # ret:         the IrTypeId for the struct, or an allocation error
 pub fun intern_struct(t: *IrTypeTable, fields: *IrTypeId, field_count: u32, align: u32) Result[IrTypeId, str] {
@@ -278,7 +278,7 @@ pub fun intern_struct(t: *IrTypeTable, fields: *IrTypeId, field_count: u32, alig
 # t:           the table
 # fields:      pointer to a contiguous array of member IrTypeIds
 # field_count: number of members
-# align:       explicit alignment (a power of two) from an `align(...)` decorator,
+# align:       explicit alignment (a power of two) from an `#[align(...)]` decorator,
 #              or 0 for natural alignment
 # ret:         the IrTypeId for the union type, or an allocation error
 pub fun intern_union(t: *IrTypeTable, fields: *IrTypeId, field_count: u32, align: u32) Result[IrTypeId, str] {
@@ -413,7 +413,7 @@ pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
             if (fa > align) { align = fa; }
             i = i + 1;
         }
-        # an `align(...)` decorator can raise the alignment (never lower it), which
+        # an `#[align(...)]` decorator can raise the alignment (never lower it), which
         # also rounds the total size up to the larger alignment.
         if (ir.data.struct_.align > align) { align = ir.data.struct_.align; }
         ret round_up(off, align);
@@ -463,7 +463,7 @@ pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
             if (fa > align) { align = fa; }
             i = i + 1;
         }
-        # an `align(...)` decorator raises the alignment above the natural maximum.
+        # an `#[align(...)]` decorator raises the alignment above the natural maximum.
         if (ir.data.struct_.align > align) { align = ir.data.struct_.align; }
         ret align;
     }

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -957,7 +957,7 @@ pub fun lower_type(lc: *LowerContext, tid: ty.TypeId) Result[ir_type.IrTypeId, s
 # referenced from another module. a type with no field table lowers to an
 # empty struct, keeping lowering total.
 fun lower_nominal(lc: *LowerContext, tid: ty.TypeId, is_union: bool) Result[ir_type.IrTypeId, str] {
-    # an `align(...)` decorator on the record/union, folded by sema and keyed by
+    # an `#[align(...)]` decorator on the record/union, folded by sema and keyed by
     # this nominal TypeId; 0 leaves the natural alignment.
     var nom_align: u32 = 0;
     val ta: Option[u32] = sess.type_align(lc.s, tid::u32);

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -1016,7 +1016,7 @@ fun decl_has_decorator(ctx: *lower.LowerContext, d: *adecl.Decl, name: str) bool
     ret false;
 }
 
-# decl_section_of: the interned section name a `section("...")` decorator places
+# decl_section_of: the interned section name a `#[section("...")]` decorator places
 # decl `d` in, or STR_NIL for the back end's default. the argument is a string
 # literal (sema validated the shape); its inner content (quotes stripped) is
 # interned.
@@ -1053,10 +1053,10 @@ fun decorator_arg_eid(ctx: *lower.LowerContext, d: *adecl.Decl, name: str, ord: 
     ret none[aid.ExprId]();
 }
 
-# global_align_of: the explicit alignment an `align(expr)` decorator pins a global
+# global_align_of: the explicit alignment an `#[align(expr)]` decorator pins a global
 # to, or 0 when none is present (the back end then uses its section default). the
 # argument is folded to a compile-time constant by the same constant path a global
-# initialiser uses (so `align($align_of(u64))` and `align(16)` both work) and must
+# initialiser uses (so `#[align($align_of(u64))]` and `#[align(16)]` both work) and must
 # be a power of two; a non-constant or non-power-of-two value is reported on the
 # binding's name and the build is gated.
 fun global_align_of(ctx: *lower.LowerContext, d: *adecl.Decl) Result[u32, str] {
@@ -1211,7 +1211,7 @@ fun is_void_ir(ctx: *lower.LowerContext, tid: ir_type.IrTypeId) bool {
 # fun_export_of: the link-name override that exempts a function declaration from
 # mangling, or none. the exemption is read from the session's `export_names`
 # registry, the single source of truth the driver populates from both exemption
-# sources: a `` `symbol("...")` `` decorator's explicit literal name, and an
+# sources: a `#[symbol("...")]` decorator's explicit literal name, and an
 # `ext fun` foreign symbol's bare name (registered keyed on `DECL_FLAG_EXT`, NOT
 # on FN_FLAG_EXTERN — a body-less mach signature is still a mangled mach symbol).
 # a definition and every reference consult this same registry, so the mangled /
@@ -1221,7 +1221,7 @@ fun fun_export_of(ctx: *lower.LowerContext, did: aid.DeclId) Option[intern.StrId
 }
 
 # global_export_of: the link-name override that exempts a global declaration from
-# mangling, or none. a `` `symbol(...)` `` decorator on the session supplies a
+# mangling, or none. a `#[symbol(...)]` decorator on the session supplies a
 # literal name (the runtime `_rt_argc/argv/envp` globals referenced by inline
 # asm). globals have no `ext` form, so the decorator is the only source.
 fun global_export_of(ctx: *lower.LowerContext, did: aid.DeclId) Option[intern.StrId] {

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -411,7 +411,7 @@ fun comptime_param_value(ctx: *lower.LowerContext, sid: resolve.SymbolId) Option
 # reference_linkage_name: the back-end symbol name a reference to module-level
 # symbol `sym` must resolve to. it is mangled against the *defining* module's
 # FQN (keyed by `sym.origin`) and honours the defining decl's export override
-# (an `ext fun` or `` `symbol(...)` `` literal stays literal), so it byte-matches the
+# (an `ext fun` or `#[symbol(...)]` literal stays literal), so it byte-matches the
 # name `lower_fun` / `lower_global` emitted for the definition: the definition
 # mangles against its own FQN through the same chokepoint with the same bare
 # name and override. a self-reference (origin == own_module) agrees trivially.

--- a/src/lang/me/lower/mangle.mach
+++ b/src/lang/me/lower/mangle.mach
@@ -5,7 +5,7 @@
 # qualified by its defining module's path so two modules' identically-named
 # `pub` declarations (e.g. `init` in dozens of modules) become distinct global
 # symbols; a symbol carrying an export override (an `ext fun` foreign symbol or
-# a `` `symbol(...)` `` entry / runtime decorator) keeps its literal name so inline
+# a `#[symbol(...)]` entry / runtime decorator) keeps its literal name so inline
 # asm and the OS entry point resolve against the exact name written in source.
 #
 # The scheme mirrors cmach's `symbol_mangle` (mach-boot symbol.c):
@@ -55,7 +55,7 @@ use float:  mach.lang.float;
 
 # linkage_name: the symbol name the back end emits for a function or global.
 # returns the export override verbatim when one is set (so `ext fun` foreign
-# symbols and `` `symbol(...)` `` entry / runtime decorators stay literal),
+# symbols and `#[symbol(...)]` entry / runtime decorators stay literal),
 # otherwise produces the module-path-qualified mangled name.
 # ---
 # s:      shared session (interner)

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -55,9 +55,9 @@ fwd modid.MODULE_NIL;
 # module_ast_count: number of registered module ASTs (the registry's logical length)
 # module_ast_cap:   allocated capacity of the module-AST registry
 # module_fqns:  ModuleId -> the module's fully-qualified path StrId; populated by the driver alongside module_asts, read by the back-end symbol mangler so a cross-module reference can name the defining module's mangled symbol (a reference is keyed on the referent's origin ModuleId, the definition on its own)
-# export_names: `(ModuleId << 32 | DeclId)` -> the literal link-name override declared by a `` `symbol("...")` `` decorator (or an `ext fun` foreign symbol); a decl present in this map keeps its literal name rather than being mangled, the sole exemption keeping the program entry, runtime, and foreign symbols linkable against the names written in inline asm
-# export_libraries: `(ModuleId << 32 | DeclId)` -> the dynamic library a `` `library("...")` `` decorator pins an `ext` import to (e.g. `"ws2_32.dll"`); consulted by the driver to build `import_libraries` once link names are final
-# type_aligns: nominal TypeId -> the explicit byte alignment an `align(...)` decorator pins a record/union to; folded once by sema (where the decl is visible) and read by the middle end when lowering the nominal to an IR struct so its layout honors the override
+# export_names: `(ModuleId << 32 | DeclId)` -> the literal link-name override declared by a `#[symbol("...")]` decorator (or an `ext fun` foreign symbol); a decl present in this map keeps its literal name rather than being mangled, the sole exemption keeping the program entry, runtime, and foreign symbols linkable against the names written in inline asm
+# export_libraries: `(ModuleId << 32 | DeclId)` -> the dynamic library a `#[library("...")]` decorator pins an `ext` import to (e.g. `"ws2_32.dll"`); consulted by the driver to build `import_libraries` once link names are final
+# type_aligns: nominal TypeId -> the explicit byte alignment an `#[align(...)]` decorator pins a record/union to; folded once by sema (where the decl is visible) and read by the middle end when lowering the nominal to an IR struct so its layout honors the override
 # import_libraries: link symbol name StrId -> the library StrId an import is pinned to; the link-name-keyed projection of `export_libraries` the back-end linker consults to attribute each PE import descriptor to a specific dependency rather than the first one
 # module_sema:    ModuleId -> its `*sema.SemaResult`, stored opaque (as `ptr`) to keep this leaf module free of an import cycle on the front end; the back-end monomorphizer casts it back to lower a generic template body against the typing of the module that declared it
 # module_resolve: ModuleId -> its `*resolve.ResolveResult`, stored opaque like module_sema, so a generic instance body is lowered against the declaring module's name resolution
@@ -322,7 +322,7 @@ pub fun module_fqn(s: *Session, mid: modid.ModuleId) intern.StrId {
 
 # register_export_name: record a literal link-name override for decl `did` in
 # module `mid`. a decl so registered keeps its literal name through lowering
-# instead of being mangled — the exemption mechanism for `` `symbol(...)` `` entry /
+# instead of being mangled — the exemption mechanism for `#[symbol(...)]` entry /
 # runtime decorators and `ext fun` foreign symbols. registering twice overwrites.
 # ---
 # s:    the session
@@ -349,7 +349,7 @@ pub fun export_name(s: *Session, mid: modid.ModuleId, did: u32) Option[intern.St
     ret none[intern.StrId]();
 }
 
-# register_export_library: record the dynamic library a `` `library("...")` ``
+# register_export_library: record the dynamic library a `#[library("...")]`
 # decorator pins decl `did` (an `ext` import) to, keyed by (ModuleId, DeclId). the
 # driver later projects this onto `import_libraries` by the decl's final link name
 # so the back-end linker can attribute the import to a specific dependency.
@@ -365,7 +365,7 @@ pub fun register_export_library(s: *Session, mid: modid.ModuleId, did: u32, lib:
 }
 
 # export_library: the library decl `did` in module `mid` is pinned to by a
-# `` `library(...)` `` decorator, or none when the import is unattributed.
+# `#[library(...)]` decorator, or none when the import is unattributed.
 # ---
 # s:   the session
 # mid: ModuleId owning the decl
@@ -378,7 +378,7 @@ pub fun export_library(s: *Session, mid: modid.ModuleId, did: u32) Option[intern
     ret none[intern.StrId]();
 }
 
-# register_type_align: record the explicit alignment an `align(...)` decorator
+# register_type_align: record the explicit alignment an `#[align(...)]` decorator
 # pins nominal TypeId `tid` to. folded once by sema; the middle end reads it when
 # lowering the nominal so its IR struct carries the override. registering twice
 # overwrites.

--- a/src/main.mach
+++ b/src/main.mach
@@ -13,7 +13,7 @@ use cmd: mach.cli.cmd;
 # argc: argument count including argv[0]
 # argv: the argument vector (argc null-terminated byte pointers)
 # ret:  the process exit code from the dispatched subcommand
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: usize, argv: **u8) i64 {
     ret cmd.dispatch(argc, argv);
 }


### PR DESCRIPTION
Phase 2 (compiler side) of epic #1526. Collapses the decorator surface to `#[attr]` only.

Closes #1535.

## What changed

- **Vendored std → mach-std 0.14.0** (`2e954441`), the `#[attr]`-only release, so the v2.4.0 compiler can build its dependency once backticks are gone.
- **Removed backtick decorator parsing** (`src/lang/fe/parser/decl.mach`). A backtick at decorator position now emits `backtick decorators were removed in v2.4.0; use #[name(...)]` (mirrors the v2.0.0 setter-removal diagnostic) and the clause is skipped so the following declaration still parses — one diagnostic, no cascade. `#[name(args)]` is the sole surface; `KIND_BACKTICK` is retained only to diagnose the removed form.
- **Migrated the compiler's own sites** to `#[attr]`: `src/main.mach` entry, the `mach init` template, `editor.mach` test sources, and the inline comments that documented the old surface.
- **Migrated `.github/tests/**`** decorator usages (run under the fresh v2.4.0 compiler) and reworked `attr/run.sh` — which derived and built a backtick twin — into a self-contained `#[attr]` correctness check.
- **Regression test** (`.github/tests/recovery/backtick`): a backtick decorator emits one migration diagnostic and recovers at the next decl; its `#[name(...)]` twin checks clean.
- **Docs**: `#[attr]` is the only decorator form; backtick production removed from the grammar; tangential mentions updated.

## Verification (local, x86_64-linux)

- Self-host fixpoint **holds, byte-reproducible from the v2.3.0 seed**: stage1 == stage2 == stage3 (`579831bb…`), no object-file diffs. Confirmed surface-only: pristine v2.3.0 source + v0.14.0 std also reproduces the seed exactly, so the std advance is inert.
- `mach test .` — **551 passed, 0 failed**.
- Integration: `recovery` (setter + varargs + new backtick + `#[attr]` twin), `decorator`, `attr` (all five directives + library PE + spaced `# [...]` comment), `inline`, `aligndec`, `sectiondec` — all green.

Ships as **v2.4.0** (version bump / release left to the maintainer).