### PR TITLE
fix(asm): a notification claims a declared byte range, not everything outstanding

### DIFF
--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -342,11 +342,20 @@ pub rec ByteBuf {
 # MIR macro-op expands to several machine instructions and collapsing them is
 # exactly the divergence this replaced (#2187).
 #
-# `accounted` is the totality guard. It trails `ByteBuf.len` as of the last
-# notification, so any byte an ISA appends without notifying leaves the two
-# unequal; `sink_unaccounted` reports the gap and the caller fails loudly naming
-# the opcode responsible. A printer that silently skips an instruction is
-# therefore not expressible - the bytes it failed to render are still counted.
+# `accounted` is the totality guard: the end of the last byte range an instruction
+# notification claimed. A notification claims `[start, ByteBuf.len)` and DECLARES its
+# own `start`, which must be exactly where the previous claim ended - so the claims
+# tile the text, each byte belongs to exactly one instruction, and a notification an
+# emitting path never sent cannot be absorbed by the next one (#2250). A claim that
+# does not begin at the cursor leaves the cursor where it is, so the bytes it skipped
+# stay unclaimed and `sink_unaccounted` reports them; the caller fails loudly naming
+# the opcode responsible. A printer that silently skips an instruction is therefore
+# not expressible - the bytes it failed to render are still counted.
+#
+# Declaring the start is what a running high-water mark could not do. `accounted` used
+# to be assigned `ByteBuf.len` outright, which made a claim cover everything back to
+# the last one: a dropped notification in the MIDDLE of a sequence was swallowed by
+# its successor, and only a miss at the very END of a MIR opcode was caught.
 #
 # `mi` is the MIR instruction currently being encoded, set by the ISA around each
 # dispatch. A renderer reads it only to name what the machine operand cannot carry
@@ -355,7 +364,7 @@ pub rec ByteBuf {
 #
 # A notification may be RENDERED IMMEDIATELY or BUFFERED. An architecture whose
 # instruction's first form is its last renders on the spot and needs nothing more
-# than `sink_account`. One whose final form is settled later - RISC-V, whose branch
+# than `sink_claim`. One whose final form is settled later - RISC-V, whose branch
 # relaxation rewrites an over-range conditional into an inverted guard plus a jump
 # after the whole function is laid out - buffers its notifications as `AsmNote`s
 # here, lets the relaxation pass edit them exactly as it edits the text, and renders
@@ -373,7 +382,7 @@ pub rec ByteBuf {
 # allocates.
 # ---
 # out:        destination writer for the rendered text
-# accounted:  `ByteBuf.len` as of the last instruction notification
+# accounted:  end of the last byte range an instruction notification claimed
 # failed:     a write error occurred; the first one is kept in `err`
 # err:        the first write error, empty until `failed`
 # mi:         the MIR instruction being encoded, for symbol / label annotation
@@ -382,6 +391,8 @@ pub rec ByteBuf {
 # note_count: number of buffered notifications
 # note_cap:   capacity of `notes`
 # note_insts: how many of the buffered notifications are instructions
+# claims:     instruction notifications accepted, buffered and streamed alike
+# refused:    notifications whose declared start was not where the last claim ended
 pub rec AsmSink {
     out:        *writer.Writer;
     accounted:  usize;
@@ -393,6 +404,8 @@ pub rec AsmSink {
     note_count: u32;
     note_cap:   u32;
     note_insts: u32;
+    claims:     u32;
+    refused:    u32;
 }
 
 # what one buffered notification stands for
@@ -440,6 +453,8 @@ pub fun sink_init(out: *writer.Writer, interner: *intern.Interner) AsmSink {
     s.note_count = 0;
     s.note_cap   = 0;
     s.note_insts = 0;
+    s.claims     = 0;
+    s.refused    = 0;
     ret s;
 }
 
@@ -456,11 +471,12 @@ pub fun note_blank() AsmNote {
     ret n;
 }
 
-# buffer one notification, marking the bytes it covers as accounted
+# buffer one notification, claiming the bytes it covers
 #
-# An instruction note advances the totality guard exactly as an immediate render
-# does: the guard compares `accounted` against the buffer length, so a byte no
-# notification covers is still reported whether the ISA streams or buffers.
+# An instruction note claims its byte range exactly as an immediate render does, and
+# it needs no separate start: `AsmNote.off` is already the instruction's first byte,
+# so the note itself declares where its claim begins and the tiling check falls out
+# of the buffered path for free.
 # ---
 # buf: the encoder byte sink carrying the assembly sink
 # n:   the notification to buffer
@@ -476,7 +492,7 @@ pub fun note_push(buf: *ByteBuf, n: *AsmNote) R.Result[bool, str] {
     s.note_count = s.note_count + 1;
     if (n.kind == ASM_NOTE_INST) {
         s.note_insts = s.note_insts + 1;
-        sink_account(buf);
+        sink_claim(buf, n.off::usize);
     }
     ret R.ok[bool, str](true);
 }
@@ -485,16 +501,27 @@ pub fun note_push(buf: *ByteBuf, n: *AsmNote) R.Result[bool, str] {
 #
 # The relaxation counterpart of writing an instruction into a gap `insert_text` just
 # opened: the new word is a real emitted instruction and must be rendered as one.
+#
+# Its bytes did not arrive at the end of the text, so this is not a sequential claim
+# and the tiling cursor cannot check a start against it. What it checks instead is
+# just as exact: the gap the caller opened must be exactly the `nbytes` this
+# notification covers, so the cursor and the text end the operation back in step. An
+# insertion that grew the text by more than one notification's worth, or a
+# notification for a gap nobody opened, breaks the equality.
 # ---
-# buf: the encoder byte sink carrying the assembly sink
-# idx: the note the new one follows
-# n:   the notification to insert (its `off` is already set)
-# ret: true on success, or an allocation error
-pub fun note_insert_after(buf: *ByteBuf, idx: u32, n: *AsmNote) R.Result[bool, str] {
+# buf:    the encoder byte sink carrying the assembly sink
+# idx:    the note the new one follows
+# n:      the notification to insert (its `off` is already set)
+# nbytes: the size of the instruction inserted into the text
+# ret:    true on success, or an allocation error
+pub fun note_insert_after(buf: *ByteBuf, idx: u32, n: *AsmNote, nbytes: u32) R.Result[bool, str] {
     if (!sink_active(buf)) { ret R.ok[bool, str](true); }
     val s: *AsmSink = buf.asm;
     if (idx >= s.note_count) {
         ret R.err[bool, str]("--emit-asm: an instruction notification was inserted after an unknown one");
+    }
+    if (n.kind == ASM_NOTE_INST && s.accounted + nbytes::usize != buf.len) {
+        ret R.err[bool, str]("--emit-asm: an inserted instruction notification does not cover the text gap that was opened for it");
     }
     if (s.note_count >= s.note_cap) {
         val res_grow: R.Result[bool, str] = grow_notes(s, buf.alloc);
@@ -510,7 +537,8 @@ pub fun note_insert_after(buf: *ByteBuf, idx: u32, n: *AsmNote) R.Result[bool, s
     s.note_count = s.note_count + 1;
     if (n.kind == ASM_NOTE_INST) {
         s.note_insts = s.note_insts + 1;
-        sink_account(buf);
+        s.claims     = s.claims + 1;
+        s.accounted  = buf.len;
     }
     ret R.ok[bool, str](true);
 }
@@ -568,12 +596,10 @@ pub fun notes_reset(buf: *ByteBuf) {
 
 # how many buffered notifications are instructions
 #
-# A fixed-width ISA turns this into an EXACT totality check - emitted bytes must
-# equal the instruction count times the instruction width - which is strictly
-# stronger than the byte-accounting `sink_unaccounted` a variable-width ISA can
-# manage. Byte accounting alone lets a later notification absorb an earlier missing
-# one, because `accounted` only ever moves forward to the buffer length; counting
-# instructions does not.
+# A fixed-width ISA turns this into a whole-function totality check - emitted bytes
+# must equal the instruction count times the instruction width - which covers the
+# out-of-sequence growth a relaxation pass produces, where the per-claim tiling in
+# `sink_claim` has no sequential cursor to check against.
 # ---
 # buf: the encoder byte sink
 # ret: the instruction-notification count, or 0 when no sink is buffering
@@ -638,29 +664,62 @@ pub fun sink_active(buf: *ByteBuf) bool {
     ret !buf.asm.failed;
 }
 
-# mark every byte written so far as rendered
+# claim `[start, ByteBuf.len)` for one instruction notification
 #
-# Called by an ISA immediately after it renders one emitted instruction.
+# Called by an ISA immediately after it renders one emitted instruction, with the
+# `.text` offset that instruction's first byte went to. Declaring the start is the
+# whole of the guard: the claim is accepted only when it begins exactly where the
+# previous one ended, so consecutive notifications tile the text and no notification
+# can stand for two instructions.
+#
+# A claim that does not begin at the cursor is REFUSED - the cursor stays put, so the
+# bytes between it and this claim remain unclaimed and `sink_unaccounted` keeps
+# reporting them until the ISA's own guard fails the build naming the opcode. A claim
+# that covers no bytes is refused for the same reason: a notification that describes
+# an instruction the encoder did not emit is the mirror image of the same defect and
+# would otherwise leave the counts looking healthy.
 # ---
-# buf: the encoder byte sink whose sink is advanced
-pub fun sink_account(buf: *ByteBuf) {
+# buf:   the encoder byte sink whose sink is advanced
+# start: `.text` offset of the notified instruction's first byte
+pub fun sink_claim(buf: *ByteBuf, start: usize) {
     if (buf == nil || buf.asm == nil) { ret; }
-    buf.asm.accounted = buf.len;
+    val s: *AsmSink = buf.asm;
+    if (start != s.accounted || buf.len <= start) {
+        s.refused = s.refused + 1;
+        ret;
+    }
+    s.accounted = buf.len;
+    s.claims    = s.claims + 1;
 }
 
-# the number of emitted bytes no instruction notification has covered
+# the number of instruction notifications this sink accepted
 #
-# Non-zero means an ISA appended bytes without rendering them, so the artifact
-# would under-report the code the encoder produced. The caller turns this into a
-# loud error naming the offending opcode rather than emitting a short `.s`.
-#
-# `accounted` is only ever assigned `buf.len`, and the text buffer only grows
-# while a function is being encoded, so `accounted <= buf.len` holds throughout.
-# The equal case is the common one (everything rendered); the comparison is
-# written `<=` rather than `==` because the subtraction below is unsigned.
+# Counts buffered and streamed claims alike, so a caller that needs "did this
+# emitting path notify at all" can take a difference across it on every target,
+# including one whose printer renders on the spot and buffers nothing.
 # ---
 # buf: the encoder byte sink
-# ret: the unaccounted byte count, or 0 when the sink is inactive
+# ret: the accepted-claim count, or 0 when no sink is attached
+pub fun sink_claims(buf: *ByteBuf) u32 {
+    if (!sink_active(buf)) { ret 0; }
+    ret buf.asm.claims;
+}
+
+# the number of emitted bytes no instruction notification has claimed
+#
+# Non-zero means an ISA appended bytes without rendering them, or rendered them under
+# a notification that did not begin where the last one ended, so the artifact would
+# under-report the code the encoder produced. The caller turns this into a loud error
+# naming the offending opcode rather than emitting a short `.s`.
+#
+# `accounted` is only ever advanced to `buf.len` by an accepted claim, and the text
+# buffer only grows while a function is being encoded, so `accounted <= buf.len`
+# holds throughout. The equal case is the common one (everything claimed); the
+# comparison is written `<=` rather than `==` because the subtraction below is
+# unsigned.
+# ---
+# buf: the encoder byte sink
+# ret: the unclaimed byte count, or 0 when the sink is inactive
 pub fun sink_unaccounted(buf: *ByteBuf) usize {
     if (!sink_active(buf)) { ret 0; }
     if (buf.len <= buf.asm.accounted) { ret 0; }
@@ -977,6 +1036,16 @@ pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *target.Target, m: *mir.MirM
         notes_free(?st.buf);
         state_dnit(?st);
         ret R.err[EncoderOutput, str](sink.err);
+    }
+    # a refused claim normally leaves a byte gap the ISA's own per-opcode guard has
+    # already failed the build over, naming it. the one shape that leaves no gap is a
+    # notification re-claiming bytes an earlier one covered - "exactly one" broken from
+    # the other side - so the count is the backstop that keeps it from passing.
+    if (sink.refused > 0) {
+        notes_free(?st.buf);
+        state_dnit(?st);
+        ret R.err[EncoderOutput, str](
+            "--emit-asm: an instruction notification claimed a byte range that does not begin where the previous one ended");
     }
     notes_free(?st.buf);
 
@@ -2148,7 +2217,7 @@ test "mach.lang.be.codegen.encode.sink_unaccounted:tracks_unrendered_bytes" {
     if (sink_unaccounted(?buf) != 3) { bad = 1; }
 
     # rendering that instruction clears the debt
-    sink_account(?buf);
+    sink_claim(?buf, 0);
     if (sink_unaccounted(?buf) != 0) { bad = 1; }
 
     # and the next unrendered emission is counted on its own, not cumulatively
@@ -2163,6 +2232,61 @@ test "mach.lang.be.codegen.encode.sink_unaccounted:tracks_unrendered_bytes" {
     if (sink_unaccounted(?plain) != 0) { bad = 1; }
 
     buf_dnit(?plain);
+    buf_dnit(?buf);
+    ret bad;
+}
+
+# the blind spot #2250 closed: a notification dropped in the MIDDLE of a sequence is
+# not absorbed by the next one
+#
+# A claim declares the offset its instruction started at, so the successor of a
+# dropped notification claims a range that does not begin at the cursor. The claim is
+# refused, the skipped bytes stay outstanding, and the ISA's per-opcode guard fails
+# the build. A running high-water mark could not tell the two cases apart: it moved to
+# the buffer end either way and only a miss at the very end of a MIR opcode survived
+# to be seen.
+test "mach.lang.be.codegen.encode.sink_claim:refuses_a_claim_that_skips_bytes" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var buf: ByteBuf = buf_init(?alloc);
+
+    var sink: AsmSink = sink_init(nil, nil);
+    buf.asm = ?sink;
+
+    var bad: i32 = 0;
+
+    # two four-byte instructions, only the second notified - the shape a dropped
+    # notification takes mid-sequence.
+    emit_u32(?buf, 0xD503201F);
+    emit_u32(?buf, 0xD503201F);
+    sink_claim(?buf, 4);
+
+    # the claim is refused, so the first instruction's bytes are still outstanding and
+    # nothing was counted as rendered
+    if (sink_unaccounted(?buf) != 8) { bad = 1; }
+    if (sink_claims(?buf) != 0)      { bad = 1; }
+    if (sink.refused != 1)           { bad = 1; }
+
+    # the same two instructions, both notified, tile the text exactly
+    var ok_buf: ByteBuf = buf_init(?alloc);
+    var ok_sink: AsmSink = sink_init(nil, nil);
+    ok_buf.asm = ?ok_sink;
+
+    emit_u32(?ok_buf, 0xD503201F);
+    sink_claim(?ok_buf, 0);
+    emit_u32(?ok_buf, 0xD503201F);
+    sink_claim(?ok_buf, 4);
+    if (sink_unaccounted(?ok_buf) != 0) { bad = 1; }
+    if (sink_claims(?ok_buf) != 2)      { bad = 1; }
+    if (ok_sink.refused != 0)           { bad = 1; }
+
+    # a notification covering no bytes is refused too: it would describe an
+    # instruction the encoder never emitted
+    sink_claim(?ok_buf, 8);
+    if (sink_claims(?ok_buf) != 2) { bad = 1; }
+    if (ok_sink.refused != 1)      { bad = 1; }
+
+    buf_dnit(?ok_buf);
     buf_dnit(?buf);
     ret bad;
 }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -6623,8 +6623,17 @@ test "mach.lang.target.isa.arm64.encode.check_accounted:rejects_unrendered_bytes
     if (!R.is_err[bool, str](check_accounted(?st, arm64.NOP::u16))) { bad = 1; }
 
     # once rendered, the same state passes again
-    encode.sink_account(?st.buf);
+    encode.sink_claim(?st.buf, 0);
     if (R.is_err[bool, str](check_accounted(?st, arm64.NOP::u16))) { bad = 1; }
+
+    # an instruction whose notification never arrives is NOT absorbed by the one after
+    # it: the successor claims from its own first byte, the sink refuses a claim that
+    # does not begin at the cursor, and the skipped word keeps failing the guard
+    # rather than disappearing into a longer claim (#2250)
+    encode.emit_u32(?st.buf, NOP_WORD);
+    encode.emit_u32(?st.buf, NOP_WORD);
+    encode.sink_claim(?st.buf, 8);
+    if (!R.is_err[bool, str](check_accounted(?st, arm64.NOP::u16))) { bad = 1; }
 
     # and with no sink attached the guard is inert, so an object-producing encode
     # never pays for it

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -275,12 +275,20 @@ pub fun note_block(buf: *enc.ByteBuf, id: u32) R.Result[bool, str] {
     ret emit_str(out, ":\n");
 }
 
+# the width of every A64 instruction word, and so of every claim made here
+val INST_BYTES: usize = 4;
+
 # render one machine instruction the encoder just emitted
 #
-# The sink's single notification point. Renders `i`, then marks every byte emitted
-# so far as accounted; the encoder's totality guard compares that mark against the
-# buffer length after each MIR opcode, so an emission path that never reaches here
-# is reported rather than silently dropped from the artifact.
+# The sink's single notification point. Renders `i`, then claims the four bytes the
+# word it describes occupies. Every A64 instruction is exactly one four-byte word and
+# each of the encoder's emitters pairs one `emit_word` with one call to this, so the
+# claim's start is the word's own offset and needs no separate declaration - which
+# makes the claim EXACT rather than "everything since the last notification". A path
+# that emits a word without reaching here leaves those four bytes outstanding, and
+# the successor's claim starts past them and is refused, so `check_accounted` fails
+# the build naming the opcode. A dropped notification in the middle of a sequence is
+# caught exactly as one at its end (#2250).
 #
 # Returns nothing: it runs on the encoder's hot path where no error can be threaded,
 # so a render failure is latched on the sink and raised by the driver.
@@ -293,7 +301,7 @@ pub fun note_inst(buf: *enc.ByteBuf, i: *Inst) {
         enc.sink_fail(buf, R.unwrap_err[bool, str](res));
         ret;
     }
-    enc.sink_account(buf);
+    enc.sink_claim(buf, buf.len - INST_BYTES);
 }
 
 # render one instruction as an indented assembly line

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -34,6 +34,14 @@
 # immediate), and it does not apply at all to a variable-length encoding like
 # x86-64's, where no such count exists ahead of the encoder.
 #
+# Under `--emit-asm` a third check applies on EVERY target, variable-length included:
+# a statement that emitted bytes must have notified the assembly sink at least once,
+# and on a fixed-width target exactly once per word it emitted. The encoder's own
+# byte tiling (`encode.sink_claim`) would catch the same omission a statement or two
+# later, when a successor's claim failed to begin at the cursor; checking it here is
+# what lets the refusal name the STATEMENT that dropped the notification instead of
+# the whole `asm` block (#2250).
+#
 # CONSERVATIVE BY DEFAULT. An unrecognized mnemonic refuses the block. A byte stream
 # the parser cannot read (a raw `.byte` payload) writes every register in every bank.
 # Precision is earned per mnemonic, on that mnemonic's own table row, and never
@@ -1279,9 +1287,11 @@ pub fun run(st: *encode.EncodeState, g: *Grammar, c: *Cursor, l: *Labels) R.Resu
         or (!R.unwrap_ok[bool, str](pr)) { done = true; }
         or {
             val before: usize = st.buf.len;
+            val claimed: u32 = encode.sink_claims(?st.buf);
             val er: R.Result[bool, str] = emit_one(st, g, c, l, ?item);
             if (R.is_err[bool, str](er)) { ret er; }
-            val wf: str = check_words(c, ?item, st.buf.len - before);
+            val wf: str = check_words(st, c, ?item, st.buf.len - before,
+                                      encode.sink_claims(?st.buf) - claimed);
             if (wf != nil) { ret R.err[bool, str](wf); }
         }
     }
@@ -1313,13 +1323,28 @@ fun emit_one(st: *encode.EncodeState, g: *Grammar, c: *Cursor, l: *Labels, item:
     ret g.emit(st, c, l, item);
 }
 
-# check an emitted instruction against the word count its mnemonic declares
+# check an emitted instruction against the word count its mnemonic declares and the
+# notifications its emission produced
 #
-# The emit-side half of the totality guard, available only where an instruction has a
-# fixed width. Returns nil when the item is accounted for, else the refusal naming
-# the statement whose emission did not match its declared form.
-fun check_words(c: *Cursor, item: *Item, emitted: usize) str {
-    if (item.kind != AI_INST)         { ret nil; }
+# The emit-side half of the totality guard. The word count is available only where an
+# instruction has a fixed width; the notification count is available on every target
+# and is the part a variable-length encoding gets, since `claims` counts machine
+# instructions rather than bytes. A fixed-width form must have notified once per word
+# it emitted, a variable-length one at least once, or the statement emitted machine
+# code the `.s` does not describe. `claims` is zero on an object-producing encode, so
+# the check applies only when a sink is attached.
+#
+# Returns nil when the item is accounted for, else the refusal naming the statement.
+fun check_words(st: *encode.EncodeState, c: *Cursor, item: *Item, emitted: usize, claims: u32) str {
+    if (item.kind != AI_INST) { ret nil; }
+
+    if (encode.sink_active(?st.buf) && emitted > 0) {
+        if (c.g.word == 0) {
+            if (claims == 0) { ret notify_message(c, item); }
+        }
+        or (claims::usize != emitted / c.g.word::usize) { ret notify_message(c, item); }
+    }
+
     if (c.g.word == 0)                { ret nil; }
     if (item.words == WORDS_VARIABLE) {
         if (emitted == 0 || emitted % c.g.word::usize != 0) {
@@ -1329,6 +1354,14 @@ fun check_words(c: *Cursor, item: *Item, emitted: usize) str {
     }
     if (emitted != item.words::usize * c.g.word::usize) { ret words_message(c, item); }
     ret nil;
+}
+
+# the diagnostic for an instruction whose emission did not reach the assembly sink
+fun notify_message(c: *Cursor, item: *Item) str {
+    ret span_message(c,
+        "encode: inline-asm instruction '", item.src_off, item.src_off + item.src_len,
+        "' emitted machine code the assembly printer was not notified of",
+        "encode: an inline-asm instruction emitted machine code the assembly printer was not notified of");
 }
 
 # the diagnostic for an instruction that emitted a different number of words than its

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -2793,7 +2793,7 @@ fun renote_relaxed_branch(st: *encode.EncodeState, guard_pos: u32, jal_pos: u32,
     guard.inst.src2.imm = 8;
     guard.inst.flags  = guard.inst.flags | inst.FLAG_LABEL_SKIP;
 
-    ret encode.note_insert_after(?st.buf, idx::u32, ?jump);
+    ret encode.note_insert_after(?st.buf, idx::u32, ?jump, WORD_SIZE);
 }
 
 # re-notify a `jal` that relaxation just rewrote into an `auipc` / `jalr` trampoline
@@ -2825,7 +2825,7 @@ fun renote_trampoline(st: *encode.EncodeState, auipc_pos: u32, jalr_pos: u32, ta
     lo.inst.src1.imm     = target_block::i64;
     lo.inst.flags        = inst.FLAG_TARGET_BLOCK;
 
-    ret encode.note_insert_after(?st.buf, idx::u32, ?lo);
+    ret encode.note_insert_after(?st.buf, idx::u32, ?lo, WORD_SIZE);
 }
 
 # widen the skip a relaxed conditional's guard renders, after its trampoline grew

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -1747,13 +1747,22 @@ fun encode_inst(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
         ret ld_sz + rest;
     }
 
+    val start: usize = buf.len;
     val n: i32 = encode_inst_one(mi, buf);
     # render whatever this call emitted and nobody else claimed. a form that
-    # legalizes itself into several instructions emits each through this same
-    # wrapper, so those are already accounted and only the tail - the instruction
-    # `mi` itself became - is left to render. an emission of zero bytes (a pseudo)
-    # renders nothing.
-    if (enc.sink_unaccounted(buf) > 0) { printer.note_inst(buf, mi); }
+    # legalizes itself into several instructions emits each through its own emitter,
+    # so those are already claimed and only the tail - the instruction `mi` itself
+    # became - is left to render. an emission of zero bytes (a pseudo) renders
+    # nothing.
+    #
+    # `start` is the offset this call began writing at, and it is what makes the
+    # claim exact on a variable-length encoding: the sink accepts a claim only when it
+    # begins where the previous one ended, so bytes some earlier path emitted without
+    # notifying are not swallowed by this instruction's notification (#2250). A
+    # decomposing form claims every byte through its emitters and leaves no tail; one
+    # that left a tail AFTER an inner claim would be claiming a range that starts
+    # behind the cursor, and the sink refuses it rather than papering over it.
+    if (enc.sink_unaccounted(buf) > 0) { printer.note_inst(buf, mi, start); }
     ret n;
 }
 
@@ -3657,32 +3666,38 @@ fun vec_reg(xmm: i32) isa.Operand {
 # render one packed SSE instruction the vector encoders emitted directly
 #
 # The packed forms write their bytes without building an `isa.Inst`, so they do
-# not pass the `encode_inst` tee and must notify the printer themselves. Missing
-# one is not silent: the sink's byte accounting reports it as unrendered and the
-# encode fails naming the opcode.
+# not pass the `encode_inst` tee and must notify the printer themselves - which makes
+# them the paths where a forgotten notification is easiest to introduce, and #2197
+# found one bypassing the choke point entirely. `start` is the offset the emitter
+# began writing this instruction at, so the claim is that exact range and not
+# "everything outstanding": an emitter that writes bytes and never reaches here is
+# caught by the NEXT emitter's claim beginning past them, rather than being absorbed
+# by it (#2250).
 # ---
 # buf:    the encoder byte sink
+# start:  `.text` offset this instruction's first byte was written to
 # opcode: the concrete packed opcode emitted
 # dst:    the destination operand
 # src:    the source operand, or a NONE operand for a one-operand form
-fun note_packed(buf: *enc.ByteBuf, opcode: u16, dst: isa.Operand, src: isa.Operand) {
+fun note_packed(buf: *enc.ByteBuf, start: usize, opcode: u16, dst: isa.Operand, src: isa.Operand) {
     if (!enc.sink_active(buf)) { ret; }
     var mi: isa.Inst = isa.inst_blank();
     mi.opcode = opcode;
     mi.dst    = dst;
     mi.src1   = src;
     mi.size   = 16;
-    printer.note_inst(buf, ?mi);
+    printer.note_inst(buf, ?mi, start);
 }
 
 # render one packed SSE instruction carrying an imm8 predicate / selector
 # ---
 # buf:    the encoder byte sink
+# start:  `.text` offset this instruction's first byte was written to
 # opcode: the concrete packed opcode emitted
 # dst:    the destination operand
 # src:    the source operand
 # imm:    the imm8 the form carries
-fun note_packed_imm(buf: *enc.ByteBuf, opcode: u16, dst: isa.Operand, src: isa.Operand, imm: u8) {
+fun note_packed_imm(buf: *enc.ByteBuf, start: usize, opcode: u16, dst: isa.Operand, src: isa.Operand, imm: u8) {
     if (!enc.sink_active(buf)) { ret; }
     var mi: isa.Inst = isa.inst_blank();
     mi.opcode = opcode;
@@ -3690,20 +3705,21 @@ fun note_packed_imm(buf: *enc.ByteBuf, opcode: u16, dst: isa.Operand, src: isa.O
     mi.src1   = src;
     mi.src2   = isa.make_imm(imm::i64, 1);
     mi.size   = 16;
-    printer.note_inst(buf, ?mi);
+    printer.note_inst(buf, ?mi, start);
 }
 
 # src is a register or 16-byte-aligned memory operand (#2208): every packed vector
 # value is register- or aligned-slot-resident, so any other shape reaching here is a
 # lowering bug the caller must not swallow
 fun emit_packed_op(op: u16, dst_xmm: i32, src: isa.Operand, buf: *enc.ByteBuf) R.Result[bool, str] {
+    val start: usize = buf.len;
     if (packed_prefix66(op)) { enc.emit_byte(buf, 0x66); }
     if (src.kind == isa.OPK_REG) {
         emit_rex_if_needed(buf, 0, dst_xmm, src.reg);
         enc.emit_byte(buf, 0x0F);
         enc.emit_byte(buf, packed_opbyte(op));
         enc.emit_byte(buf, encode_modrm(3, reg_bits(dst_xmm), reg_bits(src.reg)));
-        note_packed(buf, op, vec_reg(dst_xmm), src);
+        note_packed(buf, start, op, vec_reg(dst_xmm), src);
         ret R.ok[bool, str](true);
     }
     if (src.kind == isa.OPK_MEM) {
@@ -3711,7 +3727,7 @@ fun emit_packed_op(op: u16, dst_xmm: i32, src: isa.Operand, buf: *enc.ByteBuf) R
         enc.emit_byte(buf, 0x0F);
         enc.emit_byte(buf, packed_opbyte(op));
         encode_mem_operand(buf, dst_xmm, ?src);
-        note_packed(buf, op, vec_reg(dst_xmm), src);
+        note_packed(buf, start, op, vec_reg(dst_xmm), src);
         ret R.ok[bool, str](true);
     }
     ret R.err[bool, str]("encode: packed vector op source is not a register or aligned frame slot");
@@ -3719,52 +3735,57 @@ fun emit_packed_op(op: u16, dst_xmm: i32, src: isa.Operand, buf: *enc.ByteBuf) R
 
 # emit a packed reg-reg op with an imm8 (`[66] [REX] 0F <byte> /r ib`): CMPPS/PD and PSHUFD
 fun emit_packed_rri(op: u16, dst_xmm: i32, src_xmm: i32, imm: u8, buf: *enc.ByteBuf) {
+    val start: usize = buf.len;
     if (packed_prefix66(op)) { enc.emit_byte(buf, 0x66); }
     emit_rex_if_needed(buf, 0, dst_xmm, src_xmm);
     enc.emit_byte(buf, 0x0F);
     enc.emit_byte(buf, packed_opbyte(op));
     enc.emit_byte(buf, encode_modrm(3, reg_bits(dst_xmm), reg_bits(src_xmm)));
     enc.emit_byte(buf, imm);
-    note_packed_imm(buf, op, vec_reg(dst_xmm), vec_reg(src_xmm), imm);
+    note_packed_imm(buf, start, op, vec_reg(dst_xmm), vec_reg(src_xmm), imm);
 }
 
 # emit a packed shift-by-imm8 `<op> xmm, imm8` (group form `66 [REX] 0F <byte> /6 ib`);
 # the shifted register is the r/m operand, /6 the opcode extension in the reg field
 fun emit_packed_shift_imm(op: u16, xmm: i32, imm: u8, buf: *enc.ByteBuf) {
+    val start: usize = buf.len;
     enc.emit_byte(buf, 0x66);
     if (needs_rex(xmm)) { enc.emit_byte(buf, encode_rex(0, 0, xmm)); }
     enc.emit_byte(buf, 0x0F);
     enc.emit_byte(buf, packed_opbyte(op));
     enc.emit_byte(buf, encode_modrm(3, 6, reg_bits(xmm)));
     enc.emit_byte(buf, imm);
-    note_packed(buf, op, vec_reg(xmm), isa.make_imm(imm::i64, 1));
+    note_packed(buf, start, op, vec_reg(xmm), isa.make_imm(imm::i64, 1));
 }
 
 # emit a register-register MOVAPS (`0F 28 /r`) copying one 128-bit XMM to another
 fun emit_movaps_rr(dst_xmm: i32, src_xmm: i32, buf: *enc.ByteBuf) {
+    val start: usize = buf.len;
     emit_rex_if_needed(buf, 0, dst_xmm, src_xmm);
     enc.emit_byte(buf, 0x0F);
     enc.emit_byte(buf, 0x28);
     enc.emit_byte(buf, encode_modrm(3, reg_bits(dst_xmm), reg_bits(src_xmm)));
-    note_packed(buf, x64.MOVAPS, vec_reg(dst_xmm), vec_reg(src_xmm));
+    note_packed(buf, start, x64.MOVAPS, vec_reg(dst_xmm), vec_reg(src_xmm));
 }
 
 # emit an unaligned 128-bit load `MOVUPS xmm, [mem]` (`0F 10 /r`)
 fun emit_movups_load(xmm: i32, mem: isa.Operand, buf: *enc.ByteBuf) {
+    val start: usize = buf.len;
     emit_rex_mem(buf, 0, xmm, ?mem);
     enc.emit_byte(buf, 0x0F);
     enc.emit_byte(buf, 0x10);
     encode_mem_operand(buf, xmm, ?mem);
-    note_packed(buf, x64.MOVUPS, vec_reg(xmm), mem);
+    note_packed(buf, start, x64.MOVUPS, vec_reg(xmm), mem);
 }
 
 # emit an unaligned 128-bit store `MOVUPS [mem], xmm` (`0F 11 /r`)
 fun emit_movups_store(mem: isa.Operand, xmm: i32, buf: *enc.ByteBuf) {
+    val start: usize = buf.len;
     emit_rex_mem(buf, 0, xmm, ?mem);
     enc.emit_byte(buf, 0x0F);
     enc.emit_byte(buf, 0x11);
     encode_mem_operand(buf, xmm, ?mem);
-    note_packed(buf, x64.MOVUPS, mem, vec_reg(xmm));
+    note_packed(buf, start, x64.MOVUPS, mem, vec_reg(xmm));
 }
 
 # load a 16-byte vector operand into the XMM scratch `xmm` via MOVAPS (from an XMM
@@ -5997,8 +6018,17 @@ test "mach.lang.target.isa.x64.encode.check_accounted:rejects_unrendered_bytes" 
     if (!R.is_err[bool, str](check_accounted(?st, x64.NOP))) { bad = 1; }
 
     # once rendered, the same state passes again
-    enc.sink_account(?st.buf);
+    enc.sink_claim(?st.buf, 0);
     if (R.is_err[bool, str](check_accounted(?st, x64.NOP))) { bad = 1; }
+
+    # an instruction whose notification never arrives is NOT absorbed by the one
+    # after it: the successor declares its own first byte, the sink refuses a claim
+    # that does not begin at the cursor, and the skipped bytes keep failing the
+    # guard rather than disappearing into a longer claim (#2250)
+    enc.emit_byte(?st.buf, 0x90);
+    enc.emit_byte(?st.buf, 0x90);
+    enc.sink_claim(?st.buf, 2);
+    if (!R.is_err[bool, str](check_accounted(?st, x64.NOP))) { bad = 1; }
 
     # and with no sink attached the guard is inert, so an object-producing encode
     # never pays for it

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -86,23 +86,27 @@ pub fun note_block(buf: *enc.ByteBuf, id: u32) R.Result[bool, str] {
 
 # render one machine instruction the encoder just emitted
 #
-# The sink's single notification point. Renders `mi`, then marks every byte
-# emitted so far as accounted; the encoder's totality guard compares that mark
-# against the buffer length after each MIR opcode, so an emission path that never
-# reaches here is reported rather than silently dropped from the artifact.
+# The sink's single notification point. Renders `mi`, then claims `[start, buf.len)`
+# for it. x86-64 encodes to a variable number of bytes, so unlike a fixed-width
+# machine the claim's start cannot be derived from the buffer end and the caller
+# declares it: the `.text` offset it recorded before writing this instruction's first
+# byte. That is what makes the claim exact on a variable-length encoding - the guard
+# checks a tiling, not a high-water mark, so a path that emits bytes without reaching
+# here is not absorbed by the next instruction's notification (#2250).
 #
 # Returns nothing: it runs on the encoder's hot path where no error can be
 # threaded, so a write failure is latched on the sink and raised by the driver.
 # ---
-# buf: the encoder byte sink carrying the assembly sink
-# mi:  the machine instruction just encoded
-pub fun note_inst(buf: *enc.ByteBuf, mi: *isa.Inst) {
+# buf:   the encoder byte sink carrying the assembly sink
+# mi:    the machine instruction just encoded
+# start: `.text` offset this instruction's first byte was written to
+pub fun note_inst(buf: *enc.ByteBuf, mi: *isa.Inst, start: usize) {
     val res: R.Result[bool, str] = render_inst(buf, mi);
     if (R.is_err[bool, str](res)) {
         enc.sink_fail(buf, R.unwrap_err[bool, str](res));
         ret;
     }
-    enc.sink_account(buf);
+    enc.sink_claim(buf, start);
 }
 
 # render `<mnemonic> <dst>, <src1>, <src2>` for one machine instruction


### PR DESCRIPTION
Closes #2250. Part of #2212.

The byte-accounting guard only ever moved its cursor **forward to the buffer length**, so a claim covered everything back to the previous notification. A notification an emitting path never sent was absorbed by its successor, and only a miss at the very END of a MIR opcode was caught. That is why #2193's mutation slipped past it and the independent object-vs-asm cross-check found the drop instead (1 diverged, 102,502 / 102,503).

## The fix is one property, expressed once

A notification now **declares the `.text` offset its instruction started at**, and the sink accepts the claim only when that is exactly where the previous claim ended. Consecutive notifications tile the text: every byte belongs to exactly one instruction, and a dropped notification leaves a gap its successor cannot close.

A refused claim does not move the cursor, so the skipped bytes stay outstanding and each ISA's existing per-opcode guard fails the build naming the region — no new diagnostic vocabulary, no second failure path. The one shape that leaves no gap (a claim re-covering bytes an earlier one took, "exactly one" broken from the other side) is counted on the sink and refused by the driver.

`sink_account` is **deleted**, not deprecated. A claim with no declared start *is* the defect; leaving the entry point alive so a future emitter could reach for it would be the fallback this issue exists to remove.

## Per target, and why aarch64's answer is not the one #2250 predicted

**#2250 says aarch64 "has multi-word paths" so the exact claim would not transfer. That is wrong, and worth correcting so nobody re-derives it.** All 25 `emit_word` sites were checked against all 22 `note_inst` sites: aarch64's encoder emits **exactly one four-byte word per notification, always**. The three-site delta is two wrappers sharing `note_alu3` and three sharing `note_ldst` — not multi-word emissions. The multi-word property belongs to the **inline-asm mnemonic surface** (#2253's `ldr` / `mov Rd,imm` rows, where the encoder legalizes an out-of-range offset into a pair), not to the notification stream. So aarch64 gets the exact claim too.

| target | what a notification claims | how the start is known |
|---|---|---|
| **riscv64** | the buffered note's own byte range | free — `AsmNote.off` was already the instruction's first byte, so the buffered path gains the tiling with no riscv64 change |
| **aarch64** | exactly the four bytes of the word just emitted | derived, and exact: one `emit_word` pairs with one `note_inst` at every site |
| **x86-64** | `[start, buf.len)` for a variable-length encoding | declared: `encode_inst` records where it began writing, and each of the six packed-SSE emitters that bypass that tee records its own |

`emit_packed_op` is **not** a funnel for the packed paths — six independent emitters (`emit_packed_op`, `emit_packed_rri`, `emit_packed_shift_imm`, `emit_movaps_rr`, `emit_movups_load`, `emit_movups_store`) reach the sink from different arms of `encode_inst_one`. Capturing at "the funnel" would have meant six entry points rather than one, so each declares its own start instead. These are the paths where a forgotten notification is easiest to introduce, and #2197 found one bypassing the choke point entirely.

## Inline asm gets the statement-level half

`isa/asm.mach`'s emit-side check now sees a **notification count** as well as a byte count, on every target including a variable-length one, because claims are counted whether the printer streams or buffers. A statement that emitted bytes must have notified once per word on a fixed-width target and at least once on x86-64.

The encoder's tiling would catch the same omission a statement or two later; checking it here is what lets the refusal name the **statement** instead of the whole `asm` block.

## What each invariant does NOT catch

Extending #2253's list rather than leaving it stale.

**Shared, all targets.** A single emitter that writes two instructions' bytes and notifies once for them: the claim's declared start is that emitter's own entry, so the range tiles correctly and only a per-instruction length model could tell one instruction from two. On riscv64 and aarch64 the `bytes == 4 x notifications` identity does tell them apart, so this residual is **x86-64 only** — and closing it needs a second model of the encoding, which #2212 rules out by design. It is the same residual #2197 closed by hand-auditing those paths.

Also shared: a notification that names the **wrong instruction** while claiming the right bytes. Byte accounting is silent about content; that is what the object-vs-asm cross-check is for. And the whole guard is inert with no sink attached — it runs under `--emit-asm`, so an object-producing build pays nothing and checks nothing.

**riscv64.** Branch relaxation grows the text out of sequence, so the sequential cursor has nothing to check against there; the inserted notification is checked instead against the size of the gap that was opened for it, plus the per-function count identity. A relaxation that notified the right *number* of instructions but the wrong ones is content, not accounting.

**aarch64.** Has no per-function count identity — its `check_accounted` is the byte guard — so a duplicate notification claiming no new bytes is reported by the driver's refused-claim count, which names the module rather than the opcode.

**x86-64.** The shared residual above. It is now the only target where a byte-level invariant cannot distinguish one instruction from two.

**Inline asm, unchanged from #2253 except where noted.** riscv64 `li` declares `WORDS_VARIABLE` and is checked only as "a nonzero whole number of words"; aarch64 `mov Rd, imm` and displaced `ldr` / `str` likewise. **Corrected:** #2253 said x86-64's "parse-side accounting is the whole of its check" — it now also has the emit-side notification check above. It still declares no word count, so it is checked as "at least one notification", never an exact one.

## Verification

**The mutation, per target.** Drop exactly one notification mid-sequence — the first matching one, once per whole compile — and build the tree with `--emit-asm`.

| target | dropped | pre-#2250 high-water guard | this branch |
|---|---|---|---|
| **aarch64** | the first `FORM_LDSTP` — the prologue's `stp x29, x30, [sp, #-N]!`, with two prologue instructions after it | **build succeeds** | `--emit-asm: opcode prologue emitted bytes the aarch64 assembly printer did not render` |
| **x86-64** | the first `x64.PUSH` — `push rbp`, the same shape | **build succeeds** | `--emit-asm: opcode prologue emitted bytes the x86-64 assembly printer did not render` |

The "build succeeds" column is the **negative control**: reverting only the *guard* to dev's high-water semantics, with the identical dropped notification still in place, makes both builds pass. So each mutation is provably live and provably mid-sequence — the exact case #2250 was filed for, reproduced and then closed.

All mutations reverted; the tree is clean.

**Byte-identity.** dev's compiler and this branch's compiler, each building an identical copy of the same tree. On the rebased tree, linux-x86_64 release: **212 objects, 0 diverged. 212 `.s` files, 0 diverged. 0 missing.** Before the rebase the same harness ran the full **6 targets x 2 profiles**: **2496 objects, 0 diverged; 2496 `.s`, 0 diverged; 0 missing** — the mechanism is the same either way, so the rebase re-confirms it on one target rather than repeating ten builds. The `.s` identity matters as much as the object identity here: it says the notification stream the printer reads is unchanged instruction for instruction, so this is a check and not a codegen change.

**Totality holds on the corpus.** The tree builds with `--emit-asm` on all three ISAs x both profiles (and, pre-rebase, on all **12** target x profile combinations). A refusal is a hard error, so a clean build *is* the proof that every claim tiled: nothing anywhere in the compiler emits a byte outside a declared instruction range.

**Suites.** mach **896 / 0** (dev baseline 895, +1: the new sink test). mach-std **611 / 0** at `eff1e8e`, verified by `git rev-parse HEAD` against `mach.lock`.

**Fixpoint.** `A != B`, `B == C`. Reproduced on **unmodified dev** with the same harness — the known seed-lag condition, unchanged by this branch.

Rebased onto `0d36bb04` (post-#2269, which rewrote `isa.Inst` construction across `x64/encode.mach`); the rebase was conflict-free and the whole bar above was re-derived after it, not carried forward.

## Note on scope

`arm64/encode.mach` carries a **10-line diff confined to one test function** (`check_accounted:rejects_unrendered_bytes`) — its single `sink_account` call converted, plus an assertion that a mid-sequence drop is not absorbed. Deleting the blind-spot entry point is the fix; that call was its last remaining user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ntqq8dS4TDqoYPsx3JpVy4
