### PR TITLE
fix(doc): create the output directory recursively (#1987)

### DIFF
--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -416,7 +416,9 @@ fun document_module(out_path: *u8, fqn: *u8, a: *ast.Ast, source: str) i64 {
 # stats:   running counts updated as pages are written
 # ret:     0 on success, non-zero on a filesystem error
 fun generate(p: *driver.Project, api_dir: *u8, stats: *DocStats) i64 {
-    if (!util.ensure_dir(api_dir)) {
+    # the output dir (default `doc/api`, or a `--out` several levels deep) may have
+    # no existing parent, so create the whole path, not just the leaf.
+    if (!util.ensure_dir_all(api_dir)) {
         print.eprint("error: could not create output directory\n");
         ret 2;
     }
@@ -731,4 +733,88 @@ test "mach.cli.cmd.doc.skip_decorators" {
     val none: str = "pub val X: i64 = 0;";
     if (skip_decorators(none::*u8, 0) != 0) { ret 1; }
     ret 0;
+}
+
+# generate creates the full output path when the project has no pre-existing
+# doc/ directory (#1987): a fresh scaffold, then generate into <root>/doc/api,
+# whose <root>/doc parent does not exist yet
+test "mach.cli.cmd.doc.generate:creates_missing_output_dirs" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+
+    # scaffold a minimal single-target project on disk, with NO doc/ dir.
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "mach_doc_test");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    var root: [4096]u8;
+    val tp:   *u8   = filesystem.temp_path(?tf)::*u8;
+    val tlen: usize = util.cstr_len(tp);
+    val fits: bool  = tlen + 1 <= 4096;
+    if (fits) {
+        var j: usize = 0;
+        for (j < tlen) { root[j] = tp[j]; j = j + 1; }
+        root[tlen] = 0;
+    }
+    filesystem.temp_close_and_remove(?tf);
+    if (!fits) { ret 1; }
+
+    var bad: i32 = 0;
+    val src_dir: str = t_join(?alloc, util.cstr_str(?root[0]), "src");
+    if (R.is_err[bool, str](filesystem.create_dir_all(?alloc, util.cstr_str(?root[0]), 493))) { bad = 1; }
+    if (R.is_err[bool, str](filesystem.create_dir_all(?alloc, src_dir, 493)))                 { bad = 1; }
+
+    val manifest_text: str = "[project]\nid = \"doctest\"\nname = \"d\"\ndescription = \"d\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\n\n[artifact.doctest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/doctest\"\ntargets = [\"*\"]\n";
+    val main_text: str = "fun main() i32 { ret 0; }\n\n# a documented helper\npub fun answer() i32 { ret 42; }\n";
+    val mf: str = t_join(?alloc, util.cstr_str(?root[0]), "mach.toml");
+    val mn: str = t_join(?alloc, src_dir, "main.mach");
+    if (R.is_err[bool, str](filesystem.write_file(mf, manifest_text::*u8, util.cstr_len(manifest_text::*u8), 420))) { bad = 1; }
+    if (R.is_err[bool, str](filesystem.write_file(mn, main_text::*u8, util.cstr_len(main_text::*u8), 420)))         { bad = 1; }
+
+    if (bad != 0) { filesystem.remove_all(?alloc, util.cstr_str(?root[0])); ret 1; }
+
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { filesystem.remove_all(?alloc, util.cstr_str(?root[0])); ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](target.register_all(?s.registry))) {
+        session.dnit(?s); filesystem.remove_all(?alloc, util.cstr_str(?root[0])); ret 1;
+    }
+
+    val pr: R.Result[driver.Project, str] = driver.build_project(?s, util.cstr_str(?root[0]), mf, "linux");
+    if (R.is_err[driver.Project, str](pr)) {
+        session.dnit(?s); filesystem.remove_all(?alloc, util.cstr_str(?root[0])); ret 1;
+    }
+    var p: driver.Project = R.unwrap_ok[driver.Project, str](pr);
+
+    # <root>/doc/api - neither doc/ nor doc/api exists yet.
+    var api_dir: [4096]u8;
+    util.join_into(?api_dir[0], 4096, ?root[0], "doc/api");
+
+    var stats: DocStats;
+    stats.modules = 0;
+    stats.entries = 0;
+    if (generate(?p, ?api_dir[0], ?stats) != 0)   { bad = 1; }
+    if (!filesystem.is_dir(util.cstr_str(?api_dir[0]))) { bad = 1; }
+
+    val readme: str = t_join(?alloc, util.cstr_str(?api_dir[0]), "README.md");
+    if (!filesystem.is_file(readme)) { bad = 1; }
+
+    driver.dnit_project(?p);
+    session.dnit(?s);
+    filesystem.remove_all(?alloc, util.cstr_str(?root[0]));
+    ret bad;
+}
+
+# join two path segments with a single '/', allocated null-terminated from `a`
+# (a test-local convenience mirroring the driver's ut_cc3)
+fun t_join(a: *A.Allocator, base: str, leaf: str) str {
+    var buf: [4096]u8;
+    util.join_into(?buf[0], 4096, base::*u8, leaf::*u8);
+    val n: usize = util.cstr_len(?buf[0]);
+    val r: R.Result[*u8, str] = A.allocate[u8](a, n + 1);
+    if (R.is_err[*u8, str](r)) { ret base; }
+    val out: *u8 = R.unwrap_ok[*u8, str](r);
+    var i: usize = 0;
+    for (i < n) { out[i] = buf[i]; i = i + 1; }
+    out[n] = 0;
+    ret out::str;
 }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -527,6 +527,20 @@ pub fun ensure_parents(path: *u8) bool {
     ret true;
 }
 
+# create the directory `path` and every missing parent (mkdir -p over the whole
+# path, including the final component)
+#
+# `ensure_parents` materialises the leading directories; `ensure_dir` then creates
+# the leaf, so a directory nested several levels below an existing root is created
+# in full. Idempotent, and tolerant of concurrent creation like `ensure_dir`.
+# ---
+# path: the null-terminated directory path to create
+# ret:  true when the directory exists after the call
+pub fun ensure_dir_all(path: *u8) bool {
+    if (!ensure_parents(path)) { ret false; }
+    ret ensure_dir(path);
+}
+
 # resolve a command name to a concrete executable path for `os.spawn`
 #
 # execve performs no PATH search, so a bare name is resolved by scanning the
@@ -884,4 +898,33 @@ test "mach.cli.util.resolve_project:no_arg_walks_cwd" {
     if (R.is_err[bool, str](r)) { ret 1; }
     if (!filesystem.is_file(cstr_str(?manifest[0]))) { ret 1; }
     ret 0;
+}
+
+# ensure_dir_all creates a directory nested several levels below an existing root,
+# materialising every missing parent (mkdir -p), and is idempotent (#1987)
+test "mach.cli.util.ensure_dir_all:creates_missing_levels" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "mach_mkdirp_test");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    var base: [4096]u8;
+    val copied: bool = copy_cstr(?base[0], 4096, filesystem.temp_path(?tf)::*u8);
+    filesystem.temp_close_and_remove(?tf);
+    if (!copied) { ret 1; }
+    if (R.is_err[bool, str](filesystem.create_dir_all(?alloc, cstr_str(?base[0]), 493))) { ret 1; }
+
+    var bad: i32 = 0;
+
+    # a three-level-deep path under base: none of a, a/b, a/b/c exists yet.
+    var deep: [4096]u8;
+    if (join_into(?deep[0], 4096, ?base[0], "a/b/c") == 0) { bad = 1; }
+    if (!ensure_dir_all(?deep[0]))                { bad = 1; }
+    if (!filesystem.is_dir(cstr_str(?deep[0])))   { bad = 1; }
+    # idempotent: a second call over the existing tree still succeeds.
+    if (!ensure_dir_all(?deep[0]))                { bad = 1; }
+
+    filesystem.remove_all(?alloc, cstr_str(?base[0]));
+    ret bad;
 }


### PR DESCRIPTION
Closes #1987

`mach doc` failed with `could not create output directory` in any project with no pre-existing `doc/` directory: `generate()` created `<root>/doc/api` with a single-level `ensure_dir`, which cannot create two missing path levels.

## Fix

- New `util.ensure_dir_all(path)` — mkdir -p over the whole path, composed from the existing `ensure_parents` (parents) + `ensure_dir` (leaf); idempotent and concurrent-creation tolerant like `ensure_dir`.
- `doc.generate()` now calls `ensure_dir_all` at the output-dir site. Both the default `doc/api` and a several-levels-deep `--out` (rooted at the project) funnel through the same `api_dir`, so both are covered.

## Tests

- `mach.cli.cmd.doc.generate:creates_missing_output_dirs` — scaffolds a fresh single-target project with **no** `doc/` dir, builds it, runs `generate` into `<root>/doc/api`, and asserts the dir + `README.md` are created.
- `mach.cli.util.ensure_dir_all:creates_missing_levels` — creates `a/b/c` under a fresh root and asserts the leaf exists, plus idempotency.

## Verification (pending, in progress)

Seed build clean; suite through the fresh compiler 547 (545 dev baseline + these 2); fixpoint + e2e demo to follow.