### PR TITLE
fix: regalloc dead-mov sweep hygiene + int qemu binary naming

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -40,17 +40,32 @@
 _produce_lib_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 _flat_loader_bin=
 
+# qemu_bin <target> — the qemu-user interpreter for a harness target, keyed by ISA
+# rather than sliced from the name. linux-riscv64's name suffix happens to match its
+# qemu-user binary (qemu-riscv64), but linux-arm64's does not (qemu-aarch64, never
+# qemu-arm64), and the bare `linux` / `windows` legs carry no ISA suffix at all. keep
+# in sync with the ISA each int/*/mach.toml's `[target.<leg>]` declares when a
+# targets.conf row is added.
+qemu_bin() {
+    case "$1" in
+        linux|windows)              echo qemu-x86_64 ;;
+        linux-arm64|darwin-aarch64) echo qemu-aarch64 ;;
+        linux-riscv64)              echo qemu-riscv64 ;;
+        *) echo "int: no qemu interpreter mapping for target '$1'" >&2; return 1 ;;
+    esac
+}
+
 # produce_exec <runmode> <target> <binary>
-# runs the built binary and forwards its stdout as the observable. native mode
-# runs it directly; qemu mode runs it under the matching qemu-user (the target's
-# arch is its name suffix, e.g. linux-riscv64 -> qemu-riscv64). the producer's
-# exit status is the program's, so a crash (nonzero) fails the case.
+# runs the built binary and forwards its stdout as the observable. native mode runs
+# it directly; qemu mode runs it under the matching qemu-user (qemu_bin). the
+# producer's exit status is the program's, so a crash (nonzero) fails the case.
 produce_exec() {
     runmode=$1
     target=$2
     bin=$3
     if [ "$runmode" = "qemu" ]; then
-        "qemu-${target##*-}" "$bin"
+        interp=$(qemu_bin "$target") || return 1
+        "$interp" "$bin"
     else
         "$bin"
     fi
@@ -68,7 +83,8 @@ produce_relro_fault() {
     target=$2
     bin=$3
     if [ "$runmode" = "qemu" ]; then
-        "qemu-${target##*-}" "$bin" >/dev/null 2>&1
+        interp=$(qemu_bin "$target") || return 1
+        "$interp" "$bin" >/dev/null 2>&1
     else
         "$bin" >/dev/null 2>&1
     fi

--- a/int/run.sh
+++ b/int/run.sh
@@ -202,7 +202,8 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
                 continue
             fi
             if [ "$runmode" = qemu ]; then
-                buildcc="qemu-${target##*-} $tmp/selfhostcc"
+                interp=$(qemu_bin "$target") || exit 1
+                buildcc="$interp $tmp/selfhostcc"
             else
                 buildcc=$tmp/selfhostcc
             fi

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -3995,6 +3995,52 @@ test "mach.lang.be.codegen.regalloc.is_dead_mov:physical_dest_and_read_guards" {
     ret 0;
 }
 
+# `is_dead_mov` (the predicate, pinned above) has never had a test that actually
+# calls `sweep_dead_movs` and checks an instruction is GONE from the block - #2240.
+# This pins the pass end to end, including its documented fixpoint: deleting
+# `v1 <- v0` (v1 never read) removes v0's only read, so v0's own now-dead def
+# (`v0 <- preg 3`) is swept in the very same call, not left for a hypothetical
+# second one. The live `v2 <- preg 5` / `preg 6 <- v2` pair proves the sweep is
+# selective, not merely destructive.
+test "mach.lang.be.codegen.regalloc.sweep_dead_movs:retallies_to_a_fixpoint" {
+    var t: target.Target;
+    if (!t_target(?t)) { ret 1; }
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    #   v0 <- preg 3        (a value arriving in a fixed register)
+    #   v1 <- v0            (a copy whose destination is never read: dead)
+    #   v2 <- preg 5        (a live value ...)
+    #   preg 6 <- v2        (... read here, so it and its def survive)
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 3);
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 4);
+    t_mov(?alloc, ?b, 0, mir.op_vreg(0), mir.op_preg(3));
+    t_mov(?alloc, ?b, 1, mir.op_vreg(1), mir.op_vreg(0));
+    t_mov(?alloc, ?b, 2, mir.op_vreg(2), mir.op_preg(5));
+    t_mov(?alloc, ?b, 3, mir.op_preg(6), mir.op_vreg(2));
+    f.blocks      = ?b;
+    f.block_count = 1;
+    f.block_cap   = 1;
+
+    var slots: [3]bool;
+    slots[0] = false; slots[1] = false; slots[2] = false;
+    var ctx: AllocCtx;
+    t_ctx(?ctx, ?alloc, ?f, ?slots[0]);
+
+    if (R.is_err[bool, str](sweep_dead_movs(?t, ?ctx))) { ret 1; }
+
+    # both dead movs are gone; only the live pair remains, in order.
+    if (b.instr_count != 2) { ret 1; }
+    if (b.instrs[0].operands[0].kind != mir.MIR_OP_VREG)  { ret 1; }
+    if (b.instrs[0].operands[0].vreg != 2)                { ret 1; }
+    if (b.instrs[1].operands[0].kind != mir.MIR_OP_PREG)  { ret 1; }
+    if (b.instrs[1].operands[0].preg != 6)                { ret 1; }
+
+    ret 0;
+}
+
 # drive the full allocator over a multi-block function whose GP values live across
 # block boundaries, then read the result. a loop back edge plus an if/else keep
 # `a`, `b`, and `acc` live across edges, and `b < 0` is a signed compare of a


