### PR TITLE
fix(cd): reconcile main's cd.yml with dev (V2-only)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,18 +69,14 @@ jobs:
         run: |
           set -euo pipefail
           mach dep pull
-          if grep -q "\[artifact\." mach.toml; then
-            echo "V2 manifest detected. Running full fixpoint build..."
-            mach build . --profile release -o a
-            ./a build . --profile release -o b
-            ./b build . --profile release -o c
-            if ! cmp -s b c; then
-              echo "::error::build did not converge to the fixpoint"
-              exit 1
-            fi
-          else
-            echo "V1 manifest detected. Running bootstrap build..."
-            mach build . --profile release -o c
+          mach build . --profile release -o a
+          ./a build . --profile release -o b
+          ./b build . --profile release -o c
+
+          # ship the fixpoint: b == c (stage2 vs stage3) or the build is non-deterministic
+          if ! cmp -s b c; then
+            echo "::error::build did not converge to the fixpoint"
+            exit 1
           fi
 
       # the whole-compiler capstone of the -g additivity guard: build the compiler at
@@ -89,13 +85,7 @@ jobs:
       # per-PR because it costs two more full self-builds; the per-PR debuginfo lane
       # already asserts additivity on the fixtures across all three ELF ISAs. #1944.
       - name: verify -g additivity of the compiler itself
-        run: |
-          if grep -q "\[artifact\." mach.toml; then
-            echo "V2 manifest detected. Verifying additivity..."
-            bash dbg/self-additive.sh ./c
-          else
-            echo "V1 manifest detected. Skipping additivity check..."
-          fi
+        run: bash dbg/self-additive.sh ./c
 
       - name: package archive
         env:
