### PR TITLE
release: sweep dev → main (v3.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-07-10
+
+The shared-objects and debugging-experience release. `kind = "shared"` artifacts
+now link into real position-independent ELF shared objects — exporting
+`.dynsym`/`.hash`, with a `DT_SONAME` taken from the output basename — `dlopen`-able
+and consumable by another project through a `local` `[link.X]` entry. A release
+image is program-headers-only; a `-g` image carries a full descriptive section
+table, and `-g` stays byte-additive over the release image. And debugging under
+optimization is materially better: local variables survive phi merges,
+register-passed by-value aggregate parameters get honest frame locations, a
+breakpoint on a function lands after its parameters are homed, anonymous and
+generic-instance aggregates no longer emit empty type names, and `.debug_abbrev` is
+deduplicated across modules — 44,968 bytes down to 345 on the compiler itself. Built
+with mach 3.2.0.
+
+### Added
+- backend: **`kind = "shared"` artifacts link real ELF shared objects** —
+  position-independent, exporting `.dynsym`/`.hash` with a `DT_SONAME` from the
+  output basename, `dlopen`-able and consumable through a `local` `[link.X]` entry.
+  A release image is program-headers-only; a `-g` image carries a full descriptive
+  section table, and `-g` remains byte-additive over the release image (#1980,
+  #2004).
+
+### Fixed
+- debuginfo: **local variables survive phi merges** in optimized `-g` builds,
+  instead of losing their locations where control flow joins (#1904, #2005).
+- debuginfo: **register-passed by-value aggregate parameters** get honest frame
+  locations rather than register locations left stale after homing (#1954, #2006).
+- debuginfo: **`break <fn>` lands after parameter homing** — a `prologue_end` row
+  plus a `low_pc` anchor row put the breakpoint past the prologue (#2007, #2008).
+- debuginfo: **anonymous and generic-instance aggregates omit `DW_AT_name`**
+  instead of emitting an empty string (#1955, #2003).
+- debuginfo: **`.debug_abbrev` is deduplicated across modules** — 44,968 → 345
+  bytes on the compiler itself (#1708, #2009).
+
 ## [3.2.0] - 2026-07-10
 
 The strictness release. A declared manifest table is now **total** — every field

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "3.2.0"
+version = "3.3.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1610,6 +1610,50 @@ fun emit_static_archive(p: *driver.Project, images: *of.ObjectImage, paths: **u8
     ret 0;
 }
 
+# link the artifact's per-module objects into a real ELF shared object at its
+# declared `out` (#1980 phase 2). the object is a position-independent ET_DYN that
+# exports its defined globals and names itself by its basename (DT_SONAME), so a
+# consumer records the matching DT_NEEDED. a P2a shared object is self-contained -
+# only the project's own objects are linked; dynamic dependencies of a shared
+# object are a later phase. Sets `*out_path` to the library path on success.
+# ---
+# p:            the project carrying the target and session
+# paths:        the written per-module object paths
+# len:          the per-module object count
+# root:         the resolved project root directory
+# out_override: the `-o` artifact path, or nil to use the resolved path
+# out_path:     receives the owned library path on success
+# ret:          0 on success, 1 on a user error, 2 on an internal error
+fun emit_shared_library(p: *driver.Project, paths: **u8, len: u32, root: *u8, out_override: *u8, out_path: **u8) i64 {
+    var solib: [4096]u8;
+    if (out_override != nil) {
+        util.path_into(?solib[0], 4096, root, out_override);
+    }
+    or {
+        val opt_bin: O.Option[str] = intern.lookup(?p.s.interner, p.config.bin_out);
+        if (O.is_none[str](opt_bin) || str_empty(O.unwrap[str](opt_bin))) {
+            print.eprint("error: selected artifact has no output path; set the `out` template in mach.toml\n");
+            ret 1;
+        }
+        join_into_str(?solib[0], 4096, root, O.unwrap[str](opt_bin));
+    }
+    if (!util.ensure_parents(?solib[0])) {
+        print.eprint("error: failed to create library directory\n");
+        ret 2;
+    }
+
+    val res_link: R.Result[bool, str] =
+        linker.link(p.s, ?p.target, paths, len, nil::*intern.StrId, 0, ?solib[0], artifact_product_name(p), linker.LINK_SHARED);
+    if (R.is_err[bool, str](res_link)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](res_link));
+        print.eprint("\n");
+        ret 1;
+    }
+    @out_path = dup_cstr(p.s.alloc, ?solib[0]);
+    ret 0;
+}
+
 # write each per-module image to a relocatable `.o` on disk, then - in
 # executable mode - link the on-disk object set into the resolved artifact path
 #
@@ -1664,14 +1708,22 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
 
     # library mode (or `--emit obj`): the per-module objects are the deliverable; do
     # not link an executable. a `kind = "static"` artifact additionally archives those
-    # objects into a real `ar` library at its declared `out` (#1980). `--emit obj` and
-    # (phase 2) `kind = "shared"` keep the loose-objects deliverable unchanged.
+    # objects into a real `ar` library, and a `kind = "shared"` artifact links them
+    # into a real ELF shared object, each at its declared `out` (#1980). `--emit obj`
+    # keeps the loose-objects deliverable unchanged.
     if (te.mode == driver.MODE_LIBRARY || emit_obj) {
         if (te.mode == driver.MODE_LIBRARY && !emit_obj && te.lib_kind == manifest.LIBKIND_STATIC) {
             val arc_code: i64 = emit_static_archive(p, images, paths, root, out_override, out_path);
             free_paths(p.s.alloc, paths, len, len);
             if (arc_code != 0) { ret arc_code; }
             readout.phase_end(p.s.readout, readout.PH_LINK, 1, "archive", "archives");
+            ret 0;
+        }
+        if (te.mode == driver.MODE_LIBRARY && !emit_obj && te.lib_kind == manifest.LIBKIND_SHARED) {
+            val so_code: i64 = emit_shared_library(p, paths, len, root, out_override, out_path);
+            free_paths(p.s.alloc, paths, len, len);
+            if (so_code != 0) { ret so_code; }
+            readout.phase_end(p.s.readout, readout.PH_LINK, 1, "library", "libraries");
             ret 0;
         }
         free_paths(p.s.alloc, paths, len, len);

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -211,10 +211,14 @@ val NAME_OMIT: u32 = 0xFFFFFFFF;
 
 # DWARF 5 line-number program: standard opcodes, extended opcodes, and the tuned
 # special-opcode parameters this producer emits
-val DW_LNS_copy:         u8 = 0x01;
-val DW_LNS_advance_pc:   u8 = 0x02;
-val DW_LNS_advance_line: u8 = 0x03;
-val DW_LNS_set_file:     u8 = 0x04;
+val DW_LNS_copy:          u8 = 0x01;
+val DW_LNS_advance_pc:    u8 = 0x02;
+val DW_LNS_advance_line:  u8 = 0x03;
+val DW_LNS_set_file:      u8 = 0x04;
+# marks a row as the first past the prologue (parameter homing / entry spills), so a
+# debugger's `break <fn>` stops where every parameter is live (#2007). declared in the
+# header's standard_opcode_lengths (opcode 10, zero args) already
+val DW_LNS_set_prologue_end: u8 = 0x0a;
 
 val DW_LNE_end_sequence: u8 = 0x01;
 val DW_LNE_set_address:  u8 = 0x02;
@@ -1994,6 +1998,7 @@ fun build_line(s: *session.Session, funcs: *DwFunc, nfuncs: u32, rows: *enc.Line
         var cur_off:  u32 = fn.offset;
         var cur_line: i32 = 1;
         var cur_file: i64 = -1;
+        var first_row: bool = true;
 
         var r: u32 = 0;
         for (r < row_count) {
@@ -2004,6 +2009,19 @@ fun build_line(s: *session.Session, funcs: *DwFunc, nfuncs: u32, rows: *enc.Line
                     enc.emit_byte(b, DW_LNS_set_file);
                     uleb(b, pl.file::u64);
                     cur_file = pl.file::i64;
+                }
+                if (first_row) {
+                    # the encoder emits no row over the prologue / parameter homing. anchor a
+                    # row at the function entry (low_pc) so a debugger's line-based prologue
+                    # skip engages, then flag the first post-homing instruction prologue_end so
+                    # `break <fn>` stops where every parameter is live (#2007). when the first
+                    # row already sits at low_pc there is no homing gap to span.
+                    if (row.text_offset > fn.offset) {
+                        emit_row(b, 0, pl.line - cur_line);
+                        cur_line = pl.line;
+                    }
+                    enc.emit_byte(b, DW_LNS_set_prologue_end);
+                    first_row = false;
                 }
                 val addr_delta: u32 = row.text_offset - cur_off;
                 emit_row(b, addr_delta, pl.line - cur_line);
@@ -3558,6 +3576,45 @@ test "mach.lang.be.codegen.dwarf.emit_row:special_and_fallback" {
     var e2: [3]u8; e2[0] = DW_LNS_advance_pc; e2[1] = 100; e2[2] = DW_LNS_copy;
     if (!buf_eq(?c, ?e2[0], 3)) { code = 1; }
     enc.buf_dnit(?c);
+    ret code;
+}
+
+# build_line anchors a row at the function's low_pc and flags the first post-prologue row
+# DW_LNS_set_prologue_end, so a debugger's `break <fn>` stops past parameter homing where
+# every parameter is live (#2007)
+test "mach.lang.be.codegen.dwarf.build_line:prologue_end_and_entry_row" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var code: i32 = 0;
+
+    # one function [0,16) whose only row is a body instruction at offset 8; no source file is
+    # registered, so pos_of degrades to (file 0, line 1).
+    var fn: DwFunc;
+    fn.name = intern.STR_NIL; fn.offset = 0; fn.size = 16; fn.weak = false;
+    fn.disp = intern.STR_NIL; fn.disp_off = 0; fn.external = false;
+    fn.decl_file = 0; fn.decl_line = 1; fn.ret_ty = -1; fn.var_start = 0; fn.var_count = 0;
+
+    var row: enc.LineRow;
+    row.text_offset = 8; row.sec = 0; row.loc.file = source.FILE_NIL; row.loc.offset = 0;
+
+    var ft: FileTable; ft.count = 0;
+    var b: enc.ByteBuf = enc.buf_init(?alloc);
+    var addr_off: [1]u32; addr_off[0] = 0;
+    build_line(?s, ?fn, 1, ?row, 1, 0, 8, "/", ?ft, ?b, ?addr_off[0]);
+
+    # exactly one DW_LNS_set_prologue_end for the one function. scan the program past the
+    # DW_LNE_set_address address field (addr_off records its start) so no header u32 length
+    # byte aliases 0x0a; the entry copy + body copy use special opcodes, never 0x0a.
+    var pe: u32 = 0;
+    var i: usize = (addr_off[0] + 8)::usize;
+    for (i < b.len) { if (b.data[i] == DW_LNS_set_prologue_end) { pe = pe + 1; } i = i + 1; }
+    if (pe != 1) { code = 1; }
+
+    enc.buf_dnit(?b);
+    session.dnit(?s);
     ret code;
 }
 

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -364,6 +364,10 @@ rec DwVar {
     range_count: u32;
     loclist_off: u32;
     byref:       bool;
+    # true when a byref aggregate's frame home addresses its storage directly (a
+    # register-passed param reconstructed into a slot it owns, #1954), so the location
+    # omits the pointer deref; false when the frame slot holds the storage pointer
+    storage:     bool;
     # the inline instance this variable belongs to (0 = the function's own body, else a
     # 1-based inline-site id); the #1707 producer nests a non-zero one under its instance
     inline_site: u32;
@@ -382,12 +386,13 @@ rec DwVar {
 # off:       frame-base offset when kind == VLOC_FRAME
 # net:       salvage net constant (0 = identity)
 rec LocRange {
-    start: u32;
-    end:   u32;
-    kind:  u8;
-    reg:   i32;
-    off:   i64;
-    net:   i64;
+    start:   u32;
+    end:     u32;
+    kind:    u8;
+    reg:     i32;
+    off:     i64;
+    net:     i64;
+    storage: bool;
 }
 
 # one inlined-subroutine instance, emitted as a DW_TAG_inlined_subroutine nested under
@@ -1608,17 +1613,19 @@ fun emit_frame_base(b: *enc.ByteBuf, fb_reg: i32) {
 # tgt:      resolved target, for the ISA dwarf_reg hook
 # vl:       the variable-location record
 # out_kind/out_reg/out_off: the resolved DWARF location
-fun varloc_home(tgt: *target.Target, vl: *enc.VarLoc, out_kind: *u8, out_reg: *i32, out_off: *i64) {
-    @out_kind = VLOC_NONE;
-    @out_reg  = 0;
-    @out_off  = 0;
+fun varloc_home(tgt: *target.Target, vl: *enc.VarLoc, out_kind: *u8, out_reg: *i32, out_off: *i64, out_storage: *bool) {
+    @out_kind    = VLOC_NONE;
+    @out_reg     = 0;
+    @out_off     = 0;
+    @out_storage = false;
     if (vl.kind == enc.VARLOC_REG) {
         val f: isa.DwarfRegFn = tgt.arch.dwarf_reg::isa.DwarfRegFn;
         val d: i32 = f(vl.reg);
         if (d >= 0) { @out_kind = VLOC_REG; @out_reg = d; }
     } or (vl.kind == enc.VARLOC_FRAME) {
-        @out_kind = VLOC_FRAME;
-        @out_off  = vl.off;
+        @out_kind    = VLOC_FRAME;
+        @out_off     = vl.off;
+        @out_storage = vl.off_storage;
     }
 }
 
@@ -1671,8 +1678,9 @@ fun type_is_aggregate(tc: *TypeCtx, ty: i32) bool {
 # reg:   DWARF register number when kind == VLOC_REG
 # off:   frame-base offset when kind == VLOC_FRAME; the constant value when VLOC_CONST
 # net:   the salvage net constant (0 = identity)
-# byref: true for a by-reference aggregate located from a frame slot holding its address
-fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref: bool) {
+# byref: true for a by-reference aggregate located from a frame slot; storage true when
+#        that slot IS the aggregate's bytes (deref omitted), false when it holds the pointer
+fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref: bool, storage: bool) {
     if (kind == VLOC_CONST) {
         # the variable IS the compile-time constant `off + net`; push it and mark the
         # result a value, not a location. the DIE's DW_AT_type sizes / signs it, so the
@@ -1683,11 +1691,12 @@ fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref
         ret;
     }
     if (byref) {
-        # a frame slot holds the storage pointer: load it, add any salvage offset (an
-        # aggregate address recovered as base + k), and leave the address on the stack.
+        # the location leaves the aggregate's storage address on the stack. a direct storage
+        # slot (a register-passed param reconstructed into it, #1954) IS the bytes, so its
+        # address is DW_OP_fbreg alone; a slot holding the storage POINTER loads it (deref).
         enc.emit_byte(e, DW_OP_fbreg);
         sleb(e, off);
-        enc.emit_byte(e, DW_OP_deref);
+        if (!storage) { enc.emit_byte(e, DW_OP_deref); }
         if (net != 0) { emit_net_const(e, net); }
         ret;
     }
@@ -1717,9 +1726,10 @@ fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref
 # b:    the destination buffer
 # kind/reg/off/net: the home the expression describes
 # byref: true for a by-reference aggregate whose home addresses its storage
-fun emit_counted_loc(b: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref: bool) {
+# storage: true when a byref frame slot IS the aggregate's bytes (deref omitted)
+fun emit_counted_loc(b: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref: bool, storage: bool) {
     var e: enc.ByteBuf = enc.buf_init(b.alloc);
-    build_loc_ops(?e, kind, reg, off, net, byref);
+    build_loc_ops(?e, kind, reg, off, net, byref, storage);
     uleb(b, e.len::u64);
     var i: usize = 0;
     for (i < e.len) { enc.emit_byte(b, e.data[i]); i = i + 1; }
@@ -1731,7 +1741,7 @@ fun emit_counted_loc(b: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, by
 # b: the info buffer
 # v: the variable whose location is emitted (loc_kind is VLOC_REG or VLOC_FRAME)
 fun emit_var_location(b: *enc.ByteBuf, v: *DwVar) {
-    emit_counted_loc(b, v.loc_kind, v.reg, v.offset, v.net, v.byref);
+    emit_counted_loc(b, v.loc_kind, v.reg, v.offset, v.net, v.byref, v.storage);
 }
 
 # build the DWARF 5 `.debug_loclists` section: the unit header (offset_entry_count 0,
@@ -1789,7 +1799,7 @@ fun build_loclists(b: *enc.ByteBuf, funcs: *DwFunc, nfuncs: u32, vars: *DwVar, r
                     enc.emit_byte(b, DW_LLE_offset_pair);
                     uleb(b, (rg.start - fn.offset)::u64);
                     uleb(b, (rg.end - fn.offset)::u64);
-                    emit_counted_loc(b, rg.kind, rg.reg, rg.off, rg.net, v.byref);
+                    emit_counted_loc(b, rg.kind, rg.reg, rg.off, rg.net, v.byref, rg.storage);
                 }
                 r = r + 1;
             }
@@ -2709,6 +2719,7 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irf
             vars[@var_count].loclist_off = 0;
             vars[@var_count].inline_site = vsite;
             vars[@var_count].byref       = type_is_aggregate(tc, ty);
+            vars[@var_count].storage     = false;
             @var_count = @var_count + 1;
         }
         i = i + 1;
@@ -2732,7 +2743,8 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irf
             var kind: u8 = VLOC_NONE;
             var reg:  i32 = 0;
             var off:  i64 = 0;
-            varloc_home(tgt, vl, ?kind, ?reg, ?off);
+            var storage: bool = false;
+            varloc_home(tgt, vl, ?kind, ?reg, ?off, ?storage);
             # a binding with no register/frame home may still be a compile-time constant
             # (a folded local): render it as a computed DW_OP_const value rather than
             # dropping the location. the constant lives in `off` for VLOC_CONST.
@@ -2740,12 +2752,13 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irf
                 val oc: O.Option[i64] = ir.dbg_value_const(irfn, vl.iid::id.InstructionId);
                 if (O.is_some[i64](oc)) { kind = VLOC_CONST; off = O.unwrap[i64](oc); }
             }
-            ranges[@range_count].start = vl.text_offset;
-            ranges[@range_count].end   = hi;
-            ranges[@range_count].kind  = kind;
-            ranges[@range_count].reg   = reg;
-            ranges[@range_count].off   = off;
-            ranges[@range_count].net   = dbg_expr_net(irfn, vl.iid::id.InstructionId);
+            ranges[@range_count].start   = vl.text_offset;
+            ranges[@range_count].end     = hi;
+            ranges[@range_count].kind    = kind;
+            ranges[@range_count].reg     = reg;
+            ranges[@range_count].off     = off;
+            ranges[@range_count].net     = dbg_expr_net(irfn, vl.iid::id.InstructionId);
+            ranges[@range_count].storage = storage;
             @range_count = @range_count + 1;
             k = k + 1;
         }
@@ -2851,6 +2864,7 @@ fun classify_var(v: *DwVar, ranges: *LocRange) {
     v.reg         = ranges[first::u32].reg;
     v.offset      = ranges[first::u32].off;
     v.net         = ranges[first::u32].net;
+    v.storage     = ranges[first::u32].storage;
     v.range_count = 0;
 }
 
@@ -3634,7 +3648,7 @@ test "mach.lang.be.codegen.dwarf.emit_var_location:reg_frame_salvage" {
     # 0x78, DW_OP_deref (0x06) to load the storage pointer (address, no stack_value).
     # register-homed byref never reaches build_loc_ops (classify_var / build_loclists omit
     # it), so only the frame form is exercised.
-    var vm: DwVar; vm.loc_kind = VLOC_FRAME; vm.reg = 0; vm.offset = -8; vm.net = 0; vm.byref = true;
+    var vm: DwVar; vm.loc_kind = VLOC_FRAME; vm.reg = 0; vm.offset = -8; vm.net = 0; vm.byref = true; vm.storage = false;
     var k: enc.ByteBuf = enc.buf_init(?alloc);
     emit_var_location(?k, ?vm);
     var e6: [4]u8; e6[0] = 0x03; e6[1] = 0x91; e6[2] = 0x78; e6[3] = 0x06;
@@ -3643,12 +3657,22 @@ test "mach.lang.be.codegen.dwarf.emit_var_location:reg_frame_salvage" {
 
     # a by-reference aggregate at frame slot -8 salvaged onto base + 16: len 5, DW_OP_fbreg
     # (0x91), sleb(-8) = 0x78, DW_OP_deref (0x06), DW_OP_plus_uconst (0x23), uleb(16) = 0x10.
-    var vn: DwVar; vn.loc_kind = VLOC_FRAME; vn.reg = 0; vn.offset = -8; vn.net = 16; vn.byref = true;
+    var vn: DwVar; vn.loc_kind = VLOC_FRAME; vn.reg = 0; vn.offset = -8; vn.net = 16; vn.byref = true; vn.storage = false;
     var m: enc.ByteBuf = enc.buf_init(?alloc);
     emit_var_location(?m, ?vn);
     var e7: [6]u8; e7[0] = 0x05; e7[1] = 0x91; e7[2] = 0x78; e7[3] = 0x06; e7[4] = 0x23; e7[5] = 0x10;
     if (!buf_eq(?m, ?e7[0], 6)) { code = 1; }
     enc.buf_dnit(?m);
+
+    # a register-passed aggregate reconstructed into a frame slot it owns (#1954): storage
+    # true drops the DW_OP_deref, so the slot address IS the aggregate's bytes. len 2,
+    # DW_OP_fbreg (0x91), sleb(-8) = 0x78 - no deref (contrast vm above).
+    var vp: DwVar; vp.loc_kind = VLOC_FRAME; vp.reg = 0; vp.offset = -8; vp.net = 0; vp.byref = true; vp.storage = true;
+    var q: enc.ByteBuf = enc.buf_init(?alloc);
+    emit_var_location(?q, ?vp);
+    var e8: [3]u8; e8[0] = 0x02; e8[1] = 0x91; e8[2] = 0x78;
+    if (!buf_eq(?q, ?e8[0], 3)) { code = 1; }
+    enc.buf_dnit(?q);
     ret code;
 }
 

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -195,6 +195,19 @@ val ABBREV_SUBRANGE:    u8 = 0x16;
 val ABBREV_POINTER:     u8 = 0x17;
 val ABBREV_STRUCT_LEAF: u8 = 0x18;
 val ABBREV_UNION_LEAF:  u8 = 0x19;
+# name-less variants of the composite abbrevs (#1955): a generic instance or an
+# anonymous shape carries no source spelling, so its DIE omits DW_AT_name entirely
+# rather than pointing it at an empty string (DWARF 5 §2.13), the same leaf/kids
+# abbrev-split discipline as #1949
+val ABBREV_STRUCT_ANON:      u8 = 0x1a;
+val ABBREV_STRUCT_LEAF_ANON: u8 = 0x1b;
+val ABBREV_UNION_ANON:       u8 = 0x1c;
+val ABBREV_UNION_LEAF_ANON:  u8 = 0x1d;
+val ABBREV_MEMBER_ANON:      u8 = 0x1e;
+
+# name_off sentinel marking a composite / member with no source spelling, so the emitter
+# selects the *_ANON abbrev and omits DW_AT_name rather than emitting an empty strp (#1955)
+val NAME_OMIT: u32 = 0xFFFFFFFF;
 
 # DWARF 5 line-number program: standard opcodes, extended opcodes, and the tuned
 # special-opcode parameters this producer emits
@@ -1085,6 +1098,39 @@ fun build_abbrev(b: *enc.ByteBuf) {
     emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
     uleb(b, 0); uleb(b, 0);
 
+    # the name-less struct / union / member variants (#1955): identical to the abbrevs
+    # above minus DW_AT_name, for a composite or member with no source spelling.
+    uleb(b, ABBREV_STRUCT_ANON::u64);
+    uleb(b, DW_TAG_structure_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_yes);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_STRUCT_LEAF_ANON::u64);
+    uleb(b, DW_TAG_structure_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_UNION_ANON::u64);
+    uleb(b, DW_TAG_union_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_yes);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_UNION_LEAF_ANON::u64);
+    uleb(b, DW_TAG_union_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_MEMBER_ANON::u64);
+    uleb(b, DW_TAG_member::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_type,                 DW_FORM_ref4);
+    emit_attr(b, DW_AT_data_member_location, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
     uleb(b, 0);   # null abbrev code terminates the table
 }
 
@@ -1311,23 +1357,35 @@ fun emit_type_dies(b: *enc.ByteBuf, tc: *TypeCtx, len_pos: usize, relocs: *InfoR
         }
         or {
             # a memberless aggregate uses the DW_CHILDREN_no leaf abbrev (and no
-            # terminator), so it never advertises children it lacks (#1949).
+            # terminator), so it never advertises children it lacks (#1949); a shape with
+            # no source spelling uses the *_ANON abbrev and omits DW_AT_name (#1955).
             val kids: bool = td.memb_count > 0;
+            val anon: bool = td.name_off == NAME_OMIT;
+            var ab: u8 = ABBREV_STRUCT;
             if (td.kind == TK_UNION) {
-                if (kids) { enc.emit_byte(b, ABBREV_UNION); } or { enc.emit_byte(b, ABBREV_UNION_LEAF); }
+                if (kids) { ab = ABBREV_UNION;      if (anon) { ab = ABBREV_UNION_ANON; } }
+                or        { ab = ABBREV_UNION_LEAF; if (anon) { ab = ABBREV_UNION_LEAF_ANON; } }
             } or {
-                if (kids) { enc.emit_byte(b, ABBREV_STRUCT); } or { enc.emit_byte(b, ABBREV_STRUCT_LEAF); }
+                if (kids) { ab = ABBREV_STRUCT;      if (anon) { ab = ABBREV_STRUCT_ANON; } }
+                or        { ab = ABBREV_STRUCT_LEAF; if (anon) { ab = ABBREV_STRUCT_LEAF_ANON; } }
             }
-            push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, td.name_off::i64);
-            enc.emit_u32(b, 0);                 # DW_AT_name (strp)
+            enc.emit_byte(b, ab);
+            if (!anon) {
+                push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, td.name_off::i64);
+                enc.emit_u32(b, 0);             # DW_AT_name (strp)
+            }
             uleb(b, td.byte_size::u64);         # DW_AT_byte_size
             var m: u32 = td.memb_start;
             val mend: u32 = td.memb_start + td.memb_count;
             for (m < mend) {
                 val mb: *TypeMember = ?tc.membs[m];
-                enc.emit_byte(b, ABBREV_MEMBER);
-                push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, mb.name_off::i64);
-                enc.emit_u32(b, 0);             # DW_AT_name (strp)
+                if (mb.name_off == NAME_OMIT) {
+                    enc.emit_byte(b, ABBREV_MEMBER_ANON);
+                } or {
+                    enc.emit_byte(b, ABBREV_MEMBER);
+                    push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, mb.name_off::i64);
+                    enc.emit_u32(b, 0);         # DW_AT_name (strp)
+                }
                 push_type_fixup(fixups, nfix, b.len::u32, mb.type_ix);
                 enc.emit_u32(b, 0);             # DW_AT_type (ref4, patched)
                 uleb(b, mb.offset::u64);        # DW_AT_data_member_location
@@ -2981,8 +3039,11 @@ fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, t
 
     var tk: u8 = TK_STRUCT;
     if (t.kind == semtype.TYPE_UNI) { tk = TK_UNION; }
-    # resolve the name string before any further interning (comp_name reads `t`).
-    val name_off: u32 = str_off(strtab, comp_name(s, t));
+    # resolve the name string before any further interning (comp_name reads `t`); an
+    # anonymous shape (empty spelling) is marked NAME_OMIT so its DIE drops DW_AT_name (#1955).
+    val cnm: str = comp_name(s, t);
+    var name_off: u32 = NAME_OMIT;
+    if (str_len(cnm) > 0) { name_off = str_off(strtab, cnm); }
     val bsize: u32 = ir_type.byte_size(?irmod.types, ir_ty, tgt);
 
     val ix: i32 = comp_reserve(tc, tk, sem);
@@ -3019,7 +3080,13 @@ fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, t
         val fty: i32 = type_intern(s, tgt, irmod, tc, strtab, f_ty, address_size);
         if (fty < 0) { j = j + 1; cnt; }
         if (!memb_reserve(tc)) { j = j + 1; cnt; }
-        tc.membs[tc.nmemb].name_off = str_off(strtab, resolve(?s.interner, f_name));
+        # an anonymous field (name == STR_NIL, or an empty spelling) drops DW_AT_name (#1955).
+        var mno: u32 = NAME_OMIT;
+        if (f_name != intern.STR_NIL) {
+            val mnm: str = resolve(?s.interner, f_name);
+            if (str_len(mnm) > 0) { mno = str_off(strtab, mnm); }
+        }
+        tc.membs[tc.nmemb].name_off = mno;
         tc.membs[tc.nmemb].type_ix  = fty::u32;
         tc.membs[tc.nmemb].offset   = ir_type.byte_offset(?irmod.types, ir_ty, j, tgt);
         tc.nmemb = tc.nmemb + 1;
@@ -3285,7 +3352,7 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     page.make(?alloc);
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     build_abbrev(?b);
-    var e: [308]u8;
+    var e: [345]u8;
     e[0]=0x01; e[1]=0x11; e[2]=0x01; e[3]=0x25; e[4]=0x08; e[5]=0x03; e[6]=0x08; e[7]=0x1B;
     e[8]=0x08; e[9]=0x13; e[10]=0x05; e[11]=0x11; e[12]=0x01; e[13]=0x12; e[14]=0x07; e[15]=0x10;
     e[16]=0x17; e[17]=0x00; e[18]=0x00; e[19]=0x02; e[20]=0x24; e[21]=0x00; e[22]=0x03; e[23]=0x0E;
@@ -3347,8 +3414,18 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     e[289]=0x18; e[290]=0x13; e[291]=0x00; e[292]=0x03; e[293]=0x0E; e[294]=0x0B; e[295]=0x0F; e[296]=0x00; e[297]=0x00;
     # ABBREV_UNION_LEAF (0x19): DW_TAG_union_type, no children, name strp, byte_size udata.
     e[298]=0x19; e[299]=0x17; e[300]=0x00; e[301]=0x03; e[302]=0x0E; e[303]=0x0B; e[304]=0x0F; e[305]=0x00; e[306]=0x00;
-    e[307]=0x00;   # null abbrev code terminates the table
-    val ok: bool = buf_eq(?b, ?e[0], 308);
+    # ABBREV_STRUCT_ANON (0x1a): DW_TAG_structure_type, children, byte_size udata (no name).
+    e[307]=0x1a; e[308]=0x13; e[309]=0x01; e[310]=0x0B; e[311]=0x0F; e[312]=0x00; e[313]=0x00;
+    # ABBREV_STRUCT_LEAF_ANON (0x1b): DW_TAG_structure_type, no children, byte_size udata.
+    e[314]=0x1b; e[315]=0x13; e[316]=0x00; e[317]=0x0B; e[318]=0x0F; e[319]=0x00; e[320]=0x00;
+    # ABBREV_UNION_ANON (0x1c): DW_TAG_union_type, children, byte_size udata.
+    e[321]=0x1c; e[322]=0x17; e[323]=0x01; e[324]=0x0B; e[325]=0x0F; e[326]=0x00; e[327]=0x00;
+    # ABBREV_UNION_LEAF_ANON (0x1d): DW_TAG_union_type, no children, byte_size udata.
+    e[328]=0x1d; e[329]=0x17; e[330]=0x00; e[331]=0x0B; e[332]=0x0F; e[333]=0x00; e[334]=0x00;
+    # ABBREV_MEMBER_ANON (0x1e): DW_TAG_member, no children, type ref4, data_member_location udata.
+    e[335]=0x1e; e[336]=0x0D; e[337]=0x00; e[338]=0x49; e[339]=0x13; e[340]=0x38; e[341]=0x0F; e[342]=0x00; e[343]=0x00;
+    e[344]=0x00;   # null abbrev code terminates the table
+    val ok: bool = buf_eq(?b, ?e[0], 345);
     enc.buf_dnit(?b);
     if (!ok) { ret 1; }
     ret 0;
@@ -3400,6 +3477,48 @@ test "mach.lang.be.codegen.dwarf.emit_type_dies:composite_refs" {
     if (b.data[td[4].off::usize] != ABBREV_STRUCT_LEAF) { code = 1; }
     # the pointer references the struct, the array references the base.
     if (td[2].elem != 1 || td[3].elem != 0) { code = 1; }
+
+    enc.buf_dnit(?b);
+    ret code;
+}
+
+# an aggregate with no source spelling (name_off == NAME_OMIT) emits the name-less
+# composite abbrev and no DW_AT_name strp, per member as well as the type itself (#1955);
+# a named member in the same aggregate keeps its name.
+test "mach.lang.be.codegen.dwarf.emit_type_dies:anonymous_omits_name" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var code: i32 = 0;
+
+    # types: [0] base i32, [1] an anonymous struct with an anonymous and a named member.
+    var td: [2]TypeDie;
+    td[0].kind=TK_BASE;   td[0].off=0; td[0].sem=semtype.TYPE_NIL; td[0].name="i32"; td[0].name_off=1; td[0].encoding=DW_ATE_signed; td[0].byte_size=4; td[0].elem=-1; td[0].count=0; td[0].memb_start=0; td[0].memb_count=0;
+    td[1].kind=TK_STRUCT; td[1].off=0; td[1].sem=100; td[1].name=""; td[1].name_off=NAME_OMIT; td[1].encoding=0; td[1].byte_size=8; td[1].elem=-1; td[1].count=0; td[1].memb_start=0; td[1].memb_count=2;
+
+    var mb: [2]TypeMember;
+    mb[0].name_off=NAME_OMIT; mb[0].type_ix=0; mb[0].offset=0;
+    mb[1].name_off=20;        mb[1].type_ix=0; mb[1].offset=4;
+
+    var tc: TypeCtx;
+    tc.alloc=?alloc; tc.types=?td[0]; tc.ntypes=2; tc.type_cap=2; tc.membs=?mb[0]; tc.nmemb=2; tc.memb_cap=2;
+
+    var relocs: [16]InfoReloc;
+    var rc: u32 = 0;
+    var fixups: [8]TypeFixup;
+    var nfix: u32 = 0;
+    var b: enc.ByteBuf = enc.buf_init(?alloc);
+    emit_type_dies(?b, ?tc, 0, ?relocs[0], ?rc, ?fixups[0], ?nfix);
+
+    # the anonymous struct opens with the name-less abbrev, not ABBREV_STRUCT.
+    if (b.data[td[1].off::usize] != ABBREV_STRUCT_ANON) { code = 1; }
+    # byte_size (0x08) is one uleb byte, so the first member DIE follows at off+2; the
+    # anonymous member uses the name-less member abbrev.
+    if (b.data[(td[1].off + 2)::usize] != ABBREV_MEMBER_ANON) { code = 1; }
+    # exactly two DW_AT_name strps are relocated: the base type and the one named member.
+    # the anonymous struct and the anonymous member contribute none (pre-fix: four).
+    if (rc != 2) { code = 1; }
+    # two DW_AT_type ref4 fixups: one per member.
+    if (nfix != 2) { code = 1; }
 
     enc.buf_dnit(?b);
     ret code;

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -130,6 +130,10 @@ pub rec InlinePc {
 # kind:        VARLOC_NONE / VARLOC_REG / VARLOC_FRAME
 # reg:         physical register id when kind == VARLOC_REG
 # off:         frame-base offset when kind == VARLOC_FRAME
+# off_storage: true when a VARLOC_FRAME slot holds the value's storage directly (a
+#              register-passed aggregate reconstructed into a slot it owns, #1954), so an
+#              aggregate location addresses the slot without the byref pointer deref; false
+#              for a regalloc spill, whose slot holds the value (a pointer, for an aggregate)
 pub rec VarLoc {
     text_offset: u32;
     sec:         u32;
@@ -137,6 +141,7 @@ pub rec VarLoc {
     kind:        u8;
     reg:         i32;
     off:         i64;
+    off_storage: bool;
 }
 
 # a variable-location record's home kind
@@ -746,6 +751,7 @@ pub fun push_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, vr
     var kind: u8  = VARLOC_NONE;
     var reg:  i32 = 0;
     var off:  i64 = 0;
+    var storage: bool = false;
     if (vreg != mir.MIR_VREG_NIL && vreg < fn.vreg_count) {
         val vr: *mir.MirVReg = ?fn.vregs[vreg];
         if (vr.assigned != mir.MIR_VREG_NIL) {
@@ -756,6 +762,19 @@ pub fun push_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, vr
             var si: u32 = 0;
             for (si < fn.frame.slot_count) {
                 if (fn.frame.slots[si].value == vreg) { kind = VARLOC_FRAME; off = fn.frame.slots[si].offset; }
+                si = si + 1;
+            }
+        }
+        or {
+            # a register-passed aggregate parameter is reconstructed into a mir.SLOT_SPILL
+            # slot it owns; regalloc excludes the slot-owner vreg, so it has no assigned
+            # register and no regalloc spill. the slot holds the aggregate's bytes, so the
+            # binding is a direct frame location addressing that storage (#1954).
+            var si: u32 = 0;
+            for (si < fn.frame.slot_count) {
+                if (fn.frame.slots[si].value == vreg && fn.frame.slots[si].kind == mir.SLOT_SPILL) {
+                    kind = VARLOC_FRAME; off = fn.frame.slots[si].offset; storage = true;
+                }
                 si = si + 1;
             }
         }
@@ -771,6 +790,7 @@ pub fun push_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, vr
     st.varlocs[st.varloc_count].kind        = kind;
     st.varlocs[st.varloc_count].reg         = reg;
     st.varlocs[st.varloc_count].off         = off;
+    st.varlocs[st.varloc_count].off_storage = storage;
     st.varloc_count = st.varloc_count + 1;
     ret R.ok[bool, str](true);
 }
@@ -1308,6 +1328,43 @@ test "mach.lang.be.codegen.encode.push_varloc:reg_frame_dead" {
     if (st.varlocs[0].kind != VARLOC_REG || st.varlocs[0].reg != 7 || st.varlocs[0].iid != 100) { code = 1; }
     if (st.varlocs[1].kind != VARLOC_FRAME || st.varlocs[1].off != -16 || st.varlocs[1].iid != 101) { code = 1; }
     if (st.varlocs[2].kind != VARLOC_NONE || st.varlocs[2].iid != 102) { code = 1; }
+
+    if (st.varlocs != nil && st.varloc_cap > 0) { A.deallocate[VarLoc](?alloc, st.varlocs, st.varloc_cap::usize); }
+    buf_dnit(?st.buf);
+    ret code;
+}
+
+# push_varloc resolves a register-passed aggregate parameter - a vreg with no assigned
+# register and no regalloc spill, but owning the mir.SLOT_SPILL slot its bytes are
+# reconstructed into - to a direct frame location (VARLOC_FRAME with off_storage set), so
+# the parameter is locatable rather than silently omitted (#1954)
+test "mach.lang.be.codegen.encode.push_varloc:slot_spill_owner_is_direct_frame" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var code: i32 = 0;
+
+    var st: EncodeState;
+    t_row_state(?alloc, ?st);
+
+    # vreg 0 owns a mir.SLOT_SPILL slot at -32 (its reconstructed aggregate bytes): no
+    # assigned register and no regalloc spill.
+    var vregs: [1]mir.MirVReg;
+    vregs[0].id = 0; vregs[0].class = 0; vregs[0].spill_slot = -1; vregs[0].assigned = mir.MIR_VREG_NIL;
+
+    var slots: [1]mir.MirSlot;
+    slots[0].value = 0; slots[0].kind = mir.SLOT_SPILL; slots[0].offset = -32; slots[0].size = 16; slots[0].align = 8;
+
+    var fn: mir.MirFunction;
+    fn.vregs = ?vregs[0]; fn.vreg_count = 1;
+    fn.frame.slots = ?slots[0]; fn.frame.slot_count = 1; fn.frame.slot_cap = 1;
+    fn.frame.size = 0; fn.frame.align = 0; fn.frame.outgoing_size = 0;
+
+    val r: R.Result[bool, str] = push_varloc(?st, 0, ?fn, 0, 200); if (R.is_err[bool, str](r)) { code = 1; }
+
+    if (st.varloc_count != 1) { code = 1; }
+    # a direct frame location at the slot offset, flagged storage so the producer omits the
+    # byref pointer deref.
+    if (st.varlocs[0].kind != VARLOC_FRAME || st.varlocs[0].off != -32 || !st.varlocs[0].off_storage) { code = 1; }
 
     if (st.varlocs != nil && st.varloc_cap > 0) { A.deallocate[VarLoc](?alloc, st.varlocs, st.varloc_cap::usize); }
     buf_dnit(?st.buf);

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1399,6 +1399,14 @@ fun total_sections(modules: *of.ObjectImage, module_count: u32) u32 {
 fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
                         merged: *MergedSection, debug_names: *intern.StrId, debug_count: u32,
                         placements: *Placement, sec_base: *u32) R.Result[bool, str] {
+    # .debug_abbrev is byte-identical across every module (a deterministic, complete
+    # build_abbrev) and every CU references it at offset 0, so only the first copy is
+    # ever read. dedup it: a later object's table shares the first at offset 0 and adds
+    # no bytes to the merged section (#1708).
+    val an_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".debug_abbrev");
+    if (R.is_err[intern.StrId, str](an_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](an_r)); }
+    val abbrev_name: intern.StrId = R.unwrap_ok[intern.StrId, str](an_r);
+
     var flat: u32 = 0;
     var m: u32 = 0;
     for (m < module_count) {
@@ -1416,6 +1424,7 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
             # section routes to the name-keyed slot for its section name so distinct
             # debug sections never merge together.
             var ki: u32 = sec.kind::u32;
+            var dedup: bool = false;
             if (sec.kind == of.SK_DEBUG) {
                 var found: bool = false;
                 var di: u32 = 0;
@@ -1426,28 +1435,40 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
                 # discover_debug_names registered every debug name from these same
                 # inputs, so a miss is an internal invariant break, not an input error.
                 if (!found) { ret R.err[bool, str]("linker: debug section name not registered in the merge"); }
+                # a later .debug_abbrev copy shares the first at offset 0 (#1708).
+                if (sec.name == abbrev_name && merged[ki].used) { dedup = true; }
             }
 
-            var a: u32 = sec.align;
-            if (a == 0)               { a = 1; }
-            if (a > merged[ki].align) { merged[ki].align = a; }
-
-            # align the running offset to this section's alignment and add this
-            # section's bytes, computed in u64 so a >4GiB merged section group is
-            # rejected rather than wrapping the u32 length into a tiny value that
-            # later truncates the output.
-            val off64: u64 = bin.align_up_u64(merged[ki].len::u64, a::u64);
-            val newlen: u64 = off64 + sec.len::u64;
-            if (newlen > 0xFFFFFFFF) {
-                ret R.err[bool, str](named_message(s, "linker: merged section '", merged_section_name(s, sec.kind), "' exceeds the 4 GiB u32 limit", "linker: merged section size exceeds the 4 GiB u32 limit"));
+            if (dedup) {
+                # share the surviving first copy: offset 0, no bytes added. the copy pass
+                # rewrites offset 0 with this identical table (harmless); every CU already
+                # references offset 0, so nothing points into a dropped copy.
+                placements[flat].merged_index = ki;
+                placements[flat].offset       = 0;
+                placements[flat].vaddr        = 0;
             }
+            or {
+                var a: u32 = sec.align;
+                if (a == 0)               { a = 1; }
+                if (a > merged[ki].align) { merged[ki].align = a; }
 
-            placements[flat].merged_index = ki;
-            placements[flat].offset       = off64::u32;
-            placements[flat].vaddr        = 0;
+                # align the running offset to this section's alignment and add this
+                # section's bytes, computed in u64 so a >4GiB merged section group is
+                # rejected rather than wrapping the u32 length into a tiny value that
+                # later truncates the output.
+                val off64: u64 = bin.align_up_u64(merged[ki].len::u64, a::u64);
+                val newlen: u64 = off64 + sec.len::u64;
+                if (newlen > 0xFFFFFFFF) {
+                    ret R.err[bool, str](named_message(s, "linker: merged section '", merged_section_name(s, sec.kind), "' exceeds the 4 GiB u32 limit", "linker: merged section size exceeds the 4 GiB u32 limit"));
+                }
 
-            merged[ki].len  = newlen::u32;
-            merged[ki].used = true;
+                placements[flat].merged_index = ki;
+                placements[flat].offset       = off64::u32;
+                placements[flat].vaddr        = 0;
+
+                merged[ki].len  = newlen::u32;
+                merged[ki].used = true;
+            }
 
             flat = flat + 1;
             sc = sc + 1;

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -907,6 +907,25 @@ fun emit_shared_object(s: *session.Session, tgt: *target.Target, out_img: *of.Ob
     ret R.ok[bool, str](true);
 }
 
+# whether a symbol is a shared object's export: a defined (non-extern) GLOBAL
+# symbol that is not a debug-section anchor
+#
+# LOCAL symbols are object-private and never exported. A GLOBAL symbol defined in a
+# non-allocated debug section (a DWARF anchor the producer emits for cross-TU
+# relocation, e.g. `<module>.debug_line`) is not a runtime symbol: excluding it
+# keeps `-g` byte-additive, since the loadable `.dynsym`/`.dynstr` are then
+# identical with and without debug info.
+# ---
+# m:   the module the symbol belongs to (for its section-kind lookup)
+# sym: the symbol to classify
+# ret: true when the symbol should be published in the export table
+fun is_exported_symbol(m: *of.ObjectImage, sym: *of.Symbol) bool {
+    if (sym.section == of.SECTION_EXTERNAL)        { ret false; }
+    if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0) { ret false; }
+    if (sym.section < m.section_count && m.sections[sym.section].kind == of.SK_DEBUG) { ret false; }
+    ret true;
+}
+
 # gather the exported symbols of a shared object: every defined GLOBAL symbol
 # across the input modules, deduplicated by name, with its final virtual address
 #
@@ -914,9 +933,9 @@ fun emit_shared_object(s: *session.Session, tgt: *target.Target, out_img: *of.Ob
 # externs, this collects defined globals - the symbols a consumer resolves against
 # at load. A first pass sizes the array exactly, a second fills it; each export's
 # address is the winning definition's, read from the resolved symbol table (a
-# defined global is always present there). LOCAL symbols are object-private and
-# never exported. Returns nil with a zero count when the object exports nothing.
-# The caller frees the array
+# defined global is always present there). LOCAL symbols and debug-section anchors
+# are never exported (`is_exported_symbol`). Returns nil with a zero count when the
+# object exports nothing. The caller frees the array
 # ---
 # s:            shared session (allocator)
 # modules:      the input module images
@@ -938,8 +957,7 @@ fun collect_exports(s: *session.Session, modules: *of.ObjectImage, module_count:
         var sy: u32 = 0;
         for (sy < modules[m].symbol_count) {
             val sym: *of.Symbol = ?modules[m].symbols[sy];
-            if (sym.section == of.SECTION_EXTERNAL)                                 { sy = sy + 1; cnt; }
-            if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0)                          { sy = sy + 1; cnt; }
+            if (!is_exported_symbol(?modules[m], sym))                              { sy = sy + 1; cnt; }
             if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?seen, ?sym.name)))   { sy = sy + 1; cnt; }
             val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?seen, sym.name, n);
             if (R.is_err[bool, str](ins)) { map.dnit[intern.StrId, u32](?seen); ret R.err[*of.ExportSym, str](R.unwrap_err[bool, str](ins)); }
@@ -964,8 +982,7 @@ fun collect_exports(s: *session.Session, modules: *of.ObjectImage, module_count:
         var sy: u32 = 0;
         for (sy < modules[m].symbol_count) {
             val sym: *of.Symbol = ?modules[m].symbols[sy];
-            if (sym.section == of.SECTION_EXTERNAL)                                 { sy = sy + 1; cnt; }
-            if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0)                          { sy = sy + 1; cnt; }
+            if (!is_exported_symbol(?modules[m], sym))                              { sy = sy + 1; cnt; }
             if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?placed, ?sym.name))) { sy = sy + 1; cnt; }
 
             # a defined global is always in the resolved table; its winning address

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -162,7 +162,10 @@ rec DynState {
 # import bound at run time against those libraries, and the executable is emitted
 # through the format's `emit_dyn_exec` (ELF: PT_INTERP + .dynamic/PLT/GOT). a
 # static input definition always wins over a dynamic import of the same name.
-# `LINK_SHARED` (producing a shared object) is not yet supported.
+# `LINK_SHARED` produces a position-independent shared object (ELF ET_DYN) that
+# exports its defined globals through the format's `emit_shared`; a self-contained
+# shared object still resolves every `ext` internally (dynamic imports of other
+# libraries from a shared object are a later phase).
 # ---
 # s:            shared session (allocator, interner, diagnostics)
 # tgt:          active target - selects OS base address, entry symbol, and writers
@@ -181,9 +184,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
     if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
     if (tgt.os == nil) { ret R.err[bool, str]("link: target has no OS vtable"); }
-    if (mode == LINK_SHARED) {
-        ret R.err[bool, str]("link: shared-object output is not yet supported");
-    }
     if (obj_paths == nil || obj_count == 0) {
         ret R.err[bool, str]("link: no input objects");
     }
@@ -237,9 +237,6 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
     if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
     if (tgt.os == nil) { ret R.err[bool, str]("link: target has no OS vtable"); }
-    if (mode == LINK_SHARED) {
-        ret R.err[bool, str]("link: shared-object output is not yet supported");
-    }
     if (images == nil || image_count == 0) {
         ret R.err[bool, str]("link: no input objects");
     }
@@ -277,6 +274,10 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
                  module_count: u32, sonames: *intern.StrId, soname_count: u32,
                  out_path: *u8, name: *u8, mode: LinkMode) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
+    # a shared object is always position-independent: the loader maps it at an
+    # arbitrary base and slides its in-image absolute pointers, so it takes the same
+    # PIE-relative layout and base-relocation collection as a PIE executable.
+    val shared: bool = (mode == LINK_SHARED);
     # a PIE executable routes through the dynamic/PIE writer even with zero shared
     # dependencies: it still needs a position-independent layout and a base-relocation
     # set. PIE is requested either because the OS requires it for this arch (e.g. arm64
@@ -286,6 +287,10 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # is position-independent, and the output is an executable; libraries/
     # relocatables ignore dependencies.
     val dynamic: bool = (mode == LINK_EXE) && (soname_count > 0 || pie);
+    # both a PIE executable and a shared object need a position-independent layout
+    # (based a page above the OS base, with a base-relocation set collected during
+    # patching).
+    val position_independent: bool = pie || shared;
 
     # an empty module set (e.g. an archive holding only bookkeeping members) has
     # nothing to link, so reject rather than emit an empty artifact.
@@ -348,11 +353,13 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         ret R.err[bool, str](R.unwrap_err[bool, str](acc_r));
     }
 
-    # assign each merged section a virtual address (executables only). sections
-    # are placed in canonical order from the OS base, each kind page-aligned.
-    val assign_vaddrs: bool = (mode == LINK_EXE);
+    # assign each merged section a virtual address (an executable or a shared
+    # object; a relocatable library carries none). sections are placed in canonical
+    # order from the OS base, each kind page-aligned; a position-independent image
+    # (PIE or shared) is based a page above.
+    val assign_vaddrs: bool = (mode == LINK_EXE) || shared;
     if (assign_vaddrs) {
-        assign_section_vaddrs(tgt, merged, pie);
+        assign_section_vaddrs(tgt, merged, position_independent);
         finalize_placement_vaddrs(merged, placements, sec_total);
     }
 
@@ -400,19 +407,21 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         ret R.err[bool, str](R.unwrap_err[bool, str](build_r));
     }
 
-    # executable: resolve+patch relocations into the merged bytes, then write the
-    # page-aligned load segments through the format's executable writer.
-    if (mode == LINK_EXE) {
-        # the dynamic-link plan. for a static link `dyn` stays empty and every
-        # undefined `ext` must resolve against an input object, exactly as before;
-        # for a dynamic link the unresolved externs become imports and a relocation
-        # targeting one is recorded as a `PltFixup` instead of erroring.
+    # executable or shared object: resolve+patch relocations into the merged bytes,
+    # then write the page-aligned load segments through the format's executable or
+    # shared-library writer.
+    if (mode == LINK_EXE || shared) {
+        # the dynamic-link plan. for a static link or a self-contained shared object
+        # `dyn` carries only the base-relocation set and every undefined `ext` must
+        # resolve against an input object; for a dynamic executable the unresolved
+        # externs become imports and a relocation targeting one is recorded as a
+        # `PltFixup` instead of erroring.
         var dyn: DynState;
         init_dynstate(?dyn);
-        # a PIE image collects in-image absolute pointers as base relocations during
-        # patching and emits them through the dynamic/PIE writer; the flag must be set
-        # before patch_relocations so the collection is enabled.
-        dyn.info.pie = pie;
+        # a position-independent image (PIE executable or shared object) collects
+        # in-image absolute pointers as base relocations during patching; the flag must
+        # be set before patch_relocations so the collection is enabled.
+        dyn.info.pie = position_independent;
         if (dynamic) {
             val dr: R.Result[bool, str] =
                 build_dynamic_info(s, tgt, ?dyn, modules, module_count, ?sym_locs, sonames, soname_count);
@@ -436,7 +445,10 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         }
 
         var emit_r: R.Result[bool, str] = R.ok[bool, str](true);
-        if (dynamic) {
+        if (shared) {
+            emit_r = emit_shared_object(s, tgt, ?out_img, merged, modules, module_count, ?sym_locs, ?dyn, out_path);
+        }
+        or (dynamic) {
             emit_r = emit_dynamic_executable(s, tgt, ?out_img, merged, ?sym_locs, ?dyn, out_path, name);
         }
         or {
@@ -823,6 +835,166 @@ fun emit_dynamic_executable(s: *session.Session, tgt: *target.Target, out_img: *
         ret R.err[bool, str](R.unwrap_err[bool, str](emit_r));
     }
     ret R.ok[bool, str](true);
+}
+
+# lay the merged sections out as load segments and write the shared object through
+# the format's `emit_shared`, handing it the exported symbols (the defined globals)
+# and the dynamic plan carrying the base-relocation set
+#
+# The segment layout is identical to the executable paths; a shared object has no
+# entry point, so no entry symbol is resolved. The exported globals are gathered
+# from the input modules (their final addresses read from the resolved symbol
+# table), and the format writer frames its export table and position-independent
+# layout around the segments. An object format with no shared-library writer is
+# rejected
+# ---
+# s:            shared session (allocator, interner)
+# tgt:          active target - supplies the shared-library writer
+# out_img:      the merged image holding the patched section bytes
+# merged:       the per-kind merged-section accumulators (carry vaddrs and lengths)
+# modules:      the input module images (for the exported-symbol scan)
+# module_count: number of input modules
+# sym_locs:     resolved symbol table, for each export's final address
+# dyn:          the dynamic-link plan + collected base relocations
+# out_path:     null-terminated output file path (its basename is the soname)
+# ret:          true once the shared object is written, or an error string
+fun emit_shared_object(s: *session.Session, tgt: *target.Target, out_img: *of.ObjectImage,
+                       merged: *MergedSection, modules: *of.ObjectImage, module_count: u32,
+                       sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
+                       out_path: *u8) R.Result[bool, str] {
+    if (tgt.of.emit_shared == nil) {
+        ret R.err[bool, str]("link: object format cannot write shared libraries");
+    }
+    if (tgt.os == nil) {
+        ret R.err[bool, str]("link: target has no operating-system vtable");
+    }
+
+    val alloc: *A.Allocator = s.alloc;
+
+    var seg_count: u32 = 0;
+    val sr: R.Result[*of.LoadSegment, str] = build_load_segments(alloc, out_img, merged, ?seg_count);
+    if (R.is_err[*of.LoadSegment, str](sr)) { ret R.err[bool, str](R.unwrap_err[*of.LoadSegment, str](sr)); }
+    val segs: *of.LoadSegment = R.unwrap_ok[*of.LoadSegment, str](sr);
+
+    var export_count: u32 = 0;
+    val xr: R.Result[*of.ExportSym, str] = collect_exports(s, modules, module_count, sym_locs, ?export_count);
+    if (R.is_err[*of.ExportSym, str](xr)) {
+        A.deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
+        ret R.err[bool, str](R.unwrap_err[*of.ExportSym, str](xr));
+    }
+    val exports: *of.ExportSym = R.unwrap_ok[*of.ExportSym, str](xr);
+
+    var dbg_count: u32 = 0;
+    val dr: R.Result[*of.Section, str] = collect_debug_sections(alloc, out_img, ?dbg_count);
+    if (R.is_err[*of.Section, str](dr)) {
+        if (exports != nil && export_count > 0) { A.deallocate[of.ExportSym](alloc, exports, export_count::usize); }
+        A.deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
+        ret R.err[bool, str](R.unwrap_err[*of.Section, str](dr));
+    }
+    val dbg: *of.Section = R.unwrap_ok[*of.Section, str](dr);
+
+    val emit_r: R.Result[bool, str] =
+        tgt.of.emit_shared(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt),
+                           exports, export_count, ?dyn.info, dbg, dbg_count, out_path);
+
+    if (dbg != nil && dbg_count > 0) { A.deallocate[of.Section](alloc, dbg, dbg_count::usize); }
+    if (exports != nil && export_count > 0) { A.deallocate[of.ExportSym](alloc, exports, export_count::usize); }
+    A.deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
+
+    if (R.is_err[bool, str](emit_r)) {
+        ret R.err[bool, str](R.unwrap_err[bool, str](emit_r));
+    }
+    ret R.ok[bool, str](true);
+}
+
+# gather the exported symbols of a shared object: every defined GLOBAL symbol
+# across the input modules, deduplicated by name, with its final virtual address
+#
+# The mirror of `build_dynamic_info`'s import scan: where that collects undefined
+# externs, this collects defined globals - the symbols a consumer resolves against
+# at load. A first pass sizes the array exactly, a second fills it; each export's
+# address is the winning definition's, read from the resolved symbol table (a
+# defined global is always present there). LOCAL symbols are object-private and
+# never exported. Returns nil with a zero count when the object exports nothing.
+# The caller frees the array
+# ---
+# s:            shared session (allocator)
+# modules:      the input module images
+# module_count: number of input modules
+# sym_locs:     resolved symbol table, for each export's final address
+# count:        out - number of exports collected
+# ret:          the export array (freed by the caller), nil when count is 0, or an error string
+fun collect_exports(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
+                    sym_locs: *map.Map[intern.StrId, SymbolLoc], count: *u32) R.Result[*of.ExportSym, str] {
+    @count = 0;
+    val alloc: *A.Allocator = s.alloc;
+
+    # count the distinct defined globals so the array is sized exactly.
+    var seen: map.Map[intern.StrId, u32] =
+        map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
+    var n: u32 = 0;
+    var m: u32 = 0;
+    for (m < module_count) {
+        var sy: u32 = 0;
+        for (sy < modules[m].symbol_count) {
+            val sym: *of.Symbol = ?modules[m].symbols[sy];
+            if (sym.section == of.SECTION_EXTERNAL)                                 { sy = sy + 1; cnt; }
+            if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0)                          { sy = sy + 1; cnt; }
+            if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?seen, ?sym.name)))   { sy = sy + 1; cnt; }
+            val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?seen, sym.name, n);
+            if (R.is_err[bool, str](ins)) { map.dnit[intern.StrId, u32](?seen); ret R.err[*of.ExportSym, str](R.unwrap_err[bool, str](ins)); }
+            n = n + 1;
+            sy = sy + 1;
+        }
+        m = m + 1;
+    }
+    map.dnit[intern.StrId, u32](?seen);
+
+    if (n == 0) { ret R.ok[*of.ExportSym, str](nil); }
+
+    val ar: R.Result[*of.ExportSym, str] = A.zallocate[of.ExportSym](alloc, n::usize);
+    if (R.is_err[*of.ExportSym, str](ar)) { ret R.err[*of.ExportSym, str](R.unwrap_err[*of.ExportSym, str](ar)); }
+    val out: *of.ExportSym = R.unwrap_ok[*of.ExportSym, str](ar);
+
+    var placed: map.Map[intern.StrId, u32] =
+        map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
+    var w: u32 = 0;
+    m = 0;
+    for (m < module_count) {
+        var sy: u32 = 0;
+        for (sy < modules[m].symbol_count) {
+            val sym: *of.Symbol = ?modules[m].symbols[sy];
+            if (sym.section == of.SECTION_EXTERNAL)                                 { sy = sy + 1; cnt; }
+            if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0)                          { sy = sy + 1; cnt; }
+            if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?placed, ?sym.name))) { sy = sy + 1; cnt; }
+
+            # a defined global is always in the resolved table; its winning address
+            # is the export's value.
+            val loc_r: R.Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](sym_locs, ?sym.name);
+            if (R.is_err[*SymbolLoc, str](loc_r)) {
+                map.dnit[intern.StrId, u32](?placed);
+                A.deallocate[of.ExportSym](alloc, out, n::usize);
+                ret R.err[*of.ExportSym, str]("link: exported symbol missing from the resolved symbol table");
+            }
+            out[w].name    = sym.name;
+            out[w].vaddr   = R.unwrap_ok[*SymbolLoc, str](loc_r).vaddr;
+            out[w].is_func = (sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0;
+
+            val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?placed, sym.name, w);
+            if (R.is_err[bool, str](ins)) {
+                map.dnit[intern.StrId, u32](?placed);
+                A.deallocate[of.ExportSym](alloc, out, n::usize);
+                ret R.err[*of.ExportSym, str](R.unwrap_err[bool, str](ins));
+            }
+            w = w + 1;
+            sy = sy + 1;
+        }
+        m = m + 1;
+    }
+    map.dnit[intern.StrId, u32](?placed);
+
+    @count = n;
+    ret R.ok[*of.ExportSym, str](out);
 }
 
 # collect the non-allocated debug sections of the merged image into a freshly

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -241,6 +241,11 @@ pub rec Block {
 # dbg_expr_cap: allocated capacity of `dbg_exprs`
 # dbg_expr_ids: OP_DBG_VALUE instruction id -> the DbgExprId it applies to its
 #              operand; an absent entry means DBG_EXPR_IDENTITY
+# alloca_dbg_vars: OP_ALLOCA instruction id -> the DbgVar the promoted slot stands
+#              for (name/ty/scope). populated only under `-g`, at the local's decl
+#              lowering, so mem2reg can name the variable when it births a dbg-value
+#              at the phi it inserts for the promoted alloca (#1904). the identity is
+#              the same one the local's OP_DBG_VALUE births carry.
 pub rec Function {
     name:        intern.StrId;
     sig:         type.IrTypeId;
@@ -270,6 +275,7 @@ pub rec Function {
     dbg_expr_len: u32;
     dbg_expr_cap: u32;
     dbg_expr_ids: map.Map[id.InstructionId, DbgExprId];
+    alloca_dbg_vars: map.Map[id.InstructionId, DbgVar];
 
     # inlined-subroutine instances created by the inline pass (owned); empty when the
     # function contains no inlined code. `instr_inline_site` maps a cloned instruction
@@ -496,6 +502,7 @@ fun function_dnit(m: *Module, fn: *Function) {
     map.dnit[id.InstructionId, IrAsm](?fn.asm_blocks);
     # DbgVar owns no heap storage, so the map's own teardown suffices.
     map.dnit[id.InstructionId, DbgVar](?fn.dbg_vars);
+    map.dnit[id.InstructionId, DbgVar](?fn.alloca_dbg_vars);
 
     # each pooled expression owns its ops array; free those, then the pool and the
     # per-point id map (a DbgExprId owns no heap storage).
@@ -590,6 +597,7 @@ pub fun function_new(alloc: *A.Allocator, name: intern.StrId, sig: type.IrTypeId
     f.dbg_expr_len = 0;
     f.dbg_expr_cap = 0;
     f.dbg_expr_ids = map.init[id.InstructionId, DbgExprId](alloc, map.hash_u32, map.eq_u32);
+    f.alloca_dbg_vars = map.init[id.InstructionId, DbgVar](alloc, map.hash_u32, map.eq_u32);
     f.inline_sites      = nil;
     f.inline_site_len   = 0;
     f.inline_site_cap   = 0;
@@ -781,6 +789,31 @@ pub fun phi_append_incoming(m: *Module, phi: *instruction.Instruction, pred: id.
 pub fun dbg_var_get(fn: *Function, iid: id.InstructionId) O.Option[*DbgVar] {
     var key: id.InstructionId = iid;
     val res: R.Result[*DbgVar, str] = map.get[id.InstructionId, DbgVar](?fn.dbg_vars, ?key);
+    if (R.is_err[*DbgVar, str](res)) { ret O.none[*DbgVar](); }
+    ret O.some[*DbgVar](R.unwrap_ok[*DbgVar, str](res));
+}
+
+# link a promoted-alloca instruction id to the source variable it stands for, so
+# mem2reg can name that variable when it births a dbg-value at an inserted phi
+# (#1904). recorded only under `-g`, at the local's decl lowering
+# ---
+# fn:        the owning function
+# alloca_id: the OP_ALLOCA instruction id of the local's slot
+# dv:        the source-variable identity (the same one the local's births carry)
+# ret:       ok(true) once recorded, or an allocation error
+pub fun record_alloca_dbg_var(fn: *Function, alloca_id: id.InstructionId, dv: DbgVar) R.Result[bool, str] {
+    ret map.insert[id.InstructionId, DbgVar](?fn.alloca_dbg_vars, alloca_id, dv);
+}
+
+# the source-variable identity a promoted alloca stands for, or none when the alloca
+# has no `-g` link. read by mem2reg's phi-birth path (#1904)
+# ---
+# fn:        the owning function
+# alloca_id: an OP_ALLOCA instruction id
+# ret:       some(*DbgVar) when linked, else none
+pub fun alloca_dbg_var_get(fn: *Function, alloca_id: id.InstructionId) O.Option[*DbgVar] {
+    var key: id.InstructionId = alloca_id;
+    val res: R.Result[*DbgVar, str] = map.get[id.InstructionId, DbgVar](?fn.alloca_dbg_vars, ?key);
     if (R.is_err[*DbgVar, str](res)) { ret O.none[*DbgVar](); }
     ret O.some[*DbgVar](R.unwrap_ok[*DbgVar, str](res));
 }
@@ -1060,6 +1093,36 @@ pub fun block_append_instr(m: *Module, blk: *Block, i: id.InstructionId) R.Resul
         blk.instr_cap    = new_cap;
     }
     blk.instructions[blk.instr_count] = i;
+    blk.instr_count = blk.instr_count + 1;
+    ret R.ok[bool, str](true);
+}
+
+# prepend an InstructionId to the front of a block's body (position 0, conceptually
+# right after the phis), shifting the existing entries right. mem2reg uses this to
+# place a phi-merge dbg-value birth at the merge block entry (#1904)
+# ---
+# m:   module owning the allocator
+# blk: block whose body receives the instruction id at its front
+# i:   the instruction id to prepend
+# ret: ok(true) on success, or an allocation error
+pub fun block_prepend_instr(m: *Module, blk: *Block, i: id.InstructionId) R.Result[bool, str] {
+    if (blk.instr_count >= blk.instr_cap) {
+        var new_cap: u32 = blk.instr_cap * 2;
+        if (new_cap < INITIAL_BLOCK_LIST_CAP) { new_cap = INITIAL_BLOCK_LIST_CAP; }
+        val res_grow: R.Result[*id.InstructionId, str] =
+            A.reallocate[id.InstructionId](m.alloc, blk.instructions, blk.instr_cap::usize, new_cap::usize);
+        if (R.is_err[*id.InstructionId, str](res_grow)) {
+            ret R.err[bool, str](R.unwrap_err[*id.InstructionId, str](res_grow));
+        }
+        blk.instructions = R.unwrap_ok[*id.InstructionId, str](res_grow);
+        blk.instr_cap    = new_cap;
+    }
+    var j: u32 = blk.instr_count;
+    for (j > 0) {
+        blk.instructions[j] = blk.instructions[j - 1];
+        j = j - 1;
+    }
+    blk.instructions[0] = i;
     blk.instr_count = blk.instr_count + 1;
     ret R.ok[bool, str](true);
 }

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1170,7 +1170,8 @@ pub fun module_source(lc: *LowerContext) str {
 # val_v:     the value the variable currently holds
 # ret:       true on success, or an error
 pub fun emit_dbg_birth(lc: *LowerContext, name_span: token.Span, ty: ir_type.IrTypeId,
-                       ty_sem: type.TypeId, is_param: bool, val_v: value.Value) R.Result[bool, str] {
+                       ty_sem: type.TypeId, is_param: bool, val_v: value.Value,
+                       slot: O.Option[value.Value]) R.Result[bool, str] {
     val res_name: R.Result[intern.StrId, str] = intern.intern_span(?lc.s.interner, module_source(lc), name_span);
     if (R.is_err[intern.StrId, str](res_name)) {
         ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_name));
@@ -1184,6 +1185,22 @@ pub fun emit_dbg_birth(lc: *LowerContext, name_span: token.Span, ty: ir_type.IrT
     var sem: type.TypeId = ty_sem;
     if (lc.subst != nil && lc.subst_len > 0) {
         sem = generics.substitute(lc.s, sem, lc.subst, lc.subst_len);
+    }
+    # #1904: when the variable is slot-backed (a local's OP_ALLOCA), link that alloca to
+    # this source-variable identity so mem2reg can name the variable at the phi it
+    # inserts when it promotes the slot. params and reassignments pass none.
+    if (O.is_some[value.Value](slot)) {
+        val sv: value.Value = O.unwrap[value.Value](slot);
+        if (sv.kind == value.VAL_INSTR) {
+            var dv: ir.DbgVar;
+            dv.name     = name;
+            dv.ty       = ty;
+            dv.ty_sem   = sem;
+            dv.is_param = is_param;
+            dv.scope    = 0;
+            val res_link: R.Result[bool, str] = ir.record_alloca_dbg_var(lc.builder.fn, sv.data.instr, dv);
+            if (R.is_err[bool, str](res_link)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_link)); }
+        }
     }
     ret builder.emit_dbg_value(?lc.builder, val_v, name, ty, sem, is_param, 0);
 }

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -877,7 +877,7 @@ fun lower_params(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, fn_i
         # debug birth: bind the parameter to its incoming value, under -g only.
         if (ctx.s.debug && pool_ix::usize < ctx.a.typed_name_len) {
             val p_sem: type.TypeId = context.type_resolved_of(ctx, ctx.a.typed_names[pool_ix].ty);
-            val res_dbg: R.Result[bool, str] = context.emit_dbg_birth(ctx, ctx.a.typed_names[pool_ix].name, p_ir, p_sem, true, pval);
+            val res_dbg: R.Result[bool, str] = context.emit_dbg_birth(ctx, ctx.a.typed_names[pool_ix].name, p_ir, p_sem, true, pval, O.none[value.Value]());
             if (R.is_err[bool, str](res_dbg)) {
                 if (params != nil) { A.deallocate[value.Value](ctx.s.alloc, params, rt_count::usize); }
                 ret res_dbg;

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -2240,7 +2240,7 @@ fun lower_assign(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.Value
             val lhs_e: *expr.Expr = O.unwrap[*expr.Expr](opt_lhs);
             if (lhs_e.kind == expr.EXPR_KIND_IDENT) {
                 val lhs_sem: type.TypeId = context.expr_type_of(ctx, e.data.binary.lhs);
-                val res_dbg: R.Result[bool, str] = context.emit_dbg_birth(ctx, lhs_e.span, rhs.ty, lhs_sem, false, rhs);
+                val res_dbg: R.Result[bool, str] = context.emit_dbg_birth(ctx, lhs_e.span, rhs.ty, lhs_sem, false, rhs, O.none[value.Value]());
                 if (R.is_err[bool, str](res_dbg)) {
                     ret R.err[value.Value, str](R.unwrap_err[bool, str](res_dbg));
                 }

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -435,7 +435,7 @@ fun lower_decl_stmt(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool, st
     # debug birth: bind the source variable to the value it currently holds. only
     # under -g, so a non-debug build emits identical code.
     if (ctx.s.debug) {
-        ret context.emit_dbg_birth(ctx, d.data.bind.name, slot_ty, context.decl_type_of(ctx, did), false, birth_val);
+        ret context.emit_dbg_birth(ctx, d.data.bind.name, slot_ty, context.decl_type_of(ctx, did), false, birth_val, O.some[value.Value](slot));
     }
     ret R.ok[bool, str](true);
 }

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -158,6 +158,12 @@ fun promote_function(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
     val res_rename: R.Result[bool, str] = rename(?st);
     if (R.is_err[bool, str](res_rename)) { state_dnit(?st); ret res_rename; }
 
+    # #1904: with phis final and promoted memory stripped, birth a dbg-value at each
+    # merge-block phi that resolves a -g-linked local, so its binding is the phi across
+    # the merge. a no-op without -g (no alloca links) and for machine code (never lowers).
+    val res_births: R.Result[bool, str] = emit_phi_dbg_births(?st);
+    if (R.is_err[bool, str](res_births)) { state_dnit(?st); ret res_births; }
+
     state_dnit(?st);
     ret R.ok[bool, str](true);
 }
@@ -977,11 +983,10 @@ fun place_phi(st: *State, bid: id.BlockId, alloca_id: id.InstructionId) R.Result
         ret R.err[bool, str]("mem2reg: phi placed for a non-promotable alloca");
     }
 
-    # deferred (#1904): under -g, a promoted local's variable value at and after this
-    # merge is the phi result, so a dbg-value birth belongs here binding that variable
-    # to the phi. it is not emitted yet -- mem2reg has no alloca-to-source-variable
-    # link to name the variable -- so past a merge a binding may reflect the
-    # last-processed branch until #1904 lands.
+    # under -g, a promoted local's variable value at and after this merge is the phi
+    # result; the dbg-value birth binding that variable to the phi is emitted by
+    # emit_phi_dbg_births after rename, once the alloca's source-variable link (#1904)
+    # names the variable and the phi's result value is final.
     var phi: instruction.Instruction;
     phi.kind          = instruction.OP_PHI;
     phi.ty            = st.alloca_ty[ai];
@@ -1005,6 +1010,76 @@ fun place_phi(st: *State, bid: id.BlockId, alloca_id: id.InstructionId) R.Result
 
     val blk: *ir.Block = ?st.fn.blocks[bid::u32];
     ret ir.block_append_phi(st.m, blk, phi_id);
+}
+
+# birth a dbg-value at every merge-block phi that resolves a `-g`-linked promoted
+# alloca (#1904), so a source variable's binding at and after a control-flow merge is
+# the phi result rather than the last-processed predecessor's value
+#
+# Runs after rename (phi results final) and strip (block bodies compacted): for each
+# mem2reg phi whose alloca carries a source-variable link, an OP_DBG_VALUE binding
+# that variable to the phi result is prepended to the merge block's body -- position
+# 0, right after the phis, so the loclist opens the range at the block entry. The
+# alloca link is populated only under `-g`, so a non-debug build has no links, births
+# nothing, and stays byte-identical; OP_DBG_VALUE never lowers regardless.
+fun emit_phi_dbg_births(st: *State) R.Result[bool, str] {
+    val res_void: R.Result[type.IrTypeId, str] = type.intern_void(?st.m.types);
+    if (R.is_err[type.IrTypeId, str](res_void)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_void)); }
+    val void_ty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_void);
+
+    var bi: u32 = 0;
+    for (bi < st.block_count) {
+        val blk: *ir.Block = ?st.fn.blocks[bi];
+        # phi ids are read from phis[]; births are prepended to instructions[], so the
+        # phi list this scans is never perturbed. snapshot the count all the same.
+        val pc: u32 = blk.phi_count;
+        var pi: u32 = 0;
+        for (pi < pc) {
+            val phi_id: id.InstructionId = blk.phis[pi];
+            pi = pi + 1;
+
+            if (phi_id::u32 >= st.phi_alloca_cap) { cnt; }
+            val alloca_id: id.InstructionId = st.phi_alloca[phi_id::u32];
+            if (alloca_id == id.INSTR_NIL) { cnt; }
+
+            val opt_dv: O.Option[*ir.DbgVar] = ir.alloca_dbg_var_get(st.fn, alloca_id);
+            if (O.is_none[*ir.DbgVar](opt_dv)) { cnt; }
+            var dv: ir.DbgVar = @O.unwrap[*ir.DbgVar](opt_dv);
+
+            val opt_phi: O.Option[*instruction.Instruction] = ir.instruction_get(st.fn, phi_id);
+            if (O.is_none[*instruction.Instruction](opt_phi)) { cnt; }
+            val phi_ty: type.IrTypeId = O.unwrap[*instruction.Instruction](opt_phi).ty;
+
+            # OP_DBG_VALUE operand is the phi result value; the instruction owns its
+            # 1-slot operand array (instruction_add copies the record, keeps the ptr).
+            val res_ops: R.Result[*value.Value, str] = A.allocate[value.Value](st.alloc, 1::usize);
+            if (R.is_err[*value.Value, str](res_ops)) { ret R.err[bool, str](R.unwrap_err[*value.Value, str](res_ops)); }
+            val ops: *value.Value = R.unwrap_ok[*value.Value, str](res_ops);
+            ops[0] = value.instr(phi_id, phi_ty);
+
+            var inst: instruction.Instruction;
+            inst.kind          = instruction.OP_DBG_VALUE;
+            inst.ty            = void_ty;
+            inst.operands      = ops;
+            inst.operand_count = 1;
+            inst.operand_cap   = 1;
+            inst.flags         = 0;
+            inst.aux_ty        = type.IRT_NIL;
+            inst.loc           = source.loc_nil();
+
+            val res_id: R.Result[id.InstructionId, str] = ir.instruction_add(st.m, st.fn, inst);
+            if (R.is_err[id.InstructionId, str](res_id)) { ret R.err[bool, str](R.unwrap_err[id.InstructionId, str](res_id)); }
+            val dbg_id: id.InstructionId = R.unwrap_ok[id.InstructionId, str](res_id);
+
+            val res_rec: R.Result[bool, str] = map.insert[id.InstructionId, ir.DbgVar](?st.fn.dbg_vars, dbg_id, dv);
+            if (R.is_err[bool, str](res_rec)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_rec)); }
+
+            val res_pre: R.Result[bool, str] = ir.block_prepend_instr(st.m, ?st.fn.blocks[bi], dbg_id);
+            if (R.is_err[bool, str](res_pre)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_pre)); }
+        }
+        bi = bi + 1;
+    }
+    ret R.ok[bool, str](true);
 }
 
 # rename traversal context, threaded through the dominator-tree walk
