### PR TITLE
feat(me): vectorize affine loop indices

### DIFF
--- a/int/surface/vectorize-emit/expect.linux-arm64.txt
+++ b/int/surface/vectorize-emit/expect.linux-arm64.txt
@@ -1,5 +1,17 @@
 arch=aarch64
 add_i32k simd
+aff_const_dep scalar
+aff_cursor simd
+aff_cursor2 scalar
+aff_glob simd
+aff_load simd
+aff_matmul_row simd
+aff_ptr simd
+aff_reduce simd
+aff_reverse scalar
+aff_shift_dep scalar
+aff_store simd
+aff_stride2 scalar
 axpy_f32 simd
 carried_i32 scalar
 cond_i32 scalar

--- a/int/surface/vectorize-emit/expect.linux-arm64.txt
+++ b/int/surface/vectorize-emit/expect.linux-arm64.txt
@@ -3,6 +3,7 @@ add_i32k simd
 aff_const_dep scalar
 aff_cursor simd
 aff_cursor2 scalar
+aff_cursor_k simd
 aff_glob simd
 aff_load simd
 aff_matmul_row simd

--- a/int/surface/vectorize-emit/expect.linux-riscv64.txt
+++ b/int/surface/vectorize-emit/expect.linux-riscv64.txt
@@ -1,5 +1,17 @@
 arch=riscv64
 add_i32k scalar
+aff_const_dep scalar
+aff_cursor scalar
+aff_cursor2 scalar
+aff_glob scalar
+aff_load scalar
+aff_matmul_row scalar
+aff_ptr scalar
+aff_reduce scalar
+aff_reverse scalar
+aff_shift_dep scalar
+aff_store scalar
+aff_stride2 scalar
 axpy_f32 scalar
 carried_i32 scalar
 cond_i32 scalar

--- a/int/surface/vectorize-emit/expect.linux-riscv64.txt
+++ b/int/surface/vectorize-emit/expect.linux-riscv64.txt
@@ -3,6 +3,7 @@ add_i32k scalar
 aff_const_dep scalar
 aff_cursor scalar
 aff_cursor2 scalar
+aff_cursor_k scalar
 aff_glob scalar
 aff_load scalar
 aff_matmul_row scalar

--- a/int/surface/vectorize-emit/expect.linux.txt
+++ b/int/surface/vectorize-emit/expect.linux.txt
@@ -1,5 +1,17 @@
 arch=x86_64
 add_i32k simd
+aff_const_dep scalar
+aff_cursor simd
+aff_cursor2 scalar
+aff_glob simd
+aff_load simd
+aff_matmul_row simd
+aff_ptr simd
+aff_reduce simd
+aff_reverse scalar
+aff_shift_dep scalar
+aff_store simd
+aff_stride2 scalar
 axpy_f32 simd
 carried_i32 scalar
 cond_i32 scalar

--- a/int/surface/vectorize-emit/expect.linux.txt
+++ b/int/surface/vectorize-emit/expect.linux.txt
@@ -3,6 +3,7 @@ add_i32k simd
 aff_const_dep scalar
 aff_cursor simd
 aff_cursor2 scalar
+aff_cursor_k simd
 aff_glob simd
 aff_load simd
 aff_matmul_row simd

--- a/int/surface/vectorize-emit/src/main.mach
+++ b/int/surface/vectorize-emit/src/main.mach
@@ -48,6 +48,36 @@ pub fun add_i32k(a: *i32, b: *i32, k: i32, n: i64) { var i: i64=0; for(i<n){ a[i
 # both gaps in one loop: a module-scope array scaled by an invariant scalar
 pub fun glob_mul_f32k(k: f32) { var i: i64=0; for(i<512){ gf_a[i]=gf_b[i]*k; i=i+1; } }
 
+# affine indices (#2312): an index that is the induction variable shifted by a
+# loop-invariant offset, through a pointer parameter and a module-scope array, on the
+# store side alone and the load side alone, and with the offset hoisted into a cursor
+# of its own — a second variable incremented by one that merely starts at the offset
+pub fun aff_ptr(a: *f32, b: *f32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[o+i]=b[o+i]+b[o+i]; i=i+1; } }
+pub fun aff_glob(o: i64, n: i64) { var i: i64=0; for(i<n){ gi_a[o+i]=gi_b[o+i]+gi_c[o+i]; i=i+1; } }
+pub fun aff_store(a: *f32, b: *f32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[o+i]=b[i]+b[i]; i=i+1; } }
+pub fun aff_load(a: *f32, b: *f32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[i]=b[o+i]+b[o+i]; i=i+1; } }
+pub fun aff_cursor(a: *f32, b: *f32, o: i64, n: i64) { var i: i64=0; var t: i64=o; for(i<n){ a[t]=b[t]+b[t]; t=t+1; i=i+1; } }
+pub fun aff_reduce(a: *i64, o: i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[o+i]; i=i+1; } ret s; }
+
+# the matmul inner loop, whose two invariant row offsets over distinct bases are the
+# shape that kept the worst kernel in the benchmark scalar
+pub fun aff_matmul_row(o: *f32, b: *f32, k: f32, ro: i64, ko: i64, n: i64) { var j: i64=0; for(j<n){ o[ro+j]=o[ro+j]+k*b[ko+j]; j=j+1; } }
+
+# an affine index must not bypass the dependence proof. these all DECLINE:
+#
+# same base with UNEQUAL offsets and a store is a cross-iteration distance the runtime
+# alias guard cannot discharge — the two windows are the same storage at a shift, not
+# two objects that might overlap — at a runtime distance and at a constant one alike.
+pub fun aff_shift_dep(a: *f32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[o+i]=a[i]+a[i]; i=i+1; } }
+pub fun aff_const_dep(a: *i32, n: i64) { var i: i64=0; for(i<n){ a[i+1]=a[i]+1; i=i+1; } }
+# a non-unit stride leaves the lanes of a vector access non-adjacent, forwards and
+# backwards alike
+pub fun aff_stride2(a: *f32, b: *f32, n: i64) { var i: i64=0; for(i<n){ a[2*i]=b[2*i]+b[2*i]; i=i+1; } }
+pub fun aff_reverse(a: *f32, b: *f32, n: i64) { var i: i64=0; for(i<n){ a[n-i]=b[n-i]+b[n-i]; i=i+1; } }
+# a cursor whose step is not the induction variable's is not a closed form of the
+# trip count this transform can rescale
+pub fun aff_cursor2(a: *f32, b: *f32, o: i64, n: i64) { var i: i64=0; var t: i64=o; for(i<n){ a[t]=b[t]+b[t]; t=t+2; i=i+1; } }
+
 # the integer reduction the pass also vectorizes (partial sums, then a horizontal
 # combine); its verdict guards the reduction path alongside the element-wise one
 pub fun sum_i64(a: *i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }

--- a/int/surface/vectorize-emit/src/main.mach
+++ b/int/surface/vectorize-emit/src/main.mach
@@ -57,6 +57,9 @@ pub fun aff_glob(o: i64, n: i64) { var i: i64=0; for(i<n){ gi_a[o+i]=gi_b[o+i]+g
 pub fun aff_store(a: *f32, b: *f32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[o+i]=b[i]+b[i]; i=i+1; } }
 pub fun aff_load(a: *f32, b: *f32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[i]=b[o+i]+b[o+i]; i=i+1; } }
 pub fun aff_cursor(a: *f32, b: *f32, o: i64, n: i64) { var i: i64=0; var t: i64=o; for(i<n){ a[t]=b[t]+b[t]; t=t+1; i=i+1; } }
