### PR TITLE
fix(debuginfo): stray line-table row misattributes a std address to the entry module (#1902)

### DIFF
--- a/dbg/verify.sh
+++ b/dbg/verify.sh
@@ -289,6 +289,33 @@ verify_inline_release() {
     return 0
 }
 
+# verify_no_foreign_file <fixture_dir> <build_target> — regression for #1902 (loc
+# provenance leak). A std dependency object's .debug_line must never list the entry
+# module (main.mach) as a source file: a synthesized instruction left with a zeroed
+# {0,0} location used to read as file 0 (the first-registered = entry module) and emit
+# a stray row misattributing a std address to main.mach:1. With FILE_NIL == 0 a zeroed
+# loc is loc_nil and drops. Scans every std object under the fixture's obj tree.
+verify_no_foreign_file() {
+    dir=$1; bt=$2
+    label="${dir#"$here"/} [$bt no-foreign-file]"
+    tmp=$(mktemp -d)
+    if ! (cd "$dir" && "$compiler" dep pull && "$compiler" build . --target "$bt" --profile debug -g -o "$tmp/g") >"$tmp/b.log" 2>&1; then
+        echo "FAIL $label (build)"; sed 's/^/    /' "$tmp/b.log" >&2; rm -rf "$tmp"; return 1
+    fi
+    objdir="$dir/out/$bt/debug/obj"
+    bad=0
+    for o in $(find "$objdir" -path '*std*' -name '*.o' 2>/dev/null); do
+        if "$dwarfdump" --debug-line "$o" 2>/dev/null | grep -q 'main\.mach'; then
+            echo "FAIL $label (${o#"$objdir"/} attributes a .debug_line row to the entry module main.mach)" >&2
+            bad=$((bad + 1))
+        fi
+    done
+    rm -rf "$tmp"
+    if [ "$bad" -ne 0 ]; then return 1; fi
+    echo "PASS $label"
+    return 0
+}
+
 for dir in "$fixtures"/$filter; do
     [ -f "$dir/mach.toml" ] || continue
     # the inline fixtures are release-only (their callees inline away at -O0); they have
@@ -314,6 +341,16 @@ if [ -f "$fixtures/inline4/mach.toml" ]; then
     for bt in $elf_targets; do
         ran=$((ran + 1))
         verify_inline_release "$fixtures/inline4" "$bt" 4 "a b c d" || fails=$((fails + 1))
+    done
+fi
+
+# #1902 regression: no std dependency object may attribute a .debug_line row to the
+# entry module. The multi fixture is a [bin] main.mach pulling std, so its std objects
+# are the exact surface the loc-provenance leak corrupted.
+if [ -f "$fixtures/multi/mach.toml" ]; then
+    for bt in $elf_targets; do
+        ran=$((ran + 1))
+        verify_no_foreign_file "$fixtures/multi" "$bt" || fails=$((fails + 1))
     done
 fi
 

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -1057,9 +1057,9 @@ fun is_f32_type(types: *type.IrTypeTable, id: type.IrTypeId) bool {
 # final offset matches the final `.text`
 test "mach.lang.be.codegen.pack_rows:rehomes_sectioned_and_text" {
     var rows: [3]encode.LineRow;
-    rows[0].text_offset = 0;  rows[0].sec = 0; rows[0].loc = source.loc(0, 100);
-    rows[1].text_offset = 10; rows[1].sec = 0; rows[1].loc = source.loc(0, 200);
-    rows[2].text_offset = 20; rows[2].sec = 0; rows[2].loc = source.loc(0, 300);
+    rows[0].text_offset = 0;  rows[0].sec = 0; rows[0].loc = source.loc(1, 100);
+    rows[1].text_offset = 10; rows[1].sec = 0; rows[1].loc = source.loc(1, 200);
+    rows[2].text_offset = 20; rows[2].sec = 0; rows[2].loc = source.loc(1, 300);
 
     var enc: encode.EncoderOutput;
     enc.rows      = ?rows[0];

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -1250,10 +1250,10 @@ test "mach.lang.be.codegen.encode.insert_text:shifts_line_rows" {
     for (i < 12) { emit_byte(?st.buf, 0x90); i = i + 1; }
 
     # three real rows at 0 / 4 / 8, plus a nil-location row that must be dropped.
-    val r0: R.Result[bool, str] = push_row(?st, 0, source.loc(0, 100)); if (R.is_err[bool, str](r0)) { ret 1; }
-    val r1: R.Result[bool, str] = push_row(?st, 4, source.loc(0, 200)); if (R.is_err[bool, str](r1)) { ret 1; }
+    val r0: R.Result[bool, str] = push_row(?st, 0, source.loc(1, 100)); if (R.is_err[bool, str](r0)) { ret 1; }
+    val r1: R.Result[bool, str] = push_row(?st, 4, source.loc(1, 200)); if (R.is_err[bool, str](r1)) { ret 1; }
     val rn: R.Result[bool, str] = push_row(?st, 4, source.loc_nil());   if (R.is_err[bool, str](rn)) { ret 1; }
-    val r2: R.Result[bool, str] = push_row(?st, 8, source.loc(0, 300)); if (R.is_err[bool, str](r2)) { ret 1; }
+    val r2: R.Result[bool, str] = push_row(?st, 8, source.loc(1, 300)); if (R.is_err[bool, str](r2)) { ret 1; }
     if (st.row_count != 3) { buf_dnit(?st.buf); ret 1; }
 
     # open a 4-byte gap at offset 4 (as a relaxed branch would).

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -502,8 +502,9 @@ pub fun push_instr(ctx: *LowerCtx, mb: *mir.MirBlock, mi: mir.MirInstr) R.Result
     var ni: mir.MirInstr = mi;
     if (ni.opcode != mir.MIR_ASM) { ni.asm_block = nil; }
     # stamp the source location of the IR instruction being lowered, at the single
-    # append chokepoint - the same reason asm_block is nil'd here (struct locals are
-    # not zero-initialized, so an unstamped loc would carry residue).
+    # append chokepoint, so every MirInstr carries its real source line. (a residual
+    # unstamped loc is zeroed to {FILE_NIL=0, 0} == loc_nil == no row, harmless, but
+    # the real loc is what the line table wants.)
     ni.loc = ctx.cur_loc;
     # the inline instance rides beside loc, stamped at the same chokepoint for the same
     # non-zero-init reason, so every lowered instruction carries its inlined-from origin.

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -603,11 +603,11 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
         mi.width     = iw;
         mi.src_width = iw;
     }
-    # this splice bypasses lctx.push_instr, so enforce the asm_block invariant here:
-    # struct locals are not zero-initialized, and regalloc.flatten reads a non-nil
-    # asm_block as an inline-asm clobber barrier. the same non-zero-init reasoning
-    # applies to `loc` (FILE_NIL is not 0) and the dbg-binding list (the encoder reads
-    # it), so stamp the location and empty the binding list.
+    # this splice bypasses lctx.push_instr, so enforce its invariants here: asm_block
+    # is nil'd (struct locals are not zero-initialized, and regalloc.flatten reads a
+    # non-nil asm_block as an inline-asm clobber barrier), and loc is stamped from the
+    # cursor so the move carries the real source line (an unstamped loc would be a
+    # zeroed {FILE_NIL, 0} == loc_nil, correctly no row, since FILE_NIL is 0).
     mi.asm_block         = nil;
     mi.loc               = ctx.cur_loc;
     mi.inline_site       = ctx.cur_inline_site;

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -3014,8 +3014,8 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
     dst[@wp].src_width     = mi.src_width;
     dst[@wp].asm_block     = mi.asm_block;
     # carry the source location through register assignment so the encoder's line
-    # table still maps this instruction's final bytes to its origin (the zeroed
-    # buffer would otherwise leave file 0, a real FileId, not FILE_NIL).
+    # table maps this instruction's final bytes to its origin. (a zeroed slot is
+    # {FILE_NIL=0, 0} == loc_nil, harmless; this still carries the real loc.)
     dst[@wp].loc           = mi.loc;
     # carry the inline instance through likewise; the zeroed buffer would otherwise
     # drop every instruction back to the function body and erase the channel.
@@ -3161,7 +3161,7 @@ fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, 
     dst[@wp].width         = ctx.spill_width;
     dst[@wp].src_width     = ctx.spill_width;
     # inherit the served instruction's location so a reload-before-use is attributed
-    # to the line it serves (the zeroed buffer would otherwise leave file 0).
+    # to the line it serves.
     dst[@wp].loc           = loc;
     # and its inline instance, so a reload inside an inlined expansion stays within
     # that instance's PC range instead of splitting it at the body.

--- a/src/lang/source.mach
+++ b/src/lang/source.mach
@@ -30,8 +30,10 @@ use mach.lang.query;
 pub def FileId: u32;
 
 # sentinel FileId naming no source file, carried by a synthesized or as-yet-unset
-# location. distinct from every real FileId, which the SourceMap assigns from 0
-pub val FILE_NIL: FileId = 0xFFFFFFFF;
+# location. it is 0, and the SourceMap assigns real FileIds from 1, so zero-initialized
+# memory (a SrcLoc left `{0, 0}`) reads as loc_nil BY CONSTRUCTION -- a synthesized
+# instruction that forgets to stamp a location can never masquerade as file 0 / line 1
+pub val FILE_NIL: FileId = 0;
 
 # a source location: a file handle plus a byte offset into that file's text
 #
@@ -146,7 +148,9 @@ pub fun init(a: *A.Allocator) SourceMap {
 pub fun dnit(m: *SourceMap) {
     if (m == nil) { ret; }
 
-    var i: usize = 0;
+    # slot 0 is the FILE_NIL sentinel (reserved by add, never populated); real files
+    # occupy 1..len, so free from index 1.
+    var i: usize = 1;
     for (i < m.len) {
         val file: *SourceFile = ?m.files[i];
         str_free(m.a, file.path);
@@ -174,6 +178,13 @@ pub fun dnit(m: *SourceMap) {
 # text: source text to index and store; the stored copy is null-terminated
 # ret:  FileId of the newly added file, or an allocation error
 pub fun add(m: *SourceMap, db: *query.QueryDb, path: str, text: str) R.Result[FileId, str] {
+    # reserve FileId 0 as the FILE_NIL sentinel so real ids start at 1 (see FILE_NIL).
+    # slot 0 is never read (get rejects it) or freed (dnit skips it).
+    if (m.len == 0) {
+        val res_sentinel: R.Result[bool, str] = files_reserve(m);
+        if (R.is_err[bool, str](res_sentinel)) { ret R.err[FileId, str](R.unwrap_err[bool, str](res_sentinel)); }
+        m.len = 1;
+    }
     var line_len: usize = 0;
     val res_starts: R.Result[*usize, str] = line_index_build(m.a, text, ?line_len);
     if (R.is_err[*usize, str](res_starts)) {
@@ -325,7 +336,7 @@ pub fun load(m: *SourceMap, db: *query.QueryDb, interner: *intern.Interner, path
 # ret: some(*SourceFile) into the map's files array (invalidated by a later add
 #      that grows the array), or none when id is out of range
 pub fun get(m: *SourceMap, id: FileId) O.Option[*SourceFile] {
-    if (id::usize >= m.len) { ret O.none[*SourceFile](); }
+    if (id == FILE_NIL || id::usize >= m.len) { ret O.none[*SourceFile](); }
     ret O.some[*SourceFile](?m.files[id]);
 }
 
@@ -488,7 +499,8 @@ test "mach.lang.source.load:dedup_by_path" {
 
     if (fid1 != fid2)       { ret 1; }
     if (m.by_path.len != 1) { ret 1; }
-    if (m.len != 1)         { ret 1; }
+    # m.len counts the reserved FILE_NIL sentinel (slot 0) plus the one real file.
+    if (m.len != 2)         { ret 1; }
 
     val file1: *SourceFile = ?m.files[fid1::usize];
     if (str_len(file1.text) != 1) { ret 1; }
@@ -500,7 +512,8 @@ test "mach.lang.source.load:dedup_by_path" {
     val fid3: FileId = R.unwrap_ok[FileId, str](res3);
     if (fid3 == fid1)       { ret 1; }
     if (m.by_path.len != 2) { ret 1; }
-    if (m.len != 2)         { ret 1; }
+    # sentinel slot 0 plus the two distinct real files.
+    if (m.len != 3)         { ret 1; }
 
     dnit(?m);
     intern.dnit(?ix);


### PR DESCRIPTION
Closes #1902.

## Problem
Under `-g`, a std dependency object's `.debug_line` listed the entry module (`main.mach`) as a source file and emitted a stray row mapping a real std address to it (e.g. `close_inherited_fds` -> `./src/main.mach:1`, a `use`/comment line with no code).

## Root cause (not the issue's hypothesis)
It is **not** a cursor-not-reset leak. A synthesized backend instruction reached the encoder with a **zeroed `{file:0, offset:0}` location**, distinct from `loc_nil` (`{FILE_NIL=0xFFFFFFFF, 0}`). Because `FILE_NIL` was `0xFFFFFFFF`, `file:0` was a *real* FileId — the first-registered (entry) module — and `offset:0` its line 1, so `push_row`/`loc_is_valid` kept it. The scattered per-site loc stamping (regalloc, splice, reload/store, push_instr) was the codebase repeatedly patching this exact `{0,0}`-is-file-0 ambiguity.

## Fix (structural — kills the class)
Re-encode so **zero is invalid**: `FILE_NIL = 0`, and the `SourceMap` reserves FileId 0 as the sentinel, assigning real files from 1. A zero-initialized `SrcLoc` is now `loc_nil` **by construction**, which the encoder's existing `loc_is_valid` drop already handles — so a synthesized instruction that forgets to stamp a location can never masquerade as file 0 / line 1 again, even on future alloc paths.

- `source.mach`: `FILE_NIL = 0`; `add` reserves slot 0; `get` rejects the sentinel; `dnit` skips it. Accessors stay `m.files[id]` (id == index).
- Corrected the now-inaccurate file-0 rationale in the loc-stamp comments. The stamps themselves stay — they carry the real `cur_loc`/`mi.loc` for line accuracy (reduced to meaningful-loc stamping, per review).
- Fixed unit tests that used file 0 as a valid file (now the sentinel).

## Sweep notes
- FILE_NIL had only 3 code uses (all `source.mach`). FileIds are **not** persisted to disk (query keys are in-memory, reset per compilation), so no incremental-cache cold start.
- `m.len` now counts the sentinel + real files; `by_path.len` is the real count. Only one dedup test read `m.len` as a count (updated).

## Verification
- Reproduced: pre-fix 4 std objects leak `main.mach`; **post-fix 0**.
- Falsifiable regression `verify_no_foreign_file` (dbg lane, all 3 ISAs): fails pre-fix, passes post-fix.
- Unit suite 539/0; full dbg lane 12/12; **non-g machine code byte-identical** (loc is compile-time only).