### PR TITLE
test(2179): revert #2175 in full to prove the darwin release gate catches it — DO NOT MERGE

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,13 +13,12 @@ permissions:
 # to its own self-host fixpoint, then publishes the archives + SHA256SUMS.
 # correctness is CI's job — every change reaches main through a PR it gates.
 #
-# darwin has no prior release to self-seed from, so seed-darwin cross-builds the
-# stage-0 seed on linux first; collapse that bootstrap once a darwin archive ships.
-# the darwin archive builds on macos-15 (apple silicon), aarch64-darwin natively.
+# the darwin lane (seed cross-build + native fixpoint + self-test) lives in
+# darwin-lane.yml, shared with ci.yml's dev -> main release gate; see that file.
 #
-# workflow_dispatch runs the darwin lane (seed + native fixpoint + self-test) on a
-# branch with no tag, so on-Mac validation needs no release; the tag-verify and
-# publish steps are gated to tag pushes and stay skipped on dispatch.
+# workflow_dispatch runs the darwin lane on a branch with no tag, so on-Mac
+# validation needs no release; the tag-verify and publish steps are gated to tag
+# pushes and stay skipped on dispatch.
 jobs:
   verify:
     name: verify tag
@@ -203,119 +202,15 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # bootstrap: no prior darwin release exists to seed the native fixpoint, so
-  # cross-build the stage-0 seed on linux and hand it to the macOS runner. retire
-  # this once the first darwin archive ships and build-darwin can self-seed like
-  # every other target.
-  seed-darwin:
-    name: seed ${{ matrix.target }}
+  # the darwin lane (bootstrap seed cross-build + native fixpoint + self-test) is a
+  # reusable workflow shared with ci.yml's dev -> main release gate — see
+  # darwin-lane.yml. gated the same way build-linux/build-windows are: explicit,
+  # since the default success() skips through verify's dispatch-skip.
+  build-darwin:
+    name: darwin lane
     needs: verify
     if: ${{ !cancelled() && (needs.verify.result == 'success' || needs.verify.result == 'skipped') }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: aarch64-darwin
-            triple: darwin-aarch64
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: fetch released mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SEED: mach-*-x86_64-linux.tar.gz
-        run: |
-          set -euo pipefail
-          tmp="$(mktemp -d)"
-          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
-          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
-          chmod +x /usr/local/bin/mach
-
-      - name: cross-build the darwin seed
-        env:
-          TRIPLE: ${{ matrix.triple }}
-        run: |
-          set -euo pipefail
-          mach dep pull
-          mach build . -o m
-          ./m build . --target "$TRIPLE" --profile release -o mach-darwin-seed
-
-      - name: upload seed
-        uses: actions/upload-artifact@v4
-        with:
-          name: seed-${{ matrix.target }}
-          path: mach-darwin-seed
-          if-no-files-found: error
-          retention-days: 1
-
-  build-darwin:
-    name: build ${{ matrix.target }}
-    needs: seed-darwin
-    # explicit, since the default success() skips through verify's dispatch-skip
-    if: ${{ !cancelled() && needs.seed-darwin.result == 'success' }}
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # release lanes validate on the oldest supported macOS — forward-compat
-          # covers newer, and macos-14 is next in the runner-retirement line.
-          - target: aarch64-darwin
-            runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: download the darwin seed
-        uses: actions/download-artifact@v4
-        with:
-          name: seed-${{ matrix.target }}
-          path: seed
-
-      - name: build fixpoint
-        run: |
-          set -euo pipefail
-          chmod +x seed/mach-darwin-seed
-
-          # stage-0 is the cross-built seed; a/b/c self-host natively on the arm64 runner
-          ./seed/mach-darwin-seed dep pull
-          ./seed/mach-darwin-seed build . --profile release -o a
-          ./a build . --profile release -o b
-          ./b build . --profile release -o c
-
-          # ship the fixpoint: b == c (stage2 vs stage3) or the build is non-deterministic
-          if ! cmp -s b c; then
-            echo "::error::darwin build did not converge to the fixpoint"
-            exit 1
-          fi
-
-      - name: self test
-        run: |
-          set -euo pipefail
-          # exercises a mach-built arm64-darwin binary whose ad-hoc signature must
-          # hold (no SIGKILL) for the fixpoint and these tests to pass
-          ./c test .
-
-      - name: package archive
-        if: github.event_name == 'push'
-        env:
-          TARGET: ${{ matrix.target }}
-        run: |
-          set -euo pipefail
-          ver="${GITHUB_REF_NAME#v}"
-          mkdir -p dist stage
-          cp c stage/mach
-          cp LICENSE stage/
-          tar -C stage -czf "dist/mach-$ver-$TARGET.tar.gz" mach LICENSE
-
-      - name: upload archive
-        if: github.event_name == 'push'
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-${{ matrix.target }}
-          path: dist/mach-*-${{ matrix.target }}.tar.gz
-          if-no-files-found: error
-          retention-days: 1
+    uses: ./.github/workflows/darwin-lane.yml
 
   release:
     name: publish release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ permissions:
 # rest and after an edit (the query engine's invalidation, unexercised by the
 # from-scratch fixpoint). "release <target>" repeats the fixpoint under the opt=2
 # release profile so -O2 codegen regressions surface on PRs, not only at tag time.
+#
+# darwin is the exception: it gates the dev -> main release merge only, not every
+# PR into dev, since the macOS runners are slow and metered. see the "darwin"
+# job below and darwin-lane.yml (shared with cd.yml, so the gate can never drift
+# from the lane CD actually runs).
 jobs:
   build-linux:
     name: build ${{ matrix.target }}
@@ -396,3 +401,10 @@ jobs:
       - name: run integration suite
         shell: bash
         run: bash int/run.sh --target ${{ matrix.target }} ./m
+
+  # the release gate: only PRs targeting main (the dev -> main release merge) get
+  # a macOS runner. every other PR base schedules nothing here. #2179.
+  darwin:
+    name: darwin (release gate)
+    if: github.base_ref == 'main'
+    uses: ./.github/workflows/darwin-lane.yml

--- a/.github/workflows/darwin-lane.yml
+++ b/.github/workflows/darwin-lane.yml
@@ -1,0 +1,126 @@
+name: darwin lane
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+# darwin has no prior release to self-seed from, so seed cross-builds the stage-0
+# seed on linux first; collapse that bootstrap once a darwin archive ships. build
+# then runs on macos-15 (apple silicon), aarch64-darwin natively: it execs the
+# cross-built seed, self-hosts to a b == c fixpoint, and runs the suite.
+#
+# a reusable workflow, not a copy: cd.yml calls it for tag pushes and
+# workflow_dispatch, ci.yml calls it as the dev -> main release gate. one lane
+# means the gate can never drift from the path CD actually takes.
+#
+# github.event_name here is the event that triggered the top-level run (push,
+# workflow_dispatch, or pull_request), so the package/upload steps below stay
+# tag-push-only regardless of which caller invoked this workflow.
+jobs:
+  seed:
+    name: seed ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-darwin
+            triple: darwin-aarch64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: fetch released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED: mach-*-x86_64-linux.tar.gz
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
+          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: cross-build the darwin seed
+        env:
+          TRIPLE: ${{ matrix.triple }}
+        run: |
+          set -euo pipefail
+          mach dep pull
+          mach build . -o m
+          ./m build . --target "$TRIPLE" --profile release -o mach-darwin-seed
+
+      - name: upload seed
+        uses: actions/upload-artifact@v4
+        with:
+          name: seed-${{ matrix.target }}
+          path: mach-darwin-seed
+          if-no-files-found: error
+          retention-days: 1
+
+  build:
+    name: build ${{ matrix.target }}
+    needs: seed
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # release lanes validate on the oldest supported macOS — forward-compat
+          # covers newer, and macos-14 is next in the runner-retirement line.
+          - target: aarch64-darwin
+            runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: download the darwin seed
+        uses: actions/download-artifact@v4
+        with:
+          name: seed-${{ matrix.target }}
+          path: seed
+
+      - name: build fixpoint
+        run: |
+          set -euo pipefail
+          chmod +x seed/mach-darwin-seed
+
+          # stage-0 is the cross-built seed; a/b/c self-host natively on the arm64 runner
+          ./seed/mach-darwin-seed dep pull
+          ./seed/mach-darwin-seed build . --profile release -o a
+          ./a build . --profile release -o b
+          ./b build . --profile release -o c
+
+          # ship the fixpoint: b == c (stage2 vs stage3) or the build is non-deterministic
+          if ! cmp -s b c; then
+            echo "::error::darwin build did not converge to the fixpoint"
+            exit 1
+          fi
+
+      - name: self test
+        run: |
+          set -euo pipefail
+          # exercises a mach-built arm64-darwin binary whose ad-hoc signature must
+          # hold (no SIGKILL) for the fixpoint and these tests to pass
+          ./c test .
+
+      - name: package archive
+        if: github.event_name == 'push'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          ver="${GITHUB_REF_NAME#v}"
+          mkdir -p dist stage
+          cp c stage/mach
+          cp LICENSE stage/
+          tar -C stage -czf "dist/mach-$ver-$TARGET.tar.gz" mach LICENSE
+
+      - name: upload archive
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target }}
+          path: dist/mach-*-${{ matrix.target }}.tar.gz
+          if-no-files-found: error
+          retention-days: 1

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -113,11 +113,7 @@ val MH_PIE: u32 = 0x200000;
 
 # SG_READ_ONLY (a segment flag) marks a segment dyld maps writable, applies its
 # fixups to, then re-protects read-only - how __DATA_CONST holds rebased const
-# pointers in a PIE image without staying writable at run time.
-#
-# An image carries at most one such segment: the darwin kernel refuses to exec one
-# that marks two, killing the process with SIGKILL before dyld runs (#2172). The
-# flag therefore marks exactly the read-only segment the rebase stream writes into.
+# pointers in a PIE image without staying writable at run time
 val SG_READ_ONLY: u32 = 0x10;
 
 # VM protection bits used for segment maxprot/initprot
