### PR TITLE
feat(manifest): #1971 strict flag-day — no-defaults totality, canonical axes, closed templates

### DIFF
--- a/dbg/fixtures/aggregate/mach.toml
+++ b/dbg/fixtures/aggregate/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "dbgagg"
-name = "dbgagg"
-description = "debug-info fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.dbgagg]
 kind = "bin"
 entry = "main.mach"
 out = "bin/dbgagg"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/dbg/fixtures/inline/mach.toml
+++ b/dbg/fixtures/inline/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "inlinefix"
-name = "inlinefix"
-description = "debug-info fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.inlinefix]
 kind = "bin"
 entry = "main.mach"
 out = "bin/inlinefix"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/dbg/fixtures/inline4/mach.toml
+++ b/dbg/fixtures/inline4/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "inline4fix"
-name = "inline4fix"
-description = "debug-info fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.inline4fix]
 kind = "bin"
 entry = "main.mach"
 out = "bin/inline4fix"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/dbg/fixtures/multi/mach.toml
+++ b/dbg/fixtures/multi/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "dbgfix"
-name = "dbgfix"
-description = "debug-info fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.dbgfix]
 kind = "bin"
 entry = "main.mach"
 out = "bin/dbgfix"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/dbg/fixtures/promote/mach.toml
+++ b/dbg/fixtures/promote/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "promotefix"
-name = "promotefix"
-description = "debug-info fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.promotefix]
 kind = "bin"
 entry = "main.mach"
 out = "bin/promotefix"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/regression/1750-i32-signext/mach.toml
+++ b/int/regression/1750-i32-signext/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/regression/1762-rv64-float-vararg/mach.toml
+++ b/int/regression/1762-rv64-float-vararg/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/regression/1851-rv64-phi-signext/mach.toml
+++ b/int/regression/1851-rv64-phi-signext/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/regression/1852-rv64-self-host/mach.toml
+++ b/int/regression/1852-rv64-self-host/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -15,15 +13,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/regression/1923-comptime-field-gate/mach.toml
+++ b/int/regression/1923-comptime-field-gate/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/regression/1925-global-aggregate-byval/mach.toml
+++ b/int/regression/1925-global-aggregate-byval/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/aggregate-abi/mach.toml
+++ b/int/surface/aggregate-abi/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/control-flow/mach.toml
+++ b/int/surface/control-flow/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/elf-pie/mach.toml
+++ b/int/surface/elf-pie/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,15 +11,19 @@ abi = "sysv64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/elf-relro/mach.toml
+++ b/int/surface/elf-relro/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/float/mach.toml
+++ b/int/surface/float/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/freestanding-aarch64/mach.toml
+++ b/int/surface/freestanding-aarch64/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,12 +11,16 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []

--- a/int/surface/freestanding-riscv64/mach.toml
+++ b/int/surface/freestanding-riscv64/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,12 +11,16 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []

--- a/int/surface/freestanding/mach.toml
+++ b/int/surface/freestanding/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,12 +11,16 @@ abi = "sysv64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []

--- a/int/surface/macho-pie-aarch64/mach.toml
+++ b/int/surface/macho-pie-aarch64/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,15 +11,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/macho-pie-x86_64/mach.toml
+++ b/int/surface/macho-pie-x86_64/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,15 +11,19 @@ abi = "sysv64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/pe-aslr/mach.toml
+++ b/int/surface/pe-aslr/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,15 +11,19 @@ abi = "win64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/pe-import-attribution/mach.toml
+++ b/int/surface/pe-import-attribution/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,9 +11,11 @@ abi = "win64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
@@ -23,8 +23,12 @@ entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
 link = ["kernel32"]
+need = []
 
 [link.kernel32]
 source = "system"
 name = "kernel32.dll"
 os = ["windows"]
+isa = ["*"]
+abi = ["*"]
+export = false

--- a/int/surface/pie-reloc/mach.toml
+++ b/int/surface/pie-reloc/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/pie-relro-fault/mach.toml
+++ b/int/surface/pie-relro-fault/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/sign-extension/mach.toml
+++ b/int/surface/sign-extension/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/syscall-inline-asm/mach.toml
+++ b/int/surface/syscall-inline-asm/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "mach"
-name = "Mach Compiler"
-description = "The Mach compiler"
 version = "3.1.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.mach]
 kind = "bin"
 entry = "main.mach"
 out = "bin/mach"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/src/cli/cmd/clean.mach
+++ b/src/cli/cmd/clean.mach
@@ -102,7 +102,7 @@ fun clean_project(a: *A.Allocator, root: *u8, manifest_path: *u8) i64 {
     var tbl: toml.Table = R.unwrap_ok[toml.Table, str](tbl_r);
 
     var itn: intern.Interner = intern.init(a);
-    val man_r: R.Result[manifest.Manifest, str] = manifest.parse(a, ?itn, ?tbl);
+    val man_r: R.Result[manifest.Manifest, str] = manifest.parse(a, ?itn, ?tbl, true);
     if (R.is_err[manifest.Manifest, str](man_r)) {
         print.eprint("error: mach.toml: ");
         print.eprintln(R.unwrap_err[manifest.Manifest, str](man_r));

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -763,7 +763,7 @@ test "mach.cli.cmd.doc.generate:creates_missing_output_dirs" {
     if (R.is_err[bool, str](filesystem.create_dir_all(?alloc, util.cstr_str(?root[0]), 493))) { bad = 1; }
     if (R.is_err[bool, str](filesystem.create_dir_all(?alloc, src_dir, 493)))                 { bad = 1; }
 
-    val manifest_text: str = "[project]\nid = \"doctest\"\nname = \"d\"\ndescription = \"d\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\n\n[artifact.doctest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/doctest\"\ntargets = [\"*\"]\n";
+    val manifest_text: str = "[project]\nid = \"doctest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\n\n[artifact.doctest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/doctest\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     val main_text: str = "fun main() i32 { ret 0; }\n\n# a documented helper\npub fun answer() i32 { ret 42; }\n";
     val mf: str = t_join(?alloc, util.cstr_str(?root[0]), "mach.toml");
     val mn: str = t_join(?alloc, src_dir, "main.mach");

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -192,12 +192,6 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     buf_put(?buf, "id = \"");
     buf_put(?buf, id);
     buf_put(?buf, "\"\n");
-    buf_put(?buf, "name = \"");
-    buf_put(?buf, id);
-    buf_put(?buf, "\"\n");
-    buf_put(?buf, "description = \"");
-    buf_put(?buf, id);
-    buf_put(?buf, "\"\n");
     buf_put(?buf, "version = \"0.1.0\"\n");
     buf_put(?buf, "src = \"src\"\n");
     buf_put(?buf, "out = \"out/{target.name}/{profile.name}\"\n");
@@ -230,13 +224,17 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
         buf_put(?buf, "\"\n");
     }
     buf_put(?buf, "targets = [\"*\"]\n");
+    buf_put(?buf, "link = []\n");
+    buf_put(?buf, "need = []\n");
     buf_put(?buf, "\n");
 
     buf_put(?buf, "[profile.debug]\n");
     buf_put(?buf, "opt = 0\n");
+    buf_put(?buf, "debug = true\n");
     buf_put(?buf, "\n");
     buf_put(?buf, "[profile.release]\n");
     buf_put(?buf, "opt = 2\n");
+    buf_put(?buf, "debug = false\n");
     buf_put(?buf, "\n");
 
     buf_put(?buf, "[dep.mach-std]\n");

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -31,10 +31,10 @@ use mach.cli.util;
 #              (`.ir`) alongside each object, for debugging / transparency - the
 #              final post-pipeline IR the object is built from, so it varies with
 #              the optimization level
-# no_emit_asm: --no-emit-asm was passed; force ASM emission off, overriding a v2
-#              profile's `emit_asm` default
-# no_emit_ir:  --no-emit-ir was passed; force IR emission off, overriding a v2
-#              profile's `emit_ir` default
+# no_emit_asm: --no-emit-asm was passed; force ASM emission off (the complement of
+#              --emit-asm; IR/ASM emission is CLI-only)
+# no_emit_ir:  --no-emit-ir was passed; force IR emission off (the complement of
+#              --emit-ir; IR/ASM emission is CLI-only)
 # profile:     --profile <name> selected build profile for a v2 manifest (nil
 #              when not given)
 # bin:         --bin <name> narrows a v2 build to one `[bin.*]` artifact (nil

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2322,6 +2322,8 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
         if (R.is_err[toml.Table, str](pr)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](pr)); }
         tables[i] = R.unwrap_ok[toml.Table, str](pr);
 
+        # a dependency's manifest: as_root false, parsed permissively for its export
+        # surface only (#1971) -- the dep's totality is enforced on its own root builds.
         val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tables[i], false);
         if (R.is_err[manifest.Manifest, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mf_r)); }
         manifests[i] = R.unwrap_ok[manifest.Manifest, str](mf_r);
@@ -9863,6 +9865,7 @@ fun execute_dep_steps(p: *Project, isa: str, os: str, abi: str) R.Result[bool, s
         if (R.is_err[toml.Table, str](pr)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](pr)); }
         var tbl: toml.Table = R.unwrap_ok[toml.Table, str](pr);
 
+        # a dependency's manifest: as_root false, parsed permissively (#1971).
         val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tbl, false);
         if (R.is_err[manifest.Manifest, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mf_r)); }
         var mfd: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mf_r);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -472,7 +472,7 @@ pub fun enumerate_matrix(alloc: *A.Allocator, project_root: str, manifest_path: 
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
     var itn: intern.Interner = intern.init(alloc);
-    val mr: R.Result[manifest.Manifest, str] = manifest.parse(alloc, ?itn, ?t);
+    val mr: R.Result[manifest.Manifest, str] = manifest.parse(alloc, ?itn, ?t, true);
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[Matrix, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
 
@@ -547,7 +547,7 @@ pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, manifest_p
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
     var itn: intern.Interner = intern.init(alloc);
-    val mr: R.Result[manifest.Manifest, str] = manifest.parse(alloc, ?itn, ?t);
+    val mr: R.Result[manifest.Manifest, str] = manifest.parse(alloc, ?itn, ?t, true);
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[str, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
 
@@ -1509,7 +1509,7 @@ fun load_project_config(p: *Project, project_root: str, manifest_path: str, sel:
 # collisions are checked before anything is built. a `native` selection that
 # finds no host match emits an unmissable warning here
 fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.Selection, for_union: bool, is_test: bool) R.Result[bool, str] {
-    val mr: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, t);
+    val mr: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, t, true);
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
 
@@ -1607,7 +1607,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     val tn_s: str = O.unwrap[str](intern.lookup(?p.s.interner, bu.target.name));
     val pn_s: str = O.unwrap[str](intern.lookup(?p.s.interner, bu.profile_name));
     val out_tmpl_s: str = O.unwrap[str](intern.lookup(?p.s.interner, m.out_tmpl));
-    val res_project_out_str: R.Result[str, str] = manifest.expand(p.s.alloc, out_tmpl_s, "", tn_s, pn_s, "", "");
+    val res_project_out_str: R.Result[str, str] = manifest.expand(p.s.alloc, out_tmpl_s, "", tn_s, pn_s);
     if (R.is_ok[str, str](res_project_out_str)) {
         val project_out_str: str = R.unwrap_ok[str, str](res_project_out_str);
         val res_po_id: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, project_out_str);
@@ -2008,7 +2008,7 @@ fun validate_local_links(p: *Project, project_root: str, m: *manifest.Manifest, 
             val raw_path: str = O.unwrap[str](path_opt);
             val ename:    str = O.unwrap[str](name_opt);
 
-            val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, raw_path, proj_out, tn, pn, "", "");
+            val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, raw_path, proj_out, tn, pn);
             if (R.is_err[str, str](exp_r)) { ret R.err[bool, str](R.unwrap_err[str, str](exp_r)); }
             val exp: str = R.unwrap_ok[str, str](exp_r);
 
@@ -2322,7 +2322,7 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
         if (R.is_err[toml.Table, str](pr)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](pr)); }
         tables[i] = R.unwrap_ok[toml.Table, str](pr);
 
-        val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tables[i]);
+        val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tables[i], false);
         if (R.is_err[manifest.Manifest, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mf_r)); }
         manifests[i] = R.unwrap_ok[manifest.Manifest, str](mf_r);
 
