### PR TITLE
fix(sema): resolve each type node once per pass, so a diagnostic fires once

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6134,6 +6134,58 @@ test "mach.lang.driver:generic_named_without_type_arguments" {
     ret bad;
 }
 
+# a type-name diagnostic fires ONCE PER SITE, not once per resolution (#2334)
+#
+# `resolve_all_types` walks every AstType by index while every composite resolver
+# recurses into children that are themselves indexed nodes, and `intrinsic_operand_type`
+# resolved its operand again during body inference. Each resolution re-emitted the
+# node's diagnostics, so one bad annotation read as two or three separate problems and
+# `N errors` stopped meaning anything. These are exact COUNTS: a presence assertion
+# cannot see a duplicate, which is why the defect survived every diagnostic test the
+# suite already had
+test "mach.lang.driver:type_diagnostic_fires_once_per_site" {
+    var bad: i32 = 0;
+
+    # one site, through the intrinsic operand -- the leaf that resolved twice. 2 on dev.
+    if (ut_sema_errs("rec Box[T] { v: T; w: T; }\nfun f() u64 { ret $size_of(Box[u32, u32]); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n") != 1) { bad = 1; }
+    if (ut_sema_errs("rec Box[T] { v: T; w: T; }\nfun f() u64 { ret $size_of(Box); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n") != 1) { bad = 2; }
+    if (ut_sema_errs("rec Box[T] { v: T; w: T; }\nfun f() u64 { var n: u64 = 0; $each g in $fields(Box) { n = n + 1; } ret n; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n") != 1) { bad = 3; }
+
+    # a node nested in a composite: the index walk reaches it, and so does the pointer
+    # that encloses it. TWO sites here, and the second is not behind a composite -- 3 on
+    # dev, which is the count that proves the two causes are independent.
+    if (ut_sema_errs("rec Box[T] { v: T; w: T; }\nfun ptr(p: *Box[u32, u32]) u32 { ret 0; }\nfun ret_ty() Box[u32, u32] { var b: Box[u32]; ret b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n") != 2) { bad = 4; }
+
+    # every composite that recurses: pointer, array, `^`, and a `fun` parameter list.
+    if (ut_sema_errs("rec Box[T] { v: T; }\nfun f(p: *Box) u32 { ret 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n") != 1) { bad = 5; }
+    if (ut_sema_errs("rec Box[T] { v: T; }\nfun f() u32 { var a: [4]Box; ret 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n") != 1) { bad = 6; }
+    if (ut_sema_errs("rec Box[T] { v: T; }\nfun f(x: ^Box) u32 { ret 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n") != 1) { bad = 7; }
+    if (ut_sema_errs("rec Box[T] { v: T; }\nfun f(cb: fun(*Box) u32) u32 { ret 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n") != 1) { bad = 8; }
+
+    # six distinct sites, one diagnostic each. 10 on dev, and the shape a reader would
+    # have to hand-audit to discover the count was fiction.
+    if (ut_sema_errs("rec Box[T] { v: T; w: T; }\nrec Outer { b: Box; }\ndef Alias: Box;\nfun a(p: *Box) u64 { ret $size_of(Box) + $align_of(Box) + $offset_of(Box, w); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n") != 6) { bad = 9; }
+
+    # THE PRESERVATION EDGE, and the reason this is a memo rather than a dedup at the
+    # diagnostic sink. One span, FOUR genuinely distinct problems: the template's own
+    # check plus one per instance. They differ only by the substitution in force, which
+    # a sink that compares spans -- or messages that happened to coincide -- would
+    # destroy. The memo keys on the AST node and never reads the sink, so it cannot.
+    if (ut_sema_errs("rec Box[T] { v: T; }\nfun g[T](b: Box[T]) u32 { var x: u32 = 0; x = b.v; ret x; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var p: Box[^u32]; var q: Box[^u64]; var r: Box[u64]; g[^u32](p); g[^u64](q); g[u64](r); ret 0; }\n") != 4) { bad = 10; }
+
+    # the same node resolved under two different substitutions answers each of them,
+    # rather than serving the first instance's answer to the second.
+    if (!ut_sema_clean("rec Box[T] { v: T; w: T; }\nfun sz[T]() u64 { ret $size_of(Box[T]); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { if (sz[u8]() == sz[u64]()) { ret 1; } ret 0; }\n")) { bad = 11; }
+
+    # a REACHABLE operand that resolves to nothing is still reported once, not swallowed
+    # by the memo and not doubled by the internal-invariant guard behind it (#2178).
+    if (ut_sema_errs("fun f() u64 { ret $size_of(NoSuch); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n") != 1) { bad = 12; }
+    if (ut_vec_diag("rec Box[T] { v: T; }\nfun f() u64 { ret $size_of(Box); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
+        "internal: could not intern the type named by this comptime intrinsic argument") == 0) { bad = 13; }
+
+    ret bad;
+}
+
 # 0 when building `src` through the real build engine fails with no recorded artifact,
 # 1 on any other outcome. The end-to-end assertion #2168 needed: the leak there was not
 # a missing diagnostic but a build that PRINTED one and still reported success, linked,

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -261,6 +261,9 @@ pub fun reinfer_pack_each_body(
     sc.expr_type        = sema_result.expr_type;
     sc.type_resolved_ty = sema_result.type_resolved_ty;
     sc.decl_type        = sema_result.decl_type;
+    # no memo: an episode resolves under its instance's substitution, where the same
+    # node asks a different question per instantiation (#2334).
+    sc.type_resolved_memo = nil;
 
     sc.callee_eid       = id.EXPR_NIL;
     sc.in_comptime_gate = false;
@@ -362,6 +365,7 @@ pub fun reinfer_instance_body(
     sc.expr_type        = sema_result.expr_type;
     sc.type_resolved_ty = sema_result.type_resolved_ty;
     sc.decl_type        = sema_result.decl_type;
+    sc.type_resolved_memo = nil;
 
     sc.callee_eid       = id.EXPR_NIL;
     sc.in_comptime_gate = false;
@@ -552,6 +556,7 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     tsc.source           = source_text_of(sc.s, oa);
     tsc.expr_type        = scratch_expr;
     tsc.type_resolved_ty = o_type_resolved;
+    tsc.type_resolved_memo = nil;
     tsc.decl_type        = scratch_decl;
     tsc.callee_eid       = id.EXPR_NIL;
     tsc.in_comptime_gate = false;
@@ -721,6 +726,7 @@ fun init_context(
 
     sc.expr_type        = nil;
     sc.type_resolved_ty = nil;
+    sc.type_resolved_memo = nil;
     sc.decl_type        = nil;
 
     sc.callee_eid       = id.EXPR_NIL;
@@ -752,6 +758,16 @@ fun init_context(
             ret R.err[bool, str](R.unwrap_err[*type.TypeId, str](res_type));
         }
         sc.type_resolved_ty = R.unwrap_ok[*type.TypeId, str](res_type);
+
+        # the memo is the main pass's alone (#2334): it is sized and cleared here, freed
+        # by `dnit_context`, and deliberately NOT carried on the SemaResult, so every
+        # later episode resolves afresh under its own substitution.
+        val res_memo: R.Result[*u8, str] = memo_array_alloc(s.alloc, a.type_len);
+        if (R.is_err[*u8, str](res_memo)) {
+            dnit_context(sc);
+            ret R.err[bool, str](R.unwrap_err[*u8, str](res_memo));
+        }
+        sc.type_resolved_memo = R.unwrap_ok[*u8, str](res_memo);
     }
     if (a.decl_len > 0) {
         val res_decl: R.Result[*type.TypeId, str] = typeid_array_alloc(s.alloc, a.decl_len);
@@ -789,6 +805,24 @@ fun typeid_array_alloc(a: *A.Allocator, len: usize) R.Result[*type.TypeId, str] 
     ret R.ok[*type.TypeId, str](arr);
 }
 
+# allocate a `len`-slot memo-state array, each slot TYPE_MEMO_NONE
+# ---
+# a:   allocator
+# len: number of state slots
+# ret: the allocated array, or an allocation error
+fun memo_array_alloc(a: *A.Allocator, len: usize) R.Result[*u8, str] {
+    val res_arr: R.Result[*u8, str] = A.allocate[u8](a, len);
+    if (R.is_err[*u8, str](res_arr)) { ret res_arr; }
+    val arr: *u8 = R.unwrap_ok[*u8, str](res_arr);
+
+    var i: u32 = 0;
+    for (i < len::u32) {
+        arr[i] = context.TYPE_MEMO_NONE;
+        i = i + 1;
+    }
+    ret R.ok[*u8, str](arr);
+}
+
 # the module's source text, used to read identifier spans during inference
 #
 # The driver registers Ast.file_id with the session before sema runs, and an Ast
@@ -823,9 +857,15 @@ fun dnit_context(sc: *context.SemaContext) {
     if (sc.decl_type != nil && sc.a.decl_len > 0) {
         A.deallocate[type.TypeId](sc.s.alloc, sc.decl_type, sc.a.decl_len);
     }
-    sc.expr_type        = nil;
-    sc.type_resolved_ty = nil;
-    sc.decl_type        = nil;
+    # `build_result` clears the three transferred handles but never this one: the memo
+    # does not outlive the pass, so it is always freed here (#2334).
+    if (sc.type_resolved_memo != nil && sc.a.type_len > 0) {
+        A.deallocate[u8](sc.s.alloc, sc.type_resolved_memo, sc.a.type_len);
+    }
+    sc.expr_type          = nil;
+    sc.type_resolved_ty   = nil;
+    sc.type_resolved_memo = nil;
+    sc.decl_type          = nil;
     context.inst_worklist_dnit(sc);
 }
 

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -139,6 +139,14 @@ pub val SECRET_UNKNOWN: u8 = 0;
 pub val SECRET_ABSENT:  u8 = 1;
 pub val SECRET_PRESENT: u8 = 2;
 
+# `type_resolved_memo` states (#2334)
+#
+# QUIET and REPORTED both mean resolved; they differ on whether that resolution filed a
+# diagnostic, which is what a caller watching the sink across its own call needs back.
+pub val TYPE_MEMO_NONE:     u8 = 0;
+pub val TYPE_MEMO_QUIET:    u8 = 1;
+pub val TYPE_MEMO_REPORTED: u8 = 2;
+
 # the number of distinct mixed-secrecy generic union instances one analysis remembers
 # having reported (#2225)
 val UNI_REPORT_CAP: u32 = 256;
@@ -199,6 +207,7 @@ pub fun uni_report_mark(ur: *UniReports, key: type.TypeId) bool {
 # expr_type:        parallel to ast.exprs; written by infer_expr
 # type_resolved_ty: parallel to ast.types; written by resolve_type_ref
 # decl_type:        parallel to ast.decls; written by infer_decl
+# type_resolved_memo: parallel to type_resolved_ty; resolve_type_ref's memo, nil on an episode
 # callee_eid:       call-callee expr currently being inferred, or EXPR_NIL
 # in_comptime_gate: true while inferring a comptime `$if` gate condition
 # in_fin:           true while walking a `fin` body's statements
@@ -236,6 +245,33 @@ pub rec SemaContext {
     expr_type:        *type.TypeId;
     type_resolved_ty: *type.TypeId;
     decl_type:        *type.TypeId;
+
+    # `resolve_type_ref`'s memo (#2334): parallel to `type_resolved_ty`, marking the
+    # nodes this episode has already resolved.
+    #
+    # `resolve_all_types` walks every AstType by index, and every composite resolver
+    # recurses into children that are themselves indexed nodes, so a node nested in a
+    # composite was resolved once for its own index plus once per enclosing composite;
+    # `intrinsic_operand_type` then resolved its operand again during body inference.
+    # Each resolution re-emitted that node's diagnostics, so one ill-formed annotation
+    # read as two or three distinct problems. 38.3% of the resolutions in a compiler
+    # build recomputed an answer already held.
+    #
+    # NIL ON EVERY EPISODE, which is what makes the memo sound rather than a cache that
+    # happens to work. A resolution is redundant only when the ACTIVE SUBSTITUTION is
+    # the same: the identical node under `Box[u8]` and under `Box[u64]` asks two
+    # different questions, and collapsing them would answer with the TEMPLATE's types -
+    # the #2178 / #2257 defect. Within one module sema pass `subst` is nil throughout
+    # (`init_context` sets it so, and the re-validation drain builds NEW contexts rather
+    # than mutating this one), so there the memo is keyed by tid alone and can conflate
+    # nothing. An episode carries a substitution and gets no memo.
+    #
+    # It records whether the resolution REPORTED, not merely that it happened, because
+    # suppressing a repeat resolution also suppresses its diagnostic - and one caller
+    # (`intrinsic_operand_type`) asks "did this operand fail silently?" by watching the
+    # sink across its own call. That question survives memoization only if the answer is
+    # remembered with the node.
+    type_resolved_memo: *u8;
 
     # set transiently by infer_call so infer_ident permits a comptime-parameter
     # function in callee position (a template, callable but not a value) and

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1436,7 +1436,12 @@ fun intrinsic_operand_type(sc: *context.SemaContext, eid: id.ExprId, span: token
     # only an allocation failure gets here, so no test kills this either. It is the
     # assertion that a resource failure can never read as an empty `$each`, and it is
     # the same call `infer_generic_call` makes for the same reason (#1348).
-    if (ty == type.TYPE_ERROR && !context.reported_since(sc, mark)) {
+    #
+    # The question is asked through `resolve_reported` rather than the sink directly:
+    # this operand's node is normally resolved once by `resolve_all_types` and reached
+    # here a second time, and once that repeat is suppressed (#2334) the sink shows
+    # nothing filed across THIS call even though the operand was reported on properly.
+    if (ty == type.TYPE_ERROR && !resolve_reported(sc, e.data.type_ref.ty, mark)) {
         context.report(sc, e.span, "internal: could not intern the type named by this comptime intrinsic argument");
     }
     ret ty;
@@ -2180,13 +2185,79 @@ fun infer_struct_lit(sc: *context.SemaContext, sl: *expr.ExprStructLit, span: to
 # tid: syntactic AstType id to resolve
 # ret: the interned semantic TypeId (TYPE_ERROR on failure)
 pub fun resolve_type_ref(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
+    # a node already resolved by this pass yields the answer it yielded then, without
+    # re-running the resolution or re-emitting its diagnostics (#2334). The memo exists
+    # only on the main pass, whose substitution is nil throughout, so an instance
+    # episode is never served a template's answer -- see `type_resolved_done`.
+    if (memo_state(sc, tid) != context.TYPE_MEMO_NONE) { ret sc.type_resolved_ty[tid]; }
+
     # the active generic substitution (#2157) is applied at the NAMED leaf
     # (`type_for_symbol`), not here: every composite case below rebuilds structurally
     # by recursing through this function, so substituting the assembled result too
     # would apply it TWICE. That second pass re-reads a generic parameter the first
     # pass already substituted IN - and resolves it against the wrong argument list,
     # yielding TYPE_ERROR whenever its ordinal exceeds the inner arity (#2168).
-    ret resolve_type_ref_raw(sc, tid);
+    val mark:     usize       = context.diag_mark(sc);
+    val resolved: type.TypeId = resolve_type_ref_raw(sc, tid);
+    memo_record(sc, tid, resolved, context.reported_since(sc, mark));
+    ret resolved;
+}
+
+# `tid`'s memo state for this pass (#2334)
+#
+# TYPE_MEMO_NONE whenever the memo is absent (every episode) or the id is out of range,
+# so the caller resolves exactly as it did before the memo existed.
+# ---
+# sc:  sema context
+# tid: syntactic AstType id
+# ret: the recorded state, or TYPE_MEMO_NONE
+fun memo_state(sc: *context.SemaContext, tid: id.TypeId) u8 {
+    if (sc.type_resolved_memo == nil) { ret context.TYPE_MEMO_NONE; }
+    if (sc.type_resolved_ty == nil)   { ret context.TYPE_MEMO_NONE; }
+    if (tid >= sc.a.type_len::u32)    { ret context.TYPE_MEMO_NONE; }
+    ret sc.type_resolved_memo[tid];
+}
+
+# publish `tid`'s resolution to the memo (#2334)
+#
+# Writes the answer as well as the state, so a node first reached as some composite's
+# CHILD is recorded when that resolution completes rather than waiting for the index
+# walk to reach it -- which is where most of the redundancy was.
+#
+# `reported` is folded in because it is the resolution's outcome as much as the type
+# is: a later caller that suppresses the repeat also suppresses its diagnostic, and
+# must still be able to tell a failure that was reported from one that was silent.
+# ---
+# sc:       sema context
+# tid:      syntactic AstType id
+# resolved: the interned semantic TypeId just computed
+# reported: whether that resolution filed a diagnostic
+fun memo_record(sc: *context.SemaContext, tid: id.TypeId, resolved: type.TypeId, reported: bool) {
+    if (sc.type_resolved_memo == nil) { ret; }
+    if (sc.type_resolved_ty == nil)   { ret; }
+    if (tid >= sc.a.type_len::u32)    { ret; }
+    sc.type_resolved_ty[tid] = resolved;
+    if (reported) {
+        sc.type_resolved_memo[tid] = context.TYPE_MEMO_REPORTED;
+        ret;
+    }
+    sc.type_resolved_memo[tid] = context.TYPE_MEMO_QUIET;
+}
+
+# whether resolving `tid` filed a diagnostic, asked of whichever authority exists
+#
+# The memo when this pass has one -- a suppressed repeat files nothing, so the sink
+# cannot answer for it -- and the sink otherwise, where the resolution genuinely just
+# ran. Both answer the same question: did this node's failure go unreported (#2334)?
+# ---
+# sc:   sema context
+# tid:  syntactic AstType id just resolved
+# mark: a `diag_mark` taken before the resolution
+# ret:  true when the resolution reported
+fun resolve_reported(sc: *context.SemaContext, tid: id.TypeId, mark: usize) bool {
+    val state: u8 = memo_state(sc, tid);
+    if (state != context.TYPE_MEMO_NONE) { ret state == context.TYPE_MEMO_REPORTED; }
+    ret context.reported_since(sc, mark);
 }
 
 fun resolve_type_ref_raw(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {


### PR DESCRIPTION
Closes #2334

Instrumented first, per the issue's bar. The stated hypothesis turned out to be
wrong, and one of the three candidate fixes is unsafe.

## The hypothesis was not the cause

#2144's finding — `resolve_all_types` walks nodes the resolver never visited
(discarded `$if` arms, `probe_type_payload` orphans) — describes **extra distinct
nodes**, not repeat visits of one node, and cannot duplicate a diagnostic. The
measured causes are two others.

**A — the index walk and structural recursion overlap.** `resolve_all_types`
visits every AstType *by index*, and every composite resolver (`resolve_type_ptr`,
`_array`, `_secret`, `_fun`, `instantiate_named`, `def_underlying`) recurses into
children that are themselves indexed nodes. Traced on the two-site reproducer:

```
RTR mod=0 tid=4 phase=1 emitted=1     # Box[u32,u32], reached by its own index
RTR mod=0 tid=4 phase=1 emitted=1     # the SAME node, reached as *Box's pointee
RTR mod=0 tid=9 phase=1 emitted=1     # Box[u32,u32] in return position — once
```

2 + 1 = 3. That is why `*Box[...]` reported twice and a bare `Box[...]` once.

**B — body inference re-resolves.** `intrinsic_operand_type` resolves its operand
again at body-inference time, after `resolve_all_types` already did:

```
RTR mod=0 tid=5 phase=1 emitted=1
RTR mod=0 tid=5 phase=5 emitted=1
```

Both are the fact already documented at `src/lang/fe/sema/context.mach:148`.
#2225 solved it **for its own rule only**, with a private `UniReports` set — the
instance-level workaround for the class-level defect.

## Instrumented counts — full compiler + mach-std build

| | |
|---|---|
| `resolve_type_ref` calls | **309,354** |
| distinct (module, tid, substitution) | 191,001 |
| **redundant repeats** | **118,353 — 38.3%** |
| …no substitution active | 94,944 |
| …under a substitution | 23,409 |

Repeat-visit phases: type-resolution 45,303; body inference 46,469;
re-validation 26,581. First-visit phases: type-resolution 180,568;
re-validation 10,433.

**Body inference makes 46,469 resolutions and produces zero first visits** —
every one is a repeat.

## Why the memo is keyed the way it is

Under a substitution the same node resolves **exactly once per distinct
substitution**:

```
RTR mod=0 tid=13 phase=6 subst=84696351     # Box[u8]
RTR mod=0 tid=13 phase=6 subst=101473970    # Box[u64]
```

Those are not redundant — they are the same question with different answers. A
memo keyed on the node alone would collapse them and answer with the **template's**
types, which is the #2178 / #2257 defect class. So the memo is **nil on every
episode**, and keyed on the node only where that is sound: within one module sema
pass `subst` is nil throughout (`init_context` sets it so; the re-validation drain
builds *new* contexts rather than mutating this one).

It also records whether a resolution **reported**, not merely that it happened.
`intrinsic_operand_type` asks "did this operand fail silently?" by watching the
sink across its own call; a suppressed repeat files nothing, so without the
recorded outcome that guard fired its `internal:` message on every ordinary bad
operand. That interaction is the only one in the tree — `reported_since` has
exactly one sema caller.

**Not sink dedup**, and the corpus shows why concretely: one span can carry four
genuinely distinct problems (below). A sink comparing spans would destroy them,
and one comparing messages would be a coin flip whenever two instances produce
the same text. The memo never reads the sink at all.

**Not one designated reporting pass**: body inference legitimately needs the
answer — an operand inside a generic body must resolve under the episode's
substitution, which is what #2178 fixed. It re-resolved only because it had no way
to ask "already done".

## Result — counted by running, not by reading

| reproducer | sites | dev | this branch |
|---|---|---|---|
| `$size_of(Box[u32, u32])` | 1 | 2 | **1** |
| two wrong-arity sites in one signature | 2 | 3 | **2** |
| `$size_of(Box)` (#2311's rule) | 1 | 2 | **1** |
| `$fields(Box)` | 1 | 2 | **1** |
| bare generic, six sites | 6 | 10 | **6** |

## No diagnostic lost

A 20-program corpus of deliberately-broken inputs (mismatches, unknown names,
arity over and under, missing fields, secrecy leaks, mixed-secrecy unions,
`$fields` misuse, bad array lengths, type-as-value, nested composites, `def`
targets, in-generic-body errors), full diagnostic text and span compared:

```
DISTINCT (file, message, span) in dev but not here [lost]:  none
DISTINCT (file, message, span) here but not in dev [new]:   none

dev:         46 emitted, 30 distinct
this branch: 30 emitted, 30 distinct
spans still emitting the same diagnostic twice: none
```

Identical distinct sets; only the duplicate multiplicity is gone.

## Two genuinely distinct errors at the same span

The corpus produced one naturally, and I then built the strongest form — **four**
distinct diagnostics at one identical span, the template's own check plus one per
instance:

```
error: type mismatch: expected u32, found T      main.mach:3:43
error: type mismatch: expected u32, found ^u32   main.mach:3:43
error: type mismatch: expected u32, found ^u64   main.mach:3:43
error: type mismatch: expected u32, found u64    main.mach:3:43
```

Byte-identical on dev and on this branch. Pinned as a test.

## Verification

- **Objects byte-identical, linux-x86_64 release**, same source compiled by the
  dev-HEAD compiler and by this one — `diff -r` clean and the linked binary
  `cmp`-identical. This is diagnostics only, and it shows.
- `mach test` through the from-source HEAD compiler: `925 / 0` on dev
  `c446a879` → **`926 / 0`** here. Delta is exactly the one new test.
- `int/run.sh --target linux`: **all cases passed**, both profiles.
- mach-std at pin `eff1e8e` (`git archive`): **`611 / 0`**.
- **Compile time: ~10% faster** on a full release build — seven alternating
  pairs, mean 16.46s → 14.79s, faster in six of seven. Machine was shared and
  loaded (fix range 13.6–16.5s, dev 15.6–17.0s), so the direction is solid and
  the magnitude is approximate.
- Mutations: see the comment below.
- No fixpoint run: codegen did not move.