### PR TITLE
refactor(diag): thread a writer through the framed renderer

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -611,7 +611,9 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
         emit_summary(?p, ?ro, emit_obj, br.output_path);
     }
 
-    cli_diag.flush(?s, ?s.diags);
+    var diag_w: writer.Writer;
+    filesystem.get_writer(?filesystem.stderr, ?diag_w);
+    cli_diag.flush(?diag_w, ?s, ?s.diags);
     driver.dnit_project(?p);
     readout.dnit(?ro);
     session.dnit(?s);

--- a/src/cli/cmd/check.mach
+++ b/src/cli/cmd/check.mach
@@ -17,9 +17,10 @@ use std.print;
 use std.types.size.usize;
 use std.types.string.str;
 
-use A: std.allocator;
-use O: std.types.option;
-use R: std.types.result;
+use A:      std.allocator;
+use O:      std.types.option;
+use R:      std.types.result;
+use writer: std.io.writer;
 
 use cli_diag: mach.cli.diagnostic;
 use mach.cli.util;
@@ -107,7 +108,9 @@ fun check_buffer(es: *editor.EditorSession, path: str, text: str) i64 {
     }
     val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
 
-    cli_diag.flush(es.s, list);
+    var w: writer.Writer;
+    filesystem.get_writer(?filesystem.stderr, ?w);
+    cli_diag.flush(?w, es.s, list);
     if (diagnostic.has_errors(list)) {
         ret 1;
     }

--- a/src/cli/diagnostic.mach
+++ b/src/cli/diagnostic.mach
@@ -20,6 +20,7 @@
 # both `mach build` (whole project) and `mach check` (single buffer) render
 # through `flush`.
 
+use std.allocator.page;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -27,11 +28,14 @@ use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
 
+use A:      std.allocator;
 use O:      std.types.option;
+use R:      std.types.result;
 use writer: std.io.writer;
 use fmt:    std.format;
 
 use mach.lang.diagnostic;
+use mach.lang.fe.token;
 use mach.lang.session;
 use mach.lang.source;
 
