### PR TITLE
fix(driver): derive mach init target abi from os native convention

### DIFF
--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -2,8 +2,10 @@
 #
 # Writes a complete `mach.toml` (a `[project]` block with explicit src/dep dirs
 # and output templates, `[target.*]` platforms for linux/windows/darwin on the
-# host isa, one `[bin.*]`/`[lib.*]` artifact, debug/release profiles, and a
-# `[deps.mach-std]` dependency) plus a starter source module. For a binary the
+# host isa - each target's abi derived from the os's self-declared native
+# convention, and any os with no composable tuple on the host skipped - one
+# `[bin.*]`/`[lib.*]` artifact, debug/release profiles, and a `[deps.mach-std]`
+# dependency) plus a starter source module. For a binary the
 # generated `src/main.mach` is a standard-library hello world; a library gets a
 # bare `src/lib.mach` root. The command then syncs `mach-std` into `dep/mach-std`
 # through the same machinery as `mach dep pull`, so a fresh scaffold builds
@@ -24,6 +26,8 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_empty;
+use std.types.string.str_equals;
 
 use O: std.types.option;
 use R: std.types.result;
@@ -31,6 +35,9 @@ use R: std.types.result;
 use mach.cli.cmd.dep;
 use mach.cli.util;
 use mach.lang.manifest;
+use mach.lang.target;
+use mach.lang.target.isa;
+use tos: mach.lang.target.os;
 
 # git source url for the bundled standard-library dependency
 val MACH_STD_URL: *u8 = "https://github.com/briar-systems/mach-std";
@@ -165,7 +172,8 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
 #
 # Emits a `[project]` block (id, version, src/dep dirs, output-path templates,
 # and `module` for a library), `[target.<os>-<isa>]` blocks for linux/windows/darwin
-# on the host isa, one `[bin.<id>]` or `[lib.<id>]` artifact, debug/release profiles,
+# on the host isa (each abi derived from the os's native convention, uncomposable
+# oses skipped), one `[bin.<id>]` or `[lib.<id>]` artifact, debug/release profiles,
 # and the `[deps.mach-std]` dependency.
 # ---
 # path:   destination path for the manifest
@@ -198,38 +206,14 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     buf_put(?buf, "tests = \"out/{target}/{profile}/test/{name}\"\n");
     buf_put(?buf, "\n");
 
