### PR TITLE
fix(sema): reject a rec/uni that contains itself by value

### DIFF
--- a/int/regression/2355-linked-list/expect.txt
+++ b/int/regression/2355-linked-list/expect.txt
@@ -1,0 +1,5 @@
+sum=6
+depth=3
+tail=3
+even=4
+odd=7

--- a/int/regression/2355-linked-list/mach.toml
+++ b/int/regression/2355-linked-list/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case2355ll"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2355-linked-list/src/main.mach
+++ b/int/regression/2355-linked-list/src/main.mach
@@ -1,0 +1,67 @@
+# regression pin for #2355: a pointer-recursive record still compiles, links and RUNS
+#
+# The occurs-check rejects a type that reaches itself BY VALUE. Reaching yourself
+# through a pointer is the ordinary linked list, and it is the case a careless
+# occurs-check breaks — one that merely noticed "Node mentions Node" would reject
+# every program below.
+#
+# This is the half a sema-only test cannot cover: the rule runs in the front end, but
+# what it protects is the LOWERING descent, so the pointer form has to lower to an IR
+# aggregate, link, and produce the right answers at run time. Walking a real chain and
+# printing what it finds is the observable; a build that merely succeeded would not
+# distinguish a correctly lowered `*Node` field from a mis-lowered one.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+rec Node {
+    value: i64;
+    next:  *Node;
+}
+
+# mutual recursion through pointers is the same rule from the other side: neither
+# declaration mentions itself, and the cycle is legal because both edges indirect
+rec Even { v: i64; odd:  *Odd;  }
+rec Odd  { v: i64; even: *Even; }
+
+# sum a chain by following it to the terminator, so the `*Node` field is really
+# dereferenced rather than merely declared
+fun sum(head: *Node) i64 {
+    var total: i64 = 0;
+    var cur: *Node = head;
+    for (cur != nil) {
+        total = total + cur.value;
+        cur = cur.next;
+    }
+    ret total;
+}
+
+fun depth(head: *Node) i64 {
+    var n: i64 = 0;
+    var cur: *Node = head;
+    for (cur != nil) {
+        n = n + 1;
+        cur = cur.next;
+    }
+    ret n;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var c: Node; c.value = 3; c.next = nil;
+    var b: Node; b.value = 2; b.next = ?c;
+    var a: Node; a.value = 1; a.next = ?b;
+
+    p.printlnf("sum={}", sum(?a)::u64);
+    p.printlnf("depth={}", depth(?a)::u64);
+    p.printlnf("tail={}", a.next.next.value::u64);
+
+    # the mutually recursive pair, walked one hop each way
+    var o: Odd;  o.v = 7; o.even = nil;
+    var e: Even; e.v = 4; e.odd  = ?o;
+    p.printlnf("even={}", e.v::u64);
+    p.printlnf("odd={}", e.odd.v::u64);
+
+    ret 0;
+}

--- a/int/regression/2355-recursive-type/case.conf
+++ b/int/regression/2355-recursive-type/case.conf
@@ -1,0 +1,8 @@
+# a rec containing ITSELF by value must be REJECTED, not crash the compiler (#2355).
+# on dev this segfaulted in the unbounded lower_type / lower_nominal descent with no
+# diagnostic at all, so the observable has to be the message: build-fails requires an
+# 'error:' line, which a crash does not produce, and diffs its text.
+#
+# target-independent (a sema rule), so one leg proves it.
+run: build-fails
+targets: linux

--- a/int/regression/2355-recursive-type/expect.linux.txt
+++ b/int/regression/2355-recursive-type/expect.linux.txt
@@ -1,0 +1,1 @@
+error: recursive type has infinite size: this field contains the type being declared by value, so the type would have to contain itself; store it behind a pointer (`*T`) to break the cycle

--- a/int/regression/2355-recursive-type/mach.toml
+++ b/int/regression/2355-recursive-type/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case2355rec"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2355-recursive-type/src/main.mach
+++ b/int/regression/2355-recursive-type/src/main.mach
@@ -1,0 +1,22 @@
+# regression pin for #2355: a record containing itself by value is rejected
+#
+# `rec R { next: R; }` is the linked-list-without-the-pointer mistake, and it has no
+# finite size. Declaring a value of it segfaulted the compiler: `lower_type` and
+# `lower_nominal` walk the field graph to build the IR aggregate and recurred without
+# bound, exhausting the native stack at every size from 8 MB to 256 MB, and emitting
+# no diagnostic on the way down.
+#
+# THE END-TO-END HALF. The sema unit tests assert the diagnostic; only a full build
+# proves the pipeline now stops at sema instead of reaching the descent that crashed.
+# build-fails demands an `error:` line, which a crash cannot produce.
+
+use std.runtime;
+use std.types.size.usize;
+
+rec R { next: R; }
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var r: R;
+    ret 0;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -5234,6 +5234,83 @@ test "mach.lang.driver:secrecy_placement_byte_extent" {
     ret bad;
 }
 
