### PR TITLE
feat(debuginfo): mem2reg phi-merge dbg-value births + alloca↔source-variable link (#1904)

### DIFF
--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -241,6 +241,11 @@ pub rec Block {
 # dbg_expr_cap: allocated capacity of `dbg_exprs`
 # dbg_expr_ids: OP_DBG_VALUE instruction id -> the DbgExprId it applies to its
 #              operand; an absent entry means DBG_EXPR_IDENTITY
+# alloca_dbg_vars: OP_ALLOCA instruction id -> the DbgVar the promoted slot stands
+#              for (name/ty/scope). populated only under `-g`, at the local's decl
+#              lowering, so mem2reg can name the variable when it births a dbg-value
+#              at the phi it inserts for the promoted alloca (#1904). the identity is
+#              the same one the local's OP_DBG_VALUE births carry.
 pub rec Function {
     name:        intern.StrId;
     sig:         type.IrTypeId;
@@ -270,6 +275,7 @@ pub rec Function {
     dbg_expr_len: u32;
     dbg_expr_cap: u32;
     dbg_expr_ids: map.Map[id.InstructionId, DbgExprId];
+    alloca_dbg_vars: map.Map[id.InstructionId, DbgVar];
 
     # inlined-subroutine instances created by the inline pass (owned); empty when the
     # function contains no inlined code. `instr_inline_site` maps a cloned instruction
@@ -496,6 +502,7 @@ fun function_dnit(m: *Module, fn: *Function) {
     map.dnit[id.InstructionId, IrAsm](?fn.asm_blocks);
     # DbgVar owns no heap storage, so the map's own teardown suffices.
     map.dnit[id.InstructionId, DbgVar](?fn.dbg_vars);
+    map.dnit[id.InstructionId, DbgVar](?fn.alloca_dbg_vars);
 
     # each pooled expression owns its ops array; free those, then the pool and the
     # per-point id map (a DbgExprId owns no heap storage).
@@ -590,6 +597,7 @@ pub fun function_new(alloc: *A.Allocator, name: intern.StrId, sig: type.IrTypeId
     f.dbg_expr_len = 0;
     f.dbg_expr_cap = 0;
     f.dbg_expr_ids = map.init[id.InstructionId, DbgExprId](alloc, map.hash_u32, map.eq_u32);
+    f.alloca_dbg_vars = map.init[id.InstructionId, DbgVar](alloc, map.hash_u32, map.eq_u32);
     f.inline_sites      = nil;
     f.inline_site_len   = 0;
     f.inline_site_cap   = 0;
@@ -781,6 +789,31 @@ pub fun phi_append_incoming(m: *Module, phi: *instruction.Instruction, pred: id.
 pub fun dbg_var_get(fn: *Function, iid: id.InstructionId) O.Option[*DbgVar] {
     var key: id.InstructionId = iid;
     val res: R.Result[*DbgVar, str] = map.get[id.InstructionId, DbgVar](?fn.dbg_vars, ?key);
+    if (R.is_err[*DbgVar, str](res)) { ret O.none[*DbgVar](); }
+    ret O.some[*DbgVar](R.unwrap_ok[*DbgVar, str](res));
+}
+
+# link a promoted-alloca instruction id to the source variable it stands for, so
+# mem2reg can name that variable when it births a dbg-value at an inserted phi
+# (#1904). recorded only under `-g`, at the local's decl lowering
+# ---
+# fn:        the owning function
+# alloca_id: the OP_ALLOCA instruction id of the local's slot
+# dv:        the source-variable identity (the same one the local's births carry)
+# ret:       ok(true) once recorded, or an allocation error
+pub fun record_alloca_dbg_var(fn: *Function, alloca_id: id.InstructionId, dv: DbgVar) R.Result[bool, str] {
+    ret map.insert[id.InstructionId, DbgVar](?fn.alloca_dbg_vars, alloca_id, dv);
+}
+
+# the source-variable identity a promoted alloca stands for, or none when the alloca
+# has no `-g` link. read by mem2reg's phi-birth path (#1904)
+# ---
+# fn:        the owning function
+# alloca_id: an OP_ALLOCA instruction id
+# ret:       some(*DbgVar) when linked, else none
+pub fun alloca_dbg_var_get(fn: *Function, alloca_id: id.InstructionId) O.Option[*DbgVar] {
+    var key: id.InstructionId = alloca_id;
+    val res: R.Result[*DbgVar, str] = map.get[id.InstructionId, DbgVar](?fn.alloca_dbg_vars, ?key);
     if (R.is_err[*DbgVar, str](res)) { ret O.none[*DbgVar](); }
     ret O.some[*DbgVar](R.unwrap_ok[*DbgVar, str](res));
 }
@@ -1060,6 +1093,36 @@ pub fun block_append_instr(m: *Module, blk: *Block, i: id.InstructionId) R.Resul
         blk.instr_cap    = new_cap;
     }
     blk.instructions[blk.instr_count] = i;
+    blk.instr_count = blk.instr_count + 1;
+    ret R.ok[bool, str](true);
+}
+
+# prepend an InstructionId to the front of a block's body (position 0, conceptually
+# right after the phis), shifting the existing entries right. mem2reg uses this to
+# place a phi-merge dbg-value birth at the merge block entry (#1904)
+# ---
+# m:   module owning the allocator
+# blk: block whose body receives the instruction id at its front
+# i:   the instruction id to prepend
+# ret: ok(true) on success, or an allocation error
+pub fun block_prepend_instr(m: *Module, blk: *Block, i: id.InstructionId) R.Result[bool, str] {
+    if (blk.instr_count >= blk.instr_cap) {
+        var new_cap: u32 = blk.instr_cap * 2;
+        if (new_cap < INITIAL_BLOCK_LIST_CAP) { new_cap = INITIAL_BLOCK_LIST_CAP; }
+        val res_grow: R.Result[*id.InstructionId, str] =
+            A.reallocate[id.InstructionId](m.alloc, blk.instructions, blk.instr_cap::usize, new_cap::usize);
+        if (R.is_err[*id.InstructionId, str](res_grow)) {
+            ret R.err[bool, str](R.unwrap_err[*id.InstructionId, str](res_grow));
+        }
+        blk.instructions = R.unwrap_ok[*id.InstructionId, str](res_grow);
+        blk.instr_cap    = new_cap;
+    }
+    var j: u32 = blk.instr_count;
+    for (j > 0) {
+        blk.instructions[j] = blk.instructions[j - 1];
+        j = j - 1;
+    }
+    blk.instructions[0] = i;
     blk.instr_count = blk.instr_count + 1;
     ret R.ok[bool, str](true);
 }

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1170,7 +1170,8 @@ pub fun module_source(lc: *LowerContext) str {
 # val_v:     the value the variable currently holds
 # ret:       true on success, or an error
 pub fun emit_dbg_birth(lc: *LowerContext, name_span: token.Span, ty: ir_type.IrTypeId,
-                       ty_sem: type.TypeId, is_param: bool, val_v: value.Value) R.Result[bool, str] {
+                       ty_sem: type.TypeId, is_param: bool, val_v: value.Value,
+                       slot: O.Option[value.Value]) R.Result[bool, str] {
     val res_name: R.Result[intern.StrId, str] = intern.intern_span(?lc.s.interner, module_source(lc), name_span);
     if (R.is_err[intern.StrId, str](res_name)) {
         ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_name));
@@ -1184,6 +1185,22 @@ pub fun emit_dbg_birth(lc: *LowerContext, name_span: token.Span, ty: ir_type.IrT
     var sem: type.TypeId = ty_sem;
     if (lc.subst != nil && lc.subst_len > 0) {
         sem = generics.substitute(lc.s, sem, lc.subst, lc.subst_len);
+    }
+    # #1904: when the variable is slot-backed (a local's OP_ALLOCA), link that alloca to
+    # this source-variable identity so mem2reg can name the variable at the phi it
+    # inserts when it promotes the slot. params and reassignments pass none.
+    if (O.is_some[value.Value](slot)) {
+        val sv: value.Value = O.unwrap[value.Value](slot);
+        if (sv.kind == value.VAL_INSTR) {
+            var dv: ir.DbgVar;
+            dv.name     = name;
+            dv.ty       = ty;
+            dv.ty_sem   = sem;
+            dv.is_param = is_param;
+            dv.scope    = 0;
+            val res_link: R.Result[bool, str] = ir.record_alloca_dbg_var(lc.builder.fn, sv.data.instr, dv);
+            if (R.is_err[bool, str](res_link)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_link)); }
+        }
     }
     ret builder.emit_dbg_value(?lc.builder, val_v, name, ty, sem, is_param, 0);
 }

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -877,7 +877,7 @@ fun lower_params(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, fn_i
         # debug birth: bind the parameter to its incoming value, under -g only.
         if (ctx.s.debug && pool_ix::usize < ctx.a.typed_name_len) {
             val p_sem: type.TypeId = context.type_resolved_of(ctx, ctx.a.typed_names[pool_ix].ty);
-            val res_dbg: R.Result[bool, str] = context.emit_dbg_birth(ctx, ctx.a.typed_names[pool_ix].name, p_ir, p_sem, true, pval);
+            val res_dbg: R.Result[bool, str] = context.emit_dbg_birth(ctx, ctx.a.typed_names[pool_ix].name, p_ir, p_sem, true, pval, O.none[value.Value]());
             if (R.is_err[bool, str](res_dbg)) {
                 if (params != nil) { A.deallocate[value.Value](ctx.s.alloc, params, rt_count::usize); }
                 ret res_dbg;

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -2240,7 +2240,7 @@ fun lower_assign(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.Value
             val lhs_e: *expr.Expr = O.unwrap[*expr.Expr](opt_lhs);
             if (lhs_e.kind == expr.EXPR_KIND_IDENT) {
                 val lhs_sem: type.TypeId = context.expr_type_of(ctx, e.data.binary.lhs);
-                val res_dbg: R.Result[bool, str] = context.emit_dbg_birth(ctx, lhs_e.span, rhs.ty, lhs_sem, false, rhs);
+                val res_dbg: R.Result[bool, str] = context.emit_dbg_birth(ctx, lhs_e.span, rhs.ty, lhs_sem, false, rhs, O.none[value.Value]());
                 if (R.is_err[bool, str](res_dbg)) {
                     ret R.err[value.Value, str](R.unwrap_err[bool, str](res_dbg));
                 }

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -435,7 +435,7 @@ fun lower_decl_stmt(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool, st
     # debug birth: bind the source variable to the value it currently holds. only
     # under -g, so a non-debug build emits identical code.
     if (ctx.s.debug) {
-        ret context.emit_dbg_birth(ctx, d.data.bind.name, slot_ty, context.decl_type_of(ctx, did), false, birth_val);
+        ret context.emit_dbg_birth(ctx, d.data.bind.name, slot_ty, context.decl_type_of(ctx, did), false, birth_val, O.some[value.Value](slot));
     }
     ret R.ok[bool, str](true);
 }

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -158,6 +158,12 @@ fun promote_function(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
     val res_rename: R.Result[bool, str] = rename(?st);
     if (R.is_err[bool, str](res_rename)) { state_dnit(?st); ret res_rename; }
 
+    # #1904: with phis final and promoted memory stripped, birth a dbg-value at each
+    # merge-block phi that resolves a -g-linked local, so its binding is the phi across
+    # the merge. a no-op without -g (no alloca links) and for machine code (never lowers).
+    val res_births: R.Result[bool, str] = emit_phi_dbg_births(?st);
+    if (R.is_err[bool, str](res_births)) { state_dnit(?st); ret res_births; }
+
     state_dnit(?st);
     ret R.ok[bool, str](true);
 }
@@ -977,11 +983,10 @@ fun place_phi(st: *State, bid: id.BlockId, alloca_id: id.InstructionId) R.Result
         ret R.err[bool, str]("mem2reg: phi placed for a non-promotable alloca");
     }
 
-    # deferred (#1904): under -g, a promoted local's variable value at and after this
-    # merge is the phi result, so a dbg-value birth belongs here binding that variable
-    # to the phi. it is not emitted yet -- mem2reg has no alloca-to-source-variable
-    # link to name the variable -- so past a merge a binding may reflect the
-    # last-processed branch until #1904 lands.
+    # under -g, a promoted local's variable value at and after this merge is the phi
+    # result; the dbg-value birth binding that variable to the phi is emitted by
+    # emit_phi_dbg_births after rename, once the alloca's source-variable link (#1904)
+    # names the variable and the phi's result value is final.
     var phi: instruction.Instruction;
     phi.kind          = instruction.OP_PHI;
     phi.ty            = st.alloca_ty[ai];
@@ -1005,6 +1010,76 @@ fun place_phi(st: *State, bid: id.BlockId, alloca_id: id.InstructionId) R.Result
 
     val blk: *ir.Block = ?st.fn.blocks[bid::u32];
     ret ir.block_append_phi(st.m, blk, phi_id);
+}
+
+# birth a dbg-value at every merge-block phi that resolves a `-g`-linked promoted
+# alloca (#1904), so a source variable's binding at and after a control-flow merge is
+# the phi result rather than the last-processed predecessor's value
+#
+# Runs after rename (phi results final) and strip (block bodies compacted): for each
+# mem2reg phi whose alloca carries a source-variable link, an OP_DBG_VALUE binding
+# that variable to the phi result is prepended to the merge block's body -- position
+# 0, right after the phis, so the loclist opens the range at the block entry. The
+# alloca link is populated only under `-g`, so a non-debug build has no links, births
+# nothing, and stays byte-identical; OP_DBG_VALUE never lowers regardless.
+fun emit_phi_dbg_births(st: *State) R.Result[bool, str] {
+    val res_void: R.Result[type.IrTypeId, str] = type.intern_void(?st.m.types);
+    if (R.is_err[type.IrTypeId, str](res_void)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_void)); }
+    val void_ty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_void);
+
+    var bi: u32 = 0;
+    for (bi < st.block_count) {
+        val blk: *ir.Block = ?st.fn.blocks[bi];
+        # phi ids are read from phis[]; births are prepended to instructions[], so the
+        # phi list this scans is never perturbed. snapshot the count all the same.
+        val pc: u32 = blk.phi_count;
+        var pi: u32 = 0;
+        for (pi < pc) {
+            val phi_id: id.InstructionId = blk.phis[pi];
+            pi = pi + 1;
+
+            if (phi_id::u32 >= st.phi_alloca_cap) { cnt; }
+            val alloca_id: id.InstructionId = st.phi_alloca[phi_id::u32];
+            if (alloca_id == id.INSTR_NIL) { cnt; }
+
+            val opt_dv: O.Option[*ir.DbgVar] = ir.alloca_dbg_var_get(st.fn, alloca_id);
+            if (O.is_none[*ir.DbgVar](opt_dv)) { cnt; }
+            var dv: ir.DbgVar = @O.unwrap[*ir.DbgVar](opt_dv);
+
+            val opt_phi: O.Option[*instruction.Instruction] = ir.instruction_get(st.fn, phi_id);
+            if (O.is_none[*instruction.Instruction](opt_phi)) { cnt; }
+            val phi_ty: type.IrTypeId = O.unwrap[*instruction.Instruction](opt_phi).ty;
+
+            # OP_DBG_VALUE operand is the phi result value; the instruction owns its
+            # 1-slot operand array (instruction_add copies the record, keeps the ptr).
+            val res_ops: R.Result[*value.Value, str] = A.allocate[value.Value](st.alloc, 1::usize);
+            if (R.is_err[*value.Value, str](res_ops)) { ret R.err[bool, str](R.unwrap_err[*value.Value, str](res_ops)); }
+            val ops: *value.Value = R.unwrap_ok[*value.Value, str](res_ops);
+            ops[0] = value.instr(phi_id, phi_ty);
+
+            var inst: instruction.Instruction;
+            inst.kind          = instruction.OP_DBG_VALUE;
+            inst.ty            = void_ty;
+            inst.operands      = ops;
+            inst.operand_count = 1;
+            inst.operand_cap   = 1;
+            inst.flags         = 0;
+            inst.aux_ty        = type.IRT_NIL;
+            inst.loc           = source.loc_nil();
+
+            val res_id: R.Result[id.InstructionId, str] = ir.instruction_add(st.m, st.fn, inst);
+            if (R.is_err[id.InstructionId, str](res_id)) { ret R.err[bool, str](R.unwrap_err[id.InstructionId, str](res_id)); }
+            val dbg_id: id.InstructionId = R.unwrap_ok[id.InstructionId, str](res_id);
+
+            val res_rec: R.Result[bool, str] = map.insert[id.InstructionId, ir.DbgVar](?st.fn.dbg_vars, dbg_id, dv);
+            if (R.is_err[bool, str](res_rec)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_rec)); }
+
+            val res_pre: R.Result[bool, str] = ir.block_prepend_instr(st.m, ?st.fn.blocks[bi], dbg_id);
+            if (R.is_err[bool, str](res_pre)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_pre)); }
+        }
+        bi = bi + 1;
+    }
+    ret R.ok[bool, str](true);
 }
 
 # rename traversal context, threaded through the dominator-tree walk
