### PR TITLE
feat(driver): demand-driven [step.X] engine (dep steps, root homing, content cache, globs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Re-implements the `[step.X]` build-step engine as demand-driven with content-based caching (#1970). A step runs only when demanded — by a selected, target-matching `local` link entry whose path matches the step's `out`, an artifact's `need`, or another step's `need` — never automatically; cycles are an error. A dependency's export steps now execute (from the dep checkout, homing `{project.out}` into the consumer out tree), so vendored-C dependencies that previously failed to link now build. Step paths and `cmd` use the closed template set `{project.out}`/`{target.name}`/`{profile.name}`; an unknown `{a.b}` is a hard error.
+
+### Added
+- steps: `in` globbing (`*`, `**`) with sorted, stable expansion; an empty match is an error.
+
+### Changed
+- steps: Demand-driven execution — a step runs only when a link entry, artifact, or another step demands it; platform-filtered steps never run on a non-matching cell.
+- steps: Content-fingerprint caching (a persisted per-step stamp over the inputs' content and the expanded `cmd`) replaces mtime staleness — a warm rebuild skips unchanged steps, a `cmd` or source edit re-runs them.
+
+### Fixed
+- driver: A dependency's `[step.X]` outputs are produced (in the consumer out tree) before the link, instead of failing with "cannot find link input".
+
 ## [3.0.2] - 2026-07-07
 
 Fixes transitive dependency resolution to resolve flat relative to the current root directory instead of nesting them.

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -427,7 +427,8 @@ pub fun build_project(s: *session.Session, project_root: str, manifest_path: str
     sel.artifact     = "";
     sel.want_lib     = false;
     sel.has_artifact = false;
-    ret build_project_sel(s, project_root, manifest_path, ?sel);
+    # the doc/tooling entry: load the graph but never run steps (no shell in a doc pass).
+    ret build_project_impl(s, project_root, manifest_path, ?sel, false, false, false);
 }
 
 # one (target, artifact) cell a `mach build` invocation compiles.
@@ -582,7 +583,7 @@ pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, manifest_p
 # manifest target's tuple and flips on the union load walk (see load_config /
 # walk_comptime_if_union). `all_own_src` additionally loads every own-source module
 # as a collection root (see load_all_own_src), for `mach test`.
-fun build_project_impl(s: *session.Session, project_root: str, manifest_path: str, sel: *manifest.Selection, for_union: bool, all_own_src: bool) R.Result[Project, str] {
+fun build_project_impl(s: *session.Session, project_root: str, manifest_path: str, sel: *manifest.Selection, for_union: bool, all_own_src: bool, run_steps: bool) R.Result[Project, str] {
     var p: Project;
     init_project(?p, s);
 
@@ -607,20 +608,24 @@ fun build_project_impl(s: *session.Session, project_root: str, manifest_path: st
         ret R.err[Project, str]("internal: manifest selected no target");
     }
 
-    # run the demanded build steps: the root project's, then each dependency's
-    # export-demanded steps, all before the objects they produce are linked (#1970).
-    val res_steps: R.Result[bool, str] = execute_steps(p.s.alloc, ?p, project_root);
-    if (R.is_err[bool, str](res_steps)) {
-        dnit_project(?p);
-        ret R.err[Project, str](R.unwrap_err[bool, str](res_steps));
-    }
-    val isa_s: str = O.unwrap[str](intern.lookup(?p.s.interner, te.isa_name));
-    val os_s:  str = O.unwrap[str](intern.lookup(?p.s.interner, te.os_name));
-    val abi_s: str = O.unwrap[str](intern.lookup(?p.s.interner, te.abi_name));
-    val res_dep_steps: R.Result[bool, str] = execute_dep_steps(?p, isa_s, os_s, abi_s);
-    if (R.is_err[bool, str](res_dep_steps)) {
-        dnit_project(?p);
-        ret R.err[Project, str](R.unwrap_err[bool, str](res_dep_steps));
+    # run the demanded build steps only for build/test flows - never for a doc or
+    # workspace-union load, which must not execute shell (#1989 review). the root
+    # project's steps run first, then each dependency's export-demanded steps, all
+    # before the objects they produce are linked (#1970).
+    if (run_steps) {
+        val res_steps: R.Result[bool, str] = execute_steps(p.s.alloc, ?p, project_root);
+        if (R.is_err[bool, str](res_steps)) {
+            dnit_project(?p);
+            ret R.err[Project, str](R.unwrap_err[bool, str](res_steps));
+        }
+        val isa_s: str = O.unwrap[str](intern.lookup(?p.s.interner, te.isa_name));
+        val os_s:  str = O.unwrap[str](intern.lookup(?p.s.interner, te.os_name));
+        val abi_s: str = O.unwrap[str](intern.lookup(?p.s.interner, te.abi_name));
+        val res_dep_steps: R.Result[bool, str] = execute_dep_steps(?p, isa_s, os_s, abi_s);
+        if (R.is_err[bool, str](res_dep_steps)) {
+            dnit_project(?p);
+            ret R.err[Project, str](R.unwrap_err[bool, str](res_dep_steps));
+        }
     }
 
     val fp_r: R.Result[bool, str] = select_target(?p, te);
@@ -720,14 +725,14 @@ fun build_project_impl(s: *session.Session, project_root: str, manifest_path: st
 # repeatedly on one long-lived Session: sources dedup by path and dnit_project
 # resets the session's module registries (see dnit_project's reload contract)
 pub fun build_project_sel(s: *session.Session, project_root: str, manifest_path: str, sel: *manifest.Selection) R.Result[Project, str] {
-    ret build_project_impl(s, project_root, manifest_path, sel, false, false);
+    ret build_project_impl(s, project_root, manifest_path, sel, false, false, true);
 }
 
 # build the module graph for a `mach test` invocation: like build_project_sel, but
 # additionally loads every own-source module under `[project].src` as a collection
 # root, so tests in a module no entrypoint imports are still collected (#1863)
 pub fun build_project_test(s: *session.Session, project_root: str, manifest_path: str, sel: *manifest.Selection) R.Result[Project, str] {
-    ret build_project_impl(s, project_root, manifest_path, sel, false, true);
+    ret build_project_impl(s, project_root, manifest_path, sel, false, true, true);
 }
 
 # build the union of EVERY manifest target's AND artifact's
@@ -753,7 +758,7 @@ pub fun build_project_union(s: *session.Session, project_root: str) R.Result[Pro
     val mp_r: R.Result[str, str] = join_path(s.alloc, project_root, "mach.toml");
     if (R.is_err[str, str](mp_r)) { ret R.err[Project, str](R.unwrap_err[str, str](mp_r)); }
     val manifest_path: str = R.unwrap_ok[str, str](mp_r);
-    val pr: R.Result[Project, str] = build_project_impl(s, project_root, manifest_path, ?sel, true, false);
+    val pr: R.Result[Project, str] = build_project_impl(s, project_root, manifest_path, ?sel, true, false, false);
     str_free(s.alloc, manifest_path);
     ret pr;
 }
@@ -6117,6 +6122,33 @@ test "mach.lang.driver:step_fingerprint" {
     ret code;
 }
 
+# glob_shape_ok accepts a trailing-segment wildcard and one '**' dir segment, and
+# rejects a wildcard in a middle segment or a doubled '**' (#1989 review)
+test "mach.lang.driver:glob_shape_ok" {
+    var bad: i32 = 0;
+    if (!glob_shape_ok("dir/*.c"))       { bad = 1; }
+    if (!glob_shape_ok("dir/**/*.c"))    { bad = 1; }
+    if (!glob_shape_ok("*.c"))           { bad = 1; }
+    if (!glob_shape_ok("a/b/c.c"))       { bad = 1; }
+    if (glob_shape_ok("a/*/b.c"))        { bad = 1; }
+    if (glob_shape_ok("a/**/**/*.c"))    { bad = 1; }
+    ret bad;
+}
+
+# dep_out_home climbs dep_vr's depth BELOW project_root, so a relative and an
+# absolute root that place the dep at the same depth home identically (#1989 review)
+test "mach.lang.driver:dep_out_home" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var code: i32 = 0;
+
+    val rel: R.Result[str, str] = dep_out_home(?alloc, ".", "./dep/x", "out/linux/debug");
+    if (R.is_err[str, str](rel) || !str_equals(R.unwrap_ok[str, str](rel), "../../out/linux/debug")) { code = 1; }
+    val abs: R.Result[str, str] = dep_out_home(?alloc, "/home/u/proj", "/home/u/proj/dep/x", "out/linux/debug");
+    if (R.is_err[str, str](abs) || !str_equals(R.unwrap_ok[str, str](abs), "../../out/linux/debug")) { code = 1; }
+    ret code;
+}
+
 # #1873: an orphan module (no in-tree consumer) whose load-time comptime evaluation
 # reaches a `$error` is target-gated - loaded but kept out of the topo set and
 # counted for the skip note - so a `mach test` over a tree with other-target modules
@@ -9312,7 +9344,9 @@ fun glob_walk(alloc: *A.Allocator, root: str, base_rel: str, pat: str, recursive
                 if (reclen == 0) { reading = false; }
                 or {
                     val name: *u8 = ?ent.d_name[0];
-                    if (!is_dot_name(name)) {
+                    # skip dot entries entirely - a `*` never matches a dot-file and `**`
+                    # never descends a dot-dir (e.g. `.git`), matching shell glob rules.
+                    if (name[0] != '.'::u8) {
                         val rr: R.Result[bool, str] = glob_visit(alloc, root, base_rel, name::str, pat, recursive, out);
                         if (R.is_err[bool, str](rr)) { result = rr; reading = false; }
                     }
@@ -9323,6 +9357,46 @@ fun glob_walk(alloc: *A.Allocator, root: str, base_rel: str, pat: str, recursive
     }
     sysos.close(fd);
     ret result;
+}
+
+# whether `pattern` is a glob shape the expander supports: `*` only in the final path
+# segment, with at most one standalone `**` directory segment before it. rejects a `*`
+# in a middle segment or a `**` fused into a name (#1989 review).
+fun glob_shape_ok(pattern: str) bool {
+    val n: usize = str_len(pattern);
+    var final_start: usize = 0;
+    var j: usize = 0;
+    for (j < n) { if (pattern[j] == '/'::u8) { final_start = j + 1; } j = j + 1; }
+
+    var dstar: u32 = 0;
+    var i: usize = 0;
+    for (i < final_start) {
+        var seg_end: usize = i;
+        for (seg_end < n && pattern[seg_end] != '/'::u8) { seg_end = seg_end + 1; }
+        val slen: usize = seg_end - i;
+        if (slen > 0) {
+            if (slen == 2 && pattern[i] == '*'::u8 && pattern[i + 1] == '*'::u8) { dstar = dstar + 1; }
+            or {
+                var k: usize = i;
+                for (k < seg_end) { if (pattern[k] == '*'::u8) { ret false; } k = k + 1; }
+            }
+        }
+        i = seg_end + 1;
+    }
+    if (dstar > 1) { ret false; }
+
+    # the final segment may hold single `*` wildcards but not a `**`
+    var f: usize = final_start;
+    var prev_star: bool = false;
+    for (f < n) {
+        if (pattern[f] == '*'::u8) {
+            if (prev_star) { ret false; }
+            prev_star = true;
+        }
+        or { prev_star = false; }
+        f = f + 1;
+    }
+    ret true;
 }
 
 # expand one `*`/`**` pattern (relative to `project_root`) into `out`. `<dir>/**/<pat>`
@@ -9382,6 +9456,11 @@ fun collect_step_inputs(alloc: *A.Allocator, p: *Project, step: *manifest.StepDe
             if (R.is_err[usize, str](pr)) { str_free(alloc, exp); ret R.err[bool, str](R.unwrap_err[usize, str](pr)); }
         }
         or {
+            if (!glob_shape_ok(exp)) {
+                val msg: str = step_cc5(alloc, "mach.toml: step input glob '", exp, "' has an unsupported shape; wildcards are allowed only in the final path segment, with an optional '**' directory segment (e.g. 'dir/*.c' or 'dir/**/*.c')", "", "");
+                str_free(alloc, exp);
+                ret R.err[bool, str](msg);
+            }
             val before: usize = out.len;
             val gr: R.Result[bool, str] = glob_expand_pattern(alloc, project_root, exp, out);
             if (R.is_err[bool, str](gr)) { str_free(alloc, exp); ret gr; }
@@ -9517,6 +9596,42 @@ fun write_stamp(a: *A.Allocator, root_out: str, path: str, hex: str) {
     filesystem.write_file(path, hex::*u8, str_len(hex), 0o644);
 }
 
+# the directory part of `path` (up to the last '/'), or "" when there is none
+fun parent_dir(a: *A.Allocator, path: str) str {
+    val n: usize = str_len(path);
+    var last: i64 = -1;
+    var i: usize = 0;
+    for (i < n) { if (path[i] == '/'::u8) { last = i::i64; } i = i + 1; }
+    if (last <= 0) { ret ""; }
+    ret str_slice(a, path, 0, last::usize);
+}
+
+# create the parent directory of every declared output before a step runs, so a cmd
+# that assumes its out tree exists (no `mkdir`, like the RFC's miniz example) does not
+# fail at the tool (#1989 review). outputs expand against the ROOT out - a clean path
+# with no `..` - and are created from the build cwd for both root and dep steps.
+fun step_make_output_dirs(a: *A.Allocator, p: *Project, step: *manifest.StepDef) R.Result[bool, str] {
+    val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
+    val profile_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
+    val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
+    var oi: u32 = 0;
+    for (oi < step.out_count) {
+        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), root_out, target_name_s, profile_s, "", "");
+        if (R.is_err[str, str](out_r)) { ret R.err[bool, str](R.unwrap_err[str, str](out_r)); }
+        val out_s: str = R.unwrap_ok[str, str](out_r);
+        val dir: str = parent_dir(a, out_s);
+        str_free(a, out_s);
+        if (!str_empty(dir)) {
+            val mr: R.Result[bool, str] = filesystem.create_dir_all(a, dir, 0o755);
+            str_free(a, dir);
+            if (R.is_err[bool, str](mr)) { ret mr; }
+        }
+        or { str_free(a, dir); }
+        oi = oi + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
 # run one step from `project_root` (its shell CWD), homing `{project.out}` to
 # `home_out`. root steps home to the root out and run from the root; a dependency's
 # steps run from the dep checkout and home to a path that climbs back to the root out
@@ -9559,6 +9674,14 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
             str_free(a, expanded_cmd);
             ret R.ok[bool, str](true);
         }
+    }
+
+    # create the output parent dirs before running, so a `mkdir`-less cmd succeeds.
+    val mdr: R.Result[bool, str] = step_make_output_dirs(a, p, step);
+    if (R.is_err[bool, str](mdr)) {
+        if (stampable) { str_free(a, hex); str_free(a, stamp_path); }
+        str_free(a, expanded_cmd);
+        ret R.err[bool, str](R.unwrap_err[bool, str](mdr));
     }
 
     val msg: str = step_cc5(a, "step ", step_name, ": ", expanded_cmd, "\n");
@@ -9634,22 +9757,33 @@ fun execute_steps(a: *A.Allocator, p: *Project, project_root: str) R.Result[bool
     ret R.ok[bool, str](true);
 }
 
-# the `{project.out}` a dependency's step homes against (#1970): a relative path that
-# climbs from the dep checkout `dep_vr` (the step's CWD) back to the root, then
-# descends into the root out - so `vendor/*` inputs resolve at the dep while step
-# outputs land in the consumer out tree. e.g. dep_vr `./dep/x`, root out
-# `out/linux/debug` -> `../../out/linux/debug`.
-fun dep_out_home(alloc: *A.Allocator, dep_vr: str, root_out: str) R.Result[str, str] {
-    val n: usize = str_len(dep_vr);
+# the number of real path segments in `s`, ignoring '.' and empty runs
+fun path_seg_count(s: str) u32 {
+    val n: usize = str_len(s);
     var segs: u32 = 0;
     var i: usize = 0;
     for (i < n) {
-        for (i < n && dep_vr[i] == '/'::u8) { i = i + 1; }
+        for (i < n && s[i] == '/'::u8) { i = i + 1; }
         val start: usize = i;
-        for (i < n && dep_vr[i] != '/'::u8) { i = i + 1; }
+        for (i < n && s[i] != '/'::u8) { i = i + 1; }
         val seglen: usize = i - start;
-        if (seglen > 0 && !(seglen == 1 && dep_vr[start] == '.'::u8)) { segs = segs + 1; }
+        if (seglen > 0 && !(seglen == 1 && s[start] == '.'::u8)) { segs = segs + 1; }
     }
+    ret segs;
+}
+
+# the `{project.out}` a dependency's step homes against (#1970): a relative path that
+# climbs from the dep checkout `dep_vr` (the step's CWD) back to the root, then
+# descends into the root out - so `vendor/*` inputs resolve at the dep while step
+# outputs land in the consumer out tree. the climb is dep_vr's depth BELOW
+# `project_root` (the flat store puts every dep at `<root>/dep/<alias>`), so it is
+# correct whether the root is relative (`.` -> `../../out/...`) or absolute (counting
+# dep_vr's own segments would overshoot to the filesystem root, #1989 review).
+fun dep_out_home(alloc: *A.Allocator, project_root: str, dep_vr: str, root_out: str) R.Result[str, str] {
+    val root_segs: u32 = path_seg_count(project_root);
+    val dep_segs:  u32 = path_seg_count(dep_vr);
+    var segs: u32 = 0;
+    if (dep_segs > root_segs) { segs = dep_segs - root_segs; }
 
     val total: usize = (segs::usize) * 3 + str_len(root_out);
     val rb: R.Result[*u8, str] = A.allocate[u8](alloc, total + 1);
@@ -9690,6 +9824,7 @@ fun execute_dep_steps(p: *Project, isa: str, os: str, abi: str) R.Result[bool, s
     tgt.abi = R.unwrap_ok[intern.StrId, str](ra);
 
     val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
+    val root_project: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_root));
     val tn: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
     val pn: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
 
@@ -9717,7 +9852,7 @@ fun execute_dep_steps(p: *Project, isa: str, os: str, abi: str) R.Result[bool, s
         if (R.is_err[bool, str](dpr)) { manifest.dnit(?mfd, p.s.alloc); ret dpr; }
 
         if (dep_count > 0) {
-            val hr: R.Result[str, str] = dep_out_home(p.s.alloc, dep_vr, root_out);
+            val hr: R.Result[str, str] = dep_out_home(p.s.alloc, root_project, dep_vr, root_out);
             if (R.is_err[str, str](hr)) { A.deallocate[u32](p.s.alloc, dep_order, dep_count::usize); manifest.dnit(?mfd, p.s.alloc); ret R.err[bool, str](R.unwrap_err[str, str](hr)); }
             val dep_home: str = R.unwrap_ok[str, str](hr);
             val dep_owner: str = O.unwrap[str](intern.lookup(?p.s.interner, mfd.id));

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -6060,6 +6060,24 @@ fun ut_in_topo(p: *Project, s: *session.Session, fqn: str) bool {
     ret false;
 }
 
+# the single-segment `*` glob matcher backing step `in` expansion (#1970): `*`
+# absorbs any run (including empty), non-star chars must match, and a bare pattern
+# without `*` is an exact compare
+test "mach.lang.driver:wildcard_match" {
+    var bad: i32 = 0;
+    if (!wildcard_match("*.c", "mad.c"))          { bad = 1; }
+    if (!wildcard_match("*.c", ".c"))             { bad = 1; }
+    if (!wildcard_match("mini*.h", "miniaudio.h")) { bad = 1; }
+    if (!wildcard_match("a*b*c", "axxbyyc"))      { bad = 1; }
+    if (!wildcard_match("*", "anything"))         { bad = 1; }
+    if (!wildcard_match("exact.c", "exact.c"))    { bad = 1; }
+    if (wildcard_match("*.c", "mad.h"))           { bad = 1; }
+    if (wildcard_match("*.c", "mad.cpp"))         { bad = 1; }
+    if (wildcard_match("mini*.h", "audio.h"))     { bad = 1; }
+    if (wildcard_match("exact.c", "exact.cc"))    { bad = 1; }
+    ret bad;
+}
+
 # #1873: an orphan module (no in-tree consumer) whose load-time comptime evaluation
 # reaches a `$error` is target-gated - loaded but kept out of the topo set and
 # counted for the skip note - so a `mach test` over a tree with other-target modules
@@ -9186,6 +9204,209 @@ fun step_cc5(alloc: *A.Allocator, a: str, b: str, c: str, d: str, e: str) str {
     ret buf::str;
 }
 
+# the substring `s[start:end]` as a fresh owned string
+fun str_slice(alloc: *A.Allocator, s: str, start: usize, end: usize) str {
+    val n: usize = end - start;
+    val rb: R.Result[*u8, str] = A.allocate[u8](alloc, n + 1);
+    if (R.is_err[*u8, str](rb)) { ret ""; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    var i: usize = 0;
+    for (i < n) { buf[i] = s[start + i]; i = i + 1; }
+    buf[n] = 0;
+    ret buf::str;
+}
+
+# whether `s` contains a `*` glob metacharacter
+fun has_glob(s: str) bool {
+    val n: usize = str_len(s);
+    var i: usize = 0;
+    for (i < n) { if (s[i] == '*'::u8) { ret true; } i = i + 1; }
+    ret false;
+}
+
+# lexicographic byte order, for sorting expanded input paths into a stable order
+fun cmp_str(a: *str, b: *str) i64 {
+    val sa: str = @a;
+    val sb: str = @b;
+    val an: usize = str_len(sa);
+    val bn: usize = str_len(sb);
+    var i: usize = 0;
+    for (i < an && i < bn) {
+        if (sa[i] != sb[i]) { ret (sa[i]::i64) - (sb[i]::i64); }
+        i = i + 1;
+    }
+    ret (an::i64) - (bn::i64);
+}
+
+# whether the single path segment `name` matches the `*`-glob `pat` (no '/' in either)
+fun wildcard_match(pat: str, name: str) bool {
+    val pn: usize = str_len(pat);
+    val nn: usize = str_len(name);
+    var pi: usize = 0;
+    var ni: usize = 0;
+    var star: i64 = -1;
+    var mark: usize = 0;
+    for (ni < nn) {
+        if (pi < pn && pat[pi] == '*'::u8) { star = pi::i64; mark = ni; pi = pi + 1; }
+        or (pi < pn && pat[pi] == name[ni]) { pi = pi + 1; ni = ni + 1; }
+        or (star >= 0) { pi = (star::usize) + 1; mark = mark + 1; ni = mark; }
+        or { ret false; }
+    }
+    for (pi < pn && pat[pi] == '*'::u8) { pi = pi + 1; }
+    ret pi == pn;
+}
+
+# handle one directory entry while globbing: match a file basename against `pat`
+# (pushing `<base_rel>/<name>`), or recurse into a subdirectory when `recursive`
+fun glob_visit(alloc: *A.Allocator, root: str, base_rel: str, name: str, pat: str, recursive: bool, out: *vector.Vector[str]) R.Result[bool, str] {
+    val child_rel_r: R.Result[str, str] = join_path(alloc, base_rel, name);
+    if (R.is_err[str, str](child_rel_r)) { ret R.err[bool, str](R.unwrap_err[str, str](child_rel_r)); }
+    val child_rel: str = R.unwrap_ok[str, str](child_rel_r);
+
+    val child_abs_r: R.Result[str, str] = join_path(alloc, root, child_rel);
+    if (R.is_err[str, str](child_abs_r)) { str_free(alloc, child_rel); ret R.err[bool, str](R.unwrap_err[str, str](child_abs_r)); }
+    val child_abs: str = R.unwrap_ok[str, str](child_abs_r);
+    val fi_r: R.Result[filesystem.FileInfo, str] = filesystem.info_link(child_abs);
+    str_free(alloc, child_abs);
+    if (R.is_err[filesystem.FileInfo, str](fi_r)) { str_free(alloc, child_rel); ret R.ok[bool, str](true); }
+    val fi: filesystem.FileInfo = R.unwrap_ok[filesystem.FileInfo, str](fi_r);
+
+    if (filesystem.info_is_dir(?fi) && recursive) {
+        val rr: R.Result[bool, str] = glob_walk(alloc, root, child_rel, pat, recursive, out);
+        str_free(alloc, child_rel);
+        ret rr;
+    }
+    or (filesystem.info_is_file(?fi) && wildcard_match(pat, name)) {
+        # the vector takes ownership of child_rel
+        val pr: R.Result[usize, str] = vector.push[str](out, child_rel);
+        if (R.is_err[usize, str](pr)) { str_free(alloc, child_rel); ret R.err[bool, str](R.unwrap_err[usize, str](pr)); }
+        ret R.ok[bool, str](true);
+    }
+    str_free(alloc, child_rel);
+    ret R.ok[bool, str](true);
+}
+
+# enumerate `<root>/<base_rel>`, appending each matching file as `<base_rel>/<name>`
+# relative to root; recurse into subdirectories when `recursive`. a missing directory
+# yields no matches (the empty-match error is the caller's).
+fun glob_walk(alloc: *A.Allocator, root: str, base_rel: str, pat: str, recursive: bool, out: *vector.Vector[str]) R.Result[bool, str] {
+    val dir_abs_r: R.Result[str, str] = join_path(alloc, root, base_rel);
+    if (R.is_err[str, str](dir_abs_r)) { ret R.err[bool, str](R.unwrap_err[str, str](dir_abs_r)); }
+    val dir_abs: str = R.unwrap_ok[str, str](dir_abs_r);
+
+    val fd_raw: i64 = sysos.open(sysos.AT_FDCWD, dir_abs, sysos.O_RDONLY | sysos.O_DIRECTORY, 0);
+    str_free(alloc, dir_abs);
+    if (fd_raw < 0) { ret R.ok[bool, str](true); }
+    val fd: i32 = fd_raw::i32;
+
+    var dbuf: [8192]u8;
+    var result: R.Result[bool, str] = R.ok[bool, str](true);
+    var reading: bool = true;
+    for (reading) {
+        val nread: i64 = sysos.read_dir(fd, (?dbuf[0])::*sysos.dirent64, 8192);
+        if (nread < 0)  { result = R.err[bool, str](sysos.message(nread)); reading = false; }
+        or (nread == 0) { reading = false; }
+        or {
+            var pos: usize = 0;
+            for (reading && pos < nread::usize) {
+                val ent:    *sysos.dirent64 = ((?dbuf[0])::usize + pos)::*sysos.dirent64;
+                val reclen: usize           = ent.d_reclen::usize;
+                if (reclen == 0) { reading = false; }
+                or {
+                    val name: *u8 = ?ent.d_name[0];
+                    if (!is_dot_name(name)) {
+                        val rr: R.Result[bool, str] = glob_visit(alloc, root, base_rel, name::str, pat, recursive, out);
+                        if (R.is_err[bool, str](rr)) { result = rr; reading = false; }
+                    }
+                    pos = pos + reclen;
+                }
+            }
+        }
+    }
+    sysos.close(fd);
+    ret result;
+}
+
+# expand one `*`/`**` pattern (relative to `project_root`) into `out`. `<dir>/**/<pat>`
+# walks `<dir>` recursively matching `<pat>` at any depth; `<dir>/<pat>` or a bare
+# `<pat>` walks a single level.
+fun glob_expand_pattern(alloc: *A.Allocator, project_root: str, pattern: str, out: *vector.Vector[str]) R.Result[bool, str] {
+    val n: usize = str_len(pattern);
+    var star2: i64 = -1;
+    var i: usize = 0;
+    for (i + 1 < n && star2 < 0) {
+        if (pattern[i] == '*'::u8 && pattern[i + 1] == '*'::u8) { star2 = i::i64; }
+        i = i + 1;
+    }
+
+    if (star2 >= 0) {
+        val sp: usize = star2::usize;
+        var base_end: usize = sp;
+        if (base_end > 0 && pattern[base_end - 1] == '/'::u8) { base_end = base_end - 1; }
+        val base: str = str_slice(alloc, pattern, 0, base_end);
+        var pat_start: usize = sp + 2;
+        if (pat_start < n && pattern[pat_start] == '/'::u8) { pat_start = pat_start + 1; }
+        val pat: str = str_slice(alloc, pattern, pat_start, n);
+        var base_use: str = base;
+        if (str_empty(base)) { base_use = "."; }
+        val gr: R.Result[bool, str] = glob_walk(alloc, project_root, base_use, pat, true, out);
+        str_free(alloc, base);
+        str_free(alloc, pat);
+        ret gr;
+    }
+
+    var last: i64 = -1;
+    i = 0;
+    for (i < n) { if (pattern[i] == '/'::u8) { last = i::i64; } i = i + 1; }
+    if (last < 0) { ret glob_walk(alloc, project_root, ".", pattern, false, out); }
+    val dir: str = str_slice(alloc, pattern, 0, last::usize);
+    val pat: str = str_slice(alloc, pattern, (last::usize) + 1, n);
+    val gr: R.Result[bool, str] = glob_walk(alloc, project_root, dir, pat, false, out);
+    str_free(alloc, dir);
+    str_free(alloc, pat);
+    ret gr;
+}
+
+# expand a step's `in` list into concrete input files (templates then globs), sorted
+# for a stable order (#1970). a `*`/`**` pattern expands against `project_root` and an
+# empty match is a hard error; a plain path is taken literally. `out` receives owned
+# path strings the caller frees.
+fun collect_step_inputs(alloc: *A.Allocator, p: *Project, step: *manifest.StepDef, project_root: str, home_out: str, out: *vector.Vector[str]) R.Result[bool, str] {
+    val profile_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
+    val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
+    var i: u32 = 0;
+    for (i < step.in_count) {
+        val exp_r: R.Result[str, str] = manifest.expand(alloc, O.unwrap[str](intern.lookup(?p.s.interner, step.in[i])), home_out, target_name_s, profile_s, "", "");
+        if (R.is_err[str, str](exp_r)) { ret R.err[bool, str](R.unwrap_err[str, str](exp_r)); }
+        val exp: str = R.unwrap_ok[str, str](exp_r);
+        if (!has_glob(exp)) {
+            val pr: R.Result[usize, str] = vector.push[str](out, exp);
+            if (R.is_err[usize, str](pr)) { str_free(alloc, exp); ret R.err[bool, str](R.unwrap_err[usize, str](pr)); }
+        }
+        or {
+            val before: usize = out.len;
+            val gr: R.Result[bool, str] = glob_expand_pattern(alloc, project_root, exp, out);
+            if (R.is_err[bool, str](gr)) { str_free(alloc, exp); ret gr; }
+            if (out.len == before) {
+                val msg: str = step_cc5(alloc, "mach.toml: step input glob '", exp, "' matched no files", "", "");
+                str_free(alloc, exp);
+                ret R.err[bool, str](msg);
+            }
+            str_free(alloc, exp);
+        }
+        i = i + 1;
+    }
+    sort.sort[str](out.data, out.len, cmp_str);
+    ret R.ok[bool, str](true);
+}
+
+# free the owned input paths in `ins` and the vector backing it
+fun step_free_inputs(alloc: *A.Allocator, ins: *vector.Vector[str]) {
+    var i: usize = 0;
+    for (i < ins.len) { str_free(alloc, ins.data[i]); i = i + 1; }
+    vector.dnit[str](ins);
+}
+
 # run one step from `project_root` (its shell CWD), homing `{project.out}` to
 # `home_out`. root steps home to the root out and run from the root; a dependency's
 # steps run from the dep checkout and home to a path that climbs back to the root out
@@ -9196,28 +9417,30 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
     val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
 
     # `in`/`out`/`cmd` home through the closed template set ({project.out},
-    # {target.name}, {profile.name}); an unknown `{a.b}` is a hard error. shell `$VAR`
-    # is left to the shell. skip when every output is up to date against every input
-    # (mtime; #1970 C4 swaps this for a content fingerprint) - a step with no declared
-    # input or output cannot be dated, so it always runs.
-    var out_of_date: bool = (step.in_count == 0 || step.out_count == 0);
-    var ini: u32 = 0;
-    for (ini < step.in_count && !out_of_date) {
-        val in_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.in[ini])), project_out_s, target_name_s, profile_s, "", "");
-        if (R.is_err[str, str](in_r)) { ret R.err[bool, str](R.unwrap_err[str, str](in_r)); }
-        val in_s: str = R.unwrap_ok[str, str](in_r);
-        var outi: u32 = 0;
-        for (outi < step.out_count && !out_of_date) {
-            val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[outi])), project_out_s, target_name_s, profile_s, "", "");
-            if (R.is_err[str, str](out_r)) { str_free(a, in_s); ret R.err[bool, str](R.unwrap_err[str, str](out_r)); }
-            val out_s: str = R.unwrap_ok[str, str](out_r);
-            if (step_out_of_date(a, project_root, in_s, out_s)) { out_of_date = true; }
-            str_free(a, out_s);
-            outi = outi + 1;
+    # {target.name}, {profile.name}); an unknown `{a.b}` is a hard error and shell
+    # `$VAR` is left to the shell. `in` globs expand sorted against project_root (empty
+    # match errors). skip when every output is up to date against every input (mtime;
+    # #1970 C4 swaps this for a content fingerprint) - a step with no input or output
+    # cannot be dated, so it always runs.
+    var ins: vector.Vector[str] = vector.init[str](a);
+    val cir: R.Result[bool, str] = collect_step_inputs(a, p, step, project_root, home_out, ?ins);
+    if (R.is_err[bool, str](cir)) { step_free_inputs(a, ?ins); ret R.err[bool, str](R.unwrap_err[bool, str](cir)); }
+
+    var out_of_date: bool = (ins.len == 0 || step.out_count == 0);
+    var oi: u32 = 0;
+    for (oi < step.out_count && !out_of_date) {
+        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), project_out_s, target_name_s, profile_s, "", "");
+        if (R.is_err[str, str](out_r)) { step_free_inputs(a, ?ins); ret R.err[bool, str](R.unwrap_err[str, str](out_r)); }
+        val out_s: str = R.unwrap_ok[str, str](out_r);
+        var ii: usize = 0;
+        for (ii < ins.len && !out_of_date) {
+            if (step_out_of_date(a, project_root, ins.data[ii], out_s)) { out_of_date = true; }
+            ii = ii + 1;
         }
-        str_free(a, in_s);
-        ini = ini + 1;
+        str_free(a, out_s);
+        oi = oi + 1;
     }
+    step_free_inputs(a, ?ins);
 
     if (!out_of_date) { ret R.ok[bool, str](true); }
 

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -217,6 +217,9 @@ pub rec ProjectConfig {
     project_out:  intern.StrId;
     steps:        *manifest.StepDef;
     step_count:   u32;
+    # indices into `steps` for the demanded steps, in needs-first run order (#1970)
+    step_order:       *u32;
+    step_order_count: u32;
     links:        *manifest.LinkDef;
     link_count:   u32;
 }
@@ -1452,6 +1455,9 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
         }
         A.deallocate[manifest.StepDef](alloc, c.steps, c.step_count::usize);
     }
+    if (c.step_order != nil && c.step_order_count > 0) {
+        A.deallocate[u32](alloc, c.step_order, c.step_order_count::usize);
+    }
     c.targets      = nil;
     c.target_count = 0;
     c.deps         = nil;
@@ -1464,6 +1470,8 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
     c.link_count = 0;
     c.steps = nil;
     c.step_count = 0;
+    c.step_order = nil;
+    c.step_order_count = 0;
 }
 
 # read and parse the manifest at `manifest_path`, then synthesize the ProjectConfig
@@ -1579,7 +1587,9 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     p.config.define_count  = bu.define_count;
     p.target_entry        = ?p.config.targets[0];
     p.config.profile      = bu.profile_name;
-    
+    p.config.step_order       = nil;
+    p.config.step_order_count = 0;
+
     val tn_s: str = O.unwrap[str](intern.lookup(?p.s.interner, bu.target.name));
     val pn_s: str = O.unwrap[str](intern.lookup(?p.s.interner, bu.profile_name));
     val out_tmpl_s: str = O.unwrap[str](intern.lookup(?p.s.interner, m.out_tmpl));
@@ -1607,6 +1617,11 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
             p.config.targets[0].libs      = test_items;
             p.config.targets[0].lib_count = test_count;
         }
+
+        # compute which steps this build demands, in run order (#1970). indices are
+        # into m.steps, which p.config.steps mirrors 1:1 when copied below.
+        val spr: R.Result[bool, str] = compute_step_plan(p, ?m, ?bu, is_test, for_union, project_out_str, tn_s, pn_s);
+        if (R.is_err[bool, str](spr)) { str_free(p.s.alloc, project_out_str); manifest.dnit(?m, p.s.alloc); ret R.err[bool, str](R.unwrap_err[bool, str](spr)); }
         str_free(p.s.alloc, project_out_str);
     }
 
