### PR TITLE
feat(parser)!: require block syntax for fin

### DIFF
--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -600,7 +600,7 @@ for-stmt ::= "for" [ "(" expr ")" ] block      (* no condition => infinite loop 
 ret-stmt ::= "ret" [ expr ] ";"
 brk-stmt ::= "brk" ";"
 cnt-stmt ::= "cnt" ";"
-fin-stmt ::= "fin" stmt                          (* defer: runs stmt at scope exit *)
+fin-stmt ::= "fin" block                         (* defer: runs block at scope exit *)
 
 local-decl-stmt ::= bind-decl                    (* a "val"/"var" used as a statement *)
 
@@ -623,8 +623,8 @@ Notes:
   and `else` (`or { ... }`). Arms are parsed greedily; an `or` with a
   condition continues the chain, an `or` without one terminates it. Each
   arm body is a block.
-- `fin S` registers `S` (typically a block) to run when the enclosing scope
-  exits — Mach's defer.
+- `fin { ... }` registers a block to run when the enclosing scope exits —
+  Mach's defer. The body must be a block; the bare `fin stmt;` form is rejected.
 - `comptime-if-stmt` is the statement-scope `$if`/`$or` chain (the
   declaration-scope variant is under [Comptime](#comptime-declarations-and-directives)).
   A `$` only begins this form when the next token is the keyword `if`;

--- a/doc/language/statements.md
+++ b/doc/language/statements.md
@@ -56,24 +56,24 @@ form. The same word followed by anything else is an ordinary identifier — a
 variable named `cnt` reads and assigns normally (`cnt = x;`), even inside a
 loop that also uses bare `cnt;` for control flow.
 
-## `fin` — deferred statement
+## `fin` — deferred block
 
-`fin` schedules a statement (or block) to execute when the enclosing scope
-exits, in reverse order of declaration. Useful for cleanup that should
-happen regardless of how the scope exits.
+`fin` schedules a block to execute when the enclosing scope exits, in reverse
+order of declaration. Useful for cleanup that should happen regardless of how
+the scope exits.
 
 ```mach
 {
-    fin counter = counter - 1;
+    fin { counter = counter - 1; }
     fin { counter = counter * 2; }
 
     # ... code ...
 }
-# at scope exit: fin block runs first, then fin counter = counter - 1
+# at scope exit, in reverse order: counter * 2 runs first, then counter - 1
 ```
 
-`fin` takes either a single statement (`fin stmt;`) or a block
-(`fin { ... }`). No bare-expression form.
+`fin` requires a block body (`fin { ... }`). The bare single-statement form
+(`fin stmt;`) is rejected.
 
 ## Block
 

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -1311,14 +1311,24 @@ fun parse_cnt_stmt(p: *state.Parser, start: token.Span) id.StmtId {
     ret state.push_stmt(p, node);
 }
 
-# parse `fin stmt` -- a deferred statement run at scope exit
+# parse `fin { ... }` -- a deferred block run at scope exit
+#
+# The body must be a block; the bare single-statement form (`fin stmt;`) is
+# rejected so a deferred region is always a visible block.
 # ---
 # p:     parser state positioned at the `fin` keyword
 # start: span of the statement's first token
 # ret:   StmtId of the fin statement
 fun parse_fin_stmt(p: *state.Parser, start: token.Span) id.StmtId {
     state.advance(p);
-    val body_id: id.StmtId = parse_stmt(p);
+
+    var body_id: id.StmtId = id.STMT_NIL;
+    if (state.at(p, token.KIND_LBRACE)) {
+        body_id = parse_block_stmt(p);
+    }
+    or {
+        state.error_at_current(p, "expected '{' to open 'fin' body");
+    }
 
     var end_span: token.Span = start;
     if (body_id != id.STMT_NIL) {
@@ -1620,6 +1630,19 @@ test "mach.lang.fe.parser.decl.parse_stmt:bare_kw_as_ident" {
     ast.dnit(?a);
     lexer.dnit(?stream, ?alloc);
     ret rc;
+}
+
+# statements.md: `fin` requires a block body; the bare single-statement form
+# (`fin stmt;`) is rejected, while `fin { ... }` parses (#1548)
+test "mach.lang.fe.parser.decl.parse_fin_stmt:requires_block" {
+    # bare single-statement forms are rejected
+    if (!t_parse_module_has_errors("fun f() { fin g(); }"))              { ret 1; }
+    if (!t_parse_module_has_errors("fun f() i64 { fin ret 0; ret 0; }")) { ret 1; }
+    if (!t_parse_module_has_errors("fun f() { var x: i64 = 0; fin x = 1; }")) { ret 1; }
+    # the block form parses cleanly
+    if (t_parse_module_has_errors("fun f() { fin { } }"))                { ret 1; }
+    if (t_parse_module_has_errors("fun f() i64 { var x: i64 = 0; fin { x = x + 1; } ret x; }")) { ret 1; }
+    ret 0;
 }
 
 # a backtick decorator is rejected and the following decls still parse, with


### PR DESCRIPTION
Closes #1548

Require the block form `fin { ... }` and reject the bare single-statement form `fin stmt;`. A deferred region is now always a visible block, consistent with the other block-bodied constructs.

## Changes
- `parse_fin_stmt` requires a `{` and emits a pinned `expected '{' to open 'fin' body` diagnostic otherwise (mirrors `if`/`for` body handling), instead of accepting any `parse_stmt`.
- Added parser test `parse_fin_stmt:requires_block` covering rejection of bare forms and clean parsing of the block form.
- Updated `doc/language/statements.md` and `doc/language/grammar.md` to specify only the block form.

No in-tree usages of the bare form existed (all first-party `fin` usages were already blocks), so no migration was needed.

## Verification
- `mach test .` — 670 passed, 0 failed (includes the new test).
- `mach build .` — clean.
- End-to-end via the built compiler: bare `fin x = 1;` reports `expected '{' to open 'fin' body` (caret on the offending token); `fin { x = 1; }` compiles clean.

> Breaking syntax change: existing `fin stmt;` migrates to `fin { stmt; }`.