### PR TITLE
fix(me): carry real IRT_FN signatures on generic-instance callee references (#2063)

### DIFF
--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -82,6 +82,16 @@ pub val VC_DANGLING_ID:     VerifyCheck = 12;
 # const-int block id). opt-in alongside the other `repr` checks
 pub val VC_TYPE_AGREE:      VerifyCheck = 13;
 
+# a direct call's fixed argument operand type disagrees with the callee's declared
+# parameter type: an aggregate parameter received a non-aggregate (pointer/scalar)
+# operand - the #2035 class, a by-value aggregate arg mis-typed to a pointer - or a
+# scalar parameter received an incompatible operand. only checked when the call
+# carries a real IRT_FN signature (every direct call, since generic instances now
+# do too); an indirect / untyped-pointer call and the variadic tail are not
+# checked. always on - the durable tripwire that keeps the #2035 defect class from
+# shipping
+pub val VC_CALL_ARG_TYPE:   VerifyCheck = 14;
+
 # one invariant failure, located as precisely as the failing check allows
 # ---
 # function: index into Module.functions
@@ -192,6 +202,7 @@ pub fun describe(check: VerifyCheck) str {
     if (check == VC_TYPE_RESOLVE)    { ret "type resolution: operand or aux type does not resolve"; }
     if (check == VC_DANGLING_ID)     { ret "dangling id: a block list names an out-of-range instruction id"; }
     if (check == VC_TYPE_AGREE)      { ret "type agreement: operand types violate the opcode's typing contract"; }
+    if (check == VC_CALL_ARG_TYPE)   { ret "call argument typing: a call argument's type disagrees with the callee's declared parameter"; }
     ret "unknown verification check";
 }
 
@@ -526,6 +537,12 @@ fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: 
         val res_agree: R.Result[bool, str] = check_type_agree(m, ins, fi, bid, iid, r);
         if (R.is_err[bool, str](res_agree)) { ret res_agree; }
     }
+    # always on: a direct call's fixed argument types must agree with the callee's
+    # declared IRT_FN signature. now that generic instances carry real signatures,
+    # this makes the #2035 defect class (a by-value aggregate arg mis-typed to a
+    # pointer) structurally impossible to ship.
+    val res_call: R.Result[bool, str] = check_call_arg_types(m, ins, fi, bid, iid, r);
+    if (R.is_err[bool, str](res_call)) { ret res_call; }
     ret R.ok[bool, str](true);
 }
 
