### PR TITLE
fix(manifest): #1969 residuals — string-form filters, local-path validation, test-link union, parser acceptance

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1591,9 +1591,14 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
         if (R.is_ok[intern.StrId, str](res_po_id)) {
             p.config.project_out = R.unwrap_ok[intern.StrId, str](res_po_id);
         }
+        # up-front local link path validation (#1969): a `local` entry's path must
+        # match a step's `out` (demanding it) or exist on disk; anything else errors
+        # here naming the entry, instead of flowing to the linker to fail at link time.
+        val vr: R.Result[bool, str] = validate_local_links(p, project_root, ?m, project_out_str, tn_s, pn_s);
+        if (R.is_err[bool, str](vr)) { str_free(p.s.alloc, project_out_str); manifest.dnit(?m, p.s.alloc); ret R.err[bool, str](R.unwrap_err[bool, str](vr)); }
         str_free(p.s.alloc, project_out_str);
     }
-    
+
     # Copy links to ProjectConfig
     p.config.links      = nil;
     p.config.link_count = 0;
@@ -1869,6 +1874,70 @@ fun dcopy(buf: *u8, k: usize, s: str) usize {
     var j: usize = 0;
     for (j < n) { buf[k + j] = s[j]; j = j + 1; }
     ret k + n;
+}
+
+# build the up-front local-path validation error for a link entry that names
+# neither a step output nor an existing file
+fun local_link_error(alloc: *A.Allocator, name: str, path: str) str {
+    val a: str = "mach.toml: [link.";
+    val b: str = "] path '";
+    val c: str = "' matches no step output and does not exist on disk";
+    val total: usize = str_len(a) + str_len(name) + str_len(b) + str_len(path) + str_len(c);
+    val r: R.Result[*u8, str] = A.allocate[u8](alloc, total + 1);
+    if (R.is_err[*u8, str](r)) { ret "mach.toml: a local link path matches no step output and does not exist on disk"; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    k = dcopy(buf, k, a);
+    k = dcopy(buf, k, name);
+    k = dcopy(buf, k, b);
+    k = dcopy(buf, k, path);
+    k = dcopy(buf, k, c);
+    buf[total] = 0;
+    ret buf::str;
+}
+
+# validate every `local` [link.X] path up-front (#1969): it must match a declared
+# step's `out` (which will produce it) or already exist on disk, else an error names
+# the entry here rather than failing at link time. paths expand against the build
+# cell; the disk check resolves relative to the project root.
+fun validate_local_links(p: *Project, project_root: str, m: *manifest.Manifest, proj_out: str, tn: str, pn: str) R.Result[bool, str] {
+    val local_r: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, "local");
+    if (R.is_err[intern.StrId, str](local_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](local_r)); }
+    val local_id: intern.StrId = R.unwrap_ok[intern.StrId, str](local_r);
+
+    var li: u32 = 0;
+    for (li < m.link_count) {
+        val l: *manifest.LinkDef = ?m.links[li];
+        if (l.source == local_id) {
+            val path_opt: O.Option[str] = intern.lookup(?p.s.interner, l.path);
+            val name_opt: O.Option[str] = intern.lookup(?p.s.interner, l.name);
+            if (O.is_none[str](path_opt) || O.is_none[str](name_opt)) { ret R.err[bool, str]("internal: link entry metadata not interned"); }
+            val raw_path: str = O.unwrap[str](path_opt);
+            val ename:    str = O.unwrap[str](name_opt);
+
+            val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, raw_path, proj_out, tn, pn, "", "");
+            if (R.is_err[str, str](exp_r)) { ret R.err[bool, str](R.unwrap_err[str, str](exp_r)); }
+            val exp: str = R.unwrap_ok[str, str](exp_r);
+
+            var ok_: bool = manifest.local_path_demanded_by_step(p.s.alloc, ?p.s.interner, m, exp, proj_out, tn, pn);
+            if (!ok_) {
+                val abs_r: R.Result[str, str] = join_path(p.s.alloc, project_root, exp);
+                if (R.is_ok[str, str](abs_r)) {
+                    val abs: str = R.unwrap_ok[str, str](abs_r);
+                    ok_ = filesystem.exists(abs);
+                    str_free(p.s.alloc, abs);
+                }
+            }
+            if (!ok_) {
+                val msg: str = local_link_error(p.s.alloc, ename, exp);
+                str_free(p.s.alloc, exp);
+                ret R.err[bool, str](msg);
+            }
+            str_free(p.s.alloc, exp);
+        }
+        li = li + 1;
+    }
+    ret R.ok[bool, str](true);
 }
 
 fun intern_unwrap(itn: *intern.Interner, text: str) intern.StrId {

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1584,7 +1584,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     val tn_s: str = O.unwrap[str](intern.lookup(?p.s.interner, bu.target.name));
     val pn_s: str = O.unwrap[str](intern.lookup(?p.s.interner, bu.profile_name));
     val out_tmpl_s: str = O.unwrap[str](intern.lookup(?p.s.interner, m.out_tmpl));
-    val res_project_out_str: R.Result[str, str] = manifest.expand(p.s.alloc, out_tmpl_s, tn_s, pn_s, "", "");
+    val res_project_out_str: R.Result[str, str] = manifest.expand(p.s.alloc, out_tmpl_s, "", tn_s, pn_s, "", "");
     if (R.is_ok[str, str](res_project_out_str)) {
         val project_out_str: str = R.unwrap_ok[str, str](res_project_out_str);
         val res_po_id: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, project_out_str);
@@ -2158,7 +2158,7 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
                             val target_name: str = O.unwrap[str](tn_opt);
                             val pn_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.profile);
                             val profile_name: str = O.unwrap[str](pn_opt);
