### PR TITLE
chore(release): v2.10.0 — native arm64 macOS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -170,8 +170,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-darwin
-            triple: darwin-x86_64
           - target: aarch64-darwin
             triple: darwin-aarch64
     steps:
@@ -215,8 +213,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-darwin
-            runs-on: macos-13
           - target: aarch64-darwin
             runs-on: macos-14
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] - 2026-06-29
+
+Native arm64 macOS. mach now compiles, ad-hoc code-signs, and self-hosts
+position-independent arm64 Darwin executables that run on Apple Silicon - the
+first published Darwin release binary. Also a format-neutral base-relocation
+foundation for position independence, project-scoped `mach test`, `mach run`
+without a rebuild, a riscv64 ELF build-attributes section, and a parser
+correction. No breaking changes.
+
+### Added
+
+- target: native **arm64 Darwin (Apple Silicon)**. mach emits position-independent
+  Mach-O executables (`MH_PIE`, `LC_MAIN`, an `LC_DYLD_INFO` rebase stream, and an
+  ad-hoc `CS_LINKER_SIGNED` code signature) that exec and self-host on Apple
+  Silicon; CD publishes an `aarch64-darwin` archive (#1679, #1717, #1722). x86_64
+  Darwin stays cross-compile-only (#1728).
+- link: a format-neutral image base-relocation set - the linker collects every
+  in-image absolute pointer once and each object format encodes it, the foundation
+  for PIE/ASLR across targets (#1722).
+- arm64: `cset` in the inline-asm assembler (#1714).
+- target: a riscv64 `.riscv.attributes` ISA-string ELF section (#1673).
+- run: `mach run` executes the already-built artifact without recompiling (#1482).
+- test: `mach test` collects only the current project's tests by default; pass
+  `--include-deps` to widen (#1556).
+
+### Fixed
+
+- macho: coalesce object sections by kind so modules with more than 255 sections
+  link (Mach-O's `n_sect` is a single byte) (#1682).
+- macho: map the mach header into `__TEXT` so the Apple Silicon kernel admits the
+  signed image (#1717).
+- parser: require a block body for `fin`; a bare `fin stmt;` was never intended to
+  parse (#1548).
+
+### Changed
+
+- deps: mach-std v0.16.2 - the arm64 Darwin runtime (`LC_MAIN` entry, syscall layer).
+
 ## [2.9.0] - 2026-06-27
 
 Darwin executables, the constant-time secret qualifier in the type checker, and

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -17,6 +17,7 @@ main() {
     case "$(uname -s)-$(uname -m)" in
         Linux-x86_64) target="x86_64-linux" ;;
         Linux-aarch64|Linux-arm64) target="aarch64-linux" ;;
+        Darwin-arm64|Darwin-aarch64) target="aarch64-darwin" ;;
         *) err "unsupported host $(uname -s)-$(uname -m); prebuilt binaries: https://github.com/briar-systems/mach/releases" ;;
     esac
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.9.0"
+version = "2.10.0"
 src = "src"
 dep = "dep"
 target = "native"


### PR DESCRIPTION
Release prep for **v2.10.0**, headlined by native arm64 Darwin (Apple Silicon) — mach self-hosts PIE arm64 macОS binaries and CD publishes an `aarch64-darwin` archive. Also project-scoped `mach test`, `mach run` without rebuild, riscv64 ELF build-attributes, and the `fin` block-body parser correction. No breaking changes.

- Bumps mach.toml 2.9.0 → 2.10.0 + CHANGELOG.
- Drops the x86_64-darwin release leg (arm64-only); `install.sh` gains an arm64-darwin host case (#1728).

After merge: dev→main integration merge, then tag `v2.10.0` to trigger CD.