### PR TITLE
ci(darwin): restore x86_64-darwin as a released target

### DIFF
--- a/.github/workflows/darwin-lane.yml
+++ b/.github/workflows/darwin-lane.yml
@@ -73,6 +73,7 @@ jobs:
           # covers newer, and macos-14 is next in the runner-retirement line.
           - target: aarch64-darwin
             runs-on: macos-15
+            machine: arm64
           # x86_64-darwin self-hosts natively on Intel silicon. it was dropped in
           # 3.6.1 because the only macOS runners were apple silicon and the Intel
           # fixpoint had to run under Rosetta 2, which cannot host mach's raw
@@ -82,6 +83,7 @@ jobs:
           # image takes this row or x86_64-darwin loses its release lane again.
           - target: x86_64-darwin
             runs-on: macos-15-intel
+            machine: x86_64
     steps:
       - uses: actions/checkout@v6
 
@@ -90,6 +92,29 @@ jobs:
         with:
           name: seed-${{ matrix.target }}
           path: seed
+
+      # every binary this job execs — the seed and all three fixpoint stages — is
+      # built for matrix.target, so the runner has to BE that machine. should a
+      # runner label ever be repointed at different silicon, macOS would quietly
+      # run them under Rosetta 2, which cannot host mach's raw bsdthread_create
+      # worker threads: stage-a segfaults inside Rosetta's per-thread runtime and
+      # reads as a mach codegen bug. that misattribution already cost a release
+      # (#2104), so name the real cause here instead of crashing three steps later.
+      - name: assert the runner is native ${{ matrix.machine }}
+        env:
+          WANT: ${{ matrix.machine }}
+        run: |
+          set -euo pipefail
+          got="$(uname -m)"
+          # sysctl.proc_translated is an apple-silicon-only OID: 1 means this shell
+          # is itself translated, 0 means native, and its absence means intel
+          # hardware, where there is no Rosetta to be translated by.
+          translated="$(sysctl -n sysctl.proc_translated 2>/dev/null || echo 0)"
+          echo "runner machine: $got  sysctl.proc_translated: $translated  lane wants: $WANT"
+          if [ "$got" != "$WANT" ] || [ "$translated" != 0 ]; then
+            echo "::error::the $WANT darwin lane landed on a $got host (sysctl.proc_translated=$translated): its mach binaries would run under Rosetta 2, which cannot host mach's worker threads (#2104). the '${{ matrix.runs-on }}' runner label no longer means what this matrix row assumes."
+            exit 1
+          fi
 
       - name: build fixpoint
         run: |

--- a/.github/workflows/darwin-lane.yml
+++ b/.github/workflows/darwin-lane.yml
@@ -8,8 +8,8 @@ permissions:
 
 # darwin has no prior release to self-seed from, so seed cross-builds the stage-0
 # seed on linux first; collapse that bootstrap once a darwin archive ships. build
-# then runs on macos-15 (apple silicon), aarch64-darwin natively: it execs the
-# cross-built seed, self-hosts to a b == c fixpoint, and runs the suite.
+# then runs each darwin target on a native macOS host: it execs the cross-built
+# seed, self-hosts to a b == c fixpoint, and runs the suite.
 #
 # a reusable workflow, not a copy: cd.yml calls it for tag pushes and
 # workflow_dispatch, ci.yml calls it as the dev -> main release gate. one lane
@@ -28,6 +28,8 @@ jobs:
         include:
           - target: aarch64-darwin
             triple: darwin-aarch64
+          - target: x86_64-darwin
+            triple: darwin-x86_64
     steps:
       - uses: actions/checkout@v6
 
@@ -71,6 +73,15 @@ jobs:
           # covers newer, and macos-14 is next in the runner-retirement line.
           - target: aarch64-darwin
             runs-on: macos-15
+          # x86_64-darwin self-hosts natively on Intel silicon. it was dropped in
+          # 3.6.1 because the only macOS runners were apple silicon and the Intel
+          # fixpoint had to run under Rosetta 2, which cannot host mach's raw
+          # bsdthread_create worker threads (#2104); GitHub's native Intel runner
+          # removes the emulation and with it the crash. macos-15-intel is hosted
+          # only until August 2027 — when it retires, either a successor Intel
+          # image takes this row or x86_64-darwin loses its release lane again.
+          - target: x86_64-darwin
+            runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v6
 
@@ -85,7 +96,7 @@ jobs:
           set -euo pipefail
           chmod +x seed/mach-darwin-seed
 
-          # stage-0 is the cross-built seed; a/b/c self-host natively on the arm64 runner
+          # stage-0 is the cross-built seed; a/b/c self-host natively on the runner
           ./seed/mach-darwin-seed dep pull
           ./seed/mach-darwin-seed build . --profile release -o a
           ./a build . --profile release -o b
@@ -100,8 +111,8 @@ jobs:
       - name: self test
         run: |
           set -euo pipefail
-          # exercises a mach-built arm64-darwin binary whose ad-hoc signature must
-          # hold (no SIGKILL) for the fixpoint and these tests to pass
+          # exercises a mach-built darwin binary whose ad-hoc signature must hold
+          # (no SIGKILL on arm64) for the fixpoint and these tests to pass
           ./c test .
 
       - name: package archive

