### PR TITLE
feat(target): riscv64 relocations + asm printer (slice 4)

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1946,6 +1946,145 @@ fun ldst_lo12_scale(kind: of.RelocKind) i32 {
     ret -1;
 }
 
+# the byte gap from a riscv pc-relative low-12 instruction back to its paired auipc in
+# the `la` (load-address) sequence. the auipc immediately precedes the low instruction
+# (load / addi / store), so the low instruction's patch_va minus this gap recovers the
+# auipc's pc - the pc the low-12 displacement is measured from. baking the gap in lets
+# the lo12 relocation name the same global as its paired hi20 and be resolved
+# independently, without the on-disk hi/lo label chase the standard psABI uses.
+val RISCV_LA_HI_LO_GAP: u64 = 4;
+
+# whether a 32-bit pc-relative displacement fits the riscv auipc + low-12 split. the
+# +0x800-rounded high part must stay within a signed 32-bit value, which guarantees the
+# 20-bit auipc imm and the signed 12-bit low field together reach the displacement.
+# ---
+# delta: the pc-relative displacement (S + A - P)
+# ret:   true when the displacement is representable by an auipc + lo12 pair
+fun riscv_pcrel32_ok(delta: i64) bool {
+    val adj: i64 = delta + 0x800;
+    ret adj >= -2147483648 && adj <= 2147483647;
+}
+
+# set the U-type imm[31:12] of an auipc / lui word to ((delta + 0x800) >> 12), keeping
+# the rd[11:7] and opcode[6:0] bits. the +0x800 rounds so the paired signed 12-bit low
+# field folds back exactly.
+# ---
+# word:  the original instruction word
+# delta: the pc-relative displacement the hi/lo pair materializes
+# ret:   the word with its high-20 immediate field replaced
+fun riscv_set_hi20(word: u32, delta: i64) u32 {
+    val hi20: u32 = (((delta + 0x800) >> 12)::u64 & 0xFFFFF)::u32;
+    ret (word & 0xFFF) | (hi20 << 12);
+}
+
+# set the I-type imm[31:20] of a load / addi / jalr word to (delta & 0xFFF), keeping the
+# rd / funct3 / rs1 / opcode bits in [19:0]. the hardware sign-extends the 12-bit field,
+# which the +0x800 hi20 rounding accounts for.
+# ---
+# word:  the original instruction word
+# delta: the pc-relative displacement (relative to the paired auipc)
+# ret:   the word with its I-type immediate field replaced
+fun riscv_set_lo12_i(word: u32, delta: i64) u32 {
+    val lo12: u32 = (delta::u64 & 0xFFF)::u32;
+    ret (word & 0x000FFFFF) | (lo12 << 20);
+}
+
+# set the S-type immediate of a store word to (delta & 0xFFF), scattered into imm[11:5]
+# (bits[31:25]) and imm[4:0] (bits[11:7]), keeping the rs2 / rs1 / funct3 / opcode bits.
+# ---
+# word:  the original instruction word
+# delta: the pc-relative displacement (relative to the paired auipc)
+# ret:   the word with its S-type immediate field replaced
+fun riscv_set_lo12_s(word: u32, delta: i64) u32 {
+    val lo12: u32 = (delta::u64 & 0xFFF)::u32;
+    ret (word & 0x01FFF07F) | ((lo12 >> 5) << 25) | ((lo12 & 0x1F) << 7);
+}
+
+# apply one riscv64 relocation, the packer the be-layer registrar wires onto the
+# riscv64 vtable. The shared RK_ABS64 / RK_PC32 kinds are flat little-endian writes
+# (R_RISCV_64 / R_RISCV_32_PCREL); every other kind is a RISC-V instruction-word
+# relocation, a read-modify-write of the 32-bit little-endian word(s) at the patch
+# site that scatters the displacement into the U / I / S immediate field without
+# disturbing the opcode or register bits. RK_PLT32 patches the auipc + jalr CALL pair
+# (R_RISCV_CALL_PLT, two words); RK_PCREL_HI20 the auipc high-20; RK_PCREL_LO12_I / _S
+# the paired low-12 in an I / S immediate, measured from the paired auipc one word
+# back. an unknown kind is reported as unsupported.
+# ---
+# s:         shared session, for the overflow/unsupported diagnostics
+# kind:      the relocation kind to apply
+# dst:       the merged section bytes to patch
+# patch_off: byte offset of the instruction word within `dst`
+# sec_len:   length of the section `dst` backs, for the bounds check
+# sym_va:    the target symbol's final virtual address
+# addend:    the relocation addend
+# patch_va:  the patch site's own virtual address
+# sym_name:  interned symbol name for the overflow diagnostic (STR_NIL if absent)
+# ret:       ok(true) once written, or an overflow/unsupported error
+fun riscv64_apply_reloc(s: *session.Session, kind: of.RelocKind,
+                        dst: *u8, patch_off: u32, sec_len: u32,
+                        sym_va: u64, addend: i64, patch_va: u64,
+                        sym_name: intern.StrId) R.Result[bool, str] {
+    # the shared kinds are flat writes, not instruction-field packers.
+    if (kind == of.RK_ABS64) {
+        ret apply_abs64(s, kind, dst, patch_off, sec_len, sym_va, addend, sym_name);
+    }
+    if (kind == of.RK_PC32) {
+        ret apply_pcrel32(s, kind, dst, patch_off, sec_len, sym_va, addend, patch_va, sym_name);
+    }
+
+    # RK_PLT32 -> R_RISCV_CALL_PLT: the auipc + jalr call pair (8 bytes). the hi20 lands
+    # in the auipc at the patch site, the lo12 in the jalr one word later; both share the
+    # one displacement measured from the auipc (the patch site itself).
+    if (kind == of.RK_PLT32) {
+        if (patch_off::u64 + 8 > sec_len::u64) {
+            ret R.err[bool, str](overflow_message(s, kind, sym_name));
+        }
+        val delta: i64 = (sym_va::i64) + addend - (patch_va::i64);
+        if (!riscv_pcrel32_ok(delta)) {
+            ret R.err[bool, str](overflow_message(s, kind, sym_name));
+        }
+        val auipc: u32 = bin.read_u32_le(dst, patch_off::usize);
+        bin.write_u32_le(dst, patch_off::usize, riscv_set_hi20(auipc, delta));
+        val jalr: u32 = bin.read_u32_le(dst, (patch_off + 4)::usize);
+        bin.write_u32_le(dst, (patch_off + 4)::usize, riscv_set_lo12_i(jalr, delta));
+        ret R.ok[bool, str](true);
+    }
+
+    # every remaining riscv relocation patches a single 32-bit instruction word.
+    if (patch_off::u64 + 4 > sec_len::u64) {
+        ret R.err[bool, str](overflow_message(s, kind, sym_name));
+    }
+    val word: u32 = bin.read_u32_le(dst, patch_off::usize);
+
+    # RK_PCREL_HI20 -> R_RISCV_PCREL_HI20: auipc high-20, pc-relative to the auipc (the
+    # patch site).
+    if (kind == of.RK_PCREL_HI20) {
+        val delta: i64 = (sym_va::i64) + addend - (patch_va::i64);
+        if (!riscv_pcrel32_ok(delta)) {
+            ret R.err[bool, str](overflow_message(s, kind, sym_name));
+        }
+        bin.write_u32_le(dst, patch_off::usize, riscv_set_hi20(word, delta));
+        ret R.ok[bool, str](true);
+    }
+
+    # RK_PCREL_LO12_I / _S -> R_RISCV_PCREL_LO12_I / _S: the low-12 measured from the
+    # paired auipc, recovered as patch_va - gap (the auipc sits one word before in the la
+    # sequence). no range check: the 12-bit field always fits once the hi20 carried the
+    # high part.
+    if (kind == of.RK_PCREL_LO12_I) {
+        val delta: i64 = (sym_va::i64) + addend - ((patch_va - RISCV_LA_HI_LO_GAP)::i64);
+        bin.write_u32_le(dst, patch_off::usize, riscv_set_lo12_i(word, delta));
+        ret R.ok[bool, str](true);
+    }
+    if (kind == of.RK_PCREL_LO12_S) {
+        val delta: i64 = (sym_va::i64) + addend - ((patch_va - RISCV_LA_HI_LO_GAP)::i64);
+        bin.write_u32_le(dst, patch_off::usize, riscv_set_lo12_s(word, delta));
+        ret R.ok[bool, str](true);
+    }
+
+    ret R.err[bool, str](unsupported_message(s, kind));
+}
+
 # wire each registered arch's relocation packer onto its
 # vtable - the be-layer linker registrar. The relocation kind-set is owned by the
 # arch (one hook per vtable), but the packing bodies and their wiring live in this