@@ -626,6 +643,69 @@ fun check_type_agree(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid:
         if (ins.operands[2].kind != value.VAL_CONST_INT)         { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
     }
     ret R.ok[bool, str](true);
+}
+
+# VC_CALL_ARG_TYPE: a direct call classifies its ABI from the callee's declared
+# IRT_FN signature (`aux_ty`), so each fixed argument's operand type must agree with
+# the declared parameter type. checked only when `aux_ty` is a real IRT_FN - every
+# direct call to a named function or (now) a monomorphized instance; an indirect
+# call through an untyped function pointer carries no declared parameter types and
+# is skipped, as is the variadic tail past the declared parameter count (its
+# per-operand classification is the intended path). the first operand is the callee,
+# so argument i is operand i+1
+# ---
+# m:   the enclosing module (type-table oracle)
+# ins: the call instruction to check
+# fi:  index of the enclosing function into Module.functions
+# bid: the block holding ins (located on a violation)
+# iid: the instruction id (located on a violation)
+# r:   the report to record into
+# ret: true on completion, or an allocation error
+fun check_call_arg_types(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid: id.BlockId, iid: id.InstructionId, r: *VerifyReport) R.Result[bool, str] {
+    if (ins.kind != instruction.OP_CALL) { ret R.ok[bool, str](true); }
+    if (ins.operand_count == 0)          { ret R.ok[bool, str](true); }
+
+    val ot: O.Option[*type.IrType] = type.get(?m.types, ins.aux_ty);
+    if (!O.is_some[*type.IrType](ot))    { ret R.ok[bool, str](true); }
+    val sig: *type.IrType = O.unwrap[*type.IrType](ot);
+    if (sig.kind != type.IRT_FN)         { ret R.ok[bool, str](true); }
+
+    val pc: u32 = sig.data.fn.param_count;
+    var i: u32 = 0;
+    for (i < pc) {
+        val argix: u32 = i + 1;
+        # fewer operands than declared params is a wrong-arity call (VC_OPERAND_TYPE);
+        # stop rather than read past the operand list.
+        if (argix >= ins.operand_count) { ret R.ok[bool, str](true); }
+        if (!call_arg_type_ok(m, sig.data.fn.params[i], ins.operands[argix].ty)) {
+            val rr: R.Result[bool, str] = push(r, fi, bid, iid, VC_CALL_ARG_TYPE);
+            if (R.is_err[bool, str](rr)) { ret rr; }
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# whether a call argument operand type `q` agrees with the declared parameter type
+# `p`. an aggregate parameter takes its value by address, so it must receive an
+# aggregate operand (also by address) - a pointer or scalar operand there is the
+# #2035 mis-typing. two distinct aggregate ids are accepted: the verifier has no
+# target, so it cannot compare their ABI classification, but both flowing by
+# address is the load-bearing invariant. a non-aggregate pointer parameter
+# accepts any address form (ptr / fnptr / aggregate-by-address / nil), the same
+# leniency the binary-agree check grants; every other parameter needs an exact
+# match. an IRT_NIL sentinel on either side carries no information to check against
+# ---
+# m:   the enclosing module (type-table oracle)
+# p:   the declared parameter type
+# q:   the argument operand type
+# ret: true when the argument type agrees with the parameter type
+fun call_arg_type_ok(m: *ir.Module, p: type.IrTypeId, q: type.IrTypeId) bool {
+    if (p == q)                                 { ret true; }
+    if (p == type.IRT_NIL || q == type.IRT_NIL) { ret true; }
+    if (type.is_aggregate(?m.types, p))         { ret type.is_aggregate(?m.types, q); }
+    if (is_pointerish(m, p) && is_pointerish(m, q)) { ret true; }
+    ret false;
 }
 
 # true for the binary and comparison opcodes whose two operands must share a
@@ -1972,5 +2052,53 @@ test "mach.lang.me.ir.verify.check_type_agree:vector_ops_and_mask_compare" {
     if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
 
     if (t_total(?env, true, false) != 0) { ret 1; }
+    ret 0;
+}
+
+# always on (no repr gate): a direct call whose fixed aggregate argument is
+# mis-typed to a plain pointer - the #2035 stamp-destroying clobber - is rejected,
+# while the well-typed aggregate argument passes. this is the durable tripwire that
+# keeps the #2035 defect class from shipping once generic instances carry real
+# signatures
+test "mach.lang.me.ir.verify.check_call_arg_types:aggregate_arg_pointer_mistype" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+    val b0: id.BlockId = t_block(?env);
+    if (b0 != 0) { ret 1; }
+    builder.set_block(?env.bld, b0);
+
+    # a 32-byte aggregate parameter type and a plain pointer type.
+    val agr: R.Result[type.IrTypeId, str] = type.intern_array(?env.m.types, env.i64ty, 4);
+    if (R.is_err[type.IrTypeId, str](agr)) { ret 1; }
+    val aggty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](agr);
+    val pr: R.Result[type.IrTypeId, str] = type.intern_ptr(?env.m.types);
+    if (R.is_err[type.IrTypeId, str](pr)) { ret 1; }
+    val ptrty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](pr);
+
+    # a callee `fn(aggty) -> i64`, referenced as an extern declaration.
+    var pbuf: type.IrTypeId = aggty;
+    val sr: R.Result[type.IrTypeId, str] = type.intern_fn(?env.m.types, env.i64ty, ?pbuf, 1);
+    if (R.is_err[type.IrTypeId, str](sr)) { ret 1; }
+    val calleesig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](sr);
+    val cfr: R.Result[u32, str] = ir.function_add(?env.m, intern.STR_NIL, calleesig, ir.FN_FLAG_EXTERN);
+    if (R.is_err[u32, str](cfr)) { ret 1; }
+    val cidx: u32 = R.unwrap_ok[u32, str](cfr);
+
+    # well-typed: the aggregate argument carries the aggregate type by address.
+    var abuf: value.Value = value.param(0, aggty);
+    val callr: R.Result[value.Value, str] = builder.emit_call(?env.bld, value.fn(cidx, calleesig), ?abuf, 1, env.i64ty);
+    if (R.is_err[value.Value, str](callr)) { ret 1; }
+    val callv: value.Value = R.unwrap_ok[value.Value, str](callr);
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
+
+    # always on (repr=false): the well-typed call records no violation.
+    if (t_count(?env, false, false, VC_CALL_ARG_TYPE) != 0) { ret 1; }
+
+    # clobber the argument operand's type to a plain pointer (the #2035 mis-typing).
+    val cid: id.InstructionId = callv.data.instr;
+    env.m.functions[0].instrs[cid].operands[1].ty = ptrty;
+
+    # the always-on check now fires, without repr.
+    if (t_count(?env, false, false, VC_CALL_ARG_TYPE) < 1) { ret 1; }
     ret 0;
 }

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -18,6 +18,7 @@ use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.fe.ast;
+use adecl: mach.lang.fe.ast.decl;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
@@ -1138,6 +1139,178 @@ pub fun decl_ret_sem(lc: *LowerContext, did: id.DeclId) type.TypeId {
         ret_type = generics.substitute(lc.s, ret_type, lc.subst, lc.subst_len);
     }
     ret ret_type;
