### PR TITLE
hotfix: v2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.1] - 2026-07-04
+
+Hotfix for two defects in 2.14.0.
+
+### Fixed
+
+- codegen: **critical** - a module-global aggregate passed by value lowered to
+  its bare pointer-typed storage address, so the call ABI classified it as a
+  scalar and passed the address instead of copying the record's bytes - garbage
+  values in the callee, debug and release. Global aggregate rvalues now retype
+  to the aggregate IR type, identical to locals (#1925).
+- link/elf: `PT_GNU_RELRO` declares the actual `.data.rel.ro` extent instead of
+  the image max-page-rounded size, so the header matches what the runtime maps
+  and re-protects (#1885 follow-through; the startup-crash half shipped via
+  mach-std).
+
 ## [2.14.0] - 2026-07-03
 
 The incremental compilation back half and a hardening sweep. The full pipeline

--- a/int/regression/1925-global-aggregate-byval/expect.txt
+++ b/int/regression/1925-global-aggregate-byval/expect.txt
@@ -1,0 +1,7 @@
+direct=7
+byval=7
+big=60
+mixed=259
+split=35
+ident=7
+copy=7

--- a/int/regression/1925-global-aggregate-byval/mach.toml
+++ b/int/regression/1925-global-aggregate-byval/mach.toml
@@ -1,0 +1,52 @@
+[project]
+id      = "case"
+name    = "case"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+ext = ".exe"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.case]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/1925-global-aggregate-byval/src/main.mach
+++ b/int/regression/1925-global-aggregate-byval/src/main.mach
@@ -1,0 +1,51 @@
+# regression pin for #1925: a module-global aggregate passed BY VALUE.
+#
+# a global record's rvalue lowered to its bare ptr-typed storage address, unlike a
+# local aggregate whose address is retyped to the aggregate IR type. the call ABI
+# reads a by-value argument's copy length / aggregate-ness from the operand type,
+# so the global's ptr operand classified as a scalar: the address was passed in a
+# register (mis-sized as a pointer) instead of the record's bytes being copied.
+# direct field access (`g.a + g.b`) stayed correct — it lowers the receiver as an
+# lvalue, never through the aggregate-rvalue path — so the two must be checked
+# against each other. covers the two-GP (16B), by-reference (24B), mixed float+int,
+# and register-plus-stack-split shapes, plus a global-in / struct-out round trip.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+rec Two   { a: i64; b: i64; }
+rec Big   { a: i64; b: i64; c: i64; }
+rec Mixed { f: f64; i: i64; }
+
+var g:  Two   = Two{ a: 3, b: 4 };
+var gb: Big   = Big{ a: 10, b: 20, c: 30 };
+var gm: Mixed = Mixed{ f: 2.5, i: 9 };
+
+fun sum(t: Two) i64 { ret t.a + t.b; }
+fun sum3(b: Big) i64 { ret b.a + b.b + b.c; }
+fun mixed_fold(m: Mixed) i64 { ret (m.f * 100.0)::i64 + m.i; }
+
+# seven integer args fill the GP registers, so the trailing 16-byte struct rides
+# the register-plus-stack split.
+fun split(p0: i64, p1: i64, p2: i64, p3: i64, p4: i64, p5: i64, p6: i64, s: Two) i64 {
+    ret p0 + p1 + p2 + p3 + p4 + p5 + p6 + s.a + s.b;
+}
+
+fun ident(t: Two) Two { ret t; }
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    p.printlnf("direct={}", g.a + g.b);                    # 7
+    p.printlnf("byval={}", sum(g));                         # 7
+    p.printlnf("big={}", sum3(gb));                         # 60
+    p.printlnf("mixed={}", mixed_fold(gm));                # 259
+    p.printlnf("split={}", split(1, 2, 3, 4, 5, 6, 7, g)); # 35
+
+    var r: Two = ident(g);                                 # global in, struct out
+    p.printlnf("ident={}", r.a + r.b);                     # 7
+
+    var c: Two = g;                                        # global assigned to a local
+    p.printlnf("copy={}", c.a + c.b);                      # 7
+    ret 0;
+}

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.14.0"
+version = "2.14.1"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -60,6 +60,9 @@ use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.ir;
+use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.value;
+use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.lower;
 use mach.lang.me.lower.testrunner;
 use mach.lang.me.pipeline;
