### PR TITLE
perf(abi): stage the SysV vector-count (AL) only for variadic calls

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -806,6 +806,20 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
 
     val rslot: abi.ParamSlot = layout.ret_slot;
 
+    # whether this call reaches the variadic / unprototyped region, the sole condition
+    # under which the SysV vector-count register (AL) is a live hidden argument (#1939):
+    # a call passing arguments past its declared fixed parameters, or a prototype-less
+    # indirect call whose callee carries no IRT_FN (SysV's `%al` rule covers both). a
+    # fully-prototyped fixed-arity call - every mach-to-mach call and every non-variadic
+    # C extern - never reads it, so it stages no vector-count write. captured here before
+    # the layout is freed, since it reads `layout.param_count`.
+    val sig_it:      O.Option[*type.IrType] = type.get(ctx.types, sig);
+    var sig_is_fn:   bool = false;
+    if (O.is_some[*type.IrType](sig_it)) {
+        sig_is_fn = O.unwrap[*type.IrType](sig_it).kind == type.IRT_FN;
+    }
+    val variadic_call: bool = !sig_is_fn || ((inst.operand_count - 1) > layout.param_count);
+
     # the call's result type sizes the caller-owned aggregate result storage.
     val ret_size:  u64 = type.byte_size(ctx.types, ret_type, ctx.tgt)::u64;
     val ret_aggr:  bool = context.value_is_aggregate(ctx, ret_type);
@@ -956,14 +970,16 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     record_outgoing_size(ctx, stack_off);
 
     # the pre-call vector-count move: a convention that encodes the number of vector
-    # registers a variadic call uses (SysV's AL, the low byte of RAX) sets it before
-    # every call (a conservative upper bound is the FP count). the register rides on
-    # the variadic save model - a convention that encodes no count (win64) reports -1
-    # and the move is skipped, so the instruction is an ABI-driven hook rather than an
-    # unconditional emission on every target.
-    if (vamodel.vector_count_reg >= 0) {
-        val al: R.Result[bool, str] = context.emit_mov(ctx, mb,
-            mir.op_preg(vamodel.vector_count_reg::u32), mir.op_imm(fp_used::i64));
+    # registers a variadic call uses (SysV's AL, the low byte of RAX) sets it to the FP
+    # count (a conservative upper bound). the register rides on the variadic save model -
+    # a convention that encodes no count (win64) reports -1 and the move is skipped - and
+    # it is staged only for a variadic / prototype-less call (#1939), so a fixed-arity
+    # call carries no such write. the move is a 32-bit `mov eax, imm32` (the count is 0-8,
+    # so writing EAX sets AL and zero-extends the rest), five bytes rather than the 7-byte
+    # 64-bit immediate form.
+    if (vamodel.vector_count_reg >= 0 && variadic_call) {
+        val al: R.Result[bool, str] = context.emit_mov_w(ctx, mb,
+            mir.op_preg(vamodel.vector_count_reg::u32), mir.op_imm(fp_used::i64), 4::u8);
         if (R.is_err[bool, str](al)) { ret al; }
     }
 


### PR DESCRIPTION
Closes #1939.

## The gate

SysV call lowering staged the vector-count hidden argument (AL, the low byte of RAX) before **every** call, in the 7-byte `mov rax, 0` (`48 c7 c0 00000000`) encoding. AL is a live input only to a variadic or prototype-less callee; every fully-prototyped fixed-arity call — each mach-to-mach call and each non-variadic C extern — paid the bytes and the register write for nothing.

The stage is now gated on whether the call reaches the variadic / unprototyped region, computed in `lower_call` from the signature already in hand:

```
variadic_call = !sig_is_fn || ((operand_count - 1) > layout.param_count)
```

This is exactly SysV's `%al` rule — set for **variadic calls** (arguments past the declared fixed parameters) and **prototype-less calls** (an indirect callee carrying no IRT_FN). A needing-AL call still stages it (with the same conservative `fp_used` count as before); a fixed-arity call stages nothing. mach removed C-style `...` in v2.0.0 and monomorphizes every comptime `va: ...` pack to a concrete fixed-arity signature, and function pointers lower to a typed IRT_FN, so in the current language every reachable call is fully prototyped — the corpus loses the stage on 99.6% of call sites.

When the stage **is** emitted it is now a 5-byte `mov eax, imm32` (the count is 0–8, so writing EAX sets AL and zero-extends the rest) rather than the 7-byte 64-bit-immediate form. The change is x86_64-only: SysV is the sole convention with `vector_count_reg >= 0`; win64 / aapcs64 / lp64 report `-1` and were already skipped.

## Measured win (isolated: this change alone, off origin/dev)

Release compiler compiling itself, executable `PT_LOAD` (R E) segment:

| | R E segment |
|---|---|
| old codegen | 11,504,757 bytes (0xaf8c75) |
| this change | 11,261,086 bytes (0xabd49e) |
| **removed** | **243,671 bytes (2.12%)** |

The old codegen staged `mov rax, 0` before **49,647 of 49,828** call sites in the emitted corpus; the new codegen emits **zero** AL staging anywhere. fib's two recursion sites go from `mov rdi, rax; mov rax, 0; call fib` to `mov rdi, rax; call fib`.

## Correctness

The ON-path is correct by construction: when `variadic_call` holds, the emitted value is the same accumulated `fp_used` the old code used — only prototyped fixed-arity calls (which never read AL) lose the stage.

- compiler suite (from-source HEAD): **715 / 0**
- mach-std suite: **637 / 0** (identical seed vs branch)
- int **linux** (native) and **linux-riscv64** (qemu): all cases pass
- single-generation fixpoint **B == C** (byte-identical)
- fib runtime output correct (`832040`) under old and new codegen

(int `linux-arm64` was not executed here — it is a `native` leg with no aarch64 runner on this x86_64 host; the build succeeds, only execution is unavailable. aapcs64 has `vector_count_reg = -1`, so behavior there is unchanged.)