### PR TITLE
feat(target/of): Mach-O object format (writer, reader, executable)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,45 @@ jobs:
       - name: cross-compile and byte-verify the rv64 fixture
         run: bash test/riscv64/verify.sh "$PWD/m"
 
+  # the Darwin triples are cross-compile-only here: the Darwin runtime (#1178) is
+  # a later slice, so the compiler cannot be built or self-tested for darwin yet.
+  # this lane builds a Mach-O-capable compiler from the PR source, cross-compiles
+  # the freestanding fixture for x86_64-darwin and aarch64-darwin, and byte-verifies
+  # the emitted Mach-O object and executable with the llvm tools. there is no
+  # execution step: Darwin binaries cannot run on the Linux host, and a Darwin exit
+  # needs the libSystem runtime the #1178 slice adds.
+  cross-darwin:
+    name: cross darwin (macho)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: install llvm tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y llvm
+
+      - name: fetch released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED: mach-*-x86_64-linux.tar.gz
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
+          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: build macho-capable compiler from source
+        run: |
+          set -euo pipefail
+          mach dep pull
+          mach build . -o m
+
+      - name: cross-compile and byte-verify the macho fixture
+        run: bash test/macho/verify.sh "$PWD/m"
+
   build-windows:
     name: build ${{ matrix.target }}
     runs-on: ${{ matrix.runs-on }}

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1999,36 +1999,25 @@ fun ts_bad_input() u8 {
     ret 0;
 }
 
-# the Mach-O byte tests run on every host except windows. each `test` block is
-# built into its own executable by the `mach test .` driver, and the windows
-# driver is at its per-run memory ceiling - one more test executable fails the
-# link with "coff: unwind table alloc failed" (a pre-existing test-driver memory
-# leak, tracked as #1653, not a Mach-O fault). the writer/reader is
-# host-independent, so the linux and aarch64 lanes run these and the cross-darwin
-# CI lane byte-verifies both triples. the scenario helpers above stay ungated and
-# are dead-code-eliminated on windows where nothing references them.
-$if ($mach.build.os != $mach.os.windows) {
+# the object writer/reader and the relocation maps: the x86_64 and arm64
+# emit/parse round-trips, the machine-keyed forward map, and the PAGEOFF12
+# instruction-decode reverse map.
+test "mach.lang.target.of.macho:object_round_trip_and_reloc_maps" {
+    if (ts_x64_roundtrip() != 0)   { ret 1; }
+    if (ts_arm64_roundtrip() != 0) { ret 1; }
+    if (ts_reloc_map() != 0)       { ret 1; }
+    if (ts_pageoff12() != 0)       { ret 1; }
+    ret 0;
+}
 
-    # the object writer/reader and the relocation maps, grouped into one test (and
-    # so one test executable): the x86_64 and arm64 emit/parse round-trips, the
-    # machine-keyed forward map, and the PAGEOFF12 instruction-decode reverse map.
-    test "mach.lang.target.of.macho:object_round_trip_and_reloc_maps" {
-        if (ts_x64_roundtrip() != 0)   { ret 1; }
-        if (ts_arm64_roundtrip() != 0) { ret 1; }
-        if (ts_reloc_map() != 0)       { ret 1; }
-        if (ts_pageoff12() != 0)       { ret 1; }
-        ret 0;
-    }
-
-    # the executable writer, vtable registration, and the rejection paths: the
-    # x86_64 and arm64 static-exec skeletons, register installation, and the
-    # unsupported-kind / bad-input errors.
-    test "mach.lang.target.of.macho:exec_vtable_and_rejections" {
-        if (ts_exec_x64() != 0)         { ret 1; }
-        if (ts_exec_arm64() != 0)       { ret 1; }
-        if (ts_register() != 0)         { ret 1; }
-        if (ts_unsupported_kind() != 0) { ret 1; }
-        if (ts_bad_input() != 0)        { ret 1; }
-        ret 0;
-    }
+# the executable writer, vtable registration, and the rejection paths: the
+# x86_64 and arm64 static-exec skeletons, register installation, and the
+# unsupported-kind / bad-input errors.
+test "mach.lang.target.of.macho:exec_vtable_and_rejections" {
+    if (ts_exec_x64() != 0)         { ret 1; }
+    if (ts_exec_arm64() != 0)       { ret 1; }
+    if (ts_register() != 0)         { ret 1; }
+    if (ts_unsupported_kind() != 0) { ret 1; }
+    if (ts_bad_input() != 0)        { ret 1; }
+    ret 0;
 }

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -30,6 +30,7 @@
 # records it on `out`. register interns nothing - the vtable name fields are
 # immutable `str` constants.
 
+use std.allocator.page;
 use std.filesystem;
 use std.memory;
 use std.types.bool.bool;
@@ -1510,5 +1511,490 @@ fun recover_addend(out: *of.ObjectImage, sec_i: u32, address: u32, cputype: u32,
     if (pcrel != 0) {
         if (bytes != nil && (address::usize + 4) <= len) { ret (bin.read_u32_le(bytes, address::usize)::i32)::i64 - 4; }
     }
+    ret 0;
+}
+
+# intern a string for a test, yielding STR_NIL on the (test-only) interning failure
+# ---
+# itn: interner to intern into
+# s:   the string to intern
+# ret: the interned id, or STR_NIL on failure
+fun t_intern(itn: *intern.Interner, s: str) intern.StrId {
+    val r: R.Result[intern.StrId, str] = intern.intern(itn, s);
+    if (R.is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
+    ret R.unwrap_ok[intern.StrId, str](r);
+}
+
+# locate the file offset of the first load command of type `cmd`, scanning the
+# header's ncmds entries; returns 0 when absent.
+# ---
+# buf: the Mach-O bytes
+# cmd: the LC_* id to find
+# ret: the load command's file offset, or 0 if not present
+fun t_find_lc(buf: *u8, cmd: u32) usize {
+    val ncmds: u32 = bin.read_u32_le(buf, 16);
+    var off: usize = MACH_HEADER_64_SIZE;
+    var c: u32 = 0;
+    for (c < ncmds) {
+        if (bin.read_u32_le(buf, off) == cmd) { ret off; }
+        off = off + bin.read_u32_le(buf, off + 4)::usize;
+        c = c + 1;
+    }
+    ret 0;
+}
+
+# an x86_64 ObjectImage round-trips through emit_object / parse_object: the header,
+# sections, symbols, and relocations (PLT32, PC32, ABS64) survive, and the
+# in-place addends are recovered in the abstract field-relative convention.
+test "mach.lang.target.of.macho.emit_object:x86_64_round_trip" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    # .text: a call at offset 0 (PLT32 field at 1), a rip-relative load at offset 6
+    # (PC32 field at 8), an 8-byte absolute slot at offset 16 (ABS64). the
+    # displacement fields are zero placeholders, as the encoder emits them; the
+    # writer folds each addend into the field in place.
+    var text_bytes: [24]u8;
+    var k: usize = 0;
+    for (k < 24) { text_bytes[k] = 0; k = k + 1; }
+    text_bytes[0] = 0xE8;
+    var data_bytes: [8]u8;
+    k = 0;
+    for (k < 8) { data_bytes[k] = 0; k = k + 1; }
+
+    var secs: [2]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 24; secs[0].align = 16;
+    secs[1].name = t_intern(?i, ".data"); secs[1].kind = of.SK_DATA;
+    secs[1].bytes = ?data_bytes[0]; secs[1].len = 8; secs[1].align = 8;
+
+    var syms: [3]of.Symbol;
+    syms[0].name = t_intern(?i, "_main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 24; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    syms[1].name = t_intern(?i, "g"); syms[1].section = 1; syms[1].offset = 0;
+    syms[1].size = 8; syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_OBJECT;
+    syms[2].name = t_intern(?i, "ext_func"); syms[2].section = of.SECTION_EXTERNAL;
+    syms[2].offset = 0; syms[2].size = 0; syms[2].flags = of.SYM_OBJ_FLAG_EXTERN;
+
+    var relocs: [3]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 1;  relocs[0].kind = of.RK_PLT32;
+    relocs[0].symbol = syms[2].name; relocs[0].addend = -4;
+    relocs[1].section = 0; relocs[1].offset = 8;  relocs[1].kind = of.RK_PC32;
+    relocs[1].symbol = syms[1].name; relocs[1].addend = -4;
+    relocs[2].section = 0; relocs[2].offset = 16; relocs[2].kind = of.RK_ABS64;
+    relocs[2].symbol = syms[1].name; relocs[2].addend = 0;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.interner = ?i;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 2;
+    img.symbols = ?syms[0]; img.symbol_count = 3;
+    img.relocations = ?relocs[0]; img.reloc_count = 3;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "macho_x64");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_object(?isa_vt, ?img, tpath::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
+    val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
+
+    # header: magic, cputype, MH_OBJECT, three load commands.
+    if (bin.read_u32_le(buf.data, 0) != MH_MAGIC_64)     { ret 1; }
+    if (bin.read_u32_le(buf.data, 4) != CPU_TYPE_X86_64) { ret 1; }
+    if (bin.read_u32_le(buf.data, 12) != MH_OBJECT)      { ret 1; }
+    if (bin.read_u32_le(buf.data, 16) != 3)              { ret 1; }
+    # the segment carries two sections.
+    if (bin.read_u32_le(buf.data, MACH_HEADER_64_SIZE + 64) != 2) { ret 1; }
+
+    var out: of.ObjectImage;
+    val pr: R.Result[bool, str] = parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+    if (R.is_err[bool, str](pr)) { ret 1; }
+
+    if (out.section_count != 2) { ret 1; }
+    if (out.symbol_count != 3)  { ret 1; }
+    if (out.reloc_count != 3)   { ret 1; }
+    if (out.sections[0].kind != of.SK_TEXT || out.sections[0].len != 24) { ret 1; }
+    if (out.sections[1].kind != of.SK_DATA || out.sections[1].len != 8)  { ret 1; }
+    if (out.sections[0].align != 16 || out.sections[1].align != 8)       { ret 1; }
+    if (out.sections[0].bytes == nil)                                    { ret 1; }
+    if (out.sections[0].bytes[0] != 0xE8)                                { ret 1; }
+
+    var saw_main: bool = false;
+    var saw_ext:  bool = false;
+    var si: u32 = 0;
+    for (si < out.symbol_count) {
+        if (out.symbols[si].name == syms[0].name) {
+            saw_main = true;
+            if ((out.symbols[si].flags & of.SYM_OBJ_FLAG_GLOBAL) == 0)   { ret 1; }
+            if ((out.symbols[si].flags & of.SYM_OBJ_FLAG_FUNCTION) == 0) { ret 1; }
+            if (out.symbols[si].section != 0)                            { ret 1; }
+        }
+        if (out.symbols[si].name == syms[2].name) {
+            saw_ext = true;
+            if ((out.symbols[si].flags & of.SYM_OBJ_FLAG_EXTERN) == 0) { ret 1; }
+            if (out.symbols[si].section != of.SECTION_EXTERNAL)        { ret 1; }
+        }
+        si = si + 1;
+    }
+    if (!saw_main || !saw_ext) { ret 1; }
+
+    var ok_plt: bool = false;
+    var ok_pc:  bool = false;
+    var ok_abs: bool = false;
+    var rj: u32 = 0;
+    for (rj < out.reloc_count) {
+        val rr: *of.Relocation = ?out.relocations[rj];
+        if (rr.offset == 1 && rr.kind == of.RK_PLT32 && rr.symbol == syms[2].name && rr.addend == -4) { ok_plt = true; }
+        if (rr.offset == 8 && rr.kind == of.RK_PC32 && rr.symbol == syms[1].name && rr.addend == -4)  { ok_pc = true; }
+        if (rr.offset == 16 && rr.kind == of.RK_ABS64 && rr.symbol == syms[1].name && rr.addend == 0) { ok_abs = true; }
+        rj = rj + 1;
+    }
+    if (!ok_plt || !ok_pc || !ok_abs) { ret 1; }
+    ret 0;
+}
+
+# an arm64 ObjectImage round-trips: PAGE21 / ADD_LO12 / LDST64_LO12 (the last with
+# a non-zero addend carried in an ARM64_RELOC_ADDEND entry) / BRANCH26 in .text and
+# an ABS64 with an in-place addend in .data all survive, and PAGEOFF12 is decoded
+# back to the exact LO12 width from the patched instruction.
+test "mach.lang.target.of.macho.emit_object:arm64_round_trip" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_AARCH64;
+
+    # adrp x0,g ; add x0,x0,#:lo12:g ; ldr x1,[x0] ; bl ext_func.
+    var text_bytes: [16]u8;
+    bin.write_u32_le(?text_bytes[0], 0, 0x90000000);   # adrp x0, 0
+    bin.write_u32_le(?text_bytes[0], 4, 0x91000000);   # add  x0, x0, #0
+    bin.write_u32_le(?text_bytes[0], 8, 0xF9400001);   # ldr  x1, [x0]
+    bin.write_u32_le(?text_bytes[0], 12, 0x94000000);  # bl   0
+    var data_bytes: [8]u8;
+    var k: usize = 0;
+    for (k < 8) { data_bytes[k] = 0; k = k + 1; }
+
+    var secs: [2]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 4;
+    secs[1].name = t_intern(?i, ".data"); secs[1].kind = of.SK_DATA;
+    secs[1].bytes = ?data_bytes[0]; secs[1].len = 8; secs[1].align = 8;
+
+    var syms: [3]of.Symbol;
+    syms[0].name = t_intern(?i, "_main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    syms[1].name = t_intern(?i, "g"); syms[1].section = 1; syms[1].offset = 0;
+    syms[1].size = 8; syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_OBJECT;
+    syms[2].name = t_intern(?i, "ext_func"); syms[2].section = of.SECTION_EXTERNAL;
+    syms[2].offset = 0; syms[2].size = 0; syms[2].flags = of.SYM_OBJ_FLAG_EXTERN;
+
+    var relocs: [5]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 0;  relocs[0].kind = of.RK_PAGE21;
+    relocs[0].symbol = syms[1].name; relocs[0].addend = 0;
+    relocs[1].section = 0; relocs[1].offset = 4;  relocs[1].kind = of.RK_ADD_LO12;
+    relocs[1].symbol = syms[1].name; relocs[1].addend = 0;
+    relocs[2].section = 0; relocs[2].offset = 8;  relocs[2].kind = of.RK_LDST64_LO12;
+    relocs[2].symbol = syms[1].name; relocs[2].addend = 0x10;
+    relocs[3].section = 0; relocs[3].offset = 12; relocs[3].kind = of.RK_PLT32;
+    relocs[3].symbol = syms[2].name; relocs[3].addend = 0;
+    relocs[4].section = 1; relocs[4].offset = 0;  relocs[4].kind = of.RK_ABS64;
+    relocs[4].symbol = syms[0].name; relocs[4].addend = 0x20;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.interner = ?i;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 2;
+    img.symbols = ?syms[0]; img.symbol_count = 3;
+    img.relocations = ?relocs[0]; img.reloc_count = 5;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "macho_a64");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_object(?isa_vt, ?img, tpath::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
+    val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
+
+    if (bin.read_u32_le(buf.data, 0) != MH_MAGIC_64)    { ret 1; }
+    if (bin.read_u32_le(buf.data, 4) != CPU_TYPE_ARM64) { ret 1; }
+    if (bin.read_u32_le(buf.data, 12) != MH_OBJECT)     { ret 1; }
+    # the .text section carries five relocation_info entries (four real + one
+    # ARM64_RELOC_ADDEND for the LDST64 addend).
+    val text_sh: usize = MACH_HEADER_64_SIZE + SEGMENT_CMD_64_SIZE;
+    if (bin.read_u32_le(buf.data, text_sh + 60) != 5) { ret 1; }
+
+    var out: of.ObjectImage;
+    val pr: R.Result[bool, str] = parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+    if (R.is_err[bool, str](pr)) { ret 1; }
+    if (out.section_count != 2) { ret 1; }
+    if (out.reloc_count != 5)   { ret 1; }
+
+    var ok_page: bool = false;
+    var ok_add:  bool = false;
+    var ok_ldst: bool = false;
+    var ok_br:   bool = false;
+    var ok_abs:  bool = false;
+    var rj: u32 = 0;
+    for (rj < out.reloc_count) {
+        val rr: *of.Relocation = ?out.relocations[rj];
+        if (rr.section == 0 && rr.offset == 0 && rr.kind == of.RK_PAGE21 && rr.symbol == syms[1].name)                     { ok_page = true; }
+        if (rr.section == 0 && rr.offset == 4 && rr.kind == of.RK_ADD_LO12 && rr.symbol == syms[1].name)                   { ok_add = true; }
+        if (rr.section == 0 && rr.offset == 8 && rr.kind == of.RK_LDST64_LO12 && rr.symbol == syms[1].name && rr.addend == 0x10) { ok_ldst = true; }
+        if (rr.section == 0 && rr.offset == 12 && rr.kind == of.RK_PLT32 && rr.symbol == syms[2].name)                     { ok_br = true; }
+        if (rr.section == 1 && rr.offset == 0 && rr.kind == of.RK_ABS64 && rr.symbol == syms[0].name && rr.addend == 0x20) { ok_abs = true; }
+        rj = rj + 1;
+    }
+    if (!ok_page || !ok_add || !ok_ldst || !ok_br || !ok_abs) { ret 1; }
+    ret 0;
+}
+
+# the forward relocation map is machine-keyed: a kind resolves to the x86_64
+# X86_64_RELOC_* type for x86_64 and the arm64 ARM64_RELOC_* type for arm64, and a
+# kind an architecture has no type for is an error naming it.
+test "mach.lang.target.of.macho.macho_reloc_for:machine_keyed" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val x_abs: R.Result[MachoReloc, str] = macho_reloc_for(?i, ?alloc, isa.ARCH_X86_64, of.RK_ABS64);
+    if (R.is_err[MachoReloc, str](x_abs))                                  { ret 1; }
+    if (R.unwrap_ok[MachoReloc, str](x_abs).r_type != X86_64_RELOC_UNSIGNED) { ret 1; }
+    val x_plt: R.Result[MachoReloc, str] = macho_reloc_for(?i, ?alloc, isa.ARCH_X86_64, of.RK_PLT32);
+    if (R.unwrap_ok[MachoReloc, str](x_plt).r_type != X86_64_RELOC_BRANCH) { ret 1; }
+
+    val a_page: R.Result[MachoReloc, str] = macho_reloc_for(?i, ?alloc, isa.ARCH_AARCH64, of.RK_PAGE21);
+    if (R.is_err[MachoReloc, str](a_page))                               { ret 1; }
+    if (R.unwrap_ok[MachoReloc, str](a_page).r_type != ARM64_RELOC_PAGE21) { ret 1; }
+    val a_ldst: R.Result[MachoReloc, str] = macho_reloc_for(?i, ?alloc, isa.ARCH_AARCH64, of.RK_LDST32_LO12);
+    if (R.unwrap_ok[MachoReloc, str](a_ldst).r_type != ARM64_RELOC_PAGEOFF12) { ret 1; }
+
+    # arm64 has no Mach-O type for the x86_64-only RK_GOTPCREL kind here.
+    val a_bad: R.Result[MachoReloc, str] = macho_reloc_for(?i, ?alloc, isa.ARCH_AARCH64, of.RK_ADDR32NB);
+    if (!R.is_err[MachoReloc, str](a_bad))                                  { ret 1; }
+    if (!str_contains(R.unwrap_err[MachoReloc, str](a_bad), "addr32nb"))    { ret 1; }
+    ret 0;
+}
+
+# the reverse PAGEOFF12 map decodes the patched instruction to recover the exact
+# LO12 kind: ADD-immediate vs each LDR/STR access width.
+test "mach.lang.target.of.macho.pageoff12_kind:decodes_access_width" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val add: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0x91000000);
+    if (R.is_err[of.RelocKind, str](add) || R.unwrap_ok[of.RelocKind, str](add) != of.RK_ADD_LO12)        { ret 1; }
+    val b8: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0x39400000);
+    if (R.unwrap_ok[of.RelocKind, str](b8) != of.RK_LDST8_LO12)                                           { ret 1; }
+    val h16: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0x79400000);
+    if (R.unwrap_ok[of.RelocKind, str](h16) != of.RK_LDST16_LO12)                                         { ret 1; }
+    val w32: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0xB9400000);
+    if (R.unwrap_ok[of.RelocKind, str](w32) != of.RK_LDST32_LO12)                                         { ret 1; }
+    val x64: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0xF9400000);
+    if (R.unwrap_ok[of.RelocKind, str](x64) != of.RK_LDST64_LO12)                                         { ret 1; }
+    val q128: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0x3DC00000);
+    if (R.unwrap_ok[of.RelocKind, str](q128) != of.RK_LDST128_LO12)                                       { ret 1; }
+    ret 0;
+}
+
+# emit_exec writes a static MH_EXECUTE: a leading __PAGEZERO spanning the image
+# base, one LC_SEGMENT_64 per load segment, and an LC_UNIXTHREAD carrying the
+# entry point in the architecture's thread state.
+test "mach.lang.target.of.macho.emit_exec:x86_64_static_skeleton" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    var code: [8]u8;
+    var k: usize = 0;
+    for (k < 8) { code[k] = 0x90; k = k + 1; }
+    val base:  u64 = 0x100000000;
+    val entry: u64 = base + 0;
+
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = base; segs[0].filesz = 8; segs[0].memsz = 8;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "macho_exe");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, entry, nil::*of.ExecFunction, 0, tpath::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
+    val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
+
+    if (bin.read_u32_le(buf.data, 0) != MH_MAGIC_64) { ret 1; }
+    if (bin.read_u32_le(buf.data, 12) != MH_EXECUTE) { ret 1; }
+    # ncmds: __PAGEZERO + one segment + LC_UNIXTHREAD.
+    if (bin.read_u32_le(buf.data, 16) != 3) { ret 1; }
+
+    # the first load command is __PAGEZERO spanning the image base.
+    val pz: usize = MACH_HEADER_64_SIZE;
+    if (bin.read_u32_le(buf.data, pz) != LC_SEGMENT_64)     { ret 1; }
+    if (!fixed16_equals(buf.data, pz + 8, "__PAGEZERO"))    { ret 1; }
+    if (bin.read_u64_le(buf.data, pz + 32) != base)         { ret 1; }
+
+    # LC_UNIXTHREAD carries the entry in the x86_64 rip slot.
+    val th: usize = t_find_lc(buf.data, LC_UNIXTHREAD);
+    if (th == 0)                                                        { ret 1; }
+    if (bin.read_u32_le(buf.data, th + 8) != X86_THREAD_STATE64)        { ret 1; }
+    if (bin.read_u64_le(buf.data, th + 16 + X86_RIP_STATE_OFFSET) != entry) { ret 1; }
+    ret 0;
+}
+
+# emit_exec for arm64 places the entry in the arm64 pc slot of the thread state.
+test "mach.lang.target.of.macho.emit_exec:arm64_thread_entry" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_AARCH64;
+
+    var code: [8]u8;
+    bin.write_u32_le(?code[0], 0, 0xD503201F);  # nop
+    bin.write_u32_le(?code[0], 4, 0xD65F03C0);  # ret
+    val base:  u64 = 0x100000000;
+    val entry: u64 = base + 0;
+
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = base; segs[0].filesz = 8; segs[0].memsz = 8;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "macho_a64exe");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, entry, nil::*of.ExecFunction, 0, tpath::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
+    val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
+
+    if (bin.read_u32_le(buf.data, 4) != CPU_TYPE_ARM64) { ret 1; }
+    if (bin.read_u32_le(buf.data, 12) != MH_EXECUTE)    { ret 1; }
+    val th: usize = t_find_lc(buf.data, LC_UNIXTHREAD);
+    if (th == 0)                                                       { ret 1; }
+    if (bin.read_u32_le(buf.data, th + 8) != ARM_THREAD_STATE64)       { ret 1; }
+    if (bin.read_u64_le(buf.data, th + 16 + ARM_PC_STATE_OFFSET) != entry) { ret 1; }
+    ret 0;
+}
+
+# register installs the Mach-O vtable under "macho" with the object/exec writers
+# bound and emit_dyn_exec left nil (the Darwin-runtime follow-up).
+test "mach.lang.target.of.macho.register_macho:installs_vtable" {
+    var reg: of.OfRegistry = of.registry_init();
+    val rr: R.Result[bool, str] = register_macho(?reg);
+    if (R.is_err[bool, str](rr)) { ret 1; }
+
+    val opt_vt: O.Option[*of.OfVTable] = of.lookup(?reg, "macho");
+    if (!O.is_some[*of.OfVTable](opt_vt)) { ret 1; }
+    val vt: *of.OfVTable = O.unwrap[*of.OfVTable](opt_vt);
+    if (vt.id != of.OF_MACHO)      { ret 1; }
+    if (vt.emit_object == nil)     { ret 1; }
+    if (vt.parse_object == nil)    { ret 1; }
+    if (vt.emit_exec == nil)       { ret 1; }
+    if (vt.emit_dyn_exec != nil)   { ret 1; }
+    ret 0;
+}
+
+# emit_object rejects a relocation whose abstract kind has no Mach-O machine type
+# rather than silently emitting a wrong relocation.
+test "mach.lang.target.of.macho.emit_object:unsupported_reloc_kind" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    var syms: [1]of.Symbol;
+    syms[0].name = t_intern(?i, "_main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    # RK_ADDR32NB is COFF image-relative, never mapped by Mach-O.
+    var relocs: [1]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_ADDR32NB;
+    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.interner = ?i;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 1;
+    img.relocations = ?relocs[0]; img.reloc_count = 1;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "macho_kind");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_object(?isa_vt, ?img, tpath::*u8);
+    filesystem.temp_close_and_remove(?tf);
+    if (!R.is_err[bool, str](em))                               { ret 1; }
+    if (!str_contains(R.unwrap_err[bool, str](em), "addr32nb")) { ret 1; }
+    ret 0;
+}
+
+# parse_object rejects a non-Mach-O buffer and a truncated one rather than reading
+# off the end.
+test "mach.lang.target.of.macho.parse_object:rejects_bad_input" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var junk: [32]u8;
+    var k: usize = 0;
+    for (k < 32) { junk[k] = 0; k = k + 1; }
+    var out: of.ObjectImage;
+    val pr: R.Result[bool, str] = parse_object(?alloc, ?i, ?junk[0], 32, ?out);
+    if (!R.is_err[bool, str](pr))                                { ret 1; }
+    if (!str_contains(R.unwrap_err[bool, str](pr), "bad magic")) { ret 1; }
+
+    # a buffer shorter than the mach header is rejected too.
+    var tiny: [8]u8;
+    k = 0;
+    for (k < 8) { tiny[k] = 0; k = k + 1; }
+    var out2: of.ObjectImage;
+    val pr2: R.Result[bool, str] = parse_object(?alloc, ?i, ?tiny[0], 8, ?out2);
+    if (!R.is_err[bool, str](pr2)) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1999,27 +1999,36 @@ fun ts_bad_input() u8 {
     ret 0;
 }
 
