### PR TITLE
docs: rewrite manifest.md/cli.md and fix help for the strict V2 schema (#1977)

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -41,7 +41,7 @@ argument forwarding.
 | `run`   | execute the already-built binary (a post-`build` convenience, not a rebuild) |
 | `test`  | build the test binary and run the collected tests |
 | `clean` | remove the project's build output directory trees |
-| `dep`   | manage git-backed dependencies (clone, lock, vendor) under `<dep>` |
+| `dep`   | manage git-backed dependencies (clone, lock, vendor) under `dep` |
 | `init`  | scaffold a new project |
 | `doc`   | generate Markdown reference docs from source doc-comments |
 | `info`  | print compiler version, build host, and registered target capabilities |
@@ -91,8 +91,8 @@ resolved artifact path (its `out` template); for a `static`/`shared` library (or
 with `--emit obj`) the objects are the deliverable and nothing is linked.
 
 The optimisation pipeline comes from the selected profile's `opt` (`--profile
-<name>`, or the first declared profile); there are no `-O`/`--release`
-pipeline-selection flags.
+<name>`, or the first declared profile) — the profile is how a build picks its
+optimisation level.
 
 | Flag           | Value          | Effect |
 |----------------|----------------|--------|
@@ -307,10 +307,10 @@ on an allocator or io failure.
 mach dep <action> [args]
 ```
 
-Manages the project's dependency tree under `<dep>`. Dispatches on `argv[2]`.
+Manages the project's dependency tree under `dep`. Dispatches on `argv[2]`.
 A dependency has exactly one source form: a **git** URL plus a ref, which mach
-acquires into `<dep>/<name>/` with plain git operations, or a **path** to another
-project tree, never fetched but materialised at `<dep>/<name>/` as a relative
+acquires into `dep/<name>/` with plain git operations, or a **path** to another
+project tree, never fetched but materialised at `dep/<name>/` as a relative
 symlink so the build resolves it by the same vendor layout.
 
 | Action   | Args | Effect |
@@ -334,7 +334,7 @@ invoked with an allowlisted environment (`PATH`, `HOME`, and the common
 git/ssh/proxy/CA variables). Git's absence is a clean error naming the operation
 that needed it.
 
-For each git dependency, `pull` clones the `git` URL into `<dep>/<name>/` when
+For each git dependency, `pull` clones the `git` URL into `dep/<name>/` when
 absent, then checks out the resolved commit as a **detached HEAD**
 (`git checkout --detach`). A ref resolves as: `branch/<n>` (the remote-tracking
 branch tip), `tag/<n>`, `commit/<n>` or a 7–40 char hex SHA (the literal commit),
@@ -344,7 +344,7 @@ plain git operations, so a checkout the user also commits as a **submodule**
 composes naturally — a moved checkout surfaces as gitlink drift in the parent
 repo's `git status`. mach never invokes `git submodule`.
 
-A **non-empty** directory present under `<dep>/<name>/` without a `.git` entry,
+A **non-empty** directory present under `dep/<name>/` without a `.git` entry,
 while the manifest declares it a git dep, is a hard error: declare it a `path`
 dependency if those are vendored files. (`.git` as a file — a submodule gitlink —
 counts as a checkout.) An **empty** directory has nothing to vendor and is treated
@@ -352,7 +352,7 @@ as absent — `pull` clones into it — so a plain `git clone` (without
 `--recurse-submodules`), which leaves a submodule dep dir empty, is repaired by a
 plain `mach dep pull` (#1329).
 
-For each **path** dependency, `pull` materialises the source at `<dep>/<name>/` as
+For each **path** dependency, `pull` materialises the source at `dep/<name>/` as
 a relative symlink, so the build resolves its modules by the same vendor layout as
 a git dep. The `path` is resolved relative to the requiring manifest's directory;
 the link is relative, so a tree that moves as a whole (a monorepo, a committed
@@ -366,7 +366,7 @@ by a real directory (a stale git checkout, foreign vendored files) is a hard err
 ### Transitive resolution
 
 Transitive deps resolve into the **flat dep tree**: every git dep, direct or
-transitive, lives at `<dep>/<name>/`, so a dependency's own
+transitive, lives at `dep/<name>/`, so a dependency's own
 `[target.*].libs` cascade into the consumer's build (see `manifest.md`). The same
 name required from two different sources or refs is a hard error naming both
 requirers; there is no version resolution (reserved for the registry era).

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -37,7 +37,7 @@ argument forwarding.
 
 | Command | Summary |
 |---------|---------|
-| `build` | compile the project to objects and (for a `[bin.*]`) a linked binary |
+| `build` | compile the project to objects and (for a `bin` artifact) a linked binary |
 | `run`   | execute the already-built binary (a post-`build` convenience, not a rebuild) |
 | `test`  | build the test binary and run the collected tests |
 | `clean` | remove the project's build output directory trees |
@@ -57,16 +57,14 @@ A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 | `-v`             | —                | `mach build`: per-phase roll-up (load/resolve/sema/lower/optimize/codegen/link) with item counts + timing, then a `built … N modules … in …` summary, on stderr |
 | `-vv`            | —                | `-v` plus a per-module/file line under each phase with its duration and a `(slow)` marker on the slowest |
 | `--quiet`, `-q`  | —                | suppress non-error output |
-| `--target <name>`| target name      | select a declared target; absent, defers to `[project].target` |
-| `--profile <name>`| profile name    | select a `[profile.<name>]` build variant; absent, the first declared profile |
-| `--bin <name>`   | artifact name    | narrow the build to one `[bin.<name>]` artifact |
-| `--lib <name>`   | artifact name    | narrow the build to one `[lib.<name>]` artifact (mutually exclusive with `--bin`) |
+| `--target <name>`| target name      | select a declared target; absent, resolves the host-matching declared target (`native`) |
+| `--profile <name>`| profile name    | select a `[profile.<name>]` build variant, whose `opt` sets the optimisation pipeline; absent, the first declared profile |
+| `--bin <name>`   | artifact name    | narrow the build to one `bin` `[artifact.<name>]` |
+| `--lib <name>`   | artifact name    | narrow the build to one `static`/`shared` `[artifact.<name>]` (mutually exclusive with `--bin`) |
 | `-o <path>`      | path             | override the artifact path, rooted at the project root (build/run/test) |
 | `--all-targets`  | —                | build every declared `[target.*]`, not just the default (mutually exclusive with `-o`, which names one path) |
-| `--emit-asm`     | —                | emit per-module assembly text (`.s`); forces the selected profile's `emit_asm` on |
-| `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`) — the final post-pipeline IR the object is built from, so it varies with `-O`; forces the selected profile's `emit_ir` on |
-| `--no-emit-asm`  | —                | force per-module assembly emission off, overriding the profile's `emit_asm` |
-| `--no-emit-ir`   | —                | force per-module IR emission off, overriding the profile's `emit_ir` |
+| `--emit-asm`     | —                | emit per-module assembly text (`.s`) — emission is opt-in, controlled only by this flag |
+| `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`), the final post-pipeline IR the object is built from (so it varies with the profile's `opt`) — emission is opt-in, controlled only by this flag |
 | `--verify-ir`    | —                | run the IR verifier after each optimisation pass |
 
 > Under `mach test`, the entry module's `--emit-ir` dump shows the neutralized
@@ -83,21 +81,21 @@ A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 mach build <path> [options]
 ```
 
