### PR TITLE
feat(target): riscv64 instruction selection + lp64d completion (slice 3)

### DIFF
--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -342,9 +342,9 @@ test "mach.lang.target.select:linux_aarch64" {
 
 # selecting a Linux/RISC-V (RV64) target composes the machine description: the
 # riscv64 ISA vtable (EM_RISCV, 64-bit, gpr + fpr banks, no flags bank) and the
-# lp64d ABI vtable resolve and bind. as of slice 2 the byte encoder is wired while
-# the selector stays nil - composition stays clean and only an attempt to select
-# instructions would fail loudly. this asserts the description + encoder wiring.
+# lp64d ABI vtable resolve and bind. as of slice 3 the instruction selector and the
+# byte encoder are both wired - composition stays clean and the riscv64 codegen path
+# selects and encodes. this asserts the description + selector + encoder wiring.
 test "mach.lang.target.select:linux_riscv64" {
     var reg: TargetRegistry = registry_init();
     val res_reg: R.Result[bool, str] = register_all(?reg);
@@ -361,9 +361,9 @@ test "mach.lang.target.select:linux_riscv64" {
     # the pointer-width fields are in bytes: 8 bytes = 64-bit.
     if (t.arch.pointer_width != 8)     { ret 1; }
 
-    # slice 2 wires the byte encoder; the selector stays nil until slice 3, so the
-    # shared isel dispatcher errors loudly if reached while composition stays clean.
-    if (t.arch.select != nil) { ret 1; }
+    # slice 3 wires the instruction selector alongside the byte encoder, so the
+    # riscv64 codegen path both selects and encodes.
+    if (t.arch.select == nil) { ret 1; }
     if (t.arch.encode == nil) { ret 1; }
 
     # the machine model carries the RV64 widths and exactly the gpr + fpr banks: no

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -22,13 +22,26 @@
 # argument slot, so `indirect_result_in_argfile` is true -- the lp64 layout the
 # RISC-V psABI mandates.
 #
-# DEFERRED (later ABI-completion slice): the RISC-V hard-float struct-flattening
-# rules that place a struct of one or two floating-point members (or one float plus
-# one integer) in fa / fa+a registers, and the boundary rule that splits a 9-16
-# byte aggregate across the last integer register and the stack. Slice 1 classifies
-# such aggregates conservatively through the integer-register path, which is the
-# soft-float-correct placement but not the full lp64d hard-float layout. The vtable
-# shape, register banks, and scalar / large-aggregate placement are complete.
+# HARD-FLOAT FLATTENING: a struct that flattens to one or two floating-point members
+# (recursively, through nested structs / arrays of a single fundamental float width)
+# is passed / returned in the fa registers, one member per register at its field
+# offset - the lp64d wrapped-scalar and float-pair rules. The shared
+# `classify_signature` computes the homogeneous-float descriptor and hands it here;
+# the placement reuses the shared CLASS_HFA register-run machinery. When the fa bank
+# lacks the register(s), lp64d falls back to the integer convention.
+#
+# DEFERRED (needs a shared `emit_arg_slot` capability the back end does not yet
+# expose, so it is escalated rather than papered over): the mixed float-plus-integer
+# struct rule (one fa + one a register, each from its own field offset), the
+# different-fundamental-width float pair (an fa run with a per-member width), and the
+# boundary rule that splits a 9-16 byte integer aggregate across the last integer
+# register and the stack. None of the three has a slot the shared caller / callee /
+# return lowering can materialize (CLASS_HFA is uniform-width FP-only, the reg2 pair
+# is GP-only from fixed 0 / 8 offsets, and there is no register-plus-stack split
+# class). Each such aggregate stays on the conservative integer / by-value-stack path
+# - self-consistent across a mach caller and callee, divergent from the C psABI only
+# at an FFI boundary. The vtable shape, register banks, scalar / large-aggregate
+# placement, and the homogeneous-float flattening are complete.
 #
 # The vtable's classify/arg/ret function pointers are type-erased (`*u8`); a
 # consumer casts each back to the neutral signature declared in `abi`.
@@ -112,8 +125,9 @@ pub fun fp_param_reg(index: i32) i32 {
 # is_aggregate:  true if the value is an aggregate
 # gp_used:       integer registers already consumed
 # fp_used:       float registers already consumed
-# hfa_members:   HFA member count (AAPCS64-only; unused under lp64d)
-# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under lp64d)
+# hfa_members:   homogeneous-float member count; 1 or 2 selects the lp64d hard-float
+#                flattening (0 or > 2 falls to the integer convention)
+# hfa_elem:      homogeneous-float fundamental member width (the per-fa-register width)
 # ret:           the placement decision
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
@@ -123,11 +137,13 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 
 # assign registers or a stack slot for one argument (lp64d)
 #
-# A non-HFA aggregate larger than 16 bytes is passed by hidden reference -- the
-# caller copies it to memory and passes the pointer in the next integer register
-# (CLASS_BYREF), or, once the integer bank is exhausted, on the stack
-# (CLASS_STACK_BYREF). An aggregate of <=8 bytes takes one integer register; a 9-16
-# byte one takes a consecutive integer register pair; either spills the whole
+# An aggregate larger than 16 bytes is passed by hidden reference -- the caller copies
+# it to memory and passes the pointer in the next integer register (CLASS_BYREF), or,
+# once the integer bank is exhausted, on the stack (CLASS_STACK_BYREF). An aggregate
+# that flattens to one or two floating-point members rides one fa register per member
+# (CLASS_HFA), falling back to the integer convention when the fa bank lacks the
+# register(s). An integer-class aggregate of <=8 bytes takes one integer register; a
+# 9-16 byte one takes a consecutive integer register pair; either spills the whole
 # aggregate by value when the integer bank lacks the register(s) it needs. A scalar
 # float takes the next fa register, falling back to an integer argument register
 # (the raw bits ride the GP reg) and then the stack once the fa bank is exhausted.
@@ -143,8 +159,9 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_aggregate:  true if the argument is an aggregate
 # gp_used:       integer registers already consumed
 # fp_used:       float registers already consumed
-# hfa_members:   HFA member count (AAPCS64-only; unused under lp64d)
-# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under lp64d)
+# hfa_members:   homogeneous-float member count; 1 or 2 selects the lp64d hard-float
+#                flattening (0 or > 2 falls to the integer convention)
+# hfa_elem:      homogeneous-float fundamental member width (the per-fa-register width)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
@@ -156,6 +173,20 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
         ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, 8);
     }
 
+    # RISC-V hard-float struct flattening: an aggregate that flattens to one or two
+    # floating-point members rides one fa register per member, one member loaded into
+    # each consecutive fa register at its field offset. one member is the wrapped-
+    # scalar case (a struct of a single float), two the float-pair case. an aggregate
+    # with three or more members, a non-float member, or a mixed fundamental width is
+    # not flattened (`hfa_members` is 0 or > 2) and falls to the integer convention
+    # below. when the fa bank lacks the register(s) the flattening needs, lp64d also
+    # falls back to the integer convention rather than splitting across banks.
+    if (is_aggregate && (hfa_members == 1 || hfa_members == 2)) {
+        if (fp_used + hfa_members::i32 <= FP_PARAM_COUNT) {
+            ret abi.make_slot_hfa(fp_param_reg(fp_used), hfa_members, hfa_elem, size);
+        }
+    }
+
     if (is_aggregate) {
         if (size <= 8) {
             if (gp_used < GP_PARAM_COUNT) {
@@ -164,7 +195,12 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
             ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
         }
         # 9-16 bytes: a consecutive integer pair, or spill by value if two integer
-        # registers do not remain.
+        # registers do not remain. DEFERRED: the psABI rule that splits a 9-16 byte
+        # aggregate across the last integer register and the stack when exactly one
+        # register remains needs a register/stack split slot the shared `emit_arg_slot`
+        # does not model; until that seam exists the whole aggregate is placed by value
+        # on the stack here (self-consistent across caller and callee, divergent from
+        # the C psABI only at an FFI boundary).
         if (gp_used + 2 <= GP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), gp_param_reg(gp_used + 1), 0, size);
         }
@@ -192,20 +228,22 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # assign registers or an sret pointer for a return value (lp64d)
 #
 # A zero-size (void) return yields CLASS_GP with reg=-1. A scalar returns in a0, or
-# fa0 for a float. A non-HFA aggregate of <=8 bytes returns in a0; a 9-16 byte one
-# returns in the a0:a1 pair. A non-HFA aggregate larger than 16 bytes is returned
-# through a hidden sret pointer: the caller passes the result-storage address in a0
-# and the callee returns it in a0 (CLASS_SRET, reg=a0). This classifier is
-# RISC-V-specific by selection -- the lp64 vtable is only composed for a riscv64
-# target.
+# fa0 for a float. An aggregate larger than 16 bytes is returned through a hidden
+# sret pointer: the caller passes the result-storage address in a0 and the callee
+# returns it in a0 (CLASS_SRET, reg=a0). An aggregate that flattens to one or two
+# floating-point members returns in the fa registers (CLASS_HFA, fa0 or fa0:fa1). An
+# integer-class aggregate of <=8 bytes returns in a0; a 9-16 byte one in the a0:a1
+# pair. This classifier is RISC-V-specific by selection -- the lp64 vtable is only
+# composed for a riscv64 target.
 # ---
 # size:          return-value size in bytes
 # align:         return-value alignment in bytes
 # is_float:      true if the value is a scalar float
 # fp_eightbytes: per-eightbyte SSE mask (unused -- lp64d routes scalars by is_float)
 # is_aggregate:  true if the value is an aggregate
-# hfa_members:   HFA member count (AAPCS64-only; unused under lp64d)
-# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under lp64d)
+# hfa_members:   homogeneous-float member count; 1 or 2 selects the lp64d hard-float
+#                flattening (0 or > 2 falls to the integer convention)
+# hfa_elem:      homogeneous-float fundamental member width (the per-fa-register width)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
                         is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
@@ -216,6 +254,13 @@ pub fun classify_return(size: u64, align: u64,
 
     if (is_aggregate && size > MAX_REG_RET) {
         ret abi.make_slot(abi.CLASS_SRET, REG_A0, -1, 0, 8);
+    }
+
+    # a struct that flattens to one or two floating-point members returns in the fa
+    # registers (fa0, or fa0:fa1), the return-side twin of the argument flattening.
+    # all eight fa registers are free at a return, so the run always fits.
+    if (is_aggregate && (hfa_members == 1 || hfa_members == 2)) {
+        ret abi.make_slot_hfa(fp_param_reg(0), hfa_members, hfa_elem, size);
     }
 
     if (is_aggregate) {
@@ -437,6 +482,39 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_placement" {
     ret 0;
 }
 
+# a struct that flattens to one or two floating-point members rides the fa registers
+# (CLASS_HFA), one member per register at its fundamental width; an fa bank without
+# the registers falls back to the integer convention
+test "mach.lang.target.abi.lp64.classify_arg:hard_float_struct_flattening" {
+    # a single-float struct (8 bytes, one f64 member) rides fa0.
+    val one: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 1, 8);
+    if (one.class     != abi.CLASS_HFA)    { ret 1; }
+    if (one.reg       != fp_param_reg(0))  { ret 1; }
+    if (one.reg_count != 1)                { ret 1; }
+    if (one.reg_width != 8)                { ret 1; }
+    # a two-float struct (two f32 members) rides fa0:fa1, each 4 bytes.
+    val two: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 2, 4);
+    if (two.class     != abi.CLASS_HFA)    { ret 1; }
+    if (two.reg       != fp_param_reg(0))  { ret 1; }
+    if (two.reg_count != 2)                { ret 1; }
+    if (two.reg_width != 4)                { ret 1; }
+    # the float bank advances independently of the integer bank: with six fa
+    # registers used, a two-float struct rides the last fa pair (fa6:fa7).
+    val mid: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 3, 6, 2, 8);
+    if (mid.class != abi.CLASS_HFA)        { ret 1; }
+    if (mid.reg   != fp_param_reg(6))      { ret 1; }
+    # the fa bank lacks two registers (seven used): the struct falls back to the
+    # integer convention (a 9-16 byte pair here), not a cross-bank split.
+    val fall: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 7, 2, 8);
+    if (fall.class != abi.CLASS_GP) { ret 1; }
+    if (fall.reg   != REG_A0)       { ret 1; }
+    if (fall.reg2  != REG_A1)       { ret 1; }
+    # a three-float struct is not flattened (hfa_members > 2): the integer convention.
+    val three: abi.ParamSlot = classify_arg(0, 16, 4, false, 0, true, 0, 0, 3, 4);
+    if (three.class != abi.CLASS_GP) { ret 1; }
+    ret 0;
+}
+
 # scalar and small-aggregate returns place a0 / fa0 / a0:a1, and a >16-byte
 # aggregate returns through the a0 sret pointer
 test "mach.lang.target.abi.lp64.classify_return:placement" {
@@ -450,6 +528,12 @@ test "mach.lang.target.abi.lp64.classify_return:placement" {
     if (a.reg != REG_A0 || a.reg2 != REG_A1) { ret 1; }
     val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0);
     if (r.class != abi.CLASS_SRET || r.reg != REG_A0) { ret 1; }
+    # a struct that flattens to two floats returns in the fa0:fa1 run.
+    val h: abi.ParamSlot = classify_return(16, 8, false, 0, true, 2, 8);
+    if (h.class     != abi.CLASS_HFA)   { ret 1; }
+    if (h.reg       != fp_param_reg(0)) { ret 1; }
+    if (h.reg_count != 2)               { ret 1; }
+    if (h.reg_width != 8)               { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/isa/riscv64.mach
+++ b/src/lang/target/isa/riscv64.mach
@@ -198,3 +198,11 @@ pub val MOV:    Opcode = 13;
 pub val JMP:    Opcode = 14;
 # breakpoint trap `ebreak`, the unreachable-terminator form
 pub val EBREAK: Opcode = 15;
+# float register move / cross-bank bit reinterpret (the F/D-extension `fmv` family).
+# the selector rewrites a float MIR_MOV and a GP<->FP `:~` bitcast to this opcode; the
+# encoder picks the concrete form from the operand register classes - `fmv.d`/`fmv.s`
+# (the `fsgnj` alias) for a float-to-float copy, `fmv.d.x`/`fmv.w.x` for a GP->FP
+# reinterpret, `fmv.x.d`/`fmv.x.w` for an FP->GP reinterpret, and the `fld`/`fsd` /
+# `ld`/`sd` spill forms. the precision (S vs D) rides the operand width, so this one
+# opcode covers both and an RV32 sibling reuses it unchanged.
+pub val FMV:    Opcode = 16;

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -12,18 +12,25 @@
 # lives in the shared `encode` module; this backend supplies only the RV64 bitfield
 # packers, prologue/epilogue emission, and branch patching.
 #
-# SCOPE (slice 2 of the riscv64 backend, #1626 / #1172): the R/I/S/B/U/J
-# instruction-format packers, the integer ALU (register and immediate), the shifts,
-# neg / not / mv, constant materialization (`li`), the width-driven loads / stores,
-# the alloca / gep address arithmetic, the integer compares, the unconditional /
-# conditional block branches with their pass-2 fixups, the direct / indirect call
-# (the direct call records an `RK_PLT32` marker), the prologue / epilogue, and the
-# `asm_clobbers` analyzer. The families DEFERRED to later slices fail loudly rather
-# than emit wrong bytes: instruction selection (slice 3) feeds this encoder, the
-# inline-asm assembler and the float / divide / conversion families arrive with
-# their slices, and the pc-relative GLOBAL-symbol relocations (`la` hi20/lo12) wait
-# on the linker / ELF relocation seam (slice 4), which owns the new abstract reloc
-# kinds RISC-V needs.
+# SCOPE: slice 2 (#1626) landed the R/I/S/B/U/J instruction-format packers, the
+# integer ALU (register and immediate), the shifts, neg / not / mv, constant
+# materialization (`li`), the width-driven loads / stores, the alloca / gep address
+# arithmetic, the integer compares, the unconditional / conditional block branches
+# with their pass-2 fixups, the direct / indirect call (the direct call records an
+# `RK_PLT32` marker), the prologue / epilogue, and the `asm_clobbers` analyzer.
+# Slice 3 (#1627) adds the families the instruction selector now drives: the
+# M-extension divide / remainder (`div` / `divu` / `rem` / `remu`, word forms at
+# 32-bit width, RISC-V's defined boundary results needing no guard), the integer
+# width / representation conversions (TRUNC via `sext.w`, SEXT / ZEXT via the shift
+# pairs / `andi`), the RV64D scalar float arithmetic / negate / comparison
+# (`fadd` / `fsub` / `fmul` / `fdiv`, `fsgnjn`, `feq` / `flt` / `fle`), the float
+# conversions (`fcvt` between S / D and to / from the integer file), the `fmv` float
+# move / cross-bank reinterpret, the float loads / stores (`flw` / `fld` / `fsw` /
+# `fsd`), and the callee-saved FP spill / reload. The families still DEFERRED fail
+# loudly rather than emit wrong bytes: the inline-asm assembler arrives with its
+# slice, and the pc-relative GLOBAL-symbol relocations (`la` hi20/lo12) wait on the
+# linker / ELF relocation seam (slice 4 / #1628), which owns the new abstract reloc
+# kinds RISC-V needs - the `resolve_mem` folded-global path still routes there.
 #
 # WIDTH-HONESTY: the 32-bit instruction-word format machinery (pack_r/i/s/b/u/j),
 # the register field positions, the immediate bit-scatter, and the branch / jump
@@ -104,6 +111,71 @@ val F7_MULDIV: u32 = 0x01;  # M extension
 # branch relation funct3: equal / not-equal and the signed / unsigned orderings.
 val F3_BEQ:  u32 = 0x0;
 val F3_BNE:  u32 = 0x1;
+
+# the M-extension divide / remainder funct3 selectors (funct7 = F7_MULDIV). these
+# share their numeric values with the load / store width selectors above, so they
+# are named separately for legibility at the divide use site.
+val F3_DIV:  u32 = 0x4;  # div  (signed quotient)
+val F3_DIVU: u32 = 0x5;  # divu (unsigned quotient)
+val F3_REM:  u32 = 0x6;  # rem  (signed remainder)
+val F3_REMU: u32 = 0x7;  # remu (unsigned remainder)
+
+# the F/D-extension major opcodes. OP_FP carries every register float op (the funct7
+# names the operation and its precision, the rs2 field the source format for a
+# conversion); LOAD_FP / STORE_FP carry the float loads / stores. these are the same
+# on RV32 and RV64; the F-extension single-precision forms exist on a bare RV32F /
+# RV64F, the D forms add the double-precision twins, so nothing here is XLEN-specific.
+val OP_FP:    u32 = 0x53;
+val LOAD_FP:  u32 = 0x07;  # flw / fld
+val STORE_FP: u32 = 0x27;  # fsw / fsd
+
+# the float instruction-word funct7 selectors. each is the 5-bit operation in
+# bits [6:2] with the 2-bit format in bits [1:0] (00 = single, 01 = double), so the
+# double form is the single form set with bit 0 (`| 1`). the conversion groups
+# (FCVT_*) select the concrete source / destination width through the rs2 field.
+val F7_FADD:    u32 = 0x00;  # fadd.s  (fadd.d = | 1)
+val F7_FSUB:    u32 = 0x04;  # fsub.s
+val F7_FMUL:    u32 = 0x08;  # fmul.s
+val F7_FDIV:    u32 = 0x0C;  # fdiv.s
+val F7_FSGNJ:   u32 = 0x10;  # fsgnj.s family (fmv = funct3 0, fneg = funct3 1)
+val F7_FCMP:    u32 = 0x50;  # feq/flt/fle.s (funct3 2/1/0); rd is a GP register
+val F7_FCVT_F2F: u32 = 0x20; # fcvt.s.d / fcvt.d.s (float-to-float; rs2 picks source)
+val F7_FCVT_F2I: u32 = 0x60; # fcvt.{w,wu,l,lu}.s (float->int; rd GP, rs2 picks dest)
+val F7_FCVT_I2F: u32 = 0x68; # fcvt.s.{w,wu,l,lu} (int->float; rs1 GP, rs2 picks src)
+val F7_FMV_F2I:  u32 = 0x70; # fmv.x.w (FP bits -> GP); funct3 0, rs2 0
+val F7_FMV_I2F:  u32 = 0x78; # fmv.w.x (GP bits -> FP); funct3 0, rs2 0
+
+# the float compare relation funct3 (funct7 = F7_FCMP | fmt).
+val F3_FLE: u32 = 0x0;  # fle (less-or-equal)
+val F3_FLT: u32 = 0x1;  # flt (less-than)
+val F3_FEQ: u32 = 0x2;  # feq (equal)
+
+# the rounding-mode field (funct3 of an arithmetic / conversion OP_FP word).
+# RM_RNE is round-to-nearest-even (the field is don't-care for an exact conversion,
+# where it matches the assembler's canonical choice); RM_RTZ is round-toward-zero
+# (mach's defined float->int cast rule); RM_DYN defers to the fcsr (the
+# round-to-nearest default a value-rounding conversion / arithmetic op uses).
+val RM_RNE: u32 = 0x0;
+val RM_RTZ: u32 = 0x1;
+val RM_DYN: u32 = 0x7;
+
+# the rs2 source / destination selector of an FCVT integer conversion: W (i32), WU
+# (u32), L (i64), LU (u64). these double as the dest selector for a float->int FCVT
+# and the source selector for an int->float FCVT.
+val FCVT_W:  u32 = 0x0;
+val FCVT_WU: u32 = 0x1;
+val FCVT_L:  u32 = 0x2;
+val FCVT_LU: u32 = 0x3;
+
+# the two fixed FP scratch registers the float-op encoder routes spilled operands
+# through. f31 (the vtable's `fp_scratch_reg`, composite-tagged there) is the primary
+# scratch - a spilled left / source operand and the compute register for a spilled
+# destination; f30 is the secondary - a spilled right operand, so a binary float op
+# whose destination and both sources are all spilled has two live FP registers at
+# once. both sit above the allocatable fpr bank (f0-f29), so neither is ever an
+# assigned value.
+val FP_SCRATCH:  u32 = 31;
+val FP_SCRATCH2: u32 = 30;
 
 # the register roles the encoder uses directly, the leaf module's psABI ids cast to
 # the 5-bit register fields. ZERO discards writes and reads as 0; RA is the link
@@ -764,6 +836,575 @@ fun encode_call(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] 
     ret R.ok[bool, str](true);
 }
 
+# true when a post-isel opcode is a surviving generic divide / remainder sentinel -
+# the encoder lowers it to a single M-extension instruction.
+fun is_mir_divide(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_SEL_DIV_S || op == mir.MIR_SEL_DIV_U ||
+        op == mir.MIR_SEL_REM_S || op == mir.MIR_SEL_REM_U;
+}
+
+# the M-extension funct3 for a surviving divide / remainder sentinel.
+fun divide_funct3(op: mir.MirOpcode) u32 {
+    if (op == mir.MIR_SEL_DIV_S) { ret F3_DIV; }
+    if (op == mir.MIR_SEL_DIV_U) { ret F3_DIVU; }
+    if (op == mir.MIR_SEL_REM_S) { ret F3_REM; }
+    ret F3_REMU;
+}
+
+# materialize a surviving divide / remainder `[dst, dividend, divisor]` into a single
+# M-extension `div`/`divu`/`rem`/`remu` word (the word forms divw / remw at 32-bit
+# operand width through `alu_opcode`). RISC-V DEFINES the boundary results - a divide
+# by zero yields all-ones quotient / the dividend as remainder, and the most-negative
+# / -1 signed overflow yields the dividend / a zero remainder - so no guard sequence
+# is emitted (unlike AArch64, whose SDIV traps must be checked). a non-register
+# operand is materialized into a scratch register, mirroring `encode_alu3`.
+fun encode_divide(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 3) { ret R.err[bool, str]("encode: divide missing operands"); }
+
+    val rdr: R.Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+    val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
+
+    val rnr: R.Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH2);
+    if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+    val rs1: u32 = R.unwrap_ok[i32, str](rnr)::u32;
+
+    val rmr: R.Result[i32, str] = resolve_source(st, ?mi.operands[2], SCRATCH);
+    if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
+    val rs2: u32 = R.unwrap_ok[i32, str](rmr)::u32;
+
+    emit_word(st, pack_r(alu_opcode(mi.width), divide_funct3(mi.opcode), F7_MULDIV, rd, rs1, rs2));
+    ret R.ok[bool, str](true);
+}
+
+# an integer width / representation conversion `[dst, src]`. TRUNC narrows to a clean
+# RV64 32-bit value with `sext.w` (the canonical sign-extended-to-64 form a 32-bit
+# value lives in, the analogue of AArch64's 32-bit-move truncation; a consumer that
+# needs the value at a sub-word width re-narrows it). a GP BITCAST is a same-width
+# move (`mv` at full width, `sext.w` for a 32-bit reinterpret). SEXT sign-extends from
+# the source width - a `sext.w` for a 32-bit source, else the `slli ; srai` shift
+# pair filling from the source's sign bit. ZEXT zero-extends - `andi rd, rs, 0xFF`
+# for a byte source, else the `slli ; srli` pair. operands arrive physical (the
+# allocator reloads any spilled operand before the instruction) or as an immediate a
+# same-width BITCAST of a literal materializes through the scratch.
+fun encode_convert(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 2) { ret R.err[bool, str]("encode: conversion missing operands"); }
+    val dw: u8 = mi.width;
+    val sw: u8 = mi.src_width;
+
+    val rdr: R.Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+    val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
+
+    val rsr: R.Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH);
+    if (R.is_err[i32, str](rsr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rsr)); }
+    val rs: u32 = R.unwrap_ok[i32, str](rsr)::u32;
+
+    if (mi.opcode == mir.MIR_TRUNC) {
+        emit_word(st, pack_i(OP_IMM_32, F3_ADD, rd, rs, 0));  # sext.w rd, rs (addiw rd,rs,0)
+        ret R.ok[bool, str](true);
+    }
+    if (mi.opcode == mir.MIR_BITCAST) {
+        # a same-width reinterpret: an 8-byte value copies all 64 bits (`mv`); a
+        # 32-bit value canonicalizes to its sign-extended form (`sext.w`).
+        if (dw >= 8) { emit_word(st, pack_i(OP_IMM, F3_ADD, rd, rs, 0)); }      # mv rd, rs
+        or           { emit_word(st, pack_i(OP_IMM_32, F3_ADD, rd, rs, 0)); }   # sext.w rd, rs
+        ret R.ok[bool, str](true);
+    }
+    if (mi.opcode == mir.MIR_SEXT) {
+        if (sw >= 8) { emit_word(st, pack_i(OP_IMM, F3_ADD, rd, rs, 0)); ret R.ok[bool, str](true); }  # mv
+        if (sw == 4) { emit_word(st, pack_i(OP_IMM_32, F3_ADD, rd, rs, 0)); ret R.ok[bool, str](true); }  # sext.w
+        # sign-extend a 1 / 2-byte source: shift its sign bit to bit 63 then back.
+        val sh: u32 = 64 - (sw::u32 * 8);
+        emit_word(st, pack_i(OP_IMM, F3_SLL, rd, rs, sh));            # slli rd, rs, sh
+        emit_word(st, pack_i(OP_IMM, F3_SRL, rd, rd, sh | 0x400));    # srai rd, rd, sh
+        ret R.ok[bool, str](true);
+    }
+    # MIR_ZEXT: a byte source masks with `andi`; a 2 / 4-byte source shifts left then
+    # logical-right to clear the high bits (RV64 has no base zero-extend-word).
+    if (sw == 1) {
+        emit_word(st, pack_i(OP_IMM, F3_AND, rd, rs, 0xFF));  # andi rd, rs, 0xFF
+        ret R.ok[bool, str](true);
+    }
+    val sh: u32 = 64 - (sw::u32 * 8);
+    emit_word(st, pack_i(OP_IMM, F3_SLL, rd, rs, sh));  # slli rd, rs, sh
+    emit_word(st, pack_i(OP_IMM, F3_SRL, rd, rd, sh));  # srli rd, rd, sh
+    ret R.ok[bool, str](true);
+}
+
+# the within-bank float register index a post-regalloc float register operand names.
+# only a physical register survives to encode; a surviving virtual register is a
+# register-allocation bug. the index is recovered through `regid_index` so the
+# composite float id (class tag in the high byte) maps to the same f-register field a
+# raw index would - a raw GP index would mis-encode.
+fun req_fpr(op: *mir.MirOperand) R.Result[i32, str] {
+    if (op.kind == mir.MIR_OP_PREG) {
+        ret R.ok[i32, str](isa.regid_index(op.preg::i32));
+    }
+    if (op.kind == mir.MIR_OP_VREG) {
+        ret R.err[i32, str]("encode: virtual register survived register allocation");
+    }
+    ret R.err[i32, str]("encode: expected a float register operand");
+}
+
+# true when an operand is a physical register in the float bank. reads the class
+# straight off the composite register id - the seam that lets the move family pick
+# the FP versus GP machine form from the operands alone.
+fun reg_is_fp(op: *mir.MirOperand) bool {
+    ret op.kind == mir.MIR_OP_PREG && isa.regid_class(op.preg::i32) == isa.REG_CLASS_ID_XMM;
+}
+
+# the float load / store funct3 for an access width: flw / fsw at 4 bytes, fld / fsd
+# at 8. unlike the integer loads there is no sub-word float access.
+fun fp_mem_funct3(width: u8) u32 {
+    if (width == 4) { ret 0x2; }  # flw / fsw
+    ret 0x3;                       # fld / fsd
+}
+
+# emit a width-sized float load or store of float register `rt` at `[base + off]`. a
+# `off` within the 12-bit signed immediate uses the direct I-type load / S-type
+# store; a wider `off` is materialized into the GP scratch register, added to the
+# base, and the access addressed at `[scratch + 0]`. `base` is a GP register (s0 for
+# a frame slot, a pointer otherwise); the float analogue of `emit_mem_access`.
+fun emit_fp_mem(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width: u8, is_load: bool) {
+    var b: u32 = base;
+    var d: i64 = off;
+    if (off < -2048 || off > 2047) {
+        emit_li(st, SCRATCH2, off);
+        emit_word(st, pack_r(OP, F3_ADD, F7_ZERO, SCRATCH2, base, SCRATCH2));
+        b = SCRATCH2;
+        d = 0;
+    }
+    if (is_load) {
+        emit_word(st, pack_i(LOAD_FP, fp_mem_funct3(width), rt, b, d::u32 & 0xFFF));
+        ret;
+    }
+    emit_word(st, pack_s(STORE_FP, fp_mem_funct3(width), b, rt, d::u32 & 0xFFF));
+}
+
+# store float register `rt` to a frame-slot / pointer MEM destination at float
+# `width`. the spilled-float-destination counterpart of `emit_fp_mem`, resolving the
+# MEM operand first (an indexed float spill is never produced).
+fun emit_fp_slot_store(st: *encode.EncodeState, f: *mir.MirFunction, memop: *mir.MirOperand, rt: u32, width: u8) R.Result[bool, str] {
+    val mr: R.Result[RvMem, str] = resolve_mem(f, memop);
+    if (R.is_err[RvMem, str](mr)) { ret R.err[bool, str](R.unwrap_err[RvMem, str](mr)); }
+    val m: RvMem = R.unwrap_ok[RvMem, str](mr);
+    if (m.has_index) { ret R.err[bool, str]("encode: indexed float spill destination not expected"); }
+    emit_fp_mem(st, rt, m.base, m.off, width, false);
+    ret R.ok[bool, str](true);
+}
+
+# the GP->FP reinterpret funct7 for a float width: fmv.w.x at 4 bytes, fmv.d.x at 8.
+fun fmv_i2f_funct7(width: u8) u32 {
+    if (width == 4) { ret F7_FMV_I2F; }
+    ret F7_FMV_I2F | 1;
+}
+
+# the FP->GP reinterpret funct7 for a float width: fmv.x.w at 4 bytes, fmv.x.d at 8.
+fun fmv_f2i_funct7(width: u8) u32 {
+    if (width == 4) { ret F7_FMV_F2I; }
+    ret F7_FMV_F2I | 1;
+}
+
+# materialize a float-constant bit pattern into float register index `vd`. the bits -
+# a 32-bit pattern for an f32, a 64-bit pattern for an f64 (the shape a float CONSTANT
+# carries through lowering) - are materialized into the GP scratch via `emit_li`, then
+# bit-copied into `vd` with the GP->FP reinterpret (`fmv.w.x` for an f32, `fmv.d.x`
+# for an f64). the RV64 analogue of x86-64's float-constant load (MOVABS R11 + MOVQ
+# xmm); the GP scratch is the reserved encoder register, so a single instruction's
+# materialization never collides with a live value. `width` is 4 (S) or 8 (D).
+fun emit_fp_imm(st: *encode.EncodeState, vd: u32, bits: i64, width: u8) {
+    emit_li(st, SCRATCH, bits);
+    emit_word(st, pack_r(OP_FP, RM_RNE, fmv_i2f_funct7(width), vd, SCRATCH, 0));
+}
+
+# the float register index a float source operand contributes. a physical float
+# register is used directly; a spilled float arrives as a frame-slot MEM operand (the
+# shared allocator leaves a spilled float in place rather than reloading it through a
+# GP temp) and is loaded into `scratch`, whose index is then returned; a float-constant
+# immediate is materialized into `scratch` through the GP scratch + a GP->FP fmv,
+# whose index is returned. `width` (4 / 8) sizes the load / the S-vs-D materialization.
+fun resolve_fp_source(st: *encode.EncodeState, f: *mir.MirFunction, op: *mir.MirOperand, scratch: u32, width: u8) R.Result[i32, str] {
+    if (op.kind == mir.MIR_OP_MEM) {
+        val mr: R.Result[RvMem, str] = resolve_mem(f, op);
+        if (R.is_err[RvMem, str](mr)) { ret R.err[i32, str](R.unwrap_err[RvMem, str](mr)); }
+        val m: RvMem = R.unwrap_ok[RvMem, str](mr);
+        if (m.has_index) { ret R.err[i32, str]("encode: indexed float spill operand not expected"); }
+        emit_fp_mem(st, scratch, m.base, m.off, width, true);
+        ret R.ok[i32, str](scratch::i32);
+    }
+    if (op.kind == mir.MIR_OP_IMM) {
+        emit_fp_imm(st, scratch, op.imm, width);
+        ret R.ok[i32, str](scratch::i32);
+    }
+    ret req_fpr(op);
+}
+
+# the OP_FP funct7 for a binary float arithmetic MIR opcode and precision (the double
+# form is the single form set with bit 0).
+fun fp_arith_funct7(op: mir.MirOpcode, dbl: bool) u32 {
+    var base: u32 = F7_FADD;
+    if (op == mir.MIR_FSUB) { base = F7_FSUB; }
+    if (op == mir.MIR_FMUL) { base = F7_FMUL; }
+    if (op == mir.MIR_FDIV) { base = F7_FDIV; }
+    if (dbl) { ret base | 1; }
+    ret base;
+}
+
+# true when a surviving opcode is one of the scalar float arithmetic ops the encoder
+# materializes from its dedicated MIR opcode.
+fun is_mir_float_arith(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_FADD || op == mir.MIR_FSUB ||
+        op == mir.MIR_FMUL || op == mir.MIR_FDIV;
+}
+
+# true when a surviving opcode is one of the float conversions.
+fun is_mir_float_conv(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_FP_TRUNC || op == mir.MIR_FP_EXT ||
+        op == mir.MIR_FP_TO_SI || op == mir.MIR_FP_TO_UI ||
+        op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP;
+}
+
+# materialize a surviving float arithmetic op `[dst, lhs, rhs]` into its single RV64D
+# instruction `fop fd, fn, fm` (rounding mode dynamic). each source resolves to a
+# float register (a spilled source loaded into a scratch: lhs -> f31, rhs -> f30); a
+# register destination encodes directly, a spilled destination computes the result in
+# f31 and stores it to the slot. `mi.width` (4 / 8) selects the S vs D form.
+fun encode_fp_arith(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 3) { ret R.err[bool, str]("encode: float arithmetic missing operands"); }
+    val w: u8 = mi.width;
+    if (w != 4 && w != 8) {
+        ret R.err[bool, str]("internal compiler error: float arithmetic has a non-float operand width (expected 4 or 8)");
+    }
+    val dbl: bool = w == 8;
+
+    val rnr: R.Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH, w);
+    if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+    val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
+
+    val rmr: R.Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[2], FP_SCRATCH2, w);
+    if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
+    val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
+
+    val f7: u32 = fp_arith_funct7(mi.opcode, dbl);
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    if (dst.kind == mir.MIR_OP_MEM) {
+        emit_word(st, pack_r(OP_FP, RM_DYN, f7, FP_SCRATCH, rn, rm));
+        ret emit_fp_slot_store(st, f, dst, FP_SCRATCH, w);
+    }
+    val rdr: R.Result[i32, str] = req_fpr(dst);
+    if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+    emit_word(st, pack_r(OP_FP, RM_DYN, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rm));
+    ret R.ok[bool, str](true);
+}
+
+# materialize a surviving float negation `[dst, src]` into `fneg fd, fn` (the
+# `fsgnjn fd, fn, fn` alias, an IEEE-754 sign-bit flip). the source resolves to a
+# float register (a spilled source loaded into f31); a spilled destination computes
+# into f31 and stores back.
+fun encode_fp_neg(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 2) { ret R.err[bool, str]("encode: float negate missing operands"); }
+    val w: u8 = mi.width;
+    if (w != 4 && w != 8) {
+        ret R.err[bool, str]("internal compiler error: float negate has a non-float operand width (expected 4 or 8)");
+    }
+    var f7: u32 = F7_FSGNJ;
+    if (w == 8) { f7 = F7_FSGNJ | 1; }
+
+    val rnr: R.Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH, w);
+    if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+    val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
+
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    if (dst.kind == mir.MIR_OP_MEM) {
+        emit_word(st, pack_r(OP_FP, F3_FLT, f7, FP_SCRATCH, rn, rn));  # fsgnjn (fneg)
+        ret emit_fp_slot_store(st, f, dst, FP_SCRATCH, w);
+    }
+    val rdr: R.Result[i32, str] = req_fpr(dst);
+    if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+    emit_word(st, pack_r(OP_FP, F3_FLT, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rn));
+    ret R.ok[bool, str](true);
+}
+
+# the feq / flt / fle relation and operand order a surviving float comparison
+# captures, written into `out_funct3` / `out_swap`. mach canonicalizes a comparison to
+# the EQ / NE / LT / LE forms; `>` / `>=` are the swapped `<` / `<=`. NE has no direct
+# RISC-V form, so it rides feq and the caller inverts the boolean.
+fun fp_cmp_relation(cc: u8, out_funct3: *u32, out_swap: *bool, out_invert: *bool) {
+    @out_swap   = false;
+    @out_invert = false;
+    if (cc == mir.FCC_EQ) { @out_funct3 = F3_FEQ; ret; }
+    if (cc == mir.FCC_NE) { @out_funct3 = F3_FEQ; @out_invert = true; ret; }
+    if (cc == mir.FCC_LT) { @out_funct3 = F3_FLT; ret; }
+    if (cc == mir.FCC_LE) { @out_funct3 = F3_FLE; ret; }
+    if (cc == mir.FCC_GT) { @out_funct3 = F3_FLT; @out_swap = true; ret; }
+    # FCC_GE: the swapped fle.
+    @out_funct3 = F3_FLE;
+    @out_swap   = true;
+}
+
+# materialize a surviving float comparison `[dst, lhs, rhs]` into `frel rd, fn, fm`
+# (feq / flt / fle, which write the GP boolean directly - RISC-V needs no flag-capture
+# step). the two float sources resolve to float registers (spilled sources loaded into
+# f31 / f30); the destination is the GP boolean. an unordered-aware NE is the inverted
+# feq (`feq ; xori rd, rd, 1`); the swapped `>` / `>=` reverse the operand order. the
+# compared width (`mi.width`: 4 -> S, 8 -> D) selects the form; the condition rides
+# `mi.src_width` (an FCC_* code).
+fun encode_fp_cmp(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 3) { ret R.err[bool, str]("encode: float comparison missing operands"); }
+    val w: u8 = mi.width;
+    if (w != 4 && w != 8) {
+        ret R.err[bool, str]("internal compiler error: float comparison has a non-float operand width (expected 4 or 8)");
+    }
+    var f7: u32 = F7_FCMP;
+    if (w == 8) { f7 = F7_FCMP | 1; }
+
+    val rnr: R.Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH, w);
+    if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+    val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
+
+    val rmr: R.Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[2], FP_SCRATCH2, w);
+    if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
+    val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
+
+    val rdr: R.Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+    val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
+
+    var funct3: u32 = F3_FEQ;
+    var swap:   bool = false;
+    var invert: bool = false;
+    fp_cmp_relation(mi.src_width, ?funct3, ?swap, ?invert);
+
+    var a: u32 = rn;
+    var b: u32 = rm;
+    if (swap) { a = rm; b = rn; }
+    emit_word(st, pack_r(OP_FP, funct3, f7, rd, a, b));
+    if (invert) { emit_word(st, pack_i(OP_IMM, F3_XOR, rd, rd, 1)); }  # xori rd, rd, 1
+    ret R.ok[bool, str](true);
+}
+
+# the FCVT int->float rounding mode for a destination precision and integer source
+# width: round-to-nearest-even is exact (and the assembler's canonical encoding) only
+# when the source always fits the destination mantissa - an i32 / u32 into an f64 -
+# so the fcvt.d.w / fcvt.d.wu words match `llvm-mc`'s rm = 0; every other int->float
+# may round and uses the dynamic mode (the round-to-nearest fcsr default).
+fun int_to_fp_rm(dbl: bool, src_is_word: bool) u32 {
+    if (dbl && src_is_word) { ret RM_RNE; }
+    ret RM_DYN;
+}
+
+# materialize a surviving float conversion. FP_TRUNC / FP_EXT are a single fcvt
+# between S and D (float on both sides, routed through f31 when spilled). SI_TO_FP /
+# UI_TO_FP convert a GP source (sign / zero extended to a clean value for a sub-word
+# source, the W or L form for a 4 / 8-byte source) into a float via fcvt.{s,d}.{w,l}.
+# FP_TO_SI / FP_TO_UI convert a float source into a GP destination via
+# fcvt.{w,l}.{s,d} round-toward-zero (mach's defined cast rule). `mi.width` is the
+# destination width, `mi.src_width` the source width - for FP_TRUNC/EXT both are float
+# widths; for the int<->float forms one side is the integer width and the other the
+# float width.
+fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 2) { ret R.err[bool, str]("encode: float conversion missing operands"); }
+    val op: mir.MirOpcode = mi.opcode;
+    val dw: u8 = mi.width;
+    val sw: u8 = mi.src_width;
+
+    if (op == mir.MIR_FP_TRUNC || op == mir.MIR_FP_EXT) {
+        val rnr: R.Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH, sw);
+        if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+        val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
+        # fcvt.s.d narrows (double result selector 0x20, source rs2 = 1, rm dynamic);
+        # fcvt.d.s widens (double result selector 0x21, source rs2 = 0, exact rm).
+        var f7: u32 = F7_FCVT_F2F;       # 0x20 -> single dest (fcvt.s.d)
+        var rs2: u32 = FCVT_L;            # rs2 = 1 selects the double source
+        var rm: u32 = RM_DYN;
+        if (op == mir.MIR_FP_EXT) {
+            f7  = F7_FCVT_F2F | 1;        # 0x21 -> double dest (fcvt.d.s)
+            rs2 = FCVT_W;                 # rs2 = 0 selects the single source
+            rm  = RM_RNE;
+        }
+        val dst: *mir.MirOperand = ?mi.operands[0];
+        if (dst.kind == mir.MIR_OP_MEM) {
+            emit_word(st, pack_r(OP_FP, rm, f7, FP_SCRATCH, rn, rs2));
+            ret emit_fp_slot_store(st, f, dst, FP_SCRATCH, dw);
+        }
+        val rdr: R.Result[i32, str] = req_fpr(dst);
+        if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+        emit_word(st, pack_r(OP_FP, rm, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rs2));
+        ret R.ok[bool, str](true);
+    }
+
+    if (op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP) {
+        val signed: bool = op == mir.MIR_SI_TO_FP;
+        val gpr: R.Result[i32, str] = req_gpr(?mi.operands[1]);
+        if (R.is_err[i32, str](gpr)) { ret R.err[bool, str](R.unwrap_err[i32, str](gpr)); }
+        var gp: u32 = R.unwrap_ok[i32, str](gpr)::u32;
+        var src_word: bool = sw <= 4;
+        # a sub-word source carries undefined high bits; sign / zero extend it into the
+        # GP scratch to a clean 32-bit value before the W-form convert.
+        if (sw < 4) {
+            val shamt: u32 = 64 - (sw::u32 * 8);
+            if (signed) {
+                emit_word(st, pack_i(OP_IMM, F3_SLL, SCRATCH, gp, shamt));
+                emit_word(st, pack_i(OP_IMM, F3_SRL, SCRATCH, SCRATCH, shamt | 0x400));  # srai
+            } or (sw == 1) {
+                emit_word(st, pack_i(OP_IMM, F3_AND, SCRATCH, gp, 0xFF));                # andi
+            } or {
+                emit_word(st, pack_i(OP_IMM, F3_SLL, SCRATCH, gp, shamt));
+                emit_word(st, pack_i(OP_IMM, F3_SRL, SCRATCH, SCRATCH, shamt));          # srli
+            }
+            gp = SCRATCH;
+            src_word = true;
+        }
+        val dbl: bool = dw == 8;
+        var f7: u32 = F7_FCVT_I2F;       # single dest (fcvt.s.*)
+        if (dbl) { f7 = F7_FCVT_I2F | 1; }  # double dest (fcvt.d.*)
+        var rs2: u32 = FCVT_L;            # 64-bit source: L (signed) selector
+        if (src_word && signed)     { rs2 = FCVT_W; }
+        or (src_word && !signed)    { rs2 = FCVT_WU; }
+        or (!src_word && !signed)   { rs2 = FCVT_LU; }
+        val rm: u32 = int_to_fp_rm(dbl, src_word);
+        val dst: *mir.MirOperand = ?mi.operands[0];
+        if (dst.kind == mir.MIR_OP_MEM) {
+            emit_word(st, pack_r(OP_FP, rm, f7, FP_SCRATCH, gp, rs2));
+            ret emit_fp_slot_store(st, f, dst, FP_SCRATCH, dw);
+        }
+        val rdr: R.Result[i32, str] = req_fpr(dst);
+        if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+        emit_word(st, pack_r(OP_FP, rm, f7, R.unwrap_ok[i32, str](rdr)::u32, gp, rs2));
+        ret R.ok[bool, str](true);
+    }
+
+    # float source -> GP destination (round-toward-zero).
+    val signed: bool = op == mir.MIR_FP_TO_SI;
+    val rnr: R.Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH, sw);
+    if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+    val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
+    val rdr: R.Result[i32, str] = req_gpr(?mi.operands[0]);
+    if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+    val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
+    var f7: u32 = F7_FCVT_F2I;            # single source (fcvt.*.s)
+    if (sw == 8) { f7 = F7_FCVT_F2I | 1; }  # double source (fcvt.*.d)
+    var rs2: u32 = FCVT_L;                # 64-bit signed dest
+    if (dw <= 4 && signed)   { rs2 = FCVT_W; }
+    or (dw <= 4 && !signed)  { rs2 = FCVT_WU; }
+    or (dw > 4 && !signed)   { rs2 = FCVT_LU; }
+    emit_word(st, pack_r(OP_FP, RM_RTZ, f7, rd, rn, rs2));
+    ret R.ok[bool, str](true);
+}
+
+# materialize a float register copy, a GP<->FP `:~` bitcast (both selected to FMV), or
+# a float-constant immediate move, dispatching on the source shape, operand register
+# CLASS, and spill state:
+#   - immediate source (a float CONSTANT): the bit pattern is materialized into the
+#     destination float register (or f31 then stored for a spilled destination) via
+#     the GP scratch + a GP->FP fmv - see `emit_fp_imm`.
+#   - float <- float: `fmv.d` / `fmv.s` (the `fsgnj fd, fn, fn` alias, a float copy).
+#   - float <- GP / GP <- float: the cross-bank `fmv.d.x` / `fmv.w.x` and `fmv.x.d` /
+#     `fmv.x.w` bit reinterprets.
+#   - a spilled side (frame-slot MEM): a float copy round-trips through f31 / an
+#     fld-fsd; a cross-bank bitcast whose float side is spilled is a bit-identical GP
+#     load / store of the slot (the bits are the same in either bank).
+# `mi.width` (4 / 8) selects the S vs D form throughout.
+fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 2) { ret R.err[bool, str]("encode: fmov missing operands"); }
+    var w: u8 = mi.width;
+    if (w != 4 && w != 8) { w = 8; }
+    val dbl: bool = w == 8;
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    val src: *mir.MirOperand = ?mi.operands[1];
+
+    # a float-constant immediate source reaches here as `FMV float <- imm`.
+    if (src.kind == mir.MIR_OP_IMM) {
+        if (dst.kind == mir.MIR_OP_MEM) {
+            emit_fp_imm(st, FP_SCRATCH, src.imm, w);
+            ret emit_fp_slot_store(st, f, dst, FP_SCRATCH, w);
+        }
+        val rdr: R.Result[i32, str] = req_fpr(dst);
+        if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+        emit_fp_imm(st, R.unwrap_ok[i32, str](rdr)::u32, src.imm, w);
+        ret R.ok[bool, str](true);
+    }
+
+    if (dst.kind != mir.MIR_OP_MEM && src.kind != mir.MIR_OP_MEM) {
+        val dfp: bool = reg_is_fp(dst);
+        val sfp: bool = reg_is_fp(src);
+        if (dfp && sfp) {
+            # float-to-float copy: fmv.d / fmv.s (fsgnj fd, fn, fn).
+            val rdr: R.Result[i32, str] = req_fpr(dst);
+            if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+            val rnr: R.Result[i32, str] = req_fpr(src);
+            if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+            var f7: u32 = F7_FSGNJ;
+            if (dbl) { f7 = F7_FSGNJ | 1; }
+            val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
+            emit_word(st, pack_r(OP_FP, F3_FLE, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rn));
+            ret R.ok[bool, str](true);
+        }
+        if (dfp) {
+            # GP -> FP bit reinterpret (fmv.w.x / fmv.d.x).
+            val rdr: R.Result[i32, str] = req_fpr(dst);
+            if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+            val rnr: R.Result[i32, str] = req_gpr(src);
+            if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+            emit_word(st, pack_r(OP_FP, RM_RNE, fmv_i2f_funct7(w), R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0));
+            ret R.ok[bool, str](true);
+        }
+        if (sfp) {
+            # FP -> GP bit reinterpret (fmv.x.w / fmv.x.d).
+            val rdr: R.Result[i32, str] = req_gpr(dst);
+            if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+            val rnr: R.Result[i32, str] = req_fpr(src);
+            if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+            emit_word(st, pack_r(OP_FP, RM_RNE, fmv_f2i_funct7(w), R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0));
+            ret R.ok[bool, str](true);
+        }
+        ret R.err[bool, str]("encode: fmov names two general-purpose registers");
+    }
+
+    if (dst.kind == mir.MIR_OP_MEM) {
+        if (src.kind == mir.MIR_OP_MEM) {
+            # both spilled: a float mem-to-mem copy through f31.
+            val mr: R.Result[RvMem, str] = resolve_mem(f, src);
+            if (R.is_err[RvMem, str](mr)) { ret R.err[bool, str](R.unwrap_err[RvMem, str](mr)); }
+            val m: RvMem = R.unwrap_ok[RvMem, str](mr);
+            if (m.has_index) { ret R.err[bool, str]("encode: indexed float spill operand not expected"); }
+            emit_fp_mem(st, FP_SCRATCH, m.base, m.off, w, true);
+            ret emit_fp_slot_store(st, f, dst, FP_SCRATCH, w);
+        }
+        if (reg_is_fp(src)) {
+            # float copy, spilled destination: fsd / fsw.
+            val rnr: R.Result[i32, str] = req_fpr(src);
+            if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+            ret emit_fp_slot_store(st, f, dst, R.unwrap_ok[i32, str](rnr)::u32, w);
+        }
+        # GP -> FP bitcast, spilled float destination: store the GP bits directly.
+        ret emit_store_mem(st, f, dst, src, w);
+    }
+
+    # src is the MEM operand, dst a register.
+    if (reg_is_fp(dst)) {
+        # float copy, spilled source: fld / flw.
+        val rdr: R.Result[i32, str] = req_fpr(dst);
+        if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+        val mr: R.Result[RvMem, str] = resolve_mem(f, src);
+        if (R.is_err[RvMem, str](mr)) { ret R.err[bool, str](R.unwrap_err[RvMem, str](mr)); }
+        val m: RvMem = R.unwrap_ok[RvMem, str](mr);
+        if (m.has_index) { ret R.err[bool, str]("encode: indexed float spill operand not expected"); }
+        emit_fp_mem(st, R.unwrap_ok[i32, str](rdr)::u32, m.base, m.off, w, true);
+        ret R.ok[bool, str](true);
+    }
+    # FP -> GP bitcast, spilled float source: load the bits into the GP destination.
+    val rdr: R.Result[i32, str] = req_gpr(dst);
+    if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+    val mr: R.Result[RvMem, str] = resolve_mem(f, src);
+    if (R.is_err[RvMem, str](mr)) { ret R.err[bool, str](R.unwrap_err[RvMem, str](mr)); }
+    val m: RvMem = R.unwrap_ok[RvMem, str](mr);
+    if (m.has_index) { ret R.err[bool, str]("encode: indexed float spill operand not expected"); }
+    emit_mem_access(st, R.unwrap_ok[i32, str](rdr)::u32, m.base, m.off, w, true);
+    ret R.ok[bool, str](true);
+}
+
 # the number of set bits in a 32-bit mask.
 fun popcount32(m: u32) u32 {
     var n: u32 = 0;
@@ -781,12 +1422,14 @@ fun align16(n: u32) u32 {
 }
 
 # the 16-byte-aligned total the prologue allocates below the entry stack pointer: the
-# 16-byte ra / s0 record, the callee-saved GP save area, the local frame, and the
-# outgoing-argument region, read from the shared frame facts. unlike AArch64 the
+# 16-byte ra / s0 record, the callee-saved GP and FP save areas, the local frame, and
+# the outgoing-argument region, read from the shared frame facts. unlike AArch64 the
 # record is part of this single allocation rather than a separate pre-index push.
+# each callee-saved register (GP or FP) takes one 8-byte slot.
 fun frame_total(f: *mir.MirFunction) u32 {
     val gp_bytes: u32 = popcount32(f.callee_mask) * 8;
-    ret align16(16 + gp_bytes + f.frame.size + f.frame.outgoing_size);
+    val fp_bytes: u32 = popcount32(f.callee_mask_fp) * 8;
+    ret align16(16 + gp_bytes + fp_bytes + f.frame.size + f.frame.outgoing_size);
 }
 
 # adjust SP by `delta` bytes (subtract on entry, add on exit). a delta within the
@@ -822,6 +1465,25 @@ fun save_callee_gp(st: *encode.EncodeState, f: *mir.MirFunction, total: u32, sto
     }
 }
 
