### PR TITLE
fix(verify): accept a by-address argument for a vector parameter (rv64 #2086)

### DIFF
--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -703,6 +703,12 @@ fun check_call_arg_types(m: *ir.Module, ins: *instruction.Instruction, fi: u32, 
 fun call_arg_type_ok(m: *ir.Module, p: type.IrTypeId, q: type.IrTypeId) bool {
     if (p == q)                                 { ret true; }
     if (p == type.IRT_NIL || q == type.IRT_NIL) { ret true; }
+    # a vector parameter's passing model is target-dependent: register-class on a
+    # capable target (the `p == q` vector match above) or memory-class under
+    # scalarization (#2016), where the argument is retyped to flow by address. the
+    # verifier is target-less, so accept the union - a by-address argument (pointerish
+    # or aggregate-by-address) against a vector parameter is the scalarized form (#2086).
+    if (type.is_vector(?m.types, p))            { ret is_pointerish(m, q) || type.is_aggregate(?m.types, q); }
     if (type.is_aggregate(?m.types, p))         { ret type.is_aggregate(?m.types, q); }
     if (is_pointerish(m, p) && is_pointerish(m, q)) { ret true; }
     ret false;
@@ -2099,6 +2105,61 @@ test "mach.lang.me.ir.verify.check_call_arg_types:aggregate_arg_pointer_mistype"
     env.m.functions[0].instrs[cid].operands[1].ty = ptrty;
 
     # the always-on check now fires, without repr.
+    if (t_count(?env, false, false, VC_CALL_ARG_TYPE) < 1) { ret 1; }
+    ret 0;
+}
+
+# always on (no repr gate): a vector parameter's passing model is target-dependent -
+# register-class on a capable target (the argument stays vector-typed) and memory-class
+# under scalarization (#2016), where the pass retypes the argument to a plain pointer.
+# the target-less verifier must accept both, so a `ptr` (or aggregate-by-address)
+# argument to a vector-typed callee parameter records no violation - the #2086 false
+# positive that hard-gated every rv64 vector call. a bare scalar argument is still
+# rejected, so the relaxation stays by-address only and the #2035 discipline holds
+test "mach.lang.me.ir.verify.check_call_arg_types:vector_param_accepts_by_address_arg" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+    val b0: id.BlockId = t_block(?env);
+    if (b0 != 0) { ret 1; }
+    builder.set_block(?env.bld, b0);
+
+    # an i32x4 vector parameter type and a plain pointer type.
+    val ei: R.Result[type.IrTypeId, str] = type.intern_int(?env.m.types, 32);
+    if (R.is_err[type.IrTypeId, str](ei)) { ret 1; }
+    val vr: R.Result[type.IrTypeId, str] = type.intern_vector(?env.m.types, R.unwrap_ok[type.IrTypeId, str](ei), 4);
+    if (R.is_err[type.IrTypeId, str](vr)) { ret 1; }
+    val vecty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](vr);
+    val pr: R.Result[type.IrTypeId, str] = type.intern_ptr(?env.m.types);
+    if (R.is_err[type.IrTypeId, str](pr)) { ret 1; }
+    val ptrty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](pr);
+
+    # a callee `fn(i32x4) -> i64`, referenced as an extern declaration.
+    var pbuf: type.IrTypeId = vecty;
+    val sr: R.Result[type.IrTypeId, str] = type.intern_fn(?env.m.types, env.i64ty, ?pbuf, 1);
+    if (R.is_err[type.IrTypeId, str](sr)) { ret 1; }
+    val calleesig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](sr);
+    val cfr: R.Result[u32, str] = ir.function_add(?env.m, intern.STR_NIL, calleesig, ir.FN_FLAG_EXTERN);
+    if (R.is_err[u32, str](cfr)) { ret 1; }
+    val cidx: u32 = R.unwrap_ok[u32, str](cfr);
+
+    # well-typed on a capable target: the argument carries the vector type (p == q).
+    var abuf: value.Value = value.param(0, vecty);
+    val callr: R.Result[value.Value, str] = builder.emit_call(?env.bld, value.fn(cidx, calleesig), ?abuf, 1, env.i64ty);
+    if (R.is_err[value.Value, str](callr)) { ret 1; }
+    val callv: value.Value = R.unwrap_ok[value.Value, str](callr);
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
+    val cid: id.InstructionId = callv.data.instr;
+
+    # capable target: the vector argument matches the vector parameter, no violation.
+    if (t_count(?env, false, false, VC_CALL_ARG_TYPE) != 0) { ret 1; }
+
+    # scalarized (rv64): the argument is retyped to a plain pointer - still accepted.
+    env.m.functions[0].instrs[cid].operands[1].ty = ptrty;
+    if (t_count(?env, false, false, VC_CALL_ARG_TYPE) != 0) { ret 1; }
+
+    # a bare scalar is not a by-address form, so the check still fires against a vector
+    # parameter - the relaxation is bounded.
+    env.m.functions[0].instrs[cid].operands[1].ty = env.i64ty;
     if (t_count(?env, false, false, VC_CALL_ARG_TYPE) < 1) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Closes #2086. Urgent — hard-gates v3.4.5.

