### PR TITLE
refactor(layout): fold both type universes through one layout policy (#2289)

### DIFF
--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -1290,7 +1290,10 @@ test "mach.lang.be.codegen.mir.context.vector_scaffolding" {
     classes[0].kind = isa.RC_GENERAL;
     classes[1].kind = isa.RC_FLOAT;
     classes[1].bit_width = 128;
+    var arch: isa.IsaVTable;
+    arch.pointer_width = 8;
     var tgt: target.Target;
+    tgt.isa                 = ?arch;
     tgt.model.reg_classes   = ?classes[0];
     tgt.model.reg_class_len = 2;
     tgt.model.gpr_width     = 8;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -40,6 +40,7 @@ use mach.lang.fe.sema;
 use generics: mach.lang.fe.sema.generics;
 use mach.lang.fe.token;
 use mach.lang.intern;
+use mach.lang.layout;
 use mach.lang.manifest;
 use mach.lang.me.ir;
 use mach.lang.me.ir.instruction;
@@ -4633,7 +4634,7 @@ fun ut_sema_extent_is(text: str, name: str, size: u32, align: u32) i32 {
         val tid: O.Option[type.TypeId] = ut_nominal_typeid(?s, name);
         if (O.is_some[type.TypeId](tid)) {
             # the corpus is built for the host x86_64 target, so pointer width is 8
-            val e: generics.Extent = generics.type_extent(?s, 8, O.unwrap[type.TypeId](tid));
+            val e: layout.Extent = generics.type_extent(?s, 8, O.unwrap[type.TypeId](tid));
             if (e.ok && e.size == size && e.align == align) { bad = 0; }
         }
     }
@@ -4806,18 +4807,19 @@ test "mach.lang.driver:secrecy_placement_byte_extent" {
     ret bad;
 }
 
-# constant-time (#2167): sema's layout must agree EXACTLY with the layout the backend
-# emits, because the secrecy-placement comparison now decides overlay safety from byte
-# extents. Sema admitting an overlay the emitted layout does not produce would convert
-# that check's conservatism into an unsoundness - the leak direction.
+# constant-time (#2167 / #2289): sema's layout must agree EXACTLY with the layout the
+# backend emits, because the secrecy-placement comparison decides overlay safety from
+# byte extents. Sema admitting an overlay the emitted layout does not produce would
+# convert that check's conservatism into an unsoundness - the leak direction.
 #
-# Sema has no aggregate layout of its own before this (`check.byte_size` reports 0 for
-# every record), so `generics.type_extent` is a second implementation of a policy whose
-# authority is `me.ir.type.byte_size` / `byte_align`. This test is what keeps the two
-# from drifting: both are pinned to ONE table of constants. Each row asserts sema's
-# extent directly, and `$size_of` / `$align_of` - which fold at LOWERING, off the IR
-# layout - assert the same numbers through the other implementation, in a program that
-# must compile clean. A change to either side moves one of the two and fails here.
+# The FOLD is no longer duplicated: sema and `me.ir.type` both drive `mach.lang.layout`,
+# so the rule itself cannot drift - a mutation of it moves BOTH consumers at once. What
+# remains is the seam: each side DESCRIBES its own type universe to that policy, and two
+# describers can disagree even when the policy is shared. This test pins exactly that.
+# Each row asserts sema's extent through the sema describer, and `$size_of` / `$align_of`
+# - which fold at LOWERING, through the IR describer - assert the same numbers in a
+# program that must compile clean. A describer that mis-reports a shape moves one side
+# and fails here.
 #
 # The corpus covers every shape the fold distinguishes: scalar widths, the natural
 # alignment padding a mixed record takes, a nested aggregate, an array, a union's

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -32,6 +32,7 @@ use atype: mach.lang.fe.ast.type;
 use sema: mach.lang.fe.sema.context;
 use mach.lang.fe.token;
 use mach.lang.intern;
+use mach.lang.layout;
 use mach.lang.session;
 use mach.lang.source;
 use mach.lang.type;
@@ -362,49 +363,85 @@ fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSc
     ret true;
 }
 
-# the byte extent of a type: the size and alignment it occupies in storage (#2167)
+# describe one semantic type to the shared layout policy (a layout.NodeFn)
 #
-# `ok` is false when the extent cannot be determined - an unresolvable field table, a
-# generic parameter with no concrete argument, a graph past the depth bound. Every
-# consumer treats that as "cannot prove", never as a permissive default.
+# The sema half of the #2289 seam: it names each semantic kind's storage shape and
+# leaves the fold to `mach.lang.layout`, which `me.ir.type` drives over the IR type
+# universe through the matching describer. One policy, so sema's idea of a layout
+# cannot drift from the one the backend emits - and a drift here would let the
+# secrecy-placement comparison admit an overlay that does not exist, which is a
+# disclosure rather than a wrong number.
+#
+# `^` has no runtime representation, so it is stripped before measuring. A generic
+# parameter, a comptime pack, or a nominal whose field table cannot be resolved is
+# described as NODE_UNKNOWN, which the policy propagates as `ok = false` - the
+# fail-closed answer every secrecy caller needs.
 # ---
-# ok:    whether size / align were determined
-# size:  the type's size in bytes
-# align: the type's alignment in bytes (always >= 1 when ok)
-pub rec Extent {
-    ok:    bool;
-    size:  u32;
-    align: u32;
+# ctx: the *session.Session, erased
+# id:  the TypeId to describe
+# ret: the node's layout shape, or NODE_UNKNOWN when it cannot be established
+fun describe_type(ctx: ptr, id: u32) layout.Node {
+    val s:    *session.Session = ctx::*session.Session;
+    val base: type.TypeId      = type.strip_secret(?s.types, id::type.TypeId);
+
+    val opt_type: O.Option[*type.Type] = type.get(?s.types, base);
+    if (O.is_none[*type.Type](opt_type)) { ret layout.node(layout.NODE_UNKNOWN); }
+    val t: *type.Type = O.unwrap[*type.Type](opt_type);
+
+    val d: type.PrimDesc = type.prim_desc(t.kind);
+    if (d.class == type.PRIM_CLASS_INT || d.class == type.PRIM_CLASS_FLOAT) {
+        var n: layout.Node = layout.node(layout.NODE_SCALAR);
+        n.bytes = d.bits / 8;
+        ret n;
+    }
+    # the raw `ptr`, a typed `*T`, and a function value (a code address) all lay out
+    # as a pointer.
+    if (d.class == type.PRIM_CLASS_PTR || t.kind == type.TYPE_POINTER || t.kind == type.TYPE_FUN) {
+        ret layout.node(layout.NODE_POINTER);
+    }
+    # all ten vector shapes are 128-bit (#1965).
+    if (t.kind == type.TYPE_VECTOR) { ret layout.node(layout.NODE_VECTOR); }
+
+    if (t.kind == type.TYPE_ARRAY) {
+        var n: layout.Node = layout.node(layout.NODE_ARRAY);
+        n.child = t.data.array.base::u32;
+        n.count = t.data.array.count;
+        ret n;
+    }
+
+    if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI || t.kind == type.TYPE_INSTANCE) {
+        # a generic instance's field table is materialized lazily, so a type that
+        # reaches here with no prior elaboration must be elaborated before its fields
+        # can be read - otherwise an absent table would read as "no fields".
+        if (t.kind == type.TYPE_INSTANCE) { ensure_fields(s, base); }
+
+        val ov: O.Option[bool] = nominal_overlays(s, base);
+        if (O.is_none[bool](ov)) { ret layout.node(layout.NODE_UNKNOWN); }
+        val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, base);
+        if (O.is_none[*type.FieldTable](opt_tab)) { ret layout.node(layout.NODE_UNKNOWN); }
+
+        var n: layout.Node = layout.node(layout.NODE_AGGREGATE);
+        n.field_count = O.unwrap[*type.FieldTable](opt_tab).fields_len;
+        n.overlays    = O.unwrap[bool](ov);
+        val ta: O.Option[u32] = session.type_align(s, base::u32);
+        if (O.is_some[u32](ta)) { n.decl_align = O.unwrap[u32](ta); }
+        ret n;
+    }
+
+    ret layout.node(layout.NODE_UNKNOWN);
 }
 
