### PR TITLE
test(int): pin the reduction width matrix (#2347 groundwork)

### DIFF
--- a/int/surface/vectorize-emit/expect.linux-arm64.txt
+++ b/int/surface/vectorize-emit/expect.linux-arm64.txt
@@ -32,4 +32,13 @@ mul_f32k simd
 mul_kf32 simd
 ptr_i32add simd
 reload_i32 scalar
+sum_i16 simd
+sum_i32 simd
 sum_i64 simd
+sum_i8 simd
+widen_16_32 scalar
+widen_16_64 scalar
+widen_32_64 scalar
+widen_8_16 scalar
+widen_8_64 scalar
+widen_map scalar

--- a/int/surface/vectorize-emit/expect.linux-riscv64.txt
+++ b/int/surface/vectorize-emit/expect.linux-riscv64.txt
@@ -32,4 +32,13 @@ mul_f32k scalar
 mul_kf32 scalar
 ptr_i32add scalar
 reload_i32 scalar
+sum_i16 scalar
+sum_i32 scalar
 sum_i64 scalar
+sum_i8 scalar
+widen_16_32 scalar
+widen_16_64 scalar
+widen_32_64 scalar
+widen_8_16 scalar
+widen_8_64 scalar
+widen_map scalar

--- a/int/surface/vectorize-emit/expect.linux.txt
+++ b/int/surface/vectorize-emit/expect.linux.txt
@@ -32,4 +32,13 @@ mul_f32k simd
 mul_kf32 simd
 ptr_i32add simd
 reload_i32 scalar
+sum_i16 simd
+sum_i32 simd
 sum_i64 simd
+sum_i8 simd
+widen_16_32 scalar
+widen_16_64 scalar
+widen_32_64 scalar
+widen_8_16 scalar
+widen_8_64 scalar
+widen_map scalar

--- a/int/surface/vectorize-emit/src/main.mach
+++ b/int/surface/vectorize-emit/src/main.mach
@@ -85,6 +85,26 @@ pub fun aff_cursor2(a: *f32, b: *f32, o: i64, n: i64) { var i: i64=0; var t: i64
 # combine); its verdict guards the reduction path alongside the element-wise one
 pub fun sum_i64(a: *i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
 
+# the reduction WIDTH matrix (#2347). an integer reduction vectorizes at every lane
+# width when the accumulator is the element's own width, and declines at every width
+# pair when it is wider. The declining half is the row that matters: a widening
+# accumulate changes the lane count between the load and the accumulate, which the
+# single-vector-type transform cannot express, and there is no lane-widening convert
+# in the IR or in either capable back end to express it with. These rows exist so
+# that gap is a golden the day it closes, rather than a silent decline (#2207).
+pub fun sum_i32(a: *i32, n: i64) i32 { var s: i32=0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+pub fun sum_i16(a: *i16, n: i64) i16 { var s: i16=0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+pub fun sum_i8(a: *i8, n: i64)   i8  { var s: i8=0;  var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+pub fun widen_32_64(a: *i32, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[i]::i64; i=i+1; } ret s; }
+pub fun widen_16_64(a: *i16, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[i]::i64; i=i+1; } ret s; }
+pub fun widen_8_64(a: *i8, n: i64)   i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[i]::i64; i=i+1; } ret s; }
+pub fun widen_16_32(a: *i16, n: i64) i32 { var s: i32=0; var i: i64=0; for(i<n){ s=s+a[i]::i32; i=i+1; } ret s; }
+pub fun widen_8_16(a: *i8, n: i64)   i16 { var s: i16=0; var i: i64=0; for(i<n){ s=s+a[i]::i16; i=i+1; } ret s; }
+# the same gap on the element-wise side: a widening MAP has no reduction in it and
+# still declines, which is what shows the missing piece is the lane-widening convert
+# rather than anything about accumulators
+pub fun widen_map(a: *i64, b: *i32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]::i64; i=i+1; } }
+
 # float reductions must DECLINE here: lane-partial reassociation changes IEEE rounding,
 # and this case's profile does not set `float_reassoc` (#2160). the sibling
 # `vectorize-reassoc-emit` case is these same shapes under a profile that does set it,

--- a/src/lang/me/analysis/dependence.mach
+++ b/src/lang/me/analysis/dependence.mach
@@ -1230,6 +1230,22 @@ pub fun analyze_reduction(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u3
             if (inst.kind == instruction.OP_LOAD) {
                 var acc: MemAccess;
                 if (!classify_access(fn, la, loop_ix, iid, inst, types, ?acc)) { reduction_dnit(?ri); ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
+                # every load must be the accumulator's OWN width. A narrower element
+                # means the lane count changes between the load and the accumulate --
+                # four i32 lanes feed two i64 lanes -- and the transform below has one
+                # vector type for the whole tree, so relaxing this alone rewrites a
+                # 4-byte-strided load as a 16-byte one and reinterprets four elements
+                # as two. That is a silent wrong answer, not a declined loop: measured
+                # on a 64-element i32 sum, `0` against the scalar's `13280` (#2347).
+                #
+                # Deleting this check changes NO test, because the reduction value of a
+                # widening sum is the cast itself and supported_vector_op admits no
+                # conversion, so build_vset refuses it one gate later. That makes this
+                # rule untested but not unjustified: it is the width contract the
+                # single-vector-type transform relies on, and the gate that actually
+                # holds today is a different one. Widening needs a lane-widening
+                # convert in the IR and in both capable back ends, which do not have
+                # one -- see #2347. Do not remove it for being untested.
                 if (acc.elem_ty != elem_ty) { reduction_dnit(?ri); ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
                 ri.accesses[ri.access_count] = acc;
                 ri.access_count = ri.access_count + 1;


### PR DESCRIPTION
Refs #2347 — **groundwork and a scope escalation, not the fix.** See the issue comment for the full finding.

The issue's premise is that a widening reduction declines because `analyze_reduction` requires every load's element type to equal the accumulator's. Measured: **deleting that check changes nothing.** The reduction value of a widening sum *is* the cast, and `supported_vector_op` admits no conversion, so `build_vset` refuses it one gate later.

Relaxing both is a **silent wrong answer**, not a decline — one vector type for the whole tree turns an i32 load under an i64 accumulator into `load i64x2` through a 4-byte-strided gep. `--verify-ir` is clean on it; a 64-element i32 sum returns `0` against the scalar's `13280`.

The missing piece is a **lane-widening convert**, which exists in neither the IR nor either capable back end. That is a back-end capability, not a relaxed type check, and it is escalated on the issue rather than built here.

## What this PR does land

Both pieces are independent of how the scope question is decided:

- **`vectorize-emit` gains the width matrix** — `simd` at i8/i16/i32/i64 when the accumulator is the element's own width, `scalar` at all five widening pairs, plus a widening element-wise *map* with no accumulator in it (which is what shows the gap is the convert, not reductions). The day it closes, these rows flip in the diff rather than the pass quietly starting to fire (#2207).
- **The equal-width rule records what it protects**, the mutation that leaves it untouched, and the gate that actually holds today — the convention 793f3869 set.

Comments and tests only. Compiler byte-identical, fixpoint B == C, mach 948/0, mach-std 611/0 at pin `eff1e8e`, `int` green on `linux` / `linux-arm64` / `linux-riscv64`.

Draft: holding for the scope decision on #2347.