### PR TITLE
fix(asm): one `{name}` effect model across the three targets

### DIFF
--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -4401,8 +4401,6 @@ fun a64_emit_branch(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, i
 fun a64_emit_ldst(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) R.Result[bool, str] {
     val rt: *iasm.Operand = ?item.ops[0];
     val mem: *iasm.Operand = ?item.ops[1];
-    if (mem.kind != iasm.AOP_MEM) { ret R.err[bool, str]("internal compiler error: inline-asm statement reached the encoder unresolved"); }
-
     val is_load: bool = item.code == A64M_LDR || item.code == A64M_LDRB || item.code == A64M_LDRH;
     var w: u8 = 4;
     if (a64_is64(rt))                                          { w = 8; }

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -47,6 +47,16 @@
 # Precision is earned per mnemonic, on that mnemonic's own table row, and never
 # credited by category - `opaque-and-slow` is safe, `modeled-and-wrong` is a
 # miscompile.
+#
+# A `{name}` binding is the one operand every grammar reads the same way, so it is
+# stated here rather than three times (#2258): it denotes a frame slot, a frame slot
+# is memory, and memory is not a register - so it contributes nothing to the write
+# set and the statement around it is modeled whether or not the frame is laid out
+# yet. That is what makes the effect model a property of the parsed instruction
+# stream rather than of the parse phase: the same body folds to the same set before
+# register allocation and at emit time. The emitter never sees an unresolved binding,
+# because it always parses with a binding context, and the driver CHECKS that rather
+# than assuming it.
 
 use std.text.parse;
 use std.types.bool.bool;
@@ -189,14 +199,12 @@ pub rec Mnemonic {
 }
 
 # the parse outcomes one statement can have
+#
+# There is no "parsed but unmodeled" outcome: a statement the grammar accepts is one
+# the effect model describes, and one it does not accept refuses the block.
 pub val AI_INST:   u8 = 0;  # a modeled machine instruction
 pub val AI_LABEL:  u8 = 1;  # a numeric local-label definition
 pub val AI_BYTES:  u8 = 2;  # a raw byte directive's payload
-# a statement whose mnemonic is known but whose operands are not resolvable - a
-# `{name}` binding parsed before the frame is laid out, on a target whose effect
-# model does not attempt to model one. the instruction is not modeled, so its
-# effects fall back to everything the target's inline grammar can reach
-pub val AI_OPAQUE: u8 = 3;
 
 # what a parsed instruction still needs the encoder to resolve
 pub val AR_NONE:  u8 = 0;  # nothing: the instruction is self-contained
@@ -865,9 +873,10 @@ fun unknown_message(c: *Cursor, lo: usize, hi: usize) str {
 # target's - `[rbp + off]`, `off(s0)`, `[x29, #off]` - so the ISA's lexer calls this
 # and builds its own memory operand.
 #
-# Returns none when the parse carries no binding context: before the frame is laid
-# out a binding's displacement genuinely is unknown, and the ISA decides whether its
-# effect model can still describe the statement.
+# Returns ok(false) when the parse carries no binding context: before the frame is
+# laid out a binding's displacement genuinely is unknown. The operand stays a binding
+# and the statement is still modeled - what the displacement turns out to be cannot
+# change which registers the statement writes, since a slot is memory either way.
 # ---
 # c:   the cursor
 # lo:  body offset of the `{`
@@ -912,10 +921,13 @@ fun bind_name_eq(interner: *intern.Interner, name: intern.StrId, body: str, star
 
 # the registers one parsed item writes, folded into the running masks
 #
-# The whole effect model. A modeled instruction writes exactly the registers its
-# mnemonic's facts name; an item the parser could not model writes worst-case. An
-# unreadable byte stream reaches every bank, while an unresolved statement is bounded
-# by the general-purpose bank - no target's inline grammar names a vector register.
+# The whole effect model, and the same one on every target. An instruction writes
+# exactly the registers its mnemonic's facts name among its own operands, plus the
+# ones its form writes regardless. A raw byte payload is not an instruction the
+# parser read at all, so it reaches every register in every bank.
+#
+# A `{name}` binding names a frame slot, never a register, so a statement carrying
+# one folds to the same set resolved or unresolved (#2258).
 # ---
 # g:    the target's grammar
 # item: the parsed statement
@@ -926,10 +938,6 @@ pub fun fold_clobbers(g: *Grammar, item: *Item, gp: *u32, fp: *u32) {
     if (item.kind == AI_BYTES) {
         @gp = @gp | g.all_gp;
         @fp = @fp | g.all_fp;
-        ret;
-    }
-    if (item.kind == AI_OPAQUE) {
-        @gp = @gp | g.all_gp;
         ret;
     }
     @gp = @gp | item.implicit;
@@ -1315,12 +1323,26 @@ fun emit_one(st: *encode.EncodeState, g: *Grammar, c: *Cursor, l: *Labels, item:
         }
         ret R.ok[bool, str](true);
     }
-    # the emitter always parses with a binding context, so every `{name}` either
-    # resolved or failed the parse; an unresolved statement here is a parser bug.
-    if (item.kind == AI_OPAQUE) {
-        ret R.err[bool, str]("internal compiler error: inline-asm statement reached the encoder unresolved");
+    # the emitter always parses with a binding context, so every `{name}` resolved to
+    # its frame slot or failed the parse. checking it here, over every operand of
+    # every statement, is what lets each grammar read a binding as the memory operand
+    # it is without three emitters re-deriving the same refusal - and it covers every
+    # operand position, including the ones whose emitter reads a register field
+    # directly and would otherwise encode a base the binding never named (#2258).
+    var i: u32 = 0;
+    for (i < item.nops) {
+        if (item.ops[i::usize].kind == AOP_BIND) { ret R.err[bool, str](unresolved_message(c, item)); }
+        i = i + 1;
     }
     ret g.emit(st, c, l, item);
+}
+
+# the diagnostic for a statement whose `{name}` never resolved to a frame slot
+fun unresolved_message(c: *Cursor, item: *Item) str {
+    ret span_message(c,
+        "internal compiler error: inline-asm statement '", item.src_off, item.src_off + item.src_len,
+        "' reached the encoder with an unresolved '{name}'",
+        "internal compiler error: an inline-asm statement reached the encoder with an unresolved '{name}'");
 }
 
 # check an emitted instruction against the word count its mnemonic declares and the

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -3980,7 +3980,6 @@ fun rv_emit(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *ia
     }
     if (pat == RVP_LOAD || pat == RVP_STORE) {
         val mem: *iasm.Operand = ?item.ops[1];
-        if (mem.kind != iasm.AOP_MEM) { ret R.err[bool, str]("internal compiler error: inline-asm statement reached the encoder unresolved"); }
         if (mem.imm < -2048 || mem.imm > 2047) { ret R.err[bool, str]("encode: inline-asm load/store offset is out of the 12-bit signed range"); }
         if (pat == RVP_LOAD) {
             emit_i(st, opcode, f3, rv_reg(?item.ops[0]), mem.reg::u32, mem.imm::u32 & 0xFFF);
@@ -5310,6 +5309,22 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_atomics" {
     val ur: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "amobogus.q a0, a2, (a1)");
     if (!R.is_err[bool, str](ur)) { bad = 1; }
     or { if (!str_contains(R.unwrap_err[bool, str](ur), "unknown riscv64 inline-asm instruction")) { bad = 1; } }
+
+    # an atomic address is a memory position, so the parse accepts an unresolved
+    # `{name}` there - and the shared driver refuses it before the encoder reads a
+    # base register the binding never named. this arm carried no such check of its
+    # own, so the binding used to reach `emit_r` as a negative register index and
+    # encode a different instruction (#2258).
+    val settled: usize = st.buf.len;
+    val br: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "amoadd.d.aqrl a0, a2, {slot}");
+    if (!R.is_err[bool, str](br)) { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](br), "unresolved '{name}'")) { bad = 1; } }
+    if (!R.is_err[bool, str](rv_asm_text(?st, ?f, ?labels, "lr.d a0, {slot}")))  { bad = 1; }
+    # the load / store arm reaches the same one check.
+    if (!R.is_err[bool, str](rv_asm_text(?st, ?f, ?labels, "ld a0, {slot}")))    { bad = 1; }
+    if (!R.is_err[bool, str](rv_asm_text(?st, ?f, ?labels, "sd a0, {slot}")))    { bad = 1; }
+    # the refusal precedes the encoder, so none of the four emitted a word.
+    if (st.buf.len != settled) { bad = 1; }
 
     iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -5000,8 +5000,8 @@ val X64_MNEMONICS: [X64_MNEMONIC_COUNT]iasm.Mnemonic = [X64_MNEMONIC_COUNT]iasm.
 # map a register name to its (id, size), or false when the token names no register
 #
 # Covers the 64/32/16/8-bit general-purpose register names the x86-64 inline-asm
-# grammar accepts. It names no vector register, which is why an unresolved statement's
-# effects stay bounded by the general-purpose bank.
+# grammar accepts. It names no vector register, so only a body the parser cannot read
+# at all reaches the vector bank.
 fun x64_reg(name: str, op: *iasm.Operand) bool {
     # 64-bit
     if (str_equals(name, "rax")) { @op = iasm.op_reg(x64.RAX, 8); ret true; }
@@ -5074,8 +5074,10 @@ fun x64_operand(c: *iasm.Cursor, lo: usize, hi: usize, role: str, op: *iasm.Oper
     @op = iasm.op_none();
     if (hi <= lo) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
 
-    # a `{name}` local binding: resolved against the laid-out frame when there is one,
-    # else left unresolved for the caller to treat as opaque.
+    # a `{name}` local: with a laid-out frame it becomes the `[rbp + off]` stack slot
+    # it denotes; without one the displacement is genuinely unknown, and the operand
+    # stays a binding - it names a stack slot either way, so it can never be a
+    # register and the effect model reads it exactly as it reads memory.
     if (c.body[lo] == '{'::char) {
         var off: i64 = 0;
         val br: R.Result[bool, str] = iasm.bind_offset(c, lo, hi, ?off);
@@ -5238,9 +5240,8 @@ fun x64_bind_base_message(c: *iasm.Cursor, role: str) str {
 #
 # The operation width comes from whichever side is a register (a memory or immediate
 # operand inherits it); a `[symbol]` on either side becomes the instruction's pending
-# relocation. A statement carrying an unresolved `{name}` is not modeled: before the
-# frame is laid out its displacement genuinely is unknown, and the effect model falls
-# back to the general-purpose bank rather than describing a half-known instruction.
+# relocation. An unresolved `{name}` is a memory operand whose displacement is not
+# known yet, so the statement is modeled exactly as it is once the frame is laid out.
 fun x64_parse(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, str] {
     val pat: u16 = x64_pattern(s.m.flags);
     val n: u32 = s.nargs;
@@ -5270,7 +5271,6 @@ fun x64_parse(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, s
         if (op.kind == iasm.AOP_SYM || (op.kind == iasm.AOP_MEM && (op.flags & iasm.AOF_MEM_SYM) != 0)) {
             ret R.err[bool, str]("encode: inline-asm one-operand symbol form unsupported");
         }
-        if (op.kind == iasm.AOP_BIND) { item.kind = iasm.AI_OPAQUE; ret R.ok[bool, str](true); }
         ret R.ok[bool, str](true);
     }
 
@@ -5281,10 +5281,6 @@ fun x64_parse(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, s
     }
     if (item.ops[0].kind == iasm.AOP_SYM || item.ops[1].kind == iasm.AOP_SYM) {
         ret R.err[bool, str]("encode: inline-asm bare-symbol operand unsupported (use [symbol])");
-    }
-    if (item.ops[0].kind == iasm.AOP_BIND || item.ops[1].kind == iasm.AOP_BIND) {
-        item.kind = iasm.AI_OPAQUE;
-        ret R.ok[bool, str](true);
     }
     if ((item.ops[0].flags & iasm.AOF_MEM_SYM) != 0) {
         item.ref     = iasm.AR_SYM;
@@ -5653,12 +5649,24 @@ test "mach.lang.target.isa.x64.encode.asm_clobbers:derived_from_parse" {
     asm_clobbers("cmpxchg rbx, rdx", ?gp, ?fp);
     if (gp != ((1::u32 << x64.RBX::u32) | (1::u32 << x64.RAX::u32))) { bad = 1; }
 
-    # a `{name}` binding has no known stack displacement before the frame is laid
-    # out, so the instruction is not modeled: worst case within the bank the
-    # grammar can reach, which names no vector register.
+    # a `{name}` binding is a stack slot, so it names no register; the destination
+    # register beside it is still credited even before the frame is laid out, and a
+    # binding IN the destination position writes memory rather than a register
+    # (#2258).
     asm_clobbers("mov rax, {v}", ?gp, ?fp);
-    if (gp != X64_ALL_GP) { bad = 1; }
-    if (fp != 0)          { bad = 1; }
+    if (gp != (1::u32 << x64.RAX::u32)) { bad = 1; }
+    if (fp != 0)                        { bad = 1; }
+    asm_clobbers("mov {result}, rax", ?gp, ?fp);
+    if (gp != 0) { bad = 1; }
+    # both halves of a read-modify-write through a binding: the register half is
+    # written, the memory half is not a register.
+    asm_clobbers("lock xadd {slot}, rax", ?gp, ?fp);
+    if (gp != (1::u32 << x64.RAX::u32)) { bad = 1; }
+
+    # the load-bearing consumer: `std.sync.atomic.load`'s seq-cst body names RCX and
+    # RAX and nothing else - callee-saved registers stay allocatable across it.
+    asm_clobbers("mov rcx, {ptr}\nmov rax, [rcx]\nmov {result}, rax", ?gp, ?fp);
+    if (gp != ((1::u32 << x64.RAX::u32) | (1::u32 << x64.RCX::u32))) { bad = 1; }
 
     # raw bytes and an instruction nobody described are unreadable: every bank.
     asm_clobbers(".byte 0x90", ?gp, ?fp);
@@ -5692,6 +5700,45 @@ test "mach.lang.target.isa.x64.encode.asm_claim:refuses_unclaimed_byte" {
     if (R.is_err[bool, str](iasm.claim(?q, 4, 3)))  { bad = 1; }
     # a claim overlapping an earlier one is refused too.
     if (!R.is_err[bool, str](iasm.claim(?q, 5, 2))) { bad = 1; }
+    ret bad;
+}
+
+# an unresolved `{name}` never reaches the encoder
+#
+# The block driver always parses with a binding context, so a binding either resolved
+# to its frame slot or failed the parse. The shared driver CHECKS that over every
+# operand of every statement rather than trusting it, which is what lets each grammar
+# read a binding as the memory operand it is instead of refusing the statement early
+# (#2258). The assembly-text entry point supplies no bindings, so it is the one path
+# that reaches the check; without it a binding would encode as a whole-instruction
+# operand nobody filled in.
+test "mach.lang.target.isa.x64.encode:asm_unresolved_binding_refused_at_emit" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var st: enc.EncodeState;
+    st.alloc    = ?alloc;
+    st.buf      = enc.buf_init(?alloc);
+    st.interner = nil;
+    st.fixups   = nil; st.fixup_count = 0; st.fixup_cap = 0;
+
+    var bad: i32 = 0;
+    var f: mir.MirFunction;
+    var l: iasm.Labels;
+    iasm.labels_init(?l, ?alloc);
+
+    # a binding as the source, as the destination, and as a one-operand form's only
+    # operand - every position the check has to cover.
+    val src: R.Result[bool, str] = x64_asm_text(?st, ?f, ?l, "mov rax, {v}");
+    if (!R.is_err[bool, str](src)) { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](src), "unresolved '{name}'")) { bad = 1; } }
+    if (!R.is_err[bool, str](x64_asm_text(?st, ?f, ?l, "mov {v}, rax"))) { bad = 1; }
+    if (!R.is_err[bool, str](x64_asm_text(?st, ?f, ?l, "neg {v}")))      { bad = 1; }
+
+    # the refusal precedes the encoder, so no bytes were written for any of them.
+    if (st.buf.len != 0) { bad = 1; }
+
+    iasm.labels_dnit(?l);
+    enc.buf_dnit(?st.buf);
     ret bad;
 }
 


### PR DESCRIPTION
Closes #2258.

## What diverged

The three grammars gave three answers to one question. For an **unresolved** `{name}` — parsed pre-frame, where the displacement genuinely is unknown:

| | operand kind | statement | effect | emit-side guard |
|---|---|---|---|---|
| riscv64 | `AOP_BIND`, accepted where an address is (`rv_is_addr`) | `AI_INST` | modelled | `rv_emit` RVP_LOAD/STORE only |
| aarch64 | `AOP_BIND`, accepted where an address is (`a64_is_addr`) | `AI_INST` | modelled | `a64_emit_ldst` only |
| x86-64 | `AOP_BIND` anywhere | `AI_OPAQUE` | **all 16 GP** | the spine's `AI_OPAQUE` refusal |

The root cause, once written down: x86-64's model was a function of the **parse phase**, not of the instruction stream. Parse the same body *with* a laid-out frame and x86-64 already derived the narrow set — the binding became `[rbp + off]`, and `mark_written` credits a memory destination with nothing. `clobbers`' own doc says the set "is a property of the parsed instruction stream rather than a second reading of it"; on x86-64 that was false.

## The one model

A `{name}` denotes a frame slot. A frame slot is memory. Memory is not a register. So a binding contributes nothing to the write set on any target, and the statement around it folds to the same set resolved or unresolved. That sentence now lives once, in `asm.mach`'s header, and `AI_OPAQUE` — whose sole producer was x86-64's escape — is gone.

The emit-side half was spelled three times as well (the spine's `AI_OPAQUE` refusal plus two per-target `mem.kind != AOP_MEM` checks, all three with the same message). It is now **one scan over every operand of every statement** in the shared driver.

## Finding: riscv64's guard had a hole

`rv_amo_addr` → `rv_is_addr` accepts a binding as an AMO address, and `rv_emit`'s `RVP_AMO` / `RVP_AMO_LR` arms re-checked nothing — they read `item.ops[N].reg::u32` directly. `AOP_BIND` carries `reg = -1`, so `amoadd.d.aqrl a0, a2, {slot}` reached `emit_r` with a negative register index and encoded a **different instruction**. aarch64 had no such hole (`a64_bare_addr` refuses a binding at parse); x86-64 had none (`AI_OPAQUE` caught it). The shared scan closes it by construction, and `riscv64.encode:inline_asm_atomics` now pins it.

Not reachable from `encode_block` (which always supplies bindings), but reachable from `rv_asm_text` — the encoder-test entry point, which passes `pl = nil` on all three targets.

## Conservative by default: unchanged

An unrecognized mnemonic still refuses the block. A `.byte` payload still writes every register in every bank. A body the parser cannot read still folds to `all_gp | all_fp`. What went away is one *category* judgement ("a statement I can't fully resolve is opaque") replaced by a *per-operand fact* ("this operand is memory").

## Shadow-module equivalence — 0 wider

Two instrumented compilers (the old derivation and the new), dumping `(isa, body, gp, fp)` for every `asm.clobbers` call, over **mach + mach-std + `int/`**, all six targets, both profiles:

```
distinct (isa, body) derivations: 109   total calls: 15570
  identical: 77   narrower: 32   WIDER: 0
unchanged by isa:  aarch64 40/40   riscv64 27/27   x86_64 10
```

Every one of the 32 narrowings is x86-64 and every one carries a `{name}`. Nothing anywhere got wider.

## Measured

**Objects.** riscv64 and aarch64 **byte-identical** across the whole corpus, *both* profiles (0/428 objects differ per target/profile). x86-64 moved in exactly 5 artifacts — the four modules holding an x86-64 `asm` block with a `{name}`, plus the linked binary:

| object (release) | `.text` | |
|---|---|---|
| `std/sync/atomic.o` | 1883 → 1578 | −305 |
| `std/system/os/linux/shared.o` | 15263 → 14753 | −510 |
| `std/system/os/linux/x86_64.o` | 570 → 453 | −117 |
| `std/system/panic.o` | 151 → 111 | −40 |
| **total** | | **−972** |
| `bin/mach` exec segment | 0xa3c5ae → 0xa3c1ee | −960 |

Per function, only the functions that *contain* inline asm moved. Every other function in those objects is byte-identical; nothing else in 1284 objects moved at all.

**The case where the old model was needlessly conservative** — `std.sync.atomic.load`, x86-64 release, 97 → 53 bytes:

```asm
;; before                              ;; after
push  %rbp                             push  %rbp
mov   %rsp,%rbp                        mov   %rsp,%rbp
sub   $0x60,%rsp                       sub   $0x30,%rsp
mov   %rbx,-0x38(%rbp)                 mov   %rbx,-0x28(%rbp)
mov   %r12,-0x40(%rbp)
mov   %r13,-0x48(%rbp)
mov   %r14,-0x50(%rbp)
mov   %r15,-0x58(%rbp)
lea   -0x10(%rbp),%rax                 lea   -0x10(%rbp),%rax
mov   %rdi,(%rax)                      mov   %rdi,(%rax)
lea   -0x20(%rbp),%r8                  lea   -0x20(%rbp),%rbx
mov   %r8,-0x30(%rbp)      ;; stage
mov   -0x30(%rbp),%r8      ;; reload
movq  $0x0,(%r8)                       movq  $0x0,(%rbx)
mov   -0x10(%rbp),%rcx                 mov   -0x10(%rbp),%rcx    ;; --- asm block
mov   (%rcx),%rax                      mov   (%rcx),%rax
mov   %rax,-0x20(%rbp)                 mov   %rax,-0x20(%rbp)    ;; --- asm block
mov   -0x30(%rbp),%r8      ;; reload
mov   (%r8),%rax                       mov   (%rbx),%rax
mov   -0x38(%rbp),%rbx                 mov   -0x28(%rbp),%rbx
mov   -0x40(%rbp),%r12
mov   -0x48(%rbp),%r13
mov   -0x50(%rbp),%r14
mov   -0x58(%rbp),%r15
mov   %rbp,%rsp                        mov   %rbp,%rsp
pop   %rbp                             pop   %rbp
ret                                    ret
```

The body writes RAX and RCX. The old set was all 16, so the prologue preserved **all five** callee-saved GP registers and the address had to be **staged through a stack slot** across the barrier — the exact cost #2231 names. The new set is `{RAX, RCX}`: one callee-saved register saved, and it is saved because the allocator now *uses* it to hold the address across the block.

**Runtime**, atomics-heavy workload (3M iterations × `store` / `load` / `fetch_add` / `fetch_sub` / `exchange` / `cas`, six values live across each barrier), x86-64 release, 15 interleaved runs:

```
base:  min 69.2 ms   median 71.1 ms
new:   min 49.9 ms   median 50.9 ms
       -27.9% (min)   -28.5% (median)
```

Both binaries print identical results.

## Mutation tests

Baseline **949 / 0**.

| mutation | result | broke |
|---|---|---|
| **M1** drop the shared emit-side bind scan | **947 / 2** | `riscv64.encode:inline_asm_atomics`, `x64.encode:asm_unresolved_binding_refused_at_emit` |
| **M2** drop the implicit-write fold (the optimistic direction — a real miscompile) | **946 / 3** | all three ISAs' `asm_clobbers` tests |
| **M3** restore the old worst-case bind rule, in the shared fold | **946 / 3** | all three ISAs' `asm_clobbers` tests |

M1 shows one shared check now covers two ISAs that each had their own. M2 matters *because* of this change: under the old model a missing `implicit` fact was masked on every bind-bearing x86-64 body by the all-GP fold — it no longer is. M3 shows the new x86-64 assertions discriminate rather than pass vacuously.

## Suites

- mach **949 / 0** through the from-source HEAD compiler (948 on `dev` + the one test added).
- mach-std **611 / 0** at pin `eff1e8e` (materialized by `git archive` + `diff -r` against the submodule; a bare clone lands on `dev` and reports 663).
- `int/`: **linux** all pass, **linux-riscv64** all pass (qemu). The **linux-arm64** leg is `native` in `targets.conf` and this x86_64 host cannot execute it (`Exec format error`) — CI runs it on `ubuntu-24.04-arm`. Covered here instead by byte-identical aarch64 objects across the corpus and by the shadow's 40/40 unchanged aarch64 derivations; `int/surface/freestanding`'s aarch64 and riscv64 binaries are byte-identical, and only its x86-64 binary moved.
- Three-generation fixpoint **B == C** (`e80aadf5…`). A ≠ B is expected: the seed predates this codegen change.

## `std.sync.atomic` specifically

Its memory-ordering behaviour is untouched — no instruction, ordering suffix or fence moved; the emitted asm bodies are the same instructions, and only the *surrounding* register allocation changed. Its objects do move, which is the point of the issue, and the delta is the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ntqq8dS4TDqoYPsx3JpVy4