### PR TITLE
fix(cli): require the project path argument (#1992)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1,8 +1,8 @@
-# `mach build` - compile the current project to per-module objects and, in
+# `mach build <path>` - compile the project to per-module objects and, in
 # executable mode, a linked binary
 #
-# Resolves the project root by walking up from the working directory until a
-# mach.toml is found, initializes a Session, and loads the full module graph
+# Resolves the project root from the required path (a project directory, or a
+# manifest file directly), initializes a Session, and loads the full module graph
 # through driver.build_project (config parse + DFS load + resolve). It then
 # drives each reachable module, in topo order, through sema -> lower -> the
 # optimization pipeline -> codegen, collecting one ObjectImage per module. Each
@@ -507,9 +507,9 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
     }
     val config: cfg.Config = R.unwrap_ok[cfg.Config, str](res_config);
 
-    # resolve the (project_root, manifest) pair from the optional positional path
-    # (`mach build [path]`): no path walks up from cwd, a directory takes its
-    # mach.toml, a file is the manifest itself. see util.resolve_project.
+    # resolve the (project_root, manifest) pair from the required positional path
+    # (`mach build <path>`): a directory takes its mach.toml, a file is the manifest
+    # itself. see util.resolve_project.
     val pix: usize = util.positional_index(argc, argv, marks, 2);
     var arg: *u8 = nil;
     if (pix < argc) { arg = argv[pix]; }
@@ -2849,8 +2849,8 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     mark_build_flags(marks, argc, argv);
     if (util.reject_unknown(argc, argv, marks, 2, "mach build")) { ret 1; }
 
-    # resolve the (project_root, manifest) pair from the optional positional path
-    # (`mach build [path]`); see util.resolve_project for the rules.
+    # resolve the (project_root, manifest) pair from the required positional path
+    # (`mach build <path>`); see util.resolve_project for the rules.
     val pix: usize = util.positional_index(argc, argv, marks, 2);
     var arg: *u8 = nil;
     if (pix < argc) { arg = argv[pix]; }

--- a/src/cli/cmd/clean.mach
+++ b/src/cli/cmd/clean.mach
@@ -1,7 +1,7 @@
-# `mach clean [path]` - remove the project's build output directory trees
+# `mach clean <path>` - remove the project's build output directory trees
 #
-# Resolves the project root (the given path, or the working directory, walking up
-# to the nearest mach.toml) and removes the static directory prefix of each of the
+# Resolves the project root from the required path (a project directory, or a
+# manifest file directly) and removes the static directory prefix of each of the
 # manifest's `out`/`obj`/`ir`/`asm` path templates - the leading `/`-separated
 # components before the first `{...}` placeholder, so the whole output tree goes
 # regardless of target or profile. A project that relocates its output
@@ -52,7 +52,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         ret 2;
     }
 
-    # resolve the (project_root, manifest) pair from the optional positional path;
+    # resolve the (project_root, manifest) pair from the required positional path;
     # see util.resolve_project for the rules.
     val pix: usize = util.positional_index(argc, argv, marks, 2);
     var arg: *u8 = nil;

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -528,8 +528,8 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         ret 2;
     }
 
