### PR TITLE
fix(me): unify the dual same-name Function entries per generic instance (#2064)

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -782,9 +782,13 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     # fixed argument read their placement from this single layout so the call and
     # the callee's `lower_params` can never disagree - in particular a by-value
     # aggregate argument is classified from its DECLARED parameter type, not from
-    # the 8-byte pointer its operand carries. an indirect call through an untyped
-    # function pointer yields zero fixed params, so every argument falls back to
-    # per-operand classification below.
+    # the 8-byte pointer its operand carries. every call with a declared signature
+    # takes this path - a direct call to a named function or monomorphized instance,
+    # and an indirect call through a TYPED function pointer (its callee carries the
+    # IRT_FN). only a signature-less position yields zero fixed params and defers to
+    # per-operand classification below: the variadic tail, or a callee with no
+    # IRT_FN type (an erased / untyped function pointer). this is never a fallback
+    # for a direct call whose signature merely went uncomputed.
     val sig: type.IrTypeId = inst.aux_ty;
     # the declared return type comes from the callee signature when one is known,
     # not `inst.ty`: on a scalarized target a vector-returning call's result type is

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -645,14 +645,17 @@ fun check_type_agree(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid:
     ret R.ok[bool, str](true);
 }
 
-# VC_CALL_ARG_TYPE: a direct call classifies its ABI from the callee's declared
-# IRT_FN signature (`aux_ty`), so each fixed argument's operand type must agree with
-# the declared parameter type. checked only when `aux_ty` is a real IRT_FN - every
-# direct call to a named function or (now) a monomorphized instance; an indirect
-# call through an untyped function pointer carries no declared parameter types and
-# is skipped, as is the variadic tail past the declared parameter count (its
-# per-operand classification is the intended path). the first operand is the callee,
-# so argument i is operand i+1
+# VC_CALL_ARG_TYPE: a call that classifies its ABI from a declared IRT_FN signature
+# (`aux_ty`) must have each fixed argument's operand type agree with the declared
+# parameter. checked whenever `aux_ty` is a real IRT_FN - a direct call to a named
+# function or (now) a monomorphized instance, AND an indirect call through a TYPED
+# function pointer (its callee value carries the IRT_FN, so it classifies from the
+# pointee signature, not per-operand). the check is skipped only at positions where
+# no declared signature exists: the variadic tail past the declared parameter count,
+# and a call whose callee value is not IRT_FN-typed (an erased / untyped function
+# pointer). those are the intended homes of per-operand classification - it is never
+# a fallback for a direct call whose signature merely went uncomputed. the first
+# operand is the callee, so argument i is operand i+1
 # ---
 # m:   the enclosing module (type-table oracle)
 # ins: the call instruction to check

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -1200,6 +1200,29 @@ fun global_align_of(ctx: *context.LowerContext, d: *decl.Decl) R.Result[u32, str
 # ret:        the new function's index, or an error
 fun append_function(ctx: *context.LowerContext, name: intern.StrId, sig: ir_type.IrTypeId, flags: u32, param_hint: u32) R.Result[u32, str] {
     val m: *ir.Module = ctx.m;
+
+    # reuse a prior extern declaration of this name when defining it (#2064). a
+    # forward reference or a generic-instance reference created a signature-only
+    # FN_FLAG_EXTERN entry at the call site (ensure_extern_function), and every such
+    # call was captured as `value.fn(that-index)`. materialising the definition into
+    # a fresh entry would orphan the extern: the call keeps pointing at the bodiless
+    # extern, so the inliner (which never inlines an extern callee) can never see the
+    # body. upgrading the existing extern in place - its index, and thus every call,
+    # now names the definition - unifies the two and exposes instance/forward bodies
+    # to the inliner. only an extern is reused: a definition already present under
+    # this name is a genuine redefinition, left to append (and surface downstream).
+    # a true cross-module import is never defined locally, so append_function is
+    # never called for it and its extern stays extern.
+    val existing: O.Option[u32] = ir.function_lookup(m, name);
+    if (O.is_some[u32](existing)) {
+        val ei: u32 = O.unwrap[u32](existing);
+        if ((m.functions[ei].flags & ir.FN_FLAG_EXTERN) != 0) {
+            m.functions[ei].sig   = sig;
+            m.functions[ei].flags = flags;
+            ret R.ok[u32, str](ei);
+        }
+    }
+
     if (m.function_len == m.function_cap) {
         val new_cap: u32 = m.function_cap * 2;
         val res_grow: R.Result[*ir.Function, str] = A.reallocate[ir.Function](m.alloc, m.functions, m.function_cap::usize, new_cap::usize);


### PR DESCRIPTION
Closes #2064.

A forward reference or a generic-instance reference creates a signature-only `FN_FLAG_EXTERN` Function entry at the call site (`ensure_extern_function`), and every such call is captured as `value.fn(that-index)`. Materialising the definition into a **fresh** entry orphaned the extern: the call kept pointing at the bodiless extern, so the inliner (which never inlines an extern callee) could never see the body, and a redundant extern decl shipped alongside every instance/forward definition.

## Fix
`append_function` now **upgrades an existing extern entry of the same name in place** — its index, and thus every already-emitted call, now names the definition — unifying the two entries and exposing instance and forward-referenced bodies to the inliner. Only an extern is reused; a genuine cross-module import is never defined locally, so `append_function` is never called for it and its extern stays extern (the `should_inline` extern skip and the #1859 incremental-fingerprint invariant are preserved).

Composes with #2087's `Function.is_import`: for concrete/`ext` funcs `lower_fun` sets `is_import` *after* `append_function`, so the reuse can't lose it; for instances the reference passes `import_flag=false` and the reuse preserves it (matching a fresh entry's default), so an instance is never mis-marked an import.

The second commit is comment-only framing polish (`abi.mach`/`verify.mach`) stranded off #2063 by a merge-ordering crossing; it rides here.

## Inliner win (the point of #2064)
A generic-instance call and a forward-referenced call that previously pointed at bodiless externs — never inlinable — now inline. Demo (`-O2`): `fun main() { ret (early() + id[i64](7)) }` folds to **`ret 13`** (both `id[i64]` the instance and `late` via `early` inlined+folded), where before both remained `call`s to externs.

## Verification (from-source fix/2064 compiler, never the PATH seed)
- `mach test` **659/659** at **-O0 / -O1 / -O2**, including `mem2reg.run:phi_dbg_birth` **green at all levels** (the #2092 miscompile this unification exposed is fixed on dev by #2093) and the 42-test vector runtime suite.
- Self-host **fixpoint g2 == g3** byte-identical.
- Inliner-win demo as above (`ret 13`).

## Note
This unification is what surfaced #2092 (a pre-existing, dev-/3.5.0-reachable inliner call-result RAUW stamp clobber, fixed by #2093 and shipped in v3.5.1). #2064 was the flashlight, not the cause.