### PR TITLE
ci(cd): native darwin release lane (x86_64 + aarch64 fixpoint)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -11,10 +12,18 @@ permissions:
 # a tagged push builds the release binary for each target on its native host
 # (each to its own self-host fixpoint), then publishes the archives + SHA256SUMS.
 # correctness is CI's job — every change reaches main through a PR it gates.
+#
+# darwin has no prior release to self-seed from, so seed-darwin cross-builds the
+# stage-0 seed on linux first; collapse that bootstrap once a darwin archive ships.
+#
+# workflow_dispatch runs the darwin lane (seed + native fixpoint + self-test) on a
+# branch with no tag, so on-Mac validation needs no release; the tag-verify and
+# publish steps are gated to tag pushes and stay skipped on dispatch.
 jobs:
   verify:
     name: verify tag
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
       - name: tag matches mach.toml version
@@ -148,9 +157,124 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # bootstrap: no prior darwin release exists to seed the native fixpoint, so
+  # cross-build the stage-0 seed on linux (the cross-darwin path mach already
+  # proves in ci) and hand it to the macOS runner. retire this once the first
+  # darwin archive ships and build-darwin can self-seed like every other target.
+  seed-darwin:
+    name: seed ${{ matrix.target }}
+    needs: verify
+    if: ${{ !cancelled() && (needs.verify.result == 'success' || needs.verify.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-darwin
+            triple: darwin-x86_64
+          - target: aarch64-darwin
+            triple: darwin-aarch64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: fetch released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED: mach-*-x86_64-linux.tar.gz
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
+          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: cross-build the darwin seed
+        env:
+          TRIPLE: ${{ matrix.triple }}
+        run: |
+          set -euo pipefail
+          mach dep pull
+          mach build . -o m
+          ./m build . --target "$TRIPLE" --profile release -o mach-darwin-seed
+
+      - name: upload seed
+        uses: actions/upload-artifact@v4
+        with:
+          name: seed-${{ matrix.target }}
+          path: mach-darwin-seed
+          if-no-files-found: error
+          retention-days: 1
+
+  build-darwin:
+    name: build ${{ matrix.target }}
+    needs: seed-darwin
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-darwin
+            runs-on: macos-13
+          - target: aarch64-darwin
+            runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: download the darwin seed
+        uses: actions/download-artifact@v4
+        with:
+          name: seed-${{ matrix.target }}
+          path: seed
+
+      - name: build fixpoint
+        run: |
+          set -euo pipefail
+          chmod +x seed/mach-darwin-seed
+
+          # native stage-0 is the cross-built seed; a/b/c are native self-hosts
+          ./seed/mach-darwin-seed dep pull
+          ./seed/mach-darwin-seed build . --profile release -o a
+          ./a build . --profile release -o b
+          ./b build . --profile release -o c
+
+          # ship the fixpoint: b == c (stage2 vs stage3) or the build is non-deterministic
+          if ! cmp -s b c; then
+            echo "::error::darwin build did not converge to the fixpoint"
+            exit 1
+          fi
+
+      - name: self test
+        run: |
+          set -euo pipefail
+          # exercises a mach-built native darwin binary: arm64 must run under the
+          # ad-hoc signature (no SIGKILL) for the fixpoint and these tests to pass
+          ./c test .
+
+      - name: package archive
+        if: github.event_name == 'push'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          ver="${GITHUB_REF_NAME#v}"
+          mkdir -p dist stage
+          cp c stage/mach
+          cp LICENSE stage/
+          tar -C stage -czf "dist/mach-$ver-$TARGET.tar.gz" mach LICENSE
+
+      - name: upload archive
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target }}
+          path: dist/mach-*-${{ matrix.target }}.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
   release:
     name: publish release
-    needs: [build-linux, build-windows]
+    needs: [build-linux, build-windows, build-darwin]
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -208,6 +208,8 @@ jobs:
   build-darwin:
     name: build ${{ matrix.target }}
     needs: seed-darwin
+    # explicit, since the default success() skips through verify's dispatch-skip
+    if: ${{ !cancelled() && needs.seed-darwin.result == 'success' }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
@@ -274,7 +276,8 @@ jobs:
   release:
     name: publish release
     needs: [build-linux, build-windows, build-darwin]
-    if: github.event_name == 'push'
+    # success() keeps the build gate the default if dropped when adding the event check
+    if: ${{ github.event_name == 'push' && success() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## What

Adds the native darwin release lane to `.github/workflows/cd.yml`, mirroring
`build-linux`'s seeded native-fixpoint model:

- **`seed-darwin`** (ubuntu, per-arch): cross-builds a stage-0 darwin `mach` seed
  from source (`mach build . -o m` -> `./m build . --target darwin-<isa> --profile
  release -o mach-darwin-seed`) and uploads it per-arch. darwin has no prior release
  to self-seed from; this bootstrap retires once the first darwin archive ships.
- **`build-darwin`** matrix: `macos-13`->`x86_64-darwin`, `macos-14`->`aarch64-darwin`.
  Downloads the seed, runs the native `a->b->c --profile release` fixpoint (`cmp -s
  b c`), self-tests (`./c test .`), and tars `mach`+`LICENSE` into
  `dist/mach-$ver-<isa>-darwin.tar.gz`. The existing `release` job already globs
  `dist/mach-*.tar.gz`, so darwin flows into `SHA256SUMS` with no change there.
- **`workflow_dispatch`** trigger so the lane (seed + native fixpoint + self-test)
  can be validated on a branch with no tag. The tag-verify (`verify`) and the
  archive/publish steps stay gated to `push`, so dispatch never publishes.

mach self-signs (ad-hoc Mach-O signature, #1679), so no Apple codesign and no secrets.
`ci.yml` is untouched and keeps its cheap ubuntu `cross-darwin` byte-verify.

Archive naming follows the linux `mach-$ver-<isa>-<os>` convention
(`x86_64-darwin`, `aarch64-darwin`).

The lane was first built and proven on `fix/1680-cd-darwin-release` (draft #1716,
not merged - stale lock / predates the merged PIE writer); the two cd.yml commits are
cherry-picked here clean onto current `dev`.

## Validation

- **Off-Mac (dev regression):** `test/macho/verify.sh` cross-builds both triples and
  byte-verifies the shapes - arm64 `darwin-aarch64` is a valid `MH_PIE` image
  (`LC_MAIN`, `LC_DYLD_INFO` rebase, ad-hoc `LC_CODE_SIGNATURE`), x86_64
  `darwin-x86_64` a valid signed image. Linux self-host fixpoint byte-identical
  (`b == c`); `mach test .` green.
- **On-Mac (the proof):** dispatched on this branch - the `macos-14` aarch64 leg
  execs the seed (no `Killed: 9`), converges the native `a->b->c` fixpoint, and runs
  `mach test .` (425/1 - the 1 is the pre-existing host-specific #1724, not a
  regression). The `macos-13` x86_64 leg is included; its native proof may stay
  queued on macos-13 runner scarcity (infra, not code).

Closes #1680.
