### PR TITLE
release: v2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.3] - 2026-06-23
+
+Front-end performance and visibility. Bumps mach-std to 0.14.1, whose
+linear-time `str_region_equals` removes the quadratic-parse stall that froze the
+front-end of stdlib-heavy builds.
+
+### Added
+
+- build: `--verbose` now streams per-module `lex`/`parse`/`resolve` lines during
+  the front-end, alongside the existing `sema`/`lower`/`codegen` stages (#1567).
+
+### Changed
+
+- resolve: hash-index the module scope for O(1) name lookups instead of a linear
+  scan (#1565).
+- driver: hoist the resolve dep-closure scratch out of the per-module loop,
+  removing O(modules²) allocation during the resolve pass (#1565).
+- deps: bump mach-std to 0.14.1 (linear `str_region_equals`).
+
 ## [2.5.2] - 2026-06-22
 
 Patch — const-string global references now fold correctly.

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/octalide/mach-std"
 ref = "branch/main"
-commit = "2e95444191a98e8dd6419faeaff1a6fc23515d3a"
+commit = "eb940a5b48020c18ac73464377d2ba5471241306"

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.5.2"
+version = "2.5.3"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -549,6 +549,11 @@ fun build_unit(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_
     s.opt_explicit = cli_set;
     s.opt_release  = cli_level == pipeline.OPT_RELEASE;
 
+    # thread the CLI `--verbose` intent into the session so the front-end load walk
+    # emits per-module `lex`/`parse`/`resolve` progress lines, matching the
+    # back-end stage lines `compile_and_link` prints from `config.verbose`.
+    s.verbose = config.verbose;
+
     val proj_r: Result[driver.Project, str] = driver.build_project_sel(?s, util.cstr_str(?root[0]), ?sel);
     if (is_err[driver.Project, str](proj_r)) {
         print.eprint("error: ");

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -52,6 +52,7 @@ use fs:   std.filesystem;
 use toml: std.data.toml;
 use map:  std.collections.map;
 use maphash: std.collections.map;
+use print: std.print;
 
 use src:    mach.lang.source;
 use diag:   mach.lang.diagnostic;
@@ -2107,6 +2108,24 @@ fun parse_define_int(s: str, start: usize, len: usize, out: *i64) bool {
     ret true;
 }
 
+# emit_stage: write a `<stage> <fqn>` front-end progress line to stderr for one
+# module, matching the back-end's `--verbose` stage lines (cmd.build.emit_stage).
+# a no-op unless the session's `verbose` flag is set; an un-interned fqn renders
+# as "<?>".
+# ---
+# p:     the project (for its session interner and verbose flag)
+# stage: a short stage label (e.g. "lex", "parse", "resolve")
+# fqn:   the module's interned fully-qualified name
+fun emit_stage(p: *Project, stage: str, fqn: intern.StrId) {
+    if (!p.s.verbose) { ret; }
+    print.eprint(stage);
+    print.eprint(" ");
+    val o: Option[str] = intern.lookup(?p.s.interner, fqn);
+    if (is_some[str](o)) { print.eprint(unwrap[str](o)); }
+    or                   { print.eprint("<?>"); }
+    print.eprint("\n");
+}
+
 fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool, str] {
     val path_r: Result[str, str] = fqn_to_file_path(p, fqn);
     if (is_err[str, str](path_r)) { ret err[bool, str](unwrap_err[str, str](path_r)); }
@@ -2129,6 +2148,7 @@ fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool
     if (is_none[*src.SourceFile](file_opt)) { ret err[bool, str]("registered FileId not found in SourceMap"); }
     val file: *src.SourceFile = unwrap[*src.SourceFile](file_opt);
 
+    emit_stage(p, "lex", fqn);
     val tok_r: Result[lexer.TokenStream, str] = lexer.tokenize(file.text, p.s.alloc, file_id);
     if (is_err[lexer.TokenStream, str](tok_r)) { ret err[bool, str](unwrap_err[lexer.TokenStream, str](tok_r)); }
     var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tok_r);
@@ -2141,6 +2161,7 @@ fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool
         lexer.dnit(?stream, p.s.alloc);
         ret err[bool, str](unwrap_err[bool, str](le_r));
     }
+    emit_stage(p, "parse", fqn);
     val fatal: bool = parser.parse(?stream, ?m.a, ?p.s.diags);
     lexer.dnit(?stream, p.s.alloc);
     # a fatal allocation failure leaves the AST incomplete; refuse to walk it
@@ -2766,6 +2787,8 @@ fun run_resolve_pass(p: *Project) Result[bool, str] {
 
 fun run_resolve_one(p: *Project, mid: sess.ModuleId, visited: *bool, list: *sess.ModuleId) Result[bool, str] {
     val m: *ModuleEntry = ?p.modules[mid::u32];
+
+    emit_stage(p, "resolve", m.fqn);
 
     val deps_r: Result[resolve.ResolveDeps, str] = build_resolve_deps(p, m, visited, list);
     if (is_err[resolve.ResolveDeps, str](deps_r)) { ret err[bool, str](unwrap_err[resolve.ResolveDeps, str](deps_r)); }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2730,20 +2730,44 @@ fun register_module_asts(p: *Project) Result[bool, str] {
 }
 
 fun run_resolve_pass(p: *Project) Result[bool, str] {
+    # dep-closure scratch reused across every module: a `visited` mark array and a
+    # worklist, both bounded by module_len. allocating them once per build (not once
+    # per module in build_resolve_deps) keeps dep-set construction O(modules) in
+    # allocation rather than O(modules^2). visited is zeroed once here and each call
+    # restores it to all-false on success, so successive calls start clean.
+    val vr: Result[*bool, str] = allocate[bool](p.s.alloc, p.module_len::usize);
+    if (is_err[*bool, str](vr)) { ret err[bool, str](unwrap_err[*bool, str](vr)); }
+    val visited: *bool = unwrap_ok[*bool, str](vr);
+    var vi: u32 = 0;
+    for (vi < p.module_len) { visited[vi] = false; vi = vi + 1; }
+
+    val lr: Result[*sess.ModuleId, str] = allocate[sess.ModuleId](p.s.alloc, p.module_len::usize);
+    if (is_err[*sess.ModuleId, str](lr)) {
+        deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+        ret err[bool, str](unwrap_err[*sess.ModuleId, str](lr));
+    }
+    val list: *sess.ModuleId = unwrap_ok[*sess.ModuleId, str](lr);
+
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: sess.ModuleId = p.topo[i];
-        val r: Result[bool, str] = run_resolve_one(p, mid);
-        if (is_err[bool, str](r)) { ret r; }
+        val r: Result[bool, str] = run_resolve_one(p, mid, visited, list);
+        if (is_err[bool, str](r)) {
+            deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
+            deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+            ret r;
+        }
         i = i + 1;
     }
+    deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
+    deallocate[bool](p.s.alloc, visited, p.module_len::usize);
     ret ok[bool, str](true);
 }
 
-fun run_resolve_one(p: *Project, mid: sess.ModuleId) Result[bool, str] {
+fun run_resolve_one(p: *Project, mid: sess.ModuleId, visited: *bool, list: *sess.ModuleId) Result[bool, str] {
     val m: *ModuleEntry = ?p.modules[mid::u32];
 
-    val deps_r: Result[resolve.ResolveDeps, str] = build_resolve_deps(p, m);
+    val deps_r: Result[resolve.ResolveDeps, str] = build_resolve_deps(p, m, visited, list);
     if (is_err[resolve.ResolveDeps, str](deps_r)) { ret err[bool, str](unwrap_err[resolve.ResolveDeps, str](deps_r)); }
     var deps: resolve.ResolveDeps = unwrap_ok[resolve.ResolveDeps, str](deps_r);
 
@@ -2762,24 +2786,17 @@ fun run_resolve_one(p: *Project, mid: sess.ModuleId) Result[bool, str] {
 # `dep.alias`), so its exports must be present in the dep set or the re-export
 # resolves to nothing downstream. all closure members are earlier in topo order
 # and thus already resolved.
-fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps, str] {
+fun build_resolve_deps(p: *Project, m: *ModuleEntry, visited: *bool, list: *sess.ModuleId) Result[resolve.ResolveDeps, str] {
     var deps: resolve.ResolveDeps;
     deps.entries = nil;
     deps.count   = 0;
     if (m.dep_count == 0) { ret ok[resolve.ResolveDeps, str](deps); }
 
-    val vr: Result[*bool, str] = allocate[bool](p.s.alloc, p.module_len::usize);
-    if (is_err[*bool, str](vr)) { ret err[resolve.ResolveDeps, str](unwrap_err[*bool, str](vr)); }
-    val visited: *bool = unwrap_ok[*bool, str](vr);
-    var vi: u32 = 0;
-    for (vi < p.module_len) { visited[vi] = false; vi = vi + 1; }
-
-    val lr: Result[*sess.ModuleId, str] = allocate[sess.ModuleId](p.s.alloc, p.module_len::usize);
-    if (is_err[*sess.ModuleId, str](lr)) {
-        deallocate[bool](p.s.alloc, visited, p.module_len::usize);
-        ret err[resolve.ResolveDeps, str](unwrap_err[*sess.ModuleId, str](lr));
-    }
-    val list: *sess.ModuleId = unwrap_ok[*sess.ModuleId, str](lr);
+    # `visited` and `list` are caller-owned scratch (run_resolve_pass), reused across
+    # modules. visited is all-false on entry; every module this call marks is mirrored
+    # in list, so the success path clears exactly those entries (the portion touched)
+    # before returning. an error aborts the whole pass, so a dirty visited never leaks
+    # to a later call. list is rebuilt from list_len = 0 each call.
     var list_len: u32 = 0;
 
     var i: u32 = 0;
@@ -2804,8 +2821,6 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
     # id — matching the load walk, where `use <id>;` resolves to this same module.
     val ar: Result[*intern.StrId, str] = allocate[intern.StrId](p.s.alloc, list_len::usize);
     if (is_err[*intern.StrId, str](ar)) {
-        deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
-        deallocate[bool](p.s.alloc, visited, p.module_len::usize);
         ret err[resolve.ResolveDeps, str](unwrap_err[*intern.StrId, str](ar));
     }
     val aliases: *intern.StrId = unwrap_ok[*intern.StrId, str](ar);
@@ -2821,8 +2836,6 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
     val r: Result[*resolve.ModuleExports, str] = allocate[resolve.ModuleExports](p.s.alloc, total::usize);
     if (is_err[*resolve.ModuleExports, str](r)) {
         deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
-        deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
-        deallocate[bool](p.s.alloc, visited, p.module_len::usize);
         ret err[resolve.ResolveDeps, str](unwrap_err[*resolve.ModuleExports, str](r));
     }
     deps.entries = unwrap_ok[*resolve.ModuleExports, str](r);
@@ -2847,8 +2860,6 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
         if (is_err[resolve.ModuleExports, str](mx_r)) {
             free_resolve_deps(p.s.alloc, ?deps);
             deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
-            deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
-            deallocate[bool](p.s.alloc, visited, p.module_len::usize);
             ret err[resolve.ResolveDeps, str](unwrap_err[resolve.ModuleExports, str](mx_r));
         }
         deps.entries[w] = unwrap_ok[resolve.ModuleExports, str](mx_r);
@@ -2858,8 +2869,6 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
             if (is_err[resolve.ModuleExports, str](ax_r)) {
                 free_resolve_deps(p.s.alloc, ?deps);
                 deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
-                deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
-                deallocate[bool](p.s.alloc, visited, p.module_len::usize);
                 ret err[resolve.ResolveDeps, str](unwrap_err[resolve.ModuleExports, str](ax_r));
             }
             var ax: resolve.ModuleExports = unwrap_ok[resolve.ModuleExports, str](ax_r);
@@ -2871,8 +2880,12 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps,
     }
 
     deallocate[intern.StrId](p.s.alloc, aliases, list_len::usize);
-    deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
-    deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+
+    # restore the caller-owned visited array to all-false for the next module: every
+    # mark set this call has a matching list entry, so clearing just those indices
+    # (not the whole module_len) leaves it clean in O(list_len).
+    var c: u32 = 0;
+    for (c < list_len) { visited[list[c]::u32] = false; c = c + 1; }
     ret ok[resolve.ResolveDeps, str](deps);
 }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -215,6 +215,15 @@ rec ResolveContext {
     # SYM_IMPORTED entries, so repeated `print.println` use-sites share one
     # Symbol instead of inflating the symbol table per reference.
     imported_cache: map.Map[u64, SymbolId];
+
+    # name -> SymbolId index for the module scope only. the module/top-level scope
+    # can hold many symbols and every chain lookup ends there, so a linear scan made
+    # name binding ~O(references * module-symbols). kept in lockstep with the module
+    # scope's entries in scope_add; lookups route through it in scope_lookup_local.
+    # block scopes stay linear (small, not worth a map). the module scope never holds
+    # duplicate names (every add is guarded by a lookup), so a single entry per name
+    # matches the first-match the scan would have returned.
+    module_index: map.Map[intern.StrId, SymbolId];
 }
 
 # number of primitive type names (u8..f64, ptr).
@@ -395,6 +404,7 @@ fun init_context(
     }
 
     rc.imported_cache = map.init[u64, SymbolId](s.alloc, map.hash_u64, map.eq_u64);
+    rc.module_index   = map.init[intern.StrId, SymbolId](s.alloc, map.hash_u32, map.eq_u32);
 
     # every allocation past this point is owned by the context; on a failure
     # dnit_context tears down whatever has been allocated so far (the array
@@ -471,6 +481,7 @@ fun dnit_context(rc: *ResolveContext) {
         deallocate[SymbolId](rc.s.alloc, rc.decl_symbol, rc.a.decl_len);
     }
     map.dnit[u64, SymbolId](?rc.imported_cache);
+    map.dnit[intern.StrId, SymbolId](?rc.module_index);
 }
 
 fun open_scope(rc: *ResolveContext, parent: ScopeId) Result[ScopeId, str] {
@@ -514,11 +525,23 @@ fun scope_add(rc: *ResolveContext, scope: ScopeId, name: intern.StrId, sym: Symb
     e.sym  = sym;
     sc.entries[sc.len] = e;
     sc.len = sc.len + 1;
+
+    # mirror module-scope adds into the name index so scope_lookup_local can answer
+    # in O(1); other scopes stay linear-only.
+    if (scope == rc.module_scope) {
+        val ins: Result[bool, str] = map.insert[intern.StrId, SymbolId](?rc.module_index, name, sym);
+        if (is_err[bool, str](ins)) { ret err[bool, str](unwrap_err[bool, str](ins)); }
+    }
     ret ok[bool, str](true);
 }
 
 fun scope_lookup_local(rc: *ResolveContext, scope: ScopeId, name: intern.StrId) SymbolId {
     if (scope == SCOPE_NIL) { ret SYMBOL_NIL; }
+    if (scope == rc.module_scope) {
+        val g: Result[*SymbolId, str] = map.get[intern.StrId, SymbolId](?rc.module_index, ?name);
+        if (is_ok[*SymbolId, str](g)) { ret @unwrap_ok[*SymbolId, str](g); }
+        ret SYMBOL_NIL;
+    }
     val sc: *Scope = ?rc.scopes[scope];
     var i: u32 = 0;
     for (i < sc.len) {

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -86,6 +86,10 @@ pub rec Session {
     # was given (it wins over the manifest), opt_release its release-vs-debug sense.
     opt_explicit:     bool;
     opt_release:      bool;
+    # the CLI `--verbose` intent, set before build_project so the front-end load
+    # walk emits a per-module `lex`/`parse`/`resolve` progress line to stderr,
+    # matching the back-end's `--verbose` stage lines. off leaves the load silent.
+    verbose:          bool;
 }
 
 # init: construct an empty Session backed by the given allocator. sub-services
@@ -121,6 +125,7 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
     s.registry         = target.registry_init();
     s.opt_explicit     = false;
     s.opt_release      = false;
+    s.verbose          = false;
 
     val r_types: Result[ty.TypeInterner, str] = ty.init(alloc);
     if (is_err[ty.TypeInterner, str](r_types)) {


### PR DESCRIPTION
Patch release. --verbose front-end stages (#1567), resolve/driver perf (#1565), and mach-std bumped to 0.14.1 (linear str_region_equals — removes the quadratic-parse front-end stall).