### PR TITLE
fix(fe): read a comptime intrinsic's type operand with the type grammar

### DIFF
--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -22,6 +22,20 @@ pub val POINT_SIZE: i64 = $size_of(Point);
 pub val POINT_X:    i64 = $offset_of(Point, x);
 ```
 
+`T` is a **type**, written with the ordinary type grammar — not just a bare
+name. A generic instance, a pointer, an array, a `^` secret, and a qualified
+`module.Type` are all valid, including inside the generic that owns the
+parameter:
+
+```mach
+fun probe[T]() u64 {
+    ret $size_of(Box[T]) + $align_of(Pair[T, u64]) + $size_of(*T) + $size_of([4]T);
+}
+```
+
+`$offset_of`'s **second** argument is the exception: a bare field name, resolved
+against the record's layout, never a type or a value.
+
 ## Type intrinsic
 
 `$type_of(expr)` produces a comptime type value — the resolved type of its
@@ -51,8 +65,12 @@ and emitted.
 
 ## Field intrinsic and projection
 
-`$fields(T)` produces a comptime sequence of field descriptors for record or
-union type `T`. Each descriptor carries three readable properties:
+`$fields(T)` produces a comptime sequence of field descriptors for record type
+`T`, written with the full type grammar exactly as the layout intrinsics take it
+(`$fields(Box[T])`, `$fields(Pair[A, B])`, `$fields(mod.Rec)`). A union is
+refused: its variants overlap in storage, so a member walk over them would report
+distinct fields at distinct offsets that do not exist. Each descriptor carries
+three readable properties:
 
 | Property   | Type     | Value                                        |
 |------------|----------|----------------------------------------------|

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -670,11 +670,19 @@ mach-read      ::= comptime-ident { member }        (* $mach.build.os, $mach.arc
 
 - Intrinsic calls (`$size_of(T)`, `$align_of(T)`, `$offset_of(T, field)`,
   `$type_of(e)`, `$fields(T)`, `$error("msg")`, `$assert(cond, "msg")`) are
-  syntactically a `comptime-ident` callee with `call-args`. Their *arguments*
-  are parsed as ordinary expressions — `$size_of(T)` and `$fields(T)` pass a
-  type name that the expression grammar reads as an `IDENT`; the intrinsic
-  reinterprets it as a type at evaluation time. `$type_of(e)` takes a value
-  expression and produces a comptime type value.
+  syntactically a `comptime-ident` callee with `call-args`.
+- The **type-taking** intrinsics — `$size_of`, `$align_of`, `$offset_of`,
+  `$fields` — parse their **first argument with the `type` production**, not the
+  expression grammar, so the whole type language is spellable there:
+  `$fields(Box[T])`, `$size_of(Pair[A, B])`, `$size_of(*T)`, `$size_of([4]u16)`,
+  `$size_of(^u32)`, `$fields(mod.Rec)`. Every other argument is an ordinary
+  expression; `$offset_of`'s second is a bare field name resolved against the
+  record. `$type_of(e)` takes a value expression and produces a comptime type
+  value.
+- A **type comparison** operand (`$type_of(x) == Name`) is the one type spelling
+  read with the expression grammar, because the comparison is only recognizable
+  once both sides are parsed. Only a bare name or `module.Name` is available
+  there; a generic instance is not.
 - `$mach.*` reads are a `comptime-ident` followed by a `.`-member chain. They
   appear in `$if` conditions and as comptime initializers.
 - A bare **directive** `$intrinsic(args);` (e.g. `$error("msg");`) is the

--- a/int/regression/2178-intrinsic-type-operand/expect.txt
+++ b/int/regression/2178-intrinsic-type-operand/expect.txt
@@ -1,0 +1,7 @@
+count_inst=2
+last_inst=22
+sum_concrete=33
+count_pair=2
+count_nested=4
+sizes=16
+composites=20

--- a/int/regression/2178-intrinsic-type-operand/mach.toml
+++ b/int/regression/2178-intrinsic-type-operand/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case2178"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2178-intrinsic-type-operand/src/main.mach
+++ b/int/regression/2178-intrinsic-type-operand/src/main.mach
@@ -1,0 +1,84 @@
+# regression pin for #2178: a comptime intrinsic's type operand is a TYPE
+#
+# `$fields(Box[T])` inside a generic used to resolve to nothing, and the `$each`
+# body was dropped whole -- neither type-checked nor emitted, with no diagnostic.
+# The unit tests assert the body is TYPED; this case asserts it is EMITTED, which
+# only running the program can show: a dropped body leaves every accumulator at
+# its initial value and the program still exits 0. Every line here printed a zero,
+# or failed to parse, before the fix.
+
+use std.runtime;
+use p: std.print;
+
+rec Box[T] { v: T; w: T; }
+rec Pair[A, B] { a: A; b: B; }
+rec In[T] { x: T; }
+
+# the defect's shape: a named generic instance spelled inside the generic that
+# owns the parameter. a dropped body leaves the count at 0.
+fun count_inst[T](b: Box[T]) u64 {
+    var n: u64 = 0;
+    $each f in $fields(Box[T]) { n = n + 1; }
+    ret n;
+}
+
+# the same spelling with a real projection, so the emitted body has to read the
+# instance: the last field wins.
+fun last_inst[T](b: Box[T]) T {
+    var r: T;
+    $each f in $fields(Box[T]) { r = b.[f]; }
+    ret r;
+}
+
+# a concrete instance named from a non-generic function, which reported a bogus
+# "unresolved identifier u32" on the type argument.
+fun sum_concrete(b: Box[u32]) u64 {
+    var acc: u64 = 0;
+    $each f in $fields(Box[u32]) { acc = acc + b.[f]::u64; }
+    ret acc;
+}
+
+# a multi-argument instance, which did not parse at all: `Pair[A, B]` read as an
+# index expression and the `,` ended it.
+fun count_pair[A, B](x: Pair[A, B]) u64 {
+    var n: u64 = 0;
+    $each f in $fields(Pair[A, B]) { n = n + 1; }
+    ret n;
+}
+
+# a nested instance argument, and a nested `$each` over the same spelling: the
+# inner unroll is a second body a dropped outer sequence took with it.
+fun count_nested[T](b: Box[In[T]]) u64 {
+    var n: u64 = 0;
+    $each g in $fields(Box[In[T]]) {
+        $each f in $fields(Box[In[T]]) { n = n + 1; }
+    }
+    ret n;
+}
+
+# the layout intrinsics share the leaf. a generic-instance operand reached the IR
+# verifier instead of sema and failed there with no source location.
+fun sizes[T]() u64 { ret $size_of(Box[T]) + $align_of(Box[T]) + $offset_of(Box[T], w); }
+
+# composite spellings the expression grammar could not carry at all.
+fun composites() u64 { ret $size_of(*Box[u32]) + $size_of([4]u16) + $size_of(^u32); }
+
+#[symbol("main")]
+pub fun main(argc: i64, argv: **u8) i64 {
+    var b: Box[u32];
+    b.v = 11;
+    b.w = 22;
+    p.printf("count_inst={}\n", count_inst[u32](b));
+    p.printf("last_inst={}\n", last_inst[u32](b)::u64);
+    p.printf("sum_concrete={}\n", sum_concrete(b));
+
+    var pr: Pair[u32, u64];
+    p.printf("count_pair={}\n", count_pair[u32, u64](pr));
+
+    var bn: Box[In[u32]];
+    p.printf("count_nested={}\n", count_nested[u32](bn));
+
+    p.printf("sizes={}\n", sizes[u32]());
+    p.printf("composites={}\n", composites());
+    ret 0;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -5356,6 +5356,13 @@ test "mach.lang.driver:intrinsic_type_operand_is_a_type" {
     if (ut_vec_diag("rec Box { v: u32; }\nfun f() u64 { var n: u64 = 0; n = $fields(Box); ret n; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
         "a type name is not a value") != 0) { bad = 20; }
 
+    # a name the RESOLVER rejected is reported exactly once. sema never re-reports
+    # over it, because a build stops on the diagnostic sink before sema runs and
+    # this harness now mirrors that gate; without the gate the sema unbound-
+    # identifier assertion would fire a second time on the same name, claiming a
+    # resolver silence that did not happen (#2144).
+    if (ut_sema_errs("fun f() i64 { ret nosuchname; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n") != 1) { bad = 23; }
+
     # an inline `rec { ... }` spelling is now expressible and unrolls its own
     # fields; an empty record still expands to nothing, as documented.
     if (!ut_sema_clean("fun count() u32 { var acc: u32 = 0; $each f in $fields(rec { x: u32; y: u64; }) { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { count(); ret 0; }\n")) { bad = 21; }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4392,10 +4392,18 @@ test "mach.lang.driver:incremental_test_mode_neutralization_variant" {
     ret bad;
 }
 
-# scaffold a single-module project from `text`, run parse + resolve + the sema
-# pass, and return its error-diagnostic count (-1 on a harness failure). the
-# secret flow-typing matrix below asserts this count against an expectation
-# (#1645)
+# scaffold a single-module project from `text`, run parse + resolve and -- when
+# resolve is clean -- the sema pass, and return its error-diagnostic count (-1 on
+# a harness failure). the secret flow-typing matrix below asserts this count
+# against an expectation (#1645)
+#
+# The resolve gate mirrors the real pipeline: `engine.run_phase` checks the
+# diagnostic sink after PH_LOAD, so a module the resolver rejected never reaches
+# sema in a build. Without the gate this harness typed an AST with unbound
+# operands and counted diagnostics no build can produce -- the fidelity gap #2144
+# names, in the direction that makes sema's unbound-identifier assertion
+# unfalsifiable. A resolve-rejected program still returns its resolve error count,
+# so `ut_sema_rejects` covers rejections from either pass.
 fun ut_sema_errs(text: str) i32 {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret -1; }
@@ -4412,9 +4420,12 @@ fun ut_sema_errs(text: str) i32 {
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret -1; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
-    var errs: i32 = -1;
-    val sem: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
-    if (R.is_ok[bool, outcome.Fail](sem)) { errs = ut_count_errors(?s.diags)::i32; }
+    var errs: i32 = ut_count_errors(?s.diags)::i32;
+    if (errs == 0) {
+        errs = -1;
+        val sem: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+        if (R.is_ok[bool, outcome.Fail](sem)) { errs = ut_count_errors(?s.diags)::i32; }
+    }
 
     project.dnit_project(?p);
     session.dnit(?s);
@@ -5272,6 +5283,83 @@ test "mach.lang.driver:fields_over_generic_instance" {
     # the same at a pointer and at a nested-instance argument.
     if (!ut_sema_clean("rec Box[T] { v: T; w: T; }\nfun count[T](b: T) u32 { var acc: u32 = 0; $each f in $fields(T) { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: Box[*u32]; count[Box[*u32]](b); ret 0; }\n")) { bad = 1; }
     if (!ut_sema_clean("rec Box[T] { v: T; w: T; }\nfun count[T](b: T) u32 { var acc: u32 = 0; $each f in $fields(T) { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: Box[Box[u32]]; count[Box[Box[u32]]](b); ret 0; }\n")) { bad = 1; }
+
+    ret bad;
+}
+
+# a comptime intrinsic's type operand is a TYPE, read with the type grammar (#2178)
+#
+# The operand used to be an expression every consumer re-interpreted, and the
+# re-interpretation covered a bare name and `module.Name` only. A generic-instance
+# spelling `Box[T]` therefore resolved to nothing, `field_seq_owner` absorbed the
+# TYPE_ERROR, and the whole `$each` body was dropped - unchecked and unemitted -
+# with no diagnostic at all. Every rejection assertion here needles on a diagnostic
+# from INSIDE the body, which exists only if the body was type-checked
+test "mach.lang.driver:intrinsic_type_operand_is_a_type" {
+    var bad: i32 = 0;
+
+    # the reporting scenario. the body's `u32 = ^u32` projection is a secrecy
+    # violation; on dev this program built clean and printed 0.
+    if (ut_vec_diag("rec Box[T] { v: T; }\nfun leak[T](b: Box[T]) u32 { var acc: u32 = 0; $each f in $fields(Box[T]) { acc = b.[f]; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var s: ^u32 = 1234; var b: Box[^u32]; b.v = s; leak[^u32](b); ret 0; }\n",
+        "expected u32, found ^u32") != 0) { bad = 1; }
+
+    # the same at every other spelling the leaf now reaches: a nested instance, a
+    # multi-argument instance, and a concrete instance named from a non-generic
+    # function.
+    if (ut_vec_diag("rec In[T] { x: T; }\nrec Box[T] { v: T; }\nfun leak[T](b: Box[In[T]]) u32 { var acc: u32 = 0; $each f in $fields(Box[In[T]]) { acc = b.[f]; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: Box[In[u32]]; leak[u32](b); ret 0; }\n",
+        "expected u32, found In[T]") != 0) { bad = 2; }
+    if (ut_vec_diag("rec Pair[A, B] { a: A; b: B; }\nfun leak[A, B](p: Pair[A, B]) u32 { var acc: u32 = 0; $each f in $fields(Pair[A, B]) { acc = p.[f]; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var p: Pair[u64, u64]; leak[u64, u64](p); ret 0; }\n",
+        "expected u32, found B") != 0) { bad = 3; }
+    if (ut_vec_diag("rec Box[T] { v: T; }\nfun leak(b: Box[^u32]) u32 { var acc: u32 = 0; $each f in $fields(Box[^u32]) { acc = b.[f]; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: Box[^u32]; leak(b); ret 0; }\n",
+        "expected u32, found ^u32") != 0) { bad = 4; }
+
+    # a body inside a NESTED `$each` over the same spelling is typed too - the inner
+    # unroll is where a dropped outer sequence hid a second body.
+    if (ut_vec_diag("rec Box[T] { v: T; }\nfun leak[T](b: Box[T]) u32 { var acc: u32 = 0; $each g in $fields(Box[T]) { $each f in $fields(Box[T]) { acc = b.[f]; } } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: Box[^u32]; leak[^u32](b); ret 0; }\n",
+        "expected u32, found ^u32") != 0) { bad = 5; }
+
+    # CONTROLS - the legal forms still compile. a same-typed projection through a
+    # named instance, a nested instance, a multi-argument instance, and a nested
+    # `$each`, none of which parsed or resolved on dev.
+    if (!ut_sema_clean("rec Box[T] { v: T; }\nfun get[T](b: Box[T]) T { var r: T; $each f in $fields(Box[T]) { r = b.[f]; } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: Box[u32]; get[u32](b); ret 0; }\n")) { bad = 6; }
+    if (!ut_sema_clean("rec In[T] { x: T; }\nrec Box[T] { v: In[T]; }\nfun count[T](b: Box[T]) u32 { var acc: u32 = 0; $each f in $fields(Box[In[T]]) { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: Box[u32]; count[u32](b); ret 0; }\n")) { bad = 7; }
+    if (!ut_sema_clean("rec Pair[A, B] { a: A; b: B; }\nfun count[A, B](p: Pair[A, B]) u32 { var acc: u32 = 0; $each f in $fields(Pair[A, B]) { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var p: Pair[u32, u64]; count[u32, u64](p); ret 0; }\n")) { bad = 8; }
+    if (!ut_sema_clean("rec Box[T] { v: T; }\nfun count[T](b: Box[T]) u32 { var acc: u32 = 0; $each g in $fields(Box[T]) { $each f in $fields(Box[T]) { acc = acc + 1; } } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: Box[u32]; count[u32](b); ret 0; }\n")) { bad = 9; }
+
+    # the layout intrinsics reach the same leaf. on dev a generic-instance operand
+    # produced no diagnostic at all here - it reached the middle end and failed the
+    # IR verifier with a spanless "constant carries an incompatible type", so these
+    # two assert through LOWER, where that failure lands.
+    if (ut_lower_ok("rec Box[T] { v: T; }\nfun sz[T]() u64 { ret $size_of(Box[T]); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { sz[u32](); ret 0; }\n") != 0) { bad = 10; }
+    if (ut_lower_ok("rec Box[T] { v: T; }\nfun al[T]() u64 { ret $align_of(Box[T]); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { al[u64](); ret 0; }\n") != 0) { bad = 11; }
+    if (!ut_sema_clean("rec Pair[A, B] { a: A; b: B; }\nfun of[A, B]() u64 { ret $offset_of(Pair[A, B], b); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { of[u32, u64](); ret 0; }\n")) { bad = 12; }
+
+    # composite spellings the expression grammar could never carry: a pointer, an
+    # array, and a `^` secret qualifier.
+    if (!ut_sema_clean("rec Box[T] { v: T; }\nfun sz[T]() u64 { ret $size_of(*Box[T]); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { sz[u32](); ret 0; }\n")) { bad = 13; }
+    if (!ut_sema_clean("fun sz() u64 { ret $size_of([4]u16); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { sz(); ret 0; }\n")) { bad = 14; }
+    if (!ut_sema_clean("fun sz() u64 { ret $size_of(^u32); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { sz(); ret 0; }\n")) { bad = 15; }
+
+    # an operand that names nothing is REPORTED, rather than absorbed as a
+    # TYPE_ERROR that drops the body.
+    if (!ut_sema_rejects("fun count() u32 { var acc: u32 = 0; $each f in $fields(NoSuch) { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { count(); ret 0; }\n")) { bad = 16; }
+    if (!ut_sema_rejects("fun count() u32 { var acc: u32 = 0; $each f in $fields(NoSuch[u32]) { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { count(); ret 0; }\n")) { bad = 17; }
+    # a well-formed type that is not a record still fails the record check; a `fun`
+    # type takes the same path.
+    if (ut_vec_diag("fun count() u32 { var acc: u32 = 0; $each f in $fields(u32) { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { count(); ret 0; }\n",
+        "$fields requires a record type") != 0) { bad = 18; }
+    if (ut_vec_diag("fun count() u32 { var acc: u32 = 0; $each f in $fields(fun(u32) u32) { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { count(); ret 0; }\n",
+        "$fields requires a record type") != 0) { bad = 19; }
+
+    # a type spelling reached in VALUE position is refused rather than poisoned:
+    # `$fields(T)` is a comptime sequence consumed by `$each`, never an operand.
+    if (ut_vec_diag("rec Box { v: u32; }\nfun f() u64 { var n: u64 = 0; n = $fields(Box); ret n; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "a type name is not a value") != 0) { bad = 20; }
+
+    # an inline `rec { ... }` spelling is now expressible and unrolls its own
+    # fields; an empty record still expands to nothing, as documented.
+    if (!ut_sema_clean("fun count() u32 { var acc: u32 = 0; $each f in $fields(rec { x: u32; y: u64; }) { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { count(); ret 0; }\n")) { bad = 21; }
+    if (!ut_sema_clean("rec Empty { }\nfun count() u32 { var acc: u32 = 0; $each f in $fields(Empty) { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { count(); ret 0; }\n")) { bad = 22; }
 
     ret bad;
 }

--- a/src/lang/fe/ast/expr.mach
+++ b/src/lang/fe/ast/expr.mach
@@ -41,6 +41,12 @@ pub val EXPR_KIND_STRIP:          ExprKind = 18;
 # with a positional brace body, one element per lane. distinguished from a struct
 # literal at parse time by the body lacking `ident :` field syntax
 pub val EXPR_KIND_VECTOR_LIT:     ExprKind = 19;
+# a type spelling standing in an expression slot (#2178): the operand of a
+# type-taking comptime intrinsic (`$size_of(T)`, `$fields(Box[T])`). the parser
+# reads it with the TYPE grammar and the node carries the syntactic AstType, so
+# resolve and sema route it through the ordinary type machinery instead of
+# reinterpreting an expression as a type. it never appears anywhere else
+pub val EXPR_KIND_TYPE_REF:       ExprKind = 20;
 pub val EXPR_KIND_ERROR:          ExprKind = 255;
 
 # binary operator encoded in ExprBinary.op
@@ -228,6 +234,13 @@ pub rec ExprVectorLit {
     elems_len:   u32;
 }
 
+# a type spelling in an intrinsic's type-operand slot (#2178)
+# ---
+# ty: the syntactic AstType the operand names
+pub rec ExprTypeRef {
+    ty: id.TypeId;
+}
+
 # a syntactic expression node
 # ---
 # span: byte range of the expression in source
@@ -252,5 +265,6 @@ pub rec Expr {
         vector_lit: ExprVectorLit;
         project:    ExprProject;
         spread:     ExprSpread;
+        type_ref:   ExprTypeRef;
     };
 }

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -710,6 +710,7 @@ pub fun eval(
     if (k == expr.EXPR_KIND_ARRAY_LIT)  { ret R.err[CTValue, str]("array literals are not comptime-evaluable"); }
     if (k == expr.EXPR_KIND_STRUCT_LIT) { ret R.err[CTValue, str]("struct literals are not comptime-evaluable"); }
     if (k == expr.EXPR_KIND_VECTOR_LIT) { ret R.err[CTValue, str]("vector literals are not comptime-evaluable"); }
+    if (k == expr.EXPR_KIND_TYPE_REF)   { ret R.err[CTValue, str]("a type name has no comptime value"); }
     if (k == expr.EXPR_KIND_ERROR)      { ret R.err[CTValue, str]("expression has a parse error"); }
 
     ret R.err[CTValue, str]("expression is not comptime-evaluable");
@@ -1287,6 +1288,28 @@ fun first_call_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
     if (node.kind != expr.EXPR_KIND_CALL) { ret id.EXPR_NIL; }
     if (node.data.call.args_len < 1)      { ret id.EXPR_NIL; }
     ret a.expr_ids[node.data.call.args_start];
+}
+
+# whether the `$ident` callee spelled by `full` names an intrinsic whose first
+# argument is a TYPE rather than a value (#2178)
+#
+# `$size_of` / `$align_of` / `$offset_of` / `$fields` all take a type spelling
+# there; `$type_of` takes a value and `$error` a string. The parser consults this
+# to read that argument with the type grammar, so `Box[T]`, `*T`, `^T`, and
+# `[N]T` are all spellable; resolve and sema then bind and resolve it as an
+# ordinary type. Sole owner of the type-operand half of the closed intrinsic set.
+# ---
+# source: source text (for the callee span)
+# full:   the full span of the `$ident` callee, including the leading `$`
+# ret:    true when the callee's first argument is a type spelling
+pub fun intrinsic_takes_type_operand(source: str, full: token.Span) bool {
+    val ns: token.Span = comptime_ident_name(full);
+    if (ns.len == 0) { ret false; }
+    val text: View = span_text(source, ns);
+    ret view_eq_str(text, "size_of")
+     || view_eq_str(text, "align_of")
+     || view_eq_str(text, "offset_of")
+     || view_eq_str(text, "fields");
 }
 
 # whether `eid` is a `$type_of(arg)` intrinsic call, recognized

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -710,7 +710,6 @@ pub fun eval(
     if (k == expr.EXPR_KIND_ARRAY_LIT)  { ret R.err[CTValue, str]("array literals are not comptime-evaluable"); }
     if (k == expr.EXPR_KIND_STRUCT_LIT) { ret R.err[CTValue, str]("struct literals are not comptime-evaluable"); }
     if (k == expr.EXPR_KIND_VECTOR_LIT) { ret R.err[CTValue, str]("vector literals are not comptime-evaluable"); }
-    if (k == expr.EXPR_KIND_TYPE_REF)   { ret R.err[CTValue, str]("a type name has no comptime value"); }
     if (k == expr.EXPR_KIND_ERROR)      { ret R.err[CTValue, str]("expression has a parse error"); }
 
     ret R.err[CTValue, str]("expression is not comptime-evaluable");

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -588,12 +588,64 @@ fun parse_call_arg(p: *state.Parser) id.ExprId {
     ret state.push_expr(p, node);
 }
 
+# whether `callee` is a `$ident` naming an intrinsic whose first argument is a
+# type spelling (`$size_of`, `$align_of`, `$offset_of`, `$fields`)
+#
+# The intrinsic set itself lives in `comptime.intrinsic_takes_type_operand`; this
+# only unwraps the callee node.
+# ---
+# p:      parser state
+# callee: the callee expression of the call being parsed
+# ret:    true when argument 0 must be read with the type grammar
+fun callee_takes_type_operand(p: *state.Parser, callee: id.ExprId) bool {
+    val ce_opt: O.Option[*expr.Expr] = ast.get_expr(p.ast, callee);
+    if (O.is_none[*expr.Expr](ce_opt)) { ret false; }
+    val ce: *expr.Expr = O.unwrap[*expr.Expr](ce_opt);
+    if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret false; }
+    ret comptime.intrinsic_takes_type_operand(p.tokens.source, ce.span);
+}
+
+# parses a type-taking intrinsic's first argument with the TYPE grammar, wrapped
+# in an EXPR_KIND_TYPE_REF node so it occupies an ordinary argument slot (#2178)
+#
+# `$fields(Box[T])` / `$size_of(*T)` are type spellings, not expressions: read as
+# expressions they either mis-parse (a multi-argument `Pair[A, B]` is not an index)
+# or resolve to nothing, which is how a whole `$each` body came to be dropped with
+# no diagnostic. Reading them here with the same grammar type position uses makes
+# every type spelling available and gives resolve and sema one type path to follow.
+# ---
+# p:   parser state, cursor on the argument
+# ret: ExprId of the EXPR_KIND_TYPE_REF node
+fun parse_type_operand(p: *state.Parser) id.ExprId {
+    val start: token.Span = state.current(p).span;
+    val tid:   id.TypeId  = parse_type(p);
+
+    var payload: expr.ExprTypeRef;
+    payload.ty = tid;
+
+    # the node spans the type it wraps, so a diagnostic on the operand underlines
+    # the spelling the user wrote; an unparsed type falls back to the lead token.
+    var span: token.Span = start;
+    val t_opt: O.Option[*type.Type] = ast.get_type(p.ast, tid);
+    if (O.is_some[*type.Type](t_opt)) { span = O.unwrap[*type.Type](t_opt).span; }
+
+    var node: expr.Expr;
+    node.span          = span;
+    node.kind          = expr.EXPR_KIND_TYPE_REF;
+    node.data.type_ref = payload;
+    ret state.push_expr(p, node);
+}
+
 # parses a call expression `callee(args)`
 #
 # type_args_start/type_args_len carry any call-site generic arguments parsed by
 # parse_generic_call; both are 0 for a plain call. index_callee is EXPR_NIL
 # except for a provisional bracket call, where it carries the index-then-call
 # reading for resolve to choose (see ExprCall.index_callee).
+#
+# A type-taking comptime intrinsic reads its FIRST argument with the type grammar
+# (see parse_type_operand); every other argument, and every argument of every
+# other callee, is an ordinary expression.
 # ---
 # p:               parser state, cursor on '('
 # callee:          expression being called
@@ -603,6 +655,7 @@ fun parse_call_arg(p: *state.Parser) id.ExprId {
 # ret:             ExprId of the EXPR_KIND_CALL node
 fun parse_call(p: *state.Parser, callee: id.ExprId, type_args_start: u32, type_args_len: u32, index_callee: id.ExprId) id.ExprId {
     state.advance(p);
+    val type_operand: bool = callee_takes_type_operand(p, callee);
 
     # buffer the arguments rather than pushing them to the shared expr_id pool
     # as they are parsed: an argument that is itself a call or array literal
@@ -611,7 +664,8 @@ fun parse_call(p: *state.Parser, callee: id.ExprId, type_args_start: u32, type_a
     # block after parsing keeps the slice intact.
     var buf: state.ListBuf[id.ExprId] = state.list_buf_init[id.ExprId]();
     if (!state.at(p, token.KIND_RPAREN)) {
-        state.list_buf_push[id.ExprId](p, ?buf, parse_call_arg(p));
+        if (type_operand) { state.list_buf_push[id.ExprId](p, ?buf, parse_type_operand(p)); }
+        or                { state.list_buf_push[id.ExprId](p, ?buf, parse_call_arg(p)); }
         for (state.eat(p, token.KIND_COMMA)) {
             if (state.at(p, token.KIND_RPAREN)) { brk; }
             state.list_buf_push[id.ExprId](p, ?buf, parse_call_arg(p));

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -2148,26 +2148,18 @@ fun bind_stmt(rc: *ResolveContext, sid: id.StmtId) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# binds a `$each <ident> in <seq> { body }` (#1473): the sequence's `$fields(T)`
-# binds T as a type; the loop variable is declared in a fresh scope as a comptime
-# binding visible to the body, which is then bound. arm selection / expansion is
-# deferred to sema + lowering
+# binds a `$each <ident> in <seq> { body }` (#1473): the sequence binds as an
+# ordinary expression -- a `$fields(T)` sequence carries its T as a type-operand
+# node the call arm resolves as a type (#2178) -- and the loop variable is
+# declared in a fresh scope as a comptime binding visible to the body, which is
+# then bound. arm selection / expansion is deferred to sema + lowering
 # ---
 # rc:  resolver state for the module being resolved
 # ce:  the `$each` statement payload
 # ret: ok(true), or a binding error
 fun bind_comptime_each(rc: *ResolveContext, ce: *stmt.StmtComptimeEach) R.Result[bool, str] {
-    if (comptime.is_fields_call(rc.a, rc.source, ce.seq)) {
-        val targ: id.ExprId = comptime.fields_type_arg(rc.a, ce.seq);
-        if (targ != id.EXPR_NIL) {
-            val rt: R.Result[bool, str] = bind_intrinsic_type_arg(rc, targ);
-            if (R.is_err[bool, str](rt)) { ret rt; }
-        }
-    }
-    or {
-        val rs: R.Result[bool, str] = bind_expr(rc, ce.seq);
-        if (R.is_err[bool, str](rs)) { ret rs; }
-    }
+    val rs: R.Result[bool, str] = bind_expr(rc, ce.seq);
+    if (R.is_err[bool, str](rs)) { ret rs; }
 
     val r_s: R.Result[ScopeId, str] = open_scope(rc, rc.current_scope);
     if (R.is_err[ScopeId, str](r_s)) { ret R.err[bool, str](R.unwrap_err[ScopeId, str](r_s)); }
@@ -2358,7 +2350,36 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str] {
         }
         ret R.ok[bool, str](true);
     }
-    ret R.ok[bool, str](true);
+    if (e.kind == expr.EXPR_KIND_TYPE_REF) {
+        # a comptime intrinsic's type operand (#2178): bind the type spelling it
+        # carries through the ordinary type machinery, so `Box[T]`, `*T`, `^T` and
+        # `[N]T` all resolve exactly as they do in type position.
+        ret bind_type(rc, e.data.type_ref.ty);
+    }
+    if (expr_kind_binds_nothing(e.kind)) { ret R.ok[bool, str](true); }
+
+    # every child-bearing expression kind has an arm above; reaching here means a
+    # kind was added without one, and its identifiers would silently never be bound
+    # -- exactly how a `:^` strip cast shipped unresolved through a whole release
+    # (#2138/#2144). fail loudly at the gap rather than leaving sema to poison the
+    # unbound operand and lowering to report the wreckage.
+    ret diagnostic.error(?rc.s.diags, rc.a.file_id, e.span, "internal: this expression kind has no name-binding rule; the resolver cannot bind its operands");
+}
+
+# whether `k` is an expression kind with no name-bearing children, so binding it
+# is genuinely a no-op
+#
+# The literals, the `$ident` comptime root (a builtin, bound nowhere), and the
+# parse-error placeholder. Kept as an explicit list so `bind_expr`'s fallthrough
+# can treat anything else as a missing rule rather than as nothing to do.
+# ---
+# k:   the expression kind to classify
+# ret: true when the kind carries no names to bind
+fun expr_kind_binds_nothing(k: expr.ExprKind) bool {
+    ret k == expr.EXPR_KIND_LIT_INT   || k == expr.EXPR_KIND_LIT_FLOAT
+     || k == expr.EXPR_KIND_LIT_CHAR  || k == expr.EXPR_KIND_LIT_STR
+     || k == expr.EXPR_KIND_LIT_NIL   || k == expr.EXPR_KIND_COMPTIME_IDENT
+     || k == expr.EXPR_KIND_ERROR;
 }
 
 # bind every expression in `[start, start + len)` of the expr-id pool
@@ -2696,97 +2717,45 @@ fun edit_distance(a: str, b: str, cap: usize) usize {
 # their distance cannot be small anyway
 val SUGGEST_ROW: usize = 128;
 
-# classifies a call's callee as a comptime value intrinsic by its name: 1 for
-# `$size_of`/`$align_of` (one type argument), 2 for `$offset_of` (a type plus a
-# field), or 0 when the callee is not one of these. recognizing the intrinsic
-# in the bind pass lets its type-naming argument resolve through the primitive
-# registry (so `$size_of(i64)` works) and lets `$offset_of`'s bare field name
-# escape value-scope lookup
+# whether a call's callee is `$offset_of`, the one intrinsic whose argument list
+# is not uniformly bindable: its second argument is a bare field name, resolved
+# against the record at lowering time rather than in any scope here
 # ---
 # rc:     resolver state for the module being resolved
 # callee: the call's callee expression
-# ret:    1 for a one-type intrinsic, 2 for `$offset_of`, 0 otherwise
-fun comptime_intrinsic_kind(rc: *ResolveContext, callee: id.ExprId) u8 {
+# ret:    true when the callee is `$offset_of`
+fun callee_is_offset_of(rc: *ResolveContext, callee: id.ExprId) bool {
     val ce_opt: O.Option[*expr.Expr] = ast.get_expr(rc.a, callee);
-    if (O.is_none[*expr.Expr](ce_opt)) { ret 0; }
+    if (O.is_none[*expr.Expr](ce_opt)) { ret false; }
     val ce: *expr.Expr = O.unwrap[*expr.Expr](ce_opt);
-    if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret 0; }
+    if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret false; }
 
     val ns: token.Span = comptime.comptime_ident_name(ce.span);
-    if (ns.len == 0) { ret 0; }
+    if (ns.len == 0) { ret false; }
     val r: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, ns);
-    if (R.is_err[intern.StrId, str](r)) { ret 0; }
-    val name: intern.StrId = R.unwrap_ok[intern.StrId, str](r);
-
-    if (name == interned_literal(rc, "size_of"))   { ret 1; }
-    if (name == interned_literal(rc, "align_of"))  { ret 1; }
-    if (name == interned_literal(rc, "offset_of")) { ret 2; }
-    ret 0;
+    if (R.is_err[intern.StrId, str](r)) { ret false; }
+    ret R.unwrap_ok[intern.StrId, str](r) == interned_literal(rc, "offset_of");
 }
 
-# binds a comptime value intrinsic call's arguments. the first argument names a
-# type, so it resolves as a type spelling (primitive registry first, then the
-# value scope for user types) rather than as a value reference; `$offset_of`'s
-# second argument is a bare field name resolved against the record at lowering
-# time and is left unbound here. returns none when the call is not an intrinsic,
-# letting the caller fall back to ordinary call binding
+# binds a comptime intrinsic call whose argument list is not uniformly value
+# expressions
+#
+# A type-taking intrinsic carries its type operand as an EXPR_KIND_TYPE_REF the
+# parser read with the type grammar, so ordinary call binding already resolves it
+# as a type (#2178). The one shape that still needs handling is `$offset_of`'s
+# SECOND argument: a bare field name resolved against the record at lowering time,
+# which must escape value-scope lookup. Returns none for every other call, letting
+# the caller bind it as an ordinary call.
 # ---
 # rc:  resolver state for the module being resolved
 # c:   the call payload
-# ret: some(result) when handled as an intrinsic, none to fall through
+# ret: some(result) when handled here, none to fall through
 fun bind_comptime_intrinsic_call(rc: *ResolveContext, c: *expr.ExprCall) O.Option[R.Result[bool, str]] {
-    val kind: u8 = comptime_intrinsic_kind(rc, c.callee);
-    if (kind == 0)      { ret O.none[R.Result[bool, str]](); }
-    if (c.args_len < 1) { ret O.some[R.Result[bool, str]](R.ok[bool, str](true)); }
+    if (!callee_is_offset_of(rc, c.callee)) { ret O.none[R.Result[bool, str]](); }
+    if (c.args_len < 1)                     { ret O.some[R.Result[bool, str]](R.ok[bool, str](true)); }
 
     val arg0: id.ExprId = rc.a.expr_ids[c.args_start];
-    ret O.some[R.Result[bool, str]](bind_intrinsic_type_arg(rc, arg0));
-}
-
-# resolves an intrinsic's type-naming argument expression. a bare single
-# identifier resolves to a primitive (`i64`, `bool`, `ptr`, ...) before the
-# value scope, mirroring `resolve_type_path`; a `module.Type` member chain
-# resolves through the module's exports. the resolved SymbolId is recorded in
-# `expr_resolved` so sema can recover the operand type
-# ---
-# rc:  resolver state for the module being resolved
-# eid: the type-naming argument expression
-# ret: ok(true), or a binding error
-fun bind_intrinsic_type_arg(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str] {
-    if (eid == id.EXPR_NIL) { ret R.ok[bool, str](true); }
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(rc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret R.ok[bool, str](true); }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
-
-    if (e.kind == expr.EXPR_KIND_IDENT) {
-        val r: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, e.span);
-        if (R.is_err[intern.StrId, str](r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](r)); }
-        val name: intern.StrId = R.unwrap_ok[intern.StrId, str](r);
-
-        var sid: SymbolId = prim_symbol_for(rc, name);
-        if (sid == SYMBOL_NIL) { sid = scope_lookup_chain(rc, rc.current_scope, name); }
-        if (sid == SYMBOL_NIL) {
-            val re: R.Result[bool, str] = report_named(rc, e.span, "unresolved type name `", name, "`");
-            if (R.is_ok[bool, str](re)) { attach_suggestion(rc, name); }
-        }
-        or {
-            if (rc.expr_resolved != nil) { rc.expr_resolved[eid] = sid; }
-        }
-        ret R.ok[bool, str](true);
-    }
-
-    if (e.kind == expr.EXPR_KIND_MEMBER) {
-        # a qualified `module.Type` argument: bind the object alias first, then
-        # resolve the leaf against the module's exports (reuses the qualified
-        # member machinery used for value-position module references).
-        val ro: R.Result[bool, str] = bind_expr(rc, e.data.member.object);
-        if (R.is_err[bool, str](ro)) { ret ro; }
-        ret bind_member_qualified(rc, eid, ?e.data.member);
-    }
-
-    # any other argument shape is not a type spelling; bind it as a normal
-    # expression so a diagnostic surfaces the misuse.
-    ret bind_expr(rc, eid);
+    ret O.some[R.Result[bool, str]](bind_expr(rc, arg0));
 }
 
 # binds the two operands of a type comparison (`$type_of(...) == TypeName`,
@@ -2822,7 +2791,60 @@ fun bind_type_operand(rc: *ResolveContext, operand: id.ExprId) R.Result[bool, st
         if (O.is_none[*expr.Expr](n_opt)) { ret R.ok[bool, str](true); }
         ret bind_expr(rc, O.unwrap[*expr.Expr](n_opt).data.member.object);
     }
-    ret bind_intrinsic_type_arg(rc, operand);
+    ret bind_type_name_expr(rc, operand);
+}
+
+# binds a type name that arrives as an EXPRESSION rather than a type spelling
+#
+# Only the type-comparison operand needs this: `$type_of(x) == Name` is a binary
+# comparison whose right operand cannot be read with the type grammar, because
+# nothing at parse time distinguishes it from an ordinary value comparison -- the
+# comparison is recognized only here, after both operands are already expressions.
+# A single IDENT resolves to a primitive (`i64`, `bool`, `ptr`, ...) before the
+# value scope, mirroring `resolve_type_path`; a `module.Type` member chain
+# resolves through the module's exports. The resolved SymbolId is recorded in
+# `expr_resolved` so sema can recover the named type. A generic-instance spelling
+# (`Box[u32]`) is not expressible in this position -- the intrinsic operands that
+# CAN spell one carry a parsed type instead (#2178).
+# ---
+# rc:  resolver state for the module being resolved
+# eid: the type-naming operand expression
+# ret: ok(true), or a binding error
+fun bind_type_name_expr(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str] {
+    if (eid == id.EXPR_NIL) { ret R.ok[bool, str](true); }
+    val e_opt: O.Option[*expr.Expr] = ast.get_expr(rc.a, eid);
+    if (O.is_none[*expr.Expr](e_opt)) { ret R.ok[bool, str](true); }
+    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+
+    if (e.kind == expr.EXPR_KIND_IDENT) {
+        val r: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, e.span);
+        if (R.is_err[intern.StrId, str](r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](r)); }
+        val name: intern.StrId = R.unwrap_ok[intern.StrId, str](r);
+
+        var sid: SymbolId = prim_symbol_for(rc, name);
+        if (sid == SYMBOL_NIL) { sid = scope_lookup_chain(rc, rc.current_scope, name); }
+        if (sid == SYMBOL_NIL) {
+            val re: R.Result[bool, str] = report_named(rc, e.span, "unresolved type name `", name, "`");
+            if (R.is_ok[bool, str](re)) { attach_suggestion(rc, name); }
+        }
+        or {
+            if (rc.expr_resolved != nil) { rc.expr_resolved[eid] = sid; }
+        }
+        ret R.ok[bool, str](true);
+    }
+
+    if (e.kind == expr.EXPR_KIND_MEMBER) {
+        # a qualified `module.Type` operand: bind the object alias first, then
+        # resolve the leaf against the module's exports (reuses the qualified
+        # member machinery used for value-position module references).
+        val ro: R.Result[bool, str] = bind_expr(rc, e.data.member.object);
+        if (R.is_err[bool, str](ro)) { ret ro; }
+        ret bind_member_qualified(rc, eid, ?e.data.member);
+    }
+
+    # any other operand shape is not a type spelling; bind it as a normal
+    # expression so a diagnostic surfaces the misuse.
+    ret bind_expr(rc, eid);
 }
 
 # whether `eid` is an `f.type` operand whose object resolves, in the current

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -673,6 +673,27 @@ pub fun report(sc: *SemaContext, span: token.Span, message: str) {
     diagnostic.error(?sc.s.diags, sc.a.file_id, span, message);
 }
 
+# snapshot the diagnostic sink's length, to be paired with `reported_since`
+#
+# Lets a leaf that must never fail silently confirm that a nested resolution
+# actually filed the diagnostic explaining its failure, and supply one itself
+# when nothing did (#2178).
+# ---
+# sc:  sema context
+# ret: the current diagnostic count
+pub fun diag_mark(sc: *SemaContext) usize {
+    ret sc.s.diags.len;
+}
+
+# whether any diagnostic was filed since `mark`
+# ---
+# sc:   sema context
+# mark: a `diag_mark` snapshot taken before the work in question
+# ret:  true when the sink grew
+pub fun reported_since(sc: *SemaContext, mark: usize) bool {
+    ret sc.s.diags.len > mark;
+}
+
 # emit a SEVERITY_ERROR diagnostic at `span` with a secondary `note:` line
 #
 # The note attaches only when the error diagnostic itself landed, so a failed

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1397,9 +1397,12 @@ fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: 
 # template time and the whole body escapes the per-instance constant-time
 # re-validation.
 #
-# A TYPE_ERROR from here silently drops an entire `$each` body, so this leaf
-# guarantees a diagnostic: if the resolution failed without filing one, it files
-# one itself rather than handing callers a poison value they absorb.
+# A TYPE_ERROR from here drops an entire `$each` body, so this leaf guarantees a
+# diagnostic accompanies one. Every way an operand can fail to name a type is
+# reported by resolve or by `resolve_type_ref` itself; what is left is an
+# allocation failure interning the type, which those paths propagate silently.
+# Filing a diagnostic for that is what stops a resource failure from reading as a
+# body the program never had.
 # ---
 # sc:   sema context
 # eid:  the type-operand expression
@@ -1407,22 +1410,18 @@ fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: 
 # ret:  the named TypeId, substituted at an instance, or TYPE_ERROR
 fun intrinsic_operand_type(sc: *context.SemaContext, eid: id.ExprId, span: token.Span) type.TypeId {
     val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) {
-        context.report(sc, span, "comptime intrinsic: the type argument is missing");
+    # the parser reads this slot with the type grammar for exactly these callees,
+    # so a node that is not a type spelling cannot be produced from source.
+    if (O.is_none[*expr.Expr](e_opt) || O.unwrap[*expr.Expr](e_opt).kind != expr.EXPR_KIND_TYPE_REF) {
+        context.report(sc, span, "internal: a comptime intrinsic argument was not parsed as a type");
         ret type.TYPE_ERROR;
     }
     val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
-    # the parser reads this slot with the type grammar, so any other node here is
-    # a parse-recovery placeholder, never a type the user wrote.
-    if (e.kind != expr.EXPR_KIND_TYPE_REF) {
-        context.report(sc, span, "comptime intrinsic: this argument must name a type");
-        ret type.TYPE_ERROR;
-    }
 
-    val mark: usize        = context.diag_mark(sc);
-    val ty:   type.TypeId  = resolve_type_ref(sc, e.data.type_ref.ty);
+    val mark: usize       = context.diag_mark(sc);
+    val ty:   type.TypeId = resolve_type_ref(sc, e.data.type_ref.ty);
     if (ty == type.TYPE_ERROR && !context.reported_since(sc, mark)) {
-        context.report(sc, e.span, "comptime intrinsic: cannot resolve the type named by this argument");
+        context.report(sc, e.span, "internal: could not intern the type named by this comptime intrinsic argument");
     }
     ret ty;
 }
@@ -1478,12 +1477,14 @@ pub fun field_seq_owner(sc: *context.SemaContext, seq_eid: id.ExprId, span: toke
         context.report(sc, span, "$fields requires a record type");
         ret type.TYPE_ERROR;
     }
-    # a generic instance whose table is still absent after the materialization above did
-    # not fail the record check (that reads the target nominal, not the table) - the
-    # materialization itself failed, an allocation failure. Reporting nothing would unroll
-    # zero fields and silently skip the body; reporting the type error would blame valid
-    # source for a resource failure.
-    if (!instance_table_ready(sc, owner)) {
+    # a record that passed the check above but still carries no table: the record check
+    # reads the type's kind (for an instance, its target nominal), never the table, so a
+    # materialization that failed outright lands here. The unroll reads `field_count`,
+    # which is 0 for an absent table exactly as it is for a record with no fields --
+    # opposite outcomes, one expanding to nothing and one dropping the body unchecked.
+    # Reporting nothing would silently pick the wrong one; reporting a type error would
+    # blame valid source for a resource failure.
+    if (O.is_none[*context.FieldTable](context.field_table_for(sc, owner))) {
         context.report(sc, span, "internal: could not materialize the field table for this `$fields` type argument");
         ret type.TYPE_ERROR;
     }
@@ -1588,22 +1589,6 @@ fun infer_spread(sc: *context.SemaContext, sp: *expr.ExprSpread, span: token.Spa
         ret type.TYPE_ERROR;
     }
     ret it;
-}
-
-# whether a generic instance's field table was materialized
-#
-# Only meaningful after `ensure_fields`: a non-instance, or an instance whose table now
-# matches its target nominal's field count, is ready. A short table means the on-demand
-# materialization failed rather than that the type has no fields.
-# ---
-# sc: sema context
-# ty: the TypeId to inspect
-# ret: true when `ty` needs no table or has a complete one
-fun instance_table_ready(sc: *context.SemaContext, ty: type.TypeId) bool {
-    val to: O.Option[*type.Type] = type.get(?sc.s.types, ty);
-    if (O.is_none[*type.Type](to))                                { ret true; }
-    if (O.unwrap[*type.Type](to).kind != type.TYPE_INSTANCE)      { ret true; }
-    ret O.is_some[*type.FieldTable](type.field_table_for(?sc.s.types, ty));
 }
 
 # whether `ty` is a record (or a generic record instance), the aggregate

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -455,6 +455,14 @@ pub fun infer_expr(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
     or (e.kind == expr.EXPR_KIND_VECTOR_LIT) {
         t = infer_vector_lit(sc, ?e.data.vector_lit, e.span);
     }
+    or (e.kind == expr.EXPR_KIND_TYPE_REF) {
+        # a comptime intrinsic's type operand (#2178). the two legitimate consumers
+        # (`infer_comptime_intrinsic`, `field_seq_owner`) read it directly through
+        # `intrinsic_operand_type` and never come through here, so arriving in this
+        # walk means the intrinsic call itself sits in a value position.
+        context.report(sc, e.span, "a type name is not a value; this position takes a value expression");
+        t = type.TYPE_ERROR;
+    }
     or {
         t = type.TYPE_ERROR;
     }
@@ -467,15 +475,21 @@ pub fun infer_expr(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
 
 # IDENT: the type of the resolved symbol
 #
-# An unresolved symbol (SYMBOL_NIL upstream) yields TYPE_ERROR without a fresh
-# diagnostic -- resolve already reported the root cause.
+# An identifier with no bound symbol is an INVARIANT BREACH, not a quiet
+# TYPE_ERROR (#2144). A name the resolver rejected never reaches here at all --
+# the build stops on the diagnostic sink between the load phase and sema -- so
+# the only way to arrive unbound is for the resolver to have skipped the operand
+# without a word, as a missing `bind_expr` arm did for a `:^` strip cast through
+# an entire release (#2138). Poisoning it silently hands lowering a broken
+# expression and moves the error a whole phase away from its cause, so report it
+# here, where the gap is.
 # ---
 # sc:  sema context
 # eid: the identifier expression
 # ret: the symbol's value type, or TYPE_ERROR
 fun infer_ident(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
     val sym_opt: O.Option[*resolve.Symbol] = context.symbol_for_expr(sc, eid);
-    if (O.is_none[*resolve.Symbol](sym_opt)) { ret type.TYPE_ERROR; }
+    if (O.is_none[*resolve.Symbol](sym_opt)) { ret report_unbound_ident(sc, eid); }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](sym_opt);
 
     # a `$each a in va` pack loop variable: a comptime-flagged `SYM_VAL` with no
@@ -508,6 +522,23 @@ fun infer_ident(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
     }
 
     ret context.decl_type_for(sc, sym);
+}
+
+# report an identifier that reached type inference with no bound symbol
+#
+# The message names the actual cause -- the resolver, not the source -- because
+# the source is well-formed by construction: a name the resolver could not find
+# is reported there and stops the build before sema runs.
+# ---
+# sc:  sema context
+# eid: the unbound identifier expression
+# ret: TYPE_ERROR
+fun report_unbound_ident(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
+    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (O.is_some[*expr.Expr](e_opt)) {
+        context.report(sc, O.unwrap[*expr.Expr](e_opt).span, "internal: this identifier reached type inference unbound; the name resolver neither bound it nor reported it");
+    }
+    ret type.TYPE_ERROR;
 }
 
 # the concrete element type of a `$each a in va` pack loop variable, or TYPE_NIL
@@ -1005,9 +1036,35 @@ fun infer_type_operand(sc: *context.SemaContext, operand: id.ExprId, span: token
     if (is_field_type_operand(sc, operand)) {
         ret field_type_operand_type(sc, operand);
     }
-    val op_ty: type.TypeId = intrinsic_operand_type(sc, operand, span);
+    val op_ty: type.TypeId = type_name_expr_type(sc, operand, span);
     set_expr_type(sc, operand, op_ty);
     ret op_ty;
+}
+
+# resolve a type name that arrives as an EXPRESSION to the type it names
+#
+# The type-comparison operand is the one type spelling the parser cannot read
+# with the type grammar: `$type_of(x) == Name` is a binary comparison, and
+# nothing distinguishes it from a value comparison until resolve recognizes the
+# shape, by which point both sides are expressions. So the name arrives as an
+# IDENT or a `module.Type` member chain carrying the SymbolId resolve recorded
+# (`bind_type_name_expr`), and only those two spellings are available here -- a
+# generic instance `Box[u32]` is not expressible in this position. The intrinsic
+# operands that CAN spell one take a parsed type instead (`intrinsic_operand_type`).
+# ---
+# sc:   sema context
+# eid:  the type-name operand expression
+# span: the operand span for diagnostics
+# ret:  the named TypeId, or TYPE_ERROR
+fun type_name_expr_type(sc: *context.SemaContext, eid: id.ExprId, span: token.Span) type.TypeId {
+    val sym_opt: O.Option[*resolve.Symbol] = context.symbol_for_expr(sc, eid);
+    if (O.is_none[*resolve.Symbol](sym_opt)) {
+        # resolve reports an unresolved type name at this leaf and stops the build
+        # before sema, so an unbound operand here is a discarded comptime arm's --
+        # unreachable, and no place for a diagnostic.
+        ret type.TYPE_ERROR;
+    }
+    ret type_for_symbol(sc, O.unwrap[*resolve.Symbol](sym_opt), span);
 }
 
 # whether `eid` is an `f.type` operand whose object evaluates to a comptime field
@@ -1325,30 +1382,49 @@ fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: 
     ret prim_or_error(sc, type.TYPE_U64);
 }
 
-# resolve a comptime intrinsic's type-naming argument to its semantic type
+# resolve a comptime intrinsic's type operand to its semantic type
 #
-# The argument is a name expression bound in the resolve pass: a single IDENT
-# (primitive or user type) or a `module.Type` member chain. Both carry their
-# resolved SymbolId on the argument expression, mapped to a type by
-# `type_for_symbol` (which handles primitives, records, unions, and defs).
+# The operand is an EXPR_KIND_TYPE_REF: the parser read it with the type grammar
+# and it carries the syntactic AstType, so the whole type language is available
+# here -- a plain name, `module.Type`, a generic instance `Box[T]` / `Pair[A, B]`,
+# a pointer, a `^` secret, an array. Resolution is `resolve_type_ref`, the same
+# one type position uses, so this leaf can never drift behind the type grammar
+# the way a hand-rolled IDENT/MEMBER reinterpretation did (#2178).
 #
-# `type_for_symbol` applies the active generic substitution at its generic-parameter
+# `resolve_type_ref` applies the active generic substitution at its generic-parameter
 # leaf, so `$fields(T)` resolves to the instance's concrete record while re-inferring
 # an instance body (#2168). Without that the `$each` unroll defers exactly as at
 # template time and the whole body escapes the per-instance constant-time
 # re-validation.
+#
+# A TYPE_ERROR from here silently drops an entire `$each` body, so this leaf
+# guarantees a diagnostic: if the resolution failed without filing one, it files
+# one itself rather than handing callers a poison value they absorb.
 # ---
 # sc:   sema context
-# eid:  the type-naming argument expression
-# span: the argument span for diagnostics
+# eid:  the type-operand expression
+# span: the operand span for diagnostics
 # ret:  the named TypeId, substituted at an instance, or TYPE_ERROR
 fun intrinsic_operand_type(sc: *context.SemaContext, eid: id.ExprId, span: token.Span) type.TypeId {
-    val sym_opt: O.Option[*resolve.Symbol] = context.symbol_for_expr(sc, eid);
-    if (O.is_none[*resolve.Symbol](sym_opt)) {
-        # resolve already reported the unresolved name; absorb silently
+    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (O.is_none[*expr.Expr](e_opt)) {
+        context.report(sc, span, "comptime intrinsic: the type argument is missing");
         ret type.TYPE_ERROR;
     }
-    ret type_for_symbol(sc, O.unwrap[*resolve.Symbol](sym_opt), span);
+    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    # the parser reads this slot with the type grammar, so any other node here is
+    # a parse-recovery placeholder, never a type the user wrote.
+    if (e.kind != expr.EXPR_KIND_TYPE_REF) {
+        context.report(sc, span, "comptime intrinsic: this argument must name a type");
+        ret type.TYPE_ERROR;
+    }
+
+    val mark: usize        = context.diag_mark(sc);
+    val ty:   type.TypeId  = resolve_type_ref(sc, e.data.type_ref.ty);
+    if (ty == type.TYPE_ERROR && !context.reported_since(sc, mark)) {
+        context.report(sc, e.span, "comptime intrinsic: cannot resolve the type named by this argument");
+    }
+    ret ty;
 }
 
 # write `ty` into an expression's expr_type slot, the parallel array sema fills
@@ -2144,6 +2220,18 @@ fun resolve_type_ref_raw(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
 # The symbol is recorded by resolve in type_resolved; it maps to the nominal /
 # primitive / transparent type it names, and -- when generic args are present --
 # instantiates.
+#
+# An unbound node yields TYPE_ERROR with no diagnostic, and that silence is
+# load-bearing rather than a fallback: `resolve_all_types` walks EVERY syntactic
+# AstType in the module, including the ones the resolver deliberately never
+# visited -- a discarded `$if` arm's annotations, and the orphan nodes the
+# parser's speculative type probe leaves behind for a bracket call. Those are
+# unreachable, so a name lookup there is meaningless and reporting one would
+# reject valid programs. A REACHABLE unresolved name is reported by resolve
+# itself (`resolve_type_path`), which stops the build before sema. Contrast
+# `infer_ident`, whose unbound case really is an invariant breach (#2144), and
+# `intrinsic_operand_type`, which guarantees a diagnostic for the reachable
+# operand it owns (#2178).
 # ---
 # sc:    sema context
 # tid:   syntactic AstType id of the name
@@ -2153,7 +2241,7 @@ fun resolve_type_ref_raw(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
 fun resolve_type_named(sc: *context.SemaContext, tid: id.TypeId, named: *atype.TypeNamed, span: token.Span) type.TypeId {
     val sym_opt: O.Option[*resolve.Symbol] = context.symbol_for_type(sc, tid);
     if (O.is_none[*resolve.Symbol](sym_opt)) {
-        # resolve already reported the unresolved name; absorb silently
+        # an unreachable node the resolver never visited; see the note above
         ret type.TYPE_ERROR;
     }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](sym_opt);


### PR DESCRIPTION
Fixes two silent-failure sema defects: a comptime intrinsic's type operand that
resolved to nothing (#2178), and a poison value that hid resolver gaps until
lowering (#2144).

## #2178 — root cause

`$fields(T)` / `$size_of(T)` / `$align_of(T)` / `$offset_of(T, f)` take a **type**.
The parser stored that argument as an *expression*, and every consumer
re-interpreted the expression as a type: resolve through a hand-rolled
IDENT/MEMBER binder (`bind_intrinsic_type_arg`), sema through `symbol_for_expr` +
`type_for_symbol` (`intrinsic_operand_type`).

That re-interpretation covered two spellings out of the entire type grammar. A
generic instance `Box[T]` parses as an INDEX expression, binds to nothing and
resolves to nothing — `intrinsic_operand_type` returned `TYPE_ERROR`, and
`field_seq_owner` / `infer_stmt_comptime_each` both `ret ok` on `TYPE_ERROR`. The
whole `$each` body was neither type-checked nor emitted, with **zero diagnostics**.

The argument is a type, so it is now parsed as one. `EXPR_KIND_TYPE_REF` carries
the syntactic AstType in the argument slot; resolve binds it with `bind_type`,
sema resolves it with `resolve_type_ref` — the same paths type position uses, so
this leaf cannot drift behind the type grammar again. Both hand-rolled
re-interpretations are deleted. The expression-shaped spelling survives only where
it must: the `$type_of(x) == Name` comparison operand, which is not recognizable
as a type comparison until after both sides are parsed.

## #2178 — surface enumeration

Every row built and run.

| Form | On `dev` | Here |
|---|---|---|
| `$fields(T)` over a `T` parameter | works (1 field) | works (1 field) |
| `$fields(Box[T])` in a generic | **silently 0 fields, body dropped** | 1 field, body emitted |
| `$fields(Box[In[T]])` nested generic | **silently 0 fields** | 1 field |
| `$fields(Box[T])` inside a nested `$each` | **silently 0 fields** | 1 field |
| `$fields(Pair[A, B])` multi-argument | **parse error**, `expected ']' to close index expression` | 2 fields |
| `$fields(Box[u32])` concrete, non-generic | **`error: unresolved identifier u32`** | 1 field |
| `$fields(mod.Rec)` / `$fields(mod.G[u32])` cross-module | qualified plain name worked; instance did not | both work |
| `$fields(rec { x: u32; })` inline record | not expressible | 1 field |
| `$size_of(Box[T])`, `$align_of(Box[T])` | **`error: constant typing: constant carries an incompatible type`** (IR verifier, no span) | 4, 8 |
| `$offset_of(Pair[A, B], b)` | parse error | 8 |
| `$size_of(*Box[T])` | parse error, `expected an expression` | 8 |
| `$size_of([4]u16)` | parse error, `expected '{' after array type in array literal` | 8 |
| `$size_of(^u32)` | parse error + `unresolved identifier u32` | 4 |

Only `$fields(T)` over a bare type parameter already worked.

## #2178 — reproducer

The issue's program, verbatim. On `dev` it builds clean — 0 diagnostics — and
prints `0`. Here it is refused:

```
error: type mismatch: expected u32, found T
 --> ./src/main.mach:8:34
  |
