### PR TITLE
feat(target): of-by-name selection + freestanding e2e (#1600)

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -89,6 +89,7 @@ pub val TARGET_OPT_RELEASE: TargetOpt = 2;
 # os_name:    interned os name (e.g. "linux"); read by `$project.target.os`
 # isa_name:   interned isa name (e.g. "x86_64"); read by `$project.target.arch`
 # abi_name:   interned abi name (e.g. "sysv64"); read by `$project.target.abi`
+# of_name:    interned object-format override, "" to derive from the os default
 # entrypoint: interned entry-source path, relative to the project src dir (e.g. "main.mach")
 # mode:       whether the build links an executable or stops at the objects
 # opt:        resolved optimization level from the selected profile; TARGET_OPT_DEFAULT
@@ -104,6 +105,7 @@ pub rec TargetEntry {
     os_name:    intern.StrId;
     isa_name:   intern.StrId;
     abi_name:   intern.StrId;
+    of_name:    intern.StrId;
     entrypoint: intern.StrId;
     mode:       BuildMode;
     opt:        TargetOpt;
@@ -637,7 +639,12 @@ fun populate_union_tuples(p: *Project, m: *manifest.Manifest) R.Result[bool, str
         val abi_name: str = O.unwrap[str](abi_opt);
         val os_id:   u32 = os.os_id_for(os_name);
         val arch_id: u32 = isa.arch_id_for(isa_name);
-        val sr: R.Result[target.Target, str] = target.select(?p.s.registry, isa_name, os_name, abi_name);
+        # the object-format override is optional; an unset/empty name defers to the
+        # os default inside select_of.
+        var of_name: str = "";
+        val of_opt: O.Option[str] = intern.lookup(?p.s.interner, td.of);
+        if (O.is_some[str](of_opt)) { of_name = O.unwrap[str](of_opt); }
+        val sr: R.Result[target.Target, str] = target.select_of(?p.s.registry, isa_name, os_name, abi_name, of_name);
         if (R.is_err[target.Target, str](sr)) {
             A.deallocate[TargetTuple](p.s.alloc, tuples, n::usize);
             ret R.err[bool, str](R.unwrap_err[target.Target, str](sr));
@@ -1170,6 +1177,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     entry.os_name    = bu.target.os;
     entry.isa_name   = bu.target.isa;
     entry.abi_name   = bu.target.abi;
+    entry.of_name    = bu.target.of;
     entry.entrypoint = bu.entry;
     entry.mode       = MODE_EXECUTABLE;
     if (bu.is_lib) { entry.mode = MODE_LIBRARY; }
@@ -1671,11 +1679,12 @@ fun intern_or(i: *intern.Interner, text: str, default: str) R.Result[intern.StrI
 }
 
 # resolve the selected TargetEntry into a composed
-# target.Target. passes the entry's isa/os/abi names to target.select, which
+# target.Target. passes the entry's isa/os/abi/of names to target.select_of, which
 # composes the isa/abi/os/of vtables by name and stores the result on Project. an
 # unknown os/isa name is reported with a precise diagnostic before select runs; an
-# unregistered substrate fails through target.select. pointer width is not stored
-# here - consumers read it through p.target.arch.
+# empty of name defers to the os default; an unregistered substrate fails through
+# target.select_of. pointer width is not stored here - consumers read it through
+# p.target.arch.
 fun select_target(p: *Project, t: *TargetEntry) R.Result[bool, str] {
     val os_opt: O.Option[str] = intern.lookup(?p.s.interner, t.os_name);
     if (O.is_none[str](os_opt)) { ret R.err[bool, str]("target os name not interned"); }
@@ -1689,6 +1698,12 @@ fun select_target(p: *Project, t: *TargetEntry) R.Result[bool, str] {
     if (O.is_none[str](abi_opt)) { ret R.err[bool, str]("target abi name not interned"); }
     val abi_name: str = O.unwrap[str](abi_opt);
 
+    # the object-format override is optional; an unset/empty name defers to the os
+    # default inside select_of.
+    var of_name: str = "";
+    val of_opt: O.Option[str] = intern.lookup(?p.s.interner, t.of_name);
+    if (O.is_some[str](of_opt)) { of_name = O.unwrap[str](of_opt); }
+
     if (os.os_id_for(os_name) == os.OS_UNKNOWN) {
         ret R.err[bool, str](diag_join_named(p.s, "unknown target os name '", t.os_name, "' (expected: linux, darwin, windows)", "unknown target os name"));
     }
@@ -1696,7 +1711,7 @@ fun select_target(p: *Project, t: *TargetEntry) R.Result[bool, str] {
         ret R.err[bool, str](diag_join_named(p.s, "unknown target isa name '", t.isa_name, "' (expected: x86_64, aarch64)", "unknown target isa name"));
     }
 
-    val tr: R.Result[target.Target, str] = target.select(?p.s.registry, isa_name, os_name, abi_name);
+    val tr: R.Result[target.Target, str] = target.select_of(?p.s.registry, isa_name, os_name, abi_name, of_name);
     if (R.is_err[target.Target, str](tr)) { ret R.err[bool, str](R.unwrap_err[target.Target, str](tr)); }
     p.target = R.unwrap_ok[target.Target, str](tr);
 

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -72,6 +72,7 @@ val TK_OS:      TableKind = 7;  # an `[os.<name>]` table
 # isa:          interned instruction-set architecture (required)
 # os:           interned operating system (required)
 # abi:          interned ABI (required)
+# of:           interned object-format override, "" when omitted (derive from os)
 # ext:          interned artifact extension, "" when omitted
 # libs:         interned platform link overlay; nil when none
 # lib_count:    number of entries in libs
@@ -82,6 +83,7 @@ pub rec TargetDef {
     isa:          intern.StrId;
     os:           intern.StrId;
     abi:          intern.StrId;
+    of:           intern.StrId;
     ext:          intern.StrId;
     libs:         *intern.StrId;
     lib_count:    u32;
@@ -645,7 +647,8 @@ fun key_known(kind: TableKind, k: str) bool {
     }
     if (kind == TK_TARGET) {
         ret str_equals(k, "isa") || str_equals(k, "os") || str_equals(k, "abi")
-            || str_equals(k, "ext") || str_equals(k, "libs") || str_equals(k, "defines");
+            || str_equals(k, "of") || str_equals(k, "ext") || str_equals(k, "libs")
+            || str_equals(k, "defines");
     }
     if (kind == TK_BIN) {
         ret str_equals(k, "entry") || str_equals(k, "out") || str_equals(k, "libs")
@@ -890,6 +893,8 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
         d.isa = intern_unwrap(itn, isa_s);
         d.os  = intern_unwrap(itn, os_s);
         d.abi = intern_unwrap(itn, abi_s);
+        # of is optional: "" defers to the os default object format at select time.
+        d.of  = intern_unwrap(itn, first_nonempty(toml.get_str(sub, "of"), ""));
         d.ext = intern_unwrap(itn, first_nonempty(toml.get_str(sub, "ext"), ""));
 
         val res_libs: R.Result[StrArr, str] = parse_str_array(alloc, itn, toml.get_array(sub, "libs"),

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -7,15 +7,18 @@
 #
 # A `TargetRegistry` bundles the four per-dimension registries; the session (or
 # driver) owns one, `register_all` installs every implementation into it, and
-# `select` composes a Target from it by name: it looks up the isa, os, and abi
-# vtables under the names the manifest spells and resolves the object format
-# through the chosen os's `default_of`. The legacy os/arch/abi/of ids are derived
-# from the resolved vtables' `.id` fields and kept on the Target, so the id
-# readers and the comptime tag space are unaffected by the name-based composition.
+# `select_of` composes a Target from it by name: it looks up the isa, os, abi, and
+# object-format vtables under the names the manifest spells. The object format is
+# the one substrate with an os-derived default - an empty of name defers to the
+# chosen os's `default_of`, so `select` (the common case) is `select_of` with no
+# override. The legacy os/arch/abi/of ids are derived from the resolved vtables'
+# `.id` fields and kept on the Target, so the id readers and the comptime tag space
+# are unaffected by the name-based composition.
 
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.string.str;
+use std.types.string.str_empty;
 use std.types.string.str_equals;
 
 use O: std.types.option;
@@ -182,20 +185,23 @@ pub fun register_all(reg: *TargetRegistry) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# compose a Target from `reg` by name.
+# compose a Target from `reg` by name, with an explicit object-format override.
 #
-# looks up the isa, os, and abi vtables under their names, resolves the object
-# format through the chosen os's `default_of` name, and derives the legacy
-# os/arch/abi/of ids from the resolved vtables' `.id` fields. allocates nothing -
-# every vtable pointer is borrowed. fails if any required implementation is not
-# registered in `reg` under the requested name.
+# looks up the isa, os, and abi vtables under their names and resolves the object
+# format under `of_name` when it is non-empty, falling back to the chosen os's
+# `default_of` name when `of_name` is empty. derives the legacy os/arch/abi/of ids
+# from the resolved vtables' `.id` fields. allocates nothing - every vtable pointer
+# is borrowed. fails if any required implementation is not registered in `reg`
+# under the requested name. the of axis is the one substrate with an os-derived
+# default; isa, os, and abi are always spelled explicitly.
 # ---
 # reg:      the target registry populated by register_all
 # isa_name: instruction-set name (e.g. "x86_64", "aarch64")
 # os_name:  operating-system name (e.g. "linux", "windows")
 # abi_name: calling-convention name (e.g. "sysv64", "win64", "aapcs64")
+# of_name:  object-format name (e.g. "elf", "raw"), or "" to use the os default
 # ret:      the composed Target, or an error describing the missing piece
-pub fun select(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: str) R.Result[resolved.Target, str] {
+pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: str, of_name: str) R.Result[resolved.Target, str] {
     val opt_os_vt: O.Option[*os.OsVTable] = os.lookup(?reg.os, os_name);
     if (O.is_none[*os.OsVTable](opt_os_vt)) {
         ret R.err[resolved.Target, str]("no os implementation registered for the requested name");
@@ -210,9 +216,15 @@ pub fun select(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: str)
     if (O.is_none[*abi.AbiVTable](opt_abi_vt)) {
         ret R.err[resolved.Target, str]("no abi implementation registered for the requested name");
     }
-    val opt_of_vt: O.Option[*of.OfVTable] = of.lookup(?reg.of, os_vt.default_of);
+
+    # an explicit of name selects the object format directly; an empty name defers
+    # to the os default, so deriving the of from the os stays the default and a
+    # spelled-out name overrides it without disturbing the other axes.
+    var of_sel: str = of_name;
+    if (str_empty(of_sel)) { of_sel = os_vt.default_of; }
+    val opt_of_vt: O.Option[*of.OfVTable] = of.lookup(?reg.of, of_sel);
     if (O.is_none[*of.OfVTable](opt_of_vt)) {
-        ret R.err[resolved.Target, str]("no object-format implementation registered for the os default");
+        ret R.err[resolved.Target, str]("no object-format implementation registered for the requested name");
     }
 
     var t: resolved.Target;
@@ -238,6 +250,21 @@ pub fun select(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: str)
     t.model.shadow_space = t.abi.shadow_space;
 
     ret R.ok[resolved.Target, str](t);
+}
+
+# compose a Target from `reg` by name, using the chosen os's default object format.
+#
+# the common case: defers to `select_of` with an empty of name, so the object
+# format is derived from the os's `default_of`. isa, os, and abi are spelled
+# explicitly; the of axis follows the os.
+# ---
+# reg:      the target registry populated by register_all
+# isa_name: instruction-set name (e.g. "x86_64", "aarch64")
+# os_name:  operating-system name (e.g. "linux", "windows")
+# abi_name: calling-convention name (e.g. "sysv64", "win64", "aapcs64")
+# ret:      the composed Target, or an error describing the missing piece
+pub fun select(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: str) R.Result[resolved.Target, str] {
+    ret select_of(reg, isa_name, os_name, abi_name, "");
 }
 
 # enumeration helpers (registered_count / registered) must agree with the

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -15,15 +15,19 @@
 # `.id` fields and kept on the Target, so the id readers and the comptime tag space
 # are unaffected by the name-based composition.
 
+use std.allocator.page;
+use std.filesystem;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.string.str;
 use std.types.string.str_empty;
 use std.types.string.str_equals;
 
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use mach.lang.intern;
 use mach.lang.target.abi;
 use mach.lang.target.abi.aapcs64;
 use mach.lang.target.abi.sysv;
@@ -361,5 +365,89 @@ test "mach.lang.target.select:x86_64_freestanding_raw" {
     if (t.arch == nil)            { ret 1; }
     if (t.arch.id != isa.ARCH_X86_64) { ret 1; }
 
+    ret 0;
+}
+
+# the object format is selectable by name independently of the os: select_of with
+# an explicit name overrides the os default, an empty name (and the 4-arg select
+# wrapper) falls back to it, and an unregistered name fails with the same contract
+# as the other axes. this exercises the of-by-name mechanism in isolation.
+test "mach.lang.target.select_of:object_format_chosen_by_name" {
+    var reg: TargetRegistry = registry_init();
+    val res_reg: R.Result[bool, str] = register_all(?reg);
+    if (R.is_err[bool, str](res_reg)) { ret 1; }
+
+    # an explicit "elf" overrides the freestanding os default of "raw".
+    val r_elf: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "freestanding", "sysv64", "elf");
+    if (R.is_err[resolved.Target, str](r_elf))                       { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](r_elf).of.id != of.OF_ELF) { ret 1; }
+
+    # an empty of name defers to the os default, resolving to raw.
+    val r_def: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "freestanding", "sysv64", "");
+    if (R.is_err[resolved.Target, str](r_def))                       { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](r_def).of.id != of.OF_RAW) { ret 1; }
+
+    # the 4-arg select wrapper is exactly the empty-of case.
+    val r_wrap: R.Result[resolved.Target, str] = select(?reg, "x86_64", "freestanding", "sysv64");
+    if (R.is_err[resolved.Target, str](r_wrap))                       { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](r_wrap).of.id != of.OF_RAW) { ret 1; }
+
+    # an unregistered of name fails, mirroring the isa/os/abi unregistered contract.
+    val r_bad: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "freestanding", "sysv64", "bogus");
+    if (!R.is_err[resolved.Target, str](r_bad)) { ret 1; }
+
+    ret 0;
+}
+
+# the of-by-name path end to end: selecting freestanding with an explicit "raw" of
+# composes the flat-image writer, and emitting a one-segment program through the
+# composed writer produces a flat image - the segment's raw bytes, no container,
+# entered at the image base. this ties the name-selected of substrate to a real
+# emitted artifact (os=freestanding, of=raw, no std).
+test "mach.lang.target.select_of:freestanding_raw_emits_flat_image" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+
+    var reg: TargetRegistry = registry_init();
+    val res_reg: R.Result[bool, str] = register_all(?reg);
+    if (R.is_err[bool, str](res_reg)) { ret 1; }
+
+    val res_target: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "freestanding", "sysv64", "raw");
+    if (R.is_err[resolved.Target, str](res_target)) { ret 1; }
+    val t: resolved.Target = R.unwrap_ok[resolved.Target, str](res_target);
+    if (t.of == nil)           { ret 1; }
+    if (t.of.id != of.OF_RAW)  { ret 1; }
+    if (t.of.emit_exec == nil) { ret 1; }
+
+    # one executable segment at the freestanding image base (0), entered at base.
+    var code_bytes: [4]u8;
+    code_bytes[0] = 0xEB; code_bytes[1] = 0xFE; code_bytes[2] = 0x90; code_bytes[3] = 0x90;
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = t.os.base_addr; segs[0].filesz = 4; segs[0].memsz = 4;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code_bytes[0];
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "sel_raw");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    # enter at the image base; the raw writer rejects any other entry.
+    val em: R.Result[bool, str] =
+        t.of.emit_exec(?alloc, ?itn, t.arch, ?segs[0], 1, t.os.base_addr, nil::*of.ExecFunction, 0, tpath::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rr)) { ret 1; }
+    val b: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rr);
+
+    # a flat image: exactly the segment bytes, no ELF magic, no header.
+    if (b.len != 4)        { A.deallocate[u8](?alloc, b.data, b.len + 1); ret 1; }
+    if (b.data[0] == 0x7F) { A.deallocate[u8](?alloc, b.data, b.len + 1); ret 1; }
+    if (b.data[0] != 0xEB) { A.deallocate[u8](?alloc, b.data, b.len + 1); ret 1; }
+    if (b.data[1] != 0xFE) { A.deallocate[u8](?alloc, b.data, b.len + 1); ret 1; }
+
+    A.deallocate[u8](?alloc, b.data, b.len + 1);
     ret 0;
 }