@@ -1909,6 +1924,52 @@ fun local_link_error(alloc: *A.Allocator, name: str, path: str) str {
     k = dcopy(buf, k, c);
     buf[total] = 0;
     ret buf::str;
+}
+
+# compute the demanded step plan for the current build cell and store it in
+# p.config.step_order (#1970). demand is driven by the selected artifact for a plain
+# build, or by every declared artifact for a test/union link (which links them all).
+# ---
+# p:        the active project, receiving the plan
+# m:        the parsed root manifest
+# bu:       the resolved build unit (its artifact / target drive demand)
+# is_test:  a `mach test` link (union of all artifacts)
+# for_union: a multi-artifact union build
+# proj_out: the expanded project out the entry paths and step outs home against
+# tn:       the target name for template expansion
+# pn:       the profile name for template expansion
+fun compute_step_plan(p: *Project, m: *manifest.Manifest, bu: *manifest.BuildUnit,
+                      is_test: bool, for_union: bool, proj_out: str, tn: str, pn: str) R.Result[bool, str] {
+    p.config.step_order       = nil;
+    p.config.step_order_count = 0;
+    if (m.step_count == 0) { ret R.ok[bool, str](true); }
+
+    var names:  *intern.StrId = nil;
+    var ncount: u32           = 0;
+    var owned:  bool          = false;
+    if ((is_test || for_union) && m.artifact_count > 0) {
+        val ar: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](p.s.alloc, m.artifact_count::usize);
+        if (R.is_err[*intern.StrId, str](ar)) { ret R.err[bool, str](R.unwrap_err[*intern.StrId, str](ar)); }
+        names = R.unwrap_ok[*intern.StrId, str](ar);
+        owned = true;
+        var i: u32 = 0;
+        for (i < m.artifact_count) { names[i] = m.artifacts[i].name; i = i + 1; }
+        ncount = m.artifact_count;
+    }
+    or {
+        if (bu.artifact == nil) { ret R.ok[bool, str](true); }
+        names  = ?bu.artifact.name;
+        ncount = 1;
+    }
+
+    var order: *u32 = nil;
+    var count: u32  = 0;
+    val r: R.Result[bool, str] = manifest.plan_steps(p.s.alloc, ?p.s.interner, m, names, ncount, bu.target, proj_out, tn, pn, ?order, ?count);
+    if (owned) { A.deallocate[intern.StrId](p.s.alloc, names, m.artifact_count::usize); }
+    if (R.is_err[bool, str](r)) { ret r; }
+    p.config.step_order       = order;
+    p.config.step_order_count = count;
+    ret R.ok[bool, str](true);
 }
 
 # validate every `local` [link.X] path up-front (#1969): it must match a declared