+# save (or restore) the callee-saved FP registers `callee_mask_fp` selects, in
+# ascending register order, in the area just below the callee-saved GP area. each
+# register takes an 8-byte slot (the F/D registers are 64-bit under lp64d), the first
+# at `total - 16 - gp_bytes - 8`, addressed SP-relative through `fsd` / `fld`. the
+# area sits within `frame_total`'s FP region, below the GP region.
+fun save_callee_fp(st: *encode.EncodeState, f: *mir.MirFunction, total: u32, store: bool) {
+    val gp_bytes: i64 = (popcount32(f.callee_mask) * 8)::i64;
+    var n: u32 = 0;
+    var r: u32 = 0;
+    for (r < 32) {
+        if ((f.callee_mask_fp & (1::u32 << r)) != 0) {
+            val off: i64 = (total::i64) - 16 - gp_bytes - 8 - (8 * n)::i64;
+            emit_fp_mem(st, r, RSP, off, 8, !store);
+            n = n + 1;
+        }
+        r = r + 1;
+    }
+}
+
 # the RISC-V prologue. `addi sp, sp, -total` allocates the frame, `sd ra` / `sd s0`
 # save the record at the top of it, `addi s0, sp, total` pins the frame pointer at
 # the entry stack pointer (so incoming stack arguments sit at `[s0+0]`), and the
