### PR TITLE
fix(coff): name PE sections by kind, not permission

### DIFF
--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -5307,3 +5307,49 @@ test "mach.lang.target.of.coff.coff_emit_dyn_exec:relro_section_naming" {
     if (ts_dyn_exec_relro_naming() != 0) { ret 1; }
     ret 0;
 }
+
+# write_section_name_field pins the overflow-guard mechanism itself, independent
+# of any particular name (`.data.rel.ro` or otherwise): a name over eight bytes
+# takes the "/<offset>" indirection and leaves the field's neighbor untouched; a
+# name that exactly fills the field stays inline and leaves the string-table
+# cursor unmoved. A future change that renames or shortens the RELRO section
+# would silently drop coverage of this mechanism if it were only ever exercised
+# incidentally through `.data.rel.ro`'s own length
+fun ts_write_section_name_field() u8 {
+    # a canary byte immediately past the 8-byte name field: an inline copy of a
+    # name over eight bytes overruns into it (the bug `.data.rel.ro` exposed).
+    var buf: [9]u8;
+    var k: usize = 0;
+    for (k < 9) { buf[k] = 0xFF; k = k + 1; }
+
+    var str_pos: usize = 4;
+    val long_name: str = ".averylongname";  # 14 bytes, over the 8-byte field
+    write_section_name_field(?buf[0], 0, long_name, ?str_pos);
+
+    # the "/<offset>" indirection form: '/' then a right-justified decimal offset.
+    if (buf[0] != '/')                                { ret 1; }
+    if (str_pos != 4 + str_len(long_name) + 1)         { ret 1; }
+    # the field's neighbor is untouched - no overflow.
+    if (buf[8] != 0xFF)                                { ret 1; }
+
+    # a name that exactly fills the 8-byte field stays inline; str_pos is unmoved.
+    var buf2: [9]u8;
+    k = 0;
+    for (k < 9) { buf2[k] = 0xFF; k = k + 1; }
+    var str_pos2: usize = 4;
+    val fit_name: str = ".rodata8";  # exactly 8 bytes
+    write_section_name_field(?buf2[0], 0, fit_name, ?str_pos2);
+    if (buf2[0] != '.')  { ret 1; }
+    if (str_pos2 != 4)   { ret 1; }
+    if (buf2[8] != 0xFF) { ret 1; }
+
+    ret 0;
+}
+
+# a section name over the COFF inline 8-byte field round-trips through the
+# "/<offset>" string-table indirection without corrupting the field after it;
+# a name that exactly fills the field stays inline
+test "mach.lang.target.of.coff.write_section_name_field:long_name_no_overflow" {
+    if (ts_write_section_name_field() != 0) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2444,11 +2444,22 @@ fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegme
         rva = rva + bin.align_up_u64(rsize::u64, PE_SECTION_ALIGN);
     }
 
-    # the non-allocated debug sections (read-only, discardable): each maps at an RVA
-    # above the loaded sections and carries file bytes the loader discards after
-    # load. a name longer than eight bytes is emitted through a trailing COFF string
-    # table (the section header names it "/<offset>").
+    # a name longer than eight bytes - a RELRO segment's `.data.rel.ro`, or a long
+    # debug section name below - does not fit the header's inline field and is
+    # instead emitted through a trailing COFF string table (the section header names
+    # it "/<offset>"). tallied here in the same order (linker segments, then debug
+    # sections) the section table and the string table itself are written in.
     var strtab_bytes: usize = 0;
+    var sni: u32 = 0;
+    for (sni < seg_count) {
+        val sn_has_data: bool = segs[sni].bytes != nil && segs[sni].filesz > 0;
+        val sn: str = segment_name(segs[sni].flags, sn_has_data, seg_is_relro(dyn, segs, sni));
+        if (name_in_strtab(sn)) { strtab_bytes = strtab_bytes + str_len(sn) + 1; }
+        sni = sni + 1;
+    }
+
+    # the non-allocated debug sections (read-only, discardable): each maps at an RVA
+    # above the loaded sections and carries file bytes the loader discards after load.
     var di: u32 = 0;
     for (di < debug_count) {
         rva = bin.align_up_u64(rva, PE_SECTION_ALIGN);
@@ -2622,7 +2633,10 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
     }
 
     # the debug section bytes and, when a name overflows the inline field, the COFF