@@ -9122,186 +9183,6 @@ fun step_seg_dup(alloc: *A.Allocator, tmpl: str, start: usize, end: usize) str {
     ret buf::str;
 }
 
-fun expand_step_vars(alloc: *A.Allocator, cmd: str, target_name: str, profile_name: str, target_isa: str, target_os: str, target_abi: str, project_out: str) str {
-    val n: usize = str_len(cmd);
-    var new_len: usize = 0;
-    var i: usize = 0;
-    for (i < n) {
-        if (cmd[i] == '{') {
-            var ii: usize = i + 1;
-            for (ii < n && cmd[ii] != '}') { ii = ii + 1; }
-            if (ii < n) {
-                val name: str = step_seg_dup(alloc, cmd, i + 1, ii);
-                var val_len: usize = 0;
-                if (str_equals(name, "project.out")) { val_len = str_len(project_out); }
-                or (str_equals(name, "target.name") || str_equals(name, "target")) { val_len = str_len(target_name); }
-                or (str_equals(name, "target.isa"))  { val_len = str_len(target_isa); }
-                or (str_equals(name, "target.os"))   { val_len = str_len(target_os); }
-                or (str_equals(name, "target.abi"))  { val_len = str_len(target_abi); }
-                or (str_equals(name, "profile.name") || str_equals(name, "profile")) { val_len = str_len(profile_name); }
-                new_len = new_len + val_len;
-                i = ii + 1;
-                str_free(alloc, name);
-                cnt;
-            }
-        }
-        new_len = new_len + 1;
-        i = i + 1;
-    }
-
-    val res_buf: R.Result[*u8, str] = A.allocate[u8](alloc, new_len + 1);
-    if (R.is_err[*u8, str](res_buf)) { ret ""; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
-    var w: usize = 0;
-    i = 0;
-    for (i < n) {
-        if (cmd[i] == '{') {
-            var ii: usize = i + 1;
-            for (ii < n && cmd[ii] != '}') { ii = ii + 1; }
-            if (ii < n) {
-                val name: str = step_seg_dup(alloc, cmd, i + 1, ii);
-                var var_val: str = "";
-                if (str_equals(name, "project.out")) { var_val = project_out; }
-                or (str_equals(name, "target.name") || str_equals(name, "target")) { var_val = target_name; }
-                or (str_equals(name, "target.isa"))  { var_val = target_isa; }
-                or (str_equals(name, "target.os"))   { var_val = target_os; }
-                or (str_equals(name, "target.abi"))  { var_val = target_abi; }
-                or (str_equals(name, "profile.name") || str_equals(name, "profile")) { var_val = profile_name; }
-                
-                val vl: usize = str_len(var_val);
-                var iii: usize = 0;
-                for (iii < vl) {
-                    buf[w] = var_val[iii];
-                    w = w + 1;
-                    iii = iii + 1;
-                }
-                i = ii + 1;
-                str_free(alloc, name);
-                cnt;
-            }
-        }
-        buf[w] = cmd[i];
-        w = w + 1;
-        i = i + 1;
-    }
-    buf[w] = 0;
-    ret buf::str;
-}
-
-fun expand_env_vars(alloc: *A.Allocator, cmd: str, target_isa: str, target_os: str, target_abi: str, profile_name: str, out_dir: str) str {
-    val n: usize = str_len(cmd);
-    var new_len: usize = 0;
-    var i: usize = 0;
-    for (i < n) {
-        if (cmd[i] == '$') {
-            var var_len: usize = 0;
-            var var_name: str = "";
-            var var_value: str = "";
-            
-            if (i + 1 < n && cmd[i + 1] == '{') {
-                var ii: usize = i + 2;
-                for (ii < n && cmd[ii] != '}') { ii = ii + 1; }
-                if (ii < n) {
-                    val name: str = step_seg_dup(alloc, cmd, i + 2, ii);
-                    var_name = name;
-                    var_len = ii - i + 1;
-                }
-            }
-            or {
-                var ii: usize = i + 1;
-                for (ii < n && ((cmd[ii] >= 'A' && cmd[ii] <= 'Z') || (cmd[ii] >= 'a' && cmd[ii] <= 'z') || (cmd[ii] >= '0' && cmd[ii] <= '9') || cmd[ii] == '_')) {
-                    ii = ii + 1;
-                }
-                if (ii > i + 1) {
-                    val name: str = step_seg_dup(alloc, cmd, i + 1, ii);
-                    var_name = name;
-                    var_len = ii - i;
-                }
-            }
-            
-            if (str_len(var_name) > 0) {
-                if (str_equals(var_name, "MACH_TARGET_ISA"))      { var_value = target_isa; }
-                or (str_equals(var_name, "MACH_TARGET_OS"))       { var_value = target_os; }
-                or (str_equals(var_name, "MACH_TARGET_ABI"))      { var_value = target_abi; }
-                or (str_equals(var_name, "MACH_PROFILE"))         { var_value = profile_name; }
-                or (str_equals(var_name, "MACH_OUT"))             { var_value = out_dir; }
-                
-                if (str_len(var_value) > 0 || str_equals(var_name, "MACH_TARGET_ISA") || str_equals(var_name, "MACH_TARGET_OS") || str_equals(var_name, "MACH_TARGET_ABI") || str_equals(var_name, "MACH_PROFILE") || str_equals(var_name, "MACH_OUT")) {
-                    new_len = new_len + str_len(var_value);
-                    i = i + var_len;
-                    if (str_len(var_name) > 0) { str_free(alloc, var_name); }
-                    cnt;
-                }
-            }
-            if (str_len(var_name) > 0) { str_free(alloc, var_name); }
-        }
-        new_len = new_len + 1;
-        i = i + 1;
-    }
-    
-    val res_buf: R.Result[*u8, str] = A.allocate[u8](alloc, new_len + 1);
-    if (R.is_err[*u8, str](res_buf)) { ret cmd; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
-    
-    var w: usize = 0;
-    i = 0;
-    for (i < n) {
-        if (cmd[i] == '$') {
-            var var_len: usize = 0;
-            var var_name: str = "";
-            var var_value: str = "";
-            
-            if (i + 1 < n && cmd[i + 1] == '{') {
-                var ii: usize = i + 2;
-                for (ii < n && cmd[ii] != '}') { ii = ii + 1; }
-                if (ii < n) {
-                    val name: str = step_seg_dup(alloc, cmd, i + 2, ii);
-                    var_name = name;
-                    var_len = ii - i + 1;
-                }
-            }
-            or {
-                var ii: usize = i + 1;
-                for (ii < n && ((cmd[ii] >= 'A' && cmd[ii] <= 'Z') || (cmd[ii] >= 'a' && cmd[ii] <= 'z') || (cmd[ii] >= '0' && cmd[ii] <= '9') || cmd[ii] == '_')) {
-                    ii = ii + 1;
-                }
-                if (ii > i + 1) {
-                    val name: str = step_seg_dup(alloc, cmd, i + 1, ii);
-                    var_name = name;
-                    var_len = ii - i;
-                }
-            }
-            
-            if (str_len(var_name) > 0) {
-                if (str_equals(var_name, "MACH_TARGET_ISA"))      { var_value = target_isa; }
-                or (str_equals(var_name, "MACH_TARGET_OS"))       { var_value = target_os; }
-                or (str_equals(var_name, "MACH_TARGET_ABI"))      { var_value = target_abi; }
-                or (str_equals(var_name, "MACH_PROFILE"))         { var_value = profile_name; }
-                or (str_equals(var_name, "MACH_OUT"))             { var_value = out_dir; }
-                
-                if (str_len(var_value) > 0 || str_equals(var_name, "MACH_TARGET_ISA") || str_equals(var_name, "MACH_TARGET_OS") || str_equals(var_name, "MACH_TARGET_ABI") || str_equals(var_name, "MACH_PROFILE") || str_equals(var_name, "MACH_OUT")) {
-                    val vl: usize = str_len(var_value);
-                    var vi: usize = 0;
-                    for (vi < vl) {
-                        buf[w] = var_value[vi];
-                        w = w + 1;
-                        vi = vi + 1;
-                    }
-                    i = i + var_len;
-                    if (str_len(var_name) > 0) { str_free(alloc, var_name); }
-                    cnt;
-                }
-            }
-            if (str_len(var_name) > 0) { str_free(alloc, var_name); }
-        }
-        buf[w] = cmd[i];
-        w = w + 1;
-        i = i + 1;
-    }
-    buf[w] = 0;
-    ret buf::str;
-}
-
 fun step_cc5(alloc: *A.Allocator, a: str, b: str, c: str, d: str, e: str) str {
     val la: usize = str_len(a);
     val lb: usize = str_len(b);
@@ -9328,42 +9209,40 @@ fun step_cc5(alloc: *A.Allocator, a: str, b: str, c: str, d: str, e: str) str {
 }
 
 fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_root: str) R.Result[bool, str] {
-    val isa_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.isa_name));
-    val os_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.os_name));
-    val abi_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.abi_name));
     val profile_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
     val project_out_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
     val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
 
