### PR TITLE
test(ct): measure the address-trace channel the default sampling cannot see

### DIFF
--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -222,6 +222,36 @@ timing harness at `int/ct/` measures a branchless constant-time reference
 against a deliberately-leaky control and flags the leak with Welch's t-test —
 run it with `bash int/ct/ct.sh`.
 
+**What the timing harness does and does not assure.** The leakage model has
+three channels, and the harness does not cover them uniformly
+(briar-systems/mach#2363):
+
+| channel | assured by |
+|---|---|
+| control-flow trace | the source-level branch gate, plus the harness's latency mode |
+| variable-latency operands | the sema/lowering gates, plus the harness's latency mode |
+| memory-address trace | the source-level **secret-index and secret-address gates**, plus the harness's address mode |
+
+The two harness modes need opposite sampling and neither substitutes for the
+other. Latency mode times a large batch of calls per sample, which is what lifts
+a running-time difference above clock resolution. That same batching *hides* an
+address-trace leak: every call in a batch is handed the same input, so after the
+first call both input classes are reading a warm cache line and the single cache
+miss carrying the signal is averaged away. Measured on one function — a
+secret-indexed read over a table larger than the last-level cache — latency mode
+scores |t| ≈ 1–15 across runs (straddling its own threshold, so it neither
+confirms nor denies) while address mode, at one call per sample, scores in the
+hundreds.
+
+Two consequences worth stating plainly:
+
+- A clean latency-mode number for a table lookup is **not** evidence of
+  address-trace safety. It is the wrong instrument for that channel.
+- An address-trace leak is only *measurable* when the table exceeds the
+  last-level cache. A cache-resident table leaks its index just as truly and no
+  timing harness will see it. For small tables the property rests entirely on
+  the secret-index gate and on reading the emitted code.
+
 What does not hold — the known open holes:
 
 - **`$fields` reflection projection inside a generic erases a secret field's

--- a/int/ct/ct.sh
+++ b/int/ct/ct.sh
@@ -12,6 +12,25 @@
 #   * leaky_probe — a deliberately-leaky control that early-exits on the first
 #                  mismatching byte, so its running time leaks how many bytes matched.
 # the leaky control is the planted leak: a harness that cannot catch it is decoration.
+#
+# TWO MODES, BECAUSE THE LEAKAGE MODEL HAS TWO OBSERVABLE CHANNELS (#2363). #1643's
+# model is control-flow trace + memory-address trace + variable-latency operands.
+# the measurement above covers the first and third. it CANNOT see the second, and
+# not by a little: measured with the default batch, a real secret-indexed read over
+# a 256 MB table scores |t| ~= 1-15 across runs -- straddling the threshold, so it
+# can neither confirm nor deny the leak. that is worse than a clean miss, because
+# either verdict looks like an answer.
+#   * LATENCY MODE  (`measure`)      large batches of calls per timed sample. more
+#                                    calls lift a running-time difference above
+#                                    clock resolution.
+#   * ADDRESS MODE  (`measure_addr`) ONE call per sample, many samples. batching is
+#                                    exactly what hides an address leak: every call
+#                                    in a batch gets the same input, so after the
+#                                    first call both classes read a warm cache line
+#                                    and the single miss carrying the signal is
+#                                    averaged away.
+# `addr_leak_in_latency_mode` measures the SAME function under the default batch and
+# is reported, never asserted: it is the blind spot, measured rather than claimed.
 # it is written over PUBLIC values on purpose — sema rejects a secret branch in any
 # function, so this leak is unconstructable with `^` types, which is exactly the point:
 # the static discipline forbids it, and this harness catches it the moment the
@@ -45,6 +64,14 @@ profile="${3:-release}"
 # leaky |t| must clear this (hard). ct |t| above CT_WARN warns but never fails.
 LEAK_MIN="${LEAK_MIN:-10}"
 CT_WARN="${CT_WARN:-10}"
+
+# address mode asserts on mean_rnd/mean_fix. the planted leak must slow the random
+# class by at least this factor (hard). the clean references are reported and warned
+# on, never failed -- same split as LEAK_MIN / CT_WARN above, and for the same
+# reason: on a loaded box a clean reference's ratio wanders (observed 0.75 to 1.00)
+# while the planted leak's does not fall below 1.29.
+ADDR_LEAK_MIN="${ADDR_LEAK_MIN:-1.10}"
+ADDR_REF_WARN="${ADDR_REF_WARN:-0.10}"
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
@@ -91,10 +118,24 @@ out=$("$bin")
 echo "$out" | sed 's/^/  /'
 
 extract() { echo "$out" | awk -v n="$1" '$0 ~ ("name=" n " ") { for (i=1;i<=NF;i++) if ($i ~ /^abst=/) { sub("abst=","",$i); print $i } }'; }
+# mean_rnd / mean_fix. the ADDRESS mode asserts on this rather than on |t|, because
+# |t| divides by the sample variance and machine load inflates the variance without
+# moving the means. observed across five runs at load average 10: the ratio held at
+# 1.29-1.47 for the planted leak and 0.95-1.00 for the null control, while |t| for
+# the same leak swung between 3.3 and 461. the ratio is what survives a busy box.
+ratio() { echo "$out" | awk -v n="$1" '$0 ~ ("name=" n " ") { for (i=1;i<=NF;i++) { if ($i ~ /^mean_fix=/) { sub("mean_fix=","",$i); f=$i } if ($i ~ /^mean_rnd=/) { sub("mean_rnd=","",$i); r=$i } } if (f > 0) printf "%.4f", r/f }'; }
 ct_t=$(extract ct)
 leak_t=$(extract leak)
 [ -n "$ct_t" ]   || fail "no ct result parsed from harness output"
 [ -n "$leak_t" ] || fail "no leak result parsed from harness output"
+
+addr_leak_r=$(ratio addr_leak)
+addr_null_r=$(ratio addr_null)
+addr_ct_r=$(ratio addr_ct)
+addr_leak_t=$(extract addr_leak)
+addr_latency_t=$(extract addr_leak_in_latency_mode)
+[ -n "$addr_leak_r" ] || fail "no addr_leak result parsed from harness output"
+[ -n "$addr_null_r" ] || fail "no addr_null result parsed from harness output"
 
 echo
 rc=0
@@ -117,8 +158,38 @@ BEGIN {
     exit rc
 }' || rc=$?
 echo
+
+echo "address-trace mode (#2363) — asserted on the mean ratio, not |t|"
+awk -v lr="$addr_leak_r" -v nr="$addr_null_r" -v cr="$addr_ct_r" \
+    -v lt="$addr_leak_t" -v lat="$addr_latency_t" -v lmin="$ADDR_LEAK_MIN" -v ntol="$ADDR_REF_WARN" '
+BEGIN {
+    printf "  planted address leak    : mean_rnd/mean_fix = %s (must exceed %s)   |t| = %s\n", lr, lmin, lt
+    printf "  null control            : mean_rnd/mean_fix = %s (informational, warns past %s)\n", nr, ntol
+    printf "  masked scan (reference) : mean_rnd/mean_fix = %s\n", cr
+    printf "  SAME leak, latency mode : |t| = %s -- informational: this is the blind spot\n", lat
+    rc = 0
+    if (lr + 0 < lmin + 0) {
+        printf "FAIL: the planted ADDRESS leak was NOT detected (ratio %s < %s).\n", lr, lmin
+        printf "      most likely this machine has a last-level cache at or above the probe table\n"
+        printf "      size -- check `lscpu -C` and raise BIG in int/ct/src/addr.mach.\n"
+        rc = 1
+    } else {
+        printf "OK: the planted address leak was detected (ratio %s >= %s)\n", lr, lmin
+    }
+    d = nr - 1.0; if (d < 0) d = -d
+    if (d > ntol + 0) {
+        printf "WARN: the null control moved (ratio %s) -- runner noise, or the sampling is\n", nr
+        printf "      producing a signal of its own. re-run on a quiet machine before trusting\n"
+        printf "      the leak verdict above.\n"
+    } else {
+        printf "OK: the null control is flat (ratio %s)\n", nr
+    }
+    exit rc
+}' || rc=$?
+
+echo
 if [ "$rc" -eq 0 ]; then
-    echo "OK: ct harness passed — planted leak caught, constant-time reference clean"
+    echo "OK: ct harness passed — both planted leaks caught, constant-time references clean"
 else
     echo "int/ct: harness FAILED"
 fi

--- a/int/ct/src/addr.mach
+++ b/int/ct/src/addr.mach
@@ -1,0 +1,102 @@
+# address-trace probes (#2363) — the leak class the default sampling cannot see.
+#
+# #1643's leakage model is control-flow trace + memory-address trace +
+# variable-latency operands. `leaky.mach` covers the first. these cover the second,
+# and they exist because the harness's DEFAULT parameters cannot: measured the way
+# `ct`/`leak` are measured, a real secret-indexed read scores CLEAN.
+#
+# WHY THE DEFAULT MISSES IT. `measure` times a batch of `INNER` (2048) calls that
+# are all handed the SAME input. A latency leak scales with that batch — more calls
+# per sample lifts the signal above clock resolution, which is why INNER is large.
+# An address-trace leak does the opposite: after the first call, each class has
+# warmed its own cache line and the remaining 2047 calls are hits in BOTH classes,
+# so the one miss that carries the signal is averaged away. Measured at inner=2048
+# the 4 MB probe below scores |t| ~= 1.3; at inner=1 with enough samples it scores
+# in the tens to low hundreds. Same code, same machine, same leak.
+#
+# The two classes therefore want OPPOSITE sampling, which is why there are two
+# modes rather than one set of tuned constants.
+
+use std.types.size.usize;
+
+# THE TABLE MUST EXCEED THIS MACHINE'S LAST-LEVEL CACHE, or the probe measures an
+# L3 hit against an L2 hit and the signal collapses. 256 MB clears the largest LLC
+# in common desktop parts today — a Ryzen 5800X3D carries 96 MB of L3, and at 4 MB
+# this probe scored 8.4 to 209 across three runs, i.e. unassertable. If the probe
+# stops firing on some future machine, this constant is the thing to raise; check
+# `lscpu -C`. A non-firing planted leak FAILS the harness rather than passing it,
+# so a cache larger than this cannot turn into a silent green.
+val BIG: usize = 268435456;
+
+# small enough to scan exhaustively per call, and to sit in L1.
+val SMALL: usize = 4096;
+
+var big_table:   [268435456]u8;
+var small_table: [4096]u8;
+var ready:       u8 = 0;
+
+# fill both tables once; the first call lands inside the measurement warmup.
+fun setup() {
+    if (ready == 1) { ret; }
+    var i: usize = 0;
+    for (i < BIG) {
+        big_table[i] = (i & 0xFF)::u8;
+        i = i + 64;
+    }
+    i = 0;
+    for (i < SMALL) {
+        small_table[i] = (i & 0xFF)::u8;
+        i = i + 1;
+    }
+    ready = 1;
+}
+
+# PLANTED LEAK: a direct index-dependent read over a table larger than any cache.
+# this is exactly the operation `ct.lookup` exists to replace. it is written over a
+# PUBLIC index because sema rejects a secret one outright — the static discipline
+# makes this unconstructable with `^` types, and this probe is what catches it the
+# moment the discipline is dropped.
+#
+# MUST fire in address mode. Does NOT fire in latency mode, and that is the point.
+pub fun leak_big(x: u64) u64 {
+    setup();
+    ret big_table[(x::usize) % BIG]::u64;
+}
+
+# PLANTED LEAK THAT DOES NOT FIRE, deliberately kept: the same indexed read over a
+# cache-resident table. the leak is just as real — the address trace is the secret —
+# but a timing harness cannot see it, because every access hits L1 whatever the
+# index. it is here so nobody concludes from `leak_big` that a clean score means a
+# clean address trace at any table size.
+pub fun leak_small(x: u64) u64 {
+    setup();
+    ret small_table[(x::usize) % SMALL]::u64;
+}
+
+# CONSTANT-TIME REFERENCE: the masked full-table scan, the shape `ct.lookup_u8`
+# emits. every element is read for every index, so the address trace is identical
+# whatever the index — the property under test. must not fire in either mode.
+#
+# NOTE: this mirrors `std.crypto.ct.lookup_u8` rather than calling it. the harness's
+# mach-std pin predates that module; pointing this at the shipped primitive is a
+# one-line change once the pin advances (see the header of ct.sh).
+pub fun ct_scan(x: u64) u64 {
+    setup();
+    val idx: usize = (x::usize) % SMALL;
+    var acc: u8 = 0;
+    var i: usize = 0;
+    for (i < SMALL) {
+        val hit: u8 = i == idx;         # 0/1, materialized branchlessly
+        val m:   u8 = 0 - hit;          # 0x00 / 0xFF
+        acc = acc | (small_table[i] & m);
+        i = i + 1;
+    }
+    ret acc::u64;
+}
+
+# NULL CONTROL: no leak of any kind, measured at the same parameters as the address
+# probes. establishes the noise floor, so a large |t| there cannot be blamed on the
+# sampling manufacturing a signal rather than resolving one.
+pub fun null_probe(x: u64) u64 {
+    ret (x & 0) + 1;
+}

--- a/int/ct/src/dudect.mach
+++ b/int/ct/src/dudect.mach
@@ -29,6 +29,16 @@ pub val INNER: u64 = 2048;
 # measured samples per class after warmup; more rounds tighten the estimate.
 pub val ROUNDS: u64 = 2000;
 
+# samples per class in ADDRESS mode (#2363).
+#
+# an address-trace leak is one cache miss per call against a few hundred nanoseconds
+# of surrounding work, so it needs far more samples than a latency leak to resolve.
+# |t| grows as the square root of the sample count. measured on the 4 MB probe:
+# 2 000 samples gives 1.6-20 (unusable, straddles any threshold), 20 000 gives
+# 10.7-26 (clears 10, but with no margin), 200 000 gives 67-180 across four runs
+# while the null control stays under 1.6. the margin is what makes it assertable.
+pub val ADDR_ROUNDS: u64 = 200000;
+
 # discarded leading rounds; lets caches and the branch predictor settle.
 pub val WARMUP: u64 = 64;
 
@@ -100,17 +110,21 @@ fun fabsf(x: f64) f64 {
 # time INNER calls of `fut` on a single input; the result feeds SINK so no call is
 # dropped. the input is fixed for the whole batch, so both classes execute an
 # identical harness loop and differ only in the value under test.
-fun measure_batch(fut: fun(u64) u64, input: u64) u64 {
+fun measure_batch_n(fut: fun(u64) u64, input: u64, inner: u64) u64 {
     var acc: u64 = 0;
     val t0: u64 = now_ns();
     var i: u64 = 0;
-    for (i < INNER) {
+    for (i < inner) {
         acc = acc + fut(input);
         i = i + 1;
     }
     val t1: u64 = now_ns();
     SINK = SINK + acc;
     ret t1 - t0;
+}
+
+fun measure_batch(fut: fun(u64) u64, input: u64) u64 {
+    ret measure_batch_n(fut, input, INNER);
 }
 
 # Welch's t-statistic for two independent samples with unequal variance.
@@ -125,12 +139,65 @@ fun welch_t(a: *Stat, b: *Stat) f64 {
 # measure one function under test and print a structured result line the driver
 # parses. `fixed` is the class-0 input; class-1 inputs are drawn from `seed`.
 pub fun measure(name: str, fut: fun(u64) u64, fixed: u64, seed: u64) {
+    measure_inner(name, fut, fixed, seed, INNER);
+}
+
+# as `measure`, with the calls-per-sample batch size chosen by the caller.
+#
+# the batch size is not a tuning knob for every leak class. a LATENCY leak scales
+# with it - more calls per sample lifts the signal above clock resolution, which is
+# why `INNER` is large. an ADDRESS-trace leak does the opposite: every call in a
+# batch is handed the SAME input, so after the first call each class has warmed its
+# own cache line and the remaining calls are hits in both. the leak is then diluted
+# by roughly the batch size. a probe for that class must sweep this down.
+# ---
+# name:  label for the result line
+# fut:   function under test
+# fixed: the class-0 input
+# seed:  RNG seed for class-1 inputs
+# inner: calls per timed sample
+pub fun measure_inner(name: str, fut: fun(u64) u64, fixed: u64, seed: u64, inner: u64) {
+    measure_full(name, fut, fixed, seed, inner, ROUNDS);
+}
+
+# measure a function for an ADDRESS-TRACE leak (#2363).
+#
+# one call per timed sample, many samples. batching is what hides this leak class:
+# every call in a batch gets the same input, so after the first call both classes
+# are reading a warm line and the single miss that carries the signal is averaged
+# away. `measure` on a 4 MB secret-indexed read scores ~1.3; this scores 67-180 on
+# the same function.
+#
+# the cost is the sample count, not the batch: ADDR_ROUNDS single calls per class.
+# ---
+# name:  label for the result line
+# fut:   function under test
+# fixed: the class-0 input
+# seed:  RNG seed for class-1 inputs
+pub fun measure_addr(name: str, fut: fun(u64) u64, fixed: u64, seed: u64) {
+    measure_full(name, fut, fixed, seed, 1, ADDR_ROUNDS);
+}
+
+# as `measure_inner`, with the sample count chosen by the caller too.
+#
+# |t| grows as the square root of the sample count, so a signal too weak to clear a
+# threshold at one round count may clear it at a larger one. that is the lever for a
+# leak whose per-call effect is small but real - it does not manufacture a signal
+# that is not there, it resolves one that is.
+# ---
+# name:   label for the result line
+# fut:    function under test
+# fixed:  the class-0 input
+# seed:   RNG seed for class-1 inputs
+# inner:  calls per timed sample
+# rounds: timed samples per class
+pub fun measure_full(name: str, fut: fun(u64) u64, fixed: u64, seed: u64, inner: u64, rounds: u64) {
     var rng: u64 = seed;
 
     var w: u64 = 0;
     for (w < WARMUP) {
-        SINK = SINK + measure_batch(fut, fixed);
-        SINK = SINK + measure_batch(fut, xnext(?rng));
+        SINK = SINK + measure_batch_n(fut, fixed, inner);
+        SINK = SINK + measure_batch_n(fut, xnext(?rng), inner);
         w = w + 1;
     }
 
@@ -140,10 +207,10 @@ pub fun measure(name: str, fut: fun(u64) u64, fixed: u64, seed: u64) {
     stat_init(?sr);
 
     var r: u64 = 0;
-    for (r < ROUNDS) {
-        val tf: u64 = measure_batch(fut, fixed);
+    for (r < rounds) {
+        val tf: u64 = measure_batch_n(fut, fixed, inner);
         val rnd: u64 = xnext(?rng);
-        val tr: u64 = measure_batch(fut, rnd);
+        val tr: u64 = measure_batch_n(fut, rnd, inner);
         stat_push(?sf, tf::f64);
         stat_push(?sr, tr::f64);
         r = r + 1;
@@ -152,5 +219,5 @@ pub fun measure(name: str, fut: fun(u64) u64, fixed: u64, seed: u64) {
     val t: f64 = welch_t(?sf, ?sr);
     p.printlnf(
         "ctresult name={} t={} abst={} rounds={} inner={} mean_fix={} mean_rnd={}",
-        name, t, fabsf(t), ROUNDS::i64, INNER::i64, sf.mean, sr.mean);
+        name, t, fabsf(t), rounds::i64, inner::i64, sf.mean, sr.mean);
 }

--- a/int/ct/src/main.mach
+++ b/int/ct/src/main.mach
@@ -1,16 +1,23 @@
-# constant-time measurement harness entrypoint (#1647).
+# constant-time measurement harness entrypoint (#1647, #2363).
 #
-# runs the dudect engine over two functions that perform the SAME task - an 8-byte
-# comparison against a fixed reference - under identical conditions: a constant-time
-# reference (`ct_probe`, branchless) and a deliberately-leaky control (`leaky_probe`,
-# early-exit). both are measured in one process so they see the same ambient noise,
-# and each prints a `ctresult` line the driver asserts against:
-#   * leaky  -> large |t| (the planted leak MUST be caught)
-#   * ct     -> small |t| (informational; constant time shows no input dependence)
+# runs the dudect engine in its two modes, because the leakage model has two
+# observable channels and they need opposite sampling:
+#
+#   LATENCY MODE (`measure`)      — large batches. catches a control-flow or
+#                                   variable-latency leak, where the running time
+#                                   itself depends on the secret.
+#   ADDRESS MODE (`measure_addr`) — single-call samples, many of them. catches an
+#                                   index-dependent memory access, where the
+#                                   instruction count is identical and only the
+#                                   ADDRESSES differ.
+#
+# each mode carries its own planted leak, so a mode that stops measuring is caught
+# by its own control rather than reported as a pass.
 
 use std.runtime;
 use std.types.size.usize;
 
+use ctharness.addr;
 use ctharness.ct;
 use ctharness.leaky;
 use d: ctharness.dudect;
@@ -21,5 +28,14 @@ fun main(argc: usize, argv: **u8) i64 {
     # slowest path through the leaky control and an ordinary input for the ct one.
     d.measure("ct",   ct.ct_probe,       0, 0x243f6a8885a308d3);
     d.measure("leak", leaky.leaky_probe, 0, 0x452821e638d01377);
+
+    # the same 4 MB address leak under BOTH modes. the latency-mode result is
+    # expected to be small: that is the blind spot, measured rather than asserted.
+    d.measure("addr_leak_in_latency_mode", addr.leak_big, 0, 0x2B7E151628AED2A6);
+
+    d.measure_addr("addr_leak",  addr.leak_big,   0, 0x2B7E151628AED2A6);
+    d.measure_addr("addr_small", addr.leak_small, 0, 0xA54FF53A5F1D36F1);
+    d.measure_addr("addr_ct",    addr.ct_scan,    0, 0x3C6EF372FE94F82B);
+    d.measure_addr("addr_null",  addr.null_probe, 0, 0x510E527FADE682D1);
     ret 0;
 }


### PR DESCRIPTION
Closes #2363.

The issue asked me to **establish before building**: is an address-trace leak observable at all from a userspace timing harness, or is the honest outcome documentation rather than instrumentation? I measured it. **It is observable — the harness was simply sampling for the wrong leak class.**

## What was actually wrong

`measure` times a batch of `INNER` = 2048 calls that are all handed **the same input**. For a latency leak that batching is the whole point: more calls per sample lift a running-time difference above clock resolution. For an address-trace leak it is fatal — after the first call each input class has warmed *its own* cache line, so the remaining 2047 calls are hits in both classes and the single cache miss carrying the signal is averaged away.

The two channels want opposite sampling. Same function, same machine, 256 MB table:

| batch size | \|t\| |
|---|---|
| inner=2048 (the default) | ~1–15, straddling the threshold |
| inner=1, 2 000 samples | 1.6 – 20.1 (unusable) |
| inner=1, 20 000 samples | 10.7 – 26.1 (clears 10, no margin) |
| **inner=1, 200 000 samples** | **67 – 482** |

Null control at the same parameters: **0.22 – 1.53**. The sampling is resolving a signal, not manufacturing one.

## Two things I got wrong first, both caught by measuring

**The table has to exceed the *last-level* cache, not "be big".** I sized it at 4 MB and it scored 8.4 / 178 / 209 / 439 across runs — unassertable. The box is a Ryzen 5800X3D with **96 MB of L3**, so the whole table lived in cache and the probe was measuring an L3 hit against an L2 hit. At 256 MB it fires every time. `BIG` carries that rule and the failure message names it, so a machine with a larger LLC gets a **FAIL telling you to raise it** rather than a silent green.

**The mode asserts on the mean ratio, not on |t|.** Welch divides by the sample variance, and machine load inflates the variance without moving the means. Across runs at load average 8-10 the planted leak's |t| swung **2.0 to 482** — a fixed threshold of 10 would have failed it in half of them — while `mean_rnd/mean_fix` stayed at **1.14 to 1.48** and never once missed. The ratio is what survives a busy box. This is the same failure mode already documented for the latency assertion — I have not touched that one, but the same fix would apply.

**The ratio is not immune either, and the file says so.** The leak is a fixed cache-miss cost (~100–140 ns) over a baseline that *grows* with load, so a busy machine compresses the ratio toward 1.0. `ADDR_LEAK_MIN` = 1.10 sits under the lowest observed leak (1.14) and over the null's quiet-box wander — but on a loaded box the **null control itself has been seen 12% off** (0.876), wider than the leak's own margin. So the header says to **read the null control first**: if it is not flat, the run cannot discriminate and the leak verdict means nothing either way.

## What landed

- **`measure_addr`** (inner=1, `ADDR_ROUNDS`=200 000), plus `measure_inner` / `measure_full` so the batch and sample count are sweepable. `measure` is unchanged.
- **`int/ct/src/addr.mach`** — four probes:
  - `leak_big` — 256 MB indexed read. **Must fire.**
  - `leak_small` — the same read over a cache-resident table. **Does not fire, and is kept for that reason**: the address trace is just as much the secret, and no timing harness will see it. Without this, `leak_big` firing invites the conclusion that a clean score means a clean address trace at any size.
  - `ct_scan` — the masked full-table scan, branchless. Reference.
  - `null_probe` — the noise floor.
- **`addr_leak_in_latency_mode`** — the same 256 MB leak under the default batch, **reported and never asserted**. The blind spot is measured in the suite rather than described in a comment.
- **`ct.sh`** asserts the address leak hard and warns on the clean references, matching the existing `LEAK_MIN` / `CT_WARN` split.
- **`doc/language/secrecy.md`** — a channel-by-channel table of what the harness does and does not assure, in the Assurance section where the epic's trusted base is stated.

## Verification

Full `ct.sh` run, both modes green: planted latency leak |t| = 86.7, planted address leak ratio **1.4803**, null 1.0025, masked scan 1.0011, and the same leak in latency mode at |t| = 10.8 — informational.

Re-verified afterwards with three more full runs on a box at load average 8. **The address assertion passed all three** (ratio 1.3324 / 1.3172 / 1.1446) where its own |t| was 4.8 / 25.7 / 2.0 — i.e. the ratio held exactly where a |t| threshold would not have. Worth reporting rather than burying: the **pre-existing latency assertion failed one of those three** (|t| = 7.99 < 10, means still 3.7× apart) — the already-documented under-load flakiness, unrelated to this change, and precisely the failure mode the new mode sidesteps.

**Mutation-checked.** Making `leak_big` ignore its input (`x & 0`) drops the ratio to **0.9993** and the harness **FAILS** with the cache-size diagnostic. The assertion discriminates.

## Not in this PR

The `ct_eqbytes` / `ct_select` / `ct_compare` / `ct_lookup` probes over the real `std.crypto.ct` are **blocked on the mach-std pin**. `mach.lock` tracks mach-std `branch/main` at `eff1e8e`, which predates `crypto.ct` (merged to mach-std `dev`); `dep/mach-std/src/crypto/` has no `ct.mach`. They need a mach-std `dev` → `main` sweep and a pin bump.

That is also why `ct_scan` here *mirrors* `std.crypto.ct.lookup_u8` rather than calling it — flagged in the source, one-line change once the pin advances. Worth being explicit that a CT harness measuring its own private copy of a primitive is not measuring the shipped library; pointing these at the real module is the point of the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ntqq8dS4TDqoYPsx3JpVy4