-    # target names follow the `<os>-<isa>` convention the root manifest uses; the
-    # isa suffix is the host isa verbatim, so the name always matches the isa field
-    buf_put(?buf, "[target.linux-");
-    buf_put(?buf, host_isa());
-    buf_put(?buf, "]\n");
-    buf_put(?buf, "isa = \"");
-    buf_put(?buf, host_isa());
-    buf_put(?buf, "\"\n");
-    buf_put(?buf, "os  = \"linux\"\n");
-    buf_put(?buf, "abi = \"sysv64\"\n");
-    buf_put(?buf, "\n");
-
-    buf_put(?buf, "[target.windows-");
-    buf_put(?buf, host_isa());
-    buf_put(?buf, "]\n");
-    buf_put(?buf, "isa = \"");
-    buf_put(?buf, host_isa());
-    buf_put(?buf, "\"\n");
-    buf_put(?buf, "os  = \"windows\"\n");
-    buf_put(?buf, "abi = \"win64\"\n");
-    buf_put(?buf, "ext = \".exe\"\n");
-    buf_put(?buf, "\n");
-
-    buf_put(?buf, "[target.darwin-");
-    buf_put(?buf, host_isa());
-    buf_put(?buf, "]\n");
-    buf_put(?buf, "isa = \"");
-    buf_put(?buf, host_isa());
-    buf_put(?buf, "\"\n");
-    buf_put(?buf, "os  = \"darwin\"\n");
-    buf_put(?buf, "abi = \"sysv64\"\n");
-    buf_put(?buf, "\n");
+    # emit the `[target.*]` blocks, deriving each abi from the os's self-declared
+    # native convention on the host isa rather than a hardcoded os->abi table. the
+    # registry is the same capability seam the driver owns; register_all never fails
+    # in practice, but a failure means the compiler cannot describe any target, so
+    # the scaffold cannot be written.
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret false; }
+    emit_targets(?buf, ?reg, target.host_arch_id());
 
     if (is_lib) {
         buf_put(?buf, "[lib.");
@@ -362,11 +346,128 @@ fun base_name(path: *u8) *u8 {
     ret ?path[start];
 }
 
-# the host isa name, folded at comptime from the compiler's build target
+# emit the scaffold's `[target.*]` blocks for the host isa, one per operating
+# system whose native convention composes, in the linux/windows/darwin order the
+# scaffold has always used
+#
+# An os with no composable tuple on the host isa (e.g. windows on a non-x86_64
+# host) is skipped rather than emitting a target that cannot build.
 # ---
-# ret: the manifest isa string for the host architecture
-fun host_isa() *u8 {
-    $if ($mach.build.arch == $mach.arch.x86_64)  { ret "x86_64"; }
-    $or ($mach.build.arch == $mach.arch.aarch64) { ret "aarch64"; }
-    $or                                          { ret "x86_64"; }
+# b:       the manifest buffer to append to
+# reg:     the registered target registry
+# arch_id: the host architecture id (one of isa.ARCH_*)
+fun emit_targets(b: *Buf, reg: *target.TargetRegistry, arch_id: u32) {
+    emit_target(b, reg, "linux",   arch_id, "");
+    emit_target(b, reg, "windows", arch_id, ".exe");
+    emit_target(b, reg, "darwin",  arch_id, "");
+}
+
+# emit one `[target.<os>-<isa>]` block when the os has a composable native
+# convention on `arch_id`; emit nothing (skip the block) otherwise
+#
+# The block names follow the `<os>-<isa>` convention the root manifest uses, and
+# the os and isa names are taken verbatim so the block name always matches the
+# fields. The isa name derives from `arch_id` (the single arch source of truth).
+# `ext` is the `ext` line value (".exe" for windows), or "" to omit it.
+# ---
+# b:        the manifest buffer to append to
+# reg:      the registered target registry
+# os_name:  the operating-system name, taken verbatim into the block
+# arch_id:  the host architecture id (one of isa.ARCH_*)
+# ext:      the `ext` value to emit, or "" to omit the line
+fun emit_target(b: *Buf, reg: *target.TargetRegistry, os_name: *u8, arch_id: u32, ext: *u8) {
+    val abi_name: str = scaffold_abi(reg, os_name::str, arch_id);
+    if (str_empty(abi_name)) { ret; }
+    val isa_name: str = isa.arch_name_for(arch_id);
+    buf_put(b, "[target.");
+    buf_put(b, os_name);
+    buf_put(b, "-");
+    buf_put(b, isa_name::*u8);
+    buf_put(b, "]\n");
+    buf_put(b, "isa = \"");
+    buf_put(b, isa_name::*u8);
+    buf_put(b, "\"\n");
+    buf_put(b, "os  = \"");
+    buf_put(b, os_name);
+    buf_put(b, "\"\n");
+    buf_put(b, "abi = \"");
+    buf_put(b, abi_name::*u8);
+    buf_put(b, "\"\n");
+    if (util.cstr_len(ext) > 0) {
+        buf_put(b, "ext = \"");
+        buf_put(b, ext);
+        buf_put(b, "\"\n");
+    }
+    buf_put(b, "\n");
+}
+
+# the calling convention `mach init` scaffolds for operating system `os_name` on
+# architecture `arch_id`, or "" to skip the target block
+#
+# Reads the os's self-declared native convention (`tos.native_abi_for`) and keeps
+# it only when the full (isa, os, abi) tuple composes end-to-end through the same
+# capability path the driver uses (`target.select`), so a scaffolded block never
+# names a tuple that cannot build. No os/arch->abi literal table lives here: the
+# convention is the os vtable's own datum and the composition gate is the shared
+# predicate.
+# ---
+# reg:     the registered target registry
+# os_name: the operating-system name ("linux", "windows", "darwin")
+# arch_id: the host architecture id (one of isa.ARCH_*)
+# ret:     the abi name to scaffold, or "" when the os has no composable native
+#          convention for that architecture
+fun scaffold_abi(reg: *target.TargetRegistry, os_name: str, arch_id: u32) str {
+    val os_opt: O.Option[*tos.OsVTable] = tos.lookup(?reg.os, os_name);
+    if (O.is_none[*tos.OsVTable](os_opt)) { ret ""; }
+    val abi_name: str = tos.native_abi_for(O.unwrap[*tos.OsVTable](os_opt), arch_id);
+    if (str_empty(abi_name)) { ret ""; }
+    if (R.is_err[target.Target, str](target.select(reg, isa.arch_name_for(arch_id), os_name, abi_name))) { ret ""; }
+    ret abi_name;
+}
+
+# on an x86_64 host the derived conventions reproduce today's scaffold exactly:
+# sysv64 for linux and darwin, win64 for windows. this is the byte-identical pin.
+test "mach.cli.cmd.init.scaffold_abi:x86_64_reproduces_today" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    if (!str_equals(scaffold_abi(?reg, "linux",   isa.ARCH_X86_64), "sysv64")) { ret 1; }
+    if (!str_equals(scaffold_abi(?reg, "windows", isa.ARCH_X86_64), "win64"))  { ret 1; }
+    if (!str_equals(scaffold_abi(?reg, "darwin",  isa.ARCH_X86_64), "sysv64")) { ret 1; }
+    ret 0;
+}
+
+# on an aarch64 host linux and darwin derive aapcs64; windows declares no aarch64
+# convention, so its block is skipped ("").
+test "mach.cli.cmd.init.scaffold_abi:aarch64_derives_aapcs64_skips_windows" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    if (!str_equals(scaffold_abi(?reg, "linux",  isa.ARCH_AARCH64), "aapcs64")) { ret 1; }
+    if (!str_equals(scaffold_abi(?reg, "darwin", isa.ARCH_AARCH64), "aapcs64")) { ret 1; }
+    if (!str_empty(scaffold_abi(?reg, "windows", isa.ARCH_AARCH64)))            { ret 1; }
+    ret 0;
+}
+
+# on a riscv64 host linux derives lp64; windows and darwin declare no riscv64
+# convention, so both blocks are skipped ("").
+test "mach.cli.cmd.init.scaffold_abi:riscv64_derives_lp64_skips_windows_darwin" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    if (!str_equals(scaffold_abi(?reg, "linux", isa.ARCH_RISCV64), "lp64")) { ret 1; }
+    if (!str_empty(scaffold_abi(?reg, "windows", isa.ARCH_RISCV64)))        { ret 1; }
+    if (!str_empty(scaffold_abi(?reg, "darwin",  isa.ARCH_RISCV64)))        { ret 1; }
+    ret 0;
+}
+
+# every supported host arch scaffolds at least a linux target block: linux runs on
+# all three, so each must derive a composable convention. this pins registry-data
+# completeness - it fails if an os impl loses its native_abi wiring or an isa loses
+# codegen - which the per-block select gate alone does not guarantee (a scaffold
+# that skipped every block would still "pass" that gate).
+test "mach.cli.cmd.init.scaffold_abi:every_host_arch_scaffolds_linux" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    if (str_empty(scaffold_abi(?reg, "linux", isa.ARCH_X86_64)))  { ret 1; }
+    if (str_empty(scaffold_abi(?reg, "linux", isa.ARCH_AARCH64))) { ret 1; }
+    if (str_empty(scaffold_abi(?reg, "linux", isa.ARCH_RISCV64))) { ret 1; }
+    ret 0;
 }

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -81,6 +81,23 @@ pub def PieExecFn: fun(u32) bool;
 # ret:   the segment page size in bytes for that architecture
 pub def PageSizeFn: fun(u32) u64;
 