-                            val dep_out_r: R.Result[str, str] = manifest.expand(p.s.alloc, out_tmpl, target_name, profile_name, "", "");
+                            val dep_out_r: R.Result[str, str] = manifest.expand(p.s.alloc, out_tmpl, "", target_name, profile_name, "", "");
                             val dep_out: str = R.unwrap_ok[str, str](dep_out_r);
                             val suffix: str = step_seg_dup(p.s.alloc, raw_path, 13, str_len(raw_path));
                             val full_p_r: R.Result[str, str] = join_path(p.s.alloc, dep_out, suffix);
@@ -2171,7 +2171,7 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
                             val target_name: str = O.unwrap[str](tn_opt);
                             val pn_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.profile);
                             val profile_name: str = O.unwrap[str](pn_opt);
-                            val expanded_path_r: R.Result[str, str] = manifest.expand(p.s.alloc, raw_path, target_name, profile_name, "", "");
+                            val expanded_path_r: R.Result[str, str] = manifest.expand(p.s.alloc, raw_path, "", target_name, profile_name, "", "");
                             expanded_path = R.unwrap_ok[str, str](expanded_path_r);
                         }
                         val full_p_r: R.Result[str, str] = join_path(p.s.alloc, dep_vr, expanded_path);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -597,7 +597,7 @@ fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Se
         ret R.err[Project, str](R.unwrap_err[bool, str](q_r));
     }
 
-    val cfg_r: R.Result[bool, str] = load_project_config(?p, project_root, sel, for_union);
+    val cfg_r: R.Result[bool, str] = load_project_config(?p, project_root, sel, for_union, all_own_src);
     if (R.is_err[bool, str](cfg_r)) {
         dnit_project(?p);
         ret R.err[Project, str](R.unwrap_err[bool, str](cfg_r));
@@ -1468,7 +1468,7 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
 
 # read and parse `<project_root>/mach.toml`, then synthesize the ProjectConfig
 # through load_config
-fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection, for_union: bool) R.Result[bool, str] {
+fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection, for_union: bool, is_test: bool) R.Result[bool, str] {
     val abs_root_r: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, project_root);
     if (R.is_err[intern.StrId, str](abs_root_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](abs_root_r)); }
     p.config.project_root = R.unwrap_ok[intern.StrId, str](abs_root_r);
@@ -1482,7 +1482,7 @@ fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection
     if (R.is_err[toml.Table, str](toml_r)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](toml_r)); }
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
-    ret load_config(p, project_root, ?t, sel, for_union);
+    ret load_config(p, project_root, ?t, sel, for_union, is_test);
 }
 
 # parse the manifest, resolve the build selection into one build
@@ -1490,7 +1490,7 @@ fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection
 # single target entry plus the unit's concrete, template-expanded output paths.
 # collisions are checked before anything is built. a `native` selection that
 # finds no host match emits an unmissable warning here
-fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.Selection, for_union: bool) R.Result[bool, str] {
+fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.Selection, for_union: bool, is_test: bool) R.Result[bool, str] {
     val mr: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, t);
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
@@ -1506,7 +1506,10 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     eff_sel.artifact     = sel.artifact;
     eff_sel.want_lib     = sel.want_lib;
     eff_sel.has_artifact = sel.has_artifact;
-    if (for_union && !eff_sel.has_artifact && m.artifact_count > 1) {
+    # `mach test` (is_test) links the whole source tree, not one artifact, so like a
+    # union build it takes the first declared artifact as the primary ctx rather than
+    # raising the multi-artifact ambiguity `build_project_sel` would.
+    if ((for_union || is_test) && !eff_sel.has_artifact && m.artifact_count > 1) {
         val an_opt: O.Option[str] = intern.lookup(?p.s.interner, m.artifacts[0].name);
         if (O.is_none[str](an_opt)) { manifest.dnit(?m, p.s.alloc); ret R.err[bool, str]("internal: union primary artifact name not interned"); }
         eff_sel.artifact     = O.unwrap[str](an_opt);
@@ -1596,6 +1599,18 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
         # here naming the entry, instead of flowing to the linker to fail at link time.
         val vr: R.Result[bool, str] = validate_local_links(p, project_root, ?m, project_out_str, tn_s, pn_s);
         if (R.is_err[bool, str](vr)) { str_free(p.s.alloc, project_out_str); manifest.dnit(?m, p.s.alloc); ret R.err[bool, str](R.unwrap_err[bool, str](vr)); }
+
+        # `mach test` links the union of every artifact's referenced entries (native
+        # target), not just the primary's, plus the exported dep entries the cascade
+        # pass adds below (#1964). replaces the single-artifact libs synthesized above.
+        if (is_test) {
+            var test_items: *intern.StrId = nil;
+            var test_count: u32 = 0;
+            val tlr: R.Result[bool, str] = manifest.resolve_test_libs(p.s.alloc, ?p.s.interner, ?m, bu.target, project_out_str, tn_s, pn_s, ?test_items, ?test_count);
+            if (R.is_err[bool, str](tlr)) { str_free(p.s.alloc, project_out_str); manifest.dnit(?m, p.s.alloc); ret R.err[bool, str](R.unwrap_err[bool, str](tlr)); }
+            p.config.targets[0].libs      = test_items;
+            p.config.targets[0].lib_count = test_count;
+        }
         str_free(p.s.alloc, project_out_str);
     }
 
@@ -1779,8 +1794,12 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
         manifest.dnit(?m, p.s.alloc);
         ret R.err[bool, str]("internal: selected target tuple not interned");
     }
