### PR TITLE
fix(target/isa): riscv64 sub-word load reads src_width not clamped width

### DIFF
--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -743,23 +743,29 @@ fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *
 }
 
 # a load `[dst, mem]`. a folded-global symbol source emits the auipc-based `la` load
-# sequence; a frame-slot / pointer source resolves to a base + displacement access.
+# sequence; a frame-slot / pointer source resolves to a base + displacement access. the
+# access reads `mi.src_width` bytes (the loaded type's width) - not `mi.width`, which the
+# lowering clamps up to the register-definition width so a sub-word load defines its whole
+# destination - so a u8 / u16 load picks `lbu` / `lhu`, not the word `lwu`. the zero-
+# extending sub-word form (`load_funct3`) still defines the whole destination register.
 fun encode_load(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.operand_count < 2) { ret R.err[bool, str]("encode: load missing operands"); }
     val rdr: R.Result[i32, str] = req_gpr(?mi.operands[0]);
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
     val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
     val src: *mir.MirOperand = ?mi.operands[1];
-    if (src.kind == mir.MIR_OP_SYM) { ret emit_global_load(st, rd, src, mi.width); }
+    if (src.kind == mir.MIR_OP_SYM) { ret emit_global_load(st, rd, src, mi.src_width); }
     val mr: R.Result[RvMem, str] = resolve_mem(f, src);
     if (R.is_err[RvMem, str](mr)) { ret R.err[bool, str](R.unwrap_err[RvMem, str](mr)); }
     val m: RvMem = R.unwrap_ok[RvMem, str](mr);
-    emit_mem_access(st, rd, m.base, m.off, mi.width, true);
+    emit_mem_access(st, rd, m.base, m.off, mi.src_width, true);
     ret R.ok[bool, str](true);
 }
 
 # a store `[mem, val]`. a folded-global symbol destination emits the auipc-based `la`
-# store sequence (handled in `emit_store_mem`).
+# store sequence (handled in `emit_store_mem`). the access rides `mi.width` (the stored
+# value's width) - a store result is void, so the lowering leaves that width unclamped
+# and it is the true access width, picking `sb` / `sh` / `sw` / `sd` directly.
 fun encode_store(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.operand_count < 2) { ret R.err[bool, str]("encode: store missing operands"); }
     ret emit_store_mem(st, f, ?mi.operands[0], ?mi.operands[1], mi.width);

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -2143,6 +2143,74 @@ test "mach.lang.target.isa.riscv64.encode:width_driven_loads_stores_and_alu" {
     ret bad;
 }
 
