### PR TITLE
fix(dep): make git deps work on windows — inherit env + #1538 regression test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,18 +205,16 @@ jobs:
       - name: Put the seed on PATH
         run: Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP/seed"
 
-      - name: "Realize the vendored std (windows: direct git)"
-        # the v1.6.0 seed's `mach dep pull` can't find git.exe on windows (its git
-        # lookup misses the `.exe` extension — git is on PATH, `where git` finds it
-        # in three places, yet dep pull errors "git not found"). tracked as a
-        # compiler bug; until the seed carries the fix, realize the frozen std into
-        # dep/mach-std directly, reading the pinned commit from mach.lock (single
-        # source of truth — no second pin). linux/aarch64 lanes use `mach dep pull`.
+      - name: Realize the vendored std (mach dep pull)
+        # the seed mach.exe is cross-built from this PR's own tree, so it carries
+        # the windows git.exe PATH-resolution fix (#1538): `mach dep pull` now
+        # resolves git on PATH on windows exactly as it does on linux/aarch64.
+        # this step doubles as the regression test for #1538 — the runner has git
+        # on PATH, so the bug that broke `mach init`/`dep pull` on windows would
+        # reproduce here and turn the lane red instead of slipping past CI again.
         run: |
-          $commit = (Select-String -Path mach.lock -Pattern 'commit = "([0-9a-fA-F]+)"').Matches[0].Groups[1].Value
-          Write-Host "realizing mach-std @ $commit"
-          git clone --no-checkout https://github.com/octalide/mach-std dep/mach-std
-          git -C dep/mach-std checkout $commit
+          mach.exe dep pull
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Build the compiler (native)
         run: |

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -931,10 +931,20 @@ fun ensure_git(alloc: *Allocator, gt: *GitTool) Result[bool, str] {
     $if ($mach.build.os == $mach.os.windows) { gname = "git.exe"; }
     val git_r: Result[str, str] = find_on_path(alloc, gname);
     if (is_err[str, str](git_r)) { ret err[bool, str]("git not found on PATH (needed to fetch git dependencies)"); }
-    val env_r: Result[**u8, str] = build_env(alloc);
-    if (is_err[**u8, str](env_r)) { ret err[bool, str]("failed to build child environment for git"); }
-    gt.git   = unwrap_ok[str, str](git_r);
-    gt.env   = unwrap_ok[**u8, str](env_r);
+    gt.git = unwrap_ok[str, str](git_r);
+    # windows CreateProcess inherits the full parent environment when the child
+    # env is nil — required here, since git's winsock initialization needs
+    # SystemRoot (and friends) that the posix allowlist drops; without them the
+    # clone fails with "getaddrinfo() thread failed to start" (#1538). posix
+    # execve does not inherit and the runtime exposes no handle to environ, so
+    # there the child env is reconstructed from the allowlist.
+    $if ($mach.build.os == $mach.os.windows) {
+        gt.env = nil;
+    } $or {
+        val env_r: Result[**u8, str] = build_env(alloc);
+        if (is_err[**u8, str](env_r)) { ret err[bool, str]("failed to build child environment for git"); }
+        gt.env = unwrap_ok[**u8, str](env_r);
+    }
     gt.ready = true;
     ret ok[bool, str](true);
 }


### PR DESCRIPTION
Completes the #1538 windows fix and adds the regression test that catches it. Builds on #1539 (`resolve_cmd` PATH search).

#1538 turned out to be **two** bugs on the windows git path; #1508/#1539 only covered the first:

1. **git not found** — `resolve_cmd` searched PATH with POSIX `:`/`/` separators (fixed in #1539).
2. **clone fails after git is found** — `getaddrinfo() thread failed to start`. `build_env` hands git a reconstructed allowlist environment (`PATH`, `HOME`, …) that omits `SystemRoot` and the other windows vars winsock needs to initialize. The allowlist exists only because POSIX `execve` does not inherit and the runtime exposes no `environ` handle; on windows `CreateProcess` inherits the full parent environment natively when the child env is `nil`. So pass `nil` there — git runs with the same complete environment as `mach`, exactly as when launched from a shell. **(this PR)**

## How #1538 slipped past #1508

The `Windows (native)` CI lane couldn't run `mach dep pull` (bug 1), so it cloned `mach-std` by hand — which also meant git inherited the runner shell's full environment, hiding bug 2. So CI never exercised the real path.

This PR replaces that workaround with `mach dep pull` on the windows runner. The lane's seed `mach.exe` is cross-built from this tree (carries both fixes) and `windows-latest` has git on PATH, so the lane now reproduces the exact #1538 scenario and goes red on regression.

## Verification

- native build + windows cross-build: clean
- self-host fixpoint: byte-identical (s1==s2==s3)
- `Windows (native)` CI lane: `mach dep pull` end-to-end on real windows (the gate this PR adds)

Closes #1538.