-# an Extent that could not be determined
-fun no_extent() Extent {
-    var e: Extent;
-    e.ok    = false;
-    e.size  = 0;
-    e.align = 0;
-    ret e;
+# name field `index` of aggregate type `id` (a layout.FieldFn)
+#
+# An absent entry yields TYPE_ERROR, which describes as NODE_UNKNOWN and so fails the
+# enclosing extent closed.
+fun describe_type_field(ctx: ptr, id: u32, index: u32) u32 {
+    val s:    *session.Session = ctx::*session.Session;
+    val base: type.TypeId      = type.strip_secret(?s.types, id::type.TypeId);
+    val fe: O.Option[*type.FieldEntry] = type.field_at(?s.types, base, index);
+    if (O.is_none[*type.FieldEntry](fe)) { ret type.TYPE_ERROR::u32; }
+    ret O.unwrap[*type.FieldEntry](fe).ty::u32;
 }
-
-# a determined Extent
-fun extent(size: u32, align: u32) Extent {
-    var e: Extent;
-    e.ok    = true;
-    e.size  = size;
-    e.align = align;
-    ret e;
-}
-
-# round `v` up to the next multiple of `a`; an alignment of 0 or 1 leaves it unchanged
-fun round_up(v: u32, a: u32) u32 {
-    if (a <= 1) { ret v; }
-    val r: u32 = v % a;
-    if (r == 0) { ret v; }
-    ret v + (a - r);
-}
-
-# the depth bound on the extent walk; a graph deeper than this yields `no_extent`
-val EXTENT_MAX_DEPTH: u32 = 64;
 
 # the storage size and alignment of a semantic type (#2167)
 #
@@ -414,109 +451,15 @@ val EXTENT_MAX_DEPTH: u32 = 64;
 # `check.byte_size` cannot serve - it reports 0 for every aggregate, which is also a
 # legitimate size for an empty record, so a distinguishable `ok` is required.
 #
-# THIS MUST AGREE EXACTLY WITH `me.ir.type.byte_size` / `byte_align`, which is what the
-# backend actually lays out: sema admitting an overlay the emitted layout does not
-# produce would turn this check's conservatism into an unsoundness. It mirrors that
-# natural C-style fold - a struct rounds each field to its alignment and the whole to
-# the aggregate's, a union overlaps every member at offset 0, an `#[align(...)]`
-# override raises (never lowers) the aggregate's alignment - reading the same
-# session-registered override the lowering reads. `generics_layout_matches_lowering`
-# pins the two against each other.
-#
-# `^` has no runtime representation, so it is stripped before measuring.
+# Folded by `mach.lang.layout`, the same policy `me.ir.type` measures the emitted
+# layout with, so the two cannot disagree (#2289).
 # ---
 # s:         the session (type universe, lazy instance fields, align overrides)
 # ptr_width: the target's pointer width in bytes
 # tid:       the type to measure
 # ret:       the determined Extent, or `ok = false` when it cannot be computed
-pub fun type_extent(s: *session.Session, ptr_width: u32, tid: type.TypeId) Extent {
-    ret extent_walk(s, ptr_width, tid, 0);
-}
-
-# the recursive worker for `type_extent`, bounding the graph depth
-fun extent_walk(s: *session.Session, ptr_width: u32, tid: type.TypeId, depth: u32) Extent {
-    if (depth > EXTENT_MAX_DEPTH) { ret no_extent(); }
-
-    val base: type.TypeId = type.strip_secret(?s.types, tid);
-    val opt_type: O.Option[*type.Type] = type.get(?s.types, base);
-    if (O.is_none[*type.Type](opt_type)) { ret no_extent(); }
-    val t: *type.Type = O.unwrap[*type.Type](opt_type);
-
-    val d: type.PrimDesc = type.prim_desc(t.kind);
-    if (d.class == type.PRIM_CLASS_INT || d.class == type.PRIM_CLASS_FLOAT) {
-        ret extent(d.bits / 8, d.bits / 8);
-    }
-    # the raw `ptr`, a typed `*T`, and a function value (a code address) are all
-    # pointer-sized and pointer-aligned.
-    if (d.class == type.PRIM_CLASS_PTR || t.kind == type.TYPE_POINTER || t.kind == type.TYPE_FUN) {
-        ret extent(ptr_width, ptr_width);
-    }
-    # all ten vector shapes are 128-bit and 16-byte aligned (#1965).
-    if (t.kind == type.TYPE_VECTOR) { ret extent(16, 16); }
-
-    if (t.kind == type.TYPE_ARRAY) {
-        val e: Extent = extent_walk(s, ptr_width, t.data.array.base, depth + 1);
-        if (!e.ok) { ret no_extent(); }
-        # widen the product: a >4GiB array would wrap a u32 and report a wrong extent,
-        # so it declines rather than answering wrongly.
-        val total: u64 = e.size::u64 * t.data.array.count::u64;
-        if (total > 4294967295) { ret no_extent(); }
-        ret extent(total::u32, e.align);
-    }
-
-    if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI || t.kind == type.TYPE_INSTANCE) {
-        ret nominal_extent(s, ptr_width, base, t.kind, depth);
-    }
-
-    # a generic parameter, a comptime pack, or any kind not measured above has no
-    # storage extent here - FAIL CLOSED rather than answer with a default.
-    ret no_extent();
-}
-
-# the extent of a record / union / generic instance, folding its field table
-fun nominal_extent(s: *session.Session, ptr_width: u32, tid: type.TypeId, kind: type.TypeKind, depth: u32) Extent {
-    if (kind == type.TYPE_INSTANCE) { ensure_fields(s, tid); }
-    # a `rec` and a `uni` instantiate to structurally identical TYPE_INSTANCEs, so the
-    # instance's own kind says nothing about how its fields are placed; the nominal it
-    # carries (#2239) is what decides sequential against overlapping.
-    val ov: O.Option[bool] = nominal_overlays(s, tid);
-    if (O.is_none[bool](ov)) { ret no_extent(); }
-    val overlays: bool = O.unwrap[bool](ov);
-
-    val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, tid);
-    if (O.is_none[*type.FieldTable](opt_tab)) { ret no_extent(); }
-    val n: u32 = O.unwrap[*type.FieldTable](opt_tab).fields_len;
-
-    var align:    u32 = 1;
-    var offset:   u32 = 0;
-    var widest:   u32 = 0;
-    var f:        u32 = 0;
-    for (f < n) {
-        val fe: O.Option[*type.FieldEntry] = type.field_at(?s.types, tid, f);
-        if (O.is_none[*type.FieldEntry](fe)) { ret no_extent(); }
-        val e: Extent = extent_walk(s, ptr_width, O.unwrap[*type.FieldEntry](fe).ty, depth + 1);
-        if (!e.ok) { ret no_extent(); }
-        if (e.align > align) { align = e.align; }
-        if (overlays) {
-            if (e.size > widest) { widest = e.size; }
-        }
-        or {
-            offset = round_up(offset, e.align);
-            offset = offset + e.size;
-        }
-        f = f + 1;
-    }
-
-    # an `#[align(...)]` override raises the alignment (never lowers it), which also
-    # rounds the total size up to the larger alignment.
-    val ta: O.Option[u32] = session.type_align(s, tid::u32);
-    if (O.is_some[u32](ta)) {
-        val forced: u32 = O.unwrap[u32](ta);
-        if (forced > align) { align = forced; }
-    }
-
-    if (overlays) { ret extent(round_up(widest, align), align); }
-    ret extent(round_up(offset, align), align);
+pub fun type_extent(s: *session.Session, ptr_width: u32, tid: type.TypeId) layout.Extent {
+    ret layout.extent_of(s::ptr, describe_type, describe_type_field, tid::u32, ptr_width);
 }
 
 # whether nominal `tid` overlays every field at offset 0 (a union) rather than laying
