### PR TITLE
fix(ir): preserve use-site operand type stamps in replace_uses

### DIFF
--- a/int/regression/2092-inline-result-agg-copy/expect.txt
+++ b/int/regression/2092-inline-result-agg-copy/expect.txt
@@ -1,0 +1,3 @@
+make=24
+pick1=24
+pick0=60

--- a/int/regression/2092-inline-result-agg-copy/mach.toml
+++ b/int/regression/2092-inline-result-agg-copy/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case2092"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2092-inline-result-agg-copy/src/main.mach
+++ b/int/regression/2092-inline-result-agg-copy/src/main.mach
@@ -1,0 +1,43 @@
+# regression pin for #2092: an aggregate deref-copy of an inlined call's result.
+#
+# `var x: R = @f()` lowers to a store whose value operand is the ptr-returning
+# call stamped with the aggregate type (a by-address aggregate). when f is
+# inlined, replace_uses substitutes the callee's return value into that slot;
+# clobbering the use-site stamp with the return value's bare ptr type degraded
+# the record copy to an 8-byte pointer-bits store, so the release profile
+# printed pointer fragments while debug printed the record. covers both
+# finish_returns arms: the single-return callee (direct value) and the
+# two-return callee (result phi in the continuation).
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+rec R { a: i64; b: i64; c: i64; }
+
+var g:  R = R{ a: 7, b: 8, c: 9 };
+var g2: R = R{ a: 10, b: 20, c: 30 };
+var sel: i64 = 1;
+
+# single return: the call result is wired directly to the returned pointer.
+fun make() *R { ret ?g; }
+
+# two returns: the call result is wired to a result phi over both pointers.
+fun pick(c: i64) *R {
+    if (c != 0) { ret ?g; }
+    ret ?g2;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var x: R = @make();
+    p.printlnf("make={}", x.a + x.b + x.c);       # 24
+
+    var y: R = @pick(sel);                        # sel is a mutable global, not folded
+    p.printlnf("pick1={}", y.a + y.b + y.c);      # 24
+
+    sel = 0;
+    var z: R = @pick(sel);
+    p.printlnf("pick0={}", z.a + z.b + z.c);      # 60
+    ret 0;
+}

