### PR TITLE
feat(incremental): query-driven type-checking (Q_SEMA)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -57,7 +57,6 @@ use diag:     mach.lang.diagnostic;
 use driver:   mach.lang.driver;
 use manifest: mach.lang.manifest;
 
-use sema:    mach.lang.fe.sema;
 use token:   mach.lang.fe.token;
 
 use ir:         mach.lang.me.ir;
@@ -187,59 +186,6 @@ fun emit_stage(p: *driver.Project, stage: *u8, fqn: intern.StrId) {
     print.eprint("\n");
 }
 
-# build_sema_deps: build the SemaDeps for module `m`, one ModuleSema entry
-# per already-analysed module in the project, copying each module's
-# SemaResult decl table. cross-module symbol types are looked up by the
-# symbol's origin ModuleId, and a `fwd` re-export carries the originating
-# (transitive) module as the origin — so the snapshot must cover every
-# transitively-reachable module, not only `m`'s direct dependencies. all of
-# them are strictly earlier in topo order and thus already analysed, so
-# exposing the full set of ready modules (keyed by ModuleId) is both correct
-# and harmless: lookups match an exact origin and never a sibling.
-fun build_sema_deps(p: *driver.Project, m: *driver.ModuleEntry,
-                    results: *sema.SemaResult, ready: *bool) Result[sema.SemaDeps, str] {
-    var deps: sema.SemaDeps;
-    deps.entries = nil;
-    deps.count   = 0;
-
-    var ready_count: u32 = 0;
-    var j: u32 = 0;
-    for (j < p.module_len) {
-        if (ready[j]) { ready_count = ready_count + 1; }
-        j = j + 1;
-    }
-    if (ready_count == 0) { ret ok[sema.SemaDeps, str](deps); }
-
-    val r: Result[*sema.ModuleSema, str] = allocate[sema.ModuleSema](p.s.alloc, ready_count::usize);
-    if (is_err[*sema.ModuleSema, str](r)) { ret err[sema.SemaDeps, str](unwrap_err[*sema.ModuleSema, str](r)); }
-    deps.entries = unwrap_ok[*sema.ModuleSema, str](r);
-    deps.count   = ready_count;
-
-    var i: u32 = 0;
-    var k: u32 = 0;
-    for (i < p.module_len) {
-        if (ready[i]) {
-            val dep: *driver.ModuleEntry = ?p.modules[i];
-            var ms: sema.ModuleSema;
-            ms.path       = dep.fqn;
-            ms.module     = i::sess.ModuleId;
-            ms.decl_type  = results[i].decl_type;
-            ms.decl_count = results[i].decl_count;
-            deps.entries[k] = ms;
-            k = k + 1;
-        }
-        i = i + 1;
-    }
-    ret ok[sema.SemaDeps, str](deps);
-}
-
-fun free_sema_deps(alloc: *Allocator, deps: *sema.SemaDeps) {
-    if (deps.entries == nil) { ret; }
-    deallocate[sema.ModuleSema](alloc, deps.entries, deps.count::usize);
-    deps.entries = nil;
-    deps.count   = 0;
-}
-
 # compile_modules: drive every reachable module through the back half of the
 # pipeline. semantic analysis runs over the whole module graph first; only if
 # no module reported an error does the build proceed to lower + optimise +
@@ -251,41 +197,15 @@ fun free_sema_deps(alloc: *Allocator, deps: *sema.SemaDeps) {
 # the per-module `.ir` (written right after lowering) and `.s` (written from the
 # fully-resolved MIR inside codegen) debug artifacts.
 fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: bool, verbose: bool, ea: *EmitArtifacts,
-                    results: *sema.SemaResult, ready: *bool,
                     irs: *ir.Module, ir_ready: *bool,
                     images: *of.ObjectImage, image_ready: *bool) Result[bool, str] {
-    var ti: u32 = 0;
-    for (ti < p.topo_len) {
-        val mid: sess.ModuleId = p.topo[ti];
-        val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
-
-        if (verbose) { emit_stage(p, "sema", m.fqn); }
-
-        val deps_r: Result[sema.SemaDeps, str] = build_sema_deps(p, m, results, ready);
-        if (is_err[sema.SemaDeps, str](deps_r)) { ret err[bool, str](unwrap_err[sema.SemaDeps, str](deps_r)); }
-        var deps: sema.SemaDeps = unwrap_ok[sema.SemaDeps, str](deps_r);
-
-        val sema_r: Result[sema.SemaResult, str] = sema.sema(p.s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
-        free_sema_deps(p.s.alloc, ?deps);
-        if (is_err[sema.SemaResult, str](sema_r)) { ret err[bool, str](unwrap_err[sema.SemaResult, str](sema_r)); }
-        results[mid::u32] = unwrap_ok[sema.SemaResult, str](sema_r);
-        ready[mid::u32]   = true;
-
-        # publish this module's typing and name-resolution to the session so the
-        # back-end monomorphizer can lower a generic template body (declared in
-        # any module) against the typing of its declaring module.
-        val rs: Result[bool, str] = sess.register_module_sema(p.s, mid, (?results[mid::u32])::ptr);
-        if (is_err[bool, str](rs)) { ret err[bool, str](unwrap_err[bool, str](rs)); }
-        val rr2: Result[bool, str] = sess.register_module_resolve(p.s, mid, (m.resolve_result)::ptr);
-        if (is_err[bool, str](rr2)) { ret err[bool, str](unwrap_err[bool, str](rr2)); }
-        # publish this module's comptime context too, so a value-parameter instance
-        # of a function declared here can fold its `$if` gates against this module's
-        # own `pub val`s when lowered from a calling module.
-        val rc: Result[bool, str] = sess.register_module_comptime(p.s, mid, (?m.ctx)::ptr);
-        if (is_err[bool, str](rc)) { ret err[bool, str](unwrap_err[bool, str](rc)); }
-
-        ti = ti + 1;
-    }
+    # type-check the whole module graph through Q_SEMA in topo order — memoized and
+    # incremental across rebuilds on a long-lived session, computed fresh each CLI
+    # build (fresh session, cold cache). run_sema_pass borrows each module's
+    # SemaResult onto its ModuleEntry and publishes its typing / resolution /
+    # comptime ctx to the session for the back-end monomorphizer (#1583).
+    val sema_pass_r: Result[bool, str] = driver.run_sema_pass(p);
+    if (is_err[bool, str](sema_pass_r)) { ret err[bool, str](unwrap_err[bool, str](sema_pass_r)); }
 
     # do not lower or codegen a semantically broken module graph.
     if (diag.has_errors(?p.s.diags)) { ret ok[bool, str](true); }
@@ -293,14 +213,14 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
     # lower + optimise every module first. in test mode the project's `main` is
     # then neutralised (the runner supplies the program entry) before any module
     # is codegen'd, so the dropped `main` body never reaches an object.
-    ti = 0;
+    var ti: u32 = 0;
     for (ti < p.topo_len) {
         val mid: sess.ModuleId = p.topo[ti];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
 
         if (verbose) { emit_stage(p, "lower", m.fqn); }
 
-        val lower_r: Result[ir.Module, str] = lower.lower_module(p.s, ?p.target, m.a, m.fqn, mid, ?results[mid::u32], m.resolve_result, ?m.ctx);
+        val lower_r: Result[ir.Module, str] = lower.lower_module(p.s, ?p.target, m.a, m.fqn, mid, m.sema_result, m.resolve_result, ?m.ctx);
         if (is_err[ir.Module, str](lower_r)) { ret err[bool, str](unwrap_err[ir.Module, str](lower_r)); }
         irs[mid::u32]     = unwrap_ok[ir.Module, str](lower_r);
         ir_ready[mid::u32] = true;
@@ -367,15 +287,17 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
     ret ok[bool, str](true);
 }
 
+# free_modules: tear down the per-module IR and object images. SemaResults are NOT
+# freed here — they are borrowed from the session query DB (the Q_SEMA handles),
+# which owns and frees them (and reuses them across rebuilds), mirroring resolve
+# results and parsed ASTs (#1583).
 fun free_modules(p: *driver.Project,
-                 results: *sema.SemaResult, ready: *bool,
                  irs: *ir.Module, ir_ready: *bool,
                  images: *of.ObjectImage, image_ready: *bool) {
     var i: u32 = 0;
     for (i < p.module_len) {
         if (image_ready[i]) { obj.dnit(?images[i]); }
         if (ir_ready[i])    { ir.dnit_module(?irs[i]); }
-        if (ready[i])       { sema.dnit_result(?results[i]); }
         i = i + 1;
     }
 }
@@ -642,40 +564,34 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
         }
     }
 
-    val rr: Result[*sema.SemaResult, str] = allocate[sema.SemaResult](p.s.alloc, n);
-    if (is_err[*sema.SemaResult, str](rr)) { print.eprint("error: out of memory\n"); ret 2; }
-    val results: *sema.SemaResult = unwrap_ok[*sema.SemaResult, str](rr);
-
-    val rdy: Result[*bool, str] = allocate[bool](p.s.alloc, n);
-    if (is_err[*bool, str](rdy)) { deallocate[sema.SemaResult](p.s.alloc, results, n); print.eprint("error: out of memory\n"); ret 2; }
-    val ready: *bool = unwrap_ok[*bool, str](rdy);
-
+    # per-module SemaResults are owned by the session query DB (the Q_SEMA handles)
+    # and borrowed onto each ModuleEntry by run_sema_pass, so no per-build sema array
+    # is allocated here (#1583); only the IR and object-image arrays are.
     val iri: Result[*ir.Module, str] = allocate[ir.Module](p.s.alloc, n);
-    if (is_err[*ir.Module, str](iri)) { deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); print.eprint("error: out of memory\n"); ret 2; }
+    if (is_err[*ir.Module, str](iri)) { print.eprint("error: out of memory\n"); ret 2; }
     val irs: *ir.Module = unwrap_ok[*ir.Module, str](iri);
 
     val irr: Result[*bool, str] = allocate[bool](p.s.alloc, n);
