### PR TITLE
docs(abi): record the measured answer next to MAX_REG_RET (#2293)

### DIFF
--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -110,6 +110,10 @@ pub val STACK_ALIGN: u32 = 16;
 pub val RED_ZONE:    u32 = 0;
 # largest aggregate size in bytes passed/returned in registers; anything larger is
 # passed/returned by hidden reference
+#
+# `Result[T, str]` crossing this boundary at 24 -> 16 bytes reclassified it from X8 sret
+# to the X0:X1 pair here exactly as under SysV; see the measurement recorded at
+# `sysv.MAX_REG_RET` (#2293).
 pub val MAX_REG_RET: u64 = 16;
 
 # local aliases of the neutral vtable function signatures (`mach.lang.target.abi`).

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -83,6 +83,10 @@ pub val STACK_ALIGN: u32 = 16;
 pub val RED_ZONE:    u32 = 0;
 # largest aggregate size in bytes passed/returned in registers; anything larger is
 # passed/returned by hidden reference (2 * XLEN)
+#
+# `Result[T, str]` crossing this boundary at 24 -> 16 bytes reclassified it from A0 sret
+# to the A0:A1 pair here exactly as under SysV; see the measurement recorded at
+# `sysv.MAX_REG_RET` (#2293).
 pub val MAX_REG_RET: u64 = 16;
 
 # the integer argument register for a zero-based argument-register index, or -1

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -67,6 +67,19 @@ pub val STACK_ALIGN: u32 = 16;
 pub val RED_ZONE:    u32 = 128;
 # largest aggregate size in bytes that may be returned in registers; anything
 # larger is returned via a hidden sret pointer
+#
+# MEASURED, not assumed (#2293). #2239 shrank `Result[T, str]` from 24 bytes to 16,
+# crossing this boundary and reclassifying 3,843 of the compiler's 12,655 functions and
+# 11,618 of its ~57,400 call sites from sret to the register pair. Isolated on two
+# otherwise identical structs returned across 12M opaque calls, the register pair costs
+# 2 FEWER instructions per call than the sret form, so the boundary is placed correctly
+# for this shape and the value must not be raised on that evidence.
+#
+# It is the wrong lever for the residual `Result` cost (#2315): the release text growth
+# that accompanied the shrink is not this boundary at all - it appears on win64 too,
+# where 16 bytes stays sret - but SROA declining to split an aggregate that is now
+# honestly a union. This value is also load-bearing for `extern` interop and cannot move
+# for mach-internal reasons alone.
 pub val MAX_REG_RET: u64 = 16;
 
 # the GP argument register for a zero-based argument-register index

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -90,6 +90,10 @@ pub val SHADOW_SPACE: u64 = 32;
 # win64 admits exactly the power-of-two sizes 1, 2, 4, and 8: a 1/2/4/8-byte
 # record fits one register, while 3/5/6/7-byte and >8-byte records are passed by
 # hidden reference and returned through an sret pointer.
+#
+# This rule, not a 16-byte boundary, is why win64 is the one convention where
+# `Result[T, str]` did NOT change class when #2239 shrank it from 24 bytes to 16 - both
+# stay sret. `Result[u32, u32]` at 12 -> 8 bytes did move here, and only here (#2293).
 # ---
 # size: aggregate size in bytes
 # ret:  true if the aggregate rides in one register by value


### PR DESCRIPTION
Refs #2293. Measurement only — **no threshold changes**.

The full numbers are posted as a comment on #2293. This PR is the part the issue asked to live in the tree: the answer written down next to the threshold it concerns, plus the win64 note explaining why that one convention did not reclassify.

Headline: the compiler self-build runs **−12.0% instructions** after #2278, the ABI class flip itself is worth **2 instructions per call** in favour of the register pair, and the +2.6% release text growth is **not** this boundary — it is SROA declining to split an aggregate that is now honestly a union.