### PR TITLE
test(ct): record how machine load compresses the address-mode ratio

### DIFF
--- a/int/ct/ct.sh
+++ b/int/ct/ct.sh
@@ -67,9 +67,20 @@ CT_WARN="${CT_WARN:-10}"
 
 # address mode asserts on mean_rnd/mean_fix. the planted leak must slow the random
 # class by at least this factor (hard). the clean references are reported and warned
-# on, never failed -- same split as LEAK_MIN / CT_WARN above, and for the same
-# reason: on a loaded box a clean reference's ratio wanders (observed 0.75 to 1.00)
-# while the planted leak's does not fall below 1.29.
+# on, never failed -- same split as LEAK_MIN / CT_WARN above.
+#
+# WHY A RATIO AND NOT |t|: |t| divides by the sample variance, and machine load
+# inflates the variance without moving the means. across runs at load average 8-10
+# the planted leak's |t| swung 2.0 to 482 -- it would have failed a fixed threshold
+# in half of them -- while the ratio stayed at 1.14 to 1.48 and never once missed.
+#
+# THE RATIO IS NOT IMMUNE, THOUGH, and the mechanism matters if you are tuning this:
+# the leak is a fixed cache-miss cost (~100-140ns) over a baseline that GROWS with
+# load, so a busy box compresses the ratio toward 1.0. 1.10 sits below the lowest
+# observed leak (1.14) and above the null's quiet-box wander, but on a loaded box
+# the null itself has been seen 12% off (0.876) -- larger than the leak's own margin.
+# READ THE NULL CONTROL FIRST: if it is not flat, the run cannot discriminate and
+# the leak verdict below it means nothing either way. re-run on a quiet machine.
 ADDR_LEAK_MIN="${ADDR_LEAK_MIN:-1.10}"
 ADDR_REF_WARN="${ADDR_REF_WARN:-0.10}"
 


### PR DESCRIPTION
Follow-up to #2370 (part of #2363). **This commit existed on the #2370 branch but did not make the merge** — I pushed it while the PR was being merged, so it raced and was left behind. No blame anywhere; flagging it because what landed on `dev` contains a claim I had already disproved.

## What is wrong on `dev` right now

`int/ct/ct.sh:72` states:

```
# reason: on a loaded box a clean reference's ratio wanders (observed 0.75 to 1.00)
# while the planted leak's does not fall below 1.29.
```

**The planted leak has been observed at 1.1446.** Three full re-runs after #2370 was written, on a box at load average 8, gave ratios of 1.3324 / 1.3172 / **1.1446** — the last one only 4% above the `ADDR_LEAK_MIN` of 1.10, not the comfortable 19% the comment implies. Anyone tuning the threshold against that sentence would tune it wrong.

## What this replaces it with

The mechanism, so the number is derivable rather than memorized: **the leak is a fixed cache-miss cost (~100–140 ns) over a baseline that grows with load**, so a busy machine compresses the ratio toward 1.0. That is why it sags, and it is why raising `ADDR_ROUNDS` does not help — more samples tighten |t|, not the means.

And the caveat that matters more than the threshold: on a loaded box the **null control itself has been seen 12% off** (0.876), which is wider than the leak's own margin at that point. So the comment now says to **read the null control first** — if it is not flat, the run cannot discriminate and the leak verdict above it means nothing either way.

## The part that vindicates the design

Across the same runs the planted leak's **|t| swung 2.0 to 482** while the ratio held 1.14–1.48 and never missed. A fixed |t| threshold of 10 would have failed the address assertion in **half** of them. Choosing the ratio was right; the comment just overstated how much headroom it buys.

Related, and not touched here: the **pre-existing latency assertion failed one of those three runs** (|t| = 7.99 < 10) with its means still 3.7× apart — the already-documented under-load flakiness. The same ratio treatment would fix it, which I would rather raise as its own change than fold in silently.

Comment-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ntqq8dS4TDqoYPsx3JpVy4