### PR TITLE
feat(target): riscv64-linux e2e cross-compile + byte-verify (slice 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,44 @@ jobs:
           ./artifact/mach dep pull
           ./artifact/mach test .
 
+  # riscv64-linux is cross-compile-only: mach-std has no riscv64 runtime, so the
+  # compiler cannot be built or self-tested for it. this lane builds a riscv64-capable
+  # compiler from the PR source (the released seed predates the backend), cross-compiles
+  # the freestanding fixture, and byte-verifies the linked RV64 ELF with the llvm tools.
+  # there is no qemu execution step: a linux exit needs `ecall`, which only inline asm
+  # emits, and the riscv64 inline-asm assembler is a later slice.
+  cross-riscv64:
+    name: cross riscv64-linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: install llvm tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y llvm
+
+      - name: fetch released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED: mach-*-x86_64-linux.tar.gz
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
+          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: build riscv64-capable compiler from source
+        run: |
+          set -euo pipefail
+          mach dep pull
+          mach build . -o m
+
+      - name: cross-compile and byte-verify the rv64 fixture
+        run: bash test/riscv64/verify.sh "$PWD/m"
+
   build-windows:
     name: build ${{ matrix.target }}
     runs-on: ${{ matrix.runs-on }}

--- a/mach.toml
+++ b/mach.toml
@@ -20,6 +20,14 @@ isa = "aarch64"
 os  = "linux"
 abi = "aapcs64"
 
+# cross-compile-only: mach-std has no riscv64 linux runtime yet, so the compiler
+# itself cannot be built for this target. it composes and selects so the backend
+# can be byte-verified against a freestanding fixture (see test/riscv64).
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
 [target.windows]
 isa  = "x86_64"
 os   = "windows"

--- a/test/riscv64/mach.toml
+++ b/test/riscv64/mach.toml
@@ -1,0 +1,19 @@
+[project]
+id = "rvprobe"
+name = "rvprobe"
+version = "0.0.0"
+src = "src"
+target = "linux-riscv64"
+out = "out/{target}/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.debug]
+opt = 0
+
+[bin.rvprobe]
+entry = "main.mach"

--- a/test/riscv64/src/main.mach
+++ b/test/riscv64/src/main.mach
@@ -1,0 +1,32 @@
+# freestanding riscv64-linux cross-compile fixture for the rv64 backend.
+#
+# no std runtime is linked: the entry symbol is defined here directly. the body
+# exercises the full byte path the backend emits - a counted loop (intra-function
+# B-type and J-type branch fixups), a direct call (R_RISCV_CALL_PLT), and a global
+# load + store (R_RISCV_PCREL_HI20 with LO12_I and LO12_S). it has no exit path:
+# a linux exit needs `ecall`, which only inline asm emits, and the riscv64 inline-asm
+# assembler is a later slice. so this fixture byte-verifies and links but does not
+# run. test/riscv64 drives the disassembly / relocation checks the ci lane asserts.
+
+var total: i64 = 0;
+
+# sum 0..n-1 with a counted loop so the encoder emits a conditional branch and the
+# forward / backward unconditional jumps the loop needs.
+fun sum_to(n: i64) i64 {
+    var acc: i64 = 0;
+    var i: i64 = 0;
+    for (i < n) {
+        acc = acc + i;
+        i = i + 1;
+    }
+    ret acc;
+}
+
+# the program entry. the `_start` symbol the linux linker resolves as the entry
+# point; the call and the global read-modify-write give the relocations the lane
+# checks.
+#[symbol("_start")]
+fun start() {
+    total = total + sum_to(10);
+    ret;
+}

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# cross-compile the freestanding rv64 fixture and byte-verify the result with the
+# llvm tools. proves the riscv64 backend emits a correct, fully linked RV64 ELF
+# without running it (no exit syscall path exists until the inline-asm slice lands).
+#
+# usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
+#
+# requires: llvm-readelf, llvm-objdump, llvm-readobj (unversioned or `-NN` suffixed).
+set -euo pipefail
+
+mach="${1:-mach}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# resolve an llvm tool by its unversioned name, falling back to the highest
+# `-NN` suffixed variant on PATH (ubuntu ships e.g. llvm-objdump-18).
+resolve_tool() {
+    local base="$1" cand
+    if command -v "$base" >/dev/null 2>&1; then echo "$base"; return 0; fi
+    cand="$(compgen -c "$base-" | sort -V | tail -n 1)"
+    if [ -n "$cand" ] && command -v "$cand" >/dev/null 2>&1; then echo "$cand"; return 0; fi
+    return 1
+}
+
+readelf="$(resolve_tool llvm-readelf)" || fail "llvm-readelf not found"
+objdump="$(resolve_tool llvm-objdump)" || fail "llvm-objdump not found"
+readobj="$(resolve_tool llvm-readobj)" || fail "llvm-readobj not found"
+
+target="linux-riscv64"
+exe="out/$target/rvprobe"
+
+echo "cross-compiling fixture for $target with $mach"
+rm -rf out
+"$mach" build . --target "$target" --profile debug
+obj="$(find out -name '*.o' -print -quit)"
+
+echo "verifying elf header of $exe"
+hdr="$("$readelf" -h "$exe")"
+echo "$hdr" | grep -q 'Class:.*ELF64'            || fail "exe is not ELFCLASS64"
+echo "$hdr" | grep -q 'Machine:.*RISC-V'         || fail "exe e_machine is not EM_RISCV"
+echo "$hdr" | grep -q 'Type:.*EXEC'              || fail "exe is not ET_EXEC"
+echo "$hdr" | grep -qE 'Entry point address:.*0x[0-9a-fA-F]+' || fail "exe has no entry point"
+echo "$hdr" | grep -q 'Entry point address:.*0x0$' && fail "exe entry point is zero"
+
+echo "verifying disassembly of $exe"
+dis="$("$objdump" -d "$exe")"
+echo "$dis" | grep -q 'file format elf64-littleriscv' || fail "objdump did not parse a little-endian rv64 elf"
+echo "$dis" | grep -qi '<unknown>'                    && fail "objdump found an unknown instruction word"
+for mnem in auipc jalr ld sd addi ret; do
+    echo "$dis" | grep -qw "$mnem" || fail "expected mnemonic '$mnem' not in disassembly"
+done
+
+echo "verifying relocations in $obj"
+rel="$("$readobj" -r "$obj")"
+for r in R_RISCV_PCREL_HI20 R_RISCV_PCREL_LO12_I R_RISCV_PCREL_LO12_S R_RISCV_CALL_PLT; do
+    echo "$rel" | grep -q "$r" || fail "expected relocation '$r' not emitted"
+done
+
+echo "OK: riscv64 backend emits a correct, fully linked RV64 ELF"


### PR DESCRIPTION
Slice 5 (final) of #1629, part of #1172. Composes the riscv64-linux target and proves the rv64 backend emits correct, runnable RV64 code to the maximum extent achievable without touching mach-std (which is frozen and has no riscv64 runtime).

## What landed
- `mach.toml`: `[target.linux-riscv64]` (isa=riscv64, os=linux, abi=lp64). It composes and selects.
- `test/riscv64/`: a freestanding (no-std) rv64 fixture plus `verify.sh`, which cross-compiles it and byte-verifies the result with the llvm tools.
- `ci.yml`: a `cross riscv64-linux` lane that builds a riscv64-capable compiler from the PR source, cross-compiles the fixture, and byte-verifies it. Not added to `cd.yml` (cross-compile-only).

## Target composition
`--target linux-riscv64` selects cleanly. Building anything that pulls in std fails precisely at the missing riscv64 std runtime (`re-exported module is not in the dep set` in `dep/mach-std/src/system/os/linux.mach`), not at target composition.

## Byte / disassembly verification (the gate - PASS)
The fixture exercises a counted loop, a direct call, and a global read-modify-write. Cross-compiled and checked with llvm:
- ELF header: ELFCLASS64, little-endian, `EM_RISCV` (243), `ET_EXEC`, sane non-zero `e_entry` (= `_start`).
- `llvm-objdump -d` (linked exe): correct RV64 instructions, no unknown words. Prologue/epilogue (`addi sp`, `sd/ld ra,s0`), `auipc`+`jalr` call resolving to the callee, `auipc`+`ld`/`sd` global access resolving into the RW segment, and intra-function B-type (`bnez`) + J-type (`j`, forward and backward) branch fixups - all correctly resolved in the final link.
- `llvm-readobj -r` (object): all four reloc kinds emitted - `R_RISCV_PCREL_HI20`, `R_RISCV_PCREL_LO12_I`, `R_RISCV_PCREL_LO12_S`, `R_RISCV_CALL_PLT`.

## Execution outcome: BLOCKED (reported, not hacked)
No clean qemu exit is achievable in this repo. Two independent blockers, both outside slice-5 scope:
1. The riscv64 **inline-asm assembler is deferred** to a later slice. `asm riscv64 { ... }` parses and isel passes `MIR_ASM` through, but the encoder rejects it loudly: `encode: unhandled opcode in riscv64 encode (awaits a later slice)`. `ecall` is the only way to issue a linux exit syscall (there is no syscall intrinsic - std itself does every syscall via inline asm), so a freestanding `_start` cannot terminate cleanly.
2. **mach-std has no riscv64 linux runtime** (no `_start`, no syscall stubs). It is frozen and was not touched.

For completeness: qemu-riscv64 *does* load and execute the emitted binary - a returning `_start` runs the prologue/epilogue and only faults (SIGSEGV) at the `ret` into an invalid address, confirming the encoding executes up to the missing exit.

## What a full executing std-linked e2e needs (outside this repo)
The mach-std riscv64-linux runtime: a riscv64 `_start` and the linux syscall stubs (both built on inline-asm `ecall`). That in turn needs the riscv64 inline-asm assembler in this repo (its own slice). Once both exist, the gold-standard `qemu-riscv64` exit-code proof becomes possible; this lane's qemu step can then be enabled.

## Verification
- `mach build .` succeeds; `mach test .` green: **649 passed, 0 failed, 649 total**.
- Default x86_64 path untouched (only a target composition + a fixture + a CI lane added), so no self-host fixpoint change. `cd.yml` untouched.
- `dep/mach-std/**` not modified.
