### PR TITLE
fix(lower): re-type a `$each $fields` body per element, in every unroll (#2376)

### DIFF
--- a/int/regression/2376-fields-each-per-element/expect.txt
+++ b/int/regression/2376-fields-each-per-element/expect.txt
@@ -1,0 +1,8 @@
+generic  M4  equal   = 0
+concrete M4  equal   = 0
+generic  M4  differ  = 1 2 3 4
+concrete M4  differ  = 1 2 3 4
+generic  M4R equal   = 0
+generic  M3  equal   = 0
+generic  I4  equal   = 0
+generic  F4  equal   = 0

--- a/int/regression/2376-fields-each-per-element/mach.toml
+++ b/int/regression/2376-fields-each-per-element/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case2376"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2376-fields-each-per-element/src/main.mach
+++ b/int/regression/2376-fields-each-per-element/src/main.mach
@@ -1,0 +1,110 @@
+# regression pin for #2376: a `$each f in $fields(T)` body is typed PER ELEMENT
+#
+# The typing arrays hold one stamp per expression node, and both sema's unroll and
+# lowering's walk the same body once per field. Whatever the last field left in
+# those slots was what every emitted copy read, so `a.[f]` loaded every field at
+# the LAST field's type: `load f32` for a record ending in `f32`, `load i32` for
+# one ending in `i32` (verified in the emitted IR both ways).
+#
+# Reading identical bytes at the wrong type still compares EQUAL for almost every
+# type, which is why this survived so long. It becomes visible exactly when the
+# wrong type turns a bit pattern into a NaN, since `NaN != NaN`: `M4`'s first
+# field holds `i32 -2` = 0xFFFFFFFE, which read as `f32` is a NaN, so a record
+# compared against itself reported field 1 unequal. `M3` is the same defect with
+# the same values and reports nothing, because 0xFFFFFFFE read as part of an `f64`
+# is a denormal rather than a NaN - so the "correct" shapes here are pinning
+# coverage, not corroborating evidence.
+#
+# Both unrolls are covered on purpose. The generic one regressed at #2286 (which
+# republished the typing arrays with the concrete type, flipping the unroll off
+# the per-element re-inference path that had been hiding the defect); the concrete
+# one has been wrong in every released compiler, v4.2.2 included.
+#
+# The unequal cases are what keep this honest: a compare that always answered
+# "equal" would pass every want-0 line above them.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+rec M4  { i: i32; u: u16; f: f64; g: f32; }
+rec M4R { g: f32; f: f64; u: u16; i: i32; }
+rec M3  { i: i32; u: u16; f: f64; }
+rec I4  { a: i32; b: i32; c: i32; d: i32; }
+rec F4  { a: f64; b: f64; c: f64; d: f64; }
+
+# the 1-based index of the first field that compares unequal, 0 when all match --
+# std.derive.eq's shape, with the index reported so a wrong answer names the field
+fun gfirst[T](a: *T, b: *T) i64 {
+    var idx: i64 = 0;
+    $each f in $fields(T) {
+        idx = idx + 1;
+        if (a.[f] != b.[f]) { ret idx; }
+    }
+    ret 0;
+}
+
+# the same unroll over a CONCRETE record: no generics, so nothing defers and the
+# body is typed by the module sema pass alone
+fun cfirst(a: *M4, b: *M4) i64 {
+    var idx: i64 = 0;
+    $each f in $fields(M4) {
+        idx = idx + 1;
+        if (a.[f] != b.[f]) { ret idx; }
+    }
+    ret 0;
+}
+
+fun mk_m4(i: i32, u: u16, f: f64, g: f32) M4 {
+    var v: M4;
+    v.i = i;
+    v.u = u;
+    v.f = f;
+    v.g = g;
+    ret v;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var a4: M4 = mk_m4(-2, 9, 1.5, 2.5);
+    var b4: M4 = mk_m4(-2, 9, 1.5, 2.5);
+    p.printlnf("generic  M4  equal   = {}", gfirst[M4](?a4, ?b4));
+    p.printlnf("concrete M4  equal   = {}", cfirst(?a4, ?b4));
+
+    # each field differing in turn must be REPORTED, and reported at its own index
+    var d1: M4 = mk_m4(-3, 9, 1.5, 2.5);
+    var d2: M4 = mk_m4(-2, 8, 1.5, 2.5);
+    var d3: M4 = mk_m4(-2, 9, 2.5, 2.5);
+    var d4: M4 = mk_m4(-2, 9, 1.5, 3.5);
+    p.printlnf("generic  M4  differ  = {} {} {} {}",
+        gfirst[M4](?a4, ?d1), gfirst[M4](?a4, ?d2), gfirst[M4](?a4, ?d3), gfirst[M4](?a4, ?d4));
+    p.printlnf("concrete M4  differ  = {} {} {} {}",
+        cfirst(?a4, ?d1), cfirst(?a4, ?d2), cfirst(?a4, ?d3), cfirst(?a4, ?d4));
+
+    # the reversed field order: the mistyped load was the LAST field's type, so
+    # this shape mistyped everything as `i32` instead of `f32`
+    var ar: M4R;
+    ar.g = 2.5; ar.f = 1.5; ar.u = 9; ar.i = -2;
+    var br: M4R;
+    br.g = 2.5; br.f = 1.5; br.u = 9; br.i = -2;
+    p.printlnf("generic  M4R equal   = {}", gfirst[M4R](?ar, ?br));
+
+    var a3: M3;
+    a3.i = -2; a3.u = 9; a3.f = 1.5;
+    var b3: M3;
+    b3.i = -2; b3.u = 9; b3.f = 1.5;
+    p.printlnf("generic  M3  equal   = {}", gfirst[M3](?a3, ?b3));
+
+    var ai: I4;
+    ai.a = 1; ai.b = 2; ai.c = 3; ai.d = 4;
+    var bi: I4;
+    bi.a = 1; bi.b = 2; bi.c = 3; bi.d = 4;
+    p.printlnf("generic  I4  equal   = {}", gfirst[I4](?ai, ?bi));
+
+    var af: F4;
+    af.a = 1.0; af.b = 2.0; af.c = 3.0; af.d = 4.0;
+    var bf: F4;
+    bf.a = 1.0; bf.b = 2.0; bf.c = 3.0; bf.d = 4.0;
+    p.printlnf("generic  F4  equal   = {}", gfirst[F4](?af, ?bf));
+    ret 0;
+}

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -156,7 +156,7 @@ pub fun lower_fun(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, is_
     # an external function carries no body
     if ((flags & ir.FN_FLAG_EXTERN) != 0) { ret R.ok[bool, str](true); }
 
-    ret emit_function_body(ctx, did, d, fn_index, ret_ir, type.TYPE_NIL);
+    ret emit_function_body(ctx, did, d, fn_index, ret_ir, context.decl_ret_sem(ctx, did));
 }
 
 # lower one monomorphized generic instance: a concrete body for the template
@@ -193,7 +193,7 @@ pub fun lower_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl
 # name: the instance's mangled linkage name
 # ret:  true on success, or an error
 pub fun lower_value_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, name: intern.StrId) R.Result[bool, str] {
-    ret lower_weak_instance(ctx, did, d, name, type.TYPE_NIL);
+    ret lower_weak_instance(ctx, did, d, name, context.decl_ret_sem(ctx, did));
 }
 
 # lower one comptime variadic-pack instance: a concrete body for the pack-tailed