@@ -1632,5 +1707,96 @@ test "mach.lang.me.pass.mem2reg.run:dbg_value_is_not_an_escape" {
     # the block.
     if (R.is_err[bool, str](run(?m)))          { ret 1; }
     if (live_alloca_count(fn, entry_blk) != 0) { ret 1; }
+    ret 0;
+}
+
+# #1904: a local written on both arms of a diamond and read after the merge promotes to
+# a phi at the merge; when the alloca carries a source-variable link, mem2reg births an
+# OP_DBG_VALUE at the merge binding that variable to the phi result. this pins the birth
+# (present, at the merge block, operand = the phi, identity copied from the link).
+test "mach.lang.me.pass.mem2reg.run:phi_dbg_birth" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_module: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_module)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_module);
+
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val rb0: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb1: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb2: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb3: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rb0) || R.is_err[id.BlockId, str](rb1) || R.is_err[id.BlockId, str](rb2) || R.is_err[id.BlockId, str](rb3)) { ret 1; }
+    val entry: id.BlockId = R.unwrap_ok[id.BlockId, str](rb0);
+    val bb1:   id.BlockId = R.unwrap_ok[id.BlockId, str](rb1);
+    val bb2:   id.BlockId = R.unwrap_ok[id.BlockId, str](rb2);
+    val merge: id.BlockId = R.unwrap_ok[id.BlockId, str](rb3);
+
+    # entry: x = alloca; cbr 1, bb1, bb2   (a diamond over the promoted local x)
+    builder.set_block(?bld, entry);
+    val res_alloca: R.Result[value.Value, str] = builder.emit_alloca(?bld, i64t, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](res_alloca)) { ret 1; }
+    val x: value.Value = R.unwrap_ok[value.Value, str](res_alloca);
+    # a -g alloca -> source-variable link (name is a distinguishable non-nil StrId)
+    var dv: ir.DbgVar;
+    dv.name     = 7::intern.StrId;
+    dv.ty       = i64t;
+    dv.ty_sem   = semtype.TYPE_NIL;
+    dv.is_param = false;
+    dv.scope    = 0;
+    if (R.is_err[bool, str](ir.record_alloca_dbg_var(fn, x.data.instr, dv))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_cbr(?bld, value.const_int(1, i64t), bb1, bb2))) { ret 1; }
+
+    # bb1: store 10 -> x; br merge
+    builder.set_block(?bld, bb1);
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.const_int(10, i64t), x))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, merge))) { ret 1; }
+
+    # bb2: store 20 -> x; br merge
+    builder.set_block(?bld, bb2);
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.const_int(20, i64t), x))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, merge))) { ret 1; }
+
+    # merge: v = load x; ret v
+    builder.set_block(?bld, merge);
+    val res_load: R.Result[value.Value, str] = builder.emit_load(?bld, x, i64t);
+    if (R.is_err[value.Value, str](res_load)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?bld, R.unwrap_ok[value.Value, str](res_load)))) { ret 1; }
+
+    if (R.is_err[bool, str](run(?m))) { ret 1; }
+
+    # the merge got a phi for x
+    val mblk: *ir.Block = ?fn.blocks[merge::u32];
+    if (mblk.phi_count < 1) { ret 1; }
+    val phi_id: id.InstructionId = mblk.phis[0];
+
+    # a birth binding x to that phi sits in the merge body, and carries the linked identity
+    var found: bool = false;
+    var i: u32 = 0;
+    for (i < mblk.instr_count) {
+        val iid: id.InstructionId = mblk.instructions[i];
+        val oi: O.Option[*instruction.Instruction] = ir.instruction_get(fn, iid);
+        if (O.is_some[*instruction.Instruction](oi)) {
+            val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](oi);
+            if (inst.kind == instruction.OP_DBG_VALUE && inst.operand_count >= 1) {
+                val op: value.Value = inst.operands[0];
+                if (op.kind == value.VAL_INSTR && op.data.instr == phi_id) {
+                    val odv: O.Option[*ir.DbgVar] = ir.dbg_var_get(fn, iid);
+                    if (O.is_some[*ir.DbgVar](odv) && O.unwrap[*ir.DbgVar](odv).name == 7::intern.StrId) { found = true; }
+                }
+            }
+        }
+        i = i + 1;
+    }
+    if (!found) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Closes #1904.

