### PR TITLE
fix(manifest): #1988 — link filters in cross-target validation + empty-axis semantics

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1597,7 +1597,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
         # up-front local link path validation (#1969): a `local` entry's path must
         # match a step's `out` (demanding it) or exist on disk; anything else errors
         # here naming the entry, instead of flowing to the linker to fail at link time.
-        val vr: R.Result[bool, str] = validate_local_links(p, project_root, ?m, project_out_str, tn_s, pn_s);
+        val vr: R.Result[bool, str] = validate_local_links(p, project_root, ?m, bu.target, project_out_str, tn_s, pn_s);
         if (R.is_err[bool, str](vr)) { str_free(p.s.alloc, project_out_str); manifest.dnit(?m, p.s.alloc); ret R.err[bool, str](R.unwrap_err[bool, str](vr)); }
 
         # `mach test` links the union of every artifact's referenced entries (native
@@ -1919,7 +1919,7 @@ fun local_link_error(alloc: *A.Allocator, name: str, path: str) str {
 # step's `out` (which will produce it) or already exist on disk, else an error names
 # the entry here rather than failing at link time. paths expand against the build
 # cell; the disk check resolves relative to the project root.
-fun validate_local_links(p: *Project, project_root: str, m: *manifest.Manifest, proj_out: str, tn: str, pn: str) R.Result[bool, str] {
+fun validate_local_links(p: *Project, project_root: str, m: *manifest.Manifest, t: *manifest.TargetDef, proj_out: str, tn: str, pn: str) R.Result[bool, str] {
     val local_r: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, "local");
     if (R.is_err[intern.StrId, str](local_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](local_r)); }
     val local_id: intern.StrId = R.unwrap_ok[intern.StrId, str](local_r);
@@ -1927,7 +1927,10 @@ fun validate_local_links(p: *Project, project_root: str, m: *manifest.Manifest, 
     var li: u32 = 0;
     for (li < m.link_count) {
         val l: *manifest.LinkDef = ?m.links[li];
-        if (l.source == local_id) {
+        # only entries selected for this build cell are validated: a cross-target
+        # prebuilt (e.g. os=["windows"]) filters out of a linux build and is skipped,
+        # never expanded against the wrong cell.
+        if (l.source == local_id && manifest.link_matches_target(?p.s.interner, l, t)) {
             val path_opt: O.Option[str] = intern.lookup(?p.s.interner, l.path);
             val name_opt: O.Option[str] = intern.lookup(?p.s.interner, l.name);
             if (O.is_none[str](path_opt) || O.is_none[str](name_opt)) { ret R.err[bool, str]("internal: link entry metadata not interned"); }
@@ -5750,6 +5753,13 @@ fun ut_manifest_multi() str {
     ret "[project]\nid = \"uniontest\"\nname = \"u\"\ndescription = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\n";
 }
 
+# a manifest with a windows-only `local` link entry whose path is neither step-backed
+# nor present on disk, for the #1988 cross-target validation-skip test. building for
+# linux must ignore the entry (it filters out), not validate its linux-cell expansion
+fun ut_manifest_winlocal() str {
+    ret "[project]\nid = \"winlocal\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[link.winobj]\nsource = \"local\"\npath = \"{project.out}/win.o\"\nos = [\"windows\"]\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n";
+}
+
 # materialize a temp project (the shared ut_manifest + src/<files>) on
 # disk and return its root path; the caller removes the tree via filesystem.remove_all
 fun ut_scaffold(alloc: *A.Allocator, names: *str, texts: *str, n: u32) R.Result[str, str] {
@@ -6492,6 +6502,37 @@ test "mach.lang.driver:union_ambiguous_multi_artifact_default" {
     or (!ut_has(?pu, ?s, "uniontest.beta"))      { bad = 1; }
     or (!ut_has(?pu, ?s, "uniontest.beta_only")) { bad = 1; }
     dnit_project(?pu);
+
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+test "mach.lang.driver:validate_local_links_skips_filtered_cross_target" {
+    # #1988 regression: a windows-only `local` link entry (path neither step-backed
+    # nor on disk) must be SKIPPED when building for linux -- it filters out of the
+    # cell -- not validated against the linux-cell expansion of its path. before the
+    # link_matches_target guard, load_config errored "matches no step output...".
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = "fun main() i32 { ret 0; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_winlocal(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+    var sel: manifest.Selection;
+    sel.target = "linux"; sel.profile = ""; sel.artifact = "app"; sel.want_lib = false; sel.has_artifact = true;
+    val pr: R.Result[Project, str] = build_project_sel(?s, root, ?sel);
+    if (R.is_err[Project, str](pr)) { bad = 1; }
+    or { var p: Project = R.unwrap_ok[Project, str](pr); dnit_project(?p); }
 
     filesystem.remove_all(?alloc, root);
     session.dnit(?s);

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -85,17 +85,20 @@ pub rec DepDef {
 }
 
 pub rec LinkDef {
-    name:      intern.StrId;
-    source:    intern.StrId;
-    lib_name:  intern.StrId;
-    path:      intern.StrId;
-    os:        *intern.StrId;
-    os_count:  u32;
-    isa:       *intern.StrId;
-    isa_count: u32;
-    abi:       *intern.StrId;
-    abi_count: u32;
-    export:    bool;
+    name:        intern.StrId;
+    source:      intern.StrId;
+    lib_name:    intern.StrId;
+    path:        intern.StrId;
+    os:          *intern.StrId;
+    os_count:    u32;
+    os_present:  bool;
+    isa:         *intern.StrId;
+    isa_count:   u32;
+    isa_present: bool;
+    abi:         *intern.StrId;
+    abi_count:   u32;
+    abi_present: bool;
+    export:      bool;
 }
 
 pub rec StepDef {
@@ -177,8 +180,9 @@ pub rec ResolvedProfile {
 }
 
 rec StrArr {
-    items: *intern.StrId;
-    count: u32;
+    items:   *intern.StrId;
+    count:   u32;
+    present: bool;
 }
 
 fun cc(alloc: *A.Allocator, a: str, b: str) str {
@@ -260,8 +264,9 @@ fun intern_opt_unwrap(itn: *intern.Interner, text: str) intern.StrId {
 
 fun parse_str_array(alloc: *A.Allocator, itn: *intern.Interner, arr: *toml.Array, elem_err: str) R.Result[StrArr, str] {
     var out: StrArr;
-    out.items = nil;
-    out.count = 0;
+    out.items   = nil;
+    out.count   = 0;
+    out.present = arr != nil;
     if (arr == nil) { ret R.ok[StrArr, str](out); }
 
     val n: usize = toml.array_len(arr);
@@ -292,16 +297,22 @@ fun parse_str_array(alloc: *A.Allocator, itn: *intern.Interner, arr: *toml.Array
 
 # parse a link filter axis (os/isa/abi) that accepts a bare string or an array of
 # strings per #1964; a single string interns as a one-element list so `"linux"`
-# and `["linux"]` filter identically. an absent axis yields an empty list (match
-# any). a non-string, non-array value is a strict error.
+# and `["linux"]` filter identically. an absent axis (present false) matches any;
+# an explicit empty array (present, count 0) matches nothing. an empty-string value
+# is not a canonical value and is a strict error, as is a non-string, non-array.
 fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Table, key: str, label: str) R.Result[StrArr, str] {
     var out: StrArr;
-    out.items = nil;
-    out.count = 0;
+    out.items   = nil;
+    out.count   = 0;
+    out.present = false;
     val v: *toml.Value = toml.get(sub, key);
     if (v == nil) { ret R.ok[StrArr, str](out); }
+    out.present = true;
 
     if (v.tag == toml.TYPE_STRING) {
+        if (str_empty(v.data.string)) {
+            ret R.err[StrArr, str](cc5(alloc, "mach.toml: ", label, ".", key, " is empty; use a canonical value, \"*\", or [], or omit it"));
+        }
         val res_items: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](alloc, 1::usize);
         if (R.is_err[*intern.StrId, str](res_items)) { ret R.err[StrArr, str](R.unwrap_err[*intern.StrId, str](res_items)); }
         out.items = R.unwrap_ok[*intern.StrId, str](res_items);
@@ -316,8 +327,12 @@ fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Tab
     }
 
     if (v.tag == toml.TYPE_ARRAY) {
-        ret parse_str_array(alloc, itn, ?v.data.array,
+        val res_arr: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?v.data.array,
             cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
+        if (R.is_err[StrArr, str](res_arr)) { ret res_arr; }
+        var arr_v: StrArr = R.unwrap_ok[StrArr, str](res_arr);
+        arr_v.present = true;
+        ret R.ok[StrArr, str](arr_v);
     }
 
     ret R.err[StrArr, str](cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
@@ -805,18 +820,21 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val os_v: StrArr = R.unwrap_ok[StrArr, str](res_os);
         d.os = os_v.items;
         d.os_count = os_v.count;
+        d.os_present = os_v.present;
 
         val res_isa: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "isa", label);
         if (R.is_err[StrArr, str](res_isa)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_isa)); }
         val isa_v: StrArr = R.unwrap_ok[StrArr, str](res_isa);
         d.isa = isa_v.items;
         d.isa_count = isa_v.count;
+        d.isa_present = isa_v.present;
 
         val res_abi: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "abi", label);
         if (R.is_err[StrArr, str](res_abi)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_abi)); }
         val abi_v: StrArr = R.unwrap_ok[StrArr, str](res_abi);
         d.abi = abi_v.items;
         d.abi_count = abi_v.count;
+        d.abi_present = abi_v.present;
 
         d.export = bool_or(toml.get_bool(sub, "export"), false);
 
@@ -1198,8 +1216,12 @@ fun resolve_artifact(itn: *intern.Interner, m: *Manifest, sel: Selection) *Artif
 
 
 
-fun filter_matches(itn: *intern.Interner, items: *intern.StrId, count: u32, target: intern.StrId) bool {
-    if (items == nil || count == 0) { ret true; }
+# match a single filter axis against a target's canonical value. an absent axis
+# (present false) matches any cell; an explicit empty axis (present, count 0) is
+# "none" and matches nothing (#1964); otherwise `"*"` or a member match wins.
+fun filter_matches(itn: *intern.Interner, items: *intern.StrId, count: u32, present: bool, target: intern.StrId) bool {
+    if (!present) { ret true; }
+    if (count == 0) { ret false; }
     val star: intern.StrId = intern_unwrap(itn, "*");
     var i: u32 = 0;
     for (i < count) {
@@ -1215,9 +1237,9 @@ fun filter_matches(itn: *intern.Interner, items: *intern.StrId, count: u32, targ
 }
 
 pub fun link_matches_target(itn: *intern.Interner, l: *LinkDef, t: *TargetDef) bool {
-    if (!filter_matches(itn, l.os, l.os_count, t.os)) { ret false; }
-    if (!filter_matches(itn, l.isa, l.isa_count, t.isa)) { ret false; }
-    if (!filter_matches(itn, l.abi, l.abi_count, t.abi)) { ret false; }
+    if (!filter_matches(itn, l.os, l.os_count, l.os_present, t.os)) { ret false; }
+    if (!filter_matches(itn, l.isa, l.isa_count, l.isa_present, t.isa)) { ret false; }
+    if (!filter_matches(itn, l.abi, l.abi_count, l.abi_present, t.abi)) { ret false; }
     ret true;
 }
 
@@ -2072,6 +2094,49 @@ test "mach.lang.manifest.parse:link_filter_bad_type" {
     # a non-string, non-array filter axis is a strict error
     val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[link.bad]\nsource=\"system\"\nname=\"a\"\nos=1\n");
     if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: [link.bad].os must be a string or array of strings")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.parse:link_filter_empty_string_error" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    # os = "" is not a canonical value; it is a strict parse error (#1988), not a
+    # silent never-matching filter
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[link.bad]\nsource=\"system\"\nname=\"a\"\nos=\"\"\n");
+    if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: [link.bad].os is empty; use a canonical value, \"*\", or [], or omit it")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.parse:link_filter_empty_array_matches_nothing" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    # explicit os = [] says "none" (#1964) and matches NO cell, distinct from an
+    # absent axis which matches any until strict totality (#1971).
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[target.arm]\nisa=\"aarch64\"\nos=\"linux\"\nabi=\"aapcs64\"\n[link.none]\nsource=\"system\"\nname=\"a\"\nos=[]\n[link.absent]\nsource=\"system\"\nname=\"b\"\n";
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
+        val tl: *TargetDef = find_target_by_name(?itn, ?m, "linux");
+        val tw: *TargetDef = find_target_by_name(?itn, ?m, "windows");
+        val ta: *TargetDef = find_target_by_name(?itn, ?m, "arm");
+        if (tl == nil || tw == nil || ta == nil) { code = 1; }
+        or {
+            # os = [] matches nothing on every cell
+            if (link_matches_target(?itn, find_link(?itn, ?m, "none"), tl)) { code = 1; }
+            if (link_matches_target(?itn, find_link(?itn, ?m, "none"), tw)) { code = 1; }
+            if (link_matches_target(?itn, find_link(?itn, ?m, "none"), ta)) { code = 1; }
+            # an absent axis still matches any cell
+            if (!link_matches_target(?itn, find_link(?itn, ?m, "absent"), tl)) { code = 1; }
+            if (!link_matches_target(?itn, find_link(?itn, ?m, "absent"), tw)) { code = 1; }
+        }
+    }
     arena.dnit(?ar);
     ret code;
 }


### PR DESCRIPTION
Closes #1988.

Three filter-semantics fixes surfaced by post-merge adversarial verification of #1983 (one real regression + two #1964 divergences). Kept surgical — the #1970 worker is building demand-matching on top of `validate_local_links`/`local_path_demanded_by_step`.

- [x] **Part 1 (regression):** `validate_local_links` now skips a `local` entry whose `os`/`isa`/`abi` filters exclude the build cell (guarded by `link_matches_target` on `bu.target`, passed in at the call site). Before, a cross-target prebuilt like `os = ["windows"]` was validated on a linux build and its `{project.out}` expanded against the wrong cell, breaking a build that should just skip it.
- [x] **Part 2:** an explicit empty axis `os = []` matches **nothing** (#1964 "`[]` says none out loud"), distinct from an **absent** axis which matches any (until #1971's totality flip). `LinkDef` now tracks per-axis presence separately from count; `filter_matches` returns true only for an absent axis, false for a present-but-empty one.
- [x] **Part 3:** `os = ""` is a strict parse error (not a canonical value), instead of a silent count-1 never-matching filter.

Merged current `dev` in (picks up #1968's `manifest_path` threading through the driver entry points).

Out of scope (noted in the issue, accepted): the orphaned `bu.libs` allocation when `is_test` replaces target libs (one-shot process); `link_token`'s literal substitution vs `join_path_canonical` (unreachable `//`).

### Verification (on the merged tree)
- Unit suite through the freshly built compiler: **551 passed** (dev baseline 548 + 3 new tests, each failing on unfixed dev):
  - `manifest.parse:link_filter_empty_string_error` (part 3)
  - `manifest.parse:link_filter_empty_array_matches_nothing` (part 2)
  - `driver:validate_local_links_skips_filtered_cross_target` (part 1)
- Self-host fixpoint: gen2 built by the fresh compiler is byte-identical to gen1; gen2 suite 551/551.
- int linux: **42/42** pass.
- Issue repro: `mach build --target linux` no longer errors on a windows-only local entry (it filters out and is skipped — the build proceeds past validation); `--target windows` still errors on it (the entry applies there and its `{project.out}/win.o` is neither step-backed nor on disk).
- All 15 CI checks green.