-    # Check if out-of-date across all in/out combinations
-    var out_of_date: bool = false;
+    # `in`/`out`/`cmd` home through the closed template set ({project.out},
+    # {target.name}, {profile.name}); an unknown `{a.b}` is a hard error. shell `$VAR`
+    # is left to the shell. skip when every output is up to date against every input
+    # (mtime; #1970 C4 swaps this for a content fingerprint) - a step with no declared
+    # input or output cannot be dated, so it always runs.
+    var out_of_date: bool = (step.in_count == 0 || step.out_count == 0);
     var ini: u32 = 0;
     for (ini < step.in_count && !out_of_date) {
-        val raw_in: str = O.unwrap[str](intern.lookup(?p.s.interner, step.in[ini]));
-        val in_s: str = expand_step_vars(a, raw_in, target_name_s, profile_s, isa_s, os_s, abi_s, project_out_s);
+        val in_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.in[ini])), project_out_s, target_name_s, profile_s, "", "");
+        if (R.is_err[str, str](in_r)) { ret R.err[bool, str](R.unwrap_err[str, str](in_r)); }
+        val in_s: str = R.unwrap_ok[str, str](in_r);
         var outi: u32 = 0;
         for (outi < step.out_count && !out_of_date) {
-            val raw_out: str = O.unwrap[str](intern.lookup(?p.s.interner, step.out[outi]));
-            val out_s: str = expand_step_vars(a, raw_out, target_name_s, profile_s, isa_s, os_s, abi_s, project_out_s);
-            if (step_out_of_date(a, project_root, in_s, out_s)) {
-                out_of_date = true;
-            }
+            val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[outi])), project_out_s, target_name_s, profile_s, "", "");
+            if (R.is_err[str, str](out_r)) { str_free(a, in_s); ret R.err[bool, str](R.unwrap_err[str, str](out_r)); }
+            val out_s: str = R.unwrap_ok[str, str](out_r);
+            if (step_out_of_date(a, project_root, in_s, out_s)) { out_of_date = true; }
             str_free(a, out_s);
             outi = outi + 1;
         }
         str_free(a, in_s);
         ini = ini + 1;
     }
-    
-    if (!out_of_date) {
-        ret R.ok[bool, str](true);
-    }
-    
-    val raw_cmd: str = O.unwrap[str](intern.lookup(?p.s.interner, step.cmd));
-    val cmd_s: str = expand_step_vars(a, raw_cmd, target_name_s, profile_s, isa_s, os_s, abi_s, project_out_s);
-    val expanded_cmd: str = expand_env_vars(a, cmd_s, isa_s, os_s, abi_s, profile_s, project_out_s);
-    str_free(a, cmd_s);
-    
+
+    if (!out_of_date) { ret R.ok[bool, str](true); }
+
+    val cmd_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.cmd)), project_out_s, target_name_s, profile_s, "", "");
+    if (R.is_err[str, str](cmd_r)) { ret R.err[bool, str](R.unwrap_err[str, str](cmd_r)); }
+    val expanded_cmd: str = R.unwrap_ok[str, str](cmd_r);
+
     val step_name: str = O.unwrap[str](intern.lookup(?p.s.interner, step.name));
     val msg: str = step_cc5(a, "step ", step_name, ": ", expanded_cmd, "\n");
     print.print(msg);
@@ -9413,59 +9292,17 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
     ret R.ok[bool, str](true);
 }
 
-fun find_step_by_name(p: *Project, name: intern.StrId) i64 {
-    var i: u32 = 0;
-    for (i < p.config.step_count) {
-        if (p.config.steps[i].name == name) { ret i::i64; }
-        i = i + 1;
-    }
-    ret -1;
-}
-
-fun run_step_dfs(a: *A.Allocator, p: *Project, project_root: str, visited: *u8, idx: u32) R.Result[bool, str] {
-    if (visited[idx] == 2) { ret R.ok[bool, str](true); }
-    if (visited[idx] == 1) { ret R.err[bool, str]("mach.toml: cyclic dependency detected in build steps"); }
-    
-    visited[idx] = 1;
-    
-    val step: *manifest.StepDef = ?p.config.steps[idx];
-    var need_i: u32 = 0;
-    for (need_i < step.need_count) {
-        val dep_idx: i64 = find_step_by_name(p, step.need[need_i]);
-        if (dep_idx < 0) {
-            ret R.err[bool, str]("mach.toml: step refers to unknown dependency");
-        }
-        val res_dep: R.Result[bool, str] = run_step_dfs(a, p, project_root, visited, dep_idx::u32);
-        if (R.is_err[bool, str](res_dep)) { ret res_dep; }
-        need_i = need_i + 1;
-    }
-    
-    val res_exec: R.Result[bool, str] = run_one_step(a, p, step, project_root);
-    if (R.is_err[bool, str](res_exec)) { ret res_exec; }
-    
-    visited[idx] = 2;
-    ret R.ok[bool, str](true);
-}
-
+# run the demanded steps in the planned needs-first order (#1970). the plan
+# (manifest.plan_steps, computed at config time) already resolved demand, ordering,
+# and cycle detection; undemanded steps never run.
 fun execute_steps(a: *A.Allocator, p: *Project, project_root: str) R.Result[bool, str] {
-    if (p.config.step_count == 0) { ret R.ok[bool, str](true); }
-    
-    val res_visited: R.Result[*u8, str] = A.allocate[u8](a, p.config.step_count::usize);
-    if (R.is_err[*u8, str](res_visited)) { ret R.err[bool, str]("out of memory"); }
-    val visited: *u8 = R.unwrap_ok[*u8, str](res_visited);
     var i: u32 = 0;
-    for (i < p.config.step_count) { visited[i] = 0; i = i + 1; }
-    
-    i = 0;
-    for (i < p.config.step_count) {
-        val res_run: R.Result[bool, str] = run_step_dfs(a, p, project_root, visited, i);
-        if (R.is_err[bool, str](res_run)) {
-            A.deallocate[u8](a, visited, p.config.step_count::usize);
-            ret res_run;
-        }
+    for (i < p.config.step_order_count) {
+        val idx: u32 = p.config.step_order[i];
+        val res: R.Result[bool, str] = run_one_step(a, p, ?p.config.steps[idx], project_root);
+        if (R.is_err[bool, str](res)) { ret res; }
         i = i + 1;
     }
-    A.deallocate[u8](a, visited, p.config.step_count::usize);
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -6149,6 +6149,16 @@ test "mach.lang.driver:dep_out_home" {
     ret code;
 }
 
+# the stamp path is rooted at the ROOT project dir, so it resolves independently of the
+# invoker's cwd (`mach build <path>` from elsewhere) (#1989 review)
+test "mach.lang.driver:step_stamp_path" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sp: str = step_stamp_path(?alloc, "/home/u/proj", "out/linux/debug", "own", "s");
+    if (!str_equals(sp, "/home/u/proj/out/linux/debug/.steps/own.s.stamp")) { ret 1; }
+    ret 0;
+}
+
 # #1873: an orphan module (no in-tree consumer) whose load-time comptime evaluation
 # reaches a `$error` is target-gated - loaded but kept out of the topo set and
 # counted for the skip note - so a `mach test` over a tree with other-target modules
@@ -9540,15 +9550,21 @@ fun digest_hex(a: *A.Allocator, digest: *u8, len: usize) str {
     ret buf::str;
 }
 
-# the stamp path `<root_out>/.steps/<owner>.<step>.stamp`; per-cell (the fingerprint
-# expands per cell) and owner-id-keyed so same-named steps in two deps never collide
-fun step_stamp_path(a: *A.Allocator, root_out: str, owner_id: str, step_name: str) str {
+# the stamp path `<root_project>/<root_out>/.steps/<owner>.<step>.stamp`, rooted at the
+# ROOT project dir so it resolves independently of the invoker's cwd (#1989 review);
+# per-cell (the fingerprint expands per cell) and owner-id-keyed so same-named steps in
+# two deps never collide
+fun step_stamp_path(a: *A.Allocator, root_project: str, root_out: str, owner_id: str, step_name: str) str {
     val fname: str = step_cc5(a, owner_id, ".", step_name, ".stamp", "");
-    val dir_r: R.Result[str, str] = join_path(a, root_out, ".steps");
-    if (R.is_err[str, str](dir_r)) { str_free(a, fname); ret ""; }
-    val dir: str = R.unwrap_ok[str, str](dir_r);
-    val path_r: R.Result[str, str] = join_path(a, dir, fname);
-    str_free(a, dir);
+    val d1_r: R.Result[str, str] = join_path(a, root_project, root_out);
+    if (R.is_err[str, str](d1_r)) { str_free(a, fname); ret ""; }
+    val d1: str = R.unwrap_ok[str, str](d1_r);
+    val d2_r: R.Result[str, str] = join_path(a, d1, ".steps");
+    str_free(a, d1);
+    if (R.is_err[str, str](d2_r)) { str_free(a, fname); ret ""; }
+    val d2: str = R.unwrap_ok[str, str](d2_r);
+    val path_r: R.Result[str, str] = join_path(a, d2, fname);
+    str_free(a, d2);
     str_free(a, fname);
     if (R.is_err[str, str](path_r)) { ret ""; }
     ret R.unwrap_ok[str, str](path_r);
@@ -9585,13 +9601,11 @@ fun step_outputs_exist(a: *A.Allocator, p: *Project, step: *manifest.StepDef, pr
     ret true;
 }
 
-# write `hex` to the stamp, creating the `.steps` directory. best effort - a write
-# failure only costs the next build a re-run, never correctness (#1970).
-fun write_stamp(a: *A.Allocator, root_out: str, path: str, hex: str) {
-    val dir_r: R.Result[str, str] = join_path(a, root_out, ".steps");
-    if (R.is_err[str, str](dir_r)) { ret; }
-    val dir: str = R.unwrap_ok[str, str](dir_r);
-    filesystem.create_dir_all(a, dir, 0o755);
+# write `hex` to the (fully rooted) stamp `path`, creating its parent `.steps` dir.
+# best effort - a write failure only costs the next build a re-run, never correctness.
+fun write_stamp(a: *A.Allocator, path: str, hex: str) {
+    val dir: str = parent_dir(a, path);
+    if (!str_empty(dir)) { filesystem.create_dir_all(a, dir, 0o755); }
     str_free(a, dir);
     filesystem.write_file(path, hex::*u8, str_len(hex), 0o644);
 }
@@ -9608,10 +9622,12 @@ fun parent_dir(a: *A.Allocator, path: str) str {
 
 # create the parent directory of every declared output before a step runs, so a cmd
 # that assumes its out tree exists (no `mkdir`, like the RFC's miniz example) does not
-# fail at the tool (#1989 review). outputs expand against the ROOT out - a clean path
-# with no `..` - and are created from the build cwd for both root and dep steps.
+# fail at the tool (#1989 review). outputs expand against the ROOT out (a clean path,
+# no `..`) and are rooted at the ROOT project dir so they land in the project's out
+# tree regardless of the invoker's cwd - for both root and dep steps.
 fun step_make_output_dirs(a: *A.Allocator, p: *Project, step: *manifest.StepDef) R.Result[bool, str] {
     val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
+    val root_project: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_root));
     val profile_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
     val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
     var oi: u32 = 0;
@@ -9619,14 +9635,18 @@ fun step_make_output_dirs(a: *A.Allocator, p: *Project, step: *manifest.StepDef)
         val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), root_out, target_name_s, profile_s, "", "");
         if (R.is_err[str, str](out_r)) { ret R.err[bool, str](R.unwrap_err[str, str](out_r)); }
         val out_s: str = R.unwrap_ok[str, str](out_r);
-        val dir: str = parent_dir(a, out_s);
+        val rel_dir: str = parent_dir(a, out_s);
         str_free(a, out_s);
-        if (!str_empty(dir)) {
-            val mr: R.Result[bool, str] = filesystem.create_dir_all(a, dir, 0o755);
-            str_free(a, dir);
+        if (!str_empty(rel_dir)) {
+            val abs_r: R.Result[str, str] = join_path(a, root_project, rel_dir);
+            str_free(a, rel_dir);
+            if (R.is_err[str, str](abs_r)) { ret R.err[bool, str](R.unwrap_err[str, str](abs_r)); }
+            val abs_dir: str = R.unwrap_ok[str, str](abs_r);
+            val mr: R.Result[bool, str] = filesystem.create_dir_all(a, abs_dir, 0o755);
+            str_free(a, abs_dir);
             if (R.is_err[bool, str](mr)) { ret mr; }
         }
-        or { str_free(a, dir); }
+        or { str_free(a, rel_dir); }
         oi = oi + 1;
     }
     ret R.ok[bool, str](true);
@@ -9658,6 +9678,7 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
     # content-fingerprint cache: skip iff the stamp matches AND every output exists.
     # fail toward running - any error, mismatch, or missing output re-runs (#1970).
     val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
+    val root_project: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_root));
     var digest: [32]u8;
     val fpr: R.Result[bool, str] = step_fingerprint(a, project_root, ?ins, expanded_cmd, ?digest[0]);
     step_free_inputs(a, ?ins);