-    if (is_err[*bool, str](irr)) { deallocate[ir.Module](p.s.alloc, irs, n); deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); print.eprint("error: out of memory\n"); ret 2; }
+    if (is_err[*bool, str](irr)) { deallocate[ir.Module](p.s.alloc, irs, n); print.eprint("error: out of memory\n"); ret 2; }
     val ir_ready: *bool = unwrap_ok[*bool, str](irr);
 
     val imi: Result[*of.ObjectImage, str] = allocate[of.ObjectImage](p.s.alloc, n);
-    if (is_err[*of.ObjectImage, str](imi)) { deallocate[bool](p.s.alloc, ir_ready, n); deallocate[ir.Module](p.s.alloc, irs, n); deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); print.eprint("error: out of memory\n"); ret 2; }
+    if (is_err[*of.ObjectImage, str](imi)) { deallocate[bool](p.s.alloc, ir_ready, n); deallocate[ir.Module](p.s.alloc, irs, n); print.eprint("error: out of memory\n"); ret 2; }
     val images: *of.ObjectImage = unwrap_ok[*of.ObjectImage, str](imi);
 
     val imr: Result[*bool, str] = allocate[bool](p.s.alloc, n);
-    if (is_err[*bool, str](imr)) { deallocate[of.ObjectImage](p.s.alloc, images, n); deallocate[bool](p.s.alloc, ir_ready, n); deallocate[ir.Module](p.s.alloc, irs, n); deallocate[bool](p.s.alloc, ready, n); deallocate[sema.SemaResult](p.s.alloc, results, n); print.eprint("error: out of memory\n"); ret 2; }
+    if (is_err[*bool, str](imr)) { deallocate[of.ObjectImage](p.s.alloc, images, n); deallocate[bool](p.s.alloc, ir_ready, n); deallocate[ir.Module](p.s.alloc, irs, n); print.eprint("error: out of memory\n"); ret 2; }
     val image_ready: *bool = unwrap_ok[*bool, str](imr);
 
     var i: u32 = 0;
     for (i < p.module_len) {
-        ready[i]       = false;
         ir_ready[i]    = false;
         image_ready[i] = false;
         i = i + 1;
     }
 
     var code: i64 = 0;
-    val comp_r: Result[bool, str] = compile_modules(p, level, test_mode, verify_ir, verbose, ?ea, results, ready, irs, ir_ready, images, image_ready);
+    val comp_r: Result[bool, str] = compile_modules(p, level, test_mode, verify_ir, verbose, ?ea, irs, ir_ready, images, image_ready);
     if (is_err[bool, str](comp_r)) {
         # a `lower:reported` sentinel means lowering already filed a located
         # diagnostic on the sink; the flush prints it, so skip the raw reprint.
@@ -697,13 +613,11 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
         code = link_artifact(p, emit_obj, verbose, root, out_override, argc, argv, images, out_path);
     }
 
-    free_modules(p, results, ready, irs, ir_ready, images, image_ready);
+    free_modules(p, irs, ir_ready, images, image_ready);
     deallocate[bool](p.s.alloc, image_ready, n);
     deallocate[of.ObjectImage](p.s.alloc, images, n);
     deallocate[bool](p.s.alloc, ir_ready, n);
     deallocate[ir.Module](p.s.alloc, irs, n);
-    deallocate[bool](p.s.alloc, ready, n);
-    deallocate[sema.SemaResult](p.s.alloc, results, n);
     ret code;
 }
 

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -73,6 +73,8 @@ use token:  mach.lang.fe.token;
 
 use comptime: mach.lang.fe.comptime;
 use resolve:  mach.lang.fe.resolve;
+use sema:     mach.lang.fe.sema;
+use type:     mach.lang.type;
 
 use os:  mach.lang.target.os;
 use isa: mach.lang.target.isa;