@@ -670,8 +613,8 @@ fun sse_deep_walk(s: *session.Session, ptr_width: u32, a: type.TypeId, b: type.T
             val ty_b: type.TypeId = O.unwrap[*type.FieldEntry](fb).ty;
             if (!sse_deep_walk(s, ptr_width, ty_a, ty_b, scan)) { ret false; }
 
-            val ea: Extent = type_extent(s, ptr_width, ty_a);
-            val eb: Extent = type_extent(s, ptr_width, ty_b);
+            val ea: layout.Extent = type_extent(s, ptr_width, ty_a);
+            val eb: layout.Extent = type_extent(s, ptr_width, ty_b);
             if (!ea.ok || !eb.ok)                           { ret false; }
             if (ea.size != eb.size || ea.align != eb.align) { ret false; }
             f = f + 1;

--- a/src/lang/layout.mach
+++ b/src/lang/layout.mach
@@ -1,0 +1,268 @@
+# mach.lang.layout: the aggregate-layout policy both type universes fold through
+#
+# The single source of truth for how a type occupies storage (#2289). Both the front
+# end (sema, over `lang.type` TypeIds) and the back end (`me.ir.type`, over IrTypeIds)
+# describe their own nodes to this module and read the resulting size / alignment /
+# field offset here, so the two never drift and the rule lives in one place.
+#
+# WHY THIS IS A SHARED POLICY AND NOT A CONVENIENCE. Sema's deep secrecy-placement
+# check decides whether two aggregates may overlay each other by comparing their BYTE
+# EXTENTS. If sema's idea of a layout and the backend's ever disagreed, sema would
+# admit an overlay the emitted layout does not produce - a public field landing on a
+# secret's bytes, which is exactly the disclosure #2289 documents. That makes a second
+# layout implementation a drift risk on the PERMISSIVE side of a security boundary:
+# while the copies agree everything looks correct, and when they diverge the failure is
+# a silent under-rejection. One policy removes the failure mode by construction rather
+# than detecting it after the fact.
+#
+# A leaf module (no compiler-internal dependencies) so both fe.sema and me.ir import it
+# without a cycle - the same shape as `mach.lang.ct`, the constant-time table the front
+# and back ends likewise share.
+#
+# THE POLICY. Natural C-style layout:
+#   - a void occupies nothing and aligns to 1
+#   - a scalar occupies its own width and aligns to it
+#   - a pointer or function value occupies the target's pointer width and aligns to it
+#   - an array is `count` elements of the element's size, aligned as the element
+#   - a RECORD lays its fields out sequentially, rounding each up to its own alignment
+#   - a UNION overlays every field at offset 0 and takes the widest
+#   - either aggregate's alignment is the maximum of its fields', which an
+#     `#[align(...)]` override may RAISE but never lower, and its total size is rounded
+#     up to that alignment
+# A field's offset therefore depends only on the fields BEFORE it, never on later ones
+# or on the aggregate's own alignment - the property sema's placement comparison relies
+# on to pair two aggregates' prefixes.
+#
+# THE SEAM. A caller supplies an erased context plus two accessors - one describing a
+# node, one naming a field's node - mirroring the `fun(ptr, ...)` callback the comptime
+# resolvers already use. Every walk is depth-bounded and reports `ok = false` rather
+# than guessing, so a caller that must fail closed can, and one that treats a malformed
+# graph as a compiler bug can panic on it.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+
+# how a node occupies storage; the discriminator for `Node`
+pub def NodeKind: u8;
+
+# a node this describer cannot classify; yields `ok = false`
+pub val NODE_UNKNOWN:   NodeKind = 0;
+# an integer or float of `bytes` width, aligned to its width
+pub val NODE_SCALAR:    NodeKind = 1;
+# a pointer or function value: the target's pointer width, aligned to it
+pub val NODE_POINTER:   NodeKind = 2;
+# a 128-bit vector: 16 bytes, 16-byte aligned
+pub val NODE_VECTOR:    NodeKind = 3;
+# `count` elements of node `child`
+pub val NODE_ARRAY:     NodeKind = 4;
+# a record or union of `field_count` fields; `overlays` selects which
+pub val NODE_AGGREGATE: NodeKind = 5;
+# a node occupying no storage (a void), which still aligns to 1 so it neither moves a
+# following field nor lowers an enclosing aggregate's alignment
+pub val NODE_ZERO:      NodeKind = 6;
+
+# one type node, described by the caller in terms this policy folds
+#
+# Only the fields its `kind` selects are read, so a describer fills the rest with
+# anything. A `kind` of NODE_UNKNOWN - or any node the describer cannot resolve -
+# propagates as `ok = false` through every enclosing extent.
+# ---
+# kind:        which storage shape this node has
+# bytes:       NODE_SCALAR: the scalar's width in bytes
+# count:       NODE_ARRAY: the element count
+# child:       NODE_ARRAY: the element's node id
+# field_count: NODE_AGGREGATE: the number of fields
+# decl_align:  NODE_AGGREGATE: an `#[align(...)]` override, 0 for none
+# overlays:    NODE_AGGREGATE: true for a union (fields at offset 0), false for a record
+pub rec Node {
+    kind:        NodeKind;
+    bytes:       u32;
+    count:       u32;
+    child:       u32;
+    field_count: u32;
+    decl_align:  u32;
+    overlays:    bool;
+}
+
+# describe node `id` within the caller's erased context
+pub def NodeFn: fun(ptr, u32) Node;
+
+# the node id of field `index` of aggregate node `id`, within the caller's erased
+# context. Only called for indices below the aggregate's reported `field_count`
+pub def FieldFn: fun(ptr, u32, u32) u32;
+
+# a node's storage size and alignment, or the fact that neither could be determined
+#
+# `ok` is false when any part of the walk could not be resolved - an unknown node kind,
+# an unresolvable field, an array whose total would not fit, or a graph past the depth
+# bound. Callers that must fail closed test it; callers for whom a malformed graph is a
+# compiler bug panic on it.
+# ---
+# ok:    whether size and align were determined
+# size:  the size in bytes
+# align: the alignment in bytes (>= 1 when ok)
+pub rec Extent {
+    ok:    bool;
+    size:  u32;
+    align: u32;
+}
+
+# the depth bound on a layout walk; a graph deeper than this reports `ok = false`
+val MAX_DEPTH: u32 = 64;
+
+# the largest total an array may occupy; a bigger product would wrap a u32 and report a
+# wrong extent, so it declines instead
+val MAX_SIZE: u64 = 4294967295;
+
+# an Extent that could not be determined
+pub fun unknown_extent() Extent {
+    var e: Extent;
+    e.ok    = false;
+    e.size  = 0;
+    e.align = 0;
+    ret e;
+}
+
+# a determined Extent
+pub fun extent(size: u32, align: u32) Extent {
+    var e: Extent;
+    e.ok    = true;
+    e.size  = size;
+    e.align = align;
+    ret e;
+}
+
+# a Node of the given kind with every other field cleared, for a describer to fill
+pub fun node(kind: NodeKind) Node {
+    var n: Node;
+    n.kind        = kind;
+    n.bytes       = 0;
+    n.count       = 0;
+    n.child       = 0;
+    n.field_count = 0;
+    n.decl_align  = 0;
+    n.overlays    = false;
+    ret n;
+}
+
+# round `value` up to the next multiple of `align`
+#
+# An alignment of 0 or 1 returns `value` unchanged. The one arithmetic primitive the
+# whole policy is built from.
+# ---
+# value: the value to align
+# align: the alignment to round up to (a power of two)
+# ret:   the smallest multiple of `align` that is >= `value`
+pub fun round_up(value: u32, align: u32) u32 {
+    if (align <= 1) { ret value; }
+    val rem: u32 = value % align;
+    if (rem == 0) { ret value; }
+    ret value + (align - rem);
+}
+
+# the storage size and alignment of node `id`
+# ---
+# ctx:       the caller's erased context, passed back to both accessors
+# describe:  names a node's storage shape
+# field:     names an aggregate's field node ids
+# id:        the node to measure
+# ptr_width: the target's pointer width in bytes
+# ret:       the determined Extent, or `ok = false` when it cannot be computed
+pub fun extent_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32) Extent {
+    ret walk(ctx, describe, field, id, ptr_width, 0);
+}
+
+# the byte offset of field `field_ix` within aggregate node `id`
+#
+# A union's fields all overlay at offset 0. A record's offset is the fold over the
+# fields BEFORE it, which is why it never depends on the aggregate's own alignment.
+# ---
+# ctx:       the caller's erased context
+# describe:  names a node's storage shape
+# field:     names an aggregate's field node ids
+# id:        the aggregate node
+# field_ix:  the zero-based field index
+# ptr_width: the target's pointer width in bytes
+# ret:       an Extent whose `size` is the offset, or `ok = false` when undeterminable
+pub fun field_offset_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, field_ix: u32, ptr_width: u32) Extent {
+    val n: Node = describe(ctx, id);
+    if (n.kind != NODE_AGGREGATE)  { ret unknown_extent(); }
+    if (field_ix >= n.field_count) { ret unknown_extent(); }
+    if (n.overlays)                { ret extent(0, 1); }
+
+    var offset: u32 = 0;
+    var i:      u32 = 0;
+    for (i < n.field_count) {
+        val fe: Extent = walk(ctx, describe, field, field(ctx, id, i), ptr_width, 1);
+        if (!fe.ok) { ret unknown_extent(); }
+        offset = round_up(offset, fe.align);
+        if (i == field_ix) { ret extent(offset, fe.align); }
+        offset = offset + fe.size;
+        i = i + 1;
+    }
+    ret unknown_extent();
+}
+
+# the recursive worker for `extent_of`, bounding the graph depth
+fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, depth: u32) Extent {
+    if (depth > MAX_DEPTH) { ret unknown_extent(); }
+
+    val n: Node = describe(ctx, id);
+
+    if (n.kind == NODE_ZERO)    { ret extent(0, 1); }
+    if (n.kind == NODE_SCALAR)  { ret extent(n.bytes, n.bytes); }
+    if (n.kind == NODE_POINTER) { ret extent(ptr_width, ptr_width); }
+    if (n.kind == NODE_VECTOR)  { ret extent(16, 16); }
+
+    if (n.kind == NODE_ARRAY) {
+        val e: Extent = walk(ctx, describe, field, n.child, ptr_width, depth + 1);
+        if (!e.ok) { ret unknown_extent(); }
+        # widen the product: a total past a u32 would wrap and report a wrong extent.
+        val total: u64 = e.size::u64 * n.count::u64;
+        if (total > MAX_SIZE) { ret unknown_extent(); }
+        ret extent(total::u32, e.align);
+    }
+
+    if (n.kind == NODE_AGGREGATE) {
+        var align:  u32 = 1;
+        var offset: u32 = 0;
+        var widest: u32 = 0;
+        var i:      u32 = 0;
+        for (i < n.field_count) {
+            val e: Extent = walk(ctx, describe, field, field(ctx, id, i), ptr_width, depth + 1);
+            if (!e.ok) { ret unknown_extent(); }
+            if (e.align > align) { align = e.align; }
+            if (n.overlays) {
+                if (e.size > widest) { widest = e.size; }
+            }
+            or {
+                offset = round_up(offset, e.align);
+                offset = offset + e.size;
+            }
+            i = i + 1;
+        }
+        # an `#[align(...)]` override raises the alignment, which also rounds the total
+        # size up to the larger alignment. it never lowers it.
+        if (n.decl_align > align) { align = n.decl_align; }
+        if (n.overlays) { ret extent(round_up(widest, align), align); }
+        ret extent(round_up(offset, align), align);
+    }
+
+    # NODE_UNKNOWN, and any kind a future describer adds without teaching this fold.
+    ret unknown_extent();
+}
+
+# the policy's own arithmetic, pinned independently of either type universe: rounding
+# is identity at alignment 0 / 1, a no-op on an already-aligned value, and otherwise
+# lifts to the next multiple.
+test "mach.lang.layout.round_up:cases" {
+    if (round_up(0, 0)   != 0)  { ret 1; }
+    if (round_up(7, 1)   != 7)  { ret 1; }
+    if (round_up(8, 4)   != 8)  { ret 1; }
+    if (round_up(9, 4)   != 12) { ret 1; }
+    if (round_up(1, 8)   != 8)  { ret 1; }
+    if (round_up(16, 16) != 16) { ret 1; }
+    if (round_up(17, 16) != 32) { ret 1; }
+    ret 0;
+}

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -15,10 +15,13 @@
 #   - Integer width lives in bits on the `IRT_INT` payload, float width likewise
 #     on `IRT_FLOAT`.
 #