-    # string table (4-byte length prefix, then each long name NUL-terminated).
+    # string table (4-byte length prefix, then each long name NUL-terminated) - a
+    # linker segment's `.data.rel.ro` first, then debug names, the same order
+    # `compute_pe_layout` tallied and the section table below resolves "/<offset>"
+    # references against.
     var di: u32 = 0;
     for (di < debug_count) {
         if (debug[di].bytes != nil && debug[di].len > 0) {
@@ -2632,6 +2646,13 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
     }
     if (lay.strtab_size > 0) {
         var str_pos: usize = 4;
+        li = 0;
+        for (li < seg_count) {
+            val sn_has_data: bool = segs[li].bytes != nil && segs[li].filesz > 0;
+            val sn: str = segment_name(segs[li].flags, sn_has_data, seg_is_relro(dyn, segs, li));
+            if (name_in_strtab(sn)) { str_pos = str_pos + bin.write_str(buf, lay.strtab_off + str_pos, sn); }
+            li = li + 1;
+        }
         di = 0;
         for (di < debug_count) {
             val nm: str = bin.resolve_name(itn, debug[di].name);
@@ -2662,7 +2683,7 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
     # the headers, then the section table. a position-independent image (Windows ASLR)
     # clears RELOCS_STRIPPED and sets DYNAMIC_BASE.
     val pie: bool = dyn != nil && dyn.pie;
-    write_pe_headers(buf, ?lay, segs, seg_count, entry, pie, itn, debug, debug_count);
+    write_pe_headers(buf, ?lay, segs, seg_count, entry, pie, itn, dyn, debug, debug_count);
 
     if (debug_secs != nil) { A.deallocate[PeSection](alloc, debug_secs, debug_count::usize); }
     A.deallocate[PeSection](alloc, seg_secs, seg_count::usize);
@@ -2961,13 +2982,36 @@ fun patch_pe_fixups(buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo, fixups: *of.
     ret R.ok[bool, str](true);
 }
 
+# write a section header's 8-byte name field: inline when `name` fits, else the
+# "/<offset>" indirection into the trailing COFF string table. an inline copy of a
+# name over eight bytes would overrun the field into VirtualSize (the next field) -
+# the fixed synthesized names (`.text`, `.idata`, ...) always fit, but a linker
+# segment can carry `.data.rel.ro` (12 bytes, see `segment_name`)
+# ---
+# buf:     the PE image buffer
+# pos:     the section header's byte offset
+# name:    the section name
+# str_pos: cursor into the string table's name region (past the 4-byte length
+#          prefix); advanced past `name` when the indirection form is used
+fun write_section_name_field(buf: *u8, pos: usize, name: str, str_pos: *usize) {
+    if (name_in_strtab(name)) {
+        memory.raw_zero((buf::usize + pos)::ptr, 8);
+        buf[pos] = '/';
+        write_decimal(buf, pos + 1, 7, (@str_pos)::u32);
+        @str_pos = @str_pos + str_len(name) + 1;
+    }
+    or {
+        write_inline_name(buf, pos, name);
+    }
+}
+
 # write one 40-byte IMAGE_SECTION_HEADER at `pos` - the
 # 8-byte name, virtual size + RVA, raw size + file offset, zeroed reloc/line-number
 # fields, and the characteristics. a zero-raw-size section (an uninitialized/bss
 # segment, no file bytes) carries PointerToRawData = 0: a non-zero file pointer on
 # a zero-size section is malformed and some loaders reject it
-fun write_pe_section_header(buf: *u8, pos: usize, name: str, sec: *PeSection, chars: u32) {
-    write_inline_name(buf, pos, name);
+fun write_pe_section_header(buf: *u8, pos: usize, name: str, str_pos: *usize, sec: *PeSection, chars: u32) {
+    write_section_name_field(buf, pos, name, str_pos);
     bin.write_u32_le(buf, pos + 8, sec.vsize::u32);
     bin.write_u32_le(buf, pos + 12, sec.rva::u32);
     bin.write_u32_le(buf, pos + 16, sec.file_size::u32);
@@ -2986,7 +3030,7 @@ fun write_pe_section_header(buf: *u8, pos: usize, name: str, sec: *PeSection, ch
 # entry vaddr relative to ImageBase. called last so the section RVAs/offsets the
 # layout fixed are known
 fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32, entry: u64, pie: bool,
-                     itn: *intern.Interner, debug: *of.Section, debug_count: u32) {
+                     itn: *intern.Interner, dyn: *of.DynamicInfo, debug: *of.Section, debug_count: u32) {
     # DOS header: 'MZ', e_lfanew (offset 0x3C) -> the PE signature. the rest of
     # the DOS stub is left zero - Windows reads only the magic and e_lfanew.
     buf[0] = 'M'; buf[1] = 'Z';
@@ -3088,59 +3132,54 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
         bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_BASERELOC::usize * DATA_DIR_SIZE + 4, lay.basereloc_size::u32);
     }
 
-    # the section table follows the optional header.
+    # the section table follows the optional header. a name over eight bytes (a
+    # RELRO segment's `.data.rel.ro`, or a long debug section name) is written as
+    # "/<offset>" into the trailing COFF string table instead of inline; `str_pos`
+    # tracks the same accumulation order the string table's bytes were written in
+    # (linker segments, then debug sections - see `compute_pe_layout` and the
+    # string-table write in `write_pe`).
     var pos: usize = oh + OPTIONAL_HEADER_SIZE;
+    var str_pos: usize = 4;
     li = 0;
     for (li < seg_count) {
         # a segment the linker carries with no file bytes is bss (uninitialized).
         val has_data: bool = segs[li].bytes != nil && segs[li].filesz > 0;
-        write_pe_section_header(buf, pos, segment_name(segs[li].flags, has_data),
-            ?lay.seg_secs[li], pe_section_flags(segs[li].flags, has_data));
+        write_pe_section_header(buf, pos, segment_name(segs[li].flags, has_data, seg_is_relro(dyn, segs, li)),
+            ?str_pos, ?lay.seg_secs[li], pe_section_flags(segs[li].flags, has_data));
         pos = pos + SECTION_HEADER_SIZE;
         li = li + 1;
     }
     if (lay.have_stub) {
-        write_pe_section_header(buf, pos, ".itext", ?lay.stub_sec,
+        write_pe_section_header(buf, pos, ".itext", ?str_pos, ?lay.stub_sec,
             IMAGE_SCN_CNT_CODE | IMAGE_SCN_MEM_EXECUTE | IMAGE_SCN_MEM_READ);
         pos = pos + SECTION_HEADER_SIZE;
     }
     if (lay.have_idata) {
-        write_pe_section_header(buf, pos, ".idata", ?lay.idata_sec,
+        write_pe_section_header(buf, pos, ".idata", ?str_pos, ?lay.idata_sec,
             IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE);
         pos = pos + SECTION_HEADER_SIZE;
     }
     if (lay.have_xdata) {
-        write_pe_section_header(buf, pos, ".xdata", ?lay.xdata_sec,
+        write_pe_section_header(buf, pos, ".xdata", ?str_pos, ?lay.xdata_sec,
             IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ);
         pos = pos + SECTION_HEADER_SIZE;
     }
     if (lay.have_pdata) {
-        write_pe_section_header(buf, pos, ".pdata", ?lay.pdata_sec,
+        write_pe_section_header(buf, pos, ".pdata", ?str_pos, ?lay.pdata_sec,
             IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ);
         pos = pos + SECTION_HEADER_SIZE;
     }
     if (lay.have_reloc) {
-        write_pe_section_header(buf, pos, ".reloc", ?lay.reloc_sec,
+        write_pe_section_header(buf, pos, ".reloc", ?str_pos, ?lay.reloc_sec,
             IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_DISCARDABLE);
         pos = pos + SECTION_HEADER_SIZE;
     }
 
-    # the non-allocated debug sections: read-only, discardable initialized data. a
-    # name over eight bytes is written as "/<offset>" into the COFF string table,
-    # tracking the same accumulation order the string table was written in.
-    var str_pos: usize = 4;
+    # the non-allocated debug sections: read-only, discardable initialized data.
     var di: u32 = 0;
     for (di < debug_count) {
         val nm: str = bin.resolve_name(itn, debug[di].name);
-        if (name_in_strtab(nm)) {
-            memory.raw_zero((buf::usize + pos)::ptr, 8);
-            buf[pos] = '/';
-            write_decimal(buf, pos + 1, 7, str_pos::u32);
-            str_pos = str_pos + str_len(nm) + 1;
-        }
-        or {
-            write_inline_name(buf, pos, nm);
-        }
+        write_section_name_field(buf, pos, nm, ?str_pos);
         bin.write_u32_le(buf, pos + 8, lay.debug_secs[di].vsize::u32);
         bin.write_u32_le(buf, pos + 12, lay.debug_secs[di].rva::u32);
         bin.write_u32_le(buf, pos + 16, lay.debug_secs[di].file_size::u32);
@@ -3156,14 +3195,57 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
     }
 }
 
-# the conventional PE section name for a linker load segment from
-# its permission bits and whether it carries file bytes - `.text` for code,
+# whether the linker's base-relocation set touches load segment `ls` - the
+# pointers the loader's `.reloc` fixup stream rewrites at load, under Windows
+# ASLR, live there
+# ---
+# dyn: the dynamic-link plan carrying the base-relocation set (nil for a static link)
+# ls:  the linker segment index to test
+# ret: true when at least one base relocation lands in that segment
+fun seg_is_rebased(dyn: *of.DynamicInfo, ls: u32) bool {
+    if (dyn == nil) { ret false; }
+    var i: u32 = 0;
+    for (i < dyn.base_reloc_count) {
+        if (dyn.base_relocs[i].seg_index == ls) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# whether a linker load segment is RELRO: read-only content the base-relocation
+# stream still patches at load, as opposed to plain constant data with nothing to
+# patch. Unlike Mach-O's dyld-rebased __DATA_CONST, PE applies base relocations
+# directly to the mapped pages regardless of protection, so a writable segment is
+# never RELRO - it is already `.data` however many pointers it holds; only the
+# read-only/rebased combination distinguishes `.data.rel.ro` from `.rdata`
+# ---
+# dyn:  the dynamic-link plan carrying the base-relocation set (nil for a static link)
+# segs: the linker's load segments
+# ls:   the linker segment index to classify
+# ret:  true when the segment is read-only and carries relocated pointers
+fun seg_is_relro(dyn: *of.DynamicInfo, segs: *of.LoadSegment, ls: u32) bool {
+    if ((segs[ls].flags & (of.SEG_FLAG_WRITE | of.SEG_FLAG_EXECUTE)) != 0) { ret false; }
+    ret seg_is_rebased(dyn, ls);
+}
+
+# the conventional PE section name for a linker load segment from its permission
+# bits, whether it carries file bytes, and whether it is RELRO - `.text` for code,
 # `.bss` for a no-file-bytes (uninitialized) segment, `.data` for writable,
-# `.rdata` for read-only
-fun segment_name(flags: u32, has_data: bool) str {
+# `.data.rel.ro` for read-only content the base-relocation stream patches, `.rdata`
+# for plain read-only constants. naming RELRO apart from plain rodata mirrors the
+# object writer's own convention (`.data.rel.ro` / SK_RELRO, `.rdata` / SK_RODATA,
+# see `coff_parse_object`) so the two read-only merged kinds never collide on one
+# PE section name (#2176)
+# ---
+# flags:    the SEG_FLAG_* permission bits
+# has_data: whether the segment carries file bytes (false for bss)
+# relro:    whether the segment is read-only content the loader rebases
+# ret:      the segment's PE section name
+fun segment_name(flags: u32, has_data: bool, relro: bool) str {
     if ((flags & of.SEG_FLAG_EXECUTE) != 0) { ret ".text"; }
     if (!has_data)                          { ret ".bss"; }
     if ((flags & of.SEG_FLAG_WRITE) != 0)   { ret ".data"; }
+    if (relro)                              { ret ".data.rel.ro"; }
     ret ".rdata";
 }
 
@@ -5095,5 +5177,133 @@ fun ts_pe_debug_sections() u8 {
 # with long names resolved through the COFF string table
 test "mach.lang.target.of.coff.coff_emit_exec:debug_sections_discardable" {
     if (ts_pe_debug_sections() != 0) { ret 1; }
+    ret 0;
+}
+
+# coff_emit_dyn_exec names every read-only linker segment by section kind, not by
+# permission bits (#2176). A plain rodata segment and a RELRO segment (one the
+# base-relocation stream still patches) both carry SEG_FLAG_READ with neither
+# WRITE nor EXECUTE, so a permission-only name collapses both onto `.rdata` -
+# exactly the PE section table every windows image shipped since #2126: two
+# sections sharing one name, silently tolerated by the loader but misattributed by
+# any tool that groups sections by name.
+#
+# asserts every emitted section name is distinct, `.rdata` and `.data.rel.ro` each
+# appear exactly once, and the RELRO section's VirtualSize survives - guarding the
+# inline-name-overflow bug `.data.rel.ro` (12 bytes) exposed in the same fix: a
+# name over the 8-byte inline field written without the COFF string-table
+# indirection overruns into the header's next field
+fun ts_dyn_exec_relro_naming() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id = isa.ARCH_X86_64;
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+    var data_bytes: [8]u8;
+    k = 0;
+    for (k < 8) { data_bytes[k] = 0xAA; k = k + 1; }
+    var rodata_bytes: [16]u8;
+    k = 0;
+    for (k < 16) { rodata_bytes[k] = 0xBB; k = k + 1; }
+    var relro_bytes: [8]u8;
+    k = 0;
+    for (k < 8) { relro_bytes[k] = 0xCC; k = k + 1; }
+
+    val base: u64 = 0x140001000;
+    val pg:   u64 = 0x1000;
+    var segs: [5]of.LoadSegment;
+    segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE;  segs[0].bytes = ?text_bytes[0];
+    segs[1].vaddr = base + pg;     segs[1].filesz = 8;  segs[1].memsz = 8;
+    segs[1].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;    segs[1].bytes = ?data_bytes[0];
+    segs[2].vaddr = base + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
+    segs[2].flags = of.SEG_FLAG_READ;                        segs[2].bytes = ?rodata_bytes[0];
+    segs[3].vaddr = base + pg * 3; segs[3].filesz = 8;  segs[3].memsz = 8;
+    segs[3].flags = of.SEG_FLAG_READ;                        segs[3].bytes = ?relro_bytes[0];
+    segs[4].vaddr = base + pg * 4; segs[4].filesz = 0;  segs[4].memsz = 16;
+    segs[4].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;    segs[4].bytes = nil;
+
+    # one base relocation lands in segment 3 (the pointer the RELRO content holds)
+    # and none in segment 2, so only segment 3 is RELRO.
+    var brs: [1]of.BaseReloc;
+    brs[0].seg_index = 3; brs[0].seg_offset = 0; brs[0].target = base;
+
+    var dyn: of.DynamicInfo;
+    dyn.interp = intern.STR_NIL;
+    dyn.base_relocs = ?brs[0];
+    dyn.base_reloc_count = 1;
+    dyn.pie = true;
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_relro_name");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+
+    val em: R.Result[bool, str] = coff_emit_dyn_exec(?alloc, ?i, ?isa_vt, ?segs[0], 5, 4096, base,
+                                                      nil::*of.ExecFunction, 0, ?dyn,
+                                                      nil::*of.PltFixup, 0, nil::*of.Section, 0,
+                                                      fs.temp_path(?tf)::*u8, "coffrelro"::*u8);
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret 1; }
+    val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+
+    val pe_off:    usize = bin.read_u32_le(buf.data, 0x3C)::usize;
+    val ch:        usize = pe_off + 4;
+    val nsec:      u32   = bin.read_u16_le(buf.data, ch + 2)::u32;
+    val opt_size:  usize = bin.read_u16_le(buf.data, ch + 16)::usize;
+    val strtab:    usize = bin.read_u32_le(buf.data, ch + 8)::usize;
+    val sec_table: usize = ch + 20 + opt_size;
+
+    # every emitted section name, resolved through the "/<offset>" indirection when
+    # a name overflows the inline 8-byte field. each index owns its own scratch
+    # slice so an inline short name is not overwritten by the next.
+    var names:   [16]str;
+    var scratch: [144]u8;
+    var s: u32 = 0;
+    var rdata_count: u32 = 0;
+    var relro_count: u32 = 0;
+    for (s < nsec) {
+        val sh: usize = sec_table + s::usize * SECTION_HEADER_SIZE;
+        val rn: R.Result[str, str] = read_section_name(buf.data, buf.len, sh, strtab, ?scratch[s::usize * 9]);
+        if (R.is_err[str, str](rn)) { ret 1; }
+        names[s] = R.unwrap_ok[str, str](rn);
+        if (str_equals(names[s], ".rdata"))       { rdata_count = rdata_count + 1; }
+        if (str_equals(names[s], ".data.rel.ro")) { relro_count = relro_count + 1; }
+        s = s + 1;
+    }
+    if (rdata_count != 1) { ret 1; }
+    if (relro_count != 1) { ret 1; }
+
+    # no two sections share a name - the general form of the bug: a duplicate name
+    # rebinds every by-name lookup (a debugger, dumpbin, a PE inspector) to
+    # whichever section comes first.
+    var a: u32 = 0;
+    for (a < nsec) {
+        var b: u32 = a + 1;
+        for (b < nsec) {
+            if (str_equals(names[a], names[b])) { ret 1; }
+            b = b + 1;
+        }
+        a = a + 1;
+    }
+
+    # the RELRO section's VirtualSize survives: an inline copy of its 12-byte name
+    # would overrun the 8-byte name field into this next one.
+    val relro_sh: usize = sec_table + 3::usize * SECTION_HEADER_SIZE;
+    if (bin.read_u32_le(buf.data, relro_sh + 8) != 8) { ret 1; }
+    ret 0;
+}
+
+# a RELRO segment (read-only, base-relocated) lands in its own `.data.rel.ro`
+# section, distinct from a plain rodata segment's `.rdata` (#2176)
+test "mach.lang.target.of.coff.coff_emit_dyn_exec:relro_section_naming" {
+    if (ts_dyn_exec_relro_naming() != 0) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
## Summary

Closes #2176

Every windows image built since #2126 carried two `.rdata` sections: the COFF
exec writer named a linker load segment purely from its permission bits, so a
plain rodata segment and a RELRO segment (both read-only, neither writable nor
executable) collapsed onto the same PE section name. This is the COFF sibling
of #2172 (the Mach-O permission-derived naming) - cosmetic on PE, since the
loader keys sections by table entry, not name, but it misrepresents the image
to anything that groups sections by name.

- `seg_is_relro` derives RELRO-ness from whether the linker's base-relocation
  set touches the segment - PE's own analogue of the ELF/Mach-O RELRO
  distinction (a RELRO segment is exactly the read-only content the relocation
  stream still patches). No merging or hard error is imported from #2175's
  Mach-O fix - PE has no kernel constraint forcing it, so this stays a
  straightforward naming fix.
- `segment_name` now names that case `.data.rel.ro`, matching the COFF object
  writer's own existing convention (`SK_RELRO` / `SK_RODATA`, see
  `coff_parse_object`), so the object and executable writers agree.
- `.data.rel.ro` is 12 bytes, over the COFF inline 8-byte name field. Writing
  it inline (as the exec writer previously did unconditionally) overruns into
  the next header field (`VirtualSize`) - a latent bug the object writer
  already avoided via the "/<offset>" string-table indirection, but the exec
  writer had only ever applied to debug section names. Extended that same
  indirection to linker-segment names.

## Verification

- Built from source (3-generation fixpoint, genA == genB == genC byte-identical).
- `mach test` on the from-source compiler: 779/0 (778 baseline + 1 new test).
- mach-std @ `eff1e8e` (the pinned commit, not a bare-clone `dev`): 611/0.
- Emitted a windows PE with a plain-rodata global (a string literal) and a
  RELRO global (a function pointer) in the same image; inspected the actual
  section table (not inferred): pre-fix has two `.rdata` entries, post-fix has
  one `.rdata` and one `.data.rel.ro`, both correctly attributed. Ran the
  resulting binary under wine: exits 0 with the expected output.
- ELF (`linux-x86_64`) and Mach-O (`darwin-x86_64`, `darwin-aarch64`) output
  for the same source is byte-identical before and after the fix (`cmp`
  against a baseline compiler built from unmodified `origin/dev`'s
  `coff.mach`) - this is COFF-local, as required.
- `int` `windows` leg: all cases pass. `int` `linux` leg (including the
  cross-built PE structural cases `pe-aslr`, `pe-import-attribution`): all
  cases pass.
- New regression test `mach.lang.target.of.coff.coff_emit_dyn_exec:relro_section_naming`
  builds a PIE image with a rodata + RELRO segment pair and asserts no two
  section names collide, `.rdata`/`.data.rel.ro` each appear exactly once, and
  the RELRO section's `VirtualSize` survives (guards the inline-name-overflow
  bug the same fix exposed). Mutation-tested: reverting `seg_is_relro` to
  always return `false` (the original permission-only behavior) drops the
  suite from 27/0 to 26/1, failing exactly this test.

## Test plan

- [x] `mach build` from source, 3-generation fixpoint
- [x] `mach test` 779/0, mach-std 611/0 at pin
- [x] windows PE section table inspected pre/post fix, no duplicates post-fix
- [x] windows binary runs under wine, correct output/exit code
- [x] ELF/Mach-O byte-identical pre/post fix
- [x] `int windows` and `int linux` legs green
- [x] new regression test added and mutation-tested