@@ -1961,6 +2100,7 @@ pub fun register_reloc_hooks(reg: *isa.IsaRegistry) R.Result[bool, str] {
         val vt: *isa.IsaVTable = O.unwrap[*isa.IsaVTable](isa.registered(reg, i));
         if (str_equals(vt.name, "x86_64"))  { vt.apply_reloc = x64_apply_reloc::*u8; }
         if (str_equals(vt.name, "aarch64")) { vt.apply_reloc = arm64_apply_reloc::*u8; }
+        if (str_equals(vt.name, "riscv64")) { vt.apply_reloc = riscv64_apply_reloc::*u8; }
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -2551,6 +2691,91 @@ test "mach.lang.be.linker.arm64_apply_reloc:overflow_rejection" {
     bin.write_u32_le(?dst[0], 0, 0x90000000);
     val o4: R.Result[bool, str] = arm64_apply_reloc(?s, of.RK_PAGE21, ?dst[0], 0, 8, 4294967296, 0, 0, intern.STR_NIL);
     if (!R.is_err[bool, str](o4)) { ret 1; }
+
+    ret 0;
+}
+
+# the riscv64 bit-packers scatter the resolved displacement into the exact U / I / S
+# instruction-word fields, reproducing the `auipc t0, 0x12345 ; addi/sd/jalr ...`
+# words for a displacement of 0x12345678 (hi20 0x12345, lo12 0x678). the lo12 packers
+# measure the displacement from the paired auipc one word back, so a low instruction
+# at patch_va recovers the auipc pc as patch_va - 4 (#1628).
+test "mach.lang.be.linker.riscv64_apply_reloc:bitpackers" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var dst: [8]u8;
+    dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
+
+    # PCREL_HI20: `auipc t0, 0` (0x00000297) + delta 0x12345678 -> `auipc t0, 0x12345`
+    bin.write_u32_le(?dst[0], 0, 0x00000297);
+    val h1: R.Result[bool, str] = riscv64_apply_reloc(?s, of.RK_PCREL_HI20, ?dst[0], 0, 8, 0x12345678, 0, 0, intern.STR_NIL);
+    if (R.is_err[bool, str](h1))                   { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x12345297) { ret 1; }
+
+    # PCREL_LO12_I: `addi t0, t0, 0` (0x00028293) + lo12 0x678; the paired auipc sits at
+    # patch_va-4, so a low instruction at patch_va 4 and sym 0x12345678 yields lo12 0x678.
+    bin.write_u32_le(?dst[0], 0, 0x00028293);
+    val li: R.Result[bool, str] = riscv64_apply_reloc(?s, of.RK_PCREL_LO12_I, ?dst[0], 0, 8, 0x12345678, 0, 4, intern.STR_NIL);
+    if (R.is_err[bool, str](li))                   { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x67828293) { ret 1; }
+
+    # PCREL_LO12_S: `sd t0, 0(t0)` (0x0052B023) + lo12 0x678 -> `sd t0, 0x678(t0)`
+    bin.write_u32_le(?dst[0], 0, 0x0052B023);
+    val ls: R.Result[bool, str] = riscv64_apply_reloc(?s, of.RK_PCREL_LO12_S, ?dst[0], 0, 8, 0x12345678, 0, 4, intern.STR_NIL);
+    if (R.is_err[bool, str](ls))                   { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x6652BC23) { ret 1; }
+
+    # PLT32 -> R_RISCV_CALL_PLT: the `auipc ra, 0` (0x00000097) ; `jalr ra, ra, 0`
+    # (0x000080E7) pair patched with delta 0x12345678 -> hi20 0x12345, lo12 0x678.
+    bin.write_u32_le(?dst[0], 0, 0x00000097);
+    bin.write_u32_le(?dst[0], 4, 0x000080E7);
+    val c1: R.Result[bool, str] = riscv64_apply_reloc(?s, of.RK_PLT32, ?dst[0], 0, 8, 0x12345678, 0, 0, intern.STR_NIL);
+    if (R.is_err[bool, str](c1))                   { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0x12345097) { ret 1; }
+    if (bin.read_u32_le(?dst[0], 4) != 0x678080E7) { ret 1; }
+
+    # RK_ABS64: a flat 64-bit absolute (R_RISCV_64) shared with the other arches.
+    bin.write_u32_le(?dst[0], 0, 0); bin.write_u32_le(?dst[0], 4, 0);
+    val a1: R.Result[bool, str] = riscv64_apply_reloc(?s, of.RK_ABS64, ?dst[0], 0, 8, 0xDEADBEEF, 0x11, 0, intern.STR_NIL);
+    if (R.is_err[bool, str](a1))                          { ret 1; }
+    if (bin.read_u32_le(?dst[0], 0) != 0xDEADBF00)        { ret 1; }
+    if (bin.read_u32_le(?dst[0], 4) != 0)                 { ret 1; }
+
+    ret 0;
+}
+
+# the riscv pc-relative hi20 / call reach is the auipc + lo12 split's signed 32-bit
+# window: a displacement whose +0x800-rounded high part overflows a signed 32-bit
+# value is rejected; the lo12 kinds never overflow once the hi20 carried the high part.
+test "mach.lang.be.linker.riscv64_apply_reloc:overflow_rejection" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var dst: [8]u8;
+    dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
+
+    # HI20: delta 0x80000000 is past the signed 32-bit auipc+lo12 reach -> reject
+    bin.write_u32_le(?dst[0], 0, 0x00000297);
+    val o1: R.Result[bool, str] = riscv64_apply_reloc(?s, of.RK_PCREL_HI20, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL);
+    if (!R.is_err[bool, str](o1)) { ret 1; }
+
+    # HI20: delta 2147481599 (= 2^31 - 1 - 2048) rounds to exactly INT32_MAX -> succeed
+    bin.write_u32_le(?dst[0], 0, 0x00000297);
+    val o2: R.Result[bool, str] = riscv64_apply_reloc(?s, of.RK_PCREL_HI20, ?dst[0], 0, 8, 2147481599, 0, 0, intern.STR_NIL);
+    if (R.is_err[bool, str](o2)) { ret 1; }
+
+    # CALL pair: same signed 32-bit reach as the bare hi20 -> reject 0x80000000
+    bin.write_u32_le(?dst[0], 0, 0x00000097);
+    bin.write_u32_le(?dst[0], 4, 0x000080E7);
+    val o3: R.Result[bool, str] = riscv64_apply_reloc(?s, of.RK_PLT32, ?dst[0], 0, 8, 0x80000000, 0, 0, intern.STR_NIL);
+    if (!R.is_err[bool, str](o3)) { ret 1; }
 
     ret 0;
 }

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -26,11 +26,13 @@
 # (`fadd` / `fsub` / `fmul` / `fdiv`, `fsgnjn`, `feq` / `flt` / `fle`), the float
 # conversions (`fcvt` between S / D and to / from the integer file), the `fmv` float
 # move / cross-bank reinterpret, the float loads / stores (`flw` / `fld` / `fsw` /
-# `fsd`), and the callee-saved FP spill / reload. The families still DEFERRED fail
-# loudly rather than emit wrong bytes: the inline-asm assembler arrives with its
-# slice, and the pc-relative GLOBAL-symbol relocations (`la` hi20/lo12) wait on the
-# linker / ELF relocation seam (slice 4 / #1628), which owns the new abstract reloc
-# kinds RISC-V needs - the `resolve_mem` folded-global path still routes there.
+# `fsd`), and the callee-saved FP spill / reload. Slice 4 (#1628) adds the pc-relative
+# GLOBAL-symbol references: the auipc-based `la` sequence (`auipc %pcrel_hi` +
+# `addi`/load/store `%pcrel_lo`) for an address-of (`emit_global_addr`), a folded-global
+# load (`emit_global_load`), and a folded-global store (`emit_global_store`), each
+# recording the RK_PCREL_HI20 + RK_PCREL_LO12_I / _S markers the linker / ELF relocation
+# seam packs. The one family still DEFERRED is the inline-asm assembler, which arrives
+# with its own slice and fails loudly until then rather than emitting wrong bytes.
 #
 # WIDTH-HONESTY: the 32-bit instruction-word format machinery (pack_r/i/s/b/u/j),
 # the register field positions, the immediate bit-scatter, and the branch / jump
@@ -447,14 +449,11 @@ rec RvMem {
 # lower a post-regalloc MIR_OP_MEM operand to its base / offset / scaled-index form.
 # a frame-slot-key base folds the slot offset onto s0; a physical-register base keeps
 # `preg`. a surviving value vreg in the base or index is a register-allocation bug,
-# rejected loudly. a symbol-relative memory operand (a folded global) is deferred to
-# the relocation slice.
+# rejected loudly. a folded global arrives as a MIR_OP_SYM operand (not a MEM), so the
+# encoders route it to the auipc-based `la` sequence before reaching here.
 fun resolve_mem(f: *mir.MirFunction, op: *mir.MirOperand) R.Result[RvMem, str] {
     if (op.kind != mir.MIR_OP_MEM) {
         ret R.err[RvMem, str]("encode: expected a memory operand");
-    }
-    if (op.sym != intern.STR_NIL) {
-        ret R.err[RvMem, str]("encode: riscv64 folded-global memory operands await the relocation slice");
     }
     var m: RvMem;
     m.has_index = false;
@@ -649,8 +648,12 @@ fun encode_mov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) 
 }
 
 # store register / immediate `val_op` to the resolved memory destination. a
-# non-register value (an immediate) is materialized into the scratch register first.
+# folded-global symbol destination emits the auipc-based `la` store sequence; otherwise
+# a non-register value (an immediate) is materialized into the scratch register first.
 fun emit_store_mem(st: *encode.EncodeState, f: *mir.MirFunction, dst_mem: *mir.MirOperand, val_op: *mir.MirOperand, width: u8) R.Result[bool, str] {
+    if (dst_mem.kind == mir.MIR_OP_SYM) {
+        ret emit_global_store(st, dst_mem, val_op, width);
+    }
     val mr: R.Result[RvMem, str] = resolve_mem(f, dst_mem);
     if (R.is_err[RvMem, str](mr)) { ret R.err[bool, str](R.unwrap_err[RvMem, str](mr)); }
     val m: RvMem = R.unwrap_ok[RvMem, str](mr);
@@ -670,21 +673,93 @@ fun emit_store_mem(st: *encode.EncodeState, f: *mir.MirFunction, dst_mem: *mir.M
     ret R.ok[bool, str](true);
 }
 
-# a non-symbol load `[dst, mem]`. a folded-global symbol load is deferred to the
-# relocation slice through `resolve_mem`.
+# emit the high half of a symbol reference - `auipc rd, %pcrel_hi(sym)` with a zero
+# placeholder - and record the RK_PCREL_HI20 relocation at the auipc word start. the
+# linker fills imm[31:12] with ((S + A - P) + 0x800) >> 12, P being this auipc's own
+# address. the caller pairs it with a `%pcrel_lo` low half (addi / load / store) naming
+# the same symbol, which the linker measures from this auipc one word back.
+fun emit_pcrel_hi(st: *encode.EncodeState, rd: u32, sym: intern.StrId, addend: i32) R.Result[bool, str] {
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_u(AUIPC, rd, 0));
+    ret encode.push_reloc(st, pos, of.RK_PCREL_HI20, sym, addend);
+}
+
+# a symbol address as an rvalue (the `la` / lea equivalent) - `auipc rd, %pcrel_hi(sym)`
+# (RK_PCREL_HI20) ; `addi rd, rd, %pcrel_lo(sym)` (RK_PCREL_LO12_I). both immediates are
+# zero placeholders the linker fills from the paired relocations naming the same symbol;
+# the addend is the symbol's own constant only.
+fun emit_global_addr(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperand) R.Result[bool, str] {
+    if (symop.sym == intern.STR_NIL) {
+        ret R.err[bool, str]("encode: address-of has no resolved symbol name");
+    }
+    val hr: R.Result[bool, str] = emit_pcrel_hi(st, rd, symop.sym, symop.sym_off);
+    if (R.is_err[bool, str](hr)) { ret hr; }
+    val lo_pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_i(OP_IMM, F3_ADD, rd, rd, 0));   # addi rd, rd, %pcrel_lo(sym)
+    ret encode.push_reloc(st, lo_pos, of.RK_PCREL_LO12_I, symop.sym, symop.sym_off);
+}
+
+# a folded-global load - `auipc t0, %pcrel_hi(sym)` (RK_PCREL_HI20) ;
+# `ld/lwu/lhu/lbu rt, %pcrel_lo(sym)(t0)` (RK_PCREL_LO12_I, the zero-extending width
+# form). t0 (the reserved scratch) holds the high half; the load imm12 is a zero
+# placeholder the linker fills. the zero-extending form covers a sub-word access exactly
+# as the non-symbol path does.
+fun emit_global_load(st: *encode.EncodeState, rt: u32, symop: *mir.MirOperand, width: u8) R.Result[bool, str] {
+    if (symop.sym == intern.STR_NIL) {
+        ret R.err[bool, str]("encode: folded-global load has no resolved symbol name");
+    }
+    val hr: R.Result[bool, str] = emit_pcrel_hi(st, SCRATCH, symop.sym, symop.sym_off);
+    if (R.is_err[bool, str](hr)) { ret hr; }
+    val lo_pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_i(LOAD, load_funct3(width), rt, SCRATCH, 0));
+    ret encode.push_reloc(st, lo_pos, of.RK_PCREL_LO12_I, symop.sym, symop.sym_off);
+}
+
+# a folded-global store - the value resolves first (the zero register for an immediate
+# 0, t1 for a non-zero immediate, the value's own register otherwise) so the t0 high-
+# half materialization never clobbers it; `auipc t0, %pcrel_hi(sym)` (RK_PCREL_HI20) ;
+# `sd/sw/sh/sb rt, %pcrel_lo(sym)(t0)` (RK_PCREL_LO12_S). t0 / t1 are reserved scratch,
+# never an allocated value.
+fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *mir.MirOperand, width: u8) R.Result[bool, str] {
+    if (symop.sym == intern.STR_NIL) {
+        ret R.err[bool, str]("encode: folded-global store has no resolved symbol name");
+    }
+    var rt: u32 = RZERO;
+    if (val_op.kind == mir.MIR_OP_IMM) {
+        if (val_op.imm != 0) {
+            emit_li(st, SCRATCH2, val_op.imm);
+            rt = SCRATCH2;
+        }
+    } or {
+        val rr: R.Result[i32, str] = req_gpr(val_op);
+        if (R.is_err[i32, str](rr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rr)); }
+        rt = R.unwrap_ok[i32, str](rr)::u32;
+    }
+    val hr: R.Result[bool, str] = emit_pcrel_hi(st, SCRATCH, symop.sym, symop.sym_off);
+    if (R.is_err[bool, str](hr)) { ret hr; }
+    val lo_pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_s(STORE, store_funct3(width), SCRATCH, rt, 0));
+    ret encode.push_reloc(st, lo_pos, of.RK_PCREL_LO12_S, symop.sym, symop.sym_off);
+}
+
+# a load `[dst, mem]`. a folded-global symbol source emits the auipc-based `la` load
+# sequence; a frame-slot / pointer source resolves to a base + displacement access.
 fun encode_load(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.operand_count < 2) { ret R.err[bool, str]("encode: load missing operands"); }
     val rdr: R.Result[i32, str] = req_gpr(?mi.operands[0]);
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
     val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
