### PR TITLE
feat(isa): per-ISA DWARF + CodeView register-number tables

### DIFF
--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -306,6 +306,33 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 # opcode: the concrete post-selection opcode to classify
 pub def IsRegMoveFn: fun(u32) bool;
 
+# the concrete signature the erased `IsaVTable.dwarf_reg` pointer is cast back to
+#
+# Maps a physical encoder register id - a composite `regid` (the class tag in the
+# high byte, the within-bank index in the low byte, as `regid_make` builds) - to
+# its DWARF register number, the numbering the `DW_OP_reg*` / `DW_OP_breg*` /
+# `DW_OP_regx` / `DW_OP_bregx` variable locations and `DW_AT_frame_base` name. The
+# DWARF numbering is ISA-specific and distinct from the encoder's physical ids
+# (x86-64 in particular permutes the low eight general-purpose registers), so a
+# debug-info producer that is format-agnostic but not ISA-agnostic reads it through
+# this hook instead of branching on the arch. Returns -1 for a register id the ISA
+# assigns no DWARF number.
+# ---
+# regid: the composite physical register id to map
+pub def DwarfRegFn: fun(i32) i32;
+
+# the concrete signature the erased `IsaVTable.cv_reg` pointer is cast back to
+#
+# Maps a physical encoder register id (a composite `regid`, as `DwarfRegFn` takes)
+# to its CodeView register number - the `CV_HREG_e` enumerator a COFF/CodeView
+# debug record names a register with. The numbering is ISA-specific (x86-64's
+# `CV_AMD64_*`); only a Windows-capable ISA wires it and one with no CodeView
+# numbering leaves `cv_reg` nil. Returns -1 for a register id the ISA assigns no
+# CodeView number.
+# ---
+# regid: the composite physical register id to map
+pub def CvRegFn: fun(i32) i32;
+
 # the ISA runtime-dispatch interface
 #
 # Exactly one of these exists per architecture; the backend reads pointer width,
@@ -392,6 +419,18 @@ pub def IsRegMoveFn: fun(u32) bool;
 #                       ISA-string section into objects and executables so external
 #                       tools decode the full instruction set; nil leaves the
 #                       section absent, the same way a nil `elf_reloc_type` is no map
+# dwarf_reg:            erased fn ptr - map a physical register id to its DWARF
+#                       register number (cast back to `DwarfRegFn`), the
+#                       ISA-specific numbering the `DW_OP_reg*` / `DW_OP_breg*`
+#                       variable locations use; the frame register's DWARF number,
+#                       which `DW_AT_frame_base` / `DW_OP_fbreg` need, is
+#                       `dwarf_reg(frame_ptr_reg)`. nil when the ISA wires no DWARF
+#                       register table, which a debug-info producer treats as an
+#                       ISA with no location support
+# cv_reg:               erased fn ptr - map a physical register id to its CodeView
+#                       register number (cast back to `CvRegFn`); nil for an ISA
+#                       with no CodeView numbering (only the Windows-capable x86-64
+#                       wires it), the CodeView analogue of a nil `elf_reloc_type`
 # reserved_regs:        registers the allocator must never assign (stack/frame
 #                       pointers); owned by the per-arch impl for the process
 #                       lifetime