@@ -2422,7 +2422,7 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
                         val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
                         val tn2: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
                         val pn2: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
-                        val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, O.unwrap[str](p_opt), root_out, tn2, pn2, "", "");
+                        val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, O.unwrap[str](p_opt), root_out, tn2, pn2);
                         if (R.is_ok[str, str](exp_r)) {
                             val exp: str = R.unwrap_ok[str, str](exp_r);
                             lib_id = R.unwrap_ok[intern.StrId, str](intern.intern(?p.s.interner, exp));
@@ -5898,7 +5898,7 @@ fun ut_cc3(alloc: *A.Allocator, a: str, b: str, c: str) str {
 # `resolve_native` falls back to the first target (linux) and the host-tie assertions in
 # union_ctx_restored_to_default_tuple read the wrong default for that host (#1724)
 fun ut_manifest() str {
-    ret "[project]\nid = \"uniontest\"\nname = \"u\"\ndescription = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[target.linux-riscv64]\nisa = \"riscv64\"\nos = \"linux\"\nabi = \"lp64\"\n\n[target.darwin-x86_64]\nisa = \"x86_64\"\nos = \"darwin\"\nabi = \"sysv64\"\n\n[target.darwin-arm64]\nisa = \"aarch64\"\nos = \"darwin\"\nabi = \"aapcs64\"\n\n[artifact.uniontest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest\"\ntargets = [\"*\"]\n";
+    ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[target.linux-riscv64]\nisa = \"riscv64\"\nos = \"linux\"\nabi = \"lp64\"\n\n[target.darwin-x86_64]\nisa = \"x86_64\"\nos = \"darwin\"\nabi = \"sysv64\"\n\n[target.darwin-arm64]\nisa = \"aarch64\"\nos = \"darwin\"\nabi = \"aapcs64\"\n\n[artifact.uniontest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
 # a two-target, two-bin manifest for the multi-artifact union
@@ -5906,14 +5906,14 @@ fun ut_manifest() str {
 # bin.beta is a second whose entry the union must also load. id is "uniontest" so
 # the per-file `use uniontest.*` paths and FQN assertions match ut_manifest's
 fun ut_manifest_multi() str {
-    ret "[project]\nid = \"uniontest\"\nname = \"u\"\ndescription = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\n";
+    ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
 # a manifest with a windows-only `local` link entry whose path is neither step-backed
 # nor present on disk, for the #1988 cross-target validation-skip test. building for
 # linux must ignore the entry (it filters out), not validate its linux-cell expansion
 fun ut_manifest_winlocal() str {
-    ret "[project]\nid = \"winlocal\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[link.winobj]\nsource = \"local\"\npath = \"{project.out}/win.o\"\nos = [\"windows\"]\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n";
+    ret "[project]\nid = \"winlocal\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[link.winobj]\nsource = \"local\"\npath = \"{project.out}/win.o\"\nos = [\"windows\"]\nisa = [\"*\"]\nabi = [\"*\"]\nexport = false\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
 # materialize a temp project (the shared ut_manifest + src/<files>) on
@@ -5988,12 +5988,12 @@ fun ut_write_node(alloc: *A.Allocator, dir: str, manifest_text: str, src_name: s
 # a minimal static-lib dep manifest carrying project id `id`.
 fun ut_lib_manifest(alloc: *A.Allocator, id: str) str {
     ret ut_cc3(alloc, "[project]\nid = \"", id,
-        "\"\nname = \"l\"\ndescription = \"d\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[artifact.lib]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/l\"\ntargets = [\"*\"]\n");
+        "\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[artifact.lib]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/l\"\ntargets = [\"*\"]\nlink = []\nneed = []\n");
 }
 
 # a bin root manifest declaring the single path dep [dep.<alias>] at `path`.
 fun ut_dep_root_one(alloc: *A.Allocator, alias: str, path: str) str {
-    val head: str = "[project]\nid = \"app\"\nname = \"app\"\ndescription = \"d\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n\n[dep.";
+    val head: str = "[project]\nid = \"app\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[dep.";
     val mid: str = ut_cc3(alloc, head, alias, "]\npath = \"");
     ret ut_cc3(alloc, mid, path, "\"\n");
 }
@@ -6413,7 +6413,7 @@ test "mach.lang.driver:union_skips_uncoverable_target" {
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
 
     # one coverable target (linux/x86_64) and one this build cannot emit
-    val mf: str = "[project]\nid = \"uskip\"\nname = \"u\"\ndescription = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.good]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.bad]\nisa = \"aarch64\"\nos = \"windows\"\nabi = \"aapcs64\"\n\n[artifact.uskip]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uskip\"\ntargets = [\"*\"]\n";
+    val mf: str = "[project]\nid = \"uskip\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.good]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.bad]\nisa = \"aarch64\"\nos = \"windows\"\nabi = \"aapcs64\"\n\n[artifact.uskip]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uskip\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     var names: [1]str;
     names[0] = "main.mach";
     var texts: [1]str;
@@ -9458,7 +9458,7 @@ fun collect_step_inputs(alloc: *A.Allocator, p: *Project, step: *manifest.StepDe
     val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
     var i: u32 = 0;
     for (i < step.in_count) {
-        val exp_r: R.Result[str, str] = manifest.expand(alloc, O.unwrap[str](intern.lookup(?p.s.interner, step.in[i])), home_out, target_name_s, profile_s, "", "");
+        val exp_r: R.Result[str, str] = manifest.expand(alloc, O.unwrap[str](intern.lookup(?p.s.interner, step.in[i])), home_out, target_name_s, profile_s);
         if (R.is_err[str, str](exp_r)) { ret R.err[bool, str](R.unwrap_err[str, str](exp_r)); }
         val exp: str = R.unwrap_ok[str, str](exp_r);
         if (!has_glob(exp)) {
@@ -9586,7 +9586,7 @@ fun step_outputs_exist(a: *A.Allocator, p: *Project, step: *manifest.StepDef, pr
     val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
     var oi: u32 = 0;
     for (oi < step.out_count) {
-        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), home_out, target_name_s, profile_s, "", "");
+        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), home_out, target_name_s, profile_s);
         if (R.is_err[str, str](out_r)) { ret false; }
         val out_s: str = R.unwrap_ok[str, str](out_r);
         val abs_r: R.Result[str, str] = join_path(a, project_root, out_s);
@@ -9632,7 +9632,7 @@ fun step_make_output_dirs(a: *A.Allocator, p: *Project, step: *manifest.StepDef)
     val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
     var oi: u32 = 0;
     for (oi < step.out_count) {
-        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), root_out, target_name_s, profile_s, "", "");
+        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), root_out, target_name_s, profile_s);
         if (R.is_err[str, str](out_r)) { ret R.err[bool, str](R.unwrap_err[str, str](out_r)); }
         val out_s: str = R.unwrap_ok[str, str](out_r);
         val rel_dir: str = parent_dir(a, out_s);
@@ -9671,7 +9671,7 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
     val cir: R.Result[bool, str] = collect_step_inputs(a, p, step, project_root, home_out, ?ins);
     if (R.is_err[bool, str](cir)) { step_free_inputs(a, ?ins); ret R.err[bool, str](R.unwrap_err[bool, str](cir)); }
 
-    val cmd_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.cmd)), project_out_s, target_name_s, profile_s, "", "");
+    val cmd_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.cmd)), project_out_s, target_name_s, profile_s);
     if (R.is_err[str, str](cmd_r)) { step_free_inputs(a, ?ins); ret R.err[bool, str](R.unwrap_err[str, str](cmd_r)); }
     val expanded_cmd: str = R.unwrap_ok[str, str](cmd_r);
 
@@ -9863,7 +9863,7 @@ fun execute_dep_steps(p: *Project, isa: str, os: str, abi: str) R.Result[bool, s
         if (R.is_err[toml.Table, str](pr)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](pr)); }
         var tbl: toml.Table = R.unwrap_ok[toml.Table, str](pr);
 
-        val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tbl);
+        val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tbl, false);
         if (R.is_err[manifest.Manifest, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mf_r)); }
         var mfd: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mf_r);
 

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -320,7 +320,7 @@ fun canonical_axis_value(key: str, value: str) bool {
     ret false;
 }
 
-fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Table, key: str, label: str, strict: bool) R.Result[StrArr, str] {
+fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Table, key: str, label: str, as_root: bool) R.Result[StrArr, str] {
     var out: StrArr;
     out.items   = nil;
     out.count   = 0;
@@ -356,7 +356,7 @@ fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Tab
         ret R.err[StrArr, str](cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
     }
 
-    if (strict) {
+    if (as_root) {
         var vi: u32 = 0;
         for (vi < out.count) {
             val vs: str = idstr(itn, out.items[vi]);
@@ -369,9 +369,9 @@ fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Tab
     ret R.ok[StrArr, str](out);
 }
 
-fun parse_opt_level(alloc: *A.Allocator, name: str, sub: *toml.Table, strict: bool) R.Result[MOpt, str] {
+fun parse_opt_level(alloc: *A.Allocator, name: str, sub: *toml.Table, as_root: bool) R.Result[MOpt, str] {
     val v: *toml.Value = toml.get(sub, "opt");
-    if (v == nil && strict)         { ret R.err[MOpt, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'opt'")); }
+    if (v == nil && as_root)         { ret R.err[MOpt, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'opt'")); }
     if (v == nil)                   { ret R.ok[MOpt, str](MOPT_DEFAULT); }
     if (v.tag != toml.TYPE_INTEGER) { ret R.err[MOpt, str](opt_err(alloc, name, v)); }
     val n: i64 = v.data.integer;
@@ -398,9 +398,9 @@ fun opt_value_text(alloc: *A.Allocator, v: *toml.Value) str {
     ret "a value";
 }
 
-fun parse_debug_flag(alloc: *A.Allocator, name: str, sub: *toml.Table, strict: bool) R.Result[bool, str] {
+fun parse_debug_flag(alloc: *A.Allocator, name: str, sub: *toml.Table, as_root: bool) R.Result[bool, str] {
     val v: *toml.Value = toml.get(sub, "debug");
-    if (v == nil && strict)      { ret R.err[bool, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'debug'")); }
+    if (v == nil && as_root)      { ret R.err[bool, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'debug'")); }
     if (v == nil)                { ret R.ok[bool, str](false); }
     if (v.tag != toml.TYPE_BOOL) { ret R.err[bool, str](debug_err(alloc, name, v)); }
     ret R.ok[bool, str](v.data.boolean);
@@ -438,13 +438,14 @@ fun unknown_key_msg(alloc: *A.Allocator, key: str, label: str) str {
     ret cc(alloc, cc3(alloc, "mach.toml: unknown key '", key, "' in "), label);
 }
 
-fun key_known(kind: TableKind, k: str, strict: bool) bool {
+fun key_known(kind: TableKind, k: str, as_root: bool) bool {
     if (kind == TK_PROJECT) {
         if (str_equals(k, "id") || str_equals(k, "version") || str_equals(k, "src") || str_equals(k, "out")) { ret true; }
-        # a dependency's manifest is parsed permissively (#1971): the consumer reads
-        # only its export surface, so pre-flag-day metadata like name/description is
-        # tolerated rather than rejected. the root manifest is strict.
-        if (!strict && (str_equals(k, "name") || str_equals(k, "description"))) { ret true; }
+        # a dependency's manifest (as_root false) tolerates the pre-flag-day
+        # name/description metadata the consumer never reads (#1971); the root
+        # trims [project] to id/version/src/out. a genuinely unknown key is rejected
+        # on both paths -- only these two pre-flag-day keys relax off-root.
+        if (!as_root && (str_equals(k, "name") || str_equals(k, "description"))) { ret true; }
         ret false;
     }
     if (kind == TK_TARGET) {
@@ -470,12 +471,12 @@ fun key_known(kind: TableKind, k: str, strict: bool) bool {
     ret false;
 }
 
-fun check_keys(alloc: *A.Allocator, tab: *toml.Table, label: str, kind: TableKind, strict: bool) R.Result[bool, str] {
+fun check_keys(alloc: *A.Allocator, tab: *toml.Table, label: str, kind: TableKind, as_root: bool) R.Result[bool, str] {
     val n: usize = toml.table_len(tab);
     var i: usize = 0;
     for (i < n) {
         val k: str = toml.table_key(tab, i);
-        if (!key_known(kind, k, strict)) { ret R.err[bool, str](unknown_key_msg(alloc, k, label)); }
+        if (!key_known(kind, k, as_root)) { ret R.err[bool, str](unknown_key_msg(alloc, k, label)); }
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -498,12 +499,17 @@ fun first_nonempty(a: str, b: str) str {
     ret a;
 }
 
-# parse a manifest. `strict` enforces #1964 no-defaults totality (every declared-
-# table field spelled, [project] trimmed to id/version/src/out, canonical filter
-# axes) and is used for the root manifest being built. a dependency's manifest is
-# parsed with strict=false: the consumer reads only its export surface, so the
-# dep's own migration state must not gate the consumer's build (#1971).
-pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, strict: bool) R.Result[Manifest, str] {
+# parse a manifest. `as_root` selects the enforcement boundary (#1971): true for the
+# manifest being built (the root), where #1964 no-defaults totality is enforced --
+# every declared-table field spelled, [project] trimmed to id/version/src/out,
+# canonical filter axes. false for a dependency's manifest, parsed permissively: the
+# consumer reads only the dep's export surface (id, exported link entries, the steps
+# they demand), so the dep's own migration state must never gate the consumer's
+# build. Enforcement travels with the declaring unit -- a dep enforces its own
+# totality on ITS root builds. Unknown-key rejection is NOT part of the mode: a
+# genuinely unknown key is rejected on both paths (only pre-flag-day [project]
+# name/description relax off-root).
+pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, as_root: bool) R.Result[Manifest, str] {
     var m: Manifest;
     m.targets        = nil;
     m.target_count   = 0;
@@ -520,7 +526,7 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, strict
 
     val proj: *toml.Table = toml.get_table(t, "project");
     if (proj == nil) { ret R.err[Manifest, str]("mach.toml: missing [project] table"); }
-    val res_project_keys: R.Result[bool, str] = check_keys(alloc, proj, "[project]", TK_PROJECT, strict);
+    val res_project_keys: R.Result[bool, str] = check_keys(alloc, proj, "[project]", TK_PROJECT, as_root);
     if (R.is_err[bool, str](res_project_keys)) { ret R.err[Manifest, str](R.unwrap_err[bool, str](res_project_keys)); }
 
     val id_str: str = toml.get_str(proj, "id");
@@ -549,28 +555,28 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, strict
     m.out_tmpl = intern_unwrap(itn, out_str);
     m.default_target = intern_unwrap(itn, "native");
 
-    val res_targets: R.Result[bool, str] = parse_targets(alloc, itn, t, ?m, strict);
+    val res_targets: R.Result[bool, str] = parse_targets(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_targets)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_targets)); }
 
-    val res_artifacts: R.Result[bool, str] = parse_artifacts(alloc, itn, t, ?m, strict);
+    val res_artifacts: R.Result[bool, str] = parse_artifacts(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_artifacts)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_artifacts)); }
 
-    val res_profiles: R.Result[bool, str] = parse_profiles(alloc, itn, t, ?m, strict);
+    val res_profiles: R.Result[bool, str] = parse_profiles(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_profiles)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_profiles)); }
 
-    val res_deps: R.Result[bool, str] = parse_deps(alloc, itn, t, ?m, strict);
+    val res_deps: R.Result[bool, str] = parse_deps(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_deps)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_deps)); }
 
-    val res_links: R.Result[bool, str] = parse_links(alloc, itn, t, ?m, strict);
+    val res_links: R.Result[bool, str] = parse_links(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_links)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_links)); }
 
-    val res_steps: R.Result[bool, str] = parse_steps(alloc, itn, t, ?m, strict);
+    val res_steps: R.Result[bool, str] = parse_steps(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_steps)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_steps)); }
 
     ret R.ok[Manifest, str](m);
 }
 
-fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "target");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -593,7 +599,7 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
         }
         val sub: *toml.Table = ?v.data.table;
         val label: str = cc3(alloc, "[target.", name, "]");
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_TARGET, strict);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_TARGET, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: TargetDef;
@@ -616,7 +622,7 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
     ret R.ok[bool, str](true);
 }
 
-fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val arts: *toml.Table = toml.get_table(t, "artifact");
     if (arts == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(arts);
@@ -629,7 +635,7 @@ fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, 
 
     var i: usize = 0;
     for (i < n) {
-        val res_artifact: R.Result[ArtifactDef, str] = parse_one_artifact(alloc, itn, arts, i, strict);
+        val res_artifact: R.Result[ArtifactDef, str] = parse_one_artifact(alloc, itn, arts, i, as_root);
         if (R.is_err[ArtifactDef, str](res_artifact)) { ret R.err[bool, str](R.unwrap_err[ArtifactDef, str](res_artifact)); }
         m.artifacts[i] = R.unwrap_ok[ArtifactDef, str](res_artifact);
         i = i + 1;
@@ -637,7 +643,7 @@ fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, 
     ret R.ok[bool, str](true);
 }
 
-fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Table, k: usize, strict: bool) R.Result[ArtifactDef, str] {
+fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Table, k: usize, as_root: bool) R.Result[ArtifactDef, str] {
     val name: str = toml.table_key(tab, k);
     val v: *toml.Value = toml.table_value(tab, k);
     val label: str = cc3(alloc, "[artifact.", name, "]");
@@ -646,7 +652,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     }
     val sub: *toml.Table = ?v.data.table;
 
-    val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_ARTIFACT, strict);
+    val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_ARTIFACT, as_root);
     if (R.is_err[bool, str](res_keys)) { ret R.err[ArtifactDef, str](R.unwrap_err[bool, str](res_keys)); }
 
     var a: ArtifactDef;
@@ -689,7 +695,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     a.target_count = targets_val.count;
 
     val link_arr: *toml.Array = toml.get_array(sub, "link");
-    if (link_arr == nil && strict) {
+    if (link_arr == nil && as_root) {
         ret R.err[ArtifactDef, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'link' (use [] for none)"));
     }
     if (link_arr != nil) {
@@ -702,7 +708,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     }
 
     val need_arr: *toml.Array = toml.get_array(sub, "need");
-    if (need_arr == nil && strict) {
+    if (need_arr == nil && as_root) {
         ret R.err[ArtifactDef, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'need' (use [] for none)"));
     }
     if (need_arr != nil) {
@@ -717,7 +723,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     ret R.ok[ArtifactDef, str](a);
 }
 
-fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "profile");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -737,17 +743,17 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " must be a table"));
         }
         val sub: *toml.Table = ?v.data.table;
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_PROFILE, strict);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_PROFILE, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var pf: ProfileDef;
         pf.name = intern_unwrap(itn, name);
-        val res_opt: R.Result[MOpt, str] = parse_opt_level(alloc, name, sub, strict);
+        val res_opt: R.Result[MOpt, str] = parse_opt_level(alloc, name, sub, as_root);
         if (R.is_err[MOpt, str](res_opt)) { ret R.err[bool, str](R.unwrap_err[MOpt, str](res_opt)); }
         pf.opt      = R.unwrap_ok[MOpt, str](res_opt);
         pf.emit_ir  = bool_or(toml.get_bool(sub, "emit_ir"), false);
         pf.emit_asm = bool_or(toml.get_bool(sub, "emit_asm"), false);
-        val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub, strict);
+        val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub, as_root);
         if (R.is_err[bool, str](res_debug)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_debug)); }
         pf.debug    = R.unwrap_ok[bool, str](res_debug);
 
@@ -757,7 +763,7 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
     ret R.ok[bool, str](true);
 }
 
-fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "dep");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -781,7 +787,7 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
         if (toml.get(sub, "version") != nil) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".version is reserved for the registry era"));
         }
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_DEP, strict);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_DEP, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: DepDef;
@@ -794,10 +800,10 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " needs exactly one source key: 'git' or 'path'"));
         }
         val ref_s: str = toml.get_str(sub, "ref");
-        if (has_git && str_empty(ref_s) && strict) {
+        if (has_git && str_empty(ref_s) && as_root) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'ref' for git source"));
         }
-        if (has_path && !str_empty(ref_s) && strict) {
+        if (has_path && !str_empty(ref_s) && as_root) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".ref is not allowed for path sources"));
         }
         d.git  = intern_opt_unwrap(itn, git_s);
@@ -810,7 +816,7 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
     ret R.ok[bool, str](true);
 }
 
-fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "link");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -831,7 +837,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
         val sub: *toml.Table = ?v.data.table;
 
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_LINK, strict);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_LINK, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: LinkDef;
@@ -870,32 +876,32 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
             d.path = intern.STR_NIL;
         }
 
-        val res_os: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "os", label, strict);
+        val res_os: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "os", label, as_root);
         if (R.is_err[StrArr, str](res_os)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_os)); }
         val os_v: StrArr = R.unwrap_ok[StrArr, str](res_os);
-        if (!os_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'os' (use \"*\" for any)")); }
+        if (!os_v.present && as_root) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'os' (use \"*\" for any)")); }
         d.os = os_v.items;
         d.os_count = os_v.count;
         d.os_present = os_v.present;
 
-        val res_isa: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "isa", label, strict);
+        val res_isa: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "isa", label, as_root);
         if (R.is_err[StrArr, str](res_isa)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_isa)); }
         val isa_v: StrArr = R.unwrap_ok[StrArr, str](res_isa);
-        if (!isa_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'isa' (use \"*\" for any)")); }
+        if (!isa_v.present && as_root) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'isa' (use \"*\" for any)")); }
         d.isa = isa_v.items;
         d.isa_count = isa_v.count;
         d.isa_present = isa_v.present;
 
-        val res_abi: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "abi", label, strict);
+        val res_abi: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "abi", label, as_root);
         if (R.is_err[StrArr, str](res_abi)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_abi)); }
         val abi_v: StrArr = R.unwrap_ok[StrArr, str](res_abi);
-        if (!abi_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'abi' (use \"*\" for any)")); }
+        if (!abi_v.present && as_root) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'abi' (use \"*\" for any)")); }
         d.abi = abi_v.items;
         d.abi_count = abi_v.count;
         d.abi_present = abi_v.present;
 
         val export_v: *toml.Value = toml.get(sub, "export");
-        if (export_v == nil && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'export'")); }
+        if (export_v == nil && as_root) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'export'")); }
         if (export_v == nil) { d.export = false; }
         or (export_v.tag != toml.TYPE_BOOL) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".export must be a boolean")); }
         or { d.export = export_v.data.boolean; }
@@ -906,7 +912,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
     ret R.ok[bool, str](true);
 }
 
-fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "step");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -927,7 +933,7 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
         val sub: *toml.Table = ?v.data.table;
 
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_STEP, strict);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_STEP, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: StepDef;
@@ -979,7 +985,7 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
 
         val need_arr: *toml.Array = toml.get_array(sub, "need");
-        if (need_arr == nil && strict) {
+        if (need_arr == nil && as_root) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'need' (use [] for none)"));
         }
         if (need_arr != nil) {
@@ -2528,6 +2534,41 @@ test "mach.lang.manifest.parse:canonical_and_star" {
     # "*" on every axis and targets = ["*"] are the explicit-any token and legal
     val ok: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[artifact.a]\nkind=\"bin\"\nentry=\"m.mach\"\nout=\"bin/a\"\ntargets=[\"*\"]\nlink=[\"c\"]\nneed=[]\n[link.c]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n"));
     if (R.is_err[Manifest, str](ok)) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #1971 contract: a non-total (pre-flag-day) manifest -- mach-std-shaped, with