-Compiles the project rooted at `<path>` (e.g. `mach build .`). With no
-`--bin`/`--lib`, it builds every declared
-artifact for the default target and profile. Every reachable module is driven
-through sema → lower → optimise → codegen to one relocatable object, written
-under the manifest's resolved `obj` template at `<obj>/<fqn-as-path>.o`. For a
-`[bin.*]` the objects are linked into the resolved artifact path (the `out`
-template); for a `[lib.*]` (or with `--emit obj`) the objects are the deliverable
-and nothing is linked.
+Compiles the project named by `<path>` — a project directory (whose `mach.toml`
+is read) or a manifest file directly (e.g. `mach build .` or `mach build ci.toml`).
+With no `--bin`/`--lib`, it builds every declared artifact for the selected target
+and profile. Every reachable module is driven through sema → lower → optimise →
+codegen to one relocatable object, written under the resolved object tree at
+`<out>/obj/<fqn-as-path>.o`. For a `bin` artifact the objects are linked into the
+resolved artifact path (its `out` template); for a `static`/`shared` library (or
+with `--emit obj`) the objects are the deliverable and nothing is linked.
+
+The optimisation pipeline comes from the selected profile's `opt` (`--profile
+<name>`, or the first declared profile); there are no `-O`/`--release`
+pipeline-selection flags.
 
 | Flag           | Value          | Effect |
 |----------------|----------------|--------|
-| `--release`    | —              | select the release optimisation pipeline |
-| `-O0`          | —              | force the debug pipeline (overrides `--release`) |
-| `-O1`          | —              | select the release pipeline |
-| `-O2`          | —              | select the release pipeline |
 | `-g`           | —              | emit debug info for this build, forcing the selected profile's `debug` on (precedence `-g` > profile > off) |
 | `--emit <kind>`| `obj`\|`exe`   | `obj` stops at the relocatable objects; `exe` (default) links a binary |
 | `--pie`        | —              | emit a position-independent (ET_DYN) executable for ASLR instead of the default fixed-address one; opt-in (see below) |
@@ -105,10 +103,7 @@ and nothing is linked.
 | `-l <name>`    | name           | link a named object, archive, or shared library, resolved through the `-L` dirs (see below); repeatable |
 | *(positional)* | input path     | a bare argument that contains `/`, ends in `.o` / `.a`, or names a `.so` is linked verbatim |
 
-Plus the global flags above. The `-O<n>` flags override `--release` when both
-are present; absent any optimisation flag the build uses the debug pipeline
-(the bootstrap-stable default). `-O1` and `-O2` currently select the same
-release pipeline.
+Plus the global flags above.
 
 `--pie` is an opt-in: without it, a linux executable links fixed-address
 (`ET_EXEC`) exactly as before — a normal build is byte-identical. With it, the
@@ -122,9 +117,9 @@ dependency is rejected.
 `ext fun` declarations are forward references whose definitions are supplied at
 link time by external precompiled code — a loose `.o` object, a static `.a`
 archive, or a shared `.so` library. Those inputs come from the command line and
-from the manifest's merged `libs` overlay (`[target.*]`, `[bin.*]`/`[lib.*]`, and
-per-cell, see [manifest.md](manifest.md)); both sets are linked. An input that
-resolves to no
+from the manifest's matching `[link.X]` entries — an artifact's referenced entries
+plus exported dependency entries whose `os`/`isa`/`abi` filters match the build
+(see [manifest.md](manifest.md)); both sets are linked. An input that resolves to no
 existing file is a hard error, so a typo never silently drops a dependency.
 
 - **Explicit input path** — a bare (non-flag) argument that contains a `/`, ends
@@ -179,17 +174,17 @@ mach run <path> [options] [-- args...]
 ```
 
 Executes the binary `mach build` already produced for `<path>` — a post-build
-convenience, **not** a rebuild. The same selection flags (`--target`,
-`--profile`/`--release`, `--bin`) that narrow a build resolve which artifact to
-run; its path is read from the manifest's `out` template and the existing file
-is exec'd. When the artifact does not exist yet, `mach run` errors and points at
-`mach build` rather than building it.
+convenience, **not** a rebuild. The same selection flags (`--target`, `--profile`,
+`--bin`) that narrow a build resolve which artifact to run; its path is read from
+the artifact's `out` template and the existing file is exec'd. When the artifact
+does not exist yet, `mach run` errors and points at `mach build` rather than
+building it.
 Arguments after a `--` separator are forwarded to the child as its `argv`. The
 child's exit code becomes this command's exit code.
 
 `--emit` is rejected — running a relocatable object is not meaningful. The
-`build` selection and global flags apply; build-only flags (`-O*`, `--emit-*`)
-are accepted but have no effect, since nothing is built.
+`build` selection and global flags apply; build-only flags (`--emit-*`) are
+accepted but have no effect, since nothing is built.
 
 | Flag             | Value   | Effect |
 |------------------|---------|--------|
@@ -288,16 +283,16 @@ Exit codes: `0` all passed, `1` any failed, `2` build/internal error.
 ## `mach clean`
 
 ```
-mach clean [path]
+mach clean <path>
 ```
 
-Removes the project's build output. The trees removed are the static directory
-prefixes of the manifest's `out`/`obj`/`ir`/`asm` templates — the leading path
-components before the first `{...}` placeholder — so the whole output tree is
-cleared regardless of target or profile. Because it is driven by the templates, a
-project that relocates its output (`out = "build/..."`) is cleaned at that root
-rather than a hardcoded `out/`. `[path]` selects the project (default: the working
-directory, walking up to the nearest `mach.toml`).
+Removes the project's build output. The tree removed is the static directory
+prefix of the manifest's `out` template — the leading path components before the
+first `{...}` placeholder — so the whole output tree is cleared regardless of
+target or profile. Because it is driven by the template, a project that relocates
+its output (`out = "build/..."`) is cleaned at that root rather than a hardcoded
+`out/`. `<path>` names the project (a directory or a manifest file), like every
+project-rooted command.
 
 Only the manifest is read: no module graph is loaded and nothing under the
 dependency dir is touched. Removal is idempotent (`mach clean` on an already-clean
@@ -322,9 +317,9 @@ symlink so the build resolves it by the same vendor layout.
 |----------|------|--------|
 | `pull`   | — | realise the manifest: clone missing git deps (transitively), link path deps, re-resolve a changed ref, repair checkout-vs-lock drift, write `mach.lock`. Idempotent; the command routine use needs. |
 | `update` | `<name> \| --all` | the only lock-advancer: re-resolve branch refs to current remote tips. Tag/commit refs are an immutable no-op. Never edits the manifest. |
-| `add`    | `<name> --git <url> [--ref <ref>] \| --path <dir>` | append a `[deps.<name>]` `git`/`path` stanza to the manifest, then `pull`. |
-| `remove` | `<name> [--purge]` | drop the entry from `mach.toml` and `mach.lock`; `--purge` also deletes `<dep>/<name>/`. |
-| `list`   | — | print each `[deps.<name>]` entry with its source form, ref, locked commit, and state (`synced`/`missing`/`drifted`/`path`). |
+| `add`    | `<name> --git <url> [--ref <ref>] \| --path <dir>` | append a `[dep.<name>]` `git`/`path` stanza to the manifest, then `pull`. |
+| `remove` | `<name> [--purge]` | drop the entry from `mach.toml` and `mach.lock`; `--purge` also deletes `dep/<name>/`. |
+| `list`   | — | print each `[dep.<name>]` entry with its source form, ref, locked commit, and state (`synced`/`missing`/`drifted`/`path`). |
 
 `sync` is the pre-`pull` name, kept one cycle as a hidden alias that prints a
 deprecation note and runs `pull`.
@@ -383,13 +378,12 @@ The manifest is intent; the lock is the record of resolving it. After a `pull`,
 and resolved `commit` (path deps have no lock entry):
 
 ```toml
-# generated by `mach dep pull`; do not edit by hand.
-version = 1
+# this file is automatically generated; do not edit by hand.
 
-[deps.mach-std]
+[dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
-ref = "branch/dev"
-commit = "6b78ae1e8c3c9cc45e4ab4b916fd191d61e76aff"
+ref = "branch/main"
+commit = "9c6eb77880de143090ef48645ba7353ec786d758"
 ```
 
 `pull` honours the lock except where the manifest ref was edited — there it
@@ -400,7 +394,7 @@ to their current tips. The lock writer is idempotent: an up-to-date lock is left
 untouched. Commit `mach.lock` to pin builds.
 
 `mach dep` reads `mach.toml` from the current directory directly (it does not walk
-up to find a project root); each `[deps.<name>]` declares exactly one of
+up to find a project root); each `[dep.<name>]` declares exactly one of
 `git`/`path`, with `ref` for git (see `manifest.md`). Exit codes: `0` ok, `1` user
 error, `2` internal error.
 
@@ -412,8 +406,8 @@ mach init [dir] [options]
 
 Scaffolds a new project in `[dir]` (default: the current directory). Writes a
 complete `mach.toml` with a `[project]` block, `[target.*]` platforms for
-`linux`/`windows`/`darwin` (on the host ISA), one `[bin.*]`/`[lib.*]` artifact,
-`[profile.debug]`/`[profile.release]` variants, a `[deps.mach-std]` dependency, a
+`linux`/`windows`/`darwin` (on the host ISA), one `[artifact.<id>]`,
+`[profile.debug]`/`[profile.release]` variants, a `[dep.mach-std]` dependency, a
 starter source file, and `dep/mach-std/` cloned from the declared ref (through
 the same path as `mach dep pull`). Refuses to overwrite an existing `mach.toml`,
 `src/main.mach`, or `src/lib.mach` unless `--force`; every collision is checked
@@ -423,7 +417,7 @@ before any file is written, so a refused init leaves nothing behind.
 |----------------|-------|--------|
 | `--name <name>`| name  | project id (default: the directory base name) |
 | `--force`      | —     | scaffold even when `mach.toml`, `src/main.mach`, or `src/lib.mach` already exists |
