### PR TITLE
release: sweep dev → main (v3.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-07-10
+
+The strictness release. A declared manifest table is now **total** — every field
+is spelled or it is a parse error — so there are no silent defaults to memorize:
+`[project]` is exactly `id`/`version`/`src`/`out`, a filter axis takes a canonical
+`os`/`isa`/`abi` value or `"*"` (a typo like `"windoze"` is rejected rather than
+silently never matching), `[]` says "none" out loud, and the path template set
+closes to `{project.out}`/`{target.name}`/`{profile.name}`. Totality is enforced on
+the manifest being **built**; a **dependency's** manifest parses permissively, read
+only for its export surface, so historical commit pins keep resolving and a project
+never waits on its dependencies to migrate. `static` artifacts now emit a real `ar`
+archive with a symbol index at their declared `out`. The manifest and CLI
+documentation are rewritten against the landed schema, and the pre-flag-day CLI
+leftovers — `--release`, `--no-emit-ir`/`--no-emit-asm`, and the `[project].dep`
+read — are gone. The thirteen first-party repositories were swept to the strict
+shape in lockstep, so no in-house consumer breaks. Built with mach 3.1.0.
+
+> **Breaking:** a root manifest that relied on lenient parsing must now be total —
+> every field of every declared table spelled, canonical filter values, and only
+> the closed template set. Dependency manifests are unaffected (they parse
+> permissively for their export surface). Every first-party repository was
+> converted by the ecosystem sweep (#1971, #1979).
+
+### Added
+- manifest: **`static` artifacts emit a real `ar` archive** with a symbol index at
+  the declared `out`, the deliverable a consumer links as a `.a` (`shared` remains
+  phase 2) (#1980, #1997).
+
+### Changed
+- manifest: **no-defaults totality on the root manifest** (the #1964 flag-day) — a
+  declared table spells every field or it is a parse error; `[project]` is trimmed
+  to `id`/`version`/`src`/`out`; filter axes take a canonical value or `"*"`; the
+  template set closes to `{project.out}`/`{target.name}`/`{profile.name}`; and
+  `emit_ir`/`emit_asm` become CLI-only (#1971, #1996).
+- manifest: a **dependency's manifest parses permissively** — read only for its
+  export surface (project id, `export = true` link entries, and the steps they
+  demand) — so a dependency's own migration state never gates a consumer and
+  historical commit pins keep resolving. Unknown keys are still rejected on both
+  paths (#1971, #1996).
+- doc: **`doc/manifest.md` and `doc/cli.md` rewritten** against the landed strict
+  schema, and the `mach help` text corrected (#1977, #1998).
+- ecosystem: the **thirteen first-party repositories** were migrated to the strict
+  manifest shape in lockstep with the flag-day, so no in-house consumer breaks
+  (#1979).
+
+### Removed
+- cli: **`--release`** (rejected with a `--profile release` hint), **`--no-emit-ir`
+  / `--no-emit-asm`** (emission is CLI-only via `--emit-ir`/`--emit-asm`), and the
+  **`[project].dep` read** (the store is the hardcoded `dep/` convention) — the
+  pre-flag-day leftovers. `-O0`/`-O1`/`-O2` remain as per-invocation opt overrides
+  (#1999, #2000).
+
 ## [3.1.0] - 2026-07-09
 
 The release that makes the V2 build system work as designed. The `[step.X]`

--- a/dbg/fixtures/aggregate/mach.toml
+++ b/dbg/fixtures/aggregate/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "dbgagg"
-name = "dbgagg"
-description = "debug-info fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.dbgagg]
 kind = "bin"
 entry = "main.mach"
 out = "bin/dbgagg"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/dbg/fixtures/inline/mach.toml
+++ b/dbg/fixtures/inline/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "inlinefix"
-name = "inlinefix"
-description = "debug-info fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.inlinefix]
 kind = "bin"
 entry = "main.mach"
 out = "bin/inlinefix"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/dbg/fixtures/inline4/mach.toml
+++ b/dbg/fixtures/inline4/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "inline4fix"
-name = "inline4fix"
-description = "debug-info fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.inline4fix]
 kind = "bin"
 entry = "main.mach"
 out = "bin/inline4fix"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/dbg/fixtures/multi/mach.toml
+++ b/dbg/fixtures/multi/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "dbgfix"
-name = "dbgfix"
-description = "debug-info fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.dbgfix]
 kind = "bin"
 entry = "main.mach"
 out = "bin/dbgfix"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/dbg/fixtures/promote/mach.toml
+++ b/dbg/fixtures/promote/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "promotefix"
-name = "promotefix"
-description = "debug-info fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.promotefix]
 kind = "bin"
 entry = "main.mach"
 out = "bin/promotefix"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -41,7 +41,7 @@ argument forwarding.
 | `run`   | execute the already-built binary (a post-`build` convenience, not a rebuild) |
 | `test`  | build the test binary and run the collected tests |
 | `clean` | remove the project's build output directory trees |
-| `dep`   | manage git-backed dependencies (clone, lock, vendor) under `<dep>` |
+| `dep`   | manage git-backed dependencies (clone, lock, vendor) under `dep` |
 | `init`  | scaffold a new project |
 | `doc`   | generate Markdown reference docs from source doc-comments |
 | `info`  | print compiler version, build host, and registered target capabilities |
@@ -91,8 +91,8 @@ resolved artifact path (its `out` template); for a `static`/`shared` library (or
 with `--emit obj`) the objects are the deliverable and nothing is linked.
 
 The optimisation pipeline comes from the selected profile's `opt` (`--profile
-<name>`, or the first declared profile); there are no `-O`/`--release`
-pipeline-selection flags.
+<name>`, or the first declared profile) — the profile is how a build picks its
+optimisation level.
 
 | Flag           | Value          | Effect |
 |----------------|----------------|--------|
@@ -307,10 +307,10 @@ on an allocator or io failure.
 mach dep <action> [args]
 ```
 
-Manages the project's dependency tree under `<dep>`. Dispatches on `argv[2]`.
+Manages the project's dependency tree under `dep`. Dispatches on `argv[2]`.
 A dependency has exactly one source form: a **git** URL plus a ref, which mach
-acquires into `<dep>/<name>/` with plain git operations, or a **path** to another
-project tree, never fetched but materialised at `<dep>/<name>/` as a relative
+acquires into `dep/<name>/` with plain git operations, or a **path** to another
+project tree, never fetched but materialised at `dep/<name>/` as a relative
 symlink so the build resolves it by the same vendor layout.
 
 | Action   | Args | Effect |
@@ -334,7 +334,7 @@ invoked with an allowlisted environment (`PATH`, `HOME`, and the common
 git/ssh/proxy/CA variables). Git's absence is a clean error naming the operation
 that needed it.
 
-For each git dependency, `pull` clones the `git` URL into `<dep>/<name>/` when
+For each git dependency, `pull` clones the `git` URL into `dep/<name>/` when
 absent, then checks out the resolved commit as a **detached HEAD**
 (`git checkout --detach`). A ref resolves as: `branch/<n>` (the remote-tracking
 branch tip), `tag/<n>`, `commit/<n>` or a 7–40 char hex SHA (the literal commit),
@@ -344,7 +344,7 @@ plain git operations, so a checkout the user also commits as a **submodule**
 composes naturally — a moved checkout surfaces as gitlink drift in the parent
 repo's `git status`. mach never invokes `git submodule`.
 
-A **non-empty** directory present under `<dep>/<name>/` without a `.git` entry,
+A **non-empty** directory present under `dep/<name>/` without a `.git` entry,
 while the manifest declares it a git dep, is a hard error: declare it a `path`
 dependency if those are vendored files. (`.git` as a file — a submodule gitlink —
 counts as a checkout.) An **empty** directory has nothing to vendor and is treated
@@ -352,7 +352,7 @@ as absent — `pull` clones into it — so a plain `git clone` (without
 `--recurse-submodules`), which leaves a submodule dep dir empty, is repaired by a
 plain `mach dep pull` (#1329).
 
-For each **path** dependency, `pull` materialises the source at `<dep>/<name>/` as
+For each **path** dependency, `pull` materialises the source at `dep/<name>/` as
 a relative symlink, so the build resolves its modules by the same vendor layout as
 a git dep. The `path` is resolved relative to the requiring manifest's directory;
 the link is relative, so a tree that moves as a whole (a monorepo, a committed
@@ -366,7 +366,7 @@ by a real directory (a stale git checkout, foreign vendored files) is a hard err
 ### Transitive resolution
 
 Transitive deps resolve into the **flat dep tree**: every git dep, direct or
-transitive, lives at `<dep>/<name>/`, so a dependency's own
+transitive, lives at `dep/<name>/`, so a dependency's own
 `[target.*].libs` cascade into the consumer's build (see `manifest.md`). The same
 name required from two different sources or refs is a hard error naming both
 requirers; there is no version resolution (reserved for the registry era).

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -37,7 +37,7 @@ argument forwarding.
 
 | Command | Summary |
 |---------|---------|
-| `build` | compile the project to objects and (for a `[bin.*]`) a linked binary |
+| `build` | compile the project to objects and (for a `bin` artifact) a linked binary |
 | `run`   | execute the already-built binary (a post-`build` convenience, not a rebuild) |
 | `test`  | build the test binary and run the collected tests |
 | `clean` | remove the project's build output directory trees |
@@ -57,16 +57,14 @@ A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 | `-v`             | —                | `mach build`: per-phase roll-up (load/resolve/sema/lower/optimize/codegen/link) with item counts + timing, then a `built … N modules … in …` summary, on stderr |
 | `-vv`            | —                | `-v` plus a per-module/file line under each phase with its duration and a `(slow)` marker on the slowest |
 | `--quiet`, `-q`  | —                | suppress non-error output |
-| `--target <name>`| target name      | select a declared target; absent, defers to `[project].target` |
-| `--profile <name>`| profile name    | select a `[profile.<name>]` build variant; absent, the first declared profile |
-| `--bin <name>`   | artifact name    | narrow the build to one `[bin.<name>]` artifact |
-| `--lib <name>`   | artifact name    | narrow the build to one `[lib.<name>]` artifact (mutually exclusive with `--bin`) |
+| `--target <name>`| target name      | select a declared target; absent, resolves the host-matching declared target (`native`) |
+| `--profile <name>`| profile name    | select a `[profile.<name>]` build variant, whose `opt` sets the optimisation pipeline; absent, the first declared profile |
+| `--bin <name>`   | artifact name    | narrow the build to one `bin` `[artifact.<name>]` |
+| `--lib <name>`   | artifact name    | narrow the build to one `static`/`shared` `[artifact.<name>]` (mutually exclusive with `--bin`) |
 | `-o <path>`      | path             | override the artifact path, rooted at the project root (build/run/test) |
 | `--all-targets`  | —                | build every declared `[target.*]`, not just the default (mutually exclusive with `-o`, which names one path) |
-| `--emit-asm`     | —                | emit per-module assembly text (`.s`); forces the selected profile's `emit_asm` on |
-| `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`) — the final post-pipeline IR the object is built from, so it varies with `-O`; forces the selected profile's `emit_ir` on |
-| `--no-emit-asm`  | —                | force per-module assembly emission off, overriding the profile's `emit_asm` |
-| `--no-emit-ir`   | —                | force per-module IR emission off, overriding the profile's `emit_ir` |
+| `--emit-asm`     | —                | emit per-module assembly text (`.s`) — emission is opt-in, controlled only by this flag |
+| `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`), the final post-pipeline IR the object is built from (so it varies with the profile's `opt`) — emission is opt-in, controlled only by this flag |
 | `--verify-ir`    | —                | run the IR verifier after each optimisation pass |
 
 > Under `mach test`, the entry module's `--emit-ir` dump shows the neutralized
@@ -83,21 +81,21 @@ A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 mach build <path> [options]
 ```
 
-Compiles the project rooted at `<path>` (e.g. `mach build .`). With no
-`--bin`/`--lib`, it builds every declared
-artifact for the default target and profile. Every reachable module is driven
-through sema → lower → optimise → codegen to one relocatable object, written
-under the manifest's resolved `obj` template at `<obj>/<fqn-as-path>.o`. For a
-`[bin.*]` the objects are linked into the resolved artifact path (the `out`
-template); for a `[lib.*]` (or with `--emit obj`) the objects are the deliverable
-and nothing is linked.
+Compiles the project named by `<path>` — a project directory (whose `mach.toml`
+is read) or a manifest file directly (e.g. `mach build .` or `mach build ci.toml`).
+With no `--bin`/`--lib`, it builds every declared artifact for the selected target
+and profile. Every reachable module is driven through sema → lower → optimise →
+codegen to one relocatable object, written under the resolved object tree at
+`<out>/obj/<fqn-as-path>.o`. For a `bin` artifact the objects are linked into the
+resolved artifact path (its `out` template); for a `static`/`shared` library (or
+with `--emit obj`) the objects are the deliverable and nothing is linked.
+
+The optimisation pipeline comes from the selected profile's `opt` (`--profile
+<name>`, or the first declared profile); there are no `-O`/`--release`
+pipeline-selection flags.
 
 | Flag           | Value          | Effect |
 |----------------|----------------|--------|
-| `--release`    | —              | select the release optimisation pipeline |
-| `-O0`          | —              | force the debug pipeline (overrides `--release`) |
-| `-O1`          | —              | select the release pipeline |
-| `-O2`          | —              | select the release pipeline |
 | `-g`           | —              | emit debug info for this build, forcing the selected profile's `debug` on (precedence `-g` > profile > off) |
 | `--emit <kind>`| `obj`\|`exe`   | `obj` stops at the relocatable objects; `exe` (default) links a binary |
 | `--pie`        | —              | emit a position-independent (ET_DYN) executable for ASLR instead of the default fixed-address one; opt-in (see below) |
@@ -105,10 +103,7 @@ and nothing is linked.
 | `-l <name>`    | name           | link a named object, archive, or shared library, resolved through the `-L` dirs (see below); repeatable |
 | *(positional)* | input path     | a bare argument that contains `/`, ends in `.o` / `.a`, or names a `.so` is linked verbatim |
 
-Plus the global flags above. The `-O<n>` flags override `--release` when both
-are present; absent any optimisation flag the build uses the debug pipeline
-(the bootstrap-stable default). `-O1` and `-O2` currently select the same
-release pipeline.
+Plus the global flags above.
 
 `--pie` is an opt-in: without it, a linux executable links fixed-address
 (`ET_EXEC`) exactly as before — a normal build is byte-identical. With it, the
@@ -122,9 +117,9 @@ dependency is rejected.
 `ext fun` declarations are forward references whose definitions are supplied at
 link time by external precompiled code — a loose `.o` object, a static `.a`
 archive, or a shared `.so` library. Those inputs come from the command line and
-from the manifest's merged `libs` overlay (`[target.*]`, `[bin.*]`/`[lib.*]`, and
-per-cell, see [manifest.md](manifest.md)); both sets are linked. An input that
-resolves to no
+from the manifest's matching `[link.X]` entries — an artifact's referenced entries
+plus exported dependency entries whose `os`/`isa`/`abi` filters match the build
+(see [manifest.md](manifest.md)); both sets are linked. An input that resolves to no
 existing file is a hard error, so a typo never silently drops a dependency.
 
 - **Explicit input path** — a bare (non-flag) argument that contains a `/`, ends
@@ -179,17 +174,17 @@ mach run <path> [options] [-- args...]
 ```
 
 Executes the binary `mach build` already produced for `<path>` — a post-build
-convenience, **not** a rebuild. The same selection flags (`--target`,
-`--profile`/`--release`, `--bin`) that narrow a build resolve which artifact to
-run; its path is read from the manifest's `out` template and the existing file
-is exec'd. When the artifact does not exist yet, `mach run` errors and points at
-`mach build` rather than building it.
+convenience, **not** a rebuild. The same selection flags (`--target`, `--profile`,
+`--bin`) that narrow a build resolve which artifact to run; its path is read from
+the artifact's `out` template and the existing file is exec'd. When the artifact
+does not exist yet, `mach run` errors and points at `mach build` rather than
+building it.
 Arguments after a `--` separator are forwarded to the child as its `argv`. The
 child's exit code becomes this command's exit code.
 
 `--emit` is rejected — running a relocatable object is not meaningful. The
-`build` selection and global flags apply; build-only flags (`-O*`, `--emit-*`)
-are accepted but have no effect, since nothing is built.
+`build` selection and global flags apply; build-only flags (`--emit-*`) are
+accepted but have no effect, since nothing is built.
 
 | Flag             | Value   | Effect |
 |------------------|---------|--------|
@@ -288,16 +283,16 @@ Exit codes: `0` all passed, `1` any failed, `2` build/internal error.
 ## `mach clean`
 
 ```
-mach clean [path]
+mach clean <path>
 ```
 
-Removes the project's build output. The trees removed are the static directory
-prefixes of the manifest's `out`/`obj`/`ir`/`asm` templates — the leading path
-components before the first `{...}` placeholder — so the whole output tree is
-cleared regardless of target or profile. Because it is driven by the templates, a
-project that relocates its output (`out = "build/..."`) is cleaned at that root
-rather than a hardcoded `out/`. `[path]` selects the project (default: the working
-directory, walking up to the nearest `mach.toml`).
+Removes the project's build output. The tree removed is the static directory
+prefix of the manifest's `out` template — the leading path components before the
+first `{...}` placeholder — so the whole output tree is cleared regardless of
+target or profile. Because it is driven by the template, a project that relocates
+its output (`out = "build/..."`) is cleaned at that root rather than a hardcoded
+`out/`. `<path>` names the project (a directory or a manifest file), like every
+project-rooted command.
 
 Only the manifest is read: no module graph is loaded and nothing under the
 dependency dir is touched. Removal is idempotent (`mach clean` on an already-clean
@@ -322,9 +317,9 @@ symlink so the build resolves it by the same vendor layout.
 |----------|------|--------|
 | `pull`   | — | realise the manifest: clone missing git deps (transitively), link path deps, re-resolve a changed ref, repair checkout-vs-lock drift, write `mach.lock`. Idempotent; the command routine use needs. |
 | `update` | `<name> \| --all` | the only lock-advancer: re-resolve branch refs to current remote tips. Tag/commit refs are an immutable no-op. Never edits the manifest. |
-| `add`    | `<name> --git <url> [--ref <ref>] \| --path <dir>` | append a `[deps.<name>]` `git`/`path` stanza to the manifest, then `pull`. |
-| `remove` | `<name> [--purge]` | drop the entry from `mach.toml` and `mach.lock`; `--purge` also deletes `<dep>/<name>/`. |
-| `list`   | — | print each `[deps.<name>]` entry with its source form, ref, locked commit, and state (`synced`/`missing`/`drifted`/`path`). |
+| `add`    | `<name> --git <url> [--ref <ref>] \| --path <dir>` | append a `[dep.<name>]` `git`/`path` stanza to the manifest, then `pull`. |
+| `remove` | `<name> [--purge]` | drop the entry from `mach.toml` and `mach.lock`; `--purge` also deletes `dep/<name>/`. |
+| `list`   | — | print each `[dep.<name>]` entry with its source form, ref, locked commit, and state (`synced`/`missing`/`drifted`/`path`). |
 
 `sync` is the pre-`pull` name, kept one cycle as a hidden alias that prints a
 deprecation note and runs `pull`.
@@ -383,13 +378,12 @@ The manifest is intent; the lock is the record of resolving it. After a `pull`,
 and resolved `commit` (path deps have no lock entry):
 
 ```toml
-# generated by `mach dep pull`; do not edit by hand.
-version = 1
+# this file is automatically generated; do not edit by hand.
 
-[deps.mach-std]
+[dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
-ref = "branch/dev"
-commit = "6b78ae1e8c3c9cc45e4ab4b916fd191d61e76aff"
+ref = "branch/main"
+commit = "9c6eb77880de143090ef48645ba7353ec786d758"
 ```
 
 `pull` honours the lock except where the manifest ref was edited — there it
@@ -400,7 +394,7 @@ to their current tips. The lock writer is idempotent: an up-to-date lock is left
 untouched. Commit `mach.lock` to pin builds.
 
 `mach dep` reads `mach.toml` from the current directory directly (it does not walk
-up to find a project root); each `[deps.<name>]` declares exactly one of
+up to find a project root); each `[dep.<name>]` declares exactly one of
 `git`/`path`, with `ref` for git (see `manifest.md`). Exit codes: `0` ok, `1` user
 error, `2` internal error.
 
@@ -412,8 +406,8 @@ mach init [dir] [options]
 
 Scaffolds a new project in `[dir]` (default: the current directory). Writes a
 complete `mach.toml` with a `[project]` block, `[target.*]` platforms for
-`linux`/`windows`/`darwin` (on the host ISA), one `[bin.*]`/`[lib.*]` artifact,
-`[profile.debug]`/`[profile.release]` variants, a `[deps.mach-std]` dependency, a
+`linux`/`windows`/`darwin` (on the host ISA), one `[artifact.<id>]`,
+`[profile.debug]`/`[profile.release]` variants, a `[dep.mach-std]` dependency, a
 starter source file, and `dep/mach-std/` cloned from the declared ref (through
 the same path as `mach dep pull`). Refuses to overwrite an existing `mach.toml`,
 `src/main.mach`, or `src/lib.mach` unless `--force`; every collision is checked
@@ -423,7 +417,7 @@ before any file is written, so a refused init leaves nothing behind.
 |----------------|-------|--------|
 | `--name <name>`| name  | project id (default: the directory base name) |
 | `--force`      | —     | scaffold even when `mach.toml`, `src/main.mach`, or `src/lib.mach` already exists |
-| `--lib`        | —     | library layout: write `src/lib.mach` instead of `src/main.mach`, and scaffold a `[lib.<id>]` artifact (`kind = "static"`) instead of `[bin.<id>]` |
+| `--lib`        | —     | library layout: write `src/lib.mach` instead of `src/main.mach`, and scaffold a `static` `[artifact.<id>]` instead of a `bin` one |
 
 The first non-flag argument after `init` is the target directory.
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -1,329 +1,407 @@
 # `mach.toml` — the project manifest
 
-Every Mach project has a `mach.toml` at its root. It is the complete, readable
-statement of what the project builds: its identity, the platforms it targets, the
-artifacts it produces, the build variants it offers, and its dependencies. The
-compiler finds it by walking up from the working directory until a `mach.toml` is
-seen, so any subcommand run inside a project tree resolves the same manifest.
+A Mach project is described by a `mach.toml` at its root: its identity, the
+platforms it targets, the artifacts it produces, the build variants it offers, its
+external link requirements, the build steps that produce them, and its
+dependencies. Every `mach` subcommand takes the project explicitly — a directory
+(whose `mach.toml` is read) or a manifest file directly — so the manifest a build
+uses is never guessed from the working directory. See [cli.md](cli.md) for the
+path argument.
 
-The manifest separates the three orthogonal axes of a build — *what* is built
-(`[bin.*]`/`[lib.*]` artifacts), *where* it runs (`[target.*]` platforms), and
-*where* outputs land (the `out`/`obj`/`ir`/`asm` path templates). Repetition
-between axes is eliminated by the build engine's cartesian product, never by the
-file. Nothing is inferred: every value resolves from a stanza present in the file.
+The manifest is built from `[category.name]` tables in seven sections —
+`[project]`, `[target.X]`, `[profile.X]`, `[artifact.X]`, `[link.X]`, `[step.X]`,
+and `[dep.X]`. TOML itself enforces name uniqueness within a section.
 
-## The schema
+## Convention, then totality
+
+Convention covers what is *absent*: with no manifest at all, `src/` is the module
+tree, `src/main.mach` the entry, and a single native debug binary the build — a
+pure-mach single-binary project needs no `mach.toml`. Convention operates on absent
+manifests and absent sections, never on absent fields.
+
+A table you *declare*, you declare completely. Every field of a declared table is
+required; a missing field is a strict-parse error, not a silent default. This is
+the manifest twin of Mach's explicitness: there are no field defaults to memorize,
+because "any" and "none" are said out loud —
+
+- `"*"` is the explicit any-token for a filter axis or `targets` entry;
+- `[]` is the explicit empty list ("none").
+
+The sole exception is **shape-dependence**: a field whose presence follows another
+value in the same table. A dependency is `git` *or* `path`; a `[link.X]` names a
+`name` *or* a `path` according to its `source`. Nothing else defaults.
+
+Unknown sections and unknown keys are always errors. A path value is always
+`/`-separated; a literal `\` is rejected (`manifest paths use '/'`), so the same
+manifest is portable and is normalized to the host separator at the filesystem
+boundary.
+
+### Root vs. dependency strictness
+
+Manifest strictness is scoped to the manifest being **built**: mach enforces the
+no-defaults totality rules on your project's own `mach.toml` (the root of the
+build), but parses a **dependency's** `mach.toml` permissively, reading only its
+export surface (project id, `export = true` link entries, and the steps those
+entries demand). A dependency's own totality is enforced when that dependency is
+built as a root — so a project need not wait for its dependencies to migrate, and
+historical commit pins keep resolving. Unknown keys are always rejected, in a root
+or a dependency.
+
+## The schema at a glance
 
 ```toml
 [project]
-id      = "demo"            # required: root of every module path the project exposes
-version = "0.1.0"           # required
-src     = "src"             # source dir (default "src")
-dep     = "dep"             # vendored-dependency dir (default "dep")
-target  = "native"          # default target selector (default "native")
-out     = "out/{target}/{profile}/bin/{name}{ext}"  # artifact path template
-obj     = "out/{target}/{profile}/obj"              # intermediate-object dir template
-ir      = "out/{target}/{profile}/ir"               # IR-dump dir template
-asm     = "out/{target}/{profile}/asm"              # ASM-dump dir template
-tests   = "out/{target}/{profile}/test/{name}"      # test dispatcher executable path template (mach test)
-# optional metadata: name, description, license, authors
+id      = "demo"                       # required: identifier; root of every module path
+version = "0.1.0"                      # required
+src     = "src"                        # required: source dir, project-root-relative
+out     = "out/{target.name}/{profile.name}"  # required: output-path template root
 
-[target.linux]             # a platform: a fully-spelled tuple, nothing inferred
+[target.linux]                         # a platform: a fully-spelled tuple
 isa = "x86_64"
 os  = "linux"
 abi = "sysv64"
 
-[target.windows]
-isa     = "x86_64"
-os      = "windows"
-abi     = "win64"
-ext     = ".exe"           # artifact extension (default "")
-libs    = ["kernel32.dll"] # platform link overlay, inherited by every artifact
-defines = []               # per-target comptime defines (#1191)
+[profile.debug]                        # a build variant
+opt   = 0                              # 0 (debug pipeline) | 1 | 2 (release pipeline)
+debug = true                           # emit debug info for this profile
 
-[bin.hello]                # an executable artifact, named by its table key
-entry = "hello.mach"       # entry source, relative to the src dir (required)
+[artifact.demo]                        # a produced artifact
+kind    = "bin"                        # "bin" | "static" | "shared"
+entry   = "main.mach"                  # entry source, relative to src
+out     = "{project.out}/bin/demo"     # this artifact's output path
+targets = ["*"]                        # which declared targets build it ("*" = all)
+link    = []                           # [link.X] names this artifact links
+need    = []                           # [step.X] names this artifact demands directly
 
-[lib.core]                 # a library artifact
-entry = "lib.mach"
-kind  = "static"           # "static" (default) | "shared"
-
-[bin.hello.target.windows] # a per-cell exception refining one artifact-target pair
-entry = "hello_win.mach"   # overrides the artifact's entry for this target only
-libs  = ["user32.dll"]     # appended to the merged link overlay
-
-[profile.debug]            # a build variant
-opt   = 0                  # 0 (no optimization) | 1 (standard) | 2 (aggressive)
-debug = true               # emit debug info for this profile (default false)
-
-[profile.release]
-opt      = 2
-emit_ir  = true            # emit per-module post-pipeline IR for this profile (default false)
-emit_asm = false           # emit per-module assembly for this profile (default false)
-debug    = false           # release-with-symbols: set true to keep debug info in a release profile
-
-[deps.mach-std]            # a dependency: exactly one of git|path, plus ref for git
+[dep.std]                              # a dependency
 git = "https://github.com/briar-systems/mach-std"
-ref = "v0.4.0"
+ref = "branch/main"
 ```
+
+`[link.X]` and `[step.X]` are shown under [Link requirements](#linkx--link-requirements)
+and [Build steps](#stepx--build-steps).
 
 ## `[project]`
 
-| Key       | Type   | Required | Default    | Meaning |
-|-----------|--------|----------|------------|---------|
-| `id`      | string | yes      | —          | Root segment of every module path the project exposes. A file at `<src>/foo/bar.mach` is reachable as `<id>.foo.bar`. |
-| `version` | string | yes      | —          | Project version. Read by the `$project.version` comptime root. |
-| `module`  | string | no       | —          | Src-relative path of the module a bare `use <id>;` / `fwd <id>;` resolves to (see [Bare project-id imports](#bare-project-id-imports)). Never inferred; a library that wants to be importable by its id declares it. A declared path naming no file is an error at build start. |
-| `src`     | string | no       | `"src"`    | Source root, relative to the project root. Module paths resolve under it. |
-| `dep`     | string | no       | `"dep"`    | Vendored-dependency root, relative to the project root. Each dep lives at `<dep>/<alias>/`. |
-| `target`  | string | no       | `"native"` | Default target selector when `--target` is not passed. `native` resolves to the declared target whose tuple matches the host. |
-| `out`     | string | no       | `"out/{target}/{profile}/bin/{name}{ext}"` | Artifact path template (see [Path templates](#path-templates)). |
-| `obj`     | string | no       | `"out/{target}/{profile}/obj"` | Per-module object tree template. |
-| `ir`      | string | no       | `"out/{target}/{profile}/ir"`  | Per-module IR-dump template (used when emission is on). |
-| `asm`     | string | no       | `"out/{target}/{profile}/asm"` | Per-module assembly-dump template (used when emission is on). |
-| `tests`   | string | no       | `"out/{target}/{profile}/test/{name}"` | Test dispatcher executable path template. `mach test` builds one executable covering every collected `test` block here, with `{name}` the product name (see below). |
+| Key       | Type   | Meaning |
+|-----------|--------|---------|
+| `id`      | string | Root segment of every module path the project exposes: a file at `<src>/foo/bar.mach` is reachable as `<id>.foo.bar`. Must be a plain identifier — letters, digits, `_`, `-` — since it names the dependency store and keys step stamp files. Read by `$project.id`. |
+| `version` | string | Project version. Read by `$project.version`; the source of truth a Go-style `tag/<version>` acquisition checks. |
+| `src`     | string | Source root, project-root-relative. Module paths resolve under it. |
+| `out`     | string | The output-path template root, referenced as `{project.out}` by artifact `out`, step paths, and `cmd`s. Expanded over `{target.name}`/`{profile.name}` (see [Path templates](#path-templates)). |
 
-Optional metadata read by the `$project.*` comptime roots but not the build:
-`name`, `description`, `license`, `authors`.
+`[project]` is exactly these four keys; `name`, `description`, and any other key
+are unknown-key errors in a root manifest.
 
 ## `[target.<name>]`
 
-Each `<name>` is a selector you pass to `--target <name>` (or set as
-`[project].target`). At least one target must be declared. A target is a
+Each `<name>` is a selector you pass to `--target <name>`. A target is a
 fully-spelled platform tuple; nothing is inferred from another key. `native` is a
-reserved name — declaring `[target.native]` is an error.
+reserved name — declaring `[target.native]` is an error, because `native` resolves
+to whichever *declared* target matches the host.
 
-| Key       | Type   | Required | Default | Meaning |
-|-----------|--------|----------|---------|---------|
-| `isa`     | string | yes      | —       | Instruction-set architecture. Read by `$project.target.arch`. See the accepted set below. |
-| `os`      | string | yes      | —       | Operating system. Read by `$project.target.os`. See the accepted set below. |
-| `abi`     | string | yes      | —       | Application binary interface (e.g. `sysv64`, `win64`). Read by `$project.target.abi`. |
-| `ext`     | string | no       | `""`    | Artifact filename extension expanded by `{ext}` (e.g. `".exe"`). |
-| `libs`    | array of strings | no | `[]` | Platform link overlay — external link inputs inherited by every artifact built for this target (see [Link inputs](#link-inputs)). |
-| `defines` | array of strings | no | `[]` | Per-target comptime defines (#1191). Each is `NAME` (a `true` flag) or `NAME=VALUE`; readable as `$mach.build.NAME`. |
+| Key   | Required | Meaning |
+|-------|----------|---------|
+| `isa` | yes      | Instruction-set architecture. Read by `$project.target.arch`. |
+| `os`  | yes      | Operating system. Read by `$project.target.os`. |
+| `abi` | yes      | Application binary interface. Read by `$project.target.abi`. |
+| `of`  | no       | Object-format override; defers to the os's format when omitted (the one optional target key). See [Object-format override](#object-format-override). |
 
-### Accepted `isa` values
+### Accepted tuple values
 
-| Value     | Status |
-|-----------|--------|
-| `x86_64`  | supported — the primary ISA |
-| `aarch64` | supported — CI builds and runs linux-arm64 natively on every PR |
-| `riscv64` | supported — CI runs under qemu on every PR; self-hosting target (#1852) |
+| Axis  | Values |
+|-------|--------|
+| `isa` | `x86_64`, `aarch64`, `riscv64` |
+| `os`  | `linux`, `windows`, `darwin`, `freestanding` |
+| `abi` | `sysv64`, `win64`, `aapcs64`, `lp64` |
 
-### Accepted `os` values
+`x86_64`/`linux`/`sysv64` is the primary host and target. `aarch64`-linux builds
+and runs natively in CI on every PR; `riscv64`-linux runs under qemu and
+self-hosts (#1852). `windows` is a supported cross-compilation target (PE/COFF,
+Win64 ABI). `darwin`'s ABI and object-format support exist but the toolchain is not
+yet validated end-to-end. `freestanding` targets a raw flat image with no OS
+runtime.
 
-| Value     | Status |
-|-----------|--------|
-| `linux`   | supported — the primary host/target |
-| `windows` | supported as a cross-compilation target (PE/COFF, Win64 ABI) |
-| `darwin`  | recognized; ABI/object-format vtables exist, but the toolchain is not yet validated end-to-end |
+A value outside its axis's set is a strict-parse error, so a typo is caught rather
+than silently never matching.
 
-## `[bin.<name>]` / `[lib.<name>]`
+### Object-format override
 
-Every artifact is declared explicitly and named by its table key. A `[bin.*]`
-links an executable; a `[lib.*]` produces a library. The artifact name drives
-`{name}` in the output templates and is read by `$bin.name`.
+`of` overrides the object format an OS implies. Each os has a default format —
+`linux` → `elf`, `windows` → `coff`, `darwin` → `macho`, `freestanding` → `raw` —
+and `of` names a different one from the same closed set: `elf`, `coff`, `macho`,
+`raw`. It is the only optional key on a target; omit it to take the os default.
 
-| Key       | Type   | Applies | Required | Default | Meaning |
-|-----------|--------|---------|----------|---------|---------|
-| `entry`   | string | bin, lib | yes     | —        | Entry source, relative to the project `src` dir. The entry module's FQN is `<id>.<entry without .mach>`, with `/` turned into `.`. |
-| `kind`    | string | lib      | no       | `"static"` | `"static"` leaves the per-module objects as the deliverable; `"shared"` produces a shared library. |
-| `out`     | string | bin, lib | no       | project `out` | Per-artifact override of the artifact path template. |
-| `libs`    | array of strings | bin, lib | no | `[]` | Per-artifact link inputs, merged into the link overlay. |
-| `defines` | array of strings | bin, lib | no | `[]` | Per-artifact comptime defines. |
-
-### `[bin.<name>.target.<t>]` per-cell exceptions
-
-A per-cell table refines one artifact for one target. It may override `entry` and
-`out`, and append `libs`/`defines` at the highest precedence level. An unset key
-inherits the artifact's value.
+```toml
+[target.metal]
+isa = "x86_64"
+os  = "freestanding"   # os default object format is "raw"
+abi = "sysv64"
+of  = "elf"            # override: emit an ELF object instead
+```
 
 ## `[profile.<name>]`
 
-A profile is a build variant. The optimization level and the debug-emission
-toggles live here because they are variant concerns.
+A profile is a build variant. The optimization level and debug-emission toggle
+live here because they are variant concerns.
 
-| Key        | Type    | Default | Meaning |
-|------------|---------|---------|---------|
-| `opt`      | integer | — (debug) | Optimization level: `0` (no optimization beyond the always-on pipeline), `1` (standard), or `2` (aggressive). `1` and `2` currently select the same pass set; `2` is where future loop/vectorization work lands. Any other integer — or a non-integer — is a manifest error (`profile '<name>': opt must be 0, 1, or 2`). |
-| `emit_ir`  | bool    | `false` | Write per-module SSA IR dumps under the `ir` template for this profile — the final post-pipeline IR the object is built from, so it varies with `opt`. |
-| `emit_asm` | bool    | `false` | Write per-module assembly dumps under the `asm` template for this profile. |
-| `debug`    | bool    | `false` | Emit debug info (DWARF on ELF/Mach-O, CodeView on COFF) for this profile. Declare it once so a project ships symbols without passing a flag every build, or set it on a release profile for release-with-symbols. A non-boolean value is a manifest error (`profile '<name>': debug must be a boolean`). Gates emission only, never the optimizer. |
+| Key     | Type    | Meaning |
+|---------|---------|---------|
+| `opt`   | integer | Optimization level: `0` selects the debug pipeline (the always-on passes only), `1` and `2` select the release pipeline. `1` and `2` currently share a pass set; `2` is where future loop/vectorization work lands. Any other integer — or a non-integer — is a manifest error. |
+| `debug` | bool    | Emit debug info (DWARF on ELF/Mach-O, CodeView on COFF) for this profile. Gates emission only, never the optimizer, so a `release` profile can keep symbols with `debug = true`. A non-boolean is a manifest error. |
 
-A CLI `-O0` / `-O1` / `-O2` / `--release` flag overrides the selected profile's
-`opt` per invocation, and `--emit-ir` / `--emit-asm` / `--no-emit-ir` /
-`--no-emit-asm` override the emission toggles. A CLI `-g` forces `debug` on for one
-invocation regardless of the selected profile's key (precedence `-g` > profile >
-off); there is no flag to force it off over a `debug = true` profile — edit the
-manifest or select another profile. Absent `--profile`/`--release`, the first
-declared profile is used; with no profile declared, a `debug` default (no
-optimization, no emission) applies.
+Both keys are required in a declared profile. Emission of the human-readable IR and
+assembly side-artifacts is **not** a profile concern — it is controlled only by the
+`--emit-ir` / `--emit-asm` CLI flags (see [cli.md](cli.md)).
 
-## `[deps.<alias>]`
+The CLI selects and overrides at invocation time: `--profile <name>` picks the
+profile; `-g` forces `debug` on for one build regardless of the profile's key
+(precedence `-g` > profile > off — there is no flag to force it off over a
+`debug = true` profile; edit the manifest or pick another profile). Absent
+`--profile`, the first declared profile is used.
 
-Each `<alias>` names a dependency materialised under `<dep>/<alias>/`. The build
-resolves a dependency purely by vendor layout — it reads that directory's own
-`mach.toml` for its `[project].id` (the head segment of the dep's module paths)
-and `[project].src` (the dep's source dir). A module path whose head matches a
-dep's `id` resolves into that dep's tree.
+## `[artifact.<name>]`
+
+Every artifact is declared explicitly and named by its table key. `$project.name`
+reads the selected artifact's name.
+
+| Key       | Required | Meaning |
+|-----------|----------|---------|
+| `kind`    | yes | `"bin"` (an executable), `"static"` (a static library — the per-module objects are the deliverable), or `"shared"` (a shared library). |
+| `entry`   | yes | Entry source, relative to the project `src` dir (e.g. `main.mach` for `src/main.mach`). The entry module's FQN is `<id>.<entry without .mach>`, `/` turned into `.`. |
+| `out`     | yes | This artifact's output path, a template (see [Path templates](#path-templates)). An executable extension, where wanted, is written literally into this path. |
+| `targets` | yes | Array of declared target names this artifact builds for; `["*"]` means every declared target. |
+| `link`    | yes | Array of `[link.X]` names this artifact links (see below). `[]` for none. |
+| `need`    | yes | Array of `[step.X]` names this artifact demands directly, for step outputs that are not themselves link inputs. `[]` for none. |
+
+Per-target extension or per-target entry is not a per-cell exception table — it is a
+second artifact stanza, so the condition stays visible like everything else.
+
+## `[link.<name>]` — link requirements
+
+A `[link.X]` is a named external link requirement. Artifacts reference entries by
+name in their `link = [...]`; an entry whose filters do not match the build cell is
+skipped. An entry with `export = true` also applies to any project that links this
+project's modules, so a platform link requirement lives once — in the manifest that
+needs it — and cascades to consumers. A standalone build and a consumed build use
+the same entries, so nothing behaves differently as a dependency.
+
+| Key      | Required | Meaning |
+|----------|----------|---------|
+| `source` | yes | `"system"` (a system library resolved by name), `"framework"` (a macOS framework), or `"local"` (a file on disk). |
+| `name`   | shape | Library/framework name — required for `source = "system"`/`"framework"`, forbidden for `"local"`. |
+| `path`   | shape | File path — required for `source = "local"`, forbidden otherwise. A template (see below). |
+| `os`     | yes | Filter axis: a canonical `os` value, `"*"` (any), an array of values, or `[]` (none). |
+| `isa`    | yes | Filter axis over `isa`, same forms. |
+| `abi`    | yes | Filter axis over `abi`, same forms. |
+| `export` | yes | `true` cascades this entry to consumers; `false` keeps it to this project's own builds. |
+
+The `os`/`isa`/`abi` axes select the build cells an entry applies to. Each takes a
+single canonical value, `"*"` for any, or an array — `os = "linux"` and
+`os = ["linux"]` filter identically. `[]` matches nothing (an entry deliberately
+switched off). A non-canonical spelling is a strict-parse error. An entry applies
+to a cell when all three axes match.
+
+A `local` entry's `path` must, at build time, either match a `[step.X]`'s `out`
+(which demands that step) or already exist on disk — anything else is an up-front
+error, so a typo never silently drops an input.
+
+Whether an input links **statically** or **dynamically** follows the resolved file
+— a loose `.o` or static `.a` links statically; a shared `.so` is recorded as a
+dynamic dependency by its `DT_SONAME`. See
+[cli.md](cli.md#static-vs-dynamic-resolution) for the resolution rules and
+[language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
+`ext fun` workflow that consumes these inputs.
+
+## `[step.<name>]` — build steps
+
+A step is a command, make-recipe style, that produces files a build consumes
+(typically a `local` link input, e.g. a vendored-C object). `<name>` must be a
+plain identifier — it keys the step's stamp file.
+
+| Key    | Required | Meaning |
+|--------|----------|---------|
+| `cmd`  | yes | One command string, run through the platform shell (`sh -c` on posix, `cmd.exe /C` on windows) from the project root. Pipe, `&&`, or invoke a script freely. Templates expand in it. |
+| `in`   | yes | Declared input file list. Accepts globs (`*`, `**`), expanded sorted for a stable fingerprint; a glob that matches nothing is a hard error. |
+| `out`  | yes | Declared output file list. Concrete paths only — a glob here is an error, since the demand match and cache key expand `out` verbatim. |
+| `need` | yes | Array of other `[step.X]` names this step must run after (explicit ordering; cycles error). `[]` for none. |
+
+Steps carry **no filters** and **never run automatically**. A step runs only when
+**demanded**:
+
+- by a selected `[link.X]` whose `local` `path` matches the step's `out`;
+- by another step's `need`;
+- by an artifact's `need` (for outputs that are not link inputs).
+
+Because a step has no filter of its own, the condition for running it lives in the
+link entry that demands it: on a build cell where that entry filters out, the step
+is never demanded and never runs.
+
+A step is cached by content: its `in` contents plus its expanded `cmd` fingerprint
+the step (the query engine's `Q_LINK_CONFIG` pattern). An unchanged step whose
+outputs still exist is skipped; change an input or the command and it re-runs.
+
+**Output homing.** `{project.out}` resolves to the **root** project's expanded
+`out` in every manifest of the closure. A dependency's step outputs land in the
+consumer's output tree — exactly as a dependency's compiled modules do — and the
+dependency's own checkout is never written to.
+
+## `[dep.<alias>]`
+
+Each `<alias>` names a dependency materialised under `dep/<alias>/`. The build
+resolves a dependency by vendor layout: it reads that directory's own `mach.toml`
+for its `[project].id` (the head segment of the dep's module paths) and `src`, and
+a module path whose head matches a dep's `id` resolves into that dep's tree.
 
 A stanza declares exactly one source key:
 
-| Key    | Type   | Read by    | Meaning |
-|--------|--------|------------|---------|
-| `git`  | string | `mach dep` | Git URL to clone into `<dep>/<alias>/`. |
-| `path` | string | `mach dep` | Local path to another project tree, resolved relative to this manifest's directory; never fetched. `mach dep pull` materialises it at `<dep>/<alias>/` as a relative symlink to the resolved source, so the build reaches its modules by the same vendor layout as a git dep. |
-| `ref`  | string | `mach dep` | Git ref to check out (with `git`): a `tag/<name>`, `branch/<name>`, bare tag/branch, or commit SHA. An absent ref means the remote default branch. |
+| Key    | Meaning |
+|--------|---------|
+| `git`  | Git URL to clone into `dep/<alias>/`. Requires `ref`. |
+| `path` | Local project tree, resolved relative to this manifest's directory; never fetched. `mach dep pull` materialises it at `dep/<alias>/` as a relative symlink. Forbids `ref`. |
+| `ref`  | Git ref to check out (git only): `tag/<name>`, `branch/<name>`, a bare tag/branch, or a commit SHA. |
 
-A registry-style `version =` is reserved and rejected. Cloning, lockfile
-handling, and transitive resolution are documented in [cli.md](cli.md#mach-dep).
-`mach dep` performs only plain git operations, so a checkout the user also commits
-as a **submodule** composes naturally; mach never invokes `git submodule`.
+`git` and `path` are mutually exclusive and exactly one is required. A
+registry-style `version =` is reserved and rejected. Cloning, lockfile handling,
+and transitive resolution are documented in [cli.md](cli.md#mach-dep); `mach dep`
+performs only plain git operations, so a checkout committed as a git **submodule**
+composes naturally. A git dep is pinned to a resolved commit in `mach.lock`; a path
+dep carries no lock entry (its `path` is the whole record).
 
-A **git** dep is pinned to a resolved commit in `mach.lock`; a **path** dep has no
-pinned content, so it carries no lock entry — its `path` in the manifest is the
-whole record. `mach dep pull` materialises a path dep at `<dep>/<alias>/` as a
-relative symlink to the resolved source and is idempotent: a stale link is
-replaced, an already-correct one is left untouched, and a source that already
-lives at the vendor location is a no-op. A path that does not exist, that holds no
-`mach.toml`, or whose vendor location is occupied by a real directory (a stale git
-checkout, foreign vendored files) is a hard error — never silent success.
+Dependencies are exactly today's system: git/path deps, an alias-keyed flat `dep/`
+store, `branch`/`tag`/`commit` refs, transitive pull, `mach.lock` as-is. Every
+transitively fetched dependency registers its `[project].id` into a single flat id
+registry, so a dependency's own surface dependencies resolve in consumers. **The
+same id reached from two different sources or refs anywhere in the closure is a
+hard error** naming the requirers — the fix is to fork or upstream, never to
+version-split inside one build.
 
-### Cascading link requirements
-
-A dependency declares its own link requirements as `[target.*].libs` (full-tuple)
-or `[os.<name>].libs` (os-component) overlays, and a consumer inherits every such
-lib that matches the build it is producing — so a platform link requirement (e.g.
-`kernel32.dll`) lives once, in the providing dependency's manifest, and out of
-every consumer. Matching is by tuple/component equality; target *names* are local
-to each manifest. Within each dependency the matching os overlays precede the
-matching target libs; across dependencies the order is topological then
-declaration order, and the union is deduplicated by name. See
-[Link inputs](#link-inputs) for the overlay merge law.
-
-## `[os.<name>]`
-
-An os overlay scopes a link requirement to a single tuple component — the
-operating system — rather than a full `(isa, os, abi)` tuple. A build matches the
-overlay iff its selected target's `os` equals `<name>`, so a requirement that
-holds for every windows ISA and ABI is stated once:
-
-```toml
-[os.windows]
-libs = ["kernel32.dll"]   # linked into every windows build, this project's and any consumer's
-```
-
-| Key    | Type             | Default | Meaning |
-|--------|------------------|---------|---------|
-| `libs` | array of strings | `[]`    | Link inputs added to every build whose os matches `<name>` (see [Link inputs](#link-inputs)). |
-
-Os overlays cascade to consumers exactly like `[target.*].libs`. The
-single-component `[isa.<name>]` and `[abi.<name>]` overlays are **reserved**:
-declaring either is an error until a real case demands them.
-
-## Bare project-id imports
-
-A one-segment `use`/`fwd` path equal to a resolvable project id — a dependency's
-`[project].id`, or the current project's own id — resolves to that project's
-declared `[project].module`. So a library that sets `module = "glfw.mach"` is
-imported as `use glfw;` (binding the `glfw` module) instead of by the full path to
-its surface file. Longer paths are unaffected; a single segment is otherwise
-unresolvable, so this is purely additive.
-
-```toml
-# in glfw's manifest:
-[project]
-id     = "glfw"
-module = "glfw.mach"   # the surface a bare `use glfw;` binds
-```
-
-```mach
-// in a consumer:
-use glfw;              // binds the glfw module (glfw's [project].module)
-```
-
-A bare import of a project that declares no `module` is a resolution error naming
-the fix (import a full path, or add a `module` to the project's manifest). A
-declared `module` that names no file is a manifest error at build start whether or
-not anything imports it. A project module that `fwd`s its own id is caught by the
-existing circular-module detection.
+A dependency's export surface — all a consumer sees — is its source module tree
+(addressed by the dep's id), its `export = true` link entries, and the steps those
+entries demand. Nothing else in a dependency's manifest applies to consumers.
 
 ## Path templates
 
-Output paths come only from the declared templates, expanded over four variables:
+Output paths and `cmd`s come only from the declared templates, expanded over a
+closed, final set of three variables:
 
-- `{target}` — the resolved target name (never the literal `native`).
-- `{profile}` — the selected profile name.
-- `{name}` — the artifact name.
-- `{ext}` — the target's `ext` (the empty string by default).
+- `{project.out}` — the root project's expanded `[project].out`.
+- `{target.name}` — the resolved target name (never the literal `native`).
+- `{profile.name}` — the selected profile name.
 
-Manifest paths are always `/`-separated and normalized to the host separator at
-the filesystem boundary, so the same manifest is portable; a literal `\` in a path
-is a hard error. Two artifacts that resolve to the same `out` path collide and
-fail at build start. A per-artifact or per-cell `out` overrides the project
-template for that artifact.
-
-The `tests` template is expanded the same way and locates the single test
-dispatcher executable `mach test` builds (`{target}`/`{profile}`/`{ext}` resolve
-as usual). `{name}` is the selected artifact's product name, falling back to the
-project id for artifact-less (library) builds. The dispatcher embeds every
-collected test and runs the one selected by a decimal index argument, so a
-project's test build lands at, e.g., `out/linux/debug/test/mach`.
+There are no `{name}`/`{ext}` or bare `{target}`/`{profile}` aliases. An
+unresolvable `{...}` reference, or an unterminated `{`, is a strict-parse error.
+`{project.out}` is not available inside `[project].out` itself (it would be
+self-referential). Two artifacts that resolve to the same `out` path collide and
+fail at build start.
 
 ## Selection and the build matrix
 
 A build cell is one artifact × one target × one profile.
 
-- `mach build .` builds every declared `[bin.*]`/`[lib.*]` for the default target
-  and default profile. `--all-targets` crosses every artifact with every declared
-  target. `--bin <name>` / `--lib <name>` narrow to one artifact; `--target
-  <name>` selects a declared target; `--profile <name>` (with `--release` sugar)
-  selects a profile.
-- `mach run .` and `mach test .` build exactly one artifact; with several declared
-  and no `--bin`/`--lib`, they ask you to pick one, naming every candidate.
+- `mach build <path>` builds every declared artifact whose `targets` includes the
+  selected target, for the default profile. `--all-targets` crosses every artifact
+  with every target in its `targets`. `--bin <name>` / `--lib <name>` narrow to one
+  artifact; `--target <name>` selects a declared target; `--profile <name>` selects
+  a profile.
+- `mach run <path>` and `mach test <path>` build exactly one artifact; with several
+  declared and no `--bin`/`--lib`, they ask you to pick one, naming every candidate.
+- `mach test` links the union of all artifacts' referenced entries plus exported
+  dependency entries, filtered to the native target (tests run on native hardware
+  only). If two artifacts' objects collide on symbols in that union, that is an
+  honest link error — restructure the entries.
 
 ### `native` target resolution
 
-`native` resolves the host's `(isa, os)` tuple against the **declared** targets
-only — never a synthesized tuple. Exactly one host match is chosen; several
-matching tuples is an ambiguity error naming the candidates; no match warns
-(`no declared target matches the host (...)`) and falls back to the first declared
-target so cross-only projects still build on a foreign host.
+`native` resolves the host's `(isa, os)` against the **declared** targets only —
+never a synthesized tuple. Exactly one host match is chosen; several matching tuples
+is an ambiguity error naming the candidates; no match warns and falls back to the
+first declared target, so a cross-only project still builds on a foreign host.
 
-## Link inputs
+## Worked example: a consumer of C bindings and vendored C
 
-A `libs` entry (at the target, artifact, or per-cell level) is either an explicit
-path — a `.o` object, a `.a` archive, or a `.so` shared library, project-root-
-relative or absolute — or a bare `-l`-style name resolved to a `lib<name>.o` /
-`<name>.o` / `lib<name>.a` / `<name>.a`, then a shared `lib<name>.so`, at link
-time. Loose `.o` objects and static `.a` archives link **statically** (a `.a`
-contributes every member object); a shared `.so` is recorded as a **dynamic**
-dependency (its `DT_SONAME`), bound against undefined `ext` symbols at load time
-through a `PT_INTERP`/PLT. The overlays merge target < artifact < per-cell,
-deduplicated by name, and join every `mach build`/`run`/`test` link alongside any
-CLI `-L`/`-l`/object arguments. See
-[cli.md](cli.md#static-vs-dynamic-resolution) for the full resolution rules and
-[language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
-`ext fun` workflow that consumes these inputs.
-
-## Annotated example
-
-The compiler's own manifest builds one binary (`mach`) for two targets, keeping
-its output paths flat (no `{profile}` segment) so released paths stay stable:
+A project that uses a system-lib binding (`glfw`) and a vendored-C library
+(`miniz`), building a native binary and cross-compiling to windows. The platform
+shim is built by steps and linked through `local` entries; the OS-specific shims
+are gated by their link entries' `os` axis, so the x11 step runs on a linux build
+and never on a windows one.
 
 ```toml
 [project]
-id      = "mach"          # module-path root: this project's code is `mach.*`
-name    = "Mach Compiler" # metadata
-version = "1.3.0"
-src     = "src"           # sources under ./src
-dep     = "dep"           # vendored deps under ./dep
-target  = "native"        # default target: the host-matching tuple below
-out     = "out/{target}/bin/{name}{ext}"  # e.g. out/linux/bin/mach
-obj     = "out/{target}/obj"
-ir      = "out/{target}/ir"
-asm     = "out/{target}/asm"
-tests   = "out/{target}/test/{name}"      # e.g. out/linux/test/myproj
+id      = "demo"
+version = "0.1.0"
+src     = "src"
+out     = "out/{target.name}/{profile.name}"
+
+[dep.std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "tag/v0.17.0"
+
+[dep.glfw]
+git = "https://github.com/briar-systems/mach-glfw"
+ref = "tag/v0.2.1"
+
+[dep.mz]
+git = "https://github.com/briar-systems/mach-miniz"
+ref = "tag/v1.0.3"
+
+[link.shim]
+source = "local"
+path   = "{project.out}/obj/platform/shim.o"
+os     = "*"
+isa    = "*"
+abi    = "*"
+export = false
+
+[link.shim-x11]
+source = "local"
+path   = "{project.out}/obj/platform/x11.o"
+os     = "linux"
+isa    = "*"
+abi    = "*"
+export = false
+
+[link.shim-win32]
+source = "local"
+path   = "{project.out}/obj/platform/win32.o"
+os     = "windows"
+isa    = "*"
+abi    = "*"
+export = false
+
+[link.gl]
+source = "system"
+name   = "GL"
+os     = "linux"
+isa    = "*"
+abi    = "*"
+export = false
+
+[artifact.demo]
+kind    = "bin"
+entry   = "main.mach"
+out     = "{project.out}/bin/demo"
+targets = ["linux", "windows"]
+link    = ["shim", "shim-x11", "shim-win32", "gl"]
+need    = []
+
+[step.shim]
+cmd  = "cc -c -O2 -fPIC -Ivendor/platform -o {project.out}/obj/platform/shim.o vendor/platform/shim.c"
+in   = ["vendor/platform/shim.c"]
+out  = ["{project.out}/obj/platform/shim.o"]
+need = []
+
+[step.shim-x11]
+cmd  = "cc -c -O2 -fPIC -Ivendor/platform -o {project.out}/obj/platform/x11.o vendor/platform/x11.c"
+in   = ["vendor/platform/x11.c"]
+out  = ["{project.out}/obj/platform/x11.o"]
+need = []
+
+[step.shim-win32]
+cmd  = "cc -c -O2 -fPIC -Ivendor/platform -o {project.out}/obj/platform/win32.o vendor/platform/win32.c"
+in   = ["vendor/platform/win32.c"]
+out  = ["{project.out}/obj/platform/win32.o"]
+need = []
 
 [target.linux]
 isa = "x86_64"
@@ -331,26 +409,130 @@ os  = "linux"
 abi = "sysv64"
 
 [target.windows]
-isa  = "x86_64"
-os   = "windows"
-abi  = "win64"
-ext  = ".exe"            # the windows artifact is out/windows/bin/mach.exe
-libs = ["kernel32.dll"]  # the windows platform link requirement
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
 
-[bin.mach]
-entry = "main.mach"      # entry module mach.main, at src/main.mach
+[profile.debug]
+opt   = 0
+debug = true
 
-[deps.mach-std]
-git = "https://github.com/briar-systems/mach-std"
-ref = "branch/dev"
+[profile.release]
+opt   = 2
+debug = false
 ```
 
-`mach build .` (no `--target`) selects `linux` because `[project].target = "native"`
-resolves to the host-matching tuple, compiles `src/main.mach` and its transitive
-imports — including modules from `mach-std` vendored at `dep/mach-std/` — into
-objects under `out/linux/obj/`, and links `out/linux/bin/mach`. `mach-std` is
-realized into `dep/mach-std/` by `mach dep pull` from the manifest pin, and
-`mach build .` then resolves it purely by that vendor path — no git at build time.
+The `gl` and `shim-x11` entries carry `os = "linux"`, so on a windows build cell
+they filter out (and `shim-x11`'s step is never demanded); `shim-win32` carries
+`os = "windows"` and applies only there. The unconditional `shim` entry (`os = "*"`)
+applies to both.
+
+## Worked example: a C-binding dependency's export
+
+`mach-glfw` exports only its `system`/`framework` link entries — a consumer that
+imports its modules inherits every `export = true` entry that matches the build:
+
+```toml
+[project]
+id      = "glfw"
+version = "0.2.1"
+src     = "src"
+out     = "out/{target.name}/{profile.name}"
+
+[link.glfw]
+source = "system"
+name   = "glfw"
+os     = "*"
+isa    = "*"
+abi    = "*"
+export = true
+
+[link.cocoa]
+source = "framework"
+name   = "Cocoa"
+os     = "darwin"
+isa    = "*"
+abi    = "*"
+export = true
+```
+
+## Worked example: a vendored-C dependency
+
+`mach-miniz` exports one `local` entry whose path is produced by a step; importing
+its surface pulls the entry, and the entry's path demands the step in the
+consumer's output tree:
+
+```toml
+[project]
+id      = "mz"
+version = "1.0.3"
+src     = "src"
+out     = "out/{target.name}/{profile.name}"
+
+[link.miniz]
+source = "local"
+path   = "{project.out}/obj/miniz/miniz.o"
+os     = "*"
+isa    = "*"
+abi    = "*"
+export = true
+
+[step.miniz]
+cmd  = "cc -c -O2 -fPIC -Ivendor/miniz -o {project.out}/obj/miniz/miniz.o vendor/miniz/miniz.c"
+in   = ["vendor/miniz/*.c", "vendor/miniz/*.h"]
+out  = ["{project.out}/obj/miniz/miniz.o"]
+need = []
+```
+
+## The compiler's own manifest
+
+Mach builds itself from a manifest that declares one binary for six targets and
+depends on `mach-std`:
+
+```toml
+[project]
+id      = "mach"
+version = "3.1.0"
+src     = "src"
+out     = "out/{target.name}/{profile.name}"
+
+[target.linux-x86_64]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.windows-x86_64]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[profile.debug]
+opt   = 0
+debug = false
+
+[profile.release]
+opt   = 2
+debug = false
+
+[artifact.mach]
+kind    = "bin"
+entry   = "main.mach"
+out     = "bin/mach"
+targets = ["*"]
+link    = []
+need    = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"
+```
+
+(The full manifest declares all six supported targets.) `mach build .` selects the
+host-matching target via `native`, compiles `src/main.mach` and its transitive
+imports — including modules from `mach-std` vendored at `dep/mach-std/` — and links
+`out/<target>/<profile>/bin/mach`. `mach-std` is realized into `dep/mach-std/` by
+`mach dep pull` from the manifest pin; the build then resolves it purely by that
+vendor path, with no git at build time.
 
 ## See also
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -167,12 +167,19 @@ reads the selected artifact's name.
 
 | Key       | Required | Meaning |
 |-----------|----------|---------|
-| `kind`    | yes | `"bin"` (an executable), `"static"` (a static library — the per-module objects are the deliverable), or `"shared"` (a shared library). |
+| `kind`    | yes | `"bin"`, `"static"`, or `"shared"` (see below). |
 | `entry`   | yes | Entry source, relative to the project `src` dir (e.g. `main.mach` for `src/main.mach`). The entry module's FQN is `<id>.<entry without .mach>`, `/` turned into `.`. |
 | `out`     | yes | This artifact's output path, a template (see [Path templates](#path-templates)). An executable extension, where wanted, is written literally into this path. |
 | `targets` | yes | Array of declared target names this artifact builds for; `["*"]` means every declared target. |
 | `link`    | yes | Array of `[link.X]` names this artifact links (see below). `[]` for none. |
 | `need`    | yes | Array of `[step.X]` names this artifact demands directly, for step outputs that are not themselves link inputs. `[]` for none. |
+
+- **`bin`** links an executable at the resolved `out` path.
+- **`static`** materialises a real `ar` archive at the resolved `out` path — the
+  per-module objects with an archive symbol index, the deliverable a consumer links
+  as a `.a` (#1997).
+- **`shared`** is reserved for a shared-library deliverable; its emission is phase 2
+  (#1980).
 
 Per-target extension or per-target entry is not a per-cell exception table — it is a
 second artifact stanza, so the condition stays visible like everything else.

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -68,7 +68,7 @@ debug = true                           # emit debug info for this profile
 [artifact.demo]                        # a produced artifact
 kind    = "bin"                        # "bin" | "static" | "shared"
 entry   = "main.mach"                  # entry source, relative to src
-out     = "{project.out}/bin/demo"     # this artifact's output path
+out     = "bin/demo"                   # output path, relative to the project out
 targets = ["*"]                        # which declared targets build it ("*" = all)
 link    = []                           # [link.X] names this artifact links
 need    = []                           # [step.X] names this artifact demands directly
@@ -169,7 +169,7 @@ reads the selected artifact's name.
 |-----------|----------|---------|
 | `kind`    | yes | `"bin"`, `"static"`, or `"shared"` (see below). |
 | `entry`   | yes | Entry source, relative to the project `src` dir (e.g. `main.mach` for `src/main.mach`). The entry module's FQN is `<id>.<entry without .mach>`, `/` turned into `.`. |
-| `out`     | yes | This artifact's output path, a template (see [Path templates](#path-templates)). An executable extension, where wanted, is written literally into this path. |
+| `out`     | yes | This artifact's output path, **relative to the expanded project `out`** and rooted there automatically — write `bin/demo`, not `{project.out}/bin/demo`. An executable extension, where wanted, is written literally here. |
 | `targets` | yes | Array of declared target names this artifact builds for; `["*"]` means every declared target. |
 | `link`    | yes | Array of `[link.X]` names this artifact links (see below). `[]` for none. |
 | `need`    | yes | Array of `[step.X]` names this artifact demands directly, for step outputs that are not themselves link inputs. `[]` for none. |
@@ -289,12 +289,18 @@ entries demand. Nothing else in a dependency's manifest applies to consumers.
 
 ## Path templates
 
-Output paths and `cmd`s come only from the declared templates, expanded over a
-closed, final set of three variables:
+Paths and `cmd`s expand over a closed, final set of three variables:
 
-- `{project.out}` — the root project's expanded `[project].out`.
+- `{project.out}` — the **root** project's expanded `[project].out`, in every
+  manifest of the closure.
 - `{target.name}` — the resolved target name (never the literal `native`).
 - `{profile.name}` — the selected profile name.
+
+An artifact's `out` is relative to the expanded project `out` and is rooted there
+automatically — write `bin/demo`, not `{project.out}/bin/demo`. Step `out` lists
+and local link `path`s are **not** auto-rooted: they name `{project.out}`
+explicitly, which is what homes a dependency's build products into the *consumer's*
+output tree rather than the dependency's checkout.
 
 There are no `{name}`/`{ext}` or bare `{target}`/`{profile}` aliases. An
 unresolvable `{...}` reference, or an unterminated `{`, is a strict-parse error.
@@ -387,7 +393,7 @@ export = false
 [artifact.demo]
 kind    = "bin"
 entry   = "main.mach"
-out     = "{project.out}/bin/demo"
+out     = "bin/demo"
 targets = ["linux", "windows"]
 link    = ["shim", "shim-x11", "shim-win32", "gl"]
 need    = []
@@ -436,28 +442,38 @@ applies to both.
 
 ## Worked example: a C-binding dependency's export
 
-`mach-glfw` exports only its `system`/`framework` link entries — a consumer that
-imports its modules inherits every `export = true` entry that matches the build:
+`mach-glfw` exports its `system`/`framework` link entries — a consumer that imports
+its modules inherits every `export = true` entry that matches the build: linux and
+darwin pull the `glfw` system library, a windows build pulls `glfw3.dll`, and the
+darwin frameworks apply only on darwin.
 
 ```toml
 [project]
 id      = "glfw"
-version = "0.2.1"
+version = "0.3.0"
 src     = "src"
 out     = "out/{target.name}/{profile.name}"
 
 [link.glfw]
 source = "system"
 name   = "glfw"
-os     = "*"
+os     = ["linux", "darwin"]
 isa    = "*"
 abi    = "*"
 export = true
 
-[link.cocoa]
+[link.glfw-win]
+source = "system"
+name   = "glfw3.dll"
+os     = ["windows"]
+isa    = "*"
+abi    = "*"
+export = true
+
+[link.Cocoa]
 source = "framework"
 name   = "Cocoa"
-os     = "darwin"
+os     = ["darwin"]
 isa    = "*"
 abi    = "*"
 export = true

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -78,8 +78,7 @@ git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
 ```
 
-`[link.X]` and `[step.X]` are shown under [Link requirements](#linkx--link-requirements)
-and [Build steps](#stepx--build-steps).
+`[link.X]` and `[step.X]` each have their own section below.
 
 ## `[project]`
 

--- a/int/regression/1750-i32-signext/mach.toml
+++ b/int/regression/1750-i32-signext/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/regression/1762-rv64-float-vararg/mach.toml
+++ b/int/regression/1762-rv64-float-vararg/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/regression/1851-rv64-phi-signext/mach.toml
+++ b/int/regression/1851-rv64-phi-signext/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/regression/1852-rv64-self-host/mach.toml
+++ b/int/regression/1852-rv64-self-host/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -15,15 +13,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/regression/1923-comptime-field-gate/mach.toml
+++ b/int/regression/1923-comptime-field-gate/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/regression/1925-global-aggregate-byval/mach.toml
+++ b/int/regression/1925-global-aggregate-byval/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/aggregate-abi/mach.toml
+++ b/int/surface/aggregate-abi/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/control-flow/mach.toml
+++ b/int/surface/control-flow/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/elf-pie/mach.toml
+++ b/int/surface/elf-pie/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,15 +11,19 @@ abi = "sysv64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/elf-relro/mach.toml
+++ b/int/surface/elf-relro/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/float/mach.toml
+++ b/int/surface/float/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/freestanding-aarch64/mach.toml
+++ b/int/surface/freestanding-aarch64/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,12 +11,16 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []

--- a/int/surface/freestanding-riscv64/mach.toml
+++ b/int/surface/freestanding-riscv64/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,12 +11,16 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []

--- a/int/surface/freestanding/mach.toml
+++ b/int/surface/freestanding/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,12 +11,16 @@ abi = "sysv64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []

--- a/int/surface/macho-pie-aarch64/mach.toml
+++ b/int/surface/macho-pie-aarch64/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,15 +11,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/macho-pie-x86_64/mach.toml
+++ b/int/surface/macho-pie-x86_64/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,15 +11,19 @@ abi = "sysv64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/pe-aslr/mach.toml
+++ b/int/surface/pe-aslr/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,15 +11,19 @@ abi = "win64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/pe-import-attribution/mach.toml
+++ b/int/surface/pe-import-attribution/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,9 +11,11 @@ abi = "win64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
@@ -23,8 +23,12 @@ entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
 link = ["kernel32"]
+need = []
 
 [link.kernel32]
 source = "system"
 name = "kernel32.dll"
 os = ["windows"]
+isa = ["*"]
+abi = ["*"]
+export = false

--- a/int/surface/pie-reloc/mach.toml
+++ b/int/surface/pie-reloc/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/pie-relro-fault/mach.toml
+++ b/int/surface/pie-relro-fault/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,15 +21,19 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/sign-extension/mach.toml
+++ b/int/surface/sign-extension/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/int/surface/syscall-inline-asm/mach.toml
+++ b/int/surface/syscall-inline-asm/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "case"
-name = "case"
-description = "integration test fixture"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.case]
 kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "3.1.0"
+version = "3.2.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "mach"
-name = "Mach Compiler"
-description = "The Mach compiler"
 version = "3.1.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = false
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.mach]
 kind = "bin"
 entry = "main.mach"
 out = "bin/mach"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -392,9 +392,9 @@ pub fun build_tests(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, list
 
 # resolve the selected profile name from CLI config
 #
-# `--profile <name>` wins; `--release` is sugar for the `release` profile; absent
-# both, the empty string defers to the manifest default. Shared by the `mach
-# build` matrix-override path and selection_from_config.
+# `--profile <name>` selects the profile; absent it, the empty string defers to the
+# manifest default. Shared by the `mach build` matrix-override path and
+# selection_from_config.
 # ---
 # config: the parsed CLI config
 # ret:    the selected profile name, empty for the manifest default
@@ -526,19 +526,17 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
         ret br;
     }
 
-    # optimization level: an explicit CLI flag (`-O0` debug, `-O1`/`-O2`/
-    # `--release` release) wins outright; absent any flag the level falls to the
-    # selected profile's `opt`, then to the debug pipeline (mem2reg, constfold,
-    # dce) - what the bootstrap uses, kept fixpoint-stable. the CLI choice is
-    # resolved here; the manifest default is folded in after the target is
-    # selected (resolve_opt_level), since the target entry is only known post
-    # build_project.
+    # optimization level: an explicit `-O0`/`-O1`/`-O2` CLI flag is a per-invocation
+    # override that wins outright; absent one the level falls to the selected
+    # profile's `opt`, then to the debug pipeline (mem2reg, constfold, dce) - what
+    # the bootstrap uses, kept fixpoint-stable. the CLI choice is resolved here; the
+    # manifest default is folded in after the target is selected (resolve_opt_level),
+    # since the target entry is only known post build_project.
     var cli_level: u8   = pipeline.OPT_DEBUG;
     var cli_set:   bool = false;
-    if (util.has_flag(argc, argv, "-O0"))       { cli_level = pipeline.OPT_DEBUG;   cli_set = true; }
-    or (util.has_flag(argc, argv, "-O1"))       { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
-    or (util.has_flag(argc, argv, "-O2"))       { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
-    or (util.has_flag(argc, argv, "--release")) { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
+    if (util.has_flag(argc, argv, "-O0")) { cli_level = pipeline.OPT_DEBUG;   cli_set = true; }
+    or (util.has_flag(argc, argv, "-O1")) { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
+    or (util.has_flag(argc, argv, "-O2")) { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
 
     # the build selection threaded to the driver; it narrows target/profile/
     # artifact. an enumerated matrix cell pins target and artifact, but the profile
@@ -633,18 +631,16 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
         debug_ok = false;
     }
 
-    # fold the manifest default into the level: a CLI `-O*`/`--release` flag wins,
+    # fold the manifest default into the level: a CLI `-O*` flag wins,
     # otherwise the selected profile's opt applies, else debug.
     val level: u8 = resolve_opt_level(?p, cli_level, cli_set);
 
-    # effective emission: a CLI `--emit-*` / `--no-emit-*` flag overrides the
-    # selected profile's defaults.
+    # effective emission: IR/ASM emission is CLI-only, off by default and enabled
+    # per-invocation by `--emit-asm` / `--emit-ir`.
     var eff_emit_asm: bool = p.config.emit_asm;
     var eff_emit_ir:  bool = p.config.emit_ir;
-    if (config.emit_asm)    { eff_emit_asm = true; }
-    if (config.no_emit_asm) { eff_emit_asm = false; }
-    if (config.emit_ir)     { eff_emit_ir = true; }
-    if (config.no_emit_ir)  { eff_emit_ir = false; }
+    if (config.emit_asm) { eff_emit_asm = true; }
+    if (config.emit_ir)  { eff_emit_ir = true; }
 
     if (debug_ok) {
         br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, eff_emit_asm, eff_emit_ir, ?root[0], config.output, argc, argv, marks, ?br.output_path, tests_out, list_only);
@@ -703,7 +699,7 @@ fun emit_summary(p: *driver.Project, ro: *readout.Readout, emit_obj: bool, out: 
 # ---
 # p:         the project carrying the selected target entry
 # cli_level: the level the CLI flags resolved to
-# cli_set:   whether a CLI `-O*`/`--release` flag was present
+# cli_set:   whether a CLI `-O*` flag was present
 # ret:       the pipeline level (pipeline.OPT_DEBUG or pipeline.OPT_RELEASE)
 fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
     if (cli_set) { ret cli_level; }

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -54,6 +54,7 @@ use mach.lang.session;
 use mach.lang.source;
 use mach.lang.target;
 use mach.lang.target.of;
+use mach.lang.target.of.ar;
 
 # the outcome of a single `build` invocation
 # ---
@@ -1526,6 +1527,115 @@ fun subst_name(tmpl: str, name: str, out: *u8, cap: usize) usize {
 # images:       the per-module object images to write
 # out_path:     receives the owned produced-artifact path on success
 # ret:          0 on success, 1 on a user error, 2 on an internal error
+# free the per-member read buffers and symbol-name arrays, then the member array
+fun free_members(alloc: *A.Allocator, members: *ar.ArMember, cap: u32) {
+    var i: u32 = 0;
+    for (i < cap) {
+        if (members[i].data != nil) { A.deallocate[u8](alloc, members[i].data, (members[i].len + 1)::usize); }
+        if (members[i].sym_names != nil && members[i].sym_count > 0) { A.deallocate[str](alloc, members[i].sym_names, members[i].sym_count::usize); }
+        i = i + 1;
+    }
+    A.deallocate[ar.ArMember](alloc, members, cap::usize);
+}
+
+# fill `member.sym_names` with the object image's defined global symbol names (for the
+# archive symbol index): a symbol is global (`SYM_OBJ_FLAG_GLOBAL`) and defined here
+# (`section != SECTION_EXTERNAL`). names resolve against the image's own interner.
+fun collect_defined_globals(p: *driver.Project, img: *of.ObjectImage, member: *ar.ArMember) bool {
+    member.sym_names = nil;
+    member.sym_count = 0;
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < img.symbol_count) {
+        if ((img.symbols[i].flags & of.SYM_OBJ_FLAG_GLOBAL) != 0 && img.symbols[i].section != of.SECTION_EXTERNAL) { n = n + 1; }
+        i = i + 1;
+    }
+    if (n == 0) { ret true; }
+    val res: R.Result[*str, str] = A.allocate[str](p.s.alloc, n::usize);
+    if (R.is_err[*str, str](res)) { ret false; }
+    val names: *str = R.unwrap_ok[*str, str](res);
+    var w: u32 = 0;
+    i = 0;
+    for (i < img.symbol_count) {
+        if ((img.symbols[i].flags & of.SYM_OBJ_FLAG_GLOBAL) != 0 && img.symbols[i].section != of.SECTION_EXTERNAL) {
+            val nm: O.Option[str] = intern.lookup(img.interner, img.symbols[i].name);
+            if (O.is_some[str](nm)) { names[w] = O.unwrap[str](nm); w = w + 1; }
+        }
+        i = i + 1;
+    }
+    member.sym_names = names;
+    member.sym_count = w;
+    ret true;
+}
+
+# archive the artifact's per-module objects into a static `ar` library at its declared
+# `out` (#1980 phase 1). members are the freshly written `.o` files, each contributing
+# its defined global symbols to the archive symbol index. Sets `*out_path` to the
+# archive path on success. `paths` must still be live (the objects are read here).
+# ---
+# p:            the project carrying the module graph and session
+# images:       the per-module codegen images, indexed by module id
+# paths:        the written per-module object paths, indexed by topo position
+# root:         the resolved project root directory
+# out_override: the `-o` artifact path, or nil to use the resolved path
+# out_path:     receives the owned archive path on success
+# ret:          0 on success, 1 on a user error, 2 on an internal error
+fun emit_static_archive(p: *driver.Project, images: *of.ObjectImage, paths: **u8, root: *u8, out_override: *u8, out_path: **u8) i64 {
+    val len: u32 = p.topo_len;
+
+    var archive: [4096]u8;
+    if (out_override != nil) {
+        util.path_into(?archive[0], 4096, root, out_override);
+    }
+    or {
+        val opt_bin: O.Option[str] = intern.lookup(?p.s.interner, p.config.bin_out);
+        if (O.is_none[str](opt_bin) || str_empty(O.unwrap[str](opt_bin))) {
+            print.eprint("error: selected artifact has no output path; set the `out` template in mach.toml\n");
+            ret 1;
+        }
+        join_into_str(?archive[0], 4096, root, O.unwrap[str](opt_bin));
+    }
+    if (!util.ensure_parents(?archive[0])) {
+        print.eprint("error: failed to create library directory\n");
+        ret 2;
+    }
+
+    val res_mem: R.Result[*ar.ArMember, str] = A.allocate[ar.ArMember](p.s.alloc, len::usize);
+    if (R.is_err[*ar.ArMember, str](res_mem)) { print.eprint("error: out of memory\n"); ret 2; }
+    val members: *ar.ArMember = R.unwrap_ok[*ar.ArMember, str](res_mem);
+    var i: u32 = 0;
+    for (i < len) { members[i].name = ""; members[i].data = nil; members[i].len = 0; members[i].sym_names = nil; members[i].sym_count = 0; i = i + 1; }
+
+    i = 0;
+    for (i < len) {
+        val mid: session.ModuleId    = p.topo[i];
+        val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
+        val fqn_opt: O.Option[str]   = intern.lookup(?p.s.interner, m.fqn);
+        if (O.is_none[str](fqn_opt)) { free_members(p.s.alloc, members, len); print.eprint("error: module FQN not interned\n"); ret 2; }
+        members[i].name = O.unwrap[str](fqn_opt);
+
+        val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(p.s.alloc, paths[i]::str);
+        if (R.is_err[filesystem.Buffer, str](rr)) { free_members(p.s.alloc, members, len); print.eprint("error: cannot read object for archive\n"); ret 2; }
+        val b: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rr);
+        members[i].data = b.data;
+        members[i].len  = b.len;
+
+        if (!collect_defined_globals(p, ?images[mid::u32], ?members[i])) { free_members(p.s.alloc, members, len); print.eprint("error: out of memory\n"); ret 2; }
+        i = i + 1;
+    }
+
+    val wr: R.Result[bool, str] = ar.write_archive(p.s.alloc, members, len, util.cstr_str(?archive[0]));
+    free_members(p.s.alloc, members, len);
+    if (R.is_err[bool, str](wr)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](wr));
+        print.eprint("\n");
+        ret 2;
+    }
+    @out_path = dup_cstr(p.s.alloc, ?archive[0]);
+    ret 0;
+}
+
 fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
                   out_override: *u8,
                   argc: usize, argv: **u8, marks: *bool,
@@ -1556,9 +1666,18 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
     if (obj_code != 0) { ret obj_code; }
     var len: u32 = p.topo_len;
 
-    # library mode (or `--emit obj`): the per-module objects are the deliverable;
-    # do not link an executable.
+    # library mode (or `--emit obj`): the per-module objects are the deliverable; do
+    # not link an executable. a `kind = "static"` artifact additionally archives those
+    # objects into a real `ar` library at its declared `out` (#1980). `--emit obj` and
+    # (phase 2) `kind = "shared"` keep the loose-objects deliverable unchanged.
     if (te.mode == driver.MODE_LIBRARY || emit_obj) {
+        if (te.mode == driver.MODE_LIBRARY && !emit_obj && te.lib_kind == manifest.LIBKIND_STATIC) {
+            val arc_code: i64 = emit_static_archive(p, images, paths, root, out_override, out_path);
+            free_paths(p.s.alloc, paths, len, len);
+            if (arc_code != 0) { ret arc_code; }
+            readout.phase_end(p.s.readout, readout.PH_LINK, 1, "archive", "archives");
+            ret 0;
+        }
         free_paths(p.s.alloc, paths, len, len);
         @out_path = dup_cstr(p.s.alloc, ?obj_base[0]);
         readout.phase_end(p.s.readout, readout.PH_LINK, len, "object", "objects");

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1505,28 +1505,6 @@ fun subst_name(tmpl: str, name: str, out: *u8, cap: usize) usize {
     ret k;
 }
 
-# write each per-module image to a relocatable `.o` on disk, then - in
-# executable mode - link the on-disk object set into the resolved artifact path
-#
-# The object layout is `<root>/<resolved obj>/<rel>.o`, where `<rel>` is the FQN
-# with '.' turned into '/'; the executable is the resolved `<root>/<bin_out>`.
-# `out_override` (-o), when non-nil, replaces the artifact path: an absolute path
-# is used verbatim; a relative path is rooted at `<root>`. In library mode (or
-# with `--emit obj`) no executable is linked and the per-module objects are the
-# deliverable. Sets `*out_path` on success - the binary in executable mode, the
-# object tree root in library mode. The linker reads its inputs from disk, so the
-# per-module objects are materialized before linking.
-# ---
-# p:            the project carrying the module graph and session
-# emit_obj:     emit the per-module objects only, linking no executable
-# root:         the resolved project root directory
-# out_override: the `-o` artifact path, or nil to use the resolved path
-# argc:         argument count including argv[0]
-# argv:         the argument vector (argc null-terminated byte pointers)
-# marks:        consumption record parallel to argv, for the link-input scanners
-# images:       the per-module object images to write
-# out_path:     receives the owned produced-artifact path on success
-# ret:          0 on success, 1 on a user error, 2 on an internal error
 # free the per-member read buffers and symbol-name arrays, then the member array
 fun free_members(alloc: *A.Allocator, members: *ar.ArMember, cap: u32) {
     var i: u32 = 0;
@@ -1636,6 +1614,28 @@ fun emit_static_archive(p: *driver.Project, images: *of.ObjectImage, paths: **u8
     ret 0;
 }
 
+# write each per-module image to a relocatable `.o` on disk, then - in
+# executable mode - link the on-disk object set into the resolved artifact path
+#
+# The object layout is `<root>/<resolved obj>/<rel>.o`, where `<rel>` is the FQN
+# with '.' turned into '/'; the executable is the resolved `<root>/<bin_out>`.
+# `out_override` (-o), when non-nil, replaces the artifact path: an absolute path
+# is used verbatim; a relative path is rooted at `<root>`. In library mode (or
+# with `--emit obj`) no executable is linked and the per-module objects are the
+# deliverable. Sets `*out_path` on success - the binary in executable mode, the
+# object tree root in library mode. The linker reads its inputs from disk, so the
+# per-module objects are materialized before linking.
+# ---
+# p:            the project carrying the module graph and session
+# emit_obj:     emit the per-module objects only, linking no executable
+# root:         the resolved project root directory
+# out_override: the `-o` artifact path, or nil to use the resolved path
+# argc:         argument count including argv[0]
+# argv:         the argument vector (argc null-terminated byte pointers)
+# marks:        consumption record parallel to argv, for the link-input scanners
+# images:       the per-module object images to write
+# out_path:     receives the owned produced-artifact path on success
+# ret:          0 on success, 1 on a user error, 2 on an internal error
 fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
                   out_override: *u8,
                   argc: usize, argv: **u8, marks: *bool,

--- a/src/cli/cmd/clean.mach
+++ b/src/cli/cmd/clean.mach
@@ -102,7 +102,7 @@ fun clean_project(a: *A.Allocator, root: *u8, manifest_path: *u8) i64 {
     var tbl: toml.Table = R.unwrap_ok[toml.Table, str](tbl_r);
 
     var itn: intern.Interner = intern.init(a);
-    val man_r: R.Result[manifest.Manifest, str] = manifest.parse(a, ?itn, ?tbl);
+    val man_r: R.Result[manifest.Manifest, str] = manifest.parse(a, ?itn, ?tbl, true);
     if (R.is_err[manifest.Manifest, str](man_r)) {
         print.eprint("error: mach.toml: ");
         print.eprintln(R.unwrap_err[manifest.Manifest, str](man_r));

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -213,7 +213,7 @@ pub fun pull_project(root: str, quiet: bool) i64 {
     }
     var mt: toml.Table = R.unwrap_ok[toml.Table, str](res_manifest);
 
-    val dep_name: str = dep_dir_name(?mt);
+    val dep_name: str = "dep";
     val res_dep_root: R.Result[str, str] = join2(?a, root, dep_name::*u8);
     if (R.is_err[str, str](res_dep_root)) { ret err_oom(); }
     val dep_root: str = R.unwrap_ok[str, str](res_dep_root);
@@ -562,8 +562,7 @@ fun dep_update(argc: usize, argv: **u8) i64 {
         err_line(R.unwrap_err[toml.Table, str](res_manifest));
         ret 1;
     }
-    var mt: toml.Table = R.unwrap_ok[toml.Table, str](res_manifest);
-    val res_dep_root: R.Result[str, str] = join2(?a, ".", dep_dir_name(?mt)::*u8);
+    val res_dep_root: R.Result[str, str] = join2(?a, ".", "dep");
     if (R.is_err[str, str](res_dep_root)) { ret err_oom(); }
     val dep_root: str = R.unwrap_ok[str, str](res_dep_root);
 
@@ -800,7 +799,7 @@ fun dep_list() i64 {
         ret 0;
     }
 
-    val res_dep_root: R.Result[str, str] = join2(?a, ".", dep_dir_name(?mt)::*u8);
+    val res_dep_root: R.Result[str, str] = join2(?a, ".", "dep");
     if (R.is_err[str, str](res_dep_root)) { ret err_oom(); }
     val dep_root: str = R.unwrap_ok[str, str](res_dep_root);
     val lock_deps: *toml.Table = read_lock_deps(?a, LOCKFILE::str, nil);
@@ -1678,32 +1677,17 @@ fun dep_header(a: *A.Allocator, name: *u8) R.Result[*u8, str] {
     ret R.ok[*u8, str](buf::str);
 }
 
-# the dep directory `<dep>/<name>/` for a dependency of the current project
+# the dep directory `dep/<name>/` for a dependency of the current project
 #
-# Resolved through the manifest's `[project].dep`.
+# The store lives at the `dep/` convention (there is no key to configure it).
 # ---
-# a:    allocator for reading and the joined path
+# a:    allocator for the joined path
 # name: the dependency name
 # ret:  the dep directory path, or an error
 fun dep_dir_path(a: *A.Allocator, name: *u8) R.Result[str, str] {
-    val res_table: R.Result[toml.Table, str] = parse_file(a, MANIFEST::str);
-    if (R.is_err[toml.Table, str](res_table)) { ret R.err[str, str](R.unwrap_err[toml.Table, str](res_table)); }
-    var t: toml.Table = R.unwrap_ok[toml.Table, str](res_table);
-    val res_root: R.Result[str, str] = join2(a, ".", dep_dir_name(?t)::*u8);
+    val res_root: R.Result[str, str] = join2(a, ".", "dep");
     if (R.is_err[str, str](res_root)) { ret res_root; }
     ret join2(a, R.unwrap_ok[str, str](res_root), name);
-}
-
-# the project's dep-dir name from a parsed manifest
-#
-# Reads `[project].dep`, defaulting to "dep".
-# ---
-# mt:  the parsed manifest table
-# ret: the dep-dir name
-fun dep_dir_name(mt: *toml.Table) str {
-    val d: str = toml.get_str(mt, "project.dep");
-    if (str_empty(d)) { ret "dep"; }
-    ret d;
 }
 
 # the name of the i-th forwarded environment variable

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -763,7 +763,7 @@ test "mach.cli.cmd.doc.generate:creates_missing_output_dirs" {
     if (R.is_err[bool, str](filesystem.create_dir_all(?alloc, util.cstr_str(?root[0]), 493))) { bad = 1; }
     if (R.is_err[bool, str](filesystem.create_dir_all(?alloc, src_dir, 493)))                 { bad = 1; }
 
-    val manifest_text: str = "[project]\nid = \"doctest\"\nname = \"d\"\ndescription = \"d\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\n\n[artifact.doctest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/doctest\"\ntargets = [\"*\"]\n";
+    val manifest_text: str = "[project]\nid = \"doctest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\n\n[artifact.doctest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/doctest\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     val main_text: str = "fun main() i32 { ret 0; }\n\n# a documented helper\npub fun answer() i32 { ret 42; }\n";
     val mf: str = t_join(?alloc, util.cstr_str(?root[0]), "mach.toml");
     val mn: str = t_join(?alloc, src_dir, "main.mach");

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -77,7 +77,7 @@ fun global_flags() {
     print.print("  -v                phase roll-up with timing + a build summary on stderr\n");
     print.print("  -vv               -v plus per-module/file detail under each phase\n");
     print.print("  --quiet, -q       suppress non-error output (mutually exclusive with -v/-vv)\n");
-    print.print("  --target <name>   select a [targets.<name>] entry\n");
+    print.print("  --target <name>   select a [target.<name>] entry\n");
     print.print("  --profile <name>  select a build profile (debug/release/etc.)\n");
     print.print("  -o <path>         override the linked-binary path (build/run/test)\n");
     print.print("  --emit-asm        emit per-module .s assembly text beside each object\n");
@@ -94,7 +94,7 @@ pub fun usage() {
     print.print("usage: mach <command> [options]\n");
     print.print("\n");
     print.print("commands:\n");
-    print.print("  build    compile the current project\n");
+    print.print("  build    compile a project\n");
     print.print("  run      build and execute the current project\n");
     print.print("  test     build and run the project's tests\n");
     print.print("  clean    remove the project's build output\n");
@@ -113,7 +113,7 @@ pub fun usage() {
 fun help_build() {
     print.print("usage: mach build <path> [options] [inputs...]\n");
     print.print("\n");
-    print.print("compile the current project to relocatable objects and, in executable\n");
+    print.print("compile a project to relocatable objects and, in executable\n");
     print.print("mode, a linked binary. <path> is a project directory or a manifest file.\n");
     print.print("\n");
     print.print("options:\n");
@@ -235,7 +235,7 @@ fun help_doc() {
     print.print("\n");
     print.print("options:\n");
     print.print("  --out <dir>      output directory, rooted at the project (default: doc/api)\n");
-    print.print("  --target <name>  select a [targets.<name>] entry for module discovery\n");
+    print.print("  --target <name>  select a [target.<name>] entry for module discovery\n");
     print.print("\n");
     global_flags();
     print.print("\n");

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -192,12 +192,6 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     buf_put(?buf, "id = \"");
     buf_put(?buf, id);
     buf_put(?buf, "\"\n");
-    buf_put(?buf, "name = \"");
-    buf_put(?buf, id);
-    buf_put(?buf, "\"\n");
-    buf_put(?buf, "description = \"");
-    buf_put(?buf, id);
-    buf_put(?buf, "\"\n");
     buf_put(?buf, "version = \"0.1.0\"\n");
     buf_put(?buf, "src = \"src\"\n");
     buf_put(?buf, "out = \"out/{target.name}/{profile.name}\"\n");
@@ -230,13 +224,17 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
         buf_put(?buf, "\"\n");
     }
     buf_put(?buf, "targets = [\"*\"]\n");
+    buf_put(?buf, "link = []\n");
+    buf_put(?buf, "need = []\n");
     buf_put(?buf, "\n");
 
     buf_put(?buf, "[profile.debug]\n");
     buf_put(?buf, "opt = 0\n");
+    buf_put(?buf, "debug = true\n");
     buf_put(?buf, "\n");
     buf_put(?buf, "[profile.release]\n");
     buf_put(?buf, "opt = 2\n");
+    buf_put(?buf, "debug = false\n");
     buf_put(?buf, "\n");
 
     buf_put(?buf, "[dep.mach-std]\n");

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -31,10 +31,10 @@ use mach.cli.util;
 #              (`.ir`) alongside each object, for debugging / transparency - the
 #              final post-pipeline IR the object is built from, so it varies with
 #              the optimization level
-# no_emit_asm: --no-emit-asm was passed; force ASM emission off, overriding a v2
-#              profile's `emit_asm` default
-# no_emit_ir:  --no-emit-ir was passed; force IR emission off, overriding a v2
-#              profile's `emit_ir` default
+# no_emit_asm: --no-emit-asm was passed; force ASM emission off (the complement of
+#              --emit-asm; IR/ASM emission is CLI-only)
+# no_emit_ir:  --no-emit-ir was passed; force IR emission off (the complement of
+#              --emit-ir; IR/ASM emission is CLI-only)
 # profile:     --profile <name> selected build profile for a v2 manifest (nil
 #              when not given)
 # bin:         --bin <name> narrows a v2 build to one `[bin.*]` artifact (nil

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -9,6 +9,7 @@
 # that yields an error message.
 
 use std.types.bool.bool;
+use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 
@@ -30,11 +31,7 @@ use mach.cli.util;
 # emit_ir:     --emit-ir was passed; emit per-module human-readable SSA IR text
 #              (`.ir`) alongside each object, for debugging / transparency - the
 #              final post-pipeline IR the object is built from, so it varies with
-#              the optimization level
-# no_emit_asm: --no-emit-asm was passed; force ASM emission off (the complement of
-#              --emit-asm; IR/ASM emission is CLI-only)
-# no_emit_ir:  --no-emit-ir was passed; force IR emission off (the complement of
-#              --emit-ir; IR/ASM emission is CLI-only)
+#              the optimization level. IR/ASM emission is CLI-only and off by default
 # profile:     --profile <name> selected build profile for a v2 manifest (nil
 #              when not given)
 # bin:         --bin <name> narrows a v2 build to one `[bin.*]` artifact (nil
@@ -55,8 +52,6 @@ pub rec Config {
     output:      *u8;
     emit_asm:    bool;
     emit_ir:     bool;
-    no_emit_asm: bool;
-    no_emit_ir:  bool;
     profile:     *u8;
     bin:         *u8;
     lib:         *u8;
@@ -99,8 +94,6 @@ pub fun parse(argc: usize, argv: **u8, marks: *bool) R.Result[Config, str] {
     c.verify_ir   = util.mark_flag(marks, argc, argv, "--verify-ir");
     c.emit_asm    = util.mark_flag(marks, argc, argv, "--emit-asm");
     c.emit_ir     = util.mark_flag(marks, argc, argv, "--emit-ir");
-    c.no_emit_asm = util.mark_flag(marks, argc, argv, "--no-emit-asm");
-    c.no_emit_ir  = util.mark_flag(marks, argc, argv, "--no-emit-ir");
     c.all_targets = util.mark_flag(marks, argc, argv, "--all-targets");
     c.pie         = util.mark_flag(marks, argc, argv, "--pie");
     c.g           = util.mark_flag(marks, argc, argv, "-g");
@@ -130,4 +123,36 @@ fun flag_value_get(marks: *bool, argc: usize, argv: **u8, flag: *u8) *u8 {
     val opt_value: O.Option[*u8] = util.mark_value(marks, argc, argv, flag);
     if (O.is_none[*u8](opt_value)) { ret nil; }
     ret O.unwrap[*u8](opt_value);
+}
+
+# the removed pre-flag-day flags (#1999) are no longer marked by parse, so the
+# unknown-flag rejector reports them, while --emit-ir/--emit-asm stay recognized
+test "mach.cli.config.parse:removed_flags_rejected" {
+    var a:  [4]*u8;
+    a[0] = "mach"; a[1] = "build"; a[3] = ".";
+    var ma: [4]bool;
+
+    # each removed flag is unmarked by parse and so reported as unknown.
+    var removed: [3]*u8;
+    removed[0] = "--release"; removed[1] = "--no-emit-ir"; removed[2] = "--no-emit-asm";
+    var r: usize = 0;
+    for (r < 3) {
+        a[2] = removed[r];
+        var i: usize = 0;
+        for (i < 4) { ma[i] = false; i = i + 1; }
+        if (R.is_err[Config, str](parse(4, ?a[0], ?ma[0])))            { ret 1; }
+        if (!util.reject_unknown(4, ?a[0], ?ma[0], 2, "mach build"))   { ret 1; }
+        r = r + 1;
+    }
+
+    # --emit-ir stays recognized: parse marks it, so the rejector accepts it.
+    a[2] = "--emit-ir";
+    var j: usize = 0;
+    for (j < 4) { ma[j] = false; j = j + 1; }
+    if (R.is_err[Config, str](parse(4, ?a[0], ?ma[0])))          { ret 1; }
+    if (util.reject_unknown(4, ?a[0], ?ma[0], 2, "mach build"))  { ret 1; }
+
+    # -O2 stays a recognized per-invocation override (marked by mach build's own
+    # flag pass, not parse) — it is left for the e2e demo to exercise end to end.
+    ret 0;
 }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -261,6 +261,10 @@ pub fun reject_unknown(argc: usize, argv: **u8, marks: *bool, start: usize, cmd:
             print.eprint("' for '");
             print.eprint(cmd::str);
             print.eprint("'\n");
+            # --release was replaced by profile selection; point at the successor.
+            if (str_equals(argv[i]::str, "--release")) {
+                print.eprint("hint: optimisation comes from the profile; use --profile release\n");
+            }
             ret true;
         }
         i = i + 1;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2322,6 +2322,8 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
         if (R.is_err[toml.Table, str](pr)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](pr)); }
         tables[i] = R.unwrap_ok[toml.Table, str](pr);
 
+        # a dependency's manifest: as_root false, parsed permissively for its export
+        # surface only (#1971) -- the dep's totality is enforced on its own root builds.
         val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tables[i], false);
         if (R.is_err[manifest.Manifest, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mf_r)); }
         manifests[i] = R.unwrap_ok[manifest.Manifest, str](mf_r);
@@ -9863,6 +9865,7 @@ fun execute_dep_steps(p: *Project, isa: str, os: str, abi: str) R.Result[bool, s
         if (R.is_err[toml.Table, str](pr)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](pr)); }
         var tbl: toml.Table = R.unwrap_ok[toml.Table, str](pr);
 
+        # a dependency's manifest: as_root false, parsed permissively (#1971).
         val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tbl, false);
         if (R.is_err[manifest.Manifest, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mf_r)); }
         var mfd: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mf_r);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -3033,7 +3033,7 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) R.Result[session.Module
     # teardown never frees m.a, so a never-parsed entry needs no placeholder AST.
     m.a                 = nil;
     # resolve the active optimization mode for `$mach.build.mode`: an explicit CLI
-    # `-O*`/`--release` flag wins, else the selected target's manifest opt, else
+    # `-O*` flag wins, else the selected target's manifest opt, else
     # debug - mirroring cmd.build.resolve_opt_level so the gate matches the pipeline.
     var build_mode_id: u32 = comptime.MODE_DEBUG;
     if (p.s.opt_explicit) {

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -119,6 +119,8 @@ pub val TARGET_OPT_RELEASE: TargetOpt = 2;
 #             archive path (relative to the project root, or absolute) or a bare
 #             `-l`-style name resolved against the link search dirs; nil when none
 # lib_count:  number of entries in `libs`
+# lib_kind:   for a library build (mode == MODE_LIBRARY), whether the artifact is
+#             static or shared; meaningless for an executable (#1980)
 pub rec TargetEntry {
     name:       intern.StrId;
     os_name:    intern.StrId;
@@ -130,6 +132,7 @@ pub rec TargetEntry {
     opt:        TargetOpt;
     libs:       *intern.StrId;
     lib_count:  u32;
+    lib_kind:   manifest.LibKind;
 }
 
 # one entry under `[deps.<alias>]` in mach.toml plus the dep's
@@ -1567,6 +1570,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     entry.entrypoint = bu.entry;
     entry.mode       = MODE_EXECUTABLE;
     if (bu.is_lib) { entry.mode = MODE_LIBRARY; }
+    entry.lib_kind   = bu.kind;
     entry.opt        = map_opt(bu.opt);
     entry.libs       = bu.libs;
     entry.lib_count  = bu.lib_count;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -472,7 +472,7 @@ pub fun enumerate_matrix(alloc: *A.Allocator, project_root: str, manifest_path: 
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
     var itn: intern.Interner = intern.init(alloc);
-    val mr: R.Result[manifest.Manifest, str] = manifest.parse(alloc, ?itn, ?t);
+    val mr: R.Result[manifest.Manifest, str] = manifest.parse(alloc, ?itn, ?t, true);
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[Matrix, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
 
@@ -547,7 +547,7 @@ pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, manifest_p
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
     var itn: intern.Interner = intern.init(alloc);
-    val mr: R.Result[manifest.Manifest, str] = manifest.parse(alloc, ?itn, ?t);
+    val mr: R.Result[manifest.Manifest, str] = manifest.parse(alloc, ?itn, ?t, true);
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[str, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
 
@@ -1509,7 +1509,7 @@ fun load_project_config(p: *Project, project_root: str, manifest_path: str, sel:
 # collisions are checked before anything is built. a `native` selection that
 # finds no host match emits an unmissable warning here
 fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.Selection, for_union: bool, is_test: bool) R.Result[bool, str] {
-    val mr: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, t);
+    val mr: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, t, true);
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
 
@@ -1607,7 +1607,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     val tn_s: str = O.unwrap[str](intern.lookup(?p.s.interner, bu.target.name));
     val pn_s: str = O.unwrap[str](intern.lookup(?p.s.interner, bu.profile_name));
     val out_tmpl_s: str = O.unwrap[str](intern.lookup(?p.s.interner, m.out_tmpl));
-    val res_project_out_str: R.Result[str, str] = manifest.expand(p.s.alloc, out_tmpl_s, "", tn_s, pn_s, "", "");
+    val res_project_out_str: R.Result[str, str] = manifest.expand(p.s.alloc, out_tmpl_s, "", tn_s, pn_s);
     if (R.is_ok[str, str](res_project_out_str)) {
         val project_out_str: str = R.unwrap_ok[str, str](res_project_out_str);
         val res_po_id: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, project_out_str);
@@ -2008,7 +2008,7 @@ fun validate_local_links(p: *Project, project_root: str, m: *manifest.Manifest, 
             val raw_path: str = O.unwrap[str](path_opt);
             val ename:    str = O.unwrap[str](name_opt);
 
-            val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, raw_path, proj_out, tn, pn, "", "");
+            val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, raw_path, proj_out, tn, pn);
             if (R.is_err[str, str](exp_r)) { ret R.err[bool, str](R.unwrap_err[str, str](exp_r)); }
             val exp: str = R.unwrap_ok[str, str](exp_r);
 
@@ -2322,7 +2322,7 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
         if (R.is_err[toml.Table, str](pr)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](pr)); }
         tables[i] = R.unwrap_ok[toml.Table, str](pr);
 
-        val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tables[i]);
+        val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tables[i], false);
         if (R.is_err[manifest.Manifest, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mf_r)); }
         manifests[i] = R.unwrap_ok[manifest.Manifest, str](mf_r);
 
@@ -2422,7 +2422,7 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
                         val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
                         val tn2: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
                         val pn2: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
-                        val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, O.unwrap[str](p_opt), root_out, tn2, pn2, "", "");
+                        val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, O.unwrap[str](p_opt), root_out, tn2, pn2);
                         if (R.is_ok[str, str](exp_r)) {
                             val exp: str = R.unwrap_ok[str, str](exp_r);
                             lib_id = R.unwrap_ok[intern.StrId, str](intern.intern(?p.s.interner, exp));
@@ -5898,7 +5898,7 @@ fun ut_cc3(alloc: *A.Allocator, a: str, b: str, c: str) str {
 # `resolve_native` falls back to the first target (linux) and the host-tie assertions in
 # union_ctx_restored_to_default_tuple read the wrong default for that host (#1724)
 fun ut_manifest() str {
-    ret "[project]\nid = \"uniontest\"\nname = \"u\"\ndescription = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[target.linux-riscv64]\nisa = \"riscv64\"\nos = \"linux\"\nabi = \"lp64\"\n\n[target.darwin-x86_64]\nisa = \"x86_64\"\nos = \"darwin\"\nabi = \"sysv64\"\n\n[target.darwin-arm64]\nisa = \"aarch64\"\nos = \"darwin\"\nabi = \"aapcs64\"\n\n[artifact.uniontest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest\"\ntargets = [\"*\"]\n";
+    ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[target.linux-riscv64]\nisa = \"riscv64\"\nos = \"linux\"\nabi = \"lp64\"\n\n[target.darwin-x86_64]\nisa = \"x86_64\"\nos = \"darwin\"\nabi = \"sysv64\"\n\n[target.darwin-arm64]\nisa = \"aarch64\"\nos = \"darwin\"\nabi = \"aapcs64\"\n\n[artifact.uniontest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
 # a two-target, two-bin manifest for the multi-artifact union
@@ -5906,14 +5906,14 @@ fun ut_manifest() str {
 # bin.beta is a second whose entry the union must also load. id is "uniontest" so
 # the per-file `use uniontest.*` paths and FQN assertions match ut_manifest's
 fun ut_manifest_multi() str {
-    ret "[project]\nid = \"uniontest\"\nname = \"u\"\ndescription = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\n";
+    ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
 # a manifest with a windows-only `local` link entry whose path is neither step-backed
 # nor present on disk, for the #1988 cross-target validation-skip test. building for
 # linux must ignore the entry (it filters out), not validate its linux-cell expansion
 fun ut_manifest_winlocal() str {
-    ret "[project]\nid = \"winlocal\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[link.winobj]\nsource = \"local\"\npath = \"{project.out}/win.o\"\nos = [\"windows\"]\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n";
+    ret "[project]\nid = \"winlocal\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[link.winobj]\nsource = \"local\"\npath = \"{project.out}/win.o\"\nos = [\"windows\"]\nisa = [\"*\"]\nabi = [\"*\"]\nexport = false\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
 # materialize a temp project (the shared ut_manifest + src/<files>) on
@@ -5988,12 +5988,12 @@ fun ut_write_node(alloc: *A.Allocator, dir: str, manifest_text: str, src_name: s
 # a minimal static-lib dep manifest carrying project id `id`.
 fun ut_lib_manifest(alloc: *A.Allocator, id: str) str {
     ret ut_cc3(alloc, "[project]\nid = \"", id,
-        "\"\nname = \"l\"\ndescription = \"d\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[artifact.lib]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/l\"\ntargets = [\"*\"]\n");
+        "\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[artifact.lib]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/l\"\ntargets = [\"*\"]\nlink = []\nneed = []\n");
 }
 
 # a bin root manifest declaring the single path dep [dep.<alias>] at `path`.
 fun ut_dep_root_one(alloc: *A.Allocator, alias: str, path: str) str {
-    val head: str = "[project]\nid = \"app\"\nname = \"app\"\ndescription = \"d\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n\n[dep.";
+    val head: str = "[project]\nid = \"app\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[dep.";
     val mid: str = ut_cc3(alloc, head, alias, "]\npath = \"");
     ret ut_cc3(alloc, mid, path, "\"\n");
 }
@@ -6413,7 +6413,7 @@ test "mach.lang.driver:union_skips_uncoverable_target" {
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
 
     # one coverable target (linux/x86_64) and one this build cannot emit
-    val mf: str = "[project]\nid = \"uskip\"\nname = \"u\"\ndescription = \"u\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.good]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.bad]\nisa = \"aarch64\"\nos = \"windows\"\nabi = \"aapcs64\"\n\n[artifact.uskip]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uskip\"\ntargets = [\"*\"]\n";
+    val mf: str = "[project]\nid = \"uskip\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.good]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.bad]\nisa = \"aarch64\"\nos = \"windows\"\nabi = \"aapcs64\"\n\n[artifact.uskip]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uskip\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     var names: [1]str;
     names[0] = "main.mach";
     var texts: [1]str;
@@ -9458,7 +9458,7 @@ fun collect_step_inputs(alloc: *A.Allocator, p: *Project, step: *manifest.StepDe
     val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
     var i: u32 = 0;
     for (i < step.in_count) {
-        val exp_r: R.Result[str, str] = manifest.expand(alloc, O.unwrap[str](intern.lookup(?p.s.interner, step.in[i])), home_out, target_name_s, profile_s, "", "");
+        val exp_r: R.Result[str, str] = manifest.expand(alloc, O.unwrap[str](intern.lookup(?p.s.interner, step.in[i])), home_out, target_name_s, profile_s);
         if (R.is_err[str, str](exp_r)) { ret R.err[bool, str](R.unwrap_err[str, str](exp_r)); }
         val exp: str = R.unwrap_ok[str, str](exp_r);
         if (!has_glob(exp)) {
@@ -9586,7 +9586,7 @@ fun step_outputs_exist(a: *A.Allocator, p: *Project, step: *manifest.StepDef, pr
     val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
     var oi: u32 = 0;
     for (oi < step.out_count) {
-        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), home_out, target_name_s, profile_s, "", "");
+        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), home_out, target_name_s, profile_s);
         if (R.is_err[str, str](out_r)) { ret false; }
         val out_s: str = R.unwrap_ok[str, str](out_r);
         val abs_r: R.Result[str, str] = join_path(a, project_root, out_s);
@@ -9632,7 +9632,7 @@ fun step_make_output_dirs(a: *A.Allocator, p: *Project, step: *manifest.StepDef)
     val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
     var oi: u32 = 0;
     for (oi < step.out_count) {
-        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), root_out, target_name_s, profile_s, "", "");
+        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), root_out, target_name_s, profile_s);
         if (R.is_err[str, str](out_r)) { ret R.err[bool, str](R.unwrap_err[str, str](out_r)); }
         val out_s: str = R.unwrap_ok[str, str](out_r);
         val rel_dir: str = parent_dir(a, out_s);
@@ -9671,7 +9671,7 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
     val cir: R.Result[bool, str] = collect_step_inputs(a, p, step, project_root, home_out, ?ins);
     if (R.is_err[bool, str](cir)) { step_free_inputs(a, ?ins); ret R.err[bool, str](R.unwrap_err[bool, str](cir)); }
 
-    val cmd_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.cmd)), project_out_s, target_name_s, profile_s, "", "");
+    val cmd_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.cmd)), project_out_s, target_name_s, profile_s);
     if (R.is_err[str, str](cmd_r)) { step_free_inputs(a, ?ins); ret R.err[bool, str](R.unwrap_err[str, str](cmd_r)); }
     val expanded_cmd: str = R.unwrap_ok[str, str](cmd_r);
 
@@ -9863,7 +9863,7 @@ fun execute_dep_steps(p: *Project, isa: str, os: str, abi: str) R.Result[bool, s
         if (R.is_err[toml.Table, str](pr)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](pr)); }
         var tbl: toml.Table = R.unwrap_ok[toml.Table, str](pr);
 
-        val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tbl);
+        val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.s.alloc, ?p.s.interner, ?tbl, false);
         if (R.is_err[manifest.Manifest, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mf_r)); }
         var mfd: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mf_r);
 

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -320,7 +320,7 @@ fun canonical_axis_value(key: str, value: str) bool {
     ret false;
 }
 
-fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Table, key: str, label: str, strict: bool) R.Result[StrArr, str] {
+fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Table, key: str, label: str, as_root: bool) R.Result[StrArr, str] {
     var out: StrArr;
     out.items   = nil;
     out.count   = 0;
@@ -356,7 +356,7 @@ fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Tab
         ret R.err[StrArr, str](cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
     }
 
-    if (strict) {
+    if (as_root) {
         var vi: u32 = 0;
         for (vi < out.count) {
             val vs: str = idstr(itn, out.items[vi]);
@@ -369,9 +369,9 @@ fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Tab
     ret R.ok[StrArr, str](out);
 }
 
-fun parse_opt_level(alloc: *A.Allocator, name: str, sub: *toml.Table, strict: bool) R.Result[MOpt, str] {
+fun parse_opt_level(alloc: *A.Allocator, name: str, sub: *toml.Table, as_root: bool) R.Result[MOpt, str] {
     val v: *toml.Value = toml.get(sub, "opt");
-    if (v == nil && strict)         { ret R.err[MOpt, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'opt'")); }
+    if (v == nil && as_root)         { ret R.err[MOpt, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'opt'")); }
     if (v == nil)                   { ret R.ok[MOpt, str](MOPT_DEFAULT); }
     if (v.tag != toml.TYPE_INTEGER) { ret R.err[MOpt, str](opt_err(alloc, name, v)); }
     val n: i64 = v.data.integer;
@@ -398,9 +398,9 @@ fun opt_value_text(alloc: *A.Allocator, v: *toml.Value) str {
     ret "a value";
 }
 
-fun parse_debug_flag(alloc: *A.Allocator, name: str, sub: *toml.Table, strict: bool) R.Result[bool, str] {
+fun parse_debug_flag(alloc: *A.Allocator, name: str, sub: *toml.Table, as_root: bool) R.Result[bool, str] {
     val v: *toml.Value = toml.get(sub, "debug");
-    if (v == nil && strict)      { ret R.err[bool, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'debug'")); }
+    if (v == nil && as_root)      { ret R.err[bool, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'debug'")); }
     if (v == nil)                { ret R.ok[bool, str](false); }
     if (v.tag != toml.TYPE_BOOL) { ret R.err[bool, str](debug_err(alloc, name, v)); }
     ret R.ok[bool, str](v.data.boolean);
@@ -438,13 +438,14 @@ fun unknown_key_msg(alloc: *A.Allocator, key: str, label: str) str {
     ret cc(alloc, cc3(alloc, "mach.toml: unknown key '", key, "' in "), label);
 }
 
-fun key_known(kind: TableKind, k: str, strict: bool) bool {
+fun key_known(kind: TableKind, k: str, as_root: bool) bool {
     if (kind == TK_PROJECT) {
         if (str_equals(k, "id") || str_equals(k, "version") || str_equals(k, "src") || str_equals(k, "out")) { ret true; }
-        # a dependency's manifest is parsed permissively (#1971): the consumer reads
-        # only its export surface, so pre-flag-day metadata like name/description is
-        # tolerated rather than rejected. the root manifest is strict.
-        if (!strict && (str_equals(k, "name") || str_equals(k, "description"))) { ret true; }
+        # a dependency's manifest (as_root false) tolerates the pre-flag-day
+        # name/description metadata the consumer never reads (#1971); the root
+        # trims [project] to id/version/src/out. a genuinely unknown key is rejected
+        # on both paths -- only these two pre-flag-day keys relax off-root.
+        if (!as_root && (str_equals(k, "name") || str_equals(k, "description"))) { ret true; }
         ret false;
     }
     if (kind == TK_TARGET) {
@@ -470,12 +471,12 @@ fun key_known(kind: TableKind, k: str, strict: bool) bool {
     ret false;
 }
 
-fun check_keys(alloc: *A.Allocator, tab: *toml.Table, label: str, kind: TableKind, strict: bool) R.Result[bool, str] {
+fun check_keys(alloc: *A.Allocator, tab: *toml.Table, label: str, kind: TableKind, as_root: bool) R.Result[bool, str] {
     val n: usize = toml.table_len(tab);
     var i: usize = 0;
     for (i < n) {
         val k: str = toml.table_key(tab, i);
-        if (!key_known(kind, k, strict)) { ret R.err[bool, str](unknown_key_msg(alloc, k, label)); }
+        if (!key_known(kind, k, as_root)) { ret R.err[bool, str](unknown_key_msg(alloc, k, label)); }
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -498,12 +499,17 @@ fun first_nonempty(a: str, b: str) str {
     ret a;
 }
 
-# parse a manifest. `strict` enforces #1964 no-defaults totality (every declared-
-# table field spelled, [project] trimmed to id/version/src/out, canonical filter
-# axes) and is used for the root manifest being built. a dependency's manifest is
-# parsed with strict=false: the consumer reads only its export surface, so the
-# dep's own migration state must not gate the consumer's build (#1971).
-pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, strict: bool) R.Result[Manifest, str] {
+# parse a manifest. `as_root` selects the enforcement boundary (#1971): true for the
+# manifest being built (the root), where #1964 no-defaults totality is enforced --
+# every declared-table field spelled, [project] trimmed to id/version/src/out,
+# canonical filter axes. false for a dependency's manifest, parsed permissively: the
+# consumer reads only the dep's export surface (id, exported link entries, the steps
+# they demand), so the dep's own migration state must never gate the consumer's
+# build. Enforcement travels with the declaring unit -- a dep enforces its own
+# totality on ITS root builds. Unknown-key rejection is NOT part of the mode: a
+# genuinely unknown key is rejected on both paths (only pre-flag-day [project]
+# name/description relax off-root).
+pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, as_root: bool) R.Result[Manifest, str] {
     var m: Manifest;
     m.targets        = nil;
     m.target_count   = 0;
@@ -520,7 +526,7 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, strict
 
     val proj: *toml.Table = toml.get_table(t, "project");
     if (proj == nil) { ret R.err[Manifest, str]("mach.toml: missing [project] table"); }
-    val res_project_keys: R.Result[bool, str] = check_keys(alloc, proj, "[project]", TK_PROJECT, strict);
+    val res_project_keys: R.Result[bool, str] = check_keys(alloc, proj, "[project]", TK_PROJECT, as_root);
     if (R.is_err[bool, str](res_project_keys)) { ret R.err[Manifest, str](R.unwrap_err[bool, str](res_project_keys)); }
 
     val id_str: str = toml.get_str(proj, "id");
@@ -549,28 +555,28 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, strict
     m.out_tmpl = intern_unwrap(itn, out_str);
     m.default_target = intern_unwrap(itn, "native");
 
-    val res_targets: R.Result[bool, str] = parse_targets(alloc, itn, t, ?m, strict);
+    val res_targets: R.Result[bool, str] = parse_targets(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_targets)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_targets)); }
 
-    val res_artifacts: R.Result[bool, str] = parse_artifacts(alloc, itn, t, ?m, strict);
+    val res_artifacts: R.Result[bool, str] = parse_artifacts(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_artifacts)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_artifacts)); }
 
-    val res_profiles: R.Result[bool, str] = parse_profiles(alloc, itn, t, ?m, strict);
+    val res_profiles: R.Result[bool, str] = parse_profiles(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_profiles)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_profiles)); }
 
-    val res_deps: R.Result[bool, str] = parse_deps(alloc, itn, t, ?m, strict);
+    val res_deps: R.Result[bool, str] = parse_deps(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_deps)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_deps)); }
 
-    val res_links: R.Result[bool, str] = parse_links(alloc, itn, t, ?m, strict);
+    val res_links: R.Result[bool, str] = parse_links(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_links)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_links)); }
 
-    val res_steps: R.Result[bool, str] = parse_steps(alloc, itn, t, ?m, strict);
+    val res_steps: R.Result[bool, str] = parse_steps(alloc, itn, t, ?m, as_root);
     if (R.is_err[bool, str](res_steps)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_steps)); }
 
     ret R.ok[Manifest, str](m);
 }
 
-fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "target");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -593,7 +599,7 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
         }
         val sub: *toml.Table = ?v.data.table;
         val label: str = cc3(alloc, "[target.", name, "]");
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_TARGET, strict);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_TARGET, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: TargetDef;
@@ -616,7 +622,7 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
     ret R.ok[bool, str](true);
 }
 
-fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val arts: *toml.Table = toml.get_table(t, "artifact");
     if (arts == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(arts);
@@ -629,7 +635,7 @@ fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, 
 
     var i: usize = 0;
     for (i < n) {
-        val res_artifact: R.Result[ArtifactDef, str] = parse_one_artifact(alloc, itn, arts, i, strict);
+        val res_artifact: R.Result[ArtifactDef, str] = parse_one_artifact(alloc, itn, arts, i, as_root);
         if (R.is_err[ArtifactDef, str](res_artifact)) { ret R.err[bool, str](R.unwrap_err[ArtifactDef, str](res_artifact)); }
         m.artifacts[i] = R.unwrap_ok[ArtifactDef, str](res_artifact);
         i = i + 1;
@@ -637,7 +643,7 @@ fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, 
     ret R.ok[bool, str](true);
 }
 
-fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Table, k: usize, strict: bool) R.Result[ArtifactDef, str] {
+fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Table, k: usize, as_root: bool) R.Result[ArtifactDef, str] {
     val name: str = toml.table_key(tab, k);
     val v: *toml.Value = toml.table_value(tab, k);
     val label: str = cc3(alloc, "[artifact.", name, "]");
@@ -646,7 +652,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     }
     val sub: *toml.Table = ?v.data.table;
 
-    val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_ARTIFACT, strict);
+    val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_ARTIFACT, as_root);
     if (R.is_err[bool, str](res_keys)) { ret R.err[ArtifactDef, str](R.unwrap_err[bool, str](res_keys)); }
 
     var a: ArtifactDef;
