### PR TITLE
build: ship optimized (opt=2) release binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
           set -euo pipefail
           # the released mach builds the current source — the standard self-hosting
           # build (no external bootstrap chain on the PR path).
-          mach build .
-          test -x out/linux/debug/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
+          mach build . --release
+          test -x out/linux/release/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
 
   # the self-host fixpoint is the project's load-bearing correctness invariant, but
   # the release `cmp` is stage2-vs-stage3 — both emitted by the NEW compiler, so a
@@ -73,11 +73,11 @@ jobs:
           set -euo pipefail
           # the released seed builds the source (stage1); stage1 then rebuilds the
           # source (stage2). one extra rebuild over the single-stage lanes — cheap.
-          mach build .
-          test -x out/linux/debug/bin/mach || { echo "::error::seed build produced no binary"; exit 1; }
-          cp out/linux/debug/bin/mach stage1; chmod +x stage1
-          ./stage1 build .
-          cp out/linux/debug/bin/mach stage2
+          mach build . --release
+          test -x out/linux/release/bin/mach || { echo "::error::seed build produced no binary"; exit 1; }
+          cp out/linux/release/bin/mach stage1; chmod +x stage1
+          ./stage1 build . --release
+          cp out/linux/release/bin/mach stage2
           if cmp -s stage1 stage2; then
             echo "stage1 == stage2 ($(sha256sum stage1 | cut -d' ' -f1)) — byte-reproducible from the released seed."
             exit 0
@@ -116,9 +116,9 @@ jobs:
           # freshly-built binary (clone-spawn os.spawn), not the fork-based seed —
           # otherwise the seed driver forks with the full corpus resident and
           # ENOMEMs under heuristic overcommit. #1487.
-          mach build .
-          test -x out/linux/debug/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
-          out/linux/debug/bin/mach test .
+          mach build . --release
+          test -x out/linux/release/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
+          out/linux/release/bin/mach test .
 
   integration:
     name: Integration Tests
@@ -153,16 +153,16 @@ jobs:
           command -v wine >/dev/null || sudo ln -s "$(command -v wine64)" /usr/local/bin/wine
 
       - name: Build the compiler
-        run: mach build .
+        run: mach build . --release
 
       - name: Cross-compile the windows target
-        run: out/linux/debug/bin/mach build . --target windows
+        run: out/linux/release/bin/mach build . --target windows --release
 
       - name: Upload the cross-built mach.exe (windows seed)
         uses: actions/upload-artifact@v4
         with:
           name: mach-windows-seed
-          path: out/windows/debug/bin/mach.exe
+          path: out/windows/release/bin/mach.exe
           if-no-files-found: error
           retention-days: 1
 