--- a/src/lang/me/ir/mutate.mach
+++ b/src/lang/me/ir/mutate.mach
@@ -170,10 +170,17 @@ pub fun rewrite_apply(fn: *ir.Function, rw: *Rewrite) {
 # replaced (inlining wires a call result to its return value) and a batched map
 # would be overkill. Block-target operands ride in VAL_CONST_INT slots, so the
 # VAL_INSTR guard already skips them.
+#
+# Each rewritten slot keeps its own type, mirroring `rewrite_resolve`: the use-site
+# stamp is the slot's semantic contract (a by-address aggregate is a ptr-producing
+# value stamped with the aggregate type), so substituting which value fills the slot
+# must not change what the slot means. Clobbering the stamp with the replacement's
+# def type turned an inlined callee's deref-copied return into an 8-byte pointer
+# store (#2092).
 # ---
 # fn:          the function whose operands are rewritten in place
 # old_id:      the value-producing instruction id being replaced
-# replacement: the value to substitute in
+# replacement: the value to substitute in, retyped per use slot
 pub fun replace_uses(fn: *ir.Function, old_id: id.InstructionId, replacement: value.Value) {
     var i: u32 = 0;
     for (i < fn.instr_len) {
@@ -182,7 +189,7 @@ pub fun replace_uses(fn: *ir.Function, old_id: id.InstructionId, replacement: va
         for (ii < inst.operand_count) {
             val op: value.Value = inst.operands[ii];
             if (op.kind == value.VAL_INSTR && op.data.instr == old_id) {
-                inst.operands[ii] = replacement;
+                inst.operands[ii] = value.retype(replacement, op.ty);
             }
             ii = ii + 1;
         }

--- a/src/lang/me/ir/mutate.mach
+++ b/src/lang/me/ir/mutate.mach
@@ -15,6 +15,7 @@
 #     own predicate (dce's dead set, mem2reg's promoted memops).
 #   - cloning: `clone_instruction`, a faithful per-instruction copy.
 
+use std.allocator.page;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -25,10 +26,13 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use mach.lang.intern;
 use mach.lang.me.ir;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
+use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
+use mach.lang.source;
 
 # a batched value-replacement map (RAUW) over one function's instruction pool
 #
@@ -471,4 +475,106 @@ pub fun clone_instruction(m: *ir.Module, dst_fn: *ir.Function, src: *instruction
         ret res_id;
     }
     ret res_id;
+}
+
+# build a pool instruction with the given operands (copied into an owned array)
+# and add it to fn, returning its id (test helper; replace_uses walks the raw pool,
+# so no block wiring is needed)
+# ---
+# m:    module owning the allocator
+# fn:   function whose pool receives the instruction
+# kind: opcode
+# ty:   result type
+# ops:  operand values to copy (nil when n == 0)
+# n:    operand count
+# ret:  the new InstructionId, or an allocation error
+fun test_instr(m: *ir.Module, fn: *ir.Function, kind: instruction.InstrKind, ty: ir_type.IrTypeId, ops: *value.Value, n: u32) R.Result[id.InstructionId, str] {
+    var owned: *value.Value = nil;
+    if (n > 0) {
+        val res_ops: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, n::usize);
+        if (R.is_err[*value.Value, str](res_ops)) { ret R.err[id.InstructionId, str](R.unwrap_err[*value.Value, str](res_ops)); }
+        owned = R.unwrap_ok[*value.Value, str](res_ops);
+        var i: u32 = 0;
+        for (i < n) { owned[i] = ops[i]; i = i + 1; }
+    }
+    var inst: instruction.Instruction;
+    inst.kind          = kind;
+    inst.ty            = ty;
+    inst.operands      = owned;
+    inst.operand_count = n;
+    inst.operand_cap   = n;
+    inst.flags         = 0;
+    inst.aux_ty        = ir_type.IRT_NIL;
+    inst.loc           = source.loc_nil();
+    ret ir.instruction_add(m, fn, inst);
+}
+
+# #2092: replace_uses must preserve each rewritten slot's use-site type stamp. a
+# ptr-producing value used with an aggregate stamp is a by-address aggregate (the
+# store below means "copy the record"); substituting which value fills the slot must
+# not change what the slot means. builds `store %v:{agg} -> %slot` in the raw pool
+# and replaces %v with a bare-ptr param: the store's value operand must become the
+# param while still carrying the aggregate type, not the replacement's ptr type, and
+# the untouched pointer slot must keep its own stamp.
+test "mach.lang.me.ir.mutate.replace_uses:preserves_use_site_type" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val ri: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](ri)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ri);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val rv: R.Result[ir_type.IrTypeId, str] = ir_type.intern_void(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rv)) { ir.dnit(?m); ret 1; }
+    val voidt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rv);
+    var fields: [3]ir_type.IrTypeId;
+    fields[0] = i64t; fields[1] = i64t; fields[2] = i64t;
+    val ra: R.Result[ir_type.IrTypeId, str] = ir_type.intern_struct(?m.types, ?fields[0], 3, 8);
+    if (R.is_err[ir_type.IrTypeId, str](ra)) { ir.dnit(?m); ret 1; }
+    val aggt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ra);
+
+    val r_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](r_fn)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](r_fn)];
+
+    # %v and %slot: two ptr-producing allocas; the store's value operand is %v
+    # stamped with the aggregate type (the deref-copy idiom).
+    var count: [1]value.Value;
+    count[0] = value.const_int(1, i64t);
+    val r_v: R.Result[id.InstructionId, str] = test_instr(?m, fn, instruction.OP_ALLOCA, ptrt, ?count[0], 1);
+    if (R.is_err[id.InstructionId, str](r_v)) { ir.dnit(?m); ret 1; }
+    val v_id: id.InstructionId = R.unwrap_ok[id.InstructionId, str](r_v);
+    val r_slot: R.Result[id.InstructionId, str] = test_instr(?m, fn, instruction.OP_ALLOCA, ptrt, ?count[0], 1);
+    if (R.is_err[id.InstructionId, str](r_slot)) { ir.dnit(?m); ret 1; }
+    val slot_id: id.InstructionId = R.unwrap_ok[id.InstructionId, str](r_slot);
+
+    var store_ops: [2]value.Value;
+    store_ops[0] = value.instr(v_id, aggt);
+    store_ops[1] = value.instr(slot_id, ptrt);
+    val r_store: R.Result[id.InstructionId, str] = test_instr(?m, fn, instruction.OP_STORE, voidt, ?store_ops[0], 2);
+    if (R.is_err[id.InstructionId, str](r_store)) { ir.dnit(?m); ret 1; }
+    val store_id: id.InstructionId = R.unwrap_ok[id.InstructionId, str](r_store);
+
+    replace_uses(fn, v_id, value.param(0, ptrt));
+
+    val oi: O.Option[*instruction.Instruction] = ir.instruction_get(fn, store_id);
+    if (O.is_none[*instruction.Instruction](oi)) { ir.dnit(?m); ret 1; }
+    val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](oi);
+
+    var bad: i32 = 0;
+    if (ins.operands[0].kind != value.VAL_PARAM)  { bad = 3; }   # substitution happened
+    or (ins.operands[0].data.param_ix != 0)       { bad = 4; }
+    or (ins.operands[0].ty != aggt)               { bad = 2; }   # use-site stamp kept
+    if (bad == 0) {
+        if (ins.operands[1].kind != value.VAL_INSTR)  { bad = 5; }   # other slot untouched
+        or (ins.operands[1].data.instr != slot_id)    { bad = 6; }
+        or (ins.operands[1].ty != ptrt)               { bad = 7; }
+    }
+    ir.dnit(?m);
+    ret bad;
 }

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -1338,3 +1338,191 @@ test "mach.lang.me.pass.inline.run:preserves_aggregate_param_operand_type" {
     ir.dnit(?m);
     ret bad;
 }