@@ -689,7 +695,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     a.target_count = targets_val.count;
 
     val link_arr: *toml.Array = toml.get_array(sub, "link");
-    if (link_arr == nil && strict) {
+    if (link_arr == nil && as_root) {
         ret R.err[ArtifactDef, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'link' (use [] for none)"));
     }
     if (link_arr != nil) {
@@ -702,7 +708,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     }
 
     val need_arr: *toml.Array = toml.get_array(sub, "need");
-    if (need_arr == nil && strict) {
+    if (need_arr == nil && as_root) {
         ret R.err[ArtifactDef, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'need' (use [] for none)"));
     }
     if (need_arr != nil) {
@@ -717,7 +723,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     ret R.ok[ArtifactDef, str](a);
 }
 
-fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "profile");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -737,17 +743,17 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " must be a table"));
         }
         val sub: *toml.Table = ?v.data.table;
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_PROFILE, strict);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_PROFILE, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var pf: ProfileDef;
         pf.name = intern_unwrap(itn, name);
-        val res_opt: R.Result[MOpt, str] = parse_opt_level(alloc, name, sub, strict);
+        val res_opt: R.Result[MOpt, str] = parse_opt_level(alloc, name, sub, as_root);
         if (R.is_err[MOpt, str](res_opt)) { ret R.err[bool, str](R.unwrap_err[MOpt, str](res_opt)); }
         pf.opt      = R.unwrap_ok[MOpt, str](res_opt);
         pf.emit_ir  = bool_or(toml.get_bool(sub, "emit_ir"), false);
         pf.emit_asm = bool_or(toml.get_bool(sub, "emit_asm"), false);
