### PR TITLE
fix(codegen): pass module-global aggregates by value, not by address

### DIFF
--- a/int/regression/1925-global-aggregate-byval/expect.txt
+++ b/int/regression/1925-global-aggregate-byval/expect.txt
@@ -1,0 +1,7 @@
+direct=7
+byval=7
+big=60
+mixed=259
+split=35
+ident=7
+copy=7

--- a/int/regression/1925-global-aggregate-byval/mach.toml
+++ b/int/regression/1925-global-aggregate-byval/mach.toml
@@ -1,0 +1,52 @@
+[project]
+id      = "case"
+name    = "case"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+ext = ".exe"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.case]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/1925-global-aggregate-byval/src/main.mach
+++ b/int/regression/1925-global-aggregate-byval/src/main.mach
@@ -1,0 +1,51 @@
+# regression pin for #1925: a module-global aggregate passed BY VALUE.
+#
+# a global record's rvalue lowered to its bare ptr-typed storage address, unlike a
+# local aggregate whose address is retyped to the aggregate IR type. the call ABI
+# reads a by-value argument's copy length / aggregate-ness from the operand type,
+# so the global's ptr operand classified as a scalar: the address was passed in a
+# register (mis-sized as a pointer) instead of the record's bytes being copied.
+# direct field access (`g.a + g.b`) stayed correct — it lowers the receiver as an
+# lvalue, never through the aggregate-rvalue path — so the two must be checked
+# against each other. covers the two-GP (16B), by-reference (24B), mixed float+int,
+# and register-plus-stack-split shapes, plus a global-in / struct-out round trip.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+rec Two   { a: i64; b: i64; }
+rec Big   { a: i64; b: i64; c: i64; }
+rec Mixed { f: f64; i: i64; }
+
+var g:  Two   = Two{ a: 3, b: 4 };
+var gb: Big   = Big{ a: 10, b: 20, c: 30 };
+var gm: Mixed = Mixed{ f: 2.5, i: 9 };
+
+fun sum(t: Two) i64 { ret t.a + t.b; }
+fun sum3(b: Big) i64 { ret b.a + b.b + b.c; }
+fun mixed_fold(m: Mixed) i64 { ret (m.f * 100.0)::i64 + m.i; }
+
+# seven integer args fill the GP registers, so the trailing 16-byte struct rides
+# the register-plus-stack split.
+fun split(p0: i64, p1: i64, p2: i64, p3: i64, p4: i64, p5: i64, p6: i64, s: Two) i64 {
+    ret p0 + p1 + p2 + p3 + p4 + p5 + p6 + s.a + s.b;
+}
+
+fun ident(t: Two) Two { ret t; }
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    p.printlnf("direct={}", g.a + g.b);                    # 7
+    p.printlnf("byval={}", sum(g));                         # 7
+    p.printlnf("big={}", sum3(gb));                         # 60
+    p.printlnf("mixed={}", mixed_fold(gm));                # 259
+    p.printlnf("split={}", split(1, 2, 3, 4, 5, 6, 7, g)); # 35
+
+    var r: Two = ident(g);                                 # global in, struct out
+    p.printlnf("ident={}", r.a + r.b);                     # 7
+
+    var c: Two = g;                                        # global assigned to a local
+    p.printlnf("copy={}", c.a + c.b);                      # 7
+    ret 0;
+}

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -60,6 +60,9 @@ use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.ir;
+use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.value;
+use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.lower;
 use mach.lang.me.lower.testrunner;
 use mach.lang.me.pipeline;
