### PR TITLE
docs: correct the darwin and int-leg claims the x86_64 restore made stale

### DIFF
--- a/.github/workflows/darwin-lane.yml
+++ b/.github/workflows/darwin-lane.yml
@@ -6,10 +6,12 @@ on:
 permissions:
   contents: read
 
-# darwin has no prior release to self-seed from, so seed cross-builds the stage-0
-# seed on linux first; collapse that bootstrap once a darwin archive ships. build
-# then runs each darwin target on a native macOS host: it execs the cross-built
-# seed, self-hosts to a b == c fixpoint, and runs the suite.
+# the darwin lanes do not self-seed from a prior release: seed cross-builds the
+# stage-0 seed on linux first. an aarch64-darwin archive does ship now, so that row
+# could collapse to a `fetch released mach` like the linux/windows lanes;
+# x86_64-darwin cannot until its first archive lands. build then runs each darwin
+# target on a native macOS host: it execs the cross-built seed, self-hosts to a
+# b == c fixpoint, and runs the suite.
 #
 # a reusable workflow, not a copy: cd.yml calls it for tag pushes and
 # workflow_dispatch, ci.yml calls it as the dev -> main release gate. one lane

--- a/.github/workflows/int-main.yml
+++ b/.github/workflows/int-main.yml
@@ -5,7 +5,9 @@ name: int main
 # compiler for each darwin target has to be cross-built on linux first. running at
 # the release-integration gate catches a darwin codegen regression there while
 # paying the macOS cost only then. the leg set is still data-driven from
-# int/targets.conf (the main-cadence rows), so adding a darwin target is one row.
+# int/targets.conf (the main-cadence rows), so adding a darwin target needs no edit
+# here — but it is not free: every case manifest must declare the target too, and a
+# manifest that omits it only fails at that leg's cadence (#2353).
 
 on:
   push:

--- a/int/targets.conf
+++ b/int/targets.conf
@@ -2,7 +2,9 @@
 #
 # every executable target is one row; both the harness (run-mode lookup) and CI
 # (matrix generation, via lib/ci-matrix.sh) read this file. adding a target is one
-# row here and touches no workflow.
+# row here and touches no workflow — but every int/*/mach.toml the new leg runs
+# must also declare a [target.<name>] block, and a manifest that omits one fails
+# only when that leg's cadence comes around, not on the PR that added it (#2353).
 #
 # columns (whitespace-separated):
 #   name      the `mach --target` name, also the harness/CI leg identifier

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -101,8 +101,8 @@ fun ut_entry_symbol() str {
 # default to the host-matching target: linux (x86_64-linux), windows (x86_64-windows),
 # linux-arm64 (aarch64-linux), linux-riscv64 (riscv64-linux), darwin-x86_64
 # (x86_64-darwin), or darwin-arm64 (aarch64-darwin) in CI. a target is declared for every
-# host the corpus runs on - both darwin targets so a macos-13 (x86_64) or macos-14 (arm64)
-# host matches, and linux-riscv64 so a riscv64 host matches (#1753) - otherwise
+# host the corpus runs on - both darwin targets so a macos-15-intel (x86_64) or macos-15
+# (arm64) host matches, and linux-riscv64 so a riscv64 host matches (#1753) - otherwise
 # `resolve_native` falls back to the first target (linux) and the host-tie assertions in
 # union_ctx_restored_to_default_tuple read the wrong default for that host (#1724)
 fun ut_manifest() str {


### PR DESCRIPTION
The doc-side sweep asked for alongside #2360 — that PR merged before this landed on the branch, so it is one more PR rather than the same one. This is the whole remainder; nothing else doc-side is outstanding from #2327.

Four stale claims, each one directly falsified by restoring x86_64-darwin:

- **`darwin-lane.yml` header** said darwin has no prior release to self-seed from and told the reader to collapse the linux cross-build bootstrap "once a darwin archive ships". An `aarch64-darwin` archive has shipped since 3.x (`mach-4.2.2-aarch64-darwin.tar.gz` is in the current release), so the condition reads as unmet when it is met and simply not acted on. Now states which row could collapse and which cannot: `x86_64-darwin` has no archive until its first release lands. **Whether to actually collapse the aarch64 row to a `fetch released mach` is a design call, not a doc fix — flagged, not taken.**
- **`int/targets.conf`** said adding a target is "one row here and touches no workflow". True of the workflow, false of the ~50 case manifests — the exact gap now filed as #2353. The header says so, and points at the issue.
- **`int-main.yml`** carried the same "one row" claim; corrected the same way.
- **`src/lang/driver/tests.mach`** named `macos-13` and `macos-14` as the darwin CI hosts. They are `macos-15-intel` and `macos-15`.

Comments and documentation only; no behaviour change. Both workflow files still parse and `ci-matrix.sh` emits both cadences unchanged.