+# name/description, a profile missing debug, and a link missing isa/abi -- is
+# REJECTED as a root build yet CONSUMED cleanly as a dependency, with its exported
+# link entry resolving and filtering correctly against the build cell.
+test "mach.lang.manifest.parse:root_reject_dep_consume" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val nontotal: str = "[project]\nid=\"std\"\nname=\"Mach Standard Library\"\ndescription=\"stdlib\"\nversion=\"0.18.0\"\nsrc=\"src\"\nout=\"out/{target.name}/{profile.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[profile.debug]\nopt=0\n[profile.release]\nopt=2\n[artifact.std]\nkind=\"static\"\nentry=\"lib.mach\"\nout=\"lib/std\"\ntargets=[\"*\"]\nlink=[\"kernel32\"]\n[link.kernel32]\nsource=\"system\"\nname=\"kernel32.dll\"\nos=[\"windows\"]\nexport=true\n";
+
+    # rejected as a root build (name is an unknown key once [project] is trimmed)
+    val as_root: R.Result[Manifest, str] = tparse(?alloc, ?itn, nontotal);
+    if (R.is_ok[Manifest, str](as_root)) { code = 1; }
+
+    # consumed cleanly as a dependency: parses, and the exported entry filters right
+    val as_dep: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, nontotal);
+    if (R.is_err[Manifest, str](as_dep)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](as_dep);
+        val k: *LinkDef = find_link(?itn, ?m, "kernel32");
+        val tl: *TargetDef = find_target_by_name(?itn, ?m, "linux");
+        val tw: *TargetDef = find_target_by_name(?itn, ?m, "windows");
+        if (k == nil || tl == nil || tw == nil) { code = 1; }
+        or {
+            if (!k.export) { code = 1; }
+            # os=["windows"] with absent isa/abi (match-any): windows yes, linux no
+            if (!link_matches_target(?itn, k, tw)) { code = 1; }
+            if ( link_matches_target(?itn, k, tl)) { code = 1; }
+        }
+    }
     arena.dnit(?ar);
     ret code;
 }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -25,6 +25,7 @@ use mach.lang.intern;
 use tgt: mach.lang.target;
 use mach.lang.target.isa;
 use mach.lang.target.os;
+use mach.lang.target.abi;
 
 pub def MOpt: u8;
 
@@ -308,7 +309,18 @@ fun parse_str_array(alloc: *A.Allocator, itn: *intern.Interner, arr: *toml.Array
 # and `["linux"]` filter identically. an absent axis (present false) matches any;
 # an explicit empty array (present, count 0) matches nothing. an empty-string value
 # is not a canonical value and is a strict error, as is a non-string, non-array.
-fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Table, key: str, label: str) R.Result[StrArr, str] {
+# whether `value` is a canonical spelling for filter axis `key` (os/isa/abi), or
+# the explicit-any token "*". non-canonical spellings are strict errors (#1971) so
+# a typo like os = "windoze" never silently matches nothing.
+fun canonical_axis_value(key: str, value: str) bool {
+    if (str_equals(value, "*")) { ret true; }
+    if (str_equals(key, "os"))  { ret os.os_id_for(value) != os.OS_UNKNOWN; }
+    if (str_equals(key, "isa")) { ret isa.arch_id_for(value) != isa.ARCH_UNKNOWN; }
+    if (str_equals(key, "abi")) { ret abi.abi_id_for(value) != abi.ABI_UNKNOWN; }
+    ret false;
+}
+
+fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Table, key: str, label: str, strict: bool) R.Result[StrArr, str] {
     var out: StrArr;
     out.items   = nil;
     out.count   = 0;
@@ -331,23 +343,35 @@ fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Tab
         }
         out.items[0] = R.unwrap_ok[intern.StrId, str](res_elem);
         out.count = 1;
-        ret R.ok[StrArr, str](out);
     }
-
-    if (v.tag == toml.TYPE_ARRAY) {
+    or (v.tag == toml.TYPE_ARRAY) {
         val res_arr: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?v.data.array,
             cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
         if (R.is_err[StrArr, str](res_arr)) { ret res_arr; }
-        var arr_v: StrArr = R.unwrap_ok[StrArr, str](res_arr);
-        arr_v.present = true;
-        ret R.ok[StrArr, str](arr_v);
+        val arr_v: StrArr = R.unwrap_ok[StrArr, str](res_arr);
+        out.items = arr_v.items;
+        out.count = arr_v.count;
+    }
+    or {
+        ret R.err[StrArr, str](cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
     }
 
-    ret R.err[StrArr, str](cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
+    if (strict) {
+        var vi: u32 = 0;
+        for (vi < out.count) {
+            val vs: str = idstr(itn, out.items[vi]);
+            if (!canonical_axis_value(key, vs)) {
+                ret R.err[StrArr, str](cc(alloc, cc5(alloc, "mach.toml: ", label, ".", key, cc3(alloc, " has non-canonical value '", vs, "'")), "; use a canonical value or \"*\""));
+            }
+            vi = vi + 1;
+        }
+    }
+    ret R.ok[StrArr, str](out);
 }
 
-fun parse_opt_level(alloc: *A.Allocator, name: str, sub: *toml.Table) R.Result[MOpt, str] {
+fun parse_opt_level(alloc: *A.Allocator, name: str, sub: *toml.Table, strict: bool) R.Result[MOpt, str] {
     val v: *toml.Value = toml.get(sub, "opt");
+    if (v == nil && strict)         { ret R.err[MOpt, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'opt'")); }
     if (v == nil)                   { ret R.ok[MOpt, str](MOPT_DEFAULT); }
     if (v.tag != toml.TYPE_INTEGER) { ret R.err[MOpt, str](opt_err(alloc, name, v)); }
     val n: i64 = v.data.integer;
@@ -374,8 +398,9 @@ fun opt_value_text(alloc: *A.Allocator, v: *toml.Value) str {
     ret "a value";
 }
 
-fun parse_debug_flag(alloc: *A.Allocator, name: str, sub: *toml.Table) R.Result[bool, str] {
+fun parse_debug_flag(alloc: *A.Allocator, name: str, sub: *toml.Table, strict: bool) R.Result[bool, str] {
     val v: *toml.Value = toml.get(sub, "debug");
+    if (v == nil && strict)      { ret R.err[bool, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'debug'")); }
     if (v == nil)                { ret R.ok[bool, str](false); }
     if (v.tag != toml.TYPE_BOOL) { ret R.err[bool, str](debug_err(alloc, name, v)); }
     ret R.ok[bool, str](v.data.boolean);
@@ -413,10 +438,14 @@ fun unknown_key_msg(alloc: *A.Allocator, key: str, label: str) str {
     ret cc(alloc, cc3(alloc, "mach.toml: unknown key '", key, "' in "), label);
 }
 
-fun key_known(kind: TableKind, k: str) bool {
+fun key_known(kind: TableKind, k: str, strict: bool) bool {
     if (kind == TK_PROJECT) {
-        ret str_equals(k, "id") || str_equals(k, "name") || str_equals(k, "description")
-            || str_equals(k, "version") || str_equals(k, "src") || str_equals(k, "out");
+        if (str_equals(k, "id") || str_equals(k, "version") || str_equals(k, "src") || str_equals(k, "out")) { ret true; }
+        # a dependency's manifest is parsed permissively (#1971): the consumer reads
+        # only its export surface, so pre-flag-day metadata like name/description is
+        # tolerated rather than rejected. the root manifest is strict.
+        if (!strict && (str_equals(k, "name") || str_equals(k, "description"))) { ret true; }
+        ret false;
     }
     if (kind == TK_TARGET) {
         ret str_equals(k, "isa") || str_equals(k, "os") || str_equals(k, "abi") || str_equals(k, "of");
@@ -441,12 +470,12 @@ fun key_known(kind: TableKind, k: str) bool {
     ret false;
 }
 
-fun check_keys(alloc: *A.Allocator, tab: *toml.Table, label: str, kind: TableKind) R.Result[bool, str] {
+fun check_keys(alloc: *A.Allocator, tab: *toml.Table, label: str, kind: TableKind, strict: bool) R.Result[bool, str] {
     val n: usize = toml.table_len(tab);
     var i: usize = 0;
     for (i < n) {
         val k: str = toml.table_key(tab, i);
-        if (!key_known(kind, k)) { ret R.err[bool, str](unknown_key_msg(alloc, k, label)); }
+        if (!key_known(kind, k, strict)) { ret R.err[bool, str](unknown_key_msg(alloc, k, label)); }
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -469,7 +498,12 @@ fun first_nonempty(a: str, b: str) str {
     ret a;
 }
 
-pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table) R.Result[Manifest, str] {
+# parse a manifest. `strict` enforces #1964 no-defaults totality (every declared-
+# table field spelled, [project] trimmed to id/version/src/out, canonical filter
+# axes) and is used for the root manifest being built. a dependency's manifest is
+# parsed with strict=false: the consumer reads only its export surface, so the
+# dep's own migration state must not gate the consumer's build (#1971).
+pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, strict: bool) R.Result[Manifest, str] {
     var m: Manifest;
     m.targets        = nil;
     m.target_count   = 0;
@@ -486,17 +520,13 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table) R.Resu
 
     val proj: *toml.Table = toml.get_table(t, "project");
     if (proj == nil) { ret R.err[Manifest, str]("mach.toml: missing [project] table"); }
-    val res_project_keys: R.Result[bool, str] = check_keys(alloc, proj, "[project]", TK_PROJECT);
+    val res_project_keys: R.Result[bool, str] = check_keys(alloc, proj, "[project]", TK_PROJECT, strict);
     if (R.is_err[bool, str](res_project_keys)) { ret R.err[Manifest, str](R.unwrap_err[bool, str](res_project_keys)); }
 
     val id_str: str = toml.get_str(proj, "id");
     if (str_empty(id_str)) { ret R.err[Manifest, str]("mach.toml: [project] is missing required key 'id'"); }
     val ver_str: str = toml.get_str(proj, "version");
     if (str_empty(ver_str)) { ret R.err[Manifest, str]("mach.toml: [project] is missing required key 'version'"); }
-    # name/description are metadata the #1964 shape does not define; accepted when
-    # present, absent otherwise (STR_NIL). strict totality is #1971's flag-day.
-    val name_str: str = toml.get_str(proj, "name");
-    val desc_str: str = toml.get_str(proj, "description");
     val src_str: str = toml.get_str(proj, "src");
     if (str_empty(src_str)) { ret R.err[Manifest, str]("mach.toml: [project] is missing required key 'src'"); }
     val out_str: str = toml.get_str(proj, "out");
@@ -512,34 +542,35 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table) R.Resu
     if (!is_valid_id(id_str)) { ret R.err[Manifest, str]("mach.toml: [project].id must be an identifier (letters, digits, '_', '-')"); }
     m.id = intern_unwrap(itn, id_str);
     m.version = intern_unwrap(itn, ver_str);
-    m.name = intern_opt_unwrap(itn, name_str);
-    m.description = intern_opt_unwrap(itn, desc_str);
+    # name/description are not #1964 fields; [project] is id/version/src/out only.
+    m.name = intern.STR_NIL;
+    m.description = intern.STR_NIL;
     m.src = intern_unwrap(itn, src_str);
     m.out_tmpl = intern_unwrap(itn, out_str);
     m.default_target = intern_unwrap(itn, "native");
 
-    val res_targets: R.Result[bool, str] = parse_targets(alloc, itn, t, ?m);
+    val res_targets: R.Result[bool, str] = parse_targets(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_targets)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_targets)); }
 
-    val res_artifacts: R.Result[bool, str] = parse_artifacts(alloc, itn, t, ?m);
+    val res_artifacts: R.Result[bool, str] = parse_artifacts(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_artifacts)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_artifacts)); }
 
-    val res_profiles: R.Result[bool, str] = parse_profiles(alloc, itn, t, ?m);
+    val res_profiles: R.Result[bool, str] = parse_profiles(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_profiles)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_profiles)); }
 
-    val res_deps: R.Result[bool, str] = parse_deps(alloc, itn, t, ?m);
+    val res_deps: R.Result[bool, str] = parse_deps(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_deps)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_deps)); }
 
-    val res_links: R.Result[bool, str] = parse_links(alloc, itn, t, ?m);
+    val res_links: R.Result[bool, str] = parse_links(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_links)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_links)); }
 
-    val res_steps: R.Result[bool, str] = parse_steps(alloc, itn, t, ?m);
+    val res_steps: R.Result[bool, str] = parse_steps(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_steps)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_steps)); }
 
     ret R.ok[Manifest, str](m);
 }
 
-fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "target");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -562,7 +593,7 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
         }
         val sub: *toml.Table = ?v.data.table;
         val label: str = cc3(alloc, "[target.", name, "]");
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_TARGET);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_TARGET, strict);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: TargetDef;
@@ -585,7 +616,7 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
     ret R.ok[bool, str](true);
 }
 
-fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val arts: *toml.Table = toml.get_table(t, "artifact");
     if (arts == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(arts);
@@ -598,7 +629,7 @@ fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, 
 
     var i: usize = 0;
     for (i < n) {
-        val res_artifact: R.Result[ArtifactDef, str] = parse_one_artifact(alloc, itn, arts, i);
+        val res_artifact: R.Result[ArtifactDef, str] = parse_one_artifact(alloc, itn, arts, i, strict);
         if (R.is_err[ArtifactDef, str](res_artifact)) { ret R.err[bool, str](R.unwrap_err[ArtifactDef, str](res_artifact)); }
         m.artifacts[i] = R.unwrap_ok[ArtifactDef, str](res_artifact);
         i = i + 1;
@@ -606,7 +637,7 @@ fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, 
     ret R.ok[bool, str](true);
 }
 
-fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Table, k: usize) R.Result[ArtifactDef, str] {
+fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Table, k: usize, strict: bool) R.Result[ArtifactDef, str] {
     val name: str = toml.table_key(tab, k);
     val v: *toml.Value = toml.table_value(tab, k);
     val label: str = cc3(alloc, "[artifact.", name, "]");
@@ -615,7 +646,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     }
     val sub: *toml.Table = ?v.data.table;
 
-    val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_ARTIFACT);
+    val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_ARTIFACT, strict);
     if (R.is_err[bool, str](res_keys)) { ret R.err[ArtifactDef, str](R.unwrap_err[bool, str](res_keys)); }
 
     var a: ArtifactDef;
@@ -658,6 +689,9 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     a.target_count = targets_val.count;
 
     val link_arr: *toml.Array = toml.get_array(sub, "link");
+    if (link_arr == nil && strict) {
+        ret R.err[ArtifactDef, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'link' (use [] for none)"));
+    }
     if (link_arr != nil) {
         val res_link: R.Result[StrArr, str] = parse_str_array(alloc, itn, link_arr,
             cc3(alloc, "mach.toml: ", label, ".link must be an array of strings"));
@@ -668,6 +702,9 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     }
 
     val need_arr: *toml.Array = toml.get_array(sub, "need");
+    if (need_arr == nil && strict) {
+        ret R.err[ArtifactDef, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'need' (use [] for none)"));
+    }
     if (need_arr != nil) {
         val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr,
             cc3(alloc, "mach.toml: ", label, ".need must be an array of strings"));
@@ -680,7 +717,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     ret R.ok[ArtifactDef, str](a);
 }
 
-fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "profile");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -700,17 +737,17 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " must be a table"));
         }
         val sub: *toml.Table = ?v.data.table;
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_PROFILE);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_PROFILE, strict);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var pf: ProfileDef;
         pf.name = intern_unwrap(itn, name);
-        val res_opt: R.Result[MOpt, str] = parse_opt_level(alloc, name, sub);
+        val res_opt: R.Result[MOpt, str] = parse_opt_level(alloc, name, sub, strict);
         if (R.is_err[MOpt, str](res_opt)) { ret R.err[bool, str](R.unwrap_err[MOpt, str](res_opt)); }
         pf.opt      = R.unwrap_ok[MOpt, str](res_opt);
         pf.emit_ir  = bool_or(toml.get_bool(sub, "emit_ir"), false);
         pf.emit_asm = bool_or(toml.get_bool(sub, "emit_asm"), false);
-        val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub);
+        val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub, strict);
         if (R.is_err[bool, str](res_debug)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_debug)); }
         pf.debug    = R.unwrap_ok[bool, str](res_debug);
 
@@ -720,7 +757,7 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
     ret R.ok[bool, str](true);
 }
 
-fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "dep");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -744,7 +781,7 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
         if (toml.get(sub, "version") != nil) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".version is reserved for the registry era"));
         }
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_DEP);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_DEP, strict);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: DepDef;
@@ -756,9 +793,16 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
         if (has_git == has_path) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " needs exactly one source key: 'git' or 'path'"));
         }
+        val ref_s: str = toml.get_str(sub, "ref");
+        if (has_git && str_empty(ref_s) && strict) {
+            ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'ref' for git source"));
+        }
+        if (has_path && !str_empty(ref_s) && strict) {
+            ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".ref is not allowed for path sources"));
+        }
         d.git  = intern_opt_unwrap(itn, git_s);
         d.path = intern_opt_unwrap(itn, path_s);
-        d.ref  = intern_opt_unwrap(itn, toml.get_str(sub, "ref"));
+        d.ref  = intern_opt_unwrap(itn, ref_s);
 
         m.deps[i] = d;
         i = i + 1;
@@ -766,7 +810,7 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
     ret R.ok[bool, str](true);
 }
 
-fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "link");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -787,7 +831,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
         val sub: *toml.Table = ?v.data.table;
 
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_LINK);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_LINK, strict);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: LinkDef;
@@ -826,28 +870,35 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
             d.path = intern.STR_NIL;
         }
 
-        val res_os: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "os", label);
+        val res_os: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "os", label, strict);
         if (R.is_err[StrArr, str](res_os)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_os)); }
         val os_v: StrArr = R.unwrap_ok[StrArr, str](res_os);
+        if (!os_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'os' (use \"*\" for any)")); }
         d.os = os_v.items;
         d.os_count = os_v.count;
         d.os_present = os_v.present;
 
-        val res_isa: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "isa", label);
+        val res_isa: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "isa", label, strict);
         if (R.is_err[StrArr, str](res_isa)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_isa)); }
         val isa_v: StrArr = R.unwrap_ok[StrArr, str](res_isa);
+        if (!isa_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'isa' (use \"*\" for any)")); }
         d.isa = isa_v.items;
         d.isa_count = isa_v.count;
         d.isa_present = isa_v.present;
 
-        val res_abi: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "abi", label);
+        val res_abi: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "abi", label, strict);
         if (R.is_err[StrArr, str](res_abi)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_abi)); }
         val abi_v: StrArr = R.unwrap_ok[StrArr, str](res_abi);
+        if (!abi_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'abi' (use \"*\" for any)")); }
         d.abi = abi_v.items;
         d.abi_count = abi_v.count;
         d.abi_present = abi_v.present;
 
-        d.export = bool_or(toml.get_bool(sub, "export"), false);
+        val export_v: *toml.Value = toml.get(sub, "export");
+        if (export_v == nil && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'export'")); }
+        if (export_v == nil) { d.export = false; }
+        or (export_v.tag != toml.TYPE_BOOL) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".export must be a boolean")); }
+        or { d.export = export_v.data.boolean; }
 
         m.links[i] = d;
         i = i + 1;
@@ -855,7 +906,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
     ret R.ok[bool, str](true);
 }
 
-fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "step");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -876,10 +927,12 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
         val sub: *toml.Table = ?v.data.table;
 
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_STEP);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_STEP, strict);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: StepDef;
+        d.need       = nil;
+        d.need_count = 0;
         # the step name keys its stamp file, so it must be a plain identifier - a
         # '/' would break the stamp path and a '.' would collide owner.step keys (#1989).
         if (!is_valid_id(name)) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " name must be an identifier (letters, digits, '_', '-')")); }
@@ -926,6 +979,9 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
 
         val need_arr: *toml.Array = toml.get_array(sub, "need");
+        if (need_arr == nil && strict) {
+            ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'need' (use [] for none)"));
+        }
         if (need_arr != nil) {
             val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr,
                 cc3(alloc, "mach.toml: ", label, ".need must be an array of strings"));
@@ -933,10 +989,6 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
             val need_val: StrArr = R.unwrap_ok[StrArr, str](res_need);
             d.need = need_val.items;
             d.need_count = need_val.count;
-        }
-        or {
-            d.need = nil;
-            d.need_count = 0;
         }
 
         m.steps[i] = d;
@@ -1030,23 +1082,24 @@ fun seg_dup(alloc: *A.Allocator, tmpl: str, start: usize, end: usize) str {
     ret buf::str;
 }
 
+# the #1964 template variable set is closed and final: {project.out}, {target.name},
+# {profile.name}. no {name}/{ext} or bare {target}/{profile} aliases -- an executable
+# extension is written literally into the artifact's out, per the RFC.
 fun tmpl_value(alloc: *A.Allocator, tmpl: str, start: usize, end: usize, project_out: str,
-               target_name: str, profile_name: str, art_name: str, ext: str) R.Result[str, str] {
+               target_name: str, profile_name: str) R.Result[str, str] {
     if (seg_eq(tmpl, start, end, "project.out")) {
         # available everywhere except while expanding [project].out itself, where it
         # would be self-referential (project_out is passed empty there).
         if (str_empty(project_out)) { ret R.err[str, str]("mach.toml: '{project.out}' is not available in [project].out"); }
         ret R.ok[str, str](project_out);
     }
-    if (seg_eq(tmpl, start, end, "target.name") || seg_eq(tmpl, start, end, "target"))  { ret R.ok[str, str](target_name); }
-    if (seg_eq(tmpl, start, end, "profile.name") || seg_eq(tmpl, start, end, "profile")) { ret R.ok[str, str](profile_name); }
-    if (seg_eq(tmpl, start, end, "name"))    { ret R.ok[str, str](art_name); }
-    if (seg_eq(tmpl, start, end, "ext"))     { ret R.ok[str, str](ext); }
+    if (seg_eq(tmpl, start, end, "target.name"))  { ret R.ok[str, str](target_name); }
+    if (seg_eq(tmpl, start, end, "profile.name")) { ret R.ok[str, str](profile_name); }
     ret R.err[str, str](cc3(alloc, "mach.toml: unknown template variable '{", seg_dup(alloc, tmpl, start, end), "}'"));
 }
 
 pub fun expand(alloc: *A.Allocator, tmpl: str, project_out: str,
-               target_name: str, profile_name: str, art_name: str, ext: str) R.Result[str, str] {
+               target_name: str, profile_name: str) R.Result[str, str] {
     val n: usize = str_len(tmpl);
     var total: usize = 0;
     var i: usize = 0;
@@ -1055,7 +1108,7 @@ pub fun expand(alloc: *A.Allocator, tmpl: str, project_out: str,
             var ii: usize = i + 1;
             for (ii < n && tmpl[ii] != '}') { ii = ii + 1; }
             if (ii >= n) { ret R.err[str, str]("mach.toml: unterminated '{' in a path template"); }
-            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name, art_name, ext);
+            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name);
             if (R.is_err[str, str](res_value)) { ret R.err[str, str](R.unwrap_err[str, str](res_value)); }
             total = total + str_len(R.unwrap_ok[str, str](res_value));
             i = ii + 1;
@@ -1076,7 +1129,7 @@ pub fun expand(alloc: *A.Allocator, tmpl: str, project_out: str,
         if (tmpl[i] == '{') {
             var ii: usize = i + 1;
             for (ii < n && tmpl[ii] != '}') { ii = ii + 1; }
-            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name, art_name, ext);
+            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name);
             val value: str = R.unwrap_ok[str, str](res_value);
             val vl: usize = str_len(value);
             var iii: usize = 0;
@@ -1280,7 +1333,7 @@ fun join_path_canonical(alloc: *A.Allocator, a: str, b: str) str {
 fun link_token(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef, proj_out: str, tn: str, pn: str) R.Result[intern.StrId, str] {
     if (l.source == intern_unwrap(itn, "local")) {
         val raw_path: str = idstr(itn, l.path);
-        val expanded_r: R.Result[str, str] = expand(alloc, raw_path, proj_out, tn, pn, "", "");
+        val expanded_r: R.Result[str, str] = expand(alloc, raw_path, proj_out, tn, pn);
         if (R.is_err[str, str](expanded_r)) { ret R.err[intern.StrId, str](R.unwrap_err[str, str](expanded_r)); }
         val expanded: str = R.unwrap_ok[str, str](expanded_r);
         val res_int: R.Result[intern.StrId, str] = intern.intern(itn, expanded);
@@ -1304,7 +1357,7 @@ pub fun step_producing_out(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
         var oi: u32 = 0;
         for (oi < s.out_count) {
             val raw_out: str = idstr(itn, s.out[oi]);
-            val exp_r: R.Result[str, str] = expand(alloc, raw_out, proj_out, tn, pn, "", "");
+            val exp_r: R.Result[str, str] = expand(alloc, raw_out, proj_out, tn, pn);
             if (R.is_ok[str, str](exp_r)) {
                 val exp: str = R.unwrap_ok[str, str](exp_r);
                 val eq: bool = str_equals(exp, expanded_path);
@@ -1422,7 +1475,7 @@ pub fun plan_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
             for (li < a.link_count) {
                 val l: *LinkDef = find_link_by_name(m, a.link[li]);
                 if (l != nil && l.source == local_id && link_matches_target(itn, l, t)) {
-                    val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn, "", "");
+                    val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn);
                     if (R.is_ok[str, str](exp_r)) {
                         val exp: str = R.unwrap_ok[str, str](exp_r);
                         val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, tn, pn);
@@ -1497,7 +1550,7 @@ pub fun plan_export_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
     for (li < m.link_count) {
         val l: *LinkDef = ?m.links[li];
         if (l.export && l.source == local_id && link_matches_target(itn, l, t)) {
-            val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn, "", "");
+            val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn);
             if (R.is_ok[str, str](exp_r)) {
                 val exp: str = R.unwrap_ok[str, str](exp_r);
                 val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, tn, pn);
@@ -1570,20 +1623,11 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     if (R.is_err[str, str](res_target_name)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_target_name)); }
     val res_profile_name: R.Result[str, str] = must_lookup(itn, rp.name);
     if (R.is_err[str, str](res_profile_name)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_profile_name)); }
-    val res_art_name: R.Result[str, str] = must_lookup(itn, a.name);
-    if (R.is_err[str, str](res_art_name)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_art_name)); }
     val tn: str = R.unwrap_ok[str, str](res_target_name);
     val pn: str = R.unwrap_ok[str, str](res_profile_name);