@@ -234,6 +236,11 @@ pub rec PubConst {
 #                 run_resolve_one, nil until then. NOT freed by dnit_project — the
 #                 query DB owns it (its finalizer frees it) (#1582)
 # resolved:       true once resolve has run
+# sema_result:    borrowed pointer to this module's SemaResult, owned by the
+#                 session query DB as the Q_SEMA handle (keyed by stable_id) and
+#                 reused across rebuilds of an unchanged module; set by
+#                 run_sema_one, nil until then. NOT freed by dnit_project — the
+#                 query DB owns it (its finalizer frees it) (#1583)
 # stable_id:      this module's build-stable identity (session-assigned by FQN);
 #                 unlike the discovery-order ModuleId, it survives a graph reshape,
 #                 so cross-build resolve/sema reuse remaps through it (#1579)
@@ -250,6 +257,7 @@ pub rec ModuleEntry {
     dep_cap:           u32;
     resolve_result:    *resolve.ResolveResult;
     resolved:          bool;
+    sema_result:       *sema.SemaResult;
     stable_id:         sess.StableModuleId;
 }
 
@@ -948,9 +956,9 @@ pub fun dnit_project(p: *Project) {
     var i: u32 = 0;
     for (i < p.module_len) {
         val m: *ModuleEntry = ?p.modules[i];
-        # m.resolve_result is BORROWED from the session query DB (the Q_RESOLVE
-        # handle), which owns and frees it (and reuses it across rebuilds). do NOT
-        # free it here.
+        # m.resolve_result / m.sema_result are BORROWED from the session query DB
+        # (the Q_RESOLVE / Q_SEMA handles), which own and free them (and reuse them
+        # across rebuilds). do NOT free them here.
         comptime.dnit(?m.ctx);
         # m.a is BORROWED from the session query DB (the Q_PARSE handle), which owns
         # and frees it (and reuses it across rebuilds). do NOT free it here.
@@ -2005,6 +2013,7 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) Result[sess.ModuleId, s
     m.dep_cap           = 0;
     m.resolve_result    = nil;
     m.resolved          = false;
+    m.sema_result       = nil;
     p.modules[p.module_len] = m;
     p.module_len = p.module_len + 1;
 
@@ -2224,6 +2233,14 @@ fun ensure_query_pipeline(s: *sess.Session) Result[bool, str] {
     if (!query.registered(?s.queries, query.Q_EXPORTS)) {
         val re: Result[bool, str] = query.register_derived(?s.queries, query.Q_EXPORTS, q_exports_compute);
         if (is_err[bool, str](re)) { ret re; }
+    }
+    if (!query.registered(?s.queries, query.Q_SEMA)) {
+        val rsm: Result[bool, str] = query.register_derived_owned(?s.queries, query.Q_SEMA, q_sema_compute, q_sema_finalize);
+        if (is_err[bool, str](rsm)) { ret rsm; }
+    }
+    if (!query.registered(?s.queries, query.Q_TYPED_EXPORTS)) {
+        val rte: Result[bool, str] = query.register_derived(?s.queries, query.Q_TYPED_EXPORTS, q_typed_exports_compute);
+        if (is_err[bool, str](rte)) { ret rte; }
     }
     ret ok[bool, str](true);
 }
@@ -3040,6 +3057,14 @@ fun register_module_asts(p: *Project) Result[bool, str] {
         # remaps its stale ModuleIds into this build's numbering (#1582).
         val rs: Result[bool, str] = sess.register_stable_mid(p.s, m.stable_id, i);
         if (is_err[bool, str](rs)) { ret rs; }
+        # publish this module's current per-build ModuleId as the Q_MODULE_NUMBER
+        # input, keyed by its stable id. set_input's early-cutoff leaves last_changed
+        # untouched when the number is unchanged (a content-only edit), and advances
+        # it on a graph reshape that renumbers the module — the signal Q_SEMA depends
+        # on to re-type-check a module whose interned type identities went stale (#1583).
+        var num: u32 = i::u32;
+        val rn: Result[bool, str] = query.set_input(?p.s.queries, query.Q_MODULE_NUMBER, m.stable_id::u64, (?num)::*u8, 4);
+        if (is_err[bool, str](rn)) { ret rn; }
         i = i + 1;
     }
     ret ok[bool, str](true);
@@ -3238,6 +3263,360 @@ fun build_resolve_deps_owned(p: *Project, m: *ModuleEntry) Result[resolve.Resolv
     deallocate[sess.ModuleId](p.s.alloc, list, p.module_len::usize);
     deallocate[bool](p.s.alloc, visited, p.module_len::usize);
     ret r;
+}
+
+# run_sema_pass: type-check every module in topo order through the Q_SEMA query.
+# the active Project is installed on the session for the pass so the compute can
+# reach the per-build module graph; topo order guarantees each module's deps are
+# already type-checked (their Q_SEMA / Q_TYPED_EXPORTS entries valid) before it
+# runs. resolve must have run first (each module's resolve_result is borrowed by
+# the compute). callable standalone (the CLI compile path and the tests drive it);
+# build_project deliberately stops at resolve (#1583).
+# ---
+# p:   the active project; its topo order and per-build module graph drive the pass
+# ret: true once every module is type-checked, or the first error
+pub fun run_sema_pass(p: *Project) Result[bool, str] {
+    sess.set_active_project(p.s, p::ptr);
+
+    var i: u32 = 0;
+    for (i < p.topo_len) {
+        val mid: sess.ModuleId = p.topo[i];
+        val r: Result[bool, str] = run_sema_one(p, mid);
+        if (is_err[bool, str](r)) {
+            sess.set_active_project(p.s, nil);
+            ret r;
+        }
+        i = i + 1;
+    }
+    sess.set_active_project(p.s, nil);
+    ret ok[bool, str](true);
+}
+
+# run_sema_one: fetch module `mid`'s SemaResult through Q_SEMA — computed fresh
+# when its resolution, a dep's typed surface, the build config, or its own module
+# number changed, reused otherwise — borrow it onto the ModuleEntry, refresh its
+# typed-export fingerprint in topo order (so dependents validate against current
+# fingerprints), and publish its typing / resolution / comptime ctx to the session
+# for the back-end monomorphizer. the result is borrowed from the query DB.
+fun run_sema_one(p: *Project, mid: sess.ModuleId) Result[bool, str] {
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+
+    emit_stage(p, "sema", m.fqn);
+
+    val e_r: Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_SEMA, m.stable_id::u64);
+    if (is_err[*query.QueryEntry, str](e_r)) { ret err[bool, str](unwrap_err[*query.QueryEntry, str](e_r)); }
+    val sr: *sema.SemaResult = sema_handle_decode(unwrap_ok[*query.QueryEntry, str](e_r));
+    if (sr == nil) { ret err[bool, str]("Q_SEMA produced no result handle"); }
+
+    # refresh this module's typed-export fingerprint NOW, in topo order. the engine's
+    # validator compares a dep's STORED last_changed without recomputing derived deps,
+    # so a dependent is only firewalled (private edit: identical bytes) or invalidated
+    # (pub type change: bytes differ) correctly when its deps' fingerprints are already
+    # current. mirror of run_resolve_one's Q_EXPORTS refresh (#1582/#1583).
+    val tx_r: Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_TYPED_EXPORTS, m.stable_id::u64);
+    if (is_err[*query.QueryEntry, str](tx_r)) { ret err[bool, str](unwrap_err[*query.QueryEntry, str](tx_r)); }
+
+    m.sema_result = sr;
+
+    # publish this module's typing and name-resolution to the session so the back-end
+    # monomorphizer can lower a generic template body (declared in any module) against
+    # the typing of its declaring module. the comptime ctx is published too, so a
+    # value-parameter instance folds its `$if` gates against this module's `pub val`s.
+    val rs: Result[bool, str] = sess.register_module_sema(p.s, mid, sr::ptr);
+    if (is_err[bool, str](rs)) { ret err[bool, str](unwrap_err[bool, str](rs)); }
+    val rr2: Result[bool, str] = sess.register_module_resolve(p.s, mid, m.resolve_result::ptr);
+    if (is_err[bool, str](rr2)) { ret err[bool, str](unwrap_err[bool, str](rr2)); }
+    val rc: Result[bool, str] = sess.register_module_comptime(p.s, mid, (?m.ctx)::ptr);
+    if (is_err[bool, str](rc)) { ret err[bool, str](unwrap_err[bool, str](rc)); }
+    ret ok[bool, str](true);
+}
+
+# q_sema_compute: the Q_SEMA derived compute — type-check one module against its
+# dependencies and return the SemaResult as an opaque owned handle. reaches the
+# per-build module graph through the session's active Project, and records the deps
+# that make the entry incremental:
+#   - Q_RESOLVE(module):       a resolution change re-type-checks this module;
+#   - Q_TARGET:                a build-config change re-checks every module ($if forks);
+#   - Q_MODULE_NUMBER(module): a graph reshape that renumbers this module re-checks it,
+#                              since its nominal/instance TypeIds embed the per-build
+#                              ModuleId — a reused result whose own id moved is stale;
+#   - Q_TYPED_EXPORTS(dep) for every module in the resolve dep closure: a dep's
+#                              visible TYPE change re-checks this module, while an
+#                              impl-only edit early-cuts at Q_TYPED_EXPORTS (firewall).
+fun q_sema_compute(db: *query.QueryDb, key: u64, alloc: *Allocator) Result[query.QueryOutput, str] {
+    val s: *sess.Session = db.ctx::*sess.Session;
+    if (s == nil) { ret err[query.QueryOutput, str]("Q_SEMA: query db has no session context"); }
+    val pp: ptr = sess.active_project(s);
+    if (pp == nil) { ret err[query.QueryOutput, str]("Q_SEMA: no active project for the sema pass"); }
+    val p: *Project = pp::*Project;
+
+    val stable: sess.StableModuleId = key::u32::sess.StableModuleId;
+    val mid: sess.ModuleId = sess.module_id_for_stable(s, stable);
+    if (mid == sess.MODULE_NIL) { ret err[query.QueryOutput, str]("Q_SEMA: stable id not loaded this build"); }
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    val a: *ast.Ast = m.a;
+    if (a == nil) { ret err[query.QueryOutput, str]("Q_SEMA: module has no parsed AST"); }
+    val rr: *resolve.ResolveResult = m.resolve_result;
+    if (rr == nil) { ret err[query.QueryOutput, str]("Q_SEMA: module has no resolve result"); }
+
+    val rrd: Result[bool, str] = query.record_dep(db, query.Q_SEMA, key, query.Q_RESOLVE, key);
+    if (is_err[bool, str](rrd)) { ret err[query.QueryOutput, str](unwrap_err[bool, str](rrd)); }
+    val rt: Result[bool, str] = query.record_dep(db, query.Q_SEMA, key, query.Q_TARGET, 0);
+    if (is_err[bool, str](rt)) { ret err[query.QueryOutput, str](unwrap_err[bool, str](rt)); }
+    val rn: Result[bool, str] = query.record_dep(db, query.Q_SEMA, key, query.Q_MODULE_NUMBER, key);
+    if (is_err[bool, str](rn)) { ret err[query.QueryOutput, str](unwrap_err[bool, str](rn)); }
+
+    # record the typed-export firewall dep on each module in the resolve dep closure
+    # (direct deps plus re-export targets), fetching it first so the recorded revision
+    # is current. a duplicate (a bare-alias dep appears twice) records a redundant —
+    # harmless — dep. the resolve closure suffices: a transitively-referenced type's
+    # change cascades hop by hop through each importer's typed export (#1583).
+    val deps_r: Result[resolve.ResolveDeps, str] = build_resolve_deps_owned(p, m);
+    if (is_err[resolve.ResolveDeps, str](deps_r)) { ret err[query.QueryOutput, str](unwrap_err[resolve.ResolveDeps, str](deps_r)); }
+    var deps: resolve.ResolveDeps = unwrap_ok[resolve.ResolveDeps, str](deps_r);
+    var di: u32 = 0;
+    for (di < deps.count) {
+        val dep_mid: sess.ModuleId = deps.entries[di].module;
+        if (dep_mid::u32 < p.module_len) {
+            val dep_stable: sess.StableModuleId = p.modules[dep_mid::u32].stable_id;
+            val ge: Result[*query.QueryEntry, str] = query.get(db, query.Q_TYPED_EXPORTS, dep_stable::u64);
+            if (is_err[*query.QueryEntry, str](ge)) {
+                free_resolve_deps(s.alloc, ?deps);
+                ret err[query.QueryOutput, str](unwrap_err[*query.QueryEntry, str](ge));
+            }
+            val rd: Result[bool, str] = query.record_dep(db, query.Q_SEMA, key, query.Q_TYPED_EXPORTS, dep_stable::u64);
+            if (is_err[bool, str](rd)) {
+                free_resolve_deps(s.alloc, ?deps);
+                ret err[query.QueryOutput, str](unwrap_err[bool, str](rd));
+            }
+        }
+        di = di + 1;
+    }
+    free_resolve_deps(s.alloc, ?deps);
+
+    # the typing snapshots sema reads for cross-module symbol types: every module
+    # already type-checked this build (topo-earlier), keyed by ModuleId — exactly the
+    # set the in-place compile path's build_sema_deps exposed. correct because each
+    # lookup matches an exact origin and never a sibling.
+    val sdeps_r: Result[sema.SemaDeps, str] = build_sema_deps_query(p);
+    if (is_err[sema.SemaDeps, str](sdeps_r)) { ret err[query.QueryOutput, str](unwrap_err[sema.SemaDeps, str](sdeps_r)); }
+    var sdeps: sema.SemaDeps = unwrap_ok[sema.SemaDeps, str](sdeps_r);
+
+    val sem_r: Result[sema.SemaResult, str] = sema.sema(s, a, rr, ?sdeps, ?m.ctx, mid);
+    free_sema_deps_query(s.alloc, ?sdeps);
+    if (is_err[sema.SemaResult, str](sem_r)) { ret err[query.QueryOutput, str](unwrap_err[sema.SemaResult, str](sem_r)); }
+    var result: sema.SemaResult = unwrap_ok[sema.SemaResult, str](sem_r);
+
+    val br: Result[*sema.SemaResult, str] = allocate[sema.SemaResult](alloc, 1::usize);
+    if (is_err[*sema.SemaResult, str](br)) {
+        sema.dnit_result(?result);
+        ret err[query.QueryOutput, str](unwrap_err[*sema.SemaResult, str](br));
+    }
+    val box: *sema.SemaResult = unwrap_ok[*sema.SemaResult, str](br);
+    box[0] = result;
+    ret sema_handle_encode(alloc, box);
+}
+
+# q_sema_finalize: release the SemaResult a Q_SEMA handle owns, called by the engine
+# before it frees the handle buffer (on recompute, invalidate, dnit).
+fun q_sema_finalize(value: *u8, value_len: u32, alloc: *Allocator) {
+    if (value == nil || value_len::usize < $size_of(ptr)) { ret; }
+    val slot: *ptr = value::ptr::*ptr;
+    val r: *sema.SemaResult = slot[0]::*sema.SemaResult;
+    if (r == nil) { ret; }
+    sema.dnit_result(r);
+    deallocate[sema.SemaResult](alloc, r, 1::usize);
+}
+
+# sema_handle_encode: wrap a heap SemaResult pointer as a pointer-sized opaque handle
+# buffer — the Q_SEMA query value. like the Q_PARSE / Q_RESOLVE handles, the heavy
+# pointer-graph artifact lives in the byte-buffer DB as a handle, never serialized.
+fun sema_handle_encode(alloc: *Allocator, r: *sema.SemaResult) Result[query.QueryOutput, str] {
+    val n: u32 = $size_of(ptr)::u32;
+    val rb: Result[*u8, str] = allocate[u8](alloc, n::usize);
+    if (is_err[*u8, str](rb)) {
+        sema.dnit_result(r);
+        deallocate[sema.SemaResult](alloc, r, 1::usize);
+        ret err[query.QueryOutput, str](unwrap_err[*u8, str](rb));
+    }
+    val buf: *u8 = unwrap_ok[*u8, str](rb);
+    val slot: *ptr = buf::ptr::*ptr;
+    slot[0] = r::ptr;
+    var out: query.QueryOutput;
+    out.bytes = buf;
+    out.len   = n;
+    ret ok[query.QueryOutput, str](out);
+}
+
+# sema_handle_decode: read the SemaResult pointer back out of a Q_SEMA handle entry,
+# or nil when the entry carries no value.
+fun sema_handle_decode(e: *query.QueryEntry) *sema.SemaResult {
+    if (e.value == nil || e.value_len::usize < $size_of(ptr)) { ret nil; }
+    val slot: *ptr = e.value::ptr::*ptr;
+    ret slot[0]::*sema.SemaResult;
+}
+
+# build_sema_deps_query: assemble the SemaDeps for a Q_SEMA compute — one ModuleSema
+# entry per module already type-checked this build (its sema_result is borrowed onto
+# the ModuleEntry by an earlier run_sema_one). topo order guarantees the set covers
+# every module the analysed one references; the module being analysed has a nil
+# sema_result (set only after its compute), so it is naturally excluded. each entry
+# borrows the producer's decl_type array (owned by the query DB), so the SemaDeps is
+# freed with free_sema_deps_query — which frees only the entries array.
+fun build_sema_deps_query(p: *Project) Result[sema.SemaDeps, str] {
+    var deps: sema.SemaDeps;
+    deps.entries = nil;
+    deps.count   = 0;
+
+    var ready_count: u32 = 0;
+    var j: u32 = 0;
+    for (j < p.module_len) {
+        if (p.modules[j].sema_result != nil) { ready_count = ready_count + 1; }
+        j = j + 1;
+    }
+    if (ready_count == 0) { ret ok[sema.SemaDeps, str](deps); }
+
+    val r: Result[*sema.ModuleSema, str] = allocate[sema.ModuleSema](p.s.alloc, ready_count::usize);
+    if (is_err[*sema.ModuleSema, str](r)) { ret err[sema.SemaDeps, str](unwrap_err[*sema.ModuleSema, str](r)); }
+    val arr: *sema.ModuleSema = unwrap_ok[*sema.ModuleSema, str](r);
+
+    var i: u32 = 0;
+    var k: u32 = 0;
+    for (i < p.module_len) {
+        val sr: *sema.SemaResult = p.modules[i].sema_result;
+        if (sr != nil) {
+            var ms: sema.ModuleSema;
+            ms.path       = p.modules[i].fqn;
+            ms.module     = i::sess.ModuleId;
+            ms.decl_type  = sr.decl_type;
+            ms.decl_count = sr.decl_count;
+            arr[k] = ms;
+            k = k + 1;
+        }
+        i = i + 1;
+    }
+
+    deps.entries = arr;
+    deps.count   = ready_count;
+    ret ok[sema.SemaDeps, str](deps);
+}
+
+# free_sema_deps_query: release the entries array build_sema_deps_query allocated. the
+# borrowed decl_type arrays it points into are owned by the query DB, NOT freed here.
+fun free_sema_deps_query(alloc: *Allocator, deps: *sema.SemaDeps) {
+    if (deps.entries == nil) { ret; }
+    deallocate[sema.ModuleSema](alloc, deps.entries, deps.count::usize);
+    deps.entries = nil;
+    deps.count   = 0;
+}
+
+# q_typed_exports_compute: the Q_TYPED_EXPORTS derived compute — a deterministic
+# byte fingerprint of one module's TYPED public surface (#1583). reads the module's
+# SemaResult through Q_SEMA (recording the dep, so any re-type-check refreshes this)
+# and fingerprints exactly what an importer's type-checking binds against from this
+# module DIRECTLY: per locally-declared pub symbol, its kind, name, declared type
+# (raw TypeId), and — for a nominal — its field table (name + field TypeId per
+# field). re-exported pub symbols contribute identity only; their types are
+# fingerprinted by their origin module's Q_TYPED_EXPORTS, which a dependent depends
+# on directly via the resolve dep closure. raw TypeIds are renumber-sensitive on
+# purpose: a dep whose nominal TypeId moved (graph reshape) changes these bytes and
+# re-checks importers, while an impl-only edit leaves them identical (the firewall).
+# a plain byte-valued derived kind (early-cutoff ON), keyed by StableModuleId.
+fun q_typed_exports_compute(db: *query.QueryDb, key: u64, alloc: *Allocator) Result[query.QueryOutput, str] {
+    val s: *sess.Session = db.ctx::*sess.Session;
+    if (s == nil) { ret err[query.QueryOutput, str]("Q_TYPED_EXPORTS: query db has no session context"); }
+    val pp: ptr = sess.active_project(s);
+    if (pp == nil) { ret err[query.QueryOutput, str]("Q_TYPED_EXPORTS: no active project for the sema pass"); }
+    val p: *Project = pp::*Project;
+
+    val stable: sess.StableModuleId = key::u32::sess.StableModuleId;
+    val mid: sess.ModuleId = sess.module_id_for_stable(s, stable);
+    if (mid == sess.MODULE_NIL) { ret err[query.QueryOutput, str]("Q_TYPED_EXPORTS: stable id not loaded this build"); }
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    val rr: *resolve.ResolveResult = m.resolve_result;
+    if (rr == nil) { ret err[query.QueryOutput, str]("Q_TYPED_EXPORTS: module has no resolve result"); }
+
+    val e_r: Result[*query.QueryEntry, str] = query.get(db, query.Q_SEMA, key);
+    if (is_err[*query.QueryEntry, str](e_r)) { ret err[query.QueryOutput, str](unwrap_err[*query.QueryEntry, str](e_r)); }
+    val sr: *sema.SemaResult = sema_handle_decode(unwrap_ok[*query.QueryEntry, str](e_r));
+    if (sr == nil) { ret err[query.QueryOutput, str]("Q_TYPED_EXPORTS: module has no sema result"); }
+
+    val rd: Result[bool, str] = query.record_dep(db, query.Q_TYPED_EXPORTS, key, query.Q_SEMA, key);
+    if (is_err[bool, str](rd)) { ret err[query.QueryOutput, str](unwrap_err[bool, str](rd)); }
+
+    var fb: FpBuf;
+    fb.alloc = alloc;
+    fb.buf   = nil;
+    fb.len   = 0;
+    fb.cap   = 0;
+
+    val wr: Result[bool, str] = fp_typed_surface(?fb, s, mid, rr, sr);
+    if (is_err[bool, str](wr)) {
+        if (fb.buf != nil && fb.cap > 0) { deallocate[u8](alloc, fb.buf, fb.cap::usize); }
+        ret err[query.QueryOutput, str](unwrap_err[bool, str](wr));
+    }
+
+    var out: query.QueryOutput;
+    out.bytes = fb.buf;
+    out.len   = fb.len;
+    ret ok[query.QueryOutput, str](out);
+}
+
+# fp_typed_surface: append the typed pub surface of module `mid` to the fingerprint.
+# the pub symbols occupy indices [0, pub_count) of `rr` in source-deterministic order.
+# each contributes (kind, name); a LOCALLY-declared symbol (origin == mid) also
+# contributes its declared type (sr.decl_type[decl], raw) and, when that type has a
+# field table, the table — so a pub field-type change re-checks importers. a
+# re-exported symbol (origin != mid) contributes a sentinel in place of a type: its
+# type lives in its origin module's typed export, which a dependent depends on
+# directly. a resolution-level surface change (added/removed/reordered pub symbol,
+# changed identity) recomputes Q_SEMA and so this fingerprint transitively (#1583).
+fun fp_typed_surface(fb: *FpBuf, s: *sess.Session, mid: sess.ModuleId, rr: *resolve.ResolveResult, sr: *sema.SemaResult) Result[bool, str] {
+    val pc: Result[bool, str] = fp_u32(fb, rr.pub_count);
+    if (is_err[bool, str](pc)) { ret pc; }
+    if (rr.symbols == nil) { ret ok[bool, str](true); }
+
+    var i: u32 = 0;
+    for (i < rr.pub_count) {
+        val sym: *resolve.Symbol = ?rr.symbols[i];
+        val rk: Result[bool, str] = fp_u8(fb, sym.kind::u8);    if (is_err[bool, str](rk)) { ret rk; }
+        val rn: Result[bool, str] = fp_u32(fb, sym.name::u32);  if (is_err[bool, str](rn)) { ret rn; }
+        if (sym.origin == mid && sym.decl::u32 < sr.decl_count) {
+            val ty: type.TypeId = sr.decl_type[sym.decl];
+            val rty: Result[bool, str] = fp_u32(fb, ty::u32);   if (is_err[bool, str](rty)) { ret rty; }
+            val rf:  Result[bool, str] = fp_type_fields(fb, s, ty); if (is_err[bool, str](rf)) { ret rf; }
+        }
+        or {
+            # re-export / out-of-range: a type sentinel, no field table.
+            val rty: Result[bool, str] = fp_u32(fb, 0xFFFFFFFF); if (is_err[bool, str](rty)) { ret rty; }
+            val rf:  Result[bool, str] = fp_u32(fb, 0);          if (is_err[bool, str](rf)) { ret rf; }
+        }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# fp_type_fields: append a nominal type's field table to the fingerprint — the field
+# count followed by each field's (name, raw field TypeId) in declaration order — so a
+# pub record/union whose field name or field type changes advances the firewall. a
+# type with no registered field table (a primitive, function, pointer, or a record
+# never resolved this build) contributes a zero count. raw field TypeIds are
+# renumber-sensitive on purpose (a field of a renumbered dep's type changes here).
+fun fp_type_fields(fb: *FpBuf, s: *sess.Session, ty: type.TypeId) Result[bool, str] {
+    if (ty == type.TYPE_NIL || ty == type.TYPE_ERROR) { ret fp_u32(fb, 0); }
+    val ft_opt: Option[*type.FieldTable] = type.field_table_for(?s.types, ty);
+    if (is_none[*type.FieldTable](ft_opt)) { ret fp_u32(fb, 0); }
+    val ft: *type.FieldTable = unwrap[*type.FieldTable](ft_opt);
+    val rc: Result[bool, str] = fp_u32(fb, ft.fields_len);
+    if (is_err[bool, str](rc)) { ret rc; }
+    var i: u32 = 0;
+    for (i < ft.fields_len) {
+        val fe: *type.FieldEntry = type.field_entry_at(?s.types, ft, i);
+        val rn: Result[bool, str] = fp_u32(fb, fe.name::u32); if (is_err[bool, str](rn)) { ret rn; }
+        val rt: Result[bool, str] = fp_u32(fb, fe.ty::u32);   if (is_err[bool, str](rt)) { ret rt; }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
 }
 
 # set_build_config_input: serialize the build configuration the comptime ctx forks

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -3278,6 +3278,13 @@ fun build_resolve_deps_owned(p: *Project, m: *ModuleEntry) Result[resolve.Resolv
 pub fun run_sema_pass(p: *Project) Result[bool, str] {
     sess.set_active_project(p.s, p::ptr);
 
+    # open a fresh field-table epoch for this build: a record keeps its TypeId across
+    # rebuilds while its field types may have changed, so a builder must rebuild a
+    # table stamped with an older epoch rather than reuse its stale layout (#1583). a
+    # fresh CLI session runs its single build at epoch 1 — no observable difference
+    # from the pre-epoch build-once behaviour.
+    type.field_epoch_bump(?p.s.types);
+
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: sess.ModuleId = p.topo[i];
@@ -5123,6 +5130,423 @@ test "driver incremental: a re-exporter propagates a leaf surface change two hop
     if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_rr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
     if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.mid"),  ?sB, ut_rr_of(?pB, ?sB, "uniontest.mid")))  { bad = 1; }
     if (!rr_struct_equal(?sA, ut_rr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_rr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
+
+    dnit_project(?pB);
+    sess.dnit(?sB);
+    dnit_project(?pA2);
+    fs.remove_all(?alloc, root);
+    sess.dnit(?sA);
+    ret bad;
+}
+
+# ut_sema_lc: the last_changed revision of module `stable`'s Q_SEMA entry on session
+# `s`, or a sentinel when absent. an owned-handle shard never early-cuts, so an
+# unchanged value means the entry was NOT recomputed — the sema reuse probe (#1583).
+fun ut_sema_lc(s: *sess.Session, stable: sess.StableModuleId) query.Revision {
+    val e: Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_SEMA, stable::u64);
+    if (is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret unwrap_ok[*query.QueryEntry, str](e).last_changed;
+}
+
+# ut_module_fqn_text_equal: whether two ModuleIds name the same module by FQN text
+# across two sessions. an anonymous nominal's origin is MODULE_NIL in both; the test
+# fixtures use only named records, so two MODULE_NIL origins (with a matched decl
+# key) are treated as equal here.
+fun ut_module_fqn_text_equal(sa: *sess.Session, ma: sess.ModuleId, sb: *sess.Session, mb: sess.ModuleId) bool {
+    if (ma == sess.MODULE_NIL && mb == sess.MODULE_NIL) { ret true; }
+    if (ma == sess.MODULE_NIL || mb == sess.MODULE_NIL) { ret false; }
+    ret ut_name_text_equal(sa, sess.module_fqn(sa, ma), sb, sess.module_fqn(sb, mb));
+}
+
+# ty_struct_equal: whether two TypeIds denote the same semantic type across two
+# sessions — the cross-session comparison the sema incremental tests assert a reused
+# (or recomputed) SemaResult against an independent from-scratch build. the incremental
+# session interned its types in a different order (and a graph reshape renumbered the
+# ModuleId embedded in nominal identities), so a raw TypeId equality would not hold;
+# this compares STRUCTURALLY: primitives by kind, ptr/array/fun by recursion, nominals
+# by (declaring module FQN text, decl) — reshape-stable — and generic params by
+# (owner, index). recursion terminates because a nominal compares by identity, never
+# by recursing into its (possibly self-referential) field types. anonymous aggregates
+# (MODULE_NIL origin, per-session structural key) are out of the fixtures' scope.
+fun ty_struct_equal(sa: *sess.Session, ta: type.TypeId, sb: *sess.Session, tb: type.TypeId) bool {
+    if (ta == type.TYPE_NIL && tb == type.TYPE_NIL) { ret true; }
+    if (ta == type.TYPE_ERROR && tb == type.TYPE_ERROR) { ret true; }
+    if (ta == type.TYPE_NIL || tb == type.TYPE_NIL) { ret false; }
+    if (ta == type.TYPE_ERROR || tb == type.TYPE_ERROR) { ret false; }
+
+    val oa: Option[*type.Type] = type.get(?sa.types, ta);
+    val ob: Option[*type.Type] = type.get(?sb.types, tb);
+    if (is_none[*type.Type](oa) || is_none[*type.Type](ob)) { ret false; }
+    val a: *type.Type = unwrap[*type.Type](oa);
+    val b: *type.Type = unwrap[*type.Type](ob);
+    if (a.kind != b.kind) { ret false; }
+    val k: type.TypeKind = a.kind;
+
+    # kinds below TYPE_POINTER are the payload-free primitives; equal by kind alone.
+    if (k::u32 < type.TYPE_POINTER::u32) { ret true; }
+    if (k == type.TYPE_PACK) { ret true; }
+    if (k == type.TYPE_POINTER) {
+        ret ty_struct_equal(sa, a.data.pointer.base, sb, b.data.pointer.base);
+    }
+    if (k == type.TYPE_ARRAY) {
+        if (a.data.array.count != b.data.array.count) { ret false; }
+        ret ty_struct_equal(sa, a.data.array.base, sb, b.data.array.base);
+    }
+    if (k == type.TYPE_FUN) {
+        if (a.data.fn.params_len != b.data.fn.params_len) { ret false; }
+        if (!ty_struct_equal(sa, a.data.fn.ret_ty, sb, b.data.fn.ret_ty)) { ret false; }
+        var i: u32 = 0;
+        for (i < a.data.fn.params_len) {
+            val pa: Option[type.TypeId] = type.get_param(?sa.types, a.data.fn.params_start + i);
+            val pb: Option[type.TypeId] = type.get_param(?sb.types, b.data.fn.params_start + i);
+            if (is_none[type.TypeId](pa) || is_none[type.TypeId](pb)) { ret false; }
+            if (!ty_struct_equal(sa, unwrap[type.TypeId](pa), sb, unwrap[type.TypeId](pb))) { ret false; }
+            i = i + 1;
+        }
+        ret true;
+    }
+    if (k == type.TYPE_REC || k == type.TYPE_UNI) {
+        if (a.data.nominal.decl != b.data.nominal.decl) { ret false; }
+        ret ut_module_fqn_text_equal(sa, a.data.nominal.origin, sb, b.data.nominal.origin);
+    }
+    if (k == type.TYPE_GENERIC_PARAM) {
+        ret a.data.generic_param.owner == b.data.generic_param.owner
+            && a.data.generic_param.index == b.data.generic_param.index;
+    }
+    if (k == type.TYPE_INSTANCE) {
+        if (a.data.instance.target_decl != b.data.instance.target_decl) { ret false; }
+        if (a.data.instance.args_len != b.data.instance.args_len) { ret false; }
+        if (!ut_module_fqn_text_equal(sa, a.data.instance.target_origin, sb, b.data.instance.target_origin)) { ret false; }
+        var i: u32 = 0;
+        for (i < a.data.instance.args_len) {
+            val pa: Option[type.TypeId] = type.get_param(?sa.types, a.data.instance.args_start + i);
+            val pb: Option[type.TypeId] = type.get_param(?sb.types, b.data.instance.args_start + i);
+            if (is_none[type.TypeId](pa) || is_none[type.TypeId](pb)) { ret false; }
+            if (!ty_struct_equal(sa, unwrap[type.TypeId](pa), sb, unwrap[type.TypeId](pb))) { ret false; }
+            i = i + 1;
+        }
+        ret true;
+    }
+    ret false;
+}
+
+# sr_struct_equal: whether two SemaResults are structurally identical — the
+# type-checking-correctness comparison the incremental tests assert a reused (or
+# recomputed) result against an independent from-scratch build. compares the three
+# parallel TypeId arrays (every expr, syntactic type, and decl) element-wise under
+# ty_struct_equal, so a reused result whose interned TypeIds differ numerically from
+# the fresh build's still compares equal iff they denote the same types.
+fun sr_struct_equal(sa: *sess.Session, sra: *sema.SemaResult, sb: *sess.Session, srb: *sema.SemaResult) bool {
+    if (sra == nil || srb == nil) { ret false; }
+    if (sra.expr_count != srb.expr_count) { ret false; }
+    if (sra.type_count != srb.type_count) { ret false; }
+    if (sra.decl_count != srb.decl_count) { ret false; }
+
+    var i: u32 = 0;
+    for (i < sra.expr_count) {
+        if (!ty_struct_equal(sa, sra.expr_type[i], sb, srb.expr_type[i])) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < sra.type_count) {
+        if (!ty_struct_equal(sa, sra.type_resolved_ty[i], sb, srb.type_resolved_ty[i])) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < sra.decl_count) {
+        if (!ty_struct_equal(sa, sra.decl_type[i], sb, srb.decl_type[i])) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# ut_sr_of: the borrowed SemaResult of module `fqn` in project `p` (set by
+# run_sema_pass), or nil.
+fun ut_sr_of(p: *Project, s: *sess.Session, fqn: str) *sema.SemaResult {
+    val mid: sess.ModuleId = ut_mid(p, s, fqn);
+    if (mid == sess.MODULE_NIL) { ret nil; }
+    ret p.modules[mid::u32].sema_result;
+}
+
+test "driver incremental: a leaf's private body edit firewalls the importer's sema, which still equals a from-scratch build (#1583)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var sA: sess.Session = unwrap_ok[sess.Session, str](sr);
+    if (is_err[bool, str](tgt.register_all(?sA.registry))) { sess.dnit(?sA); ret 1; }
+
+    # main imports leaf.fa and types its return; editing fa's BODY (not its signature)
+    # leaves leaf's typed surface byte-identical, so main's type-checking is firewalled.
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "leaf.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.leaf.fa;\nfun main() i32 { val x = fa(); ret x; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+
+    val root_r: Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (is_err[str, str](root_r)) { sess.dnit(?sA); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    val pA1r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA1r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA1: Project = unwrap_ok[Project, str](pA1r);
+    if (is_err[bool, str](run_sema_pass(?pA1))) { dnit_project(?pA1); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val st_main: sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
+    val st_leaf: sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.leaf");
+    val lc_main_1: query.Revision = ut_sema_lc(?sA, st_main);
+    val lc_leaf_1: query.Revision = ut_sema_lc(?sA, st_leaf);
+    dnit_project(?pA1);
+
+    # private body edit: fa's signature/type unchanged.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val leaf_path: str = ut_cc3(?alloc, src_dir, "/", "leaf.mach");
+    val leaf_v2: str = "pub fun fa() i32 { val t: i32 = 1; ret t; }\n";
+    if (is_err[bool, str](fs.write_file(leaf_path, leaf_v2, str_len(leaf_v2), 420))) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    val pA2r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA2r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA2: Project = unwrap_ok[Project, str](pA2r);
+    if (is_err[bool, str](run_sema_pass(?pA2))) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val lc_main_2: query.Revision = ut_sema_lc(?sA, st_main);
+    val lc_leaf_2: query.Revision = ut_sema_lc(?sA, st_leaf);
+
+    # firewall: the importer was NOT re-type-checked; the edited leaf WAS.
+    if (lc_main_2 != lc_main_1) { bad = 1; }
+    if (lc_leaf_2 == lc_leaf_1) { bad = 1; }
+
+    # from-scratch build of the SAME (v2) source on a fresh session.
+    val sr2: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr2)) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var sB: sess.Session = unwrap_ok[sess.Session, str](sr2);
+    if (is_err[bool, str](tgt.register_all(?sB.registry))) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val pBr: Result[Project, str] = build_project_union(?sB, root);
+    if (is_err[Project, str](pBr)) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pB: Project = unwrap_ok[Project, str](pBr);
+    if (is_err[bool, str](run_sema_pass(?pB))) { dnit_project(?pB); sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    # the reused importer result and the re-checked leaf result each equal the
+    # independent from-scratch type-checking.
+    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
+    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
+
+    dnit_project(?pB);
+    sess.dnit(?sB);
+    dnit_project(?pA2);
+    fs.remove_all(?alloc, root);
+    sess.dnit(?sA);
+    ret bad;
+}
+
+test "driver incremental: a leaf's pub return-type change re-checks the importer, which still equals a from-scratch build (#1583)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var sA: sess.Session = unwrap_ok[sess.Session, str](sr);
+    if (is_err[bool, str](tgt.register_all(?sA.registry))) { sess.dnit(?sA); ret 1; }
+
+    # main binds `val x = fa()`, so x's inferred type IS fa's return type. changing
+    # fa's signature i32 -> i64 genuinely changes main's typing (x: i32 -> i64): a
+    # reused result would be a miscompile, so the typed firewall must re-check main.
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "leaf.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.leaf.fa;\nfun main() i32 { val x = fa(); ret x::i32; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+
+    val root_r: Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (is_err[str, str](root_r)) { sess.dnit(?sA); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    val pA1r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA1r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA1: Project = unwrap_ok[Project, str](pA1r);
+    if (is_err[bool, str](run_sema_pass(?pA1))) { dnit_project(?pA1); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val st_main: sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
+    val lc_main_1: query.Revision = ut_sema_lc(?sA, st_main);
+    dnit_project(?pA1);
+
+    # pub return-type change.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val leaf_path: str = ut_cc3(?alloc, src_dir, "/", "leaf.mach");
+    val leaf_v2: str = "pub fun fa() i64 { ret 1; }\n";
+    if (is_err[bool, str](fs.write_file(leaf_path, leaf_v2, str_len(leaf_v2), 420))) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    val pA2r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA2r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA2: Project = unwrap_ok[Project, str](pA2r);
+    if (is_err[bool, str](run_sema_pass(?pA2))) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    # the importer WAS re-type-checked (its dep's typed surface changed).
+    if (ut_sema_lc(?sA, st_main) == lc_main_1) { bad = 1; }
+
+    # from-scratch build of the v2 source on a fresh session.
+    val sr2: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr2)) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var sB: sess.Session = unwrap_ok[sess.Session, str](sr2);
+    if (is_err[bool, str](tgt.register_all(?sB.registry))) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val pBr: Result[Project, str] = build_project_union(?sB, root);
+    if (is_err[Project, str](pBr)) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pB: Project = unwrap_ok[Project, str](pBr);
+    if (is_err[bool, str](run_sema_pass(?pB))) { dnit_project(?pB); sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    # the re-checked importer and the changed leaf each equal the from-scratch build.
+    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
+    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
+
+    dnit_project(?pB);
+    sess.dnit(?sB);
+    dnit_project(?pA2);
+    fs.remove_all(?alloc, root);
+    sess.dnit(?sA);
+    ret bad;
+}
+
+test "driver incremental: a dep's pub record field-type change re-checks a field-accessing importer the resolve firewall misses, matching from-scratch (#1583)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var sA: sess.Session = unwrap_ok[sess.Session, str](sr);
+    if (is_err[bool, str](tgt.register_all(?sA.registry))) { sess.dnit(?sA); ret 1; }
+
+    # main reads leaf.P's field `x`. changing P's FIELD TYPE (i32 -> i64) does NOT
+    # change leaf's RESOLVED surface (resolve never types fields), so the resolve
+    # firewall leaves main un-re-resolved — but it changes leaf's TYPED surface, so
+    # the typed firewall must re-type-check main. without it, main's `p.x` would stay
+    # i32 (a miscompile). this is the case Q_TYPED_EXPORTS catches and Q_EXPORTS misses.
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "leaf.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.leaf.P;\nfun main() i64 { var p: P; p.x = 1; ret p.x::i64; }\n";
+    texts[1] = "pub rec P { x: i32; }\n";
+
+    val root_r: Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (is_err[str, str](root_r)) { sess.dnit(?sA); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    val pA1r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA1r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA1: Project = unwrap_ok[Project, str](pA1r);
+    if (is_err[bool, str](run_sema_pass(?pA1))) { dnit_project(?pA1); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val st_main: sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
+    val lc_sema_main_1: query.Revision = ut_sema_lc(?sA, st_main);
+    val lc_res_main_1:  query.Revision = ut_resolve_lc(?sA, st_main);
+    dnit_project(?pA1);
+
+    # pub record field-type change.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val leaf_path: str = ut_cc3(?alloc, src_dir, "/", "leaf.mach");
+    val leaf_v2: str = "pub rec P { x: i64; }\n";
+    if (is_err[bool, str](fs.write_file(leaf_path, leaf_v2, str_len(leaf_v2), 420))) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    val pA2r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA2r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA2: Project = unwrap_ok[Project, str](pA2r);
+    if (is_err[bool, str](run_sema_pass(?pA2))) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    # the resolve firewall held (main NOT re-resolved: the resolved surface is identical) ...
+    if (ut_resolve_lc(?sA, st_main) != lc_res_main_1) { bad = 1; }
+    # ... but the TYPED firewall fired (main re-type-checked: the field type changed).
+    if (ut_sema_lc(?sA, st_main) == lc_sema_main_1) { bad = 1; }
+
+    # from-scratch build of the v2 source on a fresh session.
+    val sr2: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr2)) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var sB: sess.Session = unwrap_ok[sess.Session, str](sr2);
+    if (is_err[bool, str](tgt.register_all(?sB.registry))) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val pBr: Result[Project, str] = build_project_union(?sB, root);
+    if (is_err[Project, str](pBr)) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pB: Project = unwrap_ok[Project, str](pBr);
+    if (is_err[bool, str](run_sema_pass(?pB))) { dnit_project(?pB); sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
+    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
+
+    dnit_project(?pB);
+    sess.dnit(?sB);
+    dnit_project(?pA2);
+    fs.remove_all(?alloc, root);
+    sess.dnit(?sA);
+    ret bad;
+}
+
+test "driver incremental: a graph reshape renumbers a module's nominal types; Q_SEMA re-checks it and the importer, matching from-scratch (#1583)" {
+    var alloc: Allocator;
+    if (is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var sA: sess.Session = unwrap_ok[sess.Session, str](sr);
+    if (is_err[bool, str](tgt.register_all(?sA.registry))) { sess.dnit(?sA); ret 1; }
+
+    # main imports a.Q (a record) and b.fb. swapping main's use order renumbers a and
+    # b's discovery-order ModuleIds — and a.Q's nominal TypeId embeds a's ModuleId, so
+    # a reused SemaResult for `a` would hold a stale type identity. Q_MODULE_NUMBER must
+    # re-type-check the renumbered `a`, and the changed typed surface must re-check main;
+    # both must equal a from-scratch build of the reshaped graph.
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    texts[0] = "use uniontest.a.Q;\nuse uniontest.b.fb;\nfun main() i32 { var q: Q; q.x = 1; ret q.x + fb(); }\n";
+    texts[1] = "pub rec Q { x: i32; }\n";
+    texts[2] = "pub fun fb() i32 { ret 2; }\n";
+
+    val root_r: Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
+    if (is_err[str, str](root_r)) { sess.dnit(?sA); ret 1; }
+    val root: str = unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    val pA1r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA1r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA1: Project = unwrap_ok[Project, str](pA1r);
+    if (is_err[bool, str](run_sema_pass(?pA1))) { dnit_project(?pA1); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val mid_a1: sess.ModuleId = ut_mid(?pA1, ?sA, "uniontest.a");
+    val st_main: sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
+    val st_a:    sess.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.a");
+    val lc_main_1: query.Revision = ut_sema_lc(?sA, st_main);
+    val lc_a_1:    query.Revision = ut_sema_lc(?sA, st_a);
+    dnit_project(?pA1);
+
+    # reshape: swap the use order so a and b's discovery-order ModuleIds swap.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val main_path: str = ut_cc3(?alloc, src_dir, "/", "main.mach");
+    val main_v2: str = "use uniontest.b.fb;\nuse uniontest.a.Q;\nfun main() i32 { var q: Q; q.x = 1; ret q.x + fb(); }\n";
+    if (is_err[bool, str](fs.write_file(main_path, main_v2, str_len(main_v2), 420))) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    val pA2r: Result[Project, str] = build_project_union(?sA, root);
+    if (is_err[Project, str](pA2r)) { fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pA2: Project = unwrap_ok[Project, str](pA2r);
+    if (is_err[bool, str](run_sema_pass(?pA2))) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    # the reshape actually renumbered `a` (so its nominal TypeId identity moved) ...
+    if (ut_mid(?pA2, ?sA, "uniontest.a") == mid_a1) { bad = 1; }
+    # ... so Q_SEMA re-type-checked the renumbered `a` (the self-number gate fired) ...
+    if (ut_sema_lc(?sA, st_a) == lc_a_1) { bad = 1; }
+    # ... and re-type-checked main (its edited text re-resolves and re-types it).
+    if (ut_sema_lc(?sA, st_main) == lc_main_1) { bad = 1; }
+
+    # from-scratch build of the reshaped source on a fresh session.
+    val sr2: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr2)) { dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var sB: sess.Session = unwrap_ok[sess.Session, str](sr2);
+    if (is_err[bool, str](tgt.register_all(?sB.registry))) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    val pBr: Result[Project, str] = build_project_union(?sB, root);
+    if (is_err[Project, str](pBr)) { sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+    var pB: Project = unwrap_ok[Project, str](pBr);
+    if (is_err[bool, str](run_sema_pass(?pB))) { dnit_project(?pB); sess.dnit(?sB); dnit_project(?pA2); fs.remove_all(?alloc, root); sess.dnit(?sA); ret 1; }
+
+    # the renumbered leaf and the importer each equal the independent from-scratch build,
+    # proving the reused/recomputed type identities are consistent across the reshape.
+    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.a"),    ?sB, ut_sr_of(?pB, ?sB, "uniontest.a")))    { bad = 1; }
+    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
 
     dnit_project(?pB);
     sess.dnit(?sB);

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -367,6 +367,16 @@ pub fun field_table_for(sc: *SemaContext, ty: type.TypeId) Option[*FieldTable] {
     ret type.field_table_for(?sc.s.types, ty);
 }
 
+# field_epoch: the interner's current build epoch — a field-table builder reuses an
+# existing table only when its epoch matches, otherwise rebuilds it with the current
+# layout (so a record's field-type change on a long-lived session is not left stale, #1583).
+# ---
+# sc:  sema context
+# ret: the current epoch
+pub fun field_epoch(sc: *SemaContext) u32 {
+    ret type.field_epoch(?sc.s.types);
+}
+
 # field_lookup: looks up a field by interned name within nominal or instance TypeId `ty`, returning the field's interned type, or none when the type has no table or no such field.
 # ---
 # sc:   sema context

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -106,7 +106,13 @@ pub fun instantiate(
 # s:   the shared session (type universe, AST registry, sources)
 # tid: the TypeId whose field layout must be available
 pub fun ensure_fields(s: *sess.Session, tid: ty.TypeId) {
-    if (is_some[*ty.FieldTable](ty.field_table_for(?s.types, tid))) { ret; }
+    val ex: Option[*ty.FieldTable] = ty.field_table_for(?s.types, tid);
+    if (is_some[*ty.FieldTable](ex)) {
+        # reuse an up-to-date instance table; rebuild one from an older epoch, since
+        # a re-layout (a substituted field type changed across a rebuild) keeps the
+        # instance TypeId but must refresh the cached layout (#1583).
+        if (unwrap[*ty.FieldTable](ex).epoch == ty.field_epoch(?s.types)) { ret; }
+    }
 
     val t_opt: Option[*ty.Type] = ty.get(?s.types, tid);
     if (is_none[*ty.Type](t_opt)) { ret; }
@@ -167,7 +173,10 @@ pub fun generic_nominal_of(s: *sess.Session, origin: sess.ModuleId, gdecl: id.De
 # aggregates are materialized recursively via `substitute`. a no-op when `gnom`
 # has no table or `instance` already has one.
 fun build_instance_table(s: *sess.Session, instance: ty.TypeId, gnom: ty.TypeId) {
-    if (is_some[*ty.FieldTable](ty.field_table_for(?s.types, instance))) { ret; }
+    val iex: Option[*ty.FieldTable] = ty.field_table_for(?s.types, instance);
+    if (is_some[*ty.FieldTable](iex)) {
+        if (unwrap[*ty.FieldTable](iex).epoch == ty.field_epoch(?s.types)) { ret; }
+    }
 
     val gtbl_opt: Option[*ty.FieldTable] = ty.field_table_for(?s.types, gnom);
     if (is_none[*ty.FieldTable](gtbl_opt)) { ret; }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -218,12 +218,16 @@ fun record_type_align(sc: *sema.SemaContext, did: id.DeclId, ty: type.TypeId) {
     }
 }
 
-# populates a field table for nominal `ty` from a typed_names slice, mapping
-# each field's interned name to its resolved semantic type. a table already
-# built (the nominal interned before) is left untouched.
+# populates a field table for nominal `ty` from a typed_names slice, mapping each
+# field's interned name to its resolved semantic type. an up-to-date table (built
+# this build epoch — e.g. a repeated reference to the same anonymous shape) is left
+# untouched; a table from an older epoch is rebuilt, since a record keeps its TypeId
+# across a rebuild while its field types may have changed (#1583).
 fun build_field_table(sc: *sema.SemaContext, ty: type.TypeId, fields_start: u32, fields_len: u32) {
     val existing: Option[*sema.FieldTable] = sema.field_table_for(sc, ty);
-    if (is_some[*sema.FieldTable](existing)) { ret; }
+    if (is_some[*sema.FieldTable](existing)) {
+        if (unwrap[*sema.FieldTable](existing).epoch == sema.field_epoch(sc)) { ret; }
+    }
 
     val tbl_r: Result[u32, str] = sema.field_table_begin(sc, ty);
     if (is_err[u32, str](tbl_r)) { ret; }

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -82,7 +82,13 @@ pub val Q_RESOLVE: QueryKind = 7;
 # on Q_EXPORTS stay valid; a change to the visible surface (incl. a re-exported dep's
 # resolved identity) advances it and re-resolves importers (#1581/#1582).
 pub val Q_EXPORTS: QueryKind = 8;
-# Q_SEMA: derived — a module's SemaResult, keyed on sess.ModuleId.
+# Q_SEMA: derived (owned handle) — a module's SemaResult, keyed on
+# sess.StableModuleId so an unchanged module's type-checking is reused across
+# rebuilds. reads Q_RESOLVE(module), Q_TARGET, Q_MODULE_NUMBER(module), and
+# Q_TYPED_EXPORTS(dep) per import. a reused result's interned TypeIds stay valid
+# because the session type interner is monotonic; a graph reshape that renumbers
+# a module's ModuleId-embedding type identities re-checks it via Q_MODULE_NUMBER
+# (#1583).
 pub val Q_SEMA: QueryKind = 9;
 # Q_LOWER: derived — a module's optimized ir.Module, keyed on sess.ModuleId.
 pub val Q_LOWER: QueryKind = 10;
@@ -90,6 +96,22 @@ pub val Q_LOWER: QueryKind = 10;
 pub val Q_CODEGEN: QueryKind = 11;
 # Q_LINK: derived — the linked output for the project, keyed on unit.
 pub val Q_LINK: QueryKind = 12;
+# Q_TYPED_EXPORTS: derived — a byte fingerprint of a module's TYPED public
+# surface (the resolved types of its locally-declared pub symbols plus the field
+# tables of pub nominals), keyed on sess.StableModuleId. the SEMA-level twin of
+# Q_EXPORTS: its OUTPUT early-cutoff is the firewall that stops a private edit
+# from re-type-checking importers — an impl-only edit (signatures unchanged)
+# reproduces identical bytes, so type-dependents stay valid; a pub TYPE change
+# advances it and re-checks the dependents (#1583).
+pub val Q_TYPED_EXPORTS: QueryKind = 13;
+# Q_MODULE_NUMBER: input — a module's current per-build discovery-order ModuleId,
+# keyed on sess.StableModuleId and set each build by the driver. Q_SEMA records a
+# dep on its own module's number so a graph reshape that renumbers a module
+# (changing the ModuleId embedded in its nominal/instance type identities)
+# re-type-checks it rather than reusing a result whose interned TypeIds went
+# stale; set_input's early-cutoff leaves it untouched when the number is
+# unchanged, so a content-only edit keeps reuse valid (#1583).
+pub val Q_MODULE_NUMBER: QueryKind = 14;
 
 # Revision: monotonic counter owned by the QueryDb, bumped on every
 # set_input. cached entries record the revision at which they were

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -207,6 +207,12 @@ fun register_catalog(db: *query.QueryDb) Result[bool, str] {
     val r_text: Result[bool, str] = query.register_input(db, query.Q_FILE_TEXT);
     if (is_err[bool, str](r_text)) { ret r_text; }
 
+    # Q_MODULE_NUMBER: each module's current per-build ModuleId, set by the driver
+    # so Q_SEMA can detect a graph reshape that renumbers a module's interned type
+    # identities (#1583). its early-cutoff keeps a content-only edit's sema reuse valid.
+    val r_num: Result[bool, str] = query.register_input(db, query.Q_MODULE_NUMBER);
+    if (is_err[bool, str](r_num)) { ret r_num; }
+
     ret ok[bool, str](true);
 }
 

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -187,10 +187,18 @@ pub rec FieldEntry {
 # ty:           the TypeId this table describes
 # fields_start: index of the first field in the field pool
 # fields_len:   number of fields
+# epoch:        the build epoch this table was (re)built in. a nominal keeps its
+#               TypeId across rebuilds, but its field TYPES can change (an importer
+#               on a long-lived session must see the current layout), so a builder
+#               rebuilds a table whose epoch predates the current one rather than
+#               reusing the stale layout — while a within-build rebuild request for
+#               an up-to-date table is a no-op (dedup of repeated anon references). a
+#               fresh-session build (the CLI) only ever sees epoch 0 (#1583)
 pub rec FieldTable {
     ty:           TypeId;
     fields_start: u32;
     fields_len:   u32;
+    epoch:        u32;
 }
 
 # TypeInterner: session-shared interner for the type universe.
@@ -210,6 +218,11 @@ pub rec FieldTable {
 # field_pool:      contiguous FieldEntry storage backing field_tables
 # field_pool_len:  number of FieldEntries stored
 # field_pool_cap:  allocated slots in field_pool
+# field_epoch:     the current build epoch, bumped once per sema pass by the driver
+#                  (field_epoch_bump). a field-table builder stamps it onto each
+#                  table and rebuilds any table whose epoch is older, so a record's
+#                  field-type change on a long-lived session refreshes the cached
+#                  layout instead of leaving it stale (#1583)
 pub rec TypeInterner {
     alloc: *Allocator;
 
@@ -251,6 +264,8 @@ pub rec TypeInterner {
     field_pool:     *FieldEntry;
     field_pool_len: u32;
     field_pool_cap: u32;
+
+    field_epoch: u32;
 }
 
 val INITIAL_TYPE_CAP:   u32 = 64;
@@ -281,6 +296,7 @@ pub fun init(alloc: *Allocator) Result[TypeInterner, str] {
     ti.field_pool      = nil;
     ti.field_pool_len  = 0;
     ti.field_pool_cap  = 0;
+    ti.field_epoch     = 0;
 
     val ra: Result[*Type, str] = allocate[Type](alloc, INITIAL_TYPE_CAP::usize);
     if (is_err[*Type, str](ra)) {
@@ -449,12 +465,45 @@ pub fun field_table_for(ti: *TypeInterner, ty: TypeId) Option[*FieldTable] {
     ret some[*FieldTable](?ti.field_tables[@unwrap_ok[*u32, str](idx)]);
 }
 
-# field_table_begin: begin a new field table for TypeId `ty`, returning its index; fields are appended with field_table_push. each TypeId interns to a stable id, so a table is built once and shared session-wide.
+# field_epoch_bump: advance the current build epoch, invalidating every field
+# table built in a prior epoch so the next builder rebuilds it with the current
+# layout. the driver calls this once per sema pass; a fresh session never calls it
+# (its single build runs at epoch 0). (#1583)
+# ---
+# ti: the interner
+pub fun field_epoch_bump(ti: *TypeInterner) {
+    ti.field_epoch = ti.field_epoch + 1;
+}
+
+# field_epoch: the current build epoch a field-table builder stamps onto a table
+# and compares an existing table's epoch against to decide rebuild vs reuse.
+# ---
+# ti:  the interner
+# ret: the current epoch
+pub fun field_epoch(ti: *TypeInterner) u32 {
+    ret ti.field_epoch;
+}
+
+# field_table_begin: begin a field table for TypeId `ty`, returning its index;
+# fields are appended with field_table_push. reuses `ty`'s existing table slot when
+# present (a rebuild at a newer epoch — the old field-pool slice is abandoned),
+# otherwise appends a fresh slot. the table is stamped with the current epoch.
 # ---
 # ti: the interner
 # ty: the TypeId the table describes
-# ret: the new table's index, or an allocation error
+# ret: the table's index, or an allocation error
 pub fun field_table_begin(ti: *TypeInterner, ty: TypeId) Result[u32, str] {
+    # rebuild in place: reuse the existing slot so a re-layout does not grow the
+    # table array (the abandoned field-pool slice is the rebuild's only residue).
+    val ex: Result[*u32, str] = map.get[TypeId, u32](?ti.field_index, ?ty);
+    if (is_ok[*u32, str](ex)) {
+        val ridx: u32 = @unwrap_ok[*u32, str](ex);
+        ti.field_tables[ridx].fields_start = ti.field_pool_len;
+        ti.field_tables[ridx].fields_len   = 0;
+        ti.field_tables[ridx].epoch        = ti.field_epoch;
+        ret ok[u32, str](ridx);
+    }
+
     if (ti.field_table_len == ti.field_table_cap) {
         var new_cap: u32 = ti.field_table_cap * 2;
         if (new_cap == 0) { new_cap = 16; }
@@ -476,6 +525,7 @@ pub fun field_table_begin(ti: *TypeInterner, ty: TypeId) Result[u32, str] {
     ft.ty           = ty;
     ft.fields_start = ti.field_pool_len;
     ft.fields_len   = 0;
+    ft.epoch        = ti.field_epoch;
     ti.field_tables[idx] = ft;
     ti.field_table_len = ti.field_table_len + 1;
     ret ok[u32, str](idx);


### PR DESCRIPTION
Wires type-checking through the query engine — the sema-level payoff of epic #1164, extending the resolve-level incremental (#1582) through sema.

Closes #1583. Part of #1164.

## What landed
- **`Q_SEMA(module)`** — derived owned-handle query keyed by `StableModuleId`, reading `Q_RESOLVE(module)` + `Q_TARGET` + `Q_MODULE_NUMBER(module)` + a typed-export firewall per dep. Produces the `SemaResult` as an owned handle the query DB owns/frees and reuses across rebuilds (mirroring `Q_RESOLVE`). `run_sema_pass` routes the CLI compile path's sema through it in topo order; `ModuleEntry.sema_result` borrows the query-owned result, refreshed (with its typed export) in topo order so dependents validate against current fingerprints.
- **`Q_TYPED_EXPORTS(module)`** — the sema twin of `Q_EXPORTS`: a byte fingerprint of a module's typed public surface (declared types of its locally-declared pub symbols, as raw `TypeId`s, plus the field tables of pub nominals). Its output early-cutoff is the firewall — an impl-only edit reproduces identical bytes (type-dependents stay valid) while a pub *type* change advances it and re-checks the dependents. Re-exported symbols contribute identity only (their types are fingerprinted by their origin's typed export, which a dependent depends on directly via the resolve dep closure).
- **`Q_MODULE_NUMBER(module)`** — an input holding each module's current per-build `ModuleId`. `Q_SEMA` depends on its own module's number so a graph reshape that renumbers a module — changing the `ModuleId` embedded in its nominal/instance `TypeId` identities — re-type-checks it rather than reusing a result whose interned type identities went stale. A content-only edit early-cuts and keeps reuse valid.

## Cross-build TypeId / side-table audit
- **`SemaResult` parallel arrays** (`expr_type`/`type_resolved_ty`/`decl_type`, parallel to the module's AST) are reused **together with** the AST: both are gated by `Q_PARSE` (`Q_SEMA` → `Q_RESOLVE` → `Q_PARSE`), so they never desync — no index remap needed.
- **`TypeId` values** are valid across reuse because the session type interner is monotonic and never reset within a session. The only build-relative part of a `TypeId` is the `ModuleId` embedded in nominal/instance identities; a renumber is caught at the source — the renumbered module re-type-checks via `Q_MODULE_NUMBER`, and the raw-`TypeId` typed-export fingerprint cascades the change to importers (a nominal whose origin moved produces different fingerprint bytes).
- **Field tables** (session-global, keyed by `TypeId`) were built once and never rebuilt — a latent staleness an importer on a long-lived session would have miscompiled (a record keeps its `TypeId` across a rebuild while its field types change). Fixed with a per-build field-table **epoch**: the driver bumps it once per sema pass and a builder rebuilds any table from an older epoch while still deduping repeated references within a build. Fresh CLI sessions run at epoch 1 — no observable difference from the prior build-once behaviour.

## Correctness gate
- [x] **Self-host Fixpoint byte-identical** (CI green; verified locally across 3 generations)
- [x] **Incremental CORRECTNESS tests** asserting reused/recomputed `SemaResult`s are structurally equal (cross-session, via `ty_struct_equal`/`sr_struct_equal`) to an independent from-scratch build:
  - a leaf's private body edit firewalls the importer's sema (not re-checked) + both equal from-scratch
  - a leaf's pub return-type change re-checks the importer (genuinely re-typed) + both equal from-scratch
  - a dep's pub record **field-type** change re-checks a field-accessing importer the resolve firewall misses (`resolve_lc` held, `sema_lc` advanced) — the case `Q_TYPED_EXPORTS` catches and `Q_EXPORTS` cannot
  - a graph reshape renumbers a module's nominal types: `Q_MODULE_NUMBER` re-checks it + the importer, both equal from-scratch
- [x] **Minimal-recompute probes** (per-module `Q_SEMA.last_changed` reuse assertions in each test)
- [x] **Full Test Suite + Integration Tests green** (CI)

## Scope notes
- `build_project` still stops at resolve; the CLI compile path (`cmd/build.mach`) drives `run_sema_pass`. The editor/LSP keeps its own per-buffer sema path (it is not query-routed yet — that lands with mach-lsp#117), unchanged here, consistent with #1582 leaving the editor on its own resolve path.
- Reused cached phases do not re-emit diagnostics (latent, predates this PR — Q_PARSE/Q_RESOLVE share it; tracked in #1586). No current consumer drives `build_project` incrementally on a long-lived session (the CLI uses fresh sessions), so it is inert today.