### PR TITLE
refactor(target): remove the dead FP argument-register slot and close the debug-hook wiring gap

### DIFF
--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -2906,12 +2906,16 @@ var dwarf_debug_vtable: of.DebugVTable;
 # The target layer owns the `DebugRegistry` slot but cannot name this be-layer
 # producer, so the wiring lands here. It is the last capability attached to a
 # registered vtable after the fact: the ISA relocation packers were the other, and
-# they became a contract the arch declares at construction (#2244). Unlike them
-# this one is keyed on the model's own registered name rather than on a table of
-# names a subsystem holds, so nothing here has to know the set in advance. Sets the DWARF vtable's identity and its erased `produce`
-# hook, then registers it under "dwarf" - the name elf / mach-o's `default_debug`
-# resolves against. Idempotent: `debug_register` keeps the first write-once entry.
-# Must run at startup (from `driver.setup_registry`) before any `select`.
+# they became a contract the arch declares at construction (#2244). That treatment
+# is not available here - the identity must be registrable without the back end
+# present - so the pairing is enforced at the join instead: `driver.setup_registry`
+# runs `of.debug_hooks_complete` right after this call and refuses a registry
+# holding any identity a registrar never wired (#2295).
+#
+# Sets the DWARF vtable's identity and its erased `produce` hook, then registers it
+# under "dwarf" - the name elf / mach-o's `default_debug` resolves against.
+# Idempotent: `debug_register` keeps the first write-once entry. Must run at startup
+# (from `driver.setup_registry`) before any `select`.
 # ---
 # reg: the debug registry to install the DWARF producer into
 # ret: ok(true) once registered

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -45,6 +45,7 @@ use mach.lang.query;
 use mach.lang.readout;
 use mach.lang.session;
 use mach.lang.target;
+use mach.lang.target.of;
 
 use mach.lang.driver.project;
 use dq: mach.lang.driver.query;
@@ -86,13 +87,20 @@ fwd dcfg.resolve_artifact_path;
 # substrates then wires the one remaining be-layer hook onto the registered
 # dimensions (the DWARF debug producer), so every backend-build path starts from a
 # fully composed registry
+#
+# This is also the only place both halves of the debug dimension are in scope, so
+# it is where the identity/producer pairing is checked: `debug_hooks_complete`
+# refuses a registry holding a model identity whose registrar was never added,
+# instead of letting the gap surface at `-g` codegen far away (#2295).
 # ---
 # reg: the target registry to populate before any select
 # ret: ok(true) once registered and wired, or the first error
 pub fun setup_registry(reg: *target.TargetRegistry) R.Result[bool, str] {
     val rr: R.Result[bool, str] = target.register_all(reg);
     if (R.is_err[bool, str](rr)) { ret rr; }
-    ret dwarf.register_debug_hooks(?reg.debug);
+    val dr: R.Result[bool, str] = dwarf.register_debug_hooks(?reg.debug);
+    if (R.is_err[bool, str](dr)) { ret dr; }
+    ret of.debug_hooks_complete(?reg.debug);
 }
 
 # load the project's root manifest, select `target_name`, and

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -9181,3 +9181,38 @@ test "mach.lang.driver:shift_executes_on_a_6502_core_mos6502" {
     ret bad;
 }
 
