### PR TITLE
feat(build): parallelize -g codegen via private per-worker DWARF type table

### DIFF
--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -843,30 +843,32 @@ fun base_die_of_kind(kind: semtype.TypeKind, address_size: u8) O.Option[TypeDie]
 
 # bridge a semantic type to its IR type, the single layout authority for aggregate DIEs
 # (member byte offsets / struct sizes). Mirrors the front end's `lower_type` structural
-# mapping; because the IR type interners deduplicate, this lands on the exact type
-# lowering already produced (a lookup in practice - every reachable type was lowered)
-# rather than a new one, so DWARF member offsets come from the same layout that emitted
-# the code. IR pointers are opaque, so this never recurses through one (it terminates)
+# mapping. Interns into `dtypes`, the producer's private layout-oracle table (backed by
+# the caller's allocator, worker-private under parallel codegen) rather than the module's
+# shared `irmod.types`; because the IR type interners are structural and deduplicating,
+# the recomputed layout is byte-identical to lowering's, so DWARF member offsets agree
+# with the emitted code. IR pointers are opaque, so this never recurses through one (it
+# terminates)
 # ---
-# s:     session (semantic type universe, align overrides, allocator)
-# irmod: the IR module whose type universe is consulted
-# sem:   the semantic TypeId to bridge
-# ret:   the corresponding IrTypeId, or an allocation error
-fun sem_to_ir(s: *session.Session, irmod: *ir.Module, sem: semtype.TypeId) R.Result[ir_type.IrTypeId, str] {
-    if (sem == semtype.TYPE_NIL) { ret ir_type.intern_void(?irmod.types); }
+# s:      session (semantic type universe, align overrides, allocator)
+# dtypes: the producer's private IR type table, the layout oracle
+# sem:    the semantic TypeId to bridge
+# ret:    the corresponding IrTypeId, or an allocation error
+fun sem_to_ir(s: *session.Session, dtypes: *ir_type.IrTypeTable, sem: semtype.TypeId) R.Result[ir_type.IrTypeId, str] {
+    if (sem == semtype.TYPE_NIL) { ret ir_type.intern_void(dtypes); }
     val to: O.Option[*semtype.Type] = semtype.get(?s.types, sem);
-    if (O.is_none[*semtype.Type](to)) { ret ir_type.intern_void(?irmod.types); }
+    if (O.is_none[*semtype.Type](to)) { ret ir_type.intern_void(dtypes); }
     val t: *semtype.Type = O.unwrap[*semtype.Type](to);
     val k: semtype.TypeKind = t.kind;
 
     # secrecy has no runtime representation: `^T` bridges to exactly `T`'s shape.
-    if (k == semtype.TYPE_SECRET) { ret sem_to_ir(s, irmod, t.data.secret.base); }
+    if (k == semtype.TYPE_SECRET) { ret sem_to_ir(s, dtypes, t.data.secret.base); }
 
     val d: semtype.PrimDesc = semtype.prim_desc(k);
-    if (d.class == semtype.PRIM_CLASS_INT)   { ret ir_type.intern_int(?irmod.types, d.bits); }
-    if (d.class == semtype.PRIM_CLASS_FLOAT) { ret ir_type.intern_float(?irmod.types, d.bits); }
-    if (d.class == semtype.PRIM_CLASS_PTR)   { ret ir_type.intern_ptr(?irmod.types); }
-    if (k == semtype.TYPE_POINTER)           { ret ir_type.intern_ptr(?irmod.types); }
+    if (d.class == semtype.PRIM_CLASS_INT)   { ret ir_type.intern_int(dtypes, d.bits); }
+    if (d.class == semtype.PRIM_CLASS_FLOAT) { ret ir_type.intern_float(dtypes, d.bits); }
+    if (d.class == semtype.PRIM_CLASS_PTR)   { ret ir_type.intern_ptr(dtypes); }
+    if (k == semtype.TYPE_POINTER)           { ret ir_type.intern_ptr(dtypes); }
 
     if (k == semtype.TYPE_ARRAY) {
         # capture element + count before recursing: bridging the element can materialize a
@@ -874,9 +876,9 @@ fun sem_to_ir(s: *session.Session, irmod: *ir.Module, sem: semtype.TypeId) R.Res
         # `t` - so a post-recursion `t.data.array.count` would read freed memory.
         val ebase: semtype.TypeId = t.data.array.base;
         val ecount: u32 = t.data.array.count;
-        val rb: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, irmod, ebase);
+        val rb: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, dtypes, ebase);
         if (R.is_err[ir_type.IrTypeId, str](rb)) { ret rb; }
-        ret ir_type.intern_array(?irmod.types, R.unwrap_ok[ir_type.IrTypeId, str](rb), ecount);
+        ret ir_type.intern_array(dtypes, R.unwrap_ok[ir_type.IrTypeId, str](rb), ecount);
     }
 
     # a vector bridges to an IRT_VECTOR over its lowered lane scalar, exactly as