@@ -832,6 +1494,7 @@ fun emit_prologue(st: *encode.EncodeState, f: *mir.MirFunction, total: u32) {
     emit_mem_access(st, RFP, RSP, (total::i64) - 16, 8, false);  # sd s0, total-16(sp)
     emit_addi(st, RFP, RSP, total::i64);                         # addi s0, sp, total
     save_callee_gp(st, f, total, true);
+    save_callee_fp(st, f, total, true);
 }
 
 # the RISC-V epilogue. it restores the callee-saved GP registers, reloads the ra / s0
@@ -839,6 +1502,7 @@ fun emit_prologue(st: *encode.EncodeState, f: *mir.MirFunction, total: u32) {
 # returns through ra.
 fun emit_epilogue(st: *encode.EncodeState, f: *mir.MirFunction, total: u32) {
     save_callee_gp(st, f, total, false);
+    save_callee_fp(st, f, total, false);
     emit_mem_access(st, RRA, RSP, (total::i64) - 8, 8, true);    # ld ra, total-8(sp)
     emit_mem_access(st, RFP, RSP, (total::i64) - 16, 8, true);   # ld s0, total-16(sp)
     emit_sp_adjust(st, total, false);
@@ -894,14 +1558,42 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     if (is_mir_compare(mi.opcode))    { ret encode_compare(st, mi); }
     if (mi.opcode == mir.MIR_SEL_CBR) { ret encode_cbr(st, fn_base, mi); }
 
+    # the surviving divide / remainder sentinel expands into a single M-extension word
+    # (RISC-V's defined boundary results need no guard sequence).
+    if (is_mir_divide(mi.opcode)) { ret encode_divide(st, mi); }
+
     # the register-allocator's spill reload / store carries the generic MIR_MOV
-    # opcode; route it to the move encoder, which handles its frame-slot MEM operand.
-    if (mi.opcode == mir.MIR_MOV) { ret encode_mov(st, f, mi); }
+    # opcode; route a float spill (either operand a float register) to the FP move
+    # encoder, which handles the frame-slot fld / fsd, and a GP spill to the GP move
+    # encoder, which handles its frame-slot MEM operand.
+    if (mi.opcode == mir.MIR_MOV) {
+        if (reg_is_fp(?mi.operands[0]) || reg_is_fp(?mi.operands[1])) { ret encode_fmov(st, f, mi); }
+        ret encode_mov(st, f, mi);
+    }
 
     # memory: alloca / gep address arithmetic, and non-symbol load / store.
     if (mi.opcode == mir.MIR_ALLOCA || mi.opcode == mir.MIR_GEP) { ret encode_addr(st, f, mi); }
     if (mi.opcode == mir.MIR_LOAD)                               { ret encode_load(st, f, mi); }
     if (mi.opcode == mir.MIR_STORE)                              { ret encode_store(st, f, mi); }
+
+    # integer width / representation conversions.
+    if (mi.opcode == mir.MIR_TRUNC || mi.opcode == mir.MIR_SEXT ||
+        mi.opcode == mir.MIR_ZEXT || mi.opcode == mir.MIR_BITCAST) {
+        ret encode_convert(st, mi);
+    }
+
+    # the scalar float arithmetic / negate / comparison ops survive selection keeping
+    # their dedicated MIR opcode; the encoder materializes the RV64D scalar-FP byte
+    # sequence here (the operands resolved from float registers or spilled frame slots
+    # through the FP scratch pair). they reference no branch target or relocatable
+    # symbol, so no fixup / reloc applies.
+    if (is_mir_float_arith(mi.opcode)) { ret encode_fp_arith(st, f, mi); }
+    if (mi.opcode == mir.MIR_FNEG)     { ret encode_fp_neg(st, f, mi); }
+    if (mi.opcode == mir.MIR_FCMP)     { ret encode_fp_cmp(st, f, mi); }
+
+    # the float conversions survive selection keeping their dedicated MIR_FP_* opcode;
+    # the encoder materializes the fcvt family here.
+    if (is_mir_float_conv(mi.opcode)) { ret encode_fp_conv(st, f, mi); }
 
     if (mi.opcode == mir.MIR_CALL) { ret encode_call(st, mi); }
 
@@ -918,6 +1610,7 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     if (op == riscv64.NEG::u16)    { ret encode_neg(st, mi); }
     if (op == riscv64.NOT::u16)    { ret encode_not(st, mi); }
     if (op == riscv64.MOV::u16)    { ret encode_mov(st, f, mi); }
+    if (op == riscv64.FMV::u16)    { ret encode_fmov(st, f, mi); }
     if (op == riscv64.JMP::u16)    { ret encode_branch(st, fn_base, mi); }
     if (op == riscv64.RET::u16)    { emit_word(st, pack_i(JALR, F3_ADD, RZERO, RRA, 0)); ret R.ok[bool, str](true); }
     if (op == riscv64.NOP::u16)    { emit_word(st, pack_i(OP_IMM, F3_ADD, RZERO, RZERO, 0)); ret R.ok[bool, str](true); }
@@ -930,13 +1623,11 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
 # prologue (skipped for a naked asm-only function, whose inline asm owns the stack),
 # then each block - emitting the epilogue before every RET - recording each block's
 # `.text` offset for branch patching. extern / body-less functions contribute no
-# text. callee-saved FP registers are deferred to the float slice and rejected loudly.
+# text. the callee-saved GP and FP registers are spilled / reloaded by the prologue /
+# epilogue from the frame facts.
 fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result[bool, str] {
     val fn_base: u32 = st.buf.len::u32;
     if (f.block_count == 0) { ret R.ok[bool, str](true); }
-    if (f.callee_mask_fp != 0) {
-        ret R.err[bool, str]("encode: riscv64 float callee-saves await the float slice");
-    }
 
     val ms: R.Result[bool, str] = encode.push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
     if (R.is_err[bool, str](ms)) { ret ms; }

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -167,6 +167,13 @@ val FCVT_WU: u32 = 0x1;
 val FCVT_L:  u32 = 0x2;
 val FCVT_LU: u32 = 0x3;
 
+# the rs2 source-format selector of a float-to-float FCVT (a distinct id space from
+# the integer-width selectors above): single = 0, double = 1. the destination format
+# rides the funct7 (F7_FCVT_F2F selects single, `| 1` double), so the rs2 names the
+# other side - fcvt.s.d reads FMT_D, fcvt.d.s reads FMT_S.
+val FMT_S: u32 = 0x0;
+val FMT_D: u32 = 0x1;
+
 # the two fixed FP scratch registers the float-op encoder routes spilled operands
 # through. f31 (the vtable's `fp_scratch_reg`, composite-tagged there) is the primary
 # scratch - a spilled left / source operand and the compute register for a spilled
@@ -1213,14 +1220,14 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
         val rnr: R.Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH, sw);
         if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
         val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
-        # fcvt.s.d narrows (double result selector 0x20, source rs2 = 1, rm dynamic);
-        # fcvt.d.s widens (double result selector 0x21, source rs2 = 0, exact rm).
+        # fcvt.s.d narrows (single result funct7 0x20, double source FMT_D, rm dynamic);
+        # fcvt.d.s widens (double result funct7 0x21, single source FMT_S, exact rm).
         var f7: u32 = F7_FCVT_F2F;       # 0x20 -> single dest (fcvt.s.d)
-        var rs2: u32 = FCVT_L;            # rs2 = 1 selects the double source
+        var rs2: u32 = FMT_D;             # double source
         var rm: u32 = RM_DYN;
         if (op == mir.MIR_FP_EXT) {
             f7  = F7_FCVT_F2F | 1;        # 0x21 -> double dest (fcvt.d.s)
-            rs2 = FCVT_W;                 # rs2 = 0 selects the single source
+            rs2 = FMT_S;                  # single source
             rm  = RM_RNE;
         }
         val dst: *mir.MirOperand = ?mi.operands[0];
@@ -2344,5 +2351,257 @@ test "mach.lang.target.isa.riscv64.encode:asm_clobbers_classification" {
     if (asm_reg_index("t6") != 31)  { bad = 1; }
     if (asm_reg_index("notareg") != (0 - 1)) { bad = 1; }
 
+    ret bad;
+}
+
+# a float-bank physical register operand for register index `idx` (the composite
+# float id the allocator hands the float pre-coloring). fa0/fa1/fa2 = f10/f11/f12.
+fun fp_op(idx: i32) mir.MirOperand {
+    ret mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, idx)::u32);
+}
+
+# the M-extension divide / remainder family selects the right funct3 and the RV64
+# word group at 32-bit width, byte-exact against llvm-mc. a0/a1/a2 = x10/x11/x12.
+test "mach.lang.target.isa.riscv64.encode:divide_family" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(10); ops[1] = mir.op_preg(11); ops[2] = mir.op_preg(12);
+    mi.operands = ?ops[0]; mi.operand_count = 3; mi.width = 8;
+
+    # div = 0x02c5c533 ; divu = 0x02c5d533 ; rem = 0x02c5e533 ; remu = 0x02c5f533
+    mi.opcode = mir.MIR_SEL_DIV_S; encode_divide(?st, ?mi);
+    if (read_word(?st.buf, 0) != 0x02C5C533) { bad = 1; }
+    mi.opcode = mir.MIR_SEL_DIV_U; encode_divide(?st, ?mi);
+    if (read_word(?st.buf, 4) != 0x02C5D533) { bad = 1; }
+    mi.opcode = mir.MIR_SEL_REM_S; encode_divide(?st, ?mi);
+    if (read_word(?st.buf, 8) != 0x02C5E533) { bad = 1; }
+    mi.opcode = mir.MIR_SEL_REM_U; encode_divide(?st, ?mi);
+    if (read_word(?st.buf, 12) != 0x02C5F533) { bad = 1; }
+
+    # the word forms at 32-bit width: divw = 0x02c5c53b ; remw = 0x02c5e53b
+    st.buf.len = 0; mi.width = 4;
+    mi.opcode = mir.MIR_SEL_DIV_S; encode_divide(?st, ?mi);
+    if (read_word(?st.buf, 0) != 0x02C5C53B) { bad = 1; }
+    mi.opcode = mir.MIR_SEL_REM_S; encode_divide(?st, ?mi);
+    if (read_word(?st.buf, 4) != 0x02C5E53B) { bad = 1; }
+
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the integer width / representation conversions select sext.w / the shift pairs /
+# andi off the source and destination widths, byte-exact against llvm-mc.
+test "mach.lang.target.isa.riscv64.encode:integer_conversions" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [2]mir.MirOperand;
+    ops[0] = mir.op_preg(10); ops[1] = mir.op_preg(11);  # a0, a1
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # TRUNC -> sext.w a0, a1 = 0x0005851b
+    mi.opcode = mir.MIR_TRUNC; mi.width = 4; mi.src_width = 8;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 0) != 0x0005851B) { bad = 1; }
+
+    # BITCAST width 8 -> mv a0, a1 = 0x00058513 ; width 4 -> sext.w a0, a1 = 0x0005851b
+    st.buf.len = 0;
+    mi.opcode = mir.MIR_BITCAST; mi.width = 8; mi.src_width = 8;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 0) != 0x00058513) { bad = 1; }
+    mi.width = 4; mi.src_width = 4;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 4) != 0x0005851B) { bad = 1; }
+
+    # SEXT sw=4 -> sext.w = 0x0005851b ; sw=2 -> slli 48 ; srai 48 ; sw=1 -> slli 56 ; srai 56
+    st.buf.len = 0;
+    mi.opcode = mir.MIR_SEXT; mi.width = 8; mi.src_width = 4;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 0) != 0x0005851B) { bad = 1; }
+    st.buf.len = 0; mi.src_width = 2;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 0) != 0x03059513) { bad = 1; }  # slli a0,a1,48
+    if (read_word(?st.buf, 4) != 0x43055513) { bad = 1; }  # srai a0,a0,48
+    st.buf.len = 0; mi.src_width = 1;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 0) != 0x03859513) { bad = 1; }  # slli a0,a1,56
+    if (read_word(?st.buf, 4) != 0x43855513) { bad = 1; }  # srai a0,a0,56
+
+    # ZEXT sw=1 -> andi a0,a1,0xff = 0x0ff5f513 ; sw=2 -> slli 48 ; srli 48 ;
+    # sw=4 -> slli 32 ; srli 32
+    st.buf.len = 0;
+    mi.opcode = mir.MIR_ZEXT; mi.width = 8; mi.src_width = 1;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 0) != 0x0FF5F513) { bad = 1; }
+    st.buf.len = 0; mi.src_width = 2;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 0) != 0x03059513) { bad = 1; }  # slli a0,a1,48
+    if (read_word(?st.buf, 4) != 0x03055513) { bad = 1; }  # srli a0,a0,48
+    st.buf.len = 0; mi.src_width = 4;
+    encode_convert(?st, ?mi);
+    if (read_word(?st.buf, 0) != 0x02059513) { bad = 1; }  # slli a0,a1,32
+    if (read_word(?st.buf, 4) != 0x02055513) { bad = 1; }  # srli a0,a0,32
+
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the RV64D scalar float arithmetic / negate / move / comparison forms are byte-exact
+# against llvm-mc. fa0/fa1/fa2 = f10/f11/f12 (composite float ids).
+test "mach.lang.target.isa.riscv64.encode:float_arith_neg_cmp" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = fp_op(10); ops[1] = fp_op(11); ops[2] = fp_op(12);
+    mi.operands = ?ops[0]; mi.operand_count = 3; mi.width = 8;
+
+    # fadd.d = 0x02c5f553 ; fsub.d = 0x0ac5f553 ; fmul.d = 0x12c5f553 ; fdiv.d = 0x1ac5f553
+    mi.opcode = mir.MIR_FADD; encode_fp_arith(?st, nil, ?mi);
+    if (read_word(?st.buf, 0)  != 0x02C5F553) { bad = 1; }
+    mi.opcode = mir.MIR_FSUB; encode_fp_arith(?st, nil, ?mi);
+    if (read_word(?st.buf, 4)  != 0x0AC5F553) { bad = 1; }
+    mi.opcode = mir.MIR_FMUL; encode_fp_arith(?st, nil, ?mi);
+    if (read_word(?st.buf, 8)  != 0x12C5F553) { bad = 1; }
+    mi.opcode = mir.MIR_FDIV; encode_fp_arith(?st, nil, ?mi);
+    if (read_word(?st.buf, 12) != 0x1AC5F553) { bad = 1; }
+
+    # fadd.s (width 4) = 0x00c5f553
+    st.buf.len = 0; mi.width = 4;
+    mi.opcode = mir.MIR_FADD; encode_fp_arith(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0x00C5F553) { bad = 1; }
+
+    # fneg.d fa0,fa1 = fsgnjn.d fa0,fa1,fa1 = 0x22b59553
+    st.buf.len = 0; mi.width = 8; mi.operand_count = 2;
+    mi.opcode = mir.MIR_FNEG; encode_fp_neg(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0x22B59553) { bad = 1; }
+
+    # the compares write a GP boolean directly: feq.d a0,fa1,fa2 = 0xa2c5a553 ;
+    # flt.d = 0xa2c59553 ; fle.d = 0xa2c58553 ; ne = feq ; xori a0,a0,1 (0x00154513)
+    st.buf.len = 0;
+    var ci: mir.MirInstr;
+    var cops: [3]mir.MirOperand;
+    cops[0] = mir.op_preg(10); cops[1] = fp_op(11); cops[2] = fp_op(12);  # a0, fa1, fa2
+    ci.operands = ?cops[0]; ci.operand_count = 3; ci.width = 8; ci.opcode = mir.MIR_FCMP;
+    ci.src_width = mir.FCC_EQ; encode_fp_cmp(?st, nil, ?ci);
+    if (read_word(?st.buf, 0) != 0xA2C5A553) { bad = 1; }
+    st.buf.len = 0; ci.src_width = mir.FCC_LT; encode_fp_cmp(?st, nil, ?ci);
+    if (read_word(?st.buf, 0) != 0xA2C59553) { bad = 1; }
+    st.buf.len = 0; ci.src_width = mir.FCC_LE; encode_fp_cmp(?st, nil, ?ci);
+    if (read_word(?st.buf, 0) != 0xA2C58553) { bad = 1; }
+    st.buf.len = 0; ci.src_width = mir.FCC_NE; encode_fp_cmp(?st, nil, ?ci);
+    if (read_word(?st.buf, 0) != 0xA2C5A553) { bad = 1; }  # feq.d a0,fa1,fa2
+    if (read_word(?st.buf, 4) != 0x00154513) { bad = 1; }  # xori a0,a0,1
+
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the float conversions select the fcvt / fmv forms off the source / destination
+# widths and signedness, byte-exact against llvm-mc.
+test "mach.lang.target.isa.riscv64.encode:float_conversions" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [2]mir.MirOperand;
+    mi.operands = ?ops[0]; mi.operand_count = 2;
+
+    # FP_TRUNC f64->f32: fcvt.s.d fa0,fa1 = 0x4015f553
+    ops[0] = fp_op(10); ops[1] = fp_op(11);
+    mi.opcode = mir.MIR_FP_TRUNC; mi.width = 4; mi.src_width = 8;
+    encode_fp_conv(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0x4015F553) { bad = 1; }
+
+    # FP_EXT f32->f64: fcvt.d.s fa0,fa1 = 0x42058553
+    st.buf.len = 0;
+    mi.opcode = mir.MIR_FP_EXT; mi.width = 8; mi.src_width = 4;
+    encode_fp_conv(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0x42058553) { bad = 1; }
+
+    # SI_TO_FP i64->f64: fcvt.d.l fa0,a1 = 0xd2257553 ; i32->f64: fcvt.d.w = 0xd2058553
+    st.buf.len = 0;
+    ops[0] = fp_op(10); ops[1] = mir.op_preg(11);  # fa0, a1
+    mi.opcode = mir.MIR_SI_TO_FP; mi.width = 8; mi.src_width = 8;
+    encode_fp_conv(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0xD225F553) { bad = 1; }
+    st.buf.len = 0; mi.src_width = 4;
+    encode_fp_conv(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0xD2058553) { bad = 1; }
+
+    # FP_TO_SI f64->i64: fcvt.l.d a0,fa1,rtz = 0xc2259553 ; f64->i32: fcvt.w.d = 0xc2059553
+    st.buf.len = 0;
+    ops[0] = mir.op_preg(10); ops[1] = fp_op(11);  # a0, fa1
+    mi.opcode = mir.MIR_FP_TO_SI; mi.width = 8; mi.src_width = 8;
+    encode_fp_conv(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0xC2259553) { bad = 1; }
+    st.buf.len = 0; mi.width = 4;
+    encode_fp_conv(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0xC2059553) { bad = 1; }
+
+    # FP_TO_UI f64->u64: fcvt.lu.d a0,fa1,rtz = 0xc2359553
+    st.buf.len = 0;
+    mi.opcode = mir.MIR_FP_TO_UI; mi.width = 8; mi.src_width = 8;
+    encode_fp_conv(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0xC2359553) { bad = 1; }
+
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the fmv float-move / cross-bank reinterpret and the float loads / stores are
+# byte-exact against llvm-mc.
+test "mach.lang.target.isa.riscv64.encode:fmov_and_float_memory" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [2]mir.MirOperand;
+    mi.operands = ?ops[0]; mi.operand_count = 2; mi.width = 8;
+
+    # float copy fa0 <- fa1: fmv.d fa0,fa1 = 0x22b58553
+    ops[0] = fp_op(10); ops[1] = fp_op(11);
+    encode_fmov(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0x22B58553) { bad = 1; }
+
+    # GP->FP fa0 <- a1: fmv.d.x fa0,a1 = 0xf2058553
+    st.buf.len = 0;
+    ops[0] = fp_op(10); ops[1] = mir.op_preg(11);
+    encode_fmov(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0xF2058553) { bad = 1; }
+
+    # FP->GP a0 <- fa1: fmv.x.d a0,fa1 = 0xe2058553
+    st.buf.len = 0;
+    ops[0] = mir.op_preg(10); ops[1] = fp_op(11);
+    encode_fmov(?st, nil, ?mi);
+    if (read_word(?st.buf, 0) != 0xE2058553) { bad = 1; }
+
+    # the float loads / stores by width: fld/fsd (8), flw/fsw (4) of fa0 at 16(a1)
+    st.buf.len = 0;
+    emit_fp_mem(?st, 10, 11, 16, 8, true);   # fld fa0,16(a1) = 0x0105b507
+    emit_fp_mem(?st, 10, 11, 16, 8, false);  # fsd fa0,16(a1) = 0x00a5b827
+    emit_fp_mem(?st, 10, 11, 16, 4, true);   # flw fa0,16(a1) = 0x0105a507
+    emit_fp_mem(?st, 10, 11, 16, 4, false);  # fsw fa0,16(a1) = 0x00a5a827
+    if (read_word(?st.buf, 0)  != 0x0105B507) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0x00A5B827) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0x0105A507) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0x00A5A827) { bad = 1; }
+
+    encode.buf_dnit(?st.buf);
     ret bad;
 }

