### PR TITLE
refactor: the ISA declares its ELF e_machine (drop the arch_id branch)

### DIFF
--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -329,6 +329,9 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 # ---
 # id:                   architecture id (one of ARCH_*)
 # name:                 interned architecture name ("x86_64", "aarch64")
+# elf_machine:          the ELF `e_machine` machine type for this arch (an EM_*
+#                       value); the object-format writer reads it to stamp ELF
+#                       headers instead of branching on the arch id
 # pointer_width:        pointer width in bytes
 # reg_classes:          array of register classes
 # reg_class_count:      number of register classes
@@ -391,6 +394,7 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 pub rec IsaVTable {
     id:                   u32;
     name:                 str;
+    elf_machine:          u32;
     pointer_width:        u32;
     reg_classes:          *RegClass;
     reg_class_count:      u32;

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -113,6 +113,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
 
     arm64_vtable.id                   = isa.ARCH_AARCH64;
     arm64_vtable.name                 = "aarch64";
+    arm64_vtable.elf_machine          = 183;  # EM_AARCH64
     arm64_vtable.pointer_width        = 8;
     arm64_vtable.reg_classes          = ?arm64_classes[0];
     arm64_vtable.reg_class_count      = 3;

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -114,6 +114,7 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
 
     x64_vtable.id                   = isa.ARCH_X86_64;
     x64_vtable.name                 = "x86_64";
+    x64_vtable.elf_machine          = 62;  # EM_X86_64
     x64_vtable.pointer_width        = 8;
     x64_vtable.reg_classes          = ?x64_classes[0];
     x64_vtable.reg_class_count      = 3;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -50,10 +50,6 @@ val ELFOSABI_NONE: u8 = 0;
 val ET_REL:  u16 = 1;
 val ET_EXEC: u16 = 2;
 
-# ELF machine types.
-val EM_X86_64:  u16 = 62;
-val EM_AARCH64: u16 = 183;
-
 # ELF section header types.
 val SHT_PROGBITS: u32 = 1;
 val SHT_SYMTAB:   u32 = 2;
@@ -256,15 +252,6 @@ fun validate_reloc_kinds(img: *of.ObjectImage, arch_id: u32) R.Result[bool, str]
         i = i + 1;
     }
     ret R.ok[bool, str](true);
-}
-
-# the ELF machine type for an ISA id, defaulting to x86-64
-# ---
-# arch_id: the target ISA id
-# ret:     the ELF EM_* machine type
-fun machine_for(arch_id: u32) u16 {
-    if (arch_id == isa.ARCH_AARCH64) { ret EM_AARCH64; }
-    ret EM_X86_64;
 }
 
 # the ELF section type for an abstract section kind
@@ -606,7 +593,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R.Resu
     buf[7] = ELFOSABI_NONE;
 
     bin.write_u16_le(buf, 16, ET_REL);
-    bin.write_u16_le(buf, 18, machine_for(tgt_isa.id));
+    bin.write_u16_le(buf, 18, tgt_isa.elf_machine::u16);
     bin.write_u32_le(buf, 20, 1);
     bin.write_u64_le(buf, 24, 0);
     bin.write_u64_le(buf, 32, 0);
@@ -939,7 +926,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     buf[7] = ELFOSABI_NONE;
 
     bin.write_u16_le(buf, 16, ET_EXEC);
-    bin.write_u16_le(buf, 18, machine_for(tgt_isa.id));
+    bin.write_u16_le(buf, 18, tgt_isa.elf_machine::u16);
     bin.write_u32_le(buf, 20, 1);
     bin.write_u64_le(buf, 24, entry);
     bin.write_u64_le(buf, 32, phdr_offset::u64);
@@ -1182,7 +1169,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     buf[0] = 0x7F; buf[1] = 0x45; buf[2] = 0x4C; buf[3] = 0x46;
     buf[4] = ELFCLASS64; buf[5] = ELFDATA2LSB; buf[6] = EV_CURRENT; buf[7] = ELFOSABI_NONE;
     bin.write_u16_le(buf, 16, ET_EXEC);
-    bin.write_u16_le(buf, 18, machine_for(tgt_isa.id));
+    bin.write_u16_le(buf, 18, tgt_isa.elf_machine::u16);
     bin.write_u32_le(buf, 20, 1);
     bin.write_u64_le(buf, 24, entry);
     bin.write_u64_le(buf, 32, phdr_offset::u64);


### PR DESCRIPTION
The ELF writer picked the `e_machine` header field by branching on `arch_id` (`EM_X86_64` = 62, `EM_AARCH64` = 183) through a `machine_for` helper. Adding a new arch meant editing the ELF writer.

Now the ISA declares its own ELF machine type:

- `IsaVTable` gains an `elf_machine: u32` field.
- `register_x64` sets it to 62 (EM_X86_64), `register_arm64` to 183 (EM_AARCH64).
- `of/elf.mach` stamps the header from `tgt_isa.elf_machine::u16` at all three sites (`emit_object`, `emit_exec`, `emit_dyn_exec`); the now-dead `machine_for` helper and its `EM_*` constants are removed.

Zero behavior change: every target gets the same `e_machine` as before. `mach build .` is clean and `mach test .` reports 606 passed, 0 failed, 606 total.

The named `EM_*` constants in `elf.mach` were not `pub`, so the literals carry an `# EM_*` comment at the declaration sites.

Sibling formats checked, both left as-is:
- `of/macho.mach` is a stub - `emit_object`/`emit_exec` return the unsupported-format error and write no machine code, so there is no arch branch to remove.
- `of/coff.mach` is x86-64 only - it rejects any non-x86-64 ISA up front and writes the `IMAGE_FILE_MACHINE_AMD64` constant unconditionally, so it never branches on an arch identity to pick the machine code.

Part of #1600.