### PR TITLE
release: v3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.1] - 2026-07-11
+
+The vector correctness patch. The `#2038` runtime suite's first run caught a
+shipped v3.4.0 miscompile: a by-value 128-bit vector argument or return whose
+value was not already register-resident was captured with a machine-word move,
+silently truncating lanes 2-3. Fixed at the shared capture path (a 16-byte
+`CLASS_FP` value now moves full-width on both SysV and AAPCS64); scalar codegen
+is byte-identical. Debug info for vectors also lands. Built with mach 3.4.0.
+
+**Known limitation:** win64 never classified vector arguments/returns (a
+distinct, pre-existing gap first exercised by this patch's regression test) —
+vector-by-value calls on x86_64-windows are mis-passed until #2055 lands; the
+MS x64 convention (args by reference, returns in XMM0) is specified there.
+
+### Added
+- debuginfo: vector types emit `DW_TAG_array_type` + `DW_AT_GNU_vector` DIEs —
+  gdb prints vector locals lane-by-lane on `-g` builds (#2018).
+
+### Fixed
+- codegen: **by-value vector argument/return capture is full-width** — the
+  caller's return capture and the callee's parameter capture no longer truncate
+  a non-coalesced vector register copy to 64 bits (#2053).
+- debuginfo: a struct's vector member gets its true 16-byte layout in DWARF
+  member offsets (the DWARF type bridge modeled vectors at pointer width;
+  runtime layout was always correct) (#2051).
+
 ## [3.4.0] - 2026-07-11
 
 The SIMD release. Ten 128-bit vector types (`f32x4 f64x2 i8x16 i16x8 i32x4

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "3.4.0"
+version = "3.4.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -91,6 +91,11 @@ val DW_AT_call_line:       u8 = 0x59;
 val DW_AT_data_member_location: u8 = 0x38;
 val DW_AT_count:                u8 = 0x37;
 
+# the GNU extension attribute marking a DW_TAG_array_type as a hardware vector so a
+# debugger renders it lane-by-lane (#1965/#2018). wider than a u8: its abbrev attr
+# code is written as ULEB directly, since emit_attr's `at` is a u8.
+val DW_AT_GNU_vector: u16 = 0x2107;
+
 # DW_AT_inline value: this subprogram is an abstract instance that was inlined (never
 # out-of-line here); its concrete expansions are DW_TAG_inlined_subroutine DIEs that
 # reference it by DW_AT_abstract_origin.
@@ -102,6 +107,7 @@ val DW_FORM_data8:      u8 = 0x07;
 val DW_FORM_string:     u8 = 0x08;
 val DW_FORM_data1:      u8 = 0x0b;
 val DW_FORM_flag:       u8 = 0x0c;
+val DW_FORM_flag_present: u8 = 0x19;
 val DW_FORM_ref4:       u8 = 0x13;
 val DW_FORM_udata:      u8 = 0x0f;
 val DW_FORM_strp:       u8 = 0x0e;
@@ -204,6 +210,9 @@ val ABBREV_STRUCT_LEAF_ANON: u8 = 0x1b;
 val ABBREV_UNION_ANON:       u8 = 0x1c;
 val ABBREV_UNION_LEAF_ANON:  u8 = 0x1d;
 val ABBREV_MEMBER_ANON:      u8 = 0x1e;
+
+# a hardware vector: a DW_TAG_array_type flagged DW_AT_GNU_vector (#1965/#2018).
+val ABBREV_VECTOR_ARRAY:     u8 = 0x1f;
 
 # name_off sentinel marking a composite / member with no source spelling, so the emitter
 # selects the *_ANON abbrev and omits DW_AT_name rather than emitting an empty strp (#1955)
@@ -451,12 +460,14 @@ fun home_eq(k1: u8, r1: i32, o1: i64, n1: i64, k2: u8, r2: i32, o2: i64, n2: i64
 
 # a type DIE's shape kind. TK_BASE is a scalar (DW_TAG_base_type); the rest are
 # composites: TK_STRUCT / TK_UNION carry members, TK_ARRAY an element + count,
-# TK_POINTER a pointee. Every kind records its emitted DIE offset for ref4
+# TK_POINTER a pointee, TK_VECTOR an element + lane count (a DW_AT_GNU_vector array).
+# Every kind records its emitted DIE offset for ref4
 val TK_BASE:    u8 = 0;
 val TK_STRUCT:  u8 = 1;
 val TK_UNION:   u8 = 2;
 val TK_ARRAY:   u8 = 3;
 val TK_POINTER: u8 = 4;
+val TK_VECTOR:  u8 = 5;
 
 # one type DIE in the compile unit's type table. A scalar base type (TK_BASE) carries
 # `encoding` / `byte_size` and is deduplicated by source spelling; a composite carries
@@ -758,7 +769,18 @@ fun sem_base_type(s: *session.Session, tid: semtype.TypeId, address_size: u8) O.
     if (tid == semtype.TYPE_NIL || tid == semtype.TYPE_ERROR) { ret O.none[TypeDie](); }
     val to: O.Option[*semtype.Type] = semtype.get(?s.types, tid);
     if (O.is_none[*semtype.Type](to)) { ret O.none[TypeDie](); }
-    val kind: semtype.TypeKind = O.unwrap[*semtype.Type](to).kind;
+    ret base_die_of_kind(O.unwrap[*semtype.Type](to).kind, address_size);
+}
+
+# build the TK_BASE TypeDie for a primitive scalar `kind` (its DW_ATE_* encoding, source
+# spelling, and byte width), or none when `kind` is not a primitive scalar. Shared by
+# `sem_base_type` (a scalar variable's type) and the vector intern path (a vector's lane
+# base type, whose element is stored as a bare scalar TypeKind, not a TypeId)
+# ---
+# kind:         a semantic TypeKind
+# address_size: target pointer width, for the raw `ptr` base
+# ret:          the base type DIE, or none for a non-scalar kind
+fun base_die_of_kind(kind: semtype.TypeKind, address_size: u8) O.Option[TypeDie] {
     val d: semtype.PrimDesc = semtype.prim_desc(kind);
     if (d.class == semtype.PRIM_CLASS_NONE) { ret O.none[TypeDie](); }
 
@@ -1140,6 +1162,19 @@ fun build_abbrev(b: *enc.ByteBuf) {
     emit_attr(b, DW_AT_data_member_location, DW_FORM_udata);
     uleb(b, 0); uleb(b, 0);
 
+    # a hardware vector: a DW_TAG_array_type over its lane base with DW_AT_GNU_vector so a
+    # debugger renders it lane-by-lane. the flag is DW_FORM_flag_present, so its presence
+    # lives here in the abbrev and the emitted DIE body stays byte-identical to a plain
+    # array's -- only the leading abbrev code differs (#1965/#2018). the wide attr code is
+    # written as ULEB directly (emit_attr's `at` is a u8).
+    uleb(b, ABBREV_VECTOR_ARRAY::u64);
+    uleb(b, DW_TAG_array_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_yes);
+    emit_attr(b, DW_AT_type, DW_FORM_ref4);
+    uleb(b, DW_AT_GNU_vector::u64);
+    uleb(b, DW_FORM_flag_present::u64);
+    uleb(b, 0); uleb(b, 0);
+
     uleb(b, 0);   # null abbrev code terminates the table
 }
 
@@ -1363,6 +1398,16 @@ fun emit_type_dies(b: *enc.ByteBuf, tc: *TypeCtx, len_pos: usize, relocs: *InfoR
             enc.emit_byte(b, ABBREV_SUBRANGE);  # the single subrange child gives the count
             uleb(b, td.count::u64);             # DW_AT_count
             enc.emit_byte(b, 0);                # null DIE terminates the array's children
+        }
+        or (td.kind == TK_VECTOR) {
+            # identical body to TK_ARRAY: the DW_AT_GNU_vector flag lives in the abbrev
+            # (DW_FORM_flag_present), so only the leading abbrev code differs (#1965/#2018).
+            enc.emit_byte(b, ABBREV_VECTOR_ARRAY);
+            push_type_fixup(fixups, nfix, b.len::u32, td.elem::u32);
+            enc.emit_u32(b, 0);                 # DW_AT_type (ref4, patched) -- the lane base
+            enc.emit_byte(b, ABBREV_SUBRANGE);  # the single subrange child gives the lane count
+            uleb(b, td.count::u64);             # DW_AT_count
+            enc.emit_byte(b, 0);                # null DIE terminates the vector's children
         }
         or {
             # a memberless aggregate uses the DW_CHILDREN_no leaf abbrev (and no
@@ -3031,6 +3076,25 @@ fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc:
         ret ix;
     }
 
+    if (kind == semtype.TYPE_VECTOR) {
+        # a vector is a DW_AT_GNU_vector array over its lane scalar, deduped by semantic id
+        # like the other composites. the lane is stored as a bare scalar TypeKind (not a
+        # TypeId), so intern its base DIE directly -- a scalar base never recurses back to a
+        # composite, so no interior cycle re-dedup is needed. size is synthesized by the
+        # consumer from element x count, so byte_size stays 0 (mirroring the plain array).
+        val ekind: semtype.TypeKind = t.data.vector.element;
+        val lanes: u32              = t.data.vector.lanes;
+        val obk: O.Option[TypeDie] = base_die_of_kind(ekind, address_size);
+        if (O.is_none[TypeDie](obk)) { ret -1; }
+        val el: i32 = base_intern(tc, strtab, O.unwrap[TypeDie](obk));
+        if (el < 0) { ret -1; }
+        val ix: i32 = comp_reserve(tc, TK_VECTOR, sem);
+        if (ix < 0) { ret -1; }
+        tc.types[ix::u32].elem  = el;
+        tc.types[ix::u32].count = lanes;
+        ret ix;
+    }
+
     if (kind == semtype.TYPE_REC || kind == semtype.TYPE_UNI || kind == semtype.TYPE_INSTANCE) {
         ret struct_intern(s, tgt, irmod, tc, strtab, sem, address_size);
     }
@@ -3384,7 +3448,7 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     page.make(?alloc);
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     build_abbrev(?b);
-    var e: [345]u8;
+    var e: [355]u8;
     e[0]=0x01; e[1]=0x11; e[2]=0x01; e[3]=0x25; e[4]=0x08; e[5]=0x03; e[6]=0x08; e[7]=0x1B;
     e[8]=0x08; e[9]=0x13; e[10]=0x05; e[11]=0x11; e[12]=0x01; e[13]=0x12; e[14]=0x07; e[15]=0x10;
     e[16]=0x17; e[17]=0x00; e[18]=0x00; e[19]=0x02; e[20]=0x24; e[21]=0x00; e[22]=0x03; e[23]=0x0E;
@@ -3456,8 +3520,10 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     e[328]=0x1d; e[329]=0x17; e[330]=0x00; e[331]=0x0B; e[332]=0x0F; e[333]=0x00; e[334]=0x00;
     # ABBREV_MEMBER_ANON (0x1e): DW_TAG_member, no children, type ref4, data_member_location udata.
     e[335]=0x1e; e[336]=0x0D; e[337]=0x00; e[338]=0x49; e[339]=0x13; e[340]=0x38; e[341]=0x0F; e[342]=0x00; e[343]=0x00;
-    e[344]=0x00;   # null abbrev code terminates the table
-    val ok: bool = buf_eq(?b, ?e[0], 345);
+    # ABBREV_VECTOR_ARRAY (0x1f): DW_TAG_array_type, children, element type ref4, DW_AT_GNU_vector (0x2107 -> uleb 0x87 0x42) flag_present.
+    e[344]=0x1f; e[345]=0x01; e[346]=0x01; e[347]=0x49; e[348]=0x13; e[349]=0x87; e[350]=0x42; e[351]=0x19; e[352]=0x00; e[353]=0x00;
+    e[354]=0x00;   # null abbrev code terminates the table
+    val ok: bool = buf_eq(?b, ?e[0], 355);
     enc.buf_dnit(?b);
     if (!ok) { ret 1; }
     ret 0;
@@ -3509,6 +3575,48 @@ test "mach.lang.be.codegen.dwarf.emit_type_dies:composite_refs" {
     if (b.data[td[4].off::usize] != ABBREV_STRUCT_LEAF) { code = 1; }
     # the pointer references the struct, the array references the base.
     if (td[2].elem != 1 || td[3].elem != 0) { code = 1; }
+
+    enc.buf_dnit(?b);
+    ret code;
+}
+
+# a TK_VECTOR emits the DW_AT_GNU_vector array abbrev over its lane base, with a single
+# DW_TAG_subrange child carrying the lane count and a DW_AT_type ref4 fixup to the lane
+# base; its DIE body is byte-identical to a plain array's -- only the leading abbrev code
+# differs, because the vector flag rides the abbrev as DW_FORM_flag_present (#2018).
+test "mach.lang.be.codegen.dwarf.emit_type_dies:vector" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var code: i32 = 0;
+
+    # types: [0] base i32, [1] i32x4 vector (lane base -> 0, four lanes).
+    var td: [2]TypeDie;
+    td[0].kind=TK_BASE;   td[0].off=0; td[0].sem=semtype.TYPE_NIL; td[0].name="i32"; td[0].name_off=1; td[0].encoding=DW_ATE_signed; td[0].byte_size=4; td[0].elem=-1; td[0].count=0; td[0].memb_start=0; td[0].memb_count=0;
+    td[1].kind=TK_VECTOR; td[1].off=0; td[1].sem=200; td[1].name=""; td[1].name_off=0; td[1].encoding=0; td[1].byte_size=0; td[1].elem=0; td[1].count=4; td[1].memb_start=0; td[1].memb_count=0;
+
+    var tc: TypeCtx;
+    tc.alloc=?alloc; tc.types=?td[0]; tc.ntypes=2; tc.type_cap=2; tc.membs=nil; tc.nmemb=0; tc.memb_cap=0;
+
+    var relocs: [16]InfoReloc;
+    var rc: u32 = 0;
+    var fixups: [8]TypeFixup;
+    var nfix: u32 = 0;
+    var b: enc.ByteBuf = enc.buf_init(?alloc);
+    emit_type_dies(?b, ?tc, 0, ?relocs[0], ?rc, ?fixups[0], ?nfix);
+
+    # the vector DIE opens with ABBREV_VECTOR_ARRAY, not the plain-array abbrev.
+    if (b.data[td[1].off::usize] != ABBREV_VECTOR_ARRAY) { code = 1; }
+    # exactly one ref4 fixup: the vector -> its lane base type, patched to the base's offset.
+    if (nfix != 1) { code = 1; }
+    or {
+        if (bin.read_u32_le(b.data, fixups[0].pos::usize) != td[0].off) { code = 1; }
+        if (fixups[0].target != 0)                                      { code = 1; }
+    }
+    # abbrev code (1) + DW_AT_type ref4 (4) => the subrange child opens at off+5, its
+    # DW_AT_count uleb (4) at off+6, and the null child terminator at off+7.
+    if (b.data[(td[1].off + 5)::usize] != ABBREV_SUBRANGE) { code = 1; }
+    if (b.data[(td[1].off + 6)::usize] != 4)               { code = 1; }
+    if (b.data[(td[1].off + 7)::usize] != 0)               { code = 1; }
 
     enc.buf_dnit(?b);
     ret code;

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -845,6 +845,19 @@ fun sem_to_ir(s: *session.Session, irmod: *ir.Module, sem: semtype.TypeId) R.Res
         ret ir_type.intern_array(?irmod.types, R.unwrap_ok[ir_type.IrTypeId, str](rb), ecount);
     }
 
+    # a vector bridges to an IRT_VECTOR over its lowered lane scalar, exactly as
+    # `lower_type` does, so a vector struct member is laid out at its true 16-byte size
+    # and its DWARF member offset agrees with the emitted code -- not the pointer-width
+    # slot the fallthrough would give (#2051). the lane is a bare scalar TypeKind.
+    if (k == semtype.TYPE_VECTOR) {
+        val ed: semtype.PrimDesc = semtype.prim_desc(t.data.vector.element);
+        val lanes: u32 = t.data.vector.lanes;
+        var res_elem: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?irmod.types, ed.bits);
+        if (ed.class == semtype.PRIM_CLASS_FLOAT) { res_elem = ir_type.intern_float(?irmod.types, ed.bits); }
+        if (R.is_err[ir_type.IrTypeId, str](res_elem)) { ret res_elem; }
+        ret ir_type.intern_vector(?irmod.types, R.unwrap_ok[ir_type.IrTypeId, str](res_elem), lanes);
+    }
+
     if (k == semtype.TYPE_REC || k == semtype.TYPE_UNI || k == semtype.TYPE_INSTANCE) {
         ret sem_to_ir_nominal(s, irmod, sem, k == semtype.TYPE_UNI);
     }
@@ -3619,6 +3632,45 @@ test "mach.lang.be.codegen.dwarf.emit_type_dies:vector" {
     if (b.data[(td[1].off + 7)::usize] != 0)               { code = 1; }
 
     enc.buf_dnit(?b);
+    ret code;
+}
+
+# sem_to_ir bridges a vector to an IRT_VECTOR of its lane scalar (16 bytes for the seeded
+# shapes), not the pointer-width slot the fallthrough gave -- so a vector struct member is
+# laid out at its true size and its DWARF DW_AT_data_member_location agrees with the code
+# the backend emitted, rather than shifting every later member by 8 bytes (#2051).
+test "mach.lang.be.codegen.dwarf.sem_to_ir:vector" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var code: i32 = 0;
+    val rv: R.Result[semtype.TypeId, str] = semtype.intern_vector(?s.types, semtype.TYPE_F32, 4);
+    if (R.is_err[semtype.TypeId, str](rv)) { code = 1; }
+    or {
+        val vec_sem: semtype.TypeId = R.unwrap_ok[semtype.TypeId, str](rv);
+        val im: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+        if (R.is_err[ir.Module, str](im)) { code = 1; }
+        or {
+            var m: ir.Module = R.unwrap_ok[ir.Module, str](im);
+            val ri: R.Result[ir_type.IrTypeId, str] = sem_to_ir(?s, ?m, vec_sem);
+            if (R.is_err[ir_type.IrTypeId, str](ri)) { code = 1; }
+            or {
+                val ot: O.Option[*ir_type.IrType] = ir_type.get(?m.types, R.unwrap_ok[ir_type.IrTypeId, str](ri));
+                if (O.is_none[*ir_type.IrType](ot)) { code = 1; }
+                or {
+                    val it: *ir_type.IrType = O.unwrap[*ir_type.IrType](ot);
+                    # pre-fix this was IRT_PTR (8 bytes); it must be a 4-lane vector.
+                    if (it.kind != ir_type.IRT_VECTOR)  { code = 1; }
+                    if (it.data.vector_.lanes != 4)     { code = 1; }
+                }
+            }
+            ir.dnit(?m);
+        }
+    }
+    session.dnit(?s);
     ret code;
 }
 

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1640,18 +1640,26 @@ fun rt_lane_ok(v: i32x4, l0: i32, l1: i32, l2: i32, l3: i32) bool {
 }
 
 test "mach.lang.be.codegen.mir.abi:vector_by_value_roundtrip" {
-    val src: i32x4 = i32x4{266, 10, 70000, 40000};
-    # ret-of-arg (passthru): the arg is loaded from a slot into the arg register.
-    if (!rt_lane_ok(rt_passthru(src), 266, 10, 70000, 40000)) { ret 1; }
-    # ret-of-literal: a slot-materialized literal captured into the return register.
-    if (!rt_lane_ok(rt_litret(), 266, 10, 70000, 40000)) { ret 1; }
-    # ret-of-local.
-    if (!rt_lane_ok(rt_localret(266), 266, 10, 70000, 40000)) { ret 1; }
-    # ret-of-call-result: a returned vector captured, then passed and returned again.
-    if (!rt_lane_ok(rt_passthru(rt_litret()), 266, 10, 70000, 40000)) { ret 1; }
-    # op-result return (register-resident -- the path tier-1 already proved).
-    if (!rt_lane_ok(rt_add_one(src), 267, 11, 70001, 40001)) { ret 1; }
-    # mixed scalar + vector signature round-trip.
-    if (!rt_lane_ok(rt_mixed(5, src, 9), 271, 19, 140000, 80000)) { ret 1; }
-    ret 0;
+    # win64's vector-by-value ABI is a separate, never-implemented gap (#2055): win64
+    # is the only classifier without an `is_vector` branch, so a 128-bit vector is
+    # mis-passed as CLASS_GP. skip the by-value exercise on windows until #2055 lands;
+    # the SysV/NEON capture-width fix (#2053) this guards is unaffected by it.
+    $if ($mach.build.os == $mach.os.windows) {
+        ret 0;
+    } $or {
+        val src: i32x4 = i32x4{266, 10, 70000, 40000};
+        # ret-of-arg (passthru): the arg is loaded from a slot into the arg register.
+        if (!rt_lane_ok(rt_passthru(src), 266, 10, 70000, 40000)) { ret 1; }
+        # ret-of-literal: a slot-materialized literal captured into the return register.
+        if (!rt_lane_ok(rt_litret(), 266, 10, 70000, 40000)) { ret 1; }
+        # ret-of-local.
+        if (!rt_lane_ok(rt_localret(266), 266, 10, 70000, 40000)) { ret 1; }
+        # ret-of-call-result: a returned vector captured, then passed and returned again.
+        if (!rt_lane_ok(rt_passthru(rt_litret()), 266, 10, 70000, 40000)) { ret 1; }
+        # op-result return (register-resident -- the path tier-1 already proved).
+        if (!rt_lane_ok(rt_add_one(src), 267, 11, 70001, 40001)) { ret 1; }
+        # mixed scalar + vector signature round-trip.
+        if (!rt_lane_ok(rt_mixed(5, src, 9), 271, 19, 140000, 80000)) { ret 1; }
+        ret 0;
+    }
 }

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -937,7 +937,7 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     # the result vreg.
     val dst: u32 = context.instr_vreg(ctx, iid);
     if (dst != mir.MIR_VREG_NIL && rslot.class != abi.CLASS_SRET) {
-        val rr: R.Result[bool, str] = emit_ret_slot_to_vreg(ctx, mb, rslot, dst, ret_aggr);
+        val rr: R.Result[bool, str] = emit_ret_slot_to_vreg(ctx, mb, rslot, dst, ret_aggr, ret_size);
         if (R.is_err[bool, str](rr)) { ret rr; }
     }
     if (dst != mir.MIR_VREG_NIL) {
@@ -1169,6 +1169,18 @@ fun fp_move_width(size: u64) R.Result[u8, str] {
     ret R.err[u8, str]("mir.abi.fp_move_width: CLASS_FP scalar of unsupported size (expected 4, 8, or 16 bytes)");
 }
 
+# capture a value passed / returned in `slot`'s canonical register into `dst` vreg.
+# a 128-bit vector (a CLASS_FP slot of 16 bytes) copies at its full 16-byte width so the
+# reg-reg move is a MOVAPS / NEON Q move, not a 64-bit MOVSD that drops lanes 2-3 when
+# the vreg does not coalesce onto the incoming register (#2053). every scalar -- GP or
+# float -- keeps the machine-word move it always used, so its codegen is byte-identical.
+fun capture_slot_reg(ctx: *context.LowerCtx, mb: *mir.MirBlock, dst: u32, slot: abi.ParamSlot, size: u64) R.Result[bool, str] {
+    if (slot.class == abi.CLASS_FP && size == 16) {
+        ret context.emit_fmov(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg::u32), 16);
+    }
+    ret context.emit_mov(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg::u32));
+}
+
 # the move width for materializing a scalar GP value into its argument / return
 # register. a 32-bit value rides a width-4 move so a backend can re-extend it to the
 # register width by its own convention -- RV64 lp64 holds a 32-bit register
@@ -1214,7 +1226,7 @@ fun record_outgoing_size(ctx: *context.LowerCtx, bytes: i64) {
 # dst:     the result vreg, or the result-storage pointer for an aggregate
 # is_aggr: whether the return is an aggregate flowing by address
 # ret:     ok(true) on success, or a loud error
-fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, dst: u32, is_aggr: bool) R.Result[bool, str] {
+fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, dst: u32, is_aggr: bool, size: u64) R.Result[bool, str] {
     if (is_aggr) {
         var plan: PiecePlan;
         plan.store      = true;
@@ -1225,7 +1237,7 @@ fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.P
         plan.stack_ok   = false;
         ret materialize_pieces(ctx, mb, slot, plan);
     }
-    ret context.emit_mov(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg::u32));
+    ret capture_slot_reg(ctx, mb, dst, slot, size);
 }
 
 # emit the entry-block ABI pre-coloring for incoming parameters
@@ -1369,7 +1381,7 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
         plan.stack_ok   = true;
         ret materialize_pieces(ctx, mb, slot, plan);
     }
-    ret context.emit_mov(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg::u32));
+    ret capture_slot_reg(ctx, mb, pv, slot, size);
 }
 
 # report whether IR parameter `param_ix` is read anywhere in the function body
@@ -1610,5 +1622,36 @@ test "mach.lang.be.codegen.mir.abi.param_has_use:dbg_value_is_not_a_use" {
     if (param_has_use(fn, 1) != true)  { ir.dnit(?m); ret 1; }
 
     ir.dnit(?m);
+    ret 0;
+}
+
+# #2053 colocated runtime regression: a by-value 128-bit vector passed or returned
+# must carry all four lanes, never truncate to the low 64 bits. lane values are
+# discriminating -- lanes 2-3 are nonzero with cross-byte content, so a low-half
+# truncation (the shipped bug) is detected. these helpers are referenced only by the
+# test block below, so `mach build` emits none of them into the compiler.
+fun rt_passthru(a: i32x4) i32x4 { ret a; }
+fun rt_litret() i32x4 { ret i32x4{266, 10, 70000, 40000}; }
+fun rt_localret(seed: i32) i32x4 { var v: i32x4 = i32x4{seed, 10, 70000, 40000}; ret v; }
+fun rt_add_one(a: i32x4) i32x4 { var one: i32x4 = i32x4{1, 1, 1, 1}; ret a + one; }
+fun rt_mixed(tag: i64, a: i32x4, k: i64) i32x4 { var b: i32x4 = i32x4{tag::i32, k::i32, 70000, 40000}; ret a + b; }
+fun rt_lane_ok(v: i32x4, l0: i32, l1: i32, l2: i32, l3: i32) bool {
+    ret v[0] == l0 && v[1] == l1 && v[2] == l2 && v[3] == l3;
+}
+
+test "mach.lang.be.codegen.mir.abi:vector_by_value_roundtrip" {
+    val src: i32x4 = i32x4{266, 10, 70000, 40000};
+    # ret-of-arg (passthru): the arg is loaded from a slot into the arg register.
+    if (!rt_lane_ok(rt_passthru(src), 266, 10, 70000, 40000)) { ret 1; }
+    # ret-of-literal: a slot-materialized literal captured into the return register.
+    if (!rt_lane_ok(rt_litret(), 266, 10, 70000, 40000)) { ret 1; }
+    # ret-of-local.
+    if (!rt_lane_ok(rt_localret(266), 266, 10, 70000, 40000)) { ret 1; }
+    # ret-of-call-result: a returned vector captured, then passed and returned again.
+    if (!rt_lane_ok(rt_passthru(rt_litret()), 266, 10, 70000, 40000)) { ret 1; }
+    # op-result return (register-resident -- the path tier-1 already proved).
+    if (!rt_lane_ok(rt_add_one(src), 267, 11, 70001, 40001)) { ret 1; }
+    # mixed scalar + vector signature round-trip.
+    if (!rt_lane_ok(rt_mixed(5, src, 9), 271, 19, 140000, 80000)) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Integration merge for the v3.4.1 vector correctness patch (#2053 capture-width fix, #2018 DWARF vector DIEs, #2051 DWARF member offsets; #2055 win64 gap documented). Tag v3.4.1 follows; CD publishes seeds.