--- a/src/lang/target/isa/riscv64/isel.mach
+++ b/src/lang/target/isa/riscv64/isel.mach
@@ -330,3 +330,83 @@ fun write_opcode_ice(opcode: u32) {
     os.write(os.STDERR_FD, ?digits[0], len);
     os.write(os.STDERR_FD, "\n", 1);
 }
+
+# a float-bank physical register operand for register index `idx` (the composite
+# float id the allocator hands the float pre-coloring), so a test can drive the
+# float-vs-GP move classification without a vreg table.
+fun fp_preg(idx: i32) mir.MirOperand {
+    ret mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, idx)::u32);
+}
+
+# selection rewrites each generic MIR opcode in place into the concrete RV64 opcode
+# (or the surviving sentinel / pass-through), keying the float-vs-GP move on the
+# operand register class. all-physical-register operands keep the test free of a
+# vreg table; `select` only nil-checks its target and allocator, so a zeroed pair
+# suffices.
+test "mach.lang.target.isa.riscv64.isel:opcode_rewrites" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    var tgt:   target.Target;
+
+    var instrs: [13]mir.MirInstr;
+    var ops:    [13][3]mir.MirOperand;
+    var i:      u32 = 0;
+    for (i < 13) {
+        ops[i][0] = mir.op_preg(10);
+        ops[i][1] = mir.op_preg(11);
+        ops[i][2] = mir.op_preg(12);
+        instrs[i].operands      = ?ops[i][0];
+        instrs[i].operand_count = 3;
+        instrs[i].width         = 8;
+        i = i + 1;
+    }
+
+    # the three-address integer ops, shifts, divide, and negate / not.
+    instrs[0].opcode  = mir.MIR_ADD;
+    instrs[1].opcode  = mir.MIR_SHL;
+    instrs[2].opcode  = mir.MIR_DIV_S;
+    instrs[3].opcode  = mir.MIR_NEG;
+    # the surviving compare / conditional-branch / float-arith pass-throughs.
+    instrs[4].opcode  = mir.MIR_CMP_EQ;
+    instrs[5].opcode  = mir.MIR_CBR;
+    instrs[6].opcode  = mir.MIR_FADD;
+    # a GP move and a float move - the float one keys FMV off the operand class.
+    instrs[7].opcode  = mir.MIR_MOV;
+    instrs[8].opcode  = mir.MIR_MOV;
+    ops[8][0] = fp_preg(10); ops[8][1] = fp_preg(11);
+    # a cross-bank `:~` bitcast selects FMV; a same-bank one stays MIR_BITCAST.
+    instrs[9].opcode  = mir.MIR_BITCAST;
+    ops[9][0] = fp_preg(10); ops[9][1] = mir.op_preg(11);
+    instrs[10].opcode = mir.MIR_BITCAST;
+    # control flow.
+    instrs[11].opcode = mir.MIR_BR;
+    instrs[12].opcode = mir.MIR_RET;
+
+    var blk: mir.MirBlock;
+    blk.id          = 0;
+    blk.instrs      = ?instrs[0];
+    blk.instr_count = 13;
+
+    var fn: mir.MirFunction;
+    fn.blocks      = ?blk;
+    fn.block_count = 1;
+
+    val r: R.Result[bool, str] = select(?alloc, ?tgt, ?fn);
+    if (R.is_err[bool, str](r)) { ret 1; }
+
+    if (instrs[0].opcode  != riscv64.ADD::u32)    { bad = 1; }
+    if (instrs[1].opcode  != riscv64.SLL::u32)    { bad = 1; }
+    if (instrs[2].opcode  != mir.MIR_SEL_DIV_S)   { bad = 1; }
+    if (instrs[3].opcode  != riscv64.NEG::u32)    { bad = 1; }
+    if (instrs[4].opcode  != mir.MIR_SEL_CMP_EQ)  { bad = 1; }
+    if (instrs[5].opcode  != mir.MIR_SEL_CBR)     { bad = 1; }
+    if (instrs[6].opcode  != mir.MIR_FADD)        { bad = 1; }  # float arith survives
+    if (instrs[7].opcode  != riscv64.MOV::u32)    { bad = 1; }  # GP move
+    if (instrs[8].opcode  != riscv64.FMV::u32)    { bad = 1; }  # float move
+    if (instrs[9].opcode  != riscv64.FMV::u32)    { bad = 1; }  # cross-bank bitcast
+    if (instrs[10].opcode != mir.MIR_BITCAST)     { bad = 1; }  # same-bank bitcast survives
+    if (instrs[11].opcode != riscv64.JMP::u32)    { bad = 1; }
+    if (instrs[12].opcode != riscv64.RET::u32)    { bad = 1; }
+
+    ret bad;
+}

