### PR TITLE
release: v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2026-07-10
+
+The seed-gate patch for the SIMD program. The manifest parser now accepts and
+validates the `simd` profile key (`"scalarize"` | `"require"`) without requiring
+it — the staging step that lets the next compiler parse a swept manifest tree
+before the required-everywhere flip lands with the SIMD gate. Alongside it,
+`.debug_str` is string-merge deduplicated across modules, and the aarch64
+shared-object path is verified end to end and carries its GOT relocation
+foundation. Built with mach 3.3.0.
+
+### Added
+- manifest: **the `simd` profile key parses** — accepted and value-validated
+  (`"scalarize"` | `"require"`) on a declared `[profile.X]`, not yet required;
+  the required-everywhere flip ships with the SIMD gate (#1965, #2013, #2027).
+- link: **aarch64 GOT relocation foundation** — `RK_GOT_PAGE21`/`RK_GOT_LO12`
+  mapped to `R_AARCH64_ADR_GOT_PAGE`/`R_AARCH64_LD64_GOT_LO12_NC`, with a
+  unit-tested GOT-indirect encode primitive, dormant pending the imported-data
+  ruling (RFC #2026); aarch64 `kind = "shared"` output verified end to end —
+  PIC-clean internal references, `R_AARCH64_RELATIVE` dynamic relocations, and
+  the release/`-g` byte rules (#1980, #2022, #2023).
+
+### Fixed
+- debuginfo: **`.debug_str` is string-merge deduplicated across modules** —
+  406,117 → 166,072 bytes on the compiler itself, with a per-site
+  content-equality guard that turns a wrong remap into a loud link error
+  (#1708, #2025).
+
 ## [3.3.0] - 2026-07-10
 
 The shared-objects and debugging-experience release. `kind = "shared"` artifacts

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "3.3.0"
+version = "3.3.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -280,6 +280,13 @@ pub rec MirOperand {
     index:         u32;
     scale:         u8;
     index_is_preg: bool;
+    # marks a MIR_OP_SYM whose address must be loaded GOT-indirect rather than
+    # materialized absolute (a preemptible / imported reference). arm64 encode reads
+    # it to select the adrp :got: + ldr :got_lo12: sequence. the GOT-indirect
+    # foundation ships dormant: nothing sets it yet, since routing imported data
+    # through the GOT awaits RFC #2026 (see mir.context.lower_value). always false
+    # today, so every reference keeps the position-independent adrp+add form
+    sym_got:       bool;
 }
 
 # one resolved `{name}` binding for an inline-asm block
@@ -543,6 +550,7 @@ pub fun op_vreg(vreg: u32) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -561,6 +569,7 @@ pub fun op_preg(preg: u32) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -579,6 +588,7 @@ pub fun op_imm(imm: i64) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -604,6 +614,7 @@ pub fun op_mem_slot(slotkey: u32, disp: i64) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -627,6 +638,7 @@ pub fun op_mem_preg(preg: u32, disp: i64) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -650,6 +662,7 @@ pub fun op_mem_value(base: u32, disp: i64) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -669,6 +682,7 @@ pub fun op_sym(sym: intern.StrId, sym_off: i32) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -687,6 +701,7 @@ pub fun op_block(block: u32) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -425,6 +425,14 @@ pub fun lower_value(ctx: *LowerCtx, v: value.Value) mir.MirOperand {
     }
     if (v.kind == value.VAL_GLOBAL) {
         if (v.data.global_ix < ctx.m.global_len) {
+            # NOTE: an imported (`is_extern`) global is preemptible and would load
+            # GOT-indirect (set `o.sym_got = true` here). that wiring is withheld
+            # pending RFC #2026: with no compile-time import signal and no linker
+            # GOT relaxation, routing every `is_extern` reference through the GOT
+            # would tax all cross-module data access. `is_extern` data therefore
+            # keeps the position-independent adrp+add form for now; the GOT-indirect
+            # codegen foundation (RK_GOT_*, emit_global_addr_got, MirOperand.sym_got)
+            # ships dormant.
             ret mir.op_sym(ctx.m.globals[v.data.global_ix].name, 0);
         }
         # an in-range global index is an IR invariant; an out-of-range one is a

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -2040,7 +2040,11 @@ fun lower_memzero(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructi
 fun agg_pointer_mem(ctx: *lctx.LowerCtx, v: value.Value, disp: i64) mir.MirOperand {
     val op: mir.MirOperand = lctx.lower_value(ctx, v);
     if (op.kind == mir.MIR_OP_VREG) { ret mir.op_mem_value(op.vreg, disp); }
-    if (op.kind == mir.MIR_OP_SYM)  { ret mir.op_sym(op.sym, op.sym_off + disp::i32); }
+    if (op.kind == mir.MIR_OP_SYM)  {
+        var so: mir.MirOperand = mir.op_sym(op.sym, op.sym_off + disp::i32);
+        so.sym_got = op.sym_got;
+        ret so;
+    }
     ret op;
 }
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -42,6 +42,7 @@ use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.be.obj;
+use enc: mach.lang.be.codegen.encode;
 use mach.lang.intern;
 use mach.lang.session;
 use mach.lang.target;
@@ -142,6 +143,25 @@ rec DynState {
     fixup_cap:   u32;
     base_reloc_cap: u32;
     active:      bool;
+}
+
+# the deduped `.debug_str` string table and the map from an interned string to its
+# byte offset within it, built once per link before section accumulation. every
+# module's `.debug_str` holds the same names redundantly (10k unique of ~38k on a
+# self-host `-g` build), so one physical copy per distinct string collapses the
+# section by ~60%. a strp relocation's target string interns to a `StrId` whose
+# offset here is the value written at the patch site, so identical strings across
+# modules resolve to the one copy (#1708). owns `buf` + `offs`; freed after link
+# ---
+# buf:    the deduped `.debug_str` bytes (one NUL-terminated copy per distinct string)
+# offs:   interned-string -> byte offset within `buf`
+# name:   the interned ".debug_str" section name, keying the merged slot
+# active: true when dedup is in effect (a patching-mode link carrying `.debug_str`)
+rec StrMerge {
+    buf:    enc.ByteBuf;
+    offs:   map.Map[intern.StrId, u32];
+    name:   intern.StrId;
+    active: bool;
 }
 
 # read the input object files from disk and combine them into the
@@ -307,6 +327,19 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     val dn_r: R.Result[bool, str] = discover_debug_names(alloc, modules, module_count, ?debug_names, ?debug_count);
     if (R.is_err[bool, str](dn_r)) { ret R.err[bool, str](R.unwrap_err[bool, str](dn_r)); }
 
+    # build the deduped .debug_str table before section accumulation: the merged
+    # .debug_str content is this buffer and its length sizes the merged slot. only the
+    # in-place-patched modes (executable, shared object) dedup; a relocatable output
+    # gets an inactive StrMerge and keeps the classic concatenation (#1708).
+    val patching: bool = (mode == LINK_EXE) || shared;
+    var strm: StrMerge;
+    val sm_r: R.Result[StrMerge, str] = build_str_merge(s, modules, module_count, patching);
+    if (R.is_err[StrMerge, str](sm_r)) {
+        if (debug_names != nil && debug_count > 0) { A.deallocate[intern.StrId](alloc, debug_names, debug_count::usize); }
+        ret R.err[bool, str](R.unwrap_err[StrMerge, str](sm_r));
+    }
+    strm = R.unwrap_ok[StrMerge, str](sm_r);
+
     # the merged-section accumulators: the fixed kind slots in canonical order,
     # followed by one name-keyed slot per distinct debug section name. `merged_to_out`
     # is filled by build_merged_image to map a placement's merged index to its output
@@ -316,6 +349,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     val mrg_r: R.Result[*MergedSection, str] = A.zallocate[MergedSection](alloc, merged_count::usize);
     if (R.is_err[*MergedSection, str](mrg_r)) {
         if (debug_names != nil && debug_count > 0) { A.deallocate[intern.StrId](alloc, debug_names, debug_count::usize); }
+        free_str_merge(?strm);
         ret R.err[bool, str](R.unwrap_err[*MergedSection, str](mrg_r));
     }
     merged = R.unwrap_ok[*MergedSection, str](mrg_r);
@@ -331,7 +365,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (sec_total > 0) {
         val pr: R.Result[*Placement, str] = A.zallocate[Placement](alloc, sec_total::usize);
         if (R.is_err[*Placement, str](pr)) {
-            free_scratch(alloc, nil, 0, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out);
+            free_scratch(alloc, nil, 0, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
             ret R.err[bool, str](R.unwrap_err[*Placement, str](pr));
         }
         placements = R.unwrap_ok[*Placement, str](pr);
@@ -341,15 +375,15 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     var sec_base: *u32 = nil;
     val br: R.Result[*u32, str] = A.zallocate[u32](alloc, module_count::usize);
     if (R.is_err[*u32, str](br)) {
-        free_scratch(alloc, placements, sec_total, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out);
+        free_scratch(alloc, placements, sec_total, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
         ret R.err[bool, str](R.unwrap_err[*u32, str](br));
     }
     sec_base = R.unwrap_ok[*u32, str](br);
 
     val acc_r: R.Result[bool, str] =
-        accumulate_sections(s, modules, module_count, merged, debug_names, debug_count, placements, sec_base);
+        accumulate_sections(s, modules, module_count, merged, debug_names, debug_count, placements, sec_base, ?strm);
     if (R.is_err[bool, str](acc_r)) {
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
         ret R.err[bool, str](R.unwrap_err[bool, str](acc_r));
     }
 
@@ -372,7 +406,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         collect_symbols(s, modules, module_count, placements, sec_base, ?sym_locs, assign_vaddrs);
     if (R.is_err[bool, str](collect_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
         ret R.err[bool, str](R.unwrap_err[bool, str](collect_r));
     }
 
@@ -382,7 +416,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     val img_r: R.Result[of.ObjectImage, str] = obj.init(alloc, ?s.interner, image_name(modules, module_count));
     if (R.is_err[of.ObjectImage, str](img_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
         ret R.err[bool, str](R.unwrap_err[of.ObjectImage, str](img_r));
     }
     out_img = R.unwrap_ok[of.ObjectImage, str](img_r);
@@ -393,17 +427,17 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (R.is_err[*u32, str](mto_r)) {
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
         ret R.err[bool, str](R.unwrap_err[*u32, str](mto_r));
     }
     merged_to_out = R.unwrap_ok[*u32, str](mto_r);
 
     val build_r: R.Result[bool, str] =
-        build_merged_image(s, ?out_img, modules, module_count, merged, merged_count, placements, sec_base, merged_to_out);
+        build_merged_image(s, ?out_img, modules, module_count, merged, merged_count, placements, sec_base, merged_to_out, ?strm);
     if (R.is_err[bool, str](build_r)) {
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
         ret R.err[bool, str](R.unwrap_err[bool, str](build_r));
     }
 
@@ -429,18 +463,18 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
                 free_dynstate(alloc, ?dyn);
                 obj.dnit(?out_img);
                 map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-                free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
+                free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
                 ret R.err[bool, str](R.unwrap_err[bool, str](dr));
             }
         }
 
         val patch_r: R.Result[bool, str] =
-            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, merged_to_out, ?sym_locs, ?dyn, tgt.arch);
+            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, merged_to_out, ?sym_locs, ?dyn, ?strm, tgt.arch);
         if (R.is_err[bool, str](patch_r)) {
             free_dynstate(alloc, ?dyn);
             obj.dnit(?out_img);
             map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-            free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
+            free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
             ret R.err[bool, str](R.unwrap_err[bool, str](patch_r));
         }
 
@@ -458,7 +492,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         free_dynstate(alloc, ?dyn);
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
 
         if (R.is_err[bool, str](emit_r)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](emit_r));
@@ -473,7 +507,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (R.is_err[bool, str](carry_r)) {
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
         ret R.err[bool, str](R.unwrap_err[bool, str](carry_r));
     }
 
@@ -481,7 +515,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
 
     obj.dnit(?out_img);
     map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-    free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
+    free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
 
     if (R.is_err[bool, str](obj_r)) {
         ret R.err[bool, str](R.unwrap_err[bool, str](obj_r));
@@ -1367,6 +1401,107 @@ fun discover_debug_names(alloc: *A.Allocator, modules: *of.ObjectImage, module_c
     ret R.ok[bool, str](true);
 }
 
+# build the deduped `.debug_str` table: walk every module's `.debug_str`, intern each
+# NUL-terminated string, and append one physical copy per distinct content to a growing
+# buffer, recording each string's offset. identical content across modules interns to
+# the same `StrId`, so it is stored exactly once and every strp resolves to that offset
+# during patching
+#
+# only the in-place-patched link modes (executable, shared object) dedup: a relocatable
+# output carries its strp relocations forward against the concatenated section, so it
+# must keep `.debug_str` un-deduped. an inactive `StrMerge` (no `.debug_str` input, or a
+# relocatable link) leaves the classic per-module concatenation in place.
+# ---
+# s:            shared session (allocator, interner)
+# modules:      the input image array
+# module_count: number of input images
+# patching:     true for a link mode that patches strp sites in place (exe / shared)
+# ret:          the owned StrMerge (freed after link), or an allocation error
+fun build_str_merge(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
+                    patching: bool) R.Result[StrMerge, str] {
+    val alloc: *A.Allocator = s.alloc;
+    var sm: StrMerge;
+    sm.buf    = enc.buf_init(alloc);
+    sm.offs   = map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
+    sm.name   = intern.STR_NIL;
+    sm.active = false;
+    if (!patching) { ret R.ok[StrMerge, str](sm); }
+
+    val nr: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".debug_str");
+    if (R.is_err[intern.StrId, str](nr)) { free_str_merge(?sm); ret R.err[StrMerge, str](R.unwrap_err[intern.StrId, str](nr)); }
+    sm.name = R.unwrap_ok[intern.StrId, str](nr);
+
+    var m: u32 = 0;
+    for (m < module_count) {
+        var sc: u32 = 0;
+        for (sc < modules[m].section_count) {
+            val sec: *of.Section = ?modules[m].sections[sc];
+            if (sec.kind != of.SK_DEBUG || sec.name != sm.name || sec.bytes == nil) { sc = sc + 1; cnt; }
+            sm.active = true;
+
+            # the section is a run of NUL-terminated strings; intern each, appending a
+            # single copy (bytes + NUL) to the deduped buffer on first sight.
+            var o: u32 = 0;
+            for (o < sec.len) {
+                val sr: R.Result[intern.StrId, str] = intern.intern(?s.interner, (?sec.bytes[o])::str);
+                if (R.is_err[intern.StrId, str](sr)) { free_str_merge(?sm); ret R.err[StrMerge, str](R.unwrap_err[intern.StrId, str](sr)); }
+                val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
+                val slen: u32 = str_len((?sec.bytes[o])::str)::u32;
+
+                if (R.is_err[*u32, str](map.get[intern.StrId, u32](?sm.offs, ?sid))) {
+                    val off: u32 = sm.buf.len::u32;
+                    var i: u32 = 0;
+                    for (i <= slen) { enc.emit_byte(?sm.buf, sec.bytes[o + i]); i = i + 1; }
+                    val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?sm.offs, sid, off);
+                    if (R.is_err[bool, str](ins)) { free_str_merge(?sm); ret R.err[StrMerge, str](R.unwrap_err[bool, str](ins)); }
+                }
+                o = o + slen + 1;
+            }
+            sc = sc + 1;
+        }
+        m = m + 1;
+    }
+    ret R.ok[StrMerge, str](sm);
+}
+
+# release a StrMerge's deduped buffer and offset map; nil-safe, and safe on the
+# inactive (empty) value built for a relocatable link or a debug-free link
+# ---
+# sm: the StrMerge to release
+fun free_str_merge(sm: *StrMerge) {
+    if (sm == nil) { ret; }
+    map.dnit[intern.StrId, u32](?sm.offs);
+    enc.buf_dnit(?sm.buf);
+}
+
+# whether the NUL-terminated string at `src[src_off..]` byte-equals the one at
+# `ded[ded_off..]`, both bounded by their buffer lengths. the load-bearing guard on the
+# `.debug_str` dedup remap (#1708): a wrong-but-valid strp offset is invisible to
+# `llvm-dwarfdump --verify`, so a content divergence here is turned into a loud linker
+# error instead of silently corrupt debug info
+# ---
+# src:     the module's own `.debug_str` bytes
+# src_len: length of `src`
+# src_off: the strp addend (string start within the module's `.debug_str`)
+# ded:     the deduped `.debug_str` bytes
+# ded_len: length of `ded`
+# ded_off: the remapped offset the strp is about to be written with
+# ret:     true when the two strings are byte-identical through their shared NUL
+fun debug_str_content_eq(src: *u8, src_len: u32, src_off: u32,
+                         ded: *u8, ded_len: u32, ded_off: u32) bool {
+    var i: u32 = 0;
+    for (true) {
+        if (src_off::u64 + i::u64 >= src_len::u64) { ret false; }
+        if (ded_off::u64 + i::u64 >= ded_len::u64) { ret false; }
+        val sc: u8 = src[(src_off + i)::usize];
+        val dc: u8 = ded[(ded_off + i)::usize];
+        if (sc != dc) { ret false; }
+        if (sc == 0) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
 # sum the section counts of every input image
 # ---
 # modules:      the input image array
@@ -1398,7 +1533,7 @@ fun total_sections(modules: *of.ObjectImage, module_count: u32) u32 {
 # ret:          ok(true) on success, or an error string
 fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
                         merged: *MergedSection, debug_names: *intern.StrId, debug_count: u32,
-                        placements: *Placement, sec_base: *u32) R.Result[bool, str] {
+                        placements: *Placement, sec_base: *u32, strm: *StrMerge) R.Result[bool, str] {
     # .debug_abbrev is byte-identical across every module (a deterministic, complete
     # build_abbrev) and every CU references it at offset 0, so only the first copy is
     # ever read. dedup it: a later object's table shares the first at offset 0 and adds
@@ -1425,6 +1560,7 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
             # debug sections never merge together.
             var ki: u32 = sec.kind::u32;
             var dedup: bool = false;
+            var str_slot: bool = false;
             if (sec.kind == of.SK_DEBUG) {
                 var found: bool = false;
                 var di: u32 = 0;
@@ -1437,9 +1573,25 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
                 if (!found) { ret R.err[bool, str]("linker: debug section name not registered in the merge"); }
                 # a later .debug_abbrev copy shares the first at offset 0 (#1708).
                 if (sec.name == abbrev_name && merged[ki].used) { dedup = true; }
+                # .debug_str is string-merge deduped: its merged content is the pre-built
+                # deduped buffer, so no module contributes bytes here (#1708).
+                if (strm.active && sec.name == strm.name) { str_slot = true; }
             }
 
-            if (dedup) {
+            if (str_slot) {
+                # the deduped .debug_str is build_str_merge's buffer; every module's copy
+                # adds no bytes and its placement offset is unused - strp sites resolve to
+                # deduped offsets during patching, not through this placement.
+                var a: u32 = sec.align;
+                if (a == 0)               { a = 1; }
+                if (a > merged[ki].align) { merged[ki].align = a; }
+                merged[ki].len  = strm.buf.len::u32;
+                merged[ki].used = true;
+                placements[flat].merged_index = ki;
+                placements[flat].offset       = 0;
+                placements[flat].vaddr        = 0;
+            }
+            or (dedup) {
                 # share the surviving first copy: offset 0, no bytes added. the copy pass
                 # rewrites offset 0 with this identical table (harmless); every CU already
                 # references offset 0, so nothing points into a dropped copy.
@@ -1623,7 +1775,7 @@ fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count:
 fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
                        modules: *of.ObjectImage, module_count: u32,
                        merged: *MergedSection, merged_count: u32, placements: *Placement, sec_base: *u32,
-                       merged_to_out: *u32) R.Result[bool, str] {
+                       merged_to_out: *u32, strm: *StrMerge) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
 
     # map each used merged slot to its output-section index so symbols/relocations
@@ -1640,6 +1792,13 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
             val zr: R.Result[*u8, str] = A.zallocate[u8](alloc, merged[k].len::usize);
             if (R.is_err[*u8, str](zr)) { ret R.err[bool, str](R.unwrap_err[*u8, str](zr)); }
             bytes = R.unwrap_ok[*u8, str](zr);
+
+            # the deduped .debug_str content is the pre-built buffer, written once here;
+            # the per-module byte-copy loop below skips every .debug_str source (#1708).
+            if (strm.active && merged[k].kind == of.SK_DEBUG && merged[k].name == strm.name
+                && strm.buf.len > 0) {
+                memory.copy[u8](bytes, strm.buf.data, strm.buf.len);
+            }
         }
 
         # a kind slot names itself by kind; a name-keyed debug slot carries its own
@@ -1669,6 +1828,8 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
         for (sc < modules[m].section_count) {
             val src: *of.Section = ?modules[m].sections[sc];
             if (src.kind == of.SK_BSS || src.bytes == nil || src.len == 0) { sc = sc + 1; cnt; }
+            # the deduped .debug_str was written once above; skip every per-module copy.
+            if (strm.active && src.kind == of.SK_DEBUG && src.name == strm.name) { sc = sc + 1; cnt; }
 
             val flat: u32 = sec_base[m] + sc;
             val ki: u32 = placements[flat].merged_index;
@@ -1743,13 +1904,14 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
 # merged_to_out: per-merged-slot output-section index (from build_merged_image)
 # sym_locs:      the global symbol table, for GLOBAL/extern target resolution
 # dyn:           dynamic-link state; out - collects import call-site fixups
+# strm:          the deduped .debug_str table, for strp remap (inactive to skip)
 # arch:          active instruction-set vtable, owning the relocation packer
 # ret:           ok(true) on success, or an error string
 fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
                      modules: *of.ObjectImage, module_count: u32,
                      placements: *Placement, sec_base: *u32, merged_to_out: *u32,
                      sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                     dyn: *DynState, arch: *isa.IsaVTable) R.Result[bool, str] {
+                     dyn: *DynState, strm: *StrMerge, arch: *isa.IsaVTable) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
 
     var m: u32 = 0;
@@ -1768,7 +1930,7 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
         }
 
         val pr: R.Result[bool, str] = patch_module_relocations(s, out_img, modules, m,
-            placements, sec_base, merged_to_out, sym_locs, dyn, ?local_map, arch);
+            placements, sec_base, merged_to_out, sym_locs, dyn, ?local_map, strm, arch);
         map.dnit[intern.StrId, u64](?local_map);
         if (R.is_err[bool, str](pr)) { ret R.err[bool, str](R.unwrap_err[bool, str](pr)); }
 
@@ -1823,13 +1985,35 @@ fun build_local_index(modules: *of.ObjectImage, m: u32, placements: *Placement, 
 # sym_locs:      the global symbol table, for GLOBAL/extern target resolution
 # dyn:           dynamic-link state; out - collects import call-site fixups
 # local_map:     module `m`'s LOCAL-name -> virtual-address index
+# strm:          the deduped .debug_str table, for strp remap (inactive to skip)
 # arch:          active instruction-set vtable, owning the relocation packer
 # ret:           ok(true) on success, or an error string
 fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                              modules: *of.ObjectImage, m: u32,
                              placements: *Placement, sec_base: *u32, merged_to_out: *u32,
                              sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
-                             local_map: *map.Map[intern.StrId, u64], arch: *isa.IsaVTable) R.Result[bool, str] {
+                             local_map: *map.Map[intern.StrId, u64], strm: *StrMerge,
+                             arch: *isa.IsaVTable) R.Result[bool, str] {
+    # locate module m's .debug_str section and its anchor symbol once: a strp
+    # relocation is exactly one whose target is that anchor. resolving it remaps the
+    # string to its deduped offset rather than the concatenated placement (#1708).
+    var str_sec: u32 = 0xFFFFFFFF;
+    var str_anchor: intern.StrId = intern.STR_NIL;
+    if (strm.active) {
+        var scx: u32 = 0;
+        for (scx < modules[m].section_count) {
+            if (modules[m].sections[scx].kind == of.SK_DEBUG && modules[m].sections[scx].name == strm.name) { str_sec = scx; }
+            scx = scx + 1;
+        }
+        if (str_sec != 0xFFFFFFFF) {
+            var syx: u32 = 0;
+            for (syx < modules[m].symbol_count) {
+                if (modules[m].symbols[syx].section == str_sec) { str_anchor = modules[m].symbols[syx].name; }
+                syx = syx + 1;
+            }
+        }
+    }
+
     var ri: u32 = 0;
     for (ri < modules[m].reloc_count) {
         val r: *of.Relocation = ?modules[m].relocations[ri];
@@ -1862,6 +2046,15 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
             ret R.err[bool, str]("linker: relocation patch site lands in a BSS section");
         }
         val patch_off: u32 = pl.offset + r.offset;
+
+        # a strp into .debug_str: remap it to the string's deduped offset instead of
+        # resolving the anchor's placement. skips the normal apply_one below (#1708).
+        if (strm.active && str_anchor != intern.STR_NIL && r.symbol == str_anchor) {
+            val sp: R.Result[bool, str] = resolve_strp(s, modules, m, str_sec, r, strm,
+                dst, patch_off, out_img.sections[out_ix].len, patch_va, arch);
+            if (R.is_err[bool, str](sp)) { ret R.err[bool, str](R.unwrap_err[bool, str](sp)); }
+            ri = ri + 1; cnt;
+        }
 
         # locate the target symbol's final virtual address. a LOCAL target is
         # private to module `m`; resolve it through `m`'s local index. GLOBAL targets
@@ -1917,6 +2110,55 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         ri = ri + 1;
     }
     ret R.ok[bool, str](true);
+}
+
+# resolve one `.debug_str` strp relocation to its deduped offset and write it at the
+# patch site. the addend is the string's byte offset within module `m`'s own
+# `.debug_str`; interning the string there yields the `StrId` whose deduped-buffer
+# offset is the strp value. a per-site content-equality guard (#1708) asserts the
+# deduped bytes match before writing - `llvm-dwarfdump --verify` cannot catch a
+# wrong-but-valid strp offset, so any divergence is turned into a loud linker error
+# rather than silently corrupt debug info
+# ---
+# s:         shared session (interner), for diagnostics
+# modules:   the input image array
+# m:         index of the module owning the relocation
+# str_sec:   index of module `m`'s `.debug_str` section
+# r:         the strp relocation (addend is the string offset within `.debug_str`)
+# strm:      the deduped `.debug_str` table (buffer + offset map)
+# dst:       the merged output-section bytes to patch
+# patch_off: byte offset of the patch site within `dst`
+# sec_len:   length of the output section `dst` backs, for the bounds check
+# patch_va:  the patch site's own virtual address (unused for a strp, passed through)
+# arch:      active instruction-set vtable, owning the relocation packer
+# ret:       ok(true) once the deduped offset is written, or an error string
+fun resolve_strp(s: *session.Session, modules: *of.ObjectImage, m: u32, str_sec: u32,
+                 r: *of.Relocation, strm: *StrMerge, dst: *u8, patch_off: u32, sec_len: u32,
+                 patch_va: u64, arch: *isa.IsaVTable) R.Result[bool, str] {
+    val ssec: *of.Section = ?modules[m].sections[str_sec];
+    if (ssec.bytes == nil || r.addend < 0 || r.addend::u64 >= ssec.len::u64) {
+        ret R.err[bool, str]("linker: .debug_str strp addend out of range");
+    }
+    val src_off: u32 = r.addend::u32;
+
+    val sid_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, (?ssec.bytes[src_off])::str);
+    if (R.is_err[intern.StrId, str](sid_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sid_r)); }
+    val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sid_r);
+
+    val og: R.Result[*u32, str] = map.get[intern.StrId, u32](?strm.offs, ?sid);
+    if (R.is_err[*u32, str](og)) {
+        ret R.err[bool, str]("linker: .debug_str strp target absent from the deduped table");
+    }
+    val ded_off: u32 = @R.unwrap_ok[*u32, str](og);
+
+    # the load-bearing guard: the deduped bytes must equal the module's own string.
+    if (!debug_str_content_eq(ssec.bytes, ssec.len, src_off, strm.buf.data, strm.buf.len::u32, ded_off)) {
+        ret R.err[bool, str]("linker: .debug_str dedup remapped a strp to divergent content");
+    }
+
+    # write the deduped offset as the strp value: RK_ABS32 into a non-loadable section,
+    # so `sym_va` is the debug-section-relative offset itself and the addend is zero.
+    ret apply_one(s, r.kind, dst, patch_off, sec_len, ded_off::u64, 0, patch_va, r.symbol, arch);
 }
 
 # reset a DynState to the empty (static-link) state. its plan and
@@ -3148,11 +3390,12 @@ fun free_placements(alloc: *A.Allocator, placements: *Placement, sec_total: u32)
 # debug_names:   the discovered debug-name array to release (may be nil)
 # debug_count:   length of the debug-name array
 # merged_to_out: the merged-slot -> output-section map to release (may be nil)
+# strm:          the deduped .debug_str table to release (may be nil)
 fun free_scratch(alloc: *A.Allocator, placements: *Placement, sec_total: u32,
                 sec_base: *u32, module_count: u32,
                 merged: *MergedSection, merged_count: u32,
                 debug_names: *intern.StrId, debug_count: u32,
-                merged_to_out: *u32) {
+                merged_to_out: *u32, strm: *StrMerge) {
     free_placements(alloc, placements, sec_total);
     if (sec_base != nil && module_count > 0) {
         A.deallocate[u32](alloc, sec_base, module_count::usize);
@@ -3166,6 +3409,7 @@ fun free_scratch(alloc: *A.Allocator, placements: *Placement, sec_total: u32,
     if (merged_to_out != nil && merged_count > 0) {
         A.deallocate[u32](alloc, merged_to_out, merged_count::usize);
     }
+    free_str_merge(strm);
 }
 
 # tear down every parsed input image and release the image array.

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -33,6 +33,19 @@ pub val MOPT_DEFAULT: MOpt = 0;
 pub val MOPT_DEBUG:   MOpt = 1;
 pub val MOPT_RELEASE: MOpt = 2;
 
+# the SIMD strictness lever a declared profile sets (#1965): on a target without
+# the hardware vector unit, "scalarize" emits a defined unrolled expansion while
+# "require" fails the build.
+#
+# BOOTSTRAP STAGING (#2013 seed gate): this stage makes the strict parser ACCEPT
+# and validate the key without requiring it, so a swept manifest parses cleanly
+# under this compiler once it becomes the seed. The required-everywhere flip (per
+# owner ruling 1) lands with #2013 itself; resolution and enforcement are #2017.
+pub def SimdMode: u8;
+
+pub val SIMD_SCALARIZE: SimdMode = 0;
+pub val SIMD_REQUIRE:   SimdMode = 1;
+
 pub def LibKind: u8;
 
 pub val LIBKIND_STATIC: LibKind = 0;
@@ -76,6 +89,7 @@ pub rec ProfileDef {
     emit_ir:  bool;
     emit_asm: bool;
     debug:    bool;
+    simd:     SimdMode;
 }
 
 pub rec DepDef {
@@ -411,6 +425,25 @@ fun debug_err(alloc: *A.Allocator, name: str, v: *toml.Value) str {
         opt_value_text(alloc, v), ")");
 }
 
+# parse a profile's `simd` strictness lever (#1965). BOOTSTRAP STAGING (#2013):
+# the key is ACCEPTED and value-validated ("scalarize"|"require", rejected
+# otherwise) but NOT yet required — an absent key defaults to scalarize on every
+# path. The required-everywhere flip (owner ruling 1) lands with #2013 once this
+# compiler is the seed
+fun parse_simd_mode(alloc: *A.Allocator, name: str, sub: *toml.Table, as_root: bool) R.Result[SimdMode, str] {
+    val v: *toml.Value = toml.get(sub, "simd");
+    if (v == nil)                  { ret R.ok[SimdMode, str](SIMD_SCALARIZE); }
+    if (v.tag != toml.TYPE_STRING) { ret R.err[SimdMode, str](simd_err(alloc, name, v)); }
+    if (str_equals(v.data.string, "scalarize")) { ret R.ok[SimdMode, str](SIMD_SCALARIZE); }
+    if (str_equals(v.data.string, "require"))   { ret R.ok[SimdMode, str](SIMD_REQUIRE); }
+    ret R.err[SimdMode, str](simd_err(alloc, name, v));
+}
+
+fun simd_err(alloc: *A.Allocator, name: str, v: *toml.Value) str {
+    ret cc5(alloc, "mach.toml: profile '", name, "': simd must be \"scalarize\" or \"require\" (got ",
+        opt_value_text(alloc, v), ")");
+}
+
 fun int_to_str(alloc: *A.Allocator, n: i64) str {
     if (n == 0) { ret "0"; }
     var neg: bool = false;
@@ -456,7 +489,7 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
             || str_equals(k, "targets") || str_equals(k, "link") || str_equals(k, "need");
     }
     if (kind == TK_PROFILE) {
-        if (str_equals(k, "opt") || str_equals(k, "debug")) { ret true; }
+        if (str_equals(k, "opt") || str_equals(k, "debug") || str_equals(k, "simd")) { ret true; }
         # emit_ir/emit_asm are CLI-only (--emit-ir/--emit-asm); like name/description
         # they are pre-flag-day keys tolerated off-root, an unknown key as root (#1971).
         if (!as_root && (str_equals(k, "emit_ir") || str_equals(k, "emit_asm"))) { ret true; }
@@ -758,6 +791,9 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
         val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub, as_root);
         if (R.is_err[bool, str](res_debug)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_debug)); }
         pf.debug    = R.unwrap_ok[bool, str](res_debug);
+        val res_simd: R.Result[SimdMode, str] = parse_simd_mode(alloc, name, sub, as_root);
+        if (R.is_err[SimdMode, str](res_simd)) { ret R.err[bool, str](R.unwrap_err[SimdMode, str](res_simd)); }
+        pf.simd     = R.unwrap_ok[SimdMode, str](res_simd);
 
         m.profiles[i] = pf;
         i = i + 1;
@@ -2017,6 +2053,39 @@ test "mach.lang.manifest.parse:unknown_keys" {
 
     val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\nwat=\"z\"\n");
     if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: unknown key 'wat' in [target.l]")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #2013 bootstrap staging: the strict parser ACCEPTS and value-validates `simd`
+# on a declared profile but does NOT yet require it -- "scalarize"/"require" parse
+# and store, an absent key is tolerated, and only an invalid value is rejected.
+# the required-everywhere flip lands with #2013 once this compiler is the seed
+test "mach.lang.manifest.parse:simd_accepted_not_required" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val head: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n";
+
+    # "scalarize" parses and stores.
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\nsimd=\"scalarize\"\n"));
+    if (R.is_err[Manifest, str](a)) { code = 1; }
+    or { if (R.unwrap_ok[Manifest, str](a).profiles[0].simd != SIMD_SCALARIZE) { code = 1; } }
+
+    # "require" parses and stores.
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\nsimd=\"require\"\n"));
+    if (R.is_err[Manifest, str](b)) { code = 1; }
+    or { if (R.unwrap_ok[Manifest, str](b).profiles[0].simd != SIMD_REQUIRE) { code = 1; } }
+
+    # an absent key is tolerated in this stage (not yet required) and defaults to scalarize.
+    val c: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\n"));
+    if (R.is_err[Manifest, str](c)) { code = 1; }
+    or { if (R.unwrap_ok[Manifest, str](c).profiles[0].simd != SIMD_SCALARIZE) { code = 1; } }
+
+    # an invalid value is rejected with the specific error.
+    val d: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\nsimd=\"bogus\"\n"));
+    if (R.is_ok[Manifest, str](d) || !str_contains(R.unwrap_err[Manifest, str](d), "simd must be \"scalarize\" or \"require\"")) { code = 1; }
+
     arena.dnit(?ar);
     ret code;
 }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -745,6 +745,79 @@ fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *
     ret encode.push_reloc(st, arm64_reloc_offset(pos), ldst_lo12_kind(w), symop.sym, symop.sym_off);
 }
 
