### PR TITLE
feat(cli): optional path arg with four-rule project resolution (#1974)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -507,19 +507,20 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
     }
     val config: cfg.Config = R.unwrap_ok[cfg.Config, str](res_config);
 
-    # the project root is the required non-flag positional after the subcommand
-    # (`mach build <path>`); a bare invocation with no path is a user error.
+    # resolve the (project_root, manifest) pair from the optional positional path
+    # (`mach build [path]`): no path walks up from cwd, a directory takes its
+    # mach.toml, a file is the manifest itself. see util.resolve_project.
     val pix: usize = util.positional_index(argc, argv, marks, 2);
-    if (pix >= argc) {
-        print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
-        br.code = 1;
-        ret br;
-    }
-    val start: *u8 = argv[pix];
+    var arg: *u8 = nil;
+    if (pix < argc) { arg = argv[pix]; }
 
-    var root: [4096]u8;
-    if (!util.find_project_root(start, ?root[0], 4096)) {
-        print.eprint("error: no mach.toml found in the working directory or any parent\n");
+    var root:     [4096]u8;
+    var manifest_path: [4096]u8;
+    val rr: R.Result[bool, str] = util.resolve_project(a, arg, ?root[0], 4096, ?manifest_path[0], 4096);
+    if (R.is_err[bool, str](rr)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](rr));
+        print.eprint("\n");
         br.code = 1;
         ret br;
     }
@@ -606,8 +607,8 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
     # a test build roots collection at the whole source tree (#1863); a plain
     # build / run stays entrypoint-rooted so it compiles only what the artifact needs.
     var res_project: R.Result[driver.Project, str];
-    if (test_mode) { res_project = driver.build_project_test(?s, util.cstr_str(?root[0]), ?sel); }
-    or             { res_project = driver.build_project_sel(?s, util.cstr_str(?root[0]), ?sel);  }
+    if (test_mode) { res_project = driver.build_project_test(?s, util.cstr_str(?root[0]), util.cstr_str(?manifest_path[0]), ?sel); }
+    or             { res_project = driver.build_project_sel(?s, util.cstr_str(?root[0]), util.cstr_str(?manifest_path[0]), ?sel);  }
     if (R.is_err[driver.Project, str](res_project)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[driver.Project, str](res_project));
@@ -2848,17 +2849,18 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     mark_build_flags(marks, argc, argv);
     if (util.reject_unknown(argc, argv, marks, 2, "mach build")) { ret 1; }
 
-    # the project root is the required non-flag positional (`mach build <path>`);
-    # a bare invocation with no path is a user error.
+    # resolve the (project_root, manifest) pair from the optional positional path
+    # (`mach build [path]`); see util.resolve_project for the rules.
     val pix: usize = util.positional_index(argc, argv, marks, 2);
-    if (pix >= argc) {
-        print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
-        ret 1;
-    }
-    val start: *u8 = argv[pix];
-    var root: [4096]u8;
-    if (!util.find_project_root(start, ?root[0], 4096)) {
-        print.eprint("error: no mach.toml found in the working directory or any parent\n");
+    var arg: *u8 = nil;
+    if (pix < argc) { arg = argv[pix]; }
+    var root:     [4096]u8;
+    var manifest_path: [4096]u8;
+    val rr: R.Result[bool, str] = util.resolve_project(?backing, arg, ?root[0], 4096, ?manifest_path[0], 4096);
+    if (R.is_err[bool, str](rr)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](rr));
+        print.eprint("\n");
         ret 1;
     }
 
@@ -2876,7 +2878,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         ret 2;
     }
 
-    val res_matrix: R.Result[driver.Matrix, str] = driver.enumerate_matrix(?menu_alloc, util.cstr_str(?root[0]),
+    val res_matrix: R.Result[driver.Matrix, str] = driver.enumerate_matrix(?menu_alloc, util.cstr_str(?root[0]), util.cstr_str(?manifest_path[0]),
         util.cstr_str(cstr_or(config.target)), config.all_targets,
         util.cstr_str(cstr_or(config.bin)), util.cstr_str(cstr_or(config.lib)),
         config.bin != nil, config.lib != nil);

--- a/src/cli/cmd/clean.mach
+++ b/src/cli/cmd/clean.mach
@@ -44,18 +44,6 @@ use mach.lang.manifest;
 pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     if (util.reject_unknown(argc, argv, marks, 2, "mach clean")) { ret 1; }
 
-    # the project root is the first positional, or the working directory; walk up
-    # to the nearest mach.toml. its absence is the standard no-project error.
-    val pix: usize = util.positional_index(argc, argv, marks, 2);
-    var start: *u8 = ".";
-    if (pix < argc) { start = argv[pix]; }
-
-    var root: [4096]u8;
-    if (!util.find_project_root(start, ?root[0], 4096)) {
-        print.eprint("error: no mach.toml found in the working directory or any parent\n");
-        ret 1;
-    }
-
     var backing: A.Allocator;
     var ar:      arena.Arena;
     var a:       A.Allocator;
@@ -64,29 +52,43 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         ret 2;
     }
 
-    val code: i64 = clean_project(?a, ?root[0]);
+    # resolve the (project_root, manifest) pair from the optional positional path;
+    # see util.resolve_project for the rules.
+    val pix: usize = util.positional_index(argc, argv, marks, 2);
+    var arg: *u8 = nil;
+    if (pix < argc) { arg = argv[pix]; }
+    var root:     [4096]u8;
+    var manifest_path: [4096]u8;
+    val rr: R.Result[bool, str] = util.resolve_project(?a, arg, ?root[0], 4096, ?manifest_path[0], 4096);
+    if (R.is_err[bool, str](rr)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](rr));
+        print.eprint("\n");
+        arena.dnit(?ar);
+        ret 1;
+    }
+
+    val code: i64 = clean_project(?a, ?root[0], ?manifest_path[0]);
     arena.dnit(?ar);
     ret code;
 }
 
