### PR TITLE
chore(deps): bump mach-std to 991e20b5

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "89a75402102012c8cf0a07e294ff5ca01ed1a828"
+commit = "991e20b5284675244443dd8b85b81fef3b1bfb96"


### PR DESCRIPTION
Advances the mach-std pin to the #344 release head: RFC 8259 string/key escaping in `std.data.json` emit (mach-std#337) and auxv-sourced `os.page_size()` with panic-on-invariant-breach (mach-std#336). Verified: from-source build + full test suite green against the new pin.