### PR TITLE
refactor(isa): remove 14 dead descriptor fields, one dead record, and the comments that misdirect

### DIFF
--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -585,8 +585,8 @@ fun t_target(trust_mul: bool, trust_var_shift: bool) target.Target {
 # emitter: the whole-module payload, or nil for a register machine
 # ret:     the vtable
 fun t_isa(name: str, emitter: *isa.ModuleEmitter) isa.IsaVTable {
-    if (emitter != nil) { ret isa.emitter_isa(isa.ARCH_UNKNOWN, name, 8, nil, 0, nil, emitter); }
-    ret isa.machine_isa(isa.ARCH_UNKNOWN, name, 0, 8, nil, 0, nil, nil, nil);
+    if (emitter != nil) { ret isa.emitter_isa(isa.ARCH_UNKNOWN, name, 8, nil, emitter); }
+    ret isa.machine_isa(isa.ARCH_UNKNOWN, name, 0, 8, nil, nil, nil);
 }
 
 # a secret laundered through a phi join (out-of-SSA predecessor moves into one result vreg)

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -748,7 +748,7 @@ pub rec MirBlock {
 # a virtual register and its register-allocation state
 # ---
 # id:         the vreg's own index into MirFunction.vregs
-# class:      index into target.arch.reg_classes selecting the register bank
+# class:      index into `tgt.model.reg_classes` selecting the register bank
 # spill_slot: stack-frame slot index when spilled (-1 while unspilled)
 # assigned:   physical register id assigned by regalloc (MIR_VREG_NIL until then)
 # vector:     true when the vreg holds a 128-bit SIMD vector; distinguishes a vector

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1865,7 +1865,7 @@ fun probe_ret(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 test "mach.lang.be.codegen.mir.abi.require_abi:variadic_facts_are_not_call_preconditions" {
     # a whole-module ISA: this is a convention with no register machine behind it,
     # which is exactly the shape the two variadic facts are absent from.
-    var vt: isa.IsaVTable = isa.emitter_isa(isa.ARCH_SPIRV, "probe", 8, nil, 0, nil, nil);
+    var vt: isa.IsaVTable = isa.emitter_isa(isa.ARCH_SPIRV, "probe", 8, nil, nil);
     var av: abi.AbiVTable;
     av.arg_passing = probe_arg::*u8;
     av.ret_passing = probe_ret::*u8;

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -271,7 +271,7 @@ pub fun drain_pending_dbg(ctx: *LowerCtx, mi: *mir.MirInstr) R.Result[bool, str]
 # Grows the function's vreg table on demand.
 # ---
 # ctx:       the lowering context
-# reg_class: register-class index into target.arch.reg_classes
+# reg_class: register-class index into `tgt.model.reg_classes`
 # ret:       the new vreg id, or an allocation error
 pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) R.Result[u32, str] {
     val f: *mir.MirFunction = ctx.f;
@@ -297,7 +297,7 @@ pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) R.Result[u32, str] {
 # 16-byte-aligns its spill slot for MOVAPS reloads (#2014)
 # ---
 # ctx:       the lowering context
-# reg_class: register-class index into target.arch.reg_classes
+# reg_class: register-class index into `tgt.model.reg_classes`
 # vector:    whether the vreg holds a 128-bit SIMD vector
 # ret:       the new vreg id, or an allocation error
 pub fun new_vreg_vec(ctx: *LowerCtx, reg_class: u32, vector: bool) R.Result[u32, str] {
@@ -1271,11 +1271,9 @@ test "mach.lang.be.codegen.mir.context.fp_class_index" {
     tgt.model.reg_class_len = 2;
 
     # a sub-128-bit float bank (rv64d shape) is found by kind.
-    classes[1].bit_width = 64;
     if (fp_class_index(?tgt) != 1) { ret 1; }
 
     # a 128-bit float bank (x64 / arm64 shape) resolves to the same index.
-    classes[1].bit_width = 128;
     if (fp_class_index(?tgt) != 1) { ret 1; }
 
     ret 0;
@@ -1293,9 +1291,8 @@ test "mach.lang.be.codegen.mir.context.vector_scaffolding" {
     var classes: [2]isa.RegClass;
     classes[0].kind = isa.RC_GENERAL;
     classes[1].kind = isa.RC_FLOAT;
-    classes[1].bit_width = 128;
     var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "machine", 0, 8,
-                                              nil, 0, nil, nil, nil);
+                                              nil, nil, nil);
     var tgt: target.Target;
     tgt.isa                 = ?arch;
     tgt.model.reg_classes   = ?classes[0];
@@ -1354,7 +1351,7 @@ test "mach.lang.be.codegen.mir.context.op_width_is_a_fact_about_the_value" {
     classes[0].kind = isa.RC_GENERAL;
 
     var model: isa.MachineModel;
-    var arch: isa.IsaVTable = isa.machine_isa(0, "probe", 0, 8, ?classes[0], 1, ?model, nil, nil);
+    var arch: isa.IsaVTable = isa.machine_isa(0, "probe", 0, 8, ?model, nil, nil);
     var tgt: target.Target;
     tgt.isa                 = ?arch;
     tgt.model.reg_classes   = ?classes[0];

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -449,7 +449,6 @@ pub fun init_project(p: *Project, s: *session.Session) {
     p.target.os_id   = os.OS_UNKNOWN;
     p.target.arch_id = isa.ARCH_UNKNOWN;
     p.target.abi_id  = 0;
-    p.target.of_id   = 0;
     p.target.os      = nil;
     p.target.arch    = nil;
     p.target.abi     = nil;

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -840,7 +840,7 @@ test "mach.lang.me.ir.type.byte_size:struct_i8_i64" {
     val stty: IrTypeId = R.unwrap_ok[IrTypeId, str](res_struct);
 
     # a minimal target: only pointer_width matters, and only for IRT_PTR (unused here).
-    var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, 0, nil, nil, nil);
+    var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, nil, nil);
     var tgt: target.Target;
     tgt.isa = ?arch;
 
@@ -876,7 +876,7 @@ test "mach.lang.me.ir.type.intern_struct:align_override" {
     if (R.is_err[IrTypeId, str](res_align)) { dnit(?types); ret 1; }
     val algty: IrTypeId = R.unwrap_ok[IrTypeId, str](res_align);
 
-    var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, 0, nil, nil, nil);
+    var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, nil, nil);
     var tgt: target.Target;
     tgt.isa = ?arch;
 
@@ -917,7 +917,7 @@ test "mach.lang.me.ir.type.intern_vector:dedup_size_align" {
     if (R.is_err[IrTypeId, str](r3)) { dnit(?types); ret 1; }
     if (R.unwrap_ok[IrTypeId, str](r3) == vecty) { dnit(?types); ret 1; }
 
-    var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, 0, nil, nil, nil);
+    var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, nil, nil);
     var tgt: target.Target;
     tgt.isa = ?arch;
 

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -315,7 +315,6 @@ pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: s
     t.os_id   = t.os.id;
     t.arch_id = t.isa.id;
     t.abi_id  = t.abi.id;
-    t.of_id   = t.of.id;
 
     # resolve the debug-info producer the object format declares by name (elf /
     # mach-o -> "dwarf"). an EMPTY declaration (coff / raw) legitimately leaves

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -338,7 +338,7 @@ pub fun classify_return(size: u64, align: u64,
 #
 # Writes `out[0..GP_PARAM_COUNT)` with X0-X7 (each 8 bytes wide). The caller owns
 # `out`, which must hold at least `GP_PARAM_COUNT` registers; the count is returned
-# so the call composes with `RegisterFile`.
+# so the caller holds the (regs, count) pair.
 # ---
 # out: caller-owned buffer of at least GP_PARAM_COUNT registers
 # ret: the number of registers written (GP_PARAM_COUNT)

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -402,7 +402,7 @@ pub fun classify_return(size: u64, align: u64,
 #
 # Writes `out[0..GP_PARAM_COUNT)` with a0-a7 (each 8 bytes wide). The caller owns
 # `out`, which must hold at least `GP_PARAM_COUNT` registers; the count is returned
-# so the call composes with `RegisterFile`.
+# so the caller holds the (regs, count) pair.
 # ---
 # out: caller-owned buffer of at least GP_PARAM_COUNT registers
 # ret: the number of registers written (GP_PARAM_COUNT)

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -329,7 +329,7 @@ fun ret_sse_reg(index: i32) i32 {
 #
 # Writes `out[0..GP_PARAM_COUNT)` with RDI, RSI, RDX, RCX, R8, R9 (each 8 bytes
 # wide). The caller owns `out`, which must hold at least `GP_PARAM_COUNT`
-# registers; the count is returned so the call composes with `RegisterFile`.
+# registers; the count is returned so the caller holds the (regs, count) pair.
 # ---
 # out: caller-owned buffer of at least GP_PARAM_COUNT registers
 # ret: the number of registers written (GP_PARAM_COUNT)

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -305,7 +305,7 @@ pub fun classify_return(size: u64, align: u64,
 # fill the GP argument register bank in passing order
 #
 # writes RCX, RDX, R8, R9 (each 8 bytes wide) into `out[0..GP_PARAM_COUNT)` and
-# returns the count, so the call composes with `RegisterFile`. the caller owns
+# returns the count, so the caller holds the (regs, count) pair. the caller owns
 # `out`, which must hold at least `GP_PARAM_COUNT` registers.
 # ---
 # out: caller-owned buffer of at least GP_PARAM_COUNT registers

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -84,15 +84,6 @@ pub rec Register {
     size: u8;
 }
 
-# a homogeneous set of registers (e.g. all GP regs or all FP regs)
-# ---
-# regs:  array of registers
-# count: number of registers in the set
-pub rec RegisterFile {
-    regs:  *Register;
-    count: i32;
-}
-
 # the relocation modifier a symbol reference carries
 #
 # A target that cannot reach a symbol in one instruction forms its address as a
@@ -207,65 +198,48 @@ pub val RC_FLAGS:   RegClassKind = 3;  # condition flags (unallocatable)
 # ---
 # name:      interned class name ("gpr", "xmm", "flags", ...)
 # kind:      the role the bank plays (general / float / vector / flags)
-# bit_width: width of one register in bits
 # len:       number of registers in the class
 pub rec RegClass {
     name:      str;
     kind:      RegClassKind;
-    bit_width: u32;
     len:       u32;
 }
-
-# the addressing forms the shared lowering and isel reason about, an extensible
-# flag set
-#
-# An ISA's exotic modes (a 6502 `(zp),Y`) live in that ISA's own isel, never here;
-# this set is only what the shared, model-driven stages fold and select against.
-pub def AddrForm: u32;
-pub val ADDR_BASE:            AddrForm = 0x01;  # [base]
-pub val ADDR_BASE_DISP:       AddrForm = 0x02;  # [base + disp]
-pub val ADDR_BASE_INDEX:      AddrForm = 0x04;  # [base + index*scale]
-pub val ADDR_BASE_INDEX_DISP: AddrForm = 0x08;  # [base + index*scale + disp]
-pub val ADDR_ABSOLUTE:        AddrForm = 0x10;  # [disp]
-pub val ADDR_PCREL:           AddrForm = 0x20;  # [pc + disp]
 
 # the pure machine description the shared backend stages read
 #
 # `resolved.Target` carries one of these by value; `target.select` assembles it
 # from the chosen isa's model template and the chosen abi's stack scalars. the
 # shared lower / regalloc / frame stages and the width / endianness paths in the
-# encoders are meant to read the model instead of scattered constants or an
-# `arch_id` branch, so a new target becomes a populated description rather than a
-# core edit. this definition is purely additive: the stages still read the legacy
-# constants and vtable fields until the rewiring lands (issue #1600 group B).
+# encoders read the model instead of scattered constants or an `arch_id` branch, so
+# a new target becomes a populated description rather than a core edit.
 #
 # the register file's banks self-describe via `RegClassKind`, so a stage finds the
-# general-purpose or float bank by role and never by a magic index. the addressing
-# capability is a flag set plus a legal-scale mask plus a displacement width, not a
-# universal addressing-mode descriptor: an ISA's exotic modes stay in its own isel.
+# general-purpose or float bank by role and never by a magic index.
+#
+# EVERY FIELD HERE IS READ. that is a rule, not an observation (#2366). an
+# addressing-capability block (`addr_forms` / `addr_scales` / `addr_disp_bits` /
+# `index_width`, and with them the `AddrForm` flag set they were the only readers
+# of), a scratch pool, and two frame-layout flags were removed rather
+# than kept for a future consumer, because unread machine description is
+# UNVERIFIED machine description: nothing reads it, so nothing can catch it going
+# wrong, and it had. `addr_disp_bits` recorded the ISA's immediate field width on
+# x86-64 / rv64 / 6502 and the MIR operand's width on aarch64 - two meanings under
+# one name, and a consumer folding against it would have formed addresses aarch64
+# cannot encode. re-add such a description WITH its consumer, in the same change.
 # ---
 # pointer_width:     pointer width in bytes
 # gpr_width:         general-purpose / machine-word width in bytes
-# index_width:       array-index computation width in bytes
 # spill_width:       spill / reload move width in bytes
 # endianness:        byte order of scalar storage (ENDIAN_*)
 # reg_classes:       borrowed array of the ISA's register classes
 # reg_class_len:     number of register classes
 # frame_ptr_reg:     frame-pointer register id (base of incoming stack params)
 # stack_ptr_reg:     stack-pointer register id (base of outgoing stack args)
-# scratch_regs:      borrowed reload-scratch register pool
-# scratch_len:       number of reload-scratch registers
 # reserved_regs:     borrowed registers the allocator must never assign
 # reserved_len:      number of reserved registers
 # div_reg:           register the division form pins as dividend / quotient, or -1
 # div_hi_reg:        register the division form pins as high-half / remainder, or -1
 # shift_count_reg:   register a variable shift's count must occupy, or -1
-# addr_forms:        flag set of supported addressing forms (ADDR_*)
-# addr_scales:       bitmask of legal index scales; scale S is legal iff
-#                    (addr_scales & S) != 0 (scales are powers of two)
-# addr_disp_bits:    widest displacement the ISA encodes, in bits
-# stack_grows_down:  true when the stack grows toward lower addresses
-# fp_relative_frame: true when spills home at [fp+off]; false => sp-relative
 # incoming_arg_base: byte offset from the frame pointer to the first incoming
 #                    stack argument (the frame fact the prologue establishes)
 # stack_align:       required stack alignment in bytes at a call boundary (from abi)
@@ -310,7 +284,6 @@ pub rec MachineModel {
     pointer_width: u32;
     gpr_width:     u32;
     max_alu_width: u32;
-    index_width:   u32;
     spill_width:   u32;
     endianness:    Endian;
 
@@ -318,20 +291,12 @@ pub rec MachineModel {
     reg_class_len:  u32;
     frame_ptr_reg:  i32;
     stack_ptr_reg:  i32;
-    scratch_regs:   *Register;
-    scratch_len:    i32;
     reserved_regs:  *Register;
     reserved_len:   i32;
     div_reg:         i32;
     div_hi_reg:      i32;
     shift_count_reg: i32;
 
-    addr_forms:     AddrForm;
-    addr_scales:    u32;
-    addr_disp_bits: u32;
-
-    stack_grows_down:  bool;
-    fp_relative_frame: bool;
     incoming_arg_base: i64;
     stack_align:       u32;
     red_zone:          u32;
@@ -641,8 +606,6 @@ pub rec RelocSeam {
 #                  the object-format writer reads it to stamp ELF headers instead
 #                  of branching on the arch id. 0 for an arch with no ELF mapping
 # pointer_width:   pointer width in bytes
-# reg_classes:     array of register classes
-# reg_class_count: number of register classes
 # reloc:           borrowed relocatable-object contract, or nil for an ISA that
 #                  emits no relocations at all (a raw flat image, a finished
 #                  module). a whole-module emitter cannot even express one:
@@ -662,8 +625,6 @@ pub rec IsaVTable {
     name:            str;
     elf_machine:     u32;
     pointer_width:   u32;
-    reg_classes:     *RegClass;
-    reg_class_count: u32;
     reloc:           *RelocSeam;
     machine:         *RegMachine;
     emitter:         *ModuleEmitter;
@@ -841,19 +802,15 @@ pub fun with_elf_attributes(s: *RelocSeam, f: *u8) {
 # name:            interned architecture name
 # elf_machine:     ELF `e_machine` value, or 0 for an arch with no ELF mapping
 # pointer_width:   pointer width in bytes
-# reg_classes:     array of register classes
-# reg_class_count: number of register classes
 # model:           borrowed per-arch machine-model template
 # machine:         borrowed register-machine contract
 # reloc:           borrowed relocatable-object contract, or nil for an arch that
 #                  emits no relocations
 # ret:             the composed vtable
 pub fun machine_isa(id: u32, name: str, elf_machine: u32, pointer_width: u32,
-                    reg_classes: *RegClass, reg_class_count: u32,
                     model: *MachineModel, machine: *RegMachine,
                     reloc: *RelocSeam) IsaVTable {
-    var vt: IsaVTable = isa_common(id, name, elf_machine, pointer_width,
-                                   reg_classes, reg_class_count, model);
+    var vt: IsaVTable = isa_common(id, name, elf_machine, pointer_width, model);
     vt.reloc   = reloc;
     vt.machine = machine;
     vt.emitter = nil;
@@ -870,17 +827,12 @@ pub fun machine_isa(id: u32, name: str, elf_machine: u32, pointer_width: u32,
 # id:              architecture id (one of ARCH_*)
 # name:            interned architecture name
 # pointer_width:   pointer width in bytes
-# reg_classes:     array of nominal register classes the shared MIR lowering
-#                  classes values against; never allocated
-# reg_class_count: number of register classes
 # model:           borrowed per-arch machine-model template
 # emitter:         borrowed whole-module contract
 # ret:             the composed vtable
 pub fun emitter_isa(id: u32, name: str, pointer_width: u32,
-                    reg_classes: *RegClass, reg_class_count: u32,
                     model: *MachineModel, emitter: *ModuleEmitter) IsaVTable {
-    var vt: IsaVTable = isa_common(id, name, 0, pointer_width,
-                                   reg_classes, reg_class_count, model);
+    var vt: IsaVTable = isa_common(id, name, 0, pointer_width, model);
     vt.reloc   = nil;
     vt.machine = nil;
     vt.emitter = emitter;
@@ -897,20 +849,15 @@ pub fun emitter_isa(id: u32, name: str, pointer_width: u32,
 # name:            interned architecture name
 # elf_machine:     ELF `e_machine` value, 0 for none
 # pointer_width:   pointer width in bytes
-# reg_classes:     array of register classes
-# reg_class_count: number of register classes
 # model:           borrowed machine-model template
 # ret:             a vtable with both family payloads still nil
 fun isa_common(id: u32, name: str, elf_machine: u32, pointer_width: u32,
-               reg_classes: *RegClass, reg_class_count: u32,
                model: *MachineModel) IsaVTable {
     var vt: IsaVTable;
     vt.id              = id;
     vt.name            = name;
     vt.elf_machine     = elf_machine;
     vt.pointer_width   = pointer_width;
-    vt.reg_classes     = reg_classes;
-    vt.reg_class_count = reg_class_count;
     vt.model           = model;
 
     vt.reloc   = nil;
@@ -1407,7 +1354,7 @@ test "mach.lang.target.isa.register:write_once_and_enumerate" {
 
     var m: RegMachine = t_machine();
     var rs: RelocSeam = t_reloc();
-    var vt: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, 0, nil, ?m, ?rs);
+    var vt: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, ?m, ?rs);
     register(?reg, ?vt);
     if (registered_count(?reg) != 1) { ret 1; }
 
@@ -1418,7 +1365,7 @@ test "mach.lang.target.isa.register:write_once_and_enumerate" {
     # write-once: a second registration under the same name is ignored
     var m2: RegMachine = t_machine();
     var rs2: RelocSeam = t_reloc();
-    var vt2: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, 0, nil, ?m2, ?rs2);
+    var vt2: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, ?m2, ?rs2);
     register(?reg, ?vt2);
     if (O.unwrap[*IsaVTable](lookup(?reg, "x86_64")) != ?vt) { ret 1; }
 
@@ -1438,14 +1385,14 @@ test "mach.lang.target.isa.register:write_once_and_enumerate" {
 test "mach.lang.target.isa.family:payloads_are_exclusive" {
     var m: RegMachine = t_machine();
     var rs: RelocSeam = t_reloc();
-    var mvt: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, 0, nil, ?m, ?rs);
+    var mvt: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, ?m, ?rs);
     if (mvt.machine != ?m)         { ret 1; }
     if (mvt.emitter != nil)        { ret 1; }
     if (emits_whole_module(?mvt))  { ret 1; }
 
     var hook: u8;
     var e: ModuleEmitter = module_emitter(?hook);
-    var evt: IsaVTable = emitter_isa(ARCH_SPIRV, "spirv", 8, nil, 0, nil, ?e);
+    var evt: IsaVTable = emitter_isa(ARCH_SPIRV, "spirv", 8, nil, ?e);
     if (evt.emitter != ?e)         { ret 1; }
     if (evt.machine != nil)        { ret 1; }
     if (!emits_whole_module(?evt)) { ret 1; }
@@ -1518,7 +1465,7 @@ fun t_dwarf_reg(regid: i32) i32 {
 test "mach.lang.target.isa.has_codegen:per_family" {
     var m: RegMachine = t_machine();
     var rs: RelocSeam = t_reloc();
-    var mvt: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, 0, nil, ?m, ?rs);
+    var mvt: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, ?m, ?rs);
     if (!has_codegen(?mvt)) { ret 1; }
 
     # a register machine missing its encoder is not wired
@@ -1527,12 +1474,12 @@ test "mach.lang.target.isa.has_codegen:per_family" {
 
     var hook: u8;
     var e: ModuleEmitter = module_emitter(?hook);
-    var evt: IsaVTable = emitter_isa(ARCH_SPIRV, "spirv", 8, nil, 0, nil, ?e);
+    var evt: IsaVTable = emitter_isa(ARCH_SPIRV, "spirv", 8, nil, ?e);
     if (!has_codegen(?evt)) { ret 1; }
 
     # description-only: registered so composition reports it, but neither family
     # payload is bound
-    var dvt: IsaVTable = machine_isa(ARCH_MOS6502, "desc", 0, 2, nil, 0, nil, nil, nil);
+    var dvt: IsaVTable = machine_isa(ARCH_MOS6502, "desc", 0, 2, nil, nil, nil);
     if (has_codegen(?dvt)) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -154,7 +154,6 @@ fun arm64_dwarf_reg(regid: i32) i32 {
 pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_classes[0].name      = "gpr";
     arm64_classes[0].kind      = isa.RC_GENERAL;
-    arm64_classes[0].bit_width = 64;
     arm64_classes[0].len       = arm64.GPR_COUNT::u32;
 
     # the vector bank exposes only V0-V29 (count 30) to the allocator. V30 and V31
@@ -166,12 +165,10 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # `op Sd, Sn, Sm`, which one scratch cannot supply.
     arm64_classes[1].name      = "vector";
     arm64_classes[1].kind      = isa.RC_FLOAT;
-    arm64_classes[1].bit_width = 128;
     arm64_classes[1].len       = arm64.VECTOR_COUNT::u32;
 
     arm64_classes[2].name      = "flags";
     arm64_classes[2].kind      = isa.RC_FLAGS;
-    arm64_classes[2].bit_width = 64;
     arm64_classes[2].len       = 1;
 
     arm64_reserved_regs[0].id   = arm64.SP;
@@ -223,8 +220,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
 
     # elf_machine 183 is EM_AARCH64
     arm64_vtable = isa.machine_isa(isa.ARCH_AARCH64, "aarch64", 183, 8,
-                                   ?arm64_classes[0], 3, ?arm64_model, ?arm64_machine,
-                                   ?arm64_reloc);
+                                   ?arm64_model, ?arm64_machine, ?arm64_reloc);
 
     # the machine-model template: every value equals today's reality so the stages
     # preserve behavior when they are rewired to read it. widths are in bytes; the
@@ -233,7 +229,6 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_model.pointer_width   = 8;
     arm64_model.max_alu_width = 8;
     arm64_model.gpr_width       = 8;
-    arm64_model.index_width     = 8;
     arm64_model.spill_width     = 8;
     arm64_model.endianness      = isa.ENDIAN_LITTLE;
     # NEON 128-bit vector unit is baseline on aarch64 (#1965).
@@ -254,24 +249,12 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_model.reg_class_len   = 3;
     arm64_model.frame_ptr_reg   = arm64.FP;
     arm64_model.stack_ptr_reg   = arm64.SP;
-    arm64_model.scratch_regs    = ?arm64_reload_scratch_regs[0];
-    arm64_model.scratch_len     = 3;
     arm64_model.reserved_regs   = ?arm64_reserved_regs[0];
     arm64_model.reserved_len    = 3;
     arm64_model.div_reg         = -1;
     arm64_model.div_hi_reg      = -1;
     arm64_model.shift_count_reg = -1;
 
-    # the shared MIR assumes the same addressing forms on both arches: it folds
-    # [base + index*scale + disp] and emits pc-relative symbol references, never a
-    # bare [disp] absolute memory operand. legal scales are 1|2|4|8 and the shared
-    # displacement is a signed 32-bit (the MIR operand's `disp` field).
-    arm64_model.addr_forms      = isa.ADDR_BASE | isa.ADDR_BASE_DISP | isa.ADDR_BASE_INDEX | isa.ADDR_BASE_INDEX_DISP | isa.ADDR_PCREL;
-    arm64_model.addr_scales     = 0xF;
-    arm64_model.addr_disp_bits  = 32;
-
-    arm64_model.stack_grows_down  = true;
-    arm64_model.fp_relative_frame = true;
     arm64_model.incoming_arg_base = 16;
     arm64_model.stack_align       = 0;
     arm64_model.red_zone          = 0;

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -58,7 +58,6 @@ var mos6502_reload_scratch_regs: [3]isa.Register;
 pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     mos6502_classes[0].name      = "gpr";
     mos6502_classes[0].kind      = isa.RC_GENERAL;
-    mos6502_classes[0].bit_width = 8;
     mos6502_classes[0].len       = mos6502.GPR_COUNT::u32;
 
     mos6502_reserved_regs[0].id = mos6502.FP_LO;       mos6502_reserved_regs[0].size = 1;
@@ -100,13 +99,11 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # (it reports "instruction encoding is not yet implemented" first), so the gap is
     # latent - see #2280, which the 6502 back half closes by naming a seam here.
     mos6502_vtable = isa.machine_isa(isa.ARCH_MOS6502, "mos6502", 0, 2,
-                                     ?mos6502_classes[0], 1, ?mos6502_model, ?mos6502_machine,
-                                     nil);
+                                     ?mos6502_model, ?mos6502_machine, nil);
 
     mos6502_model.pointer_width   = 2;
     mos6502_model.gpr_width       = 1;
     mos6502_model.max_alu_width   = 1;
-    mos6502_model.index_width     = 1;
     mos6502_model.spill_width     = 1;
     mos6502_model.endianness      = isa.ENDIAN_LITTLE;
     mos6502_model.has_v128        = false;
@@ -124,23 +121,12 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     mos6502_model.reg_class_len   = 1;
     mos6502_model.frame_ptr_reg   = mos6502.FRAME_REG;
     mos6502_model.stack_ptr_reg   = mos6502.STACK_REG;
-    mos6502_model.scratch_regs    = ?mos6502_reload_scratch_regs[0];
-    mos6502_model.scratch_len     = 3;
     mos6502_model.reserved_regs   = ?mos6502_reserved_regs[0];
     mos6502_model.reserved_len    = 8;
     mos6502_model.div_reg         = -1;
     mos6502_model.div_hi_reg      = -1;
     mos6502_model.shift_count_reg = -1;
 
-    # zero-page direct and frame-relative (indirect-indexed `(fp),Y`) addressing;
-    # scale 1 only (the 6502 has no scaled index), 8-bit displacements (the software
-    # frame is addressed with an 8-bit Y offset).
-    mos6502_model.addr_forms      = isa.ADDR_BASE | isa.ADDR_BASE_DISP | isa.ADDR_ABSOLUTE;
-    mos6502_model.addr_scales     = 1;
-    mos6502_model.addr_disp_bits  = 8;
-
-    mos6502_model.stack_grows_down  = true;
-    mos6502_model.fp_relative_frame = true;
     mos6502_model.incoming_arg_base = 0;
     mos6502_model.stack_align       = 0;
     mos6502_model.red_zone          = 0;

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -185,7 +185,6 @@ fun riscv64_dwarf_reg(regid: i32) i32 {
 pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_classes[0].name      = "gpr";
     riscv64_classes[0].kind      = isa.RC_GENERAL;
-    riscv64_classes[0].bit_width = 64;
     riscv64_classes[0].len       = riscv64.GPR_COUNT::u32;
 
     # the fpr bank exposes f0-f29 (count 30) to the allocator. f30 and f31
@@ -196,7 +195,6 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # 128-bit vector bank the shared float-bank lookup keys on by width.
     riscv64_classes[1].name      = "fpr";
     riscv64_classes[1].kind      = isa.RC_FLOAT;
-    riscv64_classes[1].bit_width = 64;
     riscv64_classes[1].len       = riscv64.FPR_COUNT::u32;
 
     riscv64_reserved_regs[0].id   = riscv64.ZERO;
@@ -264,22 +262,19 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
 
     # elf_machine 243 is EM_RISCV
     riscv64_vtable = isa.machine_isa(isa.ARCH_RISCV64, "riscv64", 243, 8,
-                                     ?riscv64_classes[0], 2, ?riscv64_model, ?riscv64_machine,
-                                     ?riscv64_reloc);
+                                     ?riscv64_model, ?riscv64_machine, ?riscv64_reloc);
 
     # the machine-model template the shared stages read. widths are in bytes; the
     # register-file pointers borrow the same per-arch arrays the vtable does; the
     # stack scalars stay 0 here and are overlaid by `target.select` from the abi.
     #
-    # these four width fields and the two register-class bit_widths above are the
-    # ONLY RV64-specific (XLEN=64) values in the machine description - everything
-    # else (the register file, roles, scratch ids, addressing capability, frame
-    # facts) is XLEN-independent. an RV32 (ilp32) sibling would set 4-byte widths
-    # and 32-bit class widths here and reuse the rest unchanged.
+    # these four width fields are the ONLY RV64-specific (XLEN=64) values in the
+    # machine description - everything else (the register file, roles, capability
+    # flags) is XLEN-independent. an RV32 (ilp32) sibling would set 4-byte widths
+    # here and reuse the rest unchanged.
     riscv64_model.pointer_width   = 8;
     riscv64_model.max_alu_width = 8;
     riscv64_model.gpr_width       = 8;
-    riscv64_model.index_width     = 8;
     riscv64_model.spill_width     = 8;
     riscv64_model.endianness      = isa.ENDIAN_LITTLE;
     # rv64gc has no 128-bit vector unit (the V extension is out of baseline), so
@@ -296,26 +291,12 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_model.reg_class_len   = 2;
     riscv64_model.frame_ptr_reg   = riscv64.FP;
     riscv64_model.stack_ptr_reg   = riscv64.SP;
-    riscv64_model.scratch_regs    = ?riscv64_reload_scratch_regs[0];
-    riscv64_model.scratch_len     = 3;
     riscv64_model.reserved_regs   = ?riscv64_reserved_regs[0];
     riscv64_model.reserved_len    = 6;
     riscv64_model.div_reg         = -1;
     riscv64_model.div_hi_reg      = -1;
     riscv64_model.shift_count_reg = -1;
 
-    # RV64 addressing is base + 12-bit signed displacement only: there is no
-    # scaled-index form (so ADDR_BASE_INDEX is absent and `addr_scales` is empty) and
-    # no absolute [disp] form (constant addresses are materialized into a register).
-    # symbol references are pc-relative (the auipc-based `la` sequence), so
-    # ADDR_PCREL is present. the displacement field of a load / store immediate is a
-    # signed 12-bit.
-    riscv64_model.addr_forms      = isa.ADDR_BASE | isa.ADDR_BASE_DISP | isa.ADDR_PCREL;
-    riscv64_model.addr_scales     = 0;
-    riscv64_model.addr_disp_bits  = 12;
-
-    riscv64_model.stack_grows_down  = true;
-    riscv64_model.fp_relative_frame = true;
     riscv64_model.incoming_arg_base = 0;
     riscv64_model.stack_align       = 0;
     riscv64_model.red_zone          = 0;

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -57,7 +57,6 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # every other field exists so `target.select` can copy a well-formed model.
     spirv_model.pointer_width = 8;
     spirv_model.gpr_width     = 8;
-    spirv_model.index_width   = 8;
     spirv_model.spill_width   = 8;
     spirv_model.endianness    = isa.ENDIAN_LITTLE;
     # the general-purpose bank is declared first (class index 0, the shared
@@ -65,28 +64,19 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # by kind. counts are nominal - nothing is allocated.
     spirv_classes[0].name      = "gpr";
     spirv_classes[0].kind      = isa.RC_GENERAL;
-    spirv_classes[0].bit_width = 64;
     spirv_classes[0].len       = 16;
     spirv_classes[1].name      = "fpr";
     spirv_classes[1].kind      = isa.RC_FLOAT;
-    spirv_classes[1].bit_width = 64;
     spirv_classes[1].len       = 16;
     spirv_model.reg_classes   = ?spirv_classes[0];
     spirv_model.reg_class_len = 2;
     spirv_model.frame_ptr_reg = -1;
     spirv_model.stack_ptr_reg = -1;
-    spirv_model.scratch_regs  = nil;
-    spirv_model.scratch_len   = 0;
     spirv_model.reserved_regs = nil;
     spirv_model.reserved_len  = 0;
     spirv_model.div_reg         = -1;
     spirv_model.div_hi_reg      = -1;
     spirv_model.shift_count_reg = -1;
-    spirv_model.addr_forms      = 0;
-    spirv_model.addr_scales     = 0;
-    spirv_model.addr_disp_bits  = 0;
-    spirv_model.stack_grows_down  = true;
-    spirv_model.fp_relative_frame = false;
     spirv_model.incoming_arg_base = 0;
     spirv_model.stack_align       = 0;
     spirv_model.red_zone          = 0;
@@ -107,7 +97,7 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     spirv_emitter = isa.module_emitter(emit.emit_module::*u8);
 
     spirv_vtable = isa.emitter_isa(isa.ARCH_SPIRV, "spirv", 8,
-                                   ?spirv_classes[0], 2, ?spirv_model, ?spirv_emitter);
+                                   ?spirv_model, ?spirv_emitter);
 
     isa.register(reg, ?spirv_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -209,7 +209,6 @@ fun x64_cv_reg(regid: i32) i32 {
 pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_classes[0].name      = "gpr";
     x64_classes[0].kind      = isa.RC_GENERAL;
-    x64_classes[0].bit_width = 64;
     x64_classes[0].len       = 16;
 
     # the SSE bank exposes only XMM0-XMM13 (count 14) to the allocator. XMM14 and
@@ -221,12 +220,10 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # (`FLOAT_SCRATCH0` / `FLOAT_SCRATCH1`) and the vtable declares neither (#2365).
     x64_classes[1].name      = "xmm";
     x64_classes[1].kind      = isa.RC_FLOAT;
-    x64_classes[1].bit_width = 128;
     x64_classes[1].len       = 14;
 
     x64_classes[2].name      = "flags";
     x64_classes[2].kind      = isa.RC_FLAGS;
-    x64_classes[2].bit_width = 64;
     x64_classes[2].len       = 1;
 
     x64_reserved_regs[0].id   = x64.STACK_REG;
@@ -271,8 +268,7 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
 
     # elf_machine 62 is EM_X86_64
     x64_vtable = isa.machine_isa(isa.ARCH_X86_64, "x86_64", 62, 8,
-                                 ?x64_classes[0], 3, ?x64_model, ?x64_machine,
-                                 ?x64_reloc);
+                                 ?x64_model, ?x64_machine, ?x64_reloc);
 
     # the machine-model template: every value equals today's reality so the stages
     # preserve behavior when they are rewired to read it. widths are in bytes; the
@@ -281,7 +277,6 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_model.pointer_width   = 8;
     x64_model.max_alu_width = 8;
     x64_model.gpr_width       = 8;
-    x64_model.index_width     = 8;
     x64_model.spill_width     = 8;
     x64_model.endianness      = isa.ENDIAN_LITTLE;
     # SSE2 128-bit vector unit is baseline on x86-64 (#1965).
@@ -300,24 +295,12 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_model.reg_class_len   = 3;
     x64_model.frame_ptr_reg   = x64.FRAME_REG;
     x64_model.stack_ptr_reg   = x64.STACK_REG;
-    x64_model.scratch_regs    = ?x64_reload_scratch_regs[0];
-    x64_model.scratch_len     = 3;
     x64_model.reserved_regs   = ?x64_reserved_regs[0];
     x64_model.reserved_len    = 2;
     x64_model.div_reg         = x64.RAX;
     x64_model.div_hi_reg      = x64.RDX;
     x64_model.shift_count_reg = x64.RCX;
 
-    # the shared MIR folds [base + index*scale + disp] and emits rip-relative
-    # symbol references; it never forms a bare [disp] absolute memory operand
-    # (constant addresses are materialized into a register), so ADDR_ABSOLUTE is
-    # absent. legal SIB scales are 1|2|4|8 and the displacement is a signed 32-bit.
-    x64_model.addr_forms      = isa.ADDR_BASE | isa.ADDR_BASE_DISP | isa.ADDR_BASE_INDEX | isa.ADDR_BASE_INDEX_DISP | isa.ADDR_PCREL;
-    x64_model.addr_scales     = 0xF;
-    x64_model.addr_disp_bits  = 32;
-
-    x64_model.stack_grows_down  = true;
-    x64_model.fp_relative_frame = true;
     x64_model.incoming_arg_base = 16;
     x64_model.stack_align       = 0;
     x64_model.red_zone          = 0;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3496,7 +3496,7 @@ pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
 # id:  the architecture id the vtable reports
 # ret: a description-only vtable, every other field cleared
 fun t_isa(id: u32) isa.IsaVTable {
-    ret isa.machine_isa(id, "test", 0, 8, nil, 0, nil, nil, nil);
+    ret isa.machine_isa(id, "test", 0, 8, nil, nil, nil);
 }
 
 # intern a name into the test interner, returning STR_NIL on failure (the test

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -4244,7 +4244,7 @@ val EM_AARCH64: u16 = 183;
 # reloc:       the relocatable-object seam, or nil for a test that emits none
 # ret:         a description-only vtable, every other field cleared
 fun t_isa(id: u32, elf_machine: u32, reloc: *isa.RelocSeam) isa.IsaVTable {
-    ret isa.machine_isa(id, "test", elf_machine, 8, nil, 0, nil, nil, reloc);
+    ret isa.machine_isa(id, "test", elf_machine, 8, nil, nil, reloc);
 }
 
 # a relocatable-object contract for the writer tests

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -3676,7 +3676,7 @@ fun recover_addend(out: *of.ObjectImage, sec_i: u32, address: u32, cputype: u32,
 # id:  the architecture id the vtable reports
 # ret: a description-only vtable, every other field cleared
 fun t_isa(id: u32) isa.IsaVTable {
-    ret isa.machine_isa(id, "test", 0, 8, nil, 0, nil, nil, nil);
+    ret isa.machine_isa(id, "test", 0, 8, nil, nil, nil);
 }
 
 # intern a string for a test, yielding STR_NIL on the (test-only) interning failure

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -267,7 +267,7 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
 # id:  the architecture id the vtable reports
 # ret: a description-only vtable, every other field cleared
 fun t_isa(id: u32) isa.IsaVTable {
-    ret isa.machine_isa(id, "test", 0, 8, nil, 0, nil, nil, nil);
+    ret isa.machine_isa(id, "test", 0, 8, nil, nil, nil);
 }
 
 # register installs the raw vtable and the unsupported stubs reject non-executable

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -29,7 +29,6 @@ use mach.lang.target.os;
 # os_id:    operating-system id (one of os.OS_*)
 # arch_id:  architecture id (one of isa.ARCH_*)
 # abi_id:   calling-convention id (one of abi.ABI_*)
-# of_id:    object-format id (one of of.OF_*)
 # debug_id: debug-info model id (one of of.DBG_*), DBG_UNKNOWN when the tuple
 #           carries no debug info
 # os:       borrowed operating-system vtable
@@ -51,7 +50,6 @@ pub rec Target {
     os_id:    u32;
     arch_id:  u32;
     abi_id:   u32;
-    of_id:    u32;
     debug_id: u32;
     os:       *os.OsVTable;
     isa:      *isa.IsaVTable;


### PR DESCRIPTION
Closes #2366 — the remainder of the #2341 sweep. `RegMachine.fp_scratch_reg` is **not** touched; that was #2365 / PR #2382, which is now merged and fully preserved here.

## Group B is a re-decision, and the evidence changed what I would have done

Eight `MachineModel` fields, populated by **all five ISAs** and read by **none**, behind a docstring deferring to **#1600 group B — closed in v2.6.0**.

The tempting defence is "these describe five real machines, keep them for a future addressing-mode consumer." I checked whether they actually do, and two of them do not:

- **`stack_grows_down` is `true` on all five**, including a stackless SPIR-V where the value is meaningless. It distinguishes nothing.
- **`addr_disp_bits` means two different things.** x86-64 (32), rv64 (12) and 6502 (8) record the ISA's immediate field width — a machine fact. aarch64 records **32**, and its own comment gives it away: *"the shared displacement is a signed 32-bit (the MIR operand's `disp` field)"*. aarch64 hardware encodes a **scaled imm12** or an **unscaled imm9** and has no 32-bit displacement form at all. A model-driven consumer folding against this would have formed addresses aarch64 cannot encode.
- **`scratch_regs` is superseded**: each encoder names its own scratch registers directly (aarch64 IP0/IP1 in `arm64/encode.mach`) rather than consulting the model.

So the decision is **delete**, and the reason is stronger than "unused": **unread machine description is unverified machine description.** Nothing reads these, so nothing can catch a wrong value — and one had already drifted into meaning something else entirely. A future consumer would have had to re-verify every value anyway.

Removing `addr_forms` orphaned the `AddrForm` flag set it was the only reader of, so that goes too — otherwise this change would have created exactly the dead surface it exists to remove.

The docstring now states the rule rather than a plan: **every field here is read**, and such a description is re-added *with* its consumer, in the same change.

## Group A — a descriptor superseded in place

`IsaVTable.reg_classes` / `reg_class_count` and `RegClass.bit_width`, all superseded by `MachineModel.reg_classes`. The vtable pair was fed by a parameter chain through `machine_isa` / `emitter_isa` / `isa_common` that existed **only** to populate them, so the chain goes with them — 17 call sites updated.

The three comments pointing at **`target.arch.reg_classes`, a path that does not exist** (`Target.arch` is a `*RegMachine`) now name `tgt.model.reg_classes`. A fourth comment in `riscv64/register.mach` described "the two register-class bit_widths above" and the removed addressing/frame facts; it now describes what remains.

## Group C

- `resolved.Target.of_id` — the one dead member of a five-member block whose four siblings are read.
- `isa.RegisterFile` — declared and used nowhere, while four ABI docstrings asserted the accessors *"compose with"* it. Those now say the caller holds the `(regs, count)` pair, which is what actually happens.

## Verification

- **Objects byte-identical: 146/146.** Built the pinned std (`eff1e8e`, via `git archive`) for `linux-x86_64` and `linux-arm64` with a baseline compiler and with this one; every object matches. A dead field costs nothing at runtime, and nothing moved.
- **mach-std at pin: 611 passed / 0 failed.**
- **Compiler suite: 952 / 5 / 957 — identical to pristine `dev`**, same five pre-existing failures (`printer:signed_zero`, four `generic_layout_runtime` aliasing cases). This change removes **zero** test blocks: 955 at my base, 955 after; `dev`'s 957 is +2 from #2383.
- **All five ISAs still register**: `mach info` output identical to baseline.
- **Built and run on the three linkable ISAs**: `int` corpus fully green on `linux` and `linux-riscv64` (qemu). `linux-arm64` is `native` run-mode in `targets.conf` — an ARM runner in CI — so it cannot execute on this x86_64 host; I built and ran a case under explicit `qemu-aarch64` instead and diffed it against the golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ntqq8dS4TDqoYPsx3JpVy4