+    # dedup exported dep entries against the effective own link surface: the union
+    # for a test build, the single artifact's libs otherwise (both held by the
+    # synthesized target entry).
     val cr2: R.Result[bool, str] = resolve_cascade_libs(p, project_root,
-        O.unwrap[str](isa_opt), O.unwrap[str](os_opt), O.unwrap[str](abi_opt), bu.libs, bu.lib_count);
+        O.unwrap[str](isa_opt), O.unwrap[str](os_opt), O.unwrap[str](abi_opt),
+        p.target_entry.libs, p.target_entry.lib_count);
     if (R.is_err[bool, str](cr2)) { manifest.dnit(?m, p.s.alloc); ret cr2; }
 
     # multi-target tooling build (#1391): record every manifest target's tuple so

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1418,6 +1418,78 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     ret R.ok[BuildUnit, str](u);
 }
 
+fun strid_in_buf(buf: *intern.StrId, count: u32, id: intern.StrId) bool {
+    var i: u32 = 0;
+    for (i < count) {
+        if (buf[i] == id) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# resolve the `mach test` link surface (#1964): the union of every artifact's
+# referenced link entries whose filters match target `t` (the native target for a
+# test build), deduplicated, each resolved to its link token. exported dep entries
+# are added separately by the driver's cascade pass. on success `out_items` and
+# `out_count` receive the union (nil/0 when empty).
+pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, t: *TargetDef,
+                          proj_out: str, tn: str, pn: str,
+                          out_items: **intern.StrId, out_count: *u32) R.Result[bool, str] {
+    @out_items = nil;
+    @out_count = 0;
+
+    var max: u32 = 0;
+    var ai: u32 = 0;
+    for (ai < m.artifact_count) { max = max + m.artifacts[ai].link_count; ai = ai + 1; }
+    if (max == 0) { ret R.ok[bool, str](true); }
+
+    val br: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](alloc, max::usize);
+    if (R.is_err[*intern.StrId, str](br)) { ret R.err[bool, str](R.unwrap_err[*intern.StrId, str](br)); }
+    val buf: *intern.StrId = R.unwrap_ok[*intern.StrId, str](br);
+    var w: u32 = 0;
+
+    ai = 0;
+    for (ai < m.artifact_count) {
+        val a: *ArtifactDef = ?m.artifacts[ai];
+        var li: u32 = 0;
+        for (li < a.link_count) {
+            val link_name: intern.StrId = a.link[li];
+            var found_l: *LinkDef = nil;
+            var lidx: u32 = 0;
+            for (lidx < m.link_count) {
+                if (m.links[lidx].name == link_name) { found_l = ?m.links[lidx]; }
+                lidx = lidx + 1;
+            }
+            if (found_l != nil) {
+                if (link_matches_target(itn, found_l, t)) {
+                    val tok_r: R.Result[intern.StrId, str] = link_token(alloc, itn, found_l, proj_out, tn, pn);
+                    if (R.is_err[intern.StrId, str](tok_r)) {
+                        A.deallocate[intern.StrId](alloc, buf, max::usize);
+                        ret R.err[bool, str](R.unwrap_err[intern.StrId, str](tok_r));
+                    }
+                    val tok: intern.StrId = R.unwrap_ok[intern.StrId, str](tok_r);
+                    if (!strid_in_buf(buf, w, tok)) { buf[w] = tok; w = w + 1; }
+                }
+            }
+            li = li + 1;
+        }
+        ai = ai + 1;
+    }
+
+    if (w == 0) { A.deallocate[intern.StrId](alloc, buf, max::usize); ret R.ok[bool, str](true); }
+    if (w < max) {
+        val sr: R.Result[*intern.StrId, str] = A.reallocate[intern.StrId](alloc, buf, max::usize, w::usize);
+        if (R.is_ok[*intern.StrId, str](sr)) {
+            @out_items = R.unwrap_ok[*intern.StrId, str](sr);
+            @out_count = w;
+            ret R.ok[bool, str](true);
+        }
+    }
+    @out_items = buf;
+    @out_count = w;
+    ret R.ok[bool, str](true);
+}
+
 fun artifact_err(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) str {
     if (m.artifact_count == 0) { ret "mach.toml: no [artifact.*] artifacts declared"; }
     if (sel.has_artifact) {
@@ -1954,6 +2026,39 @@ test "mach.lang.manifest.local_path_demanded_by_step" {
         # a path matching the step's expanded out is demanded; a near miss is not
         if (!local_path_demanded_by_step(?alloc, ?itn, ?m, "out/linux/obj/shim.o", "out/linux", "linux", "debug")) { code = 1; }
         if ( local_path_demanded_by_step(?alloc, ?itn, ?m, "out/linux/obj/nope.o", "out/linux", "linux", "debug")) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.resolve_test_libs:union" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    # `mach test` links the union of every artifact's referenced entries, filtered
+    # to the native target and deduplicated: app->{a,shared}, tool->{b,shared,c};
+    # c filters out (windows-only) and shared dedups, so the union is {a,b,shared}.
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.a]\nsource=\"system\"\nname=\"liba\"\nos=\"*\"\n[link.b]\nsource=\"system\"\nname=\"libb\"\nos=\"linux\"\n[link.c]\nsource=\"system\"\nname=\"libc\"\nos=\"windows\"\n[link.shared]\nsource=\"system\"\nname=\"libshared\"\nos=\"*\"\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[\"a\",\"shared\"]\n[artifact.tool]\nkind=\"bin\"\nentry=\"t.mach\"\nout=\"bin/tool\"\ntargets=[\"*\"]\nlink=[\"b\",\"shared\",\"c\"]\n";
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
+        val tl: *TargetDef = find_target_by_name(?itn, ?m, "linux");
+        if (tl == nil) { code = 1; }
+        or {
+            var items: *intern.StrId = nil;
+            var count: u32 = 0;
+            val r: R.Result[bool, str] = resolve_test_libs(?alloc, ?itn, ?m, tl, "out/linux", "linux", "debug", ?items, ?count);
+            if (R.is_err[bool, str](r)) { code = 1; }
+            or {
+                if (count != 3) { code = 1; }
+                if (!strarr_has(?itn, items, count, "liba")) { code = 1; }
+                if (!strarr_has(?itn, items, count, "libb")) { code = 1; }
+                if (!strarr_has(?itn, items, count, "libshared")) { code = 1; }
+                if ( strarr_has(?itn, items, count, "libc")) { code = 1; }
+            }
+        }
     }
     arena.dnit(?ar);
     ret code;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -996,8 +996,14 @@ fun seg_dup(alloc: *A.Allocator, tmpl: str, start: usize, end: usize) str {
     ret buf::str;
 }
 
-fun tmpl_value(alloc: *A.Allocator, tmpl: str, start: usize, end: usize,
+fun tmpl_value(alloc: *A.Allocator, tmpl: str, start: usize, end: usize, project_out: str,
                target_name: str, profile_name: str, art_name: str, ext: str) R.Result[str, str] {
+    if (seg_eq(tmpl, start, end, "project.out")) {
+        # available everywhere except while expanding [project].out itself, where it
+        # would be self-referential (project_out is passed empty there).
+        if (str_empty(project_out)) { ret R.err[str, str]("mach.toml: '{project.out}' is not available in [project].out"); }
+        ret R.ok[str, str](project_out);
+    }
     if (seg_eq(tmpl, start, end, "target.name") || seg_eq(tmpl, start, end, "target"))  { ret R.ok[str, str](target_name); }
     if (seg_eq(tmpl, start, end, "profile.name") || seg_eq(tmpl, start, end, "profile")) { ret R.ok[str, str](profile_name); }
     if (seg_eq(tmpl, start, end, "name"))    { ret R.ok[str, str](art_name); }
@@ -1005,7 +1011,7 @@ fun tmpl_value(alloc: *A.Allocator, tmpl: str, start: usize, end: usize,
     ret R.err[str, str](cc3(alloc, "mach.toml: unknown template variable '{", seg_dup(alloc, tmpl, start, end), "}'"));
 }
 
-pub fun expand(alloc: *A.Allocator, tmpl: str,
+pub fun expand(alloc: *A.Allocator, tmpl: str, project_out: str,
                target_name: str, profile_name: str, art_name: str, ext: str) R.Result[str, str] {
     val n: usize = str_len(tmpl);
     var total: usize = 0;
@@ -1015,7 +1021,7 @@ pub fun expand(alloc: *A.Allocator, tmpl: str,
             var ii: usize = i + 1;
             for (ii < n && tmpl[ii] != '}') { ii = ii + 1; }
             if (ii >= n) { ret R.err[str, str]("mach.toml: unterminated '{' in a path template"); }
-            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, target_name, profile_name, art_name, ext);
+            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name, art_name, ext);
             if (R.is_err[str, str](res_value)) { ret R.err[str, str](R.unwrap_err[str, str](res_value)); }
             total = total + str_len(R.unwrap_ok[str, str](res_value));
             i = ii + 1;
@@ -1036,7 +1042,7 @@ pub fun expand(alloc: *A.Allocator, tmpl: str,
         if (tmpl[i] == '{') {
             var ii: usize = i + 1;
             for (ii < n && tmpl[ii] != '}') { ii = ii + 1; }
-            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, target_name, profile_name, art_name, ext);
+            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name, art_name, ext);
             val value: str = R.unwrap_ok[str, str](res_value);
             val vl: usize = str_len(value);
             var iii: usize = 0;
@@ -1229,6 +1235,23 @@ fun join_path_canonical(alloc: *A.Allocator, a: str, b: str) str {
     ret cc3(alloc, a_sub, "/", b_sub);
 }
 
+# resolve a matched link entry to its interned link token: the expanded path for a
+# `local` source, or the library name for system/framework. filters are assumed
+# already matched; `{project.out}` and the target/profile templates in a local path
+# resolve against the given build cell.
+fun link_token(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef, proj_out: str, tn: str, pn: str) R.Result[intern.StrId, str] {
+    if (l.source == intern_unwrap(itn, "local")) {
+        val raw_path: str = idstr(itn, l.path);
+        val expanded_r: R.Result[str, str] = expand(alloc, raw_path, proj_out, tn, pn, "", "");
+        if (R.is_err[str, str](expanded_r)) { ret R.err[intern.StrId, str](R.unwrap_err[str, str](expanded_r)); }
+        val expanded: str = R.unwrap_ok[str, str](expanded_r);
+        val res_int: R.Result[intern.StrId, str] = intern.intern(itn, expanded);
+        str_free(alloc, expanded);
+        ret res_int;
+    }
+    ret R.ok[intern.StrId, str](l.lib_name);
+}
+
 pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
     val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target);
     if (R.is_err[ResolvedTarget, str](res_target)) { ret R.err[BuildUnit, str](R.unwrap_err[ResolvedTarget, str](res_target)); }
@@ -1294,7 +1317,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     if (str_equals(os_name, "windows")) { ex = ".exe"; }
 
     # Expand project out
-    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), tn, pn, "", "");
+    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, pn, "", "");
     if (R.is_err[str, str](res_project_out)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_project_out)); }
     val proj_out: str = R.unwrap_ok[str, str](res_project_out);
 
