### PR TITLE
chore(release): bump version to 2.11.0

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.10.0"
+version = "2.11.0"
 src = "src"
 dep = "dep"
 target = "native"


### PR DESCRIPTION
Version bump for the 2.11.0 release. Ships the 72-commit batch since v2.10.0: the lp64d ABI refactor (#1637/#1734), the riscv64 correctness cluster (#1733/#1737/#1750/#1753/#1762), the int/ integration-test system (#1759/#1760), windows ASLR (#1729), aarch64/riscv64 ELF dynamic linking (#1741), the x86_64-darwin release lane (#1728), --pie phase 1 (#1727), editor sema types (#1501), and the defensive-fallback cleanup (#1745).