### PR TITLE
perf(frontend): resolve hot paths — hoist dep scratch, hash module scope

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2730,20 +2730,44 @@ fun register_module_asts(p: *Project) Result[bool, str] {
 }
 
 fun run_resolve_pass(p: *Project) Result[bool, str] {
+    # dep-closure scratch reused across every module: a `visited` mark array and a
+    # worklist, both bounded by module_len. allocating them once per build (not once
+    # per module in build_resolve_deps) keeps dep-set construction O(modules) in
+    # allocation rather than O(modules^2). visited is zeroed once here and each call
+    # restores it to all-false on success, so successive calls start clean.
+    val vr: Result[*bool, str] = allocate[bool](p.s.alloc, p.module_len::usize);
+    if (is_err[*bool, str](vr)) { ret err[bool, str](unwrap_err[*bool, str](vr)); }
+    val visited: *bool = unwrap_ok[*bool, str](vr);
+    var vi: u32 = 0;
+    for (vi < p.module_len) { visited[vi] = false; vi = vi + 1; }
+
+    val lr: Result[*sess.ModuleId, str] = allocate[sess.ModuleId](p.s.alloc, p.module_len::usize);
+    if (is_err[*sess.ModuleId, str](lr)) {
+        deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+        ret err[bool, str](unwrap_err[*sess.ModuleId, str](lr));
+    }
+    val list: *sess.ModuleId = unwrap_ok[*sess.ModuleId, str](lr);
+
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: sess.ModuleId = p.topo[i];
-        val r: Result[bool, str] = run_resolve_one(p, mid);
-        if (is_err[bool, str](r)) { ret r; }
+        val r: Result[bool, str] = run_resolve_one(p, mid, visited, list);
+        if (is_err[bool, str](r)) {
+            deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
+            deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+            ret r;
+        }
         i = i + 1;
     }
+    deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
+    deallocate[bool](p.s.alloc, visited, p.module_len::usize);
     ret ok[bool, str](true);
 }
 
