### PR TITLE
fix(layout): give the depth bound to the caller, and name the real failure cause

### DIFF
--- a/int/regression/2368-deep-nest/expect.txt
+++ b/int/regression/2368-deep-nest/expect.txt
@@ -1,0 +1,3 @@
+deep=42
+second=7
+first_again=42

--- a/int/regression/2368-deep-nest/mach.toml
+++ b/int/regression/2368-deep-nest/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case2368"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2368-deep-nest/src/main.mach
+++ b/int/regression/2368-deep-nest/src/main.mach
@@ -1,0 +1,106 @@
+# regression pin for #2368: a struct nest deeper than the old layout depth bound
+#
+# `layout.walk` carried one MAX_DEPTH = 64 for every caller. The IR type universe is
+# acyclic by construction - `intern_struct` copies a field list whose ids all exist,
+# so an aggregate id is always greater than every id it references - and never needed
+# a bound at all; the constant only ever refused legal input. At 65 levels the compiler
+# panicked "ir.type.byte_size: type id out of range", naming a stale handle for what
+# was a depth failure, and then faulted (#2369).
+#
+# WHY 70 LEVELS AND NOT 65. Past the old bound with room to spare, so the case still
+# discriminates if someone reintroduces a bound at a slightly larger constant.
+#
+# The chain is WRITTEN AND READ at full depth, not merely declared: sizing a deep type
+# is one thing, computing every field offset down the chain is another, and a case that
+# only declared the variable would pass on a compiler that sized it right and addressed
+# it wrong.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+rec N0 { v: u8; }
+rec N1 { v: N0; }
+rec N2 { v: N1; }
+rec N3 { v: N2; }
+rec N4 { v: N3; }
+rec N5 { v: N4; }
+rec N6 { v: N5; }
+rec N7 { v: N6; }
+rec N8 { v: N7; }
+rec N9 { v: N8; }
+rec N10 { v: N9; }
+rec N11 { v: N10; }
+rec N12 { v: N11; }
+rec N13 { v: N12; }
+rec N14 { v: N13; }
+rec N15 { v: N14; }
+rec N16 { v: N15; }
+rec N17 { v: N16; }
+rec N18 { v: N17; }
+rec N19 { v: N18; }
+rec N20 { v: N19; }
+rec N21 { v: N20; }
+rec N22 { v: N21; }
+rec N23 { v: N22; }
+rec N24 { v: N23; }
+rec N25 { v: N24; }
+rec N26 { v: N25; }
+rec N27 { v: N26; }
+rec N28 { v: N27; }
+rec N29 { v: N28; }
+rec N30 { v: N29; }
+rec N31 { v: N30; }
+rec N32 { v: N31; }
+rec N33 { v: N32; }
+rec N34 { v: N33; }
+rec N35 { v: N34; }
+rec N36 { v: N35; }
+rec N37 { v: N36; }
+rec N38 { v: N37; }
+rec N39 { v: N38; }
+rec N40 { v: N39; }
+rec N41 { v: N40; }
+rec N42 { v: N41; }
+rec N43 { v: N42; }
+rec N44 { v: N43; }
+rec N45 { v: N44; }
+rec N46 { v: N45; }
+rec N47 { v: N46; }
+rec N48 { v: N47; }
+rec N49 { v: N48; }
+rec N50 { v: N49; }
+rec N51 { v: N50; }
+rec N52 { v: N51; }
+rec N53 { v: N52; }
+rec N54 { v: N53; }
+rec N55 { v: N54; }
+rec N56 { v: N55; }
+rec N57 { v: N56; }
+rec N58 { v: N57; }
+rec N59 { v: N58; }
+rec N60 { v: N59; }
+rec N61 { v: N60; }
+rec N62 { v: N61; }
+rec N63 { v: N62; }
+rec N64 { v: N63; }
+rec N65 { v: N64; }
+rec N66 { v: N65; }
+rec N67 { v: N66; }
+rec N68 { v: N67; }
+rec N69 { v: N68; }
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var x: N69;
+    x.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v = 42;
+    p.printlnf("deep={}", x.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v::u64);
+
+    # a second, independently addressed chain: proves the offsets are per-type and
+    # not a single memoised answer reused for every nest
+    var y: N69;
+    y.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v = 7;
+    p.printlnf("second={}", y.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v::u64);
+    p.printlnf("first_again={}", x.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v.v::u64);
+    ret 0;
+}

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -477,6 +477,20 @@ fun describe_type_field(ctx: ptr, id: u32, index: u32) u32 {
     ret O.unwrap[*type.FieldEntry](fe).ty::u32;
 }
 