@@ -446,6 +485,8 @@ pub rec IsaVTable {
     apply_reloc:          *u8;
     elf_reloc_type:       *u8;
     elf_attributes:       *u8;
+    dwarf_reg:            *u8;
+    cv_reg:               *u8;
     reserved_regs:        *Register;
     reserved_reg_count:   i32;
     reload_scratch_regs:  *Register;

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -79,6 +79,42 @@ fun arm64_elf_reloc_type(kind: of.RelocKind) u32 {
     ret 0;
 }
 
+# the DWARF register number of the first SIMD/FP register (V0)
+#
+# "DWARF for the Arm 64-bit Architecture (AArch64)" numbers V0..V31 contiguously
+# from 64, so V<n> is `DWARF_V0 + n`.
+val DWARF_V0: i32 = 64;
+
+# map a physical aarch64 register id to its DWARF register number
+#
+# The aarch64 half of the per-ISA DWARF register seam (#1693): a debug-info producer
+# reads it through `IsaVTable.dwarf_reg` so DWARF variable locations and
+# `DW_AT_frame_base` name aarch64's DWARF numbers. The numbering is "DWARF for the
+# Arm 64-bit Architecture (AArch64)", section 4.1: X0..X30 map identically to 0..30,
+# the stack pointer (id 31) is 31, and the SIMD/FP registers V0..V31 map to 64..95.
+# The frame pointer x29 is 29 and the link register x30 (the return address) is 30.
+# ---
+# regid: composite physical register id (class tag in the high byte, index low)
+# ret:   the DWARF register number, or -1 for an id aarch64 assigns no number
+fun arm64_dwarf_reg(regid: i32) i32 {
+    val cls: i32 = isa.regid_class(regid);
+    val idx: i32 = isa.regid_index(regid);
+
+    if (cls == isa.REG_CLASS_ID_GP) {
+        # X0..X30 -> 0..30 and SP (31) -> 31, all identity
+        if (idx >= arm64.X0 && idx <= arm64.SP) { ret idx; }
+        ret -1;
+    }
+
+    if (cls == isa.REG_CLASS_ID_XMM) {
+        # V0..V31 -> 64..95
+        if (idx >= arm64.V0 && idx <= arm64.V31) { ret DWARF_V0 + idx; }
+        ret -1;
+    }
+
+    ret -1;
+}
+
 # build and install the AArch64 ISA vtable
 #
 # Sets the architecture and register-class names, fills the three register classes
@@ -144,6 +180,11 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_vtable.name                 = "aarch64";
     arm64_vtable.elf_machine          = 183;  # EM_AARCH64
     arm64_vtable.elf_reloc_type       = arm64_elf_reloc_type::*u8;
+    # the per-ISA DWARF register map (#1693), inert until a debug-info producer
+    # consumes it. aarch64 has no CodeView numbering wired (Windows-on-ARM's
+    # CV_ARM64_* is out of scope), so cv_reg stays nil.
+    arm64_vtable.dwarf_reg            = arm64_dwarf_reg::*u8;
+    arm64_vtable.cv_reg               = nil;
     arm64_vtable.pointer_width        = 8;
     arm64_vtable.reg_classes          = ?arm64_classes[0];
     arm64_vtable.reg_class_count      = 3;
@@ -241,5 +282,29 @@ test "mach.lang.target.isa.arm64.register.arm64_elf_reloc_type:forward_map" {
     if (arm64_elf_reloc_type(of.RK_GOTPCREL) != 0) { ret 1; }
     if (arm64_elf_reloc_type(of.RK_ABS32S)   != 0) { ret 1; }
     if (arm64_elf_reloc_type(of.RK_ADDR32NB) != 0) { ret 1; }
+    ret 0;
+}
+
+# arm64_dwarf_reg reproduces the AArch64 DWARF numbering: X0..X30 and SP map
+# identically (0..31) and V0..V31 map to 64..95. The frame pointer x29 (29), link
+# register x30 (30), and stack pointer sp (31) are the load-bearing entries a DWARF
+# frame base and call-frame table name.
+test "mach.lang.target.isa.arm64.register.arm64_dwarf_reg:aapcs64_numbers" {
+    if (arm64_dwarf_reg(arm64.X0)  != 0)  { ret 1; }
+    if (arm64_dwarf_reg(arm64.X1)  != 1)  { ret 1; }
+    if (arm64_dwarf_reg(arm64.X29) != 29) { ret 1; }
+    if (arm64_dwarf_reg(arm64.X30) != 30) { ret 1; }
+    if (arm64_dwarf_reg(arm64.SP)  != 31) { ret 1; }
+
+    # the frame pointer (x29) is what DW_AT_frame_base names
+    if (arm64_dwarf_reg(arm64.FP) != 29) { ret 1; }
+    if (arm64_dwarf_reg(arm64.LR) != 30) { ret 1; }
+
+    # V0..V31 are composite ids (the vector class tag in the high byte) -> 64..95
+    if (arm64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, arm64.V0))  != 64) { ret 1; }
+    if (arm64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, arm64.V31)) != 95) { ret 1; }
+
+    # an id aarch64 assigns no DWARF number returns -1
+    if (arm64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_GP, 32))  != -1) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -113,6 +113,42 @@ fun riscv64_elf_attributes() *elf.BuildAttributes {
     ret ?riscv64_attrs;
 }
 
