### PR TITLE
release: v2.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.5] - 2026-06-23
+
+`mach doc` now reads first-class documentation, so the compiler, the docstring
+lint, and editor hover all share one doc source.
+
+### Changed
+
+- doc: `mach doc` sources documentation from each decl's `Decl.doc` span via
+  `mach.lang.fe.doc` (walking the parsed AST, recursing into comptime branches)
+  instead of re-scanning raw source text. `#[attr]` decorator lines no longer
+  leak into rendered docs, and component whitespace is normalized. Content after
+  `# ---` that is not a valid `name: desc` component is dropped, matching the
+  lint and hover.
+
 ## [2.5.4] - 2026-06-23
 
 First-class documentation. Doc-comment blocks are now captured on declarations

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.5.4"
+version = "2.5.5"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -1,17 +1,19 @@
-# mach.cli.cmd.doc: `mach doc` — generates reference documentation from source doc-comments.
+# mach.cli.cmd.doc: `mach doc` — generates reference documentation from
+# first-class doc comments.
 #
 # loads the full module graph through the same driver pipeline as `build`,
-# then for every module walks its source text and pairs each `pub`
-# declaration with the run of leading `#` comment lines immediately
-# preceding it. each module is rendered to a Markdown page under
-# `<root>/doc/api/<fqn-as-path>.md` (FQN `a.b.c` -> `doc/api/a/b/c.md`),
-# with an index at `doc/api/README.md` linking every page. the hand-written
-# `doc/language/` material is never touched.
+# then for every module walks its parsed AST and, for each `pub` declaration,
+# renders the signature from source and the documentation from the decl's
+# first-class `doc` span via `mach.lang.fe.doc` (summary + components). that is
+# the same structured doc source the docstring lint and the LSP hover read, so
+# the rendered summary and components stay in lockstep with them and `#[...]`
+# decorator lines are never mistaken for documentation.
 #
-# doc-comments are not retained on the AST — the lexer drops `#` comments at
-# tokenisation — so this is a textual extraction over the original source,
-# which is the tractable MVP. page output is written straight to the
-# filesystem; only the run summary goes through `std.print`.
+# each module is rendered to a Markdown page under `<root>/doc/api/<fqn-as-path>.md`
+# (FQN `a.b.c` -> `doc/api/a/b/c.md`), with an index at `doc/api/README.md`
+# linking every page. the hand-written `doc/language/` material is never
+# touched. page output is written straight to the filesystem through a Writer;
+# only the run summary goes through `std.print`.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -19,12 +21,11 @@ use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.option.Option;
-use std.types.option.some;
-use std.types.option.none;
 use std.types.option.is_some;
 use std.types.option.is_none;
 use std.types.option.unwrap;
 use std.types.result.Result;
+use std.types.result.ok;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
@@ -34,8 +35,11 @@ use std.allocator.Allocator;
 use page:  std.allocator.page;
 use arena: std.allocator.arena;
 
-use fs:    std.filesystem;
-use print: std.print;
+use fs:     std.filesystem;
+use writer: std.io.writer;
+use print:  std.print;
+
+use strutil: std.types.string;
 
 use intern: mach.lang.intern;
 use sess:   mach.lang.session;
@@ -43,25 +47,32 @@ use src:    mach.lang.source;
 use driver: mach.lang.driver;
 use tgt:    mach.lang.target;
 
+use token:  mach.lang.fe.token;
+use ast:    mach.lang.fe.ast;
+use module: mach.lang.fe.ast.module;
+use decl:   mach.lang.fe.ast.decl;
+use id:     mach.lang.fe.ast.id;
+use fdoc:   mach.lang.fe.doc;
+
 use cfg:  mach.cli.config;
 use util: mach.cli.util;
 
-# wr: write a null-terminated literal to an open file, ignoring short writes.
+# wr: write a null-terminated literal through a writer, ignoring short writes.
 # ---
-# f: destination file
+# w: destination writer
 # s: null-terminated byte string