@@ -1632,5 +1707,96 @@ test "mach.lang.me.pass.mem2reg.run:dbg_value_is_not_an_escape" {
     # the block.
     if (R.is_err[bool, str](run(?m)))          { ret 1; }
     if (live_alloca_count(fn, entry_blk) != 0) { ret 1; }
+    ret 0;
+}
+
+# #1904: a local written on both arms of a diamond and read after the merge promotes to
+# a phi at the merge; when the alloca carries a source-variable link, mem2reg births an
+# OP_DBG_VALUE at the merge binding that variable to the phi result. this pins the birth
+# (present, at the merge block, operand = the phi, identity copied from the link).
+test "mach.lang.me.pass.mem2reg.run:phi_dbg_birth" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_module: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_module)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_module);
+
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val rb0: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb1: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb2: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb3: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rb0) || R.is_err[id.BlockId, str](rb1) || R.is_err[id.BlockId, str](rb2) || R.is_err[id.BlockId, str](rb3)) { ret 1; }
+    val entry: id.BlockId = R.unwrap_ok[id.BlockId, str](rb0);
+    val bb1:   id.BlockId = R.unwrap_ok[id.BlockId, str](rb1);
+    val bb2:   id.BlockId = R.unwrap_ok[id.BlockId, str](rb2);
+    val merge: id.BlockId = R.unwrap_ok[id.BlockId, str](rb3);
+
+    # entry: x = alloca; cbr 1, bb1, bb2   (a diamond over the promoted local x)
+    builder.set_block(?bld, entry);
+    val res_alloca: R.Result[value.Value, str] = builder.emit_alloca(?bld, i64t, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](res_alloca)) { ret 1; }
+    val x: value.Value = R.unwrap_ok[value.Value, str](res_alloca);
+    # a -g alloca -> source-variable link (name is a distinguishable non-nil StrId)
+    var dv: ir.DbgVar;
+    dv.name     = 7::intern.StrId;
+    dv.ty       = i64t;
+    dv.ty_sem   = semtype.TYPE_NIL;
+    dv.is_param = false;
+    dv.scope    = 0;
+    if (R.is_err[bool, str](ir.record_alloca_dbg_var(fn, x.data.instr, dv))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_cbr(?bld, value.const_int(1, i64t), bb1, bb2))) { ret 1; }
+
+    # bb1: store 10 -> x; br merge
+    builder.set_block(?bld, bb1);
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.const_int(10, i64t), x))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, merge))) { ret 1; }
+
+    # bb2: store 20 -> x; br merge
+    builder.set_block(?bld, bb2);
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.const_int(20, i64t), x))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, merge))) { ret 1; }
+
+    # merge: v = load x; ret v
+    builder.set_block(?bld, merge);
+    val res_load: R.Result[value.Value, str] = builder.emit_load(?bld, x, i64t);
+    if (R.is_err[value.Value, str](res_load)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?bld, R.unwrap_ok[value.Value, str](res_load)))) { ret 1; }
+
+    if (R.is_err[bool, str](run(?m))) { ret 1; }
+
+    # the merge got a phi for x
+    val mblk: *ir.Block = ?fn.blocks[merge::u32];
+    if (mblk.phi_count < 1) { ret 1; }
+    val phi_id: id.InstructionId = mblk.phis[0];
+
+    # a birth binding x to that phi sits in the merge body, and carries the linked identity
+    var found: bool = false;
+    var i: u32 = 0;
+    for (i < mblk.instr_count) {
+        val iid: id.InstructionId = mblk.instructions[i];
+        val oi: O.Option[*instruction.Instruction] = ir.instruction_get(fn, iid);
+        if (O.is_some[*instruction.Instruction](oi)) {
+            val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](oi);
+            if (inst.kind == instruction.OP_DBG_VALUE && inst.operand_count >= 1) {
+                val op: value.Value = inst.operands[0];
+                if (op.kind == value.VAL_INSTR && op.data.instr == phi_id) {
+                    val odv: O.Option[*ir.DbgVar] = ir.dbg_var_get(fn, iid);
+                    if (O.is_some[*ir.DbgVar](odv) && O.unwrap[*ir.DbgVar](odv).name == 7::intern.StrId) { found = true; }
+                }
+            }
+        }
+        i = i + 1;
+    }
+    if (!found) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -376,6 +376,24 @@ pub rec ExecFunction {
     size:       u32;
 }
 