--- a/.github/workflows/int-main.yml
+++ b/.github/workflows/int-main.yml
@@ -1,12 +1,11 @@
 name: int main
 
 # the darwin legs of the integration matrix run on merge to main (and on manual
-# dispatch) rather than per-PR: the macOS runners are scarce, and darwin releases
-# are arm64-only, so a from-source compiler for each darwin target has to be
-# cross-built on linux first. running at the release-integration gate catches a
-# darwin codegen regression there while paying the macOS cost only then. the leg set
-# is still data-driven from int/targets.conf (the main-cadence rows), so adding a
-# darwin target is one row.
+# dispatch) rather than per-PR: the macOS runners are scarce, and a from-source
+# compiler for each darwin target has to be cross-built on linux first. running at
+# the release-integration gate catches a darwin codegen regression there while
+# paying the macOS cost only then. the leg set is still data-driven from
+# int/targets.conf (the main-cadence rows), so adding a darwin target is one row.
 
 on:
   push:
@@ -27,10 +26,10 @@ jobs:
       - id: gen
         run: echo "include=$(bash int/lib/ci-matrix.sh main)" >> "$GITHUB_OUTPUT"
 
-  # darwin releases are arm64-only (there is no x86_64-darwin seed to self-host
-  # from), so the from-source compiler for each darwin target is cross-built on
-  # linux from the x86_64-linux seed and handed to the macOS runner. this mirrors
-  # the cd.yml darwin bootstrap; collapse it once a darwin archive self-seeds.
+  # no darwin seed is published, so the from-source compiler for each darwin target
+  # is cross-built on linux from the x86_64-linux seed and handed to the macOS
+  # runner. this mirrors the darwin-lane.yml bootstrap; collapse it once a darwin
+  # archive self-seeds.
   seed:
     name: seed ${{ matrix.target }}
     needs: int-matrix

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -18,6 +18,7 @@ main() {
         Linux-x86_64) target="x86_64-linux" ;;
         Linux-aarch64|Linux-arm64) target="aarch64-linux" ;;
         Darwin-arm64|Darwin-aarch64) target="aarch64-darwin" ;;
+        Darwin-x86_64) target="x86_64-darwin" ;;
         *) err "unsupported host $(uname -s)-$(uname -m); prebuilt binaries: https://github.com/briar-systems/mach/releases" ;;
     esac
 

--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -64,9 +64,9 @@ _flat_loader_bin=
 # targets.conf row is added.
 qemu_bin() {
     case "$1" in
-        linux|windows)              echo qemu-x86_64 ;;
-        linux-arm64|darwin-aarch64) echo qemu-aarch64 ;;
-        linux-riscv64)              echo qemu-riscv64 ;;
+        linux|windows|darwin-x86_64) echo qemu-x86_64 ;;
+        linux-arm64|darwin-aarch64)  echo qemu-aarch64 ;;
+        linux-riscv64)               echo qemu-riscv64 ;;
         *) echo "int: no qemu interpreter mapping for target '$1'" >&2; return 1 ;;
     esac
 }

--- a/int/regression/1935-fused-cmp-branch/mach.toml
+++ b/int/regression/1935-fused-cmp-branch/mach.toml
@@ -24,6 +24,11 @@ isa = "x86_64"
 os  = "windows"
 abi = "win64"
 
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
 [target.darwin-aarch64]
 isa = "aarch64"
 os  = "darwin"

--- a/int/regression/1936-block-fallthrough/mach.toml
+++ b/int/regression/1936-block-fallthrough/mach.toml
@@ -24,6 +24,11 @@ isa = "x86_64"
 os  = "windows"
 abi = "win64"
 
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
 [target.darwin-aarch64]
 isa = "aarch64"
 os  = "darwin"

--- a/int/regression/1937-loop-rotation/mach.toml
+++ b/int/regression/1937-loop-rotation/mach.toml
@@ -24,6 +24,11 @@ isa = "x86_64"
 os  = "windows"
 abi = "win64"
 
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
 [target.darwin-aarch64]
 isa = "aarch64"
 os  = "darwin"

--- a/int/regression/2204-licm/mach.toml
+++ b/int/regression/2204-licm/mach.toml
@@ -24,6 +24,11 @@ isa = "x86_64"
 os  = "windows"
 abi = "win64"
 
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
 [target.darwin-aarch64]
 isa = "aarch64"
 os  = "darwin"

--- a/int/regression/2211-loop-rotation-scope/mach.toml
+++ b/int/regression/2211-loop-rotation-scope/mach.toml
@@ -24,6 +24,11 @@ isa = "x86_64"
 os  = "windows"
 abi = "win64"
 
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
 [target.darwin-aarch64]
 isa = "aarch64"
 os  = "darwin"

--- a/int/targets.conf
+++ b/int/targets.conf
@@ -16,3 +16,6 @@ linux-arm64      ubuntu-24.04-arm  native    pr
 linux-riscv64    ubuntu-latest     qemu      pr
 windows          windows-latest    native    pr
 darwin-aarch64   macos-15          native    main
