### PR TITLE
chore(ir): central IR mutation API (replace/erase/clone) + pass migration

### DIFF
--- a/src/lang/me/ir/mutate.mach
+++ b/src/lang/me/ir/mutate.mach
@@ -1,0 +1,278 @@
+# post-construction IR mutation primitives.
+#
+# `builder.mach` creates IR; this module transforms it after the fact. The two are
+# distinct lifecycle surfaces, so the shared mutation API the optimization passes
+# consume lives here rather than on the construction cursor.
+#
+# Three primitives, each the single place its kind of mutation happens so that
+# source-location (and, with debug info, OP_DBG_VALUE) maintenance is an invariant
+# of the primitive instead of a concern re-solved in every pass:
+#
+#   - value replacement (RAUW): a batched `Rewrite` map for the passes that record
+#     many substitutions then apply once (cse, algebraic, constfold, mem2reg), plus
+#     `replace_uses` for a single immediate replacement (inline).
+#   - erasure: `erase_instruction`, the one point an instruction leaves a block.
+#   - cloning: `clone_instruction`, a faithful per-instruction copy.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+
+use A: std.allocator;
+use R: std.types.result;
+
+use mach.lang.me.ir;
+use mach.lang.me.ir.id;
+use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.value;
+
+# a batched value-replacement map (RAUW) over one function's instruction pool
+#
+# Records that an instruction's result is superseded by another Value, indexed by
+# instruction id, then rewrites every operand naming a replaced instruction to its
+# replacement in a single transitive pass. This is the one shared substitution
+# facility the value-optimization passes (cse, algebraic, constfold, mem2reg) build
+# on instead of each carrying a private copy.
+#
+# The map is acyclic: a replacement never (transitively) names the instruction it
+# replaces, so `rewrite_resolve` terminates; the hop bound is a guard only.
+# ---
+# vals: replacement Value per instruction id, meaningful where live[iid] is set
+# live: whether vals[iid] holds a recorded replacement
+# len:  number of instruction slots (the function's instr_len at init)
+pub rec Rewrite {
+    vals: *value.Value;
+    live: *bool;
+    len:  u32;
+}
+
+# allocate and clear a rewrite map sized to `len` instruction slots
+# ---
+# rw:  the map to initialize in place
+# a:   allocator backing both arrays
+# len: number of instruction slots (the function's instr_len)
+# ret: ok(true) on success, or an allocation error
+pub fun rewrite_init(rw: *Rewrite, a: *A.Allocator, len: u32) R.Result[bool, str] {
+    val res_vals: R.Result[*value.Value, str] = A.allocate[value.Value](a, len::usize);
+    if (R.is_err[*value.Value, str](res_vals)) {
+        ret R.err[bool, str](R.unwrap_err[*value.Value, str](res_vals));
+    }
+    val res_live: R.Result[*bool, str] = A.allocate[bool](a, len::usize);
+    if (R.is_err[*bool, str](res_live)) {
+        A.deallocate[value.Value](a, R.unwrap_ok[*value.Value, str](res_vals), len::usize);
+        ret R.err[bool, str](R.unwrap_err[*bool, str](res_live));
+    }
+
+    rw.vals = R.unwrap_ok[*value.Value, str](res_vals);
+    rw.live = R.unwrap_ok[*bool, str](res_live);
+    rw.len  = len;
+
+    var i: u32 = 0;
+    for (i < len) { rw.live[i] = false; i = i + 1; }
+    ret R.ok[bool, str](true);
+}
+
+# free a rewrite map's arrays and zero it
+# ---
+# rw: the map to tear down
+# a:  the allocator the arrays were taken from
+pub fun rewrite_dnit(rw: *Rewrite, a: *A.Allocator) {
+    if (rw.vals != nil && rw.len > 0) { A.deallocate[value.Value](a, rw.vals, rw.len::usize); }
+    if (rw.live != nil && rw.len > 0) { A.deallocate[bool](a, rw.live, rw.len::usize); }
+    rw.vals = nil;
+    rw.live = nil;
+    rw.len  = 0;
+}
+
+# record that instruction `iid`'s result is replaced by value `v` (RAUW)
+#
+# The replacement is not applied to operands until `rewrite_apply`; recording only
+# updates the map, so matching that resolves operands through the map (a pass
+# driving itself to a fixpoint) sees the replacement immediately.
+# ---
+# rw:  the map to record into
+# iid: the instruction whose result is superseded
+# v:   the value its uses resolve to
+pub fun replace_value(rw: *Rewrite, iid: id.InstructionId, v: value.Value) {
+    rw.vals[iid::u32] = v;
+    rw.live[iid::u32] = true;
+}
+
+# whether instruction `iid` has a recorded replacement
+# ---
+# rw:  the map to query
+# iid: the instruction id to test
+# ret: true when a replacement was recorded for iid
+pub fun rewrite_has(rw: *Rewrite, iid: id.InstructionId) bool {
+    val idx: u32 = iid::u32;
+    ret idx < rw.len && rw.live[idx];
+}
+
+# resolve a value through the map, following replacement chains transitively
+#
+# A VAL_INSTR naming a replaced instruction becomes its replacement, followed
+# again if that too was replaced, up to `len` hops (an acyclicity guard). A
+# non-instruction (or unreplaced) value passes through. The result always carries
+# the original value's type, so a replacement flowing into a differently-typed use
+# slot keeps that slot's type (the aggregate-pointer identity mem2reg relies on).
+# ---
+# rw: the map to resolve through
+# v:  the value to resolve
+# ret: the transitive replacement, retyped to v's type
+pub fun rewrite_resolve(rw: *Rewrite, v: value.Value) value.Value {
+    var cur:  value.Value = v;
+    var hops: u32         = 0;
+    for (cur.kind == value.VAL_INSTR && hops <= rw.len) {
+        val iid: u32 = cur.data.instr::u32;
+        if (iid >= rw.len || rw.live[iid] == false) { ret value.retype(cur, v.ty); }
+        cur  = rw.vals[iid];
+        hops = hops + 1;
+    }
+    ret value.retype(cur, v.ty);
+}
+
+# rewrite every operand naming a replaced instruction to its resolved replacement,
+# across every instruction in the function's pool
+#
+# Only VAL_INSTR operands with a live replacement are touched, resolved
+# transitively so a chain of replacements collapses fully. Block-target operands
+# ride in VAL_CONST_INT slots and so are never rewritten.
+# ---
+# fn: the function whose operands are rewritten in place
+# rw: the populated rewrite map to apply
+pub fun rewrite_apply(fn: *ir.Function, rw: *Rewrite) {
+    var i: u32 = 0;
+    for (i < fn.instr_len) {
+        val inst: *instruction.Instruction = ?fn.instrs[i];
+        var ii: u32 = 0;
+        for (ii < inst.operand_count) {
+            val op: value.Value = inst.operands[ii];
+            if (op.kind == value.VAL_INSTR) {
+                val iid: u32 = op.data.instr::u32;
+                if (iid < rw.len && rw.live[iid]) {
+                    inst.operands[ii] = rewrite_resolve(rw, op);
+                }
+            }
+            ii = ii + 1;
+        }
+        i = i + 1;
+    }
+}
+
+# replace every operand of `fn` naming instruction `old_id` with `replacement`,
+# immediately (a single un-batched RAUW)
+#
+# The immediate counterpart to the `Rewrite` map: used where exactly one value is
+# replaced (inlining wires a call result to its return value) and a batched map
+# would be overkill. Block-target operands ride in VAL_CONST_INT slots, so the
+# VAL_INSTR guard already skips them.
+# ---
+# fn:          the function whose operands are rewritten in place
+# old_id:      the value-producing instruction id being replaced
+# replacement: the value to substitute in
+pub fun replace_uses(fn: *ir.Function, old_id: id.InstructionId, replacement: value.Value) {
+    var i: u32 = 0;
+    for (i < fn.instr_len) {
+        val inst: *instruction.Instruction = ?fn.instrs[i];
+        var ii: u32 = 0;
+        for (ii < inst.operand_count) {
+            val op: value.Value = inst.operands[ii];
+            if (op.kind == value.VAL_INSTR && op.data.instr == old_id) {
+                inst.operands[ii] = replacement;
+            }
+            ii = ii + 1;
+        }
+        i = i + 1;
+    }
+}
+
+# erase instruction `iid` from block `blk` -- the one point an instruction leaves
+# a block's lists
+#
+# CONTRACT (load-bearing): every removal of an instruction from a block MUST route
+# through this primitive; no pass may compact a block's instruction or phi list
+# privately. Debug info depends on it -- this is where #1696 salvages the
+# dbg-values of a value about to disappear -- and there is no back-pointer from an
+# instruction to its owning block, so the invariant cannot be asserted
+# mechanically. It is held by convention; #1696's dbg-value tests will expose any
+# pass that bypasses it. The caller passes the block it is already walking rather
+# than have this rediscover it by scanning, keeping erasure O(list) and honoring
+# the IR's block-owns-membership model.
+#
+# The instruction is unlinked from `blk`'s phi and instruction lists; its pool
+# entry remains as a ghost, reclaimed at function teardown. The relative order of
+# the surviving entries is preserved.
+# ---
+# blk: the block to remove iid from (supplied by the walking caller)
+# iid: the instruction id to erase
+pub fun erase_instruction(blk: *ir.Block, iid: id.InstructionId) {
+    var w: u32 = 0;
+    var r: u32 = 0;
+    for (r < blk.instr_count) {
+        if (blk.instructions[r] != iid) {
+            blk.instructions[w] = blk.instructions[r];
+            w = w + 1;
+        }
+        r = r + 1;
+    }
+    blk.instr_count = w;
+
+    w = 0;
+    r = 0;
+    for (r < blk.phi_count) {
+        if (blk.phis[r] != iid) {
+            blk.phis[w] = blk.phis[r];
+            w = w + 1;
+        }
+        r = r + 1;
+    }
+    blk.phi_count = w;
+}
+
+# clone instruction `src` into `dst_fn`'s pool and return the new instruction's id
+#
+# Copies the opcode, result / auxiliary types, modifier flags, source location,
+# and a fresh copy of the operand array. Operand Values are copied verbatim; a
+# caller remapping ids across functions (inlining) rewrites them afterward. loc
+# and the flag word ride along, so a clone is a faithful copy the debug info
+# treats as the same source position.
+# ---
+# m:      module owning the allocator
+# dst_fn: the function whose pool receives the clone
+# src:    the instruction to clone (from any function)
+# ret:    the new instruction's id, or an allocation error
+pub fun clone_instruction(m: *ir.Module, dst_fn: *ir.Function, src: *instruction.Instruction) R.Result[id.InstructionId, str] {
+    var clone: instruction.Instruction;
+    clone.kind          = src.kind;
+    clone.ty            = src.ty;
+    clone.operand_count = src.operand_count;
+    clone.operand_cap   = src.operand_count;   # instruction_add normalizes cap to count
+    clone.flags         = src.flags;
+    clone.aux_ty        = src.aux_ty;
+    clone.loc           = src.loc;
+    clone.operands      = nil;
+    if (src.operand_count > 0) {
+        val res_ops: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, src.operand_count::usize);
+        if (R.is_err[*value.Value, str](res_ops)) {
+            ret R.err[id.InstructionId, str](R.unwrap_err[*value.Value, str](res_ops));
+        }
+        val ops: *value.Value = R.unwrap_ok[*value.Value, str](res_ops);
+        var i: u32 = 0;
+        for (i < src.operand_count) {
+            ops[i] = src.operands[i];
+            i = i + 1;
+        }
+        clone.operands = ops;
+    }
+
+    val res_id: R.Result[id.InstructionId, str] = ir.instruction_add(m, dst_fn, clone);
+    if (R.is_err[id.InstructionId, str](res_id)) {
+        if (clone.operands != nil) {
+            A.deallocate[value.Value](m.alloc, clone.operands, src.operand_count::usize);
+        }
+        ret res_id;
+    }
+    ret res_id;
+}