+# one exported symbol of a shared library: a defined global the loader makes
+# visible to a consumer through the format's dynamic symbol table
+#
+# The linker collects one per defined global (non-extern) symbol when producing a
+# shared object; the format writer serializes it into the format's export table
+# (ELF `.dynsym` GLOBAL/defined entry, PE export directory, Mach-O export trie).
+# format-neutral so every shared-library format reuses it. `vaddr` is the symbol's
+# link-time (load-bias-zero) virtual address; the loader adds the image's load bias.
+# ---
+# name:    interned exported symbol name
+# vaddr:   the symbol's link-time virtual address (bias-zero; loader adds the bias)
+# is_func: true for a code (function) export, false for a data (object) export
+pub rec ExportSym {
+    name:    intern.StrId;
+    vaddr:   u64;
+    is_func: bool;
+}
+
 # a format writer: serializes an `ObjectImage` to a relocatable object file at
 # the given path
 #
@@ -487,6 +505,35 @@ pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment
 pub def DynExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64, u64,
                        *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *Section, u32, *u8, *u8) R.Result[bool, str];
 
+# a shared-library writer: serializes the linker's laid-out load segments into a
+# shared object (ELF `.so`, PE `.dll`, Mach-O `.dylib`), framing the format's
+# export table (ELF `.dynsym`/`.hash`, PE export directory, Mach-O export trie)
+# and a position-independent layout around them
+#
+# A shared object is position-independent: the loader maps it at an arbitrary base
+# and adds that bias to every symbol and in-image absolute pointer. The writer
+# emits the format's export table over `exports` (the defined globals the linker
+# resolved), records the base-relocation set the `DynamicInfo` plan carries, and
+# names the object by its own file (ELF `DT_SONAME`, Mach-O install-name) from
+# `path`'s basename. Like the other writers it takes the `IsaVTable`, not the full
+# Target, and the interner explicitly, to resolve the exported names.
+# ---
+# arg 0:  allocator backing the writer's output buffer
+# arg 1:  interner resolving the exported names
+# arg 2:  the instruction-set vtable describing the machine
+# arg 3:  the loadable segments, in ascending virtual-address order
+# arg 4:  number of load segments
+# arg 5:  the segment-alignment page size the linker aligned the vaddrs to
+# arg 6:  the exported symbols (defined globals) to publish, or nil when count is 0
+# arg 7:  number of exported symbols
+# arg 8:  the dynamic-link plan carrying the base-relocation set (`pie` always set)
+# arg 9:  non-allocated debug sections (`SK_DEBUG`), or nil when count is 0
+# arg 10: number of debug sections
+# arg 11: null-terminated output file path (its basename is the soname/install-name)
+# ret:    true on success, or an error string
+pub def SharedFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64,
+                      *ExportSym, u32, *DynamicInfo, *Section, u32, *u8) R.Result[bool, str];
+
 # maximum number of instruction sets an OfVTable's ISA-coverage list holds
 val OF_ISA_MAX: u32 = 8;
 
