### PR TITLE
release: v2.8.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug
+about: Observed behavior contradicts the spec, docs, or obvious intent
+title: ""
+labels: ["bug"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    one or more of frontend, sema, codegen, link, driver, diag, infra
+  target:*  darwin, windows, or aarch64, only when the work is target-specific
+  milestone the track this belongs to
+  flags     critical (a miscompilation, data loss, or release blocker) or blocked, when they apply
+Put relationships in the body, like "Part of #N" or "Depends on #M".
+Use this template for a defect, where the behavior is wrong. Use the Problem template
+when the behavior works as built but is wrong by design. The two are mutually exclusive.
+-->
+
+## What
+
+<!-- A one or two line summary of the defect. -->
+
+## Repro
+
+<!-- The minimal steps or program that triggers it. -->
+
+## Expected
+
+<!-- What should happen, and why. Cite the spec, docs, or intent if it helps. -->
+
+## Actual
+
+<!-- What happens instead, with the exact diagnostic, exit, or wrong output. -->
+
+## Environment
+
+<!-- The triple or target, the toolchain version or commit, and the OS if it matters. -->

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,22 @@
+---
+name: Chore
+about: Mechanical upkeep and release engineering (dep bumps, version rolls, cuts, tags, infra)
+title: ""
+labels: ["chore"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    usually infra or driver, but pick what fits
+  milestone the track this belongs to, if any
+Put relationships in the body, like "Part of #N" or "Depends on #M".
+Use the refactor or docs label instead when one of those fits better.
+-->
+
+## What
+
+<!-- The upkeep task and why it is needed now. -->
+
+## Acceptance
+
+- [ ] <!-- the concrete done state -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,36 @@
+---
+name: Epic
+about: Umbrella issue tracking a family of sub-issues
+title: "epic: "
+labels: ["epic"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    the dominant area or areas of the family
+  target:*  darwin, windows, or aarch64, only when the whole family is target-specific
+  milestone the track this epic represents
+Wire every child as a native sub-issue from the sidebar, and mirror the list in the
+## Children checklist below so the body reads on its own. Write cross-repo children
+as owner/repo#N.
+-->
+
+> ## Status (YYYY-MM-DD)
+>
+> <!-- One paragraph on where the track stands today, what is active, and what comes next.
+>      Keep this block current, since it is the first thing a reader sees. -->
+
+## What
+
+<!-- The goal of the family, why it matters, and the model that ties the children together. -->
+
+## Children
+
+<!-- Mirror the native sub-issues. Markers are [x] done, [ ] todo, and [~] partial. -->
+
+- [ ] #NNNN <!-- short description -->
+
+## Sequencing
+
+<!-- The order things land in and why, including dependencies, what de-risks what, and
+     what can run in parallel. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,26 @@
+---
+name: Feature
+about: New capability, or an extension of an existing one
+title: ""
+labels: ["feature"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    one or more of frontend, sema, codegen, link, driver, diag, infra
+  target:*  darwin, windows, or aarch64, only when the work is target-specific
+  milestone the track this belongs to
+  flags     critical (a release blocker) or blocked, when they apply
+Put relationships in the body, like "Part of #N", "Depends on #M", or "Blocks #N".
+If this is a child of an epic, also add it as a sub-issue on that epic.
+-->
+
+Part of #. Depends on #.
+
+## What
+
+<!-- The capability, why it exists, and the design, with enough detail to implement from. -->
+
+## Acceptance
+
+- [ ] <!-- what must be observably true, and the tests that must pass -->

--- a/.github/ISSUE_TEMPLATE/problem.md
+++ b/.github/ISSUE_TEMPLATE/problem.md
@@ -1,0 +1,32 @@
+---
+name: Problem
+about: A problem with an existing feature's design or behavior (working as built, wrong by design)
+title: ""
+labels: ["problem"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    one or more of frontend, sema, codegen, link, driver, diag, infra
+  target:*  darwin, windows, or aarch64, only when the work is target-specific
+  milestone the track this belongs to
+  flags     critical or blocked, when they apply
+Put relationships in the body, like "Part of #N", "Depends on #M", or "Blocks #N".
+Problem is exclusive with bug. Use this template when the behavior works as built but the
+design is wrong, and use the Bug template for an outright defect.
+-->
+
+Part of #. Depends on #.
+
+## What
+
+<!-- The current design or behavior, why it is wrong, and how that was confirmed. -->
+
+## Fix
+
+<!-- The proper fix as a design change. List the candidate designs and the preferred one
+     with its rationale. Do not propose a workaround. -->
+
+## Acceptance
+
+- [ ] <!-- what must be observably true, and the tests that must pass -->

--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -1,0 +1,32 @@
+---
+name: RFC
+about: Design discussion or request for comment, direction not yet decided
+title: "RFC: "
+labels: ["rfc"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    the area or areas the proposal touches
+  target:*  darwin, windows, or aarch64, only when the work is target-specific
+  milestone the track this belongs to, if any
+Put relationships in the body, like "Part of #N" or "Depends on #M".
+An RFC records an open question. Relabel or close it once the direction is decided and
+the implementation work is cut into feature or problem issues.
+-->
+
+## Problem
+
+<!-- What forces a decision, such as the constraint, gap, or tension. -->
+
+## Proposal
+
+<!-- The proposed direction in enough detail to evaluate, with its limits stated honestly. -->
+
+## Alternatives
+
+<!-- The other directions considered, and why this one is preferred or still open. -->
+
+## Open questions
+
+- <!-- what must be resolved before this can be cut into implementation issues -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,38 @@ jobs:
       - name: cross-compile and byte-verify the macho fixture
         run: bash test/macho/verify.sh "$PWD/m"
 
+  # the freestanding/raw flat-image build path (#1616): builds a compiler from the
+  # PR source, builds the minimal os=freestanding, of=raw x86_64 fixture (which
+  # links straight from the in-memory codegen images, no per-module .o), confirms
+  # the output is a container-free flat binary, then mmaps the position-independent
+  # image and runs it to assert its computed exit code. needs only a C compiler for
+  # the loader harness - no llvm, no qemu.
+  cross-freestanding:
+    name: cross freestanding (raw)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: fetch released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED: mach-*-x86_64-linux.tar.gz
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
+          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: build a compiler from source
+        run: |
+          set -euo pipefail
+          mach dep pull
+          mach build . -o m
+
+      - name: build and run the freestanding raw flat image
+        run: bash test/freestanding/verify.sh "$PWD/m"
+
   build-windows:
     name: build ${{ matrix.target }}
     runs-on: ${{ matrix.runs-on }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2026-06-26
+
+The first working bare-metal build, plus a riscv64 codegen fix surfaced by the
+new backend. The freestanding `raw` object format now has a real flat-image
+build path, so an `os=freestanding, of=raw` target builds end to end.
+
+### Added
+
+- build: a flat-image build path for image-producing object formats. An object
+  format declares through a `produces_image` predicate whether it round-trips
+  through relocatable `.o` files, and an image format (the freestanding `raw`
+  writer) now links straight from the in-memory codegen output, bypassing the
+  per-module `.o` emit/parse round-trip. This is the last gap to a real
+  `os=freestanding, of=raw` build (#1616).
+
+### Fixed
+
+- codegen: a riscv64 variable-amount shift with a constant value operand
+  (`1 << node`) used as a call argument now materializes the constant into a
+  register before the shift instead of failing to encode. The shift was the lone
+  reg-reg ALU encoder not materializing an immediate operand (#1657).
+- diag: the unknown-os diagnostic now lists `freestanding` among the expected
+  values (#1617).
+
 ## [2.7.0] - 2026-06-26
 
 First targets on the retargeting foundation. riscv64 lands end to end as the

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.7.0"
+version = "2.8.0"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1281,6 +1281,14 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
     val te: *driver.TargetEntry = p.target_entry;
     if (te == nil) { print.eprint("error: no target selected\n"); ret 2; }
 
+    # a flat-image object format (`produces_image`) has no relocatable `.o`
+    # container: it cannot emit per-module objects or re-parse them at link time.
+    # link the in-memory codegen images straight into the flat executable instead
+    # of round-tripping through `.o` files.
+    if (p.target.of != nil && p.target.of.produces_image) {
+        ret link_image_artifact(p, emit_obj, verbose, root, out_override, images, out_path);
+    }
+
     # the per-module object tree root: `<root>/<resolved obj template>`.
     var obj_base: [4096]u8;
     if (!resolve_obj_base(p, root, ?obj_base[0], 4096)) {
@@ -1360,6 +1368,96 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
         linker.link(p.s, ?p.target, paths, len, sonames, soname_len, ?artifact[0], linker.LINK_EXE);
     free_paths(p.s.alloc, paths, len, len);
     free_sonames(p.s.alloc, sonames, soname_len);
+    if (R.is_err[bool, str](res_link)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](res_link));
+        print.eprint("\n");
+        ret 1;
+    }
+
+    if (verbose) {
+        print.eprint("output ");
+        print.eprint((?artifact[0])::str);
+        print.eprint("\n");
+    }
+
+    @out_path = dup_cstr(p.s.alloc, ?artifact[0]);
+    ret 0;
+}
+
+# link the in-memory codegen images straight into a flat executable image,
+# bypassing the per-module `.o` emit/parse round-trip
+#
+# The build path for a flat-image object format (`produces_image`): the codegen
+# images are handed to the linker directly (`linker.link_images`), so no
+# relocatable `.o` is written or re-parsed. A flat image is self-contained and
+# has only an executable form, so library mode and `--emit obj` are rejected, and
+# there are no external relocatable link inputs (the format has no parser to
+# consume them). The images are gathered into a contiguous topo-ordered array so
+# the link order matches the on-disk path; the wrapper array is freed afterward,
+# never the images (the caller owns them). Sets `*out_path` to the produced
+# executable path on success.
+# ---
+# p:            the project carrying the module graph and session
+# emit_obj:     reject when set - a flat-image format has no relocatable object output
+# verbose:      write the image count and output path to stderr
+# root:         the resolved project root directory
+# out_override: the `-o` artifact path, or nil to use the resolved path
+# images:       the per-module codegen images, indexed by module id
+# out_path:     receives the owned produced-artifact path on success
+# ret:          0 on success, 1 on a user error, 2 on an internal error
+fun link_image_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
+                        out_override: *u8, images: *of.ObjectImage, out_path: **u8) i64 {
+    val te: *driver.TargetEntry = p.target_entry;
+    if (te == nil) { print.eprint("error: no target selected\n"); ret 2; }
+
+    # a flat image is not a relocatable object, so it has no library form.
+    if (te.mode == driver.MODE_LIBRARY || emit_obj) {
+        print.eprint("error: a flat-image object format produces only executables; library and '--emit obj' outputs are unsupported\n");
+        ret 1;
+    }
+
+    # the executable path: an absolute `-o` is used verbatim; a relative one is
+    # rooted at <root>; otherwise the unit's resolved artifact path is used.
+    var artifact: [4096]u8;
+    if (out_override != nil) {
+        util.path_into(?artifact[0], 4096, root, out_override);
+    }
+    or {
+        val opt_bin: O.Option[str] = intern.lookup(?p.s.interner, p.config.bin_out);
+        if (O.is_none[str](opt_bin) || str_empty(O.unwrap[str](opt_bin))) {
+            print.eprint("error: selected artifact has no output path; set the `out` template in mach.toml\n");
+            ret 1;
+        }
+        join_into_str(?artifact[0], 4096, root, O.unwrap[str](opt_bin));
+    }
+    if (!util.ensure_parents(?artifact[0])) {
+        print.eprint("error: failed to create binary directory\n");
+        ret 2;
+    }
+
+    # gather the topo-ordered images into a contiguous array. each `of.ObjectImage`
+    # is a shallow value carrying borrowed array pointers, so copying it shares the
+    # underlying storage; only this wrapper array is freed, never the images.
+    val len: u32 = p.topo_len;
+    val res_ord: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](p.s.alloc, len::usize);
+    if (R.is_err[*of.ObjectImage, str](res_ord)) { print.eprint("error: out of memory\n"); ret 2; }
+    val ordered: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](res_ord);
+    var i: u32 = 0;
+    for (i < len) {
+        ordered[i] = images[(p.topo[i])::u32];
+        i = i + 1;
+    }
+
+    if (verbose) {
+        print.eprint("link ");
+        print.eu64(len::u64);
+        print.eprint(" image(s)\n");
+    }
+
+    val res_link: R.Result[bool, str] =
+        linker.link_images(p.s, ?p.target, ordered, len, nil::*intern.StrId, 0, ?artifact[0], linker.LINK_EXE);
+    A.deallocate[of.ObjectImage](p.s.alloc, ordered, len::usize);
     if (R.is_err[bool, str](res_link)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[bool, str](res_link));

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -171,30 +171,101 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     if (obj_paths == nil || obj_count == 0) {
         ret R.err[bool, str]("link: no input objects");
     }
-    # a dynamic link is requested when shared dependencies are present and the
-    # output is an executable; libraries/relocatables ignore dependencies.
-    val dynamic: bool = (mode == LINK_EXE) && (soname_count > 0);
 
     val alloc: *A.Allocator = s.alloc;
 
-    # read and parse every input object file into an in-memory image array. the
-    # array and each populated image are torn down on every exit path below. an
+    # read and parse every input object file into an in-memory image array. an
     # `.a` archive input expands into one image per member object, so the parsed
     # image count can exceed the input-path count - `read_objects` reports the
     # true module count through `module_count`.
-    var modules: *of.ObjectImage = nil;
     var module_count: u32 = 0;
     val read_r: R.Result[*of.ObjectImage, str] = read_objects(s, tgt, obj_paths, obj_count, ?module_count);
     if (R.is_err[*of.ObjectImage, str](read_r)) {
         ret R.err[bool, str](R.unwrap_err[*of.ObjectImage, str](read_r));
     }
-    modules = R.unwrap_ok[*of.ObjectImage, str](read_r);
+    val modules: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](read_r);
 
-    # every input resolved to zero modules (e.g. an empty archive or one holding
-    # only bookkeeping members) - there is nothing to link, so reject rather than
-    # emit an empty artifact.
+    # the parsed images are owned here (read from disk), so they are torn down
+    # after linking regardless of outcome.
+    val r: R.Result[bool, str] =
+        link_modules(s, tgt, modules, module_count, sonames, soname_count, out_path, mode);
+    free_modules(alloc, modules, module_count);
+    ret r;
+}
+
+# combine an array of in-memory codegen images into the requested artifact,
+# bypassing the per-module `.o` emit/parse round-trip.
+#
+# the image-producing build path for a flat-image object format
+# (`tgt.of.produces_image` true): the back end's codegen images are linked
+# straight from memory rather than written to relocatable `.o` files and read
+# back through `parse_object`, which a flat-image format has no parser for. the
+# merge, symbol resolution, relocation patching, and segment layout are identical
+# to `link`; only the input source differs. the caller owns `images` and frees
+# them - this never tears them down.
+# ---
+# s:            shared session (allocator, interner, diagnostics)
+# tgt:          active target - selects OS base address, entry symbol, and writers
+# images:       the in-memory codegen images, one per module
+# image_count:  number of images
+# sonames:      interned shared-library sonames to depend on dynamically (or nil)
+# soname_count: number of shared-library dependencies
+# out_path:     null-terminated output file path
+# mode:         executable, relocatable (library), or shared
+# ret:          true once the artifact is written, or an error string
+pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.ObjectImage,
+                    image_count: u32, sonames: *intern.StrId, soname_count: u32,
+                    out_path: *u8, mode: LinkMode) R.Result[bool, str] {
+    if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
+    if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
+    if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
+    if (tgt.os == nil) { ret R.err[bool, str]("link: target has no OS vtable"); }
+    if (mode == LINK_SHARED) {
+        ret R.err[bool, str]("link: shared-object output is not yet supported");
+    }
+    if (images == nil || image_count == 0) {
+        ret R.err[bool, str]("link: no input objects");
+    }
+    ret link_modules(s, tgt, images, image_count, sonames, soname_count, out_path, mode);
+}
+
+# combine an already-built module-image array into the requested artifact.
+#
+# the shared core of `link` (disk inputs read + parsed) and `link_images`
+# (in-memory codegen images): merges symbols (rejecting duplicate strong
+# definitions), lays out the concatenated sections, and either (executable)
+# assigns virtual addresses, patches relocations, and writes page-aligned load
+# segments through `tgt.of.emit_exec`, or (library / relocatable) carries the
+# input relocations forward and writes a single merged object through
+# `obj.emit`. it never owns `modules` - the caller frees them - and frees only
+# its own scratch.
+#
+# DYNAMIC vs STATIC resolution of an undefined `ext` mirrors `link`: with no
+# shared dependencies every undefined `ext` must resolve against an input module
+# or the link fails; with shared dependencies any `ext` left undefined becomes a
+# dynamic import bound at run time, and the executable is emitted through
+# `emit_dyn_exec`.
+# ---
+# s:            shared session (allocator, interner, diagnostics)
+# tgt:          active target - selects OS base address, entry symbol, and writers
+# modules:      the input module images (caller-owned)
+# module_count: number of modules
+# sonames:      interned shared-library sonames to depend on dynamically (or nil)
+# soname_count: number of shared-library dependencies
+# out_path:     null-terminated output file path
+# mode:         executable, relocatable (library), or shared
+# ret:          true once the artifact is written, or an error string
+fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
+                 module_count: u32, sonames: *intern.StrId, soname_count: u32,
+                 out_path: *u8, mode: LinkMode) R.Result[bool, str] {
+    val alloc: *A.Allocator = s.alloc;
+    # a dynamic link is requested when shared dependencies are present and the
+    # output is an executable; libraries/relocatables ignore dependencies.
+    val dynamic: bool = (mode == LINK_EXE) && (soname_count > 0);
+
+    # an empty module set (e.g. an archive holding only bookkeeping members) has
+    # nothing to link, so reject rather than emit an empty artifact.
     if (module_count == 0) {
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str]("link: no input objects");
     }
 
@@ -211,7 +282,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     if (sec_total > 0) {
         val pr: R.Result[*Placement, str] = A.zallocate[Placement](alloc, sec_total::usize);
         if (R.is_err[*Placement, str](pr)) {
-            free_modules(alloc, modules, module_count);
             ret R.err[bool, str](R.unwrap_err[*Placement, str](pr));
         }
         placements = R.unwrap_ok[*Placement, str](pr);
@@ -222,7 +292,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     val br: R.Result[*u32, str] = A.zallocate[u32](alloc, module_count::usize);
     if (R.is_err[*u32, str](br)) {
         free_placements(alloc, placements, sec_total);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[*u32, str](br));
     }
     sec_base = R.unwrap_ok[*u32, str](br);
@@ -231,7 +300,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
         accumulate_sections(s, modules, module_count, ?merged[0], placements, sec_base);
     if (R.is_err[bool, str](acc_r)) {
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[bool, str](acc_r));
     }
 
@@ -253,7 +321,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     if (R.is_err[bool, str](collect_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[bool, str](collect_r));
     }
 
@@ -264,7 +331,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     if (R.is_err[of.ObjectImage, str](img_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[of.ObjectImage, str](img_r));
     }
     out_img = R.unwrap_ok[of.ObjectImage, str](img_r);
@@ -275,7 +341,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[bool, str](build_r));
     }
 