-    val mr: R.Result[RvMem, str] = resolve_mem(f, ?mi.operands[1]);
+    val src: *mir.MirOperand = ?mi.operands[1];
+    if (src.kind == mir.MIR_OP_SYM) { ret emit_global_load(st, rd, src, mi.width); }
+    val mr: R.Result[RvMem, str] = resolve_mem(f, src);
     if (R.is_err[RvMem, str](mr)) { ret R.err[bool, str](R.unwrap_err[RvMem, str](mr)); }
     val m: RvMem = R.unwrap_ok[RvMem, str](mr);
     emit_mem_access(st, rd, m.base, m.off, mi.width, true);
     ret R.ok[bool, str](true);
 }
 
-# a non-symbol store `[mem, val]`.
+# a store `[mem, val]`. a folded-global symbol destination emits the auipc-based `la`
+# store sequence (handled in `emit_store_mem`).
 fun encode_store(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.operand_count < 2) { ret R.err[bool, str]("encode: store missing operands"); }
     ret emit_store_mem(st, f, ?mi.operands[0], ?mi.operands[1], mi.width);
@@ -692,13 +767,16 @@ fun encode_store(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr
 
 # alloca / gep address arithmetic `[dst, mem]` - `dst = base + index*scale + off`.
 # a scaled index is shifted into the scratch register and added to the base, then the
-# constant displacement folds onto the result.
+# constant displacement folds onto the result. a symbol base is the address-of
+# `auipc rd, %pcrel_hi(sym)` + `addi rd, rd, %pcrel_lo(sym)` rvalue sequence.
 fun encode_addr(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.operand_count < 2) { ret R.err[bool, str]("encode: address op missing operands"); }
     val rdr: R.Result[i32, str] = req_gpr(?mi.operands[0]);
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
     val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
-    val mr: R.Result[RvMem, str] = resolve_mem(f, ?mi.operands[1]);
+    val memop: *mir.MirOperand = ?mi.operands[1];
+    if (memop.kind == mir.MIR_OP_SYM) { ret emit_global_addr(st, rd, memop); }
+    val mr: R.Result[RvMem, str] = resolve_mem(f, memop);
     if (R.is_err[RvMem, str](mr)) { ret R.err[bool, str](R.unwrap_err[RvMem, str](mr)); }
     val m: RvMem = R.unwrap_ok[RvMem, str](mr);
 
@@ -1432,8 +1510,9 @@ fun align16(n: u32) u32 {
 # 16-byte ra / s0 record, the callee-saved GP and FP save areas, the local frame, and
 # the outgoing-argument region, read from the shared frame facts. unlike AArch64 the
 # record is part of this single allocation rather than a separate pre-index push.
-# each callee-saved register (GP or FP) takes one 8-byte slot.
-fun frame_total(f: *mir.MirFunction) u32 {
+# each callee-saved register (GP or FP) takes one 8-byte slot. pub so the assembly
+# printer renders the exact reservation the encoder subtracts from sp.
+pub fun frame_total(f: *mir.MirFunction) u32 {
     val gp_bytes: u32 = popcount32(f.callee_mask) * 8;
     val fp_bytes: u32 = popcount32(f.callee_mask_fp) * 8;
     ret align16(16 + gp_bytes + fp_bytes + f.frame.size + f.frame.outgoing_size);
@@ -2300,6 +2379,79 @@ test "mach.lang.target.isa.riscv64.encode:call_records_plt32_marker" {
     encode_call(?st, ?ii);
     if (read_word(?st.buf, 8) != 0x000500E7) { bad = 1; }
     if (st.reloc_count != 1)                 { bad = 1; }
+
+    encode.buf_dnit(?st.buf);
+    if (st.relocs != nil && st.reloc_cap > 0) {
+        A.deallocate[encode.PendingReloc](?alloc, st.relocs, st.reloc_cap::usize);
+    }
+    ret bad;
+}
+
+# the pc-relative global-symbol `la` sequences emit the auipc high half plus the low
+# half (addi for address-of, the width-driven load / store for a folded access) and
+# record the RK_PCREL_HI20 + RK_PCREL_LO12_I / _S markers naming the same symbol at the
+# two instruction-word offsets. the words match the `auipc a0, 0` / `addi a0, a0, 0` /
+# `ld a0, 0(t0)` / `sd a1, 0(t0)` forms a RISC-V assembler emits with zero placeholders.
+test "mach.lang.target.isa.riscv64.encode:global_la_sequences" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+    st.alloc       = ?alloc;
+    st.relocs      = nil;
+    st.reloc_count = 0;
+    st.reloc_cap   = 0;
+
+    val sym: intern.StrId = 9::intern.StrId;
+
+    # address-of: auipc a0,0 (0x00000517) ; addi a0,a0,0 (0x00050513).
+    var ao: mir.MirOperand = mir.op_sym(sym, 0);
+    emit_global_addr(?st, 10, ?ao);
+    if (read_word(?st.buf, 0) != 0x00000517) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x00050513) { bad = 1; }
+    if (st.reloc_count != 2) { bad = 1; }
+    or {
+        if (st.relocs[0].kind != of.RK_PCREL_HI20)   { bad = 1; }
+        if (st.relocs[0].offset != 0)                { bad = 1; }
+        if (st.relocs[0].sym != sym)                 { bad = 1; }
+        if (st.relocs[1].kind != of.RK_PCREL_LO12_I) { bad = 1; }
+        if (st.relocs[1].offset != 4)                { bad = 1; }
+        if (st.relocs[1].sym != sym)                 { bad = 1; }
+    }
+
+    # folded-global load (width 8): auipc t0,0 (0x00000297) ; ld a0,0(t0) (0x0002B503).
+    st.buf.len = 0; st.reloc_count = 0;
+    var lo: mir.MirOperand = mir.op_sym(sym, 0);
+    emit_global_load(?st, 10, ?lo, 8);
+    if (read_word(?st.buf, 0) != 0x00000297) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x0002B503) { bad = 1; }
+    if (st.reloc_count != 2) { bad = 1; }
+    or {
+        if (st.relocs[0].kind != of.RK_PCREL_HI20)   { bad = 1; }
+        if (st.relocs[1].kind != of.RK_PCREL_LO12_I) { bad = 1; }
+        if (st.relocs[1].offset != 4)                { bad = 1; }
+    }
+
+    # a sub-word folded load selects the zero-extending form (lbu a0,0(t0), funct3 4).
+    st.buf.len = 0; st.reloc_count = 0;
+    var l1: mir.MirOperand = mir.op_sym(sym, 0);
+    emit_global_load(?st, 10, ?l1, 1);
+    if (read_word(?st.buf, 4) != 0x0002C503) { bad = 1; }
+
+    # folded-global store (width 8, value a1): auipc t0,0 ; sd a1,0(t0) (0x00B2B023),
+    # RK_PCREL_LO12_S on the store low half.
+    st.buf.len = 0; st.reloc_count = 0;
+    var so: mir.MirOperand = mir.op_sym(sym, 0);
+    var sv: mir.MirOperand = mir.op_preg(11);
+    emit_global_store(?st, ?so, ?sv, 8);
+    if (read_word(?st.buf, 0) != 0x00000297) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x00B2B023) { bad = 1; }
+    if (st.reloc_count != 2) { bad = 1; }
+    or {
+        if (st.relocs[0].kind != of.RK_PCREL_HI20)   { bad = 1; }
+        if (st.relocs[1].kind != of.RK_PCREL_LO12_S) { bad = 1; }
+        if (st.relocs[1].offset != 4)                { bad = 1; }
+    }
 
     encode.buf_dnit(?st.buf);
     if (st.relocs != nil && st.reloc_cap > 0) {

--- a/src/lang/target/isa/riscv64/printer.mach
+++ b/src/lang/target/isa/riscv64/printer.mach
@@ -1,0 +1,610 @@
+# RISC-V (RV64) assembly text printer - the riscv64 ISA's `emit_asm` entry point.
+#
+# This is the RV64 implementation of the ISA vtable's `emit_asm` operation, reached
+# only through `tgt.arch.emit_asm` by the shared `be.codegen.encode.print_asm`
+# dispatcher. It formats a fully-resolved (post-isel, post-regalloc, post-frame)
+# `mir.MirModule` as human-readable RISC-V assembly text into a writer - a debug /
+# transparency artifact paralleling the `.o` the encoder emits from the same MIR.
+#
+# Unlike the encoder this is NOT byte-exact: it renders the MIR instruction stream at
+# the level the allocator left it (a three-address ALU op prints as a single
+# `add dst, lhs, rhs`, a comparison as one `cmp.eq dst, lhs, rhs`), so a `.s` line maps
+# to a MIR instruction rather than to the exact words the encoder expands it into. A
+# `# <symbol>:` header introduces each function and the prologue / epilogue are
+# rendered as comment-flagged `addi sp, sp, -N` / `addi sp, sp, N` lines so the frame
+# shape is visible.
+#
+# Register names are the RISC-V psABI mnemonics (zero / ra / sp / a0 / t0 / s0 / ...
+# and ft0 / fa0 / fs0 / ... for the float bank); a register operand names its own bank
+# from the composite register id's class tag, so a cross-bank `fmv` prints each side in
+# its own file. The opcode mnemonics cover the concrete RV64 forms the selector emits
+# (`riscv64.ADD` ...) and the surviving generic / selection-output sentinels (the
+# divide, compare, conditional-branch, float, conversion, and memory families).
+
+use std.format;
+use std.io.writer;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_equals;
+
+use O: std.types.option;
+use R: std.types.result;
+
+use mach.lang.be.codegen.mir;
+use mach.lang.intern;
+use mach.lang.target.isa;
+use mach.lang.target.isa.riscv64;
+use mach.lang.target.isa.riscv64.encode;
+use mach.lang.target.resolved;
+
+# format a fully-resolved MIR module as RISC-V assembly text
+#
+# The `emit_asm` entry point the riscv64 ISA registers; matches
+# `be.codegen.encode.PrintAsmFn`. Emits each function in turn, each introduced by a
+# `# <symbol>:` label and its rendered prologue / body / epilogue. An extern /
+# body-less function (no blocks) contributes nothing, mirroring the encoder.
+# ---
+# tgt: resolved compilation target (its interner resolves symbol names)
+# m:   the fully-resolved MIR module to format
+# out: destination writer
+# ret: true on success, or the first write error
+pub fun print_asm_riscv64(tgt: *resolved.Target, m: *mir.MirModule, out: *writer.Writer) R.Result[bool, str] {
+    if (m == nil)   { ret R.err[bool, str]("print_asm_riscv64: nil mir module"); }
+    if (out == nil) { ret R.err[bool, str]("print_asm_riscv64: nil writer"); }
+
+    var i: u32 = 0;
+    for (i < m.function_len) {
+        val res_function: R.Result[bool, str] = print_function(out, m, ?m.functions[i]);
+        if (R.is_err[bool, str](res_function)) { ret res_function; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# render one MIR function: its `# <symbol>:` header, prologue, every block (each
+# preceded by a `.<id>:` local label), and epilogue
+#
+# A body-less (extern) function emits nothing.
+# ---
+# out: destination writer
+# m:   the owning module (its interner resolves the function / symbol names)
+# f:   the function to render
+# ret: true on success, or the first write error
+fun print_function(out: *writer.Writer, m: *mir.MirModule, f: *mir.MirFunction) R.Result[bool, str] {
+    if (f.block_count == 0) { ret R.ok[bool, str](true); }
+
+    val res_hash: R.Result[bool, str] = emit_str(out, "# ");
+    if (R.is_err[bool, str](res_hash)) { ret res_hash; }
+    val res_name: R.Result[bool, str] = emit_name(out, m.interner, f.name);
+    if (R.is_err[bool, str](res_name)) { ret res_name; }
+    val res_colon: R.Result[bool, str] = emit_str(out, ":\n");
+    if (R.is_err[bool, str](res_colon)) { ret res_colon; }
+
+    val naked: bool = function_is_naked(f);
+    val total: u32 = encode.frame_total(f);
+    if (!naked) {
+        val res_prologue: R.Result[bool, str] = print_prologue(out, total);
+        if (R.is_err[bool, str](res_prologue)) { ret res_prologue; }
+    }
+
+    var i: u32 = 0;
+    for (i < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[i];
+
+        val res_dot: R.Result[bool, str] = emit_str(out, ".");
+        if (R.is_err[bool, str](res_dot)) { ret res_dot; }
+        val res_label: R.Result[bool, str] = emit_u64(out, blk.id::u64);
+        if (R.is_err[bool, str](res_label)) { ret res_label; }
+        val res_label_colon: R.Result[bool, str] = emit_str(out, ":\n");
+        if (R.is_err[bool, str](res_label_colon)) { ret res_label_colon; }
+
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            if (mi.opcode::u16 == riscv64.RET::u16 && !naked) {
+                val res_epilogue: R.Result[bool, str] = print_epilogue(out, total);
+                if (R.is_err[bool, str](res_epilogue)) { ret res_epilogue; }
+            }
+            val res_instr: R.Result[bool, str] = print_instr(out, m, f, mi);
+            if (R.is_err[bool, str](res_instr)) { ret res_instr; }
+            ii = ii + 1;
+        }
+        i = i + 1;
+    }
+
+    ret emit_str(out, "\n");
+}
+
+# render the RISC-V prologue as a comment-flagged line so the frame shape is visible
+# without re-deriving it
+#
+# Mirrors the encoder's live `encode.emit_prologue`: the single `addi sp, sp, -total`
+# frame allocation, with the ra / s0 record and callee-saved spills it covers noted in
+# the comment. The reservation byte count is the encoder's `encode.frame_total`, so the
+# debug `.s` reports the exact amount the encoder subtracts from sp.
+# ---
+# out:   destination writer
+# total: the 16-byte-aligned frame reservation in bytes
+# ret:   true on success, or the first write error
+fun print_prologue(out: *writer.Writer, total: u32) R.Result[bool, str] {
+    if (total == 0) { ret R.ok[bool, str](true); }
+    val res_addi: R.Result[bool, str] = emit_str(out, "  addi  sp, sp, -");
+    if (R.is_err[bool, str](res_addi)) { ret res_addi; }
+    val res_amount: R.Result[bool, str] = emit_u64(out, total::u64);
+    if (R.is_err[bool, str](res_amount)) { ret res_amount; }
+    ret emit_str(out, "        # prologue (saves ra, s0, callee-saved)\n");
+}
+
+# render the RISC-V epilogue as a single comment-flagged line
+#
+# Mirrors the encoder's live `encode.emit_epilogue` (callee-saved restores, ra / s0
+# reload, then the `addi sp, sp, total` teardown), rendered compactly since this
+# artifact need not be byte-exact.
+# ---
+# out:   destination writer
+# total: the 16-byte-aligned frame reservation in bytes
+# ret:   true on success, or the first write error
+fun print_epilogue(out: *writer.Writer, total: u32) R.Result[bool, str] {
+    if (total == 0) { ret R.ok[bool, str](true); }
+    val res_addi: R.Result[bool, str] = emit_str(out, "  addi  sp, sp, ");
+    if (R.is_err[bool, str](res_addi)) { ret res_addi; }
+    val res_amount: R.Result[bool, str] = emit_u64(out, total::u64);
+    if (R.is_err[bool, str](res_amount)) { ret res_amount; }
+    ret emit_str(out, "         # epilogue\n");
+}
+
+# whether an asm-carrying function needs no frame, so its inline asm owns the stack and
+# gets no compiler prologue / epilogue
+#
+# True only when the function reserves no locals, preserves no callee-saved registers,
+# has no outgoing-argument area, and carries an inline-asm block. Mirrors the encoder's
+# `function_is_naked`.
+# ---
+# f:   the function to classify
+# ret: true when the function is naked
+fun function_is_naked(f: *mir.MirFunction) bool {
+    if (f.frame.size != 0)          { ret false; }
+    if (f.callee_mask != 0)         { ret false; }
+    if (f.callee_mask_fp != 0)      { ret false; }
+    if (f.frame.outgoing_size != 0) { ret false; }
+
+    var i: u32 = 0;
+    for (i < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[i];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            if (blk.instrs[ii].opcode == mir.MIR_ASM) { ret true; }
+            ii = ii + 1;
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# render one fully-resolved MIR instruction
+#
+# The lowering-only pseudos that emit no bytes (PCOPY / USE / LABEL fences, the
+# CALL_RES / ARG liveness markers) are skipped. An inline-asm block prints a
+# `# <inline asm>` marker rather than its expanded body. Every other instruction prints
+# `<mnemonic> <op0>, <op1>, ...` with operands resolved through the same frame layout
+# the encoder reads.
+# ---
+# out: destination writer
+# m:   the owning module (its interner resolves symbol names)
+# f:   the owning function (its frame layout resolves memory operands)
+# mi:  the instruction to render
+# ret: true on success, or the first write error
+fun print_instr(out: *writer.Writer, m: *mir.MirModule, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.opcode == isa.ISA_PCOPY || mi.opcode == isa.ISA_PCOPY_FENCE ||
+        mi.opcode == isa.ISA_USE || mi.opcode == isa.ISA_LABEL ||
+        mi.opcode == mir.MIR_CALL_RES || mi.opcode == mir.MIR_ARG) {
+        ret R.ok[bool, str](true);
+    }
+
+    if (mi.opcode == mir.MIR_ASM) {
+        ret emit_str(out, "  # <inline asm>\n");
+    }
+
+    val res_indent: R.Result[bool, str] = emit_str(out, "  ");
+    if (R.is_err[bool, str](res_indent)) { ret res_indent; }
+    val res_mnemonic: R.Result[bool, str] = emit_str(out, mnemonic(mi.opcode));
+    if (R.is_err[bool, str](res_mnemonic)) { ret res_mnemonic; }
+
+    var i: u32 = 0;
+    for (i < mi.operand_count) {
+        if (i == 0) {
+            val res_sep: R.Result[bool, str] = emit_str(out, " ");
+            if (R.is_err[bool, str](res_sep)) { ret res_sep; }
+        }
+        or {
+            val res_sep: R.Result[bool, str] = emit_str(out, ", ");
+            if (R.is_err[bool, str](res_sep)) { ret res_sep; }
+        }
+        val res_operand: R.Result[bool, str] = print_operand(out, m, f, ?mi.operands[i]);
+        if (R.is_err[bool, str](res_operand)) { ret res_operand; }
+        i = i + 1;
+    }
+    ret emit_str(out, "\n");
+}
+
+# render one MIR operand in RISC-V syntax
+#
+# A register names its physical register from its composite class tag (GP or float); an
+# immediate prints its value; a memory operand resolves a frame-slot base to
+# `off(s0)` and a physical base to `disp(reg)`, folding any scaled index; a symbol
+# prints `<name>` (with a `+off` addend); a block prints its `.<id>` local-label
+# target. A surviving virtual register is a regalloc bug and prints `<vreg N>` so the
+# artifact stays legible rather than failing the whole dump.
+# ---
+# out: destination writer
+# m:   the owning module (its interner resolves symbol names)
+# f:   the owning function (its frame layout resolves memory operands)
+# op:  the operand to render
+# ret: true on success, or the first write error
+fun print_operand(out: *writer.Writer, m: *mir.MirModule, f: *mir.MirFunction, op: *mir.MirOperand) R.Result[bool, str] {
+    if (op.kind == mir.MIR_OP_PREG) {
+        ret emit_reg(out, op.preg::i32);
+    }
+    if (op.kind == mir.MIR_OP_VREG) {
+        val res_open: R.Result[bool, str] = emit_str(out, "<vreg ");
+        if (R.is_err[bool, str](res_open)) { ret res_open; }
+        val res_vreg: R.Result[bool, str] = emit_u64(out, op.vreg::u64);
+        if (R.is_err[bool, str](res_vreg)) { ret res_vreg; }
+        ret emit_str(out, ">");
+    }
+    if (op.kind == mir.MIR_OP_IMM) {
+        ret emit_i64(out, op.imm);
+    }
+    if (op.kind == mir.MIR_OP_MEM) {
+        ret print_mem(out, f, op);
+    }
+    if (op.kind == mir.MIR_OP_SYM) {
+        val res_name: R.Result[bool, str] = emit_name(out, m.interner, op.sym);
+        if (R.is_err[bool, str](res_name)) { ret res_name; }
+        if (op.sym_off != 0) {
+            val res_plus: R.Result[bool, str] = emit_str(out, "+");
+            if (R.is_err[bool, str](res_plus)) { ret res_plus; }
+            ret emit_i64(out, op.sym_off::i64);
+        }
+        ret R.ok[bool, str](true);
+    }
+    if (op.kind == mir.MIR_OP_BLOCK) {
+        val res_dot: R.Result[bool, str] = emit_str(out, ".");
+        if (R.is_err[bool, str](res_dot)) { ret res_dot; }
+        ret emit_u64(out, op.imm::u64);
+    }
+    ret emit_str(out, "?");
+}
+
+# render a memory operand as `disp(base)` (RISC-V base + displacement syntax)
+#
+# A frame-slot-key base (`vreg != MIR_VREG_NIL`) resolves to `slot.offset + imm`
+# off s0; a physical-register base (`vreg == MIR_VREG_NIL`) forms `imm(reg)`. A scaled
+# index is appended as `+ index*scale` ahead of the base (RISC-V has no native scaled-
+# index addressing, so the printer renders the folded GEP form the encoder expands). A
+# slot key owning no slot prints `<vreg N>` so a regalloc leak stays legible rather than
+# aborting the dump.
+# ---
+# out: destination writer
+# f:   the owning function (its frame layout resolves a slot-key base)
+# op:  the memory operand to render
+# ret: true on success, or the first write error
+fun print_mem(out: *writer.Writer, f: *mir.MirFunction, op: *mir.MirOperand) R.Result[bool, str] {
+    var disp: i64 = op.imm;
+    var base: str = nil;
+    if (op.vreg != mir.MIR_VREG_NIL) {
+        val opt_slot: O.Option[i64] = frame_slot_offset(f, op.vreg);
+        if (O.is_some[i64](opt_slot)) {
+            base = "s0";
+            disp = O.unwrap[i64](opt_slot) + op.imm;
+        }
+        or {
+            val res_open: R.Result[bool, str] = emit_str(out, "<vreg ");
+            if (R.is_err[bool, str](res_open)) { ret res_open; }
+            val res_vreg: R.Result[bool, str] = emit_u64(out, op.vreg::u64);
+            if (R.is_err[bool, str](res_vreg)) { ret res_vreg; }
+            ret emit_str(out, ">");
+        }
+    }
+    or {
+        base = gp_name(op.preg::i32);
+    }
+
+    val res_disp: R.Result[bool, str] = emit_i64(out, disp);
+    if (R.is_err[bool, str](res_disp)) { ret res_disp; }
+    val res_open: R.Result[bool, str] = emit_str(out, "(");
+    if (R.is_err[bool, str](res_open)) { ret res_open; }
+    val res_base: R.Result[bool, str] = emit_str(out, base);
+    if (R.is_err[bool, str](res_base)) { ret res_base; }
+
+    if (op.index != mir.MIR_VREG_NIL && op.index_is_preg) {
+        val res_plus: R.Result[bool, str] = emit_str(out, " + ");
+        if (R.is_err[bool, str](res_plus)) { ret res_plus; }
+        val res_index: R.Result[bool, str] = emit_str(out, gp_name(op.index::i32));
+        if (R.is_err[bool, str](res_index)) { ret res_index; }
+        if (op.scale > 1) {
+            val res_star: R.Result[bool, str] = emit_str(out, "*");
+            if (R.is_err[bool, str](res_star)) { ret res_star; }
+            val res_scale: R.Result[bool, str] = emit_u64(out, op.scale::u64);
+            if (R.is_err[bool, str](res_scale)) { ret res_scale; }
+        }
+    }
+    ret emit_str(out, ")");
+}
+
+# return the frame-pointer offset of the slot a MIR value owns, or none when it owns no
+# slot
+#
+# Mirrors the encoder's lookup over the laid-out frame.
+# ---
+# f:   the owning function (carries the laid-out frame)
+# v:   the MIR value whose slot is sought
+# ret: some(offset) when v owns a slot, or none
+fun frame_slot_offset(f: *mir.MirFunction, v: u32) O.Option[i64] {
+    val frame: *mir.MirFrame = ?f.frame;
+    if (frame.slots == nil) { ret O.none[i64](); }
+    var i: u32 = 0;
+    for (i < frame.slot_count) {
+        if (frame.slots[i].value == v) { ret O.some[i64](frame.slots[i].offset); }
+        i = i + 1;
+    }
+    ret O.none[i64]();
+}
+
+# write a register name from a composite register id, naming its own bank (GP or float)
+# from the class tag - a cross-bank `fmv` prints each side in its own file.
+# ---
+# out: destination writer
+# id:  the composite register id to name
+# ret: true on success, or the write error
+fun emit_reg(out: *writer.Writer, id: i32) R.Result[bool, str] {
+    if (isa.regid_class(id) == isa.REG_CLASS_ID_XMM) { ret emit_str(out, fp_name(isa.regid_index(id))); }
+    ret emit_str(out, gp_name(isa.regid_index(id)));
+}
+
+# the RISC-V psABI integer-register mnemonic for a register index (x0-x31)
+# ---
+# idx: the integer register index
+# ret: the psABI name, or `x?` for an out-of-range index
+fun gp_name(idx: i32) str {
+    if (idx == 0)  { ret "zero"; }
+    if (idx == 1)  { ret "ra"; }
+    if (idx == 2)  { ret "sp"; }
+    if (idx == 3)  { ret "gp"; }
+    if (idx == 4)  { ret "tp"; }
+    if (idx == 5)  { ret "t0"; }
+    if (idx == 6)  { ret "t1"; }
+    if (idx == 7)  { ret "t2"; }
+    if (idx == 8)  { ret "s0"; }
+    if (idx == 9)  { ret "s1"; }
+    if (idx == 10) { ret "a0"; }
+    if (idx == 11) { ret "a1"; }
+    if (idx == 12) { ret "a2"; }
+    if (idx == 13) { ret "a3"; }
+    if (idx == 14) { ret "a4"; }
+    if (idx == 15) { ret "a5"; }
+    if (idx == 16) { ret "a6"; }
+    if (idx == 17) { ret "a7"; }
+    if (idx == 18) { ret "s2"; }
+    if (idx == 19) { ret "s3"; }
+    if (idx == 20) { ret "s4"; }
+    if (idx == 21) { ret "s5"; }
+    if (idx == 22) { ret "s6"; }
+    if (idx == 23) { ret "s7"; }
+    if (idx == 24) { ret "s8"; }
+    if (idx == 25) { ret "s9"; }
+    if (idx == 26) { ret "s10"; }
+    if (idx == 27) { ret "s11"; }
+    if (idx == 28) { ret "t3"; }
+    if (idx == 29) { ret "t4"; }
+    if (idx == 30) { ret "t5"; }
+    if (idx == 31) { ret "t6"; }
+    ret "x?";
+}
+
+# the RISC-V psABI float-register mnemonic for a register index (f0-f31)
+# ---
+# idx: the float register index
+# ret: the psABI name, or `f?` for an out-of-range index
+fun fp_name(idx: i32) str {
+    if (idx == 0)  { ret "ft0"; }
+    if (idx == 1)  { ret "ft1"; }
+    if (idx == 2)  { ret "ft2"; }
+    if (idx == 3)  { ret "ft3"; }
+    if (idx == 4)  { ret "ft4"; }
+    if (idx == 5)  { ret "ft5"; }
+    if (idx == 6)  { ret "ft6"; }
+    if (idx == 7)  { ret "ft7"; }
+    if (idx == 8)  { ret "fs0"; }
+    if (idx == 9)  { ret "fs1"; }
+    if (idx == 10) { ret "fa0"; }
+    if (idx == 11) { ret "fa1"; }
+    if (idx == 12) { ret "fa2"; }
+    if (idx == 13) { ret "fa3"; }
+    if (idx == 14) { ret "fa4"; }
+    if (idx == 15) { ret "fa5"; }
+    if (idx == 16) { ret "fa6"; }
+    if (idx == 17) { ret "fa7"; }
+    if (idx == 18) { ret "fs2"; }
+    if (idx == 19) { ret "fs3"; }
+    if (idx == 20) { ret "fs4"; }
+    if (idx == 21) { ret "fs5"; }
+    if (idx == 22) { ret "fs6"; }
+    if (idx == 23) { ret "fs7"; }
+    if (idx == 24) { ret "fs8"; }
+    if (idx == 25) { ret "fs9"; }
+    if (idx == 26) { ret "fs10"; }
+    if (idx == 27) { ret "fs11"; }
+    if (idx == 28) { ret "ft8"; }
+    if (idx == 29) { ret "ft9"; }
+    if (idx == 30) { ret "ft10"; }
+    if (idx == 31) { ret "ft11"; }
+    ret "f?";
+}
+
+# return the assembly mnemonic for a fully-resolved RV64 MIR opcode
+#
+# The concrete RV64 opcodes the selector emits map to their natural mnemonic, as do the
+# surviving generic / selection-output sentinels (the divide, compare, conditional-
+# branch, float, conversion, and memory families plus the CALL pseudo).
+# ---
+# op:  the MIR opcode to name
+# ret: the mnemonic text, or `???` for an unrecognized opcode
+fun mnemonic(op: mir.MirOpcode) str {
+    # the surviving generic / selection-output sentinels (high opcode values).
+    if (op == mir.MIR_CALL)      { ret "call"; }
+    if (op == mir.MIR_LOAD)      { ret "ld"; }
+    if (op == mir.MIR_STORE)     { ret "sd"; }
+    if (op == mir.MIR_GEP)       { ret "lea"; }
+    if (op == mir.MIR_ALLOCA)    { ret "lea"; }
+
+    if (op == mir.MIR_SEL_DIV_S) { ret "div"; }
+    if (op == mir.MIR_SEL_DIV_U) { ret "divu"; }
+    if (op == mir.MIR_SEL_REM_S) { ret "rem"; }
+    if (op == mir.MIR_SEL_REM_U) { ret "remu"; }
+
+    if (op == mir.MIR_SEL_CMP_EQ)   { ret "cmp.eq"; }
+    if (op == mir.MIR_SEL_CMP_NE)   { ret "cmp.ne"; }
+    if (op == mir.MIR_SEL_CMP_LT_S) { ret "cmp.lt_s"; }
+    if (op == mir.MIR_SEL_CMP_LT_U) { ret "cmp.lt_u"; }
+    if (op == mir.MIR_SEL_CMP_LE_S) { ret "cmp.le_s"; }
+    if (op == mir.MIR_SEL_CMP_LE_U) { ret "cmp.le_u"; }
+    if (op == mir.MIR_SEL_CBR)      { ret "cbr"; }
+
+    if (op == mir.MIR_FADD) { ret "fadd"; }
+    if (op == mir.MIR_FSUB) { ret "fsub"; }
+    if (op == mir.MIR_FMUL) { ret "fmul"; }
+    if (op == mir.MIR_FDIV) { ret "fdiv"; }
+    if (op == mir.MIR_FCMP) { ret "fcmp"; }
+    if (op == mir.MIR_FNEG) { ret "fneg"; }
+
+    if (op == mir.MIR_TRUNC)   { ret "trunc"; }
+    if (op == mir.MIR_SEXT)    { ret "sext"; }
+    if (op == mir.MIR_ZEXT)    { ret "zext"; }
+    if (op == mir.MIR_BITCAST) { ret "bitcast"; }
+    if (op == mir.MIR_FP_TRUNC) { ret "fcvt.s.d"; }
+    if (op == mir.MIR_FP_EXT)   { ret "fcvt.d.s"; }
+    if (op == mir.MIR_FP_TO_SI) { ret "fcvt.l.fp"; }
+    if (op == mir.MIR_FP_TO_UI) { ret "fcvt.lu.fp"; }
+    if (op == mir.MIR_SI_TO_FP) { ret "fcvt.fp.l"; }
+    if (op == mir.MIR_UI_TO_FP) { ret "fcvt.fp.lu"; }
+
+    ret riscv64_mnemonic(op::u16);
+}
+
+# return the mnemonic for a concrete RV64 opcode the selector emitted
+# ---
+# op:  the concrete riscv64 opcode to name
+# ret: the mnemonic text, or `???` for an unrecognized opcode
+fun riscv64_mnemonic(op: u16) str {
+    if (op == riscv64.NOP)    { ret "nop"; }
+    if (op == riscv64.RET)    { ret "ret"; }
+    if (op == riscv64.ADD)    { ret "add"; }
+    if (op == riscv64.SUB)    { ret "sub"; }
+    if (op == riscv64.MUL)    { ret "mul"; }
+    if (op == riscv64.AND)    { ret "and"; }
+    if (op == riscv64.OR)     { ret "or"; }
+    if (op == riscv64.XOR)    { ret "xor"; }
+    if (op == riscv64.SLL)    { ret "sll"; }
+    if (op == riscv64.SRL)    { ret "srl"; }
+    if (op == riscv64.SRA)    { ret "sra"; }
+    if (op == riscv64.NEG)    { ret "neg"; }
+    if (op == riscv64.NOT)    { ret "not"; }
+    if (op == riscv64.MOV)    { ret "mv"; }
+    if (op == riscv64.JMP)    { ret "j"; }
+    if (op == riscv64.EBREAK) { ret "ebreak"; }
+    if (op == riscv64.FMV)    { ret "fmv"; }
+    ret "???";
+}
+
+# write a string, mapping a format error to the bool/str result shape
+# ---
+# out: destination writer
+# s:   the string to write
+# ret: true on success, or the write error
+fun emit_str(out: *writer.Writer, s: str) R.Result[bool, str] {
+    val res_write: R.Result[usize, str] = format.write_str(out, s);
+    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](R.unwrap_err[usize, str](res_write)); }
+    ret R.ok[bool, str](true);
+}
+
+# write an unsigned integer
+# ---
+# out: destination writer
+# n:   the value to write
+# ret: true on success, or the write error
+fun emit_u64(out: *writer.Writer, n: u64) R.Result[bool, str] {
+    val res_write: R.Result[usize, str] = format.write_u64(out, n);
+    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](R.unwrap_err[usize, str](res_write)); }
+    ret R.ok[bool, str](true);
+}
+
+# write a signed integer
+# ---
+# out: destination writer
+# n:   the value to write
+# ret: true on success, or the write error
+fun emit_i64(out: *writer.Writer, n: i64) R.Result[bool, str] {
+    val res_write: R.Result[usize, str] = format.write_i64(out, n);
+    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](R.unwrap_err[usize, str](res_write)); }
+    ret R.ok[bool, str](true);
+}
+
+# write an interned name, or `<?name>` when the id does not resolve
+# ---
+# out:      destination writer
+# interner: the interner that resolves the id to text
+# id:       the interned string id to write
+# ret:      true on success, or the first write error
+fun emit_name(out: *writer.Writer, interner: *intern.Interner, id: intern.StrId) R.Result[bool, str] {
+    val opt_name: O.Option[str] = intern.lookup(interner, id);
+    if (O.is_some[str](opt_name)) { ret emit_str(out, O.unwrap[str](opt_name)); }
+    ret emit_str(out, "<?name>");
+}
+
+# the register-name tables map the integer and float bank indices to the RISC-V psABI
+# mnemonics (the role names a reader expects), and the opcode tables name each concrete
+# RV64 form and surviving generic / selection-output sentinel.
+test "mach.lang.target.isa.riscv64.printer.names:abi_mnemonics" {
+    if (!str_equals(gp_name(0), "zero"))  { ret 1; }
+    if (!str_equals(gp_name(1), "ra"))    { ret 1; }
+    if (!str_equals(gp_name(2), "sp"))    { ret 1; }
+    if (!str_equals(gp_name(8), "s0"))    { ret 1; }
+    if (!str_equals(gp_name(10), "a0"))   { ret 1; }
+    if (!str_equals(gp_name(5), "t0"))    { ret 1; }
+    if (!str_equals(gp_name(17), "a7"))   { ret 1; }
+    if (!str_equals(gp_name(31), "t6"))   { ret 1; }
+    if (!str_equals(gp_name(99), "x?"))   { ret 1; }
+
+    if (!str_equals(fp_name(0), "ft0"))   { ret 1; }
+    if (!str_equals(fp_name(8), "fs0"))   { ret 1; }
+    if (!str_equals(fp_name(10), "fa0"))  { ret 1; }
+    if (!str_equals(fp_name(31), "ft11")) { ret 1; }
+    if (!str_equals(fp_name(99), "f?"))   { ret 1; }
+    ret 0;
+}
+
+# the opcode-to-mnemonic mapping covers the concrete RV64 forms the selector emits and
+# the surviving generic / selection-output sentinels (memory, divide, compare, branch,
+# and float families).
+test "mach.lang.target.isa.riscv64.printer.mnemonic:opcode_names" {
+    if (!str_equals(riscv64_mnemonic(riscv64.ADD::u16), "add")) { ret 1; }
+    if (!str_equals(riscv64_mnemonic(riscv64.MOV::u16), "mv"))  { ret 1; }
+    if (!str_equals(riscv64_mnemonic(riscv64.JMP::u16), "j"))   { ret 1; }
+    if (!str_equals(riscv64_mnemonic(riscv64.RET::u16), "ret")) { ret 1; }
+    if (!str_equals(riscv64_mnemonic(riscv64.FMV::u16), "fmv")) { ret 1; }
+
+    if (!str_equals(mnemonic(mir.MIR_CALL), "call"))         { ret 1; }
+    if (!str_equals(mnemonic(mir.MIR_LOAD), "ld"))           { ret 1; }
+    if (!str_equals(mnemonic(mir.MIR_STORE), "sd"))          { ret 1; }
+    if (!str_equals(mnemonic(mir.MIR_GEP), "lea"))           { ret 1; }
+    if (!str_equals(mnemonic(mir.MIR_SEL_DIV_U), "divu"))    { ret 1; }
+    if (!str_equals(mnemonic(mir.MIR_SEL_CMP_EQ), "cmp.eq")) { ret 1; }
+    if (!str_equals(mnemonic(mir.MIR_FADD), "fadd"))         { ret 1; }
+    # a concrete RV64 opcode routes through the riscv64 table.
+    if (!str_equals(mnemonic(riscv64.SUB::mir.MirOpcode), "sub")) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -7,13 +7,12 @@
 # children (the encoder, and the future selector) into the parent does not close an
 # import cycle.
 #
-# As of slice 3 the machine description carries the instruction selector (`select`),
-# the byte encoder (`encode`), and the inline-asm clobber analyzer (`asm_clobbers`).
-# The remaining codegen hooks (`emit_asm` / `apply_reloc`) are left nil - the linker
-# errors loudly on a nil slot, exactly as it does for an unregistered ISA, so a
-# riscv64 target composes and the selector + encoder run while the unwired families
-# fail with a precise message. Later slices supply the inline-asm assembler and the
-# `apply_reloc` registrar and point these slots at them.
+# As of slice 4 the machine description carries the instruction selector (`select`),
+# the byte encoder (`encode`), the inline-asm clobber analyzer (`asm_clobbers`), the
+# assembly printer (`emit_asm`), and the ELF relocation forward map
+# (`elf_reloc_type`). The relocation packer (`apply_reloc`) is left nil here and wired
+# by the be-layer `be.linker.register_reloc_hooks` registrar (the packing bodies live
+# in be/, which target/ cannot depend on), the same split x86_64 and aarch64 use.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -25,6 +24,9 @@ use mach.lang.target.isa;
 use mach.lang.target.isa.riscv64;
 use mach.lang.target.isa.riscv64.encode;
 use mach.lang.target.isa.riscv64.isel;
+use mach.lang.target.isa.riscv64.printer;
+use mach.lang.target.of;
+use mach.lang.target.of.elf;
 
 # process-global storage for the RV64 vtable and its register classes. written
 # once by `register_riscv64` and borrowed by the vtable installed into the ISA
@@ -59,6 +61,30 @@ var riscv64_reserved_regs: [6]isa.Register;
 # `register_riscv64`.
 var riscv64_reload_scratch_regs: [3]isa.Register;
 
+# map an abstract relocation kind to its riscv64 ELF machine relocation type
+#
+# The forward half of the riscv64 ELF relocation seam: the ELF object writer reads it
+# through `IsaVTable.elf_reloc_type` instead of branching on the arch id, so riscv64
+# owns its own R_RISCV_* numbers (drawn from the ELF format module, the single source
+# the reverse parse map shares). RK_ABS64 maps to the width-specific R_RISCV_64 (an
+# rv32 sibling's RK_ABS32 would map to R_RISCV_32); RK_PLT32 to R_RISCV_CALL_PLT (the
+# auipc + jalr call pair); the pc-relative load-address idiom's RK_PCREL_HI20 /
+# RK_PCREL_LO12_I / RK_PCREL_LO12_S to their R_RISCV_PCREL_* types. A kind riscv64 has
+# no width-correct ELF type for returns 0 (R_RISCV_NONE), which the writer turns into
+# the unsupported-kind error.
+# ---
+# kind: the abstract relocation kind to map
+# ret:  the riscv64 ELF reloc type, or 0 when riscv64 has none for this kind
+fun riscv64_elf_reloc_type(kind: of.RelocKind) u32 {
+    if (kind == of.RK_ABS64)        { ret elf.R_RISCV_64; }
+    if (kind == of.RK_PC32)         { ret elf.R_RISCV_32_PCREL; }
+    if (kind == of.RK_PLT32)        { ret elf.R_RISCV_CALL_PLT; }
+    if (kind == of.RK_PCREL_HI20)   { ret elf.R_RISCV_PCREL_HI20; }
+    if (kind == of.RK_PCREL_LO12_I) { ret elf.R_RISCV_PCREL_LO12_I; }
+    if (kind == of.RK_PCREL_LO12_S) { ret elf.R_RISCV_PCREL_LO12_S; }
+    ret 0;
+}
+
 # build and install the RV64 ISA vtable
 #
 # Sets the architecture and register-class names, fills the two register classes
@@ -72,11 +98,11 @@ var riscv64_reload_scratch_regs: [3]isa.Register;
 # `reg`. Idempotent: the registry entry is write-once. Must run at compiler startup
 # before `target.select` requests a riscv64 target.
 #
-# Wires the slice-3 instruction selector (`select`), the byte encoder (`encode`), and
-# the inline-asm clobber analyzer (`asm_clobbers`); the `emit_asm` / `apply_reloc`
-# hooks are left nil and the linker errors loudly when reached, so the target
-# composes, selects, and encodes while the unwired families wait on their later
-# slices.
+# Wires the instruction selector (`select`), the byte encoder (`encode`), the
+# inline-asm clobber analyzer (`asm_clobbers`), the assembly printer (`emit_asm`), and
+# the ELF relocation forward map (`elf_reloc_type`); the `apply_reloc` packer is wired
+# by the be-layer `be.linker.register_reloc_hooks` registrar after this installs the
+# vtable, the same split x86_64 and aarch64 use.
 # ---
 # reg: the ISA registry to install the vtable into
 # ret: true on success
@@ -120,21 +146,21 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_vtable.id                   = isa.ARCH_RISCV64;
     riscv64_vtable.name                 = "riscv64";
     riscv64_vtable.elf_machine          = 243;  # EM_RISCV
+    riscv64_vtable.elf_reloc_type       = riscv64_elf_reloc_type::*u8;
     riscv64_vtable.pointer_width        = 8;
     riscv64_vtable.reg_classes          = ?riscv64_classes[0];
     riscv64_vtable.reg_class_count      = 2;
-    # slice 3 wires the instruction selector, the byte encoder, and the inline-asm
-    # clobber analyzer; all are stored type-erased (`*u8`) and cast back to their
-    # `SelectFn` / `EncodeFn` / `AsmClobbersFn` signatures by the shared dispatchers.
-    # `emit_asm` (the inline-asm assembler) and `apply_reloc` (slice 4's linker / ELF
-    # relocation seam) stay nil - the linker errors loudly on a nil slot, so a riscv64
-    # target composes, selects, and encodes while the unwired families fail with a
-    # precise message rather than emitting wrong code.
+    # slice 3 wired the instruction selector, the byte encoder, and the inline-asm
+    # clobber analyzer; slice 4 adds the assembly printer (`emit_asm`) and the ELF
+    # relocation forward map (`elf_reloc_type`). all are stored type-erased (`*u8`) and
+    # cast back to their concrete signatures by the shared dispatchers. `apply_reloc`
+    # (the linker relocation packer) is left nil here and wired by the be-layer
+    # `be.linker.register_reloc_hooks` registrar, since the packing bodies live in be/
+    # and target/ cannot depend on be/ - the same split x86_64 and aarch64 use.
     riscv64_vtable.select               = isel.select::*u8;
     riscv64_vtable.encode               = encode.encode_riscv64::*u8;
-    riscv64_vtable.emit_asm             = nil;
+    riscv64_vtable.emit_asm             = printer.print_asm_riscv64::*u8;
     riscv64_vtable.asm_clobbers         = encode.asm_clobbers::*u8;
-    riscv64_vtable.apply_reloc          = nil;
     riscv64_vtable.reserved_regs        = ?riscv64_reserved_regs[0];
     riscv64_vtable.reserved_reg_count   = 6;
     riscv64_vtable.reload_scratch_regs  = ?riscv64_reload_scratch_regs[0];
@@ -209,4 +235,25 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     isa.register(reg, ?riscv64_vtable);
 
     ret R.ok[bool, str](true);
+}
+
+# the riscv64 forward reloc map produces the right R_RISCV_* number for each kind it
+# supports - R_RISCV_64 for the absolute data pointer (the rv64 width), R_RISCV_CALL_PLT
+# for the direct call pair, and the R_RISCV_PCREL_* types for the auipc-based load-
+# address idiom - and 0 (R_RISCV_NONE) for a kind it has no width-correct ELF type for
+# (the x86_64 GOT / 32S and the aarch64 page / lo12 kinds are not riscv64's).
+test "mach.lang.target.isa.riscv64.register.riscv64_elf_reloc_type:forward_map" {
+    if (riscv64_elf_reloc_type(of.RK_ABS64)        != elf.R_RISCV_64)           { ret 1; }
+    if (riscv64_elf_reloc_type(of.RK_PC32)         != elf.R_RISCV_32_PCREL)     { ret 1; }
+    if (riscv64_elf_reloc_type(of.RK_PLT32)        != elf.R_RISCV_CALL_PLT)     { ret 1; }
+    if (riscv64_elf_reloc_type(of.RK_PCREL_HI20)   != elf.R_RISCV_PCREL_HI20)   { ret 1; }
+    if (riscv64_elf_reloc_type(of.RK_PCREL_LO12_I) != elf.R_RISCV_PCREL_LO12_I) { ret 1; }
+    if (riscv64_elf_reloc_type(of.RK_PCREL_LO12_S) != elf.R_RISCV_PCREL_LO12_S) { ret 1; }
+
+    # a kind riscv64 has no ELF type for maps to 0, the writer's unsupported signal.
+    if (riscv64_elf_reloc_type(of.RK_GOTPCREL) != 0) { ret 1; }
+    if (riscv64_elf_reloc_type(of.RK_ABS32S)   != 0) { ret 1; }
+    if (riscv64_elf_reloc_type(of.RK_PAGE21)   != 0) { ret 1; }
+    if (riscv64_elf_reloc_type(of.RK_ADD_LO12) != 0) { ret 1; }
+    ret 0;
 }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -74,6 +74,23 @@ pub val RK_LDST16_LO12:  RelocKind = 9;
 pub val RK_LDST32_LO12:  RelocKind = 10;
 pub val RK_LDST64_LO12:  RelocKind = 11;
 pub val RK_LDST128_LO12: RelocKind = 12;