-        val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub, strict);
+        val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub, as_root);
         if (R.is_err[bool, str](res_debug)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_debug)); }
         pf.debug    = R.unwrap_ok[bool, str](res_debug);
 
@@ -757,7 +763,7 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
     ret R.ok[bool, str](true);
 }
 
-fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "dep");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -781,7 +787,7 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
         if (toml.get(sub, "version") != nil) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".version is reserved for the registry era"));
         }
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_DEP, strict);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_DEP, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: DepDef;
@@ -794,10 +800,10 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " needs exactly one source key: 'git' or 'path'"));
         }
         val ref_s: str = toml.get_str(sub, "ref");
-        if (has_git && str_empty(ref_s) && strict) {
+        if (has_git && str_empty(ref_s) && as_root) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'ref' for git source"));
         }
-        if (has_path && !str_empty(ref_s) && strict) {
+        if (has_path && !str_empty(ref_s) && as_root) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".ref is not allowed for path sources"));
         }
         d.git  = intern_opt_unwrap(itn, git_s);
@@ -810,7 +816,7 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
     ret R.ok[bool, str](true);
 }
 
-fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "link");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -831,7 +837,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
         val sub: *toml.Table = ?v.data.table;
 
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_LINK, strict);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_LINK, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: LinkDef;
@@ -870,32 +876,32 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
             d.path = intern.STR_NIL;
         }
 