### PR DESCRIPTION
## Summary
- #2241: `int/run.sh` (and `int/lib/produce.sh`, which it sources) derived the qemu-user interpreter as `qemu-${target##*-}`, which is wrong for `linux-arm64` (`qemu-arm64` does not exist; `qemu-aarch64` does) and for the suffix-less `linux` / `windows` legs. Replaced with an explicit `qemu_bin` ISA lookup shared by all three call sites (run.sh's self-host cross-build, produce.sh's `exec` and `relro-fault` producers). `linux-riscv64`'s real qemu leg is unaffected; `targets.conf` untouched, so CI behavior is unchanged.
- #2240: `sweep_dead_movs` in `be/codegen/regalloc.mach` had zero coverage of the pass itself — only its `is_dead_mov` predicate was pinned, so disabling the sweep's call in `alloc_function` broke no test. Checked reachability first (rather than assuming): an instrumented self-build of the compiler across every target × profile swept 512-1882 dead moves per leg (14270 total), so copy coalescing (#2203), which runs *after* the sweep, never made it unreachable — it is live and load-bearing. Added a test driving `sweep_dead_movs` directly over a two-copy chain that pins its documented retally-to-fixpoint behavior, alongside a live pair that must survive. Mutation-verified: a no-op stand-in for the sweep fails exactly this one new test out of 857, nothing else.

## Test plan
- [x] `int/run.sh --target linux-arm64` runs under qemu on this x86-64 host (verified via a scratch, uncommitted `targets.conf` copy) — fails with `qemu-arm64: command not found` before the fix, passes after.
- [x] `int/run.sh --target linux-riscv64` (real qemu leg): full surface + regression suite green, including the 1852 self-host case (exercises run.sh's own `qemu_bin` call site).
- [x] Mutation test: sweep_dead_movs stubbed to a no-op fails exactly the new test (856/857), restored, full suite green again (857/0).
- [x] `mach test .` 857 passed / 0 failed; `dep/mach-std` (pinned `eff1e8e`) 611 passed / 0 failed.
- [x] Three-generation self-host fixpoint: B == C byte-identical on all 6 targets x 2 profiles (A != B expected — seed predates these changes).

Closes #2240
Closes #2241