### PR TITLE
chore(cli): remove --release remnant, --no-emit-*, [project].dep read (#1999)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -392,9 +392,9 @@ pub fun build_tests(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, list
 
 # resolve the selected profile name from CLI config
 #
-# `--profile <name>` wins; `--release` is sugar for the `release` profile; absent
-# both, the empty string defers to the manifest default. Shared by the `mach
-# build` matrix-override path and selection_from_config.
+# `--profile <name>` selects the profile; absent it, the empty string defers to the
+# manifest default. Shared by the `mach build` matrix-override path and
+# selection_from_config.
 # ---
 # config: the parsed CLI config
 # ret:    the selected profile name, empty for the manifest default
@@ -526,19 +526,17 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
         ret br;
     }
 
-    # optimization level: an explicit CLI flag (`-O0` debug, `-O1`/`-O2`/
-    # `--release` release) wins outright; absent any flag the level falls to the
-    # selected profile's `opt`, then to the debug pipeline (mem2reg, constfold,
-    # dce) - what the bootstrap uses, kept fixpoint-stable. the CLI choice is
-    # resolved here; the manifest default is folded in after the target is
-    # selected (resolve_opt_level), since the target entry is only known post
-    # build_project.
+    # optimization level: an explicit `-O0`/`-O1`/`-O2` CLI flag is a per-invocation
+    # override that wins outright; absent one the level falls to the selected
+    # profile's `opt`, then to the debug pipeline (mem2reg, constfold, dce) - what
+    # the bootstrap uses, kept fixpoint-stable. the CLI choice is resolved here; the
+    # manifest default is folded in after the target is selected (resolve_opt_level),
+    # since the target entry is only known post build_project.
     var cli_level: u8   = pipeline.OPT_DEBUG;
     var cli_set:   bool = false;