+# a cursor whose closed form needs the induction variable's own start folded out: the
+# offset is `t_init - step*iv_init`, which resolves when both are constants
+pub fun aff_cursor_k(a: *f32, b: *f32, n: i64) { var i: i64=1; var t: i64=5; for(i<n){ a[t]=b[t]+b[t]; t=t+1; i=i+1; } }
 pub fun aff_reduce(a: *i64, o: i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[o+i]; i=i+1; } ret s; }
 
 # the matmul inner loop, whose two invariant row offsets over distinct bases are the

--- a/int/surface/vectorize/expect.txt
+++ b/int/surface/vectorize/expect.txt
@@ -1,2 +1,2 @@
 mismatches=0
-acc=9956
+acc=75876

--- a/int/surface/vectorize/expect.txt
+++ b/int/surface/vectorize/expect.txt
@@ -1,2 +1,2 @@
 mismatches=0
-acc=53494
+acc=9956

--- a/int/surface/vectorize/src/main.mach
+++ b/int/surface/vectorize/src/main.mach
@@ -94,6 +94,10 @@ fun aff_s(a: *f32, b: *f32, k: f32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[
 fun affcur_v(a: *f32, b: *f32, k: f32, o: i64, n: i64) { var i: i64=0; var t: i64=o; for(i<n){ a[t]=k*b[t]+a[t]; t=t+1; i=i+1; } }
 #[scalar]
 fun affcur_s(a: *f32, b: *f32, k: f32, o: i64, n: i64) { var i: i64=0; var t: i64=o; for(i<n){ a[t]=k*b[t]+a[t]; t=t+1; i=i+1; } }
+# a cursor whose closed form needs the induction variable's own start folded out
+fun affcurk_v(a: *f32, b: *f32, k: f32, n: i64) { var i: i64=1; var t: i64=5; for(i<n){ a[t]=k*b[t]+a[t]; t=t+1; i=i+1; } }
+#[scalar]
+fun affcurk_s(a: *f32, b: *f32, k: f32, n: i64) { var i: i64=1; var t: i64=5; for(i<n){ a[t]=k*b[t]+a[t]; t=t+1; i=i+1; } }
 
 # the matmul inner loop: two invariant row offsets over distinct bases
 fun affmm_v(o: *f32, b: *f32, k: f32, ro: i64, ko: i64, n: i64) { var j: i64=0; for(j<n){ o[ro+j]=o[ro+j]+k*b[ko+j]; j=j+1; } }
@@ -112,6 +116,26 @@ fun affdep_s(a: *i32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[o+i]=a[i]+1; i
 fun affred_v(a: *i64, o: i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[o+i]; i=i+1; } ret s; }
 #[scalar]
 fun affred_s(a: *i64, o: i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[o+i]; i=i+1; } ret s; }
+
+# non-unit strides must DECLINE and stay correct: a doubled stride writes every other
+# element and a reversed one walks backwards, neither of which a contiguous lane group
+# covers. Recognizing the index affinely is what makes these reachable at all, so the
+# stride gate is what stands between them and a wrong answer
+fun affstr_v(a: *f32, b: *f32, n: i64) { var i: i64=0; for(i<n){ a[2*i]=b[2*i]+1.0; i=i+1; } }
+#[scalar]
+fun affstr_s(a: *f32, b: *f32, n: i64) { var i: i64=0; for(i<n){ a[2*i]=b[2*i]+1.0; i=i+1; } }
+fun affrev_v(a: *f32, b: *f32, n: i64) { var i: i64=0; for(i<n){ a[n-i]=b[n-i]+1.0; i=i+1; } }
+#[scalar]
+fun affrev_s(a: *f32, b: *f32, n: i64) { var i: i64=0; for(i<n){ a[n-i]=b[n-i]+1.0; i=i+1; } }
+
+# two DISTINCT bases at DIFFERENT offsets, the shape whose true address windows the
+# alias guard can only find by shifting each base by that access's own offset. Called
+# below with bases far enough apart that the unshifted windows are disjoint while the
+# shifted ones overlap by all but one element: a guard reading the unshifted windows
+# routes an overlapping run to the vector path and gets a wrong answer
+fun affpq_v(a: *f32, b: *f32, p: i64, q: i64, n: i64) { var i: i64=0; for(i<n){ a[p+i]=b[q+i]+1.0; i=i+1; } }
+#[scalar]
+fun affpq_s(a: *f32, b: *f32, p: i64, q: i64, n: i64) { var i: i64=0; for(i<n){ a[p+i]=b[q+i]+1.0; i=i+1; } }
 
 fun ck32(a: *i32, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s*131+(a[i]::i64); i=i+1; } ret s; }
 fun cku8(a: *u8, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s*131+(a[i]::i64); i=i+1; } ret s; }
@@ -222,6 +246,8 @@ fun main(argc: usize, argv: **u8) i64 {
             if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
             affcur_v(?aw[0],?ab[0],0.75,o,n); affcur_s(?as3[0],?ab[0],0.75,o,n);
             if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
+            affcurk_v(?aw[0],?ab[0],0.75,n); affcurk_s(?as3[0],?ab[0],0.75,n);
+            if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
             affmm_v(?aw[0],?ab[0],1.5,o,5,n); affmm_s(?as3[0],?ab[0],1.5,o,5,n);
             if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
             affdep_v(?qv[0],o,n); affdep_s(?qs[0],o,n);
@@ -233,10 +259,29 @@ fun main(argc: usize, argv: **u8) i64 {
             i=0; for (i < 384) { aw[i]=(i::f32)*0.25+1.0; as3[i]=(i::f32)*0.25+1.0; i=i+1; }
             aff_v(?aw[2],?aw[0],1.25,o,n); aff_s(?as3[2],?as3[0],1.25,o,n);
             if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
+            # the non-unit strides, over the same seeded arrays
+            i=0; for (i < 384) { aw[i]=(i::f32)*0.25+1.0; as3[i]=(i::f32)*0.25+1.0; i=i+1; }
+            affstr_v(?aw[0],?ab[0],n); affstr_s(?as3[0],?ab[0],n);
+            if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
+            affrev_v(?aw[0],?ab[0],n); affrev_s(?as3[0],?ab[0],n);
+            if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
+            acc=acc+norm(ckf32(?aw[0],384));
             ao=ao+1;
         }
         at=at+1;
     }
+
+    # two distinct bases at different offsets. `aw` and `aw+100` are 100 elements
+    # apart, so the windows the induction variable alone describes -- [aw, aw+64) and
+    # [aw+100, aw+164) -- are disjoint, while the ones the accesses really touch --
+    # [aw+101, aw+165) and [aw+100, aw+164) -- overlap at a shift of one element,
+    # which is a loop-carried dependence the vector path would read stale.
+    var pi2: i64 = 0;
+    for (pi2 < 384) { aw[pi2]=(pi2::f32)*0.25+1.0; as3[pi2]=(pi2::f32)*0.25+1.0; pi2=pi2+1; }
+    affpq_v(?aw[0], ?aw[100], 101, 0, 64);
+    affpq_s(?as3[0], ?as3[100], 101, 0, 64);
+    if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
+    acc=acc+norm(ckf32(?aw[0],384));
 
     p.printlnf("mismatches={}", mism);
     p.printlnf("acc={}", norm(acc));

