### PR TITLE
feat(build): parallelize per-module codegen across cores

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -33,6 +33,7 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 use ctime: std.chrono.time;
+use sys: std.system.os;
 
 use cfg: mach.cli.config;
 use cli_diag: mach.cli.diagnostic;
@@ -685,6 +686,19 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
     # middle-end scalarize/require gate reads the consumer's setting (#2017). the
     # posture is the consumer's alone; a dependency's own value never reaches here.
     p.s.simd = p.config.simd;
+
+    # resolve the parallel-codegen worker count (`--jobs <n>`, default host CPUs) onto
+    # the project so the codegen pass runs its worker pool. a malformed value skips the
+    # compile with exit 1 rather than silently serialising.
+    val res_jobs: R.Result[u32, str] = resolve_jobs(marks, argc, argv);
+    if (R.is_err[u32, str](res_jobs)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[u32, str](res_jobs));
+        print.eprint("\n");
+        br.code = 1;
+        debug_ok = false;
+    }
+    or { p.jobs = R.unwrap_ok[u32, str](res_jobs); }
 
     # fold the manifest default into the level: a CLI `-O*` flag wins,
     # otherwise the selected profile's opt applies, else debug.
@@ -3007,8 +3021,47 @@ pub fun mark_opt_flags(marks: *bool, argc: usize, argv: **u8) {
 pub fun mark_build_flags(marks: *bool, argc: usize, argv: **u8) {
     mark_opt_flags(marks, argc, argv);
     util.mark_value(marks, argc, argv, "--emit");
+    util.mark_value(marks, argc, argv, "--jobs");
     util.mark_value(marks, argc, argv, "-L");
     util.mark_value(marks, argc, argv, "-l");
+}
+
+# resolve the parallel-codegen worker count for a build from `--jobs <n>`
+#
+# An explicit `--jobs` value wins (a positive integer); absent it the count
+# defaults to the host CPU count, and 1 when that cannot be determined. The result
+# is always >= 1 - the driver clamps it down to the module count. A malformed
+# value is rejected so a typo does not silently serialise the build.
+# ---
+# marks: consumption record parallel to argv (marks the flag + its value consumed)
+# argc:  argument count
+# argv:  argument vector
+# ret:   ok with the resolved worker count, or err on a malformed `--jobs` value
+fun resolve_jobs(marks: *bool, argc: usize, argv: **u8) R.Result[u32, str] {
+    val opt_jobs: O.Option[*u8] = util.mark_value(marks, argc, argv, "--jobs");
+    if (O.is_some[*u8](opt_jobs)) {
+        val jv: i64 = parse_jobs(O.unwrap[*u8](opt_jobs));
+        if (jv < 1) { ret R.err[u32, str]("--jobs expects a positive integer"); }
+        ret R.ok[u32, str](jv::u32);
+    }
+    var n: u32 = 1;
+    val nc: i64 = sys.cpu_count();
+    if (nc > 1) { n = nc::u32; }
+    ret R.ok[u32, str](n);
+}
+
+# parse a positive decimal `--jobs` value, or -1 when empty, non-decimal, or absurd
+fun parse_jobs(s: *u8) i64 {
+    if (s == nil || s[0] == 0) { ret -1; }
+    var v: i64 = 0;
+    var i: usize = 0;
+    for (s[i] != 0) {
+        if (s[i] < '0' || s[i] > '9') { ret -1; }
+        v = v * 10 + (s[i] - '0')::i64;
+        if (v > 65536) { ret -1; }
+        i = i + 1;
+    }
+    ret v;
 }
 
 # `mach build` subcommand entry point

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -121,6 +121,7 @@ fun help_build() {
     print.print("  -O1, -O2         select the release pipeline\n");
     print.print("  -g               emit debug info for this build (overrides the profile's debug key)\n");
     print.print("  --emit <kind>    obj | exe (default exe; obj stops at the objects)\n");
+    print.print("  --jobs <n>       codegen worker threads (default: host CPUs; 1 serialises)\n");
     print.print("  -L <dir>         add a search directory for -l inputs; repeatable\n");
     print.print("  -l <name>        link a named object, archive, or shared library; repeatable\n");
     print.print("  <input>          a bare .o / .a / .so path or '/'-bearing path linked verbatim\n");

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -107,7 +107,7 @@ pub fun codegen_module(s: *session.Session, tgt: *target.Target,
     if (tgt == nil)   { ret R.err[of.ObjectImage, str]("codegen: nil target"); }
     if (irmod == nil) { ret R.err[of.ObjectImage, str]("codegen: nil ir module"); }
 
-    val res_lower: R.Result[mir.MirModule, str] = lower.lower_ir(tgt, irmod, ?s.interner);
+    val res_lower: R.Result[mir.MirModule, str] = lower.lower_ir(tgt, irmod, s.alloc, ?s.interner);
     if (R.is_err[mir.MirModule, str](res_lower)) {
         ret R.err[of.ObjectImage, str](R.unwrap_err[mir.MirModule, str](res_lower));
     }

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -55,23 +55,29 @@ use target:  mach.lang.target.resolved;
 # ---
 # tgt:      resolved compilation target; supplies register classes via `tgt.arch`
 # m:        the source IR module to lower
+# alloc:    allocator for the transient MIR (codegen scratch); a parallel worker
+#           passes a private arena, the serial path the session allocator
 # interner: session interner, recorded on the MIR module so the encoder can
 #           resolve interned strings and intern inline-asm symbol references
 # ret:      a populated mir.MirModule (owned, release with `mir.dnit_module`), or
 #           an allocation / lowering error
-pub fun lower_ir(tgt: *target.Target, m: *ir.Module, interner: *intern.Interner) R.Result[mir.MirModule, str] {
+pub fun lower_ir(tgt: *target.Target, m: *ir.Module, alloc: *A.Allocator, interner: *intern.Interner) R.Result[mir.MirModule, str] {
     if (tgt == nil || m == nil) {
         ret R.err[mir.MirModule, str]("mir.lower_ir: nil target or module");
     }
 
+    # the MirModule and everything reachable from it is transient codegen scratch,
+    # allocated from `alloc` rather than the IR module's own allocator so a parallel
+    # worker can build it in a private arena (the serial path passes the session
+    # allocator, which is m.alloc, leaving behaviour unchanged).
     var mm: mir.MirModule;
-    mm.alloc        = m.alloc;
+    mm.alloc        = alloc;
     mm.interner     = interner;
     mm.functions    = nil;
     mm.function_len = 0;
     mm.function_cap = 0;
 
-    val rf: R.Result[*mir.MirFunction, str] = A.allocate[mir.MirFunction](m.alloc, mir.INITIAL_FN_CAP::usize);
+    val rf: R.Result[*mir.MirFunction, str] = A.allocate[mir.MirFunction](alloc, mir.INITIAL_FN_CAP::usize);
     if (R.is_err[*mir.MirFunction, str](rf)) {
         ret R.err[mir.MirModule, str](R.unwrap_err[*mir.MirFunction, str](rf));
     }
@@ -80,7 +86,7 @@ pub fun lower_ir(tgt: *target.Target, m: *ir.Module, interner: *intern.Interner)
 
     var fi: u32 = 0;
     for (fi < m.function_len) {
-        val lf: R.Result[mir.MirFunction, str] = lower_function(tgt, m, ?m.functions[fi], interner);
+        val lf: R.Result[mir.MirFunction, str] = lower_function(tgt, m, ?m.functions[fi], alloc, interner);
         if (R.is_err[mir.MirFunction, str](lf)) {
             mir.dnit_module(?mm);
             ret R.err[mir.MirModule, str](R.unwrap_err[mir.MirFunction, str](lf));
@@ -105,9 +111,10 @@ pub fun lower_ir(tgt: *target.Target, m: *ir.Module, interner: *intern.Interner)
 # tgt:      resolved compilation target; routes register classes and ABI facts
 # m:        the source IR module owning `fn`
 # fn:       the IR function to lower
+# alloc:    allocator for all per-function MIR storage (codegen scratch)
 # interner: session interner, recorded on the context for inline-asm resolution
 # ret:      a populated mir.MirFunction (owned), or an allocation / lowering error
-fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interner: *intern.Interner) R.Result[mir.MirFunction, str] {
+fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, alloc: *A.Allocator, interner: *intern.Interner) R.Result[mir.MirFunction, str] {
     var mf: mir.MirFunction;
     mf.name                = fn.name;
     mf.blocks              = nil;
@@ -130,7 +137,7 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interne
         ret R.ok[mir.MirFunction, str](mf);
     }
 
-    val rv: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](m.alloc, mir.INITIAL_VREG_CAP::usize);
+    val rv: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](alloc, mir.INITIAL_VREG_CAP::usize);
     if (R.is_err[*mir.MirVReg, str](rv)) {
         ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirVReg, str](rv));
     }
@@ -138,7 +145,7 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interne
     mf.vreg_cap = mir.INITIAL_VREG_CAP;
 
     var ctx: lctx.LowerCtx;
-    ctx.alloc          = m.alloc;
+    ctx.alloc          = alloc;
     ctx.tgt            = tgt;
     ctx.m              = m;
     ctx.types          = ?m.types;
@@ -161,14 +168,14 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interne
     val setup: R.Result[bool, str] = lctx.ctx_setup(?ctx, tgt, fn);
     if (R.is_err[bool, str](setup)) {
         lctx.ctx_dnit(?ctx);
-        mir.dnit_function(m.alloc, ?mf);
+        mir.dnit_function(alloc, ?mf);
         ret R.err[mir.MirFunction, str](R.unwrap_err[bool, str](setup));
     }
 
-    val rb: R.Result[*mir.MirBlock, str] = A.allocate[mir.MirBlock](m.alloc, fn.block_count::usize);
+    val rb: R.Result[*mir.MirBlock, str] = A.allocate[mir.MirBlock](alloc, fn.block_count::usize);
     if (R.is_err[*mir.MirBlock, str](rb)) {
         lctx.ctx_dnit(?ctx);
-        mir.dnit_function(m.alloc, ?mf);
+        mir.dnit_function(alloc, ?mf);
         ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirBlock, str](rb));
     }
     mf.blocks    = R.unwrap_ok[*mir.MirBlock, str](rb);