--- a/src/lang/me/pass/algebraic.mach
+++ b/src/lang/me/pass/algebraic.mach
@@ -7,12 +7,12 @@
 # this pass simplifies an expression one of whose operands is a constant
 # identity element, or whose two operands are the same SSA value.
 #
-# The mechanism mirrors constfold's substitution table (see `SubTable`). For each
-# instruction a replacement Value may be recorded (instruction id -> Value);
-# `subtable_apply` then rewrites every operand naming a simplified instruction to
-# its replacement, and the now-dead instructions are left for dce. Because a
-# replacement can itself name an instruction result, the table is iterated to a
-# fixpoint so a chain collapses.
+# The mechanism uses the shared `mutate.Rewrite` map. For each instruction a
+# replacement Value may be recorded (instruction id -> Value); `rewrite_apply`
+# then rewrites every operand naming a simplified instruction to its replacement,
+# and the now-dead instructions are left for dce. Because a replacement can itself
+# name an instruction result, the table is iterated to a fixpoint so a chain
+# collapses.
 #
 # CORRECTNESS CONTRACT: every rewrite must preserve the exact runtime value for
 # all operand values. The pass is INTEGER-ONLY where float semantics differ:
@@ -53,26 +53,10 @@ use R: std.types.result;
 
 use mach.lang.intern;
 use mach.lang.me.ir;
+use mach.lang.me.ir.mutate;
 use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
-
-# per-instruction substitution table built during one function's simplification
-#
-# Maps an instruction id to the Value that replaces its result. `has` marks which
-# ids carry a live substitution; `subst[id]` is meaningful only where `has[id]`
-# is true. Both arrays are `len` long and indexed by instruction id. The table
-# owns the two arrays via the module allocator; `subtable_init` / `subtable_dnit`
-# bracket its lifetime.
-# ---
-# subst: replacement Value per instruction id
-# has:   liveness flag per instruction id
-# len:   instruction count, the length of both arrays
-rec SubTable {
-    subst: *value.Value;
-    has:   *bool;
-    len:   u32;
-}
 
 # run the pass over every non-extern function in the module in place
 # ---
@@ -108,16 +92,16 @@ fun simplify_function(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
         ret R.ok[bool, str](true);
     }
 
-    var st: SubTable;
-    val opt_err: O.Option[str] = subtable_init(?st, m.alloc, ilen);
-    if (O.is_some[str](opt_err)) {
-        ret R.err[bool, str](O.unwrap[str](opt_err));
+    var st: mutate.Rewrite;
+    val res_init: R.Result[bool, str] = mutate.rewrite_init(?st, m.alloc, ilen);
+    if (R.is_err[bool, str](res_init)) {
+        ret res_init;
     }
 
     simplify_to_fixpoint(m, fn, ?st);
-    subtable_apply(?st, fn);
+    mutate.rewrite_apply(fn, ?st);
 
-    subtable_dnit(?st, m.alloc);
+    mutate.rewrite_dnit(?st, m.alloc);
     ret R.ok[bool, str](true);
 }
 