@@ -487,9 +487,12 @@ fun lower_weak_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Dec
 #
 # Shared by the concrete function and the generic / value instance lowerings. The
 # pack instance manages its own parameter expansion and does not use this.
-# `ret_sem` is the semantic return type published for deferred `$each $fields(T)`
-# body re-inference (#1523); it is TYPE_NIL for a function or value instance and
-# the substituted return type for a generic instance.
+# `ret_sem` is the semantic return type published for `$each $fields(T)` body
+# re-inference (#1523, #2376), which type-checks the body's `ret`s against it: the
+# substituted return type inside a generic instance, the declared one otherwise.
+# Every function that can carry such a body must publish it - a `$fields` unroll
+# is re-typed per element in a plain function too, and a TYPE_NIL here would check
+# its `ret`s against a void return.
 # ---
 # ctx:     the context
 # did:     the function's DeclId

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -694,16 +694,15 @@ fun lower_comptime_each(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool
     }
     val fname: intern.StrId = R.unwrap_ok[intern.StrId, str](res_name);
 
-    # build a module-spanning typing snapshot for deferred body re-inference;
-    # mirrors the pack case -- the body was not typed at template sema.
+    # build a module-spanning typing snapshot for the per-element body re-inference,
+    # so a body that calls across modules resolves those signatures; mirrors the pack
+    # case.
     var deps: sema.SemaDeps;
