### PR TITLE
fix(mir): locate float bank by RC_FLOAT kind, not width threshold

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -237,13 +237,10 @@ pub val FCC_GE: u8 = 5;  # greater or equal (SETAE)
 pub val MIR_VREG_NIL: u32 = 0xFFFFFFFF;
 
 # canonical general-purpose register-class index used by `lower_ir`. by
-# convention the general-purpose bank is the first declared class and the
-# float/vector bank is selected by its wide bit width, so no arch-specific class
-# name is hardcoded.
+# convention the general-purpose bank is the first declared class; the lowering
+# locates the general and float banks by their RC_GENERAL / RC_FLOAT kind, so no
+# arch-specific class name is hardcoded.
 pub val REG_CLASS_GP: u32 = 0;
-
-# minimum register width in bits that identifies the float/vector bank
-pub val FP_CLASS_MIN_BITS: u32 = 128;
 
 # the minimum byte width an integer ALU / shift result is computed at. a register
 # that holds a value narrower than this is still saved and reloaded at the full

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -902,9 +902,9 @@ fun param_vreg(ctx: *LowerCtx, ix: u32) u32 {
 # select the register-class index for an IR value type
 #
 # An IR float type maps to the float/vector bank; everything else maps to the
-# general-purpose bank. Both banks are located in `tgt.model.reg_classes` - the
-# float bank by its wide register width, the general bank by its RC_GENERAL kind -
-# so no arch-specific class name or index is hardcoded.
+# general-purpose bank. Both banks are located in `tgt.model.reg_classes` by kind -
+# the float bank by RC_FLOAT, the general bank by RC_GENERAL - so no arch-specific
+# class name, index, or register width is hardcoded.
 # ---
 # ctx: the lowering context
 # tgt: resolved target supplying the machine model's register-class table
@@ -923,17 +923,20 @@ fun reg_class_of(ctx: *LowerCtx, tgt: *target.Target, ty: ir_type.IrTypeId) u32 
 
 # the index of the float/vector register bank
 #
-# Identified in `tgt.model.reg_classes` as the first class whose register width is
-# at least mir.FP_CLASS_MIN_BITS. A target with no wide bank cannot hold a float
-# value, so a missing bank is a target-configuration bug and fails loudly rather
-# than misclassifying a float into the GP bank.
+# Located in `tgt.model.reg_classes` by its RC_FLOAT kind rather than a register
+# width, parallel to `gp_class_index`'s RC_GENERAL lookup. The width plays no part
+# in identifying the bank, so a target whose float bank is narrower than a vector
+# register (rv64d's 64-bit f-registers) is found just like a 128-bit XMM / V bank.
+# A target with no float bank cannot hold a float value, so a missing bank is a
+# target-configuration bug and fails loudly rather than misclassifying a float
+# into the GP bank.
 # ---
 # tgt: resolved target supplying the machine model's register-class table
 # ret: the float/vector register-class index
 fun fp_class_index(tgt: *target.Target) u32 {
     var ci: u32 = 0;
     for (ci < tgt.model.reg_class_len) {
-        if (tgt.model.reg_classes[ci].bit_width >= mir.FP_CLASS_MIN_BITS) {
+        if (tgt.model.reg_classes[ci].kind == isa.RC_FLOAT) {
             ret ci;
         }
         ci = ci + 1;
@@ -1096,5 +1099,28 @@ test "mach.lang.be.codegen.mir.context.clamp_alu_width" {
     if (clamp_alu_width(3) != 4) { ret 1; }
     if (clamp_alu_width(4) != 4) { ret 1; }
     if (clamp_alu_width(8) != 8) { ret 1; }
+    ret 0;
+}
+
+# the float bank is found by RC_FLOAT kind, not a width threshold: a 64-bit float
+# bank (rv64d's f-registers) resolves just like the 128-bit XMM / V bank (x64 /
+# arm64 shape).
+test "mach.lang.be.codegen.mir.context.fp_class_index" {
+    var classes: [2]isa.RegClass;
+    classes[0].kind = isa.RC_GENERAL;
+    classes[1].kind = isa.RC_FLOAT;
+
+    var tgt: target.Target;
+    tgt.model.reg_classes   = ?classes[0];
+    tgt.model.reg_class_len = 2;
+
+    # a sub-128-bit float bank (rv64d shape) is found by kind.
+    classes[1].bit_width = 64;
+    if (fp_class_index(?tgt) != 1) { ret 1; }
+
+    # a 128-bit float bank (x64 / arm64 shape) resolves to the same index.
+    classes[1].bit_width = 128;
+    if (fp_class_index(?tgt) != 1) { ret 1; }
+
     ret 0;
 }


### PR DESCRIPTION
Closes #1624.

## The x86/arm-ism

`fp_class_index` (`be/codegen/mir/context.mach`) located the float register
bank by scanning `tgt.model.reg_classes` for the first class whose
`bit_width >= FP_CLASS_MIN_BITS` (128). That works for x86-64 (XMM, 128-bit)
and aarch64 (V, 128-bit), but it assumes every float bank is at least as
wide as a 128-bit vector register. RV64D float registers are 64-bit, so a
target with a truthful 64-bit float bank (riscv64, now on dev) would not be
found and float lowering would panic.

## The fix

Identify the float bank by its `RegClass` kind (`RC_FLOAT`), parallel to how
`gp_class_index` already finds the integer bank by `RC_GENERAL`. Register
width plays no part in identifying which bank is the float bank. `FP_CLASS_MIN_BITS`
is now unused and is removed along with its doc; the stale `REG_CLASS_GP` /
`reg_class_of` comments that referenced the width scan are corrected.

## No-op for x86-64 / aarch64

For both archs the sole `RC_FLOAT` bank is the 128-bit one and sits at the
same index the old width scan returned (index 1, after the `RC_GENERAL`
bank), so `reg_class_of` returns identical values and codegen is unchanged.
Verified: the self-host fixpoint is byte-identical (`b == c`) and a baseline
(width-based) vs changed (kind-based) compiler produce byte-identical output
for the same source.

## Unblocks

riscv64 float lowering / instruction selection (#1627) - a truthful 64-bit
fpr bank is now found.

## Verification

- `mach build .` succeeds.
- `mach test .` green: 620 passed, 0 failed (was 619; +1 for the new
  `fp_class_index` test covering both a 64-bit rv64d-shape bank and a
  128-bit x64/arm64-shape bank).
- self-host fixpoint byte-identical (`cmp b c`).