### PR TITLE
fix(codegen): materialize phi immediate merge moves at logical width

### DIFF
--- a/int/regression/1851-rv64-phi-signext/expect.txt
+++ b/int/regression/1851-rv64-phi-signext/expect.txt
@@ -1,0 +1,2 @@
+v_lt_0=true
+acc=48

--- a/int/regression/1851-rv64-phi-signext/mach.toml
+++ b/int/regression/1851-rv64-phi-signext/mach.toml
@@ -1,0 +1,52 @@
+[project]
+id      = "case"
+name    = "case"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+ext = ".exe"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.case]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/1851-rv64-phi-signext/src/main.mach
+++ b/int/regression/1851-rv64-phi-signext/src/main.mach
@@ -1,0 +1,36 @@
+# regression pin for #1851: a negative i32 constant reaching a signed compare
+# through a phi (a branch merge). the phi's constant edge must materialize at the
+# value's logical width so riscv64 sign-extends it to the lp64 register convention;
+# a full-register merge move left it un-sign-extended and the 64-bit `slt` read -1 as
+# a large positive, so `v < 0` was false and a loop-carried negative i32 took the
+# wrong arm. x86_64 / aarch64 stay correct (width-aware 32-bit compare). the loop-
+# derived `probe` keeps the branch and its phi from folding at -O2.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var probe: i32 = 0;
+    var i:     i32 = 0;
+    for (i < 5) { probe = probe + i; i = i + 1; }
+
+    var v: i32 = -1;
+    if (probe > 100) { v = probe; }
+    if (v < 0) { p.println("v_lt_0=true"); } or { p.println("v_lt_0=false"); }
+
+    # a loop-carried negative i32 across a back edge and an if/else.
+    var a:   i32 = 3;
+    var b:   i32 = -7;
+    var acc: i32 = 0;
+    var j:   i32 = 0;
+    for (j < 6) {
+        if (b < 0) { acc = acc + a; } or { acc = acc - a; }
+        b   = b + 1;
+        a   = a + 2;
+        j   = j + 1;
+    }
+    p.printlnf("acc={}", acc);
+    ret 0;
+}

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -318,6 +318,15 @@ fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) R.Re
         ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](rs));
     }
     val srcs: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rs);
+    # per-copy logical width, parallel to dsts / srcs: the phi result's byte width,
+    # so an immediate incoming value materializes at the constant's true width.
+    val rw: R.Result[*u8, str] = A.allocate[u8](ctx.alloc, np::usize);
+    if (R.is_err[*u8, str](rw)) {
+        A.deallocate[u32](ctx.alloc, dsts, np::usize);
+        A.deallocate[mir.MirOperand](ctx.alloc, srcs, np::usize);
+        ret R.err[bool, str](R.unwrap_err[*u8, str](rw));
+    }
+    val wids: *u8 = R.unwrap_ok[*u8, str](rw);
 
     var err_msg: str = nil;
     # iterate the distinct predecessor block ids of `S`. preds were copied from the
@@ -369,6 +378,7 @@ fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) R.Re
                 if (phi.operands[k].data.int_lit::u32 == pred_id) {
                     dsts[nc] = dst_vreg;
                     srcs[nc] = lctx.lower_value(ctx, phi.operands[k + 1]);
+                    wids[nc] = lctx.op_width_of(ctx, phi.ty);
                     nc = nc + 1;
                     found = true;
                 }
@@ -378,7 +388,7 @@ fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) R.Re
         }
 
         if (err_msg == nil && nc > 0) {
-            val r: R.Result[bool, str] = emit_edge_copies(ctx, pred_mb, dsts, srcs, nc);
+            val r: R.Result[bool, str] = emit_edge_copies(ctx, pred_mb, dsts, srcs, wids, nc);
             if (R.is_err[bool, str](r)) { err_msg = R.unwrap_err[bool, str](r); }
         }
         pi = pi + 1;
@@ -386,6 +396,7 @@ fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) R.Re
 
     A.deallocate[u32](ctx.alloc, dsts, np::usize);
     A.deallocate[mir.MirOperand](ctx.alloc, srcs, np::usize);
+    A.deallocate[u8](ctx.alloc, wids, np::usize);
     if (err_msg != nil) { ret R.err[bool, str](err_msg); }
     ret R.ok[bool, str](true);
 }