### PR DESCRIPTION
Last piece of the retargeting foundation (epic #1600): name-based selection of the object-format (`of`) substrate, plus an end-to-end check of the freestanding/raw path.

## of-by-name mechanism

`of` was the one target substrate still not selectable by name - it was always derived from `os.default_of`. This adds `target.select_of(reg, isa, os, abi, of_name)`, which resolves the object format from the of-registry under `of_name`, falling back to the chosen os's `default_of` when `of_name` is empty. The existing 4-arg `target.select` becomes a thin wrapper (`select_of(..., "")`), so every existing caller and the default behavior are unchanged - a default build is byte-identical to before. An unregistered `of_name` fails with the same contract as the isa/os/abi axes.

`of` is threaded through the manifest and driver: a new optional `of = "..."` key on `[target.<name>]` -> `TargetDef.of` -> `TargetEntry.of_name`, passed to `target.select_of` at both driver selection sites (single-target `select_target` and the union tuple walk; the union walk reads `TargetDef.of` directly). Omitting `of` defers to the os default exactly as today.

The 4-arg `select` wrapper is kept deliberately so the change does not touch `regalloc.mach` (which calls `select` in a test) or any shared backend stage.

Verified with the freshly-built compiler:
- `of = "bogus"` -> `error: no object-format implementation registered for the requested name` (selection-time, before any emission)
- `of = "raw"` on freestanding -> resolves to raw (same downstream path as the os default)
- `of = "elf"` on freestanding -> overrides the raw default and builds a real ELF, proving the of axis composes orthogonally with the os by name

## Tests

Two tests in `target.mach` (where the select tests live), 612 passed / 0 failed:
- `select_of:object_format_chosen_by_name` - explicit name overrides the os default, empty name and the 4-arg wrapper defer to it, unregistered name errors.
- `select_of:freestanding_raw_emits_flat_image` - selects `x86_64/freestanding/sysv64` with explicit `of=raw` and emits a one-segment program through the composed writer, asserting a flat image (segment bytes, no container, entered at the image base).

## freestanding e2e verdict: other-blocker (not entry-at-base)

A full `mach build` of a freestanding/raw program does **not** reach the `emit_exec` entry-at-base check. It trips strictly earlier, in per-module relocatable-object emission:

```
error: raw output supports only executables
```

The build pipeline is object-file-centric: each module is codegen'd to an in-memory `ObjectImage`, written to a `.o` via `tgt.of.emit_object`, then the linker reads the `.o`s back via `tgt.of.parse_object`, merges, and writes the executable via `emit_exec`. The raw flat-image format implements only `emit_exec`; `emit_object`/`parse_object` are deliberate unsupported stubs (a flat image is not a relocatable object). So a raw target has no path through the current build - it fails at the first `obj.emit`, before linking.

This is **not** the entry-at-base constraint and is not a freestanding problem: the same minimal program built as `os=freestanding, of=elf` goes all the way through (emit_object -> link -> emit_exec) and produces a working ELF. Its entry point resolves to `0x0`, exactly the freestanding image base - so for a minimal single-function program the entry-at-base contract that raw's `emit_exec` enforces **would** be satisfied (the linker's entry/segment layout is format-independent). The raw blocker is purely the missing relocatable-object representation, not entry placement.

The proper fix (a build path that links raw targets straight from in-memory images, bypassing the per-module `.o` round-trip - or a raw object representation) is an architectural change to the build/link pipeline, out of scope for this PR. Surfaced here rather than worked around. No backend stage was touched.

## Scope notes

- No default codegen path changed (of-by-name is an unused-by-default path; default selection still derives of from the os), so no self-host fixpoint was required.
- Minor pre-existing nit (not fixed, out of scope): the `select_target` unknown-os diagnostic still reads `(expected: linux, darwin, windows)` and omits `freestanding`, which `os_id_for` already accepts since #1613.

refs #1600