+# the depth past which a semantic-type layout walk declines
+#
+# CYCLE PROTECTION, NOT A LAYOUT RULE, and the reason this walk is bounded where the IR
+# one is not (#2368). `me.ir.type` interns an aggregate only after every field id exists,
+# so its graph is a DAG and terminates on its own structure. The SEMANTIC universe cannot
+# promise that: the occurs-check reports a by-value cyclic type (#2355) but leaves it
+# interned, and a later rule - a `::` / `:~` placement comparison, say - can still reach
+# one. Without a bound that walk would not return.
+#
+# It therefore refuses a legal nest deeper than this, which is a real if remote limit.
+# Removing it needs the cyclic type withdrawn from the universe at the point the
+# occurs-check reports it, not a larger constant here.
+val SEMA_LAYOUT_MAX_DEPTH: u32 = 64;
+
 # the storage size and alignment of a semantic type (#2167)
 #
 # The secrecy-placement comparison needs BYTE RANGES, not field indices: two fields at
@@ -493,7 +507,8 @@ fun describe_type_field(ctx: ptr, id: u32, index: u32) u32 {
 # tid:       the type to measure
 # ret:       the determined Extent, or `ok = false` when it cannot be computed
 pub fun type_extent(s: *session.Session, ptr_width: u32, tid: type.TypeId) layout.Extent {
-    ret layout.extent_of(s::ptr, describe_type, describe_type_field, tid::u32, ptr_width);
+    ret layout.extent_of(s::ptr, describe_type, describe_type_field, tid::u32, ptr_width,
+                         SEMA_LAYOUT_MAX_DEPTH);
 }
 
 # whether nominal `tid` overlays every field at offset 0 (a union) rather than laying

--- a/src/lang/layout.mach
+++ b/src/lang/layout.mach
@@ -35,13 +35,21 @@
 #
 # THE SEAM. A caller supplies an erased context plus two accessors - one describing a
 # node, one naming a field's node - mirroring the `fun(ptr, ...)` callback the comptime
-# resolvers already use. Every walk is depth-bounded and reports `ok = false` rather
-# than guessing, so a caller that must fail closed can, and one that treats a malformed
-# graph as a compiler bug can panic on it.
+# resolvers already use. A walk reports `ok = false` with a CAUSE rather than guessing,
+# so a caller that must fail closed can, and one that treats a malformed graph as a
+# compiler bug can panic naming the real reason.
+#
+# THE DEPTH BOUND BELONGS TO THE CALLER. Termination on a cyclic graph is the caller's
+# property, not this policy's: whoever owns the node universe knows whether it can cycle.
+# A caller with an acyclic graph passes DEPTH_UNBOUNDED and no legal input is ever
+# refused; one whose graph may cycle passes its own limit. A single constant here refused
+# a legal 65-deep nest in the acyclic IR universe for the sake of the cyclic semantic one
+# (#2368).
 
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
+use std.types.string.str;
 
 # how a node occupies storage; the discriminator for `Node`
 pub def NodeKind: u8;
@@ -92,33 +100,67 @@ pub def NodeFn: fun(ptr, u32) Node;
 # context. Only called for indices below the aggregate's reported `field_count`
 pub def FieldFn: fun(ptr, u32, u32) u32;
 
+# why a walk could not determine an extent; `EXTENT_OK` when it did
+#
+# A single boolean cannot say WHICH of the failures happened, so a caller reporting one
+# had to guess - and `ir.type`'s panic guessed "stale handle" for every cause, naming a
+# handle problem when the graph was merely deeper than the bound (#2368). The cause
+# propagates unchanged out of a nested walk, so the message names the ORIGINAL reason
+# rather than "a field failed".
+pub def ExtentCause: u8;
+
+# size and alignment were determined
+pub val EXTENT_OK:             ExtentCause = 0;
+# the describer could not classify a node (NODE_UNKNOWN, or a kind this fold predates)
+pub val EXTENT_UNKNOWN_NODE:   ExtentCause = 1;
+# the graph is deeper than the caller's depth bound
+pub val EXTENT_DEPTH:          ExtentCause = 2;
+# an array's element count times its element size would not fit a u32
+pub val EXTENT_ARRAY_OVERFLOW: ExtentCause = 3;
+# a field offset was asked of a node that is not an aggregate
+pub val EXTENT_NOT_AGGREGATE:  ExtentCause = 4;
+# a field index at or past the aggregate's field count
+pub val EXTENT_FIELD_RANGE:    ExtentCause = 5;
+
 # a node's storage size and alignment, or the fact that neither could be determined
 #
-# `ok` is false when any part of the walk could not be resolved - an unknown node kind,
-# an unresolvable field, an array whose total would not fit, or a graph past the depth
-# bound. Callers that must fail closed test it; callers for whom a malformed graph is a
-# compiler bug panic on it.
+# `ok` is false when any part of the walk could not be resolved; `cause` says which of
+# the failures it was. Callers that must fail closed test `ok`; callers for whom a
+# malformed graph is a compiler bug panic, and report `cause` so the message is true.
 # ---
 # ok:    whether size and align were determined
+# cause: why not, when `ok` is false; EXTENT_OK when it is true
 # size:  the size in bytes
 # align: the alignment in bytes (>= 1 when ok)
 pub rec Extent {
     ok:    bool;
+    cause: ExtentCause;
     size:  u32;
     align: u32;
 }
 
-# the depth bound on a layout walk; a graph deeper than this reports `ok = false`
-val MAX_DEPTH: u32 = 64;
+# passed as `max_depth` by a caller whose node graph cannot contain a cycle, so the walk
+# runs to the graph's own depth and no legal input is ever refused
+#
+# A depth bound is cycle protection, not a layout rule, so it belongs to the caller that
+# knows whether its graph can cycle - not to this policy as one constant for everyone.
+# `me.ir.type` interns a struct only after every field id exists, so a field id is always
+# SMALLER than the aggregate's own: the IR graph is a DAG by construction and passes this.
+# `fe.sema` cannot: a by-value cyclic type is reported by the occurs-check (#2355) but
+# stays in the type universe, so a later walk can still reach one and must bound itself.
+pub val DEPTH_UNBOUNDED: u32 = 0;
 
 # the largest total an array may occupy; a bigger product would wrap a u32 and report a
 # wrong extent, so it declines instead
 val MAX_SIZE: u64 = 4294967295;
 
-# an Extent that could not be determined
-pub fun unknown_extent() Extent {
+# an Extent that could not be determined, carrying the reason
+# ---
+# cause: why the walk could not answer
+pub fun unknown_extent(cause: ExtentCause) Extent {
     var e: Extent;
     e.ok    = false;
+    e.cause = cause;
     e.size  = 0;
     e.align = 0;
     ret e;
@@ -128,6 +170,7 @@ pub fun unknown_extent() Extent {
 pub fun extent(size: u32, align: u32) Extent {
     var e: Extent;
     e.ok    = true;
+    e.cause = EXTENT_OK;
     e.size  = size;
     e.align = align;
     ret e;
@@ -168,9 +211,11 @@ pub fun round_up(value: u32, align: u32) u32 {
 # field:     names an aggregate's field node ids
 # id:        the node to measure
 # ptr_width: the target's pointer width in bytes
-# ret:       the determined Extent, or `ok = false` when it cannot be computed
-pub fun extent_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32) Extent {
-    ret walk(ctx, describe, field, id, ptr_width, 0);
+# max_depth: the depth past which the walk declines; DEPTH_UNBOUNDED for an acyclic graph
+# ret:       the determined Extent, or `ok = false` with a cause when it cannot be computed
+pub fun extent_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32,
+                  max_depth: u32) Extent {
+    ret walk(ctx, describe, field, id, ptr_width, 0, max_depth);
 }
 
 # the byte offset of field `field_ix` within aggregate node `id`
@@ -184,29 +229,38 @@ pub fun extent_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width
 # id:        the aggregate node
 # field_ix:  the zero-based field index
 # ptr_width: the target's pointer width in bytes
-# ret:       an Extent whose `size` is the offset, or `ok = false` when undeterminable
-pub fun field_offset_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, field_ix: u32, ptr_width: u32) Extent {
+# max_depth: the depth past which the walk declines; DEPTH_UNBOUNDED for an acyclic graph
+# ret:       an Extent whose `size` is the offset, or `ok = false` with a cause
+pub fun field_offset_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, field_ix: u32,
+                        ptr_width: u32, max_depth: u32) Extent {
     val n: Node = describe(ctx, id);
-    if (n.kind != NODE_AGGREGATE)  { ret unknown_extent(); }
-    if (field_ix >= n.field_count) { ret unknown_extent(); }
+    if (n.kind != NODE_AGGREGATE)  { ret unknown_extent(EXTENT_NOT_AGGREGATE); }
+    if (field_ix >= n.field_count) { ret unknown_extent(EXTENT_FIELD_RANGE); }
     if (n.overlays)                { ret extent(0, 1); }
 
     var offset: u32 = 0;
     var i:      u32 = 0;
     for (i < n.field_count) {
-        val fe: Extent = walk(ctx, describe, field, field(ctx, id, i), ptr_width, 1);
-        if (!fe.ok) { ret unknown_extent(); }
+        val fe: Extent = walk(ctx, describe, field, field(ctx, id, i), ptr_width, 1, max_depth);
+        if (!fe.ok) { ret unknown_extent(fe.cause); }
         offset = round_up(offset, fe.align);
         if (i == field_ix) { ret extent(offset, fe.align); }
         offset = offset + fe.size;
         i = i + 1;
     }
-    ret unknown_extent();
+    # field_ix < field_count was checked above, so the loop always returns; an arrival
+    # here means `describe` reported a different field_count on the second call.
+    ret unknown_extent(EXTENT_FIELD_RANGE);
 }
 
-# the recursive worker for `extent_of`, bounding the graph depth
-fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, depth: u32) Extent {
-    if (depth > MAX_DEPTH) { ret unknown_extent(); }
+# the recursive worker for `extent_of`
+#
+# `max_depth` of DEPTH_UNBOUNDED disables the depth test entirely, so an acyclic caller
+# pays nothing and no legal graph is refused. A failing child's cause propagates
+# unchanged, so a depth failure eight levels down still reports as a depth failure.
+fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, depth: u32,
+         max_depth: u32) Extent {
+    if (max_depth != DEPTH_UNBOUNDED && depth > max_depth) { ret unknown_extent(EXTENT_DEPTH); }
 
     val n: Node = describe(ctx, id);
 
@@ -216,11 +270,11 @@ fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, de
     if (n.kind == NODE_VECTOR)  { ret extent(16, 16); }
 
     if (n.kind == NODE_ARRAY) {
-        val e: Extent = walk(ctx, describe, field, n.child, ptr_width, depth + 1);
-        if (!e.ok) { ret unknown_extent(); }
+        val e: Extent = walk(ctx, describe, field, n.child, ptr_width, depth + 1, max_depth);
+        if (!e.ok) { ret unknown_extent(e.cause); }
         # widen the product: a total past a u32 would wrap and report a wrong extent.
         val total: u64 = e.size::u64 * n.count::u64;
-        if (total > MAX_SIZE) { ret unknown_extent(); }
+        if (total > MAX_SIZE) { ret unknown_extent(EXTENT_ARRAY_OVERFLOW); }
         ret extent(total::u32, e.align);
     }
 
@@ -230,8 +284,8 @@ fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, de
         var widest: u32 = 0;
         var i:      u32 = 0;
         for (i < n.field_count) {
-            val e: Extent = walk(ctx, describe, field, field(ctx, id, i), ptr_width, depth + 1);
-            if (!e.ok) { ret unknown_extent(); }
+            val e: Extent = walk(ctx, describe, field, field(ctx, id, i), ptr_width, depth + 1, max_depth);
+            if (!e.ok) { ret unknown_extent(e.cause); }
             if (e.align > align) { align = e.align; }
             if (n.overlays) {
                 if (e.size > widest) { widest = e.size; }
@@ -250,7 +304,21 @@ fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, de
     }
 
     # NODE_UNKNOWN, and any kind a future describer adds without teaching this fold.
-    ret unknown_extent();
+    ret unknown_extent(EXTENT_UNKNOWN_NODE);
+}
+
+# a short, stable name for a cause, for a caller composing a message
+# ---
+# cause: the cause to name
+# ret:   a human-readable phrase, never nil
+pub fun cause_name(cause: ExtentCause) str {
+    if (cause == EXTENT_OK)             { ret "no failure"; }
+    if (cause == EXTENT_UNKNOWN_NODE)   { ret "a type the layout policy cannot classify"; }
+    if (cause == EXTENT_DEPTH)          { ret "a type graph deeper than the walk's depth bound"; }
+    if (cause == EXTENT_ARRAY_OVERFLOW) { ret "an array whose total size does not fit in 32 bits"; }
+    if (cause == EXTENT_NOT_AGGREGATE)  { ret "a field offset asked of a non-aggregate type"; }
+    if (cause == EXTENT_FIELD_RANGE)    { ret "a field index past the aggregate's field count"; }
+    ret "an unrecorded cause";
 }
 
 # the policy's own arithmetic, pinned independently of either type universe: rounding
@@ -264,5 +332,145 @@ test "mach.lang.layout.round_up:cases" {
     if (round_up(1, 8)   != 8)  { ret 1; }
     if (round_up(16, 16) != 16) { ret 1; }
     if (round_up(17, 16) != 32) { ret 1; }
+    ret 0;
+}
+
+# a node table the cause tests describe to the policy, so each failure can be provoked
+# directly. The seam takes an erased context and two accessors, so a test supplies its
+# own graph without going through either type universe.
+var tg_nodes:  [72]Node;
+var tg_fields: [72]u32;
+
+fun tg_describe(ctx: ptr, id: u32) Node { ret tg_nodes[id]; }
+
+# every test aggregate here has exactly one field, so the index is not consulted
+fun tg_field(ctx: ptr, id: u32, index: u32) u32 { ret tg_fields[id]; }
+
+# build a chain of `n` single-field aggregates ending in a 1-byte scalar, so node 0 sits
+# at depth n-1
+fun tg_chain(n: u32) {
+    var i: u32 = 0;
+    for (i < n - 1) {
+        tg_nodes[i]             = node(NODE_AGGREGATE);
+        tg_nodes[i].field_count = 1;
+        tg_fields[i]            = i + 1;
+        i = i + 1;
+    }
+    tg_nodes[n - 1]       = node(NODE_SCALAR);
+    tg_nodes[n - 1].bytes = 1;
+}
+
+# #2368: `ok = false` had to answer for four different failures at once, so `ir.type`
+# reported "type id out of range" for every one - telling the reader a handle was stale
+# when the graph was merely deeper than the bound. Each cause must now be nameable, and
+# a cause raised deep in a walk must reach the top UNCHANGED rather than being flattened
+# into "a field failed", or the message is still wrong just less obviously.
+test "mach.lang.layout.extent:causes_are_distinguishable" {
+    # a node the describer cannot classify
+    tg_nodes[0] = node(NODE_UNKNOWN);
+    val unk: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    if (unk.ok)                            { ret 1; }
+    if (unk.cause != EXTENT_UNKNOWN_NODE)  { ret 1; }
+
+    # ...and the same cause raised one level down, through an aggregate
+    tg_nodes[0]             = node(NODE_AGGREGATE);
+    tg_nodes[0].field_count = 1;
+    tg_fields[0]            = 1;
+    tg_nodes[1]             = node(NODE_UNKNOWN);
+    val prop: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    if (prop.ok)                           { ret 1; }
+    if (prop.cause != EXTENT_UNKNOWN_NODE) { ret 1; }
+
+    # PROPAGATION PROPER, and it must be a cause the enclosing level would not have
+    # produced on its own: an aggregate over an OVERFLOWING ARRAY must report the
+    # overflow, not the unknown-node the flattening version reached for. Pairing the
+    # nested case with EXTENT_UNKNOWN_NODE alone proves nothing, since that is exactly
+    # what a walk that discards the child's cause would answer.
+    tg_nodes[0]             = node(NODE_AGGREGATE);
+    tg_nodes[0].field_count = 1;
+    tg_fields[0]            = 1;
+    tg_nodes[1]             = node(NODE_ARRAY);
+    tg_nodes[1].child       = 2;
+    tg_nodes[1].count       = 4294967295;
+    tg_nodes[2]             = node(NODE_SCALAR);
+    tg_nodes[2].bytes       = 4;
+    val prop2: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    if (prop2.ok)                             { ret 1; }
+    if (prop2.cause != EXTENT_ARRAY_OVERFLOW) { ret 1; }
+
+    # the same, through field_offset_of's own propagation path
+    val prop3: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 0, 8, DEPTH_UNBOUNDED);
+    if (prop3.ok)                             { ret 1; }
+    if (prop3.cause != EXTENT_ARRAY_OVERFLOW) { ret 1; }
+
+    # a depth failure raised below an aggregate must arrive as a DEPTH failure too
+    tg_chain(8);
+    val prop4: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 3);
+    if (prop4.ok)                    { ret 1; }
+    if (prop4.cause != EXTENT_DEPTH) { ret 1; }
+
+    # an array whose total would wrap a u32
+    tg_nodes[0]       = node(NODE_ARRAY);
+    tg_nodes[0].child = 1;
+    tg_nodes[0].count = 4294967295;
+    tg_nodes[1]       = node(NODE_SCALAR);
+    tg_nodes[1].bytes = 4;
+    val ovf: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    if (ovf.ok)                             { ret 1; }
+    if (ovf.cause != EXTENT_ARRAY_OVERFLOW) { ret 1; }
+
+    # deeper than the caller's bound
+    tg_chain(8);
+    val deep: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 3);
+    if (deep.ok)                   { ret 1; }
+    if (deep.cause != EXTENT_DEPTH) { ret 1; }
+
+    # a field offset asked of something that is not an aggregate
+    tg_nodes[0]       = node(NODE_SCALAR);
+    tg_nodes[0].bytes = 4;
+    val nag: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 0, 8, DEPTH_UNBOUNDED);
+    if (nag.ok)                            { ret 1; }
+    if (nag.cause != EXTENT_NOT_AGGREGATE) { ret 1; }
+
+    # a field index past the end
+    tg_nodes[0]             = node(NODE_AGGREGATE);
+    tg_nodes[0].field_count = 1;
+    tg_fields[0]            = 1;
+    tg_nodes[1]             = node(NODE_SCALAR);
+    tg_nodes[1].bytes       = 4;
+    val rng: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 3, 8, DEPTH_UNBOUNDED);
+    if (rng.ok)                          { ret 1; }
+    if (rng.cause != EXTENT_FIELD_RANGE) { ret 1; }
+
+    # and a determined extent carries EXTENT_OK, so `cause` is never stale from a
+    # previous failure
+    val good: Extent = extent_of(nil, tg_describe, tg_field, 1, 8, DEPTH_UNBOUNDED);
+    if (!good.ok)                 { ret 1; }
+    if (good.cause != EXTENT_OK)  { ret 1; }
+    ret 0;
+}
+
+# #2368: the depth bound is CYCLE PROTECTION and belongs to the caller, not a constant
+# every caller shares. A caller whose graph cannot cycle passes DEPTH_UNBOUNDED and the
+# walk runs to the graph's own depth - the IR type universe is such a caller, and the old
+# shared constant refused its legal 65-deep nest.
+test "mach.lang.layout.extent:unbounded_walks_past_any_constant" {
+    # 70 levels: past the 64 that used to be hardcoded, and past any bound a caller
+    # would plausibly pick
+    tg_chain(70);
+    val deep: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    if (!deep.ok)          { ret 1; }
+    if (deep.size  != 1)   { ret 1; }
+    if (deep.align != 1)   { ret 1; }
+
+    # the same graph declines under a bound below its depth, and says why
+    val bounded: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 64);
+    if (bounded.ok)                    { ret 1; }
+    if (bounded.cause != EXTENT_DEPTH) { ret 1; }
+
+    # a bound at or above the depth admits it
+    val fits: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 69);
+    if (!fits.ok)        { ret 1; }
+    if (fits.size != 1)  { ret 1; }
     ret 0;
 }

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -484,13 +484,55 @@ fun describe_field(ctx: ptr, id: u32, index: u32) u32 {
 
 # the extent of `id` under the shared policy, panicking on a graph it cannot fold
 #
-# An unresolvable extent means a stale handle or a malformed table - what the verifier's
-# VC_TYPE_RESOLVE rules out - so it panics rather than silently answering 0, preserving
-# the contract these three entry points have always had.
+# An unresolvable extent means a malformed table - what the verifier's VC_TYPE_RESOLVE
+# rules out - so it panics rather than silently answering 0, preserving the contract
+# these three entry points have always had. The panic names the CAUSE the walk reported,
+# not a fixed guess: a single "type id out of range" string was printed for every failure
+# and told the reader a handle was stale when the real answer was something else (#2368).
+#
+# DEPTH_UNBOUNDED, because the IR type graph cannot cycle. `intern_struct` copies a field
+# list whose ids all exist already, so an aggregate's id is strictly greater than every
+# id it references - the graph is a DAG and the walk terminates on its own structure. A
+# depth constant here refused a legal 65-deep nest and could never have prevented a cycle
+# that construction already rules out.
 fun ir_extent(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target, what: str) layout.Extent {
-    val e: layout.Extent = layout.extent_of(t::ptr, describe_node, describe_field, id, ptr_width_of(tgt));
-    if (!e.ok) { panic(what); }
+    val e: layout.Extent = layout.extent_of(t::ptr, describe_node, describe_field, id,
+                                            ptr_width_of(tgt), layout.DEPTH_UNBOUNDED);
+    if (!e.ok) { panic_cause(what, e.cause); }
     ret e;
+}
+
+# panic naming both the query that failed and why the layout walk could not answer it
+# ---
+# what:  the failing entry point
+# cause: the walk's reported cause
+fun panic_cause(what: str, cause: layout.ExtentCause) {
+    var buf: [256]u8;
+    var n: usize = 0;
+    n = append_str(?buf[0], n, 256, what);
+    n = append_str(?buf[0], n, 256, layout.cause_name(cause));
+    n = append_str(?buf[0], n, 256, "\n");
+    buf[n] = 0;
+    panic((?buf[0])::str);
+}
+
+# append `s` to `buf` at `n`, stopping at `cap - 1` so a terminator always fits
+# ---
+# buf: destination
+# n:   current length
+# cap: capacity of `buf`
+# s:   null-terminated source
+# ret: the new length
+fun append_str(buf: *u8, n: usize, cap: usize, s: str) usize {
+    var i: usize = 0;
+    var o: usize = n;
+    val p: *u8 = s::*u8;
+    for (p[i] != 0 && o < cap - 1) {
+        buf[o] = p[i];
+        o = o + 1;
+        i = i + 1;
+    }
+    ret o;
 }
 
 # the target's pointer width, which every layout query needs
@@ -519,7 +561,7 @@ fun ptr_width_of(tgt: *target.Target) u32 {
 # tgt: resolved compilation target supplying pointer width via its ISA
 # ret: size in bytes
 pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
-    ret ir_extent(t, id, tgt, "ir.type.byte_size: type id out of range\n").size;
+    ret ir_extent(t, id, tgt, "ir.type.byte_size: ").size;
 }
 
 # the alignment in bytes of an IR type for the given target
@@ -534,7 +576,7 @@ pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
 # tgt: resolved compilation target supplying pointer width via its ISA
 # ret: alignment in bytes (always >= 1)
 pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
-    ret ir_extent(t, id, tgt, "ir.type.byte_align: type id out of range\n").align;
+    ret ir_extent(t, id, tgt, "ir.type.byte_align: ").align;
 }
 
 # the byte offset of field `field_ix` within aggregate type `id`
