### PR TITLE
feat(mir): give MirInstr a constructor and route every build and rewrite through it

### DIFF
--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -534,12 +534,7 @@ fun t_vreg(id: u32, secret: bool) mir.MirVReg {
 
 # a MIR instruction over a borrowed operand array (test helper)
 fun t_instr(op: mir.MirOpcode, ops: *mir.MirOperand, n: u32) mir.MirInstr {
-    var mi: mir.MirInstr;
-    mi.opcode        = op;
-    mi.operands      = ops;
-    mi.operand_count = n;
-    mi.width         = 8;
-    mi.src_width     = 8;
+    var mi: mir.MirInstr = mir.instr(op, ops, n, 8, 8);
     ret mi;
 }
 

--- a/src/lang/be/codegen/looprotate.mach
+++ b/src/lang/be/codegen/looprotate.mach
@@ -591,17 +591,14 @@ fun remap_operand(src: mir.MirOperand, remap: *u32, orig_vregs: u32) mir.MirOper
 # n:   the operand count
 # ret: the assembled instruction
 fun make_instr(src: *mir.MirInstr, ops: *mir.MirOperand, n: u32) mir.MirInstr {
-    var mi: mir.MirInstr = mir.instr(src.opcode, ops, n, src.width, src.src_width);
+    var mi: mir.MirInstr = mir.instr_like(src, ops, n);
+    # a CLONE, so the two owned references the derive carries are dropped rather than
+    # duplicated: an inline-asm block belongs to the instruction that declared it, and
+    # the -g dbg-binding list is owned by the original (the encoder would otherwise
+    # record the same VarLocs twice and the list would be freed twice).
     mi.asm_block         = nil;
-    mi.loc               = src.loc;
     mi.dbg_bindings      = nil;
     mi.dbg_binding_count = 0;
-    mi.inline_site       = src.inline_site;
-    mi.vec_lane          = src.vec_lane;
-    # carry the store-secret seed on a rotation clone (`var mi` is not zero-init); inert
-    # today - rotation clones compute/load, never store - but this keeps the seed the
-    # instant rotation peels a secret store, matching add_vreg_like carrying MirVReg.secret (#1646).
-    mi.writes_secret     = src.writes_secret;
     ret mi;
 }
 

--- a/src/lang/be/codegen/looprotate.mach
+++ b/src/lang/be/codegen/looprotate.mach
@@ -591,12 +591,7 @@ fun remap_operand(src: mir.MirOperand, remap: *u32, orig_vregs: u32) mir.MirOper
 # n:   the operand count
 # ret: the assembled instruction
 fun make_instr(src: *mir.MirInstr, ops: *mir.MirOperand, n: u32) mir.MirInstr {
-    var mi: mir.MirInstr;
-    mi.opcode            = src.opcode;
-    mi.operands          = ops;
-    mi.operand_count     = n;
-    mi.width             = src.width;
-    mi.src_width         = src.src_width;
+    var mi: mir.MirInstr = mir.instr(src.opcode, ops, n, src.width, src.src_width);
     mi.asm_block         = nil;
     mi.loc               = src.loc;
     mi.dbg_bindings      = nil;
@@ -744,12 +739,7 @@ fun t_ops(alloc: *A.Allocator, src: *mir.MirOperand, n: u32) *mir.MirOperand {
 
 # a MIR instruction over a heap-copied operand array (test helper)
 fun t_instr(alloc: *A.Allocator, op: mir.MirOpcode, ops: *mir.MirOperand, n: u32) mir.MirInstr {
-    var mi: mir.MirInstr;
-    mi.opcode            = op;
-    mi.operands          = t_ops(alloc, ops, n);
-    mi.operand_count     = n;
-    mi.width             = 8;
-    mi.src_width         = 8;
+    var mi: mir.MirInstr = mir.instr(op, t_ops(alloc, ops, n), n, 8, 8);
     mi.asm_block         = nil;
     mi.loc               = source.loc_nil();
     mi.dbg_bindings      = nil;

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -20,6 +20,7 @@
 # (`isel`) replaces these generic opcodes with the concrete encoder opcodes
 # owned by the active ISA.
 
+use std.memory;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -1289,5 +1290,63 @@ test "mach.lang.be.codegen.mir.vec_lane:pack_unpack" {
     val i2: u8 = vec_lane_make(VEC_LANE_INT, 2);
     if (vec_lane_kind(i2) != VEC_LANE_INT) { ret 1; }
     if (vec_lane_elem_bytes(i2) != 2)      { ret 1; }
+    ret 0;
+}
+
+# `instr` CLEARS EVERY FIELD IT DOES NOT TAKE.
+#
+# The five parameters land where they are named and the seven metadata fields come
+# back neutral, so an instruction built outside the `push_instr` chokepoint carries
+# defined metadata rather than the caller's stack.
+test "mach.lang.be.codegen.mir.instr:clears_the_metadata" {
+    var ops: [2]MirOperand;
+    val mi: MirInstr = instr(MIR_MOV, ?ops[0], 2, 8, 4);
+
+    if (mi.opcode != MIR_MOV)      { ret 1; }
+    if (mi.operands != ?ops[0])    { ret 1; }
+    if (mi.operand_count != 2)     { ret 1; }
+    if (mi.width != 8)             { ret 1; }
+    if (mi.src_width != 4)         { ret 1; }
+
+    if (mi.asm_block != nil)         { ret 1; }
+    if (mi.dbg_bindings != nil)      { ret 1; }
+    if (mi.dbg_binding_count != 0)   { ret 1; }
+    if (mi.inline_site != 0)         { ret 1; }
+    if (mi.vec_lane != VEC_LANE_NONE) { ret 1; }
+    if (mi.writes_secret)            { ret 1; }
+    ret 0;
+}
+
+# `instr_like` CARRIES EVERY FIELD, INCLUDING ONES THAT DO NOT EXIST YET.
+#
+# The guard #2032 needed. A rewrite that rebuilds an instruction field by field
+# drops whatever field it was not taught about - there, `vec_lane`, which left every
+# rewritten vector op reading as element bytes 0 and collapsed the NEON arrangement
+# to `.16b` after register assignment. Asserting the fields one by one would repeat
+# that mistake in the test, so this compares the WHOLE RECORD: derive with the same
+# operand list the source already carries, and the result must be byte-identical to
+# it. A field added to `MirInstr` that the derive forgets fails this with no edit.
+#
+# Both records are pattern-filled first, so any padding the layout holds agrees
+# whether a whole-record assignment lowers to a memcpy or to field-wise moves.
+#
+# To see it fail, replace the whole-record copy in `instr_like` with a field-by-field
+# rebuild that omits one field.
+test "mach.lang.be.codegen.mir.instr_like:carries_every_field" {
+    var src: MirInstr = instr(MIR_ADD, nil, 0, 0, 0);
+    var out: MirInstr = instr(MIR_ADD, nil, 0, 0, 0);
+    memory.raw_fill((?src)::ptr, 0xA5, $size_of(MirInstr));
+    memory.raw_fill((?out)::ptr, 0xA5, $size_of(MirInstr));
+
+    out = instr_like(?src, src.operands, src.operand_count);
+    if (!memory.equal[MirInstr](?out, ?src, 1)) { ret 1; }
+
+    # and the operand list really is the one passed, not the source's
+    var ops: [3]MirOperand;
+    val moved: MirInstr = instr_like(?src, ?ops[0], 3);
+    if (moved.operands != ?ops[0]) { ret 1; }
+    if (moved.operand_count != 3)  { ret 1; }
+    if (moved.opcode != src.opcode)     { ret 1; }
+    if (moved.vec_lane != src.vec_lane) { ret 1; }
     ret 0;
 }

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -594,6 +594,73 @@ pub rec MirInstr {
     writes_secret:     bool;
 }
 
+# build a fresh MIR instruction, every caller-owned field supplied
+#
+# THIS IS THE ONLY PLACE A `MirInstr` IS CLEARED. `var` does not zero, so a site
+# that builds one field by field leaves whatever it does not name holding the
+# frame's residue - and a field added later is named by no site at all. That is not
+# hypothetical here: `vec_lane` was added and `regalloc.rewrite_instr` did not learn
+# about it, so every rewritten vector op read as the `.16b` byte arrangement and the
+# NEON encoder collapsed every arrangement after register assignment (#2032, #2321).
+#
+# The five fields a caller genuinely chooses are positional parameters, so omitting
+# one is an arity error at build time rather than a garbage operation width reaching
+# the encoder. Everything else is METADATA the caller does not author: `asm_block`
+# belongs to MIR_ASM alone, `loc` / `inline_site` / `vec_lane` / `writes_secret` are
+# stamped from the lowering context at `mir.context.push_instr`, and the dbg-binding
+# list is attached there too. Cleared here, so an instruction built outside that
+# chokepoint carries defined metadata rather than the stack's.
+# ---
+# opcode:        the MIR opcode
+# operands:      the operand array (borrowed or owned per the caller's convention)
+# operand_count: number of operands
+# width:         operation width in bytes
+# src_width:     source width in bytes, for a widening / narrowing op
+# ret:           the instruction, with every metadata field cleared
+pub fun instr(opcode: MirOpcode, operands: *MirOperand, operand_count: u32,
+              width: u8, src_width: u8) MirInstr {
+    var mi: MirInstr;
+    mi.opcode        = opcode;
+    mi.operands      = operands;
+    mi.operand_count = operand_count;
+    mi.width         = width;
+    mi.src_width     = src_width;
+
+    mi.asm_block         = nil;
+    mi.loc               = source.loc_nil();
+    mi.dbg_bindings      = nil;
+    mi.dbg_binding_count = 0;
+    mi.inline_site       = 0;
+    mi.vec_lane          = VEC_LANE_NONE;
+    mi.writes_secret     = false;
+    ret mi;
+}
+
+# derive an instruction from an existing one, replacing its operand list
+#
+# The rewrite/clone constructor, and the one #2032 needed. A pass that rebuilds an
+# instruction with new operands - register assignment rewriting vregs to physical
+# registers, loop rotation cloning a block - must carry every field it is not
+# deliberately changing, and doing that field by field is how `vec_lane` was
+# dropped. Deciding carry-or-reset ONCE, here, means a field added to `MirInstr`
+# later flows through both callers with no visit to either.
+#
+# EVERY field is carried, including `asm_block` and the dbg-binding list. A caller
+# that must not duplicate one of those - a CLONE aliases an owned list rather than
+# taking it over - clears it explicitly afterwards, which is a semantic decision
+# visible at the site rather than a field silently missed here.
+# ---
+# src:           the instruction to derive from
+# operands:      the replacement operand array
+# operand_count: number of replacement operands
+# ret:           the derived instruction
+pub fun instr_like(src: *MirInstr, operands: *MirOperand, operand_count: u32) MirInstr {
+    var mi: MirInstr = @src;
+    mi.operands      = operands;
+    mi.operand_count = operand_count;
+    ret mi;
+}
+
 # the vector-lane element kinds packed into `MirInstr.vec_lane`'s high nibble.
 # VEC_LANE_NONE (0) means the instruction is not vector-typed. signedness is NOT a
 # lane-descriptor field: it rides the consuming opcode (a signed vs unsigned

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1018,13 +1018,9 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     if (R.is_err[*mir.MirOperand, str](rcall)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](rcall)); }
     val callops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rcall);
     callops[0] = context.lower_value(ctx, inst.operands[0]);
-    var cmi: mir.MirInstr;
-    cmi.opcode        = mir.MIR_CALL;
-    cmi.operands      = callops;
-    cmi.operand_count = 1;
     # the call selects to an address-sized CALL; its operand carries no value width.
-    cmi.width         = ctx.tgt.model.gpr_width::u8;
-    cmi.src_width     = ctx.tgt.model.gpr_width::u8;
+    var cmi: mir.MirInstr = mir.instr(mir.MIR_CALL, callops, 1,
+                                      ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
     val pc: R.Result[bool, str] = context.push_instr(ctx, mb, cmi);
     if (R.is_err[bool, str](pc)) { ret pc; }
 
@@ -1048,13 +1044,9 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         if (R.is_err[*mir.MirOperand, str](rres)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](rres)); }
         val resops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rres);
         resops[0] = mir.op_vreg(dst);
