### PR TITLE
feat(link): static archive emission (#1980 phase 1)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -54,6 +54,7 @@ use mach.lang.session;
 use mach.lang.source;
 use mach.lang.target;
 use mach.lang.target.of;
+use mach.lang.target.of.ar;
 
 # the outcome of a single `build` invocation
 # ---
@@ -1526,6 +1527,115 @@ fun subst_name(tmpl: str, name: str, out: *u8, cap: usize) usize {
 # images:       the per-module object images to write
 # out_path:     receives the owned produced-artifact path on success
 # ret:          0 on success, 1 on a user error, 2 on an internal error
+# free the per-member read buffers and symbol-name arrays, then the member array
+fun free_members(alloc: *A.Allocator, members: *ar.ArMember, cap: u32) {
+    var i: u32 = 0;
+    for (i < cap) {
+        if (members[i].data != nil) { A.deallocate[u8](alloc, members[i].data, (members[i].len + 1)::usize); }
+        if (members[i].sym_names != nil && members[i].sym_count > 0) { A.deallocate[str](alloc, members[i].sym_names, members[i].sym_count::usize); }
+        i = i + 1;
+    }
+    A.deallocate[ar.ArMember](alloc, members, cap::usize);
+}
+
+# fill `member.sym_names` with the object image's defined global symbol names (for the
+# archive symbol index): a symbol is global (`SYM_OBJ_FLAG_GLOBAL`) and defined here
+# (`section != SECTION_EXTERNAL`). names resolve against the image's own interner.
+fun collect_defined_globals(p: *driver.Project, img: *of.ObjectImage, member: *ar.ArMember) bool {
+    member.sym_names = nil;
+    member.sym_count = 0;
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < img.symbol_count) {
+        if ((img.symbols[i].flags & of.SYM_OBJ_FLAG_GLOBAL) != 0 && img.symbols[i].section != of.SECTION_EXTERNAL) { n = n + 1; }
+        i = i + 1;
+    }
+    if (n == 0) { ret true; }
+    val res: R.Result[*str, str] = A.allocate[str](p.s.alloc, n::usize);
+    if (R.is_err[*str, str](res)) { ret false; }
+    val names: *str = R.unwrap_ok[*str, str](res);
+    var w: u32 = 0;
+    i = 0;
+    for (i < img.symbol_count) {
+        if ((img.symbols[i].flags & of.SYM_OBJ_FLAG_GLOBAL) != 0 && img.symbols[i].section != of.SECTION_EXTERNAL) {
+            val nm: O.Option[str] = intern.lookup(img.interner, img.symbols[i].name);
+            if (O.is_some[str](nm)) { names[w] = O.unwrap[str](nm); w = w + 1; }
+        }
+        i = i + 1;
+    }
+    member.sym_names = names;
+    member.sym_count = w;
+    ret true;
+}
+
+# archive the artifact's per-module objects into a static `ar` library at its declared
+# `out` (#1980 phase 1). members are the freshly written `.o` files, each contributing
+# its defined global symbols to the archive symbol index. Sets `*out_path` to the
+# archive path on success. `paths` must still be live (the objects are read here).
+# ---
+# p:            the project carrying the module graph and session
+# images:       the per-module codegen images, indexed by module id
+# paths:        the written per-module object paths, indexed by topo position
+# root:         the resolved project root directory
+# out_override: the `-o` artifact path, or nil to use the resolved path
+# out_path:     receives the owned archive path on success
+# ret:          0 on success, 1 on a user error, 2 on an internal error
+fun emit_static_archive(p: *driver.Project, images: *of.ObjectImage, paths: **u8, root: *u8, out_override: *u8, out_path: **u8) i64 {
+    val len: u32 = p.topo_len;
+
+    var archive: [4096]u8;
+    if (out_override != nil) {
+        util.path_into(?archive[0], 4096, root, out_override);
+    }
+    or {
+        val opt_bin: O.Option[str] = intern.lookup(?p.s.interner, p.config.bin_out);
+        if (O.is_none[str](opt_bin) || str_empty(O.unwrap[str](opt_bin))) {
+            print.eprint("error: selected artifact has no output path; set the `out` template in mach.toml\n");
+            ret 1;
+        }
+        join_into_str(?archive[0], 4096, root, O.unwrap[str](opt_bin));
+    }
+    if (!util.ensure_parents(?archive[0])) {
+        print.eprint("error: failed to create library directory\n");
+        ret 2;
+    }
+
+    val res_mem: R.Result[*ar.ArMember, str] = A.allocate[ar.ArMember](p.s.alloc, len::usize);
+    if (R.is_err[*ar.ArMember, str](res_mem)) { print.eprint("error: out of memory\n"); ret 2; }
+    val members: *ar.ArMember = R.unwrap_ok[*ar.ArMember, str](res_mem);
+    var i: u32 = 0;
+    for (i < len) { members[i].name = ""; members[i].data = nil; members[i].len = 0; members[i].sym_names = nil; members[i].sym_count = 0; i = i + 1; }
+
+    i = 0;
+    for (i < len) {
+        val mid: session.ModuleId    = p.topo[i];
+        val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
+        val fqn_opt: O.Option[str]   = intern.lookup(?p.s.interner, m.fqn);
+        if (O.is_none[str](fqn_opt)) { free_members(p.s.alloc, members, len); print.eprint("error: module FQN not interned\n"); ret 2; }
+        members[i].name = O.unwrap[str](fqn_opt);
+
+        val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(p.s.alloc, paths[i]::str);
+        if (R.is_err[filesystem.Buffer, str](rr)) { free_members(p.s.alloc, members, len); print.eprint("error: cannot read object for archive\n"); ret 2; }
+        val b: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rr);
+        members[i].data = b.data;
+        members[i].len  = b.len;
+
+        if (!collect_defined_globals(p, ?images[mid::u32], ?members[i])) { free_members(p.s.alloc, members, len); print.eprint("error: out of memory\n"); ret 2; }
+        i = i + 1;
+    }
+
+    val wr: R.Result[bool, str] = ar.write_archive(p.s.alloc, members, len, util.cstr_str(?archive[0]));
+    free_members(p.s.alloc, members, len);
+    if (R.is_err[bool, str](wr)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](wr));
+        print.eprint("\n");
+        ret 2;
+    }
+    @out_path = dup_cstr(p.s.alloc, ?archive[0]);
+    ret 0;
+}
+
 fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
                   out_override: *u8,
                   argc: usize, argv: **u8, marks: *bool,
