### PR TITLE
assess(me): LICM register pressure (#2255) — do not merge, #2246 already closed it

### DIFF
--- a/src/lang/me/transform/licm.mach
+++ b/src/lang/me/transform/licm.mach
@@ -2600,3 +2600,155 @@ test "mach.lang.me.transform.licm:width_cast_is_cut_from_an_address_chain" {
     intern.dnit(?itn);
     ret code;
 }
+
+# demand counts a value that merely PASSES THROUGH the loop, not only one the body
+# names. The twenty values below are computed before the loop and consumed after it,
+# so nothing inside the loop mentions them -- yet the allocator must hold every one
+# across every iteration, and the invariant multiply in the body has no register to
+# move into. Reading pressure from the body's own instructions alone would see an
+# empty loop and lift it.
+test "mach.lang.me.transform.licm:demand_counts_values_passing_through" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var tgt: resolved.Target;
+    if (mk_target(?tgt) != 0) { ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var b: [4]id.BlockId;
+    var i: u32 = 0;
+    for (i < 4) {
+        val rb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+        if (R.is_err[id.BlockId, str](rb)) { ir.dnit(?m); ret 1; }
+        b[i] = R.unwrap_ok[id.BlockId, str](rb);
+        i = i + 1;
+    }
+
+    val n: u32 = 20;
+    val rv: R.Result[*value.Value, str] = A.allocate[value.Value](?alloc, n::usize);
+    if (R.is_err[*value.Value, str](rv)) { ir.dnit(?m); ret 1; }
+    val vs: *value.Value = R.unwrap_ok[*value.Value, str](rv);
+
+    # the preheader computes twenty values and enters the loop.
+    builder.set_block(?bld, b[0]);
+    i = 0;
+    for (i < n) {
+        val ra: R.Result[value.Value, str] = builder.emit_add(?bld, value.param(0, i64t), value.const_int(i::u64, i64t));
+        if (R.is_err[value.Value, str](ra)) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+        vs[i] = R.unwrap_ok[value.Value, str](ra);
+        i = i + 1;
+    }
+    if (R.is_err[bool, str](builder.emit_br(?bld, b[1]))) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+
+    builder.set_block(?bld, b[1]);
+    val rphi: R.Result[value.Value, str] = builder.emit_phi(?bld, i64t);
+    if (R.is_err[value.Value, str](rphi)) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+    val iv: value.Value = R.unwrap_ok[value.Value, str](rphi);
+    val rc: R.Result[value.Value, str] = builder.emit_cmp_lt_s(?bld, iv, value.param(0, i64t));
+    if (R.is_err[value.Value, str](rc)) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_cbr(?bld, R.unwrap_ok[value.Value, str](rc), b[2], b[3]))) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+
+    # the body names none of the twenty; only the invariant multiply is a candidate.
+    builder.set_block(?bld, b[2]);
+    val rp: R.Result[value.Value, str] = builder.emit_mul(?bld, value.param(0, i64t), value.param(0, i64t));
+    if (R.is_err[value.Value, str](rp)) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+    val cand: value.Value = R.unwrap_ok[value.Value, str](rp);
+    val ru: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](ru)) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+    val upd: value.Value = R.unwrap_ok[value.Value, str](ru);
+    if (R.is_err[bool, str](builder.emit_br(?bld, b[1]))) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+
+    # every one of the twenty is consumed after the loop, so all are live across it.
+    builder.set_block(?bld, b[3]);
+    var acc: value.Value = value.param(0, i64t);
+    i = 0;
+    for (i < n) {
+        val rs: R.Result[value.Value, str] = builder.emit_add(?bld, acc, vs[i]);
+        if (R.is_err[value.Value, str](rs)) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+        acc = R.unwrap_ok[value.Value, str](rs);
+        i = i + 1;
+    }
+    if (R.is_err[bool, str](builder.emit_ret(?bld, acc))) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, b[0], value.const_int(0, i64t)))) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, b[2], upd))) { A.deallocate[value.Value](?alloc, vs, n::usize); ir.dnit(?m); ret 1; }
+    A.deallocate[value.Value](?alloc, vs, n::usize);
+
+    var code: i32 = 0;
+    if (R.is_err[bool, str](run(?m, ?tgt))) { code = 1; }
+    if (!block_holds(fn, b[2], cand.data.instr)) { code = 1; }
+
+    ir.dnit(?m);
+    ret code;
+}
+
+# each hoist is charged against the next one. The loop below has room for a few more
+# registers and offers eight invariant multiplies; the budget fills as they are taken,
+# so some are lifted and the rest stay. Reading the demand without the values already
+# lifted would measure every candidate against the same empty headroom and take all
+# eight.
+test "mach.lang.me.transform.licm:each_hoist_is_charged_to_the_next" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var tgt: resolved.Target;
+    if (mk_target(?tgt) != 0) { ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId;
+    var iv: value.Value;
+    if (mk_loop(?m, ?bld, i64t, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); ret 1; }
+    if (fill_live_through(?m, ?bld, i64t, body, 6, iv) != 0) { ir.dnit(?m); ret 1; }
+
+    builder.set_block(?bld, body);
+    var cands: [8]value.Value;
+    var i: u32 = 0;
+    for (i < 8) {
+        val rp: R.Result[value.Value, str] = builder.emit_mul(?bld, value.param(0, i64t), value.const_int((i + 2)::u64, i64t));
+        if (R.is_err[value.Value, str](rp)) { ir.dnit(?m); ret 1; }
+        cands[i] = R.unwrap_ok[value.Value, str](rp);
+        i = i + 1;
+    }
+    if (close_loop(?bld, i64t, iv, header, body) != 0) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    if (R.is_err[bool, str](run(?m, ?tgt))) { code = 1; }
+
+    var lifted: u32 = 0;
+    i = 0;
+    for (i < 8) {
+        if (block_holds(fn, entry, cands[i].data.instr)) { lifted = lifted + 1; }
+        i = i + 1;
+    }
+    # the loop has headroom, so the budget must admit some; it runs out, so it must
+    # decline the rest.
+    if (lifted == 0) { code = 1; }
+    if (lifted == 8) { code = 1; }
+
+    ir.dnit(?m);
+    ret code;
+}

--- a/src/lang/me/transform/licm.mach
+++ b/src/lang/me/transform/licm.mach
@@ -2357,3 +2357,246 @@ test "mach.lang.me.transform.licm:no_preheader_declines" {
     ir.dnit(?m);
     ret code;
 }
