### PR TITLE
docs(fe): record at each guard why it survives its own mutation

### DIFF
--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -2363,6 +2363,11 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str] {
     # -- exactly how a `:^` strip cast shipped unresolved through a whole release
     # (#2138/#2144). fail loudly at the gap rather than leaving sema to poison the
     # unbound operand and lowering to report the wreckage.
+    #
+    # unreachable while the arms above stay complete, so no test kills it and it
+    # survives its own mutation. deleting any arm above is what fires it - that is
+    # the fault it exists for, and the whole reason it is not dead code. do not
+    # remove it for being untested.
     ret diagnostic.error(?rc.s.diags, rc.a.file_id, e.span, "internal: this expression kind has no name-binding rule; the resolver cannot bind its operands");
 }
 

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -529,6 +529,13 @@ fun infer_ident(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
 # The message names the actual cause -- the resolver, not the source -- because
 # the source is well-formed by construction: a name the resolver could not find
 # is reported there and stops the build before sema runs.
+#
+# NO SOURCE REACHES THIS, and that is the point: it is an assertion about the
+# resolver, so deleting it changes no test and it survives its own mutation. What
+# kills it is mutating the invariant instead -- delete a `bind_expr` arm and this
+# fires, where on dev the same program reported `unresolved identifier` from
+# LOWERING, blaming source for a resolver bug (#2138 shipped that way for a whole
+# release). Untested is not the same as unjustified; do not remove it.
 # ---
 # sc:  sema context
 # eid: the unbound identifier expression
@@ -1413,8 +1420,11 @@ fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: 
 # ret:  the named TypeId, substituted at an instance, or TYPE_ERROR
 fun intrinsic_operand_type(sc: *context.SemaContext, eid: id.ExprId, span: token.Span) type.TypeId {
     val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    # the parser reads this slot with the type grammar for exactly these callees,
-    # so a node that is not a type spelling cannot be produced from source.
+    # the parser reads this slot with the type grammar for exactly these callees, so
+    # a node that is not a type spelling cannot be produced from source. NOTHING IN
+    # THE SUITE REACHES THIS ARM and deleting it changes no test - it asserts that
+    # parser guarantee, and without it a violation is back to dropping the `$each`
+    # body in silence. Do not remove it for being untested; see `report_unbound_ident`.
     if (O.is_none[*expr.Expr](e_opt) || O.unwrap[*expr.Expr](e_opt).kind != expr.EXPR_KIND_TYPE_REF) {
         context.report(sc, span, "internal: a comptime intrinsic argument was not parsed as a type");
         ret type.TYPE_ERROR;
@@ -1423,6 +1433,9 @@ fun intrinsic_operand_type(sc: *context.SemaContext, eid: id.ExprId, span: token
 
     val mark: usize       = context.diag_mark(sc);
     val ty:   type.TypeId = resolve_type_ref(sc, e.data.type_ref.ty);
+    # only an allocation failure gets here, so no test kills this either. It is the
+    # assertion that a resource failure can never read as an empty `$each`, and it is
+    # the same call `infer_generic_call` makes for the same reason (#1348).
     if (ty == type.TYPE_ERROR && !context.reported_since(sc, mark)) {
         context.report(sc, e.span, "internal: could not intern the type named by this comptime intrinsic argument");
     }
@@ -1486,7 +1499,9 @@ pub fun field_seq_owner(sc: *context.SemaContext, seq_eid: id.ExprId, span: toke
     # which is 0 for an absent table exactly as it is for a record with no fields --
     # opposite outcomes, one expanding to nothing and one dropping the body unchecked.
     # Reporting nothing would silently pick the wrong one; reporting a type error would
-    # blame valid source for a resource failure.
+    # blame valid source for a resource failure. Only that failure reaches this, so no
+    # test kills it; it is the instance-only guard #2168 added for the same reason,
+    # widened to every owner. Do not remove it for being untested.
     if (O.is_none[*context.FieldTable](context.field_table_for(sc, owner))) {
         context.report(sc, span, "internal: could not materialize the field table for this `$fields` type argument");
         ret type.TYPE_ERROR;


### PR DESCRIPTION
Follow-up to #2285 (#2178 / #2144). **Comments only** — the compiler builds
byte-identical to `418373f2` (`99b19673…` from the same seed, both trees).

Five guards that PR added are unreachable from source by construction, so deleting
any of them changes no test — they survive their own mutation. The reasoning that
makes them *justified* rather than *dead* lived only in the merged PR description,
which is one refactor away from a reader applying "remove any guard that survives
its mutation" and reinstating a silent `$each`-body drop.

Each guard now carries that reasoning where it stands: what makes it unreachable,
what fault does fire it, and an explicit "do not remove it for being untested".

| Guard | Why no test reaches it | What fires it |
|---|---|---|
| `intrinsic_operand_type` — operand is not a TYPE_REF | the parser reads that slot with the type grammar for exactly these callees | a violation of that parser guarantee |
| `intrinsic_operand_type` — `reported_since` | every way an operand can fail to name a type is already reported | an allocation failure interning the type |
| `field_seq_owner` — absent field table | `ensure_fields` materializes every reachable owner | a failed materialization |
| `infer_ident` — unbound identifier | a resolver-rejected name stops the build before sema | deleting a `bind_expr` arm |
| `bind_expr` — no binding rule | the arms above are complete | deleting a `bind_expr` arm |

The last two are invariant assertions, and their comments name the mutation that
kills them: delete a `bind_expr` arm and they fire, where on `dev` the same program
reported `unresolved identifier` from **lowering**, blaming source for a resolver
bug — which is how #2138 shipped through a whole release.

The three resource-failure guards point at the precedent already in the same file
for reporting rather than poisoning at a sema leaf (`infer_generic_call`, #1348),
and at the instance-only guard #2168 added for exactly this reason, which the
`$fields` one widened to every owner.

## Verification

- Compiler **byte-identical** to `418373f2` under the same seed (`99b19673…`) — the change is provably comments.
- Three-generation fixpoint B == C (`731b9b7f…`).
- mach **911 / 0**, mach-std **611 / 0** at pin `eff1e8e`.

Refs #2178, #2144.
