### PR TITLE
fix(driver): report riscv64 host arch in mach info

### DIFF
--- a/src/cli/cmd/info.mach
+++ b/src/cli/cmd/info.mach
@@ -104,10 +104,11 @@ fun host_os_name() str {
 # Folds at compile time like host_os_name; the final arm is dead for every
 # supported architecture and exists only for totality.
 # ---
-# ret: the host architecture name ("x86_64" or "aarch64")
+# ret: the host architecture name ("x86_64", "aarch64", or "riscv64")
 fun host_arch_name() str {
     $if ($mach.build.arch == $mach.arch.x86_64)  { ret "x86_64"; }
     $or ($mach.build.arch == $mach.arch.aarch64) { ret "aarch64"; }
+    $or ($mach.build.arch == $mach.arch.riscv64) { ret "riscv64"; }
     $or                                          { ret "unknown"; }
 }
 


### PR DESCRIPTION
`host_arch_name()` in `src/cli/cmd/info.mach` had arms for x86_64 and aarch64 but none for riscv64, so a riscv64 build printed `host: linux/unknown`. Adds the riscv64 arm (using the existing `$mach.arch.riscv64` comptime constant, same pattern as `src/lang/target.mach:93`).

Surfaced during the #1742 riscv64 self-host investigation.

Sibling host-fact helpers were checked: `host_os_name()` covers linux/darwin/windows (riscv64 is not an OS — no gap), and the abi line is enumerated from the target registry rather than a host fold, so neither has the same defect.

## Verification
- Full unit suite: 475 passed, 0 failed.
- Native `mach info` unchanged: `host: linux/x86_64`.
- Cross-built for linux-riscv64 and run under qemu: `host: linux/riscv64` (was `host: linux/unknown`).

Closes #1853