--- a/int/surface/vectorize/src/main.mach
+++ b/int/surface/vectorize/src/main.mach
@@ -83,6 +83,36 @@ fun cond_v(a: *i32, b: *i32, c: *i32, n: i64) { var i: i64=0; for(i<n){ if (b[i]
 #[scalar]
 fun cond_s(a: *i32, b: *i32, c: *i32, n: i64) { var i: i64=0; for(i<n){ if (b[i] < 50) { a[i]=b[i]+c[i]; } i=i+1; } }
 
+# affine indices (#2312): the induction variable shifted by a loop-invariant offset,
+# with the offset spelled inline and hoisted into a cursor of its own. Both are run at
+# a range of offsets and trip counts, so the alias guard's shifted ranges, the vector
+# loop's lane stepping and the scalar remainder's re-entry are all exercised at
+# offsets a lane group straddles.
+fun aff_v(a: *f32, b: *f32, k: f32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[o+i]=k*b[o+i]+a[o+i]; i=i+1; } }
+#[scalar]
+fun aff_s(a: *f32, b: *f32, k: f32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[o+i]=k*b[o+i]+a[o+i]; i=i+1; } }
+fun affcur_v(a: *f32, b: *f32, k: f32, o: i64, n: i64) { var i: i64=0; var t: i64=o; for(i<n){ a[t]=k*b[t]+a[t]; t=t+1; i=i+1; } }
+#[scalar]
+fun affcur_s(a: *f32, b: *f32, k: f32, o: i64, n: i64) { var i: i64=0; var t: i64=o; for(i<n){ a[t]=k*b[t]+a[t]; t=t+1; i=i+1; } }
+
+# the matmul inner loop: two invariant row offsets over distinct bases
+fun affmm_v(o: *f32, b: *f32, k: f32, ro: i64, ko: i64, n: i64) { var j: i64=0; for(j<n){ o[ro+j]=o[ro+j]+k*b[ko+j]; j=j+1; } }
+#[scalar]
+fun affmm_s(o: *f32, b: *f32, k: f32, ro: i64, ko: i64, n: i64) { var j: i64=0; for(j<n){ o[ro+j]=o[ro+j]+k*b[ko+j]; j=j+1; } }
+
+# a shifted store over the SAME base as a load is a loop-carried dependence at the
+# runtime distance `o`, which must DECLINE and stay correct at every distance -- the
+# proof that widening the index did not widen what is vectorized without proof
+fun affdep_v(a: *i32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[o+i]=a[i]+1; i=i+1; } }
+#[scalar]
+fun affdep_s(a: *i32, o: i64, n: i64) { var i: i64=0; for(i<n){ a[o+i]=a[i]+1; i=i+1; } }
+
+# an affine reduction: no store, so no alias guard, but the shifted loads must still
+# land on the elements the scalar reduction reads
+fun affred_v(a: *i64, o: i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[o+i]; i=i+1; } ret s; }
+#[scalar]
+fun affred_s(a: *i64, o: i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[o+i]; i=i+1; } ret s; }
+
 fun ck32(a: *i32, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s*131+(a[i]::i64); i=i+1; } ret s; }
 fun cku8(a: *u8, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s*131+(a[i]::i64); i=i+1; } ret s; }
 fun ck16(a: *i16, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s*131+(a[i]::i64); i=i+1; } ret s; }