@@ -886,33 +888,34 @@ fun sem_to_ir(s: *session.Session, irmod: *ir.Module, sem: semtype.TypeId) R.Res
     if (k == semtype.TYPE_VECTOR) {
         val ed: semtype.PrimDesc = semtype.prim_desc(t.data.vector.element);
         val lanes: u32 = t.data.vector.lanes;
-        var res_elem: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?irmod.types, ed.bits);
-        if (ed.class == semtype.PRIM_CLASS_FLOAT) { res_elem = ir_type.intern_float(?irmod.types, ed.bits); }
+        var res_elem: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(dtypes, ed.bits);
+        if (ed.class == semtype.PRIM_CLASS_FLOAT) { res_elem = ir_type.intern_float(dtypes, ed.bits); }
         if (R.is_err[ir_type.IrTypeId, str](res_elem)) { ret res_elem; }
-        ret ir_type.intern_vector(?irmod.types, R.unwrap_ok[ir_type.IrTypeId, str](res_elem), lanes);
+        ret ir_type.intern_vector(dtypes, R.unwrap_ok[ir_type.IrTypeId, str](res_elem), lanes);
     }
 
     if (k == semtype.TYPE_REC || k == semtype.TYPE_UNI || k == semtype.TYPE_INSTANCE) {
-        ret sem_to_ir_nominal(s, irmod, sem, k == semtype.TYPE_UNI);
+        ret sem_to_ir_nominal(s, dtypes, sem, k == semtype.TYPE_UNI);
     }
 
     # function / generic-param / error types bridge to an opaque pointer-width slot, as
     # `lower_type` does, so a variable of such a type still sizes correctly.
-    ret ir_type.intern_ptr(?irmod.types);
+    ret ir_type.intern_ptr(dtypes);
 }
 
 # bridge a nominal (rec / uni) or generic instance to an IR struct / union of its lowered
 # field types, read from the session-global field store - the same source `lower_nominal`
-# uses, so the interned layout matches
+# uses, so the interned layout matches. Interns into the producer's private `dtypes`
 # ---
 # s:        session
-# irmod:    the IR module
+# dtypes:   the producer's private IR type table, the layout oracle
 # tid:      the nominal / instance semantic TypeId
 # is_union: bridge to an IR union rather than a struct
 # ret:      the IrTypeId, or an allocation error