+# #2355: a rec/uni that contains ITSELF by value has infinite size, and nothing
+# downstream can represent one. `lower_type` / `lower_nominal` walk the field graph to
+# build the IR aggregate and recur without bound: on `dev` `rec R { next: R; }` was
+# accepted outright when never used, and segfaulted the compiler with NO diagnostic at
+# all the moment a value of it was declared - at every stack size from 8 MB to 256 MB,
+# so genuinely unbounded rather than merely deep.
+#
+# Every rejection below must be checked BY MESSAGE. A crash and a rejection both make a
+# compile "fail", so a test that only asserted failure would have passed against the
+# unfixed compiler, which is exactly the shape of test this issue was filed about.
+#
+# The BY VALUE distinction is the whole rule, and the clean cases carry it: reaching
+# yourself through a POINTER is the ordinary linked list and must keep compiling. A
+# check that merely spotted "R mentions R" would reject every one of them.
+test "mach.lang.driver:recursive_type_occurs_check" {
+    val need: str = "recursive type has infinite size";
+
+    var bad: i32 = 0;
+    # the one-liner from the issue, in both states: never used, and used
+    if (!ut_sema_rejects_with("rec R { next: R; }\nfun main() i32 { ret 0; }\n", need))                       { bad = 1; }
+    if (!ut_sema_rejects_with("rec R { next: R; }\nfun main() i32 { var r: R; ret 0; }\n", need))             { bad = 1; }
+    # a union variant containing the union
+    if (!ut_sema_rejects_with("uni U { a: u32; b: U; }\nfun main() i32 { ret 0; }\n", need))                  { bad = 1; }
+    # an ARRAY of the type stores its elements inline, so it carries containment
+    if (!ut_sema_rejects_with("rec R { a: [4]R; }\nfun main() i32 { ret 0; }\n", need))                       { bad = 1; }
+    # mutual recursion: neither declaration mentions itself, the CYCLE is the defect
+    if (!ut_sema_rejects_with("rec A { b: B; }\nrec B { a: A; }\nfun main() i32 { ret 0; }\n", need))         { bad = 1; }
+    if (!ut_sema_rejects_with("rec A { b: B; }\nrec B { c: C; }\nrec C { a: A; }\nfun main() i32 { ret 0; }\n", need)) { bad = 1; }
+    # an anonymous record closes the cycle from inside a named one
+    if (!ut_sema_rejects_with("rec R { a: rec { b: R; }; }\nfun main() i32 { ret 0; }\n", need))              { bad = 1; }
+    # GENERICS, over the DECLARATION graph. `Wrap[Wrap[T]]` mints a fresh instance
+    # TypeId at every level, so a walk over instance ids descends forever and finds no
+    # cycle at all; resolving each instance to the nominal it instantiates is what makes
+    # this a self-edge caught at the first step.
+    if (!ut_sema_rejects_with("rec W[T] { v: T; inner: W[T]; }\nfun main() i32 { var w: W[i32]; ret 0; }\n", need))    { bad = 1; }
+    if (!ut_sema_rejects_with("rec Wrap[T] { inner: Wrap[Wrap[T]]; }\nfun main() i32 { var w: Wrap[i32]; ret 0; }\n", need)) { bad = 1; }
+
+    # INDIRECTION BREAKS THE CYCLE. a pointer stores an address, not the bytes, so each
+    # of these is a well-formed program the rule must not touch.
+    if (!ut_sema_clean("rec Node { next: *Node; }\nfun main() i32 { var n: Node; ret 0; }\n"))                { bad = 1; }
+    if (!ut_sema_clean("rec A { b: *B; }\nrec B { a: *A; }\nfun main() i32 { var a: A; ret 0; }\n"))          { bad = 1; }
+    if (!ut_sema_clean("uni U { a: u32; b: *U; }\nfun main() i32 { var u: U; ret 0; }\n"))                    { bad = 1; }
+    if (!ut_sema_clean("rec R { a: [4]*R; }\nfun main() i32 { var r: R; ret 0; }\n"))                         { bad = 1; }
+    # a DIAMOND reaches the same type by two paths without ever cycling
+    if (!ut_sema_clean("rec Leaf { v: u8; }\nrec L { l: Leaf; }\nrec Rt { r: Leaf; }\nrec D { x: L; y: Rt; }\nfun main() i32 { var d: D; ret 0; }\n")) { bad = 1; }
+    # and ordinary nesting is untouched at any depth the walk has no bound on
+    if (!ut_sema_clean("rec N0 { v: u8; }\nrec N1 { v: N0; }\nrec N2 { v: N1; }\nrec N3 { v: N2; }\nfun main() i32 { var n: N3; ret 0; }\n")) { bad = 1; }
+    ret bad;
+}
+
+# #2356: the recursive union reported the WRONG RULE. Measuring an infinitely-sized
+# type yields no extent, the deep secrecy-placement comparison fails closed on that,
+# and the union-variant rule reported a mixed-secrecy violation for a program with no
+# `^` anywhere - sending the reader to fix a secrecy defect they do not have.
+#
+# The counts are the assertion. Once the occurs-check rejects the type for its real
+# cause, the spurious diagnostic must be REPLACED, not merely joined: `== 1` fails
+# both against `dev` (1 error, the wrong one - caught by the message check) and
+# against an occurs-check that leaves the secrecy report standing (2 errors).
+test "mach.lang.driver:recursive_union_reports_its_real_defect" {
+    var bad: i32 = 0;
+
+    val rec_uni: str = "uni U[T] { a: u32; b: U[U[T]]; }\nfun main() i32 { var u: U[i32]; ret 0; }\n";
+    if (!ut_sema_rejects_with(rec_uni, "recursive type has infinite size"))     { bad = 1; }
+    if (ut_sema_errs(rec_uni) != 1)                                            { bad = 1; }
+
+    # the fail-closed default is untouched everywhere it is load-bearing: only a
+    # provable by-value cycle is skipped, never an undeterminable extent in general.
+    val need: str = "union variants must agree on secrecy";
+    if (!ut_sema_rejects_with("uni M { a: ^u32; b: u32; }\nfun main() i32 { ret 0; }\n", need))                        { bad = 1; }
+    if (!ut_sema_rejects_with("rec P { s: ^u32; }\nrec Q { s: u32; }\nuni D { a: P; b: Q; }\nfun main() i32 { ret 0; }\n", need)) { bad = 1; }
+    # a recursive union whose variants also genuinely disagree stays rejected; the
+    # skip removes a false report, it does not open a hole
+    if (!ut_sema_rejects_with("uni S { a: ^u32; b: S; c: u32; }\nfun main() i32 { ret 0; }\n", need))                  { bad = 1; }
+    ret bad;
+}
+
 # constant-time (#2167 / #2289): sema's layout must agree EXACTLY with the layout the
 # backend emits, because the secrecy-placement comparison decides overlay safety from
 # byte extents. Sema admitting an overlay the emitted layout does not produce would

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -132,6 +132,12 @@ pub fun sema(
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_decls));
     }
 