+# the DWARF register number of the first floating-point register (f0)
+#
+# the RISC-V ELF psABI numbers the F/D registers f0..f31 contiguously from 32, so
+# f<n> is `DWARF_F0 + n`.
+val DWARF_F0: i32 = 32;
+
+# map a physical riscv64 register id to its DWARF register number
+#
+# The riscv64 half of the per-ISA DWARF register seam (#1693): a debug-info producer
+# reads it through `IsaVTable.dwarf_reg` so DWARF variable locations and
+# `DW_AT_frame_base` name riscv64's DWARF numbers. The numbering is the RISC-V ELF
+# psABI "DWARF Register Numbers" table: the integer registers x0..x31 map identically
+# to 0..31 and the floating-point registers f0..f31 map to 32..63. The frame pointer
+# s0/fp is x8 (8), the return address ra is x1 (1), and the stack pointer sp is x2 (2).
+# ---
+# regid: composite physical register id (class tag in the high byte, index low)
+# ret:   the DWARF register number, or -1 for an id riscv64 assigns no number
+fun riscv64_dwarf_reg(regid: i32) i32 {
+    val cls: i32 = isa.regid_class(regid);
+    val idx: i32 = isa.regid_index(regid);
+
+    if (cls == isa.REG_CLASS_ID_GP) {
+        # x0..x31 -> 0..31, identity
+        if (idx >= riscv64.X0 && idx <= riscv64.X31) { ret idx; }
+        ret -1;
+    }
+
+    if (cls == isa.REG_CLASS_ID_XMM) {
+        # f0..f31 -> 32..63
+        if (idx >= riscv64.F0 && idx <= riscv64.F31) { ret DWARF_F0 + idx; }
+        ret -1;
+    }
+
+    ret -1;
+}
+
 # build and install the RV64 ISA vtable
 #
 # Sets the architecture and register-class names, fills the two register classes
@@ -175,6 +211,11 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_vtable.name                 = "riscv64";
     riscv64_vtable.elf_machine          = 243;  # EM_RISCV
     riscv64_vtable.elf_reloc_type       = riscv64_elf_reloc_type::*u8;
+    # the per-ISA DWARF register map (#1693), inert until a debug-info producer
+    # consumes it. riscv64 has no CodeView numbering (no Windows target), so cv_reg
+    # stays nil.
+    riscv64_vtable.dwarf_reg            = riscv64_dwarf_reg::*u8;
+    riscv64_vtable.cv_reg               = nil;
 
     # the ELF build-attributes descriptor: the writer stamps a `.riscv.attributes`
     # ISA-string section from it so external tools decode imafd with no manual
