### PR TITLE
feat(driver): cache parsed ASTs across builds (incremental parse cache)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -265,7 +265,7 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
         if (is_err[sema.SemaDeps, str](deps_r)) { ret err[bool, str](unwrap_err[sema.SemaDeps, str](deps_r)); }
         var deps: sema.SemaDeps = unwrap_ok[sema.SemaDeps, str](deps_r);
 
-        val sema_r: Result[sema.SemaResult, str] = sema.sema(p.s, ?m.a, ?m.resolve_result, ?deps, ?m.ctx, mid);
+        val sema_r: Result[sema.SemaResult, str] = sema.sema(p.s, m.a, ?m.resolve_result, ?deps, ?m.ctx, mid);
         free_sema_deps(p.s.alloc, ?deps);
         if (is_err[sema.SemaResult, str](sema_r)) { ret err[bool, str](unwrap_err[sema.SemaResult, str](sema_r)); }
         results[mid::u32] = unwrap_ok[sema.SemaResult, str](sema_r);
@@ -300,7 +300,7 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
 
         if (verbose) { emit_stage(p, "lower", m.fqn); }
 
-        val lower_r: Result[ir.Module, str] = lower.lower_module(p.s, ?p.target, ?m.a, m.fqn, mid, ?results[mid::u32], ?m.resolve_result, ?m.ctx);
+        val lower_r: Result[ir.Module, str] = lower.lower_module(p.s, ?p.target, m.a, m.fqn, mid, ?results[mid::u32], ?m.resolve_result, ?m.ctx);
         if (is_err[ir.Module, str](lower_r)) { ret err[bool, str](unwrap_err[ir.Module, str](lower_r)); }
         irs[mid::u32]     = unwrap_ok[ir.Module, str](lower_r);
         ir_ready[mid::u32] = true;

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -456,7 +456,7 @@ fun generate(p: *driver.Project, api_dir: *u8, stats: *DocStats) i64 {
         page_path[pl + 2] = 'd';
         page_path[pl + 3] = 0;
 
-        val n: i64 = document_module(?page_path[0], fqn, ?m.a, source);
+        val n: i64 = document_module(?page_path[0], fqn, m.a, source);
         if (n < 0) {
             print.eprint("error: failed to write page for ");
             print.eprint(fqn::str);

--- a/src/lang/astcache.mach
+++ b/src/lang/astcache.mach
@@ -1,0 +1,224 @@
+# mach.lang.astcache: session-owned cache of parsed ASTs, keyed by source FileId.
+#
+# the first slice of incremental rebuild (#1164): a long-lived Session reuses the
+# AST of a module whose source is unchanged across builds instead of re-lexing and
+# re-parsing it. each entry owns one `ast.Ast` and records the `source` revision it
+# was parsed at; a lookup at the same revision is a hit, a lookup at a newer
+# revision (a real edit bumped it) is a miss that store replaces. the cache lives
+# on the Session, survives `driver.dnit_project`, and is freed only in
+# `session.dnit` — so the cached ASTs (which reference the session interner's
+# StrIds and a stable FileId) stay valid for as long as their source is unchanged.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
+
+use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.deallocate;
+use std.allocator.reallocate;
+use page: std.allocator.page;
+
+use src:   mach.lang.source;
+use query: mach.lang.query;
+use ast:   mach.lang.fe.ast;
+
+# AstEntry: one cached AST for a source file.
+# ---
+# file_id:  FileId the AST was parsed from; the cache key
+# revision: source revision the AST was parsed at (SourceFile.revision)
+# a:        owned heap AST; freed by the cache on replacement or dnit
+pub rec AstEntry {
+    file_id:  src.FileId;
+    revision: query.Revision;
+    a:        *ast.Ast;
+}
+
+# AstCache: a FileId-keyed registry of owned parsed ASTs on the Session.
+# ---
+# alloc:   allocator backing the entry array and every owned AST
+# entries: contiguous AstEntry array
+# len:     number of entries currently stored
+# cap:     allocated slots in entries
+# hits:    cumulative lookups served from the cache (observability + reuse tests)
+# misses:  cumulative lookups that missed (absent or stale)
+pub rec AstCache {
+    alloc:   *Allocator;
+    entries: *AstEntry;
+    len:     u32;
+    cap:     u32;
+    hits:    u64;
+    misses:  u64;
+}
+
+val INITIAL_CACHE_CAP: u32 = 16;
+
+# init: construct an empty AST cache backed by the given allocator.
+# ---
+# alloc: allocator used for the entry array and every owned AST
+# ret:   a new empty AstCache
+pub fun init(alloc: *Allocator) AstCache {
+    var c: AstCache;
+    c.alloc   = alloc;
+    c.entries = nil;
+    c.len     = 0;
+    c.cap     = 0;
+    c.hits    = 0;
+    c.misses  = 0;
+    ret c;
+}
+
+# dnit: free every owned AST and the entry array, then zero the cache. nil is a no-op.
+# ---
+# c: the cache to tear down
+pub fun dnit(c: *AstCache) {
+    if (c == nil) { ret; }
+    var i: u32 = 0;
+    for (i < c.len) {
+        val e: *AstEntry = ?c.entries[i];
+        free_ast(c, e.a);
+        i = i + 1;
+    }
+    if (c.entries != nil && c.cap > 0) {
+        deallocate[AstEntry](c.alloc, c.entries, c.cap::usize);
+    }
+    c.entries = nil;
+    c.len     = 0;
+    c.cap     = 0;
+}
+
+# lookup: the cached AST for `fid` parsed at `rev`, or nil on a miss. an entry
+# present at a different revision (a stale parse a later edit superseded) is left
+# in place for store to replace and counts as a miss. updates hits/misses.
+# ---
+# c:   the cache
+# fid: FileId to look up
+# rev: source revision the caller requires the AST to have been parsed at
+# ret: borrowed pointer to the cached AST on a hit, or nil on a miss
+pub fun lookup(c: *AstCache, fid: src.FileId, rev: query.Revision) *ast.Ast {
+    val e: *AstEntry = find(c, fid);
+    if (e != nil && e.revision == rev) {
+        c.hits = c.hits + 1;
+        ret e.a;
+    }
+    c.misses = c.misses + 1;
+    ret nil;
+}
+
+# store: take ownership of `a` as the cached AST for `fid` at `rev`. an existing
+# entry for `fid` (a stale AST from a superseded revision) is freed and replaced;
+# a new FileId appends, growing the entry array on demand. the cache owns `a` from
+# here and frees it on a later replacement or in dnit.
+# ---
+# c:   the cache
+# fid: FileId the AST was parsed from
+# rev: source revision the AST was parsed at
+# a:   heap AST whose ownership transfers into the cache
+# ret: true on success, or an allocation error from growing the entry array
+pub fun store(c: *AstCache, fid: src.FileId, rev: query.Revision, a: *ast.Ast) Result[bool, str] {
+    val existing: *AstEntry = find(c, fid);
+    if (existing != nil) {
+        free_ast(c, existing.a);
+        existing.a        = a;
+        existing.revision = rev;
+        ret ok[bool, str](true);
+    }
+
+    if (c.entries == nil) {
+        val r: Result[*AstEntry, str] = allocate[AstEntry](c.alloc, INITIAL_CACHE_CAP::usize);
+        if (is_err[*AstEntry, str](r)) { ret err[bool, str](unwrap_err[*AstEntry, str](r)); }
+        c.entries = unwrap_ok[*AstEntry, str](r);
+        c.cap     = INITIAL_CACHE_CAP;
+    }
+    or (c.len == c.cap) {
+        val new_cap: u32 = c.cap * 2;
+        val r: Result[*AstEntry, str] = reallocate[AstEntry](c.alloc, c.entries, c.cap::usize, new_cap::usize);
+        if (is_err[*AstEntry, str](r)) { ret err[bool, str](unwrap_err[*AstEntry, str](r)); }
+        c.entries = unwrap_ok[*AstEntry, str](r);
+        c.cap     = new_cap;
+    }
+
+    val e: *AstEntry = ?c.entries[c.len];
+    e.file_id  = fid;
+    e.revision = rev;
+    e.a        = a;
+    c.len = c.len + 1;
+    ret ok[bool, str](true);
+}
+
+# find: the entry for `fid`, or nil when absent. linear scan; the per-build module
+# count is small, so a flat array beats a map's overhead.
+fun find(c: *AstCache, fid: src.FileId) *AstEntry {
+    var i: u32 = 0;
+    for (i < c.len) {
+        val e: *AstEntry = ?c.entries[i];
+        if (e.file_id == fid) { ret e; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# free_ast: tear down an owned AST and free its heap struct. nil is a no-op.
+fun free_ast(c: *AstCache, a: *ast.Ast) {
+    if (a == nil) { ret; }
+    ast.dnit(a);
+    deallocate[ast.Ast](c.alloc, a, 1::usize);
+}
+
+# t_make: allocate and init a fresh empty heap AST for cache tests, or nil on OOM.
+fun t_make(alloc: *Allocator, fid: src.FileId) *ast.Ast {
+    val r: Result[*ast.Ast, str] = allocate[ast.Ast](alloc, 1::usize);
+    if (is_err[*ast.Ast, str](r)) { ret nil; }
+    val a: *ast.Ast = unwrap_ok[*ast.Ast, str](r);
+    a[0] = ast.init(alloc, fid);
+    ret a;
+}
+
+test "astcache: hit on matching revision, miss on stale, replace frees and reuses the slot (#1576)" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var c: AstCache = init(?alloc);
+
+    val a1: *ast.Ast = t_make(?alloc, 0);
+    if (a1 == nil) { dnit(?c); ret 1; }
+    if (is_err[bool, str](store(?c, 0, 1, a1))) { dnit(?c); ret 1; }
+
+    # a hit at the parsed revision returns the same pointer and bumps hits.
+    if (lookup(?c, 0, 1) != a1) { dnit(?c); ret 1; }
+    if (c.hits != 1) { dnit(?c); ret 1; }
+
+    # a newer revision (a real edit) misses without disturbing the entry.
+    if (lookup(?c, 0, 2) != nil) { dnit(?c); ret 1; }
+    if (c.misses != 1) { dnit(?c); ret 1; }
+
+    # an unknown FileId misses.
+    if (lookup(?c, 9, 1) != nil) { dnit(?c); ret 1; }
+    if (c.misses != 2) { dnit(?c); ret 1; }
+
+    # storing a fresh AST at the new revision replaces in place (frees a1), reusing
+    # the slot rather than appending.
+    val a2: *ast.Ast = t_make(?alloc, 0);
+    if (a2 == nil) { dnit(?c); ret 1; }
+    if (is_err[bool, str](store(?c, 0, 2, a2))) { dnit(?c); ret 1; }
+    if (c.len != 1) { dnit(?c); ret 1; }
+    if (lookup(?c, 0, 2) != a2) { dnit(?c); ret 1; }
+    if (lookup(?c, 0, 1) != nil) { dnit(?c); ret 1; }
+
+    # a distinct FileId appends a new entry.
+    val a3: *ast.Ast = t_make(?alloc, 1);
+    if (a3 == nil) { dnit(?c); ret 1; }
+    if (is_err[bool, str](store(?c, 1, 5, a3))) { dnit(?c); ret 1; }
+    if (c.len != 2) { dnit(?c); ret 1; }
+    if (lookup(?c, 1, 5) != a3) { dnit(?c); ret 1; }
+
+    # dnit frees a2 and a3; a1 was already freed by the replace (no double-free).
+    dnit(?c);
+    ret 0;
+}

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -58,6 +58,7 @@ use src:    mach.lang.source;
 use diag:   mach.lang.diagnostic;
 use intern: mach.lang.intern;
 use sess:   mach.lang.session;
+use astcache: mach.lang.astcache;
 
 use lexer:  mach.lang.fe.lexer;
 use parser: mach.lang.fe.parser;
@@ -220,7 +221,7 @@ pub rec PubConst {
 # ---
 # fqn:            interned fully-qualified module path (e.g. "std.types.bool")
 # file_id:        FileId of the module's source in session.sources
-# a:              parsed AST (owned by the entry; freed by Project.dnit)
+# a:              borrowed parsed AST, owned by the session AST cache (keyed by file_id); nil until parse_module sets it. NOT freed by dnit_project — the cache owns it and reuses it across rebuilds of an unchanged file (#1164)
 # ctx:            comptime context populated during DFS load: target params,
 #                 imports' pub consts, and this-module's pub comptime vals
 # pub_consts:     snapshot of comptime vals declared `pub` in this module
@@ -230,7 +231,7 @@ pub rec PubConst {
 pub rec ModuleEntry {
     fqn:               intern.StrId;
     file_id:           src.FileId;
-    a:                 ast.Ast;
+    a:                 *ast.Ast;
     ctx:               comptime.ComptimeCtx;
     pub_consts:        *PubConst;
     pub_const_count:   u32;
@@ -709,7 +710,7 @@ fun register_export_names(p: *Project) Result[bool, str] {
 
 fun register_module_export_names(p: *Project, mid: sess.ModuleId) Result[bool, str] {
     val m: *ModuleEntry = ?p.modules[mid::u32];
-    val m_opt: Option[*module.Module] = ast.get_module(?m.a, m.a.root_module);
+    val m_opt: Option[*module.Module] = ast.get_module(m.a, m.a.root_module);
     if (is_none[*module.Module](m_opt)) { ret ok[bool, str](true); }
     val mod_node: *module.Module = unwrap[*module.Module](m_opt);
 
@@ -730,7 +731,7 @@ fun register_import_libraries(p: *Project) Result[bool, str] {
     var i: u32 = 0;
     for (i < p.module_len) {
         val m: *ModuleEntry = ?p.modules[i];
-        val m_opt: Option[*module.Module] = ast.get_module(?m.a, m.a.root_module);
+        val m_opt: Option[*module.Module] = ast.get_module(m.a, m.a.root_module);
         if (is_some[*module.Module](m_opt)) {
             val mod_node: *module.Module = unwrap[*module.Module](m_opt);
             val r: Result[bool, str] = bind_import_libraries(p, i::sess.ModuleId, mod_node.decls_start, mod_node.decls_len);
@@ -752,7 +753,7 @@ fun bind_import_libraries(p: *Project, mid: sess.ModuleId, start: u32, len: u32)
     var i: u32 = 0;
     for (i < len) {
         val did: id.DeclId = m.a.decl_ids[start + i];
-        val d_opt: Option[*decl.Decl] = ast.get_decl(?m.a, did);
+        val d_opt: Option[*decl.Decl] = ast.get_decl(m.a, did);
         if (is_some[*decl.Decl](d_opt)) {
             val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
             if (d.kind == decl.DECL_KIND_FUN && (d.flags & decl.DECL_FLAG_EXT) != 0) {
@@ -794,7 +795,7 @@ fun scan_export_directives(p: *Project, mid: sess.ModuleId, source: str, start: 
     var i: u32 = 0;
     for (i < len) {
         val did: id.DeclId = m.a.decl_ids[start + i];
-        val d_opt: Option[*decl.Decl] = ast.get_decl(?m.a, did);
+        val d_opt: Option[*decl.Decl] = ast.get_decl(m.a, did);
         if (is_some[*decl.Decl](d_opt)) {
             val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
             if (d.kind == decl.DECL_KIND_FUN && (d.flags & decl.DECL_FLAG_EXT) != 0) {
@@ -843,7 +844,7 @@ fun register_decl_decorators(p: *Project, mid: sess.ModuleId, source: str, d: *d
 
         if ((is_symbol || is_library) && dec.args_len == 1::u32) {
             val eid: id.ExprId = m.a.expr_ids[dec.args_start];
-            val ve_opt: Option[*expr.Expr] = ast.get_expr(?m.a, eid);
+            val ve_opt: Option[*expr.Expr] = ast.get_expr(m.a, eid);
             if (is_some[*expr.Expr](ve_opt)) {
                 val ve: *expr.Expr = unwrap[*expr.Expr](ve_opt);
                 if (ve.kind == expr.EXPR_KIND_LIT_STR && ve.span.len >= 2::usize) {
@@ -906,9 +907,11 @@ fun span_eq_str(source: str, span: token.Span, s: str) bool {
 # the same closure reuses FileIds instead of growing the SourceMap, and this call's
 # reset_module_registry drops the borrowed AST/sema/resolve/comptime references the
 # freed Project leaves behind — so memory stays bounded and the session stays clean
-# across rebuilds. this does NOT reuse untouched ASTs/resolve results across builds
-# (true incremental rebuild is tracked separately in #1164); each reload re-parses
-# and re-resolves the full closure.
+# across rebuilds. parsed ASTs ARE reused across builds: each `ModuleEntry.a` is
+# borrowed from the session AST cache, which this teardown leaves intact, so an
+# unchanged module's AST survives to the next build (the first slice of incremental
+# rebuild, #1164). resolve results are NOT reused — each reload re-resolves the full
+# closure (resolve-level incremental is a separate, larger effort).
 # ---
 # p: project to tear down; nil is a no-op
 pub fun dnit_project(p: *Project) {
@@ -920,7 +923,8 @@ pub fun dnit_project(p: *Project) {
             resolve.dnit_result(?m.resolve_result);
         }
         comptime.dnit(?m.ctx);
-        ast.dnit(?m.a);
+        # m.a is BORROWED from the session AST cache (parse_module), which owns and
+        # frees it (and reuses it across rebuilds). do NOT free it here.
         if (m.pub_consts != nil && m.pub_const_cap > 0) {
             deallocate[PubConst](p.s.alloc, m.pub_consts, m.pub_const_cap::usize);
         }
@@ -1937,9 +1941,9 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) Result[sess.ModuleId, s
     var m: ModuleEntry;
     m.fqn               = fqn;
     m.file_id           = 0;
-    # initialise an empty Ast up front so the entry is always teardown-safe,
-    # even if parsing never runs (parse_module overwrites it with the real one)
-    m.a                 = ast.init(p.s.alloc, 0);
+    # the AST is borrowed from the session cache; nil until parse_module sets it.
+    # teardown never frees m.a, so a never-parsed entry needs no placeholder AST.
+    m.a                 = nil;
     # resolve the active optimization mode for `$mach.build.mode`: an explicit CLI
     # `-O*`/`--release` flag wins, else the selected target's manifest opt, else
     # debug — mirroring cmd.build.resolve_opt_level so the gate matches the pipeline.
@@ -2148,26 +2152,67 @@ fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool
     if (is_none[*src.SourceFile](file_opt)) { ret err[bool, str]("registered FileId not found in SourceMap"); }
     val file: *src.SourceFile = unwrap[*src.SourceFile](file_opt);
 
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    m.file_id = file_id;
+
+    # incremental parse cache (#1164): an unchanged file across rebuilds keeps its
+    # source revision (source.update's identical-text cutoff), so a cache entry at
+    # that revision is a hit — borrow the cached AST and skip tokenize + parse. the
+    # cache owns the AST; m.a only borrows it (dnit_project never frees it).
+    val cached: *ast.Ast = astcache.lookup(?p.s.ast_cache, file_id, file.revision);
+    if (cached != nil) {
+        m.a = cached;
+        ret ok[bool, str](true);
+    }
+
     emit_stage(p, "lex", fqn);
     val tok_r: Result[lexer.TokenStream, str] = lexer.tokenize(file.text, p.s.alloc, file_id);
     if (is_err[lexer.TokenStream, str](tok_r)) { ret err[bool, str](unwrap_err[lexer.TokenStream, str](tok_r)); }
     var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tok_r);
 
-    val m: *ModuleEntry = ?p.modules[mid::u32];
-    m.file_id = file_id;
-    m.a       = ast.init(p.s.alloc, file_id);
+    # allocate the heap AST the cache will own; parse writes into it. on any failure
+    # before it is published to the cache, free it here (it is owned by nobody yet).
+    val ar: Result[*ast.Ast, str] = allocate[ast.Ast](p.s.alloc, 1::usize);
+    if (is_err[*ast.Ast, str](ar)) {
+        lexer.dnit(?stream, p.s.alloc);
+        ret err[bool, str](unwrap_err[*ast.Ast, str](ar));
+    }
+    val a: *ast.Ast = unwrap_ok[*ast.Ast, str](ar);
+    a[0] = ast.init(p.s.alloc, file_id);
+
     val le_r: Result[bool, str] = lexer.emit_diagnostics(?stream, ?p.s.diags);
     if (is_err[bool, str](le_r)) {
+        free_uncached_ast(p, a);
         lexer.dnit(?stream, p.s.alloc);
         ret err[bool, str](unwrap_err[bool, str](le_r));
     }
     emit_stage(p, "parse", fqn);
-    val fatal: bool = parser.parse(?stream, ?m.a, ?p.s.diags);
+    val fatal: bool = parser.parse(?stream, a, ?p.s.diags);
     lexer.dnit(?stream, p.s.alloc);
     # a fatal allocation failure leaves the AST incomplete; refuse to walk it
     # (the parser already emitted the OOM diagnostic onto the sink).
-    if (fatal) { ret err[bool, str]("out of memory while parsing module"); }
+    if (fatal) {
+        free_uncached_ast(p, a);
+        ret err[bool, str]("out of memory while parsing module");
+    }
+
+    # publish into the cache, which takes ownership and frees any stale entry for
+    # this FileId from a prior, now-superseded revision. m.a then borrows it.
+    val store_r: Result[bool, str] = astcache.store(?p.s.ast_cache, file_id, file.revision, a);
+    if (is_err[bool, str](store_r)) {
+        free_uncached_ast(p, a);
+        ret err[bool, str](unwrap_err[bool, str](store_r));
+    }
+    m.a = a;
     ret ok[bool, str](true);
+}
+
+# free_uncached_ast: tear down a freshly-parsed heap AST that never reached the
+# session cache (an error path in parse_module). the cache owns every AST it
+# accepts, so this only fires before the store hands ownership over.
+fun free_uncached_ast(p: *Project, a: *ast.Ast) {
+    ast.dnit(a);
+    deallocate[ast.Ast](p.s.alloc, a, 1::usize);
 }
 
 # walk_module_for_load: walk the module's decls in source order,
@@ -2176,7 +2221,7 @@ fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool
 # val initializers for export.
 fun walk_module_for_load(p: *Project, mid: sess.ModuleId) Result[bool, str] {
     val m: *ModuleEntry = ?p.modules[mid::u32];
-    val m_opt: Option[*module.Module] = ast.get_module(?m.a, m.a.root_module);
+    val m_opt: Option[*module.Module] = ast.get_module(m.a, m.a.root_module);
     if (is_none[*module.Module](m_opt)) { ret err[bool, str]("module root not set on Ast"); }
     val mod_node: *module.Module = unwrap[*module.Module](m_opt);
     ret walk_decl_list_for_load(p, mid, mod_node.decls_start, mod_node.decls_len);
@@ -2195,7 +2240,7 @@ fun walk_decl_list_for_load(p: *Project, mid: sess.ModuleId, start: u32, len: u3
 
 fun walk_one_decl_for_load(p: *Project, mid: sess.ModuleId, did: id.DeclId) Result[bool, str] {
     val m: *ModuleEntry = ?p.modules[mid::u32];
-    val d_opt: Option[*decl.Decl] = ast.get_decl(?m.a, did);
+    val d_opt: Option[*decl.Decl] = ast.get_decl(m.a, did);
     if (is_none[*decl.Decl](d_opt)) { ret err[bool, str]("DeclId out of range during walk"); }
     val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
 
@@ -2247,8 +2292,8 @@ fun walk_comptime_if_for_load(p: *Project, mid: sess.ModuleId, ci: *decl.DeclCom
 fun comptime_branch_active_load(p: *Project, mid: sess.ModuleId, br: *decl.ComptimeBranch, source: str, emit_diag: bool) Result[bool, str] {
     if (br.cond == id.EXPR_NIL) { ret ok[bool, str](true); }
     val m: *ModuleEntry = ?p.modules[mid::u32];
-    val r: Result[comptime.CTValue, str] = comptime.eval(?m.ctx, ?m.a, source, br.cond, ?p.s.interner);
-    val e_opt: Option[*expr.Expr] = ast.get_expr(?m.a, br.cond);
+    val r: Result[comptime.CTValue, str] = comptime.eval(?m.ctx, m.a, source, br.cond, ?p.s.interner);
+    val e_opt: Option[*expr.Expr] = ast.get_expr(m.a, br.cond);
     if (is_none[*expr.Expr](e_opt)) { ret err[bool, str]("comptime branch cond ExprId out of range"); }
     val cond_span: token.Span = unwrap[*expr.Expr](e_opt).span;
     if (is_err[comptime.CTValue, str](r)) {
@@ -2675,7 +2720,7 @@ fun register_val_for_load(p: *Project, mid: sess.ModuleId, d: *decl.Decl, _did: 
     # evaluation errors "identifier is not a comptime constant in scope" if the
     # name was never registered. do not promote this skip to a hard
     # definition-site error.
-    val r_val: Result[comptime.CTValue, str] = comptime.eval(?m.ctx, ?m.a, source, d.data.bind.init, ?p.s.interner);
+    val r_val: Result[comptime.CTValue, str] = comptime.eval(?m.ctx, m.a, source, d.data.bind.init, ?p.s.interner);
     if (is_err[comptime.CTValue, str](r_val)) { ret ok[bool, str](true); }
     val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](r_val);
 
@@ -2741,7 +2786,7 @@ fun register_module_asts(p: *Project) Result[bool, str] {
     var i: u32 = 0;
     for (i < p.module_len) {
         val m: *ModuleEntry = ?p.modules[i];
-        val r: Result[bool, str] = sess.register_module_ast(p.s, i, ?m.a);
+        val r: Result[bool, str] = sess.register_module_ast(p.s, i, m.a);
         if (is_err[bool, str](r)) { ret r; }
         val rf: Result[bool, str] = sess.register_module_fqn(p.s, i, m.fqn);
         if (is_err[bool, str](rf)) { ret rf; }
@@ -2794,7 +2839,7 @@ fun run_resolve_one(p: *Project, mid: sess.ModuleId, visited: *bool, list: *sess
     if (is_err[resolve.ResolveDeps, str](deps_r)) { ret err[bool, str](unwrap_err[resolve.ResolveDeps, str](deps_r)); }
     var deps: resolve.ResolveDeps = unwrap_ok[resolve.ResolveDeps, str](deps_r);
 
-    val rr_r: Result[resolve.ResolveResult, str] = resolve.resolve(p.s, ?m.a, ?deps, ?m.ctx, mid);
+    val rr_r: Result[resolve.ResolveResult, str] = resolve.resolve(p.s, m.a, ?deps, ?m.ctx, mid);
     free_resolve_deps(p.s.alloc, ?deps);
     if (is_err[resolve.ResolveResult, str](rr_r)) { ret err[bool, str](unwrap_err[resolve.ResolveResult, str](rr_r)); }
 
@@ -3627,6 +3672,73 @@ test "driver reload: a Session rebuilds after dnit_project, deduping changed sou
     if (len2 != len1) { bad = 1; }
 
     dnit_project(?p2);
+    fs.remove_all(?alloc, root);
+    sess.dnit(?s);
+    ret bad;
+}
+
+test "driver incremental: an unchanged rebuild reuses cached ASTs; an edit re-parses only the changed file (#1576)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    val rr: Result[bool, str] = tgt.register_all(?s.registry);
+    if (is_err[bool, str](rr)) { sess.dnit(?s); ret 1; }
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "a.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.a;\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+
+    # one root, three builds on it: the source paths stay identical so each module's
+    # FileId is stable and the session AST cache can hit across builds.
+    val root_r: Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (is_err[str, str](root_r)) { sess.dnit(?s); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    # build 1: a cold cache — every module parses and is stored, none reused.
+    val p1r: Result[Project, str] = build_project_union(?s, root);
+    if (is_err[Project, str](p1r)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+    var p1: Project = unwrap_ok[Project, str](p1r);
+    val n_mods: u32 = s.ast_cache.len;
+    if (n_mods == 0) { bad = 1; }
+    if (s.ast_cache.hits != 0) { bad = 1; }
+    if (s.ast_cache.misses != n_mods::u64) { bad = 1; }
+    dnit_project(?p1);
+
+    # build 2: nothing changed. source.update's identical-text cutoff keeps every
+    # file's revision, so every module is a cache hit — no module re-parses and the
+    # cache neither grows nor records a new miss.
+    val p2r: Result[Project, str] = build_project_union(?s, root);
+    if (is_err[Project, str](p2r)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+    var p2: Project = unwrap_ok[Project, str](p2r);
+    if (s.ast_cache.len != n_mods) { bad = 1; }
+    if (s.ast_cache.hits != n_mods::u64) { bad = 1; }
+    if (s.ast_cache.misses != n_mods::u64) { bad = 1; }
+    dnit_project(?p2);
+
+    # edit a.mach in place (same path → same FileId). its revision bumps, so it is a
+    # cache miss that re-parses and replaces the stale AST; main is unchanged and
+    # still hits. exactly one new miss, one new hit, and no new cache entry.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val a_path: str = ut_cc3(?alloc, src_dir, "/", "a.mach");
+    val new_a: str = "pub fun fa() i32 { ret 2; }\n";
+    val wr: Result[bool, str] = fs.write_file(a_path, new_a, str_len(new_a), 420);
+    if (is_err[bool, str](wr)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+
+    val p3r: Result[Project, str] = build_project_union(?s, root);
+    if (is_err[Project, str](p3r)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
+    var p3: Project = unwrap_ok[Project, str](p3r);
+    if (s.ast_cache.len != n_mods) { bad = 1; }
+    if (s.ast_cache.misses != (n_mods + 1)::u64) { bad = 1; }
+    if (s.ast_cache.hits != (n_mods + n_mods - 1)::u64) { bad = 1; }
+    dnit_project(?p3);
+
     fs.remove_all(?alloc, root);
     sess.dnit(?s);
     ret bad;

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -37,6 +37,7 @@ use query:  mach.lang.query;
 use target: mach.lang.target;
 use modid:  mach.lang.module;
 use ast:    mach.lang.fe.ast;
+use astcache: mach.lang.astcache;
 
 # re-export the project-wide module id so consumers can spell it as
 # `session.ModuleId` / `session.MODULE_NIL`.
@@ -51,6 +52,7 @@ fwd modid.MODULE_NIL;
 # interner: shared string interner used by sema and downstream phases
 # types:    shared type universe used by sema, middle-end, and backend
 # queries:  memoization database holding every input and derived compiler artifact; the public surface every consumer (CLI, LSP, tests) drives the compiler through
+# ast_cache: FileId-keyed cache of parsed ASTs, owning each `ast.Ast` and the source revision it was parsed at; the first slice of incremental rebuild (#1164) — survives a build's dnit_project so a long-lived session reuses an unchanged module's AST instead of re-parsing it, freed only here in session.dnit
 # module_asts: parsed AST of every loaded module, indexed by project-wide ModuleId; populated by the driver after the load pass so any phase can reach a cross-module declaration (e.g. an imported record's fields, or a generic instantiated from a transitive dependency) by ModuleId
 # module_ast_count: number of registered module ASTs (the registry's logical length)
 # module_ast_cap:   allocated capacity of the module-AST registry
@@ -69,6 +71,7 @@ pub rec Session {
     interner: intern.Interner;
     types:    ty.TypeInterner;
     queries:  query.QueryDb;
+    ast_cache:        astcache.AstCache;
     module_asts:      **ast.Ast;
     module_ast_count: u32;
     module_ast_cap:   u32;
@@ -111,6 +114,7 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
     s.sources  = source.init(alloc);
     s.diags    = diag.init(alloc);
     s.interner = intern.init(alloc);
+    s.ast_cache        = astcache.init(alloc);
     s.module_asts      = nil;
     s.module_ast_count = 0;
     s.module_ast_cap   = 0;
@@ -129,6 +133,7 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
 
     val r_types: Result[ty.TypeInterner, str] = ty.init(alloc);
     if (is_err[ty.TypeInterner, str](r_types)) {
+        astcache.dnit(?s.ast_cache);
         intern.dnit(?s.interner);
         diag.dnit(?s.diags);
         source.dnit(?s.sources);
@@ -139,6 +144,7 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
     val r_queries: Result[query.QueryDb, str] = query.init(alloc);
     if (is_err[query.QueryDb, str](r_queries)) {
         ty.dnit(?s.types);
+        astcache.dnit(?s.ast_cache);
         intern.dnit(?s.interner);
         diag.dnit(?s.diags);
         source.dnit(?s.sources);
@@ -150,6 +156,7 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
     if (is_err[bool, str](r_cat)) {
         query.dnit(?s.queries);
         ty.dnit(?s.types);
+        astcache.dnit(?s.ast_cache);
         intern.dnit(?s.interner);
         diag.dnit(?s.diags);
         source.dnit(?s.sources);
@@ -200,6 +207,7 @@ pub fun dnit(s: *Session) {
     map.dnit[modid.ModuleId, ptr](?s.module_comptime);
     query.dnit(?s.queries);
     ty.dnit(?s.types);
+    astcache.dnit(?s.ast_cache);
     intern.dnit(?s.interner);
     diag.dnit(?s.diags);
     source.dnit(?s.sources);

--- a/src/lang/source.mach
+++ b/src/lang/source.mach
@@ -15,6 +15,7 @@ use std.types.option.none;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
+use std.types.string.str_equals;
 use std.text.string.str_dup;
 use std.text.string.str_free;
 use std.types.result.Result;
@@ -213,15 +214,22 @@ pub fun add(m: *SourceMap, db: *query.QueryDb, path: str, text: str) Result[File
 
 # update: replace the text of an already-registered file, rebuilding its
 # newline index and bumping the QueryDb revision so derived entries
-# depending on the file invalidate. used for editor/LSP reloads.
+# depending on the file invalidate. used for editor/LSP reloads. new text equal
+# to the stored text byte-for-byte is an early cutoff: the file (text, line index,
+# revision) is left untouched and the revision does NOT advance, mirroring
+# query.set_input's equality cutoff — so an unchanged file reloaded across rebuilds
+# keeps its revision and revision-keyed derived caches (the session AST cache) hit.
 # ---
 # m:    the source map
-# db:   query database whose revision is bumped on a successful update
+# db:   query database whose revision is bumped on a successful, changing update
 # id:   identifier of the file to replace
 # text: new source text to index and store; the stored copy is null-terminated
-# ret:  true on success, or an allocation error; out-of-range id returns false
+# ret:  true on success (including a no-op identical-text update), or an allocation error; out-of-range id returns false
 pub fun update(m: *SourceMap, db: *query.QueryDb, id: FileId, text: str) Result[bool, str] {
     if (id::usize >= m.len) { ret ok[bool, str](false); }
+
+    # identical text: keep the prior text, line index, and revision (no bump).
+    if (str_equals((?m.files[id]).text, text)) { ret ok[bool, str](true); }
 
     val text_len: usize = str_len(text);
 
@@ -421,6 +429,40 @@ test "source: load dedups by path, reusing the FileId and swapping text in place
     if (fid3 == fid1) { ret 1; }
     if (m.by_path.len != 2) { ret 1; }
     if (m.len != 2) { ret 1; }
+
+    dnit(?m);
+    intern.dnit(?ix);
+    query.dnit(?db);
+    ret 0;
+}
+
+test "source: update early-cutoff keeps the revision on identical text (#1576)" {
+    var a: Allocator;
+    page.make(?a);
+
+    val qr: Result[query.QueryDb, str] = query.init(?a);
+    if (is_err[query.QueryDb, str](qr)) { ret 1; }
+    var db: query.QueryDb = unwrap_ok[query.QueryDb, str](qr);
+    var ix: intern.Interner = intern.init(?a);
+    var m: SourceMap = init(?a);
+
+    # first load establishes the file at some revision r0.
+    val r1: Result[FileId, str] = load(?m, ?db, ?ix, "p.mach", "hello\nworld");
+    if (is_err[FileId, str](r1)) { ret 1; }
+    val fid: FileId = unwrap_ok[FileId, str](r1);
+    val r0: query.Revision = (?m.files[fid::usize]).revision;
+
+    # reloading byte-identical text must NOT advance the file's revision (cutoff),
+    # so a revision-keyed derived cache hits instead of re-deriving.
+    val r2: Result[FileId, str] = load(?m, ?db, ?ix, "p.mach", "hello\nworld");
+    if (is_err[FileId, str](r2)) { ret 1; }
+    if ((?m.files[fid::usize]).revision != r0) { ret 1; }
+
+    # changed text DOES advance the revision and is stored.
+    val r3: Result[FileId, str] = load(?m, ?db, ?ix, "p.mach", "hello\nthere");
+    if (is_err[FileId, str](r3)) { ret 1; }
+    if ((?m.files[fid::usize]).revision == r0) { ret 1; }
+    if ((?m.files[fid::usize]).text[6] != 't') { ret 1; }
 
     dnit(?m);
     intern.dnit(?ix);


### PR DESCRIPTION
Closes #1576. First slice of incremental rebuild (epic #1164): a long-lived `Session` reuses the AST of a module whose source is unchanged across builds instead of re-reading, re-lexing, and re-parsing it.

Scope is **parse-AST caching only**. Out of scope (separate, larger effort): resolve-level incremental — reverse-dep graph, export fingerprinting, cross-build `ModuleId` stability, ctx caching. `mach.lang.query` is not used (its byte-buffer value model doesn't fit ASTs).

## What changed

- **`mach.lang.astcache`** (new): a `FileId`-keyed cache that OWNS one heap `ast.Ast` per file and records the `source` revision it was parsed at. `lookup(fid, rev)` hits only at the matching revision; `store` takes ownership and frees any stale entry for the `FileId`. `hits`/`misses` counters back the reuse tests.
- **`source.update` early-cutoff**: reloading byte-identical text now leaves the file's text, line index, and revision untouched (no bump), mirroring `query.set_input`'s equality cutoff. This is what makes "unchanged file across rebuilds → same revision → cache hit" correct. `add`/first-load unchanged.
- **`session`**: owns the cache (`init`/`dnit`); it is NOT cleared by `reset_module_registry`, so it survives `dnit_project` and persists across rebuilds on one session.
- **`parse_module` guard**: after `load_source`, a cache entry for the `FileId` at the current revision is borrowed (tokenize+parse skipped); otherwise the module is parsed into a fresh heap AST and stored. The load walk still re-runs every build (it rebuilds ctx/deps/pub_consts from the AST without mutating it).
- **Ownership flip**: `ModuleEntry.a` becomes a borrowed `*ast.Ast` into the cache. `register_module_slot` inits it `nil`; `dnit_project` no longer frees it (the cache owns/frees ASTs). Every site that took `?m.a` now passes the borrowed `m.a` (driver walk/resolve/register, `cmd/build` sema+lower, `cmd/doc`).

A real edit bumps the file revision → cache miss → re-parse and replace the stale AST, so no path serves a stale AST after an edit.

## Tests

- `astcache`: hit on matching revision, miss on stale/unknown, replace-frees-and-reuses-slot, append, dnit (no double-free).
- `source`: identical-text reload keeps the revision; changed text bumps it.
- `driver`: builds a project three times on one session — cold build (all miss, stored), unchanged rebuild (all hit, no new entry/miss), edit one file (exactly one new miss + re-parse, the rest still hit). Exercises the full build+rebuild+`dnit_project`+`session.dnit` cycle for free correctness.

## Correctness gate

Self-host Fixpoint must stay green (no double-free / use-after-free). Verified locally: `mach build .` clean and `stage1 == stage2` byte-identical.