+
+# raise loop pressure by `n` registers: define `n` values off the induction variable
+# and consume them all afterwards, so every one is live at once at the point the last
+# is defined. Each depends on the induction variable, so none is itself a hoist
+# candidate and the pressure is the only thing the helper contributes. Returns 0 on
+# success.
+fun fill_live_through(m: *ir.Module, bld: *builder.Builder, i64t: ir_type.IrTypeId,
+                      body: id.BlockId, n: u32, iv: value.Value) i32 {
+    val ra: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, n::usize);
+    if (R.is_err[*value.Value, str](ra)) { ret 1; }
+    val vs: *value.Value = R.unwrap_ok[*value.Value, str](ra);
+
+    builder.set_block(bld, body);
+    var i: u32 = 0;
+    for (i < n) {
+        val rv: R.Result[value.Value, str] = builder.emit_add(bld, iv, value.const_int(i::u64, i64t));
+        if (R.is_err[value.Value, str](rv)) { A.deallocate[value.Value](m.alloc, vs, n::usize); ret 1; }
+        vs[i] = R.unwrap_ok[value.Value, str](rv);
+        i = i + 1;
+    }
+
+    var acc: value.Value = iv;
+    i = 0;
+    for (i < n) {
+        val rs: R.Result[value.Value, str] = builder.emit_add(bld, acc, vs[i]);
+        if (R.is_err[value.Value, str](rs)) { A.deallocate[value.Value](m.alloc, vs, n::usize); ret 1; }
+        acc = R.unwrap_ok[value.Value, str](rs);
+        i = i + 1;
+    }
+
+    A.deallocate[value.Value](m.alloc, vs, n::usize);
+    ret 0;
+}
+
+# the register budget is the target's own description of its register file, never a
+# constant this pass carries. x86_64 declares sixteen general registers and withholds
+# five from value allocation -- the stack and frame pointers, and the three-register
+# reload-scratch pool -- leaving eleven; its float bank is declared at its allocatable
+# size of fourteen, the two encoder scratch registers already excluded from `len`.
+test "mach.lang.me.transform.licm:budget_is_the_target_register_file" {
+    var tgt: resolved.Target;
+    if (mk_target(?tgt) != 0) { ret 1; }
+
+    var code: i32 = 0;
+    if (bank_budget(?tgt, isa.RC_GENERAL) != 11) { code = 1; }
+    if (bank_budget(?tgt, isa.RC_FLOAT)   != 14) { code = 1; }
+
+    # a bank the target does not declare carries no budget, which the admission test
+    # reads as "no information", not as "no registers".
+    if (bank_budget(?tgt, isa.RC_VECTOR) != 0) { code = 1; }
+    ret code;
+}
+
+# a loop whose live values already fill the general bank declines an invariant
+# multiply: lifting it would hold a twelfth register on an eleven-register file, so
+# the multiply the body repeats is cheaper than the spill the hoist would cause. The
+# same loop with room lifts the identical multiply, so the decline is the budget and
+# not an inert pass.
+test "mach.lang.me.transform.licm:pressure_declines_a_saturated_loop" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var tgt: resolved.Target;
+    if (mk_target(?tgt) != 0) { ret 1; }
+
+    var code: i32 = 0;
+    var pass: u32 = 0;
+    # pass 0 saturates the general bank, pass 1 leaves it nearly empty.
+    for (pass < 2) {
+        var live: u32 = 20;
+        if (pass == 1) { live = 2; }
+
+        val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+        if (R.is_err[ir.Module, str](rm)) { ret 1; }
+        var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+        val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+        if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+        val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+
+        val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+        if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+        val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+        var bld: builder.Builder = builder.init(?m);
+        builder.set_function(?bld, fn);
+
+        var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId;
+        var iv: value.Value;
+        if (mk_loop(?m, ?bld, i64t, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); ret 1; }
+        if (fill_live_through(?m, ?bld, i64t, body, live, iv) != 0) { ir.dnit(?m); ret 1; }
+
+        builder.set_block(?bld, body);
+        val rp: R.Result[value.Value, str] = builder.emit_mul(?bld, value.param(0, i64t), value.param(0, i64t));
+        if (R.is_err[value.Value, str](rp)) { ir.dnit(?m); ret 1; }
+        val cand: value.Value = R.unwrap_ok[value.Value, str](rp);
+        if (close_loop(?bld, i64t, iv, header, body) != 0) { ir.dnit(?m); ret 1; }
+
+        if (R.is_err[bool, str](run(?m, ?tgt))) { code = 1; }
+
+        if (pass == 0 && !block_holds(fn, body, cand.data.instr))  { code = 1; }
+        if (pass == 1 && !block_holds(fn, entry, cand.data.instr)) { code = 1; }
+
+        ir.dnit(?m);
+        pass = pass + 1;
+    }
+    ret code;
+}
+
+# an address survives a saturated loop where a plain computation does not. The gep
+# indexes a module-scope array by a runtime value, so the back end has to materialize
+# the symbol and scale the index every iteration -- several instructions, against the
+# one reload a spilled hoist costs. The multiply beside it is one instruction and is
+# declined, so the pair tests the cost rule and not the budget alone.
+test "mach.lang.me.transform.licm:address_survives_a_saturated_loop" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+    var tgt: resolved.Target;
+    if (mk_target(?tgt) != 0) { intern.dnit(?itn); ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { intern.dnit(?itn); ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val rr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?m.types, i64t, 16);
+    if (R.is_err[ir_type.IrTypeId, str](rr)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val arrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rr);
+
+    var g: value.Value;
+    if (mk_global(?m, ?itn, "g_arr", arrt, ptrt, ?g) != 0) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId;
+    var iv: value.Value;
+    if (mk_loop(?m, ?bld, i64t, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    if (fill_live_through(?m, ?bld, i64t, body, 20, iv) != 0) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+
+    builder.set_block(?bld, body);
+    var idx: [2]value.Value;
+    idx[0] = value.const_int(0, i64t);
+    idx[1] = value.param(0, i64t);
+    val rg: R.Result[value.Value, str] = builder.emit_gep(?bld, g, arrt, ?idx[0], 2);
+    if (R.is_err[value.Value, str](rg)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val addr: value.Value = R.unwrap_ok[value.Value, str](rg);
+    val rq: R.Result[value.Value, str] = builder.emit_mul(?bld, value.param(0, i64t), value.param(0, i64t));
+    if (R.is_err[value.Value, str](rq)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val plain: value.Value = R.unwrap_ok[value.Value, str](rq);
+    if (close_loop(?bld, i64t, iv, header, body) != 0) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+
+    var code: i32 = 0;
+    if (R.is_err[bool, str](run(?m, ?tgt))) { code = 1; }
+
+    if (!block_holds(fn, entry, addr.data.instr)) { code = 1; }
+    if (!block_holds(fn, body, plain.data.instr)) { code = 1; }
+
+    ir.dnit(?m);
+    intern.dnit(?itn);
+    ret code;
+}
+
+# an address chain is cut where it crosses a width cast. Both casts below feed a gep
+# in a saturated loop, so both are part of an address the budget still admits -- but
+# the `zext` re-presents an index the loop already holds at another width, which the
+# allocator cannot coalesce with its source, so lifting it would make the loop carry
+# the same datum twice. The same-width `bitcast` coalesces away and is lifted.
+test "mach.lang.me.transform.licm:width_cast_is_cut_from_an_address_chain" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+    var tgt: resolved.Target;
+    if (mk_target(?tgt) != 0) { intern.dnit(?itn); ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { intern.dnit(?itn); ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val ri: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 32);
+    if (R.is_err[ir_type.IrTypeId, str](ri)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val i32t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ri);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val rr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?m.types, i64t, 16);
+    if (R.is_err[ir_type.IrTypeId, str](rr)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val arrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rr);
+
+    var ga: value.Value;
+    var gb: value.Value;
+    if (mk_global(?m, ?itn, "w_a", arrt, ptrt, ?ga) != 0) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    if (mk_global(?m, ?itn, "w_b", arrt, ptrt, ?gb) != 0) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId;
+    var iv: value.Value;
+    if (mk_loop(?m, ?bld, i64t, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    if (fill_live_through(?m, ?bld, i64t, body, 20, iv) != 0) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+
+    builder.set_block(?bld, body);
+    val rw: R.Result[value.Value, str] = builder.emit_zext(?bld, value.param(1, i32t), i64t);
+    if (R.is_err[value.Value, str](rw)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val widened: value.Value = R.unwrap_ok[value.Value, str](rw);
+    var ia: [2]value.Value;
+    ia[0] = value.const_int(0, i64t);
+    ia[1] = widened;
+    if (R.is_err[value.Value, str](builder.emit_gep(?bld, ga, arrt, ?ia[0], 2))) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+
+    val rc: R.Result[value.Value, str] = builder.emit_bitcast(?bld, gb, ptrt);
+    if (R.is_err[value.Value, str](rc)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val recast: value.Value = R.unwrap_ok[value.Value, str](rc);
+    var ib: [2]value.Value;
+    ib[0] = value.const_int(0, i64t);
+    ib[1] = value.param(0, i64t);
+    if (R.is_err[value.Value, str](builder.emit_gep(?bld, recast, arrt, ?ib[0], 2))) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    if (close_loop(?bld, i64t, iv, header, body) != 0) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+
+    var code: i32 = 0;
+    if (R.is_err[bool, str](run(?m, ?tgt))) { code = 1; }
+
+    if (!block_holds(fn, body, widened.data.instr))  { code = 1; }
+    if (!block_holds(fn, entry, recast.data.instr))  { code = 1; }
+
+    ir.dnit(?m);
+    intern.dnit(?itn);
+    ret code;
+}

--- a/src/lang/me/transform/licm.mach
+++ b/src/lang/me/transform/licm.mach
@@ -159,13 +159,10 @@ fun licm_function(m: *ir.Module, fn: *ir.Function, tgt: *target.Target) R.Result
     val order: *u32 = R.unwrap_ok[*u32, str](ro);
     order_innermost_first(?la, order);
 
-    val rpr: R.Result[Pressure, str] = pressure_init(m, fn, ?la, tgt);
-    if (R.is_err[Pressure, str](rpr)) {
-        A.deallocate[u32](m.alloc, order, n::usize);
-        loops.dnit(?la);
-        ret R.err[bool, str](R.unwrap_err[Pressure, str](rpr));
-    }
-    var pr: Pressure = R.unwrap_ok[Pressure, str](rpr);
+    # the pressure state is built on the first candidate that needs a budget
+    # decision, so a function whose loops hoist nothing never pays for a liveness
+    # solve it would not read.
+    var pr: Pressure = pressure_blank(m, fn, tgt);
 
     var changed: bool = false;
     var oi: u32 = 0;
@@ -178,6 +175,12 @@ fun licm_function(m: *ir.Module, fn: *ir.Function, tgt: *target.Target) R.Result
             ret rl;
         }
         if (R.unwrap_ok[bool, str](rl)) { changed = true; }
+        if (pr.err) {
+            pressure_dnit(?pr);
+            A.deallocate[u32](m.alloc, order, n::usize);
+            loops.dnit(?la);
+            ret R.err[bool, str]("mach.lang.me.transform.licm: out of memory building the pressure model");
+        }
         oi = oi + 1;
     }
 
@@ -239,7 +242,6 @@ fun licm_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32,
 
     val opaque: bool = loop_has_opaque_effect(fn, la, lx);
 
-    if (pr.active) { fill_addr_feeders(fn, la, lx, pr); }
 
     var changed: bool = false;
     var ri: u32 = 0;
@@ -256,8 +258,12 @@ fun licm_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32,
             k = k + 1;
 
             if (hoistable(m, fn, la, lx, tgt, iid, opaque) &&
-                pressure_admits(m, fn, pr, la, lx, iid, fn.instrs[iid::u32].kind)) {
-                if (iid::u32 < pr.nvals) { bit_set(pr.hoisted, iid::u32); }
+                pressure_admits(m, fn, pr, la, lx, pre_id, iid, fn.instrs[iid::u32].kind)) {
+                if (pr.built && pr.active && iid::u32 < pr.nvals) {
+                    bit_set(pr.hoisted, iid::u32);
+                    bit_set(pr.forced, iid::u32);
+                    loop_peak(fn, pr, la, lx, NO_SLOT, ?pr.cur_gp, ?pr.cur_fp);
+                }
                 val rp: R.Result[bool, str] = ir.block_append_instr(m, ?fn.blocks[pre_id::u32], iid);
                 if (R.is_err[bool, str](rp)) { ret rp; }
                 val rs: R.Result[bool, str] = loops.set_instr_block(la, iid, pre_id);
@@ -322,27 +328,51 @@ fun licm_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32,
 # kind: its opcode
 # ret:  true when the hoist is worth making
 fun pressure_admits(m: *ir.Module, fn: *ir.Function, pr: *Pressure, la: *loops.LoopAnalysis, lx: u32,
-                    iid: id.InstructionId, kind: instruction.InstrKind) bool {
+                    pre_id: id.BlockId, iid: id.InstructionId, kind: instruction.InstrKind) bool {
     if (!pr.active) { ret true; }
 
     val bk: RegBank = bank_of_type(m, fn.instrs[iid::u32].ty);
     if (bk == BANK_NONE) { ret true; }
 
+    if (!pr.built) {
+        pressure_build(m, fn, la, pr);
+        if (!pr.active) { ret true; }
+    }
+    if (pr.loop_lx != lx) {
+        pr.loop_lx = lx;
+        fill_addr_feeders(fn, la, lx, pr);
+        select_forced(la, lx, pre_id, pr);
+        loop_peak(fn, pr, la, lx, NO_SLOT, ?pr.cur_gp, ?pr.cur_fp);
+    }
+
     var slot: u32 = NO_SLOT;
     if (iid::u32 < pr.nvals) { slot = iid::u32; }
 
-    var gp: u32 = 0;
-    var fp: u32 = 0;
-    loop_peak(fn, pr, la, lx, slot, ?gp, ?fp);
+    # one more live value can raise the peak by at most one, so a loop with that much
+    # headroom needs no second walk.
+    var gp: u32 = pr.cur_gp + 1;
+    var fp: u32 = pr.cur_fp + 1;
+    if (over_budget(pr, bk, gp, fp)) { loop_peak(fn, pr, la, lx, slot, ?gp, ?fp); }
 
-    var full: bool = false;
-    if (bk == BANK_GP)      { full = pr.budget_gp != 0 && gp > pr.budget_gp; }
-    or { if (bk == BANK_FP) { full = pr.budget_fp != 0 && fp > pr.budget_fp; } }
-
-    if (!full)                      { ret true; }
-    if (kind == instruction.OP_GEP) { ret true; }
-    if (is_width_cast(kind))        { ret false; }
+    if (!over_budget(pr, bk, gp, fp)) { ret true; }
+    if (kind == instruction.OP_GEP)   { ret true; }
+    if (is_width_cast(kind))          { ret false; }
     ret slot != NO_SLOT && bit_get(pr.addr_feed, slot);
+}
+
+# true when a peak of `gp` / `fp` exceeds the bank `bk` draws from
+#
+# A bank the model does not declare has no budget, so nothing exceeds it.
+# ---
+# pr: the state
+# bk: the bank the candidate competes in
+# gp: the general-bank peak
+# fp: the float-bank peak
+# ret: true when the candidate's bank is over its budget
+fun over_budget(pr: *Pressure, bk: RegBank, gp: u32, fp: u32) bool {
+    if (bk == BANK_GP) { ret pr.budget_gp != 0 && gp > pr.budget_gp; }
+    if (bk == BANK_FP) { ret pr.budget_fp != 0 && fp > pr.budget_fp; }
+    ret false;
 }
 
 # true for the casts that re-present a value at a different width
@@ -987,33 +1017,54 @@ fun bank_budget(tgt: *target.Target, kind: isa.RegClassKind) u32 {
 # ---
 # alloc:       allocator backing every owned array
 # active:      true when a register budget applies
+# built:       true once the liveness arrays exist; false until the first candidate
+# loop_lx:     the loop `addr_feed` / `forced` / `cur_*` describe, or NONE_U32
+# cur_gp:      loop_lx's peak general-bank demand with `forced` live throughout
+# cur_fp:      the same for the float bank
+# err:         set when a lazy allocation failed, so the caller reports it
 # block_count: number of blocks the arrays are sized for
 # nvals:       number of value slots (instruction pool length plus parameters)
 # words:       64-bit words per per-block value set
+# sets:        the single owned allocation every value set below is a view into
+# set_len:     its length in 64-bit words
 # live_in:     block -> values live on entry, excluding the block's own phi results
 # live_out:    block -> values live on exit
 # use_set:     block -> upward-exposed uses (phi operands excluded)
 # def_set:     block -> values the block defines (phis included)
 # scratch:     one spare value set, reused by the solver and the pressure walk
+# gp_mask:     the value slots that compete in the general bank
+# fp_mask:     the value slots that compete in the float bank
 # addr_feed:   values feeding an address computation in the loop being processed
-# hoisted:     every value this pass has lifted into a preheader, forced live across
-#              any loop the walk measures
+# hoisted:     every value this pass has lifted into a preheader anywhere in the
+#              function
+# forced:      the subset of `hoisted` that belongs to the loop being measured -- its
+#              own preheader plus every block of its body -- held live throughout
 # bank:        value slot -> the RegBank it competes in
 # budget_gp:   allocatable general registers
 # budget_fp:   allocatable float registers
 rec Pressure {
     alloc:       *A.Allocator;
     active:      bool;
+    built:       bool;
+    loop_lx:     u32;
+    cur_gp:      u32;
+    cur_fp:      u32;
+    err:         bool;
     block_count: u32;
     nvals:       u32;
     words:       u32;
+    sets:        *u64;
+    set_len:     u32;
     live_in:     *u64;
     live_out:    *u64;
     use_set:     *u64;
     def_set:     *u64;
     scratch:     *u64;
+    gp_mask:     *u64;
+    fp_mask:     *u64;
     addr_feed:   *u64;
     hoisted:     *u64;
+    forced:      *u64;
     bank:        *u8;
     budget_gp:   u32;
     budget_fp:   u32;
@@ -1067,102 +1118,129 @@ fun value_slot(pr: *Pressure, fn: *ir.Function, v: value.Value) u32 {
 # marker for an operand that occupies no value slot
 val NO_SLOT: u32 = 0xFFFFFFFF;
 
-# build the liveness and peak-pressure state for one function
+# size the pressure state for one function without allocating anything
 #
-# Solves a textbook backward liveness dataflow over the CFG the loop analysis
-# already ordered, then walks each block once more to record how many values of
-# each bank are live at its busiest point. Never mutates the function.
+# The arrays are built by `pressure_build` on the first candidate that needs a
+# budget decision. Never mutates the function.
 # ---
 # m:   the module owning the allocator and type table
 # fn:  the function to analyze
-# la:  the loop analysis, supplying reverse postorder
 # tgt: the target, supplying the register budget
-# ret: the populated state, or an allocation error
-fun pressure_init(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, tgt: *target.Target) R.Result[Pressure, str] {
+# ret: the state, with its arrays unbuilt
+fun pressure_blank(m: *ir.Module, fn: *ir.Function, tgt: *target.Target) Pressure {
     var pr: Pressure;
     pr.alloc       = m.alloc;
     pr.active      = tgt.arch != nil;
+    pr.built       = false;
+    pr.loop_lx     = loops.NONE_U32;
+    pr.cur_gp      = 0;
+    pr.cur_fp      = 0;
+    pr.err         = false;
     pr.block_count = fn.block_count;
     pr.nvals       = fn.instr_len + fn.param_count;
     pr.words       = (pr.nvals + 63) / 64;
+    pr.sets        = nil;
+    pr.set_len     = 0;
     pr.live_in     = nil;
     pr.live_out    = nil;
     pr.use_set     = nil;
     pr.def_set     = nil;
     pr.scratch     = nil;
+    pr.gp_mask     = nil;
+    pr.fp_mask     = nil;
     pr.addr_feed   = nil;
     pr.hoisted     = nil;
+    pr.forced      = nil;
     pr.bank        = nil;
     pr.budget_gp   = bank_budget(tgt, isa.RC_GENERAL);
     pr.budget_fp   = bank_budget(tgt, isa.RC_FLOAT);
 
-    if (!pr.active || pr.words == 0 || pr.block_count == 0) { pr.active = false; ret R.ok[Pressure, str](pr); }
+    if (pr.words == 0 || pr.block_count == 0) { pr.active = false; }
+    ret pr;
+}
 
-    val span: usize = (pr.block_count * pr.words)::usize;
-    val r_in: R.Result[*u64, str] = A.allocate[u64](m.alloc, span);
-    if (R.is_err[*u64, str](r_in)) { ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_in)); }
-    pr.live_in = R.unwrap_ok[*u64, str](r_in);
-    val r_out: R.Result[*u64, str] = A.allocate[u64](m.alloc, span);
-    if (R.is_err[*u64, str](r_out)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_out)); }
-    pr.live_out = R.unwrap_ok[*u64, str](r_out);
-    val r_use: R.Result[*u64, str] = A.allocate[u64](m.alloc, span);
-    if (R.is_err[*u64, str](r_use)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_use)); }
-    pr.use_set = R.unwrap_ok[*u64, str](r_use);
-    val r_def: R.Result[*u64, str] = A.allocate[u64](m.alloc, span);
-    if (R.is_err[*u64, str](r_def)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_def)); }
-    pr.def_set = R.unwrap_ok[*u64, str](r_def);
-    val r_sc: R.Result[*u64, str] = A.allocate[u64](m.alloc, pr.words::usize);
-    if (R.is_err[*u64, str](r_sc)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_sc)); }
-    pr.scratch = R.unwrap_ok[*u64, str](r_sc);
-    val r_af: R.Result[*u64, str] = A.allocate[u64](m.alloc, pr.words::usize);
-    if (R.is_err[*u64, str](r_af)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_af)); }
-    pr.addr_feed = R.unwrap_ok[*u64, str](r_af);
-    val r_hs: R.Result[*u64, str] = A.allocate[u64](m.alloc, pr.words::usize);
-    if (R.is_err[*u64, str](r_hs)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_hs)); }
-    pr.hoisted = R.unwrap_ok[*u64, str](r_hs);
+# build the liveness arrays on first use, reporting failure through `pr.err`
+#
+# Called from the admission test rather than from `licm_function`, so a function
+# whose loops produce no candidate never runs a liveness solve.
+# ---
+# m:   the module
+# fn:  the function
+# la:  the loop analysis, supplying reverse postorder
+# pr:  the state to populate
+fun pressure_build(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, pr: *Pressure) {
+    pr.built = true;
+
+    # one allocation for every value set: four per-block planes followed by four
+    # single-block scratch sets. a page allocator charges per request, and a large
+    # function would otherwise pay eight.
+    val span:  u32 = pr.block_count * pr.words;
+    val total: u32 = span * 4 + pr.words * 6;
+    val rb: R.Result[*u64, str] = A.allocate[u64](m.alloc, total::usize);
+    if (R.is_err[*u64, str](rb)) { pr.err = true; pr.active = false; ret; }
+    pr.sets     = R.unwrap_ok[*u64, str](rb);
+    pr.set_len  = total;
+    pr.live_in  = ?pr.sets[0];
+    pr.live_out = ?pr.sets[span];
+    pr.use_set  = ?pr.sets[span * 2];
+    pr.def_set  = ?pr.sets[span * 3];
+    pr.scratch   = ?pr.sets[span * 4];
+    pr.gp_mask   = ?pr.sets[span * 4 + pr.words];
+    pr.fp_mask   = ?pr.sets[span * 4 + pr.words * 2];
+    pr.addr_feed = ?pr.sets[span * 4 + pr.words * 3];
+    pr.hoisted   = ?pr.sets[span * 4 + pr.words * 4];
+    pr.forced    = ?pr.sets[span * 4 + pr.words * 5];
+
     val r_bk: R.Result[*u8, str] = A.allocate[u8](m.alloc, pr.nvals::usize);
-    if (R.is_err[*u8, str](r_bk)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u8, str](r_bk)); }
+    if (R.is_err[*u8, str](r_bk)) { pressure_dnit(pr); pr.err = true; pr.active = false; ret; }
     pr.bank = R.unwrap_ok[*u8, str](r_bk);
 
     var i: u32 = 0;
