### PR TITLE
fix(lower): resolve `$each` struct pack-element lvalue to its slot

### DIFF
--- a/.github/tests/eachstructfield/app/mach.toml
+++ b/.github/tests/eachstructfield/app/mach.toml
@@ -1,0 +1,20 @@
+[project]
+id      = "eachstructfield"
+version = "0.1.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/bin/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.eachstructfield]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"

--- a/.github/tests/eachstructfield/app/src/main.mach
+++ b/.github/tests/eachstructfield/app/src/main.mach
@@ -1,0 +1,69 @@
+use std.runtime;
+
+# field access (`a.x`) and address-of (`?a`) on a struct-typed `$each` pack element
+# (#1549). field access lowers its receiver as an lvalue, and the lvalue path had no
+# pack-element branch: a struct element fell through to a fabricated extern global
+# named after the loop variable (`_M..f..a`), an undefined symbol at link. with the
+# slot resolved as the lvalue, `a.x` and `?a` read the element's storage directly.
+# exits 0 only when every instance computes the value its argument list dictates; a
+# wrong result returns that check's id.
+
+rec Point { x: i64; y: i64; }
+
+# the issue's exact case: an i64 element summed directly alongside a struct element
+# read through a field access, dispatched by `$type_of`. `a.x` is the access that
+# fabricated an undefined extern global before the fix.
+fun f(va: ...) i64 {
+    var s: i64 = 0;
+    $each a in va {
+        $if ($type_of(a) == i64)   { s = s + a; }
+        $or ($type_of(a) == Point) { s = s + a.x; }
+        $or { $error("f: unsupported argument type"); }
+    }
+    ret s;
+}
+
+# a struct-only pack with two field reads per element (`a.x` and `a.y`).
+fun sumxy(va: ...) i64 {
+    var s: i64 = 0;
+    $each a in va {
+        $if ($type_of(a) == Point) { s = s + a.x + a.y; }
+        $or { $error("sumxy: unsupported argument type"); }
+    }
+    ret s;
+}
+
+# `?a` (address-of) on a struct pack element: the element's lvalue is its storage
+# slot, so the pointer reads the same fields. exercises the same lvalue path as `a.x`.
+fun via_ptr(va: ...) i64 {
+    var s: i64 = 0;
+    $each a in va {
+        $if ($type_of(a) == Point) {
+            val pp: *Point = ?a;
+            s = s + pp.x + pp.y;
+        } $or { $error("via_ptr: unsupported argument type"); }
+    }
+    ret s;
+}
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    val p: Point = Point { x: 3, y: 4 };
+    val q: Point = Point { x: 10, y: 20 };
+
+    # the issue's repro: f(10, p) == 10 + p.x == 13.
+    if (f(10, p) != 13) { ret 1; }
+
+    # a mixed pack of two i64s and a struct: 1 + 2 + p.x(3) == 6.
+    if (f(1, p, 2) != 6) { ret 2; }
+
+    # a struct-only pack: (3+4) + (10+20) == 37.
+    if (sumxy(p, q) != 37) { ret 3; }
+
+    # a single struct element: 3 + 4 == 7.
+    if (sumxy(p) != 7) { ret 4; }
+
+    # `?a` over a struct-only pack: same field sums via the element pointer.
+    if (via_ptr(p, q) != 37) { ret 5; }
+    ret 0;
+}

