### PR TITLE
fix(driver): cover darwin hosts in union ctx-restoration test fixture

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -4042,10 +4042,15 @@ fun ut_cc3(alloc: *A.Allocator, a: str, b: str, c: str) str {
     ret buf::str;
 }
 
-# the shared three-target manifest the union tests scaffold. `native`
-# resolves the default to the host-matching target (linux, windows, or linux-arm64 in CI).
+# the shared five-target manifest the union tests scaffold. `native` resolves the
+# default to the host-matching target: linux (x86_64-linux), windows (x86_64-windows),
+# linux-arm64 (aarch64-linux), darwin-x86_64 (x86_64-darwin), or darwin-arm64
+# (aarch64-darwin) in CI. both darwin targets are declared so either a macos-13
+# (x86_64) or a macos-14 (arm64) host has a matching native target - otherwise
+# `resolve_native` falls back to the first target (linux) and the host-tie assertions in
+# union_ctx_restored_to_default_tuple read the wrong default for a darwin host (#1724).
 fun ut_manifest() str {
-    ret "[project]\nid = \"uniontest\"\nname = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\ntarget = \"native\"\nout = \"out/{target}/bin/{name}{ext}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\next = \".exe\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[bin.uniontest]\nentry = \"main.mach\"\n";
+    ret "[project]\nid = \"uniontest\"\nname = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\ntarget = \"native\"\nout = \"out/{target}/bin/{name}{ext}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\next = \".exe\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[target.darwin-x86_64]\nisa = \"x86_64\"\nos = \"darwin\"\nabi = \"sysv64\"\n\n[target.darwin-arm64]\nisa = \"aarch64\"\nos = \"darwin\"\nabi = \"aapcs64\"\n\n[bin.uniontest]\nentry = \"main.mach\"\n";
 }
 
 # a two-target, two-bin manifest for the multi-artifact union


### PR DESCRIPTION
## Summary

`mach.lang.driver:union_ctx_restored_to_default_tuple` (`src/lang/driver.mach`) FAILed only on an arm64 **darwin** host (425/1), while passing on x86_64-linux, aarch64-linux, and x86_64-windows. This blocked the darwin (and all) releases: #1680's `build-darwin` self-test gates the `release` job.

## Root cause — (a) test-fixture gap, not a restoration leak

The test asserts the restored comptime ctx equals the host's native-resolved default tuple:

```
or (cm.target_os_id != target.host_os_id())     { bad = 1; }
or (cm.target_arch_id != target.host_arch_id()) { bad = 1; }
```

`resolve_native` (`manifest.mach`) scans the manifest's declared targets for one matching the host `(os, arch)`; on **no match it falls back to `m.targets[0]`**. The fixture manifest `ut_manifest()` declared only `linux` (x86_64), `windows` (x86_64), and `linux-arm64` (aarch64-linux) — **no darwin target**. On an arm64 darwin host nothing matches, so the selected default tuple is x86_64-linux while `host_os_id()`/`host_arch_id()` return darwin/aarch64, and the host-tie assertions fail.

The union ctx-restoration itself is correct: modules `a`/`b` are seeded from `p.target` and `main` restores to the same selected default, so `cm`/`ca`/`cb` stay internally consistent on darwin too — only the host-tie comparison was wrong, because the fixture had no host-matching target for darwin.

## Fix

Declare a `darwin-arm64` (`aarch64`-`darwin`-`aapcs64`) target in `ut_manifest()` so an arm64 macOS host resolves a matching native target, restoring the `selected default == host ids` equivalence the assertion relies on. No masking, no test skip. Every declared target has a distinct `(isa, os)` so `native` is never ambiguous, and each CI host keeps matching its own declared target.

## Validation

- x86_64-linux: PR-source compiler runs `mach test .` -> **426 passed, 0 failed**; all `union_*` tests pass.
- arm64 darwin (the proof): validated via a macos-14 `workflow_dispatch` (see PR comments) — the self-test goes **426/0**.

Closes #1724