### PR TITLE
ci: x86_64-darwin release lane via Rosetta 2 on macos-14

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,12 +9,17 @@ on:
 permissions:
   contents: read
 
-# a tagged push builds the release binary for each target on its native host
-# (each to its own self-host fixpoint), then publishes the archives + SHA256SUMS.
-# correctness is CI's job — every change reaches main through a PR it gates.
+# a tagged push builds the release binary for each target — on its native host, or
+# under emulation where no practical native runner exists — each to its own
+# self-host fixpoint, then publishes the archives + SHA256SUMS. correctness is CI's
+# job — every change reaches main through a PR it gates.
 #
 # darwin has no prior release to self-seed from, so seed-darwin cross-builds the
 # stage-0 seed on linux first; collapse that bootstrap once a darwin archive ships.
+# both darwin archives build on macos-14 (apple silicon): aarch64-darwin natively
+# and x86_64-darwin under Rosetta 2 — Intel macos-13 runners are queue-starved, and
+# the cross-built x86_64 seed bakes in x86_64-darwin as its host, so its
+# under-Rosetta a/b/c fixpoint stays self-hosted on the arm64 box.
 #
 # workflow_dispatch runs the darwin lane (seed + native fixpoint + self-test) on a
 # branch with no tag, so on-Mac validation needs no release; the tag-verify and
@@ -172,6 +177,8 @@ jobs:
         include:
           - target: aarch64-darwin
             triple: darwin-aarch64
+          - target: x86_64-darwin
+            triple: darwin-x86_64
     steps:
       - uses: actions/checkout@v6
 
@@ -215,6 +222,12 @@ jobs:
         include:
           - target: aarch64-darwin
             runs-on: macos-14
+          # x86_64-darwin: an Intel Mach-O run on the arm64 box via Rosetta 2. the
+          # cross-built seed bakes in x86_64-darwin as its host, so the whole a/b/c
+          # fixpoint emits Intel binaries and self-hosts under Rosetta.
+          - target: x86_64-darwin
+            runs-on: macos-14
+            rosetta: true
     steps:
       - uses: actions/checkout@v6
 
@@ -224,12 +237,19 @@ jobs:
           name: seed-${{ matrix.target }}
           path: seed
 
+      # the x86_64-darwin seed and its fixpoint are Intel Mach-O; the arm64 runner
+      # executes them through Rosetta 2, which is deterministic, so b == c holds.
+      - name: install Rosetta 2
+        if: ${{ matrix.rosetta }}
+        run: softwareupdate --install-rosetta --agree-to-license
+
       - name: build fixpoint
         run: |
           set -euo pipefail
           chmod +x seed/mach-darwin-seed
 
-          # native stage-0 is the cross-built seed; a/b/c are native self-hosts
+          # stage-0 is the cross-built seed; a/b/c self-host on the macOS runner
+          # (arm64 natively, or x86_64 under Rosetta)
           ./seed/mach-darwin-seed dep pull
           ./seed/mach-darwin-seed build . --profile release -o a
           ./a build . --profile release -o b
@@ -244,8 +264,9 @@ jobs:
       - name: self test
         run: |
           set -euo pipefail
-          # exercises a mach-built native darwin binary: arm64 must run under the
-          # ad-hoc signature (no SIGKILL) for the fixpoint and these tests to pass
+          # exercises a mach-built darwin binary — arm64 native, or x86_64 under
+          # Rosetta — whose ad-hoc signature must hold (no SIGKILL) for the fixpoint
+          # and these tests to pass
           ./c test .
 
       - name: package archive


### PR DESCRIPTION
Closes #1728.

Restores the **x86_64-darwin** release binary that was dropped when the Intel
`macos-13` runners became chronically queue-starved — without needing a `macos-13`
runner. The new lane mirrors the existing arm64-darwin flow but runs under
**Rosetta 2** on the same `macos-14` (Apple Silicon) runner.

## What changed (`.github/workflows/cd.yml`)
- **`seed-darwin`**: matrix extended with `x86_64-darwin` (triple `darwin-x86_64`).
  Cross-builds the Intel seed on linux exactly like the arm64 seed.
- **`build-darwin`**: matrix extended with `x86_64-darwin` on `macos-14` (`rosetta: true`).
  Adds a conditional `install Rosetta 2` step (`softwareupdate --install-rosetta
  --agree-to-license`, gated on `matrix.rosetta`), then runs the shared
  seed→a→b→c fixpoint, `cmp -s b c` gate, `./c test .`, package, and upload — all
  under Rosetta.
- **`release`**: no change needed — it already globs `release-*` / `mach-*.tar.gz`,
  so `mach-<ver>-x86_64-darwin.tar.gz` flows into the artifacts + `SHA256SUMS`.
- Header comment updated to document arm64-native + x86_64-under-Rosetta darwin builds.

## Why the under-Rosetta fixpoint is sound
The host target folds at **compile time** from `$mach.build.arch` (`src/lang/target.mach`),
not from runtime hardware detection. The cross-built seed therefore bakes in
x86_64-darwin as its host, so every fixpoint stage (a/b/c) emits an Intel Mach-O,
each executed via Rosetta. Rosetta faithfully and deterministically emulates x86_64
semantics, so the compiler output is identical to a native Intel Mac and **b == c**
holds.

## Validation
A CD change can't be fully validated pre-merge. This PR:
1. **Parses** as valid YAML; all six jobs intact.
2. **Structurally mirrors** the arm64 lane (same fixpoint + convergence gate +
   self-test + package + upload shape; target-parametrized shared steps).

Real validation is a `workflow_dispatch` of `cd.yml` on `dev` **after merge**
(the darwin lane runs on a branch with no tag). Note: this costs `macos-14` minutes.

### Caveats
- If `softwareupdate --install-rosetta` turns out to need `sudo` on the hosted
  runner, the dispatch will surface it (easy one-line follow-up).
- No schedule/cron added.