-| `--lib`        | —     | library layout: write `src/lib.mach` instead of `src/main.mach`, and scaffold a `[lib.<id>]` artifact (`kind = "static"`) instead of `[bin.<id>]` |
+| `--lib`        | —     | library layout: write `src/lib.mach` instead of `src/main.mach`, and scaffold a `static` `[artifact.<id>]` instead of a `bin` one |
 
 The first non-flag argument after `init` is the target directory.
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -1,329 +1,407 @@
 # `mach.toml` — the project manifest
 
-Every Mach project has a `mach.toml` at its root. It is the complete, readable
-statement of what the project builds: its identity, the platforms it targets, the
-artifacts it produces, the build variants it offers, and its dependencies. The
-compiler finds it by walking up from the working directory until a `mach.toml` is
-seen, so any subcommand run inside a project tree resolves the same manifest.
+A Mach project is described by a `mach.toml` at its root: its identity, the
+platforms it targets, the artifacts it produces, the build variants it offers, its
+external link requirements, the build steps that produce them, and its
+dependencies. Every `mach` subcommand takes the project explicitly — a directory
+(whose `mach.toml` is read) or a manifest file directly — so the manifest a build
+uses is never guessed from the working directory. See [cli.md](cli.md) for the
+path argument.
 
-The manifest separates the three orthogonal axes of a build — *what* is built
-(`[bin.*]`/`[lib.*]` artifacts), *where* it runs (`[target.*]` platforms), and
-*where* outputs land (the `out`/`obj`/`ir`/`asm` path templates). Repetition
-between axes is eliminated by the build engine's cartesian product, never by the
-file. Nothing is inferred: every value resolves from a stanza present in the file.
+The manifest is built from `[category.name]` tables in seven sections —
+`[project]`, `[target.X]`, `[profile.X]`, `[artifact.X]`, `[link.X]`, `[step.X]`,
+and `[dep.X]`. TOML itself enforces name uniqueness within a section.
 
-## The schema
+## Convention, then totality
+
+Convention covers what is *absent*: with no manifest at all, `src/` is the module
+tree, `src/main.mach` the entry, and a single native debug binary the build — a
+pure-mach single-binary project needs no `mach.toml`. Convention operates on absent
+manifests and absent sections, never on absent fields.
+
+A table you *declare*, you declare completely. Every field of a declared table is
+required; a missing field is a strict-parse error, not a silent default. This is
+the manifest twin of Mach's explicitness: there are no field defaults to memorize,
+because "any" and "none" are said out loud —
+
+- `"*"` is the explicit any-token for a filter axis or `targets` entry;
+- `[]` is the explicit empty list ("none").
+
+The sole exception is **shape-dependence**: a field whose presence follows another
+value in the same table. A dependency is `git` *or* `path`; a `[link.X]` names a
+`name` *or* a `path` according to its `source`. Nothing else defaults.
+
+Unknown sections and unknown keys are always errors. A path value is always
+`/`-separated; a literal `\` is rejected (`manifest paths use '/'`), so the same
+manifest is portable and is normalized to the host separator at the filesystem
+boundary.
+
+### Root vs. dependency strictness
+
+Manifest strictness is scoped to the manifest being **built**: mach enforces the
+no-defaults totality rules on your project's own `mach.toml` (the root of the
+build), but parses a **dependency's** `mach.toml` permissively, reading only its
+export surface (project id, `export = true` link entries, and the steps those
+entries demand). A dependency's own totality is enforced when that dependency is
+built as a root — so a project need not wait for its dependencies to migrate, and
+historical commit pins keep resolving. Unknown keys are always rejected, in a root
+or a dependency.
+
+## The schema at a glance
 
 ```toml
 [project]
-id      = "demo"            # required: root of every module path the project exposes
-version = "0.1.0"           # required
-src     = "src"             # source dir (default "src")
-dep     = "dep"             # vendored-dependency dir (default "dep")
-target  = "native"          # default target selector (default "native")
-out     = "out/{target}/{profile}/bin/{name}{ext}"  # artifact path template
-obj     = "out/{target}/{profile}/obj"              # intermediate-object dir template
-ir      = "out/{target}/{profile}/ir"               # IR-dump dir template
-asm     = "out/{target}/{profile}/asm"              # ASM-dump dir template
-tests   = "out/{target}/{profile}/test/{name}"      # test dispatcher executable path template (mach test)
-# optional metadata: name, description, license, authors
+id      = "demo"                       # required: identifier; root of every module path
+version = "0.1.0"                      # required
+src     = "src"                        # required: source dir, project-root-relative
+out     = "out/{target.name}/{profile.name}"  # required: output-path template root
 
-[target.linux]             # a platform: a fully-spelled tuple, nothing inferred
+[target.linux]                         # a platform: a fully-spelled tuple
 isa = "x86_64"
 os  = "linux"
 abi = "sysv64"
 
-[target.windows]
-isa     = "x86_64"
-os      = "windows"
-abi     = "win64"
-ext     = ".exe"           # artifact extension (default "")
-libs    = ["kernel32.dll"] # platform link overlay, inherited by every artifact
-defines = []               # per-target comptime defines (#1191)
+[profile.debug]                        # a build variant
+opt   = 0                              # 0 (debug pipeline) | 1 | 2 (release pipeline)
+debug = true                           # emit debug info for this profile
 
-[bin.hello]                # an executable artifact, named by its table key
-entry = "hello.mach"       # entry source, relative to the src dir (required)
+[artifact.demo]                        # a produced artifact
+kind    = "bin"                        # "bin" | "static" | "shared"
+entry   = "main.mach"                  # entry source, relative to src
+out     = "{project.out}/bin/demo"     # this artifact's output path
+targets = ["*"]                        # which declared targets build it ("*" = all)
+link    = []                           # [link.X] names this artifact links
+need    = []                           # [step.X] names this artifact demands directly
 
-[lib.core]                 # a library artifact
-entry = "lib.mach"
-kind  = "static"           # "static" (default) | "shared"
-
-[bin.hello.target.windows] # a per-cell exception refining one artifact-target pair
-entry = "hello_win.mach"   # overrides the artifact's entry for this target only
-libs  = ["user32.dll"]     # appended to the merged link overlay
-
-[profile.debug]            # a build variant
-opt   = 0                  # 0 (no optimization) | 1 (standard) | 2 (aggressive)
-debug = true               # emit debug info for this profile (default false)
-
-[profile.release]
-opt      = 2
-emit_ir  = true            # emit per-module post-pipeline IR for this profile (default false)
-emit_asm = false           # emit per-module assembly for this profile (default false)
-debug    = false           # release-with-symbols: set true to keep debug info in a release profile
-
-[deps.mach-std]            # a dependency: exactly one of git|path, plus ref for git
+[dep.std]                              # a dependency
 git = "https://github.com/briar-systems/mach-std"