-    val an: str = R.unwrap_ok[str, str](res_art_name);
-
-    val res_os_name: R.Result[str, str] = must_lookup(itn, rt.target.os);
-    if (R.is_err[str, str](res_os_name)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_os_name)); }
-    val os_name: str = R.unwrap_ok[str, str](res_os_name);
-    var ex: str = "";
-    if (str_equals(os_name, "windows")) { ex = ".exe"; }
 
     # Expand project out
-    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, pn, "", "");
+    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, pn);
     if (R.is_err[str, str](res_project_out)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_project_out)); }
     val proj_out: str = R.unwrap_ok[str, str](res_project_out);
 
@@ -1645,7 +1689,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
 
     # Resolve artifact relative path
     val art_out_tmpl: intern.StrId = a.out;
-    val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, pn, an, ex);
+    val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, pn);
     if (R.is_err[str, str](res_art_out)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_art_out)); }
     val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
 
@@ -1763,28 +1807,20 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
     if (R.is_err[str, str](res_target_name)) { ret R.err[bool, str](R.unwrap_err[str, str](res_target_name)); }
     val tn: str = R.unwrap_ok[str, str](res_target_name);
 
-    val res_os_name: R.Result[str, str] = must_lookup(itn, t.os);
-    if (R.is_err[str, str](res_os_name)) { ret R.err[bool, str](R.unwrap_err[str, str](res_os_name)); }
-    val os_name: str = R.unwrap_ok[str, str](res_os_name);
-    var ex: str = "";
-    if (str_equals(os_name, "windows")) { ex = ".exe"; }
-
     val res_paths: R.Result[*str, str] = A.allocate[str](alloc, m.artifact_count::usize);
     if (R.is_err[*str, str](res_paths)) { ret R.err[bool, str](R.unwrap_err[*str, str](res_paths)); }
     val paths: *str = R.unwrap_ok[*str, str](res_paths);
 
     # Expand project out
-    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, profile_name, "", "");
+    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, profile_name);
     if (R.is_err[str, str](res_project_out)) { ret R.err[bool, str](R.unwrap_err[str, str](res_project_out)); }
     val proj_out: str = R.unwrap_ok[str, str](res_project_out);
 
     var i: u32 = 0;
     for (i < m.artifact_count) {
         val a: *ArtifactDef = ?m.artifacts[i];
-        val res_art_name: R.Result[str, str] = must_lookup(itn, a.name);
-        if (R.is_err[str, str](res_art_name)) { ret R.err[bool, str](R.unwrap_err[str, str](res_art_name)); }
         val art_out_tmpl: intern.StrId = a.out;
-        val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, profile_name, R.unwrap_ok[str, str](res_art_name), ex);
+        val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, profile_name);
         if (R.is_err[str, str](res_art_out)) { ret R.err[bool, str](R.unwrap_err[str, str](res_art_out)); }
         val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
         paths[i] = join_path_canonical(alloc, proj_out, art_out_rel);
@@ -1819,7 +1855,7 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
 # --- test helper / scaffolding ---
 
 fun demo_src() str {
-    ret "[project]\nid = \"demo\"\nname = \"demo\"\ndescription = \"demo\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.ls]\nkind = \"bin\"\nentry = \"bin/ls.mach\"\nout = \"bin/ls\"\ntargets = [\"*\"]\n\n[artifact.cat]\nkind = \"bin\"\nentry = \"bin/cat.mach\"\nout = \"bin/cat\"\ntargets = [\"*\"]\n\n[profile.debug]\nopt = 0\n\n[profile.release]\nopt = 2\n\n[dep.mach-std]\ngit = \"https://github.com/briar-systems/mach-std\"\nref = \"v0.4.0\"\n";
+    ret "[project]\nid = \"demo\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.ls]\nkind = \"bin\"\nentry = \"bin/ls.mach\"\nout = \"bin/ls\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.cat]\nkind = \"bin\"\nentry = \"bin/cat.mach\"\nout = \"bin/cat\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[profile.debug]\nopt = 0\ndebug = false\n\n[profile.release]\nopt = 2\ndebug = false\n\n[dep.mach-std]\ngit = \"https://github.com/briar-systems/mach-std\"\nref = \"v0.4.0\"\n";
 }
 
 fun host_target_stanza(alloc: *A.Allocator, name: str) str {
@@ -1872,7 +1908,17 @@ fun tparse(alloc: *A.Allocator, itn: *intern.Interner, src: str) R.Result[Manife
     val tbl_r: R.Result[toml.Table, str] = toml.parse(alloc, src);
     if (R.is_err[toml.Table, str](tbl_r)) { ret R.err[Manifest, str](R.unwrap_err[toml.Table, str](tbl_r)); }
     var tbl: toml.Table = R.unwrap_ok[toml.Table, str](tbl_r);
-    ret parse(alloc, itn, ?tbl);
+    ret parse(alloc, itn, ?tbl, true);
+}
+
+# parse a manifest permissively, as a dependency's manifest is parsed: used to
+# exercise the runtime filter/resolve semantics on entries with absent axes, which
+# the strict root parser forbids.
+fun tparse_lenient(alloc: *A.Allocator, itn: *intern.Interner, src: str) R.Result[Manifest, str] {
+    val tbl_r: R.Result[toml.Table, str] = toml.parse(alloc, src);
+    if (R.is_err[toml.Table, str](tbl_r)) { ret R.err[Manifest, str](R.unwrap_err[toml.Table, str](tbl_r)); }
+    var tbl: toml.Table = R.unwrap_ok[toml.Table, str](tbl_r);
+    ret parse(alloc, itn, ?tbl, false);
 }
 
 test "mach.lang.manifest.is_valid_id" {
@@ -1927,30 +1973,23 @@ test "mach.lang.manifest.parse:missing_required_keys" {
     ret code;
 }
 
-test "mach.lang.manifest.parse:name_description_optional" {
+test "mach.lang.manifest.parse:name_description_rejected" {
     var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    # the #1964 shape omits name/description; a manifest without them parses, with
-    # both fields interned to STR_NIL. id/version/src/out stay required.
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
-    if (R.is_err[Manifest, str](a)) { code = 1; }
-    or {
-        var m: Manifest = R.unwrap_ok[Manifest, str](a);
-        if (m.name != intern.STR_NIL)        { code = 1; }
-        if (m.description != intern.STR_NIL) { code = 1; }
-        if (!str_equals(idstr(?itn, m.id), "x")) { code = 1; }
-    }
+    # the #1964 shape trims [project] to id/version/src/out; name/description are
+    # unknown keys in the strict root parse (#1971 flag-day).
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"App\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: unknown key 'name' in [project]")) { code = 1; }
 
-    # present name/description are still accepted and recorded verbatim
-    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"App\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
-    if (R.is_err[Manifest, str](b)) { code = 1; }
-    or {
-        var m: Manifest = R.unwrap_ok[Manifest, str](b);
-        if (!str_equals(idstr(?itn, m.name), "App")) { code = 1; }
-        if (!str_equals(idstr(?itn, m.description), "d")) { code = 1; }
-    }
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: unknown key 'description' in [project]")) { code = 1; }
+
+    # a dependency's manifest is parsed permissively, so pre-flag-day name/description
+    # are tolerated there.
+    val d: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"App\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (R.is_err[Manifest, str](d)) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }
@@ -1960,10 +1999,10 @@ test "mach.lang.manifest.parse:unknown_keys" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\nbogus=\"y\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\nbogus=\"y\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
     if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: unknown key 'bogus' in [project]")) { code = 1; }
 
-    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\nwat=\"z\"\n");
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\nwat=\"z\"\n");
     if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: unknown key 'wat' in [target.l]")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -1974,7 +2013,7 @@ test "mach.lang.manifest.parse:reserved_target_native" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.native]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.native]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
     if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: [target.native] is reserved; 'native' resolves to a declared target")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -1985,10 +2024,10 @@ test "mach.lang.manifest.parse:dep_conflict" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[dep.std]\nversion=\"1.0\"\n");
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[dep.std]\nversion=\"1.0\"\n");
     if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: [dep.std].version is reserved for the registry era")) { code = 1; }
 
-    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[dep.std]\ngit=\"u\"\npath=\"p\"\n");
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[dep.std]\ngit=\"u\"\npath=\"p\"\n");
     if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: [dep.std] needs exactly one source key: 'git' or 'path'")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -1999,7 +2038,7 @@ test "mach.lang.manifest.parse:backslash_rejected" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"a\\\\b\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"a\\\\b\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
     if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: [project].src contains a '\\\\'; manifest paths use '/'")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -2010,7 +2049,7 @@ test "mach.lang.manifest.resolve_build_unit:native_resolution" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n";
+    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     val st:  str = host_target_stanza(?alloc, "foreign");
     src = cc(?alloc, src, st);
 
@@ -2041,7 +2080,7 @@ test "mach.lang.manifest.resolve_build_unit:default_profile" {
     var code: i32 = 0;
 
     # only [profile.debug] declared -> the empty profile selector resolves 'debug'
-    var s1: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\n[profile.debug]\nopt=0\n";
+    var s1: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink = []\nneed = []\n[profile.debug]\nopt=0\ndebug = false\n";
     s1 = cc(?alloc, s1, host_target_stanza(?alloc, "h"));
     val r1: R.Result[Manifest, str] = tparse(?alloc, ?itn, s1);
     if (R.is_err[Manifest, str](r1)) { code = 1; }
@@ -2053,7 +2092,7 @@ test "mach.lang.manifest.resolve_build_unit:default_profile" {
     }
 
     # no [profile] section at all -> the conventional 'debug' default, still clean
-    var s2: str = "[project]\nid=\"y\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\n";
+    var s2: str = "[project]\nid=\"y\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink = []\nneed = []\n";
     s2 = cc(?alloc, s2, host_target_stanza(?alloc, "h"));
     val r2: R.Result[Manifest, str] = tparse(?alloc, ?itn, s2);
     if (R.is_err[Manifest, str](r2)) { code = 1; }
@@ -2072,7 +2111,7 @@ test "mach.lang.manifest.resolve_build_unit:native_resolution_multi_match" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n";
+    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     src = cc(?alloc, src, host_target_stanza(?alloc, "alpha"));
     src = cc(?alloc, src, host_target_stanza(?alloc, "beta"));
 
@@ -2092,7 +2131,7 @@ test "mach.lang.manifest.resolve_build_unit:native_resolution_exact" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n";
+    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     src = cc(?alloc, src, "[target.foreign]\nisa = \"nonesuch\"\nos = \"nonesuch\"\nabi = \"x\"\n");
     src = cc(?alloc, src, host_target_stanza(?alloc, "host"));
 
@@ -2117,7 +2156,7 @@ test "mach.lang.manifest.resolve_build_unit:collision_detection" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nname=\"x\"\ndescription=\"x\"\nversion=\"0.1.0\"\nsrc=\"src\"\nout=\"bin/app\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.a]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"app\"\ntargets = [\"*\"]\n[artifact.b]\nkind=\"bin\"\nentry=\"b.mach\"\nout=\"app\"\ntargets = [\"*\"]\n");
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"0.1.0\"\nsrc=\"src\"\nout=\"bin/app\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.a]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[artifact.b]\nkind=\"bin\"\nentry=\"b.mach\"\nout=\"app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n");
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
@@ -2125,7 +2164,7 @@ test "mach.lang.manifest.resolve_build_unit:collision_detection" {
         if (R.is_ok[bool, str](cr) || !str_equals(R.unwrap_err[bool, str](cr), "mach.toml: artifacts 'a' and 'b' collide on output path 'bin/app/app'")) { code = 1; }
     }
 
