### PR TITLE
fix(sema): apply the mixed-secrecy union rule to anonymous unions

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4511,6 +4511,29 @@ test "mach.lang.driver:secret_anon_uni_field_secrecy" {
     ret bad;
 }
 
+# secret flow typing: the union rule is DECLARATION-ORDER INDEPENDENT (#2224). It reads
+# the variants' field tables, so running it during decl inference made a variant naming a
+# record declared LATER unresolvable, and the comparison - which must fail closed - then
+# rejected an entirely public union purely for being written above its variants. Each
+# program below is asserted in both orders and must give the same verdict either way:
+# public variants clean, a genuinely mixed pair rejected, named and anonymous alike
+test "mach.lang.driver:secret_uni_secrecy_order_independent" {
+    var bad: i32 = 0;
+
+    # all-public variants: clean whether the union is written above or below them
+    if (!ut_sema_clean("uni U { a: S; b: P; }\nrec S { k: u32; }\nrec P { k: u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("rec S { k: u32; }\nrec P { k: u32; }\nuni U { a: S; b: P; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("fun f() u32 { var v: uni { a: S; b: P; }; ret v.b.k; }\nrec S { k: u32; }\nrec P { k: u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("rec S { k: u32; }\nrec P { k: u32; }\nfun f() u32 { var v: uni { a: S; b: P; }; ret v.b.k; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    # a genuinely mixed pair: rejected in both orders, never order-dependently missed
+    if (!ut_sema_rejects("uni U { a: S; b: P; }\nrec S { k: ^u32; }\nrec P { k: u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("rec S { k: ^u32; }\nrec P { k: u32; }\nuni U { a: S; b: P; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun f() u32 { var v: uni { a: S; b: P; }; ret v.b.k; }\nrec S { k: ^u32; }\nrec P { k: u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("rec S { k: ^u32; }\nrec P { k: u32; }\nfun f() u32 { var v: uni { a: S; b: P; }; ret v.b.k; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    ret bad;
+}
+
 # constant-time (#1646): floating point is variable-latency and gated by default, so
 # a secret operand of an FP add / sub / mul / compare is a sema error, while the same
 # ops on public floats are clean - the gate keys on secrecy, not shape

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4492,6 +4492,25 @@ test "mach.lang.driver:secret_uni_field_secrecy" {
     ret bad;
 }
 
+# secret flow typing: the same rule reaches an ANONYMOUS `uni { ... }`, which has no
+# declaration to hang the check on and so escaped it entirely - a part-secret part-public
+# inline union leaked the secret through the public variant (#2224). Covered inline, as a
+# record field, deep through a record variant, and under a pointer / array spine; the
+# uniformly-secret and uniformly-public inline unions, and an anonymous `rec` with a
+# secret field (which has no overlapping storage), must still compile
+test "mach.lang.driver:secret_anon_uni_field_secrecy" {
+    var bad: i32 = 0;
+    if (!ut_sema_rejects("fun f() u32 { var v: uni { a: ^u32; b: u32; }; v.a = 1; ret v.b; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("rec Box { v: uni { a: ^u32; b: u32; }; }\nfun main() i32 { ret 0; }\n"))                           { bad = 1; }
+    if (!ut_sema_rejects("rec S { k: ^u32; }\nrec P { k: u32; }\nrec Box { v: uni { a: S; b: P; }; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun f(p: *uni { a: ^u32; b: u32; }) u32 { ret p.b; }\nfun main() i32 { ret 0; }\n"))               { bad = 1; }
+    if (!ut_sema_rejects("fun f() u32 { var v: [2]uni { a: ^u32; b: u32; }; ret v[0].b; }\nfun main() i32 { ret 0; }\n"))    { bad = 1; }
+    if (!ut_sema_clean("fun f() ^u32 { var v: uni { a: ^u32; b: ^u32; }; ret v.b; }\nfun main() i32 { ret 0; }\n"))          { bad = 1; }
+    if (!ut_sema_clean("fun f() u32 { var v: uni { a: u32; b: u32; }; ret v.b; }\nfun main() i32 { ret 0; }\n"))             { bad = 1; }
+    if (!ut_sema_clean("fun f() u32 { var v: rec { a: ^u32; b: u32; }; ret v.b; }\nfun main() i32 { ret 0; }\n"))            { bad = 1; }
+    ret bad;
+}
+
 # constant-time (#1646): floating point is variable-latency and gated by default, so
 # a secret operand of an FP add / sub / mul / compare is a sema error, while the same
 # ops on public floats are clean - the gate keys on secrecy, not shape

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -124,10 +124,11 @@ pub fun sema(
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_decls));
     }
 
-    # the anonymous half of the mixed-secrecy union rule (#2224). Runs here, not in the
-    # type-resolution pass: the deep secrecy comparison reads the variants' field tables,
-    # which `infer_all_decls` has just built.
-    infer.check_anon_uni_secrecy(?sc);
+    # the mixed-secrecy union rule (#2224), for named and anonymous unions alike. Runs
+    # here rather than during decl inference or type resolution: the deep secrecy
+    # comparison reads the variants' field tables, which `infer_all_decls` has just
+    # finished building, so the rule no longer depends on declaration order.
+    infer.check_uni_secrecy_all(?sc);
 
     # install the field / type-comparison resolvers so `comptime.eval` can fold a
     # `$each $fields(T)` body's gates during inference, selecting the live arm

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -124,6 +124,11 @@ pub fun sema(
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_decls));
     }
 
+    # the anonymous half of the mixed-secrecy union rule (#2224). Runs here, not in the
+    # type-resolution pass: the deep secrecy comparison reads the variants' field tables,
+    # which `infer_all_decls` has just built.
+    infer.check_anon_uni_secrecy(?sc);
+
     # install the field / type-comparison resolvers so `comptime.eval` can fold a
     # `$each $fields(T)` body's gates during inference, selecting the live arm
     # instead of type-checking every arm against the wrong field type (#1473,

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -169,7 +169,6 @@ fun infer_nominal_uni(sc: *context.SemaContext, did: id.DeclId, name_span: token
     val ty: type.TypeId = R.unwrap_ok[type.TypeId, str](tr);
 
     build_field_table(sc, ty, u.fields_start, u.fields_len);
-    check_uni_secrecy(sc, u.fields_start, u.fields_len);
     record_type_align(sc, did, ty);
     ret ty;
 }
@@ -205,23 +204,46 @@ fun check_uni_secrecy(sc: *context.SemaContext, fields_start: u32, fields_len: u
     }
 }
 
-# enforce the mixed-secrecy union rule on every ANONYMOUS `uni { ... }` in the module
-# (#2224)
+# enforce the mixed-secrecy union rule on every union the module forms - named
+# declarations and anonymous `uni { ... }` type nodes alike (#2224)
 #
-# An inline union has no declaration, so `infer_nominal_uni`'s check never reaches it and
-# `uni { a: ^u32; b: u32 }` aliases secret storage under a public overlay exactly as the
-# named twin the declaration check rejects. Which syntactic form declared the union is
-# irrelevant to the channel the rule closes, so every `uni` type node is subject to it.
+# An inline union has no declaration, so a check hung off `infer_nominal_uni` never
+# reached it and `uni { a: ^u32; b: u32 }` aliased secret storage under a public overlay
+# exactly as the named twin that check rejects. Which syntactic form declared the union
+# is irrelevant to the channel the rule closes.
 #
-# Driven off the syntax, once per `uni` node, rather than from `resolve_type_anon`: that
-# resolver runs once per REFERENCE to a shape (a `[2]uni {...}` resolves it both nested
-# and again at its own index), which would report one site two or three times. It also
-# runs before any nominal's field table exists, where the deep comparison fails closed on
-# an unresolvable variant and rejects a legal all-public `uni { a: S; b: P }`. Hence
-# after `infer_all_decls`, with the module's field tables complete.
+# The whole rule runs here, after `infer_all_decls`, for two reasons the obvious earlier
+# placements get wrong. Inside `infer_all_decls` a variant naming a record declared LATER
+# has no field table yet, and the deep comparison fails closed on it - which is why the
+# named form used to reject an all-public `uni U { a: S; b: P }` written above `S` and
+# accept the very same union written below it. And in `resolve_type_anon` the check would
+# fire once per REFERENCE to a shape (a `[2]uni {...}` resolves it both nested and again
+# at its own index), reporting one site two or three times, on top of the same
+# missing-table problem. Here every field table is complete and every site is visited
+# exactly once, so the rule is declaration-order independent.
+#
+# Named declarations are filtered by `decl_type`, which `infer_all_decls` wrote for the
+# decls it actually typed: an untaken comptime-`$if` arm is left at TYPE_NIL and stays
+# unchecked, matching the rule that a discarded branch is not compiled.
 # ---
 # sc: sema context
-pub fun check_anon_uni_secrecy(sc: *context.SemaContext) {
+pub fun check_uni_secrecy_all(sc: *context.SemaContext) {
+    if (sc.decl_type != nil) {
+        var d: u32 = 0;
+        for (d < sc.a.decl_len::u32) {
+            if (sc.decl_type[d] != type.TYPE_NIL) {
+                val d_opt: O.Option[*decl.Decl] = ast.get_decl(sc.a, d);
+                if (O.is_some[*decl.Decl](d_opt)) {
+                    val dd: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
+                    if (dd.kind == decl.DECL_KIND_UNI) {
+                        check_uni_secrecy(sc, dd.data.uni_.fields_start, dd.data.uni_.fields_len);
+                    }
+                }
+            }
+            d = d + 1;
+        }
+    }
+
     var i: u32 = 0;
     for (i < sc.a.type_len::u32) {
         val t_opt: O.Option[*atype.Type] = ast.get_type(sc.a, i);

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -205,6 +205,36 @@ fun check_uni_secrecy(sc: *context.SemaContext, fields_start: u32, fields_len: u
     }
 }
 
+# enforce the mixed-secrecy union rule on every ANONYMOUS `uni { ... }` in the module
+# (#2224)
+#
+# An inline union has no declaration, so `infer_nominal_uni`'s check never reaches it and
+# `uni { a: ^u32; b: u32 }` aliases secret storage under a public overlay exactly as the
+# named twin the declaration check rejects. Which syntactic form declared the union is
+# irrelevant to the channel the rule closes, so every `uni` type node is subject to it.
+#
+# Driven off the syntax, once per `uni` node, rather than from `resolve_type_anon`: that
+# resolver runs once per REFERENCE to a shape (a `[2]uni {...}` resolves it both nested
+# and again at its own index), which would report one site two or three times. It also
+# runs before any nominal's field table exists, where the deep comparison fails closed on
+# an unresolvable variant and rejects a legal all-public `uni { a: S; b: P }`. Hence
+# after `infer_all_decls`, with the module's field tables complete.
+# ---
+# sc: sema context
+pub fun check_anon_uni_secrecy(sc: *context.SemaContext) {
+    var i: u32 = 0;
+    for (i < sc.a.type_len::u32) {
+        val t_opt: O.Option[*atype.Type] = ast.get_type(sc.a, i);
+        if (O.is_some[*atype.Type](t_opt)) {
+            val t: *atype.Type = O.unwrap[*atype.Type](t_opt);
+            if (t.kind == atype.TYPE_KIND_UNI) {
+                check_uni_secrecy(sc, t.data.uni_.fields_start, t.data.uni_.fields_len);
+            }
+        }
+        i = i + 1;
+    }
+}
+
 # fold an `#[align(...)]` decorator on `did` and record the resulting alignment
 # for nominal TypeId `ty` on the session
 #


### PR DESCRIPTION
Closes #2224.

`check_uni_secrecy` fired from exactly one place — `infer_nominal_uni` — so only a **named** `uni` declaration was subject to the mixed-secrecy rule. An inline `uni { ... }` resolves through `resolve_type_anon`, which builds a field table and nothing else, so the rule never reached it.

Reproduced on a from-source `dev` build (not the 4.2.2 seed):

```mach
var v: uni { a: ^u32; b: u32; };
v.a = 1337;
val leaked: u32 = v.b;   # exit 57 = 1337 & 0xFF
```

Six distinct anonymous shapes leaked on `dev`, not one: inline, as a record field, deep through a record variant, behind a pointer, in an array, and as a function parameter.

## Placement

The rule runs as one pass over the module's unions after `infer_all_decls`, rather than at the site the issue names. Both earlier placements were built and measured:

- **`resolve_type_anon`** — runs once per *reference* to a shape, so `[2]uni {...}` reported one site twice and `*uni {...}` three times.
- **during type resolution or decl inference** — the deep secrecy comparison reads the variants' field tables, which do not exist yet. It fails closed and rejects a legal all-public `uni { a: S; b: P }`.

## Commits

1. **the leak fix** — the rule reaches anonymous unions.
2. **tests** for the anonymous rule, including the over-rejection controls.
3. **declaration-order independence** — a pre-existing false positive found while measuring the placement. On `dev`, `uni U { a: S; b: P; }` written *above* two entirely public records is rejected, while the identical union written *below* them compiles. Both forms now run in the one pass with every field table complete. This changes what compiles; the newly-accepted set is characterised exactly in the verification comment.

## Not covered here

`Result[^u32, u32]` is **not** reachable from the anonymous side — its variants `T` and `E` agree at the declaration, and the violation exists only after substitution, which does not re-resolve the AST. That is #2225's half, whose check keys on the instance's template nominal being a `uni` and so covers anonymous and named generic unions at one site.

Probing it surfaced #2239: an anonymous `uni` inside a generic record loses union layout in every instance, which currently **masks** #2225's hole.

## Verification

Reproduction, rejections, over-rejection controls, mutation tests, suites (mach 806/0, mach-std 611/0 @ `eff1e8e`), byte-identity and the three-generation fixpoint are in the [verification comment](https://github.com/briar-systems/mach/pull/2238#issuecomment-5076688699).