@@ -9667,7 +9688,7 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
     val stampable:  bool = R.is_ok[bool, str](fpr) && step.out_count > 0;
     if (stampable) {
         hex        = digest_hex(a, ?digest[0], 32::usize);
-        stamp_path = step_stamp_path(a, root_out, owner_id, step_name);
+        stamp_path = step_stamp_path(a, root_project, root_out, owner_id, step_name);
         if (step_outputs_exist(a, p, step, project_root, home_out) && stamp_matches(a, stamp_path, hex)) {
             str_free(a, hex);
             str_free(a, stamp_path);
@@ -9733,7 +9754,7 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
     }
 
     if (stampable) {
-        write_stamp(a, root_out, stamp_path, hex);
+        write_stamp(a, stamp_path, hex);
         str_free(a, hex);
         str_free(a, stamp_path);
     }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -607,11 +607,20 @@ fun build_project_impl(s: *session.Session, project_root: str, manifest_path: st
         ret R.err[Project, str]("internal: manifest selected no target");
     }
 
-    # run custom steps
+    # run the demanded build steps: the root project's, then each dependency's
+    # export-demanded steps, all before the objects they produce are linked (#1970).
     val res_steps: R.Result[bool, str] = execute_steps(p.s.alloc, ?p, project_root);
     if (R.is_err[bool, str](res_steps)) {
         dnit_project(?p);
         ret R.err[Project, str](R.unwrap_err[bool, str](res_steps));
+    }
+    val isa_s: str = O.unwrap[str](intern.lookup(?p.s.interner, te.isa_name));
+    val os_s:  str = O.unwrap[str](intern.lookup(?p.s.interner, te.os_name));
+    val abi_s: str = O.unwrap[str](intern.lookup(?p.s.interner, te.abi_name));
+    val res_dep_steps: R.Result[bool, str] = execute_dep_steps(?p, isa_s, os_s, abi_s);
+    if (R.is_err[bool, str](res_dep_steps)) {
+        dnit_project(?p);
+        ret R.err[Project, str](R.unwrap_err[bool, str](res_dep_steps));
     }
 
     val fp_r: R.Result[bool, str] = select_target(?p, te);
@@ -2397,43 +2406,23 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
         for (li < mfd.link_count) {
             val l: *manifest.LinkDef = ?mfd.links[li];
             if (l.export && manifest.link_matches_target(?p.s.interner, l, ?tgt)) {
-                # Pick path/lib_name depending on source
+                # a `local` entry's path homes against the ROOT project out (#1970): the
+                # exported object lands in the consumer out tree, where the demanding dep
+                # step (run beforehand by execute_dep_steps) writes it. system/framework
+                # entries contribute their lib name.
                 var lib_id: intern.StrId = intern.STR_NIL;
                 if (l.source == R.unwrap_ok[intern.StrId, str](intern.intern(?p.s.interner, "local"))) {
                     val p_opt: O.Option[str] = intern.lookup(?p.s.interner, l.path);
                     if (O.is_some[str](p_opt)) {
-                        val raw_path: str = O.unwrap[str](p_opt);
-                        var expanded_path: str;
-                        if (str_len(raw_path) >= 13 && str_equals(step_seg_dup(p.s.alloc, raw_path, 0, 13), "{project.out}")) {
-                            val out_tmpl_opt: O.Option[str] = intern.lookup(?p.s.interner, mfd.out_tmpl);
-                            val out_tmpl: str = O.unwrap[str](out_tmpl_opt);
-                            val tn_opt: O.Option[str] = intern.lookup(?p.s.interner, p.target_entry.name);
-                            val target_name: str = O.unwrap[str](tn_opt);
-                            val pn_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.profile);
-                            val profile_name: str = O.unwrap[str](pn_opt);
-                            val dep_out_r: R.Result[str, str] = manifest.expand(p.s.alloc, out_tmpl, "", target_name, profile_name, "", "");
-                            val dep_out: str = R.unwrap_ok[str, str](dep_out_r);
-                            val suffix: str = step_seg_dup(p.s.alloc, raw_path, 13, str_len(raw_path));
-                            val full_p_r: R.Result[str, str] = join_path(p.s.alloc, dep_out, suffix);
-                            expanded_path = R.unwrap_ok[str, str](full_p_r);
-                            str_free(p.s.alloc, dep_out);
-                            str_free(p.s.alloc, suffix);
+                        val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
+                        val tn2: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
+                        val pn2: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
+                        val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, O.unwrap[str](p_opt), root_out, tn2, pn2, "", "");
+                        if (R.is_ok[str, str](exp_r)) {
+                            val exp: str = R.unwrap_ok[str, str](exp_r);
+                            lib_id = R.unwrap_ok[intern.StrId, str](intern.intern(?p.s.interner, exp));
+                            str_free(p.s.alloc, exp);
                         }
-                        or {
-                            val tn_opt: O.Option[str] = intern.lookup(?p.s.interner, p.target_entry.name);
-                            val target_name: str = O.unwrap[str](tn_opt);
-                            val pn_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.profile);
-                            val profile_name: str = O.unwrap[str](pn_opt);
-                            val expanded_path_r: R.Result[str, str] = manifest.expand(p.s.alloc, raw_path, "", target_name, profile_name, "", "");
-                            expanded_path = R.unwrap_ok[str, str](expanded_path_r);
-                        }
-                        val full_p_r: R.Result[str, str] = join_path(p.s.alloc, dep_vr, expanded_path);
-                        if (R.is_ok[str, str](full_p_r)) {
-                            val full_p: str = R.unwrap_ok[str, str](full_p_r);
-                            lib_id = R.unwrap_ok[intern.StrId, str](intern.intern(?p.s.interner, full_p));
-                            str_free(p.s.alloc, full_p);
-                        }
-                        str_free(p.s.alloc, expanded_path);
                     }
                 }
                 or {
@@ -9172,17 +9161,6 @@ fun step_out_of_date(alloc: *A.Allocator, project_root: str, step_in: str, step_
     ret out_of_date;
 }
 
-fun step_seg_dup(alloc: *A.Allocator, tmpl: str, start: usize, end: usize) str {
-    val n: usize = end - start;
-    val res_buf: R.Result[*u8, str] = A.allocate[u8](alloc, n + 1);
-    if (R.is_err[*u8, str](res_buf)) { ret ""; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
-    var i: usize = 0;
-    for (i < n) { buf[i] = tmpl[start + i]; i = i + 1; }
-    buf[n] = 0;
-    ret buf::str;
-}
-
 fun step_cc5(alloc: *A.Allocator, a: str, b: str, c: str, d: str, e: str) str {
     val la: usize = str_len(a);
     val lb: usize = str_len(b);
@@ -9208,9 +9186,13 @@ fun step_cc5(alloc: *A.Allocator, a: str, b: str, c: str, d: str, e: str) str {
     ret buf::str;
 }
 
-fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_root: str) R.Result[bool, str] {
+# run one step from `project_root` (its shell CWD), homing `{project.out}` to
+# `home_out`. root steps home to the root out and run from the root; a dependency's
+# steps run from the dep checkout and home to a path that climbs back to the root out
+# (#1970), so `vendor/*` inputs resolve while outputs land in the consumer tree.
+fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_root: str, home_out: str) R.Result[bool, str] {
     val profile_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
-    val project_out_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
+    val project_out_s: str = home_out;
     val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
 
     # `in`/`out`/`cmd` home through the closed template set ({project.out},
@@ -9296,11 +9278,114 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
 # (manifest.plan_steps, computed at config time) already resolved demand, ordering,
 # and cycle detection; undemanded steps never run.
 fun execute_steps(a: *A.Allocator, p: *Project, project_root: str) R.Result[bool, str] {
+    if (p.config.step_order_count == 0) { ret R.ok[bool, str](true); }
+    val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
     var i: u32 = 0;
     for (i < p.config.step_order_count) {
         val idx: u32 = p.config.step_order[i];
-        val res: R.Result[bool, str] = run_one_step(a, p, ?p.config.steps[idx], project_root);
+        val res: R.Result[bool, str] = run_one_step(a, p, ?p.config.steps[idx], project_root, root_out);
         if (R.is_err[bool, str](res)) { ret res; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the `{project.out}` a dependency's step homes against (#1970): a relative path that
+# climbs from the dep checkout `dep_vr` (the step's CWD) back to the root, then
+# descends into the root out - so `vendor/*` inputs resolve at the dep while step
+# outputs land in the consumer out tree. e.g. dep_vr `./dep/x`, root out
+# `out/linux/debug` -> `../../out/linux/debug`.
+fun dep_out_home(alloc: *A.Allocator, dep_vr: str, root_out: str) R.Result[str, str] {
+    val n: usize = str_len(dep_vr);
+    var segs: u32 = 0;
+    var i: usize = 0;
+    for (i < n) {
+        for (i < n && dep_vr[i] == '/'::u8) { i = i + 1; }
+        val start: usize = i;
+        for (i < n && dep_vr[i] != '/'::u8) { i = i + 1; }
+        val seglen: usize = i - start;
+        if (seglen > 0 && !(seglen == 1 && dep_vr[start] == '.'::u8)) { segs = segs + 1; }
+    }
+
+    val total: usize = (segs::usize) * 3 + str_len(root_out);
+    val rb: R.Result[*u8, str] = A.allocate[u8](alloc, total + 1);
+    if (R.is_err[*u8, str](rb)) { ret R.err[str, str](R.unwrap_err[*u8, str](rb)); }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    var k: usize = 0;
+    var s: u32 = 0;
+    for (s < segs) { buf[k] = '.'::u8; buf[k + 1] = '.'::u8; buf[k + 2] = '/'::u8; k = k + 3; s = s + 1; }
+    var j: usize = 0;
+    val rl: usize = str_len(root_out);
+    for (j < rl) { buf[k] = root_out[j]; k = k + 1; j = j + 1; }
+    buf[k] = 0;
+    ret R.ok[str, str](buf::str);
+}
+
+# run every dependency's export-demanded steps before the link (#1970)
+#
+# A dep's exported `local` entries demand steps in the dep's own manifest. Each such
+# step runs from the dep checkout (so `vendor/*` sources resolve) and homes
+# `{project.out}` to a climb path (dep_out_home) so the exported object lands in the
+# consumer out tree, where resolve_cascade_libs registered it as a link input.
+# ---
+# p:   the active project (its resolved deps and target cell drive the walk)
+# isa/os/abi: the build cell, for filtering each dep's exported entries
+fun execute_dep_steps(p: *Project, isa: str, os: str, abi: str) R.Result[bool, str] {
+    val n: u32 = p.config.dep_count;
+    if (n == 0) { ret R.ok[bool, str](true); }
+
+    var tgt: manifest.TargetDef;
+    val ri: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, isa);
+    if (R.is_err[intern.StrId, str](ri)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](ri)); }
+    tgt.isa = R.unwrap_ok[intern.StrId, str](ri);
+    val ro: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, os);
+    if (R.is_err[intern.StrId, str](ro)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](ro)); }
+    tgt.os = R.unwrap_ok[intern.StrId, str](ro);
+    val ra: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, abi);
+    if (R.is_err[intern.StrId, str](ra)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](ra)); }
+    tgt.abi = R.unwrap_ok[intern.StrId, str](ra);
+
+    val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
+    val tn: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
+    val pn: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
+
+    var i: u32 = 0;
+    for (i < n) {
+        val vr_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.deps[i].vendor_root);
+        if (O.is_none[str](vr_opt)) { ret R.err[bool, str]("internal: dep metadata not interned"); }
+        val dep_vr: str = O.unwrap[str](vr_opt);
+
+        val tp_r: R.Result[str, str] = join_path(p.s.alloc, dep_vr, "mach.toml");
+        if (R.is_err[str, str](tp_r)) { ret R.err[bool, str](R.unwrap_err[str, str](tp_r)); }
+        val tp: str = R.unwrap_ok[str, str](tp_r);
+        val pr: R.Result[toml.Table, str] = parse_toml_file(p.s.alloc, tp);
+        str_free(p.s.alloc, tp);
+        if (R.is_err[toml.Table, str](pr)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](pr)); }
+        var tbl: toml.Table = R.unwrap_ok[toml.Table, str](pr);
+
+        val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tbl);
+        if (R.is_err[manifest.Manifest, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mf_r)); }
+        var mfd: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mf_r);
+
+        var dep_order: *u32 = nil;
+        var dep_count: u32  = 0;
+        val dpr: R.Result[bool, str] = manifest.plan_export_steps(p.s.alloc, ?p.s.interner, ?mfd, ?tgt, root_out, tn, pn, ?dep_order, ?dep_count);
+        if (R.is_err[bool, str](dpr)) { manifest.dnit(?mfd, p.s.alloc); ret dpr; }
+
+        if (dep_count > 0) {
+            val hr: R.Result[str, str] = dep_out_home(p.s.alloc, dep_vr, root_out);
+            if (R.is_err[str, str](hr)) { A.deallocate[u32](p.s.alloc, dep_order, dep_count::usize); manifest.dnit(?mfd, p.s.alloc); ret R.err[bool, str](R.unwrap_err[str, str](hr)); }
+            val dep_home: str = R.unwrap_ok[str, str](hr);
+            var si: u32 = 0;
+            for (si < dep_count) {
+                val rs: R.Result[bool, str] = run_one_step(p.s.alloc, p, ?mfd.steps[dep_order[si]], dep_vr, dep_home);
+                if (R.is_err[bool, str](rs)) { str_free(p.s.alloc, dep_home); A.deallocate[u32](p.s.alloc, dep_order, dep_count::usize); manifest.dnit(?mfd, p.s.alloc); ret rs; }
+                si = si + 1;
+            }
+            str_free(p.s.alloc, dep_home);
+            A.deallocate[u32](p.s.alloc, dep_order, dep_count::usize);
+        }
+        manifest.dnit(?mfd, p.s.alloc);
         i = i + 1;
     }
     ret R.ok[bool, str](true);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -6078,6 +6078,45 @@ test "mach.lang.driver:wildcard_match" {
     ret bad;
 }
 
+# the step content fingerprint is deterministic over identical inputs+cmd and
+# invalidates on a cmd edit (#1970) - the persisted-stamp behaviour asserted e2e
+test "mach.lang.driver:step_fingerprint" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var code: i32 = 0;
+
+    val res_temp: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "mach_test_fp");
+    if (R.is_err[filesystem.TempFile, str](res_temp)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](res_temp);
+    val path: str = filesystem.temp_path(?tf);
+    if (R.is_err[bool, str](filesystem.write_file(path, "hello"::*u8, 5, 0o644))) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    var ins: vector.Vector[str] = vector.init[str](?alloc);
+    if (R.is_err[usize, str](vector.push[str](?ins, path))) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    var d1: [32]u8;
+    var d2: [32]u8;
+    var d3: [32]u8;
+    val r1: R.Result[bool, str] = step_fingerprint(?alloc, "", ?ins, "cc -c x", ?d1[0]);
+    val r2: R.Result[bool, str] = step_fingerprint(?alloc, "", ?ins, "cc -c x", ?d2[0]);
+    val r3: R.Result[bool, str] = step_fingerprint(?alloc, "", ?ins, "cc -c y", ?d3[0]);
+    filesystem.temp_close_and_remove(?tf);
+    vector.dnit[str](?ins);
+    if (R.is_err[bool, str](r1) || R.is_err[bool, str](r2) || R.is_err[bool, str](r3)) { ret 1; }
+
+    var eq12: bool = true;
+    var eq13: bool = true;
+    var i: usize = 0;
+    for (i < 32) {
+        if (d1[i] != d2[i]) { eq12 = false; }
+        if (d1[i] != d3[i]) { eq13 = false; }
+        i = i + 1;
+    }
+    if (!eq12) { code = 1; }
+    if (eq13)  { code = 1; }
+    ret code;
+}
+
 # #1873: an orphan module (no in-tree consumer) whose load-time comptime evaluation
 # reaches a `$error` is target-gated - loaded but kept out of the topo set and
 # counted for the skip note - so a `mach test` over a tree with other-target modules
@@ -9138,47 +9177,6 @@ test "mach.lang.driver:secret_join_coerce_strip_clean" {
     ret 0;
 }
 