-    val res_clean: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nname=\"x\"\ndescription=\"x\"\nversion=\"0.1.0\"\nsrc=\"src\"\nout=\"out/{target.name}/{profile.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app1\"\ntargets = [\"*\"]\n[artifact.tool]\nkind=\"bin\"\nentry=\"tool.mach\"\nout=\"bin/app2\"\ntargets = [\"*\"]\n");
+    val res_clean: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"0.1.0\"\nsrc=\"src\"\nout=\"out/{target.name}/{profile.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app1\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[artifact.tool]\nkind=\"bin\"\nentry=\"tool.mach\"\nout=\"bin/app2\"\ntargets = [\"*\"]\nlink = []\nneed = []\n");
     if (R.is_err[Manifest, str](res_clean)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](res_clean);
@@ -2141,10 +2180,10 @@ test "mach.lang.manifest.resolve_build_unit:profile_debug_strict" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\n[profile.debug]\nopt = 9\n");
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[profile.debug]\nopt = 9\ndebug = false\n");
     if (R.is_ok[Manifest, str](a) || !str_contains(R.unwrap_err[Manifest, str](a), "opt must be 0, 1, or 2")) { code = 1; }
 
-    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\n[profile.debug]\ndebug = 9\n");
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[profile.debug]\nopt = 0\ndebug = 9\n");
     if (R.is_ok[Manifest, str](b) || !str_contains(R.unwrap_err[Manifest, str](b), "debug must be a boolean")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -2176,7 +2215,7 @@ test "mach.lang.manifest.resolve_build_unit:links" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[link.sys]\nsource=\"system\"\nname=\"c\"\nos=[\"linux\"]\n[link.local_lib]\nsource=\"local\"\npath=\"lib/mylib.a\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = [\"sys\", \"local_lib\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[link.sys]\nsource=\"system\"\nname=\"c\"\nos=[\"linux\"]\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[link.local_lib]\nsource=\"local\"\npath=\"lib/mylib.a\"\nos=[\"*\"]\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = [\"sys\", \"local_lib\"]\nneed = []\n";
     val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
@@ -2215,7 +2254,7 @@ test "mach.lang.manifest.parse:link_filter_string_form" {
     # exercise the string form on the other two axes. this pins the #1969 fix: a
     # string filter is no longer silently ignored (degraded to match-any).
     val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[target.arm]\nisa=\"aarch64\"\nos=\"linux\"\nabi=\"aapcs64\"\n[link.os_str]\nsource=\"system\"\nname=\"a\"\nos=\"linux\"\n[link.os_arr]\nsource=\"system\"\nname=\"b\"\nos=[\"linux\"]\n[link.os_star]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\n[link.os_absent]\nsource=\"system\"\nname=\"d\"\n[link.isa_str]\nsource=\"system\"\nname=\"e\"\nisa=\"x86_64\"\n[link.abi_str]\nsource=\"system\"\nname=\"f\"\nabi=\"sysv64\"\n";
-    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    val res_manifest: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
@@ -2252,15 +2291,15 @@ test "mach.lang.manifest.expand:project_out" {
     var code: i32 = 0;
 
     # {project.out} substitutes the expanded project out
-    val r1: R.Result[str, str] = expand(?alloc, "{project.out}/obj/x.o", "out/linux/release", "linux", "release", "", "");
+    val r1: R.Result[str, str] = expand(?alloc, "{project.out}/obj/x.o", "out/linux/release", "linux", "release");
     if (R.is_err[str, str](r1) || !str_equals(R.unwrap_ok[str, str](r1), "out/linux/release/obj/x.o")) { code = 1; }
 
     # referencing it while expanding [project].out itself (project_out empty) is an error
-    val r2: R.Result[str, str] = expand(?alloc, "{project.out}/x", "", "linux", "release", "", "");
+    val r2: R.Result[str, str] = expand(?alloc, "{project.out}/x", "", "linux", "release");
     if (R.is_ok[str, str](r2) || !str_contains(R.unwrap_err[str, str](r2), "not available in [project].out")) { code = 1; }
 
     # an unknown variable is still a strict error
-    val r3: R.Result[str, str] = expand(?alloc, "{bogus}", "o", "t", "p", "", "");
+    val r3: R.Result[str, str] = expand(?alloc, "{bogus}", "o", "t", "p");
     if (R.is_ok[str, str](r3) || !str_contains(R.unwrap_err[str, str](r3), "unknown template variable")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -2272,7 +2311,7 @@ test "mach.lang.manifest.resolve_build_unit:local_project_out" {
     var code: i32 = 0;
 
     # a local link path using {project.out} resolves to the expanded project out
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.obj]\nsource=\"local\"\npath=\"{project.out}/obj/shim.o\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = [\"obj\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.obj]\nsource=\"local\"\npath=\"{project.out}/obj/shim.o\"\nos=[\"*\"]\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = [\"obj\"]\nneed = []\n";
     val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
@@ -2294,7 +2333,7 @@ test "mach.lang.manifest.local_path_demanded_by_step" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[step.shim]\ncmd=\"cc -c shim.c\"\nin=[\"shim.c\"]\nout=[\"{project.out}/obj/shim.o\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[step.shim]\ncmd=\"cc -c shim.c\"\nin=[\"shim.c\"]\nout=[\"{project.out}/obj/shim.o\"]\nneed=[]\n";
     val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
@@ -2319,7 +2358,7 @@ test "mach.lang.manifest.plan_steps" {
     var code: i32 = 0;
 
     val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.obj]\nsource=\"local\"\npath=\"{project.out}/o/a.o\"\nos=\"*\"\n[link.win]\nsource=\"local\"\npath=\"{project.out}/o/w.o\"\nos=\"windows\"\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[\"obj\",\"win\"]\nneed=[\"gen\"]\n[step.compile]\ncmd=\"cc\"\nin=[\"a.c\"]\nout=[\"{project.out}/o/a.o\"]\n[step.winc]\ncmd=\"cc\"\nin=[\"w.c\"]\nout=[\"{project.out}/o/w.o\"]\n[step.gen]\ncmd=\"g\"\nin=[\"g.in\"]\nout=[\"{project.out}/g.h\"]\nneed=[\"dep\"]\n[step.dep]\ncmd=\"d\"\nin=[\"d.in\"]\nout=[\"{project.out}/d.o\"]\n";
-    val rm: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    val rm: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](rm)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](rm);
@@ -2361,7 +2400,7 @@ test "mach.lang.manifest.plan_steps:cycle" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nneed=[\"a\"]\n[step.a]\ncmd=\"x\"\nin=[\"i\"]\nout=[\"{project.out}/a.o\"]\nneed=[\"b\"]\n[step.b]\ncmd=\"y\"\nin=[\"i\"]\nout=[\"{project.out}/b.o\"]\nneed=[\"a\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[]\nneed=[\"a\"]\n[step.a]\ncmd=\"x\"\nin=[\"i\"]\nout=[\"{project.out}/a.o\"]\nneed=[\"b\"]\n[step.b]\ncmd=\"y\"\nin=[\"i\"]\nout=[\"{project.out}/b.o\"]\nneed=[\"a\"]\n";
     val rm: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](rm)) { code = 1; }
     or {
@@ -2390,7 +2429,7 @@ test "mach.lang.manifest.plan_export_steps" {
     var code: i32 = 0;
 
     val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.exp]\nsource=\"local\"\npath=\"{project.out}/o/m.o\"\nos=\"*\"\nexport=true\n[link.noexp]\nsource=\"local\"\npath=\"{project.out}/o/n.o\"\nos=\"*\"\nexport=false\n[link.win]\nsource=\"local\"\npath=\"{project.out}/o/w.o\"\nos=\"windows\"\nexport=true\n[step.mk]\ncmd=\"cc\"\nin=[\"m.c\"]\nout=[\"{project.out}/o/m.o\"]\n[step.no]\ncmd=\"cc\"\nin=[\"n.c\"]\nout=[\"{project.out}/o/n.o\"]\n[step.winmk]\ncmd=\"cc\"\nin=[\"w.c\"]\nout=[\"{project.out}/o/w.o\"]\n";
-    val rm: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    val rm: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](rm)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](rm);
@@ -2428,8 +2467,85 @@ test "mach.lang.manifest.parse:id_and_out_validation" {
     val ok_id: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"a-b_2\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n");
     if (R.is_err[Manifest, str](ok_id)) { code = 1; }
     # a '*' in a step out is rejected (outputs are concrete)
-    val bad_out: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[step.s]\ncmd=\"cc\"\nin=[\"a.c\"]\nout=[\"{project.out}/*.o\"]\n");
+    val bad_out: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[step.s]\ncmd=\"cc\"\nin=[\"a.c\"]\nout=[\"{project.out}/*.o\"]\nneed=[]\n");
     if (R.is_ok[Manifest, str](bad_out)) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #1971 no-defaults totality: an absent field of a declared table is a strict-parse