+}
+
+# the IR return type of a function decl
+#
+# Lowers the return type of its semantic TYPE_FUN signature (through the active
+# substitution env), defaulting to void. Shared by the concrete/instance body
+# lowerings and the pack-instance reference signature helper.
+# ---
+# lc:  the context
+# did: the function's DeclId
+# ret: the IR return type, or an error
+pub fun function_return_ir(lc: *LowerContext, did: id.DeclId) R.Result[ir_type.IrTypeId, str] {
+    val sem: type.TypeId = decl_type_of(lc, did);
+    val opt_type: O.Option[*type.Type] = type.get(?lc.s.types, sem);
+    if (O.is_none[*type.Type](opt_type)) { ret ir_type.intern_void(?lc.m.types); }
+    val t: *type.Type = O.unwrap[*type.Type](opt_type);
+    if (t.kind != type.TYPE_FUN) { ret ir_type.intern_void(?lc.m.types); }
+    ret lower_type(lc, t.data.fn.ret_type);
+}
+
+# intern the IR function type of a pack instance
+#
+# The signature is the leading fixed parameter IR types followed by the N expanded
+# element IR types, returning `ret_ir`. The expanded elements take the place of
+# the single TYPE_PACK parameter, so the instance's ABI matches the collected call
+# rather than the opaque pack. Shared by the pack-instance definition and its
+# reference signature helper, so a call and the drained body classify identically.
+# ---
+# lc:          the context (its substitution env, if any, is applied by lower_type)
+# d:           the resolved template Decl
+# fixed_count: number of leading fixed parameters
+# types:       the concrete pack element type-list
+# type_len:    number of pack element types
+# ret_ir:      the function's IR return type
+# ret:         the interned IR function type, or an error
+pub fun pack_instance_sig(lc: *LowerContext, d: *adecl.Decl, fixed_count: u32,
+                          types: *type.TypeId, type_len: u32, ret_ir: ir_type.IrTypeId) R.Result[ir_type.IrTypeId, str] {
+    val total: u32 = fixed_count + type_len;
+    if (total == 0) {
+        ret ir_type.intern_fn(?lc.m.types, ret_ir, nil, 0);
+    }
+
+    val res_buf: R.Result[*ir_type.IrTypeId, str] = A.allocate[ir_type.IrTypeId](lc.s.alloc, total::usize);
+    if (R.is_err[*ir_type.IrTypeId, str](res_buf)) { ret R.err[ir_type.IrTypeId, str](R.unwrap_err[*ir_type.IrTypeId, str](res_buf)); }
+    val buf: *ir_type.IrTypeId = R.unwrap_ok[*ir_type.IrTypeId, str](res_buf);
+
+    # buf[0 .. fixed_count) are the leading fixed parameter IR types; the rest are
+    # the expanded pack element IR types, replacing the single TYPE_PACK parameter.
+    var i: u32 = 0;
+    for (i < total) {
+        var elem_sem: type.TypeId = type.TYPE_NIL;
+        if (i < fixed_count) {
+            val pool_ix: u32 = d.data.fun_.params_start + i;
+            if (pool_ix::usize < lc.a.typed_name_len) {
+                elem_sem = type_resolved_of(lc, lc.a.typed_names[pool_ix].ty);
+            }
+        }
+        or {
+            elem_sem = types[i - fixed_count];
+        }
+        val res_elem: R.Result[ir_type.IrTypeId, str] = lower_type(lc, elem_sem);
+        if (R.is_err[ir_type.IrTypeId, str](res_elem)) {
+            A.deallocate[ir_type.IrTypeId](lc.s.alloc, buf, total::usize);
+            ret res_elem;
+        }
+        buf[i] = R.unwrap_ok[ir_type.IrTypeId, str](res_elem);
+        i = i + 1;
+    }
+
+    val res_fn: R.Result[ir_type.IrTypeId, str] = ir_type.intern_fn(?lc.m.types, ret_ir, buf, total);
+    A.deallocate[ir_type.IrTypeId](lc.s.alloc, buf, total::usize);
+    ret res_fn;
+}
+
+# the true IRT_FN signature of a generic or comptime-value instance at a reference
+# site in the referencing module
+#
+# A monomorphized-instance callee reference must carry the same signature the
+# drained definition emits, so a direct call classifies its ABI from the declared
+# parameter types rather than from per-operand stamps (the fragile contract behind
+# #2035). The signature depends on the callee's own type-parameter binding, absent
+# in the referencing context -- a naive caller-side `lower_type` erases a nested
+# generic param to pointer width. So bind the origin module's typing and the
+# concrete substitution env (as the instance drain does) and lower the template's
+# declared function type through the identical path, then restore the caller's
+# state. `lower_type` / `decl_type_of` read only the swapped fields, so nothing
+# else needs binding. `args`/`arg_len` are the concrete type-arguments for a
+# generic instance, or nil/0 for a value instance (whose signature carries no type
+# args, and whose comptime bindings never reach the signature -- lower_type folds
+# no comptime).
+# ---
+# lc:      the referencing context
+# decl_id: DeclId of the template function in `origin`'s AST
+# origin:  ModuleId declaring the template
+# args:    concrete type-argument sequence, or nil
+# arg_len: number of type arguments
+# ret:     the interned IRT_FN, or an error
+pub fun instance_ref_sig(lc: *LowerContext, decl_id: id.DeclId, origin: session.ModuleId,
+                         args: *type.TypeId, arg_len: u32) R.Result[ir_type.IrTypeId, str] {
+    val oa: *ast.Ast = session.module_ast(lc.s, origin);
+    if (oa == nil) { ret R.err[ir_type.IrTypeId, str]("lower: instance-reference origin AST not registered"); }
+    val osema: *sema.SemaResult = (session.module_sema_ptr(lc.s, origin))::*sema.SemaResult;
+    if (osema == nil) { ret R.err[ir_type.IrTypeId, str]("lower: instance-reference origin typing not registered"); }
+
+    val home_a:         *ast.Ast          = lc.a;
+    val home_sema:      *sema.SemaResult   = lc.sema_result;
+    val home_subst:     *type.TypeId       = lc.subst;
+    val home_subst_len: u32                = lc.subst_len;
+    lc.a           = oa;
+    lc.sema_result = osema;
+    lc.subst       = args;
+    lc.subst_len   = arg_len;
+
+    val res_sig: R.Result[ir_type.IrTypeId, str] = lower_type(lc, decl_type_of(lc, decl_id));
+
+    lc.a           = home_a;
+    lc.sema_result = home_sema;
+    lc.subst       = home_subst;
+    lc.subst_len   = home_subst_len;
+    ret res_sig;
+}
+
+# the true IRT_FN signature of a comptime variadic-pack instance at a reference
+# site in the referencing module
+#
+# The pack expands to `type_len` concrete element parameters after the leading
+# fixed ones, so the signature is built by `pack_instance_sig` (not the whole
+# declared function type), exactly as the drained definition builds it. Binds the
+# origin module's typing so the return and fixed-parameter types resolve against
+# the declaring module, then restores the caller's state.
+# ---
+# lc:       the referencing context
+# decl_id:  DeclId of the pack-tailed template in `origin`'s AST
+# origin:   ModuleId declaring the template
+# types:    the concrete pack element type-list (by pack ordinal)
+# type_len: number of pack element types
+# ret:      the interned IRT_FN, or an error
+pub fun pack_instance_ref_sig(lc: *LowerContext, decl_id: id.DeclId, origin: session.ModuleId,
+                              types: *type.TypeId, type_len: u32) R.Result[ir_type.IrTypeId, str] {
+    val oa: *ast.Ast = session.module_ast(lc.s, origin);
+    if (oa == nil) { ret R.err[ir_type.IrTypeId, str]("lower: pack-instance-reference origin AST not registered"); }
+    val osema: *sema.SemaResult = (session.module_sema_ptr(lc.s, origin))::*sema.SemaResult;
+    if (osema == nil) { ret R.err[ir_type.IrTypeId, str]("lower: pack-instance-reference origin typing not registered"); }
+    val opt_d: O.Option[*adecl.Decl] = ast.get_decl(oa, decl_id);
+    if (O.is_none[*adecl.Decl](opt_d)) { ret R.err[ir_type.IrTypeId, str]("lower: pack-instance-reference origin declaration not found"); }
+    val d: *adecl.Decl = O.unwrap[*adecl.Decl](opt_d);
+    if (d.kind != adecl.DECL_KIND_FUN) { ret R.err[ir_type.IrTypeId, str]("lower: pack-instance-reference origin declaration is not a function"); }
+
+    val home_a:         *ast.Ast          = lc.a;
+    val home_sema:      *sema.SemaResult   = lc.sema_result;
+    val home_subst:     *type.TypeId       = lc.subst;
+    val home_subst_len: u32                = lc.subst_len;
+    lc.a           = oa;
+    lc.sema_result = osema;
+    lc.subst       = nil;
+    lc.subst_len   = 0;
+
+    var res_sig: R.Result[ir_type.IrTypeId, str] = R.err[ir_type.IrTypeId, str]("");
+    val res_ret_ir: R.Result[ir_type.IrTypeId, str] = function_return_ir(lc, decl_id);
+    if (R.is_err[ir_type.IrTypeId, str](res_ret_ir)) {
+        res_sig = R.err[ir_type.IrTypeId, str](R.unwrap_err[ir_type.IrTypeId, str](res_ret_ir));
+    }
+    or {
+        val fixed_count: u32 = d.data.fun_.params_len - 1;
+        res_sig = pack_instance_sig(lc, d, fixed_count, types, type_len, R.unwrap_ok[ir_type.IrTypeId, str](res_ret_ir));
+    }
+
+    lc.a           = home_a;
+    lc.sema_result = home_sema;
+    lc.subst       = home_subst;
+    lc.subst_len   = home_subst_len;
+    ret res_sig;
 }
 
 # return the resolved SymbolId for an expression reference, or SYMBOL_NIL

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -123,7 +123,7 @@ pub fun lower_fun(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, is_
     # an `inline` decorator hints the inline pass, which already honors the flag.
     if (decl_has_decorator(ctx, d, "inline")) { flags = flags | ir.FN_FLAG_INLINE; }
 
-    val res_ret_ir: R.Result[ir_type.IrTypeId, str] = function_return_ir(ctx, did);
+    val res_ret_ir: R.Result[ir_type.IrTypeId, str] = context.function_return_ir(ctx, did);
     if (R.is_err[ir_type.IrTypeId, str](res_ret_ir)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](res_ret_ir)); }
     val ret_ir: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_ret_ir);
 