@@ -7412,6 +7415,71 @@ test "mach.lang.driver:incremental_lower_reuse_no_change" {
     filesystem.remove_all(?alloc, root);
     session.dnit(?sA);
     ret bad;
+}
+
+# a module-global aggregate passed BY VALUE lowers to an aggregate-typed call
+# operand, not its bare pointer (#1925). the call ABI reads a by-value argument's
+# copy length / aggregate-ness from the operand's own type, so a ptr-typed global
+# operand would pass the address as a scalar instead of copying the record's bytes.
+# the local-aggregate rvalue already retypes its storage address to the aggregate
+# type; emit_global_rvalue must match it. at O0 the callee is not inlined, so the
+# operand is observable in the lowered IR.
+test "mach.lang.driver:global_aggregate_arg_is_aggregate_typed" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "rec Two { a: i64; b: i64; }\nvar g: Two = Two{ a: 3, b: 4 };\nfun sum(t: Two) i64 { ret t.a + t.b; }\nfun main() i32 { ret sum(g)::i32; }\n";
+
+    val pr: R.Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+
+    # bad starts failed; it clears only when the aggregate-typed global operand is
+    # found, so an inlined-away or missing call can never vacuously pass.
+    var bad: i32 = 1;
+    if (R.is_err[bool, str](run_sema_pass(?p)))  { dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p))) { dnit_project(?p); session.dnit(?s); ret 1; }
+
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    if (mid != session.MODULE_NIL) {
+        val m: *ModuleEntry = ?p.modules[mid::u32];
+        if (m.ir_module != nil) { bad = ut_probe_global_agg_arg(m.ir_module); }
+    }
+
+    dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# scan a lowered module for an OP_CALL carrying a VAL_GLOBAL argument operand whose
+# IR type is an aggregate (the #1925-fixed shape). 0 when found, 1 otherwise
+fun ut_probe_global_agg_arg(m: *ir.Module) i32 {
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val fn: *ir.Function = ?m.functions[fi];
+        var ii: u32 = 0;
+        for (ii < fn.instr_len) {
+            val inst: *instruction.Instruction = ?fn.instrs[ii];
+            if (inst.kind == instruction.OP_CALL) {
+                # operand 0 is the callee; arguments follow.
+                var oi: u32 = 1;
+                for (oi < inst.operand_count) {
+                    val op: value.Value = inst.operands[oi];
+                    if (op.kind == value.VAL_GLOBAL && ir_type.is_aggregate(?m.types, op.ty)) { ret 0; }
+                    oi = oi + 1;
+                }
+            }
+            ii = ii + 1;
+        }
+        fi = fi + 1;
+    }
+    ret 1;
 }
 
 # driver incremental: editing one dependency's body re-lowers it and its importer

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -2615,7 +2615,10 @@ fun emit_global_rvalue(ctx: *context.LowerContext, global_ix: u32, vty: ir_type.
     val res_gptr: R.Result[value.Value, str] = global_pointer(ctx, global_ix);
     if (R.is_err[value.Value, str](res_gptr)) { ret res_gptr; }
     val gptr: value.Value = R.unwrap_ok[value.Value, str](res_gptr);
-    if (is_aggregate_ir(ctx, vty)) { ret R.ok[value.Value, str](gptr); }
+    # an aggregate global's rvalue is its storage address retyped to the aggregate
+    # IR type (mirroring rvalue_at): a copy / by-value argument of it then classifies
+    # as a sized aggregate rather than a scalar pointer move.
+    if (is_aggregate_ir(ctx, vty)) { ret R.ok[value.Value, str](value.retype(gptr, vty)); }
     ret builder.emit_load(?ctx.builder, gptr, vty);
 }
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1685,14 +1685,15 @@ fun write_pie_phdrs(buf: *u8, phdr_offset: usize, phdr_count: u32,
     # with relocated constants), when present. the region is mapped writable above for the
     # self-reloc; this header is the runtime's cue to re-protect it read-only (see the
     # `pie_seg_flags` contract). pure `.rodata` carries no base relocation, so it is never
-    # covered here and stays read-only from load. p_memsz is page-rounded so the runtime
-    # re-protects whole pages with no arithmetic of its own - safe because every merged
-    # kind starts on a fresh page (assign_section_vaddrs), so the next segment begins where
-    # this one ends.
+    # covered here and stays read-only from load. p_memsz is the segment's actual extent,
+    # NOT rounded to the image max-page: a max-page larger than the runtime page (a 64 KiB
+    # aarch64 image on a 4 KiB kernel) would overshoot the mapping, and the runtime's
+    # re-protect would fault ENOMEM (briar-systems/mach#1885). the runtime rounds this
+    # extent up to the runtime page (AT_PAGESZ) - the pages the kernel actually mapped.
     val relro_seg: i64 = pie_relro_seg(segs, seg_count, dyn);
     if (relro_seg >= 0) {
         val ri: u32 = relro_seg::u32;
-        val relro_size: usize = bin.align_up(segs[ri].memsz, page_size::usize);
+        val relro_size: usize = segs[ri].memsz;
         pos = write_phdr(buf, pos, PT_GNU_RELRO, PF_R, seg_offsets[ri], segs[ri].vaddr,
                          relro_size, relro_size, 1);
     }
@@ -4270,7 +4271,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:relro_splits_rodata_from_rel_ro" {
     var bad: bool = false;
 
     # walk the program headers: exactly one PT_GNU_RELRO, spanning the rel.ro segment
-    # (vaddr 0x404000, page-rounded memsz), read-only. pure `.rodata` at 0x402000 must be
+    # (vaddr 0x404000, its actual 16-byte memsz), read-only. pure `.rodata` at 0x402000 must be
     # R at load and uncovered; the writable segment at 0x403000 stays R+W and uncovered;
     # the rel.ro load segment at 0x404000 is force-mapped R+W (the self-reloc precondition).
     val e_phoff: usize = bin.read_u64_le(buf.data, 32)::usize;
@@ -4293,8 +4294,10 @@ test "mach.lang.target.of.elf.emit_pie_exec:relro_splits_rodata_from_rel_ro" {
             relro_vaddr = pvaddr;
             if (pflags != PF_R)            { bad = true; }
             if (pvaddr != 0x404000)        { bad = true; }
-            if (pfilesz != 4096) { bad = true; }
-            if (pmemsz != 4096)  { bad = true; }
+            # p_memsz is the rel.ro segment's actual extent (16 bytes here), NOT rounded to
+            # the page; the runtime rounds it up to AT_PAGESZ (mach#1885).
+            if (pfilesz != 16) { bad = true; }
+            if (pmemsz != 16)  { bad = true; }
         }
         if (pt == PT_LOAD && pvaddr == 0x402000) { rodata_load_flags = pflags; }
         if (pt == PT_LOAD && pvaddr == 0x403000) { data_load_flags = pflags; }


### PR DESCRIPTION
Hotfix release off main (v2.14.0): cherry-picks the #1925 critical miscompile fix (global aggregates by value, PR #1926: eceb3a5a + both regression tests) and the honest PT_GNU_RELRO extent (e6f83ea3, PR #1888), plus the 2.14.1 version/changelog roll. Both changes are already on dev; after tagging, main merges back into dev per the hotfix flow.