### PR TITLE
refactor: the ISA owns its relocation packers via a vtable hook

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -34,6 +34,7 @@ use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_empty;
+use std.types.string.str_equals;
 use std.types.string.str_len;
 
 use A: std.allocator;
@@ -301,7 +302,7 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
         }
 
         val patch_r: R.Result[bool, str] =
-            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, ?sym_locs, ?dyn, tgt.arch_id);
+            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, ?sym_locs, ?dyn, tgt.arch);
         if (R.is_err[bool, str](patch_r)) {
             free_dynstate(alloc, ?dyn);
             obj.dnit(?out_img);
@@ -1233,13 +1234,13 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
 # sec_base:     per-module prefix offset into `placements`
 # sym_locs:     the global symbol table, for GLOBAL/extern target resolution
 # dyn:          dynamic-link state; out - collects import call-site fixups
-# arch_id:      active architecture, selecting the relocation packers
+# arch:         active instruction-set vtable, owning the relocation packer
 # ret:          ok(true) on success, or an error string
 fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
                      modules: *of.ObjectImage, module_count: u32,
                      placements: *Placement, sec_base: *u32,
                      sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                     dyn: *DynState, arch_id: u32) R.Result[bool, str] {
+                     dyn: *DynState, arch: *isa.IsaVTable) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
 
     var m: u32 = 0;
@@ -1258,7 +1259,7 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
         }
 
         val pr: R.Result[bool, str] = patch_module_relocations(s, out_img, modules, m,
-            placements, sec_base, sym_locs, dyn, ?local_map, arch_id);
+            placements, sec_base, sym_locs, dyn, ?local_map, arch);
         map.dnit[intern.StrId, u64](?local_map);
         if (R.is_err[bool, str](pr)) { ret R.err[bool, str](R.unwrap_err[bool, str](pr)); }
 
@@ -1312,13 +1313,13 @@ fun build_local_index(modules: *of.ObjectImage, m: u32, placements: *Placement, 
 # sym_locs:     the global symbol table, for GLOBAL/extern target resolution
 # dyn:          dynamic-link state; out - collects import call-site fixups
 # local_map:    module `m`'s LOCAL-name -> virtual-address index
-# arch_id:      active architecture, selecting the relocation packers
+# arch:         active instruction-set vtable, owning the relocation packer
 # ret:          ok(true) on success, or an error string
 fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                              modules: *of.ObjectImage, m: u32,
                              placements: *Placement, sec_base: *u32,
                              sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
-                             local_map: *map.Map[intern.StrId, u64], arch_id: u32) R.Result[bool, str] {
+                             local_map: *map.Map[intern.StrId, u64], arch: *isa.IsaVTable) R.Result[bool, str] {
     var ri: u32 = 0;
     for (ri < modules[m].reloc_count) {
         val r: *of.Relocation = ?modules[m].relocations[ri];
@@ -1385,7 +1386,7 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         }
 
         val pr: R.Result[bool, str] =
-            apply_one(s, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va, r.symbol, arch_id);
+            apply_one(s, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va, r.symbol, arch);
         if (R.is_err[bool, str](pr)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](pr));
         }
@@ -1674,14 +1675,16 @@ fun dynstate_add_fixup(s: *session.Session, dyn: *DynState, seg_index: u32, seg_
     ret R.ok[bool, str](true);
 }
 
-# write a single resolved relocation into the merged bytes. RK_ABS64
-# writes a 64-bit absolute and RK_PC32 a 32-bit field-relative displacement, both
-# arch-independent (R_X86_64_64/PC32 == R_AARCH64_ABS64/PREL32). The remaining
-# kinds are arch-specific: x86_64 RK_PLT32/RK_ABS32S are flat little-endian writes;
-# aarch64 routes to `apply_one_aarch64` for the A64 instruction-field packers
-# (CALL26/PAGE21/ADD_LO12/per-width LDST*_LO12). bounds and range are checked.
-# `sym_name` is the interned symbol name used in overflow diagnostics; pass
-# `intern.STR_NIL` when the name is unavailable (e.g. in tests).
+# the concrete signature the erased `isa.IsaVTable.apply_reloc` pointer is cast
+# back to before it is called
+#
+# The vtable stores `apply_reloc` type-erased (`*u8`) for the same import-cycle
+# reason as `select` / `encode`: its body lives in this be-layer linker, which
+# imports `isa`, so a typed slot on the target-layer vtable would invert the
+# dependency. Each registered arch owns its complete relocation kind-set through
+# this one hook; the mechanical packing bodies stay shared free helpers both
+# arches call. `sym_name` is the interned symbol name used in overflow
+# diagnostics; pass `intern.STR_NIL` when the name is unavailable (e.g. in tests).
 # ---
 # s:         shared session, for the overflow/unsupported diagnostics
 # kind:      the abstract relocation kind to apply
