### PR TITLE
fix(lower): report an 8-byte scalar's width as 8, not as the machine word

### DIFF
--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -1699,6 +1699,13 @@ fun unsupported_message(op: mir.MirOpcode, width: u8) str {
     if (op == mir.MIR_GEP || op == mir.MIR_ALLOCA) {
         ret "legalize: materializing an address wider than one register is not yet legalized on this target";
     }
+    # a wide SIGN-extension became reachable only once an 8-byte scalar reported its
+    # real width (#2323); until then no wide value of any kind got this far on the one
+    # target that legalizes. It is named rather than left to the generic message, so the
+    # frontier reads as the specific unimplemented expansion it is.
+    if (op == mir.MIR_SEXT) {
+        ret "legalize: wide sign-extension is not yet legalized on this target";
+    }
     ret "legalize: operation wider than the target ALU is unsupported";
 }
 

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -433,24 +433,38 @@ pub fun ret_align(ctx: *LowerCtx, ty: ir_type.IrTypeId) u32 {
     ret align;
 }
 
-# the encoder operand width in bytes for an IR type: its `ir_type.byte_size`
-# clamped to the nearest legal x86-64 operand width (1, 2, 4, or 8)
+# the operand width in bytes for an IR type: its `ir_type.byte_size` when that is a
+# natural scalar width, and the machine word otherwise
 #
-# A scalar (int / float / pointer) maps to its own size; an aggregate or a value
-# wider than a machine word is held and addressed by pointer, so it rides at the
-# word width. A zero-sized or void type (the void result of a store) yields the
-# word width so a pseudo with no natural width still sizes its address-sized
-# fields. This is the single carrier that makes the encoder drive 1 / 2 / 4 /
-# 8-byte operations at the correct REX.W and prefix.
+# A SCALAR MAPS TO ITS OWN SIZE. The language's scalar widths are 1, 2, 4 and 8
+# bytes - every integer, float and pointer is one of them - and each is named here
+# so the width a value carries is a fact about the VALUE, not about the machine it
+# is being compiled for.
+#
+# The word-width fallthrough is for values with no natural scalar width: an
+# aggregate or an odd size, which is held and addressed by pointer, and a zero-sized
+# or void type (the void result of a store), so a pseudo with no natural width still
+# sizes its address-sized fields.
+#
+# EIGHT IS A SCALAR WIDTH, NOT THE MACHINE WORD (#2323). It used to reach the
+# fallthrough and come back as `gpr_width`, which is 8 on every 64-bit target - so
+# the answer was right for the wrong reason, and the reason failed on the one target
+# whose word is narrower than a scalar. mos6502 has a 1-byte word, so every `u64`
+# was stamped ONE byte wide: the width legalizer was then told an 8-byte add was a
+# native byte add, planned no lanes for its result, and refused the 8-byte store
+# that consumed it - so no `u64` computation reached codegen at all. A width wider
+# than the ALU is exactly what `be.codegen.legalize` exists to split; reporting it
+# honestly is what lets it.
 # ---
 # ctx: the lowering context
 # ty:  the IR type to size