@@ -210,11 +210,11 @@ pub fun lower_pack_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl
     # pack. the pack expands to `type_len` concrete parameters after them.
     val fixed_count: u32 = d.data.fun_.params_len - 1;
 
-    val res_ret_ir: R.Result[ir_type.IrTypeId, str] = function_return_ir(ctx, did);
+    val res_ret_ir: R.Result[ir_type.IrTypeId, str] = context.function_return_ir(ctx, did);
     if (R.is_err[ir_type.IrTypeId, str](res_ret_ir)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](res_ret_ir)); }
     val ret_ir: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_ret_ir);
 
-    val res_sig: R.Result[ir_type.IrTypeId, str] = pack_instance_sig(ctx, d, fixed_count, types, type_len, ret_ir);
+    val res_sig: R.Result[ir_type.IrTypeId, str] = context.pack_instance_sig(ctx, d, fixed_count, types, type_len, ret_ir);
     if (R.is_err[ir_type.IrTypeId, str](res_sig)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](res_sig)); }
     val sig: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_sig);
 
@@ -379,7 +379,7 @@ fun lower_weak_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Dec
     if (R.is_err[ir_type.IrTypeId, str](res_sig)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](res_sig)); }
     val sig: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_sig);
 
-    val res_ret_ir: R.Result[ir_type.IrTypeId, str] = function_return_ir(ctx, did);
+    val res_ret_ir: R.Result[ir_type.IrTypeId, str] = context.function_return_ir(ctx, did);
     if (R.is_err[ir_type.IrTypeId, str](res_ret_ir)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](res_ret_ir)); }
     val ret_ir: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_ret_ir);
 