@@ -168,6 +198,45 @@ fun main(argc: usize, argv: **u8) i64 {
     f32scale_v(?fr[1], ?fr[0], 1.25, 128);
     f32scale_s(?fr2[1], ?fr2[0], 1.25, 128);
     if (ckf32(?fr[0],130) != ckf32(?fr2[0],130)) { mism = mism + 1; }
+
+    # affine indices, over a grid of offsets and trip counts. the offsets deliberately
+    # include ones that are not a multiple of any lane count, so the vector loop's
+    # shifted start and the scalar remainder's re-entry are both covered.
+    var aw: [384]f32; var as3: [384]f32; var ab: [384]f32;
+    var qv: [384]i32; var qs: [384]i32;
+    var rv: [384]i64;
+    var aoffs: [5]i64; aoffs[0]=0; aoffs[1]=1; aoffs[2]=3; aoffs[3]=7; aoffs[4]=64;
+    var at: i64 = 0;
+    for (at < 4) {
+        val n: i64 = trips[at];
+        var ao: i64 = 0;
+        for (ao < 5) {
+            val o: i64 = aoffs[ao];
+            var i: i64 = 0;
+            for (i < 384) {
+                ab[i]=(i::f32)*0.5-3.0; aw[i]=(i::f32)*0.25+1.0; as3[i]=(i::f32)*0.25+1.0;
+                qv[i]=(i*3+5)::i32; qs[i]=(i*3+5)::i32; rv[i]=i*11-4;
+                i=i+1;
+            }
+            aff_v(?aw[0],?ab[0],1.25,o,n); aff_s(?as3[0],?ab[0],1.25,o,n);
+            if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
+            affcur_v(?aw[0],?ab[0],0.75,o,n); affcur_s(?as3[0],?ab[0],0.75,o,n);
+            if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
+            affmm_v(?aw[0],?ab[0],1.5,o,5,n); affmm_s(?as3[0],?ab[0],1.5,o,5,n);
+            if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
+            affdep_v(?qv[0],o,n); affdep_s(?qs[0],o,n);
+            if (ck32(?qv[0],384)!=ck32(?qs[0],384)) { mism=mism+1; }
+            if (affred_v(?rv[0],o,n) != affred_s(?rv[0],o,n)) { mism=mism+1; }
+            acc=acc+norm(ckf32(?aw[0],384))+norm(ck32(?qv[0],384))+norm(affred_v(?rv[0],o,n));
+            # the same aliasing hazard through an affine index: the shifted ranges
+            # overlap, so the guard must route to the scalar fallback
+            i=0; for (i < 384) { aw[i]=(i::f32)*0.25+1.0; as3[i]=(i::f32)*0.25+1.0; i=i+1; }
+            aff_v(?aw[2],?aw[0],1.25,o,n); aff_s(?as3[2],?as3[0],1.25,o,n);
+            if (ckf32(?aw[0],384)!=ckf32(?as3[0],384)) { mism=mism+1; }
+            ao=ao+1;
+        }
+        at=at+1;
+    }
 
     p.printlnf("mismatches={}", mism);
     p.printlnf("acc={}", norm(acc));

--- a/src/lang/me/analysis/dependence.mach
+++ b/src/lang/me/analysis/dependence.mach
@@ -262,6 +262,15 @@ pub fun dep_dnit(d: *DepInfo) {
 # closed form of the trip count, which the transform re-derives by scaling its step
 # with the lane count. Any OTHER header phi is a value carried between iterations (a
 # reduction, a scan) and still forces the conservative verdict.
+#
+# Admitting anything as a recurrence kills no test today, because two later gates
+# already refuse everything that would reach the transform: a store whose value
+# involves the extra phi is not a pure lane-op tree (stores_are_pure_trees), and one
+# whose value is live after the loop is refused by versioning (has_live_out), leaving
+# only a dead phi that DCE removed. That coincidence is not the reason this rule is
+# here -- it is the precondition scale_recurrence_steps asserts, and if one ever slips
+# past both gates this is the difference between declining the loop and aborting the
+# build on an internal invariant. Do not remove it for being untested.
 pub fun ivs_only_recurrence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32) bool {
     val lp: *loops.Loop = ?la.loops[loop_ix];
     var bi: u32 = 0;
@@ -413,6 +422,12 @@ fun secondary_iv(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, pid: i
         j = j + 1;
     }
     if (!got_init || !got_upd) { ret false; }
+    # the offset this returns is handed to the alias guard, which materializes it in a
+    # block that dominates the loop, so it must be loop-invariant. That holds for a
+    # preheader-incoming value by dominance, which is why no test kills this check and
+    # it survives its own mutation; it is the AffineIndex contract stated where the
+    # offset is produced rather than left to the reader to re-derive. Untested is not
+    # unjustified -- do not remove it for being untested.
     if (!loops.is_invariant(la, loop_ix, init)) { ret false; }
     if (upd.kind != value.VAL_INSTR) { ret false; }
 
@@ -429,6 +444,13 @@ fun secondary_iv(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, pid: i
     }
     if (step.kind != value.VAL_CONST_INT) { ret false; }
 
+    # the `- c*iv_init` correction is what makes the returned form EXACT rather than
+    # merely usable. No test kills it, and the reason is worth writing down: at unit
+    # stride -- the only stride an access is admitted at -- dropping it shifts every
+    # window in the loop by the same `iv_init` elements, and a common translation
+    # changes neither pairwise disjointness nor offset equality, which is all the two
+    # consumers ask. The next consumer to read `off` absolutely rather than relatively
+    # is the one it protects, so keep the form honest to its own contract.
     out.stride = step.data.int_lit;
     val iv_init: value.Value = lp.iv.init;
     if (is_zero_const(iv_init)) { out.off = init; ret true; }
@@ -531,8 +553,12 @@ fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid
     if (!affine_index(fn, la, loop_ix, idx, AFFINE_DEPTH, ?ax)) { ret false; }
     if (ax.stride != 1) { ret false; }
     # the offset is added to the induction variable's own range to derive the alias
-    # guard's endpoints, so it must carry that arithmetic's type. Unit stride makes
-    # the index the induction variable plus an offset, so this holds by construction
+    # guard's endpoints, so it must carry that arithmetic's type. Unit stride makes the
+    # index the induction variable plus an offset, so this holds by construction and no
+    # test kills it: it is the precondition of that add, asserted where the offset is
+    # accepted rather than where it is emitted two modules away. What fires it is a new
+    # affine rule that widens or narrows its operand -- a sign or zero extension in the
+    # index, say -- which is exactly the change that must not silently reach the guard.
     if (ax.off.ty != lp.iv.init.ty) { ret false; }
     # base must be loop-invariant
     if (!loops.is_invariant(la, loop_ix, base)) { ret false; }

--- a/src/lang/me/analysis/dependence.mach
+++ b/src/lang/me/analysis/dependence.mach
@@ -1,15 +1,16 @@
 # mach.lang.me.analysis.dependence: cross-iteration memory-dependence analysis
 #
 # Over a counted loop recognized by `mach.lang.me.analysis.loops`, decide whether
-# the loop is a unit-stride, offset-0 element-wise map -- `dst[i] = f(src0[i], ...)`
-# -- carrying no cross-iteration memory dependence, and collect its memory accesses.
+# the loop is a unit-stride element-wise map -- `dst[c+i] = f(src0[c'+i], ...)` --
+# carrying no cross-iteration memory dependence, and collect its memory accesses.
 #
 # The verdict is deliberately conservative (child 1's lesson): a positive
 # INDEPENDENT verdict is returned ONLY when every memory access in the loop is a
-# non-volatile load/store through `gep(base, iv)` -- a single index equal to the
-# loop's induction variable (offset 0, unit stride) over a loop-invariant base --
-# and the loop carries no register recurrence beyond the induction variable and no
-# opaque memory effect (call / asm / memzero). Anything unproven is DEPENDENT.
+# non-volatile load/store through `gep(base, idx)` over a loop-invariant base, where
+# `idx` is AFFINE in the loop's induction variable at UNIT stride (`off + iv` for a
+# loop-invariant `off`, #2312), and the loop carries no register recurrence beyond
+# the induction variable and its secondary add-recurrences, and no opaque memory
+# effect (call / asm / memzero). Anything unproven is DEPENDENT.
 #
 # A DEPENDENT verdict means "do not vectorize". An INDEPENDENT verdict means "safe
 # to vectorize IF the runtime alias check discharges base aliasing" -- distinct
@@ -36,11 +37,15 @@ use mach.lang.me.ir.value;
 use ir_type: mach.lang.me.ir.type;
 use loops: mach.lang.me.analysis.loops;
 
-# one recognized affine memory access `base[iv]` in a counted loop
+# one recognized affine memory access `base[off + iv]` in a counted loop
 # ---
 # instr:     the load or store instruction
-# gep:       the OP_GEP computing `base[iv]` that the access dereferences
+# gep:       the OP_GEP computing `base[off + iv]` that the access dereferences
 # base:      the loop-invariant base pointer (the gep's first operand)
+# off:       the loop-invariant ELEMENT offset the index is shifted by, in the
+#            induction variable's type. `base[iv]` carries the constant 0; any other
+#            offset shifts the whole accessed window, so every range the alias guard
+#            derives must add it
 # stride_ty: the gep's source pointee type -- the per-element stride, reused to
 #            compute the accessed byte range for the alias guard
 # elem_ty:   the loaded / stored value type
@@ -51,6 +56,7 @@ pub rec MemAccess {
     instr:     id.InstructionId;
     gep:       id.InstructionId;
     base:      value.Value;
+    off:       value.Value;
     stride_ty: ir_type.IrTypeId;
     elem_ty:   ir_type.IrTypeId;
     bytes:     u32;
@@ -109,10 +115,11 @@ pub fun analyze_dependence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u
     if (lp.iv.step.kind != value.VAL_CONST_INT) { ret R.ok[DepInfo, str](d); }
     if (lp.iv.step.data.int_lit != 1) { ret R.ok[DepInfo, str](d); }
 
-    # the induction variable must be the loop's ONLY register recurrence: the header
-    # carries exactly one phi (the iv) and no other loop block carries any phi. an
-    # extra phi is a reduction / scan carried across iterations (child 4's concern).
-    if (!single_iv_recurrence(fn, la, loop_ix)) { ret R.ok[DepInfo, str](d); }
+    # the loop's register recurrences must all be induction variables: the header
+    # carries the iv plus, at most, secondary add-recurrences, and no other loop block
+    # carries any phi. any other extra phi is a reduction / scan carried across
+    # iterations (child 4's concern).
+    if (!ivs_only_recurrence(fn, la, loop_ix)) { ret R.ok[DepInfo, str](d); }
 
     # upper-bound the accesses array by the loop's instruction count.
     var total: u32 = 0;
@@ -154,17 +161,30 @@ pub fun analyze_dependence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u
         bi = bi + 1;
     }
 
-    # every pair of accesses to the SAME base must have an identical footprint. with
-    # stride == width and offset 0 already enforced per access, equal bytes means the
-    # same per-iteration address window; a same-base pair with differing widths (an
-    # i8 load and an i64 store on `a`) is a genuine cross-iteration RAW and the guard
-    # cannot fix it (the ranges are not disjoint, they coincide).
+    # every pair of accesses to the SAME base must have an identical footprint, and --
+    # once either of them writes -- an identical element offset.
+    #
+    # equal bytes with stride == width already enforced per access means the same
+    # per-iteration address window; a same-base pair with differing widths (an i8 load
+    # and an i64 store on `a`) is a genuine cross-iteration RAW the guard cannot fix
+    # (the ranges are not disjoint, they coincide).
+    #
+    # equal offsets make that window the SAME element in every iteration -- a
+    # distance-0 self dependence, which vectorizes. Any other offset relation is a
+    # nonzero cross-iteration distance, and admitting affine indices (#2312) is what
+    # made that reachable: `a[i] = a[i-1]` is same-base at offsets 0 and -1. The
+    # runtime alias guard cannot discharge it, because the two ranges are not two
+    # objects that might overlap -- they are the same storage at a shift. Two READS at
+    # different offsets carry no dependence at all and stay admitted.
     var i: u32 = 0;
     for (i < d.access_count) {
         var j: u32 = i + 1;
         for (j < d.access_count) {
-            if (equal(d.accesses[i].base, d.accesses[j].base) && d.accesses[i].bytes != d.accesses[j].bytes) {
-                dep_dnit(?d); ret dependent(alloc);
+            if (equal(d.accesses[i].base, d.accesses[j].base)) {
+                if (d.accesses[i].bytes != d.accesses[j].bytes) { dep_dnit(?d); ret dependent(alloc); }
+                if ((d.accesses[i].is_store || d.accesses[j].is_store) && !equal(d.accesses[i].off, d.accesses[j].off)) {
+                    dep_dnit(?d); ret dependent(alloc);
+                }
             }
             j = j + 1;
         }
@@ -234,23 +254,41 @@ pub fun dep_dnit(d: *DepInfo) {
     d.access_cap   = 0;
 }
 
-# true when the loop's only phi recurrence is the induction variable: the header
-# has exactly one phi (the iv) and no other loop block has any phi
-fun single_iv_recurrence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32) bool {
+# true when every phi recurrence the loop carries is an induction variable: the
+# header holds the induction variable plus, at most, secondary add-recurrences
+# (`t = base; ...; t = t + c`), and no other loop block holds any phi.
+#
+# A secondary induction variable is not a cross-iteration data dependence -- it is a
+# closed form of the trip count, which the transform re-derives by scaling its step
+# with the lane count. Any OTHER header phi is a value carried between iterations (a
+# reduction, a scan) and still forces the conservative verdict.
+pub fun ivs_only_recurrence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32) bool {
     val lp: *loops.Loop = ?la.loops[loop_ix];
     var bi: u32 = 0;
     for (bi < lp.body_len) {
         val bid: id.BlockId = lp.body[bi];
         val blk: *ir.Block = ?fn.blocks[bid::u32];
         if (bid == lp.header) {
-            if (blk.phi_count != 1) { ret false; }
-            if (blk.phis[0] != lp.iv.phi) { ret false; }
+            var pi: u32 = 0;
+            for (pi < blk.phi_count) {
+                var ai: AffineIndex;
+                if (blk.phis[pi] != lp.iv.phi && !secondary_iv(fn, la, loop_ix, blk.phis[pi], ?ai)) { ret false; }
+                pi = pi + 1;
+            }
+            if (!header_has_phi(blk, lp.iv.phi)) { ret false; }
         } or {
             if (blk.phi_count != 0) { ret false; }
         }
         bi = bi + 1;
     }
     ret true;
+}
+
+# true when block `blk` carries phi `pid`
+fun header_has_phi(blk: *ir.Block, pid: id.InstructionId) bool {
+    var i: u32 = 0;
+    for (i < blk.phi_count) { if (blk.phis[i] == pid) { ret true; } i = i + 1; }
+    ret false;
 }
 
 # the address shape of an element-wise access: `base + iv * elem`, reached through
@@ -290,10 +328,178 @@ fun gep_elem_shape(gep: *instruction.Instruction, types: *ir_type.IrTypeTable, o
     ret true;
 }
 
-# classify a load/store as an element-wise `base[iv]` access, filling `out` on
+# the affine form of a loop index: `off + stride * iv`
+#
+# `stride` is a two's-complement element count, so a backwards index carries the
+# wrapped negative and the only stride a contiguous vector access admits is 1.
+# ---
+# off:    the loop-invariant element offset -- a constant, or a value defined outside
+#         the loop (which therefore dominates the preheader, and so any guard block
+#         spliced in front of it)
+# stride: elements advanced per iteration of the loop's induction variable
+rec AffineIndex {
+    off:    value.Value;
+    stride: u64;
+}
+
+# the recursion bound on the affine walk: an index is a shallow expression over the
+# induction variable, and bounding the descent keeps a pathological operand DAG from
+# costing exponential time. Exceeding it declines the access, never mis-reads it.
+val AFFINE_DEPTH: u32 = 8;
+
+# true when `v` is the integer constant zero, the additive identity the offset
+# algebra folds through
+fun is_zero_const(v: value.Value) bool {
+    ret v.kind == value.VAL_CONST_INT && v.data.int_lit == 0;
+}
+
+# the sum of two affine forms. Strides add; the offsets must combine WITHOUT
+# synthesizing arithmetic (nothing here may emit into the function), so one must be
+# zero or both must be constants -- an `inv1 + inv2 + iv` index declines rather than
+# growing an add the guard would have to materialize.
+fun affine_add(x: *AffineIndex, y: *AffineIndex, out: *AffineIndex) bool {
+    out.stride = x.stride + y.stride;
+    if (is_zero_const(x.off)) { out.off = y.off; ret true; }
+    if (is_zero_const(y.off)) { out.off = x.off; ret true; }
+    if (x.off.kind == value.VAL_CONST_INT && y.off.kind == value.VAL_CONST_INT) {
+        out.off = value.const_int(x.off.data.int_lit + y.off.data.int_lit, x.off.ty);
+        ret true;
+    }
+    ret false;
+}
+
+# the additive inverse of an affine form, for the right operand of a subtract
+fun affine_negate(x: *AffineIndex, out: *AffineIndex) bool {
+    out.stride = 0 - x.stride;
+    if (is_zero_const(x.off)) { out.off = x.off; ret true; }
+    if (x.off.kind == value.VAL_CONST_INT) { out.off = value.const_int(0 - x.off.data.int_lit, x.off.ty); ret true; }
+    ret false;
+}
+
+# an affine form scaled by a compile-time constant
+fun affine_scale(x: *AffineIndex, k: u64, out: *AffineIndex) bool {
+    out.stride = x.stride * k;
+    if (is_zero_const(x.off)) { out.off = x.off; ret true; }
+    if (x.off.kind == value.VAL_CONST_INT) { out.off = value.const_int(x.off.data.int_lit * k, x.off.ty); ret true; }
+    ret false;
+}
+
+# the affine form of a header phi that is itself an add-recurrence `{init, +, c}`
+# over a loop-invariant `init` and a constant `c` -- a SECONDARY induction variable,
+# the shape a loop with its own cursor produces (`t = base; ...; t = t + 1`).
+#
+# At the loop's k-th iteration such a phi holds `init + k*c` while the induction
+# variable holds `iv_init + k`, so the phi is `(init - c*iv_init) + c*iv`. That
+# offset must fold without emitting anything, which it does when the induction
+# variable starts at zero (the canonical form the loop rotation produces) or when
+# both `init` and `iv_init` are constants.
+fun secondary_iv(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, pid: id.InstructionId, out: *AffineIndex) bool {
+    val lp: *loops.Loop = ?la.loops[loop_ix];
+    if (pid::u32 >= la.instr_count || la.instr_block[pid::u32] != lp.header) { ret false; }
+    val popt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, pid);
+    if (O.is_none[*instruction.Instruction](popt)) { ret false; }
+    val phi: *instruction.Instruction = O.unwrap[*instruction.Instruction](popt);
+    if (phi.operand_count != 4) { ret false; }
+
+    var init: value.Value;
+    var upd:  value.Value;
+    var got_init: bool = false;
+    var got_upd:  bool = false;
+    var j: u32 = 0;
+    for (j < 2) {
+        val btgt: id.BlockId = ir.block_target(phi.operands[2 * j]);
+        if (btgt == lp.preheader) { init = phi.operands[2 * j + 1]; got_init = true; }
+        if (btgt == lp.latch)     { upd  = phi.operands[2 * j + 1]; got_upd  = true; }
+        j = j + 1;
+    }
+    if (!got_init || !got_upd) { ret false; }
+    if (!loops.is_invariant(la, loop_ix, init)) { ret false; }
+    if (upd.kind != value.VAL_INSTR) { ret false; }
+
+    # the latch value must be `phi + c` for a constant c
+    val uopt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, upd.data.instr);
+    if (O.is_none[*instruction.Instruction](uopt)) { ret false; }
+    val u: *instruction.Instruction = O.unwrap[*instruction.Instruction](uopt);
+    if (u.kind != instruction.OP_ADD || u.operand_count != 2) { ret false; }
+    var step: value.Value;
+    if (u.operands[0].kind == value.VAL_INSTR && u.operands[0].data.instr == pid) { step = u.operands[1]; }
+    or {
+        if (u.operands[1].kind == value.VAL_INSTR && u.operands[1].data.instr == pid) { step = u.operands[0]; }
+        or { ret false; }
+    }
+    if (step.kind != value.VAL_CONST_INT) { ret false; }
+
+    out.stride = step.data.int_lit;
+    val iv_init: value.Value = lp.iv.init;
+    if (is_zero_const(iv_init)) { out.off = init; ret true; }
+    if (init.kind == value.VAL_CONST_INT && iv_init.kind == value.VAL_CONST_INT) {
+        out.off = value.const_int(init.data.int_lit - out.stride * iv_init.data.int_lit, init.ty);
+        ret true;
+    }
+    ret false;
+}
+
+# decompose index `v` into `off + stride * iv` over loop `loop_ix`, or decline
+#
+# The single rule the access classifier keys on, replacing the syntactic "the index
+# IS the induction-variable phi" test that declined every offset index (#2312). Its
+# leaves are the induction variable, anything the loop leaves unchanged, and a
+# secondary add-recurrence; its interior nodes are the affine operators (add,
+# subtract, and multiply by a constant). Nothing here mutates `fn` or emits.
+# ---
+# fn:      the function
+# la:      the loop analysis for `fn`
+# loop_ix: index into la.loops
+# v:       the index value to decompose
+# depth:   remaining recursion budget (see AFFINE_DEPTH)
+# out:     receives the affine form on success
+# ret:     true when `v` is affine in the loop's induction variable
+fun affine_index(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, v: value.Value, depth: u32, out: *AffineIndex) bool {
+    val lp: *loops.Loop = ?la.loops[loop_ix];
+
+    # the induction variable itself is `0 + 1*iv`
+    if (v.kind == value.VAL_INSTR && v.data.instr == lp.iv.phi) {
+        out.off    = value.const_int(0, v.ty);
+        out.stride = 1;
+        ret true;
+    }
+    # anything the loop does not change is a pure offset, whatever computed it
+    if (loops.is_invariant(la, loop_ix, v)) {
+        out.off    = v;
+        out.stride = 0;
+        ret true;
+    }
+    if (depth == 0 || v.kind != value.VAL_INSTR) { ret false; }
+    val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, v.data.instr);
+    if (O.is_none[*instruction.Instruction](opt)) { ret false; }
+    val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt);
+
+    if (inst.kind == instruction.OP_PHI) { ret secondary_iv(fn, la, loop_ix, v.data.instr, out); }
+    if (inst.operand_count != 2) { ret false; }
+
+    var x: AffineIndex;
+    var y: AffineIndex;
+    if (!affine_index(fn, la, loop_ix, inst.operands[0], depth - 1, ?x)) { ret false; }
+    if (!affine_index(fn, la, loop_ix, inst.operands[1], depth - 1, ?y)) { ret false; }
+
+    if (inst.kind == instruction.OP_ADD) { ret affine_add(?x, ?y, out); }
+    if (inst.kind == instruction.OP_SUB) {
+        var ny: AffineIndex;
+        if (!affine_negate(?y, ?ny)) { ret false; }
+        ret affine_add(?x, ?ny, out);
+    }
+    if (inst.kind == instruction.OP_MUL) {
+        if (y.stride == 0 && y.off.kind == value.VAL_CONST_INT) { ret affine_scale(?x, y.off.data.int_lit, out); }
+        if (x.stride == 0 && x.off.kind == value.VAL_CONST_INT) { ret affine_scale(?y, x.off.data.int_lit, out); }
+        ret false;
+    }
+    ret false;
+}
+
+# classify a load/store as an element-wise `base[off + iv]` access, filling `out` on
 # success. requires: non-volatile; the pointer is a gep of one of the two element
