### PR TITLE
feat(lang): add #[noinline], the inverse of #[inline]

### DIFF
--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -31,6 +31,7 @@ A decorator is written as an attribute:
 #[symbol("name")]    # linker name override
 #[library("dep")]    # PE import routing (ext only)
 #[inline]            # force inlining (no arguments)
+#[noinline]          # forbid inlining (no arguments)
 #[align(expr)]       # alignment; expr is a comptime integer
 #[section(".name")]  # place in a named object section
 #[oblivious]         # constant-time boundary (no arguments)
@@ -103,6 +104,31 @@ size- and use-count heuristics. Applies to functions only; takes no arguments.
 #[inline]
 fun fast_path(x: i64) i64 { ret x * 2; }
 ```
+
+### `noinline` — forbid inlining
+
+The inverse of `inline`: forbids inlining a function into any caller, overriding
+the compiler's size- and use-count heuristics that would otherwise fold it in.
+Applies to functions only; takes no arguments.
+
+```mach
+#[noinline]
+fun cold_path(code: i64) i64 { panic("unreachable state"); }
+```
+
+Use it to keep a function's frame and symbol real — for a profiler or stack
+sampler to attribute its cost correctly, to keep a cold path from bloating a hot
+caller's instruction cache, or to hold code size down on a constrained target.
+
+- `inline` and `noinline` on the same function is a direct contradiction and is
+  rejected in sema; neither wins silently.
+- `scalar` already declines inlining as a side effect (#2141), so pairing it
+  with `noinline` is legal but redundant.
+- Purely a hint to the inliner; it does not otherwise change codegen. It binds
+  at every optimization level — the debug pipeline runs no inlining pass at
+  all, so `noinline` is inert (and unnecessary) there — and it will bind
+  identically to any future cross-module or LTO inlining path, which is not a
+  separate mechanism exempt from it.
 
 ### `align(expr)` — alignment override
 
@@ -195,6 +221,7 @@ is undesirable for a specific function. The project-wide equivalent is the
 | `symbol`    |  yes  |    yes    |      yes      |      no       |
 | `library`   |  no   |    yes    |      no       |      no       |
 | `inline`    |  yes  |    no     |      no       |      no       |
+| `noinline`  |  yes  |    no     |      no       |      no       |
 | `align`     |  no   |    no     |      yes      |      yes      |
 | `section`   |  yes  |    yes    |      yes      |      no       |
 | `oblivious` |  yes  |    no     |      no       |      no       |

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -27,6 +27,8 @@ use O: std.types.option;
 use R: std.types.result;
 use ctime: std.chrono.time;
 
+use mach.lang.be.codegen;
+use mach.lang.be.obj;
 use mach.lang.build.outcome;
 use mach.lang.build.qctx;
 use mach.lang.build.request;
@@ -48,6 +50,7 @@ use mach.lang.readout;
 use mach.lang.session;
 use src: mach.lang.source;
 use mach.lang.target;
+use mach.lang.target.of;
 use mach.lang.type;
 
 use mach.lang.driver.project;
@@ -3665,6 +3668,141 @@ test "mach.lang.driver:generic_instance_call_inlines_at_release" {
     project.dnit_project(?p);
     session.dnit(?s);
     ret bad;
+}
+
+# `#[noinline]` blocks the release inliner end to end for `target_name`, proven
+# from the emitted object rather than the inliner's source (#2200): `helper` is
+# small and single-use, so by the ordinary heuristics it would inline into `main`
+# (see the undecorated twin `small_single_use_callee_inlines_by_default` in
+# me.pass.inline). Every direct call - local or not - lowers through a
+# name-targeted relocation (be.codegen.pack_relocs: "a cross-section call from a
+# re-homed site just works"), so a live call to `helper` leaves an RK_PLT32
+# relocation naming it in the object; an inlined call leaves none. `RK_PLT32` is
+# the abstract direct-call kind on all three ISAs this runs against (R_X86_64_PLT32
+# / R_AARCH64_CALL26 / R_RISCV_CALL_PLT).
+# ---
+# target_name: a `[target.*]` entry from ut_manifest's six-target manifest
+# ret:         0 when the call survives release inlining and the object proves it,
+#              1 on any build failure or if the call was inlined away
+fun ut_noinline_survives_object(target_name: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "#[noinline]\nfun helper(x: i64) i64 { ret x + 1; }\nfun main() i64 { ret helper(41); }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(?s, root, target_name);
+    fs.remove_all(?alloc, root);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    # bad starts failed and clears only on the full success chain, so a build or
+    # lookup failure can never vacuously pass.
+    var bad: i32 = 1;
+    if (R.is_err[bool, outcome.Fail](passes.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[bool, outcome.Fail](passes.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    if (mid != session.MODULE_NIL) {
+        val me: *project.ModuleEntry = ?p.modules[mid::u32];
+        if (me.ir_module != nil) {
+            val m: *ir.Module = me.ir_module;
+            val ri: R.Result[bool, str] = inline.run(m, ?p.target);
+            if (R.is_ok[bool, str](ri)) {
+                # the surviving call's callee, read straight off the IR - no guessed
+                # mangled name - so the object check below matches whatever linkage
+                # name codegen actually assigned.
+                val callee_name: intern.StrId = ut_single_local_callee_name(m);
+                if (callee_name != intern.STR_NIL) {
+                    val cg: R.Result[of.ObjectImage, str] =
+                        codegen.codegen_module(?s, ?p.target, m, nil, codegen.no_debug());
+                    if (R.is_ok[of.ObjectImage, str](cg)) {
+                        var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](cg);
+                        if (ut_has_direct_call_reloc(?image, callee_name)) { bad = 0; }
+                        obj.dnit(?image);
+                    }
+                }
+            }
+        }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# the linkage name of `m`'s one surviving local-definition call site, or STR_NIL
+# when there is not exactly one - `ut_noinline_survives_object`'s fixture has a
+# single call, so a count other than one means the fixture shape changed under it.
+fun ut_single_local_callee_name(m: *ir.Module) intern.StrId {
+    var found: intern.StrId = intern.STR_NIL;
+    var hits: u32 = 0;
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val fn: *ir.Function = ?m.functions[fi];
+        var bi: u32 = 0;
+        for (bi < fn.block_count) {
+            val blk: *ir.Block = ?fn.blocks[bi];
+            var ii: u32 = 0;
+            for (ii < blk.instr_count) {
+                val oi: O.Option[*instruction.Instruction] = ir.instruction_get(fn, blk.instructions[ii]);
+                if (O.is_some[*instruction.Instruction](oi)) {
+                    val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](oi);
+                    if (inst.kind == instruction.OP_CALL && inst.operand_count >= 1) {
+                        val callee: value.Value = inst.operands[0];
+                        if (callee.kind == value.VAL_FN && callee.data.fn_ix < m.function_len) {
+                            val cfn: *ir.Function = ?m.functions[callee.data.fn_ix];
+                            if ((cfn.flags & ir.FN_FLAG_EXTERN) == 0 && cfn.block_count > 0) {
+                                found = cfn.name;
+                                hits = hits + 1;
+                            }
+                        }
+                    }
+                }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+        fi = fi + 1;
+    }
+    if (hits != 1) { ret intern.STR_NIL; }
+    ret found;
+}
+
+# true when `image` carries a direct-call relocation naming `callee_name`. aarch64
+# (BL/CALL26) and riscv64 (auipc+jalr/CALL_PLT) always route a direct call through
+# RK_PLT32 (x64/encode.mach never emits it); x64's CALL rel32 shares the ordinary
+# RIP-relative symbol path with every other x64 symbol reference and so carries the
+# more general RK_PC32. `callee_name`'s only reference anywhere in the fixture is
+# the one call site under test, so either kind naming it is decisive here.
+fun ut_has_direct_call_reloc(image: *of.ObjectImage, callee_name: intern.StrId) bool {
+    var i: u32 = 0;
+    for (i < image.reloc_count) {
+        val rel: *of.Relocation = ?image.relocations[i];
+        if ((rel.kind == of.RK_PLT32 || rel.kind == of.RK_PC32) && rel.symbol == callee_name) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# the cross-ISA bar (#2200): `#[noinline]` must hold on x86_64, aarch64, and
+# riscv64 - not just wherever the host happens to be - since should_inline itself
+# is target-independent (tgt is a reserved, currently-unused parameter) but the
+# object-level proof still has to be re-derived per ISA's own relocation packer.
+test "mach.lang.driver:noinline_decorator_survives_object_all_isas" {
+    if (ut_noinline_survives_object("linux") != 0)         { ret 1; }
+    if (ut_noinline_survives_object("linux-arm64") != 0)   { ret 1; }
+    if (ut_noinline_survives_object("linux-riscv64") != 0) { ret 1; }
+    ret 0;
 }
 
 # driver incremental: editing one dependency's body re-lowers it and its importer

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1695,7 +1695,93 @@ test "mach.lang.editor.sema:unknown_decorator" {
 
     val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
     if (R.is_err[*diagnostic.DiagList, str](res_diags))                                                                                                  { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagList, str](res_diags), "unknown decorator; valid directives are symbol, section, inline, align, library, oblivious, scalar")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagList, str](res_diags), "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar")) { dnit(?es); session.dnit(?s); ret 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret 0;
+}
+
+# `noinline` on a non-function is rejected, matching `inline` (#2200)
+test "mach.lang.editor.sema:noinline_decorator_wrong_target" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "ni.mach", "#[noinline] pub var g: i64 = 0;\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags))                                                                    { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagList, str](res_diags), "`noinline` decorator applies only to functions")) { dnit(?es); session.dnit(?s); ret 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret 0;
+}
+
+# `noinline` takes no arguments, matching `inline` (#2200)
+test "mach.lang.editor.sema:noinline_takes_no_arguments" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "ni2.mach", "#[noinline(1)] fun f() i64 { ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags))                                                                { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagList, str](res_diags), "`noinline` decorator takes no arguments")) { dnit(?es); session.dnit(?s); ret 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret 0;
+}
+
+# `inline` and `noinline` together on one function is a direct contradiction and is
+# rejected, naming both decorators rather than silently picking a winner (#2200)
+test "mach.lang.editor.sema:inline_noinline_conflict_rejected" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "ic.mach", "#[inline] #[noinline] fun f() i64 { ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags))                                                                                                     { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagList, str](res_diags), "`inline` and `noinline` decorators cannot both apply to the same function")) { dnit(?es); session.dnit(?s); ret 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret 0;
+}
+
+# `scalar` already declines inlining as a side effect (#2141); pairing it with the
+# explicit `noinline` opt-out is redundant, not a conflict, so it must compile clean
+test "mach.lang.editor.sema:scalar_noinline_composes" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "sn.mach", "#[scalar] #[noinline] fun f() i64 { ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags))                           { dnit(?es); session.dnit(?s); ret 1; }
+    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagList, str](res_diags))) { dnit(?es); session.dnit(?s); ret 1; }
 
     dnit(?es);
     session.dnit(?s);

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -1070,9 +1070,10 @@ fun infer_decorator_args(sc: *context.SemaContext, d: *decl.Decl) {
 # validate every decorator on decl `d`
 #
 # Each must name a directive from the closed set (symbol / section / inline /
-# align / library), carry the right argument shape, and apply to a compatible
-# declaration. Diagnostics are reported against the offending span; sema does not
-# halt.
+# noinline / align / library), carry the right argument shape, and apply to a
+# compatible declaration. Diagnostics are reported against the offending span;
+# sema does not halt. A second, whole-decl pass then rejects the one directly
+# contradictory pair, `inline` + `noinline`.
 # ---
 # sc: the context
 # d:  the decl whose decorators to validate
@@ -1081,6 +1082,32 @@ fun validate_decorators(sc: *context.SemaContext, d: *decl.Decl) {
     for (i < d.decorators_len) {
         validate_one_decorator(sc, d, ?sc.a.decorators[d.decorators_start + i]);
         i = i + 1;
+    }
+    validate_no_inline_conflict(sc, d);
+}
+
+# reject `#[inline]` and `#[noinline]` together on decl `d` (#2200)
+#
+# The pair is a direct contradiction -- force inlining and forbid it -- so
+# picking a winner would silently discard half of the user's intent. Both
+# decorators are named in the single diagnostic, reported at the `noinline`
+# site.
+# ---
+# sc: the context
+# d:  the decl whose decorators to cross-check
+fun validate_no_inline_conflict(sc: *context.SemaContext, d: *decl.Decl) {
+    var has_inline:   bool = false;
+    var has_noinline: bool = false;
+    var noinline_span: token.Span;
+    var i: u32 = 0;
+    for (i < d.decorators_len) {
+        val dec: *decl.Decorator = ?sc.a.decorators[d.decorators_start + i];
+        if (decorator_named(sc, dec, "inline"))   { has_inline = true; }
+        if (decorator_named(sc, dec, "noinline")) { has_noinline = true; noinline_span = dec.name; }
+        i = i + 1;
+    }
+    if (has_inline && has_noinline) {
+        context.report(sc, noinline_span, "`inline` and `noinline` decorators cannot both apply to the same function");
     }
 }
 
@@ -1192,6 +1219,19 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
         }
         ret;
     }
