### PR TITLE
release: v2.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,13 +176,14 @@ jobs:
       - name: cross-compile, byte-verify, and run the rv64 fixture
         run: bash test/riscv64/verify.sh "$PWD/m"
 
-  # the Darwin triples are cross-compile-only here: the Darwin runtime (#1178) is
-  # a later slice, so the compiler cannot be built or self-tested for darwin yet.
-  # this lane builds a Mach-O-capable compiler from the PR source, cross-compiles
-  # the freestanding fixture for x86_64-darwin and aarch64-darwin, and byte-verifies
-  # the emitted Mach-O object and executable with the llvm tools. there is no
-  # execution step: Darwin binaries cannot run on the Linux host, and a Darwin exit
-  # needs the libSystem runtime the #1178 slice adds.
+  # the Darwin triples are cross-compile-only here: the compiler cannot run on the
+  # Linux host, so it is not built or self-tested for darwin. this lane builds a
+  # Mach-O-capable compiler from the PR source, cross-compiles the freestanding
+  # fixtures for x86_64-darwin and aarch64-darwin, and byte-verifies both the static
+  # (LC_UNIXTHREAD) and the dynamic (LC_LOAD_DYLINKER + LC_LOAD_DYLIB + dyld bind +
+  # LC_DYSYMTAB) executables with the llvm tools. there is no execution step: Darwin
+  # binaries cannot run on the Linux host, and an arm64 Darwin binary additionally
+  # needs a code signature this writer does not emit.
   cross-darwin:
     name: cross darwin (macho)
     runs-on: ubuntu-latest
@@ -212,7 +213,7 @@ jobs:
           mach dep pull
           mach build . -o m
 
-      - name: cross-compile and byte-verify the macho fixture
+      - name: cross-compile and byte-verify the macho fixtures
         run: bash test/macho/verify.sh "$PWD/m"
 
   build-windows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.0] - 2026-06-27