-    for (i < pr.block_count * pr.words) {
-        pr.live_in[i] = 0; pr.live_out[i] = 0; pr.use_set[i] = 0; pr.def_set[i] = 0;
-        i = i + 1;
-    }
-    var h: u32 = 0;
-    for (h < pr.words) { pr.hoisted[h] = 0; h = h + 1; }
+    for (i < total) { pr.sets[i] = 0; i = i + 1; }
 
-    fill_banks(m, fn, ?pr);
-    fill_use_def(fn, ?pr);
-    solve_liveness(fn, la, ?pr);
-    ret R.ok[Pressure, str](pr);
+    fill_banks(m, fn, pr);
+    fill_use_def(fn, pr);
+    solve_liveness(fn, la, pr);
 }
 
-# release every array the pressure state owns; safe on a partially built value
+# release the pressure state's storage; safe on a state whose arrays were never built
 # ---
 # pr: the state to tear down
 fun pressure_dnit(pr: *Pressure) {
-    val span: usize = (pr.block_count * pr.words)::usize;
-    if (pr.live_in  != nil) { A.deallocate[u64](pr.alloc, pr.live_in,  span); pr.live_in  = nil; }
-    if (pr.live_out != nil) { A.deallocate[u64](pr.alloc, pr.live_out, span); pr.live_out = nil; }
-    if (pr.use_set  != nil) { A.deallocate[u64](pr.alloc, pr.use_set,  span); pr.use_set  = nil; }
-    if (pr.def_set  != nil) { A.deallocate[u64](pr.alloc, pr.def_set,  span); pr.def_set  = nil; }
-    if (pr.scratch  != nil) { A.deallocate[u64](pr.alloc, pr.scratch,  pr.words::usize); pr.scratch = nil; }
-    if (pr.addr_feed != nil) { A.deallocate[u64](pr.alloc, pr.addr_feed, pr.words::usize); pr.addr_feed = nil; }
-    if (pr.hoisted  != nil) { A.deallocate[u64](pr.alloc, pr.hoisted,  pr.words::usize); pr.hoisted  = nil; }
-    if (pr.bank     != nil) { A.deallocate[u8](pr.alloc,  pr.bank,     pr.nvals::usize); pr.bank    = nil; }
+    if (pr.sets != nil) { A.deallocate[u64](pr.alloc, pr.sets, pr.set_len::usize); pr.sets = nil; }
+    if (pr.bank != nil) { A.deallocate[u8](pr.alloc, pr.bank, pr.nvals::usize); pr.bank = nil; }
+    pr.set_len   = 0;
+    pr.live_in   = nil;
+    pr.live_out  = nil;
+    pr.use_set   = nil;
+    pr.def_set   = nil;
+    pr.scratch   = nil;
+    pr.gp_mask   = nil;
+    pr.fp_mask   = nil;
+    pr.addr_feed = nil;
+    pr.hoisted   = nil;
+    pr.forced    = nil;
 }
 
 # classify every value slot by the bank it competes in
 # ---
 # m:  the module
 # fn: the function