-        var rmi: mir.MirInstr;
-        rmi.opcode        = mir.MIR_CALL_RES;
-        rmi.operands      = resops;
-        rmi.operand_count = 1;
         # a pure liveness marker; it emits no bytes, so its width is unobserved.
-        rmi.width         = ctx.tgt.model.gpr_width::u8;
-        rmi.src_width     = ctx.tgt.model.gpr_width::u8;
+        var rmi: mir.MirInstr = mir.instr(mir.MIR_CALL_RES, resops, 1,
+                                          ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
         val pr: R.Result[bool, str] = context.push_instr(ctx, mb, rmi);
         if (R.is_err[bool, str](pr)) { ret pr; }
     }
@@ -1764,12 +1756,7 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
 # mb:  the MIR block the terminator is appended to
 # ret: ok(true) on success, or a loud error
 fun emit_bare_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[bool, str] {
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_RET;
-    mi.operands      = nil;
-    mi.operand_count = 0;
-    mi.width         = ctx.tgt.model.gpr_width::u8;
-    mi.src_width     = ctx.tgt.model.gpr_width::u8;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_RET, nil, 0, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
     ret context.push_instr(ctx, mb, mi);
 }
 

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -1189,12 +1189,7 @@ fun inst2(ctx: *LowerCtx, mb: *mir.MirBlock, opcode: mir.MirOpcode, op0: mir.Mir
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](res_ops);
     ops[0] = op0;
     ops[1] = op1;
-    var mi: mir.MirInstr;
-    mi.opcode        = opcode;
-    mi.operands      = ops;
-    mi.operand_count = 2;
-    mi.width         = width;
-    mi.src_width     = src_width;
+    var mi: mir.MirInstr = mir.instr(opcode, ops, 2, width, src_width);
     ret push_instr(ctx, mb, mi);
 }
 
@@ -1221,12 +1216,7 @@ fun inst3(ctx: *LowerCtx, mb: *mir.MirBlock, opcode: mir.MirOpcode, op0: mir.Mir
     ops[0] = op0;
     ops[1] = op1;
     ops[2] = op2;
-    var mi: mir.MirInstr;
-    mi.opcode        = opcode;
-    mi.operands      = ops;
-    mi.operand_count = 3;
-    mi.width         = width;
-    mi.src_width     = src_width;
+    var mi: mir.MirInstr = mir.instr(opcode, ops, 3, width, src_width);
     ret push_instr(ctx, mb, mi);
 }
 

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -650,16 +650,13 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
     ops[0] = dst;
     ops[1] = src;
-    var mi: mir.MirInstr;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_MOV, ops, 2, 0, 0);
     # a global / function symbol incoming value is its ADDRESS as an rvalue: a
     # mir.MIR_MOV of a symbol selects to `mov dst, [sym]` (loading the symbol's
     # contents), so it is emitted as the address-computing mir.MIR_GEP (`lea dst,
     # [sym]`) instead - the same LEA-materialization the store / call-arg / return
     # symbol paths use.
-    mi.opcode        = mir.MIR_MOV;
     if (src.kind == mir.MIR_OP_SYM) { mi.opcode = mir.MIR_GEP; }
-    mi.operands      = ops;
-    mi.operand_count = 2;
     # a register / symbol source transfers a value already in its target-canonical
     # register form, so a full GPR-width bit copy is width-agnostic for a GP or scalar
     # float value. a 128-bit vector vreg is the exception: it is 16 bytes, so a
@@ -812,26 +809,14 @@ fun split_critical_edge(ctx: *lctx.LowerCtx, pred: *mir.MirBlock, succ_id: u32) 
     if (R.is_err[*mir.MirOperand, str](rb)) { ret R.err[*mir.MirBlock, str](R.unwrap_err[*mir.MirOperand, str](rb)); }
     val bops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rb);
     bops[0] = mir.op_block(succ_id);
-    var br: mir.MirInstr;
-    br.opcode        = mir.MIR_BR;
-    br.operands      = bops;
-    br.operand_count = 1;
-    br.width         = ctx.tgt.model.gpr_width::u8;
-    br.src_width     = ctx.tgt.model.gpr_width::u8;
-    # this splice bypasses lctx.push_instr, so enforce the asm_block invariant here:
-    # struct locals are not zero-initialized, and regalloc.flatten reads a non-nil
-    # asm_block as an inline-asm clobber barrier. this is a synthesized critical-edge
-    # branch with no source instruction, so its loc is nil (the line table attributes
-    # it to the surrounding code) and it carries no dbg bindings.
-    br.asm_block         = nil;
-    br.loc               = source.loc_nil();
-    # a synthesized critical-edge branch has no inlined-from origin; attribute it to the
-    # function body (0). the encoder groups by instance, so this at worst splits an
-    # inline instance's PC range at the edge, which the range list represents faithfully.
-    br.inline_site       = 0;
-    br.dbg_bindings      = nil;
-    br.dbg_binding_count = 0;
-    br.writes_secret     = false;   # a synthesized branch never writes storage (#1646)
+    # this splice bypasses lctx.push_instr, so the constructor's cleared metadata IS
+    # the invariant: asm_block nil (regalloc.flatten reads a non-nil one as an
+    # inline-asm clobber barrier), loc nil for a synthesized branch with no source
+    # instruction (the line table attributes it to the surrounding code), inline_site
+    # 0 so it is attributed to the function body, no dbg bindings, and writes_secret
+    # false because a synthesized branch never writes storage (#1646).
+    var br: mir.MirInstr = mir.instr(mir.MIR_BR, bops, 1,
+                                     ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 
     val ri: R.Result[*mir.MirInstr, str] = A.allocate[mir.MirInstr](ctx.alloc, 1::usize);
     if (R.is_err[*mir.MirInstr, str](ri)) { A.deallocate[mir.MirOperand](ctx.alloc, bops, 1::usize); ret R.err[*mir.MirBlock, str](R.unwrap_err[*mir.MirInstr, str](ri)); }
@@ -1301,10 +1286,7 @@ fun lower_cbr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     ops[1] = lctx.lower_operand(ctx, inst, 1);
     ops[2] = lctx.lower_operand(ctx, inst, 2);
 
-    var mi: mir.MirInstr;
-    mi.opcode        = inst.kind::u32;
-    mi.operands      = ops;
-    mi.operand_count = 3;
+    var mi: mir.MirInstr = mir.instr(inst.kind::u32, ops, 3, 0, 0);
     set_generic_widths(ctx, inst, ?mi);
     # a conditional branch tests its boolean condition, but a bare bool value (e.g.
     # a struct's `tag` field) reaches the encoder in a register's low byte WITHOUT
@@ -1395,12 +1377,7 @@ fun lower_asm_instr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, iid: id.InstructionI
         payload.bind_count = src.bind_count;
     }
 
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_ASM;
-    mi.operands      = nil;
-    mi.operand_count = 0;
-    mi.width         = 0;
-    mi.src_width     = 0;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ASM, nil, 0, 0, 0);
     mi.asm_block     = payload;
 
     val push: R.Result[bool, str] = lctx.push_instr(ctx, mb, mi);
@@ -1475,12 +1452,7 @@ fun lower_shift(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
     ops[0] = mir.op_vreg(dst);
     ops[1] = value;
     ops[2] = count_op;
-    var mi: mir.MirInstr;
-    mi.opcode        = op;
-    mi.operands      = ops;
-    mi.operand_count = 3;
-    mi.width         = w;
-    mi.src_width     = w;
+    var mi: mir.MirInstr = mir.instr(op, ops, 3, w, w);
     ret lctx.push_instr(ctx, mb, mi);
 }
 
@@ -1582,12 +1554,7 @@ fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rop);
     ops[0] = mir.op_preg(acc_reg::u32);
     ops[1] = div_op;
-    var mi: mir.MirInstr;
-    mi.opcode        = inst.kind::u32;
-    mi.operands      = ops;
-    mi.operand_count = 2;
-    mi.width         = w;
-    mi.src_width     = w;
+    var mi: mir.MirInstr = mir.instr(inst.kind::u32, ops, 2, w, w);
     val pd: R.Result[bool, str] = lctx.push_instr(ctx, mb, mi);
     if (R.is_err[bool, str](pd)) { ret pd; }
 
@@ -1669,12 +1636,7 @@ fun lower_div_three_address(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr
     ops[0] = mir.op_vreg(dst);
     ops[1] = n_op;
     ops[2] = m_op;
-    var mi: mir.MirInstr;
-    mi.opcode        = inst.kind::u32;
-    mi.operands      = ops;
-    mi.operand_count = 3;
-    mi.width         = w;
-    mi.src_width     = w;
+    var mi: mir.MirInstr = mir.instr(inst.kind::u32, ops, 3, w, w);
     ret lctx.push_instr(ctx, mb, mi);
 }
 
@@ -1705,13 +1667,8 @@ fun emit_promote(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, sr
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
     ops[0] = dst;
     ops[1] = src;
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_ZEXT;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ZEXT, ops, 2, dst_w, src_w);
     if (signed) { mi.opcode = mir.MIR_SEXT; }
-    mi.operands      = ops;
-    mi.operand_count = 2;
-    mi.width         = dst_w;
-    mi.src_width     = src_w;
     ret lctx.push_instr(ctx, mb, mi);
 }
 
@@ -1769,10 +1726,7 @@ fun lower_generic(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructi
         k = k + 1;
     }
 
-    var mi: mir.MirInstr;
-    mi.opcode        = inst.kind::u32;
-    mi.operands      = ops;
-    mi.operand_count = total;
+    var mi: mir.MirInstr = mir.instr(inst.kind::u32, ops, total, 0, 0);
     set_generic_widths(ctx, inst, ?mi);
     ret lctx.push_instr(ctx, mb, mi);
 }