-# --- custom step execution helpers ---
-
-fun step_out_of_date(alloc: *A.Allocator, project_root: str, step_in: str, step_out: str) bool {
-    val abs_in_r: R.Result[str, str] = join_path(alloc, project_root, step_in);
-    val abs_out_r: R.Result[str, str] = join_path(alloc, project_root, step_out);
-    if (R.is_err[str, str](abs_in_r) || R.is_err[str, str](abs_out_r)) { ret true; }
-    val abs_in: str = R.unwrap_ok[str, str](abs_in_r);
-    val abs_out: str = R.unwrap_ok[str, str](abs_out_r);
-    
-    val exists_out: bool = filesystem.exists(abs_out);
-    val exists_in: bool = filesystem.exists(abs_in);
-    
-    var out_of_date: bool = false;
-    if (!exists_out) {
-        out_of_date = true;
-    }
-    or (!exists_in) {
-        out_of_date = false;
-    }
-    or {
-        var info_in: filesystem.FileInfo;
-        var info_out: filesystem.FileInfo;
-        val res_in: R.Result[filesystem.FileInfo, str] = filesystem.info_path(abs_in);
-        val res_out: R.Result[filesystem.FileInfo, str] = filesystem.info_path(abs_out);
-        if (R.is_err[filesystem.FileInfo, str](res_in) || R.is_err[filesystem.FileInfo, str](res_out)) {
-            out_of_date = true;
-        }
-        or {
-            info_in = R.unwrap_ok[filesystem.FileInfo, str](res_in);
-            info_out = R.unwrap_ok[filesystem.FileInfo, str](res_out);
-            if (info_in.modified > info_out.modified) {
-                out_of_date = true;
-            }
-        }
-    }
-    
-    str_free(alloc, abs_in);
-    str_free(alloc, abs_out);
-    ret out_of_date;
-}
-
 fun step_cc5(alloc: *A.Allocator, a: str, b: str, c: str, d: str, e: str) str {
     val la: usize = str_len(a);
     val lb: usize = str_len(b);
@@ -9407,59 +9405,173 @@ fun step_free_inputs(alloc: *A.Allocator, ins: *vector.Vector[str]) {
     vector.dnit[str](ins);
 }
 
+# free a fingerprint accumulation buffer
+fun fp_free(fb: *FpBuf) {
+    if (fb.buf != nil && fb.cap > 0) { A.deallocate[u8](fb.alloc, fb.buf, fb.cap::usize); }
+}
+
+# the sha256 content fingerprint of a step: the sorted input paths, each input's
+# content hash, and the expanded cmd - reusing the Q_LINK_CONFIG fingerprint helpers.
+# being content-based, a touch that changes no bytes does not invalidate while a cmd
+# or source edit does. this is the SINGLE place the composition lives.
+#
+# The digest is persisted per step in a stamp file rather than a query kind because
+# the query DB is in-memory per process today, so a fresh build would hold no prior
+# revision to compare against; folding step caching into the persisted query store is
+# deferred to the incremental epic (#1164). `digest` receives 32 bytes.
+fun step_fingerprint(a: *A.Allocator, project_root: str, ins: *vector.Vector[str], cmd_expanded: str, digest: *u8) R.Result[bool, str] {
+    var fb: FpBuf;
+    fb.alloc = a;
+    fb.buf   = nil;
+    fb.len   = 0;
+    fb.cap   = 0;
+    var i: usize = 0;
+    for (i < ins.len) {
+        val wp: R.Result[bool, str] = fp_cstr(?fb, ins.data[i]::*u8);
+        if (R.is_err[bool, str](wp)) { fp_free(?fb); ret wp; }
+        val abs_r: R.Result[str, str] = join_path(a, project_root, ins.data[i]);
+        if (R.is_err[str, str](abs_r)) { fp_free(?fb); ret R.err[bool, str](R.unwrap_err[str, str](abs_r)); }
+        val abs: str = R.unwrap_ok[str, str](abs_r);
+        val wc: R.Result[bool, str] = fp_file_content(?fb, a, abs::*u8);
+        str_free(a, abs);
+        if (R.is_err[bool, str](wc)) { fp_free(?fb); ret wc; }
+        i = i + 1;
+    }
+    val wcmd: R.Result[bool, str] = fp_cstr(?fb, cmd_expanded::*u8);
+    if (R.is_err[bool, str](wcmd)) { fp_free(?fb); ret wcmd; }
+    sha256.hash(fb.buf, fb.len::usize, digest);
+    fp_free(?fb);
+    ret R.ok[bool, str](true);
+}
+
+# lowercase hex of `len` digest bytes, as a fresh owned string
+fun digest_hex(a: *A.Allocator, digest: *u8, len: usize) str {
+    val hexchars: *u8 = "0123456789abcdef";
+    val rb: R.Result[*u8, str] = A.allocate[u8](a, len * 2 + 1);
+    if (R.is_err[*u8, str](rb)) { ret ""; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    var i: usize = 0;
+    for (i < len) {
+        val b: u8 = digest[i];
+        buf[i * 2]     = hexchars[(b >> 4)::usize];
+        buf[i * 2 + 1] = hexchars[(b & 0x0f::u8)::usize];
+        i = i + 1;
+    }
+    buf[len * 2] = 0;
+    ret buf::str;
+}
+
+# the stamp path `<root_out>/.steps/<owner>.<step>.stamp`; per-cell (the fingerprint
+# expands per cell) and owner-id-keyed so same-named steps in two deps never collide
+fun step_stamp_path(a: *A.Allocator, root_out: str, owner_id: str, step_name: str) str {
+    val fname: str = step_cc5(a, owner_id, ".", step_name, ".stamp", "");
+    val dir_r: R.Result[str, str] = join_path(a, root_out, ".steps");
+    if (R.is_err[str, str](dir_r)) { str_free(a, fname); ret ""; }
+    val dir: str = R.unwrap_ok[str, str](dir_r);
+    val path_r: R.Result[str, str] = join_path(a, dir, fname);
+    str_free(a, dir);
+    str_free(a, fname);
+    if (R.is_err[str, str](path_r)) { ret ""; }
+    ret R.unwrap_ok[str, str](path_r);
+}
+
+# whether the stamp at `path` exists and holds exactly `hex`
+fun stamp_matches(a: *A.Allocator, path: str, hex: str) bool {
+    val rr: R.Result[str, str] = filesystem.read_all(a, path);
+    if (R.is_err[str, str](rr)) { ret false; }
+    val prior: str = R.unwrap_ok[str, str](rr);
+    val eq: bool = str_equals(prior, hex);
+    str_free(a, prior);
+    ret eq;
+}
+
+# whether every declared output of `step` exists on disk (checked from `project_root`)
+fun step_outputs_exist(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_root: str, home_out: str) bool {
+    val profile_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
+    val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
+    var oi: u32 = 0;
+    for (oi < step.out_count) {
+        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), home_out, target_name_s, profile_s, "", "");
+        if (R.is_err[str, str](out_r)) { ret false; }
+        val out_s: str = R.unwrap_ok[str, str](out_r);
+        val abs_r: R.Result[str, str] = join_path(a, project_root, out_s);
+        str_free(a, out_s);
+        if (R.is_err[str, str](abs_r)) { ret false; }
+        val abs: str = R.unwrap_ok[str, str](abs_r);
+        val ex: bool = filesystem.exists(abs);
+        str_free(a, abs);
+        if (!ex) { ret false; }
+        oi = oi + 1;
+    }
+    ret true;
+}
+
+# write `hex` to the stamp, creating the `.steps` directory. best effort - a write
+# failure only costs the next build a re-run, never correctness (#1970).
+fun write_stamp(a: *A.Allocator, root_out: str, path: str, hex: str) {
+    val dir_r: R.Result[str, str] = join_path(a, root_out, ".steps");
+    if (R.is_err[str, str](dir_r)) { ret; }
+    val dir: str = R.unwrap_ok[str, str](dir_r);
+    filesystem.create_dir_all(a, dir, 0o755);
+    str_free(a, dir);
+    filesystem.write_file(path, hex::*u8, str_len(hex), 0o644);
+}
+
 # run one step from `project_root` (its shell CWD), homing `{project.out}` to
 # `home_out`. root steps home to the root out and run from the root; a dependency's
 # steps run from the dep checkout and home to a path that climbs back to the root out
 # (#1970), so `vendor/*` inputs resolve while outputs land in the consumer tree.
-fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_root: str, home_out: str) R.Result[bool, str] {
+# `owner_id` is the project id owning the step, keying its stamp file.
+fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_root: str, home_out: str, owner_id: str) R.Result[bool, str] {
     val profile_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
     val project_out_s: str = home_out;
     val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
+    val step_name: str = O.unwrap[str](intern.lookup(?p.s.interner, step.name));
 
     # `in`/`out`/`cmd` home through the closed template set ({project.out},
     # {target.name}, {profile.name}); an unknown `{a.b}` is a hard error and shell
     # `$VAR` is left to the shell. `in` globs expand sorted against project_root (empty
-    # match errors). skip when every output is up to date against every input (mtime;
-    # #1970 C4 swaps this for a content fingerprint) - a step with no input or output
-    # cannot be dated, so it always runs.
+    # match errors).
     var ins: vector.Vector[str] = vector.init[str](a);
     val cir: R.Result[bool, str] = collect_step_inputs(a, p, step, project_root, home_out, ?ins);
     if (R.is_err[bool, str](cir)) { step_free_inputs(a, ?ins); ret R.err[bool, str](R.unwrap_err[bool, str](cir)); }
 
-    var out_of_date: bool = (ins.len == 0 || step.out_count == 0);
-    var oi: u32 = 0;
-    for (oi < step.out_count && !out_of_date) {
-        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), project_out_s, target_name_s, profile_s, "", "");
-        if (R.is_err[str, str](out_r)) { step_free_inputs(a, ?ins); ret R.err[bool, str](R.unwrap_err[str, str](out_r)); }
-        val out_s: str = R.unwrap_ok[str, str](out_r);
-        var ii: usize = 0;
-        for (ii < ins.len && !out_of_date) {
-            if (step_out_of_date(a, project_root, ins.data[ii], out_s)) { out_of_date = true; }
-            ii = ii + 1;
-        }
-        str_free(a, out_s);
-        oi = oi + 1;
-    }
-    step_free_inputs(a, ?ins);
-
-    if (!out_of_date) { ret R.ok[bool, str](true); }
-
     val cmd_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.cmd)), project_out_s, target_name_s, profile_s, "", "");
-    if (R.is_err[str, str](cmd_r)) { ret R.err[bool, str](R.unwrap_err[str, str](cmd_r)); }
+    if (R.is_err[str, str](cmd_r)) { step_free_inputs(a, ?ins); ret R.err[bool, str](R.unwrap_err[str, str](cmd_r)); }
     val expanded_cmd: str = R.unwrap_ok[str, str](cmd_r);
 
-    val step_name: str = O.unwrap[str](intern.lookup(?p.s.interner, step.name));
+    # content-fingerprint cache: skip iff the stamp matches AND every output exists.
+    # fail toward running - any error, mismatch, or missing output re-runs (#1970).
+    val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
+    var digest: [32]u8;
+    val fpr: R.Result[bool, str] = step_fingerprint(a, project_root, ?ins, expanded_cmd, ?digest[0]);
+    step_free_inputs(a, ?ins);
+
+    var hex:        str  = "";
+    var stamp_path: str  = "";
+    val stampable:  bool = R.is_ok[bool, str](fpr) && step.out_count > 0;
+    if (stampable) {
+        hex        = digest_hex(a, ?digest[0], 32::usize);
+        stamp_path = step_stamp_path(a, root_out, owner_id, step_name);
+        if (step_outputs_exist(a, p, step, project_root, home_out) && stamp_matches(a, stamp_path, hex)) {
+            str_free(a, hex);
+            str_free(a, stamp_path);
+            str_free(a, expanded_cmd);
+            ret R.ok[bool, str](true);
+        }
+    }
+
     val msg: str = step_cc5(a, "step ", step_name, ": ", expanded_cmd, "\n");
     print.print(msg);
     str_free(a, msg);
-    
+
     var shell_name: *u8 = "/bin/sh";
     var shell_flag: *u8 = "-c";
     $if ($mach.build.os == $mach.os.windows) {
         shell_name = "cmd.exe";
         shell_flag = "/c";
     }
-    
+
     var full_cmd: str;
     $if ($mach.build.os == $mach.os.windows) {
         full_cmd = step_cc5(a, "cd /d \"", project_root, "\" && ", expanded_cmd, "");
@@ -9467,9 +9579,10 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
     $or {
         full_cmd = step_cc5(a, "cd '", project_root, "' && ", expanded_cmd, "");
     }
-    
+
     val res_argv: R.Result[**u8, str] = A.allocate[*u8](a, 4);
     if (R.is_err[**u8, str](res_argv)) {
+        if (stampable) { str_free(a, hex); str_free(a, stamp_path); }
         str_free(a, expanded_cmd);
         str_free(a, full_cmd);
         ret R.err[bool, str]("out of memory");
@@ -9479,21 +9592,28 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
     argv[1] = shell_flag;
     argv[2] = full_cmd::*u8;
     argv[3] = nil;
-    
+
     val res_run: R.Result[exec.ExitStatus, str] = exec.run(shell_name::str, argv, sysos.environ());
-    
+
     A.deallocate[*u8](a, argv, 4);
     str_free(a, expanded_cmd);
     str_free(a, full_cmd);
-    
+
     if (R.is_err[exec.ExitStatus, str](res_run)) {
+        if (stampable) { str_free(a, hex); str_free(a, stamp_path); }
         ret R.err[bool, str]("failed to execute build step");
     }
     val status: exec.ExitStatus = R.unwrap_ok[exec.ExitStatus, str](res_run);
     if (!exec.exited(status) || exec.code(status) != 0) {
+        if (stampable) { str_free(a, hex); str_free(a, stamp_path); }
         ret R.err[bool, str]("build step exited non-zero");
     }
-    
+
+    if (stampable) {
+        write_stamp(a, root_out, stamp_path, hex);
+        str_free(a, hex);
+        str_free(a, stamp_path);
+    }
     ret R.ok[bool, str](true);
 }
 
@@ -9503,10 +9623,11 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
 fun execute_steps(a: *A.Allocator, p: *Project, project_root: str) R.Result[bool, str] {
     if (p.config.step_order_count == 0) { ret R.ok[bool, str](true); }
     val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
+    val owner_id: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.id));
     var i: u32 = 0;
     for (i < p.config.step_order_count) {
         val idx: u32 = p.config.step_order[i];
-        val res: R.Result[bool, str] = run_one_step(a, p, ?p.config.steps[idx], project_root, root_out);
+        val res: R.Result[bool, str] = run_one_step(a, p, ?p.config.steps[idx], project_root, root_out, owner_id);
         if (R.is_err[bool, str](res)) { ret res; }
         i = i + 1;
     }
