### PR TITLE
chore(deps): bump mach-std to main @ 24ff7774 (arm64 RELRO fix)

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "ca870b611a9564db75c00532da8044ca9ae31514"
+commit = "24ff77742a572c135a338234672bb195013b4c5c"


### PR DESCRIPTION
Picks up mach-std release PR #361: the #1885 runtime fix — RELRO re-protect extent from the mapped PT_LOAD rounded to AT_PAGESZ. Expected to turn the int linux-arm64 lane green again (pie-reloc / pie-relro-fault).