### PR TITLE
fix(lower): strip `^` before resolving a field of a secret container

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4591,6 +4591,51 @@ fun ut_sema_errs(text: str) i32 {
 # whether `text` type-checks with zero sema errors
 fun ut_sema_clean(text: str) bool { ret ut_sema_errs(text) == 0; }
 
+# the number of error diagnostics on the session sink after `text` runs resolve + sema +
+# LOWER, or -1 when the harness could not get that far
+#
+# The lowering sibling of `ut_sema_errs`, and NOT interchangeable with `ut_lower_ok`:
+# that one reports the lower pass's RESULT, which a diagnostic-only failure leaves ok.
+# Lowering records some errors on the sink and returns normally, letting the sink gate
+# the build later - so a lowering defect can be present with `ut_lower_ok` still
+# reporting success. A test that a lowering rejection is gone must read the sink (#2297).
+# ---
+# text: the single-module source to compile
+# ret:  the sink's error count after lowering, or -1 on a harness failure
+fun ut_lower_errs(text: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret -1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret -1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = text;
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret -1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var errs: i32 = ut_count_errors(?s.diags)::i32;
+    if (errs == 0) {
+        errs = -1;
+        val sem: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+        if (R.is_ok[bool, outcome.Fail](sem)) {
+            passes.run_lower_pass(?p);
+            errs = ut_count_errors(?s.diags)::i32;
+        }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret errs;
+}
+
+# whether `text` reaches the end of lowering with no error on the sink
+fun ut_lower_clean(text: str) bool { ret ut_lower_errs(text) == 0; }
+
 # whether `text` is rejected with at least one sema error
 fun ut_sema_rejects(text: str) bool { ret ut_sema_errs(text) > 0; }
 
@@ -4919,6 +4964,51 @@ test "mach.lang.driver:secret_pointer_not_launderable" {
     if (!ut_sema_rejects("fun f(p: *^u8) ptr { ret p:~ptr; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
     if (!ut_sema_rejects("fun f(p: *u8, s: ^u8) { @p = s; }\nfun main() i32 { ret 0; }\n"))   { bad = 1; }
     if (!ut_sema_clean("fun f(p: *u8) ptr { ret p; }\nfun main() i32 { ret 0; }\n"))          { bad = 1; }
+    ret bad;
+}
+
+# lowering resolves a field of a SECRET container against the stripped nominal (#2297).
+#
+# `^` has no runtime representation, so `lower_type` lowers `^T` to exactly `T`'s shape -
+# but lowering's receiver resolution read the qualifier, found no field table on the `^`,
+# and reported the field missing. `sema.check_member` strips identically and accepted the
+# program, so a documented-legal read was rejected at the NEXT stage for an unrelated
+# reason. These use `ut_lower_ok`, not `ut_sema_clean`: sema was never the failing stage,
+# and a sema-only assertion passes with the defect present.
+#
+# The rejection arms are asserted BY DIAGNOSTIC TEXT, and that is the point of the issue
+# rather than a house style. A `^*Rec` receiver is a genuine secret-address hole (#2191),
+# and while this bug stood it was answered by `no field 'x'` - so the hole read as closed
+# to anyone counting errors instead of reading them. Each arm below must fail for its own
+# stated reason, or the same masking recurs the next time a gate is removed.
+test "mach.lang.driver:secret_container_field_lowers" {
+    var bad: i32 = 0;
+
+    # DOCUMENTED-LEGAL, and rejected by lowering before the fix
+    if (!ut_lower_clean("rec R { x: u8; y: u8; }\nfun f(r: ^R) ^u8 { ret r.x; }\nfun main() i32 { ret 0; }\n"))   { bad = 1; }
+    if (!ut_lower_clean("rec R { x: u8; y: u8; }\nfun f(q: *^R) ^u8 { ret q.x; }\nfun main() i32 { ret 0; }\n"))  { bad = 1; }
+    # a non-leading field, so a pass that folded every miss to ordinal 0 cannot survive
+    if (!ut_lower_clean("rec R { x: u8; y: u8; }\nfun f(r: ^R) ^u8 { ret r.y; }\nfun main() i32 { ret 0; }\n"))   { bad = 1; }
+    # nested, so the stripped receiver has to compose through an inner public record
+    if (!ut_lower_clean("rec R { x: u8; y: u8; }\nrec O { r: R; }\nfun f(o: ^O) ^u8 { ret o.r.x; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # `$offset_of` resolves its field through the same helper and had the same miss
+    if (!ut_lower_clean("rec R { x: u8; y: u8; }\ndef S: ^R;\nval N: u64 = $offset_of(S, y);\nfun f() u64 { ret N; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # the form that already worked: a secret ARRAY field of a public record
+    if (!ut_lower_clean("rec K { d: ^[4]u8; }\nfun f(k: *K) ^u8 { ret k.d[2]; }\nfun main() i32 { ret 0; }\n"))   { bad = 1; }
+
+    # THE RESULT IS STILL SECRET - a working field path must not launder the taint
+    if (!ut_sema_rejects_with("rec R { x: u8; y: u8; }\nfun f(r: ^R) u8 { ret r.x; }\nfun main() i32 { ret 0; }\n",
+        "expected u8, found ^u8")) { bad = 1; }
+    if (!ut_sema_rejects_with("rec R { x: u8; y: u8; }\nfun f(r: ^R) u8 { if (r.x == 1) { ret 1; } ret 0; }\nfun main() i32 { ret 0; }\n",
+        "secret value used as a branch condition")) { bad = 1; }
+    if (!ut_sema_rejects_with("rec R { x: u8; y: u8; }\nfun f(r: ^R, a: *u8) u8 { ret a[r.x]; }\nfun main() i32 { ret 0; }\n",
+        "secret value used as a memory index")) { bad = 1; }
+
+    # A SECRET POINTER RECEIVER IS STILL AN ADDRESS (#2191), and still says so
+    if (!ut_sema_rejects_with("rec R { x: u8; y: u8; }\nfun f(p: ^*R) ^u8 { ret p.x; }\nfun main() i32 { ret 0; }\n",
+        "secret value used as a memory address")) { bad = 1; }
+    if (!ut_sema_rejects_with("fun f(p: ^*u8) ^u8 { ret p[0]; }\nfun main() i32 { ret 0; }\n",
+        "secret value used as a memory address")) { bad = 1; }
     ret bad;
 }
 

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1306,14 +1306,21 @@ fun lower_index_lvalue(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr
     # secret-stripped for the same reason as `member_receiver`: `^*T` and `^[N]T` index
     # exactly as `*T` and `[N]T` do (#2297).
     #
-    # UNREACHABLE TODAY, and deliberately kept: the only shape that needs it is a secret
-    # POINTER receiver, which #2191's secret-address gate now rejects in sema before
-    # lowering runs - a `^[N]T` array reaches the array path either way, since
-    # `lower_type` strips there. Reverting this line leaves the whole suite green, so it
-    # carries no test of its own. It stays because the alternative is one normalization
-    # rule applied in `member_receiver` and silently not here, which is how the miss
-    # arose: any future index shape sema admits through a `^` would land on the same gep
-    # into a non-aggregate.
+    # DELIBERATELY UNTESTED, AND NOT DEAD. Do not delete it for surviving its mutation.
+    #
+    # The only shape that needs the strip here is a secret POINTER receiver, `^*T`. Sema
+    # rejects that shape as a secret address (#2191) BEFORE lowering runs, so no program
+    # reaches this line needing it and reverting it leaves the whole suite green. That is
+    # a fact about where #2191's gate currently sits, not about this code: a `^[N]T` array
+    # reaches the array path either way (`lower_type` strips there), so the array form
+    # cannot cover it either. If that gate ever moves or narrows, this becomes reachable
+    # and a test becomes possible - write it then.
+    #
+    # It stays because the alternative is the normalization applied in `member_receiver`
+    # and silently omitted in its sibling, which is exactly how #2297 arose: any index
+    # shape sema later admits through a `^` would land on the same gep into a
+    # non-aggregate. An asymmetric rule is not a smaller change, it is the same defect
+    # moved one function over.
     val obj_ty: type.TypeId = type.strip_secret(?ctx.s.types, context.expr_type_of(ctx, e.data.index.object));
     val is_ptr: bool        = is_pointer_type(ctx, obj_ty);
 

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1303,7 +1303,18 @@ fun lower_vector_lane_read(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.
 # e:   the resolved index node
 # ret: the element pointer Value, or an error
 fun lower_index_lvalue(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Result[value.Value, str] {
-    val obj_ty: type.TypeId = context.expr_type_of(ctx, e.data.index.object);
+    # secret-stripped for the same reason as `member_receiver`: `^*T` and `^[N]T` index
+    # exactly as `*T` and `[N]T` do (#2297).
+    #
+    # UNREACHABLE TODAY, and deliberately kept: the only shape that needs it is a secret
+    # POINTER receiver, which #2191's secret-address gate now rejects in sema before
+    # lowering runs - a `^[N]T` array reaches the array path either way, since
+    # `lower_type` strips there. Reverting this line leaves the whole suite green, so it
+    # carries no test of its own. It stays because the alternative is one normalization
+    # rule applied in `member_receiver` and silently not here, which is how the miss
+    # arose: any future index shape sema admits through a `^` would land on the same gep
+    # into a non-aggregate.
+    val obj_ty: type.TypeId = type.strip_secret(?ctx.s.types, context.expr_type_of(ctx, e.data.index.object));
     val is_ptr: bool        = is_pointer_type(ctx, obj_ty);
 
     # a pointer base is consumed by its rvalue; an array base by its lvalue (its
@@ -1437,7 +1448,11 @@ pub fun try_lower_comptime_intrinsic(ctx: *context.LowerContext, eid: id.ExprId,
         ret O.some[R.Result[value.Value, str]](R.err[value.Value, str]("lower: comptime intrinsic argument index out of range"));
     }
     val arg0_eid: id.ExprId   = ctx.a.expr_ids[e.data.call.args_start];
-    val op_ty:    type.TypeId = context.expr_type_of(ctx, arg0_eid);
+    # secret-stripped like every other shape decision here (#2297): `^T` occupies
+    # exactly `T`'s storage, so `$size_of` / `$align_of` already agreed via
+    # `lower_type`, while `$offset_of`'s field lookup read the qualifier and reported
+    # the field missing.
+    val op_ty:    type.TypeId = type.strip_secret(?ctx.s.types, context.expr_type_of(ctx, arg0_eid));
     val res_op_ir: R.Result[ir_type.IrTypeId, str] = context.lower_type(ctx, op_ty);
     if (R.is_err[ir_type.IrTypeId, str](res_op_ir)) {
         ret O.some[R.Result[value.Value, str]](R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_op_ir)));
@@ -3393,6 +3408,14 @@ fun fn_reference(ctx: *context.LowerContext, link: intern.StrId, vty: ir_type.Ir
 # value receiver uses its own storage (base = its lvalue, record = its type),
 # mirroring the array / pointer split in lower_index_lvalue. The record type is
 # written through `out_rec_ty`.
+#
+# Both the receiver and the pointee are secret-stripped, so a `^Rec` value and a
+# `*^Rec` pointer resolve their fields against `Rec` (#2297). `^` has no runtime
+# representation - `lower_type` lowers `^T` to exactly `T`'s shape - so every shape
+# decision here must read the same stripped type that lowering will lower, and
+# `sema.check_member` strips identically before resolving the field. Reading the
+# qualifier instead finds no field table on the `^` and reports the field missing,
+# rejecting a documented-legal read for an unrelated reason.
 # ---
 # ctx:             per-module lowering context
 # eid:             the member / projection expression (for a located diagnostic)
@@ -3401,7 +3424,7 @@ fun fn_reference(ctx: *context.LowerContext, link: intern.StrId, vty: ir_type.Ir
 # out_rec_ty:      written with the record type the field is resolved against
 # ret:             the base pointer Value, or an error
 fun member_receiver(ctx: *context.LowerContext, eid: id.ExprId, obj_eid: id.ExprId, untyped_ptr_msg: str, out_rec_ty: *type.TypeId) R.Result[value.Value, str] {
-    val obj_ty: type.TypeId = context.expr_type_of(ctx, obj_eid);
+    val obj_ty: type.TypeId = type.strip_secret(?ctx.s.types, context.expr_type_of(ctx, obj_eid));
     if (is_pointer_type(ctx, obj_ty)) {
         val opt_pt: O.Option[*type.Type] = type.get(?ctx.s.types, obj_ty);
         if (O.is_none[*type.Type](opt_pt)) { ret R.err[value.Value, str]("lower: receiver base has no pointer type"); }
@@ -3409,7 +3432,7 @@ fun member_receiver(ctx: *context.LowerContext, eid: id.ExprId, obj_eid: id.Expr
         if (pt.kind != type.TYPE_POINTER) {
             ret report_expr(ctx, eid, untyped_ptr_msg);
         }
-        @out_rec_ty = pt.data.pointer.base;
+        @out_rec_ty = type.strip_secret(?ctx.s.types, pt.data.pointer.base);
         ret lower_rvalue(ctx, obj_eid);
     }
     @out_rec_ty = obj_ty;


### PR DESCRIPTION
Closes #2297.

## Mechanism

`^` has no runtime representation — `lower_type` lowers `^T` to exactly `T`'s shape — but lowering's receiver resolution read the type with the qualifier still on, found no field table on the `^`, and reported the field missing. `sema.check_member` strips identically and accepted the program, so a **documented-legal** read was rejected at the *next* stage for an unrelated reason.

Three sites now read the same stripped type that `lower_type` will lower:

| site | shape | before |
|---|---|---|
| `member_receiver` receiver | `^R` | `no field 'x' on the receiver type` |
| `member_receiver` pointee | `*^R` | `no field 'x' on the receiver type` |
| `$size_of` / `$align_of` / `$offset_of` operand | `$offset_of(^R, y)` | `no field 'y' on the receiver type` |

The `$offset_of` case is not in the issue — I found it probing the siblings. It is the same omission in the same helper one call site over, so it is fixed here rather than filed separately.

`lower_index_lvalue` is normalized the same way but is **unreachable today** and has no test: #2191's secret-address gate rejects the only shape (`^*T`) before lowering runs, and reverting that line leaves the whole suite green. Kept, and labelled as such in the code, because the alternative is the rule applied in one receiver path and silently omitted in its sibling — which is how this arose.

## Bar

**Compiles and reads the right byte** — executed:
```
x=41 y=97 ptr=41 arr=33
```
covering `^R`, a non-leading field of `^R`, `*^R`, and the `^[4]u8` field form that already worked.

**Still secret** — each rejected with its own diagnostic, identical before and after:

| use | diagnostic |
|---|---|
| into a public slot | `type mismatch: expected u8, found ^u8` |
| branch condition | `secret value used as a branch condition` |
| memory index | `secret value used as a memory index` |

**#2191's gate still fires, and still says so** — `^*R` field and `^*u8` index both still `secret value used as a memory address`, unchanged.

## Test

`ut_lower_ok` could not see this defect: it reports the lower pass's *result*, and the miss records a diagnostic on the sink while lowering returns normally. **The first version of this test passed against the unfixed compiler.** Added `ut_lower_errs` / `ut_lower_clean`, which read the sink.

The rejection arms assert diagnostic **text**, which is this issue's own lesson — while the bug stood, a genuine secret-address hole was answered by `no field 'x'`, so it read as closed to anyone counting errors.

- Fails on pristine `dev` lowering with the same test file, passes with the fix.
- **Mutation**: reverting the `member_receiver` strip alone kills it; reverting the `$offset_of` strip alone kills it. Reverting the index strip does not — that is the unreachability above, measured rather than asserted.

## Verification

- **mach 915 / 1**, **mach-std 611 / 0** at pin `eff1e8e` (`git archive` + `diff -r`, not a clone).
- The 1 failure is **pre-existing on `dev`**: `mach.lang.target.isa.blank:every_construction_site_is_constructed` fails identically on a pristine checkout of `4fdbb2aa` with no changes of mine (914/1 there, 915/1 here — exactly +1 test, nothing broken). Reported separately; not touched.
- **Byte-identity, linux-x86_64 release**: the same fixed input compiled by the pre and post compilers is byte-identical (`b6579dee…`). Codegen does not move for anything that already compiled — the change only adds acceptance — so no fixpoint is required per the standing bar.