@@ -314,5 +355,28 @@ test "mach.lang.target.isa.riscv64.register.register_riscv64:build_attributes" {
     if (!str_equals(attr.vendor, "riscv"))              { ret 1; }
     if (attr.arch_tag != elf.TAG_RISCV_ARCH)            { ret 1; }
     if (!str_equals(attr.arch, RISCV64_ARCH_STRING))    { ret 1; }
+    ret 0;
+}
+
+# riscv64_dwarf_reg reproduces the RISC-V psABI DWARF numbering: the integer
+# registers x0..x31 map identically (0..31) and the float registers f0..f31 map to
+# 32..63. The frame pointer s0/fp (x8 -> 8), return address ra (x1 -> 1), and stack
+# pointer sp (x2 -> 2) are the load-bearing entries a DWARF frame base names.
+test "mach.lang.target.isa.riscv64.register.riscv64_dwarf_reg:psabi_numbers" {
+    if (riscv64_dwarf_reg(riscv64.X0)  != 0)  { ret 1; }
+    if (riscv64_dwarf_reg(riscv64.RA)  != 1)  { ret 1; }
+    if (riscv64_dwarf_reg(riscv64.SP)  != 2)  { ret 1; }
+    if (riscv64_dwarf_reg(riscv64.FP)  != 8)  { ret 1; }
+    if (riscv64_dwarf_reg(riscv64.X31) != 31) { ret 1; }
+
+    # the frame pointer s0/fp (x8) is what DW_AT_frame_base names
+    if (riscv64_dwarf_reg(riscv64.FRAME_REG) != 8) { ret 1; }
+
+    # f0..f31 are composite ids (the float class tag in the high byte) -> 32..63
+    if (riscv64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, riscv64.F0))  != 32) { ret 1; }
+    if (riscv64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, riscv64.F31)) != 63) { ret 1; }
+
+    # an id riscv64 assigns no DWARF number returns -1
+    if (riscv64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_GP, 32)) != -1) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -76,6 +76,102 @@ fun x64_elf_reloc_type(kind: of.RelocKind) u32 {
     ret 0;
 }
 