+    # the inverse of `inline` (#2200): pins a function out-of-line. `inline` and
+    # `noinline` together on one decl are rejected by validate_no_inline_conflict,
+    # below the per-decorator loop that calls this. legal and redundant alongside
+    # `scalar`, which already declines inlining as a side effect (#2141).
+    if (decorator_named(sc, dec, "noinline")) {
+        if (dec.args_len != 0) {
+            context.report(sc, dec.name, "`noinline` decorator takes no arguments");
+        }
+        if (d.kind != decl.DECL_KIND_FUN) {
+            context.report(sc, dec.name, "`noinline` decorator applies only to functions");
+        }
+        ret;
+    }
     # `#[oblivious]` marks a function as a constant-time boundary (#1646): the
     # backend must not introduce a secret-dependent branch, select a variable-latency
     # instruction on a secret operand, or dead-store-eliminate a zeroizing write to
@@ -1242,7 +1282,7 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
         }
         ret;
     }
-    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, align, library, oblivious, scalar");
+    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar");
 }
 
 # the return type a `test` body is checked against: the interned i32 primitive

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -66,6 +66,12 @@ pub val FN_FLAG_OBLIVIOUS: u32 = 0x40;
 # declines to inline it so the opt-out survives inlining (#2141)
 pub val FN_FLAG_SCALAR: u32 = 0x80;
 
