### PR TITLE
ci: exercise -O2 self-host on aarch64-linux and x86_64-windows per PR (#1740)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
 
-# every native host gets two checks: "build <target>" proves the most recent
+# every native host gets three checks: "build <target>" proves the most recent
 # release (the seed) builds the project to a self-host fixpoint. "test <target>"
 # reuses that fixpoint compiler to run the in-source corpus. "release <target>"
 # repeats the fixpoint under the opt=2 release profile so -O2 codegen
@@ -105,6 +105,9 @@ jobs:
           - target: x86_64-linux
             runs-on: ubuntu-latest
             seed: mach-*-x86_64-linux.tar.gz
+          - target: aarch64-linux
+            runs-on: ubuntu-24.04-arm
+            seed: mach-*-aarch64-linux.tar.gz
     steps:
       - uses: actions/checkout@v6
 
@@ -363,4 +366,54 @@ jobs:
           ./artifact/mach.exe dep pull
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           ./artifact/mach.exe test .
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  release-windows:
+    name: release ${{ matrix.target }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-windows
+            runs-on: windows-latest
+            seed: mach-*-x86_64-windows.zip
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: fetch released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED: ${{ matrix.seed }}
+        run: |
+          $seed = Join-Path $env:RUNNER_TEMP 'seed'
+          New-Item -ItemType Directory -Path $seed -Force | Out-Null
+          gh release download -R $env:GITHUB_REPOSITORY -p $env:SEED -D $seed
+          $zip = Get-ChildItem -Path $seed -Filter $env:SEED | Select-Object -First 1
+          Expand-Archive -Path $zip.FullName -DestinationPath $seed -Force
+          Add-Content -Path $env:GITHUB_PATH -Value $seed
+
+      - name: build release fixpoint
+        run: |
+          mach.exe dep pull
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          mach.exe build . --profile release -o a.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          ./a.exe build . --profile release -o b.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          ./b.exe build . --profile release -o c.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          # the opt=2 compiler must rebuild itself byte-identically (no cmp in pwsh)
+          if ((Get-FileHash b.exe).Hash -ne (Get-FileHash c.exe).Hash) {
+            Write-Error 'release build did not converge to the fixpoint'
+            exit 1
+          }
+
+      - name: self test
+        run: |
+          ./c.exe test .
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
## What

`ci.yml`'s release/opt2 lane was **x86_64-linux-only**, so **aarch64-linux** and **x86_64-windows** -O2 codegen was exercised only by `cd.yml` at tag time. A broken `-O2` PR on either shipped target merged green and was caught only at release — hard to bisect.

## Fix

- **aarch64-linux release lane** (primary fix): added an `aarch64-linux` entry to the `release-linux` matrix on `ubuntu-24.04-arm`, mirroring the `build-linux` matrix entry verbatim. The job steps are already parameterized by `matrix.runs-on` / `matrix.seed` / `matrix.target`, so the matrix entry is the whole change.
- **x86_64-windows release lane**: added a `release-windows` job mirroring `build-windows` (pwsh seed-fetch + build pattern) plus `release-linux`'s `--profile release` fixpoint + inline self-test.
- **comment**: every native host now gets build + test + release on PRs, so the `:10` header comment now reads "three checks" instead of "two".

Only `.github/workflows/ci.yml` is touched. The two new lanes mirror existing working lanes exactly; no existing lane changed.

## Validation

CI config can't be fully run locally — **this PR's own CI run is the validation**. The workflow parses cleanly (`yaml.safe_load`); the `release-linux` matrix now resolves to `[x86_64-linux, aarch64-linux]` and `release-windows` to `[x86_64-windows]`.

Note for review: **if the new aarch64 `-O2` lane (or the windows one) goes red, that is the coverage hole doing its job** — it would mean a latent aarch64/windows opt2 self-host bug exists, which should be filed and fixed rather than a reason to drop the lane.

Part of #1180. Closes #1740