-# `byte_size` / `byte_align` are target-aware: pointer size and alignment come
-# from the target ISA's `pointer_width`. Aggregate layout follows the natural
-# C-style rule (each field aligned to its own alignment, struct alignment is the
-# max field alignment, total size rounded up to that).
+# `byte_size` / `byte_align` / `byte_offset` are target-aware (pointer size comes from
+# the target ISA's `pointer_width`) and are ADAPTERS over `mach.lang.layout`, the shared
+# natural-C-style layout policy sema folds through as well. The rule lives there, in one
+# place, because sema's secrecy-placement check decides overlay safety from byte extents:
+# a second copy here that drifted from it would let sema admit an overlay this layout does
+# not produce, which is the disclosure #2289 documents. This module's job is to DESCRIBE an
+# IR node to that policy, not to re-derive the fold.
 
 use std.allocator.page;
 use std.collections.map;
@@ -35,6 +38,7 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use mach.lang.layout;
 use mach.lang.target.isa;
 use target: mach.lang.target.resolved;
 
@@ -427,76 +431,102 @@ pub fun intern_fn(t: *IrTypeTable, ret_type: IrTypeId, params: *IrTypeId, param_
     ret intern_owned(t, probe, params, param_count);
 }
 
+# describe one IrType to the shared layout policy (a layout.NodeFn)
+#
+# The IR half of the #2289 seam: it names each IR kind's storage shape and leaves the
+# fold itself to `mach.lang.layout`, which sema drives over its own type universe
+# through the matching describer. Every IR kind is classified, so an unknown node here
+# means the table handed out an id it does not hold.
+# ---
+# ctx: the *IrTypeTable, erased
+# id:  the IrTypeId to describe
+# ret: the node's layout shape, or a NODE_UNKNOWN node for an out-of-range id
+fun describe_node(ctx: ptr, id: u32) layout.Node {
+    val t: *IrTypeTable = ctx::*IrTypeTable;
+    if (id >= t.len) { ret layout.node(layout.NODE_UNKNOWN); }
+    val ir: *IrType = ?t.types[id];
+
+    if (ir.kind == IRT_VOID) { ret layout.node(layout.NODE_ZERO); }
+    if (ir.kind == IRT_INT || ir.kind == IRT_FLOAT) {
+        var n: layout.Node = layout.node(layout.NODE_SCALAR);
+        n.bytes = bits_to_bytes(ir.data.bits);
+        ret n;
+    }
+    # a first-class `fun(...)` value is a function pointer, so it lays out as one.
+    if (ir.kind == IRT_PTR || ir.kind == IRT_FN) { ret layout.node(layout.NODE_POINTER); }
+    # all ten vector shapes are 128-bit (#1965).
+    if (ir.kind == IRT_VECTOR) { ret layout.node(layout.NODE_VECTOR); }
+    if (ir.kind == IRT_ARRAY) {
+        var n: layout.Node = layout.node(layout.NODE_ARRAY);
+        n.child = ir.data.array_.element;
+        n.count = ir.data.array_.count;
+        ret n;
+    }
+    if (ir.kind == IRT_STRUCT || ir.kind == IRT_UNION) {
+        var n: layout.Node = layout.node(layout.NODE_AGGREGATE);
+        n.field_count = ir.data.struct_.field_count;
+        n.decl_align  = ir.data.struct_.align;
+        n.overlays    = ir.kind == IRT_UNION;
+        ret n;
+    }
+    ret layout.node(layout.NODE_UNKNOWN);
+}
+
+# name field `index` of aggregate `id` (a layout.FieldFn)
+fun describe_field(ctx: ptr, id: u32, index: u32) u32 {
+    val t: *IrTypeTable = ctx::*IrTypeTable;
+    if (id >= t.len) { ret IRT_NIL; }
+    val ir: *IrType = ?t.types[id];
+    if (ir.kind != IRT_STRUCT && ir.kind != IRT_UNION) { ret IRT_NIL; }
+    if (index >= ir.data.struct_.field_count)          { ret IRT_NIL; }
+    ret ir.data.struct_.fields[index];
+}
+
+# the extent of `id` under the shared policy, panicking on a graph it cannot fold
+#
+# An unresolvable extent means a stale handle or a malformed table - what the verifier's
+# VC_TYPE_RESOLVE rules out - so it panics rather than silently answering 0, preserving
+# the contract these three entry points have always had.
+fun ir_extent(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target, what: str) layout.Extent {
+    val e: layout.Extent = layout.extent_of(t::ptr, describe_node, describe_field, id, ptr_width_of(tgt));
+    if (!e.ok) { panic(what); }
+    ret e;
+}
+
+# the target's pointer width, which every layout query needs
+#
+# A Target with no ISA is not a resolved target and cannot answer this. The layout
+# reads the width up front rather than only on reaching a pointer, so an unresolved
+# target is reported here instead of surfacing as a fault deep in a walk - or, worse,
+# going unnoticed on the types that happen not to contain a pointer.
+fun ptr_width_of(tgt: *target.Target) u32 {
+    if (tgt == nil || tgt.isa == nil) {
+        panic("ir.type: layout query needs a resolved target with an instruction set\n");
+    }
+    ret tgt.isa.pointer_width;
+}
+
 # the size in bytes of an IR type for the given target
 #