+# emit `adrp Xd, :got:sym` with a zero page-delta placeholder and record the
+# RK_GOT_PAGE21 relocation at the instruction-word start. the GOT analogue of
+# emit_adrp_reloc: the page-high half of a GOT-slot address. the addend is always
+# zero - the slot holds the symbol's own base and any symbol addend is applied to
+# the loaded address afterward, since a GOT reloc cannot carry it. the caller pairs
+# it with the `ldr :got_lo12:` low half that dereferences the slot
+fun emit_adrp_got_reloc(st: *encode.EncodeState, rd: u32, sym: intern.StrId) R.Result[bool, str] {
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_adrp(rd));
+    ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_PAGE21, sym, 0);
+}
+
+# a preemptible / imported symbol's address loaded GOT-indirect -
+# `adrp Xd, :got:sym` (RK_GOT_PAGE21) ; `ldr Xd, [Xd, :got_lo12:sym]` (RK_GOT_LO12).
+# the LDR dereferences the GOT slot, so Xd holds the symbol's runtime absolute
+# address, which the dynamic loader bound through an R_AARCH64_GLOB_DAT. a nonzero
+# addend rides a trailing `add Xd, Xd, #off` (the slot addresses the symbol base
+# only). this is the imported-data analogue of the absolute emit_global_addr
+fun emit_global_addr_got(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperand) R.Result[bool, str] {
+    if (symop.sym == intern.STR_NIL) {
+        ret R.err[bool, str]("encode: GOT address-of has no resolved symbol name");
+    }
+    val ar: R.Result[bool, str] = emit_adrp_got_reloc(st, rd, symop.sym);
+    if (R.is_err[bool, str](ar)) { ret ar; }
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_ldst(ldst_base_scaled(8, true), rd, rd, 0));
+    val pr: R.Result[bool, str] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_LO12, symop.sym, 0);
+    if (R.is_err[bool, str](pr)) { ret pr; }
+    if (symop.sym_off != 0) { emit_add_imm(st, rd, rd, symop.sym_off::i64); }
+    ret R.ok[bool, str](true);
+}
+
+# a GOT-indirect load - the imported-data analogue of emit_global_load. the
+# symbol's address is loaded from its GOT slot into the destination register, then
+# dereferenced in place at the access width. the destination doubles as the address
+# scratch (the GOT sequence and the value load chain through Rt), so no reserved
+# scratch is spent
+fun emit_global_load_got(st: *encode.EncodeState, rt: u32, symop: *mir.MirOperand, width: u8) R.Result[bool, str] {
+    var w: u8 = width;
+    if (w == 0) { w = 8; }
+    val ar: R.Result[bool, str] = emit_global_addr_got(st, rt, symop);
+    if (R.is_err[bool, str](ar)) { ret ar; }
+    emit_mem_access(st, rt, rt, 0, w, true);
+    ret R.ok[bool, str](true);
+}
+
+# a GOT-indirect store - the imported-data analogue of emit_global_store. the
+# stored value resolves first (the zero register for an immediate 0, IP1 for a
+# non-zero immediate, the value's own register otherwise) so materializing the
+# symbol's address into IP0 never clobbers it; then the address is loaded from the
+# GOT slot into IP0 and the value stored through it
+fun emit_global_store_got(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *mir.MirOperand, width: u8) R.Result[bool, str] {
+    var w: u8 = width;
+    if (w == 0) { w = 8; }
+
+    var rt: u32 = ZR;
+    if (val_op.kind == mir.MIR_OP_IMM) {
+        if (val_op.imm != 0) {
+            emit_movewide_seq(st, SCRATCH1, val_op.imm::u64, is64(width));
+            rt = SCRATCH1;
+        }
+    } or {
+        val rr: R.Result[i32, str] = req_gpr(val_op);
+        if (R.is_err[i32, str](rr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rr)); }
+        rt = R.unwrap_ok[i32, str](rr)::u32;
+    }
+
+    val ar: R.Result[bool, str] = emit_global_addr_got(st, SCRATCH0, symop);
+    if (R.is_err[bool, str](ar)) { ret ar; }
+    emit_mem_access(st, rt, SCRATCH0, 0, w, false);
+    ret R.ok[bool, str](true);
+}
+
 # a direct or indirect call. a MIR_OP_SYM callee emits `bl sym` with a
 # zero imm26 placeholder and records RK_PLT32 at the instruction-word start (the
 # linker maps it to CALL26; addend is the symbol's own constant only - no x86 -4
