### PR TITLE
feat(lower): fold comptime intrinsic paths in global initializers (#1557)

### DIFF
--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -122,11 +122,12 @@ pub fun try_const_aggregate(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_t
 
     # a struct / array literal always routes here. a pointer-typed global routes
     # here when its initializer is a constant address the linker must patch in:
-    # a `str` literal (a rodata blob), an address-of `?G` / `?G.field`, or a bare
-    # function name. the global holds that *address* (a relocation), never bytes
-    # inline — and there is no init-synthesis pass, so an unfolded pointer global
-    # would stay a NULL placeholder. any other initializer is a scalar the caller
-    # folds through its own path.
+    # a `str` literal (a rodata blob), a string-valued comptime path
+    # (`$project.version`), an address-of `?G` / `?G.field`, or a bare function
+    # name. the global holds that *address* (a relocation), never bytes inline —
+    # and there is no init-synthesis pass, so an unfolded pointer global would
+    # stay a NULL placeholder. any other initializer is a scalar the caller folds
+    # through its own path.
     var is_agg: bool = e.kind == aexpr.EXPR_KIND_STRUCT_LIT || e.kind == aexpr.EXPR_KIND_ARRAY_LIT;
     if (ir_is_ptr_or_fn(ctx, gty) && is_const_addr_init(ctx, eid, e)) { is_agg = true; }
     if (!is_agg) {
@@ -270,10 +271,10 @@ fun place_array(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId
 }
 
 # lays out a pointer leaf. records a relocation patching this slot with a symbol
-# address: a `str` literal materializes an anonymous `.rodata` global; `&G` (or
-# `&G.field`) takes the address of a module global with a field-offset addend.
-# `nil` stays zero. any other pointer initializer (a runtime pointer) -> fall
-# back.
+# address: a `str` literal or a string-valued comptime path (`$project.version`)
+# materializes an anonymous `.rodata` global; `&G` (or `&G.field`) takes the
+# address of a module global with a field-offset addend. `nil` stays zero. any
+# other pointer initializer (a runtime pointer) -> fall back.
 fun place_ptr(ctx: *lower.LowerContext, eid: aid.ExprId, blob: *u8, base: u32, rb: *RelocBuf, fold: *FoldResult) Result[bool, str] {
     val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
     if (is_none[*aexpr.Expr](e_opt)) { ret err[bool, str]("constagg: pointer leaf expr out of range"); }
@@ -296,6 +297,25 @@ fun place_ptr(ctx: *lower.LowerContext, eid: aid.ExprId, blob: *u8, base: u32, r
     # without emitting any IR (no active builder block at global scope).
     if (e.kind == aexpr.EXPR_KIND_UNARY && e.data.unary.op == aexpr.UN_ADDR) {
         ret place_addr_of(ctx, e.data.unary.operand, blob, base, rb, fold);
+    }
+
+    # a comptime path (`$project.version`, `$mach.*`, ...) that folds to a string
+    # is the address of a rodata blob, exactly like a `str` literal: materialise
+    # the blob and record a relocation, mirroring expression-position folding
+    # (lower_comptime_path -> const_value_of). a path that fails to fold or folds
+    # to a non-string is not a constant address -> fall back.
+    if (comptime.is_comptime_path(ctx.a, eid)) {
+        val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner);
+        if (is_err[comptime.CTValue, str](ev)) { @fold = FOLD_FALLBACK; ret ok[bool, str](true); }
+        val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
+        if (v.kind != comptime.CT_KIND_STR) { @fold = FOLD_FALLBACK; ret ok[bool, str](true); }
+        val gv_r: Result[value.Value, str] = expr.const_value_of(ctx, eid, v);
+        if (is_err[value.Value, str](gv_r)) { ret err[bool, str](unwrap_err[value.Value, str](gv_r)); }
+        val gv: value.Value = unwrap_ok[value.Value, str](gv_r);
+        if (gv.kind != value.VAL_GLOBAL || gv.data.global_ix >= ctx.m.global_len) {
+            ret err[bool, str]("constagg: comptime string leaf did not lower to a global");
+        }
+        ret push_sym_reloc(ctx, rb, base, ctx.m.globals[gv.data.global_ix].name, 0, false);
     }
 
     # a bare function name stored in a pointer slot is a constant (a function is
@@ -458,16 +478,20 @@ fun ir_is_ptr_or_fn(ctx: *lower.LowerContext, ity: ir_type.IrTypeId) bool {
 }
 
 # true when `e` initializes a pointer global with a compile-time-constant address
-# the back end emits as a relocation: a string literal, an address-of (`?G` /
-# `?mod.G`), or a bare name resolving to a module function. routing these through
-# the folder keeps a top-level pointer global from staying a NULL placeholder
-# (there is no init-synthesis pass to fill it later). a `nil` initializer is
-# already a correct zero placeholder on the scalar path, so it is left there. a
-# bare *data* global name is the runtime contents of that global, not a constant
-# address, so it is excluded here (it would only zalloc a blob and fall back).
+# the back end emits as a relocation: a string literal, a string-valued comptime
+# path (`$project.version`, `$mach.*`), an address-of (`?G` / `?mod.G`), or a bare
+# name resolving to a module function. routing these through the folder keeps a
+# top-level pointer global from staying a NULL placeholder (there is no init-
+# synthesis pass to fill it later). a `nil` initializer is already a correct zero
+# placeholder on the scalar path, so it is left there. a bare *data* global name
+# is the runtime contents of that global, not a constant address, so it is
+# excluded here (it would only zalloc a blob and fall back). the comptime-path
+# test is structural (cheap); place_ptr folds it and falls back if it is not a
+# string, so a path resolving to a non-address constant is handled correctly.
 fun is_const_addr_init(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) bool {
     if (e.kind == aexpr.EXPR_KIND_LIT_STR) { ret true; }
     if (e.kind == aexpr.EXPR_KIND_UNARY && e.data.unary.op == aexpr.UN_ADDR) { ret true; }
+    if (comptime.is_comptime_path(ctx.a, eid)) { ret true; }
     if (e.kind == aexpr.EXPR_KIND_IDENT || e.kind == aexpr.EXPR_KIND_MEMBER) {
         ret expr.references_function(ctx, eid);
     }

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -849,11 +849,13 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
 #      (`nil::F`, `nil:~*T`) — materialised as the null constant. tried first
 #      since `comptime.eval` has no CTValue for nil and a cast over nil bottoms
 #      out at the same non-constant leaf, so no other folder reaches it.
-#   2. an aggregate (struct / array / `str`-into-pointer) whose bytes and
-#      pointer relocations are laid out as initialised data; tried before the
-#      scalar fold so a `val X: str = "..."` becomes a pointer-with-relocation,
-#      not inline bytes.
-#   3. a scalar comptime constant the frontend `comptime.eval` folds.
+#   2. an aggregate (struct / array / `str`-into-pointer, including a string-
+#      valued comptime path) whose bytes and pointer relocations are laid out as
+#      initialised data; tried before the scalar fold so a `val X: str = "..."`
+#      (or `= $project.version`) becomes a pointer-with-relocation, not inline
+#      bytes.
+#   3. a scalar comptime constant the frontend `comptime.eval` folds (an integer
+#      comptime path such as `$mach.version.major` lands here).
 #   4. a constant scalar cast (`<const>::T`, including chains), folded with the
 #      same width / sign semantics `lower_cast` lowers.
 #   5. a type-introspection intrinsic (`$size_of` / `$align_of` / `$offset_of`)


### PR DESCRIPTION
Closes #1557

## Scope
This PR is the **global-initialiser fold only** — the codegen fix. The motivating `mach.lang.version` simplification (`fun string()` → `pub val VERSION: str = $project.version;`) is deliberately deferred to a **follow-up for the next release**: it can only land once a release seed already contains this fix. Making the compiler's own `VERSION` depend on the fix in the same release crashes the bootstrap — the old seed lacks the fix, so it emits stage1's own `VERSION` in the broken raw-bytes form and the driver/`info` dereferences a corrupt pointer (SIGSEGV).

## Problem
A module-level `val`/`var` initialised to a comptime intrinsic path was not folded. The constant folder in `src/lang/me/lower/constagg.mach` routed string/char literals and const addresses through `comptime.eval`, but a string-valued comptime path (`$project.version`, `$mach.*`) emitted raw inline bytes into the global's pointer slot rather than a pointer to a rodata blob — so e.g. `pub val VERSION: str = $project.version;` compiled but yielded an empty value. Integer comptime paths (`$mach.version.major`) already folded correctly through the scalar comptime path.

## Fix
Teach the aggregate folder that a string-valued comptime path is a constant address, exactly like a `str` literal:
- `is_const_addr_init` recognises a comptime path structurally.
- `place_ptr` folds it via `comptime.eval`, materialises the rodata blob through the existing `expr.const_value_of` machinery, and records a relocation — so the pointer global holds the blob's address (`agg` + reloc), identical in shape to an existing str-literal global.

## Verification (bootstrap-safe)
1. Seed → stage1 (`mach build .`): `out/linux/bin/mach info --version` → `2.5.0` (exit 0, no crash); `out/linux/bin/mach test .` → 552 passed, 0 failed.
2. Stage1-vs-stage2 fixpoint: `mach build . -o a && ./a build . -o b && cmp -s a b` → `a == b` (the fix changes no emitted bytes, since the compiler binary has no comptime-path str global).
3. Scratch external project (not committed) with `pub val X: str = $project.version;`, built by stage1 and run → prints `X=[9.8.7]` for a manifest version `9.8.7` (folds correctly, non-empty, exit 0).

No in-source regression test is committed: an in-source test for the str-global case would itself place a comptime-path str global in the compiler binary, reintroducing the seed crash. The regression test belongs with the follow-up `version.mach` conversion, once the seed carries this fix.