### PR TITLE
fix(codegen): build the census's last bare IsaVTable through its constructor

### DIFF
--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -1290,8 +1290,8 @@ test "mach.lang.be.codegen.mir.context.vector_scaffolding" {
     classes[0].kind = isa.RC_GENERAL;
     classes[1].kind = isa.RC_FLOAT;
     classes[1].bit_width = 128;
-    var arch: isa.IsaVTable;
-    arch.pointer_width = 8;
+    var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "machine", 0, 8,
+                                              nil, 0, nil, nil, nil);
     var tgt: target.Target;
     tgt.isa                 = ?arch;
     tgt.model.reg_classes   = ?classes[0];


### PR DESCRIPTION
Closes #2329. **`dev` is red without this** — every open PR's merge build fails the same assertion, so other work is currently reading a CI failure that is not its own.

## Evidence

Clean `dev` checkout at `538a9669`, nothing else applied:

```
mach.lang.target.isa.blank:every_construction_site_is_constructed
  ./src/lang/target/isa/tests.mach:450  (exit 1)
922 passed, 1 failed, 923 total
```

With this patch: **923 passed, 0 failed, 923 total.**

## The site

```
src/lang/be/codegen/mir/context.mach:1293
test "mach.lang.be.codegen.mir.context.vector_scaffolding"

    var arch: isa.IsaVTable;
    arch.pointer_width = 8;
```

## Why it is a race, not a regression

Neither change was wrong alone:

- **#2289** (PR #2318) added the bare `IsaVTable` in a test helper.
- **#2300** widened the census to scan the whole of `src` rather than two chosen subtrees, and added `IsaVTable` to the censused set.

They landed without seeing each other, and there is no textual conflict — the collision is semantic, in a *count*, so nothing flagged it at merge time.

## The direction

Converted, not permitted. Raising the group's budget would have made the number go up without making the code right; conversion is what #2300 did to 55 other sites, and what the sibling helpers in `ctvalidate.mach` and `of/macho.mach` already do. The site only wanted `pointer_width = 8` — every other field now comes from the constructor rather than staying whatever the stack held, which is the actual point of the census.

## Size

**Not `.text`-neutral, and measured rather than assumed** (#2320 — test bodies do reach release objects):

| | dev | this PR | Δ |
|---|---:|---:|---:|
| `context.o` `.text` | 51,042 | 51,123 | **+81** |
| `context.o` total | 79,776 | 80,176 | +400 |

A constructor call that initializes every field replaces a single field write, so the growth is expected. No other object moves.

## Bar

Minimal by agreement: suite green on `dev` with it applied. No fixpoint or byte-identity run — this is a one-line test-helper change, and its `.text` effect is reported above rather than claimed to be zero.