-        val res_os: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "os", label, strict);
+        val res_os: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "os", label, as_root);
         if (R.is_err[StrArr, str](res_os)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_os)); }
         val os_v: StrArr = R.unwrap_ok[StrArr, str](res_os);
-        if (!os_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'os' (use \"*\" for any)")); }
+        if (!os_v.present && as_root) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'os' (use \"*\" for any)")); }
         d.os = os_v.items;
         d.os_count = os_v.count;
         d.os_present = os_v.present;
 
-        val res_isa: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "isa", label, strict);
+        val res_isa: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "isa", label, as_root);
         if (R.is_err[StrArr, str](res_isa)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_isa)); }
         val isa_v: StrArr = R.unwrap_ok[StrArr, str](res_isa);
-        if (!isa_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'isa' (use \"*\" for any)")); }
+        if (!isa_v.present && as_root) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'isa' (use \"*\" for any)")); }
         d.isa = isa_v.items;
         d.isa_count = isa_v.count;
         d.isa_present = isa_v.present;
 
-        val res_abi: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "abi", label, strict);
+        val res_abi: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "abi", label, as_root);
         if (R.is_err[StrArr, str](res_abi)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_abi)); }
         val abi_v: StrArr = R.unwrap_ok[StrArr, str](res_abi);
-        if (!abi_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'abi' (use \"*\" for any)")); }
+        if (!abi_v.present && as_root) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'abi' (use \"*\" for any)")); }
         d.abi = abi_v.items;
         d.abi_count = abi_v.count;
         d.abi_present = abi_v.present;
 
         val export_v: *toml.Value = toml.get(sub, "export");
