### PR TITLE
refactor: regalloc reads the machine model (spill width, float bank by role)

### DIFF
--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -35,8 +35,9 @@
 #      argument - when choosing a reload temporary. After this pass no value vreg
 #      remains in any MEM base.
 #
-# Everything target-specific flows through `tgt`: the register-class bank widths
-# from `tgt.arch.reg_classes`, the callee-saved register file from `tgt.abi`, the
+# Everything target-specific flows through `tgt`: the register-class banks and the
+# spill width from the machine model (`tgt.model.reg_classes` / `spill_width`), the
+# callee-saved register file from `tgt.abi`, the
 # never-allocatable reserved registers (stack / frame pointers) from
 # `tgt.arch.reserved_regs`, and the division / shift registers the ISA's division
 # and variable-shift forms hard-wire from `tgt.arch.div_reg` / `div_hi_reg` /
@@ -68,16 +69,6 @@ use mach.lang.target.os;
 # index of the general-purpose register bank in `reg_classes`.
 # `lower_ir` assigns this class to every non-float vreg.
 pub val REG_CLASS_GP: u32 = 0;
-
-# the floating-point / vector register bank is identified by a register width in
-# bits at least this wide, matching `mir.lower_ir`'s `fp_class_index`.
-val FP_CLASS_MIN_BITS: u32 = 128;
-
-# the byte width of a spill reload / store MOV. a spill slot is
-# sized to a full register, so the value is saved and restored at the machine-word
-# width regardless of its logical sub-register width. migrates to
-# `target.MachineModel.spill_width` when the stages are rewired (issue #1600).
-val SPILL_MOV_WIDTH: u8 = 8;
 
 # sentinel "no live range"; never a valid range index
 val RANGE_NIL: u32 = 0xFFFFFFFF;
@@ -136,6 +127,12 @@ rec BlockSpan {
 # ranges:               one live range per vreg, indexed by vreg id (vreg == slot)
 # gp_count:             number of general-purpose registers in the bank
 # fp_count:             number of floating-point registers in the bank
+# spill_width:          byte width of a spill reload / store MOV, read once from the
+#                       machine model (`tgt.model.spill_width`) at init. a spill slot
+#                       holds a full register, so a value is saved and restored at this
+#                       width regardless of its logical sub-register width. cached here
+#                       because the splice sites (emit_reload / emit_store) hold only
+#                       the context, not the target
 # callee_saved:         per-GP-register flag: is this register callee-saved
 # fp_callee_saved:      per-FP-register flag: is this XMM register callee-saved. the
 #                       FP-bank twin of callee_saved; win64 preserves XMM6-15, SysV
@@ -199,6 +196,7 @@ rec AllocCtx {
     ranges:               *LiveRange;
     gp_count:             u32;
     fp_count:             u32;
+    spill_width:          u8;
     callee_saved:         *bool;
     fp_callee_saved:      *bool;
     reserved:             *bool;
@@ -288,25 +286,25 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# index of the float/vector register bank, identified by its wide
-# register width, matching `mir.lower_ir`. a target with no wide bank cannot hold
-# a float, so a missing bank is a target-configuration bug and fails loudly rather
-# than collapsing a float class into the GP bank.
+# index of the float / vector register bank, found by its RC_FLOAT
+# role over the machine model's register classes - the same bank `lower_ir` assigns
+# every float vreg. a target that declares no RC_FLOAT class simply has no float
+# bank, so the result is RANGE_NIL, which `bank_count` reports as a zero-register
+# bank rather than panicking.
 fun fp_class_index(tgt: *target.Target) u32 {
     var ci: u32 = 0;
-    for (ci < tgt.arch.reg_class_count) {
-        if (tgt.arch.reg_classes[ci].bit_width >= FP_CLASS_MIN_BITS) { ret ci; }
+    for (ci < tgt.model.reg_class_len) {
+        if (tgt.model.reg_classes[ci].kind == isa.RC_FLOAT) { ret ci; }
         ci = ci + 1;
     }
-    panic("regalloc: target has no float/vector register bank\n");
-    ret REG_CLASS_GP;
+    ret RANGE_NIL;
 }
 
 # number of registers in a register-class bank, 0 for an out-of-range
 # class index.
 fun bank_count(tgt: *target.Target, class: u32) u32 {
-    if (class >= tgt.arch.reg_class_count) { ret 0; }
-    ret tgt.arch.reg_classes[class].len;
+    if (class >= tgt.model.reg_class_len) { ret 0; }
+    ret tgt.model.reg_classes[class].len;
 }
 
 # assign physical registers (or spill slots) to one function and
@@ -417,6 +415,7 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
     ctx.ranges       = nil;
     ctx.gp_count     = bank_count(tgt, REG_CLASS_GP);
     ctx.fp_count     = bank_count(tgt, fp_class_index(tgt));
+    ctx.spill_width  = tgt.model.spill_width::u8;
     ctx.callee_saved = nil;
     ctx.fp_callee_saved = nil;
     ctx.reserved     = nil;
@@ -2698,8 +2697,8 @@ fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32) 
     dst[@wp].operands      = ops;
     dst[@wp].operand_count = 2;
     # a spill slot holds a full register; reload it at the machine-word width.
-    dst[@wp].width         = SPILL_MOV_WIDTH;
-    dst[@wp].src_width     = SPILL_MOV_WIDTH;
+    dst[@wp].width         = ctx.spill_width;
+    dst[@wp].src_width     = ctx.spill_width;
     @wp = @wp + 1;
     ret R.ok[bool, str](true);
 }
@@ -2717,8 +2716,8 @@ fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32) R
     dst[@wp].operands      = ops;
     dst[@wp].operand_count = 2;
     # a spill slot holds a full register; store it at the machine-word width.