-# shapes whose index is exactly the induction-variable phi (offset 0, unit stride)
-# and whose base is loop-invariant.
+# shapes whose index is affine in the induction variable at unit stride, and whose
+# base is loop-invariant.
 fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid: id.InstructionId, inst: *instruction.Instruction, types: *ir_type.IrTypeTable, out: *MemAccess) bool {
     if ((inst.flags & instruction.INSTR_FLAG_VOLATILE) != 0) { ret false; }
     val is_store: bool = inst.kind == instruction.OP_STORE;
@@ -318,8 +524,16 @@ fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid
     var stride_ty: ir_type.IrTypeId;
     if (!gep_elem_shape(gep, types, ?base, ?idx, ?stride_ty)) { ret false; }
     val lp: *loops.Loop = ?la.loops[loop_ix];
-    # index must be exactly the induction variable (offset 0)
-    if (idx.kind != value.VAL_INSTR || idx.data.instr != lp.iv.phi) { ret false; }
+    # the index must be affine in the induction variable at UNIT stride: only a
+    # stride of exactly one element makes consecutive iterations land on adjacent
+    # storage, which is what a vector access over the lane group reads and writes
+    var ax: AffineIndex;
+    if (!affine_index(fn, la, loop_ix, idx, AFFINE_DEPTH, ?ax)) { ret false; }
+    if (ax.stride != 1) { ret false; }
+    # the offset is added to the induction variable's own range to derive the alias
+    # guard's endpoints, so it must carry that arithmetic's type. Unit stride makes
+    # the index the induction variable plus an offset, so this holds by construction
+    if (ax.off.ty != lp.iv.init.ty) { ret false; }
     # base must be loop-invariant
     if (!loops.is_invariant(la, loop_ix, base)) { ret false; }
 
@@ -340,6 +554,7 @@ fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid
     out.instr     = iid;
     out.gep       = ptr.data.instr;
     out.base      = base;
+    out.off       = ax.off;
     out.stride_ty = stride_ty;
     out.elem_ty   = elem_ty;
     out.bytes     = width_bytes;

--- a/src/lang/me/transform/vectorize.mach
+++ b/src/lang/me/transform/vectorize.mach
@@ -462,7 +462,6 @@ fun vectorize_one(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: 
     fshape.is_float = shape.is_float;
 
     val fast_iv_phi: id.InstructionId = flp.iv.phi;
-    val fast_iv_upd: id.InstructionId = flp.iv.update;
     val fast_cmp: id.InstructionId = flp.counted.cmp;
     val iv_phi_val: value.Value = value.instr(fast_iv_phi, iv_ty);
 
@@ -493,16 +492,10 @@ fun vectorize_one(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: 
     A.deallocate[bool](m.alloc, vset, fn.instr_len::usize);
     if (R.is_err[bool, str](rsp)) { A.deallocate[id.BlockId](m.alloc, fbody, body_len::usize); A.deallocate[id.BlockId](m.alloc, rem_blocks, body_len::usize); dep.dep_dnit(?fd); loops.dnit(?fla); ret rsp; }
 
-    # step the induction variable by the lane count (the +1 update becomes +lanes)
-    val uopt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, fast_iv_upd);
-    if (O.is_some[*instruction.Instruction](uopt)) {
-        val upd: *instruction.Instruction = O.unwrap[*instruction.Instruction](uopt);
-        var si: u32 = 0;
-        for (si < upd.operand_count) {
-            if (upd.operands[si].kind == value.VAL_CONST_INT) { upd.operands[si] = value.const_int(shape.lanes::u64, iv_ty); }
-            si = si + 1;
-        }
-    }
+    # step every recurrence the loop carries by the lane count (the +1 update becomes
+    # +lanes); the remainder was cloned above and keeps the scalar steps
+    val rss: R.Result[bool, str] = scale_recurrence_steps(fn, flp, shape.lanes);
+    if (R.is_err[bool, str](rss)) { A.deallocate[id.BlockId](m.alloc, fbody, body_len::usize); A.deallocate[id.BlockId](m.alloc, rem_blocks, body_len::usize); dep.dep_dnit(?fd); loops.dnit(?fla); ret rss; }
 
     # the vector header tests `iv <= limit` (a full lane group fits). the SIGNED
     # compare is safe even for an unsigned loop: when bound_ex < lanes the
@@ -517,14 +510,15 @@ fun vectorize_one(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: 
     }
 
     # the vector header's exit edge (to merge) now enters the remainder, which starts
-    # from the vector iv's final value
+    # from the vector loop's final recurrence values
     ver.redirect_terminator(fn, fast_header, merge, rem_header);
-    set_phi_incoming(fn, rem_header, vpre, fast_header, iv_phi_val);
+    val rer: bool = enter_remainder_from(fn, rem_header, vpre, fast_header);
 
     A.deallocate[id.BlockId](m.alloc, fbody, body_len::usize);
     A.deallocate[id.BlockId](m.alloc, rem_blocks, body_len::usize);
     dep.dep_dnit(?fd);
     loops.dnit(?fla);
+    if (!rer) { ret R.err[bool, str]("vectorize: remainder header phis do not mirror the vector header's"); }
 
     val rpr: R.Result[bool, str] = ir.preds_rebuild(m, fn);
     if (R.is_err[bool, str](rpr)) { ret R.err[bool, str](R.unwrap_err[bool, str](rpr)); }
@@ -734,26 +728,88 @@ fun emit_splat(b: *builder.Builder, v: value.Value, arr_ty: ir_type.IrTypeId, ve
     ret builder.emit_load(b, slot, vec_ty);
 }
 
-# change the phi incoming of `blk` from predecessor `from` to come from `new_block`
-# with value `new_val`
-fun set_phi_incoming(fn: *ir.Function, blk: id.BlockId, from: id.BlockId, new_block: id.BlockId, new_val: value.Value) {
-    val b: *ir.Block = ?fn.blocks[blk::u32];
+# the instruction defining phi `pid`'s incoming value on the edge from `latch`, or
+# INSTR_NIL when that edge is absent or carries a value no instruction defines
+fun latch_update(fn: *ir.Function, pid: id.InstructionId, latch: id.BlockId) id.InstructionId {
+    val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, pid);
+    if (O.is_none[*instruction.Instruction](opt)) { ret id.INSTR_NIL; }
+    val phi: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt);
+    var o: u32 = 0;
+    for (o < phi.operand_count) {
+        if ((o % 2) == 0 && ir.block_target(phi.operands[o]) == latch && o + 1 < phi.operand_count) {
+            if (phi.operands[o + 1].kind == value.VAL_INSTR) { ret phi.operands[o + 1].data.instr; }
+            ret id.INSTR_NIL;
+        }
+        o = o + 1;
+    }
+    ret id.INSTR_NIL;
+}
+
+# multiply every recurrence's constant step by the lane count
+#
+# A vector iteration covers `lanes` elements, so every add-recurrence the loop
+# carries must advance `lanes` times its scalar step: the induction variable, and
+# each secondary induction variable the dependence analysis admitted (`t = base; ...;
+# t = t + 1`, #2312). The remainder loop is cloned before this runs and keeps the
+# scalar steps.
+#
+# The analysis proved every header phi is `{init, +, c}` for a constant `c`, so a phi
+# that does not present that shape is an invariant breach between analysis and
+# transform. It is reported rather than skipped: a skipped recurrence would advance
+# at the scalar rate through a vector loop and silently miscompile.
+fun scale_recurrence_steps(fn: *ir.Function, lp: *loops.Loop, lanes: u32) R.Result[bool, str] {
+    val hdr: *ir.Block = ?fn.blocks[lp.header::u32];
     var pi: u32 = 0;
-    for (pi < b.phi_count) {
-        val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, b.phis[pi]);
-        if (O.is_some[*instruction.Instruction](opt)) {
-            val phi: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt);
-            var o: u32 = 0;
-            for (o < phi.operand_count) {
-                if ((o % 2) == 0 && ir.block_target(phi.operands[o]) == from) {
-                    phi.operands[o].data.int_lit = new_block::u64;
-                    if (o + 1 < phi.operand_count) { phi.operands[o + 1] = value.retype(new_val, phi.operands[o + 1].ty); }
-                }
-                o = o + 1;
+    for (pi < hdr.phi_count) {
+        val uid: id.InstructionId = latch_update(fn, hdr.phis[pi], lp.latch);
+        if (uid == id.INSTR_NIL) { ret R.err[bool, str]("vectorize: loop recurrence has no latch update"); }
+        val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, uid);
+        if (O.is_none[*instruction.Instruction](opt)) { ret R.err[bool, str]("vectorize: loop recurrence update is missing"); }
+        val upd: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt);
+        var scaled: bool = false;
+        var si: u32 = 0;
+        for (si < upd.operand_count) {
+            if (upd.operands[si].kind == value.VAL_CONST_INT) {
+                upd.operands[si] = value.const_int(upd.operands[si].data.int_lit * lanes::u64, upd.operands[si].ty);
+                scaled = true;
             }
+            si = si + 1;
+        }
+        if (!scaled) { ret R.err[bool, str]("vectorize: loop recurrence has no constant step"); }
+        pi = pi + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# re-enter the remainder loop from the vector loop
+#
+# The remainder header is a clone of the vector header, so their phis stand in the
+# same order and phi p continues from vector phi p's final value: for the induction
+# variable the first index the vector loop did not cover, for a secondary induction
+# variable the cursor it left off at. Relabels the cloned `from` edge to come from
+# the vector header and gives each phi that value. False when the two phi lists do
+# not mirror each other, which the clone guarantees they do.
+fun enter_remainder_from(fn: *ir.Function, rem_header: id.BlockId, from: id.BlockId, vec_header: id.BlockId) bool {
+    val rb: *ir.Block = ?fn.blocks[rem_header::u32];
+    val vb: *ir.Block = ?fn.blocks[vec_header::u32];
+    if (rb.phi_count != vb.phi_count) { ret false; }
+    var pi: u32 = 0;
+    for (pi < rb.phi_count) {
+        val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, rb.phis[pi]);
+        if (O.is_none[*instruction.Instruction](opt)) { ret false; }
+        val phi: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt);
+        val src: value.Value = value.instr(vb.phis[pi], phi.ty);
+        var o: u32 = 0;
+        for (o < phi.operand_count) {
+            if ((o % 2) == 0 && ir.block_target(phi.operands[o]) == from) {
+                phi.operands[o].data.int_lit = vec_header::u64;
+                if (o + 1 < phi.operand_count) { phi.operands[o + 1] = value.retype(src, phi.operands[o + 1].ty); }
+            }
+            o = o + 1;
         }
         pi = pi + 1;
     }
+    ret true;
 }
 
 # vectorize the reductions in one function, in two phases like run(): collect the