@@ -947,6 +1020,7 @@ fun encode_mov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) 
 # destination is a folded-global store: `adrp IP0, sym` + `str Xt, [IP0, :lo12:sym]`
 fun emit_store_mem(st: *encode.EncodeState, f: *mir.MirFunction, dst_mem: *mir.MirOperand, val_op: *mir.MirOperand, width: u8) R.Result[bool, str] {
     if (dst_mem.kind == mir.MIR_OP_SYM) {
+        if (dst_mem.sym_got) { ret emit_global_store_got(st, dst_mem, val_op, width); }
         ret emit_global_store(st, dst_mem, val_op, width);
     }
     val mr: R.Result[A64Mem, str] = resolve_mem(f, dst_mem);
@@ -1027,6 +1101,7 @@ fun encode_load(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
     val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
 
     if (src.kind == mir.MIR_OP_SYM) {
+        if (src.sym_got) { ret emit_global_load_got(st, rd, src, mi.src_width); }
         ret emit_global_load(st, rd, src, mi.src_width);
     }
     val mr: R.Result[A64Mem, str] = resolve_mem(f, src);
@@ -1057,6 +1132,7 @@ fun encode_addr(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
 
     val memop: *mir.MirOperand = ?mi.operands[1];
     if (memop.kind == mir.MIR_OP_SYM) {
+        if (memop.sym_got) { ret emit_global_addr_got(st, rd, memop); }
         ret emit_global_addr(st, rd, memop);
     }
     val mr: R.Result[A64Mem, str] = resolve_mem(f, memop);
@@ -4914,6 +4990,81 @@ test "mach.lang.target.isa.arm64.encode:call_global_emitters_record_relocs_plus_
     or {
         if (st.relocs[6].kind != of.RK_LDST32_LO12) { bad = 1; }
         if (st.relocs[6].offset != 28)              { bad = 1; }
+    }
+
+    encode.buf_dnit(?st.buf);
+    if (st.relocs != nil && st.reloc_cap > 0) {
+        A.deallocate[encode.PendingReloc](?alloc, st.relocs, st.reloc_cap::usize);
+    }
+    ret bad;
+}
+
+# the GOT-indirect emitters (a preemptible / imported symbol) drive the adrp+ldr
+# GOT sequence and record RK_GOT_PAGE21 / RK_GOT_LO12 at the instruction-word
+# starts, both addend zero (the slot holds the symbol base). the load derefs the
+# GOT-loaded address in place; the store resolves its value first then addresses
+# through IP0. the reloc fields are zero placeholders pre-link.
+# GOT emitters record GOT relocs + base words
+test "mach.lang.target.isa.arm64.encode:got_indirect_emitters_record_relocs_plus_base_words" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+    st.alloc       = ?alloc;
+    st.relocs      = nil;
+    st.reloc_count = 0;
+    st.reloc_cap   = 0;
+
+    val sym: intern.StrId = 7::intern.StrId;
+
+    # GOT address-of: adrp x0,:got:sym ; ldr x0,[x0,:got_lo12:sym] ->
+    # 0x90000000 ; 0xf9400000, RK_GOT_PAGE21 @0, RK_GOT_LO12 @4, both addend 0.
+    var ao: mir.MirOperand = mir.op_sym(sym, 0);
+    ao.sym_got = true;
+    emit_global_addr_got(?st, 0, ?ao);
+    if (read_word(?st.buf, 0) != 0x90000000) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0xF9400000) { bad = 1; }
+    if (st.reloc_count != 2)                 { bad = 1; }
+    or {
+        if (st.relocs[0].kind != of.RK_GOT_PAGE21) { bad = 1; }
+        if (st.relocs[0].offset != 0)              { bad = 1; }
+        if (st.relocs[0].addend != 0)              { bad = 1; }
+        if (st.relocs[1].kind != of.RK_GOT_LO12)   { bad = 1; }
+        if (st.relocs[1].offset != 4)              { bad = 1; }
+        if (st.relocs[1].addend != 0)              { bad = 1; }
+    }
+
+    # GOT load: adrp x0 ; ldr x0,[x0] (GOT) ; ldr x0,[x0] (deref) ->
+    # 0x90000000 ; 0xf9400000 ; 0xf9400000, RK_GOT_PAGE21 @8, RK_GOT_LO12 @12; the
+    # deref carries no reloc.
+    var lo: mir.MirOperand = mir.op_sym(sym, 0);
+    lo.sym_got = true;
+    emit_global_load_got(?st, 0, ?lo, 8);
+    if (read_word(?st.buf, 8)  != 0x90000000) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0xF9400000) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0xF9400000) { bad = 1; }
+    if (st.reloc_count != 4)                  { bad = 1; }
+    or {
+        if (st.relocs[2].kind != of.RK_GOT_PAGE21) { bad = 1; }
+        if (st.relocs[3].kind != of.RK_GOT_LO12)   { bad = 1; }
+        if (st.relocs[3].offset != 12)             { bad = 1; }
+    }
+
+    # GOT store: value x1 already in a register ; adrp x16 ; ldr x16,[x16] (GOT) ;
+    # str w1,[x16] -> 0x90000010 ; 0xf9400210 ; 0xb9000201, RK_GOT_PAGE21 @20,
+    # RK_GOT_LO12 @24; the store carries no reloc.
+    var so: mir.MirOperand = mir.op_sym(sym, 0);
+    so.sym_got = true;
+    var sv: mir.MirOperand = mir.op_preg(1);
+    emit_global_store_got(?st, ?so, ?sv, 4);
+    if (read_word(?st.buf, 20) != 0x90000010) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0xF9400210) { bad = 1; }
+    if (read_word(?st.buf, 28) != 0xB9000201) { bad = 1; }
+    if (st.reloc_count != 6)                  { bad = 1; }
+    or {
+        if (st.relocs[4].kind != of.RK_GOT_PAGE21) { bad = 1; }
+        if (st.relocs[5].kind != of.RK_GOT_LO12)   { bad = 1; }
+        if (st.relocs[5].offset != 24)             { bad = 1; }
     }
 
     encode.buf_dnit(?st.buf);

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -77,6 +77,8 @@ fun arm64_elf_reloc_type(kind: of.RelocKind) u32 {
     if (kind == of.RK_LDST64_LO12)  { ret elf.R_AARCH64_LDST64_ABS_LO12_NC; }
     if (kind == of.RK_LDST128_LO12) { ret elf.R_AARCH64_LDST128_ABS_LO12_NC; }
     if (kind == of.RK_ABS32)        { ret elf.R_AARCH64_ABS32; }
+    if (kind == of.RK_GOT_PAGE21)   { ret elf.R_AARCH64_ADR_GOT_PAGE; }
+    if (kind == of.RK_GOT_LO12)     { ret elf.R_AARCH64_LD64_GOT_LO12_NC; }
     ret 0;
 }
 