-    if (deferred) {
-        val res_deps: R.Result[sema.SemaDeps, str] = sema.collect_module_deps(ctx.s);
-        if (R.is_err[sema.SemaDeps, str](res_deps)) {
-            ret R.err[bool, str](R.unwrap_err[sema.SemaDeps, str](res_deps));
-        }
-        deps = R.unwrap_ok[sema.SemaDeps, str](res_deps);
+    val res_deps: R.Result[sema.SemaDeps, str] = sema.collect_module_deps(ctx.s);
+    if (R.is_err[sema.SemaDeps, str](res_deps)) {
+        ret R.err[bool, str](R.unwrap_err[sema.SemaDeps, str](res_deps));
     }
+    deps = R.unwrap_ok[sema.SemaDeps, str](res_deps);
 
     val n: u32 = type.field_count(?ctx.s.types, owner);
     var i: u32 = 0;
@@ -712,36 +711,46 @@ fun lower_comptime_each(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool
         val res_bind: R.Result[bool, str] = comptime.bind(ctx.ctx, fname, comptime.field_value(owner::u32, i));
         if (R.is_err[bool, str](res_bind)) {
             val res_close: R.Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
-            if (deferred)                       { sema.free_module_deps(ctx.s, ?deps); }
+            sema.free_module_deps(ctx.s, ?deps);
             if (R.is_err[bool, str](res_close)) { ret res_close; }
             ret res_bind;
         }
-        if (deferred) {
-            # re-type the body for this field (deferred at template sema), writing
-            # expression types into the shared array lowering reads next.
-            val res_reinfer: R.Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, ?deps, ctx.ctx,
-                ctx.own_module, ctx.sema_result, ctx.fn_ret_sem, ce.body_start, ce.body_len,
-                ctx.subst, ctx.subst_len, ctx.ct_insts);
-            if (R.is_err[bool, str](res_reinfer)) {
-                val res_close: R.Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
-                sema.free_module_deps(ctx.s, ?deps);
-                if (R.is_err[bool, str](res_close)) { ret res_close; }
-                ret res_reinfer;
-            }
+
+        # re-type the body for THIS field before emitting it (#2376).
+        #
+        # The body's types are per element - `a.[f]` is the field's own type - but the
+        # typing arrays hold one stamp per expression node. Sema's own unroll writes
+        # every element's types into those same slots in turn, so what survives its
+        # loop is the LAST field's, and emitting all N copies from that reads every
+        # field at the last field's type. Comparing identical bytes at the wrong type
+        # still answers "equal" for most types, which is why this stayed invisible
+        # until a record whose last field is `f32` made an `i32` payload read back as
+        # a NaN. Re-typing per element is the same episode the deferred (generic)
+        # unroll already ran; the requirement was never "was this deferred", it is
+        # "the stamps are per element".
+        val res_reinfer: R.Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, ?deps, ctx.ctx,
+            ctx.own_module, ctx.sema_result, ctx.fn_ret_sem, ce.body_start, ce.body_len,
+            ctx.subst, ctx.subst_len, ctx.ct_insts);
+        if (R.is_err[bool, str](res_reinfer)) {
+            val res_close: R.Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
+            sema.free_module_deps(ctx.s, ?deps);
+            if (R.is_err[bool, str](res_close)) { ret res_close; }
+            ret res_reinfer;
         }
+
         val res_body: R.Result[bool, str] = lower_stmt_list(ctx, ce.body_start, ce.body_len);
         val res_close: R.Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
         if (R.is_err[bool, str](res_body)) {
-            if (deferred) { sema.free_module_deps(ctx.s, ?deps); }
+            sema.free_module_deps(ctx.s, ?deps);
             ret res_body;
         }
         if (R.is_err[bool, str](res_close)) {
-            if (deferred) { sema.free_module_deps(ctx.s, ?deps); }
+            sema.free_module_deps(ctx.s, ?deps);
             ret res_close;
         }
         i = i + 1;
     }
-    if (deferred) { sema.free_module_deps(ctx.s, ?deps); }
+    sema.free_module_deps(ctx.s, ?deps);
     ret R.ok[bool, str](true);
 }
 


### PR DESCRIPTION
Closes #2376.

## What the IR says

Every field of the M4 instance was compared **as `f32`** — the type of the record's LAST field:

```
%11 = load f32 ...        <- field 1, declared i32
%15 = cmp_ne i8 %11: f32, %14: f32
%25 = load f32 ...        <- field 2, declared u16
%39 = load f32 ...        <- field 3, declared f64
%53 = load f32 ...        <- field 4, declared f32   (the only correct one)
```

Reverse the record — `rec M4R { g: f32; f: f64; u: u16; i: i32; }` — and every field loads as `i32`. **The whole unrolled body carried one type stamp: the last element's.**

## Why the four-field mixed shape specifically

It is not the field count and not mixing per se. It is **whether the wrong type turns identical bytes into a NaN**. Comparing identical memory at the wrong type still answers "equal" for every type except a float pattern that is NaN, and `NaN != NaN`:

- **M4** — last field `f32`, so field 1's `i32 -2` = `0xFFFFFFFE` read as `f32` is a **NaN** → reports unequal. Visible.
- **M3** — last field `f64`, so field 1 is read as `{i32 -2, u16 9, pad}` = `0x00000009FFFFFFFE`, a denormal, **not** NaN → equal → passes by luck. Same bug, invisible.
- **I4 / I5 / F4** — homogeneous, so "the last element's type" *is* every element's type. Same bug, unobservable.

The three "correct" shapes in the issue are not correct; they are silently mistyped in a way that happens to compare equal.

## Root cause, and why the bisect points where it does

A `$each f in $fields(T)` body's types are per element, but the typing arrays hold **one stamp per expression node**. Sema's unroll (`infer_stmt_comptime_each`) writes each field's types into those same slots in turn, so only the last field's survive; lowering unrolls again and emits all N copies from that single stamp.

The per-element re-typing episode already existed — it was gated on `deferred`, meaning *"was this unroll deferred at template sema because T was still a generic parameter"*. That was never the right question: the requirement is that the stamps are per element, which is just as true for a concrete `$fields(M4)`.

So the **concrete** unroll has been miscompiling in every released compiler:

| compiler | generic `$fields(T)` | concrete `$fields(M4)` |
|---|---|---|
| released seed **4.2.2** | correct | **WRONG** |
| bisect parent `dda66e3d` | correct | **WRONG** |
| dev `38ddef46` | **WRONG** | **WRONG** |

#2286 republished the shared typing arrays with the concrete type, which flipped `deferred` from true to false and let the **generic** path inherit the pre-existing bug. It exposed the defect rather than creating it — nothing to revert, and #2286's own fixes stand.

## The fix

Re-type the body per element in **every** `$fields` unroll. `deferred` keeps what it actually decides: substituting the owner type, and skipping a template body lowered directly.

That makes `fn_ret_sem` load-bearing for every function, not just generic instances — the re-inference checks the body's `ret`s against it, and a plain function left it `TYPE_NIL`, which reported every `ret` in such a body against a void return. `lower_fun` and `lower_value_instance` now publish the declared (substituted) return type like the generic path already did.

## Verification

- **Both faces gone**: correct answers at `opt=0`, no `constant carries an incompatible type` at `opt=2`. The issue's own reproducer returns 0 for all seven shapes at both profiles.
- **The real acceptance test**: mach-std `dev` (a separate clone, never `dep/mach-std`) built by this compiler → **679 passed / 0 failed**, up from 677/2. `eq: heterogeneous fields` and `eq: signed zero compares equal, NaN never equal` both pass.
- **Regression case** `int/regression/2376-fields-each-per-element`, covering both unrolls and both field orders, with unequal cases that discriminate: pre-fix they read `1 1 1 1` (every field reported at index 1 — the signature of one stamp for the whole body) against the correct `1 2 3 4`. Fails pre-fix on dev at debug (wrong answers) and at release (build error).
- **All three ISAs**: x86_64 and riscv64 through the harness, aarch64 under `qemu-aarch64`, both profiles. Pre-fix aarch64 reproduces the same wrong answers.
- **Mutation-tested**: re-gate the per-element re-typing on `deferred` → **0/2** (wrong answers return); drop `fn_ret_sem` for a plain function → **0/2** (spurious void-return errors).
- **Objects byte-identical**: 215 objects across mach + mach-std at pin, baseline-dev vs this compiler, `diff -r` clean. Neither tree uses `$each` over `$fields` outside test strings, so the fix is inert for them — the delta is confined to code that uses the construct.
- **Fixpoint** gen2 == gen3 byte-identical; **suites** mach 954/0, mach-std **611/0** at pin `eff1e8e`; full int suite green on linux, riscv64 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ntqq8dS4TDqoYPsx3JpVy4