+# pc-relative high-20 bits of the auipc-based load-address idiom
+# (R_RISCV_PCREL_HI20): ((S + A - P) + 0x800) >> 12 packed into the U-type imm[31:12]
+# of an `auipc rd, %pcrel_hi(sym)`, with the +0x800 rounding folding the signed
+# low-12 back. P is the auipc's own address. abstract because any arch sharing the
+# auipc/lui hi/lo idiom reuses it; pairs with one of the RK_PCREL_LO12_* kinds.
+pub val RK_PCREL_HI20:   RelocKind = 13;
+# pc-relative low-12 bits placed in an I-type immediate (R_RISCV_PCREL_LO12_I):
+# (S + A - P_hi) & 0xFFF into imm[31:20] of the load / addi / jalr that follows the
+# paired auipc. P_hi is the paired auipc's address, recovered from the low
+# instruction's own address by the la-sequence gap (the auipc immediately precedes
+# the low instruction). pairs with RK_PCREL_HI20.
+pub val RK_PCREL_LO12_I: RelocKind = 14;
+# pc-relative low-12 bits placed in an S-type immediate (R_RISCV_PCREL_LO12_S):
+# (S + A - P_hi) & 0xFFF scattered into imm[11:5] (bits[31:25]) + imm[4:0]
+# (bits[11:7]) of the store that follows the paired auipc. the store-instruction
+# counterpart of RK_PCREL_LO12_I.
+pub val RK_PCREL_LO12_S: RelocKind = 15;
 
 # object-symbol flags, combined as a bitmask in `Symbol.flags`
 # ---