+# error in the root manifest, one per declared table kind.
+test "mach.lang.manifest.parse:strict_totality" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val head: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n";
+
+    # profile spells opt + debug
+    val p_opt: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\ndebug=false\n"));
+    if (R.is_ok[Manifest, str](p_opt) || !str_contains(R.unwrap_err[Manifest, str](p_opt), "[profile.p] is missing required key 'opt'")) { code = 1; }
+    val p_dbg: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\n"));
+    if (R.is_ok[Manifest, str](p_dbg) || !str_contains(R.unwrap_err[Manifest, str](p_dbg), "[profile.p] is missing required key 'debug'")) { code = 1; }
+
+    # artifact spells link + need
+    val a_link: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[artifact.a]\nkind=\"bin\"\nentry=\"m.mach\"\nout=\"bin/a\"\ntargets=[\"*\"]\n"));
+    if (R.is_ok[Manifest, str](a_link) || !str_contains(R.unwrap_err[Manifest, str](a_link), "missing required key 'link'")) { code = 1; }
+    val a_need: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[artifact.a]\nkind=\"bin\"\nentry=\"m.mach\"\nout=\"bin/a\"\ntargets=[\"*\"]\nlink=[]\n"));
+    if (R.is_ok[Manifest, str](a_need) || !str_contains(R.unwrap_err[Manifest, str](a_need), "missing required key 'need'")) { code = 1; }
+
+    # link spells os / isa / abi / export
+    val l_os: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[link.l]\nsource=\"system\"\nname=\"c\"\n"));
+    if (R.is_ok[Manifest, str](l_os) || !str_contains(R.unwrap_err[Manifest, str](l_os), "missing required key 'os'")) { code = 1; }
+    val l_isa: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[link.l]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\n"));
+    if (R.is_ok[Manifest, str](l_isa) || !str_contains(R.unwrap_err[Manifest, str](l_isa), "missing required key 'isa'")) { code = 1; }
+    val l_abi: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[link.l]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\nisa=[\"*\"]\n"));
+    if (R.is_ok[Manifest, str](l_abi) || !str_contains(R.unwrap_err[Manifest, str](l_abi), "missing required key 'abi'")) { code = 1; }
+    val l_exp: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[link.l]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\n"));
+    if (R.is_ok[Manifest, str](l_exp) || !str_contains(R.unwrap_err[Manifest, str](l_exp), "missing required key 'export'")) { code = 1; }
+
+    # step spells need; a git dep spells ref
+    val s_need: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[step.s]\ncmd=\"c\"\nin=[\"i\"]\nout=[\"o\"]\n"));
+    if (R.is_ok[Manifest, str](s_need) || !str_contains(R.unwrap_err[Manifest, str](s_need), "missing required key 'need'")) { code = 1; }
+    val d_ref: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[dep.d]\ngit=\"u\"\n"));
+    if (R.is_ok[Manifest, str](d_ref) || !str_contains(R.unwrap_err[Manifest, str](d_ref), "missing required key 'ref' for git source")) { code = 1; }
+
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #1971: filter axes take canonical os/isa/abi values or "*"; "*" (any) is legal and
+# a non-canonical spelling is rejected rather than silently never-matching.
+test "mach.lang.manifest.parse:canonical_and_star" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val head: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n";
+
+    # a non-canonical os is a strict error
+    val bad: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[link.l]\nsource=\"system\"\nname=\"c\"\nos=\"windoze\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n"));
+    if (R.is_ok[Manifest, str](bad) || !str_contains(R.unwrap_err[Manifest, str](bad), "non-canonical value 'windoze'")) { code = 1; }
+
+    # "*" on every axis and targets = ["*"] are the explicit-any token and legal
+    val ok: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[artifact.a]\nkind=\"bin\"\nentry=\"m.mach\"\nout=\"bin/a\"\ntargets=[\"*\"]\nlink=[\"c\"]\nneed=[]\n[link.c]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n"));
+    if (R.is_err[Manifest, str](ok)) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #1971: the template variable set is closed to {project.out}/{target.name}/
+# {profile.name}; the dropped {name}/{ext} aliases are now unknown (no silent empty).
+test "mach.lang.manifest.expand:closed_set" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val ext: R.Result[str, str] = expand(?alloc, "bin/app{ext}", "out", "linux", "release");
+    if (R.is_ok[str, str](ext) || !str_contains(R.unwrap_err[str, str](ext), "unknown template variable")) { code = 1; }
+    val nm: R.Result[str, str] = expand(?alloc, "test/{name}", "out", "linux", "release");
+    if (R.is_ok[str, str](nm) || !str_contains(R.unwrap_err[str, str](nm), "unknown template variable")) { code = 1; }
+    # the closed set still resolves
+    val good: R.Result[str, str] = expand(?alloc, "{project.out}/{target.name}/{profile.name}", "o", "linux", "release");
+    if (R.is_err[str, str](good) || !str_equals(R.unwrap_ok[str, str](good), "o/linux/release")) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }
@@ -2442,7 +2558,7 @@ test "mach.lang.manifest.resolve_test_libs:union" {
     # `mach test` links the union of every artifact's referenced entries, filtered
     # to the native target and deduplicated: app->{a,shared}, tool->{b,shared,c};
     # c filters out (windows-only) and shared dedups, so the union is {a,b,shared}.
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.a]\nsource=\"system\"\nname=\"liba\"\nos=\"*\"\n[link.b]\nsource=\"system\"\nname=\"libb\"\nos=\"linux\"\n[link.c]\nsource=\"system\"\nname=\"libc\"\nos=\"windows\"\n[link.shared]\nsource=\"system\"\nname=\"libshared\"\nos=\"*\"\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[\"a\",\"shared\"]\n[artifact.tool]\nkind=\"bin\"\nentry=\"t.mach\"\nout=\"bin/tool\"\ntargets=[\"*\"]\nlink=[\"b\",\"shared\",\"c\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.a]\nsource=\"system\"\nname=\"liba\"\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[link.b]\nsource=\"system\"\nname=\"libb\"\nos=\"linux\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[link.c]\nsource=\"system\"\nname=\"libc\"\nos=\"windows\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[link.shared]\nsource=\"system\"\nname=\"libshared\"\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[\"a\",\"shared\"]\nneed=[]\n[artifact.tool]\nkind=\"bin\"\nentry=\"t.mach\"\nout=\"bin/tool\"\ntargets=[\"*\"]\nlink=[\"b\",\"shared\",\"c\"]\nneed=[]\n";
     val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
@@ -2500,7 +2616,7 @@ test "mach.lang.manifest.parse:link_filter_empty_array_matches_nothing" {
     # explicit os = [] says "none" (#1964) and matches NO cell, distinct from an
     # absent axis which matches any until strict totality (#1971).
     val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[target.arm]\nisa=\"aarch64\"\nos=\"linux\"\nabi=\"aapcs64\"\n[link.none]\nsource=\"system\"\nname=\"a\"\nos=[]\n[link.absent]\nsource=\"system\"\nname=\"b\"\n";
-    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    val res_manifest: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
@@ -2527,7 +2643,7 @@ test "mach.lang.manifest.resolve_build_unit:artifact_target_filter" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"linux\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"linux\"]\nlink = []\nneed = []\n";
     val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -456,7 +456,11 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
             || str_equals(k, "targets") || str_equals(k, "link") || str_equals(k, "need");
     }
     if (kind == TK_PROFILE) {
-        ret str_equals(k, "opt") || str_equals(k, "emit_ir") || str_equals(k, "emit_asm") || str_equals(k, "debug");
+        if (str_equals(k, "opt") || str_equals(k, "debug")) { ret true; }
+        # emit_ir/emit_asm are CLI-only (--emit-ir/--emit-asm); like name/description
+        # they are pre-flag-day keys tolerated off-root, an unknown key as root (#1971).
+        if (!as_root && (str_equals(k, "emit_ir") || str_equals(k, "emit_asm"))) { ret true; }
+        ret false;
     }
     if (kind == TK_DEP) {
         ret str_equals(k, "git") || str_equals(k, "path") || str_equals(k, "ref");
@@ -489,10 +493,6 @@ fun check_path(alloc: *A.Allocator, value: str, field: str) R.Result[bool, str] 
     ret R.ok[bool, str](true);
 }
 
-fun bool_or(o: O.Option[bool], default: bool) bool {
-    if (O.is_some[bool](o)) { ret O.unwrap[bool](o); }
-    ret default;
-}
 
 fun first_nonempty(a: str, b: str) str {
     if (str_empty(a)) { ret b; }
@@ -751,8 +751,10 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
         val res_opt: R.Result[MOpt, str] = parse_opt_level(alloc, name, sub, as_root);
         if (R.is_err[MOpt, str](res_opt)) { ret R.err[bool, str](R.unwrap_err[MOpt, str](res_opt)); }
         pf.opt      = R.unwrap_ok[MOpt, str](res_opt);
-        pf.emit_ir  = bool_or(toml.get_bool(sub, "emit_ir"), false);
-        pf.emit_asm = bool_or(toml.get_bool(sub, "emit_asm"), false);
+        # emit_ir/emit_asm are CLI-only (--emit-ir/--emit-asm); a declared profile is
+        # opt+debug (#1971). the keys are tolerated off-root but never read here.
+        pf.emit_ir  = false;
+        pf.emit_asm = false;
         val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub, as_root);
         if (R.is_err[bool, str](res_debug)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_debug)); }
         pf.debug    = R.unwrap_ok[bool, str](res_debug);
@@ -1992,9 +1994,14 @@ test "mach.lang.manifest.parse:name_description_rejected" {
     val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
     if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: unknown key 'description' in [project]")) { code = 1; }
 
-    # a dependency's manifest is parsed permissively, so pre-flag-day name/description
-    # are tolerated there.
-    val d: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"App\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    # emit_ir/emit_asm are CLI-only now; a declared profile is opt+debug, so they are
+    # unknown keys as root (#1971) -- same category as name/description.
+    val e: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[profile.debug]\nopt=0\ndebug=false\nemit_ir=true\n");
+    if (R.is_ok[Manifest, str](e) || !str_equals(R.unwrap_err[Manifest, str](e), "mach.toml: unknown key 'emit_ir' in [profile.debug]")) { code = 1; }
+
+    # a dependency's manifest is parsed permissively, so all of these pre-flag-day
+    # keys (name/description/emit_ir/emit_asm) are tolerated there.
+    val d: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"App\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[profile.debug]\nopt=0\ndebug=false\nemit_ir=true\nemit_asm=true\n");
     if (R.is_err[Manifest, str](d)) { code = 1; }
     arena.dnit(?ar);
     ret code;

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -37,6 +37,18 @@ pub val ABI_AAPCS64: u32 = 3;
 # a0-a7 and float fa0-fa7 register banks
 pub val ABI_LP64: u32 = 4;
 
+# map a calling-convention name to its canonical id
+# ---
+# name: abi name ("sysv64", "win64", "aapcs64", "lp64")
+# ret:  the matching ABI_* id, or ABI_UNKNOWN if unrecognized
+pub fun abi_id_for(name: str) u32 {
+    if (str_equals(name, "sysv64"))  { ret ABI_SYSV; }
+    if (str_equals(name, "win64"))   { ret ABI_WIN64; }
+    if (str_equals(name, "aapcs64")) { ret ABI_AAPCS64; }
+    if (str_equals(name, "lp64"))    { ret ABI_LP64; }
+    ret ABI_UNKNOWN;
+}
+
 # how a single parameter or return value is classified for passing
 pub def ParamClass: u8;
 


### PR DESCRIPTION
Closes #1971. Closes #1967.

The #1964 strict flag-day: the parser enforces no-defaults totality on the root manifest, and every first-party manifest is re-touched to the final shape in the same PR.

### Parser (strict, root-only)
- **Totality** — a declared table spells every field or it's a strict-parse error: profiles spell `opt`+`debug` (only); artifacts spell `link`+`need`; link entries spell `os`/`isa`/`abi`/`export`; steps spell `need`; a `git` dep spells `ref` (a `path` dep forbids it).
- **`[project]` trim** to `id`/`version`/`src`/`out` — `name`/`description` are now unknown keys.
- **`emit_ir`/`emit_asm` are CLI-only** (`--emit-ir`/`--emit-asm` global flags), closing the optional-key hole in profile totality: like `name`/`description` they are tolerated off-root and an unknown-key error as root.
- **Canonical filter axes** — `os`/`isa`/`abi` take a recognized value or `"*"`; a non-canonical spelling (e.g. `os = "windoze"`) is rejected rather than silently never-matching. `"*"` (and `targets = ["*"]`) are the explicit-any token and legal. `abi.abi_id_for` added to mirror the os/isa lookups.
- **Closed template set** — `{project.out}`/`{target.name}`/`{profile.name}` only; the `{name}`/`{ext}` and bare `{target}`/`{profile}` aliases are dropped (an executable extension is written literally per the RFC), so `expand` no longer takes `art_name`/`ext`.
- **Root-only enforcement (`as_root`)** — `parse` takes an `as_root` flag naming the boundary: root parses (load_config, matrix, resolve_artifact_path, clean) pass true and enforce totality; dependency parses (cascade libs, transitive deps, step dep-collection) pass false and are permissive. A consumer reads only a dep's export surface (id, exported link entries, the steps they demand), so its build is never gated on a dep's migration state — enforcement travels with the declaring unit, which enforces its own totality on ITS root builds. **This is what makes the flag-day landable before the #1979 ecosystem sweep**: the unswept mach-std still parses as a dependency. Unknown-key rejection is NOT part of the mode: a genuinely unknown key is rejected on both paths; only the pre-flag-day `[project]` `name`/`description` and profile `emit_ir`/`emit_asm` keys relax off-root.

### Re-touch (same PR)
This repo's `mach.toml`, all 27 int/ + dbg/ fixture manifests, and the `mach init` scaffold are RFC-exact. Fixture/repo profiles use `debug = false` to preserve the `-g`-driven debug-info behavior the dbg additive guard checks; the init scaffold shows the canonical `debug = true`/`false` split.

### Docs (rides #1977 — sentence for the docs worker to lift verbatim)
> Manifest strictness is scoped to the manifest being **built**: mach enforces the no-defaults totality rules on your project's own `mach.toml` (the root of the build), but parses a **dependency's** `mach.toml` permissively, reading only its export surface (project id, `export = true` link entries, and the steps those entries demand). A dependency's own totality is enforced when that dependency is built as a root — so a project need not wait for its dependencies to migrate, and historical commit pins keep resolving. Unknown keys are always rejected, in a root or a dependency.

### Verification
- Unit suite through the freshly built compiler: **567 passed** (dev baseline 563 + 4 new: `parse:strict_totality`, `parse:canonical_and_star`, `parse:root_reject_dep_consume`, `expand:closed_set`; `parse:name_description_optional` repurposed to `:name_description_rejected`, extended to cover `emit_ir`/`emit_asm`). Fixture re-touch changes no counts.
- Self-host fixpoint: gen2 is byte-identical to gen1; gen2 suite 567/567.
- int linux: **42/42**. dbg: 21 target builds pass.
- `mach init` scaffold is RFC-exact and builds under the strict compiler.
- Contract pin (`parse:root_reject_dep_consume`): a mach-std-shaped non-total manifest is rejected as a root build yet consumed cleanly as a dependency, its exported entry filtering correctly.