+# the DWARF register number of the first XMM register (XMM0)
+#
+# the System V AMD64 psABI numbers XMM0..XMM15 contiguously from 17 (Figure 3.36),
+# so XMM<n> is `DWARF_XMM0 + n`.
+val DWARF_XMM0: i32 = 17;
+
+# the CodeView CV_AMD64_* register enumerators (Microsoft's `CV_HREG_e` from
+# cvconst.h, as mirrored by LLVM's `llvm/include/llvm/DebugInfo/CodeView/CodeView.h`
+# `enum class RegisterId`). Only the anchors the mapping derives from are named: the
+# 64-bit GP registers occupy one contiguous block in CodeView's own register order
+# (RAX, RBX, RCX, RDX, RSI, RDI, RBP, RSP, R8..R15) starting at CV_AMD64_RAX, and
+# the 128-bit XMM registers split into two blocks, XMM0..XMM7 and XMM8..XMM15.
+val CV_AMD64_RAX:  i32 = 328;  # first 64-bit GP register, in CodeView order (not encoder order)
+val CV_AMD64_XMM0: i32 = 154;  # first of the XMM0..XMM7 block
+val CV_AMD64_XMM8: i32 = 252;  # first of the XMM8..XMM15 block
+
+# map a physical x86-64 register id to its DWARF register number
+#
+# The x86-64 half of the per-ISA DWARF register seam (#1693): a debug-info producer
+# reads it through `IsaVTable.dwarf_reg` so DWARF variable locations and
+# `DW_AT_frame_base` name the ISA's DWARF numbers rather than the encoder's physical
+# ids. The numbering is the System V AMD64 psABI "DWARF Register Number Mapping"
+# (Figure 3.36): the low eight GP registers are PERMUTED away from their ModRM/REX
+# ids (rax=0, rdx=1, rcx=2, rbx=3, rsi=4, rdi=5, rbp=6, rsp=7), R8..R15 map
+# identically (8..15), and XMM0..XMM15 map to 17..32. The frame pointer rbp is 6.
+# ---
+# regid: composite physical register id (class tag in the high byte, index low)
+# ret:   the DWARF register number, or -1 for an id x86-64 assigns no number
+fun x64_dwarf_reg(regid: i32) i32 {
+    val cls: i32 = isa.regid_class(regid);
+    val idx: i32 = isa.regid_index(regid);
+
+    if (cls == isa.REG_CLASS_ID_GP) {
+        if (idx == x64.RAX) { ret 0; }
+        if (idx == x64.RDX) { ret 1; }
+        if (idx == x64.RCX) { ret 2; }
+        if (idx == x64.RBX) { ret 3; }
+        if (idx == x64.RSI) { ret 4; }
+        if (idx == x64.RDI) { ret 5; }
+        if (idx == x64.RBP) { ret 6; }
+        if (idx == x64.RSP) { ret 7; }
+        # R8..R15 (physical 8..15) carry the same DWARF number as their id
+        if (idx >= x64.R8 && idx <= x64.R15) { ret idx; }
+        ret -1;
+    }
+
+    if (cls == isa.REG_CLASS_ID_XMM) {
+        # XMM0..XMM15 -> 17..32
+        if (idx >= x64.XMM0 && idx <= x64.XMM15) { ret DWARF_XMM0 + idx; }
+        ret -1;
+    }
+
+    ret -1;
+}
+
+# map a physical x86-64 register id to its CodeView register number
+#
+# The x86-64 half of the per-ISA CodeView register seam (#1693): the COFF/CodeView
+# producer reads it through `IsaVTable.cv_reg` so CodeView debug records name the
+# ISA's `CV_AMD64_*` numbers. The 64-bit GP registers sit in one contiguous
+# CodeView block from CV_AMD64_RAX in CodeView's own order (rax, rbx, rcx, rdx, rsi,
+# rdi, rbp, rsp, r8..r15) - a different order from both the encoder ids and the
+# DWARF numbering - so the low eight map by name and R8..R15 (whose CodeView ordinal
+# 8..15 equals their encoder id) fold into the block arithmetic. The 128-bit XMM
+# registers split into two blocks, XMM0..XMM7 at CV_AMD64_XMM0 and XMM8..XMM15 at
+# CV_AMD64_XMM8. The frame pointer rbp is CV_AMD64_RBP (334).
+# ---
+# regid: composite physical register id (class tag in the high byte, index low)
+# ret:   the CodeView register number, or -1 for an id x86-64 assigns no number
+fun x64_cv_reg(regid: i32) i32 {
+    val cls: i32 = isa.regid_class(regid);
+    val idx: i32 = isa.regid_index(regid);
+
+    if (cls == isa.REG_CLASS_ID_GP) {
+        if (idx == x64.RAX) { ret CV_AMD64_RAX + 0; }
+        if (idx == x64.RBX) { ret CV_AMD64_RAX + 1; }
+        if (idx == x64.RCX) { ret CV_AMD64_RAX + 2; }
+        if (idx == x64.RDX) { ret CV_AMD64_RAX + 3; }
+        if (idx == x64.RSI) { ret CV_AMD64_RAX + 4; }
+        if (idx == x64.RDI) { ret CV_AMD64_RAX + 5; }
+        if (idx == x64.RBP) { ret CV_AMD64_RAX + 6; }
+        if (idx == x64.RSP) { ret CV_AMD64_RAX + 7; }
+        # R8..R15 (encoder id 8..15) share the CodeView ordinal 8..15
+        if (idx >= x64.R8 && idx <= x64.R15) { ret CV_AMD64_RAX + idx; }
+        ret -1;
+    }
+
+    if (cls == isa.REG_CLASS_ID_XMM) {
+        if (idx >= x64.XMM0 && idx <= x64.XMM7)  { ret CV_AMD64_XMM0 + idx; }
+        if (idx >= x64.XMM8 && idx <= x64.XMM15) { ret CV_AMD64_XMM8 + (idx - x64.XMM8); }
+        ret -1;
+    }
+
+    ret -1;
+}
+
 # build and install the x86-64 ISA vtable
 #
 # sets the architecture and register-class names as immutable `str` constants,
@@ -138,6 +234,11 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_vtable.name                 = "x86_64";
     x64_vtable.elf_machine          = 62;  # EM_X86_64
     x64_vtable.elf_reloc_type       = x64_elf_reloc_type::*u8;
