### PR TITLE
test(sroa): pin the phi-partition rule; #2276 measurement says close it

### DIFF
--- a/src/lang/me/transform/sroa.mach
+++ b/src/lang/me/transform/sroa.mach
@@ -2361,3 +2361,111 @@ test "mach.lang.me.transform.sroa.run:declines_when_the_address_escapes" {
     ir.dnit(?m);
     ret code;
 }
+
+# the read-only-and-local phi rule is load-bearing: a merge block that writes a member
+# of the partition after the phi has already selected its incoming makes one shared
+# slot set unfaithful, because the write lands in the storage BOTH arms would read.
+#
+# This is the same shape as `splits_an_aggregate_phi_partition`, with one store added
+# to the merge block. With the rule in force the partition is declined and both slots
+# keep their storage; dropping the `check_partitions` call collapses them onto one
+# shared slot set and the alloca count falls to zero, which is the miscompile the rule
+# exists to prevent (#2276).
+test "mach.lang.me.transform.sroa.run:declines_a_phi_whose_merge_writes_a_member" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var reg: target.TargetRegistry;
+    var tgt: resolved.Target;
+    if (ut_target(?reg, ?tgt) != 0) { ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    var rec: ir_type.IrTypeId;
+    if (ut_rec2(?m, ?rec) != 0) { ir.dnit(?m); ret 1; }
+    val r64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](r64)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r64);
+    val r8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](r8)) { ir.dnit(?m); ret 1; }
+    val i8t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r8);
+
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+
+    var b: builder.Builder = builder.init(?m);
+    builder.set_function(?b, fn);
+    var blocks: [4]id.BlockId;
+    var n: u32 = 0;
+    for (n < 4) {
+        val rb: R.Result[id.BlockId, str] = builder.new_block(?b);
+        if (R.is_err[id.BlockId, str](rb)) { ir.dnit(?m); ret 1; }
+        blocks[n] = R.unwrap_ok[id.BlockId, str](rb);
+        n = n + 1;
+    }
+
+    var code: i32 = 0;
+    var arm: [2]value.Value;
+
+    builder.set_block(?b, blocks[0]);
+    val rcmp: R.Result[value.Value, str] = builder.emit_cmp_eq(?b, value.param(0, i64t), value.const_int(0, i64t));
+    if (R.is_err[value.Value, str](rcmp)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](rcmp), blocks[1], blocks[2]))) { code = 1; }
+
+    var a: u32 = 0;
+    for (a < 2) {
+        builder.set_block(?b, blocks[1 + a]);
+        val ra: R.Result[value.Value, str] = builder.emit_alloca(?b, rec, value.const_int(1, i64t));
+        if (R.is_err[value.Value, str](ra)) { ir.dnit(?m); ret 1; }
+        arm[a] = R.unwrap_ok[value.Value, str](ra);
+        if (R.is_err[bool, str](builder.emit_memzero(?b, arm[a], rec))) { code = 1; }
+        val g0: R.Result[value.Value, str] = ut_gep(?b, ?m, arm[a], rec, 0);
+        if (R.is_err[value.Value, str](g0)) { ir.dnit(?m); ret 1; }
+        if (R.is_err[bool, str](builder.emit_store(?b, value.const_int(a::u64, i8t), R.unwrap_ok[value.Value, str](g0)))) { code = 1; }
+        val g1: R.Result[value.Value, str] = ut_gep(?b, ?m, arm[a], rec, 1);
+        if (R.is_err[value.Value, str](g1)) { ir.dnit(?m); ret 1; }
+        if (R.is_err[bool, str](builder.emit_store(?b, value.const_int(10 + a::u64, i64t), R.unwrap_ok[value.Value, str](g1)))) { code = 1; }
+        if (R.is_err[bool, str](builder.emit_br(?b, blocks[3]))) { code = 1; }
+        a = a + 1;
+    }
+
+    # merge: phi the two addresses, then OVERWRITE arm 0's payload before reading
+    # through the phi. one shared slot set cannot express this -- the write would be
+    # visible on the arm that selected the other record.
+    builder.set_block(?b, blocks[3]);
+    val rphi: R.Result[value.Value, str] = builder.emit_phi(?b, rec);
+    if (R.is_err[value.Value, str](rphi)) { ir.dnit(?m); ret 1; }
+    val phi: value.Value = R.unwrap_ok[value.Value, str](rphi);
+    if (R.is_err[bool, str](builder.phi_add_incoming(?b, phi, blocks[1], value.retype(arm[0], rec)))) { code = 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?b, phi, blocks[2], value.retype(arm[1], rec)))) { code = 1; }
+
+    val gw: R.Result[value.Value, str] = ut_gep(?b, ?m, arm[0], rec, 1);
+    if (R.is_err[value.Value, str](gw)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?b, value.const_int(77, i64t), R.unwrap_ok[value.Value, str](gw)))) { code = 1; }
+
+    val hp: R.Result[value.Value, str] = ut_gep(?b, ?m, phi, rec, 1);
+    if (R.is_err[value.Value, str](hp)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?b, R.unwrap_ok[value.Value, str](hp), i64t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](rl)))) { code = 1; }
+
+    # before: two slots, two zero fills, one aggregate phi.
+    if (ut_count(fn, instruction.OP_ALLOCA)  != 2) { code = 1; }
+    if (ut_count(fn, instruction.OP_MEMZERO) != 2) { code = 1; }
+
+    val rs: R.Result[bool, str] = run(?m, ?tgt);
+    if (R.is_err[bool, str](rs)) { code = 1; }
+
+    # declined: both records keep their own storage, so the overwrite stays confined
+    # to arm 0. The zero fills are the discriminating observable -- splitting expands
+    # a whole-slot memzero into per-field stores, so a split leaves none, while the
+    # alloca count alone cannot tell "declined" from "split" (a two-field record's
+    # shared slot set is itself two allocas).
+    if (ut_count(fn, instruction.OP_MEMZERO) != 2) { code = 1; }
+    if (ut_count(fn, instruction.OP_ALLOCA)  != 2) { code = 1; }
+
+    ir.dnit(?m);
+    ret code;
+}


