### PR TITLE
fix(codegen): aarch64 vector live across a call corrupted (#2085)

### DIFF
--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -2633,9 +2633,14 @@ fun spill_across_calls(tgt: *target.Target, ctx: *AllocCtx) R.Result[bool, str] 
                 # callee-saved XMM survives the call once the prologue preserves it).
                 # under SysV every XMM is caller-saved, so this still spills every
                 # FP value across a call. an asm barrier additionally spills a
-                # callee-saved XMM the body writes.
+                # callee-saved XMM the body writes. a 128-bit vector is the exception on
+                # an ABI that callee-saves only the low 64 bits of its FP registers
+                # (AAPCS64's V8-V15): the callee clobbers the vector's upper half, so it
+                # must spill around the call like a caller-saved value (#2085).
                 val xidx: u32 = isa.regid_index(mv.assigned::i32)::u32;
                 if (xidx >= ctx.fp_count || !ctx.fp_callee_saved[xidx]) {
+                    must_spill = true;
+                } or (mv.vector && !tgt.abi.fp_callee_saved_full_vector) {
                     must_spill = true;
                 } or (is_asm && (asm_fp & (1::u32 << xidx)) != 0) {
                     must_spill = true;

--- a/src/lang/be/codegen/vector_runtime.mach
+++ b/src/lang/be/codegen/vector_runtime.mach
@@ -628,3 +628,34 @@ test "mach.lang.be.codegen.vector_runtime.reinterpret:u32x4_i32x4_roundtrip" {
     if (back[0] != 0x80000001 || back[1] != 0xFFFFFFFF || back[2] != 266 || back[3] != 0x7FFFFFFF) { ret 2; }
     ret 0;
 }
+
+# a 128-bit vector live across a call must survive all four lanes. AAPCS64 callee-saves
+# only the low 64 bits of V8-V15, so lanes 2-3 (the vector's upper half) are lost if a
+# caller parks the vector in a callee-saved FP register across a call instead of spilling
+# it around the call (#2085). the callee must actually write V8-V15's upper half to expose
+# the drop: `xc_clobber` parks a float in a callee-saved FP register across its own inner
+# call (an `fadd s8, ...` zeros V8's upper 64), and `xc_survive` uses its vector parameter
+# in a vector op AFTER the call, forcing it register-resident across the call. the +1 makes
+# every lane distinct so a lost upper half fails the exact per-lane compare.
+fun xc_leaf() f32 { ret 1.0; }
+
+fun xc_clobber(a: f32x4) f32 {
+    val s: f32 = a[0] + a[1] + a[2] + a[3];
+    val t: f32 = xc_leaf();
+    ret s + t;
+}
+
+fun xc_survive(v: i32x4, f: f32x4) i32x4 {
+    val junk: f32 = xc_clobber(f);
+    ret v + i32x4{ 1, 1, 1, 1 };
+}
+
+test "mach.lang.be.codegen.vector_runtime.call:vector_live_across_call" {
+    var v: i32x4 = i32x4{ 0x0A0B0C0C, 0x11223343, 0x55667787, 0x7FEEDDCB };
+    var f: f32x4 = f32x4{ 1.0, 2.0, 4.0, 8.0 };
+    var r: i32x4 = xc_survive(v, f);
+    if (r[0] != 0x0A0B0C0D || r[1] != 0x11223344) { ret 1; }
+    # lanes 2-3 ride the upper 64 of a callee-saved vector register AAPCS64 drops.
+    if (r[2] != 0x55667788 || r[3] != 0x7FEEDDCC) { ret 2; }
+    ret 0;
+}

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -298,24 +298,34 @@ pub def VaModelFn: fun() VaModel;
 #                             float-plus-integer and different-width float-pair rules);
 #                             false for the conventions that ignore it, letting
 #                             `classify_signature` skip the per-value flatten walk
+# fp_callee_saved_full_vector: true when a callee-saved FP register preserves a full
+#                             128-bit vector across a call (win64's XMM6-15), false when
+#                             it preserves only the low 64 bits (AAPCS64's V8-V15, whose
+#                             upper halves are caller-saved). the allocator spills a
+#                             vector live across a call out of a callee-saved FP register
+#                             when this is false, since the callee clobbers its upper
+#                             half. moot where no FP register is callee-saved (SysV) or no
+#                             128-bit vector reaches allocation (lp64d scalarizes), so
+#                             both set it true
 # va_model:                   erased fn ptr -- return the convention's `VaModel` (VaModelFn)
 pub rec AbiVTable {
-    id:                         u32;
-    name:                       str;
-    arch_id:                    u32;
-    classify:                   *u8;
-    arg_passing:                *u8;
-    ret_passing:                *u8;
-    gp_arg_regs:                *u8;
-    fp_arg_regs:                *u8;
-    callee_saved:               *u8;
-    stack_align:                u32;
-    red_zone:                   u32;
-    shadow_space:               u32;
-    indirect_result_reg:        i32;
-    indirect_result_in_argfile: bool;
-    consumes_agg_layout:        bool;
-    va_model:                   *u8;
+    id:                          u32;
+    name:                        str;
+    arch_id:                     u32;
+    classify:                    *u8;
+    arg_passing:                 *u8;
+    ret_passing:                 *u8;
+    gp_arg_regs:                 *u8;
+    fp_arg_regs:                 *u8;
+    callee_saved:                *u8;
+    stack_align:                 u32;
+    red_zone:                    u32;
+    shadow_space:                u32;
+    indirect_result_reg:         i32;
+    indirect_result_in_argfile:  bool;
+    consumes_agg_layout:         bool;
+    fp_callee_saved_full_vector: bool;
+    va_model:                    *u8;
 }
 
 # maximum number of ABI implementations an AbiRegistry holds

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -443,6 +443,9 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     aapcs64_vtable.indirect_result_in_argfile = false;
     # AAPCS64 ignores the flattened-aggregate descriptor (the lp64d hard-float rules).
     aapcs64_vtable.consumes_agg_layout        = false;
+    # AAPCS64 preserves only the low 64 bits of the callee-saved V8-V15; a 128-bit
+    # vector's upper half is caller-saved, so one live across a call must be spilled.
+    aapcs64_vtable.fp_callee_saved_full_vector = false;
     aapcs64_vtable.va_model                   = va_model::*u8;
 
     abi.register(reg, ?aapcs64_vtable);

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -540,6 +540,9 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     # lp64d is the one convention whose classifier reads the flattened-aggregate
     # descriptor (the mixed float+int and different-width float-pair rules).
     lp64_vtable.consumes_agg_layout        = true;
+    # riscv64 scalarizes 128-bit vectors before allocation, so none rides a callee-saved
+    # FP register across a call; the flag is moot and set true.
+    lp64_vtable.fp_callee_saved_full_vector = true;
     lp64_vtable.va_model                   = va_model::*u8;
 
     abi.register(reg, ?lp64_vtable);

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -440,6 +440,9 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     sysv_vtable.indirect_result_in_argfile = true;
     # SysV ignores the flattened-aggregate descriptor (the lp64d hard-float rules).
     sysv_vtable.consumes_agg_layout        = false;
+    # SysV callee-saves no FP register, so no vector ever rides one across a call; the
+    # flag is moot and set true (the general "callee-saved preserves the full value").
+    sysv_vtable.fp_callee_saved_full_vector = true;
 
     abi.register(reg, ?sysv_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -474,6 +474,9 @@ pub fun register_win64(reg: *abi.AbiRegistry) R.Result[bool, str] {
     win64_vtable.indirect_result_in_argfile = true;
     # win64 ignores the flattened-aggregate descriptor (the lp64d hard-float rules).
     win64_vtable.consumes_agg_layout        = false;
+    # win64 preserves the full 128 bits of the callee-saved XMM6-15, so a vector live
+    # across a call survives in one without spilling.
+    win64_vtable.fp_callee_saved_full_vector = true;
 
     abi.register(reg, ?win64_vtable);
     ret R.ok[bool, str](true);


### PR DESCRIPTION
## Summary

Fixes #2085: on aarch64, a 128-bit vector live across a call came back with corrupted
upper lanes (2–3). x86_64 was correct. Distinct from #2082/#2083 — this is a
register-allocation / ABI-modeling bug, not the vector `:~` selector.

## Root cause

AAPCS64 callee-saves only the **low 64 bits** of V8–V15; their upper halves are
caller-saved. The register allocator modeled V8–V15 as *whole-register* callee saves
(`aapcs64.mach` even notes the simplification), so a 128-bit vector parked in one
across a call kept lanes 2–3 in a register the callee freely clobbers. On x86_64/SysV
no XMM is callee-saved, so every FP value already spills across a call — hence x86_64
was unaffected. win64 is the opposite: it preserves the **full** 128 bits of XMM6–15,
so a vector there must *not* be force-spilled.

## Fix

Model the fact as an ABI vtable flag `fp_callee_saved_full_vector`:
- AAPCS64 → `false` (only low 64 preserved)
- win64 → `true` (full 128-bit XMM6–15 preserved)
- SysV / lp64d → `true` (moot: no callee-saved FP, or vectors scalarized)

In `spill_across_calls`, a vector live across a call is spilled out of a callee-saved
FP register when the flag is `false` — reusing the exact path a caller-saved value
already takes.

## Before / after (`z_normalize4`-style caller holding `q` across a call)

```
BEFORE: ldr q8, [q]        ; q parked in v8 (callee-saved)
        bl  callee          ; callee clobbers v8 upper 64 -> lanes 2,3 lost
AFTER:  stur q31, [slot]   ; q spilled to a 16-byte slot around the call
        ldur q0,  [slot]   ; reloaded intact after the call
```

## Tests

`vector_runtime.call:vector_live_across_call` — a vector parameter used in a vector op
after a call whose callee writes V8–V15's upper half; a dropped upper half fails the
exact per-lane compare. Fails on the buggy compiler under qemu-aarch64 (lanes 2–3
corrupted), passes with the fix; inert on x86_64.

## Verification (built from this branch, verified with that binary)

- The std-2021 quat repro (`z_length4` + `z_normalize4`) returns **200/200** on aarch64 with the fix (was 191/200); x86_64 unchanged at 200/200.
- Repro disasm confirms the vector is spilled around the call and reloaded intact.
- Full vector suite (37) green on x86_64 and aarch64 (qemu) legs.
- Full `mach test` green at `-O0/-O1/-O2` (647 each).
- Self-host fixpoint: stage2 == stage3, byte-identical.

Unblocks briar-systems/mach-std#372's last 2 aarch64 quaternion tests.

Closes #2085