### PR TITLE
chore(cli): require explicit project-path positional; remove --cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Breaking CLI change — the project commands now resolve the project root one way
+only. `build`, `run`, `test`, and `doc` each take the project root as a required
+positional (`mach build .`); a bare invocation with no path is a user error. This
+collapses the three redundant resolution paths (bare-cwd default, positional, and
+`--cwd`) that had drifted in, restoring a single rule (#1545).
+
+### Changed
+
+- cli: `build`, `run`, `test`, and `doc` now **require** an explicit project-path
+  positional (`mach build <path>`). A bare invocation prints
+  `error: missing project path; pass the project root (e.g. '.')` and exits `1`.
+  `doc` previously took no positional; it now requires one like the others
+  (#1545).
+
+### Removed
+
+- cli: the `--cwd <path>` flag. Pass the project root as the positional instead
+  (`mach build .`) (#1545).
+
 ## [2.4.1] - 2026-06-20
 
 Patch — windows git dependency resolution (#1538) and a multi-target union-build

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -5,9 +5,10 @@ mach <command> [options]
 ```
 
 The compiler dispatches on `argv[1]`. With no command, or an unknown one, it
-prints usage and exits non-zero. Every command except `init` runs from inside a
-project tree: it walks up from the working directory until a `mach.toml` is
-found.
+prints usage and exits non-zero. The project commands — `build`, `run`, `test`,
+and `doc` — take the project root as a **required** positional (`mach build
+<path>`) and walk up from it until a `mach.toml` is found; a bare invocation with
+no path is a user error.
 
 This page documents the flags the current binary actually parses. Flags are
 matched exactly: `--flag value` (a value follows in the next argument) or a bare
@@ -37,7 +38,6 @@ Read by `build`, `run`, `test`, and `doc` (they share one config parser).
 | `--verbose`, `-v`| —                | write extra detail (per-stage compile progress) to stderr |
 | `--quiet`, `-q`  | —                | suppress non-error output |
 | `--color <mode>` | `auto`\|`always`\|`never` | color preference for terminal output (default `auto`); an unknown mode is a parse error |
-| `--cwd <path>`   | path             | run as if started in `<path>` (project-root search begins there) |
 | `--target <name>`| target name      | select a declared target; absent, defers to `[project].target` |
 | `--profile <name>`| profile name    | select a `[profile.<name>]` build variant; absent, the first declared profile |
 | `--bin <name>`   | artifact name    | narrow the build to one `[bin.<name>]` artifact |
@@ -56,10 +56,11 @@ Read by `build`, `run`, `test`, and `doc` (they share one config parser).
 ## `mach build`
 
 ```
-mach build [options]
+mach build <path> [options]
 ```
 
-Compiles the current project. With no `--bin`/`--lib`, it builds every declared
+Compiles the project rooted at `<path>` (e.g. `mach build .`). With no
+`--bin`/`--lib`, it builds every declared
 artifact for the default target and profile. Every reachable module is driven
 through sema → lower → optimise → codegen to one relocatable object, written
 under the manifest's resolved `obj` template at `<obj>/<fqn-as-path>.o`. For a
@@ -135,16 +136,17 @@ giving a stable, deterministic link order.
 > Dynamic linking is implemented for the ELF (Linux) and PE (Windows) targets;
 > the Mach-O (Darwin) import path is not yet implemented (#1176).
 
-Exit codes: `0` ok, `1` user error (no `mach.toml`, unknown target, compile
-errors, an unresolvable link input), `2` internal error.
+Exit codes: `0` ok, `1` user error (missing project path, no `mach.toml`,
+unknown target, compile errors, an unresolvable link input), `2` internal error.
 
 ## `mach run`
 
 ```
-mach run [options] [-- args...]
+mach run <path> [options] [-- args...]
 ```
 
-Builds the project exactly like `mach build`, then executes the produced binary.
+Builds the project at `<path>` exactly like `mach build`, then executes the
+produced binary.
 Arguments after a `--` separator are forwarded to the child as its `argv`. The
 child's exit code becomes this command's exit code.
 
@@ -169,7 +171,7 @@ error.
 ## `mach test`
 
 ```
-mach test [options]
+mach test <path> [options]
 ```
 
 Builds one standalone executable per `test` declaration (the test plus the
@@ -323,7 +325,7 @@ Exit codes: `0` ok, `1` user error, `2` internal error.
 ## `mach doc`
 
 ```
-mach doc [options]
+mach doc <path> [options]
 ```
 
 Loads the project's module graph and generates Markdown reference docs from

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -274,8 +274,8 @@ A build cell is one artifact × one target × one profile.
   target. `--bin <name>` / `--lib <name>` narrow to one artifact; `--target
   <name>` selects a declared target; `--profile <name>` (with `--release` sugar)
   selects a profile.
-- `mach run` and `mach test` build exactly one artifact; with several declared and
-  no `--bin`/`--lib`, they ask you to pick one, naming every candidate.
+- `mach run .` and `mach test .` build exactly one artifact; with several declared
+  and no `--bin`/`--lib`, they ask you to pick one, naming every candidate.
 
 ### `native` target resolution
 
@@ -340,12 +340,12 @@ git = "https://github.com/octalide/mach-std"
 ref = "branch/dev"
 ```
 
-`mach build` (no `--target`) selects `linux` because `[project].target = "native"`
+`mach build .` (no `--target`) selects `linux` because `[project].target = "native"`
 resolves to the host-matching tuple, compiles `src/main.mach` and its transitive
 imports — including modules from `mach-std` vendored at `dep/mach-std/` — into
 objects under `out/linux/obj/`, and links `out/linux/bin/mach`. `mach-std` is
 realized into `dep/mach-std/` by `mach dep pull` from the manifest pin, and
-`mach build` then resolves it purely by that vendor path — no git at build time.
+`mach build .` then resolves it purely by that vendor path — no git at build time.
 
 ## See also
 

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -454,19 +454,15 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
     }
     val config: cfg.Config = unwrap_ok[cfg.Config, str](cfg_r);
 
-    # the project root: the first non-flag positional after the subcommand
-    # (`mach build <path>`), else --cwd, else the process cwd. a positional and
-    # --cwd are mutually exclusive — both naming a start dir is a user error.
-    var start: *u8 = config.cwd;
+    # the project root is the required non-flag positional after the subcommand
+    # (`mach build <path>`); a bare invocation with no path is a user error.
     val pix: usize = util.positional_index(eff, argv, 2);
-    if (pix < eff) {
-        if (config.cwd != nil) {
-            print.eprint("error: cannot combine a project-path positional with --cwd\n");
-            br.code = 1;
-            ret br;
-        }
-        start = argv[pix];
+    if (pix >= eff) {
+        print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
+        br.code = 1;
+        ret br;
     }
+    val start: *u8 = argv[pix];
 
     var root: [4096]u8;
     if (!util.find_project_root(start, ?root[0], 4096)) {
@@ -1997,16 +1993,14 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret 1;
     }
 
-    # the project root: the first non-flag positional, else --cwd, else the cwd.
-    var start: *u8 = config.cwd;
+    # the project root is the required non-flag positional (`mach build <path>`);
+    # a bare invocation with no path is a user error.
     val pix: usize = util.positional_index(eff, argv, 2);
-    if (pix < eff) {
-        if (config.cwd != nil) {
-            print.eprint("error: cannot combine a project-path positional with --cwd\n");
-            ret 1;
-        }
-        start = argv[pix];
+    if (pix >= eff) {
+        print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
+        ret 1;
     }
+    val start: *u8 = argv[pix];
     var root: [4096]u8;
     if (!util.find_project_root(start, ?root[0], 4096)) {
         print.eprint("error: no mach.toml found in the working directory or any parent\n");

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -431,8 +431,16 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     val config: cfg.Config = unwrap_ok[cfg.Config, str](cfg_r);
 
+    # the project root is the required non-flag positional (`mach doc <path>`);
+    # a bare invocation with no path is a user error.
+    val pix: usize = util.positional_index(argc, argv, 2);
+    if (pix >= argc) {
+        print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
+        ret 1;
+    }
+
     var root: [4096]u8;
-    if (!util.find_project_root(config.cwd, ?root[0], 4096)) {
+    if (!util.find_project_root(argv[pix], ?root[0], 4096)) {
         print.eprint("error: no mach.toml found in the working directory or any parent\n");
         ret 1;
     }

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -21,7 +21,6 @@ fun global_flags() {
     print.print("  --verbose, -v     surface extra detail (per-stage progress) on stderr\n");
     print.print("  --quiet, -q       suppress non-error output (mutually exclusive with -v)\n");
     print.print("  --color <mode>    auto | always | never (default auto)\n");
-    print.print("  --cwd <path>      run as if started in <path>\n");
     print.print("  --target <name>   select a [targets.<name>] entry\n");
     print.print("  -o <path>         override the linked-binary path (build/run/test)\n");
     print.print("  --artifacts <dir> override the per-target object directory (build/run/test)\n");
@@ -54,10 +53,10 @@ fun top_level_usage() {
 }
 
 fun help_build() {
-    print.print("usage: mach build [path] [options] [inputs...]\n");
+    print.print("usage: mach build <path> [options] [inputs...]\n");
     print.print("\n");
     print.print("compile the current project to relocatable objects and, in executable\n");
-    print.print("mode, a linked binary. [path] is the project root (default: the cwd).\n");
+    print.print("mode, a linked binary. <path> is the project root.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  --release        select the release optimisation pipeline\n");
@@ -74,7 +73,7 @@ fun help_build() {
 }
 
 fun help_run() {
-    print.print("usage: mach run [path] [options] [-- args...]\n");
+    print.print("usage: mach run <path> [options] [-- args...]\n");
     print.print("\n");
     print.print("build the project (all 'mach build' flags apply) and execute the\n");
     print.print("resulting binary. arguments after '--' are forwarded to the program\n");
@@ -91,7 +90,7 @@ fun help_run() {
 }
 
 fun help_test() {
-    print.print("usage: mach test [path] [options]\n");
+    print.print("usage: mach test <path> [options]\n");
     print.print("\n");
     print.print("build one standalone executable per 'test' declaration (under the\n");
     print.print("'tests' template) and run each as a separate process, reporting\n");
@@ -150,7 +149,7 @@ fun help_init() {
 }
 
 fun help_doc() {
-    print.print("usage: mach doc [options]\n");
+    print.print("usage: mach doc <path> [options]\n");
     print.print("\n");
     print.print("generate Markdown reference documentation from source doc-comments.\n");
     print.print("writes one page per module plus an index under doc/api.\n");

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -39,7 +39,6 @@ pub val COLOR_NEVER:  ColorMode = 2;
 # verbose: --verbose / -v was passed; surface extra detail
 # quiet:   --quiet / -q was passed; suppress non-error output
 # verify_ir: --verify-ir was passed; run the IR verifier after each optimisation pass
-# cwd:     resolved working directory (nil = use the process cwd)
 # target:  selected target name (nil when --target was not given)
 # output:    -o override for the linked binary path, rooted at the project
 #            root (nil = use the target's `binary` from mach.toml)
@@ -66,7 +65,6 @@ pub rec Config {
     verbose:     bool;
     quiet:       bool;
     verify_ir:   bool;
-    cwd:         *u8;
     target:      *u8;
     output:      *u8;
     artifacts:   *u8;
@@ -108,7 +106,6 @@ pub fun parse(argc: usize, argv: **u8) Result[Config, str] {
     c.verbose   = false;
     c.quiet     = false;
     c.verify_ir = false;
-    c.cwd         = nil;
     c.target      = nil;
     c.output      = nil;
     c.artifacts   = nil;
@@ -145,9 +142,6 @@ pub fun parse(argc: usize, argv: **u8) Result[Config, str] {
         or (str_equals(mode::str, "never"))  { c.color = COLOR_NEVER; }
         or                           { ret err[Config, str]("invalid --color mode (expected auto, always, or never)"); }
     }
-
-    val cwd_opt: Option[*u8] = util.get_value(argc, argv, "--cwd");
-    if (is_some[*u8](cwd_opt)) { c.cwd = unwrap[*u8](cwd_opt); }
 
     val target_opt: Option[*u8] = util.get_value(argc, argv, "--target");
     if (is_some[*u8](target_opt)) { c.target = unwrap[*u8](target_opt); }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -110,7 +110,7 @@ pub fun is_flag(s: *u8) bool {
 # ret: true when `a` is a value-taking flag
 pub fun is_value_flag(a: *u8) bool {
     ret str_equals(a::str, "-L") || str_equals(a::str, "-l") || str_equals(a::str, "-o") ||
-        str_equals(a::str, "--target") || str_equals(a::str, "--cwd") || str_equals(a::str, "--color") ||
+        str_equals(a::str, "--target") || str_equals(a::str, "--color") ||
         str_equals(a::str, "--artifacts") || str_equals(a::str, "--emit") || str_equals(a::str, "--filter") ||
         str_equals(a::str, "--out") || str_equals(a::str, "--name") || str_equals(a::str, "--ref") ||
         str_equals(a::str, "--profile") || str_equals(a::str, "--bin") || str_equals(a::str, "--lib") ||
@@ -281,27 +281,21 @@ pub fun parent_dir(path: *u8) bool {
     ret true;
 }
 
-# find_project_root: walk up from `start` (or the process cwd when nil) until a
-# directory containing mach.toml is found, writing the resolved root into
-# `out_buf` (caller-provided, must hold at least 4096 bytes). returns true on
-# success; false when no ancestor directory holds a mach.toml.
+# find_project_root: walk up from `start` until a directory containing mach.toml
+# is found, writing the resolved root into `out_buf` (caller-provided, must hold
+# at least 4096 bytes). returns true on success; false when no ancestor directory
+# holds a mach.toml.
 # ---
-# start:   starting directory, or nil to begin at the process cwd
+# start:   starting directory (required, non-nil)
 # out_buf: destination buffer for the resolved root
 # cap:     capacity of `out_buf` in bytes
 # ret:     true when a mach.toml-bearing ancestor was found
 pub fun find_project_root(start: *u8, out_buf: *u8, cap: usize) bool {
+    val n: usize = slen(start);
+    if (n + 1 > cap) { ret false; }
     var i: usize = 0;
-    if (start != nil && start[0] != 0) {
-        val n: usize = slen(start);
-        if (n + 1 > cap) { ret false; }
-        for (i < n) { out_buf[i] = start[i]; i = i + 1; }
-        out_buf[n] = 0;
-    }
-    or {
-        val g: i64 = os.getcwd(out_buf, cap);
-        if (g < 0) { ret false; }
-    }
+    for (i < n) { out_buf[i] = start[i]; i = i + 1; }
+    out_buf[n] = 0;
 
     var probe: [4096]u8;
     for (true) {


### PR DESCRIPTION
Closes #1545

Collapses the three redundant ways `build`/`run`/`test`/`doc` resolved the
project root (bare-cwd default, positional, and `--cwd`) down to one rule:
**the project-path positional is required.** `mach build .` works; bare
`mach build` is now a user error. `--cwd` is removed entirely — no trace in
source or docs.

## Changes
- `src/cli/config.mach`: removed the `cwd` field, its initializer, and the
  `--cwd` parse block.
- `src/cli/util.mach`: dropped `--cwd` from `is_value_flag`; `find_project_root`
  no longer has a nil→cwd fallback (`start` is always a required path). The
  walk-up-to-parent loop is kept.
- `src/cli/cmd/build.mach`: both the `build_unit` and the matrix `run` sites now
  require the positional and error `missing project path; pass the project root
  (e.g. '.')` (exit 1) when none is present.
- `src/cli/cmd/doc.mach`: `doc` gained a required positional (it had none).
- `src/cli/cmd/help.mach` + `doc/cli.md` + `doc/manifest.md`: usage synopses and
  examples now show `<path>`; the `--cwd` row/flag is gone.
- `CHANGELOG.md`: `## [Unreleased]` noting the breaking CLI change.

## Verification
- Fixpoint holds: stage1 == stage2 byte-identical
  (sha256 `dee51261fc3f32d5a23cbf445ab257ea725ad8fdee25535cae8c0d48a9d3f3e3`).
- `mach build` / `run` / `test` / `doc` (bare) → `error: missing project path`,
  exit 1.
- `mach build .` succeeds; `mach doc .` succeeds; `mach help build` shows
  `<path>` and no `--cwd`; top-level `mach help` global flags no longer list
  `--cwd`.
- `grep -rni cwd src/ doc/` leaves only unrelated hits (`init.mach`'s
  `os.getcwd`/`cwd_buf`, the `AT_FDCWD` syscall constant, and the x64 `CWD`
  sign-extension mnemonic) — no `--cwd` flag literal survives.
- `.github/tests/manifest/run.sh` and `.github/tests/envfwd/run.sh` both PASS.