+
+Darwin executables, the constant-time secret qualifier in the type checker, and
+the riscv64 backend hardened against real code. macOS now has working dynamic
+executables, completing both Darwin triples, and a sweep driven by compiling and
+running real std under qemu closed every riscv64 codegen gap real programs hit.
+No breaking changes.
+
+### Added
+
+- target: a macOS / Darwin OS substrate plus Mach-O dynamic executables (an
+  `emit_dyn_exec` that writes `LC_LOAD_DYLINKER`, `LC_LOAD_DYLIB`, an
+  `LC_DYLD_INFO_ONLY` bind stream, `LC_SYMTAB`/`LC_DYSYMTAB`, `LC_UNIXTHREAD`,
+  and per-arch import stubs), completing the `x86_64-darwin` and `aarch64-darwin`
+  cross-compile triples. Byte-verified static and dynamic for both (#1178).
+- target: riscv64 RV64A atomic inline-asm mnemonics, `lr`/`sc`, the `amo*`
+  family, the `.aq`/`.rl`/`.aqrl` ordering suffixes, and `pause`, so atomic
+  read-modify-write can be expressed for the riscv64 std atomics and runtime
+  (#1668).
+- sema: constant-time secret-qualifier flow typing. The `^` qualifier carries a
+  public-to-secret lattice (public coerces up, any secret operand taints the
+  result), the type checker gates what a leakage model can observe (no secret
+  branch condition, memory index, or variable-latency operand), `:^` is the only
+  downgrade, and secret pointers are welded and non-launderable. Type-checking
+  only, with codegen taint a later step (#1645, epic #1643).
+
+### Fixed
+
+- codegen(riscv64): long-branch relaxation. An out-of-range B-type conditional
+  becomes an inverted guard plus a `jal`, and an out-of-range `jal` becomes an
+  `auipc`+`jalr` trampoline, resolved by a per-function relaxation fixpoint.
+  Large functions no longer fail to encode (#1666).
+- codegen(riscv64): local frame slots no longer overlap the saved ra/s0 record,
+  fixing a silent SIGSEGV for any function with an address-taken or spilled local
+  (#1670).
+- codegen(riscv64): 32-bit `and`/`or`/`xor` now encode full-register ops instead
+  of nonexistent word-group instructions, fixing a SIGILL (#1672).
+
 ## [2.8.0] - 2026-06-26
 
 The first working bare-metal build, plus a riscv64 codegen fix surfaced by the

--- a/doc/language/README.md
+++ b/doc/language/README.md
@@ -31,6 +31,7 @@ neighboring links; start from the index below.
 
 - [literals.md](literals.md) — numeric, char, string
 - [types.md](types.md) — primitive grammar, compound types
+- [secrecy.md](secrecy.md) — the `^` secret qualifier, flow typing, gates, `:^`
 - [operators.md](operators.md) — arithmetic, bitwise, comparison, logical, pointer, cast
 - [expressions.md](expressions.md) — construction, access, calls, generic instantiation
 

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -408,8 +408,10 @@ Notes:
 - `^T` marks `T` as carrying secret data for the constant-time guarantee
   (#1643). It is a prefix qualifier binding to the type immediately to its
   right, so it nests with `*` and `[N]` in any order (`*^u8`, `^*u8`,
-  `[N]^u8`). The grammar accepts it in every type position; its flow-typing
-  semantics are not yet enforced (tracked by #1645).
+  `[N]^u8`). The grammar accepts it in every type position. Its flow-typing
+  semantics - the secrecy lattice and join, the leakage-model gates, and the
+  welded-storage pointer rules - are enforced by sema (#1645) and documented in
+  [secrecy.md](secrecy.md).
 - `*T` is a pointer; the untyped pointer type is the primitive name `ptr`
   (an ordinary `named-type`, not its own syntax).
 - `[N]T` is a fixed-length array; `N` is a full expression (a comptime
@@ -487,12 +489,13 @@ cast         ::= ( "::" | ":~" ) type
 ```
 
 `::` is a value conversion and `:~` a same-size bit reinterpret; see
-[operators.md](operators.md#cast). `:^` strips the `^` secret qualifier from
-the operand's type (#1643): a bare `:^` needs no target, while `:^Type` takes
-an optional named target for parallelism with `:~Type`. A non-`named-type`
-lead (`*`, `[`, ...) after `:^` leaves a bare strip so it still binds as a
-multiply/index on the stripped value. Its semantics are not yet enforced
-(tracked by #1645). All three bind as postfix.
+[operators.md](operators.md#cast). Neither `::` nor `:~` may add or drop the
+`^` secret qualifier. `:^` is the only downgrade: it strips `^` from the
+operand's type, producing a new public value (#1643, [secrecy.md](secrecy.md)).
+A bare `:^` needs no target, while `:^Type` names the operand's stripped public
+type (`:^` never reinterprets storage). A non-`named-type` lead (`*`, `[`, ...)
+after `:^` leaves a bare strip so it still binds as a multiply/index on the
+stripped value. All three bind as postfix.
 
 Disambiguating a postfix `[`: a bracket whose matching `]` is **not** followed
 by `(` is always an index `obj[idx]`. When it **is** followed by `(`, the

--- a/doc/language/operators.md
+++ b/doc/language/operators.md
@@ -104,7 +104,12 @@ val b: u64 = 1.5:~u64;          # 0x3FF8000000000000 (raw IEEE-754 bits)
 val f: f64 = b:~f64;            # 1.5                (bits read back as a float)
 ```
 
+Neither `::` nor `:~` may add or drop the `^` secret qualifier, and neither can
+erase a secret-welded pointer to `ptr`. The only downgrade is the `:^` strip
+cast. See [secrecy.md](secrecy.md).
+
 ## See also
 
 - [expressions.md](expressions.md) — how operators compose into expressions
 - [types.md](types.md) — which types support which operators
+- [secrecy.md](secrecy.md) — the `^` secret qualifier and the `:^` strip cast

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -1,0 +1,103 @@
+# `^` — the secret qualifier
+
+`^T` marks a type as carrying secret data for Mach's constant-time guarantee.
+Sema tracks secrecy as an information-flow discipline: secret data may move and
+be stored, but it may never reach a position a classical leakage model observes
+(a branch, a memory address, a variable-latency instruction). This page covers
+the flow-typing rules. The grammar lives in [grammar.md](grammar.md); the
+`#[oblivious]` codegen contract that turns these types into a per-build proof is
+separate.
+
+## Secrecy lattice
+
+There are two secrecy levels in a two-point lattice: public is the bottom,
+secret the top. `^` lifts a type to secret and binds to the type immediately to
+its right, so it nests with `*` and `[N]` in any order: `^u32`, `*^u8`, `^*u8`,
+`[N]^u8`, `^MyRec`. Doubling collapses: `^^T` is `^T`.
+
+A public value coerces *up* to secret wherever a secret is expected, with no
+syntax:
+
+```mach
+fun up(p: u32) ^u32 { ret p; }      # public u32 flows into a secret slot
+```
+
+The reverse never happens implicitly. The only downgrade is the explicit `:^`
+strip below.
+
+## Join
+
+Any operation with a secret operand yields a secret result. Taint joins across
+arithmetic, bitwise, shift, and comparison operators, and through a value read
+out of a secret container:
+
+```mach
+fun mix(a: ^u32, b: u32) ^u32 { ret a + b; }    # ^u32 + u32 -> ^u32
+rec Key { d: ^[32]u8; }
+fun first(k: Key) ^u8 { ret k.d[0]; }            # element of a secret array is ^u8
+```
+
+`&T` of a `^T` value is the public pointer `*^T` (the address is public, the
+pointee secret), and dereferencing `*^T` recovers the secret `^T`.
+
+## Gates
+
+A secret may not reach a position the leakage model observes. Each is a compile
+error decided by operand type:
+
+- a secret branch or loop condition (`if`, `for`)
+- a secret short-circuiting `&&` / `||` operand (it controls a branch)
+- a secret memory index (`table[i]` with `i` secret)
+- a secret operand of the always-variable-latency `/` or `%`
+
+```mach
+fun leak(a: ^u32, t: *u8) u8 {
+    if (a) { ret 1; }       # error: secret value used as a branch condition
+    ret t[a];               # error: secret value used as a memory index
+}
+```
+
+Floating-point operations (gated by default) and integer multiply (gated per the
+target's constant-time capability) join these once the codegen taint contract
+lands.
+
+## Downgrade with `:^`
+
+`:^` is the only way to remove `^`. It produces a new public value and never
+reinterprets storage in place:
+
+```mach
+fun publish(a: ^u32) u32 { ret a:^; }       # bare strip
+fun publish2(a: ^u32) u32 { ret a:^u32; }   # explicit target names the public type
+```
+
+`:^` peels exactly the outer qualifier, so it can never launder a welded pointee
+(`*^T` stays `*^T`). `::` and `:~` may neither add nor drop `^`.
+
+## Welded-storage pointers
+
+Secrecy is fixed at declaration and is non-launderable, which makes the
+public/secret aliasing leak unconstructable with no alias analysis:
+
+- a `^T` is stored only through a `*^T`, never a `*T` (the lattice forbids the
+  downgrade)
+- a secret-welded pointer cannot be erased to the untyped `ptr`
+- a `uni`'s overlapping variants must agree on secrecy
+
+```mach
+fun erase(p: *^u8) ptr { ret p; }     # error: cannot erase a secret pointer to ptr
+uni Bad { a: ^u32; b: u32; }          # error: variants disagree on secrecy
+```
+
+## Trusted base
+
+The only secret-to-public crossings are the explicit `:^` cast and inline `asm`
+blocks (which a type system cannot check). Everything else is enforced. A proof
+is always relative to a leakage model. Its fidelity to real silicon is
+empirical.
+
+## See also
+
+- [types.md](types.md) — the compound type grammar `^` qualifies
+- [operators.md](operators.md) — the `::` / `:~` casts that preserve secrecy
+- [grammar.md](grammar.md) — the formal grammar of `^` and `:^`

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -46,7 +46,8 @@ A secret may not reach a position the leakage model observes. Each is a compile
 error decided by operand type:
 
 - a secret branch or loop condition (`if`, `for`)
-- a secret short-circuiting `&&` / `||` operand (it controls a branch)
+- a secret left operand of a short-circuiting `&&` / `||` (it is the branch the
+  operator keys on; a secret right operand only taints the result)
 - a secret memory index (`table[i]` with `i` secret)
 - a secret operand of the always-variable-latency `/` or `%`
 

--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -78,5 +78,6 @@ val r:  i64   = op(2, 3);
 
 ## See also
 
+- [secrecy.md](secrecy.md) — the `^` secret qualifier over any of these types
 - [operators.md](operators.md) — what operations work on each type
 - [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`, `$align_of`

--- a/doc/language/uni.md
+++ b/doc/language/uni.md
@@ -33,6 +33,11 @@ pub uni Maybe[T] {
 A `uni`'s size is the size of its largest field, plus any alignment
 padding.
 
+A `uni`'s overlapping variants must agree on secrecy: every field is either
+secret (`^`) or every field is public. A mixed union would let the same storage
+be read at two secrecy classifications, the aliasing leak the welded-storage
+rules forbid. See [secrecy.md](secrecy.md).
+
 ## Discriminated values — by convention
 
 Mach has no tagged-union construct and no pattern-matching dispatch.
@@ -57,3 +62,4 @@ the composed form already expresses honestly.
 
 - [rec.md](rec.md) — the discriminator-and-payload outer shape
 - [statements.md](statements.md) — `if`/`or` chains for discrimination
+- [secrecy.md](secrecy.md) — why overlapping variants must agree on secrecy

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.8.0"
+version = "2.9.0"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1740,6 +1740,20 @@ fun resolve_and_store_input(p: *driver.Project, tok: *u8, root: *u8, argc: usize
         ret append_soname(p, dll_basename(tok), sonames, soname_len);
     }
 
+    # a Darwin `.dylib` is a Mach-O LC_LOAD_DYLIB dependency named by its install
+    # name, resolved by dyld at run time. like a `.dll` it is recorded by basename
+    # with no on-disk probe (a system dylib is absent on a cross host); only a
+    # Mach-O target consumes a dylib dependency, so any other format is rejected.
+    if (is_dylib_path(tok)) {
+        if (p.target.of_id != of.OF_MACHO) {
+            print.eprint("error: '");
+            print.eprint(tok::str);
+            print.eprint("' is a Mach-O dylib; .dylib inputs require a Mach-O target\n");
+            ret 1;
+        }
+        ret append_soname(p, dll_basename(tok), sonames, soname_len);
+    }
+
     var found: bool = resolve_input_into(tok, argc, argv, buf, cap);
 
     # a relative explicit path that misses the working directory is retried rooted
@@ -1954,6 +1968,27 @@ fun is_dll_path(tok: *u8) bool {
     val l2: u8 = tok[n - 2] | 0x20;
     val l3: u8 = tok[n - 1] | 0x20;
     ret d == '.' && l1 == 'd' && l2 == 'l' && l3 == 'l';
+}
+
+# whether a link-input token names a Mach-O `.dylib` shared library
+#
+# A `.dylib` is the Darwin counterpart of a Windows `.dll`: dyld resolves it by
+# its LC_LOAD_DYLIB install name at run time, so it is recorded by basename with
+# no on-disk probe (a system dylib like libSystem is absent on a cross host).
+# ---
+# tok: the token to classify
+# ret: true when `tok` ends in `.dylib` (case-insensitive)
+fun is_dylib_path(tok: *u8) bool {
+    if (tok == nil) { ret false; }
+    val n: usize = str_len(tok::str);
+    if (n < 6) { ret false; }
+    val d:  u8 = tok[n - 6];
+    val l1: u8 = tok[n - 5] | 0x20;
+    val l2: u8 = tok[n - 4] | 0x20;
+    val l3: u8 = tok[n - 3] | 0x20;
+    val l4: u8 = tok[n - 2] | 0x20;
+    val l5: u8 = tok[n - 1] | 0x20;
+    ret d == '.' && l1 == 'd' && l2 == 'y' && l3 == 'l' && l4 == 'i' && l5 == 'b';
 }
 
 # the final path component of a DLL path, stripping both POSIX `/` and Windows

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -725,13 +725,14 @@ fun patch_branches(st: *EncodeState, hooks: *EncodeHooks) R.Result[bool, str] {
 #
 # An unrecorded target is a backend bug (a branch to a block the encoder never
 # emitted), rejected loudly rather than resolved to offset 0 (which would be a
-# branch into the first function's middle).
+# branch into the first function's middle). Public so an ISA's branch-relaxation
+# pass can resolve a branch's current target offset while it grows the text.
 # ---
 # st:       the state holding the recorded block offsets
 # fn_base:  text offset of the owning function's first block
 # block_id: the function-local block id to resolve
 # ret:      the block's `.text` offset, or an error when it was never recorded
-fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) R.Result[u32, str] {
+pub fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) R.Result[u32, str] {
     var i: u32 = 0;
     for (i < st.block_count) {
         if (st.blocks[i].fn_text_base == fn_base && st.blocks[i].block_id == block_id) {
@@ -740,6 +741,84 @@ fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) R.Result[u32, st
         i = i + 1;
     }
     ret R.err[u32, str]("encode: branch target block was never recorded");
+}
+
+# open an `nbytes` gap at byte offset `pos` in the encoded text and keep every
+# recorded offset consistent
+#
+# Shifts the bytes in `[pos, len)` up by `nbytes` (growing the sink as needed),
+# zero-fills the opened gap, and advances by `nbytes` every recorded offset at or
+# past `pos`: block offsets, branch-fixup patch / next-ip / function-base fields,
+# symbol-mark offsets, and relocation offsets. This is the ISA-general mechanism a
+# branch-relaxation pass uses to grow an out-of-range branch into a longer
+# sequence while leaving the fixup, block, symbol, and relocation tables pointing
+# at the right instructions. An entry strictly before `pos` is untouched, so the
+# relaxing branch's own placeholder word (emitted before the gap) keeps its
+# position while the instructions after it slide down. The function's own base
+# offset shifts only when the whole function sits at or past `pos`, so opening a
+# gap inside a function leaves its base put and moves only the blocks after the
+# gap.
+# ---
+# st:     the encode state whose text and offset tables are adjusted
+# pos:    byte offset at which the gap opens
+# nbytes: width of the gap (the number of bytes the tail slides down)
+# ret:    ok(true) on success, or an allocation error from growing the sink
+pub fun insert_text(st: *EncodeState, pos: u32, nbytes: u32) R.Result[bool, str] {
+    if (nbytes == 0) { ret R.ok[bool, str](true); }
+    val p: usize = pos::usize;
+    val n: usize = nbytes::usize;
+    if (p > st.buf.len) {
+        ret R.err[bool, str]("encode: text-gap offset is past the end of the buffer");
+    }
+
+    val need: usize = st.buf.len + n;
+    if (need > st.buf.cap) {
+        var new_cap: usize = BYTEBUF_INIT_CAP;
+        if (st.buf.cap > 0) { new_cap = st.buf.cap; }
+        for (new_cap < need) { new_cap = new_cap * 2; }
+        val res_realloc: R.Result[*u8, str] = A.reallocate[u8](st.buf.alloc, st.buf.data, st.buf.cap, new_cap);
+        if (R.is_err[*u8, str](res_realloc)) { ret R.err[bool, str](R.unwrap_err[*u8, str](res_realloc)); }
+        st.buf.data = R.unwrap_ok[*u8, str](res_realloc);
+        st.buf.cap  = new_cap;
+    }
+
+    # slide the tail down, copying high-to-low so overlapping ranges stay intact.
+    var i: usize = st.buf.len;
+    for (i > p) {
+        i = i - 1;
+        st.buf.data[i + n] = st.buf.data[i];
+    }
+    var z: usize = p;
+    for (z < p + n) {
+        st.buf.data[z] = 0;
+        z = z + 1;
+    }
+    st.buf.len = need;
+
+    var bi: u32 = 0;
+    for (bi < st.block_count) {
+        if (st.blocks[bi].offset >= pos)       { st.blocks[bi].offset = st.blocks[bi].offset + nbytes; }
+        if (st.blocks[bi].fn_text_base >= pos) { st.blocks[bi].fn_text_base = st.blocks[bi].fn_text_base + nbytes; }
+        bi = bi + 1;
+    }
+    var fi: u32 = 0;
+    for (fi < st.fixup_count) {
+        if (st.fixups[fi].patch_pos >= pos)    { st.fixups[fi].patch_pos = st.fixups[fi].patch_pos + nbytes; }
+        if (st.fixups[fi].next_ip >= pos)      { st.fixups[fi].next_ip = st.fixups[fi].next_ip + nbytes; }
+        if (st.fixups[fi].fn_text_base >= pos) { st.fixups[fi].fn_text_base = st.fixups[fi].fn_text_base + nbytes; }
+        fi = fi + 1;
+    }
+    var si: u32 = 0;
+    for (si < st.sym_count) {
+        if (st.syms[si].offset >= pos) { st.syms[si].offset = st.syms[si].offset + nbytes; }
+        si = si + 1;
+    }
+    var ri: u32 = 0;
+    for (ri < st.reloc_count) {
+        if (st.relocs[ri].offset >= pos) { st.relocs[ri].offset = st.relocs[ri].offset + nbytes; }
+        ri = ri + 1;
+    }
+    ret R.ok[bool, str](true);
 }
 
 # grow the symbol-mark array, allocating it on first use

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -5636,3 +5636,100 @@ test "mach.lang.driver:incremental_sema_reshape_renumber_recheck" {
     session.dnit(?sA);
     ret bad;
 }
+
+# scaffold a single-module project from `text`, run parse + resolve + the sema
+# pass, and return its error-diagnostic count (-1 on a harness failure). the
+# secret flow-typing matrix below asserts this count against an expectation
+# (#1645).
+fun ut_sema_errs(text: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret -1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret -1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = text;
+
+    val pr: R.Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[Project, str](pr)) { session.dnit(?s); ret -1; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+
+    var errs: i32 = -1;
+    val sem: R.Result[bool, str] = run_sema_pass(?p);
+    if (R.is_ok[bool, str](sem)) { errs = ut_count_errors(?s.diags)::i32; }
+
+    dnit_project(?p);
+    session.dnit(?s);
+    ret errs;
+}
+
+# whether `text` type-checks with zero sema errors.
+fun ut_sema_clean(text: str) bool { ret ut_sema_errs(text) == 0; }
+
+# whether `text` is rejected with at least one sema error.
+fun ut_sema_rejects(text: str) bool { ret ut_sema_errs(text) > 0; }
+
+# secret flow typing: a clean program exercising the join, the implicit
+# public->secret up-coerce, the `:^` strip, secret record fields, storing public
+# through `*^T`, and an all-secret union, all without a sema error (#1645).
+test "mach.lang.driver:secret_join_coerce_strip_clean" {
+    val src: str = "rec Key { d: ^[32]u8; }\nuni Both { a: ^u32; b: ^u32; }\nfun join(a: ^u32, b: ^u32) ^u32 { ret a + b; }\nfun join_pub(a: ^u32) ^u32 { ret a * 2; }\nfun up(p: u32) ^u32 { ret p; }\nfun down(a: ^u32) u32 { ret a:^; }\nfun down_typed(a: ^u32) u32 { ret a:^u32; }\nfun store_ok(p: *^u8, v: u8) { @p = v; }\nfun field_read(k: Key) ^u8 { ret k.d[0]; }\nfun main() i32 { ret 0; }\n";
+    if (!ut_sema_clean(src)) { ret 1; }
+    ret 0;
+}
+
+# secret flow typing: every classical-leakage gate rejects a secret operand - a
+# branch / loop condition, a memory index, the always-variable-latency `/` and
+# `%`, and a short-circuiting `&&`. the same code on public operands is clean, so
+# the gates key on secrecy, not shape (#1645).
+test "mach.lang.driver:secret_gates_rejected" {
+    var bad: i32 = 0;
+    if (!ut_sema_rejects("fun f(a: ^u32) i32 { if (a) { ret 1; } ret 0; }\nfun main() i32 { ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: ^u32) i32 { for (a) { ret 1; } ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun f(t: *u8, i: ^u64) u8 { ret t[i]; }\nfun main() i32 { ret 0; }\n"))          { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: ^u32, b: ^u32) ^u32 { ret a / b; }\nfun main() i32 { ret 0; }\n"))      { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: ^u32, b: ^u32) ^u32 { ret a % b; }\nfun main() i32 { ret 0; }\n"))      { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: ^u32, b: u32) ^u8 { ret a && b; }\nfun main() i32 { ret 0; }\n"))       { bad = 1; }
+    if (!ut_sema_clean("fun f(a: u32) i32 { if (a) { ret 1; } ret 0; }\nfun main() i32 { ret 0; }\n"))     { bad = 1; }
+    if (!ut_sema_clean("fun f(t: *u8, i: u64) u8 { ret t[i]; }\nfun main() i32 { ret 0; }\n"))             { bad = 1; }
+    if (!ut_sema_clean("fun f(a: u32, b: u32) u32 { ret a / b; }\nfun main() i32 { ret 0; }\n"))           { bad = 1; }
+    ret bad;
+}
+
+# secret flow typing: `::` and `:~` can neither drop nor add the `^` qualifier
+# (the only downgrade is `:^`), but a cast that preserves secrecy is fine (#1645).
+test "mach.lang.driver:secret_cast_secrecy_rejected" {
+    var bad: i32 = 0;
+    if (!ut_sema_rejects("fun f(a: ^u32) u32 { ret a::u32; }\nfun main() i32 { ret 0; }\n"))                  { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: u32) i32 { var s: ^u32 = a::^u32; ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: ^u32) u32 { ret a:~u32; }\nfun main() i32 { ret 0; }\n"))                  { bad = 1; }
+    if (!ut_sema_clean("fun f(a: ^u32) ^u64 { ret a::^u64; }\nfun main() i32 { ret 0; }\n"))                  { bad = 1; }
+    ret bad;
+}
+
+# secret flow typing: welded-storage pointers are non-launderable - a `*^T`
+# cannot be erased to the untyped `ptr` (by return-coercion or by `:~`), and a
+# secret cannot be stored through a public `*T`; a public `*T` still erases to
+# `ptr` freely (#1645).
+test "mach.lang.driver:secret_pointer_not_launderable" {
+    var bad: i32 = 0;
+    if (!ut_sema_rejects("fun f(p: *^u8) ptr { ret p; }\nfun main() i32 { ret 0; }\n"))      { bad = 1; }
+    if (!ut_sema_rejects("fun f(p: *^u8) ptr { ret p:~ptr; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun f(p: *u8, s: ^u8) { @p = s; }\nfun main() i32 { ret 0; }\n"))   { bad = 1; }
+    if (!ut_sema_clean("fun f(p: *u8) ptr { ret p; }\nfun main() i32 { ret 0; }\n"))          { bad = 1; }
+    ret bad;
+}
+
+# secret flow typing: a `uni`'s overlapping variants must agree on secrecy -
+# a part-secret part-public union is rejected, a uniformly secret or uniformly
+# public one is accepted (#1645).
+test "mach.lang.driver:secret_uni_field_secrecy" {
+    var bad: i32 = 0;
+    if (!ut_sema_rejects("uni U { a: ^u32; b: u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("uni U { a: ^u32; b: ^u32; }\nfun main() i32 { ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_clean("uni U { a: u32; b: u32; }\nfun main() i32 { ret 0; }\n"))    { bad = 1; }
+    ret bad;
+}

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -5696,6 +5696,9 @@ test "mach.lang.driver:secret_gates_rejected" {
     if (!ut_sema_clean("fun f(a: u32) i32 { if (a) { ret 1; } ret 0; }\nfun main() i32 { ret 0; }\n"))     { bad = 1; }
     if (!ut_sema_clean("fun f(t: *u8, i: u64) u8 { ret t[i]; }\nfun main() i32 { ret 0; }\n"))             { bad = 1; }
     if (!ut_sema_clean("fun f(a: u32, b: u32) u32 { ret a / b; }\nfun main() i32 { ret 0; }\n"))           { bad = 1; }
+    # `&&` branches on the LEFT operand only: a public left with a secret right
+    # is no secret branch (the result is still tainted secret)
+    if (!ut_sema_clean("fun f(a: u32, b: ^u32) ^u8 { ret a && b; }\nfun main() i32 { ret 0; }\n"))         { bad = 1; }
     ret bad;
 }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -2717,6 +2717,9 @@ fun bind_type(rc: *ResolveContext, tid: id.TypeId) R.Result[bool, str] {
     if (t.kind == atype.TYPE_KIND_PTR) {
         ret bind_type(rc, t.data.ptr.pointee);
     }
+    if (t.kind == atype.TYPE_KIND_SECRET) {
+        ret bind_type(rc, t.data.secret.inner);
+    }
     if (t.kind == atype.TYPE_KIND_ARRAY) {
         val re: R.Result[bool, str] = bind_expr(rc, t.data.array.length);
         if (R.is_err[bool, str](re)) { ret re; }

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -261,7 +261,21 @@ pub fun imported_module_const_sym(sc: *context.SemaContext, sym: *resolve.Symbol
 pub fun check_index(sc: *context.SemaContext, object: type.TypeId, index: type.TypeId, span: token.Span) O.Option[type.TypeId] {
     if (object == type.TYPE_ERROR) { ret O.some[type.TypeId](type.TYPE_ERROR); }
 
-    val opt_object: O.Option[*type.Type] = type.get(?sc.s.types, object);
+    # GATE: a secret index becomes a secret-dependent memory address the leakage
+    # model observes through the access trace (#1645). reported before the integer
+    # check, which sees through the `^` and would otherwise accept it.
+    if (index != type.TYPE_ERROR && type.is_secret(?sc.s.types, index)) {
+        report_note(sc, span, "secret value used as a memory index",
+            "a secret may not address memory; the access pattern leaks through the cache trace. index by a public value, or load the whole table obliviously");
+    }
+
+    # a secret container `^[N]T` / `^*T` is indexed through its inner type, and
+    # the secrecy joins onto the element (every element of a secret aggregate is
+    # secret). `[N]^T` carries the `^` on the element directly.
+    val obj_secret: bool = type.is_secret(?sc.s.types, object);
+    val base_obj:   type.TypeId = type.strip_secret(?sc.s.types, object);
+
+    val opt_object: O.Option[*type.Type] = type.get(?sc.s.types, base_obj);
     if (O.is_none[*type.Type](opt_object)) {
         report(sc, span, "not indexable: object is neither a pointer nor an array");
         ret O.none[type.TypeId]();
@@ -283,6 +297,7 @@ pub fun check_index(sc: *context.SemaContext, object: type.TypeId, index: type.T
     if (index != type.TYPE_ERROR && !is_integer(sc, index)) {
         report(sc, span, "type mismatch: index must be an integer");
     }
+    if (obj_secret) { elem = secret_of(sc, elem); }
     ret O.some[type.TypeId](elem);
 }
 
@@ -302,9 +317,19 @@ pub fun check_index(sc: *context.SemaContext, object: type.TypeId, index: type.T
 pub fun check_member(sc: *context.SemaContext, object: type.TypeId, name: intern.StrId, span: token.Span) O.Option[type.TypeId] {
     if (object == type.TYPE_ERROR) { ret O.some[type.TypeId](type.TYPE_ERROR); }
 
-    val record: type.TypeId = deref_one(sc, object);
+    # a secret container taints every field read out of it: accessing a field of a
+    # `^Rec` (or through a `*^Rec`) yields a secret value. the field's own
+    # declared `^` (e.g. `d: ^[32]u8`) joins with the container's.
+    val deref:          type.TypeId = deref_one(sc, type.strip_secret(?sc.s.types, object));
+    val container_secret: bool      = type.is_secret(?sc.s.types, object) || type.is_secret(?sc.s.types, deref);
+    val record:         type.TypeId = type.strip_secret(?sc.s.types, deref);
+
     val opt_field: O.Option[type.TypeId] = context.field_lookup(sc, record, name);
-    if (O.is_some[type.TypeId](opt_field)) { ret opt_field; }
+    if (O.is_some[type.TypeId](opt_field)) {
+        var fty: type.TypeId = O.unwrap[type.TypeId](opt_field);
+        if (container_secret) { fty = secret_of(sc, fty); }
+        ret O.some[type.TypeId](fty);
+    }
 
     report_no_field(sc, span, name, record);
     ret O.none[type.TypeId]();
@@ -325,7 +350,14 @@ pub fun check_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId,
     if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret O.some[type.TypeId](to); }
     if (from == to)                                       { ret O.some[type.TypeId](to); }
 
-    # primitive numeric <-> primitive numeric conversion
+    # the welded-storage discipline (#1645): `::` may neither launder a secret
+    # pointer to the untyped `ptr` nor add / drop a `^`. checked before the
+    # value-conversion rules, which strip secrecy to size and classify operands.
+    if (!check_secrecy_cast(sc, from, to, span)) { ret O.none[type.TypeId](); }
+
+    # primitive numeric <-> primitive numeric conversion (secrecy preserved: the
+    # secrecy check above already proved from and to agree, so the result keeps
+    # whatever `^` the target was written with)
     if (is_numeric(sc, from) && is_numeric(sc, to)) {
         ret O.some[type.TypeId](to);
     }
@@ -343,6 +375,36 @@ pub fun check_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId,
     ret O.none[type.TypeId]();
 }
 
+# enforce the welded-storage secrecy rules common to `::` and `:~` (#1645)
+#
+# Two prohibitions keep the public/secret aliasing leak unconstructable with no
+# alias analysis: a secret-welded pointer (`*^T` and friends) may never be erased
+# to the untyped `ptr`, and a cast may never add or drop a `^` (that is the sole
+# job of the implicit up-coerce and the `:^` strip). Differing inner leaf shapes
+# the cast genuinely converts are unaffected - only `^` placement is compared.
+# ---
+# sc:   the active sema context
+# from: the operand's type
+# to:   the target type
+# span: source range of the cast
+# ret:  true when the cast respects secrecy, false (with a diagnostic) otherwise
+fun check_secrecy_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId, span: token.Span) bool {
+    val from_raw_ptr: bool = from == type.TYPE_PTR;
+    val to_raw_ptr:   bool = to == type.TYPE_PTR;
+    if ((from_raw_ptr && type.carries_secret(?sc.s.types, to))
+        || (to_raw_ptr && type.carries_secret(?sc.s.types, from))) {
+        report_note(sc, span, "cast: a secret-welded pointer cannot be erased to the untyped `ptr`",
+            "secret memory is reached only through secrecy-typed pointers; erasing `^` to `ptr` would let a public alias read it");
+        ret false;
+    }
+    if (!type.secrecy_structure_equal(?sc.s.types, from, to)) {
+        report_note(sc, span, "cast: `::` and `:~` cannot add or drop the secret qualifier `^`",
+            "a public value coerces up to secret with no syntax; `:^` is the only downgrade");
+        ret false;
+    }
+    ret true;
+}
+
 # checks a bit-reinterpret cast `value:~Type`
 #
 # legal only when `from` and `to` have a known, identical byte size; the
@@ -357,6 +419,10 @@ pub fun check_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId,
 # ret:  some(to) when the reinterpret is legal, none (with a diagnostic) otherwise
 pub fun check_reinterpret(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId, span: token.Span) O.Option[type.TypeId] {
     if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret O.some[type.TypeId](to); }
+
+    # `:~` is bound by the same welded-storage secrecy rules as `::` - it can
+    # neither erase a secret pointer to `ptr` nor change a `^` (#1645).
+    if (!check_secrecy_cast(sc, from, to, span)) { ret O.none[type.TypeId](); }
 
     val size_from: u32 = byte_size(sc, from);
     val size_to:   u32 = byte_size(sc, to);
@@ -403,6 +469,14 @@ pub fun check_return(sc: *context.SemaContext, fn_ret: type.TypeId, value: type.
 # ret:  true when the condition is an integer primitive, false otherwise
 pub fun check_condition(sc: *context.SemaContext, cond: type.TypeId, span: token.Span) bool {
     if (cond == type.TYPE_ERROR) { ret true; }
+    # GATE: a secret condition is a secret-dependent branch the leakage model
+    # observes through the control-flow trace (#1645). reported before the integer
+    # check, which sees through the `^` and would otherwise accept it.
+    if (type.is_secret(?sc.s.types, cond)) {
+        report_note(sc, span, "secret value used as a branch condition",
+            "a secret may not steer control flow; branching on it leaks through timing. compute branch-free, or `:^` to a public value when disclosure is intended");
+        ret false;
+    }
     if (is_integer(sc, cond))    { ret true; }
     report_note(sc, span, "type mismatch: condition must be an integer",
         "mach has no `bool` type; comparisons yield an integer truth value");
@@ -431,18 +505,34 @@ pub fun is_integer(sc: *context.SemaContext, t: type.TypeId) bool {
     ret type.is_integer(?sc.s.types, t);
 }
 
+# wrap `t` in the secret qualifier `^t`, used by the secrecy JOIN when a secret
+# container taints a value read out of it (#1645)
+#
+# A doubled qualifier collapses in intern_secret; an allocation failure degrades
+# to `t` unchanged (the diagnostic for the real error lands elsewhere).
+# ---
+# sc:  the active sema context
+# t:   the type to qualify
+# ret: `^t`, or `t` unchanged on an allocation failure
+fun secret_of(sc: *context.SemaContext, t: type.TypeId) type.TypeId {
+    val r: R.Result[type.TypeId, str] = type.intern_secret(?sc.s.types, t);
+    if (R.is_err[type.TypeId, str](r)) { ret t; }
+    ret R.unwrap_ok[type.TypeId, str](r);
+}
+
 # the byte size of a type, resolving pointers/arrays/records via the interner
 #
 # pointer and function values are pointer-sized, read from the target's pointer
 # width; records and unions report 0 because their layout is not computed in
 # sema (the backend owns layout). a 0 result signals "size unknown" and disables
-# same-size cast reinterpretation.
+# same-size cast reinterpretation. secrecy has no runtime width, so a `^T` sizes
+# exactly as `T`.
 # ---
 # sc:  the active sema context
 # t:   a TypeId
 # ret: the size in bytes, or 0 when the size is not known at this layer
 pub fun byte_size(sc: *context.SemaContext, t: type.TypeId) u32 {
-    val opt_type: O.Option[*type.Type] = type.get(?sc.s.types, t);
+    val opt_type: O.Option[*type.Type] = type.get(?sc.s.types, type.strip_secret(?sc.s.types, t));
     if (O.is_none[*type.Type](opt_type)) { ret 0; }
     val tp: *type.Type    = O.unwrap[*type.Type](opt_type);
     val k:  type.TypeKind = tp.kind;
@@ -1087,6 +1177,9 @@ fun type_str_len(sc: *context.SemaContext, t: type.TypeId) usize {
     if (k == type.TYPE_POINTER) {
         ret 1 + type_str_len(sc, tp.data.pointer.base);
     }
+    if (k == type.TYPE_SECRET) {
+        ret 1 + type_str_len(sc, tp.data.secret.base);
+    }
     if (k == type.TYPE_ARRAY) {
         ret 1 + decimal_len(tp.data.array.count::usize) + 1 + type_str_len(sc, tp.data.array.base);
     }
@@ -1134,6 +1227,10 @@ fun write_type_str(sc: *context.SemaContext, buf: str, k: usize, t: type.TypeId)
     if (kind == type.TYPE_POINTER) {
         val w: usize = write_char(buf, k, '*');
         ret write_type_str(sc, buf, w, tp.data.pointer.base);
+    }
+    if (kind == type.TYPE_SECRET) {
+        val w: usize = write_char(buf, k, '^');
+        ret write_type_str(sc, buf, w, tp.data.secret.base);
     }
     if (kind == type.TYPE_ARRAY) {
         var w: usize = write_char(buf, k, '[');

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -55,7 +55,15 @@ use mach.lang.type;
 #      updated), none when no literal coercion applies
 pub fun try_coerce_literal(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId) O.Option[type.TypeId] {
     if (to == type.TYPE_NIL || to == type.TYPE_ERROR) { ret O.none[type.TypeId](); }
-    ret coerce_to(sc, eid, to, false);
+
+    # a literal flowing into a secret slot fixes against the public base (a
+    # literal is public), then takes the secret type via the implicit up-coerce
+    # (public is the bottom of the lattice). so `var s: ^u32 = 5;` types `5` as
+    # `^u32` (#1645).
+    val pub_to: type.TypeId = type.strip_secret(?sc.s.types, to);
+    val r: O.Option[type.TypeId] = coerce_to(sc, eid, pub_to, false);
+    if (O.is_some[type.TypeId](r) && pub_to != to) { ret commit(sc, eid, to); }
+    ret r;
 }
 
 # recursive core of try_coerce_literal, dispatching on the expression's kind
@@ -286,6 +294,19 @@ fun commit(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId) O.Option[t
 pub fun is_assignable(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId) bool {
     if (from == to)                                       { ret true; }
     if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret true; }
+
+    # the secrecy lattice (#1645): public is the bottom, secret the top. a value
+    # coerces UP to a secret slot with no syntax, so a secret destination accepts
+    # a public or secret source of the same base. the reverse - a secret source
+    # into a public slot - is the forbidden downgrade and falls through to fail
+    # (only the explicit `:^` strip downgrades).
+    val to_secret:   bool = type.is_secret(?sc.s.types, to);
+    val from_secret: bool = type.is_secret(?sc.s.types, from);
+    if (to_secret) {
+        ret is_assignable(sc, type.strip_secret(?sc.s.types, from), type.strip_secret(?sc.s.types, to));
+    }
+    if (from_secret) { ret false; }
+
     if (ptr_compatible(sc, from, to))                     { ret true; }
     ret type.type_equals_signatures(?sc.s.types, from, to);
 }
@@ -301,8 +322,15 @@ pub fun is_assignable(sc: *context.SemaContext, from: type.TypeId, to: type.Type
 # to:   the second type
 # ret:  true when one side is the raw `ptr` and the other a typed `*T`
 fun ptr_compatible(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId) bool {
-    if (from == type.TYPE_PTR && is_typed_pointer(sc, to)) { ret true; }
-    if (to == type.TYPE_PTR && is_typed_pointer(sc, from)) { ret true; }
+    # the welded-storage rule (#1645): the untyped `ptr` interconverts with any
+    # typed pointer EXCEPT one carrying secret data. erasing a `*^T` to `ptr`
+    # would let a public alias read secret memory, so it is unconstructable.
+    if (from == type.TYPE_PTR && is_typed_pointer(sc, to)) {
+        ret !type.carries_secret(?sc.s.types, to);
+    }
+    if (to == type.TYPE_PTR && is_typed_pointer(sc, from)) {
+        ret !type.carries_secret(?sc.s.types, from);
+    }
     ret false;
 }
 

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -184,6 +184,15 @@ pub fun substitute(s: *session.Session, body_type: type.TypeId, args: *type.Type
         ret unwrap_or_error(type.intern_array(?s.types, base, count));
     }
 
+    # a `^T` body type specializes its inner type and re-wraps the qualifier, so
+    # `^T` instantiated at `u32` becomes `^u32` (#1645).
+    if (t.kind == type.TYPE_SECRET) {
+        val original_base: type.TypeId = t.data.secret.base;
+        val base:          type.TypeId = substitute(s, original_base, args, arg_count);
+        if (base == original_base) { ret body_type; }
+        ret unwrap_or_error(type.intern_secret(?s.types, base));
+    }
+
     if (t.kind == type.TYPE_FUN)      { ret substitute_fun(s, t, args, arg_count, body_type); }
     if (t.kind == type.TYPE_INSTANCE) { ret substitute_instance(s, t, args, arg_count, body_type); }
 
@@ -594,6 +603,7 @@ fun mentions_gparam(s: *session.Session, tid: type.TypeId, scan: *GParamScan) bo
 
     if (t.kind == type.TYPE_GENERIC_PARAM) { ret true; }
     if (t.kind == type.TYPE_POINTER)       { ret mentions_gparam(s, t.data.pointer.base, scan); }
+    if (t.kind == type.TYPE_SECRET)        { ret mentions_gparam(s, t.data.secret.base, scan); }
     if (t.kind == type.TYPE_ARRAY)         { ret mentions_gparam(s, t.data.array.base, scan); }
     if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI) {
         ret nominal_fields_mention(s, tid, scan);

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -606,7 +606,8 @@ fun infer_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, 
     # secrecy JOIN: an operation with any secret operand yields a secret result
     # (public is the bottom of the lattice). taint is read from the original
     # operands here and reapplied to whatever result type each operator computes.
-    val either_secret: bool = type.is_secret(?sc.s.types, lt) || type.is_secret(?sc.s.types, rt);
+    val lhs_secret:    bool = type.is_secret(?sc.s.types, lt);
+    val either_secret: bool = lhs_secret || type.is_secret(?sc.s.types, rt);
 
     # GATE: `/` and `%` are variable-latency on every target (the leakage model
     # always observes them), so a secret operand is a compile error here. the
@@ -663,10 +664,12 @@ fun infer_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, 
             context.report(sc, span, "type mismatch: logical operands must be integer types");
             ret type.TYPE_ERROR;
         }
-        # GATE: `&&` / `||` short-circuit, so a secret operand becomes a
-        # secret-dependent branch the leakage model observes.
-        if (either_secret) {
-            context.report(sc, span, "secret value used as an operand of a short-circuiting `&&` / `||`; the branch it controls leaks through control flow");
+        # GATE: `&&` / `||` short-circuit by branching on the LEFT operand (the
+        # right is evaluated conditionally), so a secret left operand is the
+        # secret-dependent branch the leakage model observes. a secret right
+        # operand only taints the result (no branch keys on it).
+        if (lhs_secret) {
+            context.report(sc, span, "secret value used as the left operand of a short-circuiting `&&` / `||`; the branch it controls leaks through control flow");
         }
         ret join_secret(sc, u8t, either_secret);
     }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -168,8 +168,35 @@ fun infer_nominal_uni(sc: *context.SemaContext, did: id.DeclId, name_span: token
     val ty: type.TypeId = R.unwrap_ok[type.TypeId, str](tr);
 
     build_field_table(sc, ty, u.fields_start, u.fields_len);
+    check_uni_secrecy(sc, u.fields_start, u.fields_len);
     record_type_align(sc, did, ty);
     ret ty;
+}
+
+# enforce that a union's overlapping variants agree on secrecy (#1645)
+#
+# A `uni`'s fields share storage, so a mixed-secrecy union would let the same
+# bytes be read as both secret and public - the welded-storage aliasing leak. All
+# variants must be uniformly secret or uniformly public. The first variant whose
+# secrecy disagrees with the first variant's is reported on its own field span.
+# ---
+# sc:           sema context
+# fields_start: start index into ast.typed_names
+# fields_len:   number of variants
+fun check_uni_secrecy(sc: *context.SemaContext, fields_start: u32, fields_len: u32) {
+    if (fields_len < 2) { ret; }
+
+    val first_tn:     *decl.TypedName = ?sc.a.typed_names[fields_start];
+    val first_secret: bool            = type.is_secret(?sc.s.types, context.resolved_type_of(sc, first_tn.ty));
+
+    var i: u32 = 1;
+    for (i < fields_len) {
+        val tn: *decl.TypedName = ?sc.a.typed_names[fields_start + i];
+        if (type.is_secret(?sc.s.types, context.resolved_type_of(sc, tn.ty)) != first_secret) {
+            context.report(sc, tn.name, "union variants must agree on secrecy: overlapping fields are part secret `^` and part public, which would alias the same storage at two classifications");
+        }
+        i = i + 1;
+    }
 }
 
 # fold an `#[align(...)]` decorator on `did` and record the resulting alignment
@@ -357,6 +384,9 @@ pub fun infer_expr(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
     }
     or (e.kind == expr.EXPR_KIND_CAST) {
         t = infer_cast(sc, ?e.data.cast, e.span);
+    }
+    or (e.kind == expr.EXPR_KIND_STRIP) {
+        t = infer_strip(sc, ?e.data.strip, e.span);
     }
     or (e.kind == expr.EXPR_KIND_ARRAY_LIT) {
         t = infer_array_lit(sc, ?e.data.array_lit, e.span);
@@ -573,6 +603,19 @@ fun infer_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, 
     var rt: type.TypeId = infer_expr(sc, b.rhs);
     if (lt == type.TYPE_ERROR || rt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
+    # secrecy JOIN: an operation with any secret operand yields a secret result
+    # (public is the bottom of the lattice). taint is read from the original
+    # operands here and reapplied to whatever result type each operator computes.
+    val either_secret: bool = type.is_secret(?sc.s.types, lt) || type.is_secret(?sc.s.types, rt);
+
+    # GATE: `/` and `%` are variable-latency on every target (the leakage model
+    # always observes them), so a secret operand is a compile error here. the
+    # float-default and integer-multiply gates are target-CT-capability dependent
+    # and land with the taint-to-MIR contract (#1646).
+    if ((b.op == expr.BIN_DIV || b.op == expr.BIN_MOD) && either_secret) {
+        context.report(sc, span, "secret value used as an operand of a variable-latency `/` or `%`; a secret divisor or dividend leaks through timing");
+    }
+
     # let a literal operand take the shape of the other side
     val co: O.Option[type.TypeId] = unify_literals(sc, b.lhs, lt, b.rhs, rt);
     if (O.is_some[type.TypeId](co)) {
@@ -608,28 +651,51 @@ fun infer_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, 
         if (int_float_mix) { report_int_float_cmp(sc, span); ret type.TYPE_ERROR; }
         val addr_ok: bool = is_pointer_like(sc, lt) && is_pointer_like(sc, rt);
         if (!operands_ok && !both_float && !addr_ok) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
-        ret u8t;
+        ret join_secret(sc, u8t, either_secret);
     }
     if (b.op == expr.BIN_LT || b.op == expr.BIN_LEQ || b.op == expr.BIN_GT || b.op == expr.BIN_GEQ) {
         if (int_float_mix)            { report_int_float_cmp(sc, span); ret type.TYPE_ERROR; }
         if (!both_int && !both_float) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
-        ret u8t;
+        ret join_secret(sc, u8t, either_secret);
     }
     if (b.op == expr.BIN_AND || b.op == expr.BIN_OR) {
         if (!both_int) {
             context.report(sc, span, "type mismatch: logical operands must be integer types");
             ret type.TYPE_ERROR;
         }
-        ret u8t;
+        # GATE: `&&` / `||` short-circuit, so a secret operand becomes a
+        # secret-dependent branch the leakage model observes.
+        if (either_secret) {
+            context.report(sc, span, "secret value used as an operand of a short-circuiting `&&` / `||`; the branch it controls leaks through control flow");
+        }
+        ret join_secret(sc, u8t, either_secret);
     }
     if (b.op == expr.BIN_BIT_AND || b.op == expr.BIN_BIT_OR || b.op == expr.BIN_BIT_XOR
         || b.op == expr.BIN_SHL || b.op == expr.BIN_SHR) {
         if (!both_int) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
-        ret lt;
+        ret join_secret(sc, lt, either_secret);
     }
     # arithmetic: ADD, SUB, MUL, DIV, MOD
     if (!operands_ok || !is_numeric(sc, lt)) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
-    ret lt;
+    ret join_secret(sc, lt, either_secret);
+}
+
+# apply the secrecy JOIN to a binary/unary result base type (#1645)
+#
+# Strips any secrecy already on `base` and re-wraps in `^` exactly when an
+# operand was secret, so a doubled qualifier never forms and the result's
+# secrecy is precisely the join of its operands'.
+# ---
+# sc:     sema context
+# base:   the operator's computed result type
+# secret: true when any operand was secret
+# ret:    `^strip(base)` when `secret`, else `strip(base)`
+fun join_secret(sc: *context.SemaContext, base: type.TypeId, secret: bool) type.TypeId {
+    val pub: type.TypeId = type.strip_secret(?sc.s.types, base);
+    if (!secret) { ret pub; }
+    val r: R.Result[type.TypeId, str] = type.intern_secret(?sc.s.types, pub);
+    if (R.is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }
+    ret R.unwrap_ok[type.TypeId, str](r);
 }
 
 # type a type comparison (`$type_of(...) == TypeName`)
@@ -749,7 +815,9 @@ fun infer_assign(sc: *context.SemaContext, b: *expr.ExprBinary, span: token.Span
 #
 # NEG returns the operand type, NOT returns u8, BIT_NOT returns the operand
 # type, ADDR returns a pointer to the operand type, DEREF returns the pointee of
-# a pointer operand.
+# a pointer operand. The value operators (`-`, `!`, `~`) join the operand's
+# secrecy onto their result; `&` instead nests it (`&^T` is the public pointer
+# `*^T`), and DEREF recovers it from the pointee (`@(*^T)` is `^T`).
 # ---
 # sc:   sema context
 # u:    the unary operation payload
@@ -759,17 +827,19 @@ fun infer_unary(sc: *context.SemaContext, u: *expr.ExprUnary, span: token.Span) 
     val ot: type.TypeId = infer_expr(sc, u.operand);
     if (ot == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
+    val ot_secret: bool = type.is_secret(?sc.s.types, ot);
+
     if (u.op == expr.UN_NEG) {
         if (!is_numeric(sc, ot)) { context.report(sc, span, "type mismatch: unary - requires a numeric operand"); ret type.TYPE_ERROR; }
-        ret ot;
+        ret join_secret(sc, ot, ot_secret);
     }
     if (u.op == expr.UN_NOT) {
         if (!is_integer(sc, ot)) { context.report(sc, span, "type mismatch: unary ! requires an integer operand"); ret type.TYPE_ERROR; }
-        ret prim_or_error(sc, type.TYPE_U8);
+        ret join_secret(sc, prim_or_error(sc, type.TYPE_U8), ot_secret);
     }
     if (u.op == expr.UN_BIT_NOT) {
         if (!is_integer(sc, ot)) { context.report(sc, span, "type mismatch: unary ~ requires an integer operand"); ret type.TYPE_ERROR; }
-        ret ot;
+        ret join_secret(sc, ot, ot_secret);
     }
     if (u.op == expr.UN_ADDR) {
         # a comptime value parameter has no runtime storage -- it folds to a
@@ -1490,6 +1560,43 @@ fun infer_cast(sc: *context.SemaContext, c: *expr.ExprCast, span: token.Span) ty
     ret O.unwrap[type.TypeId](r);
 }
 
+# STRIP: the `:^` secret-qualifier strip cast - the sole downgrade (#1645)
+#
+# Removes the outer `^` from the operand's type, producing a NEW public value
+# (the only secret->public crossing the type system permits). It peels exactly
+# the top-level qualifier: a welded `*^T` pointer's pointee secrecy is never
+# laundered by `:^` since the outer type there is a (public) pointer. A bare
+# `value:^` strips in place; `value:^Type` strips to an explicit target, which
+# must itself be public (a `^Type` target would re-add the qualifier the cast
+# removes).
+# ---
+# sc:   sema context
+# st:   the strip payload
+# span: the cast span for diagnostics
+# ret:  the stripped (public) TypeId, or TYPE_ERROR
+fun infer_strip(sc: *context.SemaContext, st: *expr.ExprStrip, span: token.Span) type.TypeId {
+    val vt: type.TypeId = infer_expr(sc, st.value);
+    if (vt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+
+    val stripped: type.TypeId = type.strip_secret(?sc.s.types, vt);
+
+    if (st.ty == id.TYPE_NIL) { ret stripped; }
+
+    val tt: type.TypeId = context.resolved_type_of(sc, st.ty);
+    if (tt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    if (type.is_secret(?sc.s.types, tt)) {
+        context.report(sc, span, "secret strip: a `:^` target type must be public; `:^` only removes the `^` qualifier");
+        ret type.TYPE_ERROR;
+    }
+    # `:^` removes secrecy only; it never reinterprets storage, so an explicit
+    # target must name the operand's own stripped type.
+    if (tt != stripped) {
+        context.report(sc, span, "secret strip: a `:^Type` target must name the operand's stripped (public) type; `:^` does not convert the value");
+        ret type.TYPE_ERROR;
+    }
+    ret tt;
+}
+
 # ARRAY_LIT: result is [count]elem of the declared array type
 #
 # Every element is checked against the element type via check.check_assignable,
@@ -1588,9 +1695,10 @@ pub fun resolve_type_ref(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
     if (O.is_none[*atype.Type](t_opt)) { ret type.TYPE_ERROR; }
     val t: *atype.Type = O.unwrap[*atype.Type](t_opt);
 
-    if (t.kind == atype.TYPE_KIND_NAMED) { ret resolve_type_named(sc, tid, ?t.data.named, t.span); }
-    if (t.kind == atype.TYPE_KIND_PTR)   { ret resolve_type_ptr(sc, ?t.data.ptr); }
-    if (t.kind == atype.TYPE_KIND_ARRAY) { ret resolve_type_array(sc, ?t.data.array, t.span); }
+    if (t.kind == atype.TYPE_KIND_NAMED)  { ret resolve_type_named(sc, tid, ?t.data.named, t.span); }
+    if (t.kind == atype.TYPE_KIND_PTR)    { ret resolve_type_ptr(sc, ?t.data.ptr); }
+    if (t.kind == atype.TYPE_KIND_SECRET) { ret resolve_type_secret(sc, ?t.data.secret); }
+    if (t.kind == atype.TYPE_KIND_ARRAY)  { ret resolve_type_array(sc, ?t.data.array, t.span); }
     if (t.kind == atype.TYPE_KIND_FUN)   { ret resolve_type_fun(sc, ?t.data.fun_); }
     if (t.kind == atype.TYPE_KIND_REC)   { ret resolve_type_anon(sc, tid, t.data.rec_.fields_start, t.data.rec_.fields_len, type.TYPE_REC); }
     if (t.kind == atype.TYPE_KIND_UNI)   { ret resolve_type_anon(sc, tid, t.data.uni_.fields_start, t.data.uni_.fields_len, type.TYPE_UNI); }
@@ -1729,6 +1837,22 @@ fun instantiate_named(sc: *context.SemaContext, sym: *resolve.Symbol, named: *at
 fun resolve_type_ptr(sc: *context.SemaContext, p: *atype.TypePtr) type.TypeId {
     val base: type.TypeId = resolve_type_ref(sc, p.pointee);
     ret ptr_to(sc, base);
+}
+
+# SECRET: recurse on the inner type and intern a `^inner` qualifier (#1645)
+#
+# A poisoned inner poisons the qualifier. `^^T` collapses in intern_secret, so
+# the secrecy lattice stays two-point.
+# ---
+# sc:  sema context
+# s:   the secret-type payload
+# ret: the `^inner` TypeId, or TYPE_ERROR
+fun resolve_type_secret(sc: *context.SemaContext, s: *atype.TypeSecret) type.TypeId {
+    val inner: type.TypeId = resolve_type_ref(sc, s.inner);
+    if (inner == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    val r: R.Result[type.TypeId, str] = type.intern_secret(?sc.s.types, inner);
+    if (R.is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }
+    ret R.unwrap_ok[type.TypeId, str](r);
 }
 
 # ARRAY: resolve the element type, evaluate the length via the comptime
@@ -1929,14 +2053,18 @@ fun ptr_to(sc: *context.SemaContext, base: type.TypeId) type.TypeId {
 
 # the pointee type of a pointer
 #
-# Non-pointer operands report a diagnostic and yield TYPE_ERROR.
+# Non-pointer operands report a diagnostic and yield TYPE_ERROR. A secret pointer
+# `^*T` is peeled to its pointer first, so dereferencing recovers the pointee
+# `T`; the canonical welded form `*^T` is already a (public) pointer whose
+# pointee is the secret `^T`.
 # ---
 # sc:   sema context
 # ty:   the operand TypeId
 # span: the operand span for diagnostics
 # ret:  the pointee TypeId, or TYPE_ERROR
 fun pointee_of(sc: *context.SemaContext, ty: type.TypeId, span: token.Span) type.TypeId {
-    val t_opt: O.Option[*type.Type] = type.get(?sc.s.types, ty);
+    val base: type.TypeId = type.strip_secret(?sc.s.types, ty);
+    val t_opt: O.Option[*type.Type] = type.get(?sc.s.types, base);
     if (O.is_none[*type.Type](t_opt)) { ret type.TYPE_ERROR; }
     val t: *type.Type = O.unwrap[*type.Type](t_opt);
     if (t.kind != type.TYPE_POINTER) {

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -924,6 +924,11 @@ pub fun lower_type(lc: *LowerContext, tid: type.TypeId) R.Result[ir_type.IrTypeI
     val t: *type.Type = O.unwrap[*type.Type](t_opt);
     val k: type.TypeKind = t.kind;
 
+    # secrecy has no runtime representation (#1645): `^T` lowers to exactly `T`'s
+    # machine shape. the secret-taint-to-MIR contract that propagates it through
+    # codegen for the constant-time guarantee lands separately (#1646).
+    if (k == type.TYPE_SECRET) { ret lower_type(lc, t.data.secret.base); }
+
     val d: type.PrimDesc = type.prim_desc(k);
     if (d.class == type.PRIM_CLASS_INT)   { ret ir_type.intern_int(?lc.m.types, d.bits); }
     if (d.class == type.PRIM_CLASS_FLOAT) { ret ir_type.intern_float(?lc.m.types, d.bits); }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -72,6 +72,7 @@ pub fun lower_rvalue(ctx: *context.LowerContext, eid: id.ExprId) R.Result[value.
     if (k == expr.EXPR_KIND_BINARY)         { ret lower_binary(ctx, eid, e); }
     if (k == expr.EXPR_KIND_UNARY)          { ret lower_unary(ctx, eid, e); }
     if (k == expr.EXPR_KIND_CAST)           { ret lower_cast(ctx, eid, e); }
+    if (k == expr.EXPR_KIND_STRIP)          { ret lower_strip(ctx, e); }
     if (k == expr.EXPR_KIND_COMPTIME_IDENT) { ret lower_comptime_path(ctx, eid); }
     if (k == expr.EXPR_KIND_ARRAY_LIT)      { ret lower_array_lit(ctx, eid, e); }
     if (k == expr.EXPR_KIND_STRUCT_LIT)     { ret lower_struct_lit(ctx, eid, e); }
@@ -2372,6 +2373,20 @@ fun lower_cast(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Resu
         ret builder.emit_zext(?ctx.builder, v, dst);
     }
     ret builder.emit_bitcast(?ctx.builder, v, dst);
+}
+
+# lower a `:^` secret-qualifier strip cast to the value it wraps (#1645)
+#
+# `:^` removes secrecy without reinterpreting storage: secrecy has no runtime
+# representation (a `^T` shares `T`'s machine shape), so stripping is a pure
+# value passthrough. sema already proved the operand's stripped type matches the
+# result, so no conversion is emitted.
+# ---
+# ctx: per-module lowering context
+# e:   the resolved strip node
+# ret: the operand's lowered Value, or an error
+fun lower_strip(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.Value, str] {
+    ret lower_rvalue(ctx, e.data.strip.value);
 }
 
 # fold a value-context comptime path to its constant value

--- a/src/lang/me/lower/mangle.mach
+++ b/src/lang/me/lower/mangle.mach
@@ -484,6 +484,12 @@ fun encoded_type_len(s: *session.Session, tid: type.TypeId) usize {
     if (kind == type.TYPE_POINTER) {
         ret 1 + encoded_type_len(s, t.data.pointer.base);
     }
+    # secrecy is erased at lowering (#1645), so `^T` mangles exactly as `T`: two
+    # instances differing only in secrecy lower to one machine shape and one
+    # symbol. (#1646's per-instance oblivious distinction revisits this.)
+    if (kind == type.TYPE_SECRET) {
+        ret encoded_type_len(s, t.data.secret.base);
+    }
     if (kind == type.TYPE_ARRAY) {
         ret 1 + decimal_len(t.data.array.count::usize) + 1 + encoded_type_len(s, t.data.array.base);
     }
@@ -524,6 +530,10 @@ fun write_encoded_type(s: *session.Session, buf: *u8, k: usize, tid: type.TypeId
     if (kind == type.TYPE_POINTER) {
         buf[k] = 'P';
         ret write_encoded_type(s, buf, k + 1, t.data.pointer.base);
+    }
+    # secrecy is erased at lowering (#1645): `^T` encodes exactly as `T`.
+    if (kind == type.TYPE_SECRET) {
+        ret write_encoded_type(s, buf, k, t.data.secret.base);
     }
     if (kind == type.TYPE_ARRAY) {
         buf[k] = 'A';

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -94,7 +94,8 @@ val JALR:      u32 = 0x67;  # jump and link register (I-type)
 val LUI:       u32 = 0x37;  # load upper immediate (U-type)
 val AUIPC:     u32 = 0x17;  # add upper immediate to pc (U-type)
 val SYSTEM:    u32 = 0x73;  # ecall / ebreak
-val MISC_MEM:  u32 = 0x0F;  # fence (the only inline-asm consumer of this group)
+val MISC_MEM:  u32 = 0x0F;  # fence / pause (the inline-asm consumers of this group)
+val AMO:       u32 = 0x2F;  # RV64A atomics (lr / sc / amo*), R-type with aq/rl bits
 
 # the three-bit funct3 selectors. for the ALU groups these name the operation; for
 # loads / stores / branches they name the access width / relation (see the width
@@ -189,6 +190,27 @@ val FMT_D: u32 = 0x1;
 # assigned value.
 val FP_SCRATCH:  u32 = 31;
 val FP_SCRATCH2: u32 = 30;
+
+# the RV64A atomic width selector (funct3 of an AMO word): W is the 32-bit form, D the
+# 64-bit form. an rv32 reuses the W forms, so this split is the only XLEN-specific bit.
+val F3_AMO_W: u32 = 0x2;
+val F3_AMO_D: u32 = 0x3;
+
+# the RV64A atomic operation selectors (the 5-bit funct5 in an AMO word's bits [31:27]).
+# the aq / rl ordering bits sit just below in [26:25], so the assembled funct7 is
+# `(funct5 << 2) | (aq << 1) | rl`. lr / sc are the load-reserved / store-conditional
+# pair; the amo* forms are the read-modify-write atomics.
+val A5_LR:      u32 = 0x02;
+val A5_SC:      u32 = 0x03;
+val A5_AMOSWAP: u32 = 0x01;
+val A5_AMOADD:  u32 = 0x00;
+val A5_AMOXOR:  u32 = 0x04;
+val A5_AMOAND:  u32 = 0x0C;
+val A5_AMOOR:   u32 = 0x08;
+val A5_AMOMIN:  u32 = 0x10;
+val A5_AMOMAX:  u32 = 0x14;
+val A5_AMOMINU: u32 = 0x18;
+val A5_AMOMAXU: u32 = 0x1C;
 
 # the register roles the encoder uses directly, the leaf module's psABI ids cast to
 # the 5-bit register fields. ZERO discards writes and reads as 0; RA is the link
@@ -2677,6 +2699,84 @@ fun rv_jalr(st: *encode.EncodeState, args: str, default_rd: u32) R.Result[bool, 
     ret R.err[bool, str]("encode: inline-asm jalr expects rs or rd, rs, imm");
 }
 
+# strip a trailing RV64A ordering suffix (`.aqrl` / `.aq` / `.rl`) from atomic mnemonic
+# `mnem` of length `len`, returning the length without the suffix and setting the aq / rl
+# bits. an atomic with no ordering suffix leaves both clear.
+fun rv_amo_ordering(mnem: str, len: usize, aq_out: *bool, rl_out: *bool) usize {
+    @aq_out = false; @rl_out = false;
+    if (len >= 5 && str_region_equals(mnem, len - 5, 5, ".aqrl")) { @aq_out = true; @rl_out = true; ret len - 5; }
+    if (len >= 3 && str_region_equals(mnem, len - 3, 3, ".aq"))   { @aq_out = true; ret len - 3; }
+    if (len >= 3 && str_region_equals(mnem, len - 3, 3, ".rl"))   { @rl_out = true; ret len - 3; }
+    ret len;
+}
+
+# map an atomic base name `mnem[0..len)` (the mnemonic with its width and ordering
+# suffixes already stripped) to its 5-bit funct5, setting `is_lr_out` for the two-operand
+# `lr` form. returns false when the base is not an RV64A atomic.
+fun rv_amo_base(mnem: str, len: usize, funct5_out: *u32, is_lr_out: *bool) bool {
+    @is_lr_out = false;
+    if (str_region_equals(mnem, 0, len, "lr"))      { @funct5_out = A5_LR; @is_lr_out = true; ret true; }
+    if (str_region_equals(mnem, 0, len, "sc"))      { @funct5_out = A5_SC;      ret true; }
+    if (str_region_equals(mnem, 0, len, "amoswap")) { @funct5_out = A5_AMOSWAP; ret true; }
+    if (str_region_equals(mnem, 0, len, "amoadd"))  { @funct5_out = A5_AMOADD;  ret true; }
+    if (str_region_equals(mnem, 0, len, "amoand"))  { @funct5_out = A5_AMOAND;  ret true; }
+    if (str_region_equals(mnem, 0, len, "amoor"))   { @funct5_out = A5_AMOOR;   ret true; }
+    if (str_region_equals(mnem, 0, len, "amoxor"))  { @funct5_out = A5_AMOXOR;  ret true; }
+    if (str_region_equals(mnem, 0, len, "amomax"))  { @funct5_out = A5_AMOMAX;  ret true; }
+    if (str_region_equals(mnem, 0, len, "amomin"))  { @funct5_out = A5_AMOMIN;  ret true; }
+    if (str_region_equals(mnem, 0, len, "amomaxu")) { @funct5_out = A5_AMOMAXU; ret true; }
+    if (str_region_equals(mnem, 0, len, "amominu")) { @funct5_out = A5_AMOMINU; ret true; }
+    ret false;
+}
+
+# encode one RV64A atomic statement (the AMO major opcode, R-type with the aq / rl
+# ordering bits folded into funct7). `lr` is `rd, (rs1)` with rs2 forced to x0; `sc` and
+# the `amo*` read-modify-writes are `rd, rs2, (rs1)`. the address is the base-only
+# `(rs1)` form atomics require - a displacement is rejected, unlike a regular load /
+# store. `matched` is set only when `mnem` decodes to a real atomic, so an unrelated
+# mnemonic falls through to the dispatch's unsupported-mnemonic error.
+fun rv_amo(st: *encode.EncodeState, mnem: str, args: str, matched: *bool) R.Result[bool, str] {
+    @matched = false;
+    val len: usize = str_len(mnem);
+    var aq: bool = false; var rl: bool = false;
+    val wlen: usize = rv_amo_ordering(mnem, len, ?aq, ?rl);
+    if (wlen < 4) { ret R.ok[bool, str](true); }
+    var funct3: u32 = 0;
+    if (str_region_equals(mnem, wlen - 2, 2, ".w")) { funct3 = F3_AMO_W; }
+    or (str_region_equals(mnem, wlen - 2, 2, ".d")) { funct3 = F3_AMO_D; }
+    or { ret R.ok[bool, str](true); }
+    var funct5: u32 = 0; var is_lr: bool = false;
+    if (!rv_amo_base(mnem, wlen - 2, ?funct5, ?is_lr)) { ret R.ok[bool, str](true); }
+    @matched = true;
+
+    var funct7: u32 = funct5 << 2;
+    if (aq) { funct7 = funct7 | 0x2; }
+    if (rl) { funct7 = funct7 | 0x1; }
+
+    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
+    var n: u32 = 0;
+    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm atomic operands"); }
+
+    if (is_lr) {
+        if (n != 2)                                                         { ret R.err[bool, str]("encode: inline-asm 'lr' expects rd, (rs1)"); }
+        var rd: RvAsmOp; var mem: RvAsmOp;
+        if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm 'lr' destination must be a register"); }
+        if (!rv_parse_operand((?b1[0])::str, ?mem) || mem.kind != RVOP_MEM) { ret R.err[bool, str]("encode: inline-asm 'lr' address must be (rs1)"); }
+        if (mem.imm != 0)                                                   { ret R.err[bool, str]("encode: inline-asm atomic address takes no displacement"); }
+        emit_word(st, pack_r(AMO, funct3, funct7, rd.reg::u32, mem.reg::u32, RZERO));
+        ret R.ok[bool, str](true);
+    }
+
+    if (n != 3)                                                        { ret R.err[bool, str]("encode: inline-asm atomic expects rd, rs2, (rs1)"); }
+    var rd: RvAsmOp; var rs2: RvAsmOp; var mem: RvAsmOp;
+    if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm atomic destination must be a register"); }
+    if (!rv_parse_operand((?b1[0])::str, ?rs2) || rs2.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm atomic source must be a register"); }
+    if (!rv_parse_operand((?b2[0])::str, ?mem) || mem.kind != RVOP_MEM) { ret R.err[bool, str]("encode: inline-asm atomic address must be (rs1)"); }
+    if (mem.imm != 0)                                                   { ret R.err[bool, str]("encode: inline-asm atomic address takes no displacement"); }
+    emit_word(st, pack_r(AMO, funct3, funct7, rd.reg::u32, mem.reg::u32, rs2.reg::u32));
+    ret R.ok[bool, str](true);
+}
+
 # parse and encode one trimmed inline-asm statement. a numeric local-label definition
 # `<digits>:` records the current offset (resolving forward references) and re-dispatches
 # any instruction following it. an unrecognized mnemonic is a hard error so the
@@ -2703,6 +2803,7 @@ fun encode_asm_stmt_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_bas
     if (str_equals(mnem, "nop"))    { emit_word(st, pack_i(OP_IMM, F3_ADD, RZERO, RZERO, 0)); ret R.ok[bool, str](true); }
     if (str_equals(mnem, "ret"))    { emit_word(st, pack_i(JALR, F3_ADD, RZERO, RRA, 0)); ret R.ok[bool, str](true); }
     if (str_equals(mnem, "fence"))  { emit_word(st, pack_i(MISC_MEM, F3_ADD, RZERO, RZERO, 0xFF)); ret R.ok[bool, str](true); }
+    if (str_equals(mnem, "pause"))  { emit_word(st, pack_i(MISC_MEM, F3_ADD, RZERO, RZERO, 0x010)); ret R.ok[bool, str](true); }
 
     # register-register ALU (R-type).
     if (str_equals(mnem, "add"))    { ret rv_three_reg(st, args, OP, F3_ADD, F7_ZERO); }
@@ -2843,6 +2944,12 @@ fun encode_asm_stmt_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_bas
         emit_word(st, pack_i(OP_IMM_32, F3_ADD, rd, rs, 0));
         ret R.ok[bool, str](true);
     }
+
+    # atomics (RV64A) - lr / sc / amo* with their width (.w/.d) and ordering
+    # (.aq/.rl/.aqrl) suffixes parsed inline; only a real atomic claims the dispatch.
+    var amo_matched: bool = false;
+    val amo_r: R.Result[bool, str] = rv_amo(st, mnem, args, ?amo_matched);
+    if (amo_matched) { ret amo_r; }
 
     ret R.err[bool, str](rv_named_err(st, "encode: unsupported riscv64 inline-asm mnemonic '", mnem, "'", "encode: unsupported riscv64 inline-asm mnemonic"));
 }
@@ -3828,6 +3935,110 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_symbol_relocs" {
 
     # an unknown mnemonic is a hard error, not silent bytes.
     val ur: R.Result[bool, str] = encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "frobnicate a0, a1");
+    if (!R.is_err[bool, str](ur)) { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](ur), "unsupported riscv64 inline-asm mnemonic")) { bad = 1; } }
+
+    rv_labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the RV64A atomic family (lr / sc / amo*) selects the AMO opcode, the .w / .d width
+# funct3, the per-operation funct5, and the .aq / .rl / .aqrl ordering bits, all
+# byte-exact against `llvm-mc -triple=riscv64 -mattr=+a --show-encoding`. `pause` is the
+# fence hint. registers a0/a1/a2 = x10/x11/x12; the address is the base-only `(a1)` form.
+test "mach.lang.target.isa.riscv64.encode:inline_asm_atomics" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: RvLabels;
+    rv_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.w a0, (a1)");           # 0
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.d a0, (a1)");           # 4
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.w a0, a2, (a1)");       # 8
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.d a0, a2, (a1)");       # 12
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.w a0, a2, (a1)");  # 16
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.d a0, a2, (a1)");  # 20
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.w a0, a2, (a1)");   # 24
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d a0, a2, (a1)");   # 28
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoand.w a0, a2, (a1)");   # 32
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoand.d a0, a2, (a1)");   # 36
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoor.w a0, a2, (a1)");    # 40
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoor.d a0, a2, (a1)");    # 44
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoxor.w a0, a2, (a1)");   # 48
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoxor.d a0, a2, (a1)");   # 52
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomax.w a0, a2, (a1)");   # 56
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomax.d a0, a2, (a1)");   # 60
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomin.w a0, a2, (a1)");   # 64
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomin.d a0, a2, (a1)");   # 68
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomaxu.w a0, a2, (a1)");  # 72
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomaxu.d a0, a2, (a1)");  # 76
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amominu.w a0, a2, (a1)");  # 80
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amominu.d a0, a2, (a1)");  # 84
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.w.aq a0, (a1)");        # 88
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.d.aq a0, (a1)");        # 92
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.w.aqrl a0, (a1)");      # 96
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.w.rl a0, a2, (a1)");    # 100
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.d.rl a0, a2, (a1)");    # 104
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.d.aqrl a0, a2, (a1)");  # 108
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.w.aq a0, a2, (a1)");  # 112
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.d.rl a0, a2, (a1)");  # 116
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.w.aqrl a0, a2, (a1)"); # 120
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d.aq a0, a2, (a1)");   # 124
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d.rl a0, a2, (a1)");   # 128
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d.aqrl a0, a2, (a1)"); # 132
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomaxu.d.aqrl a0, a2, (a1)");# 136
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "pause");                   # 140
+
+    if (read_word(?st.buf, 0)   != 0x1005A52F) { bad = 1; }
+    if (read_word(?st.buf, 4)   != 0x1005B52F) { bad = 1; }
+    if (read_word(?st.buf, 8)   != 0x18C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 12)  != 0x18C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 16)  != 0x08C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 20)  != 0x08C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 24)  != 0x00C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 28)  != 0x00C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 32)  != 0x60C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 36)  != 0x60C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 40)  != 0x40C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 44)  != 0x40C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 48)  != 0x20C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 52)  != 0x20C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 56)  != 0xA0C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 60)  != 0xA0C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 64)  != 0x80C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 68)  != 0x80C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 72)  != 0xE0C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 76)  != 0xE0C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 80)  != 0xC0C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 84)  != 0xC0C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 88)  != 0x1405A52F) { bad = 1; }
+    if (read_word(?st.buf, 92)  != 0x1405B52F) { bad = 1; }
+    if (read_word(?st.buf, 96)  != 0x1605A52F) { bad = 1; }
+    if (read_word(?st.buf, 100) != 0x1AC5A52F) { bad = 1; }
+    if (read_word(?st.buf, 104) != 0x1AC5B52F) { bad = 1; }
+    if (read_word(?st.buf, 108) != 0x1EC5B52F) { bad = 1; }
+    if (read_word(?st.buf, 112) != 0x0CC5A52F) { bad = 1; }
+    if (read_word(?st.buf, 116) != 0x0AC5B52F) { bad = 1; }
+    if (read_word(?st.buf, 120) != 0x06C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 124) != 0x04C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 128) != 0x02C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 132) != 0x06C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 136) != 0xE6C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 140) != 0x0100000F) { bad = 1; }
+
+    # an atomic address takes no displacement, unlike a regular load / store.
+    val dr: R.Result[bool, str] = encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.d a0, 8(a1)");
+    if (!R.is_err[bool, str](dr)) { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](dr), "no displacement")) { bad = 1; } }
+
+    # a non-atomic mnemonic that shares the `amo` prefix is still unsupported, not
+    # silently swallowed by the atomic dispatch.
+    val ur: R.Result[bool, str] = encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amobogus.q a0, a2, (a1)");
     if (!R.is_err[bool, str](ur)) { bad = 1; }
     or { if (!str_contains(R.unwrap_err[bool, str](ur), "unsupported riscv64 inline-asm mnemonic")) { bad = 1; } }
 

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -418,15 +418,33 @@ fun emit_mem_access(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width
     emit_word(st, pack_s(STORE, store_funct3(width), b, rt, d::u32 & 0xFFF));
 }
 