+# the MIR_LOAD / MIR_STORE dispatch sizes its access off the operand width the lowering
+# stamps. a load rides `src_width` (the loaded type's width), not `width` - the lowering
+# clamps a load's `width` up to the register-definition width, so reading `width` would
+# turn a u8 / u16 load into the word `lwu` (the #1639 bug); reading `src_width` keeps it
+# `lbu` / `lhu`. a store rides its `width`, which a void-result store leaves unclamped, so
+# a u8 / u16 store is `sb` / `sh`. byte-exact against llvm-mc. operands a0/a1 = x10/x11.
+test "mach.lang.target.isa.riscv64.encode:mir_subword_load_store_widths" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+    st.alloc       = ?alloc;
+    st.relocs      = nil;
+    st.reloc_count = 0;
+    st.reloc_cap   = 0;
+
+    var ld: mir.MirInstr;
+    var ldops: [2]mir.MirOperand;
+    ldops[0] = mir.op_preg(10);          # a0
+    ldops[1] = mir.op_mem_preg(11, 0);   # [a1 + 0]
+    ld.opcode = mir.MIR_LOAD; ld.operands = ?ldops[0]; ld.operand_count = 2;
+
+    # u8 load: width clamps to 4, but the access is src_width 1 -> lbu a0,0(a1) =
+    # 0x0005c503, NOT the pre-fix word lwu (0x0005e503).
+    ld.width = 4; ld.src_width = 1; encode_load(?st, nil, ?ld);
+    if (read_word(?st.buf, 0) != 0x0005C503) { bad = 1; }
+    # u16 load: width 4, src_width 2 -> lhu a0,0(a1) = 0x0005d503.
+    st.buf.len = 0; ld.width = 4; ld.src_width = 2; encode_load(?st, nil, ?ld);
+    if (read_word(?st.buf, 0) != 0x0005D503) { bad = 1; }
+    # u32 load: width 4, src_width 4 -> lwu a0,0(a1) = 0x0005e503.
+    st.buf.len = 0; ld.width = 4; ld.src_width = 4; encode_load(?st, nil, ?ld);
+    if (read_word(?st.buf, 0) != 0x0005E503) { bad = 1; }
+    # u64 load: width 8, src_width 8 -> ld a0,0(a1) = 0x0005b503.
+    st.buf.len = 0; ld.width = 8; ld.src_width = 8; encode_load(?st, nil, ?ld);
+    if (read_word(?st.buf, 0) != 0x0005B503) { bad = 1; }
+
+    var sr: mir.MirInstr;
+    var srops: [2]mir.MirOperand;
+    srops[0] = mir.op_mem_preg(11, 0);   # [a1 + 0]
+    srops[1] = mir.op_preg(10);          # a0
+    sr.opcode = mir.MIR_STORE; sr.operands = ?srops[0]; sr.operand_count = 2;
+
+    # u8 store: width 1 -> sb a0,0(a1) = 0x00a58023.
+    st.buf.len = 0; sr.width = 1; sr.src_width = 1; encode_store(?st, nil, ?sr);
+    if (read_word(?st.buf, 0) != 0x00A58023) { bad = 1; }
+    # u16 store: width 2 -> sh a0,0(a1) = 0x00a59023.
+    st.buf.len = 0; sr.width = 2; sr.src_width = 2; encode_store(?st, nil, ?sr);
+    if (read_word(?st.buf, 0) != 0x00A59023) { bad = 1; }
+
+    # the folded-global load path sizes off src_width too: a u8 symbol load is
+    # auipc t0,0 (0x00000297) ; lbu a0,0(t0) (0x0002c503), NOT lwu.
+    st.buf.len = 0; st.reloc_count = 0;
+    var gl: mir.MirInstr;
+    var glops: [2]mir.MirOperand;
+    glops[0] = mir.op_preg(10);          # a0
+    glops[1] = mir.op_sym(7::intern.StrId, 0);
+    gl.opcode = mir.MIR_LOAD; gl.operands = ?glops[0]; gl.operand_count = 2;
+    gl.width = 4; gl.src_width = 1; encode_load(?st, nil, ?gl);
+    if (read_word(?st.buf, 0) != 0x00000297) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x0002C503) { bad = 1; }
+
+    encode.buf_dnit(?st.buf);
+    if (st.relocs != nil && st.reloc_cap > 0) {
+        A.deallocate[encode.PendingReloc](?alloc, st.relocs, st.reloc_cap::usize);
+    }
+    ret bad;
+}
+
 # the MIR ALU / shift / mv / neg / not dispatch emits the expected words, byte-exact
 # against llvm-mc. operands a0/a1/a2 = x10/x11/x12.
 test "mach.lang.target.isa.riscv64.encode:mir_alu_shift_mov_neg_not" {


### PR DESCRIPTION
## Summary

`encode_load` in `src/lang/target/isa/riscv64/encode.mach` selected the load access
width from `mi.width`. But `lower_load` clamps a load's `mi.width` up to the
register-definition width (`clamp_alu_width`, minimum 4) so a sub-word load still
defines its whole destination register. The real access width lives in `mi.src_width`.
So a `u8` / `u16` load emitted `lwu` (a 4-byte word load) instead of `lbu` / `lhu`:

- it read 3 bytes past a 1-byte address (2 past a 2-byte one) - a potential OOB read,
- the destination got a 4-byte value, not the zero-extended sub-word value.

The fix reads the access width from `mi.src_width`, exactly as arm64's `encode_load`
does. The existing `load_funct3` already chooses the zero-extending sub-word forms
(`lbu` / `lhu` / `lwu` / `ld`), so the whole-register-definition guarantee is preserved.

## Scope

- `encode_load`: both the folded-global (`emit_global_load`) and the frame-slot /
  pointer (`emit_mem_access`) paths now pass `mi.src_width`.
- Stores: `encode_store` / `emit_global_store` ride `mi.width`, which a void-result
  store leaves **unclamped** in `lower_store` - it is the true access width there, so
  `sb` / `sh` / `sw` / `sd` were already selected correctly. No store fix needed; the
  comment is clarified to document why load and store read different width fields.
- No opcode-space change: the `LOAD` / `STORE` major opcodes plus the `funct3`
  selectors already express every form. Nothing added to `isa/riscv64.mach`.

## Signedness

mach loads always **zero-extend** (documented in `lower_load`; arm64 does the same with
`LDRB` / `LDRH`), and a `MIR_LOAD` carries no signedness field - signed widening is a
separate `SEXT` IR op. So the fix keeps the zero-extending `load_funct3` (`lbu` / `lhu`)
rather than introducing `lb` / `lh`, matching the reference backend and the documented
register-definition convention.

## Verification

- `mach build .` clean; `mach test .` green.
- Added byte-comparison (vs llvm-mc) tests driving `encode_load` / `encode_store` through
  the lowering's width/src_width convention for sub-word forms.

riscv64-only. No shared-backend or other-arch path touched. riscv64 is not
default-selected, so no self-host fixpoint is required.

Closes #1639