@@ -9599,9 +9720,10 @@ fun execute_dep_steps(p: *Project, isa: str, os: str, abi: str) R.Result[bool, s
             val hr: R.Result[str, str] = dep_out_home(p.s.alloc, dep_vr, root_out);
             if (R.is_err[str, str](hr)) { A.deallocate[u32](p.s.alloc, dep_order, dep_count::usize); manifest.dnit(?mfd, p.s.alloc); ret R.err[bool, str](R.unwrap_err[str, str](hr)); }
             val dep_home: str = R.unwrap_ok[str, str](hr);
+            val dep_owner: str = O.unwrap[str](intern.lookup(?p.s.interner, mfd.id));
             var si: u32 = 0;
             for (si < dep_count) {
-                val rs: R.Result[bool, str] = run_one_step(p.s.alloc, p, ?mfd.steps[dep_order[si]], dep_vr, dep_home);
+                val rs: R.Result[bool, str] = run_one_step(p.s.alloc, p, ?mfd.steps[dep_order[si]], dep_vr, dep_home, dep_owner);
                 if (R.is_err[bool, str](rs)) { str_free(p.s.alloc, dep_home); A.deallocate[u32](p.s.alloc, dep_order, dep_count::usize); manifest.dnit(?mfd, p.s.alloc); ret rs; }
                 si = si + 1;
             }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1274,13 +1274,14 @@ fun link_token(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef, proj_out
     ret R.ok[intern.StrId, str](l.lib_name);
 }
 
-# whether some declared step produces `expanded_path` as one of its `out` entries
-# (expanded against the same build cell), i.e. the local link entry demands that
-# step. the up-front local-path check (#1969) treats a demanded path as valid even
-# before the step runs, since the step will produce it. `expanded_path` is already
-# expanded; step outs are expanded here with the same project out / target / profile.
-pub fun local_path_demanded_by_step(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
-                                    expanded_path: str, proj_out: str, tn: str, pn: str) bool {
+# the index of the declared step that produces `expanded_path` as one of its `out`
+# entries (expanded against the same build cell), or -1 when none does. this is the
+# single match the up-front local-path check (#1969) and step demand (#1970) both
+# use, so validation and execution can never disagree about which path a step
+# produces. `expanded_path` is already expanded; step outs are expanded here with
+# the same project out / target / profile.
+pub fun step_producing_out(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
+                           expanded_path: str, proj_out: str, tn: str, pn: str) i64 {
     var si: u32 = 0;
     for (si < m.step_count) {
         val s: *StepDef = ?m.steps[si];
@@ -1292,13 +1293,20 @@ pub fun local_path_demanded_by_step(alloc: *A.Allocator, itn: *intern.Interner, 
                 val exp: str = R.unwrap_ok[str, str](exp_r);
                 val eq: bool = str_equals(exp, expanded_path);
                 str_free(alloc, exp);
-                if (eq) { ret true; }
+                if (eq) { ret si::i64; }
             }
             oi = oi + 1;
         }
         si = si + 1;
     }
-    ret false;
+    ret -1;
+}
+
+# whether some declared step produces `expanded_path`, i.e. the local link entry
+# demands that step (see step_producing_out)
+pub fun local_path_demanded_by_step(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
+                                    expanded_path: str, proj_out: str, tn: str, pn: str) bool {
+    ret step_producing_out(alloc, itn, m, expanded_path, proj_out, tn, pn) >= 0;
 }
 
 pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
@@ -2048,6 +2056,9 @@ test "mach.lang.manifest.local_path_demanded_by_step" {
         # a path matching the step's expanded out is demanded; a near miss is not
         if (!local_path_demanded_by_step(?alloc, ?itn, ?m, "out/linux/obj/shim.o", "out/linux", "linux", "debug")) { code = 1; }
         if ( local_path_demanded_by_step(?alloc, ?itn, ?m, "out/linux/obj/nope.o", "out/linux", "linux", "debug")) { code = 1; }
+        # the shared predicate reports which step produces the path (the sole shim, index 0) and -1 for a miss
+        if (step_producing_out(?alloc, ?itn, ?m, "out/linux/obj/shim.o", "out/linux", "linux", "debug") != 0)  { code = 1; }
+        if (step_producing_out(?alloc, ?itn, ?m, "out/linux/obj/nope.o", "out/linux", "linux", "debug") != -1) { code = 1; }
     }
     arena.dnit(?ar);
     ret code;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1309,6 +1309,140 @@ pub fun local_path_demanded_by_step(alloc: *A.Allocator, itn: *intern.Interner, 
     ret step_producing_out(alloc, itn, m, expanded_path, proj_out, tn, pn) >= 0;
 }
 
+# the artifact declared as `name`, or nil
+fun find_artifact_by_name(m: *Manifest, name: intern.StrId) *ArtifactDef {
+    var i: u32 = 0;
+    for (i < m.artifact_count) {
+        if (m.artifacts[i].name == name) { ret ?m.artifacts[i]; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# the link entry declared as `name`, or nil
+fun find_link_by_name(m: *Manifest, name: intern.StrId) *LinkDef {
+    var i: u32 = 0;
+    for (i < m.link_count) {
+        if (m.links[i].name == name) { ret ?m.links[i]; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# the index of the step declared as `name`, or -1
+fun find_step_index(m: *Manifest, name: intern.StrId) i64 {
+    var i: u32 = 0;
+    for (i < m.step_count) {
+        if (m.steps[i].name == name) { ret i::i64; }
+        i = i + 1;
+    }
+    ret -1;
+}
+
+# post-order visit emitting each of `idx`'s `need` steps before `idx` itself, so the
+# resulting order runs dependencies first. `state` is per-step (0 unvisited, 1
+# in-progress, 2 emitted); re-entering an in-progress step is a `need` cycle.
+fun plan_visit(m: *Manifest, idx: u32, state: *u8, order: *u32, order_len: *u32) R.Result[bool, str] {
+    if (state[idx] == 2) { ret R.ok[bool, str](true); }
+    if (state[idx] == 1) { ret R.err[bool, str]("mach.toml: cyclic dependency detected in build steps"); }
+    state[idx] = 1;
+    val s: *StepDef = ?m.steps[idx];
+    var ni: u32 = 0;
+    for (ni < s.need_count) {
+        val nidx: i64 = find_step_index(m, s.need[ni]);
+        if (nidx < 0) { ret R.err[bool, str]("mach.toml: a step 'need' refers to an unknown step"); }
+        val vr: R.Result[bool, str] = plan_visit(m, nidx::u32, state, order, order_len);
+        if (R.is_err[bool, str](vr)) { ret vr; }
+        ni = ni + 1;
+    }
+    state[idx] = 2;
+    order[@order_len] = idx;
+    @order_len = @order_len + 1;
+    ret R.ok[bool, str](true);
+}
+
+# compute the steps `art_names` demand, in topological (needs-first) order (#1970)
+#
+# A step is demanded when a selected, target-matching `local` link entry referenced
+# by one of the artifacts expands to the step's `out`, or an artifact names it in
+# `need`; demand then closes transitively over each step's own `need`. A step that
+# nothing demands never runs. Steps carry no filters - conditions live on the link
+# entries. A `need` cycle or an unknown `need` target is a hard error.
+# ---
+# art_names: the artifact names driving demand (the selected one for a build, all
+#            of them for the test union)
+# art_count: number of entries in `art_names`
+# t:         the resolved build cell, for link-entry filtering
+# proj_out:  the expanded project out the entry paths and step outs home against
+# tn:        the target name for template expansion
+# pn:        the profile name for template expansion
+# out_order: receives the owned ordered step-index array (nil when none)
+# out_count: receives the step count (0 when none)
+pub fun plan_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
+                   art_names: *intern.StrId, art_count: u32, t: *TargetDef,
+                   proj_out: str, tn: str, pn: str,
+                   out_order: **u32, out_count: *u32) R.Result[bool, str] {
+    @out_order = nil;
+    @out_count = 0;
+    if (m.step_count == 0) { ret R.ok[bool, str](true); }
+
+    val sr: R.Result[*u8, str] = A.allocate[u8](alloc, m.step_count::usize);
+    if (R.is_err[*u8, str](sr)) { ret R.err[bool, str](R.unwrap_err[*u8, str](sr)); }
+    val state: *u8 = R.unwrap_ok[*u8, str](sr);
+    var i: u32 = 0;
+    for (i < m.step_count) { state[i] = 0; i = i + 1; }
+
+    val or_: R.Result[*u32, str] = A.allocate[u32](alloc, m.step_count::usize);
+    if (R.is_err[*u32, str](or_)) { A.deallocate[u8](alloc, state, m.step_count::usize); ret R.err[bool, str](R.unwrap_err[*u32, str](or_)); }
+    val order: *u32 = R.unwrap_ok[*u32, str](or_);
+    var order_len: u32 = 0;
+
+    val local_id: intern.StrId = intern_unwrap(itn, "local");
+    var ai: u32 = 0;
+    for (ai < art_count) {
+        val a: *ArtifactDef = find_artifact_by_name(m, art_names[ai]);
+        if (a != nil) {
+            var li: u32 = 0;
+            for (li < a.link_count) {
+                val l: *LinkDef = find_link_by_name(m, a.link[li]);
+                if (l != nil && l.source == local_id && link_matches_target(itn, l, t)) {
+                    val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn, "", "");
+                    if (R.is_ok[str, str](exp_r)) {
+                        val exp: str = R.unwrap_ok[str, str](exp_r);
+                        val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, tn, pn);
+                        str_free(alloc, exp);
+                        if (sidx >= 0) {
+                            val vr: R.Result[bool, str] = plan_visit(m, sidx::u32, state, order, ?order_len);
+                            if (R.is_err[bool, str](vr)) { plan_free(alloc, state, order, m.step_count); ret vr; }
+                        }
+                    }
+                }
+                li = li + 1;
+            }
+            var ni: u32 = 0;
+            for (ni < a.need_count) {
+                val nidx: i64 = find_step_index(m, a.need[ni]);
+                if (nidx < 0) { plan_free(alloc, state, order, m.step_count); ret R.err[bool, str]("mach.toml: an artifact 'need' refers to an unknown step"); }
+                val vr: R.Result[bool, str] = plan_visit(m, nidx::u32, state, order, ?order_len);
+                if (R.is_err[bool, str](vr)) { plan_free(alloc, state, order, m.step_count); ret vr; }
+                ni = ni + 1;
+            }
+        }
+        ai = ai + 1;
+    }
+
+    A.deallocate[u8](alloc, state, m.step_count::usize);
+    if (order_len == 0) { A.deallocate[u32](alloc, order, m.step_count::usize); ret R.ok[bool, str](true); }
+    @out_order = order;
+    @out_count = order_len;
+    ret R.ok[bool, str](true);
+}
+
+fun plan_free(alloc: *A.Allocator, state: *u8, order: *u32, n: u32) {
+    A.deallocate[u8](alloc, state, n::usize);
+    A.deallocate[u32](alloc, order, n::usize);
+}
+
 pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
     val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target);
     if (R.is_err[ResolvedTarget, str](res_target)) { ret R.err[BuildUnit, str](R.unwrap_err[ResolvedTarget, str](res_target)); }
@@ -2059,6 +2193,77 @@ test "mach.lang.manifest.local_path_demanded_by_step" {
         # the shared predicate reports which step produces the path (the sole shim, index 0) and -1 for a miss
         if (step_producing_out(?alloc, ?itn, ?m, "out/linux/obj/shim.o", "out/linux", "linux", "debug") != 0)  { code = 1; }
         if (step_producing_out(?alloc, ?itn, ?m, "out/linux/obj/nope.o", "out/linux", "linux", "debug") != -1) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# demand: app links a wildcard local (obj->compile) and a windows-only local
+# (win->winc, filtered out on linux), and needs gen; gen needs dep. so the linux
+# plan is {compile, gen, dep} - winc excluded, dep ordered before gen (#1970)
+test "mach.lang.manifest.plan_steps" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.obj]\nsource=\"local\"\npath=\"{project.out}/o/a.o\"\nos=\"*\"\n[link.win]\nsource=\"local\"\npath=\"{project.out}/o/w.o\"\nos=\"windows\"\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[\"obj\",\"win\"]\nneed=[\"gen\"]\n[step.compile]\ncmd=\"cc\"\nin=[\"a.c\"]\nout=[\"{project.out}/o/a.o\"]\n[step.winc]\ncmd=\"cc\"\nin=[\"w.c\"]\nout=[\"{project.out}/o/w.o\"]\n[step.gen]\ncmd=\"g\"\nin=[\"g.in\"]\nout=[\"{project.out}/g.h\"]\nneed=[\"dep\"]\n[step.dep]\ncmd=\"d\"\nin=[\"d.in\"]\nout=[\"{project.out}/d.o\"]\n";
+    val rm: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](rm)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](rm);
+        val tl: *TargetDef = find_target_by_name(?itn, ?m, "linux");
+        if (tl == nil) { code = 1; }
+        or {
+            var names: [1]intern.StrId;
+            names[0] = intern_unwrap(?itn, "app");
+            var order: *u32 = nil;
+            var count: u32 = 0;
+            val r: R.Result[bool, str] = plan_steps(?alloc, ?itn, ?m, ?names[0], 1, tl, "out/linux", "linux", "debug", ?order, ?count);
+            if (R.is_err[bool, str](r)) { code = 1; }
+            or {
+                var has_compile: bool = false; var has_gen: bool = false; var has_dep: bool = false; var has_winc: bool = false;
+                var gen_pos: i64 = -1; var dep_pos: i64 = -1;
+                var k: u32 = 0;
+                for (k < count) {
+                    val nm: str = idstr(?itn, m.steps[order[k]].name);
+                    if (str_equals(nm, "compile")) { has_compile = true; }
+                    if (str_equals(nm, "gen"))     { has_gen = true;  gen_pos = k::i64; }
+                    if (str_equals(nm, "dep"))     { has_dep = true;  dep_pos = k::i64; }
+                    if (str_equals(nm, "winc"))    { has_winc = true; }
+                    k = k + 1;
+                }
+                if (count != 3)                              { code = 1; }
+                if (!has_compile || !has_gen || !has_dep)    { code = 1; }
+                if (has_winc)                                { code = 1; }
+                if (dep_pos < 0 || gen_pos < 0 || dep_pos > gen_pos) { code = 1; }
+            }
+        }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# demand: a `need` cycle (a->b->a, reached from an artifact need) is a hard error
+test "mach.lang.manifest.plan_steps:cycle" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nneed=[\"a\"]\n[step.a]\ncmd=\"x\"\nin=[\"i\"]\nout=[\"{project.out}/a.o\"]\nneed=[\"b\"]\n[step.b]\ncmd=\"y\"\nin=[\"i\"]\nout=[\"{project.out}/b.o\"]\nneed=[\"a\"]\n";
+    val rm: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](rm)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](rm);
+        val tl: *TargetDef = find_target_by_name(?itn, ?m, "linux");
+        if (tl == nil) { code = 1; }
+        or {
+            var names: [1]intern.StrId;
+            names[0] = intern_unwrap(?itn, "app");
+            var order: *u32 = nil;
+            var count: u32 = 0;
+            val r: R.Result[bool, str] = plan_steps(?alloc, ?itn, ?m, ?names[0], 1, tl, "out/linux", "linux", "debug", ?order, ?count);
+            if (R.is_ok[bool, str](r) || !str_equals(R.unwrap_err[bool, str](r), "mach.toml: cyclic dependency detected in build steps")) { code = 1; }
+        }
     }
     arena.dnit(?ar);
     ret code;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1443,6 +1443,65 @@ fun plan_free(alloc: *A.Allocator, state: *u8, order: *u32, n: u32) {
     A.deallocate[u32](alloc, order, n::usize);
 }
 
+# compute the steps a dependency's exports demand, in needs-first order (#1970)
+#
+# A consumer runs these to produce the dep's exported `local` objects. Unlike
+# plan_steps the seeds are the dep's `export = true`, target-matching local link
+# entries - a dep's own artifacts and needs never apply to a consumer. Paths home
+# against the ROOT project out, so the entry-to-step match and the consumer's link
+# input agree. A `need` cycle or unknown `need` target is a hard error.
+# ---
+# m:         the parsed dependency manifest
+# t:         the resolved build cell, for entry filtering
+# proj_out:  the root project's expanded out entry paths and step outs home against
+# tn:        the target name for template expansion
+# pn:        the profile name for template expansion
+# out_order: receives the owned ordered step-index array (nil when none)
+# out_count: receives the step count (0 when none)
+pub fun plan_export_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
+                          t: *TargetDef, proj_out: str, tn: str, pn: str,
+                          out_order: **u32, out_count: *u32) R.Result[bool, str] {
+    @out_order = nil;
+    @out_count = 0;
+    if (m.step_count == 0) { ret R.ok[bool, str](true); }
+
+    val sr: R.Result[*u8, str] = A.allocate[u8](alloc, m.step_count::usize);
+    if (R.is_err[*u8, str](sr)) { ret R.err[bool, str](R.unwrap_err[*u8, str](sr)); }
+    val state: *u8 = R.unwrap_ok[*u8, str](sr);
+    var i: u32 = 0;
+    for (i < m.step_count) { state[i] = 0; i = i + 1; }
+
+    val or_: R.Result[*u32, str] = A.allocate[u32](alloc, m.step_count::usize);
+    if (R.is_err[*u32, str](or_)) { A.deallocate[u8](alloc, state, m.step_count::usize); ret R.err[bool, str](R.unwrap_err[*u32, str](or_)); }
+    val order: *u32 = R.unwrap_ok[*u32, str](or_);
+    var order_len: u32 = 0;
+
+    val local_id: intern.StrId = intern_unwrap(itn, "local");
+    var li: u32 = 0;
+    for (li < m.link_count) {
+        val l: *LinkDef = ?m.links[li];
+        if (l.export && l.source == local_id && link_matches_target(itn, l, t)) {
+            val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn, "", "");
+            if (R.is_ok[str, str](exp_r)) {
+                val exp: str = R.unwrap_ok[str, str](exp_r);
+                val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, tn, pn);
+                str_free(alloc, exp);
+                if (sidx >= 0) {
+                    val vr: R.Result[bool, str] = plan_visit(m, sidx::u32, state, order, ?order_len);
+                    if (R.is_err[bool, str](vr)) { plan_free(alloc, state, order, m.step_count); ret vr; }
+                }
+            }
+        }
+        li = li + 1;
+    }
+
+    A.deallocate[u8](alloc, state, m.step_count::usize);
+    if (order_len == 0) { A.deallocate[u32](alloc, order, m.step_count::usize); ret R.ok[bool, str](true); }
+    @out_order = order;
+    @out_count = order_len;
+    ret R.ok[bool, str](true);
+}
+
 pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
     val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target);
     if (R.is_err[ResolvedTarget, str](res_target)) { ret R.err[BuildUnit, str](R.unwrap_err[ResolvedTarget, str](res_target)); }