-    # resolve the (project_root, manifest) pair from the optional positional path
-    # (`mach doc [path]`); see util.resolve_project for the rules.
+    # resolve the (project_root, manifest) pair from the required positional path
+    # (`mach doc <path>`); see util.resolve_project for the rules.
     val path_index: usize = util.positional_index(argc, argv, marks, 2);
     var arg: *u8 = nil;
     if (path_index < argc) { arg = argv[path_index]; }

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -111,11 +111,10 @@ pub fun usage() {
 
 # print the `mach build` detail page
 fun help_build() {
-    print.print("usage: mach build [path] [options] [inputs...]\n");
+    print.print("usage: mach build <path> [options] [inputs...]\n");
     print.print("\n");
     print.print("compile the current project to relocatable objects and, in executable\n");
-    print.print("mode, a linked binary. [path] is a project directory or a manifest file;\n");
-    print.print("omit it to search upward from the working directory for a mach.toml.\n");
+    print.print("mode, a linked binary. <path> is a project directory or a manifest file.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  -O0              force the debug pipeline (overrides profile)\n");
@@ -133,17 +132,16 @@ fun help_build() {
 
 # print the `mach run` detail page
 fun help_run() {
-    print.print("usage: mach run [path] [options] [-- args...]\n");
+    print.print("usage: mach run <path> [options] [-- args...]\n");
     print.print("\n");
-    print.print("execute the binary 'mach build' already produced for [path] - a\n");
+    print.print("execute the binary 'mach build' already produced for <path> - a\n");
     print.print("post-build convenience, not a rebuild. the build selection flags\n");
     print.print("(--target, --profile, --bin/--lib) resolve which artifact to run;\n");
     print.print("build-only flags (-O0/-O1/-O2) are accepted but have no effect, and\n");
     print.print("--emit is rejected. arguments after '--' are forwarded to the program\n");
     print.print("as its argv; the program's exit code becomes this command's.\n");
     print.print("\n");
-    print.print("[path] is a project directory or a manifest file; omit it to search\n");
-    print.print("upward from the working directory for a mach.toml.\n");
+    print.print("<path> is a project directory or a manifest file.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  --runner <cmd>   execute the binary as '<cmd> <binary> <args...>'.\n");
@@ -156,7 +154,7 @@ fun help_run() {
 
 # print the `mach test` detail page
 fun help_test() {
-    print.print("usage: mach test [path] [options]\n");
+    print.print("usage: mach test <path> [options]\n");
     print.print("\n");
     print.print("build one dispatcher executable covering every 'test' declaration\n");
     print.print("(under the 'tests' template) and run each test as its own process\n");
@@ -165,8 +163,7 @@ fun help_test() {
     print.print("project's own tests run by default; all 'mach build' and global\n");
     print.print("flags apply.\n");
     print.print("\n");
-    print.print("[path] is a project directory or a manifest file; omit it to search\n");
-    print.print("upward from the working directory for a mach.toml.\n");
+    print.print("<path> is a project directory or a manifest file.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  -v                  list every test under its module as it completes\n");
@@ -186,12 +183,11 @@ fun help_test() {
 
 # print the `mach clean` detail page
 fun help_clean() {
-    print.print("usage: mach clean [path]\n");
+    print.print("usage: mach clean <path>\n");
     print.print("\n");
     print.print("remove the project's build output: the output directory trees declared\n");
-    print.print("by the manifest's out/obj/ir/asm templates. [path] is a project\n");
-    print.print("directory or a manifest file; omit it to search upward from the working\n");
-    print.print("directory for a mach.toml. idempotent; takes no options.\n");
+    print.print("by the manifest's out/obj/ir/asm templates. <path> is a project\n");
+    print.print("directory or a manifest file. idempotent; takes no options.\n");
     print.print("\n");
     print.print("exit: 0 ok, 1 no project / bad manifest, 2 io failure\n");
 }
@@ -231,12 +227,11 @@ fun help_init() {
 
 # print the `mach doc` detail page
 fun help_doc() {
-    print.print("usage: mach doc [path] [options]\n");
+    print.print("usage: mach doc <path> [options]\n");
     print.print("\n");
     print.print("generate Markdown reference documentation from source doc-comments.\n");
-    print.print("writes one page per module plus an index under doc/api. [path] is a\n");
-    print.print("project directory or a manifest file; omit it to search upward from the\n");
-    print.print("working directory for a mach.toml.\n");
+    print.print("writes one page per module plus an index under doc/api. <path> is a\n");
+    print.print("project directory or a manifest file.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  --out <dir>      output directory, rooted at the project (default: doc/api)\n");

--- a/src/cli/cmd/run.mach
+++ b/src/cli/cmd/run.mach
@@ -90,8 +90,8 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         ret 1;
     }
 
-    # resolve the (project_root, manifest) pair from the optional positional path
-    # (`mach run [path]`); see util.resolve_project for the rules.
+    # resolve the (project_root, manifest) pair from the required positional path
+    # (`mach run <path>`); see util.resolve_project for the rules.
     val pix: usize = util.positional_index(sep, argv, marks, 2);
     var arg: *u8 = nil;
     if (pix < sep) { arg = argv[pix]; }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -329,35 +329,6 @@ pub fun path_into(buf: *u8, cap: usize, base: *u8, path: *u8) usize {
     ret join_into(buf, cap, base, path);
 }
 
-# walk up from `start` until a directory containing mach.toml is found, writing
-# the resolved root into `out_buf`
-#
-# `out_buf` must hold at least 4096 bytes. The search probes each ancestor for a
-# mach.toml until one is found or the filesystem root is reached.
-# ---
-# start:   starting directory (required, non-nil)
-# out_buf: destination buffer for the resolved root
-# cap:     capacity of `out_buf` in bytes
-# ret:     true when a mach.toml-bearing ancestor was found
-fun find_project_root(start: *u8, out_buf: *u8, cap: usize) bool {
-    val start_len: usize = cstr_len(start);
-    if (start_len + 1 > cap) { ret false; }
-    var i: usize = 0;
-    for (i < start_len) {
-        out_buf[i] = start[i];
-        i = i + 1;
-    }
-    out_buf[start_len] = 0;
-
-    var probe: [4096]u8;
-    for (true) {
-        val probe_len: usize = join_into(?probe[0], 4096, out_buf, "mach.toml");
-        if (probe_len > 0 && filesystem.is_file(cstr_str(?probe[0]))) { ret true; }
-        if (!parent_dir(out_buf))                                     { ret false; }
-    }
-    ret false;
-}
-
 # copy the null-terminated `src` into `buf`, terminator included
 # ---
 # buf: destination buffer
@@ -403,18 +374,17 @@ fun cat3(alloc: *A.Allocator, a: str, b: str, c: str, fallback: str) str {
     ret buf::str;
 }
 
-# resolve the (project_root, manifest_path) pair from a command's optional path
-# argument, per the four project-path resolution rules every project-rooted
-# command (build/run/test/clean/doc) shares.
+# resolve the (project_root, manifest_path) pair from a command's required path
+# argument. The path is mandatory and takes exactly two forms every project-rooted
+# command (build/run/test/clean/doc) shares:
 #
-#   arg == nil    no path was given: walk up from the working directory to the
-#                 nearest mach.toml (rule 1); an error when no ancestor has one.
-#   arg is a dir  use `<arg>/mach.toml` exactly (rule 2); an error when it is
-#                 absent - an explicitly named directory is never walked upward.
+#   arg == nil    no path was given: a user error (the argument is required).
+#   arg is a dir  use `<arg>/mach.toml` exactly; an error when it is absent - a
+#                 named directory is never walked upward.
 #   arg is a file use the file as the manifest and its parent directory as the
-#                 project root (rule 3), enabling alternate manifests such as
+#                 project root, enabling alternate manifests such as
 #                 `mach build ci.toml`.
-#   otherwise     the path names nothing that exists (rule 4); an error naming it.
+#   otherwise     the path names nothing that exists; an error naming it.
 #
 # resolve_project only locates the manifest; the driver parses and validates its
 # contents. `root_buf` receives the resolved project root and `manifest_buf` the
@@ -431,22 +401,12 @@ fun cat3(alloc: *A.Allocator, a: str, b: str, c: str, fallback: str) str {
 pub fun resolve_project(alloc: *A.Allocator, arg: *u8,
                         root_buf: *u8, root_cap: usize,
                         manifest_buf: *u8, manifest_cap: usize) R.Result[bool, str] {
-    # rule 1: no path - walk up from the working directory to the nearest mach.toml.
+    # the path is required; a bare invocation is a user error.
     if (arg == nil) {
-        var cwd: [4096]u8;
-        if (os.getcwd(?cwd[0], 4096) < 0) {
-            ret R.err[bool, str]("failed to read the working directory");
-        }
-        if (!find_project_root(?cwd[0], root_buf, root_cap)) {
-            ret R.err[bool, str]("no mach.toml found in the working directory or any parent");
-        }
-        if (join_into(manifest_buf, manifest_cap, root_buf, "mach.toml") == 0) {
-            ret R.err[bool, str]("resolved manifest path is too long");
-        }
-        ret R.ok[bool, str](true);
+        ret R.err[bool, str]("missing project path; pass a project directory or config file, e.g. '.'");
     }
 
-    # rule 3: an existing regular file is the manifest itself; its parent is the root.
+    # an existing regular file is the manifest itself; its parent is the root.
     if (filesystem.is_file(cstr_str(arg))) {
         if (!copy_cstr(manifest_buf, manifest_cap, arg)) {
             ret R.err[bool, str]("manifest path is too long");
@@ -470,7 +430,7 @@ pub fun resolve_project(alloc: *A.Allocator, arg: *u8,
         ret R.ok[bool, str](true);
     }
 
-    # rule 2: an existing directory must contain mach.toml; it is not walked upward.
+    # an existing directory must contain mach.toml; it is not walked upward.
     if (filesystem.is_dir(cstr_str(arg))) {
         if (!copy_cstr(root_buf, root_cap, arg)) {
             ret R.err[bool, str]("project path is too long");
@@ -485,7 +445,7 @@ pub fun resolve_project(alloc: *A.Allocator, arg: *u8,
         ret R.ok[bool, str](true);
     }
 
-    # rule 4: the path names neither a file nor a directory.
+    # the path names neither a file nor a directory.
     ret R.err[bool, str](cat3(alloc, "project path '", cstr_str(arg), "' does not exist",
                               "project path does not exist"));
 }
@@ -814,11 +774,11 @@ test "mach.cli.util.reject_unknown:first_unmarked_flag" {
     ret 0;
 }
 
-# resolve_project rules 2-4: an explicit directory resolves to its mach.toml, an
+# resolve_project path forms: an explicit directory resolves to its mach.toml, an
 # explicit file (including an alternate name like ci.toml) resolves to itself with
 # the parent as root, a nonexistent path errors, and a directory lacking a
-# mach.toml errors without walking upward. rule 1 (the no-arg cwd walk) is
-# exercised separately and by the e2e demo
+# mach.toml errors without walking upward. the nil-arg (missing path) case is
+# covered by resolve_project:nil_arg_errors
 test "mach.cli.util.resolve_project:explicit_paths" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -885,18 +845,16 @@ test "mach.cli.util.resolve_project:explicit_paths" {
     ret bad;
 }
 
-# resolve_project rule 1: with no path it walks up from the working directory to
-# the nearest mach.toml. the unit suite runs from a project root, so the walk
-# resolves the harness's own manifest to a real file
-test "mach.cli.util.resolve_project:no_arg_walks_cwd" {
+# resolve_project with no path is a user error: the argument is required, and the
+# upward cwd walk was removed (#1992)
+test "mach.cli.util.resolve_project:nil_arg_errors" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
 
     var root:     [4096]u8;
     var manifest: [4096]u8;
     val r: R.Result[bool, str] = resolve_project(?alloc, nil, ?root[0], 4096, ?manifest[0], 4096);
-    if (R.is_err[bool, str](r)) { ret 1; }
-    if (!filesystem.is_file(cstr_str(?manifest[0]))) { ret 1; }
+    if (R.is_ok[bool, str](r)) { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Closes #1992

Amends #1974 by owner decision: there is **no bare `mach build`**. The positional path is **required** on every project-rooted command (`build`, `run`, `test`, `clean`, `doc`), accepting two forms:

- a **directory** -> `<dir>/mach.toml`, error if absent (no upward walk);
- a **config file** -> used directly as the manifest, project root = its parent (alternate manifests like `mach build ci.toml` stay).

## Changes

- `util.resolve_project`: the `arg == nil` branch now returns the missing-path error (`missing project path; pass a project directory or config file, e.g. '.'`); the upward cwd-walk branch and the now-unreferenced `find_project_root` are deleted. The directory / file / nonexistent forms are unchanged.
- Help text (`help.mach` + per-command pages) and the build/clean header comments: `<path>` required again, described as "a project directory or a manifest file"; the "omit it to search upward" sentences from #1985 dropped.
- Unit test `resolve_project:no_arg_walks_cwd` swapped for `resolve_project:nil_arg_errors`; the explicit-paths test is unchanged.
- `os` import retained (still used by `resolve_cmd` for PATH).
- doc/cli.md wording rides #1977 (untouched here).

## Verification (in progress)

Seed build clean; suite through the fresh compiler **553** (dev baseline, one test swapped = net zero); fixpoint + e2e (no-arg error on each command; dir/file still work; nonexistent names itself) to follow.