-# Pointer size comes from `tgt.isa.pointer_width`. Aggregates use natural
-# C-style layout. A function type sizes as a pointer (a first-class `fun(...)`
-# value is a function pointer) and IRT_VOID is 0. An out-of-range id is a stale
-# handle the verifier's VC_TYPE_RESOLVE rules out, so it panics rather than
-# silently sizing to 0.
+# Pointer size comes from `tgt.isa.pointer_width`. Aggregates use the natural C-style
+# layout the shared `mach.lang.layout` policy defines, which sema folds through as well
+# so the two can never disagree (#2289). IRT_VOID is 0. An out-of-range id is a stale
+# handle the verifier's VC_TYPE_RESOLVE rules out, so it panics rather than silently
+# sizing to 0.
 # ---
 # t:   the table
 # id:  IrTypeId to measure
 # tgt: resolved compilation target supplying pointer width via its ISA
 # ret: size in bytes
 pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
-    if (id >= t.len) { panic("ir.type.byte_size: type id out of range\n"); }
-    val ir: *IrType = ?t.types[id];
-
-    if (ir.kind == IRT_VOID)                        { ret 0; }
-    if (ir.kind == IRT_INT || ir.kind == IRT_FLOAT) { ret bits_to_bytes(ir.data.bits); }
-    # a first-class `fun(...)` value is a function pointer, so it sizes as one.
-    if (ir.kind == IRT_PTR || ir.kind == IRT_FN) { ret tgt.isa.pointer_width; }
-
-    if (ir.kind == IRT_ARRAY) {
-        ret byte_size(t, ir.data.array_.element, tgt) * ir.data.array_.count;
-    }
-    # all ten vector shapes are 128-bit (#1965).
-    if (ir.kind == IRT_VECTOR) { ret 16; }
-
-    if (ir.kind == IRT_STRUCT) {
-        var offset: u32 = 0;
-        var align:  u32 = 1;
-        var i:      u32 = 0;
-        for (i < ir.data.struct_.field_count) {
-            val fid:         IrTypeId = ir.data.struct_.fields[i];
-            val field_align: u32      = byte_align(t, fid, tgt);
-            val field_size:  u32      = byte_size(t, fid, tgt);
-            offset = round_up(offset, field_align);
-            offset = offset + field_size;
-            if (field_align > align) { align = field_align; }
-            i = i + 1;
-        }
-        # an `#[align(...)]` override raises alignment (never lowers it), which
-        # also rounds the total size up to the larger alignment.
-        if (ir.data.struct_.align > align) { align = ir.data.struct_.align; }
-        ret round_up(offset, align);
-    }
-
-    if (ir.kind == IRT_UNION) {
-        var size:  u32 = 0;
-        var align: u32 = 1;
-        var i:     u32 = 0;
-        for (i < ir.data.struct_.field_count) {
-            val fid:         IrTypeId = ir.data.struct_.fields[i];
-            val field_size:  u32      = byte_size(t, fid, tgt);
-            val field_align: u32      = byte_align(t, fid, tgt);
-            if (field_size > size)   { size = field_size; }
-            if (field_align > align) { align = field_align; }
-            i = i + 1;
-        }
-        if (ir.data.struct_.align > align) { align = ir.data.struct_.align; }
-        ret round_up(size, align);
-    }
-
-    ret 0;
+    ret ir_extent(t, id, tgt, "ir.type.byte_size: type id out of range\n").size;
 }
 
 # the alignment in bytes of an IR type for the given target
 #
 # Pointer alignment equals pointer width (a function type aligns as a pointer).
