### PR TITLE
refactor: mir lowering reads the machine model (word width, arg base, register classes)

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -245,12 +245,6 @@ pub val REG_CLASS_GP: u32 = 0;
 # minimum register width in bits that identifies the float/vector bank
 pub val FP_CLASS_MIN_BITS: u32 = 128;
 
-# canonical machine-word width in bytes for address-sized and pointer-sized
-# operations (LEA address forms, ABI register moves, the call/branch pseudos).
-# the encoder also treats a `width` of 0 as this width. migrates to
-# `target.MachineModel.gpr_width` when the stages are rewired (issue #1600).
-pub val WORD_WIDTH: u8 = 8;
-
 # the minimum byte width an integer ALU / shift result is computed at. a register
 # that holds a value narrower than this is still saved and reloaded at the full
 # machine-word width, so a sub-word ALU op (which leaves the upper register bits

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1084,9 +1084,10 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[bool, s
 fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, pv: u32, size: u64,
                     stack_off: i64, is_aggr: bool) R.Result[bool, str] {
     # incoming stack parameters are addressed off the ISA's frame pointer at the
-    # arch's incoming-argument base (`[fp + incoming_arg_base + off]`), both named
-    # through the ISA vtable rather than bare literals.
-    val arg_base: i64 = ctx.tgt.arch.incoming_arg_base;
+    # machine model's incoming-argument base (`[fp + incoming_arg_base + off]`): the
+    # frame-pointer register is named through the ISA vtable and the base offset
+    # through `tgt.model`, never bare literals.
+    val arg_base: i64 = ctx.tgt.model.incoming_arg_base;
     if (slot.class == abi.CLASS_HFA) {
         # spill each incoming V member into a slot keyed on `pv` so `pv` is the
         # aggregate's storage pointer for downstream uses (the FP twin of the

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -767,8 +767,8 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     cmi.operands      = callops;
     cmi.operand_count = 1;
     # the call selects to an address-sized CALL; its operand carries no value width.
-    cmi.width         = mir.WORD_WIDTH;
-    cmi.src_width     = mir.WORD_WIDTH;
+    cmi.width         = ctx.tgt.model.gpr_width::u8;
+    cmi.src_width     = ctx.tgt.model.gpr_width::u8;
     val pc: R.Result[bool, str] = context.push_instr(ctx, mb, cmi);
     if (R.is_err[bool, str](pc)) { ret pc; }
 
@@ -790,8 +790,8 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         rmi.operands      = resops;
         rmi.operand_count = 1;
         # a pure liveness marker; it emits no bytes, so its width is unobserved.
-        rmi.width         = mir.WORD_WIDTH;
-        rmi.src_width     = mir.WORD_WIDTH;
+        rmi.width         = ctx.tgt.model.gpr_width::u8;
+        rmi.src_width     = ctx.tgt.model.gpr_width::u8;
         val pr: R.Result[bool, str] = context.push_instr(ctx, mb, rmi);
         if (R.is_err[bool, str](pr)) { ret pr; }
     }
@@ -1260,8 +1260,8 @@ fun emit_bare_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[bool, str]
     mi.opcode        = mir.MIR_RET;
     mi.operands      = nil;
     mi.operand_count = 0;
-    mi.width         = mir.WORD_WIDTH;
-    mi.src_width     = mir.WORD_WIDTH;
+    mi.width         = ctx.tgt.model.gpr_width::u8;
+    mi.src_width     = ctx.tgt.model.gpr_width::u8;
     ret context.push_instr(ctx, mb, mi);
 }
 

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -257,7 +257,7 @@ pub fun fn_return_type(ctx: *LowerCtx) ir_type.IrTypeId {
 # ret: the alignment in bytes
 pub fun ret_align(ctx: *LowerCtx, ty: ir_type.IrTypeId) u32 {
     val align: u32 = ir_type.byte_align(ctx.types, ty, ctx.tgt);
-    if (align == 0) { ret mir.WORD_WIDTH::u32; }
+    if (align == 0) { ret ctx.tgt.model.gpr_width; }
     ret align;
 }
 
@@ -279,7 +279,7 @@ pub fun op_width_of(ctx: *LowerCtx, ty: ir_type.IrTypeId) u8 {
     if (sz == 1) { ret 1; }
     if (sz == 2) { ret 2; }
     if (sz == 4) { ret 4; }
-    ret mir.WORD_WIDTH;
+    ret ctx.tgt.model.gpr_width::u8;
 }
 
 # raise a sub-`mir.ALU_MIN_WIDTH` integer ALU operation width up to
@@ -466,7 +466,7 @@ pub fun grow_instr(ctx: *LowerCtx, mb: *mir.MirBlock) R.Result[bool, str] {
 # src: source operand
 # ret: true on success, or an allocation error
 pub fun emit_mov(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand) R.Result[bool, str] {
-    ret inst2(ctx, mb, mir.MIR_MOV, dst, src, mir.WORD_WIDTH, mir.WORD_WIDTH);
+    ret inst2(ctx, mb, mir.MIR_MOV, dst, src, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
 # append a `mir.MIR_MOV (dst) <- (src)` driven at an explicit operation width
@@ -523,7 +523,7 @@ pub fun emit_fmov(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: m
 # src: the stored value operand
 # ret: true on success, or an allocation error
 pub fun emit_store_to(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, src: mir.MirOperand) R.Result[bool, str] {
-    ret inst2(ctx, mb, mir.MIR_STORE, mem, src, mir.WORD_WIDTH, mir.WORD_WIDTH);
+    ret inst2(ctx, mb, mir.MIR_STORE, mem, src, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
 # append a `mir.MIR_STORE (mem) <- (src)` at an explicit `width` (vs
@@ -587,7 +587,7 @@ pub fun push_store_chunk(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand,
 # b:   right operand
 # ret: true on success, or an allocation error
 pub fun emit_bin(ctx: *LowerCtx, mb: *mir.MirBlock, op: mir.MirOpcode, dst: u32, a: mir.MirOperand, b: mir.MirOperand) R.Result[bool, str] {
-    ret inst3(ctx, mb, op, mir.op_vreg(dst), a, b, mir.WORD_WIDTH, mir.WORD_WIDTH);
+    ret inst3(ctx, mb, op, mir.op_vreg(dst), a, b, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
 # emit a three-address ALU op `MIR_<op> (out) <- (a) , (b)` at `width`, returning
@@ -693,7 +693,7 @@ pub fun emit_not_to(ctx: *LowerCtx, mb: *mir.MirBlock, src: mir.MirOperand, widt
 # disp:      the displacement from the base
 # ret:       true on success, or an allocation error
 pub fun emit_lea_preg(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, base_preg: u32, disp: i64) R.Result[bool, str] {
-    ret inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(dst), mir.op_mem_preg(base_preg, disp), mir.WORD_WIDTH, mir.WORD_WIDTH);
+    ret inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(dst), mir.op_mem_preg(base_preg, disp), ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
 # materialize a frame-slot-relative address `[slot + disp]` into a fresh value
@@ -712,7 +712,7 @@ pub fun emit_lea_slot(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, ou
     if (R.is_err[u32, str](res_vreg)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_vreg)); }
     val v: u32 = R.unwrap_ok[u32, str](res_vreg);
 
-    val res_emit: R.Result[bool, str] = inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(v), mem, mir.WORD_WIDTH, mir.WORD_WIDTH);
+    val res_emit: R.Result[bool, str] = inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(v), mem, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
     if (R.is_err[bool, str](res_emit)) { ret res_emit; }
     @out = v;
     ret R.ok[bool, str](true);
@@ -743,7 +743,7 @@ pub fun addr_to_vreg(ctx: *LowerCtx, mb: *mir.MirBlock, argop: mir.MirOperand, o
     val v: u32 = R.unwrap_ok[u32, str](res_vreg);
 
     # the address materialization selects to a pointer-sized LEA.
-    val res_emit: R.Result[bool, str] = inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(v), argop, mir.WORD_WIDTH, mir.WORD_WIDTH);
+    val res_emit: R.Result[bool, str] = inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(v), argop, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
     if (R.is_err[bool, str](res_emit)) { ret res_emit; }
     @out_vreg = v;
     ret R.ok[bool, str](true);
@@ -863,7 +863,7 @@ pub fun alloc_result_storage(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, size: 
     if (R.is_err[bool, str](res_slot)) { ret res_slot; }
 
     # the address materialization selects to a pointer-sized LEA.
-    ret inst2(ctx, mb, mir.MIR_ALLOCA, mir.op_vreg(dst), mir.op_mem_slot(sk, 0), mir.WORD_WIDTH, mir.WORD_WIDTH);
+    ret inst2(ctx, mb, mir.MIR_ALLOCA, mir.op_vreg(dst), mir.op_mem_slot(sk, 0), ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
 # true when an instruction defines a usable SSA value

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -31,6 +31,7 @@ use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
 use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
+use mach.lang.target.isa;
 use target:  mach.lang.target.resolved;
 
 # per-function lowering state mapping each SSA definition to its virtual
@@ -901,11 +902,12 @@ fun param_vreg(ctx: *LowerCtx, ix: u32) u32 {
 # select the register-class index for an IR value type
 #
 # An IR float type maps to the float/vector bank; everything else maps to the
-# general-purpose bank. The float bank is found by its wide register width via
-# `tgt.arch.reg_classes` so no arch-specific class name or index is hardcoded.
+# general-purpose bank. Both banks are located in `tgt.model.reg_classes` - the
+# float bank by its wide register width, the general bank by its RC_GENERAL kind -
+# so no arch-specific class name or index is hardcoded.
 # ---
 # ctx: the lowering context
-# tgt: resolved target supplying the register-class table
+# tgt: resolved target supplying the machine model's register-class table
 # ty:  the IR value type to classify
 # ret: the register-class index
 fun reg_class_of(ctx: *LowerCtx, tgt: *target.Target, ty: ir_type.IrTypeId) u32 {
@@ -916,27 +918,48 @@ fun reg_class_of(ctx: *LowerCtx, tgt: *target.Target, ty: ir_type.IrTypeId) u32 
             ret fp_class_index(tgt);
         }
     }
-    ret mir.REG_CLASS_GP;
+    ret gp_class_index(tgt);
 }
 
 # the index of the float/vector register bank
 #
-# Identified as the first class whose register width is at least
-# mir.FP_CLASS_MIN_BITS. A target with no wide bank cannot hold a float value,
-# so a missing bank is a target-configuration bug and fails loudly rather than
-# misclassifying a float into the GP bank.
+# Identified in `tgt.model.reg_classes` as the first class whose register width is
+# at least mir.FP_CLASS_MIN_BITS. A target with no wide bank cannot hold a float
+# value, so a missing bank is a target-configuration bug and fails loudly rather
+# than misclassifying a float into the GP bank.
 # ---
-# tgt: resolved target supplying the register-class table
+# tgt: resolved target supplying the machine model's register-class table
 # ret: the float/vector register-class index
 fun fp_class_index(tgt: *target.Target) u32 {
     var ci: u32 = 0;
-    for (ci < tgt.arch.reg_class_count) {
-        if (tgt.arch.reg_classes[ci].bit_width >= mir.FP_CLASS_MIN_BITS) {
+    for (ci < tgt.model.reg_class_len) {
+        if (tgt.model.reg_classes[ci].bit_width >= mir.FP_CLASS_MIN_BITS) {
             ret ci;
         }
         ci = ci + 1;
     }
     panic("mir.lower_ir: target has no float/vector register bank\n");
+    ret mir.REG_CLASS_GP;
+}
+
+# the index of the general-purpose register bank
+#
+# Located in `tgt.model.reg_classes` by its RC_GENERAL kind rather than a magic
+# index, so the canonical general-purpose class is read from the machine model.
+# A target that declares no general-purpose bank is a target-configuration bug and
+# fails loudly.
+# ---
+# tgt: resolved target supplying the machine model's register-class table
+# ret: the general-purpose register-class index
+fun gp_class_index(tgt: *target.Target) u32 {
+    var ci: u32 = 0;
+    for (ci < tgt.model.reg_class_len) {
+        if (tgt.model.reg_classes[ci].kind == isa.RC_GENERAL) {
+            ret ci;
+        }
+        ci = ci + 1;
+    }
+    panic("mir.lower_ir: target has no general-purpose register bank\n");
     ret mir.REG_CLASS_GP;
 }
 

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -549,8 +549,8 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
     if (src.kind == mir.MIR_OP_SYM) { mi.opcode = mir.MIR_GEP; }
     mi.operands      = ops;
     mi.operand_count = 2;
-    mi.width         = mir.WORD_WIDTH;
-    mi.src_width     = mir.WORD_WIDTH;
+    mi.width         = ctx.tgt.model.gpr_width::u8;
+    mi.src_width     = ctx.tgt.model.gpr_width::u8;
     # this splice bypasses lctx.push_instr, so enforce the asm_block invariant here:
     # struct locals are not zero-initialized, and regalloc.flatten reads a non-nil
     # asm_block as an inline-asm clobber barrier.
@@ -667,8 +667,8 @@ fun split_critical_edge(ctx: *lctx.LowerCtx, pred: *mir.MirBlock, succ_id: u32) 
     br.opcode        = mir.MIR_BR;
     br.operands      = bops;
     br.operand_count = 1;
-    br.width         = mir.WORD_WIDTH;
-    br.src_width     = mir.WORD_WIDTH;
+    br.width         = ctx.tgt.model.gpr_width::u8;
+    br.src_width     = ctx.tgt.model.gpr_width::u8;
     # this splice bypasses lctx.push_instr, so enforce the asm_block invariant here:
     # struct locals are not zero-initialized, and regalloc.flatten reads a non-nil
     # asm_block as an inline-asm clobber barrier.
@@ -1398,7 +1398,7 @@ fun set_generic_widths(ctx: *lctx.LowerCtx, inst: *instr.Instruction, mi: *mir.M
         mi.src_width = w;
         ret;
     }
-    var dw: u8 = mir.WORD_WIDTH;
+    var dw: u8 = ctx.tgt.model.gpr_width::u8;
     if (!instr.is_terminator(inst.kind)) { dw = lctx.op_width_of(ctx, inst.ty); }
     # a register-writing integer ALU result must be defined across the full width
     # it is later spilled / reloaded at, or a sub-word op's undefined upper bits
@@ -1710,8 +1710,8 @@ fun lower_alloca(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructio
     mi.operands      = ops;
     mi.operand_count = 2;
     # the alloca selects to a LEA computing a pointer-sized address.
-    mi.width         = mir.WORD_WIDTH;
-    mi.src_width     = mir.WORD_WIDTH;
+    mi.width         = ctx.tgt.model.gpr_width::u8;
+    mi.src_width     = ctx.tgt.model.gpr_width::u8;
     ret lctx.push_instr(ctx, mb, mi);
 }
 
@@ -2073,8 +2073,8 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     mi.operands      = ops;
     mi.operand_count = 2;
     # the GEP selects to a LEA computing a pointer-sized effective address.
-    mi.width         = mir.WORD_WIDTH;
-    mi.src_width     = mir.WORD_WIDTH;
+    mi.width         = ctx.tgt.model.gpr_width::u8;
+    mi.src_width     = ctx.tgt.model.gpr_width::u8;
     ret lctx.push_instr(ctx, mb, mi);
 }
 


### PR DESCRIPTION
Rewire the MIR lowering to read the resolved target's `MachineModel` (issue #1602, merged) instead of the hardcoded `WORD_WIDTH` constant, the per-arch `incoming_arg_base` from the ISA vtable, and the hardcoded canonical GP register-class index.

This is a zero-behavior-change rewire: every model value equals today's constant/data, so reading the model is byte-identical (`gpr_width = 8`, `incoming_arg_base = 16`, and the model's `reg_classes` is the same array the vtable held).

## Changes
- `incoming_arg_base`: `mir/abi.mach` reads `tgt.model.incoming_arg_base`.
- `WORD_WIDTH`: every read across `mir/context.mach`, `mir/lower.mach`, `mir/abi.mach` reads `tgt.model.gpr_width`; the now-unused `WORD_WIDTH` val is deleted from `mir.mach`.
- register classes: `fp_class_index` reads the bank table from `tgt.model.reg_classes` / `reg_class_len`; a new model-derived `gp_class_index` finds the GP bank by `kind == RC_GENERAL`, and `reg_class_of` selects both banks from the model.

Scope: only `mir.mach`, `mir/abi.mach`, `mir/context.mach`, `mir/lower.mach`. `regalloc.mach` is untouched (separate concurrent PR).

Part of #1600.