-        if (export_v == nil && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'export'")); }
+        if (export_v == nil && as_root) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'export'")); }
         if (export_v == nil) { d.export = false; }
         or (export_v.tag != toml.TYPE_BOOL) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".export must be a boolean")); }
         or { d.export = export_v.data.boolean; }
@@ -906,7 +912,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
     ret R.ok[bool, str](true);
 }
 
-fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
+fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "step");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -927,7 +933,7 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
         val sub: *toml.Table = ?v.data.table;
 
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_STEP, strict);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_STEP, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: StepDef;
@@ -979,7 +985,7 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
 
         val need_arr: *toml.Array = toml.get_array(sub, "need");
-        if (need_arr == nil && strict) {
+        if (need_arr == nil && as_root) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'need' (use [] for none)"));
         }
         if (need_arr != nil) {
@@ -2528,6 +2534,41 @@ test "mach.lang.manifest.parse:canonical_and_star" {
     # "*" on every axis and targets = ["*"] are the explicit-any token and legal
     val ok: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[artifact.a]\nkind=\"bin\"\nentry=\"m.mach\"\nout=\"bin/a\"\ntargets=[\"*\"]\nlink=[\"c\"]\nneed=[]\n[link.c]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n"));
     if (R.is_err[Manifest, str](ok)) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #1971 contract: a non-total (pre-flag-day) manifest -- mach-std-shaped, with
