### PR TITLE
fix(target/isa/riscv64): materialize const value operand of variable shift

### DIFF
--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -554,8 +554,10 @@ fun encode_addsub(st: *encode.EncodeState, mi: *mir.MirInstr, is_sub: bool) R.Re
 # a shift `op rd, rs1, rs2|shamt`. an immediate shift amount uses the immediate form
 # (slli/srli/srai, or the RV64 word slliw/srliw/sraiw), masking the amount to 6 bits
 # (5 for the word form) and folding the srai funct7 into imm[10]; a register amount
-# uses the register form. `funct3` is SLL for left and SRL for right; `is_arith`
-# selects the arithmetic (sign-filling) right shift.
+# uses the register form. the value operand (rs1) is materialized like any other
+# reg-reg ALU operand, so a constant value (`1 << n`) lands in the scratch register
+# rather than reaching the encoder as an immediate. `funct3` is SLL for left and SRL
+# for right; `is_arith` selects the arithmetic (sign-filling) right shift.
 fun encode_shift(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, is_arith: bool) R.Result[bool, str] {
     if (mi.operand_count < 3) { ret R.err[bool, str]("encode: shift missing operands"); }
 
@@ -563,7 +565,7 @@ fun encode_shift(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, is_ari
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
     val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
 
-    val rnr: R.Result[i32, str] = req_gpr(?mi.operands[1]);
+    val rnr: R.Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH2);
     if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
     val rs1: u32 = R.unwrap_ok[i32, str](rnr)::u32;
 
@@ -3275,6 +3277,53 @@ test "mach.lang.target.isa.riscv64.encode:mir_alu_shift_mov_neg_not" {
     if (read_word(?st.buf, 4) != 0x40B00533) { bad = 1; }
     encode_not(?st, ?mv);
     if (read_word(?st.buf, 8) != 0xFFF5C513) { bad = 1; }
+
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# a variable-amount shift with a CONSTANT value operand (`1 << n`) materializes the
+# value into the scratch register (t1 / x6) before the reg-reg shift, exactly like
+# every other reg-reg ALU operand - it does not reach the encoder as a bare
+# immediate. regression for the call-argument `const << var` encode failure. the
+# `li t1, 1` (addi t1, x0, 1) = 0x00100313 precedes each shift; result a0 = x10,
+# count a2 = x12. byte-exact against llvm-mc.
+test "mach.lang.target.isa.riscv64.encode:const_value_variable_shift_materializes" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(10);   # rd = a0
+    ops[1] = mir.op_imm(1);     # value = 1 (constant, must be materialized)
+    ops[2] = mir.op_preg(12);   # count = a2 (runtime)
+    mi.operands = ?ops[0]; mi.operand_count = 3; mi.width = 8;
+
+    # sll a0, t1, a2 = 0x00c31533, preceded by li t1, 1 = 0x00100313.
+    encode_shift(?st, ?mi, F3_SLL, false);
+    if (read_word(?st.buf, 0) != 0x00100313) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x00C31533) { bad = 1; }
+
+    # srl a0, t1, a2 = 0x00c35533 (logical right).
+    st.buf.len = 0;
+    encode_shift(?st, ?mi, F3_SRL, false);
+    if (read_word(?st.buf, 0) != 0x00100313) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x00C35533) { bad = 1; }
+
+    # sra a0, t1, a2 = 0x40c35533 (arithmetic right).
+    st.buf.len = 0;
+    encode_shift(?st, ?mi, F3_SRL, true);
+    if (read_word(?st.buf, 0) != 0x00100313) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x40C35533) { bad = 1; }
+
+    # the RV64 word form keeps the same value materialization: sllw a0, t1, a2 = 0x00c3153b.
+    st.buf.len = 0;
+    mi.width = 4;
+    encode_shift(?st, ?mi, F3_SLL, false);
+    if (read_word(?st.buf, 0) != 0x00100313) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x00C3153B) { bad = 1; }
 
     encode.buf_dnit(?st.buf);
     ret bad;

--- a/test/riscv64/src/main.mach
+++ b/test/riscv64/src/main.mach
@@ -3,9 +3,11 @@
 # no std runtime is linked: the entry symbol is defined here directly. the body
 # exercises the full byte path the backend emits - a counted loop (intra-function
 # B-type and J-type branch fixups), a direct call (R_RISCV_CALL_PLT), a global