-fun sem_to_ir_nominal(s: *session.Session, irmod: *ir.Module, tid: semtype.TypeId, is_union: bool) R.Result[ir_type.IrTypeId, str] {
-    # materialize a generic instance's substituted field table before reading it, exactly
-    # as lower_type does; a no-op for a non-instance or an already-built table.
+fun sem_to_ir_nominal(s: *session.Session, dtypes: *ir_type.IrTypeTable, tid: semtype.TypeId, is_union: bool) R.Result[ir_type.IrTypeId, str] {
+    # the instance's substituted field table is materialized during lowering, before the
+    # (possibly parallel) codegen phase reaches here; this is a pure read at the current
+    # epoch, so it never mutates the shared session type universe under a worker.
     generics.ensure_fields(s, tid);
 
     var nom_align: u32 = 0;
@@ -921,8 +924,8 @@ fun sem_to_ir_nominal(s: *session.Session, irmod: *ir.Module, tid: semtype.TypeI
 
     val fields_len: u32 = semtype.field_count(?s.types, tid);
     if (fields_len == 0) {
-        if (is_union) { ret ir_type.intern_union(?irmod.types, nil, 0, nom_align); }
-        ret ir_type.intern_struct(?irmod.types, nil, 0, nom_align);
+        if (is_union) { ret ir_type.intern_union(dtypes, nil, 0, nom_align); }
+        ret ir_type.intern_struct(dtypes, nil, 0, nom_align);
     }
 
     val rbuf: R.Result[*ir_type.IrTypeId, str] = A.allocate[ir_type.IrTypeId](s.alloc, fields_len::usize);
@@ -936,7 +939,7 @@ fun sem_to_ir_nominal(s: *session.Session, irmod: *ir.Module, tid: semtype.TypeI
             A.deallocate[ir_type.IrTypeId](s.alloc, buf, fields_len::usize);
             ret R.err[ir_type.IrTypeId, str]("dwarf.sem_to_ir: corrupt field table");
         }
-        val rf: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, irmod, O.unwrap[*semtype.FieldEntry](fe).ty);
+        val rf: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, dtypes, O.unwrap[*semtype.FieldEntry](fe).ty);
         if (R.is_err[ir_type.IrTypeId, str](rf)) {
             A.deallocate[ir_type.IrTypeId](s.alloc, buf, fields_len::usize);
             ret rf;
@@ -946,8 +949,8 @@ fun sem_to_ir_nominal(s: *session.Session, irmod: *ir.Module, tid: semtype.TypeI
     }
 
     var res: R.Result[ir_type.IrTypeId, str];
-    if (is_union) { res = ir_type.intern_union(?irmod.types, buf, fields_len, nom_align); }
-    or            { res = ir_type.intern_struct(?irmod.types, buf, fields_len, nom_align); }
+    if (is_union) { res = ir_type.intern_union(dtypes, buf, fields_len, nom_align); }
+    or            { res = ir_type.intern_struct(dtypes, buf, fields_len, nom_align); }
     A.deallocate[ir_type.IrTypeId](s.alloc, buf, fields_len::usize);
     ret res;
 }
@@ -2564,8 +2567,25 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     strtab.buf = enc.buf_init(s.alloc);
     var var_count: u32 = 0;
     var range_count: u32 = 0;
+
+    # `dtypes` is the producer's private IR type table: the aggregate layout oracle
+    # `sem_to_ir` interns into to read member offsets / struct sizes. Backed by `s.alloc`
+    # (the worker's private arena under parallel codegen, so no two workers ever touch the
+    # module's shared `irmod.types`), it is populated only during gather and torn down
+    # immediately after - no type_intern runs past this point.
+    var dtypes: ir_type.IrTypeTable;
+    val rdt: O.Option[str] = ir_type.init(?dtypes, s.alloc);
+    if (O.is_some[str](rdt)) {
+        enc.buf_dnit(?strtab.buf); type_ctx_dnit(?tc);
+        A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
+        A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
+        ret R.err[bool, str](O.unwrap[str](rdt));
+    }
     gather_subprograms(s, tgt, irmod, subs, nsub, rows, row_count, varlocs, varloc_count, text_sec, ?ft, address_size,
-                       ?tc, ?strtab, vars, ?var_count, var_cap, ranges, ?range_count, range_cap);
+                       ?tc, ?strtab, ?dtypes, vars, ?var_count, var_cap, ranges, ?range_count, range_cap);
+    # the DIE table (`tc`) is fully populated with concrete byte sizes / offsets now; the
+    # IR layout oracle has served its purpose and no later stage reads it.
+    ir_type.dnit(?dtypes);
 
     # a module emits a `.debug_loclists` section only when some variable's home moves.
     var has_loclists: bool = false;