+# name/description, a profile missing debug, and a link missing isa/abi -- is
+# REJECTED as a root build yet CONSUMED cleanly as a dependency, with its exported
+# link entry resolving and filtering correctly against the build cell.
+test "mach.lang.manifest.parse:root_reject_dep_consume" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val nontotal: str = "[project]\nid=\"std\"\nname=\"Mach Standard Library\"\ndescription=\"stdlib\"\nversion=\"0.18.0\"\nsrc=\"src\"\nout=\"out/{target.name}/{profile.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[profile.debug]\nopt=0\n[profile.release]\nopt=2\n[artifact.std]\nkind=\"static\"\nentry=\"lib.mach\"\nout=\"lib/std\"\ntargets=[\"*\"]\nlink=[\"kernel32\"]\n[link.kernel32]\nsource=\"system\"\nname=\"kernel32.dll\"\nos=[\"windows\"]\nexport=true\n";
+
+    # rejected as a root build (name is an unknown key once [project] is trimmed)
+    val as_root: R.Result[Manifest, str] = tparse(?alloc, ?itn, nontotal);
+    if (R.is_ok[Manifest, str](as_root)) { code = 1; }
+
+    # consumed cleanly as a dependency: parses, and the exported entry filters right
+    val as_dep: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, nontotal);
+    if (R.is_err[Manifest, str](as_dep)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](as_dep);
+        val k: *LinkDef = find_link(?itn, ?m, "kernel32");
+        val tl: *TargetDef = find_target_by_name(?itn, ?m, "linux");
+        val tw: *TargetDef = find_target_by_name(?itn, ?m, "windows");
+        if (k == nil || tl == nil || tw == nil) { code = 1; }
+        or {
+            if (!k.export) { code = 1; }
+            # os=["windows"] with absent isa/abi (match-any): windows yes, linux no
+            if (!link_matches_target(?itn, k, tw)) { code = 1; }
+            if ( link_matches_target(?itn, k, tl)) { code = 1; }
+        }
+    }
     arena.dnit(?ar);
     ret code;
 }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -25,6 +25,7 @@ use mach.lang.intern;
 use tgt: mach.lang.target;
 use mach.lang.target.isa;
 use mach.lang.target.os;
+use mach.lang.target.abi;
 
 pub def MOpt: u8;
 
@@ -308,7 +309,18 @@ fun parse_str_array(alloc: *A.Allocator, itn: *intern.Interner, arr: *toml.Array
 # and `["linux"]` filter identically. an absent axis (present false) matches any;
 # an explicit empty array (present, count 0) matches nothing. an empty-string value
 # is not a canonical value and is a strict error, as is a non-string, non-array.
-fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Table, key: str, label: str) R.Result[StrArr, str] {
+# whether `value` is a canonical spelling for filter axis `key` (os/isa/abi), or
+# the explicit-any token "*". non-canonical spellings are strict errors (#1971) so
+# a typo like os = "windoze" never silently matches nothing.
+fun canonical_axis_value(key: str, value: str) bool {
+    if (str_equals(value, "*")) { ret true; }
+    if (str_equals(key, "os"))  { ret os.os_id_for(value) != os.OS_UNKNOWN; }
+    if (str_equals(key, "isa")) { ret isa.arch_id_for(value) != isa.ARCH_UNKNOWN; }
+    if (str_equals(key, "abi")) { ret abi.abi_id_for(value) != abi.ABI_UNKNOWN; }
+    ret false;
+}
+
+fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Table, key: str, label: str, strict: bool) R.Result[StrArr, str] {
     var out: StrArr;
     out.items   = nil;
     out.count   = 0;
@@ -331,23 +343,35 @@ fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Tab
         }
         out.items[0] = R.unwrap_ok[intern.StrId, str](res_elem);
         out.count = 1;
-        ret R.ok[StrArr, str](out);
     }
-
-    if (v.tag == toml.TYPE_ARRAY) {
+    or (v.tag == toml.TYPE_ARRAY) {
         val res_arr: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?v.data.array,
             cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
         if (R.is_err[StrArr, str](res_arr)) { ret res_arr; }
-        var arr_v: StrArr = R.unwrap_ok[StrArr, str](res_arr);
-        arr_v.present = true;
-        ret R.ok[StrArr, str](arr_v);
+        val arr_v: StrArr = R.unwrap_ok[StrArr, str](res_arr);
+        out.items = arr_v.items;
+        out.count = arr_v.count;
+    }
+    or {
+        ret R.err[StrArr, str](cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
     }
 
-    ret R.err[StrArr, str](cc5(alloc, "mach.toml: ", label, ".", key, " must be a string or array of strings"));
+    if (strict) {
+        var vi: u32 = 0;
+        for (vi < out.count) {
+            val vs: str = idstr(itn, out.items[vi]);
+            if (!canonical_axis_value(key, vs)) {
+                ret R.err[StrArr, str](cc(alloc, cc5(alloc, "mach.toml: ", label, ".", key, cc3(alloc, " has non-canonical value '", vs, "'")), "; use a canonical value or \"*\""));
+            }
+            vi = vi + 1;
+        }
+    }
+    ret R.ok[StrArr, str](out);
 }
 
-fun parse_opt_level(alloc: *A.Allocator, name: str, sub: *toml.Table) R.Result[MOpt, str] {
+fun parse_opt_level(alloc: *A.Allocator, name: str, sub: *toml.Table, strict: bool) R.Result[MOpt, str] {
     val v: *toml.Value = toml.get(sub, "opt");
+    if (v == nil && strict)         { ret R.err[MOpt, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'opt'")); }
     if (v == nil)                   { ret R.ok[MOpt, str](MOPT_DEFAULT); }
     if (v.tag != toml.TYPE_INTEGER) { ret R.err[MOpt, str](opt_err(alloc, name, v)); }
     val n: i64 = v.data.integer;
@@ -374,8 +398,9 @@ fun opt_value_text(alloc: *A.Allocator, v: *toml.Value) str {
     ret "a value";
 }
 
-fun parse_debug_flag(alloc: *A.Allocator, name: str, sub: *toml.Table) R.Result[bool, str] {
+fun parse_debug_flag(alloc: *A.Allocator, name: str, sub: *toml.Table, strict: bool) R.Result[bool, str] {
     val v: *toml.Value = toml.get(sub, "debug");
+    if (v == nil && strict)      { ret R.err[bool, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'debug'")); }
     if (v == nil)                { ret R.ok[bool, str](false); }
     if (v.tag != toml.TYPE_BOOL) { ret R.err[bool, str](debug_err(alloc, name, v)); }
     ret R.ok[bool, str](v.data.boolean);
@@ -413,10 +438,14 @@ fun unknown_key_msg(alloc: *A.Allocator, key: str, label: str) str {
     ret cc(alloc, cc3(alloc, "mach.toml: unknown key '", key, "' in "), label);
 }
 
-fun key_known(kind: TableKind, k: str) bool {
+fun key_known(kind: TableKind, k: str, strict: bool) bool {
     if (kind == TK_PROJECT) {
-        ret str_equals(k, "id") || str_equals(k, "name") || str_equals(k, "description")
-            || str_equals(k, "version") || str_equals(k, "src") || str_equals(k, "out");
+        if (str_equals(k, "id") || str_equals(k, "version") || str_equals(k, "src") || str_equals(k, "out")) { ret true; }
+        # a dependency's manifest is parsed permissively (#1971): the consumer reads
+        # only its export surface, so pre-flag-day metadata like name/description is
+        # tolerated rather than rejected. the root manifest is strict.
+        if (!strict && (str_equals(k, "name") || str_equals(k, "description"))) { ret true; }
+        ret false;
     }
     if (kind == TK_TARGET) {
         ret str_equals(k, "isa") || str_equals(k, "os") || str_equals(k, "abi") || str_equals(k, "of");
@@ -441,12 +470,12 @@ fun key_known(kind: TableKind, k: str) bool {
     ret false;
 }
 
-fun check_keys(alloc: *A.Allocator, tab: *toml.Table, label: str, kind: TableKind) R.Result[bool, str] {
+fun check_keys(alloc: *A.Allocator, tab: *toml.Table, label: str, kind: TableKind, strict: bool) R.Result[bool, str] {
     val n: usize = toml.table_len(tab);
     var i: usize = 0;
     for (i < n) {
         val k: str = toml.table_key(tab, i);
-        if (!key_known(kind, k)) { ret R.err[bool, str](unknown_key_msg(alloc, k, label)); }
+        if (!key_known(kind, k, strict)) { ret R.err[bool, str](unknown_key_msg(alloc, k, label)); }
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -469,7 +498,12 @@ fun first_nonempty(a: str, b: str) str {
     ret a;
 }
 
-pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table) R.Result[Manifest, str] {
+# parse a manifest. `strict` enforces #1964 no-defaults totality (every declared-
+# table field spelled, [project] trimmed to id/version/src/out, canonical filter
+# axes) and is used for the root manifest being built. a dependency's manifest is
+# parsed with strict=false: the consumer reads only its export surface, so the
+# dep's own migration state must not gate the consumer's build (#1971).
+pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, strict: bool) R.Result[Manifest, str] {
     var m: Manifest;
     m.targets        = nil;
     m.target_count   = 0;
@@ -486,17 +520,13 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table) R.Resu
 
     val proj: *toml.Table = toml.get_table(t, "project");
     if (proj == nil) { ret R.err[Manifest, str]("mach.toml: missing [project] table"); }
-    val res_project_keys: R.Result[bool, str] = check_keys(alloc, proj, "[project]", TK_PROJECT);
+    val res_project_keys: R.Result[bool, str] = check_keys(alloc, proj, "[project]", TK_PROJECT, strict);
     if (R.is_err[bool, str](res_project_keys)) { ret R.err[Manifest, str](R.unwrap_err[bool, str](res_project_keys)); }
 
     val id_str: str = toml.get_str(proj, "id");
     if (str_empty(id_str)) { ret R.err[Manifest, str]("mach.toml: [project] is missing required key 'id'"); }
     val ver_str: str = toml.get_str(proj, "version");
     if (str_empty(ver_str)) { ret R.err[Manifest, str]("mach.toml: [project] is missing required key 'version'"); }
-    # name/description are metadata the #1964 shape does not define; accepted when
-    # present, absent otherwise (STR_NIL). strict totality is #1971's flag-day.
-    val name_str: str = toml.get_str(proj, "name");
-    val desc_str: str = toml.get_str(proj, "description");
     val src_str: str = toml.get_str(proj, "src");
     if (str_empty(src_str)) { ret R.err[Manifest, str]("mach.toml: [project] is missing required key 'src'"); }
     val out_str: str = toml.get_str(proj, "out");
@@ -512,34 +542,35 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table) R.Resu
     if (!is_valid_id(id_str)) { ret R.err[Manifest, str]("mach.toml: [project].id must be an identifier (letters, digits, '_', '-')"); }
     m.id = intern_unwrap(itn, id_str);
     m.version = intern_unwrap(itn, ver_str);
-    m.name = intern_opt_unwrap(itn, name_str);
-    m.description = intern_opt_unwrap(itn, desc_str);
+    # name/description are not #1964 fields; [project] is id/version/src/out only.
+    m.name = intern.STR_NIL;
+    m.description = intern.STR_NIL;
     m.src = intern_unwrap(itn, src_str);
     m.out_tmpl = intern_unwrap(itn, out_str);
     m.default_target = intern_unwrap(itn, "native");
 
-    val res_targets: R.Result[bool, str] = parse_targets(alloc, itn, t, ?m);
+    val res_targets: R.Result[bool, str] = parse_targets(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_targets)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_targets)); }
 
-    val res_artifacts: R.Result[bool, str] = parse_artifacts(alloc, itn, t, ?m);
+    val res_artifacts: R.Result[bool, str] = parse_artifacts(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_artifacts)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_artifacts)); }
 
-    val res_profiles: R.Result[bool, str] = parse_profiles(alloc, itn, t, ?m);
+    val res_profiles: R.Result[bool, str] = parse_profiles(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_profiles)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_profiles)); }
 
-    val res_deps: R.Result[bool, str] = parse_deps(alloc, itn, t, ?m);
+    val res_deps: R.Result[bool, str] = parse_deps(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_deps)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_deps)); }
 
-    val res_links: R.Result[bool, str] = parse_links(alloc, itn, t, ?m);
+    val res_links: R.Result[bool, str] = parse_links(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_links)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_links)); }
 
-    val res_steps: R.Result[bool, str] = parse_steps(alloc, itn, t, ?m);
+    val res_steps: R.Result[bool, str] = parse_steps(alloc, itn, t, ?m, strict);
     if (R.is_err[bool, str](res_steps)) { dnit(?m, alloc); ret R.err[Manifest, str](R.unwrap_err[bool, str](res_steps)); }
 
     ret R.ok[Manifest, str](m);
 }
 
-fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "target");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -562,7 +593,7 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
         }
         val sub: *toml.Table = ?v.data.table;
         val label: str = cc3(alloc, "[target.", name, "]");
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_TARGET);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_TARGET, strict);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: TargetDef;
@@ -585,7 +616,7 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
     ret R.ok[bool, str](true);
 }
 
-fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val arts: *toml.Table = toml.get_table(t, "artifact");
     if (arts == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(arts);
@@ -598,7 +629,7 @@ fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, 
 
     var i: usize = 0;
     for (i < n) {
-        val res_artifact: R.Result[ArtifactDef, str] = parse_one_artifact(alloc, itn, arts, i);
+        val res_artifact: R.Result[ArtifactDef, str] = parse_one_artifact(alloc, itn, arts, i, strict);
         if (R.is_err[ArtifactDef, str](res_artifact)) { ret R.err[bool, str](R.unwrap_err[ArtifactDef, str](res_artifact)); }
         m.artifacts[i] = R.unwrap_ok[ArtifactDef, str](res_artifact);
         i = i + 1;
@@ -606,7 +637,7 @@ fun parse_artifacts(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, 
     ret R.ok[bool, str](true);
 }
 
-fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Table, k: usize) R.Result[ArtifactDef, str] {
+fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Table, k: usize, strict: bool) R.Result[ArtifactDef, str] {
     val name: str = toml.table_key(tab, k);
     val v: *toml.Value = toml.table_value(tab, k);
     val label: str = cc3(alloc, "[artifact.", name, "]");
@@ -615,7 +646,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     }
     val sub: *toml.Table = ?v.data.table;
 
-    val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_ARTIFACT);
+    val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_ARTIFACT, strict);
     if (R.is_err[bool, str](res_keys)) { ret R.err[ArtifactDef, str](R.unwrap_err[bool, str](res_keys)); }
 
     var a: ArtifactDef;
@@ -658,6 +689,9 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     a.target_count = targets_val.count;
 
     val link_arr: *toml.Array = toml.get_array(sub, "link");
+    if (link_arr == nil && strict) {
+        ret R.err[ArtifactDef, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'link' (use [] for none)"));
+    }
     if (link_arr != nil) {
         val res_link: R.Result[StrArr, str] = parse_str_array(alloc, itn, link_arr,
             cc3(alloc, "mach.toml: ", label, ".link must be an array of strings"));
@@ -668,6 +702,9 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     }
 
     val need_arr: *toml.Array = toml.get_array(sub, "need");
+    if (need_arr == nil && strict) {
+        ret R.err[ArtifactDef, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'need' (use [] for none)"));
+    }
     if (need_arr != nil) {
         val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr,
             cc3(alloc, "mach.toml: ", label, ".need must be an array of strings"));
@@ -680,7 +717,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     ret R.ok[ArtifactDef, str](a);
 }
 
-fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "profile");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -700,17 +737,17 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " must be a table"));
         }
         val sub: *toml.Table = ?v.data.table;
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_PROFILE);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_PROFILE, strict);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var pf: ProfileDef;
         pf.name = intern_unwrap(itn, name);
-        val res_opt: R.Result[MOpt, str] = parse_opt_level(alloc, name, sub);
+        val res_opt: R.Result[MOpt, str] = parse_opt_level(alloc, name, sub, strict);
         if (R.is_err[MOpt, str](res_opt)) { ret R.err[bool, str](R.unwrap_err[MOpt, str](res_opt)); }
         pf.opt      = R.unwrap_ok[MOpt, str](res_opt);
         pf.emit_ir  = bool_or(toml.get_bool(sub, "emit_ir"), false);
         pf.emit_asm = bool_or(toml.get_bool(sub, "emit_asm"), false);
-        val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub);
+        val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub, strict);
         if (R.is_err[bool, str](res_debug)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_debug)); }
         pf.debug    = R.unwrap_ok[bool, str](res_debug);
 
@@ -720,7 +757,7 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
     ret R.ok[bool, str](true);
 }
 
-fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "dep");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -744,7 +781,7 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
         if (toml.get(sub, "version") != nil) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".version is reserved for the registry era"));
         }
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_DEP);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_DEP, strict);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: DepDef;
@@ -756,9 +793,16 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
         if (has_git == has_path) {
             ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " needs exactly one source key: 'git' or 'path'"));
         }
+        val ref_s: str = toml.get_str(sub, "ref");
+        if (has_git && str_empty(ref_s) && strict) {
+            ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'ref' for git source"));
+        }
+        if (has_path && !str_empty(ref_s) && strict) {
+            ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".ref is not allowed for path sources"));
+        }
         d.git  = intern_opt_unwrap(itn, git_s);
         d.path = intern_opt_unwrap(itn, path_s);
-        d.ref  = intern_opt_unwrap(itn, toml.get_str(sub, "ref"));
+        d.ref  = intern_opt_unwrap(itn, ref_s);
 
         m.deps[i] = d;
         i = i + 1;
@@ -766,7 +810,7 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
     ret R.ok[bool, str](true);
 }
 
-fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "link");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -787,7 +831,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
         val sub: *toml.Table = ?v.data.table;
 
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_LINK);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_LINK, strict);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: LinkDef;
@@ -826,28 +870,35 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
             d.path = intern.STR_NIL;
         }
 
-        val res_os: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "os", label);
+        val res_os: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "os", label, strict);
         if (R.is_err[StrArr, str](res_os)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_os)); }
         val os_v: StrArr = R.unwrap_ok[StrArr, str](res_os);
+        if (!os_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'os' (use \"*\" for any)")); }
         d.os = os_v.items;
         d.os_count = os_v.count;
         d.os_present = os_v.present;
 
-        val res_isa: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "isa", label);
+        val res_isa: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "isa", label, strict);
         if (R.is_err[StrArr, str](res_isa)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_isa)); }
         val isa_v: StrArr = R.unwrap_ok[StrArr, str](res_isa);
+        if (!isa_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'isa' (use \"*\" for any)")); }
         d.isa = isa_v.items;
         d.isa_count = isa_v.count;
         d.isa_present = isa_v.present;
 
-        val res_abi: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "abi", label);
+        val res_abi: R.Result[StrArr, str] = parse_filter_axis(alloc, itn, sub, "abi", label, strict);
         if (R.is_err[StrArr, str](res_abi)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_abi)); }
         val abi_v: StrArr = R.unwrap_ok[StrArr, str](res_abi);
+        if (!abi_v.present && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'abi' (use \"*\" for any)")); }
         d.abi = abi_v.items;
         d.abi_count = abi_v.count;
         d.abi_present = abi_v.present;
 
-        d.export = bool_or(toml.get_bool(sub, "export"), false);
+        val export_v: *toml.Value = toml.get(sub, "export");
+        if (export_v == nil && strict) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'export'")); }
+        if (export_v == nil) { d.export = false; }
+        or (export_v.tag != toml.TYPE_BOOL) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, ".export must be a boolean")); }
+        or { d.export = export_v.data.boolean; }
 
         m.links[i] = d;
         i = i + 1;
@@ -855,7 +906,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
     ret R.ok[bool, str](true);
 }
 
-fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest) R.Result[bool, str] {
+fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, strict: bool) R.Result[bool, str] {
     val tab: *toml.Table = toml.get_table(t, "step");
     if (tab == nil) { ret R.ok[bool, str](true); }
     val n: usize = toml.table_len(tab);
@@ -876,10 +927,12 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
         val sub: *toml.Table = ?v.data.table;
 
-        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_STEP);
+        val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_STEP, strict);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
 
         var d: StepDef;
+        d.need       = nil;
+        d.need_count = 0;
         # the step name keys its stamp file, so it must be a plain identifier - a
         # '/' would break the stamp path and a '.' would collide owner.step keys (#1989).
         if (!is_valid_id(name)) { ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " name must be an identifier (letters, digits, '_', '-')")); }
@@ -926,6 +979,9 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
 
         val need_arr: *toml.Array = toml.get_array(sub, "need");
+        if (need_arr == nil && strict) {
+            ret R.err[bool, str](cc3(alloc, "mach.toml: ", label, " is missing required key 'need' (use [] for none)"));
+        }
         if (need_arr != nil) {
             val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr,
                 cc3(alloc, "mach.toml: ", label, ".need must be an array of strings"));
@@ -933,10 +989,6 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
             val need_val: StrArr = R.unwrap_ok[StrArr, str](res_need);
             d.need = need_val.items;
             d.need_count = need_val.count;
-        }
-        or {
-            d.need = nil;
-            d.need_count = 0;
         }
 
         m.steps[i] = d;
@@ -1030,23 +1082,24 @@ fun seg_dup(alloc: *A.Allocator, tmpl: str, start: usize, end: usize) str {
     ret buf::str;
 }
 