-# load + store (R_RISCV_PCREL_HI20 with LO12_I and LO12_S), and an inline-asm exit
-# syscall (the only way to emit `ecall`). the exit code is the computed sum, so the
-# qemu e2e proves the whole pipeline runs end to end.
+# load + store (R_RISCV_PCREL_HI20 with LO12_I and LO12_S), a constant-valued
+# variable-amount shift used as a call argument (`1 << node`, which must
+# materialize the constant value into a register before the reg-reg `sll`), and an
+# inline-asm exit syscall (the only way to emit `ecall`). the exit code is the
+# computed sum, so the qemu e2e proves the whole pipeline runs end to end.
 
 var total: i64 = 0;
 
@@ -21,17 +23,27 @@ fun sum_to(n: i64) i64 {
     ret acc;
 }
 
+# a six-argument sum so its caller spills the surplus arguments through registers.
+fun g(a: u64, b: u64, c: u64, d: u64, e: u64, h: u64) u64 { ret a + b + c + d + e + h; }
+
+# the const-shift-as-call-argument pattern (#1657): the value operand `1` is a
+# constant and the amount `node` is a runtime parameter, so the backend must
+# materialize the constant into a register before the reg-reg `sll`. before the fix
+# this failed to encode (`encode: expected a register operand`) on this call path.
+fun na(node: u64) u64 { ret g(0, 1 << node, 0, 0, 0, 0); }
+
 # the program entry. the `_start` symbol the linux linker resolves as the entry
-# point; the call and the global read-modify-write give the relocations the lane
-# checks, and the inline-asm `exit` syscall returns the computed sum (45) as the
+# point; the calls and the global read-modify-write give the relocations the lane
+# checks, and the inline-asm `exit` syscall returns the computed sum (53) as the
 # process exit code.
 #[symbol("_start")]
 fun start() {
-    var code: i64 = sum_to(10);
+    var code: i64 = sum_to(10);         # sum 0..9 = 45
     total = total + code;
+    code = code + na(3)::i64;            # 1 << 3 = 8, so code = 53
     asm riscv64 {
         li a7, 93        # __NR_exit
-        ld a0, {code}    # exit code = sum 0..9 = 45
+        ld a0, {code}    # exit code = 53
         ecall
     }
 }

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -9,8 +9,9 @@
 # and qemu-riscv64 (or qemu-riscv64-static) for the exit-code run.
 set -euo pipefail
 
-# the computed exit code the fixture returns (sum 0..9), the qemu e2e asserts it.
-expect_code=45
+# the computed exit code the fixture returns (sum 0..9 plus the const-shift call
+# argument 1 << 3 = 8, i.e. 45 + 8), the qemu e2e asserts it.
+expect_code=53
 
 mach="${1:-mach}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -52,7 +53,7 @@ echo "verifying disassembly of $exe"
 dis="$("$objdump" -d "$exe")"
 echo "$dis" | grep -q 'file format elf64-littleriscv' || fail "objdump did not parse a little-endian rv64 elf"
 echo "$dis" | grep -qi '<unknown>'                    && fail "objdump found an unknown instruction word"
-for mnem in auipc jalr ld sd addi ret ecall; do
+for mnem in auipc jalr ld sd addi sll ret ecall; do
     echo "$dis" | grep -qw "$mnem" || fail "expected mnemonic '$mnem' not in disassembly"
 done
 


### PR DESCRIPTION
## Summary

On `riscv64`, a left-shift whose **value** operand is a constant and whose **amount** is variable (`1 << node`) failed to encode with `encode: expected a register operand` when the result fed a call-argument slot.

`encode_shift` resolved the value operand (rs1) with `req_gpr`, which rejects an immediate. Every other reg-reg ALU encoder in this backend (`encode_alu3`, `encode_addsub`, `encode_compare`, the divide family) materializes an immediate operand through `resolve_source`/`SCRATCH2`. The shift was the lone outlier, so a constant value reached the encoder as a bare immediate.

## Fix

Resolve the shift value operand through `resolve_source(st, ?mi.operands[1], SCRATCH2)`, materializing a constant into the scratch register (`t1`) before the reg-reg `sll`/`srl`/`sra`. This is structurally correct for any `const << var` and covers all three shift forms plus the RV64 word forms. The other reg-reg ALU ops already used `resolve_source` and were never affected.

The minimal repro now encodes as:
```
li   t1, 1
sll  a2, t1, a1
```

## Verification

- The issue repro cross-compiles cleanly for `linux-riscv64` (byte-encodes).
- Freestanding qemu e2e of `const << var`, `const >> var` (logical + arithmetic), and `const - var`/`& `/`|`/`^`/`* var` as call arguments all run to the correct exit code under `qemu-riscv64`.
- New byte-exact encode regression test (`const_value_variable_shift_materializes`).
- Full `mach test .`: 658 passed, 0 failed.
- Self-host fixpoint verified.
- x86_64 / aarch64 unaffected (the change is in the riscv64 backend only).

Closes #1657