Teaches mem2reg to re-emit `OP_DBG_VALUE` births at the phi nodes it inserts, so a source variable's debug binding is correct across a control-flow merge — the phi result, not the last-processed predecessor's value.

## What changed
1. **alloca ↔ source-variable link** (`src/lang/me/ir.mach`, lowering). A new per-function side table `Function.alloca_dbg_vars` maps an `OP_ALLOCA` instruction id to the `DbgVar` (name/ty/scope) the promoted slot stands for. It's populated only under `-g`, at the local's decl lowering, with the same identity the local's `OP_DBG_VALUE` births already carry. `emit_dbg_birth` gains a `slot` Option — the local-decl site passes its alloca (linked), params and reassignments pass none.
2. **phi births in mem2reg** (`src/lang/me/pass/mem2reg.mach`). After rename (phi results final) and strip, `emit_phi_dbg_births` prepends an `OP_DBG_VALUE` to each merge block that has a mem2reg phi resolving a `-g`-linked alloca, binding the variable to the phi result at the block entry — so the DWARF loclist opens the correct range from the merge. `block_prepend_instr` is the new IR primitive for the entry-position insert.

Follows the additivity discipline (precedents #1957/#1959/#1932-D/#1960): the alloca link is populated **only under `-g`**, so a non-debug build records no links and births nothing; `OP_DBG_VALUE` never lowers regardless.

## Evidence

**IR** — `pick`'s merge block `bb3` re-emits the birth at the phi (from `--emit-ir`, release `-g`):
```
block bb3:
  %29 = phi i32 [bb1 %10, bb2 %15]
  dbg_value %29
```

**gdb money-proof** — an optimized (`--profile release -g`) binary. `pick(c)` writes `x` on both arms of an `if` and reads it after the merge; `x` was `<optimized out>` past the merge before this change, and now resolves to the phi value (`x`'s `DW_AT_location` is a real location list):
```
Breakpoint 1, pick (c=3) at src/main.mach:4
at merge entry (0x40c3f8): x = 30
after merge / ret x (0x40c41a): x = 30
```
`30` is the phi value (`c*10` for `c=3`), tracked correctly at and across the merge point.

## Verification
- Unit suite through the freshly built compiler: **571 passed** (dev baseline 570 after the #1955 merge + 1: `mem2reg.run:phi_dbg_birth`, an IR-level pin that a diamond's promoted local gets a birth at the merge bound to the phi, identity copied from the link).
- Self-host fixpoint: gen2 byte-identical to gen1; gen2 suite 571/571.
- int linux: **42/42**.
- dbg/verify.sh: all 21 target builds pass (its additive-only guard runs at both debug and release).
- dbg/self-additive.sh: the compiler's own release build is `-g` additive.
- Additivity confirmed directly on the phi fixture: every PT_LOAD segment is byte-identical between the `-g` and no-`-g` release builds (section-table metadata normalized) — `-g` changes no machine code.

Parent: #1688. The emitter side (loclists consuming these births) is the #1594 / #1955 line and is already live — this PR is the IR/mem2reg surface only.