@@ -446,59 +446,6 @@ fun clear_pack_state(ctx: *context.LowerContext) {
     ctx.pack_types    = nil;
     ctx.pack_len      = 0;
     ctx.pack_ret_type = type.TYPE_NIL;
-}
-
-# intern the IR function type of a pack instance
-#
-# The signature is the leading fixed parameter IR types followed by the N expanded
-# element IR types, returning `ret_ir`. The expanded elements take the place of
-# the single TYPE_PACK parameter, so the instance's ABI matches the collected call
-# rather than the opaque pack.
-# ---
-# ctx:         the context
-# d:           the resolved template Decl
-# fixed_count: number of leading fixed parameters
-# types:       the concrete pack element type-list
-# type_len:    number of pack element types
-# ret_ir:      the function's IR return type
-# ret:         the interned IR function type, or an error
-fun pack_instance_sig(ctx: *context.LowerContext, d: *decl.Decl, fixed_count: u32,
-                      types: *type.TypeId, type_len: u32, ret_ir: ir_type.IrTypeId) R.Result[ir_type.IrTypeId, str] {
-    val total: u32 = fixed_count + type_len;
-    if (total == 0) {
-        ret ir_type.intern_fn(?ctx.m.types, ret_ir, nil, 0);
-    }
-
-    val res_buf: R.Result[*ir_type.IrTypeId, str] = A.allocate[ir_type.IrTypeId](ctx.s.alloc, total::usize);
-    if (R.is_err[*ir_type.IrTypeId, str](res_buf)) { ret R.err[ir_type.IrTypeId, str](R.unwrap_err[*ir_type.IrTypeId, str](res_buf)); }
-    val buf: *ir_type.IrTypeId = R.unwrap_ok[*ir_type.IrTypeId, str](res_buf);
-
-    # buf[0 .. fixed_count) are the leading fixed parameter IR types; the rest are
-    # the expanded pack element IR types, replacing the single TYPE_PACK parameter.
-    var i: u32 = 0;
-    for (i < total) {
-        var elem_sem: type.TypeId = type.TYPE_NIL;
-        if (i < fixed_count) {
-            val pool_ix: u32 = d.data.fun_.params_start + i;
-            if (pool_ix::usize < ctx.a.typed_name_len) {
-                elem_sem = context.type_resolved_of(ctx, ctx.a.typed_names[pool_ix].ty);
-            }
-        }
-        or {
-            elem_sem = types[i - fixed_count];
-        }
-        val res_elem: R.Result[ir_type.IrTypeId, str] = context.lower_type(ctx, elem_sem);
-        if (R.is_err[ir_type.IrTypeId, str](res_elem)) {
-            A.deallocate[ir_type.IrTypeId](ctx.s.alloc, buf, total::usize);
-            ret res_elem;
-        }
-        buf[i] = R.unwrap_ok[ir_type.IrTypeId, str](res_elem);
-        i = i + 1;
-    }
-
-    val res_fn: R.Result[ir_type.IrTypeId, str] = ir_type.intern_fn(?ctx.m.types, ret_ir, buf, total);
-    A.deallocate[ir_type.IrTypeId](ctx.s.alloc, buf, total::usize);
-    ret res_fn;
 }
 
 # the semantic return type of a pack instance, recovered from its template's