-    if (util.has_flag(argc, argv, "-O0"))       { cli_level = pipeline.OPT_DEBUG;   cli_set = true; }
-    or (util.has_flag(argc, argv, "-O1"))       { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
-    or (util.has_flag(argc, argv, "-O2"))       { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
-    or (util.has_flag(argc, argv, "--release")) { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
+    if (util.has_flag(argc, argv, "-O0")) { cli_level = pipeline.OPT_DEBUG;   cli_set = true; }
+    or (util.has_flag(argc, argv, "-O1")) { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
+    or (util.has_flag(argc, argv, "-O2")) { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
 
     # the build selection threaded to the driver; it narrows target/profile/
     # artifact. an enumerated matrix cell pins target and artifact, but the profile
@@ -633,18 +631,16 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
         debug_ok = false;
     }
 
-    # fold the manifest default into the level: a CLI `-O*`/`--release` flag wins,
+    # fold the manifest default into the level: a CLI `-O*` flag wins,
     # otherwise the selected profile's opt applies, else debug.
     val level: u8 = resolve_opt_level(?p, cli_level, cli_set);
 
-    # effective emission: a CLI `--emit-*` / `--no-emit-*` flag overrides the
-    # selected profile's defaults.
+    # effective emission: IR/ASM emission is CLI-only, off by default and enabled
+    # per-invocation by `--emit-asm` / `--emit-ir`.
     var eff_emit_asm: bool = p.config.emit_asm;
     var eff_emit_ir:  bool = p.config.emit_ir;
-    if (config.emit_asm)    { eff_emit_asm = true; }
-    if (config.no_emit_asm) { eff_emit_asm = false; }
-    if (config.emit_ir)     { eff_emit_ir = true; }
-    if (config.no_emit_ir)  { eff_emit_ir = false; }
+    if (config.emit_asm) { eff_emit_asm = true; }
+    if (config.emit_ir)  { eff_emit_ir = true; }
 
     if (debug_ok) {
         br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, eff_emit_asm, eff_emit_ir, ?root[0], config.output, argc, argv, marks, ?br.output_path, tests_out, list_only);
@@ -703,7 +699,7 @@ fun emit_summary(p: *driver.Project, ro: *readout.Readout, emit_obj: bool, out: 
 # ---
 # p:         the project carrying the selected target entry
 # cli_level: the level the CLI flags resolved to
-# cli_set:   whether a CLI `-O*`/`--release` flag was present
+# cli_set:   whether a CLI `-O*` flag was present
 # ret:       the pipeline level (pipeline.OPT_DEBUG or pipeline.OPT_RELEASE)
 fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
     if (cli_set) { ret cli_level; }

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -213,7 +213,7 @@ pub fun pull_project(root: str, quiet: bool) i64 {
     }
     var mt: toml.Table = R.unwrap_ok[toml.Table, str](res_manifest);
 
-    val dep_name: str = dep_dir_name(?mt);
+    val dep_name: str = "dep";
     val res_dep_root: R.Result[str, str] = join2(?a, root, dep_name::*u8);
     if (R.is_err[str, str](res_dep_root)) { ret err_oom(); }
     val dep_root: str = R.unwrap_ok[str, str](res_dep_root);
@@ -562,8 +562,7 @@ fun dep_update(argc: usize, argv: **u8) i64 {
         err_line(R.unwrap_err[toml.Table, str](res_manifest));
         ret 1;
     }
-    var mt: toml.Table = R.unwrap_ok[toml.Table, str](res_manifest);
-    val res_dep_root: R.Result[str, str] = join2(?a, ".", dep_dir_name(?mt)::*u8);
+    val res_dep_root: R.Result[str, str] = join2(?a, ".", "dep");
     if (R.is_err[str, str](res_dep_root)) { ret err_oom(); }
     val dep_root: str = R.unwrap_ok[str, str](res_dep_root);
 
@@ -800,7 +799,7 @@ fun dep_list() i64 {
         ret 0;
     }
 
-    val res_dep_root: R.Result[str, str] = join2(?a, ".", dep_dir_name(?mt)::*u8);
+    val res_dep_root: R.Result[str, str] = join2(?a, ".", "dep");
     if (R.is_err[str, str](res_dep_root)) { ret err_oom(); }
     val dep_root: str = R.unwrap_ok[str, str](res_dep_root);
     val lock_deps: *toml.Table = read_lock_deps(?a, LOCKFILE::str, nil);
@@ -1678,32 +1677,17 @@ fun dep_header(a: *A.Allocator, name: *u8) R.Result[*u8, str] {
     ret R.ok[*u8, str](buf::str);
 }
 
-# the dep directory `<dep>/<name>/` for a dependency of the current project
+# the dep directory `dep/<name>/` for a dependency of the current project
 #
-# Resolved through the manifest's `[project].dep`.
+# The store lives at the `dep/` convention (there is no key to configure it).
 # ---
-# a:    allocator for reading and the joined path
+# a:    allocator for the joined path
 # name: the dependency name
 # ret:  the dep directory path, or an error
 fun dep_dir_path(a: *A.Allocator, name: *u8) R.Result[str, str] {
-    val res_table: R.Result[toml.Table, str] = parse_file(a, MANIFEST::str);
-    if (R.is_err[toml.Table, str](res_table)) { ret R.err[str, str](R.unwrap_err[toml.Table, str](res_table)); }
-    var t: toml.Table = R.unwrap_ok[toml.Table, str](res_table);
-    val res_root: R.Result[str, str] = join2(a, ".", dep_dir_name(?t)::*u8);
+    val res_root: R.Result[str, str] = join2(a, ".", "dep");
     if (R.is_err[str, str](res_root)) { ret res_root; }
     ret join2(a, R.unwrap_ok[str, str](res_root), name);
-}
-
-# the project's dep-dir name from a parsed manifest
-#
-# Reads `[project].dep`, defaulting to "dep".
-# ---
-# mt:  the parsed manifest table
-# ret: the dep-dir name
-fun dep_dir_name(mt: *toml.Table) str {
-    val d: str = toml.get_str(mt, "project.dep");
-    if (str_empty(d)) { ret "dep"; }
-    ret d;
 }
 
 # the name of the i-th forwarded environment variable

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -9,6 +9,7 @@
 # that yields an error message.
 
 use std.types.bool.bool;
+use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 
@@ -30,11 +31,7 @@ use mach.cli.util;
 # emit_ir:     --emit-ir was passed; emit per-module human-readable SSA IR text
 #              (`.ir`) alongside each object, for debugging / transparency - the
 #              final post-pipeline IR the object is built from, so it varies with
-#              the optimization level
-# no_emit_asm: --no-emit-asm was passed; force ASM emission off (the complement of
-#              --emit-asm; IR/ASM emission is CLI-only)
-# no_emit_ir:  --no-emit-ir was passed; force IR emission off (the complement of
-#              --emit-ir; IR/ASM emission is CLI-only)
+#              the optimization level. IR/ASM emission is CLI-only and off by default
 # profile:     --profile <name> selected build profile for a v2 manifest (nil
 #              when not given)
 # bin:         --bin <name> narrows a v2 build to one `[bin.*]` artifact (nil
@@ -55,8 +52,6 @@ pub rec Config {
     output:      *u8;
     emit_asm:    bool;
     emit_ir:     bool;
-    no_emit_asm: bool;
-    no_emit_ir:  bool;
     profile:     *u8;
     bin:         *u8;
     lib:         *u8;
@@ -99,8 +94,6 @@ pub fun parse(argc: usize, argv: **u8, marks: *bool) R.Result[Config, str] {
     c.verify_ir   = util.mark_flag(marks, argc, argv, "--verify-ir");
     c.emit_asm    = util.mark_flag(marks, argc, argv, "--emit-asm");
     c.emit_ir     = util.mark_flag(marks, argc, argv, "--emit-ir");
-    c.no_emit_asm = util.mark_flag(marks, argc, argv, "--no-emit-asm");
-    c.no_emit_ir  = util.mark_flag(marks, argc, argv, "--no-emit-ir");
     c.all_targets = util.mark_flag(marks, argc, argv, "--all-targets");
     c.pie         = util.mark_flag(marks, argc, argv, "--pie");
     c.g           = util.mark_flag(marks, argc, argv, "-g");
@@ -130,4 +123,36 @@ fun flag_value_get(marks: *bool, argc: usize, argv: **u8, flag: *u8) *u8 {
     val opt_value: O.Option[*u8] = util.mark_value(marks, argc, argv, flag);
     if (O.is_none[*u8](opt_value)) { ret nil; }
     ret O.unwrap[*u8](opt_value);
+}
+
+# the removed pre-flag-day flags (#1999) are no longer marked by parse, so the
+# unknown-flag rejector reports them, while --emit-ir/--emit-asm stay recognized
+test "mach.cli.config.parse:removed_flags_rejected" {
+    var a:  [4]*u8;
+    a[0] = "mach"; a[1] = "build"; a[3] = ".";
+    var ma: [4]bool;
+
+    # each removed flag is unmarked by parse and so reported as unknown.
+    var removed: [3]*u8;
+    removed[0] = "--release"; removed[1] = "--no-emit-ir"; removed[2] = "--no-emit-asm";
+    var r: usize = 0;
+    for (r < 3) {
+        a[2] = removed[r];
+        var i: usize = 0;
+        for (i < 4) { ma[i] = false; i = i + 1; }
+        if (R.is_err[Config, str](parse(4, ?a[0], ?ma[0])))            { ret 1; }
+        if (!util.reject_unknown(4, ?a[0], ?ma[0], 2, "mach build"))   { ret 1; }
+        r = r + 1;
+    }
+
+    # --emit-ir stays recognized: parse marks it, so the rejector accepts it.
+    a[2] = "--emit-ir";
+    var j: usize = 0;
+    for (j < 4) { ma[j] = false; j = j + 1; }
+    if (R.is_err[Config, str](parse(4, ?a[0], ?ma[0])))          { ret 1; }
+    if (util.reject_unknown(4, ?a[0], ?ma[0], 2, "mach build"))  { ret 1; }
+
+    # -O2 stays a recognized per-invocation override (marked by mach build's own
+    # flag pass, not parse) — it is left for the e2e demo to exercise end to end.
+    ret 0;
 }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -261,6 +261,10 @@ pub fun reject_unknown(argc: usize, argv: **u8, marks: *bool, start: usize, cmd:
             print.eprint("' for '");
             print.eprint(cmd::str);
             print.eprint("'\n");
+            # --release was replaced by profile selection; point at the successor.
+            if (str_equals(argv[i]::str, "--release")) {
+                print.eprint("hint: optimisation comes from the profile; use --profile release\n");
+            }
             ret true;
         }
         i = i + 1;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -3033,7 +3033,7 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) R.Result[session.Module
     # teardown never frees m.a, so a never-parsed entry needs no placeholder AST.
     m.a                 = nil;
     # resolve the active optimization mode for `$mach.build.mode`: an explicit CLI
-    # `-O*`/`--release` flag wins, else the selected target's manifest opt, else
+    # `-O*` flag wins, else the selected target's manifest opt, else
     # debug - mirroring cmd.build.resolve_opt_level so the gate matches the pipeline.
     var build_mode_id: u32 = comptime.MODE_DEBUG;
     if (p.s.opt_explicit) {

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -132,7 +132,7 @@ pub rec Session {
     registry: target.TargetRegistry;
 
     # CLI optimization intent, set before the build so the comptime ctx can
-    # resolve `$mach.build.mode`. opt_explicit marks an explicit `-O*`/`--release`
+    # resolve `$mach.build.mode`. opt_explicit marks an explicit `-O*`
     # flag (it wins over the manifest); opt_release is its release-vs-debug sense.
     opt_explicit: bool;
     opt_release:  bool;


### PR DESCRIPTION
Closes #1999

Removes the pre-flag-day CLI/driver leftovers the #1977 docs rewrite surfaced, per the rulings in the issue.

## Changes

1. **`--release` remnant removed.** `build.mach` no longer applies `--release` to the pipeline (it was applied but never marked, so already rejected as unknown). The unknown-flag rejector now hints `--profile release` for it. Stale `--release` comments across build/session/driver cleaned up.
2. **`--no-emit-ir`/`--no-emit-asm` removed** — config fields, marking, and the `build.mach` override gone. They negated profile `emit_ir`/`emit_asm` keys that #1996 made CLI-only; `--emit-ir`/`--emit-asm` remain the sole, opt-in emission controls.
3. **`[project].dep` read removed.** `dep.mach` hardcodes the `dep/` convention where `dep_dir_name` read the key (the strict parser rejects `[project].dep`); the now-redundant manifest parse in `dep_dir_path` is dropped. `mach dep pull` behaviour unchanged.
4. **`-O0`/`-O1`/`-O2` kept** as per-invocation opt overrides (as decided); help/doc text unchanged from #1998.

## Tests

- `mach.cli.config.parse:removed_flags_rejected` — `--release`/`--no-emit-ir`/`--no-emit-asm` are unmarked by `parse` and reported by the rejector; `--emit-ir` stays recognized.

## Verification

- Unit suite through a worktree-built compiler: **569 / 0** (dev baseline 568 + the new test).
- Self-host fixpoint: byte-identical.
- `int` linux: **42 / 42**.
- e2e:
  - `mach build . --release` → `unknown flag '--release'` + `hint: optimisation comes from the profile; use --profile release`.
  - `--no-emit-ir` / `--no-emit-asm` → unknown flags.
  - `-O2` vs `-O0` → the emitted IR differs (observably overrides the debug profile's opt).
  - `mach dep pull` → unchanged; store at `dep/mach-std`.