+
+# `setup_registry` refuses a debug identity whose producer no registrar wired
+#
+# The identity list (target layer) and the be-layer registrars are joined only by
+# the order this function calls them, so a model added to one and not the other
+# registers cleanly, resolves cleanly through `select_of`, and surfaces only when a
+# `-g` build reaches codegen. Standing in for that model: a hook-less entry planted
+# in the registry before bring-up, which `dwarf.register_debug_hooks` does not
+# claim. `setup_registry` must refuse it and name it, and must still accept the
+# registry it composes itself (#2295)
+test "mach.lang.driver:setup_registry_refuses_an_unwired_debug_identity" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    # the registry the driver composes on its own comes up wired.
+    if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+    if (of.debug_registered_count(?s.registry.debug) == 0)       { session.dnit(?s); ret 1; }
+    session.dnit(?s);
+
+    # a model whose registrar was never added: bring-up must refuse, naming it.
+    val sr2: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr2)) { ret 1; }
+    var s2: session.Session = R.unwrap_ok[session.Session, str](sr2);
+    var orphan: of.DebugVTable;
+    orphan.id = of.DBG_CODEVIEW; orphan.name = "codeview"; orphan.produce = nil;
+    of.debug_register(?s2.registry.debug, ?orphan);
+    val res: R.Result[bool, str] = driver.setup_registry(?s2.registry);
+    if (!R.is_err[bool, str](res))                                  { session.dnit(?s2); ret 1; }
+    if (!ut_str_contains(R.unwrap_err[bool, str](res), "codeview")) { session.dnit(?s2); ret 1; }
+    session.dnit(?s2);
+    ret 0;
+}

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -140,7 +140,9 @@ pub fun host_abi_id() u32 {
 # debug: debug-info producer vtable registry; populated post-hoc by the be-layer
 #        `dwarf.register_debug_hooks` (its producers live in the back end). the last
 #        dimension wired after registration rather than declared at it - the ISA
-#        relocation packers stopped being (#2244)
+#        relocation packers stopped being (#2244). it stays post-hoc because the
+#        target layer must register a model's identity without the back end present,
+#        so `of.debug_hooks_complete` enforces the pairing at bring-up instead (#2295)
 pub rec TargetRegistry {
     isa:   isa.IsaRegistry;
     os:    os.OsRegistry;

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -263,9 +263,9 @@ pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, bool, bool, i32, i32, u
 pub def RetPassingFn: fun(u64, u64, bool, u8, bool, bool, u8, u8, AggLayout) ParamSlot;
 
 # fill a caller-owned `out` buffer with a register bank in canonical order and
-# return the count written. the erased `gp_arg_regs` / `fp_arg_regs` /
-# `callee_saved` pointers are all cast back to this. the caller must size `out` to
-# hold at least the bank's maximum count
+# return the count written. the erased `gp_arg_regs` / `callee_saved` pointers are
+# both cast back to this. the caller must size `out` to hold at least the bank's
+# maximum count
 # ---
 # out: caller-owned buffer receiving the register descriptors
 # ret: the number of registers written
@@ -283,14 +283,23 @@ pub def VaModelFn: fun() VaModel;
 # erased function pointers back to the convention's concrete signatures to
 # classify parameters and returns; it never branches on the numeric `id`
 #
-# `classify` / `arg_passing` / `ret_passing` drive per-value placement. the three
-# register-file accessors expose the convention's register banks the generic
-# backend needs but cannot name without ABI knowledge: `mir` pre-colors call
-# arguments and returns into the arg/return files, and `regalloc` partitions the
-# allocatable registers into the callee-saved set (preserved by the prologue) and
-# its complement, the caller-saved set (spilled across a call). all six function
-# pointers are type-erased (`*u8`); each consumer casts back to the neutral typed
-# signature declared above.
+# `classify` / `arg_passing` / `ret_passing` drive per-value placement: each hands
+# back the concrete register or stack slot for one value, so pre-coloring a call
+# never enumerates a bank. the two register-file accessors cover the only two
+# places a consumer needs the bank ITSELF instead of a placement - `gp_arg_regs`
+# for the win64 variadic tail-float duplication, which must name the GP register
+# matching an FP argument's index, and `callee_saved` for `regalloc`'s partition of
+# the allocatable registers into the callee-saved set (preserved by the prologue)
+# and its complement, the caller-saved set (spilled across a call).
+#
+# There is deliberately no FP twin of `gp_arg_regs`. One existed from the C
+# bootstrap (2025-11-24) through v4.2.2 and never had a reader in either compiler:
+# it was mirrored from the GP slot by symmetry, not demanded by a consumer, and was
+# removed in #2341. Add one only when a consumer needs it, never to match the GP
+# side.
+#
+# all six function pointers are type-erased (`*u8`); each consumer casts back to
+# the neutral typed signature declared above.
 # ---
 # id:                         calling-convention id (one of ABI_*)
 # name:                       interned convention name ("sysv64", "win64",
@@ -305,7 +314,6 @@ pub def VaModelFn: fun() VaModel;
 # arg_passing:                erased fn ptr -- assign arg regs/stack slots (ArgPassingFn)
 # ret_passing:                erased fn ptr -- assign return regs/sret (RetPassingFn)
 # gp_arg_regs:                erased fn ptr -- fill the GP argument bank (RegFileFn)
-# fp_arg_regs:                erased fn ptr -- fill the FP/vector argument bank (RegFileFn)
 # callee_saved:               erased fn ptr -- fill the callee-saved bank (RegFileFn)
 # stack_align:                required stack alignment in bytes at a call boundary
 # red_zone:                   leaf-function red-zone size in bytes (0 if none)
@@ -344,7 +352,6 @@ pub rec AbiVTable {
     arg_passing:                 *u8;
     ret_passing:                 *u8;
     gp_arg_regs:                 *u8;
-    fp_arg_regs:                 *u8;
     callee_saved:                *u8;
     stack_align:                 u32;
     red_zone:                    u32;

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -352,23 +352,6 @@ pub fun gp_param_regs(out: *isa.Register) i32 {
     ret GP_PARAM_COUNT;
 }
 
-# fill `out` with the floating-point/vector argument registers, in passing order
-#
-# Writes `out[0..FP_PARAM_COUNT)` with V0-V7 (composite vector ids, each 16 bytes
-# wide). The caller owns `out`, which must hold at least `FP_PARAM_COUNT` registers.
-# ---
-# out: caller-owned buffer of at least FP_PARAM_COUNT registers
-# ret: the number of registers written (FP_PARAM_COUNT)
-pub fun fp_param_regs(out: *isa.Register) i32 {
-    var i: i32 = 0;
-    for (i < FP_PARAM_COUNT) {
-        out[i].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, i);
-        out[i].size = 16;
-        i = i + 1;
-    }
-    ret FP_PARAM_COUNT;
-}
-
 # fill `out` with the callee-saved registers across both banks
 #
 # Writes `out[0..CALLEE_SAVED_COUNT)` with the GP set X19-X28 (8 bytes each) then
@@ -420,7 +403,7 @@ var aapcs64_vtable: abi.AbiVTable;
 # build the AAPCS64 AbiVTable and install it into `reg`
 #
 # Sets the convention name ("aapcs64") as an immutable `str` constant, wires the
-# type-erased classify/arg/ret operation pointers and the GP/FP argument-register
+# type-erased classify/arg/ret operation pointers and the GP argument-register
 # and callee-saved register-file accessors, sets the 16-byte stack alignment, no
 # red zone, and no shadow space, and registers it under `abi.ABI_AAPCS64` so
 # `target.select` can find it through `abi.lookup`. Idempotent: the registry entry
@@ -436,7 +419,6 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     aapcs64_vtable.arg_passing  = classify_arg::*u8;
     aapcs64_vtable.ret_passing  = classify_return::*u8;
     aapcs64_vtable.gp_arg_regs  = gp_param_regs::*u8;
-    aapcs64_vtable.fp_arg_regs  = fp_param_regs::*u8;
     aapcs64_vtable.callee_saved = callee_saved::*u8;
     aapcs64_vtable.stack_align  = STACK_ALIGN;
     aapcs64_vtable.red_zone     = RED_ZONE;
@@ -612,9 +594,6 @@ test "mach.lang.target.abi.aapcs64:register_file_banks" {
     var gp: [8]isa.Register;
     if (gp_param_regs(?gp[0]) != GP_PARAM_COUNT)  { ret 1; }
     if (gp[0].id != REG_X0 || gp[7].id != REG_X7) { ret 1; }
-    var fp: [8]isa.Register;
-    if (fp_param_regs(?fp[0]) != FP_PARAM_COUNT)                    { ret 1; }
-    if (fp[0].id != fp_param_reg(0) || fp[7].id != fp_param_reg(7)) { ret 1; }
     var cs: [18]isa.Register;
     if (callee_saved(?cs[0]) != CALLEE_SAVED_COUNT)            { ret 1; }
     if (cs[0].id != REG_X19 || cs[9].id != REG_X28)            { ret 1; }

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -416,24 +416,6 @@ pub fun gp_param_regs(out: *isa.Register) i32 {
     ret GP_PARAM_COUNT;
 }
 
-# fill `out` with the float argument registers, in passing order
-#
-# Writes `out[0..FP_PARAM_COUNT)` with fa0-fa7 (composite float ids, each 8 bytes
-# wide under the D extension). The caller owns `out`, which must hold at least
-# `FP_PARAM_COUNT` registers.
-# ---
-# out: caller-owned buffer of at least FP_PARAM_COUNT registers
-# ret: the number of registers written (FP_PARAM_COUNT)
-pub fun fp_param_regs(out: *isa.Register) i32 {
-    var i: i32 = 0;
-    for (i < FP_PARAM_COUNT) {
-        out[i].id   = fp_param_reg(i);
-        out[i].size = 8;
-        i = i + 1;
-    }
-    ret FP_PARAM_COUNT;
-}
-
 # fill `out` with the callee-saved registers across both banks
 #
 # Writes `out[0..CALLEE_SAVED_COUNT)` with the integer set s1, s2-s11 (x9, x18-x27,
@@ -492,7 +474,7 @@ var lp64_vtable: abi.AbiVTable;
 # build the lp64d AbiVTable and install it into `reg`
 #
 # Sets the convention name ("lp64") as an immutable `str` constant, wires the
-# type-erased classify/arg/ret operation pointers and the integer/float
+# type-erased classify/arg/ret operation pointers and the integer
 # argument-register and callee-saved register-file accessors, sets the 16-byte
 # stack alignment, no red zone, and no shadow space, and registers it under
 # `abi.ABI_LP64` so `target.select` can find it through `abi.lookup`. The hidden
@@ -510,7 +492,6 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     lp64_vtable.arg_passing  = classify_arg::*u8;
     lp64_vtable.ret_passing  = classify_return::*u8;
     lp64_vtable.gp_arg_regs  = gp_param_regs::*u8;
-    lp64_vtable.fp_arg_regs  = fp_param_regs::*u8;
     lp64_vtable.callee_saved = callee_saved::*u8;
     lp64_vtable.stack_align  = STACK_ALIGN;
     lp64_vtable.red_zone     = RED_ZONE;
@@ -807,9 +788,6 @@ test "mach.lang.target.abi.lp64:register_file_banks" {
     var gp: [8]isa.Register;
     if (gp_param_regs(?gp[0]) != GP_PARAM_COUNT)        { ret 1; }
     if (gp[0].id != REG_A0 || gp[7].id != REG_A0 + 7)  { ret 1; }
-    var fp: [8]isa.Register;
-    if (fp_param_regs(?fp[0]) != FP_PARAM_COUNT)                    { ret 1; }
-    if (fp[0].id != fp_param_reg(0) || fp[7].id != fp_param_reg(7)) { ret 1; }
     var cs: [23]isa.Register;
     if (callee_saved(?cs[0]) != CALLEE_SAVED_COUNT)            { ret 1; }
     if (cs[0].id != REG_S1 || cs[10].id != REG_S2 + 9)        { ret 1; }

--- a/src/lang/target/abi/mos6502.mach
+++ b/src/lang/target/abi/mos6502.mach
@@ -98,9 +98,6 @@ fun gp_arg_regs(out: *isa.Register) i32 {
     ret ARG_REG_COUNT;
 }
 
-# the 6502 has no floating-point register bank
-fun fp_arg_regs(out: *isa.Register) i32 { ret 0; }
-
 # the 6502 convention is caller-saved throughout: no callee-saved registers
 fun callee_saved(out: *isa.Register) i32 { ret 0; }
 
@@ -132,7 +129,6 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     mos6502_abi_vtable.arg_passing  = arg_passing::*u8;
     mos6502_abi_vtable.ret_passing  = ret_passing::*u8;
     mos6502_abi_vtable.gp_arg_regs  = gp_arg_regs::*u8;
-    mos6502_abi_vtable.fp_arg_regs  = fp_arg_regs::*u8;
     mos6502_abi_vtable.callee_saved = callee_saved::*u8;
     mos6502_abi_vtable.va_model     = va_model::*u8;
 

--- a/src/lang/target/abi/spirv.mach
+++ b/src/lang/target/abi/spirv.mach
@@ -111,7 +111,6 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     spirv_abi_vtable.arg_passing  = classify_arg::*u8;
     spirv_abi_vtable.ret_passing  = classify_return::*u8;
     spirv_abi_vtable.gp_arg_regs  = arg_regs::*u8;
-    spirv_abi_vtable.fp_arg_regs  = arg_regs::*u8;
     spirv_abi_vtable.callee_saved = callee_saved::*u8;
     spirv_abi_vtable.stack_align  = 0;
     spirv_abi_vtable.red_zone     = 0;

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -343,23 +343,6 @@ pub fun gp_param_regs(out: *isa.Register) i32 {
     ret GP_PARAM_COUNT;
 }
 
-# fill `out` with the floating-point argument registers, in passing order
-#
-# Writes `out[0..FP_PARAM_COUNT)` with XMM0-XMM7 (each 16 bytes wide). The caller
-# owns `out`, which must hold at least `FP_PARAM_COUNT` registers.
-# ---
-# out: caller-owned buffer of at least FP_PARAM_COUNT registers
-# ret: the number of registers written (FP_PARAM_COUNT)
-pub fun fp_param_regs(out: *isa.Register) i32 {
-    var i: i32 = 0;
-    for (i < FP_PARAM_COUNT) {
-        out[i].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, i);
-        out[i].size = 16;
-        i = i + 1;
-    }
-    ret FP_PARAM_COUNT;
-}
-
 # fill `out` with the callee-saved general-purpose registers
 #
 # Writes `out[0..CALLEE_SAVED_COUNT)` with RBX, RBP, R12, R13, R14, R15 (each 8
@@ -419,7 +402,6 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     sysv_vtable.arg_passing  = classify_arg::*u8;
     sysv_vtable.ret_passing  = classify_return::*u8;
     sysv_vtable.gp_arg_regs  = gp_param_regs::*u8;
-    sysv_vtable.fp_arg_regs  = fp_param_regs::*u8;
     sysv_vtable.callee_saved = callee_saved::*u8;
     sysv_vtable.stack_align  = STACK_ALIGN;
     sysv_vtable.red_zone     = RED_ZONE;

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -320,23 +320,6 @@ pub fun gp_param_regs(out: *isa.Register) i32 {
     ret GP_PARAM_COUNT;
 }
 
-# fill the FP argument register bank in passing order
-#
-# writes XMM0-XMM3 (each 16 bytes wide) into `out[0..FP_PARAM_COUNT)`. the caller
-# owns `out`, which must hold at least `FP_PARAM_COUNT` registers.
-# ---
-# out: caller-owned buffer of at least FP_PARAM_COUNT registers
-# ret: the number of registers written (FP_PARAM_COUNT)
-pub fun fp_param_regs(out: *isa.Register) i32 {
-    var i: i32 = 0;
-    for (i < FP_PARAM_COUNT) {
-        out[i].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, i);
-        out[i].size = 16;
-        i = i + 1;
-    }
-    ret FP_PARAM_COUNT;
-}
-
 # fill the callee-saved register bank a win64 function must preserve
 #
 # writes the integer set (RBX, RBP, RDI, RSI, RSP, R12-R15, each 8 bytes wide)
@@ -431,7 +414,7 @@ var win64_vtable: abi.AbiVTable;
 # build and install the win64 AbiVTable
 #
 # sets the convention name ("win64"), wires the type-erased classify/arg/ret
-# operation pointers and the gp_arg_regs / fp_arg_regs / callee_saved register-file
+# operation pointers and the gp_arg_regs / callee_saved register-file
 # accessors, the stack alignment (16), red-zone size (0), shadow space (32), the
 # variadic model, and the sret-pointer register (RCX, in the argument file), then
 # installs it into `reg` under `abi.ABI_WIN64`. idempotent: the registry entry is
@@ -448,7 +431,6 @@ pub fun register_win64(reg: *abi.AbiRegistry) R.Result[bool, str] {
     win64_vtable.arg_passing  = classify_arg::*u8;
     win64_vtable.ret_passing  = classify_return::*u8;
     win64_vtable.gp_arg_regs  = gp_param_regs::*u8;
-    win64_vtable.fp_arg_regs  = fp_param_regs::*u8;
     win64_vtable.callee_saved = callee_saved::*u8;
     win64_vtable.stack_align  = STACK_ALIGN;
     win64_vtable.red_zone     = RED_ZONE;
@@ -667,8 +649,8 @@ test "mach.lang.target.abi.win64.va_model:home" {
     ret 0;
 }
 
-# the register files report the win64 banks: RCX/RDX/R8/R9, XMM0-XMM3, and the
-# callee-saved integer set (RBX..R15) followed by the vector set (XMM6-XMM15)
+# the register files report the win64 banks: RCX/RDX/R8/R9 and the callee-saved
+# integer set (RBX..R15) followed by the vector set (XMM6-XMM15)
 test "mach.lang.target.abi.win64:register_files" {
     var gp: [4]isa.Register;
     if (gp_param_regs(?gp[0]) != GP_PARAM_COUNT) { ret 1; }
@@ -676,11 +658,6 @@ test "mach.lang.target.abi.win64:register_files" {
     if (gp[1].id != REG_RDX)                     { ret 1; }
     if (gp[2].id != REG_R8)                      { ret 1; }
     if (gp[3].id != REG_R9)                      { ret 1; }
-
-    var fp: [4]isa.Register;
-    if (fp_param_regs(?fp[0]) != FP_PARAM_COUNT)             { ret 1; }
-    if (fp[0].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
-    if (fp[3].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
 
     var cs: [19]isa.Register;
     if (callee_saved(?cs[0]) != CALLEE_SAVED_COUNT)                                 { ret 1; }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -9,13 +9,16 @@
 # abstract `RK_*` kinds; each format maps those to its own machine relocation
 # types internally with a plain integer compare.
 
+use std.allocator.page;
 use std.system.panic.panic;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_contains;
 use std.types.string.str_equals;
+use std.types.string.str_join;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -791,7 +794,9 @@ pub val DBG_CODEVIEW: u32 = 2;  # codeview (coff/pe)
 # name:    model name ("dwarf", "codeview"); an immutable str constant
 # produce: erased fn ptr - writes a module's debug sections into the object image
 #          (cast back to the be-layer producer's `ProduceFn`); nil until the
-#          be-layer registrar wires it
+#          be-layer registrar wires it, and still nil past bring-up only in a
+#          registry composed without the back end (`debug_hooks_complete` refuses a
+#          fully composed one that leaves it so)
 pub rec DebugVTable {
     id:      u32;
     name:    str;
@@ -886,6 +891,57 @@ pub fun debug_register_identities(reg: *DebugRegistry) {
     dwarf_identity.name    = "dwarf";
     dwarf_identity.produce = nil;
     debug_register(reg, ?dwarf_identity);
+}
+
+# the message a registered-but-unwired debug model is refused with, naming it
+#
+# Page-allocated through `str_join`, the same shape `target.unregistered_message`
+# uses for the tuple diagnostics. The generic fallback is taken only when the page
+# allocator or the join itself fails; the refusal still fires, it just cannot name
+# the model.
+# ---
+# name: the registered model name whose producer is missing
+# ret:  the refusal message
+fun unwired_debug_message(name: str) str {
+    var alloc: A.Allocator;
+    val fb: str = "a registered debug-info model carries no producer hook";
+    if (O.is_some[str](page.make(?alloc))) { ret fb; }
+    val r: R.Result[str, str] = str_join(?alloc, "debug model '", name, "' is registered but no producer wired its hooks (its be-layer registrar is missing from driver.setup_registry)");
+    if (R.is_err[str, str](r)) { ret fb; }
+    ret R.unwrap_ok[str, str](r);
+}
+
+# refuse a debug registry holding an identity that no producer ever wired
+#
+# The identity/producer split is real and load-bearing: the target layer must be
+# able to register a model's name without the back end present (`mach info`,
+# `mach doc` and `mach init` compose registries from `target.register_all` alone,
+# and a format naming an unregistered model must fail `select_of` loudly there
+# too), while the producer itself can only be named from `be`. That is the same
+# import direction that erases `produce` to `*u8`, so a required constructor
+# parameter - the shape #2244 gave the relocation seam - is not available here.
+#
+# The split is also what lets the wiring MISS. The identity list and the be-layer
+# registrars are hardcoded in two files in two layers, joined only by the order
+# `driver.setup_registry` calls them; adding a model to one without the other
+# registers cleanly, resolves cleanly through `select_of`, and surfaces only when a
+# `-g` build of a target whose format names that model reaches codegen - which
+# refuses at dispatch, but names neither the model nor the missing registrar
+# (#2295). This is the invariant that split cannot express, checked at the one
+# point where both halves are present: a fully composed registry either has every
+# identity wired or refuses to come up, naming the model.
+# ---
+# reg: the debug registry, after every be-layer registrar has run
+# ret: ok(true) when every registered identity carries a producer, or the first gap
+pub fun debug_hooks_complete(reg: *DebugRegistry) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < reg.count) {
+        if (reg.entries[i].produce == nil) {
+            ret R.err[bool, str](unwired_debug_message(reg.entries[i].name));
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
 }
 
 # the debug-info vtable at enumeration index `idx` (0-based, in registration order)
@@ -1025,5 +1081,38 @@ test "mach.lang.target.of.debug_register:install_lookup_dispatch" {
 
     # an unregistered model name resolves to none.
     if (O.is_some[*DebugVTable](debug_lookup(?reg, "codeview"))) { ret 1; }
+    ret 0;
+}
+
+# the completeness check refuses exactly the state the identity/producer split can
+# leave behind: an identity registered by the target layer that no be-layer
+# registrar wired. an empty registry and a fully wired one both pass, so the check
+# fires on the gap rather than on composition order
+test "mach.lang.target.of.debug_hooks_complete:refuses_unwired_identity" {
+    var empty: DebugRegistry = debug_registry_init();
+    if (R.is_err[bool, str](debug_hooks_complete(?empty))) { ret 1; }
+
+    # what `debug_register_identities` leaves behind before the be layer runs.
+    var reg: DebugRegistry = debug_registry_init();
+    debug_register_identities(?reg);
+    if (debug_registered_count(?reg) == 0) { ret 1; }
+    val unwired: R.Result[bool, str] = debug_hooks_complete(?reg);
+    if (!R.is_err[bool, str](unwired)) { ret 1; }
+    # the refusal names the model, so the missing registrar is identifiable.
+    if (!str_contains(R.unwrap_err[bool, str](unwired), "dwarf")) { ret 1; }
+
+    # wiring the producer, as the be-layer registrar does, satisfies it.
+    val opt: O.Option[*DebugVTable] = debug_lookup(?reg, "dwarf");
+    if (!O.is_some[*DebugVTable](opt)) { ret 1; }
+    O.unwrap[*DebugVTable](opt).produce = t_debug_produce::*u8;
+    if (R.is_err[bool, str](debug_hooks_complete(?reg))) { ret 1; }
+
+    # one unwired entry among wired ones is still refused, and named.
+    var extra: DebugVTable;
+    extra.id = DBG_CODEVIEW; extra.name = "codeview"; extra.produce = nil;
+    debug_register(?reg, ?extra);
+    val mixed: R.Result[bool, str] = debug_hooks_complete(?reg);
+    if (!R.is_err[bool, str](mixed))                            { ret 1; }
+    if (!str_contains(R.unwrap_err[bool, str](mixed), "codeview")) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Closes #2341
Closes #2295

Two ends of one shape: a vtable slot whose consumer is missing.

---

## #2341 - `AbiVTable.fp_arg_regs`: leftover, or unfinished?

**Neither. It never had a reader, in either compiler.**

| commit | date | what |
| --- | --- | --- |
| `5f882a32` | 2025-11-24 | C bootstrap declares `sysv64_get_fp_arg_regs` in `mir/abi/sysv64.h` |
| `602d69ad` | 2025-11-24 | defines it in `mir/abi/sysv64.c` - no caller |
| `1cb7a70e` | 2025-12-01 | "Remove unused MIR components" deletes it, still uncalled |
| `06cb9b84` | 2026-05-31 | the self-hosted rebuild reintroduces it as an `AbiVTable` slot |

`git grep get_fp_arg_regs` at every commit the pickaxe reports returns exactly the
declaration and the definition, never a call. `git grep fp_arg_regs <commit> -- src/`
outside `target/abi/` is empty at every self-hosted commit that touches it. So it is not a
slot whose consumer was removed - it is one **mirrored from `gp_arg_regs` by symmetry at
birth**, the `ProjectConfig.vectorize` shape from #2277, and it survived the one commit
that was explicitly deleting unused MIR components.

There is no consumer to grow either. `arg_passing` / `ret_passing` hand back a concrete
register or stack slot per value, so lowering never enumerates an FP bank. `gp_arg_regs`
survives only because the win64 variadic tail-float duplication must name the GP register
at an FP argument's index (#2273) - a need with no FP twin.

Removed: the field, the six vtable writes, the four orphaned `fp_param_regs` accessors,
the mos6502 zero stub, and the three self-test assertions that only exercised them. The
record now states why no FP twin exists, so the next convention does not add one back by
symmetry.

## #2295 - `dwarf.register_debug_hooks`: can after-the-fact wiring miss?

**Yes - and it was demonstrated, not argued.** Neutering the registrar and building a
compiler:

- registration: silent
- `mach info targets`: clean, every target listed
- plain build: succeeds, correct output
- `-g` build: `error: codegen: debug producer registered no produce hook`

So it is not silent the way the reloc seam was - there is a purpose-built guard at
dispatch - but it is **late and anonymous**: `-g` only, at codegen, naming neither the
model nor the missing registrar. The identity list (target layer) and the be-layer
registrars are hardcoded in two files in two layers, joined only by the order
`driver.setup_registry` calls them.

**The #2244 treatment does not transfer.** That seam worked because `isa.machine_isa` is
one constructor every arch calls and an arch can name its own packer. Here the identity
must be registrable *without* the back end - `mach info`, `mach doc` and `mach init`
compose registries from `target.register_all` alone, and a format naming an unregistered
model has to fail `select_of` loudly there too - while the producer can only be named from
`be`. That is the same import direction that erases `produce` to `*u8`. Threading it as a
required parameter would push a be-layer pointer through the target layer's generic
bring-up and make ~40 call sites write `nil` meaning "no back end here" rather than "no
producer exists", institutionalizing the ambiguity rather than removing it.

**So the pairing is enforced at the join**, the one point where both halves are in scope:
`of.debug_hooks_complete` walks the registry after the registrars run, and
`setup_registry` refuses any registry holding an unwired identity, naming the model. Doc
comments that #2282 left describing this as the unguarded survivor now say what guards it.

**Stub-target demonstration.** A second identity (`"codeview"`) added to
`debug_register_identities` with no registrar, then removed:

```
error: debug model 'codeview' is registered but no producer wired its hooks
       (its be-layer registrar is missing from driver.setup_registry)
```

fired on *every* build, `-g` or not, at bring-up - against pre-fix behaviour where the
same gap was invisible until a `-g` codegen.

## Verification

**Objects byte-identical** - `2580` artifacts, **6 declared targets x 2 profiles**
(`linux-x86_64`, `linux-arm64`, `linux-riscv64`, `windows-x86_64`, `darwin-x86_64`,
`darwin-aarch64`; release + debug), built from one fixed source tree by the pre-change
compiler and by the post-change compiler. `sha256sum` sets equal. Covers sysv64 / aapcs64
/ lp64 / win64 and elf / coff / macho. The fixed tree is `dev` at `5f31576`; the eight
commits `dev` has taken since touch only `.github/`, `dist/`, `doc/` and `int/`, no
`src/`, so the measurement still stands against current `dev` (the compiler binary is
bit-identical before and after merging it).

**Suites** - `948 -> 950`, `0 failed`. The delta is exactly the two tests added; no test
was removed, only assertions on the deleted accessors.

**Mutation tests**

| mutation | result |
| --- | --- |
| `setup_registry` drops the `debug_hooks_complete` call | **949 / 1** (`driver:setup_registry_refuses_an_unwired_debug_identity`) |
| `debug_hooks_complete` never reports a gap | **948 / 2** (that test + `of.debug_hooks_complete:refuses_unwired_identity`) |

The first mutation initially survived, against a state-asserting test; the test was
rewritten to plant an unwired identity and drive `setup_registry` through it.

**int, three linkable ISAs** - `linux` and `linux-riscv64` green as configured;
`linux-arm64` green with its leg switched to `qemu` run-mode locally only (this host is
x86_64 - `int/targets.conf` is unmodified in the branch, and `run.sh` is explicit that the
aarch64 leg must stay `native` in CI).

**mach-std** - `611 passed, 0 failed` at pin `eff1e8e`, materialized with
`git archive eff1e8e | tar -x` rather than a clone.

**Fixpoint** - `gen2 == gen3` (`680ad94f...`). `gen1 != gen2` is the pre-existing
seed-vs-HEAD divergence: unmodified `dev` reproduces the same shape (`dgen1 != dgen2`,
`dgen2 == dgen3`) from the same seed.

## Sweep - the rest of the class

Fourteen more write-only fields and one dead record across `AbiVTable`'s peers, reported
rather than fixed. See the PR thread.