### PR TITLE
fix(codegen): build the float goldens' MirInstr through mir.instr

### DIFF
--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -6173,10 +6173,9 @@ test "mach.lang.target.isa.x64.encode.encode_float_arith:two_address_shapes" {
     var bad: i32 = 0;
 
     # FMUL [xmm2, xmm0, xmm1] -> movss xmm2,xmm0 ; mulss xmm2,xmm1  (8 bytes)
-    var mul: mir.MirInstr;
     var mops: [3]mir.MirOperand;
     mops[0] = xmm_op(x64.XMM2); mops[1] = xmm_op(x64.XMM0); mops[2] = xmm_op(x64.XMM1);
-    mul.operands = ?mops[0]; mul.operand_count = 3; mul.opcode = mir.MIR_FMUL; mul.width = 4;
+    var mul: mir.MirInstr = mir.instr(mir.MIR_FMUL, ?mops[0], 3, 4, 0);
     buf.len = 0;
     encode_float_arith(?f, ?mul, ?buf);
     if (buf.len != 8)         { bad = 1; }
@@ -6190,10 +6189,9 @@ test "mach.lang.target.isa.x64.encode.encode_float_arith:two_address_shapes" {
     or (buf.data[7] != 0xD1)  { bad = 1; }
 
     # FADD [xmm3, xmm3, xmm1] -> addss xmm3,xmm1 alone: the tied pair needs no seed
-    var add: mir.MirInstr;
     var aops: [3]mir.MirOperand;
     aops[0] = xmm_op(x64.XMM3); aops[1] = xmm_op(x64.XMM3); aops[2] = xmm_op(x64.XMM1);
-    add.operands = ?aops[0]; add.operand_count = 3; add.opcode = mir.MIR_FADD; add.width = 4;
+    var add: mir.MirInstr = mir.instr(mir.MIR_FADD, ?aops[0], 3, 4, 0);
     buf.len = 0;
     encode_float_arith(?f, ?add, ?buf);
     if (buf.len != 4)         { bad = 1; }
@@ -6205,10 +6203,9 @@ test "mach.lang.target.isa.x64.encode.encode_float_arith:two_address_shapes" {
     # FSUB [xmm1, xmm0, xmm1] -> movss xmm15,xmm1 ; movss xmm1,xmm0 ; subss xmm1,xmm15.
     # the staging copy must come FIRST; emitting the seed first would compute
     # `xmm0 - xmm0`.
-    var sub: mir.MirInstr;
     var sops: [3]mir.MirOperand;
     sops[0] = xmm_op(x64.XMM1); sops[1] = xmm_op(x64.XMM0); sops[2] = xmm_op(x64.XMM1);
-    sub.operands = ?sops[0]; sub.operand_count = 3; sub.opcode = mir.MIR_FSUB; sub.width = 4;
+    var sub: mir.MirInstr = mir.instr(mir.MIR_FSUB, ?sops[0], 3, 4, 0);
     buf.len = 0;
     encode_float_arith(?f, ?sub, ?buf);
     if (buf.len != 14)         { bad = 1; }
@@ -6229,11 +6226,10 @@ test "mach.lang.target.isa.x64.encode.encode_float_arith:two_address_shapes" {
 
     # FDIV [xmm2, xmm0, [rbp-8]] -> movss xmm2,xmm0 ; divss xmm2,[rbp-8]: a spilled
     # source is named in place, since scalar SSE takes a memory operand directly
-    var dv: mir.MirInstr;
     var dops: [3]mir.MirOperand;
     dops[0] = xmm_op(x64.XMM2); dops[1] = xmm_op(x64.XMM0);
     dops[2] = mir.op_mem_preg(x64.RBP::u32, -8);
-    dv.operands = ?dops[0]; dv.operand_count = 3; dv.opcode = mir.MIR_FDIV; dv.width = 8;
+    var dv: mir.MirInstr = mir.instr(mir.MIR_FDIV, ?dops[0], 3, 8, 0);
     buf.len = 0;
     encode_float_arith(?f, ?dv, ?buf);
     if (buf.len != 9)         { bad = 1; }
@@ -6262,11 +6258,9 @@ test "mach.lang.target.isa.x64.encode.encode_float_cmp:operands_in_place" {
     var bad: i32 = 0;
 
     # FCMP GT [rax, xmm0, xmm1] -> ucomiss xmm0,xmm1 ; seta al ; movzx rax,al
-    var gt: mir.MirInstr;
     var gops: [3]mir.MirOperand;
     gops[0] = mir.op_preg(x64.RAX::u32); gops[1] = xmm_op(x64.XMM0); gops[2] = xmm_op(x64.XMM1);
-    gt.operands = ?gops[0]; gt.operand_count = 3; gt.opcode = mir.MIR_FCMP;
-    gt.width = 4; gt.src_width = mir.FCC_GT;
+    var gt: mir.MirInstr = mir.instr(mir.MIR_FCMP, ?gops[0], 3, 4, mir.FCC_GT);
     buf.len = 0;
     encode_float_cmp(?f, ?gt, ?buf);
     if (buf.len != 10)        { bad = 1; }
@@ -6276,11 +6270,9 @@ test "mach.lang.target.isa.x64.encode.encode_float_cmp:operands_in_place" {
 
     # FCMP LT [rax, xmm0, xmm1] reverses the operands (a < b reads as b > a), and the
     # reversal decides which side is the register operand - still neither is copied
-    var lt: mir.MirInstr;
     var lops: [3]mir.MirOperand;
     lops[0] = mir.op_preg(x64.RAX::u32); lops[1] = xmm_op(x64.XMM0); lops[2] = xmm_op(x64.XMM1);
-    lt.operands = ?lops[0]; lt.operand_count = 3; lt.opcode = mir.MIR_FCMP;
-    lt.width = 4; lt.src_width = mir.FCC_LT;
+    var lt: mir.MirInstr = mir.instr(mir.MIR_FCMP, ?lops[0], 3, 4, mir.FCC_LT);
     buf.len = 0;
     encode_float_cmp(?f, ?lt, ?buf);
     if (buf.len != 10)        { bad = 1; }


### PR DESCRIPTION
Closes #2338. **`dev` is red without this** — every self-test lane fails, so every open PR's merge build is reporting a failure that is not its own.

## Evidence

`dev` at `23ebab7f`:

```
mach.lang.target.isa.blank:every_construction_site_is_constructed
  ./src/lang/target/isa/tests.mach:458  (exit 6)
929 passed, 1 failed, 930 total
```

With this patch: **930 passed, 0 failed, 930 total.**

## The sites

Six bare `mir.MirInstr` declarations in `src/lang/target/isa/x64/encode.mach`, all in the float encoder goldens — `mul`, `add`, `sub`, `dv` in `encode_float_arith:two_address_shapes`, and `gt`, `lt` in `encode_float_cmp:operands_in_place`. The exit code is the count.

## Why it happened

- **#2332** added `MirInstr` to the censused set and converted the 90 sites that existed when it started — including the three pre-existing ones **in this same file**.
- **#2266** was rebased onto `c327004a`, which predates #2332, and added six more. Green on that base.
- They merged in sequence with **no textual conflict**: the six new sites sit beside three converted ones and git had no reason to object.

Mine, and I am fixing it — but neither PR was wrong when it was tested.

## The direction

Converted, not permitted. Each site declared the record bare and then assigned exactly the five fields `mir.instr` takes positionally, so the conversion is mechanical; the operand array moves above the declaration that consumes it.

```mach
-    var mul: mir.MirInstr;
     var mops: [3]mir.MirOperand;
     mops[0] = xmm_op(x64.XMM2); mops[1] = xmm_op(x64.XMM0); mops[2] = xmm_op(x64.XMM1);
-    mul.operands = ?mops[0]; mul.operand_count = 3; mul.opcode = mir.MIR_FMUL; mul.width = 4;
+    var mul: mir.MirInstr = mir.instr(mir.MIR_FMUL, ?mops[0], 3, 4, 0);
```

The two `FCMP` sites carry their condition code in `src_width`, which the constructor takes as its fifth argument (`mir.FCC_GT` / `mir.FCC_LT`).

## Worth more than a formality

The seven metadata fields — `asm_block`, `loc`, `dbg_bindings`, `dbg_binding_count`, `inline_site`, `vec_lane`, `writes_secret` — were left holding whatever the stack held.

Nothing was actively misread: these goldens call `encode_float_arith` / `encode_float_cmp` directly, and those encoders read only the five fields that were set. But that is a reachability argument about the callee, not a guarantee about the input, and it would have stopped holding the moment either encoder grew a `vec_lane` or `loc` read. The census is right that this is a defect and not a style preference.

## Bar

Suite green on `dev` with it applied: **930 / 0**. No fixpoint or byte-identity run — this converts six test-local declarations and changes no emitted code path. Per #2320 these are `test` blocks in a shipped module, so the release object does move; the change is field initialization inside test bodies only.