@@ -7423,6 +7426,71 @@ test "mach.lang.driver:incremental_lower_reuse_no_change" {
     filesystem.remove_all(?alloc, root);
     session.dnit(?sA);
     ret bad;
+}
+
+# a module-global aggregate passed BY VALUE lowers to an aggregate-typed call
+# operand, not its bare pointer (#1925). the call ABI reads a by-value argument's
+# copy length / aggregate-ness from the operand's own type, so a ptr-typed global
+# operand would pass the address as a scalar instead of copying the record's bytes.
+# the local-aggregate rvalue already retypes its storage address to the aggregate
+# type; emit_global_rvalue must match it. at O0 the callee is not inlined, so the
+# operand is observable in the lowered IR.
+test "mach.lang.driver:global_aggregate_arg_is_aggregate_typed" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "rec Two { a: i64; b: i64; }\nvar g: Two = Two{ a: 3, b: 4 };\nfun sum(t: Two) i64 { ret t.a + t.b; }\nfun main() i32 { ret sum(g)::i32; }\n";
+
+    val pr: R.Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+
+    # bad starts failed; it clears only when the aggregate-typed global operand is
+    # found, so an inlined-away or missing call can never vacuously pass.
+    var bad: i32 = 1;
+    if (R.is_err[bool, str](run_sema_pass(?p)))  { dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p))) { dnit_project(?p); session.dnit(?s); ret 1; }
+
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    if (mid != session.MODULE_NIL) {
+        val m: *ModuleEntry = ?p.modules[mid::u32];
+        if (m.ir_module != nil) { bad = ut_probe_global_agg_arg(m.ir_module); }
+    }
+
+    dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# scan a lowered module for an OP_CALL carrying a VAL_GLOBAL argument operand whose
+# IR type is an aggregate (the #1925-fixed shape). 0 when found, 1 otherwise
+fun ut_probe_global_agg_arg(m: *ir.Module) i32 {
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val fn: *ir.Function = ?m.functions[fi];
+        var ii: u32 = 0;
+        for (ii < fn.instr_len) {
+            val inst: *instruction.Instruction = ?fn.instrs[ii];
+            if (inst.kind == instruction.OP_CALL) {
+                # operand 0 is the callee; arguments follow.
+                var oi: u32 = 1;
+                for (oi < inst.operand_count) {
+                    val op: value.Value = inst.operands[oi];
+                    if (op.kind == value.VAL_GLOBAL && ir_type.is_aggregate(?m.types, op.ty)) { ret 0; }
+                    oi = oi + 1;
+                }
+            }
+            ii = ii + 1;
+        }
+        fi = fi + 1;
+    }
+    ret 1;
 }
 
 # driver incremental: editing one dependency's body re-lowers it and its importer

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -2646,7 +2646,10 @@ fun emit_global_rvalue(ctx: *context.LowerContext, global_ix: u32, vty: ir_type.
     val res_gptr: R.Result[value.Value, str] = global_pointer(ctx, global_ix);
     if (R.is_err[value.Value, str](res_gptr)) { ret res_gptr; }
     val gptr: value.Value = R.unwrap_ok[value.Value, str](res_gptr);
-    if (is_aggregate_ir(ctx, vty)) { ret R.ok[value.Value, str](gptr); }
+    # an aggregate global's rvalue is its storage address retyped to the aggregate
+    # IR type (mirroring rvalue_at): a copy / by-value argument of it then classifies
+    # as a sized aggregate rather than a scalar pointer move.
+    if (is_aggregate_ir(ctx, vty)) { ret R.ok[value.Value, str](value.retype(gptr, vty)); }
     ret builder.emit_load(?ctx.builder, gptr, vty);
 }
 


### PR DESCRIPTION
Closes #1925.

## Root cause

A module-global aggregate used as an rvalue lowered to its `ptr`-typed storage address (via `emit_global_rvalue`), while a *local* aggregate's rvalue is its storage address **retyped to the aggregate IR type** (via `rvalue_at`). The call ABI (`mir/abi.mach` `lower_call`) reads a by-value argument's copy length and aggregate-ness from the operand's own `.ty`, so the global's `ptr`-typed operand classified as a **scalar**: the LEA'd address was passed in a register (and mis-sized as a pointer) instead of the record's bytes being copied by value. Field access (`g.a`) stayed correct because it lowers the receiver as an lvalue, never through this rvalue path.

## Fix

One line in `emit_global_rvalue`: retype an aggregate global's storage address to the aggregate IR type, mirroring `rvalue_at`. A copy / by-value argument / by-value return of a global record now classifies as a sized aggregate, identical to the local case.

## Verification

- Minimal repro (`global Two{a,b}`, `sum(g)`): `byval` garbage -> `7`, debug + release.
- Broader shapes all correct debug+release: 16B two-GP, 24B byref/sret, mixed float+int, register+stack split (7 GP args + struct), global-in/struct-out, global assigned to a local.
- New int regression case `int/regression/1925-global-aggregate-byval`.
- Full bar (unit suite, self-host fixpoint, int all legs, x86_64/arm64/riscv64) in PR checks.