@@ -1692,54 +1695,64 @@ fun dynstate_add_fixup(s: *session.Session, dyn: *DynState, seg_index: u32, seg_
 # addend:    the relocation addend
 # patch_va:  the patch site's own virtual address
 # sym_name:  interned symbol name for the overflow diagnostic (STR_NIL if absent)
-# arch_id:   active architecture, selecting the arch-specific packers
+# ret:       ok(true) once written, or an overflow/unsupported error
+pub def ApplyRelocFn: fun(*session.Session, of.RelocKind, *u8, u32, u32, u64, i64, u64, intern.StrId) R.Result[bool, str];
+
+# write a single resolved relocation into the merged bytes,
+# dispatching to the active arch's relocation packer through its vtable hook. The
+# arch owns its complete kind-set: the shared ABS64/PC32 kinds and its own
+# arch-specific kinds all flow through `arch.apply_reloc`, so this dispatcher
+# carries no per-kind handling. A nil hook (an arch the be-layer registrar did not
+# wire) is reported as unsupported, exactly as the isel / encode dispatchers
+# report an ISA that registered no selector / encoder.
+# ---
+# s:         shared session, for the overflow/unsupported diagnostics
+# kind:      the abstract relocation kind to apply
+# dst:       the merged section bytes to patch
+# patch_off: byte offset of the patch site within `dst`
+# sec_len:   length of the section `dst` backs, for the bounds check
+# sym_va:    the target symbol's final virtual address
+# addend:    the relocation addend
+# patch_va:  the patch site's own virtual address
+# sym_name:  interned symbol name for the overflow diagnostic (STR_NIL if absent)
+# arch:      active instruction-set vtable, owning the relocation packer
 # ret:       ok(true) once written, or an overflow/unsupported error
 fun apply_one(s: *session.Session, kind: of.RelocKind,
              dst: *u8, patch_off: u32, sec_len: u32,
              sym_va: u64, addend: i64, patch_va: u64,
-             sym_name: intern.StrId, arch_id: u32) R.Result[bool, str] {
-    if (kind == of.RK_ABS64) {
-        # bound the patch site in u64: patch_off + width can wrap a u32 for an
-        # offset near 0xFFFFFFFF, which would pass a u32 check and then scribble
-        # outside the merged buffer.
-        if (patch_off::u64 + 8 > sec_len::u64) {
-            ret R.err[bool, str](overflow_message(s, kind, sym_name));
-        }
-        val value: u64 = sym_va + (addend::u64);
-        bin.write_u64_le(dst, patch_off::usize, value);
-        ret R.ok[bool, str](true);
+             sym_name: intern.StrId, arch: *isa.IsaVTable) R.Result[bool, str] {
+    if (arch.apply_reloc == nil) {
+        ret R.err[bool, str](unsupported_message(s, kind));
     }
+    ret arch.apply_reloc::ApplyRelocFn(s, kind, dst, patch_off, sec_len, sym_va, addend, patch_va, sym_name);
+}
 
-    # RK_PC32 is a flat 32-bit field-relative displacement on both arches
-    # (R_X86_64_PC32 / R_AARCH64_PREL32).
-    if (kind == of.RK_PC32) {
-        ret apply_pcrel32(s, kind, dst, patch_off, sec_len, sym_va, addend, patch_va, sym_name);
+# write a 64-bit absolute (`sym + addend`) into the merged bytes, the shared body
+# of the arch-independent RK_ABS64 (R_X86_64_64 == R_AARCH64_ABS64). the patch
+# site is bounded in u64 (a near-4GiB offset cannot wrap the u32 cursor).
+# ---
+# s:         shared session, for the overflow diagnostic
+# kind:      the relocation kind, named in the overflow diagnostic
+# dst:       the merged section bytes to patch
+# patch_off: byte offset of the patch site within `dst`
+# sec_len:   length of the section `dst` backs, for the bounds check
+# sym_va:    the target symbol's final virtual address
+# addend:    the relocation addend
+# sym_name:  interned symbol name for the overflow diagnostic (STR_NIL if absent)
+# ret:       ok(true) once written, or an overflow error
+fun apply_abs64(s: *session.Session, kind: of.RelocKind,
+                dst: *u8, patch_off: u32, sec_len: u32,
+                sym_va: u64, addend: i64,
+                sym_name: intern.StrId) R.Result[bool, str] {
+    # bound the patch site in u64: patch_off + width can wrap a u32 for an offset
+    # near 0xFFFFFFFF, which would pass a u32 check and then scribble outside the
+    # merged buffer.
+    if (patch_off::u64 + 8 > sec_len::u64) {
+        ret R.err[bool, str](overflow_message(s, kind, sym_name));
     }
-
-    # aarch64 instruction-field relocations are bit-packed read-modify-write.
-    if (arch_id == isa.ARCH_AARCH64) {
-        ret apply_one_aarch64(s, kind, dst, patch_off, sec_len, sym_va, addend, patch_va, sym_name);
-    }
-
-    # x86_64 RK_PLT32: a flat 32-bit pc-relative displacement, identical to PC32.
-    if (kind == of.RK_PLT32) {
-        ret apply_pcrel32(s, kind, dst, patch_off, sec_len, sym_va, addend, patch_va, sym_name);
-    }
-
-    # x86_64 RK_ABS32S: 32-bit signed absolute.
-    if (kind == of.RK_ABS32S) {
-        if (patch_off::u64 + 4 > sec_len::u64) {
-            ret R.err[bool, str](overflow_message(s, kind, sym_name));
-        }
-        val v: i64 = (sym_va::i64) + addend;
-        if (v > 2147483647 || v < -2147483648) {
-            ret R.err[bool, str](overflow_message(s, kind, sym_name));
-        }
-        bin.write_u32_le(dst, patch_off::usize, ((v::u64) & 0xFFFFFFFF)::u32);
-        ret R.ok[bool, str](true);
-    }
-
-    ret R.err[bool, str](unsupported_message(s, kind));
+    val value: u64 = sym_va + (addend::u64);
+    bin.write_u64_le(dst, patch_off::usize, value);
+    ret R.ok[bool, str](true);
 }
 
 # write a flat 32-bit pc-relative displacement (`sym + addend - patch_va`) into the
@@ -1772,15 +1785,69 @@ fun apply_pcrel32(s: *session.Session, kind: of.RelocKind,
     ret R.ok[bool, str](true);
 }
 
-# patch an aarch64 instruction-field relocation. Each kind is a
-# read-modify-write of the 4-byte little-endian instruction word at the patch site:
-# the immediate is computed, range/alignment checked where the field is bounded, and
-# inserted into the instruction's bitfield without disturbing the opcode bits. The
-# LO12 access-size scale is carried by the reloc KIND (Option B), so the access
-# width is never recovered by decoding the instruction word.
+# apply one x86_64 relocation, the packer the be-layer registrar
+# wires onto the x86_64 vtable. The x86_64 kinds are all flat little-endian
+# writes: RK_ABS64 a 64-bit absolute, RK_PC32 / RK_PLT32 32-bit pc-relative
+# displacements, and RK_ABS32S a range-checked 32-bit signed absolute. an unknown
+# kind is reported as unsupported.
 # ---
 # s:         shared session, for the overflow/unsupported diagnostics
-# kind:      the A64 relocation kind to apply
+# kind:      the relocation kind to apply
+# dst:       the merged section bytes to patch
+# patch_off: byte offset of the patch site within `dst`
+# sec_len:   length of the section `dst` backs, for the bounds check
+# sym_va:    the target symbol's final virtual address
+# addend:    the relocation addend
+# patch_va:  the patch site's own virtual address
+# sym_name:  interned symbol name for the overflow diagnostic (STR_NIL if absent)
+# ret:       ok(true) once written, or an overflow/unsupported error
+fun x64_apply_reloc(s: *session.Session, kind: of.RelocKind,
+                    dst: *u8, patch_off: u32, sec_len: u32,
+                    sym_va: u64, addend: i64, patch_va: u64,
+                    sym_name: intern.StrId) R.Result[bool, str] {
+    # RK_ABS64: a 64-bit absolute (R_X86_64_64).
+    if (kind == of.RK_ABS64) {
+        ret apply_abs64(s, kind, dst, patch_off, sec_len, sym_va, addend, sym_name);
+    }
+
+    # RK_PC32: a flat 32-bit field-relative displacement (R_X86_64_PC32).
+    if (kind == of.RK_PC32) {
+        ret apply_pcrel32(s, kind, dst, patch_off, sec_len, sym_va, addend, patch_va, sym_name);
+    }
+
+    # RK_PLT32: a flat 32-bit pc-relative displacement, identical to PC32.
+    if (kind == of.RK_PLT32) {
+        ret apply_pcrel32(s, kind, dst, patch_off, sec_len, sym_va, addend, patch_va, sym_name);
+    }
+
+    # RK_ABS32S: 32-bit signed absolute.
+    if (kind == of.RK_ABS32S) {
+        if (patch_off::u64 + 4 > sec_len::u64) {
+            ret R.err[bool, str](overflow_message(s, kind, sym_name));
+        }
+        val v: i64 = (sym_va::i64) + addend;
+        if (v > 2147483647 || v < -2147483648) {
+            ret R.err[bool, str](overflow_message(s, kind, sym_name));
+        }
+        bin.write_u32_le(dst, patch_off::usize, ((v::u64) & 0xFFFFFFFF)::u32);
+        ret R.ok[bool, str](true);
+    }
+
+    ret R.err[bool, str](unsupported_message(s, kind));
+}
+
+# apply one aarch64 relocation, the packer the be-layer registrar
+# wires onto the aarch64 vtable. The shared RK_ABS64 / RK_PC32 kinds
+# (R_AARCH64_ABS64 / PREL32) are flat writes; every other kind is an A64
+# instruction-field relocation, a read-modify-write of the 4-byte little-endian
+# instruction word at the patch site: the immediate is computed, range/alignment
+# checked where the field is bounded, and inserted into the instruction's bitfield
+# without disturbing the opcode bits. The LO12 access-size scale is carried by the
+# reloc KIND (Option B), so the access width is never recovered by decoding the
+# instruction word.
+# ---
+# s:         shared session, for the overflow/unsupported diagnostics
+# kind:      the relocation kind to apply
 # dst:       the merged section bytes to patch
 # patch_off: byte offset of the instruction word within `dst`
 # sec_len:   length of the section `dst` backs, for the bounds check
@@ -1789,10 +1856,18 @@ fun apply_pcrel32(s: *session.Session, kind: of.RelocKind,
 # patch_va:  the patch site's own virtual address
 # sym_name:  interned symbol name for the overflow diagnostic (STR_NIL if absent)
 # ret:       ok(true) once written, or an overflow/unsupported error
-fun apply_one_aarch64(s: *session.Session, kind: of.RelocKind,
+fun arm64_apply_reloc(s: *session.Session, kind: of.RelocKind,
                      dst: *u8, patch_off: u32, sec_len: u32,
                      sym_va: u64, addend: i64, patch_va: u64,
                      sym_name: intern.StrId) R.Result[bool, str] {
+    # the shared kinds are flat writes, not A64 instruction-field packers.
+    if (kind == of.RK_ABS64) {
+        ret apply_abs64(s, kind, dst, patch_off, sec_len, sym_va, addend, sym_name);
+    }
+    if (kind == of.RK_PC32) {
+        ret apply_pcrel32(s, kind, dst, patch_off, sec_len, sym_va, addend, patch_va, sym_name);
+    }
+
     # every A64 relocation patches a single 32-bit instruction word.
     if (patch_off::u64 + 4 > sec_len::u64) {
         ret R.err[bool, str](overflow_message(s, kind, sym_name));
@@ -1869,6 +1944,26 @@ fun ldst_lo12_scale(kind: of.RelocKind) i32 {
     if (kind == of.RK_LDST64_LO12)  { ret 3; }
     if (kind == of.RK_LDST128_LO12) { ret 4; }
     ret -1;
+}
+
+# wire each registered arch's relocation packer onto its
+# vtable - the be-layer linker registrar. The relocation kind-set is owned by the
+# arch (one hook per vtable), but the packing bodies and their wiring live in this
+# be/ layer, so `driver.setup_registry` composes this after `target.register_all`
+# installs the vtables. An arch with no packer here is left nil; the linker's
+# nil-guard reports it as unsupported, exactly as an unregistered arch.
+# ---
+# reg: the ISA registry whose registered vtables are wired
+# ret: ok(true) once every registered arch is wired
+pub fun register_reloc_hooks(reg: *isa.IsaRegistry) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < isa.registered_count(reg)) {
+        val vt: *isa.IsaVTable = O.unwrap[*isa.IsaVTable](isa.registered(reg, i));
+        if (str_equals(vt.name, "x86_64"))  { vt.apply_reloc = x64_apply_reloc::*u8; }
+        if (str_equals(vt.name, "aarch64")) { vt.apply_reloc = arm64_apply_reloc::*u8; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
 }
 
 # in relocatable mode, copy each input relocation onto the
@@ -2299,7 +2394,7 @@ fun lt_link(s: *session.Session, name: intern.StrId, a: *of.Symbol, b: *of.Symbo
 }
 
 # boundary range checks for the x86_64 pc-relative kinds (#1242)
-test "mach.lang.be.linker.apply_one:pcrel32_boundary" {
+test "mach.lang.be.linker.x64_apply_reloc:pcrel32_boundary" {
     var alloc: A.Allocator;
     page.make(?alloc);
     val sr: R.Result[session.Session, str] = session.init(?alloc);
@@ -2311,23 +2406,23 @@ test "mach.lang.be.linker.apply_one:pcrel32_boundary" {
     dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
 
     # max valid positive displacement: must succeed and round-trip
-    val r1: R.Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0, intern.STR_NIL, isa.ARCH_X86_64);
+    val r1: R.Result[bool, str] = x64_apply_reloc(?s, of.RK_PC32, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0, intern.STR_NIL);
     if (R.is_err[bool, str](r1))                   { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x7FFFFFFF) { ret 1; }
 
     # one past the positive boundary: disp=2147483648 > INT32_MAX
-    val r2: R.Result[bool, str] = apply_one(?s, of.RK_PC32, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL, isa.ARCH_X86_64);
+    val r2: R.Result[bool, str] = x64_apply_reloc(?s, of.RK_PC32, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL);
     if (!R.is_err[bool, str](r2)) { ret 1; }
 
     # negative underflow via plt32: patch_va=0x80000000, addend=-1 -> disp=-2147483649 < INT32_MIN
-    val r3: R.Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0, -1, 0x80000000, intern.STR_NIL, isa.ARCH_X86_64);
+    val r3: R.Result[bool, str] = x64_apply_reloc(?s, of.RK_PLT32, ?dst[0], 0, 8, 0, -1, 0x80000000, intern.STR_NIL);
     if (!R.is_err[bool, str](r3)) { ret 1; }
 
     ret 0;
 }
 
 # boundary range checks for the x86_64 RK_ABS32S kind (#1242)
-test "mach.lang.be.linker.apply_one:abs32s_boundary" {
+test "mach.lang.be.linker.x64_apply_reloc:abs32s_boundary" {
     var alloc: A.Allocator;
     page.make(?alloc);
     val sr: R.Result[session.Session, str] = session.init(?alloc);
@@ -2339,23 +2434,23 @@ test "mach.lang.be.linker.apply_one:abs32s_boundary" {
     dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
 
     # sym_va=0x7FFFFFFF, addend=0 -> v=2147483647, within range; must round-trip
-    val r1: R.Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0, intern.STR_NIL, isa.ARCH_X86_64);
+    val r1: R.Result[bool, str] = x64_apply_reloc(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x7FFFFFFF, 0, 0, intern.STR_NIL);
     if (R.is_err[bool, str](r1))                   { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x7FFFFFFF) { ret 1; }
 
     # sym_va=0x80000000 -> v=2147483648 > INT32_MAX
-    val r2: R.Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL, isa.ARCH_X86_64);
+    val r2: R.Result[bool, str] = x64_apply_reloc(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL);
     if (!R.is_err[bool, str](r2)) { ret 1; }
 
     # sym_va=0, addend=INT32_MIN -> v=-2147483648, at boundary (valid); encodes as 0x80000000
     dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0;
-    val r3: R.Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, -2147483648, 0, intern.STR_NIL, isa.ARCH_X86_64);
+    val r3: R.Result[bool, str] = x64_apply_reloc(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, -2147483648, 0, intern.STR_NIL);
     if (R.is_err[bool, str](r3))                   { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x80000000) { ret 1; }
 
     # addend=INT32_MIN-1 -> v=-2147483649 < INT32_MIN
     val below_min: i64 = -2147483648 - 1;
-    val r4: R.Result[bool, str] = apply_one(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, below_min, 0, intern.STR_NIL, isa.ARCH_X86_64);
+    val r4: R.Result[bool, str] = x64_apply_reloc(?s, of.RK_ABS32S, ?dst[0], 0, 8, 0, below_min, 0, intern.STR_NIL);
     if (!R.is_err[bool, str](r4)) { ret 1; }
 
     ret 0;
@@ -2364,7 +2459,7 @@ test "mach.lang.be.linker.apply_one:abs32s_boundary" {
 # the aarch64 bit-packers reproduce the exact instruction words the LLVM assembler
 # emits for the resolved immediates: each base instruction (zero immediate) is
 # patched and compared to the llvm-mc golden for the equivalent concrete form (#1432).
-test "mach.lang.be.linker.apply_one:aarch64_bitpackers" {
+test "mach.lang.be.linker.arm64_apply_reloc:bitpackers" {
     var alloc: A.Allocator;
     page.make(?alloc);
     val sr: R.Result[session.Session, str] = session.init(?alloc);
@@ -2376,49 +2471,49 @@ test "mach.lang.be.linker.apply_one:aarch64_bitpackers" {
 
     # CALL26 (RK_PLT32): `bl #0` patched with disp 0x2000 -> `bl #0x2000` = 0x94000800
     bin.write_u32_le(?dst[0], 0, 0x94000000);
-    val c1: R.Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0x2000, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    val c1: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_PLT32, ?dst[0], 0, 8, 0x2000, 0, 0, intern.STR_NIL);
     if (R.is_err[bool, str](c1))                   { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x94000800) { ret 1; }
 
     # PAGE21 (RK_PAGE21): `adrp x0` patched with page delta 0x3000 -> 0xF0000000
     bin.write_u32_le(?dst[0], 0, 0x90000000);
-    val p1: R.Result[bool, str] = apply_one(?s, of.RK_PAGE21, ?dst[0], 0, 8, 0x3000, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    val p1: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_PAGE21, ?dst[0], 0, 8, 0x3000, 0, 0, intern.STR_NIL);
     if (R.is_err[bool, str](p1))                   { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0xF0000000) { ret 1; }
 
     # ADD_LO12 (RK_ADD_LO12): `add x0,x0` patched with lo12 0xABC -> 0x912AF000
     bin.write_u32_le(?dst[0], 0, 0x91000000);
-    val a1: R.Result[bool, str] = apply_one(?s, of.RK_ADD_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    val a1: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_ADD_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL);
     if (R.is_err[bool, str](a1))                   { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x912AF000) { ret 1; }
 
     # LDST8_LO12 (scale 0): `ldrb w0,[x0]` + lo12 0xABC -> 0x396AF000
     bin.write_u32_le(?dst[0], 0, 0x39400000);
-    val l8: R.Result[bool, str] = apply_one(?s, of.RK_LDST8_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    val l8: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_LDST8_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL);
     if (R.is_err[bool, str](l8))                   { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x396AF000) { ret 1; }
 
     # LDST16_LO12 (scale 1): `ldrh w0,[x0]` + lo12 0xABC -> 0x79557800
     bin.write_u32_le(?dst[0], 0, 0x79400000);
-    val l16: R.Result[bool, str] = apply_one(?s, of.RK_LDST16_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    val l16: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_LDST16_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL);
     if (R.is_err[bool, str](l16))                  { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x79557800) { ret 1; }
 
     # LDST32_LO12 (scale 2): `ldr w0,[x0]` + lo12 0xABC -> 0xB94ABC00
     bin.write_u32_le(?dst[0], 0, 0xB9400000);
-    val l32: R.Result[bool, str] = apply_one(?s, of.RK_LDST32_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    val l32: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_LDST32_LO12, ?dst[0], 0, 8, 0xABC, 0, 0, intern.STR_NIL);
     if (R.is_err[bool, str](l32))                  { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0xB94ABC00) { ret 1; }
 
     # LDST64_LO12 (scale 3): `ldr x0,[x0]` + lo12 0xAB8 -> 0xF9455C00
     bin.write_u32_le(?dst[0], 0, 0xF9400000);
-    val l64: R.Result[bool, str] = apply_one(?s, of.RK_LDST64_LO12, ?dst[0], 0, 8, 0xAB8, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    val l64: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_LDST64_LO12, ?dst[0], 0, 8, 0xAB8, 0, 0, intern.STR_NIL);
     if (R.is_err[bool, str](l64))                  { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0xF9455C00) { ret 1; }
 
     # LDST128_LO12 (scale 4): `ldr q0,[x0]` + lo12 0xAB0 -> 0x3DC2AC00
     bin.write_u32_le(?dst[0], 0, 0x3DC00000);
-    val l128: R.Result[bool, str] = apply_one(?s, of.RK_LDST128_LO12, ?dst[0], 0, 8, 0xAB0, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    val l128: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_LDST128_LO12, ?dst[0], 0, 8, 0xAB0, 0, 0, intern.STR_NIL);
     if (R.is_err[bool, str](l128))                 { ret 1; }
     if (bin.read_u32_le(?dst[0], 0) != 0x3DC2AC00) { ret 1; }
 
@@ -2427,7 +2522,7 @@ test "mach.lang.be.linker.apply_one:aarch64_bitpackers" {
 
 # the bounded A64 fields (CALL26 +-128MB 4-aligned, PAGE21 +-4GB) reject
 # out-of-range / misaligned displacements; the _NC LO12 kinds never overflow (#1432).
-test "mach.lang.be.linker.apply_one:aarch64_overflow_rejection" {
+test "mach.lang.be.linker.arm64_apply_reloc:overflow_rejection" {
     var alloc: A.Allocator;
     page.make(?alloc);
     val sr: R.Result[session.Session, str] = session.init(?alloc);
@@ -2439,22 +2534,22 @@ test "mach.lang.be.linker.apply_one:aarch64_overflow_rejection" {
 
     # CALL26: disp = +2^27 is one past the +-128MB branch range -> reject
     bin.write_u32_le(?dst[0], 0, 0x94000000);
-    val o1: R.Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 134217728, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    val o1: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_PLT32, ?dst[0], 0, 8, 134217728, 0, 0, intern.STR_NIL);
     if (!R.is_err[bool, str](o1)) { ret 1; }
 
     # CALL26: disp = -2^27 is the valid negative boundary -> succeed
     bin.write_u32_le(?dst[0], 0, 0x94000000);
-    val o2: R.Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0, 0, 134217728, intern.STR_NIL, isa.ARCH_AARCH64);
+    val o2: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_PLT32, ?dst[0], 0, 8, 0, 0, 134217728, intern.STR_NIL);
     if (R.is_err[bool, str](o2)) { ret 1; }
 
     # CALL26: a non-4-aligned displacement is not a valid branch target -> reject
     bin.write_u32_le(?dst[0], 0, 0x94000000);
-    val o3: R.Result[bool, str] = apply_one(?s, of.RK_PLT32, ?dst[0], 0, 8, 0x2002, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    val o3: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_PLT32, ?dst[0], 0, 8, 0x2002, 0, 0, intern.STR_NIL);
     if (!R.is_err[bool, str](o3)) { ret 1; }
 
     # PAGE21: page delta = +2^32 is one past the +-4GB ADRP range -> reject
     bin.write_u32_le(?dst[0], 0, 0x90000000);
-    val o4: R.Result[bool, str] = apply_one(?s, of.RK_PAGE21, ?dst[0], 0, 8, 4294967296, 0, 0, intern.STR_NIL, isa.ARCH_AARCH64);
+    val o4: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_PAGE21, ?dst[0], 0, 8, 4294967296, 0, 0, intern.STR_NIL);
     if (!R.is_err[bool, str](o4)) { ret 1; }
 
     ret 0;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -36,6 +36,7 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use be_linker: mach.lang.be.linker;
 use mach.lang.diagnostic;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
@@ -336,12 +337,16 @@ val INITIAL_MODULE_CAP: u32 = 16;
 val INITIAL_PUB_CAP:    u32 = 4;
 val INITIAL_DEP_CAP:    u32 = 4;
 
-# the single registry bring-up point - target substrates now, backend hooks later.
+# the single registry bring-up point - it installs the target
+# substrates then wires the be-layer relocation hooks onto the registered ISAs, so
+# every backend-build path starts from a fully composed registry.
 # ---
 # reg: the target registry to populate before any select
-# ret: register_all's Result unchanged
+# ret: ok(true) once registered and wired, or the first error
 pub fun setup_registry(reg: *target.TargetRegistry) R.Result[bool, str] {
-    ret target.register_all(reg);
+    val rr: R.Result[bool, str] = target.register_all(reg);
+    if (R.is_err[bool, str](rr)) { ret rr; }
+    ret be_linker.register_reloc_hooks(?reg.isa);
 }
 
 # load `project_root/mach.toml`, select `target_name`, and

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -352,6 +352,10 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 #                       register a body writes. nil when the ISA supplies no
 #                       analyzer, which regalloc treats conservatively (every
 #                       register potentially clobbered)
+# apply_reloc:          erased fn ptr - apply one relocation for this arch (cast
+#                       back to the linker's `ApplyRelocFn`); nil until the
+#                       be-layer linker registrar wires it, and the linker errors
+#                       on a nil slot exactly as it does for an unregistered ISA
 # reserved_regs:        registers the allocator must never assign (stack/frame
 #                       pointers); owned by the per-arch impl for the process
 #                       lifetime
@@ -402,6 +406,7 @@ pub rec IsaVTable {
     encode:               *u8;
     emit_asm:             *u8;
     asm_clobbers:         *u8;
+    apply_reloc:          *u8;
     reserved_regs:        *Register;
     reserved_reg_count:   i32;
     reload_scratch_regs:  *Register;


### PR DESCRIPTION
Makes each ISA own its complete relocation kind-set through one vtable hook, so the linker stops branching on `arch_id`.

## The be-layer-registrar pattern

- **Slot on the target vtable.** `isa.IsaVTable` gains an erased `apply_reloc: *u8` hook, grouped with the other erased hooks (`select` / `encode` / `emit_asm` / `asm_clobbers`). It is nil until wired, and the linker errors on a nil slot exactly as the isel / encode dispatchers do for an unregistered ISA.
- **Behavior + wiring in be/linker.** The packing bodies live in the be/ linker layer next to the kinds they implement:
  - `apply_one` becomes a thin dispatch: nil-guard `arch.apply_reloc`, then call it through `ApplyRelocFn`. No inline kind handling remains.
  - `x64_apply_reloc` owns RK_ABS64 / RK_PC32 / RK_PLT32 / RK_ABS32S.
  - `arm64_apply_reloc` (renamed from `apply_one_aarch64`) owns the shared RK_ABS64 / RK_PC32 plus the A64 instruction-field packers (CALL26 / PAGE21 / ADD_LO12 / per-width LDST*_LO12).
  - The mechanical bodies stay shared free helpers both arches call: the new `apply_abs64`, plus the existing `apply_pcrel32` / `ldst_lo12_scale`.
  - `register_reloc_hooks` enumerates the ISA registry and sets each registered arch's `apply_reloc` by name; an arch with no packer is left nil.
  - `arch: *isa.IsaVTable` replaces `arch_id: u32` threaded through `apply_one` / `patch_module_relocations` / `patch_relocations`; the top-level call passes `tgt.arch`.
- **Composed in setup_registry.** `driver.setup_registry` now runs `target.register_all` then `be_linker.register_reloc_hooks(?reg.isa)`, so every backend-build path starts from a fully composed registry.

## Zero behavior change

Each relocation kind hits the same body it did before; only the dispatch is reorganized. Verified by the self-host fixpoint: stage1 (built by the installed mach) and stage2 (built by stage1) are byte-identical.

## Gate

- `mach build .` exit 0
- `mach test .` = 606 passed, 0 failed, 606 total
- self-host fixpoint: stage1 == stage2 (byte-identical, sha256 match)

Part of #1600.