@@ -264,9 +266,10 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
 }
 
 # the aarch64 forward reloc map produces the right R_AARCH64_* number for each kind
-# it supports, including a distinct LDST type per access width (Option B), and 0
-# (R_AARCH64_NONE) for a kind it has no width-correct ELF type for (RK_GOTPCREL /
-# RK_ABS32S / RK_ADDR32NB are not aarch64's)
+# it supports, including a distinct LDST type per access width (Option B), the GOT
+# twins (the two-instruction adrp+ldr GOT-indirect load), and 0 (R_AARCH64_NONE)
+# for a kind it has no width-correct ELF type for (the one-instruction x64
+# RK_GOTPCREL / RK_ABS32S / RK_ADDR32NB are not aarch64's)
 test "mach.lang.target.isa.arm64.register.arm64_elf_reloc_type:forward_map" {
     if (arm64_elf_reloc_type(of.RK_ABS64)        != elf.R_AARCH64_ABS64)               { ret 1; }
     if (arm64_elf_reloc_type(of.RK_PC32)         != elf.R_AARCH64_PREL32)              { ret 1; }
@@ -279,6 +282,8 @@ test "mach.lang.target.isa.arm64.register.arm64_elf_reloc_type:forward_map" {
     if (arm64_elf_reloc_type(of.RK_LDST64_LO12)  != elf.R_AARCH64_LDST64_ABS_LO12_NC)  { ret 1; }
     if (arm64_elf_reloc_type(of.RK_LDST128_LO12) != elf.R_AARCH64_LDST128_ABS_LO12_NC) { ret 1; }
     if (arm64_elf_reloc_type(of.RK_ABS32)        != elf.R_AARCH64_ABS32)               { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_GOT_PAGE21)   != elf.R_AARCH64_ADR_GOT_PAGE)        { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_GOT_LO12)     != elf.R_AARCH64_LD64_GOT_LO12_NC)    { ret 1; }
 
     # a kind aarch64 has no ELF type for maps to 0, the writer's unsupported signal.
     if (arm64_elf_reloc_type(of.RK_GOTPCREL) != 0) { ret 1; }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -117,6 +117,17 @@ pub val RK_SECREL32:     RelocKind = 17;
 # symbol's section, the CodeView partner of RK_SECREL32; patches a 2-byte field.
 # COFF-only; ELF and Mach-O never emit it
 pub val RK_SECTION:      RelocKind = 18;