-ref = "v0.4.0"
+ref = "branch/main"
 ```
+
+`[link.X]` and `[step.X]` are shown under [Link requirements](#linkx--link-requirements)
+and [Build steps](#stepx--build-steps).
 
 ## `[project]`
 
-| Key       | Type   | Required | Default    | Meaning |
-|-----------|--------|----------|------------|---------|
-| `id`      | string | yes      | —          | Root segment of every module path the project exposes. A file at `<src>/foo/bar.mach` is reachable as `<id>.foo.bar`. |
-| `version` | string | yes      | —          | Project version. Read by the `$project.version` comptime root. |
-| `module`  | string | no       | —          | Src-relative path of the module a bare `use <id>;` / `fwd <id>;` resolves to (see [Bare project-id imports](#bare-project-id-imports)). Never inferred; a library that wants to be importable by its id declares it. A declared path naming no file is an error at build start. |
-| `src`     | string | no       | `"src"`    | Source root, relative to the project root. Module paths resolve under it. |
-| `dep`     | string | no       | `"dep"`    | Vendored-dependency root, relative to the project root. Each dep lives at `<dep>/<alias>/`. |
-| `target`  | string | no       | `"native"` | Default target selector when `--target` is not passed. `native` resolves to the declared target whose tuple matches the host. |
-| `out`     | string | no       | `"out/{target}/{profile}/bin/{name}{ext}"` | Artifact path template (see [Path templates](#path-templates)). |
-| `obj`     | string | no       | `"out/{target}/{profile}/obj"` | Per-module object tree template. |
-| `ir`      | string | no       | `"out/{target}/{profile}/ir"`  | Per-module IR-dump template (used when emission is on). |
-| `asm`     | string | no       | `"out/{target}/{profile}/asm"` | Per-module assembly-dump template (used when emission is on). |
-| `tests`   | string | no       | `"out/{target}/{profile}/test/{name}"` | Test dispatcher executable path template. `mach test` builds one executable covering every collected `test` block here, with `{name}` the product name (see below). |
+| Key       | Type   | Meaning |
+|-----------|--------|---------|
+| `id`      | string | Root segment of every module path the project exposes: a file at `<src>/foo/bar.mach` is reachable as `<id>.foo.bar`. Must be a plain identifier — letters, digits, `_`, `-` — since it names the dependency store and keys step stamp files. Read by `$project.id`. |
+| `version` | string | Project version. Read by `$project.version`; the source of truth a Go-style `tag/<version>` acquisition checks. |
+| `src`     | string | Source root, project-root-relative. Module paths resolve under it. |
+| `out`     | string | The output-path template root, referenced as `{project.out}` by artifact `out`, step paths, and `cmd`s. Expanded over `{target.name}`/`{profile.name}` (see [Path templates](#path-templates)). |
 
-Optional metadata read by the `$project.*` comptime roots but not the build:
-`name`, `description`, `license`, `authors`.
+`[project]` is exactly these four keys; `name`, `description`, and any other key
+are unknown-key errors in a root manifest.
 
 ## `[target.<name>]`
 
-Each `<name>` is a selector you pass to `--target <name>` (or set as
-`[project].target`). At least one target must be declared. A target is a
+Each `<name>` is a selector you pass to `--target <name>`. A target is a
 fully-spelled platform tuple; nothing is inferred from another key. `native` is a
-reserved name — declaring `[target.native]` is an error.
+reserved name — declaring `[target.native]` is an error, because `native` resolves
+to whichever *declared* target matches the host.
 
-| Key       | Type   | Required | Default | Meaning |
-|-----------|--------|----------|---------|---------|
-| `isa`     | string | yes      | —       | Instruction-set architecture. Read by `$project.target.arch`. See the accepted set below. |
-| `os`      | string | yes      | —       | Operating system. Read by `$project.target.os`. See the accepted set below. |
-| `abi`     | string | yes      | —       | Application binary interface (e.g. `sysv64`, `win64`). Read by `$project.target.abi`. |
-| `ext`     | string | no       | `""`    | Artifact filename extension expanded by `{ext}` (e.g. `".exe"`). |
-| `libs`    | array of strings | no | `[]` | Platform link overlay — external link inputs inherited by every artifact built for this target (see [Link inputs](#link-inputs)). |
-| `defines` | array of strings | no | `[]` | Per-target comptime defines (#1191). Each is `NAME` (a `true` flag) or `NAME=VALUE`; readable as `$mach.build.NAME`. |
+| Key   | Required | Meaning |
+|-------|----------|---------|
+| `isa` | yes      | Instruction-set architecture. Read by `$project.target.arch`. |
+| `os`  | yes      | Operating system. Read by `$project.target.os`. |
+| `abi` | yes      | Application binary interface. Read by `$project.target.abi`. |
+| `of`  | no       | Object-format override; defers to the os's format when omitted (the one optional target key). See [Object-format override](#object-format-override). |
 
-### Accepted `isa` values
+### Accepted tuple values
 
-| Value     | Status |
-|-----------|--------|
-| `x86_64`  | supported — the primary ISA |
-| `aarch64` | supported — CI builds and runs linux-arm64 natively on every PR |
-| `riscv64` | supported — CI runs under qemu on every PR; self-hosting target (#1852) |
+| Axis  | Values |
+|-------|--------|
+| `isa` | `x86_64`, `aarch64`, `riscv64` |
+| `os`  | `linux`, `windows`, `darwin`, `freestanding` |
+| `abi` | `sysv64`, `win64`, `aapcs64`, `lp64` |
 
-### Accepted `os` values
+`x86_64`/`linux`/`sysv64` is the primary host and target. `aarch64`-linux builds
+and runs natively in CI on every PR; `riscv64`-linux runs under qemu and
+self-hosts (#1852). `windows` is a supported cross-compilation target (PE/COFF,
+Win64 ABI). `darwin`'s ABI and object-format support exist but the toolchain is not
+yet validated end-to-end. `freestanding` targets a raw flat image with no OS
+runtime.
 
-| Value     | Status |
-|-----------|--------|
-| `linux`   | supported — the primary host/target |
-| `windows` | supported as a cross-compilation target (PE/COFF, Win64 ABI) |
-| `darwin`  | recognized; ABI/object-format vtables exist, but the toolchain is not yet validated end-to-end |
+A value outside its axis's set is a strict-parse error, so a typo is caught rather
+than silently never matching.
 
-## `[bin.<name>]` / `[lib.<name>]`
+### Object-format override
 
-Every artifact is declared explicitly and named by its table key. A `[bin.*]`
-links an executable; a `[lib.*]` produces a library. The artifact name drives
-`{name}` in the output templates and is read by `$bin.name`.
+`of` overrides the object format an OS implies. Each os has a default format —
+`linux` → `elf`, `windows` → `coff`, `darwin` → `macho`, `freestanding` → `raw` —
+and `of` names a different one from the same closed set: `elf`, `coff`, `macho`,
+`raw`. It is the only optional key on a target; omit it to take the os default.
 
-| Key       | Type   | Applies | Required | Default | Meaning |
-|-----------|--------|---------|----------|---------|---------|
-| `entry`   | string | bin, lib | yes     | —        | Entry source, relative to the project `src` dir. The entry module's FQN is `<id>.<entry without .mach>`, with `/` turned into `.`. |
-| `kind`    | string | lib      | no       | `"static"` | `"static"` leaves the per-module objects as the deliverable; `"shared"` produces a shared library. |
-| `out`     | string | bin, lib | no       | project `out` | Per-artifact override of the artifact path template. |
-| `libs`    | array of strings | bin, lib | no | `[]` | Per-artifact link inputs, merged into the link overlay. |
-| `defines` | array of strings | bin, lib | no | `[]` | Per-artifact comptime defines. |
-
-### `[bin.<name>.target.<t>]` per-cell exceptions
-
-A per-cell table refines one artifact for one target. It may override `entry` and
-`out`, and append `libs`/`defines` at the highest precedence level. An unset key
-inherits the artifact's value.
+```toml
+[target.metal]
+isa = "x86_64"
+os  = "freestanding"   # os default object format is "raw"
+abi = "sysv64"
+of  = "elf"            # override: emit an ELF object instead
+```
 
 ## `[profile.<name>]`
 
-A profile is a build variant. The optimization level and the debug-emission
-toggles live here because they are variant concerns.
+A profile is a build variant. The optimization level and debug-emission toggle
+live here because they are variant concerns.
 
-| Key        | Type    | Default | Meaning |
-|------------|---------|---------|---------|
-| `opt`      | integer | — (debug) | Optimization level: `0` (no optimization beyond the always-on pipeline), `1` (standard), or `2` (aggressive). `1` and `2` currently select the same pass set; `2` is where future loop/vectorization work lands. Any other integer — or a non-integer — is a manifest error (`profile '<name>': opt must be 0, 1, or 2`). |
-| `emit_ir`  | bool    | `false` | Write per-module SSA IR dumps under the `ir` template for this profile — the final post-pipeline IR the object is built from, so it varies with `opt`. |
-| `emit_asm` | bool    | `false` | Write per-module assembly dumps under the `asm` template for this profile. |
-| `debug`    | bool    | `false` | Emit debug info (DWARF on ELF/Mach-O, CodeView on COFF) for this profile. Declare it once so a project ships symbols without passing a flag every build, or set it on a release profile for release-with-symbols. A non-boolean value is a manifest error (`profile '<name>': debug must be a boolean`). Gates emission only, never the optimizer. |
+| Key     | Type    | Meaning |
+|---------|---------|---------|
+| `opt`   | integer | Optimization level: `0` selects the debug pipeline (the always-on passes only), `1` and `2` select the release pipeline. `1` and `2` currently share a pass set; `2` is where future loop/vectorization work lands. Any other integer — or a non-integer — is a manifest error. |
+| `debug` | bool    | Emit debug info (DWARF on ELF/Mach-O, CodeView on COFF) for this profile. Gates emission only, never the optimizer, so a `release` profile can keep symbols with `debug = true`. A non-boolean is a manifest error. |
 
-A CLI `-O0` / `-O1` / `-O2` / `--release` flag overrides the selected profile's
-`opt` per invocation, and `--emit-ir` / `--emit-asm` / `--no-emit-ir` /
-`--no-emit-asm` override the emission toggles. A CLI `-g` forces `debug` on for one
-invocation regardless of the selected profile's key (precedence `-g` > profile >
-off); there is no flag to force it off over a `debug = true` profile — edit the
-manifest or select another profile. Absent `--profile`/`--release`, the first
-declared profile is used; with no profile declared, a `debug` default (no
-optimization, no emission) applies.
+Both keys are required in a declared profile. Emission of the human-readable IR and
+assembly side-artifacts is **not** a profile concern — it is controlled only by the
+`--emit-ir` / `--emit-asm` CLI flags (see [cli.md](cli.md)).
 
-## `[deps.<alias>]`
+The CLI selects and overrides at invocation time: `--profile <name>` picks the
+profile; `-g` forces `debug` on for one build regardless of the profile's key
+(precedence `-g` > profile > off — there is no flag to force it off over a
+`debug = true` profile; edit the manifest or pick another profile). Absent
+`--profile`, the first declared profile is used.
 
-Each `<alias>` names a dependency materialised under `<dep>/<alias>/`. The build
-resolves a dependency purely by vendor layout — it reads that directory's own
-`mach.toml` for its `[project].id` (the head segment of the dep's module paths)
-and `[project].src` (the dep's source dir). A module path whose head matches a
-dep's `id` resolves into that dep's tree.
+## `[artifact.<name>]`
+
+Every artifact is declared explicitly and named by its table key. `$project.name`
+reads the selected artifact's name.
+
+| Key       | Required | Meaning |
+|-----------|----------|---------|
+| `kind`    | yes | `"bin"` (an executable), `"static"` (a static library — the per-module objects are the deliverable), or `"shared"` (a shared library). |
+| `entry`   | yes | Entry source, relative to the project `src` dir (e.g. `main.mach` for `src/main.mach`). The entry module's FQN is `<id>.<entry without .mach>`, `/` turned into `.`. |
+| `out`     | yes | This artifact's output path, a template (see [Path templates](#path-templates)). An executable extension, where wanted, is written literally into this path. |
+| `targets` | yes | Array of declared target names this artifact builds for; `["*"]` means every declared target. |
+| `link`    | yes | Array of `[link.X]` names this artifact links (see below). `[]` for none. |
+| `need`    | yes | Array of `[step.X]` names this artifact demands directly, for step outputs that are not themselves link inputs. `[]` for none. |
+
+Per-target extension or per-target entry is not a per-cell exception table — it is a
+second artifact stanza, so the condition stays visible like everything else.
+
+## `[link.<name>]` — link requirements
+
+A `[link.X]` is a named external link requirement. Artifacts reference entries by
+name in their `link = [...]`; an entry whose filters do not match the build cell is
+skipped. An entry with `export = true` also applies to any project that links this
+project's modules, so a platform link requirement lives once — in the manifest that
+needs it — and cascades to consumers. A standalone build and a consumed build use
+the same entries, so nothing behaves differently as a dependency.
+
+| Key      | Required | Meaning |
+|----------|----------|---------|
+| `source` | yes | `"system"` (a system library resolved by name), `"framework"` (a macOS framework), or `"local"` (a file on disk). |
+| `name`   | shape | Library/framework name — required for `source = "system"`/`"framework"`, forbidden for `"local"`. |
+| `path`   | shape | File path — required for `source = "local"`, forbidden otherwise. A template (see below). |
+| `os`     | yes | Filter axis: a canonical `os` value, `"*"` (any), an array of values, or `[]` (none). |
+| `isa`    | yes | Filter axis over `isa`, same forms. |
+| `abi`    | yes | Filter axis over `abi`, same forms. |
+| `export` | yes | `true` cascades this entry to consumers; `false` keeps it to this project's own builds. |
+
+The `os`/`isa`/`abi` axes select the build cells an entry applies to. Each takes a
+single canonical value, `"*"` for any, or an array — `os = "linux"` and
+`os = ["linux"]` filter identically. `[]` matches nothing (an entry deliberately
+switched off). A non-canonical spelling is a strict-parse error. An entry applies
+to a cell when all three axes match.
+
+A `local` entry's `path` must, at build time, either match a `[step.X]`'s `out`
+(which demands that step) or already exist on disk — anything else is an up-front
+error, so a typo never silently drops an input.
+
+Whether an input links **statically** or **dynamically** follows the resolved file
+— a loose `.o` or static `.a` links statically; a shared `.so` is recorded as a
+dynamic dependency by its `DT_SONAME`. See
+[cli.md](cli.md#static-vs-dynamic-resolution) for the resolution rules and
+[language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
+`ext fun` workflow that consumes these inputs.
+
+## `[step.<name>]` — build steps
+
+A step is a command, make-recipe style, that produces files a build consumes
+(typically a `local` link input, e.g. a vendored-C object). `<name>` must be a
+plain identifier — it keys the step's stamp file.
+
+| Key    | Required | Meaning |
+|--------|----------|---------|
+| `cmd`  | yes | One command string, run through the platform shell (`sh -c` on posix, `cmd.exe /C` on windows) from the project root. Pipe, `&&`, or invoke a script freely. Templates expand in it. |
+| `in`   | yes | Declared input file list. Accepts globs (`*`, `**`), expanded sorted for a stable fingerprint; a glob that matches nothing is a hard error. |
+| `out`  | yes | Declared output file list. Concrete paths only — a glob here is an error, since the demand match and cache key expand `out` verbatim. |
+| `need` | yes | Array of other `[step.X]` names this step must run after (explicit ordering; cycles error). `[]` for none. |
+
+Steps carry **no filters** and **never run automatically**. A step runs only when
+**demanded**:
+
+- by a selected `[link.X]` whose `local` `path` matches the step's `out`;
+- by another step's `need`;
+- by an artifact's `need` (for outputs that are not link inputs).
+
+Because a step has no filter of its own, the condition for running it lives in the
+link entry that demands it: on a build cell where that entry filters out, the step
+is never demanded and never runs.
+
+A step is cached by content: its `in` contents plus its expanded `cmd` fingerprint
+the step (the query engine's `Q_LINK_CONFIG` pattern). An unchanged step whose
+outputs still exist is skipped; change an input or the command and it re-runs.
+
+**Output homing.** `{project.out}` resolves to the **root** project's expanded
+`out` in every manifest of the closure. A dependency's step outputs land in the
+consumer's output tree — exactly as a dependency's compiled modules do — and the
+dependency's own checkout is never written to.
+
+## `[dep.<alias>]`
+
+Each `<alias>` names a dependency materialised under `dep/<alias>/`. The build
+resolves a dependency by vendor layout: it reads that directory's own `mach.toml`
+for its `[project].id` (the head segment of the dep's module paths) and `src`, and
+a module path whose head matches a dep's `id` resolves into that dep's tree.
 
 A stanza declares exactly one source key:
 
-| Key    | Type   | Read by    | Meaning |
-|--------|--------|------------|---------|
-| `git`  | string | `mach dep` | Git URL to clone into `<dep>/<alias>/`. |
-| `path` | string | `mach dep` | Local path to another project tree, resolved relative to this manifest's directory; never fetched. `mach dep pull` materialises it at `<dep>/<alias>/` as a relative symlink to the resolved source, so the build reaches its modules by the same vendor layout as a git dep. |
-| `ref`  | string | `mach dep` | Git ref to check out (with `git`): a `tag/<name>`, `branch/<name>`, bare tag/branch, or commit SHA. An absent ref means the remote default branch. |
+| Key    | Meaning |
+|--------|---------|
+| `git`  | Git URL to clone into `dep/<alias>/`. Requires `ref`. |
+| `path` | Local project tree, resolved relative to this manifest's directory; never fetched. `mach dep pull` materialises it at `dep/<alias>/` as a relative symlink. Forbids `ref`. |
+| `ref`  | Git ref to check out (git only): `tag/<name>`, `branch/<name>`, a bare tag/branch, or a commit SHA. |
 
-A registry-style `version =` is reserved and rejected. Cloning, lockfile
-handling, and transitive resolution are documented in [cli.md](cli.md#mach-dep).
-`mach dep` performs only plain git operations, so a checkout the user also commits
-as a **submodule** composes naturally; mach never invokes `git submodule`.
+`git` and `path` are mutually exclusive and exactly one is required. A
+registry-style `version =` is reserved and rejected. Cloning, lockfile handling,
+and transitive resolution are documented in [cli.md](cli.md#mach-dep); `mach dep`
+performs only plain git operations, so a checkout committed as a git **submodule**
+composes naturally. A git dep is pinned to a resolved commit in `mach.lock`; a path
+dep carries no lock entry (its `path` is the whole record).
 
-A **git** dep is pinned to a resolved commit in `mach.lock`; a **path** dep has no
-pinned content, so it carries no lock entry — its `path` in the manifest is the
-whole record. `mach dep pull` materialises a path dep at `<dep>/<alias>/` as a
-relative symlink to the resolved source and is idempotent: a stale link is
-replaced, an already-correct one is left untouched, and a source that already
-lives at the vendor location is a no-op. A path that does not exist, that holds no
-`mach.toml`, or whose vendor location is occupied by a real directory (a stale git
-checkout, foreign vendored files) is a hard error — never silent success.
+Dependencies are exactly today's system: git/path deps, an alias-keyed flat `dep/`
+store, `branch`/`tag`/`commit` refs, transitive pull, `mach.lock` as-is. Every
+transitively fetched dependency registers its `[project].id` into a single flat id
+registry, so a dependency's own surface dependencies resolve in consumers. **The
+same id reached from two different sources or refs anywhere in the closure is a
+hard error** naming the requirers — the fix is to fork or upstream, never to
+version-split inside one build.
 
-### Cascading link requirements
-
-A dependency declares its own link requirements as `[target.*].libs` (full-tuple)
-or `[os.<name>].libs` (os-component) overlays, and a consumer inherits every such
-lib that matches the build it is producing — so a platform link requirement (e.g.
-`kernel32.dll`) lives once, in the providing dependency's manifest, and out of
-every consumer. Matching is by tuple/component equality; target *names* are local
-to each manifest. Within each dependency the matching os overlays precede the
-matching target libs; across dependencies the order is topological then
-declaration order, and the union is deduplicated by name. See
-[Link inputs](#link-inputs) for the overlay merge law.
-
-## `[os.<name>]`
-
-An os overlay scopes a link requirement to a single tuple component — the
-operating system — rather than a full `(isa, os, abi)` tuple. A build matches the
-overlay iff its selected target's `os` equals `<name>`, so a requirement that
-holds for every windows ISA and ABI is stated once:
-
-```toml
-[os.windows]
-libs = ["kernel32.dll"]   # linked into every windows build, this project's and any consumer's
-```
-
-| Key    | Type             | Default | Meaning |
-|--------|------------------|---------|---------|
-| `libs` | array of strings | `[]`    | Link inputs added to every build whose os matches `<name>` (see [Link inputs](#link-inputs)). |
-
-Os overlays cascade to consumers exactly like `[target.*].libs`. The
-single-component `[isa.<name>]` and `[abi.<name>]` overlays are **reserved**:
-declaring either is an error until a real case demands them.
-
-## Bare project-id imports
-
-A one-segment `use`/`fwd` path equal to a resolvable project id — a dependency's
-`[project].id`, or the current project's own id — resolves to that project's
-declared `[project].module`. So a library that sets `module = "glfw.mach"` is
-imported as `use glfw;` (binding the `glfw` module) instead of by the full path to
-its surface file. Longer paths are unaffected; a single segment is otherwise
-unresolvable, so this is purely additive.
-
-```toml
-# in glfw's manifest:
-[project]
-id     = "glfw"
-module = "glfw.mach"   # the surface a bare `use glfw;` binds
-```
-
-```mach
-// in a consumer:
-use glfw;              // binds the glfw module (glfw's [project].module)
-```
-
-A bare import of a project that declares no `module` is a resolution error naming
-the fix (import a full path, or add a `module` to the project's manifest). A
-declared `module` that names no file is a manifest error at build start whether or
-not anything imports it. A project module that `fwd`s its own id is caught by the
-existing circular-module detection.
+A dependency's export surface — all a consumer sees — is its source module tree
+(addressed by the dep's id), its `export = true` link entries, and the steps those
+entries demand. Nothing else in a dependency's manifest applies to consumers.
 
 ## Path templates
 
-Output paths come only from the declared templates, expanded over four variables:
+Output paths and `cmd`s come only from the declared templates, expanded over a
+closed, final set of three variables:
 
-- `{target}` — the resolved target name (never the literal `native`).
-- `{profile}` — the selected profile name.
-- `{name}` — the artifact name.
-- `{ext}` — the target's `ext` (the empty string by default).
+- `{project.out}` — the root project's expanded `[project].out`.
+- `{target.name}` — the resolved target name (never the literal `native`).
+- `{profile.name}` — the selected profile name.
 
-Manifest paths are always `/`-separated and normalized to the host separator at
-the filesystem boundary, so the same manifest is portable; a literal `\` in a path
-is a hard error. Two artifacts that resolve to the same `out` path collide and
-fail at build start. A per-artifact or per-cell `out` overrides the project
-template for that artifact.
-
-The `tests` template is expanded the same way and locates the single test
-dispatcher executable `mach test` builds (`{target}`/`{profile}`/`{ext}` resolve
-as usual). `{name}` is the selected artifact's product name, falling back to the
-project id for artifact-less (library) builds. The dispatcher embeds every
-collected test and runs the one selected by a decimal index argument, so a
-project's test build lands at, e.g., `out/linux/debug/test/mach`.
+There are no `{name}`/`{ext}` or bare `{target}`/`{profile}` aliases. An
+unresolvable `{...}` reference, or an unterminated `{`, is a strict-parse error.
+`{project.out}` is not available inside `[project].out` itself (it would be
+self-referential). Two artifacts that resolve to the same `out` path collide and
+fail at build start.
 
 ## Selection and the build matrix
 
 A build cell is one artifact × one target × one profile.
 
-- `mach build .` builds every declared `[bin.*]`/`[lib.*]` for the default target
-  and default profile. `--all-targets` crosses every artifact with every declared
-  target. `--bin <name>` / `--lib <name>` narrow to one artifact; `--target
-  <name>` selects a declared target; `--profile <name>` (with `--release` sugar)
-  selects a profile.
-- `mach run .` and `mach test .` build exactly one artifact; with several declared
-  and no `--bin`/`--lib`, they ask you to pick one, naming every candidate.
+- `mach build <path>` builds every declared artifact whose `targets` includes the
+  selected target, for the default profile. `--all-targets` crosses every artifact
+  with every target in its `targets`. `--bin <name>` / `--lib <name>` narrow to one
+  artifact; `--target <name>` selects a declared target; `--profile <name>` selects
+  a profile.
+- `mach run <path>` and `mach test <path>` build exactly one artifact; with several
+  declared and no `--bin`/`--lib`, they ask you to pick one, naming every candidate.
+- `mach test` links the union of all artifacts' referenced entries plus exported
+  dependency entries, filtered to the native target (tests run on native hardware
+  only). If two artifacts' objects collide on symbols in that union, that is an
+  honest link error — restructure the entries.
 
 ### `native` target resolution
 
-`native` resolves the host's `(isa, os)` tuple against the **declared** targets
-only — never a synthesized tuple. Exactly one host match is chosen; several
-matching tuples is an ambiguity error naming the candidates; no match warns
-(`no declared target matches the host (...)`) and falls back to the first declared
-target so cross-only projects still build on a foreign host.
+`native` resolves the host's `(isa, os)` against the **declared** targets only —
+never a synthesized tuple. Exactly one host match is chosen; several matching tuples
+is an ambiguity error naming the candidates; no match warns and falls back to the
+first declared target, so a cross-only project still builds on a foreign host.
 
-## Link inputs
+## Worked example: a consumer of C bindings and vendored C
 
-A `libs` entry (at the target, artifact, or per-cell level) is either an explicit
-path — a `.o` object, a `.a` archive, or a `.so` shared library, project-root-
-relative or absolute — or a bare `-l`-style name resolved to a `lib<name>.o` /
-`<name>.o` / `lib<name>.a` / `<name>.a`, then a shared `lib<name>.so`, at link
-time. Loose `.o` objects and static `.a` archives link **statically** (a `.a`
-contributes every member object); a shared `.so` is recorded as a **dynamic**
-dependency (its `DT_SONAME`), bound against undefined `ext` symbols at load time
-through a `PT_INTERP`/PLT. The overlays merge target < artifact < per-cell,
-deduplicated by name, and join every `mach build`/`run`/`test` link alongside any
-CLI `-L`/`-l`/object arguments. See
-[cli.md](cli.md#static-vs-dynamic-resolution) for the full resolution rules and
-[language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
-`ext fun` workflow that consumes these inputs.
-
-## Annotated example
-
-The compiler's own manifest builds one binary (`mach`) for two targets, keeping
-its output paths flat (no `{profile}` segment) so released paths stay stable:
+A project that uses a system-lib binding (`glfw`) and a vendored-C library
+(`miniz`), building a native binary and cross-compiling to windows. The platform
+shim is built by steps and linked through `local` entries; the OS-specific shims
+are gated by their link entries' `os` axis, so the x11 step runs on a linux build
+and never on a windows one.
 
 ```toml
 [project]
-id      = "mach"          # module-path root: this project's code is `mach.*`
-name    = "Mach Compiler" # metadata
-version = "1.3.0"
-src     = "src"           # sources under ./src
-dep     = "dep"           # vendored deps under ./dep
-target  = "native"        # default target: the host-matching tuple below
-out     = "out/{target}/bin/{name}{ext}"  # e.g. out/linux/bin/mach
-obj     = "out/{target}/obj"
-ir      = "out/{target}/ir"
-asm     = "out/{target}/asm"
-tests   = "out/{target}/test/{name}"      # e.g. out/linux/test/myproj
+id      = "demo"
+version = "0.1.0"
+src     = "src"
+out     = "out/{target.name}/{profile.name}"
+
+[dep.std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "tag/v0.17.0"
+
+[dep.glfw]
+git = "https://github.com/briar-systems/mach-glfw"
+ref = "tag/v0.2.1"
+
+[dep.mz]
+git = "https://github.com/briar-systems/mach-miniz"
+ref = "tag/v1.0.3"
+
+[link.shim]
+source = "local"
+path   = "{project.out}/obj/platform/shim.o"
+os     = "*"
+isa    = "*"
+abi    = "*"
+export = false
+
+[link.shim-x11]
+source = "local"
+path   = "{project.out}/obj/platform/x11.o"
+os     = "linux"
+isa    = "*"
+abi    = "*"
+export = false
+
+[link.shim-win32]
+source = "local"
+path   = "{project.out}/obj/platform/win32.o"
+os     = "windows"
+isa    = "*"
+abi    = "*"
+export = false
+
+[link.gl]
+source = "system"
+name   = "GL"
+os     = "linux"
+isa    = "*"
+abi    = "*"
+export = false
+
+[artifact.demo]
+kind    = "bin"
+entry   = "main.mach"
+out     = "{project.out}/bin/demo"
+targets = ["linux", "windows"]
+link    = ["shim", "shim-x11", "shim-win32", "gl"]
+need    = []
+
+[step.shim]
+cmd  = "cc -c -O2 -fPIC -Ivendor/platform -o {project.out}/obj/platform/shim.o vendor/platform/shim.c"
+in   = ["vendor/platform/shim.c"]
+out  = ["{project.out}/obj/platform/shim.o"]
+need = []
+
+[step.shim-x11]
+cmd  = "cc -c -O2 -fPIC -Ivendor/platform -o {project.out}/obj/platform/x11.o vendor/platform/x11.c"
+in   = ["vendor/platform/x11.c"]
+out  = ["{project.out}/obj/platform/x11.o"]
+need = []
+
+[step.shim-win32]
+cmd  = "cc -c -O2 -fPIC -Ivendor/platform -o {project.out}/obj/platform/win32.o vendor/platform/win32.c"
+in   = ["vendor/platform/win32.c"]
+out  = ["{project.out}/obj/platform/win32.o"]
+need = []
 
 [target.linux]
 isa = "x86_64"
@@ -331,26 +409,130 @@ os  = "linux"
 abi = "sysv64"
 
 [target.windows]
-isa  = "x86_64"
-os   = "windows"
-abi  = "win64"
-ext  = ".exe"            # the windows artifact is out/windows/bin/mach.exe
-libs = ["kernel32.dll"]  # the windows platform link requirement
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
 
-[bin.mach]
-entry = "main.mach"      # entry module mach.main, at src/main.mach
+[profile.debug]
+opt   = 0
+debug = true
 
-[deps.mach-std]
-git = "https://github.com/briar-systems/mach-std"
-ref = "branch/dev"
+[profile.release]
+opt   = 2
+debug = false
 ```
 
-`mach build .` (no `--target`) selects `linux` because `[project].target = "native"`
-resolves to the host-matching tuple, compiles `src/main.mach` and its transitive
-imports — including modules from `mach-std` vendored at `dep/mach-std/` — into
-objects under `out/linux/obj/`, and links `out/linux/bin/mach`. `mach-std` is
-realized into `dep/mach-std/` by `mach dep pull` from the manifest pin, and
-`mach build .` then resolves it purely by that vendor path — no git at build time.
+The `gl` and `shim-x11` entries carry `os = "linux"`, so on a windows build cell
+they filter out (and `shim-x11`'s step is never demanded); `shim-win32` carries
+`os = "windows"` and applies only there. The unconditional `shim` entry (`os = "*"`)
+applies to both.
+
+## Worked example: a C-binding dependency's export
+
+`mach-glfw` exports only its `system`/`framework` link entries — a consumer that
+imports its modules inherits every `export = true` entry that matches the build:
+
+```toml
+[project]
+id      = "glfw"
+version = "0.2.1"
+src     = "src"
+out     = "out/{target.name}/{profile.name}"
+
+[link.glfw]
+source = "system"
+name   = "glfw"
+os     = "*"
+isa    = "*"
+abi    = "*"
+export = true
+
+[link.cocoa]
+source = "framework"
+name   = "Cocoa"
+os     = "darwin"
+isa    = "*"
+abi    = "*"
+export = true
+```
+
+## Worked example: a vendored-C dependency
+
+`mach-miniz` exports one `local` entry whose path is produced by a step; importing
+its surface pulls the entry, and the entry's path demands the step in the
+consumer's output tree:
+
+```toml
+[project]
+id      = "mz"
+version = "1.0.3"
+src     = "src"
+out     = "out/{target.name}/{profile.name}"
+
+[link.miniz]
+source = "local"
+path   = "{project.out}/obj/miniz/miniz.o"
+os     = "*"
+isa    = "*"
+abi    = "*"
+export = true
+
+[step.miniz]
+cmd  = "cc -c -O2 -fPIC -Ivendor/miniz -o {project.out}/obj/miniz/miniz.o vendor/miniz/miniz.c"
+in   = ["vendor/miniz/*.c", "vendor/miniz/*.h"]
+out  = ["{project.out}/obj/miniz/miniz.o"]
+need = []
+```
+
+## The compiler's own manifest
+
+Mach builds itself from a manifest that declares one binary for six targets and
+depends on `mach-std`:
+
+```toml
+[project]
+id      = "mach"
+version = "3.1.0"
+src     = "src"
+out     = "out/{target.name}/{profile.name}"
+
+[target.linux-x86_64]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.windows-x86_64]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[profile.debug]
+opt   = 0
+debug = false
+
+[profile.release]
+opt   = 2
+debug = false
+
+[artifact.mach]
+kind    = "bin"
+entry   = "main.mach"
+out     = "bin/mach"
+targets = ["*"]
+link    = []
+need    = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"
+```
+
+(The full manifest declares all six supported targets.) `mach build .` selects the
+host-matching target via `native`, compiles `src/main.mach` and its transitive
+imports — including modules from `mach-std` vendored at `dep/mach-std/` — and links
+`out/<target>/<profile>/bin/mach`. `mach-std` is realized into `dep/mach-std/` by
+`mach dep pull` from the manifest pin; the build then resolves it purely by that
+vendor path, with no git at build time.
 
 ## See also
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -167,12 +167,19 @@ reads the selected artifact's name.
 
 | Key       | Required | Meaning |
 |-----------|----------|---------|
-| `kind`    | yes | `"bin"` (an executable), `"static"` (a static library — the per-module objects are the deliverable), or `"shared"` (a shared library). |
+| `kind`    | yes | `"bin"`, `"static"`, or `"shared"` (see below). |
 | `entry`   | yes | Entry source, relative to the project `src` dir (e.g. `main.mach` for `src/main.mach`). The entry module's FQN is `<id>.<entry without .mach>`, `/` turned into `.`. |
 | `out`     | yes | This artifact's output path, a template (see [Path templates](#path-templates)). An executable extension, where wanted, is written literally into this path. |
 | `targets` | yes | Array of declared target names this artifact builds for; `["*"]` means every declared target. |
 | `link`    | yes | Array of `[link.X]` names this artifact links (see below). `[]` for none. |
 | `need`    | yes | Array of `[step.X]` names this artifact demands directly, for step outputs that are not themselves link inputs. `[]` for none. |
+
+- **`bin`** links an executable at the resolved `out` path.
+- **`static`** materialises a real `ar` archive at the resolved `out` path — the
+  per-module objects with an archive symbol index, the deliverable a consumer links
+  as a `.a` (#1997).
+- **`shared`** is reserved for a shared-library deliverable; its emission is phase 2
+  (#1980).
 
 Per-target extension or per-target entry is not a per-cell exception table — it is a
 second artifact stanza, so the condition stays visible like everything else.

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -68,7 +68,7 @@ debug = true                           # emit debug info for this profile
 [artifact.demo]                        # a produced artifact
 kind    = "bin"                        # "bin" | "static" | "shared"
 entry   = "main.mach"                  # entry source, relative to src
-out     = "{project.out}/bin/demo"     # this artifact's output path
+out     = "bin/demo"                   # output path, relative to the project out
 targets = ["*"]                        # which declared targets build it ("*" = all)
 link    = []                           # [link.X] names this artifact links
 need    = []                           # [step.X] names this artifact demands directly
@@ -169,7 +169,7 @@ reads the selected artifact's name.
 |-----------|----------|---------|
 | `kind`    | yes | `"bin"`, `"static"`, or `"shared"` (see below). |
 | `entry`   | yes | Entry source, relative to the project `src` dir (e.g. `main.mach` for `src/main.mach`). The entry module's FQN is `<id>.<entry without .mach>`, `/` turned into `.`. |
-| `out`     | yes | This artifact's output path, a template (see [Path templates](#path-templates)). An executable extension, where wanted, is written literally into this path. |
+| `out`     | yes | This artifact's output path, **relative to the expanded project `out`** and rooted there automatically — write `bin/demo`, not `{project.out}/bin/demo`. An executable extension, where wanted, is written literally here. |
 | `targets` | yes | Array of declared target names this artifact builds for; `["*"]` means every declared target. |
 | `link`    | yes | Array of `[link.X]` names this artifact links (see below). `[]` for none. |
 | `need`    | yes | Array of `[step.X]` names this artifact demands directly, for step outputs that are not themselves link inputs. `[]` for none. |
@@ -289,12 +289,18 @@ entries demand. Nothing else in a dependency's manifest applies to consumers.
 
 ## Path templates
 
-Output paths and `cmd`s come only from the declared templates, expanded over a
-closed, final set of three variables:
+Paths and `cmd`s expand over a closed, final set of three variables:
 
-- `{project.out}` — the root project's expanded `[project].out`.
+- `{project.out}` — the **root** project's expanded `[project].out`, in every
+  manifest of the closure.
 - `{target.name}` — the resolved target name (never the literal `native`).
 - `{profile.name}` — the selected profile name.
+
+An artifact's `out` is relative to the expanded project `out` and is rooted there
+automatically — write `bin/demo`, not `{project.out}/bin/demo`. Step `out` lists
+and local link `path`s are **not** auto-rooted: they name `{project.out}`
+explicitly, which is what homes a dependency's build products into the *consumer's*
+output tree rather than the dependency's checkout.
 
 There are no `{name}`/`{ext}` or bare `{target}`/`{profile}` aliases. An
 unresolvable `{...}` reference, or an unterminated `{`, is a strict-parse error.
@@ -387,7 +393,7 @@ export = false
 [artifact.demo]
 kind    = "bin"
 entry   = "main.mach"
-out     = "{project.out}/bin/demo"
+out     = "bin/demo"
 targets = ["linux", "windows"]
 link    = ["shim", "shim-x11", "shim-win32", "gl"]
 need    = []
@@ -436,28 +442,38 @@ applies to both.
 
 ## Worked example: a C-binding dependency's export
 
-`mach-glfw` exports only its `system`/`framework` link entries — a consumer that
-imports its modules inherits every `export = true` entry that matches the build:
+`mach-glfw` exports its `system`/`framework` link entries — a consumer that imports
+its modules inherits every `export = true` entry that matches the build: linux and
+darwin pull the `glfw` system library, a windows build pulls `glfw3.dll`, and the
+darwin frameworks apply only on darwin.
 
 ```toml
 [project]
 id      = "glfw"
-version = "0.2.1"
+version = "0.3.0"
 src     = "src"
 out     = "out/{target.name}/{profile.name}"
 
 [link.glfw]
 source = "system"
 name   = "glfw"
-os     = "*"
+os     = ["linux", "darwin"]
 isa    = "*"
 abi    = "*"
 export = true
 
-[link.cocoa]
+[link.glfw-win]
+source = "system"
+name   = "glfw3.dll"
+os     = ["windows"]
+isa    = "*"
+abi    = "*"
+export = true
+
+[link.Cocoa]
 source = "framework"
 name   = "Cocoa"
-os     = "darwin"
+os     = ["darwin"]
 isa    = "*"
 abi    = "*"
 export = true

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -78,8 +78,7 @@ git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
 ```
 
-`[link.X]` and `[step.X]` are shown under [Link requirements](#linkx--link-requirements)
-and [Build steps](#stepx--build-steps).
+`[link.X]` and `[step.X]` each have their own section below.
 
 ## `[project]`
 

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -77,7 +77,7 @@ fun global_flags() {
     print.print("  -v                phase roll-up with timing + a build summary on stderr\n");
     print.print("  -vv               -v plus per-module/file detail under each phase\n");
     print.print("  --quiet, -q       suppress non-error output (mutually exclusive with -v/-vv)\n");
-    print.print("  --target <name>   select a [targets.<name>] entry\n");
+    print.print("  --target <name>   select a [target.<name>] entry\n");
     print.print("  --profile <name>  select a build profile (debug/release/etc.)\n");
     print.print("  -o <path>         override the linked-binary path (build/run/test)\n");
     print.print("  --emit-asm        emit per-module .s assembly text beside each object\n");
@@ -94,7 +94,7 @@ pub fun usage() {
     print.print("usage: mach <command> [options]\n");
     print.print("\n");
     print.print("commands:\n");
-    print.print("  build    compile the current project\n");
+    print.print("  build    compile a project\n");
     print.print("  run      build and execute the current project\n");
     print.print("  test     build and run the project's tests\n");
     print.print("  clean    remove the project's build output\n");
@@ -113,7 +113,7 @@ pub fun usage() {
 fun help_build() {
     print.print("usage: mach build <path> [options] [inputs...]\n");
     print.print("\n");
-    print.print("compile the current project to relocatable objects and, in executable\n");
+    print.print("compile a project to relocatable objects and, in executable\n");
     print.print("mode, a linked binary. <path> is a project directory or a manifest file.\n");
     print.print("\n");
     print.print("options:\n");
@@ -235,7 +235,7 @@ fun help_doc() {
     print.print("\n");
     print.print("options:\n");
     print.print("  --out <dir>      output directory, rooted at the project (default: doc/api)\n");
-    print.print("  --target <name>  select a [targets.<name>] entry for module discovery\n");
+    print.print("  --target <name>  select a [target.<name>] entry for module discovery\n");
     print.print("\n");
     global_flags();
     print.print("\n");


### PR DESCRIPTION
Closes #1977

Rewrites the user-facing docs against the landed #1971 strict schema (dev @ 8a312c1b, includes #1997).

## doc/manifest.md (full rewrite)

- The seven sections (`[project]`/`[target.X]`/`[profile.X]`/`[artifact.X]`/`[link.X]`/`[step.X]`/`[dep.X]`), convention-then-totality, and shape-dependence.
- **Root vs. dependency strictness** — #1996's paragraph lifted verbatim (root enforces totality; a dependency parses permissively, only its export surface read).
- No-defaults totality per table; canonical filter axes (os/isa/abi ∈ the recognized sets, `"*"` = any, `[]` = none, non-canonical rejected); the closed template set `{project.out}`/`{target.name}`/`{profile.name}`.
- `[link.X]` (source system/framework/local, shape-dependent name/path, filters, export/cascade) and `[step.X]` (cmd/in/out/need, demand-only execution, content-fingerprint cache, output homing).
- **kind="static" emits a real `ar` archive** with a symbol index at its declared out (#1997); shared is phase 2 (#1980).
- The `[target.X]` `of` key documented as a real, optional **object-format override** (elf/coff/macho/raw, defaults to the os format) — see the flag note below.
- **Artifact `out` is relative** to the expanded project out (rooted automatically); `{project.out}` is for step `out`/local link `path` homing. Corrected the RFC examples, which double-rooted.
- Worked examples verified to parse; the C-binding example mirrors the swept `mach-glfw`.

## doc/cli.md

- Purge `--release`/`-O<n>`-as-profile-selection; `--profile` (whose `opt` sets the pipeline) is the selector.
- Required `<path>` (a directory or a manifest file), no cwd walk; `--emit-ir`/`--emit-asm` as the only emission control (dropped the profile-key coupling).
- V1 references fixed: `[bin.*]`/`[lib.*]` → `[artifact.X]` (kind), `[deps.*]` → `[dep.*]`, the lock example and `mach init` scaffold, and `libs` overlay → `[link.X]`.

## src/cli/cmd/help.mach

- `[targets.<name>]` → `[target.<name>]` (both sites); "compile the current project" → "compile a project" (path is required).

## Verification

- Suite through a worktree-built compiler: **568 / 0** (dev baseline; no test changes).
- Self-host fixpoint: byte-identical (help.mach is compiled in).
- Every `[project]`-bearing example in manifest.md verified schema-valid under the from-source strict binary; `mach help` output confirmed free of `[targets.`.
- `kind="static"` confirmed to emit an `ar` archive; relative artifact `out` confirmed to land single (no double-root).

## Flagged for a separate code cleanup (not docs)

The binary still carries superseded/inconsistent flags the docs now supersede: `-O0/-O1/-O2` remain live (opt-level override), `--release` is half-removed (applied but unmarked → rejected as an unknown flag), `--no-emit-ir`/`--no-emit-asm` override profile emit keys that no longer exist, and `dep.mach` still reads `[project].dep` which the strict parser rejects. Recommend removing these so the binary matches the `--profile`/strict model.