### PR TITLE
fix(driver): delete ProjectConfig's dead profile-resolved shadow fields

### DIFF
--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -223,16 +223,6 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
     }
     p.config.targets      = targets;
     p.config.target_count = 1;
-    p.config.bin_out      = bu.bin_path;
-    p.config.obj_root     = bu.obj_root;
-    p.config.ir_root      = bu.ir_root;
-    p.config.asm_root     = bu.asm_root;
-    p.config.test_root    = bu.test_root;
-    p.config.emit_ir      = bu.emit_ir;
-    p.config.emit_asm     = bu.emit_asm;
-    p.config.debug        = bu.debug;
-    p.config.simd         = bu.simd;
-    p.config.vectorize    = bu.vectorize;
     p.config.defines       = bu.defines;
     p.config.define_count  = bu.define_count;
     p.target_entry        = ?p.config.targets[0];
@@ -273,27 +263,6 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
         str_free(p.alloc, project_out_str);
     }
 
-    # Copy links to ProjectConfig
-    p.config.links      = nil;
-    p.config.link_count = 0;
-    if (m.link_count > 0) {
-        val res_links: R.Result[*manifest.LinkDef, str] = A.allocate[manifest.LinkDef](p.alloc, m.link_count::usize);
-        if (R.is_ok[*manifest.LinkDef, str](res_links)) {
-            val links: *manifest.LinkDef = R.unwrap_ok[*manifest.LinkDef, str](res_links);
-            var li: u32 = 0;
-            for (li < m.link_count) {
-                var d: manifest.LinkDef = m.links[li];
-                dup_strid_array(p.alloc, d.os,  d.os_count,  ?d.os,  ?d.os_count);
-                dup_strid_array(p.alloc, d.isa, d.isa_count, ?d.isa, ?d.isa_count);
-                dup_strid_array(p.alloc, d.abi, d.abi_count, ?d.abi, ?d.abi_count);
-                links[li] = d;
-                li = li + 1;
-            }
-            p.config.links      = links;
-            p.config.link_count = m.link_count;
-        }
-    }
-    
     # Copy steps to ProjectConfig
     p.config.steps      = nil;
     p.config.step_count = 0;

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -130,19 +130,6 @@ pub rec DepEntry {
 # target_count: number of entries in targets (always 1)
 # deps:         flat array of DepEntry records
 # dep_count:    number of entries in deps
-# bin_out:      interned resolved artifact path (root-relative)
-# obj_root:     interned resolved intermediate-object dir (root-relative)
-# ir_root:      interned resolved IR-dump dir (root-relative)
-# asm_root:     interned resolved ASM-dump dir (root-relative)
-# test_root:    interned per-test executable path template (root-relative) with a
-#               literal `{name}` placeholder `mach test` fills per test
-# emit_ir:      selected profile's IR-emission default
-# emit_asm:     selected profile's ASM-emission default
-# debug:        selected profile's debug-info default (`[profile.*] debug`); the
-#               driver ORs it with the CLI `-g` flag into the session's resolved bit
-# simd:         selected profile's SIMD strictness lever (`[profile.*] simd`); the
-#               consumer's posture over the target capability fact, resolved onto the
-#               session and read at the build's scalarize/require gate (#2017)
 # defines:      merged comptime defines for the selected unit (artifact < target
 #               < cell), each `NAME` or `NAME=VALUE`; bound into every module's
 #               comptime ctx during load (#1191); nil when none
@@ -166,16 +153,6 @@ pub rec ProjectConfig {
     target_count: u32;
     deps:         *DepEntry;
     dep_count:    u32;
-    bin_out:      intern.StrId;
-    obj_root:     intern.StrId;
-    ir_root:      intern.StrId;
-    asm_root:     intern.StrId;
-    test_root:    intern.StrId;
-    emit_ir:      bool;
-    emit_asm:     bool;
-    debug:        bool;
-    simd:         manifest.SimdMode;
-    vectorize:    bool;
     defines:      *intern.StrId;
     define_count: u32;
     cascade_libs:      *intern.StrId;
@@ -187,8 +164,6 @@ pub rec ProjectConfig {
     # indices into `steps` for the demanded steps, in needs-first run order (#1970)
     step_order:       *u32;
     step_order_count: u32;
-    links:        *manifest.LinkDef;
-    link_count:   u32;
 }
 
 # one comptime constant exported by a module to its importers
@@ -478,16 +453,6 @@ pub fun init_project(p: *Project, s: *session.Session) {
     p.config.target_count = 0;
     p.config.deps         = nil;
     p.config.dep_count    = 0;
-    p.config.bin_out      = intern.STR_NIL;
-    p.config.obj_root     = intern.STR_NIL;
-    p.config.ir_root      = intern.STR_NIL;
-    p.config.asm_root     = intern.STR_NIL;
-    p.config.test_root    = intern.STR_NIL;
-    p.config.emit_ir      = false;
-    p.config.emit_asm     = false;
-    p.config.debug        = false;
-    p.config.simd         = manifest.SIMD_SCALARIZE;
-    p.config.vectorize    = true;
     p.config.defines       = nil;
     p.config.define_count  = 0;
     p.config.cascade_libs      = nil;
@@ -529,23 +494,6 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
     if (c.cascade_libs != nil && c.cascade_lib_count > 0) {
         A.deallocate[intern.StrId](alloc, c.cascade_libs, c.cascade_lib_count::usize);
     }
-    if (c.links != nil && c.link_count > 0) {
-        var li: u32 = 0;
-        for (li < c.link_count) {
-            val l: *manifest.LinkDef = ?c.links[li];
-            if (l.os != nil && l.os_count > 0) {
-                A.deallocate[intern.StrId](alloc, l.os, l.os_count::usize);
-            }
-            if (l.isa != nil && l.isa_count > 0) {
-                A.deallocate[intern.StrId](alloc, l.isa, l.isa_count::usize);
-            }
-            if (l.abi != nil && l.abi_count > 0) {
-                A.deallocate[intern.StrId](alloc, l.abi, l.abi_count::usize);
-            }
-            li = li + 1;
-        }
-        A.deallocate[manifest.LinkDef](alloc, c.links, c.link_count::usize);
-    }
     if (c.steps != nil && c.step_count > 0) {
         var si: u32 = 0;
         for (si < c.step_count) {
@@ -574,8 +522,6 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
     c.define_count  = 0;
     c.cascade_libs      = nil;
     c.cascade_lib_count = 0;
-    c.links = nil;
-    c.link_count = 0;
     c.steps = nil;
     c.step_count = 0;
     c.step_order = nil;

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -113,6 +113,19 @@ pub rec DepEntry {
 }
 
 # parsed mach.toml plus the resolved dep metadata
+#
+# Carries identity/path/dependency metadata a tooling consumer (comptime
+# intrinsics, `mach doc`, dep resolution) reads back off the built Project.
+# It does NOT carry profile-resolved build settings (opt, debug, simd,
+# vectorize, emission flags, output paths): those are settled once into
+# `build.request.BuildRequest` by `compose`/`resolve_build_unit` and read from
+# there (`ctx.req.*`) at the point of use. A field added here by symmetry with
+# an existing BuildRequest field has no reader and stays silently inert - the
+# `simd`/`vectorize`/`debug`/`emit_ir`/`emit_asm`/`bin_out`/`obj_root`/
+# `ir_root`/`asm_root`/`test_root`/`links` fields removed by #2277 were exactly
+# this. `opt` is the one exception: legacy tooling entries (doc, union builds,
+# driver tests) that build without a composed BuildRequest still read
+# `target_entry.opt` directly (see `install_default_ctx`).
 # ---
 # id:           interned `[project].id`; read by `$project.id`
 # version:      interned `[project].version`; read by `$project.version`


### PR DESCRIPTION
## Disposition: (a), leftover from a superseded mechanism

`ProjectConfig.simd`/`.vectorize` (and, the sweep found, nine sibling fields) are
written from the resolved `manifest.BuildUnit` and read by nothing. Evidence, in
commit order:

- `86928c17` ("thread resolved simd posture onto the session") introduced
  `ProjectConfig.simd` alongside `session.simd`. The **actual read path** was
  `src/cli/cmd/build.mach: p.s.simd = p.config.simd;`, then `session.simd` read at
  the scalarize/require gate. `ProjectConfig.simd` was never itself read - it only
  fed the session copy.
- `dd267534` ("implement the build engine", 2026-07-18) replaced that whole
  mechanism: `session.simd` was deleted, `src/cli/cmd/build.mach` was gutted
  (3082 lines removed), and `manifest.BuildUnit.simd` was rethreaded onto the new
  `build.request.BuildRequest.simd` instead - read today at
  `src/lang/driver/passes.mach:981` and `src/lang/build/testing.mach:309` via
  `ctx.req.simd`. `ProjectConfig.simd` kept being written (`config.mach`) but was
  never migrated onto the new path, and nothing was left reading it.
- `2c70ca74` (`#2141`, 2026-07-23, **five days after** the build engine already
  owned this mechanism) added `.vectorize` fresh, mirroring the already-dead
  `.simd` field by symmetry, into **both** the live `BuildRequest` (which *is*
  read) and the dead `ProjectConfig` (which is not) - reproducing the exact
  failure #2277 describes, a week after the live path had already moved.

So: not (b). There is no unfinished driver-level override anywhere - no code path
reads `p.config.simd`/`.vectorize` under any condition, staged or planned, and
`BuildRequest` already is what every actual codegen decision consults.

## Sweep

Same shape (`ProjectConfig` field written from `BuildUnit`, shadowing a field
that's actually read off `BuildRequest` or read directly off `BuildUnit` in
`build/plan.mach`), all dead, all deleted:

| field | live shadow (the thing that's actually read) |
|---|---|
| `simd` | `BuildRequest.simd` (`ctx.req.simd`, passes.mach:981 / testing.mach:309) |
| `vectorize` | `BuildRequest.vectorize` (same call sites) |
| `debug` | `BuildRequest.debug` (`ctx.req.debug`, engine/plan) |
| `emit_ir` | `BuildRequest.emit_ir` (`ctx.req.emit_ir`, engine.mach:668+) |
| `emit_asm` | `BuildRequest.emit_asm` (same) |
| `bin_out` | `BuildUnit.bin_path` (plan.mach:457) |
| `obj_root` | `BuildUnit.obj_root` (plan.mach:334) |
| `ir_root` | `BuildUnit.ir_root` (plan.mach:340) |
| `asm_root` | `BuildUnit.asm_root` (plan.mach:346) |
| `test_root` | `BuildUnit.test_root` (plan.mach:443) |
| `links` / `link_count` | `Manifest.links` (`validate_local_links` reads `m.links` directly - `p.config.links` is a **deep copy**, including per-entry `os`/`isa`/`abi` sub-array duplication, allocated every build and only ever touched again to free it) |

`links` is worse than the others: it's not a free scalar copy, it's a real
allocation-and-duplicate on every build for zero consumers.

Checked and confirmed alive (not part of the sweep): every other `ProjectConfig`
field (`id`/`version`/`name`/`bin_name`/`module`/`dir_src`/`dir_dep`/
`project_root`/`deps`/`dep_count`/`defines`/`define_count`/`cascade_libs`/
`cascade_lib_count`/`profile`/`project_out`/`steps`/`step_count`/`step_order`/
`step_order_count`/`targets`/`target_count`), and every peer-record field on
`TargetEntry` and `DepEntry` - including `TargetEntry.opt`, which looked dead by
the same grep pattern until tracing it to `driver.mach:233`'s legacy
(non-engine) `install_default_ctx` path showed it's the one field that *is* read
outside `BuildRequest`, for tooling entries that build without a composed
request.

## Flagged prominently, NOT folded into this fix: `BuildRequest.verbosity` / `.quiet`

Same defect shape, different record, disposition genuinely ambiguous even after
reading the source: `compose()` sets both from `CliArgs`, but `readout.init`
(`src/cli/cmd/build.mach:271`) reads `CliArgs.verbosity` directly and never
`req.verbosity`. A dedicated test
(`request_hash:settled_fields_key_the_identity`) deliberately excludes them from
the content hash as "presentation fields" - real design intent - but no
consumer, embedding or CLI, currently reads the `BuildRequest` copies at all
(an embedding consumer that wants readout output injects its own
`readout.Progress`/`outcome.Render` sinks directly into `engine.execute`,
bypassing `BuildRequest.verbosity` entirely). Deciding delete-vs-wire here
touches the CLI presentation layer, a different subsystem boundary than
profile-resolution -> `ProjectConfig`, and deserves its own issue rather than
scope-creeping this one.

## Structurally impossible? Reasoned no

#2215's construction-site census (`src/lang/target/isa/tests.mach`) works because
"declares a record with no initializer" is a **purely syntactic** property - the
declaration form is unambiguous, no expression-context reasoning needed. "Written
and never read" is not that: it requires classifying every `.field` occurrence in
the source as write vs. read vs. incidental touch, and that classification isn't
mechanical. Concretely, a naive census would have **false-negatived on `links`
itself** - `deallocate_config`'s teardown loop touches `c.links`/`c.link_count`
(to free them), which a text-pattern check can't distinguish from a real read.
Left a doc-comment guardrail on `ProjectConfig` instead, naming the fields this PR
removed, so the next field added by symmetry with a `BuildRequest` field has
something to read before repeating the mistake.

## Verification

- Three-generation fixpoint: gen1 (seed-built) -> gen2 (self-built) -> gen3
  (self-built by gen2); gen2 == gen3 byte-identical (sha256
  `793bb54469ddf088748b6122326d3f17bc9a55623accd74056644227460d9696`).
- `mach test .` through the from-source gen3 compiler: **892 passed, 0 failed,
  892 total** (matches fresh `dev`).
- `mach test .` in `dep/mach-std` at pin `eff1e8e40686d9993047ef027bd8d7e6a7e2f5be`:
  **611 passed, 0 failed, 611 total**.
- Byte-identical objects: built the pre-fix source tree with the external seed
  (4.2.2) and separately with a seed-built compiler from this branch's fixed
  source (holding the compiler constant, varying only the source under test),
  `--emit obj --all-targets`, both `debug` and `release` profiles, for this
  project (6 declared targets: linux-x86_64/arm64/riscv64, windows-x86_64,
  darwin-x86_64/aarch64) and for `mach-std` (linux-x86_64/arm64) - `diff -rq`
  reports **zero differences** in every case. (The linked *compiler binaries*
  themselves are *not* byte-identical between baseline and fixed builds - expected
  and explained: removing fields from a record embedded by value inside `Project`
  shifts the byte offsets of every subsequently-declared field, and every
  function anywhere in the compiler that touches one of those fields by pointer
  offset recompiles to a different immediate displacement. That's struct-layout
  noise in the compiler's own self-compilation, not a behavior change - which is
  exactly what the object-level identity check above isolates and confirms.)

Closes #2277