### PR TITLE
fix(codegen): aarch64 vector `:~` bitcast selects FMOV, not a GP move (#2082)

### DIFF
--- a/src/lang/be/codegen/vector_runtime.mach
+++ b/src/lang/be/codegen/vector_runtime.mach
@@ -558,3 +558,73 @@ test "mach.lang.be.codegen.vector_runtime.spill:chain_deep" {
     if (acc[3] != -2147483549) { ret 2; }
     ret 0;
 }
+
+# bit reinterpret (`:~`) round-trips through the unsigned mask domain: the tier-3
+# stdlib's load-bearing float select/blend primitive (`doc/language/operators.md`;
+# `::` is numeric conversion, `:~` is the same-bit-pattern reinterpret). a same-bank
+# vector `:~` is a register bit copy the aarch64 NEON isel once dropped, assigning the
+# result a fresh vector register with no copy so a consumer read a never-populated one
+# (#2082, wrong lane / SIGSEGV). DISCRIMINATING bit patterns: sign-straddling floats
+# (negatives, -0.0), colliding low bytes with differing high bytes, and a following
+# vector bitwise op (the crash trigger).
+
+# f32x4 <-> u32x4 exact round-trip: each lane's IEEE-754 bits survive both directions.
+# 1.0 = 0x3F800000; -2.0 = 0xC0000000 (sign bit set); 3.5 = 0x40600000; -8.0 = 0xC1000000.
+test "mach.lang.be.codegen.vector_runtime.reinterpret:f32x4_u32x4_roundtrip" {
+    var f: f32x4 = f32x4{ 1.0, -2.0, 3.5, -8.0 };
+    var u: u32x4 = f:~u32x4;
+    if (u[0] != 0x3F800000 || u[1] != 0xC0000000 || u[2] != 0x40600000 || u[3] != 0xC1000000) { ret 1; }
+    var g: f32x4 = u:~f32x4;
+    if (g[0] != 1.0 || g[1] != -2.0 || g[2] != 3.5 || g[3] != -8.0) { ret 2; }
+    ret 0;
+}
+
+# f64x2 <-> u64x2 exact round-trip. 1.5 = 0x3FF8000000000000; -0.5 = 0xBFE0000000000000.
+test "mach.lang.be.codegen.vector_runtime.reinterpret:f64x2_u64x2_roundtrip" {
+    var f: f64x2 = f64x2{ 1.5, -0.5 };
+    var u: u64x2 = f:~u64x2;
+    if (u[0] != 0x3FF8000000000000 || u[1] != 0xBFE0000000000000) { ret 1; }
+    var g: f64x2 = u:~f64x2;
+    if (g[0] != 1.5 || g[1] != -0.5) { ret 2; }
+    ret 0;
+}
+
+# float select/blend entirely in the u32 bit domain, then reinterpret back: `:~` into
+# the mask domain, a vector bitwise blend (& | ~), `:~` out. a dropped `:~` on any of
+# the three reinterprets, or the byte-collapsed bitwise op the buggy path SIGSEGVs on,
+# fails the exact float compare. mask picks lane a where all-ones, lane b where zero.
+test "mach.lang.be.codegen.vector_runtime.reinterpret:f32x4_select_via_mask" {
+    var a: f32x4 = f32x4{ 1.0, -2.0, 3.0, -4.0 };
+    var b: f32x4 = f32x4{ 10.0, 20.0, -30.0, 40.0 };
+    var mask: u32x4 = u32x4{ M32, 0, M32, 0 };
+    var au: u32x4 = a:~u32x4;
+    var bu: u32x4 = b:~u32x4;
+    var sel: u32x4 = (au & mask) | (bu & ~mask);
+    var r: f32x4 = sel:~f32x4;
+    if (r[0] != 1.0 || r[1] != 20.0 || r[2] != 3.0 || r[3] != 40.0) { ret 1; }
+    ret 0;
+}
+
+# fabs through the mask domain: clear the sign bit in the u32 domain, reinterpret back.
+# sign-straddling lanes (negatives and -0.0) discriminate a dropped reinterpret; -0.0
+# clears to +0.0, so the lane-2 compare holds under either signed zero.
+test "mach.lang.be.codegen.vector_runtime.reinterpret:f32x4_abs_via_mask" {
+    var f: f32x4 = f32x4{ -1.5, 2.0, -0.0, -100.25 };
+    var u: u32x4 = f:~u32x4;
+    var cleared: u32x4 = u & u32x4{ 0x7FFFFFFF, 0x7FFFFFFF, 0x7FFFFFFF, 0x7FFFFFFF };
+    var r: f32x4 = cleared:~f32x4;
+    if (r[0] != 1.5 || r[1] != 2.0 || r[2] != 0.0 || r[3] != 100.25) { ret 1; }
+    ret 0;
+}
+
+# signed/unsigned integer reinterpret is also a same-bank vector `:~` (bits unchanged,
+# lane interpretation flips). colliding low bytes (266 shares byte 0 with 10) with
+# differing high bytes so a byte-collapsed move is caught; round-trips both directions.
+test "mach.lang.be.codegen.vector_runtime.reinterpret:u32x4_i32x4_roundtrip" {
+    var u: u32x4 = u32x4{ 0x80000001, 0xFFFFFFFF, 266, 0x7FFFFFFF };
+    var s: i32x4 = u:~i32x4;
+    if (s[0] != -2147483647 || s[1] != -1 || s[2] != 266 || s[3] != 2147483647) { ret 1; }
+    var back: u32x4 = s:~u32x4;
+    if (back[0] != 0x80000001 || back[1] != 0xFFFFFFFF || back[2] != 266 || back[3] != 0x7FFFFFFF) { ret 2; }
+    ret 0;
+}

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -48,8 +48,9 @@
 # pass through unchanged for the shared ABI / register-allocation passes. The scalar
 # float arithmetic / comparison / negate ops and the float conversions pass through
 # unchanged (high-sentinel MIR opcodes the encoder materializes into A64 scalar-FP
-# byte sequences); a float register copy and a GP<->FP `:~` bitcast are rewritten to
-# the concrete FMOV. Inline asm (`MIR_ASM`) passes through unchanged for the encoder
+# byte sequences); a float register copy and any `:~` bitcast touching the float /
+# vector bank (cross-bank GP<->FP scalar, or same-bank vector) are rewritten to the
+# concrete FMOV. Inline asm (`MIR_ASM`) passes through unchanged for the encoder
 # to assemble its body. Any opcode this selector does not model fails loudly with an
 # ICE so `select` is total - every opcode path returns a definite result.
 
@@ -311,14 +312,19 @@ fun rewrite(fn: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
         ret R.ok[bool, str](true);
     }
 
-    # a bit reinterpret crossing the GP and float banks (`f64 :~ i64` / `i32 :~ f32`)
-    # selects to FMOV, which transfers the raw bits between an X/W register and an S/D
-    # register; the encoder picks the direction from operand register class. a
-    # same-bank reinterpret (GP<->GP) stays MIR_BITCAST - a plain register copy the
-    # integer conversion encoder handles. a float-to-float bitcast cannot occur (a
-    # reinterpret is equal-size and the only two float widths differ).
+    # a bit reinterpret touching the float / vector bank selects to FMOV, whose encoder
+    # dispatches the machine form by operand register CLASS and width: a cross-bank
+    # scalar `:~` (`f64 :~ i64` / `i32 :~ f32`) transfers the raw bits between an X/W and
+    # an S/D register, and a same-bank vector `:~` (`f32x4 :~ u32x4`, both operands in the
+    # vector bank) materializes the 128-bit `MOV Vd.16b, Vn.16b` (a scalar float-to-float
+    # bitcast cannot occur - a reinterpret is equal-size and the two float widths differ,
+    # so both-bank-float means a vector). a same-bank GP<->GP reinterpret stays
+    # MIR_BITCAST, the plain register copy the integer conversion encoder handles. the `||`
+    # (not `!=`) is load-bearing: routing a vector bitcast to the GP MIR_BITCAST path would
+    # emit an ORR of the aliasing register index, writing a GP register and leaving the
+    # vector destination unpopulated (#2082). mirrors the MIR_MOV bank test above.
     if (o == mir.MIR_BITCAST) {
-        if (operand_is_fp(fn, ?mi.operands[0]) != operand_is_fp(fn, ?mi.operands[1])) {
+        if (operand_is_fp(fn, ?mi.operands[0]) || operand_is_fp(fn, ?mi.operands[1])) {
             mi.opcode = arm64.FMOV::u32;
         }
         ret R.ok[bool, str](true);
@@ -431,6 +437,42 @@ test "mach.lang.target.isa.arm64.isel:float_ordering_compare_selects_float" {
     mi.opcode = mir.MIR_CMP_LE_U; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 2);
     rewrite(?f, ?mi);
     if (mi.opcode != arm64.VEC_CMHS::u32) { ret 4; }
+
+    ret 0;
+}
+
+# a bit reinterpret touching the float / vector bank selects FMOV; only a GP<->GP
+# reinterpret stays MIR_BITCAST. a same-bank vector `:~` (both operands float-bank)
+# reaching the GP MIR_BITCAST encode path emits an ORR of the aliasing register index,
+# writing a GP register and leaving the vector destination unpopulated. regression
+# guard for the aarch64 vector `:~` miscompile (#2082).
+test "mach.lang.target.isa.arm64.isel:bitcast_bank_selects_fmov" {
+    var f: mir.MirFunction;
+    var vregs: [2]mir.MirVReg;
+    f.vregs = ?vregs[0]; f.vreg_count = 2;
+
+    var ops: [2]mir.MirOperand;
+    ops[0] = mir.op_vreg(0); ops[1] = mir.op_vreg(1);
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 2; mi.vec_lane = mir.VEC_LANE_NONE;
+
+    # both operands in the float / vector bank: a vector reinterpret -> FMOV.
+    vregs[0].class = 1; vregs[1].class = 1;
+    mi.opcode = mir.MIR_BITCAST;
+    rewrite(?f, ?mi);
+    if (mi.opcode != arm64.FMOV::u32) { ret 1; }
+
+    # a same-bank GP<->GP reinterpret stays MIR_BITCAST (the GP register copy).
+    vregs[0].class = mir.REG_CLASS_GP; vregs[1].class = mir.REG_CLASS_GP;
+    mi.opcode = mir.MIR_BITCAST;
+    rewrite(?f, ?mi);
+    if (mi.opcode != mir.MIR_BITCAST) { ret 2; }
+
+    # a cross-bank scalar reinterpret (one float side) -> FMOV.
+    vregs[0].class = 1; vregs[1].class = mir.REG_CLASS_GP;
+    mi.opcode = mir.MIR_BITCAST;
+    rewrite(?f, ?mi);
+    if (mi.opcode != arm64.FMOV::u32) { ret 3; }
 
     ret 0;
 }


### PR DESCRIPTION
## Summary

Fixes the shipped aarch64 miscompile in #2082: a vector bit-reinterpret
(`f32x4 :~ u32x4`) was elided and its result vreg assigned a fresh NEON register
with no copy, so consumers read a never-populated register (wrong lane reads; SIGSEGV
with a following vector bitwise op). Shipped v3.4.0–v3.4.4. x86_64 was correct.

## Root cause

A same-bank vector `:~` has **both** operands in the NEON/vector bank. The arm64 isel
`MIR_BITCAST` handler selected `FMOV` only when the banks *differ*
(`operand_is_fp(dst) != operand_is_fp(src)`), so a vector bitcast stayed `MIR_BITCAST`.
The encoder lowers a surviving `MIR_BITCAST` through `encode_convert` as a **GP** `ORR`
of the register *index* (`req_gpr` ignores class), writing a general-purpose register
and leaving the 128-bit vector destination unwritten.

The `MIR_MOV` handler already uses the correct test (`||`: either operand FP-bank →
FMOV). This aligns `MIR_BITCAST` with it. A same-bank vector bitcast then routes to
`encode_fmov`'s existing width-16 path (`MOV Vd.16b, Vn.16b`), and regalloc coalesces
it away when the vregs don't interfere. GP↔GP reinterprets still stay `MIR_BITCAST`;
cross-bank scalar `:~` is unchanged.

## Before / after (`f32x4 :~ u32x4`, arg in `q0`)

```
BEFORE (buggy)                          AFTER (fixed)
  sub  x0, x29, #0x14                     sub  x0, x29, #0x14
  mov  x1, x0        ; GP move (wrong)    str  q0, [x0]      ; stores the argument
  str  q1, [x0]      ; q1 never written   ldr  w0, [x1]
  ldr  w0, [x1]                           ...
```

The FMOV coalesced away entirely, so the argument `q0` is stored directly.

## Tests

- `arm64.isel:bitcast_bank_selects_fmov` — unit guard: vector/cross-bank `:~` → FMOV, GP↔GP stays `MIR_BITCAST`.
- Five `:~` round-trip blocks in the #2038 runtime vector suite (`vector_runtime.mach`): f32x4/f64x2 bit round-trips, float select/blend via the u32 mask domain, fabs via sign-bit clear, signed/unsigned int reinterpret. Discriminating bit patterns (sign-straddling floats, colliding low bytes, following vector bitwise op).

## Verification (built from this branch, verified with that binary)

- All 5 reinterpret tests **fail on the buggy seed** under qemu-aarch64 (one via signal 11), **pass with the fix**.
- Full vector suite (41) green on x86_64 and aarch64 (qemu) legs.
- Full `mach test` green at `-O0/-O1/-O2` (649 tests).
- Self-host fixpoint: stage2 == stage3, byte-identical.

Unblocks briar-systems/mach-std#372's aarch64 leg.

Closes #2082