### PR TITLE
chore(deps): advance mach.lock to mach-std v0.16.1

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "05f937bb7f268f7eb20789cec8024fb315f77a43"
+commit = "2a765f79a94282274d02111e4ad5d41930b36e2b"


### PR DESCRIPTION
Advances dev's pinned mach-std from v0.16.0 to v0.16.1, picking up the darwin aarch64 `_start` dialect rewrite (#320). dev was stale at v0.16.0 — its broken `_start` makes the full darwin-aarch64 compiler cross-build fail with `malformed inline-asm add/sub operands` (a masked red herring, not a new bug). Validated green at v0.16.1 by the #1680 worker (linux fixpoint converges, `mach test .` 426/0). Native darwin-aarch64 exec remains blocked on #1718 (static-image architecture).