### PR TITLE
refactor: derive index/address width from the target pointer width

### DIFF
--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -2685,17 +2685,17 @@ fun ir_type_of_expr(ctx: *context.LowerContext, eid: id.ExprId) R.Result[ir_type
     ret context.lower_type(ctx, context.expr_type_of(ctx, eid));
 }
 
-# the IR integer type used for gep indices and alloca element counts (i64)
+# the IR integer type used for gep indices and alloca element counts (pointer-width)
 # ---
 # ctx: per-module lowering context
-# ret: the i64 IR type, or an error
+# ret: the pointer-width IR int type, or an error
 fun index_type(ctx: *context.LowerContext) R.Result[ir_type.IrTypeId, str] {
-    ret ir_type.intern_int(?ctx.m.types, 64);
+    ret ir_type.intern_int(?ctx.m.types, ctx.tgt.arch.pointer_width * 8);
 }
 
-# widen a runtime gep index to the 64-bit machine-word index type
+# widen a runtime gep index to the pointer-width machine-word index type
 #
-# A narrower index (e.g. a u8 enum/kind) is extended per its signedness; a 64-bit
+# A narrower index (e.g. a u8 enum/kind) is extended per its signedness; a pointer-width
 # (or wider) index is left as-is. Without this the back end scales the index's full
 # register while its high bits are undefined, producing a wild address.
 # ---
@@ -2707,7 +2707,7 @@ fun widen_index(ctx: *context.LowerContext, v: value.Value, sem_ty: type.TypeId)
     val res_xty: R.Result[ir_type.IrTypeId, str] = index_type(ctx);
     if (R.is_err[ir_type.IrTypeId, str](res_xty)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_xty)); }
     val xty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_xty);
-    if (scalar_bits(ctx, sem_ty) >= 64) { ret R.ok[value.Value, str](v); }
+    if (scalar_bits(ctx, sem_ty) >= ctx.tgt.arch.pointer_width * 8) { ret R.ok[value.Value, str](v); }
     if (is_signed_type(ctx, sem_ty))    { ret builder.emit_sext(?ctx.builder, v, xty); }
     ret builder.emit_zext(?ctx.builder, v, xty);
 }


### PR DESCRIPTION
Route the gep-index / alloca-element-count integer width through the target pointer width instead of a hardcoded 64-bit.

`index_type` now interns `ctx.tgt.arch.pointer_width * 8` bits, and `widen_index` compares against that same pointer-width threshold rather than a literal 64. On the current targets (x64, arm64) `pointer_width == 8`, so this is a byte-for-byte no-op.

Build clean, 606/606 tests pass.

Part of #1600