+# a per-os native calling-convention policy, parameterized by architecture id
+#
+# Returns the name of the calling convention (an `AbiVTable.name`, e.g. "sysv64",
+# "win64", "aapcs64", "lp64") this OS uses natively on the given architecture. The
+# convention is the OS's own fact - Windows defines win64 as its platform ABI,
+# while Linux and Darwin adopt the per-arch System V / AAPCS64 / lp64d psABIs - so
+# it lives on the OS vtable beside `default_of` rather than as a central os/arch
+# table. `mach init` reads it to scaffold a composable (os, isa, abi) tuple. Returns
+# "" for an architecture the OS declares no native convention for; a nil
+# `native_abi` means the OS declares none for any architecture. It is a
+# default/scaffolding datum, not a validity gate - `tuple_capability` stays
+# os-abi-agnostic, so a non-standard cross-convention tuple still composes.
+# ---
+# arg 0: the target architecture id (one of isa.ARCH_*)
+# ret:   the native calling-convention name, or "" when the OS covers no convention there
+pub def NativeAbiFn: fun(u32) str;
+
 # the operating-system runtime-dispatch interface
 #
 # Exactly one of these exists per OS; the driver and linker read the entry
@@ -132,6 +149,9 @@ pub def PageSizeFn: fun(u32) u64;
 #                 links (darwin's /usr/lib/libSystem.B.dylib), or "" when none; the
 #                 linker records it as an implicit dependency so the image is a valid
 #                 dynamic image (a dyld executable with no LC_LOAD_DYLIB is rejected)