+# the #1964 template variable set is closed and final: {project.out}, {target.name},
+# {profile.name}. no {name}/{ext} or bare {target}/{profile} aliases -- an executable
+# extension is written literally into the artifact's out, per the RFC.
 fun tmpl_value(alloc: *A.Allocator, tmpl: str, start: usize, end: usize, project_out: str,
-               target_name: str, profile_name: str, art_name: str, ext: str) R.Result[str, str] {
+               target_name: str, profile_name: str) R.Result[str, str] {
     if (seg_eq(tmpl, start, end, "project.out")) {
         # available everywhere except while expanding [project].out itself, where it
         # would be self-referential (project_out is passed empty there).
         if (str_empty(project_out)) { ret R.err[str, str]("mach.toml: '{project.out}' is not available in [project].out"); }
         ret R.ok[str, str](project_out);
     }
-    if (seg_eq(tmpl, start, end, "target.name") || seg_eq(tmpl, start, end, "target"))  { ret R.ok[str, str](target_name); }
-    if (seg_eq(tmpl, start, end, "profile.name") || seg_eq(tmpl, start, end, "profile")) { ret R.ok[str, str](profile_name); }
-    if (seg_eq(tmpl, start, end, "name"))    { ret R.ok[str, str](art_name); }
-    if (seg_eq(tmpl, start, end, "ext"))     { ret R.ok[str, str](ext); }
+    if (seg_eq(tmpl, start, end, "target.name"))  { ret R.ok[str, str](target_name); }
+    if (seg_eq(tmpl, start, end, "profile.name")) { ret R.ok[str, str](profile_name); }
     ret R.err[str, str](cc3(alloc, "mach.toml: unknown template variable '{", seg_dup(alloc, tmpl, start, end), "}'"));
 }
 
 pub fun expand(alloc: *A.Allocator, tmpl: str, project_out: str,
-               target_name: str, profile_name: str, art_name: str, ext: str) R.Result[str, str] {
+               target_name: str, profile_name: str) R.Result[str, str] {
     val n: usize = str_len(tmpl);
     var total: usize = 0;
     var i: usize = 0;
@@ -1055,7 +1108,7 @@ pub fun expand(alloc: *A.Allocator, tmpl: str, project_out: str,
             var ii: usize = i + 1;
             for (ii < n && tmpl[ii] != '}') { ii = ii + 1; }
             if (ii >= n) { ret R.err[str, str]("mach.toml: unterminated '{' in a path template"); }
-            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name, art_name, ext);
+            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name);
             if (R.is_err[str, str](res_value)) { ret R.err[str, str](R.unwrap_err[str, str](res_value)); }
             total = total + str_len(R.unwrap_ok[str, str](res_value));
             i = ii + 1;
@@ -1076,7 +1129,7 @@ pub fun expand(alloc: *A.Allocator, tmpl: str, project_out: str,
         if (tmpl[i] == '{') {
             var ii: usize = i + 1;
             for (ii < n && tmpl[ii] != '}') { ii = ii + 1; }
-            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name, art_name, ext);
+            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name);
             val value: str = R.unwrap_ok[str, str](res_value);
             val vl: usize = str_len(value);
             var iii: usize = 0;
@@ -1280,7 +1333,7 @@ fun join_path_canonical(alloc: *A.Allocator, a: str, b: str) str {
 fun link_token(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef, proj_out: str, tn: str, pn: str) R.Result[intern.StrId, str] {
     if (l.source == intern_unwrap(itn, "local")) {
         val raw_path: str = idstr(itn, l.path);
-        val expanded_r: R.Result[str, str] = expand(alloc, raw_path, proj_out, tn, pn, "", "");
+        val expanded_r: R.Result[str, str] = expand(alloc, raw_path, proj_out, tn, pn);
         if (R.is_err[str, str](expanded_r)) { ret R.err[intern.StrId, str](R.unwrap_err[str, str](expanded_r)); }
         val expanded: str = R.unwrap_ok[str, str](expanded_r);
         val res_int: R.Result[intern.StrId, str] = intern.intern(itn, expanded);
@@ -1304,7 +1357,7 @@ pub fun step_producing_out(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
         var oi: u32 = 0;
         for (oi < s.out_count) {
             val raw_out: str = idstr(itn, s.out[oi]);
-            val exp_r: R.Result[str, str] = expand(alloc, raw_out, proj_out, tn, pn, "", "");
+            val exp_r: R.Result[str, str] = expand(alloc, raw_out, proj_out, tn, pn);
             if (R.is_ok[str, str](exp_r)) {
                 val exp: str = R.unwrap_ok[str, str](exp_r);
                 val eq: bool = str_equals(exp, expanded_path);
@@ -1422,7 +1475,7 @@ pub fun plan_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
             for (li < a.link_count) {
                 val l: *LinkDef = find_link_by_name(m, a.link[li]);
                 if (l != nil && l.source == local_id && link_matches_target(itn, l, t)) {
-                    val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn, "", "");
+                    val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn);
                     if (R.is_ok[str, str](exp_r)) {
                         val exp: str = R.unwrap_ok[str, str](exp_r);
                         val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, tn, pn);
@@ -1497,7 +1550,7 @@ pub fun plan_export_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
     for (li < m.link_count) {
         val l: *LinkDef = ?m.links[li];
         if (l.export && l.source == local_id && link_matches_target(itn, l, t)) {
-            val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn, "", "");
+            val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn);
             if (R.is_ok[str, str](exp_r)) {
                 val exp: str = R.unwrap_ok[str, str](exp_r);
                 val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, tn, pn);
@@ -1570,20 +1623,11 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     if (R.is_err[str, str](res_target_name)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_target_name)); }
     val res_profile_name: R.Result[str, str] = must_lookup(itn, rp.name);
     if (R.is_err[str, str](res_profile_name)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_profile_name)); }
-    val res_art_name: R.Result[str, str] = must_lookup(itn, a.name);
-    if (R.is_err[str, str](res_art_name)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_art_name)); }
     val tn: str = R.unwrap_ok[str, str](res_target_name);
     val pn: str = R.unwrap_ok[str, str](res_profile_name);
-    val an: str = R.unwrap_ok[str, str](res_art_name);
-
-    val res_os_name: R.Result[str, str] = must_lookup(itn, rt.target.os);
-    if (R.is_err[str, str](res_os_name)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_os_name)); }
-    val os_name: str = R.unwrap_ok[str, str](res_os_name);
-    var ex: str = "";
-    if (str_equals(os_name, "windows")) { ex = ".exe"; }
 
     # Expand project out
-    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, pn, "", "");
+    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, pn);
     if (R.is_err[str, str](res_project_out)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_project_out)); }
     val proj_out: str = R.unwrap_ok[str, str](res_project_out);
 
@@ -1645,7 +1689,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
 
     # Resolve artifact relative path
     val art_out_tmpl: intern.StrId = a.out;
-    val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, pn, an, ex);
+    val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, pn);
     if (R.is_err[str, str](res_art_out)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_art_out)); }
     val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
 
@@ -1763,28 +1807,20 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
     if (R.is_err[str, str](res_target_name)) { ret R.err[bool, str](R.unwrap_err[str, str](res_target_name)); }
     val tn: str = R.unwrap_ok[str, str](res_target_name);
 
-    val res_os_name: R.Result[str, str] = must_lookup(itn, t.os);
-    if (R.is_err[str, str](res_os_name)) { ret R.err[bool, str](R.unwrap_err[str, str](res_os_name)); }
-    val os_name: str = R.unwrap_ok[str, str](res_os_name);
-    var ex: str = "";
-    if (str_equals(os_name, "windows")) { ex = ".exe"; }
-
     val res_paths: R.Result[*str, str] = A.allocate[str](alloc, m.artifact_count::usize);
     if (R.is_err[*str, str](res_paths)) { ret R.err[bool, str](R.unwrap_err[*str, str](res_paths)); }
     val paths: *str = R.unwrap_ok[*str, str](res_paths);
 
     # Expand project out
-    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, profile_name, "", "");
+    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, profile_name);
     if (R.is_err[str, str](res_project_out)) { ret R.err[bool, str](R.unwrap_err[str, str](res_project_out)); }
     val proj_out: str = R.unwrap_ok[str, str](res_project_out);
 
     var i: u32 = 0;
     for (i < m.artifact_count) {
         val a: *ArtifactDef = ?m.artifacts[i];
-        val res_art_name: R.Result[str, str] = must_lookup(itn, a.name);
-        if (R.is_err[str, str](res_art_name)) { ret R.err[bool, str](R.unwrap_err[str, str](res_art_name)); }
         val art_out_tmpl: intern.StrId = a.out;
-        val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, profile_name, R.unwrap_ok[str, str](res_art_name), ex);
+        val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, profile_name);
         if (R.is_err[str, str](res_art_out)) { ret R.err[bool, str](R.unwrap_err[str, str](res_art_out)); }
         val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
         paths[i] = join_path_canonical(alloc, proj_out, art_out_rel);
@@ -1819,7 +1855,7 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
 # --- test helper / scaffolding ---
 
 fun demo_src() str {
-    ret "[project]\nid = \"demo\"\nname = \"demo\"\ndescription = \"demo\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.ls]\nkind = \"bin\"\nentry = \"bin/ls.mach\"\nout = \"bin/ls\"\ntargets = [\"*\"]\n\n[artifact.cat]\nkind = \"bin\"\nentry = \"bin/cat.mach\"\nout = \"bin/cat\"\ntargets = [\"*\"]\n\n[profile.debug]\nopt = 0\n\n[profile.release]\nopt = 2\n\n[dep.mach-std]\ngit = \"https://github.com/briar-systems/mach-std\"\nref = \"v0.4.0\"\n";
+    ret "[project]\nid = \"demo\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.ls]\nkind = \"bin\"\nentry = \"bin/ls.mach\"\nout = \"bin/ls\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.cat]\nkind = \"bin\"\nentry = \"bin/cat.mach\"\nout = \"bin/cat\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[profile.debug]\nopt = 0\ndebug = false\n\n[profile.release]\nopt = 2\ndebug = false\n\n[dep.mach-std]\ngit = \"https://github.com/briar-systems/mach-std\"\nref = \"v0.4.0\"\n";
 }
 
 fun host_target_stanza(alloc: *A.Allocator, name: str) str {
@@ -1872,7 +1908,17 @@ fun tparse(alloc: *A.Allocator, itn: *intern.Interner, src: str) R.Result[Manife
     val tbl_r: R.Result[toml.Table, str] = toml.parse(alloc, src);
     if (R.is_err[toml.Table, str](tbl_r)) { ret R.err[Manifest, str](R.unwrap_err[toml.Table, str](tbl_r)); }
     var tbl: toml.Table = R.unwrap_ok[toml.Table, str](tbl_r);
-    ret parse(alloc, itn, ?tbl);
+    ret parse(alloc, itn, ?tbl, true);
+}
+
+# parse a manifest permissively, as a dependency's manifest is parsed: used to
+# exercise the runtime filter/resolve semantics on entries with absent axes, which
+# the strict root parser forbids.
+fun tparse_lenient(alloc: *A.Allocator, itn: *intern.Interner, src: str) R.Result[Manifest, str] {
+    val tbl_r: R.Result[toml.Table, str] = toml.parse(alloc, src);
+    if (R.is_err[toml.Table, str](tbl_r)) { ret R.err[Manifest, str](R.unwrap_err[toml.Table, str](tbl_r)); }
+    var tbl: toml.Table = R.unwrap_ok[toml.Table, str](tbl_r);
+    ret parse(alloc, itn, ?tbl, false);
 }
 
 test "mach.lang.manifest.is_valid_id" {
@@ -1927,30 +1973,23 @@ test "mach.lang.manifest.parse:missing_required_keys" {
     ret code;
 }
 
-test "mach.lang.manifest.parse:name_description_optional" {
+test "mach.lang.manifest.parse:name_description_rejected" {
     var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    # the #1964 shape omits name/description; a manifest without them parses, with
-    # both fields interned to STR_NIL. id/version/src/out stay required.
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
-    if (R.is_err[Manifest, str](a)) { code = 1; }
-    or {
-        var m: Manifest = R.unwrap_ok[Manifest, str](a);
-        if (m.name != intern.STR_NIL)        { code = 1; }
-        if (m.description != intern.STR_NIL) { code = 1; }
-        if (!str_equals(idstr(?itn, m.id), "x")) { code = 1; }
-    }
+    # the #1964 shape trims [project] to id/version/src/out; name/description are
+    # unknown keys in the strict root parse (#1971 flag-day).
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"App\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: unknown key 'name' in [project]")) { code = 1; }
 
-    # present name/description are still accepted and recorded verbatim
-    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"App\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
-    if (R.is_err[Manifest, str](b)) { code = 1; }
-    or {
-        var m: Manifest = R.unwrap_ok[Manifest, str](b);
-        if (!str_equals(idstr(?itn, m.name), "App")) { code = 1; }
-        if (!str_equals(idstr(?itn, m.description), "d")) { code = 1; }
-    }
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: unknown key 'description' in [project]")) { code = 1; }
+
+    # a dependency's manifest is parsed permissively, so pre-flag-day name/description
+    # are tolerated there.
+    val d: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"App\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    if (R.is_err[Manifest, str](d)) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }
@@ -1960,10 +1999,10 @@ test "mach.lang.manifest.parse:unknown_keys" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\nbogus=\"y\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\nbogus=\"y\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
     if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: unknown key 'bogus' in [project]")) { code = 1; }
 
-    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\nwat=\"z\"\n");
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\nwat=\"z\"\n");
     if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: unknown key 'wat' in [target.l]")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -1974,7 +2013,7 @@ test "mach.lang.manifest.parse:reserved_target_native" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.native]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.native]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
     if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: [target.native] is reserved; 'native' resolves to a declared target")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -1985,10 +2024,10 @@ test "mach.lang.manifest.parse:dep_conflict" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[dep.std]\nversion=\"1.0\"\n");
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[dep.std]\nversion=\"1.0\"\n");
     if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: [dep.std].version is reserved for the registry era")) { code = 1; }
 
-    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[dep.std]\ngit=\"u\"\npath=\"p\"\n");
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[dep.std]\ngit=\"u\"\npath=\"p\"\n");
     if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: [dep.std] needs exactly one source key: 'git' or 'path'")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -1999,7 +2038,7 @@ test "mach.lang.manifest.parse:backslash_rejected" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"a\\\\b\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"a\\\\b\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
     if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: [project].src contains a '\\\\'; manifest paths use '/'")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -2010,7 +2049,7 @@ test "mach.lang.manifest.resolve_build_unit:native_resolution" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n";
+    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     val st:  str = host_target_stanza(?alloc, "foreign");
     src = cc(?alloc, src, st);
 
@@ -2041,7 +2080,7 @@ test "mach.lang.manifest.resolve_build_unit:default_profile" {
     var code: i32 = 0;
 
     # only [profile.debug] declared -> the empty profile selector resolves 'debug'
-    var s1: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\n[profile.debug]\nopt=0\n";
+    var s1: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink = []\nneed = []\n[profile.debug]\nopt=0\ndebug = false\n";
     s1 = cc(?alloc, s1, host_target_stanza(?alloc, "h"));
     val r1: R.Result[Manifest, str] = tparse(?alloc, ?itn, s1);
     if (R.is_err[Manifest, str](r1)) { code = 1; }
@@ -2053,7 +2092,7 @@ test "mach.lang.manifest.resolve_build_unit:default_profile" {
     }
 
     # no [profile] section at all -> the conventional 'debug' default, still clean
-    var s2: str = "[project]\nid=\"y\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\n";
+    var s2: str = "[project]\nid=\"y\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink = []\nneed = []\n";
     s2 = cc(?alloc, s2, host_target_stanza(?alloc, "h"));
     val r2: R.Result[Manifest, str] = tparse(?alloc, ?itn, s2);
     if (R.is_err[Manifest, str](r2)) { code = 1; }
@@ -2072,7 +2111,7 @@ test "mach.lang.manifest.resolve_build_unit:native_resolution_multi_match" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n";
+    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     src = cc(?alloc, src, host_target_stanza(?alloc, "alpha"));
     src = cc(?alloc, src, host_target_stanza(?alloc, "beta"));
 
@@ -2092,7 +2131,7 @@ test "mach.lang.manifest.resolve_build_unit:native_resolution_exact" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n";
+    var src: str = "[project]\nid = \"x\"\nversion = \"1\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     src = cc(?alloc, src, "[target.foreign]\nisa = \"nonesuch\"\nos = \"nonesuch\"\nabi = \"x\"\n");
     src = cc(?alloc, src, host_target_stanza(?alloc, "host"));
 
@@ -2117,7 +2156,7 @@ test "mach.lang.manifest.resolve_build_unit:collision_detection" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nname=\"x\"\ndescription=\"x\"\nversion=\"0.1.0\"\nsrc=\"src\"\nout=\"bin/app\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.a]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"app\"\ntargets = [\"*\"]\n[artifact.b]\nkind=\"bin\"\nentry=\"b.mach\"\nout=\"app\"\ntargets = [\"*\"]\n");
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"0.1.0\"\nsrc=\"src\"\nout=\"bin/app\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.a]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[artifact.b]\nkind=\"bin\"\nentry=\"b.mach\"\nout=\"app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n");
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
@@ -2125,7 +2164,7 @@ test "mach.lang.manifest.resolve_build_unit:collision_detection" {
         if (R.is_ok[bool, str](cr) || !str_equals(R.unwrap_err[bool, str](cr), "mach.toml: artifacts 'a' and 'b' collide on output path 'bin/app/app'")) { code = 1; }
     }
 
-    val res_clean: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nname=\"x\"\ndescription=\"x\"\nversion=\"0.1.0\"\nsrc=\"src\"\nout=\"out/{target.name}/{profile.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app1\"\ntargets = [\"*\"]\n[artifact.tool]\nkind=\"bin\"\nentry=\"tool.mach\"\nout=\"bin/app2\"\ntargets = [\"*\"]\n");
+    val res_clean: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"0.1.0\"\nsrc=\"src\"\nout=\"out/{target.name}/{profile.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app1\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[artifact.tool]\nkind=\"bin\"\nentry=\"tool.mach\"\nout=\"bin/app2\"\ntargets = [\"*\"]\nlink = []\nneed = []\n");
     if (R.is_err[Manifest, str](res_clean)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](res_clean);
@@ -2141,10 +2180,10 @@ test "mach.lang.manifest.resolve_build_unit:profile_debug_strict" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\n[profile.debug]\nopt = 9\n");
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[profile.debug]\nopt = 9\ndebug = false\n");
     if (R.is_ok[Manifest, str](a) || !str_contains(R.unwrap_err[Manifest, str](a), "opt must be 0, 1, or 2")) { code = 1; }
 
-    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\n[profile.debug]\ndebug = 9\n");
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[profile.debug]\nopt = 0\ndebug = 9\n");
     if (R.is_ok[Manifest, str](b) || !str_contains(R.unwrap_err[Manifest, str](b), "debug must be a boolean")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -2176,7 +2215,7 @@ test "mach.lang.manifest.resolve_build_unit:links" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[link.sys]\nsource=\"system\"\nname=\"c\"\nos=[\"linux\"]\n[link.local_lib]\nsource=\"local\"\npath=\"lib/mylib.a\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = [\"sys\", \"local_lib\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[link.sys]\nsource=\"system\"\nname=\"c\"\nos=[\"linux\"]\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[link.local_lib]\nsource=\"local\"\npath=\"lib/mylib.a\"\nos=[\"*\"]\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = [\"sys\", \"local_lib\"]\nneed = []\n";
     val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
@@ -2215,7 +2254,7 @@ test "mach.lang.manifest.parse:link_filter_string_form" {
     # exercise the string form on the other two axes. this pins the #1969 fix: a
     # string filter is no longer silently ignored (degraded to match-any).
     val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[target.arm]\nisa=\"aarch64\"\nos=\"linux\"\nabi=\"aapcs64\"\n[link.os_str]\nsource=\"system\"\nname=\"a\"\nos=\"linux\"\n[link.os_arr]\nsource=\"system\"\nname=\"b\"\nos=[\"linux\"]\n[link.os_star]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\n[link.os_absent]\nsource=\"system\"\nname=\"d\"\n[link.isa_str]\nsource=\"system\"\nname=\"e\"\nisa=\"x86_64\"\n[link.abi_str]\nsource=\"system\"\nname=\"f\"\nabi=\"sysv64\"\n";
-    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    val res_manifest: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
@@ -2252,15 +2291,15 @@ test "mach.lang.manifest.expand:project_out" {
     var code: i32 = 0;
 
     # {project.out} substitutes the expanded project out
-    val r1: R.Result[str, str] = expand(?alloc, "{project.out}/obj/x.o", "out/linux/release", "linux", "release", "", "");
+    val r1: R.Result[str, str] = expand(?alloc, "{project.out}/obj/x.o", "out/linux/release", "linux", "release");
     if (R.is_err[str, str](r1) || !str_equals(R.unwrap_ok[str, str](r1), "out/linux/release/obj/x.o")) { code = 1; }
 
     # referencing it while expanding [project].out itself (project_out empty) is an error
-    val r2: R.Result[str, str] = expand(?alloc, "{project.out}/x", "", "linux", "release", "", "");
+    val r2: R.Result[str, str] = expand(?alloc, "{project.out}/x", "", "linux", "release");
     if (R.is_ok[str, str](r2) || !str_contains(R.unwrap_err[str, str](r2), "not available in [project].out")) { code = 1; }
 
     # an unknown variable is still a strict error
-    val r3: R.Result[str, str] = expand(?alloc, "{bogus}", "o", "t", "p", "", "");
+    val r3: R.Result[str, str] = expand(?alloc, "{bogus}", "o", "t", "p");
     if (R.is_ok[str, str](r3) || !str_contains(R.unwrap_err[str, str](r3), "unknown template variable")) { code = 1; }
     arena.dnit(?ar);
     ret code;
@@ -2272,7 +2311,7 @@ test "mach.lang.manifest.resolve_build_unit:local_project_out" {
     var code: i32 = 0;
 
     # a local link path using {project.out} resolves to the expanded project out
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.obj]\nsource=\"local\"\npath=\"{project.out}/obj/shim.o\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = [\"obj\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.obj]\nsource=\"local\"\npath=\"{project.out}/obj/shim.o\"\nos=[\"*\"]\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = [\"obj\"]\nneed = []\n";
     val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
@@ -2294,7 +2333,7 @@ test "mach.lang.manifest.local_path_demanded_by_step" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[step.shim]\ncmd=\"cc -c shim.c\"\nin=[\"shim.c\"]\nout=[\"{project.out}/obj/shim.o\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[step.shim]\ncmd=\"cc -c shim.c\"\nin=[\"shim.c\"]\nout=[\"{project.out}/obj/shim.o\"]\nneed=[]\n";
     val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
@@ -2319,7 +2358,7 @@ test "mach.lang.manifest.plan_steps" {
     var code: i32 = 0;
 
     val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.obj]\nsource=\"local\"\npath=\"{project.out}/o/a.o\"\nos=\"*\"\n[link.win]\nsource=\"local\"\npath=\"{project.out}/o/w.o\"\nos=\"windows\"\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[\"obj\",\"win\"]\nneed=[\"gen\"]\n[step.compile]\ncmd=\"cc\"\nin=[\"a.c\"]\nout=[\"{project.out}/o/a.o\"]\n[step.winc]\ncmd=\"cc\"\nin=[\"w.c\"]\nout=[\"{project.out}/o/w.o\"]\n[step.gen]\ncmd=\"g\"\nin=[\"g.in\"]\nout=[\"{project.out}/g.h\"]\nneed=[\"dep\"]\n[step.dep]\ncmd=\"d\"\nin=[\"d.in\"]\nout=[\"{project.out}/d.o\"]\n";
-    val rm: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    val rm: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](rm)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](rm);
@@ -2361,7 +2400,7 @@ test "mach.lang.manifest.plan_steps:cycle" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nneed=[\"a\"]\n[step.a]\ncmd=\"x\"\nin=[\"i\"]\nout=[\"{project.out}/a.o\"]\nneed=[\"b\"]\n[step.b]\ncmd=\"y\"\nin=[\"i\"]\nout=[\"{project.out}/b.o\"]\nneed=[\"a\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[]\nneed=[\"a\"]\n[step.a]\ncmd=\"x\"\nin=[\"i\"]\nout=[\"{project.out}/a.o\"]\nneed=[\"b\"]\n[step.b]\ncmd=\"y\"\nin=[\"i\"]\nout=[\"{project.out}/b.o\"]\nneed=[\"a\"]\n";
     val rm: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](rm)) { code = 1; }
     or {
@@ -2390,7 +2429,7 @@ test "mach.lang.manifest.plan_export_steps" {
     var code: i32 = 0;
 
     val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.exp]\nsource=\"local\"\npath=\"{project.out}/o/m.o\"\nos=\"*\"\nexport=true\n[link.noexp]\nsource=\"local\"\npath=\"{project.out}/o/n.o\"\nos=\"*\"\nexport=false\n[link.win]\nsource=\"local\"\npath=\"{project.out}/o/w.o\"\nos=\"windows\"\nexport=true\n[step.mk]\ncmd=\"cc\"\nin=[\"m.c\"]\nout=[\"{project.out}/o/m.o\"]\n[step.no]\ncmd=\"cc\"\nin=[\"n.c\"]\nout=[\"{project.out}/o/n.o\"]\n[step.winmk]\ncmd=\"cc\"\nin=[\"w.c\"]\nout=[\"{project.out}/o/w.o\"]\n";
-    val rm: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    val rm: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](rm)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](rm);
@@ -2428,8 +2467,85 @@ test "mach.lang.manifest.parse:id_and_out_validation" {
     val ok_id: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"a-b_2\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n");
     if (R.is_err[Manifest, str](ok_id)) { code = 1; }
     # a '*' in a step out is rejected (outputs are concrete)
