### PR TITLE
refactor(target): widen ELF reloc + class seam onto the isa substrate

### DIFF
--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -357,6 +357,14 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 #                       back to the linker's `ApplyRelocFn`); nil until the
 #                       be-layer linker registrar wires it, and the linker errors
 #                       on a nil slot exactly as it does for an unregistered ISA
+# elf_reloc_type:       erased fn ptr - map an abstract `of.RelocKind` to this
+#                       arch's ELF machine relocation type number (cast back to the
+#                       ELF writer's `ElfRelocTypeFn`); returns 0 (R_*_NONE) for a
+#                       kind the arch has no width-correct ELF type for. the ELF
+#                       object writer reads it instead of branching on the arch id,
+#                       the relocation analogue of `elf_machine`. nil when the ISA
+#                       supplies no ELF relocation mapping, which the writer reports
+#                       as unsupported exactly as a nil `apply_reloc`
 # reserved_regs:        registers the allocator must never assign (stack/frame
 #                       pointers); owned by the per-arch impl for the process
 #                       lifetime
@@ -408,6 +416,7 @@ pub rec IsaVTable {
     emit_asm:             *u8;
     asm_clobbers:         *u8;
     apply_reloc:          *u8;
+    elf_reloc_type:       *u8;
     reserved_regs:        *Register;
     reserved_reg_count:   i32;
     reload_scratch_regs:  *Register;

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -20,6 +20,8 @@ use mach.lang.target.isa.arm64.isel;
 # the printer is imported only to keep its stub in the build graph and
 # type-checked: `emit_asm` is nil until a later phase wires it to `print_asm_arm64`.
 use mach.lang.target.isa.arm64.printer;
+use mach.lang.target.of;
+use mach.lang.target.of.elf;
 
 # process-global storage for the AArch64 vtable and its register classes. written
 # once by `register_arm64` and borrowed by the vtable installed into the ISA
@@ -49,6 +51,33 @@ var arm64_reserved_regs: [3]isa.Register;
 # two-register lowering sequences. borrowed by the vtable's `reload_scratch_regs`
 # field; lives for the process lifetime. filled by `register_arm64`.
 var arm64_reload_scratch_regs: [3]isa.Register;
+
+# map an abstract relocation kind to its aarch64 ELF machine relocation type
+#
+# The forward half of the aarch64 ELF relocation seam: the ELF object writer reads
+# it through `IsaVTable.elf_reloc_type` instead of branching on the arch id, so
+# aarch64 owns its own R_AARCH64_* numbers (drawn from the ELF format module, the
+# single source the reverse parse map shares). Each per-width LDST kind maps to a
+# distinct R_AARCH64_LDST*_ABS_LO12_NC so the linker recovers the access-size scale
+# from the kind alone (Option B). A kind aarch64 has no width-correct ELF type for
+# returns 0 (R_AARCH64_NONE), which the writer turns into the unsupported-kind
+# error.
+# ---
+# kind: the abstract relocation kind to map
+# ret:  the aarch64 ELF reloc type, or 0 when aarch64 has none for this kind
+fun arm64_elf_reloc_type(kind: of.RelocKind) u32 {
+    if (kind == of.RK_ABS64)        { ret elf.R_AARCH64_ABS64; }
+    if (kind == of.RK_PC32)         { ret elf.R_AARCH64_PREL32; }
+    if (kind == of.RK_PLT32)        { ret elf.R_AARCH64_CALL26; }
+    if (kind == of.RK_PAGE21)       { ret elf.R_AARCH64_ADR_PREL_PG_HI21; }
+    if (kind == of.RK_ADD_LO12)     { ret elf.R_AARCH64_ADD_ABS_LO12_NC; }
+    if (kind == of.RK_LDST8_LO12)   { ret elf.R_AARCH64_LDST8_ABS_LO12_NC; }
+    if (kind == of.RK_LDST16_LO12)  { ret elf.R_AARCH64_LDST16_ABS_LO12_NC; }
+    if (kind == of.RK_LDST32_LO12)  { ret elf.R_AARCH64_LDST32_ABS_LO12_NC; }
+    if (kind == of.RK_LDST64_LO12)  { ret elf.R_AARCH64_LDST64_ABS_LO12_NC; }
+    if (kind == of.RK_LDST128_LO12) { ret elf.R_AARCH64_LDST128_ABS_LO12_NC; }
+    ret 0;
+}
 
 # build and install the AArch64 ISA vtable
 #
@@ -114,6 +143,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_vtable.id                   = isa.ARCH_AARCH64;
     arm64_vtable.name                 = "aarch64";
     arm64_vtable.elf_machine          = 183;  # EM_AARCH64
+    arm64_vtable.elf_reloc_type       = arm64_elf_reloc_type::*u8;
     arm64_vtable.pointer_width        = 8;
     arm64_vtable.reg_classes          = ?arm64_classes[0];
     arm64_vtable.reg_class_count      = 3;
@@ -188,4 +218,27 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     isa.register(reg, ?arm64_vtable);
 
     ret R.ok[bool, str](true);
+}
+
+# the aarch64 forward reloc map produces the right R_AARCH64_* number for each kind
+# it supports, including a distinct LDST type per access width (Option B), and 0
+# (R_AARCH64_NONE) for a kind it has no width-correct ELF type for (RK_GOTPCREL /
+# RK_ABS32S / RK_ADDR32NB are not aarch64's).
+test "mach.lang.target.isa.arm64.register.arm64_elf_reloc_type:forward_map" {
+    if (arm64_elf_reloc_type(of.RK_ABS64)        != elf.R_AARCH64_ABS64)               { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_PC32)         != elf.R_AARCH64_PREL32)              { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_PLT32)        != elf.R_AARCH64_CALL26)              { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_PAGE21)       != elf.R_AARCH64_ADR_PREL_PG_HI21)    { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_ADD_LO12)     != elf.R_AARCH64_ADD_ABS_LO12_NC)     { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_LDST8_LO12)   != elf.R_AARCH64_LDST8_ABS_LO12_NC)   { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_LDST16_LO12)  != elf.R_AARCH64_LDST16_ABS_LO12_NC)  { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_LDST32_LO12)  != elf.R_AARCH64_LDST32_ABS_LO12_NC)  { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_LDST64_LO12)  != elf.R_AARCH64_LDST64_ABS_LO12_NC)  { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_LDST128_LO12) != elf.R_AARCH64_LDST128_ABS_LO12_NC) { ret 1; }
+
+    # a kind aarch64 has no ELF type for maps to 0, the writer's unsupported signal.
+    if (arm64_elf_reloc_type(of.RK_GOTPCREL) != 0) { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_ABS32S)   != 0) { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_ADDR32NB) != 0) { ret 1; }
+    ret 0;
 }

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -18,6 +18,8 @@ use mach.lang.target.isa.x64;
 use mach.lang.target.isa.x64.encode;
 use mach.lang.target.isa.x64.isel;
 use mach.lang.target.isa.x64.printer;