+
+# #2092: when the inliner replaces a call's RESULT with the callee's single return
+# value, every rewritten use must keep its use-site type stamp. a deref-copy
+# `var x: Rec = @f()` is a store whose value operand is the ptr-returning call
+# stamped with the aggregate type (by-address aggregate identity); clobbering that
+# stamp with the return value's bare ptr type turns the copy into an 8-byte
+# pointer-bits store. builds `caller(q) { slot: agg; store agg-stamped make(q) ->
+# slot; }` with `make(q) *agg { ret q; }`; after inlining, the surviving store's
+# value operand must still carry the aggregate type.
+test "mach.lang.me.pass.inline.run:preserves_aggregate_result_operand_type" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val rv: R.Result[type.IrTypeId, str] = type.intern_void(?m.types);
+    if (R.is_err[type.IrTypeId, str](rv)) { ir.dnit(?m); ret 1; }
+    val voidty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rv);
+    val ri: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](ri)) { ir.dnit(?m); ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ri);
+    val rp: R.Result[type.IrTypeId, str] = type.intern_ptr(?m.types);
+    if (R.is_err[type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rp);
+    var fields: [3]type.IrTypeId;
+    fields[0] = i64t; fields[1] = i64t; fields[2] = i64t;
+    val ra: R.Result[type.IrTypeId, str] = type.intern_struct(?m.types, ?fields[0], 3, 8);
+    if (R.is_err[type.IrTypeId, str](ra)) { ir.dnit(?m); ret 1; }
+    val aggt: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ra);
+
+    var pptr: type.IrTypeId = ptrt;
+    val rsig: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, ptrt, ?pptr, 1);
+    if (R.is_err[type.IrTypeId, str](rsig)) { ir.dnit(?m); ret 1; }
+    val sig_make: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rsig);
+
+    var bld: builder.Builder = builder.init(?m);
+
+    # function 0: make(q) { ret q; } -- small, so it inlines.
+    val r_make: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig_make, 0);
+    if (R.is_err[u32, str](r_make)) { ir.dnit(?m); ret 1; }
+    val make_ix: u32 = R.unwrap_ok[u32, str](r_make);
+    builder.set_function(?bld, ?m.functions[make_ix]);
+    val rmb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rmb)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rmb));
+    if (R.is_err[bool, str](builder.emit_ret(?bld, value.param(0, ptrt)))) { ir.dnit(?m); ret 1; }
+
+    # function 1: caller(q) { slot = alloca agg; c = make(q); store c:{agg} -> slot; }
+    val r_c: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig_make, 0);
+    if (R.is_err[u32, str](r_c)) { ir.dnit(?m); ret 1; }
+    val caller_ix: u32 = R.unwrap_ok[u32, str](r_c);
+    builder.set_function(?bld, ?m.functions[caller_ix]);
+    val rcb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rcb)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rcb));
+    val r_slot: R.Result[value.Value, str] = builder.emit_alloca(?bld, aggt, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](r_slot)) { ir.dnit(?m); ret 1; }
+    val slot: value.Value = R.unwrap_ok[value.Value, str](r_slot);
+    var c_arg: value.Value = value.param(0, ptrt);
+    val r_call: R.Result[value.Value, str] = builder.emit_call(?bld, value.fn(make_ix, sig_make), ?c_arg, 1, ptrt);
+    if (R.is_err[value.Value, str](r_call)) { ir.dnit(?m); ret 1; }
+    val c: value.Value = R.unwrap_ok[value.Value, str](r_call);
+    # the deref-copy: the ptr-returning call result used with the aggregate stamp.
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.retype(c, aggt), slot))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?bld))) { ir.dnit(?m); ret 1; }
+
+    val r_run: R.Result[bool, str] = run(?m, nil);
+    if (R.is_err[bool, str](r_run)) { ir.dnit(?m); ret 1; }
+
+    # the call is gone; the surviving store's value operand must keep the aggregate
+    # stamp (a clobber would leave the return value's bare ptr type).
+    val caller_fn: *ir.Function = ?m.functions[caller_ix];
+    var bad: i32 = 1;
+    var i: u32 = 0;
+    for (i < caller_fn.instr_len) {
+        val oi: O.Option[*instruction.Instruction] = ir.instruction_get(caller_fn, i::id.InstructionId);
+        if (O.is_some[*instruction.Instruction](oi)) {
+            val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](oi);
+            if (ins.kind == instruction.OP_STORE && ins.operand_count >= 2) {
+                if (ins.operands[0].ty == aggt) { bad = 0; }
+                or { bad = 2; }
+            }
+        }
+        i = i + 1;
+    }
+    ir.dnit(?m);
+    ret bad;
+}
+
+# #2092, the multi-return arm: with two returning blocks the inliner builds a result
+# phi in the continuation and replaces the call's uses with it. those rewritten uses
+# must keep their use-site stamp exactly as in the single-return case. builds
+# `pick(c, p, q) *agg { if c ret p; ret q; }` and a caller that deref-copies the
+# call result; after inlining, the store's value operand must name the phi and still
+# carry the aggregate type.
+test "mach.lang.me.pass.inline.run:preserves_aggregate_result_operand_type_phi" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val ri: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](ri)) { ir.dnit(?m); ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ri);
+    val rp: R.Result[type.IrTypeId, str] = type.intern_ptr(?m.types);
+    if (R.is_err[type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rp);
+    var fields: [3]type.IrTypeId;
+    fields[0] = i64t; fields[1] = i64t; fields[2] = i64t;
+    val ra: R.Result[type.IrTypeId, str] = type.intern_struct(?m.types, ?fields[0], 3, 8);
+    if (R.is_err[type.IrTypeId, str](ra)) { ir.dnit(?m); ret 1; }
+    val aggt: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ra);
+
+    var psig: [3]type.IrTypeId;
+    psig[0] = i64t; psig[1] = ptrt; psig[2] = ptrt;
+    val rsig: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, ptrt, ?psig[0], 3);
+    if (R.is_err[type.IrTypeId, str](rsig)) { ir.dnit(?m); ret 1; }
+    val sig_pick: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rsig);
+
+    var bld: builder.Builder = builder.init(?m);
+
+    # function 0: pick(c, p, q) { if c ret p; ret q; } -- two value returns.
+    val r_pick: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig_pick, 0);
+    if (R.is_err[u32, str](r_pick)) { ir.dnit(?m); ret 1; }
+    val pick_ix: u32 = R.unwrap_ok[u32, str](r_pick);
+    builder.set_function(?bld, ?m.functions[pick_ix]);
+    val rb0: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb1: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb2: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rb0) || R.is_err[id.BlockId, str](rb1) || R.is_err[id.BlockId, str](rb2)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rb0));
+    if (R.is_err[bool, str](builder.emit_cbr(?bld, value.param(0, i64t), R.unwrap_ok[id.BlockId, str](rb1), R.unwrap_ok[id.BlockId, str](rb2)))) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rb1));
+    if (R.is_err[bool, str](builder.emit_ret(?bld, value.param(1, ptrt)))) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rb2));
+    if (R.is_err[bool, str](builder.emit_ret(?bld, value.param(2, ptrt)))) { ir.dnit(?m); ret 1; }
+
+    # function 1: caller(c, p, q) { slot = alloca agg; r = pick(c, p, q); store r:{agg} -> slot; }
+    val r_c: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig_pick, 0);
+    if (R.is_err[u32, str](r_c)) { ir.dnit(?m); ret 1; }
+    val caller_ix: u32 = R.unwrap_ok[u32, str](r_c);
+    builder.set_function(?bld, ?m.functions[caller_ix]);
+    val rcb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rcb)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rcb));
+    val r_slot: R.Result[value.Value, str] = builder.emit_alloca(?bld, aggt, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](r_slot)) { ir.dnit(?m); ret 1; }
+    val slot: value.Value = R.unwrap_ok[value.Value, str](r_slot);
+    var args: [3]value.Value;
+    args[0] = value.param(0, i64t);
+    args[1] = value.param(1, ptrt);
+    args[2] = value.param(2, ptrt);
+    val r_call: R.Result[value.Value, str] = builder.emit_call(?bld, value.fn(pick_ix, sig_pick), ?args[0], 3, ptrt);
+    if (R.is_err[value.Value, str](r_call)) { ir.dnit(?m); ret 1; }
+    val c: value.Value = R.unwrap_ok[value.Value, str](r_call);
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.retype(c, aggt), slot))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?bld))) { ir.dnit(?m); ret 1; }
+
+    val r_run: R.Result[bool, str] = run(?m, nil);
+    if (R.is_err[bool, str](r_run)) { ir.dnit(?m); ret 1; }
+
+    # the store's value operand now names the result phi and must keep the aggregate
+    # stamp; the phi itself stays ptr-typed (the callee's return type).
+    val caller_fn: *ir.Function = ?m.functions[caller_ix];
+    var bad: i32 = 1;
+    var i: u32 = 0;
+    for (i < caller_fn.instr_len) {
+        val oi: O.Option[*instruction.Instruction] = ir.instruction_get(caller_fn, i::id.InstructionId);
+        if (O.is_some[*instruction.Instruction](oi)) {
+            val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](oi);
+            if (ins.kind == instruction.OP_STORE && ins.operand_count >= 2) {
+                if (ins.operands[0].kind != value.VAL_INSTR) { bad = 3; }
+                or {
+                    val oref: O.Option[*instruction.Instruction] = ir.instruction_get(caller_fn, ins.operands[0].data.instr);
+                    if (O.is_none[*instruction.Instruction](oref)) { bad = 4; }
+                    or (O.unwrap[*instruction.Instruction](oref).kind != instruction.OP_PHI) { bad = 5; }
+                    or (ins.operands[0].ty != aggt) { bad = 2; }
+                    or { bad = 0; }
+                }
+            }
+        }
+        i = i + 1;
+    }
+    ir.dnit(?m);
+    ret bad;
+}