-# the frame-pointer offset of the slot a MIR value owns, or none when it owns no
-# slot. the slot table is keyed on the slot-owning vreg ids, so a physical-register
-# base (carrying MIR_VREG_NIL) never matches.
+# the bytes the prologue reserves at the top of the frame, just below the frame
+# pointer: the 16-byte ra / s0 record plus the callee-saved GP and FP save areas.
+# `s0` is pinned at the entry stack pointer (the frame top), so the shared frame
+# phase's frame-pointer-relative local offsets - which assume locals sit immediately
+# below the frame pointer - must be biased down past this reserved region or they
+# would alias the saved record. mirrors the layout `frame_total` / `emit_prologue`
+# / `save_callee_gp` emit. pub so the assembly printer biases its rendered slot
+# offsets by the exact reservation the encoder applies.
+pub fun frame_reserved_top(f: *mir.MirFunction) i64 {
+    val gp_bytes: u32 = popcount32(f.callee_mask) * 8;
+    val fp_bytes: u32 = popcount32(f.callee_mask_fp) * 8;
+    ret (16 + gp_bytes + fp_bytes)::i64;
+}
+
+# the frame-pointer (s0) relative offset of the slot a MIR value owns, or none when
+# it owns no slot. the shared frame phase assigns each slot an offset just below the
+# frame pointer; `s0` sits at the frame top with the ra / s0 record and the
+# callee-saved areas occupying the bytes immediately below it, so the stored offset
+# is biased down past that reserved region to land in the locals area. the slot
+# table is keyed on the slot-owning vreg ids, so a physical-register base (carrying
+# MIR_VREG_NIL) never matches.
 fun frame_slot_offset(f: *mir.MirFunction, v: u32) O.Option[i64] {
     val frame: *mir.MirFrame = ?f.frame;
     if (frame.slots == nil) { ret O.none[i64](); }
     var i: u32 = 0;
     for (i < frame.slot_count) {
-        if (frame.slots[i].value == v) { ret O.some[i64](frame.slots[i].offset); }
+        if (frame.slots[i].value == v) { ret O.some[i64](frame.slots[i].offset - frame_reserved_top(f)); }
         i = i + 1;
     }
     ret O.none[i64]();

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -1722,15 +1722,120 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     ret R.err[bool, str]("encode: unhandled opcode in riscv64 encode");
 }
 
