### PR TITLE
chore: version-control issue-label taxonomy

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,77 @@
+# Issue/PR label taxonomy for octalide/mach — the source of truth.
+#
+# Four orthogonal dimensions:
+#   type      the kind of work (bug, problem, feature, refactor, docs, chore, rfc, epic); pick one
+#   area:*    which subsystem; the compiler pipeline front-to-back plus cross-cutting concerns
+#   target:*  platform-specific work; the baselines (linux, x64) stay unlabeled
+#   status    workflow signals (critical, blocked, duplicate)
+#
+# Apply with `.github/sync-labels.sh` (see that script for --prune and --dry-run).
+
+labels:
+  - name: bug
+    color: d73a4a
+    description: "defect: observed behavior contradicts the spec, docs, or obvious intent"
+  - name: problem
+    color: d93f0b
+    description: "a problem with an existing feature's design or behavior; exclusive with bug"
+  - name: feature
+    color: 0e8a16
+    description: "new capability, or an extension of an existing one"
+  - name: refactor
+    color: 5319e7
+    description: "structural or architectural change; behavior-preserving"
+  - name: docs
+    color: 0075ca
+    description: "documentation: doc/, in-source doc comments, README"
+  - name: chore
+    color: 6a737d
+    description: "mechanical upkeep + release engineering: dep bumps, version rolls, cuts, tags"
+  - name: rfc
+    color: d876e3
+    description: "design discussion / request for comment; direction not yet decided"
+  - name: epic
+    color: fbca04
+    description: "umbrella issue tracking a family of sub-issues"
+
+  - name: area:frontend
+    color: 1d76db
+    description: "lexer, parser, AST"
+  - name: area:sema
+    color: 1d76db
+    description: "resolve, type checking, coercion, inference, comptime"
+  - name: area:codegen
+    color: 1d76db
+    description: "IR/middle-end, isel, regalloc, frame, encoders, inline asm"
+  - name: area:link
+    color: 1d76db
+    description: "linker, object formats, target/ABI plumbing"
+  - name: area:driver
+    color: 1d76db
+    description: "build orchestration, CLI/UX, dependencies"
+  - name: area:diag
+    color: 1d76db
+    description: "diagnostic quality: messages, spans, suggestions"
+  - name: area:infra
+    color: 1d76db
+    description: "CI, release automation, test infra/corpus"
+
+  - name: target:windows
+    color: 6f42c1
+    description: "Windows-specific behavior or work"
+  - name: target:darwin
+    color: 6f42c1
+    description: "macOS-specific behavior or work"
+  - name: target:aarch64
+    color: 6f42c1
+    description: "aarch64-specific behavior or work"
+
+  - name: critical
+    color: b60205
+    description: "miscompilation, data loss, or release blocker; jumps the queue"
+  - name: blocked
+    color: f9d0c4
+    description: "cannot proceed: waiting on another issue, repo, or decision"
+  - name: duplicate
+    color: cfd3d7
+    description: "already tracked elsewhere; closed in favor of the original"

--- a/.github/sync-labels.sh
+++ b/.github/sync-labels.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Reconcile this repo's issue labels with the manifest in labels.yml (idempotent).
+#
+# usage:
+#   .github/sync-labels.sh             create/update labels from the manifest
+#   .github/sync-labels.sh --prune     also delete repo labels absent from the manifest
+#   .github/sync-labels.sh --dry-run   print the actions without applying them
+#
+# requires: gh (authenticated), python3 with pyyaml.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+manifest="$here/labels.yml"
+
+prune=0 dry=0
+for arg in "$@"; do
+  case "$arg" in
+    --prune)   prune=1 ;;
+    --dry-run) dry=1 ;;
+    -h|--help) sed -n '2,9p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+command -v gh >/dev/null 2>&1 || { echo "error: gh not found on PATH" >&2; exit 1; }
+python3 -c 'import yaml' >/dev/null 2>&1 || { echo "error: python3 with pyyaml required (pip install pyyaml)" >&2; exit 1; }
+
+run() { if [ "$dry" -eq 1 ]; then echo "would: $*"; else "$@"; fi; }
+
+# desired labels as name<TAB>color<TAB>description
+desired="$(python3 - "$manifest" <<'PY'
+import sys, yaml
+for l in yaml.safe_load(open(sys.argv[1]))["labels"]:
+    print("{}\t{}\t{}".format(l["name"], str(l["color"]).lstrip("#"), l.get("description", "")))
+PY
+)"
+
+while IFS=$'\t' read -r name color desc; do
+  [ -z "$name" ] && continue
+  run gh label create "$name" --color "$color" --description "$desc" --force
+done <<< "$desired"
+
+if [ "$prune" -eq 1 ]; then
+  want="$(cut -f1 <<< "$desired" | sort -u)"
+  gh label list --limit 200 --json name -q '.[].name' | sort -u | while read -r name; do
+    grep -qxF "$name" <<< "$want" || run gh label delete "$name" --yes
+  done
+fi
+
+[ "$dry" -eq 1 ] && echo "dry-run complete; no changes made." || echo "labels synced."


### PR DESCRIPTION
Captures the cleaned-up label set (36 → 21) as a committed manifest plus an idempotent apply script.

## Files
- `.github/labels.yml` — source-of-truth manifest: 21 labels across four orthogonal dimensions (type / `area:*` / `target:*` / status), each with color + description.
- `.github/sync-labels.sh` — reconciles the repo to the manifest via `gh label create --force`. `--prune` deletes repo labels absent from the manifest; `--dry-run` previews. Requires `gh` + python3/pyyaml.

## Verification
- `--dry-run --prune` against the live repo: 21 upserts, 0 prunes — the manifest exactly matches the current label set.
- A real sync run is a no-op (idempotent).

Closes #1550