@@ -1991,26 +1945,23 @@ fun lower_float_op(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
 
     val w: u8 = float_op_width(ctx, inst);
 
-    var mi: mir.MirInstr;
-    mi.operands      = ops;
-    mi.operand_count = 3;
-    mi.width         = w;
-    mi.src_width     = w;
-
+    # a float compare rides its condition code in src_width; every other float op
+    # keeps the operand width.
     val k: instr.InstrKind = inst.kind;
+    var op: mir.MirOpcode = mir.MIR_FDIV;
+    var sw: u8 = w;
     if (is_compare_kind(k)) {
-        mi.opcode    = mir.MIR_FCMP;
-        mi.src_width = float_cmp_cc(k);
+        op = mir.MIR_FCMP;
+        sw = float_cmp_cc(k);
     } or (k == instr.OP_ADD) {
-        mi.opcode = mir.MIR_FADD;
+        op = mir.MIR_FADD;
     } or (k == instr.OP_SUB) {
-        mi.opcode = mir.MIR_FSUB;
+        op = mir.MIR_FSUB;
     } or (k == instr.OP_MUL) {
-        mi.opcode = mir.MIR_FMUL;
-    } or {
-        mi.opcode = mir.MIR_FDIV;
+        op = mir.MIR_FMUL;
     }
 
+    var mi: mir.MirInstr = mir.instr(op, ops, 3, w, sw);
     ret lctx.push_instr(ctx, mb, mi);
 }
 
@@ -2045,12 +1996,7 @@ fun lower_float_neg(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruc
 
     val w: u8 = lctx.op_width_of(ctx, inst.ty);
 
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_FNEG;
-    mi.operands      = ops;
-    mi.operand_count = 2;
-    mi.width         = w;
-    mi.src_width     = w;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_FNEG, ops, 2, w, w);
     ret lctx.push_instr(ctx, mb, mi);
 }
 
@@ -2132,13 +2078,9 @@ fun lower_alloca(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructio
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
     ops[0] = mir.op_vreg(dst);
     ops[1] = mir.op_mem_slot(sk, 0);
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_ALLOCA;
-    mi.operands      = ops;
-    mi.operand_count = 2;
     # the alloca selects to a LEA computing a pointer-sized address.
-    mi.width         = ctx.tgt.model.gpr_width::u8;
-    mi.src_width     = ctx.tgt.model.gpr_width::u8;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ALLOCA, ops, 2,
+                                     ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
     ret lctx.push_instr(ctx, mb, mi);
 }
 
@@ -2172,12 +2114,7 @@ fun lower_vec_extract(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instr
     ops[1] = lctx.lower_value(ctx, inst.operands[0]);
     ops[2] = mir.op_imm(inst.operands[1].data.int_lit::i64);
 
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_VEC_EXTRACT;
-    mi.operands      = ops;
-    mi.operand_count = 3;
-    mi.width         = lctx.op_width_of(ctx, inst.ty);
-    mi.src_width     = lctx.op_width_of(ctx, inst.operands[0].ty);
+    var mi: mir.MirInstr = mir.instr(mir.MIR_VEC_EXTRACT, ops, 3, lctx.op_width_of(ctx, inst.ty), lctx.op_width_of(ctx, inst.operands[0].ty));
     ret lctx.push_instr(ctx, mb, mi);
 }
 
@@ -2210,12 +2147,7 @@ fun lower_vec_insert(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instru
     ops[2] = mir.op_imm(inst.operands[1].data.int_lit::i64);
     ops[3] = lctx.lower_value(ctx, inst.operands[2]);
 
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_VEC_INSERT;
-    mi.operands      = ops;
-    mi.operand_count = 4;
-    mi.width         = lctx.op_width_of(ctx, inst.ty);
-    mi.src_width     = lctx.op_width_of(ctx, inst.operands[2].ty);
+    var mi: mir.MirInstr = mir.instr(mir.MIR_VEC_INSERT, ops, 4, lctx.op_width_of(ctx, inst.ty), lctx.op_width_of(ctx, inst.operands[2].ty));
     ret lctx.push_instr(ctx, mb, mi);
 }
 
@@ -2260,10 +2192,6 @@ fun lower_load(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
     ops[0] = mir.op_vreg(dst);
     ops[1] = mem;
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_LOAD;
-    mi.operands      = ops;
-    mi.operand_count = 2;
     # the load accesses memory at the loaded result type's width (`src_width`) but
     # must DEFINE the full register it lands in (`width`): a sub-word load of a
     # scalar leaves the upper register bits undefined, and a downstream wider use
@@ -2272,8 +2200,9 @@ fun lower_load(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
     # `mir.ALU_MIN_WIDTH` - the same full-register-definition invariant `lctx.clamp_alu_width`
     # gives a sub-word ALU result - makes the backend zero-extend the load into a
     # clean register (a wider load keeps its own width, so width == src_width there).
-    mi.src_width     = lctx.op_width_of(ctx, inst.ty);
-    mi.width         = lctx.clamp_alu_width(ctx.tgt.model.gpr_width, mi.src_width);
+    val acc_w: u8 = lctx.op_width_of(ctx, inst.ty);
+    var mi: mir.MirInstr = mir.instr(mir.MIR_LOAD, ops, 2,
+                                     lctx.clamp_alu_width(ctx.tgt.model.gpr_width, acc_w), acc_w);
     ret lctx.push_instr(ctx, mb, mi);
 }
 
@@ -2328,14 +2257,10 @@ fun lower_store(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
     ops[0] = dest;
     ops[1] = stored;
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_STORE;
-    mi.operands      = ops;
-    mi.operand_count = 2;
     # the store accesses memory at the stored value's type width (IR operand 0);
     # the store result is void, so the value type is the only width carrier.
-    mi.width         = lctx.op_width_of(ctx, inst.operands[0].ty);
-    mi.src_width     = mi.width;
+    val st_w: u8 = lctx.op_width_of(ctx, inst.operands[0].ty);
+    var mi: mir.MirInstr = mir.instr(mir.MIR_STORE, ops, 2, st_w, st_w);
     ret lctx.push_instr(ctx, mb, mi);
 }
 
@@ -2379,12 +2304,7 @@ fun lower_store_aggregate(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.I
         val ldops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ldr);
         ldops[0] = mir.op_vreg(tmp);
         ldops[1] = src;
-        var ld: mir.MirInstr;
-        ld.opcode        = mir.MIR_LOAD;
-        ld.operands      = ldops;
-        ld.operand_count = 2;
-        ld.width         = chunk;
-        ld.src_width     = chunk;
+        var ld: mir.MirInstr = mir.instr(mir.MIR_LOAD, ldops, 2, chunk, chunk);
         val pl: R.Result[bool, str] = lctx.push_instr(ctx, mb, ld);
         if (R.is_err[bool, str](pl)) { ret pl; }
 
@@ -2576,13 +2496,9 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
     ops[0] = mir.op_vreg(dst);
     ops[1] = R.unwrap_ok[mir.MirOperand, str](mem);
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_GEP;
-    mi.operands      = ops;
-    mi.operand_count = 2;
     # the GEP selects to a LEA computing a pointer-sized effective address.
-    mi.width         = ctx.tgt.model.gpr_width::u8;
-    mi.src_width     = ctx.tgt.model.gpr_width::u8;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_GEP, ops, 2,
+                                     ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
     ret lctx.push_instr(ctx, mb, mi);
 }
 

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -3572,31 +3572,15 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
     # the rewritten instruction itself. the operation width / source width are
     # carried through unchanged from lowering so the encoder still sizes the op at
     # 1 / 2 / 4 / 8 bytes after register assignment.
-    dst[@wp].opcode        = mi.opcode;
-    dst[@wp].operands      = ops;
-    dst[@wp].operand_count = n;
-    dst[@wp].width         = mi.width;
-    dst[@wp].src_width     = mi.src_width;
-    # carry the 128-bit vector lane descriptor; the encoder reads it to pick the
-    # NEON element arrangement. a zeroed slot reads as element bytes 0 → `.16b`,
-    # collapsing every vector op to a byte arrangement, so it must be copied.
-    dst[@wp].vec_lane      = mi.vec_lane;
-    # carry the store-secret seed through register assignment (a zeroed slot would drop
-    # it); metadata, so it never perturbs allocation (#1646).
-    dst[@wp].writes_secret = mi.writes_secret;
-    dst[@wp].asm_block     = mi.asm_block;
-    # carry the source location through register assignment so the encoder's line
-    # table maps this instruction's final bytes to its origin. (a zeroed slot is
-    # {FILE_NIL=0, 0} == loc_nil, harmless; this still carries the real loc.)
-    dst[@wp].loc           = mi.loc;
-    # carry the inline instance through likewise; the zeroed buffer would otherwise
-    # drop every instruction back to the function body and erase the channel.
-    dst[@wp].inline_site   = mi.inline_site;
-    # transfer the -g dbg-binding list (ownership moves to the rewritten instruction);
-    # the encoder reads it to record VarLocs, and the original instr's array is not
-    # freed with its operands below.
-    dst[@wp].dbg_bindings      = mi.dbg_bindings;
-    dst[@wp].dbg_binding_count = mi.dbg_binding_count;
+    # every field but the operand list rides through register assignment unchanged:
+    # the widths so the encoder still sizes the op, `vec_lane` so it still picks the
+    # NEON element arrangement (a zeroed slot reads as element bytes 0 -> `.16b` and
+    # collapsed every vector op to bytes, #2032), the store-secret seed (#1646), the
+    # source location and inline instance for the line table, and the -g dbg-binding
+    # list, whose ownership moves to the rewritten instruction. `instr_like` carries
+    # all of them at once, so the next field added rides through with no edit here -
+    # rebuilding this slot field by field is what dropped `vec_lane`.
+    dst[@wp] = mir.instr_like(mi, ops, n);
     @wp = @wp + 1;
 
     # release the original operand array; its contents were copied into `ops`.

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -3866,10 +3866,7 @@ test "mach.lang.be.codegen.regalloc.instr_defines:fused_cbr_shape" {
     ops[2] = mir.op_block(1);
     ops[3] = mir.op_block(2);
 
-    var fused: mir.MirInstr;
-    fused.opcode        = mir.MIR_SEL_CBR_LT_S;
-    fused.operands      = ?ops[0];
-    fused.operand_count = 4;
+    var fused: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR_LT_S, ?ops[0], 4, 0, 0);
 
     # a block-operand-bearing terminator defines nothing: operand 0 is a use.
     if (instr_defines(?fused))                       { ret 1; }
@@ -3890,10 +3887,7 @@ test "mach.lang.be.codegen.regalloc.instr_defines:fused_cbr_shape" {
     cmp_ops[0] = mir.op_vreg(5);
     cmp_ops[1] = mir.op_vreg(3);
     cmp_ops[2] = mir.op_vreg(4);
-    var cmp: mir.MirInstr;
-    cmp.opcode        = mir.MIR_SEL_CMP_LT_S;
-    cmp.operands      = ?cmp_ops[0];
-    cmp.operand_count = 3;
+    var cmp: mir.MirInstr = mir.instr(mir.MIR_SEL_CMP_LT_S, ?cmp_ops[0], 3, 0, 0);
     if (!instr_defines(?cmp)) { ret 1; }
     ret 0;
 }
