### PR TITLE
fix(debuginfo): childless subprograms use DW_CHILDREN_no leaf abbrev (#1949)

### DIFF
--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -163,6 +163,12 @@ val ABBREV_INLINED_RANGES:      u8 = 0x0d;
 # children-bearing shapes, used when an instance has nested inlines / (later) inlined locals
 val ABBREV_INLINED_KIDS:        u8 = 0x0e;
 val ABBREV_INLINED_RANGES_KIDS: u8 = 0x0f;
+# childless concrete subprograms: DW_CHILDREN_no variants of ABBREV_SUBPROGRAM /
+# ABBREV_SUBPROGRAM_VOID, selected when a subprogram emits no parameters, locals, or
+# inlined instances. advertising DW_CHILDREN_yes with no children trips llvm-dwarfdump
+# --verify (#1949)
+val ABBREV_SUBPROGRAM_LEAF:      u8 = 0x10;
+val ABBREV_SUBPROGRAM_VOID_LEAF: u8 = 0x11;
 
 # DWARF 5 line-number program: standard opcodes, extended opcodes, and the tuned
 # special-opcode parameters this producer emits
@@ -687,8 +693,9 @@ fun emit_attr(b: *enc.ByteBuf, at: u8, form: u8) {
 }
 
 # build the `.debug_abbrev` table: the compile-unit DIE (now with children), a base
-# type, and the two subprogram shapes (with and without a return type), matching the
-# DIEs `build_info` emits. The table is identical for every module, so a CU's
+# type, and the subprogram shapes (with / without a return type, each in a
+# children-bearing and a childless-leaf form), matching the DIEs `build_info` emits.
+# The table is identical for every module, so a CU's
 # `debug_abbrev_offset` of 0 is correct even after the linker concatenates each
 # object's `.debug_abbrev`
 # ---
@@ -717,9 +724,9 @@ fun build_abbrev(b: *enc.ByteBuf) {
     uleb(b, 0); uleb(b, 0);
 
     # subprogram with a return type.
-    build_subprogram_abbrev(b, ABBREV_SUBPROGRAM, true);
+    build_subprogram_abbrev(b, ABBREV_SUBPROGRAM, true, true);
     # subprogram without a return type (void or non-primitive return).
-    build_subprogram_abbrev(b, ABBREV_SUBPROGRAM_VOID, false);
+    build_subprogram_abbrev(b, ABBREV_SUBPROGRAM_VOID, false, true);
 
     # variable / formal parameter, located and no-location shapes.
     build_var_abbrev(b, ABBREV_VARIABLE,       DW_TAG_variable,         true);
@@ -747,6 +754,11 @@ fun build_abbrev(b: *enc.ByteBuf) {
     build_inlined_abbrev(b, ABBREV_INLINED_RANGES,      true,  false);
     build_inlined_abbrev(b, ABBREV_INLINED_KIDS,        false, true);
     build_inlined_abbrev(b, ABBREV_INLINED_RANGES_KIDS, true,  true);
+
+    # childless concrete subprograms: DW_CHILDREN_no variants of the two above, for a
+    # subprogram that emits no parameters, locals, or inlined instances (#1949).
+    build_subprogram_abbrev(b, ABBREV_SUBPROGRAM_LEAF,      true,  false);
+    build_subprogram_abbrev(b, ABBREV_SUBPROGRAM_VOID_LEAF, false, false);
 
     uleb(b, 0);   # null abbrev code terminates the table
 }
@@ -778,17 +790,18 @@ fun build_inlined_abbrev(b: *enc.ByteBuf, code: u8, ranges: bool, kids: bool) {
     uleb(b, 0); uleb(b, 0);
 }
 
-# emit one subprogram abbreviation (now with children: its parameters and locals).
-# Shared by the with-return and void shapes, which differ only in the trailing
-# DW_AT_type
+# emit one subprogram abbreviation. Shared by the with-return and void shapes (which
+# differ only in the trailing DW_AT_type) and by their childless-leaf variants (which
+# differ only in the DW_CHILDREN flag)
 # ---
 # b:        the abbrev buffer
 # code:     the abbreviation code
 # has_type: true to append DW_AT_type (DW_FORM_ref4)
-fun build_subprogram_abbrev(b: *enc.ByteBuf, code: u8, has_type: bool) {
+# kids:     true for DW_CHILDREN_yes (params/locals/inlines), false for a childless leaf
+fun build_subprogram_abbrev(b: *enc.ByteBuf, code: u8, has_type: bool, kids: bool) {
     uleb(b, code::u64);
     uleb(b, DW_TAG_subprogram::u64);
-    enc.emit_byte(b, DW_CHILDREN_yes);
+    if (kids) { enc.emit_byte(b, DW_CHILDREN_yes); } or { enc.emit_byte(b, DW_CHILDREN_no); }
     emit_attr(b, DW_AT_name,       DW_FORM_strp);
     emit_attr(b, DW_AT_low_pc,     DW_FORM_addr);
     emit_attr(b, DW_AT_high_pc,    DW_FORM_data8);
@@ -858,6 +871,30 @@ fun inline_present(inlines: *DwInline, ninl: u32, f: u32, site: u32) bool {
     for (i < ninl) {
         if (inlines[i].func_idx == f && inlines[i].site_id == site) { ret true; }
         i = i + 1;
+    }
+    ret false;
+}
+
+# whether the subprogram for function `f` will emit any child DIE: a variable/parameter
+# that survives the inline-scope filter, or a top-level inlined_subroutine instance.
+# mirrors build_info's child-emission conditions so the DW_CHILDREN flag matches reality
+# (a childless DIE marked DW_CHILDREN_yes trips llvm-dwarfdump --verify, #1949)
+# ---
+# f:            the subprogram's function index (DwInline.func_idx space)
+# fn:           its DwFunc (var_start / var_count)
+# vars:         the gathered variable table
+# inlines/ninl: the gathered inline instances
+fun subprogram_has_children(f: u32, fn: *DwFunc, vars: *DwVar, inlines: *DwInline, ninl: u32) bool {
+    var vi: u32 = 0;
+    for (vi < fn.var_count) {
+        val dvr: *DwVar = ?vars[fn.var_start + vi];
+        if (dvr.inline_site == 0 || !inline_present(inlines, ninl, f, dvr.inline_site)) { ret true; }
+        vi = vi + 1;
+    }
+    var xi: u32 = 0;
+    for (xi < ninl) {
+        if (inlines[xi].func_idx == f && inlines[xi].parent == 0) { ret true; }
+        xi = xi + 1;
     }
     ret false;
 }
@@ -996,8 +1033,14 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
     var f: u32 = 0;
     for (f < nfuncs) {
         val fn: *DwFunc = ?funcs[f];
-        if (fn.ret_bt >= 0) { enc.emit_byte(b, ABBREV_SUBPROGRAM); }
-        or                  { enc.emit_byte(b, ABBREV_SUBPROGRAM_VOID); }
+        # a subprogram with no children uses the DW_CHILDREN_no leaf abbrev (and emits no
+        # terminator), so it never advertises children it lacks (#1949).
+        val has_kids: bool = subprogram_has_children(f, fn, vars, inlines, ninl);
+        if (fn.ret_bt >= 0) {
+            if (has_kids) { enc.emit_byte(b, ABBREV_SUBPROGRAM); } or { enc.emit_byte(b, ABBREV_SUBPROGRAM_LEAF); }
+        } or {
+            if (has_kids) { enc.emit_byte(b, ABBREV_SUBPROGRAM_VOID); } or { enc.emit_byte(b, ABBREV_SUBPROGRAM_VOID_LEAF); }
+        }
         push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, fn.disp_off::i64);
         enc.emit_u32(b, 0);             # DW_AT_name (strp, relocated to .debug_str)
         push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS64, IRLT_SYM, fn.name, 0);
@@ -1023,7 +1066,7 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
         # instances directly under the subprogram, nested instances under their parent).
         emit_inlines(b, f, 0, inlines, ninl, iranges, relocs, reloc_count, fn, address_size, vars, bts);
 
-        enc.emit_byte(b, 0);   # null DIE terminates this subprogram's children
+        if (has_kids) { enc.emit_byte(b, 0); }   # null DIE terminates the children (only when present)
         f = f + 1;
     }
 
@@ -2534,7 +2577,7 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     page.make(?alloc);
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     build_abbrev(?b);
-    var e: [170]u8;
+    var e: [238]u8;
     e[0]=0x01; e[1]=0x11; e[2]=0x01; e[3]=0x25; e[4]=0x08; e[5]=0x03; e[6]=0x08; e[7]=0x1B;
     e[8]=0x08; e[9]=0x13; e[10]=0x05; e[11]=0x11; e[12]=0x01; e[13]=0x12; e[14]=0x07; e[15]=0x10;
     e[16]=0x17; e[17]=0x00; e[18]=0x00; e[19]=0x02; e[20]=0x24; e[21]=0x00; e[22]=0x03; e[23]=0x0E;
@@ -2572,8 +2615,16 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     # ABBREV_INLINED_RANGES_KIDS (0x0F): as 0x0D but DW_CHILDREN_yes.
     e[184]=0x0F; e[185]=0x1D; e[186]=0x01; e[187]=0x31; e[188]=0x13; e[189]=0x55; e[190]=0x17;
     e[191]=0x58; e[192]=0x0F; e[193]=0x59; e[194]=0x0F; e[195]=0x00; e[196]=0x00;
-    e[197]=0x00;   # null abbrev code terminates the table
-    val ok: bool = buf_eq(?b, ?e[0], 198);
+    # ABBREV_SUBPROGRAM_LEAF (0x10): as 0x03 (with-type subprogram) but DW_CHILDREN_no.
+    e[197]=0x10; e[198]=0x2E; e[199]=0x00; e[200]=0x03; e[201]=0x0E; e[202]=0x11; e[203]=0x01;
+    e[204]=0x12; e[205]=0x07; e[206]=0x3F; e[207]=0x0C; e[208]=0x3A; e[209]=0x0F; e[210]=0x3B;
+    e[211]=0x0F; e[212]=0x40; e[213]=0x18; e[214]=0x49; e[215]=0x13; e[216]=0x00; e[217]=0x00;
+    # ABBREV_SUBPROGRAM_VOID_LEAF (0x11): as 0x04 (void subprogram) but DW_CHILDREN_no.
+    e[218]=0x11; e[219]=0x2E; e[220]=0x00; e[221]=0x03; e[222]=0x0E; e[223]=0x11; e[224]=0x01;
+    e[225]=0x12; e[226]=0x07; e[227]=0x3F; e[228]=0x0C; e[229]=0x3A; e[230]=0x0F; e[231]=0x3B;
+    e[232]=0x0F; e[233]=0x40; e[234]=0x18; e[235]=0x00; e[236]=0x00;
+    e[237]=0x00;   # null abbrev code terminates the table
+    val ok: bool = buf_eq(?b, ?e[0], 238);
     enc.buf_dnit(?b);
     if (!ok) { ret 1; }
     ret 0;


### PR DESCRIPTION
Closes #1949.

## Problem
`build_subprogram_abbrev` hardcoded `DW_CHILDREN_yes` for both concrete subprogram abbrevs (`ABBREV_SUBPROGRAM` / `ABBREV_SUBPROGRAM_VOID`), and `build_info` always emitted a trailing null DIE. A subprogram with no formal parameters, no locals, and no inlined instances (e.g. a childless external) then advertised children it never emitted, tripping `llvm-dwarfdump --verify`:

```
warning: DW_TAG_subprogram has DW_CHILDREN_yes but DIE has no children
```

Pre-existing since #1703's single subprogram abbrev; surfaced by #1707's release `-g` verify leg. Warning only — `--verify` still exited clean — but fixed cleanly here.

## Fix
- Add `DW_CHILDREN_no` leaf variants `ABBREV_SUBPROGRAM_LEAF` (0x10) / `ABBREV_SUBPROGRAM_VOID_LEAF` (0x11), built via a new `kids` flag on `build_subprogram_abbrev`.
- `subprogram_has_children(f, …)` mirrors `build_info`'s child-emission conditions (a var surviving the inline-scope filter, or a top-level inlined_subroutine instance).
- `build_info` selects the leaf abbrev when there are no children and omits the null terminator.
- `build_abbrev:golden` extended to the two new abbrevs (238 bytes).

## Verification
- Unit suite 539/0 (golden test passes).
- dbg lane (debug + release-inline legs, all 3 ISAs) — see PR comment once run.