+use mach.lang.target.of;
+use mach.lang.target.of.elf;
 
 # process-global storage for the x86-64 vtable and its register classes. written
 # once by `register_x64` and referenced (borrowed) by the vtable installed into
@@ -53,6 +55,26 @@ var x64_reserved_regs: [2]isa.Register;
 # by the `reload_scratch_regs` field of the installed vtable; lives for the
 # process lifetime. filled by `register_x64`.
 var x64_reload_scratch_regs: [3]isa.Register;
+
+# map an abstract relocation kind to its x86_64 ELF machine relocation type
+#
+# The forward half of the x86_64 ELF relocation seam: the ELF object writer reads
+# it through `IsaVTable.elf_reloc_type` instead of branching on the arch id, so
+# x86_64 owns its own R_X86_64_* numbers (drawn from the ELF format module, the
+# single source the reverse parse map shares). A kind x86_64 has no width-correct
+# ELF type for returns 0 (R_X86_64_NONE, never a real emitted relocation), which
+# the writer turns into the unsupported-kind error.
+# ---
+# kind: the abstract relocation kind to map
+# ret:  the x86_64 ELF reloc type, or 0 when x86_64 has none for this kind
+fun x64_elf_reloc_type(kind: of.RelocKind) u32 {
+    if (kind == of.RK_ABS64)    { ret elf.R_X86_64_64; }
+    if (kind == of.RK_PC32)     { ret elf.R_X86_64_PC32; }
+    if (kind == of.RK_PLT32)    { ret elf.R_X86_64_PLT32; }
+    if (kind == of.RK_GOTPCREL) { ret elf.R_X86_64_GOTPCREL; }
+    if (kind == of.RK_ABS32S)   { ret elf.R_X86_64_32S; }
+    ret 0;
+}
 
 # build and install the x86-64 ISA vtable
 #