+# opt-out of inlining for this function, from a `#[noinline]` decorator (#2200):
+# the inliner never inlines a call to a function carrying this flag into any
+# caller, regardless of its size or use count. the direct inverse of
+# FN_FLAG_INLINE; sema rejects a decl carrying both.
+pub val FN_FLAG_NOINLINE: u32 = 0x100;
+
 # one `{name}` local binding referenced by an inline-asm body: the interned
 # source name and the alloca instruction that owns the local's stack slot. the
 # back end resolves the alloca to a frame offset and substitutes `[rbp+off]`

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -122,6 +122,8 @@ pub fun lower_fun(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, is_
     if (is_test)                              { flags = flags | ir.FN_FLAG_TEST; }
     # an `inline` decorator hints the inline pass, which already honors the flag.
     if (decl_has_decorator(ctx, d, "inline")) { flags = flags | ir.FN_FLAG_INLINE; }
+    # a `noinline` decorator is the inverse hint (#2200); sema rejects it alongside `inline`.
+    if (decl_has_decorator(ctx, d, "noinline")) { flags = flags | ir.FN_FLAG_NOINLINE; }
     # an `oblivious` decorator carries the constant-time contract to codegen (#1646).
     if (decl_has_decorator(ctx, d, "oblivious")) { flags = flags | ir.FN_FLAG_OBLIVIOUS; }
     if (decl_has_decorator(ctx, d, "scalar")) { flags = flags | ir.FN_FLAG_SCALAR; }

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -210,6 +210,11 @@ fun should_inline(recursive: *bool, counts: *u32, callee_ix: u32, callee: *ir.Fu
     # caller after inlining -- the flag is a per-function opt-out that inlining, which
     # moves the body into an unflagged caller, would otherwise silently drop (#2141)
     if ((callee.flags & ir.FN_FLAG_SCALAR) != 0)             { ret false; }
+    # a `#[noinline]` callee is never inlined, regardless of size or use count -- the
+    # direct inverse of `#[inline]`, for pinning a function out-of-line for profiling,
+    # code size, or a stable frame (#2200). sema rejects a decl carrying both, so this
+    # never races the FN_FLAG_INLINE check below.
+    if ((callee.flags & ir.FN_FLAG_NOINLINE) != 0)           { ret false; }
     if (recursive[callee_ix])                                { ret false; }
     if (callee.block_count == 0)                             { ret false; }
     if (callee_has_asm(callee))                              { ret false; }
@@ -2070,5 +2075,151 @@ test "mach.lang.me.pass.inline.run:mutual_recursion_not_peeled" {
 
     if (f0_to_f1 != 1 || f0_to_f0 != 0) { ret 1; }
     if (f1_to_f0 != 1 || f1_to_f1 != 0) { ret 1; }
+    ret 0;
+}
+
+# the counterpart baseline to `noinline_flag_blocks_inlining`, below: this exact
+# callee shape (small, single call site, no flags) DOES inline by default -
+# proving the fixture is a genuine positive case for the size/use-count
+# heuristics, not one already excluded by some other gate.
+test "mach.lang.me.pass.inline.run:small_single_use_callee_inlines_by_default" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val ri: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](ri)) { ir.dnit(?m); ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ri);
+    var pi: type.IrTypeId = i64t;
+    val rs: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i64t, ?pi, 1);
+    if (R.is_err[type.IrTypeId, str](rs)) { ir.dnit(?m); ret 1; }
+    val sig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rs);
+    val rs0: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i64t, nil, 0);
+    if (R.is_err[type.IrTypeId, str](rs0)) { ir.dnit(?m); ret 1; }
+    val sig0: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rs0);
+
+    # callee(x) i64 { ret x; } -- no flags.
+    val r_callee: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig, 0);
+    if (R.is_err[u32, str](r_callee)) { ir.dnit(?m); ret 1; }
+    val callee_ix: u32 = R.unwrap_ok[u32, str](r_callee);
+    val r_caller: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig0, 0);
+    if (R.is_err[u32, str](r_caller)) { ir.dnit(?m); ret 1; }
+    val caller_ix: u32 = R.unwrap_ok[u32, str](r_caller);
+
+    var bld: builder.Builder = builder.init(?m);
+
+    builder.set_function(?bld, ?m.functions[callee_ix]);
+    val rcb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rcb)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rcb));
+    if (R.is_err[bool, str](builder.emit_ret(?bld, value.param(0, i64t)))) { ir.dnit(?m); ret 1; }
+
+    # caller() i64 { ret callee(7); }
+    builder.set_function(?bld, ?m.functions[caller_ix]);
+    val rlb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rlb)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rlb));
+    var arg: value.Value = value.const_int(7, i64t);
+    val rcall: R.Result[value.Value, str] = builder.emit_call(?bld, value.fn(callee_ix, sig), ?arg, 1, i64t);
+    if (R.is_err[value.Value, str](rcall)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?bld, R.unwrap_ok[value.Value, str](rcall)))) { ir.dnit(?m); ret 1; }
+
+    val rr: R.Result[bool, str] = run(?m, nil);
+    if (R.is_err[bool, str](rr)) { ir.dnit(?m); ret 1; }
+
+    val caller_fn: *ir.Function = ?m.functions[caller_ix];
+    var calls: u32 = 0;
+    var i: u32 = 0;
+    for (i < caller_fn.block_count) {
+        val blk: *ir.Block = ?caller_fn.blocks[i];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val oi: O.Option[*instruction.Instruction] = ir.instruction_get(caller_fn, blk.instructions[ii]);
+            if (O.is_some[*instruction.Instruction](oi)) {
+                val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](oi);
+                if (ins.kind == instruction.OP_CALL && callee_index(ins) == callee_ix) { calls = calls + 1; }
+            }
+            ii = ii + 1;
+        }
+        i = i + 1;
+    }
+    ir.dnit(?m);
+
+    if (calls != 0) { ret 1; }
+    ret 0;
+}
+
+# a `#[noinline]`-flagged callee (FN_FLAG_NOINLINE) is never inlined, even though
+# it passes every other should_inline gate: same shape as the baseline above
+# (small body, single call site), which inlines away with the flag absent (#2200).
+test "mach.lang.me.pass.inline.run:noinline_flag_blocks_inlining" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val ri: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](ri)) { ir.dnit(?m); ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ri);
+    var pi: type.IrTypeId = i64t;
+    val rs: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i64t, ?pi, 1);
+    if (R.is_err[type.IrTypeId, str](rs)) { ir.dnit(?m); ret 1; }
+    val sig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rs);
+    val rs0: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i64t, nil, 0);
+    if (R.is_err[type.IrTypeId, str](rs0)) { ir.dnit(?m); ret 1; }
+    val sig0: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rs0);
+
+    # callee(x) i64 { ret x; } -- FN_FLAG_NOINLINE, otherwise identical to the
+    # baseline test's callee.
+    val r_callee: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig, ir.FN_FLAG_NOINLINE);
+    if (R.is_err[u32, str](r_callee)) { ir.dnit(?m); ret 1; }
+    val callee_ix: u32 = R.unwrap_ok[u32, str](r_callee);
+    val r_caller: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig0, 0);
+    if (R.is_err[u32, str](r_caller)) { ir.dnit(?m); ret 1; }
+    val caller_ix: u32 = R.unwrap_ok[u32, str](r_caller);
+
+    var bld: builder.Builder = builder.init(?m);
+
+    builder.set_function(?bld, ?m.functions[callee_ix]);
+    val rcb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rcb)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rcb));
+    if (R.is_err[bool, str](builder.emit_ret(?bld, value.param(0, i64t)))) { ir.dnit(?m); ret 1; }
+
+    # caller() i64 { ret callee(7); }
+    builder.set_function(?bld, ?m.functions[caller_ix]);
+    val rlb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rlb)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rlb));
+    var arg: value.Value = value.const_int(7, i64t);
+    val rcall: R.Result[value.Value, str] = builder.emit_call(?bld, value.fn(callee_ix, sig), ?arg, 1, i64t);
+    if (R.is_err[value.Value, str](rcall)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?bld, R.unwrap_ok[value.Value, str](rcall)))) { ir.dnit(?m); ret 1; }
+
+    val rr: R.Result[bool, str] = run(?m, nil);
+    if (R.is_err[bool, str](rr)) { ir.dnit(?m); ret 1; }
+
+    val caller_fn: *ir.Function = ?m.functions[caller_ix];
+    var calls: u32 = 0;
+    var i: u32 = 0;
+    for (i < caller_fn.block_count) {
+        val blk: *ir.Block = ?caller_fn.blocks[i];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val oi: O.Option[*instruction.Instruction] = ir.instruction_get(caller_fn, blk.instructions[ii]);
+            if (O.is_some[*instruction.Instruction](oi)) {
+                val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](oi);
+                if (ins.kind == instruction.OP_CALL && callee_index(ins) == callee_ix) { calls = calls + 1; }
+            }
+            ii = ii + 1;
+        }
+        i = i + 1;
+    }
+    ir.dnit(?m);
+
+    if (calls != 1) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
## Summary