+# the signed byte reach of a B-type conditional branch (13-bit immediate) and a
+# J-type jump (21-bit immediate). a fixup whose displacement falls outside its form's
+# range is relaxed into a longer reaching sequence before pass 2 fills the field.
+val B_DISP_MIN: i64 = -4096;
+val B_DISP_MAX: i64 = 4094;
+val J_DISP_MIN: i64 = -1048576;
+val J_DISP_MAX: i64 = 1048574;
+
+# repack the B-type word at `pos` with a new forward displacement, keeping its
+# relation funct3 and its rs1 / rs2. used to widen a relaxed conditional's inverted
+# guard when its trampoline grows.
+fun set_branch_disp(buf: *encode.ByteBuf, pos: usize, disp: u32) {
+    val word: u32 = read_word(buf, pos);
+    write_word(buf, pos, (word & 0x01FFF07F) | b_imm(disp));
+}
+
+# write the inverted guard of a relaxed conditional at `pos`: the original B-type
+# `bne` word with its relation inverted (funct3 ^ 1 flips the eq/ne, lt/ge, ltu/geu
+# pairs) and a forward `disp` that jumps over the trampoline carrying the far target.
+fun write_inverted_guard(buf: *encode.ByteBuf, pos: usize, bne_word: u32, disp: u32) {
+    val funct3: u32 = ((bne_word >> 12) & 0x7) ^ 0x1;
+    val rs1: u32 = (bne_word >> 15) & 0x1F;
+    val rs2: u32 = (bne_word >> 20) & 0x1F;
+    write_word(buf, pos, pack_b(BRANCH, funct3, rs1, rs2, disp));
+}
+
+# relax every out-of-range intra-function branch this function just emitted into a
+# reaching sequence, iterating to a fixpoint
+#
+# RISC-V conditional branches reach only +-4 KiB and unconditional `jal` only
+# +-1 MiB, so a large function body overflows a B-type displacement that the
+# +-4 KiB field cannot hold. a conditional past +-4 KiB becomes its inverted guard
+# (a short branch skipping the trampoline) followed by a `jal` to the real target;
+# a `jal` past +-1 MiB (an unconditional branch, or the `jal` a relaxed conditional
+# now points at) becomes an `auipc t0,%hi ; jalr x0,t0,%lo` pc-relative trampoline
+# reaching the full 32-bit range. each growth opens a text gap through
+# `encode.insert_text`, which slides the rest of the function down and fixes the
+# block / fixup / symbol / relocation tables, so each rescan remeasures against the
+# grown layout - the relaxation therefore iterates to a fixpoint. the inverted guard
+# is fully resolved here (its skip is purely local); the trampoline's real-target
+# displacement is left to pass 2 through the repointed fixup, whose patch word now
+# carries the `jal` / `auipc` opcode the patcher dispatches on. only fixups this
+# function recorded ([fixup_start, fixup_count)) are considered.
+fun relax_function_riscv64(st: *encode.EncodeState, fn_base: u32, fixup_start: u32) R.Result[bool, str] {
+    val count: u32 = st.fixup_count - fixup_start;
+    if (count == 0) { ret R.ok[bool, str](true); }
+
+    # one marker per fixup: set once the fixup has become a relaxed conditional, so a
+    # later jal->trampoline growth knows to widen the inverted guard at patch_pos - 4.
+    val res_marks: R.Result[*u8, str] = A.allocate[u8](st.alloc, count::usize);
+    if (R.is_err[*u8, str](res_marks)) { ret R.err[bool, str](R.unwrap_err[*u8, str](res_marks)); }
+    val relaxed: *u8 = R.unwrap_ok[*u8, str](res_marks);
+    var z: u32 = 0;
+    for (z < count) { relaxed[z] = 0; z = z + 1; }
+
+    var changed: bool = true;
+    for (changed) {
+        changed = false;
+        var i: u32 = fixup_start;
+        for (i < st.fixup_count) {
+            val fx: *encode.BranchFixup = ?st.fixups[i];
+            val res_off: R.Result[u32, str] = encode.block_offset(st, fn_base, fx.target_block);
+            if (R.is_err[u32, str](res_off)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_off)); }
+            val target_off: u32 = R.unwrap_ok[u32, str](res_off);
+            val word: u32 = read_word(?st.buf, fx.patch_pos::usize);
+            val opcode: u32 = word & 0x7F;
+            val sdisp: i64 = (target_off::i64) - (fx.patch_pos::i64);
+
+            if (opcode == BRANCH && (sdisp < B_DISP_MIN || sdisp > B_DISP_MAX)) {
+                val guard_pos: u32 = fx.patch_pos;
+                val jal_pos: u32 = fx.patch_pos + 4;
+                val ins: R.Result[bool, str] = encode.insert_text(st, jal_pos, 4);
+                if (R.is_err[bool, str](ins)) { ret R.err[bool, str](R.unwrap_err[bool, str](ins)); }
+                write_inverted_guard(?st.buf, guard_pos::usize, word, 8);
+                write_word(?st.buf, jal_pos::usize, pack_j(JAL, RZERO, 0));
+                fx.patch_pos = jal_pos;
+                fx.next_ip   = jal_pos + 4;
+                relaxed[i - fixup_start] = 1;
+                changed = true;
+                brk;
+            }
+            if (opcode == JAL && (sdisp < J_DISP_MIN || sdisp > J_DISP_MAX)) {
+                val auipc_pos: u32 = fx.patch_pos;
+                val jalr_pos: u32 = fx.patch_pos + 4;
+                val ins: R.Result[bool, str] = encode.insert_text(st, jalr_pos, 4);
+                if (R.is_err[bool, str](ins)) { ret R.err[bool, str](R.unwrap_err[bool, str](ins)); }
+                write_word(?st.buf, auipc_pos::usize, pack_u(AUIPC, SCRATCH, 0));
+                write_word(?st.buf, jalr_pos::usize, pack_i(JALR, F3_ADD, RZERO, SCRATCH, 0));
+                fx.next_ip = auipc_pos + 8;
+                if (relaxed[i - fixup_start] != 0) {
+                    val guard_pos: u32 = auipc_pos - 4;
+                    set_branch_disp(?st.buf, guard_pos::usize, fx.next_ip - guard_pos);
+                }
+                changed = true;
+                brk;
+            }
+            i = i + 1;
+        }
+    }
+    A.deallocate[u8](st.alloc, relaxed, count::usize);
+    ret R.ok[bool, str](true);
+}
+
 # the per-function encode hook (pass 1). marks the function entry symbol, emits the
 # prologue (skipped for a naked asm-only function, whose inline asm owns the stack),
 # then each block - emitting the epilogue before every RET - recording each block's
-# `.text` offset for branch patching. extern / body-less functions contribute no
-# text. the callee-saved GP and FP registers are spilled / reloaded by the prologue /
-# epilogue from the frame facts.
+# `.text` offset for branch patching, and finally relaxes any branch whose body grew
+# past its displacement range. extern / body-less functions contribute no text. the
+# callee-saved GP and FP registers are spilled / reloaded by the prologue / epilogue
+# from the frame facts.
 fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result[bool, str] {
     val fn_base: u32 = st.buf.len::u32;
     if (f.block_count == 0) { ret R.ok[bool, str](true); }
+    val fixup_start: u32 = st.fixup_count;
 
     val ms: R.Result[bool, str] = encode.push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
     if (R.is_err[bool, str](ms)) { ret ms; }
@@ -1757,15 +1862,18 @@ fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Resu
         }
         bi = bi + 1;
     }
-    ret R.ok[bool, str](true);
+    ret relax_function_riscv64(st, fn_base, fixup_start);
 }
 
 # the per-branch patch hook (pass 2). reads the placeholder instruction word at the
 # fixup's patch site, computes the instruction-relative signed displacement
 # (`target_off - patch_pos`, with no next-instruction bias - RISC-V branch / jump
 # offsets are relative to the branch's own address), range-checks it against the