--- a/src/lang/me/transform/versioning.mach
+++ b/src/lang/me/transform/versioning.mach
@@ -139,18 +139,24 @@ pub fun emit_alias_guard(b: *builder.Builder, d: *dep.DepInfo, init: value.Value
         ret R.ok[value.Value, str](value.const_int(1, i8t));
     }
 
-    # each participating access's byte range [base+init*sz, base+bound_ex*sz)
+    # each participating access's byte range [base+(off+init)*sz, base+(off+bound_ex)*sz).
+    # the access's own element offset shifts BOTH endpoints, so an affine access's
+    # window is the one it really touches rather than the induction variable's (#2312)
     i = 0;
     for (i < n) {
         if (part[i]) {
             val acc: *dep.MemAccess = ?d.accesses[i];
+            val rlo: R.Result[value.Value, str] = shift_index(b, acc.off, init);
+            if (R.is_err[value.Value, str](rlo)) { guard_free3(m, part, starts, ends, n); ret rlo; }
             var ixs: [1]value.Value;
-            ixs[0] = init;
+            ixs[0] = R.unwrap_ok[value.Value, str](rlo);
             val rst: R.Result[value.Value, str] = builder.emit_gep(b, acc.base, acc.stride_ty, ?ixs[0], 1);
             if (R.is_err[value.Value, str](rst)) { guard_free3(m, part, starts, ends, n); ret rst; }
             starts[i] = R.unwrap_ok[value.Value, str](rst);
+            val rhi: R.Result[value.Value, str] = shift_index(b, acc.off, bound_ex);
+            if (R.is_err[value.Value, str](rhi)) { guard_free3(m, part, starts, ends, n); ret rhi; }
             var ixe: [1]value.Value;
-            ixe[0] = bound_ex;
+            ixe[0] = R.unwrap_ok[value.Value, str](rhi);
             val ren: R.Result[value.Value, str] = builder.emit_gep(b, acc.base, acc.stride_ty, ?ixe[0], 1);
             if (R.is_err[value.Value, str](ren)) { guard_free3(m, part, starts, ends, n); ret ren; }
             ends[i] = R.unwrap_ok[value.Value, str](ren);
@@ -192,6 +198,15 @@ pub fun emit_alias_guard(b: *builder.Builder, d: *dep.DepInfo, init: value.Value
 
     guard_free3(m, part, starts, ends, n);
     ret R.ok[value.Value, str](guard);
+}
+
+# the element index a range endpoint sits at: the loop index `ix` shifted by an
+# access's loop-invariant element offset. Zero is the additive identity, so an
+# unshifted `base[iv]` access emits no arithmetic and its guard is byte-for-byte the
+# one it had before affine indices were admitted.
+fun shift_index(b: *builder.Builder, off: value.Value, ix: value.Value) R.Result[value.Value, str] {
+    if (off.kind == value.VAL_CONST_INT && off.data.int_lit == 0) { ret R.ok[value.Value, str](ix); }
+    ret builder.emit_add(b, off, ix);
 }
 
 # free the three working arrays of emit_alias_guard


### PR DESCRIPTION
Closes #2312

The vectorizer accepted an index only when it *was* the loop's induction-variable phi, so every affine offset declined — `a[base+i]`, either access side alone, and even a cursor `t = base; ...; t = t + 1` that is a bare variable incremented by one. `f32_matmul`'s inner loop is exactly that shape and was the worst kernel in the suite.

## The rule

`analysis/dependence.mach` decomposes an index into `off + stride*iv`. Leaves: the induction variable, any loop-invariant value, and a secondary add-recurrence. Interior nodes: add, subtract, and multiply by a constant. Only a **unit stride** is admitted — any other leaves a vector access's lanes non-adjacent. Nothing in the decomposition emits, so an offset that cannot fold to a single value declines rather than growing arithmetic the guard would have to materialize.

Widening the index widens what must be proven, so three things move with it:

- **Same-base pairs.** Two accesses to the same base at different offsets are a nonzero cross-iteration distance the runtime guard cannot discharge — the ranges are the same storage at a shift, not two objects that might overlap. `DEPENDENT` once either writes. Equal offsets remain the distance-0 self dependence that always vectorized. `a[i] = a[i-1] + 1` still declines, now for this reason rather than for the index shape.
- **The alias guard.** Each range endpoint shifts by that access's own offset. A zero offset emits no arithmetic, so an unshifted loop's guard is unchanged.
- **Recurrences.** Every add-recurrence is stepped by the lane count, and the remainder re-enters from the vector loop's final value *per phi* rather than from the induction variable's alone.

## `f32_matmul`

Retired instructions (`instructions:u`), best of 3, C at baseline x86-64:

| | cc -O3 | mach before | mach after |
|---|---|---|---|
| `f32_matmul` | 203,503,663 | 3,420,561,569 (**16.81x**) | 763,013,734 (**3.75x**) |

**4.48x fewer instructions.** Wall clock on the same runs: **42.57x → 3.54x** vs `cc -O3`. Array-loops geomean 2.98x → 2.57x on instructions, 3.22x → 2.52x on wall; whole suite 26.15 G → 23.49 G retired instructions.

Every other kernel's delta is exactly 1.00x, and that is not a measurement claim: of the benchmark's objects only `kernels.o` and `data.o` differ at all, and within them only `k_f32_matmul` (0 → 10 packed) and `data.init` (0 → 2 packed).

## Verification

- **Checksums** `=` on every kernel, before and after.
- **Byte-identity**: compiling the compiler's own 212 objects with the baseline and with this branch, **205 are byte-identical**. The 7 that differ do so only by newly-vectorized loops — each is a `dst[off+i] = src[i]` copy (`dup_bytes`, `write_fixed16`, `seg_dup`, …), packed count up, nothing else moved.
- **Fixpoint** A == B == C.
- **Suites** through the from-source HEAD compiler: mach 911/0, mach-std 611/0 at pin `eff1e8e`; `int` all green on `linux` and `linux-riscv64`. (`linux-arm64` is a `native` leg and cannot execute here; its structural `vectorize-emit` golden is blessed and passes.)
- **Mutation**: 7 of 11 guards fail a case when mutated. The 4 that survive now record at their own site why they are justified rather than dead, per the convention 793f3869 set.

## Goldens

`vectorize-emit` gains a verdict per shape (offset inline and hoisted, either access side, pointer parameter and module-scope array, the matmul row, an affine reduction → `simd`; same-base shifted store at runtime and constant distance, doubled stride, reversed stride, a cursor stepping by two → `scalar`). `vectorize` pairs each vectorizing shape with a `#[scalar]` twin over 5 offsets × 4 trip counts, including offsets no lane count divides.

## Not in scope

**#2313 is mis-diagnosed and is not fixed here.** Integer reductions already vectorize — the shipped golden asserts `sum_i64 simd`, and an `i32` accumulator over an `i32` array emits 6 packed instructions on `dev`. What `u8_count`, `i32_filter_sum` and `i32_madd` actually need is a **widening** accumulator (`s: i64 = s + a[i]::i64` over a narrower array) plus, for the two branchy ones, if-conversion and vector compares. Details on the issue.