-# pr: the state whose `bank` array is filled
+# pr: the state whose `bank` array and bank masks are filled
 fun fill_banks(m: *ir.Module, fn: *ir.Function, pr: *Pressure) {
     var i: u32 = 0;
     for (i < fn.instr_len) { pr.bank[i] = bank_of_type(m, fn.instrs[i].ty); i = i + 1; }
     var p: u32 = 0;
     for (p < fn.param_count) { pr.bank[fn.instr_len + p] = bank_of_type(m, fn.params[p].ty); p = p + 1; }
+
+    # the same classification as a pair of bitmasks, so counting a live set is two
+    # masked popcounts per word rather than a scan of its bits.
+    var s: u32 = 0;
+    for (s < pr.nvals) {
+        if (pr.bank[s]::RegBank == BANK_GP) { bit_set(pr.gp_mask, s); }
+        or { if (pr.bank[s]::RegBank == BANK_FP) { bit_set(pr.fp_mask, s); } }
+        s = s + 1;
+    }
 }
 
 # fill each block's upward-exposed use set and definition set
@@ -1380,7 +1458,7 @@ fun loop_peak(fn: *ir.Function, pr: *Pressure, la: *loops.LoopAnalysis, lx: u32,
         val base: u32 = b * pr.words;
 
         var w: u32 = 0;
-        for (w < pr.words) { pr.scratch[w] = pr.live_out[base + w] | pr.hoisted[w]; w = w + 1; }
+        for (w < pr.words) { pr.scratch[w] = pr.live_out[base + w] | pr.forced[w]; w = w + 1; }
         if (extra != NO_SLOT && extra < pr.nvals) { bit_set(pr.scratch, extra); }
 
         var gp: u32 = 0;
@@ -1420,20 +1498,33 @@ fun count_banks(pr: *Pressure, out_gp: *u32, out_fp: *u32) {
     var fp: u32 = 0;
     var w: u32 = 0;
     for (w < pr.words) {
-        if (pr.scratch[w] == 0) { w = w + 1; cnt; }
-        var bit: u32 = 0;
-        for (bit < 64) {
-            val s: u32 = w * 64 + bit;
-            bit = bit + 1;
-            if (s >= pr.nvals) { brk; }
-            if (!bit_get(pr.scratch, s)) { cnt; }
-            if (pr.bank[s]::RegBank == BANK_GP) { gp = gp + 1; }
-            or { if (pr.bank[s]::RegBank == BANK_FP) { fp = fp + 1; } }
+        val v: u64 = pr.scratch[w];
+        if (v != 0) {
+            gp = gp + popcount(v & pr.gp_mask[w]);
+            fp = fp + popcount(v & pr.fp_mask[w]);
         }
         w = w + 1;
     }
     @out_gp = gp;
     @out_fp = fp;
+}
+
+# the number of set bits in `x`
+#
+# The standard SWAR fold -- pairwise sums, then nibbles, then a halving cascade --
+# written without the usual final multiply so it needs no wrapping arithmetic.
+# ---
+# x:   the word
+# ret: its population count
+fun popcount(x: u64) u32 {
+    var v: u64 = x;
+    v = v - ((v >> 1::u64) & 0x5555555555555555);
+    v = (v & 0x3333333333333333) + ((v >> 2::u64) & 0x3333333333333333);
+    v = (v + (v >> 4::u64)) & 0x0F0F0F0F0F0F0F0F;
+    v = v + (v >> 8::u64);
+    v = v + (v >> 16::u64);
+    v = v + (v >> 32::u64);
+    ret (v & 0x7F)::u32;
 }
 
 # move the scratch value set one instruction earlier, keeping the bank counts in
@@ -1450,7 +1541,7 @@ fun step_back(fn: *ir.Function, pr: *Pressure, iid: id.InstructionId, extra: u32
     val db: RegBank = bank_slot(pr, slot);
     # a forced-live value never dies inside the loop: its definition is in the
     # preheader, above every point this walk measures.
-    if (db != BANK_NONE && slot != extra && !bit_get(pr.hoisted, slot)) {
+    if (db != BANK_NONE && slot != extra && !bit_get(pr.forced, slot)) {
         if (bit_clr(pr.scratch, slot)) {
             if (db == BANK_GP && @out_gp > 0) { @out_gp = @out_gp - 1; }
             or { if (db == BANK_FP && @out_fp > 0) { @out_fp = @out_fp - 1; } }
@@ -1472,6 +1563,43 @@ fun step_back(fn: *ir.Function, pr: *Pressure, iid: id.InstructionId, extra: u32
             }
         }
         o = o + 1;
+    }
+}
+
+# narrow `hoisted` to the values loop `lx` actually carries
+#
+# A value this pass lifted belongs to the loop whose preheader received it and to
+# every loop enclosing that one -- for an enclosing loop the definition sits in a
+# body block, so the value is live across the part of it the nested loop occupies. A
+# value lifted out of some unrelated loop is not live here at all, and forcing it
+# would inflate this loop's demand with a register it never holds.
+#
+# Loops are processed innermost-first, so by the time an enclosing loop is measured
+# every value its children lifted is already recorded.
+# ---
+# la:     the loop analysis, whose instruction-to-block map every move keeps current
+# lx:     index into la.loops
+# pre_id: the loop's preheader
+# pr:     the state whose `forced` set is rebuilt
+fun select_forced(la: *loops.LoopAnalysis, lx: u32, pre_id: id.BlockId, pr: *Pressure) {
+    var w: u32 = 0;
+    for (w < pr.words) { pr.forced[w] = 0; w = w + 1; }
+
+    w = 0;
+    for (w < pr.words) {
+        if (pr.hoisted[w] == 0) { w = w + 1; cnt; }
+        var bit: u32 = 0;
+        for (bit < 64) {
+            val slot: u32 = w * 64 + bit;
+            bit = bit + 1;
+            if (slot >= pr.nvals) { brk; }
+            if (!bit_get(pr.hoisted, slot)) { cnt; }
+            if (slot >= la.instr_count)   { cnt; }
+            val b: id.BlockId = la.instr_block[slot];
+            if (b == id.BLOCK_NIL)          { cnt; }
+            if (b == pre_id || loops.loop_contains(la, lx, b)) { bit_set(pr.forced, slot); }
+        }
+        w = w + 1;
     }
 }
 

--- a/src/lang/me/transform/licm.mach
+++ b/src/lang/me/transform/licm.mach
@@ -55,6 +55,38 @@
 #           a parameter, a loaded pointer, a phi -- may, and declines the hoist.
 #   5. Volatile loads and stores are never moved.
 #
+# REGISTER-PRESSURE BUDGET (#2255). Safety says what MAY move; whether it is worth
+# moving depends on whether the loop has a register to keep the lifted value in. A
+# value in the preheader is live across every iteration, so it holds one register of
+# its bank for the loop's whole execution. Each loop therefore carries a budget:
+#
+#   - its DEMAND is what the loop's busiest point would need with the candidate, and
+#     every value already lifted, live throughout -- a backward liveness solve over
+#     the function (`solve_liveness`) re-read per candidate (`loop_peak`). Measuring
+#     it that way rather than adding one per hoist is what keeps it honest: a hoisted
+#     value was ALREADY live over part of the loop, so its true cost at the busiest
+#     point is zero as often as it is one;
+#   - its SUPPLY is the register file the target describes: a bank's declared size
+#     less the registers the model withholds from value allocation (`bank_budget`).
+#
+# Under budget, a hoist is pure gain and is taken. Over it, the lifted value (or one
+# it displaces) spills and its uses become reloads -- one instruction per iteration --
+# so the hoist only pays when what it removes from the body costs MORE than that
+# reload. An address does: `OP_GEP` names a whole address computation the back end
+# rebuilds in several instructions, and the arithmetic feeding one is part of the same
+# rebuild. A WIDTH CAST does not, even inside an address chain: it re-presents an index
+# the loop already holds, and the allocator cannot coalesce the result with its source,
+# so the loop carries the datum twice for at most one instruction saved. Everything
+# else -- load, reinterpret, arithmetic, comparison -- is one instruction, and one
+# instruction for one reload cannot pay.
+#
+# Neither number is tuned; both are read from the program and the target. Where
+# either is missing -- a whole-module emitter with no register machine, or a bank the
+# model does not declare -- there is no budget and hoisting is decided on safety
+# alone. The estimate is over IR values, one stage ahead of the selection that fuses
+# and folds some of them, so it is an estimate and not a bound; declining a hoist only
+# forgoes a win, so an inexact one is never a correctness question.
+#
 # The pass runs in the release pipeline only, so debug output is unchanged. It is
 # safe inside an `#[oblivious]` function: every decision is made from the static IR
 # shape and never from a runtime value, no control flow is introduced, nothing is
@@ -80,6 +112,7 @@ use mach.lang.me.ir.instruction;
 use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.target;
+use mach.lang.target.isa;
 use loops: mach.lang.me.analysis.loops;
 use dep: mach.lang.me.analysis.dependence;
 
@@ -126,11 +159,20 @@ fun licm_function(m: *ir.Module, fn: *ir.Function, tgt: *target.Target) R.Result
     val order: *u32 = R.unwrap_ok[*u32, str](ro);
     order_innermost_first(?la, order);
 
+    val rpr: R.Result[Pressure, str] = pressure_init(m, fn, ?la, tgt);
+    if (R.is_err[Pressure, str](rpr)) {
+        A.deallocate[u32](m.alloc, order, n::usize);
+        loops.dnit(?la);
+        ret R.err[bool, str](R.unwrap_err[Pressure, str](rpr));
+    }
+    var pr: Pressure = R.unwrap_ok[Pressure, str](rpr);
+
     var changed: bool = false;
     var oi: u32 = 0;
     for (oi < n) {
-        val rl: R.Result[bool, str] = licm_loop(m, fn, ?la, order[oi], tgt);
+        val rl: R.Result[bool, str] = licm_loop(m, fn, ?la, order[oi], tgt, ?pr);
         if (R.is_err[bool, str](rl)) {
+            pressure_dnit(?pr);
             A.deallocate[u32](m.alloc, order, n::usize);
             loops.dnit(?la);
             ret rl;
@@ -139,6 +181,7 @@ fun licm_function(m: *ir.Module, fn: *ir.Function, tgt: *target.Target) R.Result
         oi = oi + 1;
     }
 
+    pressure_dnit(?pr);
     A.deallocate[u32](m.alloc, order, n::usize);
     loops.dnit(?la);
     ret R.ok[bool, str](changed);
@@ -181,18 +224,22 @@ fun order_innermost_first(la: *loops.LoopAnalysis, order: *u32) {
 # which sits before the preheader's terminator because a block's terminator is not
 # part of its instruction list.
 # ---
-# m:   module owning the allocator
-# fn:  the function
-# la:  the loop analysis, kept in step with every move
-# lx:  index into la.loops
-# tgt: the target
-# ret: ok(true) if anything moved, or an allocation error
-fun licm_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32, tgt: *target.Target) R.Result[bool, str] {
+# m:        module owning the allocator
+# fn:       the function
+# la:       the loop analysis, kept in step with every move
+# lx:       index into la.loops
+# tgt:      the target
+# pr:       the function's register-pressure state
+# ret:      ok(true) if anything moved, or an allocation error
+fun licm_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32, tgt: *target.Target,
+              pr: *Pressure) R.Result[bool, str] {
     val lp: *loops.Loop = ?la.loops[lx];
     val pre_id: id.BlockId = lp.preheader;
     if (pre_id == id.BLOCK_NIL) { ret R.ok[bool, str](false); }
 
     val opaque: bool = loop_has_opaque_effect(fn, la, lx);
+
+    if (pr.active) { fill_addr_feeders(fn, la, lx, pr); }
 
     var changed: bool = false;
     var ri: u32 = 0;
@@ -208,7 +255,9 @@ fun licm_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32,
             val iid: id.InstructionId = blk.instructions[k];
             k = k + 1;
 
-            if (hoistable(m, fn, la, lx, tgt, iid, opaque)) {
+            if (hoistable(m, fn, la, lx, tgt, iid, opaque) &&
+                pressure_admits(m, fn, pr, la, lx, iid, fn.instrs[iid::u32].kind)) {
+                if (iid::u32 < pr.nvals) { bit_set(pr.hoisted, iid::u32); }
                 val rp: R.Result[bool, str] = ir.block_append_instr(m, ?fn.blocks[pre_id::u32], iid);
                 if (R.is_err[bool, str](rp)) { ret rp; }
                 val rs: R.Result[bool, str] = loops.set_instr_block(la, iid, pre_id);
@@ -227,6 +276,86 @@ fun licm_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32,
         blk.instr_count = w;
     }
     ret R.ok[bool, str](changed);
+}
+
+# true when lifting instruction `iid` out of loop `lx` is worth its register
+#
+# A value in the preheader is live across every iteration, so it holds one register
+# of its bank for the loop's whole execution. `loop_peak` reports what the loop's
+# busiest point would demand with that value -- and every value already lifted --
+# live throughout, which is exactly the pressure the allocator will see. While that
+# stays inside the register file the hoist is pure gain.
+#
+# Once the bank is full, the lifted value (or one it displaces) spills and every use
+# inside the loop becomes a RELOAD -- one instruction per iteration. So past the
+# budget the question is no longer "is this invariant" but "does what I remove from
+# the body cost more than the reload that replaces it":
+#
+#   - An address DOES. `OP_GEP` is the one IR opcode naming a whole address
+#     computation rather than a single machine operation, and `gep_is_worth_hoisting`
+#     has already restricted the candidates to the shapes no addressing mode can
+#     absorb. Rebuilding one costs several instructions every iteration, so trading
+#     it for a reload still pays. The index arithmetic FEEDING such a gep is part of
+#     the same rebuild (`addr_feed`): stranding one `add` in the body leaves the gep
+#     variant and forfeits the whole chain.
+#   - A WIDTH CAST does not, even inside an address chain. `zext` / `sext` / `trunc`
+#     do not compute an address; they re-present an index the loop already holds at
+#     another width, and unlike a same-width reinterpret the allocator cannot
+#     coalesce the result with its source. Admitting one under pressure makes the
+#     loop carry the same datum twice for at most one instruction saved, so a chain
+#     is cut where it crosses a width cast rather than followed through it.
+#   - Nothing else does. Every other invariant opcode -- a load, an arithmetic or
+#     bitwise operation, a comparison -- names one machine operation, so lifting it
+#     under pressure exchanges one instruction for one reload and cannot pay.
+#
+# This is a cost rule only: declining a safe hoist forgoes a win and never changes a
+# result. Where the register file is unavailable -- a target with no register machine,
+# or a bank the model does not declare -- there is no budget and the hoist is decided
+# on safety alone.
+# ---
+# m:    the module
+# fn:   the function
+# pr:   the function's pressure state
+# la:   the loop analysis
+# lx:   index into la.loops
+# iid:  the candidate instruction
+# kind: its opcode
+# ret:  true when the hoist is worth making
+fun pressure_admits(m: *ir.Module, fn: *ir.Function, pr: *Pressure, la: *loops.LoopAnalysis, lx: u32,
+                    iid: id.InstructionId, kind: instruction.InstrKind) bool {
+    if (!pr.active) { ret true; }
+
+    val bk: RegBank = bank_of_type(m, fn.instrs[iid::u32].ty);
+    if (bk == BANK_NONE) { ret true; }
+
+    var slot: u32 = NO_SLOT;
+    if (iid::u32 < pr.nvals) { slot = iid::u32; }
+
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+    loop_peak(fn, pr, la, lx, slot, ?gp, ?fp);
+
+    var full: bool = false;
+    if (bk == BANK_GP)      { full = pr.budget_gp != 0 && gp > pr.budget_gp; }
+    or { if (bk == BANK_FP) { full = pr.budget_fp != 0 && fp > pr.budget_fp; } }
+
+    if (!full)                      { ret true; }
+    if (kind == instruction.OP_GEP) { ret true; }
+    if (is_width_cast(kind))        { ret false; }
+    ret slot != NO_SLOT && bit_get(pr.addr_feed, slot);
+}
+
+# true for the casts that re-present a value at a different width
+#
+# `OP_BITCAST` is deliberately absent: a same-width reinterpret selects to a plain
+# register copy, which coalescing removes, so the reinterpreted and original values
+# share a register and lifting one costs nothing. A width change cannot be coalesced
+# -- the two values genuinely differ -- so the loop carries the datum twice.
+# ---
+# k:   the opcode
+# ret: true for sext / zext / trunc
+fun is_width_cast(k: instruction.InstrKind) bool {
+    ret k == instruction.OP_SEXT || k == instruction.OP_ZEXT || k == instruction.OP_TRUNC;
 }
 
 # true when instruction `iid` may be relocated to the loop's preheader
@@ -627,13 +756,13 @@ fun pointer_root(fn: *ir.Function, p: value.Value) value.Value {
 # splitting it would add a preheader instruction, lengthen a live range, and save
 # nothing in the body.
 # ---
-# m:      the module
-# fn:     the function
-# la:     the loop analysis, updated with the new instruction's block
-# lx:     index into la.loops
-# iid:    the candidate gep
-# pre_id: the loop's preheader
-# ret:    ok(true) when the gep was split, or an allocation error
+# m:        the module
+# fn:       the function
+# la:       the loop analysis, updated with the new instruction's block
+# lx:       index into la.loops
+# iid:      the candidate gep
+# pre_id:   the loop's preheader
+# ret:      ok(true) when the gep was split, or an allocation error
 fun split_invariant_gep_prefix(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32,
                                iid: id.InstructionId, pre_id: id.BlockId) R.Result[bool, str] {
     if (iid::u32 >= fn.instr_len)                          { ret R.ok[bool, str](false); }
@@ -786,6 +915,612 @@ fun emit_prefix_gep(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, k: u
     val ri: R.Result[id.InstructionId, str] = ir.instruction_add(m, fn, ni);
     if (R.is_err[id.InstructionId, str](ri)) { A.deallocate[value.Value](m.alloc, ops, (k + 1)::usize); }
     ret ri;
+}
+
+# the register bank a value competes for
+#
+# A value costs a register only where the back end keeps it in one. Integers,
+# pointers and booleans draw from the general bank; floats and vectors from the
+# float bank. A void result or a whole aggregate is not register-allocated and
+# costs nothing.
+def RegBank: u8;
+val BANK_NONE: RegBank = 0;
+val BANK_GP:   RegBank = 1;
+val BANK_FP:   RegBank = 2;
+
+# the bank a value of IR type `ty` competes in
+# ---
+# m:   the module owning the type table
+# ty:  the value's IR type
+# ret: the bank, or BANK_NONE when the value is not register-allocated
+fun bank_of_type(m: *ir.Module, ty: ir_type.IrTypeId) RegBank {
+    if (ty == ir_type.IRT_NIL) { ret BANK_NONE; }
+    val o: O.Option[*ir_type.IrType] = ir_type.get(?m.types, ty);
+    if (!O.is_some[*ir_type.IrType](o)) { ret BANK_NONE; }
+    val t: *ir_type.IrType = O.unwrap[*ir_type.IrType](o);
+    if (t.kind == ir_type.IRT_INT || t.kind == ir_type.IRT_PTR)      { ret BANK_GP; }
+    if (t.kind == ir_type.IRT_FLOAT || t.kind == ir_type.IRT_VECTOR) { ret BANK_FP; }
+    ret BANK_NONE;
+}
+
+# the number of registers of `kind` the allocator can hand to values
+#
+# Read entirely from the target's own machine model, never assumed: the bank's
+# declared size less the registers the model withholds from value allocation.
+# `reserved_regs` (the frame and stack pointers) and `scratch_regs` (the
+# spill-reload pool) name general-bank registers -- `regalloc.seed_reserved`
+# withholds them from the GP file alone -- so they are subtracted only there. Each
+# ISA's float bank is already declared at its allocatable size, with the encoder's
+# fixed scratch pair excluded from `len`.
+#
+# The count is the model's, so it is exactly as accurate as the model: on x86_64
+# it reports 16 - {RSP, RBP} - {R8, R9, R10} = 11, one more than regalloc's true
+# ten, because the encoder's mem-mem split scratch (R11) is a `RegMachine` field
+# the model does not carry. A budget one register optimistic admits one more hoist
+# than the allocator has room for; it is a cost model, not a correctness bound.
+# ---
+# tgt:  the target
+# kind: the bank to size
+# ret:  allocatable register count, or 0 when the target declares no such bank
+fun bank_budget(tgt: *target.Target, kind: isa.RegClassKind) u32 {
+    var i: u32 = 0;
+    for (i < tgt.model.reg_class_len) {
+        if (tgt.model.reg_classes[i].kind != kind) { i = i + 1; cnt; }
+
+        val len: u32 = tgt.model.reg_classes[i].len;
+        if (kind != isa.RC_GENERAL) { ret len; }
+
+        var held: u32 = 0;
+        if (tgt.model.reserved_len > 0) { held = held + tgt.model.reserved_len::u32; }
+        if (tgt.model.scratch_len  > 0) { held = held + tgt.model.scratch_len::u32; }
+        if (held >= len) { ret 0; }
+        ret len - held;
+    }
+    ret 0;
+}
+
+# one function's value liveness and the per-block peak register pressure it implies
+#
+# `active` is false when the target is a whole-module emitter (`arch == nil`): such
+# a target has no register allocator, so there is no pressure to model and the pass
+# hoists on safety alone.
+# ---
+# alloc:       allocator backing every owned array
+# active:      true when a register budget applies
+# block_count: number of blocks the arrays are sized for
+# nvals:       number of value slots (instruction pool length plus parameters)
+# words:       64-bit words per per-block value set
+# live_in:     block -> values live on entry, excluding the block's own phi results
+# live_out:    block -> values live on exit
+# use_set:     block -> upward-exposed uses (phi operands excluded)
+# def_set:     block -> values the block defines (phis included)
+# scratch:     one spare value set, reused by the solver and the pressure walk
+# addr_feed:   values feeding an address computation in the loop being processed
+# hoisted:     every value this pass has lifted into a preheader, forced live across
+#              any loop the walk measures
+# bank:        value slot -> the RegBank it competes in
+# budget_gp:   allocatable general registers
+# budget_fp:   allocatable float registers
+rec Pressure {
+    alloc:       *A.Allocator;
+    active:      bool;
+    block_count: u32;
+    nvals:       u32;
+    words:       u32;
+    live_in:     *u64;
+    live_out:    *u64;
+    use_set:     *u64;
+    def_set:     *u64;
+    scratch:     *u64;
+    addr_feed:   *u64;
+    hoisted:     *u64;
+    bank:        *u8;
+    budget_gp:   u32;
+    budget_fp:   u32;
+}
+
+# true when bit `i` of value set `b` is set
+fun bit_get(b: *u64, i: u32) bool {
+    ret (b[i / 64] & (1::u64 << (i % 64)::u64)) != 0;
+}
+
+# set bit `i` of value set `b`, reporting whether it was newly set
+fun bit_set(b: *u64, i: u32) bool {
+    val w: u32 = i / 64;
+    val k: u64 = 1::u64 << (i % 64)::u64;
+    if ((b[w] & k) != 0) { ret false; }
+    b[w] = b[w] | k;
+    ret true;
+}
+
+# clear bit `i` of value set `b`, reporting whether it was previously set
+fun bit_clr(b: *u64, i: u32) bool {
+    val w: u32 = i / 64;
+    val k: u64 = 1::u64 << (i % 64)::u64;
+    if ((b[w] & k) == 0) { ret false; }
+    b[w] = b[w] & ~k;
+    ret true;
+}
+
+# the value slot an operand names, or NO_SLOT when it names no register value
+#
+# Instruction results occupy slot `iid`; parameters follow them, one slot each.
+# Constants, globals, function symbols and block targets name no register.
+# ---
+# pr:  the pressure state, for the slot layout
+# fn:  the function
+# v:   the operand value
+# ret: the slot index, or NO_SLOT
+fun value_slot(pr: *Pressure, fn: *ir.Function, v: value.Value) u32 {
+    if (v.kind == value.VAL_INSTR) {
+        val iid: u32 = v.data.instr::u32;
+        if (iid >= fn.instr_len) { ret NO_SLOT; }
+        ret iid;
+    }
+    if (v.kind == value.VAL_PARAM) {
+        if (v.data.param_ix >= fn.param_count) { ret NO_SLOT; }
+        ret fn.instr_len + v.data.param_ix;
+    }
+    ret NO_SLOT;
+}
+
+# marker for an operand that occupies no value slot
+val NO_SLOT: u32 = 0xFFFFFFFF;
+
+# build the liveness and peak-pressure state for one function
+#
+# Solves a textbook backward liveness dataflow over the CFG the loop analysis
+# already ordered, then walks each block once more to record how many values of
+# each bank are live at its busiest point. Never mutates the function.
+# ---
+# m:   the module owning the allocator and type table
+# fn:  the function to analyze
+# la:  the loop analysis, supplying reverse postorder
+# tgt: the target, supplying the register budget
+# ret: the populated state, or an allocation error
+fun pressure_init(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, tgt: *target.Target) R.Result[Pressure, str] {
+    var pr: Pressure;
+    pr.alloc       = m.alloc;
+    pr.active      = tgt.arch != nil;
+    pr.block_count = fn.block_count;
+    pr.nvals       = fn.instr_len + fn.param_count;
+    pr.words       = (pr.nvals + 63) / 64;
+    pr.live_in     = nil;
+    pr.live_out    = nil;
+    pr.use_set     = nil;
+    pr.def_set     = nil;
+    pr.scratch     = nil;
+    pr.addr_feed   = nil;
+    pr.hoisted     = nil;
+    pr.bank        = nil;
+    pr.budget_gp   = bank_budget(tgt, isa.RC_GENERAL);
+    pr.budget_fp   = bank_budget(tgt, isa.RC_FLOAT);
+
+    if (!pr.active || pr.words == 0 || pr.block_count == 0) { pr.active = false; ret R.ok[Pressure, str](pr); }
+
+    val span: usize = (pr.block_count * pr.words)::usize;
+    val r_in: R.Result[*u64, str] = A.allocate[u64](m.alloc, span);
+    if (R.is_err[*u64, str](r_in)) { ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_in)); }
+    pr.live_in = R.unwrap_ok[*u64, str](r_in);
+    val r_out: R.Result[*u64, str] = A.allocate[u64](m.alloc, span);
+    if (R.is_err[*u64, str](r_out)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_out)); }
+    pr.live_out = R.unwrap_ok[*u64, str](r_out);
+    val r_use: R.Result[*u64, str] = A.allocate[u64](m.alloc, span);
+    if (R.is_err[*u64, str](r_use)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_use)); }
+    pr.use_set = R.unwrap_ok[*u64, str](r_use);
+    val r_def: R.Result[*u64, str] = A.allocate[u64](m.alloc, span);
+    if (R.is_err[*u64, str](r_def)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_def)); }
+    pr.def_set = R.unwrap_ok[*u64, str](r_def);
+    val r_sc: R.Result[*u64, str] = A.allocate[u64](m.alloc, pr.words::usize);
+    if (R.is_err[*u64, str](r_sc)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_sc)); }
+    pr.scratch = R.unwrap_ok[*u64, str](r_sc);
+    val r_af: R.Result[*u64, str] = A.allocate[u64](m.alloc, pr.words::usize);
+    if (R.is_err[*u64, str](r_af)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_af)); }
+    pr.addr_feed = R.unwrap_ok[*u64, str](r_af);
+    val r_hs: R.Result[*u64, str] = A.allocate[u64](m.alloc, pr.words::usize);
+    if (R.is_err[*u64, str](r_hs)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u64, str](r_hs)); }
+    pr.hoisted = R.unwrap_ok[*u64, str](r_hs);
+    val r_bk: R.Result[*u8, str] = A.allocate[u8](m.alloc, pr.nvals::usize);
+    if (R.is_err[*u8, str](r_bk)) { pressure_dnit(?pr); ret R.err[Pressure, str](R.unwrap_err[*u8, str](r_bk)); }
+    pr.bank = R.unwrap_ok[*u8, str](r_bk);
+
+    var i: u32 = 0;
+    for (i < pr.block_count * pr.words) {
+        pr.live_in[i] = 0; pr.live_out[i] = 0; pr.use_set[i] = 0; pr.def_set[i] = 0;
+        i = i + 1;
+    }
+    var h: u32 = 0;
+    for (h < pr.words) { pr.hoisted[h] = 0; h = h + 1; }
+
+    fill_banks(m, fn, ?pr);
+    fill_use_def(fn, ?pr);
+    solve_liveness(fn, la, ?pr);
+    ret R.ok[Pressure, str](pr);
+}
+
+# release every array the pressure state owns; safe on a partially built value
+# ---
+# pr: the state to tear down
+fun pressure_dnit(pr: *Pressure) {
+    val span: usize = (pr.block_count * pr.words)::usize;
+    if (pr.live_in  != nil) { A.deallocate[u64](pr.alloc, pr.live_in,  span); pr.live_in  = nil; }
+    if (pr.live_out != nil) { A.deallocate[u64](pr.alloc, pr.live_out, span); pr.live_out = nil; }
+    if (pr.use_set  != nil) { A.deallocate[u64](pr.alloc, pr.use_set,  span); pr.use_set  = nil; }
+    if (pr.def_set  != nil) { A.deallocate[u64](pr.alloc, pr.def_set,  span); pr.def_set  = nil; }
+    if (pr.scratch  != nil) { A.deallocate[u64](pr.alloc, pr.scratch,  pr.words::usize); pr.scratch = nil; }
+    if (pr.addr_feed != nil) { A.deallocate[u64](pr.alloc, pr.addr_feed, pr.words::usize); pr.addr_feed = nil; }
+    if (pr.hoisted  != nil) { A.deallocate[u64](pr.alloc, pr.hoisted,  pr.words::usize); pr.hoisted  = nil; }
+    if (pr.bank     != nil) { A.deallocate[u8](pr.alloc,  pr.bank,     pr.nvals::usize); pr.bank    = nil; }
+}
+
+# classify every value slot by the bank it competes in
+# ---
+# m:  the module
+# fn: the function
+# pr: the state whose `bank` array is filled
+fun fill_banks(m: *ir.Module, fn: *ir.Function, pr: *Pressure) {
+    var i: u32 = 0;
+    for (i < fn.instr_len) { pr.bank[i] = bank_of_type(m, fn.instrs[i].ty); i = i + 1; }
+    var p: u32 = 0;
+    for (p < fn.param_count) { pr.bank[fn.instr_len + p] = bank_of_type(m, fn.params[p].ty); p = p + 1; }
+}
+
+# fill each block's upward-exposed use set and definition set
+#
+# Walked backwards so a value defined and then used within the block never enters
+# `use`. A phi's operands are attributed to the predecessor edge, not to this
+# block, so they are excluded here and added by `solve_liveness`.
+# ---
+# fn: the function
+# pr: the state whose `use_set` / `def_set` are filled
+fun fill_use_def(fn: *ir.Function, pr: *Pressure) {
+    var b: u32 = 0;
+    for (b < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[b];
+        val base: u32 = b * pr.words;
+
+        if (blk.terminator != id.INSTR_NIL && blk.terminator::u32 < fn.instr_len) {
+            add_uses(fn, pr, ?pr.use_set[base], blk.terminator);
+        }
+
+        var k: u32 = blk.instr_count;
+        for (k > 0) {
+            k = k - 1;
+            val iid: id.InstructionId = blk.instructions[k];
+            if (iid::u32 >= fn.instr_len) { cnt; }
+            if (bank_slot(pr, iid::u32) != BANK_NONE) {
+                bit_set(?pr.def_set[base], iid::u32);
+                bit_clr(?pr.use_set[base], iid::u32);
+            }
+            add_uses(fn, pr, ?pr.use_set[base], iid);
+        }
+
+        var p: u32 = 0;
+        for (p < blk.phi_count) {
+            val pid: id.InstructionId = blk.phis[p];
+            p = p + 1;
+            if (pid::u32 >= fn.instr_len) { cnt; }
+            if (bank_slot(pr, pid::u32) == BANK_NONE) { cnt; }
+            bit_set(?pr.def_set[base], pid::u32);
+            bit_clr(?pr.use_set[base], pid::u32);
+        }
+
+        b = b + 1;
+    }
+}
+
+# the bank of value slot `s`, or BANK_NONE when the slot is out of range
+fun bank_slot(pr: *Pressure, s: u32) RegBank {
+    if (s >= pr.nvals) { ret BANK_NONE; }
+    ret pr.bank[s]::RegBank;
+}
+
+# add every register-holding operand of `iid` to value set `dst`
+#
+# Phi operands are skipped: they belong to the predecessor edge. Block targets and
+# constants hold no register and resolve to no slot.
+# ---
+# fn:  the function
+# pr:  the state, for the slot layout
+# dst: the value set to add to
+# iid: the instruction whose operands are read
+fun add_uses(fn: *ir.Function, pr: *Pressure, dst: *u64, iid: id.InstructionId) {
+    val ins: *instruction.Instruction = ?fn.instrs[iid::u32];
+    if (ins.kind == instruction.OP_PHI) { ret; }
+    var o: u32 = 0;
+    for (o < ins.operand_count) {
+        if (operand_holds_value(ins, o)) {
+            val s: u32 = value_slot(pr, fn, ins.operands[o]);
+            if (s != NO_SLOT && bank_slot(pr, s) != BANK_NONE) { bit_set(dst, s); }
+        }
+        o = o + 1;
+    }
+}
+
+# true when operand `o` of `ins` reads a value rather than naming a block
+#
+# The same operand convention the dead-code pass reads: a branch's target slots and
+# a debug record's operands name no runtime value.
+# ---
+# ins: the instruction
+# o:   the operand slot
+# ret: true when the slot holds a value use
+fun operand_holds_value(ins: *instruction.Instruction, o: u32) bool {
+    if (ins.kind == instruction.OP_BR)        { ret false; }
+    if (ins.kind == instruction.OP_CBR)       { ret o == 0; }
+    if (ins.kind == instruction.OP_PHI)       { ret (o % 2) == 1; }
+    if (ins.kind == instruction.OP_DBG_VALUE) { ret false; }
+    ret true;
+}
+
+# solve `live_in = use | (live_out - def)` to a fixed point
+#
+# Blocks are visited in reverse postorder reversed -- successors before
+# predecessors -- so a backward problem converges in few sweeps. The sets only
+# grow, so the iteration terminates.
+# ---
+# fn: the function
+# la: the loop analysis, supplying reverse postorder
+# pr: the state whose `live_in` / `live_out` are solved
+fun solve_liveness(fn: *ir.Function, la: *loops.LoopAnalysis, pr: *Pressure) {
+    var changed: bool = true;
+    for (changed) {
+        changed = false;
+        var ri: u32 = la.rpo_len;
+        for (ri > 0) {
+            ri = ri - 1;
+            val b: id.BlockId = la.rpo[ri];
+            if (b::u32 >= fn.block_count) { cnt; }
+            if (update_block_liveness(fn, pr, b)) { changed = true; }
+        }
+    }
+}
+
+# recompute one block's live-out and live-in, reporting whether either grew
+# ---
+# fn: the function
+# pr: the state
+# b:  the block
+# ret: true when a set changed
+fun update_block_liveness(fn: *ir.Function, pr: *Pressure, b: id.BlockId) bool {
+    val base: u32 = b::u32 * pr.words;
+    var changed: bool = false;
+
+    var s0: id.BlockId = id.BLOCK_NIL;
+    var s1: id.BlockId = id.BLOCK_NIL;
+    val sn: u32 = ir.block_successors(fn, ?fn.blocks[b::u32], ?s0, ?s1);
+    if (sn >= 1) { if (merge_successor(fn, pr, base, b, s0)) { changed = true; } }
+    if (sn >= 2) { if (merge_successor(fn, pr, base, b, s1)) { changed = true; } }
+
+    var w: u32 = 0;
+    for (w < pr.words) {
+        val v: u64 = pr.use_set[base + w] | (pr.live_out[base + w] & ~pr.def_set[base + w]);
+        if (pr.live_in[base + w] != v) { pr.live_in[base + w] = v; changed = true; }
+        w = w + 1;
+    }
+    ret changed;
+}
+
+# union successor `s`'s live-in, plus the phi operands `s` reads on the edge from
+# `b`, into `b`'s live-out
+# ---
+# fn:   the function
+# pr:   the state
+# base: `b`'s offset into the per-block value sets
+# b:    the predecessor block
+# s:    the successor block
+# ret:  true when `b`'s live-out grew
+fun merge_successor(fn: *ir.Function, pr: *Pressure, base: u32, b: id.BlockId, s: id.BlockId) bool {
+    if (s::u32 >= fn.block_count) { ret false; }
+    val sbase: u32 = s::u32 * pr.words;
+    var changed: bool = false;
+
+    var w: u32 = 0;
+    for (w < pr.words) {
+        val v: u64 = pr.live_out[base + w] | pr.live_in[sbase + w];
+        if (pr.live_out[base + w] != v) { pr.live_out[base + w] = v; changed = true; }
+        w = w + 1;
+    }
+
+    val blk: *ir.Block = ?fn.blocks[s::u32];
+    var p: u32 = 0;
+    for (p < blk.phi_count) {
+        val pid: id.InstructionId = blk.phis[p];
+        p = p + 1;
+        if (pid::u32 >= fn.instr_len) { cnt; }
+        val ins: *instruction.Instruction = ?fn.instrs[pid::u32];
+        var o: u32 = 0;
+        for (o + 1 < ins.operand_count) {
+            if (ir.block_target(ins.operands[o]) == b) {
+                val sl: u32 = value_slot(pr, fn, ins.operands[o + 1]);
+                if (sl != NO_SLOT && bank_slot(pr, sl) != BANK_NONE) {
+                    if (bit_set(?pr.live_out[base], sl)) { changed = true; }
+                }
+            }
+            o = o + 2;
+        }
+    }
+    ret changed;
+}
+
+# the most values of each bank live at once anywhere in loop `lx`, counting every
+# value in `hoisted` (plus `extra`, when it is a real slot) as live throughout
+#
+# This is the pressure the allocator would see after the pass finishes: a value in
+# the preheader is live across the whole loop, so measuring a candidate means forcing
+# it live at every point and re-reading the peak. Doing it this way rather than
+# adding one per hoist is what keeps the estimate honest -- a hoisted value was
+# ALREADY live over part of the loop, so its true cost at the busiest point is zero
+# as often as it is one.
+#
+# Each block is walked backwards from its live-out set, which is exactly what the
+# allocator sees: the count just before an instruction is its live-out less its own
+# result plus its operands.
+# ---
+# fn:     the function
+# pr:     the state
+# la:     the loop analysis
+# lx:     index into la.loops
+# extra:  one more value slot to force live, or NO_SLOT
+# out_gp: receives the peak general-bank pressure
+# out_fp: receives the peak float-bank pressure
+fun loop_peak(fn: *ir.Function, pr: *Pressure, la: *loops.LoopAnalysis, lx: u32, extra: u32,
+              out_gp: *u32, out_fp: *u32) {
+    val lp: *loops.Loop = ?la.loops[lx];
+    var pk_gp: u32 = 0;
+    var pk_fp: u32 = 0;
+
+    var bi: u32 = 0;
+    for (bi < lp.body_len) {
+        val b: u32 = lp.body[bi]::u32;
+        bi = bi + 1;
+        if (b >= fn.block_count) { cnt; }
+
+        val blk: *ir.Block = ?fn.blocks[b];
+        val base: u32 = b * pr.words;
+
+        var w: u32 = 0;
+        for (w < pr.words) { pr.scratch[w] = pr.live_out[base + w] | pr.hoisted[w]; w = w + 1; }
+        if (extra != NO_SLOT && extra < pr.nvals) { bit_set(pr.scratch, extra); }
+
+        var gp: u32 = 0;
+        var fp: u32 = 0;
+        count_banks(pr, ?gp, ?fp);
+        if (gp > pk_gp) { pk_gp = gp; }
+        if (fp > pk_fp) { pk_fp = fp; }
+
+        if (blk.terminator != id.INSTR_NIL && blk.terminator::u32 < fn.instr_len) {
+            step_back(fn, pr, blk.terminator, extra, ?gp, ?fp);
+            if (gp > pk_gp) { pk_gp = gp; }
+            if (fp > pk_fp) { pk_fp = fp; }
+        }
+
+        var k: u32 = blk.instr_count;
+        for (k > 0) {
+            k = k - 1;
+            val iid: id.InstructionId = blk.instructions[k];
+            if (iid::u32 >= fn.instr_len) { cnt; }
+            step_back(fn, pr, iid, extra, ?gp, ?fp);
+            if (gp > pk_gp) { pk_gp = gp; }
+            if (fp > pk_fp) { pk_fp = fp; }
+        }
+    }
+
+    @out_gp = pk_gp;
+    @out_fp = pk_fp;
+}
+
+# count the values of each bank in the scratch value set
+# ---
+# pr:     the state
+# out_gp: receives the general-bank count
+# out_fp: receives the float-bank count
+fun count_banks(pr: *Pressure, out_gp: *u32, out_fp: *u32) {
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+    var w: u32 = 0;
+    for (w < pr.words) {
+        if (pr.scratch[w] == 0) { w = w + 1; cnt; }
+        var bit: u32 = 0;
+        for (bit < 64) {
+            val s: u32 = w * 64 + bit;
+            bit = bit + 1;
+            if (s >= pr.nvals) { brk; }
+            if (!bit_get(pr.scratch, s)) { cnt; }
+            if (pr.bank[s]::RegBank == BANK_GP) { gp = gp + 1; }
+            or { if (pr.bank[s]::RegBank == BANK_FP) { fp = fp + 1; } }
+        }
+        w = w + 1;
+    }
+    @out_gp = gp;
+    @out_fp = fp;
+}
+
+# move the scratch value set one instruction earlier, keeping the bank counts in
+# step: the instruction's own result dies and its operands become live
+# ---
+# fn:     the function
+# pr:     the state
+# iid:    the instruction stepped over
+# extra:  the candidate slot forced live, or NO_SLOT
+# out_gp: the running general-bank count, updated in place
+# out_fp: the running float-bank count, updated in place
+fun step_back(fn: *ir.Function, pr: *Pressure, iid: id.InstructionId, extra: u32, out_gp: *u32, out_fp: *u32) {
+    val slot: u32 = iid::u32;
+    val db: RegBank = bank_slot(pr, slot);
+    # a forced-live value never dies inside the loop: its definition is in the
+    # preheader, above every point this walk measures.
+    if (db != BANK_NONE && slot != extra && !bit_get(pr.hoisted, slot)) {
+        if (bit_clr(pr.scratch, slot)) {
+            if (db == BANK_GP && @out_gp > 0) { @out_gp = @out_gp - 1; }
+            or { if (db == BANK_FP && @out_fp > 0) { @out_fp = @out_fp - 1; } }
+        }
+    }
+
+    val ins: *instruction.Instruction = ?fn.instrs[slot];
+    if (ins.kind == instruction.OP_PHI) { ret; }
+    var o: u32 = 0;
+    for (o < ins.operand_count) {
+        if (operand_holds_value(ins, o)) {
+            val s: u32 = value_slot(pr, fn, ins.operands[o]);
+            val ub: RegBank = bank_slot(pr, s);
+            if (s != NO_SLOT && ub != BANK_NONE) {
+                if (bit_set(pr.scratch, s)) {
+                    if (ub == BANK_GP) { @out_gp = @out_gp + 1; }
+                    or { if (ub == BANK_FP) { @out_fp = @out_fp + 1; } }
+                }
+            }
+        }
+        o = o + 1;
+    }
+}
+
+# mark every value that feeds an address computation in loop `lx`
+#
+# A gep is hoisted as a WHOLE ADDRESS, not as one instruction: the index arithmetic
+# feeding it is part of the same rebuild, and leaving a single `add` behind in the
+# body keeps the gep variant and forfeits the whole chain. So the operands of every
+# gep in the loop are marked, and the mark propagates back through their defining
+# instructions.
+#
+# One reverse sweep suffices. Loop blocks are visited in reverse postorder reversed
+# and their instructions backwards, so every use is seen before its definition -- an
+# invariant chain is acyclic and each of its definitions dominates its uses.
+# ---
+# fn: the function
+# la: the loop analysis
+# lx: index into la.loops
+# pr: the state whose `addr_feed` set is filled
+fun fill_addr_feeders(fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32, pr: *Pressure) {
+    var w: u32 = 0;
+    for (w < pr.words) { pr.addr_feed[w] = 0; w = w + 1; }
+
+    var ri: u32 = la.rpo_len;
+    for (ri > 0) {
+        ri = ri - 1;
+        val b: id.BlockId = la.rpo[ri];
+        if (!loops.loop_contains(la, lx, b)) { cnt; }
+        if (b::u32 >= fn.block_count) { cnt; }
+
+        val blk: *ir.Block = ?fn.blocks[b::u32];
+        var k: u32 = blk.instr_count;
+        for (k > 0) {
+            k = k - 1;
+            val iid: id.InstructionId = blk.instructions[k];
+            if (iid::u32 >= fn.instr_len) { cnt; }
+            val ins: *instruction.Instruction = ?fn.instrs[iid::u32];
+            if (ins.kind != instruction.OP_GEP && !bit_get(pr.addr_feed, iid::u32)) { cnt; }
+
+            var o: u32 = 0;
+            for (o < ins.operand_count) {
+                if (ins.operands[o].kind == value.VAL_INSTR) {
+                    val s: u32 = ins.operands[o].data.instr::u32;
+                    if (s < pr.nvals) { bit_set(pr.addr_feed, s); }
+                }
+                o = o + 1;
+            }
+        }
+    }
 }
 
 use std.allocator.page;