-# read the manifest at `root` and remove each distinct output-directory tree its
-# templates declare
+# read the manifest at `manifest` and remove each distinct output-directory tree
+# its templates declare, rooted under `root`
 #
 # The four templates are read for their static prefixes only; parsing the manifest
 # validates it as a real project. Every allocation is suballocated through the
 # caller's arena and reclaimed when it is torn down.
 # ---
-# a:    arena-backed allocator for the manifest read and parse
-# root: the resolved project root directory (null-terminated)
-# ret:  0 on success, 1 on an unparseable manifest, 2 on an io failure
-fun clean_project(a: *A.Allocator, root: *u8) i64 {
-    var toml_path: [4096]u8;
-    util.join_into(?toml_path[0], 4096, root, "mach.toml");
-
-    val text_r: R.Result[str, str] = filesystem.read_all(a, util.cstr_str(?toml_path[0]));
+# a:             arena-backed allocator for the manifest read and parse
+# root:          the resolved project root directory (null-terminated)
+# manifest_path: the resolved manifest path (null-terminated)
+# ret:           0 on success, 1 on an unparseable manifest, 2 on an io failure
+fun clean_project(a: *A.Allocator, root: *u8, manifest_path: *u8) i64 {
+    val text_r: R.Result[str, str] = filesystem.read_all(a, util.cstr_str(manifest_path));
     if (R.is_err[str, str](text_r)) {
         print.eprint("error: cannot read '");
-        print.eprint(util.cstr_str(?toml_path[0]));
+        print.eprint(util.cstr_str(manifest_path));
         print.eprintln("'");
         ret 2;
     }

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -514,20 +514,6 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     val opt_out: O.Option[*u8] = util.mark_value(marks, argc, argv, "--out");
     if (util.reject_unknown(argc, argv, marks, 2, "mach doc")) { ret 1; }
 
-    # the project root is the required non-flag positional (`mach doc <path>`); a
-    # bare invocation with no path is a user error.
-    val path_index: usize = util.positional_index(argc, argv, marks, 2);
-    if (path_index >= argc) {
-        print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
-        ret 1;
-    }
-
-    var root: [4096]u8;
-    if (!util.find_project_root(argv[path_index], ?root[0], 4096)) {
-        print.eprint("error: no mach.toml found in the working directory or any parent\n");
-        ret 1;
-    }
-
     # back the allocation-heavy compile with an arena over the page allocator,
     # matching build/run/test/check: the page allocator mmaps once per
     # allocation, so the module-graph build is suballocated through the arena and
@@ -538,6 +524,22 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     if (O.is_some[str](util.bootstrap_arena(?backing, ?ar, ?alloc))) {
         print.eprint("error: failed to initialise allocator\n");
         ret 2;
+    }
+
+    # resolve the (project_root, manifest) pair from the optional positional path
+    # (`mach doc [path]`); see util.resolve_project for the rules.
+    val path_index: usize = util.positional_index(argc, argv, marks, 2);
+    var arg: *u8 = nil;
+    if (path_index < argc) { arg = argv[path_index]; }
+    var root:     [4096]u8;
+    var manifest_path: [4096]u8;
+    val rr: R.Result[bool, str] = util.resolve_project(?alloc, arg, ?root[0], 4096, ?manifest_path[0], 4096);
+    if (R.is_err[bool, str](rr)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](rr));
+        print.eprint("\n");
+        arena.dnit(?ar);
+        ret 1;
     }
 
     val res_session: R.Result[session.Session, str] = session.init(?alloc);
@@ -559,7 +561,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     var target_name: *u8 = config.target;
     if (target_name == nil) { target_name = ""; }
 