@@ -2263,6 +2322,38 @@ test "mach.lang.manifest.plan_steps:cycle" {
             var count: u32 = 0;
             val r: R.Result[bool, str] = plan_steps(?alloc, ?itn, ?m, ?names[0], 1, tl, "out/linux", "linux", "debug", ?order, ?count);
             if (R.is_ok[bool, str](r) || !str_equals(R.unwrap_err[bool, str](r), "mach.toml: cyclic dependency detected in build steps")) { code = 1; }
+        }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# dep-export demand: an export=true, cell-matching local entry demands its producing
+# step; a non-exported entry and a windows-only entry (on linux) do not (#1970)
+test "mach.lang.manifest.plan_export_steps" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.exp]\nsource=\"local\"\npath=\"{project.out}/o/m.o\"\nos=\"*\"\nexport=true\n[link.noexp]\nsource=\"local\"\npath=\"{project.out}/o/n.o\"\nos=\"*\"\nexport=false\n[link.win]\nsource=\"local\"\npath=\"{project.out}/o/w.o\"\nos=\"windows\"\nexport=true\n[step.mk]\ncmd=\"cc\"\nin=[\"m.c\"]\nout=[\"{project.out}/o/m.o\"]\n[step.no]\ncmd=\"cc\"\nin=[\"n.c\"]\nout=[\"{project.out}/o/n.o\"]\n[step.winmk]\ncmd=\"cc\"\nin=[\"w.c\"]\nout=[\"{project.out}/o/w.o\"]\n";
+    val rm: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](rm)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](rm);
+        val tl: *TargetDef = find_target_by_name(?itn, ?m, "linux");
+        if (tl == nil) { code = 1; }
+        or {
+            var order: *u32 = nil;
+            var count: u32 = 0;
+            val r: R.Result[bool, str] = plan_export_steps(?alloc, ?itn, ?m, tl, "out/linux", "linux", "debug", ?order, ?count);
+            if (R.is_err[bool, str](r)) { code = 1; }
+            or {
+                # only the exported, linux-matching entry's step is demanded
+                if (count != 1) { code = 1; }
+                or {
+                    if (!str_equals(idstr(?itn, m.steps[order[0]].name), "mk")) { code = 1; }
+                }
+            }
         }
     }
     arena.dnit(?ar);

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2030,6 +2030,43 @@ test "mach.lang.manifest.resolve_build_unit:native_resolution" {
     ret code;
 }
 
+# pin (#1989 review): the default profile selection (empty selector, no --profile)
+# resolves cleanly to the first-declared profile, or the conventional 'debug' default
+# when no [profile] is declared - never a crash, never a hardcoded 'release'. a SIGSEGV
+# on this path (only-[profile.debug], bare build) was observed at 03329057 and vanished
+# in the fix round without an identified cause, so this guards the resolve path itself.
+test "mach.lang.manifest.resolve_build_unit:default_profile" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    # only [profile.debug] declared -> the empty profile selector resolves 'debug'
+    var s1: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\n[profile.debug]\nopt=0\n";
+    s1 = cc(?alloc, s1, host_target_stanza(?alloc, "h"));
+    val r1: R.Result[Manifest, str] = tparse(?alloc, ?itn, s1);
+    if (R.is_err[Manifest, str](r1)) { code = 1; }
+    or {
+        var m1: Manifest = R.unwrap_ok[Manifest, str](r1);
+        val u1: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m1, mk_sel("native", "", "app", false, true));
+        if (R.is_err[BuildUnit, str](u1)) { code = 1; }
+        or { if (!str_equals(idstr(?itn, R.unwrap_ok[BuildUnit, str](u1).profile_name), "debug")) { code = 1; } }
+    }
+
+    # no [profile] section at all -> the conventional 'debug' default, still clean
+    var s2: str = "[project]\nid=\"y\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\n";
+    s2 = cc(?alloc, s2, host_target_stanza(?alloc, "h"));
+    val r2: R.Result[Manifest, str] = tparse(?alloc, ?itn, s2);
+    if (R.is_err[Manifest, str](r2)) { code = 1; }
+    or {
+        var m2: Manifest = R.unwrap_ok[Manifest, str](r2);
+        val u2: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m2, mk_sel("native", "", "app", false, true));
+        if (R.is_err[BuildUnit, str](u2)) { code = 1; }
+        or { if (!str_equals(idstr(?itn, R.unwrap_ok[BuildUnit, str](u2).profile_name), "debug")) { code = 1; } }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
 test "mach.lang.manifest.resolve_build_unit:native_resolution_multi_match" {
     var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -220,6 +220,14 @@ pub fun host_tuple(alloc: *A.Allocator) str {
     ret cc3(alloc, host_isa_name(), "-", host_os_name());
 }
 
+# whether `s` contains a '*' glob metacharacter
+fun str_has_star(s: str) bool {
+    val n: usize = str_len(s);
+    var i: usize = 0;
+    for (i < n) { if (s[i] == '*'::u8) { ret true; } i = i + 1; }
+    ret false;
+}
+
 pub fun is_valid_id(s: str) bool {
     if (str_empty(s)) { ret false; }
     val n: usize = str_len(s);
@@ -499,6 +507,9 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table) R.Resu
     val res_check_out: R.Result[bool, str] = check_path(alloc, out_str, "[project].out");
     if (R.is_err[bool, str](res_check_out)) { ret R.err[Manifest, str](R.unwrap_err[bool, str](res_check_out)); }
 
+    # the project id names dep stores and keys step stamp files, so it must be a plain
+    # identifier - a '/' or '.' would break those paths / collide keys (#1989).
+    if (!is_valid_id(id_str)) { ret R.err[Manifest, str]("mach.toml: [project].id must be an identifier (letters, digits, '_', '-')"); }
     m.id = intern_unwrap(itn, id_str);
     m.version = intern_unwrap(itn, ver_str);
     m.name = intern_opt_unwrap(itn, name_str);
@@ -869,6 +880,9 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: StepDef;
+        # the step name keys its stamp file, so it must be a plain identifier - a
+        # '/' would break the stamp path and a '.' would collide owner.step keys (#1989).
+        if (!is_valid_id(name)) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " name must be an identifier (letters, digits, '_', '-')")); }
         d.name = intern_unwrap(itn, name);
 
         val cmd_s: str = toml.get_str(sub, "cmd");
@@ -900,10 +914,12 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val out_val: StrArr = R.unwrap_ok[StrArr, str](res_out);
         d.out = out_val.items;
         d.out_count = out_val.count;
-        # Check paths
+        # Check paths. `out` entries are concrete files - a glob there has no meaning
+        # (the demand match and cache key expand them verbatim), so reject '*' (#1989).
         ii = 0;
         for (ii < d.out_count) {
             val p: str = idstr(itn, d.out[ii]);
+            if (str_has_star(p)) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".out cannot contain a glob '*'; outputs must be concrete paths")); }
             val res_check: R.Result[bool, str] = check_path(alloc, p, cc(alloc, label, ".out"));
             if (R.is_err[bool, str](res_check)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_check)); }
             ii = ii + 1;
@@ -1342,16 +1358,16 @@ fun find_step_index(m: *Manifest, name: intern.StrId) i64 {
 # post-order visit emitting each of `idx`'s `need` steps before `idx` itself, so the
 # resulting order runs dependencies first. `state` is per-step (0 unvisited, 1
 # in-progress, 2 emitted); re-entering an in-progress step is a `need` cycle.
-fun plan_visit(m: *Manifest, idx: u32, state: *u8, order: *u32, order_len: *u32) R.Result[bool, str] {
+fun plan_visit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, idx: u32, state: *u8, order: *u32, order_len: *u32) R.Result[bool, str] {
     if (state[idx] == 2) { ret R.ok[bool, str](true); }
-    if (state[idx] == 1) { ret R.err[bool, str]("mach.toml: cyclic dependency detected in build steps"); }
+    if (state[idx] == 1) { ret R.err[bool, str](cc3(alloc, "mach.toml: build step '", idstr(itn, m.steps[idx].name), "' is part of a 'need' cycle")); }
     state[idx] = 1;
     val s: *StepDef = ?m.steps[idx];
     var ni: u32 = 0;
     for (ni < s.need_count) {
         val nidx: i64 = find_step_index(m, s.need[ni]);
-        if (nidx < 0) { ret R.err[bool, str]("mach.toml: a step 'need' refers to an unknown step"); }
-        val vr: R.Result[bool, str] = plan_visit(m, nidx::u32, state, order, order_len);
+        if (nidx < 0) { ret R.err[bool, str](cc3(alloc, "mach.toml: build step 'need' refers to unknown step '", idstr(itn, s.need[ni]), "'")); }
+        val vr: R.Result[bool, str] = plan_visit(alloc, itn, m, nidx::u32, state, order, order_len);
         if (R.is_err[bool, str](vr)) { ret vr; }
         ni = ni + 1;
     }
@@ -1412,7 +1428,7 @@ pub fun plan_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
                         val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, tn, pn);
                         str_free(alloc, exp);
                         if (sidx >= 0) {
-                            val vr: R.Result[bool, str] = plan_visit(m, sidx::u32, state, order, ?order_len);
+                            val vr: R.Result[bool, str] = plan_visit(alloc, itn, m, sidx::u32, state, order, ?order_len);
                             if (R.is_err[bool, str](vr)) { plan_free(alloc, state, order, m.step_count); ret vr; }
                         }
                     }
@@ -1423,7 +1439,7 @@ pub fun plan_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
             for (ni < a.need_count) {
                 val nidx: i64 = find_step_index(m, a.need[ni]);
                 if (nidx < 0) { plan_free(alloc, state, order, m.step_count); ret R.err[bool, str]("mach.toml: an artifact 'need' refers to an unknown step"); }
-                val vr: R.Result[bool, str] = plan_visit(m, nidx::u32, state, order, ?order_len);
+                val vr: R.Result[bool, str] = plan_visit(alloc, itn, m, nidx::u32, state, order, ?order_len);
                 if (R.is_err[bool, str](vr)) { plan_free(alloc, state, order, m.step_count); ret vr; }
                 ni = ni + 1;
             }
@@ -1487,7 +1503,7 @@ pub fun plan_export_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
                 val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, tn, pn);
                 str_free(alloc, exp);
                 if (sidx >= 0) {
-                    val vr: R.Result[bool, str] = plan_visit(m, sidx::u32, state, order, ?order_len);
+                    val vr: R.Result[bool, str] = plan_visit(alloc, itn, m, sidx::u32, state, order, ?order_len);
                     if (R.is_err[bool, str](vr)) { plan_free(alloc, state, order, m.step_count); ret vr; }
                 }
             }
@@ -2321,7 +2337,8 @@ test "mach.lang.manifest.plan_steps:cycle" {
             var order: *u32 = nil;
             var count: u32 = 0;
             val r: R.Result[bool, str] = plan_steps(?alloc, ?itn, ?m, ?names[0], 1, tl, "out/linux", "linux", "debug", ?order, ?count);
-            if (R.is_ok[bool, str](r) || !str_equals(R.unwrap_err[bool, str](r), "mach.toml: cyclic dependency detected in build steps")) { code = 1; }
+            # the re-entered step (a, reached a -> b -> a) is named in the diagnostic
+            if (R.is_ok[bool, str](r) || !str_equals(R.unwrap_err[bool, str](r), "mach.toml: build step 'a' is part of a 'need' cycle")) { code = 1; }
         }
     }
     arena.dnit(?ar);
@@ -2356,6 +2373,26 @@ test "mach.lang.manifest.plan_export_steps" {
             }
         }
     }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# parse rejects a non-identifier [project].id and a glob in a step `out` - both would
+# break stamp-file caching (a '/' in the id, a '*' in a concrete output path) (#1989)
+test "mach.lang.manifest.parse:id_and_out_validation" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    # a '/' in the project id is rejected
+    val bad_id: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"a/b\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n");
+    if (R.is_ok[Manifest, str](bad_id)) { code = 1; }
+    # a valid id parses
+    val ok_id: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"a-b_2\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n");
+    if (R.is_err[Manifest, str](ok_id)) { code = 1; }
+    # a '*' in a step out is rejected (outputs are concrete)
+    val bad_out: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[step.s]\ncmd=\"cc\"\nin=[\"a.c\"]\nout=[\"{project.out}/*.o\"]\n");
+    if (R.is_ok[Manifest, str](bad_out)) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }


### PR DESCRIPTION
Re-implements the `[step.X]` build-step engine per the design in #1964 and the audit in #1970. Child of #1966; subsumes #1943.

## What changed
- **Demand-driven execution.** A step runs only when demanded — a selected, target-matching `local` link entry whose homed path matches the step's `out`, an artifact's `need`, or another step's `need` — never automatically; a `need` cycle is a hard error. `manifest.plan_steps` computes the demanded set in needs-first order; `step_producing_out` is the single match shared with the #1969 up-front local-path validation.
- **Dependency export steps.** `execute_dep_steps` runs each dep's export-demanded steps (`plan_export_steps`) from the dep checkout, homing `{project.out}` via a climb path back into the **root** out tree; `resolve_cascade_libs` homes the matching link input to the same path. Fixes the vendored-C dependency link failure (conatus).
- **Content-fingerprint caching.** A per-step stamp at `{project.out}/.steps/<owner-id>.<step>.stamp` holds the sha256 of the sorted expanded `in` paths + their content hashes + the expanded `cmd` (reused Q_LINK_CONFIG helpers). Skip iff the stamp matches and every output exists; fail toward running otherwise. Stamp not query kind because the query DB is in-memory per process today (migration to the persisted store deferred to #1164, noted in code).
- **Glob `in`.** `*`/`**` expand sorted against the project root, reusing the compiler's own directory walk; an empty match is a hard error.
- **Closed template set.** `{project.out}`/`{target.name}`/`{profile.name}` only; unknown `{a.b}` is a hard error; shell `$VAR` left to the shell. Removed the run-all loop, the mtime staleness check, and the permissive expanders.

## Verification (from-source, linux-x86_64)
- Build OK; unit suite **558 passed / 0 failed** (dev baseline 553 + 5: `plan_steps`, `plan_steps:cycle`, `plan_export_steps`, `wildcard_match`, `step_fingerprint`).
- Self-host **fixpoint byte-identical** (stage1 == stage2); **int linux 42/42**.
- Caching e2e (mach-audio): clean-run → warm-skip → touch-noop (content-based, not mtime) → content-change rerun → deleted-.o rerun → cmd-edit rerun, all as specified.
- Glob e2e: `vendor/*.c`/`*.h` expand and run; a non-matching glob errors.
- **Real-world gate: conatus builds green** with this compiler — the dep step runs, `miniaudio.o` lands in the consumer out tree (not the dep checkout), links, and warm rebuilds skip it.

Rebased onto dev `13eb7e4c` (post #1985/#1986/#1990); demand computation is filter-aware, matching #1990's `link_matches_target` guard.

Closes #1970