### PR TITLE
fix(sema): report out-of-range integer literals with their bounds

### DIFF
--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1287,6 +1287,62 @@ test "mach.lang.editor.sema:widening_mismatch_preserved" {
     ret 0;
 }
 
+# an all-ones literal that the pre-#1804 compiler silently accepted into a signed
+# slot (wrapping to -1 at runtime) is now rejected against the signed range, while
+# the same literal into a u64 slot - where it is the legitimate maximum - stays
+# accepted (#1804)
+test "mach.lang.editor.sema:literal_out_of_range_u64_max_into_signed" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    # 0xFFFFFFFFFFFFFFFF is 18446744073709551615: out of range for i64, exactly
+    # u64's maximum. only the i64 slot must error - the single `out of range`
+    # count proves the u64 slot stayed accepted.
+    val res_fid: R.Result[source.FileId, str] = open(?es, "allones.mach",
+        "fun main() i64 { val x: i64 = 0xFFFFFFFFFFFFFFFF; val m: u64 = 0xFFFFFFFFFFFFFFFF; ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+    if (!diag_has(list, "literal 18446744073709551615 is out of range for i64 (-9223372036854775808..9223372036854775807)")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_count(list, "out of range") != 1) { dnit(?es); session.dnit(?s); ret 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret 0;
+}
+
+# an out-of-range literal into a secret slot names the secret type the author
+# wrote (`^u8`), not its public base, while ranging against the integer base
+# (#1804, #1645)
+test "mach.lang.editor.sema:literal_out_of_range_secret_type" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    # `^u8` fixes the literal against the public base u8 but the message must name
+    # the `^u8` the author wrote; the bounds stay u8's 0..255.
+    val res_fid: R.Result[source.FileId, str] = open(?es, "secret.mach",
+        "fun main() i64 { var sx: ^u8 = 300; ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags))                                                { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagList, str](res_diags), "literal 300 is out of range for ^u8 (0..255)")) { dnit(?es); session.dnit(?s); ret 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret 0;
+}
+
 # an unresolved identifier names the symbol and suggests a near match
 test "mach.lang.editor.resolve:unresolved_ident_suggestion" {
     var alloc: A.Allocator;

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1180,6 +1180,113 @@ test "mach.lang.editor.sema:int_float_compare_rejected" {
     ret 0;
 }
 
+# an out-of-range integer literal names its value and the type's bounds instead of
+# a generic mismatch, and never suggests a truncating cast (#1804)
+test "mach.lang.editor.sema:literal_out_of_range_unsigned" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    # 300 does not fit u8: the message must name the value and the 0..255 range,
+    # not report `expected u8, found i64`, and carry no cast note - a `300::u8`
+    # cast silently truncates to 44, the corruption this diagnostic exists to stop.
+    val res_fid: R.Result[source.FileId, str] = open(?es, "oor.mach",
+        "fun main() i64 { val x: u8 = 300; ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+    if (!diag_has(list, "literal 300 is out of range for u8 (0..255)")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_has(list, "type mismatch"))                                { dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_note_has(list, "no implicit widening"))                    { dnit(?es); session.dnit(?s); ret 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret 0;
+}
+
+# a signed destination reports its signed bounds (#1804)
+test "mach.lang.editor.sema:literal_out_of_range_signed" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    # 200 is above i8's maximum; the range shows the signed span -128..127.
+    val res_fid: R.Result[source.FileId, str] = open(?es, "oors.mach",
+        "fun main() i64 { val y: i8 = 200; ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags))                                                    { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagList, str](res_diags), "literal 200 is out of range for i8 (-128..127)")) { dnit(?es); session.dnit(?s); ret 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret 0;
+}
+
+# the negated-literal domain is range-checked and reported too: -129 is below i8's
+# minimum, and a negative literal never takes an unsigned type (#1804)
+test "mach.lang.editor.sema:literal_out_of_range_negative" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    # -129 undershoots i8 (min -128); -1 cannot take u8. both render the signed
+    # value and the destination's bounds.
+    val res_fid: R.Result[source.FileId, str] = open(?es, "oorn.mach",
+        "fun main() i64 { val z: i8 = -129; val w: u8 = -1; ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+    if (!diag_has(list, "literal -129 is out of range for i8 (-128..127)")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(list, "literal -1 is out of range for u8 (0..255)"))      { dnit(?es); session.dnit(?s); ret 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret 0;
+}
+
+# a genuine widening - a typed value, not a literal - keeps the mismatch message
+# and its cast note, and is never mistaken for an out-of-range literal (#1804)
+test "mach.lang.editor.sema:widening_mismatch_preserved" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    # `a` is a typed i64, not a literal, so its assignment to a u8 is the widening
+    # case the mismatch message was written for; the cast advice is correct here.
+    val res_fid: R.Result[source.FileId, str] = open(?es, "widen.mach",
+        "fun main() i64 { var a: i64 = 5; val b: u8 = a; ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+    if (!diag_has(list, "type mismatch: expected u8, found i64")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_note_has(list, "mach has no implicit widening"))    { dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_has(list, "out of range"))                          { dnit(?es); session.dnit(?s); ret 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret 0;
+}
+
 # an unresolved identifier names the symbol and suggests a near match
 test "mach.lang.editor.resolve:unresolved_ident_suggestion" {
     var alloc: A.Allocator;

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -42,7 +42,6 @@ use mach.lang.fe.ast.stmt;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema.check;
-use mach.lang.fe.sema.coerce;
 use mach.lang.fe.sema.context;
 use mach.lang.fe.sema.infer;
 use mach.lang.fe.token;
@@ -1335,8 +1334,9 @@ fun infer_local_decl(sc: *context.SemaContext, did: id.DeclId) R.Result[bool, st
 
 # check an initializer expression against the declared slot type
 #
-# Attempts a literal coercion first (which rewrites expr_type[eid] on success),
-# then delegates to check.check_assignable on the post-coercion type.
+# Delegates to check.check_coercible, which offers the initializer the declared
+# type (rewriting expr_type[eid] on a successful literal coercion) and reports
+# either an out-of-range or a widening mismatch on failure.
 # ---
 # sc:       the context
 # expected: the declared slot type
@@ -1344,16 +1344,15 @@ fun infer_local_decl(sc: *context.SemaContext, did: id.DeclId) R.Result[bool, st
 # actual:   the initializer's inferred type
 # span:     span to report a mismatch against
 fun check_binding(sc: *context.SemaContext, expected: type.TypeId, eid: id.ExprId, actual: type.TypeId, span: token.Span) {
-    var have: type.TypeId = actual;
-    val opt_coerced: O.Option[type.TypeId] = coerce.try_coerce_literal(sc, eid, expected);
-    if (O.is_some[type.TypeId](opt_coerced)) { have = O.unwrap[type.TypeId](opt_coerced); }
-    check.check_assignable(sc, expected, have, span);
+    check.check_coercible(sc, expected, eid, actual, span);
 }
 
 # check a return statement against the enclosing function's return type
 #
-# Infers the returned value (if any), applies a literal coercion toward the
-# resolved return type, then delegates to check.check_return.
+# Infers the returned value (if any). The bare-ret, void-function, and error
+# cases keep check.check_return's dedicated messages; a value returned into a real
+# type narrows through check.check_coercible, which reports an out-of-range or a
+# widening mismatch.
 # ---
 # sc:       the context
 # ret_type: the enclosing function's return type
@@ -1364,12 +1363,13 @@ fun check_return_stmt(sc: *context.SemaContext, ret_type: type.TypeId, value: id
         check.check_return(sc, ret_type, type.TYPE_NIL, span);
         ret;
     }
-    var value_ty: type.TypeId = infer.infer_expr(sc, value);
-    if (ret_type != type.TYPE_NIL && ret_type != type.TYPE_ERROR && value_ty != type.TYPE_ERROR) {
-        val opt_coerced: O.Option[type.TypeId] = coerce.try_coerce_literal(sc, value, ret_type);
-        if (O.is_some[type.TypeId](opt_coerced)) { value_ty = O.unwrap[type.TypeId](opt_coerced); }
+    val value_ty: type.TypeId = infer.infer_expr(sc, value);
+    if (ret_type == type.TYPE_NIL || ret_type == type.TYPE_ERROR
+        || value_ty == type.TYPE_ERROR || value_ty == type.TYPE_NIL) {
+        check.check_return(sc, ret_type, value_ty, span);
+        ret;
     }
-    check.check_return(sc, ret_type, value_ty, span);
+    check.check_coercible(sc, ret_type, value, value_ty, span);
 }
 
 # evaluate a comptime-branch condition, reporting whether the arm is active

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -65,6 +65,35 @@ pub fun check_assignable(sc: *context.SemaContext, expected: type.TypeId, actual
     ret false;
 }
 
+# coerce the literal at `eid` toward `expected`, then check assignability
+#
+# the single consumer of coerce's tri-state result: it offers the expression the
+# destination type (rewriting expr_type[eid] on a successful literal coercion),
+# then validates the post-coercion type. an integer literal whose value overflows
+# an integer destination reports a dedicated range diagnostic - naming the value
+# and the type's bounds, with no cast suggestion - rather than the generic
+# widening mismatch, which for an overflow would advise a truncating cast. every
+# hard-failure assignment site (bindings, assignments, returns, call arguments,
+# aggregate elements) routes here, so the overflow fact coerce computed is
+# reported in exactly one place.
+# ---
+# sc:       the active sema context
+# expected: the destination slot's type
+# eid:      the source expression; a literal is offered `expected`
+# actual:   the source's inferred (pre-coercion) type
+# span:     source range to attribute a diagnostic to
+# ret:      true when the value is assignable, false (with a diagnostic) otherwise
+pub fun check_coercible(sc: *context.SemaContext, expected: type.TypeId, eid: id.ExprId, actual: type.TypeId, span: token.Span) bool {
+    val cr: coerce.CoerceResult = coerce.try_coerce_literal(sc, eid, expected);
+    if (cr.kind == coerce.COERCE_OUT_OF_RANGE) {
+        report_out_of_range(sc, span, cr);
+        ret false;
+    }
+    var have: type.TypeId = actual;
+    if (cr.kind == coerce.COERCE_COERCED) { have = cr.ty; }
+    ret check_assignable(sc, expected, have, span);
+}
+
 # checks a call against the callee's function signature
 #
 # the callee type must be a function, the argument count must match the fixed
@@ -132,14 +161,12 @@ pub fun check_call(sc: *context.SemaContext, callee_sig: type.TypeId, args_start
         if (O.is_none[type.TypeId](opt_param_type)) { all_ok = false; brk; }
         val expected: type.TypeId = O.unwrap[type.TypeId](opt_param_type);
 
-        val arg_eid: id.ExprId = sc.a.expr_ids[args_start + i];
-        var actual: type.TypeId = expr_type_of(sc, arg_eid);
+        val arg_eid:  id.ExprId   = sc.a.expr_ids[args_start + i];
+        val actual:   type.TypeId = expr_type_of(sc, arg_eid);
+        val arg_span: token.Span  = expr_span_of(sc, arg_eid, span);
         # a bare integer / float literal argument adopts the parameter's type, so
         # `err[i64, i32](-1)` passes `-1` as an i32.
-        val opt_coerced: O.Option[type.TypeId] = coerce.try_coerce_literal(sc, arg_eid, expected);
-        if (O.is_some[type.TypeId](opt_coerced)) { actual = O.unwrap[type.TypeId](opt_coerced); }
-        val arg_span: token.Span = expr_span_of(sc, arg_eid, span);
-        if (!check_assignable(sc, expected, actual, arg_span)) {
+        if (!check_coercible(sc, expected, arg_eid, actual, arg_span)) {
             all_ok = false;
         }
         i = i + 1;
@@ -213,10 +240,8 @@ pub fun check_comptime_call(sc: *context.SemaContext, callee_sig: type.TypeId, c
             val opt_param_type: O.Option[type.TypeId] = type.get_param(?sc.s.types, rt_start + rt_seen);
             if (O.is_some[type.TypeId](opt_param_type)) {
                 val expected: type.TypeId = O.unwrap[type.TypeId](opt_param_type);
-                var actual: type.TypeId = expr_type_of(sc, arg_eid);
-                val opt_coerced: O.Option[type.TypeId] = coerce.try_coerce_literal(sc, arg_eid, expected);
-                if (O.is_some[type.TypeId](opt_coerced))               { actual = O.unwrap[type.TypeId](opt_coerced); }
-                if (!check_assignable(sc, expected, actual, arg_span)) { all_ok = false; }
+                val actual:   type.TypeId = expr_type_of(sc, arg_eid);
+                if (!check_coercible(sc, expected, arg_eid, actual, arg_span)) { all_ok = false; }
             }
             rt_seen = rt_seen + 1;
         }
@@ -1008,6 +1033,67 @@ fun report_mismatch(sc: *context.SemaContext, span: token.Span, expected: type.T
     A.deallocate[char](sc.s.alloc, msg, total + 1);
     type_str_free(sc, expected_str);
     type_str_free(sc, actual_str);
+}
+
+# report a `literal <v> is out of range for <T> (<min>..<max>)` diagnostic
+#
+# consumes an OUT_OF_RANGE coerce result: renders the offending literal's value
+# (its magnitude, signed by `negated`), the destination integer type via
+# type_to_str, and the type's inclusive bounds from coerce.int_bounds, all as
+# decimals. names the overflow directly and, unlike report_mismatch, carries no
+# cast note - a truncating cast is the corrupting advice this diagnostic exists to
+# avoid. any render or allocation failure degrades to a static, value-free message
+# so the error is always reported.
+# ---
+# sc:   the active sema context
+# span: source range to pin the diagnostic to
+# cr:   the OUT_OF_RANGE result (destination type, literal magnitude, sign)
+fun report_out_of_range(sc: *context.SemaContext, span: token.Span, cr: coerce.CoerceResult) {
+    val res_type: R.Result[str, str] = type_to_str(sc, cr.ty);
+    if (R.is_err[str, str](res_type)) {
+        report(sc, span, "integer literal out of range for its type");
+        ret;
+    }
+    val type_str: str            = R.unwrap_ok[str, str](res_type);
+    val bounds:   coerce.IntBounds = coerce.int_bounds(sc, cr.ty);
+
+    val lit:   str = "literal ";
+    val neg:   str = "-";
+    val mid:   str = " is out of range for ";
+    val open:  str = " (";
+    val dots:  str = "..";
+    val close: str = ")";
+
+    var total: usize = str_len(lit);
+    if (cr.negated) { total = total + str_len(neg); }
+    total = total + decimal_len(cr.value::usize) + str_len(mid) + str_len(type_str) + str_len(open);
+    if (bounds.min_negated) { total = total + str_len(neg); }
+    total = total + decimal_len(bounds.min_mag::usize) + str_len(dots)
+        + decimal_len(bounds.max_mag::usize) + str_len(close);
+
+    val res_buf: R.Result[*char, str] = A.allocate[char](sc.s.alloc, total + 1);
+    if (R.is_err[*char, str](res_buf)) {
+        report(sc, span, "integer literal out of range for its type");
+        type_str_free(sc, type_str);
+        ret;
+    }
+    val msg: str = R.unwrap_ok[*char, str](res_buf);
+    var w: usize = write_kw(msg, 0, lit);
+    if (cr.negated) { w = write_kw(msg, w, neg); }
+    w = write_decimal(msg, w, cr.value::usize);
+    w = write_kw(msg, w, mid);
+    w = write_kw(msg, w, type_str);
+    w = write_kw(msg, w, open);
+    if (bounds.min_negated) { w = write_kw(msg, w, neg); }
+    w = write_decimal(msg, w, bounds.min_mag::usize);
+    w = write_kw(msg, w, dots);
+    w = write_decimal(msg, w, bounds.max_mag::usize);
+    w = write_kw(msg, w, close);
+    msg[w] = 0;
+
+    report(sc, span, msg);
+    A.deallocate[char](sc.s.alloc, msg, total + 1);
+    type_str_free(sc, type_str);
 }
 
 # report_typed plus a static clarifying `note:` line

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -1039,7 +1039,7 @@ fun report_mismatch(sc: *context.SemaContext, span: token.Span, expected: type.T
 #
 # consumes an OUT_OF_RANGE coerce result: renders the offending literal's value
 # (its magnitude, signed by `negated`), the destination integer type via
-# type_to_str, and the type's inclusive bounds from coerce.int_bounds, all as
+# type_to_str, and the type's inclusive bounds carried on the result, all as
 # decimals. names the overflow directly and, unlike report_mismatch, carries no
 # cast note - a truncating cast is the corrupting advice this diagnostic exists to
 # avoid. any render or allocation failure degrades to a static, value-free message
@@ -1047,7 +1047,7 @@ fun report_mismatch(sc: *context.SemaContext, span: token.Span, expected: type.T
 # ---
 # sc:   the active sema context
 # span: source range to pin the diagnostic to
-# cr:   the OUT_OF_RANGE result (destination type, literal magnitude, sign)
+# cr:   the OUT_OF_RANGE result (destination type, literal magnitude, sign, bounds)
 fun report_out_of_range(sc: *context.SemaContext, span: token.Span, cr: coerce.CoerceResult) {
     val res_type: R.Result[str, str] = type_to_str(sc, cr.ty);
     if (R.is_err[str, str](res_type)) {
@@ -1055,7 +1055,7 @@ fun report_out_of_range(sc: *context.SemaContext, span: token.Span, cr: coerce.C
         ret;
     }
     val type_str: str            = R.unwrap_ok[str, str](res_type);
-    val bounds:   coerce.IntBounds = coerce.int_bounds(sc, cr.ty);
+    val bounds:   coerce.IntBounds = cr.bounds;
 
     val lit:   str = "literal ";
     val neg:   str = "-";

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -37,32 +37,123 @@ use mach.lang.fe.comptime;
 use mach.lang.fe.sema.context;
 use mach.lang.type;
 
+# discriminator of CoerceResult: the three outcomes of offering a literal a type
+pub def CoerceKind: u8;
+
+# the expression is not a coercible literal for `to` (a typed value, or a literal
+# whose form does not admit the destination); no diagnostic is implied
+pub val COERCE_NOT_APPLICABLE: CoerceKind = 0;
+# the literal legally took `to`; expr_type[eid] was rewritten to record it
+pub val COERCE_COERCED:        CoerceKind = 1;
+# `eid` is an integer-valued literal whose value does not fit the integer
+# destination `to`; the magnitude and sign travel to the reporter
+pub val COERCE_OUT_OF_RANGE:   CoerceKind = 2;
+
+# the outcome of a literal coercion attempt
+#
+# `kind` selects the payload: COERCED carries `ty` (the type the literal took);
+# OUT_OF_RANGE carries `ty` (the integer destination), `value` (the literal's
+# unsigned magnitude), and `negated` (whether it sat under an odd number of unary
+# `-`); NOT_APPLICABLE carries nothing meaningful. The out-of-range fact is
+# computed once here in coerce and consumed at the reporting site, so no caller
+# re-derives whether a literal fit.
+# ---
+# kind:    which outcome occurred
+# ty:      the coerced type (COERCED) or the integer destination (OUT_OF_RANGE)
+# value:   the literal's unsigned magnitude (OUT_OF_RANGE)
+# negated: whether the literal is negated (OUT_OF_RANGE)
+pub rec CoerceResult {
+    kind:    CoerceKind;
+    ty:      type.TypeId;
+    value:   u64;
+    negated: bool;
+}
+
+# the inclusive value range of an integer type, for out-of-range diagnostics
+#
+# `min_negated` marks a signed type's negative minimum; `min_mag` and `max_mag`
+# are the unsigned magnitudes of the bounds. A non-integer type yields a zero
+# range, but the reporter only queries integer destinations.
+# ---
+# min_negated: true when the minimum is negative (a signed type)
+# min_mag:     the magnitude of the minimum bound
+# max_mag:     the magnitude of the maximum bound
+pub rec IntBounds {
+    min_negated: bool;
+    min_mag:     u64;
+    max_mag:     u64;
+}
+
+# a NOT_APPLICABLE coercion outcome
+# ---
+# ret: a CoerceResult with kind COERCE_NOT_APPLICABLE
+fun not_applicable() CoerceResult {
+    var r: CoerceResult;
+    r.kind    = COERCE_NOT_APPLICABLE;
+    r.ty      = type.TYPE_ERROR;
+    r.value   = 0;
+    r.negated = false;
+    ret r;
+}
+
+# a COERCED outcome recording the type the literal took
+# ---
+# to:  the type the literal was fixed to
+# ret: a CoerceResult with kind COERCE_COERCED carrying `to`
+fun applicable(to: type.TypeId) CoerceResult {
+    var r: CoerceResult;
+    r.kind    = COERCE_COERCED;
+    r.ty      = to;
+    r.value   = 0;
+    r.negated = false;
+    ret r;
+}
+
+# an OUT_OF_RANGE outcome recording the offending literal and its destination
+# ---
+# to:      the integer destination the value overflowed
+# value:   the literal's unsigned magnitude
+# negated: whether the literal is negated
+# ret:     a CoerceResult with kind COERCE_OUT_OF_RANGE
+fun out_of_range(to: type.TypeId, value: u64, negated: bool) CoerceResult {
+    var r: CoerceResult;
+    r.kind    = COERCE_OUT_OF_RANGE;
+    r.ty      = to;
+    r.value   = value;
+    r.negated = negated;
+    ret r;
+}
+
 # fix an untyped literal expression to a requested destination type
 #
 # Only literal expressions whose form admits the destination are coerced; on
-# success `sc.expr_type[eid]` is rewritten to `to` and `some(to)` is returned.
-# Every other expression - including an already-typed variable reference -
-# returns none, because Mach performs no implicit widening between typed
-# values. Coercion descends through a unary `-`/`~` operand and the operands of
-# the value-preserving binary operators, so a folded literal adopts the context
-# type the same way a bare literal does; a unary `-` additionally flips the sign
-# domain used to range-check its inner integer literal.
+# success `sc.expr_type[eid]` is rewritten to `to` and a COERCED result is
+# returned. An integer literal whose value overflows an integer destination
+# yields OUT_OF_RANGE, carrying the value and sign so the caller can report the
+# overflow directly. Every other expression - including an already-typed variable
+# reference - yields NOT_APPLICABLE, because Mach performs no implicit widening
+# between typed values. Coercion descends through a unary `-`/`~` operand and the
+# operands of the value-preserving binary operators, so a folded literal adopts
+# the context type the same way a bare literal does; a unary `-` additionally
+# flips the sign domain used to range-check its inner integer literal.
 # ---
 # sc:  the active sema context
 # eid: the expression to coerce; indexes sc.a.exprs
 # to:  the destination TypeId the surrounding context requires
-# ret: some(to) when the literal legally takes `to` (and expr_type[eid] is
-#      updated), none when no literal coercion applies
-pub fun try_coerce_literal(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId) O.Option[type.TypeId] {
-    if (to == type.TYPE_NIL || to == type.TYPE_ERROR) { ret O.none[type.TypeId](); }
+# ret: COERCED when the literal legally takes `to` (and expr_type[eid] is
+#      updated), OUT_OF_RANGE when an integer literal overflows an integer `to`,
+#      NOT_APPLICABLE when no literal coercion applies
+pub fun try_coerce_literal(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId) CoerceResult {
+    if (to == type.TYPE_NIL || to == type.TYPE_ERROR) { ret not_applicable(); }
 
     # a literal flowing into a secret slot fixes against the public base (a
     # literal is public), then takes the secret type via the implicit up-coerce
     # (public is the bottom of the lattice). so `var s: ^u32 = 5;` types `5` as
-    # `^u32` (#1645).
+    # `^u32` (#1645). an out-of-range or non-applicable result flows through
+    # unchanged, carrying the public base as its destination.
     val pub_to: type.TypeId = type.strip_secret(?sc.s.types, to);
-    val r: O.Option[type.TypeId] = coerce_to(sc, eid, pub_to, false);
-    if (O.is_some[type.TypeId](r) && pub_to != to) { ret commit(sc, eid, to); }
+    val r: CoerceResult = coerce_to(sc, eid, pub_to, false);
+    if (r.kind == COERCE_COERCED && pub_to != to) { ret commit(sc, eid, to); }
     ret r;
 }
 
@@ -76,24 +167,23 @@ pub fun try_coerce_literal(sc: *context.SemaContext, eid: id.ExprId, to: type.Ty
 # eid:     the expression to coerce
 # to:      the destination TypeId
 # negated: true when the literal sits under an odd number of unary `-`
-# ret:     some(to) when the possibly nested literal takes `to`, else none
-fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool) O.Option[type.TypeId] {
-    if (eid == id.EXPR_NIL) { ret O.none[type.TypeId](); }
+# ret:     COERCED when the possibly nested literal takes `to`, OUT_OF_RANGE when
+#          an integer literal overflows an integer `to`, else NOT_APPLICABLE
+fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool) CoerceResult {
+    if (eid == id.EXPR_NIL) { ret not_applicable(); }
 
     val opt_e: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](opt_e)) { ret O.none[type.TypeId](); }
+    if (O.is_none[*expr.Expr](opt_e)) { ret not_applicable(); }
     val e: *expr.Expr = O.unwrap[*expr.Expr](opt_e);
 
     if (e.kind == expr.EXPR_KIND_LIT_INT) {
-        if (!int_literal_fits(sc, e.data.lit_int, to, negated)) { ret O.none[type.TypeId](); }
-        ret commit(sc, eid, to);
+        ret coerce_int_literal(sc, eid, e.data.lit_int, to, negated);
     }
     if (e.kind == expr.EXPR_KIND_LIT_CHAR) {
-        if (!int_literal_fits(sc, e.data.lit_char::u64, to, negated)) { ret O.none[type.TypeId](); }
-        ret commit(sc, eid, to);
+        ret coerce_int_literal(sc, eid, e.data.lit_char::u64, to, negated);
     }
     if (e.kind == expr.EXPR_KIND_LIT_FLOAT) {
-        if (to != type.TYPE_F32 && to != type.TYPE_F64) { ret O.none[type.TypeId](); }
+        if (to != type.TYPE_F32 && to != type.TYPE_F64) { ret not_applicable(); }
         ret commit(sc, eid, to);
     }
     if (e.kind == expr.EXPR_KIND_LIT_NIL) {
@@ -101,7 +191,7 @@ fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated
         # a typed `*T`, or a `fun(...)` (a function value is a code address, so
         # the null address is a valid null callback). `fn == nil` / `fn != nil`
         # stay related as comparisons in infer_binary, independent of this.
-        if (!type.is_pointer_like(?sc.s.types, to)) { ret O.none[type.TypeId](); }
+        if (!type.is_pointer_like(?sc.s.types, to)) { ret not_applicable(); }
         ret commit(sc, eid, to);
     }
     if (e.kind == expr.EXPR_KIND_COMPTIME_IDENT || e.kind == expr.EXPR_KIND_MEMBER) {
@@ -114,7 +204,28 @@ fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated
         ret coerce_binary(sc, eid, ?e.data.binary, to);
     }
 
-    ret O.none[type.TypeId]();
+    ret not_applicable();
+}
+
+# fix an integer-valued literal of magnitude `v` to the destination `to`
+#
+# A non-integer destination declines with NOT_APPLICABLE (an integer literal is
+# not a coercion target for a float, pointer, or nominal type - the caller reports
+# the plain mismatch). An integer destination that cannot hold `v` yields
+# OUT_OF_RANGE carrying the magnitude and sign, distinct from a non-literal; a
+# holding destination commits and returns COERCED. Shared by the integer- and
+# character-literal leaves and the comptime integer path.
+# ---
+# sc:      the active sema context
+# eid:     the literal expression to retype on success
+# v:       the literal's unsigned magnitude
+# to:      the destination TypeId
+# negated: true when the literal sits under an odd number of unary `-`
+# ret:     COERCED, OUT_OF_RANGE, or NOT_APPLICABLE per the destination
+fun coerce_int_literal(sc: *context.SemaContext, eid: id.ExprId, v: u64, to: type.TypeId, negated: bool) CoerceResult {
+    if (!type.is_integer(?sc.s.types, to))      { ret not_applicable(); }
+    if (!int_literal_fits(sc, v, to, negated))  { ret out_of_range(to, v, negated); }
+    ret commit(sc, eid, to);
 }
 
 # coerce a comptime path that folds to an integer to a destination integer type
@@ -122,22 +233,25 @@ fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated
 # A rooted comptime path (`$mach.build.os`, ...) is evaluated and, when it folds
 # to an integer, range-checked against the destination width and signedness
 # exactly like an integer literal; on a fit the path's expr_type slot is
-# committed to `to`. A path that is not a comptime path or does not fold to an
-# integer yields none, leaving it an ordinary non-coercible expression.
+# committed to `to`, and an overflow of an integer destination yields OUT_OF_RANGE
+# carrying the folded value. A path that is not a comptime path or does not fold
+# to an integer yields NOT_APPLICABLE, leaving it an ordinary non-coercible
+# expression.
 # ---
 # sc:      the active sema context
 # eid:     the path expression to coerce
 # to:      the destination TypeId
 # negated: true when the path sits under an odd number of unary `-`
-# ret:     some(to) when the folded integer fits `to`, else none
-fun coerce_comptime_int_path(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool) O.Option[type.TypeId] {
-    if (!comptime.is_comptime_path(sc.a, eid)) { ret O.none[type.TypeId](); }
+# ret:     COERCED when the folded integer fits `to`, OUT_OF_RANGE when it
+#          overflows an integer `to`, else NOT_APPLICABLE
+fun coerce_comptime_int_path(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool) CoerceResult {
+    if (!comptime.is_comptime_path(sc.a, eid)) { ret not_applicable(); }
 
     val res_eval: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
-    if (R.is_err[comptime.CTValue, str](res_eval)) { ret O.none[type.TypeId](); }
+    if (R.is_err[comptime.CTValue, str](res_eval)) { ret not_applicable(); }
     val ctval: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](res_eval);
 
-    if (ctval.kind != comptime.CT_KIND_INT) { ret O.none[type.TypeId](); }
+    if (ctval.kind != comptime.CT_KIND_INT) { ret not_applicable(); }
 
     # the path already folded to a definite value, so derive its magnitude and
     # sign rather than reading the raw i64 as a u64. a negative signed fold has a
@@ -154,8 +268,7 @@ fun coerce_comptime_int_path(sc: *context.SemaContext, eid: id.ExprId, to: type.
     var negated_total: bool = negated;
     if (value_negated) { negated_total = !negated; }
 
-    if (!int_literal_fits(sc, mag, to, negated_total)) { ret O.none[type.TypeId](); }
-    ret commit(sc, eid, to);
+    ret coerce_int_literal(sc, eid, mag, to, negated_total);
 }
 
 # coerce a unary `-`/`~` node by coercing its operand to `to`
@@ -170,15 +283,16 @@ fun coerce_comptime_int_path(sc: *context.SemaContext, eid: id.ExprId, to: type.
 # u:       the unary node payload
 # to:      the destination TypeId
 # negated: true when this node sits under an odd number of unary `-`
-# ret:     some(to) when the operand coerces, else none
-fun coerce_unary(sc: *context.SemaContext, eid: id.ExprId, u: *expr.ExprUnary, to: type.TypeId, negated: bool) O.Option[type.TypeId] {
-    if (u.op != expr.UN_NEG && u.op != expr.UN_BIT_NOT) { ret O.none[type.TypeId](); }
+# ret:     COERCED when the operand coerces, else the operand's own outcome
+#          (OUT_OF_RANGE carries the offending literal up unchanged)
+fun coerce_unary(sc: *context.SemaContext, eid: id.ExprId, u: *expr.ExprUnary, to: type.TypeId, negated: bool) CoerceResult {
+    if (u.op != expr.UN_NEG && u.op != expr.UN_BIT_NOT) { ret not_applicable(); }
 
     var operand_negated: bool = negated;
     if (u.op == expr.UN_NEG) { operand_negated = !negated; }
 
-    val opt_operand: O.Option[type.TypeId] = coerce_to(sc, u.operand, to, operand_negated);
-    if (O.is_none[type.TypeId](opt_operand)) { ret O.none[type.TypeId](); }
+    val r: CoerceResult = coerce_to(sc, u.operand, to, operand_negated);
+    if (r.kind != COERCE_COERCED) { ret r; }
     ret commit(sc, eid, to);
 }
 
@@ -194,14 +308,15 @@ fun coerce_unary(sc: *context.SemaContext, eid: id.ExprId, u: *expr.ExprUnary, t
 # eid: the binary expression to retype on success
 # b:   the binary node payload
 # to:  the destination TypeId
-# ret: some(to) when both operands coerce, else none
-fun coerce_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, to: type.TypeId) O.Option[type.TypeId] {
-    if (!is_value_preserving_binop(b.op)) { ret O.none[type.TypeId](); }
+# ret: COERCED when both operands coerce; otherwise the first non-coercing
+#      operand's outcome (an OUT_OF_RANGE operand carries its literal up unchanged)
+fun coerce_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, to: type.TypeId) CoerceResult {
+    if (!is_value_preserving_binop(b.op)) { ret not_applicable(); }
 
-    val opt_lhs: O.Option[type.TypeId] = coerce_to(sc, b.lhs, to, false);
-    if (O.is_none[type.TypeId](opt_lhs)) { ret O.none[type.TypeId](); }
-    val opt_rhs: O.Option[type.TypeId] = coerce_to(sc, b.rhs, to, false);
-    if (O.is_none[type.TypeId](opt_rhs)) { ret O.none[type.TypeId](); }
+    val lhs: CoerceResult = coerce_to(sc, b.lhs, to, false);
+    if (lhs.kind != COERCE_COERCED) { ret lhs; }
+    val rhs: CoerceResult = coerce_to(sc, b.rhs, to, false);
+    if (rhs.kind != COERCE_COERCED) { ret rhs; }
     ret commit(sc, eid, to);
 }
 
@@ -258,7 +373,40 @@ fun int_literal_fits(sc: *context.SemaContext, v: u64, to: type.TypeId, negated:
     ret v <= (1::u64 << (d.bits - 1)::usize) - 1;
 }
 
-# rewrite expr_type[eid] to the coerced type and return some(to)
+# the inclusive value range of the integer type `to`, for diagnostics
+#
+# The bounds arithmetic is the same width/signedness reasoning `int_literal_fits`
+# range-checks against, expressed as renderable magnitudes: a signed N-bit type
+# spans -2^(N-1)..2^(N-1)-1, an unsigned one 0..2^N-1 (with the 64-bit unsigned
+# maximum formed as `0 - 1` to avoid overflowing the shift). A non-integer type
+# yields a zero range; callers only pass the integer destinations coerce reports.
+# ---
+# sc:  the active sema context
+# to:  the integer destination whose bounds are wanted
+# ret: the type's inclusive value range as signed-aware magnitudes
+pub fun int_bounds(sc: *context.SemaContext, to: type.TypeId) IntBounds {
+    var b: IntBounds;
+    b.min_negated = false;
+    b.min_mag     = 0;
+    b.max_mag     = 0;
+
+    val opt_type: O.Option[*type.Type] = type.get(?sc.s.types, to);
+    if (O.is_none[*type.Type](opt_type)) { ret b; }
+    val d: type.PrimDesc = type.prim_desc(O.unwrap[*type.Type](opt_type).kind);
+    if (d.class != type.PRIM_CLASS_INT) { ret b; }
+
+    if (d.signed) {
+        b.min_negated = true;
+        b.min_mag     = 1::u64 << (d.bits - 1)::usize;
+        b.max_mag     = (1::u64 << (d.bits - 1)::usize) - 1;
+        ret b;
+    }
+    if (d.bits >= 64) { b.max_mag = 0::u64 - 1; }
+    or                { b.max_mag = (1::u64 << d.bits::usize) - 1; }
+    ret b;
+}
+
+# rewrite expr_type[eid] to the coerced type and return a COERCED result
 #
 # The write is skipped when the side table is absent or `eid` is out of its
 # range; the coercion still succeeds, since the literal legally takes `to`
@@ -267,12 +415,12 @@ fun int_literal_fits(sc: *context.SemaContext, v: u64, to: type.TypeId, negated:
 # sc:  the active sema context
 # eid: the expression whose type slot to update
 # to:  the coerced TypeId
-# ret: some(to)
-fun commit(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId) O.Option[type.TypeId] {
+# ret: a COERCED CoerceResult carrying `to`
+fun commit(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId) CoerceResult {
     if (sc.expr_type != nil && eid::usize < sc.a.expr_len) {
         sc.expr_type[eid] = to;
     }
-    ret O.some[type.TypeId](to);
+    ret applicable(to);
 }
 
 # whether a value of type `from` may be assigned to a slot of type `to`

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -37,6 +37,22 @@ use mach.lang.fe.comptime;
 use mach.lang.fe.sema.context;
 use mach.lang.type;
 
+# the inclusive value range of an integer type, for out-of-range diagnostics
+#
+# `min_negated` marks a signed type's negative minimum; `min_mag` and `max_mag`
+# are the unsigned magnitudes of the bounds. Derived once per destination in
+# `int_bounds_of` and carried on an OUT_OF_RANGE result, so the reporter renders
+# the range without recomputing it.
+# ---
+# min_negated: true when the minimum is negative (a signed type)
+# min_mag:     the magnitude of the minimum bound
+# max_mag:     the magnitude of the maximum bound
+pub rec IntBounds {
+    min_negated: bool;
+    min_mag:     u64;
+    max_mag:     u64;
+}
+
 # discriminator of CoerceResult: the three outcomes of offering a literal a type
 pub def CoerceKind: u8;
 
@@ -46,42 +62,42 @@ pub val COERCE_NOT_APPLICABLE: CoerceKind = 0;
 # the literal legally took `to`; expr_type[eid] was rewritten to record it
 pub val COERCE_COERCED:        CoerceKind = 1;
 # `eid` is an integer-valued literal whose value does not fit the integer
-# destination `to`; the magnitude and sign travel to the reporter
+# destination `to`; the magnitude, sign, and bounds travel to the reporter
 pub val COERCE_OUT_OF_RANGE:   CoerceKind = 2;
 
 # the outcome of a literal coercion attempt
 #
 # `kind` selects the payload: COERCED carries `ty` (the type the literal took);
 # OUT_OF_RANGE carries `ty` (the integer destination), `value` (the literal's
-# unsigned magnitude), and `negated` (whether it sat under an odd number of unary
-# `-`); NOT_APPLICABLE carries nothing meaningful. The out-of-range fact is
-# computed once here in coerce and consumed at the reporting site, so no caller
-# re-derives whether a literal fit.
+# unsigned magnitude), `negated` (whether it sat under an odd number of unary
+# `-`), and `bounds` (the destination's inclusive range); NOT_APPLICABLE carries
+# nothing meaningful. The whole out-of-range fact - value, sign, and bounds - is
+# computed once here in coerce from one PrimDesc read and consumed at the
+# reporting site, so no caller re-derives whether a literal fit or what the
+# destination's range is.
 # ---
 # kind:    which outcome occurred
 # ty:      the coerced type (COERCED) or the integer destination (OUT_OF_RANGE)
 # value:   the literal's unsigned magnitude (OUT_OF_RANGE)
 # negated: whether the literal is negated (OUT_OF_RANGE)
+# bounds:  the destination's inclusive value range (OUT_OF_RANGE)
 pub rec CoerceResult {
     kind:    CoerceKind;
     ty:      type.TypeId;
     value:   u64;
     negated: bool;
+    bounds:  IntBounds;
 }
 
-# the inclusive value range of an integer type, for out-of-range diagnostics
-#
-# `min_negated` marks a signed type's negative minimum; `min_mag` and `max_mag`
-# are the unsigned magnitudes of the bounds. A non-integer type yields a zero
-# range, but the reporter only queries integer destinations.
+# a zeroed IntBounds, for results that carry no range
 # ---
-# min_negated: true when the minimum is negative (a signed type)
-# min_mag:     the magnitude of the minimum bound
-# max_mag:     the magnitude of the maximum bound
-pub rec IntBounds {
-    min_negated: bool;
-    min_mag:     u64;
-    max_mag:     u64;
+# ret: an IntBounds with all fields cleared
+fun zero_bounds() IntBounds {
+    var b: IntBounds;
+    b.min_negated = false;
+    b.min_mag     = 0;
+    b.max_mag     = 0;
+    ret b;
 }
 
 # a NOT_APPLICABLE coercion outcome
@@ -93,6 +109,7 @@ fun not_applicable() CoerceResult {
     r.ty      = type.TYPE_ERROR;
     r.value   = 0;
     r.negated = false;
+    r.bounds  = zero_bounds();
     ret r;
 }
 
@@ -106,21 +123,24 @@ fun applicable(to: type.TypeId) CoerceResult {
     r.ty      = to;
     r.value   = 0;
     r.negated = false;
+    r.bounds  = zero_bounds();
     ret r;
 }
 
-# an OUT_OF_RANGE outcome recording the offending literal and its destination
+# an OUT_OF_RANGE outcome recording the offending literal, destination, and range
 # ---
 # to:      the integer destination the value overflowed
 # value:   the literal's unsigned magnitude
 # negated: whether the literal is negated
+# bounds:  the destination's inclusive value range
 # ret:     a CoerceResult with kind COERCE_OUT_OF_RANGE
-fun out_of_range(to: type.TypeId, value: u64, negated: bool) CoerceResult {
+fun out_of_range(to: type.TypeId, value: u64, negated: bool, bounds: IntBounds) CoerceResult {
     var r: CoerceResult;
     r.kind    = COERCE_OUT_OF_RANGE;
     r.ty      = to;
     r.value   = value;
     r.negated = negated;
+    r.bounds  = bounds;
     ret r;
 }
 
@@ -149,11 +169,20 @@ pub fun try_coerce_literal(sc: *context.SemaContext, eid: id.ExprId, to: type.Ty
     # a literal flowing into a secret slot fixes against the public base (a
     # literal is public), then takes the secret type via the implicit up-coerce
     # (public is the bottom of the lattice). so `var s: ^u32 = 5;` types `5` as
-    # `^u32` (#1645). an out-of-range or non-applicable result flows through
-    # unchanged, carrying the public base as its destination.
+    # `^u32` (#1645).
     val pub_to: type.TypeId = type.strip_secret(?sc.s.types, to);
     val r: CoerceResult = coerce_to(sc, eid, pub_to, false);
-    if (r.kind == COERCE_COERCED && pub_to != to) { ret commit(sc, eid, to); }
+    if (pub_to != to) {
+        # a secret destination: a coerced literal takes the secret type, and an
+        # out-of-range result names the secret type the user actually wrote while
+        # keeping the integer base's bounds. a non-applicable result is unchanged.
+        if (r.kind == COERCE_COERCED)      { ret commit(sc, eid, to); }
+        if (r.kind == COERCE_OUT_OF_RANGE) {
+            var rr: CoerceResult = r;
+            rr.ty = to;
+            ret rr;
+        }
+    }
     ret r;
 }
 
@@ -209,12 +238,14 @@ fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated
 
 # fix an integer-valued literal of magnitude `v` to the destination `to`
 #
-# A non-integer destination declines with NOT_APPLICABLE (an integer literal is
-# not a coercion target for a float, pointer, or nominal type - the caller reports
-# the plain mismatch). An integer destination that cannot hold `v` yields
-# OUT_OF_RANGE carrying the magnitude and sign, distinct from a non-literal; a
-# holding destination commits and returns COERCED. Shared by the integer- and
-# character-literal leaves and the comptime integer path.
+# The destination's integer bounds are read once (`int_bounds_of`): a non-integer
+# destination declines with NOT_APPLICABLE (an integer literal is not a coercion
+# target for a float, pointer, or nominal type - the caller reports the plain
+# mismatch); an integer destination whose range cannot hold `v` yields
+# OUT_OF_RANGE carrying the magnitude, sign, and those bounds; a holding
+# destination commits and returns COERCED. Both the accept/reject decision and the
+# reported range come from the single bounds computation. Shared by the integer-
+# and character-literal leaves and the comptime integer path.
 # ---
 # sc:      the active sema context
 # eid:     the literal expression to retype on success
@@ -223,8 +254,10 @@ fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated
 # negated: true when the literal sits under an odd number of unary `-`
 # ret:     COERCED, OUT_OF_RANGE, or NOT_APPLICABLE per the destination
 fun coerce_int_literal(sc: *context.SemaContext, eid: id.ExprId, v: u64, to: type.TypeId, negated: bool) CoerceResult {
-    if (!type.is_integer(?sc.s.types, to))      { ret not_applicable(); }
-    if (!int_literal_fits(sc, v, to, negated))  { ret out_of_range(to, v, negated); }
+    val opt_bounds: O.Option[IntBounds] = int_bounds_of(sc, to);
+    if (O.is_none[IntBounds](opt_bounds)) { ret not_applicable(); }
+    val bounds: IntBounds = O.unwrap[IntBounds](opt_bounds);
+    if (!fits_bounds(v, negated, bounds)) { ret out_of_range(to, v, negated, bounds); }
     ret commit(sc, eid, to);
 }
 
@@ -336,74 +369,54 @@ fun is_value_preserving_binop(op: expr.BinOp) bool {
     ret false;
 }
 
-# whether `to` is an integer primitive that can hold the literal magnitude `v`
+# the integer bounds of `to`, or none when `to` is not an integer primitive
 #
-# `v` is the literal's unsigned magnitude. When `negated` is set the literal
-# appears under an odd number of unary `-`, so a signed destination is checked
-# against its negative bound (|min| = max + 1) and an unsigned destination never
-# fits. Otherwise unsigned destinations are checked against their unsigned
-# maximum and signed destinations against their signed maximum. A non-integer
-# destination never fits.
-# ---
-# sc:      the active sema context
-# v:       the literal's unsigned magnitude
-# to:      the destination TypeId
-# negated: true when the literal sits under an odd number of unary `-`
-# ret:     true when `v` fits the integer destination `to`
-fun int_literal_fits(sc: *context.SemaContext, v: u64, to: type.TypeId, negated: bool) bool {
-    val opt_type: O.Option[*type.Type] = type.get(?sc.s.types, to);
-    if (O.is_none[*type.Type](opt_type)) { ret false; }
-    val d: type.PrimDesc = type.prim_desc(O.unwrap[*type.Type](opt_type).kind);
-    if (d.class != type.PRIM_CLASS_INT) { ret false; }
-
-    if (negated) {
-        # a negated literal needs a signed destination; its magnitude may reach
-        # |min| = 2^(bits-1).
-        if (!d.signed) { ret false; }
-        ret v <= (1::u64 << (d.bits - 1)::usize);
-    }
-
-    if (!d.signed) {
-        # an unsigned destination holds up to 2^bits - 1; a 64-bit one holds any
-        # u64, so it always fits (2^64 would overflow the shift).
-        if (d.bits >= 64) { ret true; }
-        ret v <= (1::u64 << d.bits::usize) - 1;
-    }
-    # a signed destination holds up to 2^(bits-1) - 1.
-    ret v <= (1::u64 << (d.bits - 1)::usize) - 1;
-}
-
-# the inclusive value range of the integer type `to`, for diagnostics
-#
-# The bounds arithmetic is the same width/signedness reasoning `int_literal_fits`
-# range-checks against, expressed as renderable magnitudes: a signed N-bit type
-# spans -2^(N-1)..2^(N-1)-1, an unsigned one 0..2^N-1 (with the 64-bit unsigned
-# maximum formed as `0 - 1` to avoid overflowing the shift). A non-integer type
-# yields a zero range; callers only pass the integer destinations coerce reports.
+# The one home for the width/signedness range arithmetic, expressed as renderable
+# magnitudes: a signed N-bit type spans -2^(N-1)..2^(N-1)-1, an unsigned one
+# 0..2^N-1 (with the 64-bit unsigned maximum formed as `0 - 1` to avoid
+# overflowing the shift). The single PrimDesc read that both the fit check
+# (`fits_bounds`) and the diagnostic range derive from.
 # ---
 # sc:  the active sema context
-# to:  the integer destination whose bounds are wanted
-# ret: the type's inclusive value range as signed-aware magnitudes
-pub fun int_bounds(sc: *context.SemaContext, to: type.TypeId) IntBounds {
-    var b: IntBounds;
-    b.min_negated = false;
-    b.min_mag     = 0;
-    b.max_mag     = 0;
-
+# to:  the destination TypeId to range
+# ret: some(bounds) for an integer primitive, none otherwise
+fun int_bounds_of(sc: *context.SemaContext, to: type.TypeId) O.Option[IntBounds] {
     val opt_type: O.Option[*type.Type] = type.get(?sc.s.types, to);
-    if (O.is_none[*type.Type](opt_type)) { ret b; }
+    if (O.is_none[*type.Type](opt_type)) { ret O.none[IntBounds](); }
     val d: type.PrimDesc = type.prim_desc(O.unwrap[*type.Type](opt_type).kind);
-    if (d.class != type.PRIM_CLASS_INT) { ret b; }
+    if (d.class != type.PRIM_CLASS_INT) { ret O.none[IntBounds](); }
 
+    var b: IntBounds;
     if (d.signed) {
         b.min_negated = true;
         b.min_mag     = 1::u64 << (d.bits - 1)::usize;
         b.max_mag     = (1::u64 << (d.bits - 1)::usize) - 1;
-        ret b;
+        ret O.some[IntBounds](b);
     }
+    b.min_negated = false;
+    b.min_mag     = 0;
     if (d.bits >= 64) { b.max_mag = 0::u64 - 1; }
     or                { b.max_mag = (1::u64 << d.bits::usize) - 1; }
-    ret b;
+    ret O.some[IntBounds](b);
+}
+
+# whether the literal magnitude `v` fits `bounds` in the given sign domain
+#
+# A negated literal needs a signed destination (a negative value never takes an
+# unsigned type) and its magnitude may reach |min|; a non-negated one is checked
+# against the maximum. The same reasoning `int_bounds_of` encodes, read back off
+# the bounds it produced rather than recomputed from the type.
+# ---
+# v:       the literal's unsigned magnitude
+# negated: true when the literal sits under an odd number of unary `-`
+# bounds:  the destination's integer bounds
+# ret:     true when `v` fits `bounds`
+fun fits_bounds(v: u64, negated: bool, bounds: IntBounds) bool {
+    if (negated) {
+        if (!bounds.min_negated) { ret false; }
+        ret v <= bounds.min_mag;
+    }
+    ret v <= bounds.max_mag;
 }
 
 # rewrite expr_type[eid] to the coerced type and return a COERCED result

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1599,7 +1599,7 @@ fun infer_strip(sc: *context.SemaContext, st: *expr.ExprStrip, span: token.Span)
 
 # ARRAY_LIT: result is [count]elem of the declared array type
 #
-# Every element is checked against the element type via check.check_assignable,
+# Every element is checked against the element type via check.check_coercible,
 # and the element count must match the declared length exactly (`[N]T` holds
 # exactly N values -- see doc/language/types.md).
 # ---

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -804,13 +804,10 @@ fun field_type_operand_type(sc: *context.SemaContext, eid: id.ExprId) type.TypeI
 # ret:  the LHS TypeId, or TYPE_ERROR
 fun infer_assign(sc: *context.SemaContext, b: *expr.ExprBinary, span: token.Span) type.TypeId {
     val lt: type.TypeId = infer_expr(sc, b.lhs);
-    var rt: type.TypeId = infer_expr(sc, b.rhs);
+    val rt: type.TypeId = infer_expr(sc, b.rhs);
     if (lt == type.TYPE_ERROR || rt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
-    val co: O.Option[type.TypeId] = coerce.try_coerce_literal(sc, b.rhs, lt);
-    if (O.is_some[type.TypeId](co)) { rt = O.unwrap[type.TypeId](co); }
-
-    check.check_assignable(sc, lt, rt, span);
+    check.check_coercible(sc, lt, b.rhs, rt, span);
     ret lt;
 }
 
@@ -1628,11 +1625,9 @@ fun infer_array_lit(sc: *context.SemaContext, al: *expr.ExprArrayLit, span: toke
     var i: u32 = 0;
     for (i < al.elems_len) {
         val ee: id.ExprId = sc.a.expr_ids[al.elems_start + i];
-        var et: type.TypeId = infer_expr(sc, ee);
+        val et: type.TypeId = infer_expr(sc, ee);
         if (elem_ty != type.TYPE_ERROR && et != type.TYPE_ERROR) {
-            val co: O.Option[type.TypeId] = coerce.try_coerce_literal(sc, ee, elem_ty);
-            if (O.is_some[type.TypeId](co)) { et = O.unwrap[type.TypeId](co); }
-            check.check_assignable(sc, elem_ty, et, span);
+            check.check_coercible(sc, elem_ty, ee, et, span);
         }
         i = i + 1;
     }
@@ -1666,7 +1661,7 @@ fun infer_struct_lit(sc: *context.SemaContext, sl: *expr.ExprStructLit, span: to
     var i: u32 = 0;
     for (i < sl.fields_len) {
         val fi: *expr.FieldInit = ?sc.a.field_inits[sl.fields_start + i];
-        var vt: type.TypeId = infer_expr(sc, fi.value);
+        val vt: type.TypeId = infer_expr(sc, fi.value);
         if (rec_ty != type.TYPE_ERROR && vt != type.TYPE_ERROR && have_table) {
             val fname: intern.StrId = intern_span_or_nil(sc, fi.name);
             val ft_opt: O.Option[type.TypeId] = context.field_lookup(sc, rec_ty, fname);
@@ -1675,9 +1670,7 @@ fun infer_struct_lit(sc: *context.SemaContext, sl: *expr.ExprStructLit, span: to
             }
             or {
                 val ft: type.TypeId = O.unwrap[type.TypeId](ft_opt);
-                val co: O.Option[type.TypeId] = coerce.try_coerce_literal(sc, fi.value, ft);
-                if (O.is_some[type.TypeId](co)) { vt = O.unwrap[type.TypeId](co); }
-                check.check_assignable(sc, ft, vt, span);
+                check.check_coercible(sc, ft, fi.value, vt, span);
             }
         }
         i = i + 1;
@@ -2155,11 +2148,15 @@ fun symbol_ast(sc: *context.SemaContext, sym: *resolve.Symbol) *ast.Ast {
 # ret: some(unified type), or none
 fun unify_literals(sc: *context.SemaContext, lhs: id.ExprId, lt: type.TypeId, rhs: id.ExprId, rt: type.TypeId) O.Option[type.TypeId] {
     if (lt == rt) { ret O.none[type.TypeId](); }
-    # try coercing the RHS literal toward the LHS type, then vice-versa
-    val cr: O.Option[type.TypeId] = coerce.try_coerce_literal(sc, rhs, lt);
-    if (O.is_some[type.TypeId](cr)) { ret O.some[type.TypeId](lt); }
-    val cl: O.Option[type.TypeId] = coerce.try_coerce_literal(sc, lhs, rt);
-    if (O.is_some[type.TypeId](cl)) { ret O.some[type.TypeId](rt); }
+    # a try-fallback site: only a genuine coercion unifies the operands. an
+    # out-of-range literal declines here exactly like a non-literal (the hard-
+    # failure sites report the overflow when it matters), preserving the
+    # non-reporting try semantics. try the RHS literal toward the LHS type, then
+    # vice-versa.
+    val cr: coerce.CoerceResult = coerce.try_coerce_literal(sc, rhs, lt);
+    if (cr.kind == coerce.COERCE_COERCED) { ret O.some[type.TypeId](lt); }
+    val cl: coerce.CoerceResult = coerce.try_coerce_literal(sc, lhs, rt);
+    if (cl.kind == coerce.COERCE_COERCED) { ret O.some[type.TypeId](rt); }
     ret O.none[type.TypeId]();
 }
 


### PR DESCRIPTION
Closes #1804

## Problem

An integer literal that does not fit its destination reported a generic
`type mismatch: expected u8, found i64`, and the note advised casting with
`value::Type`. For the out-of-range case that advice is corrupting: `300::u8`
silently truncates to 44 — the compiler detected the overflow, then recommended
data corruption as the fix.

## Fix

The preferred design from the issue: make the coercion result carry the fact it
already computes.

- `coerce.try_coerce_literal` (and its recursive core) return a tri-state
  `CoerceResult` — `COERCED` / `NOT_APPLICABLE` / `OUT_OF_RANGE` — instead of an
  `Option`. `OUT_OF_RANGE` carries the literal's unsigned magnitude, its sign,
  and the integer destination. The fact is computed once in coerce and consumed
  at the report site; nothing re-derives whether a literal fit.
- `check.check_coercible` is the single consumer at every hard-failure
  assignment site (bindings, assignments, returns, call arguments, array and
  struct elements). It emits `literal <v> is out of range for <T> (<min>..<max>)`
  with **no** cast note.
- The one try-fallback site (binary-operand unification in `infer.unify_literals`)
  treats `OUT_OF_RANGE` identically to `NOT_APPLICABLE`, preserving its
  non-reporting try semantics.
- A non-integer destination still declines with `NOT_APPLICABLE`, so an
  int-literal-into-float slot keeps its plain mismatch (no bogus range message).

## Diagnostics

```
val x: u8 = 300;   → literal 300 is out of range for u8 (0..255)
val y: i8 = 200;   → literal 200 is out of range for i8 (-128..127)
val z: i8 = -129;  → literal -129 is out of range for i8 (-128..127)
val w: u8 = -1;    → literal -1 is out of range for u8 (0..255)
val v: u64 = -1;   → literal -1 is out of range for u64 (0..18446744073709551615)
```

Widening a genuine typed value is unchanged:

```
var a: i64 = 5; val b: u8 = a;
  → type mismatch: expected u8, found i64
    note: mach has no implicit widening; cast the value with `value::Type`
```

## Tests

Four `mach.lang.editor.sema` diagnostics tests pin the new wording (unsigned,
signed, and negated/negative-into-unsigned domains) and guard that the widening
mismatch message + cast note still appear for the genuine widening case. Full
suite: 442 passed, 0 failed. Self-host fixpoint (stage2 == stage3) is
byte-identical.

## Acceptance change (language behavior)

This tightens one previously-accepted case. The 2.12.0 compiler **silently accepted** an all-ones literal in a signed slot and wrapped it at runtime — `val mask: i64 = 0xFFFFFFFFFFFFFFFF;` compiled and printed `-1`. This PR **rejects** it:

```
literal 18446744073709551615 is out of range for i64 (-9223372036854775808..9223372036854775807)
```

That strictness is the point of #1804: silent wraparound into a narrower/signed slot is exactly the corruption class this diagnostic exists to stop, and no in-tree code (src/, mach-std, int/) uses the idiom. **u64 slots are unaffected** — `val m: u64 = 0xFFFFFFFFFFFFFFFF;` stays accepted, since it is that type's legitimate maximum. Pinned by `literal_out_of_range_u64_max_into_signed` (i64 rejection + u64 acceptance via a single out-of-range count).

## Review follow-ups (addressed)

- Range arithmetic unified to one home: `int_bounds_of` reads the PrimDesc once, `fits_bounds` decides accept/reject from those bounds, and the OUT_OF_RANGE result carries them so the reporter never recomputes. Removed `int_literal_fits`, the public `int_bounds`, and the duplicated `is_integer` lookup.
- Secret-slot fidelity: `var s: ^u8 = 300;` now reports `... for ^u8 (0..255)` (names the type the author wrote; bounds stay the integer base's).
- Fixed a stale `check.check_assignable` doc comment in `infer_array_lit`.