@@ -1398,20 +1394,15 @@ fun vm_prot_for(flags: u32) u32 {
     ret p;
 }
 
-# the Mach-O segment name for a loadable segment: executable maps to __TEXT,
-# writable to __DATA, and read-only splits by whether the loader rebases it -
-# __DATA_CONST is dyld's rebased-then-read-only segment, so only the segment the
-# rebase stream writes into may claim that name; read-only content with no pointer
-# to slide is plain __RODATA and stays read-only for the process's whole life
+# the Mach-O segment name for a loadable segment's permissions: executable maps to
+# __TEXT, writable to __DATA, read-only to __DATA_CONST
 # ---
-# flags:   the SEG_FLAG_* permission bits
-# rebased: whether the loader slides in-image pointers within this segment
-# ret:     the segment name
-fun exec_segname(flags: u32, rebased: bool) str {
+# flags: the SEG_FLAG_* permission bits
+# ret:   the segment name
+fun exec_segname(flags: u32) str {
     if ((flags & of.SEG_FLAG_EXECUTE) != 0) { ret "__TEXT"; }
     if ((flags & of.SEG_FLAG_WRITE) != 0)   { ret "__DATA"; }
-    if (rebased)                            { ret "__DATA_CONST"; }
-    ret "__RODATA";
+    ret "__DATA_CONST";
 }
 
 # the CodeDirectory identifier length: the byte length of the null-terminated
@@ -1864,9 +1855,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
         }
         bin.write_u32_le(buf, lc, LC_SEGMENT_64);
         bin.write_u32_le(buf, lc + 4, SEGMENT_CMD_64_SIZE::u32);
-        # a static executable carries no loader-applied rebases, so no segment is
-        # dyld's rebased-then-read-only __DATA_CONST.
-        write_fixed16(buf, lc + 8, exec_segname(segs[li].flags, false));
+        write_fixed16(buf, lc + 8, exec_segname(segs[li].flags));
         bin.write_u64_le(buf, lc + 24, seg_vaddr);
         bin.write_u64_le(buf, lc + 32, seg_vmsize);
         bin.write_u64_le(buf, lc + 40, seg_foff);
@@ -2365,46 +2354,6 @@ fun base_reloc_loc(br: *of.BaseReloc, segs: *of.LoadSegment, text_va: u64, pz: u
     @out_off = (segs[ls].vaddr + br.seg_offset::u64) - seg_vmaddr;
 }
 
-# whether the rebase stream writes into a linker load segment
-#
-# The predicate behind __DATA_CONST and its SG_READ_ONLY: dyld maps such a segment
-# writable, slides the pointers it holds, then re-protects it read-only. A read-only
-# segment the rebase stream never touches needs neither, and must not claim the flag -
-# the kernel rejects an image marking more than one segment SG_READ_ONLY (#2172).
-# ---
-# dyn: the dynamic-link plan carrying the base-relocation set
-# ls:  the linker segment index to test
-# ret: true when at least one base relocation lands in that segment
-fun seg_is_rebased(dyn: *of.DynamicInfo, ls: u32) bool {
-    var i: u32 = 0;
-    for (i < dyn.base_reloc_count) {
-        if (dyn.base_relocs[i].seg_index == ls) { ret true; }
-        i = i + 1;
-    }
-    ret false;
-}
-
-# the number of read-only linker load segments the rebase stream writes into
-#
-# Mach-O models exactly one rebased-then-read-only segment (__DATA_CONST); a second
-# would need a second SG_READ_ONLY, which the darwin kernel refuses to exec. A count
-# above one is a layout the format cannot express, reported as a link error rather
-# than emitted as an image that dies at exec (#2172)
-# ---
-# dyn:       the dynamic-link plan carrying the base-relocation set
-# segs:      the linker's load segments
-# seg_count: number of load segments
-# ret:       how many read-only segments carry at least one base relocation
-fun rebased_ro_seg_count(dyn: *of.DynamicInfo, segs: *of.LoadSegment, seg_count: u32) u32 {
-    var n: u32 = 0;
-    var li: u32 = 0;
-    for (li < seg_count) {
-        if (vm_prot_for(segs[li].flags) == VM_PROT_READ && seg_is_rebased(dyn, li)) { n = n + 1; }
-        li = li + 1;
-    }
-    ret n;
-}
-
 # the byte length of the dyld rebase opcode stream for the image's base relocations
 # ---
 # dyn:     the dynamic-link plan carrying the base-relocation set
@@ -2644,14 +2593,6 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         sort.sort[of.BaseReloc](dyn.base_relocs, dyn.base_reloc_count::usize, base_reloc_cmp);
     }
 
-    # Mach-O expresses exactly one rebased-then-read-only segment (__DATA_CONST); a
-    # second would need a second SG_READ_ONLY, and the darwin kernel refuses to exec an
-    # image marking two. reject that layout here rather than write a file that dies at
-    # exec with no diagnostic (#2172).
-    if (rebased_ro_seg_count(dyn, segs, seg_count) > 1) {
-        ret R.err[bool, str]("macho: more than one read-only segment carries base relocations; Mach-O has a single __DATA_CONST");
-    }
-
     # load-command byte size. the segment count is __PAGEZERO + the linker segments
     # + (stubs, got when there are function imports) + __LINKEDIT.
     var seg_cmds: u32 = seg_count + 1;              # linker segments + __LINKEDIT
