### PR TITLE
fix(sema): reject a generic type named without its type arguments

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -552,7 +552,14 @@ fun ut_vec_sema(s: *session.Session, alloc: *A.Allocator, src: str) R.Result[pro
     names[0] = "main.mach";
     var texts: [1]str;
     texts[0] = src;
-    val pr: R.Result[project.Project, outcome.Fail] = ut_build(s, alloc, ?names[0], ?texts[0], 1);
+    ret ut_vec_sema_n(s, alloc, ?names[0], ?texts[0], 1);
+}
+
+# ut_vec_sema over an `n`-file project, for a rule that only fires ACROSS modules:
+# a reference whose origin is another module resolves to SYM_IMPORTED and reads its
+# declaration from that module's AST, a path a single-file fixture never enters
+fun ut_vec_sema_n(s: *session.Session, alloc: *A.Allocator, names: *str, texts: *str, n: u32) R.Result[project.Project, outcome.Fail] {
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(s, alloc, names, texts, n);
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
     val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
@@ -576,6 +583,56 @@ fun ut_vec_diag(src: str, needle: str) i32 {
     session.dnit(?s);
     if (hit) { ret 0; }
     ret 1;
+}
+
+# ut_vec_diag over a two-module project: `main` is `main.mach`, `lib` is `lib.mach`,
+# reachable from main as `uniontest.lib`
+fun ut_vec_diag2(main: str, lib: str, needle: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach";
+    names[1] = "lib.mach";
+    var texts: [2]str;
+    texts[0] = main;
+    texts[1] = lib;
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema_n(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    val hit: bool = ut_diag_has(?p.s.diags, needle);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    if (hit) { ret 0; }
+    ret 1;
+}
+
+# whether the two-module project type-checks with zero error diagnostics
+fun ut_sema_clean2(main: str, lib: str) bool {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret false; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret false; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach";
+    names[1] = "lib.mach";
+    var texts: [2]str;
+    texts[0] = main;
+    texts[1] = lib;
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema_n(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret false; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    val clean: bool = ut_count_errors(?s.diags) == 0;
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret clean;
 }
 
 # 0 when compiling `src` through sema + lower + codegen reaches a DEFINED
@@ -5970,6 +6027,15 @@ test "mach.lang.driver:generic_named_without_type_arguments" {
     # CONTROLS - every legal instance spelling still resolves: concrete, in-generic,
     # nested, multi-argument, and through a `def` alias that names the instance.
     if (!ut_sema_clean("rec Box[T] { v: T; w: T; }\nrec In[T] { x: T; }\nrec Pair[A, B] { a: A; b: B; }\ndef BA: Box[u32];\nfun a[T](b: Box[T]) u64 { ret $size_of(Box[T]) + $offset_of(Box[T], w); }\nfun b[T](x: Box[In[T]]) u64 { ret $size_of(Box[In[T]]); }\nfun c[A, B](p: Pair[A, B]) u64 { ret $size_of(Pair[A, B]); }\nfun d() u64 { var z: BA; ret $size_of(BA); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var x: Box[u32]; var y: Box[In[u32]]; var p: Pair[u32, u64]; a[u32](x); b[u32](y); c[u32, u64](p); d(); ret 0; }\n")) { bad = 21; }
+
+    # ACROSS MODULES, where the reference is a SYM_IMPORTED whose arity has to be read
+    # from the declaring module's AST. a single-file fixture never enters that path, so
+    # the branch is unfalsifiable without these two.
+    if (ut_vec_diag2("use uniontest.lib.Box;\nfun f() u64 { var b: Box; ret $size_of(Box); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "pub rec Box[T] { v: T; w: T; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 22; }
+    if (!ut_sema_clean2("use uniontest.lib.Box;\nuse uniontest.lib.Flat;\nfun f() u64 { var b: Box[u32]; var p: Flat; ret $size_of(Box[u32]) + $size_of(Flat); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "pub rec Box[T] { v: T; w: T; }\npub rec Flat { v: u32; }\n")) { bad = 23; }
 
     ret bad;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -5892,6 +5892,88 @@ test "mach.lang.driver:intrinsic_type_operand_is_a_type" {
     ret bad;
 }
 
+# a generic type named without its type arguments is REJECTED, naming the arity (#2311)
+#
+# The zero-argument spelling had no arity check at all: `resolve_type_named` forks to
+# `instantiate_named` only when args are present, and the fall-through interned the
+# nominal without ever asking whether the declaration was parameterized. So the
+# TEMPLATE was laid out - `$size_of(Box)` answered 16, a compile-time constant wrong
+# for every instantiation but the pointer-width one - and the unbound `T` escaped into
+# non-generic signatures, where the mismatch was reported against a type the user
+# cannot write at that point. Both are silent-wrong-answer shapes, so every assertion
+# here needles on the DIAGNOSTIC: a build that fails for a downstream reason is not a
+# fix. The controls carry the guard's two edges - a declaration with no type
+# parameters, and a generic PARAMETER, whose symbol carries its owner's decl and would
+# otherwise read the owner's arity as its own
+test "mach.lang.driver:generic_named_without_type_arguments" {
+    var bad: i32 = 0;
+
+    # the type positions a bare name reaches: a local, a parameter, a pointee, a return
+    # type, a field of a non-generic record, and a `def` alias target.
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\nfun f() u32 { var b: Box; ret 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 1; }
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\nfun f(b: Box) u32 { ret 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 2; }
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\nfun f(p: *Box) u32 { ret 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 3; }
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\nfun f() Box { var b: Box[u32]; ret b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 4; }
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\nrec Outer { b: Box; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 5; }
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\ndef Alias: Box;\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 6; }
+
+    # the layout intrinsics, which answered against the template. these are the
+    # numbers the issue measured wrong.
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\nfun f() u64 { ret $size_of(Box); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 7; }
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\nfun f() u64 { ret $align_of(Box); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 8; }
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\nfun f() u64 { ret $offset_of(Box, w); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 9; }
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\nfun f() u64 { var n: u64 = 0; $each g in $fields(Box) { n = n + 1; } ret n; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 10; }
+
+    # an array length sized off the template - the shape that silently allocates the
+    # wrong number of bytes.
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\nfun f() u8 { var buf: [$size_of(Box)]u8; ret buf[0]; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 11; }
+
+    # the `$type_of` comparand, the one type spelling that arrives as an EXPRESSION and
+    # so reaches the leaf by its own path.
+    if (ut_vec_diag("rec Box[T] { v: T; w: T; }\nfun f() i64 { var b: Box[u32]; $if ($type_of(b) == Box) { ret 1; } $or { ret 0; } }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "generic type `Box` named without type arguments: expected 1, found 0") != 0) { bad = 12; }
+
+    # the arity is the DECLARATION's, and a generic union takes the same path as a record.
+    if (ut_vec_diag("rec Pair[A, B] { a: A; b: B; }\nfun f() u64 { ret $size_of(Pair); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "generic type `Pair` named without type arguments: expected 2, found 0") != 0) { bad = 13; }
+    if (ut_vec_diag("uni U[T] { a: T; b: u32; }\nfun f() u64 { ret $size_of(U); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "generic type `U` named without type arguments: expected 1, found 0") != 0) { bad = 14; }
+
+    # the `T`-leak: the error is the signature's, reported ONCE, and the downstream
+    # "expected u32, found T" it used to cascade into is gone.
+    if (ut_sema_errs("rec Box[T] { v: T; }\nfun f(b: Box) u32 { ret b.v; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n") != 1) { bad = 15; }
+
+    # CONTROLS, edge one - a declaration that takes no type parameters is named bare in
+    # every one of those positions and stays clean. this is what a guard that fired on
+    # "names a declaration" rather than "declares parameters" would break.
+    if (!ut_sema_clean("rec Plain { v: u32; }\ndef PA: Plain;\nfun f(p: Plain, q: *Plain) u64 { var r: Plain; var a: PA; var n: u64 = 0; $each g in $fields(Plain) { n = n + 1; } ret $size_of(Plain) + $align_of(Plain) + $offset_of(Plain, v) + n; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var p: Plain; f(p, ?p); ret 0; }\n")) { bad = 16; }
+    if (!ut_sema_clean("rec Plain { v: u32; }\nfun f() i64 { var p: Plain; $if ($type_of(p) == Plain) { ret 1; } $or { ret 0; } }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n")) { bad = 17; }
+    if (!ut_sema_clean("uni V { a: u32; b: u32; }\nfun f(v: V) u64 { ret $size_of(V); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var v: V; f(v); ret 0; }\n")) { bad = 18; }
+
+    # CONTROLS, edge two - a generic PARAMETER named bare inside its owner. its symbol
+    # carries the OWNER's decl, so an arity read that did not exclude it would reject
+    # every generic body in the language.
+    if (!ut_sema_clean("fun f[T](v: T) T { var x: T; var p: *T; var a: [2]T; x = v; ret x; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f[u32](1); ret 0; }\n")) { bad = 19; }
+    if (!ut_sema_clean("rec P { x: u32; }\nfun f[T](v: T) u64 { var n: u64 = 0; $each g in $fields(T) { n = n + 1; } ret $size_of(T) + $align_of(T) + n; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var p: P; f[P](p); ret 0; }\n")) { bad = 20; }
+
+    # CONTROLS - every legal instance spelling still resolves: concrete, in-generic,
+    # nested, multi-argument, and through a `def` alias that names the instance.
+    if (!ut_sema_clean("rec Box[T] { v: T; w: T; }\nrec In[T] { x: T; }\nrec Pair[A, B] { a: A; b: B; }\ndef BA: Box[u32];\nfun a[T](b: Box[T]) u64 { ret $size_of(Box[T]) + $offset_of(Box[T], w); }\nfun b[T](x: Box[In[T]]) u64 { ret $size_of(Box[In[T]]); }\nfun c[A, B](p: Pair[A, B]) u64 { ret $size_of(Pair[A, B]); }\nfun d() u64 { var z: BA; ret $size_of(BA); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var x: Box[u32]; var y: Box[In[u32]]; var p: Pair[u32, u64]; a[u32](x); b[u32](y); c[u32, u64](p); d(); ret 0; }\n")) { bad = 21; }
+
+    ret bad;
+}
+
 # 0 when building `src` through the real build engine fails with no recorded artifact,
 # 1 on any other outcome. The end-to-end assertion #2168 needed: the leak there was not
 # a missing diagnostic but a build that PRINTED one and still reported success, linked,

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -788,6 +788,30 @@ pub fun report_named(sc: *context.SemaContext, span: token.Span, prefix: str, na
     A.deallocate[char](sc.s.alloc, msg, str_len(msg) + 1);
 }
 
+# report a generic type named without its type arguments, citing the declared
+# arity and the spelling that fixes it
+#
+# The note carries the rule, because the mistake is not a miscount: the template
+# is not a type at all, and the count alone reads like an off-by-one. Any
+# allocation failure degrades to a static, name-free message so the error is
+# always reported.
+# ---
+# sc:       the active sema context
+# span:     source range to pin the diagnostic to
+# name:     interned identifier of the generic declaration
+# expected: the declared type-parameter count
+pub fun report_missing_type_args(sc: *context.SemaContext, span: token.Span, name: intern.StrId, expected: u32) {
+    val note: str = "a generic declaration is a template, not a type; name it with its type arguments";
+    val res_msg: R.Result[str, str] = format.sprint(sc.s.alloc, "generic type `{}` named without type arguments: expected {}, found 0", name_str(sc, name), expected::usize);
+    if (R.is_err[str, str](res_msg)) {
+        context.report_note(sc, span, "generic type named without type arguments", note);
+        ret;
+    }
+    val msg: str = R.unwrap_ok[str, str](res_msg);
+    context.report_note(sc, span, msg, note);
+    A.deallocate[char](sc.s.alloc, msg, str_len(msg) + 1);
+}
+
 # report `<prefix><type><suffix>` at `span`, rendering `t` through type_to_str
 #
 # on any allocation failure it degrades to the static `fallback` so the

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -123,11 +123,8 @@ pub fun check_arity(
     arg_count:      u32,
     span:           token.Span
 ) bool {
-    var a: *ast.Ast = sc.a;
-    if (generic_origin != sc.own_module) {
-        a = session.module_ast(sc.s, generic_origin);
-        if (a == nil) { ret true; }
-    }
+    val a: *ast.Ast = declaring_ast(sc, generic_origin);
+    if (a == nil) { ret true; }
 
     val opt_want: O.Option[u32] = generic_count_in(a, generic_decl);
     if (O.is_none[u32](opt_want)) {
@@ -141,6 +138,43 @@ pub fun check_arity(
         ret false;
     }
     ret true;
+}
+
+# the number of type parameters a declaration declares
+#
+# The counterpart to `check_arity` for the argument-free spelling, where there is
+# no argument list to check against and the only question is whether one was
+# required (#2311). A declaration that cannot carry type parameters reads 0, so
+# a `def` or a plain record is not an arity error. An origin AST that cannot be
+# reached reads 0 for the same reason `check_arity` accepts it: the reference
+# fails at its own leaf (`type_for_symbol` reports the unresolvable import), so
+# a missing dependency never masquerades as an arity error.
+# ---
+# sc:             the active sema context
+# generic_decl:   DeclId of the declaration
+# generic_origin: ModuleId that declared it
+# ret:            the declared type-parameter count, 0 when it declares none
+pub fun declared_arity(sc: *sema.SemaContext, generic_decl: id.DeclId, generic_origin: session.ModuleId) u32 {
+    val a: *ast.Ast = declaring_ast(sc, generic_origin);
+    if (a == nil) { ret 0; }
+
+    val opt_want: O.Option[u32] = generic_count_in(a, generic_decl);
+    if (O.is_none[u32](opt_want)) { ret 0; }
+    ret O.unwrap[u32](opt_want);
+}
+
+# the AST of the module that declares a referenced declaration
+#
+# This module's own AST for a local declaration, the origin dependency's (through
+# the session registry) for a cross-module one: a use site's arity is measured
+# against the declaring module, never against the use site's.
+# ---
+# sc:     the active sema context
+# origin: ModuleId that declared the referenced declaration
+# ret:    the declaring module's AST, or nil when it cannot be reached
+fun declaring_ast(sc: *sema.SemaContext, origin: session.ModuleId) *ast.Ast {
+    if (origin == sc.own_module) { ret sc.a; }
+    ret session.module_ast(sc.s, origin);
 }
 
 # rewrite a generic body type by substituting each generic parameter with the

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -2255,12 +2255,32 @@ fun resolve_type_named(sc: *context.SemaContext, tid: id.TypeId, named: *atype.T
 # resolves to SYM_IMPORTED (the originating rec/uni/def kind is not carried on
 # the import symbol), so its type is read from the dependency's recorded
 # decl_type, which already holds the nominal TypeId or the def's underlying.
+#
+# Both callers reach here only with an ARGUMENT-FREE spelling -- `resolve_type_named`
+# forks to `instantiate_named` the moment args are present, and a `$type_of`
+# comparand cannot spell an instance -- so this is where a generic named bare is
+# caught (#2311).
 # ---
 # sc:   sema context
 # sym:  the resolved type-name symbol
 # span: the name span for diagnostics
 # ret:  the named TypeId, or TYPE_ERROR
 fun type_for_symbol(sc: *context.SemaContext, sym: *resolve.Symbol, span: token.Span) type.TypeId {
+    # a generic declaration named with no type arguments is the TEMPLATE, whose
+    # parameters are unbound and which therefore has no layout. Laying it out
+    # answered `$size_of(Box)` with a constant wrong for every instantiation, and
+    # leaked the unbound `T` into non-generic signatures, where the mismatch was
+    # reported against a type the user cannot write (#2311). Only the kinds whose
+    # `decl` IS the type declaration are asked: a SYM_GENERIC's `decl` is the owner
+    # of the parameter, whose arity is not the parameter's own.
+    if (sym.kind == resolve.SYM_REC || sym.kind == resolve.SYM_UNI || sym.kind == resolve.SYM_IMPORTED) {
+        val arity: u32 = generics.declared_arity(sc, sym.decl, sym.origin);
+        if (arity > 0) {
+            check.report_missing_type_args(sc, span, sym.name, arity);
+            ret type.TYPE_ERROR;
+        }
+    }
+
     if (sym.kind == resolve.SYM_PRIM) {
         ret prim_or_error(sc, sym.slot::type.TypeKind);
     }


### PR DESCRIPTION
Closes #2311

## The defect

`resolve_type_named` forks to `instantiate_named` only when `named.args_len > 0`;
the fall-through reached `type_for_symbol`, which interned the nominal without
ever asking whether the declaration was parameterized. So a bare `Box` where
`Box[T]` was declared was accepted in every type position, with zero diagnostics.

It was not inert. The layout intrinsics answered against the **template**, with
`T` unbound and sized as a pointer:

```
size_of(Box)      = 16      offset_of(Box, w)     = 8
size_of(Box[u8])  = 2       offset_of(Box[u8], w) = 1
```

`$size_of(Box)` was a compile-time constant wrong for every instantiation but the
pointer-width one, produced silently.

## The fix

`type_for_symbol` is the single map from a resolved type-name symbol to the type
it names, and **both** callers reach it only with the argument-free spelling
(`resolve_type_named` forks first; a `$type_of` comparand cannot spell an
instance). The arity rule lands there: a declaration that declares type
parameters does not name a type when spelled bare.

`generics.declared_arity` is the count-only counterpart to the existing
`check_arity` for the case with no argument list to check against; both now share
a `declaring_ast` helper, so "which module declares this" has one definition.

Only the symbol kinds whose `decl` **is** the type declaration are asked
(`SYM_REC`, `SYM_UNI`, `SYM_IMPORTED`). A `SYM_GENERIC` carries its *owner's*
decl, whose arity is not the parameter's own — asking it would reject every
generic body in the language.

## The diagnostic

```
error: generic type `Box` named without type arguments: expected 1, found 0
 --> ./src/main.mach:8:22
  |
8 | fun f() u32 { var b: Box; ret 0; }
  |                      ^^^
  |
  = note: a generic declaration is a template, not a type; name it with its type arguments
```

The `T`-leaking signature now points at the real cause instead of a type the user
cannot write:

| | |
|---|---|
| **before** | `error: type mismatch: expected u32, found T` at `ret b.v` (col 21), with a "cast the value" note |
| **after** | the message above at `b: Box` (col 10) — one diagnostic, on the signature |

## Surface

**Newly rejected** (each was silently accepted before, each verified to carry the
diagnostic above): local `var b: Box`, parameter `b: Box`, pointee `*Box`, return
type `fun f() Box`, field of a non-generic record, `def Alias: Box`,
`$size_of` / `$align_of` / `$offset_of` / `$fields`, an array length
`[$size_of(Box)]u8`, the `$type_of(x) == Box` comparand, a generic `uni`, and a
two-parameter generic (`expected 2, found 0`).

**Already correct, and still accepted** — verified compiling clean on both the
base and fixed compilers:

- every instance spelling: `Box[u32]`, `Box[T]` inside a generic, nested
  `Box[In[T]]`, multi-argument `Pair[A, B]`, cross-module `O.Option[u32]`
- a declaration with **no** type parameters named bare in every position above
  (local, parameter, pointee, `def` target, all four intrinsics, `$type_of`
  comparand) — `rec Plain` and `uni V`
- a generic **parameter** named bare inside its owner: `var x: T`, `*T`, `[2]T`,
  `$size_of(T)`, `$align_of(T)`, `$fields(T)`
- a `def` alias naming an instance (`def BA: Box[u32]`) and used bare

`int/regression/2178-intrinsic-type-operand` uses only argument-bearing spellings
and is unaffected.

## Verification

- **Objects byte-identical, linux-x86_64 release.** The full compiler + mach-std
  corpus compiled with the base compiler and with the fixed compiler produced
  byte-identical objects (`diff -r`) *and* a byte-identical linked binary
  (`cmp`). The base compiler was itself confirmed byte-identical to one built
  from pristine `dev` HEAD `b9748c03`.
- That same run is the corpus check: the fixed compiler builds the compiler and
  mach-std clean, so neither uses a bare generic name anywhere.
- **Suites through the from-source HEAD compiler:** `914 passed / 0 failed` on
  pristine `dev` HEAD → `915 passed / 0 failed` on this branch. Delta is exactly
  the one new test.
- mach-std materialized with `git archive` from pin `eff1e8e`.
- **Mutations** — see the comment below.
- No fixpoint run: the change is a front-end rejection and codegen did not move
  (objects byte-identical).

## Pre-existing, out of scope

A type-name diagnostic in an intrinsic operand or a signature is reported more
than once (repeated type-resolution passes). This is unchanged by the fix — on
`dev`, `$size_of(Box[u32, u32])` already reported `wrong number of type
arguments` twice, and two wrong-arity sites in a signature already reported three
times. Surfacing it rather than absorbing it; not touched here.