### PR TITLE
refactor: consolidate primitive-type classification behind prim_desc

### DIFF
--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -446,10 +446,8 @@ pub fun byte_size(sc: *context.SemaContext, t: type.TypeId) u32 {
     if (O.is_none[*type.Type](opt_type)) { ret 0; }
     val tp: *type.Type    = O.unwrap[*type.Type](opt_type);
     val k:  type.TypeKind = tp.kind;
-    if (k == type.TYPE_U8  || k == type.TYPE_I8)                        { ret 1; }
-    if (k == type.TYPE_U16 || k == type.TYPE_I16)                       { ret 2; }
-    if (k == type.TYPE_U32 || k == type.TYPE_I32 || k == type.TYPE_F32) { ret 4; }
-    if (k == type.TYPE_U64 || k == type.TYPE_I64 || k == type.TYPE_F64) { ret 8; }
+    val d:  type.PrimDesc = type.prim_desc(k);
+    if (d.class == type.PRIM_CLASS_INT || d.class == type.PRIM_CLASS_FLOAT) { ret d.bits / 8; }
     # a raw `ptr`, a typed `*T`, and a function value (a code address) are all
     # pointer-sized, read from the target's pointer width.
     if (k == type.TYPE_PTR || k == type.TYPE_POINTER || k == type.TYPE_FUN) { ret ptr_width(sc); }

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -230,25 +230,24 @@ fun is_value_preserving_binop(op: expr.BinOp) bool {
 fun int_literal_fits(sc: *context.SemaContext, v: u64, to: type.TypeId, negated: bool) bool {
     val opt_type: O.Option[*type.Type] = type.get(?sc.s.types, to);
     if (O.is_none[*type.Type](opt_type)) { ret false; }
-    val k: type.TypeKind = O.unwrap[*type.Type](opt_type).kind;
+    val d: type.PrimDesc = type.prim_desc(O.unwrap[*type.Type](opt_type).kind);
+    if (d.class != type.PRIM_CLASS_INT) { ret false; }
 
     if (negated) {
-        if (k == type.TYPE_I8)  { ret v <= 0x80; }
-        if (k == type.TYPE_I16) { ret v <= 0x8000; }
-        if (k == type.TYPE_I32) { ret v <= 0x80000000; }
-        if (k == type.TYPE_I64) { ret v <= 0x8000000000000000; }
-        ret false;
+        # a negated literal needs a signed destination; its magnitude may reach
+        # |min| = 2^(bits-1).
+        if (!d.signed) { ret false; }
+        ret v <= (1::u64 << (d.bits - 1)::usize);
     }
 
-    if (k == type.TYPE_U8)  { ret v <= 0xFF; }
-    if (k == type.TYPE_U16) { ret v <= 0xFFFF; }
-    if (k == type.TYPE_U32) { ret v <= 0xFFFFFFFF; }
-    if (k == type.TYPE_U64) { ret true; }
-    if (k == type.TYPE_I8)  { ret v <= 0x7F; }
-    if (k == type.TYPE_I16) { ret v <= 0x7FFF; }
-    if (k == type.TYPE_I32) { ret v <= 0x7FFFFFFF; }
-    if (k == type.TYPE_I64) { ret v <= 0x7FFFFFFFFFFFFFFF; }
-    ret false;
+    if (!d.signed) {
+        # an unsigned destination holds up to 2^bits - 1; a 64-bit one holds any
+        # u64, so it always fits (2^64 would overflow the shift).
+        if (d.bits >= 64) { ret true; }
+        ret v <= (1::u64 << d.bits::usize) - 1;
+    }
+    # a signed destination holds up to 2^(bits-1) - 1.
+    ret v <= (1::u64 << (d.bits - 1)::usize) - 1;
 }
 
 # rewrite expr_type[eid] to the coerced type and return some(to)

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -924,14 +924,11 @@ pub fun lower_type(lc: *LowerContext, tid: type.TypeId) R.Result[ir_type.IrTypeI
     val t: *type.Type = O.unwrap[*type.Type](t_opt);
     val k: type.TypeKind = t.kind;
 
-    if (k == type.TYPE_U8 || k == type.TYPE_I8)   { ret ir_type.intern_int(?lc.m.types, 8); }
-    if (k == type.TYPE_U16 || k == type.TYPE_I16) { ret ir_type.intern_int(?lc.m.types, 16); }
-    if (k == type.TYPE_U32 || k == type.TYPE_I32) { ret ir_type.intern_int(?lc.m.types, 32); }
-    if (k == type.TYPE_U64 || k == type.TYPE_I64) { ret ir_type.intern_int(?lc.m.types, 64); }
-    if (k == type.TYPE_F32)                       { ret ir_type.intern_float(?lc.m.types, 32); }
-    if (k == type.TYPE_F64)                       { ret ir_type.intern_float(?lc.m.types, 64); }
-    if (k == type.TYPE_PTR)                       { ret ir_type.intern_ptr(?lc.m.types); }
-    if (k == type.TYPE_POINTER)                   { ret ir_type.intern_ptr(?lc.m.types); }
+    val d: type.PrimDesc = type.prim_desc(k);
+    if (d.class == type.PRIM_CLASS_INT)   { ret ir_type.intern_int(?lc.m.types, d.bits); }
+    if (d.class == type.PRIM_CLASS_FLOAT) { ret ir_type.intern_float(?lc.m.types, d.bits); }
+    if (d.class == type.PRIM_CLASS_PTR)   { ret ir_type.intern_ptr(?lc.m.types); }
+    if (k == type.TYPE_POINTER)           { ret ir_type.intern_ptr(?lc.m.types); }
 
     if (k == type.TYPE_ARRAY) {
         val res_base: R.Result[ir_type.IrTypeId, str] = lower_type(lc, t.data.array.base);

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -2724,10 +2724,8 @@ fun scalar_bits(ctx: *context.LowerContext, tid: type.TypeId) u32 {
     val opt_t: O.Option[*type.Type] = type.get(?ctx.s.types, tid);
     if (O.is_none[*type.Type](opt_t)) { ret 0; }
     val k: type.TypeKind = O.unwrap[*type.Type](opt_t).kind;
-    if (k == type.TYPE_U8  || k == type.TYPE_I8)                            { ret 8; }
-    if (k == type.TYPE_U16 || k == type.TYPE_I16)                           { ret 16; }
-    if (k == type.TYPE_U32 || k == type.TYPE_I32 || k == type.TYPE_F32)     { ret 32; }
-    if (k == type.TYPE_U64 || k == type.TYPE_I64 || k == type.TYPE_F64)     { ret 64; }
+    val d: type.PrimDesc = type.prim_desc(k);
+    if (d.class == type.PRIM_CLASS_INT || d.class == type.PRIM_CLASS_FLOAT) { ret d.bits; }
     if (k == type.TYPE_PTR || k == type.TYPE_POINTER || k == type.TYPE_FUN) { ret ctx.tgt.arch.pointer_width * 8; }
     ret 0;
 }
@@ -2740,8 +2738,7 @@ fun scalar_bits(ctx: *context.LowerContext, tid: type.TypeId) u32 {
 fun is_signed_type(ctx: *context.LowerContext, tid: type.TypeId) bool {
     val opt_t: O.Option[*type.Type] = type.get(?ctx.s.types, tid);
     if (O.is_none[*type.Type](opt_t)) { ret false; }
-    val k: type.TypeKind = O.unwrap[*type.Type](opt_t).kind;
-    ret k == type.TYPE_I8 || k == type.TYPE_I16 || k == type.TYPE_I32 || k == type.TYPE_I64;
+    ret type.prim_desc(O.unwrap[*type.Type](opt_t).kind).signed;
 }
 
 # whether a semantic type is a float
@@ -2752,8 +2749,7 @@ fun is_signed_type(ctx: *context.LowerContext, tid: type.TypeId) bool {
 fun is_float_type(ctx: *context.LowerContext, tid: type.TypeId) bool {
     val opt_t: O.Option[*type.Type] = type.get(?ctx.s.types, tid);
     if (O.is_none[*type.Type](opt_t)) { ret false; }
-    val k: type.TypeKind = O.unwrap[*type.Type](opt_t).kind;
-    ret k == type.TYPE_F32 || k == type.TYPE_F64;
+    ret type.prim_desc(O.unwrap[*type.Type](opt_t).kind).class == type.PRIM_CLASS_FLOAT;
 }
 
 # whether a semantic type is a pointer (raw `ptr` or typed `*T`)

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -68,6 +68,63 @@ pub val TYPE_INSTANCE:      TypeKind = 17;  # concrete instantiation of a generi
 # supplied by monomorphization, never carried on the type itself.
 pub val TYPE_PACK: TypeKind = 18;
 
+# scalar class of a primitive TypeKind, the discriminator of PrimDesc
+pub def PrimClass: u8;
+
+# not a primitive scalar (a compound, nominal, or sentinel kind)
+pub val PRIM_CLASS_NONE:  PrimClass = 0;
+# an integer primitive (u8..i64); signedness lives in PrimDesc.signed
+pub val PRIM_CLASS_INT:   PrimClass = 1;
+# a floating-point primitive (f32, f64)
+pub val PRIM_CLASS_FLOAT: PrimClass = 2;
+# the raw `ptr` primitive; its width is target-defined, so bits is 0 here
+pub val PRIM_CLASS_PTR:   PrimClass = 3;
+
+# the (class, signedness, bit width) of a primitive TypeKind
+#
+# The single source of truth every site that classifies a primitive by its
+# scalar class, signedness, or width derives from, replacing the per-site
+# `(sign, bits, class)` if-ladders. A non-primitive kind yields PRIM_CLASS_NONE
+# with signed false and bits 0.
+# ---
+# class:  PRIM_CLASS_INT / FLOAT / PTR, or PRIM_CLASS_NONE for a non-primitive
+# signed: true for the signed integers (i8..i64), false otherwise
+# bits:   scalar width in bits (8/16/32/64 for int, 32/64 for float, 0 for ptr)
+pub rec PrimDesc {
+    class:  PrimClass;
+    signed: bool;
+    bits:   u32;
+}
+
+# the PrimDesc for a TypeKind
+#
+# The one if-ladder mapping a primitive kind to its scalar facts; every other
+# classifier reads this rather than restating the per-kind constants. A
+# non-primitive kind maps to PRIM_CLASS_NONE.
+# ---
+# kind: the TypeKind to describe
+# ret:  the kind's PrimDesc (PRIM_CLASS_NONE for a non-primitive kind)
+pub fun prim_desc(kind: TypeKind) PrimDesc {
+    var d: PrimDesc;
+    d.class  = PRIM_CLASS_NONE;
+    d.signed = false;
+    d.bits   = 0;
+
+    if (kind == TYPE_U8)  { d.class = PRIM_CLASS_INT;   d.signed = false; d.bits = 8;  }
+    or (kind == TYPE_U16) { d.class = PRIM_CLASS_INT;   d.signed = false; d.bits = 16; }
+    or (kind == TYPE_U32) { d.class = PRIM_CLASS_INT;   d.signed = false; d.bits = 32; }
+    or (kind == TYPE_U64) { d.class = PRIM_CLASS_INT;   d.signed = false; d.bits = 64; }
+    or (kind == TYPE_I8)  { d.class = PRIM_CLASS_INT;   d.signed = true;  d.bits = 8;  }
+    or (kind == TYPE_I16) { d.class = PRIM_CLASS_INT;   d.signed = true;  d.bits = 16; }
+    or (kind == TYPE_I32) { d.class = PRIM_CLASS_INT;   d.signed = true;  d.bits = 32; }
+    or (kind == TYPE_I64) { d.class = PRIM_CLASS_INT;   d.signed = true;  d.bits = 64; }
+    or (kind == TYPE_F32) { d.class = PRIM_CLASS_FLOAT; d.signed = false; d.bits = 32; }
+    or (kind == TYPE_F64) { d.class = PRIM_CLASS_FLOAT; d.signed = false; d.bits = 64; }
+    or (kind == TYPE_PTR) { d.class = PRIM_CLASS_PTR;   d.signed = false; d.bits = 0;  }
+
+    ret d;
+}
+
 # pointer-to-T type payload
 # ---
 # base: pointee TypeId
@@ -432,7 +489,7 @@ pub fun prim(ti: *TypeInterner, kind: TypeKind) O.Option[TypeId] {
 pub fun is_integer(ti: *TypeInterner, tid: TypeId) bool {
     val opt_type: O.Option[*Type] = get(ti, tid);
     if (O.is_none[*Type](opt_type)) { ret false; }
-    ret O.unwrap[*Type](opt_type).kind <= TYPE_I64;
+    ret prim_desc(O.unwrap[*Type](opt_type).kind).class == PRIM_CLASS_INT;
 }
 
 # whether `tid` is an integer or float primitive (u8..f64)
@@ -443,7 +500,8 @@ pub fun is_integer(ti: *TypeInterner, tid: TypeId) bool {
 pub fun is_numeric(ti: *TypeInterner, tid: TypeId) bool {
     val opt_type: O.Option[*Type] = get(ti, tid);
     if (O.is_none[*Type](opt_type)) { ret false; }
-    ret O.unwrap[*Type](opt_type).kind <= TYPE_F64;
+    val c: PrimClass = prim_desc(O.unwrap[*Type](opt_type).kind).class;
+    ret c == PRIM_CLASS_INT || c == PRIM_CLASS_FLOAT;
 }
 
 # whether `tid` is a float primitive (f32 or f64)
@@ -454,8 +512,7 @@ pub fun is_numeric(ti: *TypeInterner, tid: TypeId) bool {
 pub fun is_float(ti: *TypeInterner, tid: TypeId) bool {
     val opt_type: O.Option[*Type] = get(ti, tid);
     if (O.is_none[*Type](opt_type)) { ret false; }
-    val k: TypeKind = O.unwrap[*Type](opt_type).kind;
-    ret k == TYPE_F32 || k == TYPE_F64;
+    ret prim_desc(O.unwrap[*Type](opt_type).kind).class == PRIM_CLASS_FLOAT;
 }
 
 # whether `tid` is address-shaped - a raw `ptr`, a typed `*T`, or a function


### PR DESCRIPTION
Collapse the disjoint, repeated `(sign, bits, class)` primitive-type if-ladders
into one descriptor table (`type.PrimDesc` + `type.prim_desc`) that every site
derives from. Pure deduplication, zero behavior change. Foundation for later
composable type widths (u6, f128).

## Descriptor (src/lang/type.mach)

- `PrimClass` (`PRIM_CLASS_NONE` / `_INT` / `_FLOAT` / `_PTR`)
- `rec PrimDesc { class; signed; bits; }`
- `fun prim_desc(kind: TypeKind) PrimDesc` -- the single `(sign, bits, class)` ladder

## Ladders consolidated (derive from prim_desc)

- src/lang/type.mach:432 `is_integer` (was `kind <= TYPE_I64`)
- src/lang/type.mach:443 `is_numeric` (was `kind <= TYPE_F64`)
- src/lang/type.mach:454 `is_float` (was `kind == TYPE_F32 || TYPE_F64`)
- src/lang/fe/sema/coerce.mach:236-250 `int_literal_fits` integer range bounds (sign + bits)
- src/lang/me/lower/context.mach:927-933 `lower_type` primitive int/float/ptr -> IR type
- src/lang/fe/sema/check.mach:449-452 `byte_size` primitive int/float -> bytes (bits/8)
- src/lang/me/lower/expr.mach:2727-2730 `scalar_bits` primitive int/float width
- src/lang/me/lower/expr.mach:2744 `is_signed_type` (signed)
- src/lang/me/lower/expr.mach:2756 `is_float_type` (float class)

## Ladders left as-is (not a clean sign/width/class classification)

- src/lang/fe/resolve.mach:755-765 primitive seeding -- name->kind table (inverse mapping, canonical name list)
- src/lang/me/lower/mangle.mach:477-522 mangled-name length + spelling (name encoding, not a scalar fact)
- src/lang/fe/sema/check.mach:1071-1128 diagnostic spelling length + keyword (name encoding)
- src/lang/fe/sema/coerce.mach:88 float check compares a `TypeId` to kind ordinals (TypeId-level, not a kind classification)
- pointer-like groupings that fold in compound kinds `TYPE_POINTER` / `TYPE_FUN` (coerce.mach ptr rules, expr.mach `is_pointer_type`, check.mach/expr.mach pointer-width arms, type.mach `is_pointer_like`) -- the primitive `TYPE_PTR` arm is covered, the compound arms stay

The IR type universe (src/lang/me/ir/type.mach) already stores width on the
`IRT_INT` / `IRT_FLOAT` payload and carries no signedness, so no parallel
IR-side descriptor is needed; backend reads (`be/codegen*`) read those stored
bits directly rather than restating per-kind facts.

Gate: `mach build .` exit 0, `mach test .` 606 passed / 0 failed.

Part of #1600