@@ -180,7 +187,7 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interne
         val lb: R.Result[bool, str] = lower_block(?ctx, fn, ?fn.blocks[bi], is_entry);
         if (R.is_err[bool, str](lb)) {
             lctx.ctx_dnit(?ctx);
-            mir.dnit_function(m.alloc, ?mf);
+            mir.dnit_function(alloc, ?mf);
             ret R.err[mir.MirFunction, str](R.unwrap_err[bool, str](lb));
         }
         bi = bi + 1;
@@ -191,7 +198,7 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interne
     val lph: R.Result[bool, str] = lower_phis(?ctx, fn);
     if (R.is_err[bool, str](lph)) {
         lctx.ctx_dnit(?ctx);
-        mir.dnit_function(m.alloc, ?mf);
+        mir.dnit_function(alloc, ?mf);
         ret R.err[mir.MirFunction, str](R.unwrap_err[bool, str](lph));
     }
 

--- a/src/lang/be/obj.mach
+++ b/src/lang/be/obj.mach
@@ -19,6 +19,7 @@ use std.types.size.usize;
 use std.types.string.str;
 
 use std.allocator.page;
+use std.memory;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -146,6 +147,103 @@ pub fun add_relocation(o: *of.ObjectImage, rel: of.Relocation) R.Result[bool, st
     o.relocations[o.reloc_count] = rel;
     o.reloc_count = o.reloc_count + 1;
     ret R.ok[bool, str](true);
+}
+
+# map a name id from a child interner's id space into its base's id space
+#
+# Ids below `base_len` are already base ids and pass through; ids at or above it
+# are the child's own strings and resolve through `remap` (index `id - base_len`).
+# STR_NIL passes through unchanged.
+# ---
+# id:       the source name id (child interner space)
+# base_len: the child's base boundary
+# remap:    child-local id -> base id table (from intern.reintern_child), or nil
+# ret:      the id in the base interner's space
+fun remap_name(id: intern.StrId, base_len: usize, remap: *intern.StrId) intern.StrId {
+    if (id == intern.STR_NIL)  { ret id; }
+    if (id::usize < base_len)  { ret id; }
+    if (remap == nil)          { ret id; }
+    ret remap[id::usize - base_len];
+}
+
+# deep-copy an image built against a child interner into `dst_alloc`, remapping
+# every interned name into `dst_interner`'s id space
+#
+# A parallel-codegen worker builds its module's image in a private arena against a
+# child interner; this re-homes that image onto the destination (session)
+# allocator and rewrites its four name fields - the image name, each section name,
+# each symbol name, and each relocation's target symbol - through `remap` so they
+# resolve against the shared interner the linker keys on. Section byte buffers are
+# copied verbatim (they encode no interned ids - only self-contained bytes and
+# per-section offsets), so the re-homed image is byte-for-byte what a serial build
+# would have produced. The source image is left intact for the caller to free with
+# its arena.
+# ---
+# dst_alloc:    allocator the re-homed image and its buffers are owned by
+# dst_interner: the shared interner the remapped names resolve against
+# src:          the worker-built image to copy (child-interner name space)
+# base_len:     the child interner's base boundary
+# remap:        child-local id -> base id table, or nil when the child added nothing
+# ret:          the re-homed, remapped image (dst_alloc-owned), or an allocation error
+pub fun rehome_remap(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
+                     src: *of.ObjectImage, base_len: usize, remap: *intern.StrId) R.Result[of.ObjectImage, str] {
+    val res_img: R.Result[of.ObjectImage, str] = init(dst_alloc, dst_interner, remap_name(src.name, base_len, remap));
+    if (R.is_err[of.ObjectImage, str](res_img)) { ret res_img; }
+    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](res_img);
+
+    if (src.section_count > 0) {
+        val rs: R.Result[*of.Section, str] = A.allocate[of.Section](dst_alloc, src.section_count::usize);
+        if (R.is_err[*of.Section, str](rs)) { dnit(?img); ret R.err[of.ObjectImage, str](R.unwrap_err[*of.Section, str](rs)); }
+        img.sections = R.unwrap_ok[*of.Section, str](rs);
+        var i: u32 = 0;
+        for (i < src.section_count) {
+            var sec: of.Section = src.sections[i];
+            sec.name = remap_name(src.sections[i].name, base_len, remap);
+            if (src.sections[i].bytes != nil && src.sections[i].len > 0) {
+                val rb: R.Result[*u8, str] = A.allocate[u8](dst_alloc, src.sections[i].len::usize);
+                if (R.is_err[*u8, str](rb)) {
+                    img.section_count = i;
+                    dnit(?img);
+                    ret R.err[of.ObjectImage, str](R.unwrap_err[*u8, str](rb));
+                }
+                sec.bytes = R.unwrap_ok[*u8, str](rb);
+                memory.copy[u8](sec.bytes, src.sections[i].bytes, src.sections[i].len::usize);
+            }
+            img.sections[i] = sec;
+            img.section_count = i + 1;
+            i = i + 1;
+        }
+    }
+
+    if (src.symbol_count > 0) {
+        val ry: R.Result[*of.Symbol, str] = A.allocate[of.Symbol](dst_alloc, src.symbol_count::usize);
+        if (R.is_err[*of.Symbol, str](ry)) { dnit(?img); ret R.err[of.ObjectImage, str](R.unwrap_err[*of.Symbol, str](ry)); }
+        img.symbols = R.unwrap_ok[*of.Symbol, str](ry);
+        var i: u32 = 0;
+        for (i < src.symbol_count) {
+            var sym: of.Symbol = src.symbols[i];
+            sym.name = remap_name(src.symbols[i].name, base_len, remap);
+            img.symbols[i] = sym;
+            i = i + 1;
+        }
+        img.symbol_count = src.symbol_count;
+    }
+
+    if (src.reloc_count > 0) {
+        val rr: R.Result[*of.Relocation, str] = A.allocate[of.Relocation](dst_alloc, src.reloc_count::usize);
+        if (R.is_err[*of.Relocation, str](rr)) { dnit(?img); ret R.err[of.ObjectImage, str](R.unwrap_err[*of.Relocation, str](rr)); }
+        img.relocations = R.unwrap_ok[*of.Relocation, str](rr);
+        var i: u32 = 0;
+        for (i < src.reloc_count) {
+            var rel: of.Relocation = src.relocations[i];
+            rel.symbol = remap_name(src.relocations[i].symbol, base_len, remap);
+            img.relocations[i] = rel;
+            i = i + 1;
+        }
+        img.reloc_count = src.reloc_count;
+    }
+
+    ret R.ok[of.ObjectImage, str](img);
 }
 
 # serialize the image to disk through the active format's writer

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -10,6 +10,7 @@
 # environment when it later runs through resolve. The public entry is
 # build_project, which returns a fully populated Project or an error string.
 