+# aarch64 GOT page-high 21 bits (R_AARCH64_ADR_GOT_PAGE): the signed page delta to
+# the symbol's GOT slot packed into an ADRP, the GOT analogue of RK_PAGE21. the high
+# half of a GOT-indirect address load; pairs with RK_GOT_LO12. distinct from the
+# one-instruction x64 RK_GOTPCREL because the aarch64 GOT load is a two-instruction,
+# two-relocation adrp+ldr sequence
+pub val RK_GOT_PAGE21:   RelocKind = 19;
+# aarch64 GOT scaled lo12 (R_AARCH64_LD64_GOT_LO12_NC): (GOT(S) & 0xFFF) >> 3 into an
+# LDR imm12, the 64-bit-scaled GOT analogue of RK_LDST64_LO12. the low half of a
+# GOT-indirect address load: an LDR that dereferences the GOT slot; pairs with
+# RK_GOT_PAGE21
+pub val RK_GOT_LO12:     RelocKind = 20;
 
 # object-symbol flags, combined as a bitmask in `Symbol.flags`
 # ---
@@ -883,6 +894,8 @@ pub fun reloc_kind_name(kind: RelocKind) str {
     if (kind == RK_ABS32)        { ret "abs32"; }
     if (kind == RK_SECREL32)     { ret "secrel32"; }
     if (kind == RK_SECTION)      { ret "section"; }
+    if (kind == RK_GOT_PAGE21)   { ret "got_page21"; }
+    if (kind == RK_GOT_LO12)     { ret "got_lo12"; }
     ret "unknown";
 }
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -107,6 +107,11 @@ pub val R_AARCH64_LDST16_ABS_LO12_NC:  u32 = 284;
 pub val R_AARCH64_LDST32_ABS_LO12_NC:  u32 = 285;
 pub val R_AARCH64_LDST64_ABS_LO12_NC:  u32 = 286;
 pub val R_AARCH64_LDST128_ABS_LO12_NC: u32 = 299;
