### PR TITLE
fix(type): carry a generic instance's nominal so a union instance lays out as a union

### DIFF
--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -895,7 +895,7 @@ fun sem_to_ir(s: *session.Session, dtypes: *ir_type.IrTypeTable, sem: semtype.Ty
     }
 
     if (k == semtype.TYPE_REC || k == semtype.TYPE_UNI || k == semtype.TYPE_INSTANCE) {
-        ret sem_to_ir_nominal(s, dtypes, sem, k == semtype.TYPE_UNI);
+        ret sem_to_ir_nominal(s, dtypes, sem, semtype.is_union(?s.types, sem));
     }
 
     # function / generic-param / error types bridge to an opaque pointer-width slot, as
@@ -3473,7 +3473,7 @@ fun struct_intern(s: *session.Session, tgt: *target.Target, dtypes: *ir_type.IrT
     val t: *semtype.Type = O.unwrap[*semtype.Type](to);
 
     var tk: u8 = TK_STRUCT;
-    if (t.kind == semtype.TYPE_UNI) { tk = TK_UNION; }
+    if (semtype.is_union(?s.types, sem)) { tk = TK_UNION; }
     # resolve the name string before any further interning (comp_name reads `t`); an
     # anonymous shape (empty spelling) is marked NAME_OMIT so its DIE drops DW_AT_name (#1955).
     val cnm: str = comp_name(s, t);

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -93,7 +93,10 @@ pub fun instantiate(
         i = i + 1;
     }
 
-    ret type.intern_instance(?sc.s.types, generic_origin, generic_decl, args, arg_count);
+    # the nominal is recorded on the instance so its aggregate kind survives
+    # instantiation (#2239); a generic `fun` names no nominal and resolves to TYPE_ERROR.
+    val gnom: type.TypeId = generic_nominal_of(sc.s, generic_origin, generic_decl);
+    ret type.intern_instance(?sc.s.types, gnom, generic_origin, generic_decl, args, arg_count);
 }
 
 # validate the supplied argument count against a generic declaration's parameter
@@ -210,30 +213,6 @@ pub fun substitute(s: *session.Session, body_type: type.TypeId, args: *type.Type
 
     # primitives and raw ptr have nothing to substitute
     ret body_type;
-}
-
-# the declared kind of the nominal a generic instance specializes (#2168)
-#
-# A `TYPE_INSTANCE` is structurally identical whether it specializes a `rec` or a `uni`
-# - both carry a synthesized field table - so its aggregate kind must be read from the
-# generic declaration it targets, never inferred from the presence of a table. Callers
-# that treat a union as a record would walk overlapping storage as distinct members.
-# ---
-# s:   the shared session (type universe, AST registry)
-# tid: the TypeId to classify
-# ret: some(TYPE_REC / TYPE_UNI) for a generic instance, none when `tid` is not one or
-#      its target declaration cannot be resolved
-pub fun instance_nominal_kind(s: *session.Session, tid: type.TypeId) O.Option[type.TypeKind] {
-    val opt_type: O.Option[*type.Type] = type.get(?s.types, tid);
-    if (O.is_none[*type.Type](opt_type)) { ret O.none[type.TypeKind](); }
-    val t: *type.Type = O.unwrap[*type.Type](opt_type);
-    if (t.kind != type.TYPE_INSTANCE) { ret O.none[type.TypeKind](); }
-
-    val nominal: type.TypeId = generic_nominal_of(s, t.data.instance.target_origin, t.data.instance.target_decl);
-    if (nominal == type.TYPE_ERROR) { ret O.none[type.TypeKind](); }
-    val opt_nom: O.Option[*type.Type] = type.get(?s.types, nominal);
-    if (O.is_none[*type.Type](opt_nom)) { ret O.none[type.TypeKind](); }
-    ret O.some[type.TypeKind](O.unwrap[*type.Type](opt_nom).kind);
 }
 
 # ensure a field table exists for TypeId `tid`, materializing one on demand for a
@@ -1057,7 +1036,7 @@ fun nominal_visit_key(s: *session.Session, nom: type.TypeId, args: *type.TypeId,
     val origin:  session.ModuleId = t.data.nominal.origin;
     val decl_id: id.DeclId        = t.data.nominal.decl;
 
-    val r: R.Result[type.TypeId, str] = type.intern_instance(?s.types, origin, decl_id, args, arg_len);
+    val r: R.Result[type.TypeId, str] = type.intern_instance(?s.types, nom, origin, decl_id, args, arg_len);
     if (R.is_err[type.TypeId, str](r)) { ret nom; }
     ret R.unwrap_ok[type.TypeId, str](r);
 }