@@ -487,4 +491,203 @@ fun severity_label(severity: diagnostic.Severity) str {
     if (severity == diagnostic.SEVERITY_WARNING) { ret "warning: "; }
     if (severity == diagnostic.SEVERITY_INFO)    { ret "info: ";    }
     ret "help: ";
+}
+
+# a fixed-capacity byte sink capturing rendered output in tests.
+# ---
+# buf: destination buffer
+# cap: buffer capacity
+# len: bytes written so far
+rec RenderSink {
+    buf: *u8;
+    cap: usize;
+    len: usize;
+}
+
+# writer callback appending to a RenderSink, dropping bytes past its capacity.
+fun render_sink_write(ctx: ptr, buf: *u8, len: usize) R.Result[usize, str] {
+    val s: *RenderSink = ctx::*RenderSink;
+    var i: usize = 0;
+    for (i < len && s.len < s.cap) {
+        s.buf[s.len] = buf[i];
+        s.len = s.len + 1;
+        i = i + 1;
+    }
+    ret R.ok[usize, str](len);
+}
+
+# wire a Writer over a RenderSink backed by `buf`.
+fun render_writer(w: *writer.Writer, s: *RenderSink, buf: *u8, cap: usize) {
+    s.buf = buf;
+    s.cap = cap;
+    s.len = 0;
+    w.ctx      = s::ptr;
+    w.fn_write = render_sink_write;
+}
+
+# whether the sink's captured bytes contain `want` as a substring.
+fun sink_contains(s: *RenderSink, want: str) bool {
+    val wl: usize = str_len(want);
+    if (wl == 0)     { ret true;  }
+    if (wl > s.len)  { ret false; }
+    var i: usize = 0;
+    for (i + wl <= s.len) {
+        var j: usize = 0;
+        for (j < wl && s.buf[i + j] == want[j]) { j = j + 1; }
+        if (j == wl) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# the count of non-overlapping occurrences of `want` in the sink's bytes.
+fun sink_count(s: *RenderSink, want: str) usize {
+    val wl: usize = str_len(want);
+    if (wl == 0 || wl > s.len) { ret 0; }
+    var count: usize = 0;
+    var i: usize = 0;
+    for (i + wl <= s.len) {
+        var j: usize = 0;
+        for (j < wl && s.buf[i + j] == want[j]) { j = j + 1; }
+        if (j == wl) { count = count + 1; i = i + wl; }
+        or           { i = i + 1;                     }
+    }
+    ret count;
+}
+
+# a whole-line span over `line` of `sf`, or a zero span when it is out of range.
+fun line_span(sf: *source.SourceFile, line: usize) token.Span {
+    var sp: token.Span;
+    sp.offset = 0;
+    sp.len    = 0;
+    val opt: O.Option[source.LineSpan] = source.line_bounds(sf, line);
+    if (O.is_none[source.LineSpan](opt)) { ret sp; }
+    val b: source.LineSpan = O.unwrap[source.LineSpan](opt);
+    sp.offset = b.start;
+    sp.len    = b.end - b.start;
+    ret sp;
+}
+
+# a resolvable primary and secondary render two frames whose single- and
+# two-digit line numbers share one unified gutter, separated by a blank bar.
+test "mach.cli.diagnostic.render:separator_bar_and_unified_gutter" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_s: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](res_s)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_s);
+
+    val res_fid: R.Result[source.FileId, str] = session.load_source(?s, "t.mach",
+        "line 01\nline 02\nline 03\nline 04\nline 05\nline 06\nline 07\nline 08\nline 09\nline 10\nline 11\nline 12\n");
+    if (R.is_err[source.FileId, str](res_fid)) { session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val opt_sf: O.Option[*source.SourceFile] = source.get(?s.sources, fid);
+    if (O.is_none[*source.SourceFile](opt_sf)) { session.dnit(?s); ret 1; }
+    val sf: *source.SourceFile = O.unwrap[*source.SourceFile](opt_sf);
+
+    var list: diagnostic.DiagList = diagnostic.init(?alloc);
+    diagnostic.error(?list, fid, line_span(sf, 9), "primary here");
+    diagnostic.attach_related(?list, fid, line_span(sf, 12), "secondary here");
+
+    var buf:  [1024]u8;
+    var sink: RenderSink;
+    var w:    writer.Writer;
+    render_writer(?w, ?sink, ?buf[0], 1024);
+    flush(?w, ?s, ?list);
+
+    var code: i32 = 0;
+    # both the primary and secondary locations produced a frame.
+    if (sink_count(?sink, "--> ") != 2)                  { code = 1; }
+    # the single-digit primary line right-aligns behind a leading space so its
+    # gutter matches the two-digit secondary line.
+    if (!sink_contains(?sink, " 9 | line 09"))           { code = 1; }
+    if (!sink_contains(?sink, "12 | line 12"))           { code = 1; }
+    # a blank gutter bar separates the primary frame from the secondary frame.
+    if (!sink_contains(?sink, "   |\n  --> t.mach:12:"))  { code = 1; }
+
+    diagnostic.dnit(?list);
+    session.dnit(?s);
+    ret code;
+}
+
+# an unresolvable but captioned secondary location degrades to a trailer
+# `= note:` line rather than a frame.
+test "mach.cli.diagnostic.render:unresolvable_related_degrades_to_note" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_s: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](res_s)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_s);
+
+    val res_fid: R.Result[source.FileId, str] = session.load_source(?s, "t.mach", "alpha\nbeta\ngamma\n");
+    if (R.is_err[source.FileId, str](res_fid)) { session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val opt_sf: O.Option[*source.SourceFile] = source.get(?s.sources, fid);
+    if (O.is_none[*source.SourceFile](opt_sf)) { session.dnit(?s); ret 1; }
+    val sf: *source.SourceFile = O.unwrap[*source.SourceFile](opt_sf);
+
+    val bad_fid: source.FileId = 4242;
+    var list: diagnostic.DiagList = diagnostic.init(?alloc);
+    diagnostic.error(?list, fid, line_span(sf, 2), "primary msg");
+    diagnostic.attach_related(?list, bad_fid, line_span(sf, 2), "defined here");
+
+    var buf:  [512]u8;
+    var sink: RenderSink;
+    var w:    writer.Writer;
+    render_writer(?w, ?sink, ?buf[0], 512);
+    flush(?w, ?s, ?list);
+
+    var code: i32 = 0;
+    # only the resolvable primary produced a frame.
+    if (sink_count(?sink, "--> ") != 1)                    { code = 1; }
+    # the unresolvable caption falls through to a `= note:` trailer line.
+    if (!sink_contains(?sink, "= note: defined here"))     { code = 1; }
+
+    diagnostic.dnit(?list);
+    session.dnit(?s);
+    ret code;
+}
+
+# a primary location that does not resolve still renders every resolvable
+# secondary frame with its caption.
+test "mach.cli.diagnostic.render:unresolvable_primary_still_renders_secondary" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_s: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](res_s)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_s);
+
+    val res_fid: R.Result[source.FileId, str] = session.load_source(?s, "t.mach", "alpha\nbeta\ngamma\n");
+    if (R.is_err[source.FileId, str](res_fid)) { session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val opt_sf: O.Option[*source.SourceFile] = source.get(?s.sources, fid);
+    if (O.is_none[*source.SourceFile](opt_sf)) { session.dnit(?s); ret 1; }
+    val sf: *source.SourceFile = O.unwrap[*source.SourceFile](opt_sf);
+
+    val bad_fid: source.FileId = 4242;
+    var list: diagnostic.DiagList = diagnostic.init(?alloc);
+    diagnostic.error(?list, bad_fid, line_span(sf, 2), "primary msg");
+    diagnostic.attach_related(?list, fid, line_span(sf, 3), "look here");
+
+    var buf:  [512]u8;
+    var sink: RenderSink;
+    var w:    writer.Writer;
+    render_writer(?w, ?sink, ?buf[0], 512);
+    flush(?w, ?s, ?list);
+
+    var code: i32 = 0;
+    # the headline renders even though the primary location did not resolve.
+    if (!sink_contains(?sink, "error: primary msg")) { code = 1; }
+    # the resolvable secondary still produces its own frame, source line, caption.
+    if (sink_count(?sink, "--> ") != 1)              { code = 1; }
+    if (!sink_contains(?sink, "--> t.mach:3:"))      { code = 1; }
+    if (!sink_contains(?sink, "gamma"))              { code = 1; }
+    if (!sink_contains(?sink, "look here"))          { code = 1; }
+
+    diagnostic.dnit(?list);
+    session.dnit(?s);
+    ret code;
 }