+# GOT-indirect addressing: the page-high half on the `adrp` and the scaled lo12
+# low half on the `ldr`, the GOT analogues of ADR_PREL_PG_HI21 / LDST64_ABS_LO12_NC.
+# a reference to a preemptible / imported symbol loads its address from a GOT slot
+pub val R_AARCH64_ADR_GOT_PAGE:        u32 = 311;
+pub val R_AARCH64_LD64_GOT_LO12_NC:    u32 = 312;
 
 # riscv relocation types. pub for the riscv64 `elf_reloc_type` forward map, as with
 # the x86_64 / aarch64 numbers above. R_RISCV_32 / R_RISCV_64 are the width-specific
@@ -167,6 +172,13 @@ val PF_R: u32 = 4;
 val R_X86_64_JUMP_SLOT:  u32 = 7;
 val R_AARCH64_JUMP_SLOT: u32 = 1026;
 val R_RISCV_JUMP_SLOT:   u32 = 5;
+
+# ELF GOT-slot dynamic relocation types: the loader binds a GOT entry to the
+# absolute address of a preemptible symbol (a data import). one per GOT slot in
+# `.rela.dyn`
+val R_X86_64_GLOB_DAT:  u32 = 6;
+val R_AARCH64_GLOB_DAT: u32 = 1025;
+val R_RISCV_GLOB_DAT:   u32 = 4;
 
 # ELF base (load-bias) relocation types: the loader adds the image's load bias to
 # the slot. one per in-image absolute pointer in a PIE image's `.rela.dyn`
