### PR TITLE
ci(cd): drop x86_64-darwin as a released platform (Closes #2104)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,17 +9,13 @@ on:
 permissions:
   contents: read
 
-# a tagged push builds the release binary for each target — on its native host, or
-# under emulation where no practical native runner exists — each to its own
-# self-host fixpoint, then publishes the archives + SHA256SUMS. correctness is CI's
-# job — every change reaches main through a PR it gates.
+# a tagged push builds the release binary for each target on its native host, each
+# to its own self-host fixpoint, then publishes the archives + SHA256SUMS.
+# correctness is CI's job — every change reaches main through a PR it gates.
 #
 # darwin has no prior release to self-seed from, so seed-darwin cross-builds the
 # stage-0 seed on linux first; collapse that bootstrap once a darwin archive ships.
-# both darwin archives build on macos-14 (apple silicon): aarch64-darwin natively
-# and x86_64-darwin under Rosetta 2 — Intel macos-13 runners are queue-starved, and
-# the cross-built x86_64 seed bakes in x86_64-darwin as its host, so its
-# under-Rosetta a/b/c fixpoint stays self-hosted on the arm64 box.
+# the darwin archive builds on macos-15 (apple silicon), aarch64-darwin natively.
 #
 # workflow_dispatch runs the darwin lane (seed + native fixpoint + self-test) on a
 # branch with no tag, so on-Mac validation needs no release; the tag-verify and
@@ -222,8 +218,6 @@ jobs:
         include:
           - target: aarch64-darwin
             triple: darwin-aarch64
-          - target: x86_64-darwin
-            triple: darwin-x86_64
     steps:
       - uses: actions/checkout@v6
 
@@ -265,14 +259,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # release lanes validate on the oldest supported macOS — forward-compat
+          # covers newer, and macos-14 is next in the runner-retirement line.
           - target: aarch64-darwin
-            runs-on: macos-14
-          # x86_64-darwin: an Intel Mach-O run on the arm64 box via Rosetta 2. the
-          # cross-built seed bakes in x86_64-darwin as its host, so the whole a/b/c
-          # fixpoint emits Intel binaries and self-hosts under Rosetta.
-          - target: x86_64-darwin
-            runs-on: macos-14
-            rosetta: true
+            runs-on: macos-15
     steps:
       - uses: actions/checkout@v6
 
@@ -282,19 +272,12 @@ jobs:
           name: seed-${{ matrix.target }}
           path: seed
 
-      # the x86_64-darwin seed and its fixpoint are Intel Mach-O; the arm64 runner
-      # executes them through Rosetta 2, which is deterministic, so b == c holds.
-      - name: install Rosetta 2
-        if: ${{ matrix.rosetta }}
-        run: softwareupdate --install-rosetta --agree-to-license
-
       - name: build fixpoint
         run: |
           set -euo pipefail
           chmod +x seed/mach-darwin-seed
 
-          # stage-0 is the cross-built seed; a/b/c self-host on the macOS runner
-          # (arm64 natively, or x86_64 under Rosetta)
+          # stage-0 is the cross-built seed; a/b/c self-host natively on the arm64 runner
           ./seed/mach-darwin-seed dep pull
           ./seed/mach-darwin-seed build . --profile release -o a
           ./a build . --profile release -o b
@@ -309,9 +292,8 @@ jobs:
       - name: self test
         run: |
           set -euo pipefail
-          # exercises a mach-built darwin binary — arm64 native, or x86_64 under
-          # Rosetta — whose ad-hoc signature must hold (no SIGKILL) for the fixpoint
-          # and these tests to pass
+          # exercises a mach-built arm64-darwin binary whose ad-hoc signature must
+          # hold (no SIGKILL) for the fixpoint and these tests to pass
           ./c test .
 
       - name: package archive

--- a/int/targets.conf
+++ b/int/targets.conf
@@ -15,7 +15,4 @@ linux            ubuntu-latest     native    pr
 linux-arm64      ubuntu-24.04-arm  native    pr
 linux-riscv64    ubuntu-latest     qemu      pr
 windows          windows-latest    native    pr
-# x86_64-darwin runs on apple-silicon macos-14 under Rosetta 2, mirroring cd.yml:
-# intel macos-13 runners are queue-starved and never dispatch (#1787)
-darwin-x86_64    macos-14          native    main
-darwin-aarch64   macos-14          native    main
+darwin-aarch64   macos-15          native    main

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "9c6eb77880de143090ef48645ba7353ec786d758"
+commit = "7fd2a30e4f15a107e4c4332866a81623f97a3c1d"


### PR DESCRIPTION
Closes #2104.

Drops **x86_64-darwin** as a released/supported platform, moves the remaining aarch64-darwin lane to macos-15, and carries the mach-std bsdthread entry-ABI hardening. Zero compiler-code changes — the x86_64-darwin target triple remains a valid (now unsupported) cross-target.

## The #2104 ledger

**Symptom.** The v3.6.0 CD x86_64-darwin lane segfaults (SIGSEGV, exit 139) at stage-a of the self-host fixpoint. Deterministic (a `--failed` rerun reproduced it).

**Root cause (confirmed via CI core backtrace).** mach's parallel codegen (#2099) made per-module worker threads the default build path — the first darwin-x86_64 binary to spawn threads by default. Those threads are created with **raw `bsdthread_create` (pthread=0, flags=0)**, bypassing libpthread — the path **Rosetta 2** hooks to initialize each thread's translation context. The x86_64-darwin release lane runs **under Rosetta on the arm64 runner** (Intel macos-13 is queue-starved), so the worker thread runs translated code with no Rosetta context. The crash core (arm64) shows the faulting `pc` in the Rosetta runtime (`0x7ff7ff…`), reached from mach code (`lr` in mach's `0x1_0000_0000` image), dereferencing null+0x18 = Rosetta's per-thread context. Corroboration: `--jobs 1` (same codegen machinery, no thread spawned) builds cleanly; mach emits zero `%gs`/TSD accesses of its own; #2099's parallel codegen is verified working on native linux-x86_64 (real threads) and passes on native darwin-aarch64.

**Why no sound mach-side fix.** Making raw bsdthreads Rosetta-compatible means either linking/using libpthread (violates mach's libSystem-free design) or reverse-engineering the undocumented Rosetta+kernel bsdthread handshake to trigger Rosetta's per-thread init — fragile guessing at internals, not a sound fix.

**Native-Intel argument, and why it's unverifiable.** The x86_64-darwin *artifact* targets native Intel Macs (no Rosetta), where mach's raw threads should work (mach uses no TLS itself; the parallel logic is proven on native x86_64 linux). The crash is a Rosetta-CI artifact. But this is **not verifiable**: the native-Intel `macos-13` probe I dispatched sat queued for hours (the runner starvation the workflow itself documents), so there is no way to gate a release on native x86_64-darwin.

**Owner ruling (2026-07-12).** Drop x86_64-darwin from support — clean removal, no deprecation banners (absence is the statement). EOL hardware, Rosetta provably can't host mach threads, native Intel CI unavailable. arm64-darwin (Apple Silicon) is the supported darwin asset.

## Changes
- `cd.yml`: remove the x86_64-darwin `seed-darwin` and `build-darwin` matrix entries and the Rosetta-install step; the published-asset/SHA256SUMS wiring is glob-driven, so it drops the asset implicitly. Move the aarch64-darwin lane to **macos-15** (macos-14 nears runner retirement; release lanes validate on the oldest supported macOS).
- `int/targets.conf`: remove the `darwin-x86_64` integration row — it ran the cross-built compiler under Rosetta on macos-14 and would reproduce the #2104 crash on the first int-main run post-merge. Move the `darwin-aarch64` row to **macos-15** to match the release lane. This drops x86_64-darwin execution validation entirely — inherent to the ruling; the cross-target stays buildable but unvalidated, which is what "unsupported" means.
- `mach.lock`: bump mach-std to **7fd2a30e** (released 0.18.0 base + only mach-std #377, the naked realigning bsdthread trampoline — a real x86_64 entry-ABI hardening). Darwin-only source change → linux/windows/riscv output byte-identical (locally confirmed: linux-x86_64 release compiler byte-identical with vs without the change).

## Verification
- Dispatched darwin lane green end-to-end on **macos-15** with the bumped lock (aarch64-darwin — now the only darwin lane).
- Full PR CI green.
- Linux byte-identity unaffected by the lock bump (darwin-only mach-std change); from-source `mach test` 661/0.