### PR TITLE
docs(language): respec main.mach entrypoint as convention

### DIFF
--- a/doc/language/files.md
+++ b/doc/language/files.md
@@ -5,10 +5,38 @@ root and conventionally one of two entrypoint files:
 
 - **`lib.mach`** — library entrypoint. Used by projects that expose code for
   others to import; no executable produced.
-- **`main.mach`** — executable entrypoint. Defines `fun main()`.
+- **`main.mach`** — executable entrypoint. Conventionally holds the program's
+  entry function.
 
-A project may have both, but the dominant role is determined by the target's
-`mode` and `entrypoint` in `mach.toml`.
+Both names are conventions only — the compiler attaches no meaning to either.
+A project may declare both files; the target's `mode` and `entrypoint` in
+`mach.toml` decide which is built, and the `entrypoint`'s `.mach` basename is
+arbitrary.
+
+## Executable entry
+
+The compiler does not special-case a `main` function. An executable's entry is
+whichever function **exports the linker symbol** `main`, tagged with
+[`#[symbol("main")]`](decorators.md) and matching the runtime's expected
+signature:
+
+```mach
+use std.runtime;
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    ret 0;
+}
+```
+
+`std.runtime` provides the platform-specific `_start` symbol the linker uses as
+the true process entrypoint; `_start` decodes `argc`/`argv` and calls whatever
+function exports `main`, then terminates the process with its returned exit
+code. `use std.runtime;` is **required** to link `_start` into the binary, even
+though no code references it by name.
+
+Only the exported `main` symbol binds the entry — the Mach-level function name
+is irrelevant, so `fun entry(...)` tagged `#[symbol("main")]` works identically.
 
 ## mach.toml
 
@@ -43,3 +71,4 @@ The `id` is the root of every module path the project exposes. A file at
 
 - [modules.md](modules.md) — how files map to module paths
 - [use.md](use.md) — referencing modules from other modules
+- [decorators.md](decorators.md) — `#[symbol("main")]` and the linker-name override


### PR DESCRIPTION
## Summary

`doc/language/files.md` framed `main.mach` as defining `fun main()` as if the compiler knew the name `main`. It does not. Rewrites the section to state the actual mechanism accurately.

## Changes

- The `lib.mach` / `main.mach` bullets are now explicitly file-name conventions the compiler attaches no meaning to; the `entrypoint` `.mach` basename is arbitrary.
- New **Executable entry** section: the entry is whichever function exports the linker symbol `main` via `#[symbol("main")]` with the runtime's signature (`fun main(argc: i64, argv: **u8) i64`), linked in by `use std.runtime;` (which provides `_start`). The Mach-level function name is irrelevant.
- Cross-link to `decorators.md` for `#[symbol(...)]`.

## Audit

Audited all of `doc/language/*.md` for the same misframing. No other occurrences:
- `decorators.md` / `comptime-attrs.md` show `#[symbol("main")] fun entry(...)` — these correctly reinforce that the function name does not matter.
- `test.md`'s `main` references mean the linker symbol / synthesized runner entry — accurate.
- `README.md` already calls them "conventions".

Out of scope (`doc/manifest.md`, `doc/cli.md`) reference `src/main.mach` only as scaffold file names — no misframing, left untouched.

Closes #1631