-# Struct alignment is the max of its field alignments (1 for an empty struct).
-# IRT_VOID aligns to 1. An out-of-range id is a stale handle the verifier's
+# Aggregate alignment is the max of its field alignments, raised by an `#[align(...)]`
+# override; IRT_VOID aligns to 1. An out-of-range id is a stale handle the verifier's
 # VC_TYPE_RESOLVE rules out, so it panics rather than silently aligning to 1.
 # ---
 # t:   the table
@@ -504,81 +534,27 @@ pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
 # tgt: resolved compilation target supplying pointer width via its ISA
 # ret: alignment in bytes (always >= 1)
 pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
-    if (id >= t.len) { panic("ir.type.byte_align: type id out of range\n"); }
-    val ir: *IrType = ?t.types[id];
-
-    if (ir.kind == IRT_INT || ir.kind == IRT_FLOAT) { ret bits_to_bytes(ir.data.bits); }
-    # a function value is a function pointer; align as one.
-    if (ir.kind == IRT_PTR || ir.kind == IRT_FN) { ret tgt.isa.pointer_width; }
-    if (ir.kind == IRT_ARRAY)                    { ret byte_align(t, ir.data.array_.element, tgt); }
-    # 128-bit vectors are 16-byte aligned (#1965).
-    if (ir.kind == IRT_VECTOR)                   { ret 16; }
-
-    if (ir.kind == IRT_STRUCT || ir.kind == IRT_UNION) {
-        var align: u32 = 1;
-        var i:     u32 = 0;
-        for (i < ir.data.struct_.field_count) {
-            val field_align: u32 = byte_align(t, ir.data.struct_.fields[i], tgt);
-            if (field_align > align) { align = field_align; }
-            i = i + 1;
-        }
-        # an `#[align(...)]` override raises alignment above the natural maximum.
-        if (ir.data.struct_.align > align) { align = ir.data.struct_.align; }
-        ret align;
-    }
-
-    # IRT_VOID and any unhandled kind align to 1.
-    ret 1;
+    ret ir_extent(t, id, tgt, "ir.type.byte_align: type id out of range\n").align;
 }
 