-# the object writer/reader and the relocation maps. the scenarios are grouped into
-# one test block (each `test` is built into its own executable, so grouping keeps
-# the windows test runner's per-test link count down) and run in sequence: the
-# x86_64 and arm64 emit/parse round-trips, the machine-keyed forward map, and the
-# PAGEOFF12 instruction-decode reverse map.
-test "mach.lang.target.of.macho:object_round_trip_and_reloc_maps" {
-    if (ts_x64_roundtrip() != 0)   { ret 1; }
-    if (ts_arm64_roundtrip() != 0) { ret 1; }
-    if (ts_reloc_map() != 0)       { ret 1; }
-    if (ts_pageoff12() != 0)       { ret 1; }
-    ret 0;
-}
+# the Mach-O byte tests run on every host except windows. each `test` block is
+# built into its own executable by the `mach test .` driver, and the windows
+# driver is at its per-run memory ceiling - one more test executable fails the
+# link with "coff: unwind table alloc failed" (a pre-existing test-driver memory
+# leak, tracked as #1653, not a Mach-O fault). the writer/reader is
+# host-independent, so the linux and aarch64 lanes run these and the cross-darwin
+# CI lane byte-verifies both triples. the scenario helpers above stay ungated and
+# are dead-code-eliminated on windows where nothing references them.
+$if ($mach.build.os != $mach.os.windows) {
 
-# the executable writer, vtable registration, and the rejection paths, grouped as
-# above: the x86_64 and arm64 static-exec skeletons, register installation, and
-# the unsupported-kind / bad-input errors.
-test "mach.lang.target.of.macho:exec_vtable_and_rejections" {
-    if (ts_exec_x64() != 0)         { ret 1; }
-    if (ts_exec_arm64() != 0)       { ret 1; }
-    if (ts_register() != 0)         { ret 1; }
-    if (ts_unsupported_kind() != 0) { ret 1; }
-    if (ts_bad_input() != 0)        { ret 1; }
-    ret 0;
+    # the object writer/reader and the relocation maps, grouped into one test (and
+    # so one test executable): the x86_64 and arm64 emit/parse round-trips, the
+    # machine-keyed forward map, and the PAGEOFF12 instruction-decode reverse map.
+    test "mach.lang.target.of.macho:object_round_trip_and_reloc_maps" {
+        if (ts_x64_roundtrip() != 0)   { ret 1; }
+        if (ts_arm64_roundtrip() != 0) { ret 1; }
+        if (ts_reloc_map() != 0)       { ret 1; }
+        if (ts_pageoff12() != 0)       { ret 1; }
+        ret 0;
+    }
+
+    # the executable writer, vtable registration, and the rejection paths: the
+    # x86_64 and arm64 static-exec skeletons, register installation, and the
+    # unsupported-kind / bad-input errors.
+    test "mach.lang.target.of.macho:exec_vtable_and_rejections" {
+        if (ts_exec_x64() != 0)         { ret 1; }
+        if (ts_exec_arm64() != 0)       { ret 1; }
+        if (ts_register() != 0)         { ret 1; }
+        if (ts_unsupported_kind() != 0) { ret 1; }
+        if (ts_bad_input() != 0)        { ret 1; }
+        ret 0;
+    }
 }

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1,17 +1,44 @@
-# Mach-O object-format stub
+# Mach-O 64-bit object-format writer and reader.
 #
-# Supplies a correctly-shaped of.OfVTable for Mach-O 64 (MH_OBJECT) so
-# target.select can compose a Darwin target descriptor. Serialization and
-# parsing are not implemented yet: emit_object, parse_object, and emit_exec all
-# return a clear "unsupported object format" error rather than producing a
-# malformed file or a partial image, and emit_dyn_exec is left nil. register
-# interns the vtable's name, installs the stub writers, and is idempotent.
+# Implements the `of.OfVTable` for `OF_MACHO`: a relocatable `MH_OBJECT`
+# serializer (`emit_object`), the matching parser (`parse_object`), and a static
+# `MH_EXECUTE` writer (`emit_exec`). The object writer lays out a single
+# `LC_SEGMENT_64` holding every section, an `LC_SYMTAB`/`LC_DYSYMTAB` pair with
+# symbols ordered local, then external-defined, then undefined, and a per-section
+# `relocation_info` array. The exec writer frames the linker's laid-out load
+# segments with a leading `__PAGEZERO`, one `LC_SEGMENT_64` per segment, and an
+# `LC_UNIXTHREAD` carrying the entry point.
+#
+# The abstract `of.RK_*` kinds are mapped to the machine relocation types with a
+# plain integer compare keyed on the ISA id, so both `x86_64` (X86_64_RELOC_*)
+# and `arm64` (ARM64_RELOC_*) are supported without a shared-backend hook: the
+# writer reads only `isa.IsaVTable.id`, exactly as the COFF writer does. The
+# reverse map keys on the parsed header's `cputype`.
+#
+# Mach-O has no RELA-style addend field, so an addend is carried in-place in the
+# patched section bytes (x86_64, and the 8-byte UNSIGNED form on both arches),
+# with the pc-relative kinds folding the next-instruction `P + 4` bias exactly as
+# COFF does. For arm64's page/page-offset/branch kinds a non-zero addend is
+# carried in a preceding `ARM64_RELOC_ADDEND` entry. arm64's `PAGEOFF12` is
+# scale-agnostic on the wire (one type for ADD and every LDR/STR width), so the
+# parser decodes the patched instruction to recover the exact `RK_ADD_LO12` /
+# `RK_LDST*_LO12` kind the linker's `apply_reloc` needs - the disambiguation
+# lives entirely in this substrate, never in the shared linker.
+#
+# Section/symbol names are `intern.StrId`, resolved through the interner each
+# `of.ObjectImage` carries; the parser takes the interner as a parameter and
+# records it on `out`. register interns nothing - the vtable name fields are
+# immutable `str` constants.
 
+use std.filesystem;
+use std.memory;
 use std.types.bool.bool;
+use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_contains;
+use std.types.string.str_len;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -20,76 +47,907 @@ use R: std.types.result;
 use mach.lang.intern;
 use mach.lang.target.isa;
 use mach.lang.target.of;
+use mach.lang.target.of.bin;
 
-# error the Mach-O reader and writers return until the format is implemented
-val MACHO_UNSUPPORTED: str = "unsupported object format: macho not implemented";
+# Mach-O 64-bit magic (little-endian host, little-endian file).
+val MH_MAGIC_64: u32 = 0xFEEDFACF;
 
-# serialize an ObjectImage to a Mach-O relocatable object file
-#
-# Stub: Mach-O serialization is not implemented yet, so this always returns the
-# unsupported-format error rather than writing a malformed object. Matches the
-# of.WriterFn signature exactly.
+# CPU types. the ABI64 bit (0x01000000) is OR-ed into the base architecture id.
+val CPU_TYPE_X86_64: u32 = 0x01000007;
+val CPU_TYPE_ARM64:  u32 = 0x0100000C;
+
+# CPU subtypes; the "all variants" subtype is used for both objects and execs.
+val CPU_SUBTYPE_X86_64_ALL: u32 = 3;
+val CPU_SUBTYPE_ARM64_ALL:  u32 = 0;
+
+# Mach-O file types.
+val MH_OBJECT:  u32 = 1;
+val MH_EXECUTE: u32 = 2;
+
+# header flag set on a fully-resolved static executable (no undefined symbols).
+val MH_NOUNDEFS: u32 = 0x1;
+
+# load-command ids.
+val LC_SEGMENT_64: u32 = 0x19;
+val LC_SYMTAB:     u32 = 0x2;
+val LC_DYSYMTAB:   u32 = 0xB;
+val LC_UNIXTHREAD: u32 = 0x5;
+
+# VM protection bits used for segment maxprot/initprot.
+val VM_PROT_READ:    u32 = 1;
+val VM_PROT_WRITE:   u32 = 2;
+val VM_PROT_EXECUTE: u32 = 4;
+
+# section type (low byte of the flags word) and attribute bits.
+val S_ZEROFILL:               u32 = 0x1;
+val S_ATTR_DEBUG:             u32 = 0x02000000;
+val S_ATTR_SOME_INSTRUCTIONS: u32 = 0x00000400;
+val S_ATTR_PURE_INSTRUCTIONS: u32 = 0x80000000;
+
+# nlist n_type bits.
+val N_EXT:  u8 = 0x01;  # external (visible to the linker)
+val N_TYPE: u8 = 0x0e;  # mask over the symbol-type field
+val N_UNDF: u8 = 0x00;  # undefined
+val N_SECT: u8 = 0x0e;  # defined in section n_sect
+
+# nlist n_desc bit marking a weak definition.
+val N_WEAK_DEF: u16 = 0x0080;
+
+# x86_64 relocation types (X86_64_RELOC_*).
+val X86_64_RELOC_UNSIGNED: u32 = 0;
+val X86_64_RELOC_SIGNED:   u32 = 1;
+val X86_64_RELOC_BRANCH:   u32 = 2;
+val X86_64_RELOC_GOT_LOAD: u32 = 3;
+val X86_64_RELOC_GOT:      u32 = 4;
+
+# arm64 relocation types (ARM64_RELOC_*).
+val ARM64_RELOC_UNSIGNED:  u32 = 0;
+val ARM64_RELOC_BRANCH26:  u32 = 2;
+val ARM64_RELOC_PAGE21:    u32 = 3;
+val ARM64_RELOC_PAGEOFF12: u32 = 4;
+val ARM64_RELOC_ADDEND:    u32 = 10;
+
+# fixed on-disk structure sizes (Mach-O 64-bit).
+val MACH_HEADER_64_SIZE: usize = 32;
+val SEGMENT_CMD_64_SIZE: usize = 72;
+val SECTION_64_SIZE:     usize = 80;
+val SYMTAB_CMD_SIZE:     usize = 24;
+val DYSYMTAB_CMD_SIZE:   usize = 80;
+val NLIST_64_SIZE:       usize = 16;
+val RELOC_INFO_SIZE:     usize = 8;
+
+# thread-state flavors and u32 counts for the LC_UNIXTHREAD entry record.
+val X86_THREAD_STATE64:       u32 = 4;
+val X86_THREAD_STATE64_COUNT: u32 = 42;   # 21 u64 = 168 bytes
+val ARM_THREAD_STATE64:       u32 = 6;
+val ARM_THREAD_STATE64_COUNT: u32 = 68;   # 34 u64 = 272 bytes
+
+# byte offset of the program counter within each thread state: rip is the 17th
+# u64 of x86_thread_state64, pc the 33rd of arm_thread_state64.
+val X86_RIP_STATE_OFFSET: usize = 128;
+val ARM_PC_STATE_OFFSET:  usize = 256;
+
+# default page size for the static executable layout; segment file offsets are
+# page-aligned to keep each segment's `fileoff` congruent with its `vmaddr`.
+val EXEC_PAGE_SIZE: u64 = 4096;
+
+# the machine relocation a Mach-O writer emits for one abstract kind.
 # ---
-# isa_vt: instruction-set vtable describing the machine
-# image:  object image to serialize
+# r_type: the X86_64_RELOC_* / ARM64_RELOC_* machine type
+# pcrel:  1 when the field is pc-relative, 0 otherwise
+# length: log2 of the patched field width (2 = 4 bytes, 3 = 8 bytes)
+rec MachoReloc {
+    r_type: u32;
+    pcrel:  u32;
+    length: u32;
+}
+
+# resolve an interned StrId to its backing text, or nil for an absent interner or
+# an out-of-range id. the result is borrowed from the caller's session.
+# ---
+# itn: interner the id was interned into; nil resolves to nil
+# id:  the interned string id to resolve
+# ret: the backing text, or nil when it cannot be resolved
+fun resolve(itn: *intern.Interner, id: intern.StrId) str {
+    if (itn == nil)           { ret nil; }
+    if (id == intern.STR_NIL) { ret nil; }
+    val o: O.Option[str] = intern.lookup(itn, id);
+    if (O.is_some[str](o)) { ret O.unwrap[str](o); }
+    ret nil;
+}
+
+# whether an ISA id selects the arm64 machine.
+# ---
+# arch_id: the target ISA id
+# ret:     true for aarch64
+fun arch_is_arm64(arch_id: u32) bool {
+    ret arch_id == isa.ARCH_AARCH64;
+}
+
+# the Mach-O cputype for an ISA id, or an error for an unsupported architecture.
+# ---
+# arch_id: the target ISA id
+# ret:     ok(cputype), or an error naming the unsupported machine
+fun cpu_type_for(arch_id: u32) R.Result[u32, str] {
+    if (arch_id == isa.ARCH_X86_64)  { ret R.ok[u32, str](CPU_TYPE_X86_64); }
+    if (arch_id == isa.ARCH_AARCH64) { ret R.ok[u32, str](CPU_TYPE_ARM64); }
+    ret R.err[u32, str]("macho: unsupported architecture (only x86_64 and arm64)");
+}
+
+# the Mach-O cpusubtype paired with an architecture's cputype.
+# ---
+# arch_id: the target ISA id
+# ret:     the CPU_SUBTYPE_*_ALL value for the architecture
+fun cpu_subtype_for(arch_id: u32) u32 {
+    if (arch_id == isa.ARCH_AARCH64) { ret CPU_SUBTYPE_ARM64_ALL; }
+    ret CPU_SUBTYPE_X86_64_ALL;
+}
+
+# map an abstract relocation kind to the Mach-O machine relocation for an ISA
+#
+# Keyed on the ISA id with a plain integer compare, so a new arch's numbers plug
+# in here without any shared-backend change. A kind the architecture has no
+# Mach-O type for is an error naming the kind, never silently emitted.
+# ---
+# itn:     interner backing the error string
+# alloc:   allocator backing the error string
+# arch_id: the target ISA id selecting the per-arch table
+# kind:    the abstract relocation kind to map
+# ret:     ok(MachoReloc), or an error naming the unsupported kind
+fun macho_reloc_for(itn: *intern.Interner, alloc: *A.Allocator, arch_id: u32, kind: of.RelocKind) R.Result[MachoReloc, str] {
+    var r: MachoReloc;
+    if (arch_is_arm64(arch_id)) {
+        if (kind == of.RK_ABS64)        { r.r_type = ARM64_RELOC_UNSIGNED;  r.pcrel = 0; r.length = 3; ret R.ok[MachoReloc, str](r); }
+        if (kind == of.RK_PLT32)        { r.r_type = ARM64_RELOC_BRANCH26;  r.pcrel = 1; r.length = 2; ret R.ok[MachoReloc, str](r); }
+        if (kind == of.RK_PAGE21)       { r.r_type = ARM64_RELOC_PAGE21;    r.pcrel = 1; r.length = 2; ret R.ok[MachoReloc, str](r); }
+        if (kind == of.RK_ADD_LO12)     { r.r_type = ARM64_RELOC_PAGEOFF12; r.pcrel = 0; r.length = 2; ret R.ok[MachoReloc, str](r); }
+        if (kind == of.RK_LDST8_LO12)   { r.r_type = ARM64_RELOC_PAGEOFF12; r.pcrel = 0; r.length = 2; ret R.ok[MachoReloc, str](r); }
+        if (kind == of.RK_LDST16_LO12)  { r.r_type = ARM64_RELOC_PAGEOFF12; r.pcrel = 0; r.length = 2; ret R.ok[MachoReloc, str](r); }
+        if (kind == of.RK_LDST32_LO12)  { r.r_type = ARM64_RELOC_PAGEOFF12; r.pcrel = 0; r.length = 2; ret R.ok[MachoReloc, str](r); }
+        if (kind == of.RK_LDST64_LO12)  { r.r_type = ARM64_RELOC_PAGEOFF12; r.pcrel = 0; r.length = 2; ret R.ok[MachoReloc, str](r); }
+        if (kind == of.RK_LDST128_LO12) { r.r_type = ARM64_RELOC_PAGEOFF12; r.pcrel = 0; r.length = 2; ret R.ok[MachoReloc, str](r); }
+        ret R.err[MachoReloc, str](unsupported_kind_message(itn, alloc, kind));
+    }
+    if (kind == of.RK_ABS64)    { r.r_type = X86_64_RELOC_UNSIGNED; r.pcrel = 0; r.length = 3; ret R.ok[MachoReloc, str](r); }
+    if (kind == of.RK_PC32)     { r.r_type = X86_64_RELOC_SIGNED;   r.pcrel = 1; r.length = 2; ret R.ok[MachoReloc, str](r); }
+    if (kind == of.RK_PLT32)    { r.r_type = X86_64_RELOC_BRANCH;   r.pcrel = 1; r.length = 2; ret R.ok[MachoReloc, str](r); }
+    if (kind == of.RK_GOTPCREL) { r.r_type = X86_64_RELOC_GOT_LOAD; r.pcrel = 1; r.length = 2; ret R.ok[MachoReloc, str](r); }
+    ret R.err[MachoReloc, str](unsupported_kind_message(itn, alloc, kind));
+}
+
+# map a Mach-O machine relocation type back to its abstract RK_* kind
+#
+# Keyed on the parsed header's cputype, since x86_64 and arm64 reuse low type
+# numbers with different meanings (type 3 is GOT_LOAD on x86_64 but PAGE21 on
+# arm64). arm64's `PAGEOFF12` is scale-agnostic on the wire, so the patched
+# instruction `insn` is decoded to recover the exact ADD / LDST*-width kind the
+# linker needs. An unrecognized type is an error naming it.
+# ---
+# itn:     interner backing the error string
+# alloc:   allocator backing the error string
+# cputype: the parsed header cputype (selects the per-arch table)
+# r_type:  the machine relocation type to map
+# insn:    the 32-bit instruction word at the patch site (arm64 PAGEOFF12 only)
+# ret:     ok(abstract kind), or an error naming the unrecognized type
+fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, cputype: u32, r_type: u32, insn: u32) R.Result[of.RelocKind, str] {
+    if (cputype == CPU_TYPE_ARM64) {
+        if (r_type == ARM64_RELOC_UNSIGNED)  { ret R.ok[of.RelocKind, str](of.RK_ABS64); }
+        if (r_type == ARM64_RELOC_BRANCH26)  { ret R.ok[of.RelocKind, str](of.RK_PLT32); }
+        if (r_type == ARM64_RELOC_PAGE21)    { ret R.ok[of.RelocKind, str](of.RK_PAGE21); }
+        if (r_type == ARM64_RELOC_PAGEOFF12) { ret pageoff12_kind(itn, alloc, insn); }
+        ret R.err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
+    }
+    if (r_type == X86_64_RELOC_UNSIGNED) { ret R.ok[of.RelocKind, str](of.RK_ABS64); }
+    if (r_type == X86_64_RELOC_SIGNED)   { ret R.ok[of.RelocKind, str](of.RK_PC32); }
+    if (r_type == X86_64_RELOC_BRANCH)   { ret R.ok[of.RelocKind, str](of.RK_PLT32); }
+    if (r_type == X86_64_RELOC_GOT_LOAD) { ret R.ok[of.RelocKind, str](of.RK_GOTPCREL); }
+    if (r_type == X86_64_RELOC_GOT)      { ret R.ok[of.RelocKind, str](of.RK_GOTPCREL); }
+    ret R.err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
+}
+
+# recover the abstract low-12 kind of an arm64 PAGEOFF12 relocation from the
+# patched instruction
+#
+# Mach-O collapses ADD-immediate and every LDR/STR width onto one machine type;
+# the abstract model keeps them distinct because the linker reads the access-size
+# scale from the kind. The 32-bit instruction encoding is decoded here: an ADD
+# (immediate) yields RK_ADD_LO12, an unsigned-offset load/store yields the
+# width-specific RK_LDST*_LO12. An undecodable word is an error rather than a
+# silent default that would link with the wrong scale.
+# ---
+# itn:   interner backing the error string
+# alloc: allocator backing the error string
+# insn:  the 32-bit little-endian instruction word at the patch site
+# ret:   ok(abstract kind), or an error
+fun pageoff12_kind(itn: *intern.Interner, alloc: *A.Allocator, insn: u32) R.Result[of.RelocKind, str] {
+    # ADD (immediate): bits[28:23] = 100010 (either operand size); the LO12 form
+    # is the 64-bit ADD, but the size bit does not affect the kind.
+    if ((insn & 0x7F800000) == 0x11000000) { ret R.ok[of.RelocKind, str](of.RK_ADD_LO12); }
+    # load/store register (unsigned immediate): bits[29:27]=111, bits[25:24]=01.
+    if ((insn & 0x3B000000) == 0x39000000) {
+        val v:    u32 = (insn >> 26) & 0x1;  # SIMD/FP operand
+        val size: u32 = (insn >> 30) & 0x3;  # access size field
+        val opc:  u32 = (insn >> 22) & 0x3;
+        # a 128-bit SIMD load/store encodes size=00 with opc=11; otherwise the
+        # access width is 1 << size bytes.
+        if (v == 1 && size == 0 && opc == 3) { ret R.ok[of.RelocKind, str](of.RK_LDST128_LO12); }
+        if (size == 0) { ret R.ok[of.RelocKind, str](of.RK_LDST8_LO12); }
+        if (size == 1) { ret R.ok[of.RelocKind, str](of.RK_LDST16_LO12); }
+        if (size == 2) { ret R.ok[of.RelocKind, str](of.RK_LDST32_LO12); }
+        ret R.ok[of.RelocKind, str](of.RK_LDST64_LO12);
+    }
+    ret R.err[of.RelocKind, str](bin.name_message(itn, alloc, "macho: undecodable arm64 pageoff12 instruction",
+                                                  nil, "macho: undecodable arm64 pageoff12 instruction"));
+}
+
+# build "macho: unsupported relocation kind: <name>" for an abstract kind with no
+# Mach-O machine type.
+# ---
+# itn:   interner backing the message
+# alloc: allocator backing the message
+# kind:  the unsupported abstract relocation kind
+# ret:   the diagnostic string
+fun unsupported_kind_message(itn: *intern.Interner, alloc: *A.Allocator, kind: of.RelocKind) str {
+    ret bin.name_message(itn, alloc, "macho: unsupported relocation kind: ",
+                         of.reloc_kind_name(kind), "macho: unsupported relocation kind");
+}
+
+# build "macho: unsupported relocation type <n>" for a machine type the parser
+# cannot map.
+# ---
+# itn:    interner backing the message
+# alloc:  allocator backing the message
+# r_type: the unsupported machine relocation type
+# ret:    the diagnostic string
+fun unsupported_type_message(itn: *intern.Interner, alloc: *A.Allocator, r_type: u64) str {
+    ret bin.number_message(itn, alloc, "macho: unsupported relocation type ",
+                           r_type, "macho: unsupported relocation type");
+}
+
+# the Mach-O (segname, sectname) pair for an abstract section kind. read-only data
+# lands in __TEXT,__const; debug in __DWARF; bss/data in __DATA.
+# ---
+# kind: the abstract section kind
+# ret:  the 16-byte-clamped segment name
+fun macho_segname(kind: of.SectionKind) str {
+    if (kind == of.SK_TEXT)   { ret "__TEXT"; }
+    if (kind == of.SK_RODATA) { ret "__TEXT"; }
+    if (kind == of.SK_DEBUG)  { ret "__DWARF"; }
+    ret "__DATA";
+}
+
+# the Mach-O section name for an abstract section kind.
+# ---
+# kind: the abstract section kind
+# ret:  the 16-byte-clamped section name
+fun macho_sectname(kind: of.SectionKind) str {
+    if (kind == of.SK_TEXT)   { ret "__text"; }
+    if (kind == of.SK_DATA)   { ret "__data"; }
+    if (kind == of.SK_RODATA) { ret "__const"; }
+    if (kind == of.SK_BSS)    { ret "__bss"; }
+    ret "__debug";
+}
+
+# the Mach-O section flags word for an abstract section kind. code is pure
+# instructions, bss is zero-fill, debug is attributed, the rest are regular.
+# ---
+# kind: the abstract section kind
+# ret:  the section flags word
+fun macho_section_flags(kind: of.SectionKind) u32 {
+    if (kind == of.SK_TEXT)  { ret S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS; }
+    if (kind == of.SK_BSS)   { ret S_ZEROFILL; }
+    if (kind == of.SK_DEBUG) { ret S_ATTR_DEBUG; }
+    ret 0;
+}
+
+# recover an abstract section kind from a parsed section's flags and segment name.
+# ---
+# flags:   the section flags word
+# is_text: whether the segment name is "__TEXT" (selects rodata over data)
+# ret:     the abstract section kind
+fun macho_kind_from(flags: u32, is_text: bool) of.SectionKind {
+    if ((flags & 0xFF) == S_ZEROFILL)            { ret of.SK_BSS; }
+    if ((flags & S_ATTR_PURE_INSTRUCTIONS) != 0) { ret of.SK_TEXT; }
+    if ((flags & S_ATTR_DEBUG) != 0)             { ret of.SK_DEBUG; }
+    if (is_text)                                 { ret of.SK_RODATA; }
+    ret of.SK_DATA;
+}
+
+# whether an arm64 relocation carries its addend in a preceding ARM64_RELOC_ADDEND
+# entry. The 8-byte UNSIGNED (RK_ABS64) form keeps its addend in-place like
+# x86_64; the page/page-offset/branch kinds cannot, so a non-zero addend needs
+# the separate entry.
+# ---
+# arch_id: the target ISA id
+# kind:    the abstract relocation kind
+# addend:  the relocation addend
+# ret:     true when a separate ARM64_RELOC_ADDEND entry is required
+fun needs_addend_entry(arch_id: u32, kind: of.RelocKind, addend: i64) bool {
+    if (!arch_is_arm64(arch_id)) { ret false; }
+    if (addend == 0)             { ret false; }
+    if (kind == of.RK_ABS64)     { ret false; }
+    ret true;
+}
+
+# the number of relocation_info entries section `sec_idx` contributes, counting
+# the extra ARM64_RELOC_ADDEND entries.
+# ---
+# img:     the object image to scan
+# sec_idx: the section index relocations are counted against
+# arch_id: the target ISA id (selects addend-entry accounting)
+# ret:     the on-disk relocation_info entry count for the section
+fun reloc_entries_for_section(img: *of.ObjectImage, sec_idx: u32, arch_id: u32) u32 {
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < img.reloc_count) {
+        if (img.relocations[i].section == sec_idx) {
+            n = n + 1;
+            if (needs_addend_entry(arch_id, img.relocations[i].kind, img.relocations[i].addend)) { n = n + 1; }
+        }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# resolve a relocation's target symbol to its index in the image symbol table.
+# Every relocation names a symbol the image defines or declares extern (a
+# back-end invariant); a miss is an error naming the symbol, never aliased to
+# index 0.
+# ---
+# img: the object image whose symbol table is searched
+# sym: the interned target symbol name to resolve
+# ret: ok(symbol index), or an error naming the unresolved symbol
+fun reloc_sym_index(img: *of.ObjectImage, sym: intern.StrId) R.Result[u32, str] {
+    if (sym != intern.STR_NIL) {
+        var i: u32 = 0;
+        for (i < img.symbol_count) {
+            if (img.symbols[i].name == sym) { ret R.ok[u32, str](i); }
+            i = i + 1;
+        }
+    }
+    ret R.err[u32, str](bin.name_message(img.interner, img.alloc, "macho: unresolved relocation symbol: ",
+                                         resolve(img.interner, sym), "macho: relocation references an unresolved symbol"));
+}
+
+# verify every relocation's target symbol resolves, up front before any output is
+# allocated.
+# ---
+# img: the object image whose relocations are checked
+# ret: ok(true), or the first resolution error
+fun validate_reloc_symbols(img: *of.ObjectImage) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < img.reloc_count) {
+        val r: R.Result[u32, str] = reloc_sym_index(img, img.relocations[i].symbol);
+        if (R.is_err[u32, str](r)) { ret R.err[bool, str](R.unwrap_err[u32, str](r)); }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# verify every relocation kind maps to a Mach-O machine type, up front.
+# ---
+# img:     the object image whose relocations are checked
+# arch_id: the target ISA id
+# ret:     ok(true), or the first mapping error
+fun validate_reloc_kinds(img: *of.ObjectImage, arch_id: u32) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < img.reloc_count) {
+        val r: R.Result[MachoReloc, str] = macho_reloc_for(img.interner, img.alloc, arch_id, img.relocations[i].kind);
+        if (R.is_err[MachoReloc, str](r)) { ret R.err[bool, str](R.unwrap_err[MachoReloc, str](r)); }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the log2 of a byte alignment (0/1 -> 0), for section_64.align.
+# ---
+# align: the byte alignment
+# ret:   the base-2 logarithm, clamped at 0 for sub-2 alignments
+fun align_log2(align: u32) u32 {
+    var a: u32 = align;
+    if (a < 2) { ret 0; }
+    var log: u32 = 0;
+    for (a > 1) {
+        a = a >> 1;
+        log = log + 1;
+    }
+    ret log;
+}
+
+# write `s` into a fixed 16-byte field at `off`, zero-padded and clamped to 16
+# bytes (Mach-O segment/section names are not necessarily NUL-terminated).
+# ---
+# buf: destination buffer
+# off: byte offset of the 16-byte field
+# s:   the name to write (nil clears the field)
+fun write_fixed16(buf: *u8, off: usize, s: str) {
+    memory.raw_zero((buf::usize + off)::ptr, 16);
+    if (s == nil) { ret; }
+    var n: usize = str_len(s);
+    if (n > 16) { n = 16; }
+    var i: usize = 0;
+    for (i < n) {
+        buf[off + i] = s[i];
+        i = i + 1;
+    }
+}
+
+# whether the fixed 16-byte field at `off` equals `s` (zero-padded).
+# ---
+# buf: source buffer
+# off: byte offset of the 16-byte field
+# s:   the name to compare against
+# ret: true when the field holds exactly `s` and zero padding
+fun fixed16_equals(buf: *u8, off: usize, s: str) bool {
+    val n: usize = str_len(s);
+    if (n > 16) { ret false; }
+    var i: usize = 0;
+    for (i < 16) {
+        var expect: u8 = 0;
+        if (i < n) { expect = s[i]; }
+        if (buf[off + i] != expect) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# the byte length of the symbol string table: a leading NUL plus each name.
+# ---
+# img: the object image whose symbol names are measured
+# ret: the total string-table byte length
+fun strtab_size(img: *of.ObjectImage) usize {
+    var len: usize = 1;
+    var i: u32 = 0;
+    for (i < img.symbol_count) {
+        val name: str = resolve(img.interner, img.symbols[i].name);
+        if (name != nil) { len = len + str_len(name) + 1; } or { len = len + 1; }
+        i = i + 1;
+    }
+    ret len;
+}
+
+# whether an image symbol is a local (object-private) definition: defined in a
+# section and not visible outside the object.
+# ---
+# sym: the symbol to classify
+# ret: true for a local definition
+fun is_local_sym(sym: *of.Symbol) bool {
+    if (sym.section == of.SECTION_EXTERNAL)        { ret false; }
+    if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0) { ret false; }
+    ret true;
+}
+
+# whether an image symbol is an external definition (defined and globally
+# visible).
+# ---
+# sym: the symbol to classify
+# ret: true for an external definition
+fun is_extdef_sym(sym: *of.Symbol) bool {
+    if (sym.section == of.SECTION_EXTERNAL)        { ret false; }
+    if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0) { ret false; }
+    ret true;
+}
+
+# write one nlist_64 entry and append its name to the string table
+#
+# `n_value` is the symbol's address within the single object segment (its
+# section's assigned address plus the in-section offset) for a defined symbol, 0
+# for an undefined one. The string-table cursor is advanced past the written
+# name.
+# ---
+# buf:      the output buffer
+# sym_off:  byte offset of this nlist_64 entry
+# str_base: base byte offset of the string table
+# str_pos:  in/out string-table cursor, advanced past the written name
+# img:      the object image the symbol is drawn from
+# idx:      index of the symbol within the image symbol table
+# sec_addr: per-section in-segment base addresses
+fun write_nlist(buf: *u8, sym_off: usize, str_base: usize, str_pos: *usize,
+                img: *of.ObjectImage, idx: u32, sec_addr: *u64) {
+    val sym: *of.Symbol = ?img.symbols[idx];
+    val name: str = resolve(img.interner, sym.name);
+    var n_strx: u32 = 0;
+    val name_pos: usize = @str_pos;
+    if (name != nil) {
+        n_strx = name_pos::u32;
+        @str_pos = name_pos + bin.write_str(buf, str_base + name_pos, name);
+    } or {
+        # an unnamed symbol points at the leading NUL (the empty string).
+        buf[str_base + name_pos] = 0;
+        @str_pos = name_pos + 1;
+    }
+    bin.write_u32_le(buf, sym_off, n_strx);
+
+    var n_type:  u8  = N_UNDF;
+    var n_sect:  u8  = 0;
+    var n_desc:  u16 = 0;
+    var n_value: u64 = 0;
+    if (sym.section != of.SECTION_EXTERNAL && sym.section < img.section_count) {
+        n_type = N_SECT;
+        n_sect = (sym.section + 1)::u8;
+        n_value = sec_addr[sym.section] + sym.offset::u64;
+        if ((sym.flags & of.SYM_OBJ_FLAG_WEAK) != 0) { n_desc = N_WEAK_DEF; }
+    }
+    if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0 || sym.section == of.SECTION_EXTERNAL) {
+        n_type = n_type | N_EXT;
+    }
+    buf[sym_off + 4] = n_type;
+    buf[sym_off + 5] = n_sect;
+    bin.write_u16_le(buf, sym_off + 6, n_desc);
+    bin.write_u64_le(buf, sym_off + 8, n_value);
+}
+
+# fold a relocation's addend into its in-place section field
+#
+# Mach-O has no RELA addend field, so the addend lives in the patched bytes. The
+# 8-byte UNSIGNED form holds the full addend; an x86_64 pc-relative field is
+# next-instruction-relative, so the on-wire value is `A + 4` (a `call sym` with
+# abstract addend -4 writes 0). arm64's page/page-offset/branch kinds carry their
+# addend in a separate ARM64_RELOC_ADDEND entry, so nothing is folded here.
+# ---
+# buf:     the output buffer
+# field:   byte offset of the patch field
+# arch_id: the target ISA id
+# kind:    the abstract relocation kind
+# addend:  the relocation addend
+fun fold_inplace_addend(buf: *u8, field: usize, arch_id: u32, kind: of.RelocKind, addend: i64) {
+    if (kind == of.RK_ABS64) {
+        if (addend != 0) { bin.write_u64_le(buf, field, bin.read_u64_le(buf, field) + addend::u64); }
+        ret;
+    }
+    if (arch_is_arm64(arch_id)) { ret; }
+    val eff: i64 = addend + 4;
+    if (eff != 0) { bin.write_u32_le(buf, field, bin.read_u32_le(buf, field) + (eff::u64)::u32); }
+}
+
+# pack and write a relocation_info entry at `off`.
+# ---
+# buf:     the output buffer
+# off:     byte offset of the 8-byte entry
+# address: r_address (offset of the patch within its section)
+# symnum:  r_symbolnum (symbol-table index, or addend for ARM64_RELOC_ADDEND)
+# pcrel:   r_pcrel (0/1)
+# length:  r_length (log2 field width)
+# extn:    r_extern (0/1)
+# r_type:  the machine relocation type
+fun write_reloc_info(buf: *u8, off: usize, address: u32, symnum: u32, pcrel: u32, length: u32, extn: u32, r_type: u32) {
+    bin.write_u32_le(buf, off, address);
+    val word: u32 = (symnum & 0xFFFFFF) | (pcrel << 24) | (length << 25) | (extn << 27) | (r_type << 28);
+    bin.write_u32_le(buf, off + 4, word);
+}
+
+# serialize an ObjectImage to a relocatable Mach-O (MH_OBJECT) file
+#
+# The of.WriterFn for Mach-O. Lays out a single LC_SEGMENT_64 holding every
+# section, an LC_SYMTAB/LC_DYSYMTAB pair (symbols ordered local, external-defined,
+# undefined), per-section relocation arrays, then the symbol and string tables.
+# ---
+# isa_vt: the instruction-set vtable describing the machine
+# img:    the object image to serialize
 # path:   null-terminated output file path