@@ -515,6 +562,8 @@ val OF_ISA_MAX: u32 = 8;
 # emit_exec:      serializes laid-out load segments into a static executable
 # emit_dyn_exec:  serializes them into a dynamically-linked executable, or nil
 #                 when the format has no dynamic-link writer yet
+# emit_shared:    serializes them into a shared object (`.so`/`.dll`/`.dylib`), or
+#                 nil when the format has no shared-library writer yet
 # covers_isas:    the isa.ARCH_* ids this format's relocation mapping and
 #                 object/executable writers cover; only the first `covers_isa_count`
 #                 entries are valid. this is the format's self-declared joint (of,
@@ -540,6 +589,7 @@ pub rec OfVTable {
     parse_object:        ParserFn;
     emit_exec:           ExecFn;
     emit_dyn_exec:       DynExecFn;
+    emit_shared:         SharedFn;
     covers_isas:         [OF_ISA_MAX]u32;
     covers_isa_count:    u32;
     covers_isa_any:      bool;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -4872,6 +4872,149 @@ test "mach.lang.target.of.elf.emit_pie_exec:static_pie_layout" {
     ret 0;
 }
 
+# emit_shared writes an ET_DYN shared object that exports its defined globals: an
+# ET_DYN header with no entry and no PT_INTERP, a trailing RW PT_GNU_STACK (so a
+# loader accepts it), a .dynamic naming the object via DT_SONAME (the output
+# basename) and locating the .dynsym/.dynstr/.hash, and a .dynsym whose entries are
+# GLOBAL/defined (st_shndx != UNDEF) at the exports' link-time vaddrs. this is the
+# #1980 phase-2 export contract asserted on the emitted bytes.
+test "mach.lang.target.of.elf.emit_shared:exports_and_soname" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id            = isa.ARCH_X86_64;
+    isa_vt.elf_machine   = 62;       # EM_X86_64
+    isa_vt.pointer_width = 8;
+
+    # one executable load segment holding two exported functions.
+    var text: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text[k] = 0x90; k = k + 1; }
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = 0x401000; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text[0];
+
+    val add_r: R.Result[intern.StrId, str] = intern.intern(?i, "add_fn");
+    val mul_r: R.Result[intern.StrId, str] = intern.intern(?i, "mul_fn");
+    if (R.is_err[intern.StrId, str](add_r) || R.is_err[intern.StrId, str](mul_r)) { ret 1; }
+    var exports: [2]of.ExportSym;
+    exports[0].name = R.unwrap_ok[intern.StrId, str](add_r); exports[0].vaddr = 0x401000; exports[0].is_func = true;
+    exports[1].name = R.unwrap_ok[intern.StrId, str](mul_r); exports[1].vaddr = 0x401008; exports[1].is_func = true;
+
+    # a self-contained shared object: position-independent, no base relocations.
+    var dyn: of.DynamicInfo;
+    dyn.libs = nil;            dyn.lib_count = 0;
+    dyn.imports = nil;         dyn.import_count = 0;
+    dyn.interp = intern.STR_NIL;
+    dyn.base_relocs = nil;     dyn.base_reloc_count = 0;
+    dyn.pie = true;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "elf_shared");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_shared(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, ?exports[0], 2, ?dyn, nil::*of.Section, 0, tpath::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
+    val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
+
+    var bad: bool = false;
+
+    # ET_DYN, no entry point.
+    if (bin.read_u16_le(buf.data, 16) != ET_DYN) { bad = true; }
+    if (bin.read_u64_le(buf.data, 24) != 0)      { bad = true; }
+
+    # walk the program headers: PT_DYNAMIC present, PT_INTERP absent, PT_GNU_STACK
+    # present and RW (not executable).
+    val e_phoff: usize = bin.read_u64_le(buf.data, 32)::usize;
+    val e_phnum: usize = bin.read_u16_le(buf.data, 56)::usize;
+    var dyn_foff: usize = 0;
+    var have_interp: bool = false;
+    var gnu_stack_flags: u32 = 0;
+    var have_gnu_stack: bool = false;
+    var ph: usize = 0;
+    for (ph < e_phnum) {
+        val po: usize = e_phoff + ph * PHDR_SIZE;
+        val pt: u32 = bin.read_u32_le(buf.data, po);
+        if (pt == PT_DYNAMIC)   { dyn_foff = bin.read_u64_le(buf.data, po + 8)::usize; }
+        if (pt == PT_INTERP)    { have_interp = true; }
+        if (pt == PT_GNU_STACK) { have_gnu_stack = true; gnu_stack_flags = bin.read_u32_le(buf.data, po + 4); }
+        ph = ph + 1;
+    }
+    if (have_interp)     { bad = true; }
+    if (dyn_foff == 0)   { bad = true; }
+    if (!have_gnu_stack) { bad = true; }
+    if (gnu_stack_flags != (PF_R | PF_W)) { bad = true; }
+
+    # .dynamic: DT_SONAME + the table-locating tags.
+    var soname_off: u64 = 0xFFFFFFFFFFFFFFFF;
+    var strtab_va:  u64 = 0;
+    var symtab_va:  u64 = 0;
+    var have_hash:  bool = false;
+    var syment:     u64 = 0;
+    var d: usize = dyn_foff;
+    var seen: u32 = 0;
+    for (seen < 32) {
+        val tag: u64 = bin.read_u64_le(buf.data, d);
+        val v:   u64 = bin.read_u64_le(buf.data, d + 8);
+        if (tag == DT_SONAME) { soname_off = v; }
+        if (tag == DT_STRTAB) { strtab_va = v; }
+        if (tag == DT_SYMTAB) { symtab_va = v; }
+        if (tag == DT_HASH)   { have_hash = true; }
+        if (tag == DT_SYMENT) { syment = v; }
+        if (tag == DT_NULL) { seen = 32; } or { d = d + DYN_SIZE; seen = seen + 1; }
+    }
+    if (soname_off == 0xFFFFFFFFFFFFFFFF) { bad = true; }
+    if (strtab_va == 0) { bad = true; }
+    if (symtab_va == 0) { bad = true; }
+    if (!have_hash)     { bad = true; }
+    if (syment != 24)   { bad = true; }
+
+    # map the .dynstr / .dynsym vaddrs to file offsets through the containing PT_LOAD.
+    var strtab_off: usize = 0;
+    var symtab_off: usize = 0;
+    ph = 0;
+    for (ph < e_phnum) {
+        val po: usize = e_phoff + ph * PHDR_SIZE;
+        if (bin.read_u32_le(buf.data, po) == PT_LOAD) {
+            val pf:  u64 = bin.read_u64_le(buf.data, po + 8);
+            val pv:  u64 = bin.read_u64_le(buf.data, po + 16);
+            val psz: u64 = bin.read_u64_le(buf.data, po + 32);
+            if (strtab_va >= pv && strtab_va < pv + psz) { strtab_off = (pf + (strtab_va - pv))::usize; }
+            if (symtab_va >= pv && symtab_va < pv + psz) { symtab_off = (pf + (symtab_va - pv))::usize; }
+        }
+        ph = ph + 1;
+    }
+    if (strtab_off == 0 || symtab_off == 0) { bad = true; }
+    or {
+        # DT_SONAME resolves to the output basename in .dynstr.
+        val sn: str = ((buf.data::usize + strtab_off + soname_off::usize)::*u8)::str;
+        if (!str_equals(sn, so_basename(tpath::*u8))) { bad = true; }
+
+        # .dynsym[1] and [2]: GLOBAL/FUNC, defined (st_shndx != UNDEF), at the export vaddrs.
+        val s1: usize = symtab_off + SYM_SIZE;
+        val s2: usize = symtab_off + 2 * SYM_SIZE;
+        if (buf.data[s1 + 4] != ((STB_GLOBAL << 4) | STT_FUNC)) { bad = true; }
+        if (bin.read_u16_le(buf.data, s1 + 6) == 0)             { bad = true; }
+        if (bin.read_u64_le(buf.data, s1 + 8) != 0x401000)      { bad = true; }
+        if (bin.read_u64_le(buf.data, s2 + 8) != 0x401008)      { bad = true; }
+
+        # the first export's name resolves to "add_fn".
+        val n1_off: u64 = bin.read_u32_le(buf.data, s1)::u64;
+        val n1: str = ((buf.data::usize + strtab_off + n1_off::usize)::*u8)::str;
+        if (!str_equals(n1, "add_fn")) { bad = true; }
+    }
+
+    if (bad) { ret 1; }
+    ret 0;
+}
+
 # emit_pie_exec covers exactly the read-only-natured segment that carries a base
 # relocation (`.data.rel.ro`, holding relocated constants) with a PT_GNU_RELRO, forcing
 # it R+W at load so the self-reloc can slide its slots, and leaves pure `.rodata` (a