### PR DESCRIPTION
Closes #2092

## The defect

In this IR an aggregate value flows by address with the aggregate type stamped on the operand: a store whose value operand is a ptr-producing instruction stamped `{agg}` means "copy the aggregate", not "store the pointer". The use-site stamp is the slot's semantic contract, independent of the named value's own def type.

The batched RAUW facility (`Rewrite` / `rewrite_resolve`) preserves that contract explicitly — it retypes every resolved replacement to the slot's type, documented as "the aggregate-pointer identity mem2reg relies on". Its immediate sibling `mutate.replace_uses` — used only by the inliner's `finish_returns` to wire a call result to the callee's return value (both the single-return arm and the multi-return result-phi arm) — substituted the replacement **wholesale**, clobbering the use-site stamp with the replacement's bare def type.

Concretely: `var x: Rec = @f();` lowers to `store %call:{Rec-stamp}, %x_slot` where `f` returns `*Rec`. Once `f` is inlined, the store's operand becomes the return value typed `ptr` — the backend stores 8 bytes of pointer bits into `x` instead of copying the record. Silent wrong values.

## Reachability

**Not gated on #2064.** Plain current dev and the shipped 3.5.0 release miscompile this 20-line program at -O1/-O2 (7/8/9 expected):

```
rec R { a: i64; b: i64; c: i64; }
var g: R = R{ a: 7, b: 8, c: 9 };
fun make() *R { ret ?g; }
...
var x: R = @make();      # O2: a=4481064 b=0 c=<stack garbage>
```