@@ -550,8 +592,9 @@ pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
 # tgt:      resolved compilation target supplying pointer width via its ISA
 # ret:      byte offset of the field
 pub fun byte_offset(t: *IrTypeTable, id: IrTypeId, field_ix: u32, tgt: *target.Target) u32 {
-    val e: layout.Extent = layout.field_offset_of(t::ptr, describe_node, describe_field, id, field_ix, ptr_width_of(tgt));
-    if (!e.ok) { panic("ir.type.byte_offset: field offset of a non-aggregate type or out-of-range index\n"); }
+    val e: layout.Extent = layout.field_offset_of(t::ptr, describe_node, describe_field, id,
+                                                  field_ix, ptr_width_of(tgt), layout.DEPTH_UNBOUNDED);
+    if (!e.ok) { panic_cause("ir.type.byte_offset: ", e.cause); }
     ret e.size;
 }
 


### PR DESCRIPTION
Closes #2368.

## The two defects

**A legal, finite, sizeable type crashed the compiler.** `layout.walk` carried a single `MAX_DEPTH = 64` shared by every caller. Measured against current `dev`:

| nest depth | baseline | with this PR |
|---|---|---|
| 64 | builds | builds |
| **65** | **`ir.type.byte_size: type id out of range`, exit 139** | builds |
| 70 / 100 / 300 / 1000 | same crash | builds |