@@ -296,7 +361,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
                 obj.dnit(?out_img);
                 map.dnit[intern.StrId, SymbolLoc](?sym_locs);
                 free_scratch(alloc, placements, sec_total, sec_base, module_count);
-                free_modules(alloc, modules, module_count);
                 ret R.err[bool, str](R.unwrap_err[bool, str](dr));
             }
         }
@@ -308,7 +372,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
             obj.dnit(?out_img);
             map.dnit[intern.StrId, SymbolLoc](?sym_locs);
             free_scratch(alloc, placements, sec_total, sec_base, module_count);
-            free_modules(alloc, modules, module_count);
             ret R.err[bool, str](R.unwrap_err[bool, str](patch_r));
         }
 
@@ -324,7 +387,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
 
         if (R.is_err[bool, str](emit_r)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](emit_r));
@@ -340,7 +402,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[bool, str](carry_r));
     }
 
@@ -349,7 +410,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     obj.dnit(?out_img);
     map.dnit[intern.StrId, SymbolLoc](?sym_locs);
     free_scratch(alloc, placements, sec_total, sec_base, module_count);
-    free_modules(alloc, modules, module_count);
 
     if (R.is_err[bool, str](obj_r)) {
         ret R.err[bool, str](R.unwrap_err[bool, str](obj_r));

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1705,7 +1705,7 @@ fun select_target(p: *Project, t: *TargetEntry) R.Result[bool, str] {
     if (O.is_some[str](of_opt)) { of_name = O.unwrap[str](of_opt); }
 
     if (os.os_id_for(os_name) == os.OS_UNKNOWN) {
-        ret R.err[bool, str](diag_join_named(p.s, "unknown target os name '", t.os_name, "' (expected: linux, darwin, windows)", "unknown target os name"));
+        ret R.err[bool, str](diag_join_named(p.s, "unknown target os name '", t.os_name, "' (expected: linux, darwin, windows, freestanding)", "unknown target os name"));
     }
     if (isa.arch_id_for(isa_name) == isa.ARCH_UNKNOWN) {
         ret R.err[bool, str](diag_join_named(p.s, "unknown target isa name '", t.isa_name, "' (expected: x86_64, aarch64, riscv64)", "unknown target isa name"));

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -554,8 +554,10 @@ fun encode_addsub(st: *encode.EncodeState, mi: *mir.MirInstr, is_sub: bool) R.Re
 # a shift `op rd, rs1, rs2|shamt`. an immediate shift amount uses the immediate form
 # (slli/srli/srai, or the RV64 word slliw/srliw/sraiw), masking the amount to 6 bits
 # (5 for the word form) and folding the srai funct7 into imm[10]; a register amount
-# uses the register form. `funct3` is SLL for left and SRL for right; `is_arith`
-# selects the arithmetic (sign-filling) right shift.
+# uses the register form. the value operand (rs1) is materialized like any other
+# reg-reg ALU operand, so a constant value (`1 << n`) lands in the scratch register
+# rather than reaching the encoder as an immediate. `funct3` is SLL for left and SRL
+# for right; `is_arith` selects the arithmetic (sign-filling) right shift.
 fun encode_shift(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, is_arith: bool) R.Result[bool, str] {
     if (mi.operand_count < 3) { ret R.err[bool, str]("encode: shift missing operands"); }
 
@@ -563,7 +565,7 @@ fun encode_shift(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, is_ari
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
     val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
 
-    val rnr: R.Result[i32, str] = req_gpr(?mi.operands[1]);
+    val rnr: R.Result[i32, str] = resolve_source(st, ?mi.operands[1], SCRATCH2);
     if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
     val rs1: u32 = R.unwrap_ok[i32, str](rnr)::u32;
 
@@ -3275,6 +3277,53 @@ test "mach.lang.target.isa.riscv64.encode:mir_alu_shift_mov_neg_not" {
     if (read_word(?st.buf, 4) != 0x40B00533) { bad = 1; }
     encode_not(?st, ?mv);
     if (read_word(?st.buf, 8) != 0xFFF5C513) { bad = 1; }
+
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# a variable-amount shift with a CONSTANT value operand (`1 << n`) materializes the
+# value into the scratch register (t1 / x6) before the reg-reg shift, exactly like
+# every other reg-reg ALU operand - it does not reach the encoder as a bare
+# immediate. regression for the call-argument `const << var` encode failure. the
+# `li t1, 1` (addi t1, x0, 1) = 0x00100313 precedes each shift; result a0 = x10,
+# count a2 = x12. byte-exact against llvm-mc.
+test "mach.lang.target.isa.riscv64.encode:const_value_variable_shift_materializes" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+
+    var mi: mir.MirInstr;
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(10);   # rd = a0
+    ops[1] = mir.op_imm(1);     # value = 1 (constant, must be materialized)
+    ops[2] = mir.op_preg(12);   # count = a2 (runtime)
+    mi.operands = ?ops[0]; mi.operand_count = 3; mi.width = 8;
+
+    # sll a0, t1, a2 = 0x00c31533, preceded by li t1, 1 = 0x00100313.
+    encode_shift(?st, ?mi, F3_SLL, false);
+    if (read_word(?st.buf, 0) != 0x00100313) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x00C31533) { bad = 1; }
+
+    # srl a0, t1, a2 = 0x00c35533 (logical right).
+    st.buf.len = 0;
+    encode_shift(?st, ?mi, F3_SRL, false);
+    if (read_word(?st.buf, 0) != 0x00100313) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x00C35533) { bad = 1; }
+
+    # sra a0, t1, a2 = 0x40c35533 (arithmetic right).
+    st.buf.len = 0;
+    encode_shift(?st, ?mi, F3_SRL, true);
+    if (read_word(?st.buf, 0) != 0x00100313) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x40C35533) { bad = 1; }
+
+    # the RV64 word form keeps the same value materialization: sllw a0, t1, a2 = 0x00c3153b.
+    st.buf.len = 0;
+    mi.width = 4;
+    encode_shift(?st, ?mi, F3_SLL, false);
+    if (read_word(?st.buf, 0) != 0x00100313) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x00C3153B) { bad = 1; }
 
     encode.buf_dnit(?st.buf);
     ret bad;

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -412,21 +412,32 @@ pub def DynExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegm
 # through `emit_exec` (or `emit_dyn_exec` for a dynamic link). Each format maps
 # the abstract `RK_*` kinds to its own machine relocation types internally. It
 # never branches on `id`.
+#
+# `produces_image` declares whether the format is a container-free flat image
+# (true) or a relocatable-object format that round-trips through `.o` files
+# (false). The build driver dispatches on it: a relocatable format codegens each
+# module to a `.o` (`emit_object`), then the linker reads every input back
+# (`parse_object`) before laying out the executable; a flat-image format has no
+# relocatable container, so the driver links straight from the in-memory codegen
+# images and never calls `emit_object`/`parse_object`.
 # ---
-# id:            object-format id (one of OF_*)
-# name:          format name ("elf", "coff", "macho"); an immutable str constant
-# emit_object:   serializes an ObjectImage to a relocatable object file
-# parse_object:  reads a relocatable object file into an ObjectImage
-# emit_exec:     serializes laid-out load segments into a static executable
-# emit_dyn_exec: serializes them into a dynamically-linked executable, or nil
-#                when the format has no dynamic-link writer yet
+# id:             object-format id (one of OF_*)
+# name:           format name ("elf", "coff", "macho", "raw"); an immutable str constant
+# produces_image: true for a container-free flat image, false for a relocatable
+#                 object format that round-trips through `.o` files
+# emit_object:    serializes an ObjectImage to a relocatable object file
+# parse_object:   reads a relocatable object file into an ObjectImage
+# emit_exec:      serializes laid-out load segments into a static executable
+# emit_dyn_exec:  serializes them into a dynamically-linked executable, or nil
+#                 when the format has no dynamic-link writer yet
 pub rec OfVTable {
-    id:            u32;
-    name:          str;
-    emit_object:   WriterFn;
-    parse_object:  ParserFn;
-    emit_exec:     ExecFn;
-    emit_dyn_exec: DynExecFn;
+    id:             u32;
+    name:           str;
+    produces_image: bool;
+    emit_object:    WriterFn;
+    parse_object:   ParserFn;
+    emit_exec:      ExecFn;
+    emit_dyn_exec:  DynExecFn;
 }
 
 # maximum number of object-format implementations an OfRegistry holds

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2734,6 +2734,7 @@ var coff_vtable: of.OfVTable;
 pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
     coff_vtable.id               = of.OF_COFF;
     coff_vtable.name             = "coff";
+    coff_vtable.produces_image   = false;
     coff_vtable.emit_object      = coff_emit_object;
     coff_vtable.parse_object     = coff_parse_object;
     coff_vtable.emit_exec        = coff_emit_exec;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -892,12 +892,13 @@ var elf_vtable: of.OfVTable;
 # reg: the object-format registry to install the vtable into
 # ret: ok(true) on success
 pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
-    elf_vtable.id            = of.OF_ELF;
-    elf_vtable.name          = "elf";
-    elf_vtable.emit_object   = emit_object;
-    elf_vtable.parse_object  = parse_object;
-    elf_vtable.emit_exec     = emit_exec;
-    elf_vtable.emit_dyn_exec = emit_dyn_exec;
+    elf_vtable.id             = of.OF_ELF;
+    elf_vtable.name           = "elf";
+    elf_vtable.produces_image = false;
+    elf_vtable.emit_object    = emit_object;
+    elf_vtable.parse_object   = parse_object;
+    elf_vtable.emit_exec      = emit_exec;
+    elf_vtable.emit_dyn_exec  = emit_dyn_exec;
 
     of.register(reg, ?elf_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -950,12 +950,13 @@ var macho_vtable: of.OfVTable;
 # reg: the object-format registry to install the vtable into
 # ret: ok(true) on success
 pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
-    macho_vtable.id            = of.OF_MACHO;
-    macho_vtable.name          = "macho";
-    macho_vtable.emit_object   = emit_object;
-    macho_vtable.parse_object  = parse_object;
-    macho_vtable.emit_exec     = emit_exec;
-    macho_vtable.emit_dyn_exec = nil::of.DynExecFn;
+    macho_vtable.id             = of.OF_MACHO;
+    macho_vtable.name           = "macho";
+    macho_vtable.produces_image = false;
+    macho_vtable.emit_object    = emit_object;
+    macho_vtable.parse_object   = parse_object;
+    macho_vtable.emit_exec      = emit_exec;
+    macho_vtable.emit_dyn_exec  = nil::of.DynExecFn;
 
     of.register(reg, ?macho_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -215,12 +215,13 @@ var raw_vtable: of.OfVTable;
 # reg: object-format registry to install the vtable into
 # ret: ok(true) on success
 pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
-    raw_vtable.id            = of.OF_RAW;
-    raw_vtable.name          = "raw";
-    raw_vtable.emit_object   = emit_object;
-    raw_vtable.parse_object  = parse_object;
-    raw_vtable.emit_exec     = emit_exec;
-    raw_vtable.emit_dyn_exec = emit_dyn_exec;
+    raw_vtable.id             = of.OF_RAW;
+    raw_vtable.name           = "raw";
+    raw_vtable.produces_image = true;
+    raw_vtable.emit_object    = emit_object;
+    raw_vtable.parse_object   = parse_object;
+    raw_vtable.emit_exec      = emit_exec;
+    raw_vtable.emit_dyn_exec  = emit_dyn_exec;
 
     of.register(reg, ?raw_vtable);
     ret R.ok[bool, str](true);

--- a/test/freestanding/mach.toml
+++ b/test/freestanding/mach.toml
@@ -1,0 +1,19 @@
+[project]
+id = "rawprobe"
+name = "rawprobe"
+version = "0.0.0"
+src = "src"
+target = "freestanding-x86_64"
+out = "out/{target}/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.freestanding-x86_64]
+isa = "x86_64"
+os  = "freestanding"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+
+[bin.rawprobe]
+entry = "main.mach"

--- a/test/freestanding/src/main.mach
+++ b/test/freestanding/src/main.mach
@@ -1,0 +1,29 @@
+# freestanding x86_64 flat-image (raw) build fixture.
+#
+# no OS and no std runtime: the entry symbol is defined here and the program
+# exits through a raw `exit` syscall. it proves the object-centric build path now
+# reaches a flat image for an `os=freestanding, of=raw` target - codegen builds
+# an in-memory image per module, the driver links straight from those images (no
+# per-module `.o` round-trip, which a flat image has no parser for), and the raw
+# writer lays the single load segment out as a container-free binary entered at
+# its base. the body sums 0..9 with an intra-function counted loop and exits with
+# the result (45), so running the image asserts the emitted machine code is
+# correct end to end.
+#
+# `start` is the only function, so its code begins at file offset 0 (the image
+# base), satisfying raw's entry-at-base contract.
+
+#[symbol("_start")]
+fun start() {
+    var code: i64 = 0;
+    var i: i64 = 0;
+    for (i < 10) {
+        code = code + i;
+        i = i + 1;
+    }
+    asm x86_64 {
+        mov rax, 60      # __NR_exit
+        mov rdi, {code}  # exit code = sum 0..9 = 45
+        syscall
+    }
+}

--- a/test/freestanding/verify.sh
+++ b/test/freestanding/verify.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# build the freestanding x86_64 fixture as a raw flat image, verify the build
+# bypassed the per-module .o round-trip, confirm the output is a container-free
+# flat binary (not an ELF), then load and run it to assert its exit code. proves
+# an `os=freestanding, of=raw` program builds end to end to a working flat image
+# (mach#1616): codegen -> in-memory image link -> raw emit_exec.
+#
+# usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
+#
+# requires: a C compiler (cc) for the loader harness. the harness mmaps the flat
+# image into an executable page and calls it; the image is position-independent
+# and exits via a raw `exit` syscall, so it runs at any load address and the
+# harness process exits with the image's computed code.
+set -euo pipefail
+
+# the exit code the fixture computes (sum 0..9) and exits with.
+expect_code=45
+
+mach="${1:-mach}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+target="freestanding-x86_64"
+img="out/$target/rawprobe"
+
+echo "building flat image for $target with $mach"
+rm -rf out
+"$mach" build . --target "$target" --profile debug
+
+[ -f "$img" ] || fail "flat image was not produced at $img"
+
+# a flat-image build links straight from the in-memory codegen images, so no
+# per-module relocatable object is ever written.
+if find out -name '*.o' | grep -q .; then
+    fail "a .o was written - the per-module round-trip was not bypassed"
+fi
+
+# the image is a container-free flat binary: it must not carry an ELF header.
+magic="$(head -c4 "$img" | od -An -tx1 | tr -d ' \n')"
+[ "$magic" != "7f454c46" ] || fail "output is an ELF, not a flat image"
+
+# the first byte is the entry function's code (the image is entered at its base).
+[ -s "$img" ] || fail "flat image is empty"
+
+echo "loading and running the flat image"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+cat > "$work/harness.c" <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+int main(int argc, char** argv) {
+    FILE* f = fopen(argv[1], "rb");
+    if (!f) { perror("open"); return 2; }
+    fseek(f, 0, SEEK_END); long n = ftell(f); fseek(f, 0, SEEK_SET);
+    void* p = mmap(NULL, n, PROT_READ | PROT_WRITE | PROT_EXEC,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (p == MAP_FAILED) { perror("mmap"); return 2; }
+    if (fread(p, 1, n, f) != (size_t)n) { return 2; }
+    fclose(f);
+    ((void (*)(void))p)();
+    return 0; /* unreachable: the flat image exits via syscall */
+}
+EOF
+cc -O2 -o "$work/harness" "$work/harness.c" || fail "could not build the loader harness"
+
+set +e
+"$work/harness" "$img"
+code=$?
+set -e
+[ "$code" -eq "$expect_code" ] || fail "exit code $code, expected $expect_code"
+
+echo "OK: os=freestanding, of=raw builds a working flat image that runs to exit code $expect_code"

--- a/test/riscv64/src/main.mach
+++ b/test/riscv64/src/main.mach
@@ -3,9 +3,11 @@
 # no std runtime is linked: the entry symbol is defined here directly. the body
 # exercises the full byte path the backend emits - a counted loop (intra-function
 # B-type and J-type branch fixups), a direct call (R_RISCV_CALL_PLT), a global
-# load + store (R_RISCV_PCREL_HI20 with LO12_I and LO12_S), and an inline-asm exit
-# syscall (the only way to emit `ecall`). the exit code is the computed sum, so the
-# qemu e2e proves the whole pipeline runs end to end.
+# load + store (R_RISCV_PCREL_HI20 with LO12_I and LO12_S), a constant-valued
+# variable-amount shift used as a call argument (`1 << node`, which must
+# materialize the constant value into a register before the reg-reg `sll`), and an
+# inline-asm exit syscall (the only way to emit `ecall`). the exit code is the
+# computed sum, so the qemu e2e proves the whole pipeline runs end to end.
 
 var total: i64 = 0;
 
@@ -21,17 +23,27 @@ fun sum_to(n: i64) i64 {
     ret acc;
 }
 
+# a six-argument sum so its caller spills the surplus arguments through registers.
+fun g(a: u64, b: u64, c: u64, d: u64, e: u64, h: u64) u64 { ret a + b + c + d + e + h; }
+
+# the const-shift-as-call-argument pattern (#1657): the value operand `1` is a
+# constant and the amount `node` is a runtime parameter, so the backend must
+# materialize the constant into a register before the reg-reg `sll`. before the fix
+# this failed to encode (`encode: expected a register operand`) on this call path.
+fun na(node: u64) u64 { ret g(0, 1 << node, 0, 0, 0, 0); }
+
 # the program entry. the `_start` symbol the linux linker resolves as the entry
-# point; the call and the global read-modify-write give the relocations the lane
-# checks, and the inline-asm `exit` syscall returns the computed sum (45) as the
+# point; the calls and the global read-modify-write give the relocations the lane
+# checks, and the inline-asm `exit` syscall returns the computed sum (53) as the
 # process exit code.
 #[symbol("_start")]
 fun start() {
-    var code: i64 = sum_to(10);
+    var code: i64 = sum_to(10);         # sum 0..9 = 45
     total = total + code;
+    code = code + na(3)::i64;            # 1 << 3 = 8, so code = 53
     asm riscv64 {
         li a7, 93        # __NR_exit
-        ld a0, {code}    # exit code = sum 0..9 = 45
+        ld a0, {code}    # exit code = 53
         ecall
     }
 }

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -9,8 +9,9 @@
 # and qemu-riscv64 (or qemu-riscv64-static) for the exit-code run.
 set -euo pipefail
 
-# the computed exit code the fixture returns (sum 0..9), the qemu e2e asserts it.
-expect_code=45
+# the computed exit code the fixture returns (sum 0..9 plus the const-shift call
+# argument 1 << 3 = 8, i.e. 45 + 8), the qemu e2e asserts it.
+expect_code=53
 
 mach="${1:-mach}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -52,7 +53,7 @@ echo "verifying disassembly of $exe"
 dis="$("$objdump" -d "$exe")"
 echo "$dis" | grep -q 'file format elf64-littleriscv' || fail "objdump did not parse a little-endian rv64 elf"
 echo "$dis" | grep -qi '<unknown>'                    && fail "objdump found an unknown instruction word"
-for mnem in auipc jalr ld sd addi ret ecall; do
+for mnem in auipc jalr ld sd addi sll ret ecall; do
     echo "$dis" | grep -qw "$mnem" || fail "expected mnemonic '$mnem' not in disassembly"
 done
 


### PR DESCRIPTION
Integration merge of dev into main for the v2.8.0 release.

Since v2.7.0:
- build: flat-image build path (`produces_image` predicate) enabling real `os=freestanding, of=raw` builds (#1616)
- codegen: riscv64 const-valued variable shift as a call argument now encodes (#1657)
- diag: unknown-os diagnostic lists freestanding (#1617)

Tag v2.8.0 will be pushed on the merge commit. v2.8.0 ships the #1657 fix the mach-std riscv64-linux runtime CI needs (#307).