@@ -517,5 +534,8 @@ pub fun reloc_kind_name(kind: RelocKind) str {
     if (kind == RK_LDST32_LO12)  { ret "ldst32_lo12"; }
     if (kind == RK_LDST64_LO12)  { ret "ldst64_lo12"; }
     if (kind == RK_LDST128_LO12) { ret "ldst128_lo12"; }
+    if (kind == RK_PCREL_HI20)   { ret "pcrel_hi20"; }
+    if (kind == RK_PCREL_LO12_I) { ret "pcrel_lo12_i"; }
+    if (kind == RK_PCREL_LO12_S) { ret "pcrel_lo12_s"; }
     ret "unknown";
 }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -96,6 +96,28 @@ pub val R_AARCH64_LDST32_ABS_LO12_NC:  u32 = 285;
 pub val R_AARCH64_LDST64_ABS_LO12_NC:  u32 = 286;
 pub val R_AARCH64_LDST128_ABS_LO12_NC: u32 = 299;
 
+# riscv relocation types. pub for the riscv64 `elf_reloc_type` forward map, as with
+# the x86_64 / aarch64 numbers above. R_RISCV_32 / R_RISCV_64 are the width-specific
+# absolute-data types (a 64-bit pointer uses _64, a 32-bit pointer _32); the psABI
+# reuses the low type numbers x86_64 also uses (R_RISCV_64 == R_X86_64_PC32 == 2), so
+# the reverse parse map disambiguates riscv from the object's own e_machine rather
+# than the bare number.
+pub val R_RISCV_32:           u32 = 1;
+pub val R_RISCV_64:           u32 = 2;
+pub val R_RISCV_BRANCH:       u32 = 16;
+pub val R_RISCV_JAL:          u32 = 17;
+pub val R_RISCV_CALL_PLT:     u32 = 19;
+pub val R_RISCV_PCREL_HI20:   u32 = 23;
+pub val R_RISCV_PCREL_LO12_I: u32 = 24;
+pub val R_RISCV_PCREL_LO12_S: u32 = 25;
+pub val R_RISCV_32_PCREL:     u32 = 57;
+
+# the ELF e_machine ids the reverse parse map keys on to resolve relocation-number
+# collisions between architectures. only riscv is split out: x86_64 and aarch64 do
+# not collide with each other, but riscv reuses x86_64's low numbers with different
+# meanings, so a riscv object must be mapped through its own table.
+val EM_RISCV: u16 = 243;
+
 # ELF program header types and flags.
 val PT_LOAD:    u32 = 1;
 val PT_DYNAMIC: u32 = 2;
