### PR TITLE
docs: drop stale syscall-layer prose from os substrate docs

### DIFF
--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -1,13 +1,13 @@
 # Darwin (macOS) operating-system stub
 #
 # Supplies a correctly-shaped OsVTable for Darwin: the "_main" program entry
-# point, the darwin syscall layer, the system library directories, and the
-# executable load parameters (base virtual address 0x100000000 and a 4096-byte
-# page), stored on the vtable so the linker reads them through it rather than
-# branching on the os id. Darwin code generation is not yet supported; the
-# unsupported surface lives in the Mach-O object-format operations, which return
-# a clear "unsupported object format" error. The vtable carries data only;
-# register fills its str fields directly (no interning) and is idempotent.
+# point, the system library directories, and the executable load parameters
+# (base virtual address 0x100000000 and a 4096-byte page), stored on the vtable
+# so the linker reads them through it rather than branching on the os id.
+# Darwin code generation is not yet supported; the unsupported surface lives
+# in the Mach-O object-format operations, which return a clear "unsupported
+# object format" error. The vtable carries data only; register fills its str
+# fields directly (no interning) and is idempotent.
 
 use std.types.bool.bool;
 use std.types.bool.false;

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -1,12 +1,11 @@
 # Linux operating-system implementation
 #
 # Supplies the `OsVTable` for Linux: the `_start` program entry point, the
-# `linux` syscall layer, the ordered system library directories, and the
-# executable load parameters - base virtual address 0x400000 and a 4096-byte
-# page - stored on the vtable so the linker reads them through it rather than
-# branching on the os id. `register_linux` fills the vtable with plain str
-# constants and installs it into the OS registry; it interns nothing and is
-# idempotent.
+# ordered system library directories, and the executable load parameters -
+# base virtual address 0x400000 and a 4096-byte page - stored on the vtable
+# so the linker reads them through it rather than branching on the os id.
+# `register_linux` fills the vtable with plain str constants and installs it
+# into the OS registry; it interns nothing and is idempotent.
 
 use std.types.bool.bool;
 use std.types.bool.false;

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -1,12 +1,11 @@
 # Windows operating-system implementation
 #
 # Supplies the `OsVTable` for Windows - entry symbol "mainCRTStartup", the
-# "windows" syscall layer (kernel32 imports, no raw syscalls), the system library
-# directories, and the executable load parameters (ImageBase 0x140000000,
-# 4096-byte page) - so target.select composes a runnable Windows target through
-# the win64 ABI and the COFF/PE writer. PE links via the import directory, not a
-# PT_INTERP path, so `dynamic_linker` is empty (""). `register` sets the vtable's
-# str fields directly (no interning) and is idempotent.
+# system library directories, and the executable load parameters (ImageBase
+# 0x140000000, 4096-byte page) - so target.select composes a runnable Windows
+# target through the win64 ABI and the COFF/PE writer. PE links via the import
+# directory, not a PT_INTERP path, so `dynamic_linker` is empty (""). `register`
+# sets the vtable's str fields directly (no interning) and is idempotent.
 
 use std.types.bool.bool;
 use std.types.bool.true;


### PR DESCRIPTION
PR #1604 removed the `syscall_layer` field from `os.OsVTable`, but the
linux, darwin, and windows OS module-doc headers still described the
vtable as supplying a "syscall layer" it no longer has.

This drops the stale syscall-layer references from all three module
docs and reflows the surrounding prose. Pure doc change, no code touched.

Verified `grep -rn syscall_layer src/` returns nothing - no stray code
reference survives. Build exit 0, full suite 610 passed / 0 failed.