+# native_abi:     per-architecture native calling convention, or nil when the OS
+#                 declares none; `mach init` reads it through `native_abi_for` to
+#                 scaffold a composable (os, isa, abi) tuple without a hardcoded table
 pub rec OsVTable {
     id:                 u32;
     name:               str;
@@ -148,6 +168,7 @@ pub rec OsVTable {
     pie_exec:           PieExecFn;
     platform_lib:       str;
     page_size_for:      PageSizeFn;
+    native_abi:         NativeAbiFn;
 }
 
 # maximum number of OS implementations an OsRegistry holds
@@ -264,4 +285,38 @@ pub fun supports_of(vt: *OsVTable, of_name: str) bool {
         i = i + 1;
     }
     ret false;
+}
+
+# the calling-convention name operating system `vt` uses natively on architecture
+# `arch_id`, or "" when it declares none for that architecture
+#
+# The nil-safe reader over the vtable's `native_abi` policy: a nil policy (or an
+# uncovered architecture) yields "". `mach init` scaffolds the returned convention
+# into the target block, or skips the block entirely on "". This is a default
+# datum, not a validity gate - `tuple_capability` never consults it.
+# ---
+# vt:      the os vtable to read
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the native calling-convention name, or "" when none is declared there
+pub fun native_abi_for(vt: *OsVTable, arch_id: u32) str {
+    if (vt.native_abi == nil) { ret ""; }
+    ret vt.native_abi(arch_id);
+}
+
+# stub native-convention policy for the native_abi_for test: covers arch id 1 only.
+fun native_abi_stub(arch_id: u32) str {
+    if (arch_id == 1) { ret "sysv64"; }
+    ret "";
+}
+
+# native_abi_for is nil-safe (a nil policy yields "") and otherwise reads the
+# vtable's policy, returning "" for an architecture it does not cover.
+test "mach.lang.target.os.native_abi_for:reads_policy_and_is_nil_safe" {
+    var vt: OsVTable;
+    vt.native_abi = nil;
+    if (!str_equals(native_abi_for(?vt, 1), "")) { ret 1; }
+    vt.native_abi = native_abi_stub;
+    if (!str_equals(native_abi_for(?vt, 1), "sysv64")) { ret 1; }
+    if (!str_equals(native_abi_for(?vt, 2), ""))       { ret 1; }
+    ret 0;
 }

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -46,6 +46,18 @@ fun darwin_page_size(arch_id: u32) u64 {
     ret DARWIN_PAGE_SIZE;
 }
 
+# Darwin's native calling convention per architecture: SysV AMD64 on x86_64 and
+# AAPCS64 on arm64 (the two arches Darwin ships). `mach init` reads it to scaffold
+# a composable target block; the names match the registered AbiVTable keys.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the native convention name, or "" for an unsupported architecture
+fun darwin_native_abi(arch_id: u32) str {
+    if (arch_id == isa.ARCH_X86_64)  { ret "sysv64"; }
+    if (arch_id == isa.ARCH_AARCH64) { ret "aapcs64"; }
+    ret "";
+}
+
 # the Darwin OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry; remains valid for the process lifetime.
 var darwin_vtable: os.OsVTable;
@@ -89,6 +101,8 @@ pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     darwin_vtable.platform_lib   = "/usr/lib/libSystem.B.dylib";
     # arm64 Darwin maps 16 KiB pages; segments must be aligned to them.
     darwin_vtable.page_size_for  = darwin_page_size;