@@ -5362,6 +5505,94 @@ test "mach.lang.target.of.elf.emit_pie_exec:debug_sections_trailing_nonloaded" {
             if (sh_off >= pf && sh_off < pf + psz) { bad = true; }
         }
         ph = ph + 1;
+    }
+
+    if (bad) { ret 1; }
+    ret 0;
+}
+
+# emit_shared appends debug sections to a trailing section-header table that lies
+# outside every PT_LOAD, so building a shared object with `-g` never changes its
+# loadable image - the #1980-phase-2 slice of the standing -g byte-additivity rule.
+# falsifies a shared writer that maps debug into a load segment.
+test "mach.lang.target.of.elf.emit_shared:debug_additive_nonloaded" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id            = isa.ARCH_X86_64;
+    isa_vt.elf_machine   = 62;
+    isa_vt.pointer_width = 8;
+
+    var text: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text[k] = 0x90; k = k + 1; }
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = 0x401000; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text[0];
+
+    val add_r: R.Result[intern.StrId, str] = intern.intern(?i, "add_fn");
+    if (R.is_err[intern.StrId, str](add_r)) { ret 1; }
+    var exports: [1]of.ExportSym;
+    exports[0].name = R.unwrap_ok[intern.StrId, str](add_r); exports[0].vaddr = 0x401000; exports[0].is_func = true;
+
+    var dyn: of.DynamicInfo;
+    dyn.libs = nil;          dyn.lib_count = 0;
+    dyn.imports = nil;       dyn.import_count = 0;
+    dyn.interp = intern.STR_NIL;
+    dyn.base_relocs = nil;   dyn.base_reloc_count = 0;
+    dyn.pie = true;
+
+    var info_bytes: [4]u8;
+    info_bytes[0] = 0xDE; info_bytes[1] = 0xAD; info_bytes[2] = 0xBE; info_bytes[3] = 0xEF;
+    val nm_info: R.Result[intern.StrId, str] = intern.intern(?i, ".debug_info");
+    if (R.is_err[intern.StrId, str](nm_info)) { ret 1; }
+    var dbg: [1]of.Section;
+    dbg[0].name = R.unwrap_ok[intern.StrId, str](nm_info); dbg[0].kind = of.SK_DEBUG;
+    dbg[0].bytes = ?info_bytes[0]; dbg[0].len = 4; dbg[0].align = 1;
+
+    # emit the same shared object (one output path, so one soname) twice: once with
+    # the debug section, once without. read_all_sized copies the bytes out, so the
+    # first image stays valid after the second emit overwrites the file.
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "elf_shared_add");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tp: str = filesystem.temp_path(?tf);
+
+    val e1: R.Result[bool, str] = emit_shared(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, ?exports[0], 1, ?dyn, ?dbg[0], 1, tp::*u8);
+    if (R.is_err[bool, str](e1)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+    val rb1: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tp);
+    if (R.is_err[filesystem.Buffer, str](rb1)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+    val b1: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb1);
+
+    val e2: R.Result[bool, str] = emit_shared(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, ?exports[0], 1, ?dyn, nil::*of.Section, 0, tp::*u8);
+    if (R.is_err[bool, str](e2)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+    val rb2: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tp);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb2)) { ret 1; }
+    val b2: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb2);
+
+    var bad: bool = false;
+
+    # the no-debug object carries no section-header table; the debug object does.
+    if (bin.read_u64_le(b2.data, 40) != 0) { bad = true; }
+    if (bin.read_u64_le(b1.data, 40) == 0) { bad = true; }
+
+    # the loadable image is byte-identical: the no-debug file is a prefix of the
+    # debug file (which only appends the trailing debug SHT), and every byte outside
+    # the section-table header fields matches.
+    if (b1.len < b2.len) { bad = true; }
+    or {
+        var j: usize = 0;
+        for (j < b2.len) {
+            # e_shoff (40..48) and e_shnum/e_shstrndx (60..64) legitimately differ; every
+            # other header and loadable byte must be identical.
+            if (j >= 40 && j < 48) { j = j + 1; cnt; }
+            if (j >= 60 && j < 64) { j = j + 1; cnt; }
+            if (b1.data[j] != b2.data[j]) { bad = true; j = b2.len; cnt; }
+            j = j + 1;
+        }
     }
 
     if (bad) { ret 1; }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -2185,13 +2185,22 @@ fun so_basename(path: *u8) str {
 # and a PT_GNU_RELRO over any reloc-bearing read-only segment. Unlike an executable
 # it has no entry point and publishes an EXPORT table instead of imports: a
 # `.dynsym` of GLOBAL/defined entries (`st_value` the symbol's link-time vaddr,
-# `st_shndx` a defined marker) reachable through a single-bucket SysV `.hash`, and
-# a `.dynamic` naming the object with `DT_SONAME` (the output basename) so a
-# consumer resolves its imports against these symbols at load. The exported
-# symbols carry no allocated section-header index - like every mach image this
-# file is program-headers-only, and the dynamic loader resolves an export by its
-# `.dynsym` value, never by a section header - so `st_shndx` is a non-special
-# "defined" marker (1) that makes the loader add the load bias to `st_value`.
+# `st_shndx` the containing load segment's section index) reachable through a
+# single-bucket SysV `.hash`, and a `.dynamic` naming the object with `DT_SONAME`
+# (the output basename) so a consumer resolves its imports against these symbols at
+# load.
+#
+# Section-header contract. A RELEASE object is program-headers-only (no section
+# table) - the load truth is the program headers, and the dynamic loader resolves
+# an export by its `.dynsym` value, never by a section header. A `-g` object already
+# appends a trailing, non-loaded section table for its debug sections; this writer
+# extends that table into a full DESCRIPTIVE one - a header per load segment (its
+# `.text`/`.data`/`.rodata`), the dynamic sections, and the debug sections - so
+# tooling that reads sections resolves each export to its real section (`objdump -T`
+# shows a function as `.text` / type `T`). Only headers + names are added; no
+# loadable byte moves, so `-g` stays byte-additive. `st_shndx` names the export's
+# load segment either way: the loader ignores it (bar `SHN_UNDEF`), and it is a
+# valid index once the `-g` table exists.
 #
 # P2a scope is self-contained shared objects: exports and base relocations, no
 # dynamic imports of other libraries (those need the PLT/GOT machinery `emit_dyn_exec`
@@ -2316,31 +2325,53 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
     val struct_total: usize = dyn_off + dyn_size;
     val ro_size: usize = struct_total - ro_off;
 
-    # the allocated dynamic sections, named/located in the trailing section-header
-    # table so `nm -D` / `objdump -T` (which read sections when a table is present)
-    # see the exports instead of an empty result. their bodies already live in the RO
-    # load segment; only headers + names are added, and only on a -g build (the table
-    # exists solely to carry the debug sections). `link` is the aux section's SHT
-    # index of its cross-referenced section: aux[0..3] land at SHT indices 1..4, so
-    # .dynsym/.dynamic link .dynstr (2) and .hash links .dynsym (1). the release .so
-    # has no debug sections, so no table and no aux headers - it stays byte-identical.
-    var aux: [4]ShtAlloc;
-    aux[0].name = ".dynsym";  aux[0].sh_type = SHT_DYNSYM;  aux[0].flags = SHF_ALLOC;
-    aux[0].addr = dynsym_va;  aux[0].off = dynsym_off;  aux[0].size = dynsym_size;  aux[0].link = 2; aux[0].info = 1; aux[0].entsize = SYM_SIZE;
-    aux[1].name = ".dynstr";  aux[1].sh_type = SHT_STRTAB;  aux[1].flags = SHF_ALLOC;
-    aux[1].addr = dynstr_va;  aux[1].off = dynstr_off;  aux[1].size = dynstr_size;  aux[1].link = 0; aux[1].info = 0; aux[1].entsize = 0;
-    aux[2].name = ".hash";    aux[2].sh_type = SHT_HASH;    aux[2].flags = SHF_ALLOC;
-    aux[2].addr = hash_va;    aux[2].off = hash_off;    aux[2].size = hash_size;    aux[2].link = 1; aux[2].info = 0; aux[2].entsize = 4;
-    aux[3].name = ".dynamic"; aux[3].sh_type = SHT_DYNAMIC; aux[3].flags = SHF_ALLOC;
-    aux[3].addr = dyn_va;     aux[3].off = dyn_off;     aux[3].size = dyn_size;     aux[3].link = 2; aux[3].info = 0; aux[3].entsize = DYN_SIZE;
+    # every already-emitted allocated section, named/located in the trailing
+    # section-header table so tooling that reads sections resolves an export to its
+    # real code/data section (a function export shows as .text / type T) and finds
+    # the dynamic tables. the bodies already live in the load segments / RO block;
+    # only headers + names are added, and only on a -g build (the table exists to
+    # carry the debug sections). order: one PROGBITS per load segment at SHT indices
+    # 1..seg_count - matching each export's st_shndx below - then the dynamic
+    # sections. cross-references (.dynsym/.dynamic -> .dynstr, .hash -> .dynsym) are
+    # resolved against this order. the release .so has no debug sections, so no table
+    # and no aux headers, and stays byte-identical.
+    val aux_count: u32 = seg_count + 4;
+    var aux: *ShtAlloc = nil;
+    val axr: R.Result[*ShtAlloc, str] = A.zallocate[ShtAlloc](alloc, aux_count::usize);
+    if (R.is_err[*ShtAlloc, str](axr)) {
+        if (exp_str != nil)     { A.deallocate[usize](alloc, exp_str, nexp::usize); }
+        if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        ret R.err[bool, str]("elf: shared aux-section table alloc failed");
+    }
+    aux = R.unwrap_ok[*ShtAlloc, str](axr);
+    li = 0;
+    for (li < seg_count) {
+        aux[li].name = seg_section_name(segs[li].flags);
+        aux[li].sh_type = SHT_PROGBITS; aux[li].flags = seg_section_flags(segs[li].flags);
+        aux[li].addr = segs[li].vaddr;  aux[li].off = seg_offsets[li]; aux[li].size = segs[li].filesz;
+        aux[li].link = 0; aux[li].info = 0; aux[li].entsize = 0;
+        li = li + 1;
+    }
+    # the dynamic sections follow: .dynsym at SHT index seg_count+1, .dynstr at
+    # seg_count+2, .hash at seg_count+3, .dynamic at seg_count+4.
+    val i_dynsym: u32 = seg_count + 1;
+    val i_dynstr: u32 = seg_count + 2;
+    aux[seg_count].name = ".dynsym";      aux[seg_count].sh_type = SHT_DYNSYM;      aux[seg_count].flags = SHF_ALLOC;
+    aux[seg_count].addr = dynsym_va;      aux[seg_count].off = dynsym_off;      aux[seg_count].size = dynsym_size;  aux[seg_count].link = i_dynstr; aux[seg_count].info = 1; aux[seg_count].entsize = SYM_SIZE;
+    aux[seg_count + 1].name = ".dynstr";  aux[seg_count + 1].sh_type = SHT_STRTAB;  aux[seg_count + 1].flags = SHF_ALLOC;
+    aux[seg_count + 1].addr = dynstr_va;  aux[seg_count + 1].off = dynstr_off;  aux[seg_count + 1].size = dynstr_size;  aux[seg_count + 1].link = 0; aux[seg_count + 1].info = 0; aux[seg_count + 1].entsize = 0;
+    aux[seg_count + 2].name = ".hash";    aux[seg_count + 2].sh_type = SHT_HASH;    aux[seg_count + 2].flags = SHF_ALLOC;
+    aux[seg_count + 2].addr = hash_va;    aux[seg_count + 2].off = hash_off;    aux[seg_count + 2].size = hash_size;    aux[seg_count + 2].link = i_dynsym; aux[seg_count + 2].info = 0; aux[seg_count + 2].entsize = 4;
+    aux[seg_count + 3].name = ".dynamic"; aux[seg_count + 3].sh_type = SHT_DYNAMIC; aux[seg_count + 3].flags = SHF_ALLOC;
+    aux[seg_count + 3].addr = dyn_va;     aux[seg_count + 3].off = dyn_off;     aux[seg_count + 3].size = dyn_size;     aux[seg_count + 3].link = i_dynstr; aux[seg_count + 3].info = 0; aux[seg_count + 3].entsize = DYN_SIZE;
 
     # a section-header table trails the whole image, outside every PT_LOAD, when the
     # object carries debug sections (a -g build); it names the debug sections and the
-    # allocated dynamic sections above. absent (and the image byte-identical) with no
-    # debug input.
+    # allocated sections above. absent (and the image byte-identical) with no debug input.
     var dsht: DebugSht;
-    val dp: R.Result[DebugSht, str] = debug_sht_plan(alloc, itn, debug, debug_count, ?aux[0], 4, struct_total);
+    val dp: R.Result[DebugSht, str] = debug_sht_plan(alloc, itn, debug, debug_count, aux, aux_count, struct_total);
     if (R.is_err[DebugSht, str](dp)) {
+        A.deallocate[ShtAlloc](alloc, aux, aux_count::usize);
         if (exp_str != nil)     { A.deallocate[usize](alloc, exp_str, nexp::usize); }
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         ret R.err[bool, str](R.unwrap_err[DebugSht, str](dp));
@@ -2350,7 +2381,8 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
 
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
     if (R.is_err[*u8, str](res_buf)) {
-        debug_sht_free(alloc, ?dsht, debug_count, 4);
+        debug_sht_free(alloc, ?dsht, debug_count, aux_count);
+        A.deallocate[ShtAlloc](alloc, aux, aux_count::usize);
         if (exp_str != nil)     { A.deallocate[usize](alloc, exp_str, nexp::usize); }
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         ret R.err[bool, str]("elf: shared buffer alloc failed");
@@ -2358,7 +2390,7 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
     var buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
 
     # ELF header: ET_DYN, no entry point. e_shoff/e_shnum/e_shstrndx name the trailing
-    # debug table when present, else 0 (a bare runtime image).
+    # section table on a -g build, else 0 (a program-headers-only release image).
     buf[0] = 0x7F; buf[1] = 0x45; buf[2] = 0x4C; buf[3] = 0x46;
     buf[4] = elf_class_for(tgt_isa); buf[5] = ELFDATA2LSB; buf[6] = EV_CURRENT; buf[7] = ELFOSABI_NONE;
     bin.write_u16_le(buf, 16, ET_DYN);
@@ -2402,18 +2434,29 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
     }
 
     # .dynsym: index 0 is the reserved null entry (already zeroed). each export is a
-    # GLOBAL/defined symbol: st_value the link-time vaddr the loader biases, st_shndx a
-    # non-special "defined" marker (this file has no allocated section table; the loader
-    # resolves the export by value, never by section header).
+    # GLOBAL/defined symbol: st_value the link-time vaddr the loader biases, st_shndx
+    # the SHT index of its containing load segment (segment i is SHT section i + 1).
+    # the loader tests st_shndx only against SHN_UNDEF, so this value works whether or
+    # not a section table is present (a release .so has none); when the table IS
+    # present (-g), it resolves a function export to its .text section (objdump: T).
+    # every defined export lies in a load segment, so the scan always matches; the 1
+    # initializer is a defined marker for the degenerate no-segment case.
     var sym_off: usize = dynsym_off + SYM_SIZE;
     e = 0;
     for (e < nexp) {
         var st_type: u8 = STT_OBJECT;
         if (exports[e].is_func) { st_type = STT_FUNC; }
+        var shndx: u16 = 1;
+        var sgi: u32 = 0;
+        for (sgi < seg_count) {
+            val sv: u64 = segs[sgi].vaddr;
+            if (exports[e].vaddr >= sv && exports[e].vaddr < sv + segs[sgi].memsz::u64) { shndx = (sgi + 1)::u16; }
+            sgi = sgi + 1;
+        }
         bin.write_u32_le(buf, sym_off, exp_str[e]::u32);
         buf[sym_off + 4] = (STB_GLOBAL << 4) | (st_type & 0xF);
         buf[sym_off + 5] = 0;
-        bin.write_u16_le(buf, sym_off + 6, 1);
+        bin.write_u16_le(buf, sym_off + 6, shndx);
         bin.write_u64_le(buf, sym_off + 8, exports[e].vaddr);
         bin.write_u64_le(buf, sym_off + 16, 0);
         sym_off = sym_off + SYM_SIZE;
@@ -2473,9 +2516,10 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
     write_pie_phdrs(buf, phdr_offset, phdr_count, segs, seg_offsets, seg_count,
                     ro_off, ro_va, ro_size, dyn_off, dyn_va, dyn_size, dyn, page_size, true);
 
-    debug_sht_write(buf, itn, debug, debug_count, ?aux[0], 4, ?dsht);
-    debug_sht_free(alloc, ?dsht, debug_count, 4);
+    debug_sht_write(buf, itn, debug, debug_count, aux, aux_count, ?dsht);
+    debug_sht_free(alloc, ?dsht, debug_count, aux_count);
 
+    A.deallocate[ShtAlloc](alloc, aux, aux_count::usize);
     if (exp_str != nil)     { A.deallocate[usize](alloc, exp_str, nexp::usize); }
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
@@ -5791,6 +5835,21 @@ test "mach.lang.target.of.elf.emit_shared:dynamic_sections_in_sht" {
         or {
             val lho: usize = e_shoff + link::usize * SHDR_SIZE;
             if (bin.read_u32_le(buf.data, lho + 4) != SHT_STRTAB) { bad = true; }
+        }
+
+        # the first export (a function) resolves through its st_shndx to a section
+        # that is PROGBITS + SHF_ALLOC + SHF_EXECINSTR - the .text it lives in, the
+        # byte-level statement of `objdump -T` showing it as type T.
+        val dynsym_off: usize = bin.read_u64_le(buf.data, dynsym_hdr + 24)::usize;
+        val shndx: u32 = bin.read_u16_le(buf.data, dynsym_off + SYM_SIZE + 6)::u32;
+        if (shndx == 0 || shndx >= e_shnum) { bad = true; }
+        or {
+            val tho: usize = e_shoff + shndx::usize * SHDR_SIZE;
+            val tty: u32 = bin.read_u32_le(buf.data, tho + 4);
+            val tfl: u64 = bin.read_u64_le(buf.data, tho + 8);
+            if (tty != SHT_PROGBITS)             { bad = true; }
+            if ((tfl & SHF_ALLOC) == 0)          { bad = true; }
+            if ((tfl & SHF_EXECINSTR) == 0)      { bad = true; }
         }
     }
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -5705,3 +5705,95 @@ test "mach.lang.target.of.elf.emit_shared:debug_additive_nonloaded" {
     if (bad) { ret 1; }
     ret 0;
 }
+
+# a -g shared object's trailing section-header table names its allocated dynamic
+# sections (.dynsym/.dynstr/.hash/.dynamic), so tooling that reads sections finds
+# the exports instead of an empty result. asserts a SHT_DYNSYM entry sized to the
+# export set, linked to a SHT_STRTAB, and a SHT_DYNAMIC entry. falsifies a writer
+# that lists only debug sections (the pre-fix lie of omission).
+test "mach.lang.target.of.elf.emit_shared:dynamic_sections_in_sht" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id            = isa.ARCH_X86_64;
+    isa_vt.elf_machine   = 62;
+    isa_vt.pointer_width = 8;
+
+    var text: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text[k] = 0x90; k = k + 1; }
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = 0x401000; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text[0];
+
+    val add_r: R.Result[intern.StrId, str] = intern.intern(?i, "add_fn");
+    val mul_r: R.Result[intern.StrId, str] = intern.intern(?i, "mul_fn");
+    if (R.is_err[intern.StrId, str](add_r) || R.is_err[intern.StrId, str](mul_r)) { ret 1; }
+    var exports: [2]of.ExportSym;
+    exports[0].name = R.unwrap_ok[intern.StrId, str](add_r); exports[0].vaddr = 0x401000; exports[0].is_func = true;
+    exports[1].name = R.unwrap_ok[intern.StrId, str](mul_r); exports[1].vaddr = 0x401008; exports[1].is_func = true;
+
+    var dyn: of.DynamicInfo;
+    dyn.libs = nil;          dyn.lib_count = 0;
+    dyn.imports = nil;       dyn.import_count = 0;
+    dyn.interp = intern.STR_NIL;
+    dyn.base_relocs = nil;   dyn.base_reloc_count = 0;
+    dyn.pie = true;
+
+    var info_bytes: [4]u8;
+    info_bytes[0] = 0xDE; info_bytes[1] = 0xAD; info_bytes[2] = 0xBE; info_bytes[3] = 0xEF;
+    val nm_info: R.Result[intern.StrId, str] = intern.intern(?i, ".debug_info");
+    if (R.is_err[intern.StrId, str](nm_info)) { ret 1; }
+    var dbg: [1]of.Section;
+    dbg[0].name = R.unwrap_ok[intern.StrId, str](nm_info); dbg[0].kind = of.SK_DEBUG;
+    dbg[0].bytes = ?info_bytes[0]; dbg[0].len = 4; dbg[0].align = 1;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "elf_shared_sht");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tp: str = filesystem.temp_path(?tf);
+    val em: R.Result[bool, str] = emit_shared(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, ?exports[0], 2, ?dyn, ?dbg[0], 1, tp::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+    val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tp);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
+    val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
+
+    var bad: bool = false;
+
+    # walk the section headers for SHT_DYNSYM and SHT_DYNAMIC.
+    val e_shoff:  usize = bin.read_u64_le(buf.data, 40)::usize;
+    val e_shnum:  u32   = bin.read_u16_le(buf.data, 60)::u32;
+    if (e_shoff == 0 || e_shnum == 0) { ret 1; }
+
+    var dynsym_hdr: usize = 0;
+    var have_dynamic: bool = false;
+    var sh: u32 = 0;
+    for (sh < e_shnum) {
+        val so: usize = e_shoff + sh::usize * SHDR_SIZE;
+        val ty: u32 = bin.read_u32_le(buf.data, so + 4);
+        if (ty == SHT_DYNSYM)  { dynsym_hdr = so; }
+        if (ty == SHT_DYNAMIC) { have_dynamic = true; }
+        sh = sh + 1;
+    }
+    if (dynsym_hdr == 0) { bad = true; }
+    if (!have_dynamic)   { bad = true; }
+
+    if (dynsym_hdr != 0) {
+        # the .dynsym is SHF_ALLOC, sized to null + 2 exports, and sh_link names a
+        # SHT_STRTAB section (its .dynstr).
+        if ((bin.read_u64_le(buf.data, dynsym_hdr + 8) & SHF_ALLOC) == 0)     { bad = true; }
+        if (bin.read_u64_le(buf.data, dynsym_hdr + 32)::usize != 3 * SYM_SIZE) { bad = true; }
+        val link: u32 = bin.read_u32_le(buf.data, dynsym_hdr + 40);
+        if (link == 0 || link >= e_shnum) { bad = true; }
+        or {
+            val lho: usize = e_shoff + link::usize * SHDR_SIZE;
+            if (bin.read_u32_le(buf.data, lho + 4) != SHT_STRTAB) { bad = true; }
+        }
+    }
+
+    if (bad) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -61,7 +61,10 @@ val SHT_PROGBITS: u32 = 1;
 val SHT_SYMTAB:   u32 = 2;
 val SHT_STRTAB:   u32 = 3;
 val SHT_RELA:     u32 = 4;
+val SHT_HASH:     u32 = 5;
+val SHT_DYNAMIC:  u32 = 6;
 val SHT_NOBITS:   u32 = 8;
+val SHT_DYNSYM:   u32 = 11;
 
 # the RISC-V build-attributes section type (SHT_LOPROC + 3). pub so the riscv64
 # ISA's `BuildAttributes` descriptor names it; the writer reads the type off the
@@ -1545,19 +1548,52 @@ fun header_fits_reserved_page(phdr_count: u32, page_size: u64) bool {
     ret ELF_HEADER_SIZE + phdr_count::usize * PHDR_SIZE <= page_size::usize;
 }
 
-# the file layout of a minimal debug-only section-header table appended to a runtime
-# (ET_DYN / dynamic) image so its non-allocated debug sections are named and located
-# for a debugger. the PIE and dynamic writers otherwise emit no section headers; this
-# table is null + one non-alloc PROGBITS per debug section + `.shstrtab`, all trailing
-# the image outside every PT_LOAD. `present` is false (and the table absent) when there
-# are no debug sections, leaving the image byte-identical
+# one already-emitted allocated section (its body lives in a load segment) to name
+# and locate in the trailing section-header table, so tooling that reads sections
+# (`nm -D`, `objdump -T`) can find the dynamic tables a shared object publishes
+#
+# Only the header + name are added - never the body, which the writer placed in the
+# loadable image. `link` is the section's SHT index of a cross-referenced section
+# (e.g. a `.dynsym`'s `.dynstr`), which the caller resolves knowing the aux ordering.
 # ---
-# present:         true when the image carries a debug section-header table
+# name:    section name (e.g. ".dynsym")
+# sh_type: SHT_* kind
+# flags:   SHF_* (SHF_ALLOC, since the body is loaded)
+# addr:    virtual address of the body
+# off:     file offset of the body
+# size:    byte length of the body
+# link:    sh_link (a section index), or 0
+# info:    sh_info
+# entsize: fixed entry size, or 0
+rec ShtAlloc {
+    name:    str;
+    sh_type: u32;
+    flags:   u64;
+    addr:    u64;
+    off:     usize;
+    size:    usize;
+    link:    u32;
+    info:    u32;
+    entsize: usize;
+}
+
+# the file layout of a section-header table appended to a runtime (ET_DYN /
+# dynamic) image so its non-allocated debug sections - and, for a shared object,
+# its allocated dynamic sections - are named and located for tooling. the PIE and
+# dynamic writers otherwise emit no section headers; this table is null + one
+# header per aux (allocated) section + one non-alloc PROGBITS per debug section +
+# `.shstrtab`, all trailing the image outside every PT_LOAD. `present` is false (and
+# the table absent) when there are no debug sections - so a release image (no debug)
+# stays section-header-less and byte-identical, and the aux sections only appear on a
+# `-g` build where the table already exists
+# ---
+# present:         true when the image carries a section-header table
 # shdr_off:        file offset of the section-header table (the ELF header's e_shoff)
-# sht_count:       number of section headers (e_shnum): debug_count + null + .shstrtab
+# sht_count:       number of section headers (e_shnum): null + aux + debug + .shstrtab
 # shstrndx:        index of the .shstrtab section (e_shstrndx)
 # debug_offs:      file offset of each debug section's bytes (length debug_count)
 # debug_name_rels: each debug name's offset within .shstrtab (length debug_count)
+# aux_name_rels:   each aux section name's offset within .shstrtab (length aux_count)
 # shstr_off:       file offset of the .shstrtab bytes
 # shstr_sz:        byte length of .shstrtab
 # shstr_name_rel:  the ".shstrtab" name's offset within .shstrtab
@@ -1569,29 +1605,35 @@ rec DebugSht {
     shstrndx:        u32;
     debug_offs:      *usize;
     debug_name_rels: *usize;
+    aux_name_rels:   *usize;
     shstr_off:       usize;
     shstr_sz:        usize;
     shstr_name_rel:  usize;
     added:           usize;
 }
 
-# plan the debug section-header table starting at file offset `base` (past all of the
+# plan the section-header table starting at file offset `base` (past all of the
 # image's loadable content). allocates the per-section offset arrays on success; the
 # caller frees them through `debug_sht_free`. with no debug sections it returns an
-# empty (`present == false`) plan and allocates nothing
+# empty (`present == false`) plan and allocates nothing - so a release image stays
+# section-header-less and the aux sections never appear alone. the aux (allocated)
+# sections contribute a header and a name each but no bytes (their bodies already
+# live in a load segment)
 # ---
 # alloc:       allocator backing the plan's offset arrays
 # itn:         interner resolving the debug section names (non-nil when count > 0)
 # debug:       the non-allocated debug sections
 # debug_count: number of debug sections
-# base:        file offset where the debug table begins
+# aux:         the already-emitted allocated sections to also name/locate, or nil
+# aux_count:   number of aux sections (0 for the executable writers)
+# base:        file offset where the table begins
 # ret:         the layout plan, or an allocation error
 fun debug_sht_plan(alloc: *A.Allocator, itn: *intern.Interner, debug: *of.Section, debug_count: u32,
-                   base: usize) R.Result[DebugSht, str] {
+                   aux: *ShtAlloc, aux_count: u32, base: usize) R.Result[DebugSht, str] {
     var p: DebugSht;
     p.present = false;
     p.shdr_off = 0; p.sht_count = 0; p.shstrndx = 0;
-    p.debug_offs = nil; p.debug_name_rels = nil;
+    p.debug_offs = nil; p.debug_name_rels = nil; p.aux_name_rels = nil;
     p.shstr_off = 0; p.shstr_sz = 0; p.shstr_name_rel = 0; p.added = 0;
     if (debug_count == 0) { ret R.ok[DebugSht, str](p); }
 
@@ -1604,6 +1646,15 @@ fun debug_sht_plan(alloc: *A.Allocator, itn: *intern.Interner, debug: *of.Sectio
         ret R.err[DebugSht, str](R.unwrap_err[*usize, str](nro));
     }
     p.debug_name_rels = R.unwrap_ok[*usize, str](nro);
+    if (aux_count > 0) {
+        val aro: R.Result[*usize, str] = A.zallocate[usize](alloc, aux_count::usize);
+        if (R.is_err[*usize, str](aro)) {
+            A.deallocate[usize](alloc, p.debug_offs, debug_count::usize);
+            A.deallocate[usize](alloc, p.debug_name_rels, debug_count::usize);
+            ret R.err[DebugSht, str](R.unwrap_err[*usize, str](aro));
+        }
+        p.aux_name_rels = R.unwrap_ok[*usize, str](aro);
+    }
 
     var off: usize = base;
     var di: u32 = 0;
@@ -1616,6 +1667,8 @@ fun debug_sht_plan(alloc: *A.Allocator, itn: *intern.Interner, debug: *of.Sectio
         di = di + 1;
     }
 
+    # .shstrtab: NUL, each debug name, each aux name, then ".shstrtab". the debug
+    # names lead (unchanged from the aux-free layout the executable writers use).
     p.shstr_off = off;
     var sz: usize = 1;
     di = 0;
@@ -1624,29 +1677,40 @@ fun debug_sht_plan(alloc: *A.Allocator, itn: *intern.Interner, debug: *of.Sectio
         sz = sz + str_len(resolve(itn, debug[di].name)) + 1;
         di = di + 1;
     }
+    var ai: u32 = 0;
+    for (ai < aux_count) {
+        p.aux_name_rels[ai] = sz;
+        sz = sz + str_len(aux[ai].name) + 1;
+        ai = ai + 1;
+    }
     p.shstr_name_rel = sz;
     sz = sz + str_len(".shstrtab") + 1;
     p.shstr_sz = sz;
     off = off + sz;
 
     p.shdr_off = bin.align_up(off, 8);
-    p.sht_count = debug_count + 2;
-    p.shstrndx = debug_count + 1;
+    p.sht_count = 1 + aux_count + debug_count + 1;
+    p.shstrndx = p.sht_count - 1;
     p.present = true;
     p.added = (p.shdr_off + SHDR_SIZE * p.sht_count::usize) - base;
     ret R.ok[DebugSht, str](p);
 }
 
-# write the planned debug section-header table into `buf`: the debug section bytes,
-# the `.shstrtab`, and the section headers (null, one non-alloc PROGBITS per debug
-# section, then `.shstrtab`). a no-op when the plan is absent
+# write the planned section-header table into `buf`: the debug section bytes, the
+# `.shstrtab`, and the section headers (null, one SHF_ALLOC header per aux section,
+# one non-alloc PROGBITS per debug section, then `.shstrtab`). a no-op when the plan
+# is absent. the aux headers point at bodies the writer already placed in a load
+# segment; only their headers and names are written here
 # ---
 # buf:         the output buffer (sized to include the plan)
 # itn:         interner resolving the debug section names
 # debug:       the non-allocated debug sections
 # debug_count: number of debug sections
+# aux:         the already-emitted allocated sections to name/locate, or nil
+# aux_count:   number of aux sections (0 for the executable writers)
 # p:           the layout plan from debug_sht_plan
-fun debug_sht_write(buf: *u8, itn: *intern.Interner, debug: *of.Section, debug_count: u32, p: *DebugSht) {
+fun debug_sht_write(buf: *u8, itn: *intern.Interner, debug: *of.Section, debug_count: u32,
+                    aux: *ShtAlloc, aux_count: u32, p: *DebugSht) {
     if (!p.present) { ret; }
 
     var di: u32 = 0;
@@ -1664,11 +1728,31 @@ fun debug_sht_write(buf: *u8, itn: *intern.Interner, debug: *of.Section, debug_c
         np = np + bin.write_str(buf, p.shstr_off + np, resolve(itn, debug[di].name));
         di = di + 1;
     }
+    var ai: u32 = 0;
+    for (ai < aux_count) {
+        np = np + bin.write_str(buf, p.shstr_off + np, aux[ai].name);
+        ai = ai + 1;
+    }
     bin.write_str(buf, p.shstr_off + np, ".shstrtab");
 
-    # [0] reserved null (already zeroed), one non-alloc PROGBITS per debug section
-    # (no SHF_ALLOC, address 0, own file bytes), then .shstrtab.
+    # [0] reserved null (already zeroed), one SHF_ALLOC header per aux section (its
+    # body already loaded), one non-alloc PROGBITS per debug section, then .shstrtab.
     var hp: usize = p.shdr_off + SHDR_SIZE;
+    ai = 0;
+    for (ai < aux_count) {
+        bin.write_u32_le(buf, hp, p.aux_name_rels[ai]::u32);
+        bin.write_u32_le(buf, hp + 4, aux[ai].sh_type);
+        bin.write_u64_le(buf, hp + 8, aux[ai].flags);
+        bin.write_u64_le(buf, hp + 16, aux[ai].addr);
+        bin.write_u64_le(buf, hp + 24, aux[ai].off::u64);
+        bin.write_u64_le(buf, hp + 32, aux[ai].size::u64);
+        bin.write_u32_le(buf, hp + 40, aux[ai].link);
+        bin.write_u32_le(buf, hp + 44, aux[ai].info);
+        bin.write_u64_le(buf, hp + 48, 8);
+        bin.write_u64_le(buf, hp + 56, aux[ai].entsize::u64);
+        hp = hp + SHDR_SIZE;
+        ai = ai + 1;
+    }
     di = 0;
     for (di < debug_count) {
         var da: u32 = debug[di].align;
@@ -1703,12 +1787,15 @@ fun debug_sht_write(buf: *u8, itn: *intern.Interner, debug: *of.Section, debug_c
 # ---
 # alloc:       allocator the arrays were allocated from
 # p:           the plan whose arrays are released
-# debug_count: number of debug sections (the arrays' length)
-fun debug_sht_free(alloc: *A.Allocator, p: *DebugSht, debug_count: u32) {
+# debug_count: number of debug sections (the debug arrays' length)
+# aux_count:   number of aux sections (the aux array's length)
+fun debug_sht_free(alloc: *A.Allocator, p: *DebugSht, debug_count: u32, aux_count: u32) {
     if (p.debug_offs != nil)      { A.deallocate[usize](alloc, p.debug_offs, debug_count::usize); }
     if (p.debug_name_rels != nil) { A.deallocate[usize](alloc, p.debug_name_rels, debug_count::usize); }
+    if (p.aux_name_rels != nil)   { A.deallocate[usize](alloc, p.aux_name_rels, aux_count::usize); }
     p.debug_offs = nil;
     p.debug_name_rels = nil;
+    p.aux_name_rels = nil;
 }
 
 # write a position-independent (PIE / ET_DYN) static executable for linux ASLR
@@ -1823,7 +1910,7 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     # trails the whole image (past the RO structures), outside every PT_LOAD; the
     # runtime image is unchanged and the file stays section-header-less when absent.
     var dsht: DebugSht;
-    val dp: R.Result[DebugSht, str] = debug_sht_plan(alloc, itn, debug, debug_count, struct_total);
+    val dp: R.Result[DebugSht, str] = debug_sht_plan(alloc, itn, debug, debug_count, nil::*ShtAlloc, 0, struct_total);
     if (R.is_err[DebugSht, str](dp)) {
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         ret R.err[bool, str](R.unwrap_err[DebugSht, str](dp));
@@ -1833,7 +1920,7 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
     if (R.is_err[*u8, str](res_buf)) {
-        debug_sht_free(alloc, ?dsht, debug_count);
+        debug_sht_free(alloc, ?dsht, debug_count, 0);
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         ret R.err[bool, str]("elf: pie buffer alloc failed");
     }
@@ -1900,8 +1987,8 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     write_pie_phdrs(buf, phdr_offset, phdr_count, segs, seg_offsets, seg_count,
                     ro_off, ro_va, ro_size, dyn_off, dyn_va, dyn_size, dyn, page_size, false);
 
-    debug_sht_write(buf, itn, debug, debug_count, ?dsht);
-    debug_sht_free(alloc, ?dsht, debug_count);
+    debug_sht_write(buf, itn, debug, debug_count, nil::*ShtAlloc, 0, ?dsht);
+    debug_sht_free(alloc, ?dsht, debug_count, 0);
 
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
@@ -2229,10 +2316,30 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
     val struct_total: usize = dyn_off + dyn_size;
     val ro_size: usize = struct_total - ro_off;
 
-    # a debugger-facing section-header table for the non-allocated debug sections
-    # trails the whole image, outside every PT_LOAD; absent when there is no debug input.
+    # the allocated dynamic sections, named/located in the trailing section-header
+    # table so `nm -D` / `objdump -T` (which read sections when a table is present)
+    # see the exports instead of an empty result. their bodies already live in the RO
+    # load segment; only headers + names are added, and only on a -g build (the table
+    # exists solely to carry the debug sections). `link` is the aux section's SHT
+    # index of its cross-referenced section: aux[0..3] land at SHT indices 1..4, so
+    # .dynsym/.dynamic link .dynstr (2) and .hash links .dynsym (1). the release .so
+    # has no debug sections, so no table and no aux headers - it stays byte-identical.
+    var aux: [4]ShtAlloc;
+    aux[0].name = ".dynsym";  aux[0].sh_type = SHT_DYNSYM;  aux[0].flags = SHF_ALLOC;
+    aux[0].addr = dynsym_va;  aux[0].off = dynsym_off;  aux[0].size = dynsym_size;  aux[0].link = 2; aux[0].info = 1; aux[0].entsize = SYM_SIZE;
+    aux[1].name = ".dynstr";  aux[1].sh_type = SHT_STRTAB;  aux[1].flags = SHF_ALLOC;
+    aux[1].addr = dynstr_va;  aux[1].off = dynstr_off;  aux[1].size = dynstr_size;  aux[1].link = 0; aux[1].info = 0; aux[1].entsize = 0;
+    aux[2].name = ".hash";    aux[2].sh_type = SHT_HASH;    aux[2].flags = SHF_ALLOC;
+    aux[2].addr = hash_va;    aux[2].off = hash_off;    aux[2].size = hash_size;    aux[2].link = 1; aux[2].info = 0; aux[2].entsize = 4;
+    aux[3].name = ".dynamic"; aux[3].sh_type = SHT_DYNAMIC; aux[3].flags = SHF_ALLOC;
+    aux[3].addr = dyn_va;     aux[3].off = dyn_off;     aux[3].size = dyn_size;     aux[3].link = 2; aux[3].info = 0; aux[3].entsize = DYN_SIZE;
+
+    # a section-header table trails the whole image, outside every PT_LOAD, when the
+    # object carries debug sections (a -g build); it names the debug sections and the
+    # allocated dynamic sections above. absent (and the image byte-identical) with no
+    # debug input.
     var dsht: DebugSht;
-    val dp: R.Result[DebugSht, str] = debug_sht_plan(alloc, itn, debug, debug_count, struct_total);
+    val dp: R.Result[DebugSht, str] = debug_sht_plan(alloc, itn, debug, debug_count, ?aux[0], 4, struct_total);
     if (R.is_err[DebugSht, str](dp)) {
         if (exp_str != nil)     { A.deallocate[usize](alloc, exp_str, nexp::usize); }
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
@@ -2243,7 +2350,7 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
 
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
     if (R.is_err[*u8, str](res_buf)) {
-        debug_sht_free(alloc, ?dsht, debug_count);
+        debug_sht_free(alloc, ?dsht, debug_count, 4);
         if (exp_str != nil)     { A.deallocate[usize](alloc, exp_str, nexp::usize); }
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         ret R.err[bool, str]("elf: shared buffer alloc failed");
@@ -2366,8 +2473,8 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
     write_pie_phdrs(buf, phdr_offset, phdr_count, segs, seg_offsets, seg_count,
                     ro_off, ro_va, ro_size, dyn_off, dyn_va, dyn_size, dyn, page_size, true);
 
-    debug_sht_write(buf, itn, debug, debug_count, ?dsht);
-    debug_sht_free(alloc, ?dsht, debug_count);
+    debug_sht_write(buf, itn, debug, debug_count, ?aux[0], 4, ?dsht);
+    debug_sht_free(alloc, ?dsht, debug_count, 4);
 
     if (exp_str != nil)     { A.deallocate[usize](alloc, exp_str, nexp::usize); }
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
@@ -2650,7 +2757,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     # trails the whole image, outside every PT_LOAD; absent (and the file stays
     # section-header-less) when there are no debug sections.
     var dsht: DebugSht;
-    val dp: R.Result[DebugSht, str] = debug_sht_plan(alloc, itn, debug, debug_count, struct_total);
+    val dp: R.Result[DebugSht, str] = debug_sht_plan(alloc, itn, debug, debug_count, nil::*ShtAlloc, 0, struct_total);
     if (R.is_err[DebugSht, str](dp)) {
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         ret R.err[bool, str](R.unwrap_err[DebugSht, str](dp));
@@ -2660,7 +2767,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
     if (R.is_err[*u8, str](res_buf)) {
-        debug_sht_free(alloc, ?dsht, debug_count);
+        debug_sht_free(alloc, ?dsht, debug_count, 0);
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         ret R.err[bool, str]("elf: dyn-exec buffer alloc failed");
     }
@@ -2708,7 +2815,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     if (dyn.import_count > 0) {
         val ri: R.Result[*usize, str] = A.zallocate[usize](alloc, dyn.import_count::usize);
         if (R.is_err[*usize, str](ri)) {
-            debug_sht_free(alloc, ?dsht, debug_count);
+            debug_sht_free(alloc, ?dsht, debug_count, 0);
             if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
             A.deallocate[u8](alloc, buf, total_size);
             ret R.err[bool, str]("elf: dyn-exec import-name table alloc failed");
@@ -2719,7 +2826,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     if (dyn.lib_count > 0) {
         val rl: R.Result[*usize, str] = A.zallocate[usize](alloc, dyn.lib_count::usize);
         if (R.is_err[*usize, str](rl)) {
-            debug_sht_free(alloc, ?dsht, debug_count);
+            debug_sht_free(alloc, ?dsht, debug_count, 0);
             if (imp_str != nil)     { A.deallocate[usize](alloc, imp_str, dyn.import_count::usize); }
             if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
             A.deallocate[u8](alloc, buf, total_size);
@@ -2738,7 +2845,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 
     # an out-of-range call-site fixup fails the link rather than corrupting bytes.
     if (R.is_err[bool, str](fx_r)) {
-        debug_sht_free(alloc, ?dsht, debug_count);
+        debug_sht_free(alloc, ?dsht, debug_count, 0);
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         A.deallocate[u8](alloc, buf, total_size);
         ret R.err[bool, str](R.unwrap_err[bool, str](fx_r));
@@ -2748,8 +2855,8 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     # segments, the RO/PLT/RW synthesized segments, then PT_DYNAMIC.
     write_dyn_phdrs(buf, phdr_offset, ?lay, segs, seg_offsets, seg_count, page_size);
 
-    debug_sht_write(buf, itn, debug, debug_count, ?dsht);
-    debug_sht_free(alloc, ?dsht, debug_count);
+    debug_sht_write(buf, itn, debug, debug_count, nil::*ShtAlloc, 0, ?dsht);
+    debug_sht_free(alloc, ?dsht, debug_count, 0);
 
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -174,6 +174,7 @@ val DT_PLTGOT:   u64 = 3;
 val DT_HASH:     u64 = 4;
 val DT_STRTAB:   u64 = 5;
 val DT_SYMTAB:   u64 = 6;
+val DT_SONAME:   u64 = 14;
 val DT_STRSZ:    u64 = 10;
 val DT_SYMENT:   u64 = 11;
 val DT_RELA:     u64 = 7;
@@ -1121,6 +1122,7 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     elf_vtable.parse_object   = parse_object;
     elf_vtable.emit_exec      = emit_exec;
     elf_vtable.emit_dyn_exec  = emit_dyn_exec;
+    elf_vtable.emit_shared    = emit_shared;
 
     # ELF has a flat global namespace: an unattributed import is resolved by the
     # loader's global search, so no per-import library attribution is required.
@@ -2048,6 +2050,322 @@ fun pie_seg_flags(segs: *of.LoadSegment, li: u32, seg_count: u32, dyn: *of.Dynam
     val f: u32 = pf_flags_for(segs[li].flags);
     if (seg_has_base_reloc(dyn, li, seg_count)) { ret f | PF_W; }
     ret f;
+}
+
+# the basename of a null-terminated path (the text after the last '/'), as a str
+#
+# The shared object names itself by its own file: `DT_SONAME` is the output path's
+# basename, so a consumer that links the `.so` records the matching `DT_NEEDED`.
+# ---
+# path: the null-terminated output path
+# ret:  a str aliasing the path's basename (null-terminated, since it is a suffix)
+fun so_basename(path: *u8) str {
+    val n: usize = str_len(path::str);
+    var last: usize = 0;
+    var i: usize = 0;
+    for (i < n) {
+        if (path[i] == '/') { last = i + 1; }
+        i = i + 1;
+    }
+    ret ((path::usize + last)::*u8)::str;
+}
+
+# write a shared object (ET_DYN) that exports its defined globals, installed in the
+# ELF `of.OfVTable` as its `of.SharedFn`
+#
+# A shared object is a position-independent ET_DYN image the loader maps at an
+# arbitrary base. Like the static-PIE writer it carries its in-image absolute
+# pointers as `R_*_RELATIVE` entries in a synthesized `.rela.dyn` (the loader
+# slides them by the load bias), and shares the identical program-header layout
+# (`write_pie_phdrs`): no PT_INTERP, the first segment extended down to cover the
+# ELF header, one read-only PT_LOAD for the synthesized structures, a PT_DYNAMIC,
+# and a PT_GNU_RELRO over any reloc-bearing read-only segment. Unlike an executable
+# it has no entry point and publishes an EXPORT table instead of imports: a
+# `.dynsym` of GLOBAL/defined entries (`st_value` the symbol's link-time vaddr,
+# `st_shndx` a defined marker) reachable through a single-bucket SysV `.hash`, and
+# a `.dynamic` naming the object with `DT_SONAME` (the output basename) so a
+# consumer resolves its imports against these symbols at load. The exported
+# symbols carry no allocated section-header index - like every mach image this
+# file is program-headers-only, and the dynamic loader resolves an export by its
+# `.dynsym` value, never by a section header - so `st_shndx` is a non-special
+# "defined" marker (1) that makes the loader add the load bias to `st_value`.
+#
+# P2a scope is self-contained shared objects: exports and base relocations, no
+# dynamic imports of other libraries (those need the PLT/GOT machinery `emit_dyn_exec`
+# carries and are a later phase). An undefined `ext` symbol therefore still fails
+# the link in `patch_relocations`, exactly as a static-PIE does.
+# ---
+# alloc:        allocator for the output buffer and the layout scratch
+# itn:          interner backing the exported names and any I/O error message
+# tgt_isa:      the instruction-set vtable selecting the ELF machine + RELATIVE type
+# segs:         the linker's loadable segments, ascending virtual-address order
+# seg_count:    number of segments
+# page_size:    the segment-alignment page (p_align, header reservation, offset congruence)
+# exports:      the defined globals to publish (or nil when export_count is 0)
+# export_count: number of exported symbols
+# dyn:          the dynamic-link plan carrying the base-relocation set
+# debug:        non-allocated debug sections to frame in a trailing section table
+# debug_count:  number of debug sections
+# path:         null-terminated output file path (its basename is the DT_SONAME)
+# ret:          ok(true) on success, or an error string
+fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable,
+                segs: *of.LoadSegment, seg_count: u32, page_size: u64,
+                exports: *of.ExportSym, export_count: u32, dyn: *of.DynamicInfo,
+                debug: *of.Section, debug_count: u32, path: *u8) R.Result[bool, str] {
+    if (tgt_isa == nil) { ret R.err[bool, str]("elf: nil shared isa"); }
+    if (path == nil)    { ret R.err[bool, str]("elf: nil shared path"); }
+    if (itn == nil)     { ret R.err[bool, str]("elf: no interner for shared object"); }
+
+    val nrel: u32 = dyn.base_reloc_count;
+    val nexp: u32 = export_count;
+
+    # the highest virtual address the linker's segments reach; the synthesized
+    # export/dynamic structures are placed page-aligned above it.
+    var hi_va: u64 = 0;
+    var li: u32 = 0;
+    for (li < seg_count) {
+        val end: u64 = segs[li].vaddr + segs[li].memsz::u64;
+        if (end > hi_va) { hi_va = end; }
+        li = li + 1;
+    }
+
+    # program headers: PT_PHDR + one PT_LOAD per linker segment + the synthesized RO
+    # PT_LOAD + PT_DYNAMIC, plus a PT_GNU_RELRO when a read-only segment bears a base
+    # relocation. identical to the static-PIE writer (no PT_INTERP).
+    var relro_extra: u32 = 0;
+    if (pie_relro_seg(segs, seg_count, dyn) >= 0) { relro_extra = 1; }
+    val phdr_count: u32 = seg_count + 3 + relro_extra;
+
+    if (!header_fits_reserved_page(phdr_count, page_size)) {
+        ret R.err[bool, str]("elf: shared-object program headers exceed the one-page header reservation (too many load segments)");
+    }
+
+    val phdr_offset: usize = ELF_HEADER_SIZE;
+    val phdr_table_size: usize = phdr_count::usize * PHDR_SIZE;
+
+    # per-segment file offsets, page-aligned so `offset % page == vaddr % page` holds.
+    var struct_file: usize = bin.align_up(phdr_offset + phdr_table_size, page_size::usize);
+    var seg_offsets: *usize = nil;
+    if (seg_count > 0) {
+        val ro: R.Result[*usize, str] = A.zallocate[usize](alloc, seg_count::usize);
+        if (R.is_err[*usize, str](ro)) { ret R.err[bool, str]("elf: shared seg-offset alloc failed"); }
+        seg_offsets = R.unwrap_ok[*usize, str](ro);
+        li = 0;
+        for (li < seg_count) {
+            struct_file = bin.align_up(struct_file, page_size::usize);
+            seg_offsets[li] = struct_file;
+            struct_file = struct_file + segs[li].filesz;
+            li = li + 1;
+        }
+    }
+
+    # per-export .dynstr offset, computed while laying out .dynstr and reused by the
+    # .dynsym writer.
+    var exp_str: *usize = nil;
+    if (nexp > 0) {
+        val es: R.Result[*usize, str] = A.zallocate[usize](alloc, nexp::usize);
+        if (R.is_err[*usize, str](es)) {
+            if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+            ret R.err[bool, str]("elf: shared export-name table alloc failed");
+        }
+        exp_str = R.unwrap_ok[*usize, str](es);
+    }
+
+    # the synthesized read-only block, page-aligned above the linker segments:
+    # .dynsym, .dynstr, .hash, .rela.dyn, then .dynamic. file offset and vaddr
+    # advance in lockstep.
+    val ro_off: usize = bin.align_up(struct_file, page_size::usize);
+    val ro_va:  u64   = bin.align_up_u64(hi_va, page_size);
+
+    # .dynsym: index 0 reserved-null, then one GLOBAL/defined entry per export.
+    val dynsym_off: usize = ro_off;
+    val dynsym_va:  u64   = ro_va;
+    val dynsym_size: usize = (nexp + 1)::usize * SYM_SIZE;
+
+    # .dynstr: leading NUL, the soname, then each export name.
+    val dynstr_off: usize = dynsym_off + dynsym_size;
+    val dynstr_va:  u64   = dynsym_va + dynsym_size::u64;
+    val soname: str = so_basename(path);
+    var dynstr_size: usize = 1 + (str_len(soname) + 1);
+    var e: u32 = 0;
+    for (e < nexp) { dynstr_size = dynstr_size + dynstr_name_len(itn, exports[e].name); e = e + 1; }
+
+    # .hash: single-bucket SysV table (nbucket, nchain, bucket[1], chain[nchain]).
+    val hash_off: usize = bin.align_up(dynstr_off + dynstr_size, 8);
+    val hash_va:  u64   = bin.align_up_u64(dynstr_va + dynstr_size::u64, 8);
+    val nchain: usize = (nexp + 1)::usize;
+    val hash_size: usize = 8 + 4 + nchain * 4;
+
+    # .rela.dyn: one R_*_RELATIVE per in-image absolute pointer.
+    val reladyn_off: usize = bin.align_up(hash_off + hash_size, 8);
+    val reladyn_va:  u64   = bin.align_up_u64(hash_va + hash_size::u64, 8);
+    val reladyn_size: usize = nrel::usize * RELA_SIZE;
+
+    # .dynamic: SONAME/HASH/STRTAB/SYMTAB/STRSZ/SYMENT + (RELA tags when relocations) + DT_NULL.
+    val dyn_off: usize = bin.align_up(reladyn_off + reladyn_size, 8);
+    val dyn_va:  u64   = bin.align_up_u64(reladyn_va + reladyn_size::u64, 8);
+    var dyn_entries: u32 = 7;
+    if (nrel > 0) { dyn_entries = dyn_entries + 4; }
+    val dyn_size: usize = dyn_entries::usize * DYN_SIZE;
+
+    val struct_total: usize = dyn_off + dyn_size;
+    val ro_size: usize = struct_total - ro_off;
+
+    # a debugger-facing section-header table for the non-allocated debug sections
+    # trails the whole image, outside every PT_LOAD; absent when there is no debug input.
+    var dsht: DebugSht;
+    val dp: R.Result[DebugSht, str] = debug_sht_plan(alloc, itn, debug, debug_count, struct_total);
+    if (R.is_err[DebugSht, str](dp)) {
+        if (exp_str != nil)     { A.deallocate[usize](alloc, exp_str, nexp::usize); }
+        if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        ret R.err[bool, str](R.unwrap_err[DebugSht, str](dp));
+    }
+    dsht = R.unwrap_ok[DebugSht, str](dp);
+    val total_size: usize = struct_total + dsht.added;
+
+    val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
+    if (R.is_err[*u8, str](res_buf)) {
+        debug_sht_free(alloc, ?dsht, debug_count);
+        if (exp_str != nil)     { A.deallocate[usize](alloc, exp_str, nexp::usize); }
+        if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        ret R.err[bool, str]("elf: shared buffer alloc failed");
+    }
+    var buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+
+    # ELF header: ET_DYN, no entry point. e_shoff/e_shnum/e_shstrndx name the trailing
+    # debug table when present, else 0 (a bare runtime image).
+    buf[0] = 0x7F; buf[1] = 0x45; buf[2] = 0x4C; buf[3] = 0x46;
+    buf[4] = elf_class_for(tgt_isa); buf[5] = ELFDATA2LSB; buf[6] = EV_CURRENT; buf[7] = ELFOSABI_NONE;
+    bin.write_u16_le(buf, 16, ET_DYN);
+    bin.write_u16_le(buf, 18, tgt_isa.elf_machine::u16);
+    bin.write_u32_le(buf, 20, 1);
+    bin.write_u64_le(buf, 24, 0);
+    bin.write_u64_le(buf, 32, phdr_offset::u64);
+    if (dsht.present) { bin.write_u64_le(buf, 40, dsht.shdr_off::u64); } or { bin.write_u64_le(buf, 40, 0); }
+    bin.write_u32_le(buf, 48, 0);
+    bin.write_u16_le(buf, 52, ELF_HEADER_SIZE::u16);
+    bin.write_u16_le(buf, 54, PHDR_SIZE::u16);
+    bin.write_u16_le(buf, 56, phdr_count::u16);
+    bin.write_u16_le(buf, 58, SHDR_SIZE::u16);
+    if (dsht.present) {
+        bin.write_u16_le(buf, 60, dsht.sht_count::u16);
+        bin.write_u16_le(buf, 62, dsht.shstrndx::u16);
+    } or {
+        bin.write_u16_le(buf, 60, 0);
+        bin.write_u16_le(buf, 62, 0);
+    }
+
+    # copy the linker's segment bytes into their file offsets.
+    li = 0;
+    for (li < seg_count) {
+        if (segs[li].bytes != nil && segs[li].filesz > 0) {
+            memory.raw_copy((buf::usize + seg_offsets[li])::ptr, segs[li].bytes::ptr, segs[li].filesz);
+        }
+        li = li + 1;
+    }
+
+    # .dynstr: leading NUL, the soname, then each export name; record each offset.
+    buf[dynstr_off] = 0;
+    var str_pos: usize = 1;
+    val soname_off: usize = str_pos;
+    str_pos = str_pos + bin.write_str(buf, dynstr_off + str_pos, soname);
+    e = 0;
+    for (e < nexp) {
+        exp_str[e] = str_pos;
+        str_pos = str_pos + bin.write_str(buf, dynstr_off + str_pos, resolve(itn, exports[e].name));
+        e = e + 1;
+    }
+
+    # .dynsym: index 0 is the reserved null entry (already zeroed). each export is a
+    # GLOBAL/defined symbol: st_value the link-time vaddr the loader biases, st_shndx a
+    # non-special "defined" marker (this file has no allocated section table; the loader
+    # resolves the export by value, never by section header).
+    var sym_off: usize = dynsym_off + SYM_SIZE;
+    e = 0;
+    for (e < nexp) {
+        var st_type: u8 = STT_OBJECT;
+        if (exports[e].is_func) { st_type = STT_FUNC; }
+        bin.write_u32_le(buf, sym_off, exp_str[e]::u32);
+        buf[sym_off + 4] = (STB_GLOBAL << 4) | (st_type & 0xF);
+        buf[sym_off + 5] = 0;
+        bin.write_u16_le(buf, sym_off + 6, 1);
+        bin.write_u64_le(buf, sym_off + 8, exports[e].vaddr);
+        bin.write_u64_le(buf, sym_off + 16, 0);
+        sym_off = sym_off + SYM_SIZE;
+    }
+
+    # .hash: a single-bucket SysV table - bucket[0] points at dynsym index 1 and the
+    # chain links 1->2->...->n->0. with one bucket the loader walks the whole chain and
+    # matches each export by name, correct (if not fast) for these export sets.
+    bin.write_u32_le(buf, hash_off, 1);
+    bin.write_u32_le(buf, hash_off + 4, nchain::u32);
+    if (nexp > 0) { bin.write_u32_le(buf, hash_off + 8, 1); } or { bin.write_u32_le(buf, hash_off + 8, 0); }
+    var c: u32 = 0;
+    for (c < nchain::u32) {
+        var next: u32 = c + 1;
+        if (next >= nchain::u32) { next = 0; }
+        bin.write_u32_le(buf, hash_off + 12 + c::usize * 4, next);
+        c = c + 1;
+    }
+
+    # .rela.dyn: one R_*_RELATIVE per in-image absolute pointer. r_offset is the
+    # pointer's link-time vaddr, r_addend the link-time absolute value stored there; the
+    # loader writes load_bias + addend.
+    val rel_type: u32 = relative_type_for(tgt_isa.id);
+    var ri: u32 = 0;
+    for (ri < nrel) {
+        val br: *of.BaseReloc = ?dyn.base_relocs[ri];
+        var loc_va: u64 = 0;
+        if (br.seg_index < seg_count) { loc_va = segs[br.seg_index].vaddr + br.seg_offset::u64; }
+        val rela_off: usize = reladyn_off + ri::usize * RELA_SIZE;
+        bin.write_u64_le(buf, rela_off, loc_va);
+        bin.write_u64_le(buf, rela_off + 8, rel_type::u64);
+        bin.write_u64_le(buf, rela_off + 16, br.target);
+        ri = ri + 1;
+    }
+
+    # .dynamic: the table the loader walks. DT_SONAME names the object; the table
+    # pointers locate .hash/.dynstr/.dynsym; the RELA tags describe .rela.dyn.
+    var dpos: usize = dyn_off;
+    dpos = write_dyn_entry(buf, dpos, DT_SONAME, soname_off::u64);
+    dpos = write_dyn_entry(buf, dpos, DT_HASH,   hash_va);
+    dpos = write_dyn_entry(buf, dpos, DT_STRTAB, dynstr_va);
+    dpos = write_dyn_entry(buf, dpos, DT_SYMTAB, dynsym_va);
+    dpos = write_dyn_entry(buf, dpos, DT_STRSZ,  dynstr_size::u64);
+    dpos = write_dyn_entry(buf, dpos, DT_SYMENT, SYM_SIZE::u64);
+    if (nrel > 0) {
+        dpos = write_dyn_entry(buf, dpos, DT_RELA,      reladyn_va);
+        dpos = write_dyn_entry(buf, dpos, DT_RELASZ,    reladyn_size::u64);
+        dpos = write_dyn_entry(buf, dpos, DT_RELAENT,   RELA_SIZE::u64);
+        dpos = write_dyn_entry(buf, dpos, DT_RELACOUNT, nrel::u64);
+    }
+    dpos = write_dyn_entry(buf, dpos, DT_NULL, 0);
+
+    # the program-header table: identical shape to the static-PIE writer's (no
+    # PT_INTERP), with the synthesized RO block and PT_DYNAMIC placed above the
+    # linker segments.
+    write_pie_phdrs(buf, phdr_offset, phdr_count, segs, seg_offsets, seg_count,
+                    ro_off, ro_va, ro_size, dyn_off, dyn_va, dyn_size, dyn, page_size);
+
+    debug_sht_write(buf, itn, debug, debug_count, ?dsht);
+    debug_sht_free(alloc, ?dsht, debug_count);
+
+    if (exp_str != nil)     { A.deallocate[usize](alloc, exp_str, nexp::usize); }
+    if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+
+    val res_file: R.Result[filesystem.File, str] = filesystem.create(path, 0o755);
+    if (R.is_err[filesystem.File, str](res_file)) {
+        val cm: str = bin.io_message(itn, alloc, "elf: cannot create shared object", path::str, R.unwrap_err[filesystem.File, str](res_file), "elf: could not create shared-object file");
+        A.deallocate[u8](alloc, buf, total_size);
+        ret R.err[bool, str](cm);
+    }
+    var f: filesystem.File = R.unwrap_ok[filesystem.File, str](res_file);
+    val res_write: R.Result[usize, str] = filesystem.write(?f, buf, total_size);
+    filesystem.close(?f);
+    A.deallocate[u8](alloc, buf, total_size);
+
+    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](bin.io_message(itn, alloc, "elf: shared write failed on", path::str, R.unwrap_err[usize, str](res_write), "elf: shared write failed")); }
+    ret R.ok[bool, str](true);
 }
 
 # the ELF machine JUMP_SLOT (PLT) relocation type for an ISA

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -150,6 +150,12 @@ val PT_PHDR:    u32 = 6;
 # apply its RELATIVE relocs, then re-protected read-only before `main` (mach-std's
 # `_rt_relocate` mprotects it under `--pie`)
 val PT_GNU_RELRO: u32 = 0x6474E552;
+# marks the stack's requested permissions: an RW (non-executable) PT_GNU_STACK
+# tells the loader the stack need not be executable. a shared object with no
+# PT_GNU_STACK is treated as requiring an executable stack, which a modern loader
+# refuses to grant on `dlopen` ("cannot enable executable stack"), so every
+# shared object must carry one.
+val PT_GNU_STACK: u32 = 0x6474E551;
 val PF_X: u32 = 1;
 val PF_W: u32 = 2;
 val PF_R: u32 = 4;
@@ -1892,7 +1898,7 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     dpos = write_dyn_entry(buf, dpos, DT_NULL, 0);
 
     write_pie_phdrs(buf, phdr_offset, phdr_count, segs, seg_offsets, seg_count,
-                    ro_off, ro_va, ro_size, dyn_off, dyn_va, dyn_size, dyn, page_size);
+                    ro_off, ro_va, ro_size, dyn_off, dyn_va, dyn_size, dyn, page_size, false);
 
     debug_sht_write(buf, itn, debug, debug_count, ?dsht);
     debug_sht_free(alloc, ?dsht, debug_count);
@@ -1933,10 +1939,13 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 # dyn_off/dyn_va/dyn_size:  the .dynamic table
 # dyn:          the dynamic-link plan, for the per-segment writable check
 # page_size:    the segment-alignment page (p_align and the one-page header gap)
+# emit_gnu_stack: append a trailing RW PT_GNU_STACK (a shared object requires it;
+#                 a static-PIE executable passes false and its output is unchanged)
 fun write_pie_phdrs(buf: *u8, phdr_offset: usize, phdr_count: u32,
                     segs: *of.LoadSegment, seg_offsets: *usize, seg_count: u32,
                     ro_off: usize, ro_va: u64, ro_size: usize,
-                    dyn_off: usize, dyn_va: u64, dyn_size: usize, dyn: *of.DynamicInfo, page_size: u64) {
+                    dyn_off: usize, dyn_va: u64, dyn_size: usize, dyn: *of.DynamicInfo, page_size: u64,
+                    emit_gnu_stack: bool) {
     var pos: usize = phdr_offset;
     val phdr_bytes: usize = phdr_count::usize * PHDR_SIZE;
 
@@ -1984,6 +1993,13 @@ fun write_pie_phdrs(buf: *u8, phdr_offset: usize, phdr_count: u32,
         val relro_size: usize = segs[ri].memsz;
         pos = write_phdr(buf, pos, PT_GNU_RELRO, PF_R, seg_offsets[ri], segs[ri].vaddr,
                          relro_size, relro_size, 1);
+    }
+
+    # a trailing RW PT_GNU_STACK for a shared object: it marks the stack
+    # non-executable so `dlopen` does not refuse to load it. all fields but the
+    # permission flags are zero (the header only carries p_flags).
+    if (emit_gnu_stack) {
+        pos = write_phdr(buf, pos, PT_GNU_STACK, PF_R | PF_W, 0, 0, 0, 0, 0x10);
     }
 }
 
@@ -2130,11 +2146,13 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
     }
 
     # program headers: PT_PHDR + one PT_LOAD per linker segment + the synthesized RO
-    # PT_LOAD + PT_DYNAMIC, plus a PT_GNU_RELRO when a read-only segment bears a base
-    # relocation. identical to the static-PIE writer (no PT_INTERP).
+    # PT_LOAD + PT_DYNAMIC + a trailing RW PT_GNU_STACK (required so `dlopen` accepts
+    # the object), plus a PT_GNU_RELRO when a read-only segment bears a base
+    # relocation. the same layout as the static-PIE writer (no PT_INTERP) with the
+    # extra PT_GNU_STACK.
     var relro_extra: u32 = 0;
     if (pie_relro_seg(segs, seg_count, dyn) >= 0) { relro_extra = 1; }
-    val phdr_count: u32 = seg_count + 3 + relro_extra;
+    val phdr_count: u32 = seg_count + 4 + relro_extra;
 
     if (!header_fits_reserved_page(phdr_count, page_size)) {
         ret R.err[bool, str]("elf: shared-object program headers exceed the one-page header reservation (too many load segments)");
@@ -2292,6 +2310,7 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
         bin.write_u64_le(buf, sym_off + 8, exports[e].vaddr);
         bin.write_u64_le(buf, sym_off + 16, 0);
         sym_off = sym_off + SYM_SIZE;
+        e = e + 1;
     }
 
     # .hash: a single-bucket SysV table - bucket[0] points at dynsym index 1 and the
@@ -2341,11 +2360,11 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
     }
     dpos = write_dyn_entry(buf, dpos, DT_NULL, 0);
 
-    # the program-header table: identical shape to the static-PIE writer's (no
-    # PT_INTERP), with the synthesized RO block and PT_DYNAMIC placed above the
-    # linker segments.
+    # the program-header table: the static-PIE writer's shape (no PT_INTERP) plus a
+    # trailing RW PT_GNU_STACK, with the synthesized RO block and PT_DYNAMIC placed
+    # above the linker segments.
     write_pie_phdrs(buf, phdr_offset, phdr_count, segs, seg_offsets, seg_count,
-                    ro_off, ro_va, ro_size, dyn_off, dyn_va, dyn_size, dyn, page_size);
+                    ro_off, ro_va, ro_size, dyn_off, dyn_va, dyn_size, dyn, page_size, true);
 
     debug_sht_write(buf, itn, debug, debug_count, ?dsht);
     debug_sht_free(alloc, ?dsht, debug_count);


### PR DESCRIPTION
Integration sweep for the v3.3.0 shared-objects and debugging-experience release: #1980 P2a shared ELF objects (#2004) and the pre-SIMD debuginfo close-out (#1904/#2005, #1954/#2006, #2007/#2008, #1955/#2003, #1708-partial/#2009). CHANGELOG [3.3.0] carries the inventory.