+    # the recursive-type occurs-check (#2355). First of the post-decl rules: a type that
+    # contains itself by value has no layout, and every later rule that measures one
+    # fails closed on it and reports its own precondition instead of the real defect
+    # (#2356). Reads field tables, so it runs once `infer_all_decls` has built them.
+    infer.check_occurs_all(?sc);
+
     # the mixed-secrecy union rule (#2224), for named and anonymous unions alike. Runs
     # here rather than during decl inference or type resolution: the deep secrecy
     # comparison reads the variants' field tables, which `infer_all_decls` has just

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -173,35 +173,231 @@ fun infer_nominal_uni(sc: *context.SemaContext, did: id.DeclId, name_span: token
     ret ty;
 }
 
+# whether `ty` reaches nominal `target` BY VALUE (#2355)
+#
+# A field descends into the containment graph when it stores the contained type's
+# bytes inline: a nominal, a generic instance, or an array of one. A pointer or a
+# function value stores an ADDRESS, so neither descends -- which is precisely what
+# keeps `rec Node { next: *Node; }`, the ordinary linked list, legal.
+#
+# OVER DECLARATIONS, NOT INSTANCES. `rec Wrap[T] { inner: Wrap[Wrap[T]]; }` mints a
+# fresh TYPE_INSTANCE at every level, so a walk over instance ids descends forever
+# without ever revisiting a node -- there is no cycle in that graph to find.
+# Resolving each instance to the nominal it instantiates makes the same program a
+# self-edge on `Wrap`, caught at the first step. The nominal set is finite, and
+# `stamp` expands each nominal at most once per query, so the walk terminates on
+# any input including a cycle that does not involve `target`.
+#
+# The visited marks are generation-stamped rather than cleared per query, and the
+# recursion is bounded by the number of distinct nominals rather than by a constant,
+# so a legal 200-deep nest costs 200 frames and is accepted. A fixed depth cap here
+# would reject well-formed programs.
+# ---
+# s:      the session (type universe)
+# seen:   per-TypeId stamp of the query that last expanded that nominal
+# cap:    number of slots in `seen`
+# stamp:  this query's stamp
+# target: the nominal being tested for self-containment
+# ty:     the type to descend
+# ret:    true when `target` is reachable from `ty` without passing an indirection
+fun reaches_nominal(s: *session.Session, seen: *u32, cap: u32, stamp: u32,
+                    target: type.TypeId, ty: type.TypeId) bool {
+    val base: type.TypeId = type.strip_secret(?s.types, ty);
+    val opt: O.Option[*type.Type] = type.get(?s.types, base);
+    if (O.is_none[*type.Type](opt)) { ret false; }
+    val t: *type.Type = O.unwrap[*type.Type](opt);
+
+    # an array stores its elements inline, so it carries the element's containment.
+    # a zero-length array is included: it still names the element type, and lowering
+    # would build an IR aggregate for it exactly as for any other element count.
+    if (t.kind == type.TYPE_ARRAY) {
+        ret reaches_nominal(s, seen, cap, stamp, target, t.data.array.base);
+    }
+
+    if (t.kind != type.TYPE_REC && t.kind != type.TYPE_UNI && t.kind != type.TYPE_INSTANCE) {
+        ret false;
+    }
+
+    val nom: type.TypeId = type.aggregate_nominal(?s.types, base);
+    if (nom == type.TYPE_ERROR) { ret false; }
+    if (nom == target)          { ret true; }
+    if (nom::u32 >= cap)        { ret false; }
+    if (seen[nom::u32] == stamp) { ret false; }
+    seen[nom::u32] = stamp;
+
+    val n: u32 = type.field_count(?s.types, nom);
+    var i: u32 = 0;
+    for (i < n) {
+        val fe: O.Option[*type.FieldEntry] = type.field_at(?s.types, nom, i);
+        if (O.is_some[*type.FieldEntry](fe)) {
+            if (reaches_nominal(s, seen, cap, stamp, target, O.unwrap[*type.FieldEntry](fe).ty)) {
+                ret true;
+            }
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# reject a rec/uni whose own fields make it contain itself by value (#2355)
+#
+# An infinitely-sized type has no layout and nothing downstream can represent one:
+# `lower_type` / `lower_nominal` walk the field graph to build the IR aggregate and
+# recur without bound, exhausting the native stack with no diagnostic at all. Before
+# this rule `rec R { next: R; }` was accepted outright when never used and crashed
+# the compiler when used. This is the classic occurs-check (Rust's E0072).
+#
+# Reported per FIELD, on the field's own span, because each offending field is a
+# distinct site the author has to change; a mutually recursive pair reports on both
+# declarations, each being independently ill-formed.
+# ---
+# sc:           sema context
+# nom:          the declaration's nominal TypeId
+# fields_start: start index into ast.typed_names
+# fields_len:   number of fields
+# seen:         the shared stamp array
+# cap:          number of slots in `seen`
+# stamp:        the next unused stamp, advanced once per field queried
+# ret:          the next unused stamp
+fun check_occurs(sc: *context.SemaContext, nom: type.TypeId, fields_start: u32, fields_len: u32,
+                 seen: *u32, cap: u32, stamp: u32) u32 {
+    var next: u32 = stamp;
+    var i:    u32 = 0;
+    for (i < fields_len) {
+        val tn: *decl.TypedName = ?sc.a.typed_names[fields_start + i];
+        val ty: type.TypeId     = context.resolved_type_of(sc, tn.ty);
+        if (reaches_nominal(sc.s, seen, cap, next, nom, ty)) {
+            context.report(sc, tn.name, "recursive type has infinite size: this field contains the type being declared by value, so the type would have to contain itself; store it behind a pointer (`*T`) to break the cycle");
+        }
+        next = next + 1;
+        i = i + 1;
+    }
+    ret next;
+}
+
 # enforce that a union's overlapping variants agree on secrecy (#1645)
 #
 # A `uni`'s fields share storage, so a mixed-secrecy union would let the same
 # bytes be read as both secret and public - the welded-storage aliasing leak. All
 # variants must be uniformly secret or uniformly public. The first variant whose
-# secrecy disagrees with the first variant's is reported on its own field span.
+# secrecy disagrees with the baseline variant's is reported on its own field span.
+#
+# A variant that closes a by-value cycle with `nom` is SKIPPED, baseline included
+# (#2356). The deep comparison measures byte extents, and an infinitely-sized type
+# has none, so it fails closed and reported this rule's violation for a program with
+# no `^` anywhere - naming a secrecy defect the program does not have and sending
+# the reader to fix it. Such a union is already rejected by the occurs-check with its
+# real cause. Only that provably-cyclic case is skipped: every other undeterminable
+# extent still fails closed, since this rule guards a disclosure channel and must
+# never be loosened into a permissive default.
 # ---
 # sc:           sema context
+# nom:          the union's own TypeId, for the cycle test
 # fields_start: start index into ast.typed_names
 # fields_len:   number of variants
-fun check_uni_secrecy(sc: *context.SemaContext, fields_start: u32, fields_len: u32) {
-    if (fields_len < 2) { ret; }
+# seen:         the shared stamp array
+# cap:          number of slots in `seen`
+# stamp:        the next unused stamp, advanced once per variant queried
+# ret:          the next unused stamp
+fun check_uni_secrecy(sc: *context.SemaContext, nom: type.TypeId, fields_start: u32, fields_len: u32,
+                      seen: *u32, cap: u32, stamp: u32) u32 {
+    var next: u32 = stamp;
+    if (fields_len < 2) { ret next; }
 
-    val first_tn: *decl.TypedName = ?sc.a.typed_names[fields_start];
-    val first_ty: type.TypeId     = context.resolved_type_of(sc, first_tn.ty);
+    # the baseline is the first variant that is not itself part of a cycle; a union
+    # whose every variant is cyclic has nothing to compare and reports nothing here.
+    var first_ty: type.TypeId = type.TYPE_NIL;
+    var b:        u32         = 0;
+    for (b < fields_len) {
+        val btn: *decl.TypedName = ?sc.a.typed_names[fields_start + b];
+        val bty: type.TypeId     = context.resolved_type_of(sc, btn.ty);
+        if (!reaches_nominal(sc.s, seen, cap, next, nom, bty)) {
+            first_ty = bty;
+            next = next + 1;
+            b = b + 1;
+            brk;
+        }
+        next = next + 1;
+        b = b + 1;
+    }
+    if (first_ty == type.TYPE_NIL) { ret next; }
 
-    var i: u32 = 1;
+    var i: u32 = b;
     for (i < fields_len) {
         val tn: *decl.TypedName = ?sc.a.typed_names[fields_start + i];
         val ty: type.TypeId     = context.resolved_type_of(sc, tn.ty);
+        val cyclic: bool        = reaches_nominal(sc.s, seen, cap, next, nom, ty);
+        next = next + 1;
         # DEEP (#2165): variants must agree on secrecy through their whole field graph,
         # not just at the top level - else `uni { a: P; b: Q }` with a `^` field inside P
         # aliases the secret bytes under the public `Q` overlay and reads them out. A
         # shallow `is_secret` per variant treats `P` as public and misses it.
-        if (!generics.secrecy_structure_equal_deep(sc.s, context.ptr_width_of(sc), first_ty, ty)) {
-            context.report(sc, tn.name, "union variants must agree on secrecy: overlapping fields are part secret `^` and part public, which would alias the same storage at two classifications");
+        if (!cyclic) {
+            if (!generics.secrecy_structure_equal_deep(sc.s, context.ptr_width_of(sc), first_ty, ty)) {
+                context.report(sc, tn.name, "union variants must agree on secrecy: overlapping fields are part secret `^` and part public, which would alias the same storage at two classifications");
+            }
         }
         i = i + 1;
     }
+    ret next;
+}
+
+# reject every rec/uni in this module that contains itself by value (#2355)
+#
+# Runs after `infer_all_decls` for the same reason the union secrecy rule below does:
+# the walk reads field tables, so it needs them all built, and it is then independent
+# of declaration order. It runs BEFORE that rule deliberately - a recursive union
+# makes the deep secrecy comparison fail closed, which reported an ill-formed type as
+# a mixed-secrecy violation in a program containing no `^` at all (#2356). Rejecting
+# it here first means the diagnostic names the actual defect.
+#
+# Only NAMED declarations are walked. An anonymous `rec { ... }` has no name to be
+# referred to, so it can never close a cycle by itself; it can only sit INSIDE one,
+# reached from the named declaration that spells it, and the walk descends through it
+# from there. Named decls are filtered by `decl_type`, so an untaken comptime-`$if`
+# arm stays unchecked, matching the rule that a discarded branch is not compiled.
+#
+# The stamp array is sized to the type universe and shared across every declaration,
+# so the whole pass allocates once. A failed allocation skips the rule rather than
+# failing the build: the crash it prevents is a compiler bug, not a program error,
+# and sema has no path to report an out-of-memory here.
+# ---
+# sc: sema context
+pub fun check_occurs_all(sc: *context.SemaContext) {
+    if (sc.decl_type == nil) { ret; }
+
+    val cap: u32 = sc.s.types.type_len;
+    if (cap == 0) { ret; }
+
+    val res: R.Result[*u32, str] = A.allocate[u32](sc.s.alloc, cap::usize);
+    if (R.is_err[*u32, str](res)) { ret; }
+    val seen: *u32 = R.unwrap_ok[*u32, str](res);
+
+    # stamps start at 1 so the zeroed array reads as "never expanded"
+    var z: u32 = 0;
+    for (z < cap) { seen[z] = 0; z = z + 1; }
+    var stamp: u32 = 1;
+
+    var d: u32 = 0;
+    for (d < sc.a.decl_len::u32) {
+        if (sc.decl_type[d] != type.TYPE_NIL) {
+            val d_opt: O.Option[*decl.Decl] = ast.get_decl(sc.a, d);
+            if (O.is_some[*decl.Decl](d_opt)) {
+                val dd: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
+                if (dd.kind == decl.DECL_KIND_REC) {
+                    stamp = check_occurs(sc, sc.decl_type[d], dd.data.rec_.fields_start,
+                                         dd.data.rec_.fields_len, seen, cap, stamp);
+                }
+                if (dd.kind == decl.DECL_KIND_UNI) {
+                    stamp = check_occurs(sc, sc.decl_type[d], dd.data.uni_.fields_start,
+                                         dd.data.uni_.fields_len, seen, cap, stamp);
+                }
+            }
+        }
+        d = d + 1;
+    }
+
+    A.deallocate[u32](sc.s.alloc, seen, cap::usize);
 }
 
 # enforce the mixed-secrecy union rule on every union the module forms - named
@@ -225,9 +421,31 @@ fun check_uni_secrecy(sc: *context.SemaContext, fields_start: u32, fields_len: u
 # Named declarations are filtered by `decl_type`, which `infer_all_decls` wrote for the
 # decls it actually typed: an untaken comptime-`$if` arm is left at TYPE_NIL and stays
 # unchecked, matching the rule that a discarded branch is not compiled.
+#
+# The stamp array backs the per-variant cycle test `check_uni_secrecy` uses to skip a
+# variant whose extent is undeterminable because the union contains itself (#2356);
+# allocating it here keeps the pass to one allocation. A failed allocation runs the
+# rule with no skip, which is the previous behaviour: a false report on an already
+# rejected type, never a missed one.
 # ---
 # sc: sema context
 pub fun check_uni_secrecy_all(sc: *context.SemaContext) {
+    # cap stays 0 when there is no array to index, which `reaches_nominal` reads as
+    # "no nominal is expandable" and answers false to - the pre-#2356 behaviour.
+    var seen: *u32 = nil;
+    var cap:  u32  = 0;
+    if (sc.s.types.type_len > 0) {
+        val res: R.Result[*u32, str] = A.allocate[u32](sc.s.alloc, sc.s.types.type_len::usize);
+        if (R.is_ok[*u32, str](res)) {
+            seen = R.unwrap_ok[*u32, str](res);
+            cap  = sc.s.types.type_len;
+            var z: u32 = 0;
+            for (z < cap) { seen[z] = 0; z = z + 1; }
+        }
+    }
+    # stamps start at 1 so the zeroed array reads as "never expanded"
+    var stamp: u32 = 1;
+
     if (sc.decl_type != nil) {
         var d: u32 = 0;
         for (d < sc.a.decl_len::u32) {
@@ -236,7 +454,8 @@ pub fun check_uni_secrecy_all(sc: *context.SemaContext) {
                 if (O.is_some[*decl.Decl](d_opt)) {
                     val dd: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
                     if (dd.kind == decl.DECL_KIND_UNI) {
-                        check_uni_secrecy(sc, dd.data.uni_.fields_start, dd.data.uni_.fields_len);
+                        stamp = check_uni_secrecy(sc, sc.decl_type[d], dd.data.uni_.fields_start,
+                                                  dd.data.uni_.fields_len, seen, cap, stamp);
                     }
                 }
             }
@@ -250,11 +469,14 @@ pub fun check_uni_secrecy_all(sc: *context.SemaContext) {
         if (O.is_some[*atype.Type](t_opt)) {
             val t: *atype.Type = O.unwrap[*atype.Type](t_opt);
             if (t.kind == atype.TYPE_KIND_UNI) {
-                check_uni_secrecy(sc, t.data.uni_.fields_start, t.data.uni_.fields_len);
+                stamp = check_uni_secrecy(sc, sc.type_resolved_ty[i], t.data.uni_.fields_start,
+                                          t.data.uni_.fields_len, seen, cap, stamp);
             }
         }
         i = i + 1;
     }
+
+    if (seen != nil) { A.deallocate[u32](sc.s.alloc, seen, cap::usize); }
 }
 
 # fold an `#[align(...)]` decorator on `did` and record the resulting alignment


### PR DESCRIPTION
Closes #2355. Also closes #2356 — see below.

## The defect, refined

At `dev` `01d75af2` the behaviour is worse than the issue records — both of #620 item 7's symptoms are live at once:

| program | before |
|---|---|
| `rec R { next: R; }` **declared, unused** | **compiles clean** — silently accepted |
| `rec R { next: R; }` **used** | SIGSEGV, **no diagnostic at all** |

The crash reproduces identically at **8 MB, 64 MB and 256 MB** stack. That sweep is the evidence that this is genuinely unbounded recursion in `lower_type` ↔ `lower_nominal` rather than a merely deep walk that a larger stack would survive — which is what distinguishes it from #2368.

**The issue's stated mechanism is wrong on one point, and it matters.** `layout.walk` returning "unknown" is *not* what let this reach lowering. `layout.walk` is innocent — see the audit below. The gap is sharper than a leaky fallback: **sema never sizes a `rec` declaration at all on the path to lowering, because there is no well-formedness check on nominal declarations whatsoever.** Nothing was consulted and answered badly; nothing was consulted.

## The fix

A sema occurs-check over the **declaration** graph (Rust's E0072 rule): a `rec`/`uni` may not reach itself by value.

- **By value is the whole distinction.** A nominal, a generic instance, or an array of one stores the contained bytes inline. A pointer or function value stores an address, so `rec Node { next: *Node; }` terminates and stays legal.
- **Over declarations, not instances.** `rec Wrap[T] { inner: Wrap[Wrap[T]]; }` mints a fresh instance TypeId at every level, so an instance-graph walk descends forever and never revisits a node — there is no cycle in that graph to find. Resolving each instance to the nominal it instantiates makes it a self-edge caught at the first step.
- **No depth bound.** Visited marks are generation-stamped rather than a bounded path stack. A depth cap would have converted a crash into an arbitrary rejection while leaving the type ill-formed — and would have reintroduced the defect described under "found, not fixed" below.

Runs after `infer_all_decls` (field tables complete, so declaration-order independent) and deliberately **before** `check_uni_secrecy_all`.

## The diagnostic

```
error: recursive type has infinite size: this field contains the type being declared by value,
so the type would have to contain itself; store it behind a pointer (`*T`) to break the cycle
 --> ./src/main.mach:5:9
  |
5 | rec R { next: R; }
  |         ^^^^
```

Reported per field, on the field's own span. A mutually recursive pair reports on both declarations, each independently ill-formed.

## Behaviour

| rejected | accepted (unchanged) |
|---|---|
| `rec R { next: R; }` (used *and* unused) | `rec Node { next: *Node; }` |
| `uni U { a: u32; b: U; }` | `uni U { a: u32; b: *U; }` |
| `rec R { a: [4]R; }` | `rec R { a: [4]*R; }` |
| `rec A { b: B; } rec B { a: A; }` | `rec A { b: *B; } rec B { a: *A; }` |
| `rec A{b:B} rec B{c:C} rec C{a:A}` | diamond: `D{x:L;y:Rt}`, both → `Leaf` |
| `rec W[T] { v: T; inner: W[T]; }` | ordinary nesting at any depth |
| `rec Wrap[T] { inner: Wrap[Wrap[T]]; }` | `rec R { f: fun() *R; }` |
| `rec R { a: rec { b: R; }; }` | |

## #2356 closed as a consequence

`uni U[T] { a: u32; b: U[U[T]]; }` was rejected as a **mixed-secrecy violation in a program containing no `^`**. Root cause: `type_extent` cannot size an infinite type → the deep placement comparison fails closed → the union rule reports its own precondition. The fail-closed *decision* is right; the *message* asserts a cause it never established.

The occurs-check alone was **not** sufficient — it made the program report two errors, the right one and the wrong one. So `check_uni_secrecy` now skips a variant that provably closes a by-value cycle with the union itself, since such a union is already rejected with its real cause.

**Only that provably-cyclic case is skipped.** Every other undeterminable extent still fails closed — this rule guards a disclosure channel and is not loosened into a permissive default. Pinned: genuine mixed-secrecy unions (shallow and #2165-deep) still reject, and a recursive union whose variants *also* genuinely disagree still reports the secrecy error.

## Found here, fixed elsewhere — #2368 and #2369

**A legal, finite, sizeable type deeper than 64 crashes the compiler.**

```
rec N0 { v: u8; }  rec N1 { v: N0; }  ...  rec N64 { v: N63; }
```

Depth 64 builds; **depth 65 prints `ir.type.byte_size: type id out of range` and then SIGSEGVs.** That is `layout.MAX_DEPTH = 64` exactly. Nothing is recursive — an ordinary deep nest is rejected by an arbitrary bound, and the panic **names the wrong cause**: `ir_extent` passes one `what` string that assumes a stale handle, but `!ok` has four distinct causes and "past the depth bound" is the one that fired. This PR does **not** fix it — a 65-deep nest has no cycle. Filed as **#2368**.

Separately, `panic` exits **139 (SIGSEGV)** rather than aborting cleanly, which makes every panic look like a memory bug. Filed as **#2369**.

## `layout.walk` audit (the bar item)

Three call sites, **none silently accepts `ok = false`**:

- `me/ir/type.mach` — `byte_size` / `byte_align` / `byte_offset` **panic**.
- `fe/sema/generics.mach` — the deep secrecy comparison **fails closed**.

The fallback is not masking silent acceptance. What it *was* masking is a false report with the wrong cause — #2356, fixed here.

## Verification

**Mutation-tested; every clause is load-bearing.** Control: all four probes correct.

| mutation | effect |
|---|---|
| pass never called | all three illegal forms SIGSEGV again |
| array descent removed | `rec R { a: [4]R; }` SIGSEGVs; others still caught |
| instance→nominal mapping removed | `Wrap[Wrap[T]]` SIGSEGVs; others still caught |
| pointers descend | **legal `rec Node { next: *Node; }` rejected** |
| #2356 cycle-skip removed | recursive union reports 2 errors again |

**Tests discriminate for the right reason.** Reverting only `sema.mach` + `infer.mach` to `origin/dev` and keeping the tests: **952 passed, 2 failed, 954 total**. The int case fails against `dev` with *"build failed without an `error:` diagnostic"* and the harness prints the core dump — `build-fails` demands an `error:` line a segfault cannot produce. (The linked-list case passes both ways by design: it is a preservation pin, not a discriminator.)

- compiler suite **954 / 0** (952 + 2 new)
- mach-std **611 / 0** at pin `eff1e8e` via `git archive`
- three-generation fixpoint **b == c**
- int suite green on **linux** and **windows** legs; `linux-arm64` needs an arm64 host and `linux-riscv64` qemu — CI covers both
- **15 / 15 binaries byte-identical** m0 vs m1 across linux / linux-arm64 / windows, for programs with no recursive types