@@ -198,16 +220,30 @@ fun reloc_type_for(itn: *intern.Interner, alloc: *A.Allocator, kind: of.RelocKin
 
 # map an ELF machine relocation type back to its abstract RK_* kind
 #
-# An unrecognized type is an error naming the type rather than a silent
-# fall-through to abs64. A foreign object's 4-byte type (e.g. R_X86_64_32) must
-# not be linked as a 64-bit absolute, which would write 8 bytes over the 4-byte
+# Keyed on the parsed object's `machine` (e_machine) so an architecture's relocation
+# numbers are read against its own table. riscv reuses x86_64's low type numbers with
+# different meanings (R_RISCV_64 == R_X86_64_PC32 == 2), so a riscv object is split
+# out and mapped first; x86_64 and aarch64 share the union below since their numbers
+# do not collide. An unrecognized type is an error naming the type rather than a
+# silent fall-through to abs64. A foreign object's 4-byte type (e.g. R_X86_64_32)
+# must not be linked as a 64-bit absolute, which would write 8 bytes over the 4-byte
 # field.
 # ---
-# itn:    interner backing the error string
-# alloc:  allocator backing the error string
-# r_type: the ELF machine relocation type to map
-# ret:    ok(abstract kind), or an error naming the unrecognized type
-fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, r_type: u32) R.Result[of.RelocKind, str] {
+# itn:     interner backing the error string
+# alloc:   allocator backing the error string
+# machine: the parsed object's ELF e_machine (selects the per-arch table)
+# r_type:  the ELF machine relocation type to map
+# ret:     ok(abstract kind), or an error naming the unrecognized type
+fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, machine: u16, r_type: u32) R.Result[of.RelocKind, str] {
+    if (machine == EM_RISCV) {
+        if (r_type == R_RISCV_64)           { ret R.ok[of.RelocKind, str](of.RK_ABS64); }
+        if (r_type == R_RISCV_32_PCREL)     { ret R.ok[of.RelocKind, str](of.RK_PC32); }
+        if (r_type == R_RISCV_CALL_PLT)     { ret R.ok[of.RelocKind, str](of.RK_PLT32); }
+        if (r_type == R_RISCV_PCREL_HI20)   { ret R.ok[of.RelocKind, str](of.RK_PCREL_HI20); }
+        if (r_type == R_RISCV_PCREL_LO12_I) { ret R.ok[of.RelocKind, str](of.RK_PCREL_LO12_I); }
+        if (r_type == R_RISCV_PCREL_LO12_S) { ret R.ok[of.RelocKind, str](of.RK_PCREL_LO12_S); }
+        ret R.err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
+    }
     if (r_type == R_X86_64_64 || r_type == R_AARCH64_ABS64)     { ret R.ok[of.RelocKind, str](of.RK_ABS64); }
     if (r_type == R_X86_64_PC32 || r_type == R_AARCH64_PREL32)  { ret R.ok[of.RelocKind, str](of.RK_PC32); }
     if (r_type == R_X86_64_PLT32 || r_type == R_AARCH64_CALL26) { ret R.ok[of.RelocKind, str](of.RK_PLT32); }
@@ -1840,6 +1876,9 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
     if (itn == nil) { ret R.err[bool, str]("elf: no interner for parse"); }
     out.interner = itn;
 
+    # e_machine selects the per-arch table the reverse relocation map reads, since the
+    # psABI relocation numbers collide across architectures (R_RISCV_64 == R_X86_64_PC32).
+    val e_machine:   u16   = bin.read_u16_le(buf, 18);
     val e_shoff:     usize = bin.read_u64_le(buf, 40)::usize;
     val e_shentsize: u16   = bin.read_u16_le(buf, 58);
     val e_shnum:     u16   = bin.read_u16_le(buf, 60);
@@ -2101,7 +2140,7 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
                 or { out.relocations[idx].section = of.SECTION_EXTERNAL; }
                 out.relocations[idx].offset = bin.read_u64_le(buf, ro)::u32;
                 out.relocations[idx].addend = bin.read_u64_le(buf, ro + 16)::i64;
-                val rk: R.Result[of.RelocKind, str] = reloc_kind_for(itn, alloc, r_type);
+                val rk: R.Result[of.RelocKind, str] = reloc_kind_for(itn, alloc, e_machine, r_type);
                 if (R.is_err[of.RelocKind, str](rk)) {
                     A.deallocate[i32](alloc, sec_map, e_shnum::usize);
                     ret R.err[bool, str](R.unwrap_err[of.RelocKind, str](rk));
@@ -2150,6 +2189,22 @@ fun t_x64_elf_reloc_type(kind: of.RelocKind) u32 {
     if (kind == of.RK_PLT32)    { ret R_X86_64_PLT32; }
     if (kind == of.RK_GOTPCREL) { ret R_X86_64_GOTPCREL; }
     if (kind == of.RK_ABS32S)   { ret R_X86_64_32S; }
+    ret 0;
+}
+
+# a test-only riscv64 forward reloc map, mirroring the production map in
+# target/isa/riscv64/register.mach, duplicated here for the same import-cycle reason as
+# the x86_64 helper above. used by the riscv round-trip test to emit real R_RISCV_*
+# relocations whose numbers collide with x86_64's.
+# ---
+# kind: the abstract relocation kind to map
+# ret:  the riscv64 ELF reloc type, or 0 for a kind it has none for
+fun t_riscv_elf_reloc_type(kind: of.RelocKind) u32 {
+    if (kind == of.RK_ABS64)        { ret R_RISCV_64; }
+    if (kind == of.RK_PLT32)        { ret R_RISCV_CALL_PLT; }
+    if (kind == of.RK_PCREL_HI20)   { ret R_RISCV_PCREL_HI20; }
+    if (kind == of.RK_PCREL_LO12_I) { ret R_RISCV_PCREL_LO12_I; }
+    if (kind == of.RK_PCREL_LO12_S) { ret R_RISCV_PCREL_LO12_S; }
     ret 0;
 }
 
@@ -2293,11 +2348,46 @@ test "mach.lang.target.of.elf.reloc_kind_for:aarch64_page_lo12_reverse" {
 
     var n: usize = 0;
     for (n < 7) {
-        val kr: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, expect[n]);
+        val kr: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, 183, expect[n]);
         if (R.is_err[of.RelocKind, str](kr))                { ret 1; }
         if (R.unwrap_ok[of.RelocKind, str](kr) != kinds[n]) { ret 1; }
         n = n + 1;
     }
+    ret 0;
+}
+
+# the riscv reverse parse map keys on e_machine (EM_RISCV) to read riscv's own
+# relocation numbers, so a type that collides with x86_64 (R_RISCV_64 == 2 ==
+# R_X86_64_PC32) maps to the riscv kind for a riscv object and the x86_64 kind for an
+# x86_64 object. this is the parse-side resolution of the psABI number collision the
+# union below could not express.
+test "mach.lang.target.of.elf.reloc_kind_for:riscv_machine_keyed_reverse" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var types: [6]u32;
+    types[0] = R_RISCV_64;           types[1] = R_RISCV_32_PCREL;
+    types[2] = R_RISCV_CALL_PLT;     types[3] = R_RISCV_PCREL_HI20;
+    types[4] = R_RISCV_PCREL_LO12_I; types[5] = R_RISCV_PCREL_LO12_S;
+
+    var kinds: [6]of.RelocKind;
+    kinds[0] = of.RK_ABS64;       kinds[1] = of.RK_PC32;
+    kinds[2] = of.RK_PLT32;       kinds[3] = of.RK_PCREL_HI20;
+    kinds[4] = of.RK_PCREL_LO12_I; kinds[5] = of.RK_PCREL_LO12_S;
+
+    var n: usize = 0;
+    for (n < 6) {
+        val kr: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, EM_RISCV, types[n]);
+        if (R.is_err[of.RelocKind, str](kr))                { ret 1; }
+        if (R.unwrap_ok[of.RelocKind, str](kr) != kinds[n]) { ret 1; }
+        n = n + 1;
+    }
+
+    # the colliding type 2 reads as x86_64 PC32 for an x86_64 object, not riscv abs64.
+    val xr: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, 62, R_X86_64_PC32);
+    if (R.is_err[of.RelocKind, str](xr))                       { ret 1; }
+    if (R.unwrap_ok[of.RelocKind, str](xr) != of.RK_PC32)      { ret 1; }
     ret 0;
 }
 
