### PR TITLE
fix(dep): resolve_cmd PATH search is POSIX-only, breaks on windows (#1538)

### DIFF
--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -118,18 +118,27 @@ pub fun is_value_flag(a: *u8) bool {
 }
 
 # resolve_cmd: resolve a command name to a concrete executable path for
-# `os.spawn` (execve performs no PATH search). a name containing '/' is
-# returned verbatim; a bare name is resolved by scanning the `PATH`
+# `os.spawn` (execve performs no PATH search). a name already containing a path
+# separator is returned verbatim; a bare name is resolved by scanning the `PATH`
 # environment variable. the resolved path is allocated from `alloc`.
+#
+# the PATH list separator and the path component separator are platform-specific:
+# posix uses ':' and '/', windows uses ';' and '\'. the windows list separator
+# must not be ':', since drive-letter prefixes (`C:\...`) embed a ':' that would
+# otherwise shatter every entry (#1538).
 # ---
 # alloc: allocator for the resolved path
 # name:  command name or path to resolve
 # ret:   the executable path, or an error message ("PATH unset" / "not found on PATH")
 pub fun resolve_cmd(alloc: *Allocator, name: *u8) Result[*u8, str] {
+    var list_sep: u8 = ':';
+    var path_sep: u8 = '/';
+    $if ($mach.build.os == $mach.os.windows) { list_sep = ';'; path_sep = '\\'; }
+
     val nlen: usize = slen(name);
     var h: usize = 0;
     for (h < nlen) {
-        if (name[h] == '/') { ret ok[*u8, str](name); }
+        if (name[h] == '/' || name[h] == path_sep) { ret ok[*u8, str](name); }
         h = h + 1;
     }
 
@@ -141,7 +150,7 @@ pub fun resolve_cmd(alloc: *Allocator, name: *u8) Result[*u8, str] {
     var i: usize = 0;
     for (i < plen) {
         val start: usize = i;
-        for (i < plen && path_buf[i] != ':') { i = i + 1; }
+        for (i < plen && path_buf[i] != list_sep) { i = i + 1; }
         val end: usize = i;
         if (i < plen) { i = i + 1; }
         if (end == start) { cnt; }
@@ -154,7 +163,7 @@ pub fun resolve_cmd(alloc: *Allocator, name: *u8) Result[*u8, str] {
         var k: usize = 0;
         var j: usize = start;
         for (j < end) { cand[k] = path_buf[j]; k = k + 1; j = j + 1; }
-        cand[k] = '/'; k = k + 1;
+        cand[k] = path_sep; k = k + 1;
         j = 0;
         for (j < nlen) { cand[k] = name[j]; k = k + 1; j = j + 1; }
         cand[k] = 0;


### PR DESCRIPTION
Reinvestigation of #1538. #1508 fixed only the executable *name* (`git` → `git.exe`); the PATH search in `util.resolve_cmd` is still POSIX-hardcoded, so the lookup fails regardless.

## Root cause

`resolve_cmd` splits `PATH` on `:` and joins segments with `/`. On Windows:

- `PATH` entries are separated by `;`, not `:`.
- Windows paths embed `:` in drive letters (`C:\Program Files\Git\cmd`), so the `:` split shatters every entry into garbage (`C`, `\Program Files\Git\cmd;C`, …). No candidate is ever a real directory, so `fs.is_file` fails for all of them → `not found on PATH` → surfaced as *"git not found on PATH (needed to fetch git dependencies)"*.

`getenv("PATH")` is fine — `GetEnvironmentVariableA` is case-insensitive.

This is a central chokepoint: `mach dep`, `mach run`, and `mach test` all resolve runners through `resolve_cmd`, so all three were affected on Windows.

## Fix

Select the list separator (`;` vs `:`) and path separator (`\` vs `/`) at comptime via `$mach.build.os`, and treat a Windows `\` as an already-qualified path (no PATH search). Single-function change.

## Verification

- Native build: clean.
- **Windows cross-compile (`mach build . --target windows`): clean PE32+** — this codegens the new `;`/`\` branch rather than dead-stripping it, so the Windows path is compile-verified.
- Self-host fixpoint: stage1 == stage2 == stage3, byte-identical.
- Runtime confirmation on a real Windows box (that `mach init` now finds `git.exe`) still needs @mfbulut — the logic is sound but cannot be executed from Linux.

Closes #1538