--- a/src/cli/diagnostic.mach
+++ b/src/cli/diagnostic.mach
@@ -15,11 +15,11 @@
 # and span; an unresolvable captioned location degrades to a `= note:` line rather
 # than vanishing. output is ASCII only - no Unicode, no color, no terminal escapes
 # - and fixed-width, so it is byte-identical across linux, darwin, and windows.
+# every line is emitted through a caller-owned `writer.Writer`, so the CLI passes
+# a stderr-backed one while tests render into a sink and assert on the bytes.
 # both `mach build` (whole project) and `mach check` (single buffer) render
 # through `flush`.
 
-use std.print;
-use std.system.os;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -27,7 +27,9 @@ use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
 
-use O: std.types.option;
+use O:      std.types.option;
+use writer: std.io.writer;
+use fmt:    std.format;
 
 use mach.lang.diagnostic;
 use mach.lang.session;
@@ -36,15 +38,16 @@ use mach.lang.source;
 # source lines rendered for one multi-line span before the middle is elided
 val MAX_SPAN_LINES: usize = 10;
 
-# render every diagnostic in `list` to stderr against the session source map.
+# render every diagnostic in `list` through `out` against the session source map.
 #
 # Each diagnostic is framed individually, separated by a blank line, and a
 # non-empty run closes with a counts summary. A diagnostic whose file does not
 # resolve degrades to its headline (and note) with no source frame.
 # ---