-# field width, scatters it into the B-type (13-bit, +-4 KiB) or J-type (21-bit,
-# +-1 MiB) immediate, and writes the word back. an out-of-range displacement is
+# field width, scatters it into the B-type (13-bit, +-4 KiB), J-type (21-bit,
+# +-1 MiB), or relaxed `auipc + jalr` (32-bit pc-relative) immediate, and writes the
+# word(s) back. branch relaxation (`relax_function_riscv64`) runs before pass 2, so a
+# fixup whose target was out of range now carries a `jal` / `auipc` opcode that
+# reaches it; a displacement still out of its form's range here is a backend bug,
 # rejected loudly rather than truncated into a miscompile.
 fun patch_branch_riscv64(st: *encode.EncodeState, fx: *encode.BranchFixup, target_off: u32) R.Result[bool, str] {
     val pos: usize = fx.patch_pos::usize;
@@ -1782,7 +1890,7 @@ fun patch_branch_riscv64(st: *encode.EncodeState, fx: *encode.BranchFixup, targe
 
     if (opcode == JAL) {
         # J-type: +-1 MiB. the non-immediate bits are rd[11:7] and opcode[6:0].
-        if (sdisp < -1048576 || sdisp > 1048574) {
+        if (sdisp < J_DISP_MIN || sdisp > J_DISP_MAX) {
             ret R.err[bool, str]("encode: riscv64 jump displacement exceeds the +-1MiB range");
         }
         write_word(?st.buf, pos, (word & 0xFFF) | j_imm(disp));
@@ -1790,13 +1898,29 @@ fun patch_branch_riscv64(st: *encode.EncodeState, fx: *encode.BranchFixup, targe
     }
     if (opcode == BRANCH) {
         # B-type: +-4 KiB. the kept bits are rs2 / rs1 / funct3 / opcode.
-        if (sdisp < -4096 || sdisp > 4094) {
+        if (sdisp < B_DISP_MIN || sdisp > B_DISP_MAX) {
             ret R.err[bool, str]("encode: riscv64 branch displacement exceeds the +-4KiB range");
         }
         write_word(?st.buf, pos, (word & 0x01FFF07F) | b_imm(disp));
         ret R.ok[bool, str](true);
     }
-    ret R.err[bool, str]("encode: branch fixup site is not a B-type or J-type instruction");
+    if (opcode == AUIPC) {
+        # relaxed far trampoline: `auipc t0,%hi(disp) ; jalr x0,t0,%lo(disp)`, both
+        # pc-relative from the auipc, so the displacement spans the 32-bit signed
+        # range (the +0x800 rounding folds the signed low 12 back into the high 20).
+        if (pos + 8 > st.buf.len) {
+            ret R.err[bool, str]("encode: riscv64 trampoline fixup site is outside the text buffer");
+        }
+        if (sdisp < -2147483648 || sdisp > 2147483647) {
+            ret R.err[bool, str]("encode: riscv64 trampoline displacement exceeds the 32-bit pc-relative range");
+        }
+        val hi20: u32 = ((disp + 0x800) >> 12) & 0xFFFFF;
+        val lo12: u32 = disp & 0xFFF;
+        write_word(?st.buf, pos, pack_u(AUIPC, SCRATCH, hi20));
+        write_word(?st.buf, pos + 4, pack_i(JALR, F3_ADD, RZERO, SCRATCH, lo12));
+        ret R.ok[bool, str](true);
+    }
+    ret R.err[bool, str]("encode: branch fixup site is not a B-type, J-type, or trampoline instruction");
 }
 
 # the RV64 ISA's `encode` entry point - a thin wrapper that supplies the two RISC-V

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -535,9 +535,14 @@ fun scale_shift(scale: u8) u32 {
 }
 
 # a three-address integer ALU op `op rd, rs1, rs2`. the operands resolve to
-# registers (an immediate source is materialized into the scratch register); the
-# width selects the full-register or RV64 word group through `alu_opcode`.
-fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, funct7: u32) R.Result[bool, str] {
+# registers (an immediate source is materialized into the scratch register).
+# `word_form` selects whether a 32-bit operation uses the RV64 word group: `mul` has
+# a `mulw` word form, so it sets it and `alu_opcode` picks OP_32 at 32-bit width; the
+# bitwise `and` / `or` / `xor` have NO word form (RISC-V defines no andw / orw /
+# xorw), so they clear it and always encode as the full-register OP. a bitwise op of
+# two consistently extended 32-bit operands yields a consistently extended result, so
+# the full-register form is correct at every width.
+fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, funct7: u32, word_form: bool) R.Result[bool, str] {
     if (mi.operand_count < 3) { ret R.err[bool, str]("encode: ALU op missing operands"); }
 
     val rdr: R.Result[i32, str] = req_gpr(?mi.operands[0]);
@@ -552,7 +557,9 @@ fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, funct7:
     if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
     val rs2: u32 = R.unwrap_ok[i32, str](rmr)::u32;
 
-    emit_word(st, pack_r(alu_opcode(mi.width), funct3, funct7, rd, rs1, rs2));
+    var opcode: u32 = OP;
+    if (word_form) { opcode = alu_opcode(mi.width); }
+    emit_word(st, pack_r(opcode, funct3, funct7, rd, rs1, rs2));
     ret R.ok[bool, str](true);
 }
 
@@ -1743,10 +1750,10 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     # concrete RV64 opcodes.
     if (op == riscv64.ADD::u16)    { ret encode_addsub(st, mi, false); }
     if (op == riscv64.SUB::u16)    { ret encode_addsub(st, mi, true); }
-    if (op == riscv64.MUL::u16)    { ret encode_alu3(st, mi, F3_ADD, F7_MULDIV); }
-    if (op == riscv64.AND::u16)    { ret encode_alu3(st, mi, F3_AND, F7_ZERO); }
-    if (op == riscv64.OR::u16)     { ret encode_alu3(st, mi, F3_OR, F7_ZERO); }
-    if (op == riscv64.XOR::u16)    { ret encode_alu3(st, mi, F3_XOR, F7_ZERO); }
+    if (op == riscv64.MUL::u16)    { ret encode_alu3(st, mi, F3_ADD, F7_MULDIV, true); }
+    if (op == riscv64.AND::u16)    { ret encode_alu3(st, mi, F3_AND, F7_ZERO, false); }
+    if (op == riscv64.OR::u16)     { ret encode_alu3(st, mi, F3_OR, F7_ZERO, false); }
+    if (op == riscv64.XOR::u16)    { ret encode_alu3(st, mi, F3_XOR, F7_ZERO, false); }
     if (op == riscv64.SLL::u16)    { ret encode_shift(st, mi, F3_SLL, false); }
     if (op == riscv64.SRL::u16)    { ret encode_shift(st, mi, F3_SRL, false); }
     if (op == riscv64.SRA::u16)    { ret encode_shift(st, mi, F3_SRL, true); }

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -1913,11 +1913,23 @@ fun asm_token(s: str, start: usize, out: *u8, cap: usize, next: *usize) bool {
     ret j > 0;
 }
 
+# true when `mnem` names an RV64A atomic (lr / sc / amo*). the width (.w/.d) and
+# ordering (.aq/.rl/.aqrl) suffixes ride along, so a prefix test classifies the whole
+# family. used by the clobber classifier - lr / sc / amo* all write their rd operand.
+fun rv_mnem_is_amo(mnem: str) bool {
+    val len: usize = str_len(mnem);
+    if (len >= 3 && mnem[0] == 'l'::char && mnem[1] == 'r'::char && mnem[2] == '.'::char) { ret true; }
+    if (len >= 3 && mnem[0] == 's'::char && mnem[1] == 'c'::char && mnem[2] == '.'::char) { ret true; }
+    if (len >= 3 && mnem[0] == 'a'::char && mnem[1] == 'm'::char && mnem[2] == 'o'::char) { ret true; }
+    ret false;
+}
+
 # OR the registers one trimmed RISC-V inline-asm statement writes into `@gp`. a
 # leading `label:` is stripped and the remainder re-dispatched. a call clobbers the
-# caller-saved file; the stores / branches / system / fence / return forms write
-# nothing; the recognized destination-writing forms clobber their first register
-# operand; an unrecognized statement conservatively clobbers everything.
+# caller-saved file; the stores / branches / system / fence / pause / return forms write
+# nothing; the recognized destination-writing forms (including the RV64A atomics) clobber
+# their first register operand; an unrecognized statement conservatively clobbers
+# everything.
 fun asm_stmt_clobbers(s: str, gp: *u32, fp: *u32) {
     var mbuf: [32]u8;
     var after: usize = 0;
@@ -1938,6 +1950,7 @@ fun asm_stmt_clobbers(s: str, gp: *u32, fp: *u32) {
     if (str_equals(mnem, "sb") || str_equals(mnem, "sh") || str_equals(mnem, "sw") ||
         str_equals(mnem, "sd") || str_equals(mnem, "nop") || str_equals(mnem, "ret") ||
         str_equals(mnem, "ecall") || str_equals(mnem, "ebreak") || str_equals(mnem, "fence") ||
+        str_equals(mnem, "pause") ||
         str_equals(mnem, "j") || str_equals(mnem, "jr") ||
         str_equals(mnem, "beq") || str_equals(mnem, "bne") || str_equals(mnem, "blt") ||
         str_equals(mnem, "bge") || str_equals(mnem, "bltu") || str_equals(mnem, "bgeu") ||
@@ -1955,8 +1968,10 @@ fun asm_stmt_clobbers(s: str, gp: *u32, fp: *u32) {
         ret;
     }
 
-    # the destination-writing forms clobber their first register operand (rd).
-    if (str_equals(mnem, "li") || str_equals(mnem, "la") || str_equals(mnem, "lui") ||
+    # the destination-writing forms clobber their first register operand (rd). the
+    # RV64A atomics (lr / sc / amo*) join this set: each writes rd, the leftmost operand.
+    if (rv_mnem_is_amo(mnem) ||
+        str_equals(mnem, "li") || str_equals(mnem, "la") || str_equals(mnem, "lui") ||
         str_equals(mnem, "auipc") || str_equals(mnem, "mv") || str_equals(mnem, "neg") ||
         str_equals(mnem, "not") || str_equals(mnem, "seqz") || str_equals(mnem, "snez") ||
         str_equals(mnem, "add") || str_equals(mnem, "addi") || str_equals(mnem, "sub") ||
@@ -3732,6 +3747,17 @@ test "mach.lang.target.isa.riscv64.encode:asm_clobbers_classification" {
     asm_clobbers("loop: addi t0, t0, 1", ?gp, ?fp);
     if ((gp & (1::u32 << 5)) == 0) { bad = 1; }  # t0 = x5
     if ((gp & ~(1::u32 << 5)) != 0) { bad = 1; } # nothing else
+
+    # the RV64A atomics write their rd operand (the leftmost register); pause writes
+    # nothing. lr / sc / amo* must classify precisely, not fall to the all-clobber path.
+    gp = 0; fp = 0;
+    asm_clobbers("lr.d t0, (a1)\nsc.d t1, a2, (a1)\namoadd.d.aqrl a0, a2, (a1)\npause", ?gp, ?fp);
+    if ((gp & (1::u32 << 5)) == 0)  { bad = 1; }  # t0 = x5 written by lr.d
+    if ((gp & (1::u32 << 6)) == 0)  { bad = 1; }  # t1 = x6 written by sc.d
+    if ((gp & (1::u32 << 10)) == 0) { bad = 1; }  # a0 = x10 written by amoadd.d.aqrl
+    val amo_mask: u32 = (1::u32 << 5) | (1::u32 << 6) | (1::u32 << 10);
+    if ((gp & ~amo_mask) != 0) { bad = 1; }       # nothing else (pause writes none)
+    if (fp != 0) { bad = 1; }
 
     # an unrecognized statement conservatively clobbers everything.
     gp = 0; fp = 0;

--- a/src/lang/target/isa/riscv64/printer.mach
+++ b/src/lang/target/isa/riscv64/printer.mach
@@ -338,7 +338,8 @@ fun print_mem(out: *writer.Writer, f: *mir.MirFunction, op: *mir.MirOperand) R.R
 # return the frame-pointer offset of the slot a MIR value owns, or none when it owns no
 # slot
 #
-# Mirrors the encoder's lookup over the laid-out frame.
+# Mirrors the encoder's lookup over the laid-out frame, including the bias past the
+# reserved ra / s0 record and callee-saved areas at the frame top.
 # ---
 # f:   the owning function (carries the laid-out frame)
 # v:   the MIR value whose slot is sought
@@ -348,7 +349,7 @@ fun frame_slot_offset(f: *mir.MirFunction, v: u32) O.Option[i64] {
     if (frame.slots == nil) { ret O.none[i64](); }
     var i: u32 = 0;
     for (i < frame.slot_count) {
-        if (frame.slots[i].value == v) { ret O.some[i64](frame.slots[i].offset); }
+        if (frame.slots[i].value == v) { ret O.some[i64](frame.slots[i].offset - encode.frame_reserved_top(f)); }
         i = i + 1;
     }
     ret O.none[i64]();

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -68,11 +68,21 @@ val MH_EXECUTE: u32 = 2;
 # header flag set on a fully-resolved static executable (no undefined symbols).
 val MH_NOUNDEFS: u32 = 0x1;
 
+# header flags for a dynamically-linked image: it is bound by dyld and uses the
+# two-level namespace (each undefined symbol names the dylib that defines it).
+val MH_DYLDLINK: u32 = 0x4;
+val MH_TWOLEVEL: u32 = 0x80;
+
 # load-command ids.
-val LC_SEGMENT_64: u32 = 0x19;
-val LC_SYMTAB:     u32 = 0x2;
-val LC_DYSYMTAB:   u32 = 0xB;
-val LC_UNIXTHREAD: u32 = 0x5;
+val LC_SEGMENT_64:    u32 = 0x19;
+val LC_SYMTAB:        u32 = 0x2;
+val LC_DYSYMTAB:      u32 = 0xB;
+val LC_UNIXTHREAD:    u32 = 0x5;
+val LC_LOAD_DYLIB:    u32 = 0xC;
+val LC_LOAD_DYLINKER: u32 = 0xE;
+# the LC_REQ_DYLD bit is set on LC_DYLD_INFO_ONLY so a loader that cannot read
+# the compressed dyld-info stream refuses the image rather than mis-loading it.
+val LC_DYLD_INFO_ONLY: u32 = 0x80000022;
 
 # VM protection bits used for segment maxprot/initprot.
 val VM_PROT_READ:    u32 = 1;
@@ -94,6 +104,13 @@ val N_SECT: u8 = 0x0e;  # defined in section n_sect
 # nlist n_desc bit marking a weak definition.
 val N_WEAK_DEF: u16 = 0x0080;
 
+# nlist n_desc reference-type field (low 3 bits) and the value marking an undefined
+# symbol referenced lazily - a function call. Mach-O gives undefined symbols no
+# n_type/n_sect class, so this is how the object format round-trips a symbol's
+# function-ness, which the linker reads to give a dynamic import a call stub.
+val REFERENCE_TYPE_MASK:          u16 = 0x7;
+val REFERENCE_FLAG_UNDEFINED_LAZY: u16 = 0x1;
+
 # x86_64 relocation types (X86_64_RELOC_*).
 val X86_64_RELOC_UNSIGNED: u32 = 0;
 val X86_64_RELOC_SIGNED:   u32 = 1;
@@ -114,8 +131,37 @@ val SEGMENT_CMD_64_SIZE: usize = 72;
 val SECTION_64_SIZE:     usize = 80;
 val SYMTAB_CMD_SIZE:     usize = 24;
 val DYSYMTAB_CMD_SIZE:   usize = 80;
+val DYLD_INFO_CMD_SIZE:  usize = 48;   # cmd + cmdsize + 5 (off,size) pairs
+val DYLINKER_CMD_BASE:   usize = 12;   # cmd + cmdsize + name lc_str offset
+val DYLIB_CMD_BASE:      usize = 24;   # the dylib lc_str, then 3 version words
 val NLIST_64_SIZE:       usize = 16;
 val RELOC_INFO_SIZE:     usize = 8;
+
+# dyld bind-opcode bytes (the high nibble is the opcode, the low nibble an
+# immediate). a non-lazy pointer is bound by selecting the dylib, naming the
+# symbol, setting the pointer type, locating the slot, then DO_BIND.
+val BIND_OPCODE_DONE:                          u8 = 0x00;
+val BIND_OPCODE_SET_DYLIB_ORDINAL_IMM:         u8 = 0x10;
+val BIND_OPCODE_SET_DYLIB_ORDINAL_ULEB:        u8 = 0x20;
+val BIND_OPCODE_SET_DYLIB_SPECIAL_IMM:         u8 = 0x30;
+val BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM: u8 = 0x40;
+val BIND_OPCODE_SET_TYPE_IMM:                  u8 = 0x50;
+val BIND_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB:   u8 = 0x70;
+val BIND_OPCODE_DO_BIND:                       u8 = 0x90;
+
+# bind type for an absolute pointer slot, and the n_desc/bind code for a symbol
+# resolved by a flat (whole-process) search rather than a named dylib.
+val BIND_TYPE_POINTER:               u8  = 0x1;
+val BIND_SPECIAL_DYLIB_FLAT_LOOKUP:  u8  = 0xE;    # -2 as a 4-bit immediate
+val DYNAMIC_LOOKUP_ORDINAL:          u16 = 0xFE;   # n_desc library-ordinal byte
+
+# the dynamic loader Darwin executables name in LC_LOAD_DYLINKER.
+val DARWIN_DYLD_PATH: str = "/usr/lib/dyld";
+
+# per-arch import stub sizes: x86_64 is a 6-byte `jmp *got(%rip)`, arm64 a 12-byte
+# adrp/ldr/br through the bound got slot.
+val MACHO_X86_STUB_SIZE:   usize = 6;
+val MACHO_ARM64_STUB_SIZE: usize = 12;
 
 # thread-state flavors and u32 counts for the LC_UNIXTHREAD entry record.
 val X86_THREAD_STATE64:       u32 = 4;
@@ -569,6 +615,12 @@ fun write_nlist(buf: *u8, sym_off: usize, str_base: usize, str_pos: *usize,
         n_value = sec_addr[sym.section] + sym.offset::u64;
         if ((sym.flags & of.SYM_OBJ_FLAG_WEAK) != 0) { n_desc = N_WEAK_DEF; }
     }
+    or ((sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0) {
+        # an undefined symbol carries no n_type/n_sect class, so its function-ness
+        # (which the linker needs to give a dynamic import a call stub) is recorded
+        # as REFERENCE_FLAG_UNDEFINED_LAZY in n_desc and recovered by parse_object.
+        n_desc = REFERENCE_FLAG_UNDEFINED_LAZY;
+    }
     if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0 || sym.section == of.SECTION_EXTERNAL) {
         n_type = n_type | N_EXT;
     }
@@ -942,10 +994,11 @@ var macho_vtable: of.OfVTable;
 
 # build the Mach-O OfVTable and install it into a registry
 #
-# Sets the format name ("macho") and the object writer, parser, and static-exec
-# writer; `emit_dyn_exec` is left nil because the dyld bind/rebase writer (and the
-# libSystem dynamic linkage modern macOS requires) is the Darwin-runtime follow-up
-# (#1178), not this object-format substrate. Idempotent through `of.register`.
+# Sets the format name ("macho") and the object writer, parser, static-exec writer,
+# and dynamic-exec writer; `emit_dyn_exec` frames a dyld-loadable executable
+# (LC_LOAD_DYLINKER, LC_LOAD_DYLIB, an LC_DYLD_INFO_ONLY bind stream, and an
+# __LINKEDIT symbol/string table) for the dynamic-link plan the linker hands it.
+# Idempotent through `of.register`.
 # ---
 # reg: the object-format registry to install the vtable into
 # ret: ok(true) on success
@@ -955,7 +1008,7 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     macho_vtable.emit_object   = emit_object;
     macho_vtable.parse_object  = parse_object;
     macho_vtable.emit_exec     = emit_exec;
-    macho_vtable.emit_dyn_exec = nil::of.DynExecFn;
+    macho_vtable.emit_dyn_exec = emit_dyn_exec;
 
     of.register(reg, ?macho_vtable);
     ret R.ok[bool, str](true);
@@ -1121,6 +1174,829 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
     val wr: R.Result[bool, str] = write_file(itn, alloc, path, buf, total_size, "macho: exec");
+    A.deallocate[u8](alloc, buf, total_size);
+    ret wr;
+}
+
+# the laid-out file offsets and virtual addresses of a dynamic executable's
+# synthesized structures
+#
+# Computed once up front so the load-command writer, the segment-byte copy, the
+# stub writer, the bind/symbol writers, and the call-site patcher all read the same
+# placement. Offsets are file byte offsets; the `_va` fields are virtual addresses.
+# ---
+# hdr_span:      file/vm bytes reserved for the mach header + load commands ahead
+#                of the first linker segment, so __TEXT maps the header
+# pagezero_size: __PAGEZERO span ([0, base - hdr_span)); 0 leaves it out
+# text_va:       __TEXT virtual address (header maps here, the linker text follows)
+# stubs_off:     file offset of the import-stub section (when nimp > 0)
+# stubs_va:      virtual address of the import stubs
+# stubs_size:    total stub bytes (nimp * per-arch stub size)
+# got_off:       file offset of the bound pointer slots (when nimp > 0)
+# got_va:        virtual address of the bound pointer slots
+# got_size:      total got bytes (nimp * 8)
+# got_seg_index: index of the got segment among the image's segment commands, for
+#                the bind opcodes' segment selector
+# linkedit_off:  file offset of the __LINKEDIT segment
+# linkedit_va:   virtual address of the __LINKEDIT segment
+# linkedit_size: __LINKEDIT byte length (bind stream + symbols + strings)
+# bind_off:      file offset of the dyld bind opcode stream
+# bind_size:     bind opcode stream byte length
+# symtab_off:    file offset of the nlist_64 array
+# strtab_off:    file offset of the symbol string table
+# strtab_size:   symbol string table byte length
+rec MachoDynLayout {
+    hdr_span:      usize;
+    pagezero_size: u64;
+    text_va:       u64;
+
+    stubs_off:     usize;
+    stubs_va:      u64;
+    stubs_size:    usize;
+
+    got_off:       usize;
+    got_va:        u64;
+    got_size:      usize;
+    got_seg_index: u32;
+
+    linkedit_off:  usize;
+    linkedit_va:   u64;
+    linkedit_size: usize;
+
+    bind_off:      usize;
+    bind_size:     usize;
+    symtab_off:    usize;
+    strtab_off:    usize;
+    strtab_size:   usize;
+}
+
+# encode `v` as unsigned LEB128 into `buf` at `off`, returning the next offset.
+# ---
+# buf: the output buffer
+# off: byte offset to write at
+# v:   the value to encode
+# ret: the byte offset just past the encoding
+fun write_uleb(buf: *u8, off: usize, v: u64) usize {
+    var value: u64 = v;
+    var p:     usize = off;
+    var more:  bool = true;
+    for (more) {
+        var byte: u8 = (value & 0x7F)::u8;
+        value = value >> 7;
+        if (value != 0) { byte = byte | 0x80; } or { more = false; }
+        buf[p] = byte;
+        p = p + 1;
+    }
+    ret p;
+}
+
+# the number of bytes the unsigned LEB128 encoding of `v` occupies.
+# ---
+# v:   the value to measure
+# ret: the encoding byte length (at least 1)
+fun uleb_size(v: u64) usize {
+    var value: u64 = v;
+    var n:     usize = 1;
+    for (value >= 0x80) { value = value >> 7; n = n + 1; }
+    ret n;
+}
+
+# the number of function imports in a dynamic-link plan (data imports get no stub
+# or got slot).
+# ---
+# dyn: the dynamic-link plan
+# ret: the function-import count
+fun func_import_count(dyn: *of.DynamicInfo) u32 {
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < dyn.import_count) {
+        if (dyn.imports[i].is_func) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# the per-arch import-stub byte size: x86_64 a 6-byte rip-relative jump, arm64 a
+# 12-byte adrp/ldr/br through the bound got slot.
+# ---
+# arch_id: the target ISA id
+# ret:     the stub byte size for the architecture
+fun macho_stub_size(arch_id: u32) usize {
+    if (arch_is_arm64(arch_id)) { ret MACHO_ARM64_STUB_SIZE; }
+    ret MACHO_X86_STUB_SIZE;
+}
+
+# write one import stub that branches indirectly through its bound got slot
+#
+# x86_64 emits `jmp qword [rip + d]` reaching the slot from the instruction's end;
+# arm64 emits `adrp x16, page(got); ldr x16, [x16, lo12(got)]; br x16`. The got
+# slot is bound by dyld at load (non-lazy), so the first call through the stub
+# reaches the resolved target.
+# ---
+# buf:      the output buffer
+# arch_id:  the target ISA id selecting the encoding
+# stub_off: file offset of this stub
+# stub_va:  virtual address of this stub
+# slot_va:  virtual address of the bound got slot the stub jumps through
+fun write_macho_stub(buf: *u8, arch_id: u32, stub_off: usize, stub_va: u64, slot_va: u64) {
+    if (arch_is_arm64(arch_id)) {
+        # adrp x16, page(slot): the signed page delta packed into immlo/immhi.
+        val slot_page: u64 = (slot_va >> 12) << 12;
+        val stub_page: u64 = (stub_va >> 12) << 12;
+        val delta:     i64 = (slot_page::i64) - (stub_page::i64);
+        val imm21:     u64 = ((delta >> 12)::u64) & 0x1FFFFF;
+        val immlo:     u32 = (imm21 & 0x3)::u32;
+        val immhi:     u32 = ((imm21 >> 2) & 0x7FFFF)::u32;
+        bin.write_u32_le(buf, stub_off, 0x90000000 | (immlo << 29) | (immhi << 5) | 16);
+        # ldr x16, [x16, #lo12(slot)]: the unsigned offset is scaled by 8.
+        val imm12: u32 = (((slot_va & 0xFFF) >> 3) & 0xFFF)::u32;
+        bin.write_u32_le(buf, stub_off + 4, 0xF9400000 | (imm12 << 10) | (16 << 5) | 16);
+        # br x16.
+        bin.write_u32_le(buf, stub_off + 8, 0xD61F0200);
+        ret;
+    }
+    # x86_64: jmp qword [rip + d]  (FF 25 d) -> the got slot.
+    buf[stub_off] = 0xFF; buf[stub_off + 1] = 0x25;
+    val next: u64 = stub_va + 6;
+    bin.write_u32_le(buf, stub_off + 2, (slot_va - next)::u32);
+}
+
+# the byte size of an LC_LOAD_DYLINKER command (the fixed head plus the loader
+# path, 8-byte aligned).
+# ---
+# ret: the command byte size
+fun dylinker_cmd_size() usize {
+    ret bin.align_up(DYLINKER_CMD_BASE + str_len(DARWIN_DYLD_PATH) + 1, 8);
+}
+
+# the byte size of an LC_LOAD_DYLIB command for a dependency named `name` (the
+# fixed head plus the name, 8-byte aligned).
+# ---
+# name: the dylib install name
+# ret:  the command byte size
+fun dylib_cmd_size(name: str) usize {
+    var n: usize = 0;
+    if (name != nil) { n = str_len(name); }
+    ret bin.align_up(DYLIB_CMD_BASE + n + 1, 8);
+}
+
+# write the LC_LOAD_DYLINKER command naming the dynamic loader.
+# ---
+# buf: the output buffer
+# off: byte offset of the command
+# ret: the byte offset just past the command
+fun write_load_dylinker(buf: *u8, off: usize) usize {
+    val sz: usize = dylinker_cmd_size();
+    bin.write_u32_le(buf, off, LC_LOAD_DYLINKER);
+    bin.write_u32_le(buf, off + 4, sz::u32);
+    bin.write_u32_le(buf, off + 8, DYLINKER_CMD_BASE::u32);
+    bin.write_str(buf, off + DYLINKER_CMD_BASE, DARWIN_DYLD_PATH);
+    ret off + sz;
+}
+
+# write one LC_LOAD_DYLIB command naming a shared dependency
+#
+# The timestamp is 0 and both version fields are 1.0.0; dyld resolves the
+# dependency by install name at load, so the exact versions are not load-bearing.
+# ---
+# buf:  the output buffer
+# off:  byte offset of the command
+# name: the dylib install name
+# ret:  the byte offset just past the command
+fun write_load_dylib(buf: *u8, off: usize, name: str) usize {
+    val sz: usize = dylib_cmd_size(name);
+    bin.write_u32_le(buf, off, LC_LOAD_DYLIB);
+    bin.write_u32_le(buf, off + 4, sz::u32);
+    bin.write_u32_le(buf, off + 8, DYLIB_CMD_BASE::u32);
+    bin.write_u32_le(buf, off + 12, 0);
+    bin.write_u32_le(buf, off + 16, 0x10000);
+    bin.write_u32_le(buf, off + 20, 0x10000);
+    bin.write_str(buf, off + DYLIB_CMD_BASE, name);
+    ret off + sz;
+}
+
+# write one LC_SEGMENT_64 head, holding `nsects` following section_64 entries
+#
+# The `cmdsize` covers the segment command plus its sections; the caller writes the
+# section_64 entries into the returned offset and continues past them.
+# ---
+# buf:      the output buffer
+# off:      byte offset of the command
+# name:     the 16-byte-clamped segment name
+# vmaddr:   the segment virtual address
+# vmsize:   the segment in-memory byte size
+# fileoff:  the segment file offset
+# filesize: the segment on-disk byte size
+# maxprot:  the maximum VM protection
+# initprot: the initial VM protection
+# nsects:   the number of section_64 entries that follow
+# ret:      the byte offset of the first following section_64 entry
+fun write_segment_cmd(buf: *u8, off: usize, name: str, vmaddr: u64, vmsize: u64,
+                      fileoff: u64, filesize: u64, maxprot: u32, initprot: u32, nsects: u32) usize {
+    bin.write_u32_le(buf, off, LC_SEGMENT_64);
+    bin.write_u32_le(buf, off + 4, (SEGMENT_CMD_64_SIZE + nsects::usize * SECTION_64_SIZE)::u32);
+    write_fixed16(buf, off + 8, name);
+    bin.write_u64_le(buf, off + 24, vmaddr);
+    bin.write_u64_le(buf, off + 32, vmsize);
+    bin.write_u64_le(buf, off + 40, fileoff);
+    bin.write_u64_le(buf, off + 48, filesize);
+    bin.write_u32_le(buf, off + 56, maxprot);
+    bin.write_u32_le(buf, off + 60, initprot);
+    bin.write_u32_le(buf, off + 64, nsects);
+    bin.write_u32_le(buf, off + 68, 0);
+    ret off + SEGMENT_CMD_64_SIZE;
+}
+
+# write one section_64 entry; reloc, indirect, and reserved fields are zero
+#
+# The synthesized stub and got sections are plain (no S_SYMBOL_STUBS /
+# S_NON_LAZY_SYMBOL_POINTERS flags), so they need no indirect symbol table: dyld
+# binds the got slots through the LC_DYLD_INFO bind opcodes, which address the slot
+# by segment and offset, and the stubs are ordinary code. A real section lets the
+# llvm/otool readers map the segment index and the bind address.
+# ---
+# buf:      the output buffer
+# off:      byte offset of the section_64 entry
+# sectname: the 16-byte-clamped section name
+# segname:  the 16-byte-clamped enclosing segment name
+# addr:     the section virtual address
+# size:     the section byte size
+# fileoff:  the section file offset
+# flags:    the section flags word
+# ret:      the byte offset just past the entry
+fun write_section_64(buf: *u8, off: usize, sectname: str, segname: str, addr: u64, size: u64,
+                     fileoff: u32, flags: u32) usize {
+    write_fixed16(buf, off, sectname);
+    write_fixed16(buf, off + 16, segname);
+    bin.write_u64_le(buf, off + 32, addr);
+    bin.write_u64_le(buf, off + 40, size);
+    bin.write_u32_le(buf, off + 48, fileoff);
+    bin.write_u32_le(buf, off + 52, 0);
+    bin.write_u32_le(buf, off + 56, 0);
+    bin.write_u32_le(buf, off + 60, 0);
+    bin.write_u32_le(buf, off + 64, flags);
+    bin.write_u32_le(buf, off + 68, 0);
+    bin.write_u32_le(buf, off + 72, 0);
+    bin.write_u32_le(buf, off + 76, 0);
+    ret off + SECTION_64_SIZE;
+}
+
+# the two-level-namespace library ordinal for a function import: the 1-based index
+# of its dylib among the dependencies, or the flat-lookup ordinal when the import
+# is unattributed.
+# ---
+# dyn:          the dynamic-link plan
+# import_index: the raw import index
+# ret:          the dylib ordinal (1-based), or DYNAMIC_LOOKUP_ORDINAL for ANY
+fun dylib_ordinal_for(dyn: *of.DynamicInfo, import_index: u32) u32 {
+    val li: u32 = dyn.imports[import_index].lib_index;
+    if (li == of.DYNLIB_ANY) { ret DYNAMIC_LOOKUP_ORDINAL::u32; }
+    ret li + 1;
+}
+
+# the byte length of the dyld bind opcode stream for the plan's function imports.
+# ---
+# itn: interner resolving the import symbol names
+# dyn: the dynamic-link plan
+# ret: the bind stream byte length (0 when there are no function imports)
+fun measure_bind_info(itn: *intern.Interner, dyn: *of.DynamicInfo) usize {
+    var size: usize = 0;
+    var n:    u32 = 0;
+    var i:    u32 = 0;
+    for (i < dyn.import_count) {
+        if (dyn.imports[i].is_func) {
+            val ord: u32 = dylib_ordinal_for(dyn, i);
+            if (dyn.imports[i].lib_index == of.DYNLIB_ANY) { size = size + 1; }
+            or (ord <= 15)                                 { size = size + 1; }
+            or                                             { size = size + 1 + uleb_size(ord::u64); }
+            val name: str = resolve(itn, dyn.imports[i].symbol);
+            var nl: usize = 0;
+            if (name != nil) { nl = str_len(name); }
+            size = size + 1 + nl + 1;                       # SET_SYMBOL + name + nul
+            size = size + 1;                               # SET_TYPE_IMM
+            size = size + 1 + uleb_size(n::u64 * 8);        # SET_SEGMENT_AND_OFFSET
+            size = size + 1;                               # DO_BIND
+            n = n + 1;
+        }
+        i = i + 1;
+    }
+    if (n > 0) { size = size + 1; }                        # BIND_OPCODE_DONE
+    ret size;
+}
+
+# write the dyld bind opcode stream binding each function import's got slot
+#
+# Each import selects its dylib, names the symbol, sets the pointer type, locates
+# its got slot by segment + offset, and binds it. The binds are non-lazy, so dyld
+# resolves every slot at load.
+# ---
+# buf:           the output buffer
+# off:           byte offset of the bind stream
+# itn:           interner resolving the import symbol names
+# dyn:           the dynamic-link plan
+# got_seg_index: the got segment's index for the segment selector
+# ret:           the byte offset just past the stream
+fun write_bind_info(buf: *u8, off: usize, itn: *intern.Interner, dyn: *of.DynamicInfo, got_seg_index: u32) usize {
+    var p: usize = off;
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < dyn.import_count) {
+        if (dyn.imports[i].is_func) {
+            if (dyn.imports[i].lib_index == of.DYNLIB_ANY) {
+                buf[p] = BIND_OPCODE_SET_DYLIB_SPECIAL_IMM | BIND_SPECIAL_DYLIB_FLAT_LOOKUP;
+                p = p + 1;
+            }
+            or {
+                val ord: u32 = dylib_ordinal_for(dyn, i);
+                if (ord <= 15) {
+                    buf[p] = BIND_OPCODE_SET_DYLIB_ORDINAL_IMM | (ord::u8 & 0xF);
+                    p = p + 1;
+                }
+                or {
+                    buf[p] = BIND_OPCODE_SET_DYLIB_ORDINAL_ULEB;
+                    p = write_uleb(buf, p + 1, ord::u64);
+                }
+            }
+
+            buf[p] = BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM;
+            p = p + 1 + bin.write_str(buf, p + 1, resolve(itn, dyn.imports[i].symbol));
+
+            buf[p] = BIND_OPCODE_SET_TYPE_IMM | BIND_TYPE_POINTER;
+            p = p + 1;
+
+            buf[p] = BIND_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | (got_seg_index::u8 & 0xF);
+            p = write_uleb(buf, p + 1, n::u64 * 8);
+
+            buf[p] = BIND_OPCODE_DO_BIND;
+            p = p + 1;
+
+            n = n + 1;
+        }
+        i = i + 1;
+    }
+    if (n > 0) { buf[p] = BIND_OPCODE_DONE; p = p + 1; }
+    ret p;
+}
+
+# rewrite each deferred import call site to a pc-relative branch to its stub
+#
+# The linker recorded a `PltFixup` for every call to a function import it could not
+# resolve, carrying the patch site's segment, in-segment offset, and virtual
+# address. With the stub virtual address `S` the displacement is `S + A - P`:
+# x86_64 stores it as a 4-byte rip-relative field, arm64 packs `(disp >> 2)` into a
+# BL's imm26. The 4-byte field must lie within the segment's file bytes and the
+# displacement must fit the instruction's range, or the link fails rather than
+# writing a corrupt branch.
+# ---
+# buf:         the output buffer being patched
+# arch_id:     the target ISA id selecting the field encoding
+# lay:         the resolved dynamic-structure layout (stub addresses)
+# dyn:         the dynamic-link plan (maps import index to stub ordinal)
+# fixups:      the deferred import call-site fixups
+# fixup_count: number of fixups
+# seg_offsets: per-segment file offsets of the linker's segments
+# segs:        the linker's loadable segments
+# seg_count:   number of segments
+# nimp:        number of function imports; zero short-circuits to ok
+# ret:         ok(true), or an error on an out-of-range or overflowing fixup
+fun patch_macho_fixups(buf: *u8, arch_id: u32, lay: *MachoDynLayout, dyn: *of.DynamicInfo,
+                       fixups: *of.PltFixup, fixup_count: u32, seg_offsets: *usize,
+                       segs: *of.LoadSegment, seg_count: u32, nimp: u32) R.Result[bool, str] {
+    if (nimp == 0) { ret R.ok[bool, str](true); }
+    val stub_sz: usize = macho_stub_size(arch_id);
+    var i: u32 = 0;
+    for (i < fixup_count) {
+        val fx: *of.PltFixup = ?fixups[i];
+        if (fx.seg_index >= seg_count) {
+            ret R.err[bool, str]("macho: dynamic call-site fixup references an out-of-range segment");
+        }
+        val n: u32 = macho_func_ordinal(dyn, fx.import_index);
+        if (n == 0xFFFFFFFF) {
+            ret R.err[bool, str]("macho: dynamic call-site fixup targets a non-function import");
+        }
+        if (fx.seg_offset::usize + 4 > segs[fx.seg_index].filesz) {
+            ret R.err[bool, str]("macho: dynamic call-site fixup offset out of range");
+        }
+
+        val stub_va: u64 = lay.stubs_va + n::u64 * stub_sz::u64;
+        val disp:    i64 = (stub_va::i64) + fx.addend - (fx.patch_vaddr::i64);
+        val file_off: usize = seg_offsets[fx.seg_index] + fx.seg_offset::usize;
+
+        if (arch_is_arm64(arch_id)) {
+            val lim: i64 = 134217728;   # +-128 MiB CALL26 range
+            if (disp < -lim || disp >= lim || (disp & 3) != 0) {
+                ret R.err[bool, str]("macho: dynamic call-site displacement overflows a 26-bit branch");
+            }
+            val word:  u32 = bin.read_u32_le(buf, file_off);
+            val imm26: u32 = (((disp::u64) & 0x0FFFFFFC) >> 2)::u32;
+            bin.write_u32_le(buf, file_off, (word & 0xFC000000) | imm26);
+        }
+        or {
+            if (disp > 2147483647 || disp < -2147483648) {
+                ret R.err[bool, str]("macho: dynamic call-site displacement overflows 32 bits");
+            }
+            bin.write_u32_le(buf, file_off, (disp::u64)::u32);
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the stub ordinal (0-based among function imports) for a raw import index, or
+# 0xFFFFFFFF when the import is not a function. The stubs and got slots are laid
+# out in function-import order.
+# ---
+# dyn:          the dynamic-link plan
+# import_index: the raw import index
+# ret:          the stub ordinal, or 0xFFFFFFFF for a non-function import
+fun macho_func_ordinal(dyn: *of.DynamicInfo, import_index: u32) u32 {
+    if (import_index >= dyn.import_count)   { ret 0xFFFFFFFF; }
+    if (!dyn.imports[import_index].is_func) { ret 0xFFFFFFFF; }
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < import_index) {
+        if (dyn.imports[i].is_func) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# the section name for a linker load segment, chosen from its permissions and
+# whether it is zero-fill (bss): executable is __text, zero-fill is __bss, other
+# writable is __data, read-only is __const.
+# ---
+# flags:    the segment's SEG_FLAG_* permission bits
+# zerofill: whether the segment carries no file bytes (bss)
+# ret:      the section name
+fun dyn_sectname(flags: u32, zerofill: bool) str {
+    if ((flags & of.SEG_FLAG_EXECUTE) != 0) { ret "__text"; }
+    if (zerofill)                           { ret "__bss"; }
+    if ((flags & of.SEG_FLAG_WRITE) != 0)   { ret "__data"; }
+    ret "__const";
+}
+
+# the section flags word for a linker load segment: executable code is pure
+# instructions, zero-fill is S_ZEROFILL, the rest are regular.
+# ---
+# flags:    the segment's SEG_FLAG_* permission bits
+# zerofill: whether the segment carries no file bytes (bss)
+# ret:      the section flags word
+fun dyn_sect_flags(flags: u32, zerofill: bool) u32 {
+    if ((flags & of.SEG_FLAG_EXECUTE) != 0) { ret S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS; }
+    if (zerofill)                           { ret S_ZEROFILL; }
+    ret 0;
+}
+
+# write a dynamically-linked MH_EXECUTE Mach-O, installed as the of.DynExecFn
+#
+# Frames the linker's laid-out load segments into a dyld-loadable executable: a
+# leading __PAGEZERO, a __TEXT that maps the mach header below the linker's text so
+# dyld can read the load commands, the linker's remaining segments, synthesized
+# import-stub and got segments (when there are function imports), and a __LINKEDIT
+# carrying the LC_DYLD_INFO_ONLY bind stream plus the symbol and string tables. The
+# load commands name the dynamic loader (LC_LOAD_DYLINKER), each shared dependency
+# (LC_LOAD_DYLIB), the symbol tables (LC_SYMTAB/LC_DYSYMTAB), and the static entry
+# (LC_UNIXTHREAD). Each function import's got slot is bound non-lazily by dyld, and
+# every deferred call site is redirected to its stub.
+#
+# The image uses fixed virtual addresses (no MH_PIE): the linker assigned absolute
+# addresses from the OS base and the back end emits absolute addressing, so a load
+# bias would invalidate them. Apple Silicon additionally requires a code signature
+# the kernel verifies before exec; this writer emits no LC_CODE_SIGNATURE, so its
+# output is byte-verifiable but not runnable on arm64 without an external ad-hoc
+# sign step.
+# ---
+# alloc:       allocator for the output buffer and the scratch offset table
+# itn:         interner resolving the dynamic-plan names (sonames, imports)
+# isa_vt:      the instruction-set vtable selecting the cputype and stub encoding
+# segs:        loadable segments, in ascending virtual-address order
+# seg_count:   number of segments
+# entry:       program entry-point virtual address
+# funcs:       per-function metadata (unused)
+# func_count:  number of entries in funcs (unused)
+# dyn:         the dynamic-link plan (dependencies + imports)
+# fixups:      the deferred import call-site fixups
+# fixup_count: number of fixups
+# path:        null-terminated output file path
+# ret:         ok(true) on success, or an error string
+fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
+                  seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
+                  dyn: *of.DynamicInfo, fixups: *of.PltFixup, fixup_count: u32,
+                  path: *u8) R.Result[bool, str] {
+    if (isa_vt == nil) { ret R.err[bool, str]("macho: nil dyn-exec isa"); }
+    if (path == nil)   { ret R.err[bool, str]("macho: nil dyn-exec path"); }
+    if (dyn == nil)    { ret R.err[bool, str]("macho: nil dynamic plan"); }
+    if (itn == nil)    { ret R.err[bool, str]("macho: no interner for dyn-exec"); }
+    if (seg_count == 0) { ret R.err[bool, str]("macho: dyn-exec has no load segments"); }
+    val arch_id: u32 = isa_vt.id;
+    val ct: R.Result[u32, str] = cpu_type_for(arch_id);
+    if (R.is_err[u32, str](ct)) { ret R.err[bool, str](R.unwrap_err[u32, str](ct)); }
+
+    val page:     usize = EXEC_PAGE_SIZE::usize;
+    val nimp:     u32 = func_import_count(dyn);
+    val stub_sz:  usize = macho_stub_size(arch_id);
+
+    # load-command byte size. the segment count is __PAGEZERO + the linker segments
+    # + (stubs, got when there are function imports) + __LINKEDIT.
+    var seg_cmds: u32 = seg_count + 1;              # linker segments + __LINKEDIT
+    if (segs[0].vaddr > 0) { seg_cmds = seg_cmds + 1; }   # __PAGEZERO
+    if (nimp > 0)          { seg_cmds = seg_cmds + 2; }   # __STUBS + __DATA(got)
+
+    var thread_state: usize = X86_THREAD_STATE64_COUNT::usize * 4;
+    if (arch_is_arm64(arch_id)) { thread_state = ARM_THREAD_STATE64_COUNT::usize * 4; }
+    val thread_cmd_size: usize = 16 + thread_state;
+
+    # every loadable segment carries one section_64 entry (the linker's segments
+    # plus the synthesized stub and got segments) so the llvm/otool readers and the
+    # bind-opcode segment index resolve against a real section table.
+    var sect_total: u32 = seg_count;
+    if (nimp > 0) { sect_total = sect_total + 2; }
+
+    var sizeofcmds: usize = seg_cmds::usize * SEGMENT_CMD_64_SIZE
+                          + sect_total::usize * SECTION_64_SIZE
+                          + DYLD_INFO_CMD_SIZE + SYMTAB_CMD_SIZE + DYSYMTAB_CMD_SIZE
+                          + dylinker_cmd_size() + thread_cmd_size;
+    var di: u32 = 0;
+    for (di < dyn.lib_count) { sizeofcmds = sizeofcmds + dylib_cmd_size(resolve(itn, dyn.libs[di].soname)); di = di + 1; }
+
+    var ncmds: u32 = seg_cmds + 5 + dyn.lib_count;   # dyld_info,symtab,dysymtab,dylinker,unixthread
+
+    var lay: MachoDynLayout;
+    lay.hdr_span = bin.align_up(MACH_HEADER_64_SIZE + sizeofcmds, page);
+    if (segs[0].vaddr < lay.hdr_span::u64) {
+        ret R.err[bool, str]("macho: dyn-exec base address too low to map the header");
+    }
+    lay.text_va       = segs[0].vaddr - lay.hdr_span::u64;
+    lay.pagezero_size = lay.text_va;
+
+    # per-linker-segment file offsets. the first segment shares __TEXT with the
+    # header (its bytes follow at hdr_span); the rest are page-aligned in turn.
+    val ro: R.Result[*usize, str] = A.zallocate[usize](alloc, seg_count::usize);
+    if (R.is_err[*usize, str](ro)) { ret R.err[bool, str]("macho: dyn-exec seg-offset alloc failed"); }
+    var seg_offsets: *usize = R.unwrap_ok[*usize, str](ro);
+
+    seg_offsets[0] = lay.hdr_span;
+    var file: usize = lay.hdr_span + segs[0].filesz;
+    var li: u32 = 1;
+    for (li < seg_count) {
+        file = bin.align_up(file, page);
+        seg_offsets[li] = file;
+        file = file + segs[li].filesz;
+        li = li + 1;
+    }
+
+    # the highest linker virtual address; the synthesized segments are placed
+    # page-aligned above it.
+    var hi_va: u64 = 0;
+    li = 0;
+    for (li < seg_count) {
+        val end: u64 = segs[li].vaddr + segs[li].memsz::u64;
+        if (end > hi_va) { hi_va = end; }
+        li = li + 1;
+    }
+    var va: u64 = bin.align_up_u64(hi_va, EXEC_PAGE_SIZE);
+
+    lay.stubs_size = 0;
+    lay.got_size = 0;
+    lay.got_seg_index = 0;
+    if (nimp > 0) {
+        file = bin.align_up(file, page);
+        lay.stubs_off  = file;
+        lay.stubs_va   = va;
+        lay.stubs_size = nimp::usize * stub_sz;
+        file = file + lay.stubs_size;
+        va   = bin.align_up_u64(va + lay.stubs_size::u64, EXEC_PAGE_SIZE);
+
+        file = bin.align_up(file, page);
+        lay.got_off  = file;
+        lay.got_va   = va;
+        lay.got_size = nimp::usize * 8;
+        file = file + lay.got_size;
+        va   = bin.align_up_u64(va + lay.got_size::u64, EXEC_PAGE_SIZE);
+
+        var pz: u32 = 0;
+        if (lay.pagezero_size > 0) { pz = 1; }
+        lay.got_seg_index = pz + seg_count + 1;   # pagezero + linker segs + stubs
+    }
+
+    # __LINKEDIT: the bind stream, then the nlist array (8-aligned), then strings.
+    file = bin.align_up(file, page);
+    lay.linkedit_off = file;
+    lay.linkedit_va  = va;
+
+    lay.bind_off  = lay.linkedit_off;
+    lay.bind_size = measure_bind_info(itn, dyn);
+    lay.symtab_off = bin.align_up(lay.bind_off + lay.bind_size, 8);
+
+    lay.strtab_size = 1;
+    var si: u32 = 0;
+    for (si < dyn.import_count) {
+        if (dyn.imports[si].is_func) {
+            val name: str = resolve(itn, dyn.imports[si].symbol);
+            if (name != nil) { lay.strtab_size = lay.strtab_size + str_len(name) + 1; } or { lay.strtab_size = lay.strtab_size + 1; }
+        }
+        si = si + 1;
+    }
+    lay.strtab_off  = lay.symtab_off + nimp::usize * NLIST_64_SIZE;
+    val total_size: usize = lay.strtab_off + lay.strtab_size;
+    lay.linkedit_size = total_size - lay.linkedit_off;
+
+    val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
+    if (R.is_err[*u8, str](res_buf)) {
+        A.deallocate[usize](alloc, seg_offsets, seg_count::usize);
+        ret R.err[bool, str]("macho: dyn-exec buffer alloc failed");
+    }
+    var buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+
+    # mach_header_64: a two-level, dyld-linked executable. MH_NOUNDEFS is not set
+    # because the imports are undefined until dyld binds them.
+    bin.write_u32_le(buf, 0, MH_MAGIC_64);
+    bin.write_u32_le(buf, 4, R.unwrap_ok[u32, str](ct));
+    bin.write_u32_le(buf, 8, cpu_subtype_for(arch_id));
+    bin.write_u32_le(buf, 12, MH_EXECUTE);
+    bin.write_u32_le(buf, 16, ncmds);
+    bin.write_u32_le(buf, 20, sizeofcmds::u32);
+    bin.write_u32_le(buf, 24, MH_DYLDLINK | MH_TWOLEVEL);
+    bin.write_u32_le(buf, 28, 0);
+
+    var lc: usize = MACH_HEADER_64_SIZE;
+
+    # __PAGEZERO.
+    if (lay.pagezero_size > 0) {
+        lc = write_segment_cmd(buf, lc, "__PAGEZERO", 0, lay.pagezero_size, 0, 0, 0, 0, 0);
+    }
+
+    # __TEXT maps the mach header below the linker's text segment (its __text
+    # section starts at the linker's text address, after the header), then the rest
+    # of the linker's segments at their assigned addresses, each with one section.
+    val text_prot: u32 = vm_prot_for(segs[0].flags);
+    var tsec: usize = write_segment_cmd(buf, lc, "__TEXT", lay.text_va,
+                           bin.align_up_u64(lay.hdr_span::u64 + segs[0].memsz::u64, EXEC_PAGE_SIZE),
+                           0, lay.hdr_span::u64 + segs[0].filesz::u64, text_prot, text_prot, 1);
+    write_section_64(buf, tsec, dyn_sectname(segs[0].flags, false), "__TEXT", segs[0].vaddr,
+                     segs[0].memsz::u64, seg_offsets[0]::u32, dyn_sect_flags(segs[0].flags, false));
+    lc = tsec + SECTION_64_SIZE;
+    li = 1;
+    for (li < seg_count) {
+        val prot: u32 = vm_prot_for(segs[li].flags);
+        val zf:   bool = segs[li].filesz == 0 && segs[li].memsz > 0;
+        var lsec: usize = write_segment_cmd(buf, lc, exec_segname(segs[li].flags), segs[li].vaddr,
+                               bin.align_up_u64(segs[li].memsz::u64, EXEC_PAGE_SIZE),
+                               seg_offsets[li]::u64, segs[li].filesz::u64, prot, prot, 1);
+        var soff: u32 = seg_offsets[li]::u32;
+        if (zf) { soff = 0; }
+        write_section_64(buf, lsec, dyn_sectname(segs[li].flags, zf), exec_segname(segs[li].flags),
+                         segs[li].vaddr, segs[li].memsz::u64, soff, dyn_sect_flags(segs[li].flags, zf));
+        lc = lsec + SECTION_64_SIZE;
+        li = li + 1;
+    }
+
+    # synthesized stub (R+X) and got (R+W) segments, each with one section so the
+    # llvm/otool readers resolve the bind opcodes' segment index and address. they
+    # are named __STUBS / __GOT (not __TEXT / __DATA) so they never collide with a
+    # linker segment name, keeping the bind segment index unambiguous.
+    if (nimp > 0) {
+        var sec: usize = write_segment_cmd(buf, lc, "__STUBS", lay.stubs_va,
+                               bin.align_up_u64(lay.stubs_size::u64, EXEC_PAGE_SIZE),
+                               lay.stubs_off::u64, lay.stubs_size::u64,
+                               VM_PROT_READ | VM_PROT_EXECUTE, VM_PROT_READ | VM_PROT_EXECUTE, 1);
+        write_section_64(buf, sec, "__stubs", "__STUBS", lay.stubs_va, lay.stubs_size::u64,
+                         lay.stubs_off::u32, S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS);
+        lc = sec + SECTION_64_SIZE;
+
+        sec = write_segment_cmd(buf, lc, "__GOT", lay.got_va,
+                               bin.align_up_u64(lay.got_size::u64, EXEC_PAGE_SIZE),
+                               lay.got_off::u64, lay.got_size::u64,
+                               VM_PROT_READ | VM_PROT_WRITE, VM_PROT_READ | VM_PROT_WRITE, 1);
+        write_section_64(buf, sec, "__got", "__GOT", lay.got_va, lay.got_size::u64,
+                         lay.got_off::u32, 0);
+        lc = sec + SECTION_64_SIZE;
+    }
+
+    # __LINKEDIT.
+    lc = write_segment_cmd(buf, lc, "__LINKEDIT", lay.linkedit_va,
+                           bin.align_up_u64(lay.linkedit_size::u64, EXEC_PAGE_SIZE),
+                           lay.linkedit_off::u64, lay.linkedit_size::u64,
+                           VM_PROT_READ, VM_PROT_READ, 0);
+
+    # LC_DYLD_INFO_ONLY: only the bind stream is non-empty (fixed addresses need no
+    # rebase, and binding is eager so the lazy stream is empty).
+    bin.write_u32_le(buf, lc, LC_DYLD_INFO_ONLY);
+    bin.write_u32_le(buf, lc + 4, DYLD_INFO_CMD_SIZE::u32);
+    bin.write_u32_le(buf, lc + 8, 0);                       # rebase_off
+    bin.write_u32_le(buf, lc + 12, 0);                      # rebase_size
+    bin.write_u32_le(buf, lc + 16, lay.bind_off::u32);
+    bin.write_u32_le(buf, lc + 20, lay.bind_size::u32);
+    bin.write_u32_le(buf, lc + 24, 0);                      # weak_bind_off
+    bin.write_u32_le(buf, lc + 28, 0);                      # weak_bind_size
+    bin.write_u32_le(buf, lc + 32, 0);                      # lazy_bind_off
+    bin.write_u32_le(buf, lc + 36, 0);                      # lazy_bind_size
+    bin.write_u32_le(buf, lc + 40, 0);                      # export_off
+    bin.write_u32_le(buf, lc + 44, 0);                      # export_size
+    lc = lc + DYLD_INFO_CMD_SIZE;
+
+    # LC_SYMTAB: the undefined import symbols and their string table.
+    bin.write_u32_le(buf, lc, LC_SYMTAB);
+    bin.write_u32_le(buf, lc + 4, SYMTAB_CMD_SIZE::u32);
+    bin.write_u32_le(buf, lc + 8, lay.symtab_off::u32);
+    bin.write_u32_le(buf, lc + 12, nimp);
+    bin.write_u32_le(buf, lc + 16, lay.strtab_off::u32);
+    bin.write_u32_le(buf, lc + 20, lay.strtab_size::u32);
+    lc = lc + SYMTAB_CMD_SIZE;
+
+    # LC_DYSYMTAB: every symbol is an undefined import (no locals or external
+    # definitions); the indirect/toc tables are empty since dyld binds via opcodes.
+    bin.write_u32_le(buf, lc, LC_DYSYMTAB);
+    bin.write_u32_le(buf, lc + 4, DYSYMTAB_CMD_SIZE::u32);
+    bin.write_u32_le(buf, lc + 8, 0);                       # ilocalsym
+    bin.write_u32_le(buf, lc + 12, 0);                      # nlocalsym
+    bin.write_u32_le(buf, lc + 16, 0);                      # iextdefsym
+    bin.write_u32_le(buf, lc + 20, 0);                      # nextdefsym
+    bin.write_u32_le(buf, lc + 24, 0);                      # iundefsym
+    bin.write_u32_le(buf, lc + 28, nimp);                   # nundefsym
+    lc = lc + DYSYMTAB_CMD_SIZE;
+
+    # LC_LOAD_DYLINKER, then one LC_LOAD_DYLIB per dependency.
+    lc = write_load_dylinker(buf, lc);
+    di = 0;
+    for (di < dyn.lib_count) {
+        lc = write_load_dylib(buf, lc, resolve(itn, dyn.libs[di].soname));
+        di = di + 1;
+    }
+
+    # LC_UNIXTHREAD: the static thread entry, program counter set to the entry.
+    bin.write_u32_le(buf, lc, LC_UNIXTHREAD);
+    bin.write_u32_le(buf, lc + 4, thread_cmd_size::u32);
+    if (arch_is_arm64(arch_id)) {
+        bin.write_u32_le(buf, lc + 8, ARM_THREAD_STATE64);
+        bin.write_u32_le(buf, lc + 12, ARM_THREAD_STATE64_COUNT);
+        bin.write_u64_le(buf, lc + 16 + ARM_PC_STATE_OFFSET, entry);
+    }
+    or {
+        bin.write_u32_le(buf, lc + 8, X86_THREAD_STATE64);
+        bin.write_u32_le(buf, lc + 12, X86_THREAD_STATE64_COUNT);
+        bin.write_u64_le(buf, lc + 16 + X86_RIP_STATE_OFFSET, entry);
+    }
+
+    # copy the linker's segment bytes to their file offsets.
+    li = 0;
+    for (li < seg_count) {
+        if (segs[li].bytes != nil && segs[li].filesz > 0) {
+            memory.raw_copy((buf::usize + seg_offsets[li])::ptr, segs[li].bytes::ptr, segs[li].filesz);
+        }
+        li = li + 1;
+    }
+
+    # the import stubs.
+    if (nimp > 0) {
+        var n: u32 = 0;
+        for (n < nimp) {
+            val stub_va: u64 = lay.stubs_va + n::u64 * stub_sz::u64;
+            val slot_va: u64 = lay.got_va + n::u64 * 8;
+            write_macho_stub(buf, arch_id, lay.stubs_off + n::usize * stub_sz, stub_va, slot_va);
+            n = n + 1;
+        }
+    }
+
+    # the dyld bind stream and the symbol/string tables in __LINKEDIT.
+    write_bind_info(buf, lay.bind_off, itn, dyn, lay.got_seg_index);
+
+    buf[lay.strtab_off] = 0;
+    var str_pos: usize = 1;
+    var sym_off: usize = lay.symtab_off;
+    var di2: u32 = 0;
+    for (di2 < dyn.import_count) {
+        if (dyn.imports[di2].is_func) {
+            val name: str = resolve(itn, dyn.imports[di2].symbol);
+            var n_strx: u32 = 0;
+            if (name != nil) {
+                n_strx = str_pos::u32;
+                str_pos = str_pos + bin.write_str(buf, lay.strtab_off + str_pos, name);
+            }
+            or {
+                buf[lay.strtab_off + str_pos] = 0;
+                str_pos = str_pos + 1;
+            }
+            bin.write_u32_le(buf, sym_off, n_strx);
+            buf[sym_off + 4] = N_UNDF | N_EXT;
+            buf[sym_off + 5] = 0;
+            bin.write_u16_le(buf, sym_off + 6, dylib_ordinal_for(dyn, di2)::u16 << 8);
+            bin.write_u64_le(buf, sym_off + 8, 0);
+            sym_off = sym_off + NLIST_64_SIZE;
+        }
+        di2 = di2 + 1;
+    }
+
+    # redirect every deferred call site to its stub.
+    val fx_r: R.Result[bool, str] =
+        patch_macho_fixups(buf, arch_id, ?lay, dyn, fixups, fixup_count, seg_offsets, segs, seg_count, nimp);
+    A.deallocate[usize](alloc, seg_offsets, seg_count::usize);
+    if (R.is_err[bool, str](fx_r)) {
+        A.deallocate[u8](alloc, buf, total_size);
+        ret R.err[bool, str](R.unwrap_err[bool, str](fx_r));
+    }
+
+    val wr: R.Result[bool, str] = write_file(itn, alloc, path, buf, total_size, "macho: dyn-exec");
     A.deallocate[u8](alloc, buf, total_size);
     ret wr;
 }
@@ -1311,6 +2187,9 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
         if ((n_desc & N_WEAK_DEF) != 0) { flags = flags | of.SYM_OBJ_FLAG_WEAK; }
         if ((n_type & N_TYPE) == N_UNDF) {
             flags = flags | of.SYM_OBJ_FLAG_EXTERN;
+            # recover the function-ness emit_object encoded in the reference type so
+            # the linker can give a dynamic function import its call stub.
+            if ((n_desc & REFERENCE_TYPE_MASK) == REFERENCE_FLAG_UNDEFINED_LAZY) { flags = flags | of.SYM_OBJ_FLAG_FUNCTION; }
             out.symbols[si].section = of.SECTION_EXTERNAL;
             out.symbols[si].offset = 0;
         } or (n_sect >= 1 && (n_sect - 1)::u32 < sec_n) {
@@ -1909,8 +2788,8 @@ fun ts_exec_arm64() u8 {
     ret 0;
 }
 
-# register installs the Mach-O vtable under "macho" with the object/exec writers
-# bound and emit_dyn_exec left nil (the Darwin-runtime follow-up).
+# register installs the Mach-O vtable under "macho" with the object, static-exec,
+# and dynamic-exec writers all bound.
 fun ts_register() u8 {
     var reg: of.OfRegistry = of.registry_init();
     val rr: R.Result[bool, str] = register_macho(?reg);
@@ -1923,7 +2802,137 @@ fun ts_register() u8 {
     if (vt.emit_object == nil)     { ret 1; }
     if (vt.parse_object == nil)    { ret 1; }
     if (vt.emit_exec == nil)       { ret 1; }
-    if (vt.emit_dyn_exec != nil)   { ret 1; }
+    if (vt.emit_dyn_exec == nil)   { ret 1; }
+    ret 0;
+}
+
+# whether the byte range [start, start+len) of buf contains the bytes of `needle`.
+# ---
+# buf:    the buffer to scan
+# start:  range start offset
+# len:    range byte length
+# needle: the substring to find
+# ret:    true when `needle` occurs in the range
+fun t_bytes_contain(buf: *u8, start: usize, len: usize, needle: str) bool {
+    val nl: usize = str_len(needle);
+    if (nl == 0 || nl > len) { ret false; }
+    var i: usize = 0;
+    for (i + nl <= len) {
+        var j: usize = 0;
+        var hit: bool = true;
+        for (j < nl) {
+            if (buf[start + i + j] != needle[j]) { hit = false; brk; }
+            j = j + 1;
+        }
+        if (hit) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# emit_dyn_exec frames a dyld-loadable executable: a dylib import drives the
+# LC_LOAD_DYLINKER / LC_LOAD_DYLIB / LC_DYLD_INFO_ONLY (bind stream) / symbol-table
+# load commands, the entry lands in the per-arch thread state, and the deferred
+# call site is redirected to a non-zero displacement. checks both architectures.
+fun ts_dyn_exec(arch_id: u32) u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = arch_id;
+
+    # a single text segment whose first instruction is a call to the import: the
+    # x86_64 `call rel32` (E8 + 4 bytes) and the arm64 `bl` (one word) both put a
+    # branch displacement field the writer must redirect to the stub.
+    var code: [8]u8;
+    var k: usize = 0;
+    for (k < 8) { code[k] = 0; k = k + 1; }
+    var fixup_off: u32 = 0;
+    var fixup_add: i64 = 0;
+    if (arch_id == isa.ARCH_AARCH64) {
+        bin.write_u32_le(?code[0], 0, 0x94000000);   # bl #0
+        fixup_off = 0;
+        fixup_add = 0;
+    }
+    or {
+        code[0] = 0xE8;                               # call rel32
+        fixup_off = 1;
+        fixup_add = -4;
+    }
+    val base:  u64 = 0x100000000;
+    val entry: u64 = base;
+
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = base; segs[0].filesz = 8; segs[0].memsz = 8;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
+
+    var libs: [1]of.DynLib;
+    libs[0].soname = t_intern(?itn, "libprobe.dylib");
+    var imps: [1]of.DynImport;
+    imps[0].symbol = t_intern(?itn, "probe_add");
+    imps[0].lib_index = 0;
+    imps[0].is_func = true;
+
+    var dyn: of.DynamicInfo;
+    dyn.libs = ?libs[0]; dyn.lib_count = 1;
+    dyn.imports = ?imps[0]; dyn.import_count = 1;
+    dyn.interp = intern.STR_NIL;
+
+    var fx: [1]of.PltFixup;
+    fx[0].seg_index = 0; fx[0].seg_offset = fixup_off; fx[0].import_index = 0;
+    fx[0].patch_vaddr = base + fixup_off::u64; fx[0].addend = fixup_add;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "macho_dyn");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, entry,
+                                                nil::*of.ExecFunction, 0, ?dyn, ?fx[0], 1, tpath::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
+    val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
+
+    if (bin.read_u32_le(buf.data, 0) != MH_MAGIC_64)                       { ret 1; }
+    if (bin.read_u32_le(buf.data, 12) != MH_EXECUTE)                       { ret 1; }
+    if (bin.read_u32_le(buf.data, 24) != (MH_DYLDLINK | MH_TWOLEVEL))      { ret 1; }
+
+    # the loader, the dependency, and the dyld bind stream.
+    val dl: usize = t_find_lc(buf.data, LC_LOAD_DYLINKER);
+    if (dl == 0)                                                           { ret 1; }
+    if (!t_bytes_contain(buf.data, dl, bin.read_u32_le(buf.data, dl + 4)::usize, "/usr/lib/dyld")) { ret 1; }
+    val ld: usize = t_find_lc(buf.data, LC_LOAD_DYLIB);
+    if (ld == 0)                                                           { ret 1; }
+    if (!t_bytes_contain(buf.data, ld, bin.read_u32_le(buf.data, ld + 4)::usize, "libprobe.dylib")) { ret 1; }
+
+    val info: usize = t_find_lc(buf.data, LC_DYLD_INFO_ONLY);
+    if (info == 0)                                                         { ret 1; }
+    val bind_off:  usize = bin.read_u32_le(buf.data, info + 16)::usize;
+    val bind_size: usize = bin.read_u32_le(buf.data, info + 20)::usize;
+    if (bind_size == 0)                                                    { ret 1; }
+    if (!t_bytes_contain(buf.data, bind_off, bind_size, "probe_add"))      { ret 1; }
+
+    # one undefined import symbol in both tables.
+    val sy: usize = t_find_lc(buf.data, LC_SYMTAB);
+    if (sy == 0)                                                           { ret 1; }
+    if (bin.read_u32_le(buf.data, sy + 12) != 1)                          { ret 1; }
+    val dsy: usize = t_find_lc(buf.data, LC_DYSYMTAB);
+    if (dsy == 0)                                                          { ret 1; }
+    if (bin.read_u32_le(buf.data, dsy + 28) != 1)                         { ret 1; }
+
+    # the entry in the per-arch thread state.
+    val th: usize = t_find_lc(buf.data, LC_UNIXTHREAD);
+    if (th == 0)                                                           { ret 1; }
+    if (arch_id == isa.ARCH_AARCH64) {
+        if (bin.read_u64_le(buf.data, th + 16 + ARM_PC_STATE_OFFSET) != entry) { ret 1; }
+    }
+    or {
+        if (bin.read_u64_le(buf.data, th + 16 + X86_RIP_STATE_OFFSET) != entry) { ret 1; }
+    }
     ret 0;
 }
 
@@ -2019,5 +3028,14 @@ test "mach.lang.target.of.macho:exec_vtable_and_rejections" {
     if (ts_register() != 0)         { ret 1; }
     if (ts_unsupported_kind() != 0) { ret 1; }
     if (ts_bad_input() != 0)        { ret 1; }
+    ret 0;
+}
+
+# the dynamic-executable writer: the x86_64 and arm64 dyld-loadable skeletons
+# (loader + dependency load commands, the bind stream, the symbol tables, and the
+# thread entry).
+test "mach.lang.target.of.macho:dyn_exec" {
+    if (ts_dyn_exec(isa.ARCH_X86_64) != 0)  { ret 1; }
+    if (ts_dyn_exec(isa.ARCH_AARCH64) != 0) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -1,13 +1,13 @@
-# Darwin (macOS) operating-system stub
+# Darwin (macOS) operating-system implementation
 #
-# Supplies a correctly-shaped OsVTable for Darwin: the "_main" program entry
-# point, the system library directories, and the executable load parameters
+# Supplies the OsVTable for Darwin: the "start" program entry point (the symbol
+# the std darwin runtime defines, which the kernel/dyld jumps to with the raw
+# stack), the system library directories, and the executable load parameters
 # (base virtual address 0x100000000 and a 4096-byte page), stored on the vtable
-# so the linker reads them through it rather than branching on the os id.
-# Darwin code generation is not yet supported; the unsupported surface lives
-# in the Mach-O object-format operations, which return a clear "unsupported
-# object format" error. The vtable carries data only; register fills its str
-# fields directly (no interning) and is idempotent.
+# so the linker reads them through it rather than branching on the os id. The
+# Mach-O writer frames both static (LC_UNIXTHREAD) and dynamic (LC_LOAD_DYLINKER
+# + dyld bind) executables for it. The vtable carries data only; register fills
+# its str fields directly (no interning) and is idempotent.
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -31,12 +31,14 @@ var darwin_vtable: os.OsVTable;
 
 # build and install the Darwin OsVTable
 #
-# Sets the os name, default object format ("macho"), entry symbol ("_main"), and
+# Sets the os name, default object format ("macho"), entry symbol ("start"), and
 # default library directory as plain str constants, fills the module-level vtable
 # (including the 0x100000000 base address and 4096-byte page), and installs it
-# into reg under the "darwin" key. The vtable strings are not interned here; the
-# linker interns the ones it needs at the point of use. Must be invoked at startup
-# before target.select requests a Darwin target.
+# into reg under the "darwin" key. The entry symbol is "start" because that is the
+# symbol the std darwin runtime defines (and the conventional Mach-O thread entry);
+# the linker interns it where it keys the symbol table. The vtable strings are not
+# interned here. Must be invoked at startup before target.select requests a Darwin
+# target.
 # ---
 # reg: the OS registry to install the vtable into
 # ret: ok(true) always; the Result return is kept for registrar-signature parity
@@ -44,7 +46,7 @@ pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     darwin_vtable.id             = os.OS_DARWIN;
     darwin_vtable.name           = "darwin";
     darwin_vtable.default_of     = "macho";
-    darwin_vtable.entry_symbol   = "_main";
+    darwin_vtable.entry_symbol   = "start";
     darwin_vtable.libdirs[0]     = "/usr/lib";
     darwin_vtable.libdirs[1]     = "/usr/local/lib";
     darwin_vtable.libdir_len     = 2;

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -68,6 +68,12 @@ pub val TYPE_INSTANCE:      TypeKind = 17;  # concrete instantiation of a generi
 # supplied by monomorphization, never carried on the type itself.
 pub val TYPE_PACK: TypeKind = 18;
 
+# the `^T` secret qualifier (#1645): the top of the two-point secrecy lattice
+# (public is the bottom). wraps an inner type to mark its data secret for the
+# constant-time guarantee. secrecy has no runtime representation - a `^T` lowers
+# to the same machine shape as `T`; it constrains only sema's flow typing.
+pub val TYPE_SECRET: TypeKind = 19;
+
 # scalar class of a primitive TypeKind, the discriminator of PrimDesc
 pub def PrimClass: u8;
 
@@ -129,6 +135,16 @@ pub fun prim_desc(kind: TypeKind) PrimDesc {
 # ---
 # base: pointee TypeId
 pub rec TypePointer {
+    base: TypeId;
+}
+
+# secret-qualifier `^T` payload (#1645)
+#
+# Carries the inner type the qualifier wraps. `^^T` never forms: intern_secret
+# collapses a doubled qualifier, keeping the lattice two-point.
+# ---
+# base: the inner (public-spelled) TypeId the qualifier wraps
+pub rec TypeSecret {
     base: TypeId;
 }
 
@@ -200,6 +216,7 @@ pub rec Type {
     kind: TypeKind;
     data: uni {
         pointer:       TypePointer;
+        secret:        TypeSecret;
         array:         TypeArray;
         fn:            TypeFun;
         nominal:       TypeNominal;
@@ -482,35 +499,41 @@ pub fun prim(ti: *TypeInterner, kind: TypeKind) O.Option[TypeId] {
 # Reads the kind through the interner, so, unlike a bare `tid == TYPE_U8`
 # ordinal test, it never depends on a primitive's TypeId equaling its kind
 # ordinal. The single shared predicate for sema's infer / check / coerce passes.
+# A secret `^T` is classified by its inner type, so secret integers participate
+# in arithmetic exactly as public ones (the join and gates are layered on top).
 # ---
 # ti:  the interner
 # tid: the TypeId to classify
 # ret: true for u8..u64 and i8..i64
 pub fun is_integer(ti: *TypeInterner, tid: TypeId) bool {
-    val opt_type: O.Option[*Type] = get(ti, tid);
+    val opt_type: O.Option[*Type] = get(ti, strip_secret(ti, tid));
     if (O.is_none[*Type](opt_type)) { ret false; }
     ret prim_desc(O.unwrap[*Type](opt_type).kind).class == PRIM_CLASS_INT;
 }
 
 # whether `tid` is an integer or float primitive (u8..f64)
+#
+# A secret `^T` is classified by its inner type.
 # ---
 # ti:  the interner
 # tid: the TypeId to classify
 # ret: true for any integer or float primitive
 pub fun is_numeric(ti: *TypeInterner, tid: TypeId) bool {
-    val opt_type: O.Option[*Type] = get(ti, tid);
+    val opt_type: O.Option[*Type] = get(ti, strip_secret(ti, tid));
     if (O.is_none[*Type](opt_type)) { ret false; }
     val c: PrimClass = prim_desc(O.unwrap[*Type](opt_type).kind).class;
     ret c == PRIM_CLASS_INT || c == PRIM_CLASS_FLOAT;
 }
 
 # whether `tid` is a float primitive (f32 or f64)
+#
+# A secret `^T` is classified by its inner type.
 # ---
 # ti:  the interner
 # tid: the TypeId to classify
 # ret: true for f32 or f64
 pub fun is_float(ti: *TypeInterner, tid: TypeId) bool {
-    val opt_type: O.Option[*Type] = get(ti, tid);
+    val opt_type: O.Option[*Type] = get(ti, strip_secret(ti, tid));
     if (O.is_none[*Type](opt_type)) { ret false; }
     ret prim_desc(O.unwrap[*Type](opt_type).kind).class == PRIM_CLASS_FLOAT;
 }
@@ -519,16 +542,98 @@ pub fun is_float(ti: *TypeInterner, tid: TypeId) bool {
 # (a code address)
 #
 # Used to relate `nil` and reinterpret casts against pointer and function
-# operands.
+# operands. A secret `^T` is classified by its inner type.
 # ---
 # ti:  the interner
 # tid: the TypeId to classify
 # ret: true for TYPE_PTR / TYPE_POINTER / TYPE_FUN
 pub fun is_pointer_like(ti: *TypeInterner, tid: TypeId) bool {
-    val opt_type: O.Option[*Type] = get(ti, tid);
+    val opt_type: O.Option[*Type] = get(ti, strip_secret(ti, tid));
     if (O.is_none[*Type](opt_type)) { ret false; }
     val k: TypeKind = O.unwrap[*Type](opt_type).kind;
     ret k == TYPE_PTR || k == TYPE_POINTER || k == TYPE_FUN;
+}
+
+# whether `tid` is a secret-qualified type `^T`
+# ---
+# ti:  the interner
+# tid: the TypeId to classify
+# ret: true when `tid`'s kind is TYPE_SECRET
+pub fun is_secret(ti: *TypeInterner, tid: TypeId) bool {
+    val opt_type: O.Option[*Type] = get(ti, tid);
+    if (O.is_none[*Type](opt_type)) { ret false; }
+    ret O.unwrap[*Type](opt_type).kind == TYPE_SECRET;
+}
+
+# peel one secret qualifier from `tid`, returning the inner type
+#
+# A non-secret type is returned unchanged. `^^T` never forms (intern_secret
+# collapses it), so a single peel is exhaustive.
+# ---
+# ti:  the interner
+# tid: the TypeId to strip
+# ret: the inner type when `tid` is `^T`, else `tid` unchanged
+pub fun strip_secret(ti: *TypeInterner, tid: TypeId) TypeId {
+    val opt_type: O.Option[*Type] = get(ti, tid);
+    if (O.is_none[*Type](opt_type)) { ret tid; }
+    val t: *Type = O.unwrap[*Type](opt_type);
+    if (t.kind != TYPE_SECRET) { ret tid; }
+    ret t.data.secret.base;
+}
+
+# whether `tid` carries secret data anywhere along its pointer / array / secret
+# spine - the predicate the welded-storage rules use to keep secret memory off
+# the untyped `ptr`
+#
+# Follows `^` (true immediately), a typed pointer's pointee, and an array's
+# element. A nominal rec/uni is a leaf here (its secret fields are welded at the
+# field level), so the walk is over a finite spine and always terminates.
+# ---
+# ti:  the interner
+# tid: the TypeId to inspect
+# ret: true when a secret qualifier appears along the spine
+pub fun carries_secret(ti: *TypeInterner, tid: TypeId) bool {
+    val opt_type: O.Option[*Type] = get(ti, tid);
+    if (O.is_none[*Type](opt_type)) { ret false; }
+    val t: *Type = O.unwrap[*Type](opt_type);
+    if (t.kind == TYPE_SECRET)  { ret true; }
+    if (t.kind == TYPE_POINTER) { ret carries_secret(ti, t.data.pointer.base); }
+    if (t.kind == TYPE_ARRAY)   { ret carries_secret(ti, t.data.array.base); }
+    ret false;
+}
+
+# whether two types place the secret qualifier identically along their spines
+#
+# `::` and `:~` may neither add nor drop `^`, so a cast's operand and target must
+# match secret-for-secret at the top level and through every pointer / array
+# step. Differing inner leaf types (e.g. `^u32` vs `^u64`) still match - only the
+# `^` placement is compared, not the underlying shapes the cast itself converts.
+# ---
+# ti:  the interner
+# a:   the first TypeId
+# b:   the second TypeId
+# ret: true when both carry the same secret-qualifier placement along the spine
+pub fun secrecy_structure_equal(ti: *TypeInterner, a: TypeId, b: TypeId) bool {
+    val a_secret: bool = is_secret(ti, a);
+    val b_secret: bool = is_secret(ti, b);
+    if (a_secret != b_secret) { ret false; }
+
+    val sa: TypeId = strip_secret(ti, a);
+    val sb: TypeId = strip_secret(ti, b);
+
+    val oa: O.Option[*Type] = get(ti, sa);
+    val ob: O.Option[*Type] = get(ti, sb);
+    if (O.is_none[*Type](oa) || O.is_none[*Type](ob)) { ret true; }
+    val ta: *Type = O.unwrap[*Type](oa);
+    val tb: *Type = O.unwrap[*Type](ob);
+
+    if (ta.kind == TYPE_POINTER && tb.kind == TYPE_POINTER) {
+        ret secrecy_structure_equal(ti, ta.data.pointer.base, tb.data.pointer.base);
+    }
+    if (ta.kind == TYPE_ARRAY && tb.kind == TYPE_ARRAY) {
+        ret secrecy_structure_equal(ti, ta.data.array.base, tb.data.array.base);
+    }
+    ret true;
 }
 
 # intern a pointer-to type
@@ -542,6 +647,24 @@ pub fun intern_pointer(ti: *TypeInterner, base: TypeId) R.Result[TypeId, str] {
     var t: Type;
     t.kind              = TYPE_POINTER;
     t.data.pointer.base = base;
+    ret intern_dedup(ti, t);
+}
+
+# intern a secret-qualified type `^base` (#1645)
+#
+# A doubled qualifier collapses (`^^T` interns to `^T`) so the secrecy lattice
+# stays two-point, and a poisoned base poisons the qualifier. Returns an existing
+# TypeId when the same base has been wrapped before.
+# ---
+# ti:   the interner
+# base: the inner TypeId to wrap
+# ret:  TypeId for `^base`, or an allocation error
+pub fun intern_secret(ti: *TypeInterner, base: TypeId) R.Result[TypeId, str] {
+    if (base == TYPE_ERROR) { ret R.ok[TypeId, str](TYPE_ERROR); }
+    if (is_secret(ti, base)) { ret R.ok[TypeId, str](base); }
+    var t: Type;
+    t.kind             = TYPE_SECRET;
+    t.data.secret.base = base;
     ret intern_dedup(ti, t);
 }
 
@@ -1179,6 +1302,9 @@ fun hash_type(p: ptr) u64 {
     if (t.kind == TYPE_POINTER) {
         h = fnv1a.step_u32(h, t.data.pointer.base::u32);
     }
+    or (t.kind == TYPE_SECRET) {
+        h = fnv1a.step_u32(h, t.data.secret.base::u32);
+    }
     or (t.kind == TYPE_ARRAY) {
         h = fnv1a.step_u32(h, t.data.array.base::u32);
         h = fnv1a.step_u32(h, t.data.array.count);
@@ -1207,6 +1333,9 @@ fun eq_type(pa: ptr, pb: ptr) bool {
 
     if (a.kind == TYPE_POINTER) {
         ret a.data.pointer.base == b.data.pointer.base;
+    }
+    if (a.kind == TYPE_SECRET) {
+        ret a.data.secret.base == b.data.secret.base;
     }
     if (a.kind == TYPE_ARRAY) {
         ret a.data.array.base == b.data.array.base
@@ -1372,6 +1501,63 @@ test "mach.lang.type:numeric_predicate_boundaries" {
     if (!is_float(?ti, f32_id))   { dnit(?ti); ret 1; }
     # array is not an integer
     if (is_integer(?ti, arr_id))  { dnit(?ti); ret 1; }
+
+    dnit(?ti);
+    ret 0;
+}
+
+# intern_secret dedups, collapses a doubled qualifier, and threads the secret
+# qualifier through the classifier / spine predicates (#1645)
+test "mach.lang.type.intern_secret:dedup_collapse_and_predicates" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var ti: TypeInterner;
+    if (O.is_some[str](init(?ti, ?alloc))) { ret 1; }
+
+    val u32_id: TypeId = O.unwrap[TypeId](prim(?ti, TYPE_U32));
+
+    # `^u32` interned twice -> one TypeId, distinct from `u32`
+    val s1: R.Result[TypeId, str] = intern_secret(?ti, u32_id);
+    val s2: R.Result[TypeId, str] = intern_secret(?ti, u32_id);
+    if (R.is_err[TypeId, str](s1) || R.is_err[TypeId, str](s2)) { dnit(?ti); ret 1; }
+    val sec_u32: TypeId = R.unwrap_ok[TypeId, str](s1);
+    if (sec_u32 != R.unwrap_ok[TypeId, str](s2)) { dnit(?ti); ret 1; }
+    if (sec_u32 == u32_id)                       { dnit(?ti); ret 1; }
+
+    # `^^u32` collapses to `^u32` - the lattice is two-point
+    val s3: R.Result[TypeId, str] = intern_secret(?ti, sec_u32);
+    if (R.is_err[TypeId, str](s3))                  { dnit(?ti); ret 1; }
+    if (R.unwrap_ok[TypeId, str](s3) != sec_u32)    { dnit(?ti); ret 1; }
+
+    # is_secret / strip_secret round-trip
+    if (!is_secret(?ti, sec_u32))                 { dnit(?ti); ret 1; }
+    if (is_secret(?ti, u32_id))                   { dnit(?ti); ret 1; }
+    if (strip_secret(?ti, sec_u32) != u32_id)     { dnit(?ti); ret 1; }
+    if (strip_secret(?ti, u32_id) != u32_id)      { dnit(?ti); ret 1; }
+
+    # a secret integer is still an integer for arithmetic classification
+    if (!is_integer(?ti, sec_u32))                { dnit(?ti); ret 1; }
+    if (!is_numeric(?ti, sec_u32))                { dnit(?ti); ret 1; }
+
+    # `*^u32` carries secret along its spine; `*u32` does not
+    val pp_sec: R.Result[TypeId, str] = intern_pointer(?ti, sec_u32);
+    val pp_pub: R.Result[TypeId, str] = intern_pointer(?ti, u32_id);
+    if (R.is_err[TypeId, str](pp_sec) || R.is_err[TypeId, str](pp_pub)) { dnit(?ti); ret 1; }
+    val ptr_sec: TypeId = R.unwrap_ok[TypeId, str](pp_sec);
+    val ptr_pub: TypeId = R.unwrap_ok[TypeId, str](pp_pub);
+    if (!carries_secret(?ti, ptr_sec))            { dnit(?ti); ret 1; }
+    if (carries_secret(?ti, ptr_pub))             { dnit(?ti); ret 1; }
+    if (!carries_secret(?ti, sec_u32))            { dnit(?ti); ret 1; }
+
+    # secrecy_structure_equal: `*^u32` differs from `*u32`, matches itself, and
+    # `^u32` vs `^u64` (same placement, differing leaves) is equal
+    val u64_id:  TypeId = O.unwrap[TypeId](prim(?ti, TYPE_U64));
+    val sec_u64: R.Result[TypeId, str] = intern_secret(?ti, u64_id);
+    if (R.is_err[TypeId, str](sec_u64)) { dnit(?ti); ret 1; }
+    if (secrecy_structure_equal(?ti, ptr_sec, ptr_pub))                       { dnit(?ti); ret 1; }
+    if (!secrecy_structure_equal(?ti, ptr_sec, ptr_sec))                      { dnit(?ti); ret 1; }
+    if (!secrecy_structure_equal(?ti, sec_u32, R.unwrap_ok[TypeId, str](sec_u64))) { dnit(?ti); ret 1; }
+    if (secrecy_structure_equal(?ti, sec_u32, u32_id))                       { dnit(?ti); ret 1; }
 
     dnit(?ti);
     ret 0;

--- a/test/macho/dynamic/mach.toml
+++ b/test/macho/dynamic/mach.toml
@@ -1,0 +1,28 @@
+[project]
+id = "machodyn"
+name = "machodyn"
+version = "0.0.0"
+src = "src"
+target = "darwin-x86_64"
+out = "out/{target}/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+
+# libprobe.dylib is a phantom dependency: it is named so the link records an
+# LC_LOAD_DYLIB and binds `probe_add`, driving the dynamic-exec writer. the file
+# itself is never opened (a Mach-O dylib is resolved by install name at run time).
+[bin.machodyn]
+entry = "main.mach"
+libs = ["libprobe.dylib"]

--- a/test/macho/dynamic/src/main.mach
+++ b/test/macho/dynamic/src/main.mach
@@ -1,0 +1,24 @@
+# freestanding darwin cross-compile fixture for the dynamic Mach-O executable path.
+#
+# no std runtime is linked: the entry symbol "start" (the Darwin os vtable's entry)
+# is defined here directly. the `#[library("libprobe.dylib")]` import makes the
+# call to `probe_add` a dynamic binding, so the manifest's libprobe.dylib
+# dependency drives the linker down the dynamic path (emit_dyn_exec): the emitted
+# executable carries LC_LOAD_DYLINKER, an LC_LOAD_DYLIB for libprobe.dylib, an
+# LC_DYLD_INFO_ONLY bind stream naming `probe_add`, the LC_SYMTAB/LC_DYSYMTAB
+# pair, and an import stub the call site is redirected to. libprobe.dylib does
+# not exist; it is named only so the binding is recorded, so this fixture is
+# byte-verified, not run (Darwin binaries cannot run on the Linux CI host).
+
+#[library("libprobe.dylib")]
+ext fun probe_add(a: i64, b: i64) i64;
+
+var total: i64 = 0;
+
+# the program entry. the call to the dynamic import `probe_add` is deferred to the
+# writer as a stub fixup, and the store to the global gives a data relocation.
+#[symbol("start")]
+fun start() {
+    total = probe_add(2, 3);
+    ret;
+}

--- a/test/macho/src/main.mach
+++ b/test/macho/src/main.mach
@@ -1,14 +1,13 @@
-# freestanding darwin cross-compile fixture for the Mach-O object format.
+# freestanding darwin cross-compile fixture for the static Mach-O executable path.
 #
-# no std runtime is linked: the entry symbol "_main" (the Darwin os vtable's entry)
+# no std runtime is linked: the entry symbol "start" (the Darwin os vtable's entry)
 # is defined here directly. the body exercises the byte path the writer emits - a
 # counted loop, a direct call (a branch relocation), and a global
 # read-modify-write (a pc-relative / absolute data reference) - so the emitted
 # Mach-O object carries real sections, symbols, and relocations. it has no exit
-# path: a Darwin exit needs the libSystem runtime, which is the #1178 follow-up.
-# so this fixture byte-verifies and links but does not run; Darwin binaries also
-# cannot run on the Linux CI host. test/macho drives the structural checks the ci
-# lane asserts with the llvm tools.
+# path and is structurally byte-verified, not run; Darwin binaries cannot run on
+# the Linux CI host. test/macho drives the structural checks the ci lane asserts
+# with the llvm tools, and links through emit_exec (LC_UNIXTHREAD, no dyld).
 
 var total: i64 = 0;
 
@@ -23,10 +22,10 @@ fun sum_to(n: i64) i64 {
     ret acc;
 }
 
-# the program entry. the "_main" symbol the Darwin linker resolves as the entry
+# the program entry. the "start" symbol the Darwin linker resolves as the entry
 # point; the call and the global read-modify-write give the relocations the lane
 # checks.
-#[symbol("_main")]
+#[symbol("start")]
 fun start() {
     total = total + sum_to(10);
     ret;

--- a/test/macho/verify.sh
+++ b/test/macho/verify.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
-# cross-compile the freestanding Mach-O fixture for both Darwin triples and
-# byte-verify the emitted relocatable object and the linked executable with the
-# llvm tools. proves the Mach-O object format emits a correct object (header, load
-# commands, sections, nlist symbols, relocations) and a structurally valid static
-# executable (__PAGEZERO, segments, LC_UNIXTHREAD entry) without running them:
-# Darwin binaries cannot run on this Linux host, and a Darwin exit needs the
-# libSystem runtime, which is the #1178 follow-up. this mirrors the riscv64 cross
-# lane - byte-verification, no execution step.
+# cross-compile the freestanding Mach-O fixtures for both Darwin triples and
+# byte-verify the emitted objects and executables with the llvm tools. proves the
+# Mach-O object format emits a correct object (header, load commands, sections,
+# nlist symbols, relocations), a structurally valid STATIC executable (__PAGEZERO,
+# segments, LC_UNIXTHREAD entry), and a dyld-loadable DYNAMIC executable
+# (LC_LOAD_DYLINKER, LC_LOAD_DYLIB, an LC_DYLD_INFO_ONLY bind stream, the
+# LC_SYMTAB/LC_DYSYMTAB pair, and an import stub the call site is redirected to).
+# nothing is run: Darwin binaries cannot run on this Linux host, and an arm64
+# Darwin binary additionally needs a code signature the kernel verifies, which
+# this writer does not emit. this mirrors the riscv64 cross lane - byte
+# verification, no execution step.
 #
 # usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
 #
@@ -32,12 +35,15 @@ resolve_tool() {
 objdump="$(resolve_tool llvm-objdump)" || fail "llvm-objdump not found"
 otool="$(resolve_tool llvm-otool)"     || fail "llvm-otool not found"
 
-# verify_target <target> <machine> <thread-flavor> <reloc>...
-verify_target() {
+# verify_static <target> <machine> <thread-flavor> <reloc>...
+#
+# cross-compiles the static fixture (no dependencies, so the linker takes the
+# emit_exec path) and checks its relocatable object and its LC_UNIXTHREAD exe.
+verify_static() {
     local target="$1" machine="$2" flavor="$3"; shift 3
     local exe="out/$target/machoprobe"
 
-    echo "cross-compiling fixture for $target with $mach"
+    echo "cross-compiling static fixture for $target with $mach"
     "$mach" build . --target "$target" --profile debug
     local obj
     obj="$(find "out/$target/obj" -name '*.o' -print -quit)"
@@ -45,11 +51,11 @@ verify_target() {
 
     echo "verifying $target object $obj"
     file "$obj" | grep -q "Mach-O 64-bit $machine object" || fail "$target: object is not a Mach-O $machine object"
-    "$objdump" --macho -t "$obj" | grep -qw '_main'       || fail "$target: object missing the _main entry symbol"
+    "$objdump" --macho -t "$obj" | grep -qw 'start'       || fail "$target: object missing the 'start' entry symbol"
 
     local dis
     dis="$("$objdump" --macho -d "$obj")"
-    echo "$dis" | grep -qi 'unknown' && fail "$target: object disassembly has an unknown instruction"
+    if echo "$dis" | grep -qi 'unknown'; then fail "$target: object disassembly has an unknown instruction"; fi
 
     local rel
     rel="$("$objdump" --macho -r "$obj")"
@@ -58,7 +64,7 @@ verify_target() {
         echo "$rel" | grep -q "$r" || fail "$target: expected relocation '$r' not emitted"
     done
 
-    echo "verifying $target executable $exe"
+    echo "verifying $target static executable $exe"
     file "$exe" | grep -q "Mach-O 64-bit $machine executable" || fail "$target: not a Mach-O $machine executable"
     local lc
     lc="$("$otool" -l "$exe")"
@@ -68,8 +74,51 @@ verify_target() {
     echo "$lc" | grep -q "$flavor"       || fail "$target: executable thread state is not $flavor"
 }
 
-rm -rf out
-verify_target darwin-x86_64  x86_64 x86_THREAD_STATE64 SIGNED
-verify_target darwin-aarch64 arm64  ARM_THREAD_STATE64 PAGE21 PAGOF12 BR26
+# verify_dynamic <target> <machine>
+#
+# cross-compiles the dynamic fixture (a libprobe.dylib dependency and a
+# `probe_add` import, so the linker takes the emit_dyn_exec path) and checks every
+# dynamic-linking structure: the loader and dependency load commands, the dyld
+# bind stream naming the import, the symbol tables, and the import stub.
+verify_dynamic() {
+    local target="$1" machine="$2"
+    local exe="dynamic/out/$target/machodyn"
 
-echo "OK: Mach-O object format emits correct objects and executables for both Darwin triples"
+    echo "cross-compiling dynamic fixture for $target with $mach"
+    "$mach" build dynamic --target "$target" --profile debug
+
+    echo "verifying $target dynamic executable $exe"
+    file "$exe" | grep -q "Mach-O 64-bit $machine executable" || fail "$target: not a Mach-O $machine executable"
+
+    local lc
+    lc="$("$otool" -l "$exe")"
+    echo "$lc" | grep -q '__PAGEZERO'         || fail "$target: dyn exe missing __PAGEZERO"
+    echo "$lc" | grep -q '__LINKEDIT'         || fail "$target: dyn exe missing __LINKEDIT"
+    echo "$lc" | grep -q 'LC_DYLD_INFO_ONLY'  || fail "$target: dyn exe missing LC_DYLD_INFO_ONLY"
+    echo "$lc" | grep -q 'LC_SYMTAB'          || fail "$target: dyn exe missing LC_SYMTAB"
+    echo "$lc" | grep -q 'LC_DYSYMTAB'        || fail "$target: dyn exe missing LC_DYSYMTAB"
+    echo "$lc" | grep -q 'LC_LOAD_DYLINKER'   || fail "$target: dyn exe missing LC_LOAD_DYLINKER"
+    echo "$lc" | grep -q '/usr/lib/dyld'      || fail "$target: dyn exe dylinker is not /usr/lib/dyld"
+    echo "$lc" | grep -q 'LC_LOAD_DYLIB'      || fail "$target: dyn exe missing LC_LOAD_DYLIB"
+    echo "$lc" | grep -q 'LC_UNIXTHREAD'      || fail "$target: dyn exe missing LC_UNIXTHREAD"
+
+    "$otool" -L "$exe" | grep -q 'libprobe.dylib' || fail "$target: dyn exe does not link libprobe.dylib"
+
+    # the import is an undefined two-level symbol bound by a dyld pointer record.
+    "$objdump" --macho -t "$exe"   | grep -q 'probe_add' || fail "$target: dyn exe missing the probe_add import symbol"
+    "$objdump" --macho --bind "$exe" | grep -q 'probe_add' || fail "$target: dyn exe has no bind record for probe_add"
+
+    # the deferred call site is redirected into the __stubs section.
+    "$otool" -l "$exe" | grep -q '__stubs' || fail "$target: dyn exe missing the __stubs section"
+    local dis
+    dis="$("$objdump" --macho -d --section=__stubs "$exe")"
+    if echo "$dis" | grep -qi 'unknown'; then fail "$target: __stubs disassembly has an unknown instruction"; fi
+}
+
+rm -rf out dynamic/out
+verify_static  darwin-x86_64  x86_64 x86_THREAD_STATE64 SIGNED
+verify_static  darwin-aarch64 arm64  ARM_THREAD_STATE64 PAGE21 PAGOF12 BR26
+verify_dynamic darwin-x86_64  x86_64
+verify_dynamic darwin-aarch64 arm64
+
+echo "OK: Mach-O emits correct objects and static + dynamic executables for both Darwin triples"

--- a/test/riscv64/src/main.mach
+++ b/test/riscv64/src/main.mach
@@ -5,9 +5,10 @@
 # B-type and J-type branch fixups), a direct call (R_RISCV_CALL_PLT), a global
 # load + store (R_RISCV_PCREL_HI20 with LO12_I and LO12_S), a constant-valued
 # variable-amount shift used as a call argument (`1 << node`, which must
-# materialize the constant value into a register before the reg-reg `sll`), and an
-# inline-asm exit syscall (the only way to emit `ecall`). the exit code is the
-# computed sum, so the qemu e2e proves the whole pipeline runs end to end.
+# materialize the constant value into a register before the reg-reg `sll`), the
+# RV64A atomics (an lr/sc compare-and-swap loop and an amoadd.d read-modify-write),
+# and an inline-asm exit syscall (the only way to emit `ecall`). the exit code is
+# the computed sum, so the qemu e2e proves the whole pipeline runs end to end.
 
 var total: i64 = 0;
 
@@ -34,16 +35,43 @@ fun na(node: u64) u64 { ret g(0, 1 << node, 0, 0, 0, 0); }
 
 # the program entry. the `_start` symbol the linux linker resolves as the entry
 # point; the calls and the global read-modify-write give the relocations the lane
-# checks, and the inline-asm `exit` syscall returns the computed sum (53) as the
-# process exit code.
+# checks, the inline-asm block exercises the RV64A atomics (#1668), and the
+# inline-asm `exit` syscall returns the computed sum (71) as the process exit code.
+#
+# the atomics run on a stack cell (`{cell}`, address taken through `p`): an lr/sc
+# compare-and-swap loop swaps it from 0 to 7 - the reservation-retry (1b) and
+# mismatch (2f) arms are encoded though the fast path takes neither - then amoadd.d
+# adds 4 and returns the swapped 7. the folded result (prior 7 + post-rmw 11 = 18)
+# is added to the exit code, so a wrong atomic encoding or a lost store changes it.
 #[symbol("_start")]
 fun start() {
-    var code: i64 = sum_to(10);         # sum 0..9 = 45
+    var code: i64 = sum_to(10);          # sum 0..9 = 45
     total = total + code;
-    code = code + na(3)::i64;            # 1 << 3 = 8, so code = 53
+    code = code + na(3)::i64;             # 1 << 3 = 8, so code = 53
+
+    var cell:  i64  = 0;
+    var p:     *i64 = ?cell;
+    var probe: i64  = 0;
+    asm riscv64 {
+        ld   t2, {p}            # t2 = &cell
+        li   a3, 7              # the compare-and-swap new value
+    1:
+        lr.d t0, (t2)           # load-reserved *cell
+        bnez t0, 2f             # swap only while the cell is still zero
+        sc.d t1, a3, (t2)       # store-conditional 7
+        bnez t1, 1b             # retry if the reservation was lost
+    2:
+        li   a4, 4
+        amoadd.d t3, a4, (t2)   # *cell += 4; t3 = the prior value (7)
+        ld   t4, (t2)           # observe the final *cell (11)
+        add  t5, t3, t4         # 7 + 11 = 18
+        sd   t5, {probe}        # fold the result back into a local
+    }
+    code = code + probe;                  # 53 + 18 = 71
+
     asm riscv64 {
         li a7, 93        # __NR_exit
-        ld a0, {code}    # exit code = 53
+        ld a0, {code}    # exit code = 71
         ecall
     }
 }

--- a/test/riscv64/src/main.mach
+++ b/test/riscv64/src/main.mach
@@ -5,7 +5,9 @@
 # B-type and J-type branch fixups), a direct call (R_RISCV_CALL_PLT), a global
 # load + store (R_RISCV_PCREL_HI20 with LO12_I and LO12_S), a constant-valued
 # variable-amount shift used as a call argument (`1 << node`, which must
-# materialize the constant value into a register before the reg-reg `sll`), and an
+# materialize the constant value into a register before the reg-reg `sll`), a
+# stack-local buffer (frame-slot addressing, #1670), a function whose encoded body
+# exceeds the +-4KiB B-type branch range (long-branch relaxation, #1666), and an
 # inline-asm exit syscall (the only way to emit `ecall`). the exit code is the
 # computed sum, so the qemu e2e proves the whole pipeline runs end to end.
 
@@ -32,18 +34,89 @@ fun g(a: u64, b: u64, c: u64, d: u64, e: u64, h: u64) u64 { ret a + b + c + d + 
 # this failed to encode (`encode: expected a register operand`) on this call path.
 fun na(node: u64) u64 { ret g(0, 1 << node, 0, 0, 0, 0); }
 
+# a stack-local buffer the body writes then reads back (#1670). a local array owns a
+# frame slot, so its address is `s0 + slot.offset`; before the fix the slot offset
+# aliased the saved ra / s0 record at the frame top, so writing the buffer clobbered
+# the return address and the function faulted on return. the returned checksum
+# (deterministic) folds into the exit code, so a frame-slot regression changes it.
+fun stack_probe() i64 {
+    var b: [40]u8;
+    var i: i64 = 0;
+    for (i < 40) { b[i] = (i & 3)::u8; i = i + 1; }
+    var s: i64 = 0;
+    i = 0;
+    for (i < 40) { s = s + b[i]::i64; i = i + 1; }
+    ret s & 15;
+}
+
+# a small classifier reached by a direct call from the >4KiB probe below.
+fun classify(v: u8) i64 {
+    if (v == 0) { ret 0; } or (v == 1) { ret 7; } or (v == 2) { ret 13; }
+    or (v == 3) { ret 21; } or (v == 4) { ret 34; } or (v == 5) { ret 55; }
+    or (v == 6) { ret 89; } ret 1;
+}
+
+# a self-contained, deterministic parse over a large stack buffer that forces
+# long-branch relaxation (#1666). the [2048]u8 frame pushes every scalar local past
+# the 12-bit stack-offset immediate, so each access expands into a multi-instruction
+# sequence; with the per-token classifier calls, the match-like chain, and the
+# early-return guards this inflates the encoded body well past 4KiB and leaves a
+# conditional branch whose target is out of the B-type +-4KiB range. the encoder
+# relaxes it into an inverted guard plus a `jal`; the result matches the unrelaxed
+# x86_64 / aarch64 build, so a relaxation regression changes the exit code.
+fun parse_probe(seed: u64) i64 {
+    var buf: [2048]u8;
+    var i: u64 = 0;
+    for (i < 2048) { buf[i] = ((i * 3 + seed) & 7)::u8; i = i + 1; }
+
+    var pos: u64 = 0;
+    var sum: i64 = 0;
+    var runs: i64 = 0;
+    var hi: i64 = 0;
+    var lo: i64 = 0;
+    var mid: i64 = 0;
+    var toks: i64 = 0;
+    var bias: i64 = 0;
+    for (pos < 2048) {
+        for (pos < 2048 && buf[pos] == 0) { pos = pos + 1; }
+        var start: u64 = pos;
+        var acc: i64 = 0;
+        for (pos < 2048 && buf[pos] != 0) {
+            val c: i64 = classify(buf[pos]);
+            if (c == 0) { bias = bias + 1; } or (c == 7) { bias = bias + 2; }
+            or (c == 13) { bias = bias + 3; } or (c == 21) { bias = bias + 4; }
+            or (c == 34) { bias = bias + 5; } or (c == 55) { bias = bias + 6; }
+            or (c == 89) { bias = bias + 7; } or { bias = bias + 8; }
+            if (c > 40) { hi = hi + c; } or (c > 18) { mid = mid + c; } or (c > 10) { acc = acc + c; } or { lo = lo + c; }
+            sum = sum + buf[pos]::i64;
+            acc = acc + c - bias + mid - hi + lo;
+            if (sum > 1000000) { ret -7; }
+            pos = pos + 1;
+        }
+        if (pos > start) {
+            runs = runs + 1;
+            if (acc > 20) { toks = toks + 2; } or (acc > 5) { toks = toks + 1; } or { toks = toks + 3; }
+            if (runs > 100000) { ret -9; }
+        }
+        if (pos < 2048) { pos = pos + 1; }
+    }
+    ret (sum & 255) + (runs & 127) + (hi & 63) + (lo & 31) + (mid & 31) + (toks & 15) + (bias & 15);
+}
+
 # the program entry. the `_start` symbol the linux linker resolves as the entry
 # point; the calls and the global read-modify-write give the relocations the lane
-# checks, and the inline-asm `exit` syscall returns the computed sum (53) as the
-# process exit code.
+# checks, and the inline-asm `exit` syscall returns the computed sum as the process
+# exit code (sum_to(10)=45 + na(3)=8 + stack_probe + parse_probe(1)).
 #[symbol("_start")]
 fun start() {
-    var code: i64 = sum_to(10);         # sum 0..9 = 45
+    var code: i64 = sum_to(10);          # sum 0..9 = 45
     total = total + code;
-    code = code + na(3)::i64;            # 1 << 3 = 8, so code = 53
+    code = code + na(3)::i64;             # 1 << 3 = 8, so code = 53
+    code = code + stack_probe();          # frame-slot probe (#1670)
+    code = code + parse_probe(1);         # >4KiB long-branch relaxation probe (#1666)
     asm riscv64 {
         li a7, 93        # __NR_exit
-        ld a0, {code}    # exit code = 53
+        ld a0, {code}    # exit code = the computed sum
         ecall
     }
 }

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -9,12 +9,13 @@
 # and qemu-riscv64 (or qemu-riscv64-static) for the exit-code run.
 set -euo pipefail
 
-# the computed exit code the fixture returns: sum 0..9 (45) plus the const-shift call
-# argument 1 << 3 (8), plus the stack-local frame-slot probe (#1670), the >4KiB
-# long-branch relaxation probe (#1666), the 32-bit bitwise word-group probe (#1672),
-# and the RV64A atomics probe (#1668, 18 = swapped 7 + post-rmw cell 11). the qemu
-# e2e asserts the exact sum, so a regression in any of those changes it.
-expect_code=86
+# the computed exit code the fixture returns, low 8 bits of the running sum: sum 0..9
+# (45) plus the const-shift call argument 1 << 3 (8), the stack-local frame-slot probe
+# (#1670), the >4KiB long-branch relaxation probe (#1666), the 32-bit bitwise
+# word-group probe (#1672), and the RV64A atomics probe (#1668, 18 = swapped 7 +
+# post-rmw cell 11), wrapping to 70. the qemu e2e asserts the exact code, so a
+# regression in any of those changes it.
+expect_code=70
 
 mach="${1:-mach}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -9,9 +9,11 @@
 # and qemu-riscv64 (or qemu-riscv64-static) for the exit-code run.
 set -euo pipefail
 
-# the computed exit code the fixture returns (sum 0..9 plus the const-shift call
-# argument 1 << 3 = 8, i.e. 45 + 8), the qemu e2e asserts it.
-expect_code=53
+# the computed exit code the fixture returns: sum 0..9 (45) plus the const-shift
+# call argument 1 << 3 (8), plus the stack-local frame-slot probe and the >4KiB
+# long-branch relaxation probe. the qemu e2e asserts the exact sum, so a frame-slot
+# (#1670) or branch-relaxation (#1666) regression changes it.
+expect_code=68
 
 mach="${1:-mach}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -41,26 +43,59 @@ rm -rf out
 "$mach" build . --target "$target" --profile debug
 obj="$(find out -name '*.o' -print -quit)"
 
+# the disassembly checks read from here-strings rather than `echo "$x" | grep`: under
+# `pipefail` a `grep -q` that matches early closes the pipe, and on a large
+# disassembly the producing `echo` then dies with SIGPIPE and fails the pipeline
+# despite the match. a here-string has no pipe writer to kill.
 echo "verifying elf header of $exe"
 hdr="$("$readelf" -h "$exe")"
-echo "$hdr" | grep -q 'Class:.*ELF64'            || fail "exe is not ELFCLASS64"
-echo "$hdr" | grep -q 'Machine:.*RISC-V'         || fail "exe e_machine is not EM_RISCV"
-echo "$hdr" | grep -q 'Type:.*EXEC'              || fail "exe is not ET_EXEC"
-echo "$hdr" | grep -qE 'Entry point address:.*0x[0-9a-fA-F]+' || fail "exe has no entry point"
-echo "$hdr" | grep -q 'Entry point address:.*0x0$' && fail "exe entry point is zero"
+grep -q 'Class:.*ELF64'            <<< "$hdr" || fail "exe is not ELFCLASS64"
+grep -q 'Machine:.*RISC-V'         <<< "$hdr" || fail "exe e_machine is not EM_RISCV"
+grep -q 'Type:.*EXEC'              <<< "$hdr" || fail "exe is not ET_EXEC"
+grep -qE 'Entry point address:.*0x[0-9a-fA-F]+' <<< "$hdr" || fail "exe has no entry point"
+grep -q 'Entry point address:.*0x0$' <<< "$hdr" && fail "exe entry point is zero"
 
+# the backend emits M (mul / div / rem) and F/D (scalar float) instructions but does
+# not yet write a `.riscv.attributes` ISA-string section, so objdump defaults to base
+# RV64I and renders those valid words as `<unknown>`. decode with the extensions the
+# backend actually emits so the `<unknown>` guard still catches a genuinely malformed
+# word rather than a correctly-encoded M / F / D instruction.
 echo "verifying disassembly of $exe"
-dis="$("$objdump" -d "$exe")"
-echo "$dis" | grep -q 'file format elf64-littleriscv' || fail "objdump did not parse a little-endian rv64 elf"
-echo "$dis" | grep -qi '<unknown>'                    && fail "objdump found an unknown instruction word"
+dis="$("$objdump" -d --mattr=+m,+f,+d "$exe")"
+grep -q 'file format elf64-littleriscv' <<< "$dis" || fail "objdump did not parse a little-endian rv64 elf"
+grep -qi '<unknown>'                    <<< "$dis" && fail "objdump found an unknown instruction word"
 for mnem in auipc jalr ld sd addi sll ret ecall; do
-    echo "$dis" | grep -qw "$mnem" || fail "expected mnemonic '$mnem' not in disassembly"
+    grep -qw "$mnem" <<< "$dis" || fail "expected mnemonic '$mnem' not in disassembly"
 done
+
+# assert the >4KiB probe forced long-branch relaxation (#1666): an inverted guard
+# that skips exactly its own +8 (the trampoline word) immediately followed by an
+# unconditional `j` to a target beyond the B-type +-4KiB range. without relaxation
+# the build would have failed to encode, so this confirms the relaxed form shipped.
+echo "verifying long-branch relaxation in $exe"
+mapfile -t dlines < <(printf '%s\n' "$dis")
+relax_found=0
+for ((li=0; li<${#dlines[@]}-1; li++)); do
+    l1="${dlines[li]}"; l2="${dlines[li+1]}"
+    grep -qE $'\t(beqz|bnez|bltz|bgez|blez|bgtz|beq|bne|blt|bge|bltu|bgeu)\t' <<< "$l1" || continue
+    grep -qE $'\tj\t' <<< "$l2" || continue
+    a1="$(echo "${l1%%:*}" | tr -d '[:space:]')"
+    aj="$(echo "${l2%%:*}" | tr -d '[:space:]')"
+    [[ "$a1" =~ ^[0-9a-fA-F]+$ && "$aj" =~ ^[0-9a-fA-F]+$ ]] || continue
+    t1="$(echo "$l1" | grep -oE '0x[0-9a-f]+' | head -1)"
+    tj="$(echo "$l2" | grep -oE '0x[0-9a-f]+' | head -1)"
+    [ -n "$t1" ] && [ -n "$tj" ] || continue
+    da1=$((16#$a1)); daj=$((16#$aj)); dt1=$((t1)); dtj=$((tj))
+    [ "$dt1" -eq $((da1 + 8)) ] || continue
+    dd=$(( dtj > daj ? dtj - daj : daj - dtj ))
+    if [ "$dd" -gt 4094 ]; then relax_found=1; break; fi
+done
+[ "$relax_found" -eq 1 ] || fail "no relaxed out-of-range conditional branch (inverted guard + jal) found"
 
 echo "verifying relocations in $obj"
 rel="$("$readobj" -r "$obj")"
 for r in R_RISCV_PCREL_HI20 R_RISCV_PCREL_LO12_I R_RISCV_PCREL_LO12_S R_RISCV_CALL_PLT; do
-    echo "$rel" | grep -q "$r" || fail "expected relocation '$r' not emitted"
+    grep -q "$r" <<< "$rel" || fail "expected relocation '$r' not emitted"
 done
 
 echo "running $exe under qemu-riscv64"

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -9,9 +9,10 @@
 # and qemu-riscv64 (or qemu-riscv64-static) for the exit-code run.
 set -euo pipefail
 
-# the computed exit code the fixture returns (sum 0..9 plus the const-shift call
-# argument 1 << 3 = 8, i.e. 45 + 8), the qemu e2e asserts it.
-expect_code=53
+# the computed exit code the fixture returns (sum 0..9 = 45, plus the const-shift call
+# argument 1 << 3 = 8, plus the RV64A atomics probe 18 = cas-stored 7 + post-rmw cell
+# 11), the qemu e2e asserts it.
+expect_code=71
 
 mach="${1:-mach}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -50,11 +51,17 @@ echo "$hdr" | grep -qE 'Entry point address:.*0x[0-9a-fA-F]+' || fail "exe has n
 echo "$hdr" | grep -q 'Entry point address:.*0x0$' && fail "exe entry point is zero"
 
 echo "verifying disassembly of $exe"
-dis="$("$objdump" -d "$exe")"
+# +a enables the A-extension decode so the fixture's lr/sc/amo* words disassemble as
+# the real atomics rather than `<unknown>`.
+dis="$("$objdump" -d --mattr=+a "$exe")"
 echo "$dis" | grep -q 'file format elf64-littleriscv' || fail "objdump did not parse a little-endian rv64 elf"
 echo "$dis" | grep -qi '<unknown>'                    && fail "objdump found an unknown instruction word"
 for mnem in auipc jalr ld sd addi sll ret ecall; do
     echo "$dis" | grep -qw "$mnem" || fail "expected mnemonic '$mnem' not in disassembly"
+done
+# the RV64A atomics the probe emits must disassemble as the real instructions.
+for mnem in lr.d sc.d amoadd.d; do
+    echo "$dis" | grep -qw "$mnem" || fail "expected RV64A mnemonic '$mnem' not in disassembly"
 done
 
 echo "verifying relocations in $obj"


### PR DESCRIPTION
Integration merge of dev into main for the v2.9.0 release.

Since v2.8.0:
- Darwin OS + Mach-O dynamic executables: both x86_64-darwin and aarch64-darwin triples (#1178)
- riscv64 RV64A atomic inline-asm mnemonics (#1668)
- riscv64 backend hardening: branch relaxation (#1666), frame-slot overlap (#1670), 32-bit and/or/xor SIGILL (#1672)
- constant-time secret-qualifier flow typing (#1645)

Tag v2.9.0 pushed on the merge commit. Makes riscv64 compile + run real std, unblocking mach-std #308/#307.