### PR TITLE
fix(resolve): resolve the `:^` secret-strip cast in a full build

### DIFF
--- a/int/surface/declassify/expect.txt
+++ b/int/surface/declassify/expect.txt
@@ -1,0 +1,3 @@
+add=42
+double=42
+roundtrip=7

--- a/int/surface/declassify/mach.toml
+++ b/int/surface/declassify/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/declassify/src/main.mach
+++ b/int/surface/declassify/src/main.mach
@@ -1,0 +1,39 @@
+# secret-declassify surface case (#2138)
+#
+# `:^` is the sole secret->public downgrade in the constant-time model (#1643):
+# a secret result must be declassified to become an observable. this case runs a
+# secret computation and strips the `^` with both the bare `a:^` and the typed
+# `a:^u32` forms, then prints the declassified values. it exists because the
+# in-memory sema tests resolved `:^` while a full `mach build` did not (the
+# resolve name-binder skipped the strip node), so no end-to-end case exercised it.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+# add two secrets and declassify the result with the bare `:^` strip
+fun secret_add(a: ^u32, b: ^u32) u32 {
+    val s: ^u32 = a + b;
+    ret s:^;
+}
+
+# double a secret and declassify with the typed `:^u32` strip (names the
+# operand's own stripped public type)
+fun secret_double(a: ^u32) u32 {
+    val s: ^u32 = a * 2;
+    ret s:^u32;
+}
+
+# up-coerce a public into a secret, then strip it straight back
+fun roundtrip(x: u32) u32 {
+    val s: ^u32 = x;
+    ret s:^;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    p.printlnf("add={}", secret_add(20, 22));    # 42
+    p.printlnf("double={}", secret_double(21));  # 42
+    p.printlnf("roundtrip={}", roundtrip(7));    # 7
+    ret 0;
+}

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -2329,6 +2329,13 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str] {
         if (R.is_err[bool, str](rv)) { ret rv; }
         ret bind_type(rc, e.data.cast.ty);
     }
+    if (e.kind == expr.EXPR_KIND_STRIP) {
+        # `value:^` / `value:^Type`: bind the stripped operand, then the optional
+        # target type (TYPE_NIL for the bare form binds cleanly).
+        val rv: R.Result[bool, str] = bind_expr(rc, e.data.strip.value);
+        if (R.is_err[bool, str](rv)) { ret rv; }
+        ret bind_type(rc, e.data.strip.ty);
+    }
     if (e.kind == expr.EXPR_KIND_ARRAY_LIT) {
         val rt: R.Result[bool, str] = bind_type(rc, e.data.array_lit.ty);
         if (R.is_err[bool, str](rt)) { ret rt; }


### PR DESCRIPTION
Closes #2138.

## Root cause

The `:^` secret-strip (declassify) cast resolved in the in-memory sema unit tests but failed a full `mach build` with `unresolved identifier` on the cast operand. The divergence is in the name resolver, not the cast machinery.

`bind_expr` in `src/lang/fe/resolve.mach` — the pass that binds every identifier to its symbol — dispatches on expression kind but had **no `EXPR_KIND_STRIP` arm**. So for a strip cast (`value:^` / `value:^Type`) it fell through to the default `ok(true)` and never recursed into the operand. The operand identifier's `expr_resolved[eid]` slot stayed `SYMBOL_NIL`.

Why the two paths diverged on the *same* source:

- **sema** (`infer_strip` → `infer_ident`) tolerates the unbound operand silently: `infer_ident` returns `TYPE_ERROR` without a diagnostic (by design — it assumes resolve already reported the root cause), and `infer_strip` propagates that poison. So `ut_sema_clean` counts **zero errors** and the sema-only unit test (`mach.lang.driver:secret_join_coerce_strip_clean`) passes.
- **the full pipeline** runs lowering, where `symbol_reference` / `symbol_lvalue` in `src/lang/me/lower/expr.mach` read the `SYMBOL_NIL` binding and report `unresolved identifier`.

Resolve stayed silent (never visited the operand) and sema stayed silent (poisoned quietly), so nothing surfaced until lower — which the sema-only harness never runs. That is the test-harness fidelity gap the #1645 sema-only acceptance left open.

## Fix

Add the missing `EXPR_KIND_STRIP` arm to `bind_expr`, mirroring the existing `EXPR_KIND_CAST` arm: bind the operand, then the optional target type (`bind_type` handles the bare form's `TYPE_NIL` cleanly). Both `a:^` and `a:^u32` now bind their operand, so the operand resolves identically in-memory and in a full build.

## Verification

- **Repro fixed**: the issue's program (`fun down(a: ^u32) u32 { ret a:^; }`) built on the seed 4.1.0 and on a from-source pre-fix HEAD (pre-existing, independent of the taint work); it now compiles and runs.
- **Byte-identical for non-`:^` code**: built a base (pre-fix) and fixed compiler from the same tree; both compile the mach compiler source (a `:^`-free corpus — every `:^` in it is inside a comment or string literal, never a strip expression) to **byte-identical** output. The fix changes nothing for code that does not use `:^`.
- **Single-gen fixpoint B==C**: the fixed compiler self-hosts stably (gen B == gen C, byte-identical).
- **Full suite green**: `mach test .` 723 passed / 0 failed (incl. the sema strip test).
- **mach-std baseline**: 663 passed / 0 failed.
- **int**: all cases pass on `linux` and `linux-riscv64` (debug + release), including the new `surface/declassify` case.

## End-to-end coverage

New `int/surface/declassify` surface case: runs a secret computation and declassifies with both the bare `a:^` and typed `a:^u32` forms, then prints the values (`add=42`, `double=42`, `roundtrip=7`) against a golden. This closes the sema-only gap the issue calls out.

## Unblocks

`:^` is the only secret→public downgrade in the constant-time model (#1643). With declassification now compiling end-to-end, the #1647 ct harness and #1648 translation-validator can compile their corpora (a program that declassifies a secret to produce an observable), and an int case that declassifies-then-prints a secret is now writable.