### PR TITLE
feat(driver): stream front-end lex/parse/resolve under --verbose

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -549,6 +549,11 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
     s.opt_explicit = cli_set;
     s.opt_release  = cli_level == pipeline.OPT_RELEASE;
 
+    # thread the CLI `--verbose` intent into the session so the front-end load walk
+    # emits per-module `lex`/`parse`/`resolve` progress lines, matching the
+    # back-end stage lines `compile_and_link` prints from `config.verbose`.
+    s.verbose = config.verbose;
+
     val proj_r: Result[driver.Project, str] = driver.build_project_sel(?s, util.cstr_str(?root[0]), ?sel);
     if (is_err[driver.Project, str](proj_r)) {
         print.eprint("error: ");

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -52,6 +52,7 @@ use fs:   std.filesystem;
 use toml: std.data.toml;
 use map:  std.collections.map;
 use maphash: std.collections.map;
+use print: std.print;
 
 use src:    mach.lang.source;
 use diag:   mach.lang.diagnostic;
@@ -2107,6 +2108,24 @@ fun parse_define_int(s: str, start: usize, len: usize, out: *i64) bool {
     ret true;
 }
 
+# emit_stage: write a `<stage> <fqn>` front-end progress line to stderr for one
+# module, matching the back-end's `--verbose` stage lines (cmd.build.emit_stage).
+# a no-op unless the session's `verbose` flag is set; an un-interned fqn renders
+# as "<?>".
+# ---
+# p:     the project (for its session interner and verbose flag)
+# stage: a short stage label (e.g. "lex", "parse", "resolve")
+# fqn:   the module's interned fully-qualified name
+fun emit_stage(p: *Project, stage: str, fqn: intern.StrId) {
+    if (!p.s.verbose) { ret; }
+    print.eprint(stage);
+    print.eprint(" ");
+    val o: Option[str] = intern.lookup(?p.s.interner, fqn);
+    if (is_some[str](o)) { print.eprint(unwrap[str](o)); }
+    or                   { print.eprint("<?>"); }
+    print.eprint("\n");
+}
+
 fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool, str] {
     val path_r: Result[str, str] = fqn_to_file_path(p, fqn);
     if (is_err[str, str](path_r)) { ret err[bool, str](unwrap_err[str, str](path_r)); }
@@ -2129,6 +2148,7 @@ fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool
     if (is_none[*src.SourceFile](file_opt)) { ret err[bool, str]("registered FileId not found in SourceMap"); }
     val file: *src.SourceFile = unwrap[*src.SourceFile](file_opt);
 
+    emit_stage(p, "lex", fqn);
     val tok_r: Result[lexer.TokenStream, str] = lexer.tokenize(file.text, p.s.alloc, file_id);
     if (is_err[lexer.TokenStream, str](tok_r)) { ret err[bool, str](unwrap_err[lexer.TokenStream, str](tok_r)); }
     var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tok_r);
@@ -2141,6 +2161,7 @@ fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool
         lexer.dnit(?stream, p.s.alloc);
         ret err[bool, str](unwrap_err[bool, str](le_r));
     }
+    emit_stage(p, "parse", fqn);
     val fatal: bool = parser.parse(?stream, ?m.a, ?p.s.diags);
     lexer.dnit(?stream, p.s.alloc);
     # a fatal allocation failure leaves the AST incomplete; refuse to walk it
@@ -2766,6 +2787,8 @@ fun run_resolve_pass(p: *Project) Result[bool, str] {
 
 fun run_resolve_one(p: *Project, mid: sess.ModuleId, visited: *bool, list: *sess.ModuleId) Result[bool, str] {
     val m: *ModuleEntry = ?p.modules[mid::u32];
+
+    emit_stage(p, "resolve", m.fqn);
 
     val deps_r: Result[resolve.ResolveDeps, str] = build_resolve_deps(p, m, visited, list);
     if (is_err[resolve.ResolveDeps, str](deps_r)) { ret err[bool, str](unwrap_err[resolve.ResolveDeps, str](deps_r)); }

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -86,6 +86,10 @@ pub rec Session {
     # was given (it wins over the manifest), opt_release its release-vs-debug sense.
     opt_explicit:     bool;
     opt_release:      bool;
+    # the CLI `--verbose` intent, set before build_project so the front-end load
+    # walk emits a per-module `lex`/`parse`/`resolve` progress line to stderr,
+    # matching the back-end's `--verbose` stage lines. off leaves the load silent.
+    verbose:          bool;
 }
 
 # init: construct an empty Session backed by the given allocator. sub-services
@@ -121,6 +125,7 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
     s.registry         = target.registry_init();
     s.opt_explicit     = false;
     s.opt_release      = false;
+    s.verbose          = false;
 
     val r_types: Result[ty.TypeInterner, str] = ty.init(alloc);
     if (is_err[ty.TypeInterner, str](r_types)) {


### PR DESCRIPTION
## Summary

`mach build --verbose` was silent for the whole front-end (the `driver.build_project_sel` call) — the first `--verbose` line was the back-end's `target <name> (N module(s))`, printed only after the entire graph was lexed, parsed, and resolved. The back-end already streams per-module `sema`/`lower`/`codegen` lines via `cmd.build.emit_stage`; this closes the front-end gap in the same style and stream.

## Changes

- `session.mach`: add a `verbose: bool` CLI-intent flag on `Session`, alongside the existing `opt_explicit`/`opt_release` intent flags (default false).
- `cmd/build.mach`: set `s.verbose = config.verbose` before `build_project_sel`, mirroring how the opt intent is threaded.
- `driver.mach`: add a small `emit_stage` helper (a no-op unless `s.verbose`) and emit `lex <fqn>` / `parse <fqn>` per module in `parse_module` and `resolve <fqn>` per module in `run_resolve_one`. Format and stderr stream match `cmd.build.emit_stage`.

No pipeline refactor; the layering is preserved (driver does not depend on the CLI — emission lives in the driver, fed by a session flag).

## Behavior

```
lex vtest.main
parse vtest.main
lex vtest.util
parse vtest.util
lex vtest.math
parse vtest.math
resolve vtest.util
resolve vtest.math
resolve vtest.main
target linux (3 module(s))
sema vtest.util
...
```

Front-end lines (lex/parse in load order, resolve in topo order) now stream before the existing `target`/`sema`/`lower`/`codegen` lines. Without `--verbose`, output is unchanged (zero new lines).

## Testing

- Built the modified compiler (`mach build .`, clean).
- Full `mach test .` ran to completion green (exit 0); follow-up reruns were OOM-killed by the RAM-backed `/tmp` (tmpfs) the worktree lives on, not by test failures. Re-verified green via filtered batches across resolve/sema/lower/driver/lexer/parser/comptime/codegen/ir/target/string/map/manifest/intern/diagnostic (270 PASS, 0 FAIL, every batch exit 0).
- Manually confirmed the new `--verbose` lines appear and that the default build emits no new output.

Closes #1567