### PR TITLE
feat(incremental): query-driven name resolution (Q_RESOLVE)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -265,7 +265,7 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
         if (is_err[sema.SemaDeps, str](deps_r)) { ret err[bool, str](unwrap_err[sema.SemaDeps, str](deps_r)); }
         var deps: sema.SemaDeps = unwrap_ok[sema.SemaDeps, str](deps_r);
 
-        val sema_r: Result[sema.SemaResult, str] = sema.sema(p.s, m.a, ?m.resolve_result, ?deps, ?m.ctx, mid);
+        val sema_r: Result[sema.SemaResult, str] = sema.sema(p.s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
         free_sema_deps(p.s.alloc, ?deps);
         if (is_err[sema.SemaResult, str](sema_r)) { ret err[bool, str](unwrap_err[sema.SemaResult, str](sema_r)); }
         results[mid::u32] = unwrap_ok[sema.SemaResult, str](sema_r);
@@ -276,7 +276,7 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
         # any module) against the typing of its declaring module.
         val rs: Result[bool, str] = sess.register_module_sema(p.s, mid, (?results[mid::u32])::ptr);
         if (is_err[bool, str](rs)) { ret err[bool, str](unwrap_err[bool, str](rs)); }
-        val rr2: Result[bool, str] = sess.register_module_resolve(p.s, mid, (?m.resolve_result)::ptr);
+        val rr2: Result[bool, str] = sess.register_module_resolve(p.s, mid, (m.resolve_result)::ptr);
         if (is_err[bool, str](rr2)) { ret err[bool, str](unwrap_err[bool, str](rr2)); }
         # publish this module's comptime context too, so a value-parameter instance
         # of a function declared here can fold its `$if` gates against this module's
@@ -300,7 +300,7 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
 
         if (verbose) { emit_stage(p, "lower", m.fqn); }
 
-        val lower_r: Result[ir.Module, str] = lower.lower_module(p.s, ?p.target, m.a, m.fqn, mid, ?results[mid::u32], ?m.resolve_result, ?m.ctx);
+        val lower_r: Result[ir.Module, str] = lower.lower_module(p.s, ?p.target, m.a, m.fqn, mid, ?results[mid::u32], m.resolve_result, ?m.ctx);
         if (is_err[ir.Module, str](lower_r)) { ret err[bool, str](unwrap_err[ir.Module, str](lower_r)); }
         irs[mid::u32]     = unwrap_ok[ir.Module, str](lower_r);
         ir_ready[mid::u32] = true;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -4594,3 +4594,81 @@ test "driver incremental: a leaf's pub-surface change re-resolves the importer, 
     sess.dnit(?sA);
     ret bad;
 }
+
+test "driver incremental: a re-exporter propagates a leaf surface change two hops, and the importer equals from-scratch (#1582)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var sA: sess.Session = unwrap_ok[sess.Session, str](sr);
+    if (is_err[bool, str](tgt.register_all(?sA.registry))) { sess.dnit(?sA); ret 1; }
+
+    # main -> mid (re-exports leaf.fa via `fwd`) -> leaf. a pub-surface change to
+    # leaf must propagate THROUGH the re-exporter: leaf re-resolves, mid's Q_EXPORTS
+    # changes (its re-exported fa shifts), and main re-resolves — the re-export case
+    # the syntactic fingerprint missed. a private body edit to leaf must NOT
+    # propagate past mid (transitive firewall).
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "mid.mach"; names[2] = "leaf.mach";
+    var texts: [3]str;
+    texts[0] = "use uniontest.mid;\nfun main() i32 { ret mid.fa(); }\n";
+    texts[1] = "fwd uniontest.leaf.fa;\n";
+    texts[2] = "pub fun fa() i32 { ret 1; }\n";
+
+    val root_r: Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
+    if (is_err[str, str](root_r)) { sess.dnit(?sA); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val leaf_path: str = ut_cc3(?alloc, src_dir, "/", "leaf.mach");
+
+    val pA1r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA1r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA1: Project = unwrap_ok[Project, str](pA1r);
+    val st_main: sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
+    val st_mid:  sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.mid");
+    val lc_main_1: query.Revision = ut_resolve_lc(?sA, st_main);
+    val lc_mid_1:  query.Revision = ut_resolve_lc(?sA, st_mid);
+    dnit_project(?pA1);
+
+    # phase 1 — private body edit to leaf: must NOT propagate to mid or main.
+    val leaf_priv: str = "pub fun fa() i32 { val t: i32 = 1; ret t; }\n";
+    if (is_err[bool, str](fs.write_file(leaf_path, leaf_priv, str_len(leaf_priv), 420))) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val pPr: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pPr)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pP: Project = unwrap_ok[Project, str](pPr);
+    if (ut_resolve_lc(?sA, st_mid)  != lc_mid_1)  { bad = 1; }   # firewall held at mid
+    if (ut_resolve_lc(?sA, st_main) != lc_main_1) { bad = 1; }   # firewall held at main
+    dnit_project(?pP);
+
+    # phase 2 — pub-surface change to leaf: must propagate to mid AND main.
+    val leaf_pub: str = "pub fun fz() i32 { ret 0; }\npub fun fa() i32 { ret 1; }\n";
+    if (is_err[bool, str](fs.write_file(leaf_path, leaf_pub, str_len(leaf_pub), 420))) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val pA2r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA2r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA2: Project = unwrap_ok[Project, str](pA2r);
+    if (ut_resolve_lc(?sA, st_mid)  == lc_mid_1)  { bad = 1; }   # mid re-resolved
+    if (ut_resolve_lc(?sA, st_main) == lc_main_1) { bad = 1; }   # main re-resolved
+
+    # from-scratch build of the final source on a fresh session.
+    val sr2: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr2)) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var sB: sess.Session = unwrap_ok[sess.Session, str](sr2);
+    if (is_err[bool, str](tgt.register_all(?sB.registry))) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val pBr: Result[Project, str] = build_project_union(?sB, root);
+    if (is_err[Project, str](pBr)) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pB: Project = unwrap_ok[Project, str](pBr);
+
+    # importer, re-exporter, and leaf each equal the independent from-scratch build.
+    if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_rr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
+    if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.mid"),  ?sB, ut_rr_of(?pB, ?sB, "uniontest.mid")))  { bad = 1; }
+    if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_rr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
+
+    dnit_project(?pB);
+    sess.dnit(?sB);
+    dnit_project(?pA2);
+    fs.remove_all(?alloc, root);
+    sess.dnit(?sA);
+    ret bad;
+}

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -3068,6 +3068,17 @@ fun run_resolve_one(p: *Project, mid: sess.ModuleId) Result[bool, str] {
     val rr: *resolve.ResolveResult = resolve_handle_decode(unwrap_ok[*query.QueryEntry, str](e_r));
     if (rr == nil) { ret err[bool, str]("Q_RESOLVE produced no result handle"); }
 
+    # refresh this module's export fingerprint NOW, in topo order. the engine's
+    # validator compares a dep's STORED last_changed (it does not recursively
+    # recompute derived deps), so an importer is only invalidated correctly if its
+    # deps' Q_EXPORTS are already refreshed when it is validated. resolving in topo
+    # order and refreshing each module's Q_EXPORTS here guarantees that: every dep's
+    # fingerprint is current before any importer's Q_RESOLVE is revalidated, so the
+    # firewall both holds (private edit: identical bytes, early-cut) and fires
+    # (visible-surface change: bytes differ, importer re-resolves) (#1582).
+    val ex_r: Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_EXPORTS, m.stable_id::u64);
+    if (is_err[*query.QueryEntry, str](ex_r)) { ret err[bool, str](unwrap_err[*query.QueryEntry, str](ex_r)); }
+
     # translate the result's ModuleId-valued fields into THIS build's numbering: a
     # reused result still carries the producing build's mids (#1582). idempotent for
     # a freshly computed result (its mids already match this build).
@@ -4351,5 +4362,235 @@ test "driver incremental: Q_EXPORTS fingerprints the resolved pub surface, firew
     deallocate[u8](?alloc, fp1, len1::usize);
     fs.remove_all(?alloc, root);
     sess.dnit(?s);