--- a/src/lang/target/isa/riscv64/isel.mach
+++ b/src/lang/target/isa/riscv64/isel.mach
@@ -1,0 +1,332 @@
+# RISC-V (RV64) instruction selection - the riscv64 ISA's `select` entry point
+#
+# This is the RV64 implementation of the ISA vtable's `select` operation, reached
+# only through `tgt.arch.select` by the shared `be.codegen.isel` dispatcher. It is
+# the only target-specific back-end selection phase; register allocation, frame
+# layout, and encoding are shared. `mir.lower_ir` has already produced a
+# `MirFunction` whose instructions carry *generic* MIR opcodes that mirror the IR
+# `OP_*` values, plus the call / phi pseudo-opcodes. Instruction selection rewrites
+# each generic opcode into the concrete RV64 encoder opcode this ISA owns (see
+# `riscv64` and `riscv64.encode`).
+#
+# RISC-V is three-address (`rd, rs1, rs2`) like AArch64, so the integer binary ops
+# are rewritten IN PLACE to a concrete three-address opcode rather than surviving as
+# a two-address sentinel: register allocation keys an instruction's def/use shape on
+# its operands (operand 0 a pure def), not its opcode, so a concrete three-address
+# form is read correctly. Every such rewrite is 1:1 - the operand list already
+# matches the machine form and only `opcode` changes - and no block-list rebuild is
+# ever needed (the x86-64 NEG/NOT multi-instruction expansion has no RV64 analogue:
+# NEG is a single `sub rd, x0, rs` and NOT a single `xori rd, rs, -1`, both folded
+# by the encoder from the surviving `[dst, src]`).
+#
+# A handful of generic opcodes survive selection with a high selection-output
+# sentinel so the encoder can materialize a short byte sequence from them:
+#   - the comparison family (`MIR_CMP_* -> MIR_SEL_CMP_*`): RISC-V has no condition-
+#     flags register, so the encoder synthesizes the 0/1 boolean from the
+#     set-less-than primitives (`slt`/`sltu` + the `seqz`/`snez` idioms), keeping
+#     operand 0 a clean boolean def the register allocator reads correctly.
+#   - the conditional branch (`MIR_CBR -> MIR_SEL_CBR`): the encoder lowers it to
+#     `bne cond, x0, then ; j else`, keeping both block targets and the condition on
+#     one terminator so the allocator reads the condition as a use and resolves both
+#     successor edges for liveness.
+#   - the division / remainder family (`MIR_DIV_*`/`MIR_REM_*` -> `MIR_SEL_DIV_*`/
+#     `MIR_SEL_REM_*`): the shared lowering emits a clean three-address `[dst,
+#     dividend, divisor]` op (RV64 wires no fixed division register); the encoder
+#     lowers it to the M-extension `div`/`divu`/`rem`/`remu` (the word forms at
+#     32-bit width), whose RISC-V-defined divide-by-zero / overflow results need no
+#     guard sequence. the rewrite to a high sentinel keeps the generic opcode from
+#     colliding with a concrete RV64 opcode of the same low value.
+#
+# The memory opcodes (`MIR_ALLOCA`, `MIR_GEP`, `MIR_LOAD`, `MIR_STORE`) and the
+# integer width / representation conversions (`MIR_TRUNC`, `MIR_SEXT`, `MIR_ZEXT`,
+# `MIR_BITCAST`) survive selection unchanged: their generic opcode values sit above
+# the concrete RV64 opcode space, so the encoder dispatches them directly
+# (ALLOCA/GEP to addi / add address arithmetic, LOAD/STORE to width-driven loads /
+# stores, the conversions to sext.w / the shift-pair sign / zero extensions) without
+# a sentinel rewrite, and the register allocator reads operand 0 as a clean def (or
+# the memory destination for a store).
+#
+# The call / phi pseudo-opcodes (`MIR_CALL`, `MIR_CALL_RES`, `MIR_ARG`, `MIR_PHI`)
+# pass through unchanged for the shared ABI / register-allocation passes. The scalar
+# float arithmetic / comparison / negate ops and the float conversions pass through
+# unchanged (high-sentinel MIR opcodes the encoder materializes into RV64D scalar-FP
+# byte sequences); a float register copy and a GP<->FP `:~` bitcast are rewritten to
+# the concrete FMV. Inline asm (`MIR_ASM`) passes through unchanged for the encoder
+# to assemble its body. Any opcode this selector does not model fails loudly with an
+# ICE so `select` is total - every opcode path returns a definite result.
+#
+# WIDTH-HONESTY: the selection patterns here (MIR op -> RV64 opcode) carry no XLEN
+# assumption - the same map drives an RV32 (ilp32) sibling unchanged. The W-vs-full
+# ALU form, the load / store width, the constant-materialization length, and the
+# slot-width thresholds are all the encoder's choice off the operation's OPERAND
+# SIZE, never decided here.
+
+use std.system.os;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+
+use A: std.allocator;
+use R: std.types.result;
+
+use mach.lang.be.codegen.mir;
+use mach.lang.target.isa;
+use mach.lang.target.isa.riscv64;
+use target: mach.lang.target.resolved;
+
+# the concrete signature the erased `isa.IsaVTable.select` pointer is cast back to,
+# matching the shared `be.codegen.isel.SelectFn`
+#
+# The vtable stores `select` type-erased (`*u8`); the shared dispatcher casts it
+# back to this type before calling it.
+# ---
+# a:   backing allocator (threaded for parity with the shared SelectFn; the RV64
+#      selector rewrites in place and never reallocates a block)
+# tgt: resolved compilation target (must be RISC-V)
+# fn:  the MIR function to select instructions for; mutated in place
+# ret: ok(true) on success, or an error naming the failure
+pub def SelectFn: fun(*A.Allocator, *target.Target, *mir.MirFunction) R.Result[bool, str];
+
+# select concrete RV64 instructions for one MIR function
+#
+# Walks every block and rewrites each generic MIR opcode in place into the concrete
+# RV64 encoder opcode (or leaves it as a surviving sentinel / pass-through), failing
+# loudly on an opcode this selector does not model. This is the RV64 implementation
+# behind the ISA vtable's `select` slot, reached only through `tgt.arch.select` by
+# the shared `be.codegen.isel.run` dispatcher.
+# ---
+# a:   backing allocator (unused; the RV64 selector rewrites in place)
+# tgt: resolved compilation target (must be RISC-V)
+# fn:  the MIR function to select instructions for; mutated in place
+# ret: ok(true) on success, or an error naming the failure
+pub fun select(a: *A.Allocator, tgt: *target.Target, fn: *mir.MirFunction) R.Result[bool, str] {
+    if (a == nil)   { ret R.err[bool, str]("isel: nil allocator"); }
+    if (tgt == nil) { ret R.err[bool, str]("isel: nil target"); }
+    if (fn == nil)  { ret R.err[bool, str]("isel: nil mir function"); }
+
+    var bi: u32 = 0;
+    for (bi < fn.block_count) {
+        val b: *mir.MirBlock = ?fn.blocks[bi];
+
+        var ii: u32 = 0;
+        for (ii < b.instr_count) {
+            val res_rewrite: R.Result[bool, str] = rewrite(fn, ?b.instrs[ii]);
+            if (R.is_err[bool, str](res_rewrite)) { ret res_rewrite; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+
+    ret R.ok[bool, str](true);
+}
+
+# rewrite a single generic MIR opcode in place into its concrete RV64 encoder
+# opcode, or leave it as a surviving sentinel / pass-through
+#
+# The operand list already matches the machine form, so only `opcode` changes.
+# Fails loudly on an opcode the RV64 leaf backend does not model.
+# ---
+# fn:  the MIR function owning the instruction (for operand bank classification)
+# mi:  the instruction to rewrite in place
+# ret: ok(true) on success, or an ICE error for an unmodelled opcode
+fun rewrite(fn: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
+    val o: mir.MirOpcode = mi.opcode;
+
+    # the three-address integer binary ALU ops rewrite to a concrete RV64 three-
+    # address opcode: operand 0 stays a pure def and the encoder packs one
+    # `op rd, rs1, rs2` word (folding an immediate right operand into the `addi` /
+    # `andi` / shift-immediate form or materializing it through a scratch).
+    if (o == mir.MIR_ADD) { mi.opcode = riscv64.ADD::u32; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_SUB) { mi.opcode = riscv64.SUB::u32; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_MUL) { mi.opcode = riscv64.MUL::u32; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_AND) { mi.opcode = riscv64.AND::u32; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_OR)  { mi.opcode = riscv64.OR::u32;  ret R.ok[bool, str](true); }
+    if (o == mir.MIR_XOR) { mi.opcode = riscv64.XOR::u32; ret R.ok[bool, str](true); }
+
+    # the shifts rewrite to a single RV64 shift opcode (no x86-64 CL constraint): the
+    # encoder selects the register variant (sll/srl/sra) or the immediate variant
+    # (slli/srli/srai, masking the shift amount) from operand 2's kind, and the RV64
+    # word form (sllw/srlw/sraw) at 32-bit operand width.
+    if (o == mir.MIR_SHL)   { mi.opcode = riscv64.SLL::u32; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_SHR_U) { mi.opcode = riscv64.SRL::u32; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_SHR_S) { mi.opcode = riscv64.SRA::u32; ret R.ok[bool, str](true); }
+
+    # division / remainder survive selection as a three-address `[dst, dividend,
+    # divisor]` instruction (operand 0 a pure def), rewritten to a high SELECTION-
+    # OUTPUT sentinel so the encoder never confuses the generic opcode with a
+    # concrete RV64 opcode of the same low value (MIR_REM_U = 6 = riscv64.OR). the
+    # encoder materializes the M-extension div / divu / rem / remu (word forms at
+    # 32-bit width); RISC-V defines the divide-by-zero and signed-overflow results,
+    # so no guard sequence is needed.
+    if (o == mir.MIR_DIV_S) { mi.opcode = mir.MIR_SEL_DIV_S; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_DIV_U) { mi.opcode = mir.MIR_SEL_DIV_U; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_REM_S) { mi.opcode = mir.MIR_SEL_REM_S; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_REM_U) { mi.opcode = mir.MIR_SEL_REM_U; ret R.ok[bool, str](true); }
+
+    # negate and complement are single RV64 instructions (no x86-64 multi-instruction
+    # expansion): NEG is `sub rd, x0, rs` (the `neg` alias) and NOT is `xori rd, rs,
+    # -1` (the `not` alias). the encoder supplies the missing operand from the
+    # surviving `[dst, src]`.
+    if (o == mir.MIR_NEG) { mi.opcode = riscv64.NEG::u32; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_NOT) { mi.opcode = riscv64.NOT::u32; ret R.ok[bool, str](true); }
+
+    # the register-to-register / ABI pre-coloring move selects to a plain MOV (`mv
+    # rd, rs` for a register source, an `li` materialization for an immediate). a
+    # FLOAT move - either operand a float vreg or a float-class pre-color - selects to
+    # FMV instead, whose encoder emits the `fmv` family and dispatches the spilled
+    # frame-slot forms by register class, so a float copy never mis-encodes as a GP
+    # move of the aliasing register index. the spill reload / store moves regalloc
+    # inserts after selection keep the generic MIR_MOV (the encoder routes a float
+    # spill to the FP path by operand class).
+    if (o == mir.MIR_MOV) {
+        if (operand_is_fp(fn, ?mi.operands[0]) || operand_is_fp(fn, ?mi.operands[1])) {
+            mi.opcode = riscv64.FMV::u32;
+        }
+        or {
+            mi.opcode = riscv64.MOV::u32;
+        }
+        ret R.ok[bool, str](true);
+    }
+
+    # control flow. an unconditional branch selects to JMP (`j`); a return to RET; an
+    # unreachable terminator to an `ebreak` trap.
+    if (o == mir.MIR_BR)          { mi.opcode = riscv64.JMP::u32;    ret R.ok[bool, str](true); }
+    if (o == mir.MIR_RET)         { mi.opcode = riscv64.RET::u32;    ret R.ok[bool, str](true); }
+    if (o == mir.MIR_UNREACHABLE) { mi.opcode = riscv64.EBREAK::u32; ret R.ok[bool, str](true); }
+
+    # the comparison family survives selection as a single `[dst, lhs, rhs]`
+    # instruction keeping its generic opcode, rewritten to a high SELECTION-OUTPUT
+    # sentinel so the encoder never confuses it with a concrete RV64 opcode of the
+    # same low value; the encoder materializes the set-less-than byte sequence,
+    # reading the relation (and its signedness) from the opcode.
+    if (o == mir.MIR_CMP_EQ)   { mi.opcode = mir.MIR_SEL_CMP_EQ;   ret R.ok[bool, str](true); }
+    if (o == mir.MIR_CMP_NE)   { mi.opcode = mir.MIR_SEL_CMP_NE;   ret R.ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LT_S) { mi.opcode = mir.MIR_SEL_CMP_LT_S; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LT_U) { mi.opcode = mir.MIR_SEL_CMP_LT_U; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LE_S) { mi.opcode = mir.MIR_SEL_CMP_LE_S; ret R.ok[bool, str](true); }
+    if (o == mir.MIR_CMP_LE_U) { mi.opcode = mir.MIR_SEL_CMP_LE_U; ret R.ok[bool, str](true); }
+
+    # the conditional branch survives selection as a single
+    # `[cond, then_block, else_block]` instruction (high sentinel): the allocator
+    # reads `cond` as a use and both block operands as the two successor edges; the
+    # encoder materializes the `bne cond, x0, then ; j else` byte sequence.
+    if (o == mir.MIR_CBR) { mi.opcode = mir.MIR_SEL_CBR; ret R.ok[bool, str](true); }
+
+    # memory ops survive selection unchanged (their generic opcode values are above
+    # the concrete RV64 opcode space, so the encoder dispatches them without a
+    # sentinel rewrite). ALLOCA / GEP select to RV64 address arithmetic (addi / add),
+    # and LOAD / STORE to the width-driven loads / stores; operand 0 stays a clean def
+    # (or the memory destination for a store), so the register allocator reads the
+    # def/use shape correctly. a frame-slot MEM base survives to the encoder, which
+    # resolves it to `[s0 + slot.offset]`.
+    if (o == mir.MIR_ALLOCA || o == mir.MIR_LOAD || o == mir.MIR_STORE ||
+        o == mir.MIR_GEP) {
+        ret R.ok[bool, str](true);
+    }
+
+    # call / phi pseudo-opcodes survive selection unchanged. MIR_CALL is the
+    # caller-saved clobber barrier the shared register allocator keys on; the
+    # argument, result, and phi pseudos are resolved (or skipped) downstream.
+    if (o == mir.MIR_CALL || o == mir.MIR_ARG || o == mir.MIR_CALL_RES ||
+        o == mir.MIR_PHI) {
+        ret R.ok[bool, str](true);
+    }
+
+    # the scalar float arithmetic / comparison / negate ops survive selection keeping
+    # their dedicated high-sentinel MIR opcode, like the integer compare / divide
+    # families: each is a clean `[dst, lhs, rhs]` (or `[dst, src]`) the register
+    # allocator reads by operand shape, and the encoder materializes the RV64D scalar-
+    # FP byte sequence (fadd/fsub/fmul/fdiv single words; feq/flt/fle for the
+    # comparison; fsgnjn for the negate) from the surviving opcode, sizing the S-vs-D
+    # form by `mi.width`.
+    if (o == mir.MIR_FADD || o == mir.MIR_FSUB || o == mir.MIR_FMUL ||
+        o == mir.MIR_FDIV || o == mir.MIR_FCMP || o == mir.MIR_FNEG) {
+        ret R.ok[bool, str](true);
+    }
+
+    # a bit reinterpret crossing the GP and float banks (`f64 :~ i64` / `i32 :~ f32`)
+    # selects to FMV, which transfers the raw bits between a GP register and an F/D
+    # register; the encoder picks the direction from operand register class. a
+    # same-bank reinterpret (GP<->GP) stays MIR_BITCAST - a plain register copy the
+    # integer conversion encoder handles. a float-to-float bitcast cannot occur (a
+    # reinterpret is equal-size and the only two float widths differ).
+    if (o == mir.MIR_BITCAST) {
+        if (operand_is_fp(fn, ?mi.operands[0]) != operand_is_fp(fn, ?mi.operands[1])) {
+            mi.opcode = riscv64.FMV::u32;
+        }
+        ret R.ok[bool, str](true);
+    }
+
+    # the integer width conversions and the float conversions survive selection
+    # unchanged: their generic opcode values sit above the concrete RV64 opcode space,
+    # so the encoder dispatches each directly (sext.w / the shift-pair sign / zero
+    # extensions for the integer forms; fcvt.s.d / fcvt.d.s / fcvt.*.* / fmv for the
+    # float forms) and the allocator reads operand 0 as a clean def.
+    if (o == mir.MIR_TRUNC || o == mir.MIR_SEXT || o == mir.MIR_ZEXT ||
+        o == mir.MIR_FP_TRUNC || o == mir.MIR_FP_EXT ||
+        o == mir.MIR_FP_TO_SI || o == mir.MIR_FP_TO_UI ||
+        o == mir.MIR_SI_TO_FP || o == mir.MIR_UI_TO_FP) {
+        ret R.ok[bool, str](true);
+    }
+
+    # inline assembly survives selection unchanged: the encoder parses the asm body
+    # and emits RV64 words directly. MIR_ASM carries no operands the selector
+    # rewrites; its `asm_block` payload is the inline-asm clobber barrier the register
+    # allocator keys on.
+    if (o == mir.MIR_ASM) { ret R.ok[bool, str](true); }
+
+    write_opcode_ice(o);
+    ret R.err[bool, str]("internal compiler error: unhandled MIR opcode in instruction selection");
+}
+
+# whether a MIR operand names a float-bank value
+#
+# True for a float vreg (read from the function's vreg classes) or a float-class
+# physical register (an ABI argument / return pre-color, read from the composite
+# register id's class tag). Drives the float-vs-GP move classification without
+# hardcoding a register.
+# ---
+# fn:  the MIR function owning the operand's vreg classes
+# op:  the operand to classify
+# ret: true when the operand rides the float bank
+fun operand_is_fp(fn: *mir.MirFunction, op: *mir.MirOperand) bool {
+    if (op.kind == mir.MIR_OP_VREG) { ret mir.vreg_is_fp(fn, op.vreg); }
+    if (op.kind == mir.MIR_OP_PREG) { ret isa.regid_class(op.preg::i32) == isa.REG_CLASS_ID_XMM; }
+    ret false;
+}
+
+# write "internal compiler error: unhandled MIR opcode <N>\n" to stderr ahead of an
+# ICE return, so the numeric opcode survives in crash logs
+# ---
+# opcode: the unmodelled MIR opcode to report
+fun write_opcode_ice(opcode: u32) {
+    os.write(os.STDERR_FD, "internal compiler error: unhandled MIR opcode ", 46);
+
+    var digits: [16]u8;
+    var len:    usize = 0;
+    if (opcode == 0) {
+        digits[0] = '0';
+        len       = 1;
+    }
+    or {
+        # emit decimal digits least-significant first, then reverse them in place
+        var v: u32 = opcode;
+        for (v > 0) {
+            digits[len] = (v % 10)::u8 + '0';
+            v   = v / 10;
+            len = len + 1;
+        }
+        var i: usize = 0;
+        for (i < len / 2) {
+            val swap: u8 = digits[i];
+            digits[i] = digits[len - 1 - i];
+            digits[len - 1 - i] = swap;
+            i = i + 1;
+        }
+    }
+
+    os.write(os.STDERR_FD, ?digits[0], len);
+    os.write(os.STDERR_FD, "\n", 1);
+}

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -7,13 +7,13 @@
 # children (the encoder, and the future selector) into the parent does not close an
 # import cycle.
 #
-# As of slice 2 the machine description carries the byte encoder (`encode`) and the
-# inline-asm clobber analyzer (`asm_clobbers`). The remaining codegen hooks
-# (`select` / `emit_asm` / `apply_reloc`) are left nil - the shared isel dispatcher
-# and the linker error loudly on a nil slot, exactly as they do for an unregistered
-# ISA, so a riscv64 target composes and the encoder runs while the unwired families
-# fail with a precise message. Later slices supply `riscv64.isel`, the inline-asm
-# assembler, and the `apply_reloc` registrar and point these slots at them.
+# As of slice 3 the machine description carries the instruction selector (`select`),
+# the byte encoder (`encode`), and the inline-asm clobber analyzer (`asm_clobbers`).
+# The remaining codegen hooks (`emit_asm` / `apply_reloc`) are left nil - the linker
+# errors loudly on a nil slot, exactly as it does for an unregistered ISA, so a
+# riscv64 target composes and the selector + encoder run while the unwired families
+# fail with a precise message. Later slices supply the inline-asm assembler and the
+# `apply_reloc` registrar and point these slots at them.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -24,6 +24,7 @@ use R: std.types.result;
 use mach.lang.target.isa;
 use mach.lang.target.isa.riscv64;
 use mach.lang.target.isa.riscv64.encode;
+use mach.lang.target.isa.riscv64.isel;
 
 # process-global storage for the RV64 vtable and its register classes. written
 # once by `register_riscv64` and borrowed by the vtable installed into the ISA
@@ -71,10 +72,11 @@ var riscv64_reload_scratch_regs: [3]isa.Register;
 # `reg`. Idempotent: the registry entry is write-once. Must run at compiler startup
 # before `target.select` requests a riscv64 target.
 #
-# Wires the slice-2 byte encoder (`encode`) and inline-asm clobber analyzer
-# (`asm_clobbers`); the `select` / `emit_asm` / `apply_reloc` hooks are left nil and
-# the shared isel dispatcher / linker error loudly when reached, so the target
-# composes and encodes while the unwired families wait on their later slices.
+# Wires the slice-3 instruction selector (`select`), the byte encoder (`encode`), and
+# the inline-asm clobber analyzer (`asm_clobbers`); the `emit_asm` / `apply_reloc`
+# hooks are left nil and the linker errors loudly when reached, so the target
+# composes, selects, and encodes while the unwired families wait on their later
+# slices.
 # ---
 # reg: the ISA registry to install the vtable into
 # ret: true on success
@@ -121,14 +123,14 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_vtable.pointer_width        = 8;
     riscv64_vtable.reg_classes          = ?riscv64_classes[0];
     riscv64_vtable.reg_class_count      = 2;
-    # slice 2 wires the byte encoder and the inline-asm clobber analyzer; both are
-    # stored type-erased (`*u8`) and cast back to their `EncodeFn` / `AsmClobbersFn`
-    # signatures by the shared dispatchers. `select` (slice 3 instruction selection),
-    # `emit_asm` (the inline-asm assembler), and `apply_reloc` (slice 4's linker / ELF
-    # relocation seam) stay nil - the dispatchers and linker error loudly on a nil
-    # slot, so a riscv64 target composes and the encoder runs while the unwired
-    # families fail with a precise message rather than emitting wrong code.
-    riscv64_vtable.select               = nil;
+    # slice 3 wires the instruction selector, the byte encoder, and the inline-asm
+    # clobber analyzer; all are stored type-erased (`*u8`) and cast back to their
+    # `SelectFn` / `EncodeFn` / `AsmClobbersFn` signatures by the shared dispatchers.
+    # `emit_asm` (the inline-asm assembler) and `apply_reloc` (slice 4's linker / ELF
+    # relocation seam) stay nil - the linker errors loudly on a nil slot, so a riscv64
+    # target composes, selects, and encodes while the unwired families fail with a
+    # precise message rather than emitting wrong code.
+    riscv64_vtable.select               = isel.select::*u8;
     riscv64_vtable.encode               = encode.encode_riscv64::*u8;
     riscv64_vtable.emit_asm             = nil;
     riscv64_vtable.asm_clobbers         = encode.asm_clobbers::*u8;


### PR DESCRIPTION
Slice 3 of the riscv64 backend (#1627, part of #1172): instruction selection (the SelectFn), the divide / conversion / float encode families slice 2 deferred, and the lp64d hard-float completion. Slices 1+2 and the foundation fixes are merged.

## Instruction selection (`isa/riscv64/isel.mach`, new)
The RV64 SelectFn, modeled on the arm64 selector (RISC-V is three-address). Lowers in place:
- integer arithmetic / logic / shift -> concrete RV64 opcodes (ADD/SUB/MUL/AND/OR/XOR/SLL/SRL/SRA), immediates folded by the encoder;
- NEG / NOT -> the single-instruction `neg` / `not` aliases;
- div / rem -> the `MIR_SEL_DIV_*` / `MIR_SEL_REM_*` sentinels;
- compares -> `MIR_SEL_CMP_*` (flags-less, the encoder synthesizes the boolean from set-less-than); conditional branch -> `MIR_SEL_CBR` (`bne ; j`);
- BR/RET/UNREACHABLE -> JMP/RET/EBREAK;
- a float MIR_MOV and a cross-bank `:~` bitcast -> the new `FMV` opcode (a float copy / GP<->FP reinterpret), keyed off operand register class;
- memory ops, calls, conversions, scalar-float ops, inline asm -> pass through unchanged. Unmodelled opcodes ICE so `select` is total.

## Encode families (`isa/riscv64/encode.mach`)
- **divide / remainder**: the M-extension `div` / `divu` / `rem` / `remu` (word forms at 32-bit width). RISC-V's defined divide-by-zero / signed-overflow results need no guard sequence.
- **integer conversions**: TRUNC -> `sext.w`; BITCAST -> `mv` / `sext.w`; SEXT -> `sext.w` or the `slli ; srai` pair; ZEXT -> `andi` (byte) or the `slli ; srli` pair.
- **RV64D float**: `fadd`/`fsub`/`fmul`/`fdiv`, `fsgnjn` (negate), `feq`/`flt`/`fle` (the compares write the GP boolean directly), the `fcvt` conversions (S<->D and to/from the integer file, round-toward-zero for float->int), the `fmv` move / cross-bank reinterpret, and `flw`/`fld`/`fsw`/`fsd`. Floats use the now-correct `fp_class_index` (#1624).
- **callee-saved FP** spill / reload added to the prologue / epilogue (the slice-2 loud error removed).

## lp64d completion (`abi/lp64.mach`)
- **hard-float struct flattening**: a struct that flattens to one or two homogeneous floating-point members rides the fa registers (CLASS_HFA, one member per register at its field offset), on both argument and return sides, reusing the shared CLASS_HFA machinery; falls back to the integer convention when the fa bank lacks the registers.

## Deferred (loud errors / conservative placement)
- **Slice 4 (#1628)** owns the pc-relative global-symbol relocs. Any isel pattern needing a NEW riscv reloc kind (taking a global's address, a folded global load/store via `la` = auipc+addi PCREL_HI20/LO12) stays deferred with the slice-2 loud error in `resolve_mem`. Direct calls via the existing RK_PLT32 marker, local computation, control flow, and stack/local access need no new reloc and are implemented.
- **Foundation gap (escalated, not papered over)**: the lp64d mixed float+integer struct rule, the different-width float pair, and the 9-16 byte integer register/stack split each need a shared `emit_arg_slot` slot the back end does not expose (CLASS_HFA is uniform-width FP-only, the reg2 pair is GP-only from fixed 0/8 offsets, and there is no register-plus-stack split class). Those aggregates stay on the conservative integer / by-value-stack path - self-consistent across a mach caller and callee, divergent from the C psABI only at an FFI boundary.

## Width-honesty
The selection patterns, the flags-less compare-and-branch idiom, the three-address forms, and the lp64/ilp32 register-role assignment are XLEN-agnostic. Every RV64-specific choice (the `*W` ALU at 32-bit width, LD/SD vs LW/SW, the 64-bit constant length, the lp64d slot width / 2*XLEN thresholds) is driven off operand size read from the machine model and localized + commented, so an rv32 / ESP32-C sibling extracts cleanly.

## Verification
- `mach build .` clean; `mach test .` 640 passed / 0 failed (was 633). New: 1 isel opcode-rewrite test, 5 byte-comparison encode tests (vs llvm-mc), 1 lp64d flattening test.
- No shared-backend codegen file edited (be/codegen/*, regalloc, frame, mir conventions, linker, of/of.elf, other-arch isel/encode). The only non-riscv64 edit is the riscv64-wiring test in `target.mach`, which slice 2 authored asserting `select == nil` and explicitly expected slice 3 to flip.
- riscv64 is still not default-selected (only its vtable is wired); the default x86_64 path is byte-identical, so no self-host fixpoint is required.

Closes #1627