+# native Intel silicon, not Rosetta 2, which cannot host mach's worker threads
+# (#2104). GitHub hosts macos-15-intel only until August 2027.
+darwin-x86_64    macos-15-intel    native    main


### PR DESCRIPTION
Closes #2327

x86_64-darwin was dropped in 3.6.1 (#2104): the Intel fixpoint ran under Rosetta 2 on an apple-silicon runner, and Rosetta cannot host mach's raw `bsdthread_create` worker threads — stage-a segfaulted inside Rosetta's per-thread runtime once parallel codegen (#2099) made worker threads the default. The lane was green for 3.5.1 with the identical script, so it was never a mach defect.

GitHub now hosts native Intel macOS runners, so nothing is emulated and the crash is simply absent. The lane is **one more matrix row in each of `darwin-lane.yml`'s `seed` and `build` jobs** — the seed still cross-builds on linux exactly as aarch64-darwin's does, and no script and no per-arch branch changed.

## Verified on real runs

Three `workflow_dispatch` runs of the darwin lane on this branch, no tag cut:

| | run | result |
|---|---|---|
| CD darwin lane (HEAD `0f0b1b2e`) | [30169006127](https://github.com/briar-systems/mach/actions/runs/30169006127) | `build x86_64-darwin` green, 2m45s on `macos-15-intel` |
| CD darwin lane | [30168620669](https://github.com/briar-systems/mach/actions/runs/30168620669) | green, 2m13s |
| CD darwin lane | [30168348385](https://github.com/briar-systems/mach/actions/runs/30168348385) | green, 2m1s — three for three, not a flake |
| int main | [30168621245](https://github.com/briar-systems/mach/actions/runs/30168621245) | `int darwin-x86_64` green, 62 case×profile PASS, `int: all cases passed on darwin-x86_64` |

- **fixpoint**: seed → a → b → c with `cmp b c` identical, every run. No `B != C`, so no codegen defect on this target.
- **self test**: `948 passed, 0 failed, 948 total` — the same count the aarch64-darwin row reports on the same commit.
- **the host really is Intel**: the lane prints `runner machine: x86_64  sysctl.proc_translated: 0  lane wants: x86_64`. Corroborating, the Intel job's git resolves to `/usr/local/bin/git` where the arm64 job's resolves to `/opt/homebrew/bin/git`.

## What is in the change

- `darwin-lane.yml`: the `x86_64-darwin` / `darwin-x86_64` seed row and the `x86_64-darwin` / `macos-15-intel` build row
- `darwin-lane.yml`: **a native-silicon assertion** (below)
- `int/targets.conf`: the `darwin-x86_64` leg back at main cadence on `macos-15-intel`. The five exec cases added while the platform was dropped never declared a `darwin-x86_64` target and would have failed to compile on that leg — each gets the block back
- `int/lib/produce.sh`: the qemu-interpreter row the file's stated invariant asks for (inert — the leg is native, as darwin-aarch64's row already is)
- `dist/install.sh`: `Darwin-x86_64` maps to the archive again

`cd.yml`'s "verify archive completeness" step reads its expected target set straight out of the build matrices, so x86_64-darwin re-enters the required release set with no edit there.

## The native-silicon assertion, and its mutation test

Every binary the build job execs is built for `matrix.target`. If a runner label is ever repointed at different silicon, macOS runs those binaries under Rosetta 2 and stage-a segfaults — **a failure that reads as a mach codegen bug**. That misattribution already cost the v3.6.0 release. Each row now declares the machine it must land on, and the job names the mismatch instead of crashing three steps later.

Mutation-tested rather than assumed. On a throwaway branch the `x86_64-darwin` row was repointed at `macos-15` (apple silicon) — the exact scenario the guard exists for:

```
runner machine: arm64  sysctl.proc_translated: 0  lane wants: x86_64
##[error]the x86_64 darwin lane landed on a arm64 host (sysctl.proc_translated=0): its mach
binaries would run under Rosetta 2, which cannot host mach's worker threads (#2104). the
'macos-15' runner label no longer means what this matrix row assumes.
```

It failed in **10 seconds, before `build fixpoint`**, and the `aarch64-darwin` row in the same run passed the assertion — so it catches the real failure without false-positiving. The mutation branch is deleted.

## Cost, and the accepted end-of-life

One ~2m macOS job plus a ~35s ubuntu job per release; **+~55s of release wall-clock** (the two darwin rows run in parallel). This repo is public and `macos-15-intel` is a standard runner, so the money cost is **$0** — on a private repo GitHub bills standard macOS at $0.062/min rounded up per job, ~$0.19/release.

**GitHub hosts `macos-15-intel` only until August 2027.** This ships a platform with a known CI end-of-life, and that is a deliberate, accepted trade rather than an oversight — Intel Mac hardware is itself EOL, so the CI substrate and the platform expire together. When the runner retires, either a successor Intel image takes the row or x86_64-darwin loses its release lane again. The date is recorded beside the row in both `darwin-lane.yml` and `int/targets.conf` so whoever hits it knows why the row exists and when it dies.