@@ -130,19 +114,18 @@ fun simplify_function(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
 # m:  module owning the function's type state
 # fn: function whose instructions are simplified
 # st: substitution table to populate
-fun simplify_to_fixpoint(m: *ir.Module, fn: *ir.Function, st: *SubTable) {
+fun simplify_to_fixpoint(m: *ir.Module, fn: *ir.Function, st: *mutate.Rewrite) {
     var changed: bool = true;
     for (changed) {
         changed = false;
         var i: u32 = 0;
         for (i < st.len) {
-            if (st.has[i] == false) {
+            if (mutate.rewrite_has(st, i) == false) {
                 val inst: *instruction.Instruction = ?fn.instrs[i];
                 var out:  value.Value;
                 if (simplify_instruction(m, fn, inst, st, ?out)) {
-                    st.subst[i] = out;
-                    st.has[i]   = true;
-                    changed     = true;
+                    mutate.replace_value(st, i, out);
+                    changed = true;
                 }
             }
             i = i + 1;
@@ -163,7 +146,7 @@ fun simplify_to_fixpoint(m: *ir.Module, fn: *ir.Function, st: *SubTable) {
 # out:  receives the replacement Value on a successful rewrite
 # ret:  true when a rewrite fired and `out` was written
 fun simplify_instruction(m: *ir.Module, fn: *ir.Function, inst: *instruction.Instruction,
-                         st: *SubTable, out: *value.Value) bool {
+                         st: *mutate.Rewrite, out: *value.Value) bool {
     val k: instruction.InstrKind = inst.kind;
 
     # unary double negation: -(-x) -> x, ~(~x) -> x. integer only; float negation
@@ -172,7 +155,7 @@ fun simplify_instruction(m: *ir.Module, fn: *ir.Function, inst: *instruction.Ins
         if (is_int(m, inst.ty) == false) {
             ret false;
         }
-        val a: value.Value = subtable_resolve(st, inst.operands[0]);
+        val a: value.Value = mutate.rewrite_resolve(st, inst.operands[0]);
         if (a.kind != value.VAL_INSTR) {
             ret false;
         }
@@ -184,7 +167,7 @@ fun simplify_instruction(m: *ir.Module, fn: *ir.Function, inst: *instruction.Ins
         # the inner op must be the same negation and integer-typed; its operand is
         # then the original value, returned with this result's type.
         if (inner.kind == k && inner.operand_count == 1 && is_int(m, inner.ty)) {
-            val src: value.Value = subtable_resolve(st, inner.operands[0]);
+            val src: value.Value = mutate.rewrite_resolve(st, inner.operands[0]);
             @out = value.retype(src, inst.ty);
             ret true;
         }
@@ -196,8 +179,8 @@ fun simplify_instruction(m: *ir.Module, fn: *ir.Function, inst: *instruction.Ins
         if (is_int(m, inst.ty) == false) {
             ret false;
         }
-        val a: value.Value = subtable_resolve(st, inst.operands[0]);
-        val b: value.Value = subtable_resolve(st, inst.operands[1]);
+        val a: value.Value = mutate.rewrite_resolve(st, inst.operands[0]);
+        val b: value.Value = mutate.rewrite_resolve(st, inst.operands[1]);
         ret simplify_binary(m, k, a, b, inst.ty, out);
     }
 
@@ -307,102 +290,6 @@ fun simplify_binary(m: *ir.Module, k: instruction.InstrKind, a: value.Value, b: 
         ret false;
     }
     ret false;
-}
-
-# initialize a substitution table backed by allocator `a`
-#
-# Allocates the `subst` and `has` arrays sized to `len` and clears every
-# liveness flag. On the second allocation failing, the first array is released so
-# nothing leaks.
-# ---
-# st:  table to initialize in place
-# a:   allocator backing both arrays
-# len: instruction count, the length of both arrays
-# ret: some(err) on an allocation failure, none on success
-fun subtable_init(st: *SubTable, a: *A.Allocator, len: u32) O.Option[str] {
-    val res_subst: R.Result[*value.Value, str] = A.allocate[value.Value](a, len::usize);
-    if (R.is_err[*value.Value, str](res_subst)) {
-        ret O.some[str](R.unwrap_err[*value.Value, str](res_subst));
-    }
-    val res_has: R.Result[*bool, str] = A.allocate[bool](a, len::usize);
-    if (R.is_err[*bool, str](res_has)) {
-        A.deallocate[value.Value](a, R.unwrap_ok[*value.Value, str](res_subst), len::usize);
-        ret O.some[str](R.unwrap_err[*bool, str](res_has));
-    }
-
-    st.subst = R.unwrap_ok[*value.Value, str](res_subst);
-    st.has   = R.unwrap_ok[*bool, str](res_has);
-    st.len   = len;
-
-    var i: u32 = 0;
-    for (i < len) {
-        st.has[i] = false;
-        i = i + 1;
-    }
-    ret O.none[str]();
-}
-
-# release a substitution table's arrays and reset it to a clean slate
-# ---
-# st: table to tear down in place
-# a:  allocator the arrays were taken from
-fun subtable_dnit(st: *SubTable, a: *A.Allocator) {
-    A.deallocate[value.Value](a, st.subst, st.len::usize);
-    A.deallocate[bool](a, st.has, st.len::usize);
-    st.subst = nil;
-    st.has   = nil;
-    st.len   = 0;
-}
-
-# resolve an operand through the substitution table, following chains
-#
-# A VAL_INSTR naming a simplified instruction becomes that instruction's
-# replacement; if the replacement also names a simplified instruction it is
-# followed again, up to `st.len` hops (the table is acyclic, so the bound is a
-# guard only). A non-instruction operand passes through unchanged. The result
-# always carries the original operand's type.
-# ---
-# st:  table to resolve through
-# v:   operand to resolve
-# ret: the operand's transitive replacement, retyped to v's type
-fun subtable_resolve(st: *SubTable, v: value.Value) value.Value {
-    var cur:  value.Value = v;
-    var hops: u32         = 0;
-    for (cur.kind == value.VAL_INSTR && hops <= st.len) {
-        val iid: u32 = cur.data.instr::u32;
-        if (iid >= st.len || st.has[iid] == false) {
-            ret value.retype(cur, v.ty);
-        }
-        cur  = st.subst[iid];
-        hops = hops + 1;
-    }
-    ret value.retype(cur, v.ty);
-}
-
-# rewrite every function operand naming a simplified instruction to its replacement
-#
-# Operands are resolved transitively (via `subtable_resolve`) so a chain of
-# simplifications collapses fully.
-# ---
-# st: populated substitution table to apply
-# fn: function whose operands are rewritten in place
-fun subtable_apply(st: *SubTable, fn: *ir.Function) {
-    var i: u32 = 0;
-    for (i < fn.instr_len) {
-        val inst: *instruction.Instruction = ?fn.instrs[i];
-        var ii: u32 = 0;
-        for (ii < inst.operand_count) {
-            val op: value.Value = inst.operands[ii];
-            if (op.kind == value.VAL_INSTR) {
-                val iid: u32 = op.data.instr::u32;
-                if (iid < st.len && st.has[iid]) {
-                    inst.operands[ii] = subtable_resolve(st, op);
-                }
-            }
-            ii = ii + 1;
-        }
-        i = i + 1;
-    }
 }
 
 # test whether a resolved operand is the integer constant 0

--- a/src/lang/me/pass/constfold.mach
+++ b/src/lang/me/pass/constfold.mach
@@ -53,6 +53,7 @@ use mach.lang.me.ir;
 use mach.lang.me.ir.builder;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.mutate;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 
@@ -76,10 +77,10 @@ pub fun run(m: *ir.Module) R.Result[bool, str] {
 
 # folds one function to a local fixpoint, then propagates and simplifies branches.
 #
-# A per-instruction substitution table maps a folded instruction id to the
-# constant Value it produces; has_sub marks the live entries. Folding repeats
-# until no new instruction folds, then the substitutions are applied to every
-# operand and constant-condition branches are simplified.
+# The shared rewrite map records each folded instruction id -> the constant Value
+# it produces. Folding repeats until no new instruction folds, then the recorded
+# replacements are applied to every operand and constant-condition branches are
+# simplified.
 # ---
 # m:   module owning the function and the allocator
 # fn:  function to fold in place
@@ -88,93 +89,45 @@ fun fold_function(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
     val ilen: u32 = fn.instr_len;
     if (ilen == 0) { ret R.ok[bool, str](true); }
 
-    val res_subst: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, ilen::usize);
-    if (R.is_err[*value.Value, str](res_subst)) {
-        ret R.err[bool, str](R.unwrap_err[*value.Value, str](res_subst));
-    }
-    val subst: *value.Value = R.unwrap_ok[*value.Value, str](res_subst);
+    var rw: mutate.Rewrite;
+    val res_init: R.Result[bool, str] = mutate.rewrite_init(?rw, m.alloc, ilen);
+    if (R.is_err[bool, str](res_init)) { ret res_init; }
 
-    val res_has_sub: R.Result[*bool, str] = A.allocate[bool](m.alloc, ilen::usize);
-    if (R.is_err[*bool, str](res_has_sub)) {
-        A.deallocate[value.Value](m.alloc, subst, ilen::usize);
-        ret R.err[bool, str](R.unwrap_err[*bool, str](res_has_sub));
-    }
-    val has_sub: *bool = R.unwrap_ok[*bool, str](res_has_sub);
+    fold_to_fixpoint(m, fn, ?rw);
+    mutate.rewrite_apply(fn, ?rw);
+    val res_branches: R.Result[bool, str] = simplify_branches(m, fn, ?rw);
 
-    var i: u32 = 0;
-    for (i < ilen) {
-        has_sub[i] = false;
-        i = i + 1;
-    }
-
-    fold_to_fixpoint(m, fn, subst, has_sub, ilen);
-    apply_substitutions(fn, subst, has_sub, ilen);
-    val res_branches: R.Result[bool, str] = simplify_branches(m, fn, subst, has_sub, ilen);
-
-    A.deallocate[value.Value](m.alloc, subst, ilen::usize);
-    A.deallocate[bool](m.alloc, has_sub, ilen::usize);
+    mutate.rewrite_dnit(?rw, m.alloc);
     ret res_branches;
 }
 
 # sweeps the instruction pool, folding every instruction whose operands resolve
 # to constants, until a sweep folds nothing.
 #
-# Each fold records its result in subst/has_sub. Because operands are resolved
-# through the table, folding one instruction exposes any later op that consumed
-# it, so a chain like `(2 + 3) * 4` collapses across successive sweeps.
+# Each fold records its result in the rewrite map. Because operands are resolved
+# through the map, folding one instruction exposes any later op that consumed it,
+# so a chain like `(2 + 3) * 4` collapses across successive sweeps.
 # ---
-# m:       module owning the function
-# fn:      function whose instructions are folded
-# subst:   per-instruction substitution table, indexed by instruction id
-# has_sub: per-instruction flag marking a live substitution
-# ilen:    length of subst/has_sub and the instruction pool
-fun fold_to_fixpoint(m: *ir.Module, fn: *ir.Function,
-                     subst: *value.Value, has_sub: *bool, ilen: u32) {
+# m:  module owning the function
+# fn: function whose instructions are folded
+# rw: shared rewrite map each fold is recorded into
+fun fold_to_fixpoint(m: *ir.Module, fn: *ir.Function, rw: *mutate.Rewrite) {
     var changed: bool = true;
     for (changed) {
         changed = false;
         var i: u32 = 0;
-        for (i < ilen) {
-            if (has_sub[i] == false) {
+        for (i < rw.len) {
+            if (mutate.rewrite_has(rw, i) == false) {
                 val inst: *instruction.Instruction = ?fn.instrs[i];
                 var out: value.Value;
-                if (try_fold(m, inst, i, subst, has_sub, ilen, ?out)) {
-                    subst[i]   = out;
-                    has_sub[i] = true;
-                    changed    = true;
+                if (try_fold(m, inst, i, rw, ?out)) {
+                    mutate.replace_value(rw, i, out);
+                    changed = true;
                 }
             }
             i = i + 1;
         }
     }
-}
-
-# resolves an operand through the substitution table, following chains.
-#
-# A VAL_INSTR naming a folded instruction becomes that instruction's folded
-# value, followed again when that value itself names a folded instruction (so a
-# phi of a folded value collapses to the underlying constant in one resolve). The
-# operand's own carried type is preserved, so a fold feeding a differently-typed
-# slot keeps the slot's type. The hop count is bounded by ilen as a guard; the
-# table is acyclic in practice.
-# ---
-# v:       operand value to resolve
-# subst:   substitution table
-# has_sub: live-substitution flags
-# ilen:    table length and hop bound
-# ret:     the resolved value, carrying v's original type
-fun resolve(v: value.Value, subst: *value.Value, has_sub: *bool, ilen: u32) value.Value {
-    var cur:  value.Value = v;
-    var hops: u32         = 0;
-    for (cur.kind == value.VAL_INSTR && hops <= ilen) {
-        val iid: u32 = cur.data.instr::u32;
-        if (iid >= ilen || has_sub[iid] == false) {
-            ret value.retype(cur, v.ty);
-        }
-        cur  = subst[iid];
-        hops = hops + 1;
-    }
-    ret value.retype(cur, v.ty);
 }
 
 # attempts to fold one instruction to a constant value.
@@ -186,26 +139,24 @@ fun resolve(v: value.Value, subst: *value.Value, has_sub: *bool, ilen: u32) valu
 # m:       module owning the function
 # inst:    instruction to fold
 # self_id: inst's own id, used to ignore a phi's self-references
-# subst:   substitution table
-# has_sub: live-substitution flags
-# ilen:    table length
+# rw:      shared rewrite map operands are resolved through
 # out:     receives the folded value on success
 # ret:     true when a fold was produced
 fun try_fold(m: *ir.Module, inst: *instruction.Instruction, self_id: u32,
-             subst: *value.Value, has_sub: *bool, ilen: u32, out: *value.Value) bool {
+             rw: *mutate.Rewrite, out: *value.Value) bool {
     val k: instruction.InstrKind = inst.kind;
 
     # phi: collapse to the single value all its incomings resolve to.
     if (k == instruction.OP_PHI) {
-        ret fold_phi(inst, self_id, subst, has_sub, ilen, out);
+        ret fold_phi(inst, self_id, rw, out);
     }
 
     # binary ops [lhs, rhs]. the int and float arithmetic / comparison opcodes
     # overlap (one compare opcode rides both an int and a float compare), so the
     # int vs float path is chosen by the resolved operand kind, not the opcode.
     if ((is_int_binary(k) || is_float_binary(k)) && inst.operand_count == 2) {
-        val a: value.Value = resolve(inst.operands[0], subst, has_sub, ilen);
-        val b: value.Value = resolve(inst.operands[1], subst, has_sub, ilen);
+        val a: value.Value = mutate.rewrite_resolve(rw, inst.operands[0]);
+        val b: value.Value = mutate.rewrite_resolve(rw, inst.operands[1]);
         if (a.kind == value.VAL_CONST_INT && b.kind == value.VAL_CONST_INT && is_int_binary(k)) {
             ret fold_int_binary(m, k, a, b, inst.ty, out);
         }
@@ -217,7 +168,7 @@ fun try_fold(m: *ir.Module, inst: *instruction.Instruction, self_id: u32,
 
     # unary integer negation / not [operand].
     if ((k == instruction.OP_NEG || k == instruction.OP_NOT) && inst.operand_count == 1) {
-        val a: value.Value = resolve(inst.operands[0], subst, has_sub, ilen);
+        val a: value.Value = mutate.rewrite_resolve(rw, inst.operands[0]);
         if (a.kind == value.VAL_CONST_INT) {
             val bits: u32 = int_bits(m, inst.ty);
             if (bits == 0) { ret false; }
@@ -237,7 +188,7 @@ fun try_fold(m: *ir.Module, inst: *instruction.Instruction, self_id: u32,
 
     # integer width conversions [operand].
     if ((k == instruction.OP_TRUNC || k == instruction.OP_SEXT || k == instruction.OP_ZEXT) && inst.operand_count == 1) {
-        val a: value.Value = resolve(inst.operands[0], subst, has_sub, ilen);
+        val a: value.Value = mutate.rewrite_resolve(rw, inst.operands[0]);
         if (a.kind != value.VAL_CONST_INT) { ret false; }
         val src_bits: u32 = int_bits(m, a.ty);
         val dst_bits: u32 = int_bits(m, inst.ty);
@@ -264,18 +215,16 @@ fun try_fold(m: *ir.Module, inst: *instruction.Instruction, self_id: u32,
 # ---
 # inst:    the OP_PHI instruction
 # self_id: the phi's own id, whose self-referencing incomings are ignored
-# subst:   substitution table
-# has_sub: live-substitution flags
-# ilen:    table length
+# rw:      shared rewrite map incomings are resolved through
 # out:     receives the collapsed value on success
 # ret:     true when the phi collapsed to a single value
 fun fold_phi(inst: *instruction.Instruction, self_id: u32,
-             subst: *value.Value, has_sub: *bool, ilen: u32, out: *value.Value) bool {
+             rw: *mutate.Rewrite, out: *value.Value) bool {
     var have:   bool = false;
     var common: value.Value;
     var i: u32 = 1;                     # odd slots carry the incoming values
     for (i < inst.operand_count) {
-        val v: value.Value = resolve(inst.operands[i], subst, has_sub, ilen);
+        val v: value.Value = mutate.rewrite_resolve(rw, inst.operands[i]);
         val is_self: bool  = v.kind == value.VAL_INSTR && v.data.instr::u32 == self_id;
         if (is_self == false) {
             if (have == false) {
@@ -604,30 +553,6 @@ fun is_f64(m: *ir.Module, tid: type.IrTypeId) bool {
     ret t.data.bits == 64;
 }
 
-# rewrites every operand naming a folded instruction to its folded value,
-# following substitution chains so a fully resolved constant reaches each use.
-#
-# Operands that are not VAL_INSTR (constants, params, globals, branch-target
-# encodings) pass through unchanged, so branch targets riding as const_ints are
-# left intact.
-# ---
-# fn:      function whose operands are rewritten
-# subst:   substitution table
-# has_sub: live-substitution flags
-# ilen:    table length
-fun apply_substitutions(fn: *ir.Function, subst: *value.Value, has_sub: *bool, ilen: u32) {
-    var i: u32 = 0;
-    for (i < fn.instr_len) {
-        val inst: *instruction.Instruction = ?fn.instrs[i];
-        var ii: u32 = 0;
-        for (ii < inst.operand_count) {
-            inst.operands[ii] = resolve(inst.operands[ii], subst, has_sub, ilen);
-            ii = ii + 1;
-        }
-        i = i + 1;
-    }
-}
-
 # simplifies every OP_CBR whose condition folded to a constant into an OP_BR to
 # the statically-taken target.
 #
@@ -635,14 +560,11 @@ fun apply_substitutions(fn: *ir.Function, subst: *value.Value, has_sub: *bool, i
 # edge no longer exists are pruned, so the CFG stays consistent for dce's
 # reachability sweep and the verifier.
 # ---
-# m:       module owning the function
-# fn:      function to simplify in place
-# subst:   substitution table
-# has_sub: live-substitution flags
-# ilen:    table length
-# ret:     ok(true) on success, or the first allocation error from preds_rebuild
-fun simplify_branches(m: *ir.Module, fn: *ir.Function,
-                      subst: *value.Value, has_sub: *bool, ilen: u32) R.Result[bool, str] {
+# m:   module owning the function
+# fn:  function to simplify in place
+# rw:  shared rewrite map the folded condition is resolved through
+# ret: ok(true) on success, or the first allocation error from preds_rebuild
+fun simplify_branches(m: *ir.Module, fn: *ir.Function, rw: *mutate.Rewrite) R.Result[bool, str] {
     var rewrote: bool = false;
     var i: u32 = 0;
     for (i < fn.block_count) {
@@ -652,7 +574,7 @@ fun simplify_branches(m: *ir.Module, fn: *ir.Function,
             if (O.is_some[*instruction.Instruction](opt_term)) {
                 val term: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt_term);
                 if (term.kind == instruction.OP_CBR && term.operand_count == 3) {
-                    val cond: value.Value = resolve(term.operands[0], subst, has_sub, ilen);
+                    val cond: value.Value = mutate.rewrite_resolve(rw, term.operands[0]);
                     if (cond.kind == value.VAL_CONST_INT) {
                         # operand 1 is the then-target, operand 2 the else-target.
                         var taken: value.Value = term.operands[2];
@@ -848,8 +770,10 @@ test "mach.lang.me.pass.constfold.try_fold:int_conversions" {
     if (R.is_err[type.IrTypeId, str](res_i64)) { ret 1; }
     val i64ty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
 
-    var dummy_subst: value.Value;
-    var dummy_has_sub: bool = false;
+    # an empty rewrite map: the folded operands are constants, so resolution is a
+    # no-op and try_fold exercises only the conversion folding.
+    var rw: mutate.Rewrite;
+    if (R.is_err[bool, str](mutate.rewrite_init(?rw, ?alloc, 1))) { ret 1; }
     var out: value.Value;
 
     # sext(0xFF:i8)->i64 = 0xFFFFFFFFFFFFFFFF (sign bit set in 8-bit)
@@ -862,9 +786,9 @@ test "mach.lang.me.pass.constfold.try_fold:int_conversions" {
     sext_inst.operand_cap   = 1;
     sext_inst.flags         = 0;
     sext_inst.aux_ty        = type.IRT_NIL;
-    if (try_fold(?m, ?sext_inst, 0, ?dummy_subst, ?dummy_has_sub, 0, ?out) == false) { ret 1; }
-    if (out.kind != value.VAL_CONST_INT)                                             { ret 1; }
-    if (out.data.int_lit != 0xFFFFFFFFFFFFFFFF)                                      { ret 1; }
+    if (try_fold(?m, ?sext_inst, 0, ?rw, ?out) == false) { ret 1; }
+    if (out.kind != value.VAL_CONST_INT)                 { ret 1; }
+    if (out.data.int_lit != 0xFFFFFFFFFFFFFFFF)          { ret 1; }
 
     # zext(0xFF:i8)->i64 = 0xFF (zero-extends, no sign fill)
     var zext_inst: instruction.Instruction;
@@ -875,8 +799,8 @@ test "mach.lang.me.pass.constfold.try_fold:int_conversions" {
     zext_inst.operand_cap   = 1;
     zext_inst.flags         = 0;
     zext_inst.aux_ty        = type.IRT_NIL;
-    if (try_fold(?m, ?zext_inst, 0, ?dummy_subst, ?dummy_has_sub, 0, ?out) == false) { ret 1; }
-    if (out.data.int_lit != 0xFF)                                                    { ret 1; }
+    if (try_fold(?m, ?zext_inst, 0, ?rw, ?out) == false) { ret 1; }
+    if (out.data.int_lit != 0xFF)                        { ret 1; }
 
     # trunc(0x1FF:i64)->i8 = 0xFF (low 8 bits)
     var trunc_op: value.Value = value.const_int(0x1FF, i64ty);
@@ -888,8 +812,10 @@ test "mach.lang.me.pass.constfold.try_fold:int_conversions" {
     trunc_inst.operand_cap   = 1;
     trunc_inst.flags         = 0;
     trunc_inst.aux_ty        = type.IRT_NIL;
-    if (try_fold(?m, ?trunc_inst, 0, ?dummy_subst, ?dummy_has_sub, 0, ?out) == false) { ret 1; }
-    if (out.data.int_lit != 0xFF)                                                     { ret 1; }
+    if (try_fold(?m, ?trunc_inst, 0, ?rw, ?out) == false) { ret 1; }
+    if (out.data.int_lit != 0xFF)                         { ret 1; }
+
+    mutate.rewrite_dnit(?rw, ?alloc);
     ret 0;
 }
 
@@ -966,8 +892,9 @@ test "mach.lang.me.pass.constfold.fold_phi:collapse_and_distinct" {
     if (R.is_err[type.IrTypeId, str](res_ty)) { ret 1; }
     val ty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_ty);
 
-    var subst: value.Value;        # never dereferenced: no VAL_INSTR incomings
-    var has_sub: bool = false;
+    # an empty rewrite map: the incomings are constants, never resolved through it.
+    var rw: mutate.Rewrite;
+    if (R.is_err[bool, str](mutate.rewrite_init(?rw, ?alloc, 1))) { ret 1; }
     var out: value.Value;
 
     # single incoming 7 -> collapses to 7.
@@ -976,8 +903,8 @@ test "mach.lang.me.pass.constfold.fold_phi:collapse_and_distinct" {
     var ops1: [2]value.Value;
     var phi1: instruction.Instruction;
     build_const_phi(?phi1, ?ops1[0], ?v1[0], 1, ty);
-    if (fold_phi(?phi1, 0xFFFFFFFF, ?subst, ?has_sub, 1, ?out) == false) { ret 1; }
-    if (out.kind != value.VAL_CONST_INT || out.data.int_lit != 7)        { ret 1; }
+    if (fold_phi(?phi1, 0xFFFFFFFF, ?rw, ?out) == false)         { ret 1; }
+    if (out.kind != value.VAL_CONST_INT || out.data.int_lit != 7) { ret 1; }
 
     # two identical incomings (9, 9) -> collapses to 9.
     var v2: [2]value.Value;
@@ -986,12 +913,14 @@ test "mach.lang.me.pass.constfold.fold_phi:collapse_and_distinct" {
     var ops2: [4]value.Value;
     var phi2: instruction.Instruction;
     build_const_phi(?phi2, ?ops2[0], ?v2[0], 2, ty);
-    if (fold_phi(?phi2, 0xFFFFFFFF, ?subst, ?has_sub, 1, ?out) == false) { ret 1; }
-    if (out.data.int_lit != 9)                                           { ret 1; }
+    if (fold_phi(?phi2, 0xFFFFFFFF, ?rw, ?out) == false) { ret 1; }
+    if (out.data.int_lit != 9)                           { ret 1; }
 
     # distinct incomings (9, 5) -> not folded.
     v2[1] = value.const_int(5, ty);
     build_const_phi(?phi2, ?ops2[0], ?v2[0], 2, ty);
-    if (fold_phi(?phi2, 0xFFFFFFFF, ?subst, ?has_sub, 1, ?out)) { ret 1; }
+    if (fold_phi(?phi2, 0xFFFFFFFF, ?rw, ?out)) { ret 1; }
+
+    mutate.rewrite_dnit(?rw, ?alloc);
     ret 0;
 }

--- a/src/lang/me/pass/cse.mach
+++ b/src/lang/me/pass/cse.mach
@@ -45,24 +45,9 @@ use mach.lang.me.ir;
 use mach.lang.me.ir.builder;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.mutate;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
-
-# running substitution table mapping a redundant instruction to its canonical value
-#
-# Indexed by instruction id. An entry is live only where `live[iid]` is set; a
-# live entry's `vals[iid]` is the earlier, equal value the redundant
-# instruction's result is rewritten to. Owns both arrays, each sized to the
-# function's instruction count.
-# ---
-# vals: canonical Value per instruction id, valid where live[iid] is set
-# live: whether vals[iid] holds a recorded substitution
-# len:  number of instruction slots (the function's instr_len)
-rec Subst {
-    vals: *value.Value;
-    live: *bool;
-    len:  u32;
-}
 
 # per-block hash table of canonical CSE candidates
 #
@@ -120,16 +105,16 @@ fun cse_function(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
     val ilen: u32 = fn.instr_len;
     if (ilen == 0) { ret R.ok[bool, str](true); }
 
-    var subst: Subst;
-    val opt_subst: O.Option[str] = subst_init(?subst, m.alloc, ilen);
-    if (O.is_some[str](opt_subst)) {
-        ret R.err[bool, str](O.unwrap[str](opt_subst));
+    var subst: mutate.Rewrite;
+    val res_subst: R.Result[bool, str] = mutate.rewrite_init(?subst, m.alloc, ilen);
+    if (R.is_err[bool, str](res_subst)) {
+        ret res_subst;
     }
 
     var seen: SeenTable;
     val opt_seen: O.Option[str] = seen_init(?seen, m.alloc, ilen);
     if (O.is_some[str](opt_seen)) {
-        subst_dnit(?subst, m.alloc);
+        mutate.rewrite_dnit(?subst, m.alloc);
         ret R.err[bool, str](O.unwrap[str](opt_seen));
     }
 
@@ -140,10 +125,10 @@ fun cse_function(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
         if (cse_block(fn, ?fn.blocks[i], ?subst, ?seen)) { any = true; }
         i = i + 1;
     }
-    if (any) { apply_substitutions(fn, ?subst); }
+    if (any) { mutate.rewrite_apply(fn, ?subst); }
 
     seen_dnit(?seen, m.alloc);
-    subst_dnit(?subst, m.alloc);
+    mutate.rewrite_dnit(?subst, m.alloc);
     ret R.ok[bool, str](true);
 }
 
@@ -158,7 +143,7 @@ fun cse_function(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
 # subst: substitution table to record merges into
 # seen:  per-block candidate hash table, freshly invalidated for this block
 # ret:   true if any substitution was recorded
-fun cse_block(fn: *ir.Function, blk: *ir.Block, subst: *Subst, seen: *SeenTable) bool {
+fun cse_block(fn: *ir.Function, blk: *ir.Block, subst: *mutate.Rewrite, seen: *SeenTable) bool {
     var any: bool = false;
     var i: u32 = 0;
     for (i < blk.instr_count) {
@@ -178,7 +163,7 @@ fun cse_block(fn: *ir.Function, blk: *ir.Block, subst: *Subst, seen: *SeenTable)
                         val cand: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt_cand);
                         if (instrs_equal(inst, cand, subst)) {
                             # redundant: reuse the canonical candidate's result.
-                            subst_set(subst, iid, value.instr(cur, inst.ty));
+                            mutate.replace_value(subst, iid, value.instr(cur, inst.ty));
                             matched = true;
                             any     = true;
                         }
@@ -216,7 +201,7 @@ fun is_candidate(inst: *instruction.Instruction) bool {
 # inst:  candidate instruction
 # subst: substitution table used to resolve operands
 # ret:   the candidate's structural hash
-fun hash_candidate(inst: *instruction.Instruction, subst: *Subst) u64 {
+fun hash_candidate(inst: *instruction.Instruction, subst: *mutate.Rewrite) u64 {
     var h: u64 = fnv1a.FNV_INIT;
     h = fnv1a.step_u8(h, inst.kind::u8);
     h = fnv1a.step_u32(h, inst.flags::u32);
@@ -225,7 +210,7 @@ fun hash_candidate(inst: *instruction.Instruction, subst: *Subst) u64 {
     h = fnv1a.step_u32(h, inst.operand_count);
     var i: u32 = 0;
     for (i < inst.operand_count) {
-        h = hash_value(h, resolve(subst, inst.operands[i]));
+        h = hash_value(h, mutate.rewrite_resolve(subst, inst.operands[i]));
         i = i + 1;
     }
     ret h;
@@ -274,7 +259,7 @@ fun step_u64(h: u64, v: u64) u64 {
 # b:     second candidate
 # subst: substitution table used to resolve operands
 # ret:   true if a and b denote the same value
-fun instrs_equal(a: *instruction.Instruction, b: *instruction.Instruction, subst: *Subst) bool {
+fun instrs_equal(a: *instruction.Instruction, b: *instruction.Instruction, subst: *mutate.Rewrite) bool {
     if (a.kind          != b.kind)          { ret false; }
     if (a.flags         != b.flags)         { ret false; }
     if (a.ty            != b.ty)            { ret false; }
@@ -282,8 +267,8 @@ fun instrs_equal(a: *instruction.Instruction, b: *instruction.Instruction, subst
     if (a.operand_count != b.operand_count) { ret false; }
     var i: u32 = 0;
     for (i < a.operand_count) {
-        val va: value.Value = resolve(subst, a.operands[i]);
-        val vb: value.Value = resolve(subst, b.operands[i]);
+        val va: value.Value = mutate.rewrite_resolve(subst, a.operands[i]);
+        val vb: value.Value = mutate.rewrite_resolve(subst, b.operands[i]);
         if (values_equal(va, vb) == false) { ret false; }
         i = i + 1;
     }
@@ -320,52 +305,6 @@ fun values_equal(a: value.Value, b: value.Value) bool {
     ret false;
 }
 
-# resolve an operand through the substitution table, following chains
-#
-# A VAL_INSTR naming a CSE'd instruction becomes the canonical instruction's
-# result, followed again if that canonical was itself merged, up to `subst.len`
-# hops (the table is acyclic; the bound is a guard). Non-instruction operands pass
-# through unchanged. The result carries the original operand's type.
-# ---
-# subst: substitution table to follow
-# v:     operand value to resolve
-# ret:   the canonical value, retyped to v's type
-fun resolve(subst: *Subst, v: value.Value) value.Value {
-    var cur: value.Value = v;
-    var hops: u32 = 0;
-    for (cur.kind == value.VAL_INSTR && hops <= subst.len) {
-        val iid: u32 = cur.data.instr::u32;
-        if (iid >= subst.len || subst.live[iid] == false) { ret value.retype(cur, v.ty); }
-        cur  = subst.vals[iid];
-        hops = hops + 1;
-    }
-    ret value.retype(cur, v.ty);
-}
-
-# rewrite every operand naming a CSE'd instruction to its canonical result,
-# resolved transitively so a chain of merges collapses fully
-# ---
-# fn:    function whose instructions are rewritten in place
-# subst: substitution table recorded by the per-block passes
-fun apply_substitutions(fn: *ir.Function, subst: *Subst) {
-    var i: u32 = 0;
-    for (i < fn.instr_len) {
-        val inst: *instruction.Instruction = ?fn.instrs[i];
-        var ii: u32 = 0;
-        for (ii < inst.operand_count) {
-            val op: value.Value = inst.operands[ii];
-            if (op.kind == value.VAL_INSTR) {
-                val iid: u32 = op.data.instr::u32;
-                if (iid < subst.len && subst.live[iid]) {
-                    inst.operands[ii] = resolve(subst, op);
-                }
-            }
-            ii = ii + 1;
-        }
-        i = i + 1;
-    }
-}
-
 # smallest power of two >= n (at least 1)
 # ---
 # n:   minimum bucket count
@@ -374,55 +313,6 @@ fun round_pow2(n: u32) u32 {
     var p: u32 = 1;
     for (p < n) { p = p * 2; }
     ret p;
-}
-
-# allocate and clear a substitution table sized to `len` instruction slots
-# ---
-# s:   substitution table to initialize in place
-# a:   allocator backing both arrays
-# len: number of instruction slots
-# ret: none on success, or some(error) on allocation failure
-fun subst_init(s: *Subst, a: *A.Allocator, len: u32) O.Option[str] {
-    val res_vals: R.Result[*value.Value, str] = A.allocate[value.Value](a, len::usize);
-    if (R.is_err[*value.Value, str](res_vals)) {
-        ret O.some[str](R.unwrap_err[*value.Value, str](res_vals));
-    }
-
-    val res_live: R.Result[*bool, str] = A.allocate[bool](a, len::usize);
-    if (R.is_err[*bool, str](res_live)) {
-        A.deallocate[value.Value](a, R.unwrap_ok[*value.Value, str](res_vals), len::usize);
-        ret O.some[str](R.unwrap_err[*bool, str](res_live));
-    }
-
-    s.vals = R.unwrap_ok[*value.Value, str](res_vals);
-    s.live = R.unwrap_ok[*bool, str](res_live);
-    s.len  = len;
-
-    var i: u32 = 0;
-    for (i < len) { s.live[i] = false; i = i + 1; }
-    ret O.none[str]();
-}
-
-# free a substitution table's arrays and zero it
-# ---
-# s: substitution table to tear down
-# a: allocator the arrays were allocated from
-fun subst_dnit(s: *Subst, a: *A.Allocator) {
-    A.deallocate[value.Value](a, s.vals, s.len::usize);
-    A.deallocate[bool](a, s.live, s.len::usize);
-    s.vals = nil;
-    s.live = nil;
-    s.len  = 0;
-}
-
-# record that instruction `iid` is redundant and resolves to value `v`
-# ---
-# s:   substitution table to mutate
-# iid: the redundant instruction's id
-# v:   the canonical value it resolves to
-fun subst_set(s: *Subst, iid: id.InstructionId, v: value.Value) {
-    s.vals[iid::u32] = v;
-    s.live[iid::u32] = true;
 }
 
 # allocate and clear a candidate hash table for `len` instruction slots

--- a/src/lang/me/pass/dce.mach
+++ b/src/lang/me/pass/dce.mach
@@ -32,6 +32,7 @@ use mach.lang.me.ir;
 use mach.lang.me.ir.builder;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.mutate;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 
@@ -157,12 +158,34 @@ fun value_dce(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
         }
     }
 
-    # drop the dead instructions from each block's instruction and phi lists.
+    # drop the dead instructions from each block's phi and instruction lists,
+    # routing every removal through the shared erase primitive (no private
+    # compaction). erase removes in place, so a dead id is erased without
+    # advancing the cursor and the next survivor shifts into its slot.
     i = 0;
     for (i < fn.block_count) {
         val blk: *ir.Block = ?fn.blocks[i];
-        blk.instr_count = compact_ids(blk.instructions, blk.instr_count, dead, ilen);
-        blk.phi_count   = compact_ids(blk.phis, blk.phi_count, dead, ilen);
+
+        var pr: u32 = 0;
+        for (pr < blk.phi_count) {
+            val pid: id.InstructionId = blk.phis[pr];
+            if (pid::u32 < ilen && dead[pid::u32]) {
+                mutate.erase_instruction(blk, pid);
+            } or {
+                pr = pr + 1;
+            }
+        }
+
+        var r: u32 = 0;
+        for (r < blk.instr_count) {
+            val iid: id.InstructionId = blk.instructions[r];
+            if (iid::u32 < ilen && dead[iid::u32]) {
+                mutate.erase_instruction(blk, iid);
+            } or {
+                r = r + 1;
+            }
+        }
+
         i = i + 1;
     }
 
@@ -304,31 +327,6 @@ fun operand_instr_use(inst: *instruction.Instruction, o: u32, ilen: u32) O.Optio
     val def_id: u32 = op.data.instr::u32;
     if (def_id >= ilen) { ret O.none[u32](); }
     ret O.some[u32](def_id);
-}
-
-# compact an InstructionId list in place, dropping ids flagged dead
-#
-# An id outside the dead map's range is conservatively kept.
-# ---
-# ids:  the list to compact in place
-# len:  the list's current length
-# dead: per-instruction dead flags
-# ilen: the dead map's length (the in-range bound)
-# ret:  the compacted length
-fun compact_ids(ids: *id.InstructionId, len: u32, dead: *bool, ilen: u32) u32 {
-    var w: u32 = 0;
-    var r: u32 = 0;
-    for (r < len) {
-        val iid: id.InstructionId = ids[r];
-        var drop: bool = false;
-        if (iid::u32 < ilen) { drop = dead[iid::u32]; }
-        if (drop == false) {
-            ids[w] = iid;
-            w = w + 1;
-        }
-        r = r + 1;
-    }
-    ret w;
 }
 
 # reachability DCE for one function

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -32,6 +32,7 @@ use mach.lang.me.ir;
 use mach.lang.me.ir.builder;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.mutate;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.source;
@@ -592,32 +593,10 @@ fun clone_instructions(cx: *InlineCtx) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < callee.instr_len) {
         val src: *instruction.Instruction = ?callee.instrs[i];
-        var clone: instruction.Instruction;
-        clone.kind          = src.kind;
-        clone.ty            = src.ty;
-        clone.operand_count = src.operand_count;
-        clone.flags         = src.flags;
-        clone.aux_ty        = src.aux_ty;        # preserve GEP source pointee type
-        clone.loc           = src.loc;           # a faithful clone carries the source location
-        clone.operands      = nil;
-        if (src.operand_count > 0) {
-            val res_ops: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, src.operand_count::usize);
-            if (R.is_err[*value.Value, str](res_ops)) {
-                ret R.err[bool, str](R.unwrap_err[*value.Value, str](res_ops));
-            }
-            val ops: *value.Value = R.unwrap_ok[*value.Value, str](res_ops);
-            var ii: u32 = 0;
-            for (ii < src.operand_count) {
-                ops[ii] = src.operands[ii];
-                ii = ii + 1;
-            }
-            clone.operands = ops;
-        }
-        val res_id: R.Result[id.InstructionId, str] = ir.instruction_add(m, cx.caller, clone);
+        # operands are cloned verbatim here and remapped later by
+        # remap_clone_operands; loc and flags ride along via the primitive.
+        val res_id: R.Result[id.InstructionId, str] = mutate.clone_instruction(m, cx.caller, src);
         if (R.is_err[id.InstructionId, str](res_id)) {
-            if (clone.operands != nil) {
-                A.deallocate[value.Value](m.alloc, clone.operands, src.operand_count::usize);
-            }
             ret R.err[bool, str](R.unwrap_err[id.InstructionId, str](res_id));
         }
         cx.instr_map[i] = R.unwrap_ok[id.InstructionId, str](res_id)::u32;
@@ -937,13 +916,13 @@ fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) R.Result[bool, str
 
     # wire the call's result to the single return value or the result phi.
     if (returns_value && value_rets == 1 && have_single) {
-        replace_value_uses(caller, call_id, single_val);
+        mutate.replace_uses(caller, call_id, single_val);
     } or (returns_value && value_rets >= 2) {
         val cont: *ir.Block = ?caller.blocks[cx.cont_blk::u32];
         val res_append_phi: R.Result[bool, str] = ir.block_append_phi(m, cont, phi_id);
         if (R.is_err[bool, str](res_append_phi)) { ret res_append_phi; }
         val replacement: value.Value = value.instr(phi_id, cx.ret_type);
-        replace_value_uses(caller, call_id, replacement);
+        mutate.replace_uses(caller, call_id, replacement);
     }
 
     # the original call is already unlinked: it sat at call_ii, and
@@ -1029,32 +1008,6 @@ fun phi_append(cx: *InlineCtx, phi_id: id.InstructionId, pred: id.BlockId, v: va
         ret R.err[bool, str]("inline: phi id out of range");
     }
     ret ir.phi_append_incoming(cx.m, O.unwrap[*instruction.Instruction](opt_phi), pred, v);
-}
-
-# replace every VAL_INSTR operand naming `old_id` with `replacement`
-#
-# Walks all of the caller's instructions. Block-target operands are left
-# untouched (they never name a value result).
-# ---
-# caller:      function whose operands to rewrite
-# old_id:      the value-producing instruction id being replaced
-# replacement: the Value to substitute in
-fun replace_value_uses(caller: *ir.Function, old_id: id.InstructionId, replacement: value.Value) {
-    var i: u32 = 0;
-    for (i < caller.instr_len) {
-        val inst: *instruction.Instruction = ?caller.instrs[i];
-        var ii: u32 = 0;
-        for (ii < inst.operand_count) {
-            if (operand_is_block(inst.kind, ii) == false) {
-                val op: value.Value = inst.operands[ii];
-                if (op.kind == value.VAL_INSTR && op.data.instr == old_id) {
-                    inst.operands[ii] = replacement;
-                }
-            }
-            ii = ii + 1;
-        }
-        i = i + 1;
-    }
 }
 
 # the module's interned void IrTypeId

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -29,6 +29,7 @@ use mach.lang.me.ir;
 use mach.lang.me.ir.builder;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.mutate;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.source;
@@ -995,19 +996,17 @@ fun place_phi(st: *State, bid: id.BlockId, alloca_id: id.InstructionId) R.Result
 
 # rename traversal context, threaded through the dominator-tree walk
 # ---
-# st:        promotion state
-# subst:     removed-load result id -> replacement SSA Value
-# has_sub:   which instruction ids have an entry in subst
-# cur:       per-alloca current SSA Value (stack top)
-# defined:   per-alloca whether cur holds a live value yet
-# instr_len: snapshot of the instruction pool length when rename began
+# st:      promotion state
+# rw:      shared rewrite map (removed-load result id -> replacement SSA Value);
+#          its length is the snapshot of the pool at rename start, so phis added
+#          during the walk fall outside it and are never substituted
+# cur:     per-alloca current SSA Value (stack top)
+# defined: per-alloca whether cur holds a live value yet
 rec RenameCtx {
-    st:        *State;
-    subst:     *value.Value;
-    has_sub:   *bool;
-    cur:       *value.Value;
-    defined:   *bool;
-    instr_len: u32;
+    st:      *State;
+    rw:      mutate.Rewrite;
+    cur:     *value.Value;
+    defined: *bool;
 }
 
 # the rename pass: a pre-order walk of the dominator tree maintaining one
@@ -1025,79 +1024,62 @@ fun rename(st: *State) R.Result[bool, str] {
     val ilen: u32 = st.fn.instr_len;
 
     var rc: RenameCtx;
-    rc.st        = st;
-    rc.subst     = nil;
-    rc.has_sub   = nil;
-    rc.cur       = nil;
-    rc.defined   = nil;
-    rc.instr_len = ilen;
+    rc.st      = st;
+    rc.cur     = nil;
+    rc.defined = nil;
 
     val res_init: R.Result[bool, str] = rename_ctx_init(?rc, na, ilen);
     if (R.is_err[bool, str](res_init)) { ret res_init; }
 
     val res_walk: R.Result[bool, str] = rename_walk(?rc);
     if (R.is_ok[bool, str](res_walk)) {
-        apply_substitutions(?rc);
+        mutate.rewrite_apply(st.fn, ?rc.rw);
         strip_promoted(st);
     }
 
-    rename_ctx_dnit(?rc, na, ilen);
+    rename_ctx_dnit(?rc, na);
     ret res_walk;
 }
 
-# allocate and clear the rename context's per-instruction and per-alloca tables
+# allocate and clear the rename context's rewrite map and per-alloca tables
 # ---
-# rc:   context whose subst / has_sub / cur / defined are filled
+# rc:   context whose rw / cur / defined are filled
 # na:   number of promotable allocas (sizes cur / defined)
-# ilen: instruction pool length (sizes subst / has_sub)
+# ilen: instruction pool length (sizes the rewrite map)
 # ret:  ok(true) on success, or an allocation error
 fun rename_ctx_init(rc: *RenameCtx, na: u32, ilen: u32) R.Result[bool, str] {
     val a: *A.Allocator = rc.st.alloc;
 
-    val res_subst: R.Result[*value.Value, str] = A.allocate[value.Value](a, ilen::usize);
-    if (R.is_err[*value.Value, str](res_subst)) { ret R.err[bool, str](R.unwrap_err[*value.Value, str](res_subst)); }
-    rc.subst = R.unwrap_ok[*value.Value, str](res_subst);
-
-    val res_has_sub: R.Result[*bool, str] = A.allocate[bool](a, ilen::usize);
-    if (R.is_err[*bool, str](res_has_sub)) {
-        A.deallocate[value.Value](a, rc.subst, ilen::usize);
-        ret R.err[bool, str](R.unwrap_err[*bool, str](res_has_sub));
-    }
-    rc.has_sub = R.unwrap_ok[*bool, str](res_has_sub);
+    val res_rw: R.Result[bool, str] = mutate.rewrite_init(?rc.rw, a, ilen);
+    if (R.is_err[bool, str](res_rw)) { ret res_rw; }
 
     val res_cur: R.Result[*value.Value, str] = A.allocate[value.Value](a, na::usize);
     if (R.is_err[*value.Value, str](res_cur)) {
-        A.deallocate[value.Value](a, rc.subst, ilen::usize);
-        A.deallocate[bool](a, rc.has_sub, ilen::usize);
+        mutate.rewrite_dnit(?rc.rw, a);
         ret R.err[bool, str](R.unwrap_err[*value.Value, str](res_cur));
     }
     rc.cur = R.unwrap_ok[*value.Value, str](res_cur);
 
     val res_defined: R.Result[*bool, str] = A.allocate[bool](a, na::usize);
     if (R.is_err[*bool, str](res_defined)) {
-        A.deallocate[value.Value](a, rc.subst, ilen::usize);
-        A.deallocate[bool](a, rc.has_sub, ilen::usize);
+        mutate.rewrite_dnit(?rc.rw, a);
         A.deallocate[value.Value](a, rc.cur, na::usize);
         ret R.err[bool, str](R.unwrap_err[*bool, str](res_defined));
     }
     rc.defined = R.unwrap_ok[*bool, str](res_defined);
 
-    var i: u32 = 0;
-    for (i < ilen) { rc.has_sub[i] = false; i = i + 1; }
     var ai: u32 = 0;
     for (ai < na) { rc.defined[ai] = false; ai = ai + 1; }
     ret R.ok[bool, str](true);
 }
 
-# free the rename context's tables by their allocation sizes
+# free the rename context's rewrite map and per-alloca tables
 # ---
-# rc:   context to tear down
-# na:   number of promotable allocas (the cur / defined size)
-# ilen: instruction pool length (the subst / has_sub size)
-fun rename_ctx_dnit(rc: *RenameCtx, na: u32, ilen: u32) {
+# rc: context to tear down
+# na: number of promotable allocas (the cur / defined size)
+fun rename_ctx_dnit(rc: *RenameCtx, na: u32) {
     val a: *A.Allocator = rc.st.alloc;
-    if (rc.subst != nil)   { A.deallocate[value.Value](a, rc.subst, ilen::usize); }
-    if (rc.has_sub != nil) { A.deallocate[bool](a, rc.has_sub, ilen::usize); }
+    mutate.rewrite_dnit(?rc.rw, a);
     if (rc.cur != nil)     { A.deallocate[value.Value](a, rc.cur, na::usize); }
     if (rc.defined != nil) { A.deallocate[bool](a, rc.defined, na::usize); }
 }
@@ -1340,13 +1322,12 @@ fun rename_enter_block(rc: *RenameCtx, bid: id.BlockId) R.Result[bool, str] {
                 val ptr: value.Value = inst.operands[0];
                 if (ptr.kind == value.VAL_INSTR) {
                     val ai: u32 = alloca_index(st, ptr.data.instr);
-                    if (ai != NONE_U32 && iid::u32 < rc.instr_len) {
+                    if (ai != NONE_U32 && iid::u32 < rc.rw.len) {
                         if (rc.defined[ai]) {
-                            rc.subst[iid::u32] = rc.cur[ai];
+                            mutate.replace_value(?rc.rw, iid, rc.cur[ai]);
                         } or {
-                            rc.subst[iid::u32] = value.const_null(inst.ty);
+                            mutate.replace_value(?rc.rw, iid, value.const_null(inst.ty));
                         }
-                        rc.has_sub[iid::u32] = true;
                     }
                 }
             } or (inst.kind == instruction.OP_STORE && inst.operand_count >= 2) {
@@ -1354,7 +1335,7 @@ fun rename_enter_block(rc: *RenameCtx, bid: id.BlockId) R.Result[bool, str] {
                 if (ptr.kind == value.VAL_INSTR) {
                     val ai: u32 = alloca_index(st, ptr.data.instr);
                     if (ai != NONE_U32) {
-                        rc.cur[ai]     = resolve_value(rc, inst.operands[0]);
+                        rc.cur[ai]     = mutate.rewrite_resolve(?rc.rw, inst.operands[0]);
                         rc.defined[ai] = true;
                     }
                 }
@@ -1432,56 +1413,6 @@ fun add_phi_incomings(rc: *RenameCtx, pred: id.BlockId, succ: id.BlockId) R.Resu
     ret R.ok[bool, str](true);
 }
 
-# resolve a Value through the substitution table: if it names a promoted load,
-# follow to the load's replacement (transitively)
-#
-# The use's own type is carried onto the replacement: a load's natural type
-# matches the stored value's, so this is a no-op for scalars, but an aggregate
-# rvalue retypes a pointer-valued load to the aggregate (an aggregate value IS
-# its storage pointer) -- dropping that type for the promoted pointer's would
-# turn a sized struct copy into an 8-byte store.
-# ---
-# rc:  rename context
-# v:   the Value to resolve
-# ret: the resolved Value (v unchanged when it is not a promoted load)
-fun resolve_value(rc: *RenameCtx, v: value.Value) value.Value {
-    var cur: value.Value = v;
-    for (cur.kind == value.VAL_INSTR) {
-        val iid: u32 = cur.data.instr::u32;
-        if (iid < rc.instr_len && rc.has_sub[iid]) {
-            cur = value.retype(rc.subst[iid], cur.ty);
-        } or {
-            ret cur;
-        }
-    }
-    ret cur;
-}
-
-# apply the substitution table to every operand of every surviving instruction
-# (including phi incomings), so references to promoted loads become their
-# resolved SSA Values
-# ---
-# rc: rename context with subst / has_sub filled
-fun apply_substitutions(rc: *RenameCtx) {
-    val st: *State = rc.st;
-    var i: u32 = 0;
-    for (i < st.fn.instr_len) {
-        val inst: *instruction.Instruction = ?st.fn.instrs[i];
-        var o: u32 = 0;
-        for (o < inst.operand_count) {
-            val op: value.Value = inst.operands[o];
-            if (op.kind == value.VAL_INSTR) {
-                val iid: u32 = op.data.instr::u32;
-                if (iid < rc.instr_len && rc.has_sub[iid]) {
-                    inst.operands[o] = resolve_value(rc, op);
-                }
-            }
-            o = o + 1;
-        }
-        i = i + 1;
-    }
-}
-
 # strip promoted instructions (the allocas, and every load/store on them) from
 # their block instruction lists
 #
@@ -1493,17 +1424,18 @@ fun strip_promoted(st: *State) {
     var b: u32 = 0;
     for (b < st.block_count) {
         val blk: *ir.Block = ?st.fn.blocks[b];
-        var w: u32 = 0;
+        # route every removal through the shared erase primitive (no private
+        # compaction); erase removes in place, so a promoted memop is erased
+        # without advancing the cursor.
         var r: u32 = 0;
         for (r < blk.instr_count) {
             val iid: id.InstructionId = blk.instructions[r];
-            if (is_promoted_memop(st, iid) == false) {
-                blk.instructions[w] = iid;
-                w = w + 1;
+            if (is_promoted_memop(st, iid)) {
+                mutate.erase_instruction(blk, iid);
+            } or {
+                r = r + 1;
             }
-            r = r + 1;
         }
-        blk.instr_count = w;
         b = b + 1;
     }
 }

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -10,14 +10,22 @@
 # stages; a post-pipeline verification failure is an internal compiler error
 # (a pass bug), surfaced as the returned err.
 
+use std.allocator.page;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 
+use A: std.allocator;
 use R: std.types.result;
 
+use mach.lang.intern;
 use mach.lang.me.ir;
+use mach.lang.me.ir.builder;
+use mach.lang.me.ir.id;
+use mach.lang.me.ir.instruction;
+use ir_type: mach.lang.me.ir.type;
+use mach.lang.me.ir.value;
 use mach.lang.me.ir.verify;
 use mach.lang.me.pass.algebraic;
 use mach.lang.me.pass.constfold;
@@ -25,6 +33,7 @@ use mach.lang.me.pass.cse;
 use mach.lang.me.pass.dce;
 use mach.lang.me.pass.inline;
 use mach.lang.me.pass.mem2reg;
+use mach.lang.source;
 use mach.lang.target;
 
 # optimisation level selecting the pipeline's stage sequence
@@ -190,4 +199,76 @@ fun run_verify(m: *ir.Module, full: bool, repr: bool) R.Result[bool, str] {
     val msg: str = verify.describe(report.violations[0].check);
     verify.dnit_report(?report);
     ret R.err[bool, str](msg);
+}
+
+# an instruction's source location survives the always-on pipeline: mem2reg
+# promotes an alloca (rewriting a use of the surviving add) and constfold folds a
+# constant into its other operand, yet the add keeps the loc it lowered with. This
+# is the debug-info invariant the shared Rewrite map exists to guarantee -- RAUW
+# rewrites operands, never the loc a surviving instruction carries.
+test "mach.lang.me.pipeline.loc:survives_mem2reg_constfold_dce" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val res_i64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](res_i64)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val res_blk: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](res_blk)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](res_blk));
+
+    val p0: value.Value = value.param(0, i64t);
+
+    # a promotable local: alloca + store(p0) + load. mem2reg removes all three and
+    # rewrites the load's uses to p0.
+    val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?bld, i64t, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](res_slot)) { ir.dnit(?m); ret 1; }
+    val slot: value.Value = R.unwrap_ok[value.Value, str](res_slot);
+    if (R.is_err[bool, str](builder.emit_store(?bld, p0, slot))) { ir.dnit(?m); ret 1; }
+    val res_load: R.Result[value.Value, str] = builder.emit_load(?bld, slot, i64t);
+    if (R.is_err[value.Value, str](res_load)) { ir.dnit(?m); ret 1; }
+    val x: value.Value = R.unwrap_ok[value.Value, str](res_load);
+
+    # a constant expression constfold collapses to 5, then propagates into the add.
+    val res_k: R.Result[value.Value, str] = builder.emit_add(?bld, value.const_int(2, i64t), value.const_int(3, i64t));
+    if (R.is_err[value.Value, str](res_k)) { ir.dnit(?m); ret 1; }
+    val k: value.Value = R.unwrap_ok[value.Value, str](res_k);
+
+    # the surviving instruction, stamped with a distinctive location.
+    builder.set_loc(?bld, source.loc(9, 500));
+    val res_s: R.Result[value.Value, str] = builder.emit_add(?bld, x, k);
+    if (R.is_err[value.Value, str](res_s)) { ir.dnit(?m); ret 1; }
+    val s: value.Value = R.unwrap_ok[value.Value, str](res_s);
+    val s_id: id.InstructionId = s.data.instr;
+
+    if (R.is_err[bool, str](builder.emit_ret(?bld, s))) { ir.dnit(?m); ret 1; }
+
+    if (R.is_err[bool, str](mem2reg.run(?m)))   { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](constfold.run(?m))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](dce.run(?m)))       { ir.dnit(?m); ret 1; }
+
+    # the add survived with its opcode and its exact source location.
+    val surviving: *instruction.Instruction = ?fn.instrs[s_id::u32];
+    if (surviving.kind != instruction.OP_ADD)   { ir.dnit(?m); ret 1; }
+    if (surviving.loc.file != 9)                { ir.dnit(?m); ret 1; }
+    if (surviving.loc.offset != 500)            { ir.dnit(?m); ret 1; }
+
+    # and the passes really ran: operand 0 was promoted to p0, operand 1 folded to 5.
+    if (surviving.operands[0].kind != value.VAL_PARAM)     { ir.dnit(?m); ret 1; }
+    if (surviving.operands[0].data.param_ix != 0)          { ir.dnit(?m); ret 1; }
+    if (surviving.operands[1].kind != value.VAL_CONST_INT) { ir.dnit(?m); ret 1; }
+    if (surviving.operands[1].data.int_lit != 5)           { ir.dnit(?m); ret 1; }
+
+    ir.dnit(?m);
+    ret 0;
 }


### PR DESCRIPTION
Closes #1690. Foundation-layer work for the debug-info epic #1688 — a shared IR mutation surface so loc (and later OP_DBG_VALUE) maintenance lives in one place instead of five hand-rolled copies.

## What

**`me/ir/mutate.mach`** — a new module holding the post-construction mutation API (distinct lifecycle surface from `builder.mach`, which stays the creation API):
- **`Rewrite` map** (`replace_value` / `rewrite_resolve` / `rewrite_apply`) — the one batched RAUW table, replacing the private substitution tables in **cse, algebraic, constfold, mem2reg**. The four `resolve` variants are byte-equivalent (retype never affects chain traversal; the hop bound never trips on an acyclic map), so mem2reg's progressive-retype and the others' retype-final-to-original collapse to one implementation. mem2reg's dominator-tree rename still *populates* the map.
- **`replace_uses`** — the immediate single-value RAUW, absorbing **inline**'s `replace_value_uses`.
- **`clone_instruction`** — a faithful per-instruction copy (loc + flags ride along), absorbing **inline**'s clone loop.
- **`erase_instruction`** — the one point an instruction leaves a block; **dce** and **mem2reg-strip** route removals through it. The caller passes the block it is already walking (the IR has no instruction→block back-pointer by design), and a load-bearing contract comment states the invariant.

## Model correction (recorded on the issue)
The issue's five-pass framing is met by "each pass routes its mutations through the primitives, using the subset that applies": the four value passes use RAUW, inline uses clone + immediate RAUW, dce + mem2reg-strip use erase (dce has no RAUW — that's expected). Located in `mutate.mach`, not `builder.mach` as the issue suggested, per review.

## Verification (dev-baseline vs branch, identical pristine input, rebased on current dev)
- **Byte-identical emitted output on all six shipped targets** (linux x86_64/arm64/riscv64, windows, darwin x86_64/aarch64).
- Self-host fixpoint converges (b == c).
- Unit suite: 516 passed, 0 failed (dev baseline 515 + the one loc-survival test).
- int harness green on the linux leg.

Two byte-preserving commits (#1845-style): (a) the mutation API + pass migration; (b) the loc-survival test. Net −330 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)