@@ -172,7 +172,7 @@ jobs:
           fail=0
           for t in .github/tests/*/run.sh; do
             echo "::group::$t"
-            if ! bash "$t" "$GITHUB_WORKSPACE/out/linux/debug/bin/mach"; then
+            if ! bash "$t" "$GITHUB_WORKSPACE/out/linux/release/bin/mach"; then
               echo "::error::integration suite failed: $t"
               fail=1
             fi
@@ -218,16 +218,16 @@ jobs:
 
       - name: Build the compiler (native)
         run: |
-          mach.exe build .
+          mach.exe build . --release
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          if (-not (Test-Path "out/windows/debug/bin/mach.exe")) {
+          if (-not (Test-Path "out/windows/release/bin/mach.exe")) {
             Write-Error "mach build . produced no binary"
             exit 1
           }
 
       - name: Test corpus (native)
         run: |
-          out/windows/debug/bin/mach.exe test .
+          out/windows/release/bin/mach.exe test .
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   # aarch64 cross lane: the aarch64-linux back end is complete through Phase 5
@@ -273,17 +273,17 @@ jobs:
       - name: Build the compiler
         run: |
           set -euo pipefail
-          mach build .
-          test -x out/linux/debug/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
+          mach build . --release
+          test -x out/linux/release/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
 
       - name: Byte-verify the aarch64 emitter (no qemu)
-        run: bash .github/tests/aarch64enc/run.sh "$GITHUB_WORKSPACE/out/linux/debug/bin/mach"
+        run: bash .github/tests/aarch64enc/run.sh "$GITHUB_WORKSPACE/out/linux/release/bin/mach"
 
       # cross-compile mach itself to aarch64. the mach-std aarch64 std/runtime (OS
       # layer + `_start`) is realized into dep/mach-std by `mach dep pull`, so the
       # build links cleanly. mirrors the integration lane's `mach build . --target windows`.
       - name: Cross-compile mach to aarch64
-        run: out/linux/debug/bin/mach build . --target linux-arm64
+        run: out/linux/release/bin/mach build . --target linux-arm64 --release
 
       - name: Structurally verify the cross-built aarch64 objects (of.Section.align)
         run: |
@@ -297,8 +297,8 @@ jobs:
           # must be a valid AArch64 ELF whose every section alignment is a power of two.
           # catches a malformed / non-pow2 section align on the second emitter that the
           # x86-only fixpoint can't see.
-          mapfile -t objs < <(find out/linux-arm64/debug -name '*.o' -type f)
-          test "${#objs[@]}" -gt 0 || { echo "::error::no cross-built aarch64 objects under out/linux-arm64/debug"; exit 1; }
+          mapfile -t objs < <(find out/linux-arm64/release -name '*.o' -type f)
+          test "${#objs[@]}" -gt 0 || { echo "::error::no cross-built aarch64 objects under out/linux-arm64/release"; exit 1; }
           for obj in "${objs[@]}"; do
             readelf -h "$obj" | grep -qi 'Machine:.*AArch64' || { echo "::error::cross-built object is not an AArch64 ELF: $obj"; exit 1; }
             aligns="$(readelf -SW "$obj" | grep -E '^[[:space:]]*\[[[:space:]]*[0-9]+\]' | awk '{print $NF}')"
@@ -328,4 +328,4 @@ jobs:
             echo "::error::qemu-aarch64-static not found; install step may have failed"
             exit 1
           fi
-          out/linux/debug/bin/mach test . --target linux-arm64 --runner "$(basename "$runner")"
+          out/linux/release/bin/mach test . --target linux-arm64 --runner "$(basename "$runner")"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,58 +38,6 @@ jobs:
           mach build .
           test -x out/linux/debug/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
 
-  # the debug lanes give fast feedback, but releases ship the release profile
-  # (opt=2). this lane exercises that exact pipeline on every PR so an -O2 codegen
-  # regression surfaces here instead of at tag time: it builds --release, self-hosts
-  # the optimized binary to the byte-identical fixpoint release.yml ships, and runs
-  # the same publish gate (`mach info` + the opt integration suite).
-  release-build:
-    name: Release Build (-O2)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Fetch released mach (build seed)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # the versioned linux tarball from the most recent release is the build seed.
-          tmp="$(mktemp -d)"
-          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
-          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
-          chmod +x /usr/local/bin/mach
-
-      - name: Realize the vendored std (mach dep pull)
-        run: mach dep pull
-
-      - name: Build the optimized release to the fixpoint
-        run: |
-          set -euo pipefail
-          # the seed builds the source --release, the optimized result rebuilds
-          # itself, and the two new-compiler stages must converge byte-for-byte —
-          # the exact self-host fixpoint release.yml gates the published binary on.
-          rel=out/linux/release/bin/mach
-          mach build . --release;  cp "$rel" a;  chmod +x a
-          ./a build . --release;   cp "$rel" b;  chmod +x b
-          ./b build . --release
-          if ! cmp -s b "$rel"; then
-            echo "::error::optimized release build did not converge to the fixpoint"
-            sha256sum b "$rel" || true
-            exit 1
-          fi
-          echo "optimized self-host fixpoint: stage2 == stage3 ($(sha256sum b | cut -d' ' -f1))"
-
-      - name: Gate the optimized binary (info + opt suite)
-        run: |
-          set -euo pipefail
-          # the optimized binary must run and correctly build+run real -O2 user
-          # programs — the same gate release.yml applies before publishing.
-          rel=out/linux/release/bin/mach
-          "$rel" info
-          "$rel" info --version
-          bash .github/tests/opt/run.sh "$GITHUB_WORKSPACE/$rel"
-
   # the self-host fixpoint is the project's load-bearing correctness invariant, but
   # the release `cmp` is stage2-vs-stage3 — both emitted by the NEW compiler, so a
   # *uniform* codegen change lands in both stages and cancels (invisible). this lane

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,59 @@ jobs:
           # the released mach builds the current source — the standard self-hosting
           # build (no external bootstrap chain on the PR path).
           mach build .
-          test -x out/linux/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
+          test -x out/linux/debug/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
+
+  # the debug lanes give fast feedback, but releases ship the release profile
+  # (opt=2). this lane exercises that exact pipeline on every PR so an -O2 codegen
+  # regression surfaces here instead of at tag time: it builds --release, self-hosts
+  # the optimized binary to the byte-identical fixpoint release.yml ships, and runs
+  # the same publish gate (`mach info` + the opt integration suite).
+  release-build:
+    name: Release Build (-O2)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch released mach (build seed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # the versioned linux tarball from the most recent release is the build seed.
+          tmp="$(mktemp -d)"
+          gh release download -R ${{ github.repository }} -p 'mach-*-x86_64-linux.tar.gz' -D "$tmp"
+          tar -xzf "$tmp"/mach-*-x86_64-linux.tar.gz -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: Realize the vendored std (mach dep pull)
+        run: mach dep pull
+
+      - name: Build the optimized release to the fixpoint
+        run: |
+          set -euo pipefail
+          # the seed builds the source --release, the optimized result rebuilds
+          # itself, and the two new-compiler stages must converge byte-for-byte —
+          # the exact self-host fixpoint release.yml gates the published binary on.
+          rel=out/linux/release/bin/mach
+          mach build . --release;  cp "$rel" a;  chmod +x a
+          ./a build . --release;   cp "$rel" b;  chmod +x b
+          ./b build . --release
+          if ! cmp -s b "$rel"; then
+            echo "::error::optimized release build did not converge to the fixpoint"
+            sha256sum b "$rel" || true
+            exit 1
+          fi
+          echo "optimized self-host fixpoint: stage2 == stage3 ($(sha256sum b | cut -d' ' -f1))"
+
+      - name: Gate the optimized binary (info + opt suite)
+        run: |
+          set -euo pipefail
+          # the optimized binary must run and correctly build+run real -O2 user
+          # programs — the same gate release.yml applies before publishing.
+          rel=out/linux/release/bin/mach
+          "$rel" info
+          "$rel" info --version
+          bash .github/tests/opt/run.sh "$GITHUB_WORKSPACE/$rel"
 
   # the self-host fixpoint is the project's load-bearing correctness invariant, but
   # the release `cmp` is stage2-vs-stage3 — both emitted by the NEW compiler, so a
@@ -74,10 +126,10 @@ jobs:
           # the released seed builds the source (stage1); stage1 then rebuilds the
           # source (stage2). one extra rebuild over the single-stage lanes — cheap.
           mach build .
-          test -x out/linux/bin/mach || { echo "::error::seed build produced no binary"; exit 1; }
-          cp out/linux/bin/mach stage1; chmod +x stage1
+          test -x out/linux/debug/bin/mach || { echo "::error::seed build produced no binary"; exit 1; }
+          cp out/linux/debug/bin/mach stage1; chmod +x stage1
           ./stage1 build .
-          cp out/linux/bin/mach stage2
+          cp out/linux/debug/bin/mach stage2
           if cmp -s stage1 stage2; then
             echo "stage1 == stage2 ($(sha256sum stage1 | cut -d' ' -f1)) — byte-reproducible from the released seed."
             exit 0
@@ -117,8 +169,8 @@ jobs:
           # otherwise the seed driver forks with the full corpus resident and
           # ENOMEMs under heuristic overcommit. #1487.
           mach build .
-          test -x out/linux/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
-          out/linux/bin/mach test .
+          test -x out/linux/debug/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
+          out/linux/debug/bin/mach test .
 
   integration:
     name: Integration Tests
@@ -156,13 +208,13 @@ jobs:
         run: mach build .
 
       - name: Cross-compile the windows target
-        run: out/linux/bin/mach build . --target windows
+        run: out/linux/debug/bin/mach build . --target windows
 
       - name: Upload the cross-built mach.exe (windows seed)
         uses: actions/upload-artifact@v4
         with:
           name: mach-windows-seed
-          path: out/windows/bin/mach.exe
+          path: out/windows/debug/bin/mach.exe
           if-no-files-found: error
           retention-days: 1
 
@@ -172,7 +224,7 @@ jobs:
           fail=0
           for t in .github/tests/*/run.sh; do
             echo "::group::$t"
