### PR TITLE
refactor: funnel target-registry bring-up through setup_registry

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -516,7 +516,7 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
 
     # populate the session's target registry. register_all needs no interner -
     # every vtable names itself with an immutable `str` constant. idempotent.
-    val res_register: R.Result[bool, str] = target.register_all(?s.registry);
+    val res_register: R.Result[bool, str] = driver.setup_registry(?s.registry);
     if (R.is_err[bool, str](res_register)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[bool, str](res_register));

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -336,6 +336,14 @@ val INITIAL_MODULE_CAP: u32 = 16;
 val INITIAL_PUB_CAP:    u32 = 4;
 val INITIAL_DEP_CAP:    u32 = 4;
 
+# the single registry bring-up point - target substrates now, backend hooks later.
+# ---
+# reg: the target registry to populate before any select
+# ret: register_all's Result unchanged
+pub fun setup_registry(reg: *target.TargetRegistry) R.Result[bool, str] {
+    ret target.register_all(reg);
+}
+
 # load `project_root/mach.toml`, select `target_name`, and
 # build the full module graph plus per-module ResolveResults. a convenience
 # wrapper over build_project_sel that selects only a target (no profile/artifact
@@ -4001,7 +4009,7 @@ fun ut_build(s: *session.Session, alloc: *A.Allocator, names: *str, texts: *str,
     val root_r: R.Result[str, str] = ut_scaffold(alloc, names, texts, n);
     if (R.is_err[str, str](root_r)) { ret R.err[Project, str](R.unwrap_err[str, str](root_r)); }
     val root: str = R.unwrap_ok[str, str](root_r);
-    val rr: R.Result[bool, str] = target.register_all(?s.registry);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
     if (R.is_err[bool, str](rr)) { filesystem.remove_all(alloc, root); ret R.err[Project, str](R.unwrap_err[bool, str](rr)); }
     val pr: R.Result[Project, str] = build_project_union(s, root);
     filesystem.remove_all(alloc, root);
@@ -4015,7 +4023,7 @@ fun ut_build_multi(s: *session.Session, alloc: *A.Allocator, names: *str, texts:
     val root_r: R.Result[str, str] = ut_scaffold_m(alloc, ut_manifest_multi(), names, texts, n);
     if (R.is_err[str, str](root_r)) { ret R.err[Project, str](R.unwrap_err[str, str](root_r)); }
     val root: str = R.unwrap_ok[str, str](root_r);
-    val rr: R.Result[bool, str] = target.register_all(?s.registry);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
     if (R.is_err[bool, str](rr)) { filesystem.remove_all(alloc, root); ret R.err[Project, str](R.unwrap_err[bool, str](rr)); }
     val pr: R.Result[Project, str] = build_project_union(s, root);
     filesystem.remove_all(alloc, root);
@@ -4319,7 +4327,7 @@ test "mach.lang.driver:union_malformed_condition_reported_once" {
     val root1_r: R.Result[str, str] = ut_scaffold(?a1, ?names[0], ?texts[0], 1);
     if (R.is_err[str, str](root1_r)) { session.dnit(?s1); ret 1; }
     val root1: str = R.unwrap_ok[str, str](root1_r);
-    val rr1: R.Result[bool, str] = target.register_all(?s1.registry);
+    val rr1: R.Result[bool, str] = setup_registry(?s1.registry);
     if (R.is_err[bool, str](rr1)) { filesystem.remove_all(?a1, root1); session.dnit(?s1); ret 1; }
     var sel: manifest.Selection;
     sel.target = ""; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false;
@@ -4479,7 +4487,7 @@ test "mach.lang.driver:union_ambiguous_multi_artifact_default" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
-    val rr: R.Result[bool, str] = target.register_all(?s.registry);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
     if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
 
     var names: [4]str;
@@ -4536,7 +4544,7 @@ test "mach.lang.driver:reload_rebuild_dedup_sources_by_path" {
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
 
-    val rr: R.Result[bool, str] = target.register_all(?s.registry);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
     if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
 
     var names: [2]str;
@@ -4596,7 +4604,7 @@ test "mach.lang.driver:incremental_qparse_ast_reuse_and_reparse" {
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
 
-    val rr: R.Result[bool, str] = target.register_all(?s.registry);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
     if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
 
     var names: [2]str;
@@ -4662,7 +4670,7 @@ test "mach.lang.driver:incremental_stable_identity_across_reshape" {
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
 
-    val rr: R.Result[bool, str] = target.register_all(?s.registry);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
     if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -4731,7 +4739,7 @@ test "mach.lang.driver:incremental_qexports_firewalls_body_edit" {
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
 
-    val rr: R.Result[bool, str] = target.register_all(?s.registry);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
     if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
 
     var names: [1]str;
@@ -4893,7 +4901,7 @@ test "mach.lang.driver:incremental_resolve_firewall_body_edit_equals_scratch" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
-    if (R.is_err[bool, str](target.register_all(?sA.registry))) { session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
 
     # main imports leaf.fa and calls it; leaf exports fa. editing fa's BODY is a
     # private change that - with the parser reserving fa's DeclId before its body -
@@ -4939,7 +4947,7 @@ test "mach.lang.driver:incremental_resolve_firewall_body_edit_equals_scratch" {
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr2)) { dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = R.unwrap_ok[session.Session, str](sr2);
-    if (R.is_err[bool, str](target.register_all(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: R.Result[Project, str] = build_project_union(?sB, root);
     if (R.is_err[Project, str](pBr)) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: Project = R.unwrap_ok[Project, str](pBr);
@@ -4964,7 +4972,7 @@ test "mach.lang.driver:incremental_resolve_pub_surface_change_equals_scratch" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
-    if (R.is_err[bool, str](target.register_all(?sA.registry))) { session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
 
     # main imports leaf.fa. adding a pub `fz` BEFORE fa shifts fa's DeclId (0 -> 1),
     # a change the importer's resolution genuinely depends on (resolve.Symbol.decl):
@@ -5024,7 +5032,7 @@ test "mach.lang.driver:incremental_resolve_pub_surface_change_equals_scratch" {
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr2)) { dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = R.unwrap_ok[session.Session, str](sr2);
-    if (R.is_err[bool, str](target.register_all(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: R.Result[Project, str] = build_project_union(?sB, root);
     if (R.is_err[Project, str](pBr)) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: Project = R.unwrap_ok[Project, str](pBr);
@@ -5048,7 +5056,7 @@ test "mach.lang.driver:incremental_resolve_const_value_change_equals_scratch" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
-    if (R.is_err[bool, str](target.register_all(?sA.registry))) { session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
 
     # main imports leaf.FLAG (a pub comptime bool) and forks a `$if` on it - the fork
     # gates a function declaration, so main's RESOLVED surface depends on FLAG's
@@ -5093,7 +5101,7 @@ test "mach.lang.driver:incremental_resolve_const_value_change_equals_scratch" {
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr2)) { dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = R.unwrap_ok[session.Session, str](sr2);
-    if (R.is_err[bool, str](target.register_all(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: R.Result[Project, str] = build_project_union(?sB, root);
     if (R.is_err[Project, str](pBr)) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: Project = R.unwrap_ok[Project, str](pBr);
@@ -5116,7 +5124,7 @@ test "mach.lang.driver:incremental_resolve_reexport_two_hop_propagation" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
-    if (R.is_err[bool, str](target.register_all(?sA.registry))) { session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
 
     # main -> mid (re-exports leaf.fa via `fwd`) -> leaf. a pub-surface change to
     # leaf must propagate THROUGH the re-exporter: leaf re-resolves, mid's Q_EXPORTS
@@ -5170,7 +5178,7 @@ test "mach.lang.driver:incremental_resolve_reexport_two_hop_propagation" {
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr2)) { dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = R.unwrap_ok[session.Session, str](sr2);
-    if (R.is_err[bool, str](target.register_all(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: R.Result[Project, str] = build_project_union(?sB, root);
     if (R.is_err[Project, str](pBr)) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: Project = R.unwrap_ok[Project, str](pBr);
@@ -5324,7 +5332,7 @@ test "mach.lang.driver:incremental_sema_firewall_body_edit_equals_scratch" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
-    if (R.is_err[bool, str](target.register_all(?sA.registry))) { session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
 
     # main imports leaf.fa and types its return; editing fa's BODY (not its signature)
     # leaves leaf's typed surface byte-identical, so main's type-checking is firewalled.
@@ -5371,7 +5379,7 @@ test "mach.lang.driver:incremental_sema_firewall_body_edit_equals_scratch" {
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr2)) { dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = R.unwrap_ok[session.Session, str](sr2);
-    if (R.is_err[bool, str](target.register_all(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: R.Result[Project, str] = build_project_union(?sB, root);
     if (R.is_err[Project, str](pBr)) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: Project = R.unwrap_ok[Project, str](pBr);
@@ -5397,7 +5405,7 @@ test "mach.lang.driver:incremental_sema_return_type_change_equals_scratch" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
-    if (R.is_err[bool, str](target.register_all(?sA.registry))) { session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
 
     # main binds `val x = fa()`, so x's inferred type IS fa's return type. changing
     # fa's signature i32 -> i64 genuinely changes main's typing (x: i32 -> i64): a
@@ -5440,7 +5448,7 @@ test "mach.lang.driver:incremental_sema_return_type_change_equals_scratch" {
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr2)) { dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = R.unwrap_ok[session.Session, str](sr2);
-    if (R.is_err[bool, str](target.register_all(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: R.Result[Project, str] = build_project_union(?sB, root);
     if (R.is_err[Project, str](pBr)) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: Project = R.unwrap_ok[Project, str](pBr);
@@ -5465,7 +5473,7 @@ test "mach.lang.driver:incremental_sema_field_type_change_equals_scratch" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
-    if (R.is_err[bool, str](target.register_all(?sA.registry))) { session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
 
     # main reads leaf.P's field `x`. changing P's FIELD TYPE (i32 -> i64) does NOT
     # change leaf's RESOLVED surface (resolve never types fields), so the resolve
@@ -5513,7 +5521,7 @@ test "mach.lang.driver:incremental_sema_field_type_change_equals_scratch" {
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr2)) { dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = R.unwrap_ok[session.Session, str](sr2);
-    if (R.is_err[bool, str](target.register_all(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: R.Result[Project, str] = build_project_union(?sB, root);
     if (R.is_err[Project, str](pBr)) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: Project = R.unwrap_ok[Project, str](pBr);
@@ -5537,7 +5545,7 @@ test "mach.lang.driver:incremental_sema_reshape_renumber_recheck" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
-    if (R.is_err[bool, str](target.register_all(?sA.registry))) { session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
 
     # main imports a.Q (a record) and b.fb. swapping main's use order renumbers a and
     # b's discovery-order ModuleIds - and a.Q's nominal TypeId embeds a's ModuleId, so
@@ -5590,7 +5598,7 @@ test "mach.lang.driver:incremental_sema_reshape_renumber_recheck" {
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr2)) { dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = R.unwrap_ok[session.Session, str](sr2);
-    if (R.is_err[bool, str](target.register_all(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](setup_registry(?sB.registry))) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: R.Result[Project, str] = build_project_union(?sB, root);
     if (R.is_err[Project, str](pBr)) { session.dnit(?sB); dnit_project(?pA2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: Project = R.unwrap_ok[Project, str](pBr);


### PR DESCRIPTION
Make `driver.setup_registry` the single **backend-build bring-up point** - target substrates now, future `be/`-layer registrars later - and route every caller that reaches codegen+link through it.

Funneled:
- `src/lang/driver.mach` - all 24 `target.register_all` call sites (the driver build/test paths) now call `setup_registry`.
- `src/cli/cmd/build.mach` - the real `mach build` codegen+link bring-up now calls `driver.setup_registry`, so be-hooks added later reach an actual build.

```
pub fun setup_registry(reg: *target.TargetRegistry) R.Result[bool, str]
```

The helper just returns `target.register_all`'s Result unchanged - a pure funnel today. No `be/` registrars added yet.

Intentionally **not** funneled (these keep the bare `target.register_all` primitive):
- `src/cli/cmd/doc.mach`, `src/cli/cmd/info.mach` - non-codegen commands never run the backend, so they need only the bare target primitive, not the backend-build bring-up.
- `src/lang/target.mach` - its two `register_all` calls are in-module tests in the target/ layer.
- `src/lang/be/codegen/regalloc.mach` - a be/ test that cannot import driver (layer inversion).

Zero behavior change - same registration, same order, same per-caller error handling.

Gate: `mach build .` exit 0; `mach test .` = 606 passed, 0 failed, 606 total.

Part of #1600.