@@ -1261,22 +1208,6 @@ fun append_global(ctx: *context.LowerContext, g: ir.Global) R.Result[u32, str] {
     val res_reg: R.Result[bool, str] = ir.global_register(m, g.name, idx);
     if (R.is_err[bool, str](res_reg)) { ret R.err[u32, str](R.unwrap_err[bool, str](res_reg)); }
     ret R.ok[u32, str](idx);
-}
-
-# the IR return type of a function decl
-#
-# Lowers the return type of its semantic TYPE_FUN signature, defaulting to void.
-# ---
-# ctx: the context
-# did: the function's DeclId
-# ret: the IR return type, or an error
-fun function_return_ir(ctx: *context.LowerContext, did: id.DeclId) R.Result[ir_type.IrTypeId, str] {
-    val sem: type.TypeId = context.decl_type_of(ctx, did);
-    val opt_type: O.Option[*type.Type] = type.get(?ctx.s.types, sem);
-    if (O.is_none[*type.Type](opt_type)) { ret ir_type.intern_void(?ctx.m.types); }
-    val t: *type.Type = O.unwrap[*type.Type](opt_type);
-    if (t.kind != type.TYPE_FUN) { ret ir_type.intern_void(?ctx.m.types); }
-    ret context.lower_type(ctx, t.data.fn.ret_type);
 }
 
 # the SymbolId of function `fun_did`'s parameter at ordinal `index`

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1604,9 +1604,12 @@ fun lower_value_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr
     A.deallocate[intern.StrId](ctx.s.alloc, names, ct_len::usize);
     if (R.is_err[bool, str](res_enq)) { ret R.err[value.Value, str](R.unwrap_err[bool, str](res_enq)); }
 