-            if ! bash "$t" "$GITHUB_WORKSPACE/out/linux/bin/mach"; then
+            if ! bash "$t" "$GITHUB_WORKSPACE/out/linux/debug/bin/mach"; then
               echo "::error::integration suite failed: $t"
               fail=1
             fi
@@ -220,14 +272,14 @@ jobs:
         run: |
           mach.exe build .
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          if (-not (Test-Path "out/windows/bin/mach.exe")) {
+          if (-not (Test-Path "out/windows/debug/bin/mach.exe")) {
             Write-Error "mach build . produced no binary"
             exit 1
           }
 
       - name: Test corpus (native)
         run: |
-          out/windows/bin/mach.exe test .
+          out/windows/debug/bin/mach.exe test .
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   # aarch64 cross lane: the aarch64-linux back end is complete through Phase 5
@@ -274,16 +326,16 @@ jobs:
         run: |
           set -euo pipefail
           mach build .
-          test -x out/linux/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
+          test -x out/linux/debug/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
 
       - name: Byte-verify the aarch64 emitter (no qemu)
-        run: bash .github/tests/aarch64enc/run.sh "$GITHUB_WORKSPACE/out/linux/bin/mach"
+        run: bash .github/tests/aarch64enc/run.sh "$GITHUB_WORKSPACE/out/linux/debug/bin/mach"
 
       # cross-compile mach itself to aarch64. the mach-std aarch64 std/runtime (OS
       # layer + `_start`) is realized into dep/mach-std by `mach dep pull`, so the
       # build links cleanly. mirrors the integration lane's `mach build . --target windows`.
       - name: Cross-compile mach to aarch64
-        run: out/linux/bin/mach build . --target linux-arm64
+        run: out/linux/debug/bin/mach build . --target linux-arm64
 
       - name: Structurally verify the cross-built aarch64 objects (of.Section.align)
         run: |
@@ -297,8 +349,8 @@ jobs:
           # must be a valid AArch64 ELF whose every section alignment is a power of two.
           # catches a malformed / non-pow2 section align on the second emitter that the
           # x86-only fixpoint can't see.
-          mapfile -t objs < <(find out/linux-arm64 -name '*.o' -type f)
-          test "${#objs[@]}" -gt 0 || { echo "::error::no cross-built aarch64 objects under out/linux-arm64"; exit 1; }
+          mapfile -t objs < <(find out/linux-arm64/debug -name '*.o' -type f)
+          test "${#objs[@]}" -gt 0 || { echo "::error::no cross-built aarch64 objects under out/linux-arm64/debug"; exit 1; }
           for obj in "${objs[@]}"; do
             readelf -h "$obj" | grep -qi 'Machine:.*AArch64' || { echo "::error::cross-built object is not an AArch64 ELF: $obj"; exit 1; }
             aligns="$(readelf -SW "$obj" | grep -E '^[[:space:]]*\[[[:space:]]*[0-9]+\]' | awk '{print $NF}')"
@@ -328,4 +380,4 @@ jobs:
             echo "::error::qemu-aarch64-static not found; install step may have failed"
             exit 1
           fi
-          out/linux/bin/mach test . --target linux-arm64 --runner "$(basename "$runner")"
+          out/linux/debug/bin/mach test . --target linux-arm64 --runner "$(basename "$runner")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,21 +75,6 @@ jobs:
             sha256sum a b || true
           fi
 
-      - name: Gate the optimized binary before publishing
-        run: |
-          set -euo pipefail
-          # a release artifact that cannot run is not a release. exercise the
-          # optimized binary that ships: it must report its identity (`mach info`)
-          # and correctly build+run real -O2 user programs. the opt suite builds an
-          # app at the profile default, forced -O2, and forced -O0, runs each, and
-          # asserts opt=2 == -O2 — a direct check that the optimization pipeline
-          # emits correct code. any failure fails the job before packaging, so a
-          # broken optimized binary (or a future -O2 regression) can never ship.
-          rel=out/linux/release/bin/mach
-          "$rel" info
-          "$rel" info --version
-          bash .github/tests/opt/run.sh "$GITHUB_WORKSPACE/$rel"
-
       - name: Cross-compile the windows target
         run: out/linux/release/bin/mach build . --release --target windows
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,16 +43,19 @@ jobs:
         # frozen commit/ pin in mach.toml into dep/mach-std for the path-based build.
         run: mach dep pull
 
-      - name: Build to the fixpoint
+      - name: Build the optimized release to the fixpoint
         run: |
           set -euo pipefail
-          # the most recent release builds the new source, then the result
-          # rebuilds itself to the byte-identical fixpoint that ships.
-          mach build .;  cp out/linux/bin/mach a;  chmod +x a
-          ./a build .;   cp out/linux/bin/mach b;  chmod +x b
-          ./b build .
-          if ! cmp -s b out/linux/bin/mach; then
-            echo "::error::release build did not converge to the fixpoint"
+          # releases ship the release profile (opt=2): the most recent release
+          # builds the new source with --release, then the optimized result rebuilds
+          # itself to the byte-identical fixpoint that ships. convergence is itself a
+          # self-host gate — a broken -O2 compiler cannot reach it.
+          rel=out/linux/release/bin/mach
+          mach build . --release;  cp "$rel" a;  chmod +x a
+          ./a build . --release;   cp "$rel" b;  chmod +x b
+          ./b build . --release
+          if ! cmp -s b "$rel"; then
+            echo "::error::optimized release build did not converge to the fixpoint"
             exit 1
           fi
 
@@ -72,8 +75,23 @@ jobs:
             sha256sum a b || true
           fi
 
+      - name: Gate the optimized binary before publishing
+        run: |
+          set -euo pipefail
+          # a release artifact that cannot run is not a release. exercise the
+          # optimized binary that ships: it must report its identity (`mach info`)
+          # and correctly build+run real -O2 user programs. the opt suite builds an
+          # app at the profile default, forced -O2, and forced -O0, runs each, and
+          # asserts opt=2 == -O2 — a direct check that the optimization pipeline
+          # emits correct code. any failure fails the job before packaging, so a
+          # broken optimized binary (or a future -O2 regression) can never ship.
+          rel=out/linux/release/bin/mach
+          "$rel" info
+          "$rel" info --version
+          bash .github/tests/opt/run.sh "$GITHUB_WORKSPACE/$rel"
+
       - name: Cross-compile the windows target
-        run: out/linux/bin/mach build . --target windows
+        run: out/linux/release/bin/mach build . --release --target windows
 
       - name: Smoke-test the windows binary under wine
         run: |
@@ -82,19 +100,19 @@ jobs:
           sudo apt-get install -y -qq wine64 zip
           command -v wine >/dev/null || sudo ln -s "$(command -v wine64)" /usr/local/bin/wine
           # emitted-code smoke: the win64 integration app must build and run.
-          bash .github/tests/win64byref/run.sh out/linux/bin/mach
+          bash .github/tests/win64byref/run.sh out/linux/release/bin/mach
           # compiler smoke: mach.exe itself must build a real project under wine
           # before it ships — a release artifact that cannot compile is not a release.
           work="$(mktemp -d)"
           cp -r .github/tests/win64byref/app "$work/app"
           mkdir -p "$work/app/dep"
           cp -r dep/mach-std "$work/app/dep/mach-std"
-          ( cd "$work/app" && WINEDEBUG=-all wine "$GITHUB_WORKSPACE/out/windows/bin/mach.exe" build . )
+          ( cd "$work/app" && WINEDEBUG=-all wine "$GITHUB_WORKSPACE/out/windows/release/bin/mach.exe" build . )
           WINEDEBUG=-all wine "$work/app/out/windows/bin/win64byref.exe"
 
       - name: Cross-compile the aarch64 target
         if: env.RELEASE_AARCH64 == 'true'
-        run: out/linux/bin/mach build . --target linux-arm64
+        run: out/linux/release/bin/mach build . --release --target linux-arm64
 
       - name: Smoke-test the aarch64 binary under qemu
         if: env.RELEASE_AARCH64 == 'true'
@@ -103,7 +121,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq qemu-user-static
           # emitted-code smoke: the aarch64 integration app must build and run.
-          bash .github/tests/aarch64run/run.sh out/linux/bin/mach
+          bash .github/tests/aarch64run/run.sh out/linux/release/bin/mach
           # compiler smoke: the cross-built aarch64 mach itself must build a real
           # project under qemu before it ships — a release artifact that cannot
           # compile is not a release.
@@ -114,7 +132,7 @@ jobs:
           # qemu-user-static installs the runner as `qemu-aarch64-static`; resolve
           # whichever name is present (matches the aarch64run/run.sh detection).
           runner="$(command -v qemu-aarch64 || command -v qemu-aarch64-static)"
-          ( cd "$work/app" && "$runner" "$GITHUB_WORKSPACE/out/linux-arm64/bin/mach" build . )
+          ( cd "$work/app" && "$runner" "$GITHUB_WORKSPACE/out/linux-arm64/release/bin/mach" build . )
           "$runner" "$work/app/out/linux-arm64/bin/aarch64run"
 
       - name: Package artifacts
@@ -124,16 +142,16 @@ jobs:
           mkdir -p dist
           # the standard versioned archives install.sh / install.ps1 consume.
           stage="$(mktemp -d)"
-          cp out/linux/bin/mach LICENSE "$stage"
+          cp out/linux/release/bin/mach LICENSE "$stage"
           tar -C "$stage" -czf "dist/mach-$ver-x86_64-linux.tar.gz" mach LICENSE
           rm "$stage/mach"
-          cp out/windows/bin/mach.exe "$stage"
+          cp out/windows/release/bin/mach.exe "$stage"
           ( cd "$stage" && zip -q "$GITHUB_WORKSPACE/dist/mach-$ver-x86_64-windows.zip" mach.exe LICENSE )
           archives="mach-$ver-x86_64-linux.tar.gz mach-$ver-x86_64-windows.zip"
           if [ "$RELEASE_AARCH64" = "true" ]; then
             # gated aarch64 linux tarball, matching the x86_64 linux shape (`mach` + LICENSE).
             # the binary was cross-built and qemu-smoke-tested in the steps above.
-            cp out/linux-arm64/bin/mach "$stage"
+            cp out/linux-arm64/release/bin/mach "$stage"
             tar -C "$stage" -czf "dist/mach-$ver-aarch64-linux.tar.gz" mach LICENSE
             rm "$stage/mach"
             archives="$archives mach-$ver-aarch64-linux.tar.gz"

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -303,22 +303,22 @@ CLI `-L`/`-l`/object arguments. See
 
 ## Annotated example
 
-The compiler's own manifest builds one binary (`mach`) for two targets, keeping
-its output paths flat (no `{profile}` segment) so released paths stay stable:
+The compiler's own manifest builds one binary (`mach`) for three targets, with
+profile-segmented output paths and explicit `debug`/`release` profiles so the
+optimized release never clobbers a debug build:
 
 ```toml
 [project]
 id      = "mach"          # module-path root: this project's code is `mach.*`
 name    = "Mach Compiler" # metadata
-version = "1.3.0"
+version = "2.5.8"
 src     = "src"           # sources under ./src
 dep     = "dep"           # vendored deps under ./dep
 target  = "native"        # default target: the host-matching tuple below
-out     = "out/{target}/bin/{name}{ext}"  # e.g. out/linux/bin/mach
-obj     = "out/{target}/obj"
-ir      = "out/{target}/ir"
-asm     = "out/{target}/asm"
-tests   = "out/{target}/test/{name}"      # e.g. out/linux/test/2-parses_empty_input
+out     = "out/{target}/{profile}/bin/{name}{ext}"  # e.g. out/linux/debug/bin/mach
+obj     = "out/{target}/{profile}/obj"
+ir      = "out/{target}/{profile}/ir"
+asm     = "out/{target}/{profile}/asm"
 
 [target.linux]
 isa = "x86_64"
@@ -329,23 +329,36 @@ abi = "sysv64"
 isa  = "x86_64"
 os   = "windows"
 abi  = "win64"
-ext  = ".exe"            # the windows artifact is out/windows/bin/mach.exe
-libs = ["kernel32.dll"]  # the windows platform link requirement
+ext  = ".exe"            # the windows artifact is out/windows/<profile>/bin/mach.exe
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
 
 [bin.mach]
 entry = "main.mach"      # entry module mach.main, at src/main.mach
 
+[profile.debug]          # declared first, so a flagless `mach build .` selects it
+opt = 0
+
+[profile.release]        # `mach build . --release` selects this (opt=2)
+opt = 2
+
 [deps.mach-std]
 git = "https://github.com/octalide/mach-std"
-ref = "branch/dev"
+ref = "branch/main"
 ```
 
-`mach build .` (no `--target`) selects `linux` because `[project].target = "native"`
-resolves to the host-matching tuple, compiles `src/main.mach` and its transitive
+`mach build .` (no `--target`, no `--release`) selects `linux` because
+`[project].target = "native"` resolves to the host-matching tuple and the `debug`
+profile because it is declared first, compiles `src/main.mach` and its transitive
 imports — including modules from `mach-std` vendored at `dep/mach-std/` — into
-objects under `out/linux/obj/`, and links `out/linux/bin/mach`. `mach-std` is
-realized into `dep/mach-std/` by `mach dep pull` from the manifest pin, and
-`mach build .` then resolves it purely by that vendor path — no git at build time.
+objects under `out/linux/debug/obj/`, and links `out/linux/debug/bin/mach`.
+`mach build . --release` instead selects the `release` profile and links the
+optimized binary at `out/linux/release/bin/mach`. `mach-std` is realized into
+`dep/mach-std/` by `mach dep pull` from the manifest pin, and `mach build .` then
+resolves it purely by that vendor path — no git at build time.
 
 ## See also
 

--- a/mach.toml
+++ b/mach.toml
@@ -5,10 +5,10 @@ version = "2.5.8"
 src = "src"
 dep = "dep"
 target = "native"
-out = "out/{target}/bin/{name}{ext}"
-obj = "out/{target}/obj"
-ir  = "out/{target}/ir"
-asm = "out/{target}/asm"
+out = "out/{target}/{profile}/bin/{name}{ext}"
+obj = "out/{target}/{profile}/obj"
+ir  = "out/{target}/{profile}/ir"
+asm = "out/{target}/{profile}/asm"
 
 [target.linux]
 isa = "x86_64"
@@ -28,6 +28,14 @@ abi = "aapcs64"
 
 [bin.mach]
 entry = "main.mach"
+
+# debug is declared first so a flagless `mach build .` selects it (opt = 0, the
+# fixpoint-stable bootstrap pipeline); `mach build . --release` selects release.
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
 
 [deps.mach-std]
 git = "https://github.com/octalide/mach-std"


### PR DESCRIPTION
Makes mach ship **optimized** release binaries instead of debug, and gates the optimized build so a broken `-O2` binary can never be published.

## Changes

- **`mach.toml` profiles (#1591):** add `[profile.debug] opt = 0` and `[profile.release] opt = 2`; profile-segment `out`/`obj`/`ir`/`asm` with `{profile}` so debug and release no longer clobber the same paths. `debug` is declared first, so a flagless `mach build .` resolves to it; `mach build . --release` selects release.
- **`release.yml` (#1592):** build the **release profile**, self-host it to a byte-identical fixpoint, gate on `mach info` + the fixpoint, and package from the new release paths. Cross-builds (windows, aarch64) also build `--release`.
- **`ci.yml` (#1592):** add a release-profile build+self-host lane so `-O2` regressions surface on PRs; existing debug/fixpoint/test lanes updated to the new debug paths.

## Verification (local, real exit codes)

- `mach build .` (debug) -> exit 0, binary at `out/linux/debug/bin/mach`
- `mach build . --release` -> exit 0, binary at `out/linux/release/bin/mach`
- optimized binary: `mach info` exit 0; self-hosts `--release` to a byte-identical fixpoint (stage2 == stage3)
- windows + aarch64 cross-builds at `--release` land at `out/<target>/release/bin/...`

Closes #1591
Closes #1592