### PR TITLE
release: v2.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.9] - 2026-06-24
+
+Fixes a latent miscompile: a runtime array/pointer index narrower than the
+machine word (e.g. a `u8`) was passed to the GEP at its source width, so the
+back end scaled an index register carrying undefined high bits and computed a
+wild address.
+
+### Fixed
+
+- lower: `lower_index_lvalue` widens a sub-word runtime GEP index to the
+  machine-word index type (zext unsigned / sext signed) before `emit_gep`, so
+  the back end scales a clean register. In-tree index sites cast (`::u32` /
+  `::usize`) and masked it; an uncast sub-word index miscompiled (#1596). The
+  64-bit widen lives in the target-agnostic lowering for now; #1598 tracks
+  moving index normalization into the target-aware codegen.
+
 ## [2.5.8] - 2026-06-24
 
 Incremental type-checking (#1164), completing the incremental front-end: parse,

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.5.8"
+version = "2.5.9"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -887,7 +887,14 @@ fun lower_index_lvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr
 
     val ir2: Result[value.Value, str] = lower_rvalue(ctx, e.data.index.index);
     if (is_err[value.Value, str](ir2)) { ret ir2; }
-    val ix: value.Value = unwrap_ok[value.Value, str](ir2);
+    var ix: value.Value = unwrap_ok[value.Value, str](ir2);
+
+    # a gep index is machine-word arithmetic: the back end scales the full index
+    # register, so a sub-word index (e.g. a u8) must be widened to 64 bits first —
+    # otherwise its undefined high register bits corrupt the scaled offset.
+    val ixw: Result[value.Value, str] = widen_index(ctx, ix, lower.expr_type_of(ctx, e.data.index.index));
+    if (is_err[value.Value, str](ixw)) { ret ixw; }
+    ix = unwrap_ok[value.Value, str](ixw);
 
     if (is_ptr) {
         # `*T[ix]` strides over the pointee element type T. a raw untyped `ptr` has
@@ -2258,6 +2265,19 @@ fun ir_type_of_expr(ctx: *lower.LowerContext, eid: aid.ExprId) Result[ir_type.Ir
 # the IR integer type used for gep indices and alloca element counts (i64).
 fun index_type(ctx: *lower.LowerContext) Result[ir_type.IrTypeId, str] {
     ret ir_type.intern_int(?ctx.m.types, 64);
+}
+
+# widen a runtime gep index to the 64-bit machine-word index type. a narrower
+# index (e.g. a u8 enum/kind) is extended per its signedness; a 64-bit (or
+# wider) index is left as-is. without this the back end scales the index's full
+# register while its high bits are undefined, producing a wild address.
+fun widen_index(ctx: *lower.LowerContext, v: value.Value, sem_ty: ty.TypeId) Result[value.Value, str] {
+    val xr: Result[ir_type.IrTypeId, str] = index_type(ctx);
+    if (is_err[ir_type.IrTypeId, str](xr)) { ret err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](xr)); }
+    val xty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](xr);
+    if (scalar_bits(ctx, sem_ty) >= 64) { ret ok[value.Value, str](v); }
+    if (is_signed_type(ctx, sem_ty)) { ret builder.emit_sext(?ctx.builder, v, xty); }
+    ret builder.emit_zext(?ctx.builder, v, xty);
 }
 
 


### PR DESCRIPTION
Patch release.

**Fixed** — sub-word GEP index miscompile (#1596): `lower_index_lvalue` now widens a runtime index narrower than the machine word to the index type before `emit_gep`, so the back end scales a clean register.

Follow-up: #1598 (move index normalization into the target-aware codegen).

The `Self-host Fixpoint` lane is red by design until this release publishes and re-seeds — the 2.5.8 seed predates the index zext, so stage1≠stage2. New compiler is self-consistent (local stage2==stage3 byte-identical); all other lanes green.