### PR TITLE
release: v3.6.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,17 +9,13 @@ on:
 permissions:
   contents: read
 
-# a tagged push builds the release binary for each target — on its native host, or
-# under emulation where no practical native runner exists — each to its own
-# self-host fixpoint, then publishes the archives + SHA256SUMS. correctness is CI's
-# job — every change reaches main through a PR it gates.
+# a tagged push builds the release binary for each target on its native host, each
+# to its own self-host fixpoint, then publishes the archives + SHA256SUMS.
+# correctness is CI's job — every change reaches main through a PR it gates.
 #
 # darwin has no prior release to self-seed from, so seed-darwin cross-builds the
 # stage-0 seed on linux first; collapse that bootstrap once a darwin archive ships.
-# both darwin archives build on macos-14 (apple silicon): aarch64-darwin natively
-# and x86_64-darwin under Rosetta 2 — Intel macos-13 runners are queue-starved, and
-# the cross-built x86_64 seed bakes in x86_64-darwin as its host, so its
-# under-Rosetta a/b/c fixpoint stays self-hosted on the arm64 box.
+# the darwin archive builds on macos-15 (apple silicon), aarch64-darwin natively.
 #
 # workflow_dispatch runs the darwin lane (seed + native fixpoint + self-test) on a
 # branch with no tag, so on-Mac validation needs no release; the tag-verify and
@@ -222,8 +218,6 @@ jobs:
         include:
           - target: aarch64-darwin
             triple: darwin-aarch64
-          - target: x86_64-darwin
-            triple: darwin-x86_64
     steps:
       - uses: actions/checkout@v6
 
@@ -265,14 +259,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # release lanes validate on the oldest supported macOS — forward-compat
+          # covers newer, and macos-14 is next in the runner-retirement line.
           - target: aarch64-darwin
-            runs-on: macos-14
-          # x86_64-darwin: an Intel Mach-O run on the arm64 box via Rosetta 2. the
-          # cross-built seed bakes in x86_64-darwin as its host, so the whole a/b/c
-          # fixpoint emits Intel binaries and self-hosts under Rosetta.
-          - target: x86_64-darwin
-            runs-on: macos-14
-            rosetta: true
+            runs-on: macos-15
     steps:
       - uses: actions/checkout@v6
 
@@ -282,19 +272,12 @@ jobs:
           name: seed-${{ matrix.target }}
           path: seed
 
-      # the x86_64-darwin seed and its fixpoint are Intel Mach-O; the arm64 runner
-      # executes them through Rosetta 2, which is deterministic, so b == c holds.
-      - name: install Rosetta 2
-        if: ${{ matrix.rosetta }}
-        run: softwareupdate --install-rosetta --agree-to-license
-
       - name: build fixpoint
         run: |
           set -euo pipefail
           chmod +x seed/mach-darwin-seed
 
-          # stage-0 is the cross-built seed; a/b/c self-host on the macOS runner
-          # (arm64 natively, or x86_64 under Rosetta)
+          # stage-0 is the cross-built seed; a/b/c self-host natively on the arm64 runner
           ./seed/mach-darwin-seed dep pull
           ./seed/mach-darwin-seed build . --profile release -o a
           ./a build . --profile release -o b
@@ -309,9 +292,8 @@ jobs:
       - name: self test
         run: |
           set -euo pipefail
-          # exercises a mach-built darwin binary — arm64 native, or x86_64 under
-          # Rosetta — whose ad-hoc signature must hold (no SIGKILL) for the fixpoint
-          # and these tests to pass
+          # exercises a mach-built arm64-darwin binary whose ad-hoc signature must
+          # hold (no SIGKILL) for the fixpoint and these tests to pass
           ./c test .
 
       - name: package archive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.6.0] - 2026-07-12
+## [3.6.1] - 2026-07-12
 
 The build-speed and interop release. Parallel codegen takes the compiler
 self-build from 25.2s to 11.7s on 16 cores with byte-identical output, win64
-C interop for vectors conforms at `ext` boundaries, and the inliner finally
-sees generic-instance bodies. Built with mach 3.5.1.
+C interop for vectors conforms at `ext` boundaries, the inliner finally sees
+generic-instance bodies, and macOS support consolidates on Apple Silicon.
+Built with mach 3.5.1.
+
+(v3.6.0 was tagged but never published: its CD run caught the parallel
+compiler's worker threads crashing under Rosetta 2 on the x86_64-darwin lane,
+which led to the platform ruling below — the full ledger is #2104. This
+release supersedes the tag; the payload is otherwise identical.)
+
+### Removed
+- **the x86_64-darwin release artifact.** Intel Mac hardware is EOL and its CI
+  substrate is gone: Rosetta 2 cannot host mach's raw `bsdthread_create`
+  worker threads (the kernel entry bypasses Rosetta's per-thread
+  translation-context init — proven by core backtrace), and native Intel
+  runners no longer allocate. The `x86_64-darwin` target triple remains a
+  buildable, unvalidated cross-target; `aarch64-darwin` is the supported macOS
+  platform, now validated on macos-15 (#2104, #2105). The darwin thread entry
+  additionally gained the x86_64 stack-alignment trampoline in mach-std
+  (briar-systems/mach-std#377), a standalone ABI hardening found during the
+  investigation.
 
 ### Added
 - driver: **parallel per-module codegen** — codegen runs across a worker pool

--- a/int/targets.conf
+++ b/int/targets.conf
@@ -15,7 +15,4 @@ linux            ubuntu-latest     native    pr
 linux-arm64      ubuntu-24.04-arm  native    pr
 linux-riscv64    ubuntu-latest     qemu      pr
 windows          windows-latest    native    pr
-# x86_64-darwin runs on apple-silicon macos-14 under Rosetta 2, mirroring cd.yml:
-# intel macos-13 runners are queue-starved and never dispatch (#1787)
-darwin-x86_64    macos-14          native    main
-darwin-aarch64   macos-14          native    main
+darwin-aarch64   macos-15          native    main

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "9c6eb77880de143090ef48645ba7353ec786d758"
+commit = "7fd2a30e4f15a107e4c4332866a81623f97a3c1d"

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "3.6.0"
+version = "3.6.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 


### PR DESCRIPTION
Integration merge dev → main for the v3.6.1 release (re-cut of unpublished v3.6.0; release cut PR #2106). Parallel codegen, win64 ext vector marshaling, step template vars, imported-constant folding, inliner instance visibility, x86_64-darwin platform drop (#2104/#2105).