@@ -1320,26 +1343,9 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
             }
             if (found_l != nil) {
                 if (link_matches_target(itn, found_l, rt.target)) {
-                    if (found_l.source == intern_unwrap(itn, "local")) {
-                        val raw_path: str = idstr(itn, found_l.path);
-                        var expanded_path: str;
-                        if (str_len(raw_path) >= 13 && str_equals(seg_dup(alloc, raw_path, 0, 13), "{project.out}")) {
-                            val suffix: str = seg_dup(alloc, raw_path, 13, str_len(raw_path));
-                            val full_p: str = join_path_canonical(alloc, proj_out, suffix);
-                            expanded_path = full_p;
-                            str_free(alloc, suffix);
-                        }
-                        or {
-                            val expanded_path_r: R.Result[str, str] = expand(alloc, raw_path, tn, pn, "", "");
-                            expanded_path = R.unwrap_ok[str, str](expanded_path_r);
-                        }
-                        val res_int: R.Result[intern.StrId, str] = intern.intern(itn, expanded_path);
-                        matched_items[match_count] = R.unwrap_ok[intern.StrId, str](res_int);
-                        str_free(alloc, expanded_path);
-                    }
-                    or {
-                        matched_items[match_count] = found_l.lib_name;
-                    }
+                    val tok_r: R.Result[intern.StrId, str] = link_token(alloc, itn, found_l, proj_out, tn, pn);
+                    if (R.is_err[intern.StrId, str](tok_r)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](tok_r)); }
+                    matched_items[match_count] = R.unwrap_ok[intern.StrId, str](tok_r);
                     match_count = match_count + 1;
                 }
             }