@@ -149,23 +139,17 @@ jobs:
         run: |
           mach.exe dep pull
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $has_v2 = Select-String -Path mach.toml -Pattern "\[artifact\." -SimpleMatch -Quiet
-          if ($has_v2) {
-            Write-Output "V2 manifest detected. Running full fixpoint build..."
-            mach.exe build . --profile release -o a.exe
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-            ./a.exe build . --profile release -o b.exe
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-            ./b.exe build . --profile release -o c.exe
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-            if ((Get-FileHash b.exe).Hash -ne (Get-FileHash c.exe).Hash) {
-              Write-Error 'build did not converge to the fixpoint'
-              exit 1
-            }
-          } else {
-            Write-Output "V1 manifest detected. Running bootstrap build..."
-            mach.exe build . --profile release -o c.exe
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          mach.exe build . --profile release -o a.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          ./a.exe build . --profile release -o b.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          ./b.exe build . --profile release -o c.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          # ship the fixpoint: b == c (stage2 vs stage3) or the build is non-deterministic
+          if ((Get-FileHash b.exe).Hash -ne (Get-FileHash c.exe).Hash) {
+            Write-Error 'build did not converge to the fixpoint'
+            exit 1
           }
 
       - name: package archive
@@ -223,14 +207,8 @@ jobs:
         run: |
           set -euo pipefail
           mach dep pull
-          if grep -q "\[artifact\." mach.toml; then
-            echo "V2 manifest detected. Running self-hosted cross-build..."
-            mach build . -o m
-            ./m build . --target "$TRIPLE" --profile release -o mach-darwin-seed
-          else
-            echo "V1 manifest detected. Running direct cross-build..."
-            mach build . --target "$TRIPLE" --profile release -o mach-darwin-seed
-          fi
+          mach build . -o m
+          ./m build . --target "$TRIPLE" --profile release -o mach-darwin-seed
 
       - name: upload seed
         uses: actions/upload-artifact@v4
@@ -277,19 +255,18 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x seed/mach-darwin-seed
+
+          # stage-0 is the cross-built seed; a/b/c self-host on the macOS runner
+          # (arm64 natively, or x86_64 under Rosetta)
           ./seed/mach-darwin-seed dep pull
-          if grep -q "\[artifact\." mach.toml; then
-            echo "V2 manifest detected. Running full fixpoint build..."
-            ./seed/mach-darwin-seed build . --profile release -o a
-            ./a build . --profile release -o b
-            ./b build . --profile release -o c
-            if ! cmp -s b c; then
-              echo "::error::darwin build did not converge to the fixpoint"
-              exit 1
-            fi
-          else
-            echo "V1 manifest detected. Using the seed directly as compiler..."
-            cp seed/mach-darwin-seed c
+          ./seed/mach-darwin-seed build . --profile release -o a
+          ./a build . --profile release -o b
+          ./b build . --profile release -o c
+
+          # ship the fixpoint: b == c (stage2 vs stage3) or the build is non-deterministic
+          if ! cmp -s b c; then
+            echo "::error::darwin build did not converge to the fixpoint"
+            exit 1
           fi
 
       - name: self test
@@ -298,12 +275,7 @@ jobs:
           # exercises a mach-built darwin binary — arm64 native, or x86_64 under
           # Rosetta — whose ad-hoc signature must hold (no SIGKILL) for the fixpoint
           # and these tests to pass
-          if grep -q "\[artifact\." mach.toml; then
-            echo "V2 manifest detected. Running self test..."
-            ./c test .
-          else
-            echo "V1 manifest detected. Skipping self test..."
-          fi
+          ./c test .
 
       - name: package archive
         if: github.event_name == 'push'


### PR DESCRIPTION
Closes #1978

## Problem

The V2 landing force-rewrote `dev` after PR #1973; main's v3.0.0 sweep (`ba611ab8`) captured the old pre-rewrite `dev`, leaving `origin/main`'s `cd.yml` ~96 lines diverged. Because `dev` is a full ancestor of `main`, no routine dev→main sweep touches those lines, so main keeps the stale version indefinitely.

## Root cause

Both branches share base `0dd83ccf` (the #1963 compiler-self `-g` additivity guard). Main then carries two feature-branch-era commits that `dev` never got:

- `3a39c3ef` fix(cd): make self-hosted fixpoint builds conditional on v2 manifest presence
- `0f521a51` fix(cd): make self-additive and self-test verification conditional on v2 manifest

These wrapped four steps in `grep -q "\[artifact\." mach.toml` V1/V2 branches for the transition window. The self-manifest is now permanently V2 (`mach.toml` v3.0.2 has `[project]` + `[artifact.mach]`), so the grep is always true and every V1 `else` leg is dead code. `dev`'s version already removed them — it is the reconciled truth.

## Case: main-only

`dev`'s current `cd.yml` **is** the reconciled content. This PR lands that exact content on `main`; no dev mirror PR is needed. After merge, `git diff main dev -- .github/workflows/cd.yml` is empty.

## Hunks reconciled (all: drop the V1 `else`, keep the V2 leg)

| Step | Kept | Dropped |
|---|---|---|
| build-linux · build fixpoint | unconditional a/b/c fixpoint + `cmp` convergence | V1 single `mach build -o c` bootstrap |
| build-linux · verify -g additivity | unconditional `bash dbg/self-additive.sh ./c` (**#1963 guard preserved**) | V1 skip |
| build-windows · build fixpoint | unconditional a/b/c fixpoint + hash convergence | V1 single-build bootstrap |
| seed-darwin · cross-build seed | self-hosted `mach build -o m` then `./m build --target` | V1 direct `mach build --target` |
| build-darwin · build fixpoint | unconditional a/b/c fixpoint + `cmp` | V1 `cp seed c` |
| build-darwin · self test | unconditional `./c test .` | V1 skip |

## Verification

- YAML parses (`yaml.safe_load`).
- Reconciled file is byte-identical to `origin/dev:.github/workflows/cd.yml` (already exercising in CI on dev).
- Release path walked against **main**'s tree (where the workflow runs): tag → `verify` (greps `^version = "3.0.2"` from V2 `mach.toml`) → build jobs → dist archives → `release`. Every referenced path/flag/key exists on main:
  - `dbg/self-additive.sh` present, takes `<compiler>` — called `./c`.
  - `LICENSE` present.
  - CLI: `--profile` (config.mach:110), `--target` (config.mach:108), `-o` (config.mach:109), `build`/`test`/`dep pull` all valid; `--target` triples `darwin-aarch64`/`darwin-x86_64` match `[target.darwin-*]` manifest names.
  - Output uses explicit `-o a/b/c`, not the `out/{target.name}/{profile.name}` template, so no dependence on the project out shape.