-    dst[@wp].width         = SPILL_MOV_WIDTH;
-    dst[@wp].src_width     = SPILL_MOV_WIDTH;
+    dst[@wp].width         = ctx.spill_width;
+    dst[@wp].src_width     = ctx.spill_width;
     @wp = @wp + 1;
     ret R.ok[bool, str](true);
 }


### PR DESCRIPTION
Rewires the register allocator to read the resolved target's `MachineModel` (issue #1602, merged) instead of a hardcoded constant and a magic register-width scan. Scope is `src/lang/be/codegen/regalloc.mach` only.

## What changed
- **Spill width:** the spill / reload MOV width now comes from `tgt.model.spill_width` instead of the local `SPILL_MOV_WIDTH = 8`. The two splice sites (`emit_reload` / `emit_store`) receive only the `AllocCtx`, so the width is read once at `ctx_init` into a new `AllocCtx.spill_width` field, mirroring how `gp_count` / `fp_count` already cache model-derived bank scalars. `SPILL_MOV_WIDTH` is deleted (regalloc was its only reader).
- **Float bank by role:** `fp_class_index` finds the float bank by `kind == RC_FLOAT` over `tgt.model.reg_classes[0 .. reg_class_len]` instead of scanning for `bit_width >= 128` and panicking. A target that declares no `RC_FLOAT` class simply has no float bank (returns `RANGE_NIL`, which `bank_count` reports as a zero-register bank) rather than panicking. `FP_CLASS_MIN_BITS` is deleted (now unused).
- **Class reads:** `bank_count` routes its class reads to `tgt.model.reg_classes` / `tgt.model.reg_class_len`.

## Zero behavior change
The model's `reg_classes` is the same array the `IsaVTable` holds and `reg_class_len == reg_class_count`, and every model value equals today's constant. For x64 and arm64 the float bank is `RC_FLOAT` at index 1 with `bit_width == 128`, so the old `>= 128` scan and the new role scan resolve to the same index. The fp-bank-by-role change is exactly equivalent to the old scan for every built target; the only divergence is the "no float bank" path (panic -> RANGE_NIL/0), which no real target reaches.

## Gate
- `mach build .` exit 0
- `mach test .` -> 606 passed, 0 failed, 606 total

Part of #1600.