@@ -115,6 +137,7 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_vtable.id                   = isa.ARCH_X86_64;
     x64_vtable.name                 = "x86_64";
     x64_vtable.elf_machine          = 62;  # EM_X86_64
+    x64_vtable.elf_reloc_type       = x64_elf_reloc_type::*u8;
     x64_vtable.pointer_width        = 8;
     x64_vtable.reg_classes          = ?x64_classes[0];
     x64_vtable.reg_class_count      = 3;
@@ -181,4 +204,20 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     isa.register(reg, ?x64_vtable);
 
     ret R.ok[bool, str](true);
+}
+
+# the x86_64 forward reloc map produces the right R_X86_64_* number for each kind
+# it supports, and 0 (R_X86_64_NONE) for a kind it has no width-correct ELF type
+# for (RK_ADDR32NB is COFF-only; the aarch64 page/lo12 kinds are not x86_64's).
+test "mach.lang.target.isa.x64.register.x64_elf_reloc_type:forward_map" {
+    if (x64_elf_reloc_type(of.RK_ABS64)    != elf.R_X86_64_64)       { ret 1; }
+    if (x64_elf_reloc_type(of.RK_PC32)     != elf.R_X86_64_PC32)     { ret 1; }
+    if (x64_elf_reloc_type(of.RK_PLT32)    != elf.R_X86_64_PLT32)    { ret 1; }
+    if (x64_elf_reloc_type(of.RK_GOTPCREL) != elf.R_X86_64_GOTPCREL) { ret 1; }
+    if (x64_elf_reloc_type(of.RK_ABS32S)   != elf.R_X86_64_32S)      { ret 1; }
+
+    # a kind x86_64 has no ELF type for maps to 0, the writer's unsupported signal.
+    if (x64_elf_reloc_type(of.RK_ADDR32NB) != 0) { ret 1; }
+    if (x64_elf_reloc_type(of.RK_PAGE21)   != 0) { ret 1; }
+    ret 0;
 }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -11,9 +11,12 @@
 # that the linker drives.
 #
 # The abstract `of.RK_*` relocation kinds are a closed enum; the writer maps a
-# `Relocation.kind` to the machine relocation type for the ISA it is handed with
-# a plain integer compare (`ARCH_X86_64` -> R_X86_64_*; `ARCH_AARCH64` ->
-# R_AARCH64_*), no interner involved.
+# `Relocation.kind` to the machine relocation type by calling the target ISA's
+# `elf_reloc_type` hook (the relocation analogue of `elf_machine`), so a new arch
+# plugs its R_<arch>_* numbers in through the vtable and the writer never branches
+# on the arch id. The ELFCLASS (64/32) is likewise derived from the ISA's pointer
+# width, not the arch id. The reverse parse map (`reloc_kind_for`) keeps the union
+# of every known arch's R_* numbers, since the parser is handed no ISA.
 #
 # Section/symbol names are `intern.StrId`, so the writer resolves them through the
 # interner each `of.ObjectImage` carries beside its allocator; the parser and the
@@ -41,6 +44,7 @@ use mach.lang.target.of;
 use mach.lang.target.of.bin;
 
 # ELF identification bytes.
+val ELFCLASS32:    u8 = 1;
 val ELFCLASS64:    u8 = 2;
 val ELFDATA2LSB:   u8 = 1;
 val EV_CURRENT:    u8 = 1;
@@ -70,24 +74,27 @@ val STT_NOTYPE:  u8 = 0;
 val STT_OBJECT:  u8 = 1;
 val STT_FUNC:    u8 = 2;
 
-# x86_64 relocation types.
-val R_X86_64_64:       u32 = 1;
-val R_X86_64_PC32:     u32 = 2;
-val R_X86_64_PLT32:    u32 = 4;
-val R_X86_64_GOTPCREL: u32 = 9;
-val R_X86_64_32S:      u32 = 11;
+# x86_64 relocation types. pub so the per-arch `elf_reloc_type` forward map (which
+# lives with the x86_64 ISA, target/isa may depend on target/of) and the reverse
+# parse map here share one definition of each number.
+pub val R_X86_64_64:       u32 = 1;
+pub val R_X86_64_PC32:     u32 = 2;
+pub val R_X86_64_PLT32:    u32 = 4;
+pub val R_X86_64_GOTPCREL: u32 = 9;
+pub val R_X86_64_32S:      u32 = 11;
 
