### PR TITLE
fix(test): construct the scaffolding vtable instead of declaring it bare — dev is red

### DIFF
--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -1290,8 +1290,11 @@ test "mach.lang.be.codegen.mir.context.vector_scaffolding" {
     classes[0].kind = isa.RC_GENERAL;
     classes[1].kind = isa.RC_FLOAT;
     classes[1].bit_width = 128;
-    var arch: isa.IsaVTable;
-    arch.pointer_width = 8;
+    # through the family constructor, not a bare declaration: `var` does not zero, so
+    # the fields this test does not care about would otherwise hold the frame's residue
+    # (#2294). Only `pointer_width` is read here - the layout queries `op_width_of`
+    # routes to need a resolved target.
+    var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, 0, nil, nil, nil);
     var tgt: target.Target;
     tgt.isa                 = ?arch;
     tgt.model.reg_classes   = ?classes[0];


### PR DESCRIPTION
**`dev` is red.** `mach.lang.target.isa.blank:every_construction_site_is_constructed` fails at `538a9669` — 922 / 1. This is a one-line fix to make it green.

## Cause

The census finds exactly one unpermitted site, and it is mine:

```
src/lang/be/codegen/mir/context.mach:1293  var arch: isa.IsaVTable;
```

Added by `c17c5cec` (#2318) to give the vector-scaffolding test the resolved target the shared layout policy needs.

**Neither change was wrong when it merged.** #2294 added the census; #2318 added a bare declaration. Each was green on its own branch, and the pair is red. There was no textual conflict, so nothing flagged it — a semantic merge collision.

## The census is right on the substance

Not just bookkeeping. `var` does not zero, so every field of that vtable except `pointer_width` held the frame's residue. Nothing read them, which is the only reason it worked — and "nothing reads it today" is precisely the property that stops being true later.

It now goes through `machine_isa`, the same family constructor `ctvalidate`'s `t_isa` was moved to for this exact reason, so a field added to `IsaVTable` later is cleared here with no visit to this site.

## Verification

- **923 / 0** on this branch (`dev` is 922 / 1).
- Byte-identity linux-x86_64 release: the change is confined to a `test` block, so no shipped code moves. Reported below rather than assumed — a test-only change *can* move objects (#2320).