+# out:  the writer every line is emitted through (the CLI passes stderr)
 # s:    session carrying the source map spans resolve against
 # list: diagnostics to render, in order
-pub fun flush(s: *session.Session, list: *diagnostic.DiagList) {
+pub fun flush(out: *writer.Writer, s: *session.Session, list: *diagnostic.DiagList) {
     var errors:   usize = 0;
     var warnings: usize = 0;
 
@@ -52,8 +55,8 @@ pub fun flush(s: *session.Session, list: *diagnostic.DiagList) {
     for (i < list.len) {
         val d: *diagnostic.Diagnostic = ?list.items[i];
 
-        if (i > 0) { print.eprint("\n"); }
-        render(s, d);
+        if (i > 0) { fmt.write_str(out, "\n"); }
+        render(out, s, d);
 
         if (d.severity == diagnostic.SEVERITY_ERROR)        { errors   = errors + 1;   }
         or (d.severity == diagnostic.SEVERITY_WARNING)      { warnings = warnings + 1; }
@@ -62,8 +65,8 @@ pub fun flush(s: *session.Session, list: *diagnostic.DiagList) {
     }
 
     if (list.len > 0) {
-        print.eprint("\n");
-        emit_summary(errors, warnings);
+        fmt.write_str(out, "\n");
+        emit_summary(out, errors, warnings);
     }
 }
 
@@ -130,10 +133,11 @@ fun locate(s: *session.Session, loc: diagnostic.Location) O.Option[Frame] {
 # a captioned one degrades to a `= note:` line in the trailer, and the primary
 # failing to resolve still lets resolvable secondaries render.
 # ---
-# s: session carrying the source map
-# d: the diagnostic to render
-fun render(s: *session.Session, d: *diagnostic.Diagnostic) {
-    emit_headline(d.severity, d.message);
+# out: the writer the diagnostic is emitted through
+# s:   session carrying the source map
+# d:   the diagnostic to render
+fun render(out: *writer.Writer, s: *session.Session, d: *diagnostic.Diagnostic) {
+    emit_headline(out, d.severity, d.message);
 
     val opt_pf: O.Option[Frame] = locate(s, d.loc);
     val w: usize = gutter_width(s, d, opt_pf);
@@ -141,7 +145,7 @@ fun render(s: *session.Session, d: *diagnostic.Diagnostic) {
     var framed: bool = false;
     if (O.is_some[Frame](opt_pf)) {
         var pf: Frame = O.unwrap[Frame](opt_pf);
-        emit_frame(?pf, w, "^", nil);
+        emit_frame(out, ?pf, w, "^", nil);
         framed = true;
     }
 
@@ -150,15 +154,15 @@ fun render(s: *session.Session, d: *diagnostic.Diagnostic) {
         val rel: *diagnostic.Related = ?d.related[i];
         val opt_rf: O.Option[Frame] = locate(s, rel.loc);
         if (O.is_some[Frame](opt_rf)) {
-            if (framed) { emit_bar(w); }
+            if (framed) { emit_bar(out, w); }
             var rf: Frame = O.unwrap[Frame](opt_rf);
-            emit_frame(?rf, w, "-", rel.label);
+            emit_frame(out, ?rf, w, "-", rel.label);
             framed = true;
         }
         i = i + 1;
     }
 
-    emit_trailer(s, d, framed, w);
+    emit_trailer(out, s, d, framed, w);
 }
 
 # the gutter width unified across the primary frame and every resolvable
@@ -188,14 +192,15 @@ fun gutter_width(s: *session.Session, d: *diagnostic.Diagnostic, opt_pf: O.Optio
 # draw one frame: its `--> file:line:col` line, a blank gutter bar, and the
 # underlined source line(s).
 # ---
+# out:   the writer the frame is emitted through
 # f:     resolved frame geometry
 # w:     unified gutter width in columns
 # head:  underline glyph for the first line ("^" primary, "-" secondary)
 # label: label appended to the final underline line, or nil for none
-fun emit_frame(f: *Frame, w: usize, head: str, label: str) {
-    emit_loc(w, f.sf.path, f.line_s, f.col_s);
-    emit_bar(w);
-    emit_snippet(f.sf, w, f.line_s, f.line_e, f.off, f.end, head, label);
+fun emit_frame(out: *writer.Writer, f: *Frame, w: usize, head: str, label: str) {
+    emit_loc(out, w, f.sf.path, f.line_s, f.col_s);
+    emit_bar(out, w);
+    emit_snippet(out, f.sf, w, f.line_s, f.line_e, f.off, f.end, head, label);
 }
 
 # render the trailing lines under a diagnostic's frames: the caption of every
@@ -205,16 +210,17 @@ fun emit_frame(f: *Frame, w: usize, head: str, label: str) {
 # frames from the trailer and the lines indent to align with the gutter; the
 # unframed (degraded) path emits the lines directly under the headline.
 # ---
+# out:    the writer the trailing lines are emitted through
 # s:      session carrying the source map
 # d:      the diagnostic whose trailing lines are rendered
 # framed: whether any source frame preceded these lines
 # w:      unified gutter width in columns
-fun emit_trailer(s: *session.Session, d: *diagnostic.Diagnostic, framed: bool, w: usize) {
+fun emit_trailer(out: *writer.Writer, s: *session.Session, d: *diagnostic.Diagnostic, framed: bool, w: usize) {
     if (!has_trailer(s, d)) { ret; }
 
     var indent: usize = 2;
     if (framed) {
-        emit_bar(w);
+        emit_bar(out, w);
         indent = w + 1;
     }
 
@@ -222,12 +228,12 @@ fun emit_trailer(s: *session.Session, d: *diagnostic.Diagnostic, framed: bool, w
     for (i < d.related_len) {
         val rel: *diagnostic.Related = ?d.related[i];
         if (rel.label != nil && O.is_none[Frame](locate(s, rel.loc))) {
-            emit_tagged("note", rel.label, indent);
+            emit_tagged(out, "note", rel.label, indent);
         }
         i = i + 1;
     }
-    if (d.note != nil) { emit_tagged("note", d.note, indent); }
-    if (d.help != nil) { emit_tagged("help", d.help, indent); }
+    if (d.note != nil) { emit_tagged(out, "note", d.note, indent); }
+    if (d.help != nil) { emit_tagged(out, "help", d.help, indent); }
 }
 
 # whether a diagnostic has any trailing line to render: a note, a help, or an
@@ -254,6 +260,7 @@ fun has_trailer(s: *session.Session, d: *diagnostic.Diagnostic) bool {
 # than MAX_SPAN_LINES renders only its first and last lines with the middle
 # elided. The label, when present, trails the final underline line.
 # ---
+# out:    the writer the lines are emitted through
 # sf:     source file the lines are drawn from
 # w:      gutter width in columns
 # line_s: 1-based first line of the span
@@ -262,47 +269,48 @@ fun has_trailer(s: *session.Session, d: *diagnostic.Diagnostic) bool {
 # end:    clamped span end byte offset (exclusive)
 # head:   underline glyph for the first line ("^" primary, "-" secondary)
 # label:  label appended to the final underline line, or nil for none
-fun emit_snippet(sf: *source.SourceFile, w: usize, line_s: usize, line_e: usize, off: usize, end: usize, head: str, label: str) {
+fun emit_snippet(out: *writer.Writer, sf: *source.SourceFile, w: usize, line_s: usize, line_e: usize, off: usize, end: usize, head: str, label: str) {
     if (line_e <= line_s) {
-        emit_source_line(sf, w, line_s);
-        emit_underline(sf, w, line_s, off, end, head, label);
+        emit_source_line(out, sf, w, line_s);
+        emit_underline(out, sf, w, line_s, off, end, head, label);
         ret;
     }
 
     if (line_e - line_s + 1 <= MAX_SPAN_LINES) {
         var l: usize = line_s;
         for (l <= line_e) {
-            emit_source_line(sf, w, l);
-            if (l == line_s)      { emit_underline(sf, w, l, off, end, head, nil);  }
-            or (l == line_e)      { emit_underline(sf, w, l, off, end, "-", label); }
-            or                    { emit_underline(sf, w, l, off, end, "-", nil);   }
+            emit_source_line(out, sf, w, l);
+            if (l == line_s)      { emit_underline(out, sf, w, l, off, end, head, nil);  }
+            or (l == line_e)      { emit_underline(out, sf, w, l, off, end, "-", label); }
+            or                    { emit_underline(out, sf, w, l, off, end, "-", nil);   }
             l = l + 1;
         }
         ret;
     }
 
-    emit_source_line(sf, w, line_s);
-    emit_underline(sf, w, line_s, off, end, head, nil);
-    emit_elision(w);
-    emit_source_line(sf, w, line_e);
-    emit_underline(sf, w, line_e, off, end, "-", label);
+    emit_source_line(out, sf, w, line_s);
+    emit_underline(out, sf, w, line_s, off, end, head, nil);
+    emit_elision(out, w);
+    emit_source_line(out, sf, w, line_e);
+    emit_underline(out, sf, w, line_e, off, end, "-", label);
 }
 
 # write one numbered source line through the gutter, verbatim.
 # ---
+# out:  the writer the line is emitted through
 # sf:   source file the line is drawn from
 # w:    gutter width in columns
 # line: 1-based line number to print
-fun emit_source_line(sf: *source.SourceFile, w: usize, line: usize) {
+fun emit_source_line(out: *writer.Writer, sf: *source.SourceFile, w: usize, line: usize) {
     val opt_bounds: O.Option[source.LineSpan] = source.line_bounds(sf, line);
     if (O.is_none[source.LineSpan](opt_bounds)) { ret; }
     val b: source.LineSpan = O.unwrap[source.LineSpan](opt_bounds);
 
-    emit_gutter_num(w, line);
+    emit_gutter_num(out, w, line);
     if (b.end > b.start) {
-        os.write(os.STDERR_FD, ?sf.text[b.start], b.end - b.start);
+        fmt.write_bytes(out, ?sf.text[b.start], b.end - b.start);
     }
-    print.eprint("\n");
+    fmt.write_str(out, "\n");
 }
 
 # write the underline for the portion of `line` the span covers.
@@ -313,6 +321,7 @@ fun emit_source_line(sf: *source.SourceFile, w: usize, line: usize) {
 # zero-length range marking a single column. A non-nil `label` trails the glyph
 # run after a single space.
 # ---
+# out:   the writer the underline is emitted through
 # sf:    source file the line is drawn from
 # w:     gutter width in columns
 # line:  1-based line number being underlined
@@ -320,7 +329,7 @@ fun emit_source_line(sf: *source.SourceFile, w: usize, line: usize) {
 # end:   clamped span end byte offset (exclusive)
 # glyph: the marker glyph, "^" or "-"
 # label: label appended after the glyph run, or nil for none
-fun emit_underline(sf: *source.SourceFile, w: usize, line: usize, off: usize, end: usize, glyph: str, label: str) {
+fun emit_underline(out: *writer.Writer, sf: *source.SourceFile, w: usize, line: usize, off: usize, end: usize, glyph: str, label: str) {
     val opt_bounds: O.Option[source.LineSpan] = source.line_bounds(sf, line);
     if (O.is_none[source.LineSpan](opt_bounds)) { ret; }
     val b: source.LineSpan = O.unwrap[source.LineSpan](opt_bounds);
@@ -331,120 +340,131 @@ fun emit_underline(sf: *source.SourceFile, w: usize, line: usize, off: usize, en
     if (end >= b.start && end <= b.end) { mark_to = end; }
     if (mark_to < mark_from) { mark_to = mark_from; }
 
-    emit_gutter_bar(w);
+    emit_gutter_bar(out, w);
 
     var i: usize = b.start;
     for (i < mark_from) {
-        if (sf.text[i] == '\t') { print.eprint("\t"); }
-        or                      { print.eprint(" ");  }
+        if (sf.text[i] == '\t') { fmt.write_str(out, "\t"); }
+        or                      { fmt.write_str(out, " ");  }
         i = i + 1;
     }
 
     var n: usize = mark_to - mark_from;
     if (n == 0) { n = 1; }
     var j: usize = 0;
-    for (j < n) { print.eprint(glyph); j = j + 1; }
+    for (j < n) { fmt.write_str(out, glyph); j = j + 1; }
     if (label != nil) {
-        print.eprint(" ");
-        print.eprint(label);
+        fmt.write_str(out, " ");
+        fmt.write_str(out, label);
     }
-    print.eprint("\n");
+    fmt.write_str(out, "\n");
 }
 
 # write the `--> file:line:col` location line under the gutter.
 # ---
+# out:  the writer the line is emitted through
 # w:    gutter width in columns
 # path: source file path
 # line: 1-based line of the span start
 # col:  1-based column of the span start
-fun emit_loc(w: usize, path: str, line: usize, col: usize) {
-    emit_spaces(w);
-    print.eprint("--> ");
-    print.eprint(path);
-    print.eprint(":");
-    print.eu64(line::u64);
-    print.eprint(":");
-    print.eu64(col::u64);
-    print.eprint("\n");
+fun emit_loc(out: *writer.Writer, w: usize, path: str, line: usize, col: usize) {
+    emit_spaces(out, w);
+    fmt.write_str(out, "--> ");
+    fmt.write_str(out, path);
+    fmt.write_str(out, ":");
+    fmt.write_u64(out, line::u64);
+    fmt.write_str(out, ":");
+    fmt.write_u64(out, col::u64);
+    fmt.write_str(out, "\n");
 }
 
 # write a blank gutter line (`|`) terminated by a newline.
 # ---
-# w: gutter width in columns
-fun emit_bar(w: usize) {
-    emit_spaces(w);
-    print.eprint(" |\n");
+# out: the writer the line is emitted through
+# w:   gutter width in columns
+fun emit_bar(out: *writer.Writer, w: usize) {
+    emit_spaces(out, w);
+    fmt.write_str(out, " |\n");
 }
 
 # write the `...` elision marker standing in for omitted span lines.
 # ---
-# w: gutter width in columns
-fun emit_elision(w: usize) {
-    emit_spaces(w);
-    print.eprint(" | ...\n");
+# out: the writer the marker is emitted through
+# w:   gutter width in columns
+fun emit_elision(out: *writer.Writer, w: usize) {
+    emit_spaces(out, w);
+    fmt.write_str(out, " | ...\n");
 }
 
 # write a right-aligned line number followed by the ` | ` gutter separator.
 # ---
+# out:  the writer the gutter is emitted through
 # w:    gutter width in columns
 # line: 1-based line number to print
-fun emit_gutter_num(w: usize, line: usize) {
-    emit_spaces(w - decimal_width(line));
-    print.eu64(line::u64);
-    print.eprint(" | ");
+fun emit_gutter_num(out: *writer.Writer, w: usize, line: usize) {
+    emit_spaces(out, w - decimal_width(line));
+    fmt.write_u64(out, line::u64);
+    fmt.write_str(out, " | ");
 }
 
 # write a blank (numberless) gutter prefix ending in the ` | ` separator.
 # ---
-# w: gutter width in columns
-fun emit_gutter_bar(w: usize) {
-    emit_spaces(w);
-    print.eprint(" | ");
+# out: the writer the gutter is emitted through
+# w:   gutter width in columns
+fun emit_gutter_bar(out: *writer.Writer, w: usize) {
+    emit_spaces(out, w);
+    fmt.write_str(out, " | ");
 }
 
 # write a `= <tag>:` line indented so its `=` aligns with the gutter bar.
 # ---
+# out:    the writer the line is emitted through
 # tag:    the line tag ("note" or "help")
 # text:   the line text
 # indent: spaces preceding the `=`
-fun emit_tagged(tag: str, text: str, indent: usize) {
-    emit_spaces(indent);
-    print.eprint("= ");
-    print.eprint(tag);
-    print.eprint(": ");
-    print.eprintln(text);
+fun emit_tagged(out: *writer.Writer, tag: str, text: str, indent: usize) {
+    emit_spaces(out, indent);
+    fmt.write_str(out, "= ");
+    fmt.write_str(out, tag);
+    fmt.write_str(out, ": ");
+    fmt.write_str(out, text);
+    fmt.write_newline(out);
 }
 
 # write the closing `N errors / M warnings` counts line.
 # ---
+# out:      the writer the summary is emitted through
 # errors:   number of error-severity diagnostics rendered
 # warnings: number of warning-severity diagnostics rendered
-fun emit_summary(errors: usize, warnings: usize) {
-    print.eu64(errors::u64);
-    if (errors == 1) { print.eprint(" error");  }
-    or               { print.eprint(" errors"); }
-    print.eprint(" / ");
-    print.eu64(warnings::u64);
-    if (warnings == 1) { print.eprint(" warning");  }
-    or                 { print.eprint(" warnings"); }
-    print.eprint("\n");
+fun emit_summary(out: *writer.Writer, errors: usize, warnings: usize) {
+    fmt.write_u64(out, errors::u64);
+    if (errors == 1) { fmt.write_str(out, " error");  }
+    or               { fmt.write_str(out, " errors"); }
+    fmt.write_str(out, " / ");
+    fmt.write_u64(out, warnings::u64);
+    if (warnings == 1) { fmt.write_str(out, " warning");  }
+    or                 { fmt.write_str(out, " warnings"); }
+    fmt.write_str(out, "\n");
 }
 
 # write the `severity: message` headline line.
 # ---
+# out:      the writer the headline is emitted through
 # severity: severity of the diagnostic
 # message:  the diagnostic message
-fun emit_headline(severity: diagnostic.Severity, message: str) {
-    print.eprint(severity_label(severity));
-    print.eprintln(message);
+fun emit_headline(out: *writer.Writer, severity: diagnostic.Severity, message: str) {
+    fmt.write_str(out, severity_label(severity));
+    fmt.write_str(out, message);
+    fmt.write_newline(out);
 }
 
-# write `n` spaces to stderr.
+# write `n` spaces through `out`.
 # ---
-# n: number of spaces to emit
-fun emit_spaces(n: usize) {
+# out: the writer the spaces are emitted through
+# n:   number of spaces to emit
+fun emit_spaces(out: *writer.Writer, n: usize) {
     var i: usize = 0;
-    for (i < n) { print.eprint(" "); i = i + 1; }
+    for (i < n) { fmt.write_str(out, " "); i = i + 1; }
 }
 
 # the count of decimal digits in `n` (at least 1).


### PR DESCRIPTION
Closes #1821.

## What

The CLI diagnostic renderer (`src/cli/diagnostic.mach`) wrote directly to `STDERR_FD` (and via `print.*`), so its rendered output — including the degraded paths added in #1818 — could not be captured in-process for assertion.

## Change

Thread a `writer.Writer` (parameter `out`) through `flush` and every `emit_*` helper. The two CLI call sites (`mach check`, `mach build`) construct a stderr-backed writer via `filesystem.get_writer(?filesystem.stderr, …)` and pass it. Every `print.eprint`/`print.eu64`/`os.write(STDERR_FD, …)` becomes the equivalent `fmt.write_*` on `out`, so rendered bytes are unchanged.

This mirrors the `TestSink` over `writer.Writer` pattern established for `src/cli/json.mach` in #1816, letting tests render into a sink and assert on frames, gutters, trailers, and the degraded paths.

## Tests

Three unit tests render into a byte sink and assert:
- the #1818 degraded paths — an unresolvable captioned secondary degrades to a `= note:` trailer line; an unresolvable primary still renders a resolvable secondary frame;
- the blank separator bar between the primary and secondary frames;
- the gutter width unified across single- and two-digit line numbers.

## Verification

- `mach build .` clean; self-host fixpoint byte-identical (stage2 == stage3).
- `mach test .` green — 473 passing, including the 3 new `mach.cli.diagnostic` tests.
- `int/run.sh --target linux` all cases pass.
- `mach check` render inspected byte-for-byte (headline, `-->`, gutter, caret, summary) — identical to pre-refactor output.