### PR TITLE
infra: CD-authored darwin release build (native fixpoint)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -11,10 +12,18 @@ permissions:
 # a tagged push builds the release binary for each target on its native host
 # (each to its own self-host fixpoint), then publishes the archives + SHA256SUMS.
 # correctness is CI's job — every change reaches main through a PR it gates.
+#
+# darwin has no prior release to self-seed from, so seed-darwin cross-builds the
+# stage-0 seed on linux first; collapse that bootstrap once a darwin archive ships.
+#
+# workflow_dispatch runs the darwin lane (seed + native fixpoint + self-test) on a
+# branch with no tag, so on-Mac validation needs no release; the tag-verify and
+# publish steps are gated to tag pushes and stay skipped on dispatch.
 jobs:
   verify:
     name: verify tag
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
       - name: tag matches mach.toml version
@@ -148,9 +157,124 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # bootstrap: no prior darwin release exists to seed the native fixpoint, so
+  # cross-build the stage-0 seed on linux (the cross-darwin path mach already
+  # proves in ci) and hand it to the macOS runner. retire this once the first
+  # darwin archive ships and build-darwin can self-seed like every other target.
+  seed-darwin:
+    name: seed ${{ matrix.target }}
+    needs: verify
+    if: ${{ !cancelled() && (needs.verify.result == 'success' || needs.verify.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-darwin
+            triple: darwin-x86_64
+          - target: aarch64-darwin
+            triple: darwin-aarch64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: fetch released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED: mach-*-x86_64-linux.tar.gz
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
+          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: cross-build the darwin seed
+        env:
+          TRIPLE: ${{ matrix.triple }}
+        run: |
+          set -euo pipefail
+          mach dep pull
+          mach build . -o m
+          ./m build . --target "$TRIPLE" --profile release -o mach-darwin-seed
+
+      - name: upload seed
+        uses: actions/upload-artifact@v4
+        with:
+          name: seed-${{ matrix.target }}
+          path: mach-darwin-seed
+          if-no-files-found: error
+          retention-days: 1
+
+  build-darwin:
+    name: build ${{ matrix.target }}
+    needs: seed-darwin
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-darwin
+            runs-on: macos-13
+          - target: aarch64-darwin
+            runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: download the darwin seed
+        uses: actions/download-artifact@v4
+        with:
+          name: seed-${{ matrix.target }}
+          path: seed
+
+      - name: build fixpoint
+        run: |
+          set -euo pipefail
+          chmod +x seed/mach-darwin-seed
+
+          # native stage-0 is the cross-built seed; a/b/c are native self-hosts
+          ./seed/mach-darwin-seed dep pull
+          ./seed/mach-darwin-seed build . --profile release -o a
+          ./a build . --profile release -o b
+          ./b build . --profile release -o c
+
+          # ship the fixpoint: b == c (stage2 vs stage3) or the build is non-deterministic
+          if ! cmp -s b c; then
+            echo "::error::darwin build did not converge to the fixpoint"
+            exit 1
+          fi
+
+      - name: self test
+        run: |
+          set -euo pipefail
+          # exercises a mach-built native darwin binary: arm64 must run under the
+          # ad-hoc signature (no SIGKILL) for the fixpoint and these tests to pass
+          ./c test .
+
+      - name: package archive
+        if: github.event_name == 'push'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          ver="${GITHUB_REF_NAME#v}"
+          mkdir -p dist stage
+          cp c stage/mach
+          cp LICENSE stage/
+          tar -C stage -czf "dist/mach-$ver-$TARGET.tar.gz" mach LICENSE
+
+      - name: upload archive
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target }}
+          path: dist/mach-*-${{ matrix.target }}.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
   release:
     name: publish release
-    needs: [build-linux, build-windows]
+    needs: [build-linux, build-windows, build-darwin]
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -208,6 +208,8 @@ jobs:
   build-darwin:
     name: build ${{ matrix.target }}
     needs: seed-darwin
+    # explicit, since the default success() skips through verify's dispatch-skip
+    if: ${{ !cancelled() && needs.seed-darwin.result == 'success' }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
@@ -274,7 +276,8 @@ jobs:
   release:
     name: publish release
     needs: [build-linux, build-windows, build-darwin]
-    if: github.event_name == 'push'
+    # success() keeps the build gate the default if dropped when adding the event check
+    if: ${{ github.event_name == 'push' && success() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "05f937bb7f268f7eb20789cec8024fb315f77a43"
+commit = "2a765f79a94282274d02111e4ad5d41930b36e2b"

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1280,11 +1280,13 @@ fun write_code_signature(buf: *u8, sig_off: usize, name: *u8, code_limit: usize,
 # Frames the linker's laid-out load segments with a leading __PAGEZERO (the
 # unmapped low region below the image base), one LC_SEGMENT_64 per segment, and an
 # LC_UNIXTHREAD whose thread state carries the entry point - the static thread
-# entry, with no dyld dependency. The mach header and load commands occupy the
-# file head; each segment's file bytes follow at a page-aligned offset congruent
-# with its virtual address. A trailing __LINKEDIT segment carries an ad-hoc
-# LC_CODE_SIGNATURE so the Apple Silicon kernel admits the image (it SIGKILLs an
-# unsigned arm64 executable).
+# entry, with no dyld dependency. The mach header and load commands map into the
+# first segment (__TEXT): __TEXT starts at file offset 0 and virtual address
+# `base - hdr_span`, so the header sits inside the signed, mapped executable
+# segment ahead of the linker's text, which follows at `hdr_span`. A trailing
+# __LINKEDIT segment carries an ad-hoc LC_CODE_SIGNATURE so the Apple Silicon
+# kernel admits the image - it SIGKILLs an arm64 executable whose signature does
+# not cover the mapped header (and any unsigned arm64 executable).
 #
 # `funcs`/`func_count` are accepted for of.ExecFn conformance; no unwind table is
 # emitted.
@@ -1309,14 +1311,14 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     val ct: R.Result[u32, str] = cpu_type_for(arch_id);
     if (R.is_err[u32, str](ct)) { ret R.err[bool, str](R.unwrap_err[u32, str](ct)); }
 
-    # __PAGEZERO spans the low region below the image base; with a zero base
-    # (freestanding) there is none.
-    var pagezero_size: u64 = 0;
-    if (seg_count > 0) { pagezero_size = segs[0].vaddr & ~(EXEC_PAGE_SIZE - 1); }
+    # __PAGEZERO spans the low region below __TEXT; it is present whenever the image
+    # base is non-zero (darwin executables always carry one). its exact span depends
+    # on hdr_span, computed once the load-command size is known below.
+    var has_pagezero: bool = seg_count > 0 && segs[0].vaddr > 0;
     # the linker segments, a trailing __LINKEDIT (carrying the code signature),
     # LC_UNIXTHREAD, LC_CODE_SIGNATURE, and __PAGEZERO when the base is non-zero.
     var ncmds: u32 = seg_count + 3;
-    if (pagezero_size > 0) { ncmds = ncmds + 1; }
+    if (has_pagezero) { ncmds = ncmds + 1; }
 
     var thread_state: usize = X86_THREAD_STATE64_COUNT::usize * 4;
     if (arch_is_arm64(arch_id)) { thread_state = ARM_THREAD_STATE64_COUNT::usize * 4; }
@@ -1324,8 +1326,23 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
 
     var sizeofcmds: usize = seg_count::usize * SEGMENT_CMD_64_SIZE + thread_cmd_size
                           + SEGMENT_CMD_64_SIZE + LINKEDIT_DATA_CMD_SIZE;   # __LINKEDIT + LC_CODE_SIGNATURE
-    if (pagezero_size > 0) { sizeofcmds = sizeofcmds + SEGMENT_CMD_64_SIZE; }
+    if (has_pagezero) { sizeofcmds = sizeofcmds + SEGMENT_CMD_64_SIZE; }
     val header_end: usize = MACH_HEADER_64_SIZE + sizeofcmds;
+
+    # the mach header + load commands map into __TEXT's first hdr_span bytes: the
+    # Apple Silicon kernel admits a signed image only when the header lies inside the
+    # signed, mapped __TEXT. the first linker segment must therefore sit at least
+    # hdr_span above the image base, leaving room for the header below it.
+    val hdr_span: usize = bin.align_up(header_end, EXEC_PAGE_SIZE::usize);
+    if (seg_count > 0 && segs[0].vaddr < hdr_span::u64) {
+        ret R.err[bool, str]("macho: exec base address too low to map the header");
+    }
+    var text_va:       u64 = 0;
+    var pagezero_size: u64 = 0;
+    if (seg_count > 0) {
+        text_va       = segs[0].vaddr - hdr_span::u64;
+        pagezero_size = text_va;
+    }
 
     var seg_offsets: *usize = nil;
     if (seg_count > 0) {
@@ -1334,7 +1351,10 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
         seg_offsets = R.unwrap_ok[*usize, str](ro);
     }
 
-    var total_size: usize = bin.align_up(header_end, EXEC_PAGE_SIZE::usize);
+    # the first linker segment's bytes follow the header at hdr_span; the rest are
+    # page-aligned in turn. __TEXT (the first segment) therefore shares its file
+    # region with the header.
+    var total_size: usize = hdr_span;
     var li: u32 = 0;
     for (li < seg_count) {
         total_size = bin.align_up(total_size, EXEC_PAGE_SIZE::usize);
@@ -1343,23 +1363,21 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
         li = li + 1;
     }
 
-    # the highest mapped virtual address and the executable segment, for the trailing
-    # __LINKEDIT placement and the code signature's executable-segment fields.
-    var hi_va:      u64 = 0;
-    var exec_base:  u64 = 0;
-    var exec_limit: u64 = 0;
-    var found_exec: bool = false;
+    # the highest mapped virtual address, for the trailing __LINKEDIT placement.
+    var hi_va: u64 = 0;
     li = 0;
     for (li < seg_count) {
         val end: u64 = segs[li].vaddr + bin.align_up_u64(segs[li].memsz::u64, EXEC_PAGE_SIZE);
         if (end > hi_va) { hi_va = end; }
-        if (!found_exec && (segs[li].flags & of.SEG_FLAG_EXECUTE) != 0) {
-            exec_base  = seg_offsets[li]::u64;
-            exec_limit = segs[li].filesz::u64;
-            found_exec = true;
-        }
         li = li + 1;
     }
+
+    # __TEXT - the first segment, now carrying the header - is the executable segment
+    # the code signature authorizes: it starts at file offset 0 and spans the header
+    # plus the linker's text bytes.
+    var exec_base:  u64 = 0;
+    var exec_limit: u64 = 0;
+    if (seg_count > 0) { exec_limit = hdr_span::u64 + segs[0].filesz::u64; }
 
     # the ad-hoc code signature lives in a trailing __LINKEDIT segment and covers
     # every byte before it, so it is laid out last and page-aligned. codeLimit is the
@@ -1407,13 +1425,26 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     li = 0;
     for (li < seg_count) {
         val prot: u32 = vm_prot_for(segs[li].flags);
+        # the first segment is __TEXT: it maps the mach header + load commands ahead
+        # of the linker's text (fileoff 0, vmaddr text_va), so the signed header lies
+        # inside the mapped executable segment. the rest map at their own offsets.
+        var seg_vaddr:  u64 = segs[li].vaddr;
+        var seg_vmsize: u64 = bin.align_up_u64(segs[li].memsz::u64, EXEC_PAGE_SIZE);
+        var seg_foff:   u64 = seg_offsets[li]::u64;
+        var seg_fsz:    u64 = segs[li].filesz::u64;
+        if (li == 0) {
+            seg_vaddr  = text_va;
+            seg_vmsize = bin.align_up_u64(hdr_span::u64 + segs[0].memsz::u64, EXEC_PAGE_SIZE);
+            seg_foff   = 0;
+            seg_fsz    = hdr_span::u64 + segs[0].filesz::u64;
+        }
         bin.write_u32_le(buf, lc, LC_SEGMENT_64);
         bin.write_u32_le(buf, lc + 4, SEGMENT_CMD_64_SIZE::u32);
         write_fixed16(buf, lc + 8, exec_segname(segs[li].flags));
-        bin.write_u64_le(buf, lc + 24, segs[li].vaddr);
-        bin.write_u64_le(buf, lc + 32, bin.align_up_u64(segs[li].memsz::u64, EXEC_PAGE_SIZE));
-        bin.write_u64_le(buf, lc + 40, seg_offsets[li]::u64);
-        bin.write_u64_le(buf, lc + 48, segs[li].filesz::u64);
+        bin.write_u64_le(buf, lc + 24, seg_vaddr);
+        bin.write_u64_le(buf, lc + 32, seg_vmsize);
+        bin.write_u64_le(buf, lc + 40, seg_foff);
+        bin.write_u64_le(buf, lc + 48, seg_fsz);
         bin.write_u32_le(buf, lc + 56, prot);
         bin.write_u32_le(buf, lc + 60, prot);
         bin.write_u32_le(buf, lc + 64, 0);
@@ -3142,11 +3173,23 @@ fun ts_exec_x64() u8 {
     # ncmds: __PAGEZERO + one segment + __LINKEDIT + LC_UNIXTHREAD + LC_CODE_SIGNATURE.
     if (bin.read_u32_le(buf.data, 16) != 5) { ret 1; }
 
-    # the first load command is __PAGEZERO spanning the image base.
+    # __PAGEZERO spans [0, __TEXT.vmaddr); __TEXT (the next command) maps the mach
+    # header at file offset 0 and virtual address base - hdr_span, so the image base
+    # (the linker's code address) falls inside the signed, mapped executable segment.
     val pz: usize = MACH_HEADER_64_SIZE;
     if (bin.read_u32_le(buf.data, pz) != LC_SEGMENT_64)     { ret 1; }
     if (!fixed16_equals(buf.data, pz + 8, "__PAGEZERO"))    { ret 1; }
-    if (bin.read_u64_le(buf.data, pz + 32) != base)         { ret 1; }
+    if (bin.read_u64_le(buf.data, pz + 24) != 0)            { ret 1; }   # __PAGEZERO vmaddr
+
+    val tx: usize = pz + SEGMENT_CMD_64_SIZE;
+    if (bin.read_u32_le(buf.data, tx) != LC_SEGMENT_64)     { ret 1; }
+    if (!fixed16_equals(buf.data, tx + 8, "__TEXT"))        { ret 1; }
+    val text_va:   u64 = bin.read_u64_le(buf.data, tx + 24);
+    val text_vmsz: u64 = bin.read_u64_le(buf.data, tx + 32);
+    if (bin.read_u64_le(buf.data, tx + 40) != 0)            { ret 1; }   # __TEXT fileoff: header inside __TEXT
+    if (bin.read_u64_le(buf.data, pz + 32) != text_va)      { ret 1; }   # __PAGEZERO ends where __TEXT begins
+    if (text_va > base)                                     { ret 1; }   # base sits at or above __TEXT's start
+    if (base >= text_va + text_vmsz)                        { ret 1; }   # ... and inside __TEXT's mapping
 
     # LC_UNIXTHREAD carries the entry in the x86_64 rip slot.
     val th: usize = t_find_lc(buf.data, LC_UNIXTHREAD);


### PR DESCRIPTION
Closes #1680.

Adds the native-darwin release lane to `cd.yml`, mirroring `build-linux`'s
seeded native-fixpoint model. `ci.yml` is untouched — it keeps the cheap
ubuntu `cross-darwin` byte-verify; the full native fixpoint is `cd.yml`-only.

## What lands

- `mach.lock` advanced to mach-std **v0.16.1** (`2a765f7`), which carries the
  darwin runtime `_rt_*` symbols (#314), the aarch64 `ldr` syscall asm (#315),
  and the aarch64 `_start` dialect rewrite (#320).
- `seed-darwin` (ubuntu): cross-builds a darwin `mach` from source per-arch and
  uploads it as the stage-0 bootstrap seed (no prior darwin release to self-seed
  from).
- `build-darwin` (matrix: `macos-13` → `x86_64-darwin`, `macos-14` →
  `aarch64-darwin`): downloads the seed, runs the native `a → b → c`
  `--profile release` fixpoint (`cmp -s b c`), self-tests, and tars
  `mach`+`LICENSE` into `dist/mach-$ver-$TARGET.tar.gz` as `release-$TARGET`.
  The existing `release` job globs `mach-*.tar.gz`, so darwin flows into
  `SHA256SUMS` unchanged. No Apple codesign / no secrets — mach self-signs.
- `workflow_dispatch` trigger so the darwin lane can be validated on real macOS
  without cutting a tag (the publish/tag-verify steps are gated to tag pushes).

## Validation

STEP-0 (Linux) and STEP-2 (real macOS dispatch) evidence in the PR thread.