## Problem

The always-on `VC_CALL_ARG_TYPE` tripwire (b734ac5d, PR #2080) checks each call
argument's operand type against the callee's declared `IRT_FN` parameter type,
with no allowance for a **vector** parameter. On a scalarized target
(rv64, `has_v128 == false`, #2016) the pass retypes a vector call argument to a
plain `ptr` while **deliberately keeping the callee signature's parameter
vector-typed** for the lp64 BYREF/SRET ABI classification. So `call_arg_type_ok`
saw `p` = vector, `q` = `ptr`, matched no leniency branch (`is_aggregate(vector)`
is false, a vector is not pointerish), and fell through to `ret false` — a
`VC_CALL_ARG_TYPE` violation on **correct** IR. Every rv64 program with a vector
call that survives inlining failed to build, at both `-O0` and `-O2`. Capable
targets (x86_64 / aarch64) were unaffected: there the argument stays vector-typed
and `p == q`.

Regression on dev, bisected to b734ac5d; not caused by the #2075 int case or the
#2077 fix — that case is simply the first end-to-end rv64 vector-call coverage
(`mach test` can't run under qemu, and the #2038 runtime suite runs only on
capable targets).

## Fix

In `call_arg_type_ok`, add a vector-`p` branch before the aggregate branch: a
vector parameter accepts a by-address argument (pointerish or aggregate-by-address).
Design framing: a vector's passing model is target-dependent — register-class on a
capable target (caught by the `p == q` vector match), memory-class under
scalarization where the argument flows by address — and the verifier is
target-less, so it must accept the union. The relaxation is **by-address only**:
`is_address_typed` blesses `IRT_PTR` / aggregate but not a bare scalar, so the
#2035 aggregate discipline the tripwire was added for is untouched.

## Test

Colocated `check_call_arg_types:vector_param_accepts_by_address_arg`: a
`fn(i32x4) -> i64` callee with (1) a vector argument → no violation (capable
target), (2) the argument retyped to `ptr` → no violation (the fix; scalarized
rv64), (3) the argument retyped to a bare `i64` → violation still fires (bounded
relaxation). The existing `aggregate_arg_pointer_mistype` (#2035) test is unchanged
and still passes.

## Verification

- `mach test`: full suite green via a from-source compiler on this branch.
- int/ vectors case (`feat/2075`, PR #2076) on `linux-riscv64` under qemu: build-fails on the ABI block **before**; **after**, builds and passes at both `-O0` and `-O2`.
- Capable targets untouched: dev and branch compilers emit **byte-identical** x86_64 output for the same source (identical SHA-256).