+use std.allocator.arena;
 use std.allocator.page;
 use std.collections.map;
 use std.collections.sort;
@@ -40,6 +41,8 @@ use O: std.types.option;
 use R: std.types.result;
 use ctime: std.chrono.time;
 use sysos: std.system.os;
+use atomic: std.sync.atomic;
+use thread: std.sync.thread;
 use std.process.exec;
 use std.print;
 
@@ -289,6 +292,11 @@ pub rec ModuleEntry {
     sema_result:       *sema.SemaResult;
     ir_module:         *ir.Module;
     object_image:      *of.ObjectImage;
+    # a parallel-codegen prelude's finished image, already re-homed onto the
+    # session allocator and remapped into the session interner, waiting for
+    # Q_CODEGEN to adopt it as its value (nil on the serial path). session-owned,
+    # freed by the Q_CODEGEN handle's finalize once adopted.
+    staged_image:      *of.ObjectImage;
     stable_id:         session.StableModuleId;
     target_gated:      bool;
 }
@@ -392,6 +400,10 @@ pub rec Project {
     opt_level:    pipeline.OptLevel;
     verify_ir:    bool;
     test_mode:    bool;
+
+    # requested codegen worker count for the parallel back half (`--jobs`); 0 means
+    # auto (os.cpu_count). 1 forces the serial-equivalent single-worker path.
+    jobs:         u32;
 
     # set only while load_all_own_src loads orphan roots, so the load walk knows a
     # top-level `$error` guard it reaches marks a target-gated orphan to exclude
@@ -1434,6 +1446,7 @@ fun init_project(p: *Project, s: *session.Session) {
     p.opt_level     = pipeline.OPT_DEBUG;
     p.verify_ir     = false;
     p.test_mode     = false;
+    p.jobs          = 0;
     p.loading_orphans = false;
 }
 
@@ -3085,6 +3098,7 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) R.Result[session.Module
     m.sema_result       = nil;
     m.ir_module         = nil;
     m.object_image      = nil;
+    m.staged_image      = nil;
     m.target_gated      = false;
     p.modules[p.module_len] = m;
     p.module_len = p.module_len + 1;
@@ -5195,6 +5209,337 @@ fun free_lower_closure(alloc: *A.Allocator, cl: *LowerClosure) {
     cl.cap   = 0;
 }
 
+# per-worker parallel-codegen state: a private bump arena and a child interner over
+# the frozen session interner, plus the session view codegen_module reads
+# ---
+# backing: page allocator backing this worker's arena
+# ar:      bump arena owning all of this worker's codegen scratch and raw images
+# alloc:   allocator interface over `ar`
+# sess:    session view - a copy of the real session with alloc and interner
+#          (a child over the session interner) overridden; every other field is a
+#          frozen read shared with the real session
+# active:  the worker was initialised and needs teardown
+rec PcgWorker {
+    backing: A.Allocator;
+    ar:      arena.Arena;
+    alloc:   A.Allocator;
+    sess:    session.Session;
+    active:  bool;
+}
+
+# one module's parallel-codegen result, indexed by topo position
+# ---
+# image:  raw image in the producing worker's arena (child-interner names), or nil
+# worker: producing worker index - selects the remap at collection
+# err:    nil on success, else the module's codegen error message
+rec PcgSlot {
+    image:  *of.ObjectImage;
+    worker: u32;
+    err:    str;
+}
+
+# the running parallel-codegen job the bare thread entry reads through a global
+# ---
+# p:          the active project
+# next:       atomic cursor - the next topo index a worker claims
+# worker_seq: atomic dispenser - hands each running thread its worker index
+# stop:       atomic flag - set non-zero by the first worker to error
+# nworkers:   number of worker slots (>= threads that actually run)
+# workers:    the per-worker state array
+# slots:      the per-module result array, indexed by topo position
+# base_len:   session-interner id count snapshotted before any child - the boundary
+#             below which a name needs no remap
+rec ParallelCodegen {
+    p:          *Project;
+    next:       i64;
+    worker_seq: i64;
+    stop:       i64;
+    nworkers:   u32;
+    workers:    *PcgWorker;
+    slots:      *PcgSlot;
+    base_len:   usize;
+}
+
+# the in-flight parallel-codegen job, read by the bare thread entry point
+# (std.sync.thread hands the entry no argument, so the job is reached through this
+# global). set for the span of run_codegen_parallel and nil otherwise.
+var g_pcg: *ParallelCodegen = nil;
+
+# initialise one worker: a fresh page-backed arena and a session view whose
+# allocator and interner are worker-private
+#
+# The interner is a child over the session interner - it resolves the frozen IR
+# ids every image inherits and captures any new codegen strings locally, so the
+# worker interns without touching the shared interner. The session copy shares
+# every other (frozen) field with the real session by value.
+# ---
+# w: the worker slot to initialise
+# p: the active project (its session is the parent of the worker view)
+# ret: none on success, or the first allocation error
+fun pcg_worker_init(w: *PcgWorker, p: *Project) O.Option[str] {
+    w.active = false;
+    if (O.is_some[str](page.make(?w.backing)))          { ret O.some[str]("parallel codegen: worker backing alloc failed"); }
+    if (O.is_some[str](arena.init(?w.ar, ?w.backing, 0))) { ret O.some[str]("parallel codegen: worker arena init failed"); }
+    if (O.is_some[str](arena.make(?w.alloc, ?w.ar)))     { arena.dnit(?w.ar); ret O.some[str]("parallel codegen: worker arena bind failed"); }
+
+    w.sess          = @p.s;
+    w.sess.alloc    = ?w.alloc;
+    w.sess.interner = intern.make_child(?p.s.interner, ?w.alloc);
+    w.active        = true;
+    ret O.none[str]();
+}
+
+# tear one worker down, releasing its arena (which owns its child interner storage
+# and every raw image it built)
+fun pcg_worker_teardown(w: *PcgWorker) {
+    if (!w.active) { ret; }
+    arena.dnit(?w.ar);
+    w.active = false;
+}
+
+# the worker thread body: claim a worker index, then drain modules from the shared
+# cursor, codegen each into this worker's arena, and record it in its slot
+#
+# Bare (std.sync.thread hands no argument); reaches the job through g_pcg. Every
+# read of the project (topo, modules, target) and of the frozen session is
+# read-only and shared; every write (the MIR scratch, the image, interned strings)
+# lands in this worker's private arena and child interner. The first error sets the
+# stop flag so peers wind down.
+fun pcg_worker_main() {
+    val pc: *ParallelCodegen = g_pcg;
+    if (pc == nil) { ret; }
+    val wid_raw: i64 = atomic.fetch_add(?pc.worker_seq, 1::i64);
+    if (wid_raw < 0 || wid_raw >= pc.nworkers::i64) { ret; }
+    val wid: u32 = wid_raw::u32;
+    val w: *PcgWorker = ?pc.workers[wid::usize];
+
+    for (true) {
+        if (atomic.load(?pc.stop) != 0) { ret; }
+        val idx_raw: i64 = atomic.fetch_add(?pc.next, 1::i64);
+        if (idx_raw >= pc.p.topo_len::i64) { ret; }
+        val idx: u32 = idx_raw::u32;
+
+        val mid:  session.ModuleId = pc.p.topo[idx];
+        val m:    *ModuleEntry     = ?pc.p.modules[mid::u32];
+        val slot: *PcgSlot         = ?pc.slots[idx::usize];
+        slot.worker = wid;
+
+        val r: R.Result[of.ObjectImage, str] = codegen.codegen_module(?w.sess, ?pc.p.target, m.ir_module, nil);
+        if (R.is_err[of.ObjectImage, str](r)) {
+            slot.err   = R.unwrap_err[of.ObjectImage, str](r);
+            slot.image = nil;
+            atomic.store(?pc.stop, 1::i64);
+            ret;
+        }
+        var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](r);
+        val br: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](?w.alloc, 1::usize);
+        if (R.is_err[*of.ObjectImage, str](br)) {
+            slot.err   = "parallel codegen: worker image box allocation failed";
+            slot.image = nil;
+            atomic.store(?pc.stop, 1::i64);
+            ret;
+        }
+        val box: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](br);
+        box[0]     = img;
+        slot.image = box;
+        slot.err   = nil;
+    }
+}
+
+# codegen every module across a worker pool and stage each finished image on its
+# ModuleEntry for Q_CODEGEN to adopt
+#
+# Each worker owns a private arena and a child interner over the session interner,
+# so lowering-to-object runs with no shared mutable state (the session interner and
+# allocator are read-only for the span). Modules are handed out by an atomic cursor,
+# so the object tree is independent of worker count and scheduling. Collection is
+# serial in TOPO order: each worker's new interner strings are folded back into the
+# session interner (reintern_child) and each raw image is re-homed onto the session
+# allocator with its names remapped (obj.rehome_remap), so the staged images are
+# byte-identical to a serial build and the link that follows keys on one interner.
+# Assumes a cold cache (every module is (re)built) - the CLI's contract; a warm
+# session must use the serial incremental path.
+# ---
+# p:   the active project (jobs resolved, no DWARF - see pcg_enabled)
+# ret: true once every module is staged, or the first worker's codegen error
+fun run_codegen_parallel(p: *Project) R.Result[bool, str] {
+    val topo_len: u32 = p.topo_len;
+    if (topo_len == 0) { ret R.ok[bool, str](true); }
+
+    var nworkers: u32 = p.jobs;
+    if (nworkers == 0)        { nworkers = 1; }
+    if (nworkers > topo_len)  { nworkers = topo_len; }
+
+    val rslots: R.Result[*PcgSlot, str] = A.allocate[PcgSlot](p.s.alloc, topo_len::usize);
+    if (R.is_err[*PcgSlot, str](rslots)) { ret R.err[bool, str](R.unwrap_err[*PcgSlot, str](rslots)); }
+    val slots: *PcgSlot = R.unwrap_ok[*PcgSlot, str](rslots);
+    var si: u32 = 0;
+    for (si < topo_len) { slots[si].image = nil; slots[si].worker = 0; slots[si].err = nil; si = si + 1; }
+
+    val rworkers: R.Result[*PcgWorker, str] = A.allocate[PcgWorker](p.s.alloc, nworkers::usize);
+    if (R.is_err[*PcgWorker, str](rworkers)) {
+        A.deallocate[PcgSlot](p.s.alloc, slots, topo_len::usize);
+        ret R.err[bool, str](R.unwrap_err[*PcgWorker, str](rworkers));
+    }
+    val workers: *PcgWorker = R.unwrap_ok[*PcgWorker, str](rworkers);
+
+    var wi: u32 = 0;
+    for (wi < nworkers) {
+        val io: O.Option[str] = pcg_worker_init(?workers[wi], p);
+        if (O.is_some[str](io)) {
+            var wj: u32 = 0;
+            for (wj < wi) { pcg_worker_teardown(?workers[wj]); wj = wj + 1; }
+            A.deallocate[PcgWorker](p.s.alloc, workers, nworkers::usize);
+            A.deallocate[PcgSlot](p.s.alloc, slots, topo_len::usize);
+            ret R.err[bool, str](O.unwrap[str](io));
+        }
+        wi = wi + 1;
+    }
+
+    var ctx: ParallelCodegen;
+    ctx.p          = p;
+    ctx.next       = 0;
+    ctx.worker_seq = 0;
+    ctx.stop       = 0;
+    ctx.nworkers   = nworkers;
+    ctx.workers    = workers;
+    ctx.slots      = slots;
+    ctx.base_len   = intern.count(?p.s.interner);
+    g_pcg = ?ctx;
+
+    # spawn nworkers-1 helper threads; the calling thread is the last worker, so a
+    # single-worker (jobs 1) run drives the whole pool on this thread with no spawn.
+    var threads: *thread.Thread = nil;
+    val extra: u32 = nworkers - 1;
+    if (extra > 0) {
+        val rt: R.Result[*thread.Thread, str] = A.allocate[thread.Thread](p.s.alloc, extra::usize);
+        if (R.is_err[*thread.Thread, str](rt)) {
+            g_pcg = nil;
+            var wk: u32 = 0;
+            for (wk < nworkers) { pcg_worker_teardown(?workers[wk]); wk = wk + 1; }
+            A.deallocate[PcgWorker](p.s.alloc, workers, nworkers::usize);
+            A.deallocate[PcgSlot](p.s.alloc, slots, topo_len::usize);
+            ret R.err[bool, str](R.unwrap_err[*thread.Thread, str](rt));
+        }
+        threads = R.unwrap_ok[*thread.Thread, str](rt);
+        var k: u32 = 0;
+        for (k < extra) { thread.spawn(pcg_worker_main, ?threads[k]); k = k + 1; }
+    }
+
+    pcg_worker_main();
+
+    if (extra > 0) {
+        var k: u32 = 0;
+        for (k < extra) {
+            if (threads[k].tid >= 0) { thread.join(?threads[k]); }
+            k = k + 1;
+        }
+        A.deallocate[thread.Thread](p.s.alloc, threads, extra::usize);
+    }
+    g_pcg = nil;
+
+    # first error in topo order wins - deterministic regardless of which worker hit it.
+    var ei: u32 = 0;
+    for (ei < topo_len) {
+        if (slots[ei].err != nil) {
+            val msg: str = slots[ei].err;
+            var wk: u32 = 0;
+            for (wk < nworkers) { pcg_worker_teardown(?workers[wk]); wk = wk + 1; }
+            A.deallocate[PcgWorker](p.s.alloc, workers, nworkers::usize);
+            A.deallocate[PcgSlot](p.s.alloc, slots, topo_len::usize);
+            ret R.err[bool, str](msg);
+        }
+        ei = ei + 1;
+    }
+
+    val cr: R.Result[bool, str] = pcg_collect(p, ?ctx);
+
+    var wk: u32 = 0;
+    for (wk < nworkers) { pcg_worker_teardown(?workers[wk]); wk = wk + 1; }
+    A.deallocate[PcgWorker](p.s.alloc, workers, nworkers::usize);
+    A.deallocate[PcgSlot](p.s.alloc, slots, topo_len::usize);
+    ret cr;
+}
+
+# fold every worker's new interner strings back into the session interner and
+# re-home each raw image onto the session allocator, remapped, staged on its module
+#
+# Serial and in topo order: worker remaps are computed once each, then every image
+# is deep-copied onto the session allocator with its names rewritten into the
+# session interner's id space. On any allocation failure the images staged so far
+# are left on their modules for the normal teardown to reclaim.
+# ---
+# p:   the active project
+# ctx: the finished job (its workers hold the raw images and child interners)
+# ret: true once every image is staged, or the first allocation error
+fun pcg_collect(p: *Project, ctx: *ParallelCodegen) R.Result[bool, str] {
+    val nworkers: u32 = ctx.nworkers;
+
+    val rmaps: R.Result[**intern.StrId, str] = A.allocate[*intern.StrId](p.s.alloc, nworkers::usize);
+    if (R.is_err[**intern.StrId, str](rmaps)) { ret R.err[bool, str](R.unwrap_err[**intern.StrId, str](rmaps)); }
+    val remaps: **intern.StrId = R.unwrap_ok[**intern.StrId, str](rmaps);
+
+    var wi: u32 = 0;
+    for (wi < nworkers) {
+        val rr: R.Result[*intern.StrId, str] = intern.reintern_child(?workers_at(ctx, wi).sess.interner, p.s.alloc);
+        if (R.is_err[*intern.StrId, str](rr)) {
+            pcg_free_remaps(p, ctx, remaps, wi);
+            A.deallocate[*intern.StrId](p.s.alloc, remaps, nworkers::usize);
+            ret R.err[bool, str](R.unwrap_err[*intern.StrId, str](rr));
+        }
+        remaps[wi] = R.unwrap_ok[*intern.StrId, str](rr);
+        wi = wi + 1;
+    }
+
+    var i: u32 = 0;
+    for (i < p.topo_len) {
+        val slot: *PcgSlot = ?ctx.slots[i::usize];
+        val w:    *PcgWorker = ?ctx.workers[slot.worker::usize];
+        val rehomed: R.Result[of.ObjectImage, str] =
+            obj.rehome_remap(p.s.alloc, ?p.s.interner, slot.image, ctx.base_len, remaps[slot.worker]);
+        if (R.is_err[of.ObjectImage, str](rehomed)) {
+            pcg_free_remaps(p, ctx, remaps, nworkers);
+            A.deallocate[*intern.StrId](p.s.alloc, remaps, nworkers::usize);
+            ret R.err[bool, str](R.unwrap_err[of.ObjectImage, str](rehomed));
+        }
+        val rbox: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](p.s.alloc, 1::usize);
+        if (R.is_err[*of.ObjectImage, str](rbox)) {
+            var tmp: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](rehomed);
+            obj.dnit(?tmp);
+            pcg_free_remaps(p, ctx, remaps, nworkers);
+            A.deallocate[*intern.StrId](p.s.alloc, remaps, nworkers::usize);
+            ret R.err[bool, str](R.unwrap_err[*of.ObjectImage, str](rbox));
+        }
+        val box: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](rbox);
+        box[0] = R.unwrap_ok[of.ObjectImage, str](rehomed);
+
+        val mid: session.ModuleId = p.topo[i];
+        p.modules[mid::u32].staged_image = box;
+        i = i + 1;
+    }
+
+    pcg_free_remaps(p, ctx, remaps, nworkers);
+    A.deallocate[*intern.StrId](p.s.alloc, remaps, nworkers::usize);
+    ret R.ok[bool, str](true);
+}
+
+# the worker at index `wi` (a bounds-clear accessor for the collection phase)
+fun workers_at(ctx: *ParallelCodegen, wi: u32) *PcgWorker {
+    ret ?ctx.workers[wi::usize];
+}
+
+# free the first `n` worker remap arrays (each sized to its child's new-string count)
+fun pcg_free_remaps(p: *Project, ctx: *ParallelCodegen, remaps: **intern.StrId, n: u32) {
+    var wi: u32 = 0;
+    for (wi < n) {
+        if (remaps[wi] != nil) {
+            val len: usize = intern.count(?workers_at(ctx, wi).sess.interner);
+            if (len > 0) { A.deallocate[intern.StrId](p.s.alloc, remaps[wi], len); }
+        }
+        wi = wi + 1;
+    }
+}
+
 # codegen every module to an ObjectImage in topo order through the Q_CODEGEN query.
 # the active Project is installed on the session for the pass so the compute can
 # reach the per-build module graph. run_lower_pass must have run first (each