@@ -423,9 +434,10 @@ fun mir_block_by_id(f: *mir.MirFunction, block_id: u32) *mir.MirBlock {
 # pred_mb: the predecessor block the copies are spliced into
 # dsts:    the per-copy destination vregs (len `n`)
 # srcs:    the per-copy source operands (len `n`)
+# wids:    the per-copy value logical width in bytes (len `n`)
 # n:       the number of copies in the edge set
 # ret:     true on success, or an allocation / lowering error
-fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, srcs: *mir.MirOperand, n: u32) R.Result[bool, str] {
+fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, srcs: *mir.MirOperand, wids: *u8, n: u32) R.Result[bool, str] {
     val re: R.Result[*bool, str] = A.allocate[bool](ctx.alloc, n::usize);
     if (R.is_err[*bool, str](re)) { ret R.err[bool, str](R.unwrap_err[*bool, str](re)); }
     val done: *bool = R.unwrap_ok[*bool, str](re);
@@ -450,7 +462,7 @@ fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, sr
         for (j < n) {
             if (done[j] == false && !dst_is_pending_src(dsts, srcs, done, n, dsts[j])) {
                 val mv: R.Result[bool, str] = insert_mov_before_terminator(ctx, pred_mb,
-                    mir.op_vreg(dsts[j]), srcs[j]);
+                    mir.op_vreg(dsts[j]), srcs[j], wids[j]);
                 if (R.is_err[bool, str](mv)) { err_msg = R.unwrap_err[bool, str](mv); j = n; cnt; }
                 done[j] = true;
                 remaining = remaining - 1;
@@ -472,8 +484,10 @@ fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, sr
             val tr: R.Result[u32, str] = lctx.new_vreg(ctx, cls);
             if (R.is_err[u32, str](tr)) { err_msg = R.unwrap_err[u32, str](tr); cnt; }
             val tmp: u32 = R.unwrap_ok[u32, str](tr);
+            # the cycle-break save is a register-to-register copy of a live value,
+            # width-agnostic; carry the full register width.
             val sv: R.Result[bool, str] = insert_mov_before_terminator(ctx, pred_mb,
-                mir.op_vreg(tmp), mir.op_vreg(freed));
+                mir.op_vreg(tmp), mir.op_vreg(freed), ctx.tgt.model.gpr_width::u8);
             if (R.is_err[bool, str](sv)) { err_msg = R.unwrap_err[bool, str](sv); cnt; }
             var d: u32 = 0;
             for (d < n) {
@@ -522,8 +536,9 @@ fun dst_is_pending_src(dsts: *u32, srcs: *mir.MirOperand, done: *bool, n: u32, v
 # mb:  the block to splice into; must end in a terminator
 # dst: the move destination operand
 # src: the move source operand
+# wid: the value's logical width in bytes; consulted only for an immediate source
 # ret: true on success, or an allocation / lowering error
-fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand) R.Result[bool, str] {
+fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand, wid: u8) R.Result[bool, str] {
     if (mb.instr_count == 0) {
         ret R.err[bool, str]("mir.lower_ir: phi predecessor block has no terminator");
     }
@@ -538,19 +553,24 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
     ops[0] = dst;
     ops[1] = src;
     var mi: mir.MirInstr;
-    # a phi merge copy is normally a register-to-register / immediate move; the
-    # full-width move copies the value's low bits intact regardless of its logical
-    # width. but a global / function symbol incoming value is its ADDRESS as an
-    # rvalue: a mir.MIR_MOV of a symbol selects to `mov dst, [sym]` (loading the
-    # symbol's contents), so it is emitted as the address-computing mir.MIR_GEP
-    # (`lea dst, [sym]`) instead - the same LEA-materialization the store /
-    # call-arg / return symbol paths use.
+    # a global / function symbol incoming value is its ADDRESS as an rvalue: a
+    # mir.MIR_MOV of a symbol selects to `mov dst, [sym]` (loading the symbol's
+    # contents), so it is emitted as the address-computing mir.MIR_GEP (`lea dst,
+    # [sym]`) instead - the same LEA-materialization the store / call-arg / return
+    # symbol paths use.
     mi.opcode        = mir.MIR_MOV;
     if (src.kind == mir.MIR_OP_SYM) { mi.opcode = mir.MIR_GEP; }
     mi.operands      = ops;
     mi.operand_count = 2;
+    # a register / symbol source transfers a value already in its target-canonical
+    # register form, so a full-width bit copy is width-agnostic and correct. an
+    # immediate source is a MATERIALIZATION of a constant: it must carry the value's
+    # logical width so the encoder canonicalizes it (e.g. sign-extends a negative
+    # i32 to the lp64 register convention) rather than emitting a wrong-width bit
+    # pattern a later full-width signed op would misread.
     mi.width         = ctx.tgt.model.gpr_width::u8;
     mi.src_width     = ctx.tgt.model.gpr_width::u8;
+    if (src.kind == mir.MIR_OP_IMM) { mi.width = wid; mi.src_width = wid; }
     # this splice bypasses lctx.push_instr, so enforce the asm_block invariant here:
     # struct locals are not zero-initialized, and regalloc.flatten reads a non-nil
     # asm_block as an inline-asm clobber barrier.

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -526,6 +526,18 @@ fun dst_is_pending_src(dsts: *u32, srcs: *mir.MirOperand, done: *bool, n: u32, v
     ret false;
 }
 
+# the width to materialize an immediate phi-merge source into a GP register. a
+# 32-bit constant rides a width-4 move so the backend re-signs it to its register
+# convention (riscv64 lp64 holds an i32 sign-extended, re-signed from the width);
+# every other width keeps the full gpr-width move, since a sub-32 store leaves a
+# target's upper register bits unspecified (an x86 `mov al` does not clear them) and
+# a 64-bit value is already register-width. mirrors mir.abi.scalar_reg_move_width,
+# which clamps argument / return materialization the same way.
+fun imm_merge_width(ctx: *lctx.LowerCtx, wid: u8) u8 {
+    if (wid == 4) { ret 4; }
+    ret ctx.tgt.model.gpr_width::u8;
+}
+
 # splice a `mir.MIR_MOV (dst) <- (src)` just before a block's terminator
 #
 # A block that is a phi predecessor ends in a branch terminator (the last
@@ -564,13 +576,17 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
     mi.operand_count = 2;
     # a register / symbol source transfers a value already in its target-canonical
     # register form, so a full-width bit copy is width-agnostic and correct. an
-    # immediate source is a MATERIALIZATION of a constant: it must carry the value's
-    # logical width so the encoder canonicalizes it (e.g. sign-extends a negative
-    # i32 to the lp64 register convention) rather than emitting a wrong-width bit
-    # pattern a later full-width signed op would misread.
+    # immediate source is a MATERIALIZATION of a constant, materialized at
+    # `imm_merge_width`: a 32-bit constant rides a width-4 move so the backend
+    # re-signs it to its register convention (riscv64 lp64 holds an i32
+    # sign-extended), while every other width keeps the full-register move.
     mi.width         = ctx.tgt.model.gpr_width::u8;
     mi.src_width     = ctx.tgt.model.gpr_width::u8;
-    if (src.kind == mir.MIR_OP_IMM) { mi.width = wid; mi.src_width = wid; }
+    if (src.kind == mir.MIR_OP_IMM) {
+        val iw: u8 = imm_merge_width(ctx, wid);
+        mi.width     = iw;
+        mi.src_width = iw;
+    }
     # this splice bypasses lctx.push_instr, so enforce the asm_block invariant here:
     # struct locals are not zero-initialized, and regalloc.flatten reads a non-nil
     # asm_block as an inline-asm clobber barrier.

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -3336,3 +3336,43 @@ test "mach.lang.be.codegen.regalloc.is_dead_mov:physical_dest_and_read_guards" {
 
     ret 0;
 }
+
+# drive the full allocator over a multi-block function whose GP values live across
+# block boundaries, then read the result. a loop back edge plus an if/else keep
+# `a`, `b`, and `acc` live across edges, and `b < 0` is a signed compare of a
+# loop-carried value whose entry edge is the negative i32 constant `-7`. that
+# entry value reaches the merge as a phi immediate; on riscv64 it must be
+# materialized sign-extended to the lp64 register convention or the full-register
+# `slt` reads it positive and the first iteration takes the wrong arm (#1851).
+# built into the qemu riscv64 unit lane, this exercises the produced multi-block
+# code the miscompile corrupted, which the helper-level allocator tests never did.
+test "mach.lang.be.codegen.regalloc.cross_block_liveness:1851" {
+    var i:   i32 = 0;
+    var a:   i32 = 3;
+    var b:   i32 = -7;
+    var acc: i32 = 0;
+    for (i < 6) {
+        if (b < 0) { acc = acc + a; } or { acc = acc - a; }
+        b   = b + 1;
+        a   = a + 2;
+        i   = i + 1;
+    }
+    if (acc != 48) { ret 1; }
+    ret 0;
+}
+
+# a negative i32 constant reaching a signed compare through a phi - the branch
+# merge of `v`. the phi's constant edge (`-1`) must materialize at the value's
+# logical width so riscv64 sign-extends it to the lp64 register convention;
+# otherwise the full-register `slt` reads `-1` as a large positive and `v < 0` is
+# false (#1851). `probe` is loop-derived so the branch and its phi survive to -O2
+# instead of folding to a constant.
+test "mach.lang.be.codegen.regalloc.phi_neg_i32_signed_compare:1851" {
+    var probe: i32 = 0;
+    var i:     i32 = 0;
+    for (i < 5) { probe = probe + i; i = i + 1; }
+    var v: i32 = -1;
+    if (probe > 100) { v = probe; }
+    if (v < 0) { ret 0; }
+    ret 1;
+}


### PR DESCRIPTION
Fixes the riscv64 backend miscompiling the compiler's own cross-block liveness code, which blocked riscv64 self-host (#1742): a riscv64-hosted `mach` aborted in its own register allocator with `regalloc: GP vreg assigned a non-GP register` whenever it compiled a function carrying a value across a basic-block boundary.

## Root cause
Out-of-SSA phi destruction (`src/lang/be/codegen/mir/lower.mach`) spliced every phi merge copy at full register width (`gpr_width`). That is correct for a register/symbol source — a bit copy of a value already in its target-canonical register form is width-agnostic — but wrong for an **immediate** source, which is a *materialization* of a constant. The encoder canonicalizes an immediate by its operand width (riscv64 sign-extends a negative i32 to the lp64 "i32 held sign-extended in a 64-bit register" convention via `imm_sext_for_width`, which only re-signs width 4). A full-width (8) move left a negative i32 phi constant un-sign-extended, and RISC-V's 64-bit `slt` then read it as a large positive.

Concretely, `regalloc.mach`'s allocation loop does `var preg: i32 = -1; if (hint) { preg = pick_hint(...); } if (preg < 0) { preg = pick_gp(...); }`. The `-1` initializer flows through a phi; on riscv64 `preg < 0` read false, so `pick_gp` was skipped and the `-1` no-register sentinel reached `assign`, which rejected it as a bad register class.

IR / riscv64 asm of the minimal repro:
```
%23 = phi i32 [bb1 %11, bb2 4294967295]
cmp_lt_s i8 %23, 0
```
```
mv a1, 4294967295      # -1 materialized as 0x00000000FFFFFFFF (not sign-extended)
cmp.lt_s a0, a1, 0     # 64-bit slt reads +4294967295 -> false
```
The riscv64 encoder is **correct**; the shared phi-lowering fed it the wrong width. x86-64 was masked because its i32 signed compare selects a width-aware 32-bit instruction. Full investigation: #1851 (issuecomment-4871748567).

## Fix
Carry each phi merge copy's logical width (`op_width_of(phi.ty)`) and apply it to **immediate sources only**; register/symbol copies stay full-width. The immediate/register split is semantic: a register copy transfers an already-canonical value, an immediate source materializes a constant that needs its logical width to be canonicalized.

## Sibling-site sweep
Swept every MIR site that materializes an immediate into a register. All other width-sensitive sites (call-argument setup, scalar returns, spilled register pieces) already carry the value's logical width via `emit_mov_w` / `scalar_reg_move_width`; address materializations correctly stay full-width; immediate stores are safe (truncate + width-aware reload). The phi merge move was the sole defect of this class. Details in the sweep comment below.

## Tests
Two produced-code regression tests in `regalloc.mach`, runnable on every lane including the qemu riscv64 unit lane:
- `cross_block_liveness:1851` — a multi-block function carrying GP values across a loop back edge and an if/else, with a signed compare of a loop-carried negative i32.
- `phi_neg_i32_signed_compare:1851` — the minimal shape; a loop-derived `probe` keeps the branch/phi from folding to -O2.

Both **fail** when built for riscv64 by a pre-fix compiler (run under qemu) and **pass** post-fix; both pass natively — i.e. validated to actually catch the defect.

## Verification
- x86_64 self-host fixpoint: stage2 == stage3 byte-identical (no host regression).
- Full unit suite: 477 passed native, 477 passed riscv64-under-qemu.
- int matrix: linux and linux-riscv64 legs all pass (arm64/windows/darwin run on their CI runners); arm64 codegen smoke-tested locally under qemu-aarch64.
- #1742 self-host chain attempt under qemu: reported in a comment.

Closes #1851
