### PR TITLE
fix(lower): fold comptime type gates and module-scope vals against what they actually name (#2257, #2206)

### DIFF
--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -44,6 +44,11 @@ A bare type name (e.g. `i64`, `str`, `Point`) is the other valid operand.
 The comparison selects one branch at compile time per monomorphization
 instance — useful for per-element type dispatch inside `$each` bodies.
 
+The operand is read at the **instance's** concrete type, in a plain generic as
+much as in a pack-tailed one, and whether it is a parameter, a local, a field, or
+a type derived from a generic parameter (`*T`). `$type_of(x) == T` against a
+generic parameter compares the instance's argument on both sides, so it holds.
+
 The provably-dead arms are **pruned** before type-checking, so each arm uses
 `arg` at its own concrete type with no per-arm cast: the `str` arm above is
 never checked against a `u64` element. Only the selected arm is type-checked

--- a/doc/language/val-var.md
+++ b/doc/language/val-var.md
@@ -34,6 +34,13 @@ At module top level:
 
 Inside functions, they are local to the enclosing block.
 
+A module-level `val` whose initializer is a compile-time constant **is** that
+value at every use site, in its own module and in every module that imports it —
+however the reference is spelled (bare, module-qualified, or through a `use`
+alias). No load is emitted, and arithmetic over it folds and strength-reduces
+like any other literal. Its storage is still emitted, so `?NAME` has an address,
+and a `val` whose initializer is not a compile-time constant keeps its load.
+
 ## `ext` — foreign data imports
 
 `ext val` / `ext var` declares a binding whose storage lives in another object,

--- a/int/regression/2257-generic-instance-fold/expect.txt
+++ b/int/regression/2257-generic-instance-fold/expect.txt
@@ -1,0 +1,6 @@
+param=1 2
+local=1 2
+field=1 2
+derived=1 9
+nested=1 9
+each=2 27

--- a/int/regression/2257-generic-instance-fold/mach.toml
+++ b/int/regression/2257-generic-instance-fold/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case2257"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2257-generic-instance-fold/src/main.mach
+++ b/int/regression/2257-generic-instance-fold/src/main.mach
@@ -1,0 +1,101 @@
+# regression pin for #2257: a comptime type gate inside a plain generic, folded
+# against the instance rather than the template parameter.
+#
+# a generic template's body is typed once, against the raw generic parameter; its
+# instances are emitted later, from lowering, against the concrete arguments.
+# `$type_of`'s operand resolver reads the semantic type directly, with no
+# substitution of its own, so every gate over anything whose type mentioned `T`
+# folded against the parameter and silently selected the fallback arm - no
+# diagnostic, no crash, a plausible answer. that makes execution the only way to
+# pin it, and the value each row prints names WHICH arm was compiled.
+#
+# a second instantiation of the same template accompanies each shape, so a fold
+# that ignores the instance entirely (one arm for every instantiation) is
+# distinguishable from one that reads it (a different arm per instantiation).
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+rec Wrap[T] { a: T; n: u32; }
+
+rec Pair { x: u32; y: u32; }
+
+rec Trio { x: u32; y: u32; z: u32; }
+
+def PU32: *u32;
+
+# over a `T` parameter.
+fun by_param[T](s: T) u32 {
+    $if ($type_of(s) == u32) { ret 1; }
+    $or ($type_of(s) == u64) { ret 2; }
+    $or                      { ret 9; }
+}
+
+# over a `T` local.
+fun by_local[T](s: T) u32 {
+    var out: T = s;
+    $if ($type_of(out) == u32) { ret 1; }
+    $or ($type_of(out) == u64) { ret 2; }
+    $or                        { ret 9; }
+}
+
+# over a `T`-typed field of a generic record.
+fun by_field[T](s: T) u32 {
+    var w: Wrap[T];
+    w.a = s;
+    $if ($type_of(w.a) == u32) { ret 1; }
+    $or ($type_of(w.a) == u64) { ret 2; }
+    $or                        { ret 9; }
+}
+
+# over a local whose type is DERIVED from `T`.
+fun by_derived[T](s: T) u32 {
+    var out: *T = ?s;
+    $if ($type_of(out) == PU32) { ret 1; }
+    $or                         { ret 9; }
+}
+
+# nested: the inner gate is reached only when the outer one already folded right.
+fun by_nested[T](s: T) u32 {
+    var out: T = s;
+    $if ($type_of(out) == u32) {
+        $if ($type_of(out) == u32) { ret 1; }
+        $or                        { ret 5; }
+    }
+    $or { ret 9; }
+}
+
+# inside a `$each` over `$fields(T)`, re-inferred per element at monomorphization -
+# the gate here is over the enclosing local, not over the element.
+fun by_each[T](s: T) u32 {
+    var out: T   = s;
+    var r:   u32 = 0;
+    $each f in $fields(T) {
+        $if ($type_of(out) == Pair) { r = r + 1; }
+        $or                         { r = r + 9; }
+    }
+    ret r;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    val u: u32 = 5;
+    val w: u64 = 5;
+
+    p.printlnf("param={} {}",   by_param[u32](u),   by_param[u64](w));
+    p.printlnf("local={} {}",   by_local[u32](u),   by_local[u64](w));
+    p.printlnf("field={} {}",   by_field[u32](u),   by_field[u64](w));
+    p.printlnf("derived={} {}", by_derived[u32](u), by_derived[u64](w));
+    p.printlnf("nested={} {}",  by_nested[u32](u),  by_nested[u64](w));
+
+    var pr: Pair;
+    pr.x = 1;
+    pr.y = 2;
+    var tr: Trio;
+    tr.x = 1;
+    tr.y = 2;
+    tr.z = 3;
+    p.printlnf("each={} {}", by_each[Pair](pr), by_each[Trio](tr));
+    ret 0;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6455,10 +6455,13 @@ fun ut_has_extern_fn(s: *session.Session, m: *ir.Module, needle: str) bool {
 # reaches lowering's comptime-const fold - which read main's own table, keyed by
 # the bare leaf name, and answered 707. silently, and only because the names
 # collide. the fold now reads the DECLARING module's table: 909 appears exactly
-# once (the qualified read) and 707 never appears as an instruction operand (it
-# survives only as main's own global initialiser). the same project pins the two
-# shapes that must not change: the unqualified local `X` still loads main's own
-# global, and a qualified `b.Y` with no colliding name still resolves to b
+# once (the qualified read) and 707 exactly once (main's own unqualified read). a
+# fold answering the qualified read from main's table would put 707 twice and 909
+# never, so the pair of counts is what discriminates. every module-level `val` read
+# folds since #2206, so the same project pins what that left alone: main's own `X`
+# keeps its storage, initialised to 707, for an address-of or a module that cannot
+# fold - nothing loads it any more - and `b.Y`, with no colliding name, still folds
+# to b's value
 test "mach.lang.driver:qualified_const_ignores_local_val_shadow" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -6482,19 +6485,19 @@ test "mach.lang.driver:qualified_const_ignores_local_val_shadow" {
     if (m == nil) { bad = 1; }
     or {
         if (ut_const_uses(m, 909) != 1) { bad = 1; }  # the qualified read folded to a's value
-        if (ut_const_uses(m, 707) != 0) { bad = 1; }  # main's own const never answers for it
+        if (ut_const_uses(m, 707) != 1) { bad = 1; }  # main's own const answers only its own read
 
-        # the unqualified local reference still reads main's own storage.
+        # main's own `val` keeps its storage - an address-of, or a module that
+        # cannot fold, still needs it - but no use loads it any more (#2206).
         val gx: i64 = ut_global_ix(?s, m, "4mainN1X");
         if (gx < 0) { bad = 1; }
         or {
-            if (ut_global_uses(m, gx::u32) == 0)                        { bad = 1; }
+            if (ut_global_uses(m, gx::u32) != 0)                        { bad = 1; }
             if ((?m.globals[gx::u32]).init.data.int_lit != 707)         { bad = 1; }
         }
 
-        # a qualified reference with no colliding name is untouched: it keeps
-        # reading b's storage through a cross-module extern global.
-        if (!ut_has_extern_global(?s, m, "1bN1Y")) { bad = 1; }
+        # a qualified reference with no colliding name folds to b's value.
+        if (ut_const_uses(m, 505) != 1) { bad = 1; }
     }
 
     project.dnit_project(?p);
@@ -6569,10 +6572,13 @@ test "mach.lang.driver:qualified_member_unexported_still_errors" {
 # the qualified module across a name collision (#2223)
 #
 # Only a comptime-foldable module-level `val` reaches lowering's constant fold, so
-# a `fun`, a `var`, a `def` alias and a function-local `val` were never affected -
-# this pins that, so a later change to the lookup cannot break them silently. each
-# reference must name module `a` in its mangled linkage name / folded size, not
-# main's same-named declaration
+# a `fun`, a `var` and a `def` alias were never affected - this pins that, so a
+# later change to the lookup cannot break them silently. each reference must name
+# module `a` in its mangled linkage name / folded size, not main's same-named
+# declaration. `a.L` is the `val` itself, and since #2206 it folds - which makes
+# `a.L + L` wholly constant, so the sum is what pins the pairing: a's 606 plus
+# main's own function-local 808 is 1414, where either substitution would yield
+# 1212 or 1616
 test "mach.lang.driver:qualified_member_kinds_unaffected" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -6598,8 +6604,7 @@ test "mach.lang.driver:qualified_member_kinds_unaffected" {
         if (!ut_has_extern_global(?s, m, "1aN1G"))  { bad = 1; }  # the var read crossed to a
         if (ut_const_uses(m, 7) != 1)               { bad = 1; }  # $size_of(a.T) is a's [7]u8
         if (ut_const_uses(m, 9) != 0)               { bad = 1; }  # never main's [9]u8
-        if (!ut_has_extern_global(?s, m, "1aN1L"))  { bad = 1; }  # a function-local val never shadows
-        if (ut_const_uses(m, 808) != 1)             { bad = 1; }  # and still initialises its own slot
+        if (ut_const_uses(m, 1414) != 1)            { bad = 1; }  # a.L (606) + main's own local L (808)
     }
 
     project.dnit_project(?p);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6612,6 +6612,128 @@ test "mach.lang.driver:qualified_member_kinds_unaffected" {
     ret bad;
 }
 
+# a comptime type gate in a plain generic folds against the INSTANCE, not the
+# template parameter (#2257)
+#
+# `$type_of`'s operand resolver reads the semantic type of its operand directly -
+# it has no substitution of its own to apply - so it read the template's typing and
+# every instantiation of a gated generic selected the same arm, silently. The gate
+# names three distinct constants, so which arm each instance compiled is readable
+# from the operand counts: 111 for the u32 instance, 333 for the u64 one, and each
+# exactly once. Both were 0 before the instance body was re-typed.
+#
+# The two templates cover the two operand shapes: a `T` parameter read directly,
+# and a `T` local. Neither folded.
+test "mach.lang.driver:generic_type_gate_folds_per_instance" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "fun byloc[T](s: T) i64 { var out: T = s;\n$if ($type_of(out) == u32) { ret 111; }\n$or ($type_of(out) == u64) { ret 333; }\n$or { ret 999; } }\nfun bypar[T](s: T) i64 {\n$if ($type_of(s) == u32) { ret 222; }\n$or ($type_of(s) == u64) { ret 444; }\n$or { ret 999; } }\npub fun p1(x: u32) i64 { ret byloc[u32](x); }\npub fun p2(y: u64) i64 { ret byloc[u64](y); }\npub fun p3(x: u32) i64 { ret bypar[u32](x); }\npub fun p4(y: u64) i64 { ret bypar[u64](y); }\nfun main() i32 { ret 0; }\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+    if (m == nil) { bad = 1; }
+    or {
+        if (ut_const_uses(m, 111) != 1) { bad = 1; }  # the u32 instance of the local gate
+        if (ut_const_uses(m, 333) != 1) { bad = 1; }  # the u64 instance took the OTHER arm
+        if (ut_const_uses(m, 222) != 1) { bad = 1; }  # and likewise over a bare parameter
+        if (ut_const_uses(m, 444) != 1) { bad = 1; }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a module-scope `val` folds at its use sites in its OWN module (#2206)
+#
+# The fold ran only after the mangled-name lookup missed, so the declaring module
+# always found its own global first and loaded it. The storage is still emitted -
+# an address-of needs it, as does a module that cannot fold - it is simply never
+# read: 6543 appears once as an operand and the global has no uses at all.
+test "mach.lang.driver:module_val_folds_in_declaring_module" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "pub val N: i64 = 6543;\npub fun f() i64 { ret N; }\nfun main() i32 { ret 0; }\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+    if (m == nil) { bad = 1; }
+    or {
+        if (ut_const_uses(m, 6543) != 1) { bad = 1; }  # the use folded to the value
+        val gx: i64 = ut_global_ix(?s, m, "4mainN1N");
+        if (gx < 0) { bad = 1; }
+        or {
+            if (ut_global_uses(m, gx::u32) != 0)                { bad = 1; }  # nothing loads it
+            if ((?m.globals[gx::u32]).init.data.int_lit != 6543) { bad = 1; }  # storage kept
+        }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a module-scope `val` reached through a module ALIAS folds too (#2206)
+#
+# `use x: pkg.a;` binds the alias, not the leaf name, so the old eligibility test -
+# "this module's comptime scope binds the bare name" - never held for `x.N` and the
+# reference declared a storage-less extern global and loaded through it. Keying on
+# the referent's declaration instead makes the alias spelling fold like any other.
+# The `val` whose initializer does NOT fold is the control on the same reference
+# path: it still reaches a's storage.
+test "mach.lang.driver:aliased_module_val_folds" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "a.mach";
+    var texts: [2]str;
+    texts[0] = "use x: uniontest.a;\npub fun f() i64 { ret x.N; }\npub fun g() ptr { ret x.P; }\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub val N: i64 = 4321;\npub var G: i64 = 1;\npub val P: ptr = ?G;\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+    if (m == nil) { bad = 1; }
+    or {
+        if (ut_const_uses(m, 4321) != 1)           { bad = 1; }  # the aliased read folded
+        if (ut_has_extern_global(?s, m, "1aN1N"))  { bad = 1; }  # and needs no storage here
+        if (!ut_has_extern_global(?s, m, "1aN1P")) { bad = 1; }  # an unfoldable val still does
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
 # the error diagnostics `src` leaves on the sink after sema + lower, or -1 when a
 # pass returned a hard failure
 #

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -209,7 +209,7 @@ pub fun sema(
 #     instantiation. The worklist is owned across a whole module's lowering, so its
 #     `drained` cursor validates each distinct instance exactly once.
 #
-# The episode is the whole body, not the `$each` alone: `reinfer_pack_instance_body`
+# The episode is the whole body, not the `$each` alone: `reinfer_instance_body`
 # re-derives the enclosing statements' typing under the same substitution before the
 # unroll begins (#2254), so a `T`-typed local declared outside the `$each` reads back
 # as the instance type here.
@@ -285,16 +285,24 @@ pub fun reinfer_pack_each_body(
     ret drain_instances(?sc, deps);
 }
 
-# re-derive a pack instance's ENCLOSING body typing under its substitution (#2254)
+# re-derive a monomorphized instance's whole body typing under its substitution
+# (#2254, #2257)
 #
-# The prologue of the same inference episode `reinfer_pack_each_body` finishes: a
-# pack-tailed function's `$each` body is re-typed per element at monomorphization,
-# but the statements AROUND it were typed once, at the module sema pass, against the
-# raw generic parameter. A `val` / `var` declared there therefore left the template
-# type in the shared `decl_type` table, and `decl_type_for` reads that table raw - so
-# a use of the local from inside the `$each` saw the bare `T`, escaping the #1645
-# leakage gates, refusing well-typed programs, and folding a `$type_of` gate against
-# the parameter instead of the instance type.
+# A generic template's body is typed ONCE, at the module sema pass, against the raw
+# generic parameter; the instances are emitted later, from lowering, against the
+# concrete type arguments. The typing that pass left in the shared `expr_type` /
+# `decl_type` arrays is therefore the TEMPLATE's, and every lowering read of those
+# arrays - `expr_type_of`, `decl_type_for` - sees the bare `T` no matter which
+# instance is being emitted. Most of lowering is insulated from that because it
+# converts a semantic type to IR through `lower_type`, which applies the active
+# substitution; the reads that consume the semantic type DIRECTLY are not, and
+# `$type_of`'s operand resolver is one of them - so a comptime type gate folded
+# against the parameter and silently selected the fallback arm (#2257).
+#
+# Running this before an instance's body is lowered makes the shared arrays hold THAT
+# instance's typing for as long as it is being emitted, which is the invariant every
+# raw read already assumes. Instances are emitted one at a time, so one shared array
+# suffices; `lower_type`'s own substitution becomes idempotent rather than load-bearing.
 #
 # Substituting on the READ instead is unsound: `decl_type` is a derived table that
 # episodes rewrite IN PLACE, so a slot may already hold an instance type and a second
@@ -307,15 +315,17 @@ pub fun reinfer_pack_each_body(
 # It publishes typing state and reports nothing. Every statement it walks was already
 # checked by the module sema pass against the template parameter and, when a type
 # argument can newly trip a gate, by the CT re-validation drain against the instance's
-# concrete arguments; reporting here would duplicate all of that once per
-# (type-argument x element-type) instance. Recording is off for the same reason: those
-# statements enqueue their instances on both of the episodes that do report. The
-# `$each` bodies inside stay deferred - `infer_stmt_comptime_each` defers a pack
-# sequence, and a `$fields(T)` over a still-generic owner - so the per-element episode
-# remains their sole (and reporting) typing pass.
+# concrete arguments; reporting here would duplicate all of that once per instance.
+# Recording is off for the same reason: those statements enqueue their instances on
+# both of the episodes that do report. A `$each` body inside stays deferred -
+# `infer_stmt_comptime_each` defers a pack sequence, and a `$fields(T)` over a
+# still-generic owner - so the per-element episode remains their sole (and reporting)
+# typing pass; on a pack-tailed template this is exactly the prologue that per-element
+# episode needs (#2254), since it reads the enclosing locals' slots back out of the
+# same shared table.
 # ---
 # s:           the origin module's session
-# a:           the origin module's Ast (declares the pack-tailed template)
+# a:           the origin module's Ast (declares the template)
 # rr:          the origin module's name-resolution output
 # deps:        typing snapshots spanning every module (see collect_module_deps)
 # ctx:         comptime context for the origin module
@@ -326,9 +336,8 @@ pub fun reinfer_pack_each_body(
 # subst:       the instance's generic substitution (required: without one the walk
 #              re-derives the types it reads and there is nothing to publish)
 # subst_len:   number of substitution arguments
-# ret:         true once the enclosing statements are re-typed, or the first
-#              inference error
-pub fun reinfer_pack_instance_body(
+# ret:         true once the body is re-typed, or the first inference error
+pub fun reinfer_instance_body(
     s:           *session.Session,
     a:           *ast.Ast,
     rr:          *resolve.ResolveResult,

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -261,7 +261,7 @@ pub fun lower_pack_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl
     # before the body is walked (#2254): they were typed once, at the module sema pass,
     # against the raw generic parameter, and the `$each` body's own re-inference reads
     # their `decl_type` slots back out of the same shared table.
-    val res_encl: R.Result[bool, str] = reinfer_pack_enclosing(ctx, d);
+    val res_encl: R.Result[bool, str] = reinfer_instance_typing(ctx, d, ctx.pack_ret_type);
     if (R.is_err[bool, str](res_encl)) { clear_pack_state(ctx); ret res_encl; }
 
     val res_body: R.Result[bool, str] = stmt.lower_stmt(ctx, d.data.fun_.body);
@@ -272,18 +272,20 @@ pub fun lower_pack_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl
     ret res_close;
 }
 
-# re-type a pack instance's enclosing body statements under its substitution (#2254)
+# re-type a monomorphized instance's body under its substitution (#2254, #2257)
 #
 # A no-op outside a generic instance - with no substitution active the template types
 # ARE the instance types. Otherwise it builds the module-spanning typing snapshot the
 # re-inference needs to resolve the body's cross-module references (the same snapshot
-# the per-element unroll builds for the `$each` body) and hands it to the silent
-# re-derivation episode.
+# the per-element unroll builds for a `$each` body) and hands it to the silent
+# re-derivation episode, which republishes the shared typing arrays as this instance's
+# before the body is emitted from them.
 # ---
-# ctx: the context, bound to the origin module with the instance substitution active
-# d:   the pack-tailed template Decl
-# ret: true once re-typed (or skipped), or the first error
-fun reinfer_pack_enclosing(ctx: *context.LowerContext, d: *decl.Decl) R.Result[bool, str] {
+# ctx:    the context, bound to the origin module with the instance substitution active
+# d:      the template Decl
+# fn_ret: the instance's semantic return type, against which the body's `ret`s check
+# ret:    true once re-typed (or skipped), or the first error
+fun reinfer_instance_typing(ctx: *context.LowerContext, d: *decl.Decl, fn_ret: type.TypeId) R.Result[bool, str] {
     if (ctx.subst == nil || ctx.subst_len == 0) { ret R.ok[bool, str](true); }
 
     val res_deps: R.Result[sema.SemaDeps, str] = sema.collect_module_deps(ctx.s);
@@ -292,8 +294,8 @@ fun reinfer_pack_enclosing(ctx: *context.LowerContext, d: *decl.Decl) R.Result[b
     }
     var deps: sema.SemaDeps = R.unwrap_ok[sema.SemaDeps, str](res_deps);
 
-    val res: R.Result[bool, str] = sema.reinfer_pack_instance_body(ctx.s, ctx.a, ctx.rr, ?deps, ctx.ctx,
-        ctx.own_module, ctx.sema_result, ctx.pack_ret_type, d.data.fun_.body,
+    val res: R.Result[bool, str] = sema.reinfer_instance_body(ctx.s, ctx.a, ctx.rr, ?deps, ctx.ctx,
+        ctx.own_module, ctx.sema_result, fn_ret, d.data.fun_.body,
         ctx.subst, ctx.subst_len);
     sema.free_module_deps(ctx.s, ?deps);
     ret res;
@@ -461,6 +463,13 @@ fun lower_weak_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Dec
     val res_idx: R.Result[u32, str] = append_function(ctx, name, sig, flags, d.data.fun_.params_len);
     if (R.is_err[u32, str](res_idx)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_idx)); }
     val fn_index: u32 = R.unwrap_ok[u32, str](res_idx);
+
+    # republish the shared typing arrays as THIS instance's before the body is emitted
+    # from them (#2257): they hold the template's typing, against the raw generic
+    # parameter, and lowering's direct semantic-type reads - `$type_of`'s operand
+    # resolver among them - have no substitution of their own to apply.
+    val res_ty: R.Result[bool, str] = reinfer_instance_typing(ctx, d, context.decl_ret_sem(ctx, did));
+    if (R.is_err[bool, str](res_ty)) { ret res_ty; }
 
     ret emit_function_body(ctx, did, d, fn_index, ret_ir, ret_sem);
 }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -707,7 +707,11 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
     # paths below - the defining module emits the global too (an address-of still
     # needs storage, and a module that cannot fold reads it), and finding that
     # global first is what kept the declaring module loading its own constant.
-    val opt_cv: O.Option[comptime.CTValue] = module_const_value(ctx, sym);
+    val res_cv: R.Result[O.Option[comptime.CTValue], str] = module_const_value(ctx, sym);
+    if (R.is_err[O.Option[comptime.CTValue], str](res_cv)) {
+        ret R.err[value.Value, str](R.unwrap_err[O.Option[comptime.CTValue], str](res_cv));
+    }
+    val opt_cv: O.Option[comptime.CTValue] = R.unwrap_ok[O.Option[comptime.CTValue], str](res_cv);
     if (O.is_some[comptime.CTValue](opt_cv)) {
         ret const_value_of(ctx, eid, O.unwrap[comptime.CTValue](opt_cv));
     }
@@ -741,30 +745,38 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
 # The referent is identified STRUCTURALLY, by its declaration, not by whether this
 # module's comptime scope happens to bind the name: a ComptimeCtx is keyed by bare
 # leaf name, so a name test would answer a reference with whatever same-named
-# constant is in scope here. Requiring `sym.decl` to be a module-level `val` IN THE
-# DECLARING MODULE makes the lookup exact - a module cannot declare two module-level
-# `val`s of one name - and excludes every other referent (a `var`, a `fun`, a `def`,
-# a block-local `val`, a parameter), each of which reaches its storage or its slot
-# unchanged. The value is then read from the declaring module's context, the one
-# authority for a reference's folded value (#2223).
+# constant is in scope here. `sym.decl` naming a module-level `val` IN THE DECLARING
+# MODULE is exactly the predicate - a module cannot declare two module-level `val`s
+# of one name, so the lookup that follows is exact - and it excludes every other
+# referent (a `var`, a `fun`, a `def`, a block-local `val`, a parameter), each of
+# which reaches its storage or its slot unchanged. The value is then read from the
+# declaring module's context, the one authority for a reference's folded value
+# (#2223).
+#
+# Only a module-level symbol reaches here - a local resolves to its slot before the
+# caller ever asks - so its origin module is loaded, its decl id indexes that
+# module's AST, and that module registered a comptime context. None of the three is
+# re-derivable from a miss, so a broken one is reported loudly rather than folded
+# into "not a constant": a fold that fails open compiles a silently different
+# program. Measured to never fire, building the compiler, the standard library and
+# both suites.
 # ---
 # ctx: per-module lowering context
 # sym: the referenced symbol
-# ret: some(value) when `sym` names a folded module-level `val`, else none
-fun module_const_value(ctx: *context.LowerContext, sym: *resolve.Symbol) O.Option[comptime.CTValue] {
-    if (sym.decl == id.DECL_NIL) { ret O.none[comptime.CTValue](); }
-
+# ret: some(value) when `sym` names a folded module-level `val`, none when it names
+#      anything else, or an error when the referent's own module cannot be read
+fun module_const_value(ctx: *context.LowerContext, sym: *resolve.Symbol) R.Result[O.Option[comptime.CTValue], str] {
     val oa: *ast.Ast = session.module_ast(ctx.s, sym.origin);
-    if (oa == nil) { ret O.none[comptime.CTValue](); }
+    if (oa == nil) { ret R.err[O.Option[comptime.CTValue], str]("lower: module-level reference: origin module AST unavailable (invariant violated)"); }
     val opt_d: O.Option[*decl.Decl] = ast.get_decl(oa, sym.decl);
-    if (O.is_none[*decl.Decl](opt_d)) { ret O.none[comptime.CTValue](); }
-    if (O.unwrap[*decl.Decl](opt_d).kind != decl.DECL_KIND_VAL) { ret O.none[comptime.CTValue](); }
+    if (O.is_none[*decl.Decl](opt_d)) { ret R.err[O.Option[comptime.CTValue], str]("lower: module-level reference: decl id out of range in origin AST (invariant violated)"); }
+    if (O.unwrap[*decl.Decl](opt_d).kind != decl.DECL_KIND_VAL) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
 
     val dctx: *comptime.ComptimeCtx = context.declaring_comptime_ctx(ctx, sym);
-    if (dctx == nil) { ret O.none[comptime.CTValue](); }
+    if (dctx == nil) { ret R.err[O.Option[comptime.CTValue], str]("lower: module-level reference: declaring module comptime context unavailable (invariant violated)"); }
     val opt_nc: O.Option[*comptime.NamedConst] = comptime.lookup(dctx, sym.name);
-    if (O.is_none[*comptime.NamedConst](opt_nc)) { ret O.none[comptime.CTValue](); }
-    ret O.some[comptime.CTValue](O.unwrap[*comptime.NamedConst](opt_nc).value);
+    if (O.is_none[*comptime.NamedConst](opt_nc)) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](O.unwrap[*comptime.NamedConst](opt_nc).value));
 }
 
 # whether the identifier's semantic type is a function type

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -701,37 +701,23 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
         ret fn_reference(ctx, link, vty, references_import_function(ctx, sym));
     }
 
+    # a module-level `val` whose initializer folded is a constant at every use, in
+    # every module: it is immutable by declaration and its value is known, so the
+    # reference IS that value and never a load (#2206). Read before the storage
+    # paths below - the defining module emits the global too (an address-of still
+    # needs storage, and a module that cannot fold reads it), and finding that
+    # global first is what kept the declaring module loading its own constant.
+    val opt_cv: O.Option[comptime.CTValue] = module_const_value(ctx, sym);
+    if (O.is_some[comptime.CTValue](opt_cv)) {
+        ret const_value_of(ctx, eid, O.unwrap[comptime.CTValue](opt_cv));
+    }
+
     # global val / var: a load from the global's storage pointer, except for
     # an aggregate global whose rvalue is its storage address (the back end
     # loads halves / passes the pointer at use sites; see lower_ident_rvalue).
     val opt_gi: O.Option[u32] = find_global(ctx, link);
     if (O.is_some[u32](opt_gi)) {
         ret emit_global_rvalue(ctx, O.unwrap[u32](opt_gi), vty);
-    }
-
-    # a comptime-const val that lives in another module has no global in this
-    # module's IR (its storage was never emitted here), so the mangled-name
-    # lookup above finds nothing and the reference arrives here. such a
-    # constant; e.g. the stdlib `val true: bool = 1;` imported by name; folds to
-    # its value.
-    #
-    # the value comes from the module that DECLARES the referent, never from
-    # this module's same-named entry (#2223): a ComptimeCtx is keyed by bare leaf
-    # name, so reading this module's table answered a qualified `mod.X` with a
-    # file-local `val X` - silently, and only when the names happened to collide.
-    # eligibility is unchanged: the reference folds only when this module's
-    # comptime scope binds the name, which is what a bare `use pkg.mod.CONST;`
-    # merges in. a declaring module that registered no such constant (a
-    # non-foldable `val`) falls through to its storage below.
-    val opt_nc: O.Option[*comptime.NamedConst] = comptime.lookup(ctx.ctx, sym.name);
-    if (O.is_some[*comptime.NamedConst](opt_nc)) {
-        val dctx: *comptime.ComptimeCtx = context.declaring_comptime_ctx(ctx, sym);
-        if (dctx != nil) {
-            val opt_dc: O.Option[*comptime.NamedConst] = comptime.lookup(dctx, sym.name);
-            if (O.is_some[*comptime.NamedConst](opt_dc)) {
-                ret const_value_of(ctx, eid, O.unwrap[*comptime.NamedConst](opt_dc).value);
-            }
-        }
     }
 
     # a runtime global `val`/`var` defined in another module (imach emits one
@@ -742,6 +728,43 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
     val res_xg: R.Result[u32, str] = context.ensure_extern_global(ctx, link, vty, references_import_data(ctx, sym));
     if (R.is_err[u32, str](res_xg)) { ret R.err[value.Value, str](R.unwrap_err[u32, str](res_xg)); }
     ret emit_global_rvalue(ctx, R.unwrap_ok[u32, str](res_xg), vty);
+}
+
+# the folded value of a module-level `val` a reference names (#2206)
+#
+# A module-level `val` is immutable by declaration, so a comptime-foldable
+# initializer fixes its value at every use site in every module - the reference is
+# that value, not a load from its storage. Registered at load time by
+# `register_val_for_load`; a `val` whose initializer does not fold (a runtime
+# constant) is deliberately absent and reads its storage instead.
+#
+# The referent is identified STRUCTURALLY, by its declaration, not by whether this
+# module's comptime scope happens to bind the name: a ComptimeCtx is keyed by bare
+# leaf name, so a name test would answer a reference with whatever same-named
+# constant is in scope here. Requiring `sym.decl` to be a module-level `val` IN THE
+# DECLARING MODULE makes the lookup exact - a module cannot declare two module-level
+# `val`s of one name - and excludes every other referent (a `var`, a `fun`, a `def`,
+# a block-local `val`, a parameter), each of which reaches its storage or its slot
+# unchanged. The value is then read from the declaring module's context, the one
+# authority for a reference's folded value (#2223).
+# ---
+# ctx: per-module lowering context
+# sym: the referenced symbol
+# ret: some(value) when `sym` names a folded module-level `val`, else none
+fun module_const_value(ctx: *context.LowerContext, sym: *resolve.Symbol) O.Option[comptime.CTValue] {
+    if (sym.decl == id.DECL_NIL) { ret O.none[comptime.CTValue](); }
+
+    val oa: *ast.Ast = session.module_ast(ctx.s, sym.origin);
+    if (oa == nil) { ret O.none[comptime.CTValue](); }
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(oa, sym.decl);
+    if (O.is_none[*decl.Decl](opt_d)) { ret O.none[comptime.CTValue](); }
+    if (O.unwrap[*decl.Decl](opt_d).kind != decl.DECL_KIND_VAL) { ret O.none[comptime.CTValue](); }
+
+    val dctx: *comptime.ComptimeCtx = context.declaring_comptime_ctx(ctx, sym);
+    if (dctx == nil) { ret O.none[comptime.CTValue](); }
+    val opt_nc: O.Option[*comptime.NamedConst] = comptime.lookup(dctx, sym.name);
+    if (O.is_none[*comptime.NamedConst](opt_nc)) { ret O.none[comptime.CTValue](); }
+    ret O.some[comptime.CTValue](O.unwrap[*comptime.NamedConst](opt_nc).value);
 }
 
 # whether the identifier's semantic type is a function type


### PR DESCRIPTION
Closes #2257.
Closes #2206.

Two comptime-fold defects with **independent causes**, established rather than assumed: #2257 is a monomorphization typing gap in the middle end, #2206 is a mis-ordered and mis-keyed eligibility test in the same file's symbol-reference leaf. They share no code path and neither fix touches the other's.

## #2257 — the issue's surface is wider than it states

The issue describes a `T`-typed **local**. In a plain generic, a `$type_of` gate misfolds over **everything whose semantic type mentions `T`** — including a `T` **parameter**, which PR #2256 listed under "already sound, unchanged". That row was sound in the *pack-tailed* shape it was measured in; in a plain generic it is not.

22-row probe, built and run, `dev` vs this branch:

**Misfolded on `dev`, fixed here** — a `T` parameter; a `T` local; a `val`-declared `T` local; an uninitialized `T` local; a `T`-typed field of a generic record, through a local and through a parameter; a `*T`-typed local; a nested `$if`; a gate inside a `$each` over `$fields(T)`; inside a plain block; inside a `for` body; a local typed by a nested generic call's return; and both halves of a two-instantiation pair (`p[u32]`→1, `p[f64]`→2).

**Already sound, unchanged** — a concrete local inside a generic; a non-generic function; a pack-tailed generic (#2254's prologue already covers it); `f.type == u32` over a `$fields(T)` descriptor (projected from the substituted owner); and `$type_of(out) == T`, which stays true for every instance because both sides substitute. That last one was the regression risk in this change and it does not move.

**A note on negative controls.** `p[f64]` against `== u32` passes on `dev` *for the wrong reason*: the raw `T` compares unequal to any concrete type, so a broken fold and a correct one agree. Every negative row here is therefore paired with a positive instantiation of the same template — that pair is what discriminates, and it is the shape used in both the unit test and the int case.

### Cause and fix

A generic template's body is typed once, at the module sema pass, against the raw generic parameter; its instances are emitted later, from lowering, against the concrete arguments. Lowering is insulated from the mismatch wherever it converts a semantic type to IR through `lower_type`, which applies the active substitution — but not where it consumes the semantic type **directly**, and `$type_of`'s operand resolver is one of those.

No substitution at the read leaf: that composes, exactly as the reverted #2251 attempt measured (`Result[T, E]` → `Result[**T, *u8]`). `reinfer_pack_instance_body` already re-derives a pack instance's body under its substitution before the unroll (#2254) — from `type_resolved_ty`, a pristine input written once, so exactly one substitution is applied however many times it runs. That is the same episode a plain generic instance needs, so it is generalized to `reinfer_instance_body` and run from the generic-instance path too. The shared typing arrays then hold the instance being emitted for as long as it is being emitted, which is the invariant every raw read already assumed; `lower_type`'s own substitution becomes idempotent rather than load-bearing.

## #2206 — a different cause, and the issue's reading of the symptom was off

The fold already existed in `symbol_reference`. It was gated two ways, and both gates were wrong:

1. It ran **after** `find_global`, so the declaring module always found its own storage first and loaded it. That is the issue's "in the defining module it is a `val` but still loaded from memory".
2. Its eligibility test was *"the using module's comptime scope binds this bare leaf name"* — which a bare `use pkg.mod.CONST;` satisfies and a module alias (`d.N_SMALL`) never does. That is the consuming-module half.

The fold now runs before the storage paths and identifies its referent **structurally**: `sym.decl` must name a module-level `val` in the declaring module, whose table (the #2223 authority) then answers exactly — a module cannot declare two module-level `val`s of one name. That is strictly sharper than the name test it replaces, not looser.

**The issue's `var @… = 0` reading was a misdiagnosis**, worth recording: that is a storage-less extern *reference* the consuming module declares, not a lost initializer or a lost `pub`. The IR printer renders an extern global the same as a definition. The import path was never dropping anything; there was only ever the one folding gap, on both sides of the module boundary.

On the issue's own repro: the load leaves the loop header entirely, and `d.N_SMALL / 2` becomes `ret 32768` instead of `div_s`.

## Output deltas, with causes

Every delta below is `dev`-built vs branch-built from **identical** source (a pristine `origin/dev` tree), so the compilers are the only variable.

| | modules changed / 208 | binary |
|---|---|---|
| `dev` | — | 8,261,632 |
| #2257 only | **5** | 8,261,632 |
| #2257 + #2206 | **161** | 8,179,712 |

- **#2257's delta is 5 modules and zero size change**, and all five are inside *dead* code — see the note below. On live code it changes nothing in this source tree, because neither the compiler nor the stdlib gates a `$type_of` over a generic local.
- **#2206's delta is broad and is the fix working**: **15,219 loads removed** (53,624 → 38,405) and **3,654 extern global declarations gone** (3,755 → 101). The stdlib is full of module-level `val`s — every use of one was a memory load.

### The dead-code delta, stated rather than buried

`lower_fun` emits every generic **template** as a bare function alongside its instances (`fun never_used[T](s: T) T` with no instantiation emits `fn @…never_used(%p0: ptr): ptr`, `T` collapsed to `ptr`). Those dead bodies record instances whose type arguments are still generic parameters — `ok[*T, *u8]` mangles `okIPvP2u8E` and its `Result` payload union lowers to an empty `{}`. On `dev` that instance's **signature already says `{i8, {}}` while its body allocas `{i8, {ptr, ptr}}`**: incoherent before this branch touched it.

Those five bodies are #2257's entire footprint. The re-typing makes each body agree with its own signature. Verified dead — the only callers are other bare template bodies. This is a **third, pre-existing defect**; skipping generic templates in `lower_fun` (one line) removes the whole cluster, drops another ~29 KB, keeps both suites at 868/0 and 611/0, and reduces #2257's delta to nil. It is **not** in this branch, pending a scope decision.

## Verification

Suites through the freshly-built HEAD compiler, never the PATH seed.

- `mach test .` **871 / 0** — 868 on `dev` plus exactly the 3 tests added here. `mach test dep/mach-std` **611 / 0** at pin `eff1e8e` (`git rev-parse HEAD` in `dep/mach-std` checked against `mach.lock`; the worktree's dependency has its own gitdir, so no shared-pin hazard).
- `int/run.sh` all cases pass on **linux** and **linux-riscv64**, debug and release, including the new case.
- The new int case built and run on **all three ISAs**, both profiles — `linux` native, `linux-arm64` under `qemu-aarch64`, `linux-riscv64` under `qemu-riscv64`: 6/6 match the golden. On `dev` all three ISAs print the identical all-fallback output, confirming the defect is front-end, not codegen.
- **Three-generation fixpoint**, both profiles: g2 == g3 byte-identical, debug and release. g1 differs — documented seed lag.
- `--verify-ir` passes on `dev`, on this branch, and on the template-skip variant. Recorded because it does **not** discriminate here: the verifier does not check a body against its own declared return type, which is why the `{i8, {}}` incoherence above survives it.
- Address-of a folded `val` still resolves to real storage and derefs to the right value, executed, cross-module.

### Per-assertion discrimination

Each new assertion was run against `dev`'s lowering with its counts dumped, not just its pass/fail.

| test | pre-fix (`dev`) | post-fix |
|---|---|---|
| `generic_type_gate_folds_per_instance` | all four gated-arm constants **0**; the fallback constant appears **6** times — every one of the 6 bodies compiled the fallback | each gated constant exactly **1**; fallback down to **2** (the two bare template bodies) |
| `module_val_folds_in_declaring_module` | value folded **0** times, its global loaded **1** time | folded **1** time, global loaded **0** times, storage still initialised to 6543 |
| `aliased_module_val_folds` | aliased value folded **0** times, extern global present | folded **1** time, no extern global; the unfoldable `val` beside it still has one |

Two pre-existing #2223 tests asserted the *un-folded* shape as a proxy for correct module attribution, so #2206 moves them. Both are re-pinned on values that discriminate the same swap more sharply: `qualified_member_kinds_unaffected` now asserts `a.L + L` folds to **1414**, where answering either read from the wrong table would give 1212 or 1616.

### Mutation testing

Each mutation applied alone, over the 871-test suite.

| mutation | result |
|---|---|
| none (baseline) | 871 / 0 |
| drop the generic-instance re-typing call (the #2257 fix) | **870 / 1** |
| `silent = false` on the re-derivation episode | **870 / 1** |
| run the module-const fold *after* the module's own global lookup | **869 / 2** |
| read the using module's comptime table instead of the declaring one (#2223) | **867 / 4** |
| drop the comptime-table miss check | **segfault** |
| drop the `DECL_KIND_VAL` predicate | 871 / 0 — **survivor** |
| drop the `subst == nil` skip | 871 / 0 — **survivor** |

**Both survivors, stated rather than hidden.**

`DECL_KIND_VAL` is not a guard, it is the predicate the function is named for. Its removal is inert only because of three non-local invariants — only `DECL_KIND_VAL` decls register in a ComptimeCtx, a module scope rejects duplicate bindings, and comptime frames are scoped — and I built the collision that would exploit it (a module-level `var` sharing a name with an imported constant) to confirm the resolver rejects it: `duplicate definition`. Deleting the check would make a local function silently depend on all three; it stays.

The `subst == nil` skip is #2254's, carried into the shared helper. Its cost justification does **not** survive measurement here — with it, compiling the dev source takes 12.2–12.8 s user; without, 11.9–12.1 s, i.e. no measurable saving. Its real justification is the one #2254 gave: it confines a *silent* typing episode to the case that has something to publish. Kept on that basis, restated because the perf half is not true.

**Two guards were removed rather than kept.** The `sym.decl == DECL_NIL` test was provably redundant — `DECL_NIL` is `0xFFFFFFFF`, outside every AST's decl range, so `get_decl`'s own range check turns a decl-less symbol away. And the three remaining nil/range checks were **fail-open fallbacks**: a fold that silently reports "not a constant" on a broken precondition compiles a different program. They report loudly now, matching #2157's treatment of the same shape in `revalidate_one`. A probe on all three measured **zero** hits across a compiler build, a full dev-source build, and both suites — so they are stated invariants, not live paths.