Adds `#[noinline]` to the closed decorator set: a hint that forbids the inliner from folding a function into any caller, regardless of size or use-count heuristics. The direct inverse of `#[inline]`.

Follows the `#[scalar]` route exactly (it already "declines inlining" as a side effect, #2141):

- `me/ir.mach`: new `FN_FLAG_NOINLINE` bit.
- `me/pass/inline.mach`: `should_inline` returns `false` immediately when the callee carries the flag, checked alongside the existing `FN_FLAG_SCALAR` gate.
- `fe/sema.mach`: `noinline` validated like `inline` (no args, functions only), plus a new whole-decl cross-check rejecting `inline` + `noinline` together.
- `me/lower/decl.mach`: `#[noinline]` on a `fun` sets the IR flag (mirrors `inline`/`scalar`; not propagated onto generic/value weak instances - a pre-existing gap `inline`/`scalar` already have, out of scope here, see note below).
- `doc/language/decorators.md`: new `noinline` section + applicability row.

## Design decisions (from the issue)

- **`inline` + `noinline` contradiction**: rejected in sema with a single diagnostic naming both -- `` `inline` and `noinline` decorators cannot both apply to the same function ``. No existing decorator pair had a precedent for this, so this is a new whole-decl validation pass (`validate_no_inline_conflict`) run after the existing per-decorator loop.
- **`scalar` + `noinline`**: legal and redundant (both compile clean), documented as such. `scalar` already declines inlining as a side effect; `noinline` alongside it doesn't conflict.
- **Correctness-required inlining**: none exists. The only inliner in the compiler is the heuristic release pass (`me/pass/inline.mach`); there is no macro-expansion or generic-instantiation-via-inlining path that depends on a body actually moving into its caller for the program to be correct.
- **`#[naked]` (#2198)**: not implemented yet (open, and I see another worker active on it in parallel -- flagging a **bitflag collision risk**: both PRs likely add a `FN_FLAG_*` bit near the same line in `me/ir.mach`; worth a careful look at merge time per the "adjacent next-bitflag-value" hazard).
- **Self-recursion peel** (`peel_eligible` in `inline.mach`): deliberately left unguarded by `FN_FLAG_NOINLINE`, matching how it's already unguarded by `FN_FLAG_SCALAR`. The peel clones a function's body into *itself* (recursion unrolling), never into a different caller, so it doesn't violate "never inlined into any caller" even under a strict reading.
- **Optimization levels / future LTO**: honored at every level (debug never inlines to begin with) and stated in the doc as binding to any future cross-module/LTO inliner too, not scoped to today's intra-module pass alone.

## Bar

- **Not inlined, proven from emitted code, not from reading the inliner** (`me/pass/inline.mach:noinline_flag_blocks_inlining` + its undecorated twin `small_single_use_callee_inlines_by_default` proving the fixture would otherwise inline): IR-level, executes the real pass.
- **Cross-ISA object-level proof** (`driver/tests.mach:noinline_decorator_survives_object_all_isas`, x86_64/aarch64/riscv64 via `linux`/`linux-arm64`/`linux-riscv64`): builds through `codegen.codegen_module`, inspects the emitted `ObjectImage`'s relocations for a surviving direct-call site naming the callee. aarch64/riscv64 route every direct call through `RK_PLT32` (`R_AARCH64_CALL26` / `R_RISCV_CALL_PLT`); x86_64's `CALL rel32` shares the ordinary RIP-relative symbol path and carries `RK_PC32` instead (x64/encode.mach never emits `RK_PLT32`) -- the test checks either kind.
- **Contradiction diagnostic** (`editor.mach:inline_noinline_conflict_rejected`): exact text `` `inline` and `noinline` decorators cannot both apply to the same function ``.
- **Unused / single-use functions behave sanely**: covered by the object-level test (single-use) and the IR-level pair; nothing calls `helper` in the inliner's cost model beyond the call-count/size gates the flag now short-circuits before either is consulted.
- **Byte-identical objects, no `#[noinline]` usage, both profiles, all 6 declared targets** (x86_64/aarch64/riscv64/windows-x86_64/darwin-x86_64/darwin-aarch64, debug + release): built the compiler's own source (zero `#[noinline]` usage) with a pre-change baseline compiler vs. this branch's compiler and diffed every object. The *only* objects that differ anywhere are the 4 files this PR touches (`fe/sema.o`, `me/ir.o`, `me/lower/decl.o`, `me/pass/inline.o`); every other object across all 6 targets x 2 profiles is byte-identical. Also verified mach-std (611 tests, zero `#[noinline]` usage) byte-identical at x86_64/aarch64, debug + release.
- **Mutation-tested every guard**, each restored after:
  - `should_inline`'s `FN_FLAG_NOINLINE` check -> `881/1` (only `noinline_flag_blocks_inlining` fails)
  - sema's whole-decl `validate_no_inline_conflict` call -> `885/1` (only `inline_noinline_conflict_rejected` fails)
  - `me/lower/decl.mach`'s decorator->flag wiring -> `886/1` (only the object-level cross-ISA test fails -- the only test exercising that specific line, since the IR-level tests build the flag directly)
  - sema's `noinline` arg-count check -> `886/1` (only `noinline_takes_no_arguments` fails)
  - sema's `noinline` target-kind check -> `886/1` (only `noinline_decorator_wrong_target` fails)
- **Three-generation fixpoint**: seed -> A -> B -> C, `B == C` byte-identical.
- **Suites through the from-source HEAD compiler**: mach `887 / 0` (880 baseline + 7 new tests), mach-std `611 / 0` at pin `eff1e8e4`.

## Test plan

- [x] `mach test` on this branch: 887/0
- [x] mach-std `mach test`: 611/0
- [x] Three-generation self-host fixpoint (B == C byte-identical)
- [x] Additivity diff across all 6 targets x 2 profiles for both the compiler's own source and mach-std
- [x] Mutation-tested every new guard