@@ -1308,6 +1287,7 @@ fun substitute_fun(s: *session.Session, t: *type.Type, args: *type.TypeId, arg_c
 # original:  the instance's own TypeId, returned when nothing changed
 # ret:       the rebuilt instance TypeId, or TYPE_ERROR on failure
 fun substitute_instance(s: *session.Session, t: *type.Type, args: *type.TypeId, arg_count: u32, original: type.TypeId) type.TypeId {
+    val nominal:    type.TypeId      = t.data.instance.nominal;
     val origin:     session.ModuleId = t.data.instance.target_origin;
     val decl_id:    id.DeclId        = t.data.instance.target_decl;
     val args_start: u32              = t.data.instance.args_start;
@@ -1338,7 +1318,7 @@ fun substitute_instance(s: *session.Session, t: *type.Type, args: *type.TypeId, 
         ret original;
     }
 
-    val res_instance: R.Result[type.TypeId, str] = type.intern_instance(?s.types, origin, decl_id, arg_buf, args_len);
+    val res_instance: R.Result[type.TypeId, str] = type.intern_instance(?s.types, nominal, origin, decl_id, arg_buf, args_len);
     A.deallocate[type.TypeId](s.alloc, arg_buf, args_len::usize);
     ret unwrap_or_error(res_instance);
 }
@@ -1360,7 +1340,7 @@ fun substitute_aggregate(s: *session.Session, t: *type.Type, args: *type.TypeId,
     val origin:  session.ModuleId = t.data.nominal.origin;
     val decl_id: id.DeclId        = t.data.nominal.decl;
 
-    val res_instance: R.Result[type.TypeId, str] = type.intern_instance(?s.types, origin, decl_id, args, arg_count);
+    val res_instance: R.Result[type.TypeId, str] = type.intern_instance(?s.types, original, origin, decl_id, args, arg_count);
     if (R.is_err[type.TypeId, str](res_instance)) { ret type.TYPE_ERROR; }
     val instance: type.TypeId = R.unwrap_ok[type.TypeId, str](res_instance);
 

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1539,19 +1539,11 @@ fun instance_table_ready(sc: *context.SemaContext, ty: type.TypeId) bool {
 # ty:  the TypeId to classify
 # ret: true for a record or a fielded generic instance
 fun type_is_record(sc: *context.SemaContext, ty: type.TypeId) bool {
-    val to: O.Option[*type.Type] = type.get(?sc.s.types, ty);
-    if (O.is_none[*type.Type](to)) { ret false; }
-    val k: type.TypeKind = O.unwrap[*type.Type](to).kind;
-    if (k == type.TYPE_REC) { ret true; }
     # a generic instance is classified by the nominal it specializes, NOT by carrying a
     # field table: a generic `uni` instance has one too, and accepting it would unroll a
     # union's overlapping variants as if they were distinct members at distinct offsets
     # (#2168). `$fields` rejects the non-generic `uni` twin, so it must reject this.
-    if (k == type.TYPE_INSTANCE) {
-        val nk: O.Option[type.TypeKind] = generics.instance_nominal_kind(sc.s, ty);
-        ret O.is_some[type.TypeKind](nk) && O.unwrap[type.TypeKind](nk) == type.TYPE_REC;
-    }
-    ret false;
+    ret type.is_record(?sc.s.types, ty);
 }
 
 # PROJECT: type a `v.[f]` field projection

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1034,13 +1034,15 @@ pub fun lower_type(lc: *LowerContext, tid: type.TypeId) R.Result[ir_type.IrTypeI
         ret ir_type.intern_vector(?lc.m.types, R.unwrap_ok[ir_type.IrTypeId, str](res_elem), t.data.vector.lanes);
     }
 
-    # records, unions, and generic instances all lower to an IR struct of their
+    # records, unions, and generic instances all lower to an IR aggregate of their
     # field layout, read from the session-global field store. a generic instance
     # carries a substituted field table (built by `generics.instantiate`), so it
-    # lowers to the same concrete shape as a non-generic record -- field access
-    # within a generic body GEPs through it correctly.
+    # lowers to the same concrete shape as its non-generic twin -- field access
+    # within a generic body GEPs through it correctly. whether that shape overlaps
+    # its fields comes from the nominal the instance specializes, never from the
+    # instance's own kind, which is TYPE_INSTANCE either way (#2239).
     if (k == type.TYPE_REC || k == type.TYPE_UNI || k == type.TYPE_INSTANCE) {
-        ret lower_nominal(lc, rtid, k == type.TYPE_UNI);
+        ret lower_nominal(lc, rtid, type.is_union(?lc.s.types, rtid));
     }
 
     if (k == type.TYPE_FUN) {

--- a/src/lang/me/lower/generic_layout_runtime.mach
+++ b/src/lang/me/lower/generic_layout_runtime.mach
@@ -1,0 +1,159 @@
+# colocated runtime layout suite for aggregates reached through a generic (#2239)
+#
+# a `rec` and a `uni` instantiate to structurally identical TYPE_INSTANCEs, so the
+# instance's own kind cannot say how its fields are placed; `lower_type` resolves that
+# from the nominal the instance specializes. these cases pin the observable consequence:
+# a generic union's variants overlap, a generic record's do not.
+#
+# an orphan module: `mach build` never reaches it (the compiler binary is unaffected, so
+# the self-host fixpoint and byte-identity hold), while `mach test` loads it as a
+# collection root and runs it natively.
+#
+# ADDRESSES ARE TAKEN in every case on purpose. a probe that only reads a variant back
+# lets scalar promotion split the slot into two registers, which reads as "no aliasing"
+# on a correctly laid out union and hides the defect on a broken one. `?v.a` forces the
+# storage to exist, so the assertions describe memory rather than the optimizer.
+
+use std.types.bool.bool;
+use std.types.size.usize;
+
+# an anonymous `uni` inside a generic record - the shape of stdlib `Result[T, E]`
+rec AnonInGeneric[T, E] {
+    tag: bool;
+    v:   uni { a: T; b: E; };
+}
+
+# the non-generic twin of AnonInGeneric[u32, u32], the layout oracle for it
+rec AnonInPlain {
+    tag: bool;
+    v:   uni { a: u32; b: u32; };
+}
+
+# the non-generic twin of NamedInGeneric[u16], the layout oracle for it
+rec NestedPlain {
+    tag: bool;
+    v:   uni { a: u16; b: u32; };
+}
+
+# a named generic union
+uni NamedGeneric[T, E] { a: T; b: E; }
+
+# the non-generic twin of NamedGeneric[u32, u32]
+uni NamedPlain { a: u32; b: u32; }
+
+# a named generic union nested inside a generic record: the inner instance is reached by
+# substitution through the enclosing one rather than from an annotation.
+#
+# `NamedInGeneric` is instantiated at u16 and NOWHERE ELSE names `NamedGeneric[u16, u32]`,
+# so that inner instance is first interned by the substitution path. Interning it from an
+# annotation too would let a dedup hit supply the nominal and mask a substitution that
+# dropped it.
+rec NamedInGeneric[T] {
+    tag: bool;
+    v:   NamedGeneric[T, u32];
+}
+
+# a generic RECORD, whose variants must NOT overlap - the counterpart that fails if the
+# nominal link is read as "union" unconditionally
+rec RecGeneric[T, E] { a: T; b: E; }
+
+def AnonU32:  AnonInGeneric[u32, u32];
+def NamedU32: NamedGeneric[u32, u32];
+def NamedU64: NamedGeneric[u64, u32];
+def NestedU16: NamedInGeneric[u16];
+def RecU32:   RecGeneric[u32, u32];
+
+# byte distance from `lo` to `hi`
+fun delta(lo: usize, hi: usize) usize {
+    if (hi >= lo) { ret hi - lo; }
+    ret lo - hi;
+}
+
+# an anonymous `uni` inside a generic record overlaps its variants, exactly as its
+# non-generic twin does. pre-#2239 the variants were placed 4 bytes apart and the write
+# to `a` left `b` reading the 2 it was given.
+test "mach.lang.me.lower.generic_layout_runtime.anon_in_generic:aliases" {
+    var g: AnonU32;
+    g.v.b = 2;
+    g.v.a = 1;
+    if (delta((?g.v.a)::usize, (?g.v.b)::usize) != 0) { ret 1; }
+    if (g.v.b != 1)                                   { ret 2; }
+
+    var p: AnonInPlain;
+    p.v.b = 2;
+    p.v.a = 1;
+    if (delta((?p.v.a)::usize, (?p.v.b)::usize) != 0) { ret 3; }
+    if (p.v.b != 1)                                   { ret 4; }
+
+    # the generic instance and its non-generic twin are the same shape, not merely both
+    # "small": an instance that grew a variant would still alias if the trailing one
+    # were unused.
+    if ($size_of(AnonU32) != $size_of(AnonInPlain)) { ret 5; }
+    ret 0;
+}
+
+# a NAMED generic union aliases too. the defect was never specific to the anonymous
+# form: neither carries its declared kind on the instance.
+test "mach.lang.me.lower.generic_layout_runtime.named_generic:aliases" {
+    var g: NamedU32;
+    g.b = 2;
+    g.a = 1;
+    if (delta((?g.a)::usize, (?g.b)::usize) != 0) { ret 1; }
+    if (g.b != 1)                                 { ret 2; }
+
+    var p: NamedPlain;
+    p.b = 2;
+    p.a = 1;
+    if (delta((?p.a)::usize, (?p.b)::usize) != 0) { ret 3; }
+    if (p.b != 1)                                 { ret 4; }
+
+    if ($size_of(NamedU32) != $size_of(NamedPlain)) { ret 5; }
+    ret 0;
+}
+
+# a named generic union reached by substitution through an enclosing generic record -
+# the instance is formed by `substitute_instance`, not by an annotation, so it pins the
+# nominal surviving a rewrite rather than only an intern
+test "mach.lang.me.lower.generic_layout_runtime.named_in_generic:aliases" {
+    var g: NestedU16;
+    g.v.b = 2;
+    g.v.a = 1;
+    if (delta((?g.v.a)::usize, (?g.v.b)::usize) != 0) { ret 1; }
+    if (g.v.b != 1)                                   { ret 2; }
+    if ($size_of(NestedU16) != $size_of(NestedPlain)) { ret 3; }
+    ret 0;
+}
+
+# two instantiations of one generic union each overlap at their own width: the
+# nominal link is per-declaration, so a wider argument must widen the shared slot
+# rather than append a second one
+test "mach.lang.me.lower.generic_layout_runtime.two_instantiations:each_aliases" {
+    var narrow: NamedU32;
+    narrow.b = 2;
+    narrow.a = 1;
+    if (delta((?narrow.a)::usize, (?narrow.b)::usize) != 0) { ret 1; }
+    if (narrow.b != 1)                                      { ret 2; }
+
+    var wide: NamedU64;
+    wide.b = 2;
+    wide.a = 1;
+    if (delta((?wide.a)::usize, (?wide.b)::usize) != 0) { ret 3; }
+    if (wide.b != 1)                                    { ret 4; }
+
+    if ($size_of(NamedU32) != 4) { ret 5; }
+    if ($size_of(NamedU64) != 8) { ret 6; }
+    ret 0;
+}
+
+# a generic RECORD still places its fields at distinct offsets and keeps them
+# independent. the same nominal link decides both, so this fails the moment an
+# instance is treated as a union regardless of what it specializes.
+test "mach.lang.me.lower.generic_layout_runtime.generic_record:does_not_alias" {
+    var r: RecU32;
+    r.b = 2;
+    r.a = 1;
+    if (delta((?r.a)::usize, (?r.b)::usize) == 0) { ret 1; }
+    if (r.b != 2)                                 { ret 2; }
+    if (r.a != 1)                                 { ret 3; }
+    ret 0;
+}

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -260,11 +260,13 @@ pub rec TypeGenericParam {
 # Two instances are identical if (target_origin, target_decl) match and the
 # args sequences are element-wise equal.
 # ---
+# nominal:       the TYPE_REC / TYPE_UNI this instance specializes, or TYPE_ERROR when the target declaration is not an aggregate
 # target_origin: module that declared the generic
 # target_decl:   declaration in target_origin's Ast
 # args_start:    index into TypeInterner.params
 # args_len:      number of concrete argument types
 pub rec TypeInstance {
+    nominal:       TypeId;
     target_origin: module.ModuleId;
     target_decl:   id.DeclId;
     args_start:    u32;
@@ -985,14 +987,20 @@ pub fun intern_function(ti: *TypeInterner, ret_type: TypeId, params: *TypeId, co
 # the instance list. TYPE_INSTANCE bypasses the dedup map (its args live in the
 # side pool, which the context-free dedup hash cannot read), so dedup walks the
 # instance list resulting in O(instances), not O(type_len).
+#
+# `nominal` is the declaration's own nominal TypeId, which the instance carries so
+# that any later consumer can recover what it is an instance OF (#2239). It is a
+# function of (target_origin, target_decl), not of the arguments, so it plays no part
+# in identity and a dedup hit keeps the recorded one.
 # ---
 # ti:            the interner
+# nominal:       the TYPE_REC / TYPE_UNI being specialized, or TYPE_ERROR when the target declaration is not an aggregate
 # target_origin: module that declared the generic
 # target_decl:   declaration in target_origin's Ast
 # args:          pointer to a contiguous array of concrete arg types
 # count:         number of argument types
 # ret:           the (deduped) TypeId for the instance, or an allocation error
-pub fun intern_instance(ti: *TypeInterner, target_origin: module.ModuleId, target_decl: id.DeclId, args: *TypeId, count: u32) R.Result[TypeId, str] {
+pub fun intern_instance(ti: *TypeInterner, nominal: TypeId, target_origin: module.ModuleId, target_decl: id.DeclId, args: *TypeId, count: u32) R.Result[TypeId, str] {
     var i: u32 = 0;
     for (i < ti.instances_len) {
         val tid:  TypeId = ti.instances[i];
@@ -1022,6 +1030,7 @@ pub fun intern_instance(ti: *TypeInterner, target_origin: module.ModuleId, targe
 
     var t: Type;
     t.kind                        = TYPE_INSTANCE;
+    t.data.instance.nominal       = nominal;
     t.data.instance.target_origin = target_origin;
     t.data.instance.target_decl   = target_decl;
     t.data.instance.args_start    = start;
@@ -1233,6 +1242,66 @@ pub fun field_table_push(ti: *TypeInterner, table_idx: u32, name: intern.StrId, 
     ti.field_tables[table_idx].fields_len = ti.field_tables[table_idx].fields_len + 1;
 
     ret R.ok[bool, str](true);
+}
+
+# the nominal aggregate a TypeId denotes: itself for a `rec` / `uni`, and for a
+# generic instance the nominal it specializes (#2239)
+#
+# A `rec` and a `uni` instantiate to structurally identical TYPE_INSTANCEs - both carry
+# a synthesized field table - so an instance's own kind answers nothing about the
+# aggregate behind it. That link is recorded when the instance is interned, which is the
+# only way it can reach an anonymous nominal (the `uni { ok: T; err: E; }` inside
+# `Result[T, E]`): such a nominal is keyed structurally rather than by a source
+# declaration, so no AST can name it.
+# ---
+# ti:  the interner
+# tid: the TypeId to resolve
+# ret: the nominal's TypeId, or TYPE_ERROR when `tid` denotes no aggregate
+pub fun aggregate_nominal(ti: *TypeInterner, tid: TypeId) TypeId {
+    val opt_t: O.Option[*Type] = get(ti, tid);
+    if (O.is_none[*Type](opt_t)) { ret TYPE_ERROR; }
+    val t: *Type = O.unwrap[*Type](opt_t);
+    if (t.kind == TYPE_REC || t.kind == TYPE_UNI) { ret tid; }
+    # an instance over a non-aggregate declaration (a generic `fun` named as a type)
+    # carries no nominal and holds no fields.
+    if (t.kind != TYPE_INSTANCE) { ret TYPE_ERROR; }
+    ret t.data.instance.nominal;
+}
+
+# whether TypeId `tid` lays out as a union: its fields overlap at offset 0 rather
+# than occupying successive storage
+#
+# Every consumer that places fields must ask this rather than test for TYPE_UNI, since
+# an instance's own kind is TYPE_INSTANCE whichever aggregate it specializes (#2239).
+# ---
+# ti:  the interner
+# tid: the TypeId to classify
+# ret: true when the type's fields overlap
+pub fun is_union(ti: *TypeInterner, tid: TypeId) bool {
+    ret nominal_kind_is(ti, tid, TYPE_UNI);
+}
+
+# whether TypeId `tid` lays out as a record: its fields occupy successive storage
+#
+# The counterpart of `is_union`, and subject to the same instance rule (#2239).
+# ---
+# ti:  the interner
+# tid: the TypeId to classify
+# ret: true when the type's fields are placed at distinct offsets
+pub fun is_record(ti: *TypeInterner, tid: TypeId) bool {
+    ret nominal_kind_is(ti, tid, TYPE_REC);
+}
+
+# whether the aggregate `tid` denotes is declared with kind `want`
+# ---
+# ti:   the interner
+# tid:  the TypeId to classify
+# want: TYPE_REC or TYPE_UNI
+# ret:  true when the resolved nominal has that kind
+fun nominal_kind_is(ti: *TypeInterner, tid: TypeId, want: TypeKind) bool {
+    val opt_nom: O.Option[*Type] = get(ti, aggregate_nominal(ti, tid));
+    if (O.is_none[*Type](opt_nom)) { ret false; }
+    ret O.unwrap[*Type](opt_nom).kind == want;
 }
 
 # the field table describing nominal or instance TypeId `ty`, or none when
@@ -1598,12 +1667,16 @@ test "mach.lang.type.intern_instance:dedup_by_origin_decl_args" {
     val u32_id: TypeId = O.unwrap[TypeId](prim(?ti, TYPE_U32));
     val u8_id:  TypeId = O.unwrap[TypeId](prim(?ti, TYPE_U8));
 
+    val rn: R.Result[TypeId, str] = intern_nominal(?ti, intern.STR_NIL, 1::module.ModuleId, 0::id.DeclId, TYPE_REC);
+    if (R.is_err[TypeId, str](rn)) { dnit(?ti); ret 1; }
+    val nom: TypeId = R.unwrap_ok[TypeId, str](rn);
+
     var a1: [1]TypeId;
     a1[0] = u32_id;
 
     # same (origin, decl, args) interned twice -> same TypeId
-    val r1: R.Result[TypeId, str] = intern_instance(?ti, 1::module.ModuleId, 0::id.DeclId, ?a1[0], 1);
-    val r2: R.Result[TypeId, str] = intern_instance(?ti, 1::module.ModuleId, 0::id.DeclId, ?a1[0], 1);
+    val r1: R.Result[TypeId, str] = intern_instance(?ti, nom, 1::module.ModuleId, 0::id.DeclId, ?a1[0], 1);
+    val r2: R.Result[TypeId, str] = intern_instance(?ti, nom, 1::module.ModuleId, 0::id.DeclId, ?a1[0], 1);
     if (R.is_err[TypeId, str](r1))                                    { dnit(?ti); ret 1; }
     if (R.is_err[TypeId, str](r2))                                    { dnit(?ti); ret 1; }
     if (R.unwrap_ok[TypeId, str](r1) != R.unwrap_ok[TypeId, str](r2)) { dnit(?ti); ret 1; }
@@ -1611,7 +1684,7 @@ test "mach.lang.type.intern_instance:dedup_by_origin_decl_args" {
     # different arg type -> different TypeId
     var a1u8: [1]TypeId;
     a1u8[0] = u8_id;
-    val r3: R.Result[TypeId, str] = intern_instance(?ti, 1::module.ModuleId, 0::id.DeclId, ?a1u8[0], 1);
+    val r3: R.Result[TypeId, str] = intern_instance(?ti, nom, 1::module.ModuleId, 0::id.DeclId, ?a1u8[0], 1);
     if (R.is_err[TypeId, str](r3))                                    { dnit(?ti); ret 1; }
     if (R.unwrap_ok[TypeId, str](r1) == R.unwrap_ok[TypeId, str](r3)) { dnit(?ti); ret 1; }
 
@@ -1619,9 +1692,57 @@ test "mach.lang.type.intern_instance:dedup_by_origin_decl_args" {
     var a2: [2]TypeId;
     a2[0] = u32_id;
     a2[1] = u8_id;
-    val r4: R.Result[TypeId, str] = intern_instance(?ti, 1::module.ModuleId, 0::id.DeclId, ?a2[0], 2);
+    val r4: R.Result[TypeId, str] = intern_instance(?ti, nom, 1::module.ModuleId, 0::id.DeclId, ?a2[0], 2);
     if (R.is_err[TypeId, str](r4))                                    { dnit(?ti); ret 1; }
     if (R.unwrap_ok[TypeId, str](r1) == R.unwrap_ok[TypeId, str](r4)) { dnit(?ti); ret 1; }
+
+    dnit(?ti);
+    ret 0;
+}
+
+# an instance is classified by the nominal it specializes, so a `uni` instance reads as
+# a union and a `rec` instance as a record even though both are TYPE_INSTANCE (#2239)
+test "mach.lang.type.is_union:instance_follows_its_nominal" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var ti: TypeInterner;
+    if (O.is_some[str](init(?ti, ?alloc))) { ret 1; }
+
+    val u32_id: TypeId = O.unwrap[TypeId](prim(?ti, TYPE_U32));
+    var args: [1]TypeId;
+    args[0] = u32_id;
+
+    val rr: R.Result[TypeId, str] = intern_nominal(?ti, intern.STR_NIL, 1::module.ModuleId, 0::id.DeclId, TYPE_REC);
+    val ru: R.Result[TypeId, str] = intern_nominal(?ti, intern.STR_NIL, 1::module.ModuleId, 1::id.DeclId, TYPE_UNI);
+    if (R.is_err[TypeId, str](rr)) { dnit(?ti); ret 1; }
+    if (R.is_err[TypeId, str](ru)) { dnit(?ti); ret 1; }
+    val rec_nom: TypeId = R.unwrap_ok[TypeId, str](rr);
+    val uni_nom: TypeId = R.unwrap_ok[TypeId, str](ru);
+
+    val ri: R.Result[TypeId, str] = intern_instance(?ti, rec_nom, 1::module.ModuleId, 0::id.DeclId, ?args[0], 1);
+    val ui: R.Result[TypeId, str] = intern_instance(?ti, uni_nom, 1::module.ModuleId, 1::id.DeclId, ?args[0], 1);
+    if (R.is_err[TypeId, str](ri)) { dnit(?ti); ret 1; }
+    if (R.is_err[TypeId, str](ui)) { dnit(?ti); ret 1; }
+    val rec_inst: TypeId = R.unwrap_ok[TypeId, str](ri);
+    val uni_inst: TypeId = R.unwrap_ok[TypeId, str](ui);
+
+    # the two instances are indistinguishable by their own kind
+    if (O.unwrap[*Type](get(?ti, rec_inst)).kind != TYPE_INSTANCE) { dnit(?ti); ret 1; }
+    if (O.unwrap[*Type](get(?ti, uni_inst)).kind != TYPE_INSTANCE) { dnit(?ti); ret 1; }
+
+    if (aggregate_nominal(?ti, rec_inst) != rec_nom) { dnit(?ti); ret 1; }
+    if (aggregate_nominal(?ti, uni_inst) != uni_nom) { dnit(?ti); ret 1; }
+
+    if (is_union(?ti, uni_inst))   { } or { dnit(?ti); ret 1; }
+    if (is_record(?ti, rec_inst))  { } or { dnit(?ti); ret 1; }
+    if (is_union(?ti, rec_inst))   { dnit(?ti); ret 1; }
+    if (is_record(?ti, uni_inst))  { dnit(?ti); ret 1; }
+
+    # the bare nominals answer for themselves, and a primitive is neither
+    if (is_union(?ti, uni_nom))  { } or { dnit(?ti); ret 1; }
+    if (is_record(?ti, rec_nom)) { } or { dnit(?ti); ret 1; }
+    if (is_union(?ti, u32_id))   { dnit(?ti); ret 1; }
+    if (is_record(?ti, u32_id))  { dnit(?ti); ret 1; }
 
     dnit(?ti);
     ret 0;


### PR DESCRIPTION
Closes #2239.

## Mechanism

A `rec` and a `uni` instantiate to **structurally identical `TYPE_INSTANCE`s** — both carry a synthesized field table, and `TypeInstance` recorded only `(target_origin, target_decl, args)`. So every consumer that places fields read the instance's own kind, found `TYPE_INSTANCE` rather than `TYPE_UNI`, and laid the variants out as successive struct members:

- `src/lang/me/lower/context.mach` — `lower_nominal(lc, rtid, k == type.TYPE_UNI)`, the layout authority
- `src/lang/be/codegen/dwarf.mach` — the same test in `sem_to_ir`, and `TK_STRUCT` vs `TK_UNION` in `struct_intern`

The instance now records the nominal it specializes at intern time. That link is the **only** one that can reach an anonymous nominal: those are keyed structurally under `MODULE_NIL` with a synthetic decl id (`resolve_type_anon`), so `generic_nominal_of` — the AST lookup #2168 and #2225 use — cannot name them. An AST-based fix would have repaired the named form and left `Result`'s anonymous `uni` broken.

`type.aggregate_nominal` / `is_union` / `is_record` resolve through it, and lowering, the DWARF layout oracle, the DWARF tag, and `$fields`' record test now all ask the type universe. `generics.instance_nominal_kind` (the #2168 AST round-trip) is deleted — it was the weaker second mechanism for the same question, and it returned `none` for every anonymous instance.

## The issue's table was wrong, and so was the correction's scope

Measured with the probe below on `dev` @ `90516c86` (linux-x86_64 debug), addresses taken on both variants. Probe: write `b = 2`, then `a = 1`, read `b` back; offset is `(?v.b) - (?v.a)`.

| shape | offset PRE | reads back PRE | offset POST | reads back POST | size PRE → POST |
|---|---|---|---|---|---|
| stdlib `Result[u32, u32]` | **4** | **2** | 0 | 1 | 12 → **8** |
| anonymous `uni` in a generic `rec` | **4** | **2** | 0 | 1 | 12 → **8** |
| its non-generic twin | 0 | 1 | 0 | 1 | 8 → 8 |
| named generic `uni U[T, E]` at `[u32, u32]` | **4** | **2** | 0 | 1 | 8 → **4** |
| its non-generic twin | 0 | 1 | 0 | 1 | 4 → 4 |
| named generic `uni` nested in a generic `rec` | **4** | **2** | 0 | 1 | 12 → **8** |
| the same generic `uni` at `[u64, u32]` | **8** | **2** | 0 | 1 | 16 → **8** |
| `Result[u64, u32]` | — | — | — | — | 24 → **16** |

**No generic union instance aliased** — named, anonymous, nested, or at a second instantiation. The issue body's claim that the named form was correct, and the correction's framing, both understate it: it is one defect with one cause, and every non-generic twin was already correct.

## #2225 is in place — verified, not assumed

On `dev` before touching anything, `def RS: R.Result[^u32, u32];` is rejected:

```
error: union variants must agree on secrecy: this instantiation makes overlapping
fields part secret `^` and part public, which would alias the same storage at two
classifications
```

Still rejected after the fix, verified again post-merge. So the sema half landed first (PR #2259) and this does not convert a masked hole into a live leak.

## Size delta

`$size_of` read out of the emitted object per target (a comptime table with sentinels, so no execution needed). **Identical on all five targets and both profiles**:

| type | PRE | POST | delta |
|---|---|---|---|
| `Result[u32, u32]` | 12 | 8 | **−4 (−33%)** |
| `Result[u64, u32]` | 24 | 16 | **−8 (−33%)** |
| `Result[bool, str]` | 24 | 16 | **−8** |
| `Result[usize, str]` | 24 | 16 | **−8** |
| `Result[ptr, str]` | 24 | 16 | **−8** |
| `Result[u32, str]` | 24 | 16 | **−8** |
| `Result[str, str]` | 24 | 16 | **−8** |
| `Option[u32]` | 8 | 8 | 0 (control: generic record) |
| `Option[str]` | 16 | 16 | 0 (control) |

Targets swept: `linux`, `linux-arm64`, `linux-riscv64`, `windows`, `darwin-aarch64` × `debug`, `release`.

`Result` is the only stdlib type that changes. `toml.Value`'s `uni` is non-generic, and `Option[T]` is a generic record — both already correct.

### The compiler binary itself (linux-x86_64, self-hosted gen B, vs dev `90516c86`)

| profile | PRE | POST | delta |
|---|---|---|---|
| debug | 8,310,784 | 7,548,928 | **−761,856 (−9.2%)** |
| release | 10,584,064 | 10,858,496 | **+274,432 (+2.6%)** |

The change is entirely in the text segment; `.rodata` moves by −24 bytes in both profiles.

**Release grows, and that is expected.** SysV's `MAX_REG_RET` is 16: at 24 bytes `Result[T, str]` was MEMORY-class and returned through a hidden `sret` pointer; at 16 bytes it is returned per-eightbyte in `RAX:RDX`. Every `Result`-returning function in the compiler flips ABI class, which removes the callee's memory writes and expands call sites that need the address back. The compiler is the maximally-affected program — it is `Result` end to end — while an ordinary program that mostly *stores* `Result`s gets the plain 33% shrink and the smaller stack traffic that shows up as the debug profile's −9.2%.

## Test

`src/lang/me/lower/generic_layout_runtime.mach` — five runtime cases, addresses taken in every one (a probe that only reads a variant back lets scalar promotion split the slot and fake the symptom on a healthy type). An orphan module: proven byte-identical compiler with and without it, so the fixpoint and any byte-identity claim are untouched.

Plus a `type.mach` unit test pinning that two instances indistinguishable by their own kind classify differently through `aggregate_nominal` / `is_union` / `is_record`.

### Discrimination — every assertion checked

**Pre-fix, the new suite run through the unmodified `dev` compiler:** 4 of 5 fail, each at `exit 1` — the *first* assertion in each case, the offset check. The fifth (`generic_record:does_not_alias`) passes pre-fix, correctly: it is the direction guard, not a bug witness.

**Mutation A** — `nominal_kind_is` reads the instance's own kind instead of `aggregate_nominal(...)` (i.e. drop the link): **867 / 7**. Kills the `type.mach` unit test, all four runtime union cases, and the two pre-existing #2168 tests (`fields_over_generic_instance`, `generic_reflection_projection_secrecy`) that rest on the same question.

**Mutation B** — lowering answers "union" for every instance (`k == TYPE_UNI || k == TYPE_INSTANCE`): a compiler whose own records overlap cannot build anything, so this is scoped to the suite as a standalone project — **2 / 3**. `generic_record:does_not_alias` dies at `exit 1` (the record's fields collapsed to offset 0), and `anon_in_generic` / `named_in_generic` at `exit 5` / `exit 3` — the size-equality assertions against their non-generic twins, which is exactly what those assertions exist for.

**Mutation C** — `substitute_instance` passes `TYPE_ERROR` instead of the original's nominal: **873 / 1**, killing only `named_in_generic:aliases` at `exit 1`. This one found a real gap first: the case originally instantiated at a width an annotation also spelled, so a dedup hit supplied the nominal anyway and the mutation survived at 874/0. The case now instantiates `NamedInGeneric[u16]` with nothing else naming `NamedGeneric[u16, u32]`, so its inner instance is first interned by the substitution path.

## Verification

Everything below through the freshly-built HEAD compiler, never the PATH seed.

- **mach**: **892 / 0** (dev @ `90516c86` is 886 / 0 — exactly +6: 1 unit test + 5 runtime cases)
- **mach-std**: **611 / 0**, at pin `eff1e8e` (tree materialized with `git archive` from the pin and diffed byte-for-byte, not a bare clone — that lands on `dev` and reports 663)
- **int**: `linux` **85 / 0**, `linux-riscv64` (qemu) **64 / 0**, both profiles
- **Three-generation fixpoint**: `B == C` in **both profiles**, re-run after merging `dev`. `A != B` as expected — A is seed-built, so it carries the seed's old layout; the invariant is B == C.