@@ -2848,25 +2789,22 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     li = 1;
     for (li < seg_count) {
         var prot: u32 = vm_prot_for(segs[li].flags);
-        # the loader rebases the absolute pointers a segment holds, so a read-only
-        # segment carrying any maps read-write for dyld's fixups and is re-protected
+        # a PIE image rebases the absolute pointers in read-only const data, so that
+        # segment (__DATA_CONST) maps read-write for dyld's fixups and is re-protected
         # read-only afterward via SG_READ_ONLY; without it dyld cannot slide the slots.
-        # a read-only segment with no pointer to slide keeps neither, since a second
-        # SG_READ_ONLY makes the darwin kernel refuse the image (#2172).
-        val rebased: bool = seg_is_rebased(dyn, li);
         var seg_flags: u32 = 0;
-        if (rebased && prot == VM_PROT_READ) {
+        if (pie && prot == VM_PROT_READ) {
             prot = VM_PROT_READ | VM_PROT_WRITE;
             seg_flags = SG_READ_ONLY;
         }
         val zf:   bool = segs[li].filesz == 0 && segs[li].memsz > 0;
-        var lsec: usize = write_segment_cmd(buf, lc, exec_segname(segs[li].flags, rebased), segs[li].vaddr,
+        var lsec: usize = write_segment_cmd(buf, lc, exec_segname(segs[li].flags), segs[li].vaddr,
                                bin.align_up_u64(segs[li].memsz::u64, exec_page),
                                seg_offsets[li]::u64, segs[li].filesz::u64, prot, prot, 1);
         if (seg_flags != 0) { bin.write_u32_le(buf, lc + 68, seg_flags); }
         var soff: u32 = seg_offsets[li]::u32;
         if (zf) { soff = 0; }
-        write_section_64(buf, lsec, dyn_sectname(segs[li].flags, zf), exec_segname(segs[li].flags, rebased),
+        write_section_64(buf, lsec, dyn_sectname(segs[li].flags, zf), exec_segname(segs[li].flags),
                          segs[li].vaddr, segs[li].memsz::u64, soff, dyn_sect_flags(segs[li].flags, zf));
         lc = lsec + SECTION_64_SIZE;
         li = li + 1;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -4254,141 +4254,6 @@ fun ts_dyn_exec(arch_id: u32) u8 {
     ret 0;
 }
 
-# locate the file offset of the LC_SEGMENT_64 named `name`; returns 0 when absent
-# ---
-# buf:  the Mach-O bytes
-# name: the segment name to match
-# ret:  the load command's file offset, or 0 if not present
-fun t_find_seg(buf: *u8, name: str) usize {
-    val ncmds: u32 = bin.read_u32_le(buf, 16);
-    var off: usize = MACH_HEADER_64_SIZE;
-    var c: u32 = 0;
-    for (c < ncmds) {
-        if (bin.read_u32_le(buf, off) == LC_SEGMENT_64 && fixed16_equals(buf, off + 8, name)) { ret off; }
-        off = off + bin.read_u32_le(buf, off + 4)::usize;
-        c = c + 1;
-    }
-    ret 0;
-}
-
-# count the LC_SEGMENT_64s flagged SG_READ_ONLY
-# ---
-# buf: the Mach-O bytes
-# ret: how many segments carry the flag
-fun t_count_sg_read_only(buf: *u8) u32 {
-    val ncmds: u32 = bin.read_u32_le(buf, 16);
-    var off: usize = MACH_HEADER_64_SIZE;
-    var n:   u32 = 0;
-    var c:   u32 = 0;
-    for (c < ncmds) {
-        if (bin.read_u32_le(buf, off) == LC_SEGMENT_64
-            && (bin.read_u32_le(buf, off + 68) & SG_READ_ONLY) != 0) { n = n + 1; }
-        off = off + bin.read_u32_le(buf, off + 4)::usize;
-        c = c + 1;
-    }
-    ret n;
-}
-
-# a PIE image whose link carries two read-only segments - plain rodata and the
-# rebased rel.ro - marks exactly one of them SG_READ_ONLY: the one the rebase stream
-# writes into, which is the only segment that may be named __DATA_CONST. The other
-# stays r-- under __RODATA and is never mapped writable.
-#
-# Falsifies the permission-derived rule that flagged every read-only segment: that
-# emitted two SG_READ_ONLY segments, which the darwin kernel refuses to exec,
-# SIGKILLing the image before dyld runs (#2172). Also pins the rejection of a layout
-# with base relocations in two read-only segments, which Mach-O cannot express
-fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
-    var alloc: A.Allocator;
-    page.make(?alloc);
-    var itn: intern.Interner = intern.init(?alloc);
-
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = arch_id;
-
-    var text_bytes: [16]u8;
-    var ro_bytes:   [16]u8;
-    var relro_bytes: [16]u8;
-    var data_bytes: [16]u8;
-    var k: usize = 0;
-    for (k < 16) {
-        text_bytes[k] = 0; ro_bytes[k] = 0; relro_bytes[k] = 0; data_bytes[k] = 0;
-        k = k + 1;
-    }
-
-    # text, rodata, rel.ro, data - each on its own 16 KiB page, mirroring the linker's
-    # per-kind segment layout.
-    val base: u64 = 0x100000000;
-    val pg:   u64 = 0x4000;
-    var segs: [4]of.LoadSegment;
-    segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
-    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
-    segs[1].vaddr = base + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
-    segs[1].flags = of.SEG_FLAG_READ; segs[1].bytes = ?ro_bytes[0];
-    segs[2].vaddr = base + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
-    segs[2].flags = of.SEG_FLAG_READ; segs[2].bytes = ?relro_bytes[0];
-    segs[3].vaddr = base + pg * 3; segs[3].filesz = 16; segs[3].memsz = 16;
-    segs[3].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE; segs[3].bytes = ?data_bytes[0];
-
-    # one absolute pointer to slide, in the rel.ro segment only.
-    var brs: [2]of.BaseReloc;
-    brs[0].seg_index = 2; brs[0].seg_offset = 0; brs[0].target = base;
-    brs[1].seg_index = 1; brs[1].seg_offset = 0; brs[1].target = base;
-
-    var dyn: of.DynamicInfo;
-    dyn.interp = intern.STR_NIL;
-    dyn.base_relocs = ?brs[0];
-    dyn.base_reloc_count = 1;
-    dyn.pie = true;
-
-    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_relro_seg");
-    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
-    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
-    val tpath: str = fs.temp_path(?tf);
-
-    val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 4, pg, base,
-                                                nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
-                                                nil::*of.Section, 0, tpath::*u8, "machorelro"::*u8);
-    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
-
-    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
-    fs.temp_close_and_remove(?tf);
-    if (R.is_err[Vector[u8], str](rb)) { ret 1; }
-    val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
-
-    # exactly one segment claims the flag, and it is the rebased one: __DATA_CONST,
-    # mapped read-write for dyld's fixup pass.
-    if (t_count_sg_read_only(buf.data) != 1)                     { ret 1; }
-    val dc: usize = t_find_seg(buf.data, "__DATA_CONST");
-    if (dc == 0)                                                 { ret 1; }
-    if (bin.read_u64_le(buf.data, dc + 24) != base + pg * 2)     { ret 1; }
-    if ((bin.read_u32_le(buf.data, dc + 68) & SG_READ_ONLY) == 0) { ret 1; }
-    if (bin.read_u32_le(buf.data, dc + 60) != (VM_PROT_READ | VM_PROT_WRITE)) { ret 1; }
-
-    # the un-rebased read-only segment is plain __RODATA: read-only for the process's
-    # whole life, never writable, never flagged.
-    val rd: usize = t_find_seg(buf.data, "__RODATA");
-    if (rd == 0)                                                 { ret 1; }
-    if (bin.read_u64_le(buf.data, rd + 24) != base + pg)         { ret 1; }
-    if (bin.read_u32_le(buf.data, rd + 60) != VM_PROT_READ)      { ret 1; }
-    if (bin.read_u32_le(buf.data, rd + 56) != VM_PROT_READ)      { ret 1; }
-    if ((bin.read_u32_le(buf.data, rd + 68) & SG_READ_ONLY) != 0) { ret 1; }
-
-    # base relocations in two read-only segments have no single __DATA_CONST to live
-    # in, so the write is refused instead of producing an image that dies at exec.
-    dyn.base_reloc_count = 2;
-    val tf2_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_relro_seg2");
-    if (R.is_err[fs.TempFile, str](tf2_r)) { ret 1; }
-    var tf2: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf2_r);
-    val em2: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 4, pg, base,
-                                                 nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
-                                                 nil::*of.Section, 0, fs.temp_path(?tf2)::*u8, "machorelro"::*u8);
-    fs.temp_close_and_remove(?tf2);
-    if (!R.is_err[bool, str](em2))                                              { ret 1; }
-    if (!str_contains(R.unwrap_err[bool, str](em2), "read-only segment"))        { ret 1; }
-    ret 0;
-}
-
 # emit_object rejects a relocation whose abstract kind has no Mach-O machine type
 # rather than silently emitting a wrong relocation
 fun ts_unsupported_kind() u8 {
@@ -4489,13 +4354,10 @@ test "mach.lang.target.of.macho:exec_vtable_and_rejections" {
 
 # the dynamic-executable writer: the x86_64 and arm64 dyld-loadable skeletons
 # (loader + dependency load commands, the bind stream, the symbol tables, and the
-# thread entry), and the single-SG_READ_ONLY segment contract a PIE image with both
-# a rodata and a rel.ro segment must satisfy
+# thread entry)
 test "mach.lang.target.of.macho:dyn_exec" {
     if (ts_dyn_exec(isa.ARCH_X86_64) != 0)  { ret 1; }
     if (ts_dyn_exec(isa.ARCH_AARCH64) != 0) { ret 1; }
-    if (ts_dyn_exec_relro_segments(isa.ARCH_X86_64) != 0)  { ret 1; }
-    if (ts_dyn_exec_relro_segments(isa.ARCH_AARCH64) != 0) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -43,7 +43,6 @@ use std.types.string.str_contains;
 use std.types.string.str_len;
 
 use std.crypto.hash.sha256;
-use std.format;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -488,22 +487,19 @@ fun macho_section_flags(kind: of.SectionKind) u32 {
 }
 
 # recover an abstract section kind from a parsed section's flags and segment name.
-# a __DATA_CONST section is RELRO; a __TEXT or __RODATA non-instruction section is
-# plain rodata; so the emit -> parse round-trip preserves the RELRO/RODATA
-# distinction for both the object writer's naming (__TEXT,__const) and the
-# executable writer's (__RODATA,__const)
+# a __DATA_CONST section is RELRO; a __TEXT non-instruction section is plain
+# rodata; so the emit -> parse round-trip preserves the RELRO/RODATA distinction
 # ---
 # flags:         the section flags word
 # is_text:       whether the enclosing segment name is "__TEXT" (rodata over data)
 # is_data_const: whether the enclosing segment name is "__DATA_CONST" (RELRO)
-# is_rodata:     whether the enclosing segment name is "__RODATA" (rodata over data)
 # ret:           the abstract section kind
-fun macho_kind_from(flags: u32, is_text: bool, is_data_const: bool, is_rodata: bool) of.SectionKind {
+fun macho_kind_from(flags: u32, is_text: bool, is_data_const: bool) of.SectionKind {
     if ((flags & 0xFF) == S_ZEROFILL)            { ret of.SK_BSS; }
     if ((flags & S_ATTR_PURE_INSTRUCTIONS) != 0) { ret of.SK_TEXT; }
     if ((flags & S_ATTR_DEBUG) != 0)             { ret of.SK_DEBUG; }
     if (is_data_const)                           { ret of.SK_RELRO; }
-    if (is_text || is_rodata)                    { ret of.SK_RODATA; }
+    if (is_text)                                 { ret of.SK_RODATA; }
     ret of.SK_DATA;
 }
 
@@ -1727,15 +1723,10 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     # base is non-zero (darwin executables always carry one). its exact span depends
     # on hdr_span, computed once the load-command size is known below.
     var has_pagezero: bool = seg_count > 0 && segs[0].vaddr > 0;
-    # a static image has no loader-applied rebases, so no segment is dyld's
-    # rebased-then-read-only __DATA_CONST and the load segments collapse purely by
-    # protection: the linker's rodata and rel.ro segments are one read-only Mach-O
-    # segment, not two commands sharing a name.
-    val grp_count: u32 = seg_group_count(nil::*of.DynamicInfo, segs, seg_count);
-    # the Mach-O segments, a trailing __LINKEDIT (carrying the code signature),
+    # the linker segments, a trailing __LINKEDIT (carrying the code signature),
     # LC_UNIXTHREAD, LC_CODE_SIGNATURE, __PAGEZERO when the base is non-zero, and the
     # __DWARF segment when debug sections are present.
-    var ncmds: u32 = grp_count + 3;
+    var ncmds: u32 = seg_count + 3;
     if (has_pagezero) { ncmds = ncmds + 1; }
     if (have_dwarf)   { ncmds = ncmds + 1; }
 
@@ -1743,7 +1734,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     if (arch_is_arm64(arch_id)) { thread_state = ARM_THREAD_STATE64_COUNT::usize * 4; }
     val thread_cmd_size: usize = 16 + thread_state;
 
-    var sizeofcmds: usize = grp_count::usize * SEGMENT_CMD_64_SIZE + thread_cmd_size
+    var sizeofcmds: usize = seg_count::usize * SEGMENT_CMD_64_SIZE + thread_cmd_size
                           + SEGMENT_CMD_64_SIZE + LINKEDIT_DATA_CMD_SIZE;   # __LINKEDIT + LC_CODE_SIGNATURE
     if (has_pagezero) { sizeofcmds = sizeofcmds + SEGMENT_CMD_64_SIZE; }
     sizeofcmds = sizeofcmds + macho_dwarf_cmd_bytes(debug_count);
@@ -1857,23 +1848,14 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
 
     li = 0;
     for (li < seg_count) {
+        val prot: u32 = vm_prot_for(segs[li].flags);
         # the first segment is __TEXT: it maps the mach header + load commands ahead
         # of the linker's text (fileoff 0, vmaddr text_va), so the signed header lies
-        # inside the mapped executable segment, and it shares no command. the rest are
-        # emitted one command per run of identically-mapped segments, so a segment name
-        # is never written twice.
-        val last: u32 = seg_group_last(nil::*of.DynamicInfo, segs, seg_count, li);
-        val prot: u32 = vm_prot_for(segs[li].flags);
+        # inside the mapped executable segment. the rest map at their own offsets.
         var seg_vaddr:  u64 = segs[li].vaddr;
-        var seg_vmsize: u64 = bin.align_up_u64(segs[last].vaddr + segs[last].memsz::u64 - segs[li].vaddr,
-                                               EXEC_PAGE_SIZE);
+        var seg_vmsize: u64 = bin.align_up_u64(segs[li].memsz::u64, EXEC_PAGE_SIZE);
         var seg_foff:   u64 = seg_offsets[li]::u64;
-        var seg_fsz:    u64 = 0;
-        var m: u32 = li;
-        for (m <= last) {
-            if (segs[m].filesz > 0) { seg_fsz = (seg_offsets[m] + segs[m].filesz - seg_offsets[li])::u64; }
-            m = m + 1;
-        }
+        var seg_fsz:    u64 = segs[li].filesz::u64;
         if (li == 0) {
             seg_vaddr  = text_va;
             seg_vmsize = bin.align_up_u64(hdr_span::u64 + segs[0].memsz::u64, EXEC_PAGE_SIZE);
@@ -1895,14 +1877,10 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
         bin.write_u32_le(buf, lc + 68, 0);
         lc = lc + SEGMENT_CMD_64_SIZE;
 
-        m = li;
-        for (m <= last) {
-            if (segs[m].bytes != nil && segs[m].filesz > 0) {
-                memory.raw_copy((buf::usize + seg_offsets[m])::ptr, segs[m].bytes::ptr, segs[m].filesz);
-            }
-            m = m + 1;
+        if (segs[li].bytes != nil && segs[li].filesz > 0) {
+            memory.raw_copy((buf::usize + seg_offsets[li])::ptr, segs[li].bytes::ptr, segs[li].filesz);
         }
-        li = last + 1;
+        li = li + 1;
     }
 
     # the non-mapped __DWARF segment (debug sections) between the linker segments and
@@ -2368,35 +2346,36 @@ fun base_reloc_cmp(a: *of.BaseReloc, b: *of.BaseReloc) i64 {
 #
 # Resolves the Mach-O segment index (the load-command ordering, __PAGEZERO included)
 # and the slot's byte offset from that segment's virtual address - the two operands a
-# `REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB` needs. Load segments that share a Mach-O
-# segment share its index, so the offset is measured from the shared command's vaddr,
-# not the member's. The linker's first segment maps as __TEXT, whose vaddr is
-# `text_va` (the header sits below the linker text), so its offsets start there
+# `REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB` needs. The linker's first segment maps
+# as __TEXT, whose vaddr is `text_va` (the header sits below the linker text), so its
+# offsets are measured from there; every other segment maps at its assigned vaddr.
 # ---
-# dyn:     the dynamic-link plan, resolving which segments share a Mach-O segment
 # br:      the base relocation to locate
 # segs:    the linker's load segments
 # text_va: the __TEXT virtual address (the linker's first segment maps above it)
 # pz:      1 when a __PAGEZERO precedes the linker segments, else 0
 # out_seg: receives the Mach-O segment index
 # out_off: receives the slot's byte offset from that segment's virtual address
-fun base_reloc_loc(dyn: *of.DynamicInfo, br: *of.BaseReloc, segs: *of.LoadSegment, text_va: u64, pz: u32,
+fun base_reloc_loc(br: *of.BaseReloc, segs: *of.LoadSegment, text_va: u64, pz: u32,
                    out_seg: *u32, out_off: *u64) {
-    val ls:    u32 = br.seg_index;
-    val first: u32 = seg_group_first(dyn, segs, ls);
-    @out_seg = pz + seg_group_of(dyn, segs, ls);
-    var seg_vmaddr: u64 = segs[first].vaddr;
-    if (first == 0) { seg_vmaddr = text_va; }
+    val ls: u32 = br.seg_index;
+    @out_seg = pz + ls;
+    var seg_vmaddr: u64 = segs[ls].vaddr;
+    if (ls == 0) { seg_vmaddr = text_va; }
     @out_off = (segs[ls].vaddr + br.seg_offset::u64) - seg_vmaddr;
 }
 
 # whether the rebase stream writes into a linker load segment
+#
+# The predicate behind __DATA_CONST and its SG_READ_ONLY: dyld maps such a segment
+# writable, slides the pointers it holds, then re-protects it read-only. A read-only
+# segment the rebase stream never touches needs neither, and must not claim the flag -
+# the kernel rejects an image marking more than one segment SG_READ_ONLY (#2172).
 # ---
-# dyn: the dynamic-link plan carrying the base-relocation set (nil for a static link)
+# dyn: the dynamic-link plan carrying the base-relocation set
 # ls:  the linker segment index to test
 # ret: true when at least one base relocation lands in that segment
 fun seg_is_rebased(dyn: *of.DynamicInfo, ls: u32) bool {
-    if (dyn == nil) { ret false; }
     var i: u32 = 0;
     for (i < dyn.base_reloc_count) {
         if (dyn.base_relocs[i].seg_index == ls) { ret true; }
@@ -2405,179 +2384,25 @@ fun seg_is_rebased(dyn: *of.DynamicInfo, ls: u32) bool {
     ret false;
 }
 
-# whether a linker load segment maps as dyld's __DATA_CONST: a read-only segment the
-# rebase stream writes into
+# the number of read-only linker load segments the rebase stream writes into
 #
-# The predicate behind the segment's name, its mapped protection, and SG_READ_ONLY.
-# dyld maps such a segment read-write, slides the pointers it holds, then re-protects
-# it read-only. Read-only content with no pointer to slide needs none of that, and
-# must not claim the flag - the kernel rejects an image marking more than one segment
-# SG_READ_ONLY (#2172). A writable segment is already writable for the fixup pass, so
-# it is never __DATA_CONST however many pointers it holds
-# ---
-# dyn:  the dynamic-link plan carrying the base-relocation set (nil for a static link)
-# segs: the linker's load segments
-# ls:   the linker segment index to classify
-# ret:  true when the segment maps as __DATA_CONST
-fun seg_is_data_const(dyn: *of.DynamicInfo, segs: *of.LoadSegment, ls: u32) bool {
-    if (vm_prot_for(segs[ls].flags) != VM_PROT_READ) { ret false; }
-    ret seg_is_rebased(dyn, ls);
-}
-
-# the protection a linker load segment maps with: read-write for __DATA_CONST, so
-# dyld can apply its fixups before re-protecting it, else the segment's own
-# permissions. maxprot matches initprot, so a read-only segment stays unwritable for
-# the process's whole life - deliberate, since nothing in the image may remap
-# constants and the loader has no slot there to slide
-# ---
-# dyn:  the dynamic-link plan (nil for a static link)
-# segs: the linker's load segments
-# ls:   the linker segment index
-# ret:  the VM_PROT_* bits to map the segment with
-fun seg_vm_prot(dyn: *of.DynamicInfo, segs: *of.LoadSegment, ls: u32) u32 {
-    if (seg_is_data_const(dyn, segs, ls)) { ret VM_PROT_READ | VM_PROT_WRITE; }
-    ret vm_prot_for(segs[ls].flags);
-}
-
-# whether two linker load segments map onto the same Mach-O segment: same name, same
-# protection, same flags, so emitting both would name one segment twice
-# ---
-# dyn:  the dynamic-link plan (nil for a static link)
-# segs: the linker's load segments
-# a:    the first linker segment index
-# b:    the second linker segment index
-# ret:  true when the two share a Mach-O segment
-fun seg_same_macho_segment(dyn: *of.DynamicInfo, segs: *of.LoadSegment, a: u32, b: u32) bool {
-    if (vm_prot_for(segs[a].flags) != vm_prot_for(segs[b].flags)) { ret false; }
-    ret seg_is_data_const(dyn, segs, a) == seg_is_data_const(dyn, segs, b);
-}
-
-# the Mach-O segment index (counting from the linker's first segment) a linker load
-# segment lands in
-#
-# Segment 0 always stands alone: it is the one that maps the mach header below the
-# linker's bytes, so it can share no command with its neighbour. Every later run of
-# load segments that map onto the same Mach-O segment collapses into one
-# ---
-# dyn:  the dynamic-link plan (nil for a static link)
-# segs: the linker's load segments
-# ls:   the linker segment index
-# ret:  the 0-based Mach-O segment index among the linker's segments
-fun seg_group_of(dyn: *of.DynamicInfo, segs: *of.LoadSegment, ls: u32) u32 {
-    var g: u32 = 0;
-    var i: u32 = 1;
-    for (i <= ls) {
-        if (i == 1 || !seg_same_macho_segment(dyn, segs, i, i - 1)) { g = g + 1; }
-        i = i + 1;
-    }
-    ret g;
-}
-
-# the first linker load segment of the Mach-O segment `ls` lands in - the one whose
-# vaddr and file offset the shared load command carries
-# ---
-# dyn:  the dynamic-link plan (nil for a static link)
-# segs: the linker's load segments
-# ls:   the linker segment index
-# ret:  the first linker segment index of that Mach-O segment
-fun seg_group_first(dyn: *of.DynamicInfo, segs: *of.LoadSegment, ls: u32) u32 {
-    if (ls == 0) { ret 0; }
-    var f: u32 = ls;
-    for (f > 1 && seg_same_macho_segment(dyn, segs, f, f - 1)) { f = f - 1; }
-    ret f;
-}
-
-# the last linker load segment of the Mach-O segment starting at `first`
-# ---
-# dyn:       the dynamic-link plan (nil for a static link)
-# segs:      the linker's load segments
-# seg_count: number of load segments
-# first:     the first linker segment index of the Mach-O segment
-# ret:       the last linker segment index of that Mach-O segment
-fun seg_group_last(dyn: *of.DynamicInfo, segs: *of.LoadSegment, seg_count: u32, first: u32) u32 {
-    if (first == 0) { ret 0; }
-    var l: u32 = first;
-    for (l + 1 < seg_count && seg_same_macho_segment(dyn, segs, l + 1, l)) { l = l + 1; }
-    ret l;
-}
-
-# the number of Mach-O segments the linker's load segments collapse into
-# ---
-# dyn:       the dynamic-link plan (nil for a static link)
-# segs:      the linker's load segments
-# seg_count: number of load segments
-# ret:       the Mach-O segment count (0 when there are no load segments)
-fun seg_group_count(dyn: *of.DynamicInfo, segs: *of.LoadSegment, seg_count: u32) u32 {
-    if (seg_count == 0) { ret 0; }
-    ret seg_group_of(dyn, segs, seg_count - 1) + 1;
-}
-
-# the number of Mach-O segments flagged SG_READ_ONLY
-#
-# Mach-O maps exactly one rebased-then-read-only segment (__DATA_CONST); an image
-# marking two is refused by the darwin kernel, which SIGKILLs it before dyld runs.
-# Adjacent read-only segments the rebase stream writes into already collapse into one
-# command, so a count above one means the linker interleaved a differently-mapped
-# segment between two rebased read-only ones - a layout with no single __DATA_CONST
-# to express it (#2172)
+# Mach-O models exactly one rebased-then-read-only segment (__DATA_CONST); a second
+# would need a second SG_READ_ONLY, which the darwin kernel refuses to exec. A count
+# above one is a layout the format cannot express, reported as a link error rather
+# than emitted as an image that dies at exec (#2172)
 # ---
 # dyn:       the dynamic-link plan carrying the base-relocation set
 # segs:      the linker's load segments
 # seg_count: number of load segments
-# ret:       how many Mach-O segments carry SG_READ_ONLY
-fun data_const_seg_count(dyn: *of.DynamicInfo, segs: *of.LoadSegment, seg_count: u32) u32 {
+# ret:       how many read-only segments carry at least one base relocation
+fun rebased_ro_seg_count(dyn: *of.DynamicInfo, segs: *of.LoadSegment, seg_count: u32) u32 {
     var n: u32 = 0;
     var li: u32 = 0;
     for (li < seg_count) {
-        if (seg_is_data_const(dyn, segs, li) && seg_group_first(dyn, segs, li) == li) { n = n + 1; }
+        if (vm_prot_for(segs[li].flags) == VM_PROT_READ && seg_is_rebased(dyn, li)) { n = n + 1; }
         li = li + 1;
     }
     ret n;
-}
-
-# the diagnostic for an image needing two __DATA_CONST segments, naming both
-# offending load segments (index + virtual address) and one relocation inside the
-# second, so the report points at the layout that cannot be written rather than at
-# the flag that cannot be set twice
-# ---
-# itn:       interner the diagnostic is interned through (nil -> generic)
-# alloc:     allocator for the scratch buffer
-# dyn:       the dynamic-link plan carrying the base-relocation set
-# segs:      the linker's load segments
-# seg_count: number of load segments
-# ret:       the interned diagnostic, or the generic form
-fun data_const_conflict_message(itn: *intern.Interner, alloc: *A.Allocator, dyn: *of.DynamicInfo,
-                                segs: *of.LoadSegment, seg_count: u32) str {
-    val generic: str = "macho: two separated read-only segments carry base relocations; Mach-O maps a single __DATA_CONST";
-    if (itn == nil) { ret generic; }
-
-    var first:  u32 = 0xFFFFFFFF;
-    var second: u32 = 0xFFFFFFFF;
-    var li: u32 = 0;
-    for (li < seg_count) {
-        if (seg_is_data_const(dyn, segs, li) && seg_group_first(dyn, segs, li) == li) {
-            if (first == 0xFFFFFFFF) { first = li; }
-            or { if (second == 0xFFFFFFFF) { second = li; } }
-        }
-        li = li + 1;
-    }
-    if (second == 0xFFFFFFFF) { ret generic; }
-
-    var slot: u64 = 0;
-    var i: u32 = 0;
-    for (i < dyn.base_reloc_count) {
-        if (dyn.base_relocs[i].seg_index == second) { slot = dyn.base_relocs[i].seg_offset::u64; brk; }
-        i = i + 1;
-    }
-
-    val res: R.Result[str, str] = format.sprint(alloc,
-        "macho: read-only load segments {} (vaddr {}) and {} (vaddr {}, e.g. the pointer at +{}) both need base relocations, but Mach-O maps a single read-only __DATA_CONST and they are not adjacent",
-        first::u64, segs[first].vaddr, second::u64, segs[second].vaddr, slot);
-    if (R.is_err[str, str](res)) { ret generic; }
-    val buf: str = R.unwrap_ok[str, str](res);
-    val msg: str = bin.name_message(itn, alloc, "", buf, generic);
-    A.deallocate[u8](alloc, buf::*u8, str_len(buf) + 1);
-    ret msg;
 }
 
 # the byte length of the dyld rebase opcode stream for the image's base relocations
@@ -2594,7 +2419,7 @@ fun measure_rebase_info(dyn: *of.DynamicInfo, segs: *of.LoadSegment, text_va: u6
     for (i < dyn.base_reloc_count) {
         var seg: u32 = 0;
         var off: u64 = 0;
-        base_reloc_loc(dyn, ?dyn.base_relocs[i], segs, text_va, pz, ?seg, ?off);
+        base_reloc_loc(?dyn.base_relocs[i], segs, text_va, pz, ?seg, ?off);
         size = size + 1 + uleb_size(off) + 1;             # SET_SEGMENT_AND_OFFSET + DO_REBASE_IMM_TIMES
         i = i + 1;
     }
@@ -2626,7 +2451,7 @@ fun write_rebase_info(buf: *u8, off: usize, dyn: *of.DynamicInfo, segs: *of.Load
     for (i < dyn.base_reloc_count) {
         var seg: u32 = 0;
         var slot: u64 = 0;
-        base_reloc_loc(dyn, ?dyn.base_relocs[i], segs, text_va, pz, ?seg, ?slot);
+        base_reloc_loc(?dyn.base_relocs[i], segs, text_va, pz, ?seg, ?slot);
         buf[p] = REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | (seg::u8 & 0xF);
         p = write_uleb(buf, p + 1, slot);
         buf[p] = REBASE_OPCODE_DO_REBASE_IMM_TIMES | 1;
@@ -2819,21 +2644,17 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         sort.sort[of.BaseReloc](dyn.base_relocs, dyn.base_reloc_count::usize, base_reloc_cmp);
     }
 
-    # Mach-O maps exactly one rebased-then-read-only segment (__DATA_CONST), and the
-    # darwin kernel refuses to exec an image marking two SG_READ_ONLY. Adjacent
-    # rebased read-only load segments already share one command; two that the linker
-    # separated by a differently-mapped segment have no single command to share, so
-    # the layout is refused here rather than written as a file that dies at exec with
-    # no diagnostic (#2172).
-    if (data_const_seg_count(dyn, segs, seg_count) > 1) {
-        ret R.err[bool, str](data_const_conflict_message(itn, alloc, dyn, segs, seg_count));
+    # Mach-O expresses exactly one rebased-then-read-only segment (__DATA_CONST); a
+    # second would need a second SG_READ_ONLY, and the darwin kernel refuses to exec an
+    # image marking two. reject that layout here rather than write a file that dies at
+    # exec with no diagnostic (#2172).
+    if (rebased_ro_seg_count(dyn, segs, seg_count) > 1) {
+        ret R.err[bool, str]("macho: more than one read-only segment carries base relocations; Mach-O has a single __DATA_CONST");
     }
 
-    # load-command byte size. the segment count is __PAGEZERO + the Mach-O segments
-    # the linker's load segments collapse into + (stubs, got when there are function
-    # imports) + __LINKEDIT.
-    val grp_count: u32 = seg_group_count(dyn, segs, seg_count);
-    var seg_cmds: u32 = grp_count + 1;              # Mach-O segments + __LINKEDIT
+    # load-command byte size. the segment count is __PAGEZERO + the linker segments
+    # + (stubs, got when there are function imports) + __LINKEDIT.
+    var seg_cmds: u32 = seg_count + 1;              # linker segments + __LINKEDIT
     if (segs[0].vaddr > 0) { seg_cmds = seg_cmds + 1; }   # __PAGEZERO
     if (nimp > 0)          { seg_cmds = seg_cmds + 2; }   # __STUBS + __DATA(got)
 
@@ -2940,7 +2761,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         file = file + lay.got_size;
         va   = bin.align_up_u64(va + lay.got_size::u64, exec_page);
 
-        lay.got_seg_index = pz + grp_count + 1;   # pagezero + Mach-O segments + stubs
+        lay.got_seg_index = pz + seg_count + 1;   # pagezero + linker segs + stubs
     }
 
     # the non-mapped __DWARF segment's byte region, below __LINKEDIT (and thus below
@@ -3014,60 +2835,41 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         lc = write_segment_cmd(buf, lc, "__PAGEZERO", 0, lay.pagezero_size, 0, 0, 0, 0, 0);
     }
 
-    # __TEXT maps the mach header below the linker's first segment (its section starts
-    # at that segment's address, after the header). It stands alone for that reason -
-    # no other load segment can share a command that begins at file offset 0 - and
-    # goes through the same protection and flag rules as the rest, so a read-only,
-    # rebased first segment is flagged exactly like any other.
-    val text_prot: u32 = seg_vm_prot(dyn, segs, 0);
+    # __TEXT maps the mach header below the linker's text segment (its __text
+    # section starts at the linker's text address, after the header), then the rest
+    # of the linker's segments at their assigned addresses, each with one section.
+    val text_prot: u32 = vm_prot_for(segs[0].flags);
     var tsec: usize = write_segment_cmd(buf, lc, "__TEXT", lay.text_va,
                            bin.align_up_u64(lay.hdr_span::u64 + segs[0].memsz::u64, exec_page),
                            0, lay.hdr_span::u64 + segs[0].filesz::u64, text_prot, text_prot, 1);
-    if (seg_is_data_const(dyn, segs, 0)) { bin.write_u32_le(buf, lc + 68, SG_READ_ONLY); }
     write_section_64(buf, tsec, dyn_sectname(segs[0].flags, false), "__TEXT", segs[0].vaddr,
                      segs[0].memsz::u64, seg_offsets[0]::u32, dyn_sect_flags(segs[0].flags, false));
     lc = tsec + SECTION_64_SIZE;
-
-    # the remaining load segments, one Mach-O segment per run that maps identically:
-    # a run shares one command carrying one section per member, so a segment name is
-    # written once and every by-name lookup (otool, lldb, dsymutil) is unambiguous.
     li = 1;
     for (li < seg_count) {
-        val last: u32 = seg_group_last(dyn, segs, seg_count, li);
-        # the loader rebases the absolute pointers a read-only segment holds, so
-        # __DATA_CONST maps read-write for dyld's fixups and is re-protected read-only
-        # afterward via SG_READ_ONLY; without it dyld cannot slide the slots. read-only
-        # content with no pointer to slide keeps neither, since a second SG_READ_ONLY
-        # makes the darwin kernel refuse the image (#2172).
-        val prot: u32 = seg_vm_prot(dyn, segs, li);
-        val gname: str = exec_segname(segs[li].flags, seg_is_data_const(dyn, segs, li));
-        # the command spans its members: their file bytes are contiguous (each
-        # page-aligned in turn) and their addresses ascend, so the run's file size runs
-        # to the end of its last member holding bytes and its vm size to the last
-        # member's end.
-        var grp_fsz: u64 = 0;
-        var m: u32 = li;
-        for (m <= last) {
-            if (segs[m].filesz > 0) { grp_fsz = (seg_offsets[m] + segs[m].filesz - seg_offsets[li])::u64; }
-            m = m + 1;
+        var prot: u32 = vm_prot_for(segs[li].flags);
+        # the loader rebases the absolute pointers a segment holds, so a read-only
+        # segment carrying any maps read-write for dyld's fixups and is re-protected
+        # read-only afterward via SG_READ_ONLY; without it dyld cannot slide the slots.
+        # a read-only segment with no pointer to slide keeps neither, since a second
+        # SG_READ_ONLY makes the darwin kernel refuse the image (#2172).
+        val rebased: bool = seg_is_rebased(dyn, li);
+        var seg_flags: u32 = 0;
+        if (rebased && prot == VM_PROT_READ) {
+            prot = VM_PROT_READ | VM_PROT_WRITE;
+            seg_flags = SG_READ_ONLY;
         }
-        val grp_vmsz: u64 = bin.align_up_u64(segs[last].vaddr + segs[last].memsz::u64 - segs[li].vaddr, exec_page);
-
-        var lsec: usize = write_segment_cmd(buf, lc, gname, segs[li].vaddr, grp_vmsz,
-                               seg_offsets[li]::u64, grp_fsz, prot, prot, last - li + 1);
-        if (seg_is_data_const(dyn, segs, li)) { bin.write_u32_le(buf, lc + 68, SG_READ_ONLY); }
-        m = li;
-        for (m <= last) {
-            val zf: bool = segs[m].filesz == 0 && segs[m].memsz > 0;
-            var soff: u32 = seg_offsets[m]::u32;
-            if (zf) { soff = 0; }
-            write_section_64(buf, lsec, dyn_sectname(segs[m].flags, zf), gname,
-                             segs[m].vaddr, segs[m].memsz::u64, soff, dyn_sect_flags(segs[m].flags, zf));
-            lsec = lsec + SECTION_64_SIZE;
-            m = m + 1;
-        }
-        lc = lsec;
-        li = last + 1;
+        val zf:   bool = segs[li].filesz == 0 && segs[li].memsz > 0;
+        var lsec: usize = write_segment_cmd(buf, lc, exec_segname(segs[li].flags, rebased), segs[li].vaddr,
+                               bin.align_up_u64(segs[li].memsz::u64, exec_page),
+                               seg_offsets[li]::u64, segs[li].filesz::u64, prot, prot, 1);
+        if (seg_flags != 0) { bin.write_u32_le(buf, lc + 68, seg_flags); }
+        var soff: u32 = seg_offsets[li]::u32;
+        if (zf) { soff = 0; }
+        write_section_64(buf, lsec, dyn_sectname(segs[li].flags, zf), exec_segname(segs[li].flags, rebased),
+                         segs[li].vaddr, segs[li].memsz::u64, soff, dyn_sect_flags(segs[li].flags, zf));
+        lc = lsec + SECTION_64_SIZE;
+        li = li + 1;
     }
 
     # synthesized stub (R+X) and got (R+W) segments, each with one section so the
@@ -3371,8 +3173,7 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
                 val flags:   u32 = bin.read_u32_le(buf, sh + 64);
                 val is_text:       bool = fixed16_equals(buf, sh + 16, "__TEXT");
                 val is_data_const: bool = fixed16_equals(buf, sh + 16, "__DATA_CONST");
-                val is_rodata:     bool = fixed16_equals(buf, sh + 16, "__RODATA");
-                val kind:    of.SectionKind = macho_kind_from(flags, is_text, is_data_const, is_rodata);
+                val kind:    of.SectionKind = macho_kind_from(flags, is_text, is_data_const);
 
                 # intern the section name from the section_64 entry, mapping a Mach-O
                 # "__debug*" name back to the abstract model's ELF-canonical
@@ -4488,174 +4289,15 @@ fun t_count_sg_read_only(buf: *u8) u32 {
     ret n;
 }
 
-# count the LC_SEGMENT_64s carrying `name`; a name written twice rebinds every
-# by-name lookup (otool, lldb, and t_find_seg above) to whichever copy comes first
-# ---
-# buf:  the Mach-O bytes
-# name: the segment name to count
-# ret:  how many segments carry that name
-fun t_count_segs_named(buf: *u8, name: str) u32 {
-    val ncmds: u32 = bin.read_u32_le(buf, 16);
-    var off: usize = MACH_HEADER_64_SIZE;
-    var n:   u32 = 0;
-    var c:   u32 = 0;
-    for (c < ncmds) {
-        if (bin.read_u32_le(buf, off) == LC_SEGMENT_64 && fixed16_equals(buf, off + 8, name)) { n = n + 1; }
-        off = off + bin.read_u32_le(buf, off + 4)::usize;
-        c = c + 1;
-    }
-    ret n;
-}
-
-# the 0-based index of the segment named `name` among the LC_SEGMENT_64s - the index
-# the rebase and bind opcodes select a segment by; 0xFFFFFFFF when absent
-# ---
-# buf:  the Mach-O bytes
-# name: the segment name to locate
-# ret:  the segment's opcode index, or 0xFFFFFFFF
-fun t_seg_ordinal(buf: *u8, name: str) u32 {
-    val ncmds: u32 = bin.read_u32_le(buf, 16);
-    var off: usize = MACH_HEADER_64_SIZE;
-    var n:   u32 = 0;
-    var c:   u32 = 0;
-    for (c < ncmds) {
-        if (bin.read_u32_le(buf, off) == LC_SEGMENT_64) {
-            if (fixed16_equals(buf, off + 8, name)) { ret n; }
-            n = n + 1;
-        }
-        off = off + bin.read_u32_le(buf, off + 4)::usize;
-        c = c + 1;
-    }
-    ret 0xFFFFFFFF;
-}
-
-# whether every section_64 spells its enclosing segment's name in its `segname`
-# field - the field otool, lldb, and dsymutil attribute a section by, so a section
-# naming a segment it does not live in is unattributable
-# ---
-# buf: the Mach-O bytes
-# ret: true when every section agrees with its segment
-fun t_sections_match_segname(buf: *u8) bool {
-    val ncmds: u32 = bin.read_u32_le(buf, 16);
-    var off: usize = MACH_HEADER_64_SIZE;
-    var c:   u32 = 0;
-    for (c < ncmds) {
-        if (bin.read_u32_le(buf, off) == LC_SEGMENT_64) {
-            val nsects: u32 = bin.read_u32_le(buf, off + 64);
-            var sh: usize = off + SEGMENT_CMD_64_SIZE;
-            var k: u32 = 0;
-            for (k < nsects) {
-                var i: usize = 0;
-                for (i < 16) {
-                    if (buf[sh + 16 + i] != buf[off + 8 + i]) { ret false; }
-                    i = i + 1;
-                }
-                sh = sh + SECTION_64_SIZE;
-                k = k + 1;
-            }
-        }
-        off = off + bin.read_u32_le(buf, off + 4)::usize;
-        c = c + 1;
-    }
-    ret true;
-}
-
-# the virtual address of the `nth` rebase, resolved the way dyld resolves it: the
-# selected segment's vmaddr plus the opcode's offset
+# a PIE image whose link carries two read-only segments - plain rodata and the
+# rebased rel.ro - marks exactly one of them SG_READ_ONLY: the one the rebase stream
+# writes into, which is the only segment that may be named __DATA_CONST. The other
+# stays r-- under __RODATA and is never mapped writable.
 #
-# Walks the stream the writer emits (SET_TYPE_IMM, then SET_SEGMENT_AND_OFFSET_ULEB
-# + DO_REBASE_IMM_TIMES per slot, then DONE), so neither a mis-mapped segment index
-# nor an offset measured from the wrong base can hide behind a uleb byte
-# ---
-# buf: the Mach-O bytes
-# nth: the 0-based rebase to resolve
-# ret: the resolved virtual address, or 0 when the stream holds no such rebase
-fun t_rebase_vaddr(buf: *u8, nth: u32) u64 {
-    val info: usize = t_find_lc(buf, LC_DYLD_INFO_ONLY);
-    if (info == 0) { ret 0; }
-    val off:  usize = bin.read_u32_le(buf, info + 8)::usize;
-    val size: usize = bin.read_u32_le(buf, info + 12)::usize;
-    var p: usize = off;
-    var n: u32 = 0;
-    for (p < off + size) {
-        val op:  u8 = buf[p] & 0xF0;
-        val imm: u8 = buf[p] & 0x0F;
-        p = p + 1;
-        if (op == REBASE_OPCODE_DONE) { ret 0; }
-        if (op == REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB) {
-            var slot:  u64 = 0;
-            var shift: u32 = 0;
-            for (p < off + size) {
-                val b: u8 = buf[p];
-                p = p + 1;
-                slot = slot | ((b & 0x7F)::u64 << shift::u64);
-                if ((b & 0x80) == 0) { brk; }
-                shift = shift + 7;
-            }
-            if (n == nth) {
-                # resolve the selected segment's vmaddr, so a group index that does not
-                # name the command carrying the slot is visible here.
-                val ncmds: u32 = bin.read_u32_le(buf, 16);
-                var so: usize = MACH_HEADER_64_SIZE;
-                var si: u32 = 0;
-                var c:  u32 = 0;
-                for (c < ncmds) {
-                    if (bin.read_u32_le(buf, so) == LC_SEGMENT_64) {
-                        if (si == imm::u32) { ret bin.read_u64_le(buf, so + 24) + slot; }
-                        si = si + 1;
-                    }
-                    so = so + bin.read_u32_le(buf, so + 4)::usize;
-                    c = c + 1;
-                }
-                ret 0;
-            }
-            n = n + 1;
-        }
-    }
-    ret 0;
-}
-
-# write a PIE dyn-exec over `segs` and read the bytes back; the caller owns the
-# returned buffer and reads it through `Vector.data`
-# ---
-# alloc:     allocator for the temp file and the returned bytes
-# itn:       interner the writer resolves names through
-# isa_vt:    the instruction-set vtable
-# segs:      the load segments to frame
-# seg_count: number of load segments
-# dyn:       the dynamic-link plan
-# entry:     the entry virtual address
-# ret:       the emitted image bytes, or an error string
-fun t_emit_dyn(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
-               segs: *of.LoadSegment, seg_count: u32, dyn: *of.DynamicInfo,
-               entry: u64) R.Result[Vector[u8], str] {
-    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "macho_seg");
-    if (R.is_err[fs.TempFile, str](tf_r)) { ret R.err[Vector[u8], str]("temp"); }
-    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
-    val em: R.Result[bool, str] = emit_dyn_exec(alloc, itn, isa_vt, segs, seg_count, 0x4000, entry,
-                                                nil::*of.ExecFunction, 0, dyn, nil::*of.PltFixup, 0,
-                                                nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "machoseg"::*u8);
-    if (R.is_err[bool, str](em)) {
-        fs.temp_close_and_remove(?tf);
-        ret R.err[Vector[u8], str](R.unwrap_err[bool, str](em));
-    }
-    val rb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, fs.temp_path(?tf));
-    fs.temp_close_and_remove(?tf);
-    ret rb;
-}
-
-# the Mach-O segment table a PIE link with distinct rodata and rel.ro segments must
-# produce: exactly one segment is SG_READ_ONLY - the one the rebase stream writes
-# into, which is also the only one that may be named __DATA_CONST - while un-rebased
-# read-only content stays r--/r-- under __RODATA and writable content stays plain
-# __DATA however many pointers it holds. Every section spells its enclosing segment,
-# and the rebase opcodes select the emitted segment index.
-#
-# Falsifies the permission-derived rule that flagged every read-only segment (two
-# SG_READ_ONLY segments, which the darwin kernel refuses to exec, SIGKILLing the
-# image before dyld runs - #2172), and equally a rule that dropped the read-only
-# half and flagged the rebased __DATA, which dyld would re-protect read-only under a
-# program that then faults on its first store to a pointer-valued global
+# Falsifies the permission-derived rule that flagged every read-only segment: that
+# emitted two SG_READ_ONLY segments, which the darwin kernel refuses to exec,
+# SIGKILLing the image before dyld runs (#2172). Also pins the rejection of a layout
+# with base relocations in two read-only segments, which Mach-O cannot express
 fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     var alloc: A.Allocator;
     page.make(?alloc);
@@ -4664,202 +4306,86 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     var isa_vt: isa.IsaVTable;
     isa_vt.id = arch_id;
 
-    var bytes: [80]u8;
+    var text_bytes: [16]u8;
+    var ro_bytes:   [16]u8;
+    var relro_bytes: [16]u8;
+    var data_bytes: [16]u8;
     var k: usize = 0;
-    for (k < 80) { bytes[k] = 0; k = k + 1; }
+    for (k < 16) {
+        text_bytes[k] = 0; ro_bytes[k] = 0; relro_bytes[k] = 0; data_bytes[k] = 0;
+        k = k + 1;
+    }
 
-    # text, data, rodata, rel.ro, bss - each on its own 16 KiB page, in the linker's
-    # per-kind segment order.
-    val base: u64 = 0x100000000;
-    val pg:   u64 = 0x4000;
-    var segs: [5]of.LoadSegment;
-    segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
-    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE;  segs[0].bytes = ?bytes[0];
-    segs[1].vaddr = base + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
-    segs[1].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;    segs[1].bytes = ?bytes[16];
-    segs[2].vaddr = base + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
-    segs[2].flags = of.SEG_FLAG_READ;                        segs[2].bytes = ?bytes[32];
-    segs[3].vaddr = base + pg * 3; segs[3].filesz = 16; segs[3].memsz = 16;
-    segs[3].flags = of.SEG_FLAG_READ;                        segs[3].bytes = ?bytes[48];
-    segs[4].vaddr = base + pg * 4; segs[4].filesz = 0;  segs[4].memsz = 16;
-    segs[4].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;    segs[4].bytes = nil;
-
-    # pointers to slide in rel.ro and in data: a writable segment is already writable
-    # for dyld's fixup pass, so it must never be flagged however many it holds.
-    var brs: [3]of.BaseReloc;
-    brs[0].seg_index = 1; brs[0].seg_offset = 0; brs[0].target = base;
-    brs[1].seg_index = 3; brs[1].seg_offset = 0; brs[1].target = base;
-    brs[2].seg_index = 2; brs[2].seg_offset = 0; brs[2].target = base;
-
-    var dyn: of.DynamicInfo;
-    dyn.interp = intern.STR_NIL;
-    dyn.base_relocs = ?brs[0];
-    dyn.base_reloc_count = 2;
-    dyn.pie = true;
-
-    val r1: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 5, ?dyn, base);
-    if (R.is_err[Vector[u8], str](r1)) { ret 1; }
-    val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](r1);
-
-    # exactly one segment claims the flag, it is the rebased read-only one, and it
-    # maps read-write so dyld can apply the fixups it re-protects afterward.
-    if (t_count_sg_read_only(buf.data) != 1)                                 { ret 1; }
-    if (t_count_segs_named(buf.data, "__DATA_CONST") != 1)                   { ret 1; }
-    val dc: usize = t_find_seg(buf.data, "__DATA_CONST");
-    if (dc == 0)                                                             { ret 1; }
-    if (bin.read_u64_le(buf.data, dc + 24) != base + pg * 3)                 { ret 1; }
-    if ((bin.read_u32_le(buf.data, dc + 68) & SG_READ_ONLY) == 0)            { ret 1; }
-    if (bin.read_u32_le(buf.data, dc + 60) != (VM_PROT_READ | VM_PROT_WRITE)) { ret 1; }
-    if (bin.read_u32_le(buf.data, dc + 64) != 1)                             { ret 1; }
-
-    # the un-rebased read-only segment is plain __RODATA: read-only for the process's
-    # whole life (maxprot caps it too), never writable, never flagged.
-    if (t_count_segs_named(buf.data, "__RODATA") != 1)                       { ret 1; }
-    val rd: usize = t_find_seg(buf.data, "__RODATA");
-    if (rd == 0)                                                             { ret 1; }
-    if (bin.read_u64_le(buf.data, rd + 24) != base + pg * 2)                 { ret 1; }
-    if (bin.read_u32_le(buf.data, rd + 60) != VM_PROT_READ)                  { ret 1; }
-    if (bin.read_u32_le(buf.data, rd + 56) != VM_PROT_READ)                  { ret 1; }
-    if ((bin.read_u32_le(buf.data, rd + 68) & SG_READ_ONLY) != 0)            { ret 1; }
-
-    # the writable segment the rebase stream also writes into stays __DATA, mapped
-    # read-write and unflagged: flagging it would have dyld re-protect it read-only
-    # after fixups, faulting the program's first store to a pointer-valued global.
-    val dt: usize = t_find_seg(buf.data, "__DATA");
-    if (dt == 0)                                                             { ret 1; }
-    if (bin.read_u64_le(buf.data, dt + 24) != base + pg)                     { ret 1; }
-    if (bin.read_u32_le(buf.data, dt + 60) != (VM_PROT_READ | VM_PROT_WRITE)) { ret 1; }
-    if (bin.read_u32_le(buf.data, dt + 56) != (VM_PROT_READ | VM_PROT_WRITE)) { ret 1; }
-    if ((bin.read_u32_le(buf.data, dt + 68) & SG_READ_ONLY) != 0)            { ret 1; }
-
-    # every section names the segment it lives in, and each rebase resolves through
-    # its selected segment back to the address the linker recorded.
-    if (!t_sections_match_segname(buf.data))                                 { ret 1; }
-    if (t_rebase_vaddr(buf.data, 0) != base + pg)                            { ret 1; }
-    if (t_rebase_vaddr(buf.data, 1) != base + pg * 3)                        { ret 1; }
-    if (t_rebase_vaddr(buf.data, 2) != 0)                                    { ret 1; }
-
-    # rodata rebased as well: both read-only segments now need dyld's fixup pass, and
-    # Mach-O maps one such segment - they share it, carrying a section each, so the
-    # image keeps exactly one SG_READ_ONLY instead of being refused.
-    dyn.base_reloc_count = 3;
-    val r2: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 5, ?dyn, base);
-    if (R.is_err[Vector[u8], str](r2)) { ret 1; }
-    val buf2: Vector[u8] = R.unwrap_ok[Vector[u8], str](r2);
-    if (t_count_sg_read_only(buf2.data) != 1)                                { ret 1; }
-    if (t_count_segs_named(buf2.data, "__DATA_CONST") != 1)                  { ret 1; }
-    if (t_count_segs_named(buf2.data, "__RODATA") != 0)                      { ret 1; }
-    val dc2: usize = t_find_seg(buf2.data, "__DATA_CONST");
-    if (bin.read_u64_le(buf2.data, dc2 + 24) != base + pg * 2)               { ret 1; }
-    if (bin.read_u32_le(buf2.data, dc2 + 64) != 2)                           { ret 1; }
-    if (bin.read_u64_le(buf2.data, dc2 + 32)
-        != bin.align_up_u64(pg + 16, macho_page_size(arch_id)))              { ret 1; }
-    if (!t_sections_match_segname(buf2.data))                                { ret 1; }
-    # the merged members share one command index, and their offsets are measured from
-    # that command's address, not from the member's own.
-    if (t_rebase_vaddr(buf2.data, 0) != base + pg)                           { ret 1; }
-    if (t_rebase_vaddr(buf2.data, 1) != base + pg * 2)                       { ret 1; }
-    if (t_rebase_vaddr(buf2.data, 2) != base + pg * 3)                       { ret 1; }
-    ret 0;
-}
-
-# two read-only segments the linker separated by a writable one cannot share a
-# command, so the image would need two SG_READ_ONLY segments - the shape the darwin
-# kernel refuses. The write is refused instead, naming both segments and a
-# relocation, rather than producing a file that dies at exec with no diagnostic
-fun ts_dyn_exec_split_data_const() u8 {
-    var alloc: A.Allocator;
-    page.make(?alloc);
-    var itn: intern.Interner = intern.init(?alloc);
-
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_AARCH64;
-
-    var bytes: [64]u8;
-    var k: usize = 0;
-    for (k < 64) { bytes[k] = 0; k = k + 1; }
-
+    # text, rodata, rel.ro, data - each on its own 16 KiB page, mirroring the linker's
+    # per-kind segment layout.
     val base: u64 = 0x100000000;
     val pg:   u64 = 0x4000;
     var segs: [4]of.LoadSegment;
     segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
-    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?bytes[0];
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
     segs[1].vaddr = base + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
-    segs[1].flags = of.SEG_FLAG_READ;                       segs[1].bytes = ?bytes[16];
+    segs[1].flags = of.SEG_FLAG_READ; segs[1].bytes = ?ro_bytes[0];
     segs[2].vaddr = base + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
-    segs[2].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;   segs[2].bytes = ?bytes[32];
+    segs[2].flags = of.SEG_FLAG_READ; segs[2].bytes = ?relro_bytes[0];
     segs[3].vaddr = base + pg * 3; segs[3].filesz = 16; segs[3].memsz = 16;
-    segs[3].flags = of.SEG_FLAG_READ;                       segs[3].bytes = ?bytes[48];
+    segs[3].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE; segs[3].bytes = ?data_bytes[0];
 
+    # one absolute pointer to slide, in the rel.ro segment only.
     var brs: [2]of.BaseReloc;
-    brs[0].seg_index = 1; brs[0].seg_offset = 8; brs[0].target = base;
-    brs[1].seg_index = 3; brs[1].seg_offset = 0; brs[1].target = base;
+    brs[0].seg_index = 2; brs[0].seg_offset = 0; brs[0].target = base;
+    brs[1].seg_index = 1; brs[1].seg_offset = 0; brs[1].target = base;
 
     var dyn: of.DynamicInfo;
     dyn.interp = intern.STR_NIL;
     dyn.base_relocs = ?brs[0];
-    dyn.base_reloc_count = 2;
+    dyn.base_reloc_count = 1;
     dyn.pie = true;
 
-    val r: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 4, ?dyn, base);
-    if (!R.is_err[Vector[u8], str](r))                                       { ret 1; }
-    val msg: str = R.unwrap_err[Vector[u8], str](r);
-    # the diagnostic names both offending segments and a relocation inside the second.
-    if (!str_contains(msg, "__DATA_CONST"))                                  { ret 1; }
-    if (!str_contains(msg, "read-only load segments 1"))                     { ret 1; }
-    if (!str_contains(msg, "and 3"))                                         { ret 1; }
-    ret 0;
-}
-
-# a static image has no loader-applied rebases, so its rodata and rel.ro segments are
-# one read-only Mach-O segment spanning both - not two commands sharing a name, which
-# would rebind every by-name lookup (otool, lldb, dsymutil) to whichever came first
-fun ts_exec_merges_read_only() u8 {
-    var alloc: A.Allocator;
-    page.make(?alloc);
-    var itn: intern.Interner = intern.init(?alloc);
-
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
-
-    var bytes: [48]u8;
-    var k: usize = 0;
-    for (k < 48) { bytes[k] = 0; k = k + 1; }
-
-    val base: u64 = 0x100000000;
-    val pg:   u64 = 0x4000;
-    var segs: [3]of.LoadSegment;
-    segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
-    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?bytes[0];
-    segs[1].vaddr = base + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
-    segs[1].flags = of.SEG_FLAG_READ;                       segs[1].bytes = ?bytes[16];
-    segs[2].vaddr = base + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
-    segs[2].flags = of.SEG_FLAG_READ;                       segs[2].bytes = ?bytes[32];
-
-    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_exec_ro");
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_relro_seg");
     if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
-    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 3, pg, base,
-                                            nil::*of.ExecFunction, 0, nil::*of.Section, 0,
-                                            fs.temp_path(?tf)::*u8, "machoexecro"::*u8);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 4, pg, base,
+                                                nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
+                                                nil::*of.Section, 0, tpath::*u8, "machorelro"::*u8);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
-    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
     fs.temp_close_and_remove(?tf);
     if (R.is_err[Vector[u8], str](rb)) { ret 1; }
     val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
 
-    if (t_count_segs_named(buf.data, "__RODATA") != 1)                       { ret 1; }
-    val rd: usize = t_find_seg(buf.data, "__RODATA");
-    if (rd == 0)                                                             { ret 1; }
-    # one command spanning both read-only segments, from the first's address to the
-    # second's end.
-    if (bin.read_u64_le(buf.data, rd + 24) != base + pg)                     { ret 1; }
-    if (bin.read_u64_le(buf.data, rd + 32)
-        != bin.align_up_u64(pg + 16, EXEC_PAGE_SIZE))                        { ret 1; }
-    if (bin.read_u32_le(buf.data, rd + 60) != VM_PROT_READ)                  { ret 1; }
+    # exactly one segment claims the flag, and it is the rebased one: __DATA_CONST,
+    # mapped read-write for dyld's fixup pass.
+    if (t_count_sg_read_only(buf.data) != 1)                     { ret 1; }
+    val dc: usize = t_find_seg(buf.data, "__DATA_CONST");
+    if (dc == 0)                                                 { ret 1; }
+    if (bin.read_u64_le(buf.data, dc + 24) != base + pg * 2)     { ret 1; }
+    if ((bin.read_u32_le(buf.data, dc + 68) & SG_READ_ONLY) == 0) { ret 1; }
+    if (bin.read_u32_le(buf.data, dc + 60) != (VM_PROT_READ | VM_PROT_WRITE)) { ret 1; }
 
-    # and the parser recovers that segment's content as read-only, not as mutable data.
-    if (macho_kind_from(0, false, false, true) != of.SK_RODATA)              { ret 1; }
+    # the un-rebased read-only segment is plain __RODATA: read-only for the process's
+    # whole life, never writable, never flagged.
+    val rd: usize = t_find_seg(buf.data, "__RODATA");
+    if (rd == 0)                                                 { ret 1; }
+    if (bin.read_u64_le(buf.data, rd + 24) != base + pg)         { ret 1; }
+    if (bin.read_u32_le(buf.data, rd + 60) != VM_PROT_READ)      { ret 1; }
+    if (bin.read_u32_le(buf.data, rd + 56) != VM_PROT_READ)      { ret 1; }
+    if ((bin.read_u32_le(buf.data, rd + 68) & SG_READ_ONLY) != 0) { ret 1; }
+
+    # base relocations in two read-only segments have no single __DATA_CONST to live
+    # in, so the write is refused instead of producing an image that dies at exec.
+    dyn.base_reloc_count = 2;
+    val tf2_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_relro_seg2");
+    if (R.is_err[fs.TempFile, str](tf2_r)) { ret 1; }
+    var tf2: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf2_r);
+    val em2: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 4, pg, base,
+                                                 nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
+                                                 nil::*of.Section, 0, fs.temp_path(?tf2)::*u8, "machorelro"::*u8);
+    fs.temp_close_and_remove(?tf2);
+    if (!R.is_err[bool, str](em2))                                              { ret 1; }
+    if (!str_contains(R.unwrap_err[bool, str](em2), "read-only segment"))        { ret 1; }
     ret 0;
 }
 
@@ -4970,8 +4496,6 @@ test "mach.lang.target.of.macho:dyn_exec" {
     if (ts_dyn_exec(isa.ARCH_AARCH64) != 0) { ret 1; }
     if (ts_dyn_exec_relro_segments(isa.ARCH_X86_64) != 0)  { ret 1; }
     if (ts_dyn_exec_relro_segments(isa.ARCH_AARCH64) != 0) { ret 1; }
-    if (ts_dyn_exec_split_data_const() != 0)               { ret 1; }
-    if (ts_exec_merges_read_only() != 0)                   { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Throwaway PR for #2179 acceptance verification only. Branched from origin/main (4.2.1, a7126cab), carries the darwin release gate workflow files, and fully reverts all three #2175 commits (90855ee8, 343f8cea, 1845166f) from src/lang/target/of/macho.mach — restoring it byte-identical to its pre-#2175 state (verified: cmp against 6f4233f0's blob, and `grep -c seg_is_rebased` == 0).

This is the exact regression that let #2172 (aarch64-darwin exec SIGKILL) reach a pushed v4.2.0 tag through a 17/17 green release PR.

Expect `darwin (release gate)` to go RED. Will be closed and the branch deleted immediately once confirmed — do not merge, do not leave open (release line is live on main).