-fun wr(f: *fs.File, s: *u8) {
-    fs.write(f, s, util.slen(s));
+fun wr(w: *writer.Writer, s: *u8) {
+    writer.write_all(w, s, util.slen(s));
 }
 
-# wr_n: write `len` bytes of `s` to an open file.
+# wr_n: write `len` bytes of `s` through a writer.
 # ---
-# f:   destination file
+# w:   destination writer
 # s:   source bytes (not necessarily null-terminated within the range)
 # len: number of bytes to write
-fun wr_n(f: *fs.File, s: *u8, len: usize) {
+fun wr_n(w: *writer.Writer, s: *u8, len: usize) {
     if (len == 0) { ret; }
-    fs.write(f, s, len);
+    writer.write_all(w, s, len);
 }
 
 # line_end: index of the byte just past the current line's content (the '\n'
@@ -88,16 +99,6 @@ fun first_nonspace(s: *u8, pos: usize) usize {
     ret i;
 }
 
-# is_blank_line: true when the line starting at `pos` holds only whitespace.
-# ---
-# s:   source text
-# pos: offset of the line start
-# ret: true if the line is empty or all spaces/tabs
-fun is_blank_line(s: *u8, pos: usize) bool {
-    val i: usize = first_nonspace(s, pos);
-    ret s[i] == '\n' || s[i] == 0;
-}
-
 # starts_with: true when the bytes at `s[pos..]` begin with the literal `lit`.
 # ---
 # s:   source text
@@ -113,26 +114,6 @@ fun starts_with(s: *u8, pos: usize, lit: *u8) bool {
     ret true;
 }
 
-# is_comment_line: true when the line at `pos` is a `#` comment line.
-# ---
-# s:   source text
-# pos: offset of the line start
-# ret: true when the first significant byte is '#'
-fun is_comment_line(s: *u8, pos: usize) bool {
-    val i: usize = first_nonspace(s, pos);
-    ret s[i] == '#';
-}
-
-# is_pub_line: true when the line at `pos` opens a `pub ` declaration.
-# ---
-# s:   source text
-# pos: offset of the line start
-# ret: true when the first significant token is `pub` followed by a space
-fun is_pub_line(s: *u8, pos: usize) bool {
-    val i: usize = first_nonspace(s, pos);
-    ret starts_with(s, i, "pub ");
-}
-
 # next_line: index of the start of the line following the one at `pos`.
 # ---
 # s:   source text
@@ -142,6 +123,34 @@ fun next_line(s: *u8, pos: usize) usize {
     val e: usize = line_end(s, pos);
     if (s[e] == 0) { ret e; }
     ret e + 1;
+}
+
+# skip_decorators: advance past a declaration's leading `#[...]` decorator
+# clauses (and the whitespace and newlines between them) to the offset of its
+# first real token — the `pub`/`ext` flag or the kind keyword. a decl's `span`
+# starts at the opening `#[` when decorators are present, so this lands the
+# signature renderers on the declaration proper, never on a decorator line.
+# ---
+# s:   source text
+# pos: offset of the declaration's first token (its `span.offset`)
+# ret: offset of the first non-decorator token
+fun skip_decorators(s: *u8, pos: usize) usize {
+    var i: usize = pos;
+    var go: bool = true;
+    for (go) {
+        for (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r') { i = i + 1; }
+        if (s[i] == '#' && s[i + 1] == '[') {
+            i = i + 2;
+            var depth: i64 = 1;
+            for (depth > 0 && s[i] != 0) {
+                if (s[i] == '[')      { depth = depth + 1; }
+                or (s[i] == ']')      { depth = depth - 1; }
+                i = i + 1;
+            }
+        }
+        or { go = false; }
+    }
+    ret i;
 }
 
 # fqn_path_into: write `fqn` into `buf` with each '.' turned into '/', so an
@@ -164,32 +173,69 @@ fun fqn_path_into(buf: *u8, cap: usize, fqn: *u8) usize {
     ret n;
 }
 
-# write_comment_body: write the comment block spanning source lines
-# `[start, stop)` as Markdown, stripping the leading `# ` from each line and
-# rendering the `# ---` separator row as a blank line.
+# write_span_stripped: write the byte span `span` of `source` through `w`,
+# stripping the `#`-comment prefix from each wrapped continuation line so a
+# multi-line summary or description renders as clean Markdown prose. the first
+# line's content is already past its `#` (the doc parser trims it), so only
+# lines after an embedded newline are de-commented.
 # ---
-# f:     destination file
-# s:     source text
-# start: line-start offset of the first comment line
-# stop:  line-start offset just past the last comment line
-fun write_comment_body(f: *fs.File, s: *u8, start: usize, stop: usize) {
-    var pos: usize = start;
-    for (pos < stop) {
-        val sig: usize = first_nonspace(s, pos);
-        # sig indexes the '#'; skip it and a single following space.
-        var body: usize = sig + 1;
-        if (s[body] == ' ') { body = body + 1; }
-        val e: usize = line_end(s, pos);
+# w:      destination writer
+# source: the source text the span points into
+# span:   byte span to render
+fun write_span_stripped(w: *writer.Writer, source: str, span: token.Span) {
+    val s: *u8 = source::*u8;
+    val end: usize = span.offset + span.len;
+    var i: usize = span.offset;
+    var first: bool = true;
+    for (i < end) {
+        if (!first) {
+            for (i < end && (s[i] == ' ' || s[i] == '\t')) { i = i + 1; }
+            if (i < end && s[i] == '#') { i = i + 1; }
+            if (i < end && s[i] == ' ') { i = i + 1; }
+        }
+        first = false;
+        var le: usize = i;
+        for (le < end && s[le] != '\n') { le = le + 1; }
+        wr_n(w, ?s[i], le - i);
+        if (le < end) { wr(w, "\n"); }
+        i = le;
+        if (i < end && s[i] == '\n') { i = i + 1; }
+    }
+}
 
-        if (starts_with(s, body, "---")) {
-            wr(f, "\n");
+# write_doc: render a declaration's documentation from its first-class doc span
+# through `w` — the trimmed summary, then a blank line and each `# name: desc`
+# component on its own line, sourced through `mach.lang.fe.doc`. writes nothing
+# when the decl carries no docstring (an empty doc span).
+# ---
+# w:      destination writer
+# source: the source text the doc span points into
+# doc:    the decl's doc-block span
+fun write_doc(w: *writer.Writer, source: str, doc: token.Span) {
+    if (doc.len == 0) { ret; }
+
+    val summary: token.Span = fdoc.summary_span(source, doc);
+    if (summary.len > 0) {
+        write_span_stripped(w, source, summary);
+        wr(w, "\n");
+    }
+
+    var it: fdoc.DocComponentIter = fdoc.component_iter(source, doc);
+    var c: fdoc.DocComponent;
+    var first: bool = true;
+    for (fdoc.component_next(?it, ?c)) {
+        if (first) { wr(w, "\n"); first = false; }
+        write_span_stripped(w, source, c.name_span);
+        if (c.desc_span.len > 0) {
+            wr(w, ": ");
+            write_span_stripped(w, source, c.desc_span);
         }
         or {
-            wr_n(f, ?s[body], e - body);
-            wr(f, "\n");
+            wr(w, ":");
         }
-        pos = next_line(s, pos);
+        wr(w, "\n");
     }
+    wr(w, "\n");
 }
 
 # write_signature: write the declaration whose first line starts at `pos` as a
@@ -197,12 +243,12 @@ fun write_comment_body(f: *fs.File, s: *u8, start: usize, stop: usize) {
 # that closes the signature with `;` or `{` at the outer brace/paren depth. a
 # trailing `{` is rewritten to `;` so the rendered signature omits the body.
 # ---
-# f:   destination file
+# w:   destination writer
 # s:   source text
-# pos: line-start offset of the declaration's first line
+# pos: offset of the declaration's first real token (past any decorators)
 # ret: line-start offset just past the declaration's signature
-fun write_signature(f: *fs.File, s: *u8, pos: usize) usize {
-    wr(f, "```mach\n");
+fun write_signature(w: *writer.Writer, s: *u8, pos: usize) usize {
+    wr(w, "```mach\n");
     var line: usize = pos;
     var depth: i64 = 0;
     var done: bool = false;
@@ -226,13 +272,37 @@ fun write_signature(f: *fs.File, s: *u8, pos: usize) usize {
         for (trimmed > begin && (s[trimmed - 1] == ' ' || s[trimmed - 1] == '\t')) {
             trimmed = trimmed - 1;
         }
-        wr_n(f, ?s[begin], trimmed - begin);
-        if (saw_brace) { wr(f, ";"); }
-        wr(f, "\n");
+        wr_n(w, ?s[begin], trimmed - begin);
+        if (saw_brace) { wr(w, ";"); }
+        wr(w, "\n");
         line = next_line(s, line);
     }
-    wr(f, "```\n\n");
+    wr(w, "```\n\n");
     ret line;
+}
+
+# write_heading: write a declaration's name for use as a Markdown heading: the
+# decl line with the `pub ` prefix removed and truncated at the first `(`, `[`,
+# `:`, `=`, `{`, or `;` so only the kind keyword and name remain.
+# ---
+# w:   destination writer
+# s:   source text
+# pos: offset of the declaration's first real token (past any decorators)
+fun write_heading(w: *writer.Writer, s: *u8, pos: usize) {
+    var i: usize = first_nonspace(s, pos);
+    if (starts_with(s, i, "pub ")) { i = i + 4; }
+    i = first_nonspace(s, i);
+    val e: usize = line_end(s, i);
+    # trim trailing spaces from the captured span.
+    var stop: usize = i;
+    var k: usize = i;
+    for (k < e) {
+        val c: u8 = s[k];
+        if (c == '(' || c == '[' || c == ':' || c == '=' || c == '{' || c == ';') { k = e; cnt; }
+        if (c != ' ' && c != '\t') { stop = k + 1; }
+        k = k + 1;
+    }
+    wr_n(w, ?s[i], stop - i);
 }
 
 # DocStats: running counts for a documentation run.
@@ -244,99 +314,94 @@ rec DocStats {
     entries: u32;
 }
 
-# document_module: render one module's page from its source text. scans for
-# `pub` declarations, attaching each to its immediately-preceding run of `#`
-# comment lines (a single blank line is allowed between the comment block and
-# the decl, matching the codebase convention). returns the number of public
-# entities written, or a negative value on a filesystem error.
+# document_decl: render one `pub` declaration to the page: a `##` heading and a
+# fenced signature from source, then its documentation from the decl's
+# first-class doc span.
+# ---
+# w:      destination writer
+# source: the module's source text (the decl's spans point into it)
+# d:      the declaration to document
+fun document_decl(w: *writer.Writer, source: str, d: *decl.Decl) {
+    val s: *u8 = source::*u8;
+    val sig: usize = skip_decorators(s, d.span.offset);
+
+    wr(w, "## ");
+    write_heading(w, s, sig);
+    wr(w, "\n\n");
+
+    write_signature(w, s, sig);
+    write_doc(w, source, d.doc);
+}
+
+# document_decls: walk a module-scope decl list, documenting each `pub`
+# declaration and recursing into `$if`/`$or` comptime branches (where
+# target-gated `pub` decls live). returns the number of public entities written.
+# ---
+# w:      destination writer
+# a:      the module's parsed AST
+# source: the module's source text
+# start:  start index into a.decl_ids of the list
+# len:    number of decls in the list
+# ret:    number of public entities documented
+fun document_decls(w: *writer.Writer, a: *ast.Ast, source: str, start: u32, len: u32) i64 {
+    var count: i64 = 0;
+    var i: u32 = 0;
+    for (i < len) {
+        val did: id.DeclId = a.decl_ids[start + i];
+        val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
+        if (is_some[*decl.Decl](d_opt)) {
+            val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+            if (d.kind == decl.DECL_KIND_COMPTIME_IF) {
+                val ci: *decl.DeclComptimeIf = ?d.data.comptime_if;
+                var bi: u32 = 0;
+                for (bi < ci.branches_len) {
+                    val br: *decl.ComptimeBranch = ?a.comptime_branches[ci.branches_start + bi];
+                    count = count + document_decls(w, a, source, br.body_start, br.body_len);
+                    bi = bi + 1;
+                }
+            }
+            or ((d.flags & decl.DECL_FLAG_PUB) != 0) {
+                document_decl(w, source, d);
+                count = count + 1;
+            }
+        }
+        i = i + 1;
+    }
+    ret count;
+}
+
+# document_module: render one module's page from its parsed AST. documents every
+# `pub` declaration at module scope. returns the number of public entities
+# written, or a negative value on a filesystem error.
 # ---
 # out_path: full path of the page file to create
 # fqn:      dotted module FQN, used as the page title
-# source:   the module's full source text
+# a:        the module's parsed AST
+# source:   the module's source text
 # ret:      number of public entities documented, or -1 on error
-fun document_module(out_path: *u8, fqn: *u8, source: str) i64 {
+fun document_module(out_path: *u8, fqn: *u8, a: *ast.Ast, source: str) i64 {
     if (!util.ensure_parents(out_path)) { ret -1; }
 
     val fr: Result[fs.File, str] = fs.create(util.cstr_str(out_path), 420);
     if (is_err[fs.File, str](fr)) { ret -1; }
     var file: fs.File = unwrap_ok[fs.File, str](fr);
 
-    val s: *u8 = source::*u8;
+    var w: writer.Writer;
+    fs.get_writer(?file, ?w);
 
-    wr(?file, "# ");
-    wr(?file, fqn);
-    wr(?file, "\n\n");
+    wr(?w, "# ");
+    wr(?w, fqn);
+    wr(?w, "\n\n");
 
     var count: i64 = 0;
-    var pos: usize = 0;
-    # the start of the current contiguous comment block, or its sentinel.
-    var block_start: usize = 0;
-    var have_block: bool = false;
-
-    for (s[pos] != 0) {
-        if (is_comment_line(s, pos)) {
-            if (!have_block) { block_start = pos; have_block = true; }
-            pos = next_line(s, pos);
-            cnt;
-        }
-
-        if (is_pub_line(s, pos)) {
-            wr(?file, "## ");
-            # the declaration's leading line, sans the `pub ` prefix and any
-            # trailing `{`/`;`, serves as the heading.
-            write_heading(?file, s, pos);
-            wr(?file, "\n\n");
-
-            val sig_end: usize = write_signature(?file, s, pos);
-            if (have_block) {
-                write_comment_body(?file, s, block_start, pos);
-                wr(?file, "\n");
-            }
-            count = count + 1;
-            have_block = false;
-            pos = sig_end;
-            cnt;
-        }
-
-        # any non-comment line (including a blank) detaches the pending comment
-        # block, so a decl's doc-comment is only the contiguous `#` run flush
-        # against it — matching the codebase convention.
-        have_block = false;
-        pos = next_line(s, pos);
+    val m_opt: Option[*module.Module] = ast.get_module(a, a.root_module);
+    if (is_some[*module.Module](m_opt)) {
+        val m: *module.Module = unwrap[*module.Module](m_opt);
+        count = document_decls(?w, a, source, m.decls_start, m.decls_len);
     }
 
     fs.close(?file);
     ret count;
-}
-
-# write_heading: write a declaration's name for use as a Markdown heading: the
-# decl line with the `pub ` prefix removed and truncated at the first `(`, `[`,
-# `:`, `=`, `{`, or `;` so only the kind keyword and name remain.
-# ---
-# f:   destination file
-# s:   source text
-# pos: line-start offset of the declaration
-fun write_heading(f: *fs.File, s: *u8, pos: usize) {
-    var i: usize = first_nonspace(s, pos);
-    if (starts_with(s, i, "pub ")) { i = i + 4; }
-    i = first_nonspace(s, i);
-    val e: usize = line_end(s, i);
-    var j: usize = i;
-    for (j < e) {
-        val c: u8 = s[j];
-        if (c == '(' || c == '[' || c == ':' || c == '=' || c == '{' || c == ';') { j = e; cnt; }
-        j = j + 1;
-    }
-    # trim trailing spaces from the captured span.
-    var stop: usize = i;
-    var k: usize = i;
-    for (k < e) {
-        val c: u8 = s[k];
-        if (c == '(' || c == '[' || c == ':' || c == '=' || c == '{' || c == ';') { k = e; cnt; }
-        if (c != ' ' && c != '\t') { stop = k + 1; }
-        k = k + 1;
-    }
-    wr_n(f, ?s[i], stop - i);
 }
 
 # generate: drive the documentation run over a loaded project. writes one page
@@ -360,8 +425,10 @@ fun generate(p: *driver.Project, api_dir: *u8, stats: *DocStats) i64 {
         ret 2;
     }
     var index: fs.File = unwrap_ok[fs.File, str](ir);
-    wr(?index, "# API reference\n\n");
-    wr(?index, "generated by `mach doc` from source doc-comments.\n\n");
+    var iw: writer.Writer;
+    fs.get_writer(?index, ?iw);
+    wr(?iw, "# API reference\n\n");
+    wr(?iw, "generated by `mach doc` from source doc-comments.\n\n");
 
     var mi: u32 = 0;
     for (mi < p.module_len) {
@@ -389,7 +456,7 @@ fun generate(p: *driver.Project, api_dir: *u8, stats: *DocStats) i64 {
         page_path[pl + 2] = 'd';
         page_path[pl + 3] = 0;
 
-        val n: i64 = document_module(?page_path[0], fqn, source);
+        val n: i64 = document_module(?page_path[0], fqn, ?m.a, source);
         if (n < 0) {
             print.eprint("error: failed to write page for ");
             print.eprint(fqn::str);
@@ -399,11 +466,11 @@ fun generate(p: *driver.Project, api_dir: *u8, stats: *DocStats) i64 {
         }
 
         # index entry: a relative link to the module page.
-        wr(?index, "- [");
-        wr(?index, fqn);
-        wr(?index, "](");
-        wr(?index, ?rel[0]);
-        wr(?index, ".md)\n");
+        wr(?iw, "- [");
+        wr(?iw, fqn);
+        wr(?iw, "](");
+        wr(?iw, ?rel[0]);
+        wr(?iw, ".md)\n");
 
         stats.modules = stats.modules + 1;
         stats.entries = stats.entries + n::u32;
@@ -529,3 +596,126 @@ pub fun run(argc: usize, argv: **u8) i64 {
     ret code;
 }
 
+# t_sink: a fixed in-memory capture buffer for the rendering tests.
+# ---
+# buf: destination bytes
+# cap: capacity of buf
+# len: bytes captured so far
+rec t_sink {
+    buf: *u8;
+    cap: usize;
+    len: usize;
+}
+
+# t_sink_write: Writer callback that appends bytes to a t_sink, dropping any
+# overflow past the buffer's capacity.
+# ---
+# ctx: the backing t_sink, as an opaque pointer
+# buf: bytes to append
+# len: number of bytes offered
+# ret: always Ok(len) so write_all completes
+fun t_sink_write(ctx: ptr, buf: *u8, len: usize) Result[usize, str] {
+    val sk: *t_sink = ctx::*t_sink;
+    var i: usize = 0;
+    for (i < len && sk.len < sk.cap) {
+        sk.buf[sk.len] = buf[i];
+        sk.len = sk.len + 1;
+        i = i + 1;
+    }
+    ret ok[usize, str](len);
+}
+
+# t_doc_span: a span covering the whole of `s` from offset 0, for the tests.
+# ---
+# s:   the source string
+# ret: a span over all of `s`
+fun t_doc_span(s: str) token.Span {
+    var sp: token.Span;
+    sp.offset = 0;
+    sp.len    = strutil.str_len(s);
+    ret sp;
+}
+
+# t_render_eq: render `doc` over `source` through write_doc into a buffer and
+# compare the captured bytes to `expect`.
+# ---
+# source: source text the doc span points into
+# doc:    doc-block span to render
+# expect: the exact bytes write_doc should produce
+# ret:    true when the rendered output equals `expect`
+fun t_render_eq(source: str, doc: token.Span, expect: str) bool {
+    var buf: [512]u8;
+    var sk: t_sink;
+    sk.buf = ?buf[0];
+    sk.cap = 512;
+    sk.len = 0;
+
+    val skp: *t_sink = ?sk;
+    var w: writer.Writer;
+    w.ctx      = skp::ptr;
+    w.fn_write = t_sink_write;
+
+    write_doc(?w, source, doc);
+
+    if (sk.len != strutil.str_len(expect)) { ret false; }
+    val e: *u8 = expect::*u8;
+    var i: usize = 0;
+    for (i < sk.len) {
+        if (buf[i] != e[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# t_at: true when the bytes of `source` at `off` begin with the literal `lit`.
+# ---
+# source: source text
+# off:    offset to test
+# lit:    expected literal
+# ret:    true on a prefix match
+fun t_at(source: str, off: usize, lit: str) bool {
+    ret strutil.str_region_equals(source, off, strutil.str_len(lit), lit);
+}
+
+test "doc cmd: render summary then components from a first-class doc span" {
+    val source: str = "# sum two integers\n# ---\n# a: first addend\n# b: second addend\n# ret: the sum";
+    if (!t_render_eq(source, t_doc_span(source),
+        "sum two integers\n\na: first addend\nb: second addend\nret: the sum\n\n")) { ret 1; }
+    ret 0;
+}
+
+test "doc cmd: a summary-only doc renders just the summary" {
+    val source: str = "# yield the CPU to other threads";
+    if (!t_render_eq(source, t_doc_span(source), "yield the CPU to other threads\n\n")) { ret 1; }
+    ret 0;
+}
+
+test "doc cmd: an empty doc span renders nothing" {
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 0;
+    if (!t_render_eq("", doc, "")) { ret 1; }
+    ret 0;
+}
+
+test "doc cmd: a wrapped component description drops its continuation '#'" {
+    val source: str = "# wrapped\n# ---\n# a: long line\n#    wraps here\n# b: short";
+    if (!t_render_eq(source, t_doc_span(source),
+        "wrapped\n\na: long line\n   wraps here\nb: short\n\n")) { ret 1; }
+    ret 0;
+}
+
+test "doc cmd: skip_decorators advances past #[...] to the declaration keyword" {
+    val own: str = "#[symbol(\"_start\")]\npub fun entry() i64 { ret 0; }";
+    if (!t_at(own, skip_decorators(own::*u8, 0), "pub fun")) { ret 1; }
+
+    val inl: str = "#[inline] pub fun g() {}";
+    if (!t_at(inl, skip_decorators(inl::*u8, 0), "pub fun")) { ret 1; }
+
+    val many: str = "#[a] #[b(1)]\nrec R { x: u8; }";
+    if (!t_at(many, skip_decorators(many::*u8, 0), "rec R")) { ret 1; }
+
+    val none: str = "pub val X: i64 = 0;";
+    if (skip_decorators(none::*u8, 0) != 0) { ret 1; }
+    ret 0;
+}


### PR DESCRIPTION
Patch: `mach doc` reads first-class documentation (Decl.doc + fe.doc), sharing one doc source with the lint and LSP hover; no more #[attr] leakage. Closes #1573.