### PR TITLE
fix(link): activate PIE RELRO runtime + write-fault int guard (#1778)

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -6,6 +6,8 @@
 #
 # producers:
 #   exec        — run the program, observe its stdout (native / qemu).
+#   relro-fault — run the program and report whether its write to a RELRO'd .rodata
+#                 slot faulted (SIGSEGV -> exit 139); the --pie RELRO runtime guard.
 #   field       — coreutils (od/dd) reads of known header offsets, for format facts
 #                 execution cannot observe (PE ASLR bit, macho PIE bit). dispatched
 #                 on the artifact's own magic, so it is independent of how the case
@@ -33,6 +35,30 @@ produce_exec() {
         "qemu-${target##*-}" "$bin"
     else
         "$bin"
+    fi
+}
+
+# produce_relro_fault <runmode> <target> <binary>
+# runs the built binary (expected to write to a relocated constant's RELRO'd .rodata
+# storage) and reports whether that write faulted. after the --pie startup mprotects
+# the region read-only, the write must raise SIGSEGV, which surfaces as exit 128+11=139
+# both natively and under qemu-user; any other status means the region stayed writable.
+# the program's own stdout is discarded - the observable is purely the fault fact - so
+# this is a runtime (exec-like) producer sharing one target-independent golden.
+produce_relro_fault() {
+    runmode=$1
+    target=$2
+    bin=$3
+    if [ "$runmode" = "qemu" ]; then
+        "qemu-${target##*-}" "$bin" >/dev/null 2>&1
+    else
+        "$bin" >/dev/null 2>&1
+    fi
+    ec=$?
+    if [ "$ec" -eq 139 ]; then
+        echo "relro_write=faulted"
+    else
+        echo "relro_write=exit$ec"
     fi
 }
 
@@ -134,6 +160,7 @@ produce() {
     shift
     case "$run" in
         exec)        produce_exec "$@" ;;
+        relro-fault) produce_relro_fault "$@" ;;
         field)       produce_field "$@" ;;
         relro)       produce_relro "$@" ;;
         flat-loader) produce_flat_loader "$@" ;;

--- a/int/run.sh
+++ b/int/run.sh
@@ -150,11 +150,12 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
     # the mach target to compile: the build-target if set, else the leg itself.
     build_target=${case_build_target:-$target}
 
-    # the golden is shared across build-targets for exec (target-independent output)
-    # and per-build-target for structural producers (their fact is format-specific).
+    # the golden is shared across build-targets for runtime observables (exec and the
+    # relro-fault guard, whose output is target-independent) and per-build-target for
+    # structural producers (their fact is format-specific).
     case "$case_run" in
-        exec) golden="$dir/expect.txt" ;;
-        *)    golden="$dir/expect.$build_target.txt" ;;
+        exec|relro-fault) golden="$dir/expect.txt" ;;
+        *)                golden="$dir/expect.$build_target.txt" ;;
     esac
 
     for profile in $case_profiles; do

--- a/int/surface/pie-relro-fault/case.conf
+++ b/int/surface/pie-relro-fault/case.conf
@@ -1,0 +1,11 @@
+# build the program with --pie and RUN it: this is the runtime half of #1778, the
+# sibling of the elf-relro structural guard. the program dereferences a relocated
+# constant pointer (proving self-relocation ran) and then writes to that constant's
+# .rodata storage. mach-std's _rt_relocate mprotects the PT_GNU_RELRO region read-only
+# after applying the relocations, so the write raises SIGSEGV (exit 139); the producer
+# reports relro_write=faulted only when the region was actually re-protected. scoped to
+# the no-libc linux ELF arches that carry the self-relocating runtime (riscv64 under
+# qemu). the golden is target-independent, so it is shared across the legs.
+run: relro-fault
+targets: linux linux-arm64 linux-riscv64
+build-flags: --pie

--- a/int/surface/pie-relro-fault/expect.txt
+++ b/int/surface/pie-relro-fault/expect.txt
@@ -1,0 +1,1 @@
+relro_write=faulted