@@ -1556,9 +1666,18 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
     if (obj_code != 0) { ret obj_code; }
     var len: u32 = p.topo_len;
 
-    # library mode (or `--emit obj`): the per-module objects are the deliverable;
-    # do not link an executable.
+    # library mode (or `--emit obj`): the per-module objects are the deliverable; do
+    # not link an executable. a `kind = "static"` artifact additionally archives those
+    # objects into a real `ar` library at its declared `out` (#1980). `--emit obj` and
+    # (phase 2) `kind = "shared"` keep the loose-objects deliverable unchanged.
     if (te.mode == driver.MODE_LIBRARY || emit_obj) {
+        if (te.mode == driver.MODE_LIBRARY && !emit_obj && te.lib_kind == manifest.LIBKIND_STATIC) {
+            val arc_code: i64 = emit_static_archive(p, images, paths, root, out_override, out_path);
+            free_paths(p.s.alloc, paths, len, len);
+            if (arc_code != 0) { ret arc_code; }
+            readout.phase_end(p.s.readout, readout.PH_LINK, 1, "archive", "archives");
+            ret 0;
+        }
         free_paths(p.s.alloc, paths, len, len);
         @out_path = dup_cstr(p.s.alloc, ?obj_base[0]);
         readout.phase_end(p.s.readout, readout.PH_LINK, len, "object", "objects");

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1505,28 +1505,6 @@ fun subst_name(tmpl: str, name: str, out: *u8, cap: usize) usize {
     ret k;
 }
 
-# write each per-module image to a relocatable `.o` on disk, then - in
-# executable mode - link the on-disk object set into the resolved artifact path
-#
-# The object layout is `<root>/<resolved obj>/<rel>.o`, where `<rel>` is the FQN
-# with '.' turned into '/'; the executable is the resolved `<root>/<bin_out>`.
-# `out_override` (-o), when non-nil, replaces the artifact path: an absolute path
-# is used verbatim; a relative path is rooted at `<root>`. In library mode (or
-# with `--emit obj`) no executable is linked and the per-module objects are the
-# deliverable. Sets `*out_path` on success - the binary in executable mode, the
-# object tree root in library mode. The linker reads its inputs from disk, so the
-# per-module objects are materialized before linking.
-# ---
-# p:            the project carrying the module graph and session
-# emit_obj:     emit the per-module objects only, linking no executable
-# root:         the resolved project root directory
-# out_override: the `-o` artifact path, or nil to use the resolved path
-# argc:         argument count including argv[0]
-# argv:         the argument vector (argc null-terminated byte pointers)
-# marks:        consumption record parallel to argv, for the link-input scanners
-# images:       the per-module object images to write
-# out_path:     receives the owned produced-artifact path on success
-# ret:          0 on success, 1 on a user error, 2 on an internal error
 # free the per-member read buffers and symbol-name arrays, then the member array
 fun free_members(alloc: *A.Allocator, members: *ar.ArMember, cap: u32) {
     var i: u32 = 0;
@@ -1636,6 +1614,28 @@ fun emit_static_archive(p: *driver.Project, images: *of.ObjectImage, paths: **u8
     ret 0;
 }
 
+# write each per-module image to a relocatable `.o` on disk, then - in
+# executable mode - link the on-disk object set into the resolved artifact path
+#
+# The object layout is `<root>/<resolved obj>/<rel>.o`, where `<rel>` is the FQN
+# with '.' turned into '/'; the executable is the resolved `<root>/<bin_out>`.
+# `out_override` (-o), when non-nil, replaces the artifact path: an absolute path
+# is used verbatim; a relative path is rooted at `<root>`. In library mode (or
+# with `--emit obj`) no executable is linked and the per-module objects are the
+# deliverable. Sets `*out_path` on success - the binary in executable mode, the
+# object tree root in library mode. The linker reads its inputs from disk, so the
+# per-module objects are materialized before linking.
+# ---
+# p:            the project carrying the module graph and session
+# emit_obj:     emit the per-module objects only, linking no executable
+# root:         the resolved project root directory
+# out_override: the `-o` artifact path, or nil to use the resolved path
+# argc:         argument count including argv[0]
+# argv:         the argument vector (argc null-terminated byte pointers)
+# marks:        consumption record parallel to argv, for the link-input scanners
+# images:       the per-module object images to write
+# out_path:     receives the owned produced-artifact path on success
+# ret:          0 on success, 1 on a user error, 2 on an internal error
 fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
                   out_override: *u8,
                   argc: usize, argv: **u8, marks: *bool,

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -119,6 +119,8 @@ pub val TARGET_OPT_RELEASE: TargetOpt = 2;
 #             archive path (relative to the project root, or absolute) or a bare
 #             `-l`-style name resolved against the link search dirs; nil when none
 # lib_count:  number of entries in `libs`
+# lib_kind:   for a library build (mode == MODE_LIBRARY), whether the artifact is
+#             static or shared; meaningless for an executable (#1980)
 pub rec TargetEntry {
     name:       intern.StrId;
     os_name:    intern.StrId;
@@ -130,6 +132,7 @@ pub rec TargetEntry {
     opt:        TargetOpt;
     libs:       *intern.StrId;
     lib_count:  u32;
+    lib_kind:   manifest.LibKind;
 }
 
 # one entry under `[deps.<alias>]` in mach.toml plus the dep's
@@ -1567,6 +1570,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     entry.entrypoint = bu.entry;
     entry.mode       = MODE_EXECUTABLE;
     if (bu.is_lib) { entry.mode = MODE_LIBRARY; }
+    entry.lib_kind   = bu.kind;
     entry.opt        = map_opt(bu.opt);
     entry.libs       = bu.libs;
     entry.lib_count  = bu.lib_count;

--- a/src/lang/target/of/ar.mach
+++ b/src/lang/target/of/ar.mach
@@ -18,12 +18,19 @@
 # archiver inserts (the `/` symbol directory and the `//` long-name table), since
 # those are not objects.
 
+use std.allocator.page;
+use std.filesystem;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
 use std.types.string.str_starts_with;
+
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
 
 # the `!<arch>\n` magic that opens every `ar` file
 val MAGIC:       str   = "!<arch>\n";
@@ -234,4 +241,266 @@ fun parse_size(buf: *u8, at: usize, ok: *bool) usize {
 
     @ok = digits > 0;
     ret size;
+}
+
+# --- writer ---
+
+# one member to place into an archive: its file name, object bytes, and the names of
+# the global symbols it defines (for the `/` symbol index the linker consults)
+# ---
+# name:      the member file name (unique within the archive)
+# data:      the member's object bytes
+# len:       byte length of `data`
+# sym_names: the names of the defined global symbols this member exports
+# sym_count: number of entries in `sym_names`
+pub rec ArMember {
+    name:      str;
+    data:      *u8;
+    len:       usize;
+    sym_names: *str;
+    sym_count: u32;
+}
+
+# the even-padded on-disk length of a member body (members pad to a 2-byte boundary)
+fun even(x: usize) usize {
+    if ((x & 1) == 1) { ret x + 1; }
+    ret x;
+}
+
+# whether `name` fits the 16-byte inline name field (the name plus its `/` terminator)
+fun inline_name(name: str) bool {
+    ret str_len(name) + 1 <= 16;
+}
+
+# the number of decimal digits in `v` (at least 1)
+fun dec_digits(v: usize) usize {
+    var n: usize = 1;
+    var t: usize = v;
+    for (t >= 10) { t = t / 10; n = n + 1; }
+    ret n;
+}
+
+# write `v` as left-justified decimal ASCII at `buf[off..]`, returning the digit count
+fun put_dec(buf: *u8, off: usize, v: usize) usize {
+    val d: usize = dec_digits(v);
+    var i: usize = d;
+    var t: usize = v;
+    for (i > 0) {
+        i = i - 1;
+        buf[off + i] = ('0'::usize + (t % 10))::u8;
+        t = t / 10;
+    }
+    ret d;
+}
+
+# write the 4-byte big-endian `v` at `buf[off..]` (the `ar` symbol-index offset width)
+fun put_be32(buf: *u8, off: usize, v: u32) {
+    buf[off]     = ((v >> 24) & 0xFF)::u8;
+    buf[off + 1] = ((v >> 16) & 0xFF)::u8;
+    buf[off + 2] = ((v >> 8)  & 0xFF)::u8;
+    buf[off + 3] = (v & 0xFF)::u8;
+}
+
+# write a 60-byte member header at `buf[off..]` with mtime/uid/gid 0, mode 644, the
+# decimal `size`, and the `\x60\n` magic. the 16-byte name field is left as spaces for
+# the caller to fill (inline `name/` or `/<longtable-offset>`).
+fun put_header(buf: *u8, off: usize, size: usize) {
+    var i: usize = 0;
+    for (i < HEADER_LEN) { buf[off + i] = ' '; i = i + 1; }
+    buf[off + 16] = '0';
+    buf[off + 28] = '0';
+    buf[off + 34] = '0';
+    buf[off + 40] = '6'; buf[off + 41] = '4'; buf[off + 42] = '4';
+    put_dec(buf, off + SIZE_OFFSET, size);
+    buf[off + HEADER_LEN - 2] = 0x60;
+    buf[off + HEADER_LEN - 1] = 0x0A;
+}
+
+# write the GNU `ar` archive of `members` to `out_path`: the `!<arch>\n` magic, a `/`
+# symbol index mapping every member's defined globals to its header offset, a `//`
+# long-name table for names past 15 bytes, then each member header + object bytes
+# (padded to an even boundary). external-tool-free - mirrors the format the reader
+# above frames. used for ELF/Mach-O `.a` and the COFF `.lib` ar variant.
+# ---
+# alloc:    allocator for the archive buffer and scratch arrays
+# members:  the objects to archive, in link order
+# count:    number of members
+# out_path: the archive path to write
+# ret:      ok(true) on success, or the first allocation / write error
+pub fun write_archive(alloc: *A.Allocator, members: *ArMember, count: u32, out_path: str) R.Result[bool, str] {
+    var total_syms: usize = 0;
+    var strtab_len: usize = 0;
+    var long_len:   usize = 0;
+    var i: u32 = 0;
+    for (i < count) {
+        total_syms = total_syms + members[i].sym_count::usize;
+        var s: u32 = 0;
+        for (s < members[i].sym_count) { strtab_len = strtab_len + str_len(members[i].sym_names[s]) + 1; s = s + 1; }
+        if (!inline_name(members[i].name)) { long_len = long_len + str_len(members[i].name) + 2; }
+        i = i + 1;
+    }
+    val armap_content: usize = 4 + total_syms * 4 + strtab_len;
+    val has_long: bool = long_len > 0;
+
+    val res_lo: R.Result[*usize, str] = A.allocate[usize](alloc, count::usize);
+    if (R.is_err[*usize, str](res_lo)) { ret R.err[bool, str](R.unwrap_err[*usize, str](res_lo)); }
+    val long_off: *usize = R.unwrap_ok[*usize, str](res_lo);
+    val res_ho: R.Result[*usize, str] = A.allocate[usize](alloc, count::usize);
+    if (R.is_err[*usize, str](res_ho)) { A.deallocate[usize](alloc, long_off, count::usize); ret R.err[bool, str](R.unwrap_err[*usize, str](res_ho)); }
+    val hdr_off: *usize = R.unwrap_ok[*usize, str](res_ho);
+
+    var lo_run: usize = 0;
+    i = 0;
+    for (i < count) {
+        long_off[i] = lo_run;
+        if (!inline_name(members[i].name)) { lo_run = lo_run + str_len(members[i].name) + 2; }
+        i = i + 1;
+    }
+
+    var pos: usize = MAGIC_LEN + HEADER_LEN + even(armap_content);
+    if (has_long) { pos = pos + HEADER_LEN + even(long_len); }
+    i = 0;
+    for (i < count) {
+        hdr_off[i] = pos;
+        pos = pos + HEADER_LEN + even(members[i].len);
+        i = i + 1;
+    }
+    val total: usize = pos;
+
+    val res_buf: R.Result[*u8, str] = A.allocate[u8](alloc, total);
+    if (R.is_err[*u8, str](res_buf)) {
+        A.deallocate[usize](alloc, long_off, count::usize);
+        A.deallocate[usize](alloc, hdr_off, count::usize);
+        ret R.err[bool, str](R.unwrap_err[*u8, str](res_buf));
+    }
+    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+
+    var k: usize = 0;
+    for (k < MAGIC_LEN) { buf[k] = MAGIC[k]; k = k + 1; }
+    var off: usize = MAGIC_LEN;
+
+    put_header(buf, off, armap_content);
+    buf[off] = '/';
+    off = off + HEADER_LEN;
+    put_be32(buf, off, total_syms::u32);
+    var so: usize = off + 4;
+    var st: usize = off + 4 + total_syms * 4;
+    i = 0;
+    for (i < count) {
+        var s: u32 = 0;
+        for (s < members[i].sym_count) {
+            put_be32(buf, so, hdr_off[i]::u32);
+            so = so + 4;
+            val nm: str = members[i].sym_names[s];
+            val nl: usize = str_len(nm);
+            var j: usize = 0;
+            for (j < nl) { buf[st] = nm[j]; st = st + 1; j = j + 1; }
+            buf[st] = 0; st = st + 1;
+            s = s + 1;
+        }
+        i = i + 1;
+    }
+    off = off + armap_content;
+    if ((armap_content & 1) == 1) { buf[off] = 0x0A; off = off + 1; }
+
+    if (has_long) {
+        put_header(buf, off, long_len);
+        buf[off] = '/'; buf[off + 1] = '/';
+        off = off + HEADER_LEN;
+        i = 0;
+        for (i < count) {
+            if (!inline_name(members[i].name)) {
+                val nm: str = members[i].name;
+                val nl: usize = str_len(nm);
+                var j: usize = 0;
+                for (j < nl) { buf[off] = nm[j]; off = off + 1; j = j + 1; }
+                buf[off] = '/'; off = off + 1;
+                buf[off] = 0x0A; off = off + 1;
+            }
+            i = i + 1;
+        }
+        if ((long_len & 1) == 1) { buf[off] = 0x0A; off = off + 1; }
+    }
+
+    i = 0;
+    for (i < count) {
+        put_header(buf, off, members[i].len);
+        if (inline_name(members[i].name)) {
+            val nm: str = members[i].name;
+            val nl: usize = str_len(nm);
+            var j: usize = 0;
+            for (j < nl) { buf[off + j] = nm[j]; j = j + 1; }
+            buf[off + nl] = '/';
+        }
+        or {
+            buf[off] = '/';
+            put_dec(buf, off + 1, long_off[i]);
+        }
+        off = off + HEADER_LEN;
+        var b: usize = 0;
+        for (b < members[i].len) { buf[off] = members[i].data[b]; off = off + 1; b = b + 1; }
+        if ((members[i].len & 1) == 1) { buf[off] = 0x0A; off = off + 1; }
+        i = i + 1;
+    }
+
+    val wr: R.Result[bool, str] = filesystem.write_file(out_path, buf, total, 0o644);
+    A.deallocate[u8](alloc, buf, total);
+    A.deallocate[usize](alloc, long_off, count::usize);
+    A.deallocate[usize](alloc, hdr_off, count::usize);
+    ret wr;
+}
+
+# a written archive round-trips through the reader: valid magic, the `/` symbol index
+# and `//` long-name table are skipped as specials, and exactly the two object members
+# are yielded with their bytes intact - including a member whose name needs the
+# long-name table (#1980)
+test "mach.lang.target.of.ar.write_roundtrip" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var code: i32 = 0;
+
+    var d1: [4]u8; d1[0] = 1::u8; d1[1] = 2::u8; d1[2] = 3::u8; d1[3] = 4::u8;
+    var d2: [3]u8; d2[0] = 9::u8; d2[1] = 8::u8; d2[2] = 7::u8;
+    var s1: [2]str; s1[0] = "foo"; s1[1] = "bar";
+    var s2: [1]str; s2[0] = "aVeryLongExportedSymbolName";
+    var members: [2]ArMember;
+    members[0].name = "short.o";
+    members[0].data = ?d1[0]; members[0].len = 4; members[0].sym_names = ?s1[0]; members[0].sym_count = 2;
+    members[1].name = "a.long.member.name.needing.the.table.o";
+    members[1].data = ?d2[0]; members[1].len = 3; members[1].sym_names = ?s2[0]; members[1].sym_count = 1;
+
+    val res_temp: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "mach_test_ar");
+    if (R.is_err[filesystem.TempFile, str](res_temp)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](res_temp);
+    val path: str = filesystem.temp_path(?tf);
+    if (R.is_err[bool, str](write_archive(?alloc, ?members[0], 2, path))) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, path);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rr)) { ret 1; }
+    val b: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rr);
+
+    if (!is_archive(b.data, b.len)) { ret 1; }
+
+    var pos: usize = first_member();
+    var objs: u32 = 0;
+    var m0_ok: bool = false;
+    var m1_ok: bool = false;
+    var walking: bool = true;
+    for (walking) {
+        val step: Step = next_member(b.data, b.len, pos);
+        if (!step.ok) { code = 1; walking = false; }
+        or (step.done) { walking = false; }
+        or {
+            if (!is_special(b.data, pos)) {
+                objs = objs + 1;
+                if (step.member.len == 4 && step.member.data[0] == 1::u8 && step.member.data[3] == 4::u8) { m0_ok = true; }
+                if (step.member.len == 3 && step.member.data[0] == 9::u8 && step.member.data[2] == 7::u8) { m1_ok = true; }
+            }
+            pos = step.next;
+        }
+    }
+    if (objs != 2) { code = 1; }
+    if (!m0_ok || !m1_ok) { code = 1; }
+    ret code;
 }