+    # per-ISA debug-info register maps: x86-64 owns both a DWARF and a CodeView
+    # numbering (the only shipped ISA Windows targets). inert until a debug-info
+    # producer consumes them (#1704/#1705/#1712).
+    x64_vtable.dwarf_reg            = x64_dwarf_reg::*u8;
+    x64_vtable.cv_reg               = x64_cv_reg::*u8;
     x64_vtable.pointer_width        = 8;
     x64_vtable.reg_classes          = ?x64_classes[0];
     x64_vtable.reg_class_count      = 3;
@@ -220,5 +321,65 @@ test "mach.lang.target.isa.x64.register.x64_elf_reloc_type:forward_map" {
     # a kind x86_64 has no ELF type for maps to 0, the writer's unsupported signal.
     if (x64_elf_reloc_type(of.RK_ADDR32NB) != 0) { ret 1; }
     if (x64_elf_reloc_type(of.RK_PAGE21)   != 0) { ret 1; }
+    ret 0;
+}
+
+# x64_dwarf_reg reproduces the System V AMD64 psABI DWARF numbering (Figure 3.36):
+# the low eight GP registers are permuted away from their encoder ids, R8..R15 map
+# identically, and XMM0..XMM15 map to 17..32. The stack pointer rsp (7) and frame
+# pointer rbp (6) are the load-bearing entries a DWARF frame base names.
+test "mach.lang.target.isa.x64.register.x64_dwarf_reg:psabi_numbers" {
+    if (x64_dwarf_reg(x64.RAX) != 0) { ret 1; }
+    if (x64_dwarf_reg(x64.RDX) != 1) { ret 1; }
+    if (x64_dwarf_reg(x64.RCX) != 2) { ret 1; }
+    if (x64_dwarf_reg(x64.RBX) != 3) { ret 1; }
+    if (x64_dwarf_reg(x64.RSI) != 4) { ret 1; }
+    if (x64_dwarf_reg(x64.RDI) != 5) { ret 1; }
+    if (x64_dwarf_reg(x64.RBP) != 6) { ret 1; }
+    if (x64_dwarf_reg(x64.RSP) != 7) { ret 1; }
+    if (x64_dwarf_reg(x64.R8)  != 8) { ret 1; }
+    if (x64_dwarf_reg(x64.R15) != 15) { ret 1; }
+
+    # the frame pointer's DWARF number is what DW_AT_frame_base names
+    if (x64_dwarf_reg(x64.FRAME_REG) != 6) { ret 1; }
+
+    # XMM0..XMM15 are composite ids (the SSE class tag in the high byte) -> 17..32
+    if (x64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, x64.XMM0))  != 17) { ret 1; }
+    if (x64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, x64.XMM15)) != 32) { ret 1; }
+
+    # an id x86-64 assigns no DWARF number returns -1
+    if (x64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_GP, 16))  != -1) { ret 1; }
+    if (x64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, 16)) != -1) { ret 1; }
+    ret 0;
+}
+
+# x64_cv_reg reproduces the CodeView CV_AMD64_* numbering (cvconst.h / LLVM
+# CodeView.h): the 64-bit GP registers sit in a contiguous block from 328 in
+# CodeView's own order, and XMM0..XMM7 / XMM8..XMM15 map to 154..161 / 252..259.
+# The stack pointer rsp (335) and frame pointer rbp (334) are the load-bearing
+# entries a CodeView frame record names.
+test "mach.lang.target.isa.x64.register.x64_cv_reg:cvconst_numbers" {
+    if (x64_cv_reg(x64.RAX) != 328) { ret 1; }
+    if (x64_cv_reg(x64.RBX) != 329) { ret 1; }
+    if (x64_cv_reg(x64.RCX) != 330) { ret 1; }
+    if (x64_cv_reg(x64.RDX) != 331) { ret 1; }
+    if (x64_cv_reg(x64.RSI) != 332) { ret 1; }
+    if (x64_cv_reg(x64.RDI) != 333) { ret 1; }
+    if (x64_cv_reg(x64.RBP) != 334) { ret 1; }
+    if (x64_cv_reg(x64.RSP) != 335) { ret 1; }
+    if (x64_cv_reg(x64.R8)  != 336) { ret 1; }
+    if (x64_cv_reg(x64.R15) != 343) { ret 1; }
+
+    # the frame pointer's CodeView number is what a frame record names
+    if (x64_cv_reg(x64.FRAME_REG) != 334) { ret 1; }
+
+    # the two XMM blocks: XMM0..XMM7 = 154..161, XMM8..XMM15 = 252..259
+    if (x64_cv_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, x64.XMM0))  != 154) { ret 1; }
+    if (x64_cv_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, x64.XMM7))  != 161) { ret 1; }
+    if (x64_cv_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, x64.XMM8))  != 252) { ret 1; }
+    if (x64_cv_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, x64.XMM15)) != 259) { ret 1; }
+
+    # an id x86-64 assigns no CodeView number returns -1
+    if (x64_cv_reg(isa.regid_make(isa.REG_CLASS_ID_GP, 16)) != -1) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
## What