-fun run_resolve_one(p: *Project, mid: sess.ModuleId) Result[bool, str] {
+fun run_resolve_one(p: *Project, mid: sess.ModuleId, visited: *bool, list: *sess.ModuleId) Result[bool, str] {
     val m: *ModuleEntry = ?p.modules[mid::u32];
 
-    val deps_r: Result[resolve.ResolveDeps, str] = build_resolve_deps(p, m);
+    val deps_r: Result[resolve.ResolveDeps, str] = build_resolve_deps(p, m, visited, list);
     if (is_err[resolve.ResolveDeps, str](deps_r)) { ret err[bool, str](unwrap_err[resolve.ResolveDeps, str](deps_r)); }
     var deps: resolve.ResolveDeps = unwrap_ok[resolve.ResolveDeps, str](deps_r);
 
@@ -2762,24 +2786,17 @@ fun run_resolve_one(p: *Project, mid: sess.ModuleId) Result[bool, str] {
 # `dep.alias`), so its exports must be present in the dep set or the re-export
 # resolves to nothing downstream. all closure members are earlier in topo order
 # and thus already resolved.
-fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps, str] {
+fun build_resolve_deps(p: *Project, m: *ModuleEntry, visited: *bool, list: *sess.ModuleId) Result[resolve.ResolveDeps, str] {
     var deps: resolve.ResolveDeps;
     deps.entries = nil;
     deps.count   = 0;
     if (m.dep_count == 0) { ret ok[resolve.ResolveDeps, str](deps); }
 
-    val vr: Result[*bool, str] = allocate[bool](p.s.alloc, p.module_len::usize);
-    if (is_err[*bool, str](vr)) { ret err[resolve.ResolveDeps, str](unwrap_err[*bool, str](vr)); }
-    val visited: *bool = unwrap_ok[*bool, str](vr);
-    var vi: u32 = 0;
-    for (vi < p.module_len) { visited[vi] = false; vi = vi + 1; }
-
-    val lr: Result[*sess.ModuleId, str] = allocate[sess.ModuleId](p.s.alloc, p.module_len::usize);
-    if (is_err[*sess.ModuleId, str](lr)) {
-        deallocate[bool](p.s.alloc, visited, p.module_len::usize);
-        ret err[resolve.ResolveDeps, str](unwrap_err[*sess.ModuleId, str](lr));
-    }
-    val list: *sess.ModuleId = unwrap_ok[*sess.ModuleId, str](lr);
+    # `visited` and `list` are caller-owned scratch (run_resolve_pass), reused across
+    # modules. visited is all-false on entry; every module this call marks is mirrored
+    # in list, so the success path clears exactly those entries (the portion touched)
+    # before returning. an error aborts the whole pass, so a dirty visited never leaks
+    # to a later call. list is rebuilt from list_len = 0 each call.
     var list_len: u32 = 0;
 
     var i: u32 = 0;
@@ -2804,8 +2821,6 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
     # id — matching the load walk, where `use <id>;` resolves to this same module.
     val ar: Result[*intern.StrId, str] = allocate[intern.StrId](p.s.alloc, list_len::usize);
     if (is_err[*intern.StrId, str](ar)) {
-        deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
-        deallocate[bool](p.s.alloc, visited, p.module_len::usize);
         ret err[resolve.ResolveDeps, str](unwrap_err[*intern.StrId, str](ar));
     }
     val aliases: *intern.StrId = unwrap_ok[*intern.StrId, str](ar);
@@ -2821,8 +2836,6 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
     val r: Result[*resolve.ModuleExports, str] = allocate[resolve.ModuleExports](p.s.alloc, total::usize);
     if (is_err[*resolve.ModuleExports, str](r)) {
         deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
-        deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
-        deallocate[bool](p.s.alloc, visited, p.module_len::usize);
         ret err[resolve.ResolveDeps, str](unwrap_err[*resolve.ModuleExports, str](r));
     }
     deps.entries = unwrap_ok[*resolve.ModuleExports, str](r);
@@ -2847,8 +2860,6 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
         if (is_err[resolve.ModuleExports, str](mx_r)) {
             free_resolve_deps(p.s.alloc, ?deps);
             deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
-            deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
-            deallocate[bool](p.s.alloc, visited, p.module_len::usize);
             ret err[resolve.ResolveDeps, str](unwrap_err[resolve.ModuleExports, str](mx_r));
         }
         deps.entries[w] = unwrap_ok[resolve.ModuleExports, str](mx_r);
@@ -2858,8 +2869,6 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
             if (is_err[resolve.ModuleExports, str](ax_r)) {
                 free_resolve_deps(p.s.alloc, ?deps);
                 deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
-                deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
-                deallocate[bool](p.s.alloc, visited, p.module_len::usize);
                 ret err[resolve.ResolveDeps, str](unwrap_err[resolve.ModuleExports, str](ax_r));
             }
             var ax: resolve.ModuleExports = unwrap_ok[resolve.ModuleExports, str](ax_r);
@@ -2871,8 +2880,12 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
     }
 
     deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
-    deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
-    deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+
+    # restore the caller-owned visited array to all-false for the next module: every
+    # mark set this call has a matching list entry, so clearing just those indices
+    # (not the whole module_len) leaves it clean in O(list_len).
+    var c: u32 = 0;
+    for (c < list_len) { visited[list[c]::u32] = false; c = c + 1; }
     ret ok[resolve.ResolveDeps, str](deps);
 }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -215,6 +215,15 @@ rec ResolveContext {
     # SYM_IMPORTED entries, so repeated `print.println` use-sites share one
     # Symbol instead of inflating the symbol table per reference.
     imported_cache: map.Map[u64, SymbolId];
+
+    # name -> SymbolId index for the module scope only. the module/top-level scope
+    # can hold many symbols and every chain lookup ends there, so a linear scan made
+    # name binding ~O(references * module-symbols). kept in lockstep with the module
+    # scope's entries in scope_add; lookups route through it in scope_lookup_local.
+    # block scopes stay linear (small, not worth a map). the module scope never holds
+    # duplicate names (every add is guarded by a lookup), so a single entry per name
+    # matches the first-match the scan would have returned.
+    module_index: map.Map[intern.StrId, SymbolId];
 }
 
 # number of primitive type names (u8..f64, ptr).
@@ -395,6 +404,7 @@ fun init_context(
     }
 
     rc.imported_cache = map.init[u64, SymbolId](s.alloc, map.hash_u64, map.eq_u64);
+    rc.module_index   = map.init[intern.StrId, SymbolId](s.alloc, map.hash_u32, map.eq_u32);
 
     # every allocation past this point is owned by the context; on a failure
     # dnit_context tears down whatever has been allocated so far (the array
@@ -471,6 +481,7 @@ fun dnit_context(rc: *ResolveContext) {
         deallocate[SymbolId](rc.s.alloc, rc.decl_symbol, rc.a.decl_len);
     }
     map.dnit[u64, SymbolId](?rc.imported_cache);
+    map.dnit[intern.StrId, SymbolId](?rc.module_index);
 }
 
 fun open_scope(rc: *ResolveContext, parent: ScopeId) Result[ScopeId, str] {
@@ -514,11 +525,23 @@ fun scope_add(rc: *ResolveContext, scope: ScopeId, name: intern.StrId, sym: Symb
     e.sym  = sym;
     sc.entries[sc.len] = e;
     sc.len = sc.len + 1;
+
+    # mirror module-scope adds into the name index so scope_lookup_local can answer
+    # in O(1); other scopes stay linear-only.
+    if (scope == rc.module_scope) {
+        val ins: Result[bool, str] = map.insert[intern.StrId, SymbolId](?rc.module_index, name, sym);
+        if (is_err[bool, str](ins)) { ret err[bool, str](unwrap_err[bool, str](ins)); }
+    }
     ret ok[bool, str](true);
 }
 
 fun scope_lookup_local(rc: *ResolveContext, scope: ScopeId, name: intern.StrId) SymbolId {
     if (scope == SCOPE_NIL) { ret SYMBOL_NIL; }
+    if (scope == rc.module_scope) {
+        val g: Result[*SymbolId, str] = map.get[intern.StrId, SymbolId](?rc.module_index, ?name);
+        if (is_ok[*SymbolId, str](g)) { ret @unwrap_ok[*SymbolId, str](g); }
+        ret SYMBOL_NIL;
+    }
     val sc: *Scope = ?rc.scopes[scope];
     var i: u32 = 0;
     for (i < sc.len) {


### PR DESCRIPTION
Front-end resolve performance hot paths. Closes #1565.

### Fix 1 (T2.7a) — hoist resolve dep-closure scratch
`build_resolve_deps` allocated and zeroed two `module_len`-sized arrays (`visited`, `list`) per call, once per module from `run_resolve_pass` — O(modules^2) allocation. Now allocated once per build in `run_resolve_pass`, passed down, and `visited` is reset in O(list_len) on the success path (every mark has a paired `list` entry; an error aborts the whole pass). Behaviour identical.

### Fix 2 (T2.6) — hash-index the module scope
`scope_lookup_local` / `scope_lookup_chain` were linear scans, and every chain lookup ends at the module/top-level scope (potentially many symbols) — making name binding ~O(references × module-symbols). Added a `StrId -> SymbolId` index (mirroring the `imported_cache` / `param_index` map pattern) kept in lockstep with the module scope's entries in `scope_add`; module-scope lookups route through it. Block scopes stay linear. The module scope holds no duplicate names, so the single indexed entry per name matches the first-match the scan returned. Behaviour identical.

Full test suite (`mach test .`) green after each commit: 552 passed, 0 failed.