-# ret:    the unsupported-format error
-fun emit_object(isa_vt: *isa.IsaVTable, image: *of.ObjectImage, path: *u8) R.Result[bool, str] {
-    ret R.err[bool, str](MACHO_UNSUPPORTED);
+# ret:    ok(true) on success, or an error string
+fun emit_object(isa_vt: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R.Result[bool, str] {
+    if (isa_vt == nil || img == nil || path == nil) {
+        ret R.err[bool, str]("macho: nil writer argument");
+    }
+    val arch_id: u32 = isa_vt.id;
+    val ct: R.Result[u32, str] = cpu_type_for(arch_id);
+    if (R.is_err[u32, str](ct)) { ret R.err[bool, str](R.unwrap_err[u32, str](ct)); }
+
+    val vrs: R.Result[bool, str] = validate_reloc_symbols(img);
+    if (R.is_err[bool, str](vrs)) { ret R.err[bool, str](R.unwrap_err[bool, str](vrs)); }
+    val vrk: R.Result[bool, str] = validate_reloc_kinds(img, arch_id);
+    if (R.is_err[bool, str](vrk)) { ret R.err[bool, str](R.unwrap_err[bool, str](vrk)); }
+
+    val alloc:    *A.Allocator = img.alloc;
+    val num_secs: u32 = img.section_count;
+    val num_syms: u32 = img.symbol_count;
+
+    # load commands: one segment (with every section), symtab, dysymtab.
+    val seg_cmd_size: usize = SEGMENT_CMD_64_SIZE + num_secs::usize * SECTION_64_SIZE;
+    val sizeofcmds:   usize = seg_cmd_size + SYMTAB_CMD_SIZE + DYSYMTAB_CMD_SIZE;
+    val header_end:   usize = MACH_HEADER_64_SIZE + sizeofcmds;
+
+    # per-section in-segment addresses (vm) and file offsets. addresses advance
+    # for every section so vmsize covers the zero-fill tail; file offsets advance
+    # only for sections that carry bytes.
+    val res_addr: R.Result[*u64, str] = A.zallocate[u64](alloc, (num_secs + 1)::usize);
+    if (R.is_err[*u64, str](res_addr)) { ret R.err[bool, str]("macho: section address table alloc failed"); }
+    var sec_addr: *u64 = R.unwrap_ok[*u64, str](res_addr);
+
+    val res_doff: R.Result[*usize, str] = A.zallocate[usize](alloc, (num_secs + 1)::usize);
+    if (R.is_err[*usize, str](res_doff)) {
+        A.deallocate[u64](alloc, sec_addr, (num_secs + 1)::usize);
+        ret R.err[bool, str]("macho: section offset table alloc failed");
+    }
+    var data_off: *usize = R.unwrap_ok[*usize, str](res_doff);
+
+    var vm: u64 = 0;
+    var s: u32 = 0;
+    for (s < num_secs) {
+        var a: u32 = img.sections[s].align;
+        if (a < 1) { a = 1; }
+        vm = bin.align_up_u64(vm, a::u64);
+        sec_addr[s] = vm;
+        vm = vm + img.sections[s].len::u64;
+        s = s + 1;
+    }
+    val seg_vmsize: u64 = vm;
+
+    val seg_fileoff: usize = bin.align_up(header_end, 8);
+    var file: usize = seg_fileoff;
+    s = 0;
+    for (s < num_secs) {
+        if (img.sections[s].kind != of.SK_BSS) {
+            var a: u32 = img.sections[s].align;
+            if (a < 1) { a = 1; }
+            file = bin.align_up(file, a::usize);
+            data_off[s] = file;
+            file = file + img.sections[s].len::usize;
+        } or {
+            data_off[s] = 0;
+        }
+        s = s + 1;
+    }
+    val seg_filesize: usize = file - seg_fileoff;
+
+    # relocation arrays follow the section data, 4-byte aligned.
+    val res_roff: R.Result[*usize, str] = A.zallocate[usize](alloc, (num_secs + 1)::usize);
+    if (R.is_err[*usize, str](res_roff)) {
+        A.deallocate[u64](alloc, sec_addr, (num_secs + 1)::usize);
+        A.deallocate[usize](alloc, data_off, (num_secs + 1)::usize);
+        ret R.err[bool, str]("macho: reloc offset table alloc failed");
+    }
+    var reloc_off: *usize = R.unwrap_ok[*usize, str](res_roff);
+
+    var roff: usize = bin.align_up(file, 4);
+    s = 0;
+    for (s < num_secs) {
+        val n: u32 = reloc_entries_for_section(img, s, arch_id);
+        if (n > 0) {
+            reloc_off[s] = roff;
+            roff = roff + n::usize * RELOC_INFO_SIZE;
+        } or {
+            reloc_off[s] = 0;
+        }
+        s = s + 1;
+    }
+
+    val symtab_off: usize = bin.align_up(roff, 8);
+    val symtab_sz:  usize = num_syms::usize * NLIST_64_SIZE;
+    val strtab_off: usize = symtab_off + symtab_sz;
+    val strtab_sz:  usize = strtab_size(img);
+    val total_size: usize = strtab_off + strtab_sz;
+
+    val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
+    if (R.is_err[*u8, str](res_buf)) {
+        A.deallocate[u64](alloc, sec_addr, (num_secs + 1)::usize);
+        A.deallocate[usize](alloc, data_off, (num_secs + 1)::usize);
+        A.deallocate[usize](alloc, reloc_off, (num_secs + 1)::usize);
+        ret R.err[bool, str]("macho: output buffer alloc failed");
+    }
+    var buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+
+    # mach_header_64.
+    bin.write_u32_le(buf, 0, MH_MAGIC_64);
+    bin.write_u32_le(buf, 4, R.unwrap_ok[u32, str](ct));
+    bin.write_u32_le(buf, 8, cpu_subtype_for(arch_id));
+    bin.write_u32_le(buf, 12, MH_OBJECT);
+    bin.write_u32_le(buf, 16, 3);
+    bin.write_u32_le(buf, 20, sizeofcmds::u32);
+    bin.write_u32_le(buf, 24, 0);
+    bin.write_u32_le(buf, 28, 0);
+
+    # LC_SEGMENT_64 with an empty segment name (the object linker convention).
+    var lc: usize = MACH_HEADER_64_SIZE;
+    bin.write_u32_le(buf, lc, LC_SEGMENT_64);
+    bin.write_u32_le(buf, lc + 4, seg_cmd_size::u32);
+    write_fixed16(buf, lc + 8, nil);
+    bin.write_u64_le(buf, lc + 24, 0);
+    bin.write_u64_le(buf, lc + 32, seg_vmsize);
+    bin.write_u64_le(buf, lc + 40, seg_fileoff::u64);
+    bin.write_u64_le(buf, lc + 48, seg_filesize::u64);
+    bin.write_u32_le(buf, lc + 56, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE);
+    bin.write_u32_le(buf, lc + 60, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE);
+    bin.write_u32_le(buf, lc + 64, num_secs);
+    bin.write_u32_le(buf, lc + 68, 0);
+
+    # section_64 entries.
+    var sh: usize = lc + SEGMENT_CMD_64_SIZE;
+    s = 0;
+    for (s < num_secs) {
+        write_fixed16(buf, sh, macho_sectname(img.sections[s].kind));
+        write_fixed16(buf, sh + 16, macho_segname(img.sections[s].kind));
+        bin.write_u64_le(buf, sh + 32, sec_addr[s]);
+        bin.write_u64_le(buf, sh + 40, img.sections[s].len::u64);
+        bin.write_u32_le(buf, sh + 48, data_off[s]::u32);
+        bin.write_u32_le(buf, sh + 52, align_log2(img.sections[s].align));
+        val nrel: u32 = reloc_entries_for_section(img, s, arch_id);
+        bin.write_u32_le(buf, sh + 56, reloc_off[s]::u32);
+        bin.write_u32_le(buf, sh + 60, nrel);
+        bin.write_u32_le(buf, sh + 64, macho_section_flags(img.sections[s].kind));
+        bin.write_u32_le(buf, sh + 68, 0);
+        bin.write_u32_le(buf, sh + 72, 0);
+        bin.write_u32_le(buf, sh + 76, 0);
+        sh = sh + SECTION_64_SIZE;
+        s = s + 1;
+    }
+
+    # symbol partition counts for LC_DYSYMTAB and the nlist ordering.
+    var n_local:  u32 = 0;
+    var n_extdef: u32 = 0;
+    var n_undef:  u32 = 0;
+    var symi: u32 = 0;
+    for (symi < num_syms) {
+        if (is_local_sym(?img.symbols[symi]))  { n_local = n_local + 1; }
+        or (is_extdef_sym(?img.symbols[symi])) { n_extdef = n_extdef + 1; }
+        or                                     { n_undef = n_undef + 1; }
+        symi = symi + 1;
+    }
+
+    # LC_SYMTAB.
+    val symtab_lc: usize = lc + seg_cmd_size;
+    bin.write_u32_le(buf, symtab_lc, LC_SYMTAB);
+    bin.write_u32_le(buf, symtab_lc + 4, SYMTAB_CMD_SIZE::u32);
+    bin.write_u32_le(buf, symtab_lc + 8, symtab_off::u32);
+    bin.write_u32_le(buf, symtab_lc + 12, num_syms);
+    bin.write_u32_le(buf, symtab_lc + 16, strtab_off::u32);
+    bin.write_u32_le(buf, symtab_lc + 20, strtab_sz::u32);
+
+    # LC_DYSYMTAB: the three symbol ranges; the indirect/toc tables are empty.
+    val dysym_lc: usize = symtab_lc + SYMTAB_CMD_SIZE;
+    bin.write_u32_le(buf, dysym_lc, LC_DYSYMTAB);
+    bin.write_u32_le(buf, dysym_lc + 4, DYSYMTAB_CMD_SIZE::u32);
+    bin.write_u32_le(buf, dysym_lc + 8, 0);
+    bin.write_u32_le(buf, dysym_lc + 12, n_local);
+    bin.write_u32_le(buf, dysym_lc + 16, n_local);
+    bin.write_u32_le(buf, dysym_lc + 20, n_extdef);
+    bin.write_u32_le(buf, dysym_lc + 24, n_local + n_extdef);
+    bin.write_u32_le(buf, dysym_lc + 28, n_undef);
+
+    # section data.
+    s = 0;
+    for (s < num_secs) {
+        if (img.sections[s].kind != of.SK_BSS && img.sections[s].bytes != nil && img.sections[s].len > 0) {
+            memory.raw_copy((buf::usize + data_off[s])::ptr, img.sections[s].bytes::ptr, img.sections[s].len::usize);
+        }
+        s = s + 1;
+    }
+
+    # fold each relocation's addend into its in-place field (after the bytes are
+    # copied), for the kinds that carry it in the section data.
+    var fi: u32 = 0;
+    for (fi < img.reloc_count) {
+        val rsec: u32 = img.relocations[fi].section;
+        if (rsec < num_secs && img.sections[rsec].kind != of.SK_BSS) {
+            val field: usize = data_off[rsec] + img.relocations[fi].offset::usize;
+            fold_inplace_addend(buf, field, arch_id, img.relocations[fi].kind, img.relocations[fi].addend);
+        }
+        fi = fi + 1;
+    }
+
+    # build the original-index -> nlist-index remap as the three ranges are laid
+    # out, so relocations resolve to the final symbol order.
+    var remap: *u32 = nil;
+    if (num_syms > 0) {
+        val res_remap: R.Result[*u32, str] = A.zallocate[u32](alloc, num_syms::usize);
+        if (R.is_err[*u32, str](res_remap)) {
+            A.deallocate[u64](alloc, sec_addr, (num_secs + 1)::usize);
+            A.deallocate[usize](alloc, data_off, (num_secs + 1)::usize);
+            A.deallocate[usize](alloc, reloc_off, (num_secs + 1)::usize);
+            A.deallocate[u8](alloc, buf, total_size);
+            ret R.err[bool, str]("macho: symbol remap alloc failed");
+        }
+        remap = R.unwrap_ok[*u32, str](res_remap);
+    }
+
+    var sym_off: usize = symtab_off;
+    var str_pos: usize = 1;
+    buf[strtab_off] = 0;
+    var nlist_idx: u32 = 0;
+    # locals.
+    symi = 0;
+    for (symi < num_syms) {
+        if (!is_local_sym(?img.symbols[symi])) { symi = symi + 1; cnt; }
+        if (remap != nil) { remap[symi] = nlist_idx; }
+        write_nlist(buf, sym_off, strtab_off, ?str_pos, img, symi, sec_addr);
+        sym_off = sym_off + NLIST_64_SIZE;
+        nlist_idx = nlist_idx + 1;
+        symi = symi + 1;
+    }
+    # external definitions.
+    symi = 0;
+    for (symi < num_syms) {
+        if (!is_extdef_sym(?img.symbols[symi])) { symi = symi + 1; cnt; }
+        if (remap != nil) { remap[symi] = nlist_idx; }
+        write_nlist(buf, sym_off, strtab_off, ?str_pos, img, symi, sec_addr);
+        sym_off = sym_off + NLIST_64_SIZE;
+        nlist_idx = nlist_idx + 1;
+        symi = symi + 1;
+    }
+    # undefined.
+    symi = 0;
+    for (symi < num_syms) {
+        if (img.symbols[symi].section != of.SECTION_EXTERNAL) { symi = symi + 1; cnt; }
+        if (remap != nil) { remap[symi] = nlist_idx; }
+        write_nlist(buf, sym_off, strtab_off, ?str_pos, img, symi, sec_addr);
+        sym_off = sym_off + NLIST_64_SIZE;
+        nlist_idx = nlist_idx + 1;
+        symi = symi + 1;
+    }
+
+    # per-section relocation_info arrays, in image order, each preceded by an
+    # ARM64_RELOC_ADDEND entry when the abstract addend cannot live in-place.
+    s = 0;
+    for (s < num_secs) {
+        if (reloc_off[s] != 0) {
+            var ro: usize = reloc_off[s];
+            var ri: u32 = 0;
+            for (ri < img.reloc_count) {
+                if (img.relocations[ri].section == s) {
+                    val rsi: u32 = R.unwrap_ok[u32, str](reloc_sym_index(img, img.relocations[ri].symbol));
+                    val symnum: u32 = remap[rsi];
+                    val mr: MachoReloc = R.unwrap_ok[MachoReloc, str](macho_reloc_for(img.interner, alloc, arch_id, img.relocations[ri].kind));
+                    if (needs_addend_entry(arch_id, img.relocations[ri].kind, img.relocations[ri].addend)) {
+                        write_reloc_info(buf, ro, img.relocations[ri].offset, (img.relocations[ri].addend::u64)::u32 & 0xFFFFFF,
+                                         0, 2, 0, ARM64_RELOC_ADDEND);
+                        ro = ro + RELOC_INFO_SIZE;
+                    }
+                    write_reloc_info(buf, ro, img.relocations[ri].offset, symnum, mr.pcrel, mr.length, 1, mr.r_type);
+                    ro = ro + RELOC_INFO_SIZE;
+                }
+                ri = ri + 1;
+            }
+        }
+        s = s + 1;
+    }
+
+    if (remap != nil) { A.deallocate[u32](alloc, remap, num_syms::usize); }
+    A.deallocate[u64](alloc, sec_addr, (num_secs + 1)::usize);
+    A.deallocate[usize](alloc, data_off, (num_secs + 1)::usize);
+    A.deallocate[usize](alloc, reloc_off, (num_secs + 1)::usize);
+
+    val wr: R.Result[bool, str] = write_file(img.interner, alloc, path, buf, total_size, "macho: object");
+    A.deallocate[u8](alloc, buf, total_size);
+    ret wr;
 }
 
-# parse a Mach-O object file into an ObjectImage
-#
-# Stub: Mach-O parsing is not implemented yet, so this always returns the
-# unsupported-format error rather than producing a partial image. Matches the
-# of.ParserFn signature exactly.
+# write `buf` to `path`, framing a clear I/O diagnostic on failure.
 # ---
-# a:       allocator backing the image and its arrays
-# itn:     interner the parsed names would be interned into
-# buf:     object file bytes
-# buf_len: length of the object file bytes
-# out:     image to populate
-# ret:     the unsupported-format error
-fun parse_object(a: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_len: usize, out: *of.ObjectImage) R.Result[bool, str] {
-    ret R.err[bool, str](MACHO_UNSUPPORTED);
+# itn:   interner backing the I/O diagnostic (may be nil)
+# alloc: allocator backing the diagnostic
+# path:  null-terminated output path
+# buf:   the bytes to write
+# len:   number of bytes to write
+# label: the leading text for the diagnostic ("macho: object" / "macho: exec")
+# ret:   ok(true) on success, or an I/O error
+fun write_file(itn: *intern.Interner, alloc: *A.Allocator, path: *u8, buf: *u8, len: usize, label: str) R.Result[bool, str] {
+    val rf: R.Result[filesystem.File, str] = filesystem.create(path, 0o755);
+    if (R.is_err[filesystem.File, str](rf)) {
+        ret R.err[bool, str](bin.io_message(itn, alloc, label, path::str, R.unwrap_err[filesystem.File, str](rf), "macho: could not create output file"));
+    }
+    var f: filesystem.File = R.unwrap_ok[filesystem.File, str](rf);
+    val rw: R.Result[usize, str] = filesystem.write(?f, buf, len);
+    filesystem.close(?f);
+    if (R.is_err[usize, str](rw)) {
+        ret R.err[bool, str](bin.io_message(itn, alloc, label, path::str, R.unwrap_err[usize, str](rw), "macho: write failed"));
+    }
+    ret R.ok[bool, str](true);
 }
 
-# serialize laid-out load segments into a Mach-O executable
-#
-# Stub: Mach-O executable emission is not implemented yet, so this always
-# returns the unsupported-format error rather than writing a malformed
-# executable. Matches the of.ExecFn signature exactly.
-# ---
-# a:        allocator for the output buffer
-# itn:      interner for located I/O-failure diagnostics
-# isa_vt:   instruction-set vtable describing the machine
-# segs:     loadable segments
-# seg_len:  number of load segments
-# entry:    program entry-point virtual address
-# funcs:    per-function metadata for unwind-table emission
-# func_len: number of entries in funcs
-# path:     null-terminated output file path
-# ret:      the unsupported-format error
-fun emit_exec(a: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
-              seg_len: u32, entry: u64, funcs: *of.ExecFunction, func_len: u32,
-              path: *u8) R.Result[bool, str] {
-    ret R.err[bool, str](MACHO_UNSUPPORTED);
-}
-
-# the Mach-O object-format vtable, populated by register on first call and
-# handed to the registry as a borrowed pointer
+# the Mach-O object-format vtable, populated by register and handed out as a
+# borrowed pointer for the process lifetime.
 var macho_vtable: of.OfVTable;
 
-# build and install the Mach-O of.OfVTable
+# build the Mach-O OfVTable and install it into a registry
 #
-# Fills the vtable with the format name and the three stub writers, leaving
-# emit_dyn_exec nil because no dyld bind/rebase writer exists yet, then installs
-# it into reg under of.OF_MACHO. Idempotent: of.register keeps the first
-# write-once entry. Must run at compiler startup before target.select requests a
-# Darwin target.
+# Sets the format name ("macho") and the object writer, parser, and static-exec
+# writer; `emit_dyn_exec` is left nil because the dyld bind/rebase writer (and the
+# libSystem dynamic linkage modern macOS requires) is the Darwin-runtime follow-up
+# (#1178), not this object-format substrate. Idempotent through `of.register`.
 # ---
-# reg: object-format registry to install the vtable into
-# ret: true on success
+# reg: the object-format registry to install the vtable into
+# ret: ok(true) on success
 pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     macho_vtable.id            = of.OF_MACHO;
     macho_vtable.name          = "macho";
@@ -102,21 +960,555 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# register installs the Mach-O vtable and the stub writers reject emission
-test "mach.lang.target.of.macho.register:installs_stub_vtable" {
-    var reg: of.OfRegistry = of.registry_init();
+# the Mach-O VM protection bits for the format-neutral segment permission flags;
+# an unflagged segment defaults to read-only.
+# ---
+# flags: the SEG_FLAG_* permission bits
+# ret:   the VM_PROT_* flag set (at least VM_PROT_READ)
+fun vm_prot_for(flags: u32) u32 {
+    var p: u32 = 0;
+    if ((flags & of.SEG_FLAG_READ) != 0)    { p = p | VM_PROT_READ; }
+    if ((flags & of.SEG_FLAG_WRITE) != 0)   { p = p | VM_PROT_WRITE; }
+    if ((flags & of.SEG_FLAG_EXECUTE) != 0) { p = p | VM_PROT_EXECUTE; }
+    if (p == 0)                             { p = VM_PROT_READ; }
+    ret p;
+}
 
-    val res_register: R.Result[bool, str] = register_macho(?reg);
-    if (R.is_err[bool, str](res_register)) { ret 1; }
+# the Mach-O segment name for a loadable segment's permissions: executable maps to
+# __TEXT, writable to __DATA, read-only to __DATA_CONST.
+# ---
+# flags: the SEG_FLAG_* permission bits
+# ret:   the segment name
+fun exec_segname(flags: u32) str {
+    if ((flags & of.SEG_FLAG_EXECUTE) != 0) { ret "__TEXT"; }
+    if ((flags & of.SEG_FLAG_WRITE) != 0)   { ret "__DATA"; }
+    ret "__DATA_CONST";
+}
 
-    val opt_vt: O.Option[*of.OfVTable] = of.lookup(?reg, "macho");
-    if (!O.is_some[*of.OfVTable](opt_vt)) { ret 1; }
+# write a static MH_EXECUTE Mach-O, installed as the of.ExecFn
+#
+# Frames the linker's laid-out load segments with a leading __PAGEZERO (the
+# unmapped low region below the image base), one LC_SEGMENT_64 per segment, and an
+# LC_UNIXTHREAD whose thread state carries the entry point - the static thread
+# entry, with no dyld dependency. The mach header and load commands occupy the
+# file head; each segment's file bytes follow at a page-aligned offset congruent
+# with its virtual address. A runnable Darwin image (header inside __TEXT, dyld /
+# LC_MAIN, code signature) is the Darwin-runtime follow-up (#1178); this writer
+# emits the structurally complete static skeleton the byte-verify lane checks.
+#
+# `funcs`/`func_count` are accepted for of.ExecFn conformance; no unwind table is
+# emitted.
+# ---
+# alloc:      allocator for the output buffer and the segment-offset scratch
+# itn:        interner backing any I/O diagnostic
+# isa_vt:     the instruction-set vtable selecting the cputype and thread state
+# segs:       loadable segments, in ascending virtual-address order
+# seg_count:  number of segments
+# entry:      program entry-point virtual address
+# funcs:      per-function metadata (unused)
+# func_count: number of entries in funcs (unused)
+# path:       null-terminated output file path
+# ret:        ok(true) on success, or an error string
+fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
+              seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
+              path: *u8) R.Result[bool, str] {
+    if (isa_vt == nil) { ret R.err[bool, str]("macho: nil exec isa"); }
+    if (path == nil)   { ret R.err[bool, str]("macho: nil exec path"); }
+    val arch_id: u32 = isa_vt.id;
+    val ct: R.Result[u32, str] = cpu_type_for(arch_id);
+    if (R.is_err[u32, str](ct)) { ret R.err[bool, str](R.unwrap_err[u32, str](ct)); }
 
-    var isa_vt: isa.IsaVTable;
-    var image:  of.ObjectImage;
+    # __PAGEZERO spans the low region below the image base; with a zero base
+    # (freestanding) there is none.
+    var pagezero_size: u64 = 0;
+    if (seg_count > 0) { pagezero_size = segs[0].vaddr & ~(EXEC_PAGE_SIZE - 1); }
+    var ncmds: u32 = seg_count + 1;                 # one LC_UNIXTHREAD
+    if (pagezero_size > 0) { ncmds = ncmds + 1; }   # plus __PAGEZERO
 
-    val res_emit: R.Result[bool, str] = emit_object(?isa_vt, ?image, nil::*u8);
-    if (!R.is_err[bool, str](res_emit))                            { ret 1; }
-    if (!str_contains(R.unwrap_err[bool, str](res_emit), "macho")) { ret 1; }
+    var thread_state: usize = X86_THREAD_STATE64_COUNT::usize * 4;
+    if (arch_is_arm64(arch_id)) { thread_state = ARM_THREAD_STATE64_COUNT::usize * 4; }
+    val thread_cmd_size: usize = 16 + thread_state;
+
+    var sizeofcmds: usize = seg_count::usize * SEGMENT_CMD_64_SIZE + thread_cmd_size;
+    if (pagezero_size > 0) { sizeofcmds = sizeofcmds + SEGMENT_CMD_64_SIZE; }
+    val header_end: usize = MACH_HEADER_64_SIZE + sizeofcmds;
+
+    var seg_offsets: *usize = nil;
+    if (seg_count > 0) {
+        val ro: R.Result[*usize, str] = A.zallocate[usize](alloc, seg_count::usize);
+        if (R.is_err[*usize, str](ro)) { ret R.err[bool, str]("macho: exec offset table alloc failed"); }
+        seg_offsets = R.unwrap_ok[*usize, str](ro);
+    }
+
+    var total_size: usize = bin.align_up(header_end, EXEC_PAGE_SIZE::usize);
+    var li: u32 = 0;
+    for (li < seg_count) {
+        total_size = bin.align_up(total_size, EXEC_PAGE_SIZE::usize);
+        seg_offsets[li] = total_size;
+        total_size = total_size + segs[li].filesz;
+        li = li + 1;
+    }
+
+    val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
+    if (R.is_err[*u8, str](res_buf)) {
+        if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        ret R.err[bool, str]("macho: exec buffer alloc failed");
+    }
+    var buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+
+    bin.write_u32_le(buf, 0, MH_MAGIC_64);
+    bin.write_u32_le(buf, 4, R.unwrap_ok[u32, str](ct));
+    bin.write_u32_le(buf, 8, cpu_subtype_for(arch_id));
+    bin.write_u32_le(buf, 12, MH_EXECUTE);
+    bin.write_u32_le(buf, 16, ncmds);
+    bin.write_u32_le(buf, 20, sizeofcmds::u32);
+    bin.write_u32_le(buf, 24, MH_NOUNDEFS);
+    bin.write_u32_le(buf, 28, 0);
+
+    var lc: usize = MACH_HEADER_64_SIZE;
+    if (pagezero_size > 0) {
+        bin.write_u32_le(buf, lc, LC_SEGMENT_64);
+        bin.write_u32_le(buf, lc + 4, SEGMENT_CMD_64_SIZE::u32);
+        write_fixed16(buf, lc + 8, "__PAGEZERO");
+        bin.write_u64_le(buf, lc + 24, 0);
+        bin.write_u64_le(buf, lc + 32, pagezero_size);
+        bin.write_u64_le(buf, lc + 40, 0);
+        bin.write_u64_le(buf, lc + 48, 0);
+        bin.write_u32_le(buf, lc + 56, 0);
+        bin.write_u32_le(buf, lc + 60, 0);
+        bin.write_u32_le(buf, lc + 64, 0);
+        bin.write_u32_le(buf, lc + 68, 0);
+        lc = lc + SEGMENT_CMD_64_SIZE;
+    }
+
+    li = 0;
+    for (li < seg_count) {
+        val prot: u32 = vm_prot_for(segs[li].flags);
+        bin.write_u32_le(buf, lc, LC_SEGMENT_64);
+        bin.write_u32_le(buf, lc + 4, SEGMENT_CMD_64_SIZE::u32);
+        write_fixed16(buf, lc + 8, exec_segname(segs[li].flags));
+        bin.write_u64_le(buf, lc + 24, segs[li].vaddr);
+        bin.write_u64_le(buf, lc + 32, bin.align_up_u64(segs[li].memsz::u64, EXEC_PAGE_SIZE));
+        bin.write_u64_le(buf, lc + 40, seg_offsets[li]::u64);
+        bin.write_u64_le(buf, lc + 48, segs[li].filesz::u64);
+        bin.write_u32_le(buf, lc + 56, prot);
+        bin.write_u32_le(buf, lc + 60, prot);
+        bin.write_u32_le(buf, lc + 64, 0);
+        bin.write_u32_le(buf, lc + 68, 0);
+        lc = lc + SEGMENT_CMD_64_SIZE;
+
+        if (segs[li].bytes != nil && segs[li].filesz > 0) {
+            memory.raw_copy((buf::usize + seg_offsets[li])::ptr, segs[li].bytes::ptr, segs[li].filesz);
+        }
+        li = li + 1;
+    }
+
+    # LC_UNIXTHREAD: the static entry, with the program counter in the thread
+    # state. the surrounding state is zero (the buffer is zero-initialized).
+    bin.write_u32_le(buf, lc, LC_UNIXTHREAD);
+    bin.write_u32_le(buf, lc + 4, thread_cmd_size::u32);
+    if (arch_is_arm64(arch_id)) {
+        bin.write_u32_le(buf, lc + 8, ARM_THREAD_STATE64);
+        bin.write_u32_le(buf, lc + 12, ARM_THREAD_STATE64_COUNT);
+        bin.write_u64_le(buf, lc + 16 + ARM_PC_STATE_OFFSET, entry);
+    } or {
+        bin.write_u32_le(buf, lc + 8, X86_THREAD_STATE64);
+        bin.write_u32_le(buf, lc + 12, X86_THREAD_STATE64_COUNT);
+        bin.write_u64_le(buf, lc + 16 + X86_RIP_STATE_OFFSET, entry);
+    }
+
+    if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+
+    val wr: R.Result[bool, str] = write_file(itn, alloc, path, buf, total_size, "macho: exec");
+    A.deallocate[u8](alloc, buf, total_size);
+    ret wr;
+}
+
+# parse a relocatable Mach-O object into an ObjectImage
+#
+# The mirror of `emit_object`: reads the section, symbol, and relocation tables of
+# an MH_OBJECT into a fresh image owning copied section bytes and interned names.
+# Relocation kinds map back from the machine type keyed on the header cputype, and
+# arm64 PAGEOFF12 is disambiguated by decoding the patched instruction; the addend
+# is recovered from the in-place field, the 8-byte UNSIGNED field, or a preceding
+# ARM64_RELOC_ADDEND entry. `itn` interns the names and is recorded on `out`.
+# ---
+# alloc:    allocator for the image and its arrays
+# itn:      interner the parsed names are interned into and recorded on `out`
+# buf:      the object file bytes
+# buf_size: length of `buf`
+# out:      image to populate (its arrays are allocated here)
+# ret:      ok(true) on success, or an error string
+pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_size: usize, out: *of.ObjectImage) R.Result[bool, str] {
+    if (buf == nil || out == nil || buf_size < MACH_HEADER_64_SIZE) {
+        ret R.err[bool, str]("macho: object too small");
+    }
+    if (bin.read_u32_le(buf, 0) != MH_MAGIC_64) {
+        ret R.err[bool, str]("macho: not a 64-bit Mach-O object (bad magic; expected 0xFEEDFACF)");
+    }
+    if (itn == nil) { ret R.err[bool, str]("macho: no interner for parse"); }
+
+    val cputype: u32 = bin.read_u32_le(buf, 4);
+    val ncmds:   u32 = bin.read_u32_le(buf, 16);
+
+    out.interner = itn;
+    out.alloc = alloc;
+    out.section_count = 0;
+    out.symbol_count = 0;
+    out.reloc_count = 0;
+    out.sections = nil;
+    out.symbols = nil;
+    out.relocations = nil;
+
+    # first pass: tally sections (over every LC_SEGMENT_64) and locate the symtab.
+    var sec_n:       u32 = 0;
+    var symoff:      usize = 0;
+    var nsyms:       u32 = 0;
+    var stroff:      usize = 0;
+    var strsize:     usize = 0;
+    var have_symtab: bool = false;
+
+    var off: usize = MACH_HEADER_64_SIZE;
+    var c: u32 = 0;
+    for (c < ncmds) {
+        val vc: R.Result[bool, str] = bin.require_region(buf_size, off, 8, "macho: load command out of bounds");
+        if (R.is_err[bool, str](vc)) { ret R.err[bool, str](R.unwrap_err[bool, str](vc)); }
+        val cmd:     u32 = bin.read_u32_le(buf, off);
+        val cmdsize: usize = bin.read_u32_le(buf, off + 4)::usize;
+        if (cmdsize < 8) { ret R.err[bool, str]("macho: zero-size load command"); }
+        val vfull: R.Result[bool, str] = bin.require_region(buf_size, off, cmdsize, "macho: load command out of bounds");
+        if (R.is_err[bool, str](vfull)) { ret R.err[bool, str](R.unwrap_err[bool, str](vfull)); }
+
+        if (cmd == LC_SEGMENT_64) {
+            sec_n = sec_n + bin.read_u32_le(buf, off + 64);
+        } or (cmd == LC_SYMTAB) {
+            symoff  = bin.read_u32_le(buf, off + 8)::usize;
+            nsyms   = bin.read_u32_le(buf, off + 12);
+            stroff  = bin.read_u32_le(buf, off + 16)::usize;
+            strsize = bin.read_u32_le(buf, off + 20)::usize;
+            have_symtab = true;
+        }
+        off = off + cmdsize;
+        c = c + 1;
+    }
+
+    if (have_symtab) {
+        val vsy: R.Result[bool, str] = bin.require_region(buf_size, symoff, nsyms::usize * NLIST_64_SIZE, "macho: symbol table out of bounds");
+        if (R.is_err[bool, str](vsy)) { ret R.err[bool, str](R.unwrap_err[bool, str](vsy)); }
+        val vst: R.Result[bool, str] = bin.require_region(buf_size, stroff, strsize, "macho: string table out of bounds");
+        if (R.is_err[bool, str](vst)) { ret R.err[bool, str](R.unwrap_err[bool, str](vst)); }
+    }
+
+    if (sec_n > 0) {
+        val rsec: R.Result[*of.Section, str] = A.zallocate[of.Section](alloc, sec_n::usize);
+        if (R.is_err[*of.Section, str](rsec)) { ret R.err[bool, str]("macho: section array alloc failed"); }
+        out.sections = R.unwrap_ok[*of.Section, str](rsec);
+    }
+    if (nsyms > 0) {
+        val rsym: R.Result[*of.Symbol, str] = A.zallocate[of.Symbol](alloc, nsyms::usize);
+        if (R.is_err[*of.Symbol, str](rsym)) { ret R.err[bool, str]("macho: symbol array alloc failed"); }
+        out.symbols = R.unwrap_ok[*of.Symbol, str](rsym);
+    }
+    out.section_count = sec_n;
+    out.symbol_count  = nsyms;
+
+    # per-mach-section in-segment base address, for recovering symbol offsets.
+    var sec_base: *u64 = nil;
+    if (sec_n > 0) {
+        val rb: R.Result[*u64, str] = A.zallocate[u64](alloc, sec_n::usize);
+        if (R.is_err[*u64, str](rb)) { ret R.err[bool, str]("macho: section base table alloc failed"); }
+        sec_base = R.unwrap_ok[*u64, str](rb);
+    }
+
+    # second pass: populate sections from every LC_SEGMENT_64.
+    var sec_i: u32 = 0;
+    off = MACH_HEADER_64_SIZE;
+    c = 0;
+    for (c < ncmds) {
+        val cmd:     u32 = bin.read_u32_le(buf, off);
+        val cmdsize: usize = bin.read_u32_le(buf, off + 4)::usize;
+        if (cmd == LC_SEGMENT_64) {
+            val nsects: u32 = bin.read_u32_le(buf, off + 64);
+            var sh: usize = off + SEGMENT_CMD_64_SIZE;
+            var k: u32 = 0;
+            for (k < nsects) {
+                val addr:    u64 = bin.read_u64_le(buf, sh + 32);
+                val size:    u64 = bin.read_u64_le(buf, sh + 40);
+                val sec_off: usize = bin.read_u32_le(buf, sh + 48)::usize;
+                val align_l: u32 = bin.read_u32_le(buf, sh + 52);
+                val flags:   u32 = bin.read_u32_le(buf, sh + 64);
+                val is_text: bool = fixed16_equals(buf, sh + 16, "__TEXT");
+                val kind:    of.SectionKind = macho_kind_from(flags, is_text);
+
+                # intern the section name from the section_64 entry; the linker
+                # re-canonicalizes by kind, so the exact name is informational.
+                var name_buf: [17]u8;
+                var ni: usize = 0;
+                for (ni < 16) { name_buf[ni] = buf[sh + ni]; ni = ni + 1; }
+                name_buf[16] = 0;
+                val rin: R.Result[intern.StrId, str] = intern.intern(itn, (?name_buf[0])::str);
+                if (R.is_err[intern.StrId, str](rin)) {
+                    if (sec_base != nil) { A.deallocate[u64](alloc, sec_base, sec_n::usize); }
+                    ret R.err[bool, str](R.unwrap_err[intern.StrId, str](rin));
+                }
+
+                out.sections[sec_i].name  = R.unwrap_ok[intern.StrId, str](rin);
+                out.sections[sec_i].kind  = kind;
+                out.sections[sec_i].len   = size::u32;
+                out.sections[sec_i].align = (1::u32) << align_l;
+                out.sections[sec_i].bytes = nil;
+                sec_base[sec_i] = addr;
+
+                if (kind != of.SK_BSS && size > 0) {
+                    if (!bin.region_ok(buf_size, sec_off, size::usize)) {
+                        if (sec_base != nil) { A.deallocate[u64](alloc, sec_base, sec_n::usize); }
+                        ret R.err[bool, str]("macho: section data out of bounds");
+                    }
+                    val rbytes: R.Result[*u8, str] = A.allocate[u8](alloc, size::usize);
+                    if (R.is_err[*u8, str](rbytes)) {
+                        if (sec_base != nil) { A.deallocate[u64](alloc, sec_base, sec_n::usize); }
+                        ret R.err[bool, str]("macho: section bytes alloc failed");
+                    }
+                    out.sections[sec_i].bytes = R.unwrap_ok[*u8, str](rbytes);
+                    memory.raw_copy(out.sections[sec_i].bytes::ptr, (buf::usize + sec_off)::ptr, size::usize);
+                }
+                sec_i = sec_i + 1;
+                sh = sh + SECTION_64_SIZE;
+                k = k + 1;
+            }
+        }
+        off = off + cmdsize;
+        c = c + 1;
+    }
+
+    # symbols: each nlist_64 in file order. n_sect is 1-based over the same section
+    # order populated above.
+    var si: u32 = 0;
+    for (si < nsyms) {
+        val so: usize = symoff + si::usize * NLIST_64_SIZE;
+        val n_strx:  u32 = bin.read_u32_le(buf, so);
+        val n_type:  u8  = buf[so + 4];
+        val n_sect:  u8  = buf[so + 5];
+        val n_desc:  u16 = bin.read_u16_le(buf, so + 6);
+        val n_value: u64 = bin.read_u64_le(buf, so + 8);
+
+        val rnm: R.Result[str, str] = bin.cstr_at(buf, buf_size, stroff + n_strx::usize);
+        if (R.is_err[str, str](rnm)) {
+            if (sec_base != nil) { A.deallocate[u64](alloc, sec_base, sec_n::usize); }
+            ret R.err[bool, str](R.unwrap_err[str, str](rnm));
+        }
+        val rin: R.Result[intern.StrId, str] = intern.intern(itn, R.unwrap_ok[str, str](rnm));
+        if (R.is_err[intern.StrId, str](rin)) {
+            if (sec_base != nil) { A.deallocate[u64](alloc, sec_base, sec_n::usize); }
+            ret R.err[bool, str](R.unwrap_err[intern.StrId, str](rin));
+        }
+        out.symbols[si].name = R.unwrap_ok[intern.StrId, str](rin);
+        out.symbols[si].size = 0;
+
+        var flags: u32 = 0;
+        if ((n_type & N_EXT) != 0)      { flags = flags | of.SYM_OBJ_FLAG_GLOBAL; }
+        if ((n_desc & N_WEAK_DEF) != 0) { flags = flags | of.SYM_OBJ_FLAG_WEAK; }
+        if ((n_type & N_TYPE) == N_UNDF) {
+            flags = flags | of.SYM_OBJ_FLAG_EXTERN;
+            out.symbols[si].section = of.SECTION_EXTERNAL;
+            out.symbols[si].offset = 0;
+        } or (n_sect >= 1 && (n_sect - 1)::u32 < sec_n) {
+            val sidx: u32 = (n_sect - 1)::u32;
+            out.symbols[si].section = sidx;
+            out.symbols[si].offset = (n_value - sec_base[sidx])::u32;
+            if (out.sections[sidx].kind == of.SK_TEXT) { flags = flags | of.SYM_OBJ_FLAG_FUNCTION; }
+            or                                         { flags = flags | of.SYM_OBJ_FLAG_OBJECT; }
+        } or {
+            out.symbols[si].section = of.SECTION_EXTERNAL;
+            out.symbols[si].offset = 0;
+        }
+        out.symbols[si].flags = flags;
+        si = si + 1;
+    }
+
+    # relocations: pre-count the real (non-ARM64_RELOC_ADDEND) entries, allocate,
+    # then populate, folding each addend back into the abstract record.
+    val rel_total: R.Result[u32, str] = count_relocs(buf, buf_size, cputype, ncmds);
+    if (R.is_err[u32, str](rel_total)) {
+        if (sec_base != nil) { A.deallocate[u64](alloc, sec_base, sec_n::usize); }
+        ret R.err[bool, str](R.unwrap_err[u32, str](rel_total));
+    }
+    val rel_n: u32 = R.unwrap_ok[u32, str](rel_total);
+    if (rel_n > 0) {
+        val rrel: R.Result[*of.Relocation, str] = A.zallocate[of.Relocation](alloc, rel_n::usize);
+        if (R.is_err[*of.Relocation, str](rrel)) {
+            if (sec_base != nil) { A.deallocate[u64](alloc, sec_base, sec_n::usize); }
+            ret R.err[bool, str]("macho: reloc array alloc failed");
+        }
+        out.relocations = R.unwrap_ok[*of.Relocation, str](rrel);
+    }
+    out.reloc_count = rel_n;
+
+    val rp: R.Result[bool, str] = populate_relocs(alloc, itn, buf, buf_size, cputype, ncmds, out);
+    if (sec_base != nil) { A.deallocate[u64](alloc, sec_base, sec_n::usize); }
+    if (R.is_err[bool, str](rp)) { ret R.err[bool, str](R.unwrap_err[bool, str](rp)); }
+    ret R.ok[bool, str](true);
+}
+
+# count the real relocations across every section, excluding ARM64_RELOC_ADDEND
+# pairing entries.
+# ---
+# buf:      the object bytes
+# buf_size: length of `buf`
+# cputype:  the header cputype (selects addend-entry accounting)
+# ncmds:    the load-command count
+# ret:      ok(real relocation count), or a bounds error
+fun count_relocs(buf: *u8, buf_size: usize, cputype: u32, ncmds: u32) R.Result[u32, str] {
+    var total: u32 = 0;
+    var off: usize = MACH_HEADER_64_SIZE;
+    var c: u32 = 0;
+    for (c < ncmds) {
+        val cmd:     u32 = bin.read_u32_le(buf, off);
+        val cmdsize: usize = bin.read_u32_le(buf, off + 4)::usize;
+        if (cmd == LC_SEGMENT_64) {
+            val nsects: u32 = bin.read_u32_le(buf, off + 64);
+            var sh: usize = off + SEGMENT_CMD_64_SIZE;
+            var k: u32 = 0;
+            for (k < nsects) {
+                val reloff: usize = bin.read_u32_le(buf, sh + 56)::usize;
+                val nreloc: u32 = bin.read_u32_le(buf, sh + 60);
+                val vr: R.Result[bool, str] = bin.require_region(buf_size, reloff, nreloc::usize * RELOC_INFO_SIZE, "macho: relocation array out of bounds");
+                if (R.is_err[bool, str](vr)) { ret R.err[u32, str](R.unwrap_err[bool, str](vr)); }
+                var r: u32 = 0;
+                for (r < nreloc) {
+                    val word: u32 = bin.read_u32_le(buf, reloff + r::usize * RELOC_INFO_SIZE + 4);
+                    val r_type: u32 = (word >> 28) & 0xF;
+                    if (cputype == CPU_TYPE_ARM64 && r_type == ARM64_RELOC_ADDEND) { r = r + 1; cnt; }
+                    total = total + 1;
+                    r = r + 1;
+                }
+                sh = sh + SECTION_64_SIZE;
+                k = k + 1;
+            }
+        }
+        off = off + cmdsize;
+        c = c + 1;
+    }
+    ret R.ok[u32, str](total);
+}
+
+# populate the relocation array from every section's relocation_info array,
+# pairing ARM64_RELOC_ADDEND entries and recovering each addend.
+# ---
+# alloc:    allocator backing reloc-kind error messages
+# itn:      interner backing reloc-kind error messages
+# buf:      the object bytes
+# buf_size: length of `buf`
+# cputype:  the header cputype (selects the reverse reloc map)
+# ncmds:    the load-command count
+# out:      the image being populated (sections/symbols already filled)
+# ret:      ok(true), or an error string
+fun populate_relocs(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_size: usize, cputype: u32, ncmds: u32, out: *of.ObjectImage) R.Result[bool, str] {
+    var rel_i: u32 = 0;
+    var sec_i: u32 = 0;
+    var off: usize = MACH_HEADER_64_SIZE;
+    var c: u32 = 0;
+    for (c < ncmds) {
+        val cmd:     u32 = bin.read_u32_le(buf, off);
+        val cmdsize: usize = bin.read_u32_le(buf, off + 4)::usize;
+        if (cmd == LC_SEGMENT_64) {
+            val nsects: u32 = bin.read_u32_le(buf, off + 64);
+            var sh: usize = off + SEGMENT_CMD_64_SIZE;
+            var k: u32 = 0;
+            for (k < nsects) {
+                val reloff: usize = bin.read_u32_le(buf, sh + 56)::usize;
+                val nreloc: u32 = bin.read_u32_le(buf, sh + 60);
+                var pending: i64 = 0;
+                var have_pending: bool = false;
+                var r: u32 = 0;
+                for (r < nreloc) {
+                    val e: usize = reloff + r::usize * RELOC_INFO_SIZE;
+                    val address: u32 = bin.read_u32_le(buf, e);
+                    val word:    u32 = bin.read_u32_le(buf, e + 4);
+                    val symnum:  u32 = word & 0xFFFFFF;
+                    val pcrel:   u32 = (word >> 24) & 0x1;
+                    val extn:    u32 = (word >> 27) & 0x1;
+                    val r_type:  u32 = (word >> 28) & 0xF;
+
+                    if (cputype == CPU_TYPE_ARM64 && r_type == ARM64_RELOC_ADDEND) {
+                        pending = sign_extend24(symnum);
+                        have_pending = true;
+                        r = r + 1;
+                        cnt;
+                    }
+                    if (extn == 0) { ret R.err[bool, str]("macho: section-relative relocation unsupported"); }
+                    if (symnum >= out.symbol_count) { ret R.err[bool, str]("macho: relocation symbol index out of range"); }
+
+                    var insn: u32 = 0;
+                    if (out.sections[sec_i].bytes != nil && (address::usize + 4) <= out.sections[sec_i].len::usize) {
+                        insn = bin.read_u32_le(out.sections[sec_i].bytes, address::usize);
+                    }
+                    val rk: R.Result[of.RelocKind, str] = reloc_kind_for(itn, alloc, cputype, r_type, insn);
+                    if (R.is_err[of.RelocKind, str](rk)) { ret R.err[bool, str](R.unwrap_err[of.RelocKind, str](rk)); }
+                    val kind: of.RelocKind = R.unwrap_ok[of.RelocKind, str](rk);
+
+                    out.relocations[rel_i].section = sec_i;
+                    out.relocations[rel_i].offset  = address;
+                    out.relocations[rel_i].kind    = kind;
+                    out.relocations[rel_i].symbol  = out.symbols[symnum].name;
+                    out.relocations[rel_i].addend  = recover_addend(out, sec_i, address, cputype, kind, pcrel, pending, have_pending);
+                    rel_i = rel_i + 1;
+                    pending = 0;
+                    have_pending = false;
+                    r = r + 1;
+                }
+                sec_i = sec_i + 1;
+                sh = sh + SECTION_64_SIZE;
+                k = k + 1;
+            }
+        }
+        off = off + cmdsize;
+        c = c + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# sign-extend a 24-bit ARM64_RELOC_ADDEND value to i64.
+# ---
+# v:   the 24-bit value from r_symbolnum
+# ret: the sign-extended addend
+fun sign_extend24(v: u32) i64 {
+    var a: i64 = (v & 0xFFFFFF)::i64;
+    if ((v & 0x800000) != 0) { a = a - 0x1000000; }
+    ret a;
+}
+
+# recover a relocation's abstract addend from its in-place field or a paired
+# ARM64_RELOC_ADDEND value
+#
+# An 8-byte UNSIGNED (RK_ABS64) field holds the full addend; an x86_64
+# pc-relative field is next-instruction-relative, so the abstract addend is
+# `field - 4`. arm64 page/page-offset/branch kinds take the paired addend (0 when
+# none was present).
+# ---
+# out:          the image (its section bytes carry the in-place field)
+# sec_i:        the section the relocation patches
+# address:      the in-section patch offset
+# cputype:      the header cputype
+# kind:         the abstract relocation kind
+# pcrel:        the on-wire pc-relative bit
+# pending:      the paired ARM64_RELOC_ADDEND value
+# have_pending: whether a paired addend entry preceded this relocation
+# ret:          the abstract addend
+fun recover_addend(out: *of.ObjectImage, sec_i: u32, address: u32, cputype: u32, kind: of.RelocKind,
+                   pcrel: u32, pending: i64, have_pending: bool) i64 {
+    val bytes: *u8 = out.sections[sec_i].bytes;
+    val len:   usize = out.sections[sec_i].len::usize;
+    if (kind == of.RK_ABS64) {
+        if (bytes != nil && (address::usize + 8) <= len) { ret bin.read_u64_le(bytes, address::usize)::i64; }
+        ret 0;
+    }
+    if (cputype == CPU_TYPE_ARM64) {
+        if (have_pending) { ret pending; }
+        ret 0;
+    }
+    if (pcrel != 0) {
+        if (bytes != nil && (address::usize + 4) <= len) { ret (bin.read_u32_le(bytes, address::usize)::i32)::i64 - 4; }
+    }
     ret 0;
 }

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1546,7 +1546,7 @@ fun t_find_lc(buf: *u8, cmd: u32) usize {
 # an x86_64 ObjectImage round-trips through emit_object / parse_object: the header,
 # sections, symbols, and relocations (PLT32, PC32, ABS64) survive, and the
 # in-place addends are recovered in the abstract field-relative convention.
-test "mach.lang.target.of.macho.emit_object:x86_64_round_trip" {
+fun ts_x64_roundtrip() u8 {
     var alloc: A.Allocator;
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
@@ -1668,7 +1668,7 @@ test "mach.lang.target.of.macho.emit_object:x86_64_round_trip" {
 # a non-zero addend carried in an ARM64_RELOC_ADDEND entry) / BRANCH26 in .text and
 # an ABS64 with an in-place addend in .data all survive, and PAGEOFF12 is decoded
 # back to the exact LO12 width from the patched instruction.
-test "mach.lang.target.of.macho.emit_object:arm64_round_trip" {
+fun ts_arm64_roundtrip() u8 {
     var alloc: A.Allocator;
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
@@ -1769,7 +1769,7 @@ test "mach.lang.target.of.macho.emit_object:arm64_round_trip" {
 # the forward relocation map is machine-keyed: a kind resolves to the x86_64
 # X86_64_RELOC_* type for x86_64 and the arm64 ARM64_RELOC_* type for arm64, and a
 # kind an architecture has no type for is an error naming it.
-test "mach.lang.target.of.macho.macho_reloc_for:machine_keyed" {
+fun ts_reloc_map() u8 {
     var alloc: A.Allocator;
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
@@ -1795,7 +1795,7 @@ test "mach.lang.target.of.macho.macho_reloc_for:machine_keyed" {
 
 # the reverse PAGEOFF12 map decodes the patched instruction to recover the exact
 # LO12 kind: ADD-immediate vs each LDR/STR access width.
-test "mach.lang.target.of.macho.pageoff12_kind:decodes_access_width" {
+fun ts_pageoff12() u8 {
     var alloc: A.Allocator;
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
@@ -1818,7 +1818,7 @@ test "mach.lang.target.of.macho.pageoff12_kind:decodes_access_width" {
 # emit_exec writes a static MH_EXECUTE: a leading __PAGEZERO spanning the image
 # base, one LC_SEGMENT_64 per load segment, and an LC_UNIXTHREAD carrying the
 # entry point in the architecture's thread state.
-test "mach.lang.target.of.macho.emit_exec:x86_64_static_skeleton" {
+fun ts_exec_x64() u8 {
     var alloc: A.Allocator;
     page.make(?alloc);
     var itn: intern.Interner = intern.init(?alloc);
@@ -1869,7 +1869,7 @@ test "mach.lang.target.of.macho.emit_exec:x86_64_static_skeleton" {
 }
 
 # emit_exec for arm64 places the entry in the arm64 pc slot of the thread state.
-test "mach.lang.target.of.macho.emit_exec:arm64_thread_entry" {
+fun ts_exec_arm64() u8 {
     var alloc: A.Allocator;
     page.make(?alloc);
     var itn: intern.Interner = intern.init(?alloc);
@@ -1911,7 +1911,7 @@ test "mach.lang.target.of.macho.emit_exec:arm64_thread_entry" {
 
 # register installs the Mach-O vtable under "macho" with the object/exec writers
 # bound and emit_dyn_exec left nil (the Darwin-runtime follow-up).
-test "mach.lang.target.of.macho.register_macho:installs_vtable" {
+fun ts_register() u8 {
     var reg: of.OfRegistry = of.registry_init();
     val rr: R.Result[bool, str] = register_macho(?reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
@@ -1929,7 +1929,7 @@ test "mach.lang.target.of.macho.register_macho:installs_vtable" {
 
 # emit_object rejects a relocation whose abstract kind has no Mach-O machine type
 # rather than silently emitting a wrong relocation.
-test "mach.lang.target.of.macho.emit_object:unsupported_reloc_kind" {
+fun ts_unsupported_kind() u8 {
     var alloc: A.Allocator;
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
@@ -1976,7 +1976,7 @@ test "mach.lang.target.of.macho.emit_object:unsupported_reloc_kind" {
 
 # parse_object rejects a non-Mach-O buffer and a truncated one rather than reading
 # off the end.
-test "mach.lang.target.of.macho.parse_object:rejects_bad_input" {
+fun ts_bad_input() u8 {
     var alloc: A.Allocator;
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
@@ -1996,5 +1996,30 @@ test "mach.lang.target.of.macho.parse_object:rejects_bad_input" {
     var out2: of.ObjectImage;
     val pr2: R.Result[bool, str] = parse_object(?alloc, ?i, ?tiny[0], 8, ?out2);
     if (!R.is_err[bool, str](pr2)) { ret 1; }
+    ret 0;
+}
+
+# the object writer/reader and the relocation maps. the scenarios are grouped into
+# one test block (each `test` is built into its own executable, so grouping keeps
+# the windows test runner's per-test link count down) and run in sequence: the
+# x86_64 and arm64 emit/parse round-trips, the machine-keyed forward map, and the
+# PAGEOFF12 instruction-decode reverse map.
+test "mach.lang.target.of.macho:object_round_trip_and_reloc_maps" {
+    if (ts_x64_roundtrip() != 0)   { ret 1; }
+    if (ts_arm64_roundtrip() != 0) { ret 1; }
+    if (ts_reloc_map() != 0)       { ret 1; }
+    if (ts_pageoff12() != 0)       { ret 1; }
+    ret 0;
+}
+
+# the executable writer, vtable registration, and the rejection paths, grouped as
+# above: the x86_64 and arm64 static-exec skeletons, register installation, and
+# the unsupported-kind / bad-input errors.
+test "mach.lang.target.of.macho:exec_vtable_and_rejections" {
+    if (ts_exec_x64() != 0)         { ret 1; }
+    if (ts_exec_arm64() != 0)       { ret 1; }
+    if (ts_register() != 0)         { ret 1; }
+    if (ts_unsupported_kind() != 0) { ret 1; }
+    if (ts_bad_input() != 0)        { ret 1; }
     ret 0;
 }

--- a/test/macho/mach.toml
+++ b/test/macho/mach.toml
@@ -1,0 +1,24 @@
+[project]
+id = "machoprobe"
+name = "machoprobe"
+version = "0.0.0"
+src = "src"
+target = "darwin-x86_64"
+out = "out/{target}/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+
+[bin.machoprobe]
+entry = "main.mach"

--- a/test/macho/src/main.mach
+++ b/test/macho/src/main.mach
@@ -1,0 +1,33 @@
+# freestanding darwin cross-compile fixture for the Mach-O object format.
+#
+# no std runtime is linked: the entry symbol "_main" (the Darwin os vtable's entry)
+# is defined here directly. the body exercises the byte path the writer emits - a
+# counted loop, a direct call (a branch relocation), and a global
+# read-modify-write (a pc-relative / absolute data reference) - so the emitted
+# Mach-O object carries real sections, symbols, and relocations. it has no exit
+# path: a Darwin exit needs the libSystem runtime, which is the #1178 follow-up.
+# so this fixture byte-verifies and links but does not run; Darwin binaries also
+# cannot run on the Linux CI host. test/macho drives the structural checks the ci
+# lane asserts with the llvm tools.
+
+var total: i64 = 0;
+
+# sum 0..n-1 with a counted loop, so the encoder emits intra-function branches.
+fun sum_to(n: i64) i64 {
+    var acc: i64 = 0;
+    var i: i64 = 0;
+    for (i < n) {
+        acc = acc + i;
+        i = i + 1;
+    }
+    ret acc;
+}
+
+# the program entry. the "_main" symbol the Darwin linker resolves as the entry
+# point; the call and the global read-modify-write give the relocations the lane
+# checks.
+#[symbol("_main")]
+fun start() {
+    total = total + sum_to(10);
+    ret;
+}

--- a/test/macho/verify.sh
+++ b/test/macho/verify.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# cross-compile the freestanding Mach-O fixture for both Darwin triples and
+# byte-verify the emitted relocatable object and the linked executable with the
+# llvm tools. proves the Mach-O object format emits a correct object (header, load
+# commands, sections, nlist symbols, relocations) and a structurally valid static
+# executable (__PAGEZERO, segments, LC_UNIXTHREAD entry) without running them:
+# Darwin binaries cannot run on this Linux host, and a Darwin exit needs the
+# libSystem runtime, which is the #1178 follow-up. this mirrors the riscv64 cross
+# lane - byte-verification, no execution step.
+#
+# usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
+#
+# requires: file, llvm-objdump, llvm-otool (unversioned or `-NN` suffixed).
+set -euo pipefail
+
+mach="${1:-mach}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# resolve an llvm tool by its unversioned name, falling back to the highest
+# `-NN` suffixed variant on PATH (ubuntu ships e.g. llvm-objdump-18).
+resolve_tool() {
+    local base="$1" cand
+    if command -v "$base" >/dev/null 2>&1; then echo "$base"; return 0; fi
+    cand="$(compgen -c "$base-" | sort -V | tail -n 1)"
+    if [ -n "$cand" ] && command -v "$cand" >/dev/null 2>&1; then echo "$cand"; return 0; fi
+    return 1
+}
+
+objdump="$(resolve_tool llvm-objdump)" || fail "llvm-objdump not found"
+otool="$(resolve_tool llvm-otool)"     || fail "llvm-otool not found"
+
+# verify_target <target> <machine> <thread-flavor> <reloc>...
+verify_target() {
+    local target="$1" machine="$2" flavor="$3"; shift 3
+    local exe="out/$target/machoprobe"
+
+    echo "cross-compiling fixture for $target with $mach"
+    "$mach" build . --target "$target" --profile debug
+    local obj
+    obj="$(find "out/$target/obj" -name '*.o' -print -quit)"
+    [ -n "$obj" ] || fail "$target: no object emitted"
+
+    echo "verifying $target object $obj"
+    file "$obj" | grep -q "Mach-O 64-bit $machine object" || fail "$target: object is not a Mach-O $machine object"
+    "$objdump" --macho -t "$obj" | grep -qw '_main'       || fail "$target: object missing the _main entry symbol"
+
+    local dis
+    dis="$("$objdump" --macho -d "$obj")"
+    echo "$dis" | grep -qi 'unknown' && fail "$target: object disassembly has an unknown instruction"
+
+    local rel
+    rel="$("$objdump" --macho -r "$obj")"
+    local r
+    for r in "$@"; do
+        echo "$rel" | grep -q "$r" || fail "$target: expected relocation '$r' not emitted"
+    done
+
+    echo "verifying $target executable $exe"
+    file "$exe" | grep -q "Mach-O 64-bit $machine executable" || fail "$target: not a Mach-O $machine executable"
+    local lc
+    lc="$("$otool" -l "$exe")"
+    echo "$lc" | grep -q '__PAGEZERO'    || fail "$target: executable missing __PAGEZERO"
+    echo "$lc" | grep -q '__TEXT'        || fail "$target: executable missing __TEXT segment"
+    echo "$lc" | grep -q 'LC_UNIXTHREAD' || fail "$target: executable missing LC_UNIXTHREAD"
+    echo "$lc" | grep -q "$flavor"       || fail "$target: executable thread state is not $flavor"
+}
+
+rm -rf out
+verify_target darwin-x86_64  x86_64 x86_THREAD_STATE64 SIGNED
+verify_target darwin-aarch64 arm64  ARM_THREAD_STATE64 PAGE21 PAGOF12 BR26
+
+echo "OK: Mach-O object format emits correct objects and executables for both Darwin triples"


### PR DESCRIPTION
Implements the Mach-O 64-bit object-format substrate (#1176), the last object
format needed to unlock the Darwin triples once the Darwin OS runtime (#1178)
lands. Pure substrate authoring: the only file changed is
`src/lang/target/of/macho.mach` (plus byte-verify fixtures and a CI lane) - no
shared-backend edits.

## What it does

- `emit_object`: a relocatable `MH_OBJECT` with one `LC_SEGMENT_64` holding every
  section, an `LC_SYMTAB`/`LC_DYSYMTAB` pair (symbols ordered local, then
  external-defined, then undefined), and per-section `relocation_info` arrays.
- `parse_object`: the mirror reader, round-tripping sections, symbols, and
  relocations back into an `of.ObjectImage`.
- `emit_exec`: a static `MH_EXECUTE` (leading `__PAGEZERO`, one `LC_SEGMENT_64`
  per laid-out load segment, `LC_UNIXTHREAD` carrying the entry point).
- Relocation mapping for both `x86_64` (`X86_64_RELOC_*`) and `arm64`
  (`ARM64_RELOC_*`), keyed on the ISA id forward and the header `cputype` in
  reverse - the same `tgt_isa.id` approach the COFF substrate uses, so no
  per-format hook is added to the shared `IsaVTable`.

## Notes

- Mach-O has no RELA addend field: addends live in-place in the patched bytes
  (x86_64, and the 8-byte `UNSIGNED` form on both arches), with pc-relative kinds
  folding the next-instruction `P + 4` bias exactly as COFF does. arm64's
  page/page-offset/branch kinds carry a non-zero addend in a preceding
  `ARM64_RELOC_ADDEND` entry.
- arm64's `PAGEOFF12` is scale-agnostic on the wire (one type for ADD and every
  LDR/STR width). The parser decodes the patched instruction to recover the exact
  `RK_ADD_LO12` / `RK_LDST*_LO12` kind the linker's `apply_reloc` needs, so the
  round-trip is lossless without touching the shared linker.
- `emit_dyn_exec` is left nil: dyld bind/rebase + libSystem dynamic linkage (and
  the runnable-image details: header inside `__TEXT`, `LC_MAIN`, code signature)
  are the Darwin-runtime follow-up (#1178), gated on #1159. This PR is the object
  format only.

## Verification

- Self-host fixpoint (`mach build` x3, `cmp`) and `mach test .` green.
- In-source byte tests round-trip both arches and assert the on-wire header, load
  commands, sections, nlist symbols, and relocations.
- A `test/macho/` cross-compile fixture byte-verifies the emitted Mach-O object
  and executable with the llvm tools (Darwin binaries cannot run on the Linux CI
  host, so structural byte-verification is the bar, exactly as the riscv64 lane).

Closes #1176