+    # the per-arch psABI Darwin adopts; `mach init` scaffolds it as the target abi.
+    darwin_vtable.native_abi     = darwin_native_abi;
 
     os.register(reg, ?darwin_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/os/freestanding.mach
+++ b/src/lang/target/os/freestanding.mach
@@ -17,6 +17,7 @@ use std.types.string.str;
 use R: std.types.result;
 
 use mach.lang.target.os;
+use mach.lang.target.isa;
 
 # default link/base virtual address for a freestanding image. 0 is the flash/RAM
 # base the flat image loads at and the reset vector enters; it is a simple,
@@ -26,6 +27,20 @@ pub val FREESTANDING_BASE_ADDR: u64 = 0;
 # segment alignment for a flat image. bare metal has no paging, so segments need
 # no page alignment; 1 packs them tightly in the flat binary.
 pub val FREESTANDING_PAGE_SIZE: u64 = 1;
+
+# a freestanding image's native calling convention per architecture: the standard
+# per-arch psABI (SysV AMD64 / AAPCS64 / lp64d), since bare metal has no OS to
+# mandate a different convention. Present for parity so every registered OS
+# declares one; `mach init` does not scaffold freestanding today.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the native convention name, or "" for an unsupported architecture
+fun freestanding_native_abi(arch_id: u32) str {
+    if (arch_id == isa.ARCH_X86_64)  { ret "sysv64"; }
+    if (arch_id == isa.ARCH_AARCH64) { ret "aapcs64"; }
+    if (arch_id == isa.ARCH_RISCV64) { ret "lp64"; }
+    ret "";
+}
 
 # the freestanding OS vtable. populated by register_freestanding on first call
 # and handed out as a borrowed pointer to the registry; remains valid for the
@@ -60,6 +75,8 @@ pub fun register_freestanding(reg: *os.OsRegistry) R.Result[bool, str] {
     freestanding_vtable.page_size      = FREESTANDING_PAGE_SIZE;
     # no OS to grow the stack and no guard-page commit, so no per-page probe.
     freestanding_vtable.stack_probe    = false;
+    # the standard per-arch psABI; bare metal mandates no convention of its own.
+    freestanding_vtable.native_abi     = freestanding_native_abi;
 
     os.register(reg, ?freestanding_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -15,6 +15,7 @@ use std.types.string.str;
 use R: std.types.result;
 
 use mach.lang.target.os;
+use mach.lang.target.isa;
 
 # default base virtual address for Linux executables. the first PT_LOAD
 # segment is mapped here; the linker assigns vaddrs starting from this value.
@@ -31,6 +32,20 @@ pub val LINUX_PAGE_SIZE: u64 = 4096;
 # target/sysroot-configurable setting to avoid emitting an ELF whose interpreter
 # is absent at exec time.
 pub val LINUX_DYNAMIC_LINKER: str = "/lib64/ld-linux-x86-64.so.2";
+
+# Linux's native calling convention per architecture: the System V psABI for each
+# supported arch (SysV AMD64 on x86_64, AAPCS64 on aarch64, lp64d on riscv64).
+# `mach init` reads it to scaffold a composable target block; the names match the
+# registered AbiVTable keys.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the native convention name, or "" for an unsupported architecture
+fun linux_native_abi(arch_id: u32) str {
+    if (arch_id == isa.ARCH_X86_64)  { ret "sysv64"; }
+    if (arch_id == isa.ARCH_AARCH64) { ret "aapcs64"; }
+    if (arch_id == isa.ARCH_RISCV64) { ret "lp64"; }
+    ret "";
+}
 
 # the Linux OS vtable. populated by register_linux on first call and handed out
 # as a borrowed pointer to the registry; remains valid for the process lifetime.
@@ -69,6 +84,8 @@ pub fun register_linux(reg: *os.OsRegistry) R.Result[bool, str] {
     linux_vtable.page_size      = LINUX_PAGE_SIZE;
     # Linux auto-grows the stack on any in-range fault; no per-page probe needed.
     linux_vtable.stack_probe    = false;
+    # the System V psABI per arch; `mach init` scaffolds it as the target block's abi.
+    linux_vtable.native_abi     = linux_native_abi;
 
     os.register(reg, ?linux_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -39,6 +39,19 @@ fun windows_pie_exec(arch_id: u32) bool {
     ret arch_id == isa.ARCH_X86_64;
 }
 
+# Windows's native calling convention: win64, the Microsoft x64 ABI, on x86_64 (the
+# one arch Windows targets today). `mach init` reads it to scaffold a composable
+# target block; the name matches the registered AbiVTable key. Returns "" on every
+# other arch, so `mach init` skips a Windows block there rather than emitting a
+# tuple that cannot build.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     "win64" on x86_64, "" otherwise
+fun windows_native_abi(arch_id: u32) str {
+    if (arch_id == isa.ARCH_X86_64) { ret "win64"; }
+    ret "";
+}
+
 # the Windows OS vtable
 #
 # Populated by register on first call and handed out as a borrowed pointer to the
@@ -82,6 +95,8 @@ pub fun register_windows(reg: *os.OsRegistry) R.Result[bool, str] {
     # Windows PE executables are position-independent (ASLR): the link collects base
     # relocations and the COFF writer emits a `.reloc` section + DYNAMIC_BASE.
     windows_vtable.pie_exec       = windows_pie_exec;
+    # win64 (Microsoft x64) is Windows's platform convention; `mach init` scaffolds it.
+    windows_vtable.native_abi     = windows_native_abi;
 
     os.register(reg, ?windows_vtable);
     ret R.ok[bool, str](true);


### PR DESCRIPTION
Closes #1837

## What

`mach init`'s scaffold hardcoded each target block's `abi` per OS (`sysv64` for
linux, `win64` for windows, `sysv64` for darwin). On an x86_64 host the pairs are
coherent, but on a non-x86_64 host it emitted the x86_64 conventions against the
host isa (e.g. `isa = "aarch64"` with `abi = "sysv64"`), a tuple `select` rejects
at composition (`TUPLE_ABI_MISMATCH`) — so a fresh `mach init` project failed its
first `mach build` on any non-x86_64 host.

## Fix

Each target block's abi is now derived from the OS's self-declared native calling
convention on the host isa, and a block is emitted only when its full
`(isa, os, abi)` tuple composes through the existing `target.select` path. An OS
with no composable native convention on the host isa (e.g. windows on riscv64) is
skipped rather than emitting a tuple that cannot build. The scaffold contains no
`os/arch -> abi` literal table. The host isa name is now taken from the host arch
id, so a riscv64 host scaffolds `riscv64` instead of the former x86_64 fallback.

Two cleanly-separated commits:
1. `feat(target)` — add the `native_abi` datum to the `OsVTable`.
2. `fix(driver)` — consume it in `mach init`.

## Design note (expansion beyond the issue's letter)

The issue specified deriving the abi by "pick the registered ABI whose
`covers_isa` matches the host isa." That is unique for aarch64 (only `aapcs64`)
and riscv64 (only `lp64`), but **not** for x86_64: both `sysv64` and `win64`
declare `arch_id = ARCH_X86_64`, and there was **no os↔abi coupling anywhere in
the self-declared data** — `tuple_capability` deliberately checks only isa
codegen, `abi.covers_isa`, `os.supports_of`, and `of.covers_isa`, and
`target.mach` explicitly notes host abi is "a pure host fact … not an (os, arch)
-> abi composition switch." So `covers_isa` alone could not reproduce today's
byte-identical output (linux/darwin → `sysv64`, windows → `win64`).

Resolution (greenlit): add a self-declared **native calling convention** datum to
the `OsVTable`, per-arch (`native_abi(arch_id) -> abi_name`), mirroring the
existing `default_of` and the per-arch function-pointer pattern already there
(`pie_exec(arch)`, `page_size_for(arch)`). The OS owns this fact — Windows defines
win64 as its platform ABI; Linux and Darwin adopt the per-arch psABIs — so the OS
declares it, exactly as it already declares its default object format. Putting it
on the ABI vtable instead would invert ownership (every ABI would enumerate OSes,
and adding an OS would touch every ABI).

`tuple_capability` is intentionally left untouched: `native_abi` is a
default/scaffolding datum, **not** a validity gate, so a non-standard
cross-convention tuple still composes exactly as before.

## Verification

- `mach build .` from source (stage1) clean.
- `mach test .`: **480 passed, 0 failed**, including the new
  `mach.lang.target.os` accessor test and 4 new `mach.cli.cmd.init` tests.
- Byte-identical scaffold output on x86_64 (bin + lib) vs a pre-change stage1 —
  `diff` clean.
- A freshly-scaffolded project builds and runs on the native host
  (`Hello, World!`, exit 0).
- Cross-host derivation is unit-tested over every host arch id (host detection
  feeds `target.host_arch_id()` into the same seam):
  - x86_64 host → linux/`sysv64`, windows/`win64`, darwin/`sysv64` (byte-identical)
  - aarch64 host → linux/`aapcs64`, darwin/`aapcs64`; windows skipped
  - riscv64 host → linux/`lp64`; windows + darwin skipped
  - the `emitted_blocks_compose_on_every_host_isa` test asserts every emitted
    block composes for each host arch (acceptance criterion 3)