### PR TITLE
fix(lower): a constant with an address has exactly one (#2235)

### DIFF
--- a/doc/language/val-var.md
+++ b/doc/language/val-var.md
@@ -34,12 +34,18 @@ At module top level:
 
 Inside functions, they are local to the enclosing block.
 
-A module-level `val` whose initializer is a compile-time constant **is** that
-value at every use site, in its own module and in every module that imports it —
-however the reference is spelled (bare, module-qualified, or through a `use`
-alias). No load is emitted, and arithmetic over it folds and strength-reduces
-like any other literal. Its storage is still emitted, so `?NAME` has an address,
-and a `val` whose initializer is not a compile-time constant keeps its load.
+A module-level `val` of integer, `bool` or float type whose initializer is a
+compile-time constant **is** that value at every use site, in its own module and
+in every module that imports it — however the reference is spelled (bare,
+module-qualified, or through a `use` alias). No load is emitted, and arithmetic
+over it folds and strength-reduces like any other literal. Its storage is still
+emitted, so `?NAME` has an address, and a `val` whose initializer is not a
+compile-time constant keeps its load.
+
+A constant whose value **is** an address — a `str`, whose value is a pointer to
+its bytes — is never duplicated this way. It keeps one definition and every
+reference reads it, so two references to one `str` constant compare pointer-equal
+no matter which module they are in or how they are spelled.
 
 ## `ext` — foreign data imports
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -7334,6 +7334,63 @@ test "mach.lang.driver:aliased_module_val_folds" {
     ret bad;
 }
 
+# a `str` constant is never duplicated by the fold, however it is spelled (#2235)
+#
+# Its value is the ADDRESS of its bytes, so materialising it a second time hands
+# back a different value - observable, because `str` is `*char` and comparing two
+# of them is one `==`. Every reference therefore reads the one definition. Both
+# spellings are here because on `dev` they disagreed: a qualified `a.MSG` kept the
+# shared global while the same constant bare-imported was copied per module, so
+# identity held or failed by how the reference was written.
+#
+# The integer beside it is the discriminator in the other direction: a value with
+# no identity still folds, so this pins the boundary rather than "nothing folds".
+test "mach.lang.driver:str_const_keeps_one_definition" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "a.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.a;\nuse uniontest.a.MSG;\npub fun f() ptr { ret a.MSG; }\npub fun g() ptr { ret MSG; }\npub fun h() i64 { ret a.N; }\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub val MSG: ptr = \"hello\";\npub val N: i64 = 5150;\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+    if (m == nil) { bad = 1; }
+    or {
+        # neither spelling copies the bytes: main emits no blob of its own, and
+        # both references reach a's one definition.
+        if (ut_rodata_globals(m) != 0)             { bad = 1; }
+        if (!ut_has_extern_global(?s, m, "1aN3MSG")) { bad = 1; }
+        if (ut_const_uses(m, 5150) != 1)           { bad = 1; }  # the integer beside it still folds
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# how many globals in `m` hold raw constant bytes - the shape a materialised string
+# constant emits, so a count of 0 says nothing copied a string's bytes into `m`
+fun ut_rodata_globals(m: *ir.Module) u32 {
+    if (m == nil) { ret 0; }
+    var n:  u32 = 0;
+    var gi: u32 = 0;
+    for (gi < m.global_len) {
+        if ((?m.globals[gi]).init.kind == value.VAL_CONST_BYTES) { n = n + 1; }
+        gi = gi + 1;
+    }
+    ret n;
+}
+
 # the error diagnostics `src` leaves on the sink after sema + lower, or -1 when a
 # pass returned a hard failure
 #

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -760,6 +760,8 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
 # into "not a constant": a fold that fails open compiles a silently different
 # program. Measured to never fire, building the compiler, the standard library and
 # both suites.
+#
+# Only a value with no address identity folds; see `const_has_no_identity` (#2235).
 # ---
 # ctx: per-module lowering context
 # sym: the referenced symbol
@@ -776,7 +778,33 @@ fun module_const_value(ctx: *context.LowerContext, sym: *resolve.Symbol) R.Resul
     if (dctx == nil) { ret R.err[O.Option[comptime.CTValue], str]("lower: module-level reference: declaring module comptime context unavailable (invariant violated)"); }
     val opt_nc: O.Option[*comptime.NamedConst] = comptime.lookup(dctx, sym.name);
     if (O.is_none[*comptime.NamedConst](opt_nc)) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
-    ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](O.unwrap[*comptime.NamedConst](opt_nc).value));
+
+    val v: comptime.CTValue = O.unwrap[*comptime.NamedConst](opt_nc).value;
+    if (!const_has_no_identity(v)) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](v));
+}
+
+# whether a comptime value is the SAME value wherever it is materialised (#2235)
+#
+# An integer, a bool and a float are their bits: a copy is indistinguishable from the
+# original, so a reference may BECOME the value with nothing observable changing. A
+# string constant is not - its value is the ADDRESS of its bytes, and materialising
+# it a second time produces a second blob at a second address. That is not folding a
+# reference to a value, it is copying the referent and handing back a DIFFERENT
+# value, which pointer comparison observes directly (mach's `str` is `*char`).
+#
+# So a `str` constant keeps one definition and every reference reads it. That settles
+# #2235's address-identity question in the direction that has an invariant to state -
+# a constant with an address has exactly one - and it repairs a live divergence:
+# `a.MSG` compared equal across modules while the same constant reached through
+# `use pkg.a.MSG;` did not, so identity held or failed by SPELLING.
+# ---
+# v:   a folded comptime value
+# ret: true when materialising it anywhere yields the same value
+fun const_has_no_identity(v: comptime.CTValue) bool {
+    ret v.kind == comptime.CT_KIND_INT
+     || v.kind == comptime.CT_KIND_BOOL
+     || v.kind == comptime.CT_KIND_FLOAT;
 }
 
 # whether the identifier's semantic type is a function type