-# ret: the operand width in bytes (1, 2, 4, or 8)
+# ret: the operand width in bytes (1, 2, 4, 8, or 16 for a vector)
 pub fun op_width_of(ctx: *LowerCtx, ty: ir_type.IrTypeId) u8 {
     val sz: u32 = ir_type.byte_size(ctx.types, ty, ctx.tgt);
     if (sz == 1) { ret 1; }
     if (sz == 2) { ret 2; }
     if (sz == 4) { ret 4; }
+    if (sz == 8) { ret 8; }
     # a 128-bit vector rides its full 16-byte width in a vector register, rather
     # than clamping to the GP word width (#1965).
     if (sz == 16 && value_is_vector(ctx, ty)) { ret 16; }

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -1340,3 +1340,77 @@ test "mach.lang.be.codegen.mir.context.vector_scaffolding" {
     ir_type.dnit(?types);
     ret 0;
 }
+
+# an 8-byte scalar reports EIGHT on every target, including one whose machine word is
+# narrower than it (#2323)
+#
+# `op_width_of` names the scalar widths and falls through to the machine word for
+# everything else. Eight used to be in the fallthrough, which answered correctly on
+# every 64-bit target and wrongly on the only target whose word is narrower - mos6502's
+# one byte, where every `u64` was stamped ONE byte wide and the width legalizer was told
+# an 8-byte operation was native.
+#
+# Both machines are driven from the same type table, so the assertion is that the width
+# is a fact about the VALUE and not about the machine. The narrow machine also keeps
+# what the fallthrough was protecting: a type with no natural scalar width still rides
+# the word.
+test "mach.lang.be.codegen.mir.context.op_width_is_a_fact_about_the_value" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var types: ir_type.IrTypeTable;
+    if (O.is_some[str](ir_type.init(?types, ?alloc))) { ret 1; }
+
+    var classes: [1]isa.RegClass;
+    classes[0].kind = isa.RC_GENERAL;
+
+    var model: isa.MachineModel;
+    var arch: isa.IsaVTable = isa.machine_isa(0, "probe", 0, 8, ?classes[0], 1, ?model, nil, nil);
+    var tgt: target.Target;
+    tgt.isa                 = ?arch;
+    tgt.model.reg_classes   = ?classes[0];
+    tgt.model.reg_class_len = 1;
+    var ctx: LowerCtx;
+    ctx.types = ?types;
+    ctx.tgt   = ?tgt;
+
+    var ids: [4]ir_type.IrTypeId;
+    var bits: [4]u32;
+    bits[0] = 8; bits[1] = 16; bits[2] = 32; bits[3] = 64;
+    var i: u32 = 0;
+    for (i < 4) {
+        val r: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?types, bits[i]);
+        if (R.is_err[ir_type.IrTypeId, str](r)) { ir_type.dnit(?types); ret 1; }
+        ids[i] = R.unwrap_ok[ir_type.IrTypeId, str](r);
+        i = i + 1;
+    }
+
+    # a 64-bit machine and an 8-BIT one must agree on every scalar width.
+    var words: [2]u32;
+    words[0] = 8; words[1] = 1;
+    var ptrs: [2]u32;
+    ptrs[0] = 8; ptrs[1] = 2;
+    var w: u32 = 0;
+    for (w < 2) {
+        tgt.model.gpr_width = words[w];
+        arch.pointer_width  = ptrs[w];
+        i = 0;
+        for (i < 4) {
+            if (op_width_of(?ctx, ids[i])::u32 != bits[i] / 8) { ir_type.dnit(?types); ret 1; }
+            i = i + 1;
+        }
+        w = w + 1;
+    }
+
+    # and a type with no natural scalar width still rides the machine word, which is
+    # what the fallthrough is for - on the narrow machine that is one byte, not eight.
+    val rv: R.Result[ir_type.IrTypeId, str] = ir_type.intern_void(?types);
+    if (R.is_err[ir_type.IrTypeId, str](rv)) { ir_type.dnit(?types); ret 1; }
+    val voidty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rv);
+    tgt.model.gpr_width = 8;
+    if (op_width_of(?ctx, voidty) != 8) { ir_type.dnit(?types); ret 1; }
+    tgt.model.gpr_width = 1;
+    if (op_width_of(?ctx, voidty) != 1) { ir_type.dnit(?types); ret 1; }
+
+    ir_type.dnit(?types);
+    ret 0;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -8102,10 +8102,13 @@ test "mach.lang.driver:pack_instance_enclosing_typeof_folds" {
 # the flat memory image the mos6502 end-to-end shift test runs a real build's bytes in:
 # the zero page (the value-register file), the loaded `.text`, and the data pages the
 # incoming arguments and the caller's result storage sit in
-val UT_MOS_MEM:   usize = 0x4000;
+# the image is the 6502's whole 64K address space, which is also the most `(zp),Y` can
+# reach: a `u64` probe module is one function per constant count plus the barrel, and
+# that is tens of kilobytes of `.text`
+val UT_MOS_MEM:   usize = 0x10000;
 val UT_MOS_CODE:  u32   = 0x0200;   # where `.text` loads, clear of the zero page
-val UT_MOS_ARGS:  u32   = 0x3000;   # the incoming argument block the frame pointer names
-val UT_MOS_STORE: u32   = 0x3100;   # the caller's result storage the hidden pointer names
+val UT_MOS_ARGS:  u32   = 0xF000;   # the incoming argument block the frame pointer names
+val UT_MOS_STORE: u32   = 0xF100;   # the caller's result storage the hidden pointer names
 # the mos6502 convention rounds a stack argument to an eight-byte slot, so the second
 # parameter of `f(v, n)` begins here whatever the scalar's width
 val UT_MOS_ARG1:  u32   = 8;
@@ -8196,15 +8199,31 @@ fun ut_shift_ref(left: bool, arith: bool, bits: u32, v: u64, n: u64) u64 {
     ret (sx::i64 >> c::i64)::u64 & mask;
 }
 
-# run one function of a built mos6502 image on the reference 6502 core (test helper)
+# load a built image's `.text` into the reference core's memory once (test helper)
+#
+# Hoisted out of the per-run setup: the emitted code never writes to itself, so one
+# load serves a whole sweep - which matters once a `u64` probe module is tens of
+# kilobytes and the sweep runs it thousands of times.
+# ---
+# text: the image's `.text`
+# len:  its length
+# mem:  the reference core's memory image
+fun ut_mos_load(text: *u8, len: u32, mem: *u8) {
+    var i: usize = 0;
+    for (i < UT_MOS_MEM) { mem[i] = 0; i = i + 1; }
+    i = 0;
+    for (i < len::usize) { mem[UT_MOS_CODE::usize + i] = text[i]; i = i + 1; }
+}
+
+# run one function of a loaded mos6502 image on the reference 6502 core (test helper)
 #
 # Sets the software frame pointer at the incoming argument block and the hidden result
 # pointer at the caller's storage - the placement `abi.mos6502` gives a scalar wider
 # than one byte - writes the arguments, runs, and reads the result back out of storage.
+# Clears only the state a run can touch (the zero-page register file and the two data
+# pages), leaving the loaded code alone.
 # ---
-# text:   the image's `.text`
-# len:    its length
-# mem:    the reference core's memory image
+# mem:    the reference core's memory image, already loaded by `ut_mos_load`
 # off:    the function's offset within `.text`
 # nbytes: the scalar's byte width
 # v:      the value argument
@@ -8212,12 +8231,16 @@ fun ut_shift_ref(left: bool, arith: bool, bits: u32, v: u64, n: u64) u64 {
 # out:    receives the result read out of the caller's storage
 # cycles: receives the run's cycle count
 # ret:    true when the run completed inside the core's pinned opcode set
-fun ut_mos_run(text: *u8, len: u32, mem: *u8, off: u32, nbytes: u32,
+fun ut_mos_run(mem: *u8, off: u32, nbytes: u32,
                v: u64, n: u64, out: *u64, cycles: *u32) bool {
     var i: usize = 0;
-    for (i < UT_MOS_MEM) { mem[i] = 0; i = i + 1; }
+    for (i < 256) { mem[i] = 0; i = i + 1; }
     i = 0;
-    for (i < len::usize) { mem[UT_MOS_CODE::usize + i] = text[i]; i = i + 1; }
+    for (i < 256) {
+        mem[UT_MOS_ARGS::usize + i]  = 0;
+        mem[UT_MOS_STORE::usize + i] = 0;
+        i = i + 1;
+    }
 
     mem[mos6502.zp_addr(mos6502.FP_LO)::usize]  = (UT_MOS_ARGS & 0xFF)::u8;
     mem[mos6502.zp_addr(mos6502.FP_HI)::usize]  = ((UT_MOS_ARGS >> 8) & 0xFF)::u8;
@@ -8335,7 +8358,7 @@ fun ut_mos_text(p: *project.Project, text: **u8, len: *u32, offs: *u32, nfns: u3
 # ret:   0 when every count and value answered correctly at a fixed cycle count
 fun ut_mos_shift_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: str,
                        sop: str, left: bool, arith: bool) i32 {
-    val sr: R.Result[*u8, str] = A.allocate[u8](alloc, 4096);
+    val sr: R.Result[*u8, str] = A.allocate[u8](alloc, 8192);
     if (R.is_err[*u8, str](sr)) { ret 1; }
     val srcbuf: *u8 = R.unwrap_ok[*u8, str](sr);
     ut_mos_shift_src(srcbuf, bits, ty, sop);
@@ -8355,6 +8378,7 @@ fun ut_mos_shift_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: 
     if (!ut_mos_text(?p, ?text, ?tlen, ?offs[0], bits + 1)) { project.dnit_project(?p); ret 1; }
     # the loaded image must not reach the argument block it would otherwise overwrite.
     if (UT_MOS_CODE + tlen >= UT_MOS_ARGS) { project.dnit_project(?p); ret 1; }
+    ut_mos_load(text, tlen, mem);
 
     val nbytes: u32 = bits / 8;
     var bad: i32 = 0;
@@ -8368,7 +8392,7 @@ fun ut_mos_shift_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: 
             val v: u64 = ut_shift_value(vi);
             var got: u64 = 0;
             var cy:  u32 = 0;
-            if (!ut_mos_run(text, tlen, mem, offs[c], nbytes, v, 0, ?got, ?cy)) { bad = 1; }
+            if (!ut_mos_run(mem, offs[c], nbytes, v, 0, ?got, ?cy)) { bad = 1; }
             or {
                 if (got != ut_shift_ref(left, arith, bits, v, c::u64)) { bad = 1; }
                 # constant-time in the VALUE: one cycle count across the whole sweep.
@@ -8390,7 +8414,7 @@ fun ut_mos_shift_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: 
             val v: u64 = ut_shift_value(vi);
             var got: u64 = 0;
             var cy:  u32 = 0;
-            if (!ut_mos_run(text, tlen, mem, offs[bits], nbytes, v, n::u64, ?got, ?cy)) { bad = 1; }
+            if (!ut_mos_run(mem, offs[bits], nbytes, v, n::u64, ?got, ?cy)) { bad = 1; }
             or {
                 if (got != ut_shift_ref(left, arith, bits, v, n::u64)) { bad = 1; }
                 if (n == 0 && vi == 0) { barrel = cy; }
@@ -8403,7 +8427,98 @@ fun ut_mos_shift_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: 
 
     project.dnit_project(?p);
     A.deallocate[u8](alloc, mem, UT_MOS_MEM);
-    A.deallocate[u8](alloc, srcbuf, 4096);
+    A.deallocate[u8](alloc, srcbuf, 8192);
+    ret bad;
+}
+
+# the u64 probe module: one function per operation, in the order the runner names them
+# (test helper)
+#
+# Every function takes and returns a single 8-byte scalar, so each arrives at `[fp+0]`
+# and returns through the hidden result pointer - the one ABI shape, so the runner needs
+# no per-function knowledge. `#2323`'s three named reproducers are the first three.
+fun ut_mos_u64_src() str {
+    ret "fun f0(v: u64) u64 { ret v + 1; }\nfun f1(v: u64) u64 { ret v & 1229782938247303441; }\nfun f2(v: u64) u64 { ret (v::u8)::u64; }\nfun f3(v: u64) u64 { ret v - 1; }\nfun f4(v: u64) u64 { ret ~v; }\nfun f5(v: u64) u64 { ret v | 1229782938247303441; }\nfun f6(v: u64) u64 { ret v ^ 1229782938247303441; }\nfun f7(v: u64) u64 { ret v + 4294967297; }\nfun main() i32 { ret 0; }\n";
+}
+
+# the number of probe functions `ut_mos_u64_src` declares
+val UT_MOS_U64_OPS: u32 = 8;
+
+# the reference answer for probe function `k`, computed independently of the emitted
+# bytes (test helper)
+fun ut_mos_u64_ref(k: u32, v: u64) u64 {
+    val m: u64 = 1229782938247303441;   # $1111111111111111, every lane non-trivial
+    if (k == 0) { ret v + 1; }
+    if (k == 1) { ret v & m; }
+    if (k == 2) { ret v & 255; }
+    if (k == 3) { ret v - 1; }
+    if (k == 4) { ret ~v; }
+    if (k == 5) { ret v | m; }
+    if (k == 6) { ret v ^ m; }
+    ret v + 4294967297;                 # $100000001, a carry across the lane-4 boundary
+}
+
+# mos6502 (#2323): a `u64` COMPUTATION builds and runs, executed on a reference 6502 core
+#
+# The issue's own reproducers - `v + 1`, `v & mask`, and a widening cast - none of which
+# reached codegen at all before, because an 8-byte scalar was stamped one byte wide and
+# the width legalizer was handed an 8-byte add claiming to be a native byte add. That
+# failure was a REFUSAL, so the fix has to be proven by execution rather than by the
+# absence of a diagnostic: a width that merely stopped being rejected could still be
+# decomposed wrongly.
+#
+# Eight lanes is also the widest the carry chain has ever run - `+`, `-` and the borrow
+# through every lane - and the values sweep the patterns a carry-propagation bug hides
+# behind: all-ones (carry out of every lane), the lane boundaries, and a spread.
+test "mach.lang.driver:u64_computation_executes_on_a_6502_core_mos6502" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val mr: R.Result[*u8, str] = A.zallocate[u8](?alloc, UT_MOS_MEM);
+    if (R.is_err[*u8, str](mr)) { ret 1; }
+    val mem: *u8 = R.unwrap_ok[*u8, str](mr);
+
+    var bad: i32 = 0;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, ut_mos_u64_src(), "mos");
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (ut_run_codegen_ok(?p) != 0) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    var text: *u8 = nil;
+    var tlen: u32 = 0;
+    var offs: [16]u32;
+    if (!ut_mos_text(?p, ?text, ?tlen, ?offs[0], UT_MOS_U64_OPS)) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (UT_MOS_CODE + tlen >= UT_MOS_ARGS)                        { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    ut_mos_load(text, tlen, mem);
+
+    var k: u32 = 0;
+    for (k < UT_MOS_U64_OPS) {
+        var fixed: u32 = 0;
+        var vi: u32 = 0;
+        for (vi < UT_SHIFT_VALUES) {
+            val v: u64 = ut_shift_value(vi);
+            var got: u64 = 0;
+            var cy:  u32 = 0;
+            if (!ut_mos_run(mem, offs[k], 8, v, 0, ?got, ?cy)) { bad = 1; }
+            or {
+                if (got != ut_mos_u64_ref(k, v)) { bad = 1; }
+                # every one of these is straight-line and fixed-cost, so the cycle count
+                # cannot depend on the value - the carry chain materializes its carry as
+                # a compare rather than branching on it.
+                if (vi == 0)     { fixed = cy; }
+                or (cy != fixed) { bad = 1; }
+            }
+            vi = vi + 1;
+        }
+        k = k + 1;
+    }
+
+    project.dnit_project(?p);
+    A.deallocate[u8](?alloc, mem, UT_MOS_MEM);
+    session.dnit(?s);
     ret bad;
 }
 
@@ -8428,9 +8543,10 @@ fun ut_mos_shift_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: 
 # Asserted by executing the bytes, because #2158 is the standing reminder that a
 # sequence which reads correctly on the page answered wrong for all 65536 inputs.
 #
-# `u64` is absent because no `u64` COMPUTATION reaches codegen on this target at all: a
-# plain `v + 1` on a `u64` is refused by width legalization ahead of any shift work, a
-# frontier that predates this issue.
+# `u64` was absent until #2323: no `u64` computation reached codegen on this target at
+# all, because an 8-byte scalar was stamped one byte wide and its lanes were never
+# planned. It is swept here now, which is the check that the fix is real rather than
+# merely no longer diagnosing.
 test "mach.lang.driver:shift_executes_on_a_6502_core_mos6502" {
     var bad: i32 = 0;
     var alloc: A.Allocator;
@@ -8445,6 +8561,9 @@ test "mach.lang.driver:shift_executes_on_a_6502_core_mos6502" {
     if (ut_mos_shift_sweep(?s, ?alloc, 32, "u32", "<<", true,  false) != 0) { bad = 1; }
     if (ut_mos_shift_sweep(?s, ?alloc, 32, "u32", ">>", false, false) != 0) { bad = 1; }
     if (ut_mos_shift_sweep(?s, ?alloc, 32, "i32", ">>", false, true)  != 0) { bad = 1; }
+    if (ut_mos_shift_sweep(?s, ?alloc, 64, "u64", "<<", true,  false) != 0) { bad = 1; }
+    if (ut_mos_shift_sweep(?s, ?alloc, 64, "u64", ">>", false, false) != 0) { bad = 1; }
+    if (ut_mos_shift_sweep(?s, ?alloc, 64, "i64", ">>", false, true)  != 0) { bad = 1; }
 
     session.dnit(?s);
     ret bad;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -8518,6 +8518,21 @@ test "mach.lang.driver:u64_computation_executes_on_a_6502_core_mos6502" {
 
     project.dnit_project(?p);
     A.deallocate[u8](?alloc, mem, UT_MOS_MEM);
+
+    # THE FRONTIER THAT MOVED, PINNED POSITIVELY. A wide SIGN-extension is reachable
+    # only now that an 8-byte scalar reports its real width - before, every `u64` was a
+    # byte and nothing wide got this far - and it is not legalized. It must say so
+    # specifically rather than fall back to the generic "wider than the target ALU",
+    # which is what an unimplemented expansion looks like when nobody named it.
+    val pe: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc,
+        "fun f(v: i64) i64 { ret (v::i8)::i64; }\nfun main() i32 { ret 0; }\n", "mos");
+    if (R.is_err[project.Project, outcome.Fail](pe)) { bad = 1; }
+    or {
+        var pf: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pe);
+        if (ut_run_codegen_err(?pf, "wide sign-extension is not yet legalized") != 0) { bad = 1; }
+        project.dnit_project(?pf);
+    }
+
     session.dnit(?s);
     ret bad;
 }


### PR DESCRIPTION
Closes #2323.

## The issue's mechanism was wrong — `plan_lanes` is not the bug

The issue says the planner "keys on the defining instruction, not the value width". It does key on the defining instruction, and **that is correct**: a vreg's width is a property of what defines it. The defining instruction was carrying a **false width**.

Dumping the pre-legalize MIR for `fun f(v: u64) u64 { ret v + 1; }` on mos6502 shows it directly — the `u64` parameter loads at width 8, the store writes at width 8, and the add between them claims to be **one byte wide**:

```
MOV   w=8  v0 <- [fp+0]        # the u64 parameter, 8 lanes planned
ADD   w=1  v3 <- v0, #1        # <<< the add is ONE byte
STORE w=8  [v4] <- v3          # v3 has no lanes -> refused
```

`u16` and `u32` were fine (widths 2 and 4). Only 8 was wrong.

## Root cause — `op_width_of`, shared and target-blind

```mach
if (sz == 1) { ret 1; }
if (sz == 2) { ret 2; }
if (sz == 4) { ret 4; }
if (sz == 16 && value_is_vector(ctx, ty)) { ret 16; }
ret ctx.tgt.model.gpr_width::u8;      # <<< everything else, including sz == 8
```

Eight was not named as a scalar width — it reached the fallthrough and came back as `gpr_width`, which is 8 on every 64-bit target. **The answer was right for the wrong reason**, and the reason failed on the one target whose word is narrower than a scalar. On mos6502 (`gpr_width = 1`) every `u64` was stamped one byte, so the width legalizer was told an 8-byte add was a native byte add, planned no lanes for its result, and refused the 8-byte store that consumed it.

**What the narrower rule was protecting** — and the fix keeps it: the fallthrough exists for values with *no natural scalar width* (an aggregate, an odd size, a zero-sized or void type) which are held and addressed by pointer and genuinely ride the machine word. The function's own doc says so: "a value **wider than a machine word** is held and addressed by pointer". That framing was written for a machine where the word is 8, so an 8-byte scalar was silently *not* "wider than a machine word". Naming 8 alongside 1/2/4 leaves the protection intact and is asserted directly: `op_width_is_a_fact_about_the_value` drives the same type table through a 64-bit machine and an 8-bit one, requires them to agree on every scalar width, and requires a void type to still ride the word — one byte on the narrow machine, eight on the wide one.

**Shared, not target-specific**, and provably inert wherever the word is 8: the fallthrough already returned 8 for an 8-byte value there. This is the third issue running in this area where the substance was a shared backend assumption rather than a 6502 quirk (#2216: five of six; #2217: legalizability keyed on the opcode).

## What this unblocks

Every shape the issue named now reaches codegen — `+`, `-`, `~`, `&`, `|`, `^`, unary `-`, a widening cast, and the `u64` variable shift #2217 could not cover. Two frontiers became **newly reachable** (nothing wide got that far before) and both refuse loudly: a wide multiply by a non-constant, and a wide **sign-extension**, which was landing in the generic "wider than the target ALU" and is now named. Implementing wide `SEXT` is a follow-up, not this PR.

## Verification

- **Executed, not merely un-rejected.** The failure this closes was a *refusal*, so proving it needed execution — a width that merely stopped being rejected could still be decomposed wrongly. `u64_computation_executes_on_a_6502_core_mos6502` compiles the issue's three reproducers plus the rest of the carry chain and the bitwise ops through the real pipeline, pulls `.text` out of the object image, and runs each on the reference 6502 core against an independently computed reference. Eight lanes is the widest the carry chain has ever run, and the sweep includes the values a carry-propagation bug hides behind.
- **#2217's shift sweep gains its u64 third**, replacing the pinned piece counts it had to rely on precisely because no `u64` function could be built. The loaded image is hoisted out of the per-run setup, since a `u64` probe module is tens of kilobytes run thousands of times.
- **Objects byte-identical on linux-x86_64 release**: all 213 objects and the linked binary identical to a from-source `origin/dev` compiler on the same source. Not widened, per the standing bar — it did not diverge.
- **Fixpoint** B == C == D (codegen moves for mos6502).
- **Suites through the from-source HEAD compiler:** mach **929 / 0** (current `dev` reports 927; +2 is exactly the two new tests), mach-std **611 / 0**, with `dep/mach-std` verified against pin `eff1e8e` by `git archive` + `diff -r` (identical; the only extra path is a generated `test/relro/dep` checkout, untracked at the pin).
- **9 mutations, 9 caught.** Reverting the fix, collapsing every scalar to the word, reporting 8 as 4, returning the size where the word is wanted, dropping the sign-extension diagnostic, breaking the reference add's carry, refusing an 8-lane shift, filling a zero-extension's high lanes from the wrong source lane, and dropping the carry chain's top-lane carry-in. Each restored. One earlier attempt survived — the sign-extension diagnostic had nothing asserting it — and is now pinned positively.

## Note

`dev` was red at `538a9669` when I started (`every_construction_site_is_constructed`, a census widened by #2300 meeting a hand-built record added by #2318 — each green alone). Reported at the time and fixed on `dev` by #2332; this branch is merged up to `5ab8d799` and the suite is clean.