-# aarch64 relocation types.
-val R_AARCH64_ABS64:               u32 = 257;
-val R_AARCH64_PREL32:              u32 = 261;
-val R_AARCH64_CALL26:              u32 = 283;
-val R_AARCH64_ADR_PREL_PG_HI21:    u32 = 275;
-val R_AARCH64_ADD_ABS_LO12_NC:     u32 = 277;
-val R_AARCH64_LDST8_ABS_LO12_NC:   u32 = 278;
-val R_AARCH64_LDST16_ABS_LO12_NC:  u32 = 284;
-val R_AARCH64_LDST32_ABS_LO12_NC:  u32 = 285;
-val R_AARCH64_LDST64_ABS_LO12_NC:  u32 = 286;
-val R_AARCH64_LDST128_ABS_LO12_NC: u32 = 299;
+# aarch64 relocation types. pub for the aarch64 `elf_reloc_type` forward map, as
+# with the x86_64 numbers above.
+pub val R_AARCH64_ABS64:               u32 = 257;
+pub val R_AARCH64_PREL32:              u32 = 261;
+pub val R_AARCH64_CALL26:              u32 = 283;
+pub val R_AARCH64_ADR_PREL_PG_HI21:    u32 = 275;
+pub val R_AARCH64_ADD_ABS_LO12_NC:     u32 = 277;
+pub val R_AARCH64_LDST8_ABS_LO12_NC:   u32 = 278;
+pub val R_AARCH64_LDST16_ABS_LO12_NC:  u32 = 284;
+pub val R_AARCH64_LDST32_ABS_LO12_NC:  u32 = 285;
+pub val R_AARCH64_LDST64_ABS_LO12_NC:  u32 = 286;
+pub val R_AARCH64_LDST128_ABS_LO12_NC: u32 = 299;
 
 # ELF program header types and flags.
 val PT_LOAD:    u32 = 1;
@@ -151,38 +158,42 @@ fun resolve(itn: *intern.Interner, id: intern.StrId) str {
     ret nil;
 }
 
+# the concrete signature the erased `isa.IsaVTable.elf_reloc_type` pointer is cast
+# back to before it is called
+#
+# The vtable stores `elf_reloc_type` type-erased (`*u8`) for the same import-cycle
+# reason as `apply_reloc`: its body names `of.RelocKind`, and `of` imports `isa`,
+# so a typed slot on the isa-layer vtable would invert the dependency. Each arch
+# owns the complete forward map of its abstract kinds to ELF machine relocation
+# type numbers through this one hook; an arch with no width-correct ELF type for a
+# kind returns 0 (R_*_NONE, never a real emitted relocation), which the writer
+# turns into the "unsupported kind" error so the per-arch bodies stay pure number
+# maps with no interner or allocator.
+# ---
+# kind: the abstract relocation kind to map
+# ret:  the arch's ELF machine relocation type, or 0 when it has none for this kind
+pub def ElfRelocTypeFn: fun(of.RelocKind) u32;
+
 # map an abstract relocation kind to the ELF machine relocation type for an ISA
 #
-# An unmapped kind is an error naming the kind, never silently serialized as the
-# 64-bit absolute type (an 8-byte write over a 4-byte field). A kind the format
-# has no width-correct machine type for must fail the emit, not corrupt the
-# object.
+# Dispatches through the target ISA's `elf_reloc_type` hook, so the writer never
+# branches on the arch id. An unmapped kind (the hook returns 0) is an error naming
+# the kind, never silently serialized as the 64-bit absolute type (an 8-byte write
+# over a 4-byte field). A nil hook (an ISA that wired no ELF relocation map) is the
+# same unsupported error the linker reports for a nil `apply_reloc`.
 # ---
 # itn:     interner backing the error string
 # alloc:   allocator backing the error string
 # kind:    the abstract relocation kind to map
-# arch_id: the target ISA id selecting the machine relocation namespace
+# tgt_isa: the target ISA vtable supplying the per-arch forward map
 # ret:     ok(machine reloc type), or an error naming the unmapped kind