**And the panic named the wrong cause.** `ir_extent` passed one `what` string assuming a stale handle, but `!ok` had four distinct origins and "past the depth bound" was the one that fired.

## The fix: the bound belongs to the caller, not the policy

A depth bound is **cycle protection, not a layout rule**, and only the caller knows whether its node graph can cycle. So it moves out of the policy and becomes a parameter.

- **`me.ir.type` passes `DEPTH_UNBOUNDED`.** `intern_struct` copies a field list whose ids all already exist, so an aggregate's id is **strictly greater than every id it references** — the IR type graph is a DAG by construction and terminates on its own structure. The constant could never have prevented a cycle there; it only ever refused legal input.
- **`fe.sema` keeps a bound, now named and justified where it is applied.** The semantic universe *cannot* make that promise: the occurs-check reports a by-value cyclic type (#2355) but leaves it interned, so a later `::` / `:~` placement comparison can still reach one. Removing that one needs the cyclic type withdrawn from the universe at the point it is reported — a larger constant would not do it, and the comment says so.

This is why the constant **goes** rather than getting raised, per the issue's preferred outcome — but only where it was provably unnecessary.

## The causes are distinguishable

`Extent` gains a `cause`, and a cause raised deep in a walk **propagates unchanged** rather than flattening:

| cause | means |
|---|---|
| `EXTENT_UNKNOWN_NODE` | a type the layout policy cannot classify |
| `EXTENT_DEPTH` | a type graph deeper than the walk's depth bound |
| `EXTENT_ARRAY_OVERFLOW` | an array whose total size does not fit in 32 bits |
| `EXTENT_NOT_AGGREGATE` | a field offset asked of a non-aggregate type |
| `EXTENT_FIELD_RANGE` | a field index past the aggregate's field count |

The panic now reads `ir.type.byte_size: a type graph deeper than the walk's depth bound` instead of `type id out of range`. All six (including `EXTENT_OK`) are pinned by unit tests driving the policy's own seam with a purpose-built describer.

## Verification

**Mutation-tested; every clause load-bearing.** Control: 956 / 0, 65-deep builds.

| mutation | effect |
|---|---|
| aggregate arm discards the child's cause | **954 / 2** |
| `field_offset_of` discards the child's cause | **955 / 1** |
| `DEPTH_UNBOUNDED` not honoured | compiler cannot even self-test — panics building itself |
| IR call site passes `64` again | **suite stays 956 / 0**, 65-deep program fails |

That last row is why the int case exists. **The whole suite stays green under it**, because the compiler's own types are shallow — only a >64-deep program compiled end to end catches it. `int/regression/2368-deep-nest` is a 70-level nest that **writes and reads the chain at full depth**, since sizing a deep type and addressing every field down it are different claims. Against baseline it fails with the segfault and the old wrong message; with the fix it passes.

Two test-design notes worth recording, both caught by mutation rather than by review:
- the propagation case deliberately uses `EXTENT_ARRAY_OVERFLOW`, not `EXTENT_UNKNOWN_NODE`. A walk that discards the child's cause answers `UNKNOWN_NODE`, so pairing propagation with that cause proves nothing — the first version of this test passed under the mutation it was written to catch.
- the deep-nest probe must *declare a value* of the type. A program that only declares the records never reaches the IR layout query, and passes on the unfixed compiler.

- compiler suite **956 / 0** (954 + 2 new)
- mach-std **611 / 0** at pin `eff1e8e`
- three-generation fixpoint **b == c**
- int green on **linux** and **windows**; arm64 needs an arm64 host and riscv64 qemu, CI covers both
- **15 / 15 binaries byte-identical** baseline vs fixed across linux / linux-arm64 / windows, for programs nowhere near the bound

## #2369 is a separate PR in mach-std

briar-systems/mach-std#394 — `panic` ran `hlt`, a **privileged** instruction, which raises #GP → SIGSEGV → exit 139. It now exits deliberately with 255. The abort path was **not** unsound, which was the precondition for touching it.

This PR does not depend on it and does not bump the lock. The mach-side int case asserting the panic exit status has to wait for that PR to merge and the pin to move.