@@ -5208,6 +5553,24 @@ pub fun run_codegen_pass(p: *Project) R.Result[bool, str] {
     session.set_active_project(p.s, p::ptr);
 
     readout.phase_begin(p.s.readout, readout.PH_CODEGEN);
+
+    # when the caller opts into parallelism (jobs >= 1, CLI builds) and the build
+    # emits no DWARF, codegen every module across a worker pool up front and stage
+    # each finished image on its ModuleEntry; the serial query.get loop below then
+    # adopts the staged images (Q_CODEGEN stays the value's system of record). a
+    # `-g` build keeps the serial path: its DWARF interns IR types into each
+    # module's type table through the shared session allocator, which the worker
+    # arenas do not isolate (#1826 parallel-lowering/-g follow-up). the serial path
+    # also drives every non-CLI caller (jobs == 0) and the driver tests, keeping the
+    # in-engine codegen compute exercised.
+    if (pcg_enabled(p)) {
+        val rp: R.Result[bool, str] = run_codegen_parallel(p);
+        if (R.is_err[bool, str](rp)) {
+            session.set_active_project(p.s, nil);
+            ret rp;
+        }
+    }
+
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: session.ModuleId = p.topo[i];
@@ -5221,6 +5584,13 @@ pub fun run_codegen_pass(p: *Project) R.Result[bool, str] {
     readout.phase_end(p.s.readout, readout.PH_CODEGEN, p.topo_len, "module", "modules");
     session.set_active_project(p.s, nil);
     ret R.ok[bool, str](true);
+}
+
+# whether the parallel-codegen prelude should run for this build: the caller asked
+# for at least one worker, the build emits no DWARF (the worker arenas do not
+# isolate the `-g` type-table writes), and there is at least one module
+fun pcg_enabled(p: *Project) bool {
+    ret p.jobs >= 1 && !p.s.debug && p.topo_len > 0;
 }
 
 # fetch module `mid`'s ObjectImage through Q_CODEGEN - computed fresh when its
@@ -5271,6 +5641,17 @@ fun q_codegen_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Resul
     if (R.is_err[bool, str](rl)) { ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rl)); }
     val rt: R.Result[bool, str] = query.record_dep(db, query.Q_CODEGEN, key, query.Q_TARGET, 0);
     if (R.is_err[bool, str](rt)) { ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rt)); }