Any release-profile program deref-copying the result of an inlinable (small or single-use, same-module) pointer-returning function is affected. **Verified affected: every shipped release** — v1.0.0 (earliest, exit-code probe) and v3.0.0 empirically, v3.5.0 and dev directly; structurally the substitution is byte-identical from pre-v1.0.0 (06cb9b84) through the mutate migration (1f6c2581) to today. Details on the issue. #2064's instance unification merely widened the set of inlinable callees (`O.unwrap[*T]` et al.) until the compiler's own `emit_phi_dbg_births` hit the shape — that is the whole `phi_dbg_birth` mystery: `dv.name` became the low 32 bits of a heap pointer.

## The fix

`replace_uses` retypes the replacement to each rewritten slot's type, exactly mirroring `rewrite_resolve`. One-line semantic change; the substitution primitives now uniformly own the stamp-preservation invariant (the #2035 fix did the same for VAL_PARAM substitution in `remap_clone_operands`).

## Tests

Two opt-independent in-vitro tests over `inline.run` (the PR #2062 precedent), pinning both `finish_returns` arms:
- `preserves_aggregate_result_operand_type` — single-return callee; the surviving store keeps the `{agg}` stamp.
- `preserves_aggregate_result_operand_type_phi` — two-return callee; the store names the result phi and keeps the `{agg}` stamp.

Both fail (exit 2) without the one-line fix and pass with it.

## Verification (from-source compiler, in progress)

- [x] new tests fail-before / pass-after
- [x] full `mach test` at -O0/-O1/-O2
- [x] repro program correct at -O0/-O1/-O2
- [x] self-host fixpoint
- [x] in-vivo: #2064 unification applied on top — `phi_dbg_birth` green at -O1/-O2

- [x] int/regression/2092-inline-result-agg-copy: release leg fails on unfixed compiler, both profiles pass on fixed

