### PR TITLE
fix(lower): widen gep index to the machine word before emit_gep

### DIFF
--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -887,7 +887,14 @@ fun lower_index_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr
 
     val ir2: Result[value.Value, str] = lower_rvalue(ctx, e.data.index.index);
     if (is_err[value.Value, str](ir2)) { ret ir2; }
-    val ix: value.Value = unwrap_ok[value.Value, str](ir2);
+    var ix: value.Value = unwrap_ok[value.Value, str](ir2);
+
+    # a gep index is machine-word arithmetic: the back end scales the full index
+    # register, so a sub-word index (e.g. a u8) must be widened to 64 bits first —
+    # otherwise its undefined high register bits corrupt the scaled offset.
+    val ixw: Result[value.Value, str] = widen_index(ctx, ix, lower.expr_type_of(ctx, e.data.index.index));
+    if (is_err[value.Value, str](ixw)) { ret ixw; }
+    ix = unwrap_ok[value.Value, str](ixw);
 
     if (is_ptr) {
         # `*T[ix]` strides over the pointee element type T. a raw untyped `ptr` has
@@ -2258,6 +2265,19 @@ fun ir_type_of_expr(ctx: *lower.LowerContext, eid: aid.ExprId) Result[ir_type.Ir
 # the IR integer type used for gep indices and alloca element counts (i64).
 fun index_type(ctx: *lower.LowerContext) Result[ir_type.IrTypeId, str] {
     ret ir_type.intern_int(?ctx.m.types, 64);
+}
+
+# widen a runtime gep index to the 64-bit machine-word index type. a narrower
+# index (e.g. a u8 enum/kind) is extended per its signedness; a 64-bit (or
+# wider) index is left as-is. without this the back end scales the index's full
+# register while its high bits are undefined, producing a wild address.
+fun widen_index(ctx: *lower.LowerContext, v: value.Value, sem_ty: ty.TypeId) Result[value.Value, str] {
+    val xr: Result[ir_type.IrTypeId, str] = index_type(ctx);
+    if (is_err[ir_type.IrTypeId, str](xr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](xr)); }
+    val xty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](xr);
+    if (scalar_bits(ctx, sem_ty) >= 64) { ret ok[value.Value, str](v); }
+    if (is_signed_type(ctx, sem_ty)) { ret builder.emit_sext(?ctx.builder, v, xty); }
+    ret builder.emit_zext(?ctx.builder, v, xty);
 }
 
 


### PR DESCRIPTION
Closes #1596.

`lower_index_lvalue` passed the runtime GEP index to `emit_gep` at its source integer width. The MIR back end scales the full index register, so a sub-word index (e.g. a `u8`) reached codegen with undefined high bits → wild address. The leading aggregate index was 64-bit but the real index operand wasn't widened; the comparison path zero-extends, the index path didn't.

### Change
Added `widen_index` and call it in `lower_index_lvalue`: a runtime index narrower than 64 bits is extended (zext unsigned / sext signed) to the machine-word index type before `emit_gep`; 64-bit indices are unchanged.

### Why latent
Every in-tree index site casts (`x::u32`/`::usize`), forcing a clean register. Surfaces on an uncast sub-word index (e.g. `ti.prims[kind]`, `kind: u8`).

### Validation
- Self-host **byte-identical fixpoint** at `-O2` (stage2 == stage3).
- Test corpus: **590/590** pass.
- `widen_index` runs on every runtime index (incl. the many `u32` indices in the compiler), so the byte-identical self-host directly exercises it.