+
+    # the parallel-codegen prelude may already have built this module's image (across
+    # a worker pool) and staged it, re-homed onto the session allocator and remapped
+    # into the session interner. adopt it as this query's value instead of
+    # recomputing; the same codegen_module produced it, so it is byte-identical to the
+    # serial compute below. cleared once taken so a later demand recomputes.
+    val staged: *of.ObjectImage = m.staged_image;
+    if (staged != nil) {
+        m.staged_image = nil;
+        ret image_handle_encode(alloc, staged);
+    }
 
     val res_cg: R.Result[of.ObjectImage, str] = codegen.codegen_module(s, ?p.target, irmod, nil);
     if (R.is_err[of.ObjectImage, str](res_cg)) { ret R.err[query.QueryOutput, str](R.unwrap_err[of.ObjectImage, str](res_cg)); }

--- a/src/lang/intern.mach
+++ b/src/lang/intern.mach
@@ -284,6 +284,17 @@ pub fun child_base_len(itn: *Interner) usize {
     ret itn.base_len;
 }
 
+# the number of strings stored in THIS interner's own array
+#
+# For a root that is the whole id universe; for a child it is the count of new
+# strings it added past base_len - the length of a reintern_child remap.
+# ---
+# itn: the interner
+# ret: itn's own stored string count
+pub fun count(itn: *Interner) usize {
+    ret itn.len;
+}
+
 # fold a child's new strings back into its base and return the id remap
 #
 # Interns each string the child assigned (ids `[base_len, base_len + len)`) into

