### PR TITLE
fix(manifest): synthesize native target for zero-[target.*] manifests

### DIFF
--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1289,6 +1289,22 @@ fun resolve_target(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel
         rt.warned = false;
         ret R.ok[ResolvedTarget, str](rt);
     }
+    # zero-target manifest: 'native' synthesizes the host target rather than
+    # dereferencing an empty array, mirroring resolve_profile's zero-[profile]
+    # default. the TargetDef outlives this call, so it is allocated from `alloc`.
+    if (m.target_count == 0) {
+        val res_host: R.Result[*TargetDef, str] = A.allocate[TargetDef](alloc, 1);
+        if (R.is_err[*TargetDef, str](res_host)) { ret R.err[ResolvedTarget, str](R.unwrap_err[*TargetDef, str](res_host)); }
+        val host: *TargetDef = R.unwrap_ok[*TargetDef, str](res_host);
+        host.name = intern_unwrap(itn, "native");
+        host.isa  = intern_unwrap(itn, host_isa_name());
+        host.os   = intern_unwrap(itn, host_os_name());
+        host.abi  = intern_unwrap(itn, abi.abi_name_for(tgt.host_abi_id()));
+        host.of   = intern.STR_NIL;
+        rt.target = host;
+        rt.warned = false;
+        ret R.ok[ResolvedTarget, str](rt);
+    }
     rt.target = ?m.targets[0];
     rt.warned = true;
     ret R.ok[ResolvedTarget, str](rt);
@@ -2306,6 +2322,49 @@ test "mach.lang.manifest.resolve_build_unit:native_resolution_exact" {
             if (bu.warned)                                { code = 1; }
             if (!str_equals(idstr(?itn, bu.target_name), "host")) { code = 1; }
         }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #2108: a zero-[target.*] manifest synthesizes the host native target instead of
+# dereferencing an empty array (the segfault this fixes). the resolved unit names
+# 'native' with the host's isa/os/abi, {target.name} expands to 'native', and an
+# explicit unknown --target still errors gracefully rather than crashing.
+test "mach.lang.manifest.resolve_build_unit:native_resolution_zero_target" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val src: str = "[project]\nid = \"x\"\nversion = \"1\"\nsrc=\"src\"\nout=\"out/{target.name}\"\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
+        if (m.target_count != 0) { code = 1; }
+
+        # empty selector defaults to native and synthesizes cleanly
+        val ue: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("", "", "app", false, true));
+        if (R.is_err[BuildUnit, str](ue)) { code = 1; }
+
+        # explicit 'native' selector takes the same synthesis path
+        val u: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("native", "", "app", false, true));
+        if (R.is_err[BuildUnit, str](u)) { code = 1; }
+        or {
+            val bu: BuildUnit = R.unwrap_ok[BuildUnit, str](u);
+            if (bu.warned)                                             { code = 1; }
+            if (!str_equals(idstr(?itn, bu.target_name), "native"))    { code = 1; }
+            if (!str_equals(idstr(?itn, bu.target.isa), host_isa_name())) { code = 1; }
+            if (!str_equals(idstr(?itn, bu.target.os),  host_os_name())) { code = 1; }
+            if (!str_equals(idstr(?itn, bu.target.abi), abi.abi_name_for(tgt.host_abi_id()))) { code = 1; }
+            # {target.name} in the project out template expanded to 'native'
+            if (!str_equals(idstr(?itn, bu.obj_root), "out/native/obj")) { code = 1; }
+        }
+
+        # an explicit unknown target name still errors gracefully (no crash)
+        val uf: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("foreign", "", "app", false, true));
+        if (R.is_ok[BuildUnit, str](uf) || !str_contains(R.unwrap_err[BuildUnit, str](uf), "no target named")) { code = 1; }
     }
     arena.dnit(?ar);
     ret code;

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -49,6 +49,18 @@ pub fun abi_id_for(name: str) u32 {
     ret ABI_UNKNOWN;
 }
 