8 |     $each f in $fields(Box[T]) { acc = b.[f]; }
  |                                  ^^^^^^^^^^^
  |
  = note: mach has no implicit widening; cast the value with `value::Type`

error: type mismatch: expected u32, found ^u32
 --> ./src/main.mach:8:34
  |
8 |     $each f in $fields(Box[T]) { acc = b.[f]; }
  |                                  ^^^^^^^^^^^
  |
  = note: mach has no implicit widening; cast the value with `value::Type`
```

Two diagnostics because the body is now checked twice and both checks fire: once
at template time against `Box[T]`'s `T`-typed field, once during the per-instance
re-validation at `^u32`. The issue's "two independent defects would each have
caught it, and neither ran" is now literally true — both run.

## #2144 — the full list of sites, and what each hides

Three sema sites carry the same false comment ("resolve already reported"). Each
was instrumented to report instead of poisoning, and the compiler, mach-std, both
unit suites and the full int suite were built through it:

| Site | Hits | Disposition |
|---|---|---|
| `infer_ident` (infer.mach) | **0** | genuine invariant breach → now reports |
| `intrinsic_operand_type` (infer.mach) | **0** | #2178's site → now guarantees a diagnostic |
| `resolve_type_named` (infer.mach) | **44378** | **benign and load-bearing, kept** |

The premise behind all three is false in the same way: a name the *resolver*
rejects never reaches sema. `engine.run_phase` gates on `diagnostic.has_errors`
after PH_LOAD, so a reported resolve error stops the build before PH_SEMA. The
poison can only ever fire when the resolver was **silent**.

**`resolve_type_named` is the exception, and it is not a defect.**
`resolve_all_types` walks *every* syntactic AstType in the module in index order,
including nodes the resolver deliberately never visits: annotations in discarded
`$if` arms (`pub def usize: u16;` in mach-std's pointer-width fork) and the orphan
type nodes `probe_type_payload` leaves behind for every bracket call
(`R.ok[bool, str](...)` — this is the bulk of the 44378). Those are unreachable, a
name lookup there is meaningless, and reporting one would reject valid programs.
That site keeps its silence; only its false comment is corrected.

**What the `infer_ident` poison hides today: nothing.** `bind_expr` currently has
an arm for every child-bearing expression kind, so there is no live resolver gap.
**No new issues are filed, because the sweep found no genuine gap to file.**

The real exposure is prospective and structural, and it is the second half of the
fix: `bind_expr`'s terminal `ret R.ok(true)` silently accepted *any* expression
kind with no binding rule. That is exactly how #2138 shipped — a `:^` strip cast
with no arm, unresolved through the whole 4.1.0 release. It is now an explicit
childless-kind list (`expr_kind_binds_nothing`); anything else reports at the gap.

Recreating #2138 (mutation M8 below: delete the STRIP arm) shows the difference
directly, on `fun down(a: ^u32) u32 { ret a:^; }`:

| | diagnostic |
|---|---|
| dev's behaviour (both guards removed) | `error: unresolved identifier` — at **lowering**, blaming the source |
| sema guard only | `internal: this identifier reached type inference unbound; the name resolver neither bound it nor reported it` — at **sema**, naming the cause |
| both guards (this PR) | `internal: this expression kind has no name-binding rule; the resolver cannot bind its operands` — at **resolve**, on the gap itself |

`ut_sema_errs` also now runs sema only when resolve was clean, mirroring the phase
gate. Without it the sema-only harness typed an AST the resolver had already
rejected — the fidelity gap #2144's second bullet names, in the direction that
would have made the new assertion unfalsifiable.

## Diagnostics added

- `internal: this identifier reached type inference unbound; the name resolver neither bound it nor reported it`
- `internal: this expression kind has no name-binding rule; the resolver cannot bind its operands`
- `internal: a comptime intrinsic argument was not parsed as a type`
- `internal: could not intern the type named by this comptime intrinsic argument`
- `a type name is not a value; this position takes a value expression`

## Tests

23 assertions in `mach.lang.driver:intrinsic_type_operand_is_a_type`, plus an int
regression case. Every rejection assertion needles on a diagnostic from **inside**
the `$each` body — the only evidence the body was type-checked rather than dropped.

**12 of the 23 fail on `dev`, each for the believed reason** (verified by applying
only the test diff onto `dda66e3d` and reading the per-assertion failures): 1–5
(body silently dropped, or unparseable), 8 and 12 (`Pair[A, B]` parse error),
10–11 (operand reached the IR verifier — asserted through `ut_lower_ok`, since a
sema-only assertion cannot see a lowering failure), 13–15 (composite spellings
unparseable). Assertion 23 (a resolver-rejected name is reported exactly once)
also discriminates, against mutation M9.

The remaining 6 are no-over-rejection controls and negative-path pins that already
held on `dev`; they are regression pins, not guards.

`int/regression/2178-intrinsic-type-operand` is the end-to-end half: the unit
tests reach sema and lower, but only running the program shows the body was
**emitted**. A dropped body leaves every accumulator at its initial value and the
program still exits 0. The case fails on `dev` with 5 build errors.

## Mutation results

| Mutation | Result |
|---|---|
| **M1** parser no longer reads arg0 as a type | **KILLED at self-host** — the mutated compiler cannot compile the compiler (18 errors, `$size_of(ptr)` → `unresolved identifier ptr`) |
| **M2** drop `intrinsic_operand_type`'s not-a-type report | SURVIVED 111/111 |
| **M3** drop the `reported_since` diagnostic guarantee | SURVIVED 111/111 |
| **M4** `infer_ident` back to a silent TYPE_ERROR | SURVIVED 111/111 against the suite; **KILLED under M8+M5** (the fault it exists for) — the diagnostic moves from sema, naming the resolver, to lowering, blaming the source |
| **M5** `bind_expr` fallthrough back to `ret ok(true)` | SURVIVED 111/111 against the suite; **KILLED under M8** — with it, a missing bind arm reports at the gap; without it, the same program mis-reports a phase later |
| **M6** drop the TYPE_REF value-position report | **KILLED** 110/111 (assertion 20) |
| **M7** drop the `$fields` field-table guard | SURVIVED 111/111 |
| **M8** delete `bind_expr`'s STRIP arm (recreate #2138) | **KILLED** 100/111, 11 tests |
| **M9** drop the `ut_sema_errs` resolve gate | **KILLED** 110/111 (assertion 23) |

**Surviving guards, and why they are kept rather than removed.** M2, M3 and M7 are
each unreachable from source *because the fix works*: M2 asserts the parser
guarantee that this slot holds a type; M3 and M7 cover an allocation failure
interning a type or materializing a field table. Removing them reinstates a silent
`$each`-body drop under memory pressure, which is the exact failure mode this PR
exists to close, and the file already reports OOM at a sema leaf rather than
poisoning (`infer_generic_call`, #1348). M7 also replaces a narrower guard that was
already on `dev` (`instance_table_ready`, from #2168) — same property, strictly
wider coverage, one call instead of a kind test. M4 and M5 are invariant
assertions: they survive the suite but are killed by mutating the invariant they
protect, which is the only way to exercise an assertion about a state the code
makes unreachable. **Flagging these five explicitly for a reviewer's call.**

One guard was found dead and **removed**: a `comptime.eval` arm for TYPE_REF.
`eval` rejects the enclosing CALL before it can descend to an argument, so the arm
never fired across the compiler, mach-std, both suites and the int suite.

## Verification

- mach **869 / 0** (`dev` is 868; +1 is the new test), mach-std **611 / 0** at pin `eff1e8e` — `dep/mach-std` HEAD verified against `mach.lock`.
- int suite: all cases pass on linux, including the new one.
- Three-generation fixpoint: **B == C** (`03cb30a7…`). A != B is seed lag — the 4.2.2 seed parses these arguments as expressions.
- **Objects byte-identical**: the branch compiler and the `dev`-fixpoint compiler produce the *same bytes* (`d104a1fb…`) from unchanged `dev` source at `dda66e3d`. Zero codegen delta for code that does not hit the newly-diagnosed forms.
- Cross-target builds from source: linux-arm64, linux-riscv64, windows-x86_64, darwin-aarch64 all OK.

## Out of scope, surfaced not fixed

Two pre-existing behaviours confirmed identical on `dev` and here, so neither is a
regression from this change:

1. Naming a generic type without its arguments (`var b: Box;`, `$size_of(Box)`) is
   silently accepted; `$fields(Box)` unrolls the template's own fields with `T`
   unbound. There is no generic-arity check in type position.
2. `doc/language/decorators.md` and `grammar.md` document `#[align($align_of(u64))]`
   as valid, but a layout intrinsic in a decorator argument or an array length is
   rejected — `align on a type must be a compile-time constant` /
   `array length is not a comptime constant`. `comptime.eval` rejects CALL, and the
   constant-folding path that handles these intrinsics elsewhere is not wired here.

Closes #2178
Closes #2144