### PR DESCRIPTION
**Do not merge.** This is the assessment #2255 asked for, and the answer is that neither
of its two candidate closers should be built — because **the regression #2255 documents no
longer exists.** It was removed by #2246 (PR #2265), not by anything here. The pressure
model on this branch is complete, tested and mutation-pinned, and on current `dev` it is a
**measured regression**. It is pushed as the record behind that claim.

Recommendation: close #2255 as resolved by #2246, and close this PR.

## The finding

Every figure is `instructions:u` (this host has `perf_event_paranoid=2`, so perf narrowed
the counter to user space and kernel work was never counted). Wall and cycles are omitted:
the fleet was loaded and a same-binary cycle comparison swung **1.044x**, so they carry no
signal. The instruction-count floor, measured today by running the same binary against
itself six times under load average 20.6, is a spread of **0.00003%**.

Both sides of every pair are emitted by pipelines differing only in the change under test.

### LICM's cost on the compiler's own build, bisected across `dev`

| tree | no LICM | LICM | delta |
|---|---|---|---|
| `c382092c` (this branch's base, and what #2255 measured) | 260.863 G | 264.248 G | **+1.298%** |
| `362fcc39` (#2245 merged) | 264.045 G | 267.446 G | +1.288% |
| **`f308adbd`** (#2246: *sweep dead values by reachability from roots, not by use count*) | 224.773 G | 223.082 G | **−0.753%** |
| `origin/dev` today | 206.610 G | 205.129 G | **−0.716%** |

`f308adbd` is a single commit and it does two things at once: it cuts the compiler's own
retired instructions by **14.9%** (264.0 G → 224.8 G), and it inverts LICM's sign.

The mechanism is the one #2255 named, arriving from the other side. DCE swept by *use
count*, which cannot remove a dead cycle — a value used only by other dead values. Those
survived into the back end and occupied registers in exactly the loops LICM hoists into, so
each hoist tipped a loop into spilling. Sweeping by reachability from roots removes them,
loop pressure falls, and the same hoists now fit. **#2255's diagnosis was right; the
pressure was not LICM's to fix.** Removing it at the source is the better fix, and it
already landed.

### What this branch does to current `dev`

| | array workload | compiler self-build |
|---|---|---|
| no LICM | 19.163 G | 204.413 G |
| `dev` today | 11.737 G | 202.946 G (**−0.72%**) |
| this branch | 11.737 G (+0.0007%) | 204.422 G (**+0.73%**) |

It preserves the array win to seven digits and gives back the entire compiler win. On
current `dev` there is no version of "decline a hoist under pressure" that helps, because
the hoists it declines are now profitable.

## The other two hypotheses, assessed

**Middle-end loop rotation — assessed and rejected before building.** Rotation guards the
preheader with the loop's own entry test, so hoisted work is skipped when the loop trips
zero times. It does not change register pressure at all: a hoisted value is live across the
loop body either way, and the peak inside the loop is identical. Since #2255's residual is
90% frame-slot traffic, rotation cannot touch it. It would also make the problem worse — a
guarded preheader is reached only when the loop runs, which *relaxes* the speculation rules
and admits more hoists. The branch-count win it would otherwise buy is already banked by
#2211 (PR #2220) in the back end.

**A pressure-aware cost model — built, measured, and it does not pay.** Three revisions:

| revision | array win kept | compiler, on `c382092c` |
|---|---|---|
| budget alone | 37% | (static −54%) |
| budget + address exemption | 75% | (static −54%) |
| budget + address chains, width casts cut | **95.5%** | **−0.03%** (from +1.30%) |

On its own base it met the bar. It does not survive the base moving.

## What the model does, for the record

- **Demand** — a backward liveness solve over the function, re-read per candidate with that
  value *and every value already lifted* forced live throughout. Measuring it that way
  rather than adding one per hoist is what keeps it honest: a hoisted value was already
  live over part of the loop, so its cost at the busiest point is zero as often as one.
- **Supply** — the register file the target describes: a bank's declared size less what
  `MachineModel` withholds from value allocation. x86_64: 16 − {RSP, RBP} − {R8, R9, R10} = 11.
  No tuned constants. Where either is unavailable — a whole-module emitter with no register
  machine, or a bank the model does not declare — there is no budget and safety alone decides.
- Over budget, only what costs more than the reload replacing it is still lifted: an address
  computation and the arithmetic feeding it, with the chain **cut where it crosses a width
  cast** (a width cast re-presents an index the loop already holds and cannot be coalesced
  with its source, so lifting it makes the loop carry the datum twice).

## A correction to #2255's framing, which stands regardless

**The static spill attribution does not locate the dynamic cost.** On the base #2255 was
filed against, declining exactly the width-cast hoists removed **100%** of the retired-
instruction penalty while giving back only **14.5%** of the +2,263 frame-slot references
(603,806 → 606,069 → 605,740). `objdump` counts are immune to everything about machine load,
so this half is not in question. A handful of hot spills carried the cost and the static
count could not see which.

The supporting bisection of LICM's hoist population by opcode class, on that base, each
variant built and interleaved:

| variant declined | compiler self-build | array win kept |
|---|---|---|
| nothing (shipped) | +1.30% | 100% |
| loads | +1.29% | 55% |
| bitcasts | +1.34% | — |
| compares | +1.30% | — |
| ALU ops | +1.32% | — |
| **width casts** (`zext`/`sext`/`trunc`, 17.8% of sites) | **−0.05%** | **100%** |

## Verification

- **Suites** — mach **920 / 0** (dev baseline **914 / 0**, plus the 6 added); test-name
  inventory against dev: **0 dropped**. mach-std **611 / 0** at pin `eff1e8e`, verified
  against `mach.lock`. Both re-run through the branch's own self-hosted compiler.
- **int** — green on `linux` and `linux-riscv64`.
- **Debug byte-identical** — 208 objects and the binary, `dev` vs this branch.
- **Three-generation fixpoint** — `B == C` byte-identical.
- **Mutation testing** — seven rules disabled in turn, all seven detected:

| mutation | result |
|---|---|
| budget never binds | 5 of 15 fail |
| register file ignored, raw bank size | 2 fail |
| address exemption removed | 1 fail |
| width-cast rule removed | 1 fail |
| address chain not followed | 1 fail |
| lifted values not held live | 1 fail |
| liveness never solved | 1 fail |

- **Pass compile-time cost** — +0.79% (264.247 G → 266.328 G to compile the tree), after a
  lazy build and popcount bank counting cut it from +2.34%.

## What the next person needs

Nothing here, if #2255 closes. If a future promotion-style pass reopens the pressure
question, this branch has the whole apparatus: the model, six IR-level tests, seven
mutations, and the measurement harness — `licmdelta.sh` reports LICM's on/off delta at any
commit in two builds and is what produced the bisection table above.