+    ret bad;
+}
+
+# ut_resolve_lc: the last_changed revision of module `stable`'s Q_RESOLVE entry on
+# session `s`, or a sentinel when absent. an owned-handle shard never early-cuts, so
+# an unchanged value means the entry was NOT recomputed — the test's reuse probe.
+fun ut_resolve_lc(s: *sess.Session, stable: sess.StableModuleId) query.Revision {
+    val e: Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_RESOLVE, stable::u64);
+    if (is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret unwrap_ok[*query.QueryEntry, str](e).last_changed;
+}
+
+# ut_name_text_equal: whether two name StrIds spell the same text across two
+# sessions. the incremental and from-scratch results live in different interners
+# that number StrIds independently, so a symbol's name is compared by TEXT.
+fun ut_name_text_equal(sa: *sess.Session, na: intern.StrId, sb: *sess.Session, nb: intern.StrId) bool {
+    val oa: Option[str] = intern.lookup(?sa.interner, na);
+    val ob: Option[str] = intern.lookup(?sb.interner, nb);
+    if (is_none[str](oa) && is_none[str](ob)) { ret true; }
+    if (is_none[str](oa) || is_none[str](ob)) { ret false; }
+    val ta: str = unwrap[str](oa);
+    val tb: str = unwrap[str](ob);
+    val la: usize = str_len(ta);
+    if (la != str_len(tb)) { ret false; }
+    ret mem.raw_equal(ta::ptr, tb::ptr, la);
+}
+
+# rr_struct_equal: whether two ResolveResults are structurally identical — the
+# resolution-correctness comparison the incremental tests assert a reused (or
+# remapped) result against an independent from-scratch build. compares the binding
+# OUTPUT (the SymbolId-resolved parallel arrays — what each expr/type/decl binds to)
+# and every symbol's fields. `name` is compared by interned text (cross-session
+# interners differ); origin/slot ModuleIds match numerically because an identical
+# module graph yields an identical discovery order, the same numbering both builds
+# produce (the incremental side after remap_result).
+fun rr_struct_equal(sa: *sess.Session, ra: *resolve.ResolveResult, sb: *sess.Session, rb: *resolve.ResolveResult) bool {
+    if (ra == nil || rb == nil) { ret false; }
+    if (ra.symbol_count != rb.symbol_count) { ret false; }
+    if (ra.pub_count != rb.pub_count) { ret false; }
+    if (ra.expr_count != rb.expr_count) { ret false; }
+    if (ra.type_count != rb.type_count) { ret false; }
+    if (ra.decl_count != rb.decl_count) { ret false; }
+
+    var i: u32 = 0;
+    for (i < ra.expr_count) {
+        if (ra.expr_resolved[i] != rb.expr_resolved[i]) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < ra.type_count) {
+        if (ra.type_resolved[i] != rb.type_resolved[i]) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < ra.decl_count) {
+        if (ra.decl_symbol[i] != rb.decl_symbol[i]) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < ra.symbol_count) {
+        val xa: *resolve.Symbol = ?ra.symbols[i];
+        val xb: *resolve.Symbol = ?rb.symbols[i];
+        if (xa.kind != xb.kind) { ret false; }
+        if (xa.flags != xb.flags) { ret false; }
+        if (xa.decl != xb.decl) { ret false; }
+        if (xa.slot != xb.slot) { ret false; }
+        if (xa.origin != xb.origin) { ret false; }
+        if (!ut_name_text_equal(sa, xa.name, sb, xb.name)) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# ut_rr_of: the borrowed ResolveResult of module `fqn` in project `p`, or nil.
+fun ut_rr_of(p: *Project, s: *sess.Session, fqn: str) *resolve.ResolveResult {
+    val mid: sess.ModuleId = ut_mid(p, s, fqn);
+    if (mid == sess.MODULE_NIL) { ret nil; }
+    ret p.modules[mid::u32].resolve_result;
+}
+
+test "driver incremental: a leaf's private body edit firewalls the importer's resolve, which still equals a from-scratch build (#1582)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var sA: sess.Session = unwrap_ok[sess.Session, str](sr);
+    if (is_err[bool, str](tgt.register_all(?sA.registry))) { sess.dnit(?sA); ret 1; }
+
+    # main imports leaf.fa and calls it; leaf exports fa. editing fa's BODY is a
+    # private change that — with the parser reserving fa's DeclId before its body —
+    # leaves leaf's resolved pub surface byte-identical, so the firewall must hold.
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "leaf.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.leaf.fa;\nfun main() i32 { ret fa(); }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+
+    val root_r: Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (is_err[str, str](root_r)) { sess.dnit(?sA); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    val pA1r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA1r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA1: Project = unwrap_ok[Project, str](pA1r);
+    val st_main: sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
+    val st_leaf: sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.leaf");
+    val lc_main_1: query.Revision = ut_resolve_lc(?sA, st_main);
+    val lc_leaf_1: query.Revision = ut_resolve_lc(?sA, st_leaf);
+    dnit_project(?pA1);
+
+    # private body edit: fa's signature/identity unchanged.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val leaf_path: str = ut_cc3(?alloc, src_dir, "/", "leaf.mach");
+    val leaf_v2: str = "pub fun fa() i32 { val t: i32 = 1; ret t; }\n";
+    if (is_err[bool, str](fs.write_file(leaf_path, leaf_v2, str_len(leaf_v2), 420))) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    val pA2r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA2r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA2: Project = unwrap_ok[Project, str](pA2r);
+    val lc_main_2: query.Revision = ut_resolve_lc(?sA, st_main);
+    val lc_leaf_2: query.Revision = ut_resolve_lc(?sA, st_leaf);
+
+    # firewall: the importer was NOT re-resolved; the edited leaf WAS.
+    if (lc_main_2 != lc_main_1) { bad = 1; }
+    if (lc_leaf_2 == lc_leaf_1) { bad = 1; }
+
+    # from-scratch build of the SAME (v2) source on a fresh session.
+    val sr2: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr2)) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var sB: sess.Session = unwrap_ok[sess.Session, str](sr2);
+    if (is_err[bool, str](tgt.register_all(?sB.registry))) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val pBr: Result[Project, str] = build_project_union(?sB, root);
+    if (is_err[Project, str](pBr)) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pB: Project = unwrap_ok[Project, str](pBr);
+
+    # the reused importer result and the re-resolved leaf result each equal the
+    # independent from-scratch resolution.
+    if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_rr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
+    if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_rr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
+
+    dnit_project(?pB);
+    sess.dnit(?sB);
+    dnit_project(?pA2);
+    fs.remove_all(?alloc, root);
+    sess.dnit(?sA);
+    ret bad;
+}
+
+test "driver incremental: a leaf's pub-surface change re-resolves the importer, which still equals a from-scratch build (#1582)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var sA: sess.Session = unwrap_ok[sess.Session, str](sr);
+    if (is_err[bool, str](tgt.register_all(?sA.registry))) { sess.dnit(?sA); ret 1; }
+
+    # main imports leaf.fa. adding a pub `fz` BEFORE fa shifts fa's DeclId (0 -> 1),
+    # a change the importer's resolution genuinely depends on (resolve.Symbol.decl):
+    # the firewall fingerprint must change, the importer must re-resolve, and its new
+    # result must reflect fa's shifted decl and equal a from-scratch build.
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "leaf.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.leaf.fa;\nfun main() i32 { ret fa(); }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+
+    val root_r: Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (is_err[str, str](root_r)) { sess.dnit(?sA); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    val pA1r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA1r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA1: Project = unwrap_ok[Project, str](pA1r);
+    val st_main: sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
+    val lc_main_1: query.Revision = ut_resolve_lc(?sA, st_main);
+    # fa is the importer's single imported symbol; capture its bound decl id.
+    val rr_main_1: *resolve.ResolveResult = ut_rr_of(?pA1, ?sA, "uniontest.main");
+    var fa_decl_1: u32 = 0xFFFFFFFF;
+    var si: u32 = 0;
+    for (si < rr_main_1.symbol_count) {
+        if (rr_main_1.symbols[si].kind == resolve.SYM_IMPORTED) { fa_decl_1 = rr_main_1.symbols[si].decl::u32; }
+        si = si + 1;
+    }
+    dnit_project(?pA1);
+
+    # pub-surface change: prepend a new pub function, shifting fa's decl id.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val leaf_path: str = ut_cc3(?alloc, src_dir, "/", "leaf.mach");
+    val leaf_v2: str = "pub fun fz() i32 { ret 0; }\npub fun fa() i32 { ret 1; }\n";
+    if (is_err[bool, str](fs.write_file(leaf_path, leaf_v2, str_len(leaf_v2), 420))) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    val pA2r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA2r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA2: Project = unwrap_ok[Project, str](pA2r);
+    val lc_main_2: query.Revision = ut_resolve_lc(?sA, st_main);
+
+    # the importer WAS re-resolved (its dep's visible surface changed) ...
+    if (lc_main_2 == lc_main_1) { bad = 1; }
+    # ... and its binding now reflects fa's shifted decl id.
+    val rr_main_2: *resolve.ResolveResult = ut_rr_of(?pA2, ?sA, "uniontest.main");
+    var fa_decl_2: u32 = 0xFFFFFFFF;
+    si = 0;
+    for (si < rr_main_2.symbol_count) {
+        if (rr_main_2.symbols[si].kind == resolve.SYM_IMPORTED) { fa_decl_2 = rr_main_2.symbols[si].decl::u32; }
+        si = si + 1;
+    }
+    if (fa_decl_2 == fa_decl_1) { bad = 1; }
+
+    # from-scratch build of the SAME (v2) source on a fresh session.
+    val sr2: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr2)) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var sB: sess.Session = unwrap_ok[sess.Session, str](sr2);
+    if (is_err[bool, str](tgt.register_all(?sB.registry))) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val pBr: Result[Project, str] = build_project_union(?sB, root);
+    if (is_err[Project, str](pBr)) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pB: Project = unwrap_ok[Project, str](pBr);
+
+    # the re-resolved importer and leaf each equal the independent from-scratch build.
+    if (!rr_struct_equal(?sA, rr_main_2, ?sB, ut_rr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
+    if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_rr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
+
+    dnit_project(?pB);
+    sess.dnit(?sB);
+    dnit_project(?pA2);
+    fs.remove_all(?alloc, root);
+    sess.dnit(?sA);
     ret bad;
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2374,6 +2374,9 @@ fun q_exports_compute(db: *query.QueryDb, key: u64, alloc: *Allocator) Result[qu
 # pub symbols occupy indices [0, pub_count) in source-deterministic order. each
 # symbol contributes the exact tuple build_module_exports exposes to a dependent
 # resolve (kind, name, decl, origin, slot), with origin/slot in build-stable space.
+# the resolved pub comptime constant VALUES are appended too (rr.pub_const_fp): an
+# importer's resolution forks on them via `$if` over imported consts, but they are
+# not in the symbol identities, so they must enter the firewall fingerprint (#1582).
 fun fp_pub_surface(fb: *FpBuf, rr: *resolve.ResolveResult) Result[bool, str] {
     val pc: Result[bool, str] = fp_u32(fb, rr.pub_count);
     if (is_err[bool, str](pc)) { ret pc; }
@@ -2391,6 +2394,16 @@ fun fp_pub_surface(fb: *FpBuf, rr: *resolve.ResolveResult) Result[bool, str] {
         if (sym.kind == resolve.SYM_USE) { slot_fp = sym.slot_stable::u32; }
         val rs: Result[bool, str] = fp_u32(fb, slot_fp);                if (is_err[bool, str](rs)) { ret rs; }
         i = i + 1;
+    }
+
+    # append the pub comptime constant value fingerprint (length-prefixed).
+    val rl: Result[bool, str] = fp_u32(fb, rr.pub_const_fp_len);
+    if (is_err[bool, str](rl)) { ret rl; }
+    var b: u32 = 0;
+    for (b < rr.pub_const_fp_len) {
+        val rb: Result[bool, str] = fp_u8(fb, rr.pub_const_fp[b]);
+        if (is_err[bool, str](rb)) { ret rb; }
+        b = b + 1;
     }
     ret ok[bool, str](true);
 }
@@ -4585,6 +4598,73 @@ test "driver incremental: a leaf's pub-surface change re-resolves the importer, 
 
     # the re-resolved importer and leaf each equal the independent from-scratch build.
     if (!rr_struct_equal(?sA, rr_main_2, ?sB, ut_rr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
+    if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_rr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
+
+    dnit_project(?pB);
+    sess.dnit(?sB);
+    dnit_project(?pA2);
+    fs.remove_all(?alloc, root);
+    sess.dnit(?sA);
+    ret bad;
+}
+
+test "driver incremental: a dep's pub comptime-const value change re-resolves an importer that forks on it, matching from-scratch (#1582)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var sA: sess.Session = unwrap_ok[sess.Session, str](sr);
+    if (is_err[bool, str](tgt.register_all(?sA.registry))) { sess.dnit(?sA); ret 1; }
+
+    # main imports leaf.FLAG (a pub comptime bool) and forks a `$if` on it — the fork
+    # gates a function declaration, so main's RESOLVED surface depends on FLAG's
+    # VALUE, which lives in the comptime ctx, not in leaf's symbol identities. flipping
+    # FLAG must change leaf's export fingerprint and re-resolve main.
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "leaf.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.leaf.FLAG;\n$if (FLAG) {\n  fun extra() i32 { ret 1; }\n}\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub val FLAG = true;\n";
+
+    val root_r: Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (is_err[str, str](root_r)) { sess.dnit(?sA); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    val pA1r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA1r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA1: Project = unwrap_ok[Project, str](pA1r);
+    val st_main: sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
+    val lc_main_1: query.Revision = ut_resolve_lc(?sA, st_main);
+    val sc_main_1: u32 = ut_rr_of(?pA1, ?sA, "uniontest.main").symbol_count;
+    dnit_project(?pA1);
+
+    # flip the comptime constant: main's `$if (FLAG)` now drops `extra`.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val leaf_path: str = ut_cc3(?alloc, src_dir, "/", "leaf.mach");
+    val leaf_v2: str = "pub val FLAG = false;\n";
+    if (is_err[bool, str](fs.write_file(leaf_path, leaf_v2, str_len(leaf_v2), 420))) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    val pA2r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA2r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA2: Project = unwrap_ok[Project, str](pA2r);
+
+    # main WAS re-resolved (the dep's const value it forks on changed) and its surface
+    # actually changed (the gated `extra` is gone).
+    if (ut_resolve_lc(?sA, st_main) == lc_main_1) { bad = 1; }
+    if (ut_rr_of(?pA2, ?sA, "uniontest.main").symbol_count == sc_main_1) { bad = 1; }
+
+    # from-scratch build of the flipped source on a fresh session.
+    val sr2: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr2)) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var sB: sess.Session = unwrap_ok[sess.Session, str](sr2);
+    if (is_err[bool, str](tgt.register_all(?sB.registry))) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val pBr: Result[Project, str] = build_project_union(?sB, root);
+    if (is_err[Project, str](pBr)) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pB: Project = unwrap_ok[Project, str](pBr);
+
+    if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_rr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
     if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_rr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
 
     dnit_project(?pB);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -228,7 +228,11 @@ pub rec PubConst {
 #                 imports' pub consts, and this-module's pub comptime vals
 # pub_consts:     snapshot of comptime vals declared `pub` in this module
 # deps:           ModuleIds this module directly depends on (active uses only)
-# resolve_result: filled in by run_resolve_pass (zero-initialized otherwise)
+# resolve_result: borrowed pointer to this module's ResolveResult, owned by the
+#                 session query DB as the Q_RESOLVE handle (keyed by stable_id) and
+#                 reused across rebuilds of an unchanged module; set by
+#                 run_resolve_one, nil until then. NOT freed by dnit_project — the
+#                 query DB owns it (its finalizer frees it) (#1582)
 # resolved:       true once resolve has run
 # stable_id:      this module's build-stable identity (session-assigned by FQN);
 #                 unlike the discovery-order ModuleId, it survives a graph reshape,
@@ -244,7 +248,7 @@ pub rec ModuleEntry {
     deps:              *sess.ModuleId;
     dep_count:         u32;
     dep_cap:           u32;
-    resolve_result:    resolve.ResolveResult;
+    resolve_result:    *resolve.ResolveResult;
     resolved:          bool;
     stable_id:         sess.StableModuleId;
 }
@@ -522,6 +526,16 @@ fun build_project_impl(s: *sess.Session, project_root: str, sel: *manifest.Selec
     if (is_err[bool, str](reg_r)) {
         dnit_project(?p);
         ret err[Project, str](unwrap_err[bool, str](reg_r));
+    }
+
+    # mirror the build configuration (target tuple + manifest defines) into the
+    # Q_TARGET input. resolve forks on it through `$if`, so Q_RESOLVE records a dep
+    # on it: a config change advances Q_TARGET's last_changed and re-resolves every
+    # module, while an identical reconfigure early-cuts and keeps reuse valid (#1582).
+    val cfg_in_r: Result[bool, str] = set_build_config_input(?p);
+    if (is_err[bool, str](cfg_in_r)) {
+        dnit_project(?p);
+        ret err[Project, str](unwrap_err[bool, str](cfg_in_r));
     }
 
     val resolve_r: Result[bool, str] = run_resolve_pass(?p);
@@ -924,8 +938,9 @@ fun span_eq_str(source: str, span: token.Span, s: str) bool {
 # across rebuilds. parsed ASTs ARE reused across builds: each `ModuleEntry.a` is
 # borrowed from the session query DB (the Q_PARSE handle), which this teardown
 # leaves intact, so an unchanged module's AST survives to the next build (#1580).
-# resolve results are NOT reused — each reload re-resolves the full closure
-# (resolve-level incremental is a separate, larger effort).
+# resolve results are likewise borrowed from the query DB (the Q_RESOLVE handle)
+# and reused across rebuilds of an unchanged closure; this teardown leaves them
+# intact too (#1582).
 # ---
 # p: project to tear down; nil is a no-op
 pub fun dnit_project(p: *Project) {
@@ -933,9 +948,9 @@ pub fun dnit_project(p: *Project) {
     var i: u32 = 0;
     for (i < p.module_len) {
         val m: *ModuleEntry = ?p.modules[i];
-        if (m.resolved) {
-            resolve.dnit_result(?m.resolve_result);
-        }
+        # m.resolve_result is BORROWED from the session query DB (the Q_RESOLVE
+        # handle), which owns and frees it (and reuses it across rebuilds). do NOT
+        # free it here.
         comptime.dnit(?m.ctx);
         # m.a is BORROWED from the session query DB (the Q_PARSE handle), which owns
         # and frees it (and reuses it across rebuilds). do NOT free it here.
@@ -1988,6 +2003,7 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) Result[sess.ModuleId, s
     m.deps              = nil;
     m.dep_count         = 0;
     m.dep_cap           = 0;
+    m.resolve_result    = nil;
     m.resolved          = false;
     p.modules[p.module_len] = m;
     p.module_len = p.module_len + 1;
@@ -2191,13 +2207,19 @@ fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool
 # register the driver-owned derived kinds the build routes through. set_ctx is
 # refreshed every build (the session address is stable); each kind is registered
 # exactly once per session (registered() guards the idempotent re-call). Q_PARSE
-# carries an opaque AST handle (owned); Q_EXPORTS is a plain byte fingerprint with
-# output early-cutoff — the firewall — so it is a plain derived kind.
+# and Q_RESOLVE carry opaque heap handles (owned); Q_EXPORTS is a plain byte
+# fingerprint with output early-cutoff — the firewall — so it is a plain derived
+# kind. Q_PARSE is keyed by FileId; Q_RESOLVE and Q_EXPORTS by StableModuleId, the
+# cross-build-stable key a reused result remaps through (#1582).
 fun ensure_query_pipeline(s: *sess.Session) Result[bool, str] {
     query.set_ctx(?s.queries, s::ptr);
     if (!query.registered(?s.queries, query.Q_PARSE)) {
         val rp: Result[bool, str] = query.register_derived_owned(?s.queries, query.Q_PARSE, q_parse_compute, q_parse_finalize);
         if (is_err[bool, str](rp)) { ret rp; }
+    }
+    if (!query.registered(?s.queries, query.Q_RESOLVE)) {
+        val rr: Result[bool, str] = query.register_derived_owned(?s.queries, query.Q_RESOLVE, q_resolve_compute, q_resolve_finalize);
+        if (is_err[bool, str](rr)) { ret rr; }
     }
     if (!query.registered(?s.queries, query.Q_EXPORTS)) {
         val re: Result[bool, str] = query.register_derived(?s.queries, query.Q_EXPORTS, q_exports_compute);
@@ -2306,26 +2328,29 @@ fun q_parse_emit_stage(s: *sess.Session, stage: str, path: str) {
 }
 
 # q_exports_compute: the Q_EXPORTS derived compute — a deterministic byte
-# fingerprint of one module's public surface (#1581). reaches the module's parsed
-# AST through db.ctx and records the Q_PARSE dep, so any re-parse re-runs this;
-# but the fingerprint covers only each pub decl's kind, name, and signature shape
-# (a function body is excluded), so a private-only edit reproduces identical
-# bytes and the engine's output early-cutoff firewalls importers. a plain
-# byte-valued derived kind (early-cutoff ON), not an owned handle.
+# fingerprint of one module's RESOLVED public surface (#1581/#1582). reads the
+# module's ResolveResult through Q_RESOLVE (recording the dep) and fingerprints
+# exactly what an importer's resolution binds against: per pub symbol, its kind,
+# name, originating DeclId, build-stable origin, and (for a `fwd`/`use` module
+# re-export) the build-stable target the alias names. this is the surface
+# build_module_exports hands a dependent resolve, so the fingerprint changes iff a
+# dependent's resolution could change — including a re-exported dep whose own kind
+# shifted without this module's text changing (the syntactic fingerprint missed
+# that). a private-only edit re-runs Q_RESOLVE but leaves the pub surface identical,
+# so this reproduces identical bytes and the engine's output early-cutoff firewalls
+# importers. build-stable ids (not per-build ModuleIds) keep the bytes reshape-
+# stable. a plain byte-valued derived kind (early-cutoff ON), keyed by StableModuleId.
 fun q_exports_compute(db: *query.QueryDb, key: u64, alloc: *Allocator) Result[query.QueryOutput, str] {
     val s: *sess.Session = db.ctx::*sess.Session;
     if (s == nil) { ret err[query.QueryOutput, str]("Q_EXPORTS: query db has no session context"); }
-    val mid: sess.ModuleId = key::u32;
 
-    val a: *ast.Ast = sess.module_ast(s, mid);
-    if (a == nil) { ret err[query.QueryOutput, str]("Q_EXPORTS: module has no registered AST"); }
+    val e_r: Result[*query.QueryEntry, str] = query.get(db, query.Q_RESOLVE, key);
+    if (is_err[*query.QueryEntry, str](e_r)) { ret err[query.QueryOutput, str](unwrap_err[*query.QueryEntry, str](e_r)); }
+    val rr: *resolve.ResolveResult = resolve_handle_decode(unwrap_ok[*query.QueryEntry, str](e_r));
+    if (rr == nil) { ret err[query.QueryOutput, str]("Q_EXPORTS: module has no resolve result"); }
 
-    val rd: Result[bool, str] = query.record_dep(db, query.Q_EXPORTS, key, query.Q_PARSE, a.file_id::u64);
+    val rd: Result[bool, str] = query.record_dep(db, query.Q_EXPORTS, key, query.Q_RESOLVE, key);
     if (is_err[bool, str](rd)) { ret err[query.QueryOutput, str](unwrap_err[bool, str](rd)); }
-
-    val src_opt: Option[*src.SourceFile] = src.get(?s.sources, a.file_id);
-    if (is_none[*src.SourceFile](src_opt)) { ret err[query.QueryOutput, str]("Q_EXPORTS: FileId not registered with the session"); }
-    val source: str = unwrap[*src.SourceFile](src_opt).text;
 
     var fb: FpBuf;
     fb.alloc = alloc;
@@ -2333,20 +2358,41 @@ fun q_exports_compute(db: *query.QueryDb, key: u64, alloc: *Allocator) Result[qu
     fb.len   = 0;
     fb.cap   = 0;
 
-    val m_opt: Option[*module.Module] = ast.get_module(a, a.root_module);
-    if (is_some[*module.Module](m_opt)) {
-        val mnode: *module.Module = unwrap[*module.Module](m_opt);
-        val wr: Result[bool, str] = fp_walk_decls(?fb, a, source, mnode.decls_start, mnode.decls_len);
-        if (is_err[bool, str](wr)) {
-            if (fb.buf != nil && fb.cap > 0) { deallocate[u8](alloc, fb.buf, fb.cap::usize); }
-            ret err[query.QueryOutput, str](unwrap_err[bool, str](wr));
-        }
+    val wr: Result[bool, str] = fp_pub_surface(?fb, rr);
+    if (is_err[bool, str](wr)) {
+        if (fb.buf != nil && fb.cap > 0) { deallocate[u8](alloc, fb.buf, fb.cap::usize); }
+        ret err[query.QueryOutput, str](unwrap_err[bool, str](wr));
     }
 
     var out: query.QueryOutput;
     out.bytes = fb.buf;
     out.len   = fb.len;
     ret ok[query.QueryOutput, str](out);
+}
+
+# fp_pub_surface: append the resolved pub surface of `rr` to the fingerprint — the
+# pub symbols occupy indices [0, pub_count) in source-deterministic order. each
+# symbol contributes the exact tuple build_module_exports exposes to a dependent
+# resolve (kind, name, decl, origin, slot), with origin/slot in build-stable space.
+fun fp_pub_surface(fb: *FpBuf, rr: *resolve.ResolveResult) Result[bool, str] {
+    val pc: Result[bool, str] = fp_u32(fb, rr.pub_count);
+    if (is_err[bool, str](pc)) { ret pc; }
+    if (rr.symbols == nil) { ret ok[bool, str](true); }
+    var i: u32 = 0;
+    for (i < rr.pub_count) {
+        val sym: *resolve.Symbol = ?rr.symbols[i];
+        val rk: Result[bool, str] = fp_u8(fb, sym.kind::u8);             if (is_err[bool, str](rk)) { ret rk; }
+        val rn: Result[bool, str] = fp_u32(fb, sym.name::u32);          if (is_err[bool, str](rn)) { ret rn; }
+        val rdl: Result[bool, str] = fp_u32(fb, sym.decl::u32);         if (is_err[bool, str](rdl)) { ret rdl; }
+        val ro: Result[bool, str] = fp_u32(fb, sym.origin_stable::u32); if (is_err[bool, str](ro)) { ret ro; }
+        # SYM_USE's slot is a module reference (its build-stable twin); every other
+        # kind's slot is a build-independent index — fingerprint each in its own space.
+        var slot_fp: u32 = sym.slot;
+        if (sym.kind == resolve.SYM_USE) { slot_fp = sym.slot_stable::u32; }
+        val rs: Result[bool, str] = fp_u32(fb, slot_fp);                if (is_err[bool, str](rs)) { ret rs; }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
 }
 
 # FpBuf: a growable byte buffer the export fingerprint is appended into.
@@ -2400,103 +2446,6 @@ fun fp_u32(b: *FpBuf, v: u32) Result[bool, str] {
     b.buf[b.len + 3] = ((v >> 24) & 0xFF)::u8;
     b.len = b.len + 4;
     ret ok[bool, str](true);
-}
-
-# fp_span: append a length prefix and the source bytes covered by `span`.
-fun fp_span(b: *FpBuf, source: str, span: token.Span) Result[bool, str] {
-    val n: u32 = span.len::u32;
-    val rl: Result[bool, str] = fp_u32(b, n);
-    if (is_err[bool, str](rl)) { ret rl; }
-    val rr: Result[bool, str] = fp_reserve(b, n);
-    if (is_err[bool, str](rr)) { ret rr; }
-    var i: usize = 0;
-    for (i < span.len) {
-        b.buf[b.len] = source[span.offset + i];
-        b.len = b.len + 1;
-        i = i + 1;
-    }
-    ret ok[bool, str](true);
-}
-
-# fp_walk_decls: append every pub declaration in a decl list to the fingerprint,
-# recursing into comptime-if branches (where target-gated pub decls live). decls
-# are walked in source order, which is deterministic for a given AST.
-fun fp_walk_decls(b: *FpBuf, a: *ast.Ast, source: str, start: u32, len: u32) Result[bool, str] {
-    var i: u32 = 0;
-    for (i < len) {
-        val did: id.DeclId = a.decl_ids[start + i];
-        val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
-        if (is_some[*decl.Decl](d_opt)) {
-            val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
-            if ((d.flags & decl.DECL_FLAG_PUB) != 0::u8) {
-                val r: Result[bool, str] = fp_emit_decl(b, a, source, d);
-                if (is_err[bool, str](r)) { ret r; }
-            }
-            if (d.kind == decl.DECL_KIND_COMPTIME_IF) {
-                val ci: *decl.DeclComptimeIf = ?d.data.comptime_if;
-                var bi: u32 = 0;
-                for (bi < ci.branches_len) {
-                    val br: *decl.ComptimeBranch = ?a.comptime_branches[ci.branches_start + bi];
-                    val rb: Result[bool, str] = fp_walk_decls(b, a, source, br.body_start, br.body_len);
-                    if (is_err[bool, str](rb)) { ret rb; }
-                    bi = bi + 1;
-                }
-            }
-        }
-        i = i + 1;
-    }
-    ret ok[bool, str](true);
-}
-
-# fp_emit_decl: append one pub decl's kind, name, and signature shape. the shape
-# is the decl's source span with a function body excluded (so a body-only edit is
-# invisible to the fingerprint); for every other kind the whole decl span is the
-# public contract (a record's fields, a pub val's initializer, a def's underlying
-# type all matter to importers).
-fun fp_emit_decl(b: *FpBuf, a: *ast.Ast, source: str, d: *decl.Decl) Result[bool, str] {
-    val rk: Result[bool, str] = fp_u8(b, d.kind::u8);
-    if (is_err[bool, str](rk)) { ret rk; }
-    val rn: Result[bool, str] = fp_span(b, source, decl_name_span(d));
-    if (is_err[bool, str](rn)) { ret rn; }
-    ret fp_span(b, source, decl_shape_span(a, d));
-}
-
-# decl_name_span: the span of a decl's declared identifier (the alias for a
-# use/fwd re-export, falling back to its path when the alias is elided).
-fun decl_name_span(d: *decl.Decl) token.Span {
-    if (d.kind == decl.DECL_KIND_FUN) { ret d.data.fun_.name; }
-    if (d.kind == decl.DECL_KIND_REC) { ret d.data.rec_.name; }
-    if (d.kind == decl.DECL_KIND_UNI) { ret d.data.uni_.name; }
-    if (d.kind == decl.DECL_KIND_VAL || d.kind == decl.DECL_KIND_VAR) { ret d.data.bind.name; }
-    if (d.kind == decl.DECL_KIND_DEF) { ret d.data.def_.name; }
-    if (d.kind == decl.DECL_KIND_USE) {
-        if (d.data.use_.alias.len > 0::usize) { ret d.data.use_.alias; }
-        ret d.data.use_.path;
-    }
-    if (d.kind == decl.DECL_KIND_FWD) {
-        if (d.data.fwd_.alias.len > 0::usize) { ret d.data.fwd_.alias; }
-        ret d.data.fwd_.path;
-    }
-    ret d.span;
-}
-
-# decl_shape_span: the source span that is a decl's public contract — a function's
-# signature (its decl span up to the body block, body excluded) or the whole decl
-# span otherwise.
-fun decl_shape_span(a: *ast.Ast, d: *decl.Decl) token.Span {
-    if (d.kind == decl.DECL_KIND_FUN && d.data.fun_.body != id.STMT_NIL) {
-        val s_opt: Option[*stmt.Stmt] = ast.get_stmt(a, d.data.fun_.body);
-        if (is_some[*stmt.Stmt](s_opt)) {
-            val body_off: usize = unwrap[*stmt.Stmt](s_opt).span.offset;
-            if (body_off > d.span.offset) {
-                var sig: token.Span;
-                sig.offset = d.span.offset;
-                sig.len    = body_off - d.span.offset;
-                ret sig;
-            }
-        }
-    }
-    ret d.span;
 }
 
 # walk_module_for_load: walk the module's decls in source order,
@@ -3074,19 +3023,182 @@ fun register_module_asts(p: *Project) Result[bool, str] {
         if (is_err[bool, str](r)) { ret r; }
         val rf: Result[bool, str] = sess.register_module_fqn(p.s, i, m.fqn);
         if (is_err[bool, str](rf)) { ret rf; }
+        # record this build's StableModuleId -> ModuleId so a reused ResolveResult
+        # remaps its stale ModuleIds into this build's numbering (#1582).
+        val rs: Result[bool, str] = sess.register_stable_mid(p.s, m.stable_id, i);
+        if (is_err[bool, str](rs)) { ret rs; }
         i = i + 1;
     }
     ret ok[bool, str](true);
 }
 
+# run_resolve_pass: resolve every module in topo order through the Q_RESOLVE query.
+# the active Project is installed on the session for the pass so the compute can
+# reach the per-build module graph; topo order guarantees each module's deps are
+# already resolved (and their Q_RESOLVE/Q_EXPORTS entries valid) before it runs, so
+# the firewall gets the compute issues never recurse into an unresolved dep.
 fun run_resolve_pass(p: *Project) Result[bool, str] {
-    # dep-closure scratch reused across every module: a `visited` mark array and a
-    # worklist, both bounded by module_len. allocating them once per build (not once
-    # per module in build_resolve_deps) keeps dep-set construction O(modules) in
-    # allocation rather than O(modules^2). visited is zeroed once here and each call
-    # restores it to all-false on success, so successive calls start clean.
+    sess.set_active_project(p.s, p::ptr);
+
+    var i: u32 = 0;
+    for (i < p.topo_len) {
+        val mid: sess.ModuleId = p.topo[i];
+        val r: Result[bool, str] = run_resolve_one(p, mid);
+        if (is_err[bool, str](r)) {
+            sess.set_active_project(p.s, nil);
+            ret r;
+        }
+        i = i + 1;
+    }
+    sess.set_active_project(p.s, nil);
+    ret ok[bool, str](true);
+}
+
+# run_resolve_one: fetch module `mid`'s ResolveResult through Q_RESOLVE — computed
+# fresh when its AST or any dep's export fingerprint changed, reused otherwise — and
+# remap the (possibly cross-build) result into this build's ModuleId numbering. the
+# result is borrowed from the query DB; m.resolve_result only points at it.
+fun run_resolve_one(p: *Project, mid: sess.ModuleId) Result[bool, str] {
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+
+    emit_stage(p, "resolve", m.fqn);
+
+    val e_r: Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_RESOLVE, m.stable_id::u64);
+    if (is_err[*query.QueryEntry, str](e_r)) { ret err[bool, str](unwrap_err[*query.QueryEntry, str](e_r)); }
+    val rr: *resolve.ResolveResult = resolve_handle_decode(unwrap_ok[*query.QueryEntry, str](e_r));
+    if (rr == nil) { ret err[bool, str]("Q_RESOLVE produced no result handle"); }
+
+    # translate the result's ModuleId-valued fields into THIS build's numbering: a
+    # reused result still carries the producing build's mids (#1582). idempotent for
+    # a freshly computed result (its mids already match this build).
+    resolve.remap_result(rr, p.s);
+
+    m.resolve_result = rr;
+    m.resolved       = true;
+    ret ok[bool, str](true);
+}
+
+# q_resolve_compute: the Q_RESOLVE derived compute — resolve one module against its
+# dependencies and return the ResolveResult as an opaque owned handle. reaches the
+# per-build module graph through the session's active Project (the engine's ComputeFn
+# signature cannot carry it), and records the deps that make the entry incremental:
+#   - Q_PARSE(file): a text edit re-parses the AST and re-resolves this module;
+#   - Q_TARGET:      a build-config change re-resolves every module ($if forks on it);
+#   - Q_EXPORTS(dep) for every module in the resolve dep closure: a dep's VISIBLE
+#     surface change re-resolves this module, while a private-only edit early-cuts
+#     at Q_EXPORTS and leaves this entry valid (the firewall).
+fun q_resolve_compute(db: *query.QueryDb, key: u64, alloc: *Allocator) Result[query.QueryOutput, str] {
+    val s: *sess.Session = db.ctx::*sess.Session;
+    if (s == nil) { ret err[query.QueryOutput, str]("Q_RESOLVE: query db has no session context"); }
+    val pp: ptr = sess.active_project(s);
+    if (pp == nil) { ret err[query.QueryOutput, str]("Q_RESOLVE: no active project for the resolve pass"); }
+    val p: *Project = pp::*Project;
+
+    val stable: sess.StableModuleId = key::u32::sess.StableModuleId;
+    val mid: sess.ModuleId = sess.module_id_for_stable(s, stable);
+    if (mid == sess.MODULE_NIL) { ret err[query.QueryOutput, str]("Q_RESOLVE: stable id not loaded this build"); }
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    val a: *ast.Ast = m.a;
+    if (a == nil) { ret err[query.QueryOutput, str]("Q_RESOLVE: module has no parsed AST"); }
+
+    val rp: Result[bool, str] = query.record_dep(db, query.Q_RESOLVE, key, query.Q_PARSE, a.file_id::u64);
+    if (is_err[bool, str](rp)) { ret err[query.QueryOutput, str](unwrap_err[bool, str](rp)); }
+    val rt: Result[bool, str] = query.record_dep(db, query.Q_RESOLVE, key, query.Q_TARGET, 0);
+    if (is_err[bool, str](rt)) { ret err[query.QueryOutput, str](unwrap_err[bool, str](rt)); }
+
+    val deps_r: Result[resolve.ResolveDeps, str] = build_resolve_deps_owned(p, m);
+    if (is_err[resolve.ResolveDeps, str](deps_r)) { ret err[query.QueryOutput, str](unwrap_err[resolve.ResolveDeps, str](deps_r)); }
+    var deps: resolve.ResolveDeps = unwrap_ok[resolve.ResolveDeps, str](deps_r);
+
+    # record the firewall dep on each dep's Q_EXPORTS, fetching it first so the
+    # recorded revision is current. duplicate entries (a bare-alias dep appears
+    # twice) record a redundant — harmless — dep.
+    var di: u32 = 0;
+    for (di < deps.count) {
+        val dep_mid: sess.ModuleId = deps.entries[di].module;
+        if (dep_mid::u32 < p.module_len) {
+            val dep_stable: sess.StableModuleId = p.modules[dep_mid::u32].stable_id;
+            val ge: Result[*query.QueryEntry, str] = query.get(db, query.Q_EXPORTS, dep_stable::u64);
+            if (is_err[*query.QueryEntry, str](ge)) {
+                free_resolve_deps(s.alloc, ?deps);
+                ret err[query.QueryOutput, str](unwrap_err[*query.QueryEntry, str](ge));
+            }
+            val rd: Result[bool, str] = query.record_dep(db, query.Q_RESOLVE, key, query.Q_EXPORTS, dep_stable::u64);
+            if (is_err[bool, str](rd)) {
+                free_resolve_deps(s.alloc, ?deps);
+                ret err[query.QueryOutput, str](unwrap_err[bool, str](rd));
+            }
+        }
+        di = di + 1;
+    }
+
+    val rr_r: Result[resolve.ResolveResult, str] = resolve.resolve(s, a, ?deps, ?m.ctx, mid);
+    free_resolve_deps(s.alloc, ?deps);
+    if (is_err[resolve.ResolveResult, str](rr_r)) { ret err[query.QueryOutput, str](unwrap_err[resolve.ResolveResult, str](rr_r)); }
+    var result: resolve.ResolveResult = unwrap_ok[resolve.ResolveResult, str](rr_r);
+
+    val br: Result[*resolve.ResolveResult, str] = allocate[resolve.ResolveResult](alloc, 1::usize);
+    if (is_err[*resolve.ResolveResult, str](br)) {
+        resolve.dnit_result(?result);
+        ret err[query.QueryOutput, str](unwrap_err[*resolve.ResolveResult, str](br));
+    }
+    val box: *resolve.ResolveResult = unwrap_ok[*resolve.ResolveResult, str](br);
+    box[0] = result;
+    ret resolve_handle_encode(alloc, box);
+}
+
+# q_resolve_finalize: release the ResolveResult a Q_RESOLVE handle owns, called by
+# the engine before it frees the handle buffer (on recompute, invalidate, dnit).
+fun q_resolve_finalize(value: *u8, value_len: u32, alloc: *Allocator) {
+    if (value == nil || value_len::usize < $size_of(ptr)) { ret; }
+    val slot: *ptr = value::ptr::*ptr;
+    val r: *resolve.ResolveResult = slot[0]::*resolve.ResolveResult;
+    if (r == nil) { ret; }
+    resolve.dnit_result(r);
+    deallocate[resolve.ResolveResult](alloc, r, 1::usize);
+}
+
+# resolve_handle_encode: wrap a heap ResolveResult pointer as a pointer-sized opaque
+# handle buffer — the Q_RESOLVE query value. like the Q_PARSE AST handle, the heavy
+# pointer-graph artifact lives in the byte-buffer DB as a handle, never serialized.
+fun resolve_handle_encode(alloc: *Allocator, r: *resolve.ResolveResult) Result[query.QueryOutput, str] {
+    val n: u32 = $size_of(ptr)::u32;
+    val rb: Result[*u8, str] = allocate[u8](alloc, n::usize);
+    if (is_err[*u8, str](rb)) {
+        resolve.dnit_result(r);
+        deallocate[resolve.ResolveResult](alloc, r, 1::usize);
+        ret err[query.QueryOutput, str](unwrap_err[*u8, str](rb));
+    }
+    val buf: *u8 = unwrap_ok[*u8, str](rb);
+    val slot: *ptr = buf::ptr::*ptr;
+    slot[0] = r::ptr;
+    var out: query.QueryOutput;
+    out.bytes = buf;
+    out.len   = n;
+    ret ok[query.QueryOutput, str](out);
+}
+
+# resolve_handle_decode: read the ResolveResult pointer back out of a Q_RESOLVE
+# handle entry, or nil when the entry carries no value.
+fun resolve_handle_decode(e: *query.QueryEntry) *resolve.ResolveResult {
+    if (e.value == nil || e.value_len::usize < $size_of(ptr)) { ret nil; }
+    val slot: *ptr = e.value::ptr::*ptr;
+    ret slot[0]::*resolve.ResolveResult;
+}
+
+# build_resolve_deps_owned: build_resolve_deps with its own dep-closure scratch
+# (`visited` mark array + worklist, both bounded by module_len), so the Q_RESOLVE
+# compute — which has no access to a caller-owned scratch — can call it. the scratch
+# is allocated and freed per compute; a recompute is the cold path, so this is not
+# the per-module-in-a-tight-loop allocation the shared scratch once guarded against.
+fun build_resolve_deps_owned(p: *Project, m: *ModuleEntry) Result[resolve.ResolveDeps, str] {
+    var deps: resolve.ResolveDeps;
+    deps.entries = nil;
+    deps.count   = 0;
+    if (m.dep_count == 0) { ret ok[resolve.ResolveDeps, str](deps); }
+
     val vr: Result[*bool, str] = allocate[bool](p.s.alloc, p.module_len::usize);
-    if (is_err[*bool, str](vr)) { ret err[bool, str](unwrap_err[*bool, str](vr)); }
+    if (is_err[*bool, str](vr)) { ret err[resolve.ResolveDeps, str](unwrap_err[*bool, str](vr)); }
     val visited: *bool = unwrap_ok[*bool, str](vr);
     var vi: u32 = 0;
     for (vi < p.module_len) { visited[vi] = false; vi = vi + 1; }
@@ -3094,41 +3206,71 @@ fun run_resolve_pass(p: *Project) Result[bool, str] {
     val lr: Result[*sess.ModuleId, str] = allocate[sess.ModuleId](p.s.alloc, p.module_len::usize);
     if (is_err[*sess.ModuleId, str](lr)) {
         deallocate[bool](p.s.alloc, visited, p.module_len::usize);
-        ret err[bool, str](unwrap_err[*sess.ModuleId, str](lr));
+        ret err[resolve.ResolveDeps, str](unwrap_err[*sess.ModuleId, str](lr));
     }
     val list: *sess.ModuleId = unwrap_ok[*sess.ModuleId, str](lr);
 
-    var i: u32 = 0;
-    for (i < p.topo_len) {
-        val mid: sess.ModuleId = p.topo[i];
-        val r: Result[bool, str] = run_resolve_one(p, mid, visited, list);
-        if (is_err[bool, str](r)) {
-            deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
-            deallocate[bool](p.s.alloc, visited, p.module_len::usize);
-            ret r;
-        }
-        i = i + 1;
-    }
+    val r: Result[resolve.ResolveDeps, str] = build_resolve_deps(p, m, visited, list);
     deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
     deallocate[bool](p.s.alloc, visited, p.module_len::usize);
-    ret ok[bool, str](true);
+    ret r;
 }
 
-fun run_resolve_one(p: *Project, mid: sess.ModuleId, visited: *bool, list: *sess.ModuleId) Result[bool, str] {
-    val m: *ModuleEntry = ?p.modules[mid::u32];
+# set_build_config_input: serialize the build configuration the comptime ctx forks
+# on — target os/isa/abi tuple, optimization mode, pointer width, the manifest
+# project identity, and the active defines — into the Q_TARGET input. set_input's
+# byte-equality cutoff leaves last_changed untouched for an identical reconfigure
+# (so Q_RESOLVE stays valid) and advances it on any real change (so every module
+# re-resolves). the value is build-wide, so it is keyed under 0 (#1582).
+fun set_build_config_input(p: *Project) Result[bool, str] {
+    var build_mode_id: u32 = comptime.MODE_DEBUG;
+    if (p.s.opt_explicit) {
+        if (p.s.opt_release) { build_mode_id = comptime.MODE_RELEASE; }
+    } or (p.target_entry.opt == TARGET_OPT_RELEASE) {
+        build_mode_id = comptime.MODE_RELEASE;
+    }
 
-    emit_stage(p, "resolve", m.fqn);
+    var fb: FpBuf;
+    fb.alloc = p.s.alloc;
+    fb.buf   = nil;
+    fb.len   = 0;
+    fb.cap   = 0;
 
-    val deps_r: Result[resolve.ResolveDeps, str] = build_resolve_deps(p, m, visited, list);
-    if (is_err[resolve.ResolveDeps, str](deps_r)) { ret err[bool, str](unwrap_err[resolve.ResolveDeps, str](deps_r)); }
-    var deps: resolve.ResolveDeps = unwrap_ok[resolve.ResolveDeps, str](deps_r);
+    val w: Result[bool, str] = write_build_config(?fb, p, build_mode_id);
+    if (is_err[bool, str](w)) {
+        if (fb.buf != nil && fb.cap > 0) { deallocate[u8](p.s.alloc, fb.buf, fb.cap::usize); }
+        ret w;
+    }
 
-    val rr_r: Result[resolve.ResolveResult, str] = resolve.resolve(p.s, m.a, ?deps, ?m.ctx, mid);
-    free_resolve_deps(p.s.alloc, ?deps);
-    if (is_err[resolve.ResolveResult, str](rr_r)) { ret err[bool, str](unwrap_err[resolve.ResolveResult, str](rr_r)); }
+    val si: Result[bool, str] = query.set_input(?p.s.queries, query.Q_TARGET, 0, fb.buf, fb.len);
+    if (fb.buf != nil && fb.cap > 0) { deallocate[u8](p.s.alloc, fb.buf, fb.cap::usize); }
+    ret si;
+}
 
-    m.resolve_result = unwrap_ok[resolve.ResolveResult, str](rr_r);
-    m.resolved       = true;
+# write_build_config: append the comptime-relevant build axes into `fb`. every value
+# an importer-independent `$if` can read is captured, so a change to any of them
+# advances Q_TARGET and re-resolves the graph.
+fun write_build_config(fb: *FpBuf, p: *Project, build_mode_id: u32) Result[bool, str] {
+    val a0: Result[bool, str] = fp_u32(fb, p.target.os_id);        if (is_err[bool, str](a0)) { ret a0; }
+    val a1: Result[bool, str] = fp_u32(fb, p.target.arch_id);      if (is_err[bool, str](a1)) { ret a1; }
+    val a2: Result[bool, str] = fp_u32(fb, p.target.abi_id);       if (is_err[bool, str](a2)) { ret a2; }
+    val a3: Result[bool, str] = fp_u32(fb, build_mode_id);         if (is_err[bool, str](a3)) { ret a3; }
+    val a4: Result[bool, str] = fp_u32(fb, p.target.arch.pointer_width); if (is_err[bool, str](a4)) { ret a4; }
+    val a5: Result[bool, str] = fp_u32(fb, p.target_entry.os_name::u32);  if (is_err[bool, str](a5)) { ret a5; }
+    val a6: Result[bool, str] = fp_u32(fb, p.target_entry.isa_name::u32); if (is_err[bool, str](a6)) { ret a6; }
+    val a7: Result[bool, str] = fp_u32(fb, p.target_entry.abi_name::u32); if (is_err[bool, str](a7)) { ret a7; }
+    val a8: Result[bool, str] = fp_u32(fb, p.config.id::u32);      if (is_err[bool, str](a8)) { ret a8; }
+    val a9: Result[bool, str] = fp_u32(fb, p.config.version::u32); if (is_err[bool, str](a9)) { ret a9; }
+    val aa: Result[bool, str] = fp_u32(fb, p.config.name::u32);    if (is_err[bool, str](aa)) { ret aa; }
+    val ab: Result[bool, str] = fp_u32(fb, p.config.bin_name::u32); if (is_err[bool, str](ab)) { ret ab; }
+
+    val ac: Result[bool, str] = fp_u32(fb, p.config.define_count); if (is_err[bool, str](ac)) { ret ac; }
+    var i: u32 = 0;
+    for (i < p.config.define_count) {
+        val ad: Result[bool, str] = fp_u32(fb, p.config.defines[i]::u32);
+        if (is_err[bool, str](ad)) { ret ad; }
+        i = i + 1;
+    }
     ret ok[bool, str](true);
 }
 
@@ -3276,8 +3418,8 @@ fun canonical_module_fqn_is(p: *Project, id: intern.StrId, module: intern.StrId,
 # revisits a module.
 fun add_reexport_targets(p: *Project, mid: sess.ModuleId, visited: *bool, list: *sess.ModuleId, list_len: *u32) {
     val dep: *ModuleEntry = ?p.modules[mid::u32];
-    if (!dep.resolved) { ret; }
-    val rr: *resolve.ResolveResult = ?dep.resolve_result;
+    if (!dep.resolved || dep.resolve_result == nil) { ret; }
+    val rr: *resolve.ResolveResult = dep.resolve_result;
     if (rr.symbols == nil) { ret; }
     var i: u32 = 0;
     for (i < rr.pub_count) {
@@ -3300,7 +3442,7 @@ fun build_module_exports(p: *Project, dep_id: sess.ModuleId, dep: *ModuleEntry) 
     mx.module  = dep_id;
     mx.symbols = nil;
     mx.count   = 0;
-    if (!dep.resolved || dep.resolve_result.pub_count == 0) {
+    if (!dep.resolved || dep.resolve_result == nil || dep.resolve_result.pub_count == 0) {
         ret ok[resolve.ModuleExports, str](mx);
     }
     val pcount: u32 = dep.resolve_result.pub_count;
@@ -4127,7 +4269,7 @@ test "driver incremental: a module keeps its stable identity across a graph resh
     ret bad;
 }
 
-test "driver incremental: Q_EXPORTS fingerprints the pub surface, firewalls a private body edit (#1581)" {
+test "driver incremental: Q_EXPORTS fingerprints the resolved pub surface, firewalls a private body edit (#1581/#1582)" {
     var alloc: Allocator;
     if (is_some[str](page.make(?alloc))) { ret 1; }
     val sr: Result[sess.Session, str] = sess.init(?alloc);
@@ -4148,13 +4290,14 @@ test "driver incremental: Q_EXPORTS fingerprints the pub surface, firewalls a pr
 
     var bad: i32 = 0;
 
-    # build 1: capture the module's Q_EXPORTS fingerprint and its last_changed.
+    # build 1: capture the module's Q_EXPORTS fingerprint and its last_changed. the
+    # query is keyed by the build-stable id (#1582), captured here while p1 is alive.
     val p1r: Result[Project, str] = build_project_union(?s, root);
     if (is_err[Project, str](p1r)) { fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
     var p1: Project = unwrap_ok[Project, str](p1r);
-    val mid: sess.ModuleId = ut_mid(?p1, ?s, "uniontest.main");
-    if (mid == sess.MODULE_NIL) { bad = 1; }
-    val q1: Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_EXPORTS, mid::u64);
+    val stable: sess.StableModuleId = ut_stable(?p1, ?s, "uniontest.main");
+    if (stable == sess.STABLE_MODULE_NIL) { bad = 1; }
+    val q1: Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_EXPORTS, stable::u64);
     if (is_err[*query.QueryEntry, str](q1)) { dnit_project(?p1); fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
     val ent1: *query.QueryEntry = unwrap_ok[*query.QueryEntry, str](q1);
     val lc1: query.Revision = ent1.last_changed;
@@ -4167,8 +4310,11 @@ test "driver incremental: Q_EXPORTS fingerprints the pub surface, firewalls a pr
     if (len1 == 0) { bad = 1; }
     dnit_project(?p1);
 
-    # edit only the body: the signature is byte-identical, so Q_EXPORTS reproduces
-    # the same fingerprint and the engine early-cuts — last_changed must NOT advance.
+    # edit only the body: f's resolved pub symbol (kind/name/decl/origin) is
+    # unchanged, so Q_EXPORTS re-resolves but reproduces the same fingerprint and the
+    # engine early-cuts — last_changed must NOT advance. a type-only signature edit
+    # would behave identically: it does not change what importers BIND to (that is a
+    # sema-level concern), only their typing, so the resolve firewall holds.
     val src_dir: str = ut_cc3(?alloc, root, "/", "src");
     val main_path: str = ut_cc3(?alloc, src_dir, "/", "main.mach");
     val body_edit: str = "pub fun f(a: i32) i32 { val t: i32 = a; ret t; }\n";
@@ -4178,7 +4324,7 @@ test "driver incremental: Q_EXPORTS fingerprints the pub surface, firewalls a pr
     val p2r: Result[Project, str] = build_project_union(?s, root);
     if (is_err[Project, str](p2r)) { deallocate[u8](?alloc, fp1, len1::usize); fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
     var p2: Project = unwrap_ok[Project, str](p2r);
-    val q2: Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_EXPORTS, mid::u64);
+    val q2: Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_EXPORTS, stable::u64);
     if (is_err[*query.QueryEntry, str](q2)) { dnit_project(?p2); deallocate[u8](?alloc, fp1, len1::usize); fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
     val ent2: *query.QueryEntry = unwrap_ok[*query.QueryEntry, str](q2);
     if (ent2.last_changed != lc1) { bad = 1; }                                   # firewall: no change
@@ -4186,18 +4332,19 @@ test "driver incremental: Q_EXPORTS fingerprints the pub surface, firewalls a pr
     or (!mem.raw_equal(ent2.value::ptr, fp1::ptr, len1::usize)) { bad = 1; }      # byte-identical
     dnit_project(?p2);
 
-    # edit the pub signature: the fingerprint must change and last_changed advance.
-    val sig_edit: str = "pub fun f(a: i64) i32 { ret 0::i32; }\n";
-    val w3: Result[bool, str] = fs.write_file(main_path, sig_edit, str_len(sig_edit), 420);
+    # change the resolved pub surface (add a second pub symbol): the fingerprint must
+    # change and last_changed advance.
+    val surf_edit: str = "pub fun f(a: i32) i32 { ret a; }\npub fun g() i32 { ret 0; }\n";
+    val w3: Result[bool, str] = fs.write_file(main_path, surf_edit, str_len(surf_edit), 420);
     if (is_err[bool, str](w3)) { deallocate[u8](?alloc, fp1, len1::usize); fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
 
     val p3r: Result[Project, str] = build_project_union(?s, root);
     if (is_err[Project, str](p3r)) { deallocate[u8](?alloc, fp1, len1::usize); fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
     var p3: Project = unwrap_ok[Project, str](p3r);
-    val q3: Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_EXPORTS, mid::u64);
+    val q3: Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_EXPORTS, stable::u64);
     if (is_err[*query.QueryEntry, str](q3)) { dnit_project(?p3); deallocate[u8](?alloc, fp1, len1::usize); fs.remove_all(?alloc, root); sess.dnit(?s); ret 1; }
     val ent3: *query.QueryEntry = unwrap_ok[*query.QueryEntry, str](q3);
-    if (ent3.last_changed == lc1) { bad = 1; }                                   # pub change: advanced
+    if (ent3.last_changed == lc1) { bad = 1; }                                   # surface change: advanced
     if (ent3.value_len == len1 && mem.raw_equal(ent3.value::ptr, fp1::ptr, len1::usize)) { bad = 1; }
     dnit_project(?p3);
 

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -420,6 +420,19 @@ fun parse_fun_decl(p: *parser.Parser, start: token.Span, flags: u8) id.DeclId {
         ret_type = pexpr.parse_type(p);
     }
 
+    # reserve this function's DeclId BEFORE parsing its body. the body appends its
+    # own inner decls (block-local `val`/`var`, nested `test`s) to the shared decl
+    # store, so pushing the function last would let a body edit shift its id — and
+    # cross-module resolution caches a pub function's id (resolve.Symbol.decl, read
+    # by sema against the dep's AST). reserving keeps a function's id invariant to
+    # its own body, the stability the incremental-resolve firewall needs (#1582).
+    var placeholder: decl.Decl;
+    placeholder.span     = start;
+    placeholder.kind     = decl.DECL_KIND_FUN;
+    placeholder.flags    = flags;
+    val did: id.DeclId = parser.push_decl(p, placeholder);
+    if (did == id.DECL_NIL) { ret id.DECL_NIL; }
+
     var body: id.StmtId = id.STMT_NIL;
     var end:  token.Span = name;
     if (parser.at(p, token.KIND_LBRACE)) {
@@ -447,7 +460,12 @@ fun parse_fun_decl(p: *parser.Parser, start: token.Span, flags: u8) id.DeclId {
     d.kind     = decl.DECL_KIND_FUN;
     d.flags    = flags;
     d.data.fun_ = f;
-    ret parser.push_decl(p, d);
+
+    # write the completed decl into the reserved slot; body parsing may have grown
+    # (and moved) the decl store, so re-fetch the slot pointer by id (the push above
+    # succeeded, so the slot is present).
+    @unwrap[*decl.Decl](ast.get_decl(p.ast, did)) = d;
+    ret did;
 }
 
 # parses `rec Name[generics]? { field: Type; ... }`

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -112,6 +112,14 @@ pub val SYM_FLAG_MODULE: u8 = 4;
 #         TypeKind ordinal for SYM_PRIM, otherwise 0
 # origin: ModuleId of the module that owns `decl` (this module for locally
 #         declared symbols, the dependency for SYM_USE / SYM_IMPORTED)
+# origin_stable: build-stable identity of `origin`, captured at resolve time. a
+#         ResolveResult reused across builds carries the per-build `origin` of the
+#         build that produced it; remap_result rewrites `origin` from this stable
+#         snapshot into the new build's ModuleId space (#1582). STABLE_MODULE_NIL
+#         when origin is MODULE_NIL or has no stable id
+# slot_stable: build-stable identity of the SYM_USE target `slot` names, the slot's
+#         twin of origin_stable. STABLE_MODULE_NIL for every non-SYM_USE symbol
+#         (their slot is an index, not a ModuleId, and is build-independent)
 pub rec Symbol {
     kind:   SymKind;
     flags:  u8;
@@ -119,6 +127,8 @@ pub rec Symbol {
     decl:   id.DeclId;
     slot:   u32;
     origin: sess.ModuleId;
+    origin_stable: sess.StableModuleId;
+    slot_stable:   sess.StableModuleId;
 }
 
 # PublicSymbol: a snapshot of one pub symbol, copied by the driver into a dependent module's ResolveDeps so resolve can bind cross-module references.
@@ -272,6 +282,42 @@ pub fun param_symbol(r: *ResolveResult, decl: id.DeclId, slot: u32) SymbolId {
     val g: Result[*SymbolId, str] = map.get[u64, SymbolId](?r.param_index, ?key);
     if (is_ok[*SymbolId, str](g)) { ret @unwrap_ok[*SymbolId, str](g); }
     ret SYMBOL_NIL;
+}
+
+# stable_of_module: the build-stable identity of ModuleId `mid` on session `s`, or
+# STABLE_MODULE_NIL when `mid` is MODULE_NIL or names no registered module. resolve
+# runs after register_module_asts, so every loaded module's FQN and stable id are
+# already present; a lookup miss therefore means a synthetic/absent origin.
+fun stable_of_module(s: *sess.Session, mid: sess.ModuleId) sess.StableModuleId {
+    if (mid == sess.MODULE_NIL) { ret sess.STABLE_MODULE_NIL; }
+    val fqn: intern.StrId = sess.module_fqn(s, mid);
+    if (fqn == intern.STR_NIL) { ret sess.STABLE_MODULE_NIL; }
+    ret sess.stable_module_id_lookup(s, fqn);
+}
+
+# remap_result: rewrite every ModuleId-valued field of `r` from the build-stable
+# snapshot captured at resolve time into session `s`'s CURRENT per-build ModuleId
+# numbering. the cross-build-reuse correctness step (#1582): a ResolveResult reused
+# from an earlier build still carries that build's `origin` / SYM_USE `slot`
+# ModuleIds, which a graph reshape may have renumbered. driven once per build by the
+# driver after fetching the (possibly reused) result; idempotent — a freshly
+# computed result already holds the current build's mids, and re-deriving them from
+# the immutable stable snapshot reproduces the same values. every ModuleId-valued
+# field is covered: Symbol.origin (all symbols) and Symbol.slot (SYM_USE only).
+# ---
+# r: the result to remap in place
+# s: the session whose per-build StableModuleId -> ModuleId map drives the rewrite
+pub fun remap_result(r: *ResolveResult, s: *sess.Session) {
+    if (r == nil || r.symbols == nil) { ret; }
+    var i: u32 = 0;
+    for (i < r.symbol_count) {
+        val sym: *Symbol = ?r.symbols[i];
+        sym.origin = sess.module_id_for_stable(s, sym.origin_stable);
+        if (sym.kind == SYM_USE) {
+            sym.slot = sess.module_id_for_stable(s, sym.slot_stable)::u32;
+        }
+        i = i + 1;
+    }
 }
 
 # dnit_result: releases every array owned by the result and zeroes its fields.
@@ -578,6 +624,9 @@ fun add_symbol(rc: *ResolveContext, kind: SymKind, flags: u8, name: intern.StrId
     sym.decl   = decl_id;
     sym.slot   = slot;
     sym.origin = origin;
+    # the stable snapshots are filled in build_result once every symbol exists.
+    sym.origin_stable = sess.STABLE_MODULE_NIL;
+    sym.slot_stable   = sess.STABLE_MODULE_NIL;
     val sid: SymbolId = rc.sym_len;
     rc.symbols[rc.sym_len] = sym;
     rc.sym_len = rc.sym_len + 1;
@@ -2481,6 +2530,24 @@ fun build_result(rc: *ResolveContext) Result[ResolveResult, str] {
     remap_symbol_refs(rc.decl_symbol,   rc.a.decl_len::u32, remap, rc.sym_len);
 
     if (remap != nil) { deallocate[u32](rc.s.alloc, remap, rc.sym_len::usize); }
+
+    # snapshot each symbol's ModuleId-valued fields in build-stable space, so a
+    # ResolveResult reused in a later build can be remapped into that build's
+    # ModuleId numbering (#1582). origin is captured for every symbol; the SYM_USE
+    # target in `slot` is captured too (other kinds' slot is a build-independent
+    # index and needs no snapshot).
+    var si: u32 = 0;
+    for (si < rc.sym_len) {
+        val sym: *Symbol = ?out_syms[si];
+        sym.origin_stable = stable_of_module(rc.s, sym.origin);
+        if (sym.kind == SYM_USE) {
+            sym.slot_stable = stable_of_module(rc.s, sym.slot::sess.ModuleId);
+        }
+        or {
+            sym.slot_stable = sess.STABLE_MODULE_NIL;
+        }
+        si = si + 1;
+    }
 
     # index every parameter by (owning decl, ordinal) over the final symbol
     # array, so lowering resolves a parameter symbol in O(1) rather than scanning

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -254,6 +254,14 @@ val PRIM_COUNT: u32 = 11;
 # param_index:   (decl::u64 << 32 | slot) -> SymbolId for every SYM_PARAM, so a
 #                consumer resolves a function parameter by (owning decl, ordinal)
 #                in O(1) instead of scanning the whole symbol universe per param
+# pub_const_fp:  owned byte fingerprint of this module's pub module-level comptime
+#                constant VALUES (name + evaluated CTValue), in pub-symbol order. an
+#                importer's resolution forks on these via `$if` over imported
+#                consts, but the values live in the comptime ctx, not in the symbol
+#                identities — so Q_EXPORTS folds this blob into the firewall
+#                fingerprint to re-resolve importers when a dep's const value (even
+#                a transitively-derived one) changes (#1582). nil/0 when none
+# pub_const_fp_len: length of pub_const_fp in bytes
 pub rec ResolveResult {
     alloc:         *Allocator;
     symbols:       *Symbol;
@@ -267,6 +275,9 @@ pub rec ResolveResult {
     decl_count:    u32;
 
     param_index:   map.Map[u64, SymbolId];
+
+    pub_const_fp:     *u8;
+    pub_const_fp_len: u32;
 }
 
 # param_symbol: the SymbolId of function `decl`'s parameter at ordinal `slot`,
@@ -337,6 +348,9 @@ pub fun dnit_result(r: *ResolveResult) {
     if (r.decl_symbol != nil) {
         deallocate[SymbolId](r.alloc, r.decl_symbol, r.decl_count::usize);
     }
+    if (r.pub_const_fp != nil && r.pub_const_fp_len > 0) {
+        deallocate[u8](r.alloc, r.pub_const_fp, r.pub_const_fp_len::usize);
+    }
     map.dnit[u64, SymbolId](?r.param_index);
     r.symbols       = nil;
     r.symbol_count  = 0;
@@ -347,6 +361,8 @@ pub fun dnit_result(r: *ResolveResult) {
     r.expr_count    = 0;
     r.type_count    = 0;
     r.decl_count    = 0;
+    r.pub_const_fp     = nil;
+    r.pub_const_fp_len = 0;
 }
 
 # resolve: resolves one module against its already-resolved dependencies.
@@ -2568,6 +2584,18 @@ fun build_result(rc: *ResolveContext) Result[ResolveResult, str] {
         pk = pk + 1;
     }
 
+    # fingerprint the evaluated values of this module's pub module-level comptime
+    # constants, so the export firewall re-resolves importers when a const value an
+    # importer's `$if` reads changes (the value lives in the ctx, not the symbols).
+    var fp_len: u32 = 0;
+    val fp_r: Result[*u8, str] = pub_const_fp_build(rc, out_syms, pub_count, ?fp_len);
+    if (is_err[*u8, str](fp_r)) {
+        map.dnit[u64, SymbolId](?param_index);
+        deallocate[Symbol](rc.s.alloc, out_syms, rc.sym_len::usize);
+        dnit_context(rc);
+        ret err[ResolveResult, str](unwrap_err[*u8, str](fp_r));
+    }
+
     var out: ResolveResult;
     out.alloc         = rc.s.alloc;
     out.symbols       = out_syms;
@@ -2580,6 +2608,8 @@ fun build_result(rc: *ResolveContext) Result[ResolveResult, str] {
     out.type_count    = rc.a.type_len::u32;
     out.decl_count    = rc.a.decl_len::u32;
     out.param_index   = param_index;
+    out.pub_const_fp     = unwrap_ok[*u8, str](fp_r);
+    out.pub_const_fp_len = fp_len;
 
     rc.expr_resolved = nil;
     rc.type_resolved = nil;
@@ -2587,4 +2617,84 @@ fun build_result(rc: *ResolveContext) Result[ResolveResult, str] {
 
     dnit_context(rc);
     ret ok[ResolveResult, str](out);
+}
+
+# PUB_CONST_FP_ENTRY: bytes one pub comptime constant contributes to the value
+# fingerprint — name(u32) + CTValue kind(u8) + int_unsigned(u8) + payload bits(u64).
+val PUB_CONST_FP_ENTRY: u32 = 14;
+
+# ct_value_bits: the 8 payload bytes of a CTValue as a canonical u64, set per kind
+# so the fingerprint is deterministic (a bool writes 0/1, never the union's stale
+# upper bytes; a float's bit pattern travels verbatim through the i64 view).
+fun ct_value_bits(v: *comptime.CTValue) u64 {
+    if (v.kind == comptime.CT_KIND_BOOL) {
+        if (v.data.b) { ret 1; }
+        ret 0;
+    }
+    if (v.kind == comptime.CT_KIND_STR)  { ret v.data.s::u64; }
+    if (v.kind == comptime.CT_KIND_TYPE) { ret v.data.t::u64; }
+    ret v.data.i::u64;
+}
+
+# pub_const_fp_build: serialize the evaluated CTValue of every pub module-level
+# comptime constant in `syms[0, pub_count)` into a fresh byte blob, in pub-symbol
+# order. the values are read from the comptime ctx (bound during load); a constant
+# not foldable there records a sentinel kind. *out_len gets the blob length; a
+# module with no pub comptime constants yields nil/0.
+fun pub_const_fp_build(rc: *ResolveContext, syms: *Symbol, pub_count: u32, out_len: *u32) Result[*u8, str] {
+    @out_len = 0;
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < pub_count) {
+        if (syms[i].kind == SYM_VAL && (syms[i].flags & SYM_FLAG_MODULE) != 0) { n = n + 1; }
+        i = i + 1;
+    }
+    if (n == 0) { ret ok[*u8, str](nil); }
+
+    val total: u32 = n * PUB_CONST_FP_ENTRY;
+    val r: Result[*u8, str] = allocate[u8](rc.s.alloc, total::usize);
+    if (is_err[*u8, str](r)) { ret r; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+
+    var off: u32 = 0;
+    i = 0;
+    for (i < pub_count) {
+        val sym: *Symbol = ?syms[i];
+        if (sym.kind == SYM_VAL && (sym.flags & SYM_FLAG_MODULE) != 0) {
+            fp_put_u32(buf, off, sym.name::u32); off = off + 4;
+            val nc: Option[*comptime.NamedConst] = comptime.lookup(rc.ctx, sym.name);
+            if (is_some[*comptime.NamedConst](nc)) {
+                val v: *comptime.CTValue = ?unwrap[*comptime.NamedConst](nc).value;
+                buf[off] = v.kind::u8; off = off + 1;
+                if (v.int_unsigned) { buf[off] = 1; } or { buf[off] = 0; }
+                off = off + 1;
+                fp_put_u64(buf, off, ct_value_bits(v)); off = off + 8;
+            }
+            or {
+                buf[off] = 0xFF; off = off + 1;   # sentinel: not a foldable constant
+                buf[off] = 0;    off = off + 1;
+                fp_put_u64(buf, off, 0); off = off + 8;
+            }
+        }
+        i = i + 1;
+    }
+
+    @out_len = total;
+    ret ok[*u8, str](buf);
+}
+
+# fp_put_u32 / fp_put_u64: write a little-endian integer into `buf` at `off`.
+fun fp_put_u32(buf: *u8, off: u32, v: u32) {
+    buf[off]     = (v & 0xFF)::u8;
+    buf[off + 1] = ((v >> 8) & 0xFF)::u8;
+    buf[off + 2] = ((v >> 16) & 0xFF)::u8;
+    buf[off + 3] = ((v >> 24) & 0xFF)::u8;
+}
+
+fun fp_put_u64(buf: *u8, off: u32, v: u64) {
+    var j: u32 = 0;
+    for (j < 8) {
+        buf[off + j] = ((v >> (j * 8)) & 0xFF)::u8;
+        j = j + 1;
+    }
 }

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -65,13 +65,22 @@ pub val Q_PARSE: QueryKind = 4;
 # Q_MODULE_ID_FOR_FQN: derived — sess.ModuleId for an interned FQN, keyed on intern.StrId.
 pub val Q_MODULE_ID_FOR_FQN: QueryKind = 5;
 # Q_COMPTIME_CTX: derived — a module's seeded ComptimeCtx, keyed on sess.ModuleId.
+# reserved; the driver's load walk currently rebuilds a full, identically-seeded
+# comptime ctx every build, so a reused Q_RESOLVE sees a consistent ctx without a
+# separate cache (see run_resolve_one / register_val_for_load).
 pub val Q_COMPTIME_CTX: QueryKind = 6;
-# Q_RESOLVE: derived — a module's ResolveResult, keyed on sess.ModuleId.
+# Q_RESOLVE: derived (owned handle) — a module's ResolveResult, keyed on
+# sess.StableModuleId so an unchanged module's result is reused across rebuilds
+# even when a graph reshape renumbers per-build ModuleIds. reads Q_PARSE(file),
+# Q_TARGET, and Q_EXPORTS(dep) per import; the result's ModuleId-valued fields are
+# remapped into each build's numbering on reuse (#1582).
 pub val Q_RESOLVE: QueryKind = 7;
-# Q_EXPORTS: derived — a byte fingerprint of a module's public surface, keyed on
-# sess.ModuleId. its OUTPUT early-cutoff is the firewall that stops a private
-# edit from cascading to importers: a private-only change reproduces identical
-# fingerprint bytes, so importers depending on Q_EXPORTS stay valid (#1581).
+# Q_EXPORTS: derived — a byte fingerprint of a module's RESOLVED public surface,
+# keyed on sess.StableModuleId. its OUTPUT early-cutoff is the firewall that stops a
+# private edit from cascading to importers: a private-only change re-resolves the
+# module but reproduces an identical pub-surface fingerprint, so importers depending
+# on Q_EXPORTS stay valid; a change to the visible surface (incl. a re-exported dep's
+# resolved identity) advances it and re-resolves importers (#1581/#1582).
 pub val Q_EXPORTS: QueryKind = 8;
 # Q_SEMA: derived — a module's SemaResult, keyed on sess.ModuleId.
 pub val Q_SEMA: QueryKind = 9;

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -90,6 +90,20 @@ pub rec Session {
     # stable_id_next: monotonic source of the next StableModuleId to hand out
     stable_ids:       map.Map[intern.StrId, modid.StableModuleId];
     stable_id_next:   modid.StableModuleId;
+    # stable_to_mid: the PER-BUILD inverse of the active build's identity
+    # assignment — StableModuleId -> the discovery-order ModuleId it holds THIS
+    # build. populated by the driver alongside register_module_ast and cleared by
+    # reset_module_registry, it is the table a reused ResolveResult is remapped
+    # through (resolve.remap_result), translating a prior build's ModuleIds back
+    # into this build's numbering (#1582)
+    stable_to_mid:    map.Map[modid.StableModuleId, modid.ModuleId];
+    # active_project: opaque handle to the *driver.Project of the build currently
+    # running, installed for the span of the resolve pass so the Q_RESOLVE compute
+    # can reach the per-build module graph (deps, comptime ctxs) the engine's
+    # ComputeFn signature cannot carry. stored as `ptr` to keep this leaf module
+    # free of a driver import cycle, exactly like module_resolve/module_comptime;
+    # nil outside a resolve pass and never dereferenced by the session itself
+    active_project:   ptr;
     registry:         target.TargetRegistry;
     # the CLI optimization intent, set before build_project so the comptime ctx
     # can resolve `$mach.build.mode`: opt_explicit when a `-O*`/`--release` flag
@@ -134,6 +148,8 @@ pub fun init(alloc: *Allocator) Result[Session, str] {
     s.module_comptime  = map.init[modid.ModuleId, ptr](alloc, maphash.hash_u32, maphash.eq_u32);
     s.stable_ids       = map.init[intern.StrId, modid.StableModuleId](alloc, maphash.hash_u32, maphash.eq_u32);
     s.stable_id_next   = 0;
+    s.stable_to_mid    = map.init[modid.StableModuleId, modid.ModuleId](alloc, maphash.hash_u32, maphash.eq_u32);
+    s.active_project   = nil;
     s.registry         = target.registry_init();
     s.opt_explicit     = false;
     s.opt_release      = false;
@@ -214,6 +230,7 @@ pub fun dnit(s: *Session) {
     map.dnit[modid.ModuleId, ptr](?s.module_resolve);
     map.dnit[modid.ModuleId, ptr](?s.module_comptime);
     map.dnit[intern.StrId, modid.StableModuleId](?s.stable_ids);
+    map.dnit[modid.StableModuleId, modid.ModuleId](?s.stable_to_mid);
     query.dnit(?s.queries);
     ty.dnit(?s.types);
     intern.dnit(?s.interner);
@@ -258,6 +275,10 @@ pub fun reset_module_registry(s: *Session) {
     map.clear[modid.ModuleId, ptr](?s.module_sema);
     map.clear[modid.ModuleId, ptr](?s.module_resolve);
     map.clear[modid.ModuleId, ptr](?s.module_comptime);
+    # the per-build StableModuleId -> ModuleId inverse is rebuilt from scratch each
+    # build; clear it so a reshape's new numbering never collides with a stale entry.
+    map.clear[modid.StableModuleId, modid.ModuleId](?s.stable_to_mid);
+    s.active_project = nil;
 }
 
 # register_module_ast: record `a` as the AST of module `mid` in the session
@@ -378,6 +399,54 @@ pub fun stable_module_id_lookup(s: *Session, fqn: intern.StrId) modid.StableModu
     val r: Result[*modid.StableModuleId, str] = map.get[intern.StrId, modid.StableModuleId](?s.stable_ids, ?key);
     if (is_ok[*modid.StableModuleId, str](r)) { ret @unwrap_ok[*modid.StableModuleId, str](r); }
     ret modid.STABLE_MODULE_NIL;
+}
+
+# register_stable_mid: record that StableModuleId `stable` holds discovery-order
+# ModuleId `mid` in the build currently running. the driver calls this once per
+# module each build (alongside register_module_ast); reset_module_registry clears
+# the table so each build's numbering stands alone. registering twice overwrites.
+# ---
+# s:      the session
+# stable: the module's build-stable identity
+# mid:    the per-build ModuleId it holds this build
+# ret:    true on success, or an allocation error from the registry map
+pub fun register_stable_mid(s: *Session, stable: modid.StableModuleId, mid: modid.ModuleId) Result[bool, str] {
+    ret map.insert[modid.StableModuleId, modid.ModuleId](?s.stable_to_mid, stable, mid);
+}
+
+# module_id_for_stable: the current build's ModuleId for StableModuleId `stable`,
+# or MODULE_NIL when `stable` is STABLE_MODULE_NIL or names no module loaded this
+# build. the lookup resolve.remap_result drives to translate a reused result's
+# stale ModuleIds into the active build's numbering (#1582).
+# ---
+# s:      the session
+# stable: a build-stable module identity
+# ret:    the per-build ModuleId, or MODULE_NIL
+pub fun module_id_for_stable(s: *Session, stable: modid.StableModuleId) modid.ModuleId {
+    if (stable == modid.STABLE_MODULE_NIL) { ret modid.MODULE_NIL; }
+    var key: modid.StableModuleId = stable;
+    val r: Result[*modid.ModuleId, str] = map.get[modid.StableModuleId, modid.ModuleId](?s.stable_to_mid, ?key);
+    if (is_ok[*modid.ModuleId, str](r)) { ret @unwrap_ok[*modid.ModuleId, str](r); }
+    ret modid.MODULE_NIL;
+}
+
+# set_active_project: install (or clear, with nil) the opaque handle to the build's
+# *driver.Project for the span of the resolve pass, so the Q_RESOLVE compute can
+# reach the per-build module graph. stored verbatim and never dereferenced here.
+# ---
+# s: the session
+# p: the active Project as `ptr`, or nil to clear
+pub fun set_active_project(s: *Session, p: ptr) {
+    s.active_project = p;
+}
+
+# active_project: the opaque *driver.Project handle installed for the running
+# resolve pass, or nil outside one. the caller casts it back to *driver.Project.
+# ---
+# s:   the session
+# ret: the active Project `ptr`, or nil
+pub fun active_project(s: *Session) ptr {
+    ret s.active_project;
 }
 
 # register_export_name: record a literal link-name override for decl `did` in


### PR DESCRIPTION
Implements query-driven incremental name resolution — the resolve-level payoff of epic #1164.

Closes #1582. Part of #1164.

## What landed
- **`Q_RESOLVE(module)`** — a derived owned-handle query keyed by `StableModuleId`, reading `Q_PARSE(file)` + `Q_TARGET` + `Q_EXPORTS(dep)` per import. `run_resolve_pass`/`run_resolve_one` fetch through it; `ModuleEntry.resolve_result` borrows the query-owned result (the query DB owns/frees it and reuses it across rebuilds, mirroring the Q_PARSE AST handle).
- **`Q_EXPORTS` rebound onto the resolved surface** (keyed by `StableModuleId`): fingerprints exactly what an importer's resolution binds against — per pub symbol `(kind, name, decl, origin, slot)` with origin/slot in build-stable space — **plus the pub comptime-constant VALUES** an importer's `$if` forks on. A private edit reproduces identical bytes (firewall holds); a visible-surface change (incl. a re-exported dep's resolved identity, or a const value an importer depends on) advances it and re-resolves importers.
- **Cross-build remap**: every ModuleId-valued field of a reused result — `Symbol.origin` (all symbols) and `Symbol.slot` (SYM_USE targets) — is captured in build-stable space at resolve time and rewritten into the new build's numbering via a per-build `StableModuleId -> ModuleId` map. Reuse is gated by AST byte-identity (Q_PARSE early-cutoff) + deps' export fingerprints.
- **Parser**: a function's `DeclId` is now reserved before its body is parsed, so a body edit never shifts the function's id — the stability cross-module resolution needs (sema indexes a dep's AST by the imported symbol's `decl`).
- **Firewall validation fix**: the engine's validator compares a dep's *stored* `last_changed` without recursively recomputing derived deps, so each module's `Q_EXPORTS` is refreshed in topo order during the resolve pass — dependents are validated against current fingerprints.

## Correctness gate
- [x] Self-host Fixpoint byte-identical (verified locally 3×)
- [x] Incremental CORRECTNESS tests asserting reused ResolveResults equal an independent from-scratch build: private-body-edit firewall, pub-surface-change invalidation, comptime-const-value-change invalidation, transitive `fwd` re-export propagation (+ the changed module always equals from-scratch)
- [x] Minimal-recompute count assertions (per-module `Q_RESOLVE.last_changed` reuse probes)
- [x] Full unit corpus + 59 integration suites green (run via memory-bounded filters; the single-process `mach test .` OOMs in the sandbox)

## Known limitation (follow-up #1586)
A reused cached phase does not re-emit its diagnostics. Latent — no current consumer drives `build_project` on a long-lived session (CLI/doc use fresh sessions; the LSP uses the per-buffer `editor.mach` path); predates this PR (Q_PARSE has the same property). Tracked in #1586 as a cross-cutting "diagnostics-as-query-output" change.