@@ -3964,12 +3958,7 @@ test "mach.lang.be.codegen.regalloc.is_dead_mov:physical_dest_and_read_guards" {
     var ops: [2]mir.MirOperand;
     ops[0] = mir.op_vreg(0);
     ops[1] = mir.op_vreg(1);
-    var mv: mir.MirInstr;
-    mv.opcode        = mir.MIR_MOV;
-    mv.operands      = ?ops[0];
-    mv.operand_count = 2;
-    mv.width         = 8;
-    mv.src_width     = 8;
+    var mv: mir.MirInstr = mir.instr(mir.MIR_MOV, ?ops[0], 2, 8, 8);
     mv.asm_block     = nil;
 
     # dst = unread value vreg 0: dead.
@@ -4288,12 +4277,7 @@ test "mach.lang.be.codegen.regalloc.maybe_sink_hint:records_only_a_dying_full_wi
     var ops: [2]mir.MirOperand;
     ops[0] = mir.op_preg(7);
     ops[1] = mir.op_vreg(1);
-    var mv: mir.MirInstr;
-    mv.opcode        = mir.MIR_MOV;
-    mv.operands      = ?ops[0];
-    mv.operand_count = 2;
-    mv.width         = 8;
-    mv.src_width     = 8;
+    var mv: mir.MirInstr = mir.instr(mir.MIR_MOV, ?ops[0], 2, 8, 8);
 
     # v1 dies exactly at position 10: the hint is recorded.
     ranges[1].end_pos = 10;
@@ -4353,10 +4337,7 @@ test "mach.lang.be.codegen.regalloc.maybe_tie_hint:ties_a_dying_left_operand" {
     ops[0] = mir.op_vreg(0);
     ops[1] = mir.op_vreg(1);
     ops[2] = mir.op_vreg(2);
-    var op: mir.MirInstr;
-    op.opcode        = mir.MIR_SEL_MUL;
-    op.operands      = ?ops[0];
-    op.operand_count = 3;
+    var op: mir.MirInstr = mir.instr(mir.MIR_SEL_MUL, ?ops[0], 3, 0, 0);
 
     # v1 dies at position 20 and v0 is born there: the tie is recorded.
     ranges[1].end_pos = 20;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -4631,12 +4631,13 @@ test "mach.lang.target.isa.arm64.encode:immediate_shifts" {
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(0);
     ops[1] = mir.op_preg(1);
     ops[2] = mir.op_imm(3);
-    mi.operands = ?ops[0];
+    # the encoders under test take the opcode as their own argument, so this
+    # instruction's is never read; it carries the operands and widths only.
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 0, 0, 0);
     mi.operand_count = 3;
 
     # lsl x0, x1, #3 = 0xd37df020 ; lsl w0, w1, #3 = 0x531d7020
@@ -4755,12 +4756,11 @@ test "mach.lang.target.isa.arm64.encode:compare_with_an_immediate_lhs_materializ
 
     # `48 <= c` at u8 width: [dst w0, lhs #48, rhs w1]
     # -> movz w17,#48 ; uxtb w17,w17 ; uxtb w16,w1 ; cmp w17,w16 ; cset w0,ls
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(0);
     ops[1] = mir.op_imm(48);
     ops[2] = mir.op_preg(1);
-    mi.operands = ?ops[0]; mi.operand_count = 3;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
     mi.opcode = mir.MIR_SEL_CMP_LE_U; mi.width = 1;
 
     val r: R.Result[bool, str] = encode_compare(?st, ?mi);
@@ -4812,10 +4812,9 @@ test "mach.lang.target.isa.arm64.encode:unsigned_divide_plus_div_by_zero_trap" {
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
-    mi.operands = ?ops[0]; mi.operand_count = 3;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
     mi.opcode = mir.MIR_SEL_DIV_U; mi.width = 8;
 
     val r: R.Result[bool, str] = encode_divide(?st, ?mi);
@@ -4837,10 +4836,9 @@ test "mach.lang.target.isa.arm64.encode:signed_divide_plus_zero_overflow_traps" 
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
-    mi.operands = ?ops[0]; mi.operand_count = 3;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
     mi.opcode = mir.MIR_SEL_DIV_S; mi.width = 8;
 
     val r: R.Result[bool, str] = encode_divide(?st, ?mi);
@@ -4868,10 +4866,9 @@ test "mach.lang.target.isa.arm64.encode:signed_remainder_plus_zero_overflow_trap
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
-    mi.operands = ?ops[0]; mi.operand_count = 3;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
     mi.opcode = mir.MIR_SEL_REM_S; mi.width = 4;
 
     val r: R.Result[bool, str] = encode_divide(?st, ?mi);
@@ -4900,10 +4897,9 @@ test "mach.lang.target.isa.arm64.encode:unsigned_remainder_plus_div_by_zero_trap
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
-    mi.operands = ?ops[0]; mi.operand_count = 3;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
     mi.opcode = mir.MIR_SEL_REM_U; mi.width = 8;
 
     val r: R.Result[bool, str] = encode_divide(?st, ?mi);
@@ -5099,31 +5095,31 @@ test "mach.lang.target.isa.arm64.encode:frame_slot_ldr_str_and_spill_reload_stor
     f.frame.slot_count = 1;
 
     # MIR_STORE [slot] <- x9  -> stur x9, [x29, #-8] = 0xf81f83a9
-    var sst: mir.MirInstr;
     var sops: [2]mir.MirOperand;
     sops[0] = mir.op_mem_slot(100, 0);
     sops[1] = mir.op_preg(9);
-    sst.operands = ?sops[0]; sst.operand_count = 2; sst.width = 8; sst.src_width = 8;
+    # the encoders under test take the opcode as their own argument, so this
+    # instruction's is never read; it carries the operands and widths only.
+    var sst: mir.MirInstr = mir.instr(mir.MIR_ADD, ?sops[0], 2, 8, 8);
     encode_store(?st, ?f, ?sst);
     if (read_word(?st.buf, 0) != 0xF81F83A9) { bad = 1; }
 
     # MIR_LOAD x9 <- [slot]  -> ldur x9, [x29, #-8] = 0xf85f83a9
-    var lst: mir.MirInstr;
     var lops: [2]mir.MirOperand;
     lops[0] = mir.op_preg(9);
     lops[1] = mir.op_mem_slot(100, 0);
-    lst.operands = ?lops[0]; lst.operand_count = 2; lst.width = 8; lst.src_width = 8;
+    # the encoders under test take the opcode as their own argument, so this
+    # instruction's is never read; it carries the operands and widths only.
+    var lst: mir.MirInstr = mir.instr(mir.MIR_ADD, ?lops[0], 2, 8, 8);
     encode_load(?st, ?f, ?lst);
     if (read_word(?st.buf, 4) != 0xF85F83A9) { bad = 1; }
 
     # the spill MIR_MOV reload (reg <- [slot]) / store ([slot] <- reg) round-trip
     # through the same LDUR/STUR forms.
-    var mvl: mir.MirInstr;
-    mvl.operands = ?lops[0]; mvl.operand_count = 2; mvl.width = 8; mvl.src_width = 8;
+    var mvl: mir.MirInstr = mir.instr(mir.MIR_MOV, ?lops[0], 2, 8, 8);
     encode_mov(?st, ?f, ?mvl);
     if (read_word(?st.buf, 8) != 0xF85F83A9) { bad = 1; }
-    var mvs: mir.MirInstr;
-    mvs.operands = ?sops[0]; mvs.operand_count = 2; mvs.width = 8; mvs.src_width = 8;
+    var mvs: mir.MirInstr = mir.instr(mir.MIR_MOV, ?sops[0], 2, 8, 8);
     encode_mov(?st, ?f, ?mvs);
     if (read_word(?st.buf, 12) != 0xF81F83A9) { bad = 1; }
 
@@ -5141,8 +5137,7 @@ test "mach.lang.target.isa.arm64.encode:scalar_fp_arithmetic_fadd_fsub_fmul_fdiv
     tbuf(?st, ?alloc);
     var f: mir.MirFunction;
     var ops: [3]mir.MirOperand;
-    var mi: mir.MirInstr;
-    mi.operands = ?ops[0]; mi.operand_count = 3;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
 
     # fadd s0, s1, s2 = 0x1e222820
     ops[0] = tvec(0); ops[1] = tvec(1); ops[2] = tvec(2);
@@ -5184,8 +5179,7 @@ test "mach.lang.target.isa.arm64.encode:fneg_plus_fmov_float_copy" {
     tbuf(?st, ?alloc);
     var f: mir.MirFunction;
     var ops: [2]mir.MirOperand;
-    var mi: mir.MirInstr;
-    mi.operands = ?ops[0]; mi.operand_count = 2;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
     # fneg s12, s13 = 0x1e2141ac ; fneg d12, d13 = 0x1e6141ac
     ops[0] = tvec(12); ops[1] = tvec(13);
@@ -5216,8 +5210,7 @@ test "mach.lang.target.isa.arm64.encode:fcmp_plus_cset_float_condition_mapping" 
     tbuf(?st, ?alloc);
     var f: mir.MirFunction;
     var ops: [3]mir.MirOperand;
-    var mi: mir.MirInstr;
-    mi.operands = ?ops[0]; mi.operand_count = 3;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
 
     # fcmp d14, d15 ; cset w0, eq  -> 0x1e6f21c0 ; 0x1a9f17e0
     ops[0] = mir.op_preg(0); ops[1] = tvec(14); ops[2] = tvec(15);
@@ -5263,8 +5256,7 @@ test "mach.lang.target.isa.arm64.encode:int_float_scvtf_ucvtf" {
     tbuf(?st, ?alloc);
     var f: mir.MirFunction;
     var ops: [2]mir.MirOperand;
-    var mi: mir.MirInstr;
-    mi.operands = ?ops[0]; mi.operand_count = 2;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
     # scvtf s0,w1 / d0,w1 / s0,x1 / d0,x1
     ops[0] = tvec(0); ops[1] = mir.op_preg(1);
@@ -5309,8 +5301,7 @@ test "mach.lang.target.isa.arm64.encode:float_int_fcvtzs_fcvtzu" {
     tbuf(?st, ?alloc);
     var f: mir.MirFunction;
     var ops: [2]mir.MirOperand;
-    var mi: mir.MirInstr;
-    mi.operands = ?ops[0]; mi.operand_count = 2;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
     # fcvtzs w0,s1 / x0,s1 / w0,d1 / x0,d1
     ops[0] = mir.op_preg(0); ops[1] = tvec(1);
@@ -5355,8 +5346,7 @@ test "mach.lang.target.isa.arm64.encode:fcvt_s_d_and_gp_fp_bitcast_fmov" {
     tbuf(?st, ?alloc);
     var f: mir.MirFunction;
     var ops: [2]mir.MirOperand;
-    var mi: mir.MirInstr;
-    mi.operands = ?ops[0]; mi.operand_count = 2;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
     # fcvt d18, s19 (FP_EXT, f32->f64) = 0x1e22c272
     ops[0] = tvec(18); ops[1] = tvec(19);
@@ -5397,8 +5387,7 @@ test "mach.lang.target.isa.arm64.encode:float_constant_immediate_materialization
     tbuf(?st, ?alloc);
     var f: mir.MirFunction;
     var ops: [3]mir.MirOperand;
-    var mi: mir.MirInstr;
-    mi.operands = ?ops[0]; mi.operand_count = 2;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
     # f64 0.1 = 0x3FB999999999999A -> v0:
     #   movz x16,#0x999a ; movk x16,#0x9999,lsl#16 ; movk x16,#0x9999,lsl#32 ;
@@ -5457,8 +5446,7 @@ test "mach.lang.target.isa.arm64.encode:spilled_float_operands_route_through_fp_
     f.frame.slot_count = 1;
 
     var ops: [3]mir.MirOperand;
-    var mi: mir.MirInstr;
-    mi.operands = ?ops[0]; mi.operand_count = 3;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
 
     # spilled lhs: ldur d31,[x29,#-8] ; fadd d0, d31, d2
     ops[0] = tvec(0); ops[1] = mir.op_mem_slot(100, 0); ops[2] = tvec(2);
@@ -5475,9 +5463,8 @@ test "mach.lang.target.isa.arm64.encode:spilled_float_operands_route_through_fp_
     if (read_word(?st.buf, 4) != 0xFC1F83BF) { bad = 1; }
 
     # float copy spill reload: ldur d5,[x29,#-8]
-    var mv: mir.MirInstr;
     var mops: [2]mir.MirOperand;
-    mv.operands = ?mops[0]; mv.operand_count = 2; mv.width = 8;
+    var mv: mir.MirInstr = mir.instr(mir.MIR_MOV, ?mops[0], 2, 8, 0);
     mops[0] = tvec(5); mops[1] = mir.op_mem_slot(100, 0);
     st.buf.len = 0;
     encode_fmov(?st, ?f, ?mv); if (read_word(?st.buf, 0) != 0xFC5F83A5) { bad = 1; }
@@ -5553,33 +5540,30 @@ test "mach.lang.target.isa.arm64.encode:gep_alloca_address_arithmetic" {
     f.frame.slots      = ?slots[0];
     f.frame.slot_count = 1;
 
-    var al: mir.MirInstr;
     var aops: [2]mir.MirOperand;
     aops[0] = mir.op_preg(0);
     aops[1] = mir.op_mem_slot(100, 0);
-    al.opcode = mir.MIR_ALLOCA; al.operands = ?aops[0]; al.operand_count = 2;
+    var al: mir.MirInstr = mir.instr(mir.MIR_ALLOCA, ?aops[0], 2, 0, 0);
     al.width = 8; al.src_width = 8;
     encode_addr(?st, ?f, ?al);
     if (read_word(?st.buf, 0) != 0xD10043A0) { bad = 1; }
 
     # gep [x29 + 16] (a physical-register base + constant disp): add x0,x29,#16 = 0x910043a0
-    var g1: mir.MirInstr;
     var g1ops: [2]mir.MirOperand;
     g1ops[0] = mir.op_preg(0);
     g1ops[1] = mir.op_mem_preg(29, 16);
-    g1.opcode = mir.MIR_GEP; g1.operands = ?g1ops[0]; g1.operand_count = 2;
+    var g1: mir.MirInstr = mir.instr(mir.MIR_GEP, ?g1ops[0], 2, 0, 0);
     g1.width = 8; g1.src_width = 8;
     encode_addr(?st, ?f, ?g1);
     if (read_word(?st.buf, 4) != 0x910043A0) { bad = 1; }
 
     # gep [x1 + x2*8]: add x0,x1,x2,lsl#3 = 0x8b020c20
-    var g2: mir.MirInstr;
     var g2ops: [2]mir.MirOperand;
     g2ops[0] = mir.op_preg(0);
     var m2: mir.MirOperand = mir.op_mem_preg(1, 0);
     m2.index = 2; m2.scale = 8; m2.index_is_preg = true;
     g2ops[1] = m2;
-    g2.opcode = mir.MIR_GEP; g2.operands = ?g2ops[0]; g2.operand_count = 2;
+    var g2: mir.MirInstr = mir.instr(mir.MIR_GEP, ?g2ops[0], 2, 0, 0);
     g2.width = 8; g2.src_width = 8;
     encode_addr(?st, ?f, ?g2);
     if (read_word(?st.buf, 8) != 0x8B020C20) { bad = 1; }
@@ -5598,11 +5582,10 @@ test "mach.lang.target.isa.arm64.encode:integer_conversions" {
     tbuf(?st, ?alloc);
 
     # operands [x0, w1] for every conversion.
-    var mi: mir.MirInstr;
     var ops: [2]mir.MirOperand;
     ops[0] = mir.op_preg(0);
     ops[1] = mir.op_preg(1);
-    mi.operands = ?ops[0]; mi.operand_count = 2;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
     # sxtb x0,w1 = 0x93401c20 (SEXT, dst 8, src 1)
     mi.opcode = mir.MIR_SEXT; mi.width = 8; mi.src_width = 1;
@@ -5713,10 +5696,9 @@ test "mach.lang.target.isa.arm64.encode:branch_to_fallthrough_elided" {
     st.alloc = ?alloc; st.fixups = nil; st.fixup_count = 0; st.fixup_cap = 0;
 
     # an unconditional branch to block 4.
-    var ub: mir.MirInstr;
     var uops: [1]mir.MirOperand;
     uops[0] = mir.op_block(4);
-    ub.operands = ?uops[0]; ub.operand_count = 1; ub.opcode = mir.MIR_BR; ub.width = 8;
+    var ub: mir.MirInstr = mir.instr(mir.MIR_BR, ?uops[0], 1, 8, 0);
 
     # no successor recorded: the B word is emitted, one fixup against block 4.
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
@@ -5738,10 +5720,9 @@ test "mach.lang.target.isa.arm64.encode:branch_to_fallthrough_elided" {
 
     # a plain conditional `CBNZ cond, then ; B else`: the not-taken B else elides
     # when else (block 4) is the fallthrough successor, the taken CBNZ stays.
-    var cbr: mir.MirInstr;
     var cops: [3]mir.MirOperand;
     cops[0] = mir.op_preg(10); cops[1] = mir.op_block(3); cops[2] = mir.op_block(4);
-    cbr.operands = ?cops[0]; cbr.operand_count = 3; cbr.width = 8; cbr.opcode = mir.MIR_SEL_CBR;
+    var cbr: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR, ?cops[0], 3, 8, 0);
 
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
     encode_cbr(?st, 0, ?cbr);
@@ -5755,11 +5736,10 @@ test "mach.lang.target.isa.arm64.encode:branch_to_fallthrough_elided" {
 
     # a fused compare-and-branch `SUBS ; B.cc then ; B else`: same elision of the
     # not-taken B else, taken B.cc preserved.
-    var mi: mir.MirInstr;
     var ops: [4]mir.MirOperand;
     ops[0] = mir.op_preg(11); ops[1] = mir.op_preg(12);
     ops[2] = mir.op_block(3); ops[3] = mir.op_block(4);
-    mi.operands = ?ops[0]; mi.operand_count = 4; mi.width = 8; mi.opcode = mir.MIR_SEL_CBR_EQ;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR_EQ, ?ops[0], 4, 8, 0);
 
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
     encode_fused_cbr(?st, 0, ?mi);
@@ -5817,12 +5797,11 @@ test "mach.lang.target.isa.arm64.encode:end_to_end_leaf_add_body" {
     tbuf(?st, ?alloc);
 
     # add w0, w0, w1  - the leaf integer body (operands already register-resolved).
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(0);
     ops[1] = mir.op_preg(0);
     ops[2] = mir.op_preg(1);
-    mi.operands = ?ops[0];
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 0, 0, 0);
     mi.operand_count = 3;
     mi.width = 4;
     encode_addsub(?st, ?mi, false);
@@ -5886,10 +5865,9 @@ test "mach.lang.target.isa.arm64.encode:call_global_emitters_record_relocs_plus_
     val sym: intern.StrId = 7::intern.StrId;
 
     # direct call: bl sym -> 0x94000000, RK_PLT32 @0 addend 0.
-    var ci: mir.MirInstr;
     var cops: [1]mir.MirOperand;
     cops[0] = mir.op_sym(sym, 0);
-    ci.operands = ?cops[0]; ci.operand_count = 1;
+    var ci: mir.MirInstr = mir.instr(mir.MIR_CALL, ?cops[0], 1, 0, 0);
     encode_call(?st, ?ci);
     if (read_word(?st.buf, 0) != 0x94000000) { bad = 1; }
     if (st.reloc_count != 1)                 { bad = 1; }
@@ -5901,10 +5879,9 @@ test "mach.lang.target.isa.arm64.encode:call_global_emitters_record_relocs_plus_
     }
 
     # indirect call: blr x9 -> 0xd63f0120, no new reloc.
-    var ii: mir.MirInstr;
     var iops: [1]mir.MirOperand;
     iops[0] = mir.op_preg(9);
-    ii.operands = ?iops[0]; ii.operand_count = 1;
+    var ii: mir.MirInstr = mir.instr(mir.MIR_CALL, ?iops[0], 1, 0, 0);
     encode_call(?st, ?ii);
     if (read_word(?st.buf, 4) != 0xD63F0120) { bad = 1; }
     if (st.reloc_count != 1)                 { bad = 1; }
@@ -6467,12 +6444,7 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_name_local_resolves_to_a_fram
     pl.binds      = ?binds[0];
     pl.bind_count = 1;
 
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_ASM;
-    mi.operands      = nil;
-    mi.operand_count = 0;
-    mi.width         = 0;
-    mi.src_width     = 0;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ASM, nil, 0, 0, 0);
     mi.asm_block     = ?pl;
 
     val r: R.Result[bool, str] = encode_asm_block_arm64(?st, ?f, 0, ?mi);
@@ -6767,8 +6739,7 @@ test "mach.lang.target.isa.arm64.encode:neon_vector_op_selection" {
     tbuf(?st, ?alloc);
     var f: mir.MirFunction;
     var ops: [3]mir.MirOperand;
-    var mi: mir.MirInstr;
-    mi.operands = ?ops[0]; mi.operand_count = 3;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
     ops[0] = tvec(0); ops[1] = tvec(1); ops[2] = tvec(2);
 
     # VEC_ADD: f32x4 -> FADD.4s ; i8x16 -> ADD.16b ; i32x4 -> ADD.4s.

--- a/src/lang/target/isa/arm64/rules.mach
+++ b/src/lang/target/isa/arm64/rules.mach
@@ -647,10 +647,10 @@ test "mach.lang.target.isa.arm64.rules:generic_opcode_coverage" {
     ops[0] = mir.op_preg(10);
     ops[1] = mir.op_preg(11);
     ops[2] = mir.op_preg(12);
-    var probe: mir.MirInstr;
-    probe.operands      = ?ops[0];
-    probe.operand_count = 3;
-    probe.width         = 8;
+    # the opcode is the loop variable below - every use assigns it first - so the
+    # constructor's is dead. `vec_lane` is cleared by construction, which is the
+    # VEC_LANE_NONE this probe wants.
+    var probe: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     var f: mir.MirFunction;
 

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -944,12 +944,7 @@ fun t_encode_shift(st: *enc.EncodeState, op: mir.MirOpcode, count: i64) R.Result
     ops[0] = mir.op_preg(10);
     ops[1] = mir.op_preg(8);
     ops[2] = mir.op_imm(count);
-    var mi: mir.MirInstr;
-    mi.opcode        = op;
-    mi.operands      = ?ops[0];
-    mi.operand_count = 3;
-    mi.width         = 1;
-    mi.src_width     = 1;
+    var mi: mir.MirInstr = mir.instr(op, ?ops[0], 3, 1, 1);
     ret encode_shift(st, ?mi, op);
 }
 
@@ -1031,12 +1026,7 @@ test "mach.lang.target.isa.mos6502.encode:refuses_an_unreduced_shift" {
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(10);
     ops[1] = mir.op_preg(8);
-    var mi: mir.MirInstr;
-    mi.opcode        = mir.MIR_SHL;
-    mi.operands      = ?ops[0];
-    mi.operand_count = 3;
-    mi.width         = 1;
-    mi.src_width     = 1;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_SHL, ?ops[0], 3, 1, 1);
 
     # a runtime count: the operand shape the 6502 has no instruction for.
     ops[2] = mir.op_preg(9);

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -591,12 +591,7 @@ fun t_encode_cmp(st: *enc.EncodeState, op: mir.MirOpcode) R.Result[bool, str] {
     ops[0] = mir.op_preg(10);
     ops[1] = mir.op_preg(8);
     ops[2] = mir.op_preg(9);
-    var mi: mir.MirInstr;
-    mi.opcode        = op;
-    mi.operands      = ?ops[0];
-    mi.operand_count = 3;
-    mi.width         = 1;
-    mi.src_width     = 1;
+    var mi: mir.MirInstr = mir.instr(op, ?ops[0], 3, 1, 1);
     ret encode_cmp(st, ?mi, op);
 }
 
@@ -886,12 +881,7 @@ test "mach.lang.target.isa.mos6502.encode:refuses_a_base_that_is_not_a_pointer_p
     if (mos6502.is_ptr_pair(mos6502.FIRST_VALUE_REG + 1)) { ret 1; }
 
     var ops: [2]mir.MirOperand;
-    var mi: mir.MirInstr;
-    mi.operands      = ?ops[0];
-    mi.operand_count = 2;
-    mi.opcode        = mir.MIR_LOAD;
-    mi.width         = 1;
-    mi.src_width     = 1;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_LOAD, ?ops[0], 2, 1, 1);
     var base: i32 = 0;
     var disp: u8  = 0;
 

--- a/src/lang/target/isa/mos6502/rules.mach
+++ b/src/lang/target/isa/mos6502/rules.mach
@@ -210,11 +210,10 @@ test "mach.lang.target.isa.mos6502.rules:generic_opcode_coverage" {
     ops[0] = mir.op_preg(11);
     ops[1] = mir.op_preg(12);
     ops[2] = mir.op_preg(13);
-    var probe: mir.MirInstr;
-    probe.operands      = ?ops[0];
-    probe.operand_count = 3;
-    probe.width         = 1;
-    probe.vec_lane      = mir.VEC_LANE_NONE;
+    # the opcode is the loop variable below - every use assigns it first - so the
+    # constructor's is dead. `vec_lane` is cleared by construction, which is the
+    # VEC_LANE_NONE this probe wants.
+    var probe: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 1, 0);
 
     var f: mir.MirFunction;
 

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -4358,11 +4358,10 @@ test "mach.lang.target.isa.riscv64.encode:mir_subword_load_store_widths" {
     st.reloc_count = 0;
     st.reloc_cap   = 0;
 
-    var ld: mir.MirInstr;
     var ldops: [2]mir.MirOperand;
     ldops[0] = mir.op_preg(10);          # a0
     ldops[1] = mir.op_mem_preg(11, 0);   # [a1 + 0]
-    ld.opcode = mir.MIR_LOAD; ld.operands = ?ldops[0]; ld.operand_count = 2;
+    var ld: mir.MirInstr = mir.instr(mir.MIR_LOAD, ?ldops[0], 2, 0, 0);
 
     # u8 load: width clamps to 4, but the access is src_width 1 -> lbu a0,0(a1) =
     # 0x0005c503, NOT the clamped-width word lw (0x0005a503).
@@ -4379,11 +4378,10 @@ test "mach.lang.target.isa.riscv64.encode:mir_subword_load_store_widths" {
     st.buf.len = 0; ld.width = 8; ld.src_width = 8; encode_load(?st, nil, ?ld);
     if (read_word(?st.buf, 0) != 0x0005B503) { bad = 1; }
 
-    var sr: mir.MirInstr;
     var srops: [2]mir.MirOperand;
     srops[0] = mir.op_mem_preg(11, 0);   # [a1 + 0]
     srops[1] = mir.op_preg(10);          # a0
-    sr.opcode = mir.MIR_STORE; sr.operands = ?srops[0]; sr.operand_count = 2;
+    var sr: mir.MirInstr = mir.instr(mir.MIR_STORE, ?srops[0], 2, 0, 0);
 
     # u8 store: width 1 -> sb a0,0(a1) = 0x00a58023.
     st.buf.len = 0; sr.width = 1; sr.src_width = 1; encode_store(?st, nil, ?sr);
@@ -4395,11 +4393,10 @@ test "mach.lang.target.isa.riscv64.encode:mir_subword_load_store_widths" {
     # the folded-global load path sizes off src_width too: a u8 symbol load is
     # auipc t0,0 (0x00000297) ; lbu a0,0(t0) (0x0002c503), NOT lwu.
     st.buf.len = 0; st.reloc_count = 0;
-    var gl: mir.MirInstr;
     var glops: [2]mir.MirOperand;
     glops[0] = mir.op_preg(10);          # a0
     glops[1] = mir.op_sym(7::intern.StrId, 0);
-    gl.opcode = mir.MIR_LOAD; gl.operands = ?glops[0]; gl.operand_count = 2;
+    var gl: mir.MirInstr = mir.instr(mir.MIR_LOAD, ?glops[0], 2, 0, 0);
     gl.width = 4; gl.src_width = 1; encode_load(?st, nil, ?gl);
     if (read_word(?st.buf, 0) != 0x00000297) { bad = 1; }
     if (read_word(?st.buf, 4) != 0x0002C503) { bad = 1; }
@@ -4419,10 +4416,11 @@ test "mach.lang.target.isa.riscv64.encode:mir_alu_shift_mov_neg_not" {
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(10); ops[1] = mir.op_preg(11); ops[2] = mir.op_preg(12);
-    mi.operands = ?ops[0]; mi.operand_count = 3;
+    # the encoders under test take the opcode as their own argument, so this
+    # instruction's is never read; it carries the operands and widths only.
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
 
     # add a0,a1,a2 (width 8) = 0x00c58533 ; addw (width 4) = 0x00c5853b
     mi.width = 8; encode_addsub(?st, ?mi, false);
@@ -4450,10 +4448,11 @@ test "mach.lang.target.isa.riscv64.encode:mir_alu_shift_mov_neg_not" {
 
     # mv a0,a1 = 0x00058513 ; neg a0,a1 = 0x40b00533 ; not a0,a1 = 0xfff5c513
     st.buf.len = 0;
-    var mv: mir.MirInstr;
     var mvo: [2]mir.MirOperand;
     mvo[0] = mir.op_preg(10); mvo[1] = mir.op_preg(11);
-    mv.operands = ?mvo[0]; mv.operand_count = 2; mv.width = 8;
+    # the encoders under test take the opcode as their own argument, so this
+    # instruction's is never read; it carries the operands and widths only.
+    var mv: mir.MirInstr = mir.instr(mir.MIR_ADD, ?mvo[0], 2, 8, 0);
     encode_mov(?st, nil, ?mv);
     if (read_word(?st.buf, 0) != 0x00058513) { bad = 1; }
     encode_neg(?st, ?mv);
@@ -4477,12 +4476,13 @@ test "mach.lang.target.isa.riscv64.encode:const_value_variable_shift_materialize
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(10);   # rd = a0
     ops[1] = mir.op_imm(1);     # value = 1 (constant, must be materialized)
     ops[2] = mir.op_preg(12);   # count = a2 (runtime)
-    mi.operands = ?ops[0]; mi.operand_count = 3; mi.width = 8;
+    # the encoders under test take the opcode as their own argument, so this
+    # instruction's is never read; it carries the operands and widths only.
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     # sll a0, t1, a2 = 0x00c31533, preceded by li t1, 1 = 0x00100313.
     encode_shift(?st, ?mi, F3_SLL, false);
@@ -4520,10 +4520,9 @@ test "mach.lang.target.isa.riscv64.encode:integer_compare_sequences" {
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(10); ops[1] = mir.op_preg(11); ops[2] = mir.op_preg(12);
-    mi.operands = ?ops[0]; mi.operand_count = 3; mi.width = 8;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     # eq: xor a0,a1,a2 = 0x00c5c533 ; seqz a0,a0 (sltiu a0,a0,1) = 0x00153513
     mi.opcode = mir.MIR_SEL_CMP_EQ; encode_compare(?st, ?mi);
@@ -4590,13 +4589,12 @@ test "mach.lang.target.isa.riscv64.encode:fused_cbr_sequences" {
     st.fixup_count = 0;
     st.fixup_cap   = 0;
 
-    var mi: mir.MirInstr;
     var ops: [4]mir.MirOperand;
     ops[0] = mir.op_preg(11);
     ops[1] = mir.op_preg(12);
     ops[2] = mir.op_block(3);
     ops[3] = mir.op_block(4);
-    mi.operands = ?ops[0]; mi.operand_count = 4; mi.width = 8;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 4, 8, 0);
 
     # eq: beq a1,a2,0 = 0x00c58063 ; j 0 (jal x0,0) = 0x0000006f
     mi.opcode = mir.MIR_SEL_CBR_EQ; encode_fused_cbr(?st, 0, ?mi);
@@ -4663,10 +4661,9 @@ test "mach.lang.target.isa.riscv64.encode:branch_to_fallthrough_elided" {
     st.alloc = ?alloc; st.fixups = nil; st.fixup_count = 0; st.fixup_cap = 0;
 
     # an unconditional branch to block 4.
-    var ub: mir.MirInstr;
     var uops: [1]mir.MirOperand;
     uops[0] = mir.op_block(4);
-    ub.operands = ?uops[0]; ub.operand_count = 1; ub.opcode = mir.MIR_BR; ub.width = 8;
+    var ub: mir.MirInstr = mir.instr(mir.MIR_BR, ?uops[0], 1, 8, 0);
 
     # no successor recorded: the j word is emitted, one fixup against block 4.
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
@@ -4688,10 +4685,9 @@ test "mach.lang.target.isa.riscv64.encode:branch_to_fallthrough_elided" {
 
     # a plain conditional `bne cond,x0, then ; j else`: the taken bne always stays;
     # the not-taken j else elides when else (block 4) is the fallthrough successor.
-    var cbr: mir.MirInstr;
     var cops: [3]mir.MirOperand;
     cops[0] = mir.op_preg(10); cops[1] = mir.op_block(3); cops[2] = mir.op_block(4);
-    cbr.operands = ?cops[0]; cbr.operand_count = 3; cbr.width = 8; cbr.opcode = mir.MIR_SEL_CBR;
+    var cbr: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR, ?cops[0], 3, 8, 0);
 
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
     encode_cbr(?st, 0, ?cbr);
@@ -4706,11 +4702,10 @@ test "mach.lang.target.isa.riscv64.encode:branch_to_fallthrough_elided" {
 
     # a fused compare-and-branch `bcc a1,a2, then ; j else`: same elision of the
     # not-taken j else, taken bcc preserved.
-    var mi: mir.MirInstr;
     var ops: [4]mir.MirOperand;
     ops[0] = mir.op_preg(11); ops[1] = mir.op_preg(12);
     ops[2] = mir.op_block(3); ops[3] = mir.op_block(4);
-    mi.operands = ?ops[0]; mi.operand_count = 4; mi.width = 8; mi.opcode = mir.MIR_SEL_CBR_EQ;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR_EQ, ?ops[0], 4, 8, 0);
 
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
     encode_fused_cbr(?st, 0, ?mi);
@@ -4851,10 +4846,9 @@ test "mach.lang.target.isa.riscv64.encode:call_records_plt32_marker" {
     val sym: intern.StrId = 7::intern.StrId;
 
     # direct call: auipc ra,0 = 0x00000097 ; jalr ra,ra,0 = 0x000080e7, RK_PLT32 @0.
-    var ci: mir.MirInstr;
     var cops: [1]mir.MirOperand;
     cops[0] = mir.op_sym(sym, 0);
-    ci.operands = ?cops[0]; ci.operand_count = 1;
+    var ci: mir.MirInstr = mir.instr(mir.MIR_CALL, ?cops[0], 1, 0, 0);
     encode_call(?st, ?ci);
     if (read_word(?st.buf, 0) != 0x00000097) { bad = 1; }
     if (read_word(?st.buf, 4) != 0x000080E7) { bad = 1; }
@@ -4866,10 +4860,9 @@ test "mach.lang.target.isa.riscv64.encode:call_records_plt32_marker" {
     }
 
     # indirect call: jalr ra,a0,0 = 0x000500e7, no new reloc.
-    var ii: mir.MirInstr;
     var iops: [1]mir.MirOperand;
     iops[0] = mir.op_preg(10);
-    ii.operands = ?iops[0]; ii.operand_count = 1;
+    var ii: mir.MirInstr = mir.instr(mir.MIR_CALL, ?iops[0], 1, 0, 0);
     encode_call(?st, ?ii);
     if (read_word(?st.buf, 8) != 0x000500E7) { bad = 1; }
     if (st.reloc_count != 1)                 { bad = 1; }
@@ -5454,10 +5447,9 @@ test "mach.lang.target.isa.riscv64.encode:divide_family" {
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = mir.op_preg(10); ops[1] = mir.op_preg(11); ops[2] = mir.op_preg(12);
-    mi.operands = ?ops[0]; mi.operand_count = 3; mi.width = 8;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     # div = 0x02c5c533 ; divu = 0x02c5d533 ; rem = 0x02c5e533 ; remu = 0x02c5f533
     mi.opcode = mir.MIR_SEL_DIV_S; encode_divide(?st, ?mi);
@@ -5488,10 +5480,9 @@ test "mach.lang.target.isa.riscv64.encode:integer_conversions" {
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [2]mir.MirOperand;
     ops[0] = mir.op_preg(10); ops[1] = mir.op_preg(11);  # a0, a1
-    mi.operands = ?ops[0]; mi.operand_count = 2;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
     # TRUNC -> sext.w a0, a1 = 0x0005851b
     mi.opcode = mir.MIR_TRUNC; mi.width = 4; mi.src_width = 8;
@@ -5548,10 +5539,9 @@ test "mach.lang.target.isa.riscv64.encode:float_arith_neg_cmp" {
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [3]mir.MirOperand;
     ops[0] = fp_op(10); ops[1] = fp_op(11); ops[2] = fp_op(12);
-    mi.operands = ?ops[0]; mi.operand_count = 3; mi.width = 8;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     # fadd.d = 0x02c5f553 ; fsub.d = 0x0ac5f553 ; fmul.d = 0x12c5f553 ; fdiv.d = 0x1ac5f553
     mi.opcode = mir.MIR_FADD; encode_fp_arith(?st, nil, ?mi);
@@ -5576,10 +5566,9 @@ test "mach.lang.target.isa.riscv64.encode:float_arith_neg_cmp" {
     # the compares write a GP boolean directly: feq.d a0,fa1,fa2 = 0xa2c5a553 ;
     # flt.d = 0xa2c59553 ; fle.d = 0xa2c58553 ; ne = feq ; xori a0,a0,1 (0x00154513)
     st.buf.len = 0;
-    var ci: mir.MirInstr;
     var cops: [3]mir.MirOperand;
     cops[0] = mir.op_preg(10); cops[1] = fp_op(11); cops[2] = fp_op(12);  # a0, fa1, fa2
-    ci.operands = ?cops[0]; ci.operand_count = 3; ci.width = 8; ci.opcode = mir.MIR_FCMP;
+    var ci: mir.MirInstr = mir.instr(mir.MIR_FCMP, ?cops[0], 3, 8, 0);
     ci.src_width = mir.FCC_EQ; encode_fp_cmp(?st, nil, ?ci);
     if (read_word(?st.buf, 0) != 0xA2C5A553) { bad = 1; }
     st.buf.len = 0; ci.src_width = mir.FCC_LT; encode_fp_cmp(?st, nil, ?ci);
@@ -5602,9 +5591,8 @@ test "mach.lang.target.isa.riscv64.encode:float_conversions" {
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [2]mir.MirOperand;
-    mi.operands = ?ops[0]; mi.operand_count = 2;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
     # FP_TRUNC f64->f32: fcvt.s.d fa0,fa1 = 0x4015f553
     ops[0] = fp_op(10); ops[1] = fp_op(11);
@@ -5656,9 +5644,8 @@ test "mach.lang.target.isa.riscv64.encode:fmov_and_float_memory" {
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    var mi: mir.MirInstr;
     var ops: [2]mir.MirOperand;
-    mi.operands = ?ops[0]; mi.operand_count = 2; mi.width = 8;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_MOV, ?ops[0], 2, 8, 0);
 
     # float copy fa0 <- fa1: fmv.d fa0,fa1 = 0x22b58553
     ops[0] = fp_op(10); ops[1] = fp_op(11);

--- a/src/lang/target/isa/riscv64/rules.mach
+++ b/src/lang/target/isa/riscv64/rules.mach
@@ -441,11 +441,10 @@ test "mach.lang.target.isa.riscv64.rules:generic_opcode_coverage" {
     ops[0] = mir.op_preg(10);
     ops[1] = mir.op_preg(11);
     ops[2] = mir.op_preg(12);
-    var probe: mir.MirInstr;
-    probe.operands      = ?ops[0];
-    probe.operand_count = 3;
-    probe.width         = 8;
-    probe.vec_lane      = mir.VEC_LANE_NONE;
+    # the opcode is the loop variable below - every use assigns it first - so the
+    # constructor's is dead. `vec_lane` is cleared by construction, which is the
+    # VEC_LANE_NONE this probe wants.
+    var probe: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     var f: mir.MirFunction;
 

--- a/src/lang/target/isa/tests.mach
+++ b/src/lang/target/isa/tests.mach
@@ -1,15 +1,19 @@
 # the construction-site census for the target-layer records that own a constructor
 #
-# Six records are cleared in exactly one place each - the machine-instruction model
-# (`Inst`, `Operand`) and the four ISA contracts (`IsaVTable`, `RegMachine`,
-# `ModuleEmitter`, `RelocSeam`) - and this module proves it by reading the source
+# Seven records are cleared in exactly one place each - the machine-instruction
+# model (`Inst`, `Operand`), the four ISA contracts (`IsaVTable`, `RegMachine`,
+# `ModuleEmitter`, `RelocSeam`) and the MIR instruction (`MirInstr`) - and this
+# module proves it by reading the source
 # rather than by trusting review. `var` does not zero, so a site that builds one of
 # these records field by field leaves whatever field it does not name holding the
 # frame's residue - and a field added later is named by no site at all, on whichever
 # target happens to have written that stack.
 #
-# That is not hypothetical, twice over. `Operand.sym_mod` was added and three
-# hand-written clears did not learn about it. Then `IsaVTable` gained a
+# That is not hypothetical, three times over. `Operand.sym_mod` was added and three
+# hand-written clears did not learn about it. `MirInstr` gained `vec_lane` and
+# `regalloc.rewrite_instr` did not, so every rewritten vector op read as element
+# bytes 0 and the NEON encoder collapsed each arrangement to `.16b` after register
+# assignment - a shipped miscompile (#2032, #2321). Then `IsaVTable` gained a
 # relocatable-object seam (#2244) and sixteen hand-built vtables in the ELF writer's
 # tests silently acquired it uninitialized - `attributes_for` runs on every exec
 # emit, so those tests were handing it a function pointer off the stack and
@@ -83,11 +87,11 @@ pub rec Site {
 
 # the number of permitted (file, function) groups
 #
-# Eight constructors - `Inst` and `Operand` have two apiece, the shared model's and
+# Nine constructors - `Inst` and `Operand` have two apiece, the shared model's and
 # a target's own - plus the five arch registration modules whose process-global
 # vtable storage must be declared bare. Two kinds of entry, kept in one table so
 # neither is invisible.
-val ALLOWED_LEN: usize = 13;
+val ALLOWED_LEN: usize = 14;
 
 # the enclosing function name of each permitted group, positionally paired with
 # `allowed_file` and `allowed_count`. `<top>` is module scope
@@ -100,6 +104,7 @@ fun allowed_fun(i: usize) str {
     if (i == 5)  { ret "reloc_seam"; }
     if (i == 6)  { ret "inst"; }
     if (i == 7)  { ret "op_none"; }
+    if (i == 8)  { ret "instr"; }
     ret "<top>";
 }
 
@@ -114,10 +119,11 @@ fun allowed_file(i: usize) str {
     if (i == 5)  { ret "src/lang/target/isa.mach"; }
     if (i == 6)  { ret "src/lang/target/isa/arm64/printer.mach"; }
     if (i == 7)  { ret "src/lang/target/isa/asm.mach"; }
-    if (i == 8)  { ret "src/lang/target/isa/x64/register.mach"; }
-    if (i == 9)  { ret "src/lang/target/isa/arm64/register.mach"; }
-    if (i == 10) { ret "src/lang/target/isa/riscv64/register.mach"; }
-    if (i == 11) { ret "src/lang/target/isa/mos6502/register.mach"; }
+    if (i == 8)  { ret "src/lang/be/codegen/mir.mach"; }
+    if (i == 9)  { ret "src/lang/target/isa/x64/register.mach"; }
+    if (i == 10) { ret "src/lang/target/isa/arm64/register.mach"; }
+    if (i == 11) { ret "src/lang/target/isa/riscv64/register.mach"; }
+    if (i == 12) { ret "src/lang/target/isa/mos6502/register.mach"; }
     ret "src/lang/target/isa/spirv/register.mach";
 }
 
@@ -128,8 +134,8 @@ fun allowed_file(i: usize) str {
 # seam - a raw flat image carries no relocations) and for spirv (a whole-module
 # emitter payload instead of a register machine, and no seam by construction)
 fun allowed_count(i: usize) usize {
-    if (i <= 7)  { ret 1; }
-    if (i <= 10) { ret 3; }
+    if (i <= 8)  { ret 1; }
+    if (i <= 11) { ret 3; }
     ret 2;
 }
 
@@ -216,12 +222,14 @@ fun is_model_type(text: str, at: usize, len: usize) bool {
     if (str_region_equals(text, at, len, "RegMachine"))        { ret true; }
     if (str_region_equals(text, at, len, "ModuleEmitter"))     { ret true; }
     if (str_region_equals(text, at, len, "RelocSeam"))         { ret true; }
+    if (str_region_equals(text, at, len, "MirInstr"))          { ret true; }
     if (str_region_equals(text, at, len, "isa.Inst"))          { ret true; }
     if (str_region_equals(text, at, len, "isa.Operand"))       { ret true; }
     if (str_region_equals(text, at, len, "isa.IsaVTable"))     { ret true; }
     if (str_region_equals(text, at, len, "isa.RegMachine"))    { ret true; }
     if (str_region_equals(text, at, len, "isa.ModuleEmitter")) { ret true; }
     if (str_region_equals(text, at, len, "isa.RelocSeam"))     { ret true; }
+    if (str_region_equals(text, at, len, "mir.MirInstr"))      { ret true; }
     ret false;
 }
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -5598,10 +5598,9 @@ test "mach.lang.target.isa.x64.encode:branch_to_fallthrough_elided" {
 
     # an unconditional branch (post-isel x64.JMP) to block 4, driven through the full
     # encode_mir_instr path so the JMP fallthrough short-circuit is exercised.
-    var jm: mir.MirInstr;
     var jops: [1]mir.MirOperand;
     jops[0] = mir.op_block(4);
-    jm.operands = ?jops[0]; jm.operand_count = 1; jm.opcode = x64.JMP::u32; jm.width = 8;
+    var jm: mir.MirInstr = mir.instr(x64.JMP::u32, ?jops[0], 1, 8, 0);
 
     # no successor recorded: the 5-byte E9 jmp is emitted, one fixup against block 4.
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
@@ -5623,10 +5622,9 @@ test "mach.lang.target.isa.x64.encode:branch_to_fallthrough_elided" {
 
     # a plain conditional `TEST cond,cond ; JNE then ; JMP else`: the not-taken JMP
     # else elides when else (block 4) is the fallthrough successor, the JNE stays.
-    var cbr: mir.MirInstr;
     var cops: [3]mir.MirOperand;
     cops[0] = mir.op_preg(x64.RAX::u32); cops[1] = mir.op_block(3); cops[2] = mir.op_block(4);
-    cbr.operands = ?cops[0]; cbr.operand_count = 3; cbr.width = 8; cbr.opcode = mir.MIR_SEL_CBR;
+    var cbr: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR, ?cops[0], 3, 8, 0);
 
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
     encode_cbr(?st, ?f, 0, ?cbr);
@@ -5640,11 +5638,10 @@ test "mach.lang.target.isa.x64.encode:branch_to_fallthrough_elided" {
 
     # a fused compare-and-branch `CMP ; Jcc then ; JMP else`: same elision of the
     # not-taken JMP else, taken Jcc preserved.
-    var mi: mir.MirInstr;
     var ops: [4]mir.MirOperand;
     ops[0] = mir.op_preg(x64.RCX::u32); ops[1] = mir.op_preg(x64.RDX::u32);
     ops[2] = mir.op_block(3); ops[3] = mir.op_block(4);
-    mi.operands = ?ops[0]; mi.operand_count = 4; mi.width = 8; mi.opcode = mir.MIR_SEL_CBR_EQ;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR_EQ, ?ops[0], 4, 8, 0);
 
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
     encode_fused_cbr(?st, ?f, 0, ?mi);

--- a/src/lang/target/isa/x64/rules.mach
+++ b/src/lang/target/isa/x64/rules.mach
@@ -586,11 +586,10 @@ test "mach.lang.target.isa.x64.rules:generic_opcode_coverage" {
     ops[0] = mir.op_preg(10);
     ops[1] = mir.op_preg(11);
     ops[2] = mir.op_preg(12);
-    var probe: mir.MirInstr;
-    probe.operands      = ?ops[0];
-    probe.operand_count = 3;
-    probe.width         = 8;
-    probe.vec_lane      = mir.VEC_LANE_NONE;
+    # the opcode is the loop variable below - every use assigns it first - so the
+    # constructor's is dead. `vec_lane` is cleared by construction, which is the
+    # VEC_LANE_NONE this probe wants.
+    var probe: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     var f: mir.MirFunction;
 


### PR DESCRIPTION
Closes #2321.

## What was wrong

`mir.MirInstr` has **12 fields and no constructor**, and 90 sites declared one bare and named the three-to-five they cared about. `mir/context.push_instr` had grown a re-stamp for six of those fields — `asm_block`, `loc`, `inline_site`, `vec_lane`, `writes_secret`, the dbg-binding pair — one field at a time, with comments saying why:

```
# the dbg-binding list defaults empty here for the same reason (callers build
# instructions field-by-field and never set it)
```

That is a defensive fallback standing in for a constructor, and it only covers instructions that flow through that chokepoint. `width` and `src_width` were stamped by nothing.

It had already shipped a miscompile. `21b0de86`: `regalloc.rewrite_instr` rebuilt an instruction field by field and did not copy `vec_lane`, so every rewritten vector op read as element bytes 0 and the NEON encoder collapsed each arrangement to `.16b` after register assignment.

## Two constructors, because there are two shapes

**`mir.instr(opcode, operands, operand_count, width, src_width)`** — the five caller-owned fields positional, the seven metadata fields cleared. The `isa.inst_blank` shape. Omitting one is an arity error rather than a garbage operation width reaching the encoder.

**`mir.instr_like(src, operands, operand_count)`** — derive from an existing instruction with a new operand list, implemented as a whole-record copy so it carries **every** field including ones that do not exist yet. This is the one #2032 needed. `regalloc.rewrite_instr` and `looprotate.make_instr` were both field-wise rebuilds; a declaration-based census cannot see either, because there is no declaration — only writes through a slot.

The clone site clears the two owned references afterwards (`asm_block`, the dbg-binding list) rather than duplicating them, which is a semantic decision visible at the site instead of a field silently missed in the constructor.

## Converted

All 90 declaration sites: `mir/lower` 18, `mir/abi` 3, `mir/context` 2, `regalloc` 5, `looprotate` 2, `ctvalidate` 1, and the backends' encoders and rule packs (`arm64` 32, `riscv64` 20, `x64` 4, `mos6502` 3). Plus both copy sites. One bare declaration remains — `mir.instr` itself, the permitted clearing site.

Three sites needed more than a mechanical fold: the float-op lowering chose its opcode in an `if` chain *after* building the instruction, so the choice is hoisted above the construction rather than building one with a placeholder opcode; the load and store lowerings read `mi.src_width` back out of the instruction to compute `width`, so that value is now a local.

In the backends' encoder tests, 15 sites never set an opcode at all — the encoder under test takes it as its own argument. Eight of those name their instruction unambiguously (`encode_call` → `MIR_CALL`, `encode_mov`/`encode_fmov` → `MIR_MOV`) and now say so; the remaining six deliberately reuse one instruction across several encoders and carry a comment saying the opcode is not read.

## Shown to fire

**The derive guard.** `mach.lang.be.codegen.mir.instr_like:carries_every_field` compares the **whole record**: derive with the source's own operand list, and the result must be byte-identical to the source. Asserting fields one at a time would repeat the #2032 mistake inside the test. Both records are pattern-filled first, so padding agrees whether a whole-record assignment lowers to a memcpy or to field-wise moves.

Mutation — replace the whole-record copy with a field-by-field rebuild omitting `vec_lane`, which is exactly the #2032 bug:

```
877 passed, 39 failed, 916 total
  FAIL  mach.lang.be.codegen.mir.instr_like:carries_every_field  ./src/lang/be/codegen/mir.mach:1338
  FAIL  mach.lang.be.codegen.vector_runtime.arith:f32x4 ...   (37 vector runtime tests)
```

The guard catches the miscompile **as a unit test**, not only as 37 downstream runtime failures.

**The census.** `MirInstr` joins the censused set with `mir.instr` as its single permitted clearing site (14 groups, 22 sites). Mutation — revert one lowering site to a bare declaration:

```
915 passed, 1 failed, 916 total
  mach.lang.target.isa.blank:every_construction_site_is_constructed  ./src/lang/target/isa/tests.mach:458  (exit 1)
```

**N-1 / 1**, the census the single failure. Both mutations reverted; 916 / 0.

## The census caught a real one before this even merged

First CI run failed — `exit 2` from the census, on lanes that test the merge with `dev`. Two hand-built `MirInstr`s had landed on `dev` while this branch was open, from the 6502 shift/rotate encoder tests (#2217). Not a flaw in the census: **it is the census doing its job on the first day it existed**, catching a pattern that in-flight work was still using because nothing had forbidden it before. Merged `dev` in, converted both, green.

Worth knowing for whoever merges this: any branch currently open that adds a `var x: mir.MirInstr;` will fail this check on merge. The fix is one line per site.

## Bar

**Objects byte-identical, linux-x86_64 release.** Output equivalence — the check that says the compiler is unchanged, since the compiler's own objects necessarily differ when its source does. A `dev` checkout built by a `dev`-built compiler and by a branch-built compiler:

```
diff -r --brief pA/out pB/out  →  exit 0     (214 files)
```

No divergence, so no widening. This is the load-bearing result: 31 of the conversions are on the live lowering path, and a site that was not equivalent would have moved an emitted byte. Run three times — against the production-path commit in isolation, against the full branch, and again after merging current `dev`.

**Three-generation fixpoint**: `B == C` = `7e1cbdbc…`.

**Suites** through generation B: mach **926 / 0**, mach-std **611 / 0** at pin `eff1e8e`, materialized with `git archive` from the pin.

## Sweep

`MirInstr` was 88 of the 779 genuinely hand-built record sites under `src` and is now 0; the total is 698. What leads now: `Span` 39, `ObjectImage` 29, `Expr` 24, `MirFunction` 22, `Type` 18, `CTValue` 17, `Instruction` 16, `EncodeState` 16. `ObjectImage` still needs a target-layer clearing constructor before it can be converted — its only one is `be.obj.init`, which the target-layer writers cannot import.
