### PR TITLE
refactor: remove the dead syscall_layer OsVTable field

### DIFF
--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -59,7 +59,6 @@ pub val OS_LIBDIR_MAX: u32 = 8;
 # name:           os name ("linux", "darwin", "windows")
 # entry_symbol:   program entry-point symbol ("_start", "_main", ...); the linker
 #                 interns it where it keys the symbol table
-# syscall_layer:  syscall-layer name selecting the runtime backend
 # libdirs:        ordered system library directories the CLI link path probes for
 #                 a shared dependency, after the -L dirs; only the first
 #                 libdir_len entries are populated. per-OS, so a cross-OS link
@@ -86,7 +85,6 @@ pub rec OsVTable {
     id:             u32;
     name:           str;
     entry_symbol:   str;
-    syscall_layer:  str;
     libdirs:        [OS_LIBDIR_MAX]str;
     libdir_len:     u32;
     dynamic_linker: str;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -44,7 +44,6 @@ pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     darwin_vtable.id             = os.OS_DARWIN;
     darwin_vtable.name           = "darwin";
     darwin_vtable.entry_symbol   = "_main";
-    darwin_vtable.syscall_layer  = "darwin";
     darwin_vtable.libdirs[0]     = "/usr/lib";
     darwin_vtable.libdirs[1]     = "/usr/local/lib";
     darwin_vtable.libdir_len     = 2;

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -52,7 +52,6 @@ pub fun register_linux(reg: *os.OsRegistry) R.Result[bool, str] {
     linux_vtable.id             = os.OS_LINUX;
     linux_vtable.name           = "linux";
     linux_vtable.entry_symbol   = "_start";
-    linux_vtable.syscall_layer  = "linux";
     linux_vtable.libdirs[0]     = "/lib64";
     linux_vtable.libdirs[1]     = "/usr/lib64";
     # x86_64-linux multiarch defaults; the aarch64-linux dirs and a general

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -46,7 +46,6 @@ pub fun register_windows(reg: *os.OsRegistry) R.Result[bool, str] {
     windows_vtable.id             = os.OS_WINDOWS;
     windows_vtable.name           = "windows";
     windows_vtable.entry_symbol   = "mainCRTStartup";
-    windows_vtable.syscall_layer  = "windows";
     windows_vtable.libdirs[0]     = "C:\\Windows\\System32";
     windows_vtable.libdir_len     = 1;
     # PE imports load through the import directory, not a PT_INTERP-style path.


### PR DESCRIPTION
Removes the `syscall_layer` field from `OsVTable`. It was never read anywhere in the compiler - only declared, documented, and assigned in the three OS impls (linux, darwin, windows).

`git grep syscall_layer src` now returns nothing. Build is clean and the full suite is 606/606.

Part of #1600