+# map a calling-convention id to its canonical name
+# ---
+# id:  abi id (one of ABI_*)
+# ret: the canonical name, or "unknown" if unrecognized
+pub fun abi_name_for(id: u32) str {
+    if (id == ABI_SYSV)    { ret "sysv64"; }
+    if (id == ABI_WIN64)   { ret "win64"; }
+    if (id == ABI_AAPCS64) { ret "aapcs64"; }
+    if (id == ABI_LP64)    { ret "lp64"; }
+    ret "unknown";
+}
+
 # how a single parameter or return value is classified for passing
 pub def ParamClass: u8;
 
@@ -622,5 +634,18 @@ test "mach.lang.target.abi.covers_isa:matches_declared_arch" {
     vt.arch_id = isa.ARCH_AARCH64;
     if (!covers_isa(?vt, isa.ARCH_AARCH64)) { ret 1; }
     if (covers_isa(?vt, isa.ARCH_X86_64))   { ret 1; }
+    ret 0;
+}
+
+# abi_name_for is the inverse of abi_id_for over the known conventions, and yields
+# "unknown" for ABI_UNKNOWN
+test "mach.lang.target.abi.abi_name_for:round_trips" {
+    if (!str_equals(abi_name_for(ABI_SYSV),    "sysv64"))  { ret 1; }
+    if (!str_equals(abi_name_for(ABI_WIN64),   "win64"))   { ret 1; }
+    if (!str_equals(abi_name_for(ABI_AAPCS64), "aapcs64")) { ret 1; }
+    if (!str_equals(abi_name_for(ABI_LP64),    "lp64"))    { ret 1; }
+    if (!str_equals(abi_name_for(ABI_UNKNOWN), "unknown")) { ret 1; }
+    if (abi_id_for(abi_name_for(ABI_SYSV))    != ABI_SYSV)    { ret 1; }
+    if (abi_id_for(abi_name_for(ABI_AAPCS64)) != ABI_AAPCS64) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
A manifest declaring no `[target.*]` sections drove `resolve_target`s native branch into a fall-through that returned a nil `TargetDef` inside an `ok` result (`?m.targets[0]` with `m.target_count == 0`). `resolve_build_unit` dereferenced it, segfaulting every driver consumer (`build`/`run`/`test` and the LSP workspace load) with exit 139 and no diagnostic.

## Fix

When `m.target_count == 0` and the selector resolves to `native` (the empty-selector default, or an explicit `native`), `resolve_target` now synthesizes a host `TargetDef` allocated from the caller`s allocator so it outlives the call: name `native`, `isa`/`os` from the host ids, `abi` from `host_abi_id()`, and no object-format override (`of = STR_NIL`, matching a declared target with an absent `of`). This mirrors `resolve_profile`s zero-`[profile]` -> `debug` default; declaring targets is only needed to cross-build or to pin `{target.name}` paths.

Unchanged: the declared-but-unmatched fall-through (default to `targets[0]` with `warned = true`) and the explicit unknown-name error path (`--target foo` still errors via `find_target_by_name`).

A small `abi.abi_name_for` reverse helper was added (symmetric with `isa.arch_name_for` / `os.os_name_for`) so the synthesized abi id renders to its canonical name without a hardcoded table at the call site.

## Tests

- `mach.lang.manifest.resolve_build_unit:native_resolution_zero_target` — a zero-target manifest resolves cleanly (empty and explicit `native` selectors), the unit`s target is `native` with the host isa/os/abi, `{target.name}` expands to `native`, and an explicit unknown `--target` still errors gracefully.
- `mach.lang.target.abi.abi_name_for:round_trips` — covers the new helper.

Full `mach test .` through the freshly-built from-source compiler: **661 -> 663 passed, 0 failed** (delta is exactly the two added tests; no vanished suites, no new failures).

End-to-end repro (scratch `mach init` project with its `[target.*]` sections deleted, built with the from-source compiler): exit **0**, output homes under `out/native/...`, binary runs. The pre-fix seed compiler exits **139** on the same project.

Closes #2108