--- a/src/lang/intern.mach
+++ b/src/lang/intern.mach
@@ -28,18 +28,29 @@ pub val STR_NIL: StrId = 0xFFFFFFFF;
 #
 # Assigns each unique string a stable u32 id and collapses repeated inserts of
 # the same bytes onto a single id and a single owned copy.
+#
+# An interner is either a ROOT (`base == nil`) that owns its whole id universe,
+# or a CHILD (`base != nil`, built by `make_child`) that layers a private write
+# scratch over a frozen root: ids `[0, base_len)` resolve into the base, ids
+# `>= base_len` into the child's own `strings`. A child never writes the base, so
+# many children can read one frozen base concurrently (the parallel back half),
+# and `reintern_child` folds a child's new strings back into the base afterward.
 # ---
-# a:       allocator backing owned copies, the index array, and the dedup map
-# strings: array of owned strings indexed by StrId
-# len:     number of strings stored
-# cap:     allocated slots in strings
-# dedup:   text -> StrId map keyed by content for O(1) interning
+# a:        allocator backing owned copies, the index array, and the dedup map
+# strings:  array of owned strings indexed by StrId (offset by base_len for a child)
+# len:      number of strings stored in THIS interner's own array
+# cap:      allocated slots in strings
+# dedup:    text -> StrId map keyed by content for O(1) interning
+# base:     frozen parent whose ids [0, base_len) this interner extends, or nil for a root
+# base_len: id boundary - the base's len snapshotted at make_child; 0 for a root
 pub rec Interner {
     a:       *A.Allocator;
     strings: *str;
     len:     usize;
     cap:     usize;
     dedup:   map.Map[str, StrId];
+    base:     *Interner;
+    base_len: usize;
 }
 
 # initial capacity of the strings array on first intern
@@ -53,11 +64,37 @@ val INITIAL_CAP: usize = 32;
 # ret: a new empty interner
 pub fun init(a: *A.Allocator) Interner {
     var itn: Interner;
-    itn.a       = a;
-    itn.strings = nil;
-    itn.len     = 0;
-    itn.cap     = 0;
-    itn.dedup   = map.init[str, StrId](a, map.hash_str, map.eq_str);
+    itn.a        = a;
+    itn.strings  = nil;
+    itn.len      = 0;
+    itn.cap      = 0;
+    itn.dedup    = map.init[str, StrId](a, map.hash_str, map.eq_str);
+    itn.base     = nil;
+    itn.base_len = 0;
+    ret itn;
+}
+
+# construct a child interner extending a frozen `base` with a private write scratch
+#
+# Ids `[0, base_len)` resolve into `base`; ids the child assigns start at
+# `base_len`. The child copies nothing and must not outlive `base`, and `base`
+# must stay frozen (no interning) for the child's lifetime - which is the parallel
+# codegen contract: all lowering (the only base writer) is done before any child
+# is made. `reintern_child` maps the child's new ids back into the base once the
+# parallel region ends.
+# ---
+# base: the frozen parent interner to extend (must be a root)
+# a:    allocator backing the child's own owned copies, index array, and dedup map
+# ret:  a new empty child interner over base
+pub fun make_child(base: *Interner, a: *A.Allocator) Interner {
+    var itn: Interner;
+    itn.a        = a;
+    itn.strings  = nil;
+    itn.len      = 0;
+    itn.cap      = 0;
+    itn.dedup    = map.init[str, StrId](a, map.hash_str, map.eq_str);
+    itn.base     = base;
+    itn.base_len = base.len;
     ret itn;
 }
 