Adds the per-ISA mapping from physical encoder register ids to debug-format register numbers, one table per shipped ISA, homed on the `IsaVTable` per the retargeting philosophy (the register analogue of `elf_reloc_type` / `elf_attributes`):

- **DWARF register numbers** for x86-64, aarch64, and riscv64 (`DW_OP_reg*` / `DW_OP_breg*` locations and `DW_AT_frame_base`), reached through the new `IsaVTable.dwarf_reg` erased fn-ptr hook (`DwarfRegFn`).
- **CodeView `CV_AMD64_*` numbers** for x86-64, reached through `IsaVTable.cv_reg` (`CvRegFn`). aarch64/riscv64 leave `cv_reg` nil (no CodeView target), the analogue of a nil `elf_reloc_type`.

The frame-pointer register number each ISA exposes (rbp / x29 / s0) is `dwarf_reg(frame_ptr_reg)`, asserted per ISA in the unit tests.

A debug-info producer that is format-agnostic but **not** ISA-agnostic reads the numbering through these hooks instead of branching on the arch id — the piece #1704/#1705 (DWARF) and #1712 (CodeView) block on.

## Sources cited (in the doc comments)

Silent wrong numbers break debuggers quietly, so each table cites its authoritative ABI:

- **x86-64 DWARF** — System V AMD64 psABI, Figure 3.36 "DWARF Register Number Mapping" (the low eight GP registers are permuted away from their ModRM/REX ids; XMM0..15 → 17..32).
- **x86-64 CodeView** — Microsoft `cvconst.h` `CV_HREG_e`, mirrored by LLVM `DebugInfo/CodeView/CodeView.h` `enum class RegisterId` (GP block from 328 in CodeView order; XMM0..7 → 154..161, XMM8..15 → 252..259).
- **aarch64 DWARF** — "DWARF for the Arm 64-bit Architecture (AArch64)", §4.1 (X0..X30 = 0..30, SP = 31, V0..V31 = 64..95).
- **riscv64 DWARF** — RISC-V ELF psABI "DWARF Register Numbers" (x0..x31 = 0..31, f0..f31 = 32..63).

## Inert data

The tables are inert until an emitter consumes them — nothing in the codegen/emit path reads the new hooks yet, so all build output stays byte-identical.

- self-host fixpoint converges (`b == c`)
- **non-debug byte-compare vs a dev-baseline compiler**: my compiler building the untouched baseline tree reproduces the baseline fixpoint binary byte-for-byte (`sha256 a15b6791…`)
- unit suite: 505 passed / 0 failed (baseline 501 + 4 new tests pinning rsp/rbp/sp/fp/ra + arg/FP registers per ISA)
- integration suite: all cases pass on the linux leg

Closes #1693.