### PR TITLE
fix(x64): stamp loc + inline_site on isel expansion pieces (#1902 origin)

### DIFF
--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -201,12 +201,21 @@ fun select_block(a: *A.Allocator, b: *mir.MirBlock) R.Result[bool, str] {
             w = w + 1;
         }
         or {
-            # the expansion pieces are zeroed (no dbg bindings); move the source's -g
-            # binding list onto the first piece, at whose PC the variable becomes live,
-            # so it is neither lost nor leaked when `mi` is discarded.
+            # the expansion pieces are built field-wise into the zeroed dst buffer, so
+            # stamp the source instruction's identity fields here — the single chokepoint
+            # for every expander (#1902: an unstamped loc was {0,0} == a real file 0 / line
+            # 1 pre-#1902; each piece's PC belongs to the source's line and inline instance).
+            # the -g binding list moves onto the FIRST piece, at whose PC the variable
+            # becomes live, so it is neither lost nor leaked when `mi` is discarded.
             val first: u32 = w;
             val res_expand: R.Result[bool, str] = expand_instr(a, mi, dst, ?w);
             if (R.is_err[bool, str](res_expand)) { ret res_expand; }
+            var p: u32 = first;
+            for (p < w) {
+                dst[p].loc         = mi.loc;
+                dst[p].inline_site = mi.inline_site;
+                p = p + 1;
+            }
             dst[first].dbg_bindings      = mi.dbg_bindings;
             dst[first].dbg_binding_count = mi.dbg_binding_count;
         }


### PR DESCRIPTION
Follow-up to #1902 (its origin fix, which missed the #1951 merge — a race merged the earlier head with only the b2 structural safety net + regression, leaving this one commit stranded on the branch, already CI-green).

## What
The x64 isel expands `NEG`/`NOT` into two instructions (`expand_neg`/`expand_not` → `emit_binary`), building each piece **field-wise into a zallocated (zeroed) dst buffer** — setting opcode/operands/width but **omitting `loc` and `inline_site`**. That is the actual origin of #1902's stray row: `~(0::usize)` → `mov; xor` left both pieces at `{0,0}`. On merged dev, #1951's `FILE_NIL = 0` makes that benign (dropped row), but the expanded instruction still has **degraded line info** (no row of its own) and, worse, a **dropped `inline_site`** for expanded ops inside inlined bodies (a latent #1707 misattribution).

## Fix
Stamp `loc` + `inline_site` from the source instruction onto every expansion piece at the single expand chokepoint (beside the existing dbg-binding fixup). One place, covers every current/future x64 expander — the minimal "single-constructor" shape. The `xor` now attributes to its real line instead of being dropped. arm64/riscv64 rewrite NEG/NOT in place (no expander), so they were unaffected.

## Verification
- The stray stays 0 (both #1951's b2 and this hold it), and the `~`-expansion `xor` now resolves to its correct source line (was dropped under b2 alone).
- Unit 539/0, dbg lane 12/12, non-g machine code byte-identical, self-host fixpoint S1==S2, 15/15 CI (verified pre-strand as commit e50ce6f0).