### PR TITLE
x64: emit_packed_op error return + COFF /bigobj support

### DIFF
--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -3819,7 +3819,10 @@ fun note_packed_imm(buf: *enc.ByteBuf, opcode: u16, dst: isa.Operand, src: isa.O
     printer.note_inst(buf, ?mi);
 }
 
-fun emit_packed_op(op: u16, dst_xmm: i32, src: isa.Operand, buf: *enc.ByteBuf) {
+# src is a register or 16-byte-aligned memory operand (#2208): every packed vector
+# value is register- or aligned-slot-resident, so any other shape reaching here is a
+# lowering bug the caller must not swallow
+fun emit_packed_op(op: u16, dst_xmm: i32, src: isa.Operand, buf: *enc.ByteBuf) R.Result[bool, str] {
     if (packed_prefix66(op)) { enc.emit_byte(buf, 0x66); }
     if (src.kind == isa.OPK_REG) {
         emit_rex_if_needed(buf, 0, dst_xmm, src.reg);
@@ -3827,7 +3830,7 @@ fun emit_packed_op(op: u16, dst_xmm: i32, src: isa.Operand, buf: *enc.ByteBuf) {
         enc.emit_byte(buf, packed_opbyte(op));
         enc.emit_byte(buf, encode_modrm(3, reg_bits(dst_xmm), reg_bits(src.reg)));
         note_packed(buf, op, vec_reg(dst_xmm), src);
-        ret;
+        ret R.ok[bool, str](true);
     }
     if (src.kind == isa.OPK_MEM) {
         emit_rex_mem(buf, 0, dst_xmm, ?src);
@@ -3835,9 +3838,9 @@ fun emit_packed_op(op: u16, dst_xmm: i32, src: isa.Operand, buf: *enc.ByteBuf) {
         enc.emit_byte(buf, packed_opbyte(op));
         encode_mem_operand(buf, dst_xmm, ?src);
         note_packed(buf, op, vec_reg(dst_xmm), src);
-        ret;
+        ret R.ok[bool, str](true);
     }
-    panic("encode: packed vector op source is not a register or aligned frame slot\n");
+    ret R.err[bool, str]("encode: packed vector op source is not a register or aligned frame slot");
 }
 
 # emit a packed reg-reg op with an imm8 (`[66] [REX] 0F <byte> /r ib`): CMPPS/PD and PSHUFD
@@ -3926,13 +3929,13 @@ fun emit_vec_store(dst: isa.Operand, xmm: i32, buf: *enc.ByteBuf) R.Result[bool,
 }
 
 # set every bit of `xmm` (`PCMPEQD xmm, xmm`) - the all-ones mask for a bitwise NOT
-fun emit_vec_all_ones(xmm: i32, buf: *enc.ByteBuf) {
-    emit_packed_op(x64.PCMPEQD, xmm, vec_reg(xmm), buf);
+fun emit_vec_all_ones(xmm: i32, buf: *enc.ByteBuf) R.Result[bool, str] {
+    ret emit_packed_op(x64.PCMPEQD, xmm, vec_reg(xmm), buf);
 }
 
 # clear `xmm` (`PXOR xmm, xmm`)
-fun emit_vec_zero(xmm: i32, buf: *enc.ByteBuf) {
-    emit_packed_op(x64.PXOR, xmm, vec_reg(xmm), buf);
+fun emit_vec_zero(xmm: i32, buf: *enc.ByteBuf) R.Result[bool, str] {
+    ret emit_packed_op(x64.PXOR, xmm, vec_reg(xmm), buf);
 }
 
 # whether a post-isel opcode is a vector-ALU candidate the packed encoders own: the
@@ -4023,7 +4026,8 @@ fun encode_vector_arith(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBu
 
     val ll: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
     if (R.is_err[bool, str](ll)) { ret ll; }
-    emit_packed_op(opc, FLOAT_SCRATCH0, rhs, buf);
+    val ro: R.Result[bool, str] = emit_packed_op(opc, FLOAT_SCRATCH0, rhs, buf);
+    if (R.is_err[bool, str](ro)) { ret ro; }
     ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
 }
 
@@ -4040,8 +4044,10 @@ fun encode_vector_not(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf)
 
     val ll: R.Result[bool, str] = emit_vec_load(src, FLOAT_SCRATCH0, buf);
     if (R.is_err[bool, str](ll)) { ret ll; }
-    emit_vec_all_ones(FLOAT_SCRATCH1, buf);
-    emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+    val ra: R.Result[bool, str] = emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+    if (R.is_err[bool, str](ra)) { ret ra; }
+    val ro: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+    if (R.is_err[bool, str](ro)) { ret ro; }
     ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
 }
 
@@ -4066,13 +4072,12 @@ fun emit_vcmp_eq_s0(lhs: isa.Operand, rhs: isa.Operand, w: u8, buf: *enc.ByteBuf
     val ll: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
     if (R.is_err[bool, str](ll)) { ret ll; }
     if (w == 8) {
-        emit_packed_op(x64.PCMPEQD, FLOAT_SCRATCH0, rhs, buf);
+        val re: R.Result[bool, str] = emit_packed_op(x64.PCMPEQD, FLOAT_SCRATCH0, rhs, buf);
+        if (R.is_err[bool, str](re)) { ret re; }
         emit_packed_rri(x64.PSHUFD, FLOAT_SCRATCH1, FLOAT_SCRATCH0, 0xB1, buf);
-        emit_packed_op(x64.PAND, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
-        ret R.ok[bool, str](true);
+        ret emit_packed_op(x64.PAND, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
     }
-    emit_packed_op(pcmpeq_op(w), FLOAT_SCRATCH0, rhs, buf);
-    ret R.ok[bool, str](true);
+    ret emit_packed_op(pcmpeq_op(w), FLOAT_SCRATCH0, rhs, buf);
 }
 
 # the SETcc opcode realizing a 64-bit-lane ordering compare (LT/LE, signed/unsigned)
@@ -4193,8 +4198,10 @@ fun encode_vector_compare(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.Byte
     if (op == mir.MIR_SEL_CMP_NE) {
         val re: R.Result[bool, str] = emit_vcmp_eq_s0(lhs, rhs, w, buf);
         if (R.is_err[bool, str](re)) { ret re; }
-        emit_vec_all_ones(FLOAT_SCRATCH1, buf);
-        emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        val ra: R.Result[bool, str] = emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+        if (R.is_err[bool, str](ra)) { ret ra; }
+        val ro: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        if (R.is_err[bool, str](ro)) { ret ro; }
         ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
     }
 
@@ -4205,28 +4212,36 @@ fun encode_vector_compare(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.Byte
         # lhs < rhs (signed) = rhs > lhs = PCMPGT(rhs, lhs).
         val ld: R.Result[bool, str] = emit_vec_load(rhs, FLOAT_SCRATCH0, buf);
         if (R.is_err[bool, str](ld)) { ret ld; }
-        emit_packed_op(pcmpgt_op(w), FLOAT_SCRATCH0, lhs, buf);
+        val ro: R.Result[bool, str] = emit_packed_op(pcmpgt_op(w), FLOAT_SCRATCH0, lhs, buf);
+        if (R.is_err[bool, str](ro)) { ret ro; }
         ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
     }
     if (op == mir.MIR_SEL_CMP_LE_S) {
         # lhs <= rhs (signed) = !(lhs > rhs).
         val ld: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
         if (R.is_err[bool, str](ld)) { ret ld; }
-        emit_packed_op(pcmpgt_op(w), FLOAT_SCRATCH0, rhs, buf);
-        emit_vec_all_ones(FLOAT_SCRATCH1, buf);
-        emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        val ro: R.Result[bool, str] = emit_packed_op(pcmpgt_op(w), FLOAT_SCRATCH0, rhs, buf);
+        if (R.is_err[bool, str](ro)) { ret ro; }
+        val ra: R.Result[bool, str] = emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+        if (R.is_err[bool, str](ra)) { ret ra; }
+        val rx: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        if (R.is_err[bool, str](rx)) { ret rx; }
         ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
     }
     if (op == mir.MIR_SEL_CMP_LT_U) {
         if (w == 4) {
             # dword sign-bias then signed PCMPGTD: lhs <u rhs = biased_rhs >s biased_lhs.
-            emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+            val ra: R.Result[bool, str] = emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+            if (R.is_err[bool, str](ra)) { ret ra; }
             emit_packed_shift_imm(x64.PSLLD, FLOAT_SCRATCH1, 31, buf);
             val ld: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
             if (R.is_err[bool, str](ld)) { ret ld; }
-            emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
-            emit_packed_op(x64.PXOR, FLOAT_SCRATCH1, rhs, buf);
-            emit_packed_op(x64.PCMPGTD, FLOAT_SCRATCH1, vec_reg(FLOAT_SCRATCH0), buf);
+            val rx0: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+            if (R.is_err[bool, str](rx0)) { ret rx0; }
+            val rx1: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH1, rhs, buf);
+            if (R.is_err[bool, str](rx1)) { ret rx1; }
+            val rg: R.Result[bool, str] = emit_packed_op(x64.PCMPGTD, FLOAT_SCRATCH1, vec_reg(FLOAT_SCRATCH0), buf);
+            if (R.is_err[bool, str](rg)) { ret rg; }
             ret emit_vec_store(dst, FLOAT_SCRATCH1, buf);
         }
         # byte/word: lhs <u rhs = subus(rhs, lhs) != 0.
@@ -4234,25 +4249,36 @@ fun encode_vector_compare(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.Byte
         if (R.is_err[bool, str](ld)) { ret ld; }
         var subus: u16 = x64.PSUBUSW;
         if (w == 1) { subus = x64.PSUBUSB; }
-        emit_packed_op(subus, FLOAT_SCRATCH0, lhs, buf);
-        emit_vec_zero(FLOAT_SCRATCH1, buf);
-        emit_packed_op(pcmpeq_op(w), FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
-        emit_vec_all_ones(FLOAT_SCRATCH1, buf);
-        emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        val rs: R.Result[bool, str] = emit_packed_op(subus, FLOAT_SCRATCH0, lhs, buf);
+        if (R.is_err[bool, str](rs)) { ret rs; }
+        val rz: R.Result[bool, str] = emit_vec_zero(FLOAT_SCRATCH1, buf);
+        if (R.is_err[bool, str](rz)) { ret rz; }
+        val re: R.Result[bool, str] = emit_packed_op(pcmpeq_op(w), FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        if (R.is_err[bool, str](re)) { ret re; }
+        val ra: R.Result[bool, str] = emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+        if (R.is_err[bool, str](ra)) { ret ra; }
+        val rx: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        if (R.is_err[bool, str](rx)) { ret rx; }
         ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
     }
     # MIR_CMP_LE_U
     if (w == 4) {
         # dword: lhs <=u rhs = !(lhs >u rhs) = !(biased_lhs >s biased_rhs).
-        emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+        val ra: R.Result[bool, str] = emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+        if (R.is_err[bool, str](ra)) { ret ra; }
         emit_packed_shift_imm(x64.PSLLD, FLOAT_SCRATCH1, 31, buf);
         val ld: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
         if (R.is_err[bool, str](ld)) { ret ld; }
-        emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
-        emit_packed_op(x64.PXOR, FLOAT_SCRATCH1, rhs, buf);
-        emit_packed_op(x64.PCMPGTD, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
-        emit_vec_all_ones(FLOAT_SCRATCH1, buf);
-        emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        val rx0: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        if (R.is_err[bool, str](rx0)) { ret rx0; }
+        val rx1: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH1, rhs, buf);
+        if (R.is_err[bool, str](rx1)) { ret rx1; }
+        val rg: R.Result[bool, str] = emit_packed_op(x64.PCMPGTD, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        if (R.is_err[bool, str](rg)) { ret rg; }
+        val ra2: R.Result[bool, str] = emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+        if (R.is_err[bool, str](ra2)) { ret ra2; }
+        val rx2: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        if (R.is_err[bool, str](rx2)) { ret rx2; }
         ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
     }
     # byte/word: lhs <=u rhs = subus(lhs, rhs) == 0.
@@ -4260,9 +4286,12 @@ fun encode_vector_compare(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.Byte
     if (R.is_err[bool, str](ld)) { ret ld; }
     var subus2: u16 = x64.PSUBUSW;
     if (w == 1) { subus2 = x64.PSUBUSB; }
-    emit_packed_op(subus2, FLOAT_SCRATCH0, rhs, buf);
-    emit_vec_zero(FLOAT_SCRATCH1, buf);
-    emit_packed_op(pcmpeq_op(w), FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+    val rs2: R.Result[bool, str] = emit_packed_op(subus2, FLOAT_SCRATCH0, rhs, buf);
+    if (R.is_err[bool, str](rs2)) { ret rs2; }
+    val rz2: R.Result[bool, str] = emit_vec_zero(FLOAT_SCRATCH1, buf);
+    if (R.is_err[bool, str](rz2)) { ret rz2; }
+    val re2: R.Result[bool, str] = emit_packed_op(pcmpeq_op(w), FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+    if (R.is_err[bool, str](re2)) { ret re2; }
     ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
 }
 
@@ -6689,6 +6718,41 @@ test "mach.lang.target.isa.x64.encode.vec:mem_mem_16_stages_xmm14" {
     or (buf.data[3] != 0x30)  { bad = 1; }
     enc.buf_dnit(?buf);
     ret bad;
+}
+
+# emit_packed_op returns a diagnostic naming the shape rather than aborting the
+# process when its source operand is neither a register nor a memory operand
+# (#2208): every packed vector value is register- or aligned-slot-resident, so a
+# shape sema is assumed to exclude reaching the encoder must fail loudly, not
+# panic - matching every other x86-64 encoder failure path.
+test "mach.lang.target.isa.x64.encode.emit_packed_op:rejects_non_reg_mem_source" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var buf: enc.ByteBuf = enc.buf_init(?alloc);
+    val bad: isa.Operand = isa.make_imm(0, 16);
+    val r: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, bad, ?buf);
+    var fail: i32 = 0;
+    if (!R.is_err[bool, str](r)) { fail = 1; }
+    or (!str_equals(R.unwrap_err[bool, str](r), "encode: packed vector op source is not a register or aligned frame slot")) { fail = 1; }
+    enc.buf_dnit(?buf);
+    ret fail;
+}
+
+# emit_packed_op still succeeds for its two supported source shapes - a register
+# and a 16-byte-aligned memory operand - so the #2208 error path does not regress
+# the ordinary packed-op encoding it guards.
+test "mach.lang.target.isa.x64.encode.emit_packed_op:accepts_reg_and_mem_source" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var buf: enc.ByteBuf = enc.buf_init(?alloc);
+    val rr: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), ?buf);
+    val mem: isa.Operand = isa.make_mem(x64.RBP, -16, -1, 0, 16);
+    val rm: R.Result[bool, str] = emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, mem, ?buf);
+    var fail: i32 = 0;
+    if (R.is_err[bool, str](rr)) { fail = 1; }
+    or (R.is_err[bool, str](rm)) { fail = 1; }
+    enc.buf_dnit(?buf);
+    ret fail;
 }
 
 # the encoder's totality guard rejects an emission path that rendered no text

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -105,6 +105,23 @@ val SECTION_HEADER_SIZE: usize = 40;
 val SYMBOL_SIZE:         usize = 18;
 val RELOCATION_SIZE:     usize = 10;
 
+# /bigobj (ANON_OBJECT_HEADER_BIGOBJ), the extended object header a COFF writer
+# switches to once the classic header's 16-bit NumberOfSections (0xFFFF) is not
+# enough (#2147: per-function sections, #2125, roughly double the section count
+# of a large module). it replaces the classic header's first two fields (Machine,
+# NumberOfSections) with a fixed Sig1/Sig2 pair a reader tells the formats apart
+# on sight by: Sig1 is always IMAGE_FILE_MACHINE_UNKNOWN, a machine type no real
+# object ever carries, and Sig2 is the fixed 0xFFFF marker; the real machine type
+# moves to its own field. NumberOfSections becomes a 32-bit field (up to 2^31),
+# and the symbol table's SectionNumber field widens 16 -> 32 bits in step (a
+# symbol can name any section the header can), growing each symbol record from
+# 18 to 20 bytes (`BIGOBJ_SYMBOL_SIZE`) - see `write_sym_tail` / `read_sym_*`.
+val IMAGE_FILE_MACHINE_UNKNOWN: u16   = 0x0000;
+val BIGOBJ_SIG2:                u16   = 0xFFFF;
+val BIGOBJ_MIN_VERSION:         u16   = 2;
+val BIGOBJ_HEADER_SIZE:         usize = 56;
+val BIGOBJ_SYMBOL_SIZE:         usize = 20;
+
 # COFF file-header characteristics for a linked PE image
 val IMAGE_FILE_RELOCS_STRIPPED:     u16 = 0x0001;
 val IMAGE_FILE_EXECUTABLE_IMAGE:    u16 = 0x0002;
@@ -974,6 +991,98 @@ fun reloc_ovfl_message(itn: *intern.Interner, alloc: *A.Allocator, name_id: inte
     ret fallback;
 }
 
+# write the /bigobj ANON_OBJECT_HEADER_BIGOBJ ClassID
+# ({D1BAA1C7-BAEE-4d16-B45F-9E0E37DB40C1}), the fixed 16-byte value every
+# /bigobj header carries identifying the header shape to a reader
+fun write_bigobj_class_id(buf: *u8, off: usize) {
+    bin.write_u32_le(buf, off, 0xD1BAA1C7);
+    bin.write_u16_le(buf, off + 4, 0xBAEE);
+    bin.write_u16_le(buf, off + 6, 0x4D16);
+    buf[off + 8]  = 0xB4;
+    buf[off + 9]  = 0x5F;
+    buf[off + 10] = 0x9E;
+    buf[off + 11] = 0x0E;
+    buf[off + 12] = 0x37;
+    buf[off + 13] = 0xDB;
+    buf[off + 14] = 0x40;
+    buf[off + 15] = 0xC1;
+}
+
+# whether `buf` carries the ClassID every /bigobj header must carry at `off`;
+# a mismatch on an otherwise bigobj-shaped header (Sig1/Sig2 matched) means the
+# input is some other, unsupported extended-header format, not a genuine
+# ANON_OBJECT_HEADER_BIGOBJ
+fun bigobj_class_id_matches(buf: *u8, off: usize) bool {
+    if (bin.read_u32_le(buf, off) != 0xD1BAA1C7)      { ret false; }
+    if (bin.read_u16_le(buf, off + 4) != 0xBAEE)       { ret false; }
+    if (bin.read_u16_le(buf, off + 6) != 0x4D16)       { ret false; }
+    if (buf[off + 8]  != 0xB4)  { ret false; }
+    if (buf[off + 9]  != 0x5F)  { ret false; }
+    if (buf[off + 10] != 0x9E)  { ret false; }
+    if (buf[off + 11] != 0x0E)  { ret false; }
+    if (buf[off + 12] != 0x37)  { ret false; }
+    if (buf[off + 13] != 0xDB)  { ret false; }
+    if (buf[off + 14] != 0x40)  { ret false; }
+    if (buf[off + 15] != 0xC1)  { ret false; }
+    ret true;
+}
+
+# the COFF symbol-record stride in bytes: 18 (classic) or 20 (/bigobj, #2147) -
+# the only structural difference is a wider SectionNumber field (`write_sym_tail`
+# / `read_sym_section_number`); Name and Value keep their classic offsets
+fun sym_record_size(bigobj: bool) usize {
+    if (bigobj) { ret BIGOBJ_SYMBOL_SIZE; }
+    ret SYMBOL_SIZE;
+}
+
+# write one COFF symbol record's SectionNumber / Type / StorageClass /
+# NumberOfAuxSymbols tail at `sym_off`, in the classic 18-byte or /bigobj
+# 20-byte layout (#2147). Name (offset 0) and Value (offset 8) sit at the same
+# offset in both layouts and are written directly by the caller; only the tail
+# - SectionNumber (16 bits classic, 32 bits /bigobj) and everything after it -
+# shifts. an aux record occupies the same fixed-size slot but is written
+# through its own fields (`sym_off` advanced by `sym_record_size`), never this
+# helper.
+fun write_sym_tail(buf: *u8, sym_off: usize, bigobj: bool, sec_num: i32, ty: u16, scl: u8, naux: u8) {
+    if (bigobj) {
+        bin.write_u32_le(buf, sym_off + 12, sec_num::u32);
+        bin.write_u16_le(buf, sym_off + 16, ty);
+        buf[sym_off + 18] = scl;
+        buf[sym_off + 19] = naux;
+        ret;
+    }
+    bin.write_u16_le(buf, sym_off + 12, sec_num::u16);
+    bin.write_u16_le(buf, sym_off + 14, ty);
+    buf[sym_off + 16] = scl;
+    buf[sym_off + 17] = naux;
+}
+
+# a symbol record's (sign-extended) SectionNumber field, honouring the /bigobj
+# 32-bit width (#2147); the classic 16-bit field sign-extends through i16 first
+# so a negative special value (UNDEFINED/ABSOLUTE/DEBUG) round-trips correctly
+fun read_sym_section_number(buf: *u8, sym_off: usize, bigobj: bool) i32 {
+    if (bigobj) { ret bin.read_u32_le(buf, sym_off + 12)::i32; }
+    ret bin.read_u16_le(buf, sym_off + 12)::i16::i32;
+}
+
+# a symbol record's Type field, at its classic or /bigobj tail offset
+fun read_sym_type(buf: *u8, sym_off: usize, bigobj: bool) u16 {
+    if (bigobj) { ret bin.read_u16_le(buf, sym_off + 16); }
+    ret bin.read_u16_le(buf, sym_off + 14);
+}
+
+# a symbol record's StorageClass byte offset, classic or /bigobj
+fun sym_storage_class_off(sym_off: usize, bigobj: bool) usize {
+    if (bigobj) { ret sym_off + 18; }
+    ret sym_off + 16;
+}
+
+# a symbol record's NumberOfAuxSymbols byte offset, classic or /bigobj
+fun sym_naux_off(sym_off: usize, bigobj: bool) usize {
+    if (bigobj) { ret sym_off + 19; }
+    ret sym_off + 17;
+}
+
 # serialize a COMDAT-prepared object image to a relocatable x86-64 COFF object
 #
 # Writes the file header, section-header table, per-section raw data, per-section
@@ -1015,12 +1124,19 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
 
     # per-section relocation counts in one O(relocations) tally, reused by every
     # layout pass below instead of rescanning the whole relocation table per
-    # section. this also pins the COFF u16 narrowing: NumberOfSections and each
-    # section's relocation count are stored as u16, so a count above 0xFFFF would
-    # silently truncate into a well-formed-looking object with dropped sections or
-    # relocations. reject it (COFF's IMAGE_SCN_LNK_NRELOC_OVFL escape is not
-    # implemented) rather than corrupt the output. `counts` is freed on every exit.
-    if (num_secs > 0xFFFF) { ret R.err[bool, str]("coff: section count exceeds the COFF 0xFFFF limit"); }
+    # section. each section's relocation count is stored as a classic-header u16
+    # regardless of format (COFF's IMAGE_SCN_LNK_NRELOC_OVFL escape is not
+    # implemented), so a per-section count above 0xFFFF is rejected below rather
+    # than silently truncated. `counts` is freed on every exit.
+    #
+    # the file header's NumberOfSections field is what /bigobj widens (#2147): a
+    # module whose per-function sections (#2125) push it past the classic header's
+    # 16-bit field switches to the /bigobj header transparently - same object
+    # contents, no caller-visible flag - rather than failing the build. a count
+    # above the /bigobj spec's 2^31 field ceiling is rejected; nothing plausibly
+    # reaches it.
+    if (num_secs > 0x7FFFFFFF) { ret R.err[bool, str]("coff: section count exceeds the /bigobj 2^31 limit"); }
+    val bigobj: bool = num_secs > 0xFFFF;
     val res_counts: R.Result[*u32, str] = bin.reloc_counts(alloc, img);
     if (R.is_err[*u32, str](res_counts)) { ret R.err[bool, str](R.unwrap_err[*u32, str](res_counts)); }
     val counts: *u32 = R.unwrap_ok[*u32, str](res_counts);
@@ -1037,7 +1153,13 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
     # file layout: header, section headers, per-section raw data, per-section
     # relocation arrays, symbol table, string table. compute each region's file
     # offset up front so section headers can point at their data and relocs.
-    val secdata_base: usize = COFF_HEADER_SIZE + num_secs::usize * SECTION_HEADER_SIZE;
+    # `header_size` / `symbol_size` are the only two format-dependent strides
+    # (#2147): everything downstream that lays out or indexes these regions reads
+    # them, never the classic `COFF_HEADER_SIZE` / `SYMBOL_SIZE` constants directly.
+    var header_size: usize = COFF_HEADER_SIZE;
+    var symbol_size: usize = SYMBOL_SIZE;
+    if (bigobj) { header_size = BIGOBJ_HEADER_SIZE; symbol_size = BIGOBJ_SYMBOL_SIZE; }
+    val secdata_base: usize = header_size + num_secs::usize * SECTION_HEADER_SIZE;
 
     val res_doff: R.Result[*usize, str] = A.zallocate[usize](alloc, (num_secs + 1)::usize);
     if (R.is_err[*usize, str](res_doff)) {
@@ -1093,7 +1215,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
     # symbol is therefore `2*num_secs + i`.
     val symtab_offset: usize = cursor;
     val total_sym_records: u32 = num_secs * 2 + num_syms;
-    val symtab_size: usize = total_sym_records::usize * SYMBOL_SIZE;
+    val symtab_size: usize = total_sym_records::usize * symbol_size;
     val strtab_offset: usize = symtab_offset + symtab_size;
     val strtab_sz: usize = strtab_size(img);
     val total_file_size: usize = strtab_offset + strtab_sz;
@@ -1128,14 +1250,33 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
     }
     var buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
 
-    # file header.
-    bin.write_u16_le(buf, 0, IMAGE_FILE_MACHINE_AMD64);
-    bin.write_u16_le(buf, 2, num_secs::u16);
-    bin.write_u32_le(buf, 4, 0);
-    bin.write_u32_le(buf, 8, symtab_offset::u32);
-    bin.write_u32_le(buf, 12, total_sym_records);
-    bin.write_u16_le(buf, 16, 0);
-    bin.write_u16_le(buf, 18, 0);
+    # file header: the classic 20-byte IMAGE_FILE_HEADER, or the /bigobj 56-byte
+    # ANON_OBJECT_HEADER_BIGOBJ (#2147) once `num_secs` needs its 32-bit section
+    # count. SizeOfData is the payload size following the header - everything
+    # `total_file_size` counts past `header_size`.
+    if (bigobj) {
+        bin.write_u16_le(buf, 0, IMAGE_FILE_MACHINE_UNKNOWN);
+        bin.write_u16_le(buf, 2, BIGOBJ_SIG2);
+        bin.write_u16_le(buf, 4, BIGOBJ_MIN_VERSION);
+        bin.write_u16_le(buf, 6, IMAGE_FILE_MACHINE_AMD64);
+        bin.write_u32_le(buf, 8, 0);
+        write_bigobj_class_id(buf, 12);
+        bin.write_u32_le(buf, 28, (total_file_size - header_size)::u32);
+        bin.write_u32_le(buf, 32, 0);
+        bin.write_u32_le(buf, 36, 0);
+        bin.write_u32_le(buf, 40, 0);
+        bin.write_u32_le(buf, 44, num_secs);
+        bin.write_u32_le(buf, 48, symtab_offset::u32);
+        bin.write_u32_le(buf, 52, total_sym_records);
+    } or {
+        bin.write_u16_le(buf, 0, IMAGE_FILE_MACHINE_AMD64);
+        bin.write_u16_le(buf, 2, num_secs::u16);
+        bin.write_u32_le(buf, 4, 0);
+        bin.write_u32_le(buf, 8, symtab_offset::u32);
+        bin.write_u32_le(buf, 12, total_sym_records);
+        bin.write_u16_le(buf, 16, 0);
+        bin.write_u16_le(buf, 18, 0);
+    }
 
     # the string-table cursor starts past its own 4-byte length field; the
     # length is written last. long names (section + symbol) append here.
@@ -1144,7 +1285,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
     # section headers, recording each long section name in the string table once.
     s = 0;
     for (s < num_secs) {
-        val sh: usize = COFF_HEADER_SIZE + s::usize * SECTION_HEADER_SIZE;
+        val sh: usize = header_size + s::usize * SECTION_HEADER_SIZE;
         val sn: str = bin.resolve_name(img.interner, img.sections[s].name);
         if (name_in_strtab(sn)) {
             sec_name_offsets[s] = str_pos::u32;
@@ -1273,24 +1414,23 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
             write_inline_name(buf, sym_off, sn);
         }
         bin.write_u32_le(buf, sym_off + 8, 0);
-        bin.write_u16_le(buf, sym_off + 12, (s + 1)::u16);
-        bin.write_u16_le(buf, sym_off + 14, 0);
-        buf[sym_off + 16] = IMAGE_SYM_CLASS_STATIC;
-        buf[sym_off + 17] = 1;
-        sym_off = sym_off + SYMBOL_SIZE;
+        write_sym_tail(buf, sym_off, bigobj, (s + 1)::i32, 0, IMAGE_SYM_CLASS_STATIC, 1);
+        sym_off = sym_off + symbol_size;
 
         # aux section record: length (4), nreloc (2), nlnno (2), checksum (4),
-        # number (2), selection (1), 3 bytes pad. zeroed by the buffer alloc;
-        # fill length and reloc count. a COMDAT section sets `selection` to
-        # SELECT_ANY - the encoding the reader maps to a defined weak symbol. the
-        # `number` field stays 0: it names the associated section only for an
-        # associative COMDAT, which SELECT_ANY is not.
+        # number (2), selection (1), then pad to the record's full width. zeroed
+        # by the buffer alloc; fill length and reloc count. a COMDAT section sets
+        # `selection` to SELECT_ANY - the encoding the reader maps to a defined
+        # weak symbol. the `number` field stays 0: it names the associated
+        # section only for an associative COMDAT, which SELECT_ANY is not. the
+        # aux record's own fields sit at the same fixed offsets in both formats -
+        # only the trailing pad (and so the next record's start) changes width.
         bin.write_u32_le(buf, sym_off, img.sections[s].len);
         bin.write_u16_le(buf, sym_off + 4, counts[s]::u16);
         if (comdat != nil && comdat[s]) {
             buf[sym_off + 14] = IMAGE_COMDAT_SELECT_ANY;
         }
-        sym_off = sym_off + SYMBOL_SIZE;
+        sym_off = sym_off + symbol_size;
         s = s + 1;
     }
 
@@ -1306,18 +1446,19 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
         }
         bin.write_u32_le(buf, sym_off + 8, img.symbols[symi].offset);
 
-        var sec_num: i16 = IMAGE_SYM_UNDEFINED;
+        # the section number is 1-based; a section index wider than the classic
+        # 16-bit field only arises when `bigobj` is set, since `num_secs` itself
+        # would otherwise have failed the format check above.
+        var sec_num: i32 = IMAGE_SYM_UNDEFINED::i32;
         var sym_ty: u16 = 0;
         if (img.symbols[symi].section != of.SECTION_EXTERNAL
             && img.symbols[symi].section < num_secs) {
-            sec_num = (img.symbols[symi].section + 1)::i16;
+            sec_num = (img.symbols[symi].section + 1)::i32;
             sym_ty = symbol_type_for(img.sections[img.symbols[symi].section].kind);
         }
         if ((img.symbols[symi].flags & of.SYM_OBJ_FLAG_FUNCTION) != 0) {
             sym_ty = IMAGE_SYM_DTYPE_FUNCTION;
         }
-        bin.write_u16_le(buf, sym_off + 12, sec_num::u16);
-        bin.write_u16_le(buf, sym_off + 14, sym_ty);
 
         # global, weak, and external-undefined symbols are class EXTERNAL; a
         # local definition is class STATIC. a defined weak symbol is class
@@ -1330,9 +1471,8 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
             || (img.symbols[symi].flags & of.SYM_OBJ_FLAG_EXTERN) != 0) {
             scl = IMAGE_SYM_CLASS_EXTERNAL;
         }
-        buf[sym_off + 16] = scl;
-        buf[sym_off + 17] = 0;
-        sym_off = sym_off + SYMBOL_SIZE;
+        write_sym_tail(buf, sym_off, bigobj, sec_num, sym_ty, scl, 0);
+        sym_off = sym_off + symbol_size;
         symi = symi + 1;
     }
 
@@ -1410,18 +1550,21 @@ fun read_symbol_name(buf: *u8, buf_size: usize, so: usize, strtab_base: usize, s
 # toolchain is a strong definition and must not be weakened, so the reader gates
 # the weak flag on SELECT_ANY here. the section symbol is the STATIC record whose
 # SectionNumber is `sec_num` and value 0, carrying an aux section-definition
-# record; returns false when no such record is found
-fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32, sec_num: u32) bool {
+# record; returns false when no such record is found. `bigobj` selects the
+# classic 18-byte or /bigobj 20-byte record stride and SectionNumber width
+# (#2147) - it must match the format the caller parsed the header as.
+fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32, sec_num: u32, bigobj: bool) bool {
+    val rsize: usize = sym_record_size(bigobj);
     var ri: u32 = 0;
     for (ri < num_records) {
-        val so: usize = symtab_off + ri::usize * SYMBOL_SIZE;
-        val aux: u8 = buf[so + 17];
+        val so: usize = symtab_off + ri::usize * rsize;
+        val aux: u8 = buf[sym_naux_off(so, bigobj)];
         # the aux read is bounded by the symbol-table validation only when the aux
         # record is itself a counted record; a last record falsely claiming an aux
         # would read past the table, so require the aux index to be in range.
-        if (buf[so + 16] == IMAGE_SYM_CLASS_STATIC && aux >= 1 && (ri + 1) < num_records
-            && bin.read_u16_le(buf, so + 12)::u32 == sec_num && bin.read_u32_le(buf, so + 8) == 0) {
-            val ax: usize = so + SYMBOL_SIZE;
+        if (buf[sym_storage_class_off(so, bigobj)] == IMAGE_SYM_CLASS_STATIC && aux >= 1 && (ri + 1) < num_records
+            && read_sym_section_number(buf, so, bigobj) == sec_num::i32 && bin.read_u32_le(buf, so + 8) == 0) {
+            val ax: usize = so + rsize;
             ret buf[ax + 14] == IMAGE_COMDAT_SELECT_ANY;
         }
         ri = ri + 1 + aux::u32;
@@ -1445,20 +1588,51 @@ fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32,
 # out:      image to populate (its arrays are allocated here)
 # ret:      ok(true) on success, or an error string
 fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_size: usize, out: *of.ObjectImage) R.Result[bool, str] {
-    if (buf == nil || out == nil || buf_size < COFF_HEADER_SIZE) {
+    if (buf == nil || out == nil || buf_size < 4) {
         ret R.err[bool, str]("coff: object too small");
     }
-    if (bin.read_u16_le(buf, 0) != IMAGE_FILE_MACHINE_AMD64) {
-        ret R.err[bool, str]("coff: not an x86-64 object");
+    # /bigobj (#2147) replaces the classic header's first two fields (Machine,
+    # NumberOfSections) with a fixed Sig1/Sig2 pair: Sig1 is always
+    # IMAGE_FILE_MACHINE_UNKNOWN, a machine type no real object ever carries, and
+    # Sig2 is the fixed 0xFFFF marker. that pair is read (and only that pair) before
+    # either header shape is otherwise interpreted, so a 4-byte buffer is enough to
+    # tell the formats apart.
+    val sig1: u16 = bin.read_u16_le(buf, 0);
+    val sig2: u16 = bin.read_u16_le(buf, 2);
+    val bigobj: bool = sig1 == IMAGE_FILE_MACHINE_UNKNOWN && sig2 == BIGOBJ_SIG2;
+
+    var num_secs:     u32   = 0;
+    var symtab_off:   usize = 0;
+    var num_records:  u32   = 0;
+    var secthdr_base: usize = 0;
+    if (bigobj) {
+        if (buf_size < BIGOBJ_HEADER_SIZE) { ret R.err[bool, str]("coff: bigobj object too small"); }
+        if (bin.read_u16_le(buf, 4) < BIGOBJ_MIN_VERSION) {
+            ret R.err[bool, str]("coff: bigobj header version below the minimum");
+        }
+        if (bin.read_u16_le(buf, 6) != IMAGE_FILE_MACHINE_AMD64) {
+            ret R.err[bool, str]("coff: not an x86-64 object");
+        }
+        if (!bigobj_class_id_matches(buf, 12)) {
+            ret R.err[bool, str]("coff: bigobj header has an unrecognized ClassID");
+        }
+        num_secs     = bin.read_u32_le(buf, 44);
+        symtab_off   = bin.read_u32_le(buf, 48)::usize;
+        num_records  = bin.read_u32_le(buf, 52);
+        secthdr_base = BIGOBJ_HEADER_SIZE;
+    } or {
+        if (buf_size < COFF_HEADER_SIZE) { ret R.err[bool, str]("coff: object too small"); }
+        if (sig1 != IMAGE_FILE_MACHINE_AMD64) { ret R.err[bool, str]("coff: not an x86-64 object"); }
+        num_secs    = bin.read_u16_le(buf, 2)::u32;
+        symtab_off  = bin.read_u32_le(buf, 8)::usize;
+        num_records = bin.read_u32_le(buf, 12);
+        val opt_size: u16 = bin.read_u16_le(buf, 16);
+        secthdr_base = COFF_HEADER_SIZE + opt_size::usize;
     }
     if (itn == nil) { ret R.err[bool, str]("coff: no interner for parse"); }
     out.interner = itn;
 
-    val num_secs:     u32   = bin.read_u16_le(buf, 2)::u32;
-    val symtab_off:   usize = bin.read_u32_le(buf, 8)::usize;
-    val num_records:  u32   = bin.read_u32_le(buf, 12);
-    val opt_size:     u16   = bin.read_u16_le(buf, 16);
-    val secthdr_base: usize = COFF_HEADER_SIZE + opt_size::usize;
+    val symbol_size: usize = sym_record_size(bigobj);
 
     # validate the header-derived table extents against the input size before any
     # field is dereferenced: the section-header array and the symbol table (each a
@@ -1470,9 +1644,9 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
         num_secs::usize * SECTION_HEADER_SIZE, "coff: section header table out of bounds");
     if (R.is_err[bool, str](vsh)) { ret R.err[bool, str](R.unwrap_err[bool, str](vsh)); }
     val vsy: R.Result[bool, str] = bin.require_region(buf_size, symtab_off,
-        num_records::usize * SYMBOL_SIZE, "coff: symbol table out of bounds");
+        num_records::usize * symbol_size, "coff: symbol table out of bounds");
     if (R.is_err[bool, str](vsy)) { ret R.err[bool, str](R.unwrap_err[bool, str](vsy)); }
-    val strtab_base:  usize = symtab_off + num_records::usize * SYMBOL_SIZE;
+    val strtab_base:  usize = symtab_off + num_records::usize * symbol_size;
 
     out.alloc = alloc;
     out.section_count = 0;
@@ -1493,8 +1667,8 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
     var sym_n: u32 = 0;
     var ri: u32 = 0;
     for (ri < num_records) {
-        val so: usize = symtab_off + ri::usize * SYMBOL_SIZE;
-        val aux: u8 = buf[so + 17];
+        val so: usize = symtab_off + ri::usize * symbol_size;
+        val aux: u8 = buf[sym_naux_off(so, bigobj)];
         sym_n = sym_n + 1;
         ri = ri + 1 + aux::u32;
     }
@@ -1594,8 +1768,8 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
     ri = 0;
     for (ri < num_records) {
         rec_map[ri] = -1;
-        val so: usize = symtab_off + ri::usize * SYMBOL_SIZE;
-        val aux: u8 = buf[so + 17];
+        val so: usize = symtab_off + ri::usize * symbol_size;
+        val aux: u8 = buf[sym_naux_off(so, bigobj)];
 
         val rsyn: R.Result[str, str] = read_symbol_name(buf, buf_size, so, strtab_base, ?name_scratch[0]);
         if (R.is_err[str, str](rsyn)) {
@@ -1614,9 +1788,9 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
         out.symbols[idx].offset = bin.read_u32_le(buf, so + 8);
         out.symbols[idx].size = 0;
 
-        val sec_num: i16 = bin.read_u16_le(buf, so + 12)::i16;
-        val sym_ty:  u16 = bin.read_u16_le(buf, so + 14);
-        val scl:     u8  = buf[so + 16];
+        val sec_num: i32 = read_sym_section_number(buf, so, bigobj);
+        val sym_ty:  u16 = read_sym_type(buf, so, bigobj);
+        val scl:     u8  = buf[sym_storage_class_off(so, bigobj)];
 
         var flags: u32 = 0;
         if (scl == IMAGE_SYM_CLASS_EXTERNAL || scl == IMAGE_SYM_CLASS_WEAK_EXTERNAL) {
@@ -1625,7 +1799,7 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
         if (scl == IMAGE_SYM_CLASS_WEAK_EXTERNAL) { flags = flags | of.SYM_OBJ_FLAG_WEAK; }
         if (sym_ty == IMAGE_SYM_DTYPE_FUNCTION)   { flags = flags | of.SYM_OBJ_FLAG_FUNCTION; }
 
-        if (sec_num <= IMAGE_SYM_UNDEFINED) {
+        if (sec_num <= IMAGE_SYM_UNDEFINED::i32) {
             flags = flags | of.SYM_OBJ_FLAG_EXTERN;
             out.symbols[idx].section = of.SECTION_EXTERNAL;
         } or ((sec_num::u32 - 1) < num_secs) {
@@ -1648,7 +1822,7 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
             val dsh: usize = secthdr_base + out.symbols[idx].section::usize * SECTION_HEADER_SIZE;
             if ((bin.read_u32_le(buf, dsh + 36) & IMAGE_SCN_LNK_COMDAT) != 0
                 && comdat_select_any_for_section(buf, symtab_off, num_records,
-                                                 out.symbols[idx].section + 1)) {
+                                                 out.symbols[idx].section + 1, bigobj)) {
                 flags = flags | of.SYM_OBJ_FLAG_WEAK;
             }
         }
@@ -5352,4 +5526,100 @@ fun ts_write_section_name_field() u8 {
 test "mach.lang.target.of.coff.write_section_name_field:long_name_no_overflow" {
     if (ts_write_section_name_field() != 0) { ret 1; }
     ret 0;
+}
+
+# a section count past the classic COFF 0xFFFF field switches to the /bigobj
+# header transparently, and the reader round-trips it back (#2147). the
+# per-function-section model (#2125) is what makes this reachable on a large
+# real module; this test drives the same header/symbol-table format switch
+# directly rather than compiling tens of thousands of functions.
+test "mach.lang.target.of.coff.coff_serialize_image:bigobj_round_trip" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val n: u32 = 70000; # > 0xFFFF: unreachable through the classic header's u16 field
+    val rsec: R.Result[*of.Section, str] = A.zallocate[of.Section](?alloc, n::usize);
+    if (R.is_err[*of.Section, str](rsec)) { ret 1; }
+    val secs: *of.Section = R.unwrap_ok[*of.Section, str](rsec);
+    val text_name: intern.StrId = t_intern(?i, ".text");
+    var s: u32 = 0;
+    for (s < n) {
+        secs[s].name = text_name;
+        secs[s].kind = of.SK_TEXT;
+        secs[s].bytes = nil;
+        secs[s].len = 0;
+        secs[s].align = 1;
+        s = s + 1;
+    }
+
+    # one symbol in the first section and one in the last, so the widened
+    # SectionNumber field (#2147) round-trips a section index well past the
+    # classic 16-bit field's range, not just the header's own section count.
+    var syms: [2]of.Symbol;
+    syms[0].name = t_intern(?i, "first"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 0; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    syms[1].name = t_intern(?i, "last"); syms[1].section = n - 1; syms[1].offset = 0;
+    syms[1].size = 0; syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.interner = ?i;
+    img.name = t_intern(?i, "bigobj_test");
+    img.sections = secs; img.section_count = n;
+    img.symbols = ?syms[0]; img.symbol_count = 2;
+    img.relocations = nil; img.reloc_count = 0;
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_bigobj");
+    if (R.is_err[fs.TempFile, str](tf_r)) { A.deallocate[of.Section](?alloc, secs, n::usize); ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: R.Result[bool, str] = coff_serialize_image(?img, nil, tpath::*u8);
+    if (R.is_err[bool, str](em)) {
+        fs.temp_close_and_remove(?tf);
+        A.deallocate[of.Section](?alloc, secs, n::usize);
+        ret 1;
+    }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { A.deallocate[of.Section](?alloc, secs, n::usize); ret 1; }
+    val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+
+    # the classic header's Machine field can never legitimately be UNKNOWN, so
+    # this pair of checks is exactly the writer's / reader's own /bigobj
+    # detection signature (#2147).
+    var bad: i32 = 0;
+    if (bin.read_u16_le(buf.data, 0) != IMAGE_FILE_MACHINE_UNKNOWN) { bad = 1; }
+    or (bin.read_u16_le(buf.data, 2) != BIGOBJ_SIG2)                { bad = 1; }
+
+    var out: of.ObjectImage;
+    val pr: R.Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+    if (R.is_err[bool, str](pr))     { bad = 1; }
+    or (out.section_count != n)      { bad = 1; }
+    # the reader surfaces every COFF symbol record: the `n` section symbols the
+    # writer emits (one per section) plus the two image symbols above.
+    or (out.symbol_count != n + 2)   { bad = 1; }
+
+    if (bad == 0) {
+        var saw_first: bool = false;
+        var saw_last:  bool = false;
+        var si: u32 = 0;
+        for (si < out.symbol_count) {
+            if (out.symbols[si].name == syms[0].name) {
+                saw_first = true;
+                if (out.symbols[si].section != 0) { bad = 1; }
+            }
+            if (out.symbols[si].name == syms[1].name) {
+                saw_last = true;
+                if (out.symbols[si].section != n - 1) { bad = 1; }
+            }
+            si = si + 1;
+        }
+        if (!saw_first || !saw_last) { bad = 1; }
+    }
+
+    A.deallocate[of.Section](?alloc, secs, n::usize);
+    ret bad;
 }


### PR DESCRIPTION
## Summary

- **#2208** — `emit_packed_op` in `src/lang/target/isa/x64/encode.mach` panicked on an operand shape that is neither register nor memory. Determined the shape is **unreachable from source** (see reachability note below) and converted the panic to a named `R.err` return, matching every neighbouring encoder failure path.
- **#2147** — COFF had no `/bigobj` support, so the classic header's 16-bit `NumberOfSections` field (0xFFFF) capped per-function sections (#2125) on a sufficiently large Windows module. Implemented the `ANON_OBJECT_HEADER_BIGOBJ` variant (32-bit section count, widened symbol-table `SectionNumber`), switched to automatically once a module's section count exceeds 0xFFFF.

## #2208 reachability

Unreachable. Two independent gates both exclude a non-register/non-memory operand from ever reaching `emit_packed_op`:
- Sema (`infer_vector_binary`) rejects any scalar/vector operand mixing outright — no implicit broadcast/splat exists, so a constant can never appear on a vector op's operand.
- The auto-vectorizer's `all_operands_in_set` only admits an op into the vectorizable set when *every* operand is itself already a vectorized load — a constant, parameter, or induction-variable operand keeps the whole op out.
- `lower_value` only ever produces a `mir.MIR_OP_IMM` (the only MIR operand kind `mir_to_operand` doesn't map to a register/memory `isa.Operand`) for a `VAL_CONST_INT`/`FLOAT`/`NULL` IR value — and nothing in the compiler ever constructs one of those with a vector-shaped type (there's no way to fit 128 bits into the scalar `int_lit`/`float_lit` payload).

So the fix is error-path-only, confirmed by a byte-identical object diff (below).

## #2147 /bigobj

Constructed a real oversized module (33,000 distinct generic-function instantiations → 66,000 weak/COMDAT sections) and reproduced the pre-fix failure (`coff: section count exceeds the COFF 0xFFFF limit`) before implementing the fix; the same module now builds cleanly into a genuine `/bigobj`-formatted object (`Sig1=0x0000`, `Sig2=0xFFFF`, correct ClassID GUID, `NumberOfSections=66000`), and mach's own `coff_parse_object` round-trips it. The format switch is automatic and internal — no new CLI flag.

## Verification

- Built from source (PATH seed is 4.2.2; from-source binary used throughout).
- Three-generation self-host fixpoint: `A == B == C` (sha256 identical).
- `src/lang/target/isa/x64/encode.mach`: a program directly exercising every touched vector-encoder branch (float arith, int arith/bitwise, NOT, all compare families across lane widths) produces a **byte-identical** ELF object pre/post-fix, and a byte-identical Mach-O (darwin-aarch64) object (unaffected file, confirmed anyway).
- `src/lang/target/of/coff.mach`: a normal-sized Windows object is **byte-identical** pre/post-fix (classic-format path untouched); the new `/bigobj` path was verified both via a real 66,000-section compiled module and a dedicated 70,000-section round-trip unit test.
- New tests, each mutation-tested (guard removed → test fails with a shown count → guard restored):
  - `emit_packed_op:rejects_non_reg_mem_source`, `emit_packed_op:accepts_reg_and_mem_source`
  - `coff_serialize_image:bigobj_round_trip` (4 independent mutations: writer format-switch guard, reader format-detection guard, writer SectionNumber width, reader SectionNumber width)
- Suites: baseline **793/0** (790 + 3 new), mach-std **611/0** at pin `eff1e8e` (verified via `git rev-parse HEAD` against `mach.lock`, not a bare clone).
- `mach test --target windows-x86_64 --runner wine`: **793/0**.
- `int/run.sh --target windows` (via wine + binfmt_misc, unmodified harness): **44/44 PASS** (debug+release, including `surface/vectors`/`surface/vectorize`).
- `int/run.sh --target linux`: **44/44 PASS**.

Closes #2208
Closes #2147