### PR DESCRIPTION
Part of #1980 (owner decision: make the declarations true for both lib kinds). **Phase 1 only — static archives.** Phase 2 (shared libraries, coordinating with #1752) stays open on the issue; this PR intentionally does not use `Closes`.

## Problem
Every migrated library repo declares `[artifact.X] kind = "static"` with `out = "lib/<name>"`, but the build exits 0 having written only loose per-module objects — the declared `out` is never materialized.

## Fix
A `kind = "static"` artifact now emits a real `ar` archive at its declared `out`.
- **`of/ar.mach` gains a GNU `ar` writer** — `!<arch>\n` magic, a `/` symbol index mapping each object's defined global symbols to its member, a `//` long-name table for names past 15 bytes, and even-padded members — mirroring the existing reader in the same module. External-tool-free (mach ships its own object writers). Used for ELF/Mach-O `.a` and the COFF `.lib` ar variant.
- **`link_artifact`** archives the freshly written objects for a static library (the object bytes come from the just-written `.o`, each member's defined globals from its `ObjectImage`). `LibKind` is threaded onto `TargetEntry`. `--emit obj` and (phase 2) `kind = "shared"` keep the loose-objects deliverable unchanged; `kind = "bin"` is untouched.
- Consumption is unchanged (module tree + objects). The archive rides the existing object staleness (re-emitted when objects change) and, because the resolved `out` sits under the project out tree, `mach clean` already removes it (no clean.mach change needed).

## Verification (from-source, linux-x86_64)
- **e2e:** clean builds of **mach-std** (64 members, **2327-symbol** index) and **mach-image** (18 members, 531-symbol index) copied to `/tmp` — each materializes its `lib/<name>` archive, recognized by `file` as an `ar archive`, listed by `ar t` / `llvm-ar t`, and its symbol index parsed by `nm --print-armap`. `mach clean` removes each.
- Unit test: an `ar`-writer round-trip through the reader (armap + `//` long-name table skipped as specials; both object members recovered intact, including a long-named one).
- Full bar: unit suite **564 / 0**, self-host **fixpoint byte-identical**, **int linux 42/42**.