### PR TITLE
fix(driver): use-after-realloc in walk_comptime_if_union

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2324,16 +2324,44 @@ fun walk_comptime_if_union(p: *Project, mid: sess.ModuleId, ci: *decl.DeclCompti
         ti = ti + 1;
     }
 
-    # walk every taken branch's body into the load graph.
+    # snapshot every taken branch's (body_start, body_len) BEFORE recursing.
+    # walk_decl_list_for_load loads modules, which can reallocate(p.modules) and
+    # move the array out from under `m` — so `m`, `ci`, and any `br` deref'd
+    # through `m.a.comptime_branches` dangle the moment a body's `use` grows the
+    # module pool. read them all here, while `m` is still live, into plain locals.
+    val bs_r: Result[*u32, str] = allocate[u32](p.s.alloc, n::usize);
+    if (is_err[*u32, str](bs_r)) { deallocate[bool](p.s.alloc, taken, n::usize); ret err[bool, str](unwrap_err[*u32, str](bs_r)); }
+    val body_start: *u32 = unwrap_ok[*u32, str](bs_r);
+    val bl_r: Result[*u32, str] = allocate[u32](p.s.alloc, n::usize);
+    if (is_err[*u32, str](bl_r)) { deallocate[u32](p.s.alloc, body_start, n::usize); deallocate[bool](p.s.alloc, taken, n::usize); ret err[bool, str](unwrap_err[*u32, str](bl_r)); }
+    val body_len: *u32 = unwrap_ok[*u32, str](bl_r);
+    var sn: u32 = 0;
     var bi: u32 = 0;
     for (bi < n) {
         if (taken[bi]) {
             val br: *decl.ComptimeBranch = ?m.a.comptime_branches[ci.branches_start + bi];
-            val w: Result[bool, str] = walk_decl_list_for_load(p, mid, br.body_start, br.body_len);
-            if (is_err[bool, str](w)) { deallocate[bool](p.s.alloc, taken, n::usize); ret w; }
+            body_start[sn] = br.body_start;
+            body_len[sn]   = br.body_len;
+            sn = sn + 1;
         }
         bi = bi + 1;
     }
+
+    # walk every taken branch's body into the load graph, from the snapshot — no
+    # `m`/`ci`/`br` deref survives the reallocating recursion.
+    var si: u32 = 0;
+    for (si < sn) {
+        val w: Result[bool, str] = walk_decl_list_for_load(p, mid, body_start[si], body_len[si]);
+        if (is_err[bool, str](w)) {
+            deallocate[u32](p.s.alloc, body_len, n::usize);
+            deallocate[u32](p.s.alloc, body_start, n::usize);
+            deallocate[bool](p.s.alloc, taken, n::usize);
+            ret w;
+        }
+        si = si + 1;
+    }
+    deallocate[u32](p.s.alloc, body_len, n::usize);
+    deallocate[u32](p.s.alloc, body_start, n::usize);
     deallocate[bool](p.s.alloc, taken, n::usize);
     ret ok[bool, str](true);
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -3105,6 +3105,54 @@ fun ut_count_errors(d: *diag.DiagList) u32 {
     ret c;
 }
 