### PR DESCRIPTION
The measurement #2276 asked for. **Recommendation: close #2276 — the per-incoming form is not worth it.** This PR carries only the test the investigation showed was missing; the pass itself is unchanged.

## 1. Premise: confirmed

A loop-carried aggregate snapshot with six fields, copied on **one arm** of a diamond (the shape the handoff note prescribed — both-arms yields a DAG the old sweep already collected), with one field read. Same source, same SROA, only `dce` differs:

| | use-count DCE (pre-#2247) | mark-and-sweep (current `dev`) |
|---|---|---|
| loop-header field phis | 6 | 1 |
| merge field phis | 6 | 1 |
| **total phis** | **14** | **4** |
| loads | 12 | 12 |
| geps | 12 | 12 |
| total instructions | 50 | 40 |

**Ten dead phis — five one-arm cycles — collected.** SROA's own output does produce the shape #2247 fixed, so the premise holds.

The residual 10 dead loads + 10 dead geps are the `is_pure(OP_LOAD)` mechanism, and they sit on the **by-value parameters** `%p1`/`%p2`, which nothing can promote. I flagged in the handoff note that this analogy might not transfer to a per-incoming SROA, and it does not: a snapshot design's edge copies land on **per-field scalar slots**, which mem2reg promotes, so its loads would disappear via promotion rather than needing DCE. The mechanism is real but it is upstream of SROA, not a property of either design. It is also loop-invariant here — bb0, once per call, not per iteration.

## 2. What the two rules are actually worth

The decisive number. `check_partitions` instrumented over a full release self-build:

- 112 functions reach a phi partition at all; 152 phi candidates
- the two rules reject **30 candidates across 18 functions** (4.2% of the 706 alive at that point)

But in **all 18** of those functions, `propagate_escapes` — which runs immediately after — removes the rest of the partition anyway. The characteristic trace is `before_rules=3 after_rules=2 after_escapes=0`.

So I measured the ceiling directly: a compiler with the two rules **disabled entirely**, which is the most optimistic possible substitute (it splits everything they reject and adds no machinery). Same source, two compilers:

| | rules on | rules off |
|---|---|---|
| slot sets assigned | 5,496 | 5,543 (+47) |
| differing objects | — | **6 / 208** |
| total `.text` | 10,428,209 | 10,427,366 |

**843 bytes. 0.0081%.** That is the ceiling on what any redesign of this machinery can recover.

## 3. The comparison

**Removed** by a per-incoming form: `check_partitions`, `reaches_between`, `push_successors`, `push_block`, `is_partition_phi_block`, `block_writes_partition` — **152 lines** (91 code, 51 doc), used by nothing else, plus 3 `State` fields (`cand_local`, `visit`, `queue`) with their alloc/free.

**Added**: per-candidate slot sets rather than per-root (`assign_slots` is currently keyed on `find_root`); per-edge materialization of each field value; two-phase phi construction, because a phi partition can be cyclic (a loop-carried aggregate phi's field phis reference each other, so they must all exist before any is wired); and a dominance condition on the edge loads, replacing the locality condition being removed. Placing the loads in the predecessors avoids critical-edge splitting — a load from a non-escaping local is safe to speculate — so the CFG-neutrality of the pass survives, but a rule is traded, not deleted.

**~162 lines removed, a comparable amount added, one rule traded for another, to recover at most 843 bytes.** Not meaningfully simpler. Close it.

## 4. The finding worth keeping

The two rules had **no test**. Disabling `check_partitions` outright leaves all 896 suite tests green and every int case passing. I could not reach the rule from Mach source either: an address merge written in source is typed `ptr`, and SROA's phi candidate requires the *aggregate* type, which only `inline` produces.

So this PR builds the shape directly: the existing `splits_an_aggregate_phi_partition` case with one store added to the merge block.

**A correction on my own method.** My first version of this test passed under the mutation — a false confirmation, the exact failure mode I warned about in the handoff note, in the same session. I asserted on the alloca count, which cannot discriminate: splitting a two-field record produces two field allocas, the same count as the two original slots. The zero fills are the observable that works, because splitting expands a whole-slot memzero into per-field stores. Probing the pass directly (`cands=3 out=3` with the rule, `cands=3 out=0 survivors=3` without) is what caught it.

## Verification

- **Mutation** — remove the `check_partitions` call: **7 passed, 1 failed / 8**, failing exactly `declines_a_phi_whose_merge_writes_a_member`. Restored: **8 / 8**.
- **Suites** — `dev` baseline re-derived at `0d36bb04`: **895 / 0**. Branch: **896 / 0** (+1). mach-std **611 / 0**, materialized with `git archive` from pin `eff1e8e` and diffed byte-for-byte against the dep checkout over all 106 tracked paths.
- **Fixpoint** — `A == B == C` on release (a test-only change is inert, so even the first generation matches).
- **Inertness** — 0 of 208 objects differ against `dev`.

## A note on the 6.4% figure

SROA's win re-derived on the current tree, with the pass disabled in the pipeline: binary **−172,032 bytes (−1.57%)**, retired instructions **−2.27%** (199.48 G → 204.11 G, stable to 1e-7 across runs).

Wall time on this box swings ±20% between rounds and drifts with load from other agents — a naive sequential A-then-B measurement read **28.5%**, and interleaving the arms brought it to **7.5%**, with individual rounds overlapping. If that number is going to act as a regression gate, retired instructions is the metric that can actually hold it; wall time cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ntqq8dS4TDqoYPsx3JpVy4