-    val bad_out: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[step.s]\ncmd=\"cc\"\nin=[\"a.c\"]\nout=[\"{project.out}/*.o\"]\n");
+    val bad_out: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[step.s]\ncmd=\"cc\"\nin=[\"a.c\"]\nout=[\"{project.out}/*.o\"]\nneed=[]\n");
     if (R.is_ok[Manifest, str](bad_out)) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #1971 no-defaults totality: an absent field of a declared table is a strict-parse
+# error in the root manifest, one per declared table kind.
+test "mach.lang.manifest.parse:strict_totality" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val head: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n";
+
+    # profile spells opt + debug
+    val p_opt: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\ndebug=false\n"));
+    if (R.is_ok[Manifest, str](p_opt) || !str_contains(R.unwrap_err[Manifest, str](p_opt), "[profile.p] is missing required key 'opt'")) { code = 1; }
+    val p_dbg: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\n"));
+    if (R.is_ok[Manifest, str](p_dbg) || !str_contains(R.unwrap_err[Manifest, str](p_dbg), "[profile.p] is missing required key 'debug'")) { code = 1; }
+
+    # artifact spells link + need
+    val a_link: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[artifact.a]\nkind=\"bin\"\nentry=\"m.mach\"\nout=\"bin/a\"\ntargets=[\"*\"]\n"));
+    if (R.is_ok[Manifest, str](a_link) || !str_contains(R.unwrap_err[Manifest, str](a_link), "missing required key 'link'")) { code = 1; }
+    val a_need: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[artifact.a]\nkind=\"bin\"\nentry=\"m.mach\"\nout=\"bin/a\"\ntargets=[\"*\"]\nlink=[]\n"));
+    if (R.is_ok[Manifest, str](a_need) || !str_contains(R.unwrap_err[Manifest, str](a_need), "missing required key 'need'")) { code = 1; }
+
+    # link spells os / isa / abi / export
+    val l_os: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[link.l]\nsource=\"system\"\nname=\"c\"\n"));
+    if (R.is_ok[Manifest, str](l_os) || !str_contains(R.unwrap_err[Manifest, str](l_os), "missing required key 'os'")) { code = 1; }
+    val l_isa: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[link.l]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\n"));
+    if (R.is_ok[Manifest, str](l_isa) || !str_contains(R.unwrap_err[Manifest, str](l_isa), "missing required key 'isa'")) { code = 1; }
+    val l_abi: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[link.l]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\nisa=[\"*\"]\n"));
+    if (R.is_ok[Manifest, str](l_abi) || !str_contains(R.unwrap_err[Manifest, str](l_abi), "missing required key 'abi'")) { code = 1; }
+    val l_exp: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[link.l]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\n"));
+    if (R.is_ok[Manifest, str](l_exp) || !str_contains(R.unwrap_err[Manifest, str](l_exp), "missing required key 'export'")) { code = 1; }
+
+    # step spells need; a git dep spells ref
+    val s_need: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[step.s]\ncmd=\"c\"\nin=[\"i\"]\nout=[\"o\"]\n"));
+    if (R.is_ok[Manifest, str](s_need) || !str_contains(R.unwrap_err[Manifest, str](s_need), "missing required key 'need'")) { code = 1; }
+    val d_ref: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[dep.d]\ngit=\"u\"\n"));
+    if (R.is_ok[Manifest, str](d_ref) || !str_contains(R.unwrap_err[Manifest, str](d_ref), "missing required key 'ref' for git source")) { code = 1; }
+
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #1971: filter axes take canonical os/isa/abi values or "*"; "*" (any) is legal and
+# a non-canonical spelling is rejected rather than silently never-matching.
+test "mach.lang.manifest.parse:canonical_and_star" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val head: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n";
+
+    # a non-canonical os is a strict error
+    val bad: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[link.l]\nsource=\"system\"\nname=\"c\"\nos=\"windoze\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n"));
+    if (R.is_ok[Manifest, str](bad) || !str_contains(R.unwrap_err[Manifest, str](bad), "non-canonical value 'windoze'")) { code = 1; }
+
+    # "*" on every axis and targets = ["*"] are the explicit-any token and legal
+    val ok: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[artifact.a]\nkind=\"bin\"\nentry=\"m.mach\"\nout=\"bin/a\"\ntargets=[\"*\"]\nlink=[\"c\"]\nneed=[]\n[link.c]\nsource=\"system\"\nname=\"c\"\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n"));
+    if (R.is_err[Manifest, str](ok)) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #1971: the template variable set is closed to {project.out}/{target.name}/
+# {profile.name}; the dropped {name}/{ext} aliases are now unknown (no silent empty).
+test "mach.lang.manifest.expand:closed_set" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val ext: R.Result[str, str] = expand(?alloc, "bin/app{ext}", "out", "linux", "release");
+    if (R.is_ok[str, str](ext) || !str_contains(R.unwrap_err[str, str](ext), "unknown template variable")) { code = 1; }
+    val nm: R.Result[str, str] = expand(?alloc, "test/{name}", "out", "linux", "release");
+    if (R.is_ok[str, str](nm) || !str_contains(R.unwrap_err[str, str](nm), "unknown template variable")) { code = 1; }
+    # the closed set still resolves
+    val good: R.Result[str, str] = expand(?alloc, "{project.out}/{target.name}/{profile.name}", "o", "linux", "release");
+    if (R.is_err[str, str](good) || !str_equals(R.unwrap_ok[str, str](good), "o/linux/release")) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }
@@ -2442,7 +2558,7 @@ test "mach.lang.manifest.resolve_test_libs:union" {
     # `mach test` links the union of every artifact's referenced entries, filtered
     # to the native target and deduplicated: app->{a,shared}, tool->{b,shared,c};
     # c filters out (windows-only) and shared dedups, so the union is {a,b,shared}.
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.a]\nsource=\"system\"\nname=\"liba\"\nos=\"*\"\n[link.b]\nsource=\"system\"\nname=\"libb\"\nos=\"linux\"\n[link.c]\nsource=\"system\"\nname=\"libc\"\nos=\"windows\"\n[link.shared]\nsource=\"system\"\nname=\"libshared\"\nos=\"*\"\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[\"a\",\"shared\"]\n[artifact.tool]\nkind=\"bin\"\nentry=\"t.mach\"\nout=\"bin/tool\"\ntargets=[\"*\"]\nlink=[\"b\",\"shared\",\"c\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[link.a]\nsource=\"system\"\nname=\"liba\"\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[link.b]\nsource=\"system\"\nname=\"libb\"\nos=\"linux\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[link.c]\nsource=\"system\"\nname=\"libc\"\nos=\"windows\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[link.shared]\nsource=\"system\"\nname=\"libshared\"\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[\"a\",\"shared\"]\nneed=[]\n[artifact.tool]\nkind=\"bin\"\nentry=\"t.mach\"\nout=\"bin/tool\"\ntargets=[\"*\"]\nlink=[\"b\",\"shared\",\"c\"]\nneed=[]\n";
     val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
@@ -2500,7 +2616,7 @@ test "mach.lang.manifest.parse:link_filter_empty_array_matches_nothing" {
     # explicit os = [] says "none" (#1964) and matches NO cell, distinct from an
     # absent axis which matches any until strict totality (#1971).
     val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[target.arm]\nisa=\"aarch64\"\nos=\"linux\"\nabi=\"aapcs64\"\n[link.none]\nsource=\"system\"\nname=\"a\"\nos=[]\n[link.absent]\nsource=\"system\"\nname=\"b\"\n";
-    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    val res_manifest: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
@@ -2527,7 +2643,7 @@ test "mach.lang.manifest.resolve_build_unit:artifact_target_filter" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nname=\"x\"\ndescription=\"x\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"linux\"]\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"linux\"]\nlink = []\nneed = []\n";
     val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -456,7 +456,11 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
             || str_equals(k, "targets") || str_equals(k, "link") || str_equals(k, "need");
     }
     if (kind == TK_PROFILE) {
-        ret str_equals(k, "opt") || str_equals(k, "emit_ir") || str_equals(k, "emit_asm") || str_equals(k, "debug");
+        if (str_equals(k, "opt") || str_equals(k, "debug")) { ret true; }
+        # emit_ir/emit_asm are CLI-only (--emit-ir/--emit-asm); like name/description
+        # they are pre-flag-day keys tolerated off-root, an unknown key as root (#1971).
+        if (!as_root && (str_equals(k, "emit_ir") || str_equals(k, "emit_asm"))) { ret true; }
+        ret false;
     }
     if (kind == TK_DEP) {
         ret str_equals(k, "git") || str_equals(k, "path") || str_equals(k, "ref");
@@ -489,10 +493,6 @@ fun check_path(alloc: *A.Allocator, value: str, field: str) R.Result[bool, str] 
     ret R.ok[bool, str](true);
 }
 
-fun bool_or(o: O.Option[bool], default: bool) bool {
-    if (O.is_some[bool](o)) { ret O.unwrap[bool](o); }
-    ret default;
-}
 
 fun first_nonempty(a: str, b: str) str {
     if (str_empty(a)) { ret b; }
@@ -751,8 +751,10 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
         val res_opt: R.Result[MOpt, str] = parse_opt_level(alloc, name, sub, as_root);
         if (R.is_err[MOpt, str](res_opt)) { ret R.err[bool, str](R.unwrap_err[MOpt, str](res_opt)); }
         pf.opt      = R.unwrap_ok[MOpt, str](res_opt);
-        pf.emit_ir  = bool_or(toml.get_bool(sub, "emit_ir"), false);
-        pf.emit_asm = bool_or(toml.get_bool(sub, "emit_asm"), false);
+        # emit_ir/emit_asm are CLI-only (--emit-ir/--emit-asm); a declared profile is
+        # opt+debug (#1971). the keys are tolerated off-root but never read here.
+        pf.emit_ir  = false;
+        pf.emit_asm = false;
         val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub, as_root);
         if (R.is_err[bool, str](res_debug)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_debug)); }
         pf.debug    = R.unwrap_ok[bool, str](res_debug);
@@ -1992,9 +1994,14 @@ test "mach.lang.manifest.parse:name_description_rejected" {
     val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
     if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: unknown key 'description' in [project]")) { code = 1; }
 
-    # a dependency's manifest is parsed permissively, so pre-flag-day name/description
-    # are tolerated there.
-    val d: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"App\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
+    # emit_ir/emit_asm are CLI-only now; a declared profile is opt+debug, so they are
+    # unknown keys as root (#1971) -- same category as name/description.
+    val e: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[profile.debug]\nopt=0\ndebug=false\nemit_ir=true\n");
+    if (R.is_ok[Manifest, str](e) || !str_equals(R.unwrap_err[Manifest, str](e), "mach.toml: unknown key 'emit_ir' in [profile.debug]")) { code = 1; }
+
+    # a dependency's manifest is parsed permissively, so all of these pre-flag-day
+    # keys (name/description/emit_ir/emit_asm) are tolerated there.
+    val d: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nname=\"App\"\ndescription=\"d\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[profile.debug]\nopt=0\ndebug=false\nemit_ir=true\nemit_asm=true\n");
     if (R.is_err[Manifest, str](d)) { code = 1; }
     arena.dnit(?ar);
     ret code;

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -132,7 +132,7 @@ pub rec Session {
     registry: target.TargetRegistry;
 
     # CLI optimization intent, set before the build so the comptime ctx can
-    # resolve `$mach.build.mode`. opt_explicit marks an explicit `-O*`/`--release`
+    # resolve `$mach.build.mode`. opt_explicit marks an explicit `-O*`
     # flag (it wins over the manifest); opt_release is its release-vs-debug sense.
     opt_explicit: bool;
     opt_release:  bool;

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -37,6 +37,18 @@ pub val ABI_AAPCS64: u32 = 3;
 # a0-a7 and float fa0-fa7 register banks
 pub val ABI_LP64: u32 = 4;
 
+# map a calling-convention name to its canonical id
+# ---
+# name: abi name ("sysv64", "win64", "aapcs64", "lp64")
+# ret:  the matching ABI_* id, or ABI_UNKNOWN if unrecognized
+pub fun abi_id_for(name: str) u32 {
+    if (str_equals(name, "sysv64"))  { ret ABI_SYSV; }
+    if (str_equals(name, "win64"))   { ret ABI_WIN64; }
+    if (str_equals(name, "aapcs64")) { ret ABI_AAPCS64; }
+    if (str_equals(name, "lp64"))    { ret ABI_LP64; }
+    ret ABI_UNKNOWN;
+}
+
 # how a single parameter or return value is classified for passing
 pub def ParamClass: u8;
 

--- a/src/lang/target/of/ar.mach
+++ b/src/lang/target/of/ar.mach
@@ -18,12 +18,19 @@
 # archiver inserts (the `/` symbol directory and the `//` long-name table), since
 # those are not objects.
 
+use std.allocator.page;
+use std.filesystem;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
 use std.types.string.str_starts_with;
+
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
 
 # the `!<arch>\n` magic that opens every `ar` file
 val MAGIC:       str   = "!<arch>\n";
@@ -234,4 +241,266 @@ fun parse_size(buf: *u8, at: usize, ok: *bool) usize {
 
     @ok = digits > 0;
     ret size;
+}
+
+# --- writer ---
+
+# one member to place into an archive: its file name, object bytes, and the names of
+# the global symbols it defines (for the `/` symbol index the linker consults)
+# ---
+# name:      the member file name (unique within the archive)
+# data:      the member's object bytes
+# len:       byte length of `data`
+# sym_names: the names of the defined global symbols this member exports
+# sym_count: number of entries in `sym_names`
+pub rec ArMember {
+    name:      str;
+    data:      *u8;
+    len:       usize;
+    sym_names: *str;
+    sym_count: u32;
+}
+
+# the even-padded on-disk length of a member body (members pad to a 2-byte boundary)
+fun even(x: usize) usize {
+    if ((x & 1) == 1) { ret x + 1; }
+    ret x;
+}
+
+# whether `name` fits the 16-byte inline name field (the name plus its `/` terminator)
+fun inline_name(name: str) bool {
+    ret str_len(name) + 1 <= 16;
+}
+
+# the number of decimal digits in `v` (at least 1)
+fun dec_digits(v: usize) usize {
+    var n: usize = 1;
+    var t: usize = v;
+    for (t >= 10) { t = t / 10; n = n + 1; }
+    ret n;
+}
+
+# write `v` as left-justified decimal ASCII at `buf[off..]`, returning the digit count
+fun put_dec(buf: *u8, off: usize, v: usize) usize {
+    val d: usize = dec_digits(v);
+    var i: usize = d;
+    var t: usize = v;
+    for (i > 0) {
+        i = i - 1;
+        buf[off + i] = ('0'::usize + (t % 10))::u8;
+        t = t / 10;
+    }
+    ret d;
+}
+
+# write the 4-byte big-endian `v` at `buf[off..]` (the `ar` symbol-index offset width)
+fun put_be32(buf: *u8, off: usize, v: u32) {
+    buf[off]     = ((v >> 24) & 0xFF)::u8;
+    buf[off + 1] = ((v >> 16) & 0xFF)::u8;
+    buf[off + 2] = ((v >> 8)  & 0xFF)::u8;
+    buf[off + 3] = (v & 0xFF)::u8;
+}
+
+# write a 60-byte member header at `buf[off..]` with mtime/uid/gid 0, mode 644, the
+# decimal `size`, and the `\x60\n` magic. the 16-byte name field is left as spaces for
+# the caller to fill (inline `name/` or `/<longtable-offset>`).
+fun put_header(buf: *u8, off: usize, size: usize) {
+    var i: usize = 0;
+    for (i < HEADER_LEN) { buf[off + i] = ' '; i = i + 1; }
+    buf[off + 16] = '0';
+    buf[off + 28] = '0';
+    buf[off + 34] = '0';
+    buf[off + 40] = '6'; buf[off + 41] = '4'; buf[off + 42] = '4';
+    put_dec(buf, off + SIZE_OFFSET, size);
+    buf[off + HEADER_LEN - 2] = 0x60;
+    buf[off + HEADER_LEN - 1] = 0x0A;
+}
+
+# write the GNU `ar` archive of `members` to `out_path`: the `!<arch>\n` magic, a `/`
+# symbol index mapping every member's defined globals to its header offset, a `//`
+# long-name table for names past 15 bytes, then each member header + object bytes
+# (padded to an even boundary). external-tool-free - mirrors the format the reader
+# above frames. used for ELF/Mach-O `.a` and the COFF `.lib` ar variant.
+# ---
+# alloc:    allocator for the archive buffer and scratch arrays
+# members:  the objects to archive, in link order
+# count:    number of members
+# out_path: the archive path to write
+# ret:      ok(true) on success, or the first allocation / write error
+pub fun write_archive(alloc: *A.Allocator, members: *ArMember, count: u32, out_path: str) R.Result[bool, str] {
+    var total_syms: usize = 0;
+    var strtab_len: usize = 0;
+    var long_len:   usize = 0;
+    var i: u32 = 0;
+    for (i < count) {
+        total_syms = total_syms + members[i].sym_count::usize;
+        var s: u32 = 0;
+        for (s < members[i].sym_count) { strtab_len = strtab_len + str_len(members[i].sym_names[s]) + 1; s = s + 1; }
+        if (!inline_name(members[i].name)) { long_len = long_len + str_len(members[i].name) + 2; }
+        i = i + 1;
+    }
+    val armap_content: usize = 4 + total_syms * 4 + strtab_len;
+    val has_long: bool = long_len > 0;
+
+    val res_lo: R.Result[*usize, str] = A.allocate[usize](alloc, count::usize);
+    if (R.is_err[*usize, str](res_lo)) { ret R.err[bool, str](R.unwrap_err[*usize, str](res_lo)); }
+    val long_off: *usize = R.unwrap_ok[*usize, str](res_lo);
+    val res_ho: R.Result[*usize, str] = A.allocate[usize](alloc, count::usize);
+    if (R.is_err[*usize, str](res_ho)) { A.deallocate[usize](alloc, long_off, count::usize); ret R.err[bool, str](R.unwrap_err[*usize, str](res_ho)); }
+    val hdr_off: *usize = R.unwrap_ok[*usize, str](res_ho);
+
+    var lo_run: usize = 0;
+    i = 0;
+    for (i < count) {
+        long_off[i] = lo_run;
+        if (!inline_name(members[i].name)) { lo_run = lo_run + str_len(members[i].name) + 2; }
+        i = i + 1;
+    }
+
+    var pos: usize = MAGIC_LEN + HEADER_LEN + even(armap_content);
+    if (has_long) { pos = pos + HEADER_LEN + even(long_len); }
+    i = 0;
+    for (i < count) {
+        hdr_off[i] = pos;
+        pos = pos + HEADER_LEN + even(members[i].len);
+        i = i + 1;
+    }
+    val total: usize = pos;
+
+    val res_buf: R.Result[*u8, str] = A.allocate[u8](alloc, total);
+    if (R.is_err[*u8, str](res_buf)) {
+        A.deallocate[usize](alloc, long_off, count::usize);
+        A.deallocate[usize](alloc, hdr_off, count::usize);
+        ret R.err[bool, str](R.unwrap_err[*u8, str](res_buf));
+    }
+    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+
+    var k: usize = 0;
+    for (k < MAGIC_LEN) { buf[k] = MAGIC[k]; k = k + 1; }
+    var off: usize = MAGIC_LEN;
+
+    put_header(buf, off, armap_content);
+    buf[off] = '/';
+    off = off + HEADER_LEN;
+    put_be32(buf, off, total_syms::u32);
+    var so: usize = off + 4;
+    var st: usize = off + 4 + total_syms * 4;
+    i = 0;
+    for (i < count) {
+        var s: u32 = 0;
+        for (s < members[i].sym_count) {
+            put_be32(buf, so, hdr_off[i]::u32);
+            so = so + 4;
+            val nm: str = members[i].sym_names[s];
+            val nl: usize = str_len(nm);
+            var j: usize = 0;
+            for (j < nl) { buf[st] = nm[j]; st = st + 1; j = j + 1; }
+            buf[st] = 0; st = st + 1;
+            s = s + 1;
+        }
+        i = i + 1;
+    }
+    off = off + armap_content;
+    if ((armap_content & 1) == 1) { buf[off] = 0x0A; off = off + 1; }
+
+    if (has_long) {
+        put_header(buf, off, long_len);
+        buf[off] = '/'; buf[off + 1] = '/';
+        off = off + HEADER_LEN;
+        i = 0;
+        for (i < count) {
+            if (!inline_name(members[i].name)) {
+                val nm: str = members[i].name;
+                val nl: usize = str_len(nm);
+                var j: usize = 0;
+                for (j < nl) { buf[off] = nm[j]; off = off + 1; j = j + 1; }
+                buf[off] = '/'; off = off + 1;
+                buf[off] = 0x0A; off = off + 1;
+            }
+            i = i + 1;
+        }
+        if ((long_len & 1) == 1) { buf[off] = 0x0A; off = off + 1; }
+    }
+
+    i = 0;
+    for (i < count) {
+        put_header(buf, off, members[i].len);
+        if (inline_name(members[i].name)) {
+            val nm: str = members[i].name;
+            val nl: usize = str_len(nm);
+            var j: usize = 0;
+            for (j < nl) { buf[off + j] = nm[j]; j = j + 1; }
+            buf[off + nl] = '/';
+        }
+        or {
+            buf[off] = '/';
+            put_dec(buf, off + 1, long_off[i]);
+        }
+        off = off + HEADER_LEN;
+        var b: usize = 0;
+        for (b < members[i].len) { buf[off] = members[i].data[b]; off = off + 1; b = b + 1; }
+        if ((members[i].len & 1) == 1) { buf[off] = 0x0A; off = off + 1; }
+        i = i + 1;
+    }
+
+    val wr: R.Result[bool, str] = filesystem.write_file(out_path, buf, total, 0o644);
+    A.deallocate[u8](alloc, buf, total);
+    A.deallocate[usize](alloc, long_off, count::usize);
+    A.deallocate[usize](alloc, hdr_off, count::usize);
+    ret wr;
+}
+
+# a written archive round-trips through the reader: valid magic, the `/` symbol index
+# and `//` long-name table are skipped as specials, and exactly the two object members
+# are yielded with their bytes intact - including a member whose name needs the
+# long-name table (#1980)
+test "mach.lang.target.of.ar.write_roundtrip" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var code: i32 = 0;
+
+    var d1: [4]u8; d1[0] = 1::u8; d1[1] = 2::u8; d1[2] = 3::u8; d1[3] = 4::u8;
+    var d2: [3]u8; d2[0] = 9::u8; d2[1] = 8::u8; d2[2] = 7::u8;
+    var s1: [2]str; s1[0] = "foo"; s1[1] = "bar";
+    var s2: [1]str; s2[0] = "aVeryLongExportedSymbolName";
+    var members: [2]ArMember;
+    members[0].name = "short.o";
+    members[0].data = ?d1[0]; members[0].len = 4; members[0].sym_names = ?s1[0]; members[0].sym_count = 2;
+    members[1].name = "a.long.member.name.needing.the.table.o";
+    members[1].data = ?d2[0]; members[1].len = 3; members[1].sym_names = ?s2[0]; members[1].sym_count = 1;
+
+    val res_temp: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "mach_test_ar");
+    if (R.is_err[filesystem.TempFile, str](res_temp)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](res_temp);
+    val path: str = filesystem.temp_path(?tf);
+    if (R.is_err[bool, str](write_archive(?alloc, ?members[0], 2, path))) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, path);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rr)) { ret 1; }
+    val b: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rr);
+
+    if (!is_archive(b.data, b.len)) { ret 1; }
+
+    var pos: usize = first_member();
+    var objs: u32 = 0;
+    var m0_ok: bool = false;
+    var m1_ok: bool = false;
+    var walking: bool = true;
+    for (walking) {
+        val step: Step = next_member(b.data, b.len, pos);
+        if (!step.ok) { code = 1; walking = false; }
+        or (step.done) { walking = false; }
+        or {
+            if (!is_special(b.data, pos)) {
+                objs = objs + 1;
+                if (step.member.len == 4 && step.member.data[0] == 1::u8 && step.member.data[3] == 4::u8) { m0_ok = true; }
+                if (step.member.len == 3 && step.member.data[0] == 9::u8 && step.member.data[2] == 7::u8) { m1_ok = true; }
+            }
+            pos = step.next;
+        }
+    }
+    if (objs != 2) { code = 1; }
+    if (!m0_ok || !m1_ok) { code = 1; }
+    ret code;
 }


### PR DESCRIPTION
Integration sweep for the v3.2.0 strictness release: the #1964 flag-day (#1971/#1996, root-only totality), static ar archives (#1980 phase 1/#1997), the docs rewrite (#1977/#1998), and the CLI leftovers removal (#1999/#2000). CHANGELOG [3.2.0] carries the inventory; the 13-repo ecosystem sweep (#1979) landed in lockstep.