### PR TITLE
release: v2.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.4] - 2026-06-23
+
+First-class documentation. Doc-comment blocks are now captured on declarations
+and validated by a docstring lint, laying the groundwork for editor hover and
+`mach doc` to share one source of truth.
+
+### Added
+
+- fe: capture each declaration's doc-comment block as a span on `Decl`
+  (attribute-aware — `#[...]` lines between the docstring and the decl are
+  skipped), plus `fe/doc.mach`, an allocation-free doc-block parser exposing the
+  summary and component lines with their name/description spans.
+- fe: a `pub`-scoped docstring lint (`fe/doclint.mach`) that warns when a
+  documented component names no real parameter/field/generic/`ret`
+  (misspelled), is out of declaration order (judged over the documented subset,
+  so partial docs are fine), or has an empty description. It does NOT require
+  completeness — undocumented items are never flagged.
+
+### Fixed
+
+- fe: the doc-block parser no longer mistakes a wrapped prose continuation line
+  beginning `word:` for a component head (continuation lines are indented past
+  the `# name` column).
+
 ## [2.5.3] - 2026-06-23
 
 Front-end performance and visibility. Bumps mach-std to 0.14.1, whose

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.5.3"
+version = "2.5.4"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/lang/fe/ast/decl.mach
+++ b/src/lang/fe/ast/decl.mach
@@ -183,6 +183,9 @@ pub rec Decorator {
 # span:            byte range of the declaration in source
 # kind:            which DECL_KIND_* variant is active
 # flags:           bitfield of DECL_FLAG_* values (pub, ext)
+# doc:             byte range of the doc-comment block directly above the decl
+#                  (`#[...]` attribute lines skipped), or an empty span (len 0)
+#                  when the decl carries no docstring
 # decorators_start: start index into ast.decorators of this decl's leading decorators
 # decorators_len:  number of leading decorators, backtick or `#[...]` (0 if none)
 # data:            kind-specific payload; unused for ERROR (discriminated by kind alone)
@@ -190,6 +193,7 @@ pub rec Decl {
     span:  token.Span;
     kind:  DeclKind;
     flags: u8;
+    doc:   token.Span;
     decorators_start: u32;
     decorators_len:   u32;
     data: uni {

--- a/src/lang/fe/doc.mach
+++ b/src/lang/fe/doc.mach
@@ -1,0 +1,302 @@
+# mach.lang.fe.doc: structured read of a captured doc-comment block.
+#
+# a doc block is the `#`-comment run the parser attaches to a Decl (see
+# documentation.md): a free-prose summary, an optional `# ---` separator, then
+# `# <component>: <description>` lines — one per documentable item. this module
+# turns a doc span plus its source text into structured spans the docstring lint
+# and (later) hover / rename build on. it allocates nothing: every result is a
+# byte span back into the source.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+
+use strutil: std.types.string;
+
+use token: mach.lang.fe.token;
+
+# DocComponent: one parsed `# <name>: <description>` component line.
+# ---
+# name_span: byte span of just the `<name>` token (trimmed), for rename
+# desc_span: byte span of the description (trimmed), or an empty span when absent
+pub rec DocComponent {
+    name_span: token.Span;
+    desc_span: token.Span;
+}
+
+# DocComponentIter: a forward cursor over a doc block's component lines.
+# ---
+# source: the source text the doc span points into
+# off:    byte offset of the next unscanned position within the doc block
+# end:    byte offset just past the doc block
+pub rec DocComponentIter {
+    source: str;
+    off:    usize;
+    end:    usize;
+}
+
+# empty_span: a zero-length span, the canonical "absent" marker.
+fun empty_span() token.Span {
+    var s: token.Span;
+    s.offset = 0;
+    s.len    = 0;
+    ret s;
+}
+
+# is_doc_blank: true when byte `c` is in-line whitespace (space or tab).
+fun is_space(c: u8) bool {
+    ret c == ' ' || c == '\t';
+}
+
+# line_end: byte offset of the newline ending the line that starts at `off`, or
+# `end` when the line runs to the block's end with no newline.
+fun line_end(source: str, off: usize, end: usize) usize {
+    var i: usize = off;
+    for (i < end && source[i] != '\n') { i = i + 1; }
+    ret i;
+}
+
+# strip_hash: advance past a leading `#` and any in-line whitespace on a comment
+# line that starts at `off`, returning the offset of the first content byte. the
+# doc run guarantees each line begins with `#`, but a defensive check leaves a
+# `#`-less line untouched rather than skipping a content byte.
+fun strip_hash(source: str, off: usize, end: usize) usize {
+    var i: usize = off;
+    if (i < end && source[i] == '#') { i = i + 1; }
+    for (i < end && is_space(source[i])) { i = i + 1; }
+    ret i;
+}
+
+# trim_trailing: pull `hi` back past trailing in-line whitespace down to `lo`.
+fun trim_trailing(source: str, lo: usize, hi: usize) usize {
+    var i: usize = hi;
+    for (i > lo && is_space(source[i - 1])) { i = i - 1; }
+    ret i;
+}
+
+# is_separator_line: true when the comment line whose content (after `#` and
+# whitespace) starts at `content` and ends at `content_end` is exactly `---` —
+# the separator that introduces the component block.
+fun is_separator_line(source: str, content: usize, content_end: usize) bool {
+    val hi: usize = trim_trailing(source, content, content_end);
+    if (hi - content != 3) { ret false; }
+    ret source[content] == '-' && source[content + 1] == '-' && source[content + 2] == '-';
+}
+
+# separator_offset: byte offset of the `#` opening the `# ---` separator line
+# within the doc block, or `doc.offset + doc.len` (the block end) when the block
+# has no separator. drives both summary_span and the component iterator.
+fun separator_offset(source: str, doc: token.Span) usize {
+    val end: usize = doc.offset + doc.len;
+    var off: usize = doc.offset;
+    for (off < end) {
+        val le: usize = line_end(source, off, end);
+        val content: usize = strip_hash(source, off, le);
+        if (is_separator_line(source, content, le)) { ret off; }
+        off = le;
+        if (off < end && source[off] == '\n') { off = off + 1; }
+    }
+    ret end;
+}
+
+# has_component_block: true when the doc block carries a `# ---` separator, i.e.
+# it has a component block rather than being summary-only. the docstring lint
+# only validates decls whose docstring has a component block.
+# ---
+# source: the source text the doc span points into
+# doc:    the doc-block span (empty when the decl has no docstring)
+# ret:    true when a `# ---` separator line is present
+pub fun has_component_block(source: str, doc: token.Span) bool {
+    if (doc.len == 0) { ret false; }
+    ret separator_offset(source, doc) != doc.offset + doc.len;
+}
+
+# summary_span: the byte span of the summary — every line before the `# ---`
+# separator, or the whole block when summary-only — trimmed of the leading `#`
+# of the first line and trailing whitespace/newlines. an empty span when the doc
+# block is empty or has no summary text.
+# ---
+# source: the source text the doc span points into
+# doc:    the doc-block span
+# ret:    the summary span, or an empty span when absent
+pub fun summary_span(source: str, doc: token.Span) token.Span {
+    if (doc.len == 0) { ret empty_span(); }
+
+    val sep: usize = separator_offset(source, doc);
+    # the summary's content starts after the first line's `#` and whitespace.
+    val lo: usize = strip_hash(source, doc.offset, sep);
+    var hi: usize = sep;
+    # drop a trailing newline and trailing in-line whitespace.
+    for (hi > lo && (source[hi - 1] == '\n' || source[hi - 1] == '\r')) { hi = hi - 1; }
+    hi = trim_trailing(source, lo, hi);
+
+    if (hi <= lo) { ret empty_span(); }
+    var s: token.Span;
+    s.offset = lo;
+    s.len    = hi - lo;
+    ret s;
+}
+
+# component_iter: a cursor positioned at the first component line (the line after
+# the `# ---` separator). when the block has no separator the cursor is empty and
+# `component_next` immediately reports done.
+# ---
+# source: the source text the doc span points into
+# doc:    the doc-block span
+# ret:    a fresh iterator over the block's component lines
+pub fun component_iter(source: str, doc: token.Span) DocComponentIter {
+    var it: DocComponentIter;
+    it.source = source;
+    it.end    = doc.offset + doc.len;
+
+    if (doc.len == 0) {
+        it.off = it.end;
+        ret it;
+    }
+
+    val sep: usize = separator_offset(source, doc);
+    if (sep == it.end) {
+        it.off = it.end;
+        ret it;
+    }
+    # skip the separator line itself.
+    var off: usize = line_end(source, sep, it.end);
+    if (off < it.end && source[off] == '\n') { off = off + 1; }
+    it.off = off;
+    ret it;
+}
+
+# component_next: advance the iterator to the next `# <name>: <desc>` line,
+# writing the parsed component through `out` and returning true; returns false
+# when the block is exhausted. a line with no `:` is treated as a component whose
+# name is the whole content and whose description is empty, so the lint still
+# sees (and can flag) a malformed component line.
+# ---
+# it:  the iterator to advance
+# out: receives the parsed component on a true return
+# ret: true when a component was produced, false at end of block
+pub fun component_next(it: *DocComponentIter, out: *DocComponent) bool {
+    for (it.off < it.end) {
+        val le: usize = line_end(it.source, it.off, it.end);
+        val content: usize = strip_hash(it.source, it.off, le);
+
+        # a blank `#` line inside the block separates paragraphs; skip it.
+        if (content >= le) {
+            it.off = le;
+            if (it.off < it.end && it.source[it.off] == '\n') { it.off = it.off + 1; }
+            cnt;
+        }
+
+        # the name runs to the first `:`; the description is the rest, trimmed.
+        var colon: usize = content;
+        for (colon < le && it.source[colon] != ':') { colon = colon + 1; }
+
+        val name_hi: usize = trim_trailing(it.source, content, colon);
+        var name: token.Span;
+        name.offset = content;
+        name.len    = name_hi - content;
+
+        var desc: token.Span = empty_span();
+        if (colon < le) {
+            var desc_lo: usize = colon + 1;
+            for (desc_lo < le && is_space(it.source[desc_lo])) { desc_lo = desc_lo + 1; }
+            val desc_hi: usize = trim_trailing(it.source, desc_lo, le);
+            if (desc_hi > desc_lo) {
+                desc.offset = desc_lo;
+                desc.len    = desc_hi - desc_lo;
+            }
+        }
+
+        out.name_span = name;
+        out.desc_span = desc;
+
+        it.off = le;
+        if (it.off < it.end && it.source[it.off] == '\n') { it.off = it.off + 1; }
+        ret true;
+    }
+    ret false;
+}
+
+# t_span: build a span covering the whole of `s` (offset 0), for the tests.
+fun t_span(s: str) token.Span {
+    var sp: token.Span;
+    sp.offset = 0;
+    sp.len    = strutil.str_len(s);
+    ret sp;
+}
+
+# t_eq: true when `span` equals the byte content of `expect` within `source`.
+fun t_eq(source: str, span: token.Span, expect: str) bool {
+    ret strutil.str_region_equals(source, span.offset, span.len, expect);
+}
+
+test "doc: summary-only block has no component block and a trimmed summary" {
+    val src: str = "# yield the CPU to other threads";
+    val doc: token.Span = t_span(src);
+
+    if (has_component_block(src, doc))       { ret 1; }
+    if (!t_eq(src, summary_span(src, doc), "yield the CPU to other threads")) { ret 1; }
+
+    var it: DocComponentIter = component_iter(src, doc);
+    var c: DocComponent;
+    if (component_next(?it, ?c)) { ret 1; }
+    ret 0;
+}
+
+test "doc: a `# ---` block splits summary from ordered components" {
+    val src: str = "# read the wall-clock time\n# ---\n# out: pointer to populate\n# ret: 0 on success";
+    val doc: token.Span = t_span(src);
+
+    if (!has_component_block(src, doc)) { ret 1; }
+    if (!t_eq(src, summary_span(src, doc), "read the wall-clock time")) { ret 1; }
+
+    var it: DocComponentIter = component_iter(src, doc);
+    var c: DocComponent;
+
+    if (!component_next(?it, ?c))           { ret 1; }
+    if (!t_eq(src, c.name_span, "out"))     { ret 1; }
+    if (!t_eq(src, c.desc_span, "pointer to populate")) { ret 1; }
+
+    if (!component_next(?it, ?c))           { ret 1; }
+    if (!t_eq(src, c.name_span, "ret"))     { ret 1; }
+    if (!t_eq(src, c.desc_span, "0 on success")) { ret 1; }
+
+    if (component_next(?it, ?c)) { ret 1; }
+    ret 0;
+}
+
+test "doc: component names keep their syntactic form ([T], $order) and aligned colons trim" {
+    val src: str = "# atomic load\n# ---\n# [T]:    element type\n# $order: memory ordering\n# ptr:    pointer to load from";
+    val doc: token.Span = t_span(src);
+
+    var it: DocComponentIter = component_iter(src, doc);
+    var c: DocComponent;
+
+    if (!component_next(?it, ?c))            { ret 1; }
+    if (!t_eq(src, c.name_span, "[T]"))      { ret 1; }
+    if (!t_eq(src, c.desc_span, "element type")) { ret 1; }
+
+    if (!component_next(?it, ?c))            { ret 1; }
+    if (!t_eq(src, c.name_span, "$order"))   { ret 1; }
+
+    if (!component_next(?it, ?c))            { ret 1; }
+    if (!t_eq(src, c.name_span, "ptr"))      { ret 1; }
+    ret 0;
+}
+
+test "doc: an empty doc span has no summary, no component block, no components" {
+    val src: str = "";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 0;
+
+    if (has_component_block(src, doc))   { ret 1; }
+    if (summary_span(src, doc).len != 0) { ret 1; }
+
+    var it: DocComponentIter = component_iter(src, doc);
+    var c: DocComponent;
+    if (component_next(?it, ?c)) { ret 1; }
+    ret 0;
+}

--- a/src/lang/fe/doc.mach
+++ b/src/lang/fe/doc.mach
@@ -196,7 +196,7 @@ pub fun component_next(it: *DocComponentIter, out: *DocComponent) bool {
         val content: usize = strip_hash(it.source, it.off, le);
 
         var name_span: token.Span = empty_span();
-        val starts:    bool = component_head(it.source, content, le, ?name_span);
+        val starts:    bool = component_head(it.source, it.off, content, le, ?name_span);
 
         if (starts) {
             # a second component head ends the current one: rewind so the next
@@ -228,12 +228,21 @@ pub fun component_next(it: *DocComponentIter, out: *DocComponent) bool {
     ret false;
 }
 
-# component_head: true when the line content in `[content, le)` begins a
-# component — its pre-colon text is a single non-empty whitespace-free token —
-# writing that token's span through `name_out`. a blank line, a colon-less line,
-# or a multi-word pre-colon line is not a head.
-fun component_head(source: str, content: usize, le: usize, name_out: *token.Span) bool {
+# component_head: true when the line beginning at `off` (its content, past the
+# `#` and whitespace, at `content`) begins a component — writing that name token's
+# span through `name_out`. a component head must be at the base indentation (`#`
+# then at most one space) with a single non-empty whitespace-free token before a
+# `:`. a deeper indentation marks a wrapped continuation line, so a prose line
+# that happens to start `word:` under a component is NOT treated as a new
+# component. a blank, colon-less, or multi-word line is also not a head.
+fun component_head(source: str, off: usize, content: usize, le: usize, name_out: *token.Span) bool {
     if (content >= le) { ret false; }
+
+    # the name must sit at the base indent: `#` plus at most one space. anything
+    # more deeply indented is a continuation aligned under a description.
+    var hash: usize = off;
+    if (hash < le && source[hash] == '#') { hash = hash + 1; }
+    if (content > hash + 1) { ret false; }
 
     var colon: usize = content;
     for (colon < le && source[colon] != ':') { colon = colon + 1; }
@@ -350,6 +359,26 @@ test "doc: a wrapped, colon-less continuation line extends the prior component" 
 
     if (!component_next(?it, ?c))       { ret 1; }
     if (!t_eq(src, c.name_span, "b"))   { ret 1; }
+
+    if (component_next(?it, ?c)) { ret 1; }
+    ret 0;
+}
+
+test "doc: a deeply-indented `word:` wrapped line is a continuation, not a new component" {
+    # `a`'s description wraps onto an indented line that itself starts `facts:`.
+    # the deep indent (more than one space after `#`) marks it a continuation, so
+    # only `a` and `b` are real components — `facts` is not mistaken for one.
+    val src: str = "# wrapped\n# ---\n# a: leading text\n#       facts: still part of a\n# b: short";
+    val doc: token.Span = t_span(src);
+
+    var it: DocComponentIter = component_iter(src, doc);
+    var c: DocComponent;
+
+    if (!component_next(?it, ?c))     { ret 1; }
+    if (!t_eq(src, c.name_span, "a")) { ret 1; }
+
+    if (!component_next(?it, ?c))     { ret 1; }
+    if (!t_eq(src, c.name_span, "b")) { ret 1; }
 
     if (component_next(?it, ?c)) { ret 1; }
     ret 0;

--- a/src/lang/fe/doc.mach
+++ b/src/lang/fe/doc.mach
@@ -177,46 +177,94 @@ pub fun component_iter(source: str, doc: token.Span) DocComponentIter {
 # it:  the iterator to advance
 # out: receives the parsed component on a true return
 # ret: true when a component was produced, false at end of block
+#
+# a component line is `# <name>: <description>` where `<name>` is a single
+# whitespace-free token (a parameter/field name, `[T]`, `$name`, or `ret`). a
+# `#` line that does not fit that shape — a blank line, a colon-less prose line,
+# or a multi-word line — is a continuation of the preceding component's
+# description; its bytes extend that component's desc_span and it never starts a
+# new component. this matches the wrapped, aligned descriptions in the existing
+# corpus.
 pub fun component_next(it: *DocComponentIter, out: *DocComponent) bool {
+    var have:        bool = false;
+    var name:        token.Span = empty_span();
+    var desc_lo:     usize = 0;
+    var desc_hi:     usize = 0;
+
     for (it.off < it.end) {
-        val le: usize = line_end(it.source, it.off, it.end);
+        val le:      usize = line_end(it.source, it.off, it.end);
         val content: usize = strip_hash(it.source, it.off, le);
 
-        # a blank `#` line inside the block separates paragraphs; skip it.
-        if (content >= le) {
-            it.off = le;
-            if (it.off < it.end && it.source[it.off] == '\n') { it.off = it.off + 1; }
-            cnt;
+        var name_span: token.Span = empty_span();
+        val starts:    bool = component_head(it.source, content, le, ?name_span);
+
+        if (starts) {
+            # a second component head ends the current one: rewind so the next
+            # call begins here, and return what we have gathered.
+            if (have) { ret emit_component(out, name, desc_lo, desc_hi); }
+
+            have = true;
+            name = name_span;
+
+            var colon: usize = content;
+            for (colon < le && it.source[colon] != ':') { colon = colon + 1; }
+            var lo: usize = colon + 1;
+            for (lo < le && is_space(it.source[lo])) { lo = lo + 1; }
+            desc_lo = lo;
+            desc_hi = trim_trailing(it.source, lo, le);
         }
-
-        # the name runs to the first `:`; the description is the rest, trimmed.
-        var colon: usize = content;
-        for (colon < le && it.source[colon] != ':') { colon = colon + 1; }
-
-        val name_hi: usize = trim_trailing(it.source, content, colon);
-        var name: token.Span;
-        name.offset = content;
-        name.len    = name_hi - content;
-
-        var desc: token.Span = empty_span();
-        if (colon < le) {
-            var desc_lo: usize = colon + 1;
-            for (desc_lo < le && is_space(it.source[desc_lo])) { desc_lo = desc_lo + 1; }
-            val desc_hi: usize = trim_trailing(it.source, desc_lo, le);
-            if (desc_hi > desc_lo) {
-                desc.offset = desc_lo;
-                desc.len    = desc_hi - desc_lo;
-            }
+        or (have) {
+            # a continuation line: extend the description to cover it, ignoring a
+            # blank `#` line (which leaves desc_hi unchanged).
+            val hi: usize = trim_trailing(it.source, content, le);
+            if (hi > content) { desc_hi = hi; }
         }
-
-        out.name_span = name;
-        out.desc_span = desc;
 
         it.off = le;
         if (it.off < it.end && it.source[it.off] == '\n') { it.off = it.off + 1; }
-        ret true;
     }
+
+    if (have) { ret emit_component(out, name, desc_lo, desc_hi); }
     ret false;
+}
+
+# component_head: true when the line content in `[content, le)` begins a
+# component — its pre-colon text is a single non-empty whitespace-free token —
+# writing that token's span through `name_out`. a blank line, a colon-less line,
+# or a multi-word pre-colon line is not a head.
+fun component_head(source: str, content: usize, le: usize, name_out: *token.Span) bool {
+    if (content >= le) { ret false; }
+
+    var colon: usize = content;
+    for (colon < le && source[colon] != ':') { colon = colon + 1; }
+    if (colon >= le) { ret false; }
+
+    val name_hi: usize = trim_trailing(source, content, colon);
+    if (name_hi <= content) { ret false; }
+
+    # the name token must be a single word: no interior whitespace.
+    var i: usize = content;
+    for (i < name_hi) {
+        if (is_space(source[i])) { ret false; }
+        i = i + 1;
+    }
+
+    name_out.offset = content;
+    name_out.len    = name_hi - content;
+    ret true;
+}
+
+# emit_component: write a finished component (name span and description range)
+# through `out` and report success, the shared tail of component_next.
+fun emit_component(out: *DocComponent, name: token.Span, desc_lo: usize, desc_hi: usize) bool {
+    out.name_span = name;
+    if (desc_hi > desc_lo) {
+        out.desc_span.offset = desc_lo;
+        out.desc_span.len    = desc_hi - desc_lo;
+    } or {
+        out.desc_span = empty_span();
+    }
+    ret true;
 }
 
 # t_span: build a span covering the whole of `s` (offset 0), for the tests.
@@ -283,6 +331,27 @@ test "doc: component names keep their syntactic form ([T], $order) and aligned c
 
     if (!component_next(?it, ?c))            { ret 1; }
     if (!t_eq(src, c.name_span, "ptr"))      { ret 1; }
+    ret 0;
+}
+
+test "doc: a wrapped, colon-less continuation line extends the prior component" {
+    # the second `#` line under `a:` has no `name:` head, so it is a continuation
+    # of `a`'s description, not a new component. only two components are produced.
+    val src: str = "# wrapped\n# ---\n# a: a long description that\n#    wraps onto a second line\n# b: short";
+    val doc: token.Span = t_span(src);
+
+    var it: DocComponentIter = component_iter(src, doc);
+    var c: DocComponent;
+
+    if (!component_next(?it, ?c))       { ret 1; }
+    if (!t_eq(src, c.name_span, "a"))   { ret 1; }
+    # the description span reaches the end of the continuation line.
+    if (!t_eq(src, c.desc_span, "a long description that\n#    wraps onto a second line")) { ret 1; }
+
+    if (!component_next(?it, ?c))       { ret 1; }
+    if (!t_eq(src, c.name_span, "b"))   { ret 1; }
+
+    if (component_next(?it, ?c)) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/fe/doclint.mach
+++ b/src/lang/fe/doclint.mach
@@ -1,0 +1,309 @@
+# mach.lang.fe.doclint: the docstring component lint.
+#
+# a post-parse pass over a module AST that validates `# <component>:` lines in a
+# declaration's docstring against the declaration's documentable items. it fires
+# only for `pub` declarations whose docstring carries a `# ---` component block;
+# a non-`pub` decl, a decl with no docstring, and a summary-only docstring are
+# all silent. a docstring is never required. validated kinds are `fun`, `rec`,
+# and `uni` — the declaration forms that expose documentable items.
+#
+# the lint emits WARNINGs to the session diagnostic list (source `mach`) and runs
+# from the parser's public entry, so both the build/check path and the editor
+# parse path surface it.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.result.Result;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+
+use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.deallocate;
+
+use token: mach.lang.fe.token;
+use ast:   mach.lang.fe.ast;
+use id:    mach.lang.fe.ast.id;
+use decl:  mach.lang.fe.ast.decl;
+use doc:   mach.lang.fe.doc;
+use diag:  mach.lang.diagnostic;
+use src:   mach.lang.source;
+
+# ItemKind: how a documentable item's component name is spelled.
+def ItemKind: u8;
+# ITEM_GENERIC: a generic type parameter, written `[T]`.
+val ITEM_GENERIC: ItemKind = 0;
+# ITEM_COMPTIME: a comptime value parameter, written `$name`.
+val ITEM_COMPTIME: ItemKind = 1;
+# ITEM_PLAIN: a value parameter or field, written by its bare name.
+val ITEM_PLAIN: ItemKind = 2;
+# ITEM_RET: a function return value, written `ret`.
+val ITEM_RET: ItemKind = 3;
+
+# Item: one documentable item of a declaration in declaration order.
+# ---
+# kind:     how the component name is spelled
+# name_off: byte offset of the item's base identifier in source (unused for ret)
+# name_len: byte length of the base identifier (unused for ret)
+rec Item {
+    kind:     ItemKind;
+    name_off: usize;
+    name_len: usize;
+}
+
+# lint_module: validate every documentable `pub` declaration in `a` and append a
+# WARNING to `diags` for each mismatch. a no-op for decls that are non-`pub`, have
+# no docstring, or carry a summary-only docstring. walks the flat decl pool, so
+# module-scope, comptime-branch, and (never-`pub`) local decls are all covered.
+# ---
+# a:      the parsed module AST
+# source: the module's source text (the doc spans point into it)
+# diags:  diagnostic sink the warnings are appended to
+pub fun lint_module(a: *ast.Ast, source: str, diags: *diag.DiagList) {
+    var i: usize = 0;
+    for (i < a.decl_len) {
+        lint_decl(a, ?a.decls[i], source, diags);
+        i = i + 1;
+    }
+}
+
+# lint_decl: run the component lint for one declaration when it is in scope —
+# `pub`, documentable (fun/rec/uni), and carrying a `# ---` component block.
+fun lint_decl(a: *ast.Ast, d: *decl.Decl, source: str, diags: *diag.DiagList) {
+    if ((d.flags & decl.DECL_FLAG_PUB) == 0) { ret; }
+    if (d.doc.len == 0) { ret; }
+    if (!is_documentable(d.kind)) { ret; }
+    if (!doc.has_component_block(source, d.doc)) { ret; }
+    check_components(a, d, source, diags);
+}
+
+# is_documentable: true for the declaration kinds that expose documentable items
+# (functions, records, unions) — the kinds whose docstrings carry component lines.
+fun is_documentable(kind: decl.DeclKind) bool {
+    ret kind == decl.DECL_KIND_FUN
+     || kind == decl.DECL_KIND_REC
+     || kind == decl.DECL_KIND_UNI;
+}
+
+# item_count: the number of documentable items a declaration exposes: generics
+# plus parameters/fields, plus one for a function's non-nil return.
+fun item_count(d: *decl.Decl) usize {
+    if (d.kind == decl.DECL_KIND_FUN) {
+        val f: *decl.DeclFun = ?d.data.fun_;
+        var n: usize = f.generics_len::usize + f.params_len::usize;
+        if (f.return_type != id.TYPE_NIL) { n = n + 1; }
+        ret n;
+    }
+    if (d.kind == decl.DECL_KIND_REC) {
+        val r: *decl.DeclRec = ?d.data.rec_;
+        ret r.generics_len::usize + r.fields_len::usize;
+    }
+    if (d.kind == decl.DECL_KIND_UNI) {
+        val u: *decl.DeclUni = ?d.data.uni_;
+        ret u.generics_len::usize + u.fields_len::usize;
+    }
+    ret 0;
+}
+
+# check_components: the lint body for a decl already known to be in scope. builds
+# the declaration's ordered item list, then walks the docstring's component lines
+# once for unknown / out-of-order findings and the item list once for missing
+# findings. a buffer allocation failure drops the lint silently — a missing
+# warning never aborts the parse.
+fun check_components(a: *ast.Ast, d: *decl.Decl, source: str, diags: *diag.DiagList) {
+    val count: usize = item_count(d);
+
+    var items: *Item = nil;
+    if (count > 0) {
+        val r: Result[*Item, str] = allocate[Item](a.alloc, count);
+        if (is_err[*Item, str](r)) { ret; }
+        items = unwrap_ok[*Item, str](r);
+        fill_items(a, d, items);
+    }
+
+    var it:   doc.DocComponentIter = doc.component_iter(source, d.doc);
+    var c:    doc.DocComponent;
+    var prev: usize = 0;
+    var have_prev: bool = false;
+
+    for (doc.component_next(?it, ?c)) {
+        val idx: usize = match_item(source, items, count, c.name_span);
+        if (idx == count) {
+            warn(diags, a.file_id, c.name_span, "documented component matches no parameter, field, generic, or `ret` of this declaration");
+            cnt;
+        }
+        if (have_prev && idx < prev) {
+            warn(diags, a.file_id, c.name_span, "documented components are out of declaration order");
+        }
+        prev = idx;
+        have_prev = true;
+    }
+
+    # missing: any item never named by a component line.
+    var k: usize = 0;
+    for (k < count) {
+        if (!item_documented(source, d.doc, ?items[k])) {
+            warn(diags, a.file_id, decl_name_span(d), "declaration item is missing a documented component");
+        }
+        k = k + 1;
+    }
+
+    if (items != nil) {
+        deallocate[Item](a.alloc, items, count);
+    }
+}
+
+# fill_items: write the declaration's documentable items into `out` (sized to
+# item_count) in declaration order: for a function its generics, then value
+# parameters, then `ret` when the return type is non-nil; for a rec/uni its
+# generics, then fields.
+fun fill_items(a: *ast.Ast, d: *decl.Decl, out: *Item) {
+    var n: usize = 0;
+
+    if (d.kind == decl.DECL_KIND_FUN) {
+        val f: *decl.DeclFun = ?d.data.fun_;
+        n = put_generics(a, f.generics_start, f.generics_len, out, n);
+        n = put_typed_names(a, f.params_start, f.params_len, out, n);
+        if (f.return_type != id.TYPE_NIL) {
+            out[n].kind     = ITEM_RET;
+            out[n].name_off = 0;
+            out[n].name_len = 0;
+            n = n + 1;
+        }
+        ret;
+    }
+    if (d.kind == decl.DECL_KIND_REC) {
+        val r: *decl.DeclRec = ?d.data.rec_;
+        n = put_generics(a, r.generics_start, r.generics_len, out, n);
+        n = put_typed_names(a, r.fields_start, r.fields_len, out, n);
+        ret;
+    }
+    if (d.kind == decl.DECL_KIND_UNI) {
+        val u: *decl.DeclUni = ?d.data.uni_;
+        n = put_generics(a, u.generics_start, u.generics_len, out, n);
+        n = put_typed_names(a, u.fields_start, u.fields_len, out, n);
+        ret;
+    }
+}
+
+# put_generics: write the generics in `[start, start+len)` as ITEM_GENERIC
+# entries beginning at `n`, returning the new count.
+fun put_generics(a: *ast.Ast, start: u32, len: u32, out: *Item, n: usize) usize {
+    var i: u32 = 0;
+    var cur: usize = n;
+    for (i < len) {
+        val sp: token.Span = a.generic_names[start + i];
+        out[cur].kind     = ITEM_GENERIC;
+        out[cur].name_off = sp.offset;
+        out[cur].name_len = sp.len;
+        cur = cur + 1;
+        i = i + 1;
+    }
+    ret cur;
+}
+
+# put_typed_names: write the parameters/fields in `[start, start+len)` as
+# ITEM_COMPTIME (a `$name` comptime parameter) or ITEM_PLAIN entries beginning at
+# `n`, returning the new count.
+fun put_typed_names(a: *ast.Ast, start: u32, len: u32, out: *Item, n: usize) usize {
+    var i: u32 = 0;
+    var cur: usize = n;
+    for (i < len) {
+        val tn: *decl.TypedName = ?a.typed_names[start + i];
+        if (tn.comptime) { out[cur].kind = ITEM_COMPTIME; } or { out[cur].kind = ITEM_PLAIN; }
+        out[cur].name_off = tn.name.offset;
+        out[cur].name_len = tn.name.len;
+        cur = cur + 1;
+        i = i + 1;
+    }
+    ret cur;
+}
+
+# match_item: the index of the item whose component spelling equals the byte
+# content of `name` within `source`, or `count` when none matches.
+fun match_item(source: str, items: *Item, count: usize, name: token.Span) usize {
+    var i: usize = 0;
+    for (i < count) {
+        if (item_name_eq(source, ?items[i], name)) { ret i; }
+        i = i + 1;
+    }
+    ret count;
+}
+
+# item_name_eq: true when the component span `name` spells item `it` — `[T]` for a
+# generic, `$x` for a comptime parameter, `ret` for the return value, the bare
+# identifier otherwise.
+fun item_name_eq(source: str, it: *Item, name: token.Span) bool {
+    if (it.kind == ITEM_RET) {
+        ret span_eq_str(source, name, "ret");
+    }
+    if (it.kind == ITEM_GENERIC) {
+        # `[` + base + `]`
+        if (name.len != it.name_len + 2) { ret false; }
+        if (source[name.offset] != '[') { ret false; }
+        if (source[name.offset + name.len - 1] != ']') { ret false; }
+        ret bytes_eq(source, name.offset + 1, it.name_off, it.name_len);
+    }
+    if (it.kind == ITEM_COMPTIME) {
+        # `$` + base
+        if (name.len != it.name_len + 1) { ret false; }
+        if (source[name.offset] != '$') { ret false; }
+        ret bytes_eq(source, name.offset + 1, it.name_off, it.name_len);
+    }
+    # plain
+    if (name.len != it.name_len) { ret false; }
+    ret bytes_eq(source, name.offset, it.name_off, it.name_len);
+}
+
+# item_documented: true when some component line in doc block `doc_span` spells
+# item `it`. used for the missing-component pass.
+fun item_documented(source: str, doc_span: token.Span, it: *Item) bool {
+    var iter: doc.DocComponentIter = doc.component_iter(source, doc_span);
+    var c: doc.DocComponent;
+    for (doc.component_next(?iter, ?c)) {
+        if (item_name_eq(source, it, c.name_span)) { ret true; }
+    }
+    ret false;
+}
+
+# bytes_eq: true when the `len` bytes at `a_off` equal the `len` bytes at `b_off`
+# within `source`.
+fun bytes_eq(source: str, a_off: usize, b_off: usize, len: usize) bool {
+    var i: usize = 0;
+    for (i < len) {
+        if (source[a_off + i] != source[b_off + i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# span_eq_str: true when `span`'s bytes equal the null-terminated string `s`.
+fun span_eq_str(source: str, span: token.Span, s: str) bool {
+    var i: usize = 0;
+    for (i < span.len) {
+        if (s[i] == 0)                       { ret false; }
+        if (source[span.offset + i] != s[i]) { ret false; }
+        i = i + 1;
+    }
+    ret s[span.len] == 0;
+}
+
+# decl_name_span: the span of a declaration's identifier, used to anchor a
+# missing-component warning. falls back to the decl's full span for kinds without
+# a single name (never reached for the documentable kinds).
+fun decl_name_span(d: *decl.Decl) token.Span {
+    if (d.kind == decl.DECL_KIND_FUN) { ret (?d.data.fun_).name; }
+    if (d.kind == decl.DECL_KIND_REC) { ret (?d.data.rec_).name; }
+    if (d.kind == decl.DECL_KIND_UNI) { ret (?d.data.uni_).name; }
+    ret d.span;
+}
+
+# warn: append a docstring warning to the sink, swallowing an allocation failure
+# (a dropped lint warning never aborts a parse).
+fun warn(diags: *diag.DiagList, file_id: src.FileId, span: token.Span, message: str) {
+    val r: Result[bool, str] = diag.warning(diags, file_id, span, message);
+    if (is_err[bool, str](r)) { ret; }
+}

--- a/src/lang/fe/doclint.mach
+++ b/src/lang/fe/doclint.mach
@@ -24,13 +24,19 @@ use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 
-use token: mach.lang.fe.token;
-use ast:   mach.lang.fe.ast;
-use id:    mach.lang.fe.ast.id;
-use decl:  mach.lang.fe.ast.decl;
-use doc:   mach.lang.fe.doc;
-use diag:  mach.lang.diagnostic;
-use src:   mach.lang.source;
+use page:     std.allocator.page;
+use strutil:  std.types.string;
+
+use token:  mach.lang.fe.token;
+use ast:    mach.lang.fe.ast;
+use id:     mach.lang.fe.ast.id;
+use decl:   mach.lang.fe.ast.decl;
+use doc:    mach.lang.fe.doc;
+use diag:   mach.lang.diagnostic;
+use src:    mach.lang.source;
+use lexer:  mach.lang.fe.lexer;
+use parser: mach.lang.fe.parser.state;
+use pdecl:  mach.lang.fe.parser.decl;
 
 # ItemKind: how a documentable item's component name is spelled.
 def ItemKind: u8;
@@ -306,4 +312,137 @@ fun decl_name_span(d: *decl.Decl) token.Span {
 fun warn(diags: *diag.DiagList, file_id: src.FileId, span: token.Span, message: str) {
     val r: Result[bool, str] = diag.warning(diags, file_id, span, message);
     if (is_err[bool, str](r)) { ret; }
+}
+
+# MSG_UNKNOWN / MSG_ORDER / MSG_MISSING: the three lint messages, shared with the
+# tests so an assertion tracks the emitted text exactly.
+val MSG_UNKNOWN: str = "documented component matches no parameter, field, generic, or `ret` of this declaration";
+val MSG_ORDER:   str = "documented components are out of declaration order";
+val MSG_MISSING: str = "declaration item is missing a documented component";
+
+# t_warns: lex+parse `source`, run the lint, and return the number of warnings
+# whose message equals `msg` (the empty string counts every warning). frees all
+# temporaries before returning. a lex/parse setup failure returns a sentinel that
+# never equals a real count, failing the asserting test.
+fun t_warns(source: str, msg: str) usize {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize(source, ?alloc, 0::src.FileId);
+    if (is_err[lexer.TokenStream, str](tr)) { ret 0xFFFF; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diag.DiagList = diag.init(?alloc);
+    var p: parser.Parser = parser.init(?stream, ?a, ?diags);
+    pdecl.parse_module(?p);
+
+    lint_module(?a, stream.source, ?diags);
+
+    var n: usize = 0;
+    var i: usize = 0;
+    for (i < diags.len) {
+        val d: *diag.Diagnostic = ?diags.items[i];
+        if (d.severity == diag.SEVERITY_WARNING) {
+            if (strutil.str_empty(msg) || strutil.str_equals(d.message, msg)) { n = n + 1; }
+        }
+        i = i + 1;
+    }
+
+    diag.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret n;
+}
+
+test "doclint: a fully correct fun (generics, comptime, params, ret) warns nothing" {
+    val src: str = "# atomic load\n# ---\n# [T]: element type\n# $order: ordering\n# ptr: pointer\n# ret: loaded value\npub fun load[T]($order: i64, ptr: *T) T { ret @ptr; }";
+    if (t_warns(src, "") != 0) { ret 1; }
+    ret 0;
+}
+
+test "doclint: a misspelled component warns unknown, and missing for the real item" {
+    val src: str = "# a point\n# ---\n# x: horizontal\n# z: misspelled\npub rec Point { x: i64; y: i64; }";
+    if (t_warns(src, MSG_UNKNOWN) != 1) { ret 1; }
+    if (t_warns(src, MSG_MISSING) != 1) { ret 1; }
+    ret 0;
+}
+
+test "doclint: a missing component is flagged once for the undocumented field" {
+    val src: str = "# a point\n# ---\n# x: horizontal\npub rec Point { x: i64; y: i64; }";
+    if (t_warns(src, MSG_MISSING) != 1) { ret 1; }
+    if (t_warns(src, MSG_UNKNOWN) != 0) { ret 1; }
+    if (t_warns(src, MSG_ORDER)   != 0) { ret 1; }
+    ret 0;
+}
+
+test "doclint: components out of declaration order warn order" {
+    val src: str = "# swap order\n# ---\n# ret: result\n# ptr: pointer\npub fun oo(ptr: *i64) i64 { ret @ptr; }";
+    if (t_warns(src, MSG_ORDER) != 1) { ret 1; }
+    if (t_warns(src, MSG_UNKNOWN) != 0) { ret 1; }
+    if (t_warns(src, MSG_MISSING) != 0) { ret 1; }
+    ret 0;
+}
+
+test "doclint: ret is a validated component — required when present, absent when void" {
+    # a non-nil return with ret documented: clean.
+    val with_ret: str = "# id\n# ---\n# x: the value\n# ret: the value back\npub fun id(x: i64) i64 { ret x; }";
+    if (t_warns(with_ret, "") != 0) { ret 1; }
+
+    # a non-nil return WITHOUT ret documented: ret is a missing item.
+    val no_ret_doc: str = "# id\n# ---\n# x: the value\npub fun id(x: i64) i64 { ret x; }";
+    if (t_warns(no_ret_doc, MSG_MISSING) != 1) { ret 1; }
+
+    # a void function: ret is not an item, so documenting only the param is clean.
+    val void_fn: str = "# noop\n# ---\n# x: ignored\npub fun noop(x: i64) {}";
+    if (t_warns(void_fn, "") != 0) { ret 1; }
+
+    # a void function that documents ret: ret matches no item -> unknown.
+    val void_ret: str = "# noop\n# ---\n# x: ignored\n# ret: nothing\npub fun noop(x: i64) {}";
+    if (t_warns(void_ret, MSG_UNKNOWN) != 1) { ret 1; }
+    ret 0;
+}
+
+test "doclint: a summary-only docstring (no `# ---`) warns nothing" {
+    val src: str = "# yield the CPU\npub fun spin(x: i64) {}";
+    if (t_warns(src, "") != 0) { ret 1; }
+    ret 0;
+}
+
+test "doclint: a decl with no docstring warns nothing" {
+    val src: str = "pub fun bare(x: i64, y: i64) {}";
+    if (t_warns(src, "") != 0) { ret 1; }
+    ret 0;
+}
+
+test "doclint: a non-pub decl with a mismatched block warns nothing" {
+    val src: str = "# private\n# ---\n# bogus: nope\nfun priv(x: i64) {}";
+    if (t_warns(src, "") != 0) { ret 1; }
+    ret 0;
+}
+
+test "doclint: the docstring is read above a `#[...]` decorator, not the decorator" {
+    # the doc sits above the `#[inline]` line; capture skips the decorator, so a
+    # correct block warns nothing.
+    val ok_src: str = "# the answer\n# ---\n# ret: always 42\n#[inline]\npub fun answer() i64 { ret 42; }";
+    if (t_warns(ok_src, "") != 0) { ret 1; }
+
+    # and a mismatch above the decorator is still caught.
+    val bad_src: str = "# the answer\n# ---\n# bogus: nope\n#[inline]\npub fun answer() i64 { ret 42; }";
+    if (t_warns(bad_src, MSG_UNKNOWN) != 1) { ret 1; }
+    if (t_warns(bad_src, MSG_MISSING) != 1) { ret 1; }
+    ret 0;
+}
+
+test "doclint: generic and comptime components must use their [T] / $name forms" {
+    # documenting a generic as the bare `T` (not `[T]`) is unknown, and the
+    # generic item is then missing.
+    val bare_generic: str = "# load\n# ---\n# T: element\n# ptr: pointer\npub fun load[T](ptr: *T) { }";
+    if (t_warns(bare_generic, MSG_UNKNOWN) != 1) { ret 1; }
+    if (t_warns(bare_generic, MSG_MISSING) != 1) { ret 1; }
+
+    # the correct `[T]` form is clean.
+    val ok_generic: str = "# load\n# ---\n# [T]: element\n# ptr: pointer\npub fun load[T](ptr: *T) { }";
+    if (t_warns(ok_generic, "") != 0) { ret 1; }
+    ret 0;
 }

--- a/src/lang/fe/doclint.mach
+++ b/src/lang/fe/doclint.mach
@@ -7,6 +7,12 @@
 # all silent. a docstring is never required. validated kinds are `fun`, `rec`,
 # and `uni` — the declaration forms that expose documentable items.
 #
+# documentation may be partial: an item with no component line is never flagged.
+# the lint only validates the lines that ARE written — a component naming no real
+# item (misspelled), a component with no description, and documented components
+# in the wrong relative order. completeness (warning on undocumented items) is
+# left to an opt-in per-project flag, not the default.
+#
 # the lint emits WARNINGs to the session diagnostic list (source `mach`) and runs
 # from the parser's public entry, so both the build/check path and the editor
 # parse path surface it.
@@ -116,9 +122,18 @@ fun item_count(d: *decl.Decl) usize {
 
 # check_components: the lint body for a decl already known to be in scope. builds
 # the declaration's ordered item list, then walks the docstring's component lines
-# once for unknown / out-of-order findings and the item list once for missing
-# findings. a buffer allocation failure drops the lint silently — a missing
-# warning never aborts the parse.
+# once, validating each. partial documentation is allowed: an item with no
+# component line is never flagged. a buffer allocation failure drops the lint
+# silently — a missing warning never aborts the parse.
+#
+# per component line:
+#   - matches no documentable item            -> unknown (misspelled)
+#   - matches an item but has a blank value    -> missing value
+#   - matches an item earlier than the previous documented one -> out of order
+# the order check runs against only the items that ARE documented: the documented
+# components must keep the underlying items' relative order, but gaps between them
+# (undocumented items) are permitted, so a doc covering only `ret`, or only some
+# parameters, is never flagged for order.
 fun check_components(a: *ast.Ast, d: *decl.Decl, source: str, diags: *diag.DiagList) {
     val count: usize = item_count(d);
 
@@ -141,20 +156,14 @@ fun check_components(a: *ast.Ast, d: *decl.Decl, source: str, diags: *diag.DiagL
             warn(diags, a.file_id, c.name_span, "documented component matches no parameter, field, generic, or `ret` of this declaration");
             cnt;
         }
+        if (c.desc_span.len == 0) {
+            warn(diags, a.file_id, c.name_span, "documented component has no description");
+        }
         if (have_prev && idx < prev) {
             warn(diags, a.file_id, c.name_span, "documented components are out of declaration order");
         }
         prev = idx;
         have_prev = true;
-    }
-
-    # missing: any item never named by a component line.
-    var k: usize = 0;
-    for (k < count) {
-        if (!item_documented(source, d.doc, ?items[k])) {
-            warn(diags, a.file_id, decl_name_span(d), "declaration item is missing a documented component");
-        }
-        k = k + 1;
     }
 
     if (items != nil) {
@@ -264,17 +273,6 @@ fun item_name_eq(source: str, it: *Item, name: token.Span) bool {
     ret bytes_eq(source, name.offset, it.name_off, it.name_len);
 }
 
-# item_documented: true when some component line in doc block `doc_span` spells
-# item `it`. used for the missing-component pass.
-fun item_documented(source: str, doc_span: token.Span, it: *Item) bool {
-    var iter: doc.DocComponentIter = doc.component_iter(source, doc_span);
-    var c: doc.DocComponent;
-    for (doc.component_next(?iter, ?c)) {
-        if (item_name_eq(source, it, c.name_span)) { ret true; }
-    }
-    ret false;
-}
-
 # bytes_eq: true when the `len` bytes at `a_off` equal the `len` bytes at `b_off`
 # within `source`.
 fun bytes_eq(source: str, a_off: usize, b_off: usize, len: usize) bool {
@@ -297,16 +295,6 @@ fun span_eq_str(source: str, span: token.Span, s: str) bool {
     ret s[span.len] == 0;
 }
 
-# decl_name_span: the span of a declaration's identifier, used to anchor a
-# missing-component warning. falls back to the decl's full span for kinds without
-# a single name (never reached for the documentable kinds).
-fun decl_name_span(d: *decl.Decl) token.Span {
-    if (d.kind == decl.DECL_KIND_FUN) { ret (?d.data.fun_).name; }
-    if (d.kind == decl.DECL_KIND_REC) { ret (?d.data.rec_).name; }
-    if (d.kind == decl.DECL_KIND_UNI) { ret (?d.data.uni_).name; }
-    ret d.span;
-}
-
 # warn: append a docstring warning to the sink, swallowing an allocation failure
 # (a dropped lint warning never aborts a parse).
 fun warn(diags: *diag.DiagList, file_id: src.FileId, span: token.Span, message: str) {
@@ -314,11 +302,11 @@ fun warn(diags: *diag.DiagList, file_id: src.FileId, span: token.Span, message: 
     if (is_err[bool, str](r)) { ret; }
 }
 
-# MSG_UNKNOWN / MSG_ORDER / MSG_MISSING: the three lint messages, shared with the
+# MSG_UNKNOWN / MSG_NO_DESC / MSG_ORDER: the three lint messages, shared with the
 # tests so an assertion tracks the emitted text exactly.
 val MSG_UNKNOWN: str = "documented component matches no parameter, field, generic, or `ret` of this declaration";
+val MSG_NO_DESC: str = "documented component has no description";
 val MSG_ORDER:   str = "documented components are out of declaration order";
-val MSG_MISSING: str = "declaration item is missing a documented component";
 
 # t_warns: lex+parse `source`, run the lint, and return the number of warnings
 # whose message equals `msg` (the empty string counts every warning). frees all
@@ -361,37 +349,55 @@ test "doclint: a fully correct fun (generics, comptime, params, ret) warns nothi
     ret 0;
 }
 
-test "doclint: a misspelled component warns unknown, and missing for the real item" {
+test "doclint: a misspelled component warns unknown, with no missing-item warning" {
+    # `z` matches no field; the real field `y` simply going undocumented is fine.
     val src: str = "# a point\n# ---\n# x: horizontal\n# z: misspelled\npub rec Point { x: i64; y: i64; }";
     if (t_warns(src, MSG_UNKNOWN) != 1) { ret 1; }
-    if (t_warns(src, MSG_MISSING) != 1) { ret 1; }
+    if (t_warns(src, "")          != 1) { ret 1; }
     ret 0;
 }
 
-test "doclint: a missing component is flagged once for the undocumented field" {
+test "doclint: an undocumented item is never flagged (partial documentation is allowed)" {
+    # only `x` documented, `y` omitted: no warning at all.
     val src: str = "# a point\n# ---\n# x: horizontal\npub rec Point { x: i64; y: i64; }";
-    if (t_warns(src, MSG_MISSING) != 1) { ret 1; }
-    if (t_warns(src, MSG_UNKNOWN) != 0) { ret 1; }
-    if (t_warns(src, MSG_ORDER)   != 0) { ret 1; }
+    if (t_warns(src, "") != 0) { ret 1; }
     ret 0;
 }
 
-test "doclint: components out of declaration order warn order" {
+test "doclint: a component line with no description warns" {
+    val src: str = "# a point\n# ---\n# x:\npub rec Point { x: i64; y: i64; }";
+    if (t_warns(src, MSG_NO_DESC) != 1) { ret 1; }
+    if (t_warns(src, "")          != 1) { ret 1; }
+    ret 0;
+}
+
+test "doclint: documented components out of declaration order warn order" {
+    # `ret` then `ptr` reverses the underlying order (ptr precedes ret).
     val src: str = "# swap order\n# ---\n# ret: result\n# ptr: pointer\npub fun oo(ptr: *i64) i64 { ret @ptr; }";
     if (t_warns(src, MSG_ORDER) != 1) { ret 1; }
-    if (t_warns(src, MSG_UNKNOWN) != 0) { ret 1; }
-    if (t_warns(src, MSG_MISSING) != 0) { ret 1; }
+    if (t_warns(src, "")        != 1) { ret 1; }
     ret 0;
 }
 
-test "doclint: ret is a validated component — required when present, absent when void" {
+test "doclint: order judges only the documented items, so gaps are not out of order" {
+    # b and d documented (a, c skipped) in their real relative order: clean.
+    val gapped: str = "# four fields\n# ---\n# b: second\n# d: fourth\npub rec R { a: i64; b: i64; c: i64; d: i64; }";
+    if (t_warns(gapped, "") != 0) { ret 1; }
+
+    # documenting only `ret` of a multi-param fun is clean (no order, no missing).
+    val ret_only: str = "# adds\n# ---\n# ret: the sum\npub fun add(x: i64, y: i64) i64 { ret x + y; }";
+    if (t_warns(ret_only, "") != 0) { ret 1; }
+    ret 0;
+}
+
+test "doclint: ret is validated when present and not an item on a void fun" {
     # a non-nil return with ret documented: clean.
     val with_ret: str = "# id\n# ---\n# x: the value\n# ret: the value back\npub fun id(x: i64) i64 { ret x; }";
     if (t_warns(with_ret, "") != 0) { ret 1; }
 
-    # a non-nil return WITHOUT ret documented: ret is a missing item.
+    # a non-nil return WITHOUT ret documented: allowed (partial docs), no warning.
     val no_ret_doc: str = "# id\n# ---\n# x: the value\npub fun id(x: i64) i64 { ret x; }";
-    if (t_warns(no_ret_doc, MSG_MISSING) != 1) { ret 1; }
+    if (t_warns(no_ret_doc, "") != 0) { ret 1; }
 
     # a void function: ret is not an item, so documenting only the param is clean.
     val void_fn: str = "# noop\n# ---\n# x: ignored\npub fun noop(x: i64) {}";
@@ -400,6 +406,7 @@ test "doclint: ret is a validated component — required when present, absent wh
     # a void function that documents ret: ret matches no item -> unknown.
     val void_ret: str = "# noop\n# ---\n# x: ignored\n# ret: nothing\npub fun noop(x: i64) {}";
     if (t_warns(void_ret, MSG_UNKNOWN) != 1) { ret 1; }
+    if (t_warns(void_ret, "")          != 1) { ret 1; }
     ret 0;
 }
 
@@ -427,19 +434,19 @@ test "doclint: the docstring is read above a `#[...]` decorator, not the decorat
     val ok_src: str = "# the answer\n# ---\n# ret: always 42\n#[inline]\npub fun answer() i64 { ret 42; }";
     if (t_warns(ok_src, "") != 0) { ret 1; }
 
-    # and a mismatch above the decorator is still caught.
+    # and an unknown component above the decorator is still caught.
     val bad_src: str = "# the answer\n# ---\n# bogus: nope\n#[inline]\npub fun answer() i64 { ret 42; }";
     if (t_warns(bad_src, MSG_UNKNOWN) != 1) { ret 1; }
-    if (t_warns(bad_src, MSG_MISSING) != 1) { ret 1; }
+    if (t_warns(bad_src, "")          != 1) { ret 1; }
     ret 0;
 }
 
 test "doclint: generic and comptime components must use their [T] / $name forms" {
-    # documenting a generic as the bare `T` (not `[T]`) is unknown, and the
-    # generic item is then missing.
+    # documenting a generic as the bare `T` (not `[T]`) matches no item -> unknown;
+    # the generic going otherwise undocumented is fine.
     val bare_generic: str = "# load\n# ---\n# T: element\n# ptr: pointer\npub fun load[T](ptr: *T) { }";
     if (t_warns(bare_generic, MSG_UNKNOWN) != 1) { ret 1; }
-    if (t_warns(bare_generic, MSG_MISSING) != 1) { ret 1; }
+    if (t_warns(bare_generic, "")          != 1) { ret 1; }
 
     # the correct `[T]` form is clean.
     val ok_generic: str = "# load\n# ---\n# [T]: element\n# ptr: pointer\npub fun load[T](ptr: *T) { }";

--- a/src/lang/fe/lexer.mach
+++ b/src/lang/fe/lexer.mach
@@ -43,6 +43,21 @@ pub rec LexError {
     code: u8;
 }
 
+# CommentRun: a maximal block of consecutive `#` comment lines, recorded so the
+# parser can attach a declaration's doc-comment block. a run grows while each
+# successive comment line sits directly under the previous one (no blank or code
+# line between); a gap starts a new run. `#[...]` attribute decorators are real
+# tokens, never comments, so they never appear in a run.
+# ---
+# span:       byte range spanning the first comment line's `#` to the end of the last
+# start_line: 1-based source line of the first comment line
+# end_line:   1-based source line of the last comment line
+pub rec CommentRun {
+    span:       token.Span;
+    start_line: usize;
+    end_line:   usize;
+}
+
 # TokenStream: a flat, owning buffer of tokens and lex errors produced over one source file.
 # ---
 # tokens:    contiguous array of tokens ending in KIND_EOF
@@ -53,6 +68,9 @@ pub rec LexError {
 # errors:    contiguous array of LexError; nil if none
 # error_len: number of errors currently stored
 # error_cap: allocated slots in errors (0 when errors is nil)
+# comments:    contiguous array of CommentRun in source order; nil if none
+# comment_len: number of comment runs currently stored
+# comment_cap: allocated slots in comments (0 when comments is nil)
 pub rec TokenStream {
     tokens:    *token.Token;
     len:       usize;
@@ -62,10 +80,14 @@ pub rec TokenStream {
     errors:    *LexError;
     error_len: usize;
     error_cap: usize;
+    comments:    *CommentRun;
+    comment_len: usize;
+    comment_cap: usize;
 }
 
-val INITIAL_CAP:       usize = 256;
-val INITIAL_ERROR_CAP: usize = 8;
+val INITIAL_CAP:         usize = 256;
+val INITIAL_ERROR_CAP:   usize = 8;
+val INITIAL_COMMENT_CAP: usize = 16;
 
 # tokenize: lexes source text into a TokenStream terminated by KIND_EOF.
 # ---
@@ -75,13 +97,16 @@ val INITIAL_ERROR_CAP: usize = 8;
 # ret:     an owning TokenStream, or an allocation error
 pub fun tokenize(source: str, alloc: *Allocator, file_id: src.FileId) Result[TokenStream, str] {
     var stream: TokenStream;
-    stream.source    = source;
-    stream.file_id   = file_id;
-    stream.len       = 0;
-    stream.cap       = INITIAL_CAP;
-    stream.errors    = nil;
-    stream.error_len = 0;
-    stream.error_cap = 0;
+    stream.source      = source;
+    stream.file_id     = file_id;
+    stream.len         = 0;
+    stream.cap         = INITIAL_CAP;
+    stream.errors      = nil;
+    stream.error_len   = 0;
+    stream.error_cap   = 0;
+    stream.comments    = nil;
+    stream.comment_len = 0;
+    stream.comment_cap = 0;
 
     val r_init: Result[*token.Token, str] = allocate[token.Token](alloc, stream.cap);
     if (is_err[*token.Token, str](r_init)) {
@@ -89,11 +114,13 @@ pub fun tokenize(source: str, alloc: *Allocator, file_id: src.FileId) Result[Tok
     }
     stream.tokens = unwrap_ok[*token.Token, str](r_init);
 
-    var pos: usize = 0;
+    var pos:  usize = 0;
+    var line: usize = 1;
     for (source[pos] != 0) {
         val c: u8 = source[pos];
 
         if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+            if (c == '\n') { line = line + 1; }
             pos = pos + 1;
             cnt;
         }
@@ -102,8 +129,15 @@ pub fun tokenize(source: str, alloc: *Allocator, file_id: src.FileId) Result[Tok
         # any other `#` is a line comment to end-of-line. a literal comment that
         # begins `#[` therefore needs an intervening space (`# [...]`).
         if (c == '#' && source[pos + 1] != '[') {
+            val comment_start: usize = pos;
+            val comment_line:  usize = line;
             for (source[pos] != 0 && source[pos] != '\n') {
                 pos = pos + 1;
+            }
+            val r_cmt: Result[bool, str] = record_comment(?stream, alloc, comment_start, pos, comment_line);
+            if (is_err[bool, str](r_cmt)) {
+                deallocate[token.Token](alloc, stream.tokens, stream.cap);
+                ret err[TokenStream, str](unwrap_err[bool, str](r_cmt));
             }
             cnt;
         }
@@ -389,12 +423,18 @@ pub fun dnit(stream: *TokenStream, alloc: *Allocator) {
     if (stream.errors != nil && stream.error_cap > 0) {
         deallocate[LexError](alloc, stream.errors, stream.error_cap);
     }
-    stream.tokens    = nil;
-    stream.len       = 0;
-    stream.cap       = 0;
-    stream.errors    = nil;
-    stream.error_len = 0;
-    stream.error_cap = 0;
+    if (stream.comments != nil && stream.comment_cap > 0) {
+        deallocate[CommentRun](alloc, stream.comments, stream.comment_cap);
+    }
+    stream.tokens      = nil;
+    stream.len         = 0;
+    stream.cap         = 0;
+    stream.errors      = nil;
+    stream.error_len   = 0;
+    stream.error_cap   = 0;
+    stream.comments    = nil;
+    stream.comment_len = 0;
+    stream.comment_cap = 0;
 }
 
 # text: returns a length-counted view into the source buffer covering the token's span.
@@ -436,6 +476,94 @@ pub fun emit_diagnostics(stream: *TokenStream, diags: *diag.DiagList) Result[boo
         i = i + 1;
     }
     ret ok[bool, str](true);
+}
+
+# record_comment: fold one `#` comment line into the stream's comment runs. when
+# the line sits directly under the previous run's last line the run is extended
+# (its span and end_line grow to cover this line); otherwise a new run begins. on
+# allocation failure the comment buffer is freed and the error returned.
+# ---
+# stream: stream whose comment runs are updated
+# alloc:  allocator backing the comment buffer
+# start:  byte offset of the `#` opening this comment line
+# end:    byte offset just past the comment line (exclusive of any newline)
+# line:   1-based source line of this comment line
+# ret:    true on success, or an allocation error
+fun record_comment(stream: *TokenStream, alloc: *Allocator, start: usize, end: usize, line: usize) Result[bool, str] {
+    if (stream.comment_len > 0) {
+        val last: *CommentRun = ?stream.comments[stream.comment_len - 1];
+        if (line == last.end_line + 1) {
+            last.span.len = end - last.span.offset;
+            last.end_line = line;
+            ret ok[bool, str](true);
+        }
+    }
+
+    if (stream.comment_len == stream.comment_cap) {
+        val r: Result[*CommentRun, str] = pool.grow[CommentRun](alloc, stream.comments, stream.comment_cap, INITIAL_COMMENT_CAP, ?stream.comment_cap);
+        if (is_err[*CommentRun, str](r)) {
+            if (stream.comments != nil && stream.comment_cap > 0) {
+                deallocate[CommentRun](alloc, stream.comments, stream.comment_cap);
+            }
+            stream.comments    = nil;
+            stream.comment_cap = 0;
+            ret err[bool, str](unwrap_err[*CommentRun, str](r));
+        }
+        stream.comments = unwrap_ok[*CommentRun, str](r);
+    }
+
+    var run: CommentRun;
+    run.span.offset = start;
+    run.span.len    = end - start;
+    run.start_line  = line;
+    run.end_line    = line;
+    stream.comments[stream.comment_len] = run;
+    stream.comment_len = stream.comment_len + 1;
+    ret ok[bool, str](true);
+}
+
+# doc_run_above: the byte span of the comment run whose last line sits directly
+# above the declaration starting at `decl_offset`, or an empty span (len 0) when
+# no comment run abuts it. the parser passes the offset of a declaration's first
+# leading token — its first `#[...]` decorator when decorators are present, else
+# the keyword — so the run found is the doc block above the whole declaration
+# unit, with any attribute lines (which are tokens, not comments) skipped.
+# ---
+# stream:      lexed stream whose comment runs are searched
+# decl_offset: byte offset of the declaration's first leading token
+# ret:         the doc-block span, or a zero-length span when absent
+pub fun doc_run_above(stream: *TokenStream, decl_offset: usize) token.Span {
+    var empty: token.Span;
+    empty.offset = 0;
+    empty.len    = 0;
+
+    if (stream.comment_len == 0) { ret empty; }
+
+    val decl_line: usize = line_at(stream.source, decl_offset);
+
+    var i: usize = stream.comment_len;
+    for (i > 0) {
+        i = i - 1;
+        val run: *CommentRun = ?stream.comments[i];
+        if (run.end_line + 1 == decl_line) { ret run.span; }
+        # runs are stored in source order; once a run ends above the decl line we
+        # can stop — earlier runs end even higher.
+        if (run.end_line < decl_line) { ret empty; }
+    }
+    ret empty;
+}
+
+# line_at: the 1-based source line containing byte `offset`, counting newlines
+# from the start of `source`. used by doc_run_above to place a declaration's
+# first token relative to the recorded comment runs.
+fun line_at(source: str, offset: usize) usize {
+    var line: usize = 1;
+    var i:    usize = 0;
+    for (i < offset && source[i] != 0) {
+        if (source[i] == '\n') { line = line + 1; }
+        i = i + 1;
+    }
+    ret line;
 }
 
 fun push_error(stream: *TokenStream, alloc: *Allocator, offset: usize, len: usize, code: u8) Result[bool, str] {
@@ -659,4 +787,67 @@ test "lexer: a string literal stops at a newline and is reported unterminated (#
 
     dnit(?stream, ?alloc);
     ret 0;
+}
+
+test "lexer: consecutive comment lines fold into one run, a gap splits runs" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    # two comment lines directly stacked, then a blank line, then a third comment:
+    # the first two fold into one run; the blank line breaks it so the third is
+    # its own run.
+    val tr: Result[TokenStream, str] = tokenize("# a\n# b\n\n# c\nval x: i64 = 1;", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr)) { ret 1; }
+    var stream: TokenStream = unwrap_ok[TokenStream, str](tr);
+
+    var rc: i32 = 0;
+    if (stream.comment_len != 2) { rc = 1; }
+    or {
+        # run 0 spans "# a\n# b" (offset 0, lines 1..2)
+        if (stream.comments[0].start_line != 1) { rc = 1; }
+        or (stream.comments[0].end_line  != 2) { rc = 1; }
+        or (stream.comments[0].span.offset != 0) { rc = 1; }
+        or (stream.comments[0].span.len  != 7) { rc = 1; }
+        # run 1 is the lone "# c" on line 4
+        or (stream.comments[1].start_line != 4) { rc = 1; }
+        or (stream.comments[1].end_line  != 4) { rc = 1; }
+    }
+
+    dnit(?stream, ?alloc);
+    ret rc;
+}
+
+test "lexer: doc_run_above finds the run abutting a decl and skips attribute lines" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    # doc block, then a `#[...]` attribute line (a real token, never a comment),
+    # then the decl. the doc run ends on line 1; the decl unit's first token is
+    # the `#[` on line 2, so doc_run_above keyed on that offset finds the run.
+    val source: str = "# the doc\n#[inline]\npub fun f() {}";
+    val tr: Result[TokenStream, str] = tokenize(source, ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr)) { ret 1; }
+    var stream: TokenStream = unwrap_ok[TokenStream, str](tr);
+
+    var rc: i32 = 0;
+    # exactly one comment run (the attribute is not a comment)
+    if (stream.comment_len != 1) { rc = 1; }
+    or {
+        # the first non-comment token is the `#[` attribute opener at offset 10
+        val attr_off: usize = stream.tokens[0].span.offset;
+        if (stream.tokens[0].kind != token.KIND_ATTR_OPEN) { rc = 1; }
+        or (attr_off != 10) { rc = 1; }
+        or {
+            val span: token.Span = doc_run_above(?stream, attr_off);
+            if (span.len == 0) { rc = 1; }
+            or (span.offset != 0) { rc = 1; }
+            or (span.len != 9) { rc = 1; }
+        }
+        # a decl with no abutting comment yields an empty span
+        val none_span: token.Span = doc_run_above(?stream, 999);
+        if (none_span.len != 0) { rc = 1; }
+    }
+
+    dnit(?stream, ?alloc);
+    ret rc;
 }

--- a/src/lang/fe/parser.mach
+++ b/src/lang/fe/parser.mach
@@ -7,9 +7,10 @@
 
 use std.types.bool.bool;
 
-use lexer: mach.lang.fe.lexer;
-use diag:  mach.lang.diagnostic;
-use ast:   mach.lang.fe.ast;
+use lexer:   mach.lang.fe.lexer;
+use diag:    mach.lang.diagnostic;
+use ast:     mach.lang.fe.ast;
+use doclint: mach.lang.fe.doclint;
 
 use state: mach.lang.fe.parser.state;
 use pdecl: mach.lang.fe.parser.decl;
@@ -17,7 +18,9 @@ use pdecl: mach.lang.fe.parser.decl;
 # parse: parses the token stream into the AST, populating diagnostics along the way.
 # syntax errors are recovered from and pushed to `diags` while parsing continues;
 # the one unrecoverable condition is an allocation failure, signalled by the
-# return so the caller can refuse the now-incomplete AST.
+# return so the caller can refuse the now-incomplete AST. on a clean parse the
+# docstring lint runs over the AST, so its WARNINGs reach every parse caller (the
+# build/check driver and the editor) from this one entry point.
 # ---
 # tokens: lexer output to consume
 # out:    AST to append parsed nodes into; its root_module is set on completion
@@ -26,5 +29,8 @@ use pdecl: mach.lang.fe.parser.decl;
 pub fun parse(tokens: *lexer.TokenStream, out: *ast.Ast, diags: *diag.DiagList) bool {
     var p: state.Parser = state.init(tokens, out, diags);
     pdecl.parse_module(?p);
+    if (!p.fatal) {
+        doclint.lint_module(out, tokens.source, diags);
+    }
     ret p.fatal;
 }

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -82,15 +82,22 @@ pub fun parse_module(p: *parser.Parser) id.ModuleId {
 pub fun parse_decl(p: *parser.Parser) id.DeclId {
     val start: token.Token = parser.current(p);
 
+    # the doc-comment block is the comment run abutting the declaration's first
+    # leading token (the `#[` opener when decorators are present, else the
+    # keyword), captured before the decorators are consumed.
+    val doc: token.Span = lexer.doc_run_above(p.tokens, start.span.offset);
+
     var decorators_len: u32 = 0;
     val decorators_start: u32 = parse_decorators(p, ?decorators_len);
 
     val did: id.DeclId = parse_decl_dispatch(p, start.span);
 
-    # back-patch the decorator range onto the parsed decl; the pointer is taken
-    # after the dispatch's own appends complete, so the decls pool is stable.
+    # back-patch the doc span and decorator range onto the parsed decl; the
+    # pointer is taken after the dispatch's own appends complete, so the decls
+    # pool is stable.
     if (did != id.DECL_NIL) {
         val d: *decl.Decl = unwrap[*decl.Decl](ast.get_decl(p.ast, did));
+        d.doc              = doc;
         d.decorators_start = decorators_start;
         d.decorators_len   = decorators_len;
     }


### PR DESCRIPTION
Patch release: first-class doc capture on `Decl`, a doc-block parser (`fe/doc.mach`), and a pub-scoped docstring lint (`fe/doclint.mach`) — warns on misspelled/out-of-order/empty components, never requires completeness. Closes #1570.