@@ -92,6 +129,12 @@ pub fun dnit(itn: *Interner) {
 # id:  a StrId returned by a prior intern / intern_span / intern_bytes
 # ret: some(text) when id is in range, none otherwise
 pub fun lookup(itn: *Interner, id: StrId) O.Option[str] {
+    if (itn.base != nil) {
+        if (id::usize < itn.base_len) { ret lookup(itn.base, id); }
+        val local: usize = id::usize - itn.base_len;
+        if (local >= itn.len) { ret O.none[str](); }
+        ret O.some[str](itn.strings[local]);
+    }
     if (id::usize >= itn.len) { ret O.none[str](); }
     ret O.some[str](itn.strings[id]);
 }
@@ -105,6 +148,16 @@ pub fun lookup(itn: *Interner, id: StrId) O.Option[str] {
 # text: null-terminated text to intern
 # ret:  the StrId for text (existing or new), or an allocation error
 pub fun intern(itn: *Interner, text: str) R.Result[StrId, str] {
+    # a child dedups against the frozen base first (a read-only map lookup, safe
+    # from many workers at once), reusing a base id when the string already exists
+    # there; only genuinely new strings land in the child's own scratch.
+    if (itn.base != nil) {
+        val res_base: R.Result[*StrId, str] = map.get[str, StrId](?itn.base.dedup, ?text);
+        if (R.is_ok[*StrId, str](res_base)) {
+            ret R.ok[StrId, str](@R.unwrap_ok[*StrId, str](res_base));
+        }
+    }
+
     val res_existing: R.Result[*StrId, str] = map.get[str, StrId](?itn.dedup, ?text);
     if (R.is_ok[*StrId, str](res_existing)) {
         ret R.ok[StrId, str](@R.unwrap_ok[*StrId, str](res_existing));
@@ -159,6 +212,14 @@ fun intern_range(itn: *Interner, source: str, offset: usize, len: usize) R.Resul
     }
     val owned: str = R.unwrap_ok[str, str](res_dup);
 
+    if (itn.base != nil) {
+        val res_base: R.Result[*StrId, str] = map.get[str, StrId](?itn.base.dedup, ?owned);
+        if (R.is_ok[*StrId, str](res_base)) {
+            string.str_free(itn.a, owned);
+            ret R.ok[StrId, str](@R.unwrap_ok[*StrId, str](res_base));
+        }
+    }
+
     val res_existing: R.Result[*StrId, str] = map.get[str, StrId](?itn.dedup, ?owned);
     if (R.is_ok[*StrId, str](res_existing)) {
         string.str_free(itn.a, owned);
@@ -198,7 +259,9 @@ fun store_and_index(itn: *Interner, owned: str) R.Result[StrId, str] {
         itn.cap     = new_cap;
     }
 
-    val new_id: StrId = itn.len::u32;
+    # a child's ids continue past the base's frozen universe; a root has base_len 0,
+    # so its ids are just its own array index.
+    val new_id: StrId = (itn.base_len + itn.len)::u32;
     itn.strings[itn.len] = owned;
     itn.len = itn.len + 1;
 
@@ -211,6 +274,48 @@ fun store_and_index(itn: *Interner, owned: str) R.Result[StrId, str] {
     }
 
     ret R.ok[StrId, str](new_id);
+}
+
+# the id boundary of a child interner - ids below it live in the frozen base
+# ---
+# itn: a child interner (base != nil); a root returns 0
+# ret: base_len, the first id this interner assigns to its own strings
+pub fun child_base_len(itn: *Interner) usize {
+    ret itn.base_len;
+}
+
+# fold a child's new strings back into its base and return the id remap
+#
+# Interns each string the child assigned (ids `[base_len, base_len + len)`) into
+# the base, which grows to cover them, and returns an owned array `remap[len]`
+# where `remap[i]` is the base id for the child's local string `i` - the string
+# whose child id is `base_len + i`. A field id `< base_len` needs no remap (it is
+# already a base id); a field id `>= base_len` maps to `remap[id - base_len]`.
+# Called serially after the parallel region joins, so interning the base is safe.
+# ---
+# child: the child interner to fold in (base must be non-nil)
+# alloc: allocator for the returned remap array (caller frees, length = child len)
+# ret:   the owned remap array, or an allocation error; nil array when the child
+#        added nothing
+pub fun reintern_child(child: *Interner, alloc: *A.Allocator) R.Result[*StrId, str] {
+    if (child.base == nil) { ret R.err[*StrId, str]("reintern_child: not a child interner"); }
+    if (child.len == 0)    { ret R.ok[*StrId, str](nil); }
+
+    val res_map: R.Result[*StrId, str] = A.allocate[StrId](alloc, child.len);
+    if (R.is_err[*StrId, str](res_map)) { ret res_map; }
+    val remap: *StrId = R.unwrap_ok[*StrId, str](res_map);
+
+    var i: usize = 0;
+    for (i < child.len) {
+        val res_id: R.Result[StrId, str] = intern(child.base, child.strings[i]);
+        if (R.is_err[StrId, str](res_id)) {
+            A.deallocate[StrId](alloc, remap, child.len);
+            ret R.err[*StrId, str](R.unwrap_err[StrId, str](res_id));
+        }
+        remap[i] = R.unwrap_ok[StrId, str](res_id);
+        i = i + 1;
+    }
+    ret R.ok[*StrId, str](remap);
 }
 
 # interning the same text twice yields the same id; distinct text yields a
@@ -265,6 +370,63 @@ test "mach.lang.intern.intern_span:dedups_against_intern" {
     if (R.unwrap_ok[StrId, str](res_bytes) != hello_id) { dnit(?itn); ret 1; }
 
     dnit(?itn);
+    ret 0;
+}
+
+# a child resolves base ids, dedups new strings against the base, assigns fresh
+# ids past the base boundary, and reintern_child folds those back into the base
+test "mach.lang.intern.make_child:layers_and_reinterns" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var base: Interner = init(?alloc);
+
+    val res_a: R.Result[StrId, str] = intern(?base, "alpha");
+    val res_b: R.Result[StrId, str] = intern(?base, "beta");
+    if (R.is_err[StrId, str](res_a)) { dnit(?base); ret 1; }
+    if (R.is_err[StrId, str](res_b)) { dnit(?base); ret 1; }
+    val alpha_id: StrId = R.unwrap_ok[StrId, str](res_a);
+
+    var child: Interner = make_child(?base, ?alloc);
+    if (child_base_len(?child) != 2) { dnit(?child); dnit(?base); ret 1; }
+
+    # a base id resolves through the child, and re-interning a base string in the
+    # child returns the SAME base id (dedup against the frozen base).
+    val opt_a: O.Option[str] = lookup(?child, alpha_id);
+    if (O.is_none[str](opt_a)) { dnit(?child); dnit(?base); ret 1; }
+    val res_a2: R.Result[StrId, str] = intern(?child, "alpha");
+    if (R.is_err[StrId, str](res_a2))                { dnit(?child); dnit(?base); ret 1; }
+    if (R.unwrap_ok[StrId, str](res_a2) != alpha_id) { dnit(?child); dnit(?base); ret 1; }
+
+    # a new string lands in the child's scratch at an id past base_len, resolvable
+    # in the child but absent from the base.
+    val res_g: R.Result[StrId, str] = intern(?child, "gamma");
+    if (R.is_err[StrId, str](res_g)) { dnit(?child); dnit(?base); ret 1; }
+    val gamma_id: StrId = R.unwrap_ok[StrId, str](res_g);
+    if (gamma_id::usize != 2) { dnit(?child); dnit(?base); ret 1; }
+    if (O.is_none[str](lookup(?child, gamma_id)))  { dnit(?child); dnit(?base); ret 1; }
+    if (O.is_some[str](lookup(?base, gamma_id)))   { dnit(?child); dnit(?base); ret 1; }
+    # interning gamma again in the child dedups to the same local id.
+    val res_g2: R.Result[StrId, str] = intern(?child, "gamma");
+    if (R.is_err[StrId, str](res_g2))                { dnit(?child); dnit(?base); ret 1; }
+    if (R.unwrap_ok[StrId, str](res_g2) != gamma_id) { dnit(?child); dnit(?base); ret 1; }
+
+    # folding the child back into the base yields a remap whose local-0 entry names
+    # gamma's new base id, which now resolves in the base.
+    val res_rm: R.Result[*StrId, str] = reintern_child(?child, ?alloc);
+    if (R.is_err[*StrId, str](res_rm)) { dnit(?child); dnit(?base); ret 1; }
+    val remap: *StrId = R.unwrap_ok[*StrId, str](res_rm);
+    if (remap == nil) { dnit(?child); dnit(?base); ret 1; }
+    val gamma_base: StrId = remap[gamma_id::usize - child_base_len(?child)];
+    if (O.is_none[str](lookup(?base, gamma_base))) { A.deallocate[StrId](?alloc, remap, child.len); dnit(?child); dnit(?base); ret 1; }
+    # re-interning gamma directly into the base now resolves to the same id the
+    # remap handed back, proving the fold landed the string in the base universe.
+    val res_gb2: R.Result[StrId, str] = intern(?base, "gamma");
+    if (R.is_err[StrId, str](res_gb2))                 { A.deallocate[StrId](?alloc, remap, child.len); dnit(?child); dnit(?base); ret 1; }
+    if (R.unwrap_ok[StrId, str](res_gb2) != gamma_base) { A.deallocate[StrId](?alloc, remap, child.len); dnit(?child); dnit(?base); ret 1; }
+
+    A.deallocate[StrId](?alloc, remap, child.len);
+    dnit(?child);
+    dnit(?base);
     ret 0;
 }
 


### PR DESCRIPTION
Parallelizes the per-module **codegen** phase of `mach build` across a worker pool, byte-identical to the serial build. Implements Option A of the design fork on #1826 (premise changed after #1850 landed — see the scope note on the issue). Lowering stays serial (its monomorphization writes the shared interner — split out as #2100); codegen runs on N workers, each with a private arena and a child interner over the frozen session interner, and results are merged deterministically in topo order and recorded into the query engine.

Measured on the release self-build (163 modules, 16-core host): **codegen 17.7s → 3.3s (5.4x)**, overall **25.2s → 11.7s (2.15x)**. The remaining bottleneck is the still-serial lower phase (~6.7s) — the parallel-lowering follow-up #2100.

## Design

- **Child interner** (`intern.make_child`): a per-worker scratch that layers over the frozen session interner — ids below the snapshot boundary resolve into the base (so every worker resolves the IR StrIds each image inherits), new codegen strings land locally. Many children read one frozen base concurrently (the base's dedup map is read-only during the parallel region). `reintern_child` folds a worker's new strings back into the session interner at collection and returns the id remap.
- **Worker session view**: a copy of the real session with only `.alloc` (→ a private arena) and `.interner` (→ a child) overridden. Everything else codegen reads (sources, types, target) is frozen after the front half and shared read-only. Audited: codegen mutates *only* the interner and the allocator; it emits no diagnostics.
- **MIR scratch allocator** threaded through `lower_ir`/`lower_function` so the transient MIR builds in the worker arena instead of the IR module's (shared) allocator. Serial path passes the session allocator — behaviour-identical.
- **Collection** (`obj.rehome_remap`): each worker-built image is deep-copied onto the session allocator with its four interned-name fields rewritten into the session interner's id space, in topo order, then staged on its `ModuleEntry`.

### Engine stays authoritative (rider #2)

The prelude does not bypass Q_CODEGEN. It stages each finished image on the `ModuleEntry`; the unchanged serial `query.get(Q_CODEGEN)` loop then **adopts** the staged image as the query's value (recording the same `Q_LOWER`/`Q_TARGET` deps), so Q_CODEGEN remains the value's system of record and the downstream Q_LINK fingerprint (which folds every module's Q_CODEGEN revision) is unaffected. The in-engine codegen compute is still the sole codegen-value writer and is exercised by the driver tests and every non-CLI caller (`jobs == 0`, serial path). The same `codegen.codegen_module` produces both the staged and the inline image, so the two cannot drift.

## StrId-leak audit (rider #1)

Every place a StrId reaches image bytes or link inputs, and its disposition:

| Site | Kind | Disposition |
|---|---|---|
| `ObjectImage.name`, `Section.name`, `Symbol.name`, `Relocation.symbol` | StrId **field** | **remapped** by `rehome_remap` into the session interner |
| `.text` / `.data` / `.rodata` / `.bss` bytes | — | symbol refs are Relocations (offset + symbol field), patched at link; content bytes carry no StrId |
| `.debug_str` bytes | — | real string **content**, copied verbatim, deduped by content; no StrId |
| `.debug_info` / `.debug_line` string refs | — | **byte offset** into a per-module `.debug_str`, via a relocation against a per-module `.debug_str` anchor symbol (anchor = a remapped `Relocation.symbol`; offset = self-contained addend). No StrId numeric value in DWARF bytes |
| `.debug_*` address refs | — | relocations against function symbols (remapped `Relocation.symbol`) |
| ELF writer `.strtab`/`.symtab`/`.shstrtab` | — | resolves StrId→string at emit time; lays out by iterating image arrays in **insertion order** — StrId numeric values never affect byte layout |
| Linker merged symbol table | — | StrId-keyed maps are **lookup-only**; the output table is emitted by iterating modules in topo order then per-module insertion order — StrId numbers never affect ordering |

**No StrId numeric value is baked into any image bytes unremappably.** Output bytes are a pure function of (image array insertion order, string content), both deterministic, so byte-identity is structural — confirmed empirically below (parallel == serial, both profiles). `-g` DWARF's cross-module `.debug_str` dedup (#1708) resolves by string content, unaffected; `-g` runs serial here regardless (#2101).

## `--jobs`

`--jobs <n>` selects the worker count (default: host CPUs; `1` drives the whole pool on one thread — the same machinery, so the serial reference and the parallel path cannot diverge). Documented in `mach help build`.

## Scope

Parallel codegen runs for non-`-g` builds (both profiles build without debug info by default). `-g` builds keep the serial path — DWARF interns IR types through the shared session allocator, which the worker arenas do not isolate (#2101). Parallel **lowering** is #2100.

## Verification (from-source compiler, never the seed)

- **Parallel == serial, byte-identical** (forced-serial compiler vs parallel, full `.o` tree + linked binary): release `a2322967…`, debug `53aa429b…`. Both match.
- **Determinism across core counts**: `--jobs 1 / 4 / 7 / 16` + repeats produce an identical object tree and binary — linux-x86_64 (both profiles), linux-arm64 (both profiles), linux-riscv64 (release).
- **Self-host fixpoint through the parallel path**: g2 == g3 byte-identical.
- **Full unit suite**: 661 passed / 0 failed (adds one child-interner test; test-mode builds exercise the prelude too).
- **int/ golden-diff harness**: all cases pass on the linux leg.
- **`-g` serial fallback**: builds a valid debug ELF, exit 0.

## Follow-ups

- #2100 — parallelize lowering (the now-dominant serial phase).
- #2101 — extend parallel codegen to `-g` builds.

Closes #1826