-    val res_project: R.Result[driver.Project, str] = driver.build_project(?s, util.cstr_str(?root[0]), util.cstr_str(target_name));
+    val res_project: R.Result[driver.Project, str] = driver.build_project(?s, util.cstr_str(?root[0]), util.cstr_str(?manifest_path[0]), util.cstr_str(target_name));
     if (R.is_err[driver.Project, str](res_project)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[driver.Project, str](res_project));

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -111,10 +111,11 @@ pub fun usage() {
 
 # print the `mach build` detail page
 fun help_build() {
-    print.print("usage: mach build <path> [options] [inputs...]\n");
+    print.print("usage: mach build [path] [options] [inputs...]\n");
     print.print("\n");
     print.print("compile the current project to relocatable objects and, in executable\n");
-    print.print("mode, a linked binary. <path> is the project root.\n");
+    print.print("mode, a linked binary. [path] is a project directory or a manifest file;\n");
+    print.print("omit it to search upward from the working directory for a mach.toml.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  -O0              force the debug pipeline (overrides profile)\n");
@@ -132,14 +133,17 @@ fun help_build() {
 
 # print the `mach run` detail page
 fun help_run() {
-    print.print("usage: mach run <path> [options] [-- args...]\n");
+    print.print("usage: mach run [path] [options] [-- args...]\n");
     print.print("\n");
-    print.print("execute the binary 'mach build' already produced for <path> - a\n");
+    print.print("execute the binary 'mach build' already produced for [path] - a\n");
     print.print("post-build convenience, not a rebuild. the build selection flags\n");
     print.print("(--target, --profile, --bin/--lib) resolve which artifact to run;\n");
     print.print("build-only flags (-O0/-O1/-O2) are accepted but have no effect, and\n");
     print.print("--emit is rejected. arguments after '--' are forwarded to the program\n");
     print.print("as its argv; the program's exit code becomes this command's.\n");
+    print.print("\n");
+    print.print("[path] is a project directory or a manifest file; omit it to search\n");
+    print.print("upward from the working directory for a mach.toml.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  --runner <cmd>   execute the binary as '<cmd> <binary> <args...>'.\n");
@@ -152,7 +156,7 @@ fun help_run() {
 
 # print the `mach test` detail page
 fun help_test() {
-    print.print("usage: mach test <path> [options]\n");
+    print.print("usage: mach test [path] [options]\n");
     print.print("\n");
     print.print("build one dispatcher executable covering every 'test' declaration\n");
     print.print("(under the 'tests' template) and run each test as its own process\n");
@@ -160,6 +164,9 @@ fun help_test() {
     print.print("a crash reports its signal and the run continues. only the current\n");
     print.print("project's own tests run by default; all 'mach build' and global\n");
     print.print("flags apply.\n");
+    print.print("\n");
+    print.print("[path] is a project directory or a manifest file; omit it to search\n");
+    print.print("upward from the working directory for a mach.toml.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  -v                  list every test under its module as it completes\n");
@@ -182,8 +189,9 @@ fun help_clean() {
     print.print("usage: mach clean [path]\n");
     print.print("\n");
     print.print("remove the project's build output: the output directory trees declared\n");
-    print.print("by the manifest's out/obj/ir/asm templates. [path] selects the project\n");
-    print.print("(default: the working directory). idempotent; takes no options.\n");
+    print.print("by the manifest's out/obj/ir/asm templates. [path] is a project\n");
+    print.print("directory or a manifest file; omit it to search upward from the working\n");
+    print.print("directory for a mach.toml. idempotent; takes no options.\n");
     print.print("\n");
     print.print("exit: 0 ok, 1 no project / bad manifest, 2 io failure\n");
 }
@@ -223,10 +231,12 @@ fun help_init() {
 
 # print the `mach doc` detail page
 fun help_doc() {
-    print.print("usage: mach doc <path> [options]\n");
+    print.print("usage: mach doc [path] [options]\n");
     print.print("\n");
     print.print("generate Markdown reference documentation from source doc-comments.\n");
-    print.print("writes one page per module plus an index under doc/api.\n");
+    print.print("writes one page per module plus an index under doc/api. [path] is a\n");
+    print.print("project directory or a manifest file; omit it to search upward from the\n");
+    print.print("working directory for a mach.toml.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  --out <dir>      output directory, rooted at the project (default: doc/api)\n");

--- a/src/cli/cmd/run.mach
+++ b/src/cli/cmd/run.mach
@@ -90,17 +90,18 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         ret 1;
     }
 
-    # the project root is the required non-flag positional after the subcommand
-    # (`mach run <path>`); a bare invocation with no path is a user error.
+    # resolve the (project_root, manifest) pair from the optional positional path
+    # (`mach run [path]`); see util.resolve_project for the rules.
     val pix: usize = util.positional_index(sep, argv, marks, 2);
-    if (pix >= sep) {
-        print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
-        arena.dnit(?ar);
-        ret 1;
-    }
-    var root: [4096]u8;
-    if (!util.find_project_root(argv[pix], ?root[0], 4096)) {
-        print.eprint("error: no mach.toml found in the working directory or any parent\n");
+    var arg: *u8 = nil;
+    if (pix < sep) { arg = argv[pix]; }
+    var root:     [4096]u8;
+    var manifest_path: [4096]u8;
+    val rr: R.Result[bool, str] = util.resolve_project(?alloc, arg, ?root[0], 4096, ?manifest_path[0], 4096);
+    if (R.is_err[bool, str](rr)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](rr));
+        print.eprint("\n");
         arena.dnit(?ar);
         ret 1;
     }
@@ -115,7 +116,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         ret 1;
     }
 
-    val res_path: R.Result[str, str] = driver.resolve_artifact_path(?alloc, util.cstr_str(?root[0]), ?sel);
+    val res_path: R.Result[str, str] = driver.resolve_artifact_path(?alloc, util.cstr_str(?root[0]), util.cstr_str(?manifest_path[0]), ?sel);
     if (R.is_err[str, str](res_path)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[str, str](res_path));

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -339,7 +339,7 @@ pub fun path_into(buf: *u8, cap: usize, base: *u8, path: *u8) usize {
 # out_buf: destination buffer for the resolved root
 # cap:     capacity of `out_buf` in bytes
 # ret:     true when a mach.toml-bearing ancestor was found
-pub fun find_project_root(start: *u8, out_buf: *u8, cap: usize) bool {
+fun find_project_root(start: *u8, out_buf: *u8, cap: usize) bool {
     val start_len: usize = cstr_len(start);
     if (start_len + 1 > cap) { ret false; }
     var i: usize = 0;

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -358,6 +358,138 @@ pub fun find_project_root(start: *u8, out_buf: *u8, cap: usize) bool {
     ret false;
 }
 
+# copy the null-terminated `src` into `buf`, terminator included
+# ---
+# buf: destination buffer
+# cap: capacity of `buf` in bytes
+# src: null-terminated source string
+# ret: true when it fit and was copied, false when `cap` is too small
+fun copy_cstr(buf: *u8, cap: usize, src: *u8) bool {
+    val n: usize = cstr_len(src);
+    if (n + 1 > cap) { ret false; }
+    var i: usize = 0;
+    for (i < n) { buf[i] = src[i]; i = i + 1; }
+    buf[n] = 0;
+    ret true;
+}
+
+# concatenate three strings into a freshly allocated null-terminated str
+#
+# Builds the path-naming diagnostics resolve_project returns. On an allocation
+# failure it yields `fallback` so an error is still reported (mirrors the driver's
+# diag_join3 convention).
+# ---
+# alloc:    allocator for the result
+# a:        leading part
+# b:        middle part (the named path)
+# c:        trailing part
+# fallback: the static message returned when allocation fails
+# ret:      the joined "abc" str, or `fallback`
+fun cat3(alloc: *A.Allocator, a: str, b: str, c: str, fallback: str) str {
+    val la: usize = str_len(a);
+    val lb: usize = str_len(b);
+    val lc: usize = str_len(c);
+    val r: R.Result[*u8, str] = A.allocate[u8](alloc, la + lb + lc + 1);
+    if (R.is_err[*u8, str](r)) { ret fallback; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    var j: usize = 0;
+    for (j < la) { buf[k] = a[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < lb) { buf[k] = b[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < lc) { buf[k] = c[j]; k = k + 1; j = j + 1; }
+    buf[k] = 0;
+    ret buf::str;
+}
+
+# resolve the (project_root, manifest_path) pair from a command's optional path
+# argument, per the four project-path resolution rules every project-rooted
+# command (build/run/test/clean/doc) shares.
+#
+#   arg == nil    no path was given: walk up from the working directory to the
+#                 nearest mach.toml (rule 1); an error when no ancestor has one.
+#   arg is a dir  use `<arg>/mach.toml` exactly (rule 2); an error when it is
+#                 absent - an explicitly named directory is never walked upward.
+#   arg is a file use the file as the manifest and its parent directory as the
+#                 project root (rule 3), enabling alternate manifests such as
+#                 `mach build ci.toml`.
+#   otherwise     the path names nothing that exists (rule 4); an error naming it.
+#
+# resolve_project only locates the manifest; the driver parses and validates its
+# contents. `root_buf` receives the resolved project root and `manifest_buf` the
+# manifest file path; each must hold at least its stated capacity. The path-naming
+# error messages are allocated from `alloc`.
+# ---
+# alloc:        allocator for the returned error messages
+# arg:          the positional path token, or nil when none was given
+# root_buf:     destination buffer for the resolved project root
+# root_cap:     capacity of `root_buf` in bytes
+# manifest_buf: destination buffer for the resolved manifest path
+# manifest_cap: capacity of `manifest_buf` in bytes
+# ret:          ok(true) with both buffers filled, or err(message)
+pub fun resolve_project(alloc: *A.Allocator, arg: *u8,
+                        root_buf: *u8, root_cap: usize,
+                        manifest_buf: *u8, manifest_cap: usize) R.Result[bool, str] {
+    # rule 1: no path - walk up from the working directory to the nearest mach.toml.
+    if (arg == nil) {
+        var cwd: [4096]u8;
+        if (os.getcwd(?cwd[0], 4096) < 0) {
+            ret R.err[bool, str]("failed to read the working directory");
+        }
+        if (!find_project_root(?cwd[0], root_buf, root_cap)) {
+            ret R.err[bool, str]("no mach.toml found in the working directory or any parent");
+        }
+        if (join_into(manifest_buf, manifest_cap, root_buf, "mach.toml") == 0) {
+            ret R.err[bool, str]("resolved manifest path is too long");
+        }
+        ret R.ok[bool, str](true);
+    }
+
+    # rule 3: an existing regular file is the manifest itself; its parent is the root.
+    if (filesystem.is_file(cstr_str(arg))) {
+        if (!copy_cstr(manifest_buf, manifest_cap, arg)) {
+            ret R.err[bool, str]("manifest path is too long");
+        }
+        if (!copy_cstr(root_buf, root_cap, arg)) {
+            ret R.err[bool, str]("project path is too long");
+        }
+        # the root is the manifest's parent directory; a slash-free filename roots at ".".
+        var has_slash: bool  = false;
+        var si:        usize = 0;
+        for (arg[si] != 0) {
+            if (arg[si] == '/') { has_slash = true; }
+            si = si + 1;
+        }
+        if (has_slash) { parent_dir(root_buf); }
+        or {
+            if (!copy_cstr(root_buf, root_cap, ".")) {
+                ret R.err[bool, str]("project path is too long");
+            }
+        }
+        ret R.ok[bool, str](true);
+    }
+
+    # rule 2: an existing directory must contain mach.toml; it is not walked upward.
+    if (filesystem.is_dir(cstr_str(arg))) {
+        if (!copy_cstr(root_buf, root_cap, arg)) {
+            ret R.err[bool, str]("project path is too long");
+        }
+        if (join_into(manifest_buf, manifest_cap, arg, "mach.toml") == 0) {
+            ret R.err[bool, str]("resolved manifest path is too long");
+        }
+        if (!filesystem.is_file(cstr_str(manifest_buf))) {
+            ret R.err[bool, str](cat3(alloc, "no mach.toml in directory '", cstr_str(arg), "'",
+                                      "no mach.toml in the named directory"));
+        }
+        ret R.ok[bool, str](true);
+    }
+
+    # rule 4: the path names neither a file nor a directory.
+    ret R.err[bool, str](cat3(alloc, "project path '", cstr_str(arg), "' does not exist",
+                              "project path does not exist"));
+}
+
 # create the directory at `path` if it does not already exist
 # ---
 # path: the null-terminated directory path to create
@@ -665,5 +797,91 @@ test "mach.cli.util.reject_unknown:first_unmarked_flag" {
     i = 0;
     for (i < 4) { mb[i] = false; i = i + 1; }
     if (reject_unknown(4, ?b[0], ?mb[0], 2, "mach build")) { ret 1; }
+    ret 0;
+}
+
+# resolve_project rules 2-4: an explicit directory resolves to its mach.toml, an
+# explicit file (including an alternate name like ci.toml) resolves to itself with
+# the parent as root, a nonexistent path errors, and a directory lacking a
+# mach.toml errors without walking upward. rule 1 (the no-arg cwd walk) is
+# exercised separately and by the e2e demo
+test "mach.cli.util.resolve_project:explicit_paths" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+
+    # a fresh unique directory to host the fixture project.
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "mach_resolve_test");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    var dir: [4096]u8;
+    val copied: bool = copy_cstr(?dir[0], 4096, filesystem.temp_path(?tf)::*u8);
+    filesystem.temp_close_and_remove(?tf);
+    if (!copied) { ret 1; }
+
+    val dr: R.Result[bool, str] = filesystem.create_dir_all(?alloc, cstr_str(?dir[0]), 493);
+    if (R.is_err[bool, str](dr)) { ret 1; }
+
+    var bad: i32 = 0;
+
+    var mtoml: [4096]u8;
+    if (join_into(?mtoml[0], 4096, ?dir[0], "mach.toml") == 0) { bad = 1; }
+    val w0: R.Result[bool, str] = filesystem.write_file(cstr_str(?mtoml[0]), "[project]\n", 10, 420);
+    if (R.is_err[bool, str](w0)) { bad = 1; }
+
+    var root:     [4096]u8;
+    var manifest: [4096]u8;
+
+    # rule 2: an explicit directory resolves to <dir>/mach.toml.
+    val r2: R.Result[bool, str] = resolve_project(?alloc, ?dir[0], ?root[0], 4096, ?manifest[0], 4096);
+    if (R.is_err[bool, str](r2))                                  { bad = 1; }
+    or (!str_equals(cstr_str(?root[0]), cstr_str(?dir[0])))       { bad = 1; }
+    or (!str_equals(cstr_str(?manifest[0]), cstr_str(?mtoml[0]))) { bad = 1; }
+
+    # rule 3: an explicit mach.toml file resolves to itself; root is its parent.
+    val r3: R.Result[bool, str] = resolve_project(?alloc, ?mtoml[0], ?root[0], 4096, ?manifest[0], 4096);
+    if (R.is_err[bool, str](r3))                                  { bad = 1; }
+    or (!str_equals(cstr_str(?root[0]), cstr_str(?dir[0])))       { bad = 1; }
+    or (!str_equals(cstr_str(?manifest[0]), cstr_str(?mtoml[0]))) { bad = 1; }
+
+    # rule 3, alternate manifest name: dir/ci.toml resolves to itself.
+    var ctoml: [4096]u8;
+    if (join_into(?ctoml[0], 4096, ?dir[0], "ci.toml") == 0) { bad = 1; }
+    val wc: R.Result[bool, str] = filesystem.write_file(cstr_str(?ctoml[0]), "[project]\n", 10, 420);
+    if (R.is_err[bool, str](wc)) { bad = 1; }
+    val r3b: R.Result[bool, str] = resolve_project(?alloc, ?ctoml[0], ?root[0], 4096, ?manifest[0], 4096);
+    if (R.is_err[bool, str](r3b))                                 { bad = 1; }
+    or (!str_equals(cstr_str(?root[0]), cstr_str(?dir[0])))       { bad = 1; }
+    or (!str_equals(cstr_str(?manifest[0]), cstr_str(?ctoml[0]))) { bad = 1; }
+
+    # rule 4: a nonexistent path is an error.
+    var nope: [4096]u8;
+    if (join_into(?nope[0], 4096, ?dir[0], "nope") == 0) { bad = 1; }
+    val r4: R.Result[bool, str] = resolve_project(?alloc, ?nope[0], ?root[0], 4096, ?manifest[0], 4096);
+    if (R.is_ok[bool, str](r4)) { bad = 1; }
+
+    # rule 2 failure: an existing directory without a mach.toml is an error (no walk).
+    var sub: [4096]u8;
+    if (join_into(?sub[0], 4096, ?dir[0], "empty") == 0) { bad = 1; }
+    val ds: R.Result[bool, str] = filesystem.create_dir_all(?alloc, cstr_str(?sub[0]), 493);
+    if (R.is_err[bool, str](ds)) { bad = 1; }
+    val r2b: R.Result[bool, str] = resolve_project(?alloc, ?sub[0], ?root[0], 4096, ?manifest[0], 4096);
+    if (R.is_ok[bool, str](r2b)) { bad = 1; }
+
+    filesystem.remove_all(?alloc, cstr_str(?dir[0]));
+    ret bad;
+}
+
+# resolve_project rule 1: with no path it walks up from the working directory to
+# the nearest mach.toml. the unit suite runs from a project root, so the walk
+# resolves the harness's own manifest to a real file
+test "mach.cli.util.resolve_project:no_arg_walks_cwd" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+
+    var root:     [4096]u8;
+    var manifest: [4096]u8;
+    val r: R.Result[bool, str] = resolve_project(?alloc, nil, ?root[0], 4096, ?manifest[0], 4096);
+    if (R.is_err[bool, str](r)) { ret 1; }
+    if (!filesystem.is_file(cstr_str(?manifest[0]))) { ret 1; }
     ret 0;
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -407,23 +407,24 @@ pub fun setup_registry(reg: *target.TargetRegistry) R.Result[bool, str] {
     ret be_linker.register_reloc_hooks(?reg.isa);
 }
 
-# load `project_root/mach.toml`, select `target_name`, and
+# load the manifest at `manifest_path`, select `target_name`, and
 # build the full module graph plus per-module ResolveResults. a convenience
 # wrapper over build_project_sel that selects only a target (no profile/artifact
 # narrowing) - used by read-only consumers such as `mach doc`
 # ---
-# s:            shared session
-# project_root: filesystem path to the project root (containing mach.toml)
-# target_name:  selector that must match a declared target
-# ret:          fully populated Project, or an error message
-pub fun build_project(s: *session.Session, project_root: str, target_name: str) R.Result[Project, str] {
+# s:             shared session
+# project_root:  filesystem path to the project root
+# manifest_path: filesystem path to the manifest to read
+# target_name:   selector that must match a declared target
+# ret:           fully populated Project, or an error message
+pub fun build_project(s: *session.Session, project_root: str, manifest_path: str, target_name: str) R.Result[Project, str] {
     var sel: manifest.Selection;
     sel.target       = target_name;
     sel.profile      = "";
     sel.artifact     = "";
     sel.want_lib     = false;
     sel.has_artifact = false;
-    ret build_project_sel(s, project_root, ?sel);
+    ret build_project_sel(s, project_root, manifest_path, ?sel);
 }
 
 # one (target, artifact) cell a `mach build` invocation compiles.
@@ -452,21 +453,17 @@ pub rec Matrix {
 }
 
 # expand the build matrix a `mach build` invocation drives.
-# reads `project_root/mach.toml` and produces one MatrixUnit per (target,
+# reads the manifest at `manifest_path` and produces one MatrixUnit per (target,
 # artifact) cell to build: every declared `[bin.*]`/`[lib.*]` in declaration
 # order (bins then libs) unless narrowed by `bin`/`lib`, crossed with the
 # selected target(s) - `target_filter` when named, every declared target when
 # `all_targets`, else the single manifest default. the manifest and its interned
 # selector strings are allocated in `alloc` and must remain valid for the whole
 # build loop (so `alloc` outlives every per-unit build)
-pub fun enumerate_matrix(alloc: *A.Allocator, project_root: str,
+pub fun enumerate_matrix(alloc: *A.Allocator, project_root: str, manifest_path: str,
                          target_filter: str, all_targets: bool,
                          bin: str, lib: str, has_bin: bool, has_lib: bool) R.Result[Matrix, str] {
-    val toml_path_r: R.Result[str, str] = join_path(alloc, project_root, "mach.toml");
-    if (R.is_err[str, str](toml_path_r)) { ret R.err[Matrix, str](R.unwrap_err[str, str](toml_path_r)); }
-    val toml_path: str = R.unwrap_ok[str, str](toml_path_r);
-    val toml_r: R.Result[toml.Table, str] = parse_toml_file(alloc, toml_path);
-    str_free(alloc, toml_path);
+    val toml_r: R.Result[toml.Table, str] = parse_toml_file(alloc, manifest_path);
     if (R.is_err[toml.Table, str](toml_r)) { ret R.err[Matrix, str](R.unwrap_err[toml.Table, str](toml_r)); }
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
@@ -526,7 +523,7 @@ pub fun enumerate_matrix(alloc: *A.Allocator, project_root: str,
 
 # resolve a build selection's output-artifact path WITHOUT compiling
 #
-# Reads `project_root/mach.toml`, resolves the selection (target, profile,
+# Reads the manifest at `manifest_path`, resolves the selection (target, profile,
 # artifact) into one build unit, and returns the produced-artifact path rooted at
 # `project_root` - the exact path `mach build` produces for the same selection.
 # `mach run` uses it to locate and execute the already-built binary instead of
@@ -535,17 +532,13 @@ pub fun enumerate_matrix(alloc: *A.Allocator, project_root: str,
 # all suballocated from `alloc` and reclaimed when it is (pass an arena); the
 # returned path is owned by `alloc`.
 # ---
-# alloc:        allocator for the transient manifest state and the returned path
-# project_root: the resolved project root directory (containing mach.toml)
-# sel:          the build selection narrowing target/profile/artifact
-# ret:          ok(owned absolute artifact path), or err(manifest/selection message)
-pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, sel: *manifest.Selection) R.Result[str, str] {
-    val toml_path_r: R.Result[str, str] = join_path(alloc, project_root, "mach.toml");
-    if (R.is_err[str, str](toml_path_r)) { ret toml_path_r; }
-    val toml_path: str = R.unwrap_ok[str, str](toml_path_r);
-
-    val toml_r: R.Result[toml.Table, str] = parse_toml_file(alloc, toml_path);
-    str_free(alloc, toml_path);
+# alloc:         allocator for the transient manifest state and the returned path
+# project_root:  the resolved project root directory
+# manifest_path: filesystem path to the manifest to read
+# sel:           the build selection narrowing target/profile/artifact
+# ret:           ok(owned absolute artifact path), or err(manifest/selection message)
+pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, manifest_path: str, sel: *manifest.Selection) R.Result[str, str] {
+    val toml_r: R.Result[toml.Table, str] = parse_toml_file(alloc, manifest_path);
     if (R.is_err[toml.Table, str](toml_r)) { ret R.err[str, str](R.unwrap_err[toml.Table, str](toml_r)); }
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
@@ -571,21 +564,22 @@ pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, sel: *mani
     ret abs_r;
 }
 
-# build_project_sel: load `project_root/mach.toml` and build the module graph
-# for the given build selection (target, profile, and one artifact). the manifest
-# reader resolves the selection into the project's single target entry and
+# build_project_sel: load the manifest at `manifest_path` and build the module
+# graph for the given build selection (target, profile, and one artifact). the
+# manifest reader resolves the selection into the project's single target entry and
 # concrete output paths.
 # ---
-# s:            shared session
-# project_root: filesystem path to the project root (containing mach.toml)
-# sel:          the build selection narrowing target/profile/artifact
-# ret:          fully populated Project, or an error message
+# s:             shared session
+# project_root:  filesystem path to the project root
+# manifest_path: filesystem path to the manifest to read
+# sel:           the build selection narrowing target/profile/artifact
+# ret:           fully populated Project, or an error message
 # build_project_impl: the shared build pipeline behind both build_project_sel
 # (single target) and build_project_union (all targets). `for_union` records every
 # manifest target's tuple and flips on the union load walk (see load_config /
 # walk_comptime_if_union). `all_own_src` additionally loads every own-source module
 # as a collection root (see load_all_own_src), for `mach test`.
-fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, for_union: bool, all_own_src: bool) R.Result[Project, str] {
+fun build_project_impl(s: *session.Session, project_root: str, manifest_path: str, sel: *manifest.Selection, for_union: bool, all_own_src: bool) R.Result[Project, str] {
     var p: Project;
     init_project(?p, s);
 
@@ -597,7 +591,7 @@ fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Se
         ret R.err[Project, str](R.unwrap_err[bool, str](q_r));
     }
 
-    val cfg_r: R.Result[bool, str] = load_project_config(?p, project_root, sel, for_union, all_own_src);
+    val cfg_r: R.Result[bool, str] = load_project_config(?p, project_root, manifest_path, sel, for_union, all_own_src);
     if (R.is_err[bool, str](cfg_r)) {
         dnit_project(?p);
         ret R.err[Project, str](R.unwrap_err[bool, str](cfg_r));
@@ -713,15 +707,15 @@ fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Se
 # project's single target entry and concrete output paths. Safe to call
 # repeatedly on one long-lived Session: sources dedup by path and dnit_project
 # resets the session's module registries (see dnit_project's reload contract)
-pub fun build_project_sel(s: *session.Session, project_root: str, sel: *manifest.Selection) R.Result[Project, str] {
-    ret build_project_impl(s, project_root, sel, false, false);
+pub fun build_project_sel(s: *session.Session, project_root: str, manifest_path: str, sel: *manifest.Selection) R.Result[Project, str] {
+    ret build_project_impl(s, project_root, manifest_path, sel, false, false);
 }
 
 # build the module graph for a `mach test` invocation: like build_project_sel, but
 # additionally loads every own-source module under `[project].src` as a collection
 # root, so tests in a module no entrypoint imports are still collected (#1863)
-pub fun build_project_test(s: *session.Session, project_root: str, sel: *manifest.Selection) R.Result[Project, str] {
-    ret build_project_impl(s, project_root, sel, false, true);
+pub fun build_project_test(s: *session.Session, project_root: str, manifest_path: str, sel: *manifest.Selection) R.Result[Project, str] {
+    ret build_project_impl(s, project_root, manifest_path, sel, false, true);
 }
 
 # build the union of EVERY manifest target's AND artifact's
@@ -743,7 +737,13 @@ pub fun build_project_union(s: *session.Session, project_root: str) R.Result[Pro
     sel.artifact     = "";
     sel.want_lib     = false;
     sel.has_artifact = false;
-    ret build_project_impl(s, project_root, ?sel, true, false);
+    # workspace tooling always reads the conventional root manifest.
+    val mp_r: R.Result[str, str] = join_path(s.alloc, project_root, "mach.toml");
+    if (R.is_err[str, str](mp_r)) { ret R.err[Project, str](R.unwrap_err[str, str](mp_r)); }
+    val manifest_path: str = R.unwrap_ok[str, str](mp_r);
+    val pr: R.Result[Project, str] = build_project_impl(s, project_root, manifest_path, ?sel, true, false);
+    str_free(s.alloc, manifest_path);
+    ret pr;
 }
 
 # one own-source module discovered by the whole-source test walk: its interned FQN
@@ -1466,19 +1466,15 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
     c.step_count = 0;
 }
 
-# read and parse `<project_root>/mach.toml`, then synthesize the ProjectConfig
-# through load_config
-fun load_project_config(p: *Project, project_root: str, sel: *manifest.Selection, for_union: bool, is_test: bool) R.Result[bool, str] {
+# read and parse the manifest at `manifest_path`, then synthesize the ProjectConfig
+# through load_config. `manifest_path` is borrowed for the read (conventionally
+# `<project_root>/mach.toml`, or an alternate manifest the CLI resolved).
+fun load_project_config(p: *Project, project_root: str, manifest_path: str, sel: *manifest.Selection, for_union: bool, is_test: bool) R.Result[bool, str] {
     val abs_root_r: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, project_root);
     if (R.is_err[intern.StrId, str](abs_root_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](abs_root_r)); }
     p.config.project_root = R.unwrap_ok[intern.StrId, str](abs_root_r);
 
-    val toml_path_r: R.Result[str, str] = join_path(p.s.alloc, project_root, "mach.toml");
-    if (R.is_err[str, str](toml_path_r)) { ret R.err[bool, str](R.unwrap_err[str, str](toml_path_r)); }
-    val toml_path: str = R.unwrap_ok[str, str](toml_path_r);
-
-    val toml_r: R.Result[toml.Table, str] = parse_toml_file(p.s.alloc, toml_path);
-    str_free(p.s.alloc, toml_path);
+    val toml_r: R.Result[toml.Table, str] = parse_toml_file(p.s.alloc, manifest_path);
     if (R.is_err[toml.Table, str](toml_r)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](toml_r)); }
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
@@ -5829,7 +5825,8 @@ fun ut_build_test(s: *session.Session, alloc: *A.Allocator, names: *str, texts: 
     sel.artifact     = "";
     sel.want_lib     = false;
     sel.has_artifact = false;
-    val pr: R.Result[Project, str] = build_project_test(s, root, ?sel);
+    val mf: str = ut_cc3(alloc, root, "/", "mach.toml");
+    val pr: R.Result[Project, str] = build_project_test(s, root, mf, ?sel);
     filesystem.remove_all(alloc, root);
     ret pr;
 }
@@ -6293,7 +6290,8 @@ test "mach.lang.driver:union_malformed_condition_reported_once" {
     if (R.is_err[bool, str](rr1)) { filesystem.remove_all(?a1, root1); session.dnit(?s1); ret 1; }
     var sel: manifest.Selection;
     sel.target = ""; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false;
-    val p1r: R.Result[Project, str] = build_project_sel(?s1, root1, ?sel);
+    val mf1: str = ut_cc3(?a1, root1, "/", "mach.toml");
+    val p1r: R.Result[Project, str] = build_project_sel(?s1, root1, mf1, ?sel);
     filesystem.remove_all(?a1, root1);
     if (R.is_err[Project, str](p1r)) { session.dnit(?s1); ret 1; }
     var p1: Project = R.unwrap_ok[Project, str](p1r);
@@ -6463,19 +6461,20 @@ test "mach.lang.driver:union_ambiguous_multi_artifact_default" {
     val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_multi(), ?names[0], ?texts[0], 4);
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
+    val mf:   str = ut_cc3(?alloc, root, "/", "mach.toml");
 
     var bad: i32 = 0;
 
     # 1) no selector: the ambiguity error build_project_sel raises must still fire.
     var sel_none: manifest.Selection;
     sel_none.target = ""; sel_none.profile = ""; sel_none.artifact = ""; sel_none.want_lib = false; sel_none.has_artifact = false;
-    val p0r: R.Result[Project, str] = build_project_sel(?s, root, ?sel_none);
+    val p0r: R.Result[Project, str] = build_project_sel(?s, root, mf, ?sel_none);
     if (R.is_ok[Project, str](p0r)) { var p0: Project = R.unwrap_ok[Project, str](p0r); dnit_project(?p0); bad = 1; }
 
     # 2) --bin alpha: the single-selected build loads alpha's closure and NOT beta's.
     var sel_alpha: manifest.Selection;
     sel_alpha.target = ""; sel_alpha.profile = ""; sel_alpha.artifact = "alpha"; sel_alpha.want_lib = false; sel_alpha.has_artifact = true;
-    val par: R.Result[Project, str] = build_project_sel(?s, root, ?sel_alpha);
+    val par: R.Result[Project, str] = build_project_sel(?s, root, mf, ?sel_alpha);
     if (R.is_err[Project, str](par)) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var pa: Project = R.unwrap_ok[Project, str](par);
     if (!ut_has(?pa, ?s, "uniontest.alpha"))    { bad = 1; }
@@ -6513,13 +6512,14 @@ test "mach.lang.driver:resolve_artifact_path" {
     val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
     if (R.is_err[str, str](root_r)) { ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
+    val mf:   str = ut_cc3(?alloc, root, "/", "mach.toml");
 
     var bad: i32 = 0;
 
     # the manifest's `out` template resolves to the build's output path, rooted.
     var sel: manifest.Selection;
     sel.target = "linux"; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false;
-    val pr: R.Result[str, str] = resolve_artifact_path(?alloc, root, ?sel);
+    val pr: R.Result[str, str] = resolve_artifact_path(?alloc, root, mf, ?sel);
     if (R.is_err[str, str](pr)) { bad = 1; }
     or {
         val want: str = ut_cc3(?alloc, root, "/", "out/linux/debug/bin/uniontest");
@@ -6529,7 +6529,7 @@ test "mach.lang.driver:resolve_artifact_path" {
     # an unknown artifact selection surfaces the manifest error, never a path.
     var sel_bad: manifest.Selection;
     sel_bad.target = "linux"; sel_bad.profile = ""; sel_bad.artifact = "nope"; sel_bad.want_lib = false; sel_bad.has_artifact = true;
-    val pr_bad: R.Result[str, str] = resolve_artifact_path(?alloc, root, ?sel_bad);
+    val pr_bad: R.Result[str, str] = resolve_artifact_path(?alloc, root, mf, ?sel_bad);
     if (R.is_ok[str, str](pr_bad)) { bad = 1; }
 
     filesystem.remove_all(?alloc, root);


### PR DESCRIPTION
Closes #1974

Restores the optional positional path for project-rooted commands and defines its resolution precisely through one shared helper, `util.resolve_project`, that produces the `(project_root, manifest_path)` pair. No command re-parses the manifest independently; the resolved manifest path is threaded into the driver so an alternate manifest is read directly.

## Resolution rules (util.resolve_project)

1. **No path** -> walk up from the working directory to the nearest `mach.toml`.
2. **Directory** -> `<dir>/mach.toml` exactly; error if absent (an explicit directory is *not* walked upward).
3. **File** -> use it as the manifest, project root = its parent dir (enables `mach build ci.toml`).
4. **Nonexistent** -> error naming the path.

Rules 1-4 are applied uniformly by `build`, `run`, `test`, `clean`, and `doc`.

## Changes

- **src/cli/util.mach**: new `resolve_project` (plus `copy_cstr`/`cat3` helpers) and unit tests for all four rules. `find_project_root` is now internal to it.
- **src/lang/driver.mach**: thread `manifest_path` through `load_project_config`, `build_project_impl`, `build_project_sel`, `build_project_test`, `build_project`, `enumerate_matrix`, `resolve_artifact_path`. `build_project_union` keeps its signature and reads the conventional root manifest (so its ~60 test call sites are untouched). `clean`'s `clean_project` takes the resolved manifest path.
- **src/cli/cmd/{build,run,clean,doc}.mach**: each command's mandatory-positional block replaced by `resolve_project`; `test` inherits via the shared build path. Help text for each command's path argument updated ("[path]" now optional).

## Verification

- **Seed build**: `mach build . --profile release` clean.
- **Unit suite** through the fresh compiler: **535 passed, 0 failed** (533 baseline + 2 new resolver tests).
- **Self-host fixpoint**: stage2 == stage3 byte-identical (release).
- **e2e demo** (scratch project, all via the fresh compiler):
  - no-arg from root -> builds; no-arg from nested `src/` -> upward walk builds
  - explicit dir -> builds; explicit `mach.toml` -> builds
  - alternate `ci.toml` -> builds a **distinct** `bin/demo-ci` artifact (proves manifest threading reaches the driver)
  - nonexistent path -> `error: project path '<p>' does not exist`
  - dir without a mach.toml -> `error: no mach.toml in directory '<p>'` (no upward walk)
  - `run`/`test`/`clean`/`doc` resolve identically (no-arg, explicit dir, explicit file)

## Notes

- No regression on `mach build .` from a nested dir: it errored on the seed too (the old lexical walk never ascended from `.`). The new ergonomic form is the no-arg `mach build`, which the seed could not do at all (the path was mandatory).
- doc/cli.md path wording is left to #1977 (broader help/doc staleness), per scope.
- **Discovered, pre-existing, out of scope**: `mach doc` fails with `could not create output directory` when the project has no `doc/` dir yet, because it uses single-level `ensure_dir` for `<root>/doc/api` instead of a recursive mkdir. Reproduced identically on the unmodified 3.0.2 seed, so it is unrelated to this change - flagging for a separate fix.