--- a/int/surface/pie-relro-fault/mach.toml
+++ b/int/surface/pie-relro-fault/mach.toml
@@ -1,0 +1,36 @@
+[project]
+id      = "case"
+name    = "case"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.case]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/pie-relro-fault/src/main.mach
+++ b/int/surface/pie-relro-fault/src/main.mach
@@ -1,0 +1,31 @@
+# pie-relro-fault surface case: the static-PIE RELRO runtime guard.
+#
+# under `mach build --pie` the linker routes relocated constant pointers into a
+# PT_GNU_RELRO region and maps it writable so the startup can slide the RELATIVE
+# slots; mach-std's `_rt_relocate` then mprotects that region read-only before `main`.
+# this program reads through the relocated constant pointer (proving self-relocation
+# applied it) and then writes to the pointer's own `.rodata` storage. once the region
+# is re-protected, that store faults (SIGSEGV); the relro-fault producer observes the
+# fault as the golden. without the runtime re-protection the store would silently
+# succeed, so this is a permanent guard for the --pie RELRO round-trip.
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+var target: i64 = 1001;
+
+# a constant pointer stored in read-only data; under --pie the linker routes it into
+# the PT_GNU_RELRO region.
+val c_ptr: *i64 = ?target;
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    # read through the relocated constant pointer: proves _rt_relocate slid the slot.
+    p.printlnf("read={}", c_ptr[0]);
+    # write to the constant pointer's own storage, which lives in the RELRO'd .rodata.
+    # after startup re-protected it read-only this store raises SIGSEGV.
+    val slot: *u64 = (?c_ptr)::usize::ptr::*u64;
+    slot[0] = 0;
+    p.printlnf("relro_write=ok");
+    ret 0;
+}

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "51e0d2bb53e69d441c1a1ec6e3a8853b154c4c28"
+commit = "89a75402102012c8cf0a07e294ff5ca01ed1a828"


### PR DESCRIPTION
Final piece of #1778 — activates the RELRO runtime re-protection now that both halves have landed and mach-std has released.

## What

- **Lock bump:** `[deps.mach-std]` → `89a75402` (mach-std main head), which carries `_rt_relocate`'s `PT_GNU_RELRO` `mprotect`. The linker already emits the header (#1811); this makes the re-protection live.
- **Runtime guard:** new `pie-relro-fault` int case — a `--pie` program reads through a relocated constant pointer (proving self-relocation ran), then writes to that constant's RELRO'd `.rodata` storage. With re-protection live the write raises SIGSEGV; a new `relro-fault` producer reports `relro_write=faulted` (exit 139, native or qemu). Runs on the no-libc linux ELF legs (x86_64, arm64, riscv64) sharing one target-independent golden — the runtime sibling of the `elf-relro` structural guard.

The `relro-fault` producer runs the binary and observes the fault via exit code, discarding the program's stdout; `run.sh` classifies it with `exec` as a runtime observable (shared golden). No signal-handler or self-spawn machinery is needed (mach-std exposes no `sigaction`, and a self-execve would be fragile under qemu-user).

## Verification (from the settled tree, `mach.lock` @ 89a75402)

- **pie-relro-fault** passes on `linux` (native x86_64) and `linux-riscv64` (qemu). `linux-arm64` is a native-only leg (arm64 runner in CI); locally the arm64 binary can't exec on an x86_64 host (the same limitation as the existing `pie-reloc` exec case), but under `qemu-aarch64` it prints `read=1001` then SIGSEGVs (exit 139) — so the arm64 CI runner will report `relro_write=faulted`.
- Full int suite on `linux`: all cases pass (no regression from the `produce.sh`/`run.sh` changes).
- Self-host build reaches the **byte-identical fixpoint**; `mach test .`: 445 ok.

## Acceptance (#1778) — all now met

- ✅ `PT_GNU_RELRO` present and correctly sized under `--pie`; absent otherwise (linker, #1811 + `elf-relro`).
- ✅ Relocated constants are **read-only after startup** — a write faults (`pie-relro-fault`, verified x86_64/arm64/riscv64).
- ✅ ASLR + correctness preserved (the #1727 `pie-reloc` guard still passes); non-PIE byte-identical.

Closes #1778.

Follow-up already filed: briar-systems/mach-std#336 (surface `AT_PAGESZ` to the OS layer, replacing the hardcoded `page_size()`).