@@ -2790,12 +2810,14 @@ pub fun register_debug_hooks(reg: *of.DebugRegistry) R.Result[bool, str] {
 # address_size: target pointer width, for a raw-pointer return's byte size
 # tc:           out - the type table
 # strtab:       out - the `.debug_str` string table
+# dtypes:       the producer's private IR type table (composite layout oracle)
 # vars/var_count/var_cap: out - the shared variable array
 # ranges/range_count/range_cap: out - the shared loclist-range array
 fun gather_subprograms(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
                        funcs: *DwFunc, nfuncs: u32, rows: *enc.LineRow, row_count: u32,
                        varlocs: *enc.VarLoc, varloc_count: u32, text_sec: u32,
                        ft: *FileTable, address_size: u8, tc: *TypeCtx, strtab: *StrTab,
+                       dtypes: *ir_type.IrTypeTable,
                        vars: *DwVar, var_count: *u32, var_cap: u32,
                        ranges: *LocRange, range_count: *u32, range_cap: u32) {
     var i: u32 = 0;
@@ -2833,12 +2855,12 @@ fun gather_subprograms(s: *session.Session, tgt: *target.Target, irmod: *ir.Modu
         }
 
         # return type: any resolvable type (a composite un-defers #1907's aggregates).
-        fn.ret_ty = type_intern(s, tgt, irmod, tc, strtab, ret_sem, address_size);
+        fn.ret_ty = type_intern(s, tgt, dtypes, tc, strtab, ret_sem, address_size);
 
         # variables + parameters: join the encoder's variable-location records for this
         # function's `.text` range with the IR dbg-var identity.
         if (irfn != nil) {
-            gather_vars(s, tgt, irmod, irfn, fn.offset, fn.offset + fn.size, varlocs, varloc_count, text_sec,
+            gather_vars(s, tgt, irmod, dtypes, irfn, fn.offset, fn.offset + fn.size, varlocs, varloc_count, text_sec,
                         address_size, tc, strtab, vars, var_count, var_cap, ranges, range_count, range_cap);
             fn.var_count = @var_count - fn.var_start;
         }
@@ -2977,7 +2999,8 @@ fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfunc
 # through `type_intern`, so aggregates and typed pointers carry their composite DIE
 # ---
 # s/tgt:        session + target (the ISA dwarf_reg hook, member layout)
-# irmod:        the IR module (IR type universe for composite layout)
+# irmod:        the IR module (function / dbg-var lookup)
+# dtypes:       the producer's private IR type table (composite layout oracle)
 # irfn:         the IR function (dbg-var / dbg-expr side tables)
 # lo/hi:        the function's `.text` byte range
 # varlocs/varloc_count: the encoder's variable-location records
@@ -2987,7 +3010,7 @@ fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfunc
 # strtab:       the `.debug_str` string table
 # vars/var_count/var_cap:       the shared variable array
 # ranges/range_count/range_cap: the shared loclist-range array
-fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irfn: *ir.Function, lo: u32, hi: u32,
+fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, dtypes: *ir_type.IrTypeTable, irfn: *ir.Function, lo: u32, hi: u32,
                 varlocs: *enc.VarLoc, varloc_count: u32, text_sec: u32, address_size: u8,
                 tc: *TypeCtx, strtab: *StrTab, vars: *DwVar, var_count: *u32, var_cap: u32,
                 ranges: *LocRange, range_count: *u32, range_cap: u32) {
@@ -2998,7 +3021,7 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irf
     for (i < varloc_count) {
         val vl: *enc.VarLoc = ?varlocs[i];
         if (vl.sec != text_sec || vl.text_offset < lo || vl.text_offset >= hi) { i = i + 1; cnt; }
-        val obt: O.Option[u32] = varloc_ident(s, tgt, irmod, irfn, vl, address_size, tc, strtab);
+        val obt: O.Option[u32] = varloc_ident(s, tgt, irmod, dtypes, irfn, vl, address_size, tc, strtab);
         if (O.is_none[u32](obt)) { i = i + 1; cnt; }
         val name_off: u32 = O.unwrap[u32](obt);
         # the inline instance this variable lives in (0 = the caller's own body); a caller
@@ -3011,7 +3034,7 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irf
         for (j < @var_count) { if (vars[j].name_off == name_off && vars[j].inline_site == vsite) { found = true; } j = j + 1; }
         if (!found && @var_count < var_cap) {
             val dv: *ir.DbgVar = O.unwrap[*ir.DbgVar](ir.dbg_var_get(irfn, vl.iid::id.InstructionId));
-            val ty: i32 = type_intern(s, tgt, irmod, tc, strtab, dv.ty_sem, address_size);
+            val ty: i32 = type_intern(s, tgt, dtypes, tc, strtab, dv.ty_sem, address_size);
             vars[@var_count].name_off    = name_off;
             vars[@var_count].ty          = ty;
             vars[@var_count].is_param    = dv.is_param;
@@ -3041,7 +3064,7 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irf
             val vl: *enc.VarLoc = ?varlocs[k];
             if (vl.sec != text_sec || vl.text_offset < lo || vl.text_offset >= hi) { k = k + 1; cnt; }
             if (@range_count >= range_cap) { k = k + 1; cnt; }
-            val oid: O.Option[u32] = varloc_ident(s, tgt, irmod, irfn, vl, address_size, tc, strtab);
+            val oid: O.Option[u32] = varloc_ident(s, tgt, irmod, dtypes, irfn, vl, address_size, tc, strtab);
             if (O.is_none[u32](oid)) { k = k + 1; cnt; }
             if (O.unwrap[u32](oid) != v.name_off) { k = k + 1; cnt; }
 
@@ -3154,20 +3177,21 @@ fun cmp_sub_home(tgt: *target.Target, sub: u8, raw_reg: i32, raw_off: i64, out_r
 # ---
 # s:            session (interner, type universe)
 # tgt:          resolved target (member layout via the IR type table)
-# irmod:        the IR module (IR type universe for composite layout)
+# irmod:        the IR module (dbg-var side table lookup)
+# dtypes:       the producer's private IR type table (composite layout oracle)
 # irfn:         the IR function holding the dbg-var side table
 # vl:           the variable-location record (its `iid` joins the identity)
 # address_size: pointer width, for a raw-pointer base type
 # tc:           the type table
 # strtab:       the `.debug_str` string table
 # ret:          the variable's name offset, or none
-fun varloc_ident(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irfn: *ir.Function,
+fun varloc_ident(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, dtypes: *ir_type.IrTypeTable, irfn: *ir.Function,
                  vl: *enc.VarLoc, address_size: u8, tc: *TypeCtx, strtab: *StrTab) O.Option[u32] {
     val odv: O.Option[*ir.DbgVar] = ir.dbg_var_get(irfn, vl.iid::id.InstructionId);
     if (O.is_none[*ir.DbgVar](odv)) { ret O.none[u32](); }
     val dv: *ir.DbgVar = O.unwrap[*ir.DbgVar](odv);
     if (dv.name == intern.STR_NIL) { ret O.none[u32](); }
-    if (type_intern(s, tgt, irmod, tc, strtab, dv.ty_sem, address_size) < 0) { ret O.none[u32](); }
+    if (type_intern(s, tgt, dtypes, tc, strtab, dv.ty_sem, address_size) < 0) { ret O.none[u32](); }
     ret O.some[u32](str_off(strtab, resolve(?s.interner, dv.name)));
 }
 
@@ -3329,13 +3353,13 @@ fun comp_name(s: *session.Session, t: *semtype.Type) str {
 # ---
 # s:            session (semantic type universe, interner, allocator)
 # tgt:          resolved target (member layout via the IR type table)
-# irmod:        the IR module (IR type universe for composite layout)
+# dtypes:       the producer's private IR type table (composite layout oracle)
 # tc:           the type table
 # strtab:       the `.debug_str` string table
 # sem:          the semantic TypeId to intern
 # address_size: target pointer width, for a raw / typed pointer byte size
 # ret:          the type's index in `tc`, or -1
-fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc: *TypeCtx,
+fun type_intern(s: *session.Session, tgt: *target.Target, dtypes: *ir_type.IrTypeTable, tc: *TypeCtx,
                 strtab: *StrTab, sem: semtype.TypeId, address_size: u8) i32 {
     if (sem == semtype.TYPE_NIL || sem == semtype.TYPE_ERROR) { ret -1; }
     val to: O.Option[*semtype.Type] = semtype.get(?s.types, sem);
@@ -3344,7 +3368,7 @@ fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc:
     val kind: semtype.TypeKind = t.kind;
 
     # secrecy is representation-transparent: `^T` interns as exactly `T`.
-    if (kind == semtype.TYPE_SECRET) { ret type_intern(s, tgt, irmod, tc, strtab, t.data.secret.base, address_size); }
+    if (kind == semtype.TYPE_SECRET) { ret type_intern(s, tgt, dtypes, tc, strtab, t.data.secret.base, address_size); }
 
     # primitive scalars (incl. the raw opaque `ptr`) become base type DIEs.
     val obt: O.Option[TypeDie] = sem_base_type(s, sem, address_size);
@@ -3358,7 +3382,7 @@ fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc:
         # capture the pointee TypeId before recursing: interning it can grow s.types and
         # dangle `t`.
         val ptee: semtype.TypeId = t.data.pointer.base;
-        val pe: i32 = type_intern(s, tgt, irmod, tc, strtab, ptee, address_size);
+        val pe: i32 = type_intern(s, tgt, dtypes, tc, strtab, ptee, address_size);
         # the pointee recursion may have interned THIS exact pointer already (a cycle, e.g.
         # rec Node { next: *Node } reached via a `*Node` local), so re-dedup rather than
         # emit a second identical DIE.
@@ -3379,7 +3403,7 @@ fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc:
         # s.types and dangle `t` (a stale `t.data.array.count` would be a garbage length).
         val ebase: semtype.TypeId = t.data.array.base;
         val ecount: u32 = t.data.array.count;
-        val el: i32 = type_intern(s, tgt, irmod, tc, strtab, ebase, address_size);
+        val el: i32 = type_intern(s, tgt, dtypes, tc, strtab, ebase, address_size);
         if (el < 0) { ret -1; }
         val f2: i32 = comp_find(tc, sem);   # element recursion may have interned this array (cycle)
         if (f2 >= 0) { ret f2; }
@@ -3410,7 +3434,7 @@ fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc:
     }
 
     if (kind == semtype.TYPE_REC || kind == semtype.TYPE_UNI || kind == semtype.TYPE_INSTANCE) {
-        ret struct_intern(s, tgt, irmod, tc, strtab, sem, address_size);
+        ret struct_intern(s, tgt, dtypes, tc, strtab, sem, address_size);
     }
 
     # an unresolved type here (an unsubstituted generic parameter / pack, or a first-class
@@ -3426,18 +3450,19 @@ fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc:
 # field table. The entry is registered before its fields recurse, so a self-referential
 # aggregate terminates
 # ---
-# s/tgt/irmod:  session / target / IR module
+# s/tgt:        session / target
+# dtypes:       the producer's private IR type table (composite layout oracle)
 # tc:           the type table
 # strtab:       the `.debug_str` string table
 # sem:          the aggregate's semantic TypeId
 # address_size: target pointer width
 # ret:          the type's index, or -1
-fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc: *TypeCtx,
+fun struct_intern(s: *session.Session, tgt: *target.Target, dtypes: *ir_type.IrTypeTable, tc: *TypeCtx,
                   strtab: *StrTab, sem: semtype.TypeId, address_size: u8) i32 {
     # the IR type is the single layout authority; without it we cannot place members.
     # sem_to_ir can materialize a generic instance's field table (ensure_fields), growing
     # s.types and reallocating it - so every borrow into s.types must be taken AFTER it.
-    val rir: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, irmod, sem);
+    val rir: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, dtypes, sem);
     if (R.is_err[ir_type.IrTypeId, str](rir)) { ret -1; }
     val ir_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rir);
 
@@ -3454,7 +3479,7 @@ fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, t
     val cnm: str = comp_name(s, t);
     var name_off: u32 = NAME_OMIT;
     if (str_len(cnm) > 0) { name_off = str_off(strtab, cnm); }
-    val bsize: u32 = ir_type.byte_size(?irmod.types, ir_ty, tgt);
+    val bsize: u32 = ir_type.byte_size(dtypes, ir_ty, tgt);
 
     val ix: i32 = comp_reserve(tc, tk, sem);
     if (ix < 0) { ret -1; }
@@ -3470,7 +3495,7 @@ fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, t
         val fe: O.Option[*semtype.FieldEntry] = semtype.field_at(?s.types, sem, i);
         if (O.is_some[*semtype.FieldEntry](fe)) {
             val fty_sem: semtype.TypeId = O.unwrap[*semtype.FieldEntry](fe).ty;   # capture before recursion (fe may dangle)
-            type_intern(s, tgt, irmod, tc, strtab, fty_sem, address_size);
+            type_intern(s, tgt, dtypes, tc, strtab, fty_sem, address_size);
         }
         i = i + 1;
     }
@@ -3487,7 +3512,7 @@ fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, t
         # and dangle `fe`.
         val f_ty:   semtype.TypeId = O.unwrap[*semtype.FieldEntry](fe).ty;
         val f_name: intern.StrId   = O.unwrap[*semtype.FieldEntry](fe).name;
-        val fty: i32 = type_intern(s, tgt, irmod, tc, strtab, f_ty, address_size);
+        val fty: i32 = type_intern(s, tgt, dtypes, tc, strtab, f_ty, address_size);
         if (fty < 0) { j = j + 1; cnt; }
         if (!memb_reserve(tc)) { j = j + 1; cnt; }
         # an anonymous field (name == STR_NIL, or an empty spelling) drops DW_AT_name (#1955).
@@ -3498,7 +3523,7 @@ fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, t
         }
         tc.membs[tc.nmemb].name_off = mno;
         tc.membs[tc.nmemb].type_ix  = fty::u32;
-        tc.membs[tc.nmemb].offset   = ir_type.byte_offset(?irmod.types, ir_ty, j, tgt);
+        tc.membs[tc.nmemb].offset   = ir_type.byte_offset(dtypes, ir_ty, j, tgt);
         tc.nmemb = tc.nmemb + 1;
         count = count + 1;
         j = j + 1;
@@ -4088,7 +4113,7 @@ test "mach.lang.be.codegen.dwarf.sem_to_ir:vector" {
         if (R.is_err[ir.Module, str](im)) { code = 1; }
         or {
             var m: ir.Module = R.unwrap_ok[ir.Module, str](im);
-            val ri: R.Result[ir_type.IrTypeId, str] = sem_to_ir(?s, ?m, vec_sem);
+            val ri: R.Result[ir_type.IrTypeId, str] = sem_to_ir(?s, ?m.types, vec_sem);
             if (R.is_err[ir_type.IrTypeId, str](ri)) { code = 1; }
             or {
                 val ot: O.Option[*ir_type.IrType] = ir_type.get(?m.types, R.unwrap_ok[ir_type.IrTypeId, str](ri));

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -602,15 +602,14 @@ fun lower_phase(p: *driver.Project, st: *UnitState, rd: *outcome.Render) R.Resul
 # `jobs`) stages images up front; the serial pass adopts them through
 # Q_CODEGEN and the views collect the borrows
 fun codegen_phase(p: *driver.Project, st: *UnitState) R.Result[bool, outcome.Fail] {
-    # when the request asks for workers (jobs >= 1) and the build emits no
-    # DWARF, codegen the stale modules across the pool up front and stage each
-    # finished image on its ModuleEntry; run_codegen_pass then adopts the
-    # staged images (Q_CODEGEN stays the value's system of record). warm-valid
-    # modules never reach the pool - the cache serves them through the pass's
-    # revalidation. a `-g` build keeps the serial path: its DWARF interns IR
-    # types into each module's type table through the shared session
-    # allocator, which the worker arenas do not isolate (#1826
-    # parallel-lowering/-g follow-up).
+    # when the request asks for workers (jobs >= 1), codegen the stale modules
+    # across the pool up front and stage each finished image on its ModuleEntry;
+    # run_codegen_pass then adopts the staged images (Q_CODEGEN stays the value's
+    # system of record). warm-valid modules never reach the pool - the cache serves
+    # them through the pass's revalidation. `-g` builds parallelize too: each
+    # worker's DWARF producer synthesizes debug types into a private IR type table
+    # backed by the worker arena, so no module's shared type state is written under
+    # the pool (#2101).
     if (pcg_enabled(p)) {
         val rp: R.Result[bool, str] = run_codegen_parallel(p);
         if (R.is_err[bool, str](rp)) {
@@ -900,11 +899,12 @@ fun emit_unit_summary(p: *driver.Project, st: *UnitState, ev: *readout.Progress)
 }
 
 # whether the parallel-codegen prelude should run for this build: the request
-# asked for at least one worker, the build emits no DWARF (the worker arenas do
-# not isolate the `-g` type-table writes), and there is at least one module
+# asked for at least one worker and there is at least one module. `-g` builds
+# parallelize too - each worker synthesizes its module's DWARF into a private IR
+# type table (the layout oracle), so no two workers touch shared type state (#2101)
 fun pcg_enabled(p: *driver.Project) bool {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
-    ret ctx.req.jobs >= 1 && !ctx.req.debug && p.topo_len > 0;
+    ret ctx.req.jobs >= 1 && p.topo_len > 0;
 }
 
 # serialize the link-only build configuration into the Q_LINK_CONFIG input, keyed
@@ -1029,6 +1029,9 @@ rec PcgSlot {
 # stale_len:  number of stale entries
 # base_len:   session-interner id count snapshotted before any child - the boundary
 #             below which a name needs no remap
+# dbg:        the build's settled debug-info decision (DW_AT_producer / comp_dir),
+#             resolved once on the main thread; every worker's codegen emits DWARF
+#             through it when `-g` is on, or is a no-op when off
 rec ParallelCodegen {
     p:          *driver.Project;
     next:       i64;
@@ -1040,6 +1043,7 @@ rec ParallelCodegen {
     stale:      *u32;
     stale_len:  u32;
     base_len:   usize;
+    dbg:        codegen.DebugInfo;
 }
 
 # initialise one worker: a fresh page-backed arena and a session view whose
@@ -1103,7 +1107,7 @@ fun pcg_worker_main(arg: *u8) {
         val slot: *PcgSlot         = ?pc.slots[idx::usize];
         slot.worker = wid;
 
-        val r: R.Result[of.ObjectImage, str] = codegen.codegen_module(?w.sess, ?pc.p.target, m.ir_module, nil, codegen.no_debug());
+        val r: R.Result[of.ObjectImage, str] = codegen.codegen_module(?w.sess, ?pc.p.target, m.ir_module, nil, pc.dbg);
         if (R.is_err[of.ObjectImage, str](r)) {
             slot.err   = R.unwrap_err[of.ObjectImage, str](r);
             slot.image = nil;
@@ -1137,16 +1141,19 @@ fun pcg_worker_main(arg: *u8) {
 #
 # Each worker owns a private arena and a child interner over the session interner,
 # so lowering-to-object runs with no shared mutable state (the session interner and
-# allocator are read-only for the span). Modules are handed out by an atomic cursor,
-# so the object tree is independent of worker count and scheduling. Collection is
-# serial in TOPO order: each worker's new interner strings are folded back into the
-# session interner (reintern_child) and each raw image is re-homed onto the session
-# allocator with its names remapped (obj.rehome_remap), so the staged images are
+# allocator are read-only for the span). Under `-g`, each worker's DWARF producer
+# synthesizes its debug types into a private IR type table backed by the worker arena
+# (the layout oracle), so the module's shared type state is never written either.
+# Modules are handed out by an atomic cursor, so the object tree is independent of
+# worker count and scheduling. Collection is serial in TOPO order: each worker's new
+# interner strings are folded back into the session interner (reintern_child) and each
+# raw image is re-homed onto the session allocator with its names remapped
+# (obj.rehome_remap), so the staged images - including their `.debug_*` sections - are
 # byte-identical to a serial build and the link that follows keys on one interner.
 # Pool bookkeeping is per-call (the build channel); the staged images alone are
 # session-owned, so a warm session does not grow per rebuild.
 # ---
-# p:   the active project (jobs resolved, no DWARF - see pcg_enabled)
+# p:   the active project (jobs resolved; DWARF decision settled per debug_info_of)
 # ret: true once every stale module is staged, or the first worker's codegen error
 fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
     val topo_len: u32 = p.topo_len;
@@ -1183,6 +1190,18 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
     var si: u32 = 0;
     for (si < stale_len) { slots[si].image = nil; slots[si].worker = 0; slots[si].err = nil; si = si + 1; }
 
+    # settle the debug-info decision on the main thread, before any worker child interner
+    # snapshots the base: a `-g` build interns the DW_AT_producer string into the session
+    # interner here, so every child created below sees it below `base_len` and resolves it
+    # without a remap. off (no_debug) when `-g` is not set.
+    val rdbg: R.Result[codegen.DebugInfo, str] = driver.debug_info_of(p);
+    if (R.is_err[codegen.DebugInfo, str](rdbg)) {
+        A.deallocate[PcgSlot](p.alloc, slots, stale_len::usize);
+        A.deallocate[u32](p.alloc, stale, topo_len::usize);
+        ret R.err[bool, str](R.unwrap_err[codegen.DebugInfo, str](rdbg));
+    }
+    val dbg: codegen.DebugInfo = R.unwrap_ok[codegen.DebugInfo, str](rdbg);
+
     val rworkers: R.Result[*PcgWorker, str] = A.allocate[PcgWorker](p.alloc, nworkers::usize);
     if (R.is_err[*PcgWorker, str](rworkers)) {
         A.deallocate[PcgSlot](p.alloc, slots, stale_len::usize);
@@ -1216,6 +1235,7 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
     ctx.stale      = stale;
     ctx.stale_len  = stale_len;
     ctx.base_len   = intern.count(?p.s.interner);
+    ctx.dbg        = dbg;
 
     # spawn nworkers-1 helper threads; the calling thread is the last worker, so a
     # single-worker (jobs 1) run drives the whole pool on this thread with no spawn.


### PR DESCRIPTION
Closes #2101. Part of #1825; follow-up to #1826 (parallel codegen).

## Problem

`#1826`'s parallel per-module codegen pool ran **serial for `-g` builds** — `pcg_enabled` gated on `!req.debug`. The DWARF producer synthesized debug IR types into each module's `irmod.types` table, whose allocator is the shared **session allocator** fixed at lower time (`ir.init(s.alloc)`) and unreachable by the worker-arena override. Two workers doing `-g` codegen on distinct modules would race on `s.alloc` (arena/page allocators are not thread-safe), so debug builds got no codegen speedup.

## Approach

Decouple DWARF type synthesis from the module's shared type table.

- **`be/codegen/dwarf.mach`** — the producer now builds debug types into a **private `ir_type.IrTypeTable`** (`dtypes`), backed by the caller's allocator (the worker's private arena under the pool). It is used purely as a **layout oracle** — `sem_to_ir` interns into it and `struct_intern` reads `byte_size` / `byte_offset` from it. IR type interning is structural and deterministic, so the recomputed layout is byte-identical to lowering's and the emitted DWARF is unchanged. `sem_to_ir` / `sem_to_ir_nominal` / `type_intern` / `struct_intern` / `gather_subprograms` / `gather_vars` / `varloc_ident` thread `dtypes` instead of writing `irmod.types`. The table is created in `produce` and torn down immediately after the gather phase (no `type_intern` runs past it). `generics.ensure_fields` on this path is a pure read at the current epoch (lowering materializes every reachable instance before the parallel codegen phase), so no shared session type state is written under a worker.
- **`build/engine.mach`** — drop the `-g` gate in `pcg_enabled`; add `dbg: codegen.DebugInfo` to the pool job. `debug_info_of` runs **once on the main thread before any worker child interner snapshots the base**, so the `DW_AT_producer` string resolves below `base_len` in every child. Each worker emits its module's DWARF into its own arena + child interner; the existing `reintern_child` / `rehome_remap` collection remaps the `.debug_*` sections deterministically in topo order, exactly as the codegen path already does.

No shared mutable DWARF/type state crosses threads; the per-module DWARF is worker-private and merges in deterministic module order.

## Verification

All on this branch's from-source compiler (single-gen fixpoint reached: stage2 == stage3).

- **Jobs invariance** — `-g` self-build **byte-identical** at `--jobs 1` vs `--jobs 8`: the linked binary matches, and all 196 release `-g` objects match byte-for-byte (`.debug_*` included).
- **`-g` additivity (the sacred invariant)** — `.text` **byte-identical** with vs without `-g` across **every object, both profiles** (196 release, 200 debug; 0 differ).
- **DWARF correctness** — `llvm-dwarfdump --verify` → **No errors** on the parallel `-g` binary (179 CUs). Per-object DWARF is identical serial vs parallel.
- **Suites** — `mach test` **717/0**; mach-std **663/0**; `int` full suite green on **linux** and **linux-riscv64**, including the `surface/debuginfo` case (dwarfdump-verify + segment additivity) on both legs and both profiles.
- **Speedup** — `-g` compiler self-build **21.4s → 7.5s (~2.9x)** at 8 jobs.