### PR TITLE
fix(abi/sysv): pass >16B aggregate args by value on the stack (C-ABI conformance) (#1739)

### DIFF
--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -3,11 +3,12 @@
 # Implements `abi.AbiVTable` and self-registers under `abi.ABI_SYSV` at startup.
 # Owns the SysV AMD64 classification of parameters and return values -- the
 # <=8-byte one-register, 9-16-byte two-register (RDI:RSI for args, RAX:RDX for
-# returns), and >16-byte by-reference / sret rules -- plus the GP/FP/callee-saved
-# register files, the 16-byte stack alignment, the 128-byte red zone, and the
-# variadic save-area hooks. The three classify / arg_passing / ret_passing vtable
-# function pointers are type-erased (`*u8`); a consumer casts each back to the
-# concrete signature declared here (`ClassifyFn`, `ArgPassingFn`, `RetPassingFn`).
+# returns), >16-byte by-value-on-stack argument, and >16-byte sret return rules --
+# plus the GP/FP/callee-saved register files, the 16-byte stack alignment, the
+# 128-byte red zone, and the variadic save-area hooks. The three classify /
+# arg_passing / ret_passing vtable function pointers are type-erased (`*u8`); a
+# consumer casts each back to the concrete signature declared here (`ClassifyFn`,
+# `ArgPassingFn`, `RetPassingFn`).
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -121,10 +122,10 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 
 # assign registers or a stack slot for one argument (SysV)
 #
-# Aggregates larger than 16 bytes are passed by hidden reference (CLASS_BYREF)
-# when a GP argument register remains -- the pointer occupies that register; once
-# the GP registers are exhausted such an aggregate is MEMORY-class, passed BY
-# VALUE on the stack (its full byte size, CLASS_STACK), not by reference.
+# Aggregates larger than 16 bytes are MEMORY-class: passed BY VALUE on the stack at
+# their full byte size (CLASS_STACK), consuming NO GP register and never a hidden
+# pointer -- the System V psABI reserves the hidden-pointer form for a MEMORY-class
+# RETURN (the sret path), not an argument.
 # Aggregates of 9-16 bytes are classified PER EIGHTBYTE: each eightbyte takes a GP
 # argument register, or an SSE eightbyte (all its fields floating-point, per
 # `fp_eightbytes`) takes an XMM register, so `{f64; f64}` rides XMM0:XMM1 and
@@ -156,12 +157,11 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
     if (is_aggregate && size > MAX_REG_RET) {
-        if (gp_used < GP_PARAM_COUNT) {
-            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
-        }
-        # no GP register remains: the aggregate is MEMORY-class, passed by value on
-        # the stack at its full byte size so the caller's by-value copy, the
-        # outgoing-region cursor, and the callee's in-place read agree on its footprint.
+        # MEMORY-class argument: the SysV psABI passes it BY VALUE ON THE STACK at its
+        # full byte size, consuming no GP register and never a hidden pointer (that
+        # form is for a MEMORY-class return, the sret path). the full-size CLASS_STACK
+        # slot keeps the caller's by-value copy, the outgoing-region cursor, and the
+        # callee's in-place read agreed on its footprint.
         ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
     }
 
@@ -515,20 +515,27 @@ test "mach.lang.target.abi.sysv.register:indirect_result_in_argfile" {
     ret 0;
 }
 
-# a >16-byte aggregate is MEMORY-class (passed by value on the stack) once the GP
-# argument registers are exhausted; with one register left it is CLASS_BYREF.
-test "mach.lang.target.abi.sysv.classify_arg:large_aggregate_memory_class_when_gp_exhausted" {
-    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 6, 0, 0, 0, abi.agg_none());
+# a >16-byte aggregate argument is MEMORY-class: passed by value on the stack at its
+# full byte size, consuming NO GP register, whether or not a GP argument register
+# remains. the hidden-pointer (CLASS_BYREF) form is reserved for a MEMORY-class
+# return, never an argument.
+test "mach.lang.target.abi.sysv.classify_arg:large_aggregate_memory_class_by_value" {
+    # all six GP argument registers free: still by value on the stack, no register.
+    val s0: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    if (s0.class != abi.CLASS_STACK) { ret 1; }
+    if (s0.reg   != -1)              { ret 1; }
+    if (s0.size  != 32)              { ret 1; }
+
+    # one GP argument register still free: no hidden pointer, by value on the stack.
+    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 5, 0, 0, 0, abi.agg_none());
     if (s1.class != abi.CLASS_STACK) { ret 1; }
     if (s1.reg   != -1)              { ret 1; }
     if (s1.size  != 32)              { ret 1; }
 
+    # GP argument registers exhausted: by value on the stack, the odd size carried through.
     val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, 6, 0, 0, 0, abi.agg_none());
     if (s2.class != abi.CLASS_STACK) { ret 1; }
     if (s2.reg   != -1)              { ret 1; }
     if (s2.size  != 17)              { ret 1; }
-
-    val s3: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 5, 0, 0, 0, abi.agg_none());
-    if (s3.class != abi.CLASS_BYREF) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
## What

`sysv.classify_arg` passed a **>16-byte (MEMORY-class) aggregate argument by hidden reference** (`CLASS_BYREF` — a pointer in the next GP argument register) whenever a GP register was free, only falling back to by-value-on-stack (`CLASS_STACK`) once the GP bank was exhausted. The locking test asserted the BYREF behavior.

The SysV AMD64 psABI requires a **MEMORY-class argument to be passed by value on the stack**, consuming **no** integer register. The hidden-pointer form is for a MEMORY-class **return** (the sret path) — `classify_return` is unchanged.

## Fix

Drop the `CLASS_BYREF` branch in `classify_arg` for the >16-byte aggregate argument path so it unconditionally returns `CLASS_STACK` at full `size`. The existing no-GP-register fallback was already the psABI-correct placement, so the by-value-copy / outgoing-cursor / callee-read machinery (in `be/codegen/mir/abi.mach`) is already in place. Rewrote the locking unit test and updated the doc comments. **Only `sysv.mach` is touched** — win64/aapcs64/lp64 keep their own large-aggregate rules.

Caller and callee both classify through the same whole-signature oracle, so mach↔mach stays self-consistent at the new placement.

## Validation

- **Bug confirmed real**: the old test locked `s3.class == CLASS_BYREF` for a >16B arg with a free GP register; the return/sret path (`classify_return` → `CLASS_SRET`) is a separate function, unaffected.
- **Self-host fixpoint re-established at the new placement**: `mach build . -o a` → `./a build . -o b` → `./b build . -o c`; `b` and `c` are **byte-identical**. A clean-dev baseline fixpoint differs from this one (`c0 != c`), confirming the change does alter the compiler's own codegen — i.e. the compiler source itself passes some >16B struct by value, now emitted by value on the stack. **Output changed; the fixpoint holds.**
- **`mach build .` clean**; **`mach test .` 430/430** (project) and **690/690 with `--include-deps`**, run with the new fixpoint compiler.
- **All three fixtures green** with the new compiler: `freestanding` (exit 45), `macho` (both Darwin triples, static + dynamic + rebase + signatures), `riscv64` (RV64 ELF runs to exit code 133 under qemu — unchanged, the sysv change doesn't affect riscv/lp64d).

Closes #1739