--- a/.github/tests/eachstructfield/run.sh
+++ b/.github/tests/eachstructfield/run.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# #1549 — field access (`a.x`) on a struct-typed `$each` pack element resolves to
+# the element's storage slot instead of fabricating an undefined extern global. a
+# struct pack element reached the lvalue path (field access lowers its receiver as
+# an lvalue) which had no pack branch, so it fell through to a fabricated extern
+# global named after the loop variable and failed at link. this builds a program
+# that reads struct pack-element fields (and takes their address via `?a`) across
+# struct-only and mixed packs, then runs it natively; main exits 0 only when every
+# instance computes the right value.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+case "$MACH" in */*) MACH="$(cd "$(dirname "$MACH")" && pwd)/$(basename "$MACH")";; esac
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: mach dep pull)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+if ! ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL eachstructfield: build failed" >&2
+    exit 1
+fi
+
+BIN="$WORK/app/out/linux/bin/eachstructfield"
+test -x "$BIN" || { echo "error: binary not produced at $BIN" >&2; exit 1; }
+
+set +e
+"$BIN"; code=$?
+set -e
+if [ "$code" -ne 0 ]; then
+    echo "FAIL eachstructfield: check $code computed the wrong value" >&2
+    exit 1
+fi
+echo "PASS eachstructfield: field access and ?a on a struct \$each pack element resolve to its slot"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ collapses the three redundant resolution paths (bare-cwd default, positional, an
 - cli: the `--cwd <path>` flag. Pass the project root as the positional instead
   (`mach build .`) (#1545).
 
+### Fixed
+
+- lower: field access (`a.x`) or address-of (`?a`) on a struct-typed `$each` pack
+  element fabricated an extern global named after the loop variable, failing at
+  link with `undefined symbol`. `lower_ident_lvalue` now resolves a pack element
+  to its expanded-parameter storage slot, mirroring the rvalue path (#1549).
+
 ## [2.4.1] - 2026-06-20
 
 Patch — windows git dependency resolution (#1538) and a multi-target union-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.5.0] - 2026-06-20
 
-Breaking CLI change — the project commands now resolve the project root one way
-only. `build`, `run`, `test`, and `doc` each take the project root as a required
-positional (`mach build .`); a bare invocation with no path is a user error. This
-collapses the three redundant resolution paths (bare-cwd default, positional, and
-`--cwd`) that had drifted in, restoring a single rule (#1545).
+Minor — a breaking CLI change to project-root resolution (#1545) and a codegen
+fix for field access on struct-typed `$each` pack elements (#1549). The project
+commands now resolve the project root one way only: `build`, `run`, `test`, and
+`doc` each take the project root as a required positional (`mach build .`); a
+bare invocation with no path is a user error, collapsing the three redundant
+resolution paths (bare-cwd default, positional, and `--cwd`) that had drifted
+in.
 
 ### Changed
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.4.1"
+version = "2.5.0"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -607,6 +607,20 @@ fun lower_ident_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.V
         ret err[value.Value, str]("lower: cannot take the address of a comptime parameter");
     }
 
+    # a `$each a in va` pack loop variable (#1475): bound to a CT_KIND_PACK_ELEM
+    # descriptor, so it is neither a comptime value-param nor a real local. its
+    # lvalue is the expanded parameter slot lower_pack_instance recorded on the
+    # context — the storage address field access (`a.x`) and `?a` take. mirrors
+    # the pack branch in lower_ident_rvalue.
+    val pe: Option[u32] = pack_elem_ordinal(ctx, sid);
+    if (is_some[u32](pe)) {
+        val i: u32 = unwrap[u32](pe);
+        if (ctx.pack_slots == nil || i >= ctx.pack_len) {
+            ret err[value.Value, str]("lower: pack element ordinal out of range");
+        }
+        ret ok[value.Value, str](ctx.pack_slots[i]);
+    }
+
     val local: Option[value.Value] = lower.lookup_local(ctx, sid);
     if (is_some[value.Value](local)) {
         ret ok[value.Value, str](unwrap[value.Value](local));


### PR DESCRIPTION
Field access (`a.x`) and address-of (`?a`) on a struct-typed `$each` pack element failed at link with `undefined symbol: _M..main..a`.

## Root cause

The rvalue path `lower_ident_rvalue` handles `$each` pack elements (`pack_elem_ordinal` -> `load_pack_elem`), but the lvalue path `lower_ident_lvalue` had no such branch. A pack element is a `CT_KIND_PACK_ELEM` descriptor — neither a comptime value-param nor a real local — so `lower_ident_lvalue` fell through to `symbol_lvalue` -> `ensure_extern_global`, fabricating an extern global named after the loop variable. Field access hits the lvalue path because `lower_member_lvalue` lowers the receiver as an lvalue to add the field offset; `?a` hits it directly.

## Fix

In `src/lang/me/lower/expr.mach`, `lower_ident_lvalue` now resolves a pack element to its expanded-parameter storage slot (`ctx.pack_slots[i]`), mirroring the rvalue path. The pack slot is the storage address, which is exactly what an lvalue should return.

## Test

Added `.github/tests/eachstructfield/` (auto-discovered by CI): an end-to-end build+run test covering struct field reads (`a.x`/`a.y`) and `?a` across struct-only and mixed packs, dispatched by `$type_of`. Verified the test fails on the pre-fix compiler with the exact `undefined symbol: _M15eachstructfield4mainN1a` link error and passes on the fixed compiler. `packmono` still passes.

Closes #1549