@@ -1373,7 +1379,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
 
     # Resolve artifact relative path
     val art_out_tmpl: intern.StrId = a.out;
-    val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), tn, pn, an, ex);
+    val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, pn, an, ex);
     if (R.is_err[str, str](res_art_out)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_art_out)); }
     val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
 
@@ -1430,7 +1436,7 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
     val paths: *str = R.unwrap_ok[*str, str](res_paths);
 
     # Expand project out
-    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), tn, profile_name, "", "");
+    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, profile_name, "", "");
     if (R.is_err[str, str](res_project_out)) { ret R.err[bool, str](R.unwrap_err[str, str](res_project_out)); }
     val proj_out: str = R.unwrap_ok[str, str](res_project_out);
 
@@ -1440,7 +1446,7 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
         val res_art_name: R.Result[str, str] = must_lookup(itn, a.name);
         if (R.is_err[str, str](res_art_name)) { ret R.err[bool, str](R.unwrap_err[str, str](res_art_name)); }
         val art_out_tmpl: intern.StrId = a.out;
-        val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), tn, profile_name, R.unwrap_ok[str, str](res_art_name), ex);
+        val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, profile_name, R.unwrap_ok[str, str](res_art_name), ex);
         if (R.is_err[str, str](res_art_out)) { ret R.err[bool, str](R.unwrap_err[str, str](res_art_out)); }
         val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
         paths[i] = join_path_canonical(alloc, proj_out, art_out_rel);
@@ -1859,6 +1865,49 @@ test "mach.lang.manifest.parse:link_filter_string_form" {
             if ( link_matches_target(?itn, find_link(?itn, ?m, "isa_str"), ta)) { code = 1; }
             if (!link_matches_target(?itn, find_link(?itn, ?m, "abi_str"), tl)) { code = 1; }
             if ( link_matches_target(?itn, find_link(?itn, ?m, "abi_str"), tw)) { code = 1; }
+        }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.expand:project_out" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    # {project.out} substitutes the expanded project out
+    val r1: R.Result[str, str] = expand(?alloc, "{project.out}/obj/x.o", "out/linux/release", "linux", "release", "", "");
+    if (R.is_err[str, str](r1) || !str_equals(R.unwrap_ok[str, str](r1), "out/linux/release/obj/x.o")) { code = 1; }
+
+    # referencing it while expanding [project].out itself (project_out empty) is an error
+    val r2: R.Result[str, str] = expand(?alloc, "{project.out}/x", "", "linux", "release", "", "");
+    if (R.is_ok[str, str](r2) || !str_contains(R.unwrap_err[str, str](r2), "not available in [project].out")) { code = 1; }
+
+    # an unknown variable is still a strict error
+    val r3: R.Result[str, str] = expand(?alloc, "{bogus}", "o", "t", "p", "", "");
+    if (R.is_ok[str, str](r3) || !str_contains(R.unwrap_err[str, str](r3), "unknown template variable")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.resolve_build_unit:local_project_out" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    # a local link path using {project.out} resolves to the expanded project out
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.obj]\nsource=\"local\"\npath=\"{project.out}/obj/shim.o\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = [\"obj\"]\n";
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
+        val ul: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("linux", "", "app", false, true));
+        if (R.is_err[BuildUnit, str](ul)) { code = 1; }
+        or {
+            val bu: BuildUnit = R.unwrap_ok[BuildUnit, str](ul);
+            if (bu.lib_count != 1) { code = 1; }
+            if (!strarr_has(?itn, bu.libs, bu.lib_count, "out/linux/obj/shim.o")) { code = 1; }
         }
     }
     arena.dnit(?ar);

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -290,6 +290,39 @@ fun parse_str_array(alloc: *A.Allocator, itn: *intern.Interner, arr: *toml.Array
     ret R.ok[StrArr, str](out);
 }
 