-    val res_ptr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);
-    if (R.is_err[ir_type.IrTypeId, str](res_ptr)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_ptr)); }
-    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_ptr));
+    # carry the instance's true IRT_FN signature (no type args: a value instance's
+    # comptime parameters are stripped from the signature) so the call classifies
+    # its ABI from the declared parameters, not per-operand stamps.
+    val res_sig: R.Result[ir_type.IrTypeId, str] = context.instance_ref_sig(ctx, sym.decl, sym.origin, nil, 0);
+    if (R.is_err[ir_type.IrTypeId, str](res_sig)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_sig)); }
+    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_sig));
 }
 
 # fold a comptime call argument to a CTValue
@@ -1731,12 +1734,19 @@ fun lower_generic_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Ex
     val link: intern.StrId = R.unwrap_ok[intern.StrId, str](res_link);
 
     val res_enq: R.Result[bool, str] = context.enqueue_instance(ctx, sym.decl, sym.origin, args, argc, link);
-    A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize);
-    if (R.is_err[bool, str](res_enq)) { ret R.err[value.Value, str](R.unwrap_err[bool, str](res_enq)); }
+    if (R.is_err[bool, str](res_enq)) {
+        A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize);
+        ret R.err[value.Value, str](R.unwrap_err[bool, str](res_enq));
+    }
 
-    val res_ptr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);
-    if (R.is_err[ir_type.IrTypeId, str](res_ptr)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_ptr)); }
-    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_ptr));
+    # carry the instance's true IRT_FN signature (the concrete type-args substituted
+    # into the template's declared function type) so the call classifies its ABI from
+    # the declared parameters, not per-operand stamps -- computed from `args` before
+    # it is freed.
+    val res_sig: R.Result[ir_type.IrTypeId, str] = context.instance_ref_sig(ctx, sym.decl, sym.origin, args, argc);
+    A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize);
+    if (R.is_err[ir_type.IrTypeId, str](res_sig)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_sig)); }
+    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_sig));
 }
 
 # resolve a pack-tailed call to its monomorphized instance (#1475)
@@ -1816,12 +1826,18 @@ fun lower_pack_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr,
     val link: intern.StrId = R.unwrap_ok[intern.StrId, str](res_link);
 
     val res_enq: R.Result[bool, str] = context.enqueue_pack_instance(ctx, sym.decl, sym.origin, types, elem_len, link);
-    if (owns_types && types != nil)   { A.deallocate[type.TypeId](ctx.s.alloc, types, elem_len::usize); }
-    if (R.is_err[bool, str](res_enq)) { ret R.err[value.Value, str](R.unwrap_err[bool, str](res_enq)); }
+    if (R.is_err[bool, str](res_enq)) {
+        if (owns_types && types != nil) { A.deallocate[type.TypeId](ctx.s.alloc, types, elem_len::usize); }
+        ret R.err[value.Value, str](R.unwrap_err[bool, str](res_enq));
+    }
 
-    val res_ptr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);
-    if (R.is_err[ir_type.IrTypeId, str](res_ptr)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_ptr)); }
-    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_ptr));
+    # carry the instance's true IRT_FN signature (the pack expanded to its concrete
+    # element parameters) so the call classifies its ABI from the declared
+    # parameters, not per-operand stamps -- computed from `types` before it is freed.
+    val res_sig: R.Result[ir_type.IrTypeId, str] = context.pack_instance_ref_sig(ctx, sym.decl, sym.origin, types, elem_len);
+    if (owns_types && types != nil)   { A.deallocate[type.TypeId](ctx.s.alloc, types, elem_len::usize); }
+    if (R.is_err[ir_type.IrTypeId, str](res_sig)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_sig)); }
+    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_sig));
 }
 
 # lower a binary expression


### PR DESCRIPTION
Closes #2063.

Follow-up to #2035 / #2062. The architectural invariant behind the #2035 miscompile: a call's ABI must classify from the callee's declared signature. Generic, comptime-value, and comptime-pack **instance** callee references were typed as a bare `ptr`, so `ensure_extern_function` recorded `sig = ptr`, `emit_call` stamped a degenerate `aux_ty`, and every such call was classified per-operand from its argument stamps — the fragile contract the #2035 inliner clobber exposed.