### PR DESCRIPTION
Closes #2235.

**This repairs a regression currently on `dev`.** #2286 (merged this morning) keyed fold eligibility on the referent's declaration instead of on whether the using module's comptime scope binds the bare name — which is #2235's remaining half, so one correction covered both and a qualified cross-module const now folds however it is spelled. What it also did, unintentionally, was fold `str` constants, and that is the address-identity question #2235 asks be **decided rather than discovered**. It got discovered. This decides it.

## The decision

A `str` constant's value is the **address** of its bytes. Materialising it a second time produces a second blob at a second address, so that is not folding a reference to a value — it is copying the referent and handing back a *different value*. `str` is `*char`, so one `==` observes it.

So: **a constant with an address has exactly one.** A `str` keeps one definition and every reference reads it. Integers, bools and floats — values that are their bits, where a copy is indistinguishable from the original — fold as #2206 intended.

## Why this direction, measured rather than argued

Three spellings of one constant, executed:

| | `a.MSG` vs `b.there()` | `a.MSG` vs direct | vs `use pkg.a.MSG;` |
|---|---|---|---|
| `dev` **before** #2286 | equal | equal | **not equal** |
| `dev` **today** | not equal | not equal | not equal |
| this branch | equal | equal | equal |

The first row is the important one: identity held or failed **by spelling**. There was never a coherent guarantee to preserve — `a.MSG` kept the shared global while the same constant bare-imported was copied per module, because the bare import is exactly what put the name in the importer's scope. So the choice was never "keep identity or lose it", it was which way to make it coherent. Only one of the two has an invariant that can be stated, and it is the one that also repairs the pre-existing divergence.

## Cost

#2235 asked what the fold costs in duplicated read-only data. It is **negative** — the duplication was already being paid on the by-name path:

| vs `dev` today | |
|---|---|
| modules changed | 41 / 212 |
| constant-byte globals | 10,981 → **10,602** (−379 duplicate blobs) |
| loads | 38,833 → **39,212** (+379) |
| binary (x86_64) | 7,413,760 → **7,401,472** (−12,288) |

The two 379s are the same 379: each duplicated blob becomes one load of the one definition. Net 12 KB smaller.

Per-target, against `dev` before #2286 (so the whole #2206 + #2235 effect together):

| target | dev | branch | delta |
|---|---|---|---|
| linux-x86_64 | 7,467,008 | 7,376,896 | **−90,112** (−1.21%) |
| linux-arm64 | 6,488,064 | 6,356,992 | **−131,072** (−2.02%) |
| linux-riscv64 | 7,090,800 | 7,004,784 | **−86,016** (−1.21%) |

## Verification

- `mach test .` **912 / 0** — 911 on `dev` plus the one test added. `mach test dep/mach-std` **611 / 0** at pin `eff1e8e`, verified against `mach.lock`.
- The new test discriminates: on `dev` it fails with main emitting **2** copied byte-blobs, **no** extern reference to the one definition, and the integer beside it folding **0** times. On this branch: 0 blobs, the extern reference present, the integer folded once. The integer is deliberately in the same test — it pins the *boundary*, so a fix that simply stopped folding everything would fail it.
- Three-generation fixpoint and int legs below.

### Fixpoint, legs, ISAs

- **Three-generation fixpoint**, both profiles: g2 == g3 byte-identical, debug and release. g1 differs — documented seed lag.
- `int/run.sh` all cases pass on **linux** and **linux-riscv64**, debug and release.
- The identity probe executed on **all three ISAs** — `linux` native, `linux-arm64` under `qemu-aarch64`, `linux-riscv64` under `qemu-riscv64`: `1 1 1` on every one.

### Mutation testing

| mutation | result |
|---|---|
| none (baseline) | 912 / 0 |
| drop the identity gate entirely (every kind folds again) | **911 / 1** |
| admit `CT_KIND_STR` to the identity-free set | **911 / 1** |
| drop `CT_KIND_INT` from the identity-free set | **906 / 6** |

No survivors. The last row is the one that matters for a boundary rule: it pins the set from the *other* side, so a change that stops folding too much fails as loudly as one that folds too much. Six failures because the four #2206 / #2223 tests depend on integer constants folding, which is the behaviour this must not regress while fixing `str`.