-# the byte offset of field `field_ix` within struct type `id`
+# the byte offset of field `field_ix` within aggregate type `id`
 #
-# Uses the same natural C-style layout as byte_size; a union's members all
-# overlap at offset 0. An out-of-range id, a non-aggregate type, or a field
-# index past the struct's fields are all malformed inputs the front end and
-# verifier rule out, so each panics rather than silently landing on field 0.
+# Uses the same shared layout policy as byte_size; a union's members all overlap at
+# offset 0. An out-of-range id, a non-aggregate type, or a field index past the
+# aggregate's fields are all malformed inputs the front end and verifier rule out, so
+# each panics rather than silently landing on field 0.
 # ---
 # t:        the table
-# id:       the struct IrTypeId
+# id:       the aggregate IrTypeId
 # field_ix: zero-based field index
 # tgt:      resolved compilation target supplying pointer width via its ISA
 # ret:      byte offset of the field
 pub fun byte_offset(t: *IrTypeTable, id: IrTypeId, field_ix: u32, tgt: *target.Target) u32 {
-    if (id >= t.len) { panic("ir.type.byte_offset: type id out of range\n"); }
-    val ir: *IrType = ?t.types[id];
-
-    # a union's members all overlap at offset 0.
-    if (ir.kind == IRT_UNION)  { ret 0; }
-    if (ir.kind != IRT_STRUCT) { panic("ir.type.byte_offset: field offset of a non-aggregate type\n"); }
-
-    var offset: u32 = 0;
-    var i:      u32 = 0;
-    for (i < ir.data.struct_.field_count) {
-        val fid: IrTypeId = ir.data.struct_.fields[i];
-        offset = round_up(offset, byte_align(t, fid, tgt));
-        if (i == field_ix) { ret offset; }
-        offset = offset + byte_size(t, fid, tgt);
-        i = i + 1;
-    }
-
-    panic("ir.type.byte_offset: field index out of range\n");
-    ret 0;
+    val e: layout.Extent = layout.field_offset_of(t::ptr, describe_node, describe_field, id, field_ix, ptr_width_of(tgt));
+    if (!e.ok) { panic("ir.type.byte_offset: field offset of a non-aggregate type or out-of-range index\n"); }
+    ret e.size;
 }
 
