### PR TITLE
chore(deps): bump mach-std to main @ 5588e17b

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "40a8ab5a58c37ba5f8998fc05fe8b8036d2a5a3d"
+commit = "5588e17b0511b9c17710dfc4ded25c882ed821ef"


### PR DESCRIPTION
Picks up mach-std's release PR #357: fatal RELRO re-protection (#347, part C of the RELRO end-state with #1844/#1845), json decode accessor + float parsing (#340/#349), arm64 CI lane (#280).