-fun reloc_type_for(itn: *intern.Interner, alloc: *A.Allocator, kind: of.RelocKind, arch_id: u32) R.Result[u32, str] {
-    if (arch_id == isa.ARCH_AARCH64) {
-        if (kind == of.RK_ABS64)        { ret R.ok[u32, str](R_AARCH64_ABS64); }
-        if (kind == of.RK_PC32)         { ret R.ok[u32, str](R_AARCH64_PREL32); }
-        if (kind == of.RK_PLT32)        { ret R.ok[u32, str](R_AARCH64_CALL26); }
-        if (kind == of.RK_PAGE21)       { ret R.ok[u32, str](R_AARCH64_ADR_PREL_PG_HI21); }
-        if (kind == of.RK_ADD_LO12)     { ret R.ok[u32, str](R_AARCH64_ADD_ABS_LO12_NC); }
-        if (kind == of.RK_LDST8_LO12)   { ret R.ok[u32, str](R_AARCH64_LDST8_ABS_LO12_NC); }
-        if (kind == of.RK_LDST16_LO12)  { ret R.ok[u32, str](R_AARCH64_LDST16_ABS_LO12_NC); }
-        if (kind == of.RK_LDST32_LO12)  { ret R.ok[u32, str](R_AARCH64_LDST32_ABS_LO12_NC); }
-        if (kind == of.RK_LDST64_LO12)  { ret R.ok[u32, str](R_AARCH64_LDST64_ABS_LO12_NC); }
-        if (kind == of.RK_LDST128_LO12) { ret R.ok[u32, str](R_AARCH64_LDST128_ABS_LO12_NC); }
+fun reloc_type_for(itn: *intern.Interner, alloc: *A.Allocator, kind: of.RelocKind, tgt_isa: *isa.IsaVTable) R.Result[u32, str] {
+    if (tgt_isa.elf_reloc_type == nil) {
         ret R.err[u32, str](unsupported_kind_message(itn, alloc, kind));
     }
-    if (kind == of.RK_ABS64)    { ret R.ok[u32, str](R_X86_64_64); }
-    if (kind == of.RK_PC32)     { ret R.ok[u32, str](R_X86_64_PC32); }
-    if (kind == of.RK_PLT32)    { ret R.ok[u32, str](R_X86_64_PLT32); }
-    if (kind == of.RK_GOTPCREL) { ret R.ok[u32, str](R_X86_64_GOTPCREL); }
-    if (kind == of.RK_ABS32S)   { ret R.ok[u32, str](R_X86_64_32S); }
-    ret R.err[u32, str](unsupported_kind_message(itn, alloc, kind));
+    val t: u32 = tgt_isa.elf_reloc_type::ElfRelocTypeFn(kind);
+    if (t == 0) { ret R.err[u32, str](unsupported_kind_message(itn, alloc, kind)); }
+    ret R.ok[u32, str](t);
 }
 
 # map an ELF machine relocation type back to its abstract RK_* kind
@@ -242,16 +253,28 @@ fun unsupported_type_message(itn: *intern.Interner, alloc: *A.Allocator, r_type:
 # cleanup. An unmapped kind fails the emit naming the kind.
 # ---
 # img:     the object image whose relocations are checked
-# arch_id: the target ISA id selecting the machine relocation namespace
+# tgt_isa: the target ISA vtable supplying the per-arch forward map
 # ret:     ok(true) when every kind maps, or the first mapping error
-fun validate_reloc_kinds(img: *of.ObjectImage, arch_id: u32) R.Result[bool, str] {
+fun validate_reloc_kinds(img: *of.ObjectImage, tgt_isa: *isa.IsaVTable) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < img.reloc_count) {
-        val r: R.Result[u32, str] = reloc_type_for(img.interner, img.alloc, img.relocations[i].kind, arch_id);
+        val r: R.Result[u32, str] = reloc_type_for(img.interner, img.alloc, img.relocations[i].kind, tgt_isa);
         if (R.is_err[u32, str](r)) { ret R.err[bool, str](R.unwrap_err[u32, str](r)); }
         i = i + 1;
     }
     ret R.ok[bool, str](true);
+}
+
+# the ELFCLASS for a target, derived from its pointer width: an 8-byte pointer is
+# ELFCLASS64, a 4-byte pointer ELFCLASS32. the writer reads this instead of
+# branching on the arch id, so the class follows the substrate the same way
+# `e_machine` follows `elf_machine`.
+# ---
+# tgt_isa: the target ISA vtable carrying the pointer width
+# ret:     ELFCLASS32 for a 4-byte pointer, ELFCLASS64 otherwise
+fun elf_class_for(tgt_isa: *isa.IsaVTable) u8 {
+    if (tgt_isa.pointer_width == 4) { ret ELFCLASS32; }
+    ret ELFCLASS64;
 }
 
 # the ELF section type for an abstract section kind
@@ -449,7 +472,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R.Resu
     # map every relocation kind to a machine type up front too, so an unmapped
     # kind fails the emit naming the kind instead of being silently serialized as
     # a 64-bit absolute over a 4-byte field.
-    val vrk: R.Result[bool, str] = validate_reloc_kinds(img, tgt_isa.id);
+    val vrk: R.Result[bool, str] = validate_reloc_kinds(img, tgt_isa);
     if (R.is_err[bool, str](vrk)) { ret R.err[bool, str](R.unwrap_err[bool, str](vrk)); }
 
     val num_secs:      u32 = img.section_count;
@@ -587,7 +610,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R.Resu
     var buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
 
     buf[0] = 0x7F; buf[1] = 0x45; buf[2] = 0x4C; buf[3] = 0x46;
-    buf[4] = ELFCLASS64;
+    buf[4] = elf_class_for(tgt_isa);
     buf[5] = ELFDATA2LSB;
     buf[6] = EV_CURRENT;
     buf[7] = ELFOSABI_NONE;
@@ -689,7 +712,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R.Resu
                     val elf_sym: u64 = sym_remap[rsi]::u64;
                     # validate_reloc_kinds proved every kind maps, so the lookup
                     # cannot miss; index 0 / abs64 is never silently substituted.
-                    val elf_type: u32 = R.unwrap_ok[u32, str](reloc_type_for(img.interner, alloc, img.relocations[ri].kind, tgt_isa.id));
+                    val elf_type: u32 = R.unwrap_ok[u32, str](reloc_type_for(img.interner, alloc, img.relocations[ri].kind, tgt_isa));
                     val r_info: u64 = (elf_sym << 32) | elf_type::u64;
                     bin.write_u64_le(buf, ro + 8, r_info);
                     bin.write_u64_le(buf, ro + 16, img.relocations[ri].addend::u64);
@@ -920,7 +943,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     var buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
 
     buf[0] = 0x7F; buf[1] = 0x45; buf[2] = 0x4C; buf[3] = 0x46;
-    buf[4] = ELFCLASS64;
+    buf[4] = elf_class_for(tgt_isa);
     buf[5] = ELFDATA2LSB;
     buf[6] = EV_CURRENT;
     buf[7] = ELFOSABI_NONE;
@@ -1167,7 +1190,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     # loads an ET_EXEC carrying PT_INTERP/PT_DYNAMIC as a classic non-PIE dynamic
     # binary and still resolves the PLT.
     buf[0] = 0x7F; buf[1] = 0x45; buf[2] = 0x4C; buf[3] = 0x46;
-    buf[4] = ELFCLASS64; buf[5] = ELFDATA2LSB; buf[6] = EV_CURRENT; buf[7] = ELFOSABI_NONE;
+    buf[4] = elf_class_for(tgt_isa); buf[5] = ELFDATA2LSB; buf[6] = EV_CURRENT; buf[7] = ELFOSABI_NONE;
     bin.write_u16_le(buf, 16, ET_EXEC);
     bin.write_u16_le(buf, 18, tgt_isa.elf_machine::u16);
     bin.write_u32_le(buf, 20, 1);
@@ -2113,6 +2136,23 @@ fun t_intern(itn: *intern.Interner, s: str) intern.StrId {
     ret R.unwrap_ok[intern.StrId, str](r);
 }
 
+# a test-only x86_64 forward reloc map, wired onto a test `IsaVTable.elf_reloc_type`
+# so the writer tests can emit real x86_64 relocations. it mirrors the production
+# map in target/isa/x64/register.mach, duplicated here because of/elf cannot import
+# that arch module (the arch wires its hook through of/elf, so the reverse import
+# would close a cycle). the production map is tested where it lives.
+# ---
+# kind: the abstract relocation kind to map
+# ret:  the x86_64 ELF reloc type, or 0 for a kind it has none for
+fun t_x64_elf_reloc_type(kind: of.RelocKind) u32 {
+    if (kind == of.RK_ABS64)    { ret R_X86_64_64; }
+    if (kind == of.RK_PC32)     { ret R_X86_64_PC32; }
+    if (kind == of.RK_PLT32)    { ret R_X86_64_PLT32; }
+    if (kind == of.RK_GOTPCREL) { ret R_X86_64_GOTPCREL; }
+    if (kind == of.RK_ABS32S)   { ret R_X86_64_32S; }
+    ret 0;
+}
+
 # emit_object must reject a relocation naming a symbol absent from the image
 # symbol table (a back-end invariant violation, #1196) rather than silently
 # aliasing the reserved undefined entry (index 0).
@@ -2128,6 +2168,7 @@ test "mach.lang.target.of.elf.emit_object:unresolved_symbol" {
 
     var isa_vt: isa.IsaVTable;
     isa_vt.id = isa.ARCH_X86_64;
+    isa_vt.elf_reloc_type = t_x64_elf_reloc_type::*u8;
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -2185,6 +2226,7 @@ test "mach.lang.target.of.elf.emit_object:unmapped_reloc_kind" {
 
     var isa_vt: isa.IsaVTable;
     isa_vt.id = isa.ARCH_X86_64;
+    isa_vt.elf_reloc_type = t_x64_elf_reloc_type::*u8;
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -2227,11 +2269,12 @@ test "mach.lang.target.of.elf.emit_object:unmapped_reloc_kind" {
     ret 0;
 }
 
-# the aarch64 page/page-offset reloc kinds (#1163) map 1:1 to their R_AARCH64
-# machine types and back; each per-width LDST kind maps to a distinct
-# R_AARCH64_LDST*_ABS_LO12_NC so the linker recovers the access-size scale from the
-# kind alone (Option B).
-test "mach.lang.target.of.elf.reloc_type_for:aarch64_page_lo12_roundtrip" {
+# the aarch64 page/page-offset reloc kinds (#1163) map back from their R_AARCH64
+# machine types 1:1; each per-width LDST type recovers a distinct kind so the
+# linker reads the access-size scale from the kind alone (Option B). this covers
+# the reverse parse map (`reloc_kind_for`); the forward map now lives with the
+# aarch64 ISA and is tested in target/isa/arm64/register.mach.
+test "mach.lang.target.of.elf.reloc_kind_for:aarch64_page_lo12_reverse" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
@@ -2250,10 +2293,6 @@ test "mach.lang.target.of.elf.reloc_type_for:aarch64_page_lo12_roundtrip" {
 
     var n: usize = 0;
     for (n < 7) {
-        val tr: R.Result[u32, str] = reloc_type_for(?i, ?alloc, kinds[n], isa.ARCH_AARCH64);
-        if (R.is_err[u32, str](tr))                 { ret 1; }
-        if (R.unwrap_ok[u32, str](tr) != expect[n]) { ret 1; }
-
         val kr: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, expect[n]);
         if (R.is_err[of.RelocKind, str](kr))                { ret 1; }
         if (R.unwrap_ok[of.RelocKind, str](kr) != kinds[n]) { ret 1; }
@@ -2276,6 +2315,7 @@ test "mach.lang.target.of.elf.parse_object:unknown_reloc_type" {
 
     var isa_vt: isa.IsaVTable;
     isa_vt.id = isa.ARCH_X86_64;
+    isa_vt.elf_reloc_type = t_x64_elf_reloc_type::*u8;
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -2350,6 +2390,7 @@ test "mach.lang.target.of.elf.parse_object:truncated" {
 
     var isa_vt: isa.IsaVTable;
     isa_vt.id = isa.ARCH_X86_64;
+    isa_vt.elf_reloc_type = t_x64_elf_reloc_type::*u8;
 
     var text_bytes: [16]u8;
     var k: usize = 0;


### PR DESCRIPTION
Widens the retargeting seam so a new register-machine ISA needs no edit to the shared ELF writer for relocations or the ELF class. Refs #1625.

## Problem
`of/elf.mach` mapped an abstract `RelocKind` to its ELF machine reloc type by branching on `arch_id` (`ARCH_X86_64` -> `R_X86_64_*`; `ARCH_AARCH64` -> `R_AARCH64_*`), and hardcoded `ELFCLASS64`. Adding an ISA meant editing the shared writer.

## arch_id branches removed from of/elf.mach (relocation + header path)
- `reloc_type_for(kind, arch_id)`: the whole `if (arch_id == ARCH_AARCH64) { ...aarch64 types... } else { ...x86 types... }` block. It now takes the `*IsaVTable` and dispatches through the new `elf_reloc_type` hook; no arch compare remains.
- `validate_reloc_kinds` and the `emit_object` reloc-write site: pass `tgt_isa` instead of `tgt_isa.id`.
- ELFCLASS: the three `buf[4] = ELFCLASS64;` sites (emit_object, emit_exec, emit_dyn_exec) now read `elf_class_for(tgt_isa)`.

After this, `of/elf.mach` has no `arch_id` branch in the relocation/header path.

## The new hook + class derivation
- `IsaVTable.elf_reloc_type`: an erased `*u8` fn ptr (cast back to `ElfRelocTypeFn: fun(of.RelocKind) u32`), the relocation analogue of `elf_machine`. Returns 0 (`R_*_NONE`, never a real emitted reloc) for a kind the arch has no width-correct ELF type for; the writer turns 0 (and a nil hook) into the existing "unsupported relocation kind" error, exactly as the linker treats a nil `apply_reloc`. The per-arch bodies stay pure number maps (no interner/alloc).
- `x64_elf_reloc_type` / `arm64_elf_reloc_type` live with their arch (`target/isa/<arch>/register.mach`, wired in `register_x64`/`register_arm64` beside `elf_machine`). They draw the `R_*` numbers from the ELF format module (now `pub`), so the reverse parse map (`reloc_kind_for`) and the forward maps share one definition. Import direction stays clean: `target/isa` -> `target/of` only (never `be/`/`me/`).
- `elf_class_for` derives ELFCLASS from `pointer_width` (8 -> ELFCLASS64, 4 -> ELFCLASS32). No new field; `pointer_width` already carries it.

## apply_reloc registrar assessment (secondary)
Left `be/linker.mach` unchanged. `register_reloc_hooks` is already the intended clean registrar: one `if str_equals(name) { vt.apply_reloc = ... }` entry per arch, and the packing bodies (`x64_apply_reloc`/`arm64_apply_reloc`) and the `apply_one` dispatcher carry no `arch_id` branches. Reloc packers live in `be/` because `target/` cannot depend on `be/`, so this stays a one-line be-layer registration per arch by design. (`elf_reloc_type` needs only `of/`, so it is wired directly in the target-layer register fn, no be/ registrar.)

## Behavior preservation
x86_64/aarch64 emit the identical reloc numbers and ELFCLASS64 (pointer_width 8). Verified:
- Self-host fixpoint byte-identical: `mach build . -o a`, `a build . -o b`, `b build . -o c`, `cmp -s b c` -> b == c.
- `mach test .`: 622 passed, 0 failed (added per-arch `*_elf_reloc_type:forward_map` tests; the of/elf aarch64 roundtrip test is split into a reverse-map test here + the forward test in `arm64/register.mach`).

## Residual shared-backend surface for a new ISA (relocations)
- ELF forward map + class: zero edits to `of/elf.mach`. The arch adds its `<arch>_elf_reloc_type` in its own register module and wires the hook (and its `R_<arch>_*` numbers).
- `be/linker.mach`: one `register_reloc_hooks` registrar line + its `apply_reloc` packer (by design; packers are be-layer).
- `of/elf.mach` reverse parse map (`reloc_kind_for`) still needs the arch's `R_*` numbers added, because `parse_object` is handed no ISA. Widening it would change the `OfVTable` parser signature across every format - out of scope here.
- The x86_64-only dynamic PLT path (`jump_slot_for`, gated by `tgt_isa.id != ARCH_X86_64`) keeps its arch numbers; widening it needs per-arch PLT stub encoders - out of scope.

riscv64 leaves `elf_reloc_type` nil (zero-default); its real reloc support lands in slice 4 (#1628). No riscv64 files touched.