-# round `value` up to the next multiple of `align`
-#
-# An alignment of 0 or 1 returns `value` unchanged. Used by the natural C-style
-# aggregate-layout computations.
-# ---
-# value: the value to align
-# align: the alignment to round up to (a power of two)
-# ret:   the smallest multiple of `align` that is >= `value`
-fun round_up(value: u32, align: u32) u32 {
-    if (align <= 1) { ret value; }
-    val rem: u32 = value % align;
-    if (rem == 0) { ret value; }
-    ret value + (align - rem);
-}
 
 # intern a kind whose IrType is a complete, self-contained key - no
 # externally-owned payload to copy (void/int/float/ptr and arrays, whose element


### PR DESCRIPTION
Closes #2306

Follow-up to #2279, which closed #2289. That fix is correct and the leak is shut — but it satisfied the issue's bar the weaker way, and this replaces it with the structural one. The hazard is tracked as #2306.

## What was wrong with how it landed

#2289's bar asks for **"one shared layout policy consulted by both, with a differential test pinning sema's answer against the IR's, not a copy that happens to agree today."**

What merged was the copy plus the differential test. `generics.type_extent` re-derived the natural C-style fold that `me/ir/type.mach` already owned, and `secrecy_layout_matches_lowering` pinned the two together.

That **detects** drift. It does not **prevent** it — and this is drift on the *permissive side of a security boundary*. While the copies agree everything looks correct; when they diverge, the failure is sema admitting an overlay the emitted layout does not produce, i.e. a public field landing on a secret's bytes, which is exactly the disclosure #2289 documents. A test catches drift after someone writes it; construction prevents it from being writable.

## The change

`mach.lang.layout` now owns the fold, and both type universes **describe** their nodes to it:

- an erased context plus a node describer and a field accessor — the same `fun(ptr, ...)` seam `comptime.FieldMemberFn` / `ModuleMemberFn` / `TypeIdentFn` already use, so no new construct
- a leaf module with no compiler-internal dependencies, exactly like `mach.lang.ct`, the constant-time table the front and back ends likewise share — the established precedent here for "one policy, two enforcement points"

`ir_type.byte_size` / `byte_align` / `byte_offset` **keep their signatures** and become adapters, so all **43 call sites** across ABI, MIR lowering, LICM, SROA, constagg, codegen and DWARF are untouched. `generics.type_extent` is the matching adapter. Incidentally the fold now computes size and alignment together, where the IR version re-walked the subgraph once per query.

## Is `secrecy_layout_matches_lowering` now unnecessary?

**No — and that is not a sign the refactor is incomplete.** Reporting this plainly because the bar asks the question directly.

The **fold** can no longer drift; there is one of it, and mutating it moves both consumers at once. What remains is that each side **describes** its own type universe, and the two describers derive the same facts by independent routes:

| fact | IR describer | sema describer |
|---|---|---|
| scalar width | `(bits + 7) / 8` | `bits / 8` |
| union-ness | `ir.kind == IRT_UNION` | `aggregate_nominal(...).kind == TYPE_UNI` |

The second pair is not hypothetical. **That is precisely what disagreed in #2239**, where a generic union instance was given struct layout.

This is irreducible short of collapsing the two type universes into one, which is a non-goal — IR types exist *because* they are a resolved subset of semantic types, so a description step is inherent rather than an artifact. The test has therefore moved from covering "the fold might differ" (now impossible) to covering "the two descriptions might differ" (still possible, with history).

So the test is kept, **re-aimed, and its corpus now stresses that surface**: a generic union instance, which discriminates sharply (`G[u64]` is 8 bytes as the union it is, and would be 16 laid out sequentially), plus a generic record instance pinning the false side of the same derivation.

**Proven load-bearing by mutating each describer independently:**

| seam mutation | result | caught by |
|---|---|---|
| sema describer reports "never a union" (IR still correct) | **911 / 1** | `secrecy_layout_matches_lowering` — **the only test that catches it** |
| IR describer reports "never a union" (sema still correct) | **911 / 1** | `generic_layout_runtime` (#2239's own test) |

Without this test, a sema-side describer divergence would be silent. It earns its keep.

## Verification

**Byte-identity, linux-x86_64 release: identical** across the whole compiler, comparing the merge-base compiler against this one on identical source. I also ran `-g` (already done before the bar was trimmed, so at no extra cost) — **also identical**, and that is the run which exercises DWARF's own `byte_size` / `byte_offset`, which the release comparison never reaches.

**Three-generation fixpoint: `B == C`** (`77f1c7b8…`) — kept, since this touches layout and genuinely could break it.

Suites: mach **912 / 0**; mach-std **611 / 0** at pin `eff1e8e`.

Behaviour re-verified through the new seam: all five #2289 leak shapes rejected, #2167's case accepted, #2191's gate unaffected.

### All six of #2279's mutations, re-run through the new seam

| # | mutation | result |
|---|---|---|
| A | #2191 address gate short-circuited to always-accept | **911 / 1** |
| B | #2191 pointer-only precondition dropped | **910 / 2** |
| C | #2196 literal re-committed to the secret type | **911 / 1** |
| D | #2289 byte-extent equality on paired fields dropped | **911 / 1** |
| E | #2167 union/overlay precondition dropped | **911 / 1** |
| F | `#[align(...)]` override ignored — **the tripwire** | **910 / 2** |

**F is intact and strictly stronger.** It moved from 1 failure to 2: one edit now fails the sema differential *and* the IR layout test, because both read the one policy.

Two further mutations of the shared fold, which had no equivalent before — under the old arrangement, mutating sema's private copy could not touch codegen at all:

| mutation | result |
|---|---|
| per-field alignment rounding dropped in a record | **505 / 407** |
| union laid out sequentially instead of overlapping | **245 / 667** |

## One deliberate behaviour change

A layout query now reads the target's pointer width **up front** rather than only on reaching a pointer. A `Target` with no ISA is not a resolved target and cannot answer it, so that is reported as the malformed input it is, instead of faulting deep in a walk — or going unnoticed on types that happen to contain no pointer, which is how it previously passed.

`mir.context.vector_scaffolding` was relying on that accident (register classes, no ISA, only vectors and integers measured); it now builds a resolved target, as every other layout-calling test already did. I chose the loud precondition over a nil-guard deliberately: a silent fallback there is the same class of thing that let #2289 hide.
