### PR TITLE
feat: add the MachineModel record (define + populate)

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -247,7 +247,8 @@ pub val FP_CLASS_MIN_BITS: u32 = 128;
 
 # canonical machine-word width in bytes for address-sized and pointer-sized
 # operations (LEA address forms, ABI register moves, the call/branch pseudos).
-# the encoder also treats a `width` of 0 as this width.
+# the encoder also treats a `width` of 0 as this width. migrates to
+# `target.MachineModel.gpr_width` when the stages are rewired (issue #1600).
 pub val WORD_WIDTH: u8 = 8;
 
 # the minimum byte width an integer ALU / shift result is computed at. a register

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -75,7 +75,8 @@ val FP_CLASS_MIN_BITS: u32 = 128;
 
 # the byte width of a spill reload / store MOV. a spill slot is
 # sized to a full register, so the value is saved and restored at the machine-word
-# width regardless of its logical sub-register width.
+# width regardless of its logical sub-register width. migrates to
+# `target.MachineModel.spill_width` when the stages are rewired (issue #1600).
 val SPILL_MOV_WIDTH: u8 = 8;
 
 # sentinel "no live range"; never a valid range index
@@ -305,7 +306,7 @@ fun fp_class_index(tgt: *target.Target) u32 {
 # class index.
 fun bank_count(tgt: *target.Target, class: u32) u32 {
     if (class >= tgt.arch.reg_class_count) { ret 0; }
-    ret tgt.arch.reg_classes[class].count;
+    ret tgt.arch.reg_classes[class].len;
 }
 
 # assign physical registers (or spill slots) to one function and

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -254,6 +254,15 @@ pub fun select(reg: *TargetRegistry, os_id: u32, arch_id: u32) R.Result[resolved
     t.abi     = O.unwrap[*abi.AbiVTable](opt_abi_vt);
     t.of      = O.unwrap[*of.OfVTable](opt_of_vt);
 
+    # assemble the machine model: copy the isa's model template by value, then
+    # overlay the selected abi's stack scalars (these vary by convention - sysv vs
+    # win64 - so the per-arch template leaves them 0 and select fills them here).
+    val model_tmpl: *isa.MachineModel = t.arch.model;
+    t.model              = @model_tmpl;
+    t.model.stack_align  = t.abi.stack_align;
+    t.model.red_zone     = t.abi.red_zone;
+    t.model.shadow_space = t.abi.shadow_space;
+
     ret R.ok[resolved.Target, str](t);
 }
 

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -19,12 +19,14 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
-# byte order of a target's scalar storage. no ISA vtable carries an endianness
-# field: every supported ISA is little-endian and the object-format writers
-# hardcode it. these constants remain for the eventual big-endian abstraction (an
-# ISA field wired through the writers), added with the first big-endian target.
-pub val ENDIAN_LITTLE: u32 = 0;  # least-significant byte first
-pub val ENDIAN_BIG:    u32 = 1;  # most-significant byte first
+# byte order of a target's scalar storage
+#
+# Carried on the `MachineModel` so the encoders and object-format writers read it
+# instead of assuming little-endian. every ISA supported today is little-endian;
+# the enum exists so the first big-endian target is a description, not a core edit.
+pub def Endian: u8;
+pub val ENDIAN_LITTLE: Endian = 0;  # least-significant byte first
+pub val ENDIAN_BIG:    Endian = 1;  # most-significant byte first
 
 # canonical numeric ids for known instruction sets. stable across compiler
 # versions; user code dispatches on them through `$mach.arch.<name>` and
@@ -159,18 +161,118 @@ pub rec InstBuf {
 # seed capacity for an instruction buffer's first growth
 val INSTBUF_INIT_CAP: i32 = 64;
 
+# the role a register bank plays in the machine model
+#
+# Lets the shared backend stages find "the general-purpose bank" or "the float
+# bank" by role rather than a magic index or a ">= 128-bit width" scan-and-panic: a
+# target with no float bank simply declares no RC_FLOAT class.
+pub def RegClassKind: u8;
+pub val RC_GENERAL: RegClassKind = 0;  # integer / pointer
+pub val RC_FLOAT:   RegClassKind = 1;  # scalar float / low SIMD
+pub val RC_VECTOR:  RegClassKind = 2;  # wide vector
+pub val RC_FLAGS:   RegClassKind = 3;  # condition flags (unallocatable)
+
 # a register class exposed by an ISA
 #
 # The backend reads these to size and allocate virtual registers without
 # target-specific knowledge.
 # ---
 # name:      interned class name ("gpr", "xmm", "flags", ...)
+# kind:      the role the bank plays (general / float / vector / flags)
 # bit_width: width of one register in bits
-# count:     number of registers in the class
+# len:       number of registers in the class
 pub rec RegClass {
     name:      str;
+    kind:      RegClassKind;
     bit_width: u32;
-    count:     u32;
+    len:       u32;
+}
+
+# the addressing forms the shared lowering and isel reason about, an extensible
+# flag set
+#
+# An ISA's exotic modes (a 6502 `(zp),Y`) live in that ISA's own isel, never here;
+# this set is only what the shared, model-driven stages fold and select against.
+pub def AddrForm: u32;
+pub val ADDR_BASE:            AddrForm = 0x01;  # [base]
+pub val ADDR_BASE_DISP:       AddrForm = 0x02;  # [base + disp]
+pub val ADDR_BASE_INDEX:      AddrForm = 0x04;  # [base + index*scale]
+pub val ADDR_BASE_INDEX_DISP: AddrForm = 0x08;  # [base + index*scale + disp]
+pub val ADDR_ABSOLUTE:        AddrForm = 0x10;  # [disp]
+pub val ADDR_PCREL:           AddrForm = 0x20;  # [pc + disp]
+
+# the pure machine description the shared backend stages read
+#
+# `resolved.Target` carries one of these by value; `target.select` assembles it
+# from the chosen isa's model template and the chosen abi's stack scalars. the
+# shared lower / regalloc / frame stages and the width / endianness paths in the
+# encoders are meant to read the model instead of scattered constants or an
+# `arch_id` branch, so a new target becomes a populated description rather than a
+# core edit. this definition is purely additive: the stages still read the legacy
+# constants and vtable fields until the rewiring lands (issue #1600 group B).
+#
+# the register file's banks self-describe via `RegClassKind`, so a stage finds the
+# general-purpose or float bank by role and never by a magic index. the addressing
+# capability is a flag set plus a legal-scale mask plus a displacement width, not a
+# universal addressing-mode descriptor: an ISA's exotic modes stay in its own isel.
+# ---
+# pointer_width:     pointer width in bytes
+# gpr_width:         general-purpose / machine-word width in bytes
+# index_width:       array-index computation width in bytes
+# spill_width:       spill / reload move width in bytes
+# endianness:        byte order of scalar storage (ENDIAN_*)
+# reg_classes:       borrowed array of the ISA's register classes
+# reg_class_len:     number of register classes
+# frame_ptr_reg:     frame-pointer register id (base of incoming stack params)
+# stack_ptr_reg:     stack-pointer register id (base of outgoing stack args)
+# scratch_regs:      borrowed reload-scratch register pool
+# scratch_len:       number of reload-scratch registers
+# reserved_regs:     borrowed registers the allocator must never assign
+# reserved_len:      number of reserved registers
+# div_reg:           register the division form pins as dividend / quotient, or -1
+# div_hi_reg:        register the division form pins as high-half / remainder, or -1
+# shift_count_reg:   register a variable shift's count must occupy, or -1
+# addr_forms:        flag set of supported addressing forms (ADDR_*)
+# addr_scales:       bitmask of legal index scales; scale S is legal iff
+#                    (addr_scales & S) != 0 (scales are powers of two)
+# addr_disp_bits:    widest displacement the ISA encodes, in bits
+# stack_grows_down:  true when the stack grows toward lower addresses
+# fp_relative_frame: true when spills home at [fp+off]; false => sp-relative
+# incoming_arg_base: byte offset from the frame pointer to the first incoming
+#                    stack argument (the frame fact the prologue establishes)
+# stack_align:       required stack alignment in bytes at a call boundary (from abi)
+# red_zone:          leaf-function red-zone size in bytes, 0 if none (from abi)
+# shadow_space:      home/shadow bytes the caller reserves below the stack args
+#                    (win64's 32, 0 for SysV) (from abi)
+pub rec MachineModel {
+    pointer_width: u32;
+    gpr_width:     u32;
+    index_width:   u32;
+    spill_width:   u32;
+    endianness:    Endian;
+
+    reg_classes:    *RegClass;
+    reg_class_len:  u32;
+    frame_ptr_reg:  i32;
+    stack_ptr_reg:  i32;
+    scratch_regs:   *Register;
+    scratch_len:    i32;
+    reserved_regs:  *Register;
+    reserved_len:   i32;
+    div_reg:         i32;
+    div_hi_reg:      i32;
+    shift_count_reg: i32;
+
+    addr_forms:     AddrForm;
+    addr_scales:    u32;
+    addr_disp_bits: u32;
+
+    stack_grows_down:  bool;
+    fp_relative_frame: bool;
+    incoming_arg_base: i64;
+    stack_align:       u32;
+    red_zone:          u32;
+    shadow_space:      u32;
 }
 
 # the concrete signature the erased `IsaVTable.asm_clobbers` pointer is cast back to
@@ -280,6 +382,11 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 #                       dividend high half / remainder (x86-64 RDX), or -1
 # shift_count_reg:      register a variable shift's runtime count must occupy
 #                       (x86-64 RCX, used as CL), or -1
+# model:                borrowed per-arch `MachineModel` template (widths, register
+#                       file, addressing capability, frame model); `target.select`
+#                       copies it by value and overlays the abi's stack scalars. the
+#                       data here duplicates the per-arch model until the stages are
+#                       rewired to read the model (issue #1600 group B)
 pub rec IsaVTable {
     id:                   u32;
     name:                 str;
@@ -303,6 +410,7 @@ pub rec IsaVTable {
     div_reg:              i32;
     div_hi_reg:           i32;
     shift_count_reg:      i32;
+    model:                *MachineModel;
 }
 
 # number of architecture slots in an IsaRegistry, indexed by ARCH_* id

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -27,6 +27,13 @@ use mach.lang.target.isa.arm64.printer;
 var arm64_vtable:  isa.IsaVTable;
 var arm64_classes: [3]isa.RegClass;
 
+# process-global storage for the AArch64 machine-model template. written once by
+# `register_arm64` and pointed to by the vtable's `model` field; `target.select`
+# copies it by value and overlays the selected abi's stack scalars. lives for the
+# process lifetime. its register-file pointers borrow the same per-arch arrays the
+# vtable does (`arm64_classes`, `arm64_reload_scratch_regs`, `arm64_reserved_regs`).
+var arm64_model: isa.MachineModel;
+
 # the registers the allocator must never assign: the stack pointer (SP), the frame
 # pointer (FP/X29), and the link register (LR/X30, which holds the return
 # address). borrowed by the vtable's `reserved_regs` field; lives for the process
@@ -69,8 +76,9 @@ var arm64_reload_scratch_regs: [3]isa.Register;
 # ret: true on success
 pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_classes[0].name      = "gpr";
+    arm64_classes[0].kind      = isa.RC_GENERAL;
     arm64_classes[0].bit_width = 64;
-    arm64_classes[0].count     = arm64.GPR_COUNT::u32;
+    arm64_classes[0].len       = arm64.GPR_COUNT::u32;
 
     # the vector bank exposes only V0-V29 (count 30) to the allocator. V30 and V31
     # are held back as the two fixed FP scratch registers the float-op encoder
@@ -80,12 +88,14 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # and both sources spilled needs two FP registers live at once to form
     # `op Sd, Sn, Sm`, which one scratch cannot supply.
     arm64_classes[1].name      = "vector";
+    arm64_classes[1].kind      = isa.RC_FLOAT;
     arm64_classes[1].bit_width = 128;
-    arm64_classes[1].count     = arm64.VECTOR_COUNT::u32;
+    arm64_classes[1].len       = arm64.VECTOR_COUNT::u32;
 
     arm64_classes[2].name      = "flags";
+    arm64_classes[2].kind      = isa.RC_FLAGS;
     arm64_classes[2].bit_width = 64;
-    arm64_classes[2].count     = 1;
+    arm64_classes[2].len       = 1;
 
     arm64_reserved_regs[0].id   = arm64.SP;
     arm64_reserved_regs[0].size = 8;
@@ -134,6 +144,45 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_vtable.div_reg              = -1;
     arm64_vtable.div_hi_reg           = -1;
     arm64_vtable.shift_count_reg      = -1;
+
+    # the machine-model template: every value equals today's reality so the stages
+    # preserve behavior when they are rewired to read it. widths are in bytes; the
+    # register-file pointers borrow the same per-arch arrays the vtable does; the
+    # stack scalars stay 0 here and are overlaid by `target.select` from the abi.
+    arm64_model.pointer_width   = 8;
+    arm64_model.gpr_width       = 8;
+    arm64_model.index_width     = 8;
+    arm64_model.spill_width     = 8;
+    arm64_model.endianness      = isa.ENDIAN_LITTLE;
+
+    arm64_model.reg_classes     = ?arm64_classes[0];
+    arm64_model.reg_class_len   = 3;
+    arm64_model.frame_ptr_reg   = arm64.FP;
+    arm64_model.stack_ptr_reg   = arm64.SP;
+    arm64_model.scratch_regs    = ?arm64_reload_scratch_regs[0];
+    arm64_model.scratch_len     = 3;
+    arm64_model.reserved_regs   = ?arm64_reserved_regs[0];
+    arm64_model.reserved_len    = 3;
+    arm64_model.div_reg         = -1;
+    arm64_model.div_hi_reg      = -1;
+    arm64_model.shift_count_reg = -1;
+
+    # the shared MIR assumes the same addressing forms on both arches: it folds
+    # [base + index*scale + disp] and emits pc-relative symbol references, never a
+    # bare [disp] absolute memory operand. legal scales are 1|2|4|8 and the shared
+    # displacement is a signed 32-bit (the MIR operand's `disp` field).
+    arm64_model.addr_forms      = isa.ADDR_BASE | isa.ADDR_BASE_DISP | isa.ADDR_BASE_INDEX | isa.ADDR_BASE_INDEX_DISP | isa.ADDR_PCREL;
+    arm64_model.addr_scales     = 0xF;
+    arm64_model.addr_disp_bits  = 32;
+
+    arm64_model.stack_grows_down  = true;
+    arm64_model.fp_relative_frame = true;
+    arm64_model.incoming_arg_base = 16;
+    arm64_model.stack_align       = 0;
+    arm64_model.red_zone          = 0;
+    arm64_model.shadow_space      = 0;
+
+    arm64_vtable.model = ?arm64_model;
 
     isa.register(reg, ?arm64_vtable);
 

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -25,6 +25,13 @@ use mach.lang.target.isa.x64.printer;
 var x64_vtable:  isa.IsaVTable;
 var x64_classes: [3]isa.RegClass;
 
+# process-global storage for the x86-64 machine-model template. written once by
+# `register_x64` and pointed to by the vtable's `model` field; `target.select`
+# copies it by value and overlays the selected abi's stack scalars. lives for the
+# process lifetime. its register-file pointers borrow the same per-arch arrays the
+# vtable does (`x64_classes`, `x64_reload_scratch_regs`, `x64_reserved_regs`).
+var x64_model: isa.MachineModel;
+
 # the registers the allocator must never assign: the stack pointer (RSP) and the
 # frame pointer (RBP), both owned by the frame pass. referenced (borrowed) by the
 # `reserved_regs` field of the installed ISA vtable; lives for the process
@@ -73,8 +80,9 @@ var x64_reload_scratch_regs: [3]isa.Register;
 # ret: true on success
 pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_classes[0].name      = "gpr";
+    x64_classes[0].kind      = isa.RC_GENERAL;
     x64_classes[0].bit_width = 64;
-    x64_classes[0].count     = 16;
+    x64_classes[0].len       = 16;
 
     # the SSE bank exposes only XMM0-XMM13 (count 14) to the allocator. XMM14 and
     # XMM15 (FP_SCRATCH_REG) are held back as the two fixed scratch registers the
@@ -83,12 +91,14 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # SSE analogue of holding R10/R11 back from the GP value pool for the encoder's
     # reload / mem-mem scratch.
     x64_classes[1].name      = "xmm";
+    x64_classes[1].kind      = isa.RC_FLOAT;
     x64_classes[1].bit_width = 128;
-    x64_classes[1].count     = 14;
+    x64_classes[1].len       = 14;
 
     x64_classes[2].name      = "flags";
+    x64_classes[2].kind      = isa.RC_FLAGS;
     x64_classes[2].bit_width = 64;
-    x64_classes[2].count     = 1;
+    x64_classes[2].len       = 1;
 
     x64_reserved_regs[0].id   = x64.STACK_REG;
     x64_reserved_regs[0].size = 8;
@@ -127,6 +137,45 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_vtable.div_reg              = x64.RAX;
     x64_vtable.div_hi_reg           = x64.RDX;
     x64_vtable.shift_count_reg      = x64.RCX;
+
+    # the machine-model template: every value equals today's reality so the stages
+    # preserve behavior when they are rewired to read it. widths are in bytes; the
+    # register-file pointers borrow the same per-arch arrays the vtable does; the
+    # stack scalars stay 0 here and are overlaid by `target.select` from the abi.
+    x64_model.pointer_width   = 8;
+    x64_model.gpr_width       = 8;
+    x64_model.index_width     = 8;
+    x64_model.spill_width     = 8;
+    x64_model.endianness      = isa.ENDIAN_LITTLE;
+
+    x64_model.reg_classes     = ?x64_classes[0];
+    x64_model.reg_class_len   = 3;
+    x64_model.frame_ptr_reg   = x64.FRAME_REG;
+    x64_model.stack_ptr_reg   = x64.STACK_REG;
+    x64_model.scratch_regs    = ?x64_reload_scratch_regs[0];
+    x64_model.scratch_len     = 3;
+    x64_model.reserved_regs   = ?x64_reserved_regs[0];
+    x64_model.reserved_len    = 2;
+    x64_model.div_reg         = x64.RAX;
+    x64_model.div_hi_reg      = x64.RDX;
+    x64_model.shift_count_reg = x64.RCX;
+
+    # the shared MIR folds [base + index*scale + disp] and emits rip-relative
+    # symbol references; it never forms a bare [disp] absolute memory operand
+    # (constant addresses are materialized into a register), so ADDR_ABSOLUTE is
+    # absent. legal SIB scales are 1|2|4|8 and the displacement is a signed 32-bit.
+    x64_model.addr_forms      = isa.ADDR_BASE | isa.ADDR_BASE_DISP | isa.ADDR_BASE_INDEX | isa.ADDR_BASE_INDEX_DISP | isa.ADDR_PCREL;
+    x64_model.addr_scales     = 0xF;
+    x64_model.addr_disp_bits  = 32;
+
+    x64_model.stack_grows_down  = true;
+    x64_model.fp_relative_frame = true;
+    x64_model.incoming_arg_base = 16;
+    x64_model.stack_align       = 0;
+    x64_model.red_zone          = 0;
+    x64_model.shadow_space      = 0;
+
+    x64_vtable.model = ?x64_model;
 
     isa.register(reg, ?x64_vtable);
 

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -24,6 +24,10 @@ use mach.lang.target.os;
 # arch:    borrowed instruction-set vtable
 # abi:     borrowed calling-convention vtable
 # of:      borrowed object-format vtable
+# model:   the pure machine description the shared backend stages read, assembled
+#          by `target.select` from the isa's model template overlaid with the abi's
+#          stack scalars; held by value because those scalars vary by abi, so a
+#          shared per-arch template cannot bake them in
 pub rec Target {
     os_id:   u32;
     arch_id: u32;
@@ -33,4 +37,5 @@ pub rec Target {
     arch:    *isa.IsaVTable;
     abi:     *abi.AbiVTable;
     of:      *of.OfVTable;
+    model:   isa.MachineModel;
 }


### PR DESCRIPTION
Part of #1600 (Group B: the machine model as data). Defines and populates the keystone `MachineModel` record; nothing reads it yet, so this PR is purely additive and zero-behavior-change.

## Enums (def Kind + named-val idiom)

- `Endian` (`ENDIAN_LITTLE` / `ENDIAN_BIG`) - the existing `ENDIAN_*` vals are retyped from a bare `u32` onto a `def Endian: u8`. No other reader exists (only the `target.*` re-exports), so the retyping is transparent.
- `RegClassKind` (`RC_GENERAL` / `RC_FLOAT` / `RC_VECTOR` / `RC_FLAGS`) - added to `RegClass`, so stages find the GP / float bank by role rather than the allocator's magic ">= 128-bit width" scan.
- `AddrForm` flag set (`ADDR_BASE` / `_BASE_DISP` / `_BASE_INDEX` / `_BASE_INDEX_DISP` / `_ABSOLUTE` / `_PCREL`).

`RegClass` also gains `kind: RegClassKind` and renames `count` -> `len` (house len-over-count rule). The one reader (`regalloc.bank_count`) and the x64/arm64 class fills are updated.

## The record

`MachineModel` carries, in groups: widths in bytes + byte order (`pointer_width`, `gpr_width`, `index_width`, `spill_width`, `endianness`); the register file (`reg_classes`/`reg_class_len`, `frame_ptr_reg`, `stack_ptr_reg`, scratch + reserved sets, `div_reg`/`div_hi_reg`/`shift_count_reg`); the addressing capability (`addr_forms`, `addr_scales`, `addr_disp_bits`); the frame/stack model (`stack_grows_down`, `fp_relative_frame`, `incoming_arg_base`, `stack_align`/`red_zone`/`shadow_space`).

## Population mechanism (chosen)

Each per-arch `register.mach` builds a process-global `MachineModel` **template** (everything except the abi stack scalars, which it leaves 0). `IsaVTable` gains one `model: *MachineModel` link to its template. `target.select` copies the template **by value** into `resolved.Target.model` and overlays the selected abi's `stack_align` / `red_zone` / `shadow_space`.

By-value (not `*MachineModel`) is required for correctness: the stack scalars vary by convention (sysv: align 16 / red_zone 128 / shadow 0 vs win64: align 16 / red_zone 0 / shadow 32), so a single shared per-arch global cannot bake them in. Copy-then-overlay keeps each resolved target self-consistent and introduces no `arch_id` branch in `select`.

This keeps `target/` pure (the model is DATA) and avoids growing `select` with per-arch knowledge: it reaches each arch's model only through the vtable pointer.

## Populated values (equal to today's reality)

Both arches: `pointer_width`/`gpr_width`/`index_width`/`spill_width` = 8 bytes; `endianness` = `ENDIAN_LITTLE`; 3 reg classes (gpr=general, xmm/vector=float, flags=flags); special registers, reserved/reload-scratch sets, `incoming_arg_base` = 16, and div/shift regs copied from the existing IsaVTable scalars (x64 RAX/RDX/RCX, arm64 all -1); `stack_grows_down` = true; `fp_relative_frame` = true; `addr_scales` = `0xF` (scales 1|2|4|8); `addr_disp_bits` = 32.

### Values derived from code (noted per the task)

- **`addr_forms`** = `ADDR_BASE | ADDR_BASE_DISP | ADDR_BASE_INDEX | ADDR_BASE_INDEX_DISP | ADDR_PCREL`. The shared MIR folds `[base + index*scale + disp]` (all four base/disp/index combos, `lower.mach`) and lowers symbol bases to rip-relative references (`fold_gep_mem`, the `[rip+sym+off]` form) -> PCREL is used. It never forms a bare `[disp]` absolute memory operand: a constant-address base is materialized into a register first, so **`ADDR_ABSOLUTE` is excluded**.
- **`addr_scales` = 0xF** from `is_sib_scale` (`lower.mach`), which legalizes exactly 1/2/4/8.
- **`addr_disp_bits` = 32** from the shared MIR/`isa.Operand.disp` being a signed 32-bit field.
- **`scratch_regs`/`scratch_len`** map to the existing `reload_scratch_regs`/`reload_scratch_count` pool (the only `*Register` scratch array). The encoder's scalar `scratch_reg`/`scratch_reg2`/`fp_scratch_reg` are not in the spec's record and stay on the vtable; carrying them is a later concern under #1600.

## Constants

`WORD_WIDTH` (`mir.mach`) and `SPILL_MOV_WIDTH` (`regalloc.mach`) are left in place and only get a doc note that they migrate to `MachineModel.gpr_width` / `.spill_width` when the stages are rewired (the rewiring is a separate issue under #1600).

## Gate

`mach build .` exit 0; `mach test .` = 606 passed, 0 failed, 606 total (clean rebuild). x64 and arm64 both green.

Closes #1602. Part of #1600.

