### PR TITLE
fix(lower): fold const-string global references in global initializers (#1559)

### DIFF
--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -122,12 +122,12 @@ pub fun try_const_aggregate(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_t
 
     # a struct / array literal always routes here. a pointer-typed global routes
     # here when its initializer is a constant address the linker must patch in:
-    # a `str` literal (a rodata blob), a string-valued comptime path
-    # (`$project.version`), an address-of `?G` / `?G.field`, or a bare function
-    # name. the global holds that *address* (a relocation), never bytes inline —
-    # and there is no init-synthesis pass, so an unfolded pointer global would
-    # stay a NULL placeholder. any other initializer is a scalar the caller folds
-    # through its own path.
+    # a `str` literal (a rodata blob), any initializer that comptime-folds to a
+    # string (a comptime path `$project.version`, a const-string `val` reference),
+    # an address-of `?G` / `?G.field`, or a bare function name. the global holds
+    # that *address* (a relocation), never bytes inline — and there is no init-
+    # synthesis pass, so an unfolded pointer global would stay a NULL placeholder.
+    # any other initializer is a scalar the caller folds through its own path.
     var is_agg: bool = e.kind == aexpr.EXPR_KIND_STRUCT_LIT || e.kind == aexpr.EXPR_KIND_ARRAY_LIT;
     if (ir_is_ptr_or_fn(ctx, gty) && is_const_addr_init(ctx, eid, e)) { is_agg = true; }
     if (!is_agg) {
@@ -271,10 +271,12 @@ fun place_array(ctx: *lower.LowerContext, eid: aid.ExprId, ity: ir_type.IrTypeId
 }
 
 # lays out a pointer leaf. records a relocation patching this slot with a symbol
-# address: a `str` literal or a string-valued comptime path (`$project.version`)
-# materializes an anonymous `.rodata` global; `&G` (or `&G.field`) takes the
-# address of a module global with a field-offset addend. `nil` stays zero. any
-# other pointer initializer (a runtime pointer) -> fall back.
+# address: a `str` literal or any initializer that comptime-folds to a string (a
+# comptime path `$project.version`, a const-string `val` reference) materializes
+# an anonymous `.rodata` global; `&G` (or `&G.field`) takes the address of a
+# module global with a field-offset addend; a bare function name takes the
+# function's address. `nil` stays zero. any other pointer initializer (a runtime
+# pointer) -> fall back.
 fun place_ptr(ctx: *lower.LowerContext, eid: aid.ExprId, blob: *u8, base: u32, rb: *RelocBuf, fold: *FoldResult) Result[bool, str] {
     val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
     if (is_none[*aexpr.Expr](e_opt)) { ret err[bool, str]("constagg: pointer leaf expr out of range"); }
@@ -299,32 +301,32 @@ fun place_ptr(ctx: *lower.LowerContext, eid: aid.ExprId, blob: *u8, base: u32, r
         ret place_addr_of(ctx, e.data.unary.operand, blob, base, rb, fold);
     }
 
-    # a comptime path (`$project.version`, `$mach.*`, ...) that folds to a string
-    # is the address of a rodata blob, exactly like a `str` literal: materialise
-    # the blob and record a relocation, mirroring expression-position folding
-    # (lower_comptime_path -> const_value_of). a path that fails to fold or folds
-    # to a non-string is not a constant address -> fall back.
-    if (comptime.is_comptime_path(ctx.a, eid)) {
-        val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner);
-        if (is_err[comptime.CTValue, str](ev)) { @fold = FOLD_FALLBACK; ret ok[bool, str](true); }
-        val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
-        if (v.kind != comptime.CT_KIND_STR) { @fold = FOLD_FALLBACK; ret ok[bool, str](true); }
-        val gv_r: Result[value.Value, str] = expr.const_value_of(ctx, eid, v);
-        if (is_err[value.Value, str](gv_r)) { ret err[bool, str](unwrap_err[value.Value, str](gv_r)); }
-        val gv: value.Value = unwrap_ok[value.Value, str](gv_r);
-        if (gv.kind != value.VAL_GLOBAL || gv.data.global_ix >= ctx.m.global_len) {
-            ret err[bool, str]("constagg: comptime string leaf did not lower to a global");
-        }
-        ret push_sym_reloc(ctx, rb, base, ctx.m.globals[gv.data.global_ix].name, 0, false);
+    # a bare function name stored in a pointer slot is a constant (a function is
+    # an address); record a reloc to it. checked before the const-string fold so a
+    # function symbol never reaches the comptime evaluator.
+    if ((e.kind == aexpr.EXPR_KIND_IDENT || e.kind == aexpr.EXPR_KIND_MEMBER) && expr.references_function(ctx, eid)) {
+        ret place_fn(ctx, eid, blob, base, rb, fold);
     }
 
-    # a bare function name stored in a pointer slot is a constant (a function is
-    # an address); record a reloc to it. a bare *data* global name is the runtime
-    # contents of that global, not its address, so it is not a compile-time
-    # constant -> fall back.
-    if (e.kind == aexpr.EXPR_KIND_IDENT || e.kind == aexpr.EXPR_KIND_MEMBER) {
-        if (expr.references_function(ctx, eid)) {
-            ret place_fn(ctx, eid, blob, base, rb, fold);
+    # any initializer that comptime-folds to a string is the address of a rodata
+    # blob, exactly like a `str` literal: materialise the blob via const_value_of
+    # and record a relocation, mirroring expression-position folding
+    # (lower_comptime_path -> const_value_of). covers a comptime path
+    # (`$project.version`), a reference to a const-string `val` (`pub val B = A`),
+    # and any other const-string fold. a leaf that does not comptime-fold (a
+    # runtime data global, a runtime call) or folds to a non-string is not a
+    # constant address -> fall back.
+    val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner);
+    if (!is_err[comptime.CTValue, str](ev)) {
+        val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
+        if (v.kind == comptime.CT_KIND_STR) {
+            val gv_r: Result[value.Value, str] = expr.const_value_of(ctx, eid, v);
+            if (is_err[value.Value, str](gv_r)) { ret err[bool, str](unwrap_err[value.Value, str](gv_r)); }
+            val gv: value.Value = unwrap_ok[value.Value, str](gv_r);
+            if (gv.kind != value.VAL_GLOBAL || gv.data.global_ix >= ctx.m.global_len) {
+                ret err[bool, str]("constagg: const string leaf did not lower to a global");
+            }
+            ret push_sym_reloc(ctx, rb, base, ctx.m.globals[gv.data.global_ix].name, 0, false);
         }
     }
 
@@ -478,22 +480,29 @@ fun ir_is_ptr_or_fn(ctx: *lower.LowerContext, ity: ir_type.IrTypeId) bool {
 }
 
 # true when `e` initializes a pointer global with a compile-time-constant address
-# the back end emits as a relocation: a string literal, a string-valued comptime
-# path (`$project.version`, `$mach.*`), an address-of (`?G` / `?mod.G`), or a bare
-# name resolving to a module function. routing these through the folder keeps a
+# the back end emits as a relocation: a string literal, an address-of (`?G` /
+# `?mod.G`), a bare name resolving to a module function, or any initializer that
+# comptime-folds to a string (a comptime path `$project.version` / `$mach.*`, a
+# reference to a const-string `val`). routing these through the folder keeps a
 # top-level pointer global from staying a NULL placeholder (there is no init-
 # synthesis pass to fill it later). a `nil` initializer is already a correct zero
 # placeholder on the scalar path, so it is left there. a bare *data* global name
-# is the runtime contents of that global, not a constant address, so it is
-# excluded here (it would only zalloc a blob and fall back). the comptime-path
-# test is structural (cheap); place_ptr folds it and falls back if it is not a
-# string, so a path resolving to a non-address constant is handled correctly.
+# that is not a const string is the runtime contents of that global, not a
+# constant address, so it does not fold here and falls back. is_const_addr_init
+# and place_ptr classify identically (same fold), so a routed leaf always lays
+# out a relocation rather than being truncated back.
 fun is_const_addr_init(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) bool {
     if (e.kind == aexpr.EXPR_KIND_LIT_STR) { ret true; }
     if (e.kind == aexpr.EXPR_KIND_UNARY && e.data.unary.op == aexpr.UN_ADDR) { ret true; }
-    if (comptime.is_comptime_path(ctx.a, eid)) { ret true; }
-    if (e.kind == aexpr.EXPR_KIND_IDENT || e.kind == aexpr.EXPR_KIND_MEMBER) {
-        ret expr.references_function(ctx, eid);
-    }
-    ret false;
+    if ((e.kind == aexpr.EXPR_KIND_IDENT || e.kind == aexpr.EXPR_KIND_MEMBER) && expr.references_function(ctx, eid)) { ret true; }
+    ret folds_to_const_str(ctx, eid);
+}
+
+# true when `eid` comptime-folds to a string constant — the address of a rodata
+# blob place_ptr materializes. a leaf that is not comptime-constant, or folds to
+# a non-string, is not a const address.
+fun folds_to_const_str(ctx: *lower.LowerContext, eid: aid.ExprId) bool {
+    val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner);
+    if (is_err[comptime.CTValue, str](ev)) { ret false; }
+    ret unwrap_ok[comptime.CTValue, str](ev).kind == comptime.CT_KIND_STR;
 }


### PR DESCRIPTION
Closes #1559

## Problem
A `str`/pointer-typed global initialised to a non-comptime-path constant string *reference* mis-emitted. For example:

```mach
pub val A: str = "hi";
pub val B: str = A;
```

`A` folded correctly (`agg[8]` with a relocation to a rodata blob), but `B` fell through the relocation path — `is_const_addr_init` treats a bare data-global ident as runtime contents (not a function reference) — into the scalar path, which raw-blobbed the string into `B`'s pointer slot (`B: ptr = bytes[6]`). `B` was then a corrupt pointer. This is the sibling of #1557 (comptime-path globals).

## Fix
Generalise the #1557 approach from "structural comptime path" to "comptime-folds to a string":
- `is_const_addr_init` now classifies a pointer-global initializer as a constant address when it folds to a string (new `folds_to_const_str` helper), in addition to str literals, address-of, and function references.
- `place_ptr` folds any leaf that yields a `CT_KIND_STR` and materialises the rodata blob via the existing `expr.const_value_of` machinery, recording a relocation — identical in shape to a str-literal global.
- The function-reference check is hoisted ahead of the fold so a function symbol never reaches the comptime evaluator.

**Pointer-only.** Both touched functions are reachable only for `IRT_PTR`/`IRT_FN` leaves (`is_const_addr_init` is gated by `ir_is_ptr_or_fn`; `place_ptr` handles only pointer leaves). Array- and scalar-typed globals — including the byte-array inline path — are structurally untouched.

## Bootstrap note
Fix-only, like #1557. No module-level comptime-foldable `str` global is added to the compiler source (no in-source regression test for the global case), because the seed (v2.5.1) lacks this fix and would emit such a global broken → stage1 crash. Verified via a scratch external project instead.

## Verification (bootstrap-safe)
1. Seed → stage1 (`mach build .`): `out/linux/bin/mach info --version` → `2.5.1` (exit 0, no crash); `out/linux/bin/mach test .` → 552 passed, 0 failed.
2. Stage1-vs-stage2 fixpoint: `mach build . -o a && ./a build . -o b && cmp -s a b` → `a == b` (the generalization changes no emitted bytes).
3. Scratch external project (`pub val A: str = "hello"; pub val B: str = A;`, B printed by main), built by stage1 and run → `B=[hello]` (valid pointer, exit 0). IR confirms `B: ptr = agg[8]` with a reloc to a fresh rodata blob.