### PR TITLE
test(target): build every censused record through its constructor, and census all of src

### DIFF
--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -579,12 +579,19 @@ fun t_target(trust_mul: bool, trust_var_shift: bool) target.Target {
 
 # an instruction-set vtable naming a back half: a register machine when `emitter` is
 # nil, a whole-module emitter when it is not (test helper)
+#
+# Each arm goes through its family's constructor rather than assigning the three
+# fields it cares about, so the seven it does not care about are cleared instead of
+# holding the frame's residue - and a field added to `IsaVTable` later is cleared
+# here too, with no visit to this site (#2294). The register-machine arm passes a
+# nil payload deliberately: `ctvalidate` reads only the family and the name.
+# ---
+# name:    the architecture name the diagnostics quote
+# emitter: the whole-module payload, or nil for a register machine
+# ret:     the vtable
 fun t_isa(name: str, emitter: *isa.ModuleEmitter) isa.IsaVTable {
-    var vt: isa.IsaVTable;
-    vt.name    = name;
-    vt.machine = nil;
-    vt.emitter = emitter;
-    ret vt;
+    if (emitter != nil) { ret isa.emitter_isa(isa.ARCH_UNKNOWN, name, 8, nil, 0, nil, emitter); }
+    ret isa.machine_isa(isa.ARCH_UNKNOWN, name, 0, 8, nil, 0, nil, nil, nil);
 }
 
 # a secret laundered through a phi join (out-of-SSA predecessor moves into one result vreg)

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -821,8 +821,7 @@ test "mach.lang.me.ir.type.byte_size:struct_i8_i64" {
     val stty: IrTypeId = R.unwrap_ok[IrTypeId, str](res_struct);
 
     # a minimal target: only pointer_width matters, and only for IRT_PTR (unused here).
-    var arch: isa.IsaVTable;
-    arch.pointer_width = 8;
+    var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, 0, nil, nil, nil);
     var tgt: target.Target;
     tgt.isa = ?arch;
 
@@ -858,8 +857,7 @@ test "mach.lang.me.ir.type.intern_struct:align_override" {
     if (R.is_err[IrTypeId, str](res_align)) { dnit(?types); ret 1; }
     val algty: IrTypeId = R.unwrap_ok[IrTypeId, str](res_align);
 
-    var arch: isa.IsaVTable;
-    arch.pointer_width = 8;
+    var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, 0, nil, nil, nil);
     var tgt: target.Target;
     tgt.isa = ?arch;
 
@@ -900,8 +898,7 @@ test "mach.lang.me.ir.type.intern_vector:dedup_size_align" {
     if (R.is_err[IrTypeId, str](r3)) { dnit(?types); ret 1; }
     if (R.unwrap_ok[IrTypeId, str](r3) == vecty) { dnit(?types); ret 1; }
 
-    var arch: isa.IsaVTable;
-    arch.pointer_width = 8;
+    var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, 0, nil, nil, nil);
     var tgt: target.Target;
     tgt.isa = ?arch;
 

--- a/src/lang/target/isa/tests.mach
+++ b/src/lang/target/isa/tests.mach
@@ -1,12 +1,21 @@
-# the construction-site census for the machine-instruction model
+# the construction-site census for the target-layer records that own a constructor
 #
-# `Inst` and `Operand` are cleared in exactly one place each, and this module proves
-# it by reading the source rather than by trusting review. `var` does not zero, so a
-# site that builds one of these records field by field leaves whatever field it does
-# not name holding the frame's residue - and a field added later is named by no site
-# at all, on whichever target happens to have written that stack. That is not
-# hypothetical: `Operand.sym_mod` was added and three hand-written clears did not
-# learn about it.
+# Six records are cleared in exactly one place each - the machine-instruction model
+# (`Inst`, `Operand`) and the four ISA contracts (`IsaVTable`, `RegMachine`,
+# `ModuleEmitter`, `RelocSeam`) - and this module proves it by reading the source
+# rather than by trusting review. `var` does not zero, so a site that builds one of
+# these records field by field leaves whatever field it does not name holding the
+# frame's residue - and a field added later is named by no site at all, on whichever
+# target happens to have written that stack.
+#
+# That is not hypothetical, twice over. `Operand.sym_mod` was added and three
+# hand-written clears did not learn about it. Then `IsaVTable` gained a
+# relocatable-object seam (#2244) and sixteen hand-built vtables in the ELF writer's
+# tests silently acquired it uninitialized - `attributes_for` runs on every exec
+# emit, so those tests were handing it a function pointer off the stack and
+# comparing it to nil. Whether the comparison said "nil" was a property of the
+# stack, not of the program. The ISA contracts were outside this census when that
+# happened; they are inside it now (#2294).
 #
 # WHY THE INVARIANT IS TEXTUAL. Runtime cannot see this. A test can assert that a
 # constructor returns cleared fields, but that is a property of the constructor, not
@@ -22,9 +31,22 @@
 # this same census. Forbidding the bare form outside the constructors therefore
 # forbids hand-building outright, and it does so for fields that do not exist yet.
 #
-# The permitted list below IS the census of clearing sites. It is short on purpose:
-# adding to it is how a fifth place to forget a field gets introduced, so it should
-# be an argued change and not a convenience.
+# WHY THE PERMITTED LIST CARRIES A COUNT. Two kinds of site legitimately declare one
+# of these records bare, and they are not the same kind of thing:
+#
+#   - the CONSTRUCTORS themselves, one per record, each the single place its record
+#     is cleared;
+#   - the PROCESS-GLOBAL STORAGE an arch's registration module declares for the
+#     vtable it installs. A module-level `var` cannot carry a call as its
+#     initializer, so the storage must be declared bare and whole-assigned from a
+#     constructor at startup (`x64_vtable = isa.machine_isa(...)`). That is a
+#     declaration of storage, not a construction site - but nothing in the text
+#     distinguishes the two, so each such file is permitted with the EXACT number of
+#     globals it declares. A fourth global in a file permitted for three fails the
+#     census and has to be argued for.
+#
+# The list below IS the census of clearing sites. It is short on purpose: adding to
+# it, or raising a count, is how the next place to forget a field gets introduced.
 #
 # An orphan test-only module: nothing imports it, and `mach test` collects it by
 # rooting at the whole source tree (as with the driver and vector-runtime suites).
@@ -48,7 +70,7 @@ use R: std.types.result;
 use fs: std.filesystem;
 use std.collections.vector.Vector;
 
-# a source location that declares an `Inst` or `Operand` with no initializer
+# a source location that declares a censused record with no initializer
 # ---
 # path: repository-relative path of the file
 # line: 1-based line number
@@ -59,43 +81,70 @@ pub rec Site {
     fun:  str;
 }
 
-# the four functions permitted to declare an uninitialized `Inst` or `Operand`
+# the number of permitted (file, function) groups
 #
-# One per record that exists: `isa.Operand` and `isa.Inst` in the shared model,
-# aarch64's private machine instruction, and the inline-asm parser's operand. Each
-# is the single place its record is cleared; a fifth entry means a fifth place to
-# forget a field.
-val ALLOWED_LEN: usize = 4;
+# Eight constructors - `Inst` and `Operand` have two apiece, the shared model's and
+# a target's own - plus the five arch registration modules whose process-global
+# vtable storage must be declared bare. Two kinds of entry, kept in one table so
+# neither is invisible.
+val ALLOWED_LEN: usize = 13;
 
-# the enclosing function name of each permitted site, positionally paired with
-# `allowed_file`
+# the enclosing function name of each permitted group, positionally paired with
+# `allowed_file` and `allowed_count`. `<top>` is module scope
 fun allowed_fun(i: usize) str {
-    if (i == 0) { ret "operand_blank"; }
-    if (i == 1) { ret "inst_blank"; }
-    if (i == 2) { ret "inst"; }
-    ret "op_none";
+    if (i == 0)  { ret "operand_blank"; }
+    if (i == 1)  { ret "inst_blank"; }
+    if (i == 2)  { ret "isa_common"; }
+    if (i == 3)  { ret "reg_machine"; }
+    if (i == 4)  { ret "module_emitter"; }
+    if (i == 5)  { ret "reloc_seam"; }
+    if (i == 6)  { ret "inst"; }
+    if (i == 7)  { ret "op_none"; }
+    ret "<top>";
 }
 
-# the file of each permitted site, positionally paired with `allowed_fun`
+# the file of each permitted group, positionally paired with `allowed_fun` and
+# `allowed_count`
 fun allowed_file(i: usize) str {
-    if (i == 0) { ret "src/lang/target/isa.mach"; }
-    if (i == 1) { ret "src/lang/target/isa.mach"; }
-    if (i == 2) { ret "src/lang/target/isa/arm64/printer.mach"; }
-    ret "src/lang/target/isa/asm.mach";
+    if (i == 0)  { ret "src/lang/target/isa.mach"; }
+    if (i == 1)  { ret "src/lang/target/isa.mach"; }
+    if (i == 2)  { ret "src/lang/target/isa.mach"; }
+    if (i == 3)  { ret "src/lang/target/isa.mach"; }
+    if (i == 4)  { ret "src/lang/target/isa.mach"; }
+    if (i == 5)  { ret "src/lang/target/isa.mach"; }
+    if (i == 6)  { ret "src/lang/target/isa/arm64/printer.mach"; }
+    if (i == 7)  { ret "src/lang/target/isa/asm.mach"; }
+    if (i == 8)  { ret "src/lang/target/isa/x64/register.mach"; }
+    if (i == 9)  { ret "src/lang/target/isa/arm64/register.mach"; }
+    if (i == 10) { ret "src/lang/target/isa/riscv64/register.mach"; }
+    if (i == 11) { ret "src/lang/target/isa/mos6502/register.mach"; }
+    ret "src/lang/target/isa/spirv/register.mach";
 }
 
-# whether a site is one of the permitted constructors
+# the exact number of bare declarations each permitted group may hold
+#
+# One for each constructor. Three for an arch that installs a vtable, a register
+# machine and a relocation seam (x86-64, aarch64, riscv64); two for mos6502 (no
+# seam - a raw flat image carries no relocations) and for spirv (a whole-module
+# emitter payload instead of a register machine, and no seam by construction)
+fun allowed_count(i: usize) usize {
+    if (i <= 7)  { ret 1; }
+    if (i <= 10) { ret 3; }
+    ret 2;
+}
+
+# the permitted group a site belongs to
 # ---
 # path: repository-relative file path
-# name: enclosing function name
-# ret:  true if the pair appears in the permitted list
-fun is_allowed(path: str, name: str) bool {
+# name: enclosing function name, or "<top>" for module scope
+# ret:  the group index, or ALLOWED_LEN when the pair is not permitted
+fun group_of(path: str, name: str) usize {
     var i: usize = 0;
     for (i < ALLOWED_LEN) {
-        if (str_equals(path, allowed_file(i)) && str_equals(name, allowed_fun(i))) { ret true; }
+        if (str_equals(path, allowed_file(i)) && str_equals(name, allowed_fun(i))) { ret i; }
         i = i + 1;
     }
-    ret false;
+    ret ALLOWED_LEN;
 }
 
 # whether a byte can appear in a mach identifier
@@ -149,20 +198,30 @@ fun decl_type(text: str, start: usize, tstart: *usize, tlen: *usize) O.Option[us
     ret O.some[usize](p);
 }
 
-# whether a type name is one of the instruction-model records
+# whether a type name is one of the censused records
 #
 # Matched unqualified as well as module-qualified, because a target names its own
-# record bare inside its own module and `isa.`-qualified outside it.
+# record bare inside its own module and `isa.`-qualified outside it. The list is the
+# set of target-layer records that OWN A CONSTRUCTOR: owning one is what turns
+# hand-building from the only option into a bug.
 # ---
 # text: the buffer being scanned
 # at:   offset of the type name
 # len:  length of the type name
-# ret:  true for Inst / Operand in any spelling this tree uses
+# ret:  true for a censused record in any spelling this tree uses
 fun is_model_type(text: str, at: usize, len: usize) bool {
-    if (str_region_equals(text, at, len, "Inst"))         { ret true; }
-    if (str_region_equals(text, at, len, "Operand"))      { ret true; }
-    if (str_region_equals(text, at, len, "isa.Inst"))     { ret true; }
-    if (str_region_equals(text, at, len, "isa.Operand"))  { ret true; }
+    if (str_region_equals(text, at, len, "Inst"))              { ret true; }
+    if (str_region_equals(text, at, len, "Operand"))           { ret true; }
+    if (str_region_equals(text, at, len, "IsaVTable"))         { ret true; }
+    if (str_region_equals(text, at, len, "RegMachine"))        { ret true; }
+    if (str_region_equals(text, at, len, "ModuleEmitter"))     { ret true; }
+    if (str_region_equals(text, at, len, "RelocSeam"))         { ret true; }
+    if (str_region_equals(text, at, len, "isa.Inst"))          { ret true; }
+    if (str_region_equals(text, at, len, "isa.Operand"))       { ret true; }
+    if (str_region_equals(text, at, len, "isa.IsaVTable"))     { ret true; }
+    if (str_region_equals(text, at, len, "isa.RegMachine"))    { ret true; }
+    if (str_region_equals(text, at, len, "isa.ModuleEmitter")) { ret true; }
+    if (str_region_equals(text, at, len, "isa.RelocSeam"))     { ret true; }
     ret false;
 }
 
@@ -371,16 +430,23 @@ fun relative(path: str, root: str) str {
     ret path;
 }
 
-# EVERY `Inst` AND `Operand` IN THE BACK END IS BUILT BY A CONSTRUCTOR.
+# EVERY CENSUSED RECORD IN THE COMPILER IS BUILT BY A CONSTRUCTOR.
 #
-# The census walks `src/lang/target` and `src/lang/be` and reports every declaration
-# of one of these records that carries no initializer. Exactly four are permitted -
-# the constructors themselves, one per record - and any other is a site that clears
-# its fields by hand, which is a site that will not clear the next field added.
+# The census walks the WHOLE of `src` - not a chosen pair of subtrees - and reports
+# every declaration of one of these records that carries no initializer. Which tree
+# a hand-built record lives in has nothing to do with whether it is a bug, and a
+# census that scans some directories is an exemption for the rest that nobody can
+# see. That is the shape #2294 was: the ELF writer's tests were never scanned for
+# `IsaVTable` because `IsaVTable` was not censused at all.
+#
+# Every site must fall in a permitted group AND each group must hold exactly the
+# number of sites it declares, so a hand-built record added inside a permitted
+# function fails too - the permit is for the sites that exist, not for the file.
 #
 # To see it fail, delete the initializer at any construction site (say
-# `var ld: isa.Inst = isa.inst_blank();` in `isa/x64/encode.mach`) and re-run: the
-# count rises by one and the site is named.
+# `var ld: isa.Inst = isa.inst_blank();` in `isa/x64/encode.mach`, or
+# `var isa_vt: isa.IsaVTable = t_isa(...);` in `of/elf.mach`) and re-run: the count
+# rises by one and the site is named.
 test "mach.lang.target.isa.blank:every_construction_site_is_constructed" {
     var alloc: A.Allocator;
     page.make(?alloc);
@@ -391,30 +457,45 @@ test "mach.lang.target.isa.blank:every_construction_site_is_constructed" {
 
     var sites: Vector[Site] = vector.init[Site](?alloc);
 
-    val rj1: R.Result[str, str] = join_path(?alloc, root, "src/lang/target");
-    if (R.is_err[str, str](rj1)) { ret 1; }
-    if (O.is_some[str](scan_tree(?alloc, R.unwrap_ok[str, str](rj1), ?sites))) { ret 1; }
-
-    val rj2: R.Result[str, str] = join_path(?alloc, root, "src/lang/be");
-    if (R.is_err[str, str](rj2)) { ret 1; }
-    if (O.is_some[str](scan_tree(?alloc, R.unwrap_ok[str, str](rj2), ?sites))) { ret 1; }
+    val rj: R.Result[str, str] = join_path(?alloc, root, "src");
+    if (R.is_err[str, str](rj)) { ret 1; }
+    if (O.is_some[str](scan_tree(?alloc, R.unwrap_ok[str, str](rj), ?sites))) { ret 1; }
 
     # the walk must have found the tree: a census over zero files reports zero
     # violations and would pass without checking anything
     val total: usize = sites.len;
     if (total == 0) { ret 1; }
 
+    # every site must land in a permitted group
     var unpermitted: usize = 0;
     var i: usize = 0;
     for (i < total) {
         val rg: R.Result[*Site, str] = vector.get[Site](?sites, i);
         if (R.is_err[*Site, str](rg)) { ret 1; }
         val s: *Site = R.unwrap_ok[*Site, str](rg);
-        if (!is_allowed(relative(s.path, root), s.fun)) { unpermitted = unpermitted + 1; }
+        if (group_of(relative(s.path, root), s.fun) == ALLOWED_LEN) { unpermitted = unpermitted + 1; }
         i = i + 1;
     }
+    if (unpermitted != 0) { ret unpermitted::i32; }
 
-    if (unpermitted != 0)     { ret unpermitted::i32; }
-    if (total != ALLOWED_LEN) { ret 1; }
+    # and each group must hold exactly as many as it declares
+    var expected: usize = 0;
+    var g: usize = 0;
+    for (g < ALLOWED_LEN) {
+        var found: usize = 0;
+        var j: usize = 0;
+        for (j < total) {
+            val rg2: R.Result[*Site, str] = vector.get[Site](?sites, j);
+            if (R.is_err[*Site, str](rg2)) { ret 1; }
+            val s2: *Site = R.unwrap_ok[*Site, str](rg2);
+            if (group_of(relative(s2.path, root), s2.fun) == g) { found = found + 1; }
+            j = j + 1;
+        }
+        if (found != allowed_count(g)) { ret 1; }
+        expected = expected + allowed_count(g);
+        g = g + 1;
+    }
+
+    if (total != expected) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3483,6 +3483,21 @@ pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
+# an ISA vtable that describes an architecture and binds no back half (test helper)
+#
+# The COFF writer reads only `id` off the vtable, but it is built through
+# `isa.machine_isa` rather than field by field. A record hand-built from a bare
+# declaration leaves whatever field it does not name holding the frame's residue,
+# and a field added to `IsaVTable` later is named by no site at all - which is
+# exactly how these tests came to read an uninitialized function pointer (#2294).
+# The census in `target/isa/tests.mach` is what keeps this true.
+# ---
+# id:  the architecture id the vtable reports
+# ret: a description-only vtable, every other field cleared
+fun t_isa(id: u32) isa.IsaVTable {
+    ret isa.machine_isa(id, "test", 0, 8, nil, 0, nil, nil, nil);
+}
+
 # intern a name into the test interner, returning STR_NIL on failure (the test
 # checks the resulting image, which fails loudly if a name went missing)
 fun t_intern(i: *intern.Interner, s: str) intern.StrId {
@@ -3507,8 +3522,7 @@ test "mach.lang.target.of.coff:emit_parse_round_trip" {
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     # a minimal isa vtable: the writer reads only its `id`.
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # build a small image: .text (16 bytes, one fn `main` - sized so the abs64
     # patch field at offset 4 fits within the section), .data (4 bytes, one global
@@ -3656,8 +3670,7 @@ test "mach.lang.target.of.coff:relro_round_trip" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var text_bytes: [8]u8;
     var ro_bytes:   [8]u8;
@@ -3758,8 +3771,7 @@ test "mach.lang.target.of.coff.read_inplace_addend:rel32_p4_convention" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var text_bytes: [8]u8;
     var k: usize = 0;
@@ -3837,8 +3849,7 @@ test "mach.lang.target.of.coff.coff_emit_object:unresolved_reloc_symbol" {
     val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # a valid .text section and one defined symbol, so range validation passes
     # and only the unresolved relocation symbol can fail the emit.
@@ -3896,8 +3907,7 @@ test "mach.lang.target.of.coff:defined_weak_comdat_round_trip" {
     val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # a .text holding two functions: a strong global `main` in [0,8) and a weak
     # monomorphized instance `okI3u64P2u8E` in [8,16), the kind emitted into every
@@ -4035,8 +4045,7 @@ test "mach.lang.target.of.coff:weak_split_no_duplication" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # `.text` [0,32) = strong af[0,8), weak bw[8,16), strong cf[16,24), weak dw[24,32);
     # `.rodata` [0,4) with a strong data symbol and no weak members.
@@ -4150,8 +4159,7 @@ test "mach.lang.target.of.coff:zero_extent_weak_terminates" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # sec0 `.text` [0,8): strong `af` [0,8), a zero-extent weak `zend` at offset 8
     # (== section length), and a LOCAL end-marker `eend` also at offset 8. sec1: a
@@ -4241,8 +4249,7 @@ test "mach.lang.target.of.coff:weak_carrier_alignment_preserved" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # `.rodata` [0,32), align 16: strong `c0` [0,16) then weak `wk16` [16,32) - a
     # non-leading 16-byte-aligned weak constant. its carrier must declare align 16.
@@ -4313,8 +4320,7 @@ test "mach.lang.target.of.coff:long_names_string_table" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # a section and a symbol whose names exceed the eight inline bytes, forcing
     # the "/offset" section-name form and the symbol string-table-offset form.
@@ -4385,8 +4391,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:pe32plus_header" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # the first content segment maps one page above the 64 KiB-aligned ImageBase
     # (RVA 0x1000, right after the headers), plus a writable data segment one page
@@ -4472,8 +4477,7 @@ test "mach.lang.target.of.coff:call_target_import_function_flag" {
     val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # a defined `main` whose body calls an undefined function import, exactly as
     # codegen emits one: the import carries FUNCTION|EXTERN|GLOBAL up front.
@@ -4550,8 +4554,7 @@ test "mach.lang.target.of.coff.infer_extern_function_flags_from_calls:foreign_ca
     val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # a tiny text body with one call-site relocation targeting an undefined extern.
     var text_bytes: [8]u8;
@@ -4626,8 +4629,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:unwind_xdata_pdata" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # push rbp; mov rbp,rsp; sub rsp,0x20; mov [rbp-8],rbx; nop; ret
     var text_bytes: [14]u8;
@@ -4914,8 +4916,7 @@ test "mach.lang.target.of.coff.coff_emit_object:unsupported_reloc_kind" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -5000,8 +5001,7 @@ test "mach.lang.target.of.coff.coff_parse_object:rejects_unmapped_type" {
     val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -5068,8 +5068,7 @@ test "mach.lang.target.of.coff.coff_emit_object:reloc_count_overflow" {
     val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -5130,8 +5129,7 @@ test "mach.lang.target.of.coff.coff_parse_object:rejects_truncated" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -5268,8 +5266,7 @@ fun ts_pe_debug_sections() u8 {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -5383,8 +5380,7 @@ fun ts_dyn_exec_relro_naming() u8 {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var text_bytes: [16]u8;
     var k: usize = 0;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -4223,6 +4223,30 @@ fun t_intern(itn: *intern.Interner, s: str) intern.StrId {
     ret R.unwrap_ok[intern.StrId, str](r);
 }
 
+# the ELF e_machine ids the writer tests stamp their vtables with. EM_RISCV is
+# declared above because the production reverse parse map keys on it; these two are
+# needed only to describe a test vtable honestly
+val EM_X86_64:  u16 = 62;
+val EM_AARCH64: u16 = 183;
+
+# an ISA vtable that describes an architecture and binds no back half (test helper)
+#
+# Built through `isa.machine_isa` rather than field by field. A record hand-built
+# from a bare declaration leaves whatever field it does not name holding the
+# frame's residue, and a field added to `IsaVTable` later is named by no site at
+# all - which is exactly what happened here: the seam fields arrived and sixteen
+# sites silently began handing `attributes_for` an uninitialized function pointer
+# to compare against nil (#2294). The census in `target/isa/tests.mach` is what
+# keeps this true.
+# ---
+# id:          the architecture id the vtable reports
+# elf_machine: the `e_machine` the object writer stamps
+# reloc:       the relocatable-object seam, or nil for a test that emits none
+# ret:         a description-only vtable, every other field cleared
+fun t_isa(id: u32, elf_machine: u32, reloc: *isa.RelocSeam) isa.IsaVTable {
+    ret isa.machine_isa(id, "test", elf_machine, 8, nil, 0, nil, nil, reloc);
+}
+
 # a relocatable-object contract for the writer tests
 #
 # Carries the ELF forward map under test and a deliberate nil applier: a writer test
@@ -4300,9 +4324,7 @@ test "mach.lang.target.of.elf.emit_object:unresolved_symbol" {
     if (R.is_err[bool, str](rr)) { ret 1; }
 
     var seam: isa.RelocSeam = t_seam(t_x64_elf_reloc_type::*u8);
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id    = isa.ARCH_X86_64;
-    isa_vt.reloc = ?seam;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, ?seam);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -4359,9 +4381,7 @@ test "mach.lang.target.of.elf.emit_object:unmapped_reloc_kind" {
     if (R.is_err[bool, str](rr)) { ret 1; }
 
     var seam: isa.RelocSeam = t_seam(t_x64_elf_reloc_type::*u8);
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id    = isa.ARCH_X86_64;
-    isa_vt.reloc = ?seam;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, ?seam);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -4508,9 +4528,7 @@ test "mach.lang.target.of.elf.parse_object:unknown_reloc_type" {
     if (R.is_err[bool, str](rr)) { ret 1; }
 
     var seam: isa.RelocSeam = t_seam(t_x64_elf_reloc_type::*u8);
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id    = isa.ARCH_X86_64;
-    isa_vt.reloc = ?seam;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, ?seam);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -4588,11 +4606,7 @@ test "mach.lang.target.of.elf.parse_object:riscv_machine_roundtrip" {
     if (R.is_err[bool, str](rr)) { ret 1; }
 
     var seam: isa.RelocSeam = t_seam(t_riscv_elf_reloc_type::*u8);
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_RISCV64;
-    isa_vt.elf_machine   = EM_RISCV::u32;
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = ?seam;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_RISCV64, EM_RISCV::u32, ?seam);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -4670,9 +4684,7 @@ test "mach.lang.target.of.elf.parse_object:truncated" {
     if (R.is_err[bool, str](rr)) { ret 1; }
 
     var seam: isa.RelocSeam = t_seam(t_x64_elf_reloc_type::*u8);
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id    = isa.ARCH_X86_64;
-    isa_vt.reloc = ?seam;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, ?seam);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -4784,11 +4796,7 @@ test "mach.lang.target.of.elf.emit_object:riscv_attributes_section" {
     var seam: isa.RelocSeam = t_seam(t_riscv_elf_reloc_type::*u8);
     isa.with_elf_attributes(?seam, t_riscv_attributes::*u8);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_RISCV64;
-    isa_vt.elf_machine   = EM_RISCV::u32;
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = ?seam;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_RISCV64, EM_RISCV::u32, ?seam);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -5159,11 +5167,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:static_pie_layout" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_X86_64;
-    isa_vt.elf_machine   = 62;       # EM_X86_64
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = nil;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, nil);
 
     # one executable load segment, laid out PIE-relative (base + one-page header gap).
     var text: [16]u8;
@@ -5275,11 +5279,7 @@ test "mach.lang.target.of.elf.emit_shared:exports_and_soname" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_X86_64;
-    isa_vt.elf_machine   = 62;       # EM_X86_64
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = nil;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, nil);
 
     # one executable load segment holding two exported functions.
     var text: [16]u8;
@@ -5423,11 +5423,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:relro_splits_rodata_from_rel_ro" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_X86_64;
-    isa_vt.elf_machine   = 62;       # EM_X86_64
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = nil;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, nil);
 
     # four segments modeling the real post-#1844 PIE layout: text (R+X, no reloc); pure
     # `.rodata` (R, no reloc); writable `.data` (R+W) carrying a reloc; and `.data.rel.ro`
@@ -5533,11 +5529,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:page_align_congruence_64k" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_AARCH64;
-    isa_vt.elf_machine   = 183;      # EM_AARCH64
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = nil;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_AARCH64, EM_AARCH64::u32, nil);
 
     # three 64 KiB-aligned segments (the linker aligns vaddrs to the target page before
     # the writer runs); text, pure `.rodata`, and a reloc-bearing `.data.rel.ro`.
@@ -5626,11 +5618,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:header_overflow_refused" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_X86_64;
-    isa_vt.elf_machine   = 62;       # EM_X86_64
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = nil;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, nil);
 
     # vaddrs are immaterial: the guard fires before segment layout, so the segments carry
     # no bytes and only their count drives the refusal.
@@ -5670,11 +5658,7 @@ test "mach.lang.target.of.elf.emit_dyn_exec:header_overflow_refused" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_X86_64;
-    isa_vt.elf_machine   = 62;       # EM_X86_64
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = nil;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, nil);
 
     # vaddrs are immaterial: the guard fires before segment layout, so the segments carry
     # no bytes and only their count drives the refusal.
@@ -5718,11 +5702,7 @@ test "mach.lang.target.of.elf.emit_exec:debug_sections_nonalloc" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_X86_64;
-    isa_vt.elf_machine   = 62;       # EM_X86_64
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = nil;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, nil);
 
     var text: [16]u8;
     var k: usize = 0;
@@ -5820,11 +5800,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:debug_sections_trailing_nonloaded" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_X86_64;
-    isa_vt.elf_machine   = 62;
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = nil;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, nil);
 
     var text: [16]u8;
     var k: usize = 0;
@@ -5919,11 +5895,7 @@ test "mach.lang.target.of.elf.emit_shared:debug_additive_nonloaded" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_X86_64;
-    isa_vt.elf_machine   = 62;
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = nil;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, nil);
 
     var text: [16]u8;
     var k: usize = 0;
@@ -6009,11 +5981,7 @@ test "mach.lang.target.of.elf.emit_shared:dynamic_sections_in_sht" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id            = isa.ARCH_X86_64;
-    isa_vt.elf_machine   = 62;
-    isa_vt.pointer_width = 8;
-    isa_vt.reloc         = nil;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, nil);
 
     var text: [16]u8;
     var k: usize = 0;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -3664,6 +3664,21 @@ fun recover_addend(out: *of.ObjectImage, sec_i: u32, address: u32, cputype: u32,
     ret 0;
 }
 
+# an ISA vtable that describes an architecture and binds no back half (test helper)
+#
+# The Mach-O writer reads only `id` off the vtable, but it is built through
+# `isa.machine_isa` rather than field by field. A record hand-built from a bare
+# declaration leaves whatever field it does not name holding the frame's residue,
+# and a field added to `IsaVTable` later is named by no site at all - which is
+# exactly how these tests came to read an uninitialized function pointer (#2294).
+# The census in `target/isa/tests.mach` is what keeps this true.
+# ---
+# id:  the architecture id the vtable reports
+# ret: a description-only vtable, every other field cleared
+fun t_isa(id: u32) isa.IsaVTable {
+    ret isa.machine_isa(id, "test", 0, 8, nil, 0, nil, nil, nil);
+}
+
 # intern a string for a test, yielding STR_NIL on the (test-only) interning failure
 # ---
 # itn: interner to intern into
@@ -3701,8 +3716,7 @@ fun ts_x64_roundtrip() u8 {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # .text: a call at offset 0 (PLT32 field at 1), a rip-relative load at offset 6
     # (PC32 field at 8), an 8-byte absolute slot at offset 16 (ABS64). the
@@ -3823,8 +3837,7 @@ fun ts_relro_roundtrip() u8 {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var text_bytes:  [8]u8;
     var ro_bytes:    [8]u8;
@@ -3904,8 +3917,7 @@ fun ts_arm64_roundtrip() u8 {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_AARCH64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_AARCH64);
 
     # adrp x0,g ; add x0,x0,#:lo12:g ; ldr x1,[x0] ; bl ext_func.
     var text_bytes: [16]u8;
@@ -4009,8 +4021,7 @@ fun ts_many_sections_coalesce() u8 {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     val ndata:   u32 = 260;   # rodata input sections at indices 1..260
     val total:   u32 = 1 + ndata;
@@ -4187,8 +4198,7 @@ fun ts_exec_x64() u8 {
     page.make(?alloc);
     var itn: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var code: [8]u8;
     var k: usize = 0;
@@ -4266,8 +4276,7 @@ fun ts_exec_arm64() u8 {
     page.make(?alloc);
     var itn: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_AARCH64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_AARCH64);
 
     var code: [8]u8;
     bin.write_u32_le(?code[0], 0, 0xD503201F);  # nop
@@ -4352,8 +4361,7 @@ fun ts_dyn_exec(arch_id: u32) u8 {
     page.make(?alloc);
     var itn: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = arch_id;
+    var isa_vt: isa.IsaVTable = t_isa(arch_id);
 
     # a single text segment whose first instruction is a call to the import: the
     # x86_64 `call rel32` (E8 + 4 bytes) and the arm64 `bl` (one word) both put a
@@ -4664,8 +4672,7 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     page.make(?alloc);
     var itn: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = arch_id;
+    var isa_vt: isa.IsaVTable = t_isa(arch_id);
 
     var bytes: [80]u8;
     var k: usize = 0;
@@ -4775,8 +4782,7 @@ fun ts_dyn_exec_split_data_const() u8 {
     page.make(?alloc);
     var itn: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_AARCH64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_AARCH64);
 
     var bytes: [64]u8;
     var k: usize = 0;
@@ -4822,8 +4828,7 @@ fun ts_exec_merges_read_only() u8 {
     page.make(?alloc);
     var itn: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var bytes: [48]u8;
     var k: usize = 0;
@@ -4873,8 +4878,7 @@ fun ts_unsupported_kind() u8 {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var text_bytes: [16]u8;
     var k: usize = 0;
@@ -4990,8 +4994,7 @@ fun ts_exec_debug_roundtrip() u8 {
     page.make(?alloc);
     var itn: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var code: [8]u8;
     var k: usize = 0;
@@ -5091,8 +5094,7 @@ fun ts_object_debug_roundtrip() u8 {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var text_bytes: [8]u8;
     var k: usize = 0;

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -255,6 +255,21 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
+# an ISA vtable that describes an architecture and binds no back half (test helper)
+#
+# The flat-image writer reads only `id` off the vtable, but it is built through
+# `isa.machine_isa` rather than field by field. A record hand-built from a bare
+# declaration leaves whatever field it does not name holding the frame's residue,
+# and a field added to `IsaVTable` later is named by no site at all - which is
+# exactly how these tests came to read an uninitialized function pointer (#2294).
+# The census in `target/isa/tests.mach` is what keeps this true.
+# ---
+# id:  the architecture id the vtable reports
+# ret: a description-only vtable, every other field cleared
+fun t_isa(id: u32) isa.IsaVTable {
+    ret isa.machine_isa(id, "test", 0, 8, nil, 0, nil, nil, nil);
+}
+
 # register installs the raw vtable and the unsupported stubs reject non-executable
 # emission
 test "mach.lang.target.of.raw.register:installs_vtable" {
@@ -267,7 +282,11 @@ test "mach.lang.target.of.raw.register:installs_vtable" {
     if (!O.is_some[*of.OfVTable](opt_vt)) { ret 1; }
     if (O.unwrap[*of.OfVTable](opt_vt).id != of.OF_RAW) { ret 1; }
 
-    var isa_vt: isa.IsaVTable;
+    # the stub rejects the emit before it reads either argument. the vtable is still
+    # built rather than declared bare - an unread field today is a read field after
+    # the next change. `ObjectImage`'s only constructor is `be.obj.init`, which this
+    # target-layer module cannot import, so it stays a bare declaration (#2294).
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
     var image:  of.ObjectImage;
 
     val res_obj: R.Result[bool, str] = emit_object(?isa_vt, ?image, nil::*u8);
@@ -284,8 +303,7 @@ test "mach.lang.target.of.raw.emit_exec:flat_layout" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     # entry segment at the image base (0x1000), then a second segment after a gap
     # so the zero-fill between them is exercised.
@@ -344,8 +362,7 @@ test "mach.lang.target.of.raw.emit_exec:entry_must_be_base" {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var isa_vt: isa.IsaVTable;
-    isa_vt.id = isa.ARCH_X86_64;
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
 
     var code_bytes: [4]u8;
     code_bytes[0] = 0x90; code_bytes[1] = 0x90; code_bytes[2] = 0x90; code_bytes[3] = 0x90;


### PR DESCRIPTION
Closes #2294.

## What was wrong

`of/elf.mach`'s tests hand-built 16 `IsaVTable`s from bare declarations. When `IsaVTable` gained a relocatable-object seam in #2244 those sites silently acquired it uninitialized, and `attributes_for` — which runs unconditionally on every exec emit — was handed a function pointer off the stack to compare against nil. Whether the comparison said "nil" was a property of the stack, not of the program.

The #2215 census exists to forbid exactly this, *including for fields that do not exist yet*. It did not catch this because `IsaVTable` was not a censused record at all. The exemption was invisible: nothing said "the ISA contracts are outside the census", it was simply that the type list named two records and the trap landed on a third.

## The exemption is removed, not documented

**All 55 hand-built sites now go through a constructor.** The 16 in `of/elf.mach`, plus the same shape wherever else it occurs:

| file | sites | now |
|---|---|---|
| `target/of/coff.mach` | 19 | `t_isa(id)` → `isa.machine_isa` |
| `target/of/elf.mach` | 16 | `t_isa(id, elf_machine, reloc)` → `isa.machine_isa` |
| `target/of/macho.mach` | 13 | `t_isa(id)` → `isa.machine_isa` |
| `target/of/raw.mach` | 3 | `t_isa(id)` → `isa.machine_isa` |
| `me/ir/type.mach` | 3 | `isa.machine_isa` inline |
| `be/codegen/ctvalidate.mach` | 1 | `isa.emitter_isa` / `isa.machine_isa`, one per family |

Four of the ELF sites had never set `elf_machine` at all, so the object writer was stamping `e_machine` from the stack; they are error-path tests that never read it back, and they now say 62.

**The census covers the four ISA contracts.** `IsaVTable`, `RegMachine`, `ModuleEmitter` and `RelocSeam` join `Inst` and `Operand`, so the censused set is now a principled one: *the target-layer records that own a constructor*. Owning a constructor is what turns hand-building from the only option into a bug.

**The census walks the whole of `src`**, not `src/lang/target` plus `src/lang/be`. Which subtree a hand-built record lives in has nothing to do with whether it is a bug, and scanning some directories is an exemption for the rest that nobody can see. This is what pulled `me/ir/type.mach` in.

**The permitted list carries a count per group.** Two kinds of site legitimately declare these records bare, and they are not the same kind of thing:

- the six **constructors**, one per record, each the single place its record is cleared;
- the **process-global storage** an arch's registration module declares for the vtable it installs. A module-level `var` cannot carry a call as its initializer, so the storage must be declared bare and whole-assigned at startup (`x64_vtable = isa.machine_isa(...)`). That is a declaration of storage, not a construction site — but nothing in the text distinguishes them, so each such file is permitted with the **exact** number of globals it declares (3/3/3/2/2). A fourth global in a file permitted for three fails.

Both kinds live in one table with the count column, so neither is invisible. 21 sites, 13 groups.

## Shown to fire

**Mutation A — the reintroduced hand-built site.** Revert one `of/elf.mach` site to `var isa_vt: isa.IsaVTable;` plus field assignments:

```
failures:
  mach.lang.target.isa.blank:every_construction_site_is_constructed  ./src/lang/target/isa/tests.mach:450  (exit 1)

894 passed, 1 failed, 895 total
```

**Mutation B — a site added inside a permitted group.** Add a fourth `var x64_spare: isa.RelocSeam;` to `x64/register.mach`, permitted for three:

```
failures:
  mach.lang.target.isa.blank:every_construction_site_is_constructed  ./src/lang/target/isa/tests.mach:450  (exit 1)

894 passed, 1 failed, 895 total
```

**N-1 / 1** both times, the census the single failure, naming its file and line. Reverting each restores 895 / 0. B is the one the old membership-only permit list could not express: the pair was permitted, so only the count catches it.

## Sweep: the same shape elsewhere

1881 bare record declarations under `src`, classified by what the declaring code does next:

| | |
|---|---|
| 1046 | **filled by an out-param initializer** — `var a: A.Allocator; page.make(?a);`. The idiom for "declare storage, hand it to its initializer". Not hand-building; the initializer is the constructor. |
| 779 | **hand-built** — declared bare, fields then assigned individually. This is the shape. |
| 56 | declared and never touched |

`IsaVTable` was 56 of the hand-built 779 and is now 0. What remains, by record:

```
88  MirInstr        16  Instruction      10  MirBlock
39  Span            16  EncodeState      10  Section
29  ObjectImage     16  DynamicInfo      10  Symbol
23  Expr            15  Stmt             10  RulePack
22  MirFunction     13  Selection        10  QueryOutput
18  Type            11  Decl              9  IrType
17  CTValue                               9  Value
```

**`MirInstr` is the one to take next.** 17 fields, no constructor, 88 hand-built sites across `mir/lower`, `regalloc`, `isel`, `encode` and three target rule packs — and it has already produced a shipped miscompile of exactly this class: regalloc rebuilt a `MirInstr` without copying `vec_lane`, collapsing NEON/SSE arrangement specifiers (fixed in #2032). It is the same fix in the same order: write the constructor, convert the sites, add the record to this census. `ObjectImage` (29 sites, 11 fields) is the next one down; its only constructor is `be.obj.init`, which the target-layer writers cannot import, so it needs a target-layer clearing constructor first — the one site I touched in `of/raw.mach` is commented to that effect rather than converted.

Neither is in this PR: both are their own change with their own byte-identity argument.

## Bar

Verification ceremony has since been trimmed fleet-wide to **one target, one profile (linux-x86_64 release)**, no fixpoint for test-side changes, no `--all-targets` sweeps. The numbers below were measured before that and are wider than now required; the load-bearing lines are marked. Nothing here needs re-running — the trimmed bar is a subset of what was run.

**Byte-identity, linux-x86_64 release (load-bearing).** **7 files differ**: the six touched objects (`ctvalidate.o`, `me/ir/type.o`, `of/coff.o`, `of/elf.o`, `of/macho.o`, `of/raw.o`) and the one binary that links them.

That is a divergence, and per the rule it is therefore the finding: **`mach build` compiles test bodies into the per-module object.** `strings` finds the literal `elf_unres` — used only inside a `test` block in `of/elf.mach` — in a plain release build of `of/elf.o`. So "test-side only ⇒ objects unchanged" is not true in this build system, and no amount of narrowing the target set makes it true. The binary differs by relayout, not content: the test symbols themselves are dropped at link, and `strings` on the release binary finds no test name.

Widening confirmed the divergence is uniform and bounded rather than target-specific: across all six targets × both profiles, **84 of 2556 files differ, and they are exactly the same six files each time** plus the twelve binaries. Every other object is byte-identical.

**Output equivalence (load-bearing).** The check that actually says "the compiler is unchanged": two identical `dev` checkouts built by a `dev`-built compiler and by a branch-built compiler emit byte-identical artifacts — `diff -r --brief` exit 0 over 2556 files.

**Suites (load-bearing).** mach **895 / 0**, mach-std **611 / 0** at pin `eff1e8e`, materialized with `git archive` from the pin.

**Fixpoint** — not required for a test-side change under the trimmed bar; it was run before the change in policy and passed, `B == C` = `68fc4376…`.