@@ -310,6 +322,8 @@ fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, machine: u16, r_t
     if (r_type == R_AARCH64_LDST32_ABS_LO12_NC)                 { ret R.ok[of.RelocKind, str](of.RK_LDST32_LO12); }
     if (r_type == R_AARCH64_LDST64_ABS_LO12_NC)                 { ret R.ok[of.RelocKind, str](of.RK_LDST64_LO12); }
     if (r_type == R_AARCH64_LDST128_ABS_LO12_NC)                { ret R.ok[of.RelocKind, str](of.RK_LDST128_LO12); }
+    if (r_type == R_AARCH64_ADR_GOT_PAGE)                       { ret R.ok[of.RelocKind, str](of.RK_GOT_PAGE21); }
+    if (r_type == R_AARCH64_LD64_GOT_LO12_NC)                   { ret R.ok[of.RelocKind, str](of.RK_GOT_LO12); }
     ret R.err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
 }
 
@@ -4174,28 +4188,31 @@ test "mach.lang.target.of.elf.emit_object:unmapped_reloc_kind" {
 
 # the aarch64 page/page-offset reloc kinds (#1163) map back from their R_AARCH64
 # machine types 1:1; each per-width LDST type recovers a distinct kind so the
-# linker reads the access-size scale from the kind alone (Option B). this covers
-# the reverse parse map (`reloc_kind_for`); the forward map now lives with the
-# aarch64 ISA and is tested in target/isa/arm64/register.mach
+# linker reads the access-size scale from the kind alone (Option B), and the GOT
+# twins (ADR_GOT_PAGE / LD64_GOT_LO12_NC) recover their GOT-indirect kinds. this
+# covers the reverse parse map (`reloc_kind_for`); the forward map now lives with
+# the aarch64 ISA and is tested in target/isa/arm64/register.mach
 test "mach.lang.target.of.elf.reloc_kind_for:aarch64_page_lo12_reverse" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var kinds: [7]of.RelocKind;
+    var kinds: [9]of.RelocKind;
     kinds[0] = of.RK_PAGE21;      kinds[1] = of.RK_ADD_LO12;
     kinds[2] = of.RK_LDST8_LO12;  kinds[3] = of.RK_LDST16_LO12;
     kinds[4] = of.RK_LDST32_LO12; kinds[5] = of.RK_LDST64_LO12;
     kinds[6] = of.RK_LDST128_LO12;
+    kinds[7] = of.RK_GOT_PAGE21;  kinds[8] = of.RK_GOT_LO12;
 
-    var expect: [7]u32;
+    var expect: [9]u32;
     expect[0] = R_AARCH64_ADR_PREL_PG_HI21; expect[1] = R_AARCH64_ADD_ABS_LO12_NC;
     expect[2] = R_AARCH64_LDST8_ABS_LO12_NC; expect[3] = R_AARCH64_LDST16_ABS_LO12_NC;
     expect[4] = R_AARCH64_LDST32_ABS_LO12_NC; expect[5] = R_AARCH64_LDST64_ABS_LO12_NC;
     expect[6] = R_AARCH64_LDST128_ABS_LO12_NC;
+    expect[7] = R_AARCH64_ADR_GOT_PAGE; expect[8] = R_AARCH64_LD64_GOT_LO12_NC;
 
     var n: usize = 0;
-    for (n < 7) {
+    for (n < 9) {
         val kr: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, 183, expect[n]);
         if (R.is_err[of.RelocKind, str](kr))                { ret 1; }
         if (R.unwrap_ok[of.RelocKind, str](kr) != kinds[n]) { ret 1; }


### PR DESCRIPTION
Integration merge for the v3.3.1 seed-gate patch (stage β on #2013): manifest accepts the simd profile key (#2027), .debug_str cross-module dedup (#1708/#2025), aarch64 GOT foundation + verified shared objects (#2022/#2023). Tag v3.3.1 follows on the merge commit; CD publishes the simd-aware seeds.