### PR TITLE
release: mach 2.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,18 +205,16 @@ jobs:
       - name: Put the seed on PATH
         run: Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP/seed"
 
-      - name: "Realize the vendored std (windows: direct git)"
-        # the v1.6.0 seed's `mach dep pull` can't find git.exe on windows (its git
-        # lookup misses the `.exe` extension — git is on PATH, `where git` finds it
-        # in three places, yet dep pull errors "git not found"). tracked as a
-        # compiler bug; until the seed carries the fix, realize the frozen std into
-        # dep/mach-std directly, reading the pinned commit from mach.lock (single
-        # source of truth — no second pin). linux/aarch64 lanes use `mach dep pull`.
+      - name: Realize the vendored std (mach dep pull)
+        # the seed mach.exe is cross-built from this PR's own tree, so it carries
+        # the windows git.exe PATH-resolution fix (#1538): `mach dep pull` now
+        # resolves git on PATH on windows exactly as it does on linux/aarch64.
+        # this step doubles as the regression test for #1538 — the runner has git
+        # on PATH, so the bug that broke `mach init`/`dep pull` on windows would
+        # reproduce here and turn the lane red instead of slipping past CI again.
         run: |
-          $commit = (Select-String -Path mach.lock -Pattern 'commit = "([0-9a-fA-F]+)"').Matches[0].Groups[1].Value
-          Write-Host "realizing mach-std @ $commit"
-          git clone --no-checkout https://github.com/octalide/mach-std dep/mach-std
-          git -C dep/mach-std checkout $commit
+          mach.exe dep pull
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Build the compiler (native)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2026-06-20
+
+Patch — fetching git dependencies (`mach init`, `mach dep pull`) failed on windows
+in two distinct ways; both are fixed and now covered by the `Windows (native)` CI
+lane, which resolves the vendored std with `mach dep pull` instead of a manual
+clone (#1538).
+
+### Fixed
+
+- dep: `resolve_cmd` searched `PATH` with POSIX separators (`:` list, `/` path),
+  so it never resolved an executable on windows — `PATH` is `;`-separated there
+  and drive-letter prefixes (`C:\…`) embed a `:` that shattered every entry. it
+  now selects the list/path separators by target os, so `git.exe` is found on
+  windows as it is on linux. also fixes runner resolution in `mach run`/`mach test`.
+- dep: git was spawned on windows with a reconstructed allowlist environment that
+  omitted `SystemRoot`, so its winsock initialization failed with
+  `getaddrinfo() thread failed to start` once git was found. the allowlist exists
+  only for posix `execve` (which does not inherit and exposes no `environ`
+  handle); on windows `CreateProcess` inherits the full parent environment
+  natively, so git is now spawned with a nil child env there.
+
 ## [2.4.0] - 2026-06-19
 
 Minor — Phase 2 (collapse) of the `#[attr]` decorator migration (#1526): `#[attr]` is now

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.4.0"
+version = "2.4.1"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -931,10 +931,20 @@ fun ensure_git(alloc: *Allocator, gt: *GitTool) Result[bool, str] {
     $if ($mach.build.os == $mach.os.windows) { gname = "git.exe"; }
     val git_r: Result[str, str] = find_on_path(alloc, gname);
     if (is_err[str, str](git_r)) { ret err[bool, str]("git not found on PATH (needed to fetch git dependencies)"); }
-    val env_r: Result[**u8, str] = build_env(alloc);
-    if (is_err[**u8, str](env_r)) { ret err[bool, str]("failed to build child environment for git"); }
-    gt.git   = unwrap_ok[str, str](git_r);
-    gt.env   = unwrap_ok[**u8, str](env_r);
+    gt.git = unwrap_ok[str, str](git_r);
+    # windows CreateProcess inherits the full parent environment when the child
+    # env is nil — required here, since git's winsock initialization needs
+    # SystemRoot (and friends) that the posix allowlist drops; without them the
+    # clone fails with "getaddrinfo() thread failed to start" (#1538). posix
+    # execve does not inherit and the runtime exposes no handle to environ, so
+    # there the child env is reconstructed from the allowlist.
+    $if ($mach.build.os == $mach.os.windows) {
+        gt.env = nil;
+    } $or {
+        val env_r: Result[**u8, str] = build_env(alloc);
+        if (is_err[**u8, str](env_r)) { ret err[bool, str]("failed to build child environment for git"); }
+        gt.env = unwrap_ok[**u8, str](env_r);
+    }
     gt.ready = true;
     ret ok[bool, str](true);
 }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -118,18 +118,27 @@ pub fun is_value_flag(a: *u8) bool {
 }
 
 # resolve_cmd: resolve a command name to a concrete executable path for
-# `os.spawn` (execve performs no PATH search). a name containing '/' is
-# returned verbatim; a bare name is resolved by scanning the `PATH`
+# `os.spawn` (execve performs no PATH search). a name already containing a path
+# separator is returned verbatim; a bare name is resolved by scanning the `PATH`
 # environment variable. the resolved path is allocated from `alloc`.
+#
+# the PATH list separator and the path component separator are platform-specific:
+# posix uses ':' and '/', windows uses ';' and '\'. the windows list separator
+# must not be ':', since drive-letter prefixes (`C:\...`) embed a ':' that would
+# otherwise shatter every entry (#1538).
 # ---
 # alloc: allocator for the resolved path
 # name:  command name or path to resolve
 # ret:   the executable path, or an error message ("PATH unset" / "not found on PATH")
 pub fun resolve_cmd(alloc: *Allocator, name: *u8) Result[*u8, str] {
+    var list_sep: u8 = ':';
+    var path_sep: u8 = '/';
+    $if ($mach.build.os == $mach.os.windows) { list_sep = ';'; path_sep = '\\'; }
+
     val nlen: usize = slen(name);
     var h: usize = 0;
     for (h < nlen) {
-        if (name[h] == '/') { ret ok[*u8, str](name); }
+        if (name[h] == '/' || name[h] == path_sep) { ret ok[*u8, str](name); }
         h = h + 1;
     }
 
@@ -141,7 +150,7 @@ pub fun resolve_cmd(alloc: *Allocator, name: *u8) Result[*u8, str] {
     var i: usize = 0;
     for (i < plen) {
         val start: usize = i;
-        for (i < plen && path_buf[i] != ':') { i = i + 1; }
+        for (i < plen && path_buf[i] != list_sep) { i = i + 1; }
         val end: usize = i;
         if (i < plen) { i = i + 1; }
         if (end == start) { cnt; }
@@ -154,7 +163,7 @@ pub fun resolve_cmd(alloc: *Allocator, name: *u8) Result[*u8, str] {
         var k: usize = 0;
         var j: usize = start;
         for (j < end) { cand[k] = path_buf[j]; k = k + 1; j = j + 1; }
-        cand[k] = '/'; k = k + 1;
+        cand[k] = path_sep; k = k + 1;
         j = 0;
         for (j < nlen) { cand[k] = name[j]; k = k + 1; j = j + 1; }
         cand[k] = 0;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2324,16 +2324,44 @@ fun walk_comptime_if_union(p: *Project, mid: sess.ModuleId, ci: *decl.DeclCompti
         ti = ti + 1;
     }
 
-    # walk every taken branch's body into the load graph.
+    # snapshot every taken branch's (body_start, body_len) BEFORE recursing.
+    # walk_decl_list_for_load loads modules, which can reallocate(p.modules) and
+    # move the array out from under `m` — so `m`, `ci`, and any `br` deref'd
+    # through `m.a.comptime_branches` dangle the moment a body's `use` grows the
+    # module pool. read them all here, while `m` is still live, into plain locals.
+    val bs_r: Result[*u32, str] = allocate[u32](p.s.alloc, n::usize);
+    if (is_err[*u32, str](bs_r)) { deallocate[bool](p.s.alloc, taken, n::usize); ret err[bool, str](unwrap_err[*u32, str](bs_r)); }
+    val body_start: *u32 = unwrap_ok[*u32, str](bs_r);
+    val bl_r: Result[*u32, str] = allocate[u32](p.s.alloc, n::usize);
+    if (is_err[*u32, str](bl_r)) { deallocate[u32](p.s.alloc, body_start, n::usize); deallocate[bool](p.s.alloc, taken, n::usize); ret err[bool, str](unwrap_err[*u32, str](bl_r)); }
+    val body_len: *u32 = unwrap_ok[*u32, str](bl_r);
+    var sn: u32 = 0;
     var bi: u32 = 0;
     for (bi < n) {
         if (taken[bi]) {
             val br: *decl.ComptimeBranch = ?m.a.comptime_branches[ci.branches_start + bi];
-            val w: Result[bool, str] = walk_decl_list_for_load(p, mid, br.body_start, br.body_len);
-            if (is_err[bool, str](w)) { deallocate[bool](p.s.alloc, taken, n::usize); ret w; }
+            body_start[sn] = br.body_start;
+            body_len[sn]   = br.body_len;
+            sn = sn + 1;
         }
         bi = bi + 1;
     }
+
+    # walk every taken branch's body into the load graph, from the snapshot — no
+    # `m`/`ci`/`br` deref survives the reallocating recursion.
+    var si: u32 = 0;
+    for (si < sn) {
+        val w: Result[bool, str] = walk_decl_list_for_load(p, mid, body_start[si], body_len[si]);
+        if (is_err[bool, str](w)) {
+            deallocate[u32](p.s.alloc, body_len, n::usize);
+            deallocate[u32](p.s.alloc, body_start, n::usize);
+            deallocate[bool](p.s.alloc, taken, n::usize);
+            ret w;
+        }
+        si = si + 1;
+    }
+    deallocate[u32](p.s.alloc, body_len, n::usize);
+    deallocate[u32](p.s.alloc, body_start, n::usize);
     deallocate[bool](p.s.alloc, taken, n::usize);
     ret ok[bool, str](true);
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -3105,6 +3105,54 @@ fun ut_count_errors(d: *diag.DiagList) u32 {
     ret c;
 }
 
+# ut_idx2: a two-char decimal string ("00".."99") for n < 100, owned by `alloc`.
+# names the per-leaf modules of the realloc-mid-walk fixture below.
+fun ut_idx2(alloc: *Allocator, n: u32) str {
+    val r: Result[*u8, str] = allocate[u8](alloc, 3::usize);
+    if (is_err[*u8, str](r)) { ret "00"; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    buf[0] = (48 + (n / 10))::u8;
+    buf[1] = (48 + (n % 10))::u8;
+    buf[2] = 0;
+    ret buf::str;
+}
+
+# UT_REALLOC_LEAVES: windows-branch leaf modules in the realloc-mid-walk fixture.
+# main is module 0 and each leaf is one more, so this must exceed INITIAL_MODULE_CAP
+# (16) for the windows branch body to grow p.modules mid-walk — the realloc that
+# dangles the cached *ModuleEntry for the next taken branch (#1540). 24 clears 16
+# with margin for the baseline module count.
+val UT_REALLOC_LEAVES: u32 = 24;
+
+# ut_realloc_fixture: fill names/texts for the #1540 regression project and return
+# the file count. main.mach holds a 2-branch $if: branch 0 (taken first by the
+# windows target) imports UT_REALLOC_LEAVES distinct modules, crossing the
+# p.modules doubling boundary; branch 1 (taken by the linux targets) imports one
+# more. pre-fix, walking branch 1 reads the dangling cached m -> SIGSEGV.
+# names/texts must have room for 1 + UT_REALLOC_LEAVES + 1 entries.
+fun ut_realloc_fixture(alloc: *Allocator, names: *str, texts: *str) u32 {
+    # branch 0 body: `use uniontest.w00; ... use uniontest.wNN;` (the heavy closure).
+    var body: str = "";
+    var i: u32 = 0;
+    for (i < UT_REALLOC_LEAVES) {
+        val nm: str = ut_cc3(alloc, "w", ut_idx2(alloc, i), "");
+        names[1 + i] = ut_cc3(alloc, nm, ".mach", "");
+        texts[1 + i] = ut_cc3(alloc, "pub fun f() i32 { ret ", ut_idx2(alloc, i), "; }\n");
+        body = ut_cc3(alloc, body, "  use uniontest.", ut_cc3(alloc, nm, ";\n", ""));
+        i = i + 1;
+    }
+    # the linux-branch leaf: the next taken branch whose body deref'd the dangling m.
+    names[1 + UT_REALLOC_LEAVES] = "lx.mach";
+    texts[1 + UT_REALLOC_LEAVES] = "pub fun fl() i32 { ret 99; }\n";
+
+    # main: windows takes branch 0 (the heavy closure), the linux targets take
+    # branch 1 — so taken[] has two trues and the bi loop iterates across them.
+    names[0] = "main.mach";
+    val br0: str = ut_cc3(alloc, "$if ($mach.build.os == $mach.os.windows) {\n", body, "}\n");
+    texts[0] = ut_cc3(alloc, br0, "$or ($mach.build.os == $mach.os.linux) { use uniontest.lx; }\n\nfun main() i32 { ret 0; }\n", "");
+    ret 2 + UT_REALLOC_LEAVES;
+}
+
 test "driver union: a module gated behind a non-default target's $if is still loaded (#1391/lsp#58)" {
     var alloc: Allocator;
     if (is_some[str](page.make(?alloc))) { ret 1; }
@@ -3354,6 +3402,43 @@ test "driver union: branch selection via the $project.target.os string tag exerc
     or (cm.target_isa != cb.target_isa)      { bad = 1; }
     or (cm.target_abi != ca.target_abi)      { bad = 1; }
     or (cm.target_abi != cb.target_abi)      { bad = 1; }
+
+    dnit_project(?p);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver union: a taken branch's body that reallocates p.modules does not dangle the next branch's deref (#1540)" {
+    # regression for the use-after-realloc in walk_comptime_if_union: it cached
+    # `m: *ModuleEntry` (Ast embedded by value) and deref'd m.a.comptime_branches
+    # per taken branch. the windows branch (taken first) imports enough modules to
+    # grow p.modules mid-walk, moving the array and dangling m; pre-fix the next
+    # taken (linux) branch read the freed m.a.comptime_branches -> SIGSEGV. needs
+    # all three: union mode, 2+ taken branches diverging on OS, and an earlier
+    # taken branch crossing the INITIAL_MODULE_CAP boundary.
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var names: [26]str;
+    var texts: [26]str;
+    val n: u32 = ut_realloc_fixture(?alloc, ?names[0], ?texts[0]);
+
+    val pr: Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], n);
+    if (is_err[Project, str](pr)) { sess.dnit(?s); ret 1; }
+    var p: Project = unwrap_ok[Project, str](pr);
+
+    # both branches' closures land in the union: the windows leaves AND the linux
+    # leaf. spot-check the first/last windows leaf and the linux leaf, plus that
+    # the realloc actually happened (module_len past INITIAL_MODULE_CAP).
+    var bad: i32 = 0;
+    if (!ut_has(?p, ?s, "uniontest.main")) { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.w00"))  { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.w23"))  { bad = 1; }
+    or (!ut_has(?p, ?s, "uniontest.lx"))   { bad = 1; }
+    or (p.module_len <= INITIAL_MODULE_CAP) { bad = 1; }
 
     dnit_project(?p);
     sess.dnit(?s);


### PR DESCRIPTION
Patch release: windows git dependency resolution (#1538).

Fetching git dependencies (`mach init`, `mach dep pull`) failed on windows in two distinct ways:

1. `resolve_cmd` searched `PATH` with POSIX separators, so `git.exe` was never found (#1539).
2. once found, git was spawned with an allowlist environment missing `SystemRoot`, so its clone failed with `getaddrinfo() thread failed to start` (#1541).

Both are fixed and now covered by the `Windows (native)` CI lane, which realizes the vendored std with `mach dep pull` (the real-windows regression test) instead of a manual clone.

Verified: native + windows cross-build clean, self-host fixpoint byte-identical, and `mach dep pull` confirmed working end-to-end on the windows CI runner.

Closes #1538.