@@ -2374,6 +2464,90 @@ test "mach.lang.target.of.elf.parse_object:unknown_reloc_type" {
     val pr: R.Result[bool, str] = parse_object(?alloc, ?i, buf.data, buf.len, ?out);
     if (!R.is_err[bool, str](pr))                                      { ret 1; }
     if (!str_contains(R.unwrap_err[bool, str](pr), "relocation type")) { ret 1; }
+    ret 0;
+}
+
+# a riscv object round-trips its relocations through emit_object / parse_object: the
+# parser keys the reverse map on the object's own e_machine (243), so R_RISCV_64 (type
+# 2) reads back as RK_ABS64 and R_RISCV_PCREL_HI20 / _LO12_I as their kinds - even
+# though type 2 means R_X86_64_PC32 for an x86_64 object. this is the end-to-end proof
+# of the parse-side resolution of the psABI number collision (#1628 / #1635).
+test "mach.lang.target.of.elf.parse_object:riscv_machine_roundtrip" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: R.Result[bool, str] = register(?of_reg);
+    if (R.is_err[bool, str](rr)) { ret 1; }
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id            = isa.ARCH_RISCV64;
+    isa_vt.elf_machine   = EM_RISCV::u32;
+    isa_vt.pointer_width = 8;
+    isa_vt.elf_reloc_type = t_riscv_elf_reloc_type::*u8;
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x13; k = k + 1; }  # riscv nop pattern
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    var syms: [1]of.Symbol;
+    syms[0].name = t_intern(?i, "g"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    # two relocations whose riscv type numbers collide with x86_64's: R_RISCV_64 (2)
+    # and R_RISCV_PCREL_HI20 (23). a parser keyed on x86_64 would read type 2 as PC32.
+    var relocs: [2]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_ABS64;
+    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+    relocs[1].section = 0; relocs[1].offset = 8; relocs[1].kind = of.RK_PCREL_HI20;
+    relocs[1].symbol = syms[0].name; relocs[1].addend = 0;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.interner = ?i;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 1;
+    img.relocations = ?relocs[0]; img.reloc_count = 2;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "elf_rv");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_object(?isa_vt, ?img, tpath::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
+    val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
+
+    # the emitted header must carry e_machine 243, which the parser reads to key the map.
+    if (bin.read_u16_le(buf.data, 18) != EM_RISCV) { ret 1; }
+
+    var out: of.ObjectImage;
+    val pr: R.Result[bool, str] = parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+    if (R.is_err[bool, str](pr)) { ret 1; }
+    if (out.reloc_count != 2)    { ret 1; }
+
+    # the relocations round-trip to their riscv kinds, not the x86_64 reading of the
+    # colliding numbers.
+    var saw_abs64: bool = false;
+    var saw_hi20:  bool = false;
+    var r: u32 = 0;
+    for (r < out.reloc_count) {
+        if (out.relocations[r].kind == of.RK_ABS64)      { saw_abs64 = true; }
+        if (out.relocations[r].kind == of.RK_PCREL_HI20) { saw_hi20 = true; }
+        r = r + 1;
+    }
+    if (!saw_abs64) { ret 1; }
+    if (!saw_hi20)  { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Slice 4 of #1628 (part of the riscv64 backend epic #1172). After this slice riscv64 produces complete linkable objects; the qemu e2e is slice 5.

## What this does
Wires the riscv64 relocation seam and assembly printer end to end, and un-defers the global-symbol patterns slice 3 parked.

### Abstract reloc kinds (`of.mach`)
- `RK_PCREL_HI20` - auipc/lui high-20 (`((S+A-P)+0x800) >> 12`), abstract so any arch with the hi/lo idiom can reuse it.
- `RK_PCREL_LO12_I` - low-12 in an I-type immediate (addi / load / jalr).
- `RK_PCREL_LO12_S` - low-12 in an S-type immediate (store).
- Reuses the existing arch-neutral `RK_PLT32` for the direct call and `RK_ABS64` for 64-bit data.

### Forward + reverse maps (`of/elf.mach`, `isa/riscv64/register.mach`)
- `R_RISCV_*` numbers added (`R_RISCV_64`/`_32`/`CALL_PLT`/`PCREL_HI20`/`PCREL_LO12_I`/`PCREL_LO12_S`/`32_PCREL`/`BRANCH`/`JAL`).
- `riscv64_elf_reloc_type` (forward hook on the vtable): `RK_* -> R_RISCV_*`.
- `reloc_kind_for` (reverse parse map) is now keyed on the parsed object's **e_machine**. RISC-V's psABI reuses x86_64's low type numbers with different meanings (`R_RISCV_64 == R_X86_64_PC32 == 2`), so the union could not express both - the parser reads its own e_machine and maps riscv objects against the riscv table. This partially closes the #1635 residual (parse side now has the ISA from the object itself).

### Relocation packer (`be/linker.mach`)
- `riscv64_apply_reloc` + its `register_reloc_hooks` line: hi20/lo12-I/lo12-S immediate scatter, the auipc+jalr CALL pair (`R_RISCV_CALL_PLT`, two words), and the shared abs64/pcrel32 flat writes. The lo12 is measured from the paired auipc one word back (the la-sequence gap), so the hi and lo relocations name the same global and resolve independently.

### Un-deferred global patterns (`isa/riscv64/encode.mach`)
- `emit_global_addr` - `auipc rd, %pcrel_hi(sym)` + `addi rd, rd, %pcrel_lo(sym)` (address-of rvalue).
- `emit_global_load` - `auipc t0, %pcrel_hi(sym)` + width-driven `ld/lwu/lhu/lbu rt, %pcrel_lo(sym)(t0)`.
- `emit_global_store` - value resolved first, `auipc t0, %pcrel_hi(sym)` + `sd/sw/sh/sb rt, %pcrel_lo(sym)(t0)`.
- Routed from `MIR_OP_SYM` operands in load / store / addr; the deferred `resolve_mem` error is removed.

### Assembly printer (`isa/riscv64/printer.mach`, new)
- `print_asm_riscv64` / `emit_asm`: psABI register-name tables (zero/ra/sp/a0/t0/s0 + ft/fa/fs), per-opcode mnemonics, frame-shape prologue/epilogue comments.

## Verification
- `mach test .`: **648 passed, 0 failed** (was 640; +8: forward map, machine-keyed reverse, ELF emit/parse round-trip, two packer tests, the encode la-sequence byte test, two printer table tests).
- **Self-host fixpoint BYTE-IDENTICAL**: `a build . -o b; b build . -o c; cmp -s b c` => `b == c`. Additionally confirmed my compiler emits byte-identical output to the clean compiler on identical source, so **x86_64 / aarch64 codegen is unchanged**.
- Encoder byte goldens and the packer's relocated forms cross-checked against `llvm-mc` (`ld a0,0(t0)`=0x0002B503, `sd a1,0(t0)`=0x00B2B023, the patched `addi`/`sd`/`auipc`+`jalr` call pair all match).
- Real riscv64 compile dumped with `llvm-objdump`/`readobj`: the three global functions emit `R_RISCV_PCREL_HI20`+`R_RISCV_PCREL_LO12_I` (load, address-of) and `R_RISCV_PCREL_HI20`+`R_RISCV_PCREL_LO12_S` (store) against the global symbol, lo12 exactly 4 bytes after each hi20.

## Residual a new ISA still touches
of.mach (abstract kinds), of/elf.mach (R_* numbers + a reverse-map branch keyed on e_machine), the be-layer packer + registrar line, and a vtable forward hook - the documented #1625/#1635 surface.