+# ut_idx2: a two-char decimal string ("00".."99") for n < 100, owned by `alloc`.
+# names the per-leaf modules of the realloc-mid-walk fixture below.
+fun ut_idx2(alloc: *Allocator, n: u32) str {
+    val r: Result[*u8, str] = allocate[u8](alloc, 3::usize);
+    if (is_err[*u8, str](r)) { ret "00"; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    buf[0] = (48 + (n / 10))::u8;
+    buf[1] = (48 + (n % 10))::u8;
+    buf[2] = 0;
+    ret buf::str;
+}
+
+# UT_REALLOC_LEAVES: windows-branch leaf modules in the realloc-mid-walk fixture.
+# main is module 0 and each leaf is one more, so this must exceed INITIAL_MODULE_CAP
+# (16) for the windows branch body to grow p.modules mid-walk — the realloc that
+# dangles the cached *ModuleEntry for the next taken branch (#1540). 24 clears 16
+# with margin for the baseline module count.
+val UT_REALLOC_LEAVES: u32 = 24;
+
+# ut_realloc_fixture: fill names/texts for the #1540 regression project and return
+# the file count. main.mach holds a 2-branch $if: branch 0 (taken first by the
+# windows target) imports UT_REALLOC_LEAVES distinct modules, crossing the
+# p.modules doubling boundary; branch 1 (taken by the linux targets) imports one
+# more. pre-fix, walking branch 1 reads the dangling cached m -> SIGSEGV.
+# names/texts must have room for 1 + UT_REALLOC_LEAVES + 1 entries.
+fun ut_realloc_fixture(alloc: *Allocator, names: *str, texts: *str) u32 {
+    # branch 0 body: `use uniontest.w00; ... use uniontest.wNN;` (the heavy closure).
+    var body: str = "";
+    var i: u32 = 0;
+    for (i < UT_REALLOC_LEAVES) {
+        val nm: str = ut_cc3(alloc, "w", ut_idx2(alloc, i), "");
+        names[1 + i] = ut_cc3(alloc, nm, ".mach", "");
+        texts[1 + i] = ut_cc3(alloc, "pub fun f() i32 { ret ", ut_idx2(alloc, i), "; }\n");
+        body = ut_cc3(alloc, body, "  use uniontest.", ut_cc3(alloc, nm, ";\n", ""));
+        i = i + 1;
+    }
+    # the linux-branch leaf: the next taken branch whose body deref'd the dangling m.
+    names[1 + UT_REALLOC_LEAVES] = "lx.mach";
+    texts[1 + UT_REALLOC_LEAVES] = "pub fun fl() i32 { ret 99; }\n";
+
+    # main: windows takes branch 0 (the heavy closure), the linux targets take
+    # branch 1 — so taken[] has two trues and the bi loop iterates across them.
+    names[0] = "main.mach";
+    val br0: str = ut_cc3(alloc, "$if ($mach.build.os == $mach.os.windows) {\n", body, "}\n");
+    texts[0] = ut_cc3(alloc, br0, "$or ($mach.build.os == $mach.os.linux) { use uniontest.lx; }\n\nfun main() i32 { ret 0; }\n", "");
+    ret 2 + UT_REALLOC_LEAVES;
+}
+
 test "driver union: a module gated behind a non-default target's $if is still loaded (#1391/lsp#58)" {
     var alloc: Allocator;
     if (is_some[str](page.make(?alloc))) { ret 1; }
@@ -3354,6 +3402,43 @@ test "driver union: branch selection via the $project.target.os string tag exerc
     or (cm.target_isa != cb.target_isa)      { bad = 1; }
     or (cm.target_abi != ca.target_abi)      { bad = 1; }
     or (cm.target_abi != cb.target_abi)      { bad = 1; }
+
+    dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver union: a taken branch's body that reallocates p.modules does not dangle the next branch's deref (#1540)" {
+    # regression for the use-after-realloc in walk_comptime_if_union: it cached
+    # `m: *ModuleEntry` (Ast embedded by value) and deref'd m.a.comptime_branches
+    # per taken branch. the windows branch (taken first) imports enough modules to
+    # grow p.modules mid-walk, moving the array and dangling m; pre-fix the next
+    # taken (linux) branch read the freed m.a.comptime_branches -> SIGSEGV. needs
+    # all three: union mode, 2+ taken branches diverging on OS, and an earlier
+    # taken branch crossing the INITIAL_MODULE_CAP boundary.
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var names: [26]str;
+    var texts: [26]str;
+    val n: u32 = ut_realloc_fixture(?alloc, ?names[0], ?texts[0]);
+
+    val pr: Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], n);
+    if (is_err[Project, str](pr)) { sess.dnit(?s); ret 1; }
+    var p: Project = unwrap_ok[Project, str](pr);
+
+    # both branches' closures land in the union: the windows leaves AND the linux
+    # leaf. spot-check the first/last windows leaf and the linux leaf, plus that
+    # the realloc actually happened (module_len past INITIAL_MODULE_CAP).
+    var bad: i32 = 0;
+    if (!ut_has(?p, ?s, "uniontest.main")) { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.w00"))  { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.w23"))  { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.lx"))   { bad = 1; }
+    or (p.module_len <= INITIAL_MODULE_CAP) { bad = 1; }
 
     dnit_project(?p);
     sess.dnit(?s);


### PR DESCRIPTION
Fixes a SIGSEGV in `build_project_union` (the multi-target union load used by tooling/LSP).

## Root cause

`walk_comptime_if_union` cached `m: *ModuleEntry` (which embeds its `ast.Ast` by value) and dereferenced `m.a.comptime_branches[...]` inside the "walk every taken branch" loop. Each taken branch body recurses into `walk_decl_list_for_load`, whose `use` decls can grow `p.modules` — `register_module_slot` hits `module_len == module_cap` and `reallocate`s the array, **moving it**. The next loop iteration then reads `m.a.comptime_branches` through the freed `m`, yielding a garbage `br`; reading `br.body_start` (u32 at offset 28) faults.

## Fix

Snapshot every taken branch's `(body_start, body_len)` into plain `u32` locals while `m` is still live, then drive the recursion from the snapshot — no `m`/`ci`/`br` deref survives the reallocating recursion. Mirrors the re-derive-fresh pattern in `walk_use_for_load`. The default-tuple-restore invariant is untouched.

## Sibling audit

Swept every `walk_*_for_load` / load-walk fn for an AST-arena/`*ModuleEntry` pointer held across a `dfs_load`/recursive call:
- `walk_decl_list_for_load` — re-derives `?p.modules[mid]` fresh each iteration. safe.
- `walk_one_decl_for_load` — caches `m` but tail-returns into the recursing fn. safe.
- `walk_comptime_if_for_load` (single-target) — `ret`s on the first taken branch. safe.
- `walk_use_for_load` / `walk_fwd_for_load` — use `m` only before `dfs_load`; afterward use `mid` + a `*decl.DeclUse`/`*decl.DeclFwd` into the stable `decls` heap pool. safe.
- `register_val_for_load`, `record_dep`, `merge_pub_consts` — no module load; re-derive from ids / stable pools. safe.

Only `walk_comptime_if_union` looped while dereferencing the `ModuleEntry`-embedded Ast across a reallocating recursion.

## Scope

Union-mode-only path (`build_project_sel` / normal `mach build` never call it) — no effect on emitted code or self-host.

Regression test to follow.

Closes #1540