+# parse a link filter axis (os/isa/abi) that accepts a bare string or an array of
+# strings per #1964; a single string interns as a one-element list so `"linux"`
+# and `["linux"]` filter identically. an absent axis yields an empty list (match
+# any). a non-string, non-array value is a strict error.
+fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Table, key: str, label: str) R.Result[StrArr, str] {
+    var out: StrArr;
+    out.items = nil;
+    out.count = 0;
+    val v: *toml.Value = toml.get(sub, key);
+    if (v == nil) { ret R.ok[StrArr, str](out); }
+
+    if (v.tag == toml.TYPE_STRING) {
+        val res_items: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](alloc, 1::usize);
+        if (R.is_err[*intern.StrId, str](res_items)) { ret R.err[StrArr, str](R.unwrap_err[*intern.StrId, str](res_items)); }
+        out.items = R.unwrap_ok[*intern.StrId, str](res_items);
+        val res_elem: R.Result[intern.StrId, str] = intern.intern(itn, v.data.string);
+        if (R.is_err[intern.StrId, str](res_elem)) {
+            A.deallocate[intern.StrId](alloc, out.items, 1::usize);
+            ret R.err[StrArr, str](R.unwrap_err[intern.StrId, str](res_elem));
+        }
+        out.items[0] = R.unwrap_ok[intern.StrId, str](res_elem);
+        out.count = 1;
+        ret R.ok[StrArr, str](out);
+    }
+
+    if (v.tag == toml.TYPE_ARRAY) {
+        ret parse_str_array(alloc, itn, ?v.data.array,
+            cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
+    }
+
+    ret R.err[StrArr, str](cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
+}
+
 fun parse_opt_level(alloc: *A.Allocator, name: str, sub: *toml.Table) R.Result[MOpt, str] {
     val v: *toml.Value = toml.get(sub, "opt");
     if (v == nil)                   { ret R.ok[MOpt, str](MOPT_DEFAULT); }
@@ -437,10 +470,10 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table) R.Resu
     if (str_empty(id_str)) { ret R.err[Manifest, str]("mach.toml: [project] is missing required key 'id'"); }
     val ver_str: str = toml.get_str(proj, "version");
     if (str_empty(ver_str)) { ret R.err[Manifest, str]("mach.toml: [project] is missing required key 'version'"); }
+    # name/description are metadata the #1964 shape does not define; accepted when
+    # present, absent otherwise (STR_NIL). strict totality is #1971's flag-day.
     val name_str: str = toml.get_str(proj, "name");
-    if (str_empty(name_str)) { ret R.err[Manifest, str]("mach.toml: [project] is missing required key 'name'"); }
     val desc_str: str = toml.get_str(proj, "description");
-    if (str_empty(desc_str)) { ret R.err[Manifest, str]("mach.toml: [project] is missing required key 'description'"); }
     val src_str: str = toml.get_str(proj, "src");
     if (str_empty(src_str)) { ret R.err[Manifest, str]("mach.toml: [project] is missing required key 'src'"); }
     val out_str: str = toml.get_str(proj, "out");
@@ -453,8 +486,8 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table) R.Resu
 
     m.id = intern_unwrap(itn, id_str);
     m.version = intern_unwrap(itn, ver_str);
-    m.name = intern_unwrap(itn, name_str);
-    m.description = intern_unwrap(itn, desc_str);
+    m.name = intern_opt_unwrap(itn, name_str);
+    m.description = intern_opt_unwrap(itn, desc_str);
     m.src = intern_unwrap(itn, src_str);
     m.out_tmpl = intern_unwrap(itn, out_str);
     m.default_target = intern_unwrap(itn, "native");
@@ -767,47 +800,24 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
             d.path = intern.STR_NIL;
         }
 
-        val os_arr: *toml.Array = toml.get_array(sub, "os");
-        if (os_arr != nil) {
-            val res_os: R.Result[StrArr, str] = parse_str_array(alloc, itn, os_arr,
-                cc3(alloc, "mach.toml: ", label, ".os must be an array of strings"));
-            if (R.is_err[StrArr, str](res_os)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_os)); }
-            val os_v: StrArr = R.unwrap_ok[StrArr, str](res_os);
-            d.os = os_v.items;
-            d.os_count = os_v.count;
-        }
-        or {
-            d.os = nil;
-            d.os_count = 0;
-        }
+        val res_os: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "os", label);
+        if (R.is_err[StrArr, str](res_os)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_os)); }
+        val os_v: StrArr = R.unwrap_ok[StrArr, str](res_os);
+        d.os = os_v.items;
+        d.os_count = os_v.count;
 
