### PR TITLE
chore(cli): remove orphaned --color / ColorMode / color surface

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -38,7 +38,6 @@ A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 | `-v`             | —                | `mach build`: per-phase roll-up (load/resolve/sema/lower/optimize/codegen/link) with item counts + timing, then a `built … N modules … in …` summary, on stderr |
 | `-vv`            | —                | `-v` plus a per-module/file line under each phase with its duration and a `(slow)` marker on the slowest |
 | `--quiet`, `-q`  | —                | suppress non-error output |
-| `--color <mode>` | `auto`\|`always`\|`never` | color preference for terminal output (default `auto`); an unknown mode is a parse error |
 | `--target <name>`| target name      | select a declared target; absent, defers to `[project].target` |
 | `--profile <name>`| profile name    | select a `[profile.<name>]` build variant; absent, the first declared profile |
 | `--bin <name>`   | artifact name    | narrow the build to one `[bin.<name>]` artifact |

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -55,7 +55,6 @@ fun global_flags() {
     print.print("  -v                phase roll-up with timing + a build summary on stderr\n");
     print.print("  -vv               -v plus per-module/file detail under each phase\n");
     print.print("  --quiet, -q       suppress non-error output (mutually exclusive with -v/-vv)\n");
-    print.print("  --color <mode>    auto | always | never (default auto)\n");
     print.print("  --target <name>   select a [targets.<name>] entry\n");
     print.print("  -o <path>         override the linked-binary path (build/run/test)\n");
     print.print("  --artifacts <dir> override the per-target object directory (build/run/test)\n");

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -1,33 +1,24 @@
 # CLI-level configuration shared across subcommands.
 #
 # centralises the cross-cutting settings every subcommand respects in the same
-# way - color output, verbosity, emission toggles, and target/profile
-# selection - so each command's `run` does not reimplement the same flag
-# handling. `parse` reads these flags out of the raw argv via the `util`
-# helpers and leaves every per-subcommand flag in place for the subcommand to
-# consume itself. verbosity (`-v`/`-vv`) and `quiet` are mutually exclusive:
-# passing both is a parse error that yields an error message.
+# way - verbosity, emission toggles, and target/profile selection - so each
+# command's `run` does not reimplement the same flag handling. `parse` reads
+# these flags out of the raw argv via the `util` helpers and leaves every
+# per-subcommand flag in place for the subcommand to consume itself. verbosity
+# (`-v`/`-vv`) and `quiet` are mutually exclusive: passing both is a parse error
+# that yields an error message.
 
 use std.types.bool.bool;
 use std.types.size.usize;
 use std.types.string.str;
-use std.types.string.str_equals;
 
 use O: std.types.option;
 use R: std.types.result;
 
 use mach.cli.util;
 
-# resolved color preference for terminal output
-pub def ColorMode: u8;
-
-pub val COLOR_AUTO:   ColorMode = 0;  # tty-detect; the default
-pub val COLOR_ALWAYS: ColorMode = 1;  # force-enable color
-pub val COLOR_NEVER:  ColorMode = 2;  # force-disable color
-
 # cross-cutting CLI settings shared by every subcommand
 # ---
-# color:       resolved color preference
 # verbosity:   readout detail level: 0 plain, 1 (`-v`), 2 (`-vv`)
 # quiet:       --quiet / -q was passed; suppress non-error output
 # verify_ir:   --verify-ir was passed; run the IR verifier after each optimization pass
@@ -57,7 +48,6 @@ pub val COLOR_NEVER:  ColorMode = 2;  # force-disable color
 # pie:         --pie was passed; emit a position-independent (ET_DYN) executable for
 #              ASLR instead of the default fixed-address one. opt-in, off by default
 pub rec Config {
-    color:       ColorMode;
     verbosity:   u8;
     quiet:       bool;
     verify_ir:   bool;
@@ -76,25 +66,12 @@ pub rec Config {
     pie:         bool;
 }
 
-# resolve a ColorMode to a concrete on/off decision for the diagnostic renderer
-#
-# ALWAYS forces ANSI on, NEVER forces it off, and AUTO is currently treated as
-# off - the platform layer exposes no tty detection yet, so the conservative
-# default never emits escapes a non-terminal would show raw. `--color always`
-# is the way to force color until isatty lands.
-# ---
-# mode: the resolved color preference
-# ret:  true when the renderer should emit ANSI styling
-pub fun color_enabled(mode: ColorMode) bool {
-    ret mode == COLOR_ALWAYS;
-}
-
 # read the cross-cutting flags out of `argv` and produce a populated Config
 #
 # Per-subcommand flags are left in argv for the subcommand to consume itself.
 # Returns a specific error message on a parse error so the caller can tell the
-# user which flag was wrong: an unknown `--color` mode, or a verbosity flag
-# (`-v`/`-vv`) combined with `--quiet`.
+# user which flag was wrong: a verbosity flag (`-v`/`-vv`) combined with
+# `--quiet`.
 # ---
 # argc: argument count including argv[0]
 # argv: the argument vector (argc null-terminated byte pointers)
@@ -128,18 +105,6 @@ pub fun parse(argc: usize, argv: **u8) R.Result[Config, str] {
     c.profile   = flag_value_get(argc, argv, "--profile");
     c.bin       = flag_value_get(argc, argv, "--bin");
     c.lib       = flag_value_get(argc, argv, "--lib");
-
-    c.color = COLOR_AUTO;
-    val color_opt: O.Option[*u8] = util.get_value(argc, argv, "--color");
-    if (O.is_some[*u8](color_opt)) {
-        val mode: str = O.unwrap[*u8](color_opt)::str;
-        if (str_equals(mode, "auto"))   { c.color = COLOR_AUTO;   }
-        or (str_equals(mode, "always")) { c.color = COLOR_ALWAYS; }
-        or (str_equals(mode, "never"))  { c.color = COLOR_NEVER;  }
-        or {
-            ret R.err[Config, str]("invalid --color mode (expected auto, always, or never)");
-        }
-    }
 
     ret R.ok[Config, str](c);
 }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -140,7 +140,6 @@ pub fun is_value_flag(a: *u8) bool {
         || str_equals(s, "-l")
         || str_equals(s, "-o")
         || str_equals(s, "--target")
-        || str_equals(s, "--color")
         || str_equals(s, "--artifacts")
         || str_equals(s, "--emit")
         || str_equals(s, "--filter")


### PR DESCRIPTION
Follow-up to #1777. The ASCII-only diagnostic renderer dropped the `color` argument from the diagnostic flush, leaving `--color`, the `ColorMode` type, `config.color_enabled`, and the `Config.color` field with no readers — `--color` parsed but no-opped.

## Removed
- the `--color` flag from the value-flag table (`src/cli/util.mach`) and its help/doc entries (`src/cli/cmd/help.mach`, `doc/cli.md`)
- the `ColorMode` type + `COLOR_AUTO`/`COLOR_ALWAYS`/`COLOR_NEVER` constants
- the `color_enabled` resolver
- the `Config.color` field and its `parse` block
- the now-unused `str_equals` import in `config.mach`

The two remaining "no color" comments in `diagnostic.mach` / `check.mach` describe the renderer's permanent ASCII-only design (#1773) and are left intact.

## Verification
- `mach build .` from the installed 2.12.0 seed: green; self-host reaches a byte-identical fixpoint (stage1 rebuilt itself to the same sha256).
- `mach test .`: 438 passed, 0 failed.
- `--color` no longer appears in `mach help build`; it is no longer a recognized flag.

## Note
mach has no general unknown-flag rejector (e.g. `mach info --bogus` is silently ignored today), so `mach <cmd> --color always` now treats `always` as a stray positional rather than emitting a dedicated "unknown flag" error. Adding flag validation would be a broader behavior change outside this chore's scope; the flag is gone from the recognized surface and from help as the issue's acceptance intends.

Closes #1784