### PR TITLE
docs(sema): tie the occurs-check's unbounded walk to #2368

### DIFF
--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -191,7 +191,9 @@ fun infer_nominal_uni(sc: *context.SemaContext, did: id.DeclId, name_span: token
 # The visited marks are generation-stamped rather than cleared per query, and the
 # recursion is bounded by the number of distinct nominals rather than by a constant,
 # so a legal 200-deep nest costs 200 frames and is accepted. A fixed depth cap here
-# would reject well-formed programs.
+# would reject well-formed programs - which is not hypothetical: `layout.walk`'s
+# MAX_DEPTH does exactly that to a 65-deep nest today (#2368). Terminating on the
+# structure rather than on a constant is what makes this rule exact.
 # ---
 # s:      the session (type universe)
 # seen:   per-TypeId stamp of the query that last expanded that nominal


### PR DESCRIPTION
A three-line comment cross-reference that missed #2375 by a few minutes.

The occurs-check landed in #2375 using a generation-stamped visited array specifically so it imposes **no depth bound**. That choice is not stylistic, and the comment now says why with a concrete referent: `layout.walk`'s `MAX_DEPTH` rejects a legal 65-deep struct nest today (**#2368**) — precisely the defect a bounded scan in the occurs-check would have reproduced.

Without the pointer, the next person to read the stamp array sees machinery where a simple depth counter would seem to do, and the reason it is not a depth counter lives only in a merged PR description.

Comment only; no behaviour change. Compiler suite **954 / 0**.