### PR TITLE
refactor(cli): remove dead pub fun build

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -347,24 +347,6 @@ fun free_modules(p: *driver.Project,
     }
 }
 
-# compile a single build unit selected from the CLI flags
-#
-# The shared body behind `run` that `cmd.run` reuses so it can build one
-# artifact and then exec it; `mach build` itself iterates the build matrix
-# (`run` below). The returned `output_path`, when non-nil, is owned by `a` - the
-# caller frees it (and tears `a` down) once done with it.
-# ---
-# a:        allocator owning the session and the returned artifact path;
-#           must outlive the returned BuildResult
-# argc:     argument count including argv[0]
-# argv:     the argument vector (argc null-terminated byte pointers)
-# marks:    consumption record parallel to argv, for positional/link scanning
-# emit_obj: when true, emit a relocatable object instead of an executable
-# ret:      a BuildResult carrying the exit code and artifact path
-pub fun build(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj: bool) BuildResult {
-    ret build_unit(a, argc, argv, marks, emit_obj, false, nil, nil, false);
-}
-
 # build the single dispatcher executable covering every collected `test`
 #
 # Returns the per-test artifacts (label, source `file:line`, and dispatch


### PR DESCRIPTION
Removes `src/cli/cmd/build.mach`'s `pub fun build`, which had zero callers and a doc comment asserting a consumer that does not exist.

## Deadness proof (against `dev`)
- `grep -rn 'build\.build\b'` across the whole repo (excluding `.git`/`dep`) returns nothing — no module-qualified call site anywhere in `src/`, `int/`, or `doc/`.
- The doc comment claimed `cmd.run` reused it "so it can build one artifact and then exec it." False: `mach run` (`src/cli/cmd/run.mach`) is a post-build execute — it resolves the artifact path via `driver.resolve_artifact_path` and execs it, erroring with "run \`mach build\` first" when absent. It only borrows `build.emit_kind` and `build.selection_from_config`, never `build.build`.
- The #1835 refactor had to thread the `marks: *bool` vector through the wrapper purely to keep this dead code compiling.

## No transitive deadness
`pub fun build`'s only body was `ret build_unit(...)`. `build_unit` keeps its live callers — `build_tests` and the `mach build` matrix loop — so nothing else goes dead.

## Verification
- From-source build (`mach build .`) succeeds.
- Full unit suite (`mach test .`) green.

Closes #1840