## Fix
Each of the three instance callee-reference paths (`lower_generic_callee`, `lower_value_callee`, `lower_pack_callee`) now carries the instance's true `IRT_FN`, computed at the reference site by:
- binding the **origin module's** typing + the concrete substitution env (exactly as the instance drain does), then
- lowering the template's declared function type through the **identical path** the drained definition uses.

A reference's signature is therefore byte-identical to its definition's, so every fixed argument classifies from the declared parameter type — inlined or not. `function_return_ir` and `pack_instance_sig` moved to `context.mach` so the definition and the reference-signature helper share one implementation.

### Why not a caller-side `lower_type`
`lower_type(substitute(decl_type_of(callee), type_args))` **regresses** correct code: a nested generic param (`Pair[T]` where `T` is the callee's own type parameter) needs the callee decl's type-parameter binding, absent in the caller's context, so `lower_type` takes its pointer-width erasure fallback and the param comes out 8 bytes wide. Binding the origin context avoids this.

## Per-operand classification is now scoped, not a fallback
The per-operand argument-classification path is **not** removed — but its role is now precise: it applies only at positions where **no declared signature exists**, never as a fallback for a direct call whose signature merely went uncomputed (that gap is exactly what this fix closes). Concretely it is reached at:
- the **variadic tail** past the declared parameter count, and
- a callee whose IR value type is **not** an `IRT_FN` — an erased / untyped function pointer.

**A typed function-pointer indirect call is NOT such a position** (stated for the record per review): the loaded fn-pointer value carries the pointee `IRT_FN` as its IR type (`TYPE_FUN` lowers to `IRT_FN`), so `emit_call` stamps a real `aux_ty` and the call classifies from the pointee signature. Verified end-to-end: a typed `fun(Big) i64` pointer called indirectly with a 32-byte aggregate emits `%N = call i64 %fp: fn({i64,i64,i64,i64}) -> i64, %arg: {i64,i64,i64,i64}` and stages the aggregate to the outgoing stack (CLASS_STACK). The compiler's own backend ABI vtable (`abi.ArgPassingFn = fun(...AggLayout) ParamSlot`, an aggregate-in/aggregate-out typed fn pointer) is exactly this case and is covered. The one adjacent position genuinely not covered is a call through an *erased/untyped* `ptr` (none arise in well-typed mach today) — noted as adjacent to #2064 / the win64 ext-marshaling ruling (#2058), **not** widened here.

## Durable guard: always-on `VC_CALL_ARG_TYPE`
Now that every direct call and every typed-fn-pointer indirect call carries a real `IRT_FN`, the verifier asserts each fixed argument operand type against the callee's declared parameter. An aggregate parameter must receive an aggregate operand — a pointer/scalar there is the #2035 mis-typing, now unrepresentable. (The verifier has no target, so it cannot compare two distinct aggregate ids' ABI classification; both flowing by address is the load-bearing, target-independent invariant.)

**Promoted to always-on** (entry + exit verifier and every `--verify-ir` pass), **not** the opt-in `repr` family. Evaluation: clean across the whole compiler self-build, all unit-test modules at -O2, the stdlib, and mach-mqtt; **no measurable build-time delta** (release self-build steady at ~13s with and without it) — the check is a handful of type-table lookups per call argument. Kept out of `repr` because it needs no target and does not false-positive. Colocated test drives it directly (opt-independent → guards in CI's default `mach test`).

## Verification (from-source fix/2063 compiler, never the PATH seed)
- `mach test` **644/644** at **-O0 / -O1 / -O2** (643 baseline + the colocated verifier test; incl. the 36-test `vector_runtime` suite).
- Self-host **fixpoint g2 == g3** byte-identical. g1 != g2 — the fix corrects the compiler's own generic-instance ABI classification (expected, surgical).
- **ASM**: a 32-byte by-value aggregate arg copies to the outgoing stack (`[rsp..+24]`, CLASS_STACK); a nested-generic `Pair[T]`->`Pair[i64]` 16-byte arg passes in two GP registers (rdi/rsi) — refuting the pointer-width erasure regression, not an 8-byte register pointer.
- **mach-mqtt brokerd @ -O2** (#2035 field case): listens, blocks in accept, no SIGSEGV; mqtt suite 46/46 at -O2.

## Follow-up (not this PR)
The dual same-name Function entries per instance (#2064) are intentionally untouched; this fix makes both entries carry the real sig, so calls resolving to either stay consistent.