### PR TITLE
refactor: route x64 callee-saved through abi.RegFileFn

### DIFF
--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -68,17 +68,6 @@ pub val RED_ZONE:    u32 = 128;
 # larger is returned via a hidden sret pointer.
 pub val MAX_REG_RET: u64 = 16;
 
-# re-exports of the neutral vtable function signatures (`mach.lang.target.abi`),
-# named so a consumer casting one of sysv's erased vtable pointers can spell the
-# cast target as `sysv.RegFileFn` rather than reaching for `abi.RegFileFn`. the
-# shared typedefs live in the abi module so the neutral interface never routes
-# through a concrete convention.
-pub def ClassifyFn:   abi.ClassifyFn;
-pub def ArgPassingFn: abi.ArgPassingFn;
-pub def RetPassingFn: abi.RetPassingFn;
-pub def RegFileFn:    abi.RegFileFn;
-pub def VaModelFn:    abi.VaModelFn;
-
 # the GP argument register for a zero-based argument-register index
 # ---
 # index: zero-based GP argument-register index

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -204,7 +204,7 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 # `encode.print_asm` dispatchers, which already import `mir` and `target` - casts
 # the erased pointer back to the concrete `SelectFn` / `EncodeFn` / `PrintAsmFn`
 # signature declared in the per-arch implementation file (e.g. `target/isa/x64`),
-# exactly as `mir` casts `abi.arg_passing` back to `sysv.ArgPassingFn`. `emit_asm`
+# exactly as `mir` casts `abi.arg_passing` back to `abi.ArgPassingFn`. `emit_asm`
 # is an optional debug hook: an ISA that supplies no human-readable assembly
 # printer leaves it nil and the `print_asm` dispatcher no-ops.
 #

--- a/src/lang/target/isa/x64.mach
+++ b/src/lang/target/isa/x64.mach
@@ -15,7 +15,6 @@ use std.types.bool.true;
 use std.types.string.str;
 
 use mach.lang.target.abi;
-use mach.lang.target.abi.sysv;
 use mach.lang.target.isa;
 
 # general-purpose register ids. these are the canonical x86-64 GP register
@@ -426,7 +425,7 @@ pub fun callee_saved_gp_list(abi_vt: *abi.AbiVTable, out: *i32) i32 {
     # the file buffer holds the whole callee-saved set (GP plus vector), bounded
     # by the full register space (GP_COUNT + FP_COUNT).
     var file: [32]isa.Register;
-    val fill: sysv.RegFileFn = abi_vt.callee_saved::sysv.RegFileFn;
+    val fill: abi.RegFileFn = abi_vt.callee_saved::abi.RegFileFn;
     var total: i32 = fill(?file[0]);
     if (total > 32) { total = 32; }
 

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -86,7 +86,7 @@ use target: mach.lang.target.resolved;
 # `isa` -- a typed field there would invert that dependency and form an import
 # cycle. The shared `be.codegen.isel` dispatcher casts the erased pointer back to
 # this type before calling it (exactly as `mir` casts `abi.arg_passing` back to
-# `sysv.ArgPassingFn`). The allocator is threaded explicitly because the per-
+# `abi.ArgPassingFn`). The allocator is threaded explicitly because the per-
 # function selection needs it to rebuild a block's instruction list when expanding
 # the NEG / NOT multi-instruction forms, and neither `Target` nor `MirFunction`
 # carries one.


### PR DESCRIPTION
Routes x64's callee-saved register lookup through the ABI-neutral `abi.RegFileFn` instead of reaching into the concrete `sysv` ABI module.

`callee_saved_gp_list` in `src/lang/target/isa/x64.mach` cast the abi vtable's type-erased `callee_saved` pointer through `sysv.RegFileFn`, pulling in `mach.lang.target.abi.sysv` only to name a signature the abi vtable already exposes neutrally. The cast now goes through `abi.RegFileFn`, reached via the target's abi vtable, and the unused `use ...abi.sysv;` import is dropped. The fn pointer still resolves to the active convention's impl through the vtable, so behavior is identical.

Also removes the dead per-convention Fn-alias family in `sysv.mach` (and its blessing doc comment) that existed only so a consumer could spell the cast as `sysv.RegFileFn`, and updates two stale doc references in `isa.mach` / `isa/x64/isel.mach` that named the deleted `sysv.ArgPassingFn` to the neutral `abi.ArgPassingFn` that `mir` actually casts to.

`mach build .` exit 0 and `mach test .` reports 606 passed, 0 failed, 606 total.

Part of #1600