-        val isa_arr: *toml.Array = toml.get_array(sub, "isa");
-        if (isa_arr != nil) {
-            val res_isa: R.Result[StrArr, str] = parse_str_array(alloc, itn, isa_arr,
-                cc3(alloc, "mach.toml: ", label, ".isa must be an array of strings"));
-            if (R.is_err[StrArr, str](res_isa)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_isa)); }
-            val isa_v: StrArr = R.unwrap_ok[StrArr, str](res_isa);
-            d.isa = isa_v.items;
-            d.isa_count = isa_v.count;
-        }
-        or {
-            d.isa = nil;
-            d.isa_count = 0;
-        }
+        val res_isa: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "isa", label);
+        if (R.is_err[StrArr, str](res_isa)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_isa)); }
+        val isa_v: StrArr = R.unwrap_ok[StrArr, str](res_isa);
+        d.isa = isa_v.items;
+        d.isa_count = isa_v.count;
 
-        val abi_arr: *toml.Array = toml.get_array(sub, "abi");
-        if (abi_arr != nil) {
-            val res_abi: R.Result[StrArr, str] = parse_str_array(alloc, itn, abi_arr,
-                cc3(alloc, "mach.toml: ", label, ".abi must be an array of strings"));
-            if (R.is_err[StrArr, str](res_abi)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_abi)); }
-            val abi_v: StrArr = R.unwrap_ok[StrArr, str](res_abi);
-            d.abi = abi_v.items;
-            d.abi_count = abi_v.count;
-        }
-        or {
-            d.abi = nil;
-            d.abi_count = 0;
-        }
+        val res_abi: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "abi", label);
+        if (R.is_err[StrArr, str](res_abi)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_abi)); }
+        val abi_v: StrArr = R.unwrap_ok[StrArr, str](res_abi);
+        d.abi = abi_v.items;
+        d.abi_count = abi_v.count;
+
         d.export = bool_or(toml.get_bool(sub, "export"), false);
 
         m.links[i] = d;
@@ -1487,6 +1497,15 @@ fun idstr(itn: *intern.Interner, id: intern.StrId) str {
     ret "?";
 }
 
+fun find_link(itn: *intern.Interner, m: *Manifest, name: str) *LinkDef {
+    var i: u32 = 0;
+    for (i < m.link_count) {
+        if (str_equals(idstr(itn, m.links[i].name), name)) { ret ?m.links[i]; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
 fun mk_sel(target: str, profile: str, artifact: str, want_lib: bool, has_artifact: bool) Selection {
     var s: Selection;
     s.target       = target;
@@ -1560,6 +1579,34 @@ test "mach.lang.manifest.parse:missing_required_keys" {
 
     val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
     if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: [project] is missing required key 'version'")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.parse:name_description_optional" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    # the #1964 shape omits name/description; a manifest without them parses, with
+    # both fields interned to STR_NIL. id/version/src/out stay required.
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (R.is_err[Manifest, str](a)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](a);
+        if (m.name != intern.STR_NIL)        { code = 1; }
+        if (m.description != intern.STR_NIL) { code = 1; }
+        if (!str_equals(idstr(?itn, m.id), "x")) { code = 1; }
+    }
+
+    # present name/description are still accepted and recorded verbatim
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"App\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (R.is_err[Manifest, str](b)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](b);
+        if (!str_equals(idstr(?itn, m.name), "App")) { code = 1; }
+        if (!str_equals(idstr(?itn, m.description), "d")) { code = 1; }
+    }
     arena.dnit(?ar);
     ret code;
 }
@@ -1773,6 +1820,59 @@ test "mach.lang.manifest.resolve_build_unit:links" {
             if (!strarr_has(?itn, bu.libs, bu.lib_count, "lib/mylib.a")) { code = 1; }
         }
     }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.parse:link_filter_string_form" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    # os as a bare string (str_os) must filter identically to the array form
+    # (arr_os); "*" matches any cell; an absent axis matches any cell. isa/abi
+    # exercise the string form on the other two axes. this pins the #1969 fix: a
+    # string filter is no longer silently ignored (degraded to match-any).
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[target.arm]\nisa=\"aarch64\"\nos=\"linux\"\nabi=\"aapcs64\"\n[link.os_str]\nsource=\"system\"\nname=\"a\"\nos=\"linux\"\n[link.os_arr]\nsource=\"system\"\nname=\"b\"\nos=[\"linux\"]\n[link.os_star]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\n[link.os_absent]\nsource=\"system\"\nname=\"d\"\n[link.isa_str]\nsource=\"system\"\nname=\"e\"\nisa=\"x86_64\"\n[link.abi_str]\nsource=\"system\"\nname=\"f\"\nabi=\"sysv64\"\n";
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
+
+        val tl: *TargetDef = find_target_by_name(?itn, ?m, "linux");
+        val tw: *TargetDef = find_target_by_name(?itn, ?m, "windows");
+        val ta: *TargetDef = find_target_by_name(?itn, ?m, "arm");
+        if (tl == nil || tw == nil || ta == nil) { code = 1; }
+        or {
+            # string-form os="linux" and array-form os=["linux"] behave identically
+            if (!link_matches_target(?itn, find_link(?itn, ?m, "os_str"), tl)) { code = 1; }
+            if ( link_matches_target(?itn, find_link(?itn, ?m, "os_str"), tw)) { code = 1; }
+            if (!link_matches_target(?itn, find_link(?itn, ?m, "os_arr"), tl)) { code = 1; }
+            if ( link_matches_target(?itn, find_link(?itn, ?m, "os_arr"), tw)) { code = 1; }
+
+            # "*" and an absent axis both match any cell
+            if (!link_matches_target(?itn, find_link(?itn, ?m, "os_star"), tw)) { code = 1; }
+            if (!link_matches_target(?itn, find_link(?itn, ?m, "os_absent"), tw)) { code = 1; }
+
+            # string form on isa and abi filters the other two cells
+            if (!link_matches_target(?itn, find_link(?itn, ?m, "isa_str"), tl)) { code = 1; }
+            if ( link_matches_target(?itn, find_link(?itn, ?m, "isa_str"), ta)) { code = 1; }
+            if (!link_matches_target(?itn, find_link(?itn, ?m, "abi_str"), tl)) { code = 1; }
+            if ( link_matches_target(?itn, find_link(?itn, ?m, "abi_str"), tw)) { code = 1; }
+        }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.parse:link_filter_bad_type" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    # a non-string, non-array filter axis is a strict error
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[link.bad]\nsource=\"system\"\nname=\"a\"\nos=1\n");
+    if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: [link.bad].os must be a string or array of strings")) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1252,6 +1252,33 @@ fun link_token(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef, proj_out
     ret R.ok[intern.StrId, str](l.lib_name);
 }
 
+# whether some declared step produces `expanded_path` as one of its `out` entries
+# (expanded against the same build cell), i.e. the local link entry demands that
+# step. the up-front local-path check (#1969) treats a demanded path as valid even
+# before the step runs, since the step will produce it. `expanded_path` is already
+# expanded; step outs are expanded here with the same project out / target / profile.
+pub fun local_path_demanded_by_step(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
+                                    expanded_path: str, proj_out: str, tn: str, pn: str) bool {
+    var si: u32 = 0;
+    for (si < m.step_count) {
+        val s: *StepDef = ?m.steps[si];
+        var oi: u32 = 0;
+        for (oi < s.out_count) {
+            val raw_out: str = idstr(itn, s.out[oi]);
+            val exp_r: R.Result[str, str] = expand(alloc, raw_out, proj_out, tn, pn, "", "");
+            if (R.is_ok[str, str](exp_r)) {
+                val exp: str = R.unwrap_ok[str, str](exp_r);
+                val eq: bool = str_equals(exp, expanded_path);
+                str_free(alloc, exp);
+                if (eq) { ret true; }
+            }
+            oi = oi + 1;
+        }
+        si = si + 1;
+    }
+    ret false;
+}
+
 pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
     val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target);
     if (R.is_err[ResolvedTarget, str](res_target)) { ret R.err[BuildUnit, str](R.unwrap_err[ResolvedTarget, str](res_target)); }
@@ -1909,6 +1936,24 @@ test "mach.lang.manifest.resolve_build_unit:local_project_out" {
             if (bu.lib_count != 1) { code = 1; }
             if (!strarr_has(?itn, bu.libs, bu.lib_count, "out/linux/obj/shim.o")) { code = 1; }
         }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.local_path_demanded_by_step" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[step.shim]\ncmd=\"cc -c shim.c\"\nin=[\"shim.c\"]\nout=[\"{project.out}/obj/shim.o\"]\n";
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
+        # a path matching the step's expanded out is demanded; a near miss is not
+        if (!local_path_demanded_by_step(?alloc, ?itn, ?m, "out/linux/obj/shim.o", "out/linux", "linux", "debug")) { code = 1; }
+        if ( local_path_demanded_by_step(?alloc, ?itn, ?m, "out/linux/obj/nope.o", "out/linux", "linux", "debug")) { code = 1; }
     }
     arena.dnit(?ar);
     ret code;


### PR DESCRIPTION
Closes #1969.

Residual work from the #1964 mach.toml redesign (audit comment 2026-07-09 on #1969). Scope:

- [x] **String-form link filters** — `os`/`isa`/`abi` accept a bare string or an array; `os = "linux"` now filters identically to `os = ["linux"]`. Previously a string was read only via `get_array`, silently degrading a filtered entry to match-any with no diagnostic (critical). A non-string, non-array axis is now a strict error.
- [x] **Up-front `local` path validation** — a `local` entry's path must match a declared step's `out` (demand) or exist on disk; anything else is an error naming the entry at load time, instead of failing at link time.
- [x] **`mach test` union rule** — a test executable links the union of every artifact's referenced entries (native-filtered, deduped) plus the exported dep entries the cascade adds; a multi-artifact project no longer errors under `mach test`.
- [x] **Parser acceptance** — `[project]` `name`/`description` are optional-accepted; `{project.out}` is a known template variable (self-reference in `[project].out` is a strict error); the previously-unchecked `expand()` Result in the local-link path is now a strict error.

Does not touch the step-execution engine or dep-`{project.out}` homing (#1970).

### Verification
- Seed build (`mach dep pull && mach build . --profile release`): clean.
- Unit suite through the freshly built compiler: **540 passed** (baseline 533 + 7 new tests).
- Self-host fixpoint: gen2 (built by the fresh compiler) is byte-identical to gen1; gen2's suite passes 540/540.
- End-to-end (string `os` filter, two targets): `--target linux` includes the filtered entry (`cannot find link input 'totallyboguslinuxlib'`), `--target windows` excludes it (reaches `mainCRTStartup`).
- End-to-end (`mach test` union): a multi-artifact project where only the non-primary artifact references a lib pulls that lib into